### PR TITLE
fix(im): 飞书长连接静默失活后自动重连

### DIFF
--- a/packages/lizi-im/src/feishu/__tests__/wsClientConflict.test.ts
+++ b/packages/lizi-im/src/feishu/__tests__/wsClientConflict.test.ts
@@ -11,6 +11,9 @@ interface CapturingLogger {
 interface MockSdkOptions {
   logger: CapturingLogger;
   domain?: string;
+  wsConfig?: {
+    pingTimeout?: number;
+  };
   onReady?: () => void;
   onError?: (error: Error) => void;
 }
@@ -339,6 +342,17 @@ describe('Feishu owner binding updates', () => {
 });
 
 describe('IM service routing', () => {
+  it('enables the SDK ping watchdog for Feishu connections', async () => {
+    const connecting = wsClient.start(credentials, {
+      announceLifecycle: false,
+    });
+    const sdkClient = latestClient();
+
+    expect(sdkClient.options.wsConfig).toEqual({ pingTimeout: 30 });
+    sdkClient.options.onReady?.();
+    await expect(connecting).resolves.toBe('connected');
+  });
+
   it('selects the Lark SDK domain for Lark credentials', async () => {
     const connecting = wsClient.start(
       { ...credentials, service: 'lark' },
@@ -347,6 +361,7 @@ describe('IM service routing', () => {
     const sdkClient = latestClient();
 
     expect(sdkClient.options.domain).toBe('lark-domain');
+    expect(sdkClient.options.wsConfig).toEqual({ pingTimeout: 30 });
     sdkClient.options.onReady?.();
     await expect(connecting).resolves.toBe('connected');
   });

--- a/packages/lizi-im/src/feishu/wsClient.ts
+++ b/packages/lizi-im/src/feishu/wsClient.ts
@@ -58,6 +58,11 @@ let pendingOfflineNotice = false;
 const DEFAULT_OFFLINE_ANNOUNCE_TIMEOUT_MS = 1500;
 export const QUIT_OFFLINE_ANNOUNCE_TIMEOUT_MS = 4500;
 
+// The SDK disables its ping watchdog when this value is omitted. Keep the
+// timeout finite so a locally OPEN but silent connection is forced through the
+// existing reconnect flow instead of dropping inbound messages indefinitely.
+const FEISHU_WS_PING_TIMEOUT_SECONDS = 30;
+
 function emitRendererStatus(error?: string): void {
   feishuEvents.emit('status', {
     status: currentStatus,
@@ -261,6 +266,9 @@ export async function start(
     domain: creds.service === 'lark' ? Lark.Domain.Lark : Lark.Domain.Feishu,
     loggerLevel: Lark.LoggerLevel.info,
     autoReconnect: true,
+    wsConfig: {
+      pingTimeout: FEISHU_WS_PING_TIMEOUT_SECONDS,
+    },
     logger: makeCapturingLogger(startDetector, startedGeneration, creds.appId),
     onReady: () => {
       handleReadySignal(startDetector, startedGeneration, creds.appId);


### PR DESCRIPTION
## 这次改了什么

### 摘要

为飞书 / Lark 机器人 WebSocket 启用 SDK 自带的 30 秒 ping watchdog。当前 SDK 在未传 `wsConfig.pingTimeout` 时默认使用 `0`，此时本地仍为 OPEN、但已经收不到服务端事件的半开连接不会触发 `autoReconnect`，用户消息会静默漏收，直到手动重启 Cindy。

本 PR 让 SDK 在一次 ping 后连续 30 秒未收到 pong 或任何入站数据时主动 terminate 当前 socket，并复用现有自动重连流程恢复收件。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：与 #51 中“长时间未使用后连接异常”的现象相关；该 Issue 原结论主要覆盖 UI 状态，本 PR 补齐底层长连接存活检测
- 本 PR 包含：为 Feishu 与 Lark 的 `WSClient` 设置 `wsConfig.pingTimeout = 30`，以及两条构造参数回归断言
- 明确不包含：连接状态 UI、重连退避策略、服务端租约、Webhook 模式或本地安装包发布
- 用户可见变化：静默失活的飞书 / Lark 长连接会在 watchdog 超时后自动进入现有重连流程，不再无限期漏收消息
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit（清除本机 http_proxy / https_proxy 后，以 CI 等价网络环境运行）
结果：全部要求执行的 workspace 均 PASS；Desktop、Mobile、@cindy/im 等全部通过

pnpm --filter @cindy/im test
结果：31 个测试文件、333 项测试通过

pnpm --filter @cindy/im build
结果：通过

pnpm --filter @cindy/im lint
结果：通过

pnpm --filter @cindy/im run --if-present typecheck
结果：通过（该 package 当前无 typecheck script，自动跳过）

pnpm check:dco
结果：1 个 PR commit 已签名，通过

git diff --check origin/main..HEAD
结果：通过
```

### 手工验证

诊断现网安装版时确认：连接本地保持 ESTABLISHED 后不再产生飞书入站事件，重启建立新 WebSocket 后消息立即恢复。未把真实凭证写入仓库或测试夹具。

### 未执行的验证

未对本分支构建产物执行真实飞书 / Lark 企业凭证的长时间空闲 E2E；本地安装版未被替换。回归验证覆盖 SDK 构造参数，SDK 1.71.1 的实现会在该超时触发时 terminate socket 并进入既有 `autoReconnect`。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：飞书 / Lark WebSocket 在连续 30 秒无 pong / 入站数据时会主动重连

### 影响与回滚

- 影响范围：仅 `@cindy/im` 的飞书 / Lark 长连接客户端；不影响其他 IM 渠道、凭证、存储或 UI
- 回滚 / 降级方式：回滚本提交即可恢复 SDK 默认行为；无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码注释与回归测试；无新增用户配置）
- [x] 已确认测试结果或说明未执行原因
