### PR TITLE
feat(desktop): Claude 订阅 chip 额度段三态着色(评审收窄方案)

### DIFF
--- a/apps/desktop/src/renderer/components/status/QuotaBar.tsx
+++ b/apps/desktop/src/renderer/components/status/QuotaBar.tsx
@@ -39,11 +39,12 @@ const QUOTA_SEVERITY_RANK: Record<QuotaSeverity, number> = {
 };
 
 /**
- * 空值或 normal 才是无告警；未知非空值至少保留为 warn。
+ * 非字符串按缺失处理；字符串空值或 normal 才是无告警，未知非空值至少保留为 warn。
  * 与共享告警谓词“任何非 normal severity 均告警”保持一致，避免上游新增级别被静默降级。
  */
-function serverQuotaSeverity(value: string | null | undefined): QuotaSeverity {
-  const normalized = value?.trim().toLowerCase();
+function serverQuotaSeverity(value: unknown): QuotaSeverity {
+  if (typeof value !== 'string') return 'normal';
+  const normalized = value.trim().toLowerCase();
   if (!normalized || normalized === 'normal') return 'normal';
   if (normalized === 'warning') return 'warn';
   const parts = normalized.split(/[^a-z]+/).filter(Boolean);
@@ -54,7 +55,7 @@ function serverQuotaSeverity(value: string | null | undefined): QuotaSeverity {
 /** 本地利用率与服务端告警等级取更严重者，作为窗口的最终等级。 */
 export function effectiveQuotaSeverity(
   usedPercent: number,
-  serverSeverity: string | null | undefined,
+  serverSeverity: unknown,
 ): QuotaSeverity {
   const localSeverity = quotaSeverity(usedPercent);
   const upstreamSeverity = serverQuotaSeverity(serverSeverity);

--- a/apps/desktop/src/renderer/components/status/QuotaBar.tsx
+++ b/apps/desktop/src/renderer/components/status/QuotaBar.tsx
@@ -32,6 +32,37 @@ export function quotaSeverity(usedPercent: number): QuotaSeverity {
   return 'normal';
 }
 
+const QUOTA_SEVERITY_RANK: Record<QuotaSeverity, number> = {
+  normal: 0,
+  warn: 1,
+  crit: 2,
+};
+
+/**
+ * 空值或 normal 才是无告警；未知非空值至少保留为 warn。
+ * 与共享告警谓词“任何非 normal severity 均告警”保持一致，避免上游新增级别被静默降级。
+ */
+function serverQuotaSeverity(value: string | null | undefined): QuotaSeverity {
+  const normalized = value?.trim().toLowerCase();
+  if (!normalized || normalized === 'normal') return 'normal';
+  if (normalized === 'warning') return 'warn';
+  const parts = normalized.split(/[^a-z]+/).filter(Boolean);
+  if (parts.includes('exceeded') || parts.includes('critical')) return 'crit';
+  return 'warn';
+}
+
+/** 本地利用率与服务端告警等级取更严重者，作为窗口的最终等级。 */
+export function effectiveQuotaSeverity(
+  usedPercent: number,
+  serverSeverity: string | null | undefined,
+): QuotaSeverity {
+  const localSeverity = quotaSeverity(usedPercent);
+  const upstreamSeverity = serverQuotaSeverity(serverSeverity);
+  return QUOTA_SEVERITY_RANK[upstreamSeverity] > QUOTA_SEVERITY_RANK[localSeverity]
+    ? upstreamSeverity
+    : localSeverity;
+}
+
 const FILL_COLOR_CLASSES: Record<QuotaSeverity, string> = {
   normal: 'bg-[var(--quota-bar-fill)]',
   warn: 'bg-[var(--quota-bar-warn)]',

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1713,14 +1713,21 @@ export function TodaySpendChip({
   const showClaudeSubscriptionFallbackAlert =
     QUOTA_SEVERITY_RANK[visibleClaudeQuotaSeverity]
       < QUOTA_SEVERITY_RANK[claudeSubscriptionAlertSeverity];
+  // 隐藏窗口 / 状态告警的整 chip 兜底也保留最终等级：
+  // warn 用琥珀色，crit 才用红色，与可见额度段共用语义 token。
+  const claudeSubscriptionFallbackToneClass = showClaudeSubscriptionFallbackAlert
+    ? claudeSubscriptionAlertSeverity === 'warn'
+      ? 'text-[var(--quota-bar-warn)] hover:text-[var(--quota-bar-warn)]'
+      : 'text-[var(--quota-bar-crit)] hover:text-[var(--quota-bar-crit)]'
+    : null;
 
   // 与 ContextCapacityRing 视觉对齐 (h-5 = 20px) + reset button UA 默认 padding/border。
   // tabular-nums 让 "$306 / $1.2k" 这类数字段的字符宽度等宽, 段间数字落点对齐。
   const buttonClass = cn(
     'inline-flex h-5 shrink-0 items-center',
     'text-12 font-medium leading-none tabular-nums',
-    showClaudeSubscriptionFallbackAlert
-      ? 'text-[var(--error-fg)] hover:text-[var(--error-fg-strong)]'
+    claudeSubscriptionFallbackToneClass
+      ? claudeSubscriptionFallbackToneClass
       // 不可点(网关账号)时不加 hover 变色,避免暗示可交互。
       : cn('text-[var(--msg-tool-card-chevron)]', isDashboardClickable && 'hover:text-foreground'),
     'border-0 bg-transparent p-0 m-0',

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1060,7 +1060,12 @@ function getClaudeSubscriptionAlertSeverity(
   modelId: string | null | undefined,
 ): QuotaSeverity {
   if (!isClaudeSubscriptionAlerting(snapshot, modelId)) return 'normal';
-  if (snapshot?.rateLimitStatus?.trim().toLowerCase() === 'rejected') return 'crit';
+  // rateLimitStatus 可能来自脏的持久化/IPC 快照;非字符串按缺失处理。
+  const rawRateLimitStatus = snapshot?.rateLimitStatus;
+  if (
+    typeof rawRateLimitStatus === 'string'
+    && rawRateLimitStatus.trim().toLowerCase() === 'rejected'
+  ) return 'crit';
 
   const sessionWindows: Array<ClaudeUsageWindow | null | undefined> = [
     snapshot?.fiveHour,

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -113,7 +113,7 @@ import {
   type QuotaHoverCardSessionUsage,
   type QuotaHoverCardTurnUsage,
 } from './QuotaHoverCard';
-import { quotaSeverity } from './QuotaBar';
+import { quotaSeverity, type QuotaSeverity } from './QuotaBar';
 import { QuotaResetConfetti } from './QuotaResetConfetti';
 
 // XD 网关 / 托管账号之前会跳到内部用量看板(内部域名)—— 开源前移除该硬编码。
@@ -1017,6 +1017,36 @@ function renderClaudeQuotaSegment(content: React.ReactNode, usedPercent: number)
   );
 }
 
+const QUOTA_SEVERITY_RANK: Record<QuotaSeverity, number> = {
+  normal: 0,
+  warn: 1,
+  crit: 2,
+};
+
+/**
+ * 整 chip 兜底告警的等级：被拒或当前会话相关窗口达到 90% 为严重告警；
+ * 其余由上游非 normal severity 触发的告警按警告级处理。
+ */
+function getClaudeSubscriptionAlertSeverity(
+  snapshot: ClaudeSubscriptionUsageSnapshot | null,
+  modelId: string | null | undefined,
+): QuotaSeverity {
+  if (!isClaudeSubscriptionAlerting(snapshot, modelId)) return 'normal';
+  if (snapshot?.rateLimitStatus?.trim().toLowerCase() === 'rejected') return 'crit';
+
+  const sessionWindows: Array<ClaudeUsageWindow | null | undefined> = [
+    snapshot?.fiveHour,
+    snapshot?.sevenDay,
+    matchScopedWindowForModel(snapshot?.scoped, modelId),
+  ];
+  const hasCriticalWindow = sessionWindows.some((window) => (
+    typeof window?.utilization === 'number'
+    && Number.isFinite(window.utilization)
+    && quotaSeverity(window.utilization) === 'crit'
+  ));
+  return hasCriticalWindow ? 'crit' : 'warn';
+}
+
 interface TodaySpendChipProps {
   vendorKey?: 'cc' | 'codex' | 'pi';
   /** 当前会话模型;codex/ 折扣 GPT 恒走 gateway API, 即使 oauth-bearer spawn 也按 API 形态显示。 */
@@ -1644,12 +1674,20 @@ export function TodaySpendChip({
 
   // Claude 订阅有告警窗口段时由该段独立着色，避免把其它段与会话金额一起染红；
   // 告警来自未展示窗口或 rejected 时，仍保留整 chip 告警兜底。
-  const claudeSubscriptionAlerting = isClaudeSubscription
-    && isClaudeSubscriptionAlerting(claudeSubscriptionUsage, modelId);
-  const hasAlertingClaudeQuotaSegment = usesClaudeQuotaChipSegments
-    && chipWindows.some((window) => quotaSeverity(100 - window.remainingPercent) !== 'normal');
-  const showClaudeSubscriptionFallbackAlert = claudeSubscriptionAlerting
-    && !hasAlertingClaudeQuotaSegment;
+  const claudeSubscriptionAlertSeverity = isClaudeSubscription
+    ? getClaudeSubscriptionAlertSeverity(claudeSubscriptionUsage, modelId)
+    : 'normal';
+  const visibleClaudeQuotaSeverity = usesClaudeQuotaChipSegments
+    ? chipWindows.reduce<QuotaSeverity>((highestSeverity, window) => {
+        const severity = quotaSeverity(100 - window.remainingPercent);
+        return QUOTA_SEVERITY_RANK[severity] > QUOTA_SEVERITY_RANK[highestSeverity]
+          ? severity
+          : highestSeverity;
+      }, 'normal')
+    : 'normal';
+  const showClaudeSubscriptionFallbackAlert =
+    QUOTA_SEVERITY_RANK[visibleClaudeQuotaSeverity]
+      < QUOTA_SEVERITY_RANK[claudeSubscriptionAlertSeverity];
 
   // 与 ContextCapacityRing 视觉对齐 (h-5 = 20px) + reset button UA 默认 padding/border。
   // tabular-nums 让 "$306 / $1.2k" 这类数字段的字符宽度等宽, 段间数字落点对齐。

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1032,23 +1032,16 @@ function renderClaudeQuotaSegment(
   const severityLabel = getClaudeQuotaSeverityLabel(severity, t);
   const ariaLabel = severityLabel ? `${visibleText} ${severityLabel}` : undefined;
 
+  // 红色段不叠加呼吸圆点(2026-08-05 维护者产品结论:避免视觉噪音);
+  // 非颜色信号由 aria-label 的等级文案承担。
   return (
-    <>
-      {severity === 'crit' && (
-        <span
-          aria-hidden="true"
-          data-quota-critical-dot
-          className="session-status-breathing mr-1 inline-block size-1.5 rounded-full bg-[var(--quota-bar-crit)] align-middle"
-        />
-      )}
-      <span
-        aria-label={ariaLabel}
-        data-quota-severity={severity}
-        className={colorClass}
-      >
-        {content}
-      </span>
-    </>
+    <span
+      aria-label={ariaLabel}
+      data-quota-severity={severity}
+      className={colorClass}
+    >
+      {content}
+    </span>
   );
 }
 

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1737,8 +1737,12 @@ export function TodaySpendChip({
           : highestSeverity;
       }, 'normal')
     : 'normal';
+  const showClaudeSubscriptionFallbackAlert =
+    QUOTA_SEVERITY_RANK[visibleClaudeQuotaSeverity]
+      < QUOTA_SEVERITY_RANK[claudeSubscriptionAlertSeverity];
   // button 自身的 aria-label 会覆盖后代段落的 accessible name；把每个升级段使用的
   // 同一份严重度文案提升到 trigger，确保读屏仍能听见 warn / crit 的区别。
+  // 兜底告警（隐藏窗口告警 / rejected 状态）只染色不加段落，等级文案也要并入名称。
   const triggerAccessibleName = usageDashboardLabel
     ? [
         usageDashboardLabel,
@@ -1753,11 +1757,12 @@ export function TodaySpendChip({
               ))
               .filter((label): label is string => label !== null)
           : []),
+        ...(showClaudeSubscriptionFallbackAlert
+          ? [getClaudeQuotaSeverityLabel(claudeSubscriptionAlertSeverity, t)]
+              .filter((label): label is string => label !== null)
+          : []),
       ].join(' ')
     : null;
-  const showClaudeSubscriptionFallbackAlert =
-    QUOTA_SEVERITY_RANK[visibleClaudeQuotaSeverity]
-      < QUOTA_SEVERITY_RANK[claudeSubscriptionAlertSeverity];
   // 隐藏窗口 / 状态告警的整 chip 兜底也保留最终等级：
   // warn 用琥珀色，crit 才用红色，与可见额度段共用语义 token。
   const claudeSubscriptionFallbackToneClass = showClaudeSubscriptionFallbackAlert

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -113,6 +113,7 @@ import {
   type QuotaHoverCardSessionUsage,
   type QuotaHoverCardTurnUsage,
 } from './QuotaHoverCard';
+import { quotaSeverity } from './QuotaBar';
 import { QuotaResetConfetti } from './QuotaResetConfetti';
 
 // XD 网关 / 托管账号之前会跳到内部用量看板(内部域名)—— 开源前移除该硬编码。
@@ -993,6 +994,29 @@ function renderSegmentedLabel(segments: React.ReactNode[]): React.ReactNode {
   ));
 }
 
+/** Claude 订阅额度段只按本窗口已用比例着色，不影响相邻窗口与会话金额。 */
+function renderClaudeQuotaSegment(content: React.ReactNode, usedPercent: number): React.ReactNode {
+  const severity = quotaSeverity(usedPercent);
+  const colorClass = severity === 'warn'
+    ? 'text-[var(--quota-bar-warn)]'
+    : severity === 'crit'
+      ? 'text-[var(--quota-bar-crit)]'
+      : undefined;
+
+  return (
+    <>
+      {severity === 'crit' && (
+        <span
+          aria-hidden="true"
+          data-quota-critical-dot
+          className="mr-1 inline-block size-1.5 rounded-full bg-[var(--quota-bar-crit)] align-middle animate-pulse motion-reduce:animate-none"
+        />
+      )}
+      <span data-quota-severity={severity} className={colorClass}>{content}</span>
+    </>
+  );
+}
+
 interface TodaySpendChipProps {
   vendorKey?: 'cc' | 'codex' | 'pi';
   /** 当前会话模型;codex/ 折扣 GPT 恒走 gateway API, 即使 oauth-bearer spawn 也按 API 形态显示。 */
@@ -1375,9 +1399,15 @@ export function TodaySpendChip({
   const windowSlotB = chipWindows[1] ?? null;
   const rollupA = useQuotaResetRollup(windowSlotA);
   const rollupB = useQuotaResetRollup(windowSlotB);
+  const usesClaudeQuotaChipSegments = isClaudeSubscription && !usesCodexQuotaForm;
   // 窗口段元素登记表(key → span): 撒花锚点用, 段消失时由 ref 回调置 null。
   const segmentElsRef = React.useRef<Record<string, HTMLSpanElement | null>>({});
   const windowSegments: React.ReactNode[] = chipWindows.map((window, index) => {
+    const renderWindowContent = (content: React.ReactNode) => (
+      usesClaudeQuotaChipSegments
+        ? renderClaudeQuotaSegment(content, 100 - window.remainingPercent)
+        : content
+    );
     if (window.resetPending) {
       // 悬念期: 倒计时已归零、新快照未落地 —— 旧百分比已失真, 换成「重置中…」,
       // 呼吸省略号 (HTML span + opacity, 仅悬念期挂载; motion-safe = 尊重
@@ -1385,8 +1415,12 @@ export function TodaySpendChip({
       // 动画从 0% 跳到新值揭晓。
       return (
         <React.Fragment key={window.key}>
-          {t('todaySpend.resetPendingSegment', { label: window.label })}
-          <span className="motion-safe:animate-pulse">…</span>
+          {renderWindowContent(
+            <>
+              {t('todaySpend.resetPendingSegment', { label: window.label })}
+              <span className="motion-safe:animate-pulse">…</span>
+            </>,
+          )}
         </React.Fragment>
       );
     }
@@ -1407,7 +1441,7 @@ export function TodaySpendChip({
           segmentElsRef.current[window.key] = el;
         }}
       >
-        {text}
+        {renderWindowContent(text)}
       </span>
     );
   });
@@ -1608,19 +1642,19 @@ export function TodaySpendChip({
     }
   }
 
-  // Claude 订阅告警态: 影响当前会话的窗口 (5h / 总周限 / 当前模型 scoped) 任一逼近 /
-  // 打满, 或 headers 报 rejected → chip 变 error 色 (语义豁免色, 跨主题一致)。
-  // 其它模型的周限吃紧不染红 —— chip 上没有那一段, 红了也无从解释 (见
-  // isClaudeSubscriptionAlerting 对 allowed_warning 的取舍)。
+  // Claude 订阅有窗口段时由各段 used% 独立着色，避免一段吃紧把其它段与会话金额一起
+  // 染红；窗口数据缺失时仍保留 rejected / 上游 severity 的整 chip 告警兜底。
   const claudeSubscriptionAlerting = isClaudeSubscription
     && isClaudeSubscriptionAlerting(claudeSubscriptionUsage, modelId);
+  const showClaudeSubscriptionFallbackAlert = claudeSubscriptionAlerting
+    && windowSegments.length === 0;
 
   // 与 ContextCapacityRing 视觉对齐 (h-5 = 20px) + reset button UA 默认 padding/border。
   // tabular-nums 让 "$306 / $1.2k" 这类数字段的字符宽度等宽, 段间数字落点对齐。
   const buttonClass = cn(
     'inline-flex h-5 shrink-0 items-center',
     'text-12 font-medium leading-none tabular-nums',
-    claudeSubscriptionAlerting
+    showClaudeSubscriptionFallbackAlert
       ? 'text-[var(--error-fg)] hover:text-[var(--error-fg-strong)]'
       // 不可点(网关账号)时不加 hover 变色,避免暗示可交互。
       : cn('text-[var(--msg-tool-card-chevron)]', isDashboardClickable && 'hover:text-foreground'),

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1642,12 +1642,14 @@ export function TodaySpendChip({
     }
   }
 
-  // Claude 订阅有窗口段时由各段 used% 独立着色，避免一段吃紧把其它段与会话金额一起
-  // 染红；窗口数据缺失时仍保留 rejected / 上游 severity 的整 chip 告警兜底。
+  // Claude 订阅有告警窗口段时由该段独立着色，避免把其它段与会话金额一起染红；
+  // 告警来自未展示窗口或 rejected 时，仍保留整 chip 告警兜底。
   const claudeSubscriptionAlerting = isClaudeSubscription
     && isClaudeSubscriptionAlerting(claudeSubscriptionUsage, modelId);
+  const hasAlertingClaudeQuotaSegment = usesClaudeQuotaChipSegments
+    && chipWindows.some((window) => quotaSeverity(100 - window.remainingPercent) !== 'normal');
   const showClaudeSubscriptionFallbackAlert = claudeSubscriptionAlerting
-    && windowSegments.length === 0;
+    && !hasAlertingClaudeQuotaSegment;
 
   // 与 ContextCapacityRing 视觉对齐 (h-5 = 20px) + reset button UA 默认 padding/border。
   // tabular-nums 让 "$306 / $1.2k" 这类数字段的字符宽度等宽, 段间数字落点对齐。

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -115,7 +115,6 @@ import {
 } from './QuotaHoverCard';
 import {
   effectiveQuotaSeverity,
-  quotaSeverity,
   type QuotaSeverity,
 } from './QuotaBar';
 import { QuotaResetConfetti } from './QuotaResetConfetti';
@@ -360,6 +359,8 @@ function toEpochMs(epochSeconds: number | null | undefined): number | null {
  */
 interface ChipWindowSegment extends ChipWindowSlot {
   label: string;
+  /** Claude 窗口的服务端告警级别；Codex 窗口无此信号。 */
+  serverSeverity?: string | null;
   /**
    * 倒计时已过点、快照还停在上个周期 —— 悬念期: 段显示「重置中…」(呼吸省略号)
    * 而不是僵住的旧百分比, 新快照落地时由重置滚动动画揭晓。
@@ -657,6 +658,7 @@ function getClaudeChipWindows(
       key: 'claude-5h',
       label: countdown ?? '5h',
       remainingPercent: 100 - clampPercent(fiveHour.utilization),
+      serverSeverity: fiveHour.severity,
       resetsAtMs,
       resetPending: isResetPending(resetsAtMs, nowMs),
     });
@@ -677,6 +679,7 @@ function getClaudeChipWindows(
       key: weekly.modelDisplayName ? `claude-weekly:${weekly.modelDisplayName}` : 'claude-weekly:total',
       label,
       remainingPercent: 100 - clampPercent(weekly.window.utilization),
+      serverSeverity: weekly.window.severity,
       resetsAtMs,
       resetPending: isResetPending(resetsAtMs, nowMs),
     });
@@ -998,9 +1001,13 @@ function renderSegmentedLabel(segments: React.ReactNode[]): React.ReactNode {
   ));
 }
 
-/** Claude 订阅额度段只按本窗口已用比例着色，不影响相邻窗口与会话金额。 */
-function renderClaudeQuotaSegment(content: React.ReactNode, usedPercent: number): React.ReactNode {
-  const severity = quotaSeverity(usedPercent);
+/** Claude 订阅额度段合并本地利用率与服务端等级着色，不影响相邻窗口与会话金额。 */
+function renderClaudeQuotaSegment(
+  content: React.ReactNode,
+  usedPercent: number,
+  serverSeverity: string | null | undefined,
+): React.ReactNode {
+  const severity = effectiveQuotaSeverity(usedPercent, serverSeverity);
   const colorClass = severity === 'warn'
     ? 'text-[var(--quota-bar-warn)]'
     : severity === 'crit'
@@ -1446,7 +1453,11 @@ export function TodaySpendChip({
   const windowSegments: React.ReactNode[] = chipWindows.map((window, index) => {
     const renderWindowContent = (content: React.ReactNode) => (
       usesClaudeQuotaChipSegments
-        ? renderClaudeQuotaSegment(content, 100 - window.remainingPercent)
+        ? renderClaudeQuotaSegment(
+            content,
+            100 - window.remainingPercent,
+            window.serverSeverity,
+          )
         : content
     );
     if (window.resetPending) {
@@ -1690,7 +1701,10 @@ export function TodaySpendChip({
     : 'normal';
   const visibleClaudeQuotaSeverity = usesClaudeQuotaChipSegments
     ? chipWindows.reduce<QuotaSeverity>((highestSeverity, window) => {
-        const severity = quotaSeverity(100 - window.remainingPercent);
+        const severity = effectiveQuotaSeverity(
+          100 - window.remainingPercent,
+          window.serverSeverity,
+        );
         return QUOTA_SEVERITY_RANK[severity] > QUOTA_SEVERITY_RANK[highestSeverity]
           ? severity
           : highestSeverity;

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1001,6 +1001,19 @@ function renderSegmentedLabel(segments: React.ReactNode[]): React.ReactNode {
   ));
 }
 
+/** Claude 额度段的非颜色严重度文案；普通段无需额外读出。 */
+function getClaudeQuotaSeverityLabel(
+  severity: QuotaSeverity,
+  t: TFunction,
+): string | null {
+  if (severity === 'normal') return null;
+  return t(
+    severity === 'warn'
+      ? 'todaySpend.claude.limitWarning'
+      : 'todaySpend.claude.limitRejected',
+  );
+}
+
 /** Claude 订阅额度段合并本地利用率与服务端等级着色，不影响相邻窗口与会话金额。 */
 function renderClaudeQuotaSegment(
   content: React.ReactNode,
@@ -1016,13 +1029,8 @@ function renderClaudeQuotaSegment(
       ? 'text-[var(--quota-bar-crit)]'
       : undefined;
   // 普通段沿用可见文字，只有告警段补充非颜色信号；严重级必须与警告级读出不同语义。
-  const ariaLabel = severity === 'normal'
-    ? undefined
-    : `${visibleText} ${t(
-        severity === 'warn'
-          ? 'todaySpend.claude.limitWarning'
-          : 'todaySpend.claude.limitRejected',
-      )}`;
+  const severityLabel = getClaudeQuotaSeverityLabel(severity, t);
+  const ariaLabel = severityLabel ? `${visibleText} ${severityLabel}` : undefined;
 
   return (
     <>
@@ -1729,6 +1737,24 @@ export function TodaySpendChip({
           : highestSeverity;
       }, 'normal')
     : 'normal';
+  // button 自身的 aria-label 会覆盖后代段落的 accessible name；把每个升级段使用的
+  // 同一份严重度文案提升到 trigger，确保读屏仍能听见 warn / crit 的区别。
+  const triggerAccessibleName = usageDashboardLabel
+    ? [
+        usageDashboardLabel,
+        ...(usesClaudeQuotaChipSegments
+          ? chipWindows
+              .map((window) => getClaudeQuotaSeverityLabel(
+                effectiveQuotaSeverity(
+                  100 - window.remainingPercent,
+                  window.serverSeverity,
+                ),
+                t,
+              ))
+              .filter((label): label is string => label !== null)
+          : []),
+      ].join(' ')
+    : null;
   const showClaudeSubscriptionFallbackAlert =
     QUOTA_SEVERITY_RANK[visibleClaudeQuotaSeverity]
       < QUOTA_SEVERITY_RANK[claudeSubscriptionAlertSeverity];
@@ -1797,7 +1823,7 @@ export function TodaySpendChip({
                   closeQuotaPopoverImmediately();
                 }}
                 className={buttonClass}
-                aria-label={usageDashboardLabel ?? undefined}
+                aria-label={triggerAccessibleName ?? undefined}
               >
                 {labelNode}
               </button>
@@ -1869,7 +1895,7 @@ export function TodaySpendChip({
               type="button"
               onClick={handleClick}
               className={buttonClass}
-              aria-label={usageDashboardLabel ?? undefined}
+              aria-label={triggerAccessibleName ?? undefined}
             >
               {labelNode}
             </button>

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -1004,8 +1004,10 @@ function renderSegmentedLabel(segments: React.ReactNode[]): React.ReactNode {
 /** Claude 订阅额度段合并本地利用率与服务端等级着色，不影响相邻窗口与会话金额。 */
 function renderClaudeQuotaSegment(
   content: React.ReactNode,
+  visibleText: string,
   usedPercent: number,
   serverSeverity: string | null | undefined,
+  t: TFunction,
 ): React.ReactNode {
   const severity = effectiveQuotaSeverity(usedPercent, serverSeverity);
   const colorClass = severity === 'warn'
@@ -1013,6 +1015,14 @@ function renderClaudeQuotaSegment(
     : severity === 'crit'
       ? 'text-[var(--quota-bar-crit)]'
       : undefined;
+  // 普通段沿用可见文字，只有告警段补充非颜色信号；严重级必须与警告级读出不同语义。
+  const ariaLabel = severity === 'normal'
+    ? undefined
+    : `${visibleText} ${t(
+        severity === 'warn'
+          ? 'todaySpend.claude.limitWarning'
+          : 'todaySpend.claude.limitRejected',
+      )}`;
 
   return (
     <>
@@ -1020,10 +1030,16 @@ function renderClaudeQuotaSegment(
         <span
           aria-hidden="true"
           data-quota-critical-dot
-          className="mr-1 inline-block size-1.5 rounded-full bg-[var(--quota-bar-crit)] align-middle animate-pulse motion-reduce:animate-none"
+          className="session-status-breathing mr-1 inline-block size-1.5 rounded-full bg-[var(--quota-bar-crit)] align-middle"
         />
       )}
-      <span data-quota-severity={severity} className={colorClass}>{content}</span>
+      <span
+        aria-label={ariaLabel}
+        data-quota-severity={severity}
+        className={colorClass}
+      >
+        {content}
+      </span>
     </>
   );
 }
@@ -1451,12 +1467,14 @@ export function TodaySpendChip({
   // 窗口段元素登记表(key → span): 撒花锚点用, 段消失时由 ref 回调置 null。
   const segmentElsRef = React.useRef<Record<string, HTMLSpanElement | null>>({});
   const windowSegments: React.ReactNode[] = chipWindows.map((window, index) => {
-    const renderWindowContent = (content: React.ReactNode) => (
+    const renderWindowContent = (content: React.ReactNode, visibleText: string) => (
       usesClaudeQuotaChipSegments
         ? renderClaudeQuotaSegment(
             content,
+            visibleText,
             100 - window.remainingPercent,
             window.serverSeverity,
+            t,
           )
         : content
     );
@@ -1472,6 +1490,7 @@ export function TodaySpendChip({
               {t('todaySpend.resetPendingSegment', { label: window.label })}
               <span className="motion-safe:animate-pulse">…</span>
             </>,
+            `${t('todaySpend.resetPendingSegment', { label: window.label })}…`,
           )}
         </React.Fragment>
       );
@@ -1493,7 +1512,7 @@ export function TodaySpendChip({
           segmentElsRef.current[window.key] = el;
         }}
       >
-        {renderWindowContent(text)}
+        {renderWindowContent(text, text)}
       </span>
     );
   });

--- a/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
+++ b/apps/desktop/src/renderer/components/status/TodaySpendChip.tsx
@@ -113,7 +113,11 @@ import {
   type QuotaHoverCardSessionUsage,
   type QuotaHoverCardTurnUsage,
 } from './QuotaHoverCard';
-import { quotaSeverity, type QuotaSeverity } from './QuotaBar';
+import {
+  effectiveQuotaSeverity,
+  quotaSeverity,
+  type QuotaSeverity,
+} from './QuotaBar';
 import { QuotaResetConfetti } from './QuotaResetConfetti';
 
 // XD 网关 / 托管账号之前会跳到内部用量看板(内部域名)—— 开源前移除该硬编码。
@@ -1024,8 +1028,8 @@ const QUOTA_SEVERITY_RANK: Record<QuotaSeverity, number> = {
 };
 
 /**
- * 整 chip 兜底告警的等级：被拒或当前会话相关窗口达到 90% 为严重告警；
- * 其余由上游非 normal severity 触发的告警按警告级处理。
+ * 整 chip 兜底告警的等级：被拒直接视为严重告警；其余窗口分别合并本地利用率
+ * 与服务端 severity 后取最高等级。非窗口信号触发的告警按警告级处理。
  */
 function getClaudeSubscriptionAlertSeverity(
   snapshot: ClaudeSubscriptionUsageSnapshot | null,
@@ -1039,12 +1043,19 @@ function getClaudeSubscriptionAlertSeverity(
     snapshot?.sevenDay,
     matchScopedWindowForModel(snapshot?.scoped, modelId),
   ];
-  const hasCriticalWindow = sessionWindows.some((window) => (
-    typeof window?.utilization === 'number'
-    && Number.isFinite(window.utilization)
-    && quotaSeverity(window.utilization) === 'crit'
-  ));
-  return hasCriticalWindow ? 'crit' : 'warn';
+  const highestWindowSeverity = sessionWindows.reduce<QuotaSeverity>(
+    (highestSeverity, window) => {
+      if (typeof window?.utilization !== 'number' || !Number.isFinite(window.utilization)) {
+        return highestSeverity;
+      }
+      const severity = effectiveQuotaSeverity(window.utilization, window.severity);
+      return QUOTA_SEVERITY_RANK[severity] > QUOTA_SEVERITY_RANK[highestSeverity]
+        ? severity
+        : highestSeverity;
+    },
+    'normal',
+  );
+  return highestWindowSeverity === 'normal' ? 'warn' : highestWindowSeverity;
 }
 
 interface TodaySpendChipProps {

--- a/apps/desktop/src/renderer/components/status/__tests__/QuotaBar.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/QuotaBar.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { QuotaBar, quotaSeverity } from '../QuotaBar';
+import { effectiveQuotaSeverity, QuotaBar, quotaSeverity } from '../QuotaBar';
 
 const colorsSource = readFileSync(
   resolve(__dirname, '..', '..', '..', 'themes', 'colors.ts'),
@@ -48,6 +48,23 @@ describe('QuotaBar', () => {
   ] as const)('derives $usedPercent as $expected severity', ({ usedPercent, expected }) => {
     expect(quotaSeverity(usedPercent)).toBe(expected);
   });
+
+  // 任何非 normal 的未知服务端等级都至少保留告警，且不能覆盖更严重的本地利用率等级。
+  it.each([
+    { serverSeverity: 'warning', usedPercent: 50, expected: 'warn' },
+    { serverSeverity: undefined, usedPercent: 50, expected: 'normal' },
+    { serverSeverity: '', usedPercent: 50, expected: 'normal' },
+    { serverSeverity: 'unknown-upstream-value', usedPercent: 50, expected: 'warn' },
+    { serverSeverity: 'hard_limit', usedPercent: 50, expected: 'warn' },
+    { serverSeverity: 'quota_exceeded', usedPercent: 50, expected: 'crit' },
+    { serverSeverity: 'critical', usedPercent: 50, expected: 'crit' },
+    { serverSeverity: 'normal', usedPercent: 93, expected: 'crit' },
+  ] as const)(
+    'combines server severity $serverSeverity and $usedPercent% utilization as $expected',
+    ({ serverSeverity, usedPercent, expected }) => {
+      expect(effectiveQuotaSeverity(usedPercent, serverSeverity)).toBe(expected);
+    },
+  );
 
   it('renders distinct regular and mini size classes', () => {
     const { getByRole, rerender } = render(<QuotaBar usedPercent={1} />);

--- a/apps/desktop/src/renderer/components/status/__tests__/QuotaBar.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/QuotaBar.test.tsx
@@ -66,6 +66,13 @@ describe('QuotaBar', () => {
     },
   );
 
+  // 脏快照可能把 severity 写成非字符串;按缺失处理,本地利用率等级不受影响。
+  it('treats non-string dirty server severity as missing without throwing', () => {
+    expect(effectiveQuotaSeverity(50, 123)).toBe('normal');
+    expect(effectiveQuotaSeverity(93, { level: 'exceeded' })).toBe('crit');
+    expect(effectiveQuotaSeverity(50, ['critical'])).toBe('normal');
+  });
+
   it('renders distinct regular and mini size classes', () => {
     const { getByRole, rerender } = render(<QuotaBar usedPercent={1} />);
     const regular = getByRole('progressbar');

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -213,7 +213,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(normalSegment?.getAttribute('aria-label')).toBeNull();
   });
 
-  it('93% 已用量只把对应段染红并显示可降级的 6px 呼吸圆点', () => {
+  it('93% 已用量只把对应段染红，不叠加圆点等附加装饰(维护者产品结论)', () => {
     setClaudeUsage(93, 20);
     const { container } = renderClaudeSubscriptionChip();
 
@@ -226,15 +226,8 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
       }),
     ).toBeTruthy();
 
-    const dot = criticalSegment?.parentElement?.querySelector<HTMLElement>(
-      '[data-quota-critical-dot]',
-    );
-    expect(dot).toBeTruthy();
-    expect(dot?.className).toContain('size-1.5');
-    expect(dot?.className).toContain('rounded-full');
-    expect(dot?.className).toContain('session-status-breathing');
-    expect(dot?.className).not.toContain('animate-pulse');
-    expect(dot?.getAttribute('aria-hidden')).toBe('true');
+    // 2026-08-05 dashhuang APPROVE 附带结论:红色段前不再叠加红点。
+    expect(container.querySelector('[data-quota-critical-dot]')).toBeNull();
 
     const normalSegment = container.querySelector<HTMLElement>('[data-quota-severity="normal"]');
     expect(normalSegment?.textContent).toBe('6天 剩余 80%');

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -245,7 +245,41 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(container.textContent).toContain('Opus 6天 剩余 80%');
     expect(container.textContent).not.toContain('剩余 5%');
     expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
-      .toContain('text-[var(--error-fg)]');
+      .toContain('text-[var(--quota-bar-crit)]');
+  });
+
+  it('可见窗口均正常但隐藏总周限为 warning 时显示琥珀色兜底', () => {
+    setClaudeUsage(20, 20);
+    mocks.claudeSnapshot!.sevenDay!.severity = 'warning';
+    mocks.claudeSnapshot!.scoped = [{
+      utilization: 20,
+      modelDisplayName: 'Opus',
+      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+    }];
+    const { container } = renderClaudeSubscriptionChip();
+
+    const segments = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
+    );
+    expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['normal', 'normal']);
+    const buttonClass = screen.getByRole('button', { name: '打开 Claude 用量页面' }).className;
+    expect(buttonClass).toContain('text-[var(--quota-bar-warn)]');
+    expect(buttonClass).not.toContain('--quota-bar-crit');
+    expect(buttonClass).not.toContain('--error-fg');
+  });
+
+  it('rejected 状态在可见窗口均正常时仍显示红色兜底', () => {
+    setClaudeUsage(20, 20);
+    mocks.claudeSnapshot!.rateLimitStatus = 'rejected';
+    const { container } = renderClaudeSubscriptionChip();
+
+    const segments = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
+    );
+    expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['normal', 'normal']);
+    const buttonClass = screen.getByRole('button', { name: '打开 Claude 用量页面' }).className;
+    expect(buttonClass).toContain('text-[var(--quota-bar-crit)]');
+    expect(buttonClass).not.toContain('--quota-bar-warn');
   });
 
   it('隐藏总周限利用率仅 50% 但服务端为 critical 时仍显示红色兜底', () => {
@@ -262,7 +296,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(container.textContent).toContain('Opus 6天 剩余 80%');
     expect(container.textContent).not.toContain('周限 剩余 50%');
     expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
-      .toContain('text-[var(--error-fg)]');
+      .toContain('text-[var(--quota-bar-crit)]');
   });
 
   it('隐藏总周限利用率 50% 且服务端为 normal 时保持原有警告段展示', () => {

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -194,6 +194,42 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
       .not.toContain('--error-fg');
   });
 
+  it('当前模型 scoped 周限正常但隐藏的总周限告警时保留整 chip 告警兜底', () => {
+    setClaudeUsage(20, 95);
+    mocks.claudeSnapshot!.scoped = [{
+      utilization: 20,
+      modelDisplayName: 'Opus',
+      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+    }];
+    const { container } = renderClaudeSubscriptionChip();
+
+    const segments = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
+    );
+    expect(segments).toHaveLength(2);
+    expect(segments.every((segment) => segment.dataset.quotaSeverity === 'normal')).toBe(true);
+    expect(container.textContent).toContain('Opus 6天 剩余 80%');
+    expect(container.textContent).not.toContain('剩余 5%');
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .toContain('text-[var(--error-fg)]');
+  });
+
+  it('当前模型 scoped 周限已有红色段时不重复显示整 chip 告警兜底', () => {
+    setClaudeUsage(20, 95);
+    mocks.claudeSnapshot!.scoped = [{
+      utilization: 93,
+      modelDisplayName: 'Opus',
+      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+    }];
+    const { container } = renderClaudeSubscriptionChip();
+
+    const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
+    expect(criticalSegment?.textContent).toBe('Opus 6天 剩余 7%');
+    expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .not.toContain('--error-fg');
+  });
+
   it('非 Claude 订阅计费形态不挂载额度严重度 span', () => {
     setClaudeUsage(93, 76);
     mocks.accountUsage = {

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -168,6 +168,39 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(container.querySelector('[data-quota-critical-dot]')).toBeNull();
   });
 
+  it('可见窗口利用率 50% 但服务端为 warning 时段显示琥珀色且不重复整 chip 告警', () => {
+    setClaudeUsage(50, 20);
+    mocks.claudeSnapshot!.fiveHour!.severity = 'warning';
+    const { container } = renderClaudeSubscriptionChip();
+
+    const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
+    expect(warningSegment?.textContent).toBe('5小时 剩余 50%');
+    expect(warningSegment?.className).toContain('text-[var(--quota-bar-warn)]');
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .not.toContain('--error-fg');
+  });
+
+  it('可见窗口利用率 50% 但服务端为 critical 时段显示红色', () => {
+    setClaudeUsage(50, 20);
+    mocks.claudeSnapshot!.fiveHour!.severity = 'critical';
+    const { container } = renderClaudeSubscriptionChip();
+
+    const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
+    expect(criticalSegment?.textContent).toBe('5小时 剩余 50%');
+    expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .not.toContain('--error-fg');
+  });
+
+  it('可见窗口利用率 50% 且服务端等级缺省时保持普通段', () => {
+    setClaudeUsage(50, 20);
+    const { container } = renderClaudeSubscriptionChip();
+
+    const normalSegment = container.querySelector<HTMLElement>('[data-quota-severity="normal"]');
+    expect(normalSegment?.textContent).toBe('5小时 剩余 50%');
+    expect(normalSegment?.getAttribute('class')).toBeNull();
+  });
+
   it('93% 已用量只把对应段染红并显示可降级的 6px 呼吸圆点', () => {
     setClaudeUsage(93, 20);
     const { container } = renderClaudeSubscriptionChip();

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -23,6 +23,8 @@ vi.mock('react-i18next', () => ({
         'todaySpend.claude.weeklyLabel': '周限',
         'todaySpend.claude.modelWeeklyLabel': '{{model}} 周限',
         'todaySpend.claude.windowSegment': '{{label}} 剩余 {{remaining}}',
+        'todaySpend.claude.limitWarning': '接近套餐限额',
+        'todaySpend.claude.limitRejected': '已触发套餐限额，请求可能被拒绝',
         'todaySpend.codex.limitWindow': '限额',
         'todaySpend.codex.windowSegment': '{{label}} 剩余 {{remaining}}',
         'todaySpend.sessionCostLabel': '本任务 {{cost}}',
@@ -176,6 +178,9 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 50%');
     expect(warningSegment?.className).toContain('text-[var(--quota-bar-warn)]');
+    expect(warningSegment?.getAttribute('aria-label')).toBe(
+      '5小时 剩余 50% 接近套餐限额',
+    );
     expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
       .not.toContain('--error-fg');
   });
@@ -188,6 +193,9 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
     expect(criticalSegment?.textContent).toBe('5小时 剩余 50%');
     expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
+    expect(criticalSegment?.getAttribute('aria-label')).toBe(
+      '5小时 剩余 50% 已触发套餐限额，请求可能被拒绝',
+    );
     expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
       .not.toContain('--error-fg');
   });
@@ -199,6 +207,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const normalSegment = container.querySelector<HTMLElement>('[data-quota-severity="normal"]');
     expect(normalSegment?.textContent).toBe('5小时 剩余 50%');
     expect(normalSegment?.getAttribute('class')).toBeNull();
+    expect(normalSegment?.getAttribute('aria-label')).toBeNull();
   });
 
   it('93% 已用量只把对应段染红并显示可降级的 6px 呼吸圆点', () => {
@@ -215,8 +224,8 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(dot).toBeTruthy();
     expect(dot?.className).toContain('size-1.5');
     expect(dot?.className).toContain('rounded-full');
-    expect(dot?.className).toContain('animate-pulse');
-    expect(dot?.className).toContain('motion-reduce:animate-none');
+    expect(dot?.className).toContain('session-status-breathing');
+    expect(dot?.className).not.toContain('animate-pulse');
     expect(dot?.getAttribute('aria-hidden')).toBe('true');
 
     const normalSegment = container.querySelector<HTMLElement>('[data-quota-severity="normal"]');

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { ClaudeSubscriptionUsageSnapshot } from '../../../../shared/claudeSubscriptionUsage';
+import type { RateLimitSnapshot } from '@/hooks/useAccountUsage';
+
+const mocks = vi.hoisted(() => ({
+  claudeSnapshot: null as ClaudeSubscriptionUsageSnapshot | null,
+  accountUsage: null as RateLimitSnapshot | null,
+  displaySnapshot: { messages: [] as Array<Record<string, unknown>> },
+  openExternal: vi.fn(() => Promise.resolve()),
+  refreshCodexRateLimits: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'zh-CN', resolvedLanguage: 'zh-CN' },
+    t: (key: string, options: Record<string, string | number> = {}) => {
+      const templates: Record<string, string> = {
+        'todaySpend.openClaudeUsage': '打开 Claude 用量页面',
+        'todaySpend.claude.weeklyLabel': '周限',
+        'todaySpend.claude.modelWeeklyLabel': '{{model}} 周限',
+        'todaySpend.claude.windowSegment': '{{label}} 剩余 {{remaining}}',
+        'todaySpend.codex.limitWindow': '限额',
+        'todaySpend.codex.windowSegment': '{{label}} 剩余 {{remaining}}',
+        'todaySpend.sessionCostLabel': '本任务 {{cost}}',
+        'todaySpend.unit.day': '天',
+        'todaySpend.unit.hour': '小时',
+        'todaySpend.unit.minute': '分钟',
+        'todaySpend.unit.second': '秒',
+      };
+      return (templates[key] ?? key).replace(/{{(\w+)}}/g, (_, name: string) =>
+        String(options[name] ?? ''),
+      );
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useApiKey', () => ({
+  useApiKey: () => ({ hasSavedKey: false, isReconciling: false }),
+}));
+vi.mock('@/hooks/useClaudeOAuthConnected', () => ({
+  useClaudeOAuthConnected: () => true,
+}));
+vi.mock('@/hooks/useClaudeSessionRoute', () => ({
+  useClaudeSessionRoute: () => null,
+}));
+vi.mock('@/hooks/useSessionUsageMoney', () => ({
+  useSessionUsageMoney: () => ({
+    actualMoney: null,
+    estimatedValueMoney: null,
+    totalMoney: null,
+  }),
+}));
+vi.mock('@/hooks/useSessionTokens', () => ({ useSessionTokens: () => null }));
+vi.mock('@/hooks/useAccountUsage', () => ({
+  requestCodexAccountRefresh: vi.fn(),
+  useAccountUsage: () => mocks.accountUsage,
+}));
+vi.mock('@/hooks/useClaudeAccountUsage', () => ({ useClaudeAccountUsage: () => null }));
+vi.mock('@/hooks/useModelAccessCreditUsage', () => ({ useModelAccessCreditUsage: () => null }));
+vi.mock('@/hooks/useClaudeSubscriptionUsage', () => ({
+  requestClaudeSubscriptionRefresh: vi.fn(),
+  useClaudeSubscriptionUsage: () => mocks.claudeSnapshot,
+}));
+vi.mock('@/hooks/useCodexRuntimeRoute', () => ({
+  useCodexRuntimeRoute: () => ({ authInjection: null }),
+}));
+vi.mock('@/hooks/useCodexRateLimits', () => ({
+  useCodexRateLimits: () => ({
+    snapshot: null,
+    refresh: mocks.refreshCodexRateLimits,
+  }),
+}));
+vi.mock('@/hooks/useXaiRateLimit', () => ({ useXaiRateLimit: () => null }));
+vi.mock('@/components/chat/ChatDisplaySnapshotContext', () => ({
+  useChatDisplaySnapshot: () => mocks.displaySnapshot,
+}));
+vi.mock('@/lib/makerChatStore', () => ({
+  makerChatStore: {
+    getSnapshot: () => mocks.displaySnapshot,
+    subscribe: () => () => undefined,
+  },
+}));
+
+import { TodaySpendChip } from '../TodaySpendChip';
+
+const NOW_MS = Date.UTC(2026, 7, 2, 0, 0, 0);
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+function setClaudeUsage(fiveHourUsed: number, weeklyUsed: number) {
+  mocks.claudeSnapshot = {
+    source: 'oauth-endpoint',
+    subscriptionType: 'max',
+    fiveHour: {
+      utilization: fiveHourUsed,
+      resetsAt: (NOW_MS + 5 * HOUR_MS) / 1000,
+    },
+    sevenDay: {
+      utilization: weeklyUsed,
+      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+    },
+  };
+}
+
+function renderClaudeSubscriptionChip() {
+  return render(
+    <TodaySpendChip
+      vendorKey="cc"
+      providerId="anthropic"
+      modelId="claude-opus-5[1m]"
+      sessionId="session-1"
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW_MS);
+  mocks.accountUsage = null;
+  mocks.displaySnapshot.messages = [];
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: { openExternal: mocks.openExternal },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('TodaySpendChip Claude 订阅额度段着色', () => {
+  it('正常段不着色，且完整保留原有动态倒计时文字', () => {
+    setClaudeUsage(1, 4);
+    const { container } = renderClaudeSubscriptionChip();
+
+    const segments = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
+    );
+    expect(segments.map((segment) => segment.textContent)).toEqual([
+      '5小时 剩余 99%',
+      '6天 剩余 96%',
+    ]);
+    expect(segments.every((segment) => segment.dataset.quotaSeverity === 'normal')).toBe(true);
+    expect(segments.every((segment) => !segment.getAttribute('class'))).toBe(true);
+    expect(container.querySelector('[data-quota-critical-dot]')).toBeNull();
+
+    const text = screen.getByRole('button', { name: '打开 Claude 用量页面' }).textContent ?? '';
+    expect(text).toContain('5小时 剩余 99%');
+    expect(text).toContain('6天 剩余 96%');
+    expect(text).not.toContain('5h');
+    expect(text).not.toContain('周');
+  });
+
+  it('76% 已用量只把对应段染成琥珀色，不显示圆点', () => {
+    setClaudeUsage(76, 20);
+    const { container } = renderClaudeSubscriptionChip();
+
+    const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
+    expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
+    expect(warningSegment?.className).toContain('text-[var(--quota-bar-warn)]');
+    expect(container.querySelector('[data-quota-critical-dot]')).toBeNull();
+  });
+
+  it('93% 已用量只把对应段染红并显示可降级的 6px 呼吸圆点', () => {
+    setClaudeUsage(93, 20);
+    const { container } = renderClaudeSubscriptionChip();
+
+    const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
+    expect(criticalSegment?.textContent).toBe('5小时 剩余 7%');
+    expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
+
+    const dot = criticalSegment?.parentElement?.querySelector<HTMLElement>(
+      '[data-quota-critical-dot]',
+    );
+    expect(dot).toBeTruthy();
+    expect(dot?.className).toContain('size-1.5');
+    expect(dot?.className).toContain('rounded-full');
+    expect(dot?.className).toContain('animate-pulse');
+    expect(dot?.className).toContain('motion-reduce:animate-none');
+    expect(dot?.getAttribute('aria-hidden')).toBe('true');
+
+    const normalSegment = container.querySelector<HTMLElement>('[data-quota-severity="normal"]');
+    expect(normalSegment?.textContent).toBe('6天 剩余 80%');
+    expect(normalSegment?.getAttribute('class')).toBeNull();
+    expect(normalSegment?.parentElement?.querySelector('[data-quota-critical-dot]')).toBeNull();
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .not.toContain('--error-fg');
+  });
+
+  it('非 Claude 订阅计费形态不挂载额度严重度 span', () => {
+    setClaudeUsage(93, 76);
+    mocks.accountUsage = {
+      primary: {
+        usedPercent: 93,
+        windowMinutes: 300,
+        resetsAt: (NOW_MS + 5 * HOUR_MS) / 1000,
+      },
+      secondary: {
+        usedPercent: 76,
+        windowMinutes: 10_080,
+        resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+      },
+    };
+    const { container } = render(
+      <TodaySpendChip
+        vendorKey="cc"
+        providerId="openai"
+        modelId="chatgpt/gpt-5.5"
+        sessionId="session-1"
+      />,
+    );
+
+    expect(container.textContent).toContain('5小时 剩余 7%');
+    expect(container.textContent).toContain('6天 剩余 24%');
+    expect(container.querySelector('[data-quota-severity]')).toBeNull();
+    expect(container.querySelector('[data-quota-critical-dot]')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -167,6 +167,9 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
     expect(warningSegment?.className).toContain('text-[var(--quota-bar-warn)]');
+    expect(screen.getByRole('button', {
+      name: '打开 Claude 用量页面 接近套餐限额',
+    })).toBeTruthy();
     expect(container.querySelector('[data-quota-critical-dot]')).toBeNull();
   });
 
@@ -181,7 +184,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(warningSegment?.getAttribute('aria-label')).toBe(
       '5小时 剩余 50% 接近套餐限额',
     );
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .not.toContain('--error-fg');
   });
 
@@ -196,7 +199,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(criticalSegment?.getAttribute('aria-label')).toBe(
       '5小时 剩余 50% 已触发套餐限额，请求可能被拒绝',
     );
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .not.toContain('--error-fg');
   });
 
@@ -217,6 +220,9 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
     expect(criticalSegment?.textContent).toBe('5小时 剩余 7%');
     expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
+    expect(screen.getByRole('button', {
+      name: '打开 Claude 用量页面 已触发套餐限额，请求可能被拒绝',
+    })).toBeTruthy();
 
     const dot = criticalSegment?.parentElement?.querySelector<HTMLElement>(
       '[data-quota-critical-dot]',
@@ -232,7 +238,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(normalSegment?.textContent).toBe('6天 剩余 80%');
     expect(normalSegment?.getAttribute('class')).toBeNull();
     expect(normalSegment?.parentElement?.querySelector('[data-quota-critical-dot]')).toBeNull();
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .not.toContain('--error-fg');
   });
 
@@ -253,7 +259,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(container.textContent).toContain('5小时 剩余 24%');
     expect(container.textContent).toContain('Opus 6天 剩余 80%');
     expect(container.textContent).not.toContain('剩余 5%');
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .toContain('text-[var(--quota-bar-crit)]');
   });
 
@@ -271,7 +277,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
       container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
     );
     expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['normal', 'normal']);
-    const buttonClass = screen.getByRole('button', { name: '打开 Claude 用量页面' }).className;
+    const buttonClass = screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className;
     expect(buttonClass).toContain('text-[var(--quota-bar-warn)]');
     expect(buttonClass).not.toContain('--quota-bar-crit');
     expect(buttonClass).not.toContain('--error-fg');
@@ -286,7 +292,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
       container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
     );
     expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['normal', 'normal']);
-    const buttonClass = screen.getByRole('button', { name: '打开 Claude 用量页面' }).className;
+    const buttonClass = screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className;
     expect(buttonClass).toContain('text-[var(--quota-bar-crit)]');
     expect(buttonClass).not.toContain('--quota-bar-warn');
   });
@@ -304,7 +310,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(container.textContent).toContain('5小时 剩余 24%');
     expect(container.textContent).toContain('Opus 6天 剩余 80%');
     expect(container.textContent).not.toContain('周限 剩余 50%');
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .toContain('text-[var(--quota-bar-crit)]');
   });
 
@@ -321,7 +327,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
     expect(container.textContent).not.toContain('周限 剩余 50%');
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .not.toContain('--error-fg');
   });
 
@@ -337,7 +343,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
     expect(criticalSegment?.textContent).toBe('Opus 6天 剩余 7%');
     expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .not.toContain('--error-fg');
   });
 
@@ -354,7 +360,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
     expect(container.textContent).not.toContain('周限 剩余 80%');
-    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
       .not.toContain('--error-fg');
   });
 

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -215,6 +215,40 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
       .toContain('text-[var(--error-fg)]');
   });
 
+  it('隐藏总周限利用率仅 50% 但服务端为 critical 时仍显示红色兜底', () => {
+    setClaudeUsage(76, 50);
+    mocks.claudeSnapshot!.sevenDay!.severity = 'critical';
+    mocks.claudeSnapshot!.scoped = [{
+      utilization: 20,
+      modelDisplayName: 'Opus',
+      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+    }];
+    const { container } = renderClaudeSubscriptionChip();
+
+    expect(container.textContent).toContain('5小时 剩余 24%');
+    expect(container.textContent).toContain('Opus 6天 剩余 80%');
+    expect(container.textContent).not.toContain('周限 剩余 50%');
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .toContain('text-[var(--error-fg)]');
+  });
+
+  it('隐藏总周限利用率 50% 且服务端为 normal 时保持原有警告段展示', () => {
+    setClaudeUsage(76, 50);
+    mocks.claudeSnapshot!.sevenDay!.severity = 'normal';
+    mocks.claudeSnapshot!.scoped = [{
+      utilization: 20,
+      modelDisplayName: 'Opus',
+      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+    }];
+    const { container } = renderClaudeSubscriptionChip();
+
+    const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
+    expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
+    expect(container.textContent).not.toContain('周限 剩余 50%');
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .not.toContain('--error-fg');
+  });
+
   it('当前模型 scoped 周限已有红色段时不重复显示整 chip 告警兜底', () => {
     setClaudeUsage(20, 95);
     mocks.claudeSnapshot!.scoped = [{

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -194,8 +194,8 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
       .not.toContain('--error-fg');
   });
 
-  it('当前模型 scoped 周限正常但隐藏的总周限告警时保留整 chip 告警兜底', () => {
-    setClaudeUsage(20, 95);
+  it('可见段仅为警告色但隐藏总周限已严重告警时保留整 chip 告警兜底', () => {
+    setClaudeUsage(76, 95);
     mocks.claudeSnapshot!.scoped = [{
       utilization: 20,
       modelDisplayName: 'Opus',
@@ -207,7 +207,8 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
       container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
     );
     expect(segments).toHaveLength(2);
-    expect(segments.every((segment) => segment.dataset.quotaSeverity === 'normal')).toBe(true);
+    expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['warn', 'normal']);
+    expect(container.textContent).toContain('5小时 剩余 24%');
     expect(container.textContent).toContain('Opus 6天 剩余 80%');
     expect(container.textContent).not.toContain('剩余 5%');
     expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
@@ -226,6 +227,23 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
     expect(criticalSegment?.textContent).toBe('Opus 6天 剩余 7%');
     expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
+    expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
+      .not.toContain('--error-fg');
+  });
+
+  it('可见警告段与隐藏窗口的警告级告警等强时不重复显示整 chip 告警兜底', () => {
+    setClaudeUsage(76, 20);
+    mocks.claudeSnapshot!.sevenDay!.severity = 'warning';
+    mocks.claudeSnapshot!.scoped = [{
+      utilization: 20,
+      modelDisplayName: 'Opus',
+      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+    }];
+    const { container } = renderClaudeSubscriptionChip();
+
+    const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
+    expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
+    expect(container.textContent).not.toContain('周限 剩余 80%');
     expect(screen.getByRole('button', { name: '打开 Claude 用量页面' }).className)
       .not.toContain('--error-fg');
   });

--- a/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
+++ b/apps/desktop/src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx
@@ -142,9 +142,7 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     setClaudeUsage(1, 4);
     const { container } = renderClaudeSubscriptionChip();
 
-    const segments = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
-    );
+    const segments = Array.from(container.querySelectorAll<HTMLElement>('[data-quota-severity]'));
     expect(segments.map((segment) => segment.textContent)).toEqual([
       '5小时 剩余 99%',
       '6天 剩余 96%',
@@ -167,9 +165,11 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
     expect(warningSegment?.className).toContain('text-[var(--quota-bar-warn)]');
-    expect(screen.getByRole('button', {
-      name: '打开 Claude 用量页面 接近套餐限额',
-    })).toBeTruthy();
+    expect(
+      screen.getByRole('button', {
+        name: '打开 Claude 用量页面 接近套餐限额',
+      }),
+    ).toBeTruthy();
     expect(container.querySelector('[data-quota-critical-dot]')).toBeNull();
   });
 
@@ -181,11 +181,10 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 50%');
     expect(warningSegment?.className).toContain('text-[var(--quota-bar-warn)]');
-    expect(warningSegment?.getAttribute('aria-label')).toBe(
-      '5小时 剩余 50% 接近套餐限额',
+    expect(warningSegment?.getAttribute('aria-label')).toBe('5小时 剩余 50% 接近套餐限额');
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className).not.toContain(
+      '--error-fg',
     );
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .not.toContain('--error-fg');
   });
 
   it('可见窗口利用率 50% 但服务端为 critical 时段显示红色', () => {
@@ -199,8 +198,9 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(criticalSegment?.getAttribute('aria-label')).toBe(
       '5小时 剩余 50% 已触发套餐限额，请求可能被拒绝',
     );
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .not.toContain('--error-fg');
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className).not.toContain(
+      '--error-fg',
+    );
   });
 
   it('可见窗口利用率 50% 且服务端等级缺省时保持普通段', () => {
@@ -220,9 +220,11 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
     expect(criticalSegment?.textContent).toBe('5小时 剩余 7%');
     expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
-    expect(screen.getByRole('button', {
-      name: '打开 Claude 用量页面 已触发套餐限额，请求可能被拒绝',
-    })).toBeTruthy();
+    expect(
+      screen.getByRole('button', {
+        name: '打开 Claude 用量页面 已触发套餐限额，请求可能被拒绝',
+      }),
+    ).toBeTruthy();
 
     const dot = criticalSegment?.parentElement?.querySelector<HTMLElement>(
       '[data-quota-critical-dot]',
@@ -238,46 +240,52 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     expect(normalSegment?.textContent).toBe('6天 剩余 80%');
     expect(normalSegment?.getAttribute('class')).toBeNull();
     expect(normalSegment?.parentElement?.querySelector('[data-quota-critical-dot]')).toBeNull();
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .not.toContain('--error-fg');
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className).not.toContain(
+      '--error-fg',
+    );
   });
 
   it('可见段仅为警告色但隐藏总周限已严重告警时保留整 chip 告警兜底', () => {
     setClaudeUsage(76, 95);
-    mocks.claudeSnapshot!.scoped = [{
-      utilization: 20,
-      modelDisplayName: 'Opus',
-      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
-    }];
+    mocks.claudeSnapshot!.scoped = [
+      {
+        utilization: 20,
+        modelDisplayName: 'Opus',
+        resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+      },
+    ];
     const { container } = renderClaudeSubscriptionChip();
 
-    const segments = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
-    );
+    const segments = Array.from(container.querySelectorAll<HTMLElement>('[data-quota-severity]'));
     expect(segments).toHaveLength(2);
     expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['warn', 'normal']);
     expect(container.textContent).toContain('5小时 剩余 24%');
     expect(container.textContent).toContain('Opus 6天 剩余 80%');
     expect(container.textContent).not.toContain('剩余 5%');
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .toContain('text-[var(--quota-bar-crit)]');
+    // 兜底告警只染色不加段落，等级文案必须并入 trigger 可达名称供读屏播报。
+    const button = screen.getByRole('button', {
+      name: '打开 Claude 用量页面 接近套餐限额 已触发套餐限额，请求可能被拒绝',
+    });
+    expect(button.className).toContain('text-[var(--quota-bar-crit)]');
   });
 
   it('可见窗口均正常但隐藏总周限为 warning 时显示琥珀色兜底', () => {
     setClaudeUsage(20, 20);
     mocks.claudeSnapshot!.sevenDay!.severity = 'warning';
-    mocks.claudeSnapshot!.scoped = [{
-      utilization: 20,
-      modelDisplayName: 'Opus',
-      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
-    }];
+    mocks.claudeSnapshot!.scoped = [
+      {
+        utilization: 20,
+        modelDisplayName: 'Opus',
+        resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+      },
+    ];
     const { container } = renderClaudeSubscriptionChip();
 
-    const segments = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
-    );
+    const segments = Array.from(container.querySelectorAll<HTMLElement>('[data-quota-severity]'));
     expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['normal', 'normal']);
-    const buttonClass = screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className;
+    const buttonClass = screen.getByRole('button', {
+      name: '打开 Claude 用量页面 接近套餐限额',
+    }).className;
     expect(buttonClass).toContain('text-[var(--quota-bar-warn)]');
     expect(buttonClass).not.toContain('--quota-bar-crit');
     expect(buttonClass).not.toContain('--error-fg');
@@ -288,11 +296,11 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
     mocks.claudeSnapshot!.rateLimitStatus = 'rejected';
     const { container } = renderClaudeSubscriptionChip();
 
-    const segments = Array.from(
-      container.querySelectorAll<HTMLElement>('[data-quota-severity]'),
-    );
+    const segments = Array.from(container.querySelectorAll<HTMLElement>('[data-quota-severity]'));
     expect(segments.map((segment) => segment.dataset.quotaSeverity)).toEqual(['normal', 'normal']);
-    const buttonClass = screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className;
+    const buttonClass = screen.getByRole('button', {
+      name: '打开 Claude 用量页面 已触发套餐限额，请求可能被拒绝',
+    }).className;
     expect(buttonClass).toContain('text-[var(--quota-bar-crit)]');
     expect(buttonClass).not.toContain('--quota-bar-warn');
   });
@@ -300,68 +308,83 @@ describe('TodaySpendChip Claude 订阅额度段着色', () => {
   it('隐藏总周限利用率仅 50% 但服务端为 critical 时仍显示红色兜底', () => {
     setClaudeUsage(76, 50);
     mocks.claudeSnapshot!.sevenDay!.severity = 'critical';
-    mocks.claudeSnapshot!.scoped = [{
-      utilization: 20,
-      modelDisplayName: 'Opus',
-      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
-    }];
+    mocks.claudeSnapshot!.scoped = [
+      {
+        utilization: 20,
+        modelDisplayName: 'Opus',
+        resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+      },
+    ];
     const { container } = renderClaudeSubscriptionChip();
 
     expect(container.textContent).toContain('5小时 剩余 24%');
     expect(container.textContent).toContain('Opus 6天 剩余 80%');
     expect(container.textContent).not.toContain('周限 剩余 50%');
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .toContain('text-[var(--quota-bar-crit)]');
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className).toContain(
+      'text-[var(--quota-bar-crit)]',
+    );
   });
 
   it('隐藏总周限利用率 50% 且服务端为 normal 时保持原有警告段展示', () => {
     setClaudeUsage(76, 50);
     mocks.claudeSnapshot!.sevenDay!.severity = 'normal';
-    mocks.claudeSnapshot!.scoped = [{
-      utilization: 20,
-      modelDisplayName: 'Opus',
-      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
-    }];
+    mocks.claudeSnapshot!.scoped = [
+      {
+        utilization: 20,
+        modelDisplayName: 'Opus',
+        resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+      },
+    ];
     const { container } = renderClaudeSubscriptionChip();
 
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
     expect(container.textContent).not.toContain('周限 剩余 50%');
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .not.toContain('--error-fg');
+    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className).not.toContain(
+      '--error-fg',
+    );
   });
 
   it('当前模型 scoped 周限已有红色段时不重复显示整 chip 告警兜底', () => {
     setClaudeUsage(20, 95);
-    mocks.claudeSnapshot!.scoped = [{
-      utilization: 93,
-      modelDisplayName: 'Opus',
-      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
-    }];
+    mocks.claudeSnapshot!.scoped = [
+      {
+        utilization: 93,
+        modelDisplayName: 'Opus',
+        resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+      },
+    ];
     const { container } = renderClaudeSubscriptionChip();
 
     const criticalSegment = container.querySelector<HTMLElement>('[data-quota-severity="crit"]');
     expect(criticalSegment?.textContent).toBe('Opus 6天 剩余 7%');
     expect(criticalSegment?.className).toContain('text-[var(--quota-bar-crit)]');
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .not.toContain('--error-fg');
+    // 兜底被可见红段压制时，可达名称也只保留可见段的一份等级文案。
+    expect(
+      screen.getByRole('button', {
+        name: '打开 Claude 用量页面 已触发套餐限额，请求可能被拒绝',
+      }).className,
+    ).not.toContain('--error-fg');
   });
 
   it('可见警告段与隐藏窗口的警告级告警等强时不重复显示整 chip 告警兜底', () => {
     setClaudeUsage(76, 20);
     mocks.claudeSnapshot!.sevenDay!.severity = 'warning';
-    mocks.claudeSnapshot!.scoped = [{
-      utilization: 20,
-      modelDisplayName: 'Opus',
-      resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
-    }];
+    mocks.claudeSnapshot!.scoped = [
+      {
+        utilization: 20,
+        modelDisplayName: 'Opus',
+        resetsAt: (NOW_MS + 6 * DAY_MS) / 1000,
+      },
+    ];
     const { container } = renderClaudeSubscriptionChip();
 
     const warningSegment = container.querySelector<HTMLElement>('[data-quota-severity="warn"]');
     expect(warningSegment?.textContent).toBe('5小时 剩余 24%');
     expect(container.textContent).not.toContain('周限 剩余 80%');
-    expect(screen.getByRole('button', { name: /打开 Claude 用量页面/ }).className)
-      .not.toContain('--error-fg');
+    expect(
+      screen.getByRole('button', { name: '打开 Claude 用量页面 接近套餐限额' }).className,
+    ).not.toContain('--error-fg');
   });
 
   it('非 Claude 订阅计费形态不挂载额度严重度 span', () => {


### PR DESCRIPTION
> ⚠️ **Stacked PR**：基于 #1300 的分支续作。先合 #1300，本 PR 的 diff 即收敛为着色 commit。
> 📝 **本 PR 已按维护者 review 整体重做**：原「迷你进度条」方案经 @dashhuang 产品评审否决（底栏侵入性偏重），现方案为其批准的收窄版。旧实现相关的 review 线程所指代码已不存在。

## 这次改了什么

### 摘要

Claude 订阅计费形态的底栏额度 chip 增加**三态着色**（维护者获批的收窄方案）：文字内容与布局零改动——保留现有动态倒计时段（如「5小时 剩余 99%」），仅按对应窗口用量着色：≤70% 完全无变化；>70% 该段文字变琥珀；≥90% 该段变红（按 2026-08-05 维护者产品结论，不叠加圆点等附加装饰；非颜色信号由 aria 等级文案承担）。额度详情继续由 hover 卡片（#1300）承担。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求：#1261（chip 部分，经 #1316 评审收窄）
- 本 PR 包含：`TodaySpendChip` Claude 订阅分支 chip 段落着色（复用 #1300 的 `quotaSeverity` 与已注册语义 token）+ 配对测试 6 项。
- 明确不包含：任何文字/标签/布局变更（维护者明确保留动态倒计时设计）；进度条类元素；其它计费形态（byte-for-byte 不变）。
- 用户可见变化：仅额度紧张时的颜色提示；常态与现状完全一致。
- 是否存在 breaking change：无

### UI 变化

真组件渲染（配对测试同款环境导出 HTML × 应用样式管线成像；文字为动态倒计时段实值，演示数据）：

| 常态（≤70%，与线上现状逐字一致） | 深色 |
|---|---|
| ![normal](https://raw.githubusercontent.com/0xmariowu/cindy/quota-issue-assets/chipv2-normal.png) | ![dark](https://raw.githubusercontent.com/0xmariowu/cindy/quota-issue-assets/chipv2-dark.png) |

| >70% 该段琥珀 | ≥90% 该段红（截图中的呼吸点已按维护者结论移除） | 隐藏窗口 warn 告警兜底（整 chip 琥珀） |
|---|---|---|
| ![warn](https://raw.githubusercontent.com/0xmariowu/cindy/quota-issue-assets/chipv2-warn.png) | ![crit](https://raw.githubusercontent.com/0xmariowu/cindy/quota-issue-assets/chipv2-crit.png) | ![warnfb](https://raw.githubusercontent.com/0xmariowu/cindy/quota-issue-assets/chipv2-warnfb.png) |

维护者批准的方向示意见 PR 讨论。

- 引用的设计规范：同 #1300（阈值沿用 `quotaSeverity` 70/90 先例；颜色消费已注册语义 token `--quota-bar-warn`/`--quota-bar-crit`）。2026-08-05 维护者 APPROVE 附带结论已落地：红色段不叠加红点（`6c09d688`）；段间分割线为上游 chip 既有排版，本 PR 未新增。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/components/status/__tests__/TodaySpendChip.quotaChip.test.tsx \
  src/renderer/components/status/__tests__/TodaySpendChip.popover.test.tsx \
  src/renderer/__tests__/todaySpendChip.test.ts
结果：34 passed (34), exit 0
（含断言：段落文字仍为倒计时格式、不存在固定 5h/周 标签、三态钩子、非 Claude 形态零变化）
pnpm check:dco → 全部 signed off
```

### 手工验证

三态着色见 PR 讨论示意图；常态与线上现状逐字一致。

### 未执行的验证

同 #1300（Windows/Linux 未实测）。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Claude 订阅 chip 段落的条件着色。
- 回滚 / 降级方式：revert 着色 commit 即完整还原。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因


