### PR TITLE
fix(mobile): 语音态占位文案改用普通态 placeholder 同色

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -9154,8 +9154,10 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     flexDirection: 'row',
     minHeight: COMPOSER_INPUT_LINE_HEIGHT,
   },
+  // 语音态占位文案渲染的就是普通态 TextInput 的 placeholder,颜色必须同源
+  // (placeholderTextColor 也是 textTertiary),否则一进语音态这行字会变色。
   voiceDraftListeningText: {
-    color: colors.statusReady,
+    color: colors.textTertiary,
     ...MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   },
   palettePanel: {

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3635,8 +3635,10 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     flexDirection: 'row',
     minHeight: MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
   },
+  // 语音态占位文案渲染的就是普通态 TextInput 的 placeholder,颜色必须同源
+  // (placeholderTextColor 也是 textTertiary),否则一进语音态这行字会变色。
   voiceDraftListeningText: {
-    color: colors.statusReady,
+    color: colors.textTertiary,
     ...MOBILE_COMPOSER_DRAFT_TEXT_STYLE,
   },
   composerToolbarWrap: {

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -936,6 +936,11 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('<Text style={styles.voiceDraftListeningText}>{composerListeningPlaceholder}</Text>');
     // 听写 mic 波形 caret 用正文色(对齐桌面 --chat-input-text,2026-07-28 用户定案),不用 statusReady 蓝绿。
     expect(newSource).toContain('<VoiceMicWaveCaret color={colors.textPrimary} testID="newSession.voiceMicCaret" />');
+    // 语音态占位文案就是普通态 TextInput 的 placeholder,必须与 placeholderTextColor 同源,
+    // 否则一进语音态这行字会变色(2026-07-31 用户定案:不再用 statusReady 蓝绿)。
+    expect(newSource).toContain('placeholderTextColor={colors.textTertiary}');
+    expect(newSource).toContain('voiceDraftListeningText: {\n    color: colors.textTertiary,');
+    expect(newSource).not.toContain('voiceDraftListeningText: {\n    color: colors.statusReady,');
     expect(newSource).toContain('const voiceDraftShowsListeningPrompt = voiceIsListening && draft.firstMessage.length === 0;');
     expect(newSource).toContain('firstMessageInputRef.current?.setNativeProps({ selection: { start: end, end } });');
     expect(newSource).toContain('voiceDraftScrollRef.current?.scrollToEnd({ animated: false });');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -414,6 +414,11 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('top: voiceDraftCaretFrame.top');
     expect(source).not.toContain('voiceMicCaretInline');
     expect(source).not.toContain('<VoiceMicWaveCaret color={colors.statusReady} inline />');
+    // 语音态占位文案就是普通态 TextInput 的 placeholder,必须与 placeholderTextColor 同源,
+    // 否则一进语音态这行字会变色(2026-07-31 用户定案:不再用 statusReady 蓝绿)。
+    expect(source).toContain('placeholderTextColor={colors.textTertiary}');
+    expect(source).toContain('voiceDraftListeningText: {\n    color: colors.textTertiary,');
+    expect(source).not.toContain('voiceDraftListeningText: {\n    color: colors.statusReady,');
     expect(source).toContain('finishVoiceRecordingRef.current?.();');
     expect(source).toContain('const voiceStopInFlightRef = useRef(false);');
     expect(voiceSource).toContain('|| voiceStopInFlightRef.current');


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版语音输入时，输入框里那行占位文案是蓝绿色（`statusReady` `#19D2C1`），一进语音态就跟普通态变了色。

这行文案渲染的**就是普通态 TextInput 的 placeholder 本身**（会话页取 `composerLayout.input.placeholder`，新建会话页取 `buildSessionComposerLayout` 产出的同一份文案）——语音态只是把它搬到 overlay 层重画了一遍。既然是同一段文案，颜色就该同源，所以改成与 `placeholderTextColor` 一致的 `colors.textTertiary`。

这是 #730 的收尾：那次已把麦克风波形图标从蓝绿改成正文色（`textPrimary`），当时留下的「旁边这行占位文字要不要一起改」由本 PR 落地。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#730 的遗留收尾（该 PR 已合并，麦克风图标部分已改；本 PR 补占位文案）
- 本 PR 包含：
  - `apps/mobile/app/sessions/[sessionId].tsx` 与 `apps/mobile/app/sessions/new.tsx` 的 `voiceDraftListeningText` 颜色：`colors.statusReady` → `colors.textTertiary`
  - 两处对应的 source-level 回归护栏：锁住「语音态占位文案色 = 普通态 `placeholderTextColor`」，并禁止回退到 `statusReady`
- 明确不包含：
  - **不引入手机端通用 placeholder token**。DESIGN.md §4 要求 placeholder 用比 tertiary 更浅的专用 slot（`--text-placeholder`，桌面 `#c4c4c4` / `#525252`），而手机端 `tokens.ts` 目前没有这个 token，全部输入框（聊天、新建会话等）的 placeholder 统一用 `textTertiary`（token 注释即「三级文字 / placeholder / metadata」）。这是手机端**既有的全局偏差**，不是本 PR 引入的；补齐它会动到所有输入框，属独立议题，不塞进这个只改一处异色的 PR。
  - 不动麦克风图标颜色（#730 已改为 `textPrimary`，本 PR 保持不变）。
  - 不动语音输入的任何行为、布局、时序或文案内容。
- 用户可见变化：手机版语音输入进行中、草稿还为空时，输入框里那行占位提示由蓝绿色变为与普通态一致的三级文字灰。切入/切出语音态时这行字不再变色。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - **DESIGN.md §10「Light / Dark Dual-Mode Delivery Gate（双模式交付门槛）」** —— 颜色一律走语义 token，禁止只适配一种模式的硬编码或条件补丁。本改动把硬性强调色换成语义 token `textTertiary`，Light `#686B72` / Dark `#BFC1C4` 两模式均已在 `apps/mobile/src/theme/tokens.ts` 注册，无需条件分支，两模式自动生效。
  - **DESIGN.md §2「Neutrals & Text」/ §4「Inputs & Forms」** —— placeholder 必须读起来明显是空的，不能读作真实输入内容。原先的 `statusReady` 是 teal 强调色，视觉重量远超 placeholder 语义（会被读成「有内容/有状态」）；换成三级文字色符合该约束的方向。§4 要求的专用 `--text-placeholder` slot 在手机端尚不存在，本 PR 与手机端所有输入框现状对齐（见「明确不包含」）。
  - **DESIGN.md §7「Don't」** —— 不把强调色用在非强调语义上。

**界面效果证据**（按源码常量复刻的 HTML，非示意图；保存为 `.html` 直接打开即可看到改前 / 改后 × Light / Dark 四格对照）：

<details>
<summary>展开 HTML —— 语音听写态占位文案 改前 / 改后 × Light / Dark</summary>

```html
<!DOCTYPE html>
<!--
  PR #1199 界面效果证据 — 手机版语音听写态占位文案颜色
  按 apps/mobile 真实常量复刻，非示意图：
    字号 typeScale.code = 15px   行高 lineHeight.body = 22px
    输入行 padding 10px / spacing.md 12px   minHeight 50px   radius.pill
    麦克风容器 18x22 (marginLeft 2 / marginRight 5)，lucide Mic size=18 stroke=2
    内部波形条 3 根 w1.15 gap1.1 (侧 h3.4 / 中 h6.4)，容器 left5.9 top6.8 w6.2 h8
  色值取自 apps/mobile/src/theme/tokens.ts；对比度为 WCAG 相对亮度算法实算值。
-->
<html lang="zh-CN">
<head>
<meta charset="utf-8">
<title>PR #1199 — 语音听写态占位文案颜色（改前 / 改后 × Light / Dark）</title>
<style>
  :root { font-family: -apple-system, BlinkMacSystemFont, "PingFang SC", "Helvetica Neue", sans-serif; }
  body { margin: 0; padding: 28px; background: #ffffff; color: #3C3F43; }
  h1 { font-size: 17px; margin: 0 0 4px; }
  .sub { font-size: 13px; color: #686B72; margin-bottom: 22px; }
  .grid { display: grid; grid-template-columns: repeat(2, minmax(320px, 1fr)); gap: 18px; max-width: 860px; }
  .pane { border-radius: 14px; padding: 16px; border: 1px solid #DCDFE3; }
  .pane.light { background: #EDEDED; }              /* mobile lightColors.surface */
  .pane.dark  { background: #2A2828; border-color: #434343; }  /* mobile darkColors.surface */
  .tag { font-size: 11px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; margin-bottom: 10px; }
  .light .tag { color: #686B72; }
  .dark  .tag { color: #BFC1C4; }
  .tag .bad  { color: #D91F37; }
  .tag .good { color: #0F9B6C; }

  /* 输入行 — MobileComposerInputRow styles.row */
  .row {
    display: flex; align-items: center;
    min-height: 50px; padding: 10px 12px;
    border-radius: 9999px; border-width: 1px; border-style: solid;
    margin-bottom: 10px;
  }
  .light .row { background: #F8F8F8; border-color: #DCDFE3; }  /* chatCodeSurface / sheetActionBorder */
  .dark  .row { background: #353333; border-color: #505050; }

  /* 语音态 overlay 的 listening prompt — styles.voiceDraftListeningPrompt */
  .prompt { display: flex; align-items: center; min-height: 22px; padding: 0 4px; }

  /* 麦克风 caret — styles.voiceMicCaret（#730 已定为 textPrimary，本 PR 不动） */
  .mic { position: relative; width: 18px; height: 22px; margin-left: 2px; margin-right: 5px;
         display: flex; align-items: center; justify-content: center; }
  .mic svg { display: block; }
  .bars { position: absolute; left: 5.9px; top: 6.8px; width: 6.2px; height: 8px;
          display: flex; align-items: center; justify-content: center; gap: 1.1px; overflow: hidden; }
  .bars i { display: block; width: 1.15px; border-radius: 9999px; }
  .bars i.side { height: 3.4px; }
  .bars i.mid  { height: 6.4px; }

  /* 占位文案 — styles.voiceDraftListeningText + MOBILE_COMPOSER_DRAFT_TEXT_STYLE */
  .ph { font-size: 15px; line-height: 22px; }

  .note { font-size: 11.5px; line-height: 1.6; margin-top: 10px; }
  .light .note { color: #686B72; }
  .dark  .note { color: #BFC1C4; }
  code { font-size: 11.5px; }
  .legend { max-width: 860px; margin-top: 20px; font-size: 12.5px; line-height: 1.7; color: #3C3F43; }
  table { border-collapse: collapse; font-size: 12.5px; margin-top: 8px; }
  th, td { border: 1px solid #DCDFE3; padding: 5px 9px; text-align: left; }
  th { background: #F8F8F8; font-weight: 600; }
</style>
</head>
<body>

<h1>PR #1199 — 语音听写态占位文案颜色</h1>
<div class="sub">
  场景：语音听写进行中、草稿仍为空。此时输入框里显示的是<strong>普通态 TextInput 的 placeholder 本身</strong>，
  由语音 overlay 层重画。上排会话页（文案「输入远程消息」），下排新建会话页（文案「今天我们做点什么呢~」）。
  麦克风图标为 #730 已定的 <code>textPrimary</code>，本 PR 不改。
</div>

<div class="grid">

  <!-- ============ LIGHT 改前 ============ -->
  <div class="pane light">
    <div class="tag"><span class="bad">改前</span> · Light · <code>statusReady</code> #19D2C1</div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3C3F43" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#3C3F43"></i><i class="mid" style="background:#3C3F43"></i><i class="side" style="background:#3C3F43"></i></div>
        </div>
        <span class="ph" style="color:#19D2C1">输入远程消息</span>
      </div>
    </div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3C3F43" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#3C3F43"></i><i class="mid" style="background:#3C3F43"></i><i class="side" style="background:#3C3F43"></i></div>
        </div>
        <span class="ph" style="color:#19D2C1">今天我们做点什么呢~</span>
      </div>
    </div>
    <div class="note">teal 强调色。与同屏普通态 placeholder（<code>#686B72</code>）不同色 —— 切入语音态这行字会变色。</div>
  </div>

  <!-- ============ LIGHT 改后 ============ -->
  <div class="pane light">
    <div class="tag"><span class="good">改后</span> · Light · <code>textTertiary</code> #686B72</div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3C3F43" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#3C3F43"></i><i class="mid" style="background:#3C3F43"></i><i class="side" style="background:#3C3F43"></i></div>
        </div>
        <span class="ph" style="color:#686B72">输入远程消息</span>
      </div>
    </div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#3C3F43" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#3C3F43"></i><i class="mid" style="background:#3C3F43"></i><i class="side" style="background:#3C3F43"></i></div>
        </div>
        <span class="ph" style="color:#686B72">今天我们做点什么呢~</span>
      </div>
    </div>
    <div class="note">与同屏 <code>placeholderTextColor={colors.textTertiary}</code> 同源 —— 切入 / 切出语音态不再变色。</div>
  </div>

  <!-- ============ DARK 改前 ============ -->
  <div class="pane dark">
    <div class="tag"><span class="bad">改前</span> · Dark · <code>statusReady</code> #19D2C1</div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#D4D4D4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#D4D4D4"></i><i class="mid" style="background:#D4D4D4"></i><i class="side" style="background:#D4D4D4"></i></div>
        </div>
        <span class="ph" style="color:#19D2C1">输入远程消息</span>
      </div>
    </div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#D4D4D4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#D4D4D4"></i><i class="mid" style="background:#D4D4D4"></i><i class="side" style="background:#D4D4D4"></i></div>
        </div>
        <span class="ph" style="color:#19D2C1">今天我们做点什么呢~</span>
      </div>
    </div>
    <div class="note">同一 teal 值跨模式恒定（不随模式调整），色相在中性灰界面里突出，读作「有状态」。</div>
  </div>

  <!-- ============ DARK 改后 ============ -->
  <div class="pane dark">
    <div class="tag"><span class="good">改后</span> · Dark · <code>textTertiary</code> #BFC1C4</div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#D4D4D4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#D4D4D4"></i><i class="mid" style="background:#D4D4D4"></i><i class="side" style="background:#D4D4D4"></i></div>
        </div>
        <span class="ph" style="color:#BFC1C4">输入远程消息</span>
      </div>
    </div>
    <div class="row">
      <div class="prompt">
        <div class="mic">
          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#D4D4D4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
            <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
            <line x1="12" x2="12" y1="19" y2="22"/>
          </svg>
          <div class="bars"><i class="side" style="background:#D4D4D4"></i><i class="mid" style="background:#D4D4D4"></i><i class="side" style="background:#D4D4D4"></i></div>
        </div>
        <span class="ph" style="color:#BFC1C4">今天我们做点什么呢~</span>
      </div>
    </div>
    <div class="note">语义 token 自带 dark 值，无条件分支 —— 双模式同一套代码路径。</div>
  </div>

</div>

<div class="legend">
  <strong>色值与对比度</strong>（WCAG 相对亮度实算；底色取占位文案真实所在的<strong>输入框底</strong>
  <code>chatCodeSurface</code>，Light #F8F8F8 / Dark #353333）
  <table>
    <tr><th>模式</th><th>改前 statusReady</th><th>改后 textTertiary</th><th>同屏普通态 placeholder</th></tr>
    <tr><td>Light</td><td>#19D2C1 · 1.79:1</td><td>#686B72 · 5.03:1</td><td>#686B72 · 5.03:1 ✅ 同源</td></tr>
    <tr><td>Dark</td><td>#19D2C1 · 6.59:1</td><td>#BFC1C4 · 6.96:1</td><td>#BFC1C4 · 6.96:1 ✅ 同源</td></tr>
  </table>
  <p>
    两个模式的差异性质不同，如实区分：<strong>Light 下 teal 仅 1.79:1</strong>，作正文级文字偏弱；
    <strong>Dark 下 teal 与改后色对比度接近</strong>（6.59 vs 6.96），问题不在对比度，而在
    <code>#19D2C1</code> 跨模式恒定、色相在中性灰界面里显著突出，读作「有状态」而非「空占位」。
  </p>
  <p>
    引用规范：<strong>DESIGN.md §10 双模式交付门槛</strong>（颜色走语义 token，禁止单模式硬编码 —— 本改动用
    <code>textTertiary</code>，两模式均已在 <code>tokens.ts</code> 注册，无条件分支）；
    <strong>§2 Neutrals &amp; Text / §4 Inputs &amp; Forms</strong>（placeholder 不得读作真实输入 —— teal 强调色的视觉重量远超
    placeholder 语义）；<strong>§7 Don't</strong>（强调色不用于非强调语义）。
  </p>
  <p>
    已知偏差（本 PR 不含，见 PR 描述「明确不包含」与已 resolve 的 review thread）：mobile 尚无桌面
    <code>--text-placeholder</code> 对应的专用 slot，全仓 26 处 <code>placeholderTextColor</code> 统一用
    <code>textTertiary</code>。桌面规范值搬到 mobile 底色上只有 Light 1.49:1 / Dark 1.88:1，需为 mobile 另定色值并做实机验证，属独立议题。
  </p>
  <p><em>本页为按源码常量复刻的静态对照，不含 caret 的呼吸动画（bars 在真机上 550ms 循环、opacity 0.5→1、scaleY 0.42→1）。</em></p>
</div>

</body>
</html>
```

</details>

要点（HTML 内含完整色值与实算对比度表）：

- 场景是「听写进行中 + 草稿为空」，此时输入框里显示的就是普通态 TextInput 的 placeholder，由语音 overlay 重画。
- 排版按真实常量复刻：字号 `typeScale.code` 15px、行高 `lineHeight.body` 22px、输入行 padding 10px / `spacing.md` 12px、`radius.pill`；麦克风容器 18×22（`lucide Mic` size 18 / stroke 2）。
- 麦克风图标是 #730 已定的 `textPrimary`，本 PR 不动。
- 两个模式的问题性质不同（已在 HTML 中如实区分）：Light 下 teal 对输入框底仅 **1.79:1**，作文字偏弱；Dark 下 teal 与改后色对比度接近（**6.59 vs 6.96**），问题不在对比度，而在 `#19D2C1` 跨模式恒定、色相在中性灰界面里读作「有状态」而非「空占位」。
- 静态对照不含 caret 呼吸动画（真机上 bars 550ms 循环、opacity 0.5→1、scaleY 0.42→1），该动画本 PR 未改。

## 怎么验证的

### 自动验证

```text
# 定向测试（含本次新增护栏）
cd apps/mobile && npx vitest run --pool=threads \
  src/__tests__/sessionComposerDesktopFirst.test.ts \
  src/__tests__/newSession.test.ts \
  src/__tests__/composerVoiceDraftMetrics.test.ts \
  src/__tests__/themeTokens.test.ts
结果：4 files / 69 tests 全部通过

pnpm --filter mobile run typecheck
结果：0 错误

pnpm test:unit（仓库根门禁，全量）
结果：全部 workspace PASS / 0 fail（`apps/mobile unit` PASS 10.5s）
```

补充说明：首次跑门禁时因新 worktree 未初始化 `cindy-protocol` submodule 而**一行未跑就退出**
（`Manifest declares non-pnpm workspace: cindy-protocol/packages/device-link-protocol`），
mobile typecheck 也因此报 `Cannot find module '@cindy/device-link-protocol'`。
按 `docs/dev-rules/environment-setup.md` 执行
`git submodule update --init --recursive cindy-protocol` + `pnpm install` 后，
两项均转为全绿。属环境准备缺失，与本 PR 改动无关。

### 手工验证

不涉及。

### 未执行的验证

- **未在模拟器/真机上目检 Light / Dark 两种模式的实际观感。** 按 DESIGN.md §10，双模式目检是尽力而非阻塞门槛，此处如实声明：本次只做了 token 层与 source-level 验证——`textTertiary` 在 Light / Dark 两个 palette 中均有独立注册值（`#686B72` / `#BFC1C4`），且与同屏其他 placeholder 完全同源，故不存在「只适配一种模式」的实现缺口；但两种模式的实机观感均未目检，不把「复用了既有 themed token」当成「双模式已验证」。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅手机版聊天输入框在「语音听写进行中且草稿为空」这一瞬态下那行占位文案的颜色。不改结构、不改布局度量、不改行为时序、不改文案内容。未触及 `app.json` / `app.config.js` / `eas.json` / `apps/mobile/package.json` / `plugins/` / `modules/` 等 runtime fingerprint 输入，**不触发冷更**。
- 回滚 / 降级方式：revert 本 PR 即可，两处样式各一行，无状态、无数据、无迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（规则性约束以测试护栏 + 源码注释固化，无需新增文档）
- [x] 已确认测试结果或说明未执行原因
