### PR TITLE
fix(model-providers): 防止远端 catalog 遮蔽内置预设

### DIFF
--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -482,7 +482,8 @@
           "models": [
             {
               "id": "MiniMax-M3",
-              "name": "MiniMax M3"
+              "name": "MiniMax M3",
+              "contextWindow": 1000000
             },
             {
               "id": "MiniMax-M2.5",
@@ -517,7 +518,8 @@
           "models": [
             {
               "id": "MiniMax-M3",
-              "name": "MiniMax M3"
+              "name": "MiniMax M3",
+              "contextWindow": 1000000
             },
             {
               "id": "MiniMax-M2.5",

--- a/packages/model-providers/src/__tests__/presets.test.ts
+++ b/packages/model-providers/src/__tests__/presets.test.ts
@@ -3,7 +3,7 @@
  *
  * 关键不变量：
  *   - presets 是纯 UI 模板数据，坏条目**逐条丢弃**，绝不让整份目录 parse 失败回退 bundled；
- *   - mergeWithBundled：远端带 presets 用远端的，远端没带回落 bundled 的；
+ *   - mergeWithBundled：远端与 bundled 按 id 合并，同 id 远端优先、bundled 补缺；
  *   - BUNDLED_CATALOG 自带的首批预设本身合法（每条至少一个 runtime、字段完整）。
  */
 
@@ -147,15 +147,73 @@ describe('parseCatalog presets 容错', () => {
 });
 
 describe('mergeWithBundled presets 兜底', () => {
-  it('远端带 presets → 用远端的', () => {
+  it('远端 presets 与 bundled 按 id 合并：远端同 id 优先，bundled 缺项不丢', () => {
     const merged = mergeWithBundled(minimalCatalog({ presets: [VALID_PRESET] }));
-    expect(merged.presets?.map((p) => p.id)).toEqual(['openrouter']);
+    expect(merged.presets?.find((preset) => preset.id === 'openrouter')).toEqual(VALID_PRESET);
+    expect(merged.presets?.map((preset) => preset.id)).toEqual(
+      BUNDLED_CATALOG.presets?.map((preset) => preset.id),
+    );
+    expect(merged.presets?.map((preset) => preset.id)).toEqual(
+      expect.arrayContaining(['zhipu-coding-plan-cn', 'zai-coding-plan-global']),
+    );
   });
 
   it('远端没带 presets → 回落 bundled 的', () => {
     const merged = mergeWithBundled(minimalCatalog());
     expect(merged.presets).toEqual(BUNDLED_CATALOG.presets);
     expect(merged.presets?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('远端独有 preset 按远端原序追加在 bundled 之后', () => {
+    const remoteOnly = { ...VALID_PRESET, id: 'remote-only' };
+    const merged = mergeWithBundled(minimalCatalog({ presets: [remoteOnly] }));
+    expect(merged.presets?.at(-1)).toEqual(remoteOnly);
+  });
+
+  it('同 id 远端保留 runtime/model 时回填 bundled contextWindow，不复活被移除的 runtime/model', () => {
+    const remoteMiniMax = {
+      id: 'minimax-global',
+      name: 'Remote MiniMax',
+      runtimes: {
+        'claude-code': {
+          baseUrl: 'https://remote.example/anthropic',
+          models: [{ id: 'MiniMax-M3', name: 'Remote M3' }],
+        },
+      },
+    };
+    const merged = mergeWithBundled(minimalCatalog({ presets: [remoteMiniMax] }));
+    const preset = merged.presets?.find((candidate) => candidate.id === 'minimax-global');
+    expect(preset).toEqual({
+      ...remoteMiniMax,
+      runtimes: {
+        'claude-code': {
+          ...remoteMiniMax.runtimes['claude-code'],
+          models: [{ id: 'MiniMax-M3', name: 'Remote M3', contextWindow: 1_000_000 }],
+        },
+      },
+    });
+    expect(preset?.runtimes.codex).toBeUndefined();
+  });
+
+  it('远端显式 contextWindow 优先于 bundled', () => {
+    const remoteMiniMax = {
+      id: 'minimax-global',
+      name: 'Remote MiniMax',
+      runtimes: {
+        'claude-code': {
+          baseUrl: 'https://remote.example/anthropic',
+          models: [{ id: 'MiniMax-M3', name: 'Remote M3', contextWindow: 512_000 }],
+        },
+      },
+    };
+    const merged = mergeWithBundled(minimalCatalog({ presets: [remoteMiniMax] }));
+    expect(
+      merged.presets
+        ?.find((candidate) => candidate.id === 'minimax-global')
+        ?.runtimes['claude-code']
+        ?.models[0]
+        ?.contextWindow,
+    ).toBe(512_000);
   });
 });
 
@@ -375,6 +433,10 @@ describe('MiniMax OpenAI Responses 预设契约 (issue #345)', () => {
     const preset = BUNDLED_CATALOG.presets?.find((candidate) => candidate.id === id);
     expect(preset?.docsUrl).toBe(docsUrl);
     expect(preset?.runtimes['claude-code']?.baseUrl).toMatch(/\/anthropic$/);
+    expect(preset?.runtimes['claude-code']?.models).toEqual([
+      { id: 'MiniMax-M3', name: 'MiniMax M3', contextWindow: 1_000_000 },
+      { id: 'MiniMax-M2.5', name: 'MiniMax M2.5' },
+    ]);
     expect(preset?.runtimes.codex).toEqual({
       baseUrl: codexBaseUrl,
       models: [
@@ -425,6 +487,19 @@ describe('官方渠道预设契约', () => {
       wireProtocol: 'openai-chat',
     }));
   });
+
+  it.each(['zhipu-coding-plan-cn', 'zai-coding-plan-global'])(
+    '%s 的 Claude Code GLM-5.2 1M 入口保留完整窗口元数据',
+    (id) => {
+      expect(
+        preset(id)?.runtimes['claude-code']?.models.find((model) => model.id === 'glm-5.2[1m]'),
+      ).toEqual({
+        id: 'glm-5.2[1m]',
+        name: 'GLM-5.2 (1M)',
+        contextWindow: 1_000_000,
+      });
+    },
+  );
 
   it('小米按量与 Token Plan 凭证不会混用端点', () => {
     expect(preset('xiaomi-mimo-api-cn')?.runtimes.codex?.baseUrl)

--- a/packages/model-providers/src/source.ts
+++ b/packages/model-providers/src/source.ts
@@ -14,7 +14,7 @@
  */
 
 import { BUNDLED_CATALOG, parseCatalog } from './catalog.js';
-import type { Catalog, Provider } from './types.js';
+import type { AgentKind, Catalog, Provider, ProviderPreset } from './types.js';
 
 /** 公共模型目录 API 路径。发布版由 model-access-server 匿名提供完整 Catalog。 */
 export const CATALOG_API_PATH = '/api/model-catalog/catalog';
@@ -98,6 +98,40 @@ function legacyAccessFor(primary: Provider, bundled: Provider): Provider['access
 }
 
 /**
+ * 同 id preset 仍以远端为主；bundled 只给远端仍保留的同 runtime / 同 model
+ * 回填缺失的 contextWindow。这样旧远端不会把已核实的长上下文元数据降级，同时远端
+ * 仍可通过移除 runtime / model 停止新建，或用显式窗口覆盖 bundled。
+ */
+function backfillPresetContextWindows(
+  primary: ProviderPreset,
+  bundled: ProviderPreset,
+): ProviderPreset {
+  let changed = false;
+  const runtimes: ProviderPreset['runtimes'] = {};
+  for (const [agent, runtime] of Object.entries(primary.runtimes) as [
+    AgentKind,
+    NonNullable<ProviderPreset['runtimes'][AgentKind]>,
+  ][]) {
+    const bundledRuntime = bundled.runtimes[agent];
+    if (!bundledRuntime) {
+      runtimes[agent] = runtime;
+      continue;
+    }
+    const bundledModels = new Map(bundledRuntime.models.map((model) => [model.id, model]));
+    let runtimeChanged = false;
+    const models = runtime.models.map((model) => {
+      const bundledContextWindow = bundledModels.get(model.id)?.contextWindow;
+      if (model.contextWindow !== undefined || bundledContextWindow === undefined) return model;
+      runtimeChanged = true;
+      changed = true;
+      return { ...model, contextWindow: bundledContextWindow };
+    });
+    runtimes[agent] = runtimeChanged ? { ...runtime, models } : runtime;
+  }
+  return changed ? { ...primary, runtimes } : primary;
+}
+
+/**
  * 把远端 / 本地目录与内置 bundled 合并：以输入目录为主，bundled 补它缺失的
  * provider（按 id），并给旧目录中同 id provider 补缺失的 access 元数据。primary
  * 明确提供的 access 永远优先，不被 bundled 覆盖。
@@ -122,9 +156,20 @@ export function mergeWithBundled(primary: Catalog): Catalog {
   for (const p of withAccess) {
     if (!bundledById.has(p.id)) merged.push(p);
   }
-  // presets 同理兜底：远端带了用远端的，远端没带回落 bundled 的（预设是纯 UI 模板数据）。
-  const presets = primary.presets ?? BUNDLED_CATALOG.presets;
-  // cindyModelMeta 同 presets 兜底语义透传(消费点见 types.ts:服务端 + 客户端展示元数据基线)。
+  // presets 与 providers 同样按 id 合并：bundled 保序兜底，同 id 远端内容优先，
+  // 远端独有项按远端原序追加。避免旧远端的非空 presets 整段遮掉新版客户端内置条目。
+  const primaryPresets = primary.presets ?? [];
+  const bundledPresets = BUNDLED_CATALOG.presets ?? [];
+  const primaryPresetsById = new Map(primaryPresets.map((preset) => [preset.id, preset]));
+  const bundledPresetIds = new Set(bundledPresets.map((preset) => preset.id));
+  const presets = bundledPresets.map((bundled) => {
+    const remote = primaryPresetsById.get(bundled.id);
+    return remote ? backfillPresetContextWindows(remote, bundled) : bundled;
+  });
+  for (const preset of primaryPresets) {
+    if (!bundledPresetIds.has(preset.id)) presets.push(preset);
+  }
+  // cindyModelMeta 仍按整段缺省兜底透传(消费点见 types.ts:服务端 + 客户端展示元数据基线)。
   const cindyModelMeta = primary.cindyModelMeta ?? BUNDLED_CATALOG.cindyModelMeta;
   return {
     version: primary.version,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复远端 model catalog 的非空 `presets` 整段覆盖 bundled catalog，导致新客户端内置的 Coding Plan 等预设被陈旧远端目录遮蔽的问题。

预设现在按 ID 合并：bundled 提供稳定基线与顺序，同 ID 由远端覆盖，远端独有项追加；对于远端仍保留的同 runtime / 同 model，仅回填缺失的 `contextWindow`，不会复活远端主动移除的 runtime 或模型。同时为 MiniMax M3 的中国大陆与 Global Claude Code 预设补齐已由官方确认的 1M 上下文元数据。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1164
- 本 PR 包含：客户端 preset 按 ID 合并；匹配模型的 `contextWindow` 缺省回填；MiniMax M3 Claude Code 1M 元数据；回归测试。
- 明确不包含：model-access-server 的线上 catalog 数据同步与部署；服务端位于独立仓库。
- 用户可见变化：后续客户端即使拉到陈旧远端 catalog，添加供应商列表仍保留 bundled 中的智谱 / Z.ai Coding Plan 等预设，并正确识别 MiniMax M3 的 1M 上下文。
- 是否存在 breaking change：无。

### UI 变化

不涉及：未修改 UI 布局、样式、交互或文案；现有供应商设置页继续消费 active catalog，仅恢复原本被陈旧远端数据遮蔽的条目。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：GATE_EXIT=0，全仓 test:unit 通过。

pnpm --filter @cindy/model-providers test
结果：13 个测试文件、405 个测试全部通过。

pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/models.test.ts
结果：12 个测试全部通过。

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：包未定义 typecheck script，按仓库门禁规则跳过。

pnpm check:dco
结果：1 个提交 DCO 校验通过。
```

### 手工验证

使用当前线上中国大陆版 model-access catalog（`version=2`、10 个 preset）作为远端输入运行客户端合并逻辑：

- active catalog 得到完整 22 个 preset；
- `zhipu-coding-plan-cn` 与 `zai-coding-plan-global` 均存在；
- MiniMax CN / Global 的 Claude Code `MiniMax-M3` 均得到 `contextWindow: 1000000`；
- 远端已有 Codex runtime 保持不变。

### 未执行的验证

未启动 Desktop 做 UI 目检：本次未改 UI，核心行为由 catalog 纯逻辑测试与线上 payload 集成验证覆盖。

`@cindy/model-providers` 的非门禁 `build` 仍命中 `origin/main` 已存在的 `source-registry.test.ts:493-494` 类型错误；该文件未在本 PR 修改，未混入无关修复。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：catalog 合并语义与 Claude Code 模型窗口元数据

### 影响与回滚

- 影响范围：客户端启动时的 provider catalog 合并，以及从 preset 新建自定义供应商时使用的模型窗口元数据。无 prompt、tool、event loop 或热路径改动；启动期合并仍是小规模 O(n)。
- 回滚 / 降级方式：回退本提交即可恢复旧的远端 presets 整段优先语义。线上 catalog 仍需独立同步；本 PR 不改变服务端数据。

远端仍可通过同 ID preset 显式覆盖端点、runtime、模型集合和 `contextWindow`；移除 runtime / model 仍会停止新建。整个 preset 的缺失现在解释为远端落后并由 bundled 兜底；若未来需要远端显式下线整个 preset，应另行增加 disabled / tombstone 协议。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI，已注明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认无需补充用户文档；行为与边界已在测试和 PR 描述中说明
- [x] 已确认测试结果或说明未执行原因
