### PR TITLE
fix(mobile): 按活动时间混排项目和对话

### DIFF
--- a/apps/mobile/src/__tests__/homeSections.test.ts
+++ b/apps/mobile/src/__tests__/homeSections.test.ts
@@ -60,21 +60,20 @@ describe('buildHomeSections', () => {
     expect(sections.find((s) => s.key === 'pinned')).toBeUndefined();
   });
 
-  it('分组模式按桌面层级拆分数据,但不渲染项目 / 对话汇总表头', () => {
+  it('分组模式把项目与普通对话放在同一分区,不渲染项目 / 对话汇总表头', () => {
     const home = presentation({
       chats: [listItem('c1', '2026-06-01T00:00:00Z')],
       projects: [projectGroup('proj-a', '2026-06-02T00:00:00Z', [listItem('s1', '2026-06-02T00:00:00Z')])],
     });
     expect(buildHomeSections(home, false, false).find((s) => s.title === null)?.key).toBe('mixed');
     expect(buildHomeSections(home, true, false).map((s) => [s.key, s.title])).toEqual([
-      ['projects', null],
-      ['dialogue', null],
+      ['grouped', null],
     ]);
   });
 });
 
 describe('homeRowBefore(跨 section 邻接:分割线唯一化的 prevIsBlock 依据)', () => {
-  // 分组模式:置顶 + 项目区 + 对话区(首行是自动化组会话 —— 首页里以块呈现,自画顶线)。
+  // 分组模式:置顶区 + 按活动时间混排的主列表(首行是自动化组会话 —— 首页里以块呈现,自画顶线)。
   const automationChat = {
     session: { id: 'auto-1' },
     lastActivityAt: '2026-06-06T00:00:00Z',
@@ -89,22 +88,23 @@ describe('homeRowBefore(跨 section 邻接:分割线唯一化的 prevIsBlock 依
     ],
   });
 
-  it('项目区末块 → 对话区首行(自动化组):跨区取到末位项目行,块顶线得以让位', () => {
+  it('置顶区 → 主列表首行:跨区取到末位置顶会话', () => {
     const sections = buildHomeSections(home, true, false);
-    const prev = homeRowBefore(sections, 'dialogue', 0);
-    expect(prev?.kind).toBe('project');
-    expect(prev && prev.kind === 'project' ? prev.project.key : null).toBe('proj-b');
+    const prev = homeRowBefore(sections, 'grouped', 0);
+    expect(prev?.kind).toBe('session');
+    expect(prev && prev.kind === 'session' ? prev.item.session.id : null).toBe('pin-1');
   });
 
   it('同区内仍取 index-1,不受跨区逻辑影响', () => {
     const sections = buildHomeSections(home, true, false);
-    const prev = homeRowBefore(sections, 'projects', 1);
-    expect(prev && prev.kind === 'project' ? prev.project.key : null).toBe('proj-a');
+    const prev = homeRowBefore(sections, 'grouped', 1);
+    expect(prev?.kind).toBe('session');
+    expect(prev && prev.kind === 'session' ? prev.item.session.id : null).toBe('auto-1');
   });
 
   it('置顶收起时 pinned 区 data 为空:跨区回溯要跳过空区', () => {
     const sections = buildHomeSections(home, true, true);
-    const prev = homeRowBefore(sections, 'projects', 0);
+    const prev = homeRowBefore(sections, 'grouped', 0);
     expect(prev).toBeUndefined();
   });
 
@@ -117,7 +117,10 @@ describe('homeRowBefore(跨 section 邻接:分割线唯一化的 prevIsBlock 依
 
 describe('buildMixedHomeRows / buildGroupedHomeRows', () => {
   const home = presentation({
-    chats: [listItem('chat-old', '2026-06-01T00:00:00Z')],
+    chats: [
+      listItem('chat-new', '2026-06-06T00:00:00Z'),
+      listItem('chat-old', '2026-06-01T00:00:00Z'),
+    ],
     projects: [
       projectGroup('proj-new', '2026-06-05T00:00:00Z', [
         listItem('s1', '2026-06-05T00:00:00Z'),
@@ -129,16 +132,20 @@ describe('buildMixedHomeRows / buildGroupedHomeRows', () => {
   it('混排:项目下属会话展平为 session 行,按活动时间倒序', () => {
     const rows = buildMixedHomeRows(home);
     expect(rows.every((r) => r.kind === 'session')).toBe(true);
-    // proj 的两条(06-05/06-04)比 chat(06-01)新 → 排在前
-    expect(rows.map((r) => (r.kind === 'session' ? r.source : 'project'))).toEqual(['project', 'project', 'chat']);
+    expect(rows.map((r) => (r.kind === 'session' ? r.item.session.id : 'project'))).toEqual([
+      'chat-new',
+      's1',
+      's2',
+      'chat-old',
+    ]);
   });
 
-  it('分组:固定桌面层级,项目文件夹始终在普通对话之前', () => {
+  it('分组:项目保留 folder 行,与普通对话按活动时间倒序混排', () => {
     const rows = buildGroupedHomeRows(home);
-    const kinds = rows.map((r) => r.kind);
-    expect(kinds).toContain('project');
-    expect(kinds).toContain('session');
-    // 用户口头定稿:移动端跟 Mac 侧栏一致,分组模式不再按时间把普通对话插到项目上方。
-    expect(rows[0].kind).toBe('project');
+    expect(rows.map((row) => row.kind === 'project' ? row.project.key : row.item.session.id)).toEqual([
+      'chat-new',
+      'proj-new',
+      'chat-old',
+    ]);
   });
 });

--- a/apps/mobile/src/__tests__/homeSections.test.ts
+++ b/apps/mobile/src/__tests__/homeSections.test.ts
@@ -148,4 +148,26 @@ describe('buildMixedHomeRows / buildGroupedHomeRows', () => {
       'chat-old',
     ]);
   });
+
+  it('活动时间相同时按 row key 稳定排序,不受上游输入顺序影响', () => {
+    const activityAt = '2026-06-07T00:00:00Z';
+    const forward = presentation({
+      chats: [listItem('chat-z', activityAt), listItem('chat-a', activityAt)],
+      projects: [
+        projectGroup('project-z', activityAt, [listItem('session-z', activityAt)]),
+        projectGroup('project-a', activityAt, [listItem('session-a', activityAt)]),
+      ],
+    });
+    const reversed = presentation({
+      chats: [...forward.chats].reverse(),
+      projects: [...forward.projects].reverse(),
+    });
+
+    for (const buildRows of [buildMixedHomeRows, buildGroupedHomeRows]) {
+      const forwardKeys = buildRows(forward).map((row) => row.key);
+      const reversedKeys = buildRows(reversed).map((row) => row.key);
+      expect(forwardKeys).toEqual([...forwardKeys].sort((a, b) => a.localeCompare(b)));
+      expect(reversedKeys).toEqual(forwardKeys);
+    }
+  });
 });

--- a/apps/mobile/src/session/homeSections.ts
+++ b/apps/mobile/src/session/homeSections.ts
@@ -103,7 +103,7 @@ export function buildGroupedHomeRows(home: MobileHomePresentation): HomeRow[] {
 }
 
 function compareHomeRowsByActivityDesc(a: HomeRow, b: HomeRow): number {
-  return homeRowActivity(b).localeCompare(homeRowActivity(a));
+  return homeRowActivity(b).localeCompare(homeRowActivity(a)) || a.key.localeCompare(b.key);
 }
 
 function homeRowActivity(row: HomeRow): string {

--- a/apps/mobile/src/session/homeSections.ts
+++ b/apps/mobile/src/session/homeSections.ts
@@ -14,8 +14,8 @@ export type HomeSection = { data: HomeRow[]; key: string; title: string | null }
  * 把 home 展示模型拆成 SectionList 的分区(纯函数,便于单测)。
  * - 置顶单独成区;`pinnedCollapsed` 时清空 data 但**保留分区**(SectionList 对空 data 仍渲染
  *   表头,所以折叠时表头照常显示,只折叠下属会话)。
- * - 分组模式仅用于固定顺序:项目 folder 行在普通对话前;不渲染额外「项目 / 对话」汇总表头。
- * - 混排模式仍把普通对话 + 项目下属会话展平,按活动时间倒序。
+ * - 分组模式保留项目 folder 行,与普通对话按活动时间倒序混排。
+ * - 非分组模式把普通对话 + 项目下属会话展平,按活动时间倒序。
  */
 export function buildHomeSections(
   home: MobileHomePresentation,
@@ -33,32 +33,13 @@ export function buildHomeSections(
     });
   }
 
-  if (groupByProject) {
-    const projectRows = buildProjectHomeRows(home);
-    if (projectRows.length > 0) {
-      sections.push({
-        data: projectRows,
-        key: 'projects',
-        title: null,
-      });
-    }
-    const dialogueRows = buildDialogueHomeRows(home);
-    if (dialogueRows.length > 0) {
-      sections.push({
-        data: dialogueRows,
-        key: 'dialogue',
-        title: null,
-      });
-    }
-  } else {
-    const rows = buildMixedHomeRows(home);
-    if (rows.length > 0) {
-      sections.push({
-        data: rows,
-        key: 'mixed',
-        title: null,
-      });
-    }
+  const rows = groupByProject ? buildGroupedHomeRows(home) : buildMixedHomeRows(home);
+  if (rows.length > 0) {
+    sections.push({
+      data: rows,
+      key: groupByProject ? 'grouped' : 'mixed',
+      title: null,
+    });
   }
   return sections;
 }
@@ -66,8 +47,8 @@ export function buildHomeSections(
 /**
  * 取某行在整个列表里的前一行:同 section 内取 index-1;section 首行跨区取前一个
  * **非空** section 的末行(置顶收起时 pinned 区 data 为空,要跳过)。
- * SectionList 的 renderItem 只给区内 index,分组模式 projects → dialogue 边界的
- * 分割线唯一化(prevIsBlock)必须跨区看邻接,否则项目末块底线 + 组块顶线叠成双线。
+ * SectionList 的 renderItem 只给区内 index,置顶区 → 主列表边界的分割线唯一化
+ * (prevIsBlock)必须跨区看邻接,否则相邻块的边线可能叠成双线。
  */
 export function homeRowBefore(
   sections: HomeSection[],
@@ -113,12 +94,12 @@ export function buildMixedHomeRows(home: MobileHomePresentation): HomeRow[] {
   ].sort(compareHomeRowsByActivityDesc);
 }
 
-/** 分组模式:固定为桌面侧栏层级,先 project folders,再 dialogue sessions;各段内保留上游排序。 */
+/** 分组模式:项目保留 folder 行,与普通对话统一按活动时间倒序混排。 */
 export function buildGroupedHomeRows(home: MobileHomePresentation): HomeRow[] {
   return [
     ...buildProjectHomeRows(home),
     ...buildDialogueHomeRows(home),
-  ];
+  ].sort(compareHomeRowsByActivityDesc);
 }
 
 function compareHomeRowsByActivityDesc(a: HomeRow, b: HomeRow): number {


### PR DESCRIPTION
## 这次改了什么

### 摘要

恢复手机版首页按项目分组时的活动时间混排：项目仍保留为可展开的文件夹行，但项目文件夹与普通对话统一按最近活动时间倒序排列，不再把全部普通对话固定放在项目区之后。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户确认的手机版列表排序调整
- 本 PR 包含：手机版首页分组模式的 section 构造、项目/对话活动时间混排、对应单元测试
- 明确不包含：桌面端侧栏排序调整；关闭“按项目分组”时的展平排序调整
- 用户可见变化：开启“按项目分组”后，最近有活动的普通对话可以排在较旧项目之前
- 是否存在 breaking change：无

### UI 变化

- 手机版首页的信息顺序发生变化；项目、对话行的组件、视觉样式、文案和交互均保持不变，无新增截图。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §8 Mobile、§15.13 Cross-Platform Skin Rules；本次复用现有 Mobile 项目文件夹和会话行，仅调整数据排序，不新增颜色、几何、层级样式或主题分支，Light / Dark 渲染路径不变。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/homeSections.test.ts
结果：10 项测试通过

pnpm --filter mobile typecheck
结果：通过

pnpm --filter mobile test
结果：275 个测试文件、2931 项测试全部通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-mobile-grouped-activity-mix
结果：全仓单元测试门禁通过
```

### 手工验证

不涉及：本次使用含“新对话 → 项目 → 旧对话”的排序 fixture 验证分组混排结果。

### 未执行的验证

- 未运行 iOS / Android 模拟器目检，因此没有 Metro 归属或 `__DEV__` build label 证据。
- 未修改原生配置、依赖或 fingerprint 输入，不涉及冷更验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：手机版首页分组模式的信息排序行为变化

### 影响与回滚

- 影响范围：仅手机版首页开启“按项目分组”时的未置顶项目/普通对话顺序；置顶区、项目内会话顺序和非分组模式不变。
- 回滚 / 降级方式：回退本 PR，即恢复“全部项目在前、普通对话在后”的固定层级。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
