### PR TITLE
fix(desktop): 修复外置浏览器误拦代理 fake-IP 网站

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/browserManagedConfig.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browserManagedConfig.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildManagedConfig } from '../browser-managed-config.js';
+
+describe('managed browser runtime config', () => {
+  it('allows private-network destinations so proxy fake-IP DNS is not blocked', () => {
+    expect(buildManagedConfig().browser?.ssrfPolicy).toEqual({
+      dangerouslyAllowPrivateNetwork: true,
+    });
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browserManagedConfig.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browserManagedConfig.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { buildManagedConfig } from '../browser-managed-config.js';
 
 describe('managed browser runtime config', () => {
-  it('allows private-network destinations so proxy fake-IP DNS is not blocked', () => {
+  it('allows only proxy fake-IP ranges without disabling private-network protection', () => {
     expect(buildManagedConfig().browser?.ssrfPolicy).toEqual({
-      dangerouslyAllowPrivateNetwork: true,
+      allowRfc2544BenchmarkRange: true,
+      allowIpv6UniqueLocalRange: true,
     });
   });
 });

--- a/apps/desktop/src/main/mcp-integrations/browser-managed-config.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-managed-config.ts
@@ -54,13 +54,12 @@ const MANAGED_CDP_PORT = 18800;
  * (`browser-backend-settings-store` resolves `'external'` as the system default,
  * so this config is what a user who never touched the toggle gets.)
  *
- * SECURITY POSTURE (intentional, owner-decided 2026-06):
- *  - `dangerouslyAllowPrivateNetwork:true` keeps localhost / private-network
- *    navigation available. This is deliberate: Cindy is an internal tool and
- *    users need the agent to drive local dev servers / internal sites. It also
- *    prevents system-proxy fake-IP DNS answers (for example 198.18.0.0/15) from
- *    making ordinary public sites look like SSRF attempts. Do not tighten this
- *    setting without re-confirming that product decision.
+ * SECURITY POSTURE:
+ *  - Only the fake-IP ranges used by system proxies are exempted from the SSRF
+ *    guard. This prevents Surge/Clash/sing-box DNS answers (198.18.0.0/15 or
+ *    IPv6 ULA) from making ordinary public sites look like SSRF attempts while
+ *    localhost, RFC1918, metadata, link-local, and other special-use addresses
+ *    remain blocked.
  *  - Page-context `evaluate` (and recipe `evaluate` steps) run author/agent JS in
  *    Chromium, whose network stack is NOT subject to the Node SSRF guard — a
  *    same-origin `fetch` there can reach any host the browser can. This residual
@@ -74,7 +73,8 @@ export function buildManagedConfig(): BrowserRuntimeConfig {
       defaultProfile: MANAGED_PROFILE,
       headless: false, // headed so the user can see + log into sites
       ssrfPolicy: {
-        dangerouslyAllowPrivateNetwork: true,
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
       },
       profiles: {
         [MANAGED_PROFILE]: {

--- a/apps/desktop/src/main/mcp-integrations/browser-managed-config.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-managed-config.ts
@@ -1,0 +1,88 @@
+import type { BrowserRuntimeConfig } from '@cindy/browser-control-runtime';
+
+/**
+ * Managed profile identity. The profile key doubles as (a) the Chrome profile
+ * display name rendered in the launched browser's top-right profile button and (b)
+ * the user-data-dir folder name — so it's branded "Cindy" to make the automation
+ * browser obviously distinct from the user's everyday Chrome at a glance. The runtime
+ * seeds the name + color into the profile's Local State / Preferences before launch
+ * (decoration re-checks the desired name every launch, so a profile dir carried over
+ * with an old display name self-heals to "Cindy" on first run).
+ * (Same Chrome binary as the user's, so the dock/taskbar icon is unchanged.)
+ *
+ * ⚠️ 磁盘标识符:这是 2026-07 品牌翻转时钉死的目录名,之后【不要】再跟随
+ * @cindy/maker-shared/branding 的 BRAND_NAME 变化——改了会指向新的空 profile
+ * 目录,丢失既有登录态/Cookie。老 profile 的接续路径:
+ *  - 老 userData(xdt-maker)里的 `browser-runtime/browser/XDMaker` 由 mToc 首登
+ *    迁移(legacyUserDataMigration.ts)复制为新 userData 的 `browser/Cindy`;
+ *  - 新 userData 里若已有旧名目录(翻转前的 dev 实例),browser.ts module-eval 的
+ *    就地改名自愈处理。两处的 'XDMaker'/'Cindy' 字面量与本常量保持一致。
+ */
+export const MANAGED_PROFILE = 'Cindy';
+
+/**
+ * Fixed brand tint for the managed profile. This intentionally stays on the vivid
+ * teal variant instead of the Default Light auto-approval text color. NOTE:
+ * Chrome treats this as a *seed* and generates a tonal toolbar theme from it (Material
+ * You), so it is NOT painted literally — but a SATURATED hue like this renders as a
+ * clean teal, unlike a neutral/near-black seed which Chrome muddies into a grey-blue.
+ * (The darker #000050 variant is near-neutral and would muddy, so we use #00D9C5.)
+ */
+const DEFAULT_PROFILE_COLOR = '#00D9C5';
+
+/**
+ * Vendored "managed launch" driver enum value (required by the runtime to mark a
+ * profile as launch-and-own vs attach-to-existing). It DOES surface in the
+ * `profiles`/`status`/`doctor` diagnostic output, so the runtime scrubs the
+ * vendored brand from those success bodies at its boundary (see runtime.ts
+ * DIAGNOSTIC_ACTIONS) — the agent never sees the raw "openclaw" string.
+ */
+const MANAGED_DRIVER = 'openclaw' as const;
+
+/**
+ * Managed Chrome CDP port. The runtime only auto-assigns a port to its built-in
+ * default profile (keyed by the vendored default name); a custom-named managed
+ * profile MUST define its own `cdpPort` or the runtime rejects it with "must define
+ * cdpPort or cdpUrl". 18800 is the vendored default CDP port-range start.
+ */
+const MANAGED_CDP_PORT = 18800;
+
+/**
+ * Default ("managed") config: a single playwright-launched Chrome profile, headed,
+ * with a STABLE persistent user-data-dir (logins survive across sessions). This is
+ * the product default — a "dedicated persistent login automation browser".
+ * (`browser-backend-settings-store` resolves `'external'` as the system default,
+ * so this config is what a user who never touched the toggle gets.)
+ *
+ * SECURITY POSTURE (intentional, owner-decided 2026-06):
+ *  - `dangerouslyAllowPrivateNetwork:true` keeps localhost / private-network
+ *    navigation available. This is deliberate: Cindy is an internal tool and
+ *    users need the agent to drive local dev servers / internal sites. It also
+ *    prevents system-proxy fake-IP DNS answers (for example 198.18.0.0/15) from
+ *    making ordinary public sites look like SSRF attempts. Do not tighten this
+ *    setting without re-confirming that product decision.
+ *  - Page-context `evaluate` (and recipe `evaluate` steps) run author/agent JS in
+ *    Chromium, whose network stack is NOT subject to the Node SSRF guard — a
+ *    same-origin `fetch` there can reach any host the browser can. This residual
+ *    surface is accepted as inherent to browser automation (it's the same
+ *    capability the `act:evaluate` tool already exposes), not a regression.
+ */
+export function buildManagedConfig(): BrowserRuntimeConfig {
+  return {
+    browser: {
+      enabled: true,
+      defaultProfile: MANAGED_PROFILE,
+      headless: false, // headed so the user can see + log into sites
+      ssrfPolicy: {
+        dangerouslyAllowPrivateNetwork: true,
+      },
+      profiles: {
+        [MANAGED_PROFILE]: {
+          driver: MANAGED_DRIVER,
+          color: DEFAULT_PROFILE_COLOR,
+          cdpPort: MANAGED_CDP_PORT,
+        },
+      },
+    },
+  };
+}

--- a/apps/desktop/src/main/mcp-integrations/browser.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser.ts
@@ -12,7 +12,6 @@ import { app, ipcMain } from 'electron';
 import {
   createBrowserControlRuntime,
   type BrowserControlRuntime,
-  type BrowserRuntimeConfig,
 } from '@cindy/browser-control-runtime';
 
 import { createLogger } from '../logger.js';
@@ -46,94 +45,14 @@ import {
   requireObject,
   optionalNullableString,
 } from '../utils/ipcValidate.js';
+import { buildManagedConfig, MANAGED_PROFILE } from './browser-managed-config.js';
 
 export { extractBrowserAvailability, type BrowserAvailability } from './browser-availability.js';
 
 const logger = createLogger('mcp/cindy_browser');
 
-/**
- * Managed profile identity. The profile key doubles as (a) the Chrome profile
- * display name rendered in the launched browser's top-right profile button and (b)
- * the user-data-dir folder name — so it's branded "Cindy" to make the automation
- * browser obviously distinct from the user's everyday Chrome at a glance. The runtime
- * seeds the name + color into the profile's Local State / Preferences before launch
- * (decoration re-checks the desired name every launch, so a profile dir carried over
- * with an old display name self-heals to "Cindy" on first run).
- * (Same Chrome binary as the user's, so the dock/taskbar icon is unchanged.)
- *
- * ⚠️ 磁盘标识符:这是 2026-07 品牌翻转时钉死的目录名,之后【不要】再跟随
- * @cindy/maker-shared/branding 的 BRAND_NAME 变化——改了会指向新的空 profile
- * 目录,丢失既有登录态/Cookie。老 profile 的接续路径:
- *  - 老 userData(xdt-maker)里的 `browser-runtime/browser/XDMaker` 由 mToc 首登
- *    迁移(legacyUserDataMigration.ts)复制为新 userData 的 `browser/Cindy`;
- *  - 新 userData 里若已有旧名目录(翻转前的 dev 实例),下方 module-eval 的
- *    就地改名自愈处理。两处的 'XDMaker'/'Cindy' 字面量与本常量保持一致。
- */
-const MANAGED_PROFILE = 'Cindy';
 /** 翻转前(≤2026-07-17)创建的受管 profile 目录名,仅用于就地改名自愈。 */
 const LEGACY_MANAGED_PROFILE = 'XDMaker';
-/**
- * Fixed brand tint for the managed profile. This intentionally stays on the vivid
- * teal variant instead of the Default Light auto-approval text color. NOTE:
- * Chrome treats this as a *seed* and generates a tonal toolbar theme from it (Material
- * You), so it is NOT painted literally — but a SATURATED hue like this renders as a
- * clean teal, unlike a neutral/near-black seed which Chrome muddies into a grey-blue.
- * (The darker #000050 variant is near-neutral and would muddy, so we use #00D9C5.)
- */
-const DEFAULT_PROFILE_COLOR = '#00D9C5';
-/**
- * Vendored "managed launch" driver enum value (required by the runtime to mark a
- * profile as launch-and-own vs attach-to-existing). It DOES surface in the
- * `profiles`/`status`/`doctor` diagnostic output, so the runtime scrubs the
- * vendored brand from those success bodies at its boundary (see runtime.ts
- * DIAGNOSTIC_ACTIONS) — the agent never sees the raw "openclaw" string.
- */
-const MANAGED_DRIVER = 'openclaw' as const;
-/**
- * Managed Chrome CDP port. The runtime only auto-assigns a port to its built-in
- * default profile (keyed by the vendored default name); a custom-named managed
- * profile MUST define its own `cdpPort` or the runtime rejects it with "must define
- * cdpPort or cdpUrl". 18800 is the vendored default CDP port-range start.
- */
-const MANAGED_CDP_PORT = 18800;
-
-/**
- * Default ("managed") config: a single playwright-launched Chrome profile, headed,
- * with a STABLE persistent user-data-dir (logins survive across sessions). This is
- * the product default — a "dedicated persistent login automation browser".
- * (`browser-backend-settings-store` resolves `'external'` as the system default,
- * so this config is what a user who never touched the toggle gets.)
- *
- * SECURITY POSTURE (intentional, owner-decided 2026-06):
- *  - No `ssrfPolicy` is set → the strict browser-side DNS-rebinding gate +
- *    redirect-chain inspection stay OFF, so the agent CAN navigate to
- *    localhost / private-network hosts. This is deliberate: Cindy is an internal
- *    tool and users need the agent to drive local dev servers / internal sites.
- *    (Private-IP *literals* are still classified by the vendored resolver; what's
- *    intentionally allowed is hostname→private navigation.) Do not arm
- *    `dangerouslyAllowPrivateNetwork:false` here without re-confirming that call.
- *  - Page-context `evaluate` (and recipe `evaluate` steps) run author/agent JS in
- *    Chromium, whose network stack is NOT subject to the Node SSRF guard — a
- *    same-origin `fetch` there can reach any host the browser can. This residual
- *    surface is accepted as inherent to browser automation (it's the same
- *    capability the `act:evaluate` tool already exposes), not a regression.
- */
-function buildManagedConfig(): BrowserRuntimeConfig {
-  return {
-    browser: {
-      enabled: true,
-      defaultProfile: MANAGED_PROFILE,
-      headless: false, // headed so the user can see + log into sites
-      profiles: {
-        [MANAGED_PROFILE]: {
-          driver: MANAGED_DRIVER,
-          color: DEFAULT_PROFILE_COLOR,
-          cdpPort: MANAGED_CDP_PORT,
-        },
-      },
-    },
-  };
-}
 
 /**
  * 就地改名自愈:同一 userData 下存在翻转前的 `browser/XDMaker` 而无 `browser/Cindy`

--- a/packages/browser-control-runtime/src/__tests__/runtime-config-application.test.ts
+++ b/packages/browser-control-runtime/src/__tests__/runtime-config-application.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { resolveBrowserConfig } from '../_generated/extension/src/browser/config.js';
 import { createBrowserControlRuntime } from '../index.js';
 
 // Regression: the host-injected config must actually reach the vendored dispatcher.
@@ -8,6 +9,20 @@ import { createBrowserControlRuntime } from '../index.js';
 // fell back to the vendored DEFAULT profiles ("openclaw"/"user") and every
 // host-set profile (name, color, ports) was ignored. This locks the fix in.
 describe('host config application', () => {
+  it('preserves narrow fake-IP SSRF allowances through vendored config resolution', () => {
+    const resolved = resolveBrowserConfig({
+      ssrfPolicy: {
+        allowRfc2544BenchmarkRange: true,
+        allowIpv6UniqueLocalRange: true,
+      },
+    });
+
+    expect(resolved.ssrfPolicy).toEqual({
+      allowRfc2544BenchmarkRange: true,
+      allowIpv6UniqueLocalRange: true,
+    });
+  });
+
   it('uses the host-set custom profile as default (not the vendored "openclaw")', async () => {
     const rt = createBrowserControlRuntime({
       config: {

--- a/packages/browser-control-runtime/src/__tests__/ssrf-guard.test.ts
+++ b/packages/browser-control-runtime/src/__tests__/ssrf-guard.test.ts
@@ -4,6 +4,7 @@ import { fetchWithSsrFGuard } from '../shim/ssrf-runtime.js';
 import {
   isBlockedHostnameOrIp,
   isPrivateIpAddress,
+  resolvePinnedHostnameWithPolicy,
 } from '../_generated/leaf/src/infra/net/ssrf.js';
 
 /**
@@ -25,6 +26,15 @@ describe('vendored SSRF decision primitives', () => {
 
   it('does not flag a public IP as private', () => {
     expect(isPrivateIpAddress('8.8.8.8')).toBe(false);
+  });
+
+  it('allows proxy fake-IP DNS answers when private-network access is enabled', async () => {
+    const resolved = await resolvePinnedHostnameWithPolicy('example.com', {
+      policy: { dangerouslyAllowPrivateNetwork: true },
+      lookupFn: async () => [{ address: '198.18.0.1', family: 4 }],
+    });
+
+    expect(resolved.addresses).toEqual(['198.18.0.1']);
   });
 });
 

--- a/packages/browser-control-runtime/src/__tests__/ssrf-guard.test.ts
+++ b/packages/browser-control-runtime/src/__tests__/ssrf-guard.test.ts
@@ -5,7 +5,16 @@ import {
   isBlockedHostnameOrIp,
   isPrivateIpAddress,
   resolvePinnedHostnameWithPolicy,
+  type LookupFn,
 } from '../_generated/leaf/src/infra/net/ssrf.js';
+
+const FAKE_IP_POLICY = {
+  allowRfc2544BenchmarkRange: true,
+  allowIpv6UniqueLocalRange: true,
+};
+
+const lookupAddresses = (addresses: Array<{ address: string; family: 4 | 6 }>): LookupFn =>
+  (async () => addresses) as unknown as LookupFn;
 
 /**
  * These assert the REAL vendored SSRF decision logic (not our thin fetch shell)
@@ -28,14 +37,39 @@ describe('vendored SSRF decision primitives', () => {
     expect(isPrivateIpAddress('8.8.8.8')).toBe(false);
   });
 
-  it('allows proxy fake-IP DNS answers when private-network access is enabled', async () => {
+  it('allows an RFC 2544 proxy fake-IP DNS answer without enabling private networks', async () => {
     const resolved = await resolvePinnedHostnameWithPolicy('example.com', {
-      policy: { dangerouslyAllowPrivateNetwork: true },
-      lookupFn: async () => [{ address: '198.18.0.1', family: 4 }],
+      policy: FAKE_IP_POLICY,
+      lookupFn: lookupAddresses([{ address: '198.18.0.1', family: 4 }]),
     });
 
     expect(resolved.addresses).toEqual(['198.18.0.1']);
   });
+
+  it('allows an IPv6 ULA proxy fake-IP DNS answer without enabling private networks', async () => {
+    const resolved = await resolvePinnedHostnameWithPolicy('example.com', {
+      policy: FAKE_IP_POLICY,
+      lookupFn: lookupAddresses([{ address: 'fd00::1', family: 6 }]),
+    });
+
+    expect(resolved.addresses).toEqual(['fd00::1']);
+  });
+
+  it.each([
+    ['cloud metadata', '169.254.169.254', 4],
+    ['link-local', '169.254.1.1', 4],
+    ['RFC1918', '10.0.0.5', 4],
+  ] as const)(
+    'still blocks %s DNS answers under the narrow fake-IP policy',
+    async (_kind, address, family) => {
+      await expect(
+        resolvePinnedHostnameWithPolicy('example.com', {
+          policy: FAKE_IP_POLICY,
+          lookupFn: lookupAddresses([{ address, family }]),
+        }),
+      ).rejects.toThrow(/blocked/i);
+    },
+  );
 });
 
 describe('fetchWithSsrFGuard thin shell', () => {
@@ -64,7 +98,7 @@ describe('fetchWithSsrFGuard thin shell', () => {
     await expect(
       fetchWithSsrFGuard({
         url: 'http://127.0.0.1:59999/',
-        policy: { allowedHostnames: ['127.0.0.1'], dangerouslyAllowPrivateNetwork: true },
+        policy: { allowedHostnames: ['127.0.0.1'] },
         timeoutMs: 1500,
       }),
     ).rejects.not.toThrow(/blocked|not in allowlist/i);

--- a/packages/browser-control-runtime/src/_generated/extension/src/browser/config.ts
+++ b/packages/browser-control-runtime/src/_generated/extension/src/browser/config.ts
@@ -286,16 +286,25 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
   const rawPolicy = cfg?.ssrfPolicy as BrowserSsrFPolicyCompat | undefined;
   const allowPrivateNetwork = rawPolicy?.allowPrivateNetwork;
   const dangerouslyAllowPrivateNetwork = rawPolicy?.dangerouslyAllowPrivateNetwork;
+  // LOCAL PATCH (Cindy, via sync.mjs): upstream's config resolver currently
+  // drops the narrow fake-IP allowances even though the SSRF layer supports
+  // them. Preserve explicit booleans so hosts can allow only proxy fake-IP
+  // ranges without disabling protection for metadata, link-local, or RFC1918.
+  const allowRfc2544BenchmarkRange = rawPolicy?.allowRfc2544BenchmarkRange;
+  const allowIpv6UniqueLocalRange = rawPolicy?.allowIpv6UniqueLocalRange;
   const allowedHostnames = normalizeStringList(rawPolicy?.allowedHostnames);
   const hostnameAllowlist = normalizeStringList(rawPolicy?.hostnameAllowlist);
   const hasExplicitPrivateSetting =
     allowPrivateNetwork !== undefined || dangerouslyAllowPrivateNetwork !== undefined;
+  const hasExplicitFakeIpSetting =
+    allowRfc2544BenchmarkRange !== undefined || allowIpv6UniqueLocalRange !== undefined;
   const resolvedAllowPrivateNetwork =
     dangerouslyAllowPrivateNetwork === true || allowPrivateNetwork === true;
 
   if (
     !resolvedAllowPrivateNetwork &&
     !hasExplicitPrivateSetting &&
+    !hasExplicitFakeIpSetting &&
     !allowedHostnames &&
     !hostnameAllowlist
   ) {
@@ -310,6 +319,8 @@ function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | 
     allowPrivateNetwork === false
       ? { dangerouslyAllowPrivateNetwork: resolvedAllowPrivateNetwork }
       : {}),
+    ...(allowRfc2544BenchmarkRange !== undefined ? { allowRfc2544BenchmarkRange } : {}),
+    ...(allowIpv6UniqueLocalRange !== undefined ? { allowIpv6UniqueLocalRange } : {}),
     ...(allowedHostnames ? { allowedHostnames } : {}),
     ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
   };

--- a/packages/browser-control-runtime/src/shim/_local/config-types-browser.ts
+++ b/packages/browser-control-runtime/src/shim/_local/config-types-browser.ts
@@ -38,6 +38,10 @@ export type BrowserTabCleanupConfig = {
 export type BrowserSsrFPolicyConfig = {
   /** If true, permit browser navigation to private/internal networks. Default: true */
   dangerouslyAllowPrivateNetwork?: boolean;
+  /** Permit RFC 2544 benchmark addresses (198.18.0.0/15) used by fake-IP proxy DNS. */
+  allowRfc2544BenchmarkRange?: boolean;
+  /** Permit IPv6 Unique Local Addresses (fc00::/7) used by fake-IP proxy DNS. */
+  allowIpv6UniqueLocalRange?: boolean;
   /**
    * Explicitly allowed hostnames (exact-match), including blocked names like localhost.
    * Example: ["localhost", "metadata.internal"]

--- a/packages/browser-control-runtime/src/shim/_local/config-types-browser.ts
+++ b/packages/browser-control-runtime/src/shim/_local/config-types-browser.ts
@@ -36,7 +36,7 @@ export type BrowserTabCleanupConfig = {
   sweepMinutes?: number;
 };
 export type BrowserSsrFPolicyConfig = {
-  /** If true, permit browser navigation to private/internal networks. Default: true */
+  /** If true, permit browser navigation to private/internal networks. Default: false */
   dangerouslyAllowPrivateNetwork?: boolean;
   /** Permit RFC 2544 benchmark addresses (198.18.0.0/15) used by fake-IP proxy DNS. */
   allowRfc2544BenchmarkRange?: boolean;

--- a/packages/browser-control-runtime/upstream/MAINTAINING.md
+++ b/packages/browser-control-runtime/upstream/MAINTAINING.md
@@ -36,7 +36,7 @@ playwright-core → 托管 Chrome(Cindy profile, 持久 user-data-dir)
 
 ## 3. 配置流(以及那个静默 bug)
 
-host 在 `browser-managed-config.ts` 用 `buildManagedConfig()` 造出 `{ browser: { enabled, defaultProfile:'Cindy', headless:false, ssrfPolicy:{ dangerouslyAllowPrivateNetwork:true }, profiles:{ Cindy:{ driver:'openclaw', color, cdpPort } } } }`,`browser.ts` 在模块求值时将其传给 `createBrowserControlRuntime({ config })`。显式放开 private network 是产品决定:Agent 需要访问 localhost / 内网站点,也避免 Surge/Clash/sing-box 等代理的 fake-IP DNS(`198.18.0.0/15` 等)把普通公网域名误拦成 SSRF。runtime 内部把 config 存进 in-memory 配置快照;vendored dispatcher 每次请求经
+host 在 `browser-managed-config.ts` 用 `buildManagedConfig()` 造出 `{ browser: { enabled, defaultProfile:'Cindy', headless:false, ssrfPolicy:{ allowRfc2544BenchmarkRange:true, allowIpv6UniqueLocalRange:true }, profiles:{ Cindy:{ driver:'openclaw', color, cdpPort } } } }`,`browser.ts` 在模块求值时将其传给 `createBrowserControlRuntime({ config })`。这两个窄开关只豁免 Surge/Clash/sing-box 等代理使用的 fake-IP DNS(`198.18.0.0/15` 与 IPv6 ULA),避免普通公网域名被误拦;localhost、RFC1918、cloud metadata、link-local 与其它 special-use 地址继续由 SSRF guard 阻断。上游 SSRF 层已经支持这两个字段,但 config resolver 尚未透传,所以 `sync.mjs` 用 fail-loud `LOCAL_PATCHES` 保留它们。runtime 内部把 config 存进 in-memory 配置快照;vendored dispatcher 每次请求经
 `getRuntimeConfigSourceSnapshot() ?? getRuntimeConfig()` 再取 `.browser` 拿到它。
 
 > ⚠️ **不变量(踩过的最大的坑):** `src/shim/runtime-config-snapshot.ts` 的 `getRuntimeConfigSourceSnapshot()` **必须返回 `OpenClawConfig | null`**(默认 `return null`)。它一旦返回 `{config, source}` 这种 wrapper,上面的 `?? getRuntimeConfig()` 永远短路、`.browser` 取到 `undefined`,**host 注入的整份 config 被静默丢弃、runtime 跑纯 vendored 默认值**(于是 profile 显示成上游默认名、颜色/目录全不对)。由 `src/__tests__/runtime-config-application.test.ts` 守护——别删那条测试。

--- a/packages/browser-control-runtime/upstream/MAINTAINING.md
+++ b/packages/browser-control-runtime/upstream/MAINTAINING.md
@@ -32,11 +32,11 @@ playwright-core → 托管 Chrome(Cindy profile, 持久 user-data-dir)
 |---|---|---|
 | **L1 vendored runtime** | `packages/browser-control-runtime/` | `src/types.ts`(中性契约 `BrowserControlRuntime` / `BrowserRuntimeConfig` / Request / Result)、`src/runtime.ts`(`createBrowserControlRuntime` 把 vendored dispatcher 包到契约后面)、`src/unavailable.ts`(未配置时的安全 stub)、`src/shim/**`(手写替换上游 plugin-sdk 面,见 `shim-spec.md`)、`_generated/**`(**生成物,禁止手改**) |
 | **L2 MCP 面** | `packages/lizi-mcps/src/browser/` | `tools.ts`(唯一一个 `browser` 工具,17 个 action,`rules:['browser-workflow']`)、`server.ts`(`list_tools`/`call_tool` + 把 rules 打进响应)、`tool-registry.ts`、`index.ts`(`createBrowserMcpServer`)、`prompts/rules/browser-workflow.md`(**喂给 agent 的用法规则**)。在 `packages/lizi-mcps/src/providers.ts` 注册成 `cindy_browser` provider |
-| **L3 desktop host** | `apps/desktop/src/main/mcp-integrations/` | `browser-runtime-env.ts`(**import 前置副作用**,见坑 #2)、`browser.ts`(托管 config + runtime 单例 + `getBrowserMcpDeps`/`getBrowserAvailability`/`openBrowserForLogin`)、`browser-availability.ts`(status → UI 数据)。IPC:`maker-ipc/{channels,register}.ts` 的 `BROWSER_STATUS` + `BROWSER_OPEN_FOR_LOGIN`。UI:`renderer/components/settings/ComputerUseSection.tsx`(设置 →「自动操作」)+ 4 语言 i18n。开关 gate:`maker-host/plugins/plugin-registry.ts`(plugin id `browser`) |
+| **L3 desktop host** | `apps/desktop/src/main/mcp-integrations/` | `browser-runtime-env.ts`(**import 前置副作用**,见坑 #2)、`browser-managed-config.ts`(托管 config)、`browser.ts`(runtime 单例 + `getBrowserMcpDeps`/`getBrowserAvailability`/`openBrowserForLogin`)、`browser-availability.ts`(status → UI 数据)。IPC:`maker-ipc/{channels,register}.ts` 的 `BROWSER_STATUS` + `BROWSER_OPEN_FOR_LOGIN`。UI:`renderer/components/settings/ComputerUseSection.tsx`(设置 →「自动操作」)+ 4 语言 i18n。开关 gate:`maker-host/plugins/plugin-registry.ts`(plugin id `browser`) |
 
 ## 3. 配置流(以及那个静默 bug)
 
-host 在 `browser.ts` 用 `buildManagedConfig()` 造出 `{ browser: { enabled, defaultProfile:'Cindy', headless:false, profiles:{ Cindy:{ driver:'openclaw', color, cdpPort } } } }`,在模块求值时 `createBrowserControlRuntime({ config })` 注入。runtime 内部把它存进 in-memory 配置快照;vendored dispatcher 每次请求经
+host 在 `browser-managed-config.ts` 用 `buildManagedConfig()` 造出 `{ browser: { enabled, defaultProfile:'Cindy', headless:false, ssrfPolicy:{ dangerouslyAllowPrivateNetwork:true }, profiles:{ Cindy:{ driver:'openclaw', color, cdpPort } } } }`,`browser.ts` 在模块求值时将其传给 `createBrowserControlRuntime({ config })`。显式放开 private network 是产品决定:Agent 需要访问 localhost / 内网站点,也避免 Surge/Clash/sing-box 等代理的 fake-IP DNS(`198.18.0.0/15` 等)把普通公网域名误拦成 SSRF。runtime 内部把 config 存进 in-memory 配置快照;vendored dispatcher 每次请求经
 `getRuntimeConfigSourceSnapshot() ?? getRuntimeConfig()` 再取 `.browser` 拿到它。
 
 > ⚠️ **不变量(踩过的最大的坑):** `src/shim/runtime-config-snapshot.ts` 的 `getRuntimeConfigSourceSnapshot()` **必须返回 `OpenClawConfig | null`**(默认 `return null`)。它一旦返回 `{config, source}` 这种 wrapper,上面的 `?? getRuntimeConfig()` 永远短路、`.browser` 取到 `undefined`,**host 注入的整份 config 被静默丢弃、runtime 跑纯 vendored 默认值**(于是 profile 显示成上游默认名、颜色/目录全不对)。由 `src/__tests__/runtime-config-application.test.ts` 守护——别删那条测试。
@@ -63,7 +63,7 @@ host 在 `browser.ts` 用 `buildManagedConfig()` 造出 `{ browser: { enabled, d
 ## 6. 产品中性(硬约束)
 
 "OpenClaw" / 🦞 **不得出现在任何产品可见处**:Chrome profile UI、日志、报错文案、喂 agent 的 rules、Settings、i18n。
-- `browser.ts` 里 `MANAGED_DRIVER = 'openclaw'` 是 vendored 要求的**内部 enum 值**,从不进入用户可见面,保留即可。
+- `browser-managed-config.ts` 里 `MANAGED_DRIVER = 'openclaw'` 是 vendored 要求的**内部 enum 值**,从不进入用户可见面,保留即可。
 - 上游名**只允许**出现在:`_generated/**`、`upstream/**` 元数据、`scripts/browser-runtime/sync.mjs`、以及 shim 内部实现细节。改动后用 `grep -ri "openclaw\|🦞" <产品可见路径>` 自查。
 
 ## 7. agent 暴露面(Claude / Codex)

--- a/packages/browser-control-runtime/upstream/browser-runtime.lock.json
+++ b/packages/browser-control-runtime/upstream/browser-runtime.lock.json
@@ -16,11 +16,15 @@
   "patches": [
     {
       "file": "extension/src/browser/config.ts",
+      "desc": "preserve narrow fake-IP SSRF allowances from the host config without enabling general private-network access"
+    },
+    {
+      "file": "extension/src/browser/config.ts",
       "desc": "skip upstream auto-injected \"openclaw\"/\"user\" profiles when the host provides its own (avoids CDP port 18800 collision with the managed profile + never drives the user's Chrome)"
     }
   ],
   "fileCount": 335,
-  "contentHash": "3b9b7006ff975c85aa03602bc6021840e65acab2fb5783da51b061337f8cfd69",
+  "contentHash": "1bc2c6ddddf76824846b6e14ce5bf27e3b222b3283c9fbf2beda1d4283d3040a",
   "fsSafe": {
     "package": "@openclaw/fs-safe",
     "version": "0.4.0"

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -184,6 +184,84 @@ function header(srcLabel) {
 const LOCAL_PATCHES = {
   'extension/src/browser/config.ts': [
     {
+      desc: 'preserve narrow fake-IP SSRF allowances from the host config without enabling general private-network access',
+      find: `function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
+  const rawPolicy = cfg?.ssrfPolicy as BrowserSsrFPolicyCompat | undefined;
+  const allowPrivateNetwork = rawPolicy?.allowPrivateNetwork;
+  const dangerouslyAllowPrivateNetwork = rawPolicy?.dangerouslyAllowPrivateNetwork;
+  const allowedHostnames = normalizeStringList(rawPolicy?.allowedHostnames);
+  const hostnameAllowlist = normalizeStringList(rawPolicy?.hostnameAllowlist);
+  const hasExplicitPrivateSetting =
+    allowPrivateNetwork !== undefined || dangerouslyAllowPrivateNetwork !== undefined;
+  const resolvedAllowPrivateNetwork =
+    dangerouslyAllowPrivateNetwork === true || allowPrivateNetwork === true;
+
+  if (
+    !resolvedAllowPrivateNetwork &&
+    !hasExplicitPrivateSetting &&
+    !allowedHostnames &&
+    !hostnameAllowlist
+  ) {
+    // Keep the default policy object present so CDP guards still enforce
+    // fail-closed private-network checks on unconfigured installs.
+    return {};
+  }
+
+  return {
+    ...(resolvedAllowPrivateNetwork ||
+    dangerouslyAllowPrivateNetwork === false ||
+    allowPrivateNetwork === false
+      ? { dangerouslyAllowPrivateNetwork: resolvedAllowPrivateNetwork }
+      : {}),
+    ...(allowedHostnames ? { allowedHostnames } : {}),
+    ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
+  };
+}`,
+      replace: `function resolveBrowserSsrFPolicy(cfg: BrowserConfig | undefined): SsrFPolicy | undefined {
+  const rawPolicy = cfg?.ssrfPolicy as BrowserSsrFPolicyCompat | undefined;
+  const allowPrivateNetwork = rawPolicy?.allowPrivateNetwork;
+  const dangerouslyAllowPrivateNetwork = rawPolicy?.dangerouslyAllowPrivateNetwork;
+  // LOCAL PATCH (Cindy, via sync.mjs): upstream's config resolver currently
+  // drops the narrow fake-IP allowances even though the SSRF layer supports
+  // them. Preserve explicit booleans so hosts can allow only proxy fake-IP
+  // ranges without disabling protection for metadata, link-local, or RFC1918.
+  const allowRfc2544BenchmarkRange = rawPolicy?.allowRfc2544BenchmarkRange;
+  const allowIpv6UniqueLocalRange = rawPolicy?.allowIpv6UniqueLocalRange;
+  const allowedHostnames = normalizeStringList(rawPolicy?.allowedHostnames);
+  const hostnameAllowlist = normalizeStringList(rawPolicy?.hostnameAllowlist);
+  const hasExplicitPrivateSetting =
+    allowPrivateNetwork !== undefined || dangerouslyAllowPrivateNetwork !== undefined;
+  const hasExplicitFakeIpSetting =
+    allowRfc2544BenchmarkRange !== undefined || allowIpv6UniqueLocalRange !== undefined;
+  const resolvedAllowPrivateNetwork =
+    dangerouslyAllowPrivateNetwork === true || allowPrivateNetwork === true;
+
+  if (
+    !resolvedAllowPrivateNetwork &&
+    !hasExplicitPrivateSetting &&
+    !hasExplicitFakeIpSetting &&
+    !allowedHostnames &&
+    !hostnameAllowlist
+  ) {
+    // Keep the default policy object present so CDP guards still enforce
+    // fail-closed private-network checks on unconfigured installs.
+    return {};
+  }
+
+  return {
+    ...(resolvedAllowPrivateNetwork ||
+    dangerouslyAllowPrivateNetwork === false ||
+    allowPrivateNetwork === false
+      ? { dangerouslyAllowPrivateNetwork: resolvedAllowPrivateNetwork }
+      : {}),
+    ...(allowRfc2544BenchmarkRange !== undefined ? { allowRfc2544BenchmarkRange } : {}),
+    ...(allowIpv6UniqueLocalRange !== undefined ? { allowIpv6UniqueLocalRange } : {}),
+    ...(allowedHostnames ? { allowedHostnames } : {}),
+    ...(hostnameAllowlist ? { hostnameAllowlist } : {}),
+  };
+}`,
+    },
+    {
       desc: 'skip upstream auto-injected "openclaw"/"user" profiles when the host provides its own (avoids CDP port 18800 collision with the managed profile + never drives the user\'s Chrome)',
       find:
         '  let profiles = ensureDefaultUserBrowserProfile(\n' +


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复独立外置浏览器在 Surge、Clash、sing-box 等 fake-IP 代理环境下，把普通公网域名解析到 `198.18.0.0/15` 或 IPv6 ULA 后误判为 SSRF 并拦截的问题。

Desktop 现在只启用 runtime 已有的 `allowRfc2544BenchmarkRange` 与 `allowIpv6UniqueLocalRange` 两个窄策略，并通过 fail-loud vendoring patch 补齐 config resolver 的字段透传；不再放开全部 private network。localhost、RFC1918、cloud metadata、link-local 与其它 special-use 地址继续被拦截。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1264
- 本 PR 包含：外置浏览器托管配置启用两个 fake-IP 网段开关；runtime config resolver 透传补丁；fake-IP IPv4/IPv6 放行与高风险地址继续阻断的回归测试；维护文档同步
- 明确不包含：侧边栏内置浏览器、浏览器后端默认值、UI 与文案调整
- 用户可见变化：使用 fake-IP 代理时，Agent 可恢复访问普通网站；localhost、RFC1918、cloud metadata、link-local 等目的地仍受 SSRF 策略保护
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
node scripts/browser-runtime/sync.mjs --check
结果：通过，生成内容与 lock 一致

pnpm --filter @cindy/browser-control-runtime test
结果：7 个文件、41 个测试通过

pnpm --filter @cindy/browser-control-runtime build
结果：typecheck 通过

pnpm --filter desktop exec vitest run \
  src/main/mcp-integrations/__tests__/browserManagedConfig.test.ts
结果：1 个文件、1 个测试通过

pnpm --filter desktop typecheck
结果：通过

NODE_OPTIONS='--experimental-webstorage --localstorage-file=/tmp/cindy-unit-gate-webstorage' \
  bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <repo-root>
结果：GATE_EXIT=0

pnpm check:dco
结果：通过，2 个 commit 已签署 DCO
```

完整门禁默认的 Desktop `threads` 池在本机 Node 22 上稳定发生 Vitest worker teardown `SIGSEGV`；排除本 PR 新增测试后仍可复现。最终使用仓库已定义的 WebStorage 检测分支切换到 `forks` 池，完整门禁通过。

### 手工验证

不涉及 UI；未启动完整 Desktop 做网站登录态验证。fake-IP 判定路径已由注入 IPv4/IPv6 DNS 结果的回归测试覆盖。

### 未执行的验证

未在真实 Surge / Clash / sing-box 环境中启动完整 Desktop。原因：修复点是传入运行时的策略配置与 resolver 透传，已从 Desktop 配置层、运行时配置解析层和 DNS 安全判定层覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅独立外置浏览器的导航 SSRF 策略。允许代理常用的 RFC 2544 benchmark range 与 IPv6 ULA；不设置 `dangerouslyAllowPrivateNetwork`，因此 localhost、RFC1918、cloud metadata、link-local 与其它 special-use 地址继续阻断。页面内 `evaluate` 原本具备的 Chromium 网络访问能力不变，本 PR 不新增工具能力面。
- 回滚 / 降级方式：回滚本 PR 即恢复升级前的严格拦截；用户侧可临时切换到「侧边栏内置浏览器」绕过外置运行时路径。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
