### PR TITLE
fix(desktop): keep ask answers retryable on delivery failure

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -129,6 +129,7 @@ const getPendingInteractions = vi.fn<
     }>
   >
 >(async () => []);
+const resolveInteraction = vi.fn(async () => {});
 
 const input = {
   getProjection: vi.fn(async (sessionId: string) => projection(sessionId)),
@@ -205,7 +206,7 @@ function installElectronBridge(): void {
           return vi.fn();
         },
         send: vi.fn(async () => ({ accepted: true })),
-        resolveInteraction: vi.fn(async () => {}),
+        resolveInteraction,
         submitPluginSetupInline: vi.fn(async () => {}),
         getPendingInteractions,
         steer: vi.fn(async () => true),
@@ -1735,7 +1736,7 @@ describe('makerChatStore text delta batching', () => {
     );
   });
 
-  it('preserves terminal interaction state on late initial DB-created echoes', () => {
+  it('preserves terminal interaction state on late initial DB-created echoes', async () => {
     emitInteractionRequest(
       {
         kind: 'ask_user_question',
@@ -1756,6 +1757,7 @@ describe('makerChatStore text delta batching', () => {
 
     makerChatStore.answerUserQuestion(SESSION_ID, 'ask-terminal', { 'Continue?': 'Yes' });
     makerChatStore.respondToPlanReview(SESSION_ID, 'plan-terminal', false, 'Needs more detail');
+    await flushPromises();
 
     expect(makerChatStore.getSnapshot(SESSION_ID).messages).toEqual(
       expect.arrayContaining([
@@ -1817,6 +1819,50 @@ describe('makerChatStore text delta batching', () => {
         createdAt: '2026-06-15T00:00:04.000Z',
       }),
     );
+  });
+
+  it('keeps ask_user_question pending when answer delivery fails and allows retry', async () => {
+    emitInteractionRequest(
+      {
+        kind: 'ask_user_question',
+        requestId: 'ask-retry',
+        questions: [{ question: 'Continue?', options: [{ label: 'Yes' }] }],
+      },
+      'ask-retry-message',
+    );
+    resolveInteraction.mockRejectedValueOnce(new Error('device link unavailable'));
+
+    makerChatStore.answerUserQuestion(SESSION_ID, 'ask-retry', { 'Continue?': 'Yes' });
+    makerChatStore.answerUserQuestion(SESSION_ID, 'ask-retry', { 'Continue?': 'Yes' });
+    await flushPromises();
+
+    expect(resolveInteraction).toHaveBeenCalledTimes(1);
+    expect(makerChatStore.getSnapshot(SESSION_ID)).toMatchObject({
+      pendingAskUser: { requestId: 'ask-retry' },
+      messages: [
+        expect.objectContaining({
+          clientId: 'ask-retry-message',
+          askUserStatus: 'pending',
+          askUserReply: null,
+        }),
+      ],
+    });
+
+    makerChatStore.answerUserQuestion(SESSION_ID, 'ask-retry', { 'Continue?': 'Yes' });
+    await flushPromises();
+
+    expect(resolveInteraction).toHaveBeenCalledTimes(2);
+    expect(makerChatStore.getSnapshot(SESSION_ID)).toMatchObject({
+      pendingAskUser: null,
+      messages: [
+        expect.objectContaining({
+          clientId: 'ask-retry-message',
+          askUserStatus: 'answered',
+          askUserReply: 'Continue?: Yes',
+          askUserAnswers: { 'Continue?': 'Yes' },
+        }),
+      ],
+    });
   });
 
   it('preserves dismissed interaction state on stale pending hydration', () => {

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -8500,6 +8500,8 @@ function updateSystemCardData(
  * F7.4/F7.5: Send all user answers for ask-user-question to the main process.
  * Updates the corresponding ask_user message to 'answered' state.
  */
+const askUserAnswerInFlight = new Set<string>();
+
 function answerUserQuestion(
   sessionId: string,
   requestId: string,
@@ -8510,6 +8512,10 @@ function answerUserQuestion(
   if (!state.pendingAskUser) return;
   if (state.pendingAskUser.requestId !== requestId) return;
 
+  const inFlightKey = `${sessionId}\0${requestId}`;
+  if (askUserAnswerInFlight.has(inFlightKey)) return;
+  askUserAnswerInFlight.add(inFlightKey);
+
   // Build a human-readable reply summary
   const replySummary = formatAskUserReply(answers);
 
@@ -8518,45 +8524,47 @@ function answerUserQuestion(
     (m) => m.askUserRequestId === requestId && m.askUserStatus === 'pending',
   );
 
-  // Update message to answered + clear pendingAskUser
-  setState(sessionId, (s) => ({
-    ...s,
-    pendingAskUser: null,
-    // F-AUQ-MIN-5: question resolved — reset viewer for the next one.
-    askUserViewerState: 'expanded',
-    // F-AUQ-DRAFT: question resolved — drop the draft so a future question
-    // (potentially with the same questions[] payload) starts at step 1.
-    askUserDraft: null,
-    messages: s.messages.map((m) =>
-      m.askUserRequestId === requestId && m.askUserStatus === 'pending'
-        ? {
-            ...m,
-            askUserStatus: 'answered' as const,
-            askUserReply: replySummary,
-            askUserAnswers: answers,
-          }
-        : m,
-    ),
-  }));
-
   // F7.6: Persist answered state via PATCH API。
   // device-link 远程会话:被控端在 RESOLVE_INTERACTION 里权威落库(onInteractionResolved),
   // 控制端再写就是写自己的空库(dead write + 错误日志)→ 远程跳过,只本机会话走这条。
-  if (askMsg && !isRemoteSession(sessionId)) {
-    messageService
-      .updateContent(sessionId, askMsg.clientId, {
-        requestId,
-        questions: askMsg.askUserQuestions ?? null,
-        status: 'answered',
-        answers,
-      })
-      .catch((err) => log.error('Failed to persist ask_user answered state:', err));
-  }
-
-  // Send to maker (InteractionDecision kind: 'ask_user_question')
+  // Deliver before committing the terminal UI state. If the IPC/device-link
+  // call fails, keep the pending card so the user can safely retry.
   makerApiFor(sessionId)
     .resolveInteraction(requestId, { kind: 'ask_user_question', answers })
-    .catch((err) => log.error('Failed to answer user question:', err));
+    .then(() => {
+      setState(sessionId, (s) => {
+        const resolvesCurrent = s.pendingAskUser?.requestId === requestId;
+        return {
+          ...s,
+          pendingAskUser: resolvesCurrent ? null : s.pendingAskUser,
+          askUserViewerState: resolvesCurrent ? 'expanded' : s.askUserViewerState,
+          askUserDraft: resolvesCurrent ? null : s.askUserDraft,
+          messages: s.messages.map((m) =>
+            m.askUserRequestId === requestId && m.askUserStatus === 'pending'
+              ? {
+                  ...m,
+                  askUserStatus: 'answered' as const,
+                  askUserReply: replySummary,
+                  askUserAnswers: answers,
+                }
+              : m,
+          ),
+        };
+      });
+
+      if (askMsg && !isRemoteSession(sessionId)) {
+        messageService
+          .updateContent(sessionId, askMsg.clientId, {
+            requestId,
+            questions: askMsg.askUserQuestions ?? null,
+            status: 'answered',
+            answers,
+          })
+          .catch((err) => log.error('Failed to persist ask_user answered state:', err));
+      }
+    })
+    .catch((err) => log.error('Failed to answer user question:', err))
+    .finally(() => askUserAnswerInFlight.delete(inFlightKey));
 }
 
 function respondToPluginSetup(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `ask_user_question` 回答发送失败后卡片仍被标记为已回答、导致用户无法重试的问题。现在先等待 `resolveInteraction` 成功，再提交终态；发送期间会拦截重复点击，失败时保留待回答状态。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1323
- 本 PR 包含：调整 renderer 中回答提交时序；增加发送失败、重复点击和重试成功的回归测试。
- 明确不包含：不修改 IPC 协议、主进程处理逻辑、布局、样式或文案。
- 用户可见变化：回答发送失败时问题卡片保持待回答，可再次提交；提交中的重复点击只发送一次。
- 是否存在 breaking change：无。

### UI 变化

不涉及：仅调整既有交互卡片的提交时序和失败重试状态，不改变布局、样式或文案。

- 引用的设计规范：不涉及：未改变视觉、布局或交互控件设计。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
结果：67 tests passed

NODE_OPTIONS=--max-old-space-size=4096 pnpm --dir apps/desktop typecheck
结果：通过

pnpm test:unit
结果：通过；脚本层 332 passed / 1 skipped，Desktop、Mobile 及所有适用 workspace 均通过

pnpm check:dco
结果：1 commit signed off
```

### 手工验证

不涉及：该失败分支依赖 IPC/device-link 异常，已通过可控 mock 回归测试覆盖。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop renderer 的 `ask_user_question` 回答提交状态。
- 回滚 / 降级方式：回退本 PR commit；不涉及数据迁移或协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因
