### PR TITLE
fix(desktop): 自动续跑期间不播放任务失败音效

### DIFF
--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -2636,6 +2636,77 @@ describe('AgentIslandService native publishing', () => {
     });
   });
 
+  it('keeps an auto-resumed failure transition silent and restores it if recovery does not start', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const playSound = vi.fn<(sound: AgentIslandSoundChoice) => boolean>(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish, playSound },
+    });
+    syncEnabledForTest(service, publish);
+    service.setSoundSettings({
+      enabled: true,
+      sounds: {
+        ...DEFAULT_AGENT_ISLAND_SOUND_SETTINGS.sounds,
+        error: customSound('error.wav'),
+      },
+    });
+    const meta = { sessionId: 'auto-resume', agentKind: 'claude-code' };
+    service.handleUserPrompt(meta, 'run tests');
+    playSound.mockClear();
+
+    service.handleAgentEvent(meta, terminalErrorEvent('connection closed mid-response'), {
+      suppressErrorSound: true,
+    });
+
+    expect(playSound).not.toHaveBeenCalled();
+    expect(publish.mock.calls.at(-1)?.[0].sessions[0]).toMatchObject({
+      sessionId: 'auto-resume',
+      phase: 'error',
+      detail: 'connection closed mid-response',
+    });
+    service.restoreTaskFailureSound(meta.sessionId);
+    expect(playSound).toHaveBeenCalledTimes(1);
+    expect(playSound).toHaveBeenCalledWith(customSound('error.wav'));
+  });
+
+  it('keeps an auto-resumed failure silent through the initial enabled sync', async () => {
+    const { AgentIslandService } = await import('../service.js');
+    const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {
+      void state;
+      void frameOrFrames;
+      return true;
+    });
+    const playSound = vi.fn<(sound: AgentIslandSoundChoice) => boolean>(() => true);
+    const service = new AgentIslandService({
+      getMainWindow: () => null,
+      nativeHost: { failed: false, publish, playSound },
+    });
+    service.setSoundSettings({
+      enabled: true,
+      sounds: {
+        ...DEFAULT_AGENT_ISLAND_SOUND_SETTINGS.sounds,
+        error: customSound('error.wav'),
+      },
+    });
+    const meta = { sessionId: 'pre-sync-auto-resume', agentKind: 'claude-code' };
+    service.handleUserPrompt(meta, 'run tests');
+    service.handleAgentEvent(meta, terminalErrorEvent('connection closed before sync'), {
+      suppressErrorSound: true,
+    });
+    service.setEnabled(true);
+
+    expect(playSound).not.toHaveBeenCalled();
+    service.restoreTaskFailureSound(meta.sessionId);
+    expect(playSound).toHaveBeenCalledTimes(1);
+    expect(playSound).toHaveBeenCalledWith(customSound('error.wav'));
+  });
+
   it('allows a remote daemon close inside the upgrade window to converge to completed', async () => {
     const { AgentIslandService } = await import('../service.js');
     const publish = vi.fn((state: AgentIslandDisplayState, frameOrFrames: AgentIslandNativeFrame | AgentIslandNativeFrame[]) => {

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -150,6 +150,11 @@ interface AgentIslandUserPromptDebugMeta {
   notifiedAt?: number;
 }
 
+interface AgentIslandEventOptions {
+  /** The host is automatically recovering this failure, so this transition stays silent. */
+  suppressErrorSound?: boolean;
+}
+
 export interface AgentIslandServiceDeps {
   getMainWindow: () => BrowserWindow | null;
   nativeHost?: AgentIslandNativeRenderer;
@@ -242,6 +247,7 @@ export class AgentIslandService {
   private readonly silencedRunHadAttention = new Map<string, boolean>();
   private readonly silencedRunClearTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly mutedCompletionSoundSessionIds = new Set<string>();
+  private readonly mutedErrorSoundSessionIds = new Set<string>();
   private readonly stoppedSessionIds = new Set<string>();
   private readonly replacementTurnPendingSessionIds = new Set<string>();
   private readonly replacementTurnDispatchingSessionIds = new Set<string>();
@@ -509,6 +515,7 @@ export class AgentIslandService {
     this.hiddenPublished = false;
     if (!wasSynced && !enabled) {
       this.mutedCompletionSoundSessionIds.clear();
+      this.mutedErrorSoundSessionIds.clear();
       this.clearPublishTimer();
       this.hiddenPublished = true;
       return;
@@ -559,6 +566,7 @@ export class AgentIslandService {
     this.metadataLoading.clear();
     this.lastSoundDisplayState = null;
     this.soundCooldownUntilByEvent.clear();
+    this.mutedErrorSoundSessionIds.clear();
     this.silencedRunSessionIds.clear();
     this.silencedSessionRunIds.clear();
     this.silencedRunHadAttention.clear();
@@ -605,7 +613,11 @@ export class AgentIslandService {
     setAgentIslandAppFocused(this.state, focused, now);
   }
 
-  handleAgentEvent(meta: AgentIslandSessionMeta, event: AgentEvent): void {
+  handleAgentEvent(
+    meta: AgentIslandSessionMeta,
+    event: AgentEvent,
+    options: AgentIslandEventOptions = {},
+  ): void {
     const hydrated = this.hydrateMeta(meta);
     const providerTurnId = providerTurnIdFromAgentEvent(event);
     const replacementPending =
@@ -719,7 +731,24 @@ export class AgentIslandService {
       return;
     }
     this.clearStreamingPreviewPublishTimer();
+    if (isTerminalAgentErrorEvent(event) && options.suppressErrorSound === true) {
+      // Keep the mute through the initial enabled-state sync. A sound-capable
+      // publish consumes it immediately; no retry or delivery lifecycle is stored.
+      this.mutedErrorSoundSessionIds.add(hydrated.sessionId);
+    }
     this.publish();
+  }
+
+  /** Automatic recovery did not start; notify only while the failure still needs attention. */
+  restoreTaskFailureSound(sessionId: string): void {
+    this.mutedErrorSoundSessionIds.delete(sessionId);
+    if (!this.enabledSynced || !this.enabled) return;
+    const now = Date.now();
+    const displayState = buildAgentIslandDisplayState(this.state, now);
+    if (!displayState.visible || displayState.smartSuppressed) return;
+    const session = displayState.sessions.find((candidate) => candidate.sessionId === sessionId);
+    if (!session?.attention || session.phase !== 'error') return;
+    this.playConfiguredSound('error', now);
   }
 
   handleScheduleEvent(event: SchedulerEvent): void {
@@ -1255,6 +1284,7 @@ export class AgentIslandService {
       next,
       this.mutedCompletionSoundSessionIds,
       new Set(this.silencedSessionRunIds.keys()),
+      this.mutedErrorSoundSessionIds,
     );
     if (!event) return;
     this.playConfiguredSound(event, now);
@@ -1401,6 +1431,7 @@ export class AgentIslandService {
     }
     if (!this.enabled) {
       this.mutedCompletionSoundSessionIds.clear();
+      this.mutedErrorSoundSessionIds.clear();
       this.clearStreamingPreviewPublishTimer();
       this.lastSoundDisplayState = withAgentIslandConfig(
         buildAgentIslandDisplayState(this.state, now),
@@ -1433,6 +1464,7 @@ export class AgentIslandService {
     this.scheduleNextPublish(now);
     this.playSoundForDisplayTransition(this.lastSoundDisplayState, displayState, now);
     this.mutedCompletionSoundSessionIds.clear();
+    this.mutedErrorSoundSessionIds.clear();
     this.lastSoundDisplayState = displayState;
 
     if (this.nativeHost.failed) {
@@ -2168,6 +2200,7 @@ function getAgentIslandSoundEventForTransition(
   next: AgentIslandDisplayState,
   mutedCompletionSessionIds: ReadonlySet<string> = new Set(),
   mutedStartSessionIds: ReadonlySet<string> = new Set(),
+  mutedErrorSessionIds: ReadonlySet<string> = new Set(),
 ): AgentIslandSoundEvent | null {
   const previousById = new Map(previous?.sessions.map((session) => [session.sessionId, session]) ?? []);
   for (const session of next.sessions) {
@@ -2177,6 +2210,7 @@ function getAgentIslandSoundEventForTransition(
   }
   for (const session of next.sessions) {
     if (!session.attention || session.phase !== 'error') continue;
+    if (mutedErrorSessionIds.has(session.sessionId)) continue;
     const prev = previousById.get(session.sessionId);
     if (prev?.phase !== 'error') return 'error';
   }
@@ -2264,4 +2298,3 @@ function isPlaceholderSessionTitle(title: string | null): boolean {
   const normalized = title.trim().toLowerCase();
   return normalized === '' || normalized === 'new maker' || normalized === 'untitled';
 }
-

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -2222,7 +2222,16 @@ function handleAgentIslandEventAfterBroadcast(
       service.deferRemoteAuthRetryError(meta, event);
       return;
     }
-    service.handleAgentEvent(meta, event);
+    const terminalError = event.type === 'error' && isTerminalTurnErrorEvent(event);
+    const suppressErrorSound = terminalError && (
+      agentInputCoordinatorHolder?.isAutoResumePending(session.id) === true ||
+      agentInputCoordinatorHolder?.isAutoResumeDeferred(session.id) === true
+    );
+    service.handleAgentEvent(meta, event, {
+      // The auto-resume decision owns this one failure transition. A later
+      // retry failure is evaluated independently and sounds normally if final.
+      suppressErrorSound,
+    });
   } catch (error) {
     log.warn('Agent Island event update failed after maker event broadcast', {
       sessionId: session.id,
@@ -7745,6 +7754,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     // 被按住的 error 最终没接管 → 只补落 error 行(横幅 coordinator 自己设)。
     onResumableTurnErrorDiscarded: (sessionId: string) => {
       autoResumeBookkeeping.flushSuppressedError(sessionId);
+      getAgentIslandService()?.restoreTaskFailureSound(sessionId);
     },
     onResumableTurnError: (sessionId: string, signals: InterruptedTurnErrorSignals) => {
       if (!isInterruptedTurnError(signals)) return null;
@@ -7795,6 +7805,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
               autoResumeBookkeeping.finalizeSuppressedError(sessionId, {
                 surfaceBanner: outcome === 'no-progress',
               });
+              if (outcome === 'no-progress') {
+                getAgentIslandService()?.restoreTaskFailureSound(sessionId);
+              }
               log.debug('interrupted-turn auto-resume not dispatched', { sessionId, outcome });
               return;
             }
@@ -7805,6 +7818,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
             interruptedTurnAutoResumeGuard.noteResumeSendFailed(sessionId);
             // 补发本身失败 → 回落成常规错误呈现,让用户能手点重试。
             autoResumeBookkeeping.finalizeSuppressedError(sessionId, { surfaceBanner: true });
+            getAgentIslandService()?.restoreTaskFailureSound(sessionId);
             log.warn('interrupted-turn auto-resume failed', {
               sessionId,
               error: err instanceof Error ? err.message : String(err),


### PR DESCRIPTION
## 这次改了什么

### 摘要

自动续跑接管当前失败时，只静音这一次任务失败音效；如果接管在决策或补发阶段没有真正开始，则在该错误仍需要用户注意时恢复正常提醒。后续重试产生的新失败独立判断，不继承上一轮静音状态。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈
- 本 PR 包含：在 terminal error 进入 Agent Island 时，根据 coordinator 已有的自动续跑 pending/deferred 决策静音当前失败 transition；自动续跑没有开始时按当前错误状态补响。
- 明确不包含：自动续跑策略、重试次数、队列/派发/running/关闭生命周期、错误卡片视觉、其它通知音效。
- 用户可见变化：自动重连/续跑接管的当次失败不再播放任务失败音效；未被接管或最终重试失败仍正常提醒。
- 是否存在 breaking change：无。

### UI 变化

不涉及：未修改 UI、视觉、布局或文案，仅调整 main 侧 Agent Island 音效决策。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/agent-island/__tests__/service.test.ts src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts src/main/__tests__/makerEventHotPathOrdering.test.ts
结果：通过，3 个测试文件、352 项测试。

pnpm --filter desktop run --if-present typecheck
结果：通过。

/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-suppress-retry-failure-sound
结果：通过，完整 unit gate 全绿（GATE_EXIT=0）。

pnpm check:dco
结果：通过，1 个 commit 已签署 DCO。
```

额外定向 ESLint 未发现本 PR 新增问题；`register.ts` 仍报告 3 个 `origin/main` 已存在的未使用导入。

### 手工验证

未执行原生 Agent Island 音效实机验证。

### 未执行的验证

- 原生 Agent Island 音效实机验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：通知音效时序

### 影响与回滚

- 影响范围：仅 Agent Island 对 interrupted-turn 自动续跑错误的失败音效；错误卡片、自动续跑业务状态与其它音效不变。
- 回滚 / 降级方式：回退本 PR commit 即恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及，无需新增文档）
- [x] 已确认测试结果或说明未执行原因
