### PR TITLE
fix(desktop): 重试零产出失败后软删被取代的重复用户消息

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/messagesSupersedeRetriedUserTurn.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/messagesSupersedeRetriedUserTurn.test.ts
@@ -1,0 +1,257 @@
+/**
+ * retry-supersede:supersedeRetriedUserTurn 的窗口定位、守卫与广播契约。
+ *
+ * 场景背景:零产出失败 turn 被「重试」克隆重发后,历史里会留下两条一模一样的
+ * user 行(旧行 + 克隆行)与夹在中间的 error 行。本函数把旧 user 行与窗口内的
+ * error 行软删(置 rewind_at),经 messages:deleted 广播让各端移除。
+ */
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { messages, sessions } from '../../schema';
+
+const h = vi.hoisted(() => ({
+  db: null as ReturnType<typeof drizzle> | null,
+  tapWindowBroadcast: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+  },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+vi.mock('../../../logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../../../logger.js', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('../../../maker-host/codex-local-sessions', () => ({
+  importExternalCodexMessagesForSession: vi.fn(async () => undefined),
+}));
+vi.mock('../../../maker-host/claude-local-sessions', () => ({
+  importExternalClaudeCodeMessagesForSession: vi.fn(async () => undefined),
+}));
+vi.mock('../../../embedders/chat-history-embedder', () => ({
+  onMessageCreated: vi.fn(async () => undefined),
+}));
+vi.mock('../../../git-context/prRefsStore', () => ({
+  recomputePrRefsForSession: vi.fn(async () => undefined),
+  recordPrRefsForMessage: vi.fn(async () => undefined),
+}));
+vi.mock('../../client/current', () => ({
+  getDbClient: () => ({ drizzle: h.db }),
+}));
+vi.mock('../../../device-link/broadcast-tap', () => ({
+  tapWindowBroadcast: h.tapWindowBroadcast,
+}));
+
+import { supersedeRetriedUserTurn } from '../messages';
+
+const SESSION = 'session-1';
+
+function createDb(): Database.Database {
+  const sqlite = new Database(':memory:');
+  sqlite.exec(`
+    CREATE TABLE messages (
+      id TEXT PRIMARY KEY,
+      client_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      role TEXT NOT NULL,
+      content TEXT NOT NULL,
+      tool_use_id TEXT,
+      agent_meta TEXT,
+      agent_kind TEXT,
+      created_at INTEGER NOT NULL,
+      rewind_at INTEGER
+    );
+    CREATE UNIQUE INDEX uniq_messages_session_client ON messages(session_id, client_id);
+  `);
+  h.db = drizzle(sqlite, { schema: { messages, sessions } });
+  return sqlite;
+}
+
+function insertRow(
+  sqlite: Database.Database,
+  input: {
+    clientId: string;
+    role: string;
+    createdAt: number;
+    sessionId?: string;
+    rewindAt?: number | null;
+  },
+): void {
+  sqlite
+    .prepare(
+      `INSERT INTO messages (id, client_id, session_id, role, content, created_at, rewind_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      `id-${input.clientId}`,
+      input.clientId,
+      input.sessionId ?? SESSION,
+      input.role,
+      JSON.stringify({ text: input.clientId }),
+      input.createdAt,
+      input.rewindAt ?? null,
+    );
+}
+
+function rewindAtOf(sqlite: Database.Database, clientId: string): number | null {
+  const row = sqlite
+    .prepare('SELECT rewind_at AS rewindAt FROM messages WHERE session_id = ? AND client_id = ?')
+    .get(SESSION, clientId) as { rewindAt: number | null } | undefined;
+  if (!row) throw new Error(`row not found: ${clientId}`);
+  return row.rewindAt;
+}
+
+describe('supersedeRetriedUserTurn', () => {
+  let sqlite: Database.Database;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sqlite = createDb();
+  });
+
+  it('soft-deletes the superseded user row and the error rows inside the window', async () => {
+    insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100 });
+    insertRow(sqlite, { clientId: 'error-0', role: 'error', createdAt: 101 });
+    insertRow(sqlite, { clientId: 'user-1', role: 'user', createdAt: 200 });
+
+    const removed = await supersedeRetriedUserTurn(SESSION, {
+      supersededUserClientId: 'user-0',
+      retryUserClientId: 'user-1',
+    });
+
+    expect(removed).toEqual(['user-0', 'error-0']);
+    expect(rewindAtOf(sqlite, 'user-0')).toEqual(expect.any(Number));
+    expect(rewindAtOf(sqlite, 'error-0')).toEqual(expect.any(Number));
+    expect(rewindAtOf(sqlite, 'user-1')).toBeNull();
+    // 广播复用消息删除通道:本机窗口(mock 为空)之外,device-link 转发必须带上
+    // 单值兼容位(clientId)与整批 clientIds。
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:messages:deleted', {
+      sessionId: SESSION,
+      clientId: 'user-0',
+      clientIds: ['user-0', 'error-0'],
+    });
+  });
+
+  it('keeps rows outside the (created_at, rowid) window and non-error rows inside it', async () => {
+    insertRow(sqlite, { clientId: 'error-before', role: 'error', createdAt: 50 });
+    insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100 });
+    // 防御:窗口内非 error 行绝不触碰(零产出场景本不该有,误闯的产出行也要保住)。
+    insertRow(sqlite, { clientId: 'assistant-mid', role: 'assistant', createdAt: 150 });
+    insertRow(sqlite, { clientId: 'error-mid', role: 'error', createdAt: 160 });
+    insertRow(sqlite, { clientId: 'user-1', role: 'user', createdAt: 200 });
+    insertRow(sqlite, { clientId: 'error-after', role: 'error', createdAt: 300 });
+
+    const removed = await supersedeRetriedUserTurn(SESSION, {
+      supersededUserClientId: 'user-0',
+      retryUserClientId: 'user-1',
+    });
+
+    expect(removed).toEqual(['user-0', 'error-mid']);
+    expect(rewindAtOf(sqlite, 'error-before')).toBeNull();
+    expect(rewindAtOf(sqlite, 'assistant-mid')).toBeNull();
+    expect(rewindAtOf(sqlite, 'error-after')).toBeNull();
+  });
+
+  it('breaks created_at ties with rowid on both window edges', async () => {
+    // error 行的 createdAt 被设计成"本轮最后行 + 1",但历史数据/时钟边缘仍可能
+    // 与相邻 user 行同毫秒 —— 窗口两端都必须退回 rowid 比插入序。
+    insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100 });
+    insertRow(sqlite, { clientId: 'error-0', role: 'error', createdAt: 100 });
+    insertRow(sqlite, { clientId: 'user-1', role: 'user', createdAt: 100 });
+    insertRow(sqlite, { clientId: 'error-late', role: 'error', createdAt: 100 });
+
+    const removed = await supersedeRetriedUserTurn(SESSION, {
+      supersededUserClientId: 'user-0',
+      retryUserClientId: 'user-1',
+    });
+
+    expect(removed).toEqual(['user-0', 'error-0']);
+    expect(rewindAtOf(sqlite, 'error-late')).toBeNull();
+  });
+
+  it('is a no-op when the superseded row is missing, already hidden, or not a user row', async () => {
+    insertRow(sqlite, { clientId: 'user-1', role: 'user', createdAt: 200 });
+
+    await expect(
+      supersedeRetriedUserTurn(SESSION, {
+        supersededUserClientId: 'missing',
+        retryUserClientId: 'user-1',
+      }),
+    ).resolves.toEqual([]);
+
+    insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100, rewindAt: 90 });
+    await expect(
+      supersedeRetriedUserTurn(SESSION, {
+        supersededUserClientId: 'user-0',
+        retryUserClientId: 'user-1',
+      }),
+    ).resolves.toEqual([]);
+
+    insertRow(sqlite, { clientId: 'error-x', role: 'error', createdAt: 110 });
+    await expect(
+      supersedeRetriedUserTurn(SESSION, {
+        supersededUserClientId: 'error-x',
+        retryUserClientId: 'user-1',
+      }),
+    ).resolves.toEqual([]);
+
+    expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when the retry row has not been persisted (deferred error race guard)', async () => {
+    insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100 });
+
+    await expect(
+      supersedeRetriedUserTurn(SESSION, {
+        supersededUserClientId: 'user-0',
+        retryUserClientId: 'not-persisted-yet',
+      }),
+    ).resolves.toEqual([]);
+
+    expect(rewindAtOf(sqlite, 'user-0')).toBeNull();
+    expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('is idempotent: a second call after success is a no-op', async () => {
+    insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100 });
+    insertRow(sqlite, { clientId: 'error-0', role: 'error', createdAt: 101 });
+    insertRow(sqlite, { clientId: 'user-1', role: 'user', createdAt: 200 });
+
+    await supersedeRetriedUserTurn(SESSION, {
+      supersededUserClientId: 'user-0',
+      retryUserClientId: 'user-1',
+    });
+    h.tapWindowBroadcast.mockClear();
+
+    await expect(
+      supersedeRetriedUserTurn(SESSION, {
+        supersededUserClientId: 'user-0',
+        retryUserClientId: 'user-1',
+      }),
+    ).resolves.toEqual([]);
+    expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
+  });
+
+  it('never crosses session boundaries', async () => {
+    insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100 });
+    insertRow(sqlite, { clientId: 'error-other', role: 'error', createdAt: 150, sessionId: 'other' });
+    insertRow(sqlite, { clientId: 'user-1', role: 'user', createdAt: 200 });
+
+    const removed = await supersedeRetriedUserTurn(SESSION, {
+      supersededUserClientId: 'user-0',
+      retryUserClientId: 'user-1',
+    });
+
+    expect(removed).toEqual(['user-0']);
+    const other = sqlite
+      .prepare("SELECT rewind_at AS rewindAt FROM messages WHERE session_id = 'other'")
+      .get() as { rewindAt: number | null };
+    expect(other.rewindAt).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/localDb/ipc/__tests__/messagesSupersedeRetriedUserTurn.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/messagesSupersedeRetriedUserTurn.test.ts
@@ -3,8 +3,7 @@
  *
  * 场景背景:零产出失败 turn 被「重试」克隆重发后,历史里会留下两条一模一样的
  * user 行(旧行 + 克隆行)与夹在中间的 error 行。本函数把旧 user 行与窗口内的
- * error 行软删(置 rewind_at),经 messages:deleted 广播让各端移除,并返回软删后的
- * 会话列表投影(preview + 可见消息数)供调用方广播 sessions:patched。
+ * error 行软删(置 rewind_at),经 messages:deleted 广播让各端移除。
  */
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
@@ -55,8 +54,6 @@ const SESSION = 'session-1';
 
 function createDb(): Database.Database {
   const sqlite = new Database(':memory:');
-  // sessions 表只需 id / cleared_at:软删后的会话列表投影(preview + 可见消息数)
-  // 要读 clearedAt 才能与 sessions:list 同口径。
   sqlite.exec(`
     CREATE TABLE messages (
       id TEXT PRIMARY KEY,
@@ -71,12 +68,7 @@ function createDb(): Database.Database {
       rewind_at INTEGER
     );
     CREATE UNIQUE INDEX uniq_messages_session_client ON messages(session_id, client_id);
-    CREATE TABLE sessions (
-      id TEXT PRIMARY KEY,
-      cleared_at INTEGER
-    );
   `);
-  sqlite.prepare('INSERT INTO sessions (id, cleared_at) VALUES (?, NULL)').run(SESSION);
   h.db = drizzle(sqlite, { schema: { messages, sessions } });
   return sqlite;
 }
@@ -133,11 +125,7 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed.clientIds).toEqual(['user-0', 'error-0']);
-    // 会话列表投影必须是软删**之后**的真相(未软删时可见 user 行是 2 条):调用方
-    // 靠它广播 sessions:patched,漏刷新则侧栏/被控端的消息计数会停在软删前。
-    expect(removed.messageCount).toBe(1);
-    expect(removed.preview).toBe('user-1');
+    expect(removed).toEqual(['user-0', 'error-0']);
     expect(rewindAtOf(sqlite, 'user-0')).toEqual(expect.any(Number));
     expect(rewindAtOf(sqlite, 'error-0')).toEqual(expect.any(Number));
     expect(rewindAtOf(sqlite, 'user-1')).toBeNull();
@@ -164,7 +152,7 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed.clientIds).toEqual(['user-0', 'error-mid']);
+    expect(removed).toEqual(['user-0', 'error-mid']);
     expect(rewindAtOf(sqlite, 'error-before')).toBeNull();
     expect(rewindAtOf(sqlite, 'assistant-mid')).toBeNull();
     expect(rewindAtOf(sqlite, 'error-after')).toBeNull();
@@ -183,7 +171,7 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed.clientIds).toEqual(['user-0', 'error-0']);
+    expect(removed).toEqual(['user-0', 'error-0']);
     expect(rewindAtOf(sqlite, 'error-late')).toBeNull();
   });
 
@@ -195,7 +183,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'missing',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toMatchObject({ clientIds: [] });
+    ).resolves.toEqual([]);
 
     insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100, rewindAt: 90 });
     await expect(
@@ -203,7 +191,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'user-0',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toMatchObject({ clientIds: [] });
+    ).resolves.toEqual([]);
 
     insertRow(sqlite, { clientId: 'error-x', role: 'error', createdAt: 110 });
     await expect(
@@ -211,7 +199,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'error-x',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toMatchObject({ clientIds: [] });
+    ).resolves.toEqual([]);
 
     expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
   });
@@ -224,7 +212,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'user-0',
         retryUserClientId: 'not-persisted-yet',
       }),
-    ).resolves.toMatchObject({ clientIds: [] });
+    ).resolves.toEqual([]);
 
     expect(rewindAtOf(sqlite, 'user-0')).toBeNull();
     expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
@@ -246,7 +234,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'user-0',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toMatchObject({ clientIds: [] });
+    ).resolves.toEqual([]);
     expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
   });
 
@@ -260,7 +248,7 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed.clientIds).toEqual(['user-0']);
+    expect(removed).toEqual(['user-0']);
     const other = sqlite
       .prepare("SELECT rewind_at AS rewindAt FROM messages WHERE session_id = 'other'")
       .get() as { rewindAt: number | null };

--- a/apps/desktop/src/main/localDb/ipc/__tests__/messagesSupersedeRetriedUserTurn.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/messagesSupersedeRetriedUserTurn.test.ts
@@ -3,7 +3,8 @@
  *
  * 场景背景:零产出失败 turn 被「重试」克隆重发后,历史里会留下两条一模一样的
  * user 行(旧行 + 克隆行)与夹在中间的 error 行。本函数把旧 user 行与窗口内的
- * error 行软删(置 rewind_at),经 messages:deleted 广播让各端移除。
+ * error 行软删(置 rewind_at),经 messages:deleted 广播让各端移除,并返回软删后的
+ * 会话列表投影(preview + 可见消息数)供调用方广播 sessions:patched。
  */
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
@@ -54,6 +55,8 @@ const SESSION = 'session-1';
 
 function createDb(): Database.Database {
   const sqlite = new Database(':memory:');
+  // sessions 表只需 id / cleared_at:软删后的会话列表投影(preview + 可见消息数)
+  // 要读 clearedAt 才能与 sessions:list 同口径。
   sqlite.exec(`
     CREATE TABLE messages (
       id TEXT PRIMARY KEY,
@@ -68,7 +71,12 @@ function createDb(): Database.Database {
       rewind_at INTEGER
     );
     CREATE UNIQUE INDEX uniq_messages_session_client ON messages(session_id, client_id);
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      cleared_at INTEGER
+    );
   `);
+  sqlite.prepare('INSERT INTO sessions (id, cleared_at) VALUES (?, NULL)').run(SESSION);
   h.db = drizzle(sqlite, { schema: { messages, sessions } });
   return sqlite;
 }
@@ -125,7 +133,11 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed).toEqual(['user-0', 'error-0']);
+    expect(removed.clientIds).toEqual(['user-0', 'error-0']);
+    // 会话列表投影必须是软删**之后**的真相(未软删时可见 user 行是 2 条):调用方
+    // 靠它广播 sessions:patched,漏刷新则侧栏/被控端的消息计数会停在软删前。
+    expect(removed.messageCount).toBe(1);
+    expect(removed.preview).toBe('user-1');
     expect(rewindAtOf(sqlite, 'user-0')).toEqual(expect.any(Number));
     expect(rewindAtOf(sqlite, 'error-0')).toEqual(expect.any(Number));
     expect(rewindAtOf(sqlite, 'user-1')).toBeNull();
@@ -152,7 +164,7 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed).toEqual(['user-0', 'error-mid']);
+    expect(removed.clientIds).toEqual(['user-0', 'error-mid']);
     expect(rewindAtOf(sqlite, 'error-before')).toBeNull();
     expect(rewindAtOf(sqlite, 'assistant-mid')).toBeNull();
     expect(rewindAtOf(sqlite, 'error-after')).toBeNull();
@@ -171,7 +183,7 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed).toEqual(['user-0', 'error-0']);
+    expect(removed.clientIds).toEqual(['user-0', 'error-0']);
     expect(rewindAtOf(sqlite, 'error-late')).toBeNull();
   });
 
@@ -183,7 +195,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'missing',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject({ clientIds: [] });
 
     insertRow(sqlite, { clientId: 'user-0', role: 'user', createdAt: 100, rewindAt: 90 });
     await expect(
@@ -191,7 +203,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'user-0',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject({ clientIds: [] });
 
     insertRow(sqlite, { clientId: 'error-x', role: 'error', createdAt: 110 });
     await expect(
@@ -199,7 +211,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'error-x',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject({ clientIds: [] });
 
     expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
   });
@@ -212,7 +224,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'user-0',
         retryUserClientId: 'not-persisted-yet',
       }),
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject({ clientIds: [] });
 
     expect(rewindAtOf(sqlite, 'user-0')).toBeNull();
     expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
@@ -234,7 +246,7 @@ describe('supersedeRetriedUserTurn', () => {
         supersededUserClientId: 'user-0',
         retryUserClientId: 'user-1',
       }),
-    ).resolves.toEqual([]);
+    ).resolves.toMatchObject({ clientIds: [] });
     expect(h.tapWindowBroadcast).not.toHaveBeenCalled();
   });
 
@@ -248,7 +260,7 @@ describe('supersedeRetriedUserTurn', () => {
       retryUserClientId: 'user-1',
     });
 
-    expect(removed).toEqual(['user-0']);
+    expect(removed.clientIds).toEqual(['user-0']);
     const other = sqlite
       .prepare("SELECT rewind_at AS rewindAt FROM messages WHERE session_id = 'other'")
       .get() as { rewindAt: number | null };

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -7,7 +7,7 @@
  */
 
 import { ipcMain, BrowserWindow } from 'electron';
-import { and, asc, count, eq, lt, gt, gte, desc, isNull, or, sql, type SQL } from 'drizzle-orm';
+import { and, asc, count, eq, inArray, lt, gt, gte, desc, isNull, or, sql, type SQL } from 'drizzle-orm';
 import { createId } from '@paralleldrive/cuid2';
 
 import { getDbClient } from '../client/current';
@@ -834,6 +834,83 @@ export async function dismissErrorMessage(
   // banner 判定即时熄灭;发起端自身的乐观更新早已生效,重复广播幂等。
   if (updated) broadcastMessageRow(sessionId, updated);
   return updated;
+}
+
+/**
+ * retry-supersede:零产出失败 turn 被「重试」克隆重发后,软删被取代的旧 user 行
+ * 与其后的 role='error' 行(coordinator 在克隆行 onPersisted 边界调用,见
+ * AgentInputQueuedMessage.supersedesUserClientId)。
+ *
+ * 语义与守卫:
+ *  - 软删 = 置 rewind_at。普通历史读取、fork 复制、外部 transcript 导入、错误
+ *    尾行告警全部按 rewind_at IS NULL 过滤,行本体保留可审计——与 context_rebuild
+ *    借该列隐藏的既有先例同口径,不是 rewind-session 的回滚语义。
+ *  - error 行按 (created_at, rowid) 双键窗口定位:严格晚于旧 user 行、严格早于
+ *    克隆行。零产出失败的窗口内只可能有本次失败的 error 行;role 过滤兜底,
+ *    绝不触碰任何产出行。
+ *  - 旧行必须仍是可见的 user 行、克隆行必须已落库,任一缺失即整体 no-op(防御
+ *    误传参与 deferred error 补落竞态);UPDATE 带 rewind_at IS NULL,重复调用幂等。
+ *  - 单条 UPDATE 原子置位后经 messages:deleted 广播(本机各窗口 + device-link
+ *    转发),desktop / mobile 的移除处理复用消息删除的既有消费端。
+ *
+ * @returns 实际软删的 clientIds(空数组 = no-op),仅供调用方与测试观察。
+ */
+export async function supersedeRetriedUserTurn(
+  sessionId: string,
+  args: { supersededUserClientId: string; retryUserClientId: string },
+): Promise<string[]> {
+  const db = getDbClient().drizzle;
+  const [oldRow] = await db
+    .select({
+      clientId: messages.clientId,
+      createdAt: messages.createdAt,
+      rowid: messageRowid,
+    })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.sessionId, sessionId),
+        eq(messages.clientId, args.supersededUserClientId),
+        eq(messages.role, 'user'),
+        isNull(messages.rewindAt),
+      ),
+    )
+    .limit(1);
+  const [retryRow] = await db
+    .select({ createdAt: messages.createdAt, rowid: messageRowid })
+    .from(messages)
+    .where(
+      and(eq(messages.sessionId, sessionId), eq(messages.clientId, args.retryUserClientId)),
+    )
+    .limit(1);
+  if (!oldRow || !retryRow) return [];
+  const errorRows = await db
+    .select({ clientId: messages.clientId })
+    .from(messages)
+    .where(
+      and(
+        eq(messages.sessionId, sessionId),
+        eq(messages.role, 'error'),
+        isNull(messages.rewindAt),
+        sql`(${messages.createdAt} > ${oldRow.createdAt}
+          OR (${messages.createdAt} = ${oldRow.createdAt} AND ${sql.raw('"messages"."rowid"')} > ${oldRow.rowid}))`,
+        sql`(${messages.createdAt} < ${retryRow.createdAt}
+          OR (${messages.createdAt} = ${retryRow.createdAt} AND ${sql.raw('"messages"."rowid"')} < ${retryRow.rowid}))`,
+      ),
+    );
+  const clientIds = [oldRow.clientId, ...errorRows.map((r) => r.clientId)];
+  await db
+    .update(messages)
+    .set({ rewindAt: Date.now() })
+    .where(
+      and(
+        eq(messages.sessionId, sessionId),
+        inArray(messages.clientId, clientIds),
+        isNull(messages.rewindAt),
+      ),
+    );
+  broadcastMessageDeleted({ sessionId, clientId: oldRow.clientId, clientIds });
+  return clientIds;
 }
 
 export async function updateMessageContent(

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -747,37 +747,11 @@ export async function commitMessageDeletion(
   }
   void recomputePrRefsForSession(sessionId).catch(() => undefined);
 
-  // 删除后同步带出 canonical session-list projection，避免其它窗口 / device-link
-  // 控制端继续显示已删除的末条消息预览或旧 _count(见 computeSessionListProjection)。
-  const { preview, messageCount } = await computeSessionListProjection(sessionId, {
-    op: 'message-delete',
-    deletedClientIds: clientIds,
-  });
-  return {
-    sessionId,
-    deletedClientIds: result.messages.map((message) => message.clientId),
-    updatedAt: now,
-    preview,
-    messageCount,
-  };
-}
-
-/**
- * 会话列表投影(末条预览 + 可见消息数)的 canonical 计算。凡是「让已落库的消息行
- * 不再可见」的路径都要带上它一起广播 sessions:patched —— 那些消费者只做 shallow
- * merge、不会主动重拉,漏带就会让侧栏与 device-link 控制端一直显示旧预览和旧
- * _count。count / preview 口径与 sessions:list 的可见消息保持一致。
- *
- * 现有两个调用方:上面的 commitMessageDeletion(菜单删除)与下面的
- * supersedeRetriedUserTurn(零产出重试软删)。
- *
- * 不抛:调用方的删除或软删已经原子提交，投影查询失败不能把成功操作伪装成失败。
- * 保守返回空值，后续 sessions:list / reseed 会按 DB 真相收敛。
- */
-async function computeSessionListProjection(
-  sessionId: string,
-  logFields: Record<string, unknown>,
-): Promise<{ preview: string | null; messageCount: number }> {
+  // sessions:patched 的消费者只做 shallow merge，不会主动重拉。删除后同步带出
+  // canonical session-list projection，避免其它窗口 / device-link 控制端继续显示
+  // 已删除的末条消息预览或旧 _count。count 口径与 sessions:list / preview 的可见消息保持一致。
+  let preview: string | null = null;
+  let messageCount = 0;
   try {
     const db = getDbClient().drizzle;
     const [sessionRow] = await db
@@ -806,18 +780,24 @@ async function computeSessionListProjection(
         .orderBy(desc(messages.createdAt), desc(messageRowid))
         .limit(1),
     ]);
-    return {
-      preview: extractMessagePreview(latestRow?.content, latestRow?.role),
-      messageCount: countRow?.messageCount ?? 0,
-    };
+    preview = extractMessagePreview(latestRow?.content, latestRow?.role);
+    messageCount = countRow?.messageCount ?? 0;
   } catch (error) {
-    log.warn('session list projection refresh failed', {
+    // 删除已经原子提交；投影查询失败不能把成功操作伪装成失败。广播保守空值，
+    // 后续 sessions:list / reseed 会按 DB 真相收敛。
+    log.warn('message delete session projection refresh failed', {
       sessionId,
-      ...logFields,
+      deletedClientIds: clientIds,
       error: error instanceof Error ? error.message : String(error),
     });
-    return { preview: null, messageCount: 0 };
   }
+  return {
+    sessionId,
+    deletedClientIds: result.messages.map((message) => message.clientId),
+    updatedAt: now,
+    preview,
+    messageCount,
+  };
 }
 
 export function broadcastMessageDeleted(payload: MessageDeletedPayload): void {
@@ -872,17 +852,20 @@ export async function dismissErrorMessage(
  *    误传参与 deferred error 补落竞态);UPDATE 带 rewind_at IS NULL,重复调用幂等。
  *  - 单条 UPDATE 原子置位后经 messages:deleted 广播(本机各窗口 + device-link
  *    转发),desktop / mobile 的移除处理复用消息删除的既有消费端。
+ *  - **刻意不广播 sessions:patched**(review 追问过):会话列表 `_count.messages` 的
+ *    权威口径是「该会话全部 messages 行数,不过滤 role / rewind_at / cleared_at」
+ *    (见 sessions.ts 的 SESSION_MESSAGE_COUNT_SQL),而软删只置 rewind_at 不删行,
+ *    总行数不变;preview 口径虽过滤 rewind_at,但克隆行 created_at 更大、始终是最新
+ *    可见行,也不变。两个值都没变,广播是多余的;拿「可见 user/assistant 数」去覆盖
+ *    _count 更会把侧栏与被控端的计数打成偏小值(消费端只 shallow merge,错到下次
+ *    reseed 才收敛)。
  *
- * @returns 实际软删的 clientIds(空数组 = no-op)与软删后的会话列表投影。调用方
- *   在 clientIds 非空时必须把 preview / _count 经 sessions:patched 广播出去
- *   (见 computeSessionListProjection):软删让旧 user 行退出可见集,漏广播则侧栏与
- *   被控端的消息计数会一直停在软删前。sessions:patched 由调用方发,本模块不 import
- *   sessions ipc(避免 messages ↔ sessions 循环依赖)。
+ * @returns 实际软删的 clientIds(空数组 = no-op),仅供调用方与测试观察。
  */
 export async function supersedeRetriedUserTurn(
   sessionId: string,
   args: { supersededUserClientId: string; retryUserClientId: string },
-): Promise<{ clientIds: string[]; preview: string | null; messageCount: number }> {
+): Promise<string[]> {
   const db = getDbClient().drizzle;
   const [oldRow] = await db
     .select({
@@ -907,7 +890,7 @@ export async function supersedeRetriedUserTurn(
       and(eq(messages.sessionId, sessionId), eq(messages.clientId, args.retryUserClientId)),
     )
     .limit(1);
-  if (!oldRow || !retryRow) return { clientIds: [], preview: null, messageCount: 0 };
+  if (!oldRow || !retryRow) return [];
   // 窗口两端都用 (created_at, rowid) 双键:error 行的 createdAt 取"本轮最后行 + 1",
   // 但历史数据与时钟边缘仍可能与相邻 user 行同毫秒。口径与 rewind / fork 的边界
   // 比较一致(messageRowid + gt/lt 组合),orderBy 让返回顺序确定,不依赖执行计划。
@@ -942,11 +925,7 @@ export async function supersedeRetriedUserTurn(
       ),
     );
   broadcastMessageDeleted({ sessionId, clientId: oldRow.clientId, clientIds });
-  const { preview, messageCount } = await computeSessionListProjection(sessionId, {
-    op: 'retry-supersede',
-    supersededClientIds: clientIds,
-  });
-  return { clientIds, preview, messageCount };
+  return clientIds;
 }
 
 export async function updateMessageContent(

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -747,11 +747,37 @@ export async function commitMessageDeletion(
   }
   void recomputePrRefsForSession(sessionId).catch(() => undefined);
 
-  // sessions:patched 的消费者只做 shallow merge，不会主动重拉。删除后同步带出
-  // canonical session-list projection，避免其它窗口 / device-link 控制端继续显示
-  // 已删除的末条消息预览或旧 _count。count 口径与 sessions:list / preview 的可见消息保持一致。
-  let preview: string | null = null;
-  let messageCount = 0;
+  // 删除后同步带出 canonical session-list projection，避免其它窗口 / device-link
+  // 控制端继续显示已删除的末条消息预览或旧 _count(见 computeSessionListProjection)。
+  const { preview, messageCount } = await computeSessionListProjection(sessionId, {
+    op: 'message-delete',
+    deletedClientIds: clientIds,
+  });
+  return {
+    sessionId,
+    deletedClientIds: result.messages.map((message) => message.clientId),
+    updatedAt: now,
+    preview,
+    messageCount,
+  };
+}
+
+/**
+ * 会话列表投影(末条预览 + 可见消息数)的 canonical 计算。凡是「让已落库的消息行
+ * 不再可见」的路径都要带上它一起广播 sessions:patched —— 那些消费者只做 shallow
+ * merge、不会主动重拉,漏带就会让侧栏与 device-link 控制端一直显示旧预览和旧
+ * _count。count / preview 口径与 sessions:list 的可见消息保持一致。
+ *
+ * 现有两个调用方:上面的 commitMessageDeletion(菜单删除)与下面的
+ * supersedeRetriedUserTurn(零产出重试软删)。
+ *
+ * 不抛:调用方的删除或软删已经原子提交，投影查询失败不能把成功操作伪装成失败。
+ * 保守返回空值，后续 sessions:list / reseed 会按 DB 真相收敛。
+ */
+async function computeSessionListProjection(
+  sessionId: string,
+  logFields: Record<string, unknown>,
+): Promise<{ preview: string | null; messageCount: number }> {
   try {
     const db = getDbClient().drizzle;
     const [sessionRow] = await db
@@ -780,24 +806,18 @@ export async function commitMessageDeletion(
         .orderBy(desc(messages.createdAt), desc(messageRowid))
         .limit(1),
     ]);
-    preview = extractMessagePreview(latestRow?.content, latestRow?.role);
-    messageCount = countRow?.messageCount ?? 0;
+    return {
+      preview: extractMessagePreview(latestRow?.content, latestRow?.role),
+      messageCount: countRow?.messageCount ?? 0,
+    };
   } catch (error) {
-    // 删除已经原子提交；投影查询失败不能把成功操作伪装成失败。广播保守空值，
-    // 后续 sessions:list / reseed 会按 DB 真相收敛。
-    log.warn('message delete session projection refresh failed', {
+    log.warn('session list projection refresh failed', {
       sessionId,
-      deletedClientIds: clientIds,
+      ...logFields,
       error: error instanceof Error ? error.message : String(error),
     });
+    return { preview: null, messageCount: 0 };
   }
-  return {
-    sessionId,
-    deletedClientIds: result.messages.map((message) => message.clientId),
-    updatedAt: now,
-    preview,
-    messageCount,
-  };
 }
 
 export function broadcastMessageDeleted(payload: MessageDeletedPayload): void {
@@ -838,7 +858,7 @@ export async function dismissErrorMessage(
 
 /**
  * retry-supersede:零产出失败 turn 被「重试」克隆重发后,软删被取代的旧 user 行
- * 与其后的 role='error' 行(coordinator 在克隆行 onPersisted 边界调用,见
+ * 与其后的 role='error' 行(coordinator 在克隆行落库且 vendor 派发成功之后调用,见
  * AgentInputQueuedMessage.supersedesUserClientId)。
  *
  * 语义与守卫:
@@ -853,12 +873,16 @@ export async function dismissErrorMessage(
  *  - 单条 UPDATE 原子置位后经 messages:deleted 广播(本机各窗口 + device-link
  *    转发),desktop / mobile 的移除处理复用消息删除的既有消费端。
  *
- * @returns 实际软删的 clientIds(空数组 = no-op),仅供调用方与测试观察。
+ * @returns 实际软删的 clientIds(空数组 = no-op)与软删后的会话列表投影。调用方
+ *   在 clientIds 非空时必须把 preview / _count 经 sessions:patched 广播出去
+ *   (见 computeSessionListProjection):软删让旧 user 行退出可见集,漏广播则侧栏与
+ *   被控端的消息计数会一直停在软删前。sessions:patched 由调用方发,本模块不 import
+ *   sessions ipc(避免 messages ↔ sessions 循环依赖)。
  */
 export async function supersedeRetriedUserTurn(
   sessionId: string,
   args: { supersededUserClientId: string; retryUserClientId: string },
-): Promise<string[]> {
+): Promise<{ clientIds: string[]; preview: string | null; messageCount: number }> {
   const db = getDbClient().drizzle;
   const [oldRow] = await db
     .select({
@@ -883,7 +907,10 @@ export async function supersedeRetriedUserTurn(
       and(eq(messages.sessionId, sessionId), eq(messages.clientId, args.retryUserClientId)),
     )
     .limit(1);
-  if (!oldRow || !retryRow) return [];
+  if (!oldRow || !retryRow) return { clientIds: [], preview: null, messageCount: 0 };
+  // 窗口两端都用 (created_at, rowid) 双键:error 行的 createdAt 取"本轮最后行 + 1",
+  // 但历史数据与时钟边缘仍可能与相邻 user 行同毫秒。口径与 rewind / fork 的边界
+  // 比较一致(messageRowid + gt/lt 组合),orderBy 让返回顺序确定,不依赖执行计划。
   const errorRows = await db
     .select({ clientId: messages.clientId })
     .from(messages)
@@ -892,12 +919,17 @@ export async function supersedeRetriedUserTurn(
         eq(messages.sessionId, sessionId),
         eq(messages.role, 'error'),
         isNull(messages.rewindAt),
-        sql`(${messages.createdAt} > ${oldRow.createdAt}
-          OR (${messages.createdAt} = ${oldRow.createdAt} AND ${sql.raw('"messages"."rowid"')} > ${oldRow.rowid}))`,
-        sql`(${messages.createdAt} < ${retryRow.createdAt}
-          OR (${messages.createdAt} = ${retryRow.createdAt} AND ${sql.raw('"messages"."rowid"')} < ${retryRow.rowid}))`,
+        or(
+          gt(messages.createdAt, oldRow.createdAt),
+          and(eq(messages.createdAt, oldRow.createdAt), gt(messageRowid, oldRow.rowid)),
+        ),
+        or(
+          lt(messages.createdAt, retryRow.createdAt),
+          and(eq(messages.createdAt, retryRow.createdAt), lt(messageRowid, retryRow.rowid)),
+        ),
       ),
-    );
+    )
+    .orderBy(asc(messages.createdAt), asc(messageRowid));
   const clientIds = [oldRow.clientId, ...errorRows.map((r) => r.clientId)];
   await db
     .update(messages)
@@ -910,7 +942,11 @@ export async function supersedeRetriedUserTurn(
       ),
     );
   broadcastMessageDeleted({ sessionId, clientId: oldRow.clientId, clientIds });
-  return clientIds;
+  const { preview, messageCount } = await computeSessionListProjection(sessionId, {
+    op: 'retry-supersede',
+    supersededClientIds: clientIds,
+  });
+  return { clientIds, preview, messageCount };
 }
 
 export async function updateMessageContent(

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -215,7 +215,7 @@ function createHarness() {
   const onUserEnqueue = vi.fn<NonNullable<AgentInputCoordinatorDeps['onUserEnqueue']>>(() => {});
   const supersedeRetriedUserTurn = vi.fn<
     NonNullable<AgentInputCoordinatorDeps['supersedeRetriedUserTurn']>
-  >(async () => []);
+  >(async () => ({ clientIds: [], preview: null, messageCount: 0 }));
   const coordinator = new AgentInputCoordinator({
     sendToAgent,
     steerToAgent,
@@ -2064,9 +2064,9 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.onUiRetry).toHaveBeenCalledWith(sid, expect.any(String));
   });
 
-  it('zero-progress retry supersedes the failed user row once the clone is persisted', async () => {
+  it('zero-progress retry supersedes the failed user row once the clone is dispatched', async () => {
     // retry-supersede:零产出克隆重发会在历史里留下两条一模一样的 user 行
-    // (旧行 + 克隆行)。克隆行落库(onPersisted)后必须软删旧行,且锚定的是
+    // (旧行 + 克隆行)。克隆行落库并派发成功后必须软删旧行,且锚定的是
     // 本轮被取代的那条与新克隆行——软删本体在 host(见 supersedeRetriedUserTurn
     // dep),这里锁 coordinator 的触发时机与参数。
     const h = createHarness();
@@ -2167,6 +2167,36 @@ describe('AgentInputCoordinator send transaction', () => {
     await h.coordinator.retryLastError(sid);
     await flush();
 
+    expect(h.supersedeRetriedUserTurn).not.toHaveBeenCalled();
+  });
+
+  it('does not supersede when the clone is persisted but cancelled before vendor dispatch', async () => {
+    // review(greptile P1)回归锁:软删一度挂在 onPersisted 上,而落库到派发之间
+    // 还夹着 beforeDispatch / onAccepted 两个 hook —— 期间停止或关闭会话会走
+    // cancelled-before-dispatch,那时旧行若已被藏,历史里只剩一条从未送达模型的
+    // 克隆消息,连原失败 error 行上的「重试」入口都没了。派发确实发生前不许软删。
+    const h = createHarness();
+    const sid = 'retry-supersede-cancelled-before-dispatch';
+    h.setHasAssistantProgressAfter(async () => false);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+
+    h.sendToAgent.mockImplementationOnce(async (sessionId, _message, _createOpts, sendOpts) => {
+      // 克隆行照常落库(onPersisted 走完),但 vendor 派发被取消。
+      await persistQueuedUserMessage(sessionId, sendOpts);
+      return sessionDispatchFailure('stopped before dispatch');
+    });
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(
+      h.sendToAgent.mock.calls[1]?.[3]?.persistUserMessage?.clientId,
+    ).toEqual(expect.any(String));
     expect(h.supersedeRetriedUserTurn).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -215,7 +215,7 @@ function createHarness() {
   const onUserEnqueue = vi.fn<NonNullable<AgentInputCoordinatorDeps['onUserEnqueue']>>(() => {});
   const supersedeRetriedUserTurn = vi.fn<
     NonNullable<AgentInputCoordinatorDeps['supersedeRetriedUserTurn']>
-  >(async () => ({ clientIds: [], preview: null, messageCount: 0 }));
+  >(async () => []);
   const coordinator = new AgentInputCoordinator({
     sendToAgent,
     steerToAgent,

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -213,12 +213,16 @@ function createHarness() {
   >();
   const onUiRetry = vi.fn<NonNullable<AgentInputCoordinatorDeps['onUiRetry']>>(() => {});
   const onUserEnqueue = vi.fn<NonNullable<AgentInputCoordinatorDeps['onUserEnqueue']>>(() => {});
+  const supersedeRetriedUserTurn = vi.fn<
+    NonNullable<AgentInputCoordinatorDeps['supersedeRetriedUserTurn']>
+  >(async () => []);
   const coordinator = new AgentInputCoordinator({
     sendToAgent,
     steerToAgent,
     abortSession,
     onUiRetry,
     onUserEnqueue,
+    supersedeRetriedUserTurn,
     isTurnRunning: () => running,
     reconcileTurnIdle,
     hasPendingInteraction: () => pendingInteraction,
@@ -270,6 +274,7 @@ function createHarness() {
     projections,
     onUiRetry,
     onUserEnqueue,
+    supersedeRetriedUserTurn,
     setRunning(value: boolean) {
       running = value;
     },
@@ -2057,6 +2062,112 @@ describe('AgentInputCoordinator send transaction', () => {
     // 回调传出去。hook 侧的渠道回流(turn.reopen)依赖它: 零产出失败恰是上游过载
     // 最典型的形态, 也最需要把结果接回渠道那条消息。
     expect(h.onUiRetry).toHaveBeenCalledWith(sid, expect.any(String));
+  });
+
+  it('zero-progress retry supersedes the failed user row once the clone is persisted', async () => {
+    // retry-supersede:零产出克隆重发会在历史里留下两条一模一样的 user 行
+    // (旧行 + 克隆行)。克隆行落库(onPersisted)后必须软删旧行,且锚定的是
+    // 本轮被取代的那条与新克隆行——软删本体在 host(见 supersedeRetriedUserTurn
+    // dep),这里锁 coordinator 的触发时机与参数。
+    const h = createHarness();
+    const sid = 'retry-supersede-basic';
+    h.setHasAssistantProgressAfter(async () => false);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+    expect(h.supersedeRetriedUserTurn).not.toHaveBeenCalled();
+
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    const persist = h.sendToAgent.mock.calls[1]?.[3]?.persistUserMessage;
+    expect(persist?.clientId).toEqual(expect.any(String));
+    expect(persist?.clientId).not.toBe('q-first');
+    expect(h.supersedeRetriedUserTurn).toHaveBeenCalledTimes(1);
+    expect(h.supersedeRetriedUserTurn).toHaveBeenCalledWith(sid, {
+      supersededUserClientId: 'q-first',
+      retryUserClientId: persist?.clientId,
+    });
+  });
+
+  it('continue-prompt retry (turn made progress) never supersedes the original row', async () => {
+    // 续跑分支的原消息是真实历史,不取代。这里同时锁住展开继承陷阱:续跑 item
+    // 由 recovery.item 展开而来,若不显式清 supersedesUserClientId,上一轮克隆
+    // 消费过的旧值会跟着落库,把"有产出失败"的 error 行一并误藏。
+    const h = createHarness();
+    const sid = 'retry-supersede-continue-exempt';
+    h.setHasAssistantProgressAfter(async () => true);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.supersedeRetriedUserTurn).not.toHaveBeenCalled();
+    expect(
+      h.onDispatchedUserTurn.mock.calls[1]?.[1]?.supersedesUserClientId,
+    ).toBeUndefined();
+  });
+
+  it('chained zero-progress retries anchor each supersede on the previous clone', async () => {
+    // 连环失败回归锁:第二次重试的克隆项由 recovery.item(= 第一次的克隆项)
+    // 展开而来,取代目标必须显式覆盖为第一次克隆行,不能顺着展开继承退回最初
+    // 那条(它已被软删,窗口锚错会漏掉第二次失败的 error 行)。
+    const h = createHarness();
+    const sid = 'retry-supersede-chain';
+    h.setHasAssistantProgressAfter(async () => false);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+    await h.coordinator.retryLastError(sid);
+    await flush();
+    const firstClone =
+      h.supersedeRetriedUserTurn.mock.calls[0]?.[1]?.retryUserClientId;
+    expect(firstClone).toEqual(expect.any(String));
+
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed again');
+    await flush();
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.supersedeRetriedUserTurn).toHaveBeenCalledTimes(2);
+    const second = h.supersedeRetriedUserTurn.mock.calls[1]?.[1];
+    expect(second?.supersededUserClientId).toBe(firstClone);
+    expect(second?.retryUserClientId).not.toBe(firstClone);
+  });
+
+  it('does not supersede when the retry dispatch fails before the clone is persisted', async () => {
+    // 软删只能发生在克隆行确定落库之后:落库前派发失败时旧行是用户消息的唯一
+    // 载体,动它就是消息凭空消失。
+    const h = createHarness();
+    const sid = 'retry-supersede-persist-fail';
+    h.setHasAssistantProgressAfter(async () => false);
+
+    h.coordinator.enqueue(sid, makeItem('q-first', 'original task'));
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', 'turn failed');
+    await flush();
+
+    h.sendToAgent.mockImplementationOnce(async () => {
+      throw new Error('vendor exploded before persist');
+    });
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.supersedeRetriedUserTurn).not.toHaveBeenCalled();
   });
 
   it('signals an explicit UI retry on both retry shapes (continue prompt and original resend)', async () => {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -151,10 +151,11 @@ export interface AgentInputCoordinatorDeps {
    */
   hasAssistantProgressAfter?: (sessionId: string, userClientId: string) => Promise<boolean>;
   /**
-   * retry-supersede:零产出重试的克隆行(supersedesUserClientId 非空)落库成功后,
-   * 把被取代的旧 user 行与其后的 role='error' 行软删(置 rewind_at + 广播),让
-   * 历史里只留重发的那一条。在 onPersisted 边界 fire-and-forget 调用:软删失败
-   * 只是退回"显示两条"的旧观感,绝不阻塞 vendor dispatch。未注入 = 保持旧行为。
+   * retry-supersede:零产出重试的克隆行(supersedesUserClientId 非空)落库且 vendor
+   * 派发成功后,把被取代的旧 user 行与其后的 role='error' 行软删(置 rewind_at +
+   * 广播),让历史里只留重发的那一条。在派发已不可逆的边界 await 调用(与
+   * onDispatchedUserTurn 同侧):派发前取消时旧 error 行还是用户唯一的重试入口,
+   * 不能先藏。失败只吞错落日志,退回"显示两条"的旧观感;未注入 = 保持旧行为。
    */
   supersedeRetriedUserTurn?: (
     sessionId: string,
@@ -2401,26 +2402,6 @@ export class AgentInputCoordinator {
                 // 已送达的消息二次恢复(issue #761)。
                 this.maybePersistQueueSnapshot(sessionId);
               }
-              // retry-supersede:克隆重发行已确定落库,被取代的旧 user 行从此冗余,
-              // 软删它(连同其后的 error 行)。fire-and-forget:软删失败只是退回
-              // "显示两条"的旧观感,不拦派发;之后的取消路径也不需要回滚——文本
-              // 已经保存在本条新行里,用户的消息不会丢。
-              if (head.supersedesUserClientId) {
-                const supersededUserClientId = head.supersedesUserClientId;
-                void this.deps
-                  .supersedeRetriedUserTurn?.(sessionId, {
-                    supersededUserClientId,
-                    retryUserClientId: head.clientId,
-                  })
-                  ?.catch((err) => {
-                    log.warn('supersedeRetriedUserTurn failed', {
-                      sessionId,
-                      supersededUserClientId,
-                      retryUserClientId: head.clientId,
-                      error: err instanceof Error ? err.message : String(err),
-                    });
-                  });
-              }
               await this.deps.beforeDispatchUserTurn?.(sessionId, head);
               if (!this.isActiveTurnCurrent(sessionId, active)) {
                 throw new Error('[SEND_CANCELLED_BEFORE_DISPATCH] User turn was cancelled before vendor dispatch');
@@ -2456,6 +2437,31 @@ export class AgentInputCoordinator {
           clientId: head.clientId,
           error: err instanceof Error ? err.message : String(err),
         });
+      }
+      // retry-supersede:克隆重发行既落库又真正派发出去了,被取代的旧 user 行从此
+      // 冗余,软删它(连同其后的 error 行)。落在这里而不是 onPersisted 里:落库到
+      // 派发之间还夹着 beforeDispatch / onAccepted 两个 hook,期间停止或关闭会话会走
+      // cancelled-before-dispatch —— 那时若已软删,历史里只剩一条从未送达模型的克隆
+      // 消息,原失败的 error 行连同它上面的「重试」入口一起消失(与上面 durable-ack
+      // 同一个「派发已不可逆才动持久化状态」的边界理由)。
+      // await 而非 fire-and-forget:软删先落库再继续推进本 turn,把"克隆已落库、旧行
+      // 还在"的窗口压到最小。软删失败(或崩在这个窗口里)只退回"显示两条"的旧观感,
+      // 文本已经保存在克隆行里,用户的消息不会丢。
+      if (head.supersedesUserClientId) {
+        const supersededUserClientId = head.supersedesUserClientId;
+        try {
+          await this.deps.supersedeRetriedUserTurn?.(sessionId, {
+            supersededUserClientId,
+            retryUserClientId: head.clientId,
+          });
+        } catch (err) {
+          log.warn('supersedeRetriedUserTurn failed', {
+            sessionId,
+            supersededUserClientId,
+            retryUserClientId: head.clientId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
       }
       if (this.discardOnStaleActiveTurn(sessionId, active)) return;
       if (active.pendingTerminalEvent) {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -150,6 +150,16 @@ export interface AgentInputCoordinatorDeps {
    * 判定走 DB(代码确定性,规则 9);未注入时一律按零产出处理(向后兼容)。
    */
   hasAssistantProgressAfter?: (sessionId: string, userClientId: string) => Promise<boolean>;
+  /**
+   * retry-supersede:零产出重试的克隆行(supersedesUserClientId 非空)落库成功后,
+   * 把被取代的旧 user 行与其后的 role='error' 行软删(置 rewind_at + 广播),让
+   * 历史里只留重发的那一条。在 onPersisted 边界 fire-and-forget 调用:软删失败
+   * 只是退回"显示两条"的旧观感,绝不阻塞 vendor dispatch。未注入 = 保持旧行为。
+   */
+  supersedeRetriedUserTurn?: (
+    sessionId: string,
+    args: { supersededUserClientId: string; retryUserClientId: string },
+  ) => Promise<unknown>;
   getLastAssistantTranscriptUuid?: (sessionId: string) => string | undefined;
   /**
    * 一个**留下了 active-turn recovery 入口**的 terminal error 刚落地。host 据此决定
@@ -1587,6 +1597,10 @@ export class AgentInputCoordinator {
           // 附件 / mention 属于原始消息,已在失败 turn 里送达过模型,续跑指令不重带。
           files: undefined,
           mentions: undefined,
+          // retry-supersede 只属于零产出克隆重发。续跑分支的原消息是真实历史,
+          // 不取代;展开继承的旧值若留着,落库后会把本轮"有产出失败"的 error 行
+          // 一并误藏(窗口从更早的行一直铺到本条)。
+          supersedesUserClientId: undefined,
           // 合成续跑指令显式普通执行:原消息若带 planMode=true,原样克隆会把隐藏
           // 指令路由进计划模式而不是立刻续跑(review P2)。与 sendUiTrigger 的
           // 合成 UI 动作同语义 —— planMode 强制 false。
@@ -1619,6 +1633,11 @@ export class AgentInputCoordinator {
         item = {
           ...recovery.item,
           clientId,
+          // retry-supersede:零产出克隆重发 —— 旧 user 行已落库但模型从未收到,
+          // 本条落库成功后 host 把旧行(与其后的 error 行)软删,历史只留这一条。
+          // 显式覆盖而非依赖展开继承:recovery.item 可能带着上一轮已消费的旧值
+          // (连环失败时指向更早的行),窗口必须锚定在本轮被取代的那条上。
+          supersedesUserClientId: recovery.item.clientId,
           chatMessage: {
             ...recovery.item.chatMessage,
             clientId,
@@ -2381,6 +2400,26 @@ export class AgentInputCoordinator {
                 // 辖区,若等到下一次 emit(turn done)才写,长 turn 内崩溃会把
                 // 已送达的消息二次恢复(issue #761)。
                 this.maybePersistQueueSnapshot(sessionId);
+              }
+              // retry-supersede:克隆重发行已确定落库,被取代的旧 user 行从此冗余,
+              // 软删它(连同其后的 error 行)。fire-and-forget:软删失败只是退回
+              // "显示两条"的旧观感,不拦派发;之后的取消路径也不需要回滚——文本
+              // 已经保存在本条新行里,用户的消息不会丢。
+              if (head.supersedesUserClientId) {
+                const supersededUserClientId = head.supersedesUserClientId;
+                void this.deps
+                  .supersedeRetriedUserTurn?.(sessionId, {
+                    supersededUserClientId,
+                    retryUserClientId: head.clientId,
+                  })
+                  ?.catch((err) => {
+                    log.warn('supersedeRetriedUserTurn failed', {
+                      sessionId,
+                      supersededUserClientId,
+                      retryUserClientId: head.clientId,
+                      error: err instanceof Error ? err.message : String(err),
+                    });
+                  });
               }
               await this.deps.beforeDispatchUserTurn?.(sessionId, head);
               if (!this.isActiveTurnCurrent(sessionId, active)) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -7737,22 +7737,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     },
     // retry-supersede:零产出重试的克隆行落库并派发成功后,软删被取代的旧 user 行
     // 与其后的 error 行(实现与守卫见 localDb/ipc/messages.supersedeRetriedUserTurn)。
-    supersedeRetriedUserTurn: async (sessionId, args) => {
-      const result = await supersedeRetriedUserTurn(sessionId, args);
-      // 没软删任何行 = 无投影变化。messageCount 为 0 只能是投影查询失败被吞错
-      // (软删后至少还有克隆行可见),此时广播会把侧栏预览清空、计数打成 0 ——
-      // 宁可不广播,交给后续 sessions:list / reseed 按 DB 真相收敛。
-      if (result.clientIds.length === 0 || result.messageCount === 0) return result;
-      // 软删把旧 user 行移出可见集,会话列表投影必须跟着刷新 —— 与菜单删除同一
-      // 口径(见 messageDeleteHandler 的 onCommitted)。刻意不带 sdkSessionId: null:
-      // 被软删的旧行从未进入原生 transcript(零产出失败连模型都没到),不需要像
-      // 删消息那样重建上下文;清了反而会白白丢弃当前 session 绑定。
-      broadcastSessionPatched(sessionId, {
-        preview: result.preview,
-        _count: { messages: result.messageCount },
-      });
-      return result;
-    },
+    // 只发 messages:deleted、不额外发 sessions:patched:软删既不改变会话列表的
+    // _count(权威口径不过滤 rewind_at,行本体还在)也不改变 preview(克隆行仍是最新
+    // 可见行),理由与踩过的坑记在 helper 的注释里。
+    supersedeRetriedUserTurn,
     getLastAssistantTranscriptUuid,
     onAcceptedQueuedMessage: (sessionId, item): Promise<void> | undefined => {
       // 已派发 → 该项不会再走 discard,释放 scheduler 的 discard 监听防泄漏。

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -7735,9 +7735,24 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await drainPersistQueue();
       return hasAssistantProgressAfterMessage(sessionId, userClientId);
     },
-    // retry-supersede:零产出重试的克隆行落库后,软删被取代的旧 user 行与其后的
-    // error 行(实现与守卫见 localDb/ipc/messages.supersedeRetriedUserTurn)。
-    supersedeRetriedUserTurn,
+    // retry-supersede:零产出重试的克隆行落库并派发成功后,软删被取代的旧 user 行
+    // 与其后的 error 行(实现与守卫见 localDb/ipc/messages.supersedeRetriedUserTurn)。
+    supersedeRetriedUserTurn: async (sessionId, args) => {
+      const result = await supersedeRetriedUserTurn(sessionId, args);
+      // 没软删任何行 = 无投影变化。messageCount 为 0 只能是投影查询失败被吞错
+      // (软删后至少还有克隆行可见),此时广播会把侧栏预览清空、计数打成 0 ——
+      // 宁可不广播,交给后续 sessions:list / reseed 按 DB 真相收敛。
+      if (result.clientIds.length === 0 || result.messageCount === 0) return result;
+      // 软删把旧 user 行移出可见集,会话列表投影必须跟着刷新 —— 与菜单删除同一
+      // 口径(见 messageDeleteHandler 的 onCommitted)。刻意不带 sdkSessionId: null:
+      // 被软删的旧行从未进入原生 transcript(零产出失败连模型都没到),不需要像
+      // 删消息那样重建上下文;清了反而会白白丢弃当前 session 绑定。
+      broadcastSessionPatched(sessionId, {
+        preview: result.preview,
+        _count: { messages: result.messageCount },
+      });
+      return result;
+    },
     getLastAssistantTranscriptUuid,
     onAcceptedQueuedMessage: (sessionId, item): Promise<void> | undefined => {
       // 已派发 → 该项不会再走 discard,释放 scheduler 的 discard 监听防泄漏。

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -136,6 +136,7 @@ import {
   findParkedEngineSession,
   getMessageDeletionTarget,
   listMessagesForAgentHandoff,
+  supersedeRetriedUserTurn,
 } from '../localDb/ipc/messages.js';
 import { visibleMessageTextForConversationSearch } from '../localDb/conversationSearch.pure.js';
 import {
@@ -7734,6 +7735,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       await drainPersistQueue();
       return hasAssistantProgressAfterMessage(sessionId, userClientId);
     },
+    // retry-supersede:零产出重试的克隆行落库后,软删被取代的旧 user 行与其后的
+    // error 行(实现与守卫见 localDb/ipc/messages.supersedeRetriedUserTurn)。
+    supersedeRetriedUserTurn,
     getLastAssistantTranscriptUuid,
     onAcceptedQueuedMessage: (sessionId, item): Promise<void> | undefined => {
       // 已派发 → 该项不会再走 discard,释放 scheduler 的 discard 监听防泄漏。

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -222,6 +222,19 @@ export interface AgentInputQueuedMessage {
    * 一起透传到落库 agentMeta，供「已重新连接」活动行的展开详情用。
    */
   autoResumeInfo?: AutoResumeInfo;
+  /**
+   * 本条是零产出失败 turn 的克隆重发(错误横幅「重试」,见 performRetryLastError),
+   * 值 = 被取代的那条已落库 user 行的 clientId。本条自己落库成功后,host 据此把
+   * 旧 user 行与其后的 role='error' 行软删(置 rewind_at + messages:deleted 广播),
+   * 否则历史里会留下两条一模一样的用户消息。
+   *
+   * 只在克隆重发分支置位:续跑指令(失败 turn 已有产出)不重发原文,旧行是真实
+   * 历史,不取代。软删必须等本条**确定落库**之后才执行——之前的任何失败路径都要
+   * 保住旧行,不然用户的消息会凭空消失。
+   *
+   * 旧队列快照缺省该字段(undefined = 不软删),向后兼容。
+   */
+  supersedesUserClientId?: string;
 }
 
 export type AgentInputDelivery = 'turn' | 'steer';

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -224,13 +224,14 @@ export interface AgentInputQueuedMessage {
   autoResumeInfo?: AutoResumeInfo;
   /**
    * 本条是零产出失败 turn 的克隆重发(错误横幅「重试」,见 performRetryLastError),
-   * 值 = 被取代的那条已落库 user 行的 clientId。本条自己落库成功后,host 据此把
+   * 值 = 被取代的那条已落库 user 行的 clientId。本条落库并派发成功后,host 据此把
    * 旧 user 行与其后的 role='error' 行软删(置 rewind_at + messages:deleted 广播),
    * 否则历史里会留下两条一模一样的用户消息。
    *
    * 只在克隆重发分支置位:续跑指令(失败 turn 已有产出)不重发原文,旧行是真实
-   * 历史,不取代。软删必须等本条**确定落库**之后才执行——之前的任何失败路径都要
-   * 保住旧行,不然用户的消息会凭空消失。
+   * 历史,不取代。软删必须等本条**落库且真正派发出去**之后才执行:落库前的失败路径
+   * 里旧行是用户消息的唯一载体,动它就是消息凭空消失;落库后、派发前的取消路径里
+   * 旧 error 行还是用户唯一的重试入口,提前藏掉会让人卡在"消息发了没反应"。
    *
    * 旧队列快照缺省该字段(undefined = 不软删),向后兼容。
    */


### PR DESCRIPTION
## 这次改了什么

### 摘要

首条(或任意一条)用户消息发出后 API 直接失败(零产出:模型什么都没收到)时,错误横幅的「重试」会以新 clientId 克隆重发原文——这是既有设计(hook-control 按新 clientId 做权威归属)。但旧 user 行不删不藏,会话历史里从此留下**两条一模一样的用户消息**和夹在中间的 error 行,观感像重复发送、造成误解。

本 PR 在克隆行**落库且 vendor 派发成功后**,把被取代的旧 user 行与 `(created_at, rowid)` 窗口内的 `role='error'` 行软删(置 `rewind_at`,与 `context_rebuild` 借该列隐藏历史行的既有先例同口径),并经既有 `local-db:messages:deleted` 广播让本机各窗口 / device-link 控制端 / 手机端即时移除。行本体保留在 DB 可审计,不物理删除。

关键守卫:

- 软删只发生在 vendor 派发已不可逆之后(与 `onDispatchedUserTurn` 的 durable-ack 同侧),`await` 落库:落库前的派发失败保住旧行(消息绝不凭空消失),落库后、派发前的取消路径也保住旧 error 行(它承载着用户唯一的「重试」入口)。软删自身失败只是退回"显示两条"的旧观感,不影响本 turn。
- 续跑分支(失败 turn 已有产出,改发隐藏续跑指令)显式清空该标记:原消息是真实历史,不取代;同时防住 `...recovery.item` 展开继承上一轮旧值导致误藏"有产出失败"的 error 行。
- 连环失败时每轮克隆显式锚定"上一条被取代的行",不会顺着展开继承退回最初那条。
- helper 对旧行缺失 / 已隐藏 / 非 user 行、克隆行未落库一律整体 no-op,重复调用幂等,绝不跨会话。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无(用户实际数据核实:一次 403 认证失败 + 重试后,会话历史留下两条相同首句)
- 本 PR 包含：`AgentInputQueuedMessage.supersedesUserClientId` 可选字段;coordinator 克隆/续跑分支的标记管理与派发后触发;`localDb/ipc/messages.supersedeRetriedUserTurn`(软删 + `messages:deleted` 广播);register 接线;单测 12 例
- 明确不包含：对历史上已经产生的重复行做追溯清理;error 行呈现方式的任何改动;queue-head recovery(派发前失败,本就只有一条)路径
- 用户可见变化：零产出失败后点「重试」,历史里只留重发的那一条用户消息,不再出现重复气泡与滞留的错误行
- 是否存在 breaking change：无。dep 未注入 / 旧队列快照缺字段时行为与现状完全一致

**多端适配结论**(docs/dev-rules/remote-and-mobile-adaptation.md):

1. SSH 远程工作区:不涉及 workdir 文件 / agent 进程路径;软删发生在拥有会话 DB 的 main 进程,与本机会话同一条路径。
2. IPC / 推送:**零新增**。触发端复用 `maker:input:retry-last-error`(已在 device-link invoke 白名单),通知端复用 `local-db:messages:deleted`(桌面 `handleMessageDeletedRaw` 与手机端 `remoteSessionStore.removeMessages` 均为既有消费逻辑,payload 沿用菜单删除路径既有的 `{ clientId, clientIds }` 双写形状,未新增字段)。单值位对旧控制端的批量兼容局限见「Review 跟进」第 6 条与 #1284 —— 属通道级既有属性,非本 PR 引入。
3. 手机版:无需新入口 / UI;手机端点重试后由被控端软删并经既有广播同步。

### UI 变化

不涉及:无新 UI 元素、样式或文案,改动全部在 main 进程与 shared 类型;历史行移除复用既有 `messages:deleted` 消费端的现成行为。

- 引用的设计规范：不涉及(无视觉 / 交互 / 文案变化)

### Review 跟进(7ad00f7d)

首版 review 提了 4 条,3 条确认有效并已修,1 条按取舍说明保留(逐条回复见对应 thread):

1. **软删早于派发边界**(greptile P1):软删原本挂在 `onPersisted`,而落库到派发之间还夹着 `beforeDispatch` / `onAccepted` 两个 hook —— 期间停止/关闭会话走 `cancelled-before-dispatch` 时旧行已被藏,历史只剩一条从未送达模型的克隆消息,「重试」入口也没了。已挪到 durable-ack 之后并改 `await`,补回归用例。
2. **会话列表投影未刷新**(greptile P1):**经核实前提不成立,一度采纳后已在 003d5ff2 完整回退**。会话列表 `_count.messages` 的权威口径是「该会话全部 messages 行数,不过滤 role / `rewind_at` / `cleared_at`」(`sessions.ts:322-332`),软删只置 `rewind_at`、不删行 → 总行数不变;`preview` 虽按可见行取,但克隆行 `created_at` 更大、始终是最新可见行 → 也不变。两个值都没变,`sessions:patched` 是多余的;按"可见 user/assistant 数"广播反而会把侧栏与被控端计数打成偏小值(浅合并,错到下次 reseed)。口径结论已写进 helper 与接线注释。详见 [回退说明](https://github.com/makecindy/cindy/pull/1277#issuecomment-5149982282)。
3. **rowid 口径与排序**(copilot):窗口比较从 `sql.raw` 改回仓库既有的 `messageRowid` + `gt/lt/or` 组合(与 `rewind.ts` / `fork.ts` 一致),并补 `orderBy(createdAt, rowid)`。
4. **崩溃窗口内 supersede 意图未持久化**(codex P2):现象成立,已用 `await` 把窗口压到一次 UPDATE;不做持久化补偿的理由见下方「未执行的验证」的已知边缘。
5. **`_count` 口径不符**(codex P2,针对上面第 2 条引入的广播):正确,并由此发现整段广播本不必要 → 见第 2 条的回退。顺带发现**菜单删除路径存在同类既有缺陷**(同样用可见计数覆盖 `_count`,而删除保留 tombstone 行、总行数也不变),改它要连手机端 `messageCountLabel` 一起确认,不在本 PR 范围,已单独开 #1282。
6. **批量删除对旧控制端不兼容**(codex P2):现象在「存在只读 `clientId` 的旧控制端」这个前提下成立,但**不是本 PR 引入的面** —— `{ clientId, clientIds }` 双写形状是菜单删除路径既有的(`register.ts` 的 `onCommitted`),本 PR 逐字复用、未新增字段;而菜单删除一次会连带删掉整个 turn 的产出行,旧端漏得比本 PR(1 条 `error` 行)更多。按字面只给 supersede 逐条广播会造成路径分叉;统一到 `broadcastMessageDeleted` 则外扩出本 PR 范围,还要绕开 renderer `bumpMessagesEpoch` 被反复触发、作废 in-flight 历史分页的坑。且「哪些发布版本的控制端只读 `clientId`」在本仓已重写的历史里查不到,是动手的前置。归为通道级问题单独开 #1284。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:通过(exit 0,全仓单元测试门禁)

pnpm --filter desktop run --if-present typecheck
结果:通过(exit 0,在最终代码状态执行)

pnpm exec vitest run src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts \
  src/main/localDb/ipc/__tests__/messagesSupersedeRetriedUserTurn.test.ts
结果:2 文件 236 例全过(coordinator 229 例含新增 5 例;新增 helper 测试 7 例)

以上均为回退后(003d5ff2)的最终状态

pnpm check:dco
结果:通过(3 commits signed off)
```

新增用例覆盖:零产出重试触发时机与参数、有产出续跑不触发且标记被清、连环失败锚点回归锁、落库前失败不软删、**落库后派发前取消不软删**(review 回归锁);helper 的窗口边界(含同毫秒 rowid tie-break)、role 守卫、幂等、no-op 分支、会话隔离、广播 payload。

### 手工验证

维护者已验收 diff 与测试结果。未做实机 UI 目检(worktree 改动不热更运行中实例;无新 UI 元素,移除行为复用既有消息删除链路)。

### 未执行的验证

实机复现"首条消息 API 403 → 点重试"端到端场景(需构造上游认证失败;coordinator 触发路径与 DB 行为已分别由单测锁定)。

已知可接受边缘(均不影响数据正确性,最坏都只是退回本 PR 之前的"显示两条"观感):

- remote auth retry 放弃路径的 error 行若在用户点重试之后才补落,该行会漏藏。
- 新旧行广播之间存在毫秒级"三行并存"的一闪窗口。
- 派发成功到软删 UPDATE 提交之间若进程被杀,重启后不会重做软删(supersede 意图未持久化到消息行)。刻意不做补偿:要闭环需把意图写进克隆行 `agent_meta` 并加启动期补偿扫描(还要处理补偿时窗口锚点已被其它删除 / rewind 改变的情况),复杂度对"多显示一条重复消息"的代价不成比例。

## 风险

### 风险分类

- [x] 其他：用户会话历史行软删(非物理删除,`rewind_at` 置位,可审计可恢复)

无 SQLite migration(`rewind_at` 为既有列,无 DDL / schema 变更);无协议兼容影响(零新增 IPC / 推送 / allowlist 条目);不涉及插件、system prompt、原生层与跨平台差异。

### 影响与回滚

- 影响范围：仅错误横幅「重试」的零产出分支(active-turn recovery + 无 assistant 产出);其余发送 / 续跑 / 自愈路径行为不变。fork、历史读取、transcript 导入、错误尾行告警沿既有 `rewind_at IS NULL` 过滤自然一致。
- 回滚 / 降级方式：revert 本 commit 即可(单 commit,无数据结构变更);已被软删的行未物理删除,必要时可将对应行 `rewind_at` 置回 NULL 完整恢复。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（实现契约以代码注释形式随行,无规则文档需更新）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)



