### PR TITLE
fix(session-reference): 外部任务链接解析失败时仍发送给 Agent

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/outboundSessionReferences.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/outboundSessionReferences.test.ts
@@ -6,6 +6,7 @@ vi.mock('../../maker-ipc/sessionReferenceResolver.js', () => ({ resolveSessionRe
 import {
   outboundSessionReferencesRequested,
   rewriteOutboundSessionReferences,
+  stripOutboundSessionReferenceSideChannels,
 } from '../outboundSessionReferences.js';
 import type { AgentInputQueuedMessage } from '../../../shared/agentInputQueue.js';
 
@@ -140,6 +141,39 @@ describe('rewriteOutboundSessionReferences', () => {
     expect(rewritten).toBe(args);
     expect(JSON.stringify(rewritten)).toBe('["target-on-b","client-1","plain edit"]');
     expect(resolveSessionReferences).not.toHaveBeenCalled();
+  });
+
+  it('strips every queue-mutation side channel without changing user text', () => {
+    const enqueue = stripOutboundSessionReferenceSideChannels('maker:input:enqueue', [
+      'target-on-b',
+      queued([{ sessionId: 'source' }]),
+    ]);
+    const updateContent = stripOutboundSessionReferenceSideChannels('maker:input:update-content', [
+      'target-on-b',
+      'client-1',
+      queued([{ sessionId: 'source' }]),
+    ]);
+    const updateText = stripOutboundSessionReferenceSideChannels('maker:input:update-text', [
+      'target-on-b',
+      'client-1',
+      'keep cindy://session/source',
+      [{ sessionId: 'source' }],
+      [{ sessionId: 'source', messages: [] }],
+    ]);
+
+    for (const item of [enqueue[1], updateContent[2]] as AgentInputQueuedMessage[]) {
+      expect(item.text).toBe('compare linked session');
+      expect(item.sessionRefs).toBeUndefined();
+      expect(item.trustedSessionReferenceContexts).toBeUndefined();
+      expect(item.sessionReferencesRequireTrustedSnapshot).toBeUndefined();
+    }
+    expect(updateText).toEqual([
+      'target-on-b',
+      'client-1',
+      'keep cindy://session/source',
+      [],
+      [],
+    ]);
   });
 
   it('resolves references in a full queued-content replacement', async () => {

--- a/apps/desktop/src/main/device-link/__tests__/outboundSessionReferences.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/outboundSessionReferences.test.ts
@@ -75,14 +75,17 @@ describe('rewriteOutboundSessionReferences', () => {
     expect(JSON.stringify(rewritten)).not.toContain('renderer-forged history');
   });
 
-  it('does not borrow the target device identity when the controller cannot read a third device', async () => {
+  it('falls back to raw link text when the controller cannot read a third device', async () => {
     resolveSessionReferences.mockRejectedValueOnce(new Error('source device access revoked'));
-    await expect(
-      rewriteOutboundSessionReferences('maker:input:steer', [
-        'target-on-b',
-        queued([{ sessionId: 'on-c', deviceId: 'device-c' }]),
-      ]),
-    ).rejects.toThrow('access revoked');
+    const rewritten = await rewriteOutboundSessionReferences('maker:input:steer', [
+      'target-on-b',
+      queued([{ sessionId: 'on-c', deviceId: 'device-c' }]),
+    ]);
+
+    expect((rewritten[1] as AgentInputQueuedMessage).text).toBe('compare linked session');
+    expect((rewritten[1] as AgentInputQueuedMessage).sessionRefs).toBeUndefined();
+    expect((rewritten[1] as AgentInputQueuedMessage).trustedSessionReferenceContexts)
+      .toBeUndefined();
   });
 
   it('lets a queued remove-from-queue steer use the target stored snapshot', async () => {
@@ -108,6 +111,26 @@ describe('rewriteOutboundSessionReferences', () => {
     ]);
     expect(resolveSessionReferences).toHaveBeenCalledWith(refs);
     expect(rewritten[4]).toEqual(snapshot);
+  });
+
+  it('drops unresolved update-text side channels while preserving the edited text', async () => {
+    const refs = [{ sessionId: 'foreign', deviceId: 'device-c' }];
+    resolveSessionReferences.mockRejectedValueOnce(new Error('foreign session'));
+
+    const rewritten = await rewriteOutboundSessionReferences('maker:input:update-text', [
+      'target-on-b',
+      'client-1',
+      'now use cindy://session/foreign',
+      refs,
+    ]);
+
+    expect(rewritten).toEqual([
+      'target-on-b',
+      'client-1',
+      'now use cindy://session/foreign',
+      [],
+      [],
+    ]);
   });
 
   it('keeps the legacy three-argument update-text shape unchanged', async () => {

--- a/apps/desktop/src/main/device-link/__tests__/sessionReferenceCompatibility.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/sessionReferenceCompatibility.test.ts
@@ -22,7 +22,7 @@ function queuedWithReference() {
 }
 
 describe('device-link target session-reference capability gate', () => {
-  it('rejects an old target before resolving or sending the referenced message', async () => {
+  it('rewrites references before rejecting an old target', async () => {
     const invoke = vi.fn<DeviceLinkIpcDeps['invoke']>().mockResolvedValue({
       ok: false,
       error: { code: 'CHANNEL_NOT_ALLOWED', message: 'unknown channel' },
@@ -42,10 +42,10 @@ describe('device-link target session-reference capability gate', () => {
       DL_SESSION_REFERENCE_CAPABILITY_CHANNEL,
       [],
     );
-    expect(rewrite).not.toHaveBeenCalled();
+    expect(rewrite).toHaveBeenCalledTimes(1);
   });
 
-  it('probes a new target before rewriting and sending the message', async () => {
+  it('rewrites before probing a new target and sending the message', async () => {
     const invoke = vi
       .fn<DeviceLinkIpcDeps['invoke']>()
       .mockResolvedValueOnce({ ok: true, result: { supported: true, version: 1 } })
@@ -67,6 +67,33 @@ describe('device-link target session-reference capability gate', () => {
       'maker:input:enqueue',
     ]);
     expect(rewrite).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends a raw foreign link without probing reference support', async () => {
+    const invoke = vi
+      .fn<DeviceLinkIpcDeps['invoke']>()
+      .mockResolvedValueOnce({ ok: true, result: { accepted: true } });
+    const rewrite = vi.fn(async (_channel: string, args: unknown[]) => [
+      args[0],
+      { ...(args[1] as object), sessionRefs: undefined },
+    ]);
+
+    await expect(
+      handleInvoke(depsForInvoke(invoke, rewrite), 'target-device', 'maker:input:enqueue', [
+        'target-session',
+        queuedWithReference(),
+      ]),
+    ).resolves.toEqual({ accepted: true });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith(
+      'target-device',
+      'maker:input:enqueue',
+      [
+        'target-session',
+        expect.objectContaining({ text: 'compare cindy://session/source' }),
+      ],
+    );
   });
 
   it('accepts newer compatible capability versions', async () => {

--- a/apps/desktop/src/main/device-link/__tests__/sessionReferenceCompatibility.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/sessionReferenceCompatibility.test.ts
@@ -22,11 +22,14 @@ function queuedWithReference() {
 }
 
 describe('device-link target session-reference capability gate', () => {
-  it('rewrites references before rejecting an old target', async () => {
-    const invoke = vi.fn<DeviceLinkIpcDeps['invoke']>().mockResolvedValue({
-      ok: false,
-      error: { code: 'CHANNEL_NOT_ALLOWED', message: 'unknown channel' },
-    });
+  it('sends raw link text when an old target cannot consume trusted reference fields', async () => {
+    const invoke = vi
+      .fn<DeviceLinkIpcDeps['invoke']>()
+      .mockResolvedValueOnce({
+        ok: false,
+        error: { code: 'CHANNEL_NOT_ALLOWED', message: 'unknown channel' },
+      })
+      .mockResolvedValueOnce({ ok: true, result: { accepted: true } });
     const rewrite = vi.fn(async (_channel: string, args: unknown[]) => args);
 
     await expect(
@@ -34,13 +37,23 @@ describe('device-link target session-reference capability gate', () => {
         'target-session',
         queuedWithReference(),
       ]),
-    ).rejects.toThrow('[SESSION_REFERENCE_UNSUPPORTED]');
+    ).resolves.toEqual({ accepted: true });
 
-    expect(invoke).toHaveBeenCalledTimes(1);
-    expect(invoke).toHaveBeenCalledWith(
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke).toHaveBeenNthCalledWith(
+      1,
       'target-device',
       DL_SESSION_REFERENCE_CAPABILITY_CHANNEL,
       [],
+    );
+    expect(invoke).toHaveBeenNthCalledWith(
+      2,
+      'target-device',
+      'maker:input:enqueue',
+      [
+        'target-session',
+        { text: 'compare cindy://session/source' },
+      ],
     );
     expect(rewrite).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -43,6 +43,7 @@ import { rewriteOutboundMedia } from './outboundMedia';
 import {
   outboundSessionReferencesRequested,
   rewriteOutboundSessionReferences,
+  stripOutboundSessionReferenceSideChannels,
 } from './outboundSessionReferences';
 import {
   isPlaceholderDeviceName,
@@ -472,41 +473,42 @@ export async function handleInvoke(
     }
     if (!capability.ok) {
       if (capability.error.code === 'CHANNEL_NOT_ALLOWED') {
-        throwIpcError(
-          'SESSION_REFERENCE_UNSUPPORTED',
-          '目标设备版本不支持任务引用，请升级目标设备后重试',
-        );
-      }
-      if (capability.error.code === 'IPC_ERROR') {
+        log.warn('target does not support session references; sending raw link text', {
+          channel,
+        });
+        callArgs = stripOutboundSessionReferenceSideChannels(channel, callArgs);
+      } else if (capability.error.code === 'IPC_ERROR') {
         throwIpcError(
           'SESSION_REFERENCE_UNAVAILABLE',
           '目标设备仍在启动，任务引用暂不可用，请稍后重试',
         );
+      } else {
+        throwIpcError(
+          DEVICE_LINK_CODE_MAP[capability.error.code] ?? 'INTERNAL',
+          capability.error.message,
+        );
       }
-      throwIpcError(
-        DEVICE_LINK_CODE_MAP[capability.error.code] ?? 'INTERNAL',
-        capability.error.message,
-      );
-    }
-    const capabilityVersion =
-      capability.result &&
-      typeof capability.result === 'object' &&
-      !Array.isArray(capability.result)
-        ? (capability.result as { version?: unknown }).version
-        : undefined;
-    if (
-      !capability.result ||
-      typeof capability.result !== 'object' ||
-      Array.isArray(capability.result) ||
-      (capability.result as { supported?: unknown }).supported !== true ||
-      typeof capabilityVersion !== 'number' ||
-      !Number.isFinite(capabilityVersion) ||
-      capabilityVersion < 1
-    ) {
-      throwIpcError(
-        'SESSION_REFERENCE_UNSUPPORTED',
-        '目标设备版本不支持任务引用，请升级目标设备后重试',
-      );
+    } else {
+      const capabilityVersion =
+        capability.result &&
+        typeof capability.result === 'object' &&
+        !Array.isArray(capability.result)
+          ? (capability.result as { version?: unknown }).version
+          : undefined;
+      if (
+        !capability.result ||
+        typeof capability.result !== 'object' ||
+        Array.isArray(capability.result) ||
+        (capability.result as { supported?: unknown }).supported !== true ||
+        typeof capabilityVersion !== 'number' ||
+        !Number.isFinite(capabilityVersion) ||
+        capabilityVersion < 1
+      ) {
+        log.warn('target does not support session references; sending raw link text', {
+          channel,
+        });
+        callArgs = stripOutboundSessionReferenceSideChannels(channel, callArgs);
+      }
     }
   }
 

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -443,6 +443,22 @@ export async function handleInvoke(
   }
   let callArgs = Array.isArray(args) ? args : [];
 
+  // Resolve controller-relative references first. If the source session is
+  // foreign or unavailable, the rewrite drops only the optional reference
+  // side channel and preserves the raw link text. Recompute the capability
+  // need afterwards so that plain-link fallback also works with older targets.
+  if (deps.rewriteOutboundSessionReferences) {
+    try {
+      callArgs = await deps.rewriteOutboundSessionReferences(channel, callArgs);
+    } catch (err) {
+      throwIpcError(
+        'SESSION_REFERENCE_UNAVAILABLE',
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+    assertControlTargetEnabled(deps, normalizedDeviceId);
+  }
+
   if (outboundSessionReferencesRequested(channel, callArgs)) {
     let capability: InvokeResultPayload;
     try {
@@ -492,19 +508,6 @@ export async function handleInvoke(
         '目标设备版本不支持任务引用，请升级目标设备后重试',
       );
     }
-  }
-
-  // 会话引用必须在控制端坐标系解析；放在附件上传前，引用失败时不产生无用 OSS 写入。
-  if (deps.rewriteOutboundSessionReferences) {
-    try {
-      callArgs = await deps.rewriteOutboundSessionReferences(channel, callArgs);
-    } catch (err) {
-      throwIpcError(
-        'SESSION_REFERENCE_UNAVAILABLE',
-        err instanceof Error ? err.message : String(err),
-      );
-    }
-    assertControlTargetEnabled(deps, normalizedDeviceId);
   }
 
   // 出方向附件:发往远程前先把本机附件上传 OSS、替换成引用串(bytes 不内联进 relay)。

--- a/apps/desktop/src/main/device-link/outboundSessionReferences.ts
+++ b/apps/desktop/src/main/device-link/outboundSessionReferences.ts
@@ -5,9 +5,11 @@
  * 再解释。这里在越过 device-link 前由控制端 main 读取权威历史并固化快照。
  */
 import type { AgentInputQueuedMessage } from '../../shared/agentInputQueue.js';
+import { createLogger } from '../logger.js';
 import { resolveSessionReferences } from '../maker-ipc/sessionReferenceResolver.js';
 
 const QUEUED_CHANNELS = new Set(['maker:input:enqueue', 'maker:input:steer', 'maker:input:update-content']);
+const log = createLogger('device-link:session-reference');
 
 function usesTargetStoredSnapshot(channel: string, args: unknown[], item: AgentInputQueuedMessage): boolean {
   if (channel !== 'maker:input:steer') return false;
@@ -37,6 +39,31 @@ export function outboundSessionReferencesRequested(channel: string, args: unknow
   return Array.isArray(refs) && refs.length > 0;
 }
 
+/** Preserve user-authored text while removing every trusted-reference side channel. */
+export function stripOutboundSessionReferenceSideChannels(
+  channel: string,
+  args: unknown[],
+): unknown[] {
+  if (channel === 'maker:input:update-text') {
+    if (!Array.isArray(args[3])) return args;
+    const next = [...args];
+    next[3] = [];
+    next[4] = [];
+    return next;
+  }
+  if (!QUEUED_CHANNELS.has(channel)) return args;
+  const itemIndex = channel === 'maker:input:update-content' ? 2 : 1;
+  const item = args[itemIndex];
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return args;
+  const nextItem: AgentInputQueuedMessage = { ...(item as AgentInputQueuedMessage) };
+  delete nextItem.sessionRefs;
+  delete nextItem.trustedSessionReferenceContexts;
+  delete nextItem.sessionReferencesRequireTrustedSnapshot;
+  const next = [...args];
+  next[itemIndex] = nextItem;
+  return next;
+}
+
 export async function rewriteOutboundSessionReferences(
   channel: string,
   args: unknown[],
@@ -47,11 +74,15 @@ export async function rewriteOutboundSessionReferences(
     const next = [...args];
     try {
       next[4] = refs && refs.length > 0 ? await resolveSessionReferences(refs) : [];
-    } catch {
+    } catch (error) {
       // Preserve the edited text, but do not ask the target to trust an
       // unresolved controller-side reference or reject the whole edit.
-      next[3] = [];
-      next[4] = [];
+      log.warn('session reference enrichment skipped; sending raw link text', {
+        channel,
+        referenceCount: refs?.length ?? 0,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return stripOutboundSessionReferenceSideChannels(channel, args);
     }
     return next;
   }
@@ -67,12 +98,16 @@ export async function rewriteOutboundSessionReferences(
   if (queued.sessionRefs && queued.sessionRefs.length > 0) {
     try {
       nextItem.trustedSessionReferenceContexts = await resolveSessionReferences(queued.sessionRefs);
-    } catch {
+    } catch (error) {
       // The raw deep link remains in `text`.  Dropping both side-channel
       // fields keeps the target from reinterpreting a foreign session id in
       // its own account while still letting the Agent handle the link.
-      delete nextItem.sessionRefs;
-      delete nextItem.sessionReferencesRequireTrustedSnapshot;
+      log.warn('session reference enrichment skipped; sending raw link text', {
+        channel,
+        referenceCount: queued.sessionRefs.length,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return stripOutboundSessionReferenceSideChannels(channel, args);
     }
   }
   const next = [...args];

--- a/apps/desktop/src/main/device-link/outboundSessionReferences.ts
+++ b/apps/desktop/src/main/device-link/outboundSessionReferences.ts
@@ -45,7 +45,14 @@ export async function rewriteOutboundSessionReferences(
     if (!Array.isArray(args[3])) return args;
     const refs = args[3] as AgentInputQueuedMessage['sessionRefs'];
     const next = [...args];
-    next[4] = refs && refs.length > 0 ? await resolveSessionReferences(refs) : [];
+    try {
+      next[4] = refs && refs.length > 0 ? await resolveSessionReferences(refs) : [];
+    } catch {
+      // Preserve the edited text, but do not ask the target to trust an
+      // unresolved controller-side reference or reject the whole edit.
+      next[3] = [];
+      next[4] = [];
+    }
     return next;
   }
   if (!QUEUED_CHANNELS.has(channel)) return args;
@@ -58,7 +65,15 @@ export async function rewriteOutboundSessionReferences(
   // renderer 永远不能夹带可信正文；无论是否有 refs 都先清掉。
   delete nextItem.trustedSessionReferenceContexts;
   if (queued.sessionRefs && queued.sessionRefs.length > 0) {
-    nextItem.trustedSessionReferenceContexts = await resolveSessionReferences(queued.sessionRefs);
+    try {
+      nextItem.trustedSessionReferenceContexts = await resolveSessionReferences(queued.sessionRefs);
+    } catch {
+      // The raw deep link remains in `text`.  Dropping both side-channel
+      // fields keeps the target from reinterpreting a foreign session id in
+      // its own account while still letting the Agent handle the link.
+      delete nextItem.sessionRefs;
+      delete nextItem.sessionReferencesRequireTrustedSnapshot;
+    }
   }
   const next = [...args];
   next[itemIndex] = nextItem;

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -500,6 +500,32 @@ describe('AgentInputCoordinator trusted session reference snapshots', () => {
     expect(latestProjection(h.projections).error).toBeNull();
   });
 
+  it('sends a foreign session link as ordinary Agent text when history enrichment fails', async () => {
+    const h = createHarness();
+    h.resolveSessionReferences.mockRejectedValueOnce(new Error('session belongs to another account'));
+    const text = 'inspect cindy://session/foreign-session';
+
+    h.coordinator.enqueue('target-session', makeItem('quoted-foreign', text, {
+      sessionRefs: [{ sessionId: 'foreign-session' }],
+    }));
+    await flush();
+
+    expect(h.resolveSessionReferences).toHaveBeenCalledWith([
+      { sessionId: 'foreign-session' },
+    ]);
+    expect(h.sendToAgent).toHaveBeenCalledWith(
+      'target-session',
+      { type: 'user', content: text },
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(latestProjection(h.projections).error).toBeNull();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      'session reference enrichment skipped',
+      expect.objectContaining({ referenceCount: 1 }),
+    );
+  });
+
   it('clears a stale trusted snapshot on a full-content rewrite without refs', () => {
     const h = createHarness();
     const item = makeItem('quoted-content-rewrite', 'compare cindy://session/source-session', {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -2236,7 +2236,19 @@ export class AgentInputCoordinator {
     if (item.sessionReferencesRequireTrustedSnapshot) {
       throw new Error('Remote session reference snapshot is missing; edit and resend the message.');
     }
-    return this.deps.resolveSessionReferences?.(item.sessionRefs) ?? [];
+    try {
+      return await (this.deps.resolveSessionReferences?.(item.sessionRefs) ?? []);
+    } catch (error) {
+      // Session links are still useful as ordinary Agent-facing text when the
+      // referenced session belongs to another account, was deleted, or is
+      // temporarily unavailable.  Quoted history is an optional enrichment:
+      // fail closed on the history body, but do not fail the user's message.
+      log.warn('session reference enrichment skipped', {
+        referenceCount: item.sessionRefs.length,
+        error: errorMessage(error),
+      });
+      return [];
+    }
   }
 
   private isDispatchBoundaryBusy(sessionId: string, state: SessionInputState): boolean {

--- a/apps/mobile/src/__tests__/sessionReferences.test.ts
+++ b/apps/mobile/src/__tests__/sessionReferences.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   DeviceLinkError,
   DL_HISTORY_MESSAGES_CHANNEL,
@@ -24,6 +24,14 @@ import {
 // 文案已 i18n 化;固定 zh-CN 让字面量断言与语言环境解耦(全局 mock 默认 en-US)。
 beforeAll(async () => {
   await i18n.changeLanguage('zh-CN');
+});
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 function message(
@@ -74,6 +82,29 @@ describe('mobile session-reference links', () => {
       () => 'dev-source',
       'dev-target',
     )).resolves.toBe(item);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[session-references] trusted history unavailable; preserving raw link text',
+      expect.objectContaining({ phase: 'stored-snapshot' }),
+    );
+  });
+
+  it('does not reuse a stored steer projection when the target itself is unavailable', async () => {
+    const item = {
+      text: 'continue cindy://session/source',
+      sessionRefs: [{ sessionId: 'source', deviceId: 'dev-source' }],
+    };
+    const invoke = asInvoke(async (_deviceId, channel) => {
+      expect(channel).toBe(DL_SESSION_REFERENCE_CAPABILITY_CHANNEL);
+      throw new DeviceLinkError('DEVICE_OFFLINE', 'target offline');
+    });
+
+    await expect(prepareMobileQueuedSessionReferencesForSteer(
+      item,
+      invoke,
+      () => 'dev-source',
+      'dev-target',
+    )).rejects.toMatchObject({ code: 'SESSION_REFERENCE_OFFLINE' });
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it('extracts both schemes, anchors, source devices, and removes exact duplicates', () => {
@@ -168,6 +199,28 @@ describe('mobile session-reference links', () => {
       'target-old',
     )).resolves.toEqual({ text: 'compare cindy://session/source' });
     expect(invoke).toHaveBeenCalledTimes(1);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[session-references] trusted history unavailable; preserving raw link text',
+      expect.objectContaining({
+        phase: 'target-capability',
+        code: 'SESSION_REFERENCE_UNSUPPORTED',
+      }),
+    );
+  });
+
+  it('preserves target availability errors instead of treating them as source fallback', async () => {
+    const invoke = vi.fn(async (_deviceId: string, channel: string) => {
+      expect(channel).toBe(DL_SESSION_REFERENCE_CAPABILITY_CHANNEL);
+      throw new DeviceLinkError('DEVICE_OFFLINE', 'target offline');
+    });
+
+    await expect(prepareMobileQueuedSessionReferences(
+      { text: 'compare cindy://session/source' },
+      asInvoke(invoke),
+      () => 'source-device',
+      'target-offline',
+    )).rejects.toMatchObject({ code: 'SESSION_REFERENCE_OFFLINE' });
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it('falls back to raw link text when the source session is foreign', async () => {
@@ -193,6 +246,10 @@ describe('mobile session-reference links', () => {
       DL_SESSION_REFERENCE_CAPABILITY_CHANNEL,
       'local-db:sessions:get',
     ]);
+    expect(console.warn).toHaveBeenCalledWith(
+      '[session-references] trusted history unavailable; preserving raw link text',
+      expect.objectContaining({ phase: 'source-resolution' }),
+    );
   });
 
   it('probes a new target before resolving source history', async () => {

--- a/apps/mobile/src/__tests__/sessionReferences.test.ts
+++ b/apps/mobile/src/__tests__/sessionReferences.test.ts
@@ -154,7 +154,7 @@ describe('mobile session-reference links', () => {
     })).toBe('链接附近 · 4 条 · 已截断');
   });
 
-  it('rejects an old target before reading history from the source device', async () => {
+  it('falls back to raw link text when the target does not support references', async () => {
     const invoke = vi.fn(async (deviceId: string, channel: string) => {
       expect(deviceId).toBe('target-old');
       expect(channel).toBe(DL_SESSION_REFERENCE_CAPABILITY_CHANNEL);
@@ -166,8 +166,33 @@ describe('mobile session-reference links', () => {
       asInvoke(invoke),
       () => 'source-device',
       'target-old',
-    )).rejects.toMatchObject({ code: 'SESSION_REFERENCE_UNSUPPORTED' });
+    )).resolves.toEqual({ text: 'compare cindy://session/source' });
     expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to raw link text when the source session is foreign', async () => {
+    const invoke = vi.fn(async (_deviceId: string, channel: string) => {
+      if (channel === DL_SESSION_REFERENCE_CAPABILITY_CHANNEL) {
+        return { supported: true, version: 1 };
+      }
+      if (channel === 'local-db:sessions:get') return null;
+      throw new Error(`unexpected channel ${channel}`);
+    });
+
+    await expect(prepareMobileQueuedSessionReferences(
+      {
+        text: 'compare cindy://session/foreign',
+        sessionRefs: [{ sessionId: 'stale', deviceId: 'old-device' }],
+        sessionReferencesRequireTrustedSnapshot: true,
+      },
+      asInvoke(invoke),
+      () => 'source-device',
+      'target-new',
+    )).resolves.toEqual({ text: 'compare cindy://session/foreign' });
+    expect(invoke.mock.calls.map((call) => call[1])).toEqual([
+      DL_SESSION_REFERENCE_CAPABILITY_CHANNEL,
+      'local-db:sessions:get',
+    ]);
   });
 
   it('probes a new target before resolving source history', async () => {

--- a/apps/mobile/src/session/sessionReferences.ts
+++ b/apps/mobile/src/session/sessionReferences.ts
@@ -789,18 +789,30 @@ export async function resolveMobileSessionReferences(
  * This deliberately removes stale snapshots first, so editing a link away cannot retain
  * previously trusted history and steering a display-safe projection always re-reads source data.
  */
-async function prepareMobileQueuedSessionReferencesStrict<T extends MobileQueuedReferenceCarrier>(
+function stripMobileSessionReferenceSideChannels<T extends MobileQueuedReferenceCarrier>(
   item: T,
-  invoke: RemoteInvoke,
-  deviceIdForSession: (sessionId: string) => string | undefined,
-  targetDeviceId: string,
-): Promise<T> {
-  const refs = extractMobileSessionReferences(item.text, deviceIdForSession, item.sessionRefs);
+): T {
   const prepared = { ...item };
   delete prepared.sessionRefs;
   delete prepared.trustedSessionReferenceContexts;
   delete prepared.sessionReferencesRequireTrustedSnapshot;
-  if (refs.length === 0) return prepared;
+  return prepared;
+}
+
+function warnMobileSessionReferenceFallback(
+  phase: 'target-capability' | 'source-resolution' | 'stored-snapshot',
+  error: unknown,
+): void {
+  console.warn('[session-references] trusted history unavailable; preserving raw link text', {
+    phase,
+    code: error instanceof MobileSessionReferenceError ? error.code : 'UNKNOWN',
+  });
+}
+
+async function assertMobileTargetSessionReferenceCapability(
+  invoke: RemoteInvoke,
+  targetDeviceId: string,
+): Promise<void> {
   try {
     const capability = await invoke<unknown>(
       targetDeviceId,
@@ -847,9 +859,6 @@ async function prepareMobileQueuedSessionReferencesStrict<T extends MobileQueued
       `The target device is unavailable: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
-  prepared.sessionRefs = refs;
-  prepared.trustedSessionReferenceContexts = await resolveMobileSessionReferences(refs, invoke);
-  return prepared;
 }
 
 /**
@@ -865,18 +874,28 @@ export async function prepareMobileQueuedSessionReferences<T extends MobileQueue
   deviceIdForSession: (sessionId: string) => string | undefined,
   targetDeviceId: string,
 ): Promise<T> {
+  const refs = extractMobileSessionReferences(item.text, deviceIdForSession, item.sessionRefs);
+  const prepared = stripMobileSessionReferenceSideChannels(item);
+  if (refs.length === 0) return prepared;
   try {
-    return await prepareMobileQueuedSessionReferencesStrict(
-      item,
-      invoke,
-      deviceIdForSession,
-      targetDeviceId,
-    );
-  } catch {
-    const prepared = { ...item };
-    delete prepared.sessionRefs;
-    delete prepared.trustedSessionReferenceContexts;
-    delete prepared.sessionReferencesRequireTrustedSnapshot;
+    await assertMobileTargetSessionReferenceCapability(invoke, targetDeviceId);
+  } catch (error) {
+    if (!(error instanceof MobileSessionReferenceError) ||
+        error.code !== 'SESSION_REFERENCE_UNSUPPORTED') {
+      throw error;
+    }
+    warnMobileSessionReferenceFallback('target-capability', error);
+    return prepared;
+  }
+  try {
+    const contexts = await resolveMobileSessionReferences(refs, invoke);
+    return {
+      ...prepared,
+      sessionRefs: refs,
+      trustedSessionReferenceContexts: contexts,
+    };
+  } catch (error) {
+    warnMobileSessionReferenceFallback('source-resolution', error);
     return prepared;
   }
 }
@@ -896,19 +915,32 @@ export async function prepareMobileQueuedSessionReferencesForSteer<T extends Mob
   deviceIdForSession: (sessionId: string) => string | undefined,
   targetDeviceId: string,
 ): Promise<T> {
+  const refs = extractMobileSessionReferences(item.text, deviceIdForSession, item.sessionRefs);
+  const prepared = stripMobileSessionReferenceSideChannels(item);
+  if (refs.length === 0) return prepared;
   try {
-    return await prepareMobileQueuedSessionReferencesStrict(
-      item,
-      invoke,
-      deviceIdForSession,
-      targetDeviceId,
-    );
+    await assertMobileTargetSessionReferenceCapability(invoke, targetDeviceId);
   } catch (error) {
-    if (canFallbackToStoredMobileSessionReferenceSnapshot(error)) return item;
-    const prepared = { ...item };
-    delete prepared.sessionRefs;
-    delete prepared.trustedSessionReferenceContexts;
-    delete prepared.sessionReferencesRequireTrustedSnapshot;
+    if (!(error instanceof MobileSessionReferenceError) ||
+        error.code !== 'SESSION_REFERENCE_UNSUPPORTED') {
+      throw error;
+    }
+    warnMobileSessionReferenceFallback('target-capability', error);
+    return prepared;
+  }
+  try {
+    const contexts = await resolveMobileSessionReferences(refs, invoke);
+    return {
+      ...prepared,
+      sessionRefs: refs,
+      trustedSessionReferenceContexts: contexts,
+    };
+  } catch (error) {
+    if (canFallbackToStoredMobileSessionReferenceSnapshot(error)) {
+      warnMobileSessionReferenceFallback('stored-snapshot', error);
+      return item;
+    }
+    warnMobileSessionReferenceFallback('source-resolution', error);
     return prepared;
   }
 }

--- a/apps/mobile/src/session/sessionReferences.ts
+++ b/apps/mobile/src/session/sessionReferences.ts
@@ -789,7 +789,7 @@ export async function resolveMobileSessionReferences(
  * This deliberately removes stale snapshots first, so editing a link away cannot retain
  * previously trusted history and steering a display-safe projection always re-reads source data.
  */
-export async function prepareMobileQueuedSessionReferences<T extends MobileQueuedReferenceCarrier>(
+async function prepareMobileQueuedSessionReferencesStrict<T extends MobileQueuedReferenceCarrier>(
   item: T,
   invoke: RemoteInvoke,
   deviceIdForSession: (sessionId: string) => string | undefined,
@@ -852,6 +852,35 @@ export async function prepareMobileQueuedSessionReferences<T extends MobileQueue
   return prepared;
 }
 
+/**
+ * Prepare optional trusted history for a queued mobile message.
+ *
+ * A session link may point at another account or an unavailable device. In
+ * that case the safe fallback is the already-present raw link text: omit all
+ * trusted-reference side channels and let the Agent handle the link itself.
+ */
+export async function prepareMobileQueuedSessionReferences<T extends MobileQueuedReferenceCarrier>(
+  item: T,
+  invoke: RemoteInvoke,
+  deviceIdForSession: (sessionId: string) => string | undefined,
+  targetDeviceId: string,
+): Promise<T> {
+  try {
+    return await prepareMobileQueuedSessionReferencesStrict(
+      item,
+      invoke,
+      deviceIdForSession,
+      targetDeviceId,
+    );
+  } catch {
+    const prepared = { ...item };
+    delete prepared.sessionRefs;
+    delete prepared.trustedSessionReferenceContexts;
+    delete prepared.sessionReferencesRequireTrustedSnapshot;
+    return prepared;
+  }
+}
+
 /** Reuse the target's trusted snapshot only when the source cannot currently be read. */
 export function canFallbackToStoredMobileSessionReferenceSnapshot(error: unknown): boolean {
   return error instanceof MobileSessionReferenceError && (
@@ -868,14 +897,18 @@ export async function prepareMobileQueuedSessionReferencesForSteer<T extends Mob
   targetDeviceId: string,
 ): Promise<T> {
   try {
-    return await prepareMobileQueuedSessionReferences(
+    return await prepareMobileQueuedSessionReferencesStrict(
       item,
       invoke,
       deviceIdForSession,
       targetDeviceId,
     );
   } catch (error) {
-    if (!canFallbackToStoredMobileSessionReferenceSnapshot(error)) throw error;
-    return item;
+    if (canFallbackToStoredMobileSessionReferenceSnapshot(error)) return item;
+    const prepared = { ...item };
+    delete prepared.sessionRefs;
+    delete prepared.trustedSessionReferenceContexts;
+    delete prepared.sessionReferencesRequireTrustedSnapshot;
+    return prepared;
   }
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

粘贴任务链接时，如果对应任务不属于当前账号、已删除或暂时不可访问，不再因为可信历史补全失败而拒绝整条消息。用户主动输入的链接原文仍会发送给 Agent；只有自动读取并注入任务历史的增强能力会被跳过。

同时覆盖 Desktop 本地发送、Desktop Device Link 远程控制和 Mobile 远程发送路径。目标设备版本不支持可信引用字段时，两端控制入口都会移除 side channel 并发送纯链接文本；目标设备离线、拒绝访问或仍在启动时则保留原错误，不把真正的投递失败误判成可降级的引用失败。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈：粘贴其他账号的任务链接时不应报错，链接应继续发送给 Agent
- 本 PR 包含：会话引用解析失败或目标不支持可信引用时降级为原始文本；清除无法信任的引用 side channel；记录降级日志；Desktop / Mobile / Device Link 回归测试
- 明确不包含：服务端改动、跨账号任务内容读取、链接访问权限变更、UI 改动
- 用户可见变化：粘贴无法解析的任务链接后消息仍正常发送，Agent 能看到完整链接原文；旧目标设备也按纯文本处理链接
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及；本 PR 只修改 main/device-link/mobile 的非视觉消息处理逻辑

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-allow-foreign-task-link
结果：通过，GATE_EXIT=0（仓库根完整 pnpm test:unit 门禁；review 修复后重跑）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/device-link/__tests__/outboundSessionReferences.test.ts src/main/device-link/__tests__/sessionReferenceCompatibility.test.ts src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
结果：通过，3 个测试文件、255 个测试

pnpm --filter mobile exec vitest run src/__tests__/sessionReferences.test.ts
结果：通过，31 个测试
```

### 手工验证

不涉及；本次是非视觉的消息投递与可信上下文降级逻辑，已由本地、远程控制及 Mobile 路径的单元测试覆盖。

### 未执行的验证

未做 Desktop / Mobile 实机操作验证；没有 UI 或原生层改动。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 本地消息、Desktop Device Link 远程消息、Mobile 远程消息的任务引用解析和目标能力探测路径。未修改 wire schema；旧目标设备不能消费引用字段时会收到不带 side channel 的普通文本。目标离线、拒绝访问与启动竞态仍阻断投递。权限边界保持不变：不会自动读取或注入其他账号的任务历史，只发送用户主动输入的链接文本。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复原先的拒绝发送行为；无数据库、配置或持久数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
