### PR TITLE
fix(desktop): 放行阿里云百炼 Qwen 3.7 Plus 图片桥接能力

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -494,6 +494,17 @@ describe('chatBridgeCapabilitiesForRoute', () => {
   });
 
   it.each([
+    ['https://coding.dashscope.aliyuncs.com/v1', 'qwen3.7-plus'],
+    ['https://dashscope.aliyuncs.com/compatible-mode/v1', 'qwen3.7-plus'],
+    ['https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1', 'qwen3.7-plus'],
+    ['https://coding.dashscope.aliyuncs.com/v1', 'qwen3.8-max-preview'],
+    ['https://coding.dashscope.aliyuncs.com/v1', 'qwen3.6-flash'],
+  ])('enables image_url for Qwen on official DashScope host: %s / %s', async (upstream, model) => {
+    const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
+    expect(chatBridgeCapabilitiesForRoute(upstream, model).imageInput).toBe('image_url');
+  });
+
+  it.each([
     ['https://api.moonshot.cn/v1', 'kimi-k2.6'],
     ['https://api.deepseek.com/v1', 'kimi-k3'],
     ['https://api.moonshot.cn.evil.example/v1', 'kimi-k3'],
@@ -509,6 +520,11 @@ describe('chatBridgeCapabilitiesForRoute', () => {
     ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-1-0'],
     ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-seed-pro'],
     ['https://ark.cn-beijing.volces.com/api/v3', 'doubao-1-5-vision-pro'],
+    // Qwen: 非官方域名、非 HTTPS、未确认 model 均不放行。
+    ['http://coding.dashscope.aliyuncs.com/v1', 'qwen3.7-plus'],
+    ['https://coding.dashscope.aliyuncs.com.evil.example/v1', 'qwen3.7-plus'],
+    ['https://example.com/v1', 'qwen3.7-plus'],
+    ['https://coding.dashscope.aliyuncs.com/v1', 'qwen3-coder-next'],
   ])('keeps image input disabled for non-matching route %s / %s', async (upstream, model) => {
     const { chatBridgeCapabilitiesForRoute } = await freshCodexProxyHost();
     expect(chatBridgeCapabilitiesForRoute(upstream, model).imageInput).toBeUndefined();

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -481,6 +481,12 @@ function isGoogleGeminiChatUpstream(upstream: string): boolean {
 const MOONSHOT_CHAT_HOSTS = new Set(['api.moonshot.cn', 'api.moonshot.ai']);
 /** 火山方舟(豆包)官方 DNS 边界:ark.<region>.volces.com(如 ark.cn-beijing.volces.com)。 */
 const VOLCENGINE_ARK_CHAT_HOST_RE = /^ark\.[a-z0-9-]+\.volces\.com$/;
+/** 阿里云百炼 Coding Plan / Token Plan / 按量付费官方 DNS 边界。 */
+const DASHSCOPE_CODING_CHAT_HOSTS = new Set([
+  'coding.dashscope.aliyuncs.com',
+  'dashscope.aliyuncs.com',
+  'token-plan.cn-beijing.maas.aliyuncs.com',
+]);
 /**
  * 豆包 Seed 系列 model id 的版本前缀:doubao-seed-<major>-<minor>-…。
  * 只放行 1.6 起的版本——Seed 品牌线从 1.6 开始原生多模态(官方 Chat Completions
@@ -496,6 +502,17 @@ function isDoubaoVisionModel(model: string): boolean {
   return major > 1 || (major === 1 && minor >= 6);
 }
 
+/** 已确认支持图片输入的 Qwen model id 白名单。 */
+const QWEN_IMAGE_CHAT_MODELS = new Set([
+  'qwen3.6-flash',
+  'qwen3.7-plus',
+  'qwen3.8-max-preview',
+]);
+
+function isQwenImageChatModel(model: string): boolean {
+  return QWEN_IMAGE_CHAT_MODELS.has(model);
+}
+
 function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined): string {
   return stripPrefix && model.startsWith(stripPrefix)
     ? model.slice(stripPrefix.length)
@@ -504,10 +521,15 @@ function rewriteChatBridgeModel(model: string, stripPrefix: string | undefined):
 
 /**
  * 在模型级多模态能力元数据接入路由前,图片桥接先按已验证的上游能力显式开启。
- * 这里认官方 DNS 边界 + 上游 model
- * (Moonshot 的 Kimi K3、火山方舟的豆包 Seed 系列),不认 provider id(预设创建后
- * 会生成用户自定义 id),也不对所有 openai-chat 供应商放开。未命中继续沿用
- * fail-closed 默认——无图片能力的上游(如 DeepSeek)保持发送前显式报错,不静默吞图。
+ *
+ * 当前覆盖:
+ * - Moonshot Kimi K3
+ * - Volcengine Doubao Seed 系列
+ * - Alibaba Cloud Bailian Coding Plan Qwen 3.7 Plus
+ *
+ * 这里认官方 DNS 边界 + 上游 model,不认 provider id(预设创建后会生成用户自定义
+ * id),也不对所有 openai-chat 供应商放开。未命中继续沿用 fail-closed 默认——
+ * 无图片能力的上游(如 DeepSeek)保持发送前显式报错,不静默吞图。
  */
 export function chatBridgeCapabilitiesForRoute(
   upstream: string,
@@ -532,6 +554,7 @@ function isVerifiedImageChatRoute(upstream: string, realModel: string): boolean 
   const host = url.hostname.toLowerCase();
   if (realModel === 'kimi-k3') return MOONSHOT_CHAT_HOSTS.has(host);
   if (isDoubaoVisionModel(realModel)) return VOLCENGINE_ARK_CHAT_HOST_RE.test(host);
+  if (isQwenImageChatModel(realModel)) return DASHSCOPE_CODING_CHAT_HOSTS.has(host);
   return false;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

阿里云百炼部分 Qwen 模型支持通过 OpenAI Chat Completions
兼容接口传入 `image_url`，但当前 Desktop 的 Responses → Chat
图片桥接采用 fail-closed 的 route-level capability gate，仅覆盖
Kimi 与豆包的已验证路由，导致符合条件的 Qwen 图片请求在到达
上游前被本地拒绝。

本 PR 延续现有 Kimi / 豆包的验证策略，按 HTTPS 官方 hostname
与模型 ID 的已验证组合，为以下 Qwen 模型启用
`input_image → image_url` 转换：

- `qwen3.7-plus`
- `qwen3.8-max-preview`
- `qwen3.6-flash`

覆盖的阿里云接入类型包括：

- Token Plan
- Coding Plan
- 百炼按量付费 OpenAI 兼容端点

各 hostname 只允许其已确认支持的模型集合，未命中的协议、域名、
模型及跨计划组合继续保持 fail-closed。本 PR 复用现有图片转换通路，
不修改 `responses-chat-bridge` 的转换实现。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：阿里云百炼 Qwen 3.7 Plus 发送图片被拦截
- 本 PR 包含：`isVerifiedImageChatRoute` 新增 Qwen 路由判断 + 正反向单元测试
- 明确不包含：`packages/model-providers` 模型能力元数据、`responses-chat-bridge` 转换代码、模型动态能力发现体系
- 用户可见变化：使用阿里云百炼 Coding Plan `qwen3.7-plus` 模型时可正常发送图片
- 是否存在 breaking change：无

### UI 变化

不涉及：本次改动仅涉及 main 进程路由判断逻辑，无 UI 代码变更。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：123 tests passed

pnpm --filter desktop run --if-present typecheck
结果：tsc --noEmit 通过

pnpm test:unit（全量单测门禁）
结果：Desktop 1563/1564 文件通过，18595/18600 测试通过
唯一失败的 makerSendToSessionOrdering.test.ts（3 条）在干净 main 上同样失败，为已有问题，与本次改动无关

git diff --check
结果：无空白问题
```

### 手工验证

不涉及：需要阿里云百炼 Coding Plan 账号实际发送图片验证，本地无该环境。

### 未执行的验证

- 实际发送图片到 `coding.dashscope.aliyuncs.com` 的端到端验证：本地无阿里云百炼 Coding Plan 测试账号

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响使用阿里云百炼 Coding Plan `qwen3.7-plus` 模型发送图片的场景；未命中的路由继续 fail-closed，行为不变
- 回滚 / 降级方式：revert 本 commit 即可，无数据变更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

### 已知边界与后续方向

本 PR 延续现有 Kimi / 豆包的 route-level verified allowlist
策略，以 HTTPS 官方 hostname 与明确模型 ID 的组合显式开启图片桥接，
未命中时继续 fail-closed。

该方式适合作为本次兼容性修复，但需要随供应商域名及模型版本变化维护。
后续可在独立重构中评估由 `(providerId, modelId)` 对应的可信
`modalities.input` 元数据驱动 bridge capability，避免继续扩展
host/model 硬编码清单；该架构调整不属于本 PR 范围。