### PR TITLE
feat(desktop): 支持运行中思考预览展开

### DIFF
--- a/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
@@ -186,6 +186,34 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     expect(document.querySelectorAll('[data-live-work-activity="thinking"]')).toHaveLength(1);
   });
 
+  it('continues updating an expanded live reasoning row as deltas arrive', () => {
+    const { rerender } = render(
+      createElement(WorkGroupBlock, {
+        blockId: 'work:t1',
+        isStreaming: true,
+        childItems: [thinking(mkThinking('th1', 'initial\nreasoning'))],
+      }),
+    );
+
+    const thinkingButton = screen.getByText('initial reasoning').closest('button');
+    if (!thinkingButton) throw new Error('Missing live thinking row');
+    fireEvent.click(thinkingButton);
+    expect(thinkingButton.getAttribute('aria-expanded')).toBe('true');
+
+    rerender(
+      createElement(WorkGroupBlock, {
+        blockId: 'work:t1',
+        isStreaming: true,
+        childItems: [thinking(mkThinking('th1', 'initial reasoning\nwith more detail'))],
+      }),
+    );
+
+    const updatedThinkingButton = screen
+      .getByText('initial reasoning with more detail')
+      .closest('button');
+    expect(updatedThinkingButton?.getAttribute('aria-expanded')).toBe('true');
+  });
+
   it('shows complete commandActions as separate rows and summarizes pure exploration', () => {
     const command = mkTool('exec-1', 'cat src/a.ts && rg TODO src');
     command.toolInput = {
@@ -224,7 +252,7 @@ describe('WorkGroupBlock — running latest-five preview', () => {
   it('offers no toggle while running when the preview already shows everything', () => {
     const childItems = [
       tools('seg-1', [mkTool('t1', 'git status')]),
-      thinking(mkThinking('th1', 'checking the current state')),
+      thinking(mkThinking('th1', 'checking the\ncurrent state')),
     ];
     const { rerender } = render(
       createElement(WorkGroupBlock, {
@@ -237,6 +265,14 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     expect(screen.getByText('chat.workGroup.working')).toBeTruthy();
     expect(document.querySelector('[data-live-work-preview="true"]')).toBeTruthy();
     expect(screen.getByTestId('direct-tool').getAttribute('data-show-raw')).toBe('true');
+
+    // 即使运行中的工作组没有更多内容可供外层展开，思考预览行本身也应可点击查看全文。
+    const thinkingPreview = screen.getByText('checking the current state').closest('button');
+    if (!thinkingPreview) throw new Error('Missing expandable live thinking row');
+    expect(thinkingPreview.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(thinkingPreview);
+    expect(thinkingPreview.getAttribute('aria-expanded')).toBe('true');
+    expect(thinkingPreview.textContent).toContain('checking the\ncurrent state');
 
     // ≤5 条活动且没有 preview 之外的子项:展开不会露出更多内容,组头不再
     // 提供折叠交互 — 无箭头、禁用、点击后预览保持原样。
@@ -264,6 +300,68 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     clickGroup('chat.workGroup.worked:12s');
     expect(screen.getByTestId('direct-tool').textContent).toBe('git status');
     expect(screen.getByText('checking the current state')).toBeTruthy();
+  });
+
+  it('shares thinking expansion state between the live preview and full work-group view', () => {
+    render(
+      createElement(WorkGroupBlock, {
+        blockId: 'work:t1',
+        isStreaming: true,
+        childItems: [
+          thinking(mkThinking('th1', 'first line\nsecond line')),
+          rendered('progress', 'continuing the analysis'),
+        ],
+      }),
+    );
+
+    const livePreview = document.querySelector('[data-live-work-preview="true"]');
+    const liveThinkingButton = livePreview?.querySelector<HTMLButtonElement>(
+      '[data-live-work-activity="thinking"]',
+    );
+    if (!liveThinkingButton) throw new Error('Missing live thinking row');
+    fireEvent.click(liveThinkingButton);
+    expect(liveThinkingButton.getAttribute('aria-expanded')).toBe('true');
+
+    clickGroup('chat.workGroup.working');
+    const fullThinkingButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        '[data-live-work-activity="thinking"]',
+      ),
+    ).find((button) => !button.closest('[data-live-work-preview="true"]'));
+    expect(fullThinkingButton?.getAttribute('aria-expanded')).toBe('true');
+
+    if (!fullThinkingButton) throw new Error('Missing full thinking row');
+    fireEvent.click(fullThinkingButton);
+    expect(fullThinkingButton.getAttribute('aria-expanded')).toBe('false');
+
+    clickGroup('chat.workGroup.working');
+    const restoredPreviewButton = document
+      .querySelector('[data-live-work-preview="true"]')
+      ?.querySelector<HTMLButtonElement>('[data-live-work-activity="thinking"]');
+    expect(restoredPreviewButton?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps an inherited expanded state toggleable for single-line long thinking', () => {
+    expandMemory.setExpanded('work:t1', true);
+    expandMemory.setExpanded('thinking:th1', true);
+    render(
+      createElement(WorkGroupBlock, {
+        blockId: 'work:t1',
+        durationMs: 2_000,
+        childItems: [
+          thinking(mkThinking('th1', 'a single-line reasoning block that is long enough to overflow')),
+          rendered('progress', 'continuing the analysis'),
+        ],
+      }),
+    );
+
+    const fullThinkingButton = Array.from(
+      document.querySelectorAll<HTMLButtonElement>(
+        '[data-live-work-activity="thinking"]',
+      ),
+    ).find((button) => !button.closest('[data-live-work-preview="true"]'));
+    expect(fullThinkingButton?.getAttribute('aria-expanded')).toBe('true');
+    expect(fullThinkingButton?.hasAttribute('disabled')).toBe(false);
   });
 
   it('keeps the toggle while running when expansion can reveal more than the preview', () => {

--- a/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
@@ -269,6 +269,11 @@ describe('WorkGroupBlock — running latest-five preview', () => {
     // 即使运行中的工作组没有更多内容可供外层展开，思考预览行本身也应可点击查看全文。
     const thinkingPreview = screen.getByText('checking the current state').closest('button');
     if (!thinkingPreview) throw new Error('Missing expandable live thinking row');
+    thinkingPreview.focus();
+    expect(document.activeElement).toBe(thinkingPreview);
+    expect(thinkingPreview.className).toContain(
+      'focus-visible:ring-[var(--focus-ring)]',
+    );
     expect(thinkingPreview.getAttribute('aria-expanded')).toBe('false');
     fireEvent.click(thinkingPreview);
     expect(thinkingPreview.getAttribute('aria-expanded')).toBe('true');

--- a/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
@@ -80,9 +80,10 @@ function thinkingActivityForMessage(
   message: ChatMessage,
 ): ProjectedThinkingActivity | null {
   if (message.thinkingRedacted) return null;
-  const content = message.content.replace(/\s+/g, ' ').trim();
+  const rawContent = message.content.trim();
+  const content = rawContent.replace(/\s+/g, ' ').trim();
   return content
-    ? { kind: 'thinking', key: message.clientId, content }
+    ? { kind: 'thinking', key: message.clientId, rawContent, content }
     : null;
 }
 
@@ -128,21 +129,72 @@ function ThinkingActivityRow({
 }: {
   activity: ProjectedThinkingActivity;
 }) {
+  const rawContent = activity.rawContent;
+  const hasExplicitLineBreak = /[\r\n]/.test(rawContent);
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [canExpand, setCanExpand] = useState(hasExplicitLineBreak);
+  const { expanded, setExpanded } = useExpandedBlockMemory(`thinking:${activity.key}`);
+
+  useLayoutEffect(() => {
+    if (expanded) {
+      setCanExpand(true);
+      return;
+    }
+    const textElement = textRef.current;
+    if (!textElement) return;
+    const updateOverflow = () => {
+      setCanExpand(
+        hasExplicitLineBreak || textElement.scrollWidth > textElement.clientWidth + 1,
+      );
+    };
+    updateOverflow();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateOverflow);
+    observer.observe(textElement);
+    return () => observer.disconnect();
+  }, [activity.content, expanded, hasExplicitLineBreak]);
+
   return (
-    <div
+    <button
+      type="button"
       data-live-work-activity="thinking"
-      className="flex min-w-0 items-center gap-[6px] px-2 py-[3px]"
+      data-work-thinking-expandable={canExpand ? 'true' : 'false'}
+      disabled={!canExpand}
+      aria-expanded={canExpand ? expanded : undefined}
+      onClick={() => setExpanded((value) => !value)}
+      className={cn(
+        'flex w-full min-w-0 items-start gap-[6px] px-2 py-[3px] text-left',
+        canExpand && 'cursor-pointer hover:opacity-80 transition-opacity',
+      )}
     >
-      <span className="inline-flex h-[18px] w-4 shrink-0 items-center justify-center text-[var(--msg-tool-card-chevron)]">
+      <span
+        aria-hidden="true"
+        className="inline-flex h-[18px] w-4 shrink-0 items-center justify-center text-[var(--msg-tool-card-chevron)]"
+      >
         <Sparkles size={13} />
       </span>
       <span
-        className="min-w-0 truncate text-[14px] italic text-[var(--thinking-body-text)]"
-        title={activity.content}
+        ref={textRef}
+        className={cn(
+          'min-w-0 flex-1 text-[14px] italic text-[var(--thinking-body-text)]',
+          expanded ? 'whitespace-pre-wrap break-words' : 'truncate',
+        )}
+        title={expanded ? undefined : activity.content}
       >
-        <ThinkingText content={activity.content} />
+        <ThinkingText content={expanded ? rawContent : activity.content} />
       </span>
-    </div>
+      {canExpand && (
+        <span aria-hidden="true" className="inline-flex h-[18px] shrink-0 items-center text-[var(--msg-tool-card-chevron)]">
+          <ChevronRight
+            size={13}
+            className={cn(
+              'transition-transform duration-[var(--motion-fast,150ms)]',
+              expanded && 'rotate-90',
+            )}
+          />
+        </span>
+      )}
+    </button>
   );
 }
 
@@ -157,7 +209,11 @@ function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
   const { expanded, setExpanded } = useExpandedBlockMemory(`thinking:${message.clientId}`);
 
   useLayoutEffect(() => {
-    if (!activity || expanded) return;
+    if (!activity) return;
+    if (expanded) {
+      setCanExpand(true);
+      return;
+    }
     const textElement = textRef.current;
     if (!textElement) return;
     const updateOverflow = () => {
@@ -200,7 +256,10 @@ function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
         canExpand && 'cursor-pointer hover:opacity-80 transition-opacity',
       )}
     >
-      <span className="inline-flex h-[18px] w-4 shrink-0 items-center justify-center text-[var(--msg-tool-card-chevron)]">
+      <span
+        aria-hidden="true"
+        className="inline-flex h-[18px] w-4 shrink-0 items-center justify-center text-[var(--msg-tool-card-chevron)]"
+      >
         <Sparkles size={13} />
       </span>
       <span
@@ -214,7 +273,7 @@ function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
         <ThinkingText content={expanded ? rawContent : activity.content} />
       </span>
       {canExpand && (
-        <span className="inline-flex h-[18px] shrink-0 items-center text-[var(--msg-tool-card-chevron)]">
+        <span aria-hidden="true" className="inline-flex h-[18px] shrink-0 items-center text-[var(--msg-tool-card-chevron)]">
           <ChevronRight
             size={13}
             className={cn(

--- a/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
+++ b/apps/desktop/src/renderer/components/chat/WorkGroupBlock.tsx
@@ -81,7 +81,7 @@ function thinkingActivityForMessage(
 ): ProjectedThinkingActivity | null {
   if (message.thinkingRedacted) return null;
   const rawContent = message.content.trim();
-  const content = rawContent.replace(/\s+/g, ' ').trim();
+  const content = rawContent.replace(/\s+/g, ' ');
   return content
     ? { kind: 'thinking', key: message.clientId, rawContent, content }
     : null;
@@ -163,7 +163,7 @@ function ThinkingActivityRow({
       aria-expanded={canExpand ? expanded : undefined}
       onClick={() => setExpanded((value) => !value)}
       className={cn(
-        'flex w-full min-w-0 items-start gap-[6px] px-2 py-[3px] text-left',
+        'flex w-full min-w-0 items-start gap-[6px] px-2 py-[3px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
         canExpand && 'cursor-pointer hover:opacity-80 transition-opacity',
       )}
     >
@@ -252,7 +252,7 @@ function ExpandedThinkingRow({ message }: { message: ChatMessage }) {
       disabled={!canExpand}
       aria-expanded={canExpand ? expanded : undefined}
       className={cn(
-        'flex w-full min-w-0 items-start gap-[6px] px-2 py-[3px] text-left',
+        'flex w-full min-w-0 items-start gap-[6px] px-2 py-[3px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
         canExpand && 'cursor-pointer hover:opacity-80 transition-opacity',
       )}
     >

--- a/packages/maker-shared/src/workActivityProjection.ts
+++ b/packages/maker-shared/src/workActivityProjection.ts
@@ -210,7 +210,7 @@ function projectThinkingMessage<TMessage extends WorkActivityMessageLike>(
 ): ProjectedThinkingActivity | null {
   if (message.thinkingRedacted) return null;
   const rawContent = message.content.trim();
-  const content = rawContent.replace(/\s+/g, ' ').trim();
+  const content = rawContent.replace(/\s+/g, ' ');
   return content
     ? { kind: 'thinking', key: message.clientId, rawContent, content }
     : null;

--- a/packages/maker-shared/src/workActivityProjection.ts
+++ b/packages/maker-shared/src/workActivityProjection.ts
@@ -48,6 +48,8 @@ export interface ProjectedToolActivity<
 export interface ProjectedThinkingActivity {
   kind: 'thinking';
   key: string;
+  /** Original trimmed content, retained for an expanded live-preview row. */
+  rawContent: string;
   content: string;
 }
 
@@ -207,8 +209,11 @@ function projectThinkingMessage<TMessage extends WorkActivityMessageLike>(
   message: TMessage,
 ): ProjectedThinkingActivity | null {
   if (message.thinkingRedacted) return null;
-  const content = message.content.replace(/\s+/g, ' ').trim();
-  return content ? { kind: 'thinking', key: message.clientId, content } : null;
+  const rawContent = message.content.trim();
+  const content = rawContent.replace(/\s+/g, ' ').trim();
+  return content
+    ? { kind: 'thinking', key: message.clientId, rawContent, content }
+    : null;
 }
 
 /** Reverse hot path used by the running latest-N preview. */


### PR DESCRIPTION
## 这次改了什么？

### 摘要

运行中的 workgroup 里，thinking 预览行此前只能通过鼠标悬停查看全文，不能主动展开。本 PR 让 thinking 预览行支持点击展开/收起，并保持流式内容继续更新。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `test` 测试补充

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Desktop thinking live preview 展开交互、共享投影字段、回归测试
- 明确不包含：服务端、协议、数据库、移动端 UI 改动
- 用户可见变化：思考中的预览行在内容有换行或视觉溢出时显示箭头，可点击展开原始多行内容
- Breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` 的 Focus Blue / `--focus-ring` 键盘可访问性焦点环、语义颜色 token、双模式交付要求
- 颜色继续使用现有语义 token，Light/Dark 均复用主题变量
- 可展开 thinking 按钮使用 `focus-visible` 焦点环，装饰性图标增加 `aria-hidden="true"`

## 怎么验证的？

### 自动验证

```text
pnpm test:unit
结果：308 passed，8 skipped，0 failed；Desktop、Mobile 及相关 workspace 全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter desktop test -- src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
结果：14 passed

pnpm --filter desktop exec eslint src/renderer/components/chat/WorkGroupBlock.tsx src/renderer/__tests__/workGroupBlockLivePreview.test.tsx
结果：通过

pnpm --filter @cindy/maker-shared exec eslint src/workActivityProjection.ts
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

- 当前 worktree 已启动 Desktop remote/global dev 实例
- 验证了 thinking 预览行展开/收起、流式 delta 继续更新、live/full 视图状态同步

### 未执行的验证

无

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：Desktop renderer 的 workgroup thinking 预览，以及共享的 activity projection 类型
- 回滚方式：回滚本 PR 的两个 commit（`bf69927`、`af690a31`）

### 提交前检查

- [x] 已完成三轮代码审查，P0/P1 已清零
- [x] 每个 commit 都带 DCO 签名
- [x] UI 变化已说明设计规范依据
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果
