### PR TITLE
fix(mobile): 系统边界卡不再挂消息操作条

### DIFF
--- a/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
@@ -47,6 +47,23 @@ describe('mobile message actions desktop-first surface', () => {
     );
   });
 
+  it('never hangs the action bar on a system boundary card', () => {
+    // 系统卡(agent-switch / auto-resume / goal / slash 命令卡)不是发言:桌面
+    // MessageStream 对 systemCardType 提前 return SystemCard,卡片下方没有任何操作
+    // 行。手机版曾漏掉这条,跨 Agent 切换的分隔线药丸下多出一行「··· 刚刚」。
+    const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
+
+    expect(source).toContain('const showCompletedActionBar = mobileMessageShowsActionBar({');
+    expect(source).toContain('hasSystemCard: !!item.message.systemCardType,');
+    expect(source).toContain('isTurnFinalAssistant: item.message.isTurnFinalAssistant === true,');
+    // 时间、花费与 More 都必须由该判据统一 gate,不得绕过它单独计算。
+    expect(source).toContain(
+      "const relativeTime = showCompletedActionBar ? formatMessageRelativeTime(item.message.createdAt) : '';",
+    );
+    expect(source).toContain('const turnCost = showCompletedActionBar && ');
+    expect(source).not.toContain('const suppressAssistantActions');
+  });
+
   it('only exposes the More menu on a completed turn boundary', () => {
     const source = readFileSync(resolve(process.cwd(), 'src/session/MessageRenderer.tsx'), 'utf8');
 

--- a/apps/mobile/src/__tests__/messageActions.test.ts
+++ b/apps/mobile/src/__tests__/messageActions.test.ts
@@ -7,6 +7,7 @@ import {
   formatMessageAbsoluteTime,
   formatMessageRelativeTime,
   formatMessageTurnCost,
+  mobileMessageShowsActionBar,
 } from '@/session/messageActions';
 import type { NormalizedRemoteMessage } from '@/session/messageNormalize';
 import type { RemoteMoney, RemoteMoneyCurrency } from '@/session/remoteMoney';
@@ -44,6 +45,42 @@ describe('messageActions', () => {
       canRewind: true,
       isStreaming: true,
     })).toEqual([]);
+  });
+
+  it('hangs the completed action bar only on real turn-final utterances', () => {
+    const base = {
+      hasSystemCard: false,
+      isStreamingAssistant: false,
+      isTurnFinalAssistant: false,
+    };
+
+    // user 消息与本轮收尾正文照常挂。
+    expect(mobileMessageShowsActionBar({ ...base, kind: 'user' })).toBe(true);
+    expect(mobileMessageShowsActionBar({
+      ...base,
+      kind: 'assistant',
+      isTurnFinalAssistant: true,
+    })).toBe(true);
+
+    // turn 中间句不挂;流式 assistant 只显示「生成中」也不挂。
+    expect(mobileMessageShowsActionBar({ ...base, kind: 'assistant' })).toBe(false);
+    expect(mobileMessageShowsActionBar({
+      ...base,
+      kind: 'assistant',
+      isStreamingAssistant: true,
+      isTurnFinalAssistant: true,
+    })).toBe(false);
+
+    // 系统边界卡整行不挂:跨 Agent 切换分隔线(kind='system')、goal 卡(role
+    // assistant 派生),以及「user 行渲染系统卡」被渲染层降级前后的 auto-resume 行。
+    expect(mobileMessageShowsActionBar({ ...base, hasSystemCard: true, kind: 'system' })).toBe(false);
+    expect(mobileMessageShowsActionBar({
+      ...base,
+      hasSystemCard: true,
+      kind: 'assistant',
+      isTurnFinalAssistant: true,
+    })).toBe(false);
+    expect(mobileMessageShowsActionBar({ ...base, hasSystemCard: true, kind: 'user' })).toBe(false);
   });
 
   it('builds desktop-compatible copy text with attachment names', () => {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -141,6 +141,7 @@ import {
   formatMessageRelativeTime,
   formatMessageTurnCost,
   formatModelShortLabel,
+  mobileMessageShowsActionBar,
   writeClipboardText,
   type MobileMessageControlActionId,
   type CopyMessageStatus,
@@ -1558,13 +1559,16 @@ function MessageBubble({
   const isFirstUserMessage = item.message.kind === 'user' && clientId === actions.firstUserMessageClientId;
   const copyText = buildMobileMessageCopyText(item.message);
   const canUseCompletedActions = !isStreamingAssistant;
-  // 操作行只挂在每轮收尾正文(对齐桌面 #456):任务执行过程中的中间句不再逐条
-  // 带一行复制/分叉/时间,消息流更紧凑。user 消息、流式「生成中」状态与正文
-  // 的文本选择(canSelectVisibleText)不受影响。
-  const suppressAssistantActions = item.message.kind === 'assistant'
-    && !isStreamingAssistant
-    && item.message.isTurnFinalAssistant !== true;
-  const showCompletedActionBar = canUseCompletedActions && !suppressAssistantActions;
+  // 操作行只挂在每轮收尾正文、且该行确实是一条发言(判据见
+  // mobileMessageShowsActionBar):中间句不再逐条带复制/分叉/时间,系统边界卡整行
+  // 不挂。user 消息、流式「生成中」状态与正文的文本选择(canSelectVisibleText)
+  // 不受影响。
+  const showCompletedActionBar = mobileMessageShowsActionBar({
+    hasSystemCard: !!item.message.systemCardType,
+    isStreamingAssistant,
+    isTurnFinalAssistant: item.message.isTurnFinalAssistant === true,
+    kind: item.message.kind,
+  });
   const canCopy = showCompletedActionBar && copyText.trim().length > 0;
   const canSelectVisibleText = canUseCompletedActions && copyText.trim().length > 0;
   const relativeTime = showCompletedActionBar ? formatMessageRelativeTime(item.message.createdAt) : '';

--- a/apps/mobile/src/session/messageActions.ts
+++ b/apps/mobile/src/session/messageActions.ts
@@ -36,6 +36,32 @@ export function buildMobileMessageCopyText(message: NormalizedRemoteMessage): st
   return parts.filter((part) => part.trim().length > 0).join('\n\n');
 }
 
+export interface MobileMessageActionBarInput {
+  /** 归一化 kind(「user 行渲染系统卡」形态在渲染层已降级为 'system')。 */
+  kind: NormalizedRemoteMessage['kind'];
+  /** 该行渲染成系统边界卡(agent-switch / auto-resume / goal / slash 命令卡)。 */
+  hasSystemCard: boolean;
+  /** assistant 消息仍在流式输出。 */
+  isStreamingAssistant: boolean;
+  /** assistant 消息是本轮收尾正文(messageRenderModel 标注)。 */
+  isTurnFinalAssistant: boolean;
+}
+
+/**
+ * 消息行是否挂完成态操作条(复制 / 时间 / 花费 / More)。三条规则都对齐桌面:
+ * - 流式 assistant 只显示「生成中」,不挂完成态操作;
+ * - assistant 只有每轮收尾正文挂(桌面 AssistantMessage 的 showActionBar,#456);
+ * - 系统边界卡整行不挂:它不是任何人的发言,没有复制 / 分叉 / 消息锚点 / 发送时间
+ *   语义(桌面 MessageStream 对 systemCardType 提前 return SystemCard,卡片下方
+ *   不存在操作行)。漏掉这条时,手机版跨 Agent 切换的分隔线药丸下会多出一行
+ *   「··· 刚刚」。
+ */
+export function mobileMessageShowsActionBar(input: MobileMessageActionBarInput): boolean {
+  if (input.isStreamingAssistant) return false;
+  if (input.hasSystemCard) return false;
+  return input.kind !== 'assistant' || input.isTurnFinalAssistant;
+}
+
 export function buildMobileMessageControlItems(
   input: MobileMessageControlInput,
 ): MobileMessageControlActionId[] {


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版跨 Agent 聊天时，「已从 Codex 切换到 Claude Code」这条分隔线药丸下面会多出一行孤立的
`··· 刚刚`。

原因：desktop 落库的 `role='agent_switch'` 行在手机侧被归一化成 `kind='system'` +
`systemCardType='agent-switch'`（`messageNormalize.ts`），然后照普通消息进 `MessageBubble`，
挂上了完成态操作条 —— 正文为空所以没有复制图标，只剩 More（`···`）和相对时间，而切换就发生在
本轮，于是显示「刚刚」。桌面侧不会这样：`MessageStream.tsx` 对带 `systemCardType` 的行提前
`return <SystemCard>`，卡片下方根本不存在操作行。

修法是把「该行是否挂操作条」从组件里散落的条件收成纯函数 `mobileMessageShowsActionBar()`，
在原有两条规则（流式 assistant 不挂、assistant 只有每轮收尾正文挂）之外补上第三条「系统边界卡
整行不挂」。时间、花费、复制、More 与 fork / rewind / delete 本来就都由同一个
`showCompletedActionBar` gate，所以一处收口即可，不需要逐个 affordance 打补丁。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（Dash 在手机版实机发现并反馈）
- 本 PR 包含：mobile 消息流里系统边界卡不再渲染操作条；判据抽成可测纯函数并补单测 + 源码契约测试
- 明确不包含：桌面侧渲染（本来就正确）、系统卡自身的视觉与文案、归一化层的 kind / turn 边界语义
- 用户可见变化：手机版跨 Agent 切换分隔线下的孤立 `··· 刚刚` 消失；同款残留行在
  「连接中断，已自动继续」（auto-resume）、goal 卡与 `/context`、`/cost`、`/status` 等本地命令卡
  下也一并消失。这些卡片此前可通过 More 菜单取「复制消息链接 / 添加到对话」，现在与桌面一致地不再提供
- 是否存在 breaking change：无

### UI 变化

手机版消息流：`agent-switch` 分隔线药丸（`⇄ 已从 Codex 切换到 Claude Code · claude-opus-5`）
下方原本多一行左对齐的 `··· 刚刚`，现在分隔线直接接下一条消息。改动是**移除**一个既有渲染节点，
不新增任何颜色、字号、间距或圆角。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §5「Whitespace Philosophy」：*one clear idea per surface*、
    *no surface overstays its welcome*。分隔线的唯一职责是标出引擎切换边界，替它挂一行
    没有语义的时间 + More 属于往同一表面塞第二个概念，删掉即符合。
  - `docs/design-rules/DESIGN.md` §10「Light / Dark Dual-Mode Delivery Gate」：本次不新增也不修改
    任何颜色取值，删除的元信息行原本就走 `colors.textTertiary` 语义 token，两种模式的表现一致
    （见下方「未执行的验证」对目检范围的如实说明）。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/messageActions.test.ts src/__tests__/messageActionDesktopFirst.test.ts src/__tests__/messageActionMenu.test.ts
结果：Test Files 3 passed (3)，Tests 25 passed (25)

pnpm --filter mobile run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm test:unit（仓库根全量单元测试门禁）
结果：GATE_EXIT=0，0 FAIL，含 apps/mobile 与 apps/desktop
```

新增测试：

- `messageActions.test.ts`：`mobileMessageShowsActionBar()` 的真值表 —— user 消息与收尾正文挂；
  turn 中间句与流式 assistant 不挂；`agent-switch`（`kind='system'`）、goal（assistant 派生）、
  auto-resume（`kind='user'`，渲染层降级前后）三种系统卡都不挂。
- `messageActionDesktopFirst.test.ts`：新增源码契约 `never hangs the action bar on a system
  boundary card`，锁住 `showCompletedActionBar` 必须走该判据、且时间与花费不得绕过它单独计算。

### 手工验证

iOS Simulator（iPhone 17 Pro / iOS 27.0）+ 国服 development client `com.xd.cindycn`，加载本分支
Metro：

- `pnpm mobile:sim:whoami -- --region=cn` → `✓ PASS`，8081 归属
  `cindy-mobile-system-card-action-bar`，源码指纹
  `dash/mobile-system-card-action-bar@b1c19aca5+05507cd36e`
- Metro 打印 `iOS Bundled 752ms apps/mobile/index.js (3844 modules)`
- Dash 本人在该实机会话中确认孤立的 `··· 刚刚` 已消失、分隔线显示正常

### 未执行的验证

- **Dark 模式未单独目检**：实机确认在模拟器当时的外观模式下完成，未逐一切换到另一模式复看。
  依据是本次不新增任何颜色取值、只删除一个已走语义 token 的节点；按 DESIGN.md §10，目检为
  best-effort，此处如实标注未覆盖的模式，不把「复用了 themed 样式」当作双模式已验证。
- Android 未验证（该渲染路径与平台无关，无平台分支代码）。
- 未跑 `pnpm test:all`：改动局限于 mobile 渲染层判据 + 测试，全量单测门禁已绿，其余交 CI。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `apps/mobile` 消息流的操作条挂载判定。不动归一化层、不动 turn 边界、不动桌面侧。
  不触碰 `app.json` / `app.config.js` / `apps/mobile/package.json` / `plugins/` / `modules/` /
  `eas.json`，**不改变 runtime fingerprint，不触发冷更**（纯 JS/TS 改动，走 OTA 即可）。
- 回滚 / 降级方式：单 commit，`git revert` 即可完全恢复旧行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（判据的完整理由写在 `mobileMessageShowsActionBar()` 的 JSDoc 里；无需改
      `docs/`）
- [x] 已确认测试结果或说明未执行原因
