### PR TITLE
fix(desktop): 修复模型面板配置交互与展开回弹

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -423,6 +423,81 @@ describe('ModelSelector trigger variants', () => {
     expect(requestProviderModelsAutoRefresh).not.toHaveBeenCalled();
   });
 
+  it('keeps short model discovery out of the morph opening geometry', async () => {
+    vi.useFakeTimers();
+    let resolveRefresh!: (value: { ok: true }) => void;
+    const refresh = new Promise<{ ok: true }>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    requestProviderModelsAutoRefresh.mockImplementationOnce(() => refresh);
+
+    try {
+      render(
+        React.createElement(ModelSelector, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          useMorphPopover: true,
+        }),
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /Current: Opus 4\.8/ }));
+      });
+      expect(requestProviderModelsAutoRefresh).toHaveBeenCalledOnce();
+      expect(screen.queryByText('newChat.modelSelector.discovering')).toBeNull();
+
+      await act(async () => {
+        resolveRefresh({ ok: true });
+        await refresh;
+        await vi.runAllTimersAsync();
+      });
+      expect(screen.queryByText('newChat.modelSelector.discovering')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('still explains a model discovery that remains in flight', async () => {
+    vi.useFakeTimers();
+    let resolveRefresh!: (value: { ok: true }) => void;
+    const refresh = new Promise<{ ok: true }>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    requestProviderModelsAutoRefresh.mockImplementationOnce(() => refresh);
+
+    try {
+      render(
+        React.createElement(ModelSelector, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          useMorphPopover: true,
+        }),
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /Current: Opus 4\.8/ }));
+      });
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      expect(screen.getByText('newChat.modelSelector.discovering')).toBeTruthy();
+
+      await act(async () => {
+        resolveRefresh({ ok: true });
+        await refresh;
+      });
+      expect(screen.queryByText('newChat.modelSelector.discovering')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps row-count caps finite and within the shared 300px ceiling', () => {
     expect(modelListMaxHeightForRows()).toBeUndefined();
     expect(modelListMaxHeightForRows(Number.NaN)).toBeUndefined();
@@ -1599,8 +1674,9 @@ describe('ModelSelector trigger variants', () => {
     expect(within(information).queryByRole('option')).toBeNull();
   });
 
-  it('lets inactive provider rows edit the injected preset without switching the model', () => {
+  it('selects an inactive provider row after its effort preset is clicked', () => {
     const onProviderChange = vi.fn();
+    const onDismiss = vi.fn();
     const setEffort = vi.fn();
     const modelMemory = {
       getEffort: vi.fn(),
@@ -1618,6 +1694,7 @@ describe('ModelSelector trigger variants', () => {
         vendorKey: 'cc',
         currentProviderId: 'anthropic',
         onProviderChange,
+        onDismiss,
         modelMemory,
       }),
     );
@@ -1635,7 +1712,113 @@ describe('ModelSelector trigger variants', () => {
     fireEvent.click(within(options).getByRole('option', { name: 'high' }));
 
     expect(setEffort).toHaveBeenCalledWith('claude-code', 'anthropic', 'claude-sonnet-4-6', 'high');
-    expect(onProviderChange).not.toHaveBeenCalled();
+    expect(onProviderChange).toHaveBeenCalledWith('anthropic', 'claude-sonnet-4-6');
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(setEffort.mock.invocationCallOrder[0]).toBeLessThan(
+      onProviderChange.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('selects an inactive provider row after its Fast toggle is clicked', () => {
+    const onProviderChange = vi.fn();
+    const onDismiss = vi.fn();
+    const setFast = vi.fn();
+    const modelMemory = {
+      getEffort: vi.fn(),
+      setEffort: vi.fn(),
+      getFast: vi.fn(() => false),
+      setFast,
+    };
+    agentCapabilitiesRef.capabilities = {
+      ...agentCapabilitiesRef.DEFAULT_CAPABILITIES,
+      hasFastMode: true,
+    };
+    providersRef.providers = [
+      {
+        ...(providersRef.DEFAULT_PROVIDERS[0] as Record<string, unknown>),
+        models: {
+          'claude-code': (
+            providersRef.DEFAULT_PROVIDERS[0] as { models: { 'claude-code': unknown[] } }
+          ).models['claude-code'].map((model) =>
+            (model as { id: string }).id === 'claude-sonnet-4-6'
+              ? { ...(model as Record<string, unknown>), supportsFastMode: true }
+              : model,
+          ),
+        },
+      },
+    ];
+
+    try {
+      render(
+        React.createElement(ModelSelectorContent, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          fastMode: false,
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          onFastModeChange: vi.fn(),
+          vendorKey: 'cc',
+          currentProviderId: 'anthropic',
+          onProviderChange,
+          onDismiss,
+          modelMemory,
+        }),
+      );
+
+      fireEvent.pointerEnter(screen.getByRole('option', { name: /Sonnet 4\.6/ }));
+      fireEvent.click(screen.getByRole('button', { name: 'Fast Mode' }));
+
+      expect(setFast).toHaveBeenCalledWith('claude-code', 'anthropic', 'claude-sonnet-4-6', true);
+      expect(onProviderChange).toHaveBeenCalledWith('anthropic', 'claude-sonnet-4-6');
+      expect(onDismiss).not.toHaveBeenCalled();
+      expect(setFast.mock.invocationCallOrder[0]).toBeLessThan(
+        onProviderChange.mock.invocationCallOrder[0],
+      );
+    } finally {
+      agentCapabilitiesRef.capabilities = agentCapabilitiesRef.DEFAULT_CAPABILITIES;
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
+  it('keeps the model picker open after an inactive row configuration selects that model', async () => {
+    const modelMemory = {
+      getEffort: vi.fn(),
+      setEffort: vi.fn(),
+      getFast: vi.fn(),
+      setFast: vi.fn(),
+    };
+
+    function Harness() {
+      const [selection, setSelection] = React.useState({
+        providerId: 'anthropic',
+        modelId: 'claude-opus-4-8',
+      });
+      return React.createElement(ModelSelector, {
+        modelId: selection.modelId,
+        effort: 'high',
+        onModelChange: (modelId: string) =>
+          setSelection((current) => ({ ...current, modelId })),
+        onEffortChange: vi.fn(),
+        vendorKey: 'cc',
+        currentProviderId: selection.providerId,
+        onProviderChange: (providerId: string | null, modelId?: string) => {
+          if (providerId && modelId) setSelection({ providerId, modelId });
+        },
+        modelMemory,
+      });
+    }
+
+    render(React.createElement(Harness));
+    await clickTrigger();
+
+    fireEvent.pointerEnter(screen.getByRole('option', { name: /Sonnet 4\.6/ }));
+    const options = screen.getByRole('group', { name: /Sonnet 4\.6/ });
+    fireEvent.click(within(options).getByRole('option', { name: 'high' }));
+
+    expect(screen.getByRole('option', { name: /Sonnet 4\.6/ }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+    expect(screen.getByRole('option', { name: /Opus 4\.8/ })).toBeTruthy();
   });
 
   it('keeps target-agent provider rows and effort memory configurable while browsing Codex', async () => {
@@ -1661,6 +1844,7 @@ describe('ModelSelector trigger variants', () => {
       },
     ];
     const setEffort = vi.fn();
+    const onDismiss = vi.fn();
     const confirmBrowseSwitch = vi.fn(async () => true);
     const onSwitch = vi.fn();
     const modelMemory = {
@@ -1684,6 +1868,7 @@ describe('ModelSelector trigger variants', () => {
           vendorKey: 'cc',
           currentProviderId: 'anthropic',
           onProviderChange: vi.fn(),
+          onDismiss,
           modelMemory,
           agentSwitch: { currentVendor: 'cc', confirmBrowseSwitch, onSwitch },
         }),
@@ -1706,10 +1891,9 @@ describe('ModelSelector trigger variants', () => {
       fireEvent.click(within(options).getByRole('option', { name: 'low' }));
       expect(setEffort).toHaveBeenCalledWith('codex', 'zeta-codex', 'gpt-5.5', 'low');
       expect(confirmBrowseSwitch).toHaveBeenCalledTimes(1);
-
-      fireEvent.click(row);
       expect(onSwitch).toHaveBeenCalledWith('codex', 'gpt-5.5', 'zeta-codex');
-      // 模型确认与意图期配置不再触发确认；确认门只在 Agent 分段切换。
+      expect(onDismiss).not.toHaveBeenCalled();
+      // 配置点击同时选中目标模型；确认门仍只在 Agent 分段切换。
       expect(confirmBrowseSwitch).toHaveBeenCalledTimes(1);
 
       fireEvent.click(screen.getByRole('tab', { name: /Claude/ }));

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -1913,6 +1913,18 @@ describe('ModelSelector trigger variants', () => {
     const opusRow = screen.getByRole('option', { name: /Opus 4\.8/ });
     expect(opusRow.getAttribute('aria-disabled')).toBe('true');
     expect(screen.queryByRole('group', { name: /Sonnet 4\.6/ })).toBeNull();
+    const searchInput = screen.getByRole('textbox', {
+      name: 'newChat.modelSelector.search.placeholderAll',
+    });
+    expect(searchInput.hasAttribute('disabled')).toBe(true);
+    expect(searchInput.className).toContain('cursor-not-allowed');
+    expect(searchInput.className).toContain('text-[var(--text-disabled)]');
+    expect(searchInput.className).toContain(
+      'placeholder:text-[var(--text-disabled-tertiary)]',
+    );
+    expect(searchInput.parentElement?.className).toContain(
+      'bg-[var(--surface-elevated-soft)]',
+    );
 
     fireEvent.click(opusRow);
     fireEvent.pointerEnter(opusRow);
@@ -1942,14 +1954,32 @@ describe('ModelSelector trigger variants', () => {
         },
       },
     ];
-    const setEffort = vi.fn();
+    let rememberedEffort: Effort = 'high';
+    const setEffort = vi.fn(
+      (_agent: string, _providerId: string, _modelId: string, nextEffort: Effort) => {
+        rememberedEffort = nextEffort;
+      },
+    );
     const onDismiss = vi.fn();
     const confirmBrowseSwitch = vi.fn(async () => true);
-    const onSwitch = vi.fn();
+    let releaseFirstSwitch!: () => void;
+    const firstSwitch = new Promise<void>((resolve) => {
+      releaseFirstSwitch = resolve;
+    });
+    const observedSwitchEfforts: Effort[] = [];
+    const onSwitch = vi
+      .fn()
+      .mockImplementationOnce(async () => {
+        observedSwitchEfforts.push(rememberedEffort);
+        await firstSwitch;
+      })
+      .mockImplementationOnce(() => {
+        observedSwitchEfforts.push(rememberedEffort);
+      });
     const modelMemory = {
       getEffort: vi.fn((agent: string, providerId: string, modelId: string) =>
         agent === 'codex' && providerId === 'zeta-codex' && modelId === 'gpt-5.5'
-          ? 'high'
+          ? rememberedEffort
           : undefined,
       ),
       setEffort,
@@ -1990,10 +2020,37 @@ describe('ModelSelector trigger variants', () => {
       fireEvent.click(within(options).getByRole('option', { name: 'low' }));
       expect(setEffort).toHaveBeenCalledWith('codex', 'zeta-codex', 'gpt-5.5', 'low');
       expect(confirmBrowseSwitch).toHaveBeenCalledTimes(1);
-      expect(onSwitch).toHaveBeenCalledWith('codex', 'gpt-5.5', 'zeta-codex');
+      await waitFor(() =>
+        expect(onSwitch).toHaveBeenCalledWith('codex', 'gpt-5.5', 'zeta-codex'),
+      );
       expect(onDismiss).not.toHaveBeenCalled();
       // 配置点击同时选中目标模型；确认门仍只在 Agent 分段切换。
       expect(confirmBrowseSwitch).toHaveBeenCalledTimes(1);
+
+      fireEvent.click(
+        within(screen.getByRole('group', { name: /GPT-5\.5/ })).getByRole('option', {
+          name: 'high',
+        }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      // 第一笔事务仍在途时，后一次配置只入队，不能并发覆盖。
+      expect(onSwitch).toHaveBeenCalledTimes(1);
+      expect(setEffort).toHaveBeenNthCalledWith(
+        2,
+        'codex',
+        'zeta-codex',
+        'gpt-5.5',
+        'high',
+      );
+
+      await act(async () => {
+        releaseFirstSwitch();
+        await firstSwitch;
+      });
+      await waitFor(() => expect(onSwitch).toHaveBeenCalledTimes(2));
+      expect(observedSwitchEfforts).toEqual(['low', 'high']);
 
       fireEvent.click(screen.getByRole('tab', { name: /Claude/ }));
       await waitFor(() =>

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -498,6 +498,55 @@ describe('ModelSelector trigger variants', () => {
     }
   });
 
+  it('restarts the discovery delay after a row closes and reopens the picker', async () => {
+    vi.useFakeTimers();
+    requestProviderModelsAutoRefresh
+      .mockImplementationOnce(() => new Promise(() => undefined))
+      .mockImplementationOnce(() => new Promise(() => undefined));
+
+    try {
+      render(
+        React.createElement(ModelSelector, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          useMorphPopover: true,
+        }),
+      );
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /Current: Opus 4\.8/ }));
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+      expect(screen.getByText('newChat.modelSelector.discovering')).toBeTruthy();
+
+      fireEvent.click(screen.getByRole('option', { name: /Sonnet 4\.6/ }));
+      expect(screen.queryByText('newChat.modelSelector.discovering')).toBeNull();
+
+      act(() => {
+        fireEvent.click(screen.getByRole('button', { name: /Current: Opus 4\.8/ }));
+      });
+      expect(requestProviderModelsAutoRefresh).toHaveBeenCalledTimes(2);
+      expect(screen.queryByText('newChat.modelSelector.discovering')).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(299);
+      });
+      expect(screen.queryByText('newChat.modelSelector.discovering')).toBeNull();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+      expect(screen.getByText('newChat.modelSelector.discovering')).toBeTruthy();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps row-count caps finite and within the shared 300px ceiling', () => {
     expect(modelListMaxHeightForRows()).toBeUndefined();
     expect(modelListMaxHeightForRows(Number.NaN)).toBeUndefined();
@@ -1819,6 +1868,56 @@ describe('ModelSelector trigger variants', () => {
       'true',
     );
     expect(screen.getByRole('option', { name: /Opus 4\.8/ })).toBeTruthy();
+  });
+
+  it('locks an open remote picker while its configuration selection is in flight', async () => {
+    const onProviderChange = vi.fn();
+    const modelMemory = {
+      getEffort: vi.fn(),
+      setEffort: vi.fn(),
+      getFast: vi.fn(),
+      setFast: vi.fn(),
+    };
+    function Harness() {
+      const [switching, setSwitching] = React.useState(false);
+      return React.createElement(ModelSelector, {
+        modelId: 'claude-opus-4-8',
+        effort: 'high',
+        onModelChange: vi.fn(),
+        onEffortChange: vi.fn(),
+        vendorKey: 'cc',
+        currentProviderId: 'anthropic',
+        onProviderChange: (providerId: string | null, modelId?: string) => {
+          onProviderChange(providerId, modelId);
+          setSwitching(true);
+        },
+        modelMemory,
+        switching,
+      });
+    }
+
+    render(React.createElement(Harness));
+    await clickTrigger();
+
+    fireEvent.pointerEnter(screen.getByRole('option', { name: /Sonnet 4\.6/ }));
+    fireEvent.click(
+      within(screen.getByRole('group', { name: /Sonnet 4\.6/ })).getByRole('option', {
+        name: 'high',
+      }),
+    );
+
+    expect(onProviderChange).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByRole('button', { name: /Current: Opus 4\.8/ }).hasAttribute('disabled'),
+    ).toBe(true);
+    const opusRow = screen.getByRole('option', { name: /Opus 4\.8/ });
+    expect(opusRow.getAttribute('aria-disabled')).toBe('true');
+    expect(screen.queryByRole('group', { name: /Sonnet 4\.6/ })).toBeNull();
+
+    fireEvent.click(opusRow);
+    fireEvent.pointerEnter(opusRow);
+    expect(onProviderChange).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('group', { name: /Opus 4\.8/ })).toBeNull();
   });
 
   it('keeps target-agent provider rows and effort memory configurable while browsing Codex', async () => {

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -558,6 +558,7 @@ function ModelSelectorContentView({
     agentSwitch?.currentVendor ?? vendorKey ?? 'cc',
   );
   const browseSwitchPendingRef = useRef(false);
+  const agentSwitchQueueRef = useRef<Promise<void>>(Promise.resolve());
   const handleBrowseVendorChange = async (next: 'cc' | 'codex') => {
     if (interactionDisabled || next === browseVendor || browseSwitchPendingRef.current) return;
     // 返回当前引擎（含已有意图时浏览原引擎准备撤销）不需要确认；只有从
@@ -581,6 +582,22 @@ function ModelSelectorContentView({
     ? vendorKeyToAgentKind(browseVendor)
     : vendorKeyToAgentKind(vendorKey);
   const browseTargetLabel = browseVendor === 'codex' ? 'Codex' : 'Claude Code';
+  const enqueueAgentSwitch = (
+    targetAgentKind: 'claude-code' | 'codex',
+    targetModelId: string,
+    targetProviderId: string | null,
+  ) => {
+    if (!agentSwitch) return;
+    const run = () => agentSwitch.onSwitch(targetAgentKind, targetModelId, targetProviderId);
+    // 配置面板保持可连续操作，但切换事务必须按点击顺序执行：否则较早的请求可能
+    // 较晚完成并覆盖用户最后一次选择。失败也不能阻断后续已排队的意图。
+    agentSwitchQueueRef.current = agentSwitchQueueRef.current
+      .then(run, run)
+      .then(
+        () => undefined,
+        () => undefined,
+      );
+  };
   // 同时拉两个 agent —— vendorKey 不传时把两边模型一起展示。hooks 必须按固定顺序调用。
   const cc = useAgentCapabilities('claude-code', deviceId);
   const codex = useAgentCapabilities('codex', deviceId);
@@ -1046,7 +1063,7 @@ function ModelSelectorContentView({
     // providerId 一起带上:切换后 sessions.provider_id 直接落用户选的来源,
     // trigger 来源 icon / 路由立即正确(null = flat 退化行,交给默认路由)。
     if (browsing && agentSwitch) {
-      void agentSwitch.onSwitch(browseVendor === 'codex' ? 'codex' : 'claude-code', id, providerId);
+      enqueueAgentSwitch(browseVendor === 'codex' ? 'codex' : 'claude-code', id, providerId);
       if (dismiss) onDismiss?.();
       return;
     }
@@ -1624,15 +1641,35 @@ function ModelSelectorContentView({
         </>
       )}
       {/* 搜索框 —— 药丸样式。 */}
-      <div className="flex items-center gap-2 rounded-full border border-[var(--model-dropdown-border)] bg-[var(--surface)] px-3 py-[7px]">
-        <Search size={16} className="shrink-0 text-[var(--text-tertiary)]" />
+      <div
+        className={cn(
+          'flex items-center gap-2 rounded-full border border-[var(--model-dropdown-border)] px-3 py-[7px] transition-colors',
+          interactionDisabled
+            ? 'cursor-not-allowed bg-[var(--surface-elevated-soft)]'
+            : 'bg-[var(--surface)]',
+        )}
+      >
+        <Search
+          size={16}
+          className={cn(
+            'shrink-0',
+            interactionDisabled
+              ? 'text-[var(--text-disabled-tertiary)]'
+              : 'text-[var(--text-tertiary)]',
+          )}
+        />
         <input
           type="text"
           disabled={interactionDisabled}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t('newChat.modelSelector.search.placeholderAll')}
-          className="min-w-0 flex-1 bg-transparent text-14 text-[var(--model-item-text)] outline-none placeholder:text-[var(--text-tertiary)]"
+          className={cn(
+            'min-w-0 flex-1 bg-transparent text-14 outline-none',
+            interactionDisabled
+              ? 'cursor-not-allowed text-[var(--text-disabled)] placeholder:text-[var(--text-disabled-tertiary)]'
+              : 'text-[var(--model-item-text)] placeholder:text-[var(--text-tertiary)]',
+          )}
           aria-label={t('newChat.modelSelector.search.placeholderAll')}
         />
       </div>

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -504,6 +504,8 @@ interface ModelSelectorContentProps {
    * 成功的结果),列表结构不动、不产生跳变,只是明说「还在找」。
    */
   discoveringModels?: boolean;
+  /** 外层异步切换进行中时锁住已打开面板，避免重复提交互相覆盖。 */
+  interactionDisabled?: boolean;
 }
 
 function vendorKeyToAgentKind(v?: 'cc' | 'codex'): AgentKind | null {
@@ -543,6 +545,7 @@ function ModelSelectorContentView({
   fluidWidth = false,
   agentSwitch,
   discoveringModels = false,
+  interactionDisabled = false,
   pricing,
 }: ModelSelectorContentProps & { pricing: ModelPricingCatalog | null }) {
   // 当前来源解析器:已建会话 = 实际路由口径(含停用拷贝),其余 = 准入口径。
@@ -556,7 +559,7 @@ function ModelSelectorContentView({
   );
   const browseSwitchPendingRef = useRef(false);
   const handleBrowseVendorChange = async (next: 'cc' | 'codex') => {
-    if (next === browseVendor || browseSwitchPendingRef.current) return;
+    if (interactionDisabled || next === browseVendor || browseSwitchPendingRef.current) return;
     // 返回当前引擎（含已有意图时浏览原引擎准备撤销）不需要确认；只有从
     // currentVendor 进入另一 Agent 浏览态才调用上层风险确认。确认前绝不翻分段。
     if (agentSwitch && next !== agentSwitch.currentVendor && agentSwitch.confirmBrowseSwitch) {
@@ -675,6 +678,15 @@ function ModelSelectorContentView({
     },
     [],
   );
+
+  useEffect(() => {
+    if (!interactionDisabled) return;
+    if (closeOptionsTimerRef.current !== null) {
+      clearTimeout(closeOptionsTimerRef.current);
+      closeOptionsTimerRef.current = null;
+    }
+    setEditing(null);
+  }, [interactionDisabled]);
 
   // 模型清单来源:本机会话从 live providers 派生(builtin + 自定义合集);device-link 远程会话
   // 必须列**被控端**模型(cc/codex.capabilities.availableModels,deviceId 作用域),不读控制端本地
@@ -1029,6 +1041,7 @@ function ModelSelectorContentView({
     id: string,
     dismiss = true,
   ) => {
+    if (interactionDisabled) return;
     // 浏览目标引擎态:选中模型 = 确认切换引擎(两步式的第二步),走切换事务。
     // providerId 一起带上:切换后 sessions.provider_id 直接落用户选的来源,
     // trigger 来源 icon / 路由立即正确(null = flat 退化行,交给默认路由)。
@@ -1079,6 +1092,7 @@ function ModelSelectorContentView({
   // 当前行可编辑配置的边界:选中行写实时状态;非选中供应商行写模型级全局预设。
   // flat 非选中行没有来源 capability / 写穿上下文,只展示模型信息,避免出现点击后无效果的配置项。
   const canConfigure =
+    !interactionDisabled &&
     configurationEnabled &&
     !!editingModel &&
     (editingIsActive || (!!modelMemory && !!currentAgentKind && !!editingProviderId));
@@ -1099,7 +1113,7 @@ function ModelSelectorContentView({
     : false;
 
   const handleEditEffort = (e: Effort) => {
-    if (!editing || !editingModel) return;
+    if (interactionDisabled || !editing || !editingModel) return;
     if (editingIsActive) {
       onEffortChange(e);
     } else {
@@ -1114,7 +1128,7 @@ function ModelSelectorContentView({
     }
   };
   const handleEditFast = (enabled: boolean) => {
-    if (!editing || !editingModel) return;
+    if (interactionDisabled || !editing || !editingModel) return;
     if (editingIsActive) {
       // 当前选中模型的 Fast 是会话实时状态,必须等 onFastModeChange 持久化成功后再由
       // ChatInput 同步草稿默认;这里不能预写 modelMemory,否则 device-link 远程失败会污染被控端草稿。
@@ -1324,7 +1338,7 @@ function ModelSelectorContentView({
     const isSelected = isSelectedRow(providerId, model.id);
     const isBudgetModel = model.id.startsWith('codex/');
     const isSubscriptionModel = provider?.access?.kind === 'subscription';
-    const disabled = modelDisabledOf(model.id);
+    const disabled = interactionDisabled || modelDisabledOf(model.id);
     const disabledReason = subscriptionDirectDisabledReason(model.id);
     const rowEffort = rowEffortOf(providerId, model);
     const rowFastOn = fastOnOf(providerId, model);
@@ -1531,6 +1545,7 @@ function ModelSelectorContentView({
         {onNavigateToProviders && (
           <button
             type="button"
+            disabled={interactionDisabled}
             onClick={onNavigateToProviders}
             className={cn(
               'flex h-[34px] w-full items-center justify-center rounded-[8px]',
@@ -1585,6 +1600,7 @@ function ModelSelectorContentView({
         <>
           <button
             type="button"
+            disabled={interactionDisabled}
             onClick={() => {
               followSession.onFollow();
               onDismiss?.();
@@ -1612,6 +1628,7 @@ function ModelSelectorContentView({
         <Search size={16} className="shrink-0 text-[var(--text-tertiary)]" />
         <input
           type="text"
+          disabled={interactionDisabled}
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t('newChat.modelSelector.search.placeholderAll')}
@@ -1675,6 +1692,7 @@ function ModelSelectorContentView({
           <div className="mx-1 h-px bg-[var(--model-dropdown-border)]" />
           <button
             type="button"
+            disabled={interactionDisabled}
             onClick={onNavigateToProviders}
             className={cn(
               'flex w-full items-center gap-1.5 rounded-[8px] px-3 py-2',
@@ -1737,29 +1755,43 @@ export function ModelSelector({
   const discovery = useModelDiscoveryPending();
   const [showDiscoveryPending, setShowDiscoveryPending] = useState(false);
   const showDiscoveryPendingRef = useRef(false);
-  useEffect(() => {
-    if (!discovery.pending) {
-      // 短任务从未越过门槛时不发一次无意义的 false→false 更新；除了少一次 render，
-      // 也保证打开面板只为真正可见的状态变化补量。
-      if (showDiscoveryPendingRef.current) {
-        showDiscoveryPendingRef.current = false;
-        setShowDiscoveryPending(false);
-      }
-      return;
+  const discoveryIndicatorTimerRef = useRef<number | null>(null);
+  const resetDiscoveryPresentation = useCallback((): void => {
+    if (discoveryIndicatorTimerRef.current !== null) {
+      window.clearTimeout(discoveryIndicatorTimerRef.current);
+      discoveryIndicatorTimerRef.current = null;
     }
-    const timer = window.setTimeout(
-      () => {
-        showDiscoveryPendingRef.current = true;
-        setShowDiscoveryPending(true);
-      },
-      MODEL_DISCOVERY_INDICATOR_DELAY_MS,
-    );
-    return () => window.clearTimeout(timer);
-  }, [discovery.pending]);
-  const setOpenWithoutAutoRefresh = useCallback((next: boolean): void => {
-    openRef.current = next;
-    setOpen(next);
+    if (!showDiscoveryPendingRef.current) return;
+    showDiscoveryPendingRef.current = false;
+    setShowDiscoveryPending(false);
   }, []);
+  useEffect(() => {
+    resetDiscoveryPresentation();
+    if (!discovery.pending) return;
+    const timer = window.setTimeout(() => {
+      discoveryIndicatorTimerRef.current = null;
+      showDiscoveryPendingRef.current = true;
+      setShowDiscoveryPending(true);
+    }, MODEL_DISCOVERY_INDICATOR_DELAY_MS);
+    discoveryIndicatorTimerRef.current = timer;
+    return () => {
+      window.clearTimeout(timer);
+      if (discoveryIndicatorTimerRef.current === timer) {
+        discoveryIndicatorTimerRef.current = null;
+      }
+    };
+  }, [discovery.pending, resetDiscoveryPresentation]);
+  const setOpenWithoutAutoRefresh = useCallback(
+    (next: boolean): void => {
+      openRef.current = next;
+      if (!next) {
+        discovery.reset();
+        resetDiscoveryPresentation();
+      }
+      setOpen(next);
+    },
+    [discovery, resetDiscoveryPresentation],
+  );
   const handleOpenChange = useCallback(
     (next: boolean): void => {
       const nextOpen = disabled ? false : next;
@@ -1770,10 +1802,13 @@ export function ModelSelector({
           window.electronAPI.maker.requestProviderModelsAutoRefresh('model-selector-open'),
         );
       }
-      if (!nextOpen) discovery.reset();
+      if (!nextOpen) {
+        discovery.reset();
+        resetDiscoveryPresentation();
+      }
       setOpen(nextOpen);
     },
-    [deviceId, disabled, discovery],
+    [deviceId, disabled, discovery, resetDiscoveryPresentation],
   );
 
   // AlertDialog 打开时会被 Popover 视作外部交互并请求关闭。Agent 分段确认期间
@@ -2239,7 +2274,8 @@ export function ModelSelector({
       pointerRevealRequiresIntent={morphEnabled}
       fluidWidth={isFieldTrigger}
       agentSwitch={contentAgentSwitch}
-      discoveringModels={showDiscoveryPending}
+      discoveringModels={showDiscoveryPending && discovery.pending}
+      interactionDisabled={switching || disabled}
       pricing={pricing}
       followSession={
         fallbackOption

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -67,6 +67,11 @@ import { getModelPriceQuote } from '../../../shared/modelPriceQuote';
 import type { ModelPricingCatalog } from '../../../shared/regionalMoney';
 import { buildProviderSections } from './sourceSwitch';
 
+// 短刷新（尤其 auto-refresh cooldown 命中）不应让状态行参与 MorphPopover 的首帧量高：
+// 否则它在 220ms 开场内消失后，settle 补量会把面板再缩一次，形成“先变大再变小”。
+// 300ms 门槛也与仓库其它本地/远程混合 loading 提示一致；真正的秒级发现仍会明确反馈。
+const MODEL_DISCOVERY_INDICATOR_DELAY_MS = 300;
+
 // 厂商分类 / 分组标题 key 表的纯逻辑在 ./sourceSwitch。这里 re-export 给 ChatInput
 // (它从 './ModelSelector' import categorize / CATEGORY_LABEL_KEY / ModelCategory 做跨厂商确认弹窗)。
 export { categorize, CATEGORY_LABEL_KEY, type ModelCategory } from './sourceSwitch';
@@ -488,7 +493,8 @@ interface ModelSelectorContentProps {
     ) => void | Promise<void>;
   };
   /**
-   * 打开选择器触发的那次供应商模型发现是否仍在途。
+   * 是否显示打开选择器触发的供应商模型发现提示。调用方可延迟短任务的提示，但一旦传 true，
+   * 对应的发现仍必须在途。
    *
    * 为什么需要它:发现不是本地读取 —— ChatGPT 订阅那条要起一个 codex app-server 再 RPC 列
    * 模型,秒级到十几秒。以前这个过程完全静默,列表在用户看完关掉之后才更新,于是「只能看到
@@ -1018,13 +1024,17 @@ function ModelSelectorContentView({
   }, [sections, flatModels]);
 
   // ── 行选择 ───────────────────────────────────────────────────────────────
-  const handleRowSelect = (providerId: string | null, id: string) => {
+  const handleRowSelect = (
+    providerId: string | null,
+    id: string,
+    dismiss = true,
+  ) => {
     // 浏览目标引擎态:选中模型 = 确认切换引擎(两步式的第二步),走切换事务。
     // providerId 一起带上:切换后 sessions.provider_id 直接落用户选的来源,
     // trigger 来源 icon / 路由立即正确(null = flat 退化行,交给默认路由)。
     if (browsing && agentSwitch) {
       void agentSwitch.onSwitch(browseVendor === 'codex' ? 'codex' : 'claude-code', id, providerId);
-      onDismiss?.();
+      if (dismiss) onDismiss?.();
       return;
     }
     if (isSelectedRow(providerId, id)) {
@@ -1036,7 +1046,7 @@ function ModelSelectorContentView({
         if (sections && providerId) onProviderChange?.(providerId, id);
         else onModelChange(id);
       }
-      onDismiss?.();
+      if (dismiss) onDismiss?.();
       return;
     }
     if (sections && providerId) {
@@ -1045,7 +1055,7 @@ function ModelSelectorContentView({
     } else {
       onModelChange(id);
     }
-    onDismiss?.();
+    if (dismiss) onDismiss?.();
   };
   // ── hover / focus 浮层目标 ───────────────────────────────────────────────
   const editingModel: RowModel | null = useMemo(() => {
@@ -1093,11 +1103,14 @@ function ModelSelectorContentView({
     if (editingIsActive) {
       onEffortChange(e);
     } else {
-      // 非选中行:只写该设备的全局模型预设;不传 modelMemory(flat 选择器)则纯 no-op。
+      // 非选中行:先写该设备的全局模型预设,再选中这行。选择事务会同步读取刚写入的
+      // effort,从而一次点击同时落定 model/provider/effort,不再留下「改了配置但勾还在旧模型」的状态。
       if (currentAgentKind && editing.providerId) {
         modelMemory?.setEffort(currentAgentKind, editing.providerId, editingModel.id, e);
       }
       bump();
+      // 配置点击同时选中模型，但保留模型选择窗口，方便继续比较和调整。
+      handleRowSelect(editing.providerId, editingModel.id, false);
     }
   };
   const handleEditFast = (enabled: boolean) => {
@@ -1107,10 +1120,13 @@ function ModelSelectorContentView({
       // ChatInput 同步草稿默认;这里不能预写 modelMemory,否则 device-link 远程失败会污染被控端草稿。
       void onFastModeChange?.(enabled);
     } else {
-      // 非选中行:只写该设备的模型级全局预设;来源参数用于 capability / device-link 写穿路由。
+      // 非选中行:先写模型级全局预设,再选中这行。模型切换恢复 Fast 时会读到本次点击值。
+      // 来源参数用于 capability / device-link 写穿路由。
       if (currentAgentKind && editing.providerId) {
         modelMemory?.setFast(currentAgentKind, editing.providerId, editingModel.id, enabled);
       }
+      // 配置点击同时选中模型，但保留模型选择窗口，方便继续比较和调整。
+      handleRowSelect(editing.providerId, editingModel.id, false);
     }
     bump();
   };
@@ -1719,6 +1735,27 @@ export function ModelSelector({
   const [keepOpenForAgentConfirmation, setKeepOpenForAgentConfirmation] = useState(false);
   // 打开触发的那次模型发现是否仍在途(并发语义与理由见 useModelDiscoveryPending)。
   const discovery = useModelDiscoveryPending();
+  const [showDiscoveryPending, setShowDiscoveryPending] = useState(false);
+  const showDiscoveryPendingRef = useRef(false);
+  useEffect(() => {
+    if (!discovery.pending) {
+      // 短任务从未越过门槛时不发一次无意义的 false→false 更新；除了少一次 render，
+      // 也保证打开面板只为真正可见的状态变化补量。
+      if (showDiscoveryPendingRef.current) {
+        showDiscoveryPendingRef.current = false;
+        setShowDiscoveryPending(false);
+      }
+      return;
+    }
+    const timer = window.setTimeout(
+      () => {
+        showDiscoveryPendingRef.current = true;
+        setShowDiscoveryPending(true);
+      },
+      MODEL_DISCOVERY_INDICATOR_DELAY_MS,
+    );
+    return () => window.clearTimeout(timer);
+  }, [discovery.pending]);
   const setOpenWithoutAutoRefresh = useCallback((next: boolean): void => {
     openRef.current = next;
     setOpen(next);
@@ -2202,7 +2239,7 @@ export function ModelSelector({
       pointerRevealRequiresIntent={morphEnabled}
       fluidWidth={isFieldTrigger}
       agentSwitch={contentAgentSwitch}
-      discoveringModels={discovery.pending}
+      discoveringModels={showDiscoveryPending}
       pricing={pricing}
       followSession={
         fallbackOption


### PR DESCRIPTION
## 这次改了什么

### 摘要

- 点击非当前模型的推理强度或 Fast 配置时，先保存该模型预设，再同步选中对应来源与模型。
- 配置点击不会收起模型选择窗口，用户可以继续比较和调整；直接点击模型行仍按原行为收起。
- 跨 Agent 浏览时的连续配置操作按点击顺序串行提交，避免较早请求迟到后覆盖用户最后一次选择。
- 远程模型切换期间锁定面板交互，并为搜索框补齐 Light / Dark 共用的语义化禁用视觉态。
- 将模型发现提示延迟 300ms 显示，避免短刷新状态行参与 Morph 首帧测量而产生“先变大再变小”的回弹；真正的慢发现仍会显示进度。
- 补充 effort、Fast、跨 Agent 浏览、窗口保持打开、远程锁定及短／慢模型发现的回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：模型选择面板交互反馈
- 本 PR 包含：Desktop 模型选择器的配置点击语义、跨 Agent 配置串行化、远程切换锁定视觉、Morph 开场稳定性及对应测试
- 明确不包含：服务端、Mobile、供应商路由协议及持久化格式变更
- 用户可见变化：调整非当前模型的推理强度或 Fast 后，该模型立即选中且窗口保持打开；模型面板不再因短刷新在开场后回缩；远程切换锁定期间搜索框呈现明确禁用态
- 是否存在 breaking change：无

### UI 变化

- 改动后界面效果（文字证据，macOS Desktop）：
  - 调整非当前模型的推理强度或 Fast 后，目标模型行立即成为选中态，模型选择窗口保持打开，可继续比较和调整。
  - 打开模型选择器时保留既有 Morph 展开动效，不再出现面板先变大再回缩。
  - 远程模型切换锁定期间，搜索框使用 dimmed 背景、禁用文字与禁用光标，Light / Dark 均由现有语义 token 提供颜色。
- 未附截图／录屏；前两项已在命名隔离开发实例中完成手工验证，远程锁定搜索框的禁用视觉由样式与回归断言覆盖，未单独实机目检。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4 Select & Dropdown：选中态继续由模型行本身表达，配置浮层不改变既有菜单视觉层级。
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：禁用背景、图标、文字与 placeholder 均使用现有语义 token，无单主题硬编码。
  - `docs/design-rules/DESIGN.md` §14.4 Container transform：保留 220ms chip-to-panel Morph，仅阻止短暂发现状态参与首帧几何，消除非设计的二次回缩；慢发现提示仍响应 reduced-motion 约束。

## 怎么验证的

### 自动验证

```text
/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-select-model-after-tuning
结果：通过（全仓 unit 门禁）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts src/renderer/__tests__/morphPopover.test.tsx src/renderer/__tests__/useModelDiscoveryPending.test.tsx src/renderer/__tests__/composerMorphScope.test.ts
结果：通过，4 个测试文件、57 项测试

pnpm --filter desktop exec eslint src/renderer/components/new-chat/ModelSelector.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过

git diff --check
结果：通过
```

### 手工验证

- macOS，隔离实例 `Cindy-dev-select-model-tuning`。
- 打开模型选择器，调整非当前模型的推理强度和 Fast：目标模型被选中，选择窗口保持打开。
- 重复打开模型选择器：保留既有 Morph 动效，不再出现展开后立即回缩。

### 未执行的验证

- 未在 Windows 实机目检；本次改动为 Desktop Renderer 通用 React 状态与定时逻辑，无平台分支。
- 未单独目检远程切换时搜索框禁用态的 Light / Dark 实机效果；实现复用现有主题语义 token，并已验证对应禁用 class，不把它表述为双模式实机验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 模型选择器。
- 回滚 / 降级方式：回退本 PR commit 即恢复旧交互；不涉及数据迁移或持久化兼容。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
