### PR TITLE
fix(desktop): 保留用户自有媒体来源跨区域可用

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -155,33 +155,42 @@ describe('projectProviderCatalogForBuildRegion — 用户自有媒体来源', ()
     expect(xd?.videoModels?.map((m) => m.id)).toEqual(['seedance-fast', 'seedance-pro']);
   });
 
-  it('非 xd 供应商 models dict 中的媒体型号在 cn 区域保持不变', () => {
-    const thirdParty: Provider = {
-      id: 'third',
-      name: 'Third Party',
-      source: 'builtin',
-      agents: ['claude-code'],
-      auth: { method: 'oauth' },
-      routing: {},
-      models: {
-        'claude-code': [
-          { ...model('seedance-fast'), group: 'video' },
-          model('chat-model'),
-        ],
-      },
-    };
-    const base = catalog();
-    const projected = projectProviderCatalogForBuildRegion(
-      { ...base, providers: [...base.providers, thirdParty] },
-      'cn',
-    );
-    const third = projected.providers.find((p) => p.id === 'third');
-    expect(third).toBe(thirdParty);
-    expect(third?.models['claude-code']?.map((m) => m.id)).toEqual([
-      'seedance-fast',
-      'chat-model',
-    ]);
-  });
+  it.each(['cn', 'dev'] as const)(
+    '非 xd 供应商在 %s 保留图像与聊天能力,暂不暴露视频能力',
+    (region) => {
+      const thirdParty: Provider = {
+        id: 'third',
+        name: 'Third Party',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'oauth' },
+        routing: {},
+        models: {
+          'claude-code': [
+            { ...model('seedance-fast'), group: 'video' },
+            { ...model('third/image'), group: 'image' },
+            model('chat-model'),
+          ],
+        },
+        imageModels: [{ id: 'third/image', name: 'Third Image' }],
+        imageDefaults: { standard: 'third/image' },
+        videoModels: [{ id: 'seedance-fast', name: 'Seedance Fast' }],
+        videoDefaults: { standard: 'seedance-fast' },
+      };
+      const base = catalog();
+      const projected = projectProviderCatalogForBuildRegion(
+        { ...base, providers: [...base.providers, thirdParty] },
+        region,
+      );
+      const third = projected.providers.find((p) => p.id === 'third');
+      expect(third).not.toBe(thirdParty);
+      expect(third?.models['claude-code']?.map((m) => m.id)).toEqual(['third/image', 'chat-model']);
+      expect(third?.imageModels).toBe(thirdParty.imageModels);
+      expect(third?.imageDefaults).toBe(thirdParty.imageDefaults);
+      expect(third?.videoModels).toEqual([]);
+      expect(third?.videoDefaults).toBeUndefined();
+    },
+  );
 
   it('mode: image_generation 的用户模型在 cn 区域保持可用', () => {
     const modeOnly: Provider = {

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -118,8 +118,8 @@ describe('provider access policy', () => {
   );
 });
 
-describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', () => {
-  it('非 global 区域对所有供应商清空图像清单/默认,新来源不绕地区闸', () => {
+describe('projectProviderCatalogForBuildRegion — 用户自有媒体来源', () => {
+  it('非 global 区域只投影 Cindy AI,保留用户连接的图像来源', () => {
     const gemini: Provider = {
       id: 'gemini',
       name: 'Google Gemini',
@@ -139,7 +139,7 @@ describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', ()
       routing: {},
       models: { 'claude-code': [] },
       imageModels: [{ id: 'openai/gpt-image-2', name: 'GPT Image 2' }],
-      // 防御对象:即使有人违反"只有 xd 声明 defaults"的契约,大陆闸也要剥掉。
+      // 防御对象:即使未来用户来源声明 defaults,区域投影也不应改写它。
       imageDefaults: { standard: 'openai/gpt-image-2' },
     };
     const base = catalog();
@@ -147,16 +147,15 @@ describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', ()
       { ...base, providers: [...base.providers, gemini, openai] },
       'cn',
     );
-    for (const p of projected.providers) {
-      expect(p.imageModels ?? []).toEqual([]);
-      expect(p.imageDefaults).toBeUndefined();
-    }
-    // 视频白名单维持 xd 专属:非 xd 供应商声明的视频清单一并清空。
+    expect(projected.providers.find((p) => p.id === 'gemini')).toBe(gemini);
+    expect(projected.providers.find((p) => p.id === 'openai')).toBe(openai);
     const xd = projected.providers.find((p) => p.id === 'xd');
+    expect(xd?.imageModels).toEqual([]);
+    expect(xd?.imageDefaults).toBeUndefined();
     expect(xd?.videoModels?.map((m) => m.id)).toEqual(['seedance-fast', 'seedance-pro']);
   });
 
-  it('非 xd 供应商 models dict 中的 mainland video 型号在 cn 区域同样被剥离', () => {
+  it('非 xd 供应商 models dict 中的媒体型号在 cn 区域保持不变', () => {
     const thirdParty: Provider = {
       id: 'third',
       name: 'Third Party',
@@ -177,10 +176,14 @@ describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', ()
       'cn',
     );
     const third = projected.providers.find((p) => p.id === 'third');
-    expect(third?.models['claude-code']?.map((m) => m.id)).toEqual(['chat-model']);
+    expect(third).toBe(thirdParty);
+    expect(third?.models['claude-code']?.map((m) => m.id)).toEqual([
+      'seedance-fast',
+      'chat-model',
+    ]);
   });
 
-  it('mode: image_generation 的模型在 cn 区域被剥离(classifyModel 权威分类,不依赖 id 关键词)', () => {
+  it('mode: image_generation 的用户模型在 cn 区域保持可用', () => {
     const modeOnly: Provider = {
       id: 'xai',
       name: 'xAI',
@@ -201,7 +204,11 @@ describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', ()
       'cn',
     );
     const xai = projected.providers.find((p) => p.id === 'xai');
-    expect(xai?.models['claude-code']?.map((m) => m.id)).toEqual(['xai/grok-chat']);
+    expect(xai).toBe(modeOnly);
+    expect(xai?.models['claude-code']?.map((m) => m.id)).toEqual([
+      'xai/aurora',
+      'xai/grok-chat',
+    ]);
   });
 
   it('global 区域原样返回(含新来源的媒体清单)', () => {
@@ -219,5 +226,10 @@ describe('projectProviderCatalogForBuildRegion — 图像多来源(2026-07)', ()
     const input = { ...base, providers: [...base.providers, gemini] };
     const projected = projectProviderCatalogForBuildRegion(input, 'global');
     expect(projected).toBe(input);
+  });
+
+  it('目录没有 Cindy AI 时非 global 也保持原对象', () => {
+    const input: Catalog = { version: 'test', providers: [] };
+    expect(projectProviderCatalogForBuildRegion(input, 'cn')).toBe(input);
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -55,6 +55,7 @@ function catalog(): Catalog {
     draft: 'happyhorse',
     best: 'seedance-pro',
   };
+  xd.models.codex = undefined;
   return {
     version: 'test',
     providers: [
@@ -114,6 +115,7 @@ describe('provider access policy', () => {
         'seedance-fast',
         'seedance-pro',
       ]);
+      expect(xd?.models.codex).toEqual([]);
     },
   );
 });
@@ -171,6 +173,7 @@ describe('projectProviderCatalogForBuildRegion — 用户自有媒体来源', ()
             { ...model('third/image'), group: 'image' },
             model('chat-model'),
           ],
+          codex: undefined,
         },
         imageModels: [{ id: 'third/image', name: 'Third Image' }],
         imageDefaults: { standard: 'third/image' },
@@ -185,6 +188,7 @@ describe('projectProviderCatalogForBuildRegion — 用户自有媒体来源', ()
       const third = projected.providers.find((p) => p.id === 'third');
       expect(third).not.toBe(thirdParty);
       expect(third?.models['claude-code']?.map((m) => m.id)).toEqual(['third/image', 'chat-model']);
+      expect(third?.models.codex).toEqual([]);
       expect(third?.imageModels).toBe(thirdParty.imageModels);
       expect(third?.imageDefaults).toBe(thirdParty.imageDefaults);
       expect(third?.videoModels).toEqual([]);

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -37,10 +37,10 @@ function projectVideoDefaults(
  * capabilities that the regional Cindy service supports.
  *
  * Region is a build-time choice for Cindy-owned services, not a restriction on
- * providers the user connected locally. Therefore this projection only changes
- * `xd`; OpenAI/Codex OAuth, xAI OAuth, Gemini API keys and custom providers keep
- * their own catalog in every build. Applying the gate to all providers makes a
- * Mainland build silently discard user-owned capabilities that work directly.
+ * providers the user connected locally. OpenAI/Codex OAuth, xAI OAuth, Gemini
+ * API keys and custom providers therefore keep their image catalog in every
+ * build. Video dispatch is not provider-aware yet, so non-XD video capabilities
+ * stay hidden outside Global until the runtime can route them by provider.
  */
 export function projectProviderCatalogForBuildRegion(
   catalog: Catalog,
@@ -51,12 +51,34 @@ export function projectProviderCatalogForBuildRegion(
   let changed = false;
   const providers = catalog.providers.map((provider) => {
     const isCindyAi = provider.id === CINDY_AI_PROVIDER_ID;
-    if (!isCindyAi) return provider;
+    if (!isCindyAi) {
+      const models = Object.fromEntries(
+        Object.entries(provider.models).map(([agent, list]) => [
+          agent,
+          list.filter((model) => classifyModel(model) !== 'video'),
+        ]),
+      ) as Provider['models'];
+      const hasVideoModels = Object.values(provider.models).some(
+        (list) => list?.some((model) => classifyModel(model) === 'video') ?? false,
+      );
+      const hasVideoCatalog =
+        provider.videoModels !== undefined || provider.videoDefaults !== undefined;
+      if (!hasVideoModels && !hasVideoCatalog) return provider;
+
+      changed = true;
+      const projected: Provider = {
+        ...provider,
+        models,
+        videoModels: [],
+      };
+      delete projected.videoDefaults;
+      return projected;
+    }
     changed = true;
 
-    const videoModels = isCindyAi
-      ? (provider.videoModels ?? []).filter((model) => MAINLAND_VIDEO_MODEL_IDS.has(model.id))
-      : [];
+    const videoModels = (provider.videoModels ?? []).filter((model) =>
+      MAINLAND_VIDEO_MODEL_IDS.has(model.id),
+    );
     const videoIds = new Set(videoModels.map((model) => model.id));
     const videoDefaults = projectVideoDefaults(provider.videoDefaults, videoIds);
     const models = Object.fromEntries(
@@ -64,7 +86,7 @@ export function projectProviderCatalogForBuildRegion(
         agent,
         list.filter((model) => {
           const group = classifyModel(model);
-          return group !== 'image' && (group !== 'video' || (isCindyAi && MAINLAND_VIDEO_MODEL_IDS.has(model.id)));
+          return group !== 'image' && (group !== 'video' || MAINLAND_VIDEO_MODEL_IDS.has(model.id));
         }),
       ]),
     ) as Provider['models'];

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -32,14 +32,15 @@ function projectVideoDefaults(
 }
 
 /**
- * Build-region projection for the media catalog. Global keeps the catalog
- * source verbatim; Mainland China and dev share the Mainland product semantics
- * and expose only the media capabilities supported there.
+ * Build-region projection for Cindy-managed media capabilities. Global keeps
+ * the catalog source verbatim; Mainland China and dev expose only the media
+ * capabilities that the regional Cindy service supports.
  *
- * 2026-07 图像多来源:投影不再只针对 xd —— 大陆版「无图像能力」是产品语义,
- * **所有**供应商的 imageModels/imageDefaults 一律清空(新来源不得绕过地区闸);
- * 视频白名单(seedance 两型号)维持 xd 专属逻辑,其它供应商目前不声明视频清单,
- * 声明了也一并清空(大陆视频能力只经 xd 网关合规通道)。
+ * Region is a build-time choice for Cindy-owned services, not a restriction on
+ * providers the user connected locally. Therefore this projection only changes
+ * `xd`; OpenAI/Codex OAuth, xAI OAuth, Gemini API keys and custom providers keep
+ * their own catalog in every build. Applying the gate to all providers makes a
+ * Mainland build silently discard user-owned capabilities that work directly.
  */
 export function projectProviderCatalogForBuildRegion(
   catalog: Catalog,
@@ -49,16 +50,8 @@ export function projectProviderCatalogForBuildRegion(
 
   let changed = false;
   const providers = catalog.providers.map((provider) => {
-    const hasMedia =
-      (provider.imageModels?.length ?? 0) > 0 ||
-      provider.imageDefaults !== undefined ||
-      (provider.videoModels?.length ?? 0) > 0 ||
-      provider.videoDefaults !== undefined ||
-      Object.values(provider.models).some((list) =>
-        list?.some((m) => { const g = classifyModel(m); return g === 'image' || g === 'video'; }),
-      );
     const isCindyAi = provider.id === CINDY_AI_PROVIDER_ID;
-    if (!hasMedia && !isCindyAi) return provider;
+    if (!isCindyAi) return provider;
     changed = true;
 
     const videoModels = isCindyAi

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -55,7 +55,7 @@ export function projectProviderCatalogForBuildRegion(
       const models = Object.fromEntries(
         Object.entries(provider.models).map(([agent, list]) => [
           agent,
-          list.filter((model) => classifyModel(model) !== 'video'),
+          (list ?? []).filter((model) => classifyModel(model) !== 'video'),
         ]),
       ) as Provider['models'];
       const hasVideoModels = Object.values(provider.models).some(
@@ -84,7 +84,7 @@ export function projectProviderCatalogForBuildRegion(
     const models = Object.fromEntries(
       Object.entries(provider.models).map(([agent, list]) => [
         agent,
-        list.filter((model) => {
+        (list ?? []).filter((model) => {
           const group = classifyModel(model);
           return group !== 'image' && (group !== 'video' || MAINLAND_VIDEO_MODEL_IDS.has(model.id));
         }),


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正媒体模型目录的构建区域投影：`cn` / `dev` 只限制 Cindy 自营 `xd` 服务，不再清空用户自行连接的 OpenAI、Gemini、xAI 和自定义供应商媒体能力。

根因是原实现把“中国大陆版不提供 Cindy 自营图像服务”扩大成了“清空所有供应商的图像模型”，导致本地凭证能够直连的模型也从插件白名单中消失。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：正式版 Cindy Art 在中国大陆版看不到用户自有图像模型
- 本 PR 包含：区域投影只改写 `xd`；补齐用户来源及无 `xd` 目录的回归测试
- 明确不包含：新增供应商执行通道、修改 Cindy 自营媒体可用范围、UI 改动
- 用户可见变化：中国大陆版和 dev 构建可继续使用用户自行连接的媒体模型
- 是否存在 breaking change：无

行为契约：构建区域只约束 Cindy 自营服务；用户 key、订阅 OAuth 和自定义供应商不因 `cn` / `global` 构建身份被静默删除。

### 合并关系

本 PR 与 #1249、#1250 无代码依赖，可任意顺序合并。只合本 PR 会立即恢复中国大陆版已有 OpenAI Platform/Gemini 用户来源；后两条通道合入后会自然获得同样的跨区域可见性。

### UI 变化

不涉及：仅修正 Main 进程目录投影逻辑，没有视觉、交互或文案改动。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/providerAccessPolicy.test.ts --maxWorkers=2
结果：11 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过
```

三条图像来源 PR 还使用 `git merge-tree --write-tree` 两两验证，任意合并顺序均无冲突。

### 手工验证

不涉及 UI；未启动 Desktop 实例。

### 未执行的验证

- 未在本机运行无界全仓 `pnpm test:unit`，完整门禁交由 CI 执行，避免本地高并发资源耗尽。
- 未在正式打包版执行插件端到端验收；合并发版后应在中国大陆版打开 Cindy Art，确认已连接的 Gemini/OpenAI/xAI 来源进入模型清单。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：区域产品行为变化

### 影响与回滚

- 影响范围：`cn` / `dev` 的媒体模型目录；`global` 原样返回，Cindy 自营 `xd` 的大陆白名单保持不变
- 回滚 / 降级方式：回滚本 PR 即恢复旧的全供应商清空逻辑

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
