### PR TITLE
fix(model-providers): 修正 Kimi 模型上下文窗口

### DIFF
--- a/apps/desktop/src/renderer/__tests__/contextWindowDisplay.test.ts
+++ b/apps/desktop/src/renderer/__tests__/contextWindowDisplay.test.ts
@@ -18,6 +18,13 @@ describe('resolveDisplayContextWindow', () => {
     })).toBe(1_048_576);
   });
 
+  it('uses Kimi K3 model metadata instead of Claude Code defaults', () => {
+    expect(resolveDisplayContextWindow({
+      modelContextWindow: 1_048_576,
+      sdkContextWindow: 200_000,
+    })).toBe(1_048_576);
+  });
+
   it('keeps non-default SDK values as runtime ground truth', () => {
     expect(resolveDisplayContextWindow({
       modelContextWindow: 992_000,

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -337,7 +337,7 @@
             {
               "id": "kimi-k3",
               "name": "Kimi K3",
-              "contextWindow": 1000000
+              "contextWindow": 1048576
             },
             {
               "id": "kimi-k2.7-code",
@@ -358,15 +358,18 @@
           "models": [
             {
               "id": "kimi-k3",
-              "name": "Kimi K3"
+              "name": "Kimi K3",
+              "contextWindow": 1048576
             },
             {
               "id": "kimi-k2.7-code",
-              "name": "Kimi K2.7 Code"
+              "name": "Kimi K2.7 Code",
+              "contextWindow": 262144
             },
             {
               "id": "kimi-k2.6",
-              "name": "Kimi K2.6"
+              "name": "Kimi K2.6",
+              "contextWindow": 262144
             }
           ],
           "modelsUrl": "https://api.moonshot.cn/v1/models"
@@ -385,7 +388,7 @@
             {
               "id": "kimi-k3",
               "name": "Kimi K3",
-              "contextWindow": 1000000
+              "contextWindow": 1048576
             },
             {
               "id": "kimi-k2.7-code",
@@ -406,15 +409,18 @@
           "models": [
             {
               "id": "kimi-k3",
-              "name": "Kimi K3"
+              "name": "Kimi K3",
+              "contextWindow": 1048576
             },
             {
               "id": "kimi-k2.7-code",
-              "name": "Kimi K2.7 Code"
+              "name": "Kimi K2.7 Code",
+              "contextWindow": 262144
             },
             {
               "id": "kimi-k2.6",
-              "name": "Kimi K2.6"
+              "name": "Kimi K2.6",
+              "contextWindow": 262144
             }
           ],
           "modelsUrl": "https://api.moonshot.ai/v1/models"

--- a/packages/model-providers/src/__tests__/presets.test.ts
+++ b/packages/model-providers/src/__tests__/presets.test.ts
@@ -389,6 +389,23 @@ describe('官方渠道预设契约', () => {
   const preset = (id: string) =>
     BUNDLED_CATALOG.presets?.find((candidate) => candidate.id === id);
 
+  it.each(['moonshot-kimi-cn', 'moonshot-kimi-global'])(
+    '%s 的 Claude Code 与 Codex 模型携带真实 contextWindow',
+    (id) => {
+      const moonshot = preset(id);
+      expect(moonshot).toBeDefined();
+      for (const agent of ['claude-code', 'codex'] as const) {
+        expect(
+          moonshot?.runtimes[agent]?.models.map((model) => [model.id, model.contextWindow]),
+        ).toEqual([
+          ['kimi-k3', 1_048_576],
+          ['kimi-k2.7-code', 262_144],
+          ['kimi-k2.6', 262_144],
+        ]);
+      }
+    },
+  );
+
   it('LiteLLM 是可编辑回环端点，并明确走无鉴权而非复用 CLI 订阅凭证', () => {
     const liteLlm = preset('litellm');
     expect(liteLlm?.authMethod).toBe('none');


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Moonshot 中国站和国际站预设补齐 Kimi K3、Kimi K2.7 Code 与 Kimi K2.6 在 Claude Code / Codex runtime 下的真实 contextWindow 元数据，使自定义 API Key 渠道使用模型能力值，而不是落到 SDK 默认窗口。

同时增加 provider catalog 契约测试和 Desktop 展示回归测试，确保 Kimi K3 的 1,048,576 token 窗口不会被 Claude Code 的 200K 默认值覆盖。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：Closes #1145
- 本 PR 包含：Moonshot CN / Global 的 Kimi 模型 contextWindow 元数据及回归测试
- 明确不包含：通用模型上下文自动探测、用户手动覆盖配置
- 用户可见变化：Kimi K3 显示并采用 1,048,576 token 上下文；Kimi K2.7 Code / K2.6 采用 262,144 token
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 结构、交互或文案变化；仅修正既有上下文预算展示的数据来源。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
corepack pnpm --dir packages/model-providers test
结果：通过，402/402 tests

corepack pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/contextWindowDisplay.test.ts
结果：通过，6/6 tests

corepack pnpm --dir apps/desktop typecheck
结果：通过

corepack pnpm test:unit --workspace-concurrency=1
结果：除 apps/desktop 的既有 Windows taskkill 时序用例偶发超时外，其余工作区通过；Desktop 为 16,988 passed、25 skipped、1 failed。失败用例与本改动无关，随后单独重跑通过（3/3）。

corepack pnpm --dir apps/desktop exec vitest run src/main/scheduler-host/__tests__/procUtil.test.ts --pool=forks --maxWorkers=1
结果：通过，3/3 tests

corepack pnpm check:dco
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

无。完整 unit 门禁已执行；上述 Windows taskkill 用例在全量负载下偶发超时，已单独复跑确认通过。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：Moonshot 中国站和国际站预设中的 Kimi 模型上下文预算解析
- 回滚 / 降级方式：回退本提交即可恢复旧 metadata

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动不涉及设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果并说明全量门禁中的无关 flaky