### PR TITLE
fix(desktop): remove promotions from model trigger

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerNarrowToolbarContract.test.ts
@@ -31,7 +31,6 @@ describe('composer narrow toolbar contract', () => {
     );
     expect(modelSelectorSource).toContain("'w-[148px] min-w-[72px]'");
     expect(modelSelectorSource).toContain("'w-[64px] min-w-[64px]'");
-    expect(modelSelectorSource).toContain('triggerPromotionLabel && !isCompactToolbar');
     expect(modelSelectorSource).toContain('effortLabel && !isCompactToolbar');
     expect(permissionSelectorSource).toContain(
       'const isIconOnly = iconOnly && !isFieldTrigger;',

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -788,7 +788,7 @@ describe('ModelSelector trigger variants', () => {
     expect(pricingRef.renderCalls).toBe(1);
   });
 
-  it('shows Gateway discount and free promotions in the selected-model trigger', () => {
+  it('does not show Gateway promotions in the selected-model trigger', () => {
     providersRef.providers = [
       {
         id: 'xd',
@@ -846,11 +846,11 @@ describe('ModelSelector trigger variants', () => {
           onProviderChange: vi.fn(),
         }),
       );
-      const discountTrigger = screen.getByRole('button', { name: /Current: Opus 4\.8/ });
-      const discountBadge = within(discountTrigger).getByText('立省 50%');
-      expect(discountBadge.hasAttribute('data-model-promotion-badge')).toBe(true);
-      expect(discountBadge.className).toContain('bg-[var(--accent-cta-bg)]');
-      expect(discountBadge.className).toContain('text-[var(--accent-pure-cta-fg)]');
+      const promotionTrigger = screen.getByRole('button', { name: /Current: Opus 4\.8/ });
+      // 折扣和免费标签已从输入框 trigger 移除，仅在下拉菜单/详情里展示。
+      expect(within(promotionTrigger).queryByText('立省 50%')).toBeNull();
+      expect(within(promotionTrigger).queryByText('限时免费')).toBeNull();
+      expect(promotionTrigger.querySelector('[data-model-promotion-badge]')).toBeNull();
       discounted.unmount();
 
       pricingRef.pricing = {};
@@ -866,8 +866,8 @@ describe('ModelSelector trigger variants', () => {
         }),
       );
       expect(
-        within(screen.getByRole('button', { name: /Current: Sonnet 4\.6/ })).getByText('限时免费'),
-      ).toBeTruthy();
+        within(screen.getByRole('button', { name: /Current: Sonnet 4\.6/ })).queryByText('限时免费'),
+      ).toBeNull();
     } finally {
       providersRef.providers = providersRef.DEFAULT_PROVIDERS;
       pricingRef.pricing = pricingRef.DEFAULT_PRICING;

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1879,28 +1879,6 @@ export function ModelSelector({
     triggerActiveProvider && currentAgentKind
       ? getModel(triggerActiveProvider, modelId, currentAgentKind)?.icon
       : undefined;
-  const triggerPricePresentation = (() => {
-    if (deviceId || activeSourceId !== 'xd' || !triggerActiveProvider || !currentAgentKind)
-      return null;
-    const quote = getModelPriceQuote(pricing, activeSourceId, modelId);
-    if (quote && quote.source !== 'gateway') return null;
-    if (!quote && pricing == null) return null;
-    return modelPricePresentation(
-      quote ?? null,
-      getModel(triggerActiveProvider, modelId, currentAgentKind)?.cost,
-    );
-  })();
-  const triggerPromotionLabel =
-    triggerPricePresentation?.kind === 'free'
-      ? t('newChat.modelSelector.pricing.free')
-      : triggerPricePresentation?.kind === 'priced' &&
-          triggerPricePresentation.discount !== undefined
-        ? t(
-            'newChat.modelSelector.pricing.discount',
-            modelPriceDiscountLabelValues(triggerPricePresentation.discount),
-          )
-        : null;
-  // 断开态同一规则,只是来源取「真实断开来源」(currentProviderId)。
   const disconnectedProvider = currentProviderId
     ? providers.find((p) => p.id === currentProviderId)
     : undefined;
@@ -2137,9 +2115,6 @@ export function ModelSelector({
           >
             {displayLabel}
           </span>
-          {!fallbackOption?.active && triggerPromotionLabel && !isCompactToolbar && (
-            <ModelPromotionBadge>{triggerPromotionLabel}</ModelPromotionBadge>
-          )}
           {effortLabel && !isCompactToolbar && (
             <>
               <span


### PR DESCRIPTION
## 这次改了什么
- 移除输入框底部模型选择 trigger 上的“折扣 / 立省 / 免费”标签。
- 保留下拉菜单和模型详情中的价格、折扣与免费促销信息。
- 更新 trigger 与 composer contract 测试，确保标签不会回到输入框。

## 怎么验证的
- `pnpm test:unit`
- `pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts`
- `pnpm --filter desktop run --if-present typecheck`
- `git diff --check`

## UI 变化
- 输入框模型 trigger 不再展示促销标签；下拉菜单仍保留。

### 引用的设计规范
- `docs/design-rules/DESIGN.md`：本次仅移除既有促销标签，不新增视觉样式或交互状态；Light/Dark 均沿用原有语义 token。

## 风险
- 仅影响 Desktop Renderer 的模型选择器 trigger 展示，不改变价格计算、模型选择或发送逻辑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
