### PR TITLE
fix(desktop): keep Ghost hooks enabled for Orca leads

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
@@ -445,7 +445,7 @@ describe('will-assistant-message 出口钩子拦截(screenAssistantMessage)', ()
 });
 
 describe('isGhostEligibleSessionRow(订阅投递资格行级判定)', () => {
-  it('desktop / shared 主会话放行;IM / 自动化 / orca 排除', () => {
+  it('desktop / shared 与 Orca Lead 放行;IM / 自动化 / 其它 Orca 角色排除', () => {
     // 用户主会话:亲手建的 + 分享导入的(2026-07-13 实撞:shared 曾被误排除)。
     expect(isGhostEligibleSessionRow({ source: 'desktop', orcaRole: null })).toBe(true);
     expect(isGhostEligibleSessionRow({ source: 'shared', orcaRole: null })).toBe(true);
@@ -455,9 +455,10 @@ describe('isGhostEligibleSessionRow(订阅投递资格行级判定)', () => {
     for (const source of ['feishu', 'slack', 'discord', 'scheduler', 'learn']) {
       expect(isGhostEligibleSessionRow({ source, orcaRole: null }), source).toBe(false);
     }
-    // Orca 协同(lead/worker)排除。
-    expect(isGhostEligibleSessionRow({ source: 'desktop', orcaRole: 'lead' })).toBe(false);
+    // 只明确放行 Orca Lead；其它当前或未来角色都按内部执行噪音 fail-closed。
+    expect(isGhostEligibleSessionRow({ source: 'desktop', orcaRole: 'lead' })).toBe(true);
     expect(isGhostEligibleSessionRow({ source: 'shared', orcaRole: 'worker' })).toBe(false);
+    expect(isGhostEligibleSessionRow({ source: 'plugin', orcaRole: 'reviewer' })).toBe(false);
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
+++ b/apps/desktop/src/main/cindy-brain/subscriptionGateway.ts
@@ -435,9 +435,9 @@ export class GhostSubscriptionGateway {
 
 /**
  * 订阅事件投递资格的行级判定(纯谓词,抽出便于单测;DB 查询在调用方):
- * 只投**用户主会话**——亲手建的(desktop)与分享导入后自己在用的(shared);
- * IM 机器人渠道(feishu/slack/discord)、本机自动化(scheduler/learn)与 Orca
- * 协同会话(orcaRole 非空)一律排除,它们的动态对意识是噪音。
+ * 只投**用户主会话**——亲手建的(desktop)与分享导入后自己在用的(shared),
+ * 包括仍由用户直接交互的 Orca Lead;IM 机器人渠道(feishu/slack/discord)、
+ * 本机自动化(scheduler/learn)与其它 Orca 角色排除,它们的动态对意识是噪音。
  * (2026-07-13 实撞:shared 会话被旧的 desktop-only 判定静默排除,用户切到
  * 分享导入的会话时 did-session-switched 不发,还连带切回时重复发上一会话。)
  */
@@ -445,10 +445,10 @@ export function isGhostEligibleSessionRow(row: {
   source: string | null | undefined;
   orcaRole: string | null | undefined;
 }): boolean {
-  // orcaRole 宽松判空:worker-thread 代理序列化可能把 NULL 列变 undefined。
   // plugin 来源:workspace 槽创建的项目会话,用户打开后正常交互,应享有完整的
   // ghost 事件(turn/hook/session-switched 等),与 desktop/shared 同等待遇。
-  return (row.source === 'desktop' || row.source === 'shared' || row.source === 'plugin') && row.orcaRole == null;
+  return (row.source === 'desktop' || row.source === 'shared' || row.source === 'plugin')
+    && (row.orcaRole == null || row.orcaRole === 'lead');
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

Cindy 的 Ghost 订阅资格判断原先只允许 `orcaRole == null` 的用户主会话。一旦用户主会话调用 `start_team`，同一会话会被标记为 `orcaRole = 'lead'`，随后其 turn 生命周期事件也会被过滤，Ghost 插件无法收到主会话的 `did-turn-end` 等事件。

本 PR 将 Orca Lead 继续视为用户直接交互的主会话，同时保持 Worker 与任何未知/未来 Orca 角色默认拒绝：

```ts
allowedSource && (orcaRole == null || orcaRole === 'lead')
```

这里没有采用 `orcaRole !== 'worker'`，因为数据库列和共享读取模型可出现任意字符串；订阅入口应只明确放行已知安全角色，避免未来新增内部角色被静默暴露给 Ghost 插件。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Orca Lead 完成 turn 后仍需按用户主会话规则投递 Ghost 生命周期事件。
- 本 PR 包含：收窄 Ghost 订阅中的 Orca 角色过滤；更新既有单测并增加未知角色回归覆盖。
- 明确不包含：Orca Worker 派发、claw-kit report/finalizer 实现、插件侧逻辑。
- 用户可见变化：用户主会话开启 Orca 协同后，Ghost 插件仍能收到该主会话的 turn/session 生命周期事件。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run apps/desktop/src/main/cindy-brain/__tests__/subscriptionGateway.test.ts
结果：1 个测试文件通过，27/27 项通过。

pnpm check:dco
结果：1 个 commit 通过 DCO 检查。
```

回归断言覆盖：

- 普通 desktop/shared 主会话继续放行；
- `orcaRole = 'lead'` 放行；
- `orcaRole = 'worker'` 拒绝；
- 未知角色 `reviewer` 拒绝，锁定 fail-closed 行为；
- IM 与自动化来源继续拒绝。

### 手工验证

不涉及 UI 手工验证。

### 未执行的验证

仓库级 `pnpm test:unit` 未作为本次提交的最终门禁。此前 Windows CRLF checkout 的尝试命中了一个与本 PR 无关的 Mobile 源码字符串断言（硬编码 `\n`，目标文件为 `\r\n`）；切换到 LF checkout 后的最终全量重跑按本次范围决定停止，仅保留上述相关测试结果。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Ghost 生命周期事件的会话资格谓词。来源过滤保持不变，只新增明确的 Orca Lead 放行；Worker 和未知角色仍被拒绝。
- 回滚 / 降级方式：恢复 `orcaRole == null` 条件即可回到原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 无需补充产品文档
- [x] 已如实记录测试结果与未执行项
