### PR TITLE
refactor(desktop): 建立多账号 Profile Registry 基线

### DIFF
--- a/apps/desktop/src/main/appSessionState.ts
+++ b/apps/desktop/src/main/appSessionState.ts
@@ -11,6 +11,7 @@ import crypto from 'node:crypto';
 
 import { createLogger } from './logger.js';
 import { createOverrideSettingsFile } from './maker-host/override-settings-file.js';
+import { LOCAL_PROFILE_DATA_OWNER_ID } from './profile/profileRegistryModel.js';
 
 export type AppSessionMode = 'signed-out' | 'local' | 'cloud';
 
@@ -20,7 +21,8 @@ export interface ActiveAppSession {
   generation: number;
 }
 
-export const LOCAL_DATA_OWNER_ID = 'local-v1';
+/** Backward-compatible name for the canonical Profile model constant. */
+export const LOCAL_DATA_OWNER_ID = LOCAL_PROFILE_DATA_OWNER_ID;
 
 /** Filesystem/storage-safe opaque namespace for a data owner. */
 export function dataOwnerStorageKey(ownerId: string): string {

--- a/apps/desktop/src/main/profile/__tests__/profileRegistryModel.test.ts
+++ b/apps/desktop/src/main/profile/__tests__/profileRegistryModel.test.ts
@@ -1,0 +1,144 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  LOCAL_PROFILE_DATA_OWNER_ID,
+  assertValidProfileDescriptor,
+  createProfileId,
+  emptyProfileRegistry,
+  findProfileByIdentity,
+  parseProfileDescriptor,
+  profileIdentityKey,
+  registerProfile,
+  resolveProfileDbPath,
+  serializeProfileDescriptor,
+  setDefaultProfile,
+  type ProfileDescriptor,
+  type ProfileId,
+} from '../profileRegistryModel.js';
+
+const PROFILE_A = '00000000-0000-4000-8000-000000000001' as ProfileId;
+const PROFILE_B = '00000000-0000-4000-8000-000000000002' as ProfileId;
+
+function cloudProfile(overrides: Partial<ProfileDescriptor> = {}): ProfileDescriptor {
+  return {
+    profileId: PROFILE_A,
+    mode: 'cloud',
+    authRealm: 'global',
+    dataOwnerId: 'owner-a',
+    displayName: 'Account A',
+    status: 'active',
+    storageMode: 'profile_dir',
+    legacyUserId: null,
+    createdAt: 1,
+    lastOpenedAt: null,
+    lastVerifiedAt: null,
+    ...overrides,
+  };
+}
+
+describe('profile registry model', () => {
+  it('creates opaque UUID profile ids and validates local identity', () => {
+    expect(createProfileId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+    );
+    expect(() => assertValidProfileDescriptor(cloudProfile({ mode: 'local' }))).toThrow(
+      'local profile cannot have an auth realm',
+    );
+    expect(() =>
+      assertValidProfileDescriptor(
+        cloudProfile({ mode: 'local', authRealm: null, dataOwnerId: 'owner-a' }),
+      ),
+    ).toThrow(`local profile must use ${LOCAL_PROFILE_DATA_OWNER_ID}`);
+    expect(() =>
+      assertValidProfileDescriptor(
+        cloudProfile({
+          mode: 'local',
+          authRealm: null,
+          dataOwnerId: LOCAL_PROFILE_DATA_OWNER_ID,
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('uses (auth realm, data owner) as the account uniqueness key', () => {
+    const state = registerProfile(emptyProfileRegistry(), cloudProfile());
+    expect(
+      findProfileByIdentity(state, { mode: 'cloud', authRealm: 'global', dataOwnerId: 'owner-a' }),
+    ).toEqual(cloudProfile());
+    expect(() =>
+      registerProfile(
+        state,
+        cloudProfile({ profileId: PROFILE_B, displayName: 'Duplicate account' }),
+      ),
+    ).toThrow('already exists');
+
+    const cnProfile = cloudProfile({ profileId: PROFILE_B, authRealm: 'cn' });
+    expect(() => registerProfile(state, cnProfile)).not.toThrow();
+    expect(profileIdentityKey({ mode: 'cloud', authRealm: 'cn', dataOwnerId: 'owner-a' })).not.toBe(
+      profileIdentityKey({ mode: 'cloud', authRealm: 'global', dataOwnerId: 'owner-a' }),
+    );
+  });
+
+  it('keeps legacy database paths unchanged and derives new paths from profileId', () => {
+    const legacy = cloudProfile({
+      storageMode: 'legacy_user_db',
+      legacyUserId: 'user-123',
+    });
+    expect(resolveProfileDbPath(legacy, { userDataDir: '/user-data', dbFilePrefix: 'cindy' })).toBe(
+      path.join('/user-data', 'cindy-user-123.db'),
+    );
+
+    const modern = cloudProfile({ storageMode: 'profile_dir', legacyUserId: 'old-user-123' });
+    expect(resolveProfileDbPath(modern, { userDataDir: '/user-data', dbFilePrefix: 'cindy' })).toBe(
+      path.join('/user-data', 'profiles', PROFILE_A, 'profile.db'),
+    );
+    expect(
+      resolveProfileDbPath(modern, { userDataDir: '/user-data', dbFilePrefix: 'cindy' }),
+    ).not.toContain('owner-a');
+  });
+
+  it('rejects path traversal in legacy ids and prefixes', () => {
+    expect(() =>
+      resolveProfileDbPath(
+        cloudProfile({ storageMode: 'legacy_user_db', legacyUserId: '../other' }),
+        { userDataDir: '/user-data', dbFilePrefix: 'cindy' },
+      ),
+    ).toThrow('legacyUserId');
+    expect(() =>
+      resolveProfileDbPath(cloudProfile(), { userDataDir: '/user-data', dbFilePrefix: '../cindy' }),
+    ).toThrow('dbFilePrefix');
+  });
+
+  it('serializes only registry fields and never carries credentials', () => {
+    const input = {
+      ...cloudProfile(),
+      accessToken: 'secret',
+      refreshToken: 'secret',
+    } as ProfileDescriptor & {
+      accessToken: string;
+      refreshToken: string;
+    };
+    const serialized = serializeProfileDescriptor(input);
+    expect(serialized).not.toHaveProperty('accessToken');
+    expect(serialized).not.toHaveProperty('refreshToken');
+
+    const parsed = parseProfileDescriptor({ ...serialized, accessToken: 'secret' });
+    expect(parsed).toEqual(cloudProfile());
+    expect(parsed).not.toHaveProperty('accessToken');
+  });
+
+  it('selects the first registered profile by default and permits explicit changes', () => {
+    const state = registerProfile(emptyProfileRegistry(), cloudProfile());
+    const withSecond = registerProfile(
+      state,
+      cloudProfile({ profileId: PROFILE_B, dataOwnerId: 'owner-b', displayName: 'Account B' }),
+    );
+    expect(withSecond.defaultProfileId).toBe(PROFILE_A);
+    expect(setDefaultProfile(withSecond, PROFILE_B).defaultProfileId).toBe(PROFILE_B);
+    expect(() =>
+      setDefaultProfile(withSecond, '00000000-0000-4000-8000-000000000099' as ProfileId),
+    ).toThrow('unknown profile');
+  });
+});

--- a/apps/desktop/src/main/profile/__tests__/profileRegistryModel.test.ts
+++ b/apps/desktop/src/main/profile/__tests__/profileRegistryModel.test.ts
@@ -8,6 +8,7 @@ import {
   createProfileId,
   emptyProfileRegistry,
   findProfileByIdentity,
+  markProfileOpened,
   parseProfileDescriptor,
   profileIdentityKey,
   registerProfile,
@@ -129,6 +130,17 @@ describe('profile registry model', () => {
     expect(parsed).not.toHaveProperty('accessToken');
   });
 
+  it('rejects registry records without a required creation timestamp', () => {
+    expect(() => parseProfileDescriptor({ ...cloudProfile(), createdAt: null })).toThrow(
+      'createdAt must be a non-negative integer',
+    );
+
+    const state = registerProfile(emptyProfileRegistry(), cloudProfile());
+    expect(() => markProfileOpened(state, PROFILE_A, null as unknown as number)).toThrow(
+      'openedAt must be a non-negative integer',
+    );
+  });
+
   it('selects the first registered profile by default and permits explicit changes', () => {
     const state = registerProfile(emptyProfileRegistry(), cloudProfile());
     const withSecond = registerProfile(
@@ -140,5 +152,23 @@ describe('profile registry model', () => {
     expect(() =>
       setDefaultProfile(withSecond, '00000000-0000-4000-8000-000000000099' as ProfileId),
     ).toThrow('unknown profile');
+  });
+
+  it('never selects a deleting profile as the default', () => {
+    const deletingFirst = registerProfile(
+      emptyProfileRegistry(),
+      cloudProfile({ status: 'deleting' }),
+    );
+    expect(deletingFirst.defaultProfileId).toBeNull();
+
+    const withTwoProfiles = registerProfile(
+      registerProfile(emptyProfileRegistry(), cloudProfile()),
+      cloudProfile({ profileId: PROFILE_B, dataOwnerId: 'owner-b', displayName: 'Account B' }),
+    );
+    const afterDefaultDeletion = registerProfile(
+      withTwoProfiles,
+      cloudProfile({ status: 'deleting' }),
+    );
+    expect(afterDefaultDeletion.defaultProfileId).toBe(PROFILE_B);
   });
 });

--- a/apps/desktop/src/main/profile/profileRegistryModel.ts
+++ b/apps/desktop/src/main/profile/profileRegistryModel.ts
@@ -1,0 +1,294 @@
+import { randomUUID } from 'node:crypto';
+import path from 'node:path';
+
+import type { AuthRegion } from '@cindy/auth-client';
+
+/** Local mode has no server membership, so it uses one stable synthetic owner. */
+export const LOCAL_PROFILE_DATA_OWNER_ID = 'local-v1';
+
+const PROFILE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ProfileId = string & { readonly __profileId: unique symbol };
+export type ProfileMode = 'local' | 'cloud';
+export type ProfileStatus = 'active' | 'signed_out' | 'needs_login' | 'deleting';
+export type ProfileStorageMode = 'legacy_user_db' | 'profile_dir';
+
+/**
+ * The allow-listed fields that may be persisted in the machine registry.
+ *
+ * Tokens and other credentials intentionally have no representation here. The
+ * registry is a machine-level coordination database, not a secret store.
+ */
+export interface ProfileDescriptor {
+  profileId: ProfileId;
+  mode: ProfileMode;
+  authRealm: AuthRegion | null;
+  dataOwnerId: string;
+  displayName: string;
+  status: ProfileStatus;
+  storageMode: ProfileStorageMode;
+  /** Kept while a legacy database remains the canonical storage location. */
+  legacyUserId: string | null;
+  createdAt: number;
+  lastOpenedAt: number | null;
+  lastVerifiedAt: number | null;
+}
+
+/** This is the exact row-shaped payload the future SQLite registry may store. */
+export type ProfileRegistryRecord = ProfileDescriptor;
+
+export interface ProfileRegistryState {
+  profiles: readonly ProfileDescriptor[];
+  defaultProfileId: ProfileId | null;
+}
+
+export interface ProfileDbPathContext {
+  userDataDir: string;
+  dbFilePrefix: string;
+}
+
+export interface ProfileIdentity {
+  mode: ProfileMode;
+  authRealm: AuthRegion | null;
+  dataOwnerId: string;
+}
+
+export function createProfileId(): ProfileId {
+  return randomUUID() as ProfileId;
+}
+
+export function isProfileId(value: unknown): value is ProfileId {
+  return typeof value === 'string' && PROFILE_ID_RE.test(value);
+}
+
+export function parseProfileId(value: unknown): ProfileId {
+  if (!isProfileId(value)) throw new Error('invalid profileId');
+  return value;
+}
+
+/**
+ * Build the registry uniqueness key. JSON tuple encoding avoids delimiter
+ * collisions while preserving the documented `(auth_realm, data_owner_id)`
+ * uniqueness constraint.
+ */
+export function profileIdentityKey(identity: ProfileIdentity): string {
+  return JSON.stringify([identity.authRealm, identity.dataOwnerId]);
+}
+
+export function profileDescriptorIdentity(profile: ProfileDescriptor): ProfileIdentity {
+  return {
+    mode: profile.mode,
+    authRealm: profile.authRealm,
+    dataOwnerId: profile.dataOwnerId,
+  };
+}
+
+function assertSafePathSegment(value: unknown, field: string): asserts value is string {
+  if (
+    typeof value !== 'string' ||
+    !value ||
+    value === '.' ||
+    value === '..' ||
+    /[\\/\0]/.test(value)
+  ) {
+    throw new Error(`${field} must be a single safe path segment`);
+  }
+}
+
+function assertTimestamp(value: unknown, field: string): asserts value is number | null {
+  if (value === null) return;
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer or null`);
+  }
+}
+
+/** Validate invariants before a descriptor enters the registry. */
+export function assertValidProfileDescriptor(profile: ProfileDescriptor): void {
+  parseProfileId(profile.profileId);
+
+  if (profile.mode !== 'local' && profile.mode !== 'cloud') {
+    throw new Error('profile mode must be local or cloud');
+  }
+  if (profile.mode === 'local') {
+    if (profile.authRealm !== null) throw new Error('local profile cannot have an auth realm');
+    if (profile.dataOwnerId !== LOCAL_PROFILE_DATA_OWNER_ID) {
+      throw new Error(`local profile must use ${LOCAL_PROFILE_DATA_OWNER_ID}`);
+    }
+  } else if (profile.authRealm !== 'cn' && profile.authRealm !== 'global') {
+    throw new Error('cloud profile must have a valid auth realm');
+  }
+
+  if (typeof profile.dataOwnerId !== 'string' || !profile.dataOwnerId.trim()) {
+    throw new Error('profile dataOwnerId is required');
+  }
+  if (typeof profile.displayName !== 'string' || !profile.displayName.trim()) {
+    throw new Error('profile displayName is required');
+  }
+  if (
+    profile.status !== 'active' &&
+    profile.status !== 'signed_out' &&
+    profile.status !== 'needs_login' &&
+    profile.status !== 'deleting'
+  ) {
+    throw new Error('invalid profile status');
+  }
+  if (profile.storageMode !== 'legacy_user_db' && profile.storageMode !== 'profile_dir') {
+    throw new Error('invalid profile storage mode');
+  }
+  if (profile.storageMode === 'legacy_user_db') {
+    if (!profile.legacyUserId) throw new Error('legacy storage requires legacyUserId');
+    assertSafePathSegment(profile.legacyUserId, 'legacyUserId');
+  } else if (profile.legacyUserId !== null) {
+    assertSafePathSegment(profile.legacyUserId, 'legacyUserId');
+  }
+
+  assertTimestamp(profile.createdAt, 'createdAt');
+  assertTimestamp(profile.lastOpenedAt, 'lastOpenedAt');
+  assertTimestamp(profile.lastVerifiedAt, 'lastVerifiedAt');
+}
+
+/**
+ * Allow-list serialization for the future SQLite adapter. Unknown fields are
+ * deliberately dropped, so a token accidentally attached by a caller cannot
+ * become part of the registry record.
+ */
+export function serializeProfileDescriptor(profile: ProfileDescriptor): ProfileRegistryRecord {
+  assertValidProfileDescriptor(profile);
+  return {
+    profileId: profile.profileId,
+    mode: profile.mode,
+    authRealm: profile.authRealm,
+    dataOwnerId: profile.dataOwnerId,
+    displayName: profile.displayName,
+    status: profile.status,
+    storageMode: profile.storageMode,
+    legacyUserId: profile.legacyUserId,
+    createdAt: profile.createdAt,
+    lastOpenedAt: profile.lastOpenedAt,
+    lastVerifiedAt: profile.lastVerifiedAt,
+  };
+}
+
+/** Parse a registry row without allowing extra fields into the model. */
+export function parseProfileDescriptor(raw: unknown): ProfileDescriptor {
+  if (!raw || typeof raw !== 'object') throw new Error('invalid profile registry record');
+  const value = raw as Record<string, unknown>;
+  const profile: ProfileDescriptor = {
+    profileId: parseProfileId(value.profileId),
+    mode: value.mode as ProfileMode,
+    authRealm: value.authRealm as AuthRegion | null,
+    dataOwnerId: value.dataOwnerId as string,
+    displayName: value.displayName as string,
+    status: value.status as ProfileStatus,
+    storageMode: value.storageMode as ProfileStorageMode,
+    legacyUserId: value.legacyUserId as string | null,
+    createdAt: value.createdAt as number,
+    lastOpenedAt: value.lastOpenedAt as number | null,
+    lastVerifiedAt: value.lastVerifiedAt as number | null,
+  };
+  assertValidProfileDescriptor(profile);
+  return profile;
+}
+
+export function emptyProfileRegistry(): ProfileRegistryState {
+  return { profiles: [], defaultProfileId: null };
+}
+
+export function findProfileById(
+  state: ProfileRegistryState,
+  profileId: ProfileId,
+): ProfileDescriptor | null {
+  return state.profiles.find((profile) => profile.profileId === profileId) ?? null;
+}
+
+export function findProfileByIdentity(
+  state: ProfileRegistryState,
+  identity: ProfileIdentity,
+): ProfileDescriptor | null {
+  const key = profileIdentityKey(identity);
+  return (
+    state.profiles.find(
+      (profile) => profileIdentityKey(profileDescriptorIdentity(profile)) === key,
+    ) ?? null
+  );
+}
+
+/**
+ * Insert or update a Profile while rejecting both identity and id collisions.
+ * A duplicate identity must reuse the existing local Profile instead of
+ * silently creating a second database for the same account.
+ */
+export function registerProfile(
+  state: ProfileRegistryState,
+  profile: ProfileDescriptor,
+): ProfileRegistryState {
+  const serialized = serializeProfileDescriptor(profile);
+  const existingById = findProfileById(state, profile.profileId);
+  const existingByIdentity = findProfileByIdentity(state, profileDescriptorIdentity(profile));
+
+  if (
+    existingById &&
+    profileIdentityKey(profileDescriptorIdentity(existingById)) !==
+      profileIdentityKey(profileDescriptorIdentity(profile))
+  ) {
+    throw new Error(`profileId ${profile.profileId} is already bound to another identity`);
+  }
+  if (existingByIdentity && existingByIdentity.profileId !== profile.profileId) {
+    throw new Error(
+      `profile identity ${profileIdentityKey(profileDescriptorIdentity(profile))} already exists`,
+    );
+  }
+
+  const profiles = existingById
+    ? state.profiles.map((item) => (item.profileId === profile.profileId ? serialized : item))
+    : [...state.profiles, serialized];
+  return {
+    profiles,
+    defaultProfileId: state.defaultProfileId ?? profile.profileId,
+  };
+}
+
+export function setDefaultProfile(
+  state: ProfileRegistryState,
+  profileId: ProfileId,
+): ProfileRegistryState {
+  const profile = findProfileById(state, profileId);
+  if (!profile) throw new Error(`cannot select unknown profile ${profileId}`);
+  if (profile.status === 'deleting') throw new Error('deleting profile cannot be selected');
+  return { ...state, defaultProfileId: profileId };
+}
+
+export function markProfileOpened(
+  state: ProfileRegistryState,
+  profileId: ProfileId,
+  openedAt: number,
+): ProfileRegistryState {
+  const profile = findProfileById(state, profileId);
+  if (!profile) throw new Error(`cannot open unknown profile ${profileId}`);
+  assertTimestamp(openedAt, 'openedAt');
+  return {
+    ...state,
+    profiles: state.profiles.map((item) =>
+      item.profileId === profileId ? { ...item, lastOpenedAt: openedAt } : item,
+    ),
+  };
+}
+
+/**
+ * Resolve the database path without ever using dataOwnerId as a filename.
+ * Legacy profiles retain the exact `<prefix>-<userId>.db` path until a later,
+ * independently verified physical migration.
+ */
+export function resolveProfileDbPath(
+  profile: ProfileDescriptor,
+  context: ProfileDbPathContext,
+): string {
+  assertValidProfileDescriptor(profile);
+  assertSafePathSegment(context.dbFilePrefix, 'dbFilePrefix');
+  if (!context.userDataDir.trim()) throw new Error('userDataDir is required');
+
+  if (profile.storageMode === 'legacy_user_db') {
+    return path.join(context.userDataDir, `${context.dbFilePrefix}-${profile.legacyUserId}.db`);
+  }
+  return path.join(context.userDataDir, 'profiles', profile.profileId, 'profile.db');
+}

--- a/apps/desktop/src/main/profile/profileRegistryModel.ts
+++ b/apps/desktop/src/main/profile/profileRegistryModel.ts
@@ -95,10 +95,16 @@ function assertSafePathSegment(value: unknown, field: string): asserts value is 
   }
 }
 
-function assertTimestamp(value: unknown, field: string): asserts value is number | null {
+function assertOptionalTimestamp(value: unknown, field: string): asserts value is number | null {
   if (value === null) return;
   if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
     throw new Error(`${field} must be a non-negative integer or null`);
+  }
+}
+
+function assertRequiredTimestamp(value: unknown, field: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${field} must be a non-negative integer`);
   }
 }
 
@@ -142,9 +148,9 @@ export function assertValidProfileDescriptor(profile: ProfileDescriptor): void {
     assertSafePathSegment(profile.legacyUserId, 'legacyUserId');
   }
 
-  assertTimestamp(profile.createdAt, 'createdAt');
-  assertTimestamp(profile.lastOpenedAt, 'lastOpenedAt');
-  assertTimestamp(profile.lastVerifiedAt, 'lastVerifiedAt');
+  assertRequiredTimestamp(profile.createdAt, 'createdAt');
+  assertOptionalTimestamp(profile.lastOpenedAt, 'lastOpenedAt');
+  assertOptionalTimestamp(profile.lastVerifiedAt, 'lastVerifiedAt');
 }
 
 /**
@@ -242,9 +248,18 @@ export function registerProfile(
   const profiles = existingById
     ? state.profiles.map((item) => (item.profileId === profile.profileId ? serialized : item))
     : [...state.profiles, serialized];
+
+  const currentDefault = state.defaultProfileId
+    ? (profiles.find(
+        (item) => item.profileId === state.defaultProfileId && item.status !== 'deleting',
+      )?.profileId ?? null)
+    : null;
+  const firstSelectableProfile =
+    profiles.find((item) => item.status !== 'deleting')?.profileId ?? null;
+
   return {
     profiles,
-    defaultProfileId: state.defaultProfileId ?? profile.profileId,
+    defaultProfileId: currentDefault ?? firstSelectableProfile,
   };
 }
 
@@ -265,7 +280,7 @@ export function markProfileOpened(
 ): ProfileRegistryState {
   const profile = findProfileById(state, profileId);
   if (!profile) throw new Error(`cannot open unknown profile ${profileId}`);
-  assertTimestamp(openedAt, 'openedAt');
+  assertRequiredTimestamp(openedAt, 'openedAt');
   return {
     ...state,
     profiles: state.profiles.map((item) =>

--- a/docs/dev-rules/database-and-migrations.md
+++ b/docs/dev-rules/database-and-migrations.md
@@ -7,6 +7,10 @@
 本文只治理 Desktop 的 Drizzle／SQLite。本仓不包含服务端数据库；服务端 migration 以
 对应服务端仓规则为准。
 
+多账号场景下的 Profile、Machine Registry、Runtime Lease 与表级 ownership 约束见
+[`multi-account-database-architecture.md`](multi-account-database-architecture.md)。该文档
+是架构基线；在它的所有权边界确认前，不要通过批量增加 `owner_id` 来改造存量业务表。
+
 > **增量适用原则**：本规则约束新数据库改动，不要求为统一形式专项改造存量代码。
 > 不得借普通功能修改重写历史 migration 或批量迁移旧数据库访问方式。
 

--- a/docs/dev-rules/multi-account-database-architecture.md
+++ b/docs/dev-rules/multi-account-database-architecture.md
@@ -1,0 +1,303 @@
+# Desktop 多账号数据库与数据所有权架构
+
+> **状态**：架构基线（先梳理，不代表多账号功能已实现）
+> **范围**：Desktop 本地数据、SQLite、凭证命名空间、Profile 生命周期与运行时隔离。
+> **跟踪 Issue**：[#1266](https://github.com/makecindy/cindy/issues/1266)
+> **当前结论**：本阶段不新增业务功能，不批量给现有业务表增加 `owner_id`，也不直接写
+> migration；先冻结所有权边界，再按后续实现需要追加最小迁移。
+
+## 1. 结论先行
+
+未来多账号采用 **一个账号一个 Profile、一个 Profile 一份 Profile DB、一个 Profile 一个
+独立运行时** 的模型。
+
+- Profile 是内部隔离边界，用户界面可以只称为“账号”。
+- Profile 代表一个稳定的 Data Owner / membership，不代表一次登录窗口，也不等同于
+  `region`。
+- Profile DB 内的业务表天然属于该 Profile，因此不需要在每张表重复保存 `owner_id`。
+- 同一 Profile 的第二次启动只聚焦或复用已有运行时；同一账号不允许在两个 Profile
+  运行时中同时作为 active owner。
+- 多个账号同时运行通过多个 Profile 运行时完成，不通过一个主进程切换多个全局单例。
+- CN / Global 仍是构建期固定维度，不能作为多账号隔离键，也不能变成用户可选项。
+
+这意味着当前最重要的工作不是改表，而是把“数据库文件、数据库之外的持久化文件、凭证、
+运行时租约”归到同一套 Profile 边界下。
+
+## 2. 术语与边界
+
+| 术语 | 含义 | 不是它 |
+|---|---|---|
+| Machine | 当前安装、当前 `userData` 根目录对应的一台机器 / 一个本地安装 | 账号、组织或服务器 membership |
+| Profile | 本地稳定的账号容器；持有一个 Data Owner 的本地数据、配置与凭证命名空间 | 一次窗口、一个 renderer、一个登录请求 |
+| Data Owner | 服务端确认的 membership / owner id；用于服务端权限和数据归属 | `profileId`，也不应直接作为文件名 |
+| Profile DB | 一个 Profile 的 SQLite 数据库，包含该 Profile 的业务数据 | 机器级缓存或机器注册表 |
+| Runtime Lease | 防止同一 Profile 被多个进程同时运行的短期租约 | 任务历史、消息或账号配置 |
+| Machine Registry | 登录前即可读取的 Profile 目录与运行时协调控制面 | refresh token、业务消息 |
+
+`profileId` 是本地生成的 opaque id；`dataOwnerId` 是服务端身份。两者必须分开，避免
+“重新登录同一账号”“membership 变化”“本地 Profile 重命名”互相改写文件路径。
+
+## 3. 现状盘点
+
+当前 Desktop 已经是“按账号分数据库文件”的模型：
+
+```text
+<userData>/<dbFilePrefix>-<userId>.db
+```
+
+`localDb/index.ts`、`localDb/client/current.ts`、`authManager.ts`、Scheduler、Maker、
+IM、Device Link 等仍是模块级单例。切账号时是 teardown 旧 owner，再打开新 DB，而不是
+同一进程同时拥有多个数据库上下文。
+
+数据库以外已经存在一部分 owner 命名空间：
+
+```text
+<userData>/owners/<hash(dataOwnerId)>/...
+```
+
+但仍有一些持久化路径直接落在 `<userData>` 根目录，例如历史 auth session、部分
+Device Link 设置、layout / provider runtime 文件、媒体字节仓和旧集成缓存。它们与 SQLite
+按账号分文件的语义并不完全一致，这正是未来多账号最容易串号的地方。
+
+## 4. 目标分层
+
+### 4.1 Machine Registry：独立小型 SQLite
+
+选择独立 SQLite，而不是 JSON，原因是未来会同时有多个 Profile 进程，需要原子地完成：
+
+- Profile 创建、删除、默认 Profile 与最近打开时间更新；
+- 同一账号去重；
+- 启动前抢占 / 释放 Profile Runtime Lease；
+- 崩溃后的过期租约接管；
+- 多进程并发写入不丢字段。
+
+建议路径：
+
+```text
+<userData>/profile-registry.sqlite
+```
+
+建议逻辑表（不是本阶段要直接创建的 schema）：
+
+```text
+profiles
+  profile_id TEXT PRIMARY KEY                 -- 本地 opaque UUID
+  data_owner_id TEXT                          -- cloud membership；local 模式使用 `local-v1`
+  auth_realm TEXT                              -- 观测到的 auth realm，仅用于校验/诊断
+  display_name TEXT NOT NULL
+  status TEXT NOT NULL                         -- active / signed_out / needs_login / deleting
+  storage_mode TEXT NOT NULL                   -- legacy_user_db / profile_dir
+  legacy_user_id TEXT                          -- 兼容旧 <prefix>-<userId>.db，迁完可为空
+  created_at INTEGER NOT NULL
+  last_opened_at INTEGER
+  last_verified_at INTEGER
+
+profile_runtime_leases
+  profile_id TEXT PRIMARY KEY
+  lease_id TEXT NOT NULL
+  pid INTEGER NOT NULL
+  started_at INTEGER NOT NULL
+  heartbeat_at INTEGER NOT NULL
+
+machine_meta
+  key TEXT PRIMARY KEY
+  value TEXT
+```
+
+约束：
+
+- cloud Profile 对 `(auth_realm, data_owner_id)` 建唯一约束，保证一个账号只有一个本地
+  Profile；local Profile 使用固定的 `LOCAL_DATA_OWNER_ID` 语义。
+- Registry 不存 access token、refresh token、OAuth code、API key 或私钥。
+- 不存任意用户可控绝对路径；Profile DB 路径由 `profile_id` 派生，旧库路径只通过
+  `storage_mode + legacy_user_id` 兼容。
+- `auth_realm` 不是账号隔离键，更不是用户可修改的区域选择；它只用于阻止跨 realm
+  误用凭证和帮助诊断。
+
+### 4.2 Profile DB：默认保持一库一 Profile
+
+目标路径：
+
+```text
+<userData>/profiles/<profileId>/profile.db
+```
+
+在兼容阶段，已有库可以继续使用：
+
+```text
+<userData>/<dbFilePrefix>-<legacyUserId>.db
+```
+
+Registry 将该文件登记为一个 Profile 的 legacy storage，不在首次迁移时复制或重写大库。
+新建的 Profile 使用 `profiles/<profileId>/profile.db`；旧 Profile 后续可单独做可回滚的
+物理搬迁。
+
+Profile DB 的规则：
+
+1. 业务表默认都属于当前 Profile，不加重复的 `owner_id`。
+2. 表间 FK 继续在同一 DB 内表达，删除和事务语义不改变。
+3. 跨 Profile 的导入 / 分享必须通过显式 envelope 携带来源 Profile 与授权信息，不能
+   直接把一张业务表当作跨账号共享表。
+4. `DbClient` 必须绑定 `profileId` / scope key；未绑定 Profile 的查询 fail closed。
+5. DB 内的 `migration_meta`、`migration_history` 仍是该 DB 的 schema 控制面，不搬到业务
+   表，也不承担 Machine Registry 的职责。
+
+跨账号实时协作不是 Profile DB 的隐式能力。未来若需要账号 A 与账号 B 共同访问同一个
+任务，应单独建立 Shared Workspace / Shared Task 层和 ACL；Profile DB 只保存私有数据或
+受控镜像，不能因为两个账号在同一台机器上就自动互相可见。
+
+### 4.3 Runtime / Lease State：与业务数据分开
+
+同一 Profile 的多个进程必须有单一 active runtime。Runtime Lease 位于 Machine Registry
+或等价的机器级 broker 中，按 `profile_id` CAS + heartbeat 处理；它不应与 sessions、
+messages 等业务表混在一起。
+
+现有 `device_link_ownership` 的行为仍然需要保留，但目标是把它看成 Profile Runtime Lease，
+而不是账号业务数据：
+
+- 旧库阶段可以继续使用该表完成兼容仲裁；
+- 新架构由 `profile_runtime_leases` 统一承载；
+- Lease 失效只影响进程 / Device Link 连接，不删除 Profile 数据；
+- 不同账号的 Profile 不共享同一行，也不互相顶号。
+
+### 4.4 Machine Shared Cache：默认不承载用户内容
+
+机器级缓存可以共享 agent 二进制、模型下载、插件包和明确可再生的公开缓存，但必须满足：
+
+- 缓存本身不表达账号归属；
+- 任何用户内容的归属由 Profile DB ledger / refs 表达；
+- 没有 Profile 授权时，缓存命中不能直接成为可读权限；
+- 共享缓存不能绕过现有安全协议与内容授权。
+
+第一阶段不把私人媒体字节做跨 Profile 共享。这样可以保持媒体读取与 Profile DB 的权限
+一致，避免“知道 hash 就能读取另一个账号媒体”的隐患。需要共享媒体时，另建机器级
+cache ledger 和授权协议，不把它作为本次数据库改造的顺手优化。
+
+## 5. Ownership Matrix
+
+“是否需要 `owner_id`”按目标架构回答，不按当前文件布局回答：Profile DB 本身已经是
+owner 边界，所以大多数行答案是“否”。
+
+| 表 / 虚表 | 当前归属 | 目标归属 | `owner_id` 列 | 后续迁移 |
+|---|---|---|---|---|
+| `sessions` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `messages` / `messages_fts` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `session_pr_refs` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `session_goals` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `orca_teams` / `orca_workers` / `orca_worker_creation_reservations` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `schedules` / `schedule_runs` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `im_bindings` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `wechat_sync_state` / `wechat_inbox` / `wechat_outbox` / `wechat_file_attachments` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移；凭证与 staging 路径需按 Profile 收口 |
+| `recent_workdirs` / `project_aliases` / `project_automation_consents` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `right_sidebar_tabs` / `agent_input_queue_snapshots` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `account_usage_snapshots` / `daily_spend` / `daily_model_usage` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `embedding_jobs` / `embedding_meta` / `vec_table_meta` / `chat_messages_vec_v1` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `skill_usage_sources` / `skill_usage_exposures` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移；raw transcript 路径必须按 Profile 可解析 |
+| `custom_providers` / `custom_mcp_servers` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移；secret key 迁到 Profile namespace |
+| `media_refs` | 当前账号 DB | Profile DB | 否 | 保持 ledger 语义；路径与协议改造另行设计 |
+| `media_blobs` | 当前账号 DB 元数据；字节仓当前落在 userData 根下 | Profile DB 元数据 + Profile 私有媒体仓 | 否 | 需要单独的媒体路径兼容迁移，不能直接共享现有根目录 |
+| `ghost_cards` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移 |
+| `hook_group_messages` | 当前账号 DB | Profile DB | 否 | 无 schema 迁移；hook 连接配置需按 Profile 收口 |
+| `device_link_ownership` | 当前账号 DB 中的单行运行时仲裁 | Runtime Lease（按 Profile） | 否 | 后续把租约抽到 Registry / broker；旧表兼容期保留 |
+| `migration_meta` / `migration_history` | 当前账号 DB 控制面 | 各 Profile DB 控制面 | 否 | 保持现有 append-only 规则 |
+
+### 5.1 特殊边界
+
+#### 媒体
+
+`mediaBlobs` 是内容寻址元数据，`mediaRefs` 是归属与生命周期账本。当前物理字节在
+`<userData>/cindy-media`，这在多 Profile 下不应继续作为默认写入位置。第一阶段目标是
+把字节仓也放进 Profile 私有目录；内容寻址仍可在同一 Profile 内去重。跨 Profile 共享
+字节属于另一个“机器缓存 + 授权 ledger”问题，不能只把 `mediaBlobs` 搬到共享 DB。
+
+#### Device Link
+
+Device Link 的 relay 身份和本地授权都跟 Profile / Data Owner 绑定。`device_link_ownership`
+不是消息数据；它的长期归属是 Runtime Lease。即使多个账号并行运行，也只能在各自 Profile
+范围内仲裁，不应使用一个全局单行表把不同账号串在一起。
+
+#### Embedding
+
+embedding job 的 `source_id` 通常指向 message / document 等 Profile 内容；向量表和
+元信息也必须跟随 Profile。机器级模型缓存可以共享，但向量结果不能共享为无 owner 的全局
+数据。
+
+#### Provider / MCP
+
+`custom_providers` 与 `custom_mcp_servers` 继续只保存非秘密配置；API key、OAuth 凭证、
+MCP token 仍走 safeStorage。未来 safeStorage 的物理 key 应以 `profileId` 命名空间隔离，
+并通过兼容映射读取现有 `dataOwnerId` 命名空间，不能要求用户重新填写密钥。
+
+## 6. 数据库之外的必须同步收口项
+
+这部分不是本阶段的实现，但它决定多账号是否真正安全：
+
+| 当前形态 | 目标 | 备注 |
+|---|---|---|
+| auth refresh session / realm 在 userData 根目录 | Registry 只保存 Profile 元数据；凭证落 safeStorage 的 Profile namespace | 不因新 Profile 覆盖旧 Profile token |
+| `owners/<hash(dataOwnerId)>` | `profiles/<profileId>/...` 为 canonical；旧 owner 路径作为迁移 alias | 保留 `dataOwnerId` 作为服务端身份 |
+| `device-link-settings.json` 根目录 | 每个 Profile 一份；机器级偏好与账号授权拆开 | `keepAwake` 这类机器偏好可另留 Machine 层 |
+| `cindy-media/` 根目录 | Profile 私有媒体仓；可再生共享缓存另行设计 | 不能让 hash 直接跨 Profile 可读 |
+| layout / provider runtime / hook / IM 辅助文件 | 按其语义明确标为 Profile 或 Machine | 不能因为“只是 JSON”就默认共享 |
+| Agent / model / plugin 下载缓存 | Machine Shared Cache | 缓存命中不等于账号授权 |
+
+此外，跨物理设备的“互相登出”不由本地 Profile DB 单独解决。服务端需要按设备 / 登录会话
+维护独立 refresh-token family；普通 logout 只撤销当前 family，“退出所有设备”才撤销全部
+family。客户端收到当前 family 失效时，只清理当前 Profile。
+
+## 7. Legacy 兼容迁移顺序
+
+迁移必须先建立边界，再搬数据；不做“一次性把所有文件移动到新目录”的大迁移。
+
+1. **引入 Registry（不动现有 Profile DB）**：首次成功验证已有 refresh session 后，创建
+   一个 Profile 记录，绑定 `dataOwnerId`，并把现有 `<prefix>-<userId>.db` 登记为
+   `legacy_user_db`。用户不需要重新登录。
+2. **统一 Profile Context**：运行时从 Registry 选择 Profile，`DbClient`、auth、secret
+   store、Scheduler、Maker、IM、Device Link 全部接收同一个 Profile scope。
+3. **新账号走新目录**：新建账号使用 `profiles/<profileId>/profile.db` 和 Profile 私有
+   文件树；旧 Profile 继续读旧文件，直到对应迁移完成。
+4. **按模块迁移旁路存储**：凭证、IM、hook、Device Link 授权、layout、媒体等逐项做
+   可重试、可回滚、幂等迁移；每项都保留旧路径只读兼容窗口。
+5. **最后再考虑物理搬迁旧 DB**：确认所有运行时与备份工具都支持新路径后，才将 legacy
+   DB 改名或移动。这个动作不是多账号上线的前置条件。
+
+任何迁移都必须满足：
+
+- 不丢聊天、附件、Provider 配置或已有 safeStorage 凭证；
+- 不因切换 Profile 删除另一个账号的 refresh token；
+- 失败可重试，重复执行不产生第二份数据；
+- SQLite schema 变化仍只用 Drizzle 追加 migration，并通过 `db:validate` 与 replay；
+- 未合入 migration 不连接共享 userData，使用隔离数据库验证。
+
+## 8. 暂不做的事情
+
+- 不给 `sessions`、`messages`、`schedules` 等所有表批量加 `owner_id`。
+- 不在一个主进程中把多个账号的 DB client / Scheduler / Maker 单例强行改成多租户容器。
+- 不把 CN / Global 当作 Profile 维度，也不增加用户选择区域的入口。
+- 不把 refresh token、OAuth 凭证、Provider key 放入 SQLite。
+- 不在本阶段新增业务功能、账号切换 UI 或多账号并行启动流程。
+- 不为了“统一目录”直接移动用户现有数据库或媒体文件。
+
+## 9. 验收不变量
+
+后续实现多账号时，至少必须保持：
+
+1. 任意运行时只打开一个 Profile DB；DB client 的 scope 与 Profile Registry 选择一致。
+2. 同一 `(auth_realm, data_owner_id)` 只有一个 Profile 记录。
+3. 同一 Profile 同时最多一个 active Runtime Lease；崩溃后只能按 heartbeat / CAS 接管。
+4. Profile A 的查询、凭证、媒体 URL、Device Link 事件不能在 Profile B 可见。
+5. 手机 / 远程控制请求必须携带并校验目标 Profile / Data Owner 路由，不能只靠当前全局
+   `currentUser` 猜测。
+6. Profile DB 业务表继续保持无 `owner_id` 的单 owner 语义；跨 Profile 操作必须显式授权。
+7. 旧用户升级后什么都不做，现有聊天、配置和凭证继续可用。
+
+## 10. 本阶段交付边界
+
+本阶段已先落下不依赖 Electron／真实用户目录的 Registry 纯模型：
+`apps/desktop/src/main/profile/profileRegistryModel.ts` 负责 Profile 描述、账号唯一性、
+旧库路径派生、Profile DB 路径派生和凭证字段 allow-list；对应测试位于
+`apps/desktop/src/main/profile/__tests__/profileRegistryModel.test.ts`。它还不是
+`profile-registry.sqlite` 的运行时实现，也不改变现有 `localDb` 打开路径。
+
+下一步仍应为 Registry SQLite 适配器、Profile Context、Runtime Lease 和旁路文件建立单独
+任务；在这些边界得到实现验证前，不应创建新的业务表或批量 migration。


### PR DESCRIPTION
## 这次改了什么

### 摘要

建立多账号演进所需的 Profile Registry 架构基线，先把 Profile、Data Owner、legacy 数据库路径和账号唯一性定义清楚，再接运行时和独立 Registry SQLite。这样可以避免通过给所有业务表批量增加 `owner_id` 来解决本应由数据库文件边界解决的问题。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Refs #1266
- 本 PR 包含：
  - 新增纯逻辑 Profile Registry model，覆盖 cloud / local Profile、opaque `profileId`、`dataOwnerId`、`authRealm`、legacy storage 和 Profile DB 路径。
  - 用 `(authRealm, dataOwnerId)` 约束同一账号只对应一个本地 Profile。
  - 用 allow-list 序列化保证 access token、refresh token 等凭证不会进入 Machine Registry 模型。
  - 保持现有 `<dbFilePrefix>-<userId>.db` 路径不变；新 Profile 预留 `profiles/<profileId>/profile.db`。
  - 补充多账号数据库 ownership、共享任务边界和向下兼容文档。
- 明确不包含：
  - `profile-registry.sqlite` 的运行时读写。
  - Profile Context、Runtime Lease、账号切换 UI、多账号并行启动。
  - 现有业务表 migration、旧数据库搬迁、媒体和凭证物理路径迁移。
- 用户可见变化：无；本 PR 仅建立架构模型与规则，开发版手工启动仅做兼容性验证。
- 是否存在 breaking change：无。

### UI 变化

- 不涉及：没有修改 UI、交互或产品文案。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-multi-account-db-architecture
结果：GATE_EXIT=0

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/profile/__tests__/profileRegistryModel.test.ts --pool=threads
结果：8/8 通过

pnpm check:dco
结果：2 个提交通过 DCO 签名检查
```

### 手工验证

在 macOS 上使用当前任务 worktree 启动：

```text
pnpm restart:desktop:remote --region=cn --preserve-running
pnpm desktop:whoami
```

结果：当前实例为 `MATCH`，运行在本任务 worktree，`mode=remote`、`passive=true`。启动日志确认：数据库 schema version 为 83、pending migration 为 0、schema drift 为 clean、SQLite smoke table count 为 147、`localDb.ensureReady.ok` 成功。

### 未执行的验证

- `db:validate` / `test:migration-replay`：本 PR 没有新增或修改 SQLite schema、migration 或 companion script，因此不适用。
- 独立 `profile-registry.sqlite` 运行时回放：该适配器不在本 PR 范围内。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：当前只新增纯逻辑模型、测试和架构文档；现有 Profile DB 路径、业务表、凭证和媒体文件均不改变，升级后无需重新登录或迁移数据。
- 回滚 / 降级方式：回滚本 PR 提交即可；由于没有新增 migration 或运行时 Registry 文件，不需要数据回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（本 PR 不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

