### PR TITLE
feat(im): 群里 owner 裸斜杠命令视为显式召唤(个人 Telegram)

### DIFF
--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -233,10 +233,13 @@ describe('TelegramIM', () => {
     api.pushUpdates([
       groupMessage({ text: '/project', fromId: 111, messageId: 55 }),
       groupMessage({ text: '/new', fromId: 222, messageId: 56 }),
+      // 显式发给其它 bot 的命令: 本 bot 不抢答(多 bot 群, review P1)
+      groupMessage({ text: '/new@another_bot', fromId: 111, messageId: 58 }),
       groupMessage({ text: '/nonsense extra args', fromId: 111, messageId: 57 }),
     ]);
     await vi.waitFor(() => expect(events).toHaveLength(2));
-    // owner 裸命令(55/57)按原文进事件流(slash 层消费); 成员裸命令(56)静默丢弃
+    // owner 裸命令(55/57)按原文进事件流(slash 层消费);
+    // 成员裸命令(56)与发给其它 bot 的命令(58)静默丢弃
     expect(events[0]).toMatchObject({ senderId: 'g/-100200', text: '/project' });
     expect(events[1]).toMatchObject({ senderId: 'g/-100200', text: '/nonsense extra args' });
   });

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -226,6 +226,21 @@ describe('TelegramIM', () => {
     });
   });
 
+  it('群里 owner 裸斜杠命令视为召唤(不带 @ 也进 slash); 成员裸命令仍静默', async () => {
+    const events: IMMessageEvent[] = [];
+    im.onMessage((e) => events.push(e));
+    await connect();
+    api.pushUpdates([
+      groupMessage({ text: '/project', fromId: 111, messageId: 55 }),
+      groupMessage({ text: '/new', fromId: 222, messageId: 56 }),
+      groupMessage({ text: '/nonsense extra args', fromId: 111, messageId: 57 }),
+    ]);
+    await vi.waitFor(() => expect(events).toHaveLength(2));
+    // owner 裸命令(55/57)按原文进事件流(slash 层消费); 成员裸命令(56)静默丢弃
+    expect(events[0]).toMatchObject({ senderId: 'g/-100200', text: '/project' });
+    expect(events[1]).toMatchObject({ senderId: 'g/-100200', text: '/nonsense extra args' });
+  });
+
   it('名字召唤: 手打 "@显示名" 与句首裸名字都触发(非 username), 句中提到不触发', async () => {
     const events: IMMessageEvent[] = [];
     im.onMessage((e) => events.push(e));
@@ -781,8 +796,8 @@ describe('TelegramIM', () => {
     expect(events[0].senderId).toBe('g/-100200');
     // ambient 触发的表情回应被抑制
     expect(await im.reactToMessage('-100200|50', '👀')).toBeNull();
-    // ambient 路径不消费命令(即使 owner)
-    api.pushUpdates([groupMessage({ text: '/new', fromId: 111, messageId: 51 })]);
+    // ambient 路径不消费成员命令(owner 裸命令走显式召唤通道, 另有用例)
+    api.pushUpdates([groupMessage({ text: '/new', fromId: 222, messageId: 51 })]);
     await new Promise((r) => setTimeout(r, 100));
     expect(events).toHaveLength(1);
     // NO_REPLY 哨兵: 惰性占位下从头到尾零消息(不发送、无需删除 — 真零痕迹)

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -935,6 +935,14 @@ export class TelegramIM extends BaseIM implements ChannelIM {
 
       let trigger = detectGroupTrigger(m, this.botId, this.botUsername, this.botDisplayName);
       let ambient = false;
+      const isOwner = String(m.from.id) === this.ownerUserId;
+      if (!trigger && isOwner) {
+        // owner 的裸斜杠命令视为显式召唤: 群里命令语义只属于本 bot, 主人手打
+        // /project 不该因为没带 @username 而石沉大海(2026-07-31 实测反馈)。
+        // 成员的裸命令不在此列 — 仍走"命令 owner 专属"的静默丢弃。
+        const plain = (m.text ?? '').trim();
+        if (/^\/[a-zA-Z]/.test(plain)) trigger = { text: plain };
+      }
       if (!trigger) {
         // 全响应·自主判断(per-chat 配置): 未被召唤的消息也进 turn, 打 ambient
         // 标记 — 业务层注入安静上下文, 模型可用 NO_REPLY 沉默。
@@ -945,7 +953,6 @@ export class TelegramIM extends BaseIM implements ChannelIM {
         trigger = { text: plain };
         ambient = true;
       }
-      const isOwner = String(m.from.id) === this.ownerUserId;
       {
         const probe = trigger.text.trimStart();
         const isCommand = probe.startsWith('/') || probe.startsWith('!');

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -937,11 +937,14 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       let ambient = false;
       const isOwner = String(m.from.id) === this.ownerUserId;
       if (!trigger && isOwner) {
-        // owner 的裸斜杠命令视为显式召唤: 群里命令语义只属于本 bot, 主人手打
-        // /project 不该因为没带 @username 而石沉大海(2026-07-31 实测反馈)。
+        // owner 的裸斜杠命令视为显式召唤: 群里主人手打 /project 不该因为没带
+        // @username 而石沉大海(2026-07-31 实测反馈)。只认**不带 @ 后缀**的
+        // 命令 token — `/cmd@其它bot` 是显式发给别的 bot 的, 不抢答(带
+        // @本bot 后缀的由 detectGroupTrigger 的 bot_command 分支处理)。
         // 成员的裸命令不在此列 — 仍走"命令 owner 专属"的静默丢弃。
         const plain = (m.text ?? '').trim();
-        if (/^\/[a-zA-Z]/.test(plain)) trigger = { text: plain };
+        const firstToken = plain.split(/\s/, 1)[0] ?? '';
+        if (/^\/[a-zA-Z][a-zA-Z0-9_]{0,63}$/.test(firstToken)) trigger = { text: plain };
       }
       if (!trigger) {
         // 全响应·自主判断(per-chat 配置): 未被召唤的消息也进 turn, 打 ambient


### PR DESCRIPTION
## 这次改了什么

### 摘要

个人 Telegram bot(#1078)上线后实测反馈:群里手打 `/project`(不带 `@botname` 后缀)没反应——群触发只认 @提及/回复/名字召唤,而命令菜单只注册在 owner 私聊 scope,群里没有自动补全,手打裸命令是最自然的操作。

本 PR:**owner 的裸斜杠命令在群里视为显式召唤**,直接进 slash 层(含全响应群——不再被 ambient 路径吞掉);群成员的裸命令维持静默丢弃(命令 owner 专属不变);`/project@botname` 老形态不受影响。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1078 上线后维护者实测反馈
- 本 PR 包含：`packages/lizi-im/src/telegram/index.ts` 群触发判定(+9 行)与两个测试用例
- 明确不包含：命令菜单的群 scope 注册(BotCommandScopeChatMember,另议)
- 用户可见变化：群里 owner 手打 `/project` `/new` `/session` 等裸命令直接生效
- 是否存在 breaking change：无(纯放宽;成员命令语义不变)

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
packages/lizi-im vitest: 20 文件 240 测试全绿(新增: owner 裸命令召唤/成员裸命令静默、
  always 群 ambient 不消费成员命令改写)
packages/lizi-im tsc --noEmit: 通过
pnpm check:dco: 1 commit 签名通过
仓库根 pnpm test:unit: 首轮 GATE_EXIT=1 — 唯一失败为 MessageActionBar 渲染测试
  5s 超时(与本 diff 无交集; 单独复跑 4/4 全绿, 为并发负载下的基线 flaky);
  干净复跑结果见 PR 后续评论补充。
```

### 手工验证

不适用(行为由单测覆盖;真机验证待随版本发布后在正式版群里手打 /project)。

### 未执行的验证

真 bot 群内实测(修复需随版本发布;当前正式版可用 `/project@botname` 形态,已验证可用)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅个人 Telegram 群消息触发判定;成员命令与官方通道不受影响
- 回滚 / 降级方式：revert 本 PR 即可

远程连接/手机版适配说明(规则 26):不涉及——transport 内部触发判定,无新 IPC、无端差异。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(无需)
- [x] 已确认测试结果或说明未执行原因
