### PR TITLE
fix(desktop): 修复 DeepSeek 图片失败后会话无法恢复

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -2108,7 +2108,7 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.onUiRetry).toHaveBeenCalledWith(sid, expect.any(String));
   });
 
-  it('removes an unsupported image when retrying a zero-progress text-and-image turn', async () => {
+  it('removes unsupported image blocks but preserves GIF and PDF files on retry', async () => {
     const h = createHarness();
     const sid = 'retry-unsupported-image-with-text';
     h.setHasAssistantProgressAfter(async () => false);
@@ -2123,6 +2123,16 @@ describe('AgentInputCoordinator send transaction', () => {
         category: 'image',
         mimeType: 'image/png',
         url: 'data:image/png;base64,aW1hZ2U=',
+      },
+      {
+        id: 'gif-1',
+        name: 'clip.gif',
+        path: '/repo/clip.gif',
+        ext: '.gif',
+        size: 6,
+        category: 'image',
+        mimeType: 'image/gif',
+        url: 'xdt-image://session/clip.gif',
       },
       {
         id: 'file-1',
@@ -2140,6 +2150,10 @@ describe('AgentInputCoordinator send transaction', () => {
         url: 'data:image/png;base64,aW1hZ2U=',
         mimeType: 'image/png',
         originalName: 'image.png',
+      }, {
+        url: 'xdt-image://session/clip.gif',
+        mimeType: 'image/gif',
+        originalName: 'clip.gif',
       }],
       files: [{ name: 'notes.pdf', path: '/repo/notes.pdf' }],
     });
@@ -2149,6 +2163,10 @@ describe('AgentInputCoordinator send transaction', () => {
         url: 'data:image/png;base64,aW1hZ2U=',
         mimeType: 'image/png',
         originalName: 'image.png',
+      }, {
+        url: 'xdt-image://session/clip.gif',
+        mimeType: 'image/gif',
+        originalName: 'clip.gif',
       }],
       files: [{ name: 'notes.pdf', path: '/repo/notes.pdf' }],
     };
@@ -2171,19 +2189,34 @@ describe('AgentInputCoordinator send transaction', () => {
       type: 'user',
       content: [
         { type: 'text', text: 'describe this' },
+        { type: 'file', path: 'xdt-image://session/clip.gif', mimeType: 'image/gif' },
         { type: 'file', path: '/repo/notes.pdf', mimeType: 'application/pdf' },
       ],
     });
     const retried = h.onDispatchedUserTurn.mock.calls[1]?.[1];
-    expect(retried?.files).toEqual([expect.objectContaining({ id: 'file-1', category: 'pdf' })]);
-    expect(retried?.chatMessage.images).toBeUndefined();
+    expect(retried?.files).toEqual([
+      expect.objectContaining({ id: 'gif-1', ext: '.gif', category: 'image' }),
+      expect.objectContaining({ id: 'file-1', category: 'pdf' }),
+    ]);
+    expect(retried?.chatMessage.images).toEqual([{
+      url: 'xdt-image://session/clip.gif',
+      mimeType: 'image/gif',
+      originalName: 'clip.gif',
+    }]);
     expect(retried?.chatMessage.files).toEqual([{ name: 'notes.pdf', path: '/repo/notes.pdf' }]);
     expect((retried?.chatMessage as typeof retried.chatMessage & {
       retryFiles?: AgentInputQueuedMessage['files'];
-    }).retryFiles).toEqual([expect.objectContaining({ id: 'file-1', category: 'pdf' })]);
+    }).retryFiles).toEqual([
+      expect.objectContaining({ id: 'gif-1', ext: '.gif', category: 'image' }),
+      expect.objectContaining({ id: 'file-1', category: 'pdf' }),
+    ]);
     expect(JSON.parse(retried?.persistedContent ?? '{}')).toEqual({
       text: 'describe this',
-      images: [],
+      images: [{
+        url: 'xdt-image://session/clip.gif',
+        mimeType: 'image/gif',
+        originalName: 'clip.gif',
+      }],
       files: [{ name: 'notes.pdf', path: '/repo/notes.pdf' }],
     });
   });

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -2095,6 +2095,145 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.onUiRetry).toHaveBeenCalledWith(sid, expect.any(String));
   });
 
+  it('removes an unsupported image when retrying a zero-progress text-and-image turn', async () => {
+    const h = createHarness();
+    const sid = 'retry-unsupported-image-with-text';
+    h.setHasAssistantProgressAfter(async () => false);
+    const item = makeItem('q-first', 'describe this');
+    item.files = [
+      {
+        id: 'image-1',
+        name: 'image.png',
+        path: 'clipboard://image.png',
+        ext: '.png',
+        size: 4,
+        category: 'image',
+        mimeType: 'image/png',
+        url: 'data:image/png;base64,aW1hZ2U=',
+      },
+      {
+        id: 'file-1',
+        name: 'notes.pdf',
+        path: '/repo/notes.pdf',
+        ext: '.pdf',
+        size: 8,
+        category: 'pdf',
+        mimeType: 'application/pdf',
+      },
+    ];
+    item.persistedContent = JSON.stringify({
+      text: item.text,
+      images: [{
+        url: 'data:image/png;base64,aW1hZ2U=',
+        mimeType: 'image/png',
+        originalName: 'image.png',
+      }],
+      files: [{ name: 'notes.pdf', path: '/repo/notes.pdf' }],
+    });
+    item.chatMessage = {
+      ...item.chatMessage,
+      images: [{
+        url: 'data:image/png;base64,aW1hZ2U=',
+        mimeType: 'image/png',
+        originalName: 'image.png',
+      }],
+      files: [{ name: 'notes.pdf', path: '/repo/notes.pdf' }],
+    };
+
+    h.coordinator.enqueue(sid, item);
+    await flush();
+    h.setRunning(false);
+    const error = JSON.stringify({
+      error: {
+        type: 'invalid_request_error',
+        code: 'unsupported_feature',
+        message: 'Responses feature is not supported by the Chat Completions bridge: input_image',
+      },
+    });
+    h.coordinator.onTurnEvent(sid, 'error', error);
+    await flush();
+
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+      type: 'user',
+      content: [
+        { type: 'text', text: 'describe this' },
+        { type: 'file', path: '/repo/notes.pdf', mimeType: 'application/pdf' },
+      ],
+    });
+    const retried = h.onDispatchedUserTurn.mock.calls[1]?.[1];
+    expect(retried?.files).toEqual([expect.objectContaining({ id: 'file-1', category: 'pdf' })]);
+    expect(retried?.chatMessage.images).toBeUndefined();
+    expect(retried?.chatMessage.files).toEqual([{ name: 'notes.pdf', path: '/repo/notes.pdf' }]);
+    expect(JSON.parse(retried?.persistedContent ?? '{}')).toEqual({
+      text: 'describe this',
+      images: [],
+      files: [{ name: 'notes.pdf', path: '/repo/notes.pdf' }],
+    });
+  });
+
+  it('keeps an unsupported image-only retry recoverable without fabricating text', async () => {
+    const h = createHarness();
+    const sid = 'retry-unsupported-image-only';
+    h.setHasAssistantProgressAfter(async () => false);
+    const item = makeItem('q-first', '');
+    item.files = [{
+      id: 'image-1',
+      name: 'image.png',
+      path: 'clipboard://image.png',
+      ext: '.png',
+      size: 4,
+      category: 'image',
+      mimeType: 'image/png',
+      url: 'data:image/png;base64,aW1hZ2U=',
+    }];
+    item.persistedContent = JSON.stringify({
+      text: '',
+      images: [{
+        url: 'data:image/png;base64,aW1hZ2U=',
+        mimeType: 'image/png',
+        originalName: 'image.png',
+      }],
+      files: [],
+    });
+    item.chatMessage = {
+      ...item.chatMessage,
+      images: [{
+        url: 'data:image/png;base64,aW1hZ2U=',
+        mimeType: 'image/png',
+        originalName: 'image.png',
+      }],
+    };
+
+    h.coordinator.enqueue(sid, item);
+    await flush();
+    h.setRunning(false);
+    const error = JSON.stringify({
+      error: {
+        type: 'invalid_request_error',
+        code: 'unsupported_feature',
+        message: 'Responses feature is not supported by the Chat Completions bridge: input_image',
+      },
+    });
+    h.coordinator.onTurnEvent(sid, 'error', error);
+    await flush();
+
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(latestProjection(h.projections).error).toBe(error);
+    expect(latestProjection(h.projections).recovery?.kind).toBe('active-turn');
+
+    h.coordinator.enqueue(sid, makeItem('q-next', 'continue in text'));
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'continue in text' });
+  });
+
   it('zero-progress retry supersedes the failed user row once the clone is dispatched', async () => {
     // retry-supersede:零产出克隆重发会在历史里留下两条一模一样的 user 行
     // (旧行 + 克隆行)。克隆行落库并派发成功后必须软删旧行,且锚定的是

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { UnsupportedResponsesFeatureError } from '@cindy/responses-chat-bridge';
 import { AgentInputCoordinator } from '../agent-input-coordinator.js';
 import type {
   AgentInputCoordinatorDeps,
@@ -155,13 +154,8 @@ function sessionRunningError(): Error & { code: string } {
 function unsupportedChatBridgeImageError(
   feature = "input content part 'input_image'",
 ): string {
-  return JSON.stringify({
-    error: {
-      type: 'invalid_request_error',
-      code: 'unsupported_feature',
-      message: new UnsupportedResponsesFeatureError(feature).message,
-    },
-  });
+  return 'unexpected status 400 Bad Request: Responses feature is not supported by the '
+    + `Chat Completions bridge: ${feature}, url: http://127.0.0.1/v1/responses`;
 }
 
 function createHarness() {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UnsupportedResponsesFeatureError } from '@cindy/responses-chat-bridge';
 import { AgentInputCoordinator } from '../agent-input-coordinator.js';
 import type {
   AgentInputCoordinatorDeps,
@@ -148,6 +149,18 @@ function sessionDispatchFailure(context: string): AgentInputSendResult {
 function sessionRunningError(): Error & { code: string } {
   return Object.assign(new Error('[SESSION_RUNNING] Session is already running a turn'), {
     code: 'SESSION_RUNNING',
+  });
+}
+
+function unsupportedChatBridgeImageError(
+  feature = "input content part 'input_image'",
+): string {
+  return JSON.stringify({
+    error: {
+      type: 'invalid_request_error',
+      code: 'unsupported_feature',
+      message: new UnsupportedResponsesFeatureError(feature).message,
+    },
   });
 }
 
@@ -2139,17 +2152,14 @@ describe('AgentInputCoordinator send transaction', () => {
       }],
       files: [{ name: 'notes.pdf', path: '/repo/notes.pdf' }],
     };
+    (item.chatMessage as typeof item.chatMessage & {
+      retryFiles?: AgentInputQueuedMessage['files'];
+    }).retryFiles = item.files;
 
     h.coordinator.enqueue(sid, item);
     await flush();
     h.setRunning(false);
-    const error = JSON.stringify({
-      error: {
-        type: 'invalid_request_error',
-        code: 'unsupported_feature',
-        message: 'Responses feature is not supported by the Chat Completions bridge: input_image',
-      },
-    });
+    const error = unsupportedChatBridgeImageError();
     h.coordinator.onTurnEvent(sid, 'error', error);
     await flush();
 
@@ -2168,6 +2178,9 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(retried?.files).toEqual([expect.objectContaining({ id: 'file-1', category: 'pdf' })]);
     expect(retried?.chatMessage.images).toBeUndefined();
     expect(retried?.chatMessage.files).toEqual([{ name: 'notes.pdf', path: '/repo/notes.pdf' }]);
+    expect((retried?.chatMessage as typeof retried.chatMessage & {
+      retryFiles?: AgentInputQueuedMessage['files'];
+    }).retryFiles).toEqual([expect.objectContaining({ id: 'file-1', category: 'pdf' })]);
     expect(JSON.parse(retried?.persistedContent ?? '{}')).toEqual({
       text: 'describe this',
       images: [],
@@ -2211,13 +2224,7 @@ describe('AgentInputCoordinator send transaction', () => {
     h.coordinator.enqueue(sid, item);
     await flush();
     h.setRunning(false);
-    const error = JSON.stringify({
-      error: {
-        type: 'invalid_request_error',
-        code: 'unsupported_feature',
-        message: 'Responses feature is not supported by the Chat Completions bridge: input_image',
-      },
-    });
+    const error = unsupportedChatBridgeImageError();
     h.coordinator.onTurnEvent(sid, 'error', error);
     await flush();
 
@@ -2232,6 +2239,35 @@ describe('AgentInputCoordinator send transaction', () => {
     await flush();
     expect(h.sendToAgent).toHaveBeenCalledTimes(2);
     expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'continue in text' });
+  });
+
+  it('keeps retry recovery compatible with the legacy bridge image error', async () => {
+    const h = createHarness();
+    const sid = 'retry-unsupported-image-legacy-error';
+    h.setHasAssistantProgressAfter(async () => false);
+    const item = makeItem('q-first', 'describe this');
+    item.files = [{
+      id: 'image-1',
+      name: 'image.png',
+      path: 'clipboard://image.png',
+      ext: '.png',
+      size: 4,
+      category: 'image',
+      mimeType: 'image/png',
+      url: 'data:image/png;base64,aW1hZ2U=',
+    }];
+
+    h.coordinator.enqueue(sid, item);
+    await flush();
+    h.setRunning(false);
+    h.coordinator.onTurnEvent(sid, 'error', unsupportedChatBridgeImageError('input_image'));
+    await flush();
+
+    await h.coordinator.retryLastError(sid);
+    await flush();
+
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'describe this' });
   });
 
   it('zero-progress retry supersedes the failed user row once the clone is dispatched', async () => {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -24,6 +24,7 @@
  * 它只提交 intent payload；排序、投递模式、回滚和持久化由本模块决定。
  */
 
+import { isUnsupportedResponsesImageErrorPayload } from '@cindy/responses-chat-bridge';
 import { createLogger } from '../logger.js';
 import { createMessage as createDbMessage } from '../localDb/ipc/messages.js';
 import { touchUserSendInDb } from '../localDb/ipc/sessions.js';
@@ -65,16 +66,6 @@ const SESSION_RUNNING_RETRY_DELAY_MS = 250;
 const CREDENTIAL_SWITCH_RETRY_DELAY_MS = 10_000;
 const TERMINAL_DONE_FALLBACK_DELAY_MS = 250;
 const REWIND_BOUNDARY_POLL_INTERVAL_MS = 100;
-const CHAT_BRIDGE_UNSUPPORTED_IMAGE_MARKER =
-  'Responses feature is not supported by the Chat Completions bridge: input_image';
-
-function isUnsupportedChatBridgeImageError(message: string | null): boolean {
-  return Boolean(
-    message
-    && message.includes('unsupported_feature')
-    && message.includes(CHAT_BRIDGE_UNSUPPORTED_IMAGE_MARKER),
-  );
-}
 
 function stripQueuedMessageImages(item: AgentInputQueuedMessage): AgentInputQueuedMessage {
   const remainingFiles = item.files?.filter((file) => file.category !== 'image');
@@ -1707,7 +1698,7 @@ export class AgentInputCoordinator {
     if (
       !continueItem
       && retryItem
-      && isUnsupportedChatBridgeImageError(state.error ?? state.stickyError)
+      && isUnsupportedResponsesImageErrorPayload(state.error ?? state.stickyError)
     ) {
       retryItem = stripQueuedMessageImages(retryItem);
       if (!hasRetryableQueuedContent(retryItem)) {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -65,6 +65,63 @@ const SESSION_RUNNING_RETRY_DELAY_MS = 250;
 const CREDENTIAL_SWITCH_RETRY_DELAY_MS = 10_000;
 const TERMINAL_DONE_FALLBACK_DELAY_MS = 250;
 const REWIND_BOUNDARY_POLL_INTERVAL_MS = 100;
+const CHAT_BRIDGE_UNSUPPORTED_IMAGE_MARKER =
+  'Responses feature is not supported by the Chat Completions bridge: input_image';
+
+function isUnsupportedChatBridgeImageError(message: string | null): boolean {
+  return Boolean(
+    message
+    && message.includes('unsupported_feature')
+    && message.includes(CHAT_BRIDGE_UNSUPPORTED_IMAGE_MARKER),
+  );
+}
+
+function stripQueuedMessageImages(item: AgentInputQueuedMessage): AgentInputQueuedMessage {
+  const remainingFiles = item.files?.filter((file) => file.category !== 'image');
+  const chatMessage = { ...item.chatMessage };
+  delete chatMessage.images;
+
+  // Renderer queue objects historically carry retryFiles as an extra presentation field even
+  // though it is not part of the main-process wire contract. Strip image entries when present so
+  // the replacement bubble cannot rehydrate the rejected attachment through an older renderer.
+  const compatibleChatMessage = chatMessage as typeof chatMessage & {
+    retryFiles?: Array<{ category?: string }>;
+  };
+  if (Array.isArray(compatibleChatMessage.retryFiles)) {
+    const retryFiles = compatibleChatMessage.retryFiles.filter((file) => file.category !== 'image');
+    if (retryFiles.length > 0) compatibleChatMessage.retryFiles = retryFiles;
+    else delete compatibleChatMessage.retryFiles;
+  }
+
+  let persistedContent = item.persistedContent;
+  try {
+    const parsed = JSON.parse(persistedContent) as unknown;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      persistedContent = JSON.stringify({
+        ...(parsed as Record<string, unknown>),
+        images: [],
+      });
+    }
+  } catch {
+    // Historical plain-text queue payloads contain no persisted image references.
+  }
+
+  const stripped: AgentInputQueuedMessage = {
+    ...item,
+    persistedContent,
+    chatMessage,
+  };
+  if (remainingFiles && remainingFiles.length > 0) stripped.files = remainingFiles;
+  else delete stripped.files;
+  return stripped;
+}
+
+function hasRetryableQueuedContent(item: AgentInputQueuedMessage): boolean {
+  return getAgentFacingText(item).trim().length > 0
+    || (item.files?.length ?? 0) > 0
+    || (item.mentions?.length ?? 0) > 0
+    || (item.sessionRefs?.length ?? 0) > 0;
+}
 
 export interface AgentInputSendOpts {
   messageUuid?: string;
@@ -1646,6 +1703,20 @@ export class AgentInputCoordinator {
       log.debug('auto retry skipped — no assistant progress to continue from', { sessionId });
       return { projection: this.getProjection(sessionId), outcome: 'no-progress' };
     }
+    let retryItem = recovery.kind === 'active-turn' ? recovery.item : null;
+    if (
+      !continueItem
+      && retryItem
+      && isUnsupportedChatBridgeImageError(state.error ?? state.stickyError)
+    ) {
+      retryItem = stripQueuedMessageImages(retryItem);
+      if (!hasRetryableQueuedContent(retryItem)) {
+        // An image-only turn has no truthful fallback. Keep the error/recovery intact so a later
+        // text message or model switch can take over instead of inventing replacement text.
+        log.debug('image-only retry skipped for unsupported Chat bridge input', { sessionId });
+        return { projection: this.getProjection(sessionId), outcome: 'no-progress' };
+      }
+    }
     state.error = null;
     state.stickyError = null;
     // 接管态在补发这一刻结束:聊天流里的「重新连接中」活动行交棒给落库的
@@ -1657,7 +1728,7 @@ export class AgentInputCoordinator {
       if (!item) {
         const clientId = crypto.randomUUID();
         item = {
-          ...recovery.item,
+          ...(retryItem ?? recovery.item),
           clientId,
           // retry-supersede:零产出克隆重发 —— 旧 user 行已落库但模型从未收到,
           // 本条落库成功后 host 把旧行(与其后的 error 行)软删,历史只留这一条。
@@ -1665,7 +1736,7 @@ export class AgentInputCoordinator {
           // (连环失败时指向更早的行),窗口必须锚定在本轮被取代的那条上。
           supersedesUserClientId: recovery.item.clientId,
           chatMessage: {
-            ...recovery.item.chatMessage,
+            ...(retryItem ?? recovery.item).chatMessage,
             clientId,
             createdAt: new Date().toISOString(),
           },

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -42,6 +42,7 @@ import type {
 } from '../../shared/agentInputQueue.js';
 import {
   buildMakerUserMessage,
+  getAgentInputAttachmentBlockType,
   getAgentFacingText,
   projectionRetryText,
   sanitizeQueuedMessageForPersistence,
@@ -67,19 +68,49 @@ const CREDENTIAL_SWITCH_RETRY_DELAY_MS = 10_000;
 const TERMINAL_DONE_FALLBACK_DELAY_MS = 250;
 const REWIND_BOUNDARY_POLL_INTERVAL_MS = 100;
 
+type QueuedAttachment = NonNullable<AgentInputQueuedMessage['files']>[number];
+
+function isMakerImageAttachment(file: Pick<QueuedAttachment, 'category' | 'ext'>): boolean {
+  return getAgentInputAttachmentBlockType(file.category, file.ext) === 'image';
+}
+
+function attachmentSourceKey(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.url === 'string') return `url:${record.url}`;
+  if (typeof record.base64 === 'string') return `base64:${record.base64}`;
+  return null;
+}
+
 function stripQueuedMessageImages(item: AgentInputQueuedMessage): AgentInputQueuedMessage {
-  const remainingFiles = item.files?.filter((file) => file.category !== 'image');
+  const remainingFiles = item.files?.filter((file) => !isMakerImageAttachment(file));
+  const remainingImageSources = new Set(
+    (remainingFiles ?? [])
+      .filter((file) => file.category === 'image')
+      .map(attachmentSourceKey)
+      .filter((source): source is string => source !== null),
+  );
   const chatMessage = { ...item.chatMessage };
-  delete chatMessage.images;
+  const remainingChatImages = chatMessage.images?.filter((image) => {
+    const source = attachmentSourceKey(image);
+    return source !== null && remainingImageSources.has(source);
+  });
+  if (remainingChatImages && remainingChatImages.length > 0) {
+    chatMessage.images = remainingChatImages;
+  } else {
+    delete chatMessage.images;
+  }
 
   // Renderer queue objects historically carry retryFiles as an extra presentation field even
-  // though it is not part of the main-process wire contract. Strip image entries when present so
-  // the replacement bubble cannot rehydrate the rejected attachment through an older renderer.
+  // though it is not part of the main-process wire contract. Strip only attachments that become
+  // maker image blocks: GIF keeps category=image for preview, but is sent as a file block.
   const compatibleChatMessage = chatMessage as typeof chatMessage & {
-    retryFiles?: Array<{ category?: string }>;
+    retryFiles?: QueuedAttachment[];
   };
   if (Array.isArray(compatibleChatMessage.retryFiles)) {
-    const retryFiles = compatibleChatMessage.retryFiles.filter((file) => file.category !== 'image');
+    const retryFiles = compatibleChatMessage.retryFiles.filter(
+      (file) => !isMakerImageAttachment(file),
+    );
     if (retryFiles.length > 0) compatibleChatMessage.retryFiles = retryFiles;
     else delete compatibleChatMessage.retryFiles;
   }
@@ -88,9 +119,16 @@ function stripQueuedMessageImages(item: AgentInputQueuedMessage): AgentInputQueu
   try {
     const parsed = JSON.parse(persistedContent) as unknown;
     if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const record = parsed as Record<string, unknown>;
+      const remainingPersistedImages = Array.isArray(record.images)
+        ? record.images.filter((image) => {
+            const source = attachmentSourceKey(image);
+            return source !== null && remainingImageSources.has(source);
+          })
+        : [];
       persistedContent = JSON.stringify({
-        ...(parsed as Record<string, unknown>),
-        images: [],
+        ...record,
+        images: remainingPersistedImages,
       });
     }
   } catch {

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -513,6 +513,27 @@ describe('translateResponsesRequest', () => {
     ]);
   });
 
+  it('drops untranslatable file_id images from replayed history on image-url routes', () => {
+    const out = translateResponsesRequest(base({
+      input: [
+        {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'describe this' },
+            { type: 'input_image', file_id: 'file_1' },
+          ],
+        },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'continue in text' }] },
+      ],
+    }), { capabilities: { imageInput: 'image_url' } });
+
+    expect(out.messages).toEqual([
+      { role: 'user', content: 'describe this' },
+      { role: 'user', content: 'continue in text' },
+    ]);
+  });
+
   it('drops image-only replayed turns but keeps the newest unsupported image fail-closed', () => {
     const imageUrl = 'data:image/png;base64,aW1hZ2U=';
     const out = translateResponsesRequest(base({

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -491,6 +491,67 @@ describe('translateResponsesRequest', () => {
     ]);
   });
 
+  it('drops unsupported images from replayed user history so a later text turn can recover', () => {
+    const imageUrl = 'data:image/png;base64,aW1hZ2U=';
+    const out = translateResponsesRequest(base({
+      input: [
+        {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'describe this' },
+            { type: 'input_image', image_url: imageUrl },
+          ],
+        },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'continue in text' }] },
+      ],
+    }));
+
+    expect(out.messages).toEqual([
+      { role: 'user', content: 'describe this' },
+      { role: 'user', content: 'continue in text' },
+    ]);
+  });
+
+  it('drops image-only replayed turns but keeps the newest unsupported image fail-closed', () => {
+    const imageUrl = 'data:image/png;base64,aW1hZ2U=';
+    const out = translateResponsesRequest(base({
+      input: [
+        {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_image', image_url: imageUrl }],
+        },
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'continue in text' }] },
+      ],
+    }));
+
+    expect(out.messages).toEqual([{ role: 'user', content: 'continue in text' }]);
+    expect(() => translateResponsesRequest(base({
+      input: [
+        { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'history' }] },
+        {
+          type: 'message',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'describe this' },
+            { type: 'input_image', image_url: imageUrl },
+          ],
+        },
+      ],
+    }))).toThrow("input content part 'input_image'");
+    expect(() => translateResponsesRequest(base({
+      input: [
+        {
+          type: 'message',
+          role: 'user',
+          content: [{ type: 'input_image', image_url: imageUrl }],
+        },
+        { type: 'message', role: 'latest_reminder', content: 'current-turn reminder' },
+      ],
+    }))).toThrow("input content part 'input_image'");
+  });
+
   it('drops empty user messages produced by auto-compact collapsing image-only turns', () => {
     // Codex auto-compact 的 replacement_history 把「无文字纯图片」用户消息折叠成单个
     // 空 input_text；桥接层若原样透传，Moonshot/Kimi 会以

--- a/packages/responses-chat-bridge/src/__tests__/types.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isUnsupportedResponsesImageErrorPayload,
+  UnsupportedResponsesFeatureError,
+} from '../types.js';
+
+function unsupportedFeaturePayload(feature: string, code = 'unsupported_feature'): string {
+  return JSON.stringify({
+    error: {
+      type: 'invalid_request_error',
+      code,
+      message: new UnsupportedResponsesFeatureError(feature).message,
+    },
+  });
+}
+
+describe('isUnsupportedResponsesImageErrorPayload', () => {
+  it.each([
+    "input content part 'input_image'",
+    "input content part 'image_url'",
+    "input content part 'image'",
+    'input_image',
+    'input_image.file_id',
+  ])('accepts current and compatible image feature shapes: %s', (feature) => {
+    expect(isUnsupportedResponsesImageErrorPayload(unsupportedFeaturePayload(feature))).toBe(true);
+  });
+
+  it.each([
+    unsupportedFeaturePayload("input content part 'input_file'"),
+    unsupportedFeaturePayload("input content part 'input_image'", 'invalid_request'),
+    JSON.stringify({ error: { code: 'unsupported_feature', message: 'input_image' } }),
+    'not json',
+    '',
+  ])('rejects unrelated or malformed payloads: %s', (payload) => {
+    expect(isUnsupportedResponsesImageErrorPayload(payload)).toBe(false);
+  });
+});

--- a/packages/responses-chat-bridge/src/__tests__/types.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/types.test.ts
@@ -15,6 +15,10 @@ function unsupportedFeaturePayload(feature: string, code = 'unsupported_feature'
   });
 }
 
+function codexUnexpectedResponse(messageOrBody: string): string {
+  return `unexpected status 400 Bad Request: ${messageOrBody}, url: http://127.0.0.1/v1/responses`;
+}
+
 describe('isUnsupportedResponsesImageErrorPayload', () => {
   it.each([
     "input content part 'input_image'",
@@ -26,10 +30,27 @@ describe('isUnsupportedResponsesImageErrorPayload', () => {
     expect(isUnsupportedResponsesImageErrorPayload(unsupportedFeaturePayload(feature))).toBe(true);
   });
 
+  it('accepts the bridge message rendered by the pinned Codex runtime', () => {
+    const message =
+      "Responses feature is not supported by the Chat Completions bridge: input content part 'input_image'";
+
+    expect(isUnsupportedResponsesImageErrorPayload(codexUnexpectedResponse(message))).toBe(true);
+  });
+
+  it('accepts a Codex error that retains the serialized bridge response body', () => {
+    const payload = unsupportedFeaturePayload("input content part 'input_image'");
+
+    expect(isUnsupportedResponsesImageErrorPayload(codexUnexpectedResponse(payload))).toBe(true);
+  });
+
   it.each([
     unsupportedFeaturePayload("input content part 'input_file'"),
     unsupportedFeaturePayload("input content part 'input_image'", 'invalid_request'),
     JSON.stringify({ error: { code: 'unsupported_feature', message: 'input_image' } }),
+    codexUnexpectedResponse(
+      "Responses feature is not supported by the Chat Completions bridge: input content part 'input_file'",
+    ),
+    'unexpected status 401 Unauthorized: Responses feature is not supported by the Chat Completions bridge: input_image',
     'not json',
     '',
   ])('rejects unrelated or malformed payloads: %s', (payload) => {

--- a/packages/responses-chat-bridge/src/index.ts
+++ b/packages/responses-chat-bridge/src/index.ts
@@ -8,6 +8,8 @@ export {
 } from './translate-request.js';
 export { ChatBridgeToolContext, type ChatBridgeToolKind, type ChatBridgeToolSpec } from './tool-context.js';
 export {
+  isResponsesImageContentPartType,
+  isUnsupportedResponsesImageErrorPayload,
   UnsupportedResponsesFeatureError,
   type ChatBridgeCapabilities,
   type ChatBridgeHandleArgs,

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -96,6 +96,13 @@ function hasImageSource(part: Record<string, unknown>): boolean {
     );
 }
 
+function isImagePartTranslatable(
+  part: Record<string, unknown>,
+  capabilities: ChatMediaCapabilities,
+): boolean {
+  return capabilities.imageInput === 'image_url' && part.file_id === undefined;
+}
+
 function hasFileSource(part: Record<string, unknown>): boolean {
   const source = isPlainObject(part.file) ? part.file : part;
   return source.file_id !== undefined
@@ -180,10 +187,11 @@ function messageContent(
       && normalizedRole === 'user'
       && isResponsesImageContentPartType(rawPart.type)
       && hasImageSource(rawPart)
-      && mediaCapabilities.imageInput !== 'image_url'
+      && !isImagePartTranslatable(rawPart, mediaCapabilities)
     ) {
       // Codex replays failed user input in later Responses requests. A Chat-only provider that
       // rejected that image once would otherwise reject every subsequent text turn as well.
+      // Provider-scoped file IDs remain untranslatable even when the route accepts image URLs.
       // Only replayed images are removed: the newest user turn remains fail-closed below.
       continue;
     }

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -144,6 +144,7 @@ function messageContent(
   itemIndex: number,
   developerRole: ChatDeveloperRole,
   mediaCapabilities: ChatMediaCapabilities,
+  dropUnsupportedHistoricalImages = false,
 ): string | ChatUserContentPart[] {
   if (typeof item.content === 'string') return item.content;
   if (!Array.isArray(item.content)) {
@@ -171,6 +172,18 @@ function messageContent(
     if (rawPart.type === 'refusal' && typeof rawPart.refusal === 'string') {
       text += rawPart.refusal;
       content.push({ type: 'text', text: rawPart.refusal });
+      continue;
+    }
+    if (
+      dropUnsupportedHistoricalImages
+      && normalizedRole === 'user'
+      && (rawPart.type === 'input_image' || rawPart.type === 'image_url' || rawPart.type === 'image')
+      && hasImageSource(rawPart)
+      && mediaCapabilities.imageInput !== 'image_url'
+    ) {
+      // Codex replays failed user input in later Responses requests. A Chat-only provider that
+      // rejected that image once would otherwise reject every subsequent text turn as well.
+      // Only replayed images are removed: the newest user turn remains fail-closed below.
       continue;
     }
     const translatedMedia = mediaPart(rawPart, mediaCapabilities);
@@ -317,6 +330,27 @@ function ensureToolCallCompatibility(message: ChatAssistantMessage, opts: Transl
 function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOptions): ChatMessage[] {
   if (typeof input === 'string') return [{ role: 'user', content: input }];
   if (!Array.isArray(input)) throw new UnsupportedResponsesFeatureError('input');
+
+  let newestNormalizedUserMessageIndex = -1;
+  let newestUserMessageIndex = -1;
+  for (let index = input.length - 1; index >= 0; index -= 1) {
+    const item = input[index];
+    if (!isPlainObject(item)) continue;
+    const role = (item as Record<string, unknown>).role;
+    if (typeof role !== 'string') continue;
+    if (role === 'user') {
+      newestUserMessageIndex = index;
+      break;
+    }
+    if (
+      newestNormalizedUserMessageIndex < 0
+      && role !== 'assistant'
+      && normalizeRole(role, opts.developerRole) === 'user'
+    ) newestNormalizedUserMessageIndex = index;
+  }
+  // Codex can append user-like synthetic reminders after the real user item. Treat the latest
+  // explicit user item as the current-turn boundary so a fresh image is never silently discarded.
+  if (newestUserMessageIndex < 0) newestUserMessageIndex = newestNormalizedUserMessageIndex;
 
   const messages: ChatMessage[] = [];
   let assistant: ChatAssistantMessage | null = null;
@@ -474,6 +508,7 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
         index,
         opts.developerRole,
         opts.mediaCapabilities,
+        index < newestUserMessageIndex,
       );
       if (item.role === 'assistant') {
         if (typeof content !== 'string') {

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -1,4 +1,5 @@
 import {
+  isResponsesImageContentPartType,
   UnsupportedResponsesFeatureError,
   type ChatAssistantMessage,
   type ChatAudioInput,
@@ -112,7 +113,7 @@ function mediaPart(
   capabilities: ChatMediaCapabilities,
   failClosed = false,
 ): ChatUserContentPart | undefined {
-  if (part.type === 'input_image' || part.type === 'image_url' || part.type === 'image') {
+  if (isResponsesImageContentPartType(part.type)) {
     if (!hasImageSource(part)) return undefined;
     if (capabilities.imageInput !== 'image_url') {
       if (failClosed) throw new UnsupportedResponsesFeatureError(String(part.type));
@@ -177,7 +178,7 @@ function messageContent(
     if (
       dropUnsupportedHistoricalImages
       && normalizedRole === 'user'
-      && (rawPart.type === 'input_image' || rawPart.type === 'image_url' || rawPart.type === 'image')
+      && isResponsesImageContentPartType(rawPart.type)
       && hasImageSource(rawPart)
       && mediaCapabilities.imageInput !== 'image_url'
     ) {

--- a/packages/responses-chat-bridge/src/types.ts
+++ b/packages/responses-chat-bridge/src/types.ts
@@ -360,11 +360,55 @@ export interface ResponsesChatBridgeHandler {
   handle(args: ChatBridgeHandleArgs): Promise<void>;
 }
 
+const UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX =
+  'Responses feature is not supported by the Chat Completions bridge: ';
+const RESPONSES_IMAGE_CONTENT_PART_TYPES = new Set(['input_image', 'image_url', 'image']);
+
+export function isResponsesImageContentPartType(
+  value: unknown,
+): value is 'input_image' | 'image_url' | 'image' {
+  return typeof value === 'string' && RESPONSES_IMAGE_CONTENT_PART_TYPES.has(value);
+}
+
+function unsupportedResponsesFeatureFromMessage(message: string): string | null {
+  return message.startsWith(UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX)
+    ? message.slice(UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX.length)
+    : null;
+}
+
+function isUnsupportedResponsesImageFeature(feature: string): boolean {
+  const contentPartMatch = /^input content part '([^']+)'$/.exec(feature);
+  const contentPartType = contentPartMatch?.[1] ?? feature;
+  return isResponsesImageContentPartType(contentPartType)
+    || contentPartType.startsWith('input_image.');
+}
+
+/**
+ * Classifies the serialized OpenAI-style error body emitted by this bridge for unsupported image
+ * input. Both the current content-part feature and the legacy direct `input_image` feature are
+ * accepted so persisted retries from older Cindy versions remain recoverable.
+ */
+export function isUnsupportedResponsesImageErrorPayload(payload: string | null): boolean {
+  if (!payload) return false;
+  try {
+    const parsed = JSON.parse(payload) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return false;
+    const error = (parsed as Record<string, unknown>).error;
+    if (typeof error !== 'object' || error === null || Array.isArray(error)) return false;
+    const { code, message } = error as Record<string, unknown>;
+    if (code !== 'unsupported_feature' || typeof message !== 'string') return false;
+    const feature = unsupportedResponsesFeatureFromMessage(message);
+    return feature !== null && isUnsupportedResponsesImageFeature(feature);
+  } catch {
+    return false;
+  }
+}
+
 export class UnsupportedResponsesFeatureError extends Error {
   readonly feature: string;
 
   constructor(feature: string) {
-    super(`Responses feature is not supported by the Chat Completions bridge: ${feature}`);
+    super(`${UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX}${feature}`);
     this.name = 'UnsupportedResponsesFeatureError';
     this.feature = feature;
   }

--- a/packages/responses-chat-bridge/src/types.ts
+++ b/packages/responses-chat-bridge/src/types.ts
@@ -363,6 +363,14 @@ export interface ResponsesChatBridgeHandler {
 const UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX =
   'Responses feature is not supported by the Chat Completions bridge: ';
 const RESPONSES_IMAGE_CONTENT_PART_TYPES = new Set(['input_image', 'image_url', 'image']);
+const CODEX_UNEXPECTED_BAD_REQUEST_PREFIX = /^unexpected status 400(?: Bad Request)?: /;
+const CODEX_ERROR_METADATA_MARKERS = [
+  ', url: ',
+  ', cf-ray: ',
+  ', request id: ',
+  ', auth error: ',
+  ', auth error code: ',
+] as const;
 
 export function isResponsesImageContentPartType(
   value: unknown,
@@ -383,25 +391,66 @@ function isUnsupportedResponsesImageFeature(feature: string): boolean {
     || contentPartType.startsWith('input_image.');
 }
 
+function isUnsupportedResponsesImageErrorObject(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const error = (value as Record<string, unknown>).error;
+  if (typeof error !== 'object' || error === null || Array.isArray(error)) return false;
+  const { code, message } = error as Record<string, unknown>;
+  if (code !== 'unsupported_feature' || typeof message !== 'string') return false;
+  const feature = unsupportedResponsesFeatureFromMessage(message);
+  return feature !== null && isUnsupportedResponsesImageFeature(feature);
+}
+
+function parseJson(value: string): unknown {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function parseCodexWrappedJson(value: string): unknown {
+  const jsonStart = value.indexOf('{');
+  if (jsonStart < 0) return null;
+
+  // Codex may append transport metadata after the serialized response body. Walk closing braces
+  // from right to left so braces in that metadata cannot prevent recovery of the response object.
+  let jsonEnd = value.lastIndexOf('}');
+  while (jsonEnd > jsonStart) {
+    const parsed = parseJson(value.slice(jsonStart, jsonEnd + 1));
+    if (parsed !== null) return parsed;
+    jsonEnd = value.lastIndexOf('}', jsonEnd - 1);
+  }
+  return null;
+}
+
+function stripCodexErrorMetadata(value: string): string {
+  let end = value.length;
+  for (const marker of CODEX_ERROR_METADATA_MARKERS) {
+    const index = value.indexOf(marker);
+    if (index >= 0 && index < end) end = index;
+  }
+  return value.slice(0, end);
+}
+
 /**
- * Classifies the serialized OpenAI-style error body emitted by this bridge for unsupported image
- * input. Both the current content-part feature and the legacy direct `input_image` feature are
- * accepted so persisted retries from older Cindy versions remain recoverable.
+ * Classifies an unsupported-image error emitted by this bridge. Direct OpenAI-style response
+ * bodies and Codex's `unexpected status 400 ...` rendering are both accepted; current Codex
+ * extracts `error.message`, while older/future runtimes may retain the serialized body. Both the
+ * current content-part feature and the legacy direct `input_image` feature remain recoverable.
  */
 export function isUnsupportedResponsesImageErrorPayload(payload: string | null): boolean {
   if (!payload) return false;
-  try {
-    const parsed = JSON.parse(payload) as unknown;
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return false;
-    const error = (parsed as Record<string, unknown>).error;
-    if (typeof error !== 'object' || error === null || Array.isArray(error)) return false;
-    const { code, message } = error as Record<string, unknown>;
-    if (code !== 'unsupported_feature' || typeof message !== 'string') return false;
-    const feature = unsupportedResponsesFeatureFromMessage(message);
-    return feature !== null && isUnsupportedResponsesImageFeature(feature);
-  } catch {
-    return false;
-  }
+  if (isUnsupportedResponsesImageErrorObject(parseJson(payload))) return true;
+
+  const codexPrefix = CODEX_UNEXPECTED_BAD_REQUEST_PREFIX.exec(payload);
+  if (!codexPrefix) return false;
+  const renderedBody = payload.slice(codexPrefix[0].length);
+  if (isUnsupportedResponsesImageErrorObject(parseCodexWrappedJson(renderedBody))) return true;
+
+  const message = stripCodexErrorMetadata(renderedBody);
+  const feature = unsupportedResponsesFeatureFromMessage(message);
+  return feature !== null && isUnsupportedResponsesImageFeature(feature);
 }
 
 export class UnsupportedResponsesFeatureError extends Error {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 DeepSeek 等不支持图片输入的 Chat Completions 路由在一次图片请求失败后，后续纯文字请求与重试仍被同一张图片持续阻塞的问题。

- Responses → Chat 桥接层只移除历史回放中当前路由不支持的图片，保留同一历史消息里的文字；最新用户输入中的图片仍保持 fail-closed。
- 零产出失败的“文字 + 图片”重试会移除实际的图片块后重发文字，并保留 GIF、PDF 等以文件块发送的附件。
- 纯图片失败不会伪造替代文字或重复发送图片；错误与恢复入口保留，后续新文字消息可以正常接管会话。
- 兼容 Codex 0.145.0 实际的 `unexpected status 400 Bad Request: …` 错误包装，并补充桥接层与 Desktop 输入协调器回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1314；Refs #593
- 本 PR 包含：Responses → Chat 历史图片恢复、Desktop 失败重试附件清理及回归测试。
- 明确不包含：#593 的发送前模型能力提示、Composer 禁用态或 Mobile/UI 改动。
- 用户可见变化：DeepSeek 图片失败后可继续发送纯文字；文字加图片的失败重试会自动去掉图片；纯图片重试不会制造空消息。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及；本 PR 未修改 UI、交互布局或文案。

## 怎么验证的

### 自动验证

```text
pnpm test:unit（Desktop 以 forks / maxWorkers=1 运行，测试选择不变）
结果：完整 root unit tier 全部通过；Desktop、Mobile、所有必跑共享包与协议包均 PASS。默认 Desktop threads 在本机 native worker teardown 偶发 SIGSEGV，因此最终门禁仅切换隔离与并发方式，未缩小测试范围。

pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=1 --poolOptions.forks.singleFork=true <unit tier excludes>
结果：相同 Desktop unit 覆盖在稳定模式下通过；1517 个文件、18423 项通过，2 项既有跳过。

pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果：均通过。

pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
结果：239 项通过；覆盖 PNG 去除、GIF 与 PDF 保留。

pnpm --filter @cindy/responses-chat-bridge exec vitest run src/__tests__/types.test.ts src/__tests__/translate-request.test.ts
结果：70 项通过。

pnpm check:dco
结果：5 个提交通过 DCO 检查。

git diff --check
结果：通过。
```

### 手工验证

不涉及 UI。通过 Codex 0.145.0 的 `unexpected status 400 Bad Request: …` 包装、当前 bridge 的 `input content part 'input_image'` 错误与旧版 `input_image` 错误载荷，覆盖 image_url 路由的历史 file_id 清理、文字加图片重试、纯图片重试、`retryFiles` 非图片附件保留与后续文字恢复链路。

### 未执行的验证

未使用 DeepSeek 官方账号做真实 API 端到端验证：本地没有贡献者的 DeepSeek 凭证，且不应索取或写入仓库。桥接与重试边界已由回归测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Chat bridge 历史裁剪与失败重试行为。

### 影响与回滚

- 影响范围：仅 Chat Completions bridge 未声明图片能力时的历史回放，以及 Desktop 对该桥接错误的人工重试；支持图片的路由和当前新发图片的 fail-closed 行为不变。
- 回滚 / 降级方式：回滚本提交即可恢复原行为；不涉及 schema、协议、配置或持久数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

