### PR TITLE
feat: Claude Code 自定义供应商支持 Anthropic / Chat Completions / Responses 三种协议

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -75,6 +75,7 @@
     "@fontsource-variable/jetbrains-mono": "^5.2.8",
     "@google/model-viewer": "^4.0.0",
     "@lezer/highlight": "^1.2.3",
+    "@cindy/anthropic-chat-bridge": "workspace:*",
     "@cindy/anthropic-compat-proxy": "workspace:*",
     "@cindy/anthropic-responses-bridge": "workspace:*",
     "@cindy/responses-anthropic-bridge": "workspace:*",

--- a/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeSessionRouteObservation.test.ts
@@ -33,7 +33,9 @@ vi.mock('../claude-fast-mode-log', () => ({
   createClaudeFastModeResponseObserver: () => () => undefined,
 }));
 vi.mock('../provider-route', () => ({
-  // 默认路由会话: 显式供应商解析恒 null; 网关默认决策 = 有 key 才换。
+  // 默认路由会话: 显式供应商解析恒 null(无本地桥接候选、无 per-session 路由);
+  // 网关默认决策 = 有 key 才换。
+  getSessionRoutingDescriptor: vi.fn(() => null),
   resolveSessionRouteDecision: vi.fn(() => null),
   gatewayDefaultRouteDecision: vi.fn((_agent: string, gatewayKey: string | null) =>
     gatewayKey ? { headerOverride: { 'x-api-key': gatewayKey } } : null),

--- a/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
@@ -356,7 +356,9 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
     },
   );
 
-  it('rejects unsupported protocol/runtime combinations', () => {
+  it('accepts bridged protocols for both Claude Code and Codex runtimes', () => {
+    // Claude Code 自定义供应商支持三种 wire 协议(Anthropic 直连 / Responses / Chat 桥接),
+    // 与 Codex 一致 —— 见 anthropic-compat-proxy-host 的本地桥接路由。
     expect(validateCustomProviderConfig({
       ...valid,
       runtimes: {
@@ -365,8 +367,12 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
           wireProtocol: 'openai-chat',
           models: [{ id: 'm', name: 'M' }],
         },
+        codex: {
+          ...valid.runtimes.codex!,
+          wireProtocol: 'openai-responses',
+        },
       },
-    }).ok).toBe(false);
+    }).ok).toBe(true);
   });
 
   it('update returns null when row absent', async () => {

--- a/apps/desktop/src/main/maker-host/anthropic-chat-bridge-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-chat-bridge-host.ts
@@ -1,0 +1,81 @@
+/**
+ * Desktop 端 anthropic-chat-bridge 装配 —— Claude Code 自定义供应商
+ * (`wireProtocol: 'openai-chat'`)的本地协议翻译 handler。
+ *
+ * 与 anthropic-responses-bridge-host 同构:compat-proxy 的 routingTransform 在会话显式
+ * 选了 Chat-Completions wire 的自定义供应商时,把请求经 `RoutingDecision.localHandler`
+ * 直接交给本 handler(Anthropic Messages ↔ Chat Completions 双向翻译在
+ * @cindy/anthropic-chat-bridge 内完成),消息流不多跳、无独立进程内服务。
+ *
+ * 失败兜底:装配抛错 → 返回 null,routingTransform 回落原转发逻辑(自定义供应商的
+ * anthropic-messages 直连语义);摘掉本分支即整体退回旧行为。
+ */
+
+import { createAnthropicChatHandler, type AnthropicChatBridgeHandler } from '@cindy/anthropic-chat-bridge';
+
+import { createMakerLogger } from './logger-adapter.js';
+import { outboundFetch } from './outbound-fetch.js';
+import { getActiveCatalog } from './active-catalog.js';
+import { buildLocalHandlerHeaders, type ResolvedSessionRoute } from './provider-route.js';
+import { reportProviderUpstreamError } from './provider-upstream-error-observer.js';
+
+const log = createMakerLogger('cc-chat-bridge');
+
+/**
+ * 为一条已解析的 Claude Code 会话路由装配 Chat Completions 桥接决策。
+ * `route.routing.wireProtocol !== 'openai-chat'` 时返回 null(调用方回落原逻辑)。
+ *
+ * 按 codex-proxy-host 的 createChatBridgeDecision 同构实现:每请求装配(handler 是
+ * 轻量闭包,无 IO;目录/凭证变化天然即时生效,无需缓存失效)。
+ */
+export function createClaudeChatBridgeDecision(
+  route: NonNullable<ResolvedSessionRoute>,
+): {
+  handler: AnthropicChatBridgeHandler;
+} | null {
+  if (route.routing.wireProtocol !== 'openai-chat') return null;
+
+  // host 构造的 outbound headers(含自定义供应商 API key 注入;与透明转发分支同源,
+  // 见 buildLocalHandlerHeaders 的 api-key-header 分支)。
+  const { headers } = buildLocalHandlerHeaders(route, 'claude-code');
+
+  const providerId = route.providerId;
+  const providerName =
+    getActiveCatalog().providers.find((p) => p.id === providerId)?.name ?? providerId;
+
+  // localHandler 绕过 proxy 的 responseObserver,自定义(user)供应商的上游错误不会被
+  // createProviderUpstreamErrorObserver 看到。显式把非 2xx 上游错误喂回同一广播通道,
+  // 让 Chat 桥接会话与透明自定义供应商一样弹结构化 providerError.* 提示。
+  const onUpstreamError = route.providerSource === 'user'
+    ? ({ status, body }: { status: number; body: string }): void => {
+        reportProviderUpstreamError({
+          agent: 'claude-code',
+          providerId,
+          providerName,
+          status,
+          bodyText: body,
+        });
+      }
+    : undefined;
+
+  const handler = createAnthropicChatHandler({
+    providers: [
+      {
+        // 自定义供应商的模型 id 无统一前缀:空前缀 = 匹配该 route 的所有请求
+        // (进入 localHandler 的请求已经过路由 scope 门,即该供应商的模型)。
+        prefix: '',
+        upstreamBase: route.routing.upstream,
+        ...(route.routing.requestPath
+          ? { chatCompletionsPath: route.routing.requestPath }
+          : {}),
+        buildHeaders: async () => headers,
+        ...(onUpstreamError ? { onUpstreamError } : {}),
+      },
+    ],
+    logger: log,
+    // localHandler 分支的上游请求由 chat bridge 自己发,绕开了 compat-proxy 转发层的
+    // 出站代理;显式注入代理感知 fetch(见 outbound-fetch.ts)。
+    fetchImpl: outboundFetch,
+  });
+  return { handler };
+}

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -35,12 +35,14 @@ import {
   stripNonAnthropicFields,
   stripToolUseProviderSpecificFields,
   type ProxyHandle,
+  type RoutingDecision,
   type RoutingTransform,
 } from '@cindy/anthropic-compat-proxy';
 
 import { ANTHROPIC_DIRECT_UPSTREAM, CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY, anthropicCatalogModelIds, isAnthropicWireModel } from './claude-gateway-config.js';
 import { getActiveCatalog } from './active-catalog.js';
-import { getResponsesBridgeHandler } from './anthropic-responses-bridge-host.js';
+import { getResponsesBridgeHandler, createClaudeResponsesBridgeHandler } from './anthropic-responses-bridge-host.js';
+import { createClaudeChatBridgeDecision } from './anthropic-chat-bridge-host.js';
 import { getSessionEffort, getSessionFastMode } from './session-effort-store.js';
 import { isSubscriptionDirectModel } from '../../shared/subscriptionModels.js';
 import {
@@ -51,7 +53,9 @@ import { recordClaudeSessionRoute } from './claude-session-route-registry.js';
 import { getSessionProvider } from './session-provider-store.js';
 import {
   gatewayDefaultRouteDecision,
+  getSessionRoutingDescriptor,
   getUserProviderIdForSession,
+  resolveSessionRoute,
   resolveSessionRouteDecision,
 } from './provider-route.js';
 import { createProviderUpstreamErrorObserver } from './provider-upstream-error-observer.js';
@@ -192,13 +196,93 @@ export function createModelRoutingTransform(): RoutingTransform {
 
     const gatewayKey = _readGatewayKey();
 
-    // ① 该会话显式选了供应商 → 据 catalog 统一路由。
-    //    x-claude-code-session-id = cc sdkSessionId,经注入的 resolver 反解成 xdt sessionId。
     const sdkSessionId = ctx.headers['x-claude-code-session-id'];
     const sessionId = sdkSessionId && _resolveCcSessionId
       ? _resolveCcSessionId(sdkSessionId)
       : null;
+
+    // ② 未显式选供应商 → 据请求凭证判定 spawn 形态(见 createModelRoutingTransform 头注释)。
+    // 提取成闭包:① 的 local-bridge 分支解析失败时也要回落同一逻辑。
+    const recordDefaultRoute = sessionId !== null && getSessionProvider(sessionId) == null;
+    const defaultSpawnRoute = (): RoutingDecision | null => {
+      // provider-oauth spawn 的占位 key **不是可用凭证**:scope 门放下来的辅助请求
+      // (如 openai / xai 来源 cc 会话里 CLI 自发的 claude-* 权限分类器调用)带着它
+      // passthrough 会在网关吃确定性 401 → 误触发 auto→ask 降级(#831)。与 codex
+      // ①.5 段 #890 修复同语义:占位 key 按「无可用凭证」处理,走下方换网关 key 的
+      // 默认路由;真实 key(gateway-spawn)照旧 passthrough。
+      const apiKeyHeader = headerValue(ctx.headers, 'x-api-key');
+      const hasUsableApiKey =
+        apiKeyHeader !== null && apiKeyHeader !== CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY;
+      if (hasUsableApiKey) {
+        // gateway-spawn:自带网关 key,passthrough。
+        if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
+        return null;
+      }
+      const decision = gatewayDefaultRouteDecision('claude-code', gatewayKey);
+      if (decision) {
+        // oauth-spawn 默认:全量换网关 key(防订阅 token 泄漏到网关)。
+        if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
+        return decision;
+      }
+      if (apiKeyHeader !== null) {
+        // 占位 key 且无网关 key:保持改动前行为(passthrough,上游 401)——下方的
+        // Anthropic 直连支路是给 oauth-spawn 订阅 token 准备的,占位 key 不适用。
+        log.warn('provider-oauth cc spawn 占位 key 且无网关 key; passthrough (预期 401)', { wireModel });
+        return null;
+      }
+      // 没网关 key:Anthropic 模型只能直连(唯一出路),其余 passthrough + 记一条诊断。
+      // 判据 = 前缀地板 ∪ 目录 anthropic 供应商模型集合(新家族改 OSS 目录即可,无需发版)。
+      if (isAnthropicWireModel(wireModel, anthropicCatalogModelIds(getActiveCatalog()))) {
+        if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'subscription');
+        return { upstreamOverride: ANTHROPIC_DIRECT_UPSTREAM };
+      }
+      if (wireModel) {
+        // 无 key 的非 Anthropic 模型 passthrough 大概率 401 —— 路由归属不明确, 不记录。
+        log.warn('claude oauth-spawn but no gateway key; non-anthropic passthrough (可能 401)', { wireModel });
+      }
+      return null;
+    };
+
+    // ① 该会话显式选了供应商 → 据 catalog 统一路由。
+    //    x-claude-code-session-id = cc sdkSessionId,经注入的 resolver 反解成 xdt sessionId。
     if (sessionId) {
+      // 本地协议翻译候选:wireProtocol 为 openai-chat / openai-responses 的供应商 ——
+      // Claude Code 只会说 Anthropic Messages,这两种上游必须经本地 bridge(chat /
+      // responses 翻译器)转换,不能透明转发。同步预判(不读凭证,热路径零额外开销),
+      // 命中才走 async 解析。
+      const selectedRouting = getSessionRoutingDescriptor(sessionId, 'claude-code', wireModel);
+      const usesLocalBridge = (
+        selectedRouting?.wireProtocol === 'openai-chat'
+        || selectedRouting?.wireProtocol === 'openai-responses'
+      );
+      if (usesLocalBridge) {
+        return resolveSessionRoute(sessionId, 'claude-code', wireModel).then((localRoute) => {
+          // Chat Completions 上游 → anthropic-chat-bridge(Anthropic Messages ↔ Chat)。
+          if (localRoute?.routing.wireProtocol === 'openai-chat') {
+            const chat = createClaudeChatBridgeDecision(localRoute);
+            if (chat) {
+              return { localHandler: (args) => chat.handler.handle(args) };
+            }
+          }
+          // Responses 上游 → anthropic-responses-bridge(Anthropic Messages ↔ Responses)。
+          // 会话态(effort / Fast)在决策点解析后**闭包**进 handler(与订阅直连分支同口径)。
+          if (localRoute?.routing.wireProtocol === 'openai-responses') {
+            const handler = createClaudeResponsesBridgeHandler(localRoute);
+            if (handler) {
+              const effort = getSessionEffort(sessionId);
+              const fast = getSessionFastMode(sessionId);
+              return {
+                localHandler: (args) =>
+                  handler.handle({ ...args, prefs: { reasoningEffort: effort ?? undefined, fast } }),
+              };
+            }
+          }
+          // 解析失败(凭证变更窗口)或装配失败 → 回落透明转发 + spawn 默认(no-break)。
+          const perSession = resolveSessionRouteDecision(sessionId, 'claude-code', gatewayKey, wireModel);
+          if (perSession) return perSession;
+          return defaultSpawnRoute();
+        });
+      }
       // wireModel 传给 scope 门:cc 内部辅助调用(权限 auto 分类器等 claude-* 小模型请求)
       // 不在订阅直连供应商(xai / openai-cc)声明的 modelPrefixes 范围内 → 返回 null,
       // 落到下方 ② 段 spawn 默认路由,分类器照常走网关/直连(issue #886)。
@@ -206,47 +290,7 @@ export function createModelRoutingTransform(): RoutingTransform {
       if (perSession) return perSession;
     }
 
-    // ② 未显式选供应商 → 据请求凭证判定 spawn 形态(见上方注释)。
-    // 计费路由旁路只记「未显式选供应商」的会话(registry 声明的语义,消费方也只在
-    // providerId=null 时读)——显式选了供应商但被 scope 门放下来的辅助请求(如 xai 会话
-    // 的 claude-* 分类器调用)不该往表里写死记录。
-    const recordDefaultRoute = sessionId !== null && getSessionProvider(sessionId) == null;
-    // provider-oauth spawn 的占位 key **不是可用凭证**:scope 门放下来的辅助请求
-    // (如 openai / xai 来源 cc 会话里 CLI 自发的 claude-* 权限分类器调用)带着它
-    // passthrough 会在网关吃确定性 401 → 误触发 auto→ask 降级(#831)。与 codex
-    // ①.5 段 #890 修复同语义:占位 key 按「无可用凭证」处理,走下方换网关 key 的
-    // 默认路由;真实 key(gateway-spawn)照旧 passthrough。
-    const apiKeyHeader = headerValue(ctx.headers, 'x-api-key');
-    const hasUsableApiKey =
-      apiKeyHeader !== null && apiKeyHeader !== CLAUDE_PROVIDER_AUTH_PLACEHOLDER_KEY;
-    if (hasUsableApiKey) {
-      // gateway-spawn:自带网关 key,passthrough。
-      if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
-      return null;
-    }
-    const decision = gatewayDefaultRouteDecision('claude-code', gatewayKey);
-    if (decision) {
-      // oauth-spawn 默认:全量换网关 key(防订阅 token 泄漏到网关)。
-      if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'gateway');
-      return decision;
-    }
-    if (apiKeyHeader !== null) {
-      // 占位 key 且无网关 key:保持改动前行为(passthrough,上游 401)——下方的
-      // Anthropic 直连支路是给 oauth-spawn 订阅 token 准备的,占位 key 不适用。
-      log.warn('provider-oauth cc spawn 占位 key 且无网关 key; passthrough (预期 401)', { wireModel });
-      return null;
-    }
-    // 没网关 key:Anthropic 模型只能直连(唯一出路),其余 passthrough + 记一条诊断。
-    // 判据 = 前缀地板 ∪ 目录 anthropic 供应商模型集合(新家族改 OSS 目录即可,无需发版)。
-    if (isAnthropicWireModel(wireModel, anthropicCatalogModelIds(getActiveCatalog()))) {
-      if (recordDefaultRoute) recordClaudeSessionRoute(sessionId, 'subscription');
-      return { upstreamOverride: ANTHROPIC_DIRECT_UPSTREAM };
-    }
-    if (wireModel) {
-      // 无 key 的非 Anthropic 模型 passthrough 大概率 401 —— 路由归属不明确, 不记录。
-      log.warn('claude oauth-spawn but no gateway key; non-anthropic passthrough (可能 401)', { wireModel });
-    }
-    return null;
+    return defaultSpawnRoute();
   };
 }
 

--- a/apps/desktop/src/main/maker-host/anthropic-responses-bridge-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-responses-bridge-host.ts
@@ -37,6 +37,9 @@ import { buildChatgptBridgeHeaders } from './chatgpt-bridge-headers.js';
 import { recordXaiRateLimitSnapshot } from '../usageBroadcaster.js';
 import { xaiServerSideTools } from './xai-server-side-tools.js';
 import { CHATGPT_MODEL_PREFIX, XAI_MODEL_PREFIX } from '../../shared/subscriptionModels.js';
+import { getActiveCatalog } from './active-catalog.js';
+import { buildLocalHandlerHeaders, type ResolvedSessionRoute } from './provider-route.js';
+import { reportProviderUpstreamError } from './provider-upstream-error-observer.js';
 
 const log = createMakerLogger('cc-bridge');
 
@@ -323,4 +326,65 @@ export function getResponsesBridgeHandler(): ResponsesBridgeHandler | null {
     log.error('responses bridge handler 装配失败', { err: err instanceof Error ? err.message : String(err) });
   }
   return _handler;
+}
+
+/**
+ * 为一条已解析的 Claude Code 会话路由装配 Responses 桥接 handler —— 自定义供应商
+ * (`wireProtocol: 'openai-responses'`)的本地协议翻译。`route.routing.wireProtocol !==
+ * 'openai-responses'` 时返回 null(调用方回落原逻辑)。
+ *
+ * 与 createClaudeChatBridgeDecision 同构:每请求装配(轻量闭包,无缓存失效问题)。
+ * 会话态(effort / Fast)由 routingTransform 在决策点解析后经 `prefs` 闭包传入。
+ */
+export function createClaudeResponsesBridgeHandler(
+  route: NonNullable<ResolvedSessionRoute>,
+): ResponsesBridgeHandler | null {
+  if (route.routing.wireProtocol !== 'openai-responses') return null;
+
+  // host 构造的 outbound headers(含自定义供应商 API key 注入;与透明转发分支同源)。
+  const { headers } = buildLocalHandlerHeaders(route, 'claude-code');
+
+  const providerId = route.providerId;
+  const providerName =
+    getActiveCatalog().providers.find((p) => p.id === providerId)?.name ?? providerId;
+
+  // localHandler 绕过 proxy 的 responseObserver:非 2xx 上游错误喂回同一广播通道,
+  // 与透明自定义供应商一样弹结构化 providerError.* 提示。
+  const onUpstreamError = route.providerSource === 'user'
+    ? ({ status, body }: { status: number; body: string }): void => {
+        reportProviderUpstreamError({
+          agent: 'claude-code',
+          providerId,
+          providerName,
+          status,
+          bodyText: body,
+        });
+      }
+    : undefined;
+
+  try {
+    return createResponsesHandler({
+      providers: [
+        {
+          // 自定义供应商的模型 id 无统一前缀:空前缀 = 匹配该 route 的所有请求
+          // (进入 localHandler 的请求已经过路由 scope 门,即该供应商的模型)。
+          prefix: '',
+          wireProtocol: 'openai-responses',
+          upstreamBase: route.routing.upstream,
+          // 标准 Responses 端点(ChatGPT 订阅后端是唯一不支持 max_output_tokens 的特例)。
+          maxOutputTokensSupported: true,
+          buildHeaders: async () => headers,
+          ...(onUpstreamError ? { onUpstreamError } : {}),
+        },
+      ],
+      logger: log,
+      fetchImpl: outboundFetch,
+    });
+  } catch (err) {
+    log.error('claude responses bridge handler 装配失败', {
+      providerId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
 }

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -111,9 +111,9 @@ function validateRuntime(agent: string, rt: unknown): ValidationResult {
     }
   }
   if (r.wireProtocol !== undefined) {
-    const allowed = agent === 'claude-code'
-      ? ['anthropic-messages']
-      : ['openai-responses', 'openai-chat', 'anthropic-messages'];
+    // 两种 agent 都接受三种 wire 协议:Claude Code 的 openai-chat / openai-responses
+    // 分别进对应的本地 chat / responses bridge(见 anthropic-compat-proxy-host)。
+    const allowed = ['openai-responses', 'openai-chat', 'anthropic-messages'];
     if (typeof r.wireProtocol !== 'string' || !allowed.includes(r.wireProtocol)) {
       return invalid(`runtime '${agent}' wireProtocol invalid`);
     }

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -1287,12 +1287,12 @@ export function AddProviderWizard({
               ) : (
                 <InfoLine text={t('settings.providers.wizard.noAuthNote')} />
               )}
-              {/* 官方端点默认只读；本机 / 自托管代理预设可编辑。codex + openai-chat
-                  上游标注「Cindy 桥接」，让用户明确该通道是协议转换而非原生。 */}
+              {/* 官方端点默认只读；本机 / 自托管代理预设可编辑。openai-chat 上游标注
+                  「Cindy 桥接」，让用户明确该通道是协议转换而非原生（任一 agent 适用）。 */}
               <div className="flex flex-col gap-2">
                 {presetAgents.map((agent) => {
                   const rt = sel.preset.runtimes[agent];
-                  const bridged = agent === 'codex' && rt?.wireProtocol === 'openai-chat';
+                  const bridged = rt?.wireProtocol === 'openai-chat';
                   if (rt?.baseUrlEditable) {
                     const value = presetBaseUrls[agent] ?? rt.baseUrl;
                     const valid = isValidEditablePresetBaseUrl(value.trim());

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -48,9 +48,9 @@ import {
   type CustomProviderAuthMode,
 } from '@/lib/providerModelFetch';
 import {
-  CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS,
-  customProviderCodexWireProtocolOption,
-  type CustomProviderCodexWireProtocol,
+  CUSTOM_PROVIDER_WIRE_PROTOCOLS,
+  customProviderWireProtocolOption,
+  type CustomProviderWireProtocol,
 } from '@/lib/customProviderWireProtocols';
 
 import { isProviderRequestPath, sortPresetsForLocale } from '@cindy/model-providers';
@@ -491,13 +491,13 @@ export function CustomProviderDialog({
   );
 
   /** 切换协议时保留用户已填写的 endpoint，仅使旧测试结果失效。 */
-  const changeCodexWireProtocol = useCallback(
-    (wireProtocol: CustomProviderCodexWireProtocol) => {
+  const changeWireProtocol = useCallback(
+    (agent: AgentKind, wireProtocol: CustomProviderWireProtocol) => {
       setRtSynced((prev) => ({
         ...prev,
-        codex: { ...prev.codex, wireProtocol },
+        [agent]: { ...prev[agent], wireProtocol },
       }));
-      setTest((prev) => ({ ...prev, codex: IDLE_TEST }));
+      setTest((prev) => ({ ...prev, [agent]: IDLE_TEST }));
     },
     [setRtSynced],
   );
@@ -1161,36 +1161,37 @@ export function CustomProviderDialog({
               border: '1px solid var(--settings-theme-card-border)',
             }}
           >
-            {activeTab === 'codex' && (
-              <div className="flex flex-col gap-[7px]">
-                <FieldLabel>{t('settings.providers.custom.fields.wireProtocol')}</FieldLabel>
-                <div className="flex flex-wrap gap-1.5">
-                  {CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS.map((option) => (
-                    <button
-                      key={option.value}
-                      type="button"
-                      onClick={() => changeCodexWireProtocol(option.value)}
-                      className={cn(
-                        'rounded-full border px-3 py-1.5 text-12 font-medium transition-colors',
-                        f.wireProtocol === option.value
-                          ? 'border-[var(--settings-input-border-focus)] text-[var(--settings-section-title)]'
-                          : 'border-[var(--settings-input-border)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]',
-                      )}
-                      style={
-                        f.wireProtocol === option.value
-                          ? { backgroundColor: 'var(--surface-elevated)' }
-                          : undefined
-                      }
-                    >
-                      {t(option.labelKey)}
-                    </button>
-                  ))}
-                </div>
-                <span className="text-12 leading-snug text-[var(--text-tertiary)]">
-                  {t(customProviderCodexWireProtocolOption(f.wireProtocol).helpKey)}
-                </span>
+            {/* 上游协议：Claude Code 与 Codex 都支持三种协议 —— Anthropic Messages 原生 /
+                OpenAI Responses / Chat Completions 由 Cindy 桥接（responses-chat / chat 系
+                转换器按协议自动接管）。切换协议保留用户已填写的 endpoint。 */}
+            <div className="flex flex-col gap-[7px]">
+              <FieldLabel>{t('settings.providers.custom.fields.wireProtocol')}</FieldLabel>
+              <div className="flex flex-wrap gap-1.5">
+                {CUSTOM_PROVIDER_WIRE_PROTOCOLS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => changeWireProtocol(activeTab, option.value)}
+                    className={cn(
+                      'rounded-full border px-3 py-1.5 text-12 font-medium transition-colors',
+                      f.wireProtocol === option.value
+                        ? 'border-[var(--settings-input-border-focus)] text-[var(--settings-section-title)]'
+                        : 'border-[var(--settings-input-border)] text-[var(--text-secondary)] hover:bg-[var(--surface-hover)]',
+                    )}
+                    style={
+                      f.wireProtocol === option.value
+                        ? { backgroundColor: 'var(--surface-elevated)' }
+                        : undefined
+                    }
+                  >
+                    {t(option.labelKey)}
+                  </button>
+                ))}
               </div>
-            )}
+              <span className="text-12 leading-snug text-[var(--text-tertiary)]">
+                {t(customProviderWireProtocolOption(f.wireProtocol).helpKey)}
+              </span>
+            </div>
 
             {/* 基础 URL */}
             <div className="flex flex-col gap-[7px]">
@@ -1208,11 +1209,7 @@ export function CustomProviderDialog({
               <TextInput
                 value={f.requestPath}
                 onChange={(v) => patch(activeTab, (x) => ({ ...x, requestPath: v }))}
-                placeholder={
-                  activeTab === 'claude-code'
-                    ? '/v1/messages'
-                    : customProviderCodexWireProtocolOption(f.wireProtocol).defaultRequestPath
-                }
+                placeholder={customProviderWireProtocolOption(f.wireProtocol).defaultRequestPath}
               />
               <span className="text-12 leading-snug text-[var(--text-tertiary)]">
                 {t('settings.providers.custom.fields.requestPathHelp')}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1296,16 +1296,16 @@
           "removeRow": "Remove row"
         },
         "wireProtocol": {
-          "responses": "OpenAI Responses (native)",
+          "responses": "OpenAI Responses",
           "chat": "Chat Completions (Cindy bridge)",
-          "anthropic": "Anthropic Messages (Cindy bridge)",
-          "responsesHelp": "The provider supports the Responses API natively, so Cindy forwards its event stream unchanged.",
-          "chatHelp": "For providers that only expose Chat Completions. Cindy converts streaming text and function tool calls; some advanced Responses features are unavailable.",
-          "anthropicHelp": "For providers that expose the Anthropic Messages API. Cindy converts Responses messages, images, tools, reasoning, and streaming events."
+          "anthropic": "Anthropic Messages",
+          "responsesHelp": "The upstream natively speaks the OpenAI Responses API. Cindy bridges it for Claude Code; Codex uses it natively.",
+          "chatHelp": "For providers that only expose Chat Completions. Cindy converts streaming text and function tool calls; some advanced capabilities are unavailable.",
+          "anthropicHelp": "The upstream natively speaks the Anthropic Messages API. Claude Code uses it directly; Cindy bridges it for Codex."
         },
         "protocol": {
           "claude": "Claude Code",
-          "claudeDesc": "Claude Code follows the Anthropic protocol (auth via x-api-key). Enter this source's baseURL, key, and models for Claude Code; leave blank to skip Claude Code for this source.",
+          "claudeDesc": "Claude Code speaks the Anthropic Messages protocol (auth via x-api-key). Choose native Anthropic, or let Cindy bridge OpenAI Responses or Chat Completions. Enter this source's baseURL, key, and models for Claude Code; leave blank to skip Claude Code for this source.",
           "codex": "Codex",
           "codexDesc": "Codex speaks the OpenAI Responses protocol. Choose native Responses, or let Cindy bridge Chat Completions or Anthropic Messages. Enter this source's base URL, key, and models for Codex; leave blank to skip Codex for this source."
         },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1296,16 +1296,16 @@
           "removeRow": "删除该行"
         },
         "wireProtocol": {
-          "responses": "OpenAI Responses（原生）",
+          "responses": "OpenAI Responses",
           "chat": "Chat Completions（Cindy 桥接）",
-          "anthropic": "Anthropic Messages（Cindy 桥接）",
-          "responsesHelp": "供应商原生支持 Responses API，Cindy 透明转发完整事件。",
-          "chatHelp": "适用于仅提供 Chat Completions 的供应商。Cindy 转换流式文本和函数工具调用；部分高级 Responses 能力不可用。",
-          "anthropicHelp": "适用于提供 Anthropic Messages API 的供应商。Cindy 转换 Responses 消息、图片、工具、推理内容与流式事件。"
+          "anthropic": "Anthropic Messages",
+          "responsesHelp": "上游原生使用 OpenAI Responses API。Claude Code 经 Cindy 桥接使用；Codex 透明直连。",
+          "chatHelp": "适用于仅提供 Chat Completions 的供应商。Cindy 转换流式文本和函数工具调用；部分高级能力不可用。",
+          "anthropicHelp": "上游原生提供 Anthropic Messages API。Claude Code 直连使用；Codex 经 Cindy 桥接。"
         },
         "protocol": {
           "claude": "Claude Code",
-          "claudeDesc": "Claude Code 遵循 Anthropic 协议(用 x-api-key 鉴权)。填该来源用于 Claude Code 的 baseURL、密钥与模型，留空则此来源不提供 Claude Code。",
+          "claudeDesc": "Claude Code 遵循 Anthropic Messages 协议(用 x-api-key 鉴权)。上游可选择原生 Anthropic，或由 Cindy 桥接 OpenAI Responses、Chat Completions。填该来源用于 Claude Code 的 baseURL、密钥与模型，留空则此来源不提供 Claude Code。",
           "codex": "Codex",
           "codexDesc": "Codex 使用 OpenAI Responses 协议。上游可选择原生 Responses，或由 Cindy 桥接 Chat Completions、Anthropic Messages。填该来源用于 Codex 的 baseURL、密钥与模型，留空则此来源不提供 Codex。"
         },

--- a/apps/desktop/src/renderer/lib/__tests__/customProviderWireProtocols.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviderWireProtocols.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS,
-  customProviderCodexWireProtocolOption,
+  CUSTOM_PROVIDER_WIRE_PROTOCOLS,
+  customProviderWireProtocolOption,
 } from '../customProviderWireProtocols';
 
-describe('custom provider Codex wire protocols', () => {
-  it('offers every supported Codex route including the Anthropic Messages bridge', () => {
-    expect(CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS.map((option) => option.value)).toEqual([
+describe('custom provider wire protocols', () => {
+  it('offers every supported wire protocol route including the Anthropic Messages bridge', () => {
+    expect(CUSTOM_PROVIDER_WIRE_PROTOCOLS.map((option) => option.value)).toEqual([
       'openai-responses',
       'openai-chat',
       'anthropic-messages',
@@ -15,9 +15,15 @@ describe('custom provider Codex wire protocols', () => {
   });
 
   it('uses the Anthropic Messages endpoint as its default request path', () => {
-    expect(customProviderCodexWireProtocolOption('anthropic-messages')).toMatchObject({
+    expect(customProviderWireProtocolOption('anthropic-messages')).toMatchObject({
       helpKey: 'settings.providers.custom.wireProtocol.anthropicHelp',
       defaultRequestPath: '/v1/messages',
+    });
+  });
+
+  it('uses the Chat Completions endpoint as its default request path', () => {
+    expect(customProviderWireProtocolOption('openai-chat')).toMatchObject({
+      defaultRequestPath: '/chat/completions',
     });
   });
 });

--- a/apps/desktop/src/renderer/lib/customProviderWireProtocols.ts
+++ b/apps/desktop/src/renderer/lib/customProviderWireProtocols.ts
@@ -1,18 +1,20 @@
 import type { ProviderWireProtocol } from '@cindy/model-providers';
 
-export type CustomProviderCodexWireProtocol = Extract<
-  ProviderWireProtocol,
-  'openai-responses' | 'openai-chat' | 'anthropic-messages'
->;
+/**
+ * 自定义供应商的 wire 协议选项 —— Claude Code 与 Codex 共用同一份列表:
+ * 任一 agent 的 runtime 都可选 Anthropic Messages / OpenAI Responses / Chat Completions,
+ * 运行时按协议走对应通道(原生直连 / responses bridge / chat bridge)。
+ */
+export type CustomProviderWireProtocol = ProviderWireProtocol;
 
 interface CustomProviderWireProtocolOption {
-  value: CustomProviderCodexWireProtocol;
+  value: CustomProviderWireProtocol;
   labelKey: string;
   helpKey: string;
   defaultRequestPath: string;
 }
 
-export const CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS = [
+export const CUSTOM_PROVIDER_WIRE_PROTOCOLS = [
   {
     value: 'openai-responses',
     labelKey: 'settings.providers.custom.wireProtocol.responses',
@@ -33,9 +35,9 @@ export const CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS = [
   },
 ] as const satisfies readonly CustomProviderWireProtocolOption[];
 
-export function customProviderCodexWireProtocolOption(
+export function customProviderWireProtocolOption(
   protocol: ProviderWireProtocol,
-): (typeof CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS)[number] {
-  return CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS.find((option) => option.value === protocol)
-    ?? CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS[0];
+): (typeof CUSTOM_PROVIDER_WIRE_PROTOCOLS)[number] {
+  return CUSTOM_PROVIDER_WIRE_PROTOCOLS.find((option) => option.value === protocol)
+    ?? CUSTOM_PROVIDER_WIRE_PROTOCOLS[0];
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
 | [plugin-setup-runtime.md](./plugin-setup-runtime.md) | 技术设计 | 参考 | `ghost_list` / `ghost_call` 插件配置前置检查、Ask-shell Setup 卡片、配置变更回调与原调用恢复 | — |
 | [desktop-login-hosted-callback.md](./desktop-login-hosted-callback.md) | 跨仓契约 | 参考 | Desktop 系统浏览器登录的托管回调链路：auth-server 路由契约、结果页模板交付、灰度开关与回滚 | — |
 | [auth-realm-routing.md](./auth-realm-routing.md) | 跨仓契约 | 参考 | 组织 SSO 双区域发现、会话区域持久化与 token 消费端点路由 | — |
+| [claude-code-protocol-bridges.md](./claude-code-protocol-bridges.md) | 技术设计 | 参考 | Claude Code 自定义供应商多协议支持（Anthropic / Chat Completions / Responses 桥接）与 `packages/anthropic-chat-bridge` | — |
 | [legal/README.md](./legal/README.md) | 法律/合规索引 | authoritative | 法律合规资料归档边界与固定路径例外 | — |
 | [legal/wechat-open-sdk-compliance.md](./legal/wechat-open-sdk-compliance.md) | 合规记录 | restricted-review-required | Mobile 微信 Open SDK 版本、隐私披露和发布前签核 | — |
 | [legal/notices/README.md](./legal/notices/README.md) | 第三方许可/SBOM | generated | `pnpm licenses:generate`、Desktop/Mobile 随包声明 | — |

--- a/docs/claude-code-protocol-bridges.md
+++ b/docs/claude-code-protocol-bridges.md
@@ -1,0 +1,125 @@
+# Claude Code 多协议桥接（Anthropic / Chat Completions / Responses）
+
+> 状态：已实施（2026-07）。
+> 范围：Claude Code 自定义供应商的 wire 协议扩展 —— 在原有 Anthropic Messages 直连之上，
+> 支持经本地桥接使用 OpenAI Chat Completions 与 OpenAI Responses 上游。
+> 相关现状：[`openai-chat-dual-channel-plan.md`](./openai-chat-dual-channel-plan.md) 记录 Codex
+> 侧的 Responses → Chat 桥接；本文是 Claude Code 侧的对应物。
+
+## 1. 目标与最终结论
+
+Claude Code 只会说 Anthropic Messages 协议，此前内置的自定义供应商对 `claude-code` runtime
+只允许 `anthropic-messages` 一种 wire（UI 不渲染协议选择器、后端校验白名单锁定）。Codex 侧
+早已支持三种协议（原生 Responses / Chat 桥接 / Anthropic Messages 桥接），Claude Code 侧缺
+少同等的协议选择与对应的本地翻译器。
+
+本轮补齐：
+
+```mermaid
+flowchart LR
+  CC["Claude Code<br/>Anthropic Messages"]
+  PX["Cindy loopback proxy<br/>(localHandler 插槽)"]
+  AM["Anthropic Messages 上游<br/>(原生直连)"]
+  BR1["anthropic-responses-bridge<br/>(Anthropic ↔ Responses)"]
+  BR2["anthropic-chat-bridge<br/>(Anthropic ↔ Chat Completions)"]
+  OR["OpenAI Responses 上游"]
+  OC["OpenAI Chat Completions 上游"]
+
+  CC --> PX
+  PX -->|"wireProtocol=anthropic-messages"| AM
+  PX -->|"wireProtocol=openai-responses"| BR1
+  PX -->|"wireProtocol=openai-chat"| BR2
+  BR1 --> OR
+  BR2 --> OC
+```
+
+实施边界：
+
+1. **不引入第二套常驻代理。** 沿用 compat-proxy 的 `RoutingDecision.localHandler` 插槽，
+   bridge 为进程内 handler，消息流不多跳。
+2. **不串联已有桥。** Chat 通道是**直接转换器**（Anthropic → Chat 单向成对），不是把
+   responses-anthropic-bridge 与 responses-chat-bridge 串起来走两跳。
+3. **数据驱动选协议。** 协议由 `RoutingDescriptor.wireProtocol` 声明，路由按描述符分发；
+   禁止按 provider id 堆条件分支。
+4. **同协议永远优先透明直连。** `anthropic-messages` 保持原转发语义（字节级不变），只有
+   非 Anthropic 上游进入本地桥。
+5. **桥接不等于原生完整兼容。** 产品 UI 明确区分「原生 / Cindy 桥接」，help 文案标注降级
+   能力（见 §4）。
+
+## 2. 现状基线
+
+- 协议枚举：`ProviderWireProtocol = 'anthropic-messages' | 'openai-responses' | 'openai-chat'`
+  （`packages/model-providers`），自定义供应商配置（`CustomProviderRuntimeConfig.wireProtocol`）
+  与路由描述符（`RoutingDescriptor.wireProtocol`）早已支持，无需改类型。
+- Codex 侧三种协议全支持（`codex-proxy-host.ts` 的 `createLocalBridgeDecision`），本轮不动。
+- Claude Code 侧原缺口：
+  - UI：协议选择器只在 codex tab 渲染（`CustomProviderDialog.tsx`），claude-code tab 无选择；
+  - 校验：`custom-provider-store.ts` 的 `validateRuntime` 对 claude-code 白名单仅
+    `['anthropic-messages']`；
+  - 运行时：已有 `anthropic-responses-bridge`（Anthropic ↔ Responses），但只注册
+    chatgpt/xai 官方订阅源（模型前缀 `chatgpt/`、`xai/`），自定义供应商的 Responses
+    上游无接入路径；**没有 Anthropic → Chat Completions 转换器**。
+
+## 3. 实现
+
+### 3.1 新包 `packages/anthropic-chat-bridge`
+
+进程内协议翻译 handler（`createAnthropicChatHandler`），结构对齐
+`packages/anthropic-responses-bridge`：
+
+- `translate-request.ts`：Anthropic Messages → Chat Completions。system 合并置首；
+  user 消息按 block 顺序拆出 `tool` 消息（tool_result 独立成 `role:'tool'` 消息，原 user
+  文本保留原位，天然满足 Chat 的交替要求）；assistant 的 text / tool_use / thinking 合并进
+  一条 assistant 消息（content + tool_calls + reasoning_content）；thinking 请求经
+  `capabilities.reasoningField` 映射（默认不发）；max_tokens 经 `maxTokensField` 映射。
+- `translate-sse.ts`：Chat SSE → Anthropic SSE 状态机。content → text 块、reasoning_content
+  → thinking 块（惰性开块，防纯空白块回放 400）；**tool_calls 累积到流尾一次性输出**——
+  Chat 流没有「单个工具 arguments 结束」的显式信号，逐 delta 转发会违反 Anthropic 单开块
+  不变量并产生残缺 tool_use，延迟输出以完整 arguments 保证工具可执行；usage 尾帧 →
+  message_delta。
+- `handler.ts`：compat-proxy `localHandler` 形态；count_tokens 本地估算；上游错误转 Anthropic
+  error 形状；`x-ratelimit-*` 头回调；零事件流合成诊断 error（#941 同口径）。
+- capabilities 全部数据表达、默认 fail-closed（DeepSeek/Kimi 的 `reasoning_content` 回放、
+  占位等按上游确认后开启）。
+
+### 3.2 host 装配（`apps/desktop`）
+
+- `maker-host/anthropic-chat-bridge-host.ts`：`createClaudeChatBridgeDecision(route)` —— 为
+  已解析的 Claude Code 会话路由装配 chat bridge（`buildLocalHandlerHeaders` 同源构造
+  鉴权头，`reportProviderUpstreamError` 喂回错误广播通道）。
+- `maker-host/anthropic-responses-bridge-host.ts`：新增
+  `createClaudeResponsesBridgeHandler(route)` —— 为自定义供应商的 Responses 上游装配
+  responses bridge（原 `getResponsesBridgeHandler` 保持订阅直连专用）。
+- `maker-host/anthropic-compat-proxy-host.ts` 的 `createModelRoutingTransform`：① 段
+  （per-session 路由）在 `getSessionRoutingDescriptor` 预判 wireProtocol（同步、不读凭证），
+  命中 `openai-chat` / `openai-responses` 时走 `resolveSessionRoute` 异步解析并返回
+  `localHandler`；未命中保持原 `resolveSessionRouteDecision` 透明转发；② 段 spawn 默认
+  路由提取为闭包，local-bridge 分支解析失败时回落（no-break）。
+
+### 3.3 UI / 校验
+
+- `CustomProviderDialog.tsx`：协议选择器从 codex-only 改为两个 tab 都渲染；
+  `changeCodexWireProtocol` → `changeWireProtocol(agent, protocol)`；requestPath placeholder
+  按所选协议推导。
+- `lib/customProviderWireProtocols.ts`：`CUSTOM_PROVIDER_CODEX_WIRE_PROTOCOLS` →
+  `CUSTOM_PROVIDER_WIRE_PROTOCOLS`（双 agent 共用；类型本就是 `ProviderWireProtocol` 全集）。
+- `custom-provider-store.ts` `validateRuntime`：claude-code 白名单放宽为三种协议。
+- i18n（zh-CN / en）：协议 label 与 help 文案改为双 agent 通用；`claudeDesc` 补充协议说明。
+
+## 4. 能力边界（已知降级）
+
+| 通道 | Claude Code 侧 |
+|---|---|
+| Anthropic Messages（原生） | 全能力，字节级透传 |
+| OpenAI Responses（桥接） | 文本 / 工具调用 / 图片 / reasoning（encrypted_content 回放经
+  `anthropic-responses-bridge` 既有约定，effort / Fast 由 host 会话态闭包注入） |
+| Chat Completions（桥接） | 流式文本 / 函数工具调用 / thinking（reasoning_content）；工具
+  calls 非逐字流式（累积后块级输出）；无 signature 的 thinking 不回放下游（默认丢弃历史
+  thinking）；厂商扩展参数（reasoning_content 回放等）按 capabilities 逐厂商开启 |
+
+## 5. 测试
+
+- `packages/anthropic-chat-bridge/src/__tests__/`：请求翻译（消息拆分、图片、tools、
+  tool_choice、max_tokens、thinking 映射、占位注入）与 SSE 翻译（文本/思考/工具流、
+  usage 尾帧、stop_reason 映射、空白块、失败收尾）单测。
+- host 侧改动沿用现有 proxy 路由单测（`providerRoute.test.ts` 等）验证 no-break。

--- a/packages/anthropic-chat-bridge/eslint.config.mjs
+++ b/packages/anthropic-chat-bridge/eslint.config.mjs
@@ -1,0 +1,10 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ['dist/'],
+  },
+);

--- a/packages/anthropic-chat-bridge/package.json
+++ b/packages/anthropic-chat-bridge/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@cindy/anthropic-chat-bridge",
+  "version": "0.0.0",
+  "private": true,
+  "description": "In-process protocol translation handler that bridges Anthropic Messages API <-> OpenAI Chat Completions, letting Claude Code SDK drive Chat-Completions-only providers (DeepSeek, GLM, Kimi, SiliconFlow, ...) over their native wire protocol with a plain API key.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc --noEmit",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "lint": "eslint src/"
+  },
+  "author": {
+    "name": "XD Inc.",
+    "email": "feedback@cindy.app"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "@types/node": "*",
+    "eslint": "^9.0.0",
+    "typescript": "^5.7.0",
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/anthropic-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-chat-bridge/src/__tests__/translate-request.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from 'vitest';
+
+import { translateRequest } from '../translate-request.js';
+import type { AnthropicMessagesRequest } from '../types.js';
+
+describe('translateRequest', () => {
+  it('maps system → leading system message and user text → user message', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'deepseek/deepseek-chat',
+      system: 'You are terse.',
+      messages: [{ role: 'user', content: 'hi' }],
+    };
+    const out = translateRequest(req, { model: 'deepseek-chat' });
+    expect(out.model).toBe('deepseek-chat');
+    expect(out.stream).toBe(true);
+    expect(out.stream_options).toEqual({ include_usage: true });
+    expect(out.messages).toEqual([
+      { role: 'system', content: 'You are terse.' },
+      { role: 'user', content: 'hi' },
+    ]);
+  });
+
+  it('joins array-form system blocks', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      system: [
+        { type: 'text', text: 'A' },
+        { type: 'text', text: 'B' },
+      ],
+      messages: [{ role: 'user', content: 'x' }],
+    };
+    expect(translateRequest(req, { model: 'm' }).messages[0]).toEqual({
+      role: 'system',
+      content: 'A\n\nB',
+    });
+  });
+
+  it('maps assistant tool_use → tool_calls and user tool_result → tool message', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [
+        { role: 'user', content: 'weather?' },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'let me check' },
+            { type: 'tool_use', id: 'tu_1', name: 'get_weather', input: { city: 'beijing' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'tu_1', content: 'sunny' },
+            { type: 'text', text: 'thanks' },
+          ],
+        },
+      ],
+    };
+    const out = translateRequest(req, { model: 'm' });
+    expect(out.messages).toEqual([
+      { role: 'user', content: 'weather?' },
+      {
+        role: 'assistant',
+        content: 'let me check',
+        tool_calls: [
+          { id: 'tu_1', type: 'function', function: { name: 'get_weather', arguments: '{"city":"beijing"}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'tu_1', content: 'sunny' },
+      { role: 'user', content: 'thanks' },
+    ]);
+  });
+
+  it('pure tool_result user message emits only the tool message (no empty user)', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [
+        { role: 'user', content: 'go' },
+        { role: 'assistant', content: [{ type: 'tool_use', id: 'tu_1', name: 'bash', input: {} }] },
+        { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'tu_1', content: 'ok' }] },
+      ],
+    };
+    const out = translateRequest(req, { model: 'm' });
+    expect(out.messages.map((m) => m.role)).toEqual(['user', 'assistant', 'tool']);
+  });
+
+  it('skips empty-string messages and empty assistant messages', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [
+        { role: 'user', content: '' },
+        { role: 'assistant', content: '' },
+        { role: 'user', content: 'real' },
+      ],
+    };
+    const out = translateRequest(req, { model: 'm' });
+    expect(out.messages).toEqual([{ role: 'user', content: 'real' }]);
+  });
+
+  it('maps image blocks to image_url parts (data URL) by default', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'what is this?' },
+            { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'aGk=' } },
+          ],
+        },
+      ],
+    };
+    const out = translateRequest(req, { model: 'm' });
+    expect(out.messages).toEqual([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'what is this?' },
+          { type: 'image_url', image_url: { url: 'data:image/png;base64,aGk=' } },
+        ],
+      },
+    ]);
+  });
+
+  it('replaces images with an explicit placeholder when imageInput is none', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [
+        { role: 'user', content: [{ type: 'image', source: { type: 'base64', data: 'aGk=' } }] },
+      ],
+    };
+    const out = translateRequest(req, { model: 'm', capabilities: { imageInput: 'none' } });
+    const content = out.messages[0].content;
+    expect(typeof content).toBe('string');
+    expect(content).toContain('[image omitted');
+  });
+
+  it('maps tools and tool_choice', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [{ role: 'user', content: 'x' }],
+      tools: [
+        { name: 'get_weather', description: 'd', input_schema: { type: 'object', properties: { city: { type: 'string' } } } },
+      ],
+      tool_choice: { type: 'any' },
+    };
+    const out = translateRequest(req, { model: 'm' });
+    expect(out.tools).toEqual([
+      {
+        type: 'function',
+        function: {
+          name: 'get_weather',
+          description: 'd',
+          parameters: { type: 'object', properties: { city: { type: 'string' } } },
+        },
+      },
+    ]);
+    expect(out.tool_choice).toBe('required');
+    expect(out.parallel_tool_calls).toBe(true);
+  });
+
+  it('maps tool_choice tool → named function', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [{ role: 'user', content: 'x' }],
+      tools: [{ name: 'a' }],
+      tool_choice: { type: 'tool', name: 'a' },
+    };
+    expect(translateRequest(req, { model: 'm' }).tool_choice).toEqual({
+      type: 'function',
+      function: { name: 'a' },
+    });
+  });
+
+  it('maps max_tokens to max_tokens by default and max_completion_tokens via capability', () => {
+    const base: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [{ role: 'user', content: 'x' }],
+      max_tokens: 4096,
+    };
+    expect(translateRequest(base, { model: 'm' }).max_tokens).toBe(4096);
+    expect(translateRequest(base, { model: 'm', capabilities: { maxTokensField: 'max_completion_tokens' } }).max_completion_tokens).toBe(4096);
+    const omitted = translateRequest(base, { model: 'm', capabilities: { maxTokensField: 'omit' } });
+    expect(omitted.max_tokens).toBeUndefined();
+    expect(omitted.max_completion_tokens).toBeUndefined();
+  });
+
+  it('maps thinking → upstream reasoning params per capability (default none)', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [{ role: 'user', content: 'x' }],
+      thinking: { type: 'enabled', budget_tokens: 8000 },
+    };
+    const defaultOut = translateRequest(req, { model: 'm' });
+    expect(defaultOut.reasoning_effort).toBeUndefined();
+    expect(defaultOut.reasoning).toBeUndefined();
+    expect(defaultOut.thinking).toBeUndefined();
+    const effort = translateRequest(req, { model: 'm', capabilities: { reasoningField: 'reasoning_effort' } });
+    expect(effort.reasoning_effort).toBe('medium');
+    const nested = translateRequest(req, { model: 'm', capabilities: { reasoningField: 'reasoning.effort' } });
+    expect(nested.reasoning).toEqual({ effort: 'medium' });
+    const thinking = translateRequest(req, { model: 'm', capabilities: { reasoningField: 'thinking.type' } });
+    expect(thinking.thinking).toEqual({ type: 'enabled' });
+  });
+
+  it('maps assistant thinking → reasoning_content only when reasoningHistoryField enables it', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [
+        { role: 'user', content: 'x' },
+        { role: 'assistant', content: [{ type: 'thinking', thinking: 'hmm' }, { type: 'text', text: 'answer' }] },
+      ],
+    };
+    const dropped = translateRequest(req, { model: 'm' });
+    expect((dropped.messages[1] as unknown as Record<string, unknown>).reasoning_content).toBeUndefined();
+    const kept = translateRequest(req, { model: 'm', capabilities: { reasoningHistoryField: 'reasoning_content' } });
+    expect((kept.messages[1] as unknown as Record<string, unknown>).reasoning_content).toBe('hmm');
+  });
+
+  it('injects reasoning placeholder for tool_call assistant messages when enabled', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [
+        { role: 'user', content: 'x' },
+        { role: 'assistant', content: [{ type: 'tool_use', id: 'tu_1', name: 'a', input: {} }] },
+      ],
+    };
+    const out = translateRequest(req, { model: 'm', capabilities: { toolCallReasoningPlaceholder: true } });
+    const assistant = out.messages[1] as unknown as Record<string, unknown>;
+    expect(assistant.reasoning_content).toBe(' ');
+    expect(assistant.content).toBeNull();
+  });
+
+  it('prepends a user message when the sequence would start with assistant (defensive)', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'm',
+      messages: [{ role: 'assistant', content: 'stray' }],
+    };
+    const out = translateRequest(req, { model: 'm' });
+    expect(out.messages[0]).toEqual({ role: 'user', content: '' });
+    expect(out.messages[1]).toEqual({ role: 'assistant', content: 'stray' });
+  });
+});

--- a/packages/anthropic-chat-bridge/src/__tests__/translate-sse.test.ts
+++ b/packages/anthropic-chat-bridge/src/__tests__/translate-sse.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from 'vitest';
+
+import { AnthropicSseTranslator, type AnthropicSseEvent } from '../translate-sse.js';
+
+/** 把一段事件流压缩成 (event, key 字段) 列表,便于断言结构。 */
+function shape(events: AnthropicSseEvent[]): Array<{ event: string; index?: number; deltaType?: string; text?: string; stopReason?: string | null }> {
+  return events.map((ev) => {
+    const data = ev.data as Record<string, unknown>;
+    if (ev.event === 'content_block_start') {
+      const block = data.content_block as Record<string, unknown>;
+      return { event: ev.event, index: data.index as number, deltaType: block.type as string };
+    }
+    if (ev.event === 'content_block_delta') {
+      const delta = data.delta as Record<string, unknown>;
+      return {
+        event: ev.event,
+        index: data.index as number,
+        deltaType: delta.type as string,
+        text: (delta.thinking ?? delta.text ?? delta.partial_json) as string | undefined,
+      };
+    }
+    if (ev.event === 'content_block_stop') {
+      return { event: ev.event, index: data.index as number };
+    }
+    if (ev.event === 'message_delta') {
+      const delta = data.delta as Record<string, unknown>;
+      return { event: ev.event, stopReason: delta.stop_reason as string | null };
+    }
+    return { event: ev.event };
+  });
+}
+
+function run(chunks: unknown[]): AnthropicSseEvent[] {
+  const t = new AnthropicSseTranslator('deepseek/deepseek-chat');
+  const out: AnthropicSseEvent[] = [];
+  for (const c of chunks) out.push(...t.push(c));
+  t.markTerminal();
+  out.push(...t.finish());
+  return out;
+}
+
+describe('AnthropicSseTranslator', () => {
+  it('emits message_start then streams text blocks and stops with end_turn', () => {
+    const events = run([
+      { id: 'chatcmpl-1', choices: [{ delta: { role: 'assistant', content: 'Hel' }, finish_reason: null }] },
+      { id: 'chatcmpl-1', choices: [{ delta: { content: 'lo' }, finish_reason: null }] },
+      { id: 'chatcmpl-1', choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(events[0]).toMatchObject({
+      event: 'message_start',
+      data: { message: { model: 'deepseek/deepseek-chat', role: 'assistant', id: 'chatcmpl-1' } },
+    });
+    expect(shape(events.slice(1))).toEqual([
+      { event: 'content_block_start', index: 0, deltaType: 'text' },
+      { event: 'content_block_delta', index: 0, deltaType: 'text_delta', text: 'Hel' },
+      { event: 'content_block_delta', index: 0, deltaType: 'text_delta', text: 'lo' },
+      { event: 'content_block_stop', index: 0 },
+      { event: 'message_delta', stopReason: 'end_turn' },
+      { event: 'message_stop' },
+    ]);
+  });
+
+  it('streams reasoning_content as thinking blocks before text', () => {
+    const events = run([
+      { choices: [{ delta: { reasoning_content: 'think' }, finish_reason: null }] },
+      { choices: [{ delta: { content: 'answer' }, finish_reason: null }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    expect(shape(events.slice(1))).toEqual([
+      { event: 'content_block_start', index: 0, deltaType: 'thinking' },
+      { event: 'content_block_delta', index: 0, deltaType: 'thinking_delta', text: 'think' },
+      { event: 'content_block_stop', index: 0 },
+      { event: 'content_block_start', index: 1, deltaType: 'text' },
+      { event: 'content_block_delta', index: 1, deltaType: 'text_delta', text: 'answer' },
+      { event: 'content_block_stop', index: 1 },
+      { event: 'message_delta', stopReason: 'end_turn' },
+      { event: 'message_stop' },
+    ]);
+  });
+
+  it('emits tool_use blocks at stream end in index order with full arguments', () => {
+    const events = run([
+      {
+        choices: [{
+          delta: {
+            tool_calls: [
+              { index: 0, id: 'call_1', type: 'function', function: { name: 'get_weather', arguments: '' } },
+            ],
+          },
+          finish_reason: null,
+        }],
+      },
+      {
+        choices: [{
+          delta: {
+            tool_calls: [
+              { index: 1, id: 'call_2', type: 'function', function: { name: 'get_time', arguments: '' } },
+            ],
+          },
+          finish_reason: null,
+        }],
+      },
+      {
+        choices: [{
+          delta: {
+            tool_calls: [
+              { index: 0, function: { arguments: '{"city":' } },
+              { index: 1, function: { arguments: '{"tz":' } },
+            ],
+          },
+          finish_reason: null,
+        }],
+      },
+      {
+        choices: [{
+          delta: {
+            tool_calls: [{ index: 0, function: { arguments: '"beijing"}' } }],
+          },
+          finish_reason: null,
+        }],
+      },
+      { choices: [{ delta: {}, finish_reason: 'tool_calls' }] },
+    ]);
+    const s = shape(events.slice(1));
+    // 两个 tool_use 块按 index 顺序输出,块内带完整 arguments。
+    const toolBlocks = s.filter((e) => e.deltaType === 'tool_use');
+    expect(toolBlocks).toEqual([
+      { event: 'content_block_start', index: 0, deltaType: 'tool_use' },
+      { event: 'content_block_start', index: 1, deltaType: 'tool_use' },
+    ]);
+    const args = s.filter((e) => e.deltaType === 'input_json_delta').map((e) => e.text);
+    expect(args).toEqual(['{"city":"beijing"}', '{"tz":']);
+    expect(s[s.length - 2]).toEqual({ event: 'message_delta', stopReason: 'tool_use' });
+  });
+
+  it('includes usage from the include_usage tail frame in message_delta', () => {
+    const events = run([
+      { choices: [{ delta: { content: 'x' }, finish_reason: 'stop' }] },
+      { choices: [], usage: { prompt_tokens: 100, completion_tokens: 20, prompt_tokens_details: { cached_tokens: 30 } } },
+    ]);
+    const messageDelta = events.find((e) => e.event === 'message_delta')!;
+    expect(messageDelta.data.usage).toEqual({
+      input_tokens: 70,
+      output_tokens: 20,
+      cache_read_input_tokens: 30,
+      cache_creation_input_tokens: 0,
+    });
+  });
+
+  it('maps length finish reason to max_tokens', () => {
+    const events = run([
+      { choices: [{ delta: { content: 'x' }, finish_reason: 'length' }] },
+    ]);
+    const messageDelta = events.find((e) => e.event === 'message_delta')!;
+    expect((messageDelta.data.delta as Record<string, unknown>).stop_reason).toBe('max_tokens');
+  });
+
+  it('does not emit empty/whitespace-only text blocks', () => {
+    const events = run([
+      { choices: [{ delta: { content: '   ' }, finish_reason: null }] },
+      { choices: [{ delta: { content: 'x' }, finish_reason: null }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    const starts = events.filter((e) => e.event === 'content_block_start');
+    expect(starts).toHaveLength(1);
+    const firstDelta = events.find((e) => e.event === 'content_block_delta')!;
+    expect((firstDelta.data.delta as Record<string, unknown>).text).toBe('   x');
+  });
+
+  it('interrupts an open thinking block when content arrives (single-open invariant)', () => {
+    const events = run([
+      { choices: [{ delta: { reasoning_content: 'a' }, finish_reason: null }] },
+      { choices: [{ delta: { reasoning_content: 'b', content: 'c' }, finish_reason: null }] },
+      { choices: [{ delta: {}, finish_reason: 'stop' }] },
+    ]);
+    const s = shape(events.slice(1));
+    const stops = s.filter((e) => e.event === 'content_block_stop');
+    expect(stops).toHaveLength(2);
+    // 同一 chunk 内 reasoning 先于 content 处理:'b' 追加进打开的 thinking 块,
+    // content 'c' 到达时打断(关 thinking)再开 text 块 —— 无交错开块。
+    expect(s[0]).toEqual({ event: 'content_block_start', index: 0, deltaType: 'thinking' });
+    expect(s[1]).toEqual({ event: 'content_block_delta', index: 0, deltaType: 'thinking_delta', text: 'a' });
+    expect(s[2]).toEqual({ event: 'content_block_delta', index: 0, deltaType: 'thinking_delta', text: 'b' });
+    expect(s[3]).toEqual({ event: 'content_block_stop', index: 0 });
+    expect(s[4]).toEqual({ event: 'content_block_start', index: 1, deltaType: 'text' });
+    expect(s[5]).toEqual({ event: 'content_block_delta', index: 1, deltaType: 'text_delta', text: 'c' });
+  });
+
+  it('fails with an error event and no normal termination on streamed error frames', () => {
+    const t = new AnthropicSseTranslator('m');
+    const out = t.push({ error: { message: 'upstream exploded' } });
+    const evs = [...out, ...t.finish()];
+    expect(evs[evs.length - 1]).toMatchObject({
+      event: 'error',
+      data: { error: { type: 'api_error', message: 'upstream exploded' } },
+    });
+    expect(evs.some((e) => e.event === 'message_stop')).toBe(false);
+  });
+
+  it('fails when the stream ends without any terminal marker', () => {
+    const t = new AnthropicSseTranslator('m');
+    t.push({ choices: [{ delta: { content: 'partial' }, finish_reason: null }] });
+    const evs = t.finish(true);
+    expect(evs[evs.length - 1]).toMatchObject({ event: 'error' });
+    expect(evs.some((e) => e.event === 'message_stop')).toBe(false);
+  });
+
+  it('drops accumulated tool_use on fail', () => {
+    const t = new AnthropicSseTranslator('m');
+    t.push({
+      choices: [{
+        delta: { tool_calls: [{ index: 0, id: 'call_1', function: { name: 'a', arguments: '{}' } }] },
+        finish_reason: null,
+      }],
+    });
+    const evs = t.fail('boom');
+    expect(evs.some((e) => e.event === 'content_block_start')).toBe(false);
+  });
+});

--- a/packages/anthropic-chat-bridge/src/handler.ts
+++ b/packages/anthropic-chat-bridge/src/handler.ts
@@ -1,0 +1,388 @@
+/**
+ * Bridge handler ——
+ *
+ * 以 anthropic-compat-proxy 的 `RoutingDecision.localHandler` 形态运行(**不是**独立 server):
+ * 代理在路由决策命中 Chat-Completions wire 的自定义供应商时,把已收集的请求(parsed body +
+ * ctx + res)直接交给本 handler,由它:
+ *   1. strip model 前缀 → 真实 model id
+ *   2. translateRequest → OpenAI Chat Completions 请求
+ *   3. 注入 provider headers(buildHeaders 拿 API key)→ POST 上游 /chat/completions
+ *   4. 逐条把上游 Chat Completions SSE 翻译成 Anthropic Messages SSE 写回 res
+ *
+ * 与 anthropic-responses-bridge 的分工一致:本包是插进引擎 `localHandler` 插槽的协议
+ * 翻译 handler;消息流不多跳。响应是**翻译流**(非字节透传),逐事件翻译不缓冲整流,
+ * 流式延迟仍接近零(唯一的缓冲是 tool_calls —— 见 translate-sse.ts 头注释的累积策略)。
+ *
+ * 错误契约(与引擎 runLocalHandler 对齐):本 handler 内部把可预期错误写成 Anthropic 风格
+ * error 响应;意外抛错交给引擎(未写头 → 502 fail-open)。
+ */
+
+import type { ServerResponse } from 'node:http';
+
+import { translateRequest } from './translate-request.js';
+import { AnthropicSseTranslator, type AnthropicSseEvent } from './translate-sse.js';
+import type {
+  AnthropicMessagesRequest,
+  BridgeLogger,
+  ChatBridgeProviderConfig,
+  UpstreamRateLimitInfo,
+} from './types.js';
+
+/**
+ * 解析上游响应的 `x-ratelimit-*` 头(标准 OpenAI 风格)。全部字段都解析不出 → null(不回调)。
+ * reset 类头格式跨供应商不稳定,不解析 —— 只取确定的数值字段,诚实降级。
+ */
+function parseRateLimitHeaders(headers: Headers): UpstreamRateLimitInfo | null {
+  const num = (name: string): number | undefined => {
+    const raw = headers.get(name);
+    if (raw == null) return undefined;
+    const v = Number(raw);
+    return Number.isFinite(v) ? v : undefined;
+  };
+  const info: UpstreamRateLimitInfo = {
+    limitRequests: num('x-ratelimit-limit-requests'),
+    remainingRequests: num('x-ratelimit-remaining-requests'),
+    limitTokens: num('x-ratelimit-limit-tokens'),
+    remainingTokens: num('x-ratelimit-remaining-tokens'),
+  };
+  return Object.values(info).some((v) => v !== undefined) ? info : null;
+}
+
+/** 按 model 前缀匹配 provider 配置(最长前缀优先,防前缀互为子串时歧义;空前缀匹配所有)。 */
+function matchProvider(model: string, providers: ChatBridgeProviderConfig[]): ChatBridgeProviderConfig | null {
+  let best: ChatBridgeProviderConfig | null = null;
+  for (const p of providers) {
+    if (p.prefix && model.startsWith(p.prefix) && (!best || p.prefix.length > best.prefix.length)) {
+      best = p;
+    } else if (!p.prefix && !best) {
+      best = p;
+    }
+  }
+  return best;
+}
+
+/** upstream 状态码 → Anthropic error type(尽量语义对齐,方便 SDK 分类)。 */
+function anthropicErrorType(status: number): string {
+  if (status === 401 || status === 403) return 'authentication_error';
+  if (status === 429) return 'rate_limit_error';
+  if (status === 400) return 'invalid_request_error';
+  return 'api_error';
+}
+
+function writeJson(res: ServerResponse, status: number, body: unknown): void {
+  const buf = Buffer.from(JSON.stringify(body), 'utf8');
+  res.writeHead(status, { 'content-type': 'application/json', 'content-length': String(buf.length) });
+  res.end(buf);
+}
+
+function writeSseEvent(res: ServerResponse, ev: AnthropicSseEvent): void {
+  res.write(`event: ${ev.event}\ndata: ${JSON.stringify(ev.data)}\n\n`);
+}
+
+/** image block 的粗估 token 占位(与 anthropic-responses-bridge 同值)。 */
+const IMAGE_BLOCK_ESTIMATE_CHARS = 1400 * 4;
+
+/** chars/4 粗估 token —— 给 count_tokens 用(Chat 系上游无 Anthropic 的 count 端点)。 */
+function estimateTokens(req: AnthropicMessagesRequest): number {
+  let chars = 0;
+  const sys = req.system;
+  if (typeof sys === 'string') chars += sys.length;
+  else if (Array.isArray(sys)) for (const b of sys) chars += (b?.text ?? '').length;
+  // tools 的 JSON schema 是 prompt 的大头(Claude Code 常带几十 KB 工具定义),不算会让
+  // /context 上下文表严重偏小、compaction 迟触发。
+  for (const t of req.tools ?? []) {
+    chars += (t.name?.length ?? 0) + (t.description?.length ?? 0);
+    if (t.input_schema) {
+      try {
+        chars += JSON.stringify(t.input_schema).length;
+      } catch {
+        /* 环引用等异常 schema:跳过,不影响其余估算 */
+      }
+    }
+  }
+  for (const m of req.messages ?? []) {
+    if (typeof m.content === 'string') chars += m.content.length;
+    else if (Array.isArray(m.content)) {
+      for (const block of m.content) {
+        const rec = block as Record<string, unknown>;
+        if (typeof rec.text === 'string') chars += rec.text.length;
+        // 图像 block:base64 字节数与 token 数无关(vision 按分辨率计),且 stringify 整段
+        // base64 会为一个 /4 粗估分配数 MB 临时串 —— 用固定占位。
+        else if (rec.type === 'image') chars += IMAGE_BLOCK_ESTIMATE_CHARS;
+        else chars += JSON.stringify(rec).length;
+      }
+    }
+  }
+  return Math.max(1, Math.ceil(chars / 4));
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}
+
+/** createAnthropicChatHandler 的 handle 入参 —— 与 compat-proxy LocalRequestHandler 的 args 同形。 */
+export interface AnthropicChatHandleArgs {
+  parsedBody: unknown;
+  ctx: { readonly method: string; readonly url: string; readonly headers: Readonly<Record<string, string>> };
+  res: ServerResponse;
+}
+
+export interface AnthropicChatBridgeHandler {
+  handle(args: AnthropicChatHandleArgs): Promise<void>;
+}
+
+export interface AnthropicChatHandlerOptions {
+  /** 供应商配置列表(按 model 前缀路由;空前缀匹配所有)。前缀需互不为前缀关系,避免歧义。 */
+  providers: ChatBridgeProviderConfig[];
+  logger?: BridgeLogger;
+  /**
+   * 上游 fetch。默认全局 fetch(undici)—— 它**不吃系统代理**,宿主在「系统代理」模式
+   * 下必须注入自己的代理感知实现(desktop 注入 maker-host/outbound-fetch)。
+   */
+  fetchImpl?: typeof fetch;
+}
+
+// 去尾部斜杠。不用 /\/+$/ 正则——超长 '/' 串上会 O(n²) 回溯(CodeQL js/polynomial-redos)。
+function trimTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 0x2f) end -= 1;
+  return s.slice(0, end);
+}
+
+/**
+ * 创建 Anthropic → Chat Completions 翻译 handler。host 把它包进 compat-proxy 的
+ * `RoutingDecision.localHandler`:`{ localHandler: (args) => handler.handle(args) }`。
+ */
+export function createAnthropicChatHandler(opts: AnthropicChatHandlerOptions): AnthropicChatBridgeHandler {
+  // 协议标识 fail-fast:注册了未实现的 wireProtocol 直接抛,不让它静默注册成不可用的源。
+  for (const p of opts.providers) {
+    if (p.wireProtocol !== undefined && p.wireProtocol !== 'openai-chat') {
+      throw new Error(`bridge provider '${p.prefix}' 声明了未实现的 wireProtocol: ${String(p.wireProtocol)}`);
+    }
+  }
+  const providers = opts.providers.map((p) => ({ ...p, upstreamBase: trimTrailingSlashes(p.upstreamBase) }));
+  const log = opts.logger ?? {};
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  let reqSeq = 0;
+
+  async function handle({ parsedBody, ctx, res }: AnthropicChatHandleArgs): Promise<void> {
+    const reqId = ++reqSeq;
+
+    if (!isPlainObject(parsedBody)) {
+      writeJson(res, 400, { type: 'error', error: { type: 'invalid_request_error', message: 'invalid JSON body' } });
+      return;
+    }
+    const parsed = parsedBody as AnthropicMessagesRequest;
+
+    // 按 model 前缀匹配 provider(count_tokens 请求 body 也带 model)。
+    const wireModel = typeof parsed.model === 'string' ? parsed.model : '';
+    const provider = matchProvider(wireModel, providers);
+    if (!provider) {
+      writeJson(res, 400, {
+        type: 'error',
+        error: { type: 'invalid_request_error', message: `no bridge provider for model '${wireModel}'` },
+      });
+      return;
+    }
+    // [1m] 是 cc 侧 wire 约定(目录窗口 ≥1M 的模型会带,见 maker-core toSdkModelString);
+    // Chat 系上游不认识这个后缀,必须剥掉。
+    const realModel = wireModel.slice(provider.prefix.length).replace(/\[1m\]$/, '');
+
+    // count_tokens:上游无对应端点,本地估算返回。
+    if (ctx.url.includes('count_tokens')) {
+      writeJson(res, 200, { input_tokens: estimateTokens(parsed) });
+      return;
+    }
+
+    const sessionId = ctx.headers['x-claude-code-session-id'] ?? undefined;
+
+    // 鉴权:每请求让 provider 构造最新 headers。
+    let providerHeaders: Record<string, string>;
+    try {
+      providerHeaders = await provider.buildHeaders({ sessionId });
+    } catch (err) {
+      log.error?.('buildHeaders failed', { reqId, prefix: provider.prefix, err: err instanceof Error ? err.message : String(err) });
+      writeJson(res, 502, {
+        type: 'error',
+        error: { type: 'authentication_error', message: `bridge auth unavailable for ${provider.prefix}(请检查 API 密钥配置)` },
+      });
+      return;
+    }
+
+    const chatRequest = translateRequest(parsed, {
+      model: realModel,
+      capabilities: provider.capabilities,
+    });
+
+    const abort = new AbortController();
+    res.on('close', () => abort.abort());
+
+    let upstream: Response;
+    try {
+      upstream = await fetchImpl(
+        `${provider.upstreamBase}${provider.chatCompletionsPath ?? '/chat/completions'}`,
+        {
+          method: 'POST',
+          headers: {
+            ...providerHeaders,
+            'content-type': 'application/json',
+            accept: 'text/event-stream',
+          },
+          body: JSON.stringify(chatRequest),
+          signal: abort.signal,
+        },
+      );
+    } catch (err) {
+      if (abort.signal.aborted) return;
+      log.error?.('upstream fetch failed', { reqId, err: err instanceof Error ? err.message : String(err) });
+      writeJson(res, 502, { type: 'error', error: { type: 'api_error', message: `upstream unreachable: ${String(err)}` } });
+      return;
+    }
+
+    if (!upstream.ok || !upstream.body) {
+      const text = upstream.body ? await upstream.text().catch(() => '') : '';
+      log.warn?.('upstream non-2xx', { reqId, status: upstream.status, body: text.slice(0, 2000) });
+      if (!upstream.ok && provider.onUpstreamError) {
+        try {
+          await provider.onUpstreamError({
+            status: upstream.status,
+            body: text,
+            requestHeaders: providerHeaders,
+          });
+        } catch (err) {
+          // Provider 状态收口失败不能吞掉或改写真实上游错误;调用方仍需看到原始状态码/正文。
+          log.warn?.('onUpstreamError failed', {
+            reqId,
+            prefix: provider.prefix,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+      writeJson(res, upstream.status, {
+        type: 'error',
+        error: { type: anthropicErrorType(upstream.status), message: text.slice(0, 2000) || `upstream ${upstream.status}` },
+      });
+      return;
+    }
+
+    // 上游限流头(标准 OpenAI 风格,多数 Chat 端点返 x-ratelimit-*)→ 尽力回调给 host 做额度展示。
+    if (provider.onRateLimit) {
+      const rateLimit = parseRateLimitHeaders(upstream.headers);
+      if (rateLimit) {
+        try {
+          provider.onRateLimit(rateLimit);
+        } catch {
+          /* 回调异常不影响流转发 */
+        }
+      }
+    }
+
+    // 上游 2xx 但 content-type 不是 SSE(反代/网关吐 JSON 或 HTML):大概率整流翻不出
+    // 任何事件,先留一条 warn —— 零事件收尾时的合成 error 会带上正文前缀。
+    const upstreamContentType = upstream.headers.get('content-type') ?? '';
+    if (!upstreamContentType.toLowerCase().includes('event-stream')) {
+      log.warn?.('upstream 2xx with non-SSE content-type', {
+        reqId,
+        status: upstream.status,
+        contentType: upstreamContentType || '(missing)',
+      });
+    }
+
+    // 开始流式回写。
+    res.writeHead(200, {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+    });
+
+    // 用 wireModel(带前缀)而非 realModel 构造 —— message_start 回显带前缀 id,
+    // CC 的 modelUsage 据此记账,下游 usage 可按前缀区分桥接轮,不与真网关同名裸模型混淆。
+    const translator = new AnthropicSseTranslator(wireModel);
+    const reader = upstream.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = '';
+    // 零事件诊断:整流一条 Anthropic 事件都没写回时,CLI 只能报
+    // "empty or malformed response (HTTP 200)" 并盲目重试,真实错误被完全掩盖。
+    // 记录写回事件数与上游正文前缀,收尾时合成一条带上游信息的 error 事件 + warn 日志。
+    let eventsWritten = 0;
+    let rawPrefix = '';
+    const RAW_PREFIX_LIMIT = 500;
+    const writeOut = (ev: AnthropicSseEvent): void => {
+      eventsWritten += 1;
+      writeSseEvent(res, ev);
+    };
+    const finalizeStream = (): void => {
+      for (const outEv of translator.finish(true)) writeOut(outEv);
+      if (eventsWritten > 0) return;
+      const bodyPrefix = rawPrefix.trim().slice(0, 300);
+      log.warn?.('upstream stream yielded no translatable events', {
+        reqId,
+        contentType: upstreamContentType || '(missing)',
+        bodyPrefix,
+      });
+      writeOut({
+        event: 'error',
+        data: {
+          type: 'error',
+          error: {
+            type: 'api_error',
+            message:
+              `upstream returned HTTP ${upstream.status} but produced no translatable SSE events ` +
+              `(content-type: ${upstreamContentType || 'missing'}${bodyPrefix ? `; body: ${bodyPrefix}` : ''})`,
+          },
+        },
+      });
+    };
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunkText = decoder.decode(value, { stream: true });
+        if (rawPrefix.length < RAW_PREFIX_LIMIT) {
+          rawPrefix = (rawPrefix + chunkText).slice(0, RAW_PREFIX_LIMIT);
+        }
+        buf += chunkText;
+        // SSE 事件以空行分隔;逐行取 `data:` 负载。用游标扫描、chunk 末尾一次性 slice ——
+        // 避免每行 slice 整个剩余缓冲(大 chunk 数百行时是 O(n²) 拷贝,这是每 token 热路径)。
+        let start = 0;
+        let nl: number;
+        while ((nl = buf.indexOf('\n', start)) >= 0) {
+          const line = buf.slice(start, nl).replace(/\r$/, '');
+          start = nl + 1;
+          if (!line.startsWith('data:')) continue;
+          const payload = line.slice(5).trim();
+          if (!payload) continue;
+          if (payload === '[DONE]') {
+            translator.markTerminal();
+            continue;
+          }
+          let ev: unknown;
+          try {
+            ev = JSON.parse(payload);
+          } catch {
+            continue;
+          }
+          for (const outEv of translator.push(ev)) writeOut(outEv);
+        }
+        if (start > 0) buf = buf.slice(start);
+      }
+      // 上游正常结束:兜底收尾(finish_reason + [DONE] 时已按需输出;这里补 tool_use /
+      // message 收尾)。整流零事件时合成带上游信息的 error 事件,绝不空 200 收尾。
+      finalizeStream();
+    } catch (err) {
+      if (!abort.signal.aborted) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        log.warn?.('upstream stream error', { reqId, err: errMsg });
+        // 断流不走 finalizeStream:已写出部分事件后再补 message_stop,Claude Code 会
+        // 把截断响应当正常完成、上游读取错误被掩盖(review 反馈 P1)。fail() 关块后
+        // 发 error 事件收尾(错误帧已收尾时返回空,不重复报错)。
+        for (const outEv of translator.fail(`upstream stream error: ${errMsg}`)) writeOut(outEv);
+      }
+    } finally {
+      res.end();
+    }
+  }
+
+  log.debug?.('anthropic-chat-bridge handler ready', { providers: providers.map((p) => p.prefix || '(all)') });
+  return { handle };
+}

--- a/packages/anthropic-chat-bridge/src/index.ts
+++ b/packages/anthropic-chat-bridge/src/index.ts
@@ -1,0 +1,52 @@
+/**
+ * @cindy/anthropic-chat-bridge
+ *
+ * 协议翻译 handler:让 Claude Code SDK(只会说 Anthropic Messages API)通过用户自配的
+ * API key,以 Chat-Completions-only 上游(DeepSeek / GLM / Kimi / SiliconFlow 等)的
+ * native wire 协议调用其模型。请求侧 Anthropic Messages → Chat Completions,响应侧
+ * Chat SSE → Anthropic SSE。
+ *
+ * 与 @cindy/anthropic-compat-proxy 的分工(一层代理、引擎 + 插槽):
+ *   - compat-proxy:代理引擎 —— 字节级透传 + 字段裁剪 + 路由,守 SSE 零延迟(响应不解析)。
+ *   - 本包:插进引擎 `RoutingDecision.localHandler` 插槽的协议翻译 handler(请求重组 +
+ *     响应逐事件翻译),**不是独立 server** —— 消息流不多跳。
+ *
+ * 方向性说明:与 @cindy/responses-chat-bridge(Codex:Responses ↔ Chat)不同,本包是
+ * Claude Code 侧的对应物(Anthropic Messages ↔ Chat),两条链路独立、互不依赖。
+ */
+
+export { createAnthropicChatHandler } from './handler.js';
+export { translateRequest } from './translate-request.js';
+export { AnthropicSseTranslator } from './translate-sse.js';
+export { mapUsage } from './usage.js';
+export type {
+  AnthropicChatBridgeHandler,
+  AnthropicChatHandleArgs,
+  AnthropicChatHandlerOptions,
+} from './handler.js';
+export type { AnthropicSseEvent } from './translate-sse.js';
+export type { AnthropicUsage } from './usage.js';
+export type { TranslateRequestOptions } from './translate-request.js';
+export type {
+  AnthropicChatBridgeCapabilities,
+  AnthropicContentBlock,
+  AnthropicMessage,
+  AnthropicMessagesRequest,
+  AnthropicTool,
+  AnthropicToolChoice,
+  BridgeLogger,
+  BridgeWireProtocol,
+  ChatAssistantMessage,
+  ChatBridgeProviderConfig,
+  ChatBridgeUpstreamErrorInfo,
+  ChatCompletionsRequest,
+  ChatDeveloperRole,
+  ChatImageInput,
+  ChatMaxTokensField,
+  ChatMessage,
+  ChatReasoningField,
+  ChatReasoningHistoryField,
+  ChatToolCall,
+  ChatUserContentPart,
+  UpstreamRateLimitInfo,
+} from './types.js';

--- a/packages/anthropic-chat-bridge/src/translate-request.ts
+++ b/packages/anthropic-chat-bridge/src/translate-request.ts
@@ -1,0 +1,358 @@
+/**
+ * 请求翻译 —— Anthropic Messages API → OpenAI Chat Completions。
+ *
+ * 映射总览:
+ *   system                    → 首条 { role: system|developer, content } 消息
+ *   messages[]                → Chat 消息序列(按 block 顺序拆出 tool 消息)
+ *   user text                 → { role:'user', content }
+ *   user image                → user 消息 content 里的 image_url part(data URL)
+ *   user tool_result          → { role:'tool', tool_call_id, content }(独立消息)
+ *   assistant text            → { role:'assistant', content }
+ *   assistant tool_use        → assistant 消息的 tool_calls[](同消息内与文本共存)
+ *   assistant thinking        → assistant 消息的 reasoning_content(capability 开启时)
+ *   tools[].input_schema      → Chat tools[].function.parameters
+ *   tool_choice               → tool_choice(auto / required / 指名 function / none)
+ *   thinking.budget_tokens    → reasoning 参数(capability.reasoningField 控制,默认不发)
+ *   max_tokens                → max_tokens / max_completion_tokens(capability 控制)
+ *   (恒定)                    → stream:true + stream_options.include_usage
+ *
+ * 消息形态差异处理:
+ *   - Anthropic 的 tool_result 嵌在 user 消息里;Chat 需要独立 `tool` 角色消息。
+ *     拆分后原 user 消息的剩余文本留在原 user 消息中(顺序保持:assistant(tool_calls)
+ *     → tool → user(text) → ... 天然满足 Chat 的交替要求)。
+ *   - 纯 tool_result 的 user 消息拆成 tool 消息后不再产生空 user 消息。
+ *   - Chat 兼容端点普遍要求消息序列以 user/system 开头;极端情况下首条为
+ *     assistant 时前插一条空 user 消息(防御,Claude Code 正常不会触发)。
+ */
+
+import type {
+  AnthropicChatBridgeCapabilities,
+  AnthropicContentBlock,
+  AnthropicMessagesRequest,
+  AnthropicToolChoice,
+  ChatAssistantMessage,
+  ChatCompletionsRequest,
+  ChatMessage,
+  ChatToolCall,
+  ChatUserContentPart,
+} from './types.js';
+
+/** system(string 或 text block 数组)拍平成字符串。 */
+function systemToText(system: AnthropicMessagesRequest['system']): string | undefined {
+  if (system == null) return undefined;
+  if (typeof system === 'string') return system;
+  if (Array.isArray(system)) {
+    return system
+      .map((b) => (b && typeof b === 'object' && typeof b.text === 'string' ? b.text : ''))
+      .filter(Boolean)
+      .join('\n\n');
+  }
+  return undefined;
+}
+
+/** tool_result.content(string / block 数组)拍平成 Chat tool 消息需要的字符串。 */
+function toolResultToString(content: unknown): string {
+  if (content == null) return '';
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => {
+        if (b && typeof b === 'object') {
+          const rec = b as Record<string, unknown>;
+          if (rec.type === 'text' && typeof rec.text === 'string') return rec.text;
+          // 工具结果里嵌图片等非文本内容:Chat 的 tool 消息 content 只吃字符串,
+          // 退化成占位描述,不丢整条(模型仍知道该工具产出过内容)。文案与
+          // anthropic-responses-bridge 同构:不带说明的 '[image]' 会被模型当作
+          // 空结果,诱发反复重读或臆测图像内容。
+          if (rec.type === 'image') {
+            return (
+              '[image omitted: this tool returned an image, but tool results on this '
+              + 'provider route are delivered as plain text only, so the image data could '
+              + 'not be included. Do NOT guess or fabricate what the image contains. '
+              + 'Tell the user the image could not be delivered on the current route, and '
+              + 'ask them to paste the relevant content as text or attach the image '
+              + 'directly to a chat message instead.]'
+            );
+          }
+          return JSON.stringify(rec);
+        }
+        return String(b);
+      })
+      .join('\n');
+  }
+  try {
+    return JSON.stringify(content);
+  } catch {
+    return String(content);
+  }
+}
+
+/** Anthropic image block → Chat image_url part 的 data URL。 */
+function imageToDataUrl(block: Extract<AnthropicContentBlock, { type: 'image' }>): string | null {
+  const src = block.source;
+  if (!src) return null;
+  if (src.type === 'url' && src.url) return src.url;
+  if (src.type === 'base64' && src.data) {
+    const mt = src.media_type ?? 'image/png';
+    return `data:${mt};base64,${src.data}`;
+  }
+  return null;
+}
+
+/** image 输入关闭时的占位文本:图片被丢弃必须显式告知模型,不能静默丢上下文。 */
+const IMAGE_OMITTED_PLACEHOLDER =
+  '[image omitted: this provider route does not accept image input, so the attached '
+  + 'image could not be included. Do NOT guess what the image contains.]';
+
+function imagePlaceholderText(block: Extract<AnthropicContentBlock, { type: 'image' }>): string {
+  const src = block.source;
+  if (src?.type === 'url' && src.url) return `${IMAGE_OMITTED_PLACEHOLDER} (image URL: ${src.url})`;
+  return IMAGE_OMITTED_PLACEHOLDER;
+}
+
+function toolChoiceToChat(tc: AnthropicToolChoice | undefined): unknown {
+  if (!tc) return undefined;
+  switch (tc.type) {
+    case 'auto':
+      return 'auto';
+    case 'any':
+      return 'required';
+    case 'none':
+      return 'none';
+    case 'tool':
+      return { type: 'function', function: { name: tc.name } };
+    default:
+      return undefined;
+  }
+}
+
+/** thinking.budget_tokens → reasoning 档位(与 anthropic-responses-bridge 同口径)。 */
+function budgetToEffort(thinking: AnthropicMessagesRequest['thinking']): 'low' | 'medium' | 'high' {
+  if (!thinking || thinking.type !== 'enabled') return 'medium';
+  const b = thinking.budget_tokens ?? 0;
+  if (b <= 0) return 'medium';
+  if (b <= 4096) return 'low';
+  if (b <= 16384) return 'medium';
+  return 'high';
+}
+
+export interface TranslateRequestOptions {
+  /** 发给上游的真实 model id(已 strip 掉 bridge 前缀)。 */
+  model: string;
+  capabilities?: AnthropicChatBridgeCapabilities;
+}
+
+/**
+ * Anthropic Messages 请求 → Chat Completions 请求。
+ *
+ * `opts.model` 是已去前缀的真实 model id(bridge 层负责 strip),不直接用 req.model。
+ */
+export function translateRequest(
+  req: AnthropicMessagesRequest,
+  opts: TranslateRequestOptions,
+): ChatCompletionsRequest {
+  const caps = opts.capabilities ?? {};
+  const developerRole = caps.developerRole ?? 'system';
+  // 图片是 Anthropic 输入的核心形态,Chat 兼容层普遍支持 image_url —— 默认开启。
+  const imageInput = caps.imageInput ?? 'image_url';
+  const messages: ChatMessage[] = [];
+
+  // 顶层 system → 首条消息(合并置首,对齐 cc-switch 的 anthropic→openai 行为)。
+  const systemText = systemToText(req.system);
+  if (systemText) {
+    messages.push({ role: developerRole, content: systemText });
+  }
+
+  for (const msg of req.messages ?? []) {
+    if (typeof msg.content === 'string') {
+      // 空字符串消息(Chat 端点会 400 空 content)直接跳过 —— 不丢语义。
+      if (msg.content.length === 0) continue;
+      if (msg.role === 'system') {
+        messages.push({ role: developerRole, content: msg.content });
+      } else {
+        messages.push({ role: msg.role, content: msg.content });
+      }
+      continue;
+    }
+
+    if (msg.role === 'user') {
+      const userParts: ChatUserContentPart[] = [];
+      let pendingTool: { tool_use_id: string; content: string } | null = null;
+      const flushTool = (): void => {
+        if (!pendingTool) return;
+        messages.push({
+          role: 'tool',
+          tool_call_id: pendingTool.tool_use_id,
+          content: pendingTool.content,
+        });
+        pendingTool = null;
+      };
+      // 纯文本单 part 收敛成字符串 content(上游兼容性最好);含图片等多 part 才用数组。
+      const flushUser = (): void => {
+        if (userParts.length === 0) return;
+        const content: string | ChatUserContentPart[] =
+          userParts.length === 1 && userParts[0].type === 'text'
+            ? userParts[0].text
+            : [...userParts];
+        messages.push({ role: 'user', content });
+        userParts.length = 0;
+      };
+      for (const block of msg.content) {
+        switch (block.type) {
+          case 'text': {
+            const text = (block as { text?: string }).text ?? '';
+            if (text) userParts.push({ type: 'text', text });
+            break;
+          }
+          case 'image': {
+            if (imageInput === 'image_url') {
+              const url = imageToDataUrl(block as Extract<AnthropicContentBlock, { type: 'image' }>);
+              if (url) userParts.push({ type: 'image_url', image_url: { url } });
+              else userParts.push({ type: 'text', text: imagePlaceholderText(block as Extract<AnthropicContentBlock, { type: 'image' }>) });
+            } else {
+              userParts.push({ type: 'text', text: imagePlaceholderText(block as Extract<AnthropicContentBlock, { type: 'image' }>) });
+            }
+            break;
+          }
+          case 'tool_result': {
+            // tool_result 必须在当前 user 文本之前落位(Anthropic block 顺序即语义顺序):
+            // 先 flush 已累积的 user parts,再发 tool 消息,保持 tool → user 交替。
+            flushUser();
+            flushTool();
+            const tr = block as Extract<AnthropicContentBlock, { type: 'tool_result' }>;
+            pendingTool = {
+              tool_use_id: tr.tool_use_id,
+              content: toolResultToString(tr.content),
+            };
+            break;
+          }
+          default:
+            // 未知 block 类型:忽略(不阻断整条请求)。
+            break;
+        }
+      }
+      flushTool();
+      flushUser();
+      continue;
+    }
+
+    if (msg.role === 'assistant') {
+      const textParts: string[] = [];
+      let reasoning: string | undefined;
+      const toolCalls: ChatToolCall[] = [];
+      for (const block of msg.content) {
+        switch (block.type) {
+          case 'text': {
+            const text = (block as { text?: string }).text ?? '';
+            if (text) textParts.push(text);
+            break;
+          }
+          case 'thinking': {
+            if (caps.reasoningHistoryField === 'reasoning_content') {
+              const th = block as Extract<AnthropicContentBlock, { type: 'thinking' }>;
+              // 无可见文本的 thinking 不回放(占位无意义);有文本才带。
+              if (th.thinking) reasoning = (reasoning ? `${reasoning}\n` : '') + th.thinking;
+            }
+            break;
+          }
+          case 'tool_use': {
+            const tu = block as Extract<AnthropicContentBlock, { type: 'tool_use' }>;
+            toolCalls.push({
+              id: tu.id,
+              type: 'function',
+              function: {
+                name: tu.name,
+                arguments: JSON.stringify(tu.input ?? {}),
+              },
+            });
+            break;
+          }
+          default:
+            // redacted_thinking(无可回放文本)及其它未知块:忽略。
+            break;
+        }
+      }
+      const hasContent = textParts.length > 0;
+      const hasToolCalls = toolCalls.length > 0;
+      if (!hasContent && !hasToolCalls && !reasoning) continue;
+      const out: ChatAssistantMessage = { role: 'assistant' };
+      // 带 tool_calls 时 content 置 null 而非空串 —— 严格端点对空字符串 content 400,
+      // 对 null 则按「无文本」处理(OpenAI 官方行为)。
+      if (hasContent) out.content = textParts.join('\n');
+      else if (hasToolCalls) out.content = null;
+      if (reasoning) out.reasoning_content = reasoning;
+      else if (caps.toolCallReasoningPlaceholder && hasToolCalls) {
+        // DeepSeek/Kimi 思考模型:带 tool_calls 的 assistant 消息必须有非空
+        // reasoning_content,否则上游 400。注入占位。
+        out.reasoning_content = ' ';
+      }
+      if (hasToolCalls) out.tool_calls = toolCalls;
+      messages.push(out);
+      continue;
+    }
+  }
+
+  // 防御:Chat 兼容端点普遍要求消息序列以 user/system 开头。Anthropic 正常请求总是
+  // 以 user 开头,但极端历史(截断/合成)可能以 assistant/tool 起首 —— 前插空 user。
+  if (messages.length > 0 && messages[0].role !== 'user' && messages[0].role !== 'system' && messages[0].role !== 'developer') {
+    messages.unshift({ role: 'user', content: '' });
+  }
+
+  const out: ChatCompletionsRequest = {
+    model: opts.model,
+    messages,
+    // 恒 stream:handler 的响应翻译只解析 SSE(非流式 JSON 会被静默丢成空响应),
+    // 与 anthropic-responses-bridge 同口径。
+    stream: true,
+  };
+
+  if (caps.streamUsage !== false) out.stream_options = { include_usage: true };
+
+  const tools = (req.tools ?? []).map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      ...(t.description ? { description: t.description } : {}),
+      parameters: t.input_schema ?? { type: 'object', properties: {} },
+      ...(t.input_schema?.strict === true ? { strict: true } : {}),
+    },
+  }));
+  if (tools.length > 0) {
+    out.tools = tools;
+    out.parallel_tool_calls = true;
+  }
+
+  const toolChoice = toolChoiceToChat(req.tool_choice);
+  if (toolChoice !== undefined && tools.length > 0) out.tool_choice = toolChoice;
+  else if (req.tool_choice?.type === 'none') out.tool_choice = 'none';
+
+  // thinking → 上游 reasoning 参数(reasoningField 控制;默认 'none' 不发)。
+  const reasoningField = caps.reasoningField ?? 'none';
+  if (reasoningField !== 'none' && req.thinking) {
+    const enabled = req.thinking.type === 'enabled';
+    switch (reasoningField) {
+      case 'reasoning_effort':
+        out.reasoning_effort = enabled ? budgetToEffort(req.thinking) : 'low';
+        break;
+      case 'reasoning.effort':
+        out.reasoning = { effort: enabled ? budgetToEffort(req.thinking) : 'low' };
+        break;
+      case 'thinking.type':
+        out.thinking = { type: enabled ? 'enabled' : 'disabled' };
+        break;
+      case 'enable_thinking':
+        out.enable_thinking = enabled;
+        break;
+    }
+  }
+
+  const maxTokensField = caps.maxTokensField ?? 'max_tokens';
+  if (maxTokensField !== 'omit' && typeof req.max_tokens === 'number' && req.max_tokens > 0) {
+    if (maxTokensField === 'max_completion_tokens') out.max_completion_tokens = req.max_tokens;
+    else out.max_tokens = req.max_tokens;
+  }
+
+  if (typeof req.temperature === 'number') out.temperature = req.temperature;
+
+  return out;
+}

--- a/packages/anthropic-chat-bridge/src/translate-sse.ts
+++ b/packages/anthropic-chat-bridge/src/translate-sse.ts
@@ -1,0 +1,396 @@
+/**
+ * 流式响应翻译 —— OpenAI Chat Completions SSE → Anthropic Messages SSE(有状态)。
+ *
+ * 用法:handler 逐条 parse 上游 `data:` 行成对象,喂给 `push(chunk)`,拿回 0..N 条
+ * Anthropic SSE 事件顺序写回客户端。上游流结束后调 `finish()` 兜底收尾。
+ *
+ * Chat Completions SSE 形态(无 event 行,纯 data 帧):
+ *   {"choices":[{"delta":{"role":"assistant","content":""},"finish_reason":null}]}
+ *   {"choices":[{"delta":{"content":"Hello"}}]}
+ *   {"choices":[{"delta":{"reasoning_content":"思考..."}}]}            ← DeepSeek/Kimi 扩展
+ *   {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","type":"function",
+ *     "function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}
+ *   {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":"}}]}}]}
+ *   {"choices":[{"delta":{},"finish_reason":"tool_calls"}]}
+ *   {"choices":[],"usage":{"prompt_tokens":9,"completion_tokens":12}}   ← include_usage 尾帧
+ *   data: [DONE]
+ *
+ * 块映射:
+ *   content(delta 流)           → text 块(text_delta 流,惰性开块)
+ *   reasoning_content(delta 流) → thinking 块(thinking_delta 流,惰性开块)
+ *   tool_calls(按 index 累积)   → tool_use 块(**延迟到流尾一次性输出** —— 见下)
+ *   finish_reason               → message_delta.stop_reason
+ *   usage(尾帧)                 → message_delta.usage
+ *
+ * 单开块不变量(Anthropic SSE 硬约定):同一时刻至多一个 content block 打开,块必须
+ * 严格顺序 start→delta→stop。text / thinking 块**可打断**(Anthropic 允许同一消息内
+ * 多个同类型块;上游 reasoning 段严格先于 content 段,实际很少触发)。
+ *
+ * tool_calls 为什么延迟到流尾一次性输出:Chat 流里没有「某 tool 的 arguments 流结束」
+ * 的显式信号 —— 多工具并行时 arguments 交错到达(finish_reason='tool_calls' 才宣告
+ * 全部结束)。若逐 delta 转发,两个 tool_use 块会交错打开,违反单开块不变量,且被提前
+ * 关闭的 tool_use 会带残缺 arguments(Claude Code 拿到残缺 JSON 执行工具)。累积到
+ * finish_reason / 流结束再按 index 顺序输出完整块,天然满足「tool_use 块完整」语义,
+ * 代价仅是工具调用非逐字流式(Claude Code 对 tool_use 的展示本就是块级的)。
+ *
+ * 块内容惰性开块:空块 / 纯空白块会被 Anthropic 回放 400("text content blocks must
+ * contain non-whitespace text"),text / thinking 块只在首个含非空白字符的 delta 到达
+ * 时打开,此前空白先缓冲;全程纯空白则整块不落地。
+ */
+
+import { mapUsage } from './usage.js';
+
+/** 一条待写回客户端的 Anthropic SSE 事件。 */
+export interface AnthropicSseEvent {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+function asRecord(v: unknown): Record<string, unknown> {
+  return v && typeof v === 'object' ? (v as Record<string, unknown>) : {};
+}
+
+function str(v: unknown): string {
+  return typeof v === 'string' ? v : '';
+}
+
+function num(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+/** delta 里的可见思考文本(DeepSeek/Kimi 的 reasoning_content;其它厂商变体兜底)。 */
+function extractReasoning(delta: Record<string, unknown>): string {
+  for (const key of ['reasoning_content', 'reasoning', 'reasoning_details']) {
+    const raw = delta[key];
+    if (typeof raw === 'string' && raw) return raw;
+    if (Array.isArray(raw)) {
+      const text = raw
+        .map((part) => (asRecord(part).type === 'text' ? str(asRecord(part).text) : ''))
+        .join('');
+      if (text) return text;
+    }
+  }
+  return '';
+}
+
+interface ToolCallState {
+  index: number;
+  id: string;
+  name: string;
+  arguments: string;
+}
+
+interface OpenBlockState {
+  kind: 'text' | 'thinking';
+  blockIndex: number;
+}
+
+export class AnthropicSseTranslator {
+  private messageStarted = false;
+  private finished = false;
+  private nextBlockIndex = 0;
+  private hasToolUse = false;
+  private pendingFinishReason: string | null = null;
+  private sawTerminalMarker = false;
+  private usage: unknown | undefined;
+  /** 累积的 tool_calls(按 index 升序,延迟到流尾输出)。 */
+  private readonly tools = new Map<number, ToolCallState>();
+  /** 当前打开的 text / thinking 块(null = 无块打开)。 */
+  private open: OpenBlockState | null = null;
+  private messageId = '';
+  private model: string;
+  private readonly modelPinned: boolean;
+  /** text / thinking 块惰性开块前的空白缓冲。 */
+  private pendingText = '';
+  private pendingThinking = '';
+
+  constructor(model: string) {
+    this.model = model;
+    this.modelPinned = model.length > 0;
+  }
+
+  /** 喂一条上游 Chat Completions chunk,返回要写回客户端的 Anthropic 事件(可能 0 条)。 */
+  push(raw: unknown): AnthropicSseEvent[] {
+    if (this.finished) return [];
+    const chunk = asRecord(raw);
+    const out: AnthropicSseEvent[] = [];
+
+    // 首块回显 id/model 用于 message_start 回显(wire model 固定用构造值,不被覆盖)。
+    const rawId = str(chunk.id);
+    if (rawId && !this.messageStarted) this.messageId = rawId;
+
+    // 流内错误帧(无 choices,带 error 对象)→ turn 级错误。
+    const error = asRecord(chunk.error);
+    if (isPlainObject(chunk) && chunk.error && typeof chunk.error === 'object') {
+      const message = str(error.message) || 'upstream returned an error event';
+      return this.fail(message);
+    }
+
+    if (chunk.usage && typeof chunk.usage === 'object') this.usage = chunk.usage;
+
+    const choices = Array.isArray(chunk.choices) ? chunk.choices : [];
+    // n 恒为 1(请求侧不设 n),只处理第一个 choice。
+    const choice = choices[0];
+    if (choice && typeof choice === 'object') {
+      const c = asRecord(choice);
+      const delta = asRecord(c.delta);
+
+      const reasoning = extractReasoning(delta);
+      if (reasoning) {
+        for (const ev of this.pushThinking(reasoning)) out.push(ev);
+      }
+      const content = str(delta.content);
+      if (content) {
+        for (const ev of this.pushText(content)) out.push(ev);
+      }
+      if (Array.isArray(delta.tool_calls)) {
+        this.collectToolCalls(delta.tool_calls);
+      }
+      const finishReason = str(c.finish_reason);
+      if (finishReason) {
+        this.pendingFinishReason = finishReason;
+        this.sawTerminalMarker = true;
+      }
+    }
+    return out;
+  }
+
+  /** 收到 `[DONE]` 帧(规范流的正常收尾标记)。 */
+  markTerminal(): void {
+    this.sawTerminalMarker = true;
+  }
+
+  /**
+   * 上游流正常结束时的兜底收尾(极少触发 —— 正常路径 finish_reason + [DONE] 已收尾)。
+   * requireTerminalMarker:上游 EOF 前未收到任何终止标记时按失败处理(空流 / 静默截断)。
+   */
+  finish(requireTerminalMarker = false): AnthropicSseEvent[] {
+    if (this.finished) return [];
+    if (requireTerminalMarker && !this.sawTerminalMarker) {
+      return this.fail('upstream SSE stream ended before a terminal marker');
+    }
+    const out: AnthropicSseEvent[] = [];
+    this.ensureMessageStart(out);
+    this.closeOpenBlock(out);
+    this.emitToolUseBlocks(out);
+    const stopReason = this.resolveStopReason();
+    const usage = mapUsage(this.usage);
+    out.push({
+      event: 'message_delta',
+      data: {
+        type: 'message_delta',
+        delta: { stop_reason: stopReason, stop_sequence: null },
+        usage: {
+          input_tokens: usage.input_tokens,
+          output_tokens: usage.output_tokens,
+          cache_read_input_tokens: usage.cache_read_input_tokens,
+          cache_creation_input_tokens: usage.cache_creation_input_tokens,
+        },
+      },
+    });
+    out.push({ event: 'message_stop', data: { type: 'message_stop' } });
+    this.finished = true;
+    return out;
+  }
+
+  /**
+   * 上游读流中途失败(reader 抛错 / 流内错误帧)时的收尾:关掉已打开的块 + `error` 事件,
+   * **不发** message_delta/message_stop —— 已写出部分内容后再补正常收尾,Claude Code
+   * 会把截断响应当成正常完成,上游读取错误被完全掩盖(review 反馈 P1)。已收尾则返回空。
+   * 已累积未输出的 tool_use 一并丢弃(断流后工具调用已注定残缺)。
+   */
+  fail(message: string): AnthropicSseEvent[] {
+    if (this.finished) return [];
+    const out: AnthropicSseEvent[] = [];
+    this.closeOpenBlock(out);
+    this.tools.clear();
+    out.push({
+      event: 'error',
+      data: { type: 'error', error: { type: 'api_error', message } },
+    });
+    this.finished = true;
+    return out;
+  }
+
+  // ── message_start ──────────────────────────────────────────────────────────
+  private ensureMessageStart(out: AnthropicSseEvent[]): void {
+    if (this.messageStarted) return;
+    this.messageStarted = true;
+    out.push({
+      event: 'message_start',
+      data: {
+        type: 'message_start',
+        message: {
+          id: this.messageId || `msg_${Date.now()}`,
+          type: 'message',
+          role: 'assistant',
+          // 回显 wire model(带 bridge 前缀,如 deepseek/deepseek-chat)—— 下游 token
+          // 记账靠前缀区分「桥接轮」与其它上游同名裸模型。
+          model: this.model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 },
+        },
+      },
+    });
+  }
+
+  /**
+   * 单开块不变量的执行点:要为**另一个**块输出前,先关掉当前打开的块。text / thinking
+   * 块可安全打断(之后再来 delta 走「补开」路径开新块续写,内容不丢)。
+   */
+  private closeOpenBlock(out: AnthropicSseEvent[]): void {
+    if (!this.open) return;
+    out.push({
+      event: 'content_block_stop',
+      data: { type: 'content_block_stop', index: this.open.blockIndex },
+    });
+    this.open = null;
+  }
+
+  private openBlock(out: AnthropicSseEvent[], kind: 'text' | 'thinking', blockIndex: number): void {
+    this.open = { kind, blockIndex };
+    out.push({
+      event: 'content_block_start',
+      data: {
+        type: 'content_block_start',
+        index: blockIndex,
+        content_block: kind === 'thinking' ? { type: 'thinking', thinking: '' } : { type: 'text', text: '' },
+      },
+    });
+  }
+
+  // ── text ───────────────────────────────────────────────────────────────────
+  private pushText(delta: string): AnthropicSseEvent[] {
+    const out: AnthropicSseEvent[] = [];
+    this.ensureMessageStart(out);
+    if (this.open?.kind === 'text') {
+      out.push({
+        event: 'content_block_delta',
+        data: { type: 'content_block_delta', index: this.open.blockIndex, delta: { type: 'text_delta', text: delta } },
+      });
+      return out;
+    }
+    // 换块(thinking → text 或断块续写):开新 text 块。前导空白随首个 delta 一并发出。
+    this.closeOpenBlock(out);
+    const pending = this.pendingText + delta;
+    if (pending.trim().length === 0) {
+      this.pendingText = pending;
+      return out;
+    }
+    this.pendingText = '';
+    this.openBlock(out, 'text', this.nextBlockIndex++);
+    out.push({
+      event: 'content_block_delta',
+      data: { type: 'content_block_delta', index: this.open?.blockIndex ?? 0, delta: { type: 'text_delta', text: pending } },
+    });
+    return out;
+  }
+
+  // ── thinking ───────────────────────────────────────────────────────────────
+  private pushThinking(delta: string): AnthropicSseEvent[] {
+    const out: AnthropicSseEvent[] = [];
+    this.ensureMessageStart(out);
+    if (this.open?.kind === 'thinking') {
+      out.push({
+        event: 'content_block_delta',
+        data: { type: 'content_block_delta', index: this.open.blockIndex, delta: { type: 'thinking_delta', thinking: delta } },
+      });
+      return out;
+    }
+    this.closeOpenBlock(out);
+    const pending = this.pendingThinking + delta;
+    if (pending.trim().length === 0) {
+      this.pendingThinking = pending;
+      return out;
+    }
+    this.pendingThinking = '';
+    this.openBlock(out, 'thinking', this.nextBlockIndex++);
+    out.push({
+      event: 'content_block_delta',
+      data: { type: 'content_block_delta', index: this.open?.blockIndex ?? 0, delta: { type: 'thinking_delta', thinking: pending } },
+    });
+    return out;
+  }
+
+  // ── tool_calls(累积,流尾输出)────────────────────────────────────────────────
+  private collectToolCalls(toolCalls: unknown[]): void {
+    for (const [position, rawCall] of toolCalls.entries()) {
+      const call = asRecord(rawCall);
+      if (!isPlainObject(call)) continue;
+      // OpenAI 规范带 index;个别厂商缺失时按数组位置。
+      const index = num(call.index);
+      const key = typeof call.index === 'number' ? index : position;
+      const existing = this.tools.get(key);
+      const function_ = asRecord(call.function);
+      const id = str(call.id);
+      const name = str(function_.name);
+      const args = str(function_.arguments);
+      if (existing) {
+        if (name) existing.name = name;
+        if (args) existing.arguments += args;
+      } else {
+        // 首个 delta 必有 id + name;缺失(厂商不标准)时兜底合成。
+        this.tools.set(key, {
+          index: key,
+          id: id || `call_${key}`,
+          name: name || '',
+          arguments: args,
+        });
+      }
+    }
+  }
+
+  /** 流尾一次性输出全部累积的 tool_use 块(按 index 升序,保证多工具顺序稳定)。 */
+  private emitToolUseBlocks(out: AnthropicSseEvent[]): void {
+    if (this.tools.size === 0) return;
+    const sorted = [...this.tools.values()].sort((a, b) => a.index - b.index);
+    for (const tool of sorted) {
+      const blockIndex = this.nextBlockIndex++;
+      this.hasToolUse = true;
+      out.push({
+        event: 'content_block_start',
+        data: {
+          type: 'content_block_start',
+          index: blockIndex,
+          content_block: { type: 'tool_use', id: tool.id, name: tool.name, input: {} },
+        },
+      });
+      // 完整 arguments 一次性作为单条 input_json_delta 发出(累积式输出,见头注释)。
+      if (tool.arguments) {
+        out.push({
+          event: 'content_block_delta',
+          data: { type: 'content_block_delta', index: blockIndex, delta: { type: 'input_json_delta', partial_json: tool.arguments } },
+        });
+      }
+      out.push({
+        event: 'content_block_stop',
+        data: { type: 'content_block_stop', index: blockIndex },
+      });
+    }
+    this.tools.clear();
+  }
+
+  // ── 收尾 ────────────────────────────────────────────────────────────────────
+  private resolveStopReason(): string {
+    const raw = this.pendingFinishReason ?? '';
+    switch (raw) {
+      case 'stop':
+        return 'end_turn';
+      case 'length':
+        return 'max_tokens';
+      case 'tool_calls':
+        return 'tool_use';
+      case 'content_filter':
+        // 内容被过滤 ≠ 触顶:保守回落默认,别让 CC 误判成 max_tokens 触发自动续写。
+        return this.hasToolUse ? 'tool_use' : 'end_turn';
+      default:
+        return this.hasToolUse ? 'tool_use' : 'end_turn';
+    }
+  }
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null && !Array.isArray(v);
+}

--- a/packages/anthropic-chat-bridge/src/types.ts
+++ b/packages/anthropic-chat-bridge/src/types.ts
@@ -1,0 +1,254 @@
+/**
+ * 公开类型 —— Anthropic Messages API(输入)与 OpenAI Chat Completions(输出)的最小
+ * 子集(仅覆盖 Claude Code SDK 实际会发/收的形态),以及 bridge 的注入接口。
+ *
+ * 设计原则(与 @cindy/anthropic-responses-bridge 对齐):
+ *   - 只声明本包实际读写的字段,不追求覆盖两套 API 的全量 schema;
+ *   - 未知字段一律保留(request 翻译只搬我们认识的键,SSE 翻译按 `type`/字段名分发,
+ *     不认识的事件直接丢弃)。
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Anthropic Messages API —— bridge 的**输入**(Claude Code 发来的请求)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Anthropic 请求里的 content block(user / assistant 两侧的并集)。 */
+export type AnthropicContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; source: AnthropicImageSource }
+  | { type: 'tool_use'; id: string; name: string; input: unknown }
+  | { type: 'tool_result'; tool_use_id: string; content?: unknown; is_error?: boolean }
+  | { type: 'thinking'; thinking: string; signature?: string }
+  | { type: 'redacted_thinking'; data: string }
+  | { type: string; [k: string]: unknown };
+
+export interface AnthropicImageSource {
+  type: 'base64' | 'url';
+  media_type?: string;
+  data?: string;
+  url?: string;
+}
+
+export interface AnthropicMessage {
+  // Claude Code 除 user/assistant 外,还会在 messages 里塞 role:"system" 的消息
+  // (典型:ToolSearch 延迟工具提醒等 mid-conversation system-reminder)。
+  role: 'user' | 'assistant' | 'system';
+  content: string | AnthropicContentBlock[];
+}
+
+export interface AnthropicTool {
+  name: string;
+  description?: string;
+  input_schema?: Record<string, unknown>;
+}
+
+export type AnthropicToolChoice =
+  | { type: 'auto' }
+  | { type: 'any' }
+  | { type: 'tool'; name: string }
+  | { type: 'none' };
+
+export interface AnthropicThinkingConfig {
+  type: 'enabled' | 'disabled';
+  budget_tokens?: number;
+}
+
+export interface AnthropicMessagesRequest {
+  model: string;
+  messages: AnthropicMessage[];
+  system?: string | Array<{ type: 'text'; text: string }>;
+  tools?: AnthropicTool[];
+  tool_choice?: AnthropicToolChoice;
+  thinking?: AnthropicThinkingConfig;
+  max_tokens?: number;
+  temperature?: number;
+  stream?: boolean;
+  metadata?: { user_id?: string; [k: string]: unknown };
+  [k: string]: unknown;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OpenAI Chat Completions —— bridge 的**输出**(发往 Chat-Completions-only 上游)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface ChatTextContentPart {
+  type: 'text';
+  text: string;
+}
+
+export interface ChatImageUrlContentPart {
+  type: 'image_url';
+  image_url: { url: string; detail?: string };
+}
+
+export type ChatUserContentPart = ChatTextContentPart | ChatImageUrlContentPart;
+
+export interface ChatTextMessage {
+  role: 'system' | 'developer';
+  content: string;
+}
+
+export interface ChatUserMessage {
+  role: 'user';
+  content: string | ChatUserContentPart[];
+}
+
+export interface ChatToolCall {
+  id: string;
+  type: 'function';
+  function: { name: string; arguments: string };
+}
+
+export interface ChatAssistantMessage {
+  role: 'assistant';
+  content?: string | null;
+  /**
+   * DeepSeek/Kimi/Moonshot 的思考模型要求带 tool_calls 的 assistant 消息携带非空
+   * reasoning_content(否则上游报 `reasoning_content is missing in assistant tool call
+   * message`);由 capabilities.reasoningHistoryField / toolCallReasoningPlaceholder 控制。
+   */
+  reasoning_content?: string;
+  tool_calls?: ChatToolCall[];
+}
+
+export interface ChatToolMessage {
+  role: 'tool';
+  tool_call_id: string;
+  content: string;
+}
+
+export type ChatMessage = ChatTextMessage | ChatUserMessage | ChatAssistantMessage | ChatToolMessage;
+
+export interface ChatCompletionsRequest {
+  model: string;
+  messages: ChatMessage[];
+  tools?: Array<{
+    type: 'function';
+    function: {
+      name: string;
+      description?: string;
+      parameters: Record<string, unknown>;
+      strict?: boolean;
+    };
+  }>;
+  tool_choice?: unknown;
+  parallel_tool_calls?: boolean;
+  max_tokens?: number;
+  max_completion_tokens?: number;
+  reasoning_effort?: string;
+  reasoning?: { effort: string };
+  thinking?: { type: string };
+  enable_thinking?: boolean;
+  temperature?: number;
+  stream: boolean;
+  stream_options?: { include_usage: true };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bridge 注入接口
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface BridgeLogger {
+  debug?: (msg: string, meta?: Record<string, unknown>) => void;
+  info?: (msg: string, meta?: Record<string, unknown>) => void;
+  warn?: (msg: string, meta?: Record<string, unknown>) => void;
+  error?: (msg: string, meta?: Record<string, unknown>) => void;
+}
+
+export type ChatDeveloperRole = 'system' | 'developer';
+export type ChatMaxTokensField = 'max_tokens' | 'max_completion_tokens' | 'omit';
+export type ChatImageInput = 'image_url' | 'none';
+export type ChatReasoningField =
+  | 'reasoning_effort'
+  | 'reasoning.effort'
+  | 'thinking.type'
+  | 'enable_thinking'
+  | 'none';
+export type ChatReasoningHistoryField = 'reasoning_content' | 'none';
+
+/**
+ * 上游差异(同协议族内的厂商参数分歧),全部由数据表达 —— 对齐 responses-chat-bridge
+ * 的 ChatBridgeCapabilities 设计哲学:默认值保守(fail-closed),只有确认支持的厂商才开。
+ */
+export interface AnthropicChatBridgeCapabilities {
+  /** 顶层 system 落成的消息角色;默认 'system'(OpenAI 兼容端点普遍接受)。 */
+  developerRole?: ChatDeveloperRole;
+  /**
+   * Anthropic `max_tokens` 的上游字段。默认 'max_tokens'(兼容端点最通用);
+   * 仅 o 系列等强制 `max_completion_tokens` 的官方端点用 'max_completion_tokens';
+   * 上游自行管理输出长度时可 'omit'。
+   */
+  maxTokensField?: ChatMaxTokensField;
+  /**
+   * Anthropic `thinking` 请求映射成的上游参数。默认 'none' = 不发送任何 reasoning
+   * 参数(上游自行决定,兼容性最好)。
+   */
+  reasoningField?: ChatReasoningField;
+  /**
+   * 会话历史里的 Anthropic `thinking` 块 → assistant 消息 `reasoning_content`。
+   * 默认 'none' = 丢弃 thinking(上游不认该扩展字段时回放会被 400)。
+   */
+  reasoningHistoryField?: ChatReasoningHistoryField;
+  /**
+   * 带 tool_calls 的 assistant 消息需要非空 reasoning_content 的厂商(DeepSeek/Kimi)。
+   * 开启后为缺失的 tool_call assistant 消息注入占位文本。
+   */
+  toolCallReasoningPlaceholder?: boolean;
+  /**
+   * Anthropic 图片块的上游等价形态。缺省 = 'image_url'(Chat 兼容层最通用,默认开启);
+   * 显式 'none' = 关闭图片输入,图片块替换成显式占位文本(不静默丢上下文)。
+   */
+  imageInput?: ChatImageInput;
+  /** 请求 `stream_options.include_usage`。默认 true;不支持的旧端点可关。 */
+  streamUsage?: boolean;
+}
+
+/**
+ * 单个上游供应商的配置(= Chat-Completions 源 adapter 契约)。bridge 按 model 前缀匹配
+ * provider(空前缀 = 匹配所有模型),用它的 upstream / headers / quirks 翻译转发。
+ * 新增 Chat 系订阅源 = 加一份本配置,**不改翻译器 / server 代码**。
+ */
+export interface ChatBridgeProviderConfig {
+  /** model id 前缀(如 'deepseek/');bridge 收到后 strip 掉再发上游。空串 = 匹配所有模型。 */
+  prefix: string;
+  /** 上游 wire 协议;省略 = 'openai-chat'(当前唯一实现)。 */
+  wireProtocol?: BridgeWireProtocol;
+  /** 上游 Chat Completions base(不含路径),如 https://api.deepseek.com。 */
+  upstreamBase: string;
+  /** 缺省 `/chat/completions`;少数厂商可显式覆盖。 */
+  chatCompletionsPath?: string;
+  /**
+   * 构造发往上游的 provider 专属 headers(**含鉴权**,如 authorization Bearer)。
+   * 每请求调用一次;抛错 → 该请求回 502(鉴权不可用),不影响其它并发请求 / 其它 provider。
+   */
+  buildHeaders: (ctx: { sessionId?: string }) => Promise<Record<string, string>>;
+  capabilities?: AnthropicChatBridgeCapabilities;
+  /** 上游返回非 2xx 后、错误响应写回调用方前触发;回调异常只记日志,不覆盖原始上游错误。 */
+  onUpstreamError?: (info: ChatBridgeUpstreamErrorInfo) => void | Promise<void>;
+  /** 上游响应头里的 `x-ratelimit-*` 限流信息(标准 OpenAI 风格);缺头 → 不回调。 */
+  onRateLimit?: (info: UpstreamRateLimitInfo) => void;
+}
+
+/** Provider 在上游返回非 2xx 后收到的请求级错误上下文。 */
+export interface ChatBridgeUpstreamErrorInfo {
+  status: number;
+  body: string;
+  /** 本次实际发往上游的 provider headers;可能含凭证,只能用于内存态关联,禁止记录日志。 */
+  requestHeaders: Readonly<Record<string, string>>;
+}
+
+/** 上游 `x-ratelimit-*` 响应头解析结果(仅数值可解析的字段;全 undefined 时不回调)。 */
+export interface UpstreamRateLimitInfo {
+  limitRequests?: number;
+  remainingRequests?: number;
+  limitTokens?: number;
+  remainingTokens?: number;
+}
+
+/**
+ * bridge 侧的上游 wire 协议标识。当前唯一实现是 'openai-chat'(Anthropic Messages ↔
+ * OpenAI Chat Completions 翻译器);预留 'openai-responses' 扩展位 —— 那一条已有
+ * @cindy/anthropic-responses-bridge,不在此实现。
+ * createAnthropicChatHandler 对未实现的协议 fail-fast 抛错,防止注册了却静默不可用。
+ */
+export type BridgeWireProtocol = 'openai-chat';

--- a/packages/anthropic-chat-bridge/src/usage.ts
+++ b/packages/anthropic-chat-bridge/src/usage.ts
@@ -1,0 +1,41 @@
+/**
+ * usage 映射 —— OpenAI Chat Completions usage → Anthropic Messages usage。
+ *
+ * Chat:  { prompt_tokens(含 cached), completion_tokens, total_tokens,
+ *         prompt_tokens_details:{cached_tokens}(部分厂商), ... }
+ * Anthropic:  { input_tokens(不含 cache_read), output_tokens,
+ *               cache_read_input_tokens, cache_creation_input_tokens }
+ *
+ * 与 anthropic-responses-bridge 的 mapUsage 同口径:Anthropic 的 input_tokens **不含**
+ * cache_read,而 Chat 的 prompt_tokens 通常**含** cached;所以 input_tokens =
+ * prompt_tokens - cached_tokens,cache_read_input_tokens = cached_tokens。
+ * output_tokens 直接透传(已含 reasoning,正是要计费的)。
+ */
+
+export interface AnthropicUsage {
+  input_tokens: number;
+  output_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+}
+
+function num(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+export function mapUsage(chatUsage: unknown): AnthropicUsage {
+  const u = (chatUsage ?? {}) as Record<string, unknown>;
+  const promptTokens = num(u.prompt_tokens);
+  // 兼容两种形态:OpenAI 官方 prompt_tokens_details.cached_tokens,以及部分厂商
+  // 直接把缓存部分摊进 prompt_tokens 明细的变体;都拿不到则按 0(诚实降级)。
+  const details = (u.prompt_tokens_details ?? {}) as Record<string, unknown>;
+  const cached = num(details.cached_tokens);
+  return {
+    input_tokens: Math.max(0, promptTokens - cached),
+    output_tokens: num(u.completion_tokens),
+    cache_read_input_tokens: cached,
+    // Chat 系上游没有显式「写缓存」的计费概念(cache_creation 只存在于 Anthropic
+    // 原生),恒 0 —— 与 anthropic-responses-bridge 同口径。
+    cache_creation_input_tokens: 0,
+  };
+}

--- a/packages/anthropic-chat-bridge/tsconfig.json
+++ b/packages/anthropic-chat-bridge/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "sourceMap": true,
+    "baseUrl": "."
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -143,8 +143,10 @@ export type OAuthProviderDescriptor =
 export interface RoutingDescriptor {
   /**
    * 上游 wire protocol。缺省按 agent 保持历史语义：Claude Code = anthropic-messages，
-   * Codex = openai-responses。Codex 的 openai-chat / anthropic-messages 会分别进入
-   * 对应的本地 Responses bridge。
+   * Codex = openai-responses。任一 agent 的 openai-chat / openai-responses（Claude Code）
+   * 与 openai-chat / anthropic-messages（Codex）都会分别进入对应的本地协议 bridge
+   * （anthropic-chat-bridge / anthropic-responses-bridge / responses-chat-bridge /
+   * responses-anthropic-bridge）。
    */
   wireProtocol?: ProviderWireProtocol;
   /** 真实上游 base URL（direct 时是供应商自家；gateway 时是 XD 网关 base）。 */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
 
   apps/desktop:
     dependencies:
+      '@cindy/anthropic-chat-bridge':
+        specifier: workspace:*
+        version: link:../../packages/anthropic-chat-bridge
       '@cindy/anthropic-compat-proxy':
         specifier: workspace:*
         version: link:../../packages/anthropic-compat-proxy
@@ -756,6 +759,27 @@ importers:
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)
+
+  packages/anthropic-chat-bridge:
+    devDependencies:
+      '@eslint/js':
+        specifier: ^9.0.0
+        version: 9.39.5
+      '@types/node':
+        specifier: '*'
+        version: 25.9.5
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.5(jiti@2.7.0)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
         version: 3.2.7(@types/debug@4.1.13)(@types/node@25.9.5)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@1.8.0))(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)


### PR DESCRIPTION
## 背景

给内置 Claude Code 添加自定义模型供应商时，目前只能使用 Anthropic Messages 协议（UI 不提供协议选择、后端校验白名单锁定）；而 Codex 侧早已支持三种 wire 协议（原生 Responses / Chat Completions 桥接 / Anthropic Messages 桥接）。本 PR 借鉴 cc-switch 的协议适配思路，把同样的能力补到 Claude Code 侧：**添加/编辑供应商时，Claude Code 与 Codex 都可独立选择 Anthropic / Chat Completions / Responses 任意一种协议**，配置后由 Cindy 运行时自动走对应的本地协议桥接，开箱即用。

## 改动

### 新包 `packages/anthropic-chat-bridge`
Claude Code 侧的 Chat Completions 桥接（`Anthropic Messages ↔ Chat Completions`），结构对齐既有 `anthropic-responses-bridge`，进程内 handler（`RoutingDecision.localHandler` 插槽，无独立 server、消息流不多跳）：

- **请求翻译**：system 合并置首；`tool_result` 拆成独立 `role:'tool'` 消息（保持 Chat 交替要求）；assistant 的 text / tool_use / thinking 合并进一条消息；thinking 请求经 `capabilities.reasoningField` 映射（默认不发）；图片 → `image_url` part（可显式关闭并替换占位文本）
- **流式响应翻译**：`content` → text 块、`reasoning_content` → thinking 块（惰性开块，杜绝纯空白块回放 400）；**tool_calls 累积到流尾一次性输出**——Chat 流没有单个工具 arguments 结束的显式信号，逐 delta 转发会违反 Anthropic 单开块不变量并产生残缺 tool_use；usage 尾帧 → `message_delta`
- **handler**：`count_tokens` 本地估算、上游错误转 Anthropic error 形状、`x-ratelimit-*` 头回调、零事件流合成诊断 error（与 #941 同口径）
- 24 个单元测试覆盖请求/响应翻译全路径

### 配置层（与 Codex 对齐）
- `CustomProviderDialog`：协议选择器从 codex-only 改为两个 tab 都渲染
- `custom-provider-store`：claude-code runtime 的 wireProtocol 白名单放宽为三种
- `customProviderWireProtocols`：选项列表双 agent 共用
- i18n（zh-CN / en）：协议文案改为双 agent 通用

### 运行时层（Claude Code 侧）
- `anthropic-chat-bridge-host.ts`：为 `openai-chat` 供应商装配 chat bridge（`buildLocalHandlerHeaders` 同源鉴权头、上游错误喂回 `providerError` 广播通道）
- `anthropic-responses-bridge-host.ts`：新增 `createClaudeResponsesBridgeHandler`，为 `openai-responses` 供应商装配 responses bridge（effort / Fast 会话态闭包注入）
- `anthropic-compat-proxy-host.ts`：① 段同步预判 wireProtocol（不读凭证，热路径零额外开销），命中 `openai-chat` / `openai-responses` 走异步解析 + `localHandler`；② 段 spawn 默认路由提取为闭包，解析失败回落 no-break

### 文档
- `docs/claude-code-protocol-bridges.md`：架构、装配链路、能力边界（已知降级）说明

## 验证

- 新包：`tsc` / `eslint` / 24 个单测全绿
- desktop：`tsc --noEmit` 通过；`custom-provider-store`（24）、`providerRoute`（45）、`claudeProxyScopeGate` + `claudeSessionRouteObservation`（13）、`customProviderWireProtocols`（3）测试全部通过
- 现有 wireProtocol 校验用例更新为接受桥接协议；`claudeSessionRouteObservation` 的 provider-route mock 补齐新函数

## 已知边界

- Chat 桥接的工具调用非逐字流式（累积后块级输出，保证完整性优先）
- 无 signature 的 thinking 默认不回放下游（`reasoning_content` 回放等厂商扩展参数按 capabilities 逐厂商开启）
- 预设（AddProviderWizard）不动：现有预设对 claude-code 均为 Anthropic 兼容端点
