### PR TITLE
fix(desktop): hook 会话标题用 source.userText, 不吃 prompt 里的上下文块

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -418,6 +418,41 @@ describe('dispatcher 核心语义', () => {
     });
   });
 
+  it('标题用 source.userText, 不吃 prompt 里 server 挂的 thread 上下文块', async () => {
+    // server 会把 thread 上下文拼进 prompt(Slack 的 injectThreadContext 一直
+    // 如此, X 也已接上)。按 prompt 前 24 字取标题的话, 整条 thread 派出来的
+    // 会话标题全是 `[Team-slack] <thread_context> [@alice…`, 既看不出任务是
+    // 什么, 同一 thread 里还条条雷同。
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({ runner: fr.runner });
+    const c = collector();
+
+    d.handleDispatch(
+      'conn-1',
+      dispatch({
+        prompt: '<thread_context>\n[@alice] 为啥大厂都自研 agent\n</thread_context>\n\n以上仅供参考\n\n你来解释下这个问题',
+        source: { im: 'x', userText: '你来解释下这个问题' },
+      }),
+      c.send,
+    );
+    await tick();
+
+    expect(fr.calls[0]).toMatchObject({ title: '[X] 你来解释下这个问题' });
+    // prompt 本身照旧整份交给 agent —— 上下文不能因为标题的取舍被砍掉
+    expect(fr.calls[0]?.prompt).toContain('<thread_context>');
+  });
+
+  it('source.userText 缺失或为空时回退 prompt(老 server / 纯 @ 无正文)', async () => {
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({ runner: fr.runner });
+    const c = collector();
+
+    d.handleDispatch('conn-1', dispatch({ source: { im: 'x', userText: '   ' } }), c.send);
+    await tick();
+
+    expect(fr.calls[0]).toMatchObject({ title: '[X] 干活' });
+  });
+
   it('同 key 第二次 dispatch 复用同一 session(铁律)', async () => {
     const bindings = memoryBindings();
     const sessions: Record<string, { workingDir: string; usable: boolean }> = {};

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -449,6 +449,13 @@ export function normalizeTaskSource(source: TaskSource): TaskSource {
  * (`[XD Inc.·Slack·DM] ...`)—— 多绑定设备上区分「哪个 workspace 派来的」,
  * team 名在前便于列表扫读; 放括号内保持标题统一以 `[` 开头对齐
  * (老 server / 单绑定不下发, 无 teamName 分支格式不变)。
+ *
+ * **摘要取 `source.userText`, 而不是 `prompt`。** 二者通常一致, 但 server 会在
+ * prompt 前面挂 thread 上下文块(Slack 的 `injectThreadContext` 一直如此, X 也
+ * 刚接上): 那时 `prompt` 开头是 `<thread_context>` 加一串别人的发言, 截前 24
+ * 字得到的标题既看不出是什么任务, 同一 thread 里还条条雷同。`userText` 正是
+ * server 为 UI 单独下发的干净原文(协议 `TaskSource.userText`)。
+ * 老 server 不下发时回退 prompt, 行为与此前一致。
  */
 export function buildHookSessionTitle(
   providerName: string,
@@ -1514,6 +1521,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     const providerName =
       payload.source?.im?.trim() || (colon > 0 ? payload.externalKey.slice(0, colon) : config.name);
     const bareKey = colon > 0 ? payload.externalKey.slice(colon + 1) : payload.externalKey;
+    // 标题摘要用 server 单独下发的干净原文, 而不是 prompt —— prompt 可能带
+    // thread 上下文块(见 buildHookSessionTitle 注释)。空串按"没有"处理:
+    // 纯 @ 无正文时 server 的 userText 为空, 而 prompt 仍是原文, 回退它更有信息。
+    const sourceUserText = payload.source?.userText ?? '';
+    const titleText = sourceUserText.trim().length > 0 ? sourceUserText : payload.prompt;
     return {
       run: {
         sessionId,
@@ -1528,7 +1540,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         ...(payload.workspace ? { workspaceAlias: payload.workspace } : {}),
         title: buildHookSessionTitle(
           providerName,
-          payload.prompt,
+          titleText,
           bareKey,
           payload.source?.teamName ??
             (payload.source?.im === 'telegram' || payload.source?.im === 'x'


### PR DESCRIPTION
## 这次改了什么

### 摘要

hook 会话的标题摘要一直取 `payload.prompt` 的前 24 字,而 **server 会把 thread 上下文拼进 prompt** —— Slack 的 `injectThreadContext` 一直如此。于是从已有 thread 派出来的会话,标题长这样:

```
[Slack] <thread_context> [@alice…
```

既看不出这条任务要干什么,同一条 thread 派出的会话在列表里还**条条雷同**,根本分不开。

`source.userText` 正是 server 为 UI 单独下发的干净原文(协议 `TaskSource.userText`),UI 渲染本来就用它,唯独标题漏了。改成优先取它。

空串按「没有」处理、回退 `prompt`,而不是直接落到 bareKey:纯 @ 无正文时 server 的 `userText` 为空,而 `prompt` 仍是原文,回退它更有信息。老 server 不下发该字段时行为与此前完全一致。

**这是既有缺陷,不是新引入的** —— Slack 现在就是这个样子。发现它是因为 xindong/cindy-server 侧正在给 X 接上同样的 prompt 注入(把 thread 回复链喂给 agent),那个改动会让 X 立刻出现同样的形态。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:makecindy/cindy#691(X bot);对侧 xindong/cindy-server 的 X thread 上下文修复
- 本 PR 包含:`buildHookSessionTitle` 的取值改用 `source.userText`(带空串回退)+ 两条派发路径回归用例
- 明确不包含:server 侧的 prompt 注入本身(在 cindy-server 仓);`threadContext` 的 UI 渲染不动
- 用户可见变化:**IM 驱动的会话标题**。此前从已有 thread 派出的 Slack 会话标题是 `<thread_context> …`,现在是用户那句话。历史会话标题不回填(标题只在建会话时写一次)。
- 是否存在 breaking change:无

### UI 变化

不涉及:只改会话标题字符串的**取值来源**,不动任何组件、布局、样式或文案措辞。标题格式(`[Provider] 摘要`、`·DM`、teamName 首段)与截断长度均未变。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/hook-control/__tests__/dispatcher.test.ts --pool=threads
结果:Tests 101 passed (101)  ← 含本 PR 新增 2 条

pnpm --filter desktop run typecheck
结果:通过,无 error TS

仓库根单测门禁(git skill 的 run-unit-gate.sh,非裸跑)
结果:GATE_EXIT=0,全量 FAIL 行 0 处;apps/desktop unit PASS (57.0s)
```

新增的两条用例走的是**派发路径**而不是只测纯函数 —— 缺陷出在「调用方传了哪个字符串」,只测 `buildHookSessionTitle` 本身抓不到:

1. prompt 带 `<thread_context>` 块 + `source.userText` 时,标题取 userText;同时断言 `prompt` **整份原样**交给 agent(标题的取舍不能反过来砍掉上下文)。
2. `userText` 为空白串时回退 prompt。

### 手工验证

不涉及:X 的对侧 server 改动尚未上线,本地跑不出「prompt 带上下文块」的真实派发;缺陷形态与修复效果由上述派发路径用例覆盖。

### 未执行的验证

- 未在真实 Slack thread 上回归。原因:需要一个已有历史消息的 thread + 已绑定的 workspace,当前环境不具备;该路径与用例走的是同一段代码(`resolveTarget` → `buildHookSessionTitle`)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

`source.userText` 是**既有**协议字段,本 PR 只是多读一处,不新增、不修改协议,老 server 不下发时走回退分支。

### 影响与回滚

- 影响范围:仅 IM(Slack / Telegram / X)驱动**新建**会话时的标题字符串。不影响 prompt、不影响 UI 渲染、不影响已有会话。
- 回滚 / 降级方式:revert 即可,无数据与状态残留。

### 上线顺序(供合并时参考)

xindong/cindy-server 侧给 X 接 prompt 注入的改动**依赖本 PR 先上或同时上**;否则 server 一发,X 的会话标题会立刻变成 `[X] <thread_context> …`。本 PR 单独合并也完全安全(它修的是 Slack 现存的问题)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`,见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(本 PR 不涉及 UI,已写明理由)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(改动集中在 `buildHookSessionTitle` 的函数注释,已写明为什么取 userText 而非 prompt)
- [x] 已确认测试结果或说明未执行原因
