### PR TITLE
feat(desktop): 模型选择器按供应商分组展示

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -1,0 +1,281 @@
+// @vitest-environment jsdom
+
+/**
+ * modelSelectorProviderGroups.test.tsx
+ * ---------------------------------------------------------------------------
+ * 验证模型选择器按供应商分组渲染:
+ *   1. 两个供应商分别显示自己的分组标题
+ *   2. 每个模型出现在正确的供应商下
+ *   3. flat 模式(不传 onProviderChange)不显示供应商标题
+ *   4. 分割线只出现在组间,不出现在第一组之前
+ *   5. 长供应商名称不撑破弹层(truncate)
+ */
+
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      const translations: Record<string, string> = {
+        'settings.providers.anthropic.title': 'Anthropic',
+        'settings.providers.xd.title': 'Cindy AI',
+        'newChat.modelSelector.trigger.placeholder': '选择模型',
+        'newChat.modelSelector.trigger.aria': `Select model. Current: ${options?.model ?? ''}`,
+        'newChat.modelSelector.trigger.ariaWithEffort': `Select model. Current: ${options?.model ?? ''}, effort: ${options?.effort ?? ''}`,
+        'newChat.modelSelector.search.noResults': '无匹配模型',
+        'newChat.modelSelector.pricing.free': '限时免费',
+        'newChat.modelSelector.source.disconnected': '已断开',
+      };
+      return translations[key] ?? options?.defaultValue ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/popover', async () => {
+  const React = await import('react');
+  const OpenContext = React.createContext<{
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }>({ open: true });
+  return {
+    Popover: ({
+      children,
+      open,
+      onOpenChange,
+    }: {
+      children: React.ReactNode;
+      open?: boolean;
+      onOpenChange?: (open: boolean) => void;
+    }) =>
+      React.createElement(
+        OpenContext.Provider,
+        { value: { open: open ?? true, onOpenChange } },
+        children,
+      ),
+    PopoverTrigger: ({ children }: { children: React.ReactNode }) => {
+      const state = React.useContext(OpenContext);
+      const child = children as React.ReactElement<{ onClick?: React.MouseEventHandler }>;
+      return React.cloneElement(child, {
+        onClick: (event: React.MouseEvent) => {
+          child.props.onClick?.(event);
+          state.onOpenChange?.(!state.open);
+        },
+      });
+    },
+    PopoverAnchor: ({ children }: { children: React.ReactNode }) => children,
+    PopoverContent: ({ children }: { children: React.ReactNode }) => {
+      const state = React.useContext(OpenContext);
+      return state.open
+        ? React.createElement('div', { 'data-testid': 'model-options-popover' }, children)
+        : null;
+    },
+  };
+});
+
+vi.mock('@/lib/scrollbarAutoHide', () => ({ flashScrollbar: vi.fn() }));
+
+vi.mock('@/hooks/useAgentCapabilities', () => ({
+  useAgentCapabilities: () => ({ capabilities: null }),
+}));
+
+vi.mock('@/hooks/useApiKey', () => ({
+  useApiKey: () => ({ hasSavedKey: true }),
+}));
+
+vi.mock('@/hooks/useConnectedSource', () => ({
+  useConnectedSource: () => ({ hasConnectedSource: true, loading: false }),
+}));
+
+vi.mock('@/hooks/useModelPricing', () => ({
+  useModelPricing: () => ({}),
+}));
+
+const providersRef = vi.hoisted(() => {
+  const DEFAULT_PROVIDERS = [
+    {
+      id: 'anthropic',
+      name: 'Anthropic',
+      source: 'builtin',
+      agents: ['claude-code'],
+      auth: { method: 'oauth' },
+      routing: { 'claude-code': {} },
+      connected: true,
+      models: {
+        'claude-code': [
+          {
+            id: 'claude-opus-4-8',
+            name: 'Opus 4.8',
+            contextWindow: 200000,
+            efforts: ['low', 'medium', 'high'],
+            defaultEffort: 'high',
+          },
+          {
+            id: 'claude-sonnet-4-6',
+            name: 'Sonnet 4.6',
+            contextWindow: 200000,
+            efforts: ['low', 'medium', 'high'],
+            defaultEffort: 'medium',
+          },
+        ],
+      },
+    },
+    {
+      id: 'custom-dashscope',
+      name: '阿里云百炼',
+      source: 'user',
+      agents: ['claude-code'],
+      auth: { method: 'api-key' },
+      routing: { 'claude-code': {} },
+      connected: true,
+      models: {
+        'claude-code': [
+          {
+            id: 'qwen3.7-plus',
+            name: 'qwen3.7-plus',
+            contextWindow: 131072,
+            efforts: ['low', 'medium', 'high'],
+            defaultEffort: 'medium',
+          },
+        ],
+      },
+    },
+  ] as unknown[];
+  return { DEFAULT_PROVIDERS, providers: DEFAULT_PROVIDERS };
+});
+vi.mock('@/hooks/useProviders', () => ({
+  useProviders: () => ({ providers: providersRef.providers }),
+}));
+
+vi.mock('@/hooks/useDeviceProviders', () => ({
+  useDeviceProviders: () => ({ providers: [], loading: false }),
+}));
+
+vi.mock('@/lib/providerModels', () => ({
+  providerMonogram: (name: string) => name.slice(0, 1).toUpperCase(),
+  isChatBridgedCodexProvider: () => false,
+  filterChatBridgedCodexProviders: (providers: unknown[]) => providers,
+  resolveVisibleModelAgentKind: ({ agentKind }: { agentKind: string | null }) =>
+    agentKind ?? 'claude-code',
+  selectVisibleModels: () => [],
+}));
+
+vi.mock('@/state/modelVisibilityPrefs', () => ({
+  isModelEnabled: () => true,
+  useModelVisibilityVersion: () => 0,
+}));
+
+vi.mock('@/state/providerModelMemory', () => ({
+  useProviderModelMemoryVersion: () => 0,
+}));
+
+vi.mock('@/state/deviceLinkModelMirror', () => ({
+  useDeviceLinkModelMirrorVersion: () => 0,
+}));
+
+import { ModelSelector } from '@/components/new-chat/ModelSelector';
+
+const requestProviderModelsAutoRefresh = vi.fn(async () => ({ ok: true as const }));
+
+beforeEach(() => {
+  requestProviderModelsAutoRefresh.mockClear();
+  providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    maker: { requestProviderModelsAutoRefresh },
+  };
+});
+
+function renderSelector(props: Partial<React.ComponentProps<typeof ModelSelector>> = {}) {
+  return render(
+    React.createElement(ModelSelector, {
+      modelId: 'claude-opus-4-8',
+      effort: 'high',
+      onModelChange: vi.fn(),
+      onEffortChange: vi.fn(),
+      vendorKey: 'cc',
+      currentProviderId: 'anthropic',
+      onProviderChange: vi.fn(),
+      ...props,
+    }),
+  );
+}
+
+async function openDropdown(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Select model/ }));
+  });
+}
+
+describe('ModelSelector provider groups', () => {
+  it('renders a group heading for each provider', async () => {
+    renderSelector();
+    await openDropdown();
+    const popover = screen.getByTestId('model-options-popover');
+    const groups = within(popover).getAllByRole('group');
+    expect(groups).toHaveLength(2);
+    expect(within(groups[0]).getByText('Anthropic')).toBeTruthy();
+    expect(within(groups[1]).getByText('阿里云百炼')).toBeTruthy();
+  });
+
+  it('places each model under the correct provider group', async () => {
+    renderSelector();
+    await openDropdown();
+    const popover = screen.getByTestId('model-options-popover');
+    const groups = within(popover).getAllByRole('group');
+    const anthropicGroup = groups[0];
+    const dashscopeGroup = groups[1];
+    expect(within(anthropicGroup).getByText('Opus 4.8')).toBeTruthy();
+    expect(within(anthropicGroup).getByText('Sonnet 4.6')).toBeTruthy();
+    expect(within(dashscopeGroup).getByText('qwen3.7-plus')).toBeTruthy();
+    expect(within(dashscopeGroup).queryByText('Opus 4.8')).toBeNull();
+  });
+
+  it('does not render group headings in flat mode (no onProviderChange)', async () => {
+    renderSelector({ currentProviderId: undefined, onProviderChange: undefined });
+    await openDropdown();
+    const popover = screen.getByTestId('model-options-popover');
+    expect(within(popover).queryAllByRole('group')).toHaveLength(0);
+  });
+
+  it('renders separator between groups but not before the first', async () => {
+    renderSelector();
+    await openDropdown();
+    const popover = screen.getByTestId('model-options-popover');
+    const groups = within(popover).getAllByRole('group');
+    expect(groups).toHaveLength(2);
+    const firstGroupSeparators = groups[0].querySelectorAll('[class*="h-px"]');
+    expect(firstGroupSeparators).toHaveLength(0);
+  });
+
+  it('truncates long provider names', async () => {
+    providersRef.providers = [
+      {
+        id: 'long-name-provider',
+        name: 'A Very Long Provider Name That Should Definitely Be Truncated In The Dropdown',
+        source: 'user',
+        agents: ['claude-code'],
+        auth: { method: 'api-key' },
+        routing: { 'claude-code': {} },
+        connected: true,
+        models: {
+          'claude-code': [
+            {
+              id: 'some-model',
+              name: 'Some Model',
+              contextWindow: 100000,
+              efforts: [],
+              defaultEffort: null,
+            },
+          ],
+        },
+      },
+    ] as unknown[];
+    renderSelector({ modelId: 'some-model', currentProviderId: 'long-name-provider' });
+    await openDropdown();
+    const popover = screen.getByTestId('model-options-popover');
+    const heading = within(popover).getByText(/A Very Long Provider Name/);
+    expect(heading.className).toContain('truncate');
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1710,8 +1710,22 @@ function ModelSelectorContentView({
             </div>
           )
         ) : sections ? (
-          // 平铺:每行带来源 mark 前缀,无分组标题(同供应商行仍因 buildProviderSections 顺序而相邻)。
-          sections.flatMap((sec) => sec.models.map((m) => renderModelItem(sec.provider, m)))
+          // 按供应商分组:每组一个轻量标题 + 该供应商下的模型行。
+          sections
+            .filter((sec) => sec.models.length > 0)
+            .map((sec, index) => (
+              <div key={sec.provider.id} role="group" aria-label={providerDisplayName(sec.provider, t)}>
+                {index > 0 && (
+                  <div className="mx-1 my-1 h-px bg-[var(--model-dropdown-border)]" />
+                )}
+                <div className="truncate px-3 pb-0.5 pt-1 text-11 font-medium text-[var(--text-tertiary)]">
+                  {providerDisplayName(sec.provider, t)}
+                </div>
+                <div className="flex flex-col gap-0.5">
+                  {sec.models.map((m) => renderModelItem(sec.provider, m))}
+                </div>
+              </div>
+            ))
         ) : (
           (flatModels ?? []).map((m) => renderModelItem(null, m))
         )}


### PR DESCRIPTION
## 这次改了什么

### 摘要

当前模型选择器将 `buildProviderSections` 返回的供应商分组数据 `flatMap` 拍平成单一列表，用户只能依靠小图标判断模型来源，同名模型来自多个供应商时难以区分。

本次将平铺渲染改为按供应商分组展示：每组一个轻量标题 + 该供应商下的模型行，复用现有分组数据和分割线 token，模型行内部逻辑（选中、effort、Fast、价格、路由）零改动。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：模型选择器按供应商分组展示
- 本 PR 包含：`ModelSelector.tsx` 渲染层分组改造 + 5 个聚焦单元测试
- 明确不包含：供应商排序、模型排序、模型图标、折叠展开、sticky header、Mobile 模型选择器、模型路由、数据库、IPC
- 用户可见变化：模型下拉列表从平铺变为按供应商分组，每组有供应商标题和组间分割线
- 是否存在 breaking change：无

### UI 变化

模型选择器下拉列表新增供应商标题行和组间分割线。

- 引用的设计规范：DESIGN.md §文字层级（标题使用 `text-11` / `font-medium` / `--text-tertiary`）；§Select 菜单行规约（模型行样式不变，继续走 `--model-item-hover`）；分割线复用现有 `--model-dropdown-border` token（与文件内已有分割线 `mx-1 my-1 h-px bg-[var(--model-dropdown-border)]` 一致）。颜色全部走语义 token，Light / Dark 自动适配。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
结果：5 tests passed

pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：42 tests passed（无回归）

pnpm --filter desktop run --if-present typecheck
结果：tsc --noEmit 通过

pnpm test:unit（全量单测门禁）
结果：除 apps/desktop 的 makerSendToSessionOrdering.test.ts（3 条）外全部通过；
该失败在干净 main 上同样存在，为已有问题，与本次改动无关

git diff --check
结果：无空白问题
```

### 手工验证

未执行：本地无完整桌面端运行环境进行实机目检。

### 未执行的验证

- Light / Dark 实机目检：颜色全部走语义 token（`--text-tertiary` / `--model-dropdown-border`），理论上双模式自动适配，但未实机确认

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响模型选择器下拉列表的外层排版；模型行逻辑、选中状态、路由、flat 模式均不变
- 回滚 / 降级方式：revert 本 commit 即可，无数据变更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因