### PR TITLE
fix(maker-core): 移除 DeepSeek 单轮工具调用硬上限

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -200,6 +200,23 @@ function assistantToolUse(id: string, command = 'sleep 999'): Record<string, unk
   };
 }
 
+function assistantTaskOutput(id: string): Record<string, unknown> {
+  return {
+    type: 'assistant',
+    message: {
+      role: 'assistant',
+      content: [
+        {
+          type: 'tool_use',
+          id,
+          name: 'TaskOutput',
+          input: { task_id: 'task-1', block: true, timeout: 30_000 },
+        },
+      ],
+    },
+  };
+}
+
 function userToolResult(id: string, content = 'done'): Record<string, unknown> {
   return {
     type: 'user',
@@ -350,6 +367,30 @@ describe('DeepSeek tool-loop guard runtime integration', () => {
     stream.emit(successResult());
 
     await pumpUntil(() => handle.isTurnRunning?.() === false, 'long DeepSeek turn done');
+    expect(toolLoopError(events)).toBeUndefined();
+    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('真实 SDK 事件流中的稳定 TaskOutput 轮询不会中断 turn', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream(
+      'deepseek/deepseek-v4-flash',
+    );
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    await handle.send({ type: 'user', content: 'wait for the background task' });
+
+    for (let i = 0; i < 30; i += 1) {
+      const id = `toolu_task_output_${i}`;
+      stream.emit(assistantTaskOutput(id));
+      stream.emit(userToolResult(id, 'still running'));
+    }
+    stream.emit(successResult());
+
+    await pumpUntil(() => handle.isTurnRunning?.() === false, 'TaskOutput polling turn done');
     expect(toolLoopError(events)).toBeUndefined();
     expect(fakeQuery.interrupt).not.toHaveBeenCalled();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -141,7 +141,7 @@ async function makeTempDir(): Promise<string> {
   return dir;
 }
 
-async function startSessionWithStream() {
+async function startSessionWithStream(model = 'claude-opus-4-6') {
   const configDir = await makeTempDir();
   process.env.CLAUDE_CONFIG_DIR = configDir;
   const workingDir = await makeTempDir();
@@ -163,7 +163,7 @@ async function startSessionWithStream() {
   const agent = new ClaudeCodeAgent(createDeps());
   const handle = await agent.startSession({
     sessionId: 'session-idle-watchdog',
-    model: 'claude-opus-4-6',
+    model,
     workingDir,
     permissionMode: 'acceptEdits',
   });
@@ -190,22 +190,22 @@ function successResult(): Record<string, unknown> {
   };
 }
 
-function assistantToolUse(id: string): Record<string, unknown> {
+function assistantToolUse(id: string, command = 'sleep 999'): Record<string, unknown> {
   return {
     type: 'assistant',
     message: {
       role: 'assistant',
-      content: [{ type: 'tool_use', id, name: 'Bash', input: { command: 'sleep 999' } }],
+      content: [{ type: 'tool_use', id, name: 'Bash', input: { command } }],
     },
   };
 }
 
-function userToolResult(id: string): Record<string, unknown> {
+function userToolResult(id: string, content = 'done'): Record<string, unknown> {
   return {
     type: 'user',
     message: {
       role: 'user',
-      content: [{ type: 'tool_result', tool_use_id: id, content: 'done' }],
+      content: [{ type: 'tool_result', tool_use_id: id, content }],
     },
   };
 }
@@ -224,6 +224,14 @@ function idleTimeoutError(events: AgentEvent[]): AgentEvent | undefined {
     (e) =>
       e.type === 'error' &&
       (e.data as Record<string, unknown> | undefined)?.reason === 'upstream_response_idle_timeout',
+  );
+}
+
+function toolLoopError(events: AgentEvent[]): AgentEvent | undefined {
+  return events.find(
+    (e) =>
+      e.type === 'error' &&
+      (e.data as Record<string, unknown> | undefined)?.reason === 'tool_use_loop_detected',
   );
 }
 
@@ -317,6 +325,32 @@ describe('upstream-response-idle watchdog suspend awareness', () => {
 
     await vi.advanceTimersByTimeAsync(10 * 60_000);
     expect(idleTimeoutError(events)).toBeUndefined();
+    expect(fakeQuery.interrupt).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+});
+
+describe('DeepSeek tool-loop guard runtime integration', () => {
+  it('真实 SDK 事件流中的 150 次不同调用与结果可以完成同一个 turn', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream(
+      'deepseek/deepseek-v4-flash',
+    );
+
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] });
+    await handle.send({ type: 'user', content: 'analyze 150 different projects' });
+
+    for (let i = 0; i < 150; i += 1) {
+      const id = `toolu_project_${i}`;
+      stream.emit(assistantToolUse(id, `read-project-${i}`));
+      stream.emit(userToolResult(id, `project-update-${i}`));
+    }
+    stream.emit(successResult());
+
+    await pumpUntil(() => handle.isTurnRunning?.() === false, 'long DeepSeek turn done');
+    expect(toolLoopError(events)).toBeUndefined();
     expect(fakeQuery.interrupt).not.toHaveBeenCalled();
 
     vi.useRealTimers();

--- a/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
@@ -334,7 +334,7 @@ describe('upstream-response-idle watchdog suspend awareness', () => {
 });
 
 describe('DeepSeek tool-loop guard runtime integration', () => {
-  it('真实 SDK 事件流中的 150 次不同调用与结果可以完成同一个 turn', async () => {
+  it('真实 SDK 事件流中的 150 次不同调用与空结果可以完成同一个 turn', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream(
       'deepseek/deepseek-v4-flash',
     );
@@ -345,7 +345,7 @@ describe('DeepSeek tool-loop guard runtime integration', () => {
     for (let i = 0; i < 150; i += 1) {
       const id = `toolu_project_${i}`;
       stream.emit(assistantToolUse(id, `read-project-${i}`));
-      stream.emit(userToolResult(id, `project-update-${i}`));
+      stream.emit(userToolResult(id, ''));
     }
     stream.emit(successResult());
 

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2866,9 +2866,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                   if (verdict?.kind === 'hard') {
                     const loopHint = verdict.reason === 'consecutive'
                       ? `连续 ${verdict.count} 次发起完全相同的 ${verdict.toolName} 调用`
-                      : verdict.reason === 'pingpong'
-                        ? `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`
-                        : `最近 ${verdict.count} 次工具调用重复相同调用序列(含 ${verdict.toolName}),且对应结果没有变化`;
+                      : `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`;
                     // 与 upstream-idle watchdog 同款兜底: tool-loop 中断 = "整个 turn 序列已死",
                     // bridge counter 归零避免 filter 吞掉本条 error / counter 永久停在 >0。
                     // 实践上 bridge /compact turn 不用 tool, 该分支难以触发, 归零是防御性一致。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2864,10 +2864,11 @@ export class ClaudeCodeAgent extends BaseAgent {
                 if (turnInFlight) {
                   const verdict = toolLoopGuard?.onToolResult(id, output);
                   if (verdict?.kind === 'hard') {
-                    const loopHint =
-                      verdict.reason === 'consecutive'
-                        ? `连续 ${verdict.count} 次发起完全相同的 ${verdict.toolName} 调用`
-                        : `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`;
+                    const loopHint = verdict.reason === 'consecutive'
+                      ? `连续 ${verdict.count} 次发起完全相同的 ${verdict.toolName} 调用`
+                      : verdict.reason === 'pingpong'
+                        ? `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`
+                        : `最近 ${verdict.count} 次工具调用(含 ${verdict.toolName})没有产生足够的新调用或新结果`;
                     // 与 upstream-idle watchdog 同款兜底: tool-loop 中断 = "整个 turn 序列已死",
                     // bridge counter 归零避免 filter 吞掉本条 error / counter 永久停在 >0。
                     // 实践上 bridge /compact turn 不用 tool, 该分支难以触发, 归零是防御性一致。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2868,7 +2868,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                       ? `连续 ${verdict.count} 次发起完全相同的 ${verdict.toolName} 调用`
                       : verdict.reason === 'pingpong'
                         ? `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`
-                        : `最近 ${verdict.count} 次工具调用一直在有限调用集合(含 ${verdict.toolName})中反复打转`;
+                        : `最近 ${verdict.count} 次工具调用重复相同调用序列(含 ${verdict.toolName}),且对应结果没有变化`;
                     // 与 upstream-idle watchdog 同款兜底: tool-loop 中断 = "整个 turn 序列已死",
                     // bridge counter 归零避免 filter 吞掉本条 error / counter 永久停在 >0。
                     // 实践上 bridge /compact turn 不用 tool, 该分支难以触发, 归零是防御性一致。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2868,7 +2868,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                       ? `连续 ${verdict.count} 次发起完全相同的 ${verdict.toolName} 调用`
                       : verdict.reason === 'pingpong'
                         ? `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`
-                        : `最近 ${verdict.count} 次工具调用(含 ${verdict.toolName})没有产生足够的新调用或新结果`;
+                        : `最近 ${verdict.count} 次工具调用一直在有限调用集合(含 ${verdict.toolName})中反复打转`;
                     // 与 upstream-idle watchdog 同款兜底: tool-loop 中断 = "整个 turn 序列已死",
                     // bridge counter 归零避免 filter 吞掉本条 error / counter 永久停在 >0。
                     // 实践上 bridge /compact turn 不用 tool, 该分支难以触发, 归零是防御性一致。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2867,9 +2867,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                     const loopHint =
                       verdict.reason === 'consecutive'
                         ? `连续 ${verdict.count} 次发起完全相同的 ${verdict.toolName} 调用`
-                        : verdict.reason === 'pingpong'
-                          ? `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`
-                          : `单轮已累计 ${verdict.count} 次工具调用仍未收敛`;
+                        : `最近 ${verdict.count} 次工具调用一直在极少数几种(含 ${verdict.toolName})之间反复打转`;
                     // 与 upstream-idle watchdog 同款兜底: tool-loop 中断 = "整个 turn 序列已死",
                     // bridge counter 归零避免 filter 吞掉本条 error / counter 永久停在 >0。
                     // 实践上 bridge /compact turn 不用 tool, 该分支难以触发, 归零是防御性一致。

--- a/packages/maker-core/src/agents/shared/loop-guard.test.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.test.ts
@@ -63,10 +63,10 @@ describe('ToolLoopGuard', () => {
   });
 
   // ── 第 3 层:长窗口进展代理 ────────────────────────────────────────────────
-  it('三种调用循环会在长窗口判 stagnation,不会逃过短窗口', () => {
+  it('三种调用与对应结果都重复六轮时判 stagnation,不会逃过短窗口', () => {
     const g = new ToolLoopGuard({
       stagnationWindowSize: 18,
-      stagnationCallDistinctLimit: 3,
+      stagnationCycleRepeats: 6,
     });
     for (let i = 0; i < 18; i += 1) {
       const v = feed(
@@ -74,10 +74,43 @@ describe('ToolLoopGuard', () => {
         `id${i}`,
         ['Read', 'Bash', 'WebFetch'][i % 3],
         { target: `fixed-${i % 3}` },
-        `changing-output-${i}`,
+        `stable-output-${i % 3}`,
       );
       if (i < 17) expect(v.kind).toBe('ok');
       else expect(v).toMatchObject({ kind: 'hard', reason: 'stagnation', count: 18 });
+    }
+  });
+
+  it('九种调用循环也会按重复序列判 stagnation,不依赖固定 distinct 阈值', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 54; i += 1) {
+      const position = i % 9;
+      const v = feed(
+        g,
+        `id${i}`,
+        'TaskOutput',
+        { taskId: `task-${position}` },
+        `stable-status-${position}`,
+      );
+      if (i < 53) expect(v.kind).toBe('ok');
+      else expect(v).toMatchObject({ kind: 'hard', reason: 'stagnation', count: 54 });
+    }
+  });
+
+  it('固定八个目标轮询时只要对应结果持续推进就不判 stagnation', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 48; i += 1) {
+      const position = i % 8;
+      const round = Math.floor(i / 8);
+      expect(
+        feed(
+          g,
+          `id${i}`,
+          'TaskOutput',
+          { taskId: `task-${position}` },
+          `progress-${position}-${round}`,
+        ).kind,
+      ).toBe('ok');
     }
   });
 

--- a/packages/maker-core/src/agents/shared/loop-guard.test.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.test.ts
@@ -62,10 +62,42 @@ describe('ToolLoopGuard', () => {
     }
   });
 
+  // ── 第 3 层:长窗口进展代理 ────────────────────────────────────────────────
+  it('三种调用循环会在长窗口判 stagnation,不会逃过短窗口', () => {
+    const g = new ToolLoopGuard({
+      stagnationWindowSize: 18,
+      stagnationCallDistinctLimit: 3,
+    });
+    for (let i = 0; i < 18; i += 1) {
+      const v = feed(
+        g,
+        `id${i}`,
+        ['Read', 'Bash', 'WebFetch'][i % 3],
+        { target: `fixed-${i % 3}` },
+        `changing-output-${i}`,
+      );
+      if (i < 17) expect(v.kind).toBe('ok');
+      else expect(v).toMatchObject({ kind: 'hard', reason: 'stagnation', count: 18 });
+    }
+  });
+
+  it('参数持续变化但结果高度重复时判 stagnation', () => {
+    const g = new ToolLoopGuard({
+      stagnationWindowSize: 18,
+      stagnationCallDistinctLimit: 3,
+      stagnationOutputDistinctLimit: 2,
+    });
+    for (let i = 0; i < 18; i += 1) {
+      const v = feed(g, `id${i}`, 'Read', { file: `missing-${i}.ts` }, 'not found');
+      if (i < 17) expect(v.kind).toBe('ok');
+      else expect(v).toMatchObject({ kind: 'hard', reason: 'stagnation', count: 18 });
+    }
+  });
+
   it('超过 100 次且每次调用都不同的合法长任务不误判', () => {
     const g = new ToolLoopGuard();
     for (let i = 0; i < 250; i += 1) {
-      expect(feed(g, `id${i}`, 'Read', { file: `f${i}.ts` }, 'content').kind).toBe('ok');
+      expect(feed(g, `id${i}`, 'Read', { file: `f${i}.ts` }, `content-${i}`).kind).toBe('ok');
     }
   });
 

--- a/packages/maker-core/src/agents/shared/loop-guard.test.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.test.ts
@@ -62,25 +62,11 @@ describe('ToolLoopGuard', () => {
     }
   });
 
-  it('每次调用都不同(合法长任务)不误判', () => {
+  it('超过 100 次且每次调用都不同的合法长任务不误判', () => {
     const g = new ToolLoopGuard();
-    for (let i = 0; i < 30; i += 1) {
+    for (let i = 0; i < 250; i += 1) {
       expect(feed(g, `id${i}`, 'Read', { file: `f${i}.ts` }, 'content').kind).toBe('ok');
     }
-  });
-
-  // ── 第 3 层: 单 turn tool result 硬上限 ───────────────────────────────────
-  it('在 turn 内调用总数超硬上限时判 turn-cap(任何形态兜底)', () => {
-    // 放宽前两层, 只验证兜底: 每次 input 都不同, 不会触发 consecutive / pingpong
-    const g = new ToolLoopGuard({ turnHardCap: 5, windowSize: 1000, consecutiveLimit: 1000 });
-    for (let i = 0; i < 5; i += 1) {
-      expect(feed(g, `id${i}`, 'Read', { file: `f${i}` }, `o${i}`).kind).toBe('ok');
-    }
-    expect(feed(g, 'id5', 'Read', { file: 'f5' }, 'o5')).toMatchObject({
-      kind: 'hard',
-      reason: 'turn-cap',
-      count: 6,
-    });
   });
 
   // ── 配对 / 放行 ───────────────────────────────────────────────────────────

--- a/packages/maker-core/src/agents/shared/loop-guard.test.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.test.ts
@@ -62,66 +62,65 @@ describe('ToolLoopGuard', () => {
     }
   });
 
-  // ── 第 3 层:长窗口进展代理 ────────────────────────────────────────────────
-  it('三种调用与对应结果都重复六轮时判 stagnation,不会逃过短窗口', () => {
-    const g = new ToolLoopGuard({
-      stagnationWindowSize: 18,
-      stagnationCycleRepeats: 6,
-    });
-    for (let i = 0; i < 18; i += 1) {
-      const v = feed(
-        g,
-        `id${i}`,
-        ['Read', 'Bash', 'WebFetch'][i % 3],
-        { target: `fixed-${i % 3}` },
-        `stable-output-${i % 3}`,
-      );
-      if (i < 17) expect(v.kind).toBe('ok');
-      else expect(v).toMatchObject({ kind: 'hard', reason: 'stagnation', count: 18 });
-    }
-  });
-
-  it('九种调用循环也会按重复序列判 stagnation,不依赖固定 distinct 阈值', () => {
+  // ── 合法长 turn / 原生轮询工具 ───────────────────────────────────────────
+  it('TaskOutput 状态长期不变仍放行,不会被通用重复判据中断', () => {
     const g = new ToolLoopGuard();
-    for (let i = 0; i < 54; i += 1) {
-      const position = i % 9;
-      const v = feed(
-        g,
-        `id${i}`,
-        'TaskOutput',
-        { taskId: `task-${position}` },
-        `stable-status-${position}`,
-      );
-      if (i < 53) expect(v.kind).toBe('ok');
-      else expect(v).toMatchObject({ kind: 'hard', reason: 'stagnation', count: 54 });
-    }
-  });
-
-  it('固定八个目标轮询时只要对应结果持续推进就不判 stagnation', () => {
-    const g = new ToolLoopGuard();
-    for (let i = 0; i < 48; i += 1) {
-      const position = i % 8;
-      const round = Math.floor(i / 8);
+    for (let i = 0; i < 250; i += 1) {
       expect(
         feed(
           g,
           `id${i}`,
           'TaskOutput',
-          { taskId: `task-${position}` },
-          `progress-${position}-${round}`,
+          { task_id: 'task-1', block: true, timeout: 30_000 },
+          'still running',
         ).kind,
       ).toBe('ok');
     }
   });
 
-  it('参数持续变化时即使结果高度重复也不判 stagnation', () => {
+  it('TaskOutput 会切断普通工具在等待前后的重复累计', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 3; i += 1) {
+      expect(feed(g, `before-${i}`, 'Bash', { cmd: 'ls' }, 'same').kind).toBe('ok');
+    }
+    expect(
+      feed(
+        g,
+        'poll',
+        'TaskOutput',
+        { task_id: 'task-1', block: true, timeout: 30_000 },
+        'still running',
+      ).kind,
+    ).toBe('ok');
+    for (let i = 0; i < 3; i += 1) {
+      expect(feed(g, `after-${i}`, 'Bash', { cmd: 'ls' }, 'same').kind).toBe('ok');
+    }
+  });
+
+  it('三十三项固定序列不会被有限窗口冒充为通用硬上限', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 198; i += 1) {
+      const position = i % 33;
+      expect(
+        feed(
+          g,
+          `id${i}`,
+          'Read',
+          { file: `project-${position}.json` },
+          `stable-${position}`,
+        ).kind,
+      ).toBe('ok');
+    }
+  });
+
+  it('参数持续变化时即使结果高度重复也不判 hard', () => {
     const g = new ToolLoopGuard();
     for (let i = 0; i < 250; i += 1) {
       expect(feed(g, `id${i}`, 'Read', { file: `missing-${i}.ts` }, 'not found').kind).toBe('ok');
     }
   });
 
-  it('参数持续变化且结果为空或纯空白时也不判 stagnation', () => {
+  it('参数持续变化且结果为空或纯空白时也不判 hard', () => {
     const g = new ToolLoopGuard();
     for (let i = 0; i < 250; i += 1) {
       const output = i % 2 === 0 ? '' : '   ';

--- a/packages/maker-core/src/agents/shared/loop-guard.test.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.test.ts
@@ -81,23 +81,18 @@ describe('ToolLoopGuard', () => {
     }
   });
 
-  it('参数持续变化但结果高度重复时判 stagnation', () => {
-    const g = new ToolLoopGuard({
-      stagnationWindowSize: 18,
-      stagnationCallDistinctLimit: 3,
-      stagnationOutputDistinctLimit: 2,
-    });
-    for (let i = 0; i < 18; i += 1) {
-      const v = feed(g, `id${i}`, 'Read', { file: `missing-${i}.ts` }, 'not found');
-      if (i < 17) expect(v.kind).toBe('ok');
-      else expect(v).toMatchObject({ kind: 'hard', reason: 'stagnation', count: 18 });
+  it('参数持续变化时即使结果高度重复也不判 stagnation', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 250; i += 1) {
+      expect(feed(g, `id${i}`, 'Read', { file: `missing-${i}.ts` }, 'not found').kind).toBe('ok');
     }
   });
 
-  it('超过 100 次且每次调用都不同的合法长任务不误判', () => {
+  it('参数持续变化且结果为空或纯空白时也不判 stagnation', () => {
     const g = new ToolLoopGuard();
     for (let i = 0; i < 250; i += 1) {
-      expect(feed(g, `id${i}`, 'Read', { file: `f${i}.ts` }, `content-${i}`).kind).toBe('ok');
+      const output = i % 2 === 0 ? '' : '   ';
+      expect(feed(g, `id${i}`, 'Write', { file: `f${i}.ts` }, output).kind).toBe('ok');
     }
   });
 

--- a/packages/maker-core/src/agents/shared/loop-guard.test.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.test.ts
@@ -78,22 +78,47 @@ describe('ToolLoopGuard', () => {
     }
   });
 
-  it('TaskOutput 会切断普通工具在等待前后的重复累计', () => {
+  it('TaskOutput 不会隐藏穿插在轮询之间的连续普通工具循环', () => {
     const g = new ToolLoopGuard();
-    for (let i = 0; i < 3; i += 1) {
-      expect(feed(g, `before-${i}`, 'Bash', { cmd: 'ls' }, 'same').kind).toBe('ok');
+    for (let i = 0; i < 4; i += 1) {
+      const ordinary = feed(g, `bash-${i}`, 'Bash', { cmd: 'ls' }, 'same');
+      if (i < 3) expect(ordinary.kind).toBe('ok');
+      else expect(ordinary).toMatchObject({ kind: 'hard', reason: 'consecutive' });
+
+      expect(
+        feed(
+          g,
+          `poll-${i}`,
+          'TaskOutput',
+          { task_id: 'task-1', block: true, timeout: 30_000 },
+          'still running',
+        ).kind,
+      ).toBe('ok');
     }
-    expect(
-      feed(
+  });
+
+  it('TaskOutput 不会隐藏穿插在轮询之间的 ABAB 普通工具循环', () => {
+    const g = new ToolLoopGuard();
+    for (let i = 0; i < 12; i += 1) {
+      const ordinary = feed(
         g,
-        'poll',
-        'TaskOutput',
-        { task_id: 'task-1', block: true, timeout: 30_000 },
-        'still running',
-      ).kind,
-    ).toBe('ok');
-    for (let i = 0; i < 3; i += 1) {
-      expect(feed(g, `after-${i}`, 'Bash', { cmd: 'ls' }, 'same').kind).toBe('ok');
+        `ordinary-${i}`,
+        'Bash',
+        i % 2 === 0 ? { cmd: 'python run.py' } : { cmd: 'p4 sync' },
+        `output-${i}`,
+      );
+      if (i < 11) expect(ordinary.kind).toBe('ok');
+      else expect(ordinary).toMatchObject({ kind: 'hard', reason: 'pingpong' });
+
+      expect(
+        feed(
+          g,
+          `poll-${i}`,
+          'TaskOutput',
+          { task_id: 'task-1', block: true, timeout: 30_000 },
+          'still running',
+        ).kind,
+      ).toBe('ok');
     }
   });
 

--- a/packages/maker-core/src/agents/shared/loop-guard.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.ts
@@ -16,14 +16,12 @@ const DEFAULT_WINDOW_SIZE = 12;
 /** 第 2 层:窗口填满后, distinct 指纹数 ≤ 此值即判循环(2 = 一直在 ≤2 种调用里转)。 */
 const DEFAULT_WINDOW_DISTINCT_LIMIT = 2;
 /**
- * 第 3 层(进展代理):更长的窗口,用于识别短窗口刻意放过的 3+ 调用循环,以及
- * 参数持续变化但结果高度重复的循环。48 次约等于最多 8 种调用重复 6 轮。
+ * 第 3 层(进展代理):更长的窗口,用于识别短窗口刻意放过的 3+ 调用循环。
+ * 48 次约等于最多 8 种调用重复 6 轮。
  */
 const DEFAULT_STAGNATION_WINDOW_SIZE = 48;
 /** 第 3 层:长窗口内 name+input 指纹不超过此值,视为有限调用集反复循环。 */
 const DEFAULT_STAGNATION_CALL_DISTINCT_LIMIT = 8;
-/** 第 3 层:长窗口内结果指纹不超过此值,视为参数变化但没有获得新结果。 */
-const DEFAULT_STAGNATION_OUTPUT_DISTINCT_LIMIT = 4;
 
 interface PendingToolUse {
   name: string;
@@ -41,8 +39,6 @@ export interface ToolLoopGuardOptions {
   stagnationWindowSize?: number;
   /** 第 3 层:窗口内 distinct name+input 指纹 ≤ 此值判停滞。 */
   stagnationCallDistinctLimit?: number;
-  /** 第 3 层:窗口内 distinct output 指纹 ≤ 此值判停滞。 */
-  stagnationOutputDistinctLimit?: number;
 }
 
 /** 命中哪一层判据。consecutive=机械重复 / pingpong=短循环 / stagnation=长窗口无进展。 */
@@ -58,7 +54,7 @@ export type ToolLoopGuardVerdict =
  * 只在工具结果返回后判断。任一层命中即返回 hard, 由调用方决定如何中断:
  *   1. 连续完全相同(name+input+output)—— 快路径, 零误判;
  *   2. name+input 滑动窗口多样性坍缩 —— 抓 ABAB 交替 / output 易变的重复;
- *   3. 长窗口里调用或结果多样性坍缩 —— 抓 3+ 调用循环 / 参数漂移循环;
+ *   3. 长窗口里调用多样性坍缩 —— 抓 3+ 调用循环;
  *
  * 类本身不依赖 Electron / SDK / provider, 也不做 IO;调用方决定何时启用和如何中断。
  */
@@ -68,7 +64,6 @@ export class ToolLoopGuard {
   readonly windowDistinctLimit: number;
   readonly stagnationWindowSize: number;
   readonly stagnationCallDistinctLimit: number;
-  readonly stagnationOutputDistinctLimit: number;
 
   private pendingToolUses = new Map<string, PendingToolUse>();
 
@@ -79,9 +74,8 @@ export class ToolLoopGuard {
   // 第 2 层状态: 最近 windowSize 个 name+input 指纹
   private callWindow: string[] = [];
 
-  // 第 3 层状态:更长窗口里的调用与结果指纹,作为“是否获得新证据”的保守代理。
+  // 第 3 层状态:更长窗口里的调用指纹,用于识别更大的有限调用循环。
   private stagnationCallWindow: string[] = [];
-  private stagnationOutputWindow: string[] = [];
 
   constructor(options: ToolLoopGuardOptions = {}) {
     this.consecutiveLimit = options.consecutiveLimit ?? DEFAULT_CONSECUTIVE_LIMIT;
@@ -91,8 +85,6 @@ export class ToolLoopGuard {
       options.stagnationWindowSize ?? DEFAULT_STAGNATION_WINDOW_SIZE;
     this.stagnationCallDistinctLimit =
       options.stagnationCallDistinctLimit ?? DEFAULT_STAGNATION_CALL_DISTINCT_LIMIT;
-    this.stagnationOutputDistinctLimit =
-      options.stagnationOutputDistinctLimit ?? DEFAULT_STAGNATION_OUTPUT_DISTINCT_LIMIT;
   }
 
   /**
@@ -106,7 +98,7 @@ export class ToolLoopGuard {
   }
 
   /**
-   * 工具结果到达后配对并按两层判据判断。没有配到完整 tool_use 时直接放行,
+   * 工具结果到达后配对并按三层判据判断。没有配到完整 tool_use 时直接放行,
    * 避免用不完整信息误判。
    */
   onToolResult(toolUseId: string, output: string): ToolLoopGuardVerdict {
@@ -147,21 +139,16 @@ export class ToolLoopGuard {
       }
     }
 
-    // 第 3 层:长窗口进展代理。不能用绝对调用次数判断——批量读取数百个项目是合法任务;
-    // 只有调用集合反复复用,或参数虽在变化但结果高度重复时,才认为没有获得新证据。
+    // 第 3 层:长窗口进展代理。不能用绝对调用次数或低输出多样性判断——批量读取、
+    // 无 stdout 的成功命令、Write / MCP null result 都是合法任务;只有调用集合本身
+    // 反复复用时才认为停滞。参数不同即视为在处理新目标,不猜测工具语义。
     this.stagnationCallWindow.push(callFingerprint);
-    this.stagnationOutputWindow.push(fingerprintToolOutput(output));
     if (this.stagnationCallWindow.length > this.stagnationWindowSize) {
       this.stagnationCallWindow.shift();
-      this.stagnationOutputWindow.shift();
     }
     if (this.stagnationCallWindow.length >= this.stagnationWindowSize) {
       const distinctCalls = new Set(this.stagnationCallWindow).size;
-      const distinctOutputs = new Set(this.stagnationOutputWindow).size;
-      if (
-        distinctCalls <= this.stagnationCallDistinctLimit ||
-        distinctOutputs <= this.stagnationOutputDistinctLimit
-      ) {
+      if (distinctCalls <= this.stagnationCallDistinctLimit) {
         return {
           kind: 'hard',
           reason: 'stagnation',
@@ -181,12 +168,7 @@ export class ToolLoopGuard {
     this.consecutiveStreak = 0;
     this.callWindow = [];
     this.stagnationCallWindow = [];
-    this.stagnationOutputWindow = [];
   }
-}
-
-function fingerprintToolOutput(output: string): string {
-  return createHash('sha256').update('output:').update(output).digest('hex');
 }
 
 /**

--- a/packages/maker-core/src/agents/shared/loop-guard.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.ts
@@ -17,7 +17,8 @@ const DEFAULT_WINDOW_SIZE = 12;
 const DEFAULT_WINDOW_DISTINCT_LIMIT = 2;
 /**
  * TaskOutput 是 SDK 明确定义的等待/轮询工具。状态文本不变只代表任务仍在等待,
- * 不能作为模型死循环证据;它也会切断前后的普通调用序列,避免跨等待阶段累计。
+ * 不能作为模型死循环证据。它本身不进入指纹,但也不重置普通工具的轨迹,
+ * 避免模型通过在重复调用间插入轮询来绕过检测。
  */
 const LOOP_GUARD_EXEMPT_TOOL_NAMES = new Set(['TaskOutput']);
 
@@ -92,10 +93,7 @@ export class ToolLoopGuard {
     const toolUse = this.pendingToolUses.get(toolUseId);
     this.pendingToolUses.delete(toolUseId);
     if (!toolUse) return { kind: 'ok' };
-    if (LOOP_GUARD_EXEMPT_TOOL_NAMES.has(toolUse.name)) {
-      this.resetPatternState();
-      return { kind: 'ok' };
-    }
+    if (LOOP_GUARD_EXEMPT_TOOL_NAMES.has(toolUse.name)) return { kind: 'ok' };
 
     // 第 1 层: 连续 name+input+output 完全相同
     const fullFingerprint = fingerprintToolCall(toolUse.name, toolUse.input, output);

--- a/packages/maker-core/src/agents/shared/loop-guard.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.ts
@@ -16,16 +16,21 @@ const DEFAULT_WINDOW_SIZE = 12;
 /** 第 2 层:窗口填满后, distinct 指纹数 ≤ 此值即判循环(2 = 一直在 ≤2 种调用里转)。 */
 const DEFAULT_WINDOW_DISTINCT_LIMIT = 2;
 /**
- * 第 3 层(进展代理):更长的窗口,用于识别短窗口刻意放过的 3+ 调用循环。
- * 48 次约等于最多 8 种调用重复 6 轮。
+ * 第 3 层(进展代理):保留足够长的历史,用于识别短窗口刻意放过的 3+ 调用循环。
+ * 192 次可覆盖最多 32 种调用重复 6 轮,同时保持内存有界。
  */
-const DEFAULT_STAGNATION_WINDOW_SIZE = 48;
-/** 第 3 层:长窗口内 name+input 指纹不超过此值,视为有限调用集反复循环。 */
-const DEFAULT_STAGNATION_CALL_DISTINCT_LIMIT = 8;
+const DEFAULT_STAGNATION_WINDOW_SIZE = 192;
+/** 第 3 层:同一调用序列及其对应结果连续重复多少轮才判停滞。 */
+const DEFAULT_STAGNATION_CYCLE_REPEATS = 6;
 
 interface PendingToolUse {
   name: string;
   input: unknown;
+}
+
+interface CompletedToolCall {
+  callFingerprint: string;
+  outputFingerprint: string;
 }
 
 export interface ToolLoopGuardOptions {
@@ -37,8 +42,8 @@ export interface ToolLoopGuardOptions {
   windowDistinctLimit?: number;
   /** 第 3 层:进展代理窗口大小。 */
   stagnationWindowSize?: number;
-  /** 第 3 层:窗口内 distinct name+input 指纹 ≤ 此值判停滞。 */
-  stagnationCallDistinctLimit?: number;
+  /** 第 3 层:同一调用序列及其对应结果连续重复多少轮才判停滞。 */
+  stagnationCycleRepeats?: number;
 }
 
 /** 命中哪一层判据。consecutive=机械重复 / pingpong=短循环 / stagnation=长窗口无进展。 */
@@ -54,7 +59,7 @@ export type ToolLoopGuardVerdict =
  * 只在工具结果返回后判断。任一层命中即返回 hard, 由调用方决定如何中断:
  *   1. 连续完全相同(name+input+output)—— 快路径, 零误判;
  *   2. name+input 滑动窗口多样性坍缩 —— 抓 ABAB 交替 / output 易变的重复;
- *   3. 长窗口里调用多样性坍缩 —— 抓 3+ 调用循环;
+ *   3. 同一调用序列重复多轮且对应结果不变 —— 抓真正无进展的 3+ 调用循环;
  *
  * 类本身不依赖 Electron / SDK / provider, 也不做 IO;调用方决定何时启用和如何中断。
  */
@@ -63,7 +68,7 @@ export class ToolLoopGuard {
   readonly windowSize: number;
   readonly windowDistinctLimit: number;
   readonly stagnationWindowSize: number;
-  readonly stagnationCallDistinctLimit: number;
+  readonly stagnationCycleRepeats: number;
 
   private pendingToolUses = new Map<string, PendingToolUse>();
 
@@ -74,8 +79,8 @@ export class ToolLoopGuard {
   // 第 2 层状态: 最近 windowSize 个 name+input 指纹
   private callWindow: string[] = [];
 
-  // 第 3 层状态:更长窗口里的调用指纹,用于识别更大的有限调用循环。
-  private stagnationCallWindow: string[] = [];
+  // 第 3 层状态:更长窗口里的调用与结果指纹,用于区分固定目标轮询和真正无进展。
+  private stagnationWindow: CompletedToolCall[] = [];
 
   constructor(options: ToolLoopGuardOptions = {}) {
     this.consecutiveLimit = options.consecutiveLimit ?? DEFAULT_CONSECUTIVE_LIMIT;
@@ -83,8 +88,8 @@ export class ToolLoopGuard {
     this.windowDistinctLimit = options.windowDistinctLimit ?? DEFAULT_WINDOW_DISTINCT_LIMIT;
     this.stagnationWindowSize =
       options.stagnationWindowSize ?? DEFAULT_STAGNATION_WINDOW_SIZE;
-    this.stagnationCallDistinctLimit =
-      options.stagnationCallDistinctLimit ?? DEFAULT_STAGNATION_CALL_DISTINCT_LIMIT;
+    this.stagnationCycleRepeats =
+      options.stagnationCycleRepeats ?? DEFAULT_STAGNATION_CYCLE_REPEATS;
   }
 
   /**
@@ -139,23 +144,26 @@ export class ToolLoopGuard {
       }
     }
 
-    // 第 3 层:长窗口进展代理。不能用绝对调用次数或低输出多样性判断——批量读取、
-    // 无 stdout 的成功命令、Write / MCP null result 都是合法任务;只有调用集合本身
-    // 反复复用时才认为停滞。参数不同即视为在处理新目标,不猜测工具语义。
-    this.stagnationCallWindow.push(callFingerprint);
-    if (this.stagnationCallWindow.length > this.stagnationWindowSize) {
-      this.stagnationCallWindow.shift();
+    // 第 3 层:长窗口进展代理。固定目标轮询、批量读取、无 stdout 的成功命令都是
+    // 合法任务;只有同一调用序列重复多轮,且每个位置的对应结果也没有变化,才认为停滞。
+    this.stagnationWindow.push({
+      callFingerprint,
+      outputFingerprint: fingerprintToolOutput(output),
+    });
+    if (this.stagnationWindow.length > this.stagnationWindowSize) {
+      this.stagnationWindow.shift();
     }
-    if (this.stagnationCallWindow.length >= this.stagnationWindowSize) {
-      const distinctCalls = new Set(this.stagnationCallWindow).size;
-      if (distinctCalls <= this.stagnationCallDistinctLimit) {
-        return {
-          kind: 'hard',
-          reason: 'stagnation',
-          count: this.stagnationCallWindow.length,
-          toolName: toolUse.name,
-        };
-      }
+    const stagnantCycleLength = findRepeatedStagnantCycleLength(
+      this.stagnationWindow,
+      this.stagnationCycleRepeats,
+    );
+    if (stagnantCycleLength !== null) {
+      return {
+        kind: 'hard',
+        reason: 'stagnation',
+        count: stagnantCycleLength * this.stagnationCycleRepeats,
+        toolName: toolUse.name,
+      };
     }
 
     return { kind: 'ok' };
@@ -167,8 +175,45 @@ export class ToolLoopGuard {
     this.lastFullFingerprint = null;
     this.consecutiveStreak = 0;
     this.callWindow = [];
-    this.stagnationCallWindow = [];
+    this.stagnationWindow = [];
   }
+}
+
+/**
+ * 检查历史末尾是否由同一段 3+ 调用序列重复组成,且每轮对应结果完全相同。
+ * 1 个调用的机械重复由第 1 层处理,2 个调用的往返由第 2 层处理。
+ */
+function findRepeatedStagnantCycleLength(
+  history: CompletedToolCall[],
+  repeats: number,
+): number | null {
+  if (repeats < 2) return null;
+
+  const maxCycleLength = Math.floor(history.length / repeats);
+  for (let cycleLength = 3; cycleLength <= maxCycleLength; cycleLength += 1) {
+    const start = history.length - cycleLength * repeats;
+    let matches = true;
+
+    for (let repeat = 1; repeat < repeats && matches; repeat += 1) {
+      for (let offset = 0; offset < cycleLength; offset += 1) {
+        const baseline = history[start + offset];
+        const candidate = history[start + repeat * cycleLength + offset];
+        if (
+          !baseline ||
+          !candidate ||
+          baseline.callFingerprint !== candidate.callFingerprint ||
+          baseline.outputFingerprint !== candidate.outputFingerprint
+        ) {
+          matches = false;
+          break;
+        }
+      }
+    }
+
+    if (matches) return cycleLength;
+  }
+
+  return null;
 }
 
 /**
@@ -186,6 +231,10 @@ function fingerprintToolCall(toolName: string, input: unknown, output: string | 
     hash.update(output);
   }
   return hash.digest('hex');
+}
+
+function fingerprintToolOutput(output: string): string {
+  return createHash('sha256').update(output).digest('hex');
 }
 
 /**

--- a/packages/maker-core/src/agents/shared/loop-guard.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.ts
@@ -16,21 +16,14 @@ const DEFAULT_WINDOW_SIZE = 12;
 /** 第 2 层:窗口填满后, distinct 指纹数 ≤ 此值即判循环(2 = 一直在 ≤2 种调用里转)。 */
 const DEFAULT_WINDOW_DISTINCT_LIMIT = 2;
 /**
- * 第 3 层(进展代理):保留足够长的历史,用于识别短窗口刻意放过的 3+ 调用循环。
- * 192 次可覆盖最多 32 种调用重复 6 轮,同时保持内存有界。
+ * TaskOutput 是 SDK 明确定义的等待/轮询工具。状态文本不变只代表任务仍在等待,
+ * 不能作为模型死循环证据;它也会切断前后的普通调用序列,避免跨等待阶段累计。
  */
-const DEFAULT_STAGNATION_WINDOW_SIZE = 192;
-/** 第 3 层:同一调用序列及其对应结果连续重复多少轮才判停滞。 */
-const DEFAULT_STAGNATION_CYCLE_REPEATS = 6;
+const LOOP_GUARD_EXEMPT_TOOL_NAMES = new Set(['TaskOutput']);
 
 interface PendingToolUse {
   name: string;
   input: unknown;
-}
-
-interface CompletedToolCall {
-  callFingerprint: string;
-  outputFingerprint: string;
 }
 
 export interface ToolLoopGuardOptions {
@@ -40,26 +33,24 @@ export interface ToolLoopGuardOptions {
   windowSize?: number;
   /** 第 2 层:窗口内 distinct 指纹 ≤ 此值判循环。 */
   windowDistinctLimit?: number;
-  /** 第 3 层:进展代理窗口大小。 */
-  stagnationWindowSize?: number;
-  /** 第 3 层:同一调用序列及其对应结果连续重复多少轮才判停滞。 */
-  stagnationCycleRepeats?: number;
 }
 
-/** 命中哪一层判据。consecutive=机械重复 / pingpong=短循环 / stagnation=长窗口无进展。 */
-export type ToolLoopReason = 'consecutive' | 'pingpong' | 'stagnation';
+/** 命中哪一层判据。consecutive=机械重复 / pingpong=短循环。 */
+export type ToolLoopReason = 'consecutive' | 'pingpong';
 
 export type ToolLoopGuardVerdict =
   | { kind: 'ok' }
   | { kind: 'hard'; reason: ToolLoopReason; count: number; toolName: string };
 
 /**
- * Result-aware tool loop detector(三层防御)。
+ * Result-aware tool loop detector(两层防御)。
  *
- * 只在工具结果返回后判断。任一层命中即返回 hard, 由调用方决定如何中断:
+ * 只在非轮询工具结果返回后判断。任一层命中即返回 hard, 由调用方决定如何中断:
  *   1. 连续完全相同(name+input+output)—— 快路径, 零误判;
  *   2. name+input 滑动窗口多样性坍缩 —— 抓 ABAB 交替 / output 易变的重复;
- *   3. 同一调用序列重复多轮且对应结果不变 —— 抓真正无进展的 3+ 调用循环;
+ *
+ * 不按调用总数或任意长度的重复序列硬中断:仅凭工具 trace 无法区分合法批处理、
+ * 稳定状态轮询与死循环,有限窗口也只能移动误判/漏判边界。
  *
  * 类本身不依赖 Electron / SDK / provider, 也不做 IO;调用方决定何时启用和如何中断。
  */
@@ -67,8 +58,6 @@ export class ToolLoopGuard {
   readonly consecutiveLimit: number;
   readonly windowSize: number;
   readonly windowDistinctLimit: number;
-  readonly stagnationWindowSize: number;
-  readonly stagnationCycleRepeats: number;
 
   private pendingToolUses = new Map<string, PendingToolUse>();
 
@@ -79,17 +68,10 @@ export class ToolLoopGuard {
   // 第 2 层状态: 最近 windowSize 个 name+input 指纹
   private callWindow: string[] = [];
 
-  // 第 3 层状态:更长窗口里的调用与结果指纹,用于区分固定目标轮询和真正无进展。
-  private stagnationWindow: CompletedToolCall[] = [];
-
   constructor(options: ToolLoopGuardOptions = {}) {
     this.consecutiveLimit = options.consecutiveLimit ?? DEFAULT_CONSECUTIVE_LIMIT;
     this.windowSize = options.windowSize ?? DEFAULT_WINDOW_SIZE;
     this.windowDistinctLimit = options.windowDistinctLimit ?? DEFAULT_WINDOW_DISTINCT_LIMIT;
-    this.stagnationWindowSize =
-      options.stagnationWindowSize ?? DEFAULT_STAGNATION_WINDOW_SIZE;
-    this.stagnationCycleRepeats =
-      options.stagnationCycleRepeats ?? DEFAULT_STAGNATION_CYCLE_REPEATS;
   }
 
   /**
@@ -103,13 +85,17 @@ export class ToolLoopGuard {
   }
 
   /**
-   * 工具结果到达后配对并按三层判据判断。没有配到完整 tool_use 时直接放行,
+   * 工具结果到达后配对并按两层判据判断。没有配到完整 tool_use 时直接放行,
    * 避免用不完整信息误判。
    */
   onToolResult(toolUseId: string, output: string): ToolLoopGuardVerdict {
     const toolUse = this.pendingToolUses.get(toolUseId);
     this.pendingToolUses.delete(toolUseId);
     if (!toolUse) return { kind: 'ok' };
+    if (LOOP_GUARD_EXEMPT_TOOL_NAMES.has(toolUse.name)) {
+      this.resetPatternState();
+      return { kind: 'ok' };
+    }
 
     // 第 1 层: 连续 name+input+output 完全相同
     const fullFingerprint = fingerprintToolCall(toolUse.name, toolUse.input, output);
@@ -144,76 +130,20 @@ export class ToolLoopGuard {
       }
     }
 
-    // 第 3 层:长窗口进展代理。固定目标轮询、批量读取、无 stdout 的成功命令都是
-    // 合法任务;只有同一调用序列重复多轮,且每个位置的对应结果也没有变化,才认为停滞。
-    this.stagnationWindow.push({
-      callFingerprint,
-      outputFingerprint: fingerprintToolOutput(output),
-    });
-    if (this.stagnationWindow.length > this.stagnationWindowSize) {
-      this.stagnationWindow.shift();
-    }
-    const stagnantCycleLength = findRepeatedStagnantCycleLength(
-      this.stagnationWindow,
-      this.stagnationCycleRepeats,
-    );
-    if (stagnantCycleLength !== null) {
-      return {
-        kind: 'hard',
-        reason: 'stagnation',
-        count: stagnantCycleLength * this.stagnationCycleRepeats,
-        toolName: toolUse.name,
-      };
-    }
-
     return { kind: 'ok' };
   }
 
   /** 每个 user turn 开始时重置, 避免跨 turn 的合法重复被累计。 */
   resetTurn(): void {
     this.pendingToolUses.clear();
+    this.resetPatternState();
+  }
+
+  private resetPatternState(): void {
     this.lastFullFingerprint = null;
     this.consecutiveStreak = 0;
     this.callWindow = [];
-    this.stagnationWindow = [];
   }
-}
-
-/**
- * 检查历史末尾是否由同一段 3+ 调用序列重复组成,且每轮对应结果完全相同。
- * 1 个调用的机械重复由第 1 层处理,2 个调用的往返由第 2 层处理。
- */
-function findRepeatedStagnantCycleLength(
-  history: CompletedToolCall[],
-  repeats: number,
-): number | null {
-  if (repeats < 2) return null;
-
-  const maxCycleLength = Math.floor(history.length / repeats);
-  for (let cycleLength = 3; cycleLength <= maxCycleLength; cycleLength += 1) {
-    const start = history.length - cycleLength * repeats;
-    let matches = true;
-
-    for (let repeat = 1; repeat < repeats && matches; repeat += 1) {
-      for (let offset = 0; offset < cycleLength; offset += 1) {
-        const baseline = history[start + offset];
-        const candidate = history[start + repeat * cycleLength + offset];
-        if (
-          !baseline ||
-          !candidate ||
-          baseline.callFingerprint !== candidate.callFingerprint ||
-          baseline.outputFingerprint !== candidate.outputFingerprint
-        ) {
-          matches = false;
-          break;
-        }
-      }
-    }
-
-    if (matches) return cycleLength;
-  }
-
-  return null;
 }
 
 /**
@@ -231,10 +161,6 @@ function fingerprintToolCall(toolName: string, input: unknown, output: string | 
     hash.update(output);
   }
   return hash.digest('hex');
-}
-
-function fingerprintToolOutput(output: string): string {
-  return createHash('sha256').update(output).digest('hex');
 }
 
 /**

--- a/packages/maker-core/src/agents/shared/loop-guard.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.ts
@@ -15,12 +15,6 @@ const DEFAULT_CONSECUTIVE_LIMIT = 4;
 const DEFAULT_WINDOW_SIZE = 12;
 /** 第 2 层:窗口填满后, distinct 指纹数 ≤ 此值即判循环(2 = 一直在 ≤2 种调用里转)。 */
 const DEFAULT_WINDOW_DISTINCT_LIMIT = 2;
-/**
- * 第 3 层(兜底):单个 user turn 内 tool result 总数硬上限。
- * 不做任何指纹判断, 对一切循环形态有效, 纯粹防止烧爆 context / token。
- * 设得高, 正常复杂任务一个 turn 调几十个工具很常见, 这里只兜"绝不可能是正常行为"。
- */
-const DEFAULT_TURN_HARD_CAP = 100;
 
 interface PendingToolUse {
   name: string;
@@ -34,24 +28,21 @@ export interface ToolLoopGuardOptions {
   windowSize?: number;
   /** 第 2 层:窗口内 distinct 指纹 ≤ 此值判循环。 */
   windowDistinctLimit?: number;
-  /** 第 3 层:单 turn tool result 总数硬上限。 */
-  turnHardCap?: number;
 }
 
-/** 命中哪一层判据。consecutive=机械重复 / pingpong=交替或输出易变的重复 / turn-cap=硬上限兜底。 */
-export type ToolLoopReason = 'consecutive' | 'pingpong' | 'turn-cap';
+/** 命中哪一层判据。consecutive=机械重复 / pingpong=交替或输出易变的重复。 */
+export type ToolLoopReason = 'consecutive' | 'pingpong';
 
 export type ToolLoopGuardVerdict =
   | { kind: 'ok' }
   | { kind: 'hard'; reason: ToolLoopReason; count: number; toolName: string };
 
 /**
- * Result-aware tool loop detector(三层防御)。
+ * Result-aware tool loop detector(两层防御)。
  *
- * 只在工具结果返回后计数。三层任一命中即返回 hard, 由调用方决定如何中断:
+ * 只在工具结果返回后判断。任一层命中即返回 hard, 由调用方决定如何中断:
  *   1. 连续完全相同(name+input+output)—— 快路径, 零误判;
  *   2. name+input 滑动窗口多样性坍缩 —— 抓 ABAB 交替 / output 易变的重复;
- *   3. 单 turn tool result 硬上限 —— 兜一切形态。
  *
  * 类本身不依赖 Electron / SDK / provider, 也不做 IO;调用方决定何时启用和如何中断。
  */
@@ -59,7 +50,6 @@ export class ToolLoopGuard {
   readonly consecutiveLimit: number;
   readonly windowSize: number;
   readonly windowDistinctLimit: number;
-  readonly turnHardCap: number;
 
   private pendingToolUses = new Map<string, PendingToolUse>();
 
@@ -70,14 +60,10 @@ export class ToolLoopGuard {
   // 第 2 层状态: 最近 windowSize 个 name+input 指纹
   private callWindow: string[] = [];
 
-  // 第 3 层状态: 本 turn 已配对的 tool result 数
-  private turnToolResultCount = 0;
-
   constructor(options: ToolLoopGuardOptions = {}) {
     this.consecutiveLimit = options.consecutiveLimit ?? DEFAULT_CONSECUTIVE_LIMIT;
     this.windowSize = options.windowSize ?? DEFAULT_WINDOW_SIZE;
     this.windowDistinctLimit = options.windowDistinctLimit ?? DEFAULT_WINDOW_DISTINCT_LIMIT;
-    this.turnHardCap = options.turnHardCap ?? DEFAULT_TURN_HARD_CAP;
   }
 
   /**
@@ -91,19 +77,13 @@ export class ToolLoopGuard {
   }
 
   /**
-   * 工具结果到达后配对并按三层判据计数。没有配到完整 tool_use 时直接放行,
+   * 工具结果到达后配对并按两层判据判断。没有配到完整 tool_use 时直接放行,
    * 避免用不完整信息误判。
    */
   onToolResult(toolUseId: string, output: string): ToolLoopGuardVerdict {
     const toolUse = this.pendingToolUses.get(toolUseId);
     this.pendingToolUses.delete(toolUseId);
     if (!toolUse) return { kind: 'ok' };
-
-    // 第 3 层: turn 硬上限(先数, 任何形态兜底)
-    this.turnToolResultCount += 1;
-    if (this.turnToolResultCount > this.turnHardCap) {
-      return { kind: 'hard', reason: 'turn-cap', count: this.turnToolResultCount, toolName: toolUse.name };
-    }
 
     // 第 1 层: 连续 name+input+output 完全相同
     const fullFingerprint = fingerprintToolCall(toolUse.name, toolUse.input, output);
@@ -147,7 +127,6 @@ export class ToolLoopGuard {
     this.lastFullFingerprint = null;
     this.consecutiveStreak = 0;
     this.callWindow = [];
-    this.turnToolResultCount = 0;
   }
 }
 

--- a/packages/maker-core/src/agents/shared/loop-guard.ts
+++ b/packages/maker-core/src/agents/shared/loop-guard.ts
@@ -15,6 +15,15 @@ const DEFAULT_CONSECUTIVE_LIMIT = 4;
 const DEFAULT_WINDOW_SIZE = 12;
 /** 第 2 层:窗口填满后, distinct 指纹数 ≤ 此值即判循环(2 = 一直在 ≤2 种调用里转)。 */
 const DEFAULT_WINDOW_DISTINCT_LIMIT = 2;
+/**
+ * 第 3 层(进展代理):更长的窗口,用于识别短窗口刻意放过的 3+ 调用循环,以及
+ * 参数持续变化但结果高度重复的循环。48 次约等于最多 8 种调用重复 6 轮。
+ */
+const DEFAULT_STAGNATION_WINDOW_SIZE = 48;
+/** 第 3 层:长窗口内 name+input 指纹不超过此值,视为有限调用集反复循环。 */
+const DEFAULT_STAGNATION_CALL_DISTINCT_LIMIT = 8;
+/** 第 3 层:长窗口内结果指纹不超过此值,视为参数变化但没有获得新结果。 */
+const DEFAULT_STAGNATION_OUTPUT_DISTINCT_LIMIT = 4;
 
 interface PendingToolUse {
   name: string;
@@ -28,21 +37,28 @@ export interface ToolLoopGuardOptions {
   windowSize?: number;
   /** 第 2 层:窗口内 distinct 指纹 ≤ 此值判循环。 */
   windowDistinctLimit?: number;
+  /** 第 3 层:进展代理窗口大小。 */
+  stagnationWindowSize?: number;
+  /** 第 3 层:窗口内 distinct name+input 指纹 ≤ 此值判停滞。 */
+  stagnationCallDistinctLimit?: number;
+  /** 第 3 层:窗口内 distinct output 指纹 ≤ 此值判停滞。 */
+  stagnationOutputDistinctLimit?: number;
 }
 
-/** 命中哪一层判据。consecutive=机械重复 / pingpong=交替或输出易变的重复。 */
-export type ToolLoopReason = 'consecutive' | 'pingpong';
+/** 命中哪一层判据。consecutive=机械重复 / pingpong=短循环 / stagnation=长窗口无进展。 */
+export type ToolLoopReason = 'consecutive' | 'pingpong' | 'stagnation';
 
 export type ToolLoopGuardVerdict =
   | { kind: 'ok' }
   | { kind: 'hard'; reason: ToolLoopReason; count: number; toolName: string };
 
 /**
- * Result-aware tool loop detector(两层防御)。
+ * Result-aware tool loop detector(三层防御)。
  *
  * 只在工具结果返回后判断。任一层命中即返回 hard, 由调用方决定如何中断:
  *   1. 连续完全相同(name+input+output)—— 快路径, 零误判;
  *   2. name+input 滑动窗口多样性坍缩 —— 抓 ABAB 交替 / output 易变的重复;
+ *   3. 长窗口里调用或结果多样性坍缩 —— 抓 3+ 调用循环 / 参数漂移循环;
  *
  * 类本身不依赖 Electron / SDK / provider, 也不做 IO;调用方决定何时启用和如何中断。
  */
@@ -50,6 +66,9 @@ export class ToolLoopGuard {
   readonly consecutiveLimit: number;
   readonly windowSize: number;
   readonly windowDistinctLimit: number;
+  readonly stagnationWindowSize: number;
+  readonly stagnationCallDistinctLimit: number;
+  readonly stagnationOutputDistinctLimit: number;
 
   private pendingToolUses = new Map<string, PendingToolUse>();
 
@@ -60,10 +79,20 @@ export class ToolLoopGuard {
   // 第 2 层状态: 最近 windowSize 个 name+input 指纹
   private callWindow: string[] = [];
 
+  // 第 3 层状态:更长窗口里的调用与结果指纹,作为“是否获得新证据”的保守代理。
+  private stagnationCallWindow: string[] = [];
+  private stagnationOutputWindow: string[] = [];
+
   constructor(options: ToolLoopGuardOptions = {}) {
     this.consecutiveLimit = options.consecutiveLimit ?? DEFAULT_CONSECUTIVE_LIMIT;
     this.windowSize = options.windowSize ?? DEFAULT_WINDOW_SIZE;
     this.windowDistinctLimit = options.windowDistinctLimit ?? DEFAULT_WINDOW_DISTINCT_LIMIT;
+    this.stagnationWindowSize =
+      options.stagnationWindowSize ?? DEFAULT_STAGNATION_WINDOW_SIZE;
+    this.stagnationCallDistinctLimit =
+      options.stagnationCallDistinctLimit ?? DEFAULT_STAGNATION_CALL_DISTINCT_LIMIT;
+    this.stagnationOutputDistinctLimit =
+      options.stagnationOutputDistinctLimit ?? DEFAULT_STAGNATION_OUTPUT_DISTINCT_LIMIT;
   }
 
   /**
@@ -118,6 +147,30 @@ export class ToolLoopGuard {
       }
     }
 
+    // 第 3 层:长窗口进展代理。不能用绝对调用次数判断——批量读取数百个项目是合法任务;
+    // 只有调用集合反复复用,或参数虽在变化但结果高度重复时,才认为没有获得新证据。
+    this.stagnationCallWindow.push(callFingerprint);
+    this.stagnationOutputWindow.push(fingerprintToolOutput(output));
+    if (this.stagnationCallWindow.length > this.stagnationWindowSize) {
+      this.stagnationCallWindow.shift();
+      this.stagnationOutputWindow.shift();
+    }
+    if (this.stagnationCallWindow.length >= this.stagnationWindowSize) {
+      const distinctCalls = new Set(this.stagnationCallWindow).size;
+      const distinctOutputs = new Set(this.stagnationOutputWindow).size;
+      if (
+        distinctCalls <= this.stagnationCallDistinctLimit ||
+        distinctOutputs <= this.stagnationOutputDistinctLimit
+      ) {
+        return {
+          kind: 'hard',
+          reason: 'stagnation',
+          count: this.stagnationCallWindow.length,
+          toolName: toolUse.name,
+        };
+      }
+    }
+
     return { kind: 'ok' };
   }
 
@@ -127,7 +180,13 @@ export class ToolLoopGuard {
     this.lastFullFingerprint = null;
     this.consecutiveStreak = 0;
     this.callWindow = [];
+    this.stagnationCallWindow = [];
+    this.stagnationOutputWindow = [];
   }
+}
+
+function fingerprintToolOutput(output: string): string {
+  return createHash('sha256').update('output:').update(output).digest('hex');
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

移除仅对 `deepseek/*` 启用的单 user turn 100 次 tool result 绝对硬上限。该上限不判断任务是否仍在推进，合法的批量分析会在第 101 次工具结果时被误判并终止。

保留原有两类短机械循环检测：连续完全相同的非轮询调用，以及 12 次窗口内只在一两种调用间往返。SDK 明确定义为等待/轮询的 `TaskOutput` 不参与通用循环判定，但不会切断其前后普通工具调用的累计状态。

收敛后的判据不变量与各路径如下：

- 工具调用总数本身永远不是中断条件。
- 参数持续变化代表仍在处理新目标；即使 output 相同、为空或纯空白也放行。
- `TaskOutput` 是原生等待工具；它本身不参与指纹、单个或多个目标的状态暂时不变都放行，但普通工具的两类短循环轨迹会跨轮询继续累计。
- 3 项、33 项或更长的固定序列不靠有限窗口硬中断。仅凭工具 trace 无法区分合法批处理、稳定轮询和死循环，继续扩大窗口只会移动误判/漏判边界。
- 非 `TaskOutput` 的连续完全相同调用与一两种调用间的短 ping-pong 仍按原策略中断。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack 用户反馈 DeepSeek V4 Flash 在批量分析 GameJam 项目时被 101 次工具调用保护误中断
- 本 PR 包含：删除绝对次数上限；保留两类短机械循环检测；放行原生 `TaskOutput` 轮询且保留其前后普通工具轨迹；补充 guard 与真实 SDK 事件流回归
- 明确不包含：增加用户配置、修改其他模型的 Agent Loop、为任意长度工具序列重造通用 Agent Loop 或资源预算
- 用户可见变化：DeepSeek 的合法长任务不再仅因单轮工具调用总数、稳定轮询或较长固定序列而终止；短机械循环仍会自动中断，且不能靠穿插 `TaskOutput` 绕过
- 是否存在 breaking change：无；`@cindy/maker-core` 为仓库内私有 package，删除的选项没有其他调用方

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/shared/loop-guard.test.ts src/agents/claude-code/__tests__/upstream-idle-watchdog.test.ts
结果：通过，2 个 test files、18 个 tests 全部通过

pnpm --filter @cindy/maker-core test
结果：通过，60 个 test files、1228 个 tests 全部通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过；该 package 当前没有 typecheck script，按仓库门禁规则自动跳过

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree-root>
结果：通过；rebase 到最新 origin/main 后完整 pnpm test:unit 门禁全绿。首次运行命中 scripts 测试间假平台目录删除/扫描竞态，定位后按 flake 规则重跑一次通过

pnpm check:dco
结果：通过，6 个 commit 均已签名
```

附加检查：本次核心 guard 文件的定向 ESLint 通过。

### 手工验证

不涉及 UI；未启动 Desktop。

### 未执行的验证

未真实发起一次超过 100 次工具调用的 DeepSeek 在线任务；使用可控 SDK 流模拟同一运行时路径：150 组不同 tool_use + 空 tool_result，以及 30 组结果持续为 `still running` 的 `TaskOutput` 均正常完成，未触发 interrupt。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：DeepSeek Agent Loop 防卡死策略

### 影响与回滚

- 影响范围：仅 `deepseek/*` 的 Claude Code Agent 路径。连续完全相同 4 次或最近 12 次只在一两种非轮询调用间反复时仍会中断；`TaskOutput` 自身不计入指纹，但不会重置普通工具的这两类轨迹。总调用数、原生 `TaskOutput` 轮询及 3 种以上的调用序列不再触发 Cindy 侧硬中断。
- 已知取舍：多样化或较长的真实死循环不再由 Cindy 连接层猜测并强制终止，纯 `TaskOutput` 等待也不因状态稳定被硬停；它们仍受上游上下文/服务限制并可由用户 Stop。该取舍避免重新引入本 PR 要修复的合法任务误杀。
- 回滚 / 降级方式：revert 本 PR 即可恢复原 100 次硬上限。
- maker-core 核心指标：不改 system prompt、tool 定义、model 路由或 usage 计量，prompt cache 与返回内容不受影响；热路径删除了长窗口与额外 output hash，只保留原有 12 项短窗口，性能开销下降；真实 SDK 事件流验证事件顺序、完成态与 interrupt 行为正确。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
