### PR TITLE
fix(desktop): 修复会话浮层状态溢出

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionTooltip.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionTooltip.tsx
@@ -216,12 +216,16 @@ function PrLine({ prRef, status }: { prRef: SessionPrRef; status: PrStatusResult
   const unresolved = status?.ok && status.unresolvedCount ? status.unresolvedCount : 0;
 
   return (
-    <div className="flex max-w-80 items-center gap-1.5">
+    <div className="flex min-w-0 max-w-80 items-center gap-1.5">
       <Icon size={12} strokeWidth={1.75} className="shrink-0" style={{ color }} />
-      <span className="shrink-0">
+      <span className="min-w-0 truncate">
         {prRef.owner}/{prRef.repo}#{prRef.prNumber}
       </span>
-      {kind && <span className="shrink-0">· {t(`ccAgent.gitContext.pr.status.${kind}`)}</span>}
+      {kind && (
+        <span className="shrink-0 whitespace-nowrap">
+          · {t(`ccAgent.gitContext.pr.status.${kind}`)}
+        </span>
+      )}
       {unresolved > 0 && (
         <span
           className="inline-flex shrink-0 items-center gap-0.5"

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionTooltip.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionTooltip.test.ts
@@ -7,6 +7,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Tooltip } from '@/components/ui/tooltip';
 import { SessionTooltip } from '../SessionTooltip';
 import type { SessionPrRef } from '@/lib/gitContext.types';
+import { prStatusKey } from '@/hooks/useSessionGitContext';
+
+const { prStatuses } = vi.hoisted(() => ({
+  prStatuses: new Map(),
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -16,13 +21,14 @@ vi.mock('react-i18next', () => ({
 
 vi.mock('@/contexts/PrRefsContext', () => ({
   usePrStatuses: () => ({
-    statuses: new Map(),
+    statuses: prStatuses,
     fetchStatusesForSession: vi.fn(),
   }),
 }));
 
 afterEach(() => {
   cleanup();
+  prStatuses.clear();
 });
 
 const prRef: SessionPrRef = {
@@ -84,5 +90,50 @@ describe('SessionTooltip', () => {
     fireEvent.focus(screen.getByText('Session row'));
 
     expect(screen.queryByText('XDMaker')).toBeNull();
+  });
+
+  it('lets a long repository label shrink without pushing the PR status outside the tooltip', async () => {
+    const longRepoRef = {
+      ...prRef,
+      repo: 'repository-name-that-is-much-wider-than-the-tooltip-content-area',
+    };
+    prStatuses.set(prStatusKey(longRepoRef), {
+      ok: true,
+      owner: longRepoRef.owner,
+      repo: longRepoRef.repo,
+      prNumber: longRepoRef.prNumber,
+      status: 'merged',
+      branch: 'fix/long-repository-name',
+      title: 'Keep the merged state inside the tooltip',
+      htmlUrl: longRepoRef.url,
+      unresolvedCount: 0,
+    });
+
+    render(
+      createElement(
+        SessionTooltip,
+        { sessionId: 'session-1', prRefs: [longRepoRef] } as unknown as ComponentProps<
+          typeof SessionTooltip
+        >,
+        createElement('div', null, 'Session row'),
+      ),
+    );
+
+    fireEvent.pointerMove(screen.getByText('Session row'), { pointerType: 'mouse' });
+
+    const repoLabels = await screen.findAllByText(
+      `makecindy/${longRepoRef.repo}#${longRepoRef.prNumber}`,
+    );
+    const statusLabels = screen.getAllByText('· ccAgent.gitContext.pr.status.merged');
+
+    for (const repoLabel of repoLabels) {
+      expect(repoLabel.classList.contains('min-w-0')).toBe(true);
+      expect(repoLabel.classList.contains('truncate')).toBe(true);
+      expect(repoLabel.classList.contains('shrink-0')).toBe(false);
+    }
+    for (const statusLabel of statusLabels) {
+      expect(statusLabel.classList.contains('shrink-0')).toBe(true);
+      expect(statusLabel.classList.contains('whitespace-nowrap')).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复会话列表 PR hover 浮层在仓库名过长时把右侧状态文字挤出容器的问题。仓库标签现在会在可用宽度内收缩并省略，PR 状态保持完整单行显示，同时保留浮层原有的水平内边距。

补充超长仓库名 + `merged` 状态的回归测试，锁定仓库标签可收缩、状态不可收缩的布局契约。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1240
- 本 PR 包含：Desktop 会话列表 `SessionTooltip` 的 PR 行收缩布局及对应回归测试
- 明确不包含：其他 tooltip、会话数据、PR 状态获取逻辑、Mobile
- 用户可见变化：长仓库名会省略，右侧“已合并”等状态完整保留在浮层内容区内
- 是否存在 breaking change：无

### UI 变化

- 使用静态浏览器 harness 分别目检 Light / Dark：两种模式下长仓库名均省略，状态未贴边或溢出；浏览器测量确认状态右边界位于内容区内、仓库名实际收缩、左右 padding 均保持 10px
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §5 Layout Principles：在受限容器内保持清晰的信息层级与既有间距
  - `docs/design-rules/DESIGN.md` §8 Window & Adaptive Behavior：内容随可用宽度收缩
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：未新增硬编码颜色或单模式分支，继续复用现有语义 token

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/cc-agent/sidebar/__tests__/sessionTooltip.test.ts
结果：通过，3 tests

pnpm --filter desktop run --if-present typecheck
结果：通过

bash -c 'for v in $(env | awk -F= "/^CLAUDE/{print $1}"); do unset $v; done; pnpm test:unit'
结果：通过，全部 required workspace 通过

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

- macOS，Chromium 静态 UI harness
- Light / Dark 各渲染一条超长仓库名 + “已合并” + PR 标题的浮层
- 目检并测量：仓库名出现省略号；状态完整；状态不越过内容右边界；左右内边距保持 10px

### 未执行的验证

- 未在真实 Cindy dev 会话中复现：当前正式版实例正在运行，独立沙盒没有可复现该 PR 关联数据；为避免共享 userData 或打扰现有实例，采用不入仓的静态 harness 验证
- 未在 Windows 硬件目检；改动仅使用跨平台 Renderer flex / overflow CSS

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅会话列表 PR hover 浮层的一行布局
- 回滚 / 降级方式：回退本提交即可恢复原布局；不涉及数据或配置迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本修复无需新增文档）
- [x] 已确认测试结果或说明未执行原因
