### PR TITLE
ci: pin pr-code-review to latest upstream v1

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -69,7 +69,7 @@ jobs:
     #
     # 已知残余风险(有意接受,不是疏漏):钉这一行锁住的是「跑哪份 workflow 文件、
     # 什么 prompt、什么权限声明、什么工具白名单」,锁不住「该文件在运行期拉取
-    # 并执行哪个版本的 action」。截至 0838103,被调用文件内部是两个浮动 tag——
+    # 并执行哪个版本的 action」。截至 8744cd0,被调用文件内部是两个浮动 tag——
     # actions/checkout@v6 与 anthropics/claude-code-action@v1——它们运行在持有
     # ANTHROPIC_API_KEY 与 pull-requests:write 的 job 里。
     # 接受的理由:这两个分别是 GitHub 与 Anthropic 的第一方 action,tag 被恶意
@@ -78,7 +78,7 @@ jobs:
     # 真正的修法在上游:让 krosdai/.github 把内部 action 钉到 SHA,本仓再 re-pin
     # 到新的上游 SHA。届时删掉本段注释。
     # 背景见 PR #985 与安全门 issue #999。
-    uses: krosdai/.github/.github/workflows/code-review.yml@0838103fffe7d4c38247050098defc8ae47b8355 # v1
+    uses: krosdai/.github/.github/workflows/code-review.yml@8744cd0f82b5bb4bd26bdf998fe8ce8f4f2249f7 # v1
     with:
       pr_number: ${{ github.event.pull_request.number }}
       is_draft: ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 `.github/workflows/pr-code-review.yml` 里复用的 `krosdai/.github` code-review workflow 从旧 pin `0838103…` 更新到当前上游 `v1` tag 的 commit SHA `8744cd0…`（上游变更：改用 Claude Opus 5）。同步更新注释里的「截至」短 SHA。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（常规 pin 升级）
- 本 PR 包含：`pr-code-review.yml` 上游 SHA pin + 对应注释
- 明确不包含：上游 workflow 内容本身、本仓 REVIEW.md / 其它 CI
- 用户可见变化：无（仅影响 PR 自动 code review 所用模型版本）
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
# 解析上游 v1 tag 当前指向
git ls-remote https://github.com/krosdai/.github.git refs/tags/v1
# → 8744cd0f82b5bb4bd26bdf998fe8ce8f4f2249f7

gh api repos/krosdai/.github/commits/v1 --jq '{sha, message}'
# → 8744cd0… "Merge pull request #36 … use Claude Opus 5"

# 对比旧 pin → 新 pin
gh api repos/krosdai/.github/compare/0838103…8744cd0 --jq '{ahead_by, commits}'
# → ahead_by: 2（Opus 5 相关）

# 新 pin 处被调用 workflow 内部仍是浮动 tag（与注释一致）
# actions/checkout@v6、anthropics/claude-code-action@v1

pnpm check:dco
# DCO check passed: 1 commit signed off — range b43447da..15511da7
```

`pnpm test:unit` 在本 orb 跑过：300 pass / 15 fail。失败全部来自 `dev-migration-policy` / `fixed-baseline` 等 fixture 里的 `git commit`——orb 的 SSH 签名 helper 在子进程 fixture 仓库里写不了签名缓冲（`failed reading ssh signing data buffer`），与本 PR 的 workflow-only 改动无关。本改动不涉及任何 package，无需 typecheck。

### 手工验证

不涉及（YAML pin 更新；合并后下一次非 draft 同仓 PR 的 `pr-code-review` run 会实际拉到新 SHA）。

### 未执行的验证

- 未在真实 PR 上实跑 `pr-code-review` job（需合并或临时指向本分支后由事件触发）。
- 全量 `pnpm test:unit` 因 orb 签名环境对 fixture commit 的干扰未作为本 PR 的有效门禁证据；失败与 diff 无交集。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：跨 org reusable workflow 升级；自动 review 所用模型变为 Opus 5

### 影响与回滚

- 影响范围：同仓非 draft PR 的建议性 auto code review（持有 `pull-requests:write` + `ANTHROPIC_API_KEY`）。上游 diff 仅模型升级；内部 action 仍为 `actions/checkout@v6` 与 `anthropics/claude-code-action@v1` 浮动 tag（与现有注释中的有意接受风险一致）。
- 回滚 / 降级方式：将 `uses:` 行 pin 回 `0838103fffe7d4c38247050098defc8ae47b8355` 并开 PR 合并。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因