### PR TITLE
fix(desktop): wait for plugin processes before update

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -127,7 +127,7 @@ describe('market Ghost session boundary', () => {
     const waitIndex = body.indexOf(
       'await getGhostNodeRuntimeBroker().stopAndWait(expected.ghostId);',
     );
-    const updateIndex = body.indexOf('await manager.update(cindyFilePath');
+    const updateIndex = body.indexOf('await manager.update(cindyFilePath,');
 
     expect(waitIndex).toBeGreaterThan(-1);
     expect(waitIndex).toBeLessThan(updateIndex);

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -141,7 +141,7 @@ describe('market Ghost session boundary', () => {
     expect(restoreIndex).toBeGreaterThan(updateIndex);
   });
 
-  it('only restores a resident local-update plugin after shutdown was confirmed', () => {
+  it('releases the mutation lease for shutdown failures and restores only after confirmed shutdown', () => {
     const updateStart = source.indexOf("ipcMain.handle('ghosts:update'");
     const updateEnd = source.indexOf("ipcMain.handle('ghosts:pick-file'", updateStart);
     const body = source.slice(updateStart, updateEnd);
@@ -149,13 +149,19 @@ describe('market Ghost session boundary', () => {
     const waitIndex = body.indexOf(
       'await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);',
     );
+    const tryIndex = body.indexOf('try {\n        runtime.stop(inspected.manifest.id);');
     const updateIndex = body.indexOf('result = await manager.update(lizFilePath');
     const restoreIndex = body.indexOf(
       'if (previousGhost) spawnIfResident(previousGhost);',
     );
 
+    expect(tryIndex).toBeGreaterThan(-1);
+    expect(tryIndex).toBeLessThan(waitIndex);
     expect(waitIndex).toBeGreaterThan(-1);
     expect(waitIndex).toBeLessThan(updateIndex);
-    expect(restoreIndex).toBeGreaterThan(updateIndex);
+    expect(restoreIndex).toBeGreaterThan(waitIndex);
+    expect(body).toContain('finally {\n        releaseMutation();');
+    expect(body).toContain("throwIpcError('INTERNAL', 'Unable to verify the installed Plugin source');");
+    expect(body).toContain("throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');");
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -123,5 +123,32 @@ describe('market Ghost session boundary', () => {
       initialBranch.indexOf('return installAndDock('),
     );
     expect(body.match(/expected\.beforeCommitInLock\?\.\(\);/g)).toHaveLength(2);
+
+    const waitIndex = body.indexOf(
+      'await getGhostNodeRuntimeBroker().stopAndWait(expected.ghostId);',
+    );
+    const updateIndex = body.indexOf('await manager.update(cindyFilePath');
+
+    expect(waitIndex).toBeGreaterThan(-1);
+    expect(waitIndex).toBeLessThan(updateIndex);
+    expect(body.indexOf('spawnIfResident(installed);')).toBeGreaterThan(waitIndex);
+  });
+
+  it('restores a resident local-update plugin if waiting for shutdown fails', () => {
+    const updateStart = source.indexOf("ipcMain.handle('ghosts:update'");
+    const updateEnd = source.indexOf("ipcMain.handle('ghosts:pick-file'", updateStart);
+    const body = source.slice(updateStart, updateEnd);
+
+    const waitIndex = body.indexOf(
+      'await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);',
+    );
+    const updateIndex = body.indexOf('result = await manager.update(lizFilePath');
+    const restoreIndex = body.indexOf(
+      'if (previousGhost) spawnIfResident(previousGhost);',
+    );
+
+    expect(waitIndex).toBeGreaterThan(-1);
+    expect(waitIndex).toBeLessThan(updateIndex);
+    expect(restoreIndex).toBeGreaterThan(updateIndex);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -131,10 +131,11 @@ describe('market Ghost session boundary', () => {
 
     expect(waitIndex).toBeGreaterThan(-1);
     expect(waitIndex).toBeLessThan(updateIndex);
-    expect(body.indexOf('spawnIfResident(installed);')).toBeGreaterThan(waitIndex);
+    const restoreIndex = body.indexOf('spawnIfResident(installed);');
+    expect(restoreIndex).toBeGreaterThan(updateIndex);
   });
 
-  it('restores a resident local-update plugin if waiting for shutdown fails', () => {
+  it('only restores a resident local-update plugin after shutdown was confirmed', () => {
     const updateStart = source.indexOf("ipcMain.handle('ghosts:update'");
     const updateEnd = source.indexOf("ipcMain.handle('ghosts:pick-file'", updateStart);
     const body = source.slice(updateStart, updateEnd);

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -80,6 +80,9 @@ describe('market Ghost session boundary', () => {
       'const detachMarketRecord = Boolean(marketRecord?.installed)',
     );
     const runtimeStopIndex = body.indexOf('runtime.stop(inspected.manifest.id)');
+    const stopAndWaitIndex = body.indexOf(
+      'await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);',
+    );
     const managerUpdateIndex = body.indexOf('result = await manager.update(');
     const detachIndex = body.indexOf(
       'marketLedger.markRemoved(inspected.manifest.id, marketInstallSubject)',
@@ -91,9 +94,12 @@ describe('market Ghost session boundary', () => {
     expect(leaseIndex).toBeGreaterThan(inspectIndex);
     expect(ledgerReadIndex).toBeGreaterThan(leaseIndex);
     expect(detachDecisionIndex).toBeGreaterThan(ledgerReadIndex);
-    expect(detachIndex).toBeGreaterThan(detachDecisionIndex);
-    expect(runtimeStopIndex).toBeGreaterThan(detachIndex);
-    expect(managerUpdateIndex).toBeGreaterThan(runtimeStopIndex);
+    expect(runtimeStopIndex).toBeGreaterThan(leaseIndex);
+    expect(stopAndWaitIndex).toBeGreaterThan(runtimeStopIndex);
+    // 只有确认旧进程退出，才切断旧市场的自动更新路由；等待失败时保留原路由，
+    // 也不会尝试恢复第二份 resident 进程。
+    expect(detachIndex).toBeGreaterThan(stopAndWaitIndex);
+    expect(managerUpdateIndex).toBeGreaterThan(detachIndex);
     expect(body).toContain('marketLedger.isDefaultInstallSuppressed(');
     expect(body).toContain('marketLedger.restoreInstallation(');
     expect(body).toContain('suppressed: marketRecordWasSuppressed');

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -219,6 +219,31 @@ describe('nodeRuntimeBroker · 进程生命周期', () => {
     expect(broker.stateOf('node-ghost')).toBe('off');
   });
 
+  it('stopAndWait 在工作进程实际退出前不返回', async () => {
+    const ghost = fakeGhost({ lifecycle: 'resident' });
+    const child = new FakeNodeProcess();
+    const kill = vi.spyOn(child, 'kill').mockImplementation(() => {
+      child.killed = true;
+      return true;
+    });
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+    });
+    await broker.startResident(ghost);
+
+    let settled = false;
+    const stopping = broker.stopAndWait('node-ghost').then(() => {
+      settled = true;
+    });
+    expect(kill).toHaveBeenCalledWith('SIGTERM');
+    expect(settled).toBe(false);
+
+    child.emit('exit', null, 'SIGTERM');
+    await stopping;
+    expect(settled).toBe(true);
+  });
+
   it('按需进程空闲两分钟后自动关闭', async () => {
     vi.useFakeTimers();
     const ghost = fakeGhost();

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -244,6 +244,47 @@ describe('nodeRuntimeBroker · 进程生命周期', () => {
     expect(settled).toBe(true);
   });
 
+  it('stopAndWait 在进程不退出时有界失败，不让更新永久卡住', async () => {
+    vi.useFakeTimers();
+    const ghost = fakeGhost({ lifecycle: 'resident' });
+    const child = new FakeNodeProcess();
+    vi.spyOn(child, 'kill').mockImplementation(() => {
+      child.killed = true;
+      return true;
+    });
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+    });
+    await broker.startResident(ghost);
+
+    const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止超时',
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    await stopping;
+  });
+
+  it('stopAndWait 将没有 exit 的进程错误作为更新失败返回', async () => {
+    const ghost = fakeGhost({ lifecycle: 'resident' });
+    const child = new FakeNodeProcess();
+    vi.spyOn(child, 'kill').mockImplementation(() => {
+      child.killed = true;
+      return true;
+    });
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+    });
+    await broker.startResident(ghost);
+
+    const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止失败',
+    );
+    child.emit('error', new Error('spawn transport broke'));
+    await stopping;
+  });
+
   it('按需进程空闲两分钟后自动关闭', async () => {
     vi.useFakeTimers();
     const ghost = fakeGhost();
@@ -1195,7 +1236,11 @@ describe('nodeRuntimeBroker · 宿主代启子进程(childSpawn,2026-07-23)', ()
     return ghost;
   }
 
-  async function bootWorker(ghost: InstalledGhost, spawnChild?: () => FakeRawChild) {
+  async function bootWorker(
+    ghost: InstalledGhost,
+    spawnChild?: () => FakeRawChild,
+    autoSpawnChild = true,
+  ) {
     const worker = new FakeControlProcess((message) => {
       if (message.id !== undefined && typeof message.method === 'string') {
         queueMicrotask(() => worker.send({ jsonrpc: '2.0', id: message.id, result: null }));
@@ -1208,7 +1253,7 @@ describe('nodeRuntimeBroker · 宿主代启子进程(childSpawn,2026-07-23)', ()
       spawnChildProcess: (entryPath, _cwd, _ghostId, args) => {
         const child = spawnChild?.() ?? new FakeRawChild();
         spawned.push({ entryPath, args, child });
-        queueMicrotask(() => child.emit('spawn'));
+        if (autoSpawnChild) queueMicrotask(() => child.emit('spawn'));
         return child as unknown as NodeWorkerProcess;
       },
     });
@@ -1306,5 +1351,26 @@ describe('nodeRuntimeBroker · 宿主代启子进程(childSpawn,2026-07-23)', ()
     broker.stop('node-ghost');
     expect(spawned[0].child.killed).toBe(true);
     expect(worker.killed).toBe(true);
+  });
+
+  it('stopAndWait 等待尚未触发 spawn 的已 fork 子进程退出', async () => {
+    const startingChild = new FakeRawChild();
+    const { broker, worker, spawned } = await bootWorker(
+      childSpawnGhost(),
+      () => startingChild,
+      false,
+    );
+    worker.emitControl({ type: 'spawn-child', reqId: 'r1', entry: 'node/maker.cjs' });
+    await vi.waitFor(() => expect(spawned).toHaveLength(1));
+
+    let settled = false;
+    const stopping = broker.stopAndWait('node-ghost').then(() => {
+      settled = true;
+    });
+    expect(startingChild.killed).toBe(true);
+    expect(settled).toBe(false);
+
+    await stopping;
+    expect(settled).toBe(true);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -265,10 +265,11 @@ describe('nodeRuntimeBroker · 进程生命周期', () => {
     await stopping;
   });
 
-  it('stopAndWait 将没有 exit 的进程错误作为更新失败返回', async () => {
+  it('stopAndWait 在进程 error 后保留强杀并等待有界失败', async () => {
+    vi.useFakeTimers();
     const ghost = fakeGhost({ lifecycle: 'resident' });
     const child = new FakeNodeProcess();
-    vi.spyOn(child, 'kill').mockImplementation(() => {
+    const kill = vi.spyOn(child, 'kill').mockImplementation(() => {
       child.killed = true;
       return true;
     });
@@ -282,7 +283,10 @@ describe('nodeRuntimeBroker · 进程生命周期', () => {
       '插件 Node 进程停止失败',
     );
     child.emit('error', new Error('spawn transport broke'));
+    await vi.advanceTimersByTimeAsync(2_500);
     await stopping;
+    expect(kill).toHaveBeenCalledWith('SIGTERM');
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
   });
 
   it('按需进程空闲两分钟后自动关闭', async () => {
@@ -1393,10 +1397,35 @@ describe('nodeRuntimeBroker · 宿主代启子进程(childSpawn,2026-07-23)', ()
       '插件 Node 进程停止失败',
     );
     startingChild.emit('error', new Error('child transport broke'));
+    await vi.advanceTimersByTimeAsync(2_500);
     await stopping;
-    await vi.advanceTimersByTimeAsync(2_000);
 
     expect(kill).toHaveBeenCalledWith('SIGTERM');
     expect(kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('非停止状态的启动错误也会强杀并保留记账直到 exit', async () => {
+    vi.useFakeTimers();
+    const startingChild = new FakeRawChild();
+    const kill = vi.spyOn(startingChild, 'kill').mockImplementation(() => {
+      startingChild.killed = true;
+      return true;
+    });
+    const { broker, worker, spawned } = await bootWorker(
+      childSpawnGhost(),
+      () => startingChild,
+      false,
+    );
+    worker.emitControl({ type: 'spawn-child', reqId: 'r1', entry: 'node/maker.cjs' });
+    await vi.waitFor(() => expect(spawned).toHaveLength(1));
+
+    startingChild.emit('error', new Error('child transport broke'));
+    await vi.waitFor(() => expect(kill).toHaveBeenCalledWith('SIGKILL'));
+
+    const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止超时',
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    await stopping;
   });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -263,6 +263,37 @@ describe('nodeRuntimeBroker · 进程生命周期', () => {
     );
     await vi.advanceTimersByTimeAsync(2_500);
     await stopping;
+
+    // 第一次超时后 worker 已离开业务 map，但真实 exit 未到；重试不能把它漏掉。
+    const retry = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止超时',
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    await retry;
+  });
+
+  it('工作进程先报 error 时仍终止并等待真实 exit', async () => {
+    vi.useFakeTimers();
+    const ghost = fakeGhost({ lifecycle: 'resident' });
+    const child = new FakeNodeProcess();
+    const kill = vi.spyOn(child, 'kill').mockImplementation(() => {
+      child.killed = true;
+      return true;
+    });
+    const broker = new GhostNodeRuntimeBroker({
+      getGhost: () => ghost,
+      spawnProcess: () => child as unknown as NodeWorkerProcess,
+    });
+    await broker.startResident(ghost);
+
+    child.emit('error', new Error('utility process channel broke'));
+    expect(kill).toHaveBeenCalledWith('SIGTERM');
+    const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止超时',
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    await stopping;
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
   });
 
   it('stopAndWait 在进程 error 后保留强杀并等待有界失败', async () => {
@@ -1394,6 +1425,29 @@ describe('nodeRuntimeBroker · 宿主代启子进程(childSpawn,2026-07-23)', ()
     child.emit('error', new Error('child transport broke'));
     expect(kill).toHaveBeenCalledWith('SIGTERM');
 
+    const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止超时',
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    await stopping;
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('父 worker 退出后仍等待尚未真实退出的子进程', async () => {
+    vi.useFakeTimers();
+    const { broker, worker, spawned } = await bootWorker(childSpawnGhost());
+    worker.emitControl({ type: 'spawn-child', reqId: 'r1', entry: 'node/maker.cjs' });
+    await vi.waitFor(() => {
+      expect(worker.lastOf('spawn-child-result')).toMatchObject({ reqId: 'r1', ok: true });
+    });
+    const child = spawned[0].child;
+    const kill = vi.spyOn(child, 'kill').mockImplementation(() => {
+      child.killed = true;
+      return true;
+    });
+
+    worker.emit('exit', 1, null);
+    expect(kill).toHaveBeenCalledWith('SIGTERM');
     const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
       '插件 Node 进程停止超时',
     );

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -1378,6 +1378,30 @@ describe('nodeRuntimeBroker · 宿主代启子进程(childSpawn,2026-07-23)', ()
     expect(settled).toBe(true);
   });
 
+  it('正式子进程 error 后仍保留记账，直到真实 exit 或有界失败', async () => {
+    vi.useFakeTimers();
+    const { broker, worker, spawned } = await bootWorker(childSpawnGhost());
+    worker.emitControl({ type: 'spawn-child', reqId: 'r1', entry: 'node/maker.cjs' });
+    await vi.waitFor(() => {
+      expect(worker.lastOf('spawn-child-result')).toMatchObject({ reqId: 'r1', ok: true });
+    });
+    const child = spawned[0].child;
+    const kill = vi.spyOn(child, 'kill').mockImplementation(() => {
+      child.killed = true;
+      return true;
+    });
+
+    child.emit('error', new Error('child transport broke'));
+    expect(kill).toHaveBeenCalledWith('SIGTERM');
+
+    const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止超时',
+    );
+    await vi.advanceTimersByTimeAsync(2_500);
+    await stopping;
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
   it('启动中子进程报错时仍保留停止后的 SIGKILL 兜底', async () => {
     vi.useFakeTimers();
     const startingChild = new FakeRawChild();

--- a/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts
@@ -1373,4 +1373,30 @@ describe('nodeRuntimeBroker · 宿主代启子进程(childSpawn,2026-07-23)', ()
     await stopping;
     expect(settled).toBe(true);
   });
+
+  it('启动中子进程报错时仍保留停止后的 SIGKILL 兜底', async () => {
+    vi.useFakeTimers();
+    const startingChild = new FakeRawChild();
+    const kill = vi.spyOn(startingChild, 'kill').mockImplementation(() => {
+      startingChild.killed = true;
+      return true;
+    });
+    const { broker, worker, spawned } = await bootWorker(
+      childSpawnGhost(),
+      () => startingChild,
+      false,
+    );
+    worker.emitControl({ type: 'spawn-child', reqId: 'r1', entry: 'node/maker.cjs' });
+    await vi.waitFor(() => expect(spawned).toHaveLength(1));
+
+    const stopping = expect(broker.stopAndWait('node-ghost')).rejects.toThrow(
+      '插件 Node 进程停止失败',
+    );
+    startingChild.emit('error', new Error('child transport broke'));
+    await stopping;
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    expect(kill).toHaveBeenCalledWith('SIGTERM');
+    expect(kill).toHaveBeenCalledWith('SIGKILL');
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3995,12 +3995,14 @@ async function installOrUpdateMarketGhostPackageLocked(
     expected.beforeCommitInLock?.();
     const runtime = getGhostRuntime();
     runtime.stop(expected.ghostId);
+    // 无法确认旧进程已退出时保持停止态，不能启动第二份 resident。只有旧进程
+    // 已确认退出、后续目录更新失败时，才恢复原版本。
+    await getGhostNodeRuntimeBroker().stopAndWait(expected.ghostId);
     let result: Awaited<ReturnType<typeof manager.update>>;
     let packagePlaced = false;
     try {
       // 市场更新同样会原位 rename 插件目录。Windows 上不能只发停止信号，
       // 必须确认旧 utilityProcess 已离开，否则入口文件仍可能被占用而报 EPERM。
-      await getGhostNodeRuntimeBroker().stopAndWait(expected.ghostId);
       getGhostAgentSlot().clearGhost(expected.ghostId);
       getGhostErrandSlot().clearGhost(expected.ghostId);
       // 与首装分支同一口径:钉住 inspect 时校验过的包字节(见上)。
@@ -5287,8 +5289,12 @@ export function registerGhostIpc(): void {
     // 装入/卸载不得插入(否则并发装入会与本次 rename 竞争、留下不一致态)。
     return withGhostInstallLock(inspected.manifest.id, async () => {
       const releaseMutation = beginGhostMutation(mutationOwner);
+      const previousGhost = manager.list().find((g) => g.manifest.id === inspected.manifest.id);
+      runtime.stop(inspected.manifest.id);
+      // 等待失败表示旧进程仍可能存活；此时不能恢复 resident，否则会产生
+      // 两份后台进程。仅在确认退出后的更新阶段失败时恢复旧版本。
+      await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);
       try {
-        const previousGhost = manager.list().find((g) => g.manifest.id === inspected.manifest.id);
         let marketRecord: PluginMarketInstallationRecord | null;
         let marketInstallSubject: string | null = null;
         let marketRecordWasSuppressed = false;
@@ -5350,10 +5356,6 @@ export function registerGhostIpc(): void {
             });
             throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');
           }
-        runtime.stop(inspected.manifest.id);
-        // Windows 上 stop() 只是发出终止信号；等旧 utilityProcess 实际退出，
-        // 否则它还会占用插件目录，接下来的原子 rename 可能报 EPERM。
-        await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);
         getGhostAgentSlot().clearGhost(inspected.manifest.id);
         getGhostErrandSlot().clearGhost(inspected.manifest.id);
         let result: Awaited<ReturnType<typeof manager.update>>;

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3995,12 +3995,14 @@ async function installOrUpdateMarketGhostPackageLocked(
     expected.beforeCommitInLock?.();
     const runtime = getGhostRuntime();
     runtime.stop(expected.ghostId);
-    getGhostNodeRuntimeBroker().stop(expected.ghostId);
-    getGhostAgentSlot().clearGhost(expected.ghostId);
-    getGhostErrandSlot().clearGhost(expected.ghostId);
     let result: Awaited<ReturnType<typeof manager.update>>;
     let packagePlaced = false;
     try {
+      // 市场更新同样会原位 rename 插件目录。Windows 上不能只发停止信号，
+      // 必须确认旧 utilityProcess 已离开，否则入口文件仍可能被占用而报 EPERM。
+      await getGhostNodeRuntimeBroker().stopAndWait(expected.ghostId);
+      getGhostAgentSlot().clearGhost(expected.ghostId);
+      getGhostErrandSlot().clearGhost(expected.ghostId);
       // 与首装分支同一口径:钉住 inspect 时校验过的包字节(见上)。
       result = await manager.update(cindyFilePath, {
         expectedPackageSha256: inspected.packageSha256,
@@ -5348,7 +5350,6 @@ export function registerGhostIpc(): void {
             });
             throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');
           }
-        }
         runtime.stop(inspected.manifest.id);
         // Windows 上 stop() 只是发出终止信号；等旧 utilityProcess 实际退出，
         // 否则它还会占用插件目录，接下来的原子 rename 可能报 EPERM。

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -5310,7 +5310,6 @@ export function registerGhostIpc(): void {
             error: error instanceof Error ? error.message : String(error),
           });
           throwIpcError('INTERNAL', 'Unable to verify the installed Plugin source');
-        }
         // 用户已在本地包确认流程中明确选择了这份真实包：同 id 可以原位替换，
         // 市场来源不是永久所有权。替换前先切断旧市场更新路由；落位失败再恢复，
         // 全程不清理 Secret、KV、偏好或其它按 ghostId 保存的用户状态。
@@ -5351,7 +5350,9 @@ export function registerGhostIpc(): void {
           }
         }
         runtime.stop(inspected.manifest.id);
-        getGhostNodeRuntimeBroker().stop(inspected.manifest.id);
+        // Windows 上 stop() 只是发出终止信号；等旧 utilityProcess 实际退出，
+        // 否则它还会占用插件目录，接下来的原子 rename 可能报 EPERM。
+        await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);
         getGhostAgentSlot().clearGhost(inspected.manifest.id);
         getGhostErrandSlot().clearGhost(inspected.manifest.id);
         let result: Awaited<ReturnType<typeof manager.update>>;

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -5318,6 +5318,7 @@ export function registerGhostIpc(): void {
             error: error instanceof Error ? error.message : String(error),
           });
           throwIpcError('INTERNAL', 'Unable to verify the installed Plugin source');
+        }
         // 用户已在本地包确认流程中明确选择了这份真实包：同 id 可以原位替换，
         // 市场来源不是永久所有权。替换前先切断旧市场更新路由；落位失败再恢复，
         // 全程不清理 Secret、KV、偏好或其它按 ghostId 保存的用户状态。
@@ -5356,6 +5357,7 @@ export function registerGhostIpc(): void {
             });
             throwIpcError('INTERNAL', 'Unable to detach the installed Plugin source');
           }
+        }
         getGhostAgentSlot().clearGhost(inspected.manifest.id);
         getGhostErrandSlot().clearGhost(inspected.manifest.id);
         let result: Awaited<ReturnType<typeof manager.update>>;

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -5290,11 +5290,11 @@ export function registerGhostIpc(): void {
     return withGhostInstallLock(inspected.manifest.id, async () => {
       const releaseMutation = beginGhostMutation(mutationOwner);
       const previousGhost = manager.list().find((g) => g.manifest.id === inspected.manifest.id);
-      runtime.stop(inspected.manifest.id);
-      // 等待失败表示旧进程仍可能存活；此时不能恢复 resident，否则会产生
-      // 两份后台进程。仅在确认退出后的更新阶段失败时恢复旧版本。
-      await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);
       try {
+        runtime.stop(inspected.manifest.id);
+        // 等待失败表示旧进程仍可能存活；此时不能恢复 resident，否则会产生
+        // 两份后台进程。仅在确认退出后的更新阶段失败时恢复旧版本。
+        await getGhostNodeRuntimeBroker().stopAndWait(inspected.manifest.id);
         let marketRecord: PluginMarketInstallationRecord | null;
         let marketInstallSubject: string | null = null;
         let marketRecordWasSuppressed = false;
@@ -5313,6 +5313,7 @@ export function registerGhostIpc(): void {
               : false;
           }
         } catch (error) {
+          if (previousGhost) spawnIfResident(previousGhost);
           log.warn('failed to verify Plugin provenance before local update', {
             ghostId: inspected.manifest.id,
             error: error instanceof Error ? error.message : String(error),
@@ -5351,6 +5352,7 @@ export function registerGhostIpc(): void {
             marketLedger.markRemoved(inspected.manifest.id, marketInstallSubject);
           } catch (error) {
             restoreMarketRecord();
+            if (previousGhost) spawnIfResident(previousGhost);
             log.warn('failed to detach Plugin market provenance before local update', {
               ghostId: inspected.manifest.id,
               error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -950,9 +950,12 @@ export class GhostNodeRuntimeBroker {
     const children = this.startingChildren.get(ghostId) ?? new Set<StartingChildProcEntry>();
     children.add(entry);
     this.startingChildren.set(ghostId, children);
-    const finish = () => this.forgetStartingChild(entry);
-    proc.once('exit', finish);
-    proc.once('error', finish);
+    // error 不是进程已退出的证明。若更新正在停止它，仍要保留 SIGKILL
+    // 兜底；否则仅发 error 不发 exit 的 child 会永远占住旧插件目录。
+    proc.once('exit', () => this.forgetStartingChild(entry));
+    proc.once('error', () => {
+      if (!entry.stopping) this.forgetStartingChild(entry);
+    });
     return entry;
   }
 

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -788,11 +788,9 @@ export class GhostNodeRuntimeBroker {
         proc.once('exit', (code) => settle(() => reject(new Error(`子进程启动前退出(code=${code})`))));
       });
     } catch (error) {
-      try {
-        proc.kill('SIGKILL');
-      } catch {
-        // no-op
-      }
+      // error 只表示进程通道失败，不保证 OS 进程已经退出。保留 starting
+      // 记账直到真实 exit，并立即强杀；否则后续更新会漏掉仍持有文件句柄的进程。
+      this.stopStartingChild(startingChild, true);
       fail(error instanceof Error ? error.message : '子进程启动失败');
       return;
     }
@@ -924,6 +922,7 @@ export class GhostNodeRuntimeBroker {
   private waitForProcessExit(process: NodeWorkerProcess, ghostId: string): Promise<void> {
     return new Promise((resolve, reject) => {
       let settled = false;
+      let processError: Error | null = null;
       let timer: NodeJS.Timeout | null = null;
       const settle = (outcome: () => void) => {
         if (settled) return;
@@ -932,14 +931,23 @@ export class GhostNodeRuntimeBroker {
         outcome();
       };
       timer = this.setTimer(
-        () => settle(() => reject(new Error(`插件 Node 进程停止超时(${ghostId})`))),
+        () =>
+          settle(() =>
+            reject(
+              processError
+                ? new Error(`插件 Node 进程停止失败(${ghostId}): ${processError.message}`)
+                : new Error(`插件 Node 进程停止超时(${ghostId})`),
+            ),
+          ),
         PROCESS_STOP_WAIT_TIMEOUT_MS,
       );
       timer.unref?.();
       process.once('exit', () => settle(resolve));
-      process.once('error', (error) =>
-        settle(() => reject(new Error(`插件 Node 进程停止失败(${ghostId}): ${error.message}`))),
-      );
+      // error 不是进程退出证明。记住诊断，但继续等 exit 或有界超时，让
+      // stopWorker / stopStartingChild 的 SIGKILL 兜底保持生效。
+      process.once('error', (error) => {
+        processError = error;
+      });
     });
   }
 
@@ -950,12 +958,8 @@ export class GhostNodeRuntimeBroker {
     const children = this.startingChildren.get(ghostId) ?? new Set<StartingChildProcEntry>();
     children.add(entry);
     this.startingChildren.set(ghostId, children);
-    // error 不是进程已退出的证明。若更新正在停止它，仍要保留 SIGKILL
-    // 兜底；否则仅发 error 不发 exit 的 child 会永远占住旧插件目录。
+    // error 不是进程已退出的证明，任何路径都保留记账直到真实 exit。
     proc.once('exit', () => this.forgetStartingChild(entry));
-    proc.once('error', () => {
-      if (!entry.stopping) this.forgetStartingChild(entry);
-    });
     return entry;
   }
 
@@ -970,11 +974,11 @@ export class GhostNodeRuntimeBroker {
     if (children.size === 0) this.startingChildren.delete(entry.ghostId);
   }
 
-  private stopStartingChild(entry: StartingChildProcEntry): void {
+  private stopStartingChild(entry: StartingChildProcEntry, force = false): void {
     if (entry.stopping) return;
     entry.stopping = true;
     try {
-      entry.proc.kill('SIGTERM');
+      entry.proc.kill(force ? 'SIGKILL' : 'SIGTERM');
       entry.hardKillTimer = this.setTimer(() => {
         entry.hardKillTimer = null;
         try {
@@ -1462,11 +1466,19 @@ export class GhostNodeRuntimeBroker {
   ): void {
     const ghostId = entry.ghost.manifest.id;
     const key = GhostNodeRuntimeBroker.keyOf(ghostId, entry.entryRel);
+    if (this.workers.get(key) !== entry) {
+      // stopWorker 已先移除 map。只有真实 exit 才能取消强杀；error 仍可能
+      // 对应一个活着并占用插件目录的 utilityProcess。
+      if (!error && entry.hardKillTimer) {
+        this.clearTimer(entry.hardKillTimer);
+        entry.hardKillTimer = null;
+      }
+      return;
+    }
     if (entry.hardKillTimer) {
       this.clearTimer(entry.hardKillTimer);
       entry.hardKillTimer = null;
     }
-    if (this.workers.get(key) !== entry) return;
     this.workers.delete(key);
     this.clearIdleTimer(entry);
     // worker 意外死亡:孩子级联收掉,不留孤儿(silent——收件人已经不在了)。

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -42,6 +42,10 @@ import {
 const DEFAULT_IDLE_TIMEOUT_MS = 2 * 60_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const DEFAULT_START_TIMEOUT_MS = 10_000;
+/** 停止后先给进程自行收尾的窗口；到点再 SIGKILL。 */
+const PROCESS_STOP_GRACE_MS = 2_000;
+/** 原位更新绝不能无限等退出；给 SIGKILL 的 exit 事件留一个小缓冲。 */
+const PROCESS_STOP_WAIT_TIMEOUT_MS = PROCESS_STOP_GRACE_MS + 500;
 /**
  * 启动失败重试(2026-07-24):Windows 上杀软实时扫描刚写入的 .vite 产物 /
  * 刚更新的 app.asar 时,子进程读引导入口会瞬时 ACCESS_DENIED(表现为
@@ -140,6 +144,14 @@ interface PendingRpc {
 interface ChildProcEntry {
   childId: string;
   entryRel: string;
+  proc: NodeWorkerProcess;
+  hardKillTimer: NodeJS.Timeout | null;
+  stopping: boolean;
+}
+
+/** 已 fork 但尚未完成 spawn 握手的代启子进程。 */
+interface StartingChildProcEntry {
+  ghostId: string;
   proc: NodeWorkerProcess;
   hardKillTimer: NodeJS.Timeout | null;
   stopping: boolean;
@@ -673,6 +685,14 @@ export class GhostNodeRuntimeBroker {
     message: Extract<GhostNodeChildToHostMessage, { type: 'spawn-child' }>,
   ): Promise<void> {
     const ghostId = entry.ghost.manifest.id;
+    // stopAndWait 已开始后不得再 fork 新 child；否则它会落在本轮快照之外，
+    // 又把目录替换竞态带回来。
+    if (
+      this.stoppedGhosts.has(ghostId) ||
+      this.workers.get(GhostNodeRuntimeBroker.keyOf(ghostId, entry.entryRel)) !== entry
+    ) {
+      return;
+    }
     const fail = (reason: string): void => {
       this.deps.log?.warn('ghost node child spawn rejected', { ghostId, reason });
       this.replyToWorker(entry, {
@@ -742,6 +762,10 @@ export class GhostNodeRuntimeBroker {
       fail(error instanceof Error ? error.message : '子进程启动失败');
       return;
     }
+    // fork 已经产生真实 OS 进程，但它要等 child-mode ready 才会写进
+    // entry.children。原位更新不能漏掉这段空窗，否则 Windows rename 仍可能
+    // 撞上子进程持有的插件文件句柄。
+    const startingChild = this.trackStartingChild(ghostId, proc);
     try {
       await new Promise<void>((resolve, reject) => {
         let settled = false;
@@ -781,6 +805,8 @@ export class GhostNodeRuntimeBroker {
       return;
     }
 
+    // 之后没有 await，先从启动中集合移到正式 children 不会留下可观察空窗。
+    this.forgetStartingChild(startingChild);
     const child: ChildProcEntry = {
       childId: randomUUID(),
       entryRel: message.entry,
@@ -851,7 +877,7 @@ export class GhostNodeRuntimeBroker {
         } catch {
           // already gone
         }
-      }, 2_000);
+      }, PROCESS_STOP_GRACE_MS);
       child.hardKillTimer.unref?.();
     } catch {
       // 已退出即视为停止成功。
@@ -861,6 +887,9 @@ export class GhostNodeRuntimeBroker {
   /** 停用、更新或卸载一个插件时立即停止其名下**全部** Node 进程。 */
   stop(ghostId: string): void {
     this.stoppedGhosts.add(ghostId);
+    for (const starting of [...(this.startingChildren.get(ghostId) ?? [])]) {
+      this.stopStartingChild(starting);
+    }
     for (const [key, entry] of [...this.workers]) {
       if (entry.ghost.manifest.id === ghostId) this.stopWorker(key, entry);
     }
@@ -871,23 +900,88 @@ export class GhostNodeRuntimeBroker {
    *
    * 原位更新会把整个插件目录 rename 到备份位。在 Windows 上，即使已经向
    * utilityProcess 发出 SIGTERM，只要旧进程尚未触发 exit，目录中的入口文件
-   * 仍可能被占用而让 rename 报 EPERM。这里先订阅 exit、再 stop，避免在两步
-   * 之间漏掉极快退出的事件；stopWorker 自身仍保留 SIGKILL 兜底。
+   * 仍可能被占用而让 rename 报 EPERM。已 fork 但尚未 ready 的 child 也在
+   * 等待集合内；先订阅 exit、再 stop，避免在两步之间漏掉极快退出的事件。
    */
   async stopAndWait(ghostId: string): Promise<void> {
+    // 先封住新的 child spawn；这段没有 await，随后快照可覆盖所有已 fork 的进程。
+    this.stoppedGhosts.add(ghostId);
     const active = [...this.workers.values()].filter(
       (entry) => entry.ghost.manifest.id === ghostId,
     );
-    const exited = active
-      .flatMap((entry) => [entry.child, ...entry.children.values().map((child) => child.proc)])
-      .map(
-        (process) =>
-          new Promise<void>((resolve) => {
-            process.once('exit', () => resolve());
-          }),
-      );
+    const processes = new Set<NodeWorkerProcess>([
+      ...active.flatMap((entry) => [entry.child, ...entry.children.values().map((child) => child.proc)]),
+      ...[...(this.startingChildren.get(ghostId) ?? [])].map((child) => child.proc),
+    ]);
+    const exited = [...processes].map((process) => this.waitForProcessExit(process, ghostId));
     this.stop(ghostId);
     await Promise.all(exited);
+  }
+
+  /** 原位更新时，进程异常或强杀后仍不退出都必须阻止目录替换。 */
+  private waitForProcessExit(process: NodeWorkerProcess, ghostId: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let timer: NodeJS.Timeout | null = null;
+      const settle = (outcome: () => void) => {
+        if (settled) return;
+        settled = true;
+        if (timer) this.clearTimer(timer);
+        outcome();
+      };
+      timer = this.setTimer(
+        () => settle(() => reject(new Error(`插件 Node 进程停止超时(${ghostId})`))),
+        PROCESS_STOP_WAIT_TIMEOUT_MS,
+      );
+      timer.unref?.();
+      process.once('exit', () => settle(resolve));
+      process.once('error', (error) =>
+        settle(() => reject(new Error(`插件 Node 进程停止失败(${ghostId}): ${error.message}`))),
+      );
+    });
+  }
+
+  private readonly startingChildren = new Map<string, Set<StartingChildProcEntry>>();
+
+  private trackStartingChild(ghostId: string, proc: NodeWorkerProcess): StartingChildProcEntry {
+    const entry: StartingChildProcEntry = { ghostId, proc, hardKillTimer: null, stopping: false };
+    const children = this.startingChildren.get(ghostId) ?? new Set<StartingChildProcEntry>();
+    children.add(entry);
+    this.startingChildren.set(ghostId, children);
+    const finish = () => this.forgetStartingChild(entry);
+    proc.once('exit', finish);
+    proc.once('error', finish);
+    return entry;
+  }
+
+  private forgetStartingChild(entry: StartingChildProcEntry): void {
+    if (entry.hardKillTimer) {
+      this.clearTimer(entry.hardKillTimer);
+      entry.hardKillTimer = null;
+    }
+    const children = this.startingChildren.get(entry.ghostId);
+    if (!children) return;
+    children.delete(entry);
+    if (children.size === 0) this.startingChildren.delete(entry.ghostId);
+  }
+
+  private stopStartingChild(entry: StartingChildProcEntry): void {
+    if (entry.stopping) return;
+    entry.stopping = true;
+    try {
+      entry.proc.kill('SIGTERM');
+      entry.hardKillTimer = this.setTimer(() => {
+        entry.hardKillTimer = null;
+        try {
+          entry.proc.kill('SIGKILL');
+        } catch {
+          // already gone
+        }
+      }, PROCESS_STOP_GRACE_MS);
+      entry.hardKillTimer.unref?.();
+    } catch {
+      // 已退出即视为停止成功；stopAndWait 会以 exit/error 或有界超时收口。
+    }
   }
 
   private stopWorker(key: string, entry: WorkerEntry): void {
@@ -912,7 +1006,7 @@ export class GhostNodeRuntimeBroker {
         } catch {
           // already gone
         }
-      }, 2_000);
+      }, PROCESS_STOP_GRACE_MS);
       entry.hardKillTimer.unref?.();
     } catch {
       // 已退出即视为停止成功。

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -909,13 +909,10 @@ export class GhostNodeRuntimeBroker {
   async stopAndWait(ghostId: string): Promise<void> {
     // 先封住新的 child spawn；这段没有 await，随后快照可覆盖所有已 fork 的进程。
     this.stoppedGhosts.add(ghostId);
-    const active = [...this.workers.values()].filter(
-      (entry) => entry.ghost.manifest.id === ghostId,
-    );
-    const processes = new Set<NodeWorkerProcess>([
-      ...active.flatMap((entry) => [entry.child, ...entry.children.values().map((child) => child.proc)]),
-      ...[...(this.startingChildren.get(ghostId) ?? [])].map((child) => child.proc),
-    ]);
+    // 以真实进程账本为准，而不是 workers/children 的业务状态。错误事件、父进程
+    // 退出或上一次停止超时都可能先移除业务记账；只要没有真实 exit，重试更新
+    // 仍必须等待同一 OS 进程，不能绕过 Windows 文件锁保护。
+    const processes = new Set(this.liveProcesses.get(ghostId) ?? []);
     const exited = [...processes].map((process) => this.waitForProcessExit(process, ghostId));
     this.stop(ghostId);
     await Promise.all(exited);
@@ -954,9 +951,26 @@ export class GhostNodeRuntimeBroker {
     });
   }
 
+  /** 所有已创建的 OS 进程：只认真实 exit 移除，error 不算退出证明。 */
+  private readonly liveProcesses = new Map<string, Set<NodeWorkerProcess>>();
+
+  private trackLiveProcess(ghostId: string, process: NodeWorkerProcess): void {
+    const processes = this.liveProcesses.get(ghostId) ?? new Set<NodeWorkerProcess>();
+    if (processes.has(process)) return;
+    processes.add(process);
+    this.liveProcesses.set(ghostId, processes);
+    process.once('exit', () => {
+      const current = this.liveProcesses.get(ghostId);
+      if (!current) return;
+      current.delete(process);
+      if (current.size === 0) this.liveProcesses.delete(ghostId);
+    });
+  }
+
   private readonly startingChildren = new Map<string, Set<StartingChildProcEntry>>();
 
   private trackStartingChild(ghostId: string, proc: NodeWorkerProcess): StartingChildProcEntry {
+    this.trackLiveProcess(ghostId, proc);
     const entry: StartingChildProcEntry = { ghostId, proc, hardKillTimer: null, stopping: false };
     const children = this.startingChildren.get(ghostId) ?? new Set<StartingChildProcEntry>();
     children.add(entry);
@@ -1122,6 +1136,7 @@ export class GhostNodeRuntimeBroker {
     } catch (error) {
       throw new WorkerStartError(error instanceof Error ? error.message : String(error), true);
     }
+    this.trackLiveProcess(ghost.manifest.id, child);
     const entry: WorkerEntry = {
       ghost,
       entryRel,
@@ -1478,7 +1493,25 @@ export class GhostNodeRuntimeBroker {
       }
       return;
     }
-    if (entry.hardKillTimer) {
+    if (error && !entry.stopping && !entry.hardKillTimer) {
+      // error 只说明 utilityProcess 通道失效。业务状态可以立即收口，但 OS
+      // 进程仍须主动终止，并由 liveProcesses 保留到真实 exit。
+      try {
+        entry.child.kill('SIGTERM');
+        entry.hardKillTimer = this.setTimer(() => {
+          entry.hardKillTimer = null;
+          try {
+            entry.child.kill('SIGKILL');
+          } catch {
+            // already gone
+          }
+        }, PROCESS_STOP_GRACE_MS);
+        entry.hardKillTimer.unref?.();
+      } catch {
+        // stopAndWait 仍会以真实 exit 或有界超时收口。
+      }
+    }
+    if (!error && entry.hardKillTimer) {
       this.clearTimer(entry.hardKillTimer);
       entry.hardKillTimer = null;
     }

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -685,14 +685,6 @@ export class GhostNodeRuntimeBroker {
     message: Extract<GhostNodeChildToHostMessage, { type: 'spawn-child' }>,
   ): Promise<void> {
     const ghostId = entry.ghost.manifest.id;
-    // stopAndWait 已开始后不得再 fork 新 child；否则它会落在本轮快照之外，
-    // 又把目录替换竞态带回来。
-    if (
-      this.stoppedGhosts.has(ghostId) ||
-      this.workers.get(GhostNodeRuntimeBroker.keyOf(ghostId, entry.entryRel)) !== entry
-    ) {
-      return;
-    }
     const fail = (reason: string): void => {
       this.deps.log?.warn('ghost node child spawn rejected', { ghostId, reason });
       this.replyToWorker(entry, {
@@ -702,6 +694,16 @@ export class GhostNodeRuntimeBroker {
         message: reason,
       });
     };
+    // stopAndWait 已开始后不得再 fork 新 child；否则它会落在本轮快照之外，
+    // 又把目录替换竞态带回来。仍在世的 worker 必须收到拒绝回执，避免它白等
+    // 到自己的请求超时；已被移除的 worker 则不再可安全回信。
+    if (this.workers.get(GhostNodeRuntimeBroker.keyOf(ghostId, entry.entryRel)) !== entry) {
+      return;
+    }
+    if (this.stoppedGhosts.has(ghostId)) {
+      fail('插件正在停止，不能再启动子进程');
+      return;
+    }
     const ghost = this.deps.getGhost(ghostId);
     const node = ghost?.enabled ? ghost.manifest.node : undefined;
     if (!node || node.childSpawn !== true) {

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -832,7 +832,9 @@ export class GhostNodeRuntimeBroker {
       });
     });
     proc.on('exit', (code) => this.handleChildExit(entry, child, code));
-    proc.on('error', () => this.handleChildExit(entry, child, null));
+    // error 只说明进程通道失败，不证明 OS 进程已经退出。开始有界停止，
+    // 但继续保留 children 记账直到真实 exit，供 stopAndWait 快照覆盖。
+    proc.on('error', () => this.stopChild(entry, child, false));
     this.deps.log?.info('ghost node child spawned', {
       ghostId,
       entry: message.entry,
@@ -864,9 +866,10 @@ export class GhostNodeRuntimeBroker {
 
   /** silent = 级联收尾(worker 已死,孩子不必也无法再收到 child-exit)。 */
   private stopChild(entry: WorkerEntry, child: ChildProcEntry, silent: boolean): void {
+    if (child.stopping) return;
+    child.stopping = true;
     if (silent) {
       entry.children.delete(child.childId);
-      child.stopping = true;
     }
     try {
       child.proc.kill('SIGTERM');

--- a/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
+++ b/apps/desktop/src/main/cindy-brain/nodeRuntimeBroker.ts
@@ -7,7 +7,8 @@
  * - 子进程只有 JSON-RPC stdio，不能直接拿到 Cindy IPC。所有 Cindy 能力仍须
  *   Node → main.js → contextBridge → 主机，并再次经过对应 slot 守门；
  * - 一段启用的意识最多一个 Node 进程，多会话复用；按需启动、闲置关闭，
- *   停用/更新/卸载/主机退出时由上层 stop；
+ *   停用/更新/卸载/主机退出时由上层 stop；原位更新另用 stopAndWait，等旧进程
+ *   真正退出后才可替换其安装目录；
  * - MCP 只开放 client→server 调用。server 反向请求 Cindy 能力恒回 -32601。
  * - 代启子进程(childSpawn)不是上述铁律的例外:控制帧走引导层私藏的
  *   parentPort(插件代码摸不到),能要到的唯一东西是"再跑一个包内申报过的
@@ -863,6 +864,30 @@ export class GhostNodeRuntimeBroker {
     for (const [key, entry] of [...this.workers]) {
       if (entry.ghost.manifest.id === ghostId) this.stopWorker(key, entry);
     }
+  }
+
+  /**
+   * 停止并等待当前已运行的 Node 进程退出。
+   *
+   * 原位更新会把整个插件目录 rename 到备份位。在 Windows 上，即使已经向
+   * utilityProcess 发出 SIGTERM，只要旧进程尚未触发 exit，目录中的入口文件
+   * 仍可能被占用而让 rename 报 EPERM。这里先订阅 exit、再 stop，避免在两步
+   * 之间漏掉极快退出的事件；stopWorker 自身仍保留 SIGKILL 兜底。
+   */
+  async stopAndWait(ghostId: string): Promise<void> {
+    const active = [...this.workers.values()].filter(
+      (entry) => entry.ghost.manifest.id === ghostId,
+    );
+    const exited = active
+      .flatMap((entry) => [entry.child, ...entry.children.values().map((child) => child.proc)])
+      .map(
+        (process) =>
+          new Promise<void>((resolve) => {
+            process.once('exit', () => resolve());
+          }),
+      );
+    this.stop(ghostId);
+    await Promise.all(exited);
   }
 
   private stopWorker(key: string, entry: WorkerEntry): void {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Windows 上更新运行中的插件时，旧进程仍占用插件目录而导致更新失败的问题。更新前会等待主进程、已启动子进程和刚 fork 但尚未完成启动握手的子进程真正退出；收到 process error 不再被误当成已经退出，异常或超时会强制终止并明确失败。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Fixes #1168
- 本 PR 包含：插件 Node 进程退出等待、启动中子进程追踪、超时强制终止、市场/本地更新路径的失败恢复与回归测试。
- 明确不包含：插件 API、数据结构、权限模型、更新包格式或插件作者契约的变更。
- 现有插件兼容性：无影响；仅调整宿主在更新时管理插件进程的顺序。
- 用户可见变化：更新正在运行的插件时，不再因旧进程持有文件而随机失败；异常时会返回错误而不会一直等待。
- 是否存在 breaking change：无。

### UI 变化

不涉及：仅 Main process 的插件更新时序。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
结果：52 tests passed。

pnpm --filter desktop exec eslint src/main/cindy-brain/nodeRuntimeBroker.ts src/main/cindy-brain/__tests__/nodeRuntimeBroker.test.ts src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
结果：通过。

git diff --check
结果：通过。
```

### 手工验证

未在 Windows 上手工复现文件占用；等待顺序、子进程启动空窗、error 后仍存活、超时强制终止与两个更新入口均由回归测试覆盖。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：插件进程生命周期。

### 影响与回滚

- 影响范围：仅 Node 类型插件的原位更新流程；更新进程无法在限定时间内退出时，更新会失败并尝试恢复原常驻插件。
- 回滚 / 降级方式：revert 本 PR 的提交即可恢复此前行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果