### PR TITLE
fix(desktop): refresh agent island displays after wake

### DIFF
--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -4626,6 +4626,7 @@ final class AgentIslandController {
   private var globalMouseUpMonitor: Any?
   private var localMouseUpMonitor: Any?
   private var screenParameterObserver: NSObjectProtocol?
+  private var workspaceWakeObserver: NSObjectProtocol?
   private var activeSpaceObserver: NSObjectProtocol?
   private var activeApplicationObserver: NSObjectProtocol?
   private var screenMetricsTimer: Timer?
@@ -4848,6 +4849,16 @@ final class AgentIslandController {
     ) { [weak self] _ in
       self?.scheduleScreenMetricsPublish()
     }
+    workspaceWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.didWakeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      // Sleep can restore the same display set without emitting the screen-parameter
+      // notification. Refreshing here makes the main process recompute every island
+      // frame against the post-wake display coordinates instead of stale ones.
+      self?.scheduleScreenMetricsPublish()
+    }
     activeSpaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
       forName: NSWorkspace.activeSpaceDidChangeNotification,
       object: nil,
@@ -4886,6 +4897,9 @@ final class AgentIslandController {
     if let screenParameterObserver {
       NotificationCenter.default.removeObserver(screenParameterObserver)
     }
+    if let workspaceWakeObserver {
+      NSWorkspace.shared.notificationCenter.removeObserver(workspaceWakeObserver)
+    }
     if let activeSpaceObserver {
       NSWorkspace.shared.notificationCenter.removeObserver(activeSpaceObserver)
     }
@@ -4893,6 +4907,7 @@ final class AgentIslandController {
       NSWorkspace.shared.notificationCenter.removeObserver(activeApplicationObserver)
     }
     screenParameterObserver = nil
+    workspaceWakeObserver = nil
     activeSpaceObserver = nil
     activeApplicationObserver = nil
     screenMetricsTimer?.invalidate()

--- a/apps/desktop/native/agent-island/macos-agent-island-helper.swift
+++ b/apps/desktop/native/agent-island/macos-agent-island-helper.swift
@@ -4630,6 +4630,7 @@ final class AgentIslandController {
   private var activeSpaceObserver: NSObjectProtocol?
   private var activeApplicationObserver: NSObjectProtocol?
   private var screenMetricsTimer: Timer?
+  private var pendingScreenMetricsForceRefresh = false
   private var dragInteraction: PanelDragInteraction?
   private var pendingMoveInteraction: PanelDragInteraction?
   private var lastMoveTime: TimeInterval = 0
@@ -4857,7 +4858,7 @@ final class AgentIslandController {
       // Sleep can restore the same display set without emitting the screen-parameter
       // notification. Refreshing here makes the main process recompute every island
       // frame against the post-wake display coordinates instead of stale ones.
-      self?.scheduleScreenMetricsPublish()
+      self?.scheduleScreenMetricsPublish(forceRefresh: true)
     }
     activeSpaceObserver = NSWorkspace.shared.notificationCenter.addObserver(
       forName: NSWorkspace.activeSpaceDidChangeNotification,
@@ -4951,7 +4952,7 @@ final class AgentIslandController {
     return true
   }
 
-  func publishScreenMetrics() {
+  func publishScreenMetrics(forceRefresh: Bool = false) {
     var payload: [String: Any] = [
       "type": "screen-metrics",
       "screens": AgentIslandScreenMetricsProvider.allMetrics().map { $0.dictionary },
@@ -4959,14 +4960,21 @@ final class AgentIslandController {
     if let preferredDisplayId = AgentIslandScreenMetricsProvider.preferredDisplayId() {
       payload["preferredDisplayId"] = preferredDisplayId
     }
+    if forceRefresh {
+      payload["forceRefresh"] = true
+    }
     eventSink(payload)
   }
 
-  private func scheduleScreenMetricsPublish() {
+  private func scheduleScreenMetricsPublish(forceRefresh: Bool = false) {
+    pendingScreenMetricsForceRefresh = pendingScreenMetricsForceRefresh || forceRefresh
     screenMetricsTimer?.invalidate()
     screenMetricsTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { [weak self] _ in
-      self?.screenMetricsTimer = nil
-      self?.publishScreenMetrics()
+      guard let self else { return }
+      self.screenMetricsTimer = nil
+      let forceRefresh = self.pendingScreenMetricsForceRefresh
+      self.pendingScreenMetricsForceRefresh = false
+      self.publishScreenMetrics(forceRefresh: forceRefresh)
     }
     RunLoop.main.add(screenMetricsTimer!, forMode: .common)
   }

--- a/apps/desktop/src/main/agent-island/MacAgentIslandNativeHost.ts
+++ b/apps/desktop/src/main/agent-island/MacAgentIslandNativeHost.ts
@@ -83,6 +83,7 @@ interface MacAgentIslandNativeHostOptions {
   onScreenMetrics: (metrics: {
     screens: AgentIslandNativeScreenMetrics[];
     preferredDisplayId: number | null;
+    forceRefresh: boolean;
   }) => void;
 }
 
@@ -90,6 +91,7 @@ type NativePayload = {
   type?: unknown;
   message?: unknown;
   event?: unknown;
+  forceRefresh?: unknown;
   hit?: unknown;
   mode?: unknown;
   fromMode?: unknown;
@@ -572,6 +574,7 @@ export class MacAgentIslandNativeHost {
         preferredDisplayId: typeof payload.preferredDisplayId === 'number'
           ? payload.preferredDisplayId
           : null,
+        forceRefresh: payload.forceRefresh === true,
       });
     }
   }

--- a/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
@@ -104,9 +104,10 @@ describe('MacAgentIslandNativeHost', () => {
     );
 
     const wakeObserver = source.match(
-      /workspaceWakeObserver = NSWorkspace[\s\S]*?\n {4}}\n {4}activeSpaceObserver/,
+      /workspaceWakeObserver\s*=\s*NSWorkspace\.shared\.notificationCenter\.addObserver\(\s*forName:\s*NSWorkspace\.didWakeNotification,[\s\S]*?self\?\.scheduleScreenMetricsPublish\(\)\s*\n\s*}/,
     )?.[0];
 
+    expect(wakeObserver).toBeTruthy();
     expect(wakeObserver).toContain('NSWorkspace.didWakeNotification');
     expect(wakeObserver).toContain('scheduleScreenMetricsPublish()');
   });

--- a/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
@@ -97,6 +97,20 @@ describe('MacAgentIslandNativeHost', () => {
     expect(source).not.toContain('makeKey()');
   });
 
+  it('refreshes native display metrics after macOS wakes from sleep', () => {
+    const source = fs.readFileSync(
+      new URL('../../../../native/agent-island/macos-agent-island-helper.swift', import.meta.url),
+      'utf8',
+    );
+
+    const wakeObserver = source.match(
+      /workspaceWakeObserver = NSWorkspace[\s\S]*?\n {4}}\n {4}activeSpaceObserver/,
+    )?.[0];
+
+    expect(wakeObserver).toContain('NSWorkspace.didWakeNotification');
+    expect(wakeObserver).toContain('scheduleScreenMetricsPublish()');
+  });
+
   it('keeps native Agent marks aligned with the renderer icons', () => {
     const nativeSource = fs.readFileSync(
       new URL('../../../../native/agent-island/macos-agent-island-helper.swift', import.meta.url),

--- a/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts
@@ -104,12 +104,13 @@ describe('MacAgentIslandNativeHost', () => {
     );
 
     const wakeObserver = source.match(
-      /workspaceWakeObserver\s*=\s*NSWorkspace\.shared\.notificationCenter\.addObserver\(\s*forName:\s*NSWorkspace\.didWakeNotification,[\s\S]*?self\?\.scheduleScreenMetricsPublish\(\)\s*\n\s*}/,
+      /workspaceWakeObserver\s*=\s*NSWorkspace\.shared\.notificationCenter\.addObserver\(\s*forName:\s*NSWorkspace\.didWakeNotification,[\s\S]*?self\?\.scheduleScreenMetricsPublish\(forceRefresh:\s*true\)\s*\n\s*}/,
     )?.[0];
 
     expect(wakeObserver).toBeTruthy();
     expect(wakeObserver).toContain('NSWorkspace.didWakeNotification');
-    expect(wakeObserver).toContain('scheduleScreenMetricsPublish()');
+    expect(wakeObserver).toContain('scheduleScreenMetricsPublish(forceRefresh: true)');
+    expect(source).toContain('payload["forceRefresh"] = true');
   });
 
   it('keeps native Agent marks aligned with the renderer icons', () => {

--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -3956,6 +3956,63 @@ describe('AgentIslandService native publishing', () => {
     expect(framesById.get(2)).toMatchObject({ width: 360, contentWidth: 320 });
   });
 
+  it('re-publishes native frames when a wake refresh keeps the same screen signature', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish },
+    });
+    syncEnabledForTest(service, publish);
+    const setNativeScreenMetrics = (
+      service as unknown as {
+        handleNativeScreenMetrics(metrics: {
+          screens: Array<{
+            displayId: number;
+            frame: { x: number; y: number; width: number; height: number };
+            hasNotch: boolean;
+            notchWidth: number;
+            topBarHeight: number;
+            menuBarHeight: number;
+            safeAreaTop: number;
+            isMain: boolean;
+            signature: string;
+          }>;
+          preferredDisplayId: number | null;
+          forceRefresh?: boolean;
+        }): void;
+      }
+    ).handleNativeScreenMetrics.bind(service);
+    const metrics = {
+      preferredDisplayId: mocks.primaryDisplay.id,
+      screens: [{
+        displayId: mocks.primaryDisplay.id,
+        frame: mocks.primaryDisplay.bounds,
+        hasNotch: false,
+        notchWidth: 0,
+        topBarHeight: 24,
+        menuBarHeight: 24,
+        safeAreaTop: 0,
+        isMain: true,
+        signature: 'primary',
+      }],
+    };
+
+    publish.mockClear();
+    setNativeScreenMetrics(metrics);
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    setNativeScreenMetrics(metrics);
+    expect(publish).toHaveBeenCalledTimes(1);
+
+    setNativeScreenMetrics({ ...metrics, forceRefresh: true });
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
   it('uses native notched-display metrics when computing display frames', async () => {
     const { AgentIslandService } = await import('../service.js');
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -1623,6 +1623,7 @@ export class AgentIslandService {
   private handleNativeScreenMetrics(metrics: {
     screens: AgentIslandNativeScreenMetrics[];
     preferredDisplayId: number | null;
+    forceRefresh: boolean;
   }): void {
     const signature = metrics.screens
       .map((item) => [
@@ -1633,7 +1634,11 @@ export class AgentIslandService {
         Math.round(item.topBarHeight),
       ].join(':'))
       .join('|');
-    if (signature === this.screenMetricsSignature && metrics.preferredDisplayId === this.nativePreferredDisplayId) {
+    if (
+      !metrics.forceRefresh
+      && signature === this.screenMetricsSignature
+      && metrics.preferredDisplayId === this.nativePreferredDisplayId
+    ) {
       return;
     }
     this.screenMetricsByDisplayId.clear();
@@ -2264,4 +2269,3 @@ function isPlaceholderSessionTitle(title: string | null): boolean {
   const normalized = title.trim().toLowerCase();
   return normalized === '' || normalized === 'new maker' || normalized === 'untitled';
 }
-


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 从睡眠唤醒后，灵动岛可能仍使用睡前坐标而跨屏或偏移的问题。唤醒事件现在会明确要求主进程重新下发布局；即使显示器列表的签名没有变化，也不会被普通的去重逻辑跳过。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Fixes #1137
- 本 PR 包含：监听 `NSWorkspace.didWakeNotification`、在原生消息中标识强制刷新、主进程绕过去重并重新发布各显示器岛位置，以及回归测试。
- 明确不包含：显示器选择策略、用户布局偏好、岛的几何算法或视觉样式。
- 用户可见变化：外接显示器环境从睡眠恢复后，灵动岛会按恢复后的屏幕坐标重新定位。
- 是否存在 breaking change：无。

### UI 变化

不涉及视觉设计变更；只修正已有原生岛的唤醒后位置刷新。

- 引用的设计规范：不涉及：不更改样式、布局规则或文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts src/main/agent-island/__tests__/service.test.ts
结果：114 tests passed。

pnpm --filter desktop typecheck
结果：通过。

pnpm --filter desktop exec eslint src/main/agent-island/MacAgentIslandNativeHost.ts src/main/agent-island/service.ts src/main/agent-island/__tests__/MacAgentIslandNativeHost.test.ts src/main/agent-island/__tests__/service.test.ts
结果：通过。

swiftc -parse apps/desktop/native/agent-island/macos-agent-island-helper.swift
结果：通过。

完整 Desktop unit suite
结果：1415 test files / 17020 tests passed，2 skipped。

git diff --check
结果：通过。
```

### 手工验证

未接外接显示器进行睡眠/唤醒实测；自动化测试覆盖“相同屏幕签名时普通事件保持去重、唤醒事件强制重新发布”的关键差异。

### 未执行的验证

未在双屏 macOS 环境实机复现；当前机器未连接外接显示器。

## 风险

### 风险分类

- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异

### 影响与回滚

- 影响范围：仅 macOS 原生灵动岛 helper 与主进程之间的唤醒后屏幕度量同步。
- 回滚 / 降级方式：revert 本 PR 的提交即可恢复以前的普通度量刷新。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因