### PR TITLE
fix(codex): 恢复订阅直连 Responses WebSocket

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1608,13 +1608,40 @@ describe('codex proxy host', () => {
     expect(proxyOpts.resolveWebSocketUpstream(ctxForThread('thread-safe'))).toBe(
       'https://chatgpt.com/backend-api/codex',
     );
-    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith(
-      'thread-encrypted',
-      { includeUnscoped: true },
-    );
-    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith(
-      'thread-image',
-      { includeUnscoped: true },
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-encrypted');
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-image');
+  });
+
+  it('keeps native websocket behavior when no scoped socket can be recovered safely', async () => {
+    const host = await freshCodexProxyHost();
+    const disconnectWebSocketsForThread = vi.fn(() => 0);
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      disconnectWebSocketsForThread,
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    const proxyOpts = mockState.createAnthropicCompatProxy.mock.calls[0][0] as {
+      resolveWebSocketUpstream: (ctx: {
+        url: string;
+        headers: Readonly<Record<string, string>>;
+      }) => string | null;
+    };
+    const ctx = {
+      url: '/v1/responses',
+      headers: { 'thread-id': 'thread-unscoped' },
+    };
+
+    expect(host.armCodexHttpRecovery({
+      sessionId: 'session-unscoped',
+      threadId: 'thread-unscoped',
+      message: 'invalid_encrypted_content',
+    })).toBeNull();
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-unscoped');
+    expect(proxyOpts.resolveWebSocketUpstream(ctx)).toBe(
+      'https://chatgpt.com/backend-api/codex',
     );
   });
 
@@ -1642,10 +1669,7 @@ describe('codex proxy host', () => {
     expect(mockState.capturedRegistry?.get('thread-parent')).toBe('PRODUCT_PROMPT');
     expect(mockState.capturedRegistry?.get('thread-child')).toBe('PRODUCT_PROMPT');
     expect(mockState.capturedRegistry?.get('thread-sibling')).toBe('PRODUCT_PROMPT');
-    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith(
-      'thread-child',
-      { includeUnscoped: true },
-    );
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-child');
 
     host.unregister('session-family');
     expect(mockState.capturedRegistry?.get('thread-parent')).toBeUndefined();
@@ -1657,6 +1681,7 @@ describe('codex proxy host', () => {
     const host = await freshCodexProxyHost();
     mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
       url: 'http://127.0.0.1:43210',
+      disconnectWebSocketsForThread: vi.fn(() => 1),
       dispose: vi.fn(async () => undefined),
     });
     await host.ensureCodexProxyReady();

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1608,8 +1608,49 @@ describe('codex proxy host', () => {
     expect(proxyOpts.resolveWebSocketUpstream(ctxForThread('thread-safe'))).toBe(
       'https://chatgpt.com/backend-api/codex',
     );
-    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-encrypted');
-    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-image');
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith(
+      'thread-encrypted',
+      { includeUnscoped: true },
+    );
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith(
+      'thread-image',
+      { includeUnscoped: true },
+    );
+  });
+
+  it('arming recovery for a child thread preserves its parent and sibling routes', async () => {
+    const host = await freshCodexProxyHost();
+    const disconnectWebSocketsForThread = vi.fn(() => 2);
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      disconnectWebSocketsForThread,
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    host.registerComposed('session-family', 'thread-parent', 'PRODUCT_PROMPT');
+    expect(host.registerChildThread('thread-parent', 'thread-child')).toBe(true);
+    expect(host.registerChildThread('thread-parent', 'thread-sibling')).toBe(true);
+
+    expect(host.armCodexHttpRecovery({
+      sessionId: 'session-family',
+      threadId: 'thread-child',
+      message: 'invalid_encrypted_content',
+    })).toBe('encrypted_content');
+
+    expect(mockState.capturedRegistry?.get('thread-parent')).toBe('PRODUCT_PROMPT');
+    expect(mockState.capturedRegistry?.get('thread-child')).toBe('PRODUCT_PROMPT');
+    expect(mockState.capturedRegistry?.get('thread-sibling')).toBe('PRODUCT_PROMPT');
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith(
+      'thread-child',
+      { includeUnscoped: true },
+    );
+
+    host.unregister('session-family');
+    expect(mockState.capturedRegistry?.get('thread-parent')).toBeUndefined();
+    expect(mockState.capturedRegistry?.get('thread-child')).toBeUndefined();
+    expect(mockState.capturedRegistry?.get('thread-sibling')).toBeUndefined();
   });
 
   it('clears the websocket recovery fallback when its session is unregistered', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -85,8 +85,20 @@ vi.mock('@cindy/anthropic-compat-proxy', () => ({
   createInstructionsInjectionTransform: mockState.createInstructionsInjectionTransform,
   createActiveStripTransform: () => (() => null),
   createThreadStripController: () => ({ markActive: () => {}, reconcile: () => {}, shouldStrip: () => false, clear: () => {} }),
-  createEncryptedContentRecoveryRule: () => ({ id: 'encrypted_content', enabled: () => false, matches: () => false, strip: () => null }),
-  createImageGenerationIdRecoveryRule: () => ({ id: 'image_generation_id', enabled: () => true, matches: () => false, strip: () => null }),
+  createEncryptedContentRecoveryRule: (opts: { enabled: () => boolean }) => ({
+    id: 'encrypted_content',
+    enabled: opts.enabled,
+    matches: (text: string) =>
+      /invalid_encrypted_content|could not decrypt the provided encrypted_content/i.test(text),
+    strip: () => null,
+  }),
+  createImageGenerationIdRecoveryRule: () => ({
+    id: 'image_generation_id',
+    enabled: () => true,
+    matches: (text: string) =>
+      /image generation items without [`']?id[`']? are not supported/i.test(text),
+    strip: () => null,
+  }),
   stripEncryptedContentFromBody: () => null,
   stripImageGenerationItemsWithoutIdFromBody: () => null,
   stripNonAnthropicFields: mockState.stripNonAnthropicFields,
@@ -322,7 +334,7 @@ describe('codex gateway config', () => {
     expect(args).toContain('model_providers.cindy_openai.base_url="http://127.0.0.1:12345"');
     expect(args).toContain('model_providers.cindy_openai.wire_api="responses"');
     expect(args).toContain('model_providers.cindy_openai.requires_openai_auth=true');
-    expect(args).toContain('model_providers.cindy_openai.supports_websockets=false');
+    expect(args).toContain('model_providers.cindy_openai.supports_websockets=true');
     // is_openai + OAuth 命中时 codex 默认 zstd 压缩请求体,loopback proxy 无法解析,必须关。
     expect(args).toContain('features.enable_request_compression=false');
   });
@@ -1527,6 +1539,109 @@ describe('codex proxy host', () => {
       upstream: () => string;
     };
     expect(proxyOpts.upstream()).toBe(`${XD_GATEWAY_BASE_URL}/v1`);
+  });
+
+  it('only resolves the websocket upstream for the oauth-bearer spawn identity', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+
+    const proxyOpts = mockState.createAnthropicCompatProxy.mock.calls[0][0] as {
+      resolveWebSocketUpstream: (ctx: {
+        url: string;
+        headers: Readonly<Record<string, string>>;
+      }) => string | null;
+    };
+    const ctx = { url: '/v1/responses', headers: {} };
+
+    host.setCodexProxyAuthInjection('env-key');
+    expect(proxyOpts.resolveWebSocketUpstream(ctx)).toBeNull();
+    host.setCodexProxyAuthInjection('provider-oauth');
+    expect(proxyOpts.resolveWebSocketUpstream(ctx)).toBeNull();
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    expect(proxyOpts.resolveWebSocketUpstream(ctx)).toBe(
+      'https://chatgpt.com/backend-api/codex',
+    );
+  });
+
+  it('declines the next websocket upgrade after a body recovery error is armed', async () => {
+    const host = await freshCodexProxyHost();
+    const disconnectWebSocketsForThread = vi.fn(() => 2);
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      disconnectWebSocketsForThread,
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    const proxyOpts = mockState.createAnthropicCompatProxy.mock.calls[0][0] as {
+      resolveWebSocketUpstream: (ctx: {
+        url: string;
+        headers: Readonly<Record<string, string>>;
+      }) => string | null;
+    };
+    const ctxForThread = (threadId: string) => ({
+      url: '/v1/responses',
+      headers: { 'thread-id': threadId },
+    });
+
+    expect(proxyOpts.resolveWebSocketUpstream(ctxForThread('thread-safe'))).toBe(
+      'https://chatgpt.com/backend-api/codex',
+    );
+    expect(host.armCodexHttpRecovery({
+      sessionId: 'session-encrypted',
+      threadId: 'thread-encrypted',
+      message: 'invalid_encrypted_content',
+    })).toBe('encrypted_content');
+    expect(host.armCodexHttpRecovery({
+      sessionId: 'session-image',
+      threadId: 'thread-image',
+      message: 'Image generation items without `id` are not supported for this request.',
+    })).toBe('image_generation_id');
+
+    expect(proxyOpts.resolveWebSocketUpstream(ctxForThread('thread-encrypted'))).toBeNull();
+    expect(proxyOpts.resolveWebSocketUpstream(ctxForThread('thread-image'))).toBeNull();
+    expect(proxyOpts.resolveWebSocketUpstream(ctxForThread('thread-safe'))).toBe(
+      'https://chatgpt.com/backend-api/codex',
+    );
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-encrypted');
+    expect(disconnectWebSocketsForThread).toHaveBeenCalledWith('thread-image');
+  });
+
+  it('clears the websocket recovery fallback when its session is unregistered', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    const proxyOpts = mockState.createAnthropicCompatProxy.mock.calls[0][0] as {
+      resolveWebSocketUpstream: (ctx: {
+        url: string;
+        headers: Readonly<Record<string, string>>;
+      }) => string | null;
+    };
+    const ctx = {
+      url: '/v1/responses',
+      headers: { 'thread-id': 'thread-recovery' },
+    };
+    expect(host.armCodexHttpRecovery({
+      sessionId: 'session-recovery',
+      threadId: 'thread-recovery',
+      message: 'invalid_encrypted_content',
+    })).toBe('encrypted_content');
+    expect(proxyOpts.resolveWebSocketUpstream(ctx)).toBeNull();
+
+    host.unregister('session-recovery');
+    expect(proxyOpts.resolveWebSocketUpstream(ctx)).toBe(
+      'https://chatgpt.com/backend-api/codex',
+    );
   });
 
   it('falls back to direct gateway /v1 endpoint when proxy is not ready', async () => {

--- a/apps/desktop/src/main/maker-host/codex-gateway-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-gateway-config.ts
@@ -71,7 +71,8 @@ export function buildCodexGatewayBaseUrl(upstream = claudeUpstreamEndpoint()): s
  *     proxy 直转 gateway(不破坏现有纯 key 用户)。
  *   - provider-oauth (如 xAI): env_key=XDT_CODEX_API_KEY → codex 带占位 key,
  *     proxy 按会话用供应商 OAuth token 覆盖 Authorization。
- * supports_websockets 显式冻成 false, 防止 Codex startup prewarm 在 threadId 登记前打模型。
+ * cindy_gateway 显式冻成 false；仅 oauth-bearer 额外定义的 cindy_openai 打开 WS。
+ * 后者的 upgrade 由 loopback proxy 按 thread 转发，任何建连不兼容都会用 426 回到旧 HTTP。
  */
 export function buildCodexProxySpawnArgs(baseUrl: string, authMode: CodexProxySpawnAuthMode): string[] {
   const p = CODEX_GATEWAY_PROVIDER_ID;
@@ -84,6 +85,10 @@ export function buildCodexProxySpawnArgs(baseUrl: string, authMode: CodexProxySp
     '-c', `model_providers.${p}.base_url="${baseUrl}"`,
     '-c', `model_providers.${p}.wire_api="responses"`,
     '-c', authArg,
+    // cindy_gateway 必须留在 HTTP:proxy 要整段 JSON.parse 请求体做 instructions 注入、
+    // 按 model 分流改写与 recoveryRules,这些能力在 WS 帧上不存在(proxy 的 WS 通道只做
+    // socket 级透传)。网关 / xAI / 自定义供应商都走这个 provider,因此一律不发 upgrade。
+    // 只有不依赖请求体改写的订阅直连 provider(下面的 cindy_openai)才放开 WS。
     '-c', `model_providers.${p}.supports_websockets=false`,
   ];
   if (authMode === 'oauth-bearer') {
@@ -97,7 +102,28 @@ export function buildCodexProxySpawnArgs(baseUrl: string, authMode: CodexProxySp
       '-c', `model_providers.${o}.base_url="${baseUrl}"`,
       '-c', `model_providers.${o}.wire_api="responses"`,
       '-c', `model_providers.${o}.requires_openai_auth=true`,
-      '-c', `model_providers.${o}.supports_websockets=false`,
+      // 订阅直连走 bundled codex 原生的 Responses WebSocket:Codex 自己执行
+      // startup prewarm、连接复用、重试与 HTTP fallback；Cindy 只把 loopback upgrade
+      // 原样隧道到同一个 ChatGPT endpoint。这样 at-capacity / 重连语义由同版本 Codex
+      // 和上游决定，不在宿主侧另造一套传输策略。
+      //
+      // 字段是 boolean(实测传字符串报 `expected a boolean`),没有「只开通道不开预热」
+      // 的中间档,true 即含 prewarm。因此灰度只能由外层控制(proxy 侧
+      // resolveWebSocketUpstream 返回 null → 426 → codex 退回 HTTP),不能靠这个字段分档。
+      //
+      // 前提:proxy 必须支持 upgrade 转发(见 anthropic-compat-proxy 的
+      // resolveWebSocketUpstream),否则 codex 的 WS 会打在一个不认 upgrade 的 loopback 上。
+      //
+      // 代价(WS 上 proxy 看不到请求体,以下能力对订阅直连失效):
+      //  - recoveryRules(encrypted_content / image-id 修复):app-server 报错后由
+      //    maker-core 通知 host 按同一套 rule 判定，逐出该 thread 的预热 WS；
+      //    下一次 upgrade 返回 426，codex 降到 HTTP 后由原 recoveryRules 接管。
+      //  - responseObserver 的限流 header 观测:订阅直连已由 app-server 的
+      //    `account/rateLimits/updated` 原生通道覆盖(不经 body,不受 WS 影响)。
+      //  - prompt 改走原生 developerInstructions:Codex 0.145 自动 compact 会把当前
+      //    session 的 canonical developer context 重新注入 replacement history(中途
+      //    compact)或下一次正常采样(pre-turn compact),无需 proxy 逐请求重复注入。
+      '-c', `model_providers.${o}.supports_websockets=true`,
       // is_openai + codex-backend OAuth 命中时 codex 默认对 /responses 请求体做 zstd
       // 压缩(enable_request_compression 默认开);loopback proxy 要整段 JSON.parse
       // 改写请求体,无法解 zstd,必须显式关掉(仅少传输优化,无功能损失)。

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -142,6 +142,20 @@ export function armCodexHttpRecovery(args: {
     });
     return null;
   }
+  httpRecoveryReasonByThread.set(threadId, rule.id);
+  const disconnectedWebSockets = _handle?.disconnectWebSocketsForThread?.(threadId) ?? 0;
+  if (disconnectedWebSockets === 0) {
+    httpRecoveryReasonByThread.delete(threadId);
+    // startup-prewarm 没有稳定 thread header，且 shared app-server 会跨业务 session
+    // 复用这些连接。不能为恢复 thread A 而全局断开匿名连接（可能正承载 thread B）；
+    // 无法精确定位时保留 Codex 原生错误语义，不自动重投，也不制造跨会话降级。
+    log.info('codex websocket recovery left to native transport; no scoped socket found', {
+      sessionId,
+      threadId,
+      reason: rule.id,
+    });
+    return null;
+  }
   if (sessionId && !existingSessionId) {
     // recovery 只需要让 unregister 能清掉 thread 标记，不能调用 bindThreadToSession：
     // 子 Agent thread 与主 thread 属于同一业务 session，但 bind 会把它当成主 thread
@@ -151,11 +165,6 @@ export function armCodexHttpRecovery(args: {
     sessionToThreads.set(sessionId, threads);
     threadToSession.set(threadId, sessionId);
   }
-  httpRecoveryReasonByThread.set(threadId, rule.id);
-  const disconnectedWebSockets = _handle?.disconnectWebSocketsForThread?.(
-    threadId,
-    { includeUnscoped: true },
-  ) ?? 0;
   log.info('codex websocket recovery fallback armed', {
     sessionId,
     threadId,

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -83,6 +83,7 @@ const sessionToThread = new Map<string, string>();
 const sessionToThreads = new Map<string, Set<string>>();
 const threadToSession = new Map<string, string>();
 const reviewerModelBySession = new Map<string, string>();
+const httpRecoveryReasonByThread = new Map<string, string>();
 
 const CODEX_AUTO_REVIEW_MODEL = 'codex-auto-review';
 const CODEX_GUARDIAN_SUBAGENT = 'guardian';
@@ -95,6 +96,54 @@ let _disposeGeneration = 0;
 let dumpSeq = 0;
 
 const CODEX_RESPONSE_OBSERVER_MAX_BYTES = 2 * 1024 * 1024;
+
+const encryptedContentRecoveryRule = createEncryptedContentRecoveryRule({
+  enabled: () => readSilentEncryptedRetrySettings().enabled,
+  onRetry: (threadId, model) => encryptedStripController.markActive(threadId, model),
+});
+const imageGenerationIdRecoveryRule = createImageGenerationIdRecoveryRule({
+  onRetry: (threadId, model) => imageGenerationStripController.markActive(threadId, model),
+});
+const CODEX_BODY_RECOVERY_RULES = [
+  encryptedContentRecoveryRule,
+  imageGenerationIdRecoveryRule,
+] as const;
+
+/**
+ * WS 已建立后 proxy 只转发 socket，真正的上游请求错误会由 app-server 报给 maker-core。
+ * maker-core 把错误文本回传到这里，由与 HTTP recovery 完全相同的 rule 判定并登记：
+ * 下一次 upgrade 返回 426，Codex 原生 transport 随即切到 HTTP，既有 strip+retry 接管。
+ */
+export function armCodexHttpRecovery(args: {
+  sessionId: string;
+  threadId: string;
+  message: string;
+  additionalDetails?: string | null;
+}): string | null {
+  const threadId = args.threadId.trim();
+  if (!threadId) return null;
+  const errorText = [args.message, args.additionalDetails]
+    .filter((part): part is string => typeof part === 'string' && part.length > 0)
+    .join('\n');
+  if (!errorText) return null;
+
+  const rule = CODEX_BODY_RECOVERY_RULES.find(
+    (candidate) => candidate.enabled() && candidate.matches(errorText),
+  );
+  if (!rule) return null;
+
+  const sessionId = args.sessionId.trim();
+  if (sessionId) bindThreadToSession(sessionId, threadId);
+  httpRecoveryReasonByThread.set(threadId, rule.id);
+  const disconnectedWebSockets = _handle?.disconnectWebSocketsForThread?.(threadId) ?? 0;
+  log.info('codex websocket recovery fallback armed', {
+    sessionId,
+    threadId,
+    reason: rule.id,
+    disconnectedWebSockets,
+  });
+  return rule.id;
+}
 
 // codex 走 Responses API,每轮**全量重发**整个 thread 历史;导入的存量长会话
 // (贴图 base64 + 加密 reasoning blob,字节数膨胀远快于 token 数)单次请求体可以
@@ -2194,17 +2243,40 @@ function createCodexProxyHandle(
     ),
     maxRequestBodyBytes: CODEX_PROXY_MAX_REQUEST_BODY_BYTES,
     debugDumpRequestBody: process.env.XDT_PROXY_DUMP_REQUEST_BODY === '1',
-    recoveryRules: [
-      createEncryptedContentRecoveryRule({
-        enabled: () => readSilentEncryptedRetrySettings().enabled,
-        onRetry: (threadId, model) => encryptedStripController.markActive(threadId, model),
-      }),
-      createImageGenerationIdRecoveryRule({
-        onRetry: (threadId, model) => imageGenerationStripController.markActive(threadId, model),
-      }),
-    ],
+    recoveryRules: [...CODEX_BODY_RECOVERY_RULES],
     logger: log,
     resolveOutboundProxy: resolveDesktopOutboundProxy,
+    /**
+     * WS upgrade 的上游固定为 ChatGPT 订阅后端。
+     *
+     * 为什么可以固定: 只有订阅直连 provider(CODEX_OPENAI_COMPACT_PROVIDER_ID)打开了
+     * supports_websockets, 网关 / xAI / 自定义供应商一律保持 false 且永不发出 upgrade
+     * 请求 —— 所以任何进到这里的 upgrade 必然属于订阅直连路由, 上游是确定的, 不需要
+     * 像 HTTP 路径那样按 model 推导(upgrade 也没有 body 可供推导)。
+     *
+     * 非 oauth-bearer 态返回 null → proxy 回 426 → codex 退回 HTTP transport:
+     * 该 provider 只在 oauth spawn 时定义(见 buildCodexProxySpawnArgs), env-key /
+     * provider-oauth 进程本不该有 upgrade 进来; 真收到就让它降级, 而不是拿一个凭据
+     * 形态不匹配的连接去打订阅后端。
+     *
+     * WS 内首次命中 body recovery 错误后，maker-core 调 armCodexHttpRecovery 登记
+     * thread；下一次 upgrade 在这里回 426，Codex 原生 transport 按 session 级稳定
+     * 降到 HTTP，再由上面的 recoveryRules 清理并透明重试。没有实际命中过错误的
+     * thread 不预扫描、不降级，继续保留原生 WS 容量体验。
+     */
+    resolveWebSocketUpstream: ({ headers }) => {
+      if ((frozenAuthInjection ?? getCodexProxyAuthInjection()) !== 'oauth-bearer') return null;
+      const threadId = selectedThreadIdFromHeaders(headers);
+      const recoveryReason = httpRecoveryReasonByThread.get(threadId);
+      if (recoveryReason) {
+        log.info('codex websocket declined for HTTP body recovery', {
+          threadId,
+          reason: recoveryReason,
+        });
+        return null;
+      }
+      return CODEX_OAUTH_UPSTREAM;
+    },
   });
 }
 
@@ -2427,6 +2499,7 @@ function clearSessionThreads(sessionId: string): string[] {
     if (threadToSession.get(threadId) === sessionId) {
       threadToSession.delete(threadId);
       registry.delete(threadId);
+      httpRecoveryReasonByThread.delete(threadId);
     }
   }
   return threadIds;
@@ -2469,6 +2542,7 @@ export async function disposeCodexProxy(): Promise<void> {
   sessionToThreads.clear();
   threadToSession.clear();
   reviewerModelBySession.clear();
+  httpRecoveryReasonByThread.clear();
 
   if (_startPromise) {
     await _startPromise.catch(() => undefined);

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -133,9 +133,29 @@ export function armCodexHttpRecovery(args: {
   if (!rule) return null;
 
   const sessionId = args.sessionId.trim();
-  if (sessionId) bindThreadToSession(sessionId, threadId);
+  const existingSessionId = threadToSession.get(threadId);
+  if (sessionId && existingSessionId && existingSessionId !== sessionId) {
+    log.warn('refusing to arm codex websocket recovery for a thread owned by another session', {
+      sessionId,
+      threadId,
+      existingSessionId,
+    });
+    return null;
+  }
+  if (sessionId && !existingSessionId) {
+    // recovery 只需要让 unregister 能清掉 thread 标记，不能调用 bindThreadToSession：
+    // 子 Agent thread 与主 thread 属于同一业务 session，但 bind 会把它当成主 thread
+    // 切换并清空整个父子线程集合，连 registry 与已有 recovery 标记一起误删。
+    const threads = sessionToThreads.get(sessionId) ?? new Set<string>();
+    threads.add(threadId);
+    sessionToThreads.set(sessionId, threads);
+    threadToSession.set(threadId, sessionId);
+  }
   httpRecoveryReasonByThread.set(threadId, rule.id);
-  const disconnectedWebSockets = _handle?.disconnectWebSocketsForThread?.(threadId) ?? 0;
+  const disconnectedWebSockets = _handle?.disconnectWebSocketsForThread?.(
+    threadId,
+    { includeUnscoped: true },
+  ) ?? 0;
   log.info('codex websocket recovery fallback armed', {
     sessionId,
     threadId,

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -104,6 +104,7 @@ import { claudeSubagentUsageBridge } from './claude-subagent-usage-bridge.js';
 import { notifyAutoPermissionClassifierUnavailable } from './claude-auto-permission-fallback.js';
 import { hasClaudeAiOAuth } from './claude-credentials-store.js';
 import {
+  armCodexHttpRecovery,
   clearCodexProxyAuthInjection,
   ensureCodexControlPlaneProxyReady,
   ensureCodexProxyReady,
@@ -1110,6 +1111,7 @@ export function getMaker(): Maker {
       prepareCodexResumeSession: prepareExternalCodexSessionForResume,
       registerCodexSystemPromptForThread: ({ sessionId, threadId, text }) =>
         registerCodexProxyComposed(sessionId, threadId, text),
+      armCodexHttpRecovery,
       registerCodexReviewerRouteContext: ({ sessionId, threadId, model }) =>
         registerCodexReviewerRouteContext(sessionId, threadId, model),
       registerCodexChildThreadForParent: ({ parentThreadId, childThreadId }) => {

--- a/packages/anthropic-compat-proxy/src/headers.ts
+++ b/packages/anthropic-compat-proxy/src/headers.ts
@@ -16,9 +16,13 @@
  *   - x-client-request-id      —— **每请求唯一**,只作最后兜底;命中它时 Layer-2 标记
  *     跨不过下一请求(但 Layer-1 反应式仍每轮兜底,功能不受影响,只是少省一次往返)。
  */
-export const DEFAULT_THREAD_ID_HEADERS = [
+export const STABLE_THREAD_ID_HEADERS = [
   'x-claude-code-session-id',
   'thread-id',
+] as const;
+
+export const DEFAULT_THREAD_ID_HEADERS = [
+  ...STABLE_THREAD_ID_HEADERS,
   'x-client-request-id',
 ] as const;
 

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -304,6 +304,30 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     );
   });
 
+  it('still falls back when the discarded refusal body fails mid-stream', async () => {
+    const upstream = createServer((_req, res) => {
+      res.writeHead(403, {
+        'content-type': 'text/plain',
+        'transfer-encoding': 'chunked',
+      });
+      const socket = res.socket;
+      res.write('websocket blocked', () => socket?.destroy());
+    });
+    const port = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toBe(
+      'HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n',
+    );
+  });
+
   it.each([
     [401, 'Unauthorized'],
     [429, 'Too Many Requests'],

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -1,0 +1,419 @@
+import { createServer, type IncomingMessage } from 'node:http';
+import { connect, type Socket } from 'node:net';
+import type { Duplex } from 'node:stream';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createAnthropicCompatProxy } from './server.js';
+import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
+import { startSocks5Stub } from './test-socks5-stub.js';
+import type { ProxyHandle } from './types.js';
+
+interface UpgradeResponse {
+  socket: Socket;
+  head: string;
+  rest: Buffer;
+}
+
+const sockets = new Set<Socket | Duplex>();
+const cleanups: Array<() => Promise<void> | void> = [];
+let proxy: ProxyHandle | null = null;
+
+afterEach(async () => {
+  if (proxy) {
+    await proxy.dispose();
+    proxy = null;
+  }
+  for (const socket of sockets) socket.destroy();
+  sockets.clear();
+  while (cleanups.length) await cleanups.pop()!();
+});
+
+function upgradeRequest(
+  path: string,
+  host: string,
+  tail = Buffer.alloc(0),
+  extraHeaders: readonly string[] = [],
+): Buffer {
+  const head = [
+    `GET ${path} HTTP/1.1`,
+    `Host: ${host}`,
+    'Connection: Upgrade',
+    'Upgrade: websocket',
+    'Sec-WebSocket-Key: dGVzdC13ZWJzb2NrZXQta2V5',
+    'Sec-WebSocket-Version: 13',
+    ...extraHeaders,
+    '',
+    '',
+  ].join('\r\n');
+  return Buffer.concat([Buffer.from(head), tail]);
+}
+
+function openUpgrade(
+  proxyUrl: string,
+  path = '/v1/responses',
+  tail = Buffer.alloc(0),
+  extraHeaders: readonly string[] = [],
+): Promise<UpgradeResponse> {
+  const endpoint = new URL(proxyUrl);
+  return new Promise<UpgradeResponse>((resolve, reject) => {
+    const socket = connect(Number(endpoint.port), endpoint.hostname);
+    sockets.add(socket);
+    const chunks: Buffer[] = [];
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error('timed out waiting for upgrade response'));
+    }, 2_000);
+    const fail = (error: Error): void => {
+      clearTimeout(timeout);
+      reject(error);
+    };
+    socket.once('error', fail);
+    socket.once('connect', () => {
+      socket.write(upgradeRequest(path, endpoint.host, tail, extraHeaders));
+    });
+    const onData = (chunk: Buffer): void => {
+      chunks.push(chunk);
+      const all = Buffer.concat(chunks);
+      const boundary = all.indexOf('\r\n\r\n');
+      if (boundary < 0) return;
+      clearTimeout(timeout);
+      socket.off('error', fail);
+      socket.off('data', onData);
+      resolve({
+        socket,
+        head: all.subarray(0, boundary + 4).toString('latin1'),
+        rest: all.subarray(boundary + 4),
+      });
+    };
+    socket.on('data', onData);
+  });
+}
+
+async function readUpgradeFailure(proxyUrl: string, path = '/v1/responses'): Promise<string> {
+  const { socket, head, rest } = await openUpgrade(proxyUrl, path);
+  const chunks = [rest];
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.destroy();
+      reject(new Error('timed out waiting for failed upgrade to close'));
+    }, 2_000);
+    socket.on('data', (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+    socket.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    const finish = (): void => {
+      clearTimeout(timeout);
+      resolve();
+    };
+    socket.once('end', finish);
+    socket.once('close', finish);
+  });
+  return head + Buffer.concat(chunks).toString('utf8');
+}
+
+function waitForSocketText(socket: Socket, initial: Buffer, expected: string): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let collected = initial.toString('utf8');
+    if (collected.includes(expected)) {
+      resolve(collected);
+      return;
+    }
+    const timeout = setTimeout(() => {
+      reject(new Error(`timed out waiting for socket text ${expected}`));
+    }, 2_000);
+    const onData = (chunk: Buffer): void => {
+      collected += chunk.toString('utf8');
+      if (!collected.includes(expected)) return;
+      clearTimeout(timeout);
+      socket.off('data', onData);
+      resolve(collected);
+    };
+    socket.on('data', onData);
+  });
+}
+
+function startUpgradeUpstream(opts: { handshakeDelayMs?: number } = {}): Promise<{
+  url: string;
+  requests: IncomingMessage[];
+  received: string[];
+}> {
+  const requests: IncomingMessage[] = [];
+  const received: string[] = [];
+  const server = createServer();
+  server.on('upgrade', (req, socket) => {
+    sockets.add(socket);
+    requests.push(req);
+    setTimeout(() => {
+      socket.write([
+        'HTTP/1.1 101 Switching Protocols',
+        'Connection: Upgrade',
+        'Upgrade: websocket',
+        'Sec-WebSocket-Extensions: permessage-deflate',
+        'X-Upstream: accepted',
+        '',
+        'SERVER_HEAD',
+      ].join('\r\n'));
+    }, opts.handshakeDelayMs ?? 0);
+    socket.on('data', (chunk) => {
+      received.push(chunk.toString('utf8'));
+      if (Buffer.concat([Buffer.from(received.join(''))]).includes(Buffer.from('PING'))) {
+        socket.write('PONG');
+      }
+    });
+    // 模拟正常的 WebSocket 对端:收到 TCP FIN 后也结束自己的写侧,完成双向关闭。
+    socket.on('end', () => socket.end());
+  });
+  return listenOnAvailableLoopbackPort(server).then((port) => {
+    cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
+    return { url: `http://127.0.0.1:${port}`, requests, received };
+  });
+}
+
+describe('anthropic-compat-proxy websocket upgrades', () => {
+  it('forwards the upgrade handshake, strips /v1, and pipes buffered bytes both ways', async () => {
+    const upstream = await startUpgradeUpstream();
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `${upstream.url}/backend-api/codex`,
+    });
+
+    const response = await openUpgrade(
+      proxy.url,
+      '/v1/responses?feature=websocket',
+      Buffer.from('CLIENT_HEAD'),
+      [
+        'Authorization: Bearer test-token',
+        'OpenAI-Beta: responses_websockets=2026-02-06',
+        'X-Codex-Turn-Metadata: test-metadata',
+      ],
+    );
+    expect(response.head).toContain('HTTP/1.1 101 Switching Protocols');
+    expect(response.head.toLowerCase()).toContain('connection: upgrade');
+    expect(response.head.toLowerCase()).toContain('upgrade: websocket');
+    expect(response.head.toLowerCase()).toContain(
+      'sec-websocket-extensions: permessage-deflate',
+    );
+    expect(response.head.toLowerCase()).toContain('x-upstream: accepted');
+    expect(response.rest.toString('utf8')).toContain('SERVER_HEAD');
+
+    response.socket.write('PING');
+    const clientBytes = await waitForSocketText(response.socket, response.rest, 'PONG');
+    expect(clientBytes).toContain('SERVER_HEAD');
+    expect(clientBytes).toContain('PONG');
+
+    expect(upstream.requests).toHaveLength(1);
+    expect(upstream.requests[0].url).toBe('/backend-api/codex/responses?feature=websocket');
+    expect(upstream.requests[0].headers.connection?.toLowerCase()).toBe('upgrade');
+    expect(upstream.requests[0].headers.upgrade?.toLowerCase()).toBe('websocket');
+    expect(upstream.requests[0].headers.host).toBe(
+      new URL(upstream.url).host,
+    );
+    expect(upstream.requests[0].headers.authorization).toBe('Bearer test-token');
+    expect(upstream.requests[0].headers['openai-beta']).toBe(
+      'responses_websockets=2026-02-06',
+    );
+    expect(upstream.requests[0].headers['x-codex-turn-metadata']).toBe('test-metadata');
+    expect(upstream.received.join('')).toContain('CLIENT_HEAD');
+    expect(upstream.received.join('')).toContain('PING');
+  });
+
+  it('returns 426 as a complete HTTP response when the host requests HTTP fallback', async () => {
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => null,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toBe(
+      'HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n',
+    );
+  });
+
+  it('forwards an upstream at-capacity response without stale chunk framing', async () => {
+    const upstream = createServer((_req, res) => {
+      res.writeHead(503, {
+        'content-type': 'application/json',
+        'transfer-encoding': 'chunked',
+        'x-upstream': 'capacity',
+      });
+      res.write('{"error":{"code":"');
+      res.end('server_is_overloaded"}}');
+    });
+    const port = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    const [head, body] = response.split('\r\n\r\n', 2);
+    expect(head).toContain('HTTP/1.1 503 Service Unavailable');
+    expect(head.toLowerCase()).not.toContain('transfer-encoding');
+    expect(head.toLowerCase()).not.toContain('content-length');
+    expect(head.toLowerCase()).toContain('connection: close');
+    expect(head).toContain('x-upstream: capacity');
+    expect(body).toBe('{"error":{"code":"server_is_overloaded"}}');
+  });
+
+  it('falls back to HTTP when the network path refuses websocket upgrades', async () => {
+    const upstream = createServer((_req, res) => {
+      res.writeHead(403, { 'content-type': 'text/plain' });
+      res.end('websocket blocked by intermediary');
+    });
+    const port = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toBe(
+      'HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n',
+    );
+  });
+
+  it.each([
+    [401, 'Unauthorized'],
+    [429, 'Too Many Requests'],
+  ])('preserves upstream status %i instead of hiding it behind HTTP fallback', async (
+    status,
+    statusText,
+  ) => {
+    const upstream = createServer((_req, res) => {
+      res.writeHead(status, { 'content-type': 'application/json' });
+      res.end(`{"error":{"status":${status}}}`);
+    });
+    const port = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toContain(`HTTP/1.1 ${status} ${statusText}`);
+    expect(response).toContain(`{"error":{"status":${status}}}`);
+  });
+
+  it('does not impose a local websocket capacity limit', async () => {
+    // 容量由 Codex / 上游控制。proxy 自设连接上限会凭空制造 503,让 Cindy 的
+    // at-capacity 行为与官方 Codex 不一致。
+    const upstream = await startUpgradeUpstream({ handshakeDelayMs: 25 });
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => upstream.url,
+    });
+
+    const attempts = await Promise.all(
+      Array.from({ length: 9 }, (_, i) => openUpgrade(proxy!.url, `/v1/responses?slot=${i}`)),
+    );
+    expect(attempts).toHaveLength(9);
+    expect(attempts.every((result) => result.head.includes(' 101 '))).toBe(true);
+  });
+
+  it('disconnects only the prewarmed websocket clients for the requested thread', async () => {
+    const upstream = await startUpgradeUpstream();
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => upstream.url,
+    });
+
+    const threadA = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      ['Thread-Id: thread-a'],
+    );
+    const threadB = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      ['Thread-Id: thread-b'],
+    );
+    const threadAClosed = new Promise<void>((resolve) => {
+      threadA.socket.once('close', () => resolve());
+    });
+
+    expect(proxy.disconnectWebSocketsForThread?.('thread-a')).toBe(1);
+    await threadAClosed;
+    expect(threadA.socket.destroyed).toBe(true);
+    expect(threadB.socket.destroyed).toBe(false);
+
+    threadB.socket.write('PING');
+    await expect(waitForSocketText(threadB.socket, threadB.rest, 'PONG')).resolves.toContain('PONG');
+    expect(proxy.disconnectWebSocketsForThread?.('thread-missing')).toBe(0);
+  });
+
+  it('routes an https websocket upstream through the configured HTTP CONNECT proxy', async () => {
+    const connects: string[] = [];
+    const outbound = createServer();
+    outbound.on('connect', (req, clientSocket) => {
+      connects.push(req.url ?? '');
+      clientSocket.end('HTTP/1.1 502 Bad Gateway\r\n\r\n');
+    });
+    const outboundPort = await listenOnAvailableLoopbackPort(outbound);
+    cleanups.push(() => new Promise<void>((resolve) => outbound.close(() => resolve())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => 'https://upstream.invalid/backend-api/codex',
+      resolveOutboundProxy: () => `http://127.0.0.1:${outboundPort}`,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toContain('HTTP/1.1 426 Upgrade Required');
+    expect(connects).toEqual(['upstream.invalid:443']);
+  });
+
+  it('tunnels a websocket through SOCKS5 and leaves upstream DNS to the proxy', async () => {
+    const upstream = await startUpgradeUpstream();
+    const upstreamPort = Number(new URL(upstream.url).port);
+    const socks = await startSocks5Stub({ tunnelToPort: upstreamPort });
+    cleanups.push(() => socks.close());
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => 'http://upstream.invalid:8080/backend-api/codex',
+      resolveOutboundProxy: () => `socks5://127.0.0.1:${socks.port}`,
+    });
+
+    const response = await openUpgrade(proxy.url);
+    expect(response.head).toContain('HTTP/1.1 101 Switching Protocols');
+    expect(socks.requests).toEqual([
+      { atyp: 0x03, host: 'upstream.invalid', port: 8080 },
+    ]);
+    expect(upstream.requests[0].url).toBe('/backend-api/codex/responses');
+  });
+
+  it('dispose closes established websocket clients instead of waiting on the long connection', async () => {
+    const upstream = await startUpgradeUpstream();
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => upstream.url,
+    });
+    const response = await openUpgrade(proxy.url);
+    const closed = new Promise<void>((resolve) => response.socket.once('close', () => resolve()));
+
+    await proxy.dispose();
+    proxy = null;
+    await closed;
+
+    expect(response.socket.destroyed).toBe(true);
+  });
+});

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -1,5 +1,5 @@
 import { ClientRequest, createServer, type IncomingMessage } from 'node:http';
-import { connect, type Socket } from 'node:net';
+import { connect, Socket } from 'node:net';
 import type { Duplex } from 'node:stream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -251,6 +251,64 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     expect(response).toBe(
       'HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n',
     );
+  });
+
+  it('handles an asynchronous socket error while writing an early 426 response', async () => {
+    const originalEnd = Socket.prototype.end;
+    let injectedWriteError = false;
+    const endSpy = vi.spyOn(Socket.prototype, 'end');
+    const implementation = function (
+      this: Socket,
+      chunk?: unknown,
+      ...rest: unknown[]
+    ): Socket {
+      if (
+        !injectedWriteError
+        && typeof chunk === 'string'
+        && chunk.startsWith('HTTP/1.1 426 Upgrade Required')
+      ) {
+        injectedWriteError = true;
+        queueMicrotask(() => {
+          const error = Object.assign(new Error('simulated early upgrade write failure'), {
+            code: 'EPIPE',
+          });
+          this.emit('error', error);
+        });
+        return this;
+      }
+      return Reflect.apply(originalEnd, this, [chunk, ...rest]) as Socket;
+    };
+    endSpy.mockImplementation(implementation as typeof Socket.prototype.end);
+
+    try {
+      proxy = await createAnthropicCompatProxy({
+        upstream: 'http://unused.invalid',
+        transformRequest: [],
+        resolveWebSocketUpstream: () => null,
+      });
+      const endpoint = new URL(proxy.url);
+      await new Promise<void>((resolve, reject) => {
+        const socket = connect(Number(endpoint.port), endpoint.hostname);
+        sockets.add(socket);
+        const timeout = setTimeout(() => {
+          socket.destroy();
+          reject(new Error('timed out waiting for failed upgrade socket to close'));
+        }, 2_000);
+        socket.once('error', () => {
+          // Server-side simulated EPIPE may surface as a reset to this test client.
+        });
+        socket.once('close', () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+        socket.once('connect', () => {
+          socket.write(upgradeRequest('/v1/responses', endpoint.host));
+        });
+      });
+      expect(injectedWriteError).toBe(true);
+    } finally {
+      endSpy.mockRestore();
+    }
   });
 
   it('forwards an upstream at-capacity response without stale chunk framing', async () => {

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -261,6 +261,29 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     expect(body).toBe('{"error":{"code":"server_is_overloaded"}}');
   });
 
+  it('closes the client when a preserved refusal body fails mid-stream', async () => {
+    const upstream = createServer((_req, res) => {
+      res.writeHead(503, {
+        'content-type': 'application/json',
+        'transfer-encoding': 'chunked',
+      });
+      const socket = res.socket;
+      res.write('{"error":"partial', () => socket?.destroy());
+    });
+    const port = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((resolve) => upstream.close(() => resolve())));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+    });
+
+    const response = await readUpgradeFailure(proxy.url);
+    expect(response).toContain('HTTP/1.1 503 Service Unavailable');
+    expect(response).toContain('{"error":"partial');
+  });
+
   it('falls back to HTTP when the network path refuses websocket upgrades', async () => {
     const upstream = createServer((_req, res) => {
       res.writeHead(403, { 'content-type': 'text/plain' });
@@ -355,6 +378,52 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     threadB.socket.write('PING');
     await expect(waitForSocketText(threadB.socket, threadB.rest, 'PONG')).resolves.toContain('PONG');
     expect(proxy.disconnectWebSocketsForThread?.('thread-missing')).toBe(0);
+  });
+
+  it('can evict unscoped startup-prewarm sockets without closing other owned threads', async () => {
+    const upstream = await startUpgradeUpstream();
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://unused.invalid',
+      transformRequest: [],
+      resolveWebSocketUpstream: () => upstream.url,
+    });
+
+    const unscoped = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      ['X-Client-Request-Id: request-only-id'],
+    );
+    const target = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      ['Thread-Id: thread-target'],
+    );
+    const other = await openUpgrade(
+      proxy.url,
+      '/v1/responses',
+      Buffer.alloc(0),
+      ['Thread-Id: thread-other'],
+    );
+    const unscopedClosed = new Promise<void>((resolve) => {
+      unscoped.socket.once('close', () => resolve());
+    });
+    const targetClosed = new Promise<void>((resolve) => {
+      target.socket.once('close', () => resolve());
+    });
+
+    expect(proxy.disconnectWebSocketsForThread?.(
+      'thread-target',
+      { includeUnscoped: true },
+    )).toBe(2);
+    await Promise.all([unscopedClosed, targetClosed]);
+    expect(unscoped.socket.destroyed).toBe(true);
+    expect(target.socket.destroyed).toBe(true);
+    expect(other.socket.destroyed).toBe(false);
+
+    other.socket.write('PING');
+    await expect(waitForSocketText(other.socket, other.rest, 'PONG')).resolves.toContain('PONG');
   });
 
   it('routes an https websocket upstream through the configured HTTP CONNECT proxy', async () => {

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -137,12 +137,15 @@ function startUpgradeUpstream(opts: { handshakeDelayMs?: number } = {}): Promise
   url: string;
   requests: IncomingMessage[];
   received: string[];
+  connections: Duplex[];
 }> {
   const requests: IncomingMessage[] = [];
   const received: string[] = [];
+  const connections: Duplex[] = [];
   const server = createServer();
   server.on('upgrade', (req, socket) => {
     sockets.add(socket);
+    connections.push(socket);
     requests.push(req);
     setTimeout(() => {
       socket.write([
@@ -166,7 +169,7 @@ function startUpgradeUpstream(opts: { handshakeDelayMs?: number } = {}): Promise
   });
   return listenOnAvailableLoopbackPort(server).then((port) => {
     cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
-    return { url: `http://127.0.0.1:${port}`, requests, received };
+    return { url: `http://127.0.0.1:${port}`, requests, received, connections };
   });
 }
 
@@ -509,7 +512,7 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     expect(upstream.requests[0].url).toBe('/backend-api/codex/responses');
   });
 
-  it('dispose closes established websocket clients instead of waiting on the long connection', async () => {
+  it('dispose closes both sides of established websockets instead of leaking the upstream', async () => {
     const upstream = await startUpgradeUpstream();
     proxy = await createAnthropicCompatProxy({
       upstream: 'http://unused.invalid',
@@ -517,12 +520,16 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
       resolveWebSocketUpstream: () => upstream.url,
     });
     const response = await openUpgrade(proxy.url);
-    const closed = new Promise<void>((resolve) => response.socket.once('close', () => resolve()));
+    const upstreamSocket = upstream.connections[0];
+    if (!upstreamSocket) throw new Error('expected established upstream socket');
+    const clientClosed = new Promise<void>((resolve) => response.socket.once('close', () => resolve()));
+    const upstreamClosed = new Promise<void>((resolve) => upstreamSocket.once('close', () => resolve()));
 
     await proxy.dispose();
     proxy = null;
-    await closed;
+    await Promise.all([clientClosed, upstreamClosed]);
 
     expect(response.socket.destroyed).toBe(true);
+    expect(upstreamSocket.destroyed).toBe(true);
   });
 });

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -283,6 +283,7 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
   });
 
   it('closes the client when a preserved refusal body fails mid-stream', async () => {
+    const warns: Array<{ msg: string; ctx?: Record<string, unknown> }> = [];
     const upstream = createServer((_req, res) => {
       res.writeHead(503, {
         'content-type': 'application/json',
@@ -298,11 +299,16 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
       upstream: 'http://unused.invalid',
       transformRequest: [],
       resolveWebSocketUpstream: () => `http://127.0.0.1:${port}`,
+      logger: { warn: (msg, ctx) => warns.push({ msg, ctx }) },
     });
 
     const response = await readUpgradeFailure(proxy.url);
     expect(response).toContain('HTTP/1.1 503 Service Unavailable');
     expect(response).toContain('{"error":"partial');
+    expect(warns).toContainEqual(expect.objectContaining({
+      msg: 'websocket refusal response body failed',
+      ctx: expect.objectContaining({ reason: 'aborted', status: 503 }),
+    }));
   });
 
   it('falls back to HTTP when the network path refuses websocket upgrades', async () => {

--- a/packages/anthropic-compat-proxy/src/server-websocket.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-websocket.test.ts
@@ -1,7 +1,7 @@
-import { createServer, type IncomingMessage } from 'node:http';
+import { ClientRequest, createServer, type IncomingMessage } from 'node:http';
 import { connect, type Socket } from 'node:net';
 import type { Duplex } from 'node:stream';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createAnthropicCompatProxy } from './server.js';
 import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
@@ -219,6 +219,24 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     expect(upstream.received.join('')).toContain('PING');
   });
 
+  it('uses a short timeout for the websocket handshake', async () => {
+    const setTimeoutSpy = vi.spyOn(ClientRequest.prototype, 'setTimeout');
+    try {
+      const upstream = await startUpgradeUpstream();
+      proxy = await createAnthropicCompatProxy({
+        upstream: 'http://unused.invalid',
+        transformRequest: [],
+        resolveWebSocketUpstream: () => upstream.url,
+      });
+
+      const response = await openUpgrade(proxy.url);
+      expect(response.head).toContain('HTTP/1.1 101 Switching Protocols');
+      expect(setTimeoutSpy.mock.calls.some(([timeout]) => timeout === 15_000)).toBe(true);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it('returns 426 as a complete HTTP response when the host requests HTTP fallback', async () => {
     proxy = await createAnthropicCompatProxy({
       upstream: 'http://unused.invalid',
@@ -404,7 +422,7 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
     expect(proxy.disconnectWebSocketsForThread?.('thread-missing')).toBe(0);
   });
 
-  it('can evict unscoped startup-prewarm sockets without closing other owned threads', async () => {
+  it('does not evict unscoped startup-prewarm sockets for another thread', async () => {
     const upstream = await startUpgradeUpstream();
     proxy = await createAnthropicCompatProxy({
       upstream: 'http://unused.invalid',
@@ -430,22 +448,20 @@ describe('anthropic-compat-proxy websocket upgrades', () => {
       Buffer.alloc(0),
       ['Thread-Id: thread-other'],
     );
-    const unscopedClosed = new Promise<void>((resolve) => {
-      unscoped.socket.once('close', () => resolve());
-    });
     const targetClosed = new Promise<void>((resolve) => {
       target.socket.once('close', () => resolve());
     });
 
-    expect(proxy.disconnectWebSocketsForThread?.(
-      'thread-target',
-      { includeUnscoped: true },
-    )).toBe(2);
-    await Promise.all([unscopedClosed, targetClosed]);
-    expect(unscoped.socket.destroyed).toBe(true);
+    expect(proxy.disconnectWebSocketsForThread?.('thread-target')).toBe(1);
+    await targetClosed;
+    expect(unscoped.socket.destroyed).toBe(false);
     expect(target.socket.destroyed).toBe(true);
     expect(other.socket.destroyed).toBe(false);
 
+    unscoped.socket.write('PING');
+    await expect(
+      waitForSocketText(unscoped.socket, unscoped.rest, 'PONG'),
+    ).resolves.toContain('PONG');
     other.socket.write('PING');
     await expect(waitForSocketText(other.socket, other.rest, 'PONG')).resolves.toContain('PONG');
   });

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -1856,16 +1856,35 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         // 中途断开，必须自己结束客户端写侧；否则 Codex 会一直等 EOF，未监听的
         // IncomingMessage error 还可能升级为进程级异常。用 end 而不是立即 destroy，
         // 先尽量刷出已经收到的状态行和错误详情。
-        upstreamRes.once('error', (err) => {
+        let refusalBodyTerminal = false;
+        const failRefusalBody = (
+          reason: 'error' | 'aborted' | 'close',
+          err?: Error,
+        ): void => {
+          if (refusalBodyTerminal) return;
+          refusalBodyTerminal = true;
           logger.warn?.('websocket refusal response body failed', {
             reqId,
             status,
             path: upstreamPath,
-            err: String(err),
+            reason,
+            err: err ? String(err) : undefined,
           });
           if (!clientSocket.destroyed) {
             clientSocket.end(() => clientSocket.destroy());
           }
+        };
+        upstreamRes.once('end', () => {
+          refusalBodyTerminal = true;
+        });
+        upstreamRes.once('error', (err) => failRefusalBody('error', err));
+        // IncomingMessage 对提前断流的事件形态取决于 Node/代理/平台：可能有 error，
+        // 也可能只有 aborted 或 incomplete close。三路必须汇入同一个幂等收口，
+        // 否则裸 socket 没有 EOF，Codex 会一直等拒绝响应结束。
+        upstreamRes.once('aborted', () => failRefusalBody('aborted'));
+        upstreamRes.once('close', () => {
+          if (refusalBodyTerminal || upstreamRes.complete) return;
+          failRefusalBody('close');
         });
         upstreamRes.pipe(clientSocket);
       });

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -13,7 +13,7 @@
  *      详见 dispose() 内注释。
  */
 
-import { createServer, request as httpRequest, type IncomingMessage, type RequestOptions, type Server, type ServerResponse } from 'node:http';
+import { createServer, request as httpRequest, type ClientRequest, type IncomingMessage, type RequestOptions, type Server, type ServerResponse } from 'node:http';
 import { request as httpsRequest } from 'node:https';
 import type { Socket, TcpSocketConnectOpts } from 'node:net';
 import { URL } from 'node:url';
@@ -258,6 +258,75 @@ function respondRoutingFailure(
     return;
   }
   res.destroy(err instanceof Error ? err : new Error(String(err)));
+}
+
+/**
+ * upgrade 阶段失败时写回一个明确的 HTTP 状态行再断开。
+ *
+ * **不能只 destroy socket**: codex 对裸断开会以 ~1s 间隔持续发 willRetry=true 的 error
+ * notification, 而客户端按协议对 willRetry 不收口 —— turn 永不结束、UI 的 generating
+ * 永不复位(远端 codex "永卡 generating" 就是这个形态, 见客户端仓 PR #715)。写回状态行
+ * 才能让 codex 走它自己的终态路径。
+ *
+ * 状态码语义(调用方按场景选):
+ *  - **426**: 让 codex 优雅退回 HTTP transport。这是它唯一认作降级信号的状态码,
+ *    用于宿主主动把某个会话导回 HTTP(见 ProxyOptions.resolveWebSocketUpstream)。
+ *  - 501: 本 proxy 不支持这种 upgrade(非 websocket 协议)。
+ *  - 502 / 503 / 504: 上游或本地转发失败。
+ */
+function writeUpgradeFailure(socket: Socket, status: number, message: string): void {
+  try {
+    // 先完整刷出状态行再断开。`write()` 后立刻 `destroy()` 在 Windows 上可能让尚未
+    // 进入内核发送缓冲的小响应变成 RST，codex 看不到 426 就不会切回 HTTP。
+    socket.end(
+      `HTTP/1.1 ${status} ${message}\r\nConnection: close\r\n\r\n`,
+      () => socket.destroy(),
+    );
+  } catch {
+    // socket 可能已经废了(客户端先断/写入竞态), 此处无可挽回也无需上报。
+    socket.destroy();
+  }
+}
+
+/**
+ * 非 101 响应是否更像「这条网络路径不支持 WebSocket」而非模型服务故障。
+ *
+ * 这些状态在 upgrade 阶段尚未创建模型响应，退回 HTTP 不会重复执行 turn：
+ * - 2xx/3xx/大多数 4xx：透明代理/WAF 拦了 upgrade、端点不支持 WS 等，旧 HTTP 可能可用；
+ * - 401：凭证本身失效，应保留原错误；
+ * - 429：真实限流/容量信号，应交给同版本 Codex；
+ * - 5xx：上游服务状态（含 at-capacity）应原样交给 Codex，不能被本地改写。
+ */
+function shouldFallbackToHttpAfterUpgradeResponse(status: number): boolean {
+  return status < 500 && status !== 401 && status !== 429;
+}
+
+/**
+ * 把上游响应的状态行与 header 序列化回原始 HTTP 报文头。
+ *
+ * upgrade 路径上客户端拿到的是裸 socket, 没有 ServerResponse 可用, 只能自己拼报文 ——
+ * 无论是成功的 101 还是上游拒绝时的普通响应, 都要原样回写状态码与 header。
+ */
+function serializeResponseHead(
+  res: IncomingMessage,
+  opts?: {
+    /** 要丢弃的 header 名(大小写不敏感)。 */
+    readonly dropHeaders?: readonly string[];
+    /** 追加/覆盖的 header。 */
+    readonly extraHeaders?: Readonly<Record<string, string>>;
+  },
+): string {
+  const dropped = new Set((opts?.dropHeaders ?? []).map((h) => h.toLowerCase()));
+  const statusLine = `HTTP/1.1 ${res.statusCode ?? 502} ${res.statusMessage ?? ''}\r\n`;
+  const lines = Object.entries(res.headers)
+    .flatMap(([key, value]) => {
+      if (value == null || dropped.has(key.toLowerCase())) return [];
+      return Array.isArray(value) ? value.map((v) => `${key}: ${v}`) : [`${key}: ${value}`];
+    });
+  for (const [key, value] of Object.entries(opts?.extraHeaders ?? {})) {
+    lines.push(`${key}: ${value}`);
+  }
+  return `${statusLine}${lines.join('\r\n')}\r\n\r\n`;
 }
 
 /** 路由层是最后的信任边界；任何调用方给出的路径覆盖都必须保持同源且不可注入 header。 */
@@ -1478,6 +1547,292 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     );
   });
 
+  // 同时占用的 WS 数(正在握手 + 已建立),仅用于日志观测,不参与拒绝策略。
+  // 容量控制属于 Codex / 上游职责；proxy 自设上限会凭空制造本地 503,让 Cindy 的
+  // at-capacity 体验反而劣于同版本 Codex。刻意不并入 inflight —— WS 是长连接,
+  // 计入会让 dispose 的清零等待永不满足。
+  let liveWebSockets = 0;
+  interface LiveWebSocket {
+    readonly threadId: string;
+    readonly clientSocket: Socket;
+    upstreamSocket: Socket | null;
+    closeForHostFallback(): void;
+  }
+  const liveWebSocketConnections = new Set<LiveWebSocket>();
+
+  /**
+   * WebSocket upgrade 透传。
+   *
+   * **为什么需要**: bundled codex 的 Responses transport 自己负责 startup prewarm、
+   * 连接复用、重试与 HTTP fallback。proxy 不支持 upgrade 时只能给 provider 设
+   * supports_websockets=false,Cindy 就无法使用与同版本 Codex 相同的原生传输。
+   * 本层只做透明隧道,不自行解释或改写 at-capacity / 重连语义。
+   *
+   * **刻意只做 socket 级透传, 不解析 WS 帧**: requestTransform / routingTransform 的
+   * body 改写、recoveryRules、responseObserver 全部依赖读写一次性请求体, 而 WS 帧里
+   * 没有这个东西。需要那些能力的会话应由宿主在 resolveWebSocketUpstream 返回 null,
+   * 走 426 退回 HTTP(见 types.ts 该字段注释), 而不是在这里半解析。
+   *
+   * inflight 计数刻意不加: WS 是长连接, 计入会让 dispose 的清零等待永不满足。socket
+   * 本身由下面的 'connection' 监听收录进 inflightSockets, dispose 时统一 destroy。
+   */
+  server.on('upgrade', (req, clientSocket: Socket, head: Buffer) => {
+    const reqId = ++reqIdSeq;
+    const headers = flattenRequestHeaders(req.headers);
+    const url = req.url ?? '/';
+    const resolveWsUpstream = opts.resolveWebSocketUpstream;
+
+    // 不配 resolver = 本 proxy 不接 upgrade(Claude Code 侧就是这样, 行为与扩展前一致)。
+    if (!resolveWsUpstream) {
+      logger.debug?.('upgrade rejected — resolveWebSocketUpstream not configured', { reqId, url });
+      writeUpgradeFailure(clientSocket, 501, 'Not Implemented');
+      return;
+    }
+    // 只接 websocket; 其它 upgrade 协议(h2c 等)不猜语义。
+    if ((headers.upgrade ?? '').toLowerCase() !== 'websocket') {
+      logger.debug?.('upgrade rejected — not a websocket upgrade', {
+        reqId, url, upgrade: headers.upgrade ?? '',
+      });
+      writeUpgradeFailure(clientSocket, 501, 'Not Implemented');
+      return;
+    }
+    let upstreamUrl: string | null;
+    try {
+      upstreamUrl = resolveWsUpstream({ url, headers });
+    } catch (err) {
+      logger.warn?.('resolveWebSocketUpstream threw — falling back to HTTP', {
+        reqId,
+        url,
+        err: String(err),
+      });
+      writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+      return;
+    }
+    if (!upstreamUrl) {
+      // **426 而不是 501**: 这是 codex 唯一认作"退回 HTTP transport"的状态码, 且它的
+      // 降级是 session 级(一次即稳定)。宿主返回 null 的语义是"这个会话走 HTTP 更合适"
+      // (需要 recoveryRules / responseObserver), 不是拒绝服务 —— 用 501 会让 codex
+      // 直接报错而不是降级。
+      logger.debug?.('upgrade declined by host — signalling 426 to fall back to HTTP', { reqId, url });
+      writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+      return;
+    }
+
+    let target: UpstreamTarget;
+    try {
+      target = parseUpstream(upstreamUrl);
+    } catch (err) {
+      logger.error?.('resolveWebSocketUpstream returned an unusable url — falling back to HTTP', {
+        reqId,
+        err: String(err),
+      });
+      writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+      return;
+    }
+
+    // 异步出网前开始计数,让日志同时覆盖 pending 与 established。
+    liveWebSockets += 1;
+
+    let established = false;
+    let settled = false;
+    let upstreamReqForEarlyClose: ClientRequest | null = null;
+    const threadId = selectedHeaderValue(headers, DEFAULT_THREAD_ID_HEADERS);
+    const connection: LiveWebSocket = {
+      threadId,
+      clientSocket,
+      upstreamSocket: null,
+      closeForHostFallback: () => {
+        settle('host-http-fallback');
+        connection.upstreamSocket?.destroy();
+        clientSocket.destroy();
+        if (!established) upstreamReqForEarlyClose?.destroy();
+      },
+    };
+    const settle = (why: string, err?: Error): void => {
+      if (settled) return;
+      settled = true;
+      liveWebSockets -= 1;
+      liveWebSocketConnections.delete(connection);
+      logger.info?.('◀ websocket closed', {
+        reqId,
+        threadId: threadId || undefined,
+        why,
+        live: liveWebSockets,
+        err: err ? String(err) : undefined,
+      });
+    };
+    liveWebSocketConnections.add(connection);
+
+    // client 可能在 resolveOutboundForTarget 尚未返回时就离开。close 必须立即归还预占
+    // 槽位;若上游请求已经创建,同时终止它,避免无人接收的握手继续占网络资源。
+    clientSocket.on('close', () => {
+      settle('client-close');
+      if (!established) upstreamReqForEarlyClose?.destroy();
+    });
+    // resolver / PAC 解析本身是异步的。error listener 必须在 await 之前安装,否则
+    // Windows 代理切换、网络瞬断等事件若恰好落在这个窗口,Socket 的未监听 error
+    // 可能上抛到进程级。upstream request 尚未创建时只记账；创建后同时终止它。
+    clientSocket.on('error', (err) => {
+      if (established) return;
+      logger.debug?.('client socket error before upgrade established', { reqId, err: String(err) });
+      settle('client-error', err);
+      upstreamReqForEarlyClose?.destroy();
+    });
+
+    void (async () => {
+      const outbound = await resolveOutboundForTarget(target, reqId);
+      if (settled || clientSocket.destroyed) return;
+
+      // codex 构造 WS URL 的规则是 `base_url + "/responses"`。宿主给 codex 的 base_url
+      // 常带 `/v1` 前缀(OpenAI 兼容风格), 而真上游(如 chatgpt.com/backend-api/codex)
+      // 下**没有这一段** —— 带上去直接 403, 且上游对 path 严格、不会降级(2026-07-30
+      // 实测: .../codex/responses 拿到 101, .../codex/v1/responses 拿到 403)。所以这里
+      // 剥掉入站 path 的 /v1, 再拼上游自己的 basePath。
+      const inboundPath = url.replace(/^\/v1(?=\/|$)/, '') || '/';
+      const upstreamPath =
+        `${target.basePath}${inboundPath.startsWith('/') ? inboundPath : `/${inboundPath}`}`;
+      const reqFn = target.protocol === 'https:' ? httpsRequest : httpRequest;
+
+      // WS 是低频事件(一个 session 通常只建一两条长连接), 用 info 让它落盘 ——
+      // 这条链路出问题时"有没有建连 / 谁先关的 / 关在哪一步"是唯一有用的线索,
+      // debug 级别在打包版里拿不到。
+      logger.info?.('▶ upgrade to upstream', {
+        reqId,
+        upstreamBase: formatUpstreamBase(target),
+        path: upstreamPath,
+        viaProxy: outbound ? outbound.target.url : 'direct',
+      });
+
+      // flattenRequestHeaders 刻意剥掉 hop-by-hop header(connection / keep-alive /
+      // transfer-encoding …), 对普通转发是对的 —— 但 **WebSocket 握手必须带
+      // `Connection: Upgrade`**(RFC 6455), 缺了上游不会回 101。所以这里显式补回
+      // 握手必需的两个头; Sec-WebSocket-* 不属于 hop-by-hop, 已在 headers 里。
+      const upstreamReq = reqFn({
+        hostname: target.hostname,
+        port: target.port,
+        method: req.method ?? 'GET',
+        path: upstreamPath,
+        headers: {
+          ...headers,
+          host: formatHostHeader(target.hostname, target.port, target.protocol),
+          connection: 'Upgrade',
+          upgrade: 'websocket',
+        },
+        ...(outbound ? { agent: outbound.agent } : {}),
+      });
+      upstreamReqForEarlyClose = upstreamReq;
+
+      // 握手阶段必须有上限(上游可能既不回 101 也不回响应)。**建立成功后立刻解除** ——
+      // 否则这个 socket 级超时会在 10 分钟后把正常的长连接杀掉, 表现为"WS 隔一段固定
+      // 时间就断", 极难归因。
+      upstreamReq.setTimeout(UPSTREAM_SOCKET_TIMEOUT_MS, () => {
+        logger.warn?.('upgrade handshake timed out', { reqId, path: upstreamPath });
+        if (!established && !settled) {
+          settle('handshake-timeout');
+          writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+        }
+        upstreamReq.destroy();
+      });
+
+      upstreamReq.on('upgrade', (upstreamRes, upstreamSocket: Socket, upstreamHead: Buffer) => {
+        established = true;
+        connection.upstreamSocket = upstreamSocket;
+        // 解除握手超时(长连接不能被它杀掉)。
+        upstreamReq.setTimeout(0);
+        upstreamSocket.setTimeout(0);
+
+        clientSocket.write(serializeResponseHead(upstreamRes));
+        // 双向把握手时已缓冲的首包补上, 再对接。
+        if (upstreamHead?.length) clientSocket.write(upstreamHead);
+        if (head?.length) upstreamSocket.write(head);
+
+        clientSocket.setNoDelay(true);
+        upstreamSocket.setNoDelay(true);
+
+        // **正常关闭只记账, 绝不 destroy 对端**。
+        // pipe 的默认 end:true 已经负责把 FIN 传下去, 并且会先冲完缓冲里未写出的数据;
+        // 在 close 里主动 destroy 另一端会**立即丢弃这些缓冲** —— 实测表现为上游发完
+        // 最后一帧就 close 时, `response.completed` 被截掉: 模型文本已经完整输出
+        // (response.output_text.done 到了), 但 turn 永不收口, UI 卡在「正在生成」。
+        upstreamSocket.on('close', () => settle('upstream-close'));
+
+        // 只有出错才强拆两端 —— 那时缓冲里的数据已经没有意义。
+        const abort = (why: string) => (err?: Error): void => {
+          settle(why, err);
+          upstreamSocket.destroy();
+          clientSocket.destroy();
+        };
+        clientSocket.on('error', abort('client-error'));
+        upstreamSocket.on('error', abort('upstream-error'));
+
+        upstreamSocket.pipe(clientSocket);
+        clientSocket.pipe(upstreamSocket);
+        logger.info?.('◀ websocket established', {
+          reqId, status: upstreamRes.statusCode, live: liveWebSockets,
+          upstreamHeadBytes: upstreamHead?.length ?? 0,
+          clientHeadBytes: head?.length ?? 0,
+        });
+      });
+
+      // 上游没给 101 而是普通响应(403 / 426 / 503 等): **连 body 一起原样回写**。
+      // 只写状态行会丢掉 body 里的错误详情, 排查时无从下手; 而 426 更必须准确透传 ——
+      // 它是 codex 退回 HTTP transport 的信号。
+      upstreamReq.on('response', (upstreamRes) => {
+        settle('upstream-refused');
+        const status = upstreamRes.statusCode ?? 502;
+        logger.warn?.('upstream refused websocket upgrade', {
+          reqId,
+          status,
+          path: upstreamPath,
+        });
+        upstreamReq.setTimeout(0);
+        if (shouldFallbackToHttpAfterUpgradeResponse(status)) {
+          logger.info?.('websocket upgrade unsupported on current path — falling back to HTTP', {
+            reqId,
+            status,
+            path: upstreamPath,
+          });
+          upstreamRes.resume();
+          writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+          return;
+        }
+        try {
+          // 裸 socket 上**不能沿用上游的 framing 头**: upstreamRes 是 Node 已解码的流
+          // (chunked 已经解掉), 原样带 transfer-encoding: chunked 会让客户端拿一段
+          // 已解码的数据去解 chunk。改成 connection: close, 由 EOF 定界。
+          clientSocket.write(serializeResponseHead(upstreamRes, {
+            dropHeaders: ['transfer-encoding', 'content-length', 'connection', 'keep-alive'],
+            extraHeaders: { Connection: 'close' },
+          }));
+        } catch {
+          // socket 可能已废; body pipe 下面照常尝试, 失败由 socket 自己的 error 收口。
+        }
+        upstreamRes.pipe(clientSocket);
+      });
+
+      upstreamReq.on('error', (err) => {
+        logger.warn?.('upgrade upstream request failed — falling back to HTTP', {
+          reqId,
+          err: String(err),
+        });
+        if (!established && !settled) {
+          settle('upstream-error', err);
+          writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+        }
+      });
+
+      upstreamReq.end();
+    })().catch((err: unknown) => {
+      // 与 respondRoutingFailure 同款理由: 不让 async handler 的 rejection 漂成
+      // process-level unhandledRejection。
+      logger.error?.('websocket upgrade handler threw', { reqId, err: String(err) });
+      if (!established && !settled) {
+        settle('handler-error', err instanceof Error ? err : new Error(String(err)));
+        writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
+      }
+    });
+  });
+
   // 跟踪所有底层 socket,dispose 时强制 destroy
   server.on('connection', (socket) => {
     inflightSockets.add(socket);
@@ -1492,6 +1847,14 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
 
   return {
     url,
+    disconnectWebSocketsForThread(threadId) {
+      const normalized = threadId.trim();
+      if (!normalized) return 0;
+      const matches = Array.from(liveWebSocketConnections)
+        .filter((connection) => connection.threadId === normalized);
+      for (const connection of matches) connection.closeForHostFallback();
+      return matches.length;
+    },
     async dispose() {
       logger.debug?.('anthropic-compat-proxy disposing', { inflight });
       // 退出场景: 客户端(Claude Code 子进程)也即将被 SIGTERM, in-flight 请求保留无意义。

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -19,7 +19,7 @@ import type { Socket, TcpSocketConnectOpts } from 'node:net';
 import { URL } from 'node:url';
 import { brotliDecompressSync, gunzipSync, inflateRawSync, inflateSync } from 'node:zlib';
 
-import { DEFAULT_THREAD_ID_HEADERS, selectedHeaderValue } from './headers.js';
+import { DEFAULT_THREAD_ID_HEADERS, selectedHeaderValue, STABLE_THREAD_ID_HEADERS } from './headers.js';
 import {
   formatAuthority,
   formatHostHeader,
@@ -1636,7 +1636,10 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     let established = false;
     let settled = false;
     let upstreamReqForEarlyClose: ClientRequest | null = null;
-    const threadId = selectedHeaderValue(headers, DEFAULT_THREAD_ID_HEADERS);
+    // x-client-request-id 是每次握手唯一值，不能用来关联后续 recovery。startup-prewarm
+    // 发生在线程对宿主可见之前，通常没有稳定 header；保留空值，让宿主可在恢复时
+    // 显式逐出这些可能被目标 thread 复用的匿名预热连接。
+    const threadId = selectedHeaderValue(headers, STABLE_THREAD_ID_HEADERS);
     const connection: LiveWebSocket = {
       threadId,
       clientSocket,
@@ -1807,6 +1810,21 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         } catch {
           // socket 可能已废; body pipe 下面照常尝试, 失败由 socket 自己的 error 收口。
         }
+        // pipe 不会把源流 error 自动传播给目标 socket。上游若在 401/429/5xx body
+        // 中途断开，必须自己结束客户端写侧；否则 Codex 会一直等 EOF，未监听的
+        // IncomingMessage error 还可能升级为进程级异常。用 end 而不是立即 destroy，
+        // 先尽量刷出已经收到的状态行和错误详情。
+        upstreamRes.once('error', (err) => {
+          logger.warn?.('websocket refusal response body failed', {
+            reqId,
+            status,
+            path: upstreamPath,
+            err: String(err),
+          });
+          if (!clientSocket.destroyed) {
+            clientSocket.end(() => clientSocket.destroy());
+          }
+        });
         upstreamRes.pipe(clientSocket);
       });
 
@@ -1847,11 +1865,14 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
 
   return {
     url,
-    disconnectWebSocketsForThread(threadId) {
+    disconnectWebSocketsForThread(threadId, options) {
       const normalized = threadId.trim();
       if (!normalized) return 0;
       const matches = Array.from(liveWebSocketConnections)
-        .filter((connection) => connection.threadId === normalized);
+        .filter((connection) =>
+          connection.threadId === normalized
+          || (options?.includeUnscoped === true && connection.threadId === ''),
+        );
       for (const connection of matches) connection.closeForHostFallback();
       return matches.length;
     },

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -58,6 +58,10 @@ const REQUEST_TOO_LARGE_DRAIN_TIMEOUT_MS = 10 * 1000;
 // 转发请求的客户端不响应超时(socket 级别);LLM 请求经常 60s+,这里保守给 10 分钟。
 const UPSTREAM_SOCKET_TIMEOUT_MS = 10 * 60 * 1000;
 
+// WebSocket 这里只等 HTTP 101 握手，不应沿用允许长时间生成的 10 分钟超时。
+// 中间代理静默丢弃 Upgrade 时尽快回 426，让 Codex 原生 transport 降到 HTTP。
+const WEBSOCKET_UPGRADE_TIMEOUT_MS = 15 * 1000;
+
 // Happy Eyeballs 单地址连接尝试超时。Node 20+ 默认开启 autoSelectFamily(双栈并竞),
 // 但每个地址的 TCP 握手默认只给 250ms(net.getDefaultAutoSelectFamilyAttemptTimeout());
 // 高延迟网络下到 Cloudflare 系上游(chatgpt.com 等)握手经常 >250ms,DNS 解出的所有地址
@@ -1725,10 +1729,9 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       });
       upstreamReqForEarlyClose = upstreamReq;
 
-      // 握手阶段必须有上限(上游可能既不回 101 也不回响应)。**建立成功后立刻解除** ——
-      // 否则这个 socket 级超时会在 10 分钟后把正常的长连接杀掉, 表现为"WS 隔一段固定
-      // 时间就断", 极难归因。
-      upstreamReq.setTimeout(UPSTREAM_SOCKET_TIMEOUT_MS, () => {
+      // 握手阶段必须有独立的秒级上限(上游可能既不回 101 也不回响应)。
+      // **建立成功后立刻解除**，避免任何握手 timer 误杀正常长连接。
+      upstreamReq.setTimeout(WEBSOCKET_UPGRADE_TIMEOUT_MS, () => {
         logger.warn?.('upgrade handshake timed out', { reqId, path: upstreamPath });
         if (!established && !settled) {
           settle('handshake-timeout');
@@ -1893,14 +1896,11 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
 
   return {
     url,
-    disconnectWebSocketsForThread(threadId, options) {
+    disconnectWebSocketsForThread(threadId) {
       const normalized = threadId.trim();
       if (!normalized) return 0;
       const matches = Array.from(liveWebSocketConnections)
-        .filter((connection) =>
-          connection.threadId === normalized
-          || (options?.includeUnscoped === true && connection.threadId === ''),
-        );
+        .filter((connection) => connection.threadId === normalized);
       for (const connection of matches) connection.closeForHostFallback();
       return matches.length;
     },

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -1795,6 +1795,17 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
             status,
             path: upstreamPath,
           });
+          // 客户端已经只需要 426，仍要消费上游 body 才能复用/释放连接；但 resume
+          // 不会吞掉源流 error。代理/WAF 若在 403 body 中途断开，监听并记日志，
+          // 避免 IncomingMessage error 上升成进程级未处理异常。
+          upstreamRes.once('error', (err) => {
+            logger.warn?.('websocket fallback response body failed', {
+              reqId,
+              status,
+              path: upstreamPath,
+              err: String(err),
+            });
+          });
           upstreamRes.resume();
           writeUpgradeFailure(clientSocket, 426, 'Upgrade Required');
           return;

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -279,6 +279,10 @@ function respondRoutingFailure(
  *  - 502 / 503 / 504: 上游或本地转发失败。
  */
 function writeUpgradeFailure(socket: Socket, status: number, message: string): void {
+  // 这些失败有一部分发生在 upgrade handler 安装通用 socket error listener 之前。
+  // end() 的写失败是异步 error 事件，try/catch 捕不到；客户端若恰好取消预热或退出，
+  // 必须在写入前就收口 EPIPE/ECONNRESET，避免错误冒泡终止 Desktop main 进程。
+  socket.once('error', () => socket.destroy());
   try {
     // 先完整刷出状态行再断开。`write()` 后立刻 `destroy()` 在 Windows 上可能让尚未
     // 进入内核发送缓冲的小响应变成 RST，codex 看不到 426 就不会切回 HTTP。

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -1738,19 +1738,21 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       });
 
       upstreamReq.on('upgrade', (upstreamRes, upstreamSocket: Socket, upstreamHead: Buffer) => {
-        established = true;
-        connection.upstreamSocket = upstreamSocket;
         // 解除握手超时(长连接不能被它杀掉)。
         upstreamReq.setTimeout(0);
         upstreamSocket.setTimeout(0);
 
-        clientSocket.write(serializeResponseHead(upstreamRes));
-        // 双向把握手时已缓冲的首包补上, 再对接。
-        if (upstreamHead?.length) clientSocket.write(upstreamHead);
-        if (head?.length) upstreamSocket.write(head);
+        // 客户端可能恰好在上游 101 到达前断开。此时 close listener 已经 settle，
+        // 或 socket 已 destroy 但 close 事件尚未派发；都不能再把上游连接接入隧道。
+        if (settled || clientSocket.destroyed || upstreamSocket.destroyed) {
+          settle('upgrade-raced-with-close');
+          upstreamSocket.destroy();
+          clientSocket.destroy();
+          return;
+        }
 
-        clientSocket.setNoDelay(true);
-        upstreamSocket.setNoDelay(true);
+        established = true;
+        connection.upstreamSocket = upstreamSocket;
 
         // **正常关闭只记账, 绝不 destroy 对端**。
         // pipe 的默认 end:true 已经负责把 FIN 传下去, 并且会先冲完缓冲里未写出的数据;
@@ -1767,6 +1769,21 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         };
         clientSocket.on('error', abort('client-error'));
         upstreamSocket.on('error', abort('upstream-error'));
+
+        try {
+          clientSocket.write(serializeResponseHead(upstreamRes));
+          // 双向把握手时已缓冲的首包补上, 再对接。
+          if (upstreamHead?.length) clientSocket.write(upstreamHead);
+          if (head?.length) upstreamSocket.write(head);
+
+          clientSocket.setNoDelay(true);
+          upstreamSocket.setNoDelay(true);
+        } catch (err) {
+          abort('handshake-forward-error')(
+            err instanceof Error ? err : new Error(String(err)),
+          );
+          return;
+        }
 
         upstreamSocket.pipe(clientSocket);
         clientSocket.pipe(upstreamSocket);

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -1674,7 +1674,14 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     // 槽位;若上游请求已经创建,同时终止它,避免无人接收的握手继续占网络资源。
     clientSocket.on('close', () => {
       settle('client-close');
-      if (!established) upstreamReqForEarlyClose?.destroy();
+      if (!established) {
+        upstreamReqForEarlyClose?.destroy();
+        return;
+      }
+      // 正常 FIN 会先触发 end/readableEnded，pipe 负责把写侧冲完并结束上游；
+      // destroy/RST 则只有 close，Node 不会把 source close 传播成 destination end。
+      // 后一种必须显式拆上游，否则 dispose 或客户端崩溃会留下远端 WS 与事件循环。
+      if (!clientSocket.readableEnded) connection.upstreamSocket?.destroy();
     });
     // resolver / PAC 解析本身是异步的。error listener 必须在 await 之前安装,否则
     // Windows 代理切换、网络瞬断等事件若恰好落在这个窗口,Socket 的未监听 error
@@ -1762,7 +1769,11 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
         // 在 close 里主动 destroy 另一端会**立即丢弃这些缓冲** —— 实测表现为上游发完
         // 最后一帧就 close 时, `response.completed` 被截掉: 模型文本已经完整输出
         // (response.output_text.done 到了), 但 turn 永不收口, UI 卡在「正在生成」。
-        upstreamSocket.on('close', () => settle('upstream-close'));
+        upstreamSocket.on('close', () => {
+          settle('upstream-close');
+          // 与下游同理：正常 FIN 交给 pipe 冲完；只有无 end 的异常销毁才强拆对端。
+          if (!upstreamSocket.readableEnded) clientSocket.destroy();
+        });
 
         // 只有出错才强拆两端 —— 那时缓冲里的数据已经没有意义。
         const abort = (why: string) => (err?: Error): void => {
@@ -1913,6 +1924,11 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
       // 副作用: in-flight 请求那一侧 (Claude Code 子进程) 会收 ECONNRESET。bootstrap-electron
       // 注释 (onQuit 'anthropic-compat-proxy' 段) 已显式接受此语义: "session 本来就在 close
       // 路径上, 这种 error 直接被吞, 影响可接受"。
+      // 已建立的 WS 上游不属于 server 的入站 socket 集；先显式关闭隧道两端，
+      // 避免只 destroy 下游后把远端连接留在事件循环里。
+      for (const connection of Array.from(liveWebSocketConnections)) {
+        connection.closeForHostFallback();
+      }
       for (const s of inflightSockets) {
         try { s.destroy(); } catch { /* no-op */ }
       }

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -1243,7 +1243,7 @@ const TOOL_EXCHANGE_ADJACENCY_RE =
 
 /**
  * invalid_encrypted_content 恢复规则: 剥掉请求体里所有 encrypted_content 重发。
- * 受 enabled() gate(由 host 接 silentEncryptedRetry 设置,默认关)。
+ * 受 enabled() gate(由 host 接 silentEncryptedRetry 设置,默认开,用户可关闭)。
  */
 export function createEncryptedContentRecoveryRule(opts: {
   enabled: () => boolean;

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -299,7 +299,18 @@ export interface ProxyHandle {
    * 用于宿主把已命中 HTTP-only recovery 的 Codex thread 从预热连接池中逐出；
    * 否则下一次请求会复用旧 WS，无法通过新的 upgrade 响应触发 transport fallback。
    */
-  disconnectWebSocketsForThread?(threadId: string): number;
+  disconnectWebSocketsForThread?(
+    threadId: string,
+    options?: {
+      /**
+       * 同时断开没有稳定 thread header 的 startup-prewarm 隧道。
+       *
+       * Codex 可能在线程创建完成前预热连接；这类连接后续会被真实 thread 复用，
+       * recovery 时必须逐出，才能让重投的新 upgrade 收到 426。
+       */
+      readonly includeUnscoped?: boolean;
+    },
+  ): number;
   /** 优雅关闭 —— close listener + 等待 in-flight 请求结束(2s 超时强关) */
   dispose(): Promise<void>;
 }

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -247,6 +247,34 @@ export interface ProxyOptions {
    */
   resolveOutboundProxy?: OutboundProxyResolver;
   /**
+   * 可选: WebSocket upgrade 的上游解析器。**不传 = 完全不接受 upgrade**
+   * (Claude Code 侧的 proxy 就不传, 行为与扩展前逐字节一致)。
+   *
+   * 返回上游 URL → 接受 upgrade 并把两端 socket 对接到该上游;
+   * 返回 **null → 回 426 Upgrade Required**, codex 据此优雅退回 HTTP transport
+   * (426 是它唯一认作降级信号的状态码, 见 codex core/src/client.rs 的
+   * `StatusCode::UPGRADE_REQUIRED` 分支; 其余错误一律 Err 抛出 = 用户吃报错)。
+   * 而 codex 侧的降级是 **session 级**的(一个 turn 触发后同 session 后续 turn
+   * 都走 HTTP), 所以一次 426 即稳定, 不会在两种传输之间抖动。
+   *
+   * 因此 null 的语义不是"拒绝服务", 而是"这个会话走 HTTP 更合适" —— 宿主可以据此
+   * 把需要 body 级能力(recoveryRules / responseObserver)的会话导回 HTTP 路径,
+   * 而不牺牲其余会话的 WS 长连接。
+   *
+   * **为什么不复用 routingTransform 来定 WS 上游**: 那条路按请求体里的 model 分流,
+   * 而 upgrade 请求没有 body、也未必带 session/thread header, 会 fallback 到默认
+   * 上游。开了 WS 的 provider 是明确且唯一的, 上游可以直接给定, 不需要推导。
+   *
+   * **WS 流量上以下能力一律不生效**(proxy 只做 socket 级转发, 不解析 WS 帧):
+   * requestTransform / routingTransform 的 body 改写、recoveryRules、
+   * responseObserver、maxRequestBodyBytes。放开某个 provider 的 WS 前必须确认
+   * 它不依赖这些。
+   */
+  resolveWebSocketUpstream?: (ctx: {
+    readonly url: string;
+    readonly headers: Readonly<Record<string, string>>;
+  }) => string | null;
+  /**
    * 可选: debug 级别下是否 dump 入站请求 body(截断到 64KiB)。默认 false ——
    * dev 的日志级别默认 trace,若默认 dump,agent 高并发场景(code-review 扇出 +
    * 429 重试,2026-07-17 实测峰值 80 req/s)每请求几十 KiB 的 util.format /
@@ -265,6 +293,13 @@ export interface ProxyOptions {
 export interface ProxyHandle {
   /** Claude Code 子进程应该用的 ANTHROPIC_BASE_URL,例: http://127.0.0.1:54321 */
   readonly url: string;
+  /**
+   * 强制断开指定 thread 当前已建立或正在握手的 WS 隧道，返回断开的隧道数。
+   *
+   * 用于宿主把已命中 HTTP-only recovery 的 Codex thread 从预热连接池中逐出；
+   * 否则下一次请求会复用旧 WS，无法通过新的 upgrade 响应触发 transport fallback。
+   */
+  disconnectWebSocketsForThread?(threadId: string): number;
   /** 优雅关闭 —— close listener + 等待 in-flight 请求结束(2s 超时强关) */
   dispose(): Promise<void>;
 }

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -299,18 +299,7 @@ export interface ProxyHandle {
    * 用于宿主把已命中 HTTP-only recovery 的 Codex thread 从预热连接池中逐出；
    * 否则下一次请求会复用旧 WS，无法通过新的 upgrade 响应触发 transport fallback。
    */
-  disconnectWebSocketsForThread?(
-    threadId: string,
-    options?: {
-      /**
-       * 同时断开没有稳定 thread header 的 startup-prewarm 隧道。
-       *
-       * Codex 可能在线程创建完成前预热连接；这类连接后续会被真实 thread 复用，
-       * recovery 时必须逐出，才能让重投的新 upgrade 收到 426。
-       */
-      readonly includeUnscoped?: boolean;
-    },
-  ): number;
+  disconnectWebSocketsForThread?(threadId: string): number;
   /** 优雅关闭 —— close listener + 等待 in-flight 请求结束(2s 超时强关) */
   dispose(): Promise<void>;
 }

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -398,6 +398,21 @@ export interface AgentDeps {
   }) => void;
 
   /**
+   * Codex 专用：WS turn 命中仅 HTTP proxy 能处理的请求体恢复错误时，通知宿主把
+   * 该 thread 的后续 WS upgrade 导回 HTTP。
+   *
+   * 宿主负责按自己的 recovery rules 识别错误并登记 transport policy；返回稳定
+   * reason 表示已登记，null 表示不匹配。调用必须同步、纯内存且不得抛错。
+   * maker-core 只在零产出 turn 上据此自动重投一次，不解析供应商错误协议。
+   */
+  armCodexHttpRecovery?: (args: {
+    sessionId: string;
+    threadId: string;
+    message: string;
+    additionalDetails?: string | null;
+  }) => string | null;
+
+  /**
    * Codex 专用：登记 Guardian 子线程回到父业务 session 时应使用的主模型。
    *
    * Codex app-server 的模型目录由共享进程持有，不能代表单个 session 的实际

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4532,6 +4532,74 @@ describe('CodexAgent MCP thread context hooks', () => {
       await handle.close();
     });
 
+    it.each([false, true])(
+      'defers HTTP fallback until an early recovery error gets turn/start ownership (started=%s)',
+      async (startedBeforeError) => {
+        const firstStart = deferred<{ turn: { id: string } }>();
+        let turnStarts = 0;
+        const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+        const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+        const host = installFakeHost(agent, (method) => {
+          if (method !== Method.TurnStart) return undefined;
+          turnStarts += 1;
+          if (turnStarts === 1) return firstStart.promise;
+          return { turn: { id: `turn-${turnStarts}` } };
+        });
+        const handle = await agent.startSession({
+          sessionId: 'session-ws-body-recovery-before-start-response',
+          model: 'gpt-5.4',
+          workingDir: '/repo',
+        });
+        const events: AgentEvent[] = [];
+        void (async () => {
+          for await (const event of handle.events()) events.push(event);
+        })();
+
+        const sendPromise = handle.send({ type: 'user', content: 'hello' });
+        await waitForExpectation(() => expect(turnStarts).toBe(1));
+        const handlers = host.getThreadHandlers();
+        if (!handlers?.error || !handlers.turnStarted) throw new Error('expected handlers');
+        if (startedBeforeError) {
+          handlers.turnStarted({
+            threadId: 'start-thread-id',
+            turn: { id: 'turn-1' },
+          });
+        }
+        handlers.error({
+          threadId: 'start-thread-id',
+          turnId: 'turn-1',
+          willRetry: false,
+          error: {
+            message: 'Bad request',
+            additionalDetails: ENCRYPTED_ERROR,
+            codexErrorInfo: 'badRequest',
+          },
+        });
+
+        await Promise.resolve();
+        expect(turnStarts).toBe(1);
+        expect(events.some(
+          (event) =>
+            event.type === 'error'
+            && (event.data as { isTerminal?: boolean }).isTerminal === true,
+        )).toBe(false);
+
+        firstStart.resolve({ turn: { id: 'turn-1' } });
+        await sendPromise;
+        await waitForExpectation(() => {
+          expect(turnStarts).toBe(2);
+          expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+        });
+        expect(armCodexHttpRecovery).toHaveBeenCalledTimes(1);
+        expect(events.some(
+          (event) =>
+            event.type === 'error'
+            && (event.data as { isTerminal?: boolean }).isTerminal === true,
+        )).toBe(false);
+        await handle.close();
+      },
+    );
+
     it('does not replay a recovery error after the turn has produced output', async () => {
       const armCodexHttpRecovery = vi.fn(() => 'image_generation_id');
       const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -1977,6 +1977,56 @@ describe('CodexAgent.startSession developerInstructions', () => {
     await handle.close();
   });
 
+  it('reinjects websocket developerInstructions when daemon recovery resumes the thread', async () => {
+    const registerCodexSystemPromptForThread = vi.fn();
+    const agent = new CodexAgent(createDeps(
+      { systemPrompt: 'HOST PRODUCT PROMPT' },
+      { registerCodexSystemPromptForThread },
+    ));
+    let turnStarts = 0;
+    const host = installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) {
+        turnStarts += 1;
+        if (turnStarts === 1) throw new Error('thread not found');
+        return { turn: { id: `turn-${turnStarts}` } };
+      }
+      if (method === Method.ThreadResume) {
+        return {
+          thread: { id: 'start-thread-id' },
+          model: 'gpt-5.4',
+          modelProvider: 'cindy_openai',
+          cwd: '/repo',
+        };
+      }
+      return undefined;
+    }, {
+      codexProxyActive: true,
+      remoteCompactionProviderId: 'cindy_openai',
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-websocket-daemon-recovery',
+      model: 'gpt-5.4',
+      providerId: 'openai',
+      workingDir: '/repo',
+      userPrompt: 'USER PROMPT',
+    });
+    await handle.send({ type: 'user', content: 'hello' });
+
+    const startParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { developerInstructions?: string };
+    const resumeParams = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadResume,
+    )?.[1] as { developerInstructions?: string; modelProvider?: string };
+    expect(resumeParams.modelProvider).toBe('cindy_openai');
+    expect(resumeParams.developerInstructions).toBe(startParams.developerInstructions);
+    expect(resumeParams.developerInstructions).toContain('HOST PRODUCT PROMPT');
+    expect(resumeParams.developerInstructions).toContain('USER PROMPT');
+    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    await handle.close();
+  });
+
   it('omits thread/resume developerInstructions and registers prompt when codex proxy is active', async () => {
     const runtimeConfig = { systemPrompt: 'HOST PRODUCT PROMPT' };
     const userPrompt = [
@@ -4490,6 +4540,17 @@ describe('CodexAgent MCP thread context hooks', () => {
           codexErrorInfo: 'badRequest',
         },
       });
+      expect(
+        host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+      ).toHaveLength(1);
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          error: { message: ENCRYPTED_ERROR },
+        },
+      });
 
       await waitForExpectation(() => {
         expect(
@@ -4558,7 +4619,9 @@ describe('CodexAgent MCP thread context hooks', () => {
         const sendPromise = handle.send({ type: 'user', content: 'hello' });
         await waitForExpectation(() => expect(turnStarts).toBe(1));
         const handlers = host.getThreadHandlers();
-        if (!handlers?.error || !handlers.turnStarted) throw new Error('expected handlers');
+        if (!handlers?.error || !handlers.turnStarted || !handlers.turnCompleted) {
+          throw new Error('expected handlers');
+        }
         if (startedBeforeError) {
           handlers.turnStarted({
             threadId: 'start-thread-id',
@@ -4583,6 +4646,15 @@ describe('CodexAgent MCP thread context hooks', () => {
             event.type === 'error'
             && (event.data as { isTerminal?: boolean }).isTerminal === true,
         )).toBe(false);
+        handlers.turnCompleted({
+          threadId: 'start-thread-id',
+          turn: {
+            id: 'turn-1',
+            status: 'failed',
+            error: { message: ENCRYPTED_ERROR },
+          },
+        });
+        expect(turnStarts).toBe(1);
 
         firstStart.resolve({ turn: { id: 'turn-1' } });
         await sendPromise;
@@ -4666,6 +4738,109 @@ describe('CodexAgent MCP thread context hooks', () => {
       },
     );
 
+    it('surfaces one terminal failure when recovery completes before turn/start rejects', async () => {
+      const firstStart = deferred<{ turn: { id: string } }>();
+      const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+      const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+      const host = installFakeHost(agent, (method) => {
+        if (method === Method.TurnStart) return firstStart.promise;
+        return undefined;
+      });
+      const handle = await agent.startSession({
+        sessionId: 'session-ws-body-recovery-start-rejects',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const events: AgentEvent[] = [];
+      void (async () => {
+        for await (const event of handle.events()) events.push(event);
+      })();
+
+      const sendPromise = handle.send({ type: 'user', content: 'hello' });
+      await waitForExpectation(() => {
+        expect(
+          host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+        ).toHaveLength(1);
+      });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error || !handlers.turnCompleted) throw new Error('expected handlers');
+      handlers.error({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        willRetry: false,
+        error: {
+          message: 'Bad request',
+          additionalDetails: ENCRYPTED_ERROR,
+          codexErrorInfo: 'badRequest',
+        },
+      });
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          error: { message: ENCRYPTED_ERROR },
+        },
+      });
+      firstStart.reject(new Error('turn/start transport failed'));
+      await sendPromise;
+
+      await waitForExpectation(() => {
+        expect(events.filter(
+          (event) =>
+            event.type === 'error'
+            && (event.data as { isTerminal?: boolean }).isTerminal === true,
+        )).toHaveLength(1);
+      });
+      expect(
+        host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+      ).toHaveLength(1);
+      await handle.close();
+    });
+
+    it('cancels a recorded recovery intent without replaying the turn', async () => {
+      const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+      const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+      const host = installRecoveryHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-ws-body-recovery-cancelled',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+
+      await handle.send({ type: 'user', content: 'hello' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error || !handlers.turnCompleted) throw new Error('expected handlers');
+      handlers.error({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        willRetry: false,
+        error: {
+          message: 'Bad request',
+          additionalDetails: ENCRYPTED_ERROR,
+          codexErrorInfo: 'badRequest',
+        },
+      });
+
+      await handle.abort();
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          error: { message: ENCRYPTED_ERROR },
+        },
+      });
+      await Promise.resolve();
+
+      expect(
+        host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+      ).toHaveLength(1);
+      expect(armCodexHttpRecovery).toHaveBeenCalledTimes(1);
+      expect(handle.isTurnRunning?.()).toBe(false);
+      await handle.close();
+    });
+
     it('does not replay a recovery error after the turn has produced output', async () => {
       const armCodexHttpRecovery = vi.fn(() => 'image_generation_id');
       const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
@@ -4697,7 +4872,7 @@ describe('CodexAgent MCP thread context hooks', () => {
       });
       await Promise.resolve();
 
-      expect(armCodexHttpRecovery).toHaveBeenCalledTimes(1);
+      expect(armCodexHttpRecovery).not.toHaveBeenCalled();
       expect(
         host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
       ).toHaveLength(1);
@@ -4721,18 +4896,28 @@ describe('CodexAgent MCP thread context hooks', () => {
 
       await handle.send({ type: 'user', content: 'hello' });
       const handlers = host.getThreadHandlers();
-      if (!handlers?.error) throw new Error('expected error handler');
+      if (!handlers?.error || !handlers.turnCompleted) throw new Error('expected handlers');
 
-      const failTurn = (turnId: string) => handlers.error?.({
-        threadId: 'start-thread-id',
-        turnId,
-        willRetry: false,
-        error: {
-          message: 'Bad request',
-          additionalDetails: ENCRYPTED_ERROR,
-          codexErrorInfo: 'badRequest',
-        },
-      });
+      const failTurn = (turnId: string) => {
+        handlers.error?.({
+          threadId: 'start-thread-id',
+          turnId,
+          willRetry: false,
+          error: {
+            message: 'Bad request',
+            additionalDetails: ENCRYPTED_ERROR,
+            codexErrorInfo: 'badRequest',
+          },
+        });
+        handlers.turnCompleted?.({
+          threadId: 'start-thread-id',
+          turn: {
+            id: turnId,
+            status: 'failed',
+            error: { message: ENCRYPTED_ERROR },
+          },
+        });
+      };
       failTurn('turn-1');
       await waitForExpectation(() => {
         expect(

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -1943,6 +1943,40 @@ describe('CodexAgent.startSession developerInstructions', () => {
     expect(unregisterCodexMcpThreadContext).toHaveBeenCalledWith('grandchild-thread-id');
   });
 
+  it('keeps thread/start developerInstructions on the websocket provider and skips proxy registration', async () => {
+    const registerCodexSystemPromptForThread = vi.fn();
+    const agent = new CodexAgent(createDeps(
+      { systemPrompt: 'HOST PRODUCT PROMPT' },
+      { registerCodexSystemPromptForThread },
+    ));
+    const host = installFakeHost(agent, undefined, {
+      codexProxyActive: true,
+      remoteCompactionProviderId: 'cindy_openai',
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-websocket-start',
+      model: 'gpt-5.4',
+      providerId: 'openai',
+      workingDir: '/repo',
+      userPrompt: 'USER PROMPT',
+    });
+    const params = host.request.mock.calls.find(([method]) => method === Method.ThreadStart)?.[1] as {
+      developerInstructions?: string;
+      modelProvider?: string;
+    };
+
+    expect(params.modelProvider).toBe('cindy_openai');
+    expect(params.developerInstructions).toContain('HOST PRODUCT PROMPT');
+    expect(params.developerInstructions).toContain('USER PROMPT');
+    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    expect(handle.codexProductPromptDelivery).toEqual({
+      threadId: 'start-thread-id',
+      historyHasProductPrompt: true,
+    });
+    await handle.close();
+  });
+
   it('omits thread/resume developerInstructions and registers prompt when codex proxy is active', async () => {
     const runtimeConfig = { systemPrompt: 'HOST PRODUCT PROMPT' };
     const userPrompt = [
@@ -1997,6 +2031,78 @@ describe('CodexAgent.startSession developerInstructions', () => {
 
     await startBaselineHandle.close();
     await proxyHandle.close();
+  });
+
+  it('keeps thread/resume developerInstructions on the websocket provider when history lacks them', async () => {
+    const registerCodexSystemPromptForThread = vi.fn();
+    const agent = new CodexAgent(createDeps(
+      { systemPrompt: 'HOST PRODUCT PROMPT' },
+      { registerCodexSystemPromptForThread },
+    ));
+    const host = installFakeHost(agent, undefined, {
+      codexProxyActive: true,
+      remoteCompactionProviderId: 'cindy_openai',
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-websocket-resume',
+      model: 'gpt-5.4',
+      providerId: 'openai',
+      workingDir: '/repo',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+      codexHistoryHasProductPrompt: false,
+      userPrompt: 'USER PROMPT',
+    });
+    const params = host.request.mock.calls.find(([method]) => method === Method.ThreadResume)?.[1] as {
+      developerInstructions?: string;
+      modelProvider?: string;
+    };
+
+    expect(params.modelProvider).toBe('cindy_openai');
+    expect(params.developerInstructions).toContain('HOST PRODUCT PROMPT');
+    expect(params.developerInstructions).toContain('USER PROMPT');
+    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    expect(handle.codexProductPromptDelivery).toEqual({
+      threadId: 'resume-thread-id',
+      historyHasProductPrompt: true,
+    });
+    await handle.close();
+  });
+
+  it('keeps thread/resume developerInstructions on the websocket provider when history already contains them', async () => {
+    const registerCodexSystemPromptForThread = vi.fn();
+    const agent = new CodexAgent(createDeps(
+      { systemPrompt: 'HOST PRODUCT PROMPT' },
+      { registerCodexSystemPromptForThread },
+    ));
+    const host = installFakeHost(agent, undefined, {
+      codexProxyActive: true,
+      remoteCompactionProviderId: 'cindy_openai',
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-websocket-resume-existing-prompt',
+      model: 'gpt-5.4',
+      providerId: 'openai',
+      workingDir: '/repo',
+      resumeSessionId: '123e4567-e89b-12d3-a456-426614174000',
+      codexHistoryHasProductPrompt: true,
+      userPrompt: 'USER PROMPT',
+    });
+    const params = host.request.mock.calls.find(([method]) => method === Method.ThreadResume)?.[1] as {
+      developerInstructions?: string;
+      modelProvider?: string;
+    };
+
+    expect(params.modelProvider).toBe('cindy_openai');
+    expect(params.developerInstructions).toContain('HOST PRODUCT PROMPT');
+    expect(params.developerInstructions).toContain('USER PROMPT');
+    expect(registerCodexSystemPromptForThread).not.toHaveBeenCalled();
+    expect(handle.codexProductPromptDelivery).toEqual({
+      threadId: 'resume-thread-id',
+      historyHasProductPrompt: true,
+    });
+    await handle.close();
   });
 
   it('omits developerInstructions from thread/resume params when codex proxy is inactive and history already has product prompt', async () => {
@@ -4339,6 +4445,213 @@ describe('CodexAgent MCP thread context hooks', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  describe('websocket body recovery auto-retry', () => {
+    const ENCRYPTED_ERROR =
+      'Encrypted content could not be decrypted or parsed. code=invalid_encrypted_content';
+
+    function installRecoveryHost(agent: CodexAgent): ReturnType<typeof installFakeHost> {
+      let turnSeq = 0;
+      return installFakeHost(agent, (method) => {
+        if (method === Method.TurnStart) {
+          turnSeq += 1;
+          return { turn: { id: `turn-${turnSeq}` } };
+        }
+        return undefined;
+      });
+    }
+
+    it('arms HTTP fallback and retries the same zero-output turn once', async () => {
+      const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+      const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+      const host = installRecoveryHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-ws-body-recovery',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const events: AgentEvent[] = [];
+      void (async () => {
+        for await (const event of handle.events()) events.push(event);
+      })();
+
+      await handle.send({ type: 'user', content: 'hello' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error || !handlers.turnCompleted) throw new Error('expected handlers');
+
+      handlers.error({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        willRetry: false,
+        error: {
+          message: 'Bad request',
+          additionalDetails: ENCRYPTED_ERROR,
+          codexErrorInfo: 'badRequest',
+        },
+      });
+
+      await waitForExpectation(() => {
+        expect(
+          host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+        ).toHaveLength(2);
+        expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+      });
+      expect(armCodexHttpRecovery).toHaveBeenCalledWith({
+        sessionId: 'session-ws-body-recovery',
+        threadId: 'start-thread-id',
+        message: 'Bad request',
+        additionalDetails: ENCRYPTED_ERROR,
+      });
+      expect(
+        events.some(
+          (event) =>
+            event.type === 'error' &&
+            (event.data as { isTerminal?: boolean }).isTerminal === true,
+        ),
+      ).toBe(false);
+
+      // 原 WS turn 的迟到终态已落墓碑，不得把 HTTP 重投收口掉。
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          error: { message: ENCRYPTED_ERROR },
+        },
+      });
+      expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: { id: 'turn-2', status: 'completed' },
+      });
+      await waitForExpectation(() => {
+        expect(events.some((event) => event.type === 'done')).toBe(true);
+      });
+      await handle.close();
+    });
+
+    it('does not replay a recovery error after the turn has produced output', async () => {
+      const armCodexHttpRecovery = vi.fn(() => 'image_generation_id');
+      const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+      const host = installRecoveryHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-ws-body-recovery-output',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      await handle.send({ type: 'user', content: 'hello' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error || !handlers.reasoningTextDelta) throw new Error('expected handlers');
+
+      handlers.reasoningTextDelta({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        itemId: 'reasoning-1',
+        contentIndex: 0,
+        delta: 'already produced output',
+      });
+      handlers.error({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        willRetry: false,
+        error: {
+          message: 'Image generation items without `id` are not supported for this request.',
+          codexErrorInfo: 'badRequest',
+        },
+      });
+      await Promise.resolve();
+
+      expect(armCodexHttpRecovery).toHaveBeenCalledTimes(1);
+      expect(
+        host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+      ).toHaveLength(1);
+      expect(handle.isTurnRunning?.()).toBe(false);
+      await handle.close();
+    });
+
+    it('does not retry the same logical send again when the HTTP retry also fails', async () => {
+      const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+      const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+      const host = installRecoveryHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-ws-body-recovery-once',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const events: AgentEvent[] = [];
+      void (async () => {
+        for await (const event of handle.events()) events.push(event);
+      })();
+
+      await handle.send({ type: 'user', content: 'hello' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error) throw new Error('expected error handler');
+
+      const failTurn = (turnId: string) => handlers.error?.({
+        threadId: 'start-thread-id',
+        turnId,
+        willRetry: false,
+        error: {
+          message: 'Bad request',
+          additionalDetails: ENCRYPTED_ERROR,
+          codexErrorInfo: 'badRequest',
+        },
+      });
+      failTurn('turn-1');
+      await waitForExpectation(() => {
+        expect(
+          host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+        ).toHaveLength(2);
+      });
+
+      failTurn('turn-2');
+      await waitForExpectation(() => {
+        expect(events.some(
+          (event) =>
+            event.type === 'error'
+            && (event.data as { isTerminal?: boolean }).isTerminal === true,
+        )).toBe(true);
+      });
+      expect(
+        host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+      ).toHaveLength(2);
+      expect(handle.isTurnRunning?.()).toBe(false);
+      await handle.close();
+    });
+
+    it('recovers from a failed turn/completed when no error notification was delivered', async () => {
+      const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+      const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+      const host = installRecoveryHost(agent);
+      const handle = await agent.startSession({
+        sessionId: 'session-ws-body-recovery-completed-only',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+
+      await handle.send({ type: 'user', content: 'hello' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.turnCompleted) throw new Error('expected turnCompleted handler');
+      handlers.turnCompleted({
+        threadId: 'start-thread-id',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          error: { message: ENCRYPTED_ERROR },
+        },
+      });
+
+      await waitForExpectation(() => {
+        expect(
+          host.request.mock.calls.filter(([method]) => method === Method.TurnStart),
+        ).toHaveLength(2);
+        expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+      });
+      expect(armCodexHttpRecovery).toHaveBeenCalledTimes(1);
+      await handle.close();
+    });
   });
 
   // ── 服务过载（模型容量不足）退避重投 ──────────────────────────────────────

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4600,6 +4600,72 @@ describe('CodexAgent MCP thread context hooks', () => {
       },
     );
 
+    it.each([false, true])(
+      'defers HTTP fallback until an early failed turn/completed gets turn/start ownership (started=%s)',
+      async (startedBeforeCompletion) => {
+        const firstStart = deferred<{ turn: { id: string } }>();
+        let turnStarts = 0;
+        const armCodexHttpRecovery = vi.fn(() => 'encrypted_content');
+        const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));
+        const host = installFakeHost(agent, (method) => {
+          if (method !== Method.TurnStart) return undefined;
+          turnStarts += 1;
+          if (turnStarts === 1) return firstStart.promise;
+          return { turn: { id: `turn-${turnStarts}` } };
+        });
+        const handle = await agent.startSession({
+          sessionId: 'session-ws-body-recovery-completed-before-start-response',
+          model: 'gpt-5.4',
+          workingDir: '/repo',
+        });
+        const events: AgentEvent[] = [];
+        void (async () => {
+          for await (const event of handle.events()) events.push(event);
+        })();
+
+        const sendPromise = handle.send({ type: 'user', content: 'hello' });
+        await waitForExpectation(() => expect(turnStarts).toBe(1));
+        const handlers = host.getThreadHandlers();
+        if (!handlers?.turnCompleted || !handlers.turnStarted) throw new Error('expected handlers');
+        if (startedBeforeCompletion) {
+          handlers.turnStarted({
+            threadId: 'start-thread-id',
+            turn: { id: 'turn-1' },
+          });
+        }
+        handlers.turnCompleted({
+          threadId: 'start-thread-id',
+          turn: {
+            id: 'turn-1',
+            status: 'failed',
+            error: { message: ENCRYPTED_ERROR },
+          },
+        });
+
+        await Promise.resolve();
+        expect(turnStarts).toBe(1);
+        expect(events.some(
+          (event) =>
+            event.type === 'error'
+            && (event.data as { isTerminal?: boolean }).isTerminal === true,
+        )).toBe(false);
+
+        firstStart.resolve({ turn: { id: 'turn-1' } });
+        await sendPromise;
+        await waitForExpectation(() => {
+          expect(turnStarts).toBe(2);
+          expect(handle.getCurrentTurnId?.()).toBe('turn-2');
+        });
+        expect(armCodexHttpRecovery).toHaveBeenCalledTimes(1);
+        expect(events.some(
+          (event) =>
+            event.type === 'error'
+            && (event.data as { isTerminal?: boolean }).isTerminal === true,
+        )).toBe(false);
+        await handle.close();
+      },
+    );
+
     it('does not replay a recovery error after the turn has produced output', async () => {
       const armCodexHttpRecovery = vi.fn(() => 'image_generation_id');
       const agent = new CodexAgent(createDeps({}, { armCodexHttpRecovery }));

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2207,8 +2207,13 @@ export class CodexAgent extends BaseAgent {
     });
 
     // ── Maker Memory: 启动时预拉 MEMORY.md 索引 + 写入规范段 ────────────────
-    // thread/start 仍把 developerInstructions 写入新 thread; thread/resume 在非 proxy
+    // thread/start 仍把 developerInstructions 写入新 thread; thread/resume 在普通非 proxy
     // 路径只在 host 明确告知历史未含产品 prompt 时补发一次,避免常规 resume 重复堆积。
+    // WS thread 恢复时则始终携带当前值:Codex 的 SessionMeta 不持久化该字段,冷恢复若只
+    // 依赖历史里的旧 developer message,后续 compact 重建 canonical context 时会丢产品
+    // prompt。Codex 0.145 对仍在内存中的 loaded thread 会忽略 resume override,且冷恢复
+    // 首轮的 steady-state diff 不补一条发生变化的 plain developer_instructions；正常
+    // resume 沿用同一份文本时历史里已有它,compact 也会从当前 cold-resume 配置重建。
     // proxy active 时两条路径都用同一份构建结果登记到 registry。跟 userPrompt 同语义 — 启动时快照,跨 session 不实时同步。
     let makerMemoryRules = '';
     let makerMemoryIndex = '';
@@ -2367,6 +2372,8 @@ export class CodexAgent extends BaseAgent {
     let overloadRetry: {
       retry: () => Promise<void>;
       attempt: number;
+      /** 同一逻辑 send 最多接管一次 WS→HTTP body recovery，避免坏响应形成重投环。 */
+      httpRecoveryRetryAttempted: boolean;
       timer: ReturnType<typeof setTimeout> | null;
       /**
        * 重投的 turn/start RPC 是否在途。计时器到点后 `timer` 已清空、新 turn 又
@@ -2998,8 +3005,6 @@ export class CodexAgent extends BaseAgent {
     };
 
     const hostUsesCodexProxy = host.isCodexProxyActive();
-    const isCodexProxyChannelReady = (): boolean =>
-      hostUsesCodexProxy && typeof this.deps.registerCodexSystemPromptForThread === 'function';
 
     // ── OpenAI 远端压缩身份(thread 级,start/resume 冻结)────────────────────
     // 仅当 ① host 是 oauth spawn 且下发了 OpenAI 身份 provider(见
@@ -3016,6 +3021,36 @@ export class CodexAgent extends BaseAgent {
       const family = credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
       return family === 'oauth-bearer' ? providerIdFromHost : undefined;
     })();
+
+    /**
+     * 本 thread 的 Responses 请求是否走 WebSocket。
+     *
+     * 等价于「选了 OpenAI 身份 provider」:spawn args 里只有该 provider 打开了
+     * `supports_websockets`(见 desktop 侧 buildCodexProxySpawnArgs),cindy_gateway
+     * 与其余供应商一律 false。所以 threadModelProvider 非空 ⟺ 该 thread 走 WS。
+     *
+     * 单独起个名字而不是直接用 `!threadModelProvider`:两者当前等价但语义不同 ——
+     * 前者问"走不走 WS"(决定 prompt 注入通道),后者问"选没选那个 provider"
+     * (原本只为远端压缩)。哪天该 provider 不再开 WS,要改的是这里而不是下面的判定。
+     */
+    const threadUsesWebSocket = !!threadModelProvider;
+
+    /**
+     * proxy 的 registry 注入通道本 thread 是否可用。
+     *
+     * 除 host 侧条件外还要求**本 thread 不走 WebSocket**:proxy 的 WS 通道只做 socket
+     * 级透传、看不到请求体,registry 注入不会生效。这类 thread 必须改走 codex 原生的
+     * developerInstructions 字段(下面 thread/start 与 thread/resume 的
+     * `!useProxyChannel` 分支)。
+     *
+     * 刻意复用 threadUsesWebSocket 这一个判定,不另立一套「是不是订阅直连」的推导 ——
+     * 两处推导迟早漂移,而漂移的后果是 prompt 静默丢失(既不注入 registry、也不写
+     * developerInstructions)。
+     */
+    const isCodexProxyChannelReady = (): boolean =>
+      hostUsesCodexProxy
+      && !threadUsesWebSocket
+      && typeof this.deps.registerCodexSystemPromptForThread === 'function';
 
     let registeredDeveloperInstructions = '';
     const registerCodexDeveloperInstructions = (threadId: string, text: string): void => {
@@ -3169,6 +3204,14 @@ export class CodexAgent extends BaseAgent {
           });
         }
       }
+      // WS proxy 看不到请求体,不能像 HTTP registry 通道那样逐请求补 prompt。即使历史
+      // marker=true,冷恢复时也必须把当前值重新写进 Codex 的 session configuration,
+      // 保证自动 compact 后构建出来的 canonical developer context 仍含 Cindy 指令。
+      // loaded-thread resume 在 Codex 0.145 会忽略 override；同文本仍由既有历史保留。
+      const shouldSendNativeDeveloperInstructions =
+        !!developerInstructions
+        && !useProxyChannel
+        && (threadUsesWebSocket || opts.codexHistoryHasProductPrompt !== true);
       const params: ThreadResumeParams = {
         threadId: opts.resumeSessionId,
         ...(resumeExcludeTurnsSupported ? { excludeTurns: true } : {}),
@@ -3177,7 +3220,7 @@ export class CodexAgent extends BaseAgent {
         ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
         ...(mutableModel && mutableModel !== 'gpt-5' ? { model: mutableModel } : {}),
         ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
-        ...(developerInstructions && !useProxyChannel && opts.codexHistoryHasProductPrompt !== true
+        ...(shouldSendNativeDeveloperInstructions
           ? { developerInstructions }
           : {}),
       };
@@ -3202,7 +3245,7 @@ export class CodexAgent extends BaseAgent {
         if (useProxyChannel) {
           registerCodexDeveloperInstructions(threadId, developerInstructions);
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: false };
-        } else if (developerInstructions && opts.codexHistoryHasProductPrompt !== true) {
+        } else if (shouldSendNativeDeveloperInstructions) {
           codexProductPromptDelivery = { threadId, historyHasProductPrompt: true };
         }
         sdkSessionId = threadId;
@@ -5208,6 +5251,117 @@ export class CodexAgent extends BaseAgent {
       }
     };
 
+    const armHttpRecoveryForError = (
+      error: { message?: string; additionalDetails?: unknown } | null | undefined,
+    ): string | null => {
+      if (opts.remoteHostId || !this.deps.armCodexHttpRecovery) return null;
+      const message = typeof error?.message === 'string' ? error.message : '';
+      const additionalDetails =
+        typeof error?.additionalDetails === 'string' ? error.additionalDetails : null;
+      if (!message && !additionalDetails) return null;
+      try {
+        return this.deps.armCodexHttpRecovery({
+          sessionId: sid,
+          threadId,
+          message,
+          additionalDetails,
+        });
+      } catch (errorFromHost) {
+        log.warn('codex HTTP recovery arming failed; surfacing original error', {
+          threadId,
+          error: errorFromHost instanceof Error ? errorFromHost.message : String(errorFromHost),
+        });
+        return null;
+      }
+    };
+
+    /**
+     * 已确认是 HTTP proxy 可恢复的 WS 请求校验错误时，立即重投同一份冻结 turnParams。
+     * host 已把 thread 标成 HTTP-only；重投新建 transport 时会收到 426 并走既有
+     * recoveryRules。只接管本 logical send、零产出、无其它 start 在飞的明确 turn。
+     */
+    const retryTurnViaHttpRecovery = (deadTurnId: string, reason: string): boolean => {
+      const state = overloadRetry;
+      if (!state || closed || state.httpRecoveryRetryAttempted || state.isCancelled()) return false;
+      const origin = turnOriginByTurnId.get(deadTurnId);
+      if (origin?.sendGen !== state.sendGen) return false;
+      if (producedOutputTurnIds.has(deadTurnId)) {
+        log.info('codex WS body recovery error after partial output — not auto-retrying', {
+          threadId,
+          deadTurnId,
+          reason,
+        });
+        return false;
+      }
+      if (
+        inFlightStarts.size > 0 ||
+        state.timer !== null ||
+        state.inFlight ||
+        state.deferredCapacityFailure !== null
+      ) {
+        log.warn('codex WS body recovery retry skipped because another retry/start is pending', {
+          threadId,
+          deadTurnId,
+          reason,
+          inFlightStarts: inFlightStarts.size,
+        });
+        return false;
+      }
+
+      state.httpRecoveryRetryAttempted = true;
+      terminalErroredTurnIds.add(deadTurnId);
+      dismissPendingUserInputForTurn(deadTurnId, 'turn_failed');
+      clearActiveToolContextsForTurn(deadTurnId);
+      stopActiveRolloutPlanFallback();
+      isTurnInFlight = false;
+      if (currentTurnId === deadTurnId) currentTurnId = null;
+      if (
+        codexPermissionStrictnessRank(state.launchedPermissionMode)
+        < codexPermissionStrictnessRank(mutablePermissionMode)
+      ) {
+        pendingTightenInterrupt = true;
+      }
+      log.info('codex WS body recovery error — retrying turn through HTTP fallback', {
+        threadId,
+        deadTurnId,
+        reason,
+      });
+
+      void state.retry().catch((retryError) => {
+        if (closed || overloadRetry !== state || state.isCancelled()) {
+          log.info('codex HTTP recovery retry rejected after cancellation — not surfacing', {
+            threadId,
+            reason,
+            error: retryError instanceof Error ? retryError.message : String(retryError),
+          });
+          return;
+        }
+        log.error('codex HTTP recovery turn/start retry failed', {
+          threadId,
+          reason,
+          error: retryError instanceof Error ? retryError.message : String(retryError),
+        });
+        quarantineTurnsAfterStartFailure('HTTP recovery turn/start retry failed', {
+          ownsSession: sendGeneration === state.sendGen,
+        });
+        discardOverloadRetry('HTTP recovery retry failed');
+        eventQueue.push({
+          type: 'error',
+          data: {
+            message: `turn/start HTTP recovery retry failed: ${String(retryError)}`,
+            isTerminal: true,
+          },
+          source: 'codex',
+        });
+        eventQueue.push({
+          type: 'status',
+          data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+          source: 'codex',
+        });
+      });
+      return true;
+    };
+
     /**
      * 计划模式下拦截 plan item (proposed plan / <proposed_plan> 块): 记录最新文本,
      * 不进 translator —— 计划内容由 turn 结束后的 plan_review 卡片呈现, 不再渲染
@@ -5224,6 +5378,14 @@ export class CodexAgent extends BaseAgent {
 
     function handleTurnCompleted(params: TurnCompletedParams): void {
       const turn = params.turn;
+      if (
+        turn.status === 'failed' &&
+        turn.error &&
+        !terminalErroredTurnIds.has(turn.id)
+      ) {
+        const recoveryReason = armHttpRecoveryForError(turn.error);
+        if (recoveryReason) retryTurnViaHttpRecovery(turn.id, recoveryReason);
+      }
       // turn/start RPC 响应未回时就收到终态 → 记墓碑, 阻止稍后到达的
       // handleTurnStartResp / 乱序 turnStarted 把已终结的 turn 重新置活。
       if (isTurnStartPending) turnsCompletedBeforeStartResp.add(turn.id);
@@ -6584,6 +6746,18 @@ export class CodexAgent extends BaseAgent {
           }
         }
         const wasTurnRunning = isTurnInFlight || targetsPendingTurn;
+        if (isTerminalError && targetsCurrentTurn && !isTransportError) {
+          const recoveryReason = armHttpRecoveryForError(effectiveParams.error);
+          if (
+            recoveryReason &&
+            retryTurnViaHttpRecovery(
+              effectiveParams.turnId || currentTurnId || '',
+              recoveryReason,
+            )
+          ) {
+            return;
+          }
+        }
         // 服务过载(模型容量不足)时接管重投：translator 命中 capacity 才回调，
         // 拿到进度就把错误透成非终止状态，本函数随后跳过 Done 收口。
         let overloadRetryScheduled = false;
@@ -6979,6 +7153,7 @@ export class CodexAgent extends BaseAgent {
         // 计划模式状态错乱。
         overloadRetry = {
           attempt: 0,
+          httpRecoveryRetryAttempted: false,
           timer: null,
           inFlight: false,
           isCancelled: () => sendOpts?.signal?.aborted === true,
@@ -7087,7 +7262,8 @@ export class CodexAgent extends BaseAgent {
             // 判据用 attempt > 0 限定在"本轮确实被重投接管过"上: 没发生过重投的
             // 普通 send 里 signal 仍只是**受理前**的取消边界, 语义不变。
             const retryOwnsActiveTurn =
-              armedRetryState.attempt > 0 && (currentTurnId !== null || isTurnInFlight);
+              (armedRetryState.attempt > 0 || armedRetryState.httpRecoveryRetryAttempted)
+              && (currentTurnId !== null || isTurnInFlight);
             if (!overloadRetryPending(armedRetryState) && !retryOwnsActiveTurn) return;
             cancelOverloadRetry('send signal aborted');
             settleCancelledOverloadRetry(armedRetryState, 'send signal aborted');

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2374,6 +2374,11 @@ export class CodexAgent extends BaseAgent {
       attempt: number;
       /** 同一逻辑 send 最多接管一次 WS→HTTP body recovery，避免坏响应形成重投环。 */
       httpRecoveryRetryAttempted: boolean;
+      /**
+       * `error` notification 只登记恢复意图；权威的 turn/completed 到达后才真正重投。
+       * 单一事实源放在 logical send 状态上，不再分散到各个 turn/start 请求条目。
+       */
+      pendingHttpRecovery: { deadTurnId: string; reason: string } | null;
       timer: ReturnType<typeof setTimeout> | null;
       /**
        * 重投的 turn/start RPC 是否在途。计时器到点后 `timer` 已清空、新 turn 又
@@ -2419,18 +2424,10 @@ export class CodexAgent extends BaseAgent {
      * 每个 per-request 的事实都住在自己的条目里, 请求 settle 时整条删掉, 天然不串味;
      * "有没有 start 在飞"一律由 `inFlightStarts.size` 派生, 不再有第二份真相。
      */
-    type DeferredHttpRecovery = {
-      deadTurnId: string;
-      reason: string;
-      sendGen: number;
-      terminalMessage: string;
-      responseMatched: boolean;
-    };
     const inFlightStarts = new Map<number, {
       quarantined: boolean;
       terminalSettled: boolean;
       sendGen: number;
-      deferredHttpRecovery: DeferredHttpRecovery | null;
     }>();
     /** 每次 turn/start RPC 的自增序号, 作为登记表的键。 */
     let turnStartSeq = 0;
@@ -2451,7 +2448,6 @@ export class CodexAgent extends BaseAgent {
         quarantined: false,
         terminalSettled: false,
         sendGen: ownerSendGen,
-        deferredHttpRecovery: null,
       });
       isTurnStartPending = true;
       return seq;
@@ -5380,14 +5376,15 @@ export class CodexAgent extends BaseAgent {
     };
 
     /**
-     * body recovery 的终态通知可能先于 turn/start RPC 响应到达。此时尚无
-     * turnOrigin，不能立即重投；只有唯一且属于本 send 的 start 在飞时才暂存，
-     * 等响应用同一个 turn id 建立权威归属后再走正常 HTTP recovery。
+     * 记录本 logical send 的一次 HTTP recovery 意图。
+     *
+     * `error` notification 只负责登记并保持 UI running；真正重投只由权威的
+     * turn/completed 驱动。这样无论 error / completed / turn-start response
+     * 如何乱序，都只有一个执行入口。
      */
-    const deferHttpRecoveryUntilTurnStartSettles = (
+    const recordHttpRecoveryIntent = (
       deadTurnId: string,
-      reason: string,
-      terminalMessage: string,
+      error: { message?: string; additionalDetails?: unknown } | null | undefined,
     ): boolean => {
       const state = overloadRetry;
       if (
@@ -5396,84 +5393,46 @@ export class CodexAgent extends BaseAgent {
         || closed
         || state.httpRecoveryRetryAttempted
         || state.isCancelled()
-        || (currentTurnId !== null && currentTurnId !== deadTurnId)
-        || inFlightStarts.size !== 1
         || state.timer !== null
         || state.deferredCapacityFailure !== null
         || producedOutputTurnIds.has(deadTurnId)
       ) {
         return false;
       }
-      const [startSeq, start] = Array.from(inFlightStarts.entries())[0] ?? [];
-      if (
-        startSeq === undefined
-        || !start
-        || start.sendGen !== state.sendGen
-        || start.quarantined
-        || start.terminalSettled
-        || start.deferredHttpRecovery !== null
-      ) {
+      if (state.pendingHttpRecovery) {
+        return state.pendingHttpRecovery.deadTurnId === deadTurnId;
+      }
+
+      const origin = turnOriginByTurnId.get(deadTurnId);
+      const [startSeq, start] =
+        inFlightStarts.size === 1
+          ? Array.from(inFlightStarts.entries())[0] ?? []
+          : [];
+      const ownedByCurrentSend = origin?.sendGen === state.sendGen;
+      const ownedBySolePendingStart =
+        origin === undefined
+        && (currentTurnId === null || currentTurnId === deadTurnId)
+        && startSeq !== undefined
+        && start?.sendGen === state.sendGen
+        && !start.quarantined
+        && !start.terminalSettled;
+      if (!ownedByCurrentSend && !ownedBySolePendingStart) {
         return false;
       }
 
-      start.deferredHttpRecovery = {
+      const reason = armHttpRecoveryForError(error);
+      if (!reason) return false;
+      state.pendingHttpRecovery = {
         deadTurnId,
         reason,
-        sendGen: state.sendGen,
-        terminalMessage,
-        responseMatched: false,
       };
-      // 挡住死 turn 在 RPC 响应前后的迟到事件；响应 id 对上后会补权威 origin，
-      // 并因这块墓碑拒绝重新激活。
-      terminalErroredTurnIds.add(deadTurnId);
-      dismissPendingUserInputForTurn(deadTurnId, 'turn_failed');
-      clearActiveToolContextsForTurn(deadTurnId);
-      stopActiveRolloutPlanFallback();
-      isTurnInFlight = false;
-      if (currentTurnId === deadTurnId) currentTurnId = null;
-      log.info('codex WS body recovery waiting for turn/start ownership', {
+      log.info('codex WS body recovery recorded; waiting for turn/completed', {
         threadId,
         deadTurnId,
         reason,
-        startSeq,
+        startSeq: startSeq ?? null,
       });
       return true;
-    };
-
-    const resumeDeferredHttpRecovery = (
-      deferred: DeferredHttpRecovery | null,
-      rpcSettledOk: boolean,
-    ): void => {
-      if (!deferred || !rpcSettledOk || !deferred.responseMatched) return;
-      const state = overloadRetry;
-      if (
-        !state
-        || closed
-        || state.sendGen !== deferred.sendGen
-        || state.isCancelled()
-      ) {
-        return;
-      }
-      if (retryTurnViaHttpRecovery(deferred.deadTurnId, deferred.reason)) return;
-
-      // 归属已经建立且本 send 仍有效时，重投若因意外状态无法接管，必须恢复原终态，
-      // 不能让被暂存的错误消失后把逻辑 turn 永久挂住。
-      log.error('deferred codex HTTP recovery could not start; surfacing original error', {
-        threadId,
-        deadTurnId: deferred.deadTurnId,
-        reason: deferred.reason,
-      });
-      discardOverloadRetry('deferred HTTP recovery could not start');
-      eventQueue.push({
-        type: 'error',
-        data: { message: deferred.terminalMessage, isTerminal: true },
-        source: 'codex',
-      });
-      eventQueue.push({
-        type: 'status',
-        data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
-        source: 'codex',
-      });
     };
 
     /**
@@ -5492,27 +5451,60 @@ export class CodexAgent extends BaseAgent {
 
     function handleTurnCompleted(params: TurnCompletedParams): void {
       const turn = params.turn;
+      let recoveryState = overloadRetry;
+      let pendingRecovery =
+        recoveryState?.pendingHttpRecovery?.deadTurnId === turn.id
+          ? recoveryState.pendingHttpRecovery
+          : null;
       if (
-        turn.status === 'failed' &&
-        turn.error &&
-        !terminalErroredTurnIds.has(turn.id)
+        turn.status === 'failed'
+        && (!terminalErroredTurnIds.has(turn.id) || pendingRecovery)
       ) {
-        const recoveryReason = armHttpRecoveryForError(turn.error);
-        if (recoveryReason) {
-          if (retryTurnViaHttpRecovery(turn.id, recoveryReason)) return;
-          if (
-            deferHttpRecoveryUntilTurnStartSettles(
-              turn.id,
-              recoveryReason,
-              turn.error.message
-                || (typeof turn.error.additionalDetails === 'string'
-                  ? turn.error.additionalDetails
-                  : 'Codex turn failed before HTTP recovery could start'),
-            )
-          ) {
-            return;
-          }
+        if (!pendingRecovery && turn.error && recordHttpRecoveryIntent(turn.id, turn.error)) {
+          recoveryState = overloadRetry;
+          pendingRecovery =
+            recoveryState?.pendingHttpRecovery?.deadTurnId === turn.id
+              ? recoveryState.pendingHttpRecovery
+              : null;
         }
+        if (recoveryState && pendingRecovery) {
+          if (inFlightStarts.size > 0) {
+            const [start] = inFlightStarts.values();
+            if (
+              inFlightStarts.size === 1
+              && start?.sendGen === recoveryState.sendGen
+              && (currentTurnId === null || currentTurnId === turn.id)
+            ) {
+              // 权威 completed 已到、但对应 start RPC 仍未 settle。复用既有终态缓冲，
+              // 等响应建立 turn 归属后再由 completed 这一唯一入口重进并执行重投。
+              turnsCompletedBeforeStartResp.add(turn.id);
+              terminalErroredTurnIds.add(turn.id);
+              dismissPendingUserInputForTurn(turn.id, 'turn_failed');
+              clearActiveToolContextsForTurn(turn.id);
+              stopActiveRolloutPlanFallback();
+              isTurnInFlight = false;
+              if (currentTurnId === turn.id) currentTurnId = null;
+              deferredTerminalTurnCompletions.set(turn.id, params);
+              return;
+            }
+          }
+
+          recoveryState.pendingHttpRecovery = null;
+          if (retryTurnViaHttpRecovery(turn.id, pendingRecovery.reason)) return;
+          // 已登记但归属后来未能坐实时，恢复原终态处理；不能吞掉失败让 UI 悬空。
+          terminalErroredTurnIds.delete(turn.id);
+          log.warn('codex HTTP recovery intent could not be executed; surfacing turn failure', {
+            threadId,
+            deadTurnId: turn.id,
+            reason: pendingRecovery.reason,
+          });
+        }
+      }
+      if (pendingRecovery && recoveryState?.pendingHttpRecovery?.deadTurnId === turn.id) {
+        // 极端协议形状：先报可恢复 terminal error，最终 turn 却不是 failed。
+        // 以权威 completed 为准，取消本次恢复意图并正常收口。
+        recoveryState.pendingHttpRecovery = null;
+        terminalErroredTurnIds.delete(turn.id);
       }
       // turn/start RPC 响应未回时就收到终态 → 记墓碑, 阻止稍后到达的
       // handleTurnStartResp / 乱序 turnStarted 把已终结的 turn 重新置活。
@@ -5839,6 +5831,7 @@ export class CodexAgent extends BaseAgent {
      *   - `inFlight`：计时器已到点、重投 RPC 在途、新 turn 尚未激活；
      *   - `deferredCapacityFailure !== null`：失败已记账、等在途 turn/start settle 后
      *     补排（那一刻既没有计时器也没有 inFlight）。
+     *   - `pendingHttpRecovery !== null`：WS body 错误已登记、等权威 turn/completed。
      *
      * 抽成单一判据是因为它同时决定三件事: 会话忙不忙(isTurnRunning)、取消要不要收口
      * (signal abort)、权限收紧要不要作用到重投。前几轮每处各写一份, 第三种状态加进来
@@ -5848,7 +5841,12 @@ export class CodexAgent extends BaseAgent {
       state: typeof overloadRetry = overloadRetry,
     ): state is NonNullable<typeof overloadRetry> =>
       state != null
-      && (state.timer != null || state.inFlight || state.deferredCapacityFailure !== null);
+      && (
+        state.timer != null
+        || state.inFlight
+        || state.deferredCapacityFailure !== null
+        || state.pendingHttpRecovery !== null
+      );
 
     /**
      * 逻辑 send 被终态收口(terminal error + Done 都已推出)时, 撤销挂起 / 延后的重投。
@@ -6875,25 +6873,10 @@ export class CodexAgent extends BaseAgent {
         }
         const wasTurnRunning = isTurnInFlight || targetsPendingTurn;
         if (isTerminalError && targetsCurrentTurn && !isTransportError) {
-          const recoveryReason = armHttpRecoveryForError(effectiveParams.error);
-          if (recoveryReason) {
-            const recoveryTurnId = effectiveParams.turnId || currentTurnId || '';
-            if (retryTurnViaHttpRecovery(recoveryTurnId, recoveryReason)) return;
-            if (
-              (targetsPendingTurn
-                || (currentTurnId === recoveryTurnId && inFlightStarts.size === 1))
-              && deferHttpRecoveryUntilTurnStartSettles(
-                recoveryTurnId,
-                recoveryReason,
-                effectiveParams.error?.message
-                  || (typeof effectiveParams.error?.additionalDetails === 'string'
-                    ? effectiveParams.error.additionalDetails
-                    : 'Codex request failed before HTTP recovery could start'),
-              )
-            ) {
-              return;
-            }
-          }
+          const recoveryTurnId = effectiveParams.turnId || currentTurnId || '';
+          // error notification 只登记恢复意图并保持 logical turn 运行；
+          // 权威 turn/completed 才负责收口旧 turn 与发起一次 HTTP 重投。
+          if (recordHttpRecoveryIntent(recoveryTurnId, effectiveParams.error)) return;
         }
         // 服务过载(模型容量不足)时接管重投：translator 命中 capacity 才回调，
         // 拿到进度就把错误透成非终止状态，本函数随后跳过 Done 收口。
@@ -7168,23 +7151,18 @@ export class CodexAgent extends BaseAgent {
         const handleTurnStartResp = (resp: TurnStartResponse, ownerSeq: number): void => {
           if (resp.turn?.id) {
             const startEntry = inFlightStarts.get(ownerSeq);
-            const deferredHttpRecovery = startEntry?.deferredHttpRecovery;
-            if (deferredHttpRecovery) {
-              deferredHttpRecovery.responseMatched =
-                deferredHttpRecovery.deadTurnId === resp.turn.id;
-              if (deferredHttpRecovery.responseMatched) {
-                turnOriginByTurnId.set(resp.turn.id, {
-                  startSeq: ownerSeq,
-                  sendGen: deferredHttpRecovery.sendGen,
-                });
-              } else {
-                log.warn('deferred codex HTTP recovery did not match turn/start response', {
-                  threadId,
-                  errorTurnId: deferredHttpRecovery.deadTurnId,
-                  responseTurnId: resp.turn.id,
-                  ownerSeq,
-                });
-              }
+            const pendingHttpRecovery = overloadRetry?.pendingHttpRecovery;
+            if (
+              startEntry
+              && pendingHttpRecovery?.deadTurnId === resp.turn.id
+              && startEntry.sendGen === overloadRetry?.sendGen
+            ) {
+              // completed 已经把该 turn 记为终态，下面不会重新激活；这里仅补权威
+              // 归属，供 start finally flush completed 后的一次 HTTP 重投校验。
+              turnOriginByTurnId.set(resp.turn.id, {
+                startSeq: ownerSeq,
+                sendGen: startEntry.sendGen,
+              });
             }
             // 缓冲的歧义 started 对账 (codex R9 P2): 本响应确立在飞 RPC 的
             // turnId — 缓冲里 id 一致的是它的合法 started (下方正常激活),
@@ -7310,6 +7288,7 @@ export class CodexAgent extends BaseAgent {
         overloadRetry = {
           attempt: 0,
           httpRecoveryRetryAttempted: false,
+          pendingHttpRecovery: null,
           timer: null,
           inFlight: false,
           isCancelled: () => sendOpts?.signal?.aborted === true,
@@ -7385,12 +7364,12 @@ export class CodexAgent extends BaseAgent {
               rpcSettledOk = true;
             } finally {
               state.inFlight = false;
-              const deferredHttpRecovery =
-                inFlightStarts.get(retryStartSeq)?.deferredHttpRecovery ?? null;
+              if (!rpcSettledOk && overloadRetry === state) {
+                state.pendingHttpRecovery = null;
+              }
               // 注销本次请求(isTurnStartPending 由登记表重算, 不会误清别的请求的状态)。
               endTurnStart(retryStartSeq);
               flushDeferredTerminalTurnCompletionsIfIdle();
-              resumeDeferredHttpRecovery(deferredHttpRecovery, rpcSettledOk);
               // 在途期间又撞容量、当时被延后的那条失败在这里收尾。只有新 turn 确实
               // 没能激活时才补排（它被落了墓碑、响应因此拒绝激活）；turn 活了就说明
               // 那条错误针对的是别的 turn，不该重排。预算耗尽时必须自己推终态，
@@ -7483,6 +7462,7 @@ export class CodexAgent extends BaseAgent {
                 ...(threadModelProvider ? { modelProvider: threadModelProvider } : {}),
                 ...(resumeModel && resumeModel !== 'gpt-5' ? { model: resumeModel } : {}),
                 ...(mutableServiceTier !== undefined ? { serviceTier: mutableServiceTier } : {}),
+                ...(developerInstructions && !useProxyChannel ? { developerInstructions } : {}),
               };
               const resumeResp = await host.request<ThreadResumeResponse>(Method.ThreadResume, resumeParams, {
                 timeoutMs: CRITICAL_THREAD_RPC_TIMEOUT_MS,
@@ -7557,7 +7537,12 @@ export class CodexAgent extends BaseAgent {
           // 条目即将被删, 先把"已由取消收口"取出来供下面的 finalErr 分支判断。
           const initialStartEntry = inFlightStarts.get(initialStartSeq);
           initialStartSettledByCancel = initialStartEntry?.terminalSettled === true;
-          const deferredHttpRecovery = initialStartEntry?.deferredHttpRecovery ?? null;
+          if (
+            !initialStartSettledOk
+            && overloadRetry?.sendGen === mySendGen
+          ) {
+            overloadRetry.pendingHttpRecovery = null;
+          }
           // 先注销本次请求(isTurnStartPending 由登记表重算) —— 无条件置 false 会在两个
           // start 并存时清掉属于**另一个**请求的状态(review #844 codex P1)。注销必须早于
           // flush: 后者按 idle 与否决定是否放行缓存的终态。
@@ -7569,7 +7554,6 @@ export class CodexAgent extends BaseAgent {
           // discardOverloadRetry + terminal error 收口。
           const armedState = overloadRetry;
           if (armedState) {
-            resumeDeferredHttpRecovery(deferredHttpRecovery, initialStartSettledOk);
             // rpcSettledOk 的本意是"我这次 RPC 失败了, 别在推终态之外再排一个计时器"。
             // 但延后的那条失败可能属于**另一轮仍然活着的** send(它的容量错误在我还在飞时
             // 到达, 于是只被记账): 那一轮的命运与我这次 RPC 成败无关, 用我的失败去压掉它
@@ -7777,7 +7761,7 @@ export class CodexAgent extends BaseAgent {
         // 用户点 Stop = 明确不想继续这一轮，挂起的过载重投必须一起撤掉。
         // 放在 currentTurnId 判空之前：重投等待期间 turn 已死、currentTurnId 为
         // null，此时正是最需要响应 Stop 的时刻（否则计时器到点又发一个新 turn）。
-        const hadPendingOverloadRetry = overloadRetryPending();
+        const hadPendingRetry = overloadRetryPending();
         discardOverloadRetry('aborted');
         if (closed) return;
         // 有挂起重投时的 Stop **必须**由这里显式收口逻辑 turn —— desktop 的
@@ -7792,8 +7776,8 @@ export class CodexAgent extends BaseAgent {
         //    cancelledMidFlight 把同一个 id 落墓碑, handleTurnCompleted 于是把唯一
         //    那条完成事件压掉, 派发闩永远不释放（review #844 codex P1）。这里自己
         //    落墓碑 + interrupt + 推终态, 保证恰好一次收口。
-        if (hadPendingOverloadRetry) {
-          teardownActiveTurnForCancellation('stopped while an overload retry was pending');
+        if (hadPendingRetry) {
+          teardownActiveTurnForCancellation('stopped while an automatic retry was pending');
           markInFlightStartsTerminallySettled();
           // turn/start 还在飞时按下 Stop: 这里马上会推终态事件, 而那个 RPC 的响应随后
           // 才回来。不武装隔离的话 handleTurnStartResp 会照常激活它 —— 用户看到
@@ -7802,7 +7786,7 @@ export class CodexAgent extends BaseAgent {
           eventQueue.push({
             type: 'error',
             data: {
-              message: 'Codex turn stopped while waiting to retry a model-capacity failure',
+              message: 'Codex turn stopped while waiting for an automatic retry',
               isTerminal: true,
               reason: 'codex-overload-retry-aborted',
             },

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2419,7 +2419,19 @@ export class CodexAgent extends BaseAgent {
      * 每个 per-request 的事实都住在自己的条目里, 请求 settle 时整条删掉, 天然不串味;
      * "有没有 start 在飞"一律由 `inFlightStarts.size` 派生, 不再有第二份真相。
      */
-    const inFlightStarts = new Map<number, { quarantined: boolean; terminalSettled: boolean }>();
+    type DeferredHttpRecovery = {
+      deadTurnId: string;
+      reason: string;
+      sendGen: number;
+      terminalMessage: string;
+      responseMatched: boolean;
+    };
+    const inFlightStarts = new Map<number, {
+      quarantined: boolean;
+      terminalSettled: boolean;
+      sendGen: number;
+      deferredHttpRecovery: DeferredHttpRecovery | null;
+    }>();
     /** 每次 turn/start RPC 的自增序号, 作为登记表的键。 */
     let turnStartSeq = 0;
     /**
@@ -2433,9 +2445,14 @@ export class CodexAgent extends BaseAgent {
     let sendGeneration = 0;
 
     /** 登记一次即将发出的 turn/start, 返回它的序号。 */
-    const beginTurnStart = (): number => {
+    const beginTurnStart = (ownerSendGen: number): number => {
       const seq = ++turnStartSeq;
-      inFlightStarts.set(seq, { quarantined: false, terminalSettled: false });
+      inFlightStarts.set(seq, {
+        quarantined: false,
+        terminalSettled: false,
+        sendGen: ownerSendGen,
+        deferredHttpRecovery: null,
+      });
       isTurnStartPending = true;
       return seq;
     };
@@ -5363,6 +5380,103 @@ export class CodexAgent extends BaseAgent {
     };
 
     /**
+     * body recovery 的终态通知可能先于 turn/start RPC 响应到达。此时尚无
+     * turnOrigin，不能立即重投；只有唯一且属于本 send 的 start 在飞时才暂存，
+     * 等响应用同一个 turn id 建立权威归属后再走正常 HTTP recovery。
+     */
+    const deferHttpRecoveryUntilTurnStartSettles = (
+      deadTurnId: string,
+      reason: string,
+      terminalMessage: string,
+    ): boolean => {
+      const state = overloadRetry;
+      if (
+        !deadTurnId
+        || !state
+        || closed
+        || state.httpRecoveryRetryAttempted
+        || state.isCancelled()
+        || (currentTurnId !== null && currentTurnId !== deadTurnId)
+        || inFlightStarts.size !== 1
+        || state.timer !== null
+        || state.deferredCapacityFailure !== null
+        || producedOutputTurnIds.has(deadTurnId)
+      ) {
+        return false;
+      }
+      const [startSeq, start] = Array.from(inFlightStarts.entries())[0] ?? [];
+      if (
+        startSeq === undefined
+        || !start
+        || start.sendGen !== state.sendGen
+        || start.quarantined
+        || start.terminalSettled
+        || start.deferredHttpRecovery !== null
+      ) {
+        return false;
+      }
+
+      start.deferredHttpRecovery = {
+        deadTurnId,
+        reason,
+        sendGen: state.sendGen,
+        terminalMessage,
+        responseMatched: false,
+      };
+      // 挡住死 turn 在 RPC 响应前后的迟到事件；响应 id 对上后会补权威 origin，
+      // 并因这块墓碑拒绝重新激活。
+      terminalErroredTurnIds.add(deadTurnId);
+      dismissPendingUserInputForTurn(deadTurnId, 'turn_failed');
+      clearActiveToolContextsForTurn(deadTurnId);
+      stopActiveRolloutPlanFallback();
+      isTurnInFlight = false;
+      if (currentTurnId === deadTurnId) currentTurnId = null;
+      log.info('codex WS body recovery waiting for turn/start ownership', {
+        threadId,
+        deadTurnId,
+        reason,
+        startSeq,
+      });
+      return true;
+    };
+
+    const resumeDeferredHttpRecovery = (
+      deferred: DeferredHttpRecovery | null,
+      rpcSettledOk: boolean,
+    ): void => {
+      if (!deferred || !rpcSettledOk || !deferred.responseMatched) return;
+      const state = overloadRetry;
+      if (
+        !state
+        || closed
+        || state.sendGen !== deferred.sendGen
+        || state.isCancelled()
+      ) {
+        return;
+      }
+      if (retryTurnViaHttpRecovery(deferred.deadTurnId, deferred.reason)) return;
+
+      // 归属已经建立且本 send 仍有效时，重投若因意外状态无法接管，必须恢复原终态，
+      // 不能让被暂存的错误消失后把逻辑 turn 永久挂住。
+      log.error('deferred codex HTTP recovery could not start; surfacing original error', {
+        threadId,
+        deadTurnId: deferred.deadTurnId,
+        reason: deferred.reason,
+      });
+      discardOverloadRetry('deferred HTTP recovery could not start');
+      eventQueue.push({
+        type: 'error',
+        data: { message: deferred.terminalMessage, isTerminal: true },
+        source: 'codex',
+      });
+      eventQueue.push({
+        type: 'status',
+        data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+        source: 'codex',
+      });
+    };
+
+    /**
      * 计划模式下拦截 plan item (proposed plan / <proposed_plan> 块): 记录最新文本,
      * 不进 translator —— 计划内容由 turn 结束后的 plan_review 卡片呈现, 不再渲染
      * update_plan 工具行 (避免同一份计划在聊天里出现两次)。
@@ -6748,14 +6862,23 @@ export class CodexAgent extends BaseAgent {
         const wasTurnRunning = isTurnInFlight || targetsPendingTurn;
         if (isTerminalError && targetsCurrentTurn && !isTransportError) {
           const recoveryReason = armHttpRecoveryForError(effectiveParams.error);
-          if (
-            recoveryReason &&
-            retryTurnViaHttpRecovery(
-              effectiveParams.turnId || currentTurnId || '',
-              recoveryReason,
-            )
-          ) {
-            return;
+          if (recoveryReason) {
+            const recoveryTurnId = effectiveParams.turnId || currentTurnId || '';
+            if (retryTurnViaHttpRecovery(recoveryTurnId, recoveryReason)) return;
+            if (
+              (targetsPendingTurn
+                || (currentTurnId === recoveryTurnId && inFlightStarts.size === 1))
+              && deferHttpRecoveryUntilTurnStartSettles(
+                recoveryTurnId,
+                recoveryReason,
+                effectiveParams.error?.message
+                  || (typeof effectiveParams.error?.additionalDetails === 'string'
+                    ? effectiveParams.error.additionalDetails
+                    : 'Codex request failed before HTTP recovery could start'),
+              )
+            ) {
+              return;
+            }
           }
         }
         // 服务过载(模型容量不足)时接管重投：translator 命中 capacity 才回调，
@@ -7030,6 +7153,25 @@ export class CodexAgent extends BaseAgent {
         // 普通 LLM 错误 / 超时 / auth 失败照原路径报错。
         const handleTurnStartResp = (resp: TurnStartResponse, ownerSeq: number): void => {
           if (resp.turn?.id) {
+            const startEntry = inFlightStarts.get(ownerSeq);
+            const deferredHttpRecovery = startEntry?.deferredHttpRecovery;
+            if (deferredHttpRecovery) {
+              deferredHttpRecovery.responseMatched =
+                deferredHttpRecovery.deadTurnId === resp.turn.id;
+              if (deferredHttpRecovery.responseMatched) {
+                turnOriginByTurnId.set(resp.turn.id, {
+                  startSeq: ownerSeq,
+                  sendGen: deferredHttpRecovery.sendGen,
+                });
+              } else {
+                log.warn('deferred codex HTTP recovery did not match turn/start response', {
+                  threadId,
+                  errorTurnId: deferredHttpRecovery.deadTurnId,
+                  responseTurnId: resp.turn.id,
+                  ownerSeq,
+                });
+              }
+            }
             // 缓冲的歧义 started 对账 (codex R9 P2): 本响应确立在飞 RPC 的
             // turnId — 缓冲里 id 一致的是它的合法 started (下方正常激活),
             // 不一致的是失败 RPC 的孤儿 (interrupt + 墓碑, 没人消费)。
@@ -7176,7 +7318,7 @@ export class CodexAgent extends BaseAgent {
             // RPC 在途也算忙（见 isTurnRunning 注释）：计时器已清、turn 未激活的
             // 这段窗口若报 idle，并发 send 会把原消息挤掉。
             state.inFlight = true;
-            const retryStartSeq = beginTurnStart();
+            const retryStartSeq = beginTurnStart(state.sendGen);
             // RPC 是否走完了成功路径。补排延后的容量失败**只能**在成功路径上做:
             // finally 先于外层 state.retry().catch 执行, 若 RPC 已经 reject 却在这里
             // 排上新计时器, 紧随其后的 catch 会推终态 error + Done 收口 UI, 而那个
@@ -7229,9 +7371,12 @@ export class CodexAgent extends BaseAgent {
               rpcSettledOk = true;
             } finally {
               state.inFlight = false;
+              const deferredHttpRecovery =
+                inFlightStarts.get(retryStartSeq)?.deferredHttpRecovery ?? null;
               // 注销本次请求(isTurnStartPending 由登记表重算, 不会误清别的请求的状态)。
               endTurnStart(retryStartSeq);
               flushDeferredTerminalTurnCompletionsIfIdle();
+              resumeDeferredHttpRecovery(deferredHttpRecovery, rpcSettledOk);
               // 在途期间又撞容量、当时被延后的那条失败在这里收尾。只有新 turn 确实
               // 没能激活时才补排（它被落了墓碑、响应因此拒绝激活）；turn 活了就说明
               // 那条错误针对的是别的 turn，不该重排。预算耗尽时必须自己推终态，
@@ -7276,7 +7421,7 @@ export class CodexAgent extends BaseAgent {
         let finalErr: unknown = null;
         // 初始 RPC 在飞期间到达的空 id 容量拒绝只会被"延后"(不排计时器), 由下面的
         // finally 在响应处理完之后补排 —— 保证任一时刻只有一个 turn/start 在飞。
-        const initialStartSeq = beginTurnStart();
+        const initialStartSeq = beginTurnStart(mySendGen);
         let initialStartSettledOk = false;
         /** 本次请求是否已被 Stop / 撤单收口过(条目会在 finally 里删掉, 所以先取出来)。 */
         let initialStartSettledByCancel = false;
@@ -7396,8 +7541,9 @@ export class CodexAgent extends BaseAgent {
           }
         } finally {
           // 条目即将被删, 先把"已由取消收口"取出来供下面的 finalErr 分支判断。
-          initialStartSettledByCancel =
-            inFlightStarts.get(initialStartSeq)?.terminalSettled === true;
+          const initialStartEntry = inFlightStarts.get(initialStartSeq);
+          initialStartSettledByCancel = initialStartEntry?.terminalSettled === true;
+          const deferredHttpRecovery = initialStartEntry?.deferredHttpRecovery ?? null;
           // 先注销本次请求(isTurnStartPending 由登记表重算) —— 无条件置 false 会在两个
           // start 并存时清掉属于**另一个**请求的状态(review #844 codex P1)。注销必须早于
           // flush: 后者按 idle 与否决定是否放行缓存的终态。
@@ -7409,6 +7555,7 @@ export class CodexAgent extends BaseAgent {
           // discardOverloadRetry + terminal error 收口。
           const armedState = overloadRetry;
           if (armedState) {
+            resumeDeferredHttpRecovery(deferredHttpRecovery, initialStartSettledOk);
             // rpcSettledOk 的本意是"我这次 RPC 失败了, 别在推终态之外再排一个计时器"。
             // 但延后的那条失败可能属于**另一轮仍然活着的** send(它的容量错误在我还在飞时
             // 到达, 于是只被记账): 那一轮的命运与我这次 RPC 成败无关, 用我的失败去压掉它

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -5498,7 +5498,21 @@ export class CodexAgent extends BaseAgent {
         !terminalErroredTurnIds.has(turn.id)
       ) {
         const recoveryReason = armHttpRecoveryForError(turn.error);
-        if (recoveryReason) retryTurnViaHttpRecovery(turn.id, recoveryReason);
+        if (recoveryReason) {
+          if (retryTurnViaHttpRecovery(turn.id, recoveryReason)) return;
+          if (
+            deferHttpRecoveryUntilTurnStartSettles(
+              turn.id,
+              recoveryReason,
+              turn.error.message
+                || (typeof turn.error.additionalDetails === 'string'
+                  ? turn.error.additionalDetails
+                  : 'Codex turn failed before HTTP recovery could start'),
+            )
+          ) {
+            return;
+          }
+        }
       }
       // turn/start RPC 响应未回时就收到终态 → 记墓碑, 阻止稍后到达的
       // handleTurnStartResp / 乱序 turnStarted 把已终结的 turn 重新置活。


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 的 ChatGPT OAuth 订阅直连此前被固定为 HTTP，失去了 bundled Codex 原生的 Responses WebSocket 预热与连接复用，因此在 `gpt-5.6-sol + ultra` 等紧张容量场景中更容易逐 turn 重新竞争容量并遇到 `at capacity`。

本 PR 让本地 loopback proxy 透明转发 WebSocket，并且只为订阅直连 provider 开启。握手不兼容、代理拦截或 WS 网络失败时返回 Codex 识别的 426，自动退回现有 HTTP；真实的 401/429/5xx（含上游容量错误）仍原样交给同版本 Codex。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：恢复 Cindy 订阅直连与 bundled Codex 一致的 WS 传输能力，降低 `at capacity` 体验差异。
- 本 PR 包含：
  - proxy 的 WS upgrade 透明隧道、`/v1` 路径校正、完整 101/非 101 响应转发和 426 HTTP fallback；
  - 复用现有桌面出站代理解析，覆盖直连、系统代理/PAC、HTTP CONNECT、SOCKS5；
  - 仅 `cindy_openai`（ChatGPT OAuth 订阅）开启 WS，gateway、xAI、自定义 provider 保持 HTTP；
  - WS thread 改用 Codex 原生 `developerInstructions`，内容不变；
  - `encrypted_content` / image-id 首次命中时，仅在 WS 握手有稳定 thread 归属且零产出时自动退回 HTTP 重投；匿名 startup-prewarm 无法安全归属，保留直接 Codex 的原生错误行为，避免影响其他会话；
  - WS 建连/关闭日志和协议、代理、fallback、prompt、recovery 单测。
- 明确不包含：远端 host 的 WS 改造；standalone web-search 能力对齐；Codex 自身 loaded-thread resume override 问题的本地 workaround。
- 用户可见变化：订阅直连恢复 WS 预热/复用；WS 不可用时自动沿用原 HTTP。无 UI 变化。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（Desktop、Mobile、maker-core、anthropic-compat-proxy 等全部 required unit workspace）。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/anthropic-compat-proxy run --if-present typecheck
结果：通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（该包当前无 typecheck script，命令按仓库门禁约定成功退出）。

pnpm --filter @cindy/anthropic-compat-proxy run lint
结果：通过。

node scripts/check-dco.mjs --base origin/main --head HEAD
结果：全部 PR commits 签名校验通过。
```

覆盖点包括：101 握手与双向首包、`/v1` 剥离、非默认端口 Host、上游 503/401/429 原样透传、WS 拦截后 426、无本地连接容量上限、按 thread 断连、HTTP CONNECT、SOCKS5、dispose、原生 developer instructions、两类 body recovery 的单次安全重投。

### 手工验证

- macOS 本地 dev，bundled Codex 0.145，ChatGPT OAuth，`gpt-5.6-sol + ultra`：三次会话均看到 WS 101/prewarm，完整收到 `turn/completed`；该小样本中 `at capacity` 为 0。
- 用 bundled Codex 0.145 做 426 黑盒回退：观察到 1 次 upgrade、随后 1 次 HTTP `/responses` POST，文本返回且 `turnCompleted=true`。
- 本地日志确认上游路径为 `/backend-api/codex/responses`，连接由 Codex 客户端主动正常关闭，无 proxy error。

### 未执行的验证

- 未做 Windows 实机矩阵；Windows 与 macOS 复用同一个 `resolveDesktopOutboundProxy` 数据流，系统代理/PAC 由 Electron 解析，HTTP CONNECT 与 SOCKS5 隧道已有自动验证，426 响应采用 flush 后关闭避免 Windows RST。仍建议 CI/合并后在 Windows 做一次烟测。
- 三次对话只能证明通道和收口正确，不能统计证明长期 `at capacity` 频率；需实际使用继续观测。
- Codex 0.145 对仍在内存中的 loaded thread 会忽略 resume 的 developerInstructions override（openai/codex#19045）；直接使用 Codex 同样存在，本 PR 不在 Cindy 层分叉修复，等待 bundled Codex 升级。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：Codex Responses transport

### 影响与回滚

- 影响范围：仅本地 Desktop 的 ChatGPT OAuth 订阅直连 thread。prompt 文本与顺序不变，只从 proxy 每请求注入改为 Codex 原生 `developerInstructions`；mobile/device-link 控制面、远端 host、gateway、xAI、自定义 provider 不改传输。
- 回滚 / 降级方式：运行时 WS 握手不兼容会自动 426 降到原 HTTP；需要整体回滚时 revert 本提交即可恢复 `supports_websockets=false`。真实上游 401/429/5xx 不被 fallback 掩盖。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI，已注明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码契约与 PR 风险说明；无独立用户文档变更）
- [x] 已确认测试结果或说明未执行原因


