### PR TITLE
fix(i18n): 补齐 worktree 草稿提示的 en/ja/ko 翻译

### DIFF
--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5839,6 +5839,8 @@
       "remoteProviderUnsupported": "This provider is not supported in SSH remote sessions — pick another source",
       "remoteNativeOauthUnavailable": "Claude.ai subscription is not connected — connect it first or pick a gateway model",
       "deviceStillLoading": "Remote device is still loading, please wait",
+      "worktreeMissingRepo": "Can't create a worktree: the current directory's repo root is missing",
+      "worktreeRepoHint": "Try picking the working directory again, and retry once the folder badge at the bottom right refreshes",
       "sessionInactive": "Session is no longer active",
       "remoteProjectBanner": "New session in {{project}} on {{device}}",
       "remoteDialogueBanner": "New chat on {{device}} (no project)"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5828,6 +5828,8 @@
       "remoteProviderUnsupported": "このプロバイダーは SSH リモートセッションに対応していません。別のソースを選択してください",
       "remoteNativeOauthUnavailable": "Claude.ai サブスクリプションが未接続です。先に接続するか、ゲートウェイモデルを選択してください",
       "deviceStillLoading": "リモートデバイスの読み込み中です。しばらくお待ちください",
+      "worktreeMissingRepo": "worktree を作成できません：現在のディレクトリのリポジトリルートが見つかりません",
+      "worktreeRepoHint": "作業ディレクトリを選び直し、右下のフォルダー表示が更新されてから再試行してください",
       "sessionInactive": "セッションはすでにアクティブではありません",
       "remoteProjectBanner": "{{device}} の {{project}} で新しいセッションを作成",
       "remoteDialogueBanner": "{{device}} で新しい対話（プロジェクトなし）"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5828,6 +5828,8 @@
       "remoteProviderUnsupported": "이 제공자는 SSH 원격 세션을 지원하지 않습니다. 다른 소스를 선택하세요",
       "remoteNativeOauthUnavailable": "Claude.ai 구독이 연결되지 않았습니다. 먼저 연결하거나 게이트웨이 모델을 선택하세요",
       "deviceStillLoading": "원격 기기가 아직 로딩 중입니다. 잠시 기다려 주세요",
+      "worktreeMissingRepo": "worktree를 만들 수 없습니다: 현재 디렉터리의 리포지토리 루트가 없습니다",
+      "worktreeRepoHint": "작업 디렉터리를 다시 선택한 뒤 오른쪽 아래 폴더 표시가 갱신되면 다시 시도하세요",
       "sessionInactive": "세션이 더 이상 활성 상태가 아닙니다",
       "remoteProjectBanner": "{{device}}의 {{project}}에서 새 세션 만들기",
       "remoteDialogueBanner": "{{device}}에서 새 대화(프로젝트 없음)"


### PR DESCRIPTION
## 这次改了什么

### 摘要

#886 落地时 `ccAgent.draft.worktreeMissingRepo` / `ccAgent.draft.worktreeRepoHint` 两个 key 只加了 zh-CN，en/ja/ko 缺失。main 上 `pnpm check:i18n` 门禁因此挂掉，所有基于当前 main 的 PR 的 `verify` 都被卡住（例如 #668 最新一轮 CI 就挂在这一步）。本 PR 补齐这 4 处翻译（en/ja/ko × 2 key），别的什么都不动。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#886 落地遗留；解锁受 `check:i18n` 门禁影响的在途 PR（如 #668）
- 本 PR 包含：`en` / `ja` / `ko` 三份 `common.json` 各补 2 个 key
- 明确不包含：任何代码改动；`check:i18n` 输出里既有的 503 处警告（空字符串值 / 疑似未翻译）不在本次范围
- 用户可见变化：en/ja/ko 界面在「worktree 开启失败」场景下显示对应语言文案，不再回退英文键名
- 是否存在 breaking change：无

### UI 变化

不涉及：纯 locale 文案补齐，无视觉/交互变化；文案本身为既有 zh-CN 语义的对应翻译。

- 引用的设计规范：不涉及（无视觉/交互/布局变化；术语遵循 `i18n/GLOSSARY.md`：worktree 四语保留英文小写原词，「仓库根」沿用 `repoRoot` 键既有译法，「工作目录」沿用 working directory / 作業ディレクトリ / 작업 디렉터리）

## 怎么验证的

### 自动验证

```text
node scripts/check-i18n.mjs
结果：✅ zh-CN / en / ja / ko 共 6232 个 key 全部一致（警告 503 处为存量，与本 PR 无关）

node scripts/check-i18n-glossary.mjs
结果：✅ 术语表 32 条已裁决 / 29 条待讨论，en / zh-CN / ja / ko 无新增违规
```

### 手工验证

不涉及：纯 locale JSON 补键，语义对照 zh-CN 原文与相邻键（`repoRoot`、`deviceStillLoading`）的既有译法。

### 未执行的验证

未跑全仓 `pnpm test:unit`：本 PR 只改 3 个 locale JSON，无代码路径变化；`check:i18n` / `check:i18n-glossary` 已本地通过，其余交 CI。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 en/ja/ko 三份 `common.json` 各 +2 行；无。
- 回滚 / 降级方式：revert 本 PR 即可（会重新让 `check:i18n` 门禁挂掉）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
