### PR TITLE
fix(desktop): 会话拆线时给插件补 did-turn-end

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -31,6 +31,11 @@ describe('maker:event hot path ordering', () => {
     expect(wireSessionSource).toContain(
       'registration.disposers.push(session.onStatusChange((status) => {',
     );
+    // #1286:拆线(实例替换 / 会话关闭)必须给插件补 did-turn-end,否则订阅方的
+    // 「AI 在忙」外层状态永久卡在 working,除重启没有自愈手段。
+    expect(wireSessionSource).toContain(
+      'registration.disposers.push(() => ghostSessionTap.dispose());',
+    );
   });
 
   it('broadcasts EVENT before usage/context/island/idle side effects', () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
@@ -626,6 +626,29 @@ describe('GhostTurnTranslator(status/done/error → did-turn-*)', () => {
     expect(starts).toHaveLength(1);
   });
 
+  it('拆线:补发的 end 与 start 报同一个 agent(不退回 DB 的 agent_kind)', () => {
+    const nowRef = { t: 0 };
+    const starts: unknown[] = [];
+    const ends: unknown[] = [];
+    // opts.agent 取 sessions.agent_kind 的真实取值('cc',见 localDb/schema.ts),
+    // 事件 source 则是 'claude-code'——两者取值域不同,补发退回 opts.agent 会让
+    // 同一对 start/end 报不同 agent,按 agent 分组的插件照样配不上。
+    const tr = new GhostTurnTranslator({
+      sessionId: 's1',
+      agent: 'cc',
+      now: () => nowRef.t,
+      graceMs: 500,
+      sink: { turnStart: (d) => starts.push(d), turnEnd: (d) => ends.push(d) },
+    });
+    tr.handleEvent({ type: 'status', data: { isRunning: true }, source: 'claude-code' });
+    expect(starts).toMatchObject([{ agent: 'claude-code' }]);
+    nowRef.t = 1_200;
+    tr.dispose();
+    expect(ends).toMatchObject([
+      { agent: 'claude-code', endReason: 'interrupted', durationMs: 1_200 },
+    ]);
+  });
+
   it('normalizeTurnUsage:cc snake_case / codex(promptTokens 系)/ 通用 camelCase 都认', () => {
     expect(normalizeTurnUsage({ inputTokens: 1, cachedInputTokens: 2 })).toEqual({
       inputTokens: 1,

--- a/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
@@ -579,6 +579,53 @@ describe('GhostTurnTranslator(status/done/error → did-turn-*)', () => {
     expect(ends).toHaveLength(1);
   });
 
+  // 拆线补发(#1286):会话关闭与 Session 实例替换都会跑 register.ts 的 disposer,
+  // turn 在场时不补 end,插件的「AI 在忙」外层状态就永久卡在 working。
+  it('拆线:running 态 dispose 补一条 interrupted,配对闭合', () => {
+    const nowRef = { t: 1_000 };
+    const { tr, starts, ends } = makeTranslator(nowRef);
+    tr.handleEvent({ type: 'status', data: { isRunning: true } });
+    expect(starts).toHaveLength(1);
+    nowRef.t = 3_400;
+    tr.dispose();
+    expect(ends).toEqual([
+      {
+        sessionId: 's1',
+        agent: 'claude-code',
+        model: 'opus',
+        durationMs: 2_400,
+        endReason: 'interrupted',
+      },
+    ]);
+  });
+
+  it('拆线:closing 态 dispose 只补一条,时长按 status(false) 时刻算,宽限定时器一并清掉', () => {
+    const nowRef = { t: 0 };
+    const { tr, ends } = makeTranslator(nowRef);
+    tr.handleEvent({ type: 'status', data: { isRunning: true } });
+    nowRef.t = 700;
+    tr.handleEvent({ type: 'status', data: { isRunning: false } });
+    nowRef.t = 900; // 宽限窗内就被拆线
+    tr.dispose();
+    expect(ends).toMatchObject([{ endReason: 'interrupted', durationMs: 700 }]);
+    vi.advanceTimersByTime(1_000);
+    expect(ends).toHaveLength(1); // 定时器已清,不会补出第二条 end
+  });
+
+  it('拆线:idle 态 dispose 不发事件(实例替换只在会话空闲时落实,这是常态路径)', () => {
+    const nowRef = { t: 0 };
+    const { tr, starts, ends } = makeTranslator(nowRef);
+    tr.dispose(); // 一个 turn 都没跑过
+    expect(starts).toHaveLength(0);
+    expect(ends).toHaveLength(0);
+    tr.handleEvent({ type: 'status', data: { isRunning: true } });
+    tr.handleEvent({ type: 'done', data: {} });
+    expect(ends).toHaveLength(1);
+    tr.dispose(); // 正常收口后再拆线,不重复补发
+    expect(ends).toHaveLength(1);
+    expect(starts).toHaveLength(1);
+  });
+
   it('normalizeTurnUsage:cc snake_case / codex(promptTokens 系)/ 通用 camelCase 都认', () => {
     expect(normalizeTurnUsage({ inputTokens: 1, cachedInputTokens: 2 })).toEqual({
       inputTokens: 1,

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1566,6 +1566,8 @@ cindy.onHostMessage(function (msg) {
     // msg.data = { sessionId, agent, model?, durationMs, endReason, usage? }
     // usage 各字段可选(cc/codex 上报详尽度不同,别假设字段必在):
     //   { inputTokens?, outputTokens?, cacheReadTokens?, cacheCreationTokens? }
+    // 配对保证:每条 did-turn-start 都会等到一条 did-turn-end——会话被关掉或
+    // 引擎被替换时主机补发 endReason: 'interrupted',你不必自己写超时兜底。
     // msg.seq 每意识单调递增;msg.dropped(可选)= 你熄灯期溢出丢弃的事件数。
     return;
   }

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1566,9 +1566,10 @@ cindy.onHostMessage(function (msg) {
     // msg.data = { sessionId, agent, model?, durationMs, endReason, usage? }
     // usage 各字段可选(cc/codex 上报详尽度不同,别假设字段必在):
     //   { inputTokens?, outputTokens?, cacheReadTokens?, cacheCreationTokens? }
-    // 配对保证:每条 did-turn-start 都会等到一条 did-turn-end——会话被关掉或
-    // 引擎被替换时主机补发 endReason: 'interrupted',你不必自己写超时兜底。
     // msg.seq 每意识单调递增;msg.dropped(可选)= 你熄灯期溢出丢弃的事件数。
+    // 生命周期:会话被关掉或引擎被替换时,主机会给还在场的那一轮补发
+    // endReason: 'interrupted',让 start/end 成对。但这不是投递保证——熄灯期
+    // 缓冲溢出照样会丢(见 msg.dropped),状态机别只靠 end 归位。
     return;
   }
   // did-turn-start / did-session-created / did-session-archived 同理(见 topics)。

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -1191,11 +1191,17 @@ async function isGhostEligibleSession(
  * onEvent 监听):把 AgentEvent 折叠成 did-turn-* 发进网关。
  * - 只投用户主会话(desktop、非 orca;资格 DB 现查,判定期事件小缓冲回放);
  * - 自动化轮次(turnOrigin 非 user)不投——hook-control 后台会话由此天然滤除。
+ *
+ * 拆线必须调 `dispose()`:register.ts 的 disposer 一跑,事件源就没了,turn 在场时
+ * 只有这里能给插件补上缺失的 did-turn-end(见 GhostTurnTranslator.dispose)。
  */
 export function createGhostSessionTap(sessionId: string): {
   handleEvent(ev: MinimalAgentEvent & { turnOrigin?: { kind?: string } }): void;
+  dispose(): void;
 } {
   let translator: GhostTurnTranslator | null = null;
+  /** 拆线不可逆:资格判定是异步的,回调必须知道自己已经没有归属会话了。 */
+  let disposed = false;
   // 资格判定**惰性化 + 可重试**:接线发生在启动重连期,DbClient 可能还没
   // 就绪——判定挪到第一个事件到达时(用户已在交互,DB 必然可用);暂时性
   // 失败(retry)不定性,下个事件再试,封顶后放弃(防怪会话反复打 DB)。
@@ -1214,6 +1220,9 @@ export function createGhostSessionTap(sessionId: string): {
     state = 'resolving';
     attempts += 1;
     void isGhostEligibleSession(sessionId).then((info) => {
+      // 判定期间会话已拆线:不建 translator、不回放,否则会向已经没人配对的
+      // topic 发出一条永远等不到 end 的 did-turn-start。
+      if (disposed) return;
       if (info.outcome === 'retry') {
         state = 'unknown'; // 暂时态:留着 pending,下个事件再试
         return;
@@ -1242,6 +1251,7 @@ export function createGhostSessionTap(sessionId: string): {
 
   return {
     handleEvent(ev) {
+      if (disposed) return;
       if (ev.turnOrigin?.kind && ev.turnOrigin.kind !== 'user') return;
       if (state === 'eligible') {
         translator?.handleEvent(ev);
@@ -1250,6 +1260,23 @@ export function createGhostSessionTap(sessionId: string): {
       if (state === 'ineligible') return;
       if (pending.length < 32) pending.push({ type: ev.type, data: ev.data, source: ev.source });
       kickResolve();
+    },
+    dispose() {
+      if (disposed) return; // 两条 disposer 路径都可能跑到,补发只做一次
+      disposed = true;
+      // 补发 end 会走插件分发链路,它的异常不能打断 register.ts 的 disposer 队列
+      // ——实例替换路径是裸调用,后面还排着 onEvent 退订。
+      try {
+        translator?.dispose();
+      } catch (err) {
+        log.warn('ghost session tap dispose failed', {
+          sessionId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      translator = null;
+      state = 'ineligible';
+      pending.length = 0;
     },
   };
 }

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -601,15 +601,44 @@ export class GhostTurnTranslator {
     }
   }
 
+  /**
+   * 会话拆线收口(tap dispose 调用):turn 在场时补一条 did-turn-end。
+   *
+   * 漏发的后果是插件永久卡住:订阅方靠 did-turn-start / did-turn-end 配对维护
+   * 「AI 是否在忙」,拆线时缺了 end,它的外层状态就停在 working 再也回不来——下一轮
+   * 到达时序列变成 start, start,配对彻底断掉,插件除重启没有自愈手段。
+   *
+   * 两条拆线路径(会话关闭、Session 实例替换)一律报 interrupted:对插件的含义相同
+   * ——这一轮的产出不会再来。实例替换不会因此把一个仍在跑的 turn 拆成两轮,因为
+   * agent 切换只在会话空闲时落实(`applyPendingAgentSwitchIfIdle` 的 `isTurnRunning`
+   * 守卫),替换发生时本状态机必然已回到 idle,下面的补发分支根本不触发。
+   *
+   * dispose 时没有 ev 可用,`agent` 退化成 `opts.agent`(丢掉 `ev.source` 覆盖):
+   * 补发的这条 end 只负责让配对闭合,来源精度不是它的职责。
+   */
+  dispose(): void {
+    this.clearGraceTimer();
+    if (this.state === 'idle') return;
+    const { sessionId, agent, model } = this.opts;
+    this.finish(
+      { sessionId, agent, ...(model !== undefined ? { model } : {}) },
+      'interrupted',
+      undefined,
+    );
+  }
+
+  private clearGraceTimer(): void {
+    if (!this.graceTimer) return;
+    clearTimeout(this.graceTimer);
+    this.graceTimer = null;
+  }
+
   private finish(
     base: GhostEventTurnStartData,
     endReason: GhostEventTurnEndData['endReason'],
     usage: GhostEventTurnEndData['usage'],
   ): void {
-    if (this.graceTimer) {
-      clearTimeout(this.graceTimer);
-      this.graceTimer = null;
-    }
+    this.clearGraceTimer();
     // running 态直接定性(done 先于 status false 的容错路径)用当前时刻;
     // closing 态用 status(false) 到达时刻,宽限等待不算进 turn 时长。
     const endAt = this.state === 'closing' ? this.endedAt : this.opts.now();

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -537,6 +537,9 @@ export class GhostTurnTranslator {
   /** closing 进入时刻(duration 以它为准,不算宽限等待)。 */
   private endedAt = 0;
   private graceTimer: ReturnType<typeof setTimeout> | null = null;
+  /** 本轮 did-turn-start 实际发出去的 agent(已含 ev.source 覆盖);拆线补发 end 要
+   *  复用它,不能退回 opts.agent——两者取值域不同,见 dispose。 */
+  private startedAgent: string | null = null;
 
   constructor(
     private readonly opts: {
@@ -569,6 +572,7 @@ export class GhostTurnTranslator {
         if (this.state === 'idle') {
           this.state = 'running';
           this.startedAt = now();
+          this.startedAgent = base.agent;
           sink.turnStart(base);
         }
       } else if (this.state === 'running') {
@@ -613,15 +617,21 @@ export class GhostTurnTranslator {
    * agent 切换只在会话空闲时落实(`applyPendingAgentSwitchIfIdle` 的 `isTurnRunning`
    * 守卫),替换发生时本状态机必然已回到 idle,下面的补发分支根本不触发。
    *
-   * dispose 时没有 ev 可用,`agent` 退化成 `opts.agent`(丢掉 `ev.source` 覆盖):
-   * 补发的这条 end 只负责让配对闭合,来源精度不是它的职责。
+   * dispose 时没有 ev 可用,`agent` 复用本轮 start 发出的值而不是 `opts.agent`:后者
+   * 来自 `sessions.agent_kind`(默认 `'cc'`),而 start 走的是 `ev.source`
+   * (`'claude-code'`)。补发的 end 必须与那条 start 报同一个 agent,否则按 agent
+   * 分组维护状态的插件配不上这一对,配对照样闭合不了。
    */
   dispose(): void {
     this.clearGraceTimer();
     if (this.state === 'idle') return;
     const { sessionId, agent, model } = this.opts;
     this.finish(
-      { sessionId, agent, ...(model !== undefined ? { model } : {}) },
+      {
+        sessionId,
+        agent: this.startedAgent ?? agent,
+        ...(model !== undefined ? { model } : {}),
+      },
       'interrupted',
       undefined,
     );
@@ -643,6 +653,7 @@ export class GhostTurnTranslator {
     // closing 态用 status(false) 到达时刻,宽限等待不算进 turn 时长。
     const endAt = this.state === 'closing' ? this.endedAt : this.opts.now();
     this.state = 'idle';
+    this.startedAgent = null;
     this.opts.sink.turnEnd({
       ...base,
       durationMs: Math.max(0, endAt - this.startedAt),

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -2716,6 +2716,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
   // 订阅槽①旁听 tap(独立监听,叠加在主转发之外互不干扰):AgentEvent →
   // did-turn-*。资格(用户主会话)与自动化轮次过滤都在 tap 内部,这里零逻辑。
   const ghostSessionTap = createGhostSessionTap(session.id);
+  // 拆线收口:实例替换(上面的 existing.disposers)与会话关闭(下面 closed 的
+  // finally)两条路径都要给插件补上缺失的 did-turn-end,否则订阅方的「AI 在忙」
+  // 外层状态永久卡在 working。
+  registration.disposers.push(() => ghostSessionTap.dispose());
   registration.disposers.push(session.onEvent((event: AgentEvent) => {
     ghostSessionTap.handleEvent(
       event as { type: string; data?: unknown; source?: string; turnOrigin?: { kind?: string } },


### PR DESCRIPTION
## 这次改了什么

### 摘要

`GhostTurnTranslator` 在会话关闭或 `Session` 实例替换时被直接丢弃。turn 在场时，订阅 `turn` topic 的插件收到 `did-turn-start` 之后再也收不到配对的 `did-turn-end`，它维护的「AI 是否在忙」外层状态永久卡在 working；下一轮到达时序列变成 `start, start`，配对彻底断掉，插件除重启没有自愈手段。本 PR 在拆线前给插件补一条终止边界。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Closes #1286
- 本 PR 包含：
  - `GhostTurnTranslator.dispose()`：turn 在场时补一条 `endReason: 'interrupted'` 的 `did-turn-end`；抽出 `clearGraceTimer()` 统一清宽限定时器；
  - `createGhostSessionTap` 暴露 `dispose()`，并用 `disposed` 标志让资格判定的异步回调在拆线后不再建 translator、不再回放 pending（否则会发出一条永远等不到 end 的 `did-turn-start`）；
  - `wireSessionToIpc` 把 `tap.dispose()` 挂进 `registration.disposers`，覆盖实例替换（`existing.disposers`）与会话关闭（`closed` 的 `finally`）两条路径；
  - `FORGE_GUIDE` §4.6 的 `did-turn-end` 段补一句配对保证。
- 明确不包含：**不新增 `endReason` 取值**（issue 里的待定决策，结论见下）；`shared/ghost.ts` 一行未改；activity topic 的收口属于 #1283 的范围。
- 用户可见变化：无 UI 变化。对插件作者可见：`did-turn-start` / `did-turn-end` 现在保证配对。
- 是否存在 breaking change：无

### 关于 issue 里的待定决策

issue 担心「实例替换后新实例为同一逻辑轮次重发 `status(true)`，插件看到 `start → end(interrupted) → start`，同一轮被拆成两轮」，因此考虑加 `'detached'` 之类的新取值。

调研结论：**不会发生，两条路径统一报 `interrupted` 即可。** 实例替换的来源是 deferred agent switch（见 `register.ts` 里 `wiredSessionsById` 的注释），而它有硬守卫 —— `sessionAgentSwitchHandler.ts` 的 `applyPendingAgentSwitchIfIdle`：

```ts
const live = deps.getLiveSession(sessionId);
if (live?.isTurnRunning()) return;   // turn 在跑就保留 pending，本次不 apply
```

turn 在跑时不会替换实例，所以替换发生时状态机必然已回到 `idle`，`dispose()` 的补发分支根本不触发（本 PR 有对应用例）。因此不必改 wire protocol，也就不触发存量插件兼容红线里的「管子协议消息形态」。

未穷尽验证的部分：lazy-create / SSH 重连换实例的场景没有逐条走查，但那些场景旧 `Session` 已经死了、turn 不会续跑，`interrupted` 语义同样成立。

### 与 #1283 的关系

issue 描述的代码基线其实是 #1283 的分支：`dispose()` / `clearGraceTimer()` / `GhostActivityTracker.finishAll()` 都由 #1283 引入，`main` 上不存在。本 PR base 是 `main`，因此自建了 dispose 骨架（约 25 行而非 issue 估的 6 行）。

**与 #1283 有三处会冲突**，都是同位置加法、语义一致：`subscriptionGateway.ts`（同名 `dispose` / `clearGraceTimer`）、`index.ts`（tap 返回值形状）、`register.ts`（同一位置 push disposer）。谁后合谁解，解法是把两个 disposer body 并起来（#1283 那条还要摘 `installInteractionLifecycleObserver`）。

### UI 变化

不涉及。

- 引用的设计规范：不涉及（无 UI 改动）

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/subscriptionGateway.test.ts src/main/__tests__/makerEventHotPathOrdering.test.ts src/main/cindy-brain/__tests__/forge.test.ts
结果：3 files / 65 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm test:unit
结果：全部通过，EXITCODE=0（apps/desktop unit PASS，214.1s）

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

新增用例（`subscriptionGateway.test.ts`）：

- running 态 dispose → 补一条 `interrupted`，`durationMs` 按拆线时刻算；
- closing 态 dispose → 只补一条，时长按 `status(false)` 时刻算，宽限定时器一并清掉（推进定时器不会补出第二条）；
- idle 态 dispose → 不发事件（实例替换的常态路径）。

`makerEventHotPathOrdering.test.ts` 加了一条源码契约断言，锁住 `registration.disposers.push(() => ghostSessionTap.dispose());` 不被后人删掉。

### 手工验证

不涉及：改动在 main 进程的插件事件分发层，无 UI 表面。

### 未执行的验证

- **tap 层与 register 接线没有单测覆盖**：`createGhostSessionTap` 在本仓一直没有单测（依赖 DB 资格查询与 gateway 单例），本 PR 未新建 mock 基础设施。补发逻辑本身在 translator 层有单测，接线靠上述源码契约断言与类型覆盖。
- 未做实机验证：需要一个订阅 `turn` topic 的插件在 turn 中途关会话／切 agent 来观察其外层状态，本次未做；也未做 cc / codex 双 agent 对照。
- 未跑 `pnpm test:all`。

## 风险

### 风险分类

- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）

### 影响与回滚

- 影响范围：`main/cindy-brain/`（`subscriptionGateway.ts`、`index.ts`、`forge.ts`）与 `maker-ipc/register.ts` 的 `wireSessionToIpc` 接线。只影响订阅了 `turn` topic 的插件收到的事件序列。
- **存量插件影响：无**。事件名、`endReason` 取值、载荷字段一律未变（`shared/ghost.ts` 零改动），批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式全部未触及。用户升级后什么都不做，已装、已批准、已启用的插件照旧可用。唯一变化是**原本漏发的 end 现在会发**：对按 start/end 配对的插件是修复，对忽略 end 的插件无影响；`'interrupted'` 本就是既有取值，旧插件原本就要处理它。因此没有需要迁移的旧数据，也没有对应的升级用例可跑。
- **命中插件基座白名单确认门**（改到 `main/cindy-brain/`）：按 `docs/dev-rules/plugin-security-and-authoring.md` 第 5 节，需放行人在本 PR 上明确 Approve 才能合并，不看 diff 大小、不因是 bugfix 豁免。
- 手册已同步：`FORGE_GUIDE` §4.6（subscribe 槽）的 `did-turn-end` 段补了配对保证一句。未改字段 / 取值 / 校验，作者契约本身无变化。
- 回滚 / 降级方式：直接 revert 本 commit，回到「拆线不补 end」的旧行为，无数据残留、无需迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
