### PR TITLE
fix(desktop): 补齐 API key 输入的明文切换

### DIFF
--- a/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
@@ -5,6 +5,8 @@
  *   1. entry={kind:'preset',presetId}:presets 异步载入后直达表单步(step 2,
  *      名称预填预设名),一次性消费。
  *   2. presetId 在目录里不存在 → 回落目录第一步,不假装直达。
+ *   3. API Key 输入默认遮罩,但必须能显形核对——粘错 key / 多余空格 / 前缀不对
+ *      在遮罩下查不出来。向导曾漏掉这个切换,只有编辑弹窗有(见 SettingsTextInput)。
  */
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -174,6 +176,20 @@ describe('AddProviderWizard — preset 直达', () => {
     expect(screen.getByPlaceholderText('sk-…')).not.toBeNull();
     // 不在目录步(搜索框只在 step 1)。
     expect(screen.queryByPlaceholderText('settings.providers.wizard.searchPlaceholder')).toBeNull();
+  });
+
+  it('API Key 默认遮罩,eye 能切明文再切回(粘贴后核对)', async () => {
+    renderWizard('deepseek');
+
+    const keyInput = await screen.findByPlaceholderText('sk-…');
+    expect(keyInput.getAttribute('type')).toBe('password');
+
+    // 遮罩态按钮语义是「显示密钥」,点击后翻转为「隐藏密钥」。
+    fireEvent.click(screen.getByLabelText('settings.apiKey.showKey'));
+    expect(keyInput.getAttribute('type')).toBe('text');
+
+    fireEvent.click(screen.getByLabelText('settings.apiKey.hideKey'));
+    expect(keyInput.getAttribute('type')).toBe('password');
   });
 
   it('OAuth 授权步提供「改用 API Key 接入」→ 切到官方 API 预设表单', async () => {

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
@@ -183,6 +183,9 @@ describe('AddProviderWizard — preset 直达', () => {
 
     const keyInput = await screen.findByPlaceholderText('sk-…');
     expect(keyInput.getAttribute('type')).toBe('password');
+    // 密钥框要挡住密码管理器建议与拼写红线(普通文本字段则保留浏览器默认,不禁用)。
+    expect(keyInput.getAttribute('autocomplete')).toBe('off');
+    expect(keyInput.getAttribute('spellcheck')).toBe('false');
 
     // 遮罩态按钮语义是「显示密钥」,点击后翻转为「隐藏密钥」。
     fireEvent.click(screen.getByLabelText('settings.apiKey.showKey'));

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
@@ -195,6 +195,17 @@ describe('AddProviderWizard — preset 直达', () => {
     expect(keyInput.getAttribute('type')).toBe('password');
   });
 
+  it('密钥框底色是 DESIGN.md §4 的 --surface-elevated,不是 settings 的 ivory', async () => {
+    renderWizard('deepseek');
+
+    // 共享化时把底色顺手换成 --settings-input-bg 会退化:该 token 解析到
+    // --surface-card-ivory,而 ProvidersSection 的卡片本身就是这个值,行内密钥框会与卡片
+    // 同色、只剩边框。DESIGN.md §4 input/text 规定 fill = --surface-elevated。
+    const cls = (await screen.findByPlaceholderText('sk-…')).className;
+    expect(cls).toContain('bg-[var(--surface-elevated)]');
+    expect(cls).not.toContain('bg-[var(--settings-input-bg)]');
+  });
+
   it('OAuth 授权步提供「改用 API Key 接入」→ 切到官方 API 预设表单', async () => {
     render(
       React.createElement(AddProviderWizard, {

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -30,6 +30,7 @@ import { isChatGptConnectionConnected, useCodexAuth } from '@/hooks/useCodexAuth
 import { useProviderOAuthDeviceCode } from '@/hooks/useProviderOAuthDeviceCode';
 import { hasProviderLogo, ProviderLogoMark } from '@/components/icons/ProviderLogoMark';
 import { OAuthDeviceCodeCard } from './OAuthDeviceCodeCard';
+import { SettingsTextInput } from './SettingsTextInput';
 
 import {
   isLoopbackProviderUrl,
@@ -1231,18 +1232,7 @@ export function AddProviderWizard({
                 <label className="text-12 font-medium" style={{ color: 'var(--text-secondary)' }}>
                   {t('settings.providers.custom.fields.apiKey')}
                 </label>
-                <input
-                  type="password"
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  autoComplete="off"
-                  className="h-9 rounded-full border px-4 font-mono text-13 outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
-                  style={{
-                    borderColor: 'var(--border-default)',
-                    backgroundColor: 'var(--surface-elevated)',
-                    color: 'var(--settings-section-title)',
-                  }}
-                />
+                <SettingsTextInput value={apiKey} onChange={setApiKey} size="md" mono secret />
               </div>
             </div>
           )}
@@ -1270,18 +1260,13 @@ export function AddProviderWizard({
                   <label className="text-12 font-medium" style={{ color: 'var(--text-secondary)' }}>
                     {t('settings.providers.custom.fields.apiKey')}
                   </label>
-                  <input
-                    type="password"
+                  <SettingsTextInput
                     value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
+                    onChange={setApiKey}
                     placeholder="sk-…"
-                    autoComplete="off"
-                    className="h-9 rounded-full border px-4 font-mono text-13 outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
-                    style={{
-                      borderColor: 'var(--border-default)',
-                      backgroundColor: 'var(--surface-elevated)',
-                      color: 'var(--settings-section-title)',
-                    }}
+                    size="md"
+                    mono
+                    secret
                   />
                 </div>
               ) : (

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -7,23 +7,12 @@
  *
  * 「提供商 ID」内部句柄由显示名自动 slug 派生 + 去重,对用户隐藏(密钥名/文件名不能含 . 或 /)。
  * 配置经 maker IPC 入 localDb；密钥按 runtime 经 safeStorage 存(见 lib/customProviders)。
- * 编辑态密钥遮罩、留空 = 不改；id 不可改。颜色全走主题 token。
+ * 编辑态回填已存密钥(默认遮罩,eye 可显形核对)、留空 = 不改；id 不可改。颜色全走主题 token。
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Check,
-  ChevronDown,
-  Eye,
-  EyeOff,
-  Plug,
-  Plus,
-  RefreshCw,
-  Sparkles,
-  Trash2,
-  X,
-} from 'lucide-react';
+import { Check, ChevronDown, Plug, Plus, RefreshCw, Sparkles, Trash2, X } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
@@ -61,6 +50,7 @@ import type {
   ProviderRuntimeModelConfig,
   ProviderWireProtocol,
 } from '@cindy/model-providers';
+import { SettingsTextInput } from './SettingsTextInput';
 
 const AGENTS: AgentKind[] = ['claude-code', 'codex'];
 
@@ -167,43 +157,6 @@ function isCommittableWindowText(text: string): boolean {
   if (!/^[0-9]+(?:[,_ ][0-9]+)*$/.test(trimmed)) return false;
   const parsed = BigInt(trimmed.replace(/[,_ ]/g, ''));
   return parsed > 0n && parsed <= BigInt(Number.MAX_SAFE_INTEGER);
-}
-
-function TextInput({
-  value,
-  onChange,
-  onBlur,
-  placeholder,
-  type = 'text',
-  trailing,
-}: {
-  value: string;
-  onChange: (v: string) => void;
-  onBlur?: () => void;
-  placeholder?: string;
-  type?: string;
-  trailing?: React.ReactNode;
-}) {
-  return (
-    <div className="relative">
-      <input
-        type={type}
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        onBlur={onBlur}
-        placeholder={placeholder}
-        className={cn(
-          // 单行输入按设计规范走药丸圆角(DESIGN.md §4-5:9999px,明令禁止 10px)。
-          'h-[40px] w-full rounded-full pl-[12px] text-14 outline-none transition-colors',
-          trailing ? 'pr-9' : 'pr-[12px]',
-          'text-[var(--settings-input-text)] placeholder:text-[var(--settings-input-placeholder)]',
-          'border border-[var(--settings-input-border)] bg-[var(--settings-input-bg)] focus:border-[var(--settings-input-border-focus)]',
-        )}
-        style={{ userSelect: 'text', WebkitUserSelect: 'text' }}
-      />
-      {trailing}
-    </div>
-  );
 }
 
 /**
@@ -315,7 +268,6 @@ export function CustomProviderDialog({
   const [activeTab, setActiveTab] = useState<AgentKind>(
     () => (initial && VISIBLE_AGENTS.find((a) => initial.runtimes[a])) || 'claude-code',
   );
-  const [showKey, setShowKey] = useState(false);
   const [hasKey, setHasKey] = useState<Record<AgentKind, boolean>>({
     'claude-code': false,
     codex: false,
@@ -1006,7 +958,7 @@ export function CustomProviderDialog({
           {/* 显示名称（共享） */}
           <div className="flex flex-col gap-[7px]">
             <FieldLabel>{t('settings.providers.custom.fields.name')}</FieldLabel>
-            <TextInput
+            <SettingsTextInput
               value={name}
               onChange={setName}
               placeholder={t('settings.providers.custom.fields.namePlaceholder')}
@@ -1086,7 +1038,7 @@ export function CustomProviderDialog({
                     <FieldLabel>
                       {t(`settings.providers.custom.authMode.fields.${field}`)}
                     </FieldLabel>
-                    <TextInput
+                    <SettingsTextInput
                       value={oauthFields[field]}
                       onChange={(v) => setOauthFields((prev) => ({ ...prev, [field]: v }))}
                       placeholder={ph}
@@ -1195,7 +1147,7 @@ export function CustomProviderDialog({
             {/* 基础 URL */}
             <div className="flex flex-col gap-[7px]">
               <FieldLabel>{t('settings.providers.custom.fields.baseUrl')}</FieldLabel>
-              <TextInput
+              <SettingsTextInput
                 value={f.baseUrl}
                 onChange={(v) => patch(activeTab, (x) => ({ ...x, baseUrl: v }))}
                 placeholder={t('settings.providers.custom.fields.baseUrlPlaceholder')}
@@ -1205,7 +1157,7 @@ export function CustomProviderDialog({
             {/* 精确推理路径：给非标准兼容端点使用；留空仍按所选协议推导。 */}
             <div className="flex flex-col gap-[7px]">
               <FieldLabel>{t('settings.providers.custom.fields.requestPath')}</FieldLabel>
-              <TextInput
+              <SettingsTextInput
                 value={f.requestPath}
                 onChange={(v) => patch(activeTab, (x) => ({ ...x, requestPath: v }))}
                 placeholder={
@@ -1238,23 +1190,12 @@ export function CustomProviderDialog({
                     </span>
                   )}
                 </div>
-                <TextInput
+                <SettingsTextInput
                   value={f.apiKey}
                   onChange={(v) => patch(activeTab, (x) => ({ ...x, apiKey: v }))}
                   placeholder={keyPlaceholder}
-                  type={showKey ? 'text' : 'password'}
-                  trailing={
-                    <button
-                      type="button"
-                      onClick={() => setShowKey((v) => !v)}
-                      className="absolute right-[12px] top-1/2 -translate-y-1/2 text-[var(--settings-eye-icon)] transition-colors hover:text-[var(--settings-eye-icon-hover)]"
-                      aria-label={
-                        showKey ? t('settings.apiKey.hideKey') : t('settings.apiKey.showKey')
-                      }
-                    >
-                      {showKey ? <Eye size={16} /> : <EyeOff size={16} />}
-                    </button>
-                  }
+                  mono
+                  secret
                 />
                 <span className="text-12 text-[var(--text-tertiary)]">
                   {t('settings.providers.custom.fields.apiKeyHelp')}
@@ -1291,7 +1232,7 @@ export function CustomProviderDialog({
                   {f.models.map((m, i) => (
                     <div key={i} className="flex items-center gap-2">
                       <div className="flex-1">
-                        <TextInput
+                        <SettingsTextInput
                           value={m.id}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({
@@ -1305,7 +1246,7 @@ export function CustomProviderDialog({
                         />
                       </div>
                       <div className="flex-1">
-                        <TextInput
+                        <SettingsTextInput
                           value={m.name}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({
@@ -1324,7 +1265,7 @@ export function CustomProviderDialog({
                             只接受正整数(允许逗号/下划线/空格做分隔),其它字符直接
                             拒绝本次变更(保持原值)——绝不剥字符再拼数字,-5 / 1e6 /
                             262144.9 这类输入不得被静默纠正成另一个合法值(review P1)。 */}
-                        <TextInput
+                        <SettingsTextInput
                           value={
                             windowDrafts[`${activeTab}:${i}`]
                             ?? (m.contextWindow != null ? String(m.contextWindow) : '')
@@ -1426,7 +1367,7 @@ export function CustomProviderDialog({
                   {f.headers.map((h, i) => (
                     <div key={i} className="flex items-center gap-2">
                       <div className="flex-1">
-                        <TextInput
+                        <SettingsTextInput
                           value={h.name}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({
@@ -1438,7 +1379,7 @@ export function CustomProviderDialog({
                         />
                       </div>
                       <div className="flex-1">
-                        <TextInput
+                        <SettingsTextInput
                           value={h.value}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -8,6 +8,10 @@
  * 「提供商 ID」内部句柄由显示名自动 slug 派生 + 去重,对用户隐藏(密钥名/文件名不能含 . 或 /)。
  * 配置经 maker IPC 入 localDb；密钥按 runtime 经 safeStorage 存(见 lib/customProviders)。
  * 编辑态回填已存密钥(默认遮罩,eye 可显形核对)、留空 = 不改；id 不可改。颜色全走主题 token。
+ *
+ * 本弹窗的输入统一传 `surface="ivory"`：面板是白色(`--surface-elevated`),ivory 底给出 fill
+ * 抬升,这是收敛进 SettingsTextInput 之前就有的底色,原样保留。共享组件的默认底色是
+ * DESIGN.md §4 规定的 `--surface-elevated`(压在 ivory settings 卡上的输入必须用它)。
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -959,6 +963,7 @@ export function CustomProviderDialog({
           <div className="flex flex-col gap-[7px]">
             <FieldLabel>{t('settings.providers.custom.fields.name')}</FieldLabel>
             <SettingsTextInput
+              surface="ivory"
               value={name}
               onChange={setName}
               placeholder={t('settings.providers.custom.fields.namePlaceholder')}
@@ -1039,6 +1044,7 @@ export function CustomProviderDialog({
                       {t(`settings.providers.custom.authMode.fields.${field}`)}
                     </FieldLabel>
                     <SettingsTextInput
+                      surface="ivory"
                       value={oauthFields[field]}
                       onChange={(v) => setOauthFields((prev) => ({ ...prev, [field]: v }))}
                       placeholder={ph}
@@ -1148,6 +1154,7 @@ export function CustomProviderDialog({
             <div className="flex flex-col gap-[7px]">
               <FieldLabel>{t('settings.providers.custom.fields.baseUrl')}</FieldLabel>
               <SettingsTextInput
+                surface="ivory"
                 value={f.baseUrl}
                 onChange={(v) => patch(activeTab, (x) => ({ ...x, baseUrl: v }))}
                 placeholder={t('settings.providers.custom.fields.baseUrlPlaceholder')}
@@ -1158,6 +1165,7 @@ export function CustomProviderDialog({
             <div className="flex flex-col gap-[7px]">
               <FieldLabel>{t('settings.providers.custom.fields.requestPath')}</FieldLabel>
               <SettingsTextInput
+                surface="ivory"
                 value={f.requestPath}
                 onChange={(v) => patch(activeTab, (x) => ({ ...x, requestPath: v }))}
                 placeholder={
@@ -1191,6 +1199,7 @@ export function CustomProviderDialog({
                   )}
                 </div>
                 <SettingsTextInput
+                  surface="ivory"
                   value={f.apiKey}
                   onChange={(v) => patch(activeTab, (x) => ({ ...x, apiKey: v }))}
                   placeholder={keyPlaceholder}
@@ -1233,6 +1242,7 @@ export function CustomProviderDialog({
                     <div key={i} className="flex items-center gap-2">
                       <div className="flex-1">
                         <SettingsTextInput
+                          surface="ivory"
                           value={m.id}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({
@@ -1247,6 +1257,7 @@ export function CustomProviderDialog({
                       </div>
                       <div className="flex-1">
                         <SettingsTextInput
+                          surface="ivory"
                           value={m.name}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({
@@ -1266,6 +1277,7 @@ export function CustomProviderDialog({
                             拒绝本次变更(保持原值)——绝不剥字符再拼数字,-5 / 1e6 /
                             262144.9 这类输入不得被静默纠正成另一个合法值(review P1)。 */}
                         <SettingsTextInput
+                          surface="ivory"
                           value={
                             windowDrafts[`${activeTab}:${i}`]
                             ?? (m.contextWindow != null ? String(m.contextWindow) : '')
@@ -1368,6 +1380,7 @@ export function CustomProviderDialog({
                     <div key={i} className="flex items-center gap-2">
                       <div className="flex-1">
                         <SettingsTextInput
+                          surface="ivory"
                           value={h.name}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({
@@ -1380,6 +1393,7 @@ export function CustomProviderDialog({
                       </div>
                       <div className="flex-1">
                         <SettingsTextInput
+                          surface="ivory"
                           value={h.value}
                           onChange={(v) =>
                             patch(activeTab, (x) => ({

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -54,6 +54,7 @@ import {
 import { CustomProviderDialog } from './CustomProviderDialog';
 import { AddProviderWizard, type WizardEntry } from './AddProviderWizard';
 import { OAuthDeviceCodeCard } from './OAuthDeviceCodeCard';
+import { SettingsTextInput } from './SettingsTextInput';
 import { buildUnionRows, UnifiedModelList } from './UnifiedModelList';
 import { AnthropicMark } from '@/components/icons/AnthropicMark';
 import { OpenAIMark } from '@/components/icons/OpenAIMark';
@@ -604,18 +605,14 @@ function ImageApiKeyRow({
         </>
       ) : (
         <>
-          <input
-            type="password"
+          <SettingsTextInput
             value={draftKey}
-            onChange={(e) => setDraftKey(e.target.value)}
-            autoComplete="off"
+            onChange={setDraftKey}
             placeholder={t('settings.providers.imagesKey.placeholder')}
-            className="h-8 min-w-0 flex-1 rounded-full border px-3 font-mono text-12 outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
-            style={{
-              borderColor: 'var(--border-default)',
-              backgroundColor: 'var(--surface-elevated)',
-              color: 'var(--settings-section-title)',
-            }}
+            size="sm"
+            mono
+            secret
+            className="min-w-0 flex-1"
           />
           <PillButton
             label={t('settings.providers.imagesKey.save')}
@@ -836,7 +833,9 @@ function GenericOAuthHeader({
  * 内置 API-key 供应商详情头(如 Gemini 图像来源,2026-07 图像多来源)。
  * 连接态 = key 已存(provider-service builtinApiKeyConnected);「更换」重写 key,
  * 「断开」删除 key(safeStorage),断开后左栏行按既有契约消失、重连入口回向导。
- * key 全程掩码,不回显明文。
+ * **已存 key 永不回显**:它是 MAIN_ONLY 键,renderer 只能查存在性/写/删(见
+ * ImageApiKeyRow 注释),架构上拿不到明文。输入框的明文切换只显形用户本次输入的
+ * 草稿(草稿本就在 renderer state 里),不构成凭证下放。
  */
 function BuiltinApiKeyHeader({
   provider,
@@ -922,18 +921,14 @@ function BuiltinApiKeyHeader({
 
   const detail = editing ? (
     <div className="flex items-center gap-2 pt-2">
-      <input
-        type="password"
+      <SettingsTextInput
         value={draftKey}
-        onChange={(e) => setDraftKey(e.target.value)}
-        autoComplete="off"
+        onChange={setDraftKey}
         placeholder={t('settings.providers.builtinApiKey.keyPlaceholder')}
-        className="h-8 min-w-0 flex-1 rounded-full border px-3 font-mono text-12 outline-none focus:ring-2 focus:ring-[var(--focus-ring)]"
-        style={{
-          borderColor: 'var(--border-default)',
-          backgroundColor: 'var(--surface-elevated)',
-          color: 'var(--settings-section-title)',
-        }}
+        size="sm"
+        mono
+        secret
+        className="min-w-0 flex-1"
       />
       <PillButton
         label={t('settings.providers.builtinApiKey.saveKey')}

--- a/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
@@ -93,6 +93,10 @@ export function SettingsTextInput({
       onClick={() => setRevealed((v) => !v)}
       className={cn(
         'absolute top-1/2 -translate-y-1/2 text-[var(--settings-eye-icon)] transition-colors hover:text-[var(--settings-eye-icon-hover)]',
+        // globals.css 的 F3 全局规则把 *:focus-visible 的 outline 抹掉了(只有 input /
+        // textarea 恢复),按钮不自带焦点提示——键盘用户看不出焦点落在眼睛上。按 DESIGN.md
+        // 的 Focus Blue 约定补 ring(--focus-ring),写法与其它图标按钮一致。
+        'rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
         eyeStyle.offset,
       )}
       aria-label={revealed ? t('settings.apiKey.hideKey') : t('settings.apiKey.showKey')}
@@ -110,9 +114,10 @@ export function SettingsTextInput({
         onChange={(e) => onChange(e.target.value)}
         onBlur={onBlur}
         placeholder={placeholder}
-        // 密钥框不该触发 Electron 的密码管理器建议，值也不该被拼写检查划红。
-        autoComplete="off"
-        spellCheck={false}
+        // 只对密钥关掉:密码管理器建议和拼写红线对密钥是干扰,但普通文本字段(显示名称、
+        // baseUrl、模型名、请求头)该保留浏览器的自动补全与拼写检查,不能一并禁掉。
+        autoComplete={secret ? 'off' : undefined}
+        spellCheck={secret ? false : undefined}
         className={cn(
           // 单行输入按设计规范走药丸圆角(DESIGN.md §4-5:9999px,明令禁止 10px)。
           'w-full rounded-full outline-none transition-colors',

--- a/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
@@ -127,6 +127,11 @@ export function SettingsTextInput({
           mono && 'font-mono',
           'text-[var(--settings-input-text)] placeholder:text-[var(--settings-input-placeholder)]',
           'border border-[var(--settings-input-border)] bg-[var(--settings-input-bg)] focus:border-[var(--settings-input-border-focus)]',
+          // Focus Blue 环(DESIGN.md §4 Inputs 的 focus 槽 + §「Focus Blue」的 --focus-ring):
+          // 迁移进来的密钥输入原本就带 focus:ring-2,不能在收敛时丢掉——同一个表单里紧邻的
+          // 名称框仍是蓝环,只留 border 变色会让上下两个框焦点表现不一致。用 opaque
+          // --focus-ring 而非 --focus-ring-soft:与这些框的原值、以及相邻未迁移输入一致。
+          'focus:ring-2 focus:ring-[var(--focus-ring)]',
         )}
         style={{ userSelect: 'text', WebkitUserSelect: 'text' }}
       />

--- a/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
@@ -21,6 +21,21 @@ import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 
 export type SettingsTextInputSize = 'sm' | 'md' | 'lg';
+export type SettingsTextInputSurface = 'elevated' | 'ivory';
+
+/**
+ * 底色：默认 `elevated` = DESIGN.md §4 `input/text` 规定的 fill(`--surface-elevated`)。
+ *
+ * `ivory` 是给「输入压在白色弹窗面板上」的调用点保留的既有底色(`--settings-input-bg`,
+ * 解析到 `--surface-card-ivory`)。这份 ivory 在设计文档里没有任何背书,属 colors.ts 的
+ * 无文档漂移;它在白面板上能给出 fill 抬升,所以不在本 PR 里翻成白色,但也不能当默认——
+ * settings 卡片本身就是 ivory(`--settings-theme-card-bg`),ivory 输入压在 ivory 卡上会和
+ * 背景同色,填充对比度归零。settings 域这处 ivory / elevated 的收口是独立议题。
+ */
+const SURFACE_STYLES: Record<SettingsTextInputSurface, string> = {
+  elevated: 'bg-[var(--surface-elevated)]',
+  ivory: 'bg-[var(--settings-input-bg)]',
+};
 
 /** 各档的框体几何 + 无 trailing 时的右内边距（有 trailing 时统一让位给按钮）。 */
 const SIZE_STYLES: Record<
@@ -61,6 +76,7 @@ export function SettingsTextInput({
   placeholder,
   type = 'text',
   size = 'lg',
+  surface = 'elevated',
   mono = false,
   secret = false,
   trailing,
@@ -73,6 +89,8 @@ export function SettingsTextInput({
   /** `secret` 为真时由组件接管（明文 / 遮罩切换），此处传值无效。 */
   type?: string;
   size?: SettingsTextInputSize;
+  /** 底色档:默认 §4 规定的 `--surface-elevated`;`ivory` 见 SURFACE_STYLES 注释。 */
+  surface?: SettingsTextInputSurface;
   /** 等宽字体——密钥、ID 这类需要逐字核对的值。 */
   mono?: boolean;
   /** 密钥字段：遮罩输入 + 自带明文切换按钮。 */
@@ -126,7 +144,8 @@ export function SettingsTextInput({
           trailingNode ? sizeStyle.trailingPaddingRight : sizeStyle.paddingRight,
           mono && 'font-mono',
           'text-[var(--settings-input-text)] placeholder:text-[var(--settings-input-placeholder)]',
-          'border border-[var(--settings-input-border)] bg-[var(--settings-input-bg)] focus:border-[var(--settings-input-border-focus)]',
+          SURFACE_STYLES[surface],
+          'border border-[var(--settings-input-border)] focus:border-[var(--settings-input-border-focus)]',
           // Focus Blue 环(DESIGN.md §4 Inputs 的 focus 槽 + §「Focus Blue」的 --focus-ring):
           // 迁移进来的密钥输入原本就带 focus:ring-2,不能在收敛时丢掉——同一个表单里紧邻的
           // 名称框仍是蓝环,只留 border 变色会让上下两个框焦点表现不一致。用 opaque

--- a/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx
@@ -1,0 +1,131 @@
+/**
+ * SettingsTextInput —— 设置页统一的单行文本 / 密钥输入框。
+ *
+ * 收敛背景：设置页各处原本各写一份私有 TextInput（高度 32 / 36 / 40 / 42px 混杂），
+ * 密钥字段的「明文切换」只在 CustomProviderDialog 做了——同一个 API key 在「添加供应商」
+ * 向导里看不见、在编辑弹窗里看得见。本组件以 CustomProviderDialog 那份为基线（它是唯一
+ * 走 DESIGN.md §4-5 药丸圆角的实现），把 eye 显形收进 `secret`，调用点不再各自手写
+ * showKey state + 按钮。
+ *
+ * `secret` 只显形**用户本次输入的草稿**（草稿本就在 renderer state 里）。已存密钥要不要
+ * 回显由调用方决定：内置 API-key 走 MAIN_ONLY 的 builtinApiKey* IPC，renderer 架构上读不到
+ * 明文，回显无从谈起；自定义供应商的 key 由调用方显式读回。本组件不触碰凭证读取边界。
+ *
+ * 尺寸：DESIGN.md §4 锁定单行输入的 radius（9999px）与颜色 token，未锁高度，因此保留
+ * sm / md / lg 三档以贴合各调用点既有版式。radius 与 `--settings-input-*` token 不可变。
+ */
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+export type SettingsTextInputSize = 'sm' | 'md' | 'lg';
+
+/** 各档的框体几何 + 无 trailing 时的右内边距（有 trailing 时统一让位给按钮）。 */
+const SIZE_STYLES: Record<
+  SettingsTextInputSize,
+  { box: string; paddingLeft: string; paddingRight: string; trailingPaddingRight: string }
+> = {
+  sm: {
+    box: 'h-8 text-12',
+    paddingLeft: 'pl-3',
+    paddingRight: 'pr-3',
+    trailingPaddingRight: 'pr-8',
+  },
+  md: {
+    box: 'h-9 text-13',
+    paddingLeft: 'pl-4',
+    paddingRight: 'pr-4',
+    trailingPaddingRight: 'pr-9',
+  },
+  lg: {
+    box: 'h-[40px] text-14',
+    paddingLeft: 'pl-[12px]',
+    paddingRight: 'pr-[12px]',
+    trailingPaddingRight: 'pr-9',
+  },
+};
+
+/** eye 按钮：小号框用小图标 / 更贴边，避免挤压 32px 行高。 */
+const EYE_STYLES: Record<SettingsTextInputSize, { iconSize: number; offset: string }> = {
+  sm: { iconSize: 14, offset: 'right-[10px]' },
+  md: { iconSize: 16, offset: 'right-[12px]' },
+  lg: { iconSize: 16, offset: 'right-[12px]' },
+};
+
+export function SettingsTextInput({
+  value,
+  onChange,
+  onBlur,
+  placeholder,
+  type = 'text',
+  size = 'lg',
+  mono = false,
+  secret = false,
+  trailing,
+  className,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  /** `secret` 为真时由组件接管（明文 / 遮罩切换），此处传值无效。 */
+  type?: string;
+  size?: SettingsTextInputSize;
+  /** 等宽字体——密钥、ID 这类需要逐字核对的值。 */
+  mono?: boolean;
+  /** 密钥字段：遮罩输入 + 自带明文切换按钮。 */
+  secret?: boolean;
+  /** 自定义尾随元素（需自行绝对定位）。`secret` 优先，两者不叠加。 */
+  trailing?: React.ReactNode;
+  /** 附加到**外层容器**（内层 input 恒为 w-full），供 flex 行传 `flex-1 min-w-0`。 */
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const [revealed, setRevealed] = useState(false);
+  const sizeStyle = SIZE_STYLES[size];
+  const eyeStyle = EYE_STYLES[size];
+
+  const eyeButton = secret ? (
+    <button
+      type="button"
+      onClick={() => setRevealed((v) => !v)}
+      className={cn(
+        'absolute top-1/2 -translate-y-1/2 text-[var(--settings-eye-icon)] transition-colors hover:text-[var(--settings-eye-icon-hover)]',
+        eyeStyle.offset,
+      )}
+      aria-label={revealed ? t('settings.apiKey.hideKey') : t('settings.apiKey.showKey')}
+    >
+      {revealed ? <Eye size={eyeStyle.iconSize} /> : <EyeOff size={eyeStyle.iconSize} />}
+    </button>
+  ) : null;
+  const trailingNode = eyeButton ?? trailing;
+
+  return (
+    <div className={cn('relative', className)}>
+      <input
+        type={secret ? (revealed ? 'text' : 'password') : type}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        // 密钥框不该触发 Electron 的密码管理器建议，值也不该被拼写检查划红。
+        autoComplete="off"
+        spellCheck={false}
+        className={cn(
+          // 单行输入按设计规范走药丸圆角(DESIGN.md §4-5:9999px,明令禁止 10px)。
+          'w-full rounded-full outline-none transition-colors',
+          sizeStyle.box,
+          sizeStyle.paddingLeft,
+          trailingNode ? sizeStyle.trailingPaddingRight : sizeStyle.paddingRight,
+          mono && 'font-mono',
+          'text-[var(--settings-input-text)] placeholder:text-[var(--settings-input-placeholder)]',
+          'border border-[var(--settings-input-border)] bg-[var(--settings-input-bg)] focus:border-[var(--settings-input-border-focus)]',
+        )}
+        style={{ userSelect: 'text', WebkitUserSelect: 'text' }}
+      />
+      {trailingNode}
+    </div>
+  );
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

填 API key 的地方一半能看明文、一半不能：「添加供应商」向导和供应商详情页的行内密钥输入是裸
`<input type="password">`，没有小眼睛；只有 `CustomProviderDialog` 用的私有 `TextInput` 有。
于是同一个 key 在**新增**时看不见、在**编辑**时看得见——粘错 key、多余空格、前缀不对，在遮罩下
都查不出来。

根因不是配置差异，而是 `TextInput` 从来不是共享组件，而是 4 份各自私有的拷贝
（`CustomProviderDialog` / `McpServerDialog` / `DingTalkBotSection` / `PublishDialog`），高度
32/36/40/42px 混杂。直接在向导里再抄一份会做实「第 5 份拷贝」，所以先提取共享组件
`SettingsTextInput`，把 eye 显形收进 `secret` prop，再让 4 个缺切换的位置接入。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户反馈「新增 Provider 填 API-KEY 不能显示明文，但 Edit 时却有」）
- 本 PR 包含：
  - 新建 `apps/desktop/src/renderer/components/settings/SettingsTextInput.tsx`，以
    `CustomProviderDialog` 的私有实现为基线（它是唯一走 DESIGN.md §4-5 药丸圆角的一份），
    新增 `size`（sm/md/lg）、`mono`、`secret` 三个变体。
  - 4 处接入：`AddProviderWizard` 的 preset 与 builtinApiKey 两个 key 输入；
    `ProvidersSection` 的 `BuiltinApiKeyHeader`（更换密钥）与 `ImageApiKeyRow`。
  - 收敛 `CustomProviderDialog`：删掉私有 `TextInput`、`showKey` state 与手写 eye 按钮，
    10 处调用点改用共享组件（统一传 `surface="ivory"`，底色与改动前一致）。
  - 顺带补 `autoComplete="off"` + `spellCheck={false}`——原私有实现漏了，密码框会触发
    Electron 密码管理器建议（`DingTalkBotSection` / `FeishuBotSection` 两份都有，以它们为准）。
  - 修正两处与实际行为不符的注释（见下方「风险」末尾说明）。
  - 新增 eye toggle 回归测试（仓库此前没有任何一处测过这个切换）。
- 明确不包含：
  - `McpServerDialog` / `DingTalkBotSection` / `PublishDialog` 的私有拷贝**未动**——各有样式
    差异，且 `McpServerDialog` 的 `rounded-[10px]` 违反 DESIGN §5「单行输入必须 pill」，
    那是独立的规范修复，混进来会让本 PR 的 diff 失焦。
  - `--focus-ring` 与 `--focus-ring-soft` 之间的取值判定**未动**：共享组件用 opaque
    `--focus-ring`，与被迁移输入的原值、以及同表单内未迁移输入（名称框等）一致。settings 域
    47 处 ring 里 soft / opaque 混用是既有状态，统一收口不在本 PR 范围。
  - settings 域「输入用 ivory 底」这个既有漂移**未收口**：`--settings-input-bg` 解析到
    `--surface-card-ivory`，与 §4 规定的 `--surface-elevated` 不符，且 `design-decision-log.md`
    / `token-decision-table.md` / `figma-component-spec.md` 里查不到任何背书。本 PR 只保证被
    迁移的调用点底色不变（`surface` 档），把这份漂移原样留在 `CustomProviderDialog` 等既有
    调用点上；要不要全域翻成 `--surface-elevated` 是独立的设计判定。
- 用户可见变化：
  - 上述 4 处密钥输入新增小眼睛，可切明文核对。
  - 输入框底色（**首版有回归，已在 review 后修复**）：这 4 处密钥框的底色现在与改动前完全
    一致 —— `--surface-elevated`（#ffffff / #2c2c2a），也正是 DESIGN.md §4 `input/text` 规定的
    fill。首版把它们一并换成了 settings 域的 `--settings-input-bg`（解析到 `--surface-card-ivory`
    #faf9f5），而 `ProvidersSection` 的卡片本身就是这个值（`--settings-theme-card-bg`，
    `ProvidersSection.tsx:1733`），行内密钥框会与所在卡片同色、填充对比度归零 —— 感谢 codex
    抓到。修法：共享组件加 `surface` 档，默认 `elevated`（§4 规定值），`CustomProviderDialog`
    传 `ivory` 保住它压在白色弹窗面板上的既有底色。文字色与边框色本就同值，无变化。
  - 键盘焦点态（**首版有回归，已在 review 后修复**）：共享组件同时给出 Focus Blue 环
    （`focus:ring-2` + `--focus-ring`，DESIGN.md §4 Inputs 的 focus 槽）与 settings 域既有的
    border 变色。首版只保留了 border 变色，把被迁移的 4 处密钥输入原有的 `focus:ring-2`
    丢了，导致 step 2 里名称框（未迁移，仍蓝环）与密钥框焦点表现不一致 —— 感谢 codex 抓到。
    连带影响：`CustomProviderDialog` 的 10 处输入原本只有 border 变色，现在也获得 Focus Blue
    环，属向 §4 靠拢的扩大项，非回归。
  - 显形按钮补 `focus-visible` ring：`globals.css`（F3）全局抹掉 `*:focus-visible` 的 outline
    且只对 input/textarea 恢复，`<button>` 不恢复，原先键盘用户看不出焦点落在眼睛上。
  - `CustomProviderDialog` 的密钥字段新增 `font-mono`，与其余密钥字段统一。
- 是否存在 breaking change：无

### UI 变化

<img width="575" height="78" alt="api-key-eyeon" src="https://github.com/user-attachments/assets/c3130948-476b-4d6b-85c4-fe1451efbc88" />
<img width="580" height="78" alt="api-key-eyeoff" src="https://github.com/user-attachments/assets/33474386-9a1a-4994-bda1-d8917d187832" />

平台：Windows 11（`--isolated` 命名沙箱，`--region=cn`）。

> 两张图摄于**首版**，框内底色是当时误换上的 ivory；现已按 §4 恢复为改动前的白色
> （见下方「用户可见变化」的底色条目）。eye 的形态、位置与交互不受影响。

- 引用的设计规范：
  - **DESIGN.md §4 Inputs & Forms**：单行输入 `radius 9999px`（pill）、颜色全走
    `--settings-input-*` token、placeholder 收口至 `--text-placeholder`。共享组件保持这三条
    不变，并把 4 处裸 `<input>` 的硬编码 inline style 收敛到 token。
  - **DESIGN.md §5 三档圆角**：单行输入属「pill（9999px）」档，本组件恒用 `rounded-full`，
    不引入 10px。
  - **§4 未锁定输入高度**（只锁 radius 与颜色 token），因此保留 `size` 三档以贴合各调用点
    既有版式，实现视觉零回归（除上文明确列出的底色 / focus / 等宽三项）。
  - **双模式交付门槛**：eye 图标走语义 token `--settings-eye-icon` /
    `--settings-eye-icon-hover`（`themes/colors.ts` 已定义 light/dark 两值），无任何单模式
    硬编码或条件补丁。**实现覆盖两种模式；实机目检只做了 Light，Dark 未实机验证**，见
    「未执行的验证」。
  - **i18n**：未新增文案，复用既有 `settings.apiKey.showKey` / `hideKey`（zh-CN / en / ja / ko
    四语言齐全），不触发 `check:i18n-glossary`。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全绿，0 FAIL（apps/desktop 247.3s PASS、apps/mobile PASS、全部 packages 与
      cindy-protocol 各 tier 均 PASS）

pnpm --filter desktop typecheck
结果：exit 0

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx \
  src/renderer/__tests__/addProviderWizardOpenaiEntry.test.tsx \
  src/renderer/__tests__/addProviderWizardOpenAiAuth.test.tsx
结果：3 files / 22 tests passed（含新增的 eye toggle case）

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/providersSectionDeepLink.test.tsx \
  src/renderer/__tests__/providersSectionUnavailableModels.test.tsx \
  src/renderer/__tests__/connectProviderCard.test.tsx \
  src/renderer/__tests__/connectProviderBanner.test.tsx
结果：4 files / 21 tests passed

pnpm check:dco
结果：passed — 1 commit signed off
```

新增测试（`addProviderWizardPresetEntry.test.tsx`）锁的是：preset 表单的 key 输入默认
`type="password"`，点 eye 变 `text`，再点回 `password`。此前仓库没有任何一处测过密钥显形切换。

### 手工验证

平台 Windows 11，`pnpm restart:desktop:remote --region=cn --isolated=apikey`（命名沙箱，
与正式版 userData 完全隔离）：

1. 设置 → 模型供应商 → 添加供应商 → 选 preset → 密钥框出现小眼睛，点击切明文、再点回遮罩
   （即上方两张截图，Light 模式）。

上面「UI 变化」的两张图对应的就是这一条；其余场景与 Dark 模式见下方「未执行的验证」。

### 未执行的验证

- **另外三处接入点未实机点验**，只有自动化测试与 typecheck 覆盖：向导的内置 API-key 渠道
  （`builtinApiKey` step 2）、供应商详情页「更换密钥」的行内输入（`size="sm"`，32px 行高最容易
  被改胖，值得 reviewer 留意）、编辑自定义 Provider 弹窗（对照组，回填与「已保存」徽标）。
  三处与已验证的那处走**同一个** `SettingsTextInput`，差异只在 `size` 档与 `placeholder`。
- **Dark 模式未实机验证**：只目检了 Light。eye 图标走语义 token `--settings-eye-icon` /
  `--settings-eye-icon-hover`，`themes/colors.ts` 里 light / dark 两值均已定义，组件无单模式
  硬编码或条件分支；但按 DESIGN.md 的双模式交付门槛，这里如实记为未实机目检，不拿「复用了
  themed token」当已验证。附注：本 PR 的底色收敛在 Dark 下两 token 同值（`#2c2c2a`），
  Dark 无视觉变化，真正需要人眼判断的 Light 已看过。
- macOS 未实机验证：本次改动只涉及 renderer 的 Tailwind class 与语义 token，无平台分支代码。
- `pnpm lint` / `prettier --check` 在本仓当前状态下整体不干净（未改动的 `McpServerDialog`、
  `providerModels.ts` 等文件也报，共 134 项），故未作为门禁。已单独确认：新增文件
  `SettingsTextInput.tsx` prettier 合格、本 PR 新增行无超宽；`CustomProviderDialog` 残留的
  两个 `_drop` unused-vars 不在本 PR diff 内。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop renderer 的 settings UI（供应商相关 4 处密钥输入 + 1 个新增共享组件 +
  `CustomProviderDialog` 的 10 处调用点改名）。不涉及 main 进程、IPC、凭证存取链路、
  数据库或协议。

- **凭证边界（勾选「权限 / 安全 / 用户数据」的原因，请 reviewer 重点看这条）**：明文切换
  **只显形用户本次正在输入的草稿**，草稿本就在 renderer state 里，不新增任何凭证读取路径。
  - 内置 API-key（`BuiltinApiKeyHeader` / `ImageApiKeyRow`）：key 是 MAIN_ONLY 键，走
    `builtinApiKey*` 专用 IPC，renderer 只能查存在性 / 写 / 删，**架构上拿不到已存明文**，
    所以「已存 key 回显」根本不可能发生，本 PR 也没有去改这条链路。
  - 自定义供应商（`CustomProviderDialog`）：编辑态回填已存 key 是**本 PR 之前就有**的既有
    行为（`readCustomProviderKey`，见该文件回填 effect 的注释），eye 只是让这份已经在
    renderer 里的值可读，不改变它怎么来的。
  - 因此 `docs/dev-rules/credentials-and-local-storage.md`「不要把秘密下放给 Renderer」不受
    影响：没有秘密被新下放。
  - 附带说明：`ProvidersSection` 原有注释写「key 全程掩码，不回显明文」，容易被读成「加 eye
    就是违规」。已改写为「已存 key 永不回显（MAIN_ONLY，renderer 架构上拿不到），明文切换
    只显形本次输入的草稿」。同理 `CustomProviderDialog` 顶部注释原写「编辑态密钥遮罩」，与
    实际回填明文的行为不符，也一并改准。两处都只是注释，无行为变更。

- 回滚 / 降级方式：4 个 commit（主改动 + 3 次 review 修复），`git revert` 这几个即可完整
  回滚；无数据迁移、无持久化格式变更、无需清理任何用户状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（新组件的收敛背景、`secret` 的凭证边界、`size` 为何多档，都写在
      `SettingsTextInput.tsx` 的文件头注释里）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)



