### PR TITLE
feat(desktop): 支持供应商拖动排序

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/provider-order-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/provider-order-store.test.ts
@@ -4,8 +4,6 @@ import path from 'node:path';
 
 import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { ProviderView } from '@cindy/model-providers';
-
 const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-order-store-test-'));
 
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp/never-used-here' } }));
@@ -16,7 +14,7 @@ vi.mock('../../appSessionState.js', () => ({
   ownerScopedUserDataPath: (name: string) => path.join(tmpDir, name),
 }));
 
-const { __testing, readProviderOrder, setProviderOrder, sortProvidersForDisplay } =
+const { __testing, readProviderOrder, setProviderOrder } =
   await import('../provider-order-store.js');
 
 afterEach(() => __testing.reset());
@@ -42,14 +40,5 @@ describe('provider-order-store', () => {
     setProviderOrder(['xd', 'anthropic', 'openai']);
     setProviderOrder(['openai', 'xd']);
     expect(readProviderOrder()).toEqual(['openai', 'anthropic', 'xd']);
-  });
-
-  it('puts Cindy AI first, then appends catalog entries not observed yet', () => {
-    const providers = [{ id: 'openai' }, { id: 'anthropic' }, { id: 'xd' }] as ProviderView[];
-    expect(sortProvidersForDisplay(providers).map((provider) => provider.id)).toEqual([
-      'xd',
-      'openai',
-      'anthropic',
-    ]);
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/provider-order-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/provider-order-store.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ProviderView } from '@cindy/model-providers';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'provider-order-store-test-'));
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp/never-used-here' } }));
+vi.mock('../logger-adapter.js', () => ({
+  desktopMakerLogger: { child: () => ({ info: () => {}, warn: () => {}, error: () => {} }) },
+}));
+vi.mock('../../appSessionState.js', () => ({
+  ownerScopedUserDataPath: (name: string) => path.join(tmpDir, name),
+}));
+
+const { __testing, readProviderOrder, setProviderOrder, sortProvidersForDisplay } =
+  await import('../provider-order-store.js');
+
+afterEach(() => __testing.reset());
+afterAll(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe('provider-order-store', () => {
+  it('seeds an empty order with Cindy AI without creating a preference file', () => {
+    expect(readProviderOrder()).toEqual(['xd']);
+    expect(fs.existsSync(path.join(tmpDir, 'provider-order-prefs.json'))).toBe(false);
+  });
+
+  it('appends providers as they first appear and avoids unchanged writes', () => {
+    expect(setProviderOrder(['xd', 'openai'])).toBe(true);
+    expect(setProviderOrder(['xd', 'openai'])).toBe(false);
+    expect(setProviderOrder(['xd', 'openai', 'anthropic'])).toBe(true);
+    expect(readProviderOrder()).toEqual(['xd', 'openai', 'anthropic']);
+    expect(
+      JSON.parse(fs.readFileSync(path.join(tmpDir, 'provider-order-prefs.json'), 'utf8')),
+    ).toEqual({ providerOrder: ['xd', 'openai', 'anthropic'] });
+  });
+
+  it('reorders visible providers while retaining a currently hidden provider slot', () => {
+    setProviderOrder(['xd', 'anthropic', 'openai']);
+    setProviderOrder(['openai', 'xd']);
+    expect(readProviderOrder()).toEqual(['openai', 'anthropic', 'xd']);
+  });
+
+  it('puts Cindy AI first, then appends catalog entries not observed yet', () => {
+    const providers = [{ id: 'openai' }, { id: 'anthropic' }, { id: 'xd' }] as ProviderView[];
+    expect(sortProvidersForDisplay(providers).map((provider) => provider.id)).toEqual([
+      'xd',
+      'openai',
+      'anthropic',
+    ]);
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/provider-order-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/provider-order-store.test.ts
@@ -41,4 +41,12 @@ describe('provider-order-store', () => {
     setProviderOrder(['openai', 'xd']);
     expect(readProviderOrder()).toEqual(['openai', 'anthropic', 'xd']);
   });
+
+  it('does not reorder an already recorded provider when observing it alone', () => {
+    setProviderOrder(['xd', 'custom', 'openai']);
+    setProviderOrder(['openai', 'custom', 'xd']);
+
+    expect(setProviderOrder(['custom'])).toBe(false);
+    expect(readProviderOrder()).toEqual(['openai', 'custom', 'xd']);
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
@@ -20,29 +20,6 @@ describe('createProviderService', () => {
     expect(byId).toEqual({ anthropic: false, openai: false, xai: false, xd: true, gemini: false });
   });
 
-  it('applies user order only to display reads and preserves catalog order for routing reads', async () => {
-    const sortForDisplay = vi.fn((providers) => [...providers].reverse());
-    const svc = createProviderService({
-      getCatalog: bundledCatalog,
-      connection: {
-        xd: () => false,
-        anthropic: () => false,
-        openai: () => false,
-        xai: () => false,
-      },
-      sortForDisplay,
-    });
-
-    const routingOrder = (await svc.listProviders()).map((provider) => provider.id);
-    const displayOrder = (
-      await svc.listProviders({ sortForDisplay: true })
-    ).map((provider) => provider.id);
-
-    expect(routingOrder).toEqual(BUNDLED_CATALOG.providers.map((provider) => provider.id));
-    expect(displayOrder).toEqual([...routingOrder].reverse());
-    expect(sortForDisplay).toHaveBeenCalledOnce();
-  });
-
   it('builtin API-key provider connection follows builtinApiKeyConnected (2026-07 图像多来源)', async () => {
     const svc = createProviderService({
       getCatalog: bundledCatalog,

--- a/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerService.test.ts
@@ -20,6 +20,29 @@ describe('createProviderService', () => {
     expect(byId).toEqual({ anthropic: false, openai: false, xai: false, xd: true, gemini: false });
   });
 
+  it('applies user order only to display reads and preserves catalog order for routing reads', async () => {
+    const sortForDisplay = vi.fn((providers) => [...providers].reverse());
+    const svc = createProviderService({
+      getCatalog: bundledCatalog,
+      connection: {
+        xd: () => false,
+        anthropic: () => false,
+        openai: () => false,
+        xai: () => false,
+      },
+      sortForDisplay,
+    });
+
+    const routingOrder = (await svc.listProviders()).map((provider) => provider.id);
+    const displayOrder = (
+      await svc.listProviders({ sortForDisplay: true })
+    ).map((provider) => provider.id);
+
+    expect(routingOrder).toEqual(BUNDLED_CATALOG.providers.map((provider) => provider.id));
+    expect(displayOrder).toEqual([...routingOrder].reverse());
+    expect(sortForDisplay).toHaveBeenCalledOnce();
+  });
+
   it('builtin API-key provider connection follows builtinApiKeyConnected (2026-07 图像多来源)', async () => {
     const svc = createProviderService({
       getCatalog: bundledCatalog,

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -55,7 +55,6 @@ import {
 } from './model-discovery/anthropic.js';
 import { createProviderService, type ProviderService } from './provider-service.js';
 import { readModelDisableOverrides } from './model-disable-store.js';
-import { sortProvidersForDisplay } from './provider-order-store.js';
 import { listCustomProvidersWithSecureHeaders } from './custom-provider-header-secrets.js';
 import {
   setCustomProviderKeyReader,
@@ -754,9 +753,6 @@ export function getDesktopProviderService(): ProviderService {
     // 「模型 / 供应商停用」override:main 侧持久化真源,烘焙进 ProviderView 后
     // renderer / IM / Orca / device-link 全部消费同一份准入事实。
     getModelAccess: readModelDisableOverrides,
-    // 仅 provider:list 显式请求显示顺序；main 内部路由继续使用目录原序，避免用户
-    // 拖动设置列表意外改变默认模型解析或 first-match 路由行为。
-    sortForDisplay: sortProvidersForDisplay,
   });
   return singleton;
 }

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -55,6 +55,7 @@ import {
 } from './model-discovery/anthropic.js';
 import { createProviderService, type ProviderService } from './provider-service.js';
 import { readModelDisableOverrides } from './model-disable-store.js';
+import { sortProvidersForDisplay } from './provider-order-store.js';
 import { listCustomProvidersWithSecureHeaders } from './custom-provider-header-secrets.js';
 import {
   setCustomProviderKeyReader,
@@ -753,6 +754,9 @@ export function getDesktopProviderService(): ProviderService {
     // 「模型 / 供应商停用」override:main 侧持久化真源,烘焙进 ProviderView 后
     // renderer / IM / Orca / device-link 全部消费同一份准入事实。
     getModelAccess: readModelDisableOverrides,
+    // 仅 provider:list 显式请求显示顺序；main 内部路由继续使用目录原序，避免用户
+    // 拖动设置列表意外改变默认模型解析或 first-match 路由行为。
+    sortForDisplay: sortProvidersForDisplay,
   });
   return singleton;
 }

--- a/apps/desktop/src/main/maker-host/provider-order-store.ts
+++ b/apps/desktop/src/main/maker-host/provider-order-store.ts
@@ -7,10 +7,7 @@
  * every other newly visible provider appends at the end.
  */
 
-import type { ProviderView } from '@cindy/model-providers';
-
 import {
-  applyProviderOrder,
   mergeObservedProviderOrder,
   normalizeProviderOrder,
 } from '../../shared/providerOrder.js';
@@ -46,10 +43,6 @@ export function readProviderOrder(): string[] {
   store.invalidateIfChanged();
   const order = [...store.read().providerOrder];
   return order.includes(CINDY_AI_PROVIDER_ID) ? order : [CINDY_AI_PROVIDER_ID, ...order];
-}
-
-export function sortProvidersForDisplay(providers: readonly ProviderView[]): ProviderView[] {
-  return applyProviderOrder(providers, readProviderOrder());
 }
 
 export function setProviderOrder(visibleProviderIds: readonly string[]): boolean {

--- a/apps/desktop/src/main/maker-host/provider-order-store.ts
+++ b/apps/desktop/src/main/maker-host/provider-order-store.ts
@@ -1,0 +1,67 @@
+/**
+ * provider-order-store — owner-scoped provider display-order override.
+ *
+ * File: <userData>/provider-order-prefs.json
+ * The persisted list is the order in which providers have appeared in Settings,
+ * subsequently adjusted by explicit drag operations. Cindy AI seeds an empty list;
+ * every other newly visible provider appends at the end.
+ */
+
+import type { ProviderView } from '@cindy/model-providers';
+
+import {
+  applyProviderOrder,
+  mergeObservedProviderOrder,
+  normalizeProviderOrder,
+} from '../../shared/providerOrder.js';
+import { ownerScopedUserDataPath } from '../appSessionState.js';
+import { desktopMakerLogger } from './logger-adapter.js';
+import { createOverrideSettingsFile } from './override-settings-file.js';
+
+const log = desktopMakerLogger.child('provider-order-store');
+const CINDY_AI_PROVIDER_ID = 'xd';
+
+interface ProviderOrderPrefs {
+  providerOrder: string[];
+}
+
+const DEFAULTS: ProviderOrderPrefs = { providerOrder: [] };
+
+function normalize(raw: unknown): ProviderOrderPrefs {
+  if (!raw || typeof raw !== 'object') return { providerOrder: [] };
+  return {
+    providerOrder: normalizeProviderOrder((raw as { providerOrder?: unknown }).providerOrder),
+  };
+}
+
+const store = createOverrideSettingsFile<ProviderOrderPrefs>({
+  filePath: () => ownerScopedUserDataPath('provider-order-prefs.json'),
+  defaults: DEFAULTS,
+  normalize,
+  log,
+  label: 'provider-order',
+});
+
+export function readProviderOrder(): string[] {
+  store.invalidateIfChanged();
+  const order = [...store.read().providerOrder];
+  return order.includes(CINDY_AI_PROVIDER_ID) ? order : [CINDY_AI_PROVIDER_ID, ...order];
+}
+
+export function sortProvidersForDisplay(providers: readonly ProviderView[]): ProviderView[] {
+  return applyProviderOrder(providers, readProviderOrder());
+}
+
+export function setProviderOrder(visibleProviderIds: readonly string[]): boolean {
+  store.invalidateIfChanged();
+  const current = readProviderOrder();
+  const next = mergeObservedProviderOrder(current, normalizeProviderOrder(visibleProviderIds));
+  if (next.length === current.length && next.every((id, index) => id === current[index])) {
+    return false;
+  }
+  store.writePatch({ providerOrder: next });
+  log.info('provider display order written', { count: next.length });
+  return true;
+}
+
+export const __testing = { normalize, reset: () => store.reset() };

--- a/apps/desktop/src/main/maker-host/provider-order-store.ts
+++ b/apps/desktop/src/main/maker-host/provider-order-store.ts
@@ -1,7 +1,7 @@
 /**
  * provider-order-store — owner-scoped provider display-order override.
  *
- * File: <userData>/provider-order-prefs.json
+ * File: the active owner's namespace via ownerScopedUserDataPath('provider-order-prefs.json').
  * The persisted list is the order in which providers have appeared in Settings,
  * subsequently adjusted by explicit drag operations. Cindy AI seeds an empty list;
  * every other newly visible provider appends at the end.

--- a/apps/desktop/src/main/maker-host/provider-service.ts
+++ b/apps/desktop/src/main/maker-host/provider-service.ts
@@ -39,8 +39,6 @@ export interface ProviderListOptions extends ConnectionReadOptions {
    * rather than the user-selectable projection. Never sourced from IPC input.
    */
   catalog?: Catalog;
-  /** Apply the persisted user-facing order. Internal routing callers leave this false. */
-  sortForDisplay?: boolean;
 }
 
 /** 内置三家供应商「是否已连接」的判定器（由 host 注入，读各自凭证存储）。 */
@@ -88,8 +86,6 @@ export interface ProviderServiceDeps {
    * 消费方(renderer / IM / Orca 路由 / device-link)拿到同一份准入事实。缺省 = 全启用。
    */
   getModelAccess?: () => ModelDisableOverrides;
-  /** User-facing projection only; never applied to internal routing/default resolution. */
-  sortForDisplay?: (providers: readonly ProviderView[]) => ProviderView[];
 }
 
 export interface ProviderService {
@@ -156,10 +152,7 @@ export function createProviderService(deps: ProviderServiceDeps): ProviderServic
         if (failure) discoveryFailures[p.id] = failure;
       }
     }
-    const providers = buildRegistry(catalog, connected, discoveryFailures, deps.getModelAccess?.());
-    return opts?.sortForDisplay === true && deps.sortForDisplay
-      ? deps.sortForDisplay(providers)
-      : providers;
+    return buildRegistry(catalog, connected, discoveryFailures, deps.getModelAccess?.());
   }
 
   return { listProviders };

--- a/apps/desktop/src/main/maker-host/provider-service.ts
+++ b/apps/desktop/src/main/maker-host/provider-service.ts
@@ -39,6 +39,8 @@ export interface ProviderListOptions extends ConnectionReadOptions {
    * rather than the user-selectable projection. Never sourced from IPC input.
    */
   catalog?: Catalog;
+  /** Apply the persisted user-facing order. Internal routing callers leave this false. */
+  sortForDisplay?: boolean;
 }
 
 /** 内置三家供应商「是否已连接」的判定器（由 host 注入，读各自凭证存储）。 */
@@ -86,6 +88,8 @@ export interface ProviderServiceDeps {
    * 消费方(renderer / IM / Orca 路由 / device-link)拿到同一份准入事实。缺省 = 全启用。
    */
   getModelAccess?: () => ModelDisableOverrides;
+  /** User-facing projection only; never applied to internal routing/default resolution. */
+  sortForDisplay?: (providers: readonly ProviderView[]) => ProviderView[];
 }
 
 export interface ProviderService {
@@ -152,7 +156,10 @@ export function createProviderService(deps: ProviderServiceDeps): ProviderServic
         if (failure) discoveryFailures[p.id] = failure;
       }
     }
-    return buildRegistry(catalog, connected, discoveryFailures, deps.getModelAccess?.());
+    const providers = buildRegistry(catalog, connected, discoveryFailures, deps.getModelAccess?.());
+    return opts?.sortForDisplay === true && deps.sortForDisplay
+      ? deps.sortForDisplay(providers)
+      : providers;
   }
 
   return { listProviders };

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -153,6 +153,7 @@ describe('provider:list IPC handler', () => {
     const result = await harness.invoke(MAKER_INVOKE.PROVIDER_LIST);
     expect(result).toEqual({
       dataOwnerId: 'owner-a',
+      ownerGeneration: 1,
       providers: views,
       providerOrder,
       modelVisibilityOverrides: overrides,
@@ -269,6 +270,7 @@ describe('provider:order:set handler', () => {
     await expect(
       harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
         dataOwnerId: 'owner-a',
+        ownerGeneration: 1,
         providerIds: ['openai', 'xd', 'anthropic'],
       }),
     ).resolves.toEqual({ ok: true });
@@ -277,12 +279,15 @@ describe('provider:order:set handler', () => {
   });
 
   it.each([
-    { dataOwnerId: 'owner-a', providerIds: [] },
-    { dataOwnerId: 'owner-a', providerIds: ['xd', 'xd'] },
-    { dataOwnerId: 'owner-a', providerIds: ['xd', 'unknown'] },
-    { dataOwnerId: 'owner-a', providerIds: ['xd', 'openai'], extra: true },
-    { dataOwnerId: 42, providerIds: ['xd'] },
-    { providerIds: ['xd'] },
+    { dataOwnerId: 'owner-a', ownerGeneration: 1, providerIds: [] },
+    { dataOwnerId: 'owner-a', ownerGeneration: 1, providerIds: ['xd', 'xd'] },
+    { dataOwnerId: 'owner-a', ownerGeneration: 1, providerIds: ['xd', 'unknown'] },
+    { dataOwnerId: 'owner-a', ownerGeneration: 1, providerIds: ['xd', 'openai'], extra: true },
+    { dataOwnerId: 42, ownerGeneration: 1, providerIds: ['xd'] },
+    { dataOwnerId: 'owner-a', ownerGeneration: -1, providerIds: ['xd'] },
+    { dataOwnerId: 'owner-a', ownerGeneration: 1.5, providerIds: ['xd'] },
+    { dataOwnerId: 'owner-a', providerIds: ['xd'] },
+    { ownerGeneration: 1, providerIds: ['xd'] },
     { reset: true },
   ])('rejects invalid visible order input: %j', async (input) => {
     const harness = new IpcHarness();
@@ -306,6 +311,7 @@ describe('provider:order:set handler', () => {
     await expect(
       harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
         dataOwnerId: 'owner-a',
+        ownerGeneration: 1,
         providerIds: ['xd', 'openai'],
       }),
     ).resolves.toEqual({ ok: true });
@@ -324,6 +330,26 @@ describe('provider:order:set handler', () => {
     await expect(
       harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
         dataOwnerId: 'owner-a',
+        ownerGeneration: 1,
+        providerIds: ['openai', 'xd'],
+      }),
+    ).rejects.toThrow(/INTERNAL/);
+    expect(deps.setProviderOrder).not.toHaveBeenCalled();
+    expect(deps.broadcastChanged).not.toHaveBeenCalled();
+  });
+
+  it('rejects a delayed order write after an A→B→A owner round trip', async () => {
+    const harness = new IpcHarness();
+    const deps = makeDeps({
+      listProviderIds: () => ['xd', 'openai'],
+      currentOwnerSession: () => ({ dataOwnerId: 'owner-a', generation: 3 }),
+    });
+    registerProviderHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
+        dataOwnerId: 'owner-a',
+        ownerGeneration: 1,
         providerIds: ['openai', 'xd'],
       }),
     ).rejects.toThrow(/INTERNAL/);

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -163,6 +163,34 @@ describe('provider:list IPC handler', () => {
     });
   });
 
+  it('rejects a catalog snapshot when the active owner changes during the async read', async () => {
+    const harness = new IpcHarness();
+    let owner = 'owner-a';
+    let releaseList!: (providers: ProviderView[]) => void;
+    const listProviders = vi.fn(
+      () =>
+        new Promise<ProviderView[]>((resolve) => {
+          releaseList = resolve;
+        }),
+    );
+    const getProviderOrder = vi.fn(() => ['xd']);
+    registerProviderHandlers(
+      harness,
+      makeDeps({
+        listProviders,
+        getProviderOrder,
+        currentOwnerId: () => owner,
+      }),
+    );
+
+    const request = harness.invoke(MAKER_INVOKE.PROVIDER_LIST);
+    owner = 'owner-b';
+    releaseList([fakeView('xd', true)]);
+
+    await expect(request).rejects.toThrow(/INTERNAL/);
+    expect(getProviderOrder).not.toHaveBeenCalled();
+  });
+
   it('propagates service errors to the caller', async () => {
     const harness = new IpcHarness();
     registerProviderHandlers(
@@ -231,11 +259,15 @@ describe('provider:list IPC handler', () => {
 describe('provider:order:set handler', () => {
   it('persists the visible provider order and broadcasts a display change', async () => {
     const harness = new IpcHarness();
-    const deps = makeDeps({ listProviderIds: () => ['xd', 'anthropic', 'openai'] });
+    const deps = makeDeps({
+      listProviderIds: () => ['xd', 'anthropic', 'openai'],
+      currentOwnerId: () => 'owner-a',
+    });
     registerProviderHandlers(harness, deps);
 
     await expect(
       harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
+        dataOwnerId: 'owner-a',
         providerIds: ['openai', 'xd', 'anthropic'],
       }),
     ).resolves.toEqual({ ok: true });
@@ -244,10 +276,12 @@ describe('provider:order:set handler', () => {
   });
 
   it.each([
-    { providerIds: [] },
-    { providerIds: ['xd', 'xd'] },
-    { providerIds: ['xd', 'unknown'] },
-    { providerIds: ['xd', 'openai'], extra: true },
+    { dataOwnerId: 'owner-a', providerIds: [] },
+    { dataOwnerId: 'owner-a', providerIds: ['xd', 'xd'] },
+    { dataOwnerId: 'owner-a', providerIds: ['xd', 'unknown'] },
+    { dataOwnerId: 'owner-a', providerIds: ['xd', 'openai'], extra: true },
+    { dataOwnerId: 42, providerIds: ['xd'] },
+    { providerIds: ['xd'] },
     { reset: true },
   ])('rejects invalid visible order input: %j', async (input) => {
     const harness = new IpcHarness();
@@ -264,13 +298,35 @@ describe('provider:order:set handler', () => {
     const deps = makeDeps({
       listProviderIds: () => ['xd', 'anthropic', 'openai'],
       setProviderOrder: vi.fn(() => false),
+      currentOwnerId: () => 'owner-a',
     });
     registerProviderHandlers(harness, deps);
 
     await expect(
-      harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, { providerIds: ['xd', 'openai'] }),
+      harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
+        dataOwnerId: 'owner-a',
+        providerIds: ['xd', 'openai'],
+      }),
     ).resolves.toEqual({ ok: true });
     expect(deps.setProviderOrder).toHaveBeenCalledWith(['xd', 'openai']);
+    expect(deps.broadcastChanged).not.toHaveBeenCalled();
+  });
+
+  it('rejects a delayed order write after the active owner changes', async () => {
+    const harness = new IpcHarness();
+    const deps = makeDeps({
+      listProviderIds: () => ['xd', 'openai'],
+      currentOwnerId: () => 'owner-b',
+    });
+    registerProviderHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
+        dataOwnerId: 'owner-a',
+        providerIds: ['openai', 'xd'],
+      }),
+    ).rejects.toThrow(/INTERNAL/);
+    expect(deps.setProviderOrder).not.toHaveBeenCalled();
     expect(deps.broadcastChanged).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -81,6 +81,8 @@ function makeDeps(over: Partial<ProviderHandlerDeps> = {}): ProviderHandlerDeps 
     refreshCatalog: vi.fn(async () => {}),
     beginRouteMutation: vi.fn(() => () => {}),
     broadcastChanged: vi.fn(() => {}),
+    listProviderIds: () => [],
+    setProviderOrder: vi.fn(() => true),
     listPresets: () => [],
     testConnection: vi.fn(async () => ({ ok: true, latencyMs: 1 })),
     fetchModels: vi.fn(async () => ({ ok: true, models: [{ id: 'm1', name: 'M1' }] })),
@@ -144,6 +146,10 @@ describe('provider:list IPC handler', () => {
     const result = await harness.invoke(MAKER_INVOKE.PROVIDER_LIST);
     expect(result).toEqual({ providers: views, modelVisibilityOverrides: overrides });
     expect(listProviders).toHaveBeenCalledOnce();
+    expect(listProviders).toHaveBeenCalledWith({
+      allowSideEffects: false,
+      sortForDisplay: true,
+    });
   });
 
   it('propagates service errors to the caller', async () => {
@@ -208,6 +214,53 @@ describe('provider:list IPC handler', () => {
     expect(result.providers[0].routing.pi?.headerOverride).toBeUndefined();
     // 非密字段仍完整回传,编辑表单据此渲染 endpoint/鉴权策略。
     expect(result.providers[0].routing.pi?.upstream).toBe('https://custom.example/v1');
+  });
+});
+
+describe('provider:order:set handler', () => {
+  it('persists the visible provider order and broadcasts a display change', async () => {
+    const harness = new IpcHarness();
+    const deps = makeDeps({ listProviderIds: () => ['xd', 'anthropic', 'openai'] });
+    registerProviderHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, {
+        providerIds: ['openai', 'xd', 'anthropic'],
+      }),
+    ).resolves.toEqual({ ok: true });
+    expect(deps.setProviderOrder).toHaveBeenCalledWith(['openai', 'xd', 'anthropic']);
+    expect(deps.broadcastChanged).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { providerIds: [] },
+    { providerIds: ['xd', 'xd'] },
+    { providerIds: ['xd', 'unknown'] },
+    { providerIds: ['xd', 'openai'], extra: true },
+    { reset: true },
+  ])('rejects invalid visible order input: %j', async (input) => {
+    const harness = new IpcHarness();
+    const deps = makeDeps({ listProviderIds: () => ['xd', 'openai'] });
+    registerProviderHandlers(harness, deps);
+
+    await expect(harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, input)).rejects.toThrow();
+    expect(deps.setProviderOrder).not.toHaveBeenCalled();
+    expect(deps.broadcastChanged).not.toHaveBeenCalled();
+  });
+
+  it('accepts a partial visible list and skips broadcasting an unchanged order', async () => {
+    const harness = new IpcHarness();
+    const deps = makeDeps({
+      listProviderIds: () => ['xd', 'anthropic', 'openai'],
+      setProviderOrder: vi.fn(() => false),
+    });
+    registerProviderHandlers(harness, deps);
+
+    await expect(
+      harness.invoke(MAKER_INVOKE.PROVIDER_ORDER_SET, { providerIds: ['xd', 'openai'] }),
+    ).resolves.toEqual({ ok: true });
+    expect(deps.setProviderOrder).toHaveBeenCalledWith(['xd', 'openai']);
+    expect(deps.broadcastChanged).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -146,7 +146,7 @@ describe('provider:list IPC handler', () => {
         listProviders,
         getModelVisibilityOverrides: () => overrides,
         getProviderOrder: () => providerOrder,
-        currentOwnerId: () => 'owner-a',
+        currentOwnerSession: () => ({ dataOwnerId: 'owner-a', generation: 1 }),
       }),
     );
 
@@ -163,9 +163,9 @@ describe('provider:list IPC handler', () => {
     });
   });
 
-  it('rejects a catalog snapshot when the active owner changes during the async read', async () => {
+  it('rejects a catalog snapshot after an A→B→A owner round trip during the async read', async () => {
     const harness = new IpcHarness();
-    let owner = 'owner-a';
+    let ownerSession = { dataOwnerId: 'owner-a' as string | null, generation: 1 };
     let releaseList!: (providers: ProviderView[]) => void;
     const listProviders = vi.fn(
       () =>
@@ -179,12 +179,13 @@ describe('provider:list IPC handler', () => {
       makeDeps({
         listProviders,
         getProviderOrder,
-        currentOwnerId: () => owner,
+        currentOwnerSession: () => ownerSession,
       }),
     );
 
     const request = harness.invoke(MAKER_INVOKE.PROVIDER_LIST);
-    owner = 'owner-b';
+    ownerSession = { dataOwnerId: 'owner-b', generation: 2 };
+    ownerSession = { dataOwnerId: 'owner-a', generation: 3 };
     releaseList([fakeView('xd', true)]);
 
     await expect(request).rejects.toThrow(/INTERNAL/);
@@ -261,7 +262,7 @@ describe('provider:order:set handler', () => {
     const harness = new IpcHarness();
     const deps = makeDeps({
       listProviderIds: () => ['xd', 'anthropic', 'openai'],
-      currentOwnerId: () => 'owner-a',
+      currentOwnerSession: () => ({ dataOwnerId: 'owner-a', generation: 1 }),
     });
     registerProviderHandlers(harness, deps);
 
@@ -298,7 +299,7 @@ describe('provider:order:set handler', () => {
     const deps = makeDeps({
       listProviderIds: () => ['xd', 'anthropic', 'openai'],
       setProviderOrder: vi.fn(() => false),
-      currentOwnerId: () => 'owner-a',
+      currentOwnerSession: () => ({ dataOwnerId: 'owner-a', generation: 1 }),
     });
     registerProviderHandlers(harness, deps);
 
@@ -316,7 +317,7 @@ describe('provider:order:set handler', () => {
     const harness = new IpcHarness();
     const deps = makeDeps({
       listProviderIds: () => ['xd', 'openai'],
-      currentOwnerId: () => 'owner-b',
+      currentOwnerSession: () => ({ dataOwnerId: 'owner-b', generation: 2 }),
     });
     registerProviderHandlers(harness, deps);
 
@@ -441,14 +442,19 @@ describe('model-disable:set handler', () => {
     expect(order).toEqual(['disable', 'enable']);
   });
 
-  it('异步窗口内切账号 → INTERNAL 拒写:A 的点击不落进 B 的 owner-scoped 偏好', async () => {
+  it('异步窗口内 A→B→A → INTERNAL 拒写:旧会话点击不落进新会话', async () => {
     const harness = new IpcHarness();
-    let owner = 'owner-a';
+    let ownerSession = { dataOwnerId: 'owner-a' as string | null, generation: 1 };
+    let shouldRoundTrip = true;
     const deps = makeDeps({
-      currentOwnerId: () => owner,
-      // 目录校验的 await 窗口内发生账号切换。
+      currentOwnerSession: () => ownerSession,
+      // 目录校验的 await 窗口内发生 A→B→A；owner id 最终相同但 generation 已变。
       listProviders: async () => {
-        owner = 'owner-b';
+        if (shouldRoundTrip) {
+          shouldRoundTrip = false;
+          ownerSession = { dataOwnerId: 'owner-b', generation: 2 };
+          ownerSession = { dataOwnerId: 'owner-a', generation: 3 };
+        }
         return xdCatalog();
       },
     });
@@ -1304,11 +1310,11 @@ describe('provider:custom:* CRUD handlers', () => {
     // Authorization 或 API key 按 B 的 owner-scoped storage key 落盘。
     mountDb();
     const harness = new IpcHarness();
-    let owner: string | null = 'owner-a';
+    let ownerSession = { dataOwnerId: 'owner-a' as string | null, generation: 1 };
     const storeCustomProviderKey = vi.fn(() => true);
     const storeCustomProviderHeaders = vi.fn(() => true);
     const deps = makeDeps({
-      currentOwnerId: () => owner,
+      currentOwnerSession: () => ownerSession,
       storeCustomProviderKey,
       storeCustomProviderHeaders,
     });
@@ -1340,7 +1346,7 @@ describe('provider:custom:* CRUD handlers', () => {
         },
       },
     }, { pi: 'owner-a-new-key' });
-    owner = 'owner-b';
+    ownerSession = { dataOwnerId: 'owner-b', generation: 2 };
 
     await expect(update).rejects.toThrow(/active account changed during provider mutation/);
     expect(storeCustomProviderKey).not.toHaveBeenCalled();

--- a/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/providerHandlers.test.ts
@@ -83,6 +83,7 @@ function makeDeps(over: Partial<ProviderHandlerDeps> = {}): ProviderHandlerDeps 
     broadcastChanged: vi.fn(() => {}),
     listProviderIds: () => [],
     setProviderOrder: vi.fn(() => true),
+    getProviderOrder: () => [],
     listPresets: () => [],
     testConnection: vi.fn(async () => ({ ok: true, latencyMs: 1 })),
     fetchModels: vi.fn(async () => ({ ok: true, models: [{ id: 'm1', name: 'M1' }] })),
@@ -133,22 +134,32 @@ afterEach(() => {
 });
 
 describe('provider:list IPC handler', () => {
-  it('wraps the injected service result as { providers } + visibility overrides snapshot', async () => {
+  it('keeps providers in catalog order and returns display order as owner-scoped metadata', async () => {
     const harness = new IpcHarness();
     const views = [fakeView('xd', true), fakeView('anthropic', false)];
     const listProviders = vi.fn(async () => views);
     const overrides = { 'claude-code:xd:claude-opus-4-8': false };
+    const providerOrder = ['anthropic', 'xd'];
     registerProviderHandlers(
       harness,
-      makeDeps({ listProviders, getModelVisibilityOverrides: () => overrides }),
+      makeDeps({
+        listProviders,
+        getModelVisibilityOverrides: () => overrides,
+        getProviderOrder: () => providerOrder,
+        currentOwnerId: () => 'owner-a',
+      }),
     );
 
     const result = await harness.invoke(MAKER_INVOKE.PROVIDER_LIST);
-    expect(result).toEqual({ providers: views, modelVisibilityOverrides: overrides });
+    expect(result).toEqual({
+      dataOwnerId: 'owner-a',
+      providers: views,
+      providerOrder,
+      modelVisibilityOverrides: overrides,
+    });
     expect(listProviders).toHaveBeenCalledOnce();
     expect(listProviders).toHaveBeenCalledWith({
       allowSideEffects: false,
-      sortForDisplay: true,
     });
   });
 

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -215,6 +215,12 @@ export const MAKER_INVOKE = {
    * **不进 device-link allowlist**(远程改被控端全局设置越权,见 allowlist.ts 准入判据)。
    */
   MODEL_DISABLE_SET: 'maker:model-disable:set',
+  /**
+   * Owner-scoped provider display-order override. Input = { providerIds: string[] }.
+   * Settings mutation: local trusted renderer only; deliberately excluded from the
+   * device-link allowlist.
+   */
+  PROVIDER_ORDER_SET: 'maker:provider:order:set',
   /** Visual Settings UI only: read/write/reset a per-provider × runtime × model price estimate. */
   MODEL_PRICE_OVERRIDE_GET: 'maker:model-price-override:get',
   MODEL_PRICE_OVERRIDE_SET: 'maker:model-price-override:set',

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -216,7 +216,8 @@ export const MAKER_INVOKE = {
    */
   MODEL_DISABLE_SET: 'maker:model-disable:set',
   /**
-   * Owner-scoped provider display-order override. Input = { providerIds: string[] }.
+   * Owner-scoped provider display-order override.
+   * Input = { dataOwnerId: string | null; providerIds: string[] }.
    * Settings mutation: local trusted renderer only; deliberately excluded from the
    * device-link allowlist.
    */

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -217,7 +217,7 @@ export const MAKER_INVOKE = {
   MODEL_DISABLE_SET: 'maker:model-disable:set',
   /**
    * Owner-scoped provider display-order override.
-   * Input = { dataOwnerId: string | null; providerIds: string[] }.
+   * Input = { dataOwnerId: string | null; ownerGeneration: number; providerIds: string[] }.
    * Settings mutation: local trusted renderer only; deliberately excluded from the
    * device-link allowlist.
    */

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -332,13 +332,12 @@ export interface ProviderHandlerDeps {
    */
   stageClearProviderDisableOverrides?(providerId: string): () => boolean;
   /**
-   * 当前数据归属账号 id(生产 = getCurrentDataOwnerId)。停用写入是 owner-scoped
-   * 持久化(model-disable-prefs.json 按账号分目录),而 handler 内有异步窗口(串行
-   * 队列排队 + 目录校验的 listProviders await)—— 期间切了账号,写入会落进**新**账号
-   * 的偏好文件。在入口捕获、持久化前复核,变了就拒(PR #744 review 第七轮)。
+   * 当前数据归属会话(生产 = getActiveAppSession)。provider handler 内有异步窗口
+   * (串行队列排队 + 目录读取 await),必须同时比较 owner id 与单调 generation；只比 id
+   * 会漏掉 A→B→A 往返，让旧操作在第二个 A 会话里继续返回或落盘。
    * 可选:未注入(单测最小桩)= 不做归属校验。
    */
-  currentOwnerId?(): string | null;
+  currentOwnerSession?(): { dataOwnerId: string | null; generation: number };
   /** Active account ledger currency; used to reject unsupported reverse-FX overrides. */
   getLedgerCurrency(): MoneyCurrency;
   readModelPriceOverride(target: ModelPriceOverrideTarget): ModelPriceOverrideView;
@@ -813,10 +812,30 @@ export function registerProviderHandlers(
   // Owner-scoped provider reads and writes must stay bound to the account that was active at
   // ingress. Several provider operations cross async boundaries; reject instead of mixing an
   // earlier catalog snapshot with a later owner's preferences or persisting into that owner.
-  const providerMutationOwnerMatches = (ownerAtIngress: string | null): boolean =>
-    !deps.currentOwnerId || (deps.currentOwnerId() ?? null) === ownerAtIngress;
-  const assertProviderMutationOwner = (ownerAtIngress: string | null): void => {
+  const captureProviderOwnerSession = () => deps.currentOwnerSession?.();
+  const providerMutationOwnerMatches = (
+    ownerAtIngress: { dataOwnerId: string | null; generation: number } | undefined,
+  ): boolean => {
+    if (!deps.currentOwnerSession || !ownerAtIngress) return true;
+    const current = deps.currentOwnerSession();
+    return (
+      current.dataOwnerId === ownerAtIngress.dataOwnerId
+      && current.generation === ownerAtIngress.generation
+    );
+  };
+  const assertProviderMutationOwner = (
+    ownerAtIngress: { dataOwnerId: string | null; generation: number } | undefined,
+    message = 'active account changed during provider mutation',
+  ): void => {
     if (!providerMutationOwnerMatches(ownerAtIngress)) {
+      throwIpcError('INTERNAL', message);
+    }
+  };
+  const assertRequestedProviderOwner = (requestedDataOwnerId: string | null): void => {
+    if (
+      deps.currentOwnerSession
+      && deps.currentOwnerSession().dataOwnerId !== requestedDataOwnerId
+    ) {
       throwIpcError('INTERNAL', 'active account changed during provider mutation');
     }
   };
@@ -834,12 +853,13 @@ export function registerProviderHandlers(
     }> => {
       // 只有本机主页面能顺带触发绑定自愈与清单拉取:这条通道也服务 device-link(合成
       // event)和可能不受信的渲染上下文,它们只该拿到只读快照(PR #548 review)。
-      const dataOwnerId = deps.currentOwnerId?.() ?? null;
+      const ownerAtIngress = captureProviderOwnerSession();
+      const dataOwnerId = ownerAtIngress?.dataOwnerId ?? null;
       const trusted = deps.isTrustedSender?.(event) === true;
       const providers = await deps.listProviders({
         allowSideEffects: trusted,
       });
-      assertProviderMutationOwner(dataOwnerId);
+      assertProviderMutationOwner(ownerAtIngress);
       const providerOrder = deps.getProviderOrder();
       // 运行期鉴权请求头(Authorization / x-api-key 等)一律不经 provider:list 下发任何
       // Renderer——即使本机主页面 trusted:任何 Renderer 注入(XSS)都能读走这些长期凭证
@@ -933,7 +953,7 @@ export function registerProviderHandlers(
     ) {
       throwIpcError('INVALID_PARAMS', 'providerIds must be a bounded unique non-empty string[]');
     }
-    assertProviderMutationOwner(requestedDataOwnerId as string | null);
+    assertRequestedProviderOwner(requestedDataOwnerId as string | null);
     const catalogIds = new Set(deps.listProviderIds());
     const requestedIds = ids as string[];
     if (requestedIds.some((id) => !catalogIds.has(id))) {
@@ -1034,11 +1054,12 @@ export function registerProviderHandlers(
     // 归属捕获:store 路径按账号分目录且在 run() 执行时才解析,队列排队 + 目录校验
     // 的 await 窗口内切账号会把 A 的点击写进 B 的偏好 —— 持久化前复核,变了就拒
     // (PR #744 review 第七轮)。
-    const ownerAtIngress = deps.currentOwnerId?.() ?? null;
+    const ownerAtIngress = captureProviderOwnerSession();
     const assertSameOwner = (): void => {
-      if (deps.currentOwnerId && (deps.currentOwnerId() ?? null) !== ownerAtIngress) {
-        throwIpcError('INTERNAL', 'active account changed before persisting model disable override');
-      }
+      assertProviderMutationOwner(
+        ownerAtIngress,
+        'active account changed before persisting model disable override',
+      );
     };
     const run = async () => {
       if (i.kind === 'reset') {
@@ -1174,13 +1195,14 @@ export function registerProviderHandlers(
     if (desired.currency === 'CNY' && deps.getLedgerCurrency() === 'USD') {
       throwIpcError('INVALID_PARAMS', 'CNY price overrides cannot project into a USD ledger');
     }
-    const ownerAtIngress = deps.currentOwnerId?.() ?? null;
+    const ownerAtIngress = captureProviderOwnerSession();
     return withProviderConfigMutation(target.providerId, () =>
       enqueuePriceMutation(async () => {
         await requirePriceTargetModel(target);
-        if (deps.currentOwnerId && (deps.currentOwnerId() ?? null) !== ownerAtIngress) {
-          throwIpcError('INTERNAL', 'active account changed before persisting price override');
-        }
+        assertProviderMutationOwner(
+          ownerAtIngress,
+          'active account changed before persisting price override',
+        );
         try {
           deps.writeModelPriceOverride(target, desired);
         } catch (err) {
@@ -1201,12 +1223,13 @@ export function registerProviderHandlers(
   registry.handle(MAKER_INVOKE.MODEL_PRICE_OVERRIDE_RESET, async (event, input: unknown) => {
     assertTrustedProviderMutationSender(event);
     const target = parsePriceTarget(input);
-    const ownerAtIngress = deps.currentOwnerId?.() ?? null;
+    const ownerAtIngress = captureProviderOwnerSession();
     return withProviderConfigMutation(target.providerId, () =>
       enqueuePriceMutation(async () => {
-        if (deps.currentOwnerId && (deps.currentOwnerId() ?? null) !== ownerAtIngress) {
-          throwIpcError('INTERNAL', 'active account changed before resetting price override');
-        }
+        assertProviderMutationOwner(
+          ownerAtIngress,
+          'active account changed before resetting price override',
+        );
         try {
           deps.clearModelPriceOverride(target);
         } catch (err) {
@@ -1232,7 +1255,7 @@ export function registerProviderHandlers(
     if (!keys) throwIpcError('INVALID_PARAMS', 'invalid provider runtime keys');
     const config = input as CustomProviderConfig;
     const separated = splitCustomProviderHeaders(config);
-    const ownerAtIngress = deps.currentOwnerId?.() ?? null;
+    const ownerAtIngress = captureProviderOwnerSession();
     return withProviderConfigMutation(config.id, async () => {
       assertProviderMutationOwner(ownerAtIngress);
       if (await customProviderExists(config.id)) {
@@ -1274,7 +1297,7 @@ export function registerProviderHandlers(
     if (!keys) throwIpcError('INVALID_PARAMS', 'invalid provider runtime keys');
     const config = input as CustomProviderConfig;
     const separated = splitCustomProviderHeaders(config);
-    const ownerAtIngress = deps.currentOwnerId?.() ?? null;
+    const ownerAtIngress = captureProviderOwnerSession();
     return withProviderConfigMutation(config.id, async () => {
       let generation: symbol | null = null;
       try {
@@ -1355,7 +1378,7 @@ export function registerProviderHandlers(
     if (typeof providerId !== 'string' || providerId.length === 0) {
       throwIpcError('INVALID_PARAMS', 'providerId required');
     }
-    const ownerAtIngress = deps.currentOwnerId?.() ?? null;
+    const ownerAtIngress = captureProviderOwnerSession();
     return withProviderConfigMutation(providerId, async () => {
       // 同类 delete 也会在 per-provider 队列后写 owner-scoped 凭证。
       assertProviderMutationOwner(ownerAtIngress);

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -201,7 +201,6 @@ export interface ProviderHandlerDeps {
    */
   listProviders(opts?: {
     allowSideEffects?: boolean;
-    sortForDisplay?: boolean;
   }): Promise<ProviderView[]>;
   /**
    * 「模型显示/隐藏」override 快照(renderer → main 镜像,生产 = getModelVisibilityMirrorSnapshot)。
@@ -222,6 +221,8 @@ export interface ProviderHandlerDeps {
   listProviderIds(): string[];
   /** Merge the currently visible order into the persisted observed-provider order. */
   setProviderOrder(providerIds: readonly string[]): boolean;
+  /** Persisted Settings display order, returned as metadata without reordering ProviderView[]. */
+  getProviderOrder(): string[];
   /** 目录 presets 段（生产 = () => getActiveCatalog().presets ?? []）。 */
   listPresets(): ProviderPreset[];
   /** 测试连接（生产 = testProviderConnection；单测注入 stub 不联网）。 */
@@ -815,7 +816,9 @@ export function registerProviderHandlers(
     async (
       event,
     ): Promise<{
+      dataOwnerId: string | null;
       providers: ProviderView[];
+      providerOrder: string[];
       modelVisibilityOverrides: Record<string, boolean>;
     }> => {
       // 只有本机主页面能顺带触发绑定自愈与清单拉取:这条通道也服务 device-link(合成
@@ -823,14 +826,19 @@ export function registerProviderHandlers(
       const trusted = deps.isTrustedSender?.(event) === true;
       const providers = await deps.listProviders({
         allowSideEffects: trusted,
-        sortForDisplay: true,
       });
+      // Capture owner + owner-scoped order synchronously after the async provider read. The
+      // renderer rejects this snapshot if its owner generation no longer matches.
+      const dataOwnerId = deps.currentOwnerId?.() ?? null;
+      const providerOrder = deps.getProviderOrder();
       // 运行期鉴权请求头(Authorization / x-api-key 等)一律不经 provider:list 下发任何
       // Renderer——即使本机主页面 trusted:任何 Renderer 注入(XSS)都能读走这些长期凭证
       // (codex review)。头凭证是 main-only 密文,renderer 从不回读:编辑时未显式改动
       // 请求头,update 由 main 侧保留旧值(planProviderHeaderMutations 'update' 分支)。
       return {
+        dataOwnerId,
         providers: providers.map(withoutProviderHeaderCredentials),
+        providerOrder,
         modelVisibilityOverrides: deps.getModelVisibilityOverrides(),
       };
     },

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -810,6 +810,17 @@ export function registerProviderHandlers(
     return headersRestored && keysRestored;
   };
 
+  // Owner-scoped provider reads and writes must stay bound to the account that was active at
+  // ingress. Several provider operations cross async boundaries; reject instead of mixing an
+  // earlier catalog snapshot with a later owner's preferences or persisting into that owner.
+  const providerMutationOwnerMatches = (ownerAtIngress: string | null): boolean =>
+    !deps.currentOwnerId || (deps.currentOwnerId() ?? null) === ownerAtIngress;
+  const assertProviderMutationOwner = (ownerAtIngress: string | null): void => {
+    if (!providerMutationOwnerMatches(ownerAtIngress)) {
+      throwIpcError('INTERNAL', 'active account changed during provider mutation');
+    }
+  };
+
   // 只读聚合：loadCatalog 永不抛（最差回退内置目录），故无需 throwIpcError 包裹。
   registry.handle(
     MAKER_INVOKE.PROVIDER_LIST,
@@ -823,13 +834,12 @@ export function registerProviderHandlers(
     }> => {
       // 只有本机主页面能顺带触发绑定自愈与清单拉取:这条通道也服务 device-link(合成
       // event)和可能不受信的渲染上下文,它们只该拿到只读快照(PR #548 review)。
+      const dataOwnerId = deps.currentOwnerId?.() ?? null;
       const trusted = deps.isTrustedSender?.(event) === true;
       const providers = await deps.listProviders({
         allowSideEffects: trusted,
       });
-      // Capture owner + owner-scoped order synchronously after the async provider read. The
-      // renderer rejects this snapshot if its owner generation no longer matches.
-      const dataOwnerId = deps.currentOwnerId?.() ?? null;
+      assertProviderMutationOwner(dataOwnerId);
       const providerOrder = deps.getProviderOrder();
       // 运行期鉴权请求头(Authorization / x-api-key 等)一律不经 provider:list 下发任何
       // Renderer——即使本机主页面 trusted:任何 Renderer 注入(XSS)都能读走这些长期凭证
@@ -905,9 +915,11 @@ export function registerProviderHandlers(
     }
     const value = input as Record<string, unknown>;
     const keys = Object.keys(value);
+    const requestedDataOwnerId = value.dataOwnerId;
     const ids = value.providerIds;
     if (
-      keys.length !== 1 ||
+      keys.length !== 2 ||
+      (requestedDataOwnerId !== null && typeof requestedDataOwnerId !== 'string') ||
       !Array.isArray(ids) ||
       ids.length === 0 ||
       ids.length > MAX_PROVIDER_ORDER_ITEMS ||
@@ -921,6 +933,7 @@ export function registerProviderHandlers(
     ) {
       throwIpcError('INVALID_PARAMS', 'providerIds must be a bounded unique non-empty string[]');
     }
+    assertProviderMutationOwner(requestedDataOwnerId as string | null);
     const catalogIds = new Set(deps.listProviderIds());
     const requestedIds = ids as string[];
     if (requestedIds.some((id) => !catalogIds.has(id))) {
@@ -937,17 +950,6 @@ export function registerProviderHandlers(
     }
     return { ok: true };
   });
-
-  // 自定义供应商的 DB 与 key/header 密文都按当前 data owner 选路径。CRUD 虽由
-  // per-provider 队列串行，但排队与 DB 读取均有 await：若 A 发起后切到 B，后续
-  // safeStorage 写会按 B 的 owner 路径落盘。入口捕获 owner，在异步边界和凭证写入前复核。
-  const providerMutationOwnerMatches = (ownerAtIngress: string | null): boolean =>
-    !deps.currentOwnerId || (deps.currentOwnerId() ?? null) === ownerAtIngress;
-  const assertProviderMutationOwner = (ownerAtIngress: string | null): void => {
-    if (!providerMutationOwnerMatches(ownerAtIngress)) {
-      throwIpcError('INTERNAL', 'active account changed during provider mutation');
-    }
-  };
 
   // 「模型 / 供应商停用」override 写入。设置类写操作:仅本机主页面可调(device-link
   // 合成 event 与不受信 frame 一律拒绝 —— 远程改被控端全局设置越权);守卫缺席按拒绝

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -33,6 +33,10 @@ import type {
 } from '../../shared/modelPriceOverride.js';
 import type { MoneyCurrency } from '../../shared/regionalMoney.js';
 import {
+  MAX_PROVIDER_ORDER_ID_LENGTH,
+  MAX_PROVIDER_ORDER_ITEMS,
+} from '../../shared/providerOrder.js';
+import {
   BUILTIN_REFRESHABLE_PROVIDER_IDS,
   isBuiltinRefreshableProviderId,
   isProviderModelAutoRefreshRendererTrigger,
@@ -195,7 +199,10 @@ export interface ProviderHandlerDeps {
    * 服务 device-link（合成 event）与可能不受信的渲染上下文，所以默认纯读，只有确认 sender
    * 是本机主页面时才放行副作用（PR #548 review）。
    */
-  listProviders(opts?: { allowSideEffects?: boolean }): Promise<ProviderView[]>;
+  listProviders(opts?: {
+    allowSideEffects?: boolean;
+    sortForDisplay?: boolean;
+  }): Promise<ProviderView[]>;
   /**
    * 「模型显示/隐藏」override 快照(renderer → main 镜像,生产 = getModelVisibilityMirrorSnapshot)。
    * PROVIDER_LIST 附带回传,供 device-link 控制端(手机)按被控端用户开关过滤模型列表;
@@ -211,6 +218,10 @@ export interface ProviderHandlerDeps {
   beginRouteMutation(providerId: string): () => void;
   /** CRUD 成功后广播变更（生产 = 向所有窗口 send PROVIDER_CHANGED）。 */
   broadcastChanged(): void;
+  /** Current selectable catalog ids, used to validate visible provider order entries. */
+  listProviderIds(): string[];
+  /** Merge the currently visible order into the persisted observed-provider order. */
+  setProviderOrder(providerIds: readonly string[]): boolean;
   /** 目录 presets 段（生产 = () => getActiveCatalog().presets ?? []）。 */
   listPresets(): ProviderPreset[];
   /** 测试连接（生产 = testProviderConnection；单测注入 stub 不联网）。 */
@@ -810,7 +821,10 @@ export function registerProviderHandlers(
       // 只有本机主页面能顺带触发绑定自愈与清单拉取:这条通道也服务 device-link(合成
       // event)和可能不受信的渲染上下文,它们只该拿到只读快照(PR #548 review)。
       const trusted = deps.isTrustedSender?.(event) === true;
-      const providers = await deps.listProviders({ allowSideEffects: trusted });
+      const providers = await deps.listProviders({
+        allowSideEffects: trusted,
+        sortForDisplay: true,
+      });
       // 运行期鉴权请求头(Authorization / x-api-key 等)一律不经 provider:list 下发任何
       // Renderer——即使本机主页面 trusted:任何 Renderer 注入(XSS)都能读走这些长期凭证
       // (codex review)。头凭证是 main-only 密文,renderer 从不回读:编辑时未显式改动
@@ -873,6 +887,48 @@ export function registerProviderHandlers(
     }
     deps.assertTrustedSender(event);
   }
+
+  // 供应商显示顺序是 owner-scoped 设置。Renderer 只提交当前左栏可见项；store 会
+  // 保留曾出现但当前隐藏的项，并把第一次出现的项追加到末尾。
+  registry.handle(MAKER_INVOKE.PROVIDER_ORDER_SET, (event, input: unknown) => {
+    assertTrustedProviderMutationSender(event);
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+      throwIpcError('INVALID_PARAMS', 'invalid provider order input');
+    }
+    const value = input as Record<string, unknown>;
+    const keys = Object.keys(value);
+    const ids = value.providerIds;
+    if (
+      keys.length !== 1 ||
+      !Array.isArray(ids) ||
+      ids.length === 0 ||
+      ids.length > MAX_PROVIDER_ORDER_ITEMS ||
+      ids.some(
+        (id) =>
+          typeof id !== 'string' ||
+          id.length === 0 ||
+          id.length > MAX_PROVIDER_ORDER_ID_LENGTH,
+      ) ||
+      new Set(ids).size !== ids.length
+    ) {
+      throwIpcError('INVALID_PARAMS', 'providerIds must be a bounded unique non-empty string[]');
+    }
+    const catalogIds = new Set(deps.listProviderIds());
+    const requestedIds = ids as string[];
+    if (requestedIds.some((id) => !catalogIds.has(id))) {
+      throwIpcError('INVALID_PARAMS', 'providerIds must belong to the current provider catalog');
+    }
+    try {
+      const changed = deps.setProviderOrder(requestedIds);
+      if (changed) deps.broadcastChanged();
+    } catch (err) {
+      log.warn('provider display order persist failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throwIpcError('INTERNAL', 'failed to persist provider order');
+    }
+    return { ok: true };
+  });
 
   // 自定义供应商的 DB 与 key/header 密文都按当前 data owner 选路径。CRUD 虽由
   // per-provider 队列串行，但排队与 DB 读取均有 await：若 A 发起后切到 B，后续

--- a/apps/desktop/src/main/maker-ipc/providerHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/providerHandlers.ts
@@ -831,10 +831,17 @@ export function registerProviderHandlers(
       throwIpcError('INTERNAL', message);
     }
   };
-  const assertRequestedProviderOwner = (requestedDataOwnerId: string | null): void => {
+  const assertRequestedProviderOwner = (
+    requestedDataOwnerId: string | null,
+    requestedOwnerGeneration: number,
+  ): void => {
+    const current = deps.currentOwnerSession?.();
     if (
-      deps.currentOwnerSession
-      && deps.currentOwnerSession().dataOwnerId !== requestedDataOwnerId
+      current
+      && (
+        current.dataOwnerId !== requestedDataOwnerId
+        || current.generation !== requestedOwnerGeneration
+      )
     ) {
       throwIpcError('INTERNAL', 'active account changed during provider mutation');
     }
@@ -847,6 +854,7 @@ export function registerProviderHandlers(
       event,
     ): Promise<{
       dataOwnerId: string | null;
+      ownerGeneration: number;
       providers: ProviderView[];
       providerOrder: string[];
       modelVisibilityOverrides: Record<string, boolean>;
@@ -867,6 +875,7 @@ export function registerProviderHandlers(
       // 请求头,update 由 main 侧保留旧值(planProviderHeaderMutations 'update' 分支)。
       return {
         dataOwnerId,
+        ownerGeneration: ownerAtIngress?.generation ?? 0,
         providers: providers.map(withoutProviderHeaderCredentials),
         providerOrder,
         modelVisibilityOverrides: deps.getModelVisibilityOverrides(),
@@ -936,10 +945,14 @@ export function registerProviderHandlers(
     const value = input as Record<string, unknown>;
     const keys = Object.keys(value);
     const requestedDataOwnerId = value.dataOwnerId;
+    const requestedOwnerGeneration = value.ownerGeneration;
     const ids = value.providerIds;
     if (
-      keys.length !== 2 ||
+      keys.length !== 3 ||
       (requestedDataOwnerId !== null && typeof requestedDataOwnerId !== 'string') ||
+      typeof requestedOwnerGeneration !== 'number' ||
+      !Number.isSafeInteger(requestedOwnerGeneration) ||
+      requestedOwnerGeneration < 0 ||
       !Array.isArray(ids) ||
       ids.length === 0 ||
       ids.length > MAX_PROVIDER_ORDER_ITEMS ||
@@ -953,7 +966,10 @@ export function registerProviderHandlers(
     ) {
       throwIpcError('INVALID_PARAMS', 'providerIds must be a bounded unique non-empty string[]');
     }
-    assertRequestedProviderOwner(requestedDataOwnerId as string | null);
+    assertRequestedProviderOwner(
+      requestedDataOwnerId as string | null,
+      requestedOwnerGeneration,
+    );
     const catalogIds = new Set(deps.listProviderIds());
     const requestedIds = ids as string[];
     if (requestedIds.some((id) => !catalogIds.has(id))) {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -506,7 +506,6 @@ import {
   stageProviderDisableOverridesClear,
 } from '../maker-host/model-disable-store.js';
 import { readProviderOrder, setProviderOrder } from '../maker-host/provider-order-store.js';
-import { getCurrentDataOwnerId } from '../authManager.js';
 import {
   resolveLenientSessionRoute,
   verdictForModelRoute,
@@ -4469,9 +4468,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       stageProviderDisableOverridesClear(providerId),
     // 「恢复默认」= 删除该供应商整组停用 override(configuration-and-overrides.md §4)。
     clearProviderDisableOverrides: (providerId) => clearProviderDisableOverrides(providerId),
-    // 停用写入的归属校验:入口捕获 / 持久化前复核,异步窗口内切账号即拒,防 A 的
-    // 点击写进 B 的 owner-scoped 偏好文件(PR #744 review 第七轮)。
-    currentOwnerId: () => getCurrentDataOwnerId(),
+    // 所有跨 await 的 provider 读写都捕获完整 app session；generation 能识别 A→B→A，
+    // 防止旧请求返回混合快照或写进后来重新进入的 A 会话。
+    currentOwnerSession: () => getActiveAppSession(),
     readCustomProviderHeadersForMutation,
     storeCustomProviderHeaders,
     removeCustomProviderHeaders,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -435,6 +435,7 @@ import {
 } from '../mcp-integrations/custom-mcp-registry.js';
 import {
   getDesktopProviderService,
+  getDesktopSelectableCatalog,
   refreshActiveCatalogFromSource,
   refreshCustomProvidersIntoCatalog,
 } from '../maker-host/createDesktopProviderService.js';
@@ -504,6 +505,7 @@ import {
   setProviderDisabled,
   stageProviderDisableOverridesClear,
 } from '../maker-host/model-disable-store.js';
+import { setProviderOrder } from '../maker-host/provider-order-store.js';
 import { getCurrentDataOwnerId } from '../authManager.js';
 import {
   resolveLenientSessionRoute,
@@ -4436,6 +4438,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     refreshCatalog: () => refreshCustomProvidersIntoCatalog(),
     beginRouteMutation: (providerId) => beginProviderRouteMutation(providerId),
     broadcastChanged: () => broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {}),
+    listProviderIds: () => getDesktopSelectableCatalog().providers.map((provider) => provider.id),
+    setProviderOrder: (providerIds) => setProviderOrder(providerIds),
     listPresets: () => getActiveCatalog().presets ?? [],
     testConnection: (input) => testProviderConnection(input),
     fetchModels: (spec) => fetchProviderModels(spec),

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -505,7 +505,7 @@ import {
   setProviderDisabled,
   stageProviderDisableOverridesClear,
 } from '../maker-host/model-disable-store.js';
-import { setProviderOrder } from '../maker-host/provider-order-store.js';
+import { readProviderOrder, setProviderOrder } from '../maker-host/provider-order-store.js';
 import { getCurrentDataOwnerId } from '../authManager.js';
 import {
   resolveLenientSessionRoute,
@@ -4440,6 +4440,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     broadcastChanged: () => broadcastToAllWindows(MAKER_PUSH.PROVIDER_CHANGED, {}),
     listProviderIds: () => getDesktopSelectableCatalog().providers.map((provider) => provider.id),
     setProviderOrder: (providerIds) => setProviderOrder(providerIds),
+    getProviderOrder: () => readProviderOrder(),
     listPresets: () => getActiveCatalog().presets ?? [],
     testConnection: (input) => testProviderConnection(input),
     fetchModels: (spec) => fetchProviderModels(spec),

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -4332,6 +4332,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
         // configuration-and-overrides.md §4 的「删 override 跟随默认」语义。
         | { kind: 'reset'; providerId: string },
     ): Promise<{ ok: true }> => ipcRenderer.invoke('maker:model-disable:set', input),
+    /** Persist the currently visible provider order for the active owner. */
+    setProviderOrder: (providerIds: string[]): Promise<{ ok: true }> =>
+      ipcRenderer.invoke('maker:provider:order:set', { providerIds }),
     getModelPriceOverride: (
       target: import('../shared/modelPriceOverride').ModelPriceOverrideTarget,
     ): Promise<import('../shared/modelPriceOverride').ModelPriceOverrideView> =>

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -4158,7 +4158,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('maker:get-workflow-progress', sessionId, taskId),
 
     // 模型供应商目录（只读）—— 内置目录元数据 + 各供应商实时连接状态。
-    listProviders: (): Promise<{ providers: import('@cindy/model-providers').ProviderView[] }> =>
+    listProviders: (): Promise<{
+      dataOwnerId: string | null;
+      providers: import('@cindy/model-providers').ProviderView[];
+      providerOrder: string[];
+    }> =>
       ipcRenderer.invoke('maker:provider:list'),
     /** Refresh one built-in provider through its existing main-process discovery source. */
     refreshBuiltinProviderModels: (

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -4160,6 +4160,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // 模型供应商目录（只读）—— 内置目录元数据 + 各供应商实时连接状态。
     listProviders: (): Promise<{
       dataOwnerId: string | null;
+      ownerGeneration: number;
       providers: import('@cindy/model-providers').ProviderView[];
       providerOrder: string[];
     }> =>
@@ -4339,9 +4340,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     /** Persist the visible provider order only if the active owner still matches. */
     setProviderOrder: (
       dataOwnerId: string | null,
+      ownerGeneration: number,
       providerIds: string[],
     ): Promise<{ ok: true }> =>
-      ipcRenderer.invoke('maker:provider:order:set', { dataOwnerId, providerIds }),
+      ipcRenderer.invoke('maker:provider:order:set', {
+        dataOwnerId,
+        ownerGeneration,
+        providerIds,
+      }),
     getModelPriceOverride: (
       target: import('../shared/modelPriceOverride').ModelPriceOverrideTarget,
     ): Promise<import('../shared/modelPriceOverride').ModelPriceOverrideView> =>

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -4336,9 +4336,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
         // configuration-and-overrides.md §4 的「删 override 跟随默认」语义。
         | { kind: 'reset'; providerId: string },
     ): Promise<{ ok: true }> => ipcRenderer.invoke('maker:model-disable:set', input),
-    /** Persist the currently visible provider order for the active owner. */
-    setProviderOrder: (providerIds: string[]): Promise<{ ok: true }> =>
-      ipcRenderer.invoke('maker:provider:order:set', { providerIds }),
+    /** Persist the visible provider order only if the active owner still matches. */
+    setProviderOrder: (
+      dataOwnerId: string | null,
+      providerIds: string[],
+    ): Promise<{ ok: true }> =>
+      ipcRenderer.invoke('maker:provider:order:set', { dataOwnerId, providerIds }),
     getModelPriceOverride: (
       target: import('../shared/modelPriceOverride').ModelPriceOverrideTarget,
     ): Promise<import('../shared/modelPriceOverride').ModelPriceOverrideView> =>

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -85,13 +85,12 @@ function LoginHandoffHost({ children }: { children: React.ReactNode }) {
 }
 
 function MakerBootstrap() {
-  const { isAuthenticated } = useAuth();
+  const { isAuthenticated, dataOwnerId } = useAuth();
 
   useResyncAgentIslandSettingsAfterLogin(isAuthenticated);
 
   useEffect(() => {
     makerChatStore.syncActiveTurnsFromMain();
-    void preloadLocalCatalogSnapshot();
     // main 先提交 active catalog + capabilities 再广播；renderer 收到任一目录/鉴权变化后
     // 联合重拉 providers 与两份 capabilities，整组成功且代际最新时才切换。
     const refresh = () => {
@@ -104,6 +103,12 @@ function MakerBootstrap() {
       offProviders?.();
     };
   }, []);
+
+  // Auth 广播的多个 listener 没有顺序契约；等 AuthContext 提交新 owner 后再预热一次，
+  // 保证 provider 快照与 capabilities 不会沿用或提交前一个 owner 的在途结果。
+  useEffect(() => {
+    void preloadLocalCatalogSnapshot();
+  }, [dataOwnerId]);
   return null;
 }
 

--- a/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/authContextRace.test.ts
@@ -34,14 +34,16 @@ describe('AuthContext auth-state races', () => {
   });
 
   it('publishes a data-owner generation at every auth boundary', () => {
-    expect(source).toContain('setDataOwnerGeneration(state.dataOwnerId);');
+    expect(source).toContain('setDataOwnerGeneration(dataOwnerId);');
+    expect(source).toContain('invalidateProvidersSnapshot();');
+    expect(source).toContain('publishDataOwnerGeneration(state.dataOwnerId);');
     expect(source).toContain('// Invalidate in-flight remote sends before the confirmation dialog resolves.');
-    expect(source.match(/setDataOwnerGeneration\(null\);/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(source.match(/publishDataOwnerGeneration\(null\);/g)?.length).toBeGreaterThanOrEqual(2);
     const enterLocal = source.indexOf('const enterLocalMode = useCallback');
     const exitLocal = source.indexOf('const exitLocalMode = useCallback');
-    expect(source.indexOf('setDataOwnerGeneration(state.dataOwnerId);', enterLocal))
+    expect(source.indexOf('publishDataOwnerGeneration(state.dataOwnerId);', enterLocal))
       .toBeLessThan(exitLocal);
-    expect(source.indexOf('setDataOwnerGeneration(state.dataOwnerId);', exitLocal))
+    expect(source.indexOf('publishDataOwnerGeneration(state.dataOwnerId);', exitLocal))
       .toBeGreaterThan(exitLocal);
   });
 

--- a/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => {
     getLoginState: vi.fn(),
     dispatchLoginAction: vi.fn(),
     logout: vi.fn(async () => undefined),
+    enterLocalMode: vi.fn(),
+    exitLocalMode: vi.fn(),
     consumeAccountDeletionRestoredNotice: vi.fn(async () => true),
     onAuthStateChange: vi.fn((listener: (state: unknown) => void) => {
       authStateListener = listener;
@@ -27,6 +29,7 @@ const mocks = vi.hoisted(() => {
     getMe: vi.fn(async () => ({ role: 'user' })),
     clearWorkersCache: vi.fn(),
     invalidateProvidersSnapshot: vi.fn(),
+    preloadLocalCatalogSnapshot: vi.fn(async () => undefined),
     confirm: vi.fn(async () => true),
     emitAuth(state: unknown) {
       authStateListener?.(state);
@@ -56,6 +59,9 @@ vi.mock('@/features/cc-agent/hooks/useWorkers', () => ({
 vi.mock('@/lib/providersSnapshotStore', () => ({
   invalidateProvidersSnapshot: mocks.invalidateProvidersSnapshot,
 }));
+vi.mock('@/lib/localCatalogSnapshot', () => ({
+  preloadLocalCatalogSnapshot: mocks.preloadLocalCatalogSnapshot,
+}));
 vi.mock('@/components/ui/confirm-dialog-provider', () => ({
   useConfirmDialog: () => ({ confirm: mocks.confirm }),
 }));
@@ -70,7 +76,10 @@ vi.mock('@/lib/toast', () => ({
 }));
 
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
-import { __testing as dataOwnerGenerationTesting } from '@/contexts/dataOwnerGeneration';
+import {
+  __testing as dataOwnerGenerationTesting,
+  getDataOwnerGeneration,
+} from '@/contexts/dataOwnerGeneration';
 
 function user(id: string) {
   return {
@@ -127,12 +136,15 @@ describe('AuthContext session cache boundaries', () => {
     mocks.getMe.mockClear();
     mocks.clearWorkersCache.mockClear();
     mocks.invalidateProvidersSnapshot.mockClear();
+    mocks.preloadLocalCatalogSnapshot.mockClear();
     dataOwnerGenerationTesting.reset();
     mocks.service.consumeAccountDeletionRestoredNotice.mockClear();
     restoredToast.mockClear();
     mocks.confirm.mockClear();
     mocks.service.initialize.mockResolvedValue(authState('account-a'));
     mocks.service.logout.mockResolvedValue(undefined);
+    mocks.service.enterLocalMode.mockResolvedValue(localAuthState());
+    mocks.service.exitLocalMode.mockResolvedValue(authState(null));
     (window as unknown as { electronAPI: { onAuthSessionExpired: typeof mocks.registerExpired } }).electronAPI = {
       onAuthSessionExpired: mocks.registerExpired,
     };
@@ -174,6 +186,127 @@ describe('AuthContext session cache boundaries', () => {
     mocks.reset.mockClear();
     act(() => mocks.emitExpired());
     await waitFor(() => expect(mocks.reset).toHaveBeenCalledTimes(1));
+  });
+
+  it.each([
+    ['logout', 'account-a', authState('account-a')],
+    ['enterLocalMode', 'account-a', authState('account-a')],
+    ['exitLocalMode', 'local-v1', localAuthState()],
+  ] as const)(
+    'restores and reloads the current owner snapshot when %s fails',
+    async (action, expectedOwner, initialState) => {
+      mocks.service.initialize.mockResolvedValue(initialState);
+      mocks.service[action].mockRejectedValueOnce(new Error(`${action} failed`));
+      const view = renderHook(() => useAuth(), { wrapper });
+      await waitFor(() => expect(view.result.current.dataOwnerId).toBe(expectedOwner));
+
+      await act(async () => {
+        await expect(view.result.current[action]()).rejects.toThrow(`${action} failed`);
+      });
+
+      expect(view.result.current.dataOwnerId).toBe(expectedOwner);
+      expect(getDataOwnerGeneration().dataOwnerId).toBe(expectedOwner);
+      expect(mocks.preloadLocalCatalogSnapshot).toHaveBeenCalledOnce();
+    },
+  );
+
+  it('keeps a newer pushed owner when an older auth boundary later rejects', async () => {
+    let rejectLogout!: (error: Error) => void;
+    mocks.service.logout.mockReturnValueOnce(new Promise<void>((_resolve, reject) => {
+      rejectLogout = reject;
+    }));
+    const view = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(view.result.current.dataOwnerId).toBe('account-a'));
+
+    let logout!: Promise<void>;
+    act(() => {
+      logout = view.result.current.logout();
+    });
+    act(() => mocks.emitAuth(authState('account-b')));
+    await act(async () => {
+      rejectLogout(new Error('logout failed'));
+      await expect(logout).rejects.toThrow('logout failed');
+    });
+
+    expect(view.result.current.dataOwnerId).toBe('account-b');
+    expect(getDataOwnerGeneration().dataOwnerId).toBe('account-b');
+    expect(mocks.preloadLocalCatalogSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('restores the stable owner after overlapping auth boundaries both reject', async () => {
+    let rejectFirst!: (error: Error) => void;
+    let rejectSecond!: (error: Error) => void;
+    mocks.service.logout
+      .mockReturnValueOnce(new Promise<void>((_resolve, reject) => {
+        rejectFirst = reject;
+      }))
+      .mockReturnValueOnce(new Promise<void>((_resolve, reject) => {
+        rejectSecond = reject;
+      }));
+    const view = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(view.result.current.dataOwnerId).toBe('account-a'));
+
+    const first = view.result.current.logout();
+    const second = view.result.current.logout();
+    await act(async () => {
+      rejectFirst(new Error('first logout failed'));
+      await expect(first).rejects.toThrow('first logout failed');
+    });
+    await act(async () => {
+      rejectSecond(new Error('second logout failed'));
+      await expect(second).rejects.toThrow('second logout failed');
+    });
+
+    expect(getDataOwnerGeneration().dataOwnerId).toBe('account-a');
+    expect(mocks.preloadLocalCatalogSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('restores a locally committed owner when the next boundary fails before an auth push', async () => {
+    mocks.service.initialize.mockResolvedValue(authState(null));
+    mocks.service.exitLocalMode.mockRejectedValueOnce(new Error('exit failed'));
+    const view = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(view.result.current.dataOwnerId).toBeNull());
+
+    await act(async () => {
+      await view.result.current.enterLocalMode();
+    });
+    expect(view.result.current.dataOwnerId).toBe('local-v1');
+
+    await act(async () => {
+      await expect(view.result.current.exitLocalMode()).rejects.toThrow('exit failed');
+    });
+    expect(getDataOwnerGeneration().dataOwnerId).toBe('local-v1');
+    expect(mocks.preloadLocalCatalogSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('keeps a successful overlapping owner transition when a sibling later rejects', async () => {
+    let resolveFirst!: (state: ReturnType<typeof authState>) => void;
+    let rejectSecond!: (error: Error) => void;
+    mocks.service.initialize.mockResolvedValue(localAuthState());
+    mocks.service.exitLocalMode
+      .mockReturnValueOnce(new Promise((resolve) => {
+        resolveFirst = resolve;
+      }))
+      .mockReturnValueOnce(new Promise((_resolve, reject) => {
+        rejectSecond = reject;
+      }));
+    const view = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(view.result.current.dataOwnerId).toBe('local-v1'));
+
+    const first = view.result.current.exitLocalMode();
+    const second = view.result.current.exitLocalMode();
+    await act(async () => {
+      resolveFirst(authState(null));
+      await first;
+    });
+    await act(async () => {
+      rejectSecond(new Error('second exit failed'));
+      await expect(second).rejects.toThrow('second exit failed');
+    });
+
+    expect(view.result.current.dataOwnerId).toBeNull();
+    expect(getDataOwnerGeneration().dataOwnerId).toBeNull();
+    expect(mocks.preloadLocalCatalogSnapshot).toHaveBeenCalledOnce();
   });
 
   it('updates Canary state without treating it as an account switch', async () => {

--- a/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
     reset: vi.fn(),
     getMe: vi.fn(async () => ({ role: 'user' })),
     clearWorkersCache: vi.fn(),
+    invalidateProvidersSnapshot: vi.fn(),
     confirm: vi.fn(async () => true),
     emitAuth(state: unknown) {
       authStateListener?.(state);
@@ -52,6 +53,9 @@ vi.mock('@/lib/meService', () => ({ getMe: mocks.getMe }));
 vi.mock('@/features/cc-agent/hooks/useWorkers', () => ({
   clearWorkersCache: mocks.clearWorkersCache,
 }));
+vi.mock('@/lib/providersSnapshotStore', () => ({
+  invalidateProvidersSnapshot: mocks.invalidateProvidersSnapshot,
+}));
 vi.mock('@/components/ui/confirm-dialog-provider', () => ({
   useConfirmDialog: () => ({ confirm: mocks.confirm }),
 }));
@@ -66,6 +70,7 @@ vi.mock('@/lib/toast', () => ({
 }));
 
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { __testing as dataOwnerGenerationTesting } from '@/contexts/dataOwnerGeneration';
 
 function user(id: string) {
   return {
@@ -121,6 +126,8 @@ describe('AuthContext session cache boundaries', () => {
     mocks.reset.mockClear();
     mocks.getMe.mockClear();
     mocks.clearWorkersCache.mockClear();
+    mocks.invalidateProvidersSnapshot.mockClear();
+    dataOwnerGenerationTesting.reset();
     mocks.service.consumeAccountDeletionRestoredNotice.mockClear();
     restoredToast.mockClear();
     mocks.confirm.mockClear();
@@ -140,15 +147,19 @@ describe('AuthContext session cache boundaries', () => {
     const view = renderHook(() => useAuth(), { wrapper });
     await waitFor(() => expect(view.result.current.user?.id).toBe('account-a'));
     expect(mocks.reset).toHaveBeenCalledTimes(1);
+    expect(mocks.invalidateProvidersSnapshot).toHaveBeenCalledTimes(1);
 
     act(() => mocks.emitAuth(authState('account-b')));
     expect(mocks.reset).toHaveBeenCalledTimes(2);
+    expect(mocks.invalidateProvidersSnapshot).toHaveBeenCalledTimes(2);
 
     act(() => mocks.emitAuth(authState('account-b')));
     expect(mocks.reset).toHaveBeenCalledTimes(2);
+    expect(mocks.invalidateProvidersSnapshot).toHaveBeenCalledTimes(2);
 
     act(() => mocks.emitAuth(authState(null)));
     expect(mocks.reset).toHaveBeenCalledTimes(3);
+    expect(mocks.invalidateProvidersSnapshot).toHaveBeenCalledTimes(3);
 
     await act(async () => {
       await view.result.current.logout();

--- a/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/authContextSessionBoundary.test.tsx
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => {
     initialize: vi.fn(),
     getLoginState: vi.fn(),
     dispatchLoginAction: vi.fn(),
-    logout: vi.fn(async () => undefined),
+    logout: vi.fn<() => Promise<void>>(async () => undefined),
     enterLocalMode: vi.fn(),
     exitLocalMode: vi.fn(),
     consumeAccountDeletionRestoredNotice: vi.fn(async () => true),

--- a/apps/desktop/src/renderer/__tests__/localCatalogSnapshot.test.ts
+++ b/apps/desktop/src/renderer/__tests__/localCatalogSnapshot.test.ts
@@ -68,6 +68,7 @@ describe('refreshLocalCatalogSnapshot', () => {
   it('does not commit capabilities when the provider snapshot owner is stale', async () => {
     const providers = {
       dataOwnerId: 'owner-b',
+      ownerGeneration: 2,
       providers: [{ id: 'owner-b-provider' }],
       providerOrder: ['owner-b-provider'],
     };

--- a/apps/desktop/src/renderer/__tests__/localCatalogSnapshot.test.ts
+++ b/apps/desktop/src/renderer/__tests__/localCatalogSnapshot.test.ts
@@ -65,6 +65,21 @@ describe('refreshLocalCatalogSnapshot', () => {
     expect(mocks.warn).toHaveBeenCalledOnce();
   });
 
+  it('does not commit capabilities when the provider snapshot owner is stale', async () => {
+    const providers = {
+      dataOwnerId: 'owner-b',
+      providers: [{ id: 'owner-b-provider' }],
+      providerOrder: ['owner-b-provider'],
+    };
+    mocks.loadProviders.mockResolvedValueOnce(providers);
+    mocks.loadCapabilities.mockResolvedValueOnce([]);
+    mocks.providersCurrent.mockImplementation((_token, snapshot) => snapshot !== providers);
+
+    await expect(refreshLocalCatalogSnapshot()).resolves.toBe(false);
+    expect(mocks.commitProviders).not.toHaveBeenCalled();
+    expect(mocks.commitCapabilities).not.toHaveBeenCalled();
+  });
+
   it('drops an older refresh that finishes after a newer generation', async () => {
     const oldProviders = deferred<unknown[]>();
     const oldCapabilities = deferred<unknown[]>();

--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -146,7 +146,7 @@ const providersRef = vi.hoisted(() => {
   return { DEFAULT_PROVIDERS, providers: DEFAULT_PROVIDERS };
 });
 vi.mock('@/hooks/useProviders', () => ({
-  useProviders: () => ({ providers: providersRef.providers }),
+  useProviders: () => ({ providers: providersRef.providers, providerOrder: [] }),
 }));
 
 vi.mock('@/hooks/useDeviceProviders', () => ({

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -266,10 +266,13 @@ const providersRef = vi.hoisted(() => {
       },
     },
   ] as unknown[];
-  return { DEFAULT_PROVIDERS, providers: DEFAULT_PROVIDERS };
+  return { DEFAULT_PROVIDERS, providers: DEFAULT_PROVIDERS, providerOrder: [] as string[] };
 });
 vi.mock('@/hooks/useProviders', () => ({
-  useProviders: () => ({ providers: providersRef.providers }),
+  useProviders: () => ({
+    providers: providersRef.providers,
+    providerOrder: providersRef.providerOrder,
+  }),
 }));
 
 const deviceProvidersRef = vi.hoisted(() => ({ providers: [] as unknown[] }));
@@ -377,6 +380,7 @@ const requestProviderModelsAutoRefresh = vi.fn(async () => ({ ok: true as const 
 
 beforeEach(() => {
   requestProviderModelsAutoRefresh.mockClear();
+  providersRef.providerOrder = [];
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     maker: { requestProviderModelsAutoRefresh },
   };
@@ -390,6 +394,53 @@ describe('ModelSelector trigger variants', () => {
       fireEvent.click(screen.getByRole('button', { name: /Current: Opus 4\.8/ }));
     });
   };
+
+  it('orders local provider sections by the Settings display preference', () => {
+    providersRef.providers = [
+      ...providersRef.DEFAULT_PROVIDERS,
+      {
+        id: 'zeta',
+        name: 'Zeta',
+        source: 'user',
+        connected: true,
+        agents: ['claude-code'],
+        routing: { 'claude-code': {} },
+        models: {
+          'claude-code': [
+            {
+              id: 'claude-zeta',
+              name: 'Zeta Model',
+              contextWindow: 100000,
+              efforts: ['high'],
+              defaultEffort: 'high',
+            },
+          ],
+        },
+      },
+    ];
+    providersRef.providerOrder = ['zeta', 'anthropic'];
+
+    try {
+      render(
+        React.createElement(ModelSelectorContent, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          currentProviderId: 'anthropic',
+          onProviderChange: vi.fn(),
+        }),
+      );
+
+      const modelRows = screen.getAllByRole('option');
+      expect(modelRows[0]?.textContent).toContain('Zeta Model');
+      expect(modelRows[1]?.textContent).toContain('Opus 4.8');
+    } finally {
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+      providersRef.providerOrder = [];
+    }
+  });
 
   it('requests a silent refresh when a local selector opens, but not for a remote device', async () => {
     const local = render(

--- a/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
@@ -144,6 +144,7 @@ beforeEach(() => {
     maker: {
       scanLocalCli: vi.fn(async () => ({ detections: [] })),
       requestProviderModelsAutoRefresh: vi.fn(async () => ({ ok: true })),
+      setProviderOrder: vi.fn(async () => ({ ok: true })),
     },
   };
 });
@@ -249,6 +250,7 @@ describe('ProvidersSection — 深链定位', () => {
         providerOAuthLogin,
         providerOAuthCancel,
         onProviderOAuthProgress,
+        setProviderOrder: vi.fn(async () => ({ ok: true })),
       },
     };
 

--- a/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
@@ -17,7 +17,7 @@ import type { ProviderView } from '@cindy/model-providers';
 
 const { wizardSpy, providersState } = vi.hoisted(() => ({
   wizardSpy: vi.fn(),
-  providersState: { providers: [] as unknown[] },
+  providersState: { providers: [] as unknown[], order: [] as string[] },
 }));
 
 vi.mock('react-i18next', () => ({
@@ -25,7 +25,12 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/hooks/useProviders', () => ({
-  useProviders: () => ({ providers: providersState.providers, loading: false, refetch: vi.fn() }),
+  useProviders: () => ({
+    providers: providersState.providers,
+    providerOrder: providersState.order,
+    loading: false,
+    refetch: vi.fn(),
+  }),
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({

--- a/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/hooks/useProviders', () => ({
   useProviders: () => ({
     providers: providersState.providers,
     providerOrder: providersState.order,
+    ownerGeneration: 1,
     loading: false,
     refetch: vi.fn(),
   }),

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -30,6 +30,7 @@ const {
   authState: { dataOwnerId: 'owner-1' as string | null },
   providerSnapshotState: {
     dataOwnerId: 'owner-1' as string | null,
+    ownerGeneration: 1,
     order: ['anthropic', 'xd', 'custom'],
   },
   wizardSpy: vi.fn(),
@@ -103,6 +104,10 @@ vi.mock('@/hooks/useProviders', () => ({
         providerSnapshotState.dataOwnerId === authState.dataOwnerId
           ? providerSnapshotState.order
           : [],
+      ownerGeneration:
+        providerSnapshotState.dataOwnerId === authState.dataOwnerId
+          ? providerSnapshotState.ownerGeneration
+          : null,
       loading: providerSnapshotState.dataOwnerId !== authState.dataOwnerId,
       refetch: refetchProvidersSpy,
     };
@@ -184,6 +189,7 @@ let scanResult: ScanResult;
 beforeEach(() => {
   authState.dataOwnerId = 'owner-1';
   providerSnapshotState.dataOwnerId = 'owner-1';
+  providerSnapshotState.ownerGeneration = 1;
   providerSnapshotState.order = ['anthropic', 'xd', 'custom'];
   scanResult = { detections: [] };
   (window as unknown as { electronAPI: unknown }).electronAPI = {
@@ -281,13 +287,13 @@ describe('ProvidersSection — 双栏管理', () => {
     const handles = await screen.findAllByRole('button', {
       name: 'settings.providers.order.handle',
     });
-    expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['custom']);
+    expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', 1, ['custom']);
     await act(async () => {
       fireEvent.keyDown(handles[0]!, { key: 'ArrowDown' });
       await Promise.resolve();
     });
     // Renderer 只提交左栏顺序；Main 负责保留曾出现但当前隐藏的供应商槽位。
-    expect(setProviderOrderSpy).toHaveBeenLastCalledWith('owner-1', ['custom', 'xd']);
+    expect(setProviderOrderSpy).toHaveBeenLastCalledWith('owner-1', 1, ['custom', 'xd']);
     const selectedRows = screen
       .getAllByRole('button')
       .filter((button) => button.getAttribute('aria-current') === 'true');
@@ -370,7 +376,7 @@ describe('ProvidersSection — 双栏管理', () => {
       React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)),
     );
     await waitFor(() => {
-      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['custom']);
+      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', 1, ['custom']);
     });
     setProviderOrderSpy.mockClear();
 
@@ -383,12 +389,13 @@ describe('ProvidersSection — 双栏管理', () => {
 
     await act(async () => {
       providerSnapshotState.dataOwnerId = 'owner-2';
+      providerSnapshotState.ownerGeneration = 2;
       providerSnapshotState.order = ['xd'];
       view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
       await Promise.resolve();
     });
     await waitFor(() => {
-      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-2', ['custom']);
+      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-2', 2, ['custom']);
     });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -271,6 +271,7 @@ describe('ProvidersSection — 双栏管理', () => {
   });
 
   it('首次记录可见项，并用方向键提交新的可见顺序', async () => {
+    providerSnapshotState.order = ['anthropic', 'xd'];
     const view = render(
       React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)),
     );
@@ -278,7 +279,7 @@ describe('ProvidersSection — 双栏管理', () => {
     const handles = await screen.findAllByRole('button', {
       name: 'settings.providers.order.handle',
     });
-    expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['xd', 'custom']);
+    expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['custom']);
     await act(async () => {
       fireEvent.keyDown(handles[0]!, { key: 'ArrowDown' });
       await Promise.resolve();
@@ -311,12 +312,23 @@ describe('ProvidersSection — 双栏管理', () => {
     expect(providerRows[1]?.textContent).toContain('Custom');
   });
 
+  it('已有顺序快照挂载时不自动回写，避免旧窗口覆盖显式排序', async () => {
+    providerSnapshotState.order = ['anthropic', 'custom', 'xd'];
+    render(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+
+    await screen.findAllByRole('button', {
+      name: 'settings.providers.order.handle',
+    });
+    expect(setProviderOrderSpy).not.toHaveBeenCalled();
+  });
+
   it('切换数据 owner 后会按新 owner 重新记录可见项', async () => {
+    providerSnapshotState.order = ['anthropic', 'xd'];
     const view = render(
       React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)),
     );
     await waitFor(() => {
-      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['xd', 'custom']);
+      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['custom']);
     });
     setProviderOrderSpy.mockClear();
 
@@ -329,11 +341,12 @@ describe('ProvidersSection — 双栏管理', () => {
 
     await act(async () => {
       providerSnapshotState.dataOwnerId = 'owner-2';
+      providerSnapshotState.order = ['xd'];
       view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
       await Promise.resolve();
     });
     await waitFor(() => {
-      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-2', ['xd', 'custom']);
+      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-2', ['custom']);
     });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -95,10 +95,11 @@ vi.mock('@/hooks/useProviders', () => ({
     return {
       providers:
         providerSnapshotState.dataOwnerId === authState.dataOwnerId
-          ? providerSnapshotState.order.flatMap((id) => {
-              const provider = byId.get(id);
-              return provider ? [provider] : [];
-            })
+          ? [...byId.values()]
+          : [],
+      providerOrder:
+        providerSnapshotState.dataOwnerId === authState.dataOwnerId
+          ? providerSnapshotState.order
           : [],
       loading: providerSnapshotState.dataOwnerId !== authState.dataOwnerId,
       refetch: vi.fn(),

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -2,7 +2,7 @@
 
 /**
  * ProvidersSection(双栏重构)关键不变量:
- *   1. Cindy AI(xd)固定置顶且默认选中;实时模型清单为空时仍保留手动刷新入口。
+ *   1. 首个可见供应商默认选中;Cindy AI 实时模型清单为空时仍保留手动刷新入口。
  *   2. 未连接的内置渠道不再常驻占行(入口在向导目录 + 检测建议)。
  *   3. 本机 CLI 检测命中且渠道未连接时,左栏出现建议行,点击直达向导授权步。
  */
@@ -14,9 +14,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ProviderView } from '@cindy/model-providers';
 
-const { refreshBuiltinModelsSpy, requestAutoRefreshSpy, wizardSpy } = vi.hoisted(() => ({
+const {
+  refreshBuiltinModelsSpy,
+  requestAutoRefreshSpy,
+  setProviderOrderSpy,
+  wizardSpy,
+} = vi.hoisted(() => ({
   refreshBuiltinModelsSpy: vi.fn(async () => ({ ok: true, providerId: 'xd' as const })),
   requestAutoRefreshSpy: vi.fn(async () => ({ ok: true as const })),
+  setProviderOrderSpy: vi.fn(async () => ({ ok: true as const })),
   wizardSpy: vi.fn(),
 }));
 
@@ -56,6 +62,26 @@ vi.mock('@/hooks/useProviders', () => ({
         routing: {},
         models: { 'claude-code': [], codex: [] },
         connected: false,
+      } satisfies ProviderView,
+      {
+        id: 'custom',
+        name: 'Custom',
+        source: 'user',
+        agents: ['codex'],
+        auth: { method: 'apiKey' },
+        routing: {},
+        models: {
+          codex: [
+            {
+              id: 'custom-model',
+              name: 'Custom model',
+              contextWindow: 128_000,
+              efforts: [],
+              defaultEffort: null,
+            },
+          ],
+        },
+        connected: true,
       } satisfies ProviderView,
     ],
     loading: false,
@@ -138,6 +164,7 @@ beforeEach(() => {
       scanLocalCli: vi.fn(async () => scanResult),
       refreshBuiltinProviderModels: refreshBuiltinModelsSpy,
       requestProviderModelsAutoRefresh: requestAutoRefreshSpy,
+      setProviderOrder: setProviderOrderSpy,
     },
   };
 });
@@ -148,7 +175,7 @@ afterEach(() => {
 });
 
 describe('ProvidersSection — 双栏管理', () => {
-  it('Cindy AI 置顶默认选中;未连接内置渠道不占行;零模型仍可手动刷新', async () => {
+  it('首个可见供应商默认选中;未连接内置渠道不占行;零模型仍可手动刷新', async () => {
     // ProvidersSection 内部消费 useSearchParams(深链定位),测试需要 Router 上下文。
     render(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
     expect(requestAutoRefreshSpy).toHaveBeenCalledWith('providers-open');
@@ -216,5 +243,21 @@ describe('ProvidersSection — 双栏管理', () => {
     // 向导以 entry 直达 anthropic。
     expect(screen.getByTestId('wizard-stub')).not.toBeNull();
     expect(wizardSpy).toHaveBeenCalledWith({ kind: 'builtin', providerId: 'anthropic' });
+  });
+
+  it('首次记录可见项，并用方向键提交新的可见顺序', async () => {
+    render(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+
+    const handles = await screen.findAllByRole('button', {
+      name: 'settings.providers.order.handle',
+    });
+    expect(setProviderOrderSpy).toHaveBeenCalledWith(['xd', 'custom']);
+    await act(async () => {
+      fireEvent.keyDown(handles[0]!, { key: 'ArrowDown' });
+      await Promise.resolve();
+    });
+    // Renderer 只提交左栏顺序；Main 负责保留曾出现但当前隐藏的供应商槽位。
+    expect(setProviderOrderSpy).toHaveBeenLastCalledWith(['custom', 'xd']);
+    expect(screen.queryByRole('button', { name: 'settings.providers.order.reset' })).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -18,6 +18,7 @@ const {
   refreshBuiltinModelsSpy,
   requestAutoRefreshSpy,
   setProviderOrderSpy,
+  refetchProvidersSpy,
   authState,
   providerSnapshotState,
   wizardSpy,
@@ -25,6 +26,7 @@ const {
   refreshBuiltinModelsSpy: vi.fn(async () => ({ ok: true, providerId: 'xd' as const })),
   requestAutoRefreshSpy: vi.fn(async () => ({ ok: true as const })),
   setProviderOrderSpy: vi.fn(async () => ({ ok: true as const })),
+  refetchProvidersSpy: vi.fn(),
   authState: { dataOwnerId: 'owner-1' as string | null },
   providerSnapshotState: {
     dataOwnerId: 'owner-1' as string | null,
@@ -102,7 +104,7 @@ vi.mock('@/hooks/useProviders', () => ({
           ? providerSnapshotState.order
           : [],
       loading: providerSnapshotState.dataOwnerId !== authState.dataOwnerId,
-      refetch: vi.fn(),
+      refetch: refetchProvidersSpy,
     };
   },
 }));
@@ -320,6 +322,46 @@ describe('ProvidersSection — 双栏管理', () => {
       name: 'settings.providers.order.handle',
     });
     expect(setProviderOrderSpy).not.toHaveBeenCalled();
+  });
+
+  it('写入结束后的同目录权威快照会结束乐观排序，以另一窗口的后写结果为准', async () => {
+    let resolveOrderWrite!: (value: { ok: true }) => void;
+    const orderWrite = new Promise<{ ok: true }>((resolve) => {
+      resolveOrderWrite = resolve;
+    });
+    setProviderOrderSpy.mockReturnValueOnce(orderWrite);
+    const view = render(
+      React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)),
+    );
+
+    const handles = await screen.findAllByRole('button', {
+      name: 'settings.providers.order.handle',
+    });
+    fireEvent.keyDown(handles[0]!, { key: 'ArrowDown' });
+    let providerRows = screen
+      .getAllByRole('button')
+      .filter((button) => button.hasAttribute('aria-current'));
+    expect(providerRows[0]?.textContent).toContain('Custom');
+    expect(providerRows[1]?.textContent).toContain('settings.providers.xd.title');
+
+    await act(async () => {
+      resolveOrderWrite({ ok: true });
+      await orderWrite;
+      await Promise.resolve();
+    });
+    expect(refetchProvidersSpy).toHaveBeenCalledOnce();
+
+    // B 窗口后写成为 Main 最终顺序；目录成员没变，但新快照必须结束 A 的 pending。
+    await act(async () => {
+      providerSnapshotState.order = ['anthropic', 'xd', 'custom'];
+      view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+      await Promise.resolve();
+    });
+    providerRows = screen
+      .getAllByRole('button')
+      .filter((button) => button.hasAttribute('aria-current'));
+    expect(providerRows[0]?.textContent).toContain('settings.providers.xd.title');
+    expect(providerRows[1]?.textContent).toContain('Custom');
   });
 
   it('切换数据 owner 后会按新 owner 重新记录可见项', async () => {

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -278,13 +278,13 @@ describe('ProvidersSection — 双栏管理', () => {
     const handles = await screen.findAllByRole('button', {
       name: 'settings.providers.order.handle',
     });
-    expect(setProviderOrderSpy).toHaveBeenCalledWith(['xd', 'custom']);
+    expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['xd', 'custom']);
     await act(async () => {
       fireEvent.keyDown(handles[0]!, { key: 'ArrowDown' });
       await Promise.resolve();
     });
     // Renderer 只提交左栏顺序；Main 负责保留曾出现但当前隐藏的供应商槽位。
-    expect(setProviderOrderSpy).toHaveBeenLastCalledWith(['custom', 'xd']);
+    expect(setProviderOrderSpy).toHaveBeenLastCalledWith('owner-1', ['custom', 'xd']);
     const selectedRows = screen
       .getAllByRole('button')
       .filter((button) => button.getAttribute('aria-current') === 'true');
@@ -316,7 +316,7 @@ describe('ProvidersSection — 双栏管理', () => {
       React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)),
     );
     await waitFor(() => {
-      expect(setProviderOrderSpy).toHaveBeenCalledWith(['xd', 'custom']);
+      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-1', ['xd', 'custom']);
     });
     setProviderOrderSpy.mockClear();
 
@@ -333,7 +333,7 @@ describe('ProvidersSection — 双栏管理', () => {
       await Promise.resolve();
     });
     await waitFor(() => {
-      expect(setProviderOrderSpy).toHaveBeenCalledWith(['xd', 'custom']);
+      expect(setProviderOrderSpy).toHaveBeenCalledWith('owner-2', ['xd', 'custom']);
     });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -7,7 +7,7 @@
  *   3. 本机 CLI 检测命中且渠道未连接时,左栏出现建议行,点击直达向导授权步。
  */
 
-import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -18,11 +18,13 @@ const {
   refreshBuiltinModelsSpy,
   requestAutoRefreshSpy,
   setProviderOrderSpy,
+  authState,
   wizardSpy,
 } = vi.hoisted(() => ({
   refreshBuiltinModelsSpy: vi.fn(async () => ({ ok: true, providerId: 'xd' as const })),
   requestAutoRefreshSpy: vi.fn(async () => ({ ok: true as const })),
   setProviderOrderSpy: vi.fn(async () => ({ ok: true as const })),
+  authState: { dataOwnerId: 'owner-1' as string | null },
   wizardSpy: vi.fn(),
 }));
 
@@ -90,7 +92,11 @@ vi.mock('@/hooks/useProviders', () => ({
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({
-  useAuth: () => ({ mode: 'cloud', exitLocalMode: vi.fn(async () => undefined) }),
+  useAuth: () => ({
+    mode: 'cloud',
+    dataOwnerId: authState.dataOwnerId,
+    exitLocalMode: vi.fn(async () => undefined),
+  }),
 }));
 
 vi.mock('@/hooks/useCodexAuth', () => ({
@@ -158,6 +164,7 @@ type ScanResult = { detections: unknown[] };
 let scanResult: ScanResult;
 
 beforeEach(() => {
+  authState.dataOwnerId = 'owner-1';
   scanResult = { detections: [] };
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     maker: {
@@ -258,6 +265,30 @@ describe('ProvidersSection — 双栏管理', () => {
     });
     // Renderer 只提交左栏顺序；Main 负责保留曾出现但当前隐藏的供应商槽位。
     expect(setProviderOrderSpy).toHaveBeenLastCalledWith(['custom', 'xd']);
+    const selectedRows = screen
+      .getAllByRole('button')
+      .filter((button) => button.getAttribute('aria-current') === 'true');
+    expect(selectedRows).toHaveLength(1);
+    expect(selectedRows[0]?.textContent).toContain('settings.providers.xd.title');
     expect(screen.queryByRole('button', { name: 'settings.providers.order.reset' })).toBeNull();
+  });
+
+  it('切换数据 owner 后会按新 owner 重新记录可见项', async () => {
+    const view = render(
+      React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)),
+    );
+    await waitFor(() => {
+      expect(setProviderOrderSpy).toHaveBeenCalledWith(['xd', 'custom']);
+    });
+    setProviderOrderSpy.mockClear();
+
+    await act(async () => {
+      authState.dataOwnerId = 'owner-2';
+      view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+    });
+
+    await waitFor(() => {
+      expect(setProviderOrderSpy).toHaveBeenCalledWith(['xd', 'custom']);
+    });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -19,12 +19,17 @@ const {
   requestAutoRefreshSpy,
   setProviderOrderSpy,
   authState,
+  providerSnapshotState,
   wizardSpy,
 } = vi.hoisted(() => ({
   refreshBuiltinModelsSpy: vi.fn(async () => ({ ok: true, providerId: 'xd' as const })),
   requestAutoRefreshSpy: vi.fn(async () => ({ ok: true as const })),
   setProviderOrderSpy: vi.fn(async () => ({ ok: true as const })),
   authState: { dataOwnerId: 'owner-1' as string | null },
+  providerSnapshotState: {
+    dataOwnerId: 'owner-1' as string | null,
+    order: ['anthropic', 'xd', 'custom'],
+  },
   wizardSpy: vi.fn(),
 }));
 
@@ -33,8 +38,8 @@ vi.mock('react-i18next', () => ({
 }));
 
 vi.mock('@/hooks/useProviders', () => ({
-  useProviders: () => ({
-    providers: [
+  useProviders: () => {
+    const providers = [
       {
         id: 'anthropic',
         name: 'Anthropic',
@@ -85,10 +90,20 @@ vi.mock('@/hooks/useProviders', () => ({
         },
         connected: true,
       } satisfies ProviderView,
-    ],
-    loading: false,
-    refetch: vi.fn(),
-  }),
+    ];
+    const byId = new Map(providers.map((provider) => [provider.id, provider]));
+    return {
+      providers:
+        providerSnapshotState.dataOwnerId === authState.dataOwnerId
+          ? providerSnapshotState.order.flatMap((id) => {
+              const provider = byId.get(id);
+              return provider ? [provider] : [];
+            })
+          : [],
+      loading: providerSnapshotState.dataOwnerId !== authState.dataOwnerId,
+      refetch: vi.fn(),
+    };
+  },
 }));
 
 vi.mock('@/contexts/AuthContext', () => ({
@@ -165,6 +180,8 @@ let scanResult: ScanResult;
 
 beforeEach(() => {
   authState.dataOwnerId = 'owner-1';
+  providerSnapshotState.dataOwnerId = 'owner-1';
+  providerSnapshotState.order = ['anthropic', 'xd', 'custom'];
   scanResult = { detections: [] };
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     maker: {
@@ -253,7 +270,9 @@ describe('ProvidersSection — 双栏管理', () => {
   });
 
   it('首次记录可见项，并用方向键提交新的可见顺序', async () => {
-    render(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+    const view = render(
+      React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)),
+    );
 
     const handles = await screen.findAllByRole('button', {
       name: 'settings.providers.order.handle',
@@ -271,6 +290,24 @@ describe('ProvidersSection — 双栏管理', () => {
     expect(selectedRows).toHaveLength(1);
     expect(selectedRows[0]?.textContent).toContain('settings.providers.xd.title');
     expect(screen.queryByRole('button', { name: 'settings.providers.order.reset' })).toBeNull();
+
+    // Main 对未观察隐藏项的权威结果会把它放到末尾。pending 只比较左栏可见顺序，
+    // 收到该快照后应清除；后续 Main 顺序变化不得再被旧乐观状态覆盖。
+    await act(async () => {
+      providerSnapshotState.order = ['custom', 'xd', 'anthropic'];
+      view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+      await Promise.resolve();
+    });
+    await act(async () => {
+      providerSnapshotState.order = ['xd', 'custom', 'anthropic'];
+      view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+      await Promise.resolve();
+    });
+    const providerRows = screen
+      .getAllByRole('button')
+      .filter((button) => button.hasAttribute('aria-current'));
+    expect(providerRows[0]?.textContent).toContain('settings.providers.xd.title');
+    expect(providerRows[1]?.textContent).toContain('Custom');
   });
 
   it('切换数据 owner 后会按新 owner 重新记录可见项', async () => {
@@ -285,8 +322,15 @@ describe('ProvidersSection — 双栏管理', () => {
     await act(async () => {
       authState.dataOwnerId = 'owner-2';
       view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+      await Promise.resolve();
     });
+    expect(setProviderOrderSpy).not.toHaveBeenCalled();
 
+    await act(async () => {
+      providerSnapshotState.dataOwnerId = 'owner-2';
+      view.rerender(React.createElement(MemoryRouter, null, React.createElement(ProvidersSection)));
+      await Promise.resolve();
+    });
     await waitFor(() => {
       expect(setProviderOrderSpy).toHaveBeenCalledWith(['xd', 'custom']);
     });

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -64,6 +64,7 @@ import {
 } from '@cindy/model-providers';
 import { isProviderLogoKind } from '@cindy/model-providers/branding';
 import { getModelPriceQuote } from '../../../shared/modelPriceQuote';
+import { applyProviderOrder } from '../../../shared/providerOrder';
 import type { ModelPricingCatalog } from '../../../shared/regionalMoney';
 import { buildProviderSections } from './sourceSwitch';
 
@@ -904,6 +905,15 @@ function ModelSelectorContentView({
     if (!actual?.connected || !actual.agents.includes(currentAgentKind)) return connected;
     return [...connected, actual];
   }, [connected, providers, activeSourceId, currentAgentKind]);
+  // Provider order is a display preference. Apply it only to local picker sections so source
+  // resolution and first-wins catalog derivation keep their canonical catalog order.
+  const orderedSectionProviders = useMemo(
+    () =>
+      deviceId
+        ? sectionProviders
+        : applyProviderOrder(sectionProviders, localProviders.providerOrder),
+    [deviceId, localProviders.providerOrder, sectionProviders],
+  );
   const suspendedActiveSourceId =
     sectionProviders === connected ? null : activeSourceId;
   // biome-ignore lint/correctness/useExhaustiveDependencies: visibilityVersion 是外部可见性偏好的刷新信号,需要强制重算分段列表。
@@ -917,7 +927,7 @@ function ModelSelectorContentView({
     const restrictSuspended = (pid: string, mid: string): boolean =>
       !(suspendedActiveSourceId && pid === suspendedActiveSourceId && mid !== modelId);
     return buildProviderSections({
-      providers: sectionProviders,
+      providers: orderedSectionProviders,
       agent: currentAgentKind,
       selectedModelId: modelId,
       selectedProviderId: activeSourceId,
@@ -950,6 +960,7 @@ function ModelSelectorContentView({
   }, [
     sourcesEnabled,
     sectionProviders,
+    orderedSectionProviders,
     suspendedActiveSourceId,
     currentAgentKind,
     modelId,

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -2,7 +2,7 @@
  * ProvidersSection —— 设置 → 模型供应商页(2026-07 重构:双栏管理)。
  *
  * 布局:一张卡片内左右双栏 ——
- *   - 左栏:扁平供应商列表。Cindy AI(xd)固定置顶(产品自己的服务);其余行只在
+ *   - 左栏:可拖动排序的扁平供应商列表;供应商只在
  *     「已连接 / 已添加」后出现;底部「＋ 添加供应商」打开三步向导。未连接的内置
  *     渠道不再常驻占行 —— 入口在向导目录里,另有「检测建议」组:本机装了
  *     Claude Code / Codex CLI 时置一条建议行,点击直达该渠道的授权步。
@@ -20,13 +20,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Check, MoreHorizontal, Pencil, Plus, RefreshCw, Trash2 } from 'lucide-react';
+import {
+  Check,
+  GripVertical,
+  MoreHorizontal,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Trash2,
+} from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { useProviders } from '@/hooks/useProviders';
 import { isChatGptConnectionConnected, useCodexAuth } from '@/hooks/useCodexAuth';
 import { useApiKey } from '@/hooks/useApiKey';
 import { useModelAccessStatus } from '@/hooks/useModelAccessStatus';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { useSignInToCindy } from '@/hooks/useSignInToCindy';
 import { useProviderOAuthDeviceCode } from '@/hooks/useProviderOAuthDeviceCode';
@@ -60,9 +69,14 @@ import { AnthropicMark } from '@/components/icons/AnthropicMark';
 import { OpenAIMark } from '@/components/icons/OpenAIMark';
 import { XDIncMark } from '@/components/icons/XDIncMark';
 import { hasProviderLogo, ProviderLogoMark } from '@/components/icons/ProviderLogoMark';
+import { SortableList } from '@/components/sidebar/SortableList';
 
 import type { LocalCliDetection } from '../../../shared/localCliDetect';
 import { isBuiltinRefreshableProviderId } from '../../../shared/providerModelRefresh';
+import {
+  applyProviderOrder,
+  mergeVisibleProviderOrder,
+} from '../../../shared/providerOrder';
 import type { CustomProviderConfig, ProviderView } from '@cindy/model-providers';
 
 // ---------------------------------------------------------------------------
@@ -1303,10 +1317,18 @@ function ListRow({
   provider,
   selected,
   onSelect,
+  position,
+  total,
+  onMove,
+  sortable,
 }: {
   provider: ProviderView;
   selected: boolean;
   onSelect: () => void;
+  position: number;
+  total: number;
+  onMove: (delta: -1 | 1) => void;
+  sortable: boolean;
 }) {
   const { t } = useTranslation();
   const modelCount = useMemo(
@@ -1315,56 +1337,82 @@ function ListRow({
   );
   const title = provider.id === 'xd' ? t('settings.providers.xd.title') : provider.name;
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-current={selected}
+    <div
       className={cn(
-        'flex w-full items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors',
+        'relative flex w-full items-center rounded-lg text-left transition-colors',
         !selected && 'hover:bg-[var(--surface-hover)]',
       )}
       style={selected ? { backgroundColor: 'var(--surface-chip)' } : undefined}
     >
-      <div
-        className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
-        style={{
-          backgroundColor: 'var(--settings-integration-avatar-bg)',
-          border: '1px solid var(--settings-integration-avatar-border)',
-          color: 'var(--settings-integration-avatar-icon)',
-        }}
-      >
-        {providerIcon(provider, 14)}
-      </div>
-      <span
-        className="min-w-0 flex-1 truncate text-13 font-medium"
-        style={{
-          color: provider.suspended ? 'var(--text-tertiary)' : 'var(--settings-section-title)',
-        }}
-      >
-        {title}
-      </span>
-      {provider.suspended ? (
-        // 已停用比模型数更要紧:窄栏(224px)只放得下一个注记,停用时以状态取代计数。
-        <span className="shrink-0 select-none text-11" style={{ color: 'var(--text-tertiary)' }}>
-          {t('settings.providers.pill.suspended')}
-        </span>
-      ) : (
-        modelCount !== null && (
-          <span className="shrink-0 text-11 tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
-            {t('settings.providers.models.modelCount', { count: modelCount })}
-          </span>
-        )
+      {sortable && (
+        <button
+          type="button"
+          className="provider-order-handle absolute inset-y-0 left-0 z-[1] my-auto flex h-9 w-3 cursor-grab items-center justify-center rounded-md outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-[var(--focus-ring-soft)]"
+          aria-label={t('settings.providers.order.handle', {
+            provider: title,
+            position,
+            total,
+          })}
+          aria-keyshortcuts="ArrowUp ArrowDown"
+          onKeyDown={(event) => {
+            if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return;
+            event.preventDefault();
+            onMove(event.key === 'ArrowUp' ? -1 : 1);
+          }}
+          style={{ color: 'var(--text-tertiary)' }}
+        >
+          <GripVertical size={12} />
+        </button>
       )}
-      <span
-        className="h-1.5 w-1.5 shrink-0 rounded-full"
-        style={{
-          backgroundColor:
-            provider.connected && !provider.suspended
-              ? 'var(--remote-status-ready)'
-              : 'var(--border-default)',
-        }}
-      />
-    </button>
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-current={selected}
+        className="flex min-w-0 flex-1 items-center gap-2.5 py-2 pl-3 pr-2.5 text-left"
+      >
+        <div
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
+          style={{
+            backgroundColor: 'var(--settings-integration-avatar-bg)',
+            border: '1px solid var(--settings-integration-avatar-border)',
+            color: 'var(--settings-integration-avatar-icon)',
+          }}
+        >
+          {providerIcon(provider, 14)}
+        </div>
+        <span
+          className="min-w-0 flex-1 truncate text-13 font-medium"
+          style={{
+            color: provider.suspended
+              ? 'var(--text-tertiary)'
+              : 'var(--settings-section-title)',
+          }}
+        >
+          {title}
+        </span>
+        {provider.suspended ? (
+          // 已停用比模型数更要紧:窄栏(224px)只放得下一个注记,停用时以状态取代计数。
+          <span className="shrink-0 select-none text-11" style={{ color: 'var(--text-tertiary)' }}>
+            {t('settings.providers.pill.suspended')}
+          </span>
+        ) : (
+          modelCount !== null && (
+            <span className="shrink-0 text-11 tabular-nums" style={{ color: 'var(--text-tertiary)' }}>
+              {t('settings.providers.models.modelCount', { count: modelCount })}
+            </span>
+          )
+        )}
+        <span
+          className="h-1.5 w-1.5 shrink-0 rounded-full"
+          style={{
+            backgroundColor:
+              provider.connected && !provider.suspended
+                ? 'var(--remote-status-ready)'
+                : 'var(--border-default)',
+          }}
+        />
+      </button>
+    </div>
   );
 }
 
@@ -1425,6 +1473,7 @@ function SuggestionRow({
 
 export function ProvidersSection() {
   const { t } = useTranslation();
+  const reducedMotion = useReducedMotion();
   const signInToCindy = useSignInToCindy();
   const { confirm } = useConfirmDialog();
   const { providers, loading, refetch } = useProviders();
@@ -1434,6 +1483,10 @@ export function ProvidersSection() {
   const openaiReconnectRequired = codexAuth.state.kind === 'reconnect-required';
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [pendingProviderOrder, setPendingProviderOrder] = useState<string[] | null>(null);
+  const [orderAnnouncement, setOrderAnnouncement] = useState('');
+  const providerOrderMutationRef = useRef(0);
+  const observedProviderIdsRef = useRef(new Set<string>());
   // 向导:null = 关;{ entry } = 打开(entry 指定直达的供应商,来自检测建议)。
   const [wizard, setWizard] = useState<null | { entry?: WizardEntry }>(null);
   // 自定义供应商完整表单(编辑,或从向导「自定义端点」进入新建)。
@@ -1480,28 +1533,50 @@ export function ProvidersSection() {
     };
   }, []);
 
+  // SortableJS drop 后先由 React 乐观铺新顺序，等 PROVIDER_CHANGED 回来的 main 快照
+  // 与目标一致再清掉覆盖；这样 DOM 回滚与 IPC 往返之间不会闪回旧顺序。
+  const orderedProviders = useMemo(
+    () =>
+      pendingProviderOrder
+        ? applyProviderOrder(providers, pendingProviderOrder)
+        : providers,
+    [pendingProviderOrder, providers],
+  );
+  useEffect(() => {
+    if (!pendingProviderOrder) return;
+    const incomingIds = providers.map((provider) => provider.id);
+    const sameCatalog =
+      incomingIds.length === pendingProviderOrder.length &&
+      incomingIds.every((id) => pendingProviderOrder.includes(id));
+    if (!sameCatalog || incomingIds.every((id, index) => id === pendingProviderOrder[index])) {
+      setPendingProviderOrder(null);
+    }
+  }, [pendingProviderOrder, providers]);
+
   const byId = useMemo(() => {
     const map = new Map<string, ProviderView>();
-    providers.forEach((p) => map.set(p.id, p));
+    orderedProviders.forEach((p) => map.set(p.id, p));
     return map;
-  }, [providers]);
+  }, [orderedProviders]);
 
-  // 左栏行集合:xd 置顶;内置/通用 OAuth 渠道只在已连接后占行(未连接的入口在向导
-  // 目录 + 检测建议);自定义供应商保持既有过滤(有模型或 OAuth 形态)。
-  // 停用的供应商**沉底**(稳定分区,组内保持既有顺序)——「停用的东西往下沉、变灰、
-  // 离开活跃区」是本页的统一隐喻,与右栏模型列表的「已停用」分区同构。
+  // 左栏实际供应商严格沿用 main 的显示顺序;未连接的内置渠道仍只在向导 / 检测建议
+  // 出现。Cindy 登录引导与检测建议是伪行,不进入持久化顺序。
   const listProviders = useMemo(() => {
     const rows: ProviderView[] = [];
-    const xd = byId.get('xd');
-    if (xd) rows.push(xd);
-    for (const p of providers) {
-      if (p.id === 'xd') continue;
+    for (const p of orderedProviders) {
       if (p.source === 'builtin') {
         // reconnect-required 视同占行:凭证失效 ≠ 用户断开,重连入口必须保留。
         // OpenAI 图像 key 与 ChatGPT OAuth 两套凭证解耦:imageModels 已声明时,
         // 即使未做 OAuth 登录也需占行以便配置 / 管理图像 key。
         const openaiHasImageCap = p.id === 'openai' && (p.imageModels?.length ?? 0) > 0;
-        if (p.connected || (p.id === 'openai' && openaiReconnectRequired) || openaiHasImageCap) rows.push(p);
+        if (
+          p.id === 'xd' ||
+          p.connected ||
+          (p.id === 'openai' && openaiReconnectRequired) ||
+          openaiHasImageCap
+        ) {
+          rows.push(p);
+        }
         continue;
       }
       if (
@@ -1511,8 +1586,66 @@ export function ProvidersSection() {
         rows.push(p);
       }
     }
-    return [...rows.filter((p) => !p.suspended), ...rows.filter((p) => p.suspended)];
-  }, [providers, byId, openaiReconnectRequired]);
+    return rows;
+  }, [orderedProviders, openaiReconnectRequired]);
+
+  // Main 只持久化曾经真正进入过左栏的供应商。首次出现的新项按当前可见顺序追加；
+  // 已记录但暂时隐藏的项由 store 保留，因此断开重连不会丢失用户排位。
+  useEffect(() => {
+    const visibleIds = listProviders.map((provider) => provider.id);
+    const hasNewProvider = visibleIds.some((id) => !observedProviderIdsRef.current.has(id));
+    visibleIds.forEach((id) => observedProviderIdsRef.current.add(id));
+    if (!hasNewProvider || visibleIds.length === 0) return;
+    void window.electronAPI.maker
+      .setProviderOrder(visibleIds)
+      .catch(() => toast.error(t('settings.providers.order.saveFailed')));
+  }, [listProviders, t]);
+
+  const persistVisibleProviderOrder = useCallback(
+    (reorderedVisibleIds: string[]): void => {
+      const currentIds = orderedProviders.map((provider) => provider.id);
+      const nextIds = mergeVisibleProviderOrder(currentIds, reorderedVisibleIds);
+      if (nextIds.every((id, index) => id === currentIds[index])) return;
+      const generation = ++providerOrderMutationRef.current;
+      setPendingProviderOrder(nextIds);
+      void window.electronAPI.maker
+        .setProviderOrder(reorderedVisibleIds)
+        .then(() => {
+          if (providerOrderMutationRef.current === generation) refetch();
+        })
+        .catch(() => {
+          if (providerOrderMutationRef.current !== generation) return;
+          setPendingProviderOrder(null);
+          toast.error(t('settings.providers.order.saveFailed'));
+        });
+    },
+    [orderedProviders, refetch, t],
+  );
+
+  const moveProviderWithKeyboard = useCallback(
+    (providerId: string, delta: -1 | 1): void => {
+      const currentIds = listProviders.map((provider) => provider.id);
+      const index = currentIds.indexOf(providerId);
+      const nextIndex = index + delta;
+      if (index < 0 || nextIndex < 0 || nextIndex >= currentIds.length) return;
+      const nextIds = [...currentIds];
+      const [moved] = nextIds.splice(index, 1);
+      nextIds.splice(nextIndex, 0, moved!);
+      persistVisibleProviderOrder(nextIds);
+      const provider = byId.get(providerId);
+      setOrderAnnouncement(
+        t('settings.providers.order.moved', {
+          provider:
+            provider?.id === 'xd'
+              ? t('settings.providers.xd.title')
+              : provider?.name ?? providerId,
+          position: nextIndex + 1,
+          total: currentIds.length,
+        }),
+      );
+    },
+    [byId, listProviders, persistVisibleProviderOrder, t],
+  );
 
   // 检测建议:CLI 已安装 + 对应渠道存在于目录 + 未连接,且**未以任何形态占行**
   // (OpenAI reconnect-required 已在主列表时,不再重复出建议行)。
@@ -1759,14 +1892,37 @@ export function ProvidersSection() {
                   onSelect={() => setSelectedId(CINDY_SIGNIN_ID)}
                 />
               )}
-              {listProviders.map((p) => (
-                <ListRow
-                  key={p.id}
-                  provider={p}
-                  selected={!cindySigninActive && effectiveSelected?.id === p.id}
-                  onSelect={() => setSelectedId(p.id)}
-                />
-              ))}
+              {listProviders.length > 1 && (
+                <div className="select-none px-1.5 pb-1 pt-1">
+                  <span className="text-11" style={{ color: 'var(--text-tertiary)' }}>
+                    {t('settings.providers.order.hint')}
+                  </span>
+                </div>
+              )}
+              <SortableList
+                items={listProviders}
+                getId={(provider) => provider.id}
+                onReorder={persistVisibleProviderOrder}
+                renderItem={(provider, index) => (
+                  <ListRow
+                    provider={provider}
+                    selected={!cindySigninActive && effectiveSelected?.id === provider.id}
+                    onSelect={() => setSelectedId(provider.id)}
+                    position={index + 1}
+                    total={listProviders.length}
+                    onMove={(delta) => moveProviderWithKeyboard(provider.id, delta)}
+                    sortable={listProviders.length > 1}
+                  />
+                )}
+                disabled={listProviders.length < 2}
+                reducedMotion={reducedMotion}
+                filter="input, textarea, select, a, [data-no-drag]"
+                className="flex flex-col gap-0.5"
+                rowClassName="provider-settings-sortable-row"
+              />
+              <span className="sr-only" aria-live="polite" aria-atomic="true">
+                {orderAnnouncement}
+              </span>
               {suggestions.length > 0 && (
                 <>
                   <span

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -2,7 +2,7 @@
  * ProvidersSection —— 设置 → 模型供应商页(2026-07 重构:双栏管理)。
  *
  * 布局:一张卡片内左右双栏 ——
- *   - 左栏:可拖动排序的扁平供应商列表;供应商只在
+ *   - 左栏:可拖动排序的扁平供应商列表;除 Cindy AI 外,供应商只在
  *     「已连接 / 已添加」后出现;底部「＋ 添加供应商」打开三步向导。未连接的内置
  *     渠道不再常驻占行 —— 入口在向导目录里,另有「检测建议」组:本机装了
  *     Claude Code / Codex CLI 时置一条建议行,点击直达该渠道的授权步。
@@ -39,6 +39,7 @@ import { useReducedMotion } from '@/hooks/useReducedMotion';
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { useSignInToCindy } from '@/hooks/useSignInToCindy';
 import { useProviderOAuthDeviceCode } from '@/hooks/useProviderOAuthDeviceCode';
+import { useAuth } from '@/contexts/AuthContext';
 import { toast } from '@/lib/toast';
 import {
   appendDiscoveredCustomProviderModels,
@@ -1475,6 +1476,7 @@ export function ProvidersSection() {
   const { t } = useTranslation();
   const reducedMotion = useReducedMotion();
   const signInToCindy = useSignInToCindy();
+  const { dataOwnerId } = useAuth();
   const { confirm } = useConfirmDialog();
   const { providers, loading, refetch } = useProviders();
   // OpenAI 的 reconnect-required 是 useCodexAuth 独有状态(目录 connected 此时为 false):
@@ -1483,10 +1485,16 @@ export function ProvidersSection() {
   const openaiReconnectRequired = codexAuth.state.kind === 'reconnect-required';
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
-  const [pendingProviderOrder, setPendingProviderOrder] = useState<string[] | null>(null);
+  const [pendingProviderOrder, setPendingProviderOrder] = useState<{
+    dataOwnerId: string | null;
+    ids: string[];
+  } | null>(null);
   const [orderAnnouncement, setOrderAnnouncement] = useState('');
   const providerOrderMutationRef = useRef(0);
-  const observedProviderIdsRef = useRef(new Set<string>());
+  const observedProviderIdsRef = useRef<{
+    dataOwnerId: string | null;
+    ids: Set<string>;
+  }>({ dataOwnerId, ids: new Set<string>() });
   // 向导:null = 关;{ entry } = 打开(entry 指定直达的供应商,来自检测建议)。
   const [wizard, setWizard] = useState<null | { entry?: WizardEntry }>(null);
   // 自定义供应商完整表单(编辑,或从向导「自定义端点」进入新建)。
@@ -1535,23 +1543,32 @@ export function ProvidersSection() {
 
   // SortableJS drop 后先由 React 乐观铺新顺序，等 PROVIDER_CHANGED 回来的 main 快照
   // 与目标一致再清掉覆盖；这样 DOM 回滚与 IPC 往返之间不会闪回旧顺序。
+  const pendingProviderOrderIds =
+    pendingProviderOrder && pendingProviderOrder.dataOwnerId === dataOwnerId
+      ? pendingProviderOrder.ids
+      : null;
   const orderedProviders = useMemo(
     () =>
-      pendingProviderOrder
-        ? applyProviderOrder(providers, pendingProviderOrder)
+      pendingProviderOrderIds
+        ? applyProviderOrder(providers, pendingProviderOrderIds)
         : providers,
-    [pendingProviderOrder, providers],
+    [pendingProviderOrderIds, providers],
   );
   useEffect(() => {
-    if (!pendingProviderOrder) return;
+    if (pendingProviderOrder && pendingProviderOrder.dataOwnerId !== dataOwnerId) {
+      providerOrderMutationRef.current += 1;
+      setPendingProviderOrder(null);
+      return;
+    }
+    if (!pendingProviderOrderIds) return;
     const incomingIds = providers.map((provider) => provider.id);
     const sameCatalog =
-      incomingIds.length === pendingProviderOrder.length &&
-      incomingIds.every((id) => pendingProviderOrder.includes(id));
-    if (!sameCatalog || incomingIds.every((id, index) => id === pendingProviderOrder[index])) {
+      incomingIds.length === pendingProviderOrderIds.length &&
+      incomingIds.every((id) => pendingProviderOrderIds.includes(id));
+    if (!sameCatalog || incomingIds.every((id, index) => id === pendingProviderOrderIds[index])) {
       setPendingProviderOrder(null);
     }
-  }, [pendingProviderOrder, providers]);
+  }, [dataOwnerId, pendingProviderOrder, pendingProviderOrderIds, providers]);
 
   const byId = useMemo(() => {
     const map = new Map<string, ProviderView>();
@@ -1592,22 +1609,33 @@ export function ProvidersSection() {
   // Main 只持久化曾经真正进入过左栏的供应商。首次出现的新项按当前可见顺序追加；
   // 已记录但暂时隐藏的项由 store 保留，因此断开重连不会丢失用户排位。
   useEffect(() => {
+    if (observedProviderIdsRef.current.dataOwnerId !== dataOwnerId) {
+      observedProviderIdsRef.current = { dataOwnerId, ids: new Set<string>() };
+    }
+    const observedProviderIds = observedProviderIdsRef.current.ids;
     const visibleIds = listProviders.map((provider) => provider.id);
-    const hasNewProvider = visibleIds.some((id) => !observedProviderIdsRef.current.has(id));
-    visibleIds.forEach((id) => observedProviderIdsRef.current.add(id));
+    const hasNewProvider = visibleIds.some((id) => !observedProviderIds.has(id));
+    visibleIds.forEach((id) => observedProviderIds.add(id));
     if (!hasNewProvider || visibleIds.length === 0) return;
     void window.electronAPI.maker
       .setProviderOrder(visibleIds)
       .catch(() => toast.error(t('settings.providers.order.saveFailed')));
-  }, [listProviders, t]);
+  }, [dataOwnerId, listProviders, t]);
 
   const persistVisibleProviderOrder = useCallback(
     (reorderedVisibleIds: string[]): void => {
       const currentIds = orderedProviders.map((provider) => provider.id);
       const nextIds = mergeVisibleProviderOrder(currentIds, reorderedVisibleIds);
       if (nextIds.every((id, index) => id === currentIds[index])) return;
+      if (
+        selectedId !== CINDY_SIGNIN_ID &&
+        !listProviders.some((provider) => provider.id === selectedId) &&
+        listProviders[0]
+      ) {
+        setSelectedId(listProviders[0].id);
+      }
       const generation = ++providerOrderMutationRef.current;
-      setPendingProviderOrder(nextIds);
+      setPendingProviderOrder({ dataOwnerId, ids: nextIds });
       void window.electronAPI.maker
         .setProviderOrder(reorderedVisibleIds)
         .then(() => {
@@ -1619,7 +1647,7 @@ export function ProvidersSection() {
           toast.error(t('settings.providers.order.saveFailed'));
         });
     },
-    [orderedProviders, refetch, t],
+    [dataOwnerId, listProviders, orderedProviders, refetch, selectedId, t],
   );
 
   const moveProviderWithKeyboard = useCallback(

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1623,7 +1623,7 @@ export function ProvidersSection() {
     visibleIds.forEach((id) => observedProviderIds.add(id));
     if (!hasNewProvider || visibleIds.length === 0) return;
     void window.electronAPI.maker
-      .setProviderOrder(visibleIds)
+      .setProviderOrder(dataOwnerId, visibleIds)
       .catch(() => toast.error(t('settings.providers.order.saveFailed')));
   }, [dataOwnerId, listProviders, t]);
 
@@ -1641,7 +1641,7 @@ export function ProvidersSection() {
       const generation = ++providerOrderMutationRef.current;
       setPendingProviderOrder({ dataOwnerId, ids: reorderedVisibleIds });
       void window.electronAPI.maker
-        .setProviderOrder(reorderedVisibleIds)
+        .setProviderOrder(dataOwnerId, reorderedVisibleIds)
         .then(() => {
           if (providerOrderMutationRef.current === generation) refetch();
         })

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1485,9 +1485,12 @@ export function ProvidersSection() {
   const [pendingProviderOrder, setPendingProviderOrder] = useState<{
     dataOwnerId: string | null;
     ids: string[];
+    providerOrderAtMutationEnd?: string[];
   } | null>(null);
   const [orderAnnouncement, setOrderAnnouncement] = useState('');
   const providerOrderMutationRef = useRef(0);
+  const latestProviderOrderRef = useRef(providerOrder);
+  latestProviderOrderRef.current = providerOrder;
   const observedProviderIdsRef = useRef<{
     dataOwnerId: string | null;
     ids: Set<string>;
@@ -1606,10 +1609,25 @@ export function ProvidersSection() {
     const sameCatalog =
       incomingIds.length === pendingProviderOrderIds.length &&
       incomingIds.every((id) => pendingProviderOrderIds.includes(id));
-    if (!sameCatalog || incomingIds.every((id, index) => id === pendingProviderOrderIds[index])) {
+    // 每次权威快照都会携带新的 providerOrder 数组引用。写结束后首个新快照无论顺序
+    // 是否仍等于本窗口目标，都要结束 pending：另一窗口可能已经成为最后写入者。
+    const hasSnapshotAfterMutation =
+      pendingProviderOrder?.providerOrderAtMutationEnd !== undefined
+      && providerOrder !== pendingProviderOrder.providerOrderAtMutationEnd;
+    if (
+      !sameCatalog
+      || incomingIds.every((id, index) => id === pendingProviderOrderIds[index])
+      || hasSnapshotAfterMutation
+    ) {
       setPendingProviderOrder(null);
     }
-  }, [dataOwnerId, orderedVisibleProviders, pendingProviderOrder, pendingProviderOrderIds]);
+  }, [
+    dataOwnerId,
+    orderedVisibleProviders,
+    pendingProviderOrder,
+    pendingProviderOrderIds,
+    providerOrder,
+  ]);
 
   // Main 只持久化曾经真正进入过左栏的供应商。自动观察只逐个提交权威快照里缺失的
   // 新项：singleton 写入只会追加，另一窗口刚保存的显式排序不会被旧快照重排。
@@ -1648,7 +1666,16 @@ export function ProvidersSection() {
       void window.electronAPI.maker
         .setProviderOrder(dataOwnerId, reorderedVisibleIds)
         .then(() => {
-          if (providerOrderMutationRef.current === generation) refetch();
+          if (providerOrderMutationRef.current !== generation) return;
+          setPendingProviderOrder((current) =>
+            current?.dataOwnerId === dataOwnerId
+              ? {
+                  ...current,
+                  providerOrderAtMutationEnd: latestProviderOrderRef.current,
+                }
+              : current,
+          );
+          refetch();
         })
         .catch(() => {
           if (providerOrderMutationRef.current !== generation) return;

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1611,7 +1611,8 @@ export function ProvidersSection() {
     }
   }, [dataOwnerId, orderedVisibleProviders, pendingProviderOrder, pendingProviderOrderIds]);
 
-  // Main 只持久化曾经真正进入过左栏的供应商。首次出现的新项按当前可见顺序追加；
+  // Main 只持久化曾经真正进入过左栏的供应商。自动观察只逐个提交权威快照里缺失的
+  // 新项：singleton 写入只会追加，另一窗口刚保存的显式排序不会被旧快照重排。
   // 已记录但暂时隐藏的项由 store 保留，因此断开重连不会丢失用户排位。
   useEffect(() => {
     if (observedProviderIdsRef.current.dataOwnerId !== dataOwnerId) {
@@ -1619,13 +1620,17 @@ export function ProvidersSection() {
     }
     const observedProviderIds = observedProviderIdsRef.current.ids;
     const visibleIds = listProviders.map((provider) => provider.id);
-    const hasNewProvider = visibleIds.some((id) => !observedProviderIds.has(id));
+    const persistedIds = new Set(providerOrder);
+    const unrecordedIds = visibleIds.filter(
+      (id) => !observedProviderIds.has(id) && !persistedIds.has(id),
+    );
     visibleIds.forEach((id) => observedProviderIds.add(id));
-    if (!hasNewProvider || visibleIds.length === 0) return;
-    void window.electronAPI.maker
-      .setProviderOrder(dataOwnerId, visibleIds)
+    if (unrecordedIds.length === 0) return;
+    void Promise.all(
+      unrecordedIds.map((id) => window.electronAPI.maker.setProviderOrder(dataOwnerId, [id])),
+    )
       .catch(() => toast.error(t('settings.providers.order.saveFailed')));
-  }, [dataOwnerId, listProviders, t]);
+  }, [dataOwnerId, listProviders, providerOrder, t]);
 
   const persistVisibleProviderOrder = useCallback(
     (reorderedVisibleIds: string[]): void => {

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1475,7 +1475,7 @@ export function ProvidersSection() {
   const signInToCindy = useSignInToCindy();
   const { dataOwnerId } = useAuth();
   const { confirm } = useConfirmDialog();
-  const { providers, providerOrder, loading, refetch } = useProviders();
+  const { providers, providerOrder, ownerGeneration, loading, refetch } = useProviders();
   // OpenAI 的 reconnect-required 是 useCodexAuth 独有状态(目录 connected 此时为 false):
   // 该状态下 OpenAI 行必须留在左栏,否则「重新连接」入口不可达,用户被迫从向导重发现。
   const codexAuth = useCodexAuth();
@@ -1643,17 +1643,19 @@ export function ProvidersSection() {
       (id) => !observedProviderIds.has(id) && !persistedIds.has(id),
     );
     visibleIds.forEach((id) => observedProviderIds.add(id));
-    if (unrecordedIds.length === 0) return;
+    if (unrecordedIds.length === 0 || ownerGeneration === null) return;
     void Promise.all(
-      unrecordedIds.map((id) => window.electronAPI.maker.setProviderOrder(dataOwnerId, [id])),
+      unrecordedIds.map((id) =>
+        window.electronAPI.maker.setProviderOrder(dataOwnerId, ownerGeneration, [id])),
     )
       .catch(() => toast.error(t('settings.providers.order.saveFailed')));
-  }, [dataOwnerId, listProviders, providerOrder, t]);
+  }, [dataOwnerId, listProviders, ownerGeneration, providerOrder, t]);
 
   const persistVisibleProviderOrder = useCallback(
     (reorderedVisibleIds: string[]): void => {
       const currentIds = listProviders.map((provider) => provider.id);
       if (reorderedVisibleIds.every((id, index) => id === currentIds[index])) return;
+      if (ownerGeneration === null) return;
       if (
         selectedId !== CINDY_SIGNIN_ID &&
         !listProviders.some((provider) => provider.id === selectedId) &&
@@ -1664,7 +1666,7 @@ export function ProvidersSection() {
       const generation = ++providerOrderMutationRef.current;
       setPendingProviderOrder({ dataOwnerId, ids: reorderedVisibleIds });
       void window.electronAPI.maker
-        .setProviderOrder(dataOwnerId, reorderedVisibleIds)
+        .setProviderOrder(dataOwnerId, ownerGeneration, reorderedVisibleIds)
         .then(() => {
           if (providerOrderMutationRef.current !== generation) return;
           setPendingProviderOrder((current) =>
@@ -1683,7 +1685,7 @@ export function ProvidersSection() {
           toast.error(t('settings.providers.order.saveFailed'));
         });
     },
-    [dataOwnerId, listProviders, refetch, selectedId, t],
+    [dataOwnerId, listProviders, ownerGeneration, refetch, selectedId, t],
   );
 
   const moveProviderWithKeyboard = useCallback(

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -74,10 +74,7 @@ import { SortableList } from '@/components/sidebar/SortableList';
 
 import type { LocalCliDetection } from '../../../shared/localCliDetect';
 import { isBuiltinRefreshableProviderId } from '../../../shared/providerModelRefresh';
-import {
-  applyProviderOrder,
-  mergeVisibleProviderOrder,
-} from '../../../shared/providerOrder';
+import { applyProviderOrder } from '../../../shared/providerOrder';
 import type { CustomProviderConfig, ProviderView } from '@cindy/model-providers';
 
 // ---------------------------------------------------------------------------
@@ -1541,46 +1538,24 @@ export function ProvidersSection() {
     };
   }, []);
 
-  // SortableJS drop 后先由 React 乐观铺新顺序，等 PROVIDER_CHANGED 回来的 main 快照
-  // 与目标一致再清掉覆盖；这样 DOM 回滚与 IPC 往返之间不会闪回旧顺序。
+  // SortableJS drop 后先由 React 乐观铺左栏可见顺序，等 PROVIDER_CHANGED 回来的 main
+  // 快照与目标一致再清掉覆盖；隐藏项是否有持久化槽位只由 Main 判定，Renderer 不猜。
   const pendingProviderOrderIds =
     pendingProviderOrder && pendingProviderOrder.dataOwnerId === dataOwnerId
       ? pendingProviderOrder.ids
       : null;
-  const orderedProviders = useMemo(
-    () =>
-      pendingProviderOrderIds
-        ? applyProviderOrder(providers, pendingProviderOrderIds)
-        : providers,
-    [pendingProviderOrderIds, providers],
-  );
-  useEffect(() => {
-    if (pendingProviderOrder && pendingProviderOrder.dataOwnerId !== dataOwnerId) {
-      providerOrderMutationRef.current += 1;
-      setPendingProviderOrder(null);
-      return;
-    }
-    if (!pendingProviderOrderIds) return;
-    const incomingIds = providers.map((provider) => provider.id);
-    const sameCatalog =
-      incomingIds.length === pendingProviderOrderIds.length &&
-      incomingIds.every((id) => pendingProviderOrderIds.includes(id));
-    if (!sameCatalog || incomingIds.every((id, index) => id === pendingProviderOrderIds[index])) {
-      setPendingProviderOrder(null);
-    }
-  }, [dataOwnerId, pendingProviderOrder, pendingProviderOrderIds, providers]);
 
   const byId = useMemo(() => {
     const map = new Map<string, ProviderView>();
-    orderedProviders.forEach((p) => map.set(p.id, p));
+    providers.forEach((p) => map.set(p.id, p));
     return map;
-  }, [orderedProviders]);
+  }, [providers]);
 
   // 左栏实际供应商严格沿用 main 的显示顺序;未连接的内置渠道仍只在向导 / 检测建议
   // 出现。Cindy 登录引导与检测建议是伪行,不进入持久化顺序。
-  const listProviders = useMemo(() => {
+  const visibleProviders = useMemo(() => {
     const rows: ProviderView[] = [];
-    for (const p of orderedProviders) {
+    for (const p of providers) {
       if (p.source === 'builtin') {
         // reconnect-required 视同占行:凭证失效 ≠ 用户断开,重连入口必须保留。
         // OpenAI 图像 key 与 ChatGPT OAuth 两套凭证解耦:imageModels 已声明时,
@@ -1604,7 +1579,31 @@ export function ProvidersSection() {
       }
     }
     return rows;
-  }, [orderedProviders, openaiReconnectRequired]);
+  }, [providers, openaiReconnectRequired]);
+
+  const listProviders = useMemo(
+    () =>
+      pendingProviderOrderIds
+        ? applyProviderOrder(visibleProviders, pendingProviderOrderIds)
+        : visibleProviders,
+    [pendingProviderOrderIds, visibleProviders],
+  );
+
+  useEffect(() => {
+    if (pendingProviderOrder && pendingProviderOrder.dataOwnerId !== dataOwnerId) {
+      providerOrderMutationRef.current += 1;
+      setPendingProviderOrder(null);
+      return;
+    }
+    if (!pendingProviderOrderIds) return;
+    const incomingIds = visibleProviders.map((provider) => provider.id);
+    const sameCatalog =
+      incomingIds.length === pendingProviderOrderIds.length &&
+      incomingIds.every((id) => pendingProviderOrderIds.includes(id));
+    if (!sameCatalog || incomingIds.every((id, index) => id === pendingProviderOrderIds[index])) {
+      setPendingProviderOrder(null);
+    }
+  }, [dataOwnerId, pendingProviderOrder, pendingProviderOrderIds, visibleProviders]);
 
   // Main 只持久化曾经真正进入过左栏的供应商。首次出现的新项按当前可见顺序追加；
   // 已记录但暂时隐藏的项由 store 保留，因此断开重连不会丢失用户排位。
@@ -1624,9 +1623,8 @@ export function ProvidersSection() {
 
   const persistVisibleProviderOrder = useCallback(
     (reorderedVisibleIds: string[]): void => {
-      const currentIds = orderedProviders.map((provider) => provider.id);
-      const nextIds = mergeVisibleProviderOrder(currentIds, reorderedVisibleIds);
-      if (nextIds.every((id, index) => id === currentIds[index])) return;
+      const currentIds = listProviders.map((provider) => provider.id);
+      if (reorderedVisibleIds.every((id, index) => id === currentIds[index])) return;
       if (
         selectedId !== CINDY_SIGNIN_ID &&
         !listProviders.some((provider) => provider.id === selectedId) &&
@@ -1635,7 +1633,7 @@ export function ProvidersSection() {
         setSelectedId(listProviders[0].id);
       }
       const generation = ++providerOrderMutationRef.current;
-      setPendingProviderOrder({ dataOwnerId, ids: nextIds });
+      setPendingProviderOrder({ dataOwnerId, ids: reorderedVisibleIds });
       void window.electronAPI.maker
         .setProviderOrder(reorderedVisibleIds)
         .then(() => {
@@ -1647,7 +1645,7 @@ export function ProvidersSection() {
           toast.error(t('settings.providers.order.saveFailed'));
         });
     },
-    [dataOwnerId, listProviders, orderedProviders, refetch, selectedId, t],
+    [dataOwnerId, listProviders, refetch, selectedId, t],
   );
 
   const moveProviderWithKeyboard = useCallback(

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -1475,7 +1475,7 @@ export function ProvidersSection() {
   const signInToCindy = useSignInToCindy();
   const { dataOwnerId } = useAuth();
   const { confirm } = useConfirmDialog();
-  const { providers, loading, refetch } = useProviders();
+  const { providers, providerOrder, loading, refetch } = useProviders();
   // OpenAI 的 reconnect-required 是 useCodexAuth 独有状态(目录 connected 此时为 false):
   // 该状态下 OpenAI 行必须留在左栏,否则「重新连接」入口不可达,用户被迫从向导重发现。
   const codexAuth = useCodexAuth();
@@ -1551,8 +1551,9 @@ export function ProvidersSection() {
     return map;
   }, [providers]);
 
-  // 左栏实际供应商严格沿用 main 的显示顺序;未连接的内置渠道仍只在向导 / 检测建议
-  // 出现。Cindy 登录引导与检测建议是伪行,不进入持久化顺序。
+  // 共享 provider 快照保持目录原序，避免显示偏好影响模型来源推导；只有设置页左栏
+  // 应用 Main 并列下发的 owner-scoped 显示顺序。Cindy 登录引导与检测建议是伪行，
+  // 不进入持久化顺序。
   const visibleProviders = useMemo(() => {
     const rows: ProviderView[] = [];
     for (const p of providers) {
@@ -1581,12 +1582,17 @@ export function ProvidersSection() {
     return rows;
   }, [providers, openaiReconnectRequired]);
 
+  const orderedVisibleProviders = useMemo(
+    () => applyProviderOrder(visibleProviders, providerOrder),
+    [providerOrder, visibleProviders],
+  );
+
   const listProviders = useMemo(
     () =>
       pendingProviderOrderIds
-        ? applyProviderOrder(visibleProviders, pendingProviderOrderIds)
-        : visibleProviders,
-    [pendingProviderOrderIds, visibleProviders],
+        ? applyProviderOrder(orderedVisibleProviders, pendingProviderOrderIds)
+        : orderedVisibleProviders,
+    [orderedVisibleProviders, pendingProviderOrderIds],
   );
 
   useEffect(() => {
@@ -1596,14 +1602,14 @@ export function ProvidersSection() {
       return;
     }
     if (!pendingProviderOrderIds) return;
-    const incomingIds = visibleProviders.map((provider) => provider.id);
+    const incomingIds = orderedVisibleProviders.map((provider) => provider.id);
     const sameCatalog =
       incomingIds.length === pendingProviderOrderIds.length &&
       incomingIds.every((id) => pendingProviderOrderIds.includes(id));
     if (!sameCatalog || incomingIds.every((id, index) => id === pendingProviderOrderIds[index])) {
       setPendingProviderOrder(null);
     }
-  }, [dataOwnerId, pendingProviderOrder, pendingProviderOrderIds, visibleProviders]);
+  }, [dataOwnerId, orderedVisibleProviders, pendingProviderOrder, pendingProviderOrderIds]);
 
   // Main 只持久化曾经真正进入过左栏的供应商。首次出现的新项按当前可见顺序追加；
   // 已记录但暂时隐藏的项由 store 保留，因此断开重连不会丢失用户排位。

--- a/apps/desktop/src/renderer/contexts/AuthContext.tsx
+++ b/apps/desktop/src/renderer/contexts/AuthContext.tsx
@@ -33,7 +33,11 @@ import { isGhostPanelWindow } from '@/lib/ghostPanelWindow';
 import { setNewMakerDraftOwner } from '@/state/newMakerDraft';
 import { setComposerDraftOwner } from '@/lib/composerDraftStore';
 import { setPendingHandoffOwner } from '@/state/pendingFirstMessage';
-import { setDataOwnerGeneration } from './dataOwnerGeneration';
+import { invalidateProvidersSnapshot } from '@/lib/providersSnapshotStore';
+import {
+  getDataOwnerGeneration,
+  setDataOwnerGeneration,
+} from './dataOwnerGeneration';
 
 /**
  * 登录态上下文：user / isAuthenticated / isCanary / deviceId 全部来自 main 的
@@ -75,6 +79,12 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 
 const log = createLogger('AuthContext');
 
+function publishDataOwnerGeneration(dataOwnerId: string | null): void {
+  const previousOwnerId = getDataOwnerGeneration().dataOwnerId;
+  setDataOwnerGeneration(dataOwnerId);
+  if (previousOwnerId !== dataOwnerId) invalidateProvidersSnapshot();
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
   const [mode, setMode] = useState<'signed-out' | 'local' | 'cloud'>('signed-out');
@@ -114,7 +124,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const applyIncomingState = useCallback(
     (state: AuthState) => {
       const ownerChanged = activeDataOwnerIdRef.current !== state.dataOwnerId;
-      setDataOwnerGeneration(state.dataOwnerId);
+      publishDataOwnerGeneration(state.dataOwnerId);
       if (ownerChanged) {
         sessionsStore.reset();
         clearWorkersCache();
@@ -187,7 +197,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setCanEnterApp(false);
         setMode('signed-out');
         setDataOwnerId(null);
-        setDataOwnerGeneration(null);
+        publishDataOwnerGeneration(null);
         activeDataOwnerIdRef.current = null;
         activeUserIdRef.current = null;
         setLoginState(null);
@@ -226,7 +236,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       if (handling) return;
       handling = true;
       // Invalidate in-flight remote sends before the confirmation dialog resolves.
-      setDataOwnerGeneration(null);
+      publishDataOwnerGeneration(null);
       // main 只给客户端内部分类(不透传服务端原文),按 reason 选本地化文案,
       // 让用户区分「被顶下线 / 凭证被外部实例清除 / 自然过期 / 账号不可用」。
       const descriptionKey =
@@ -276,16 +286,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const logout = useCallback(async () => {
-    setDataOwnerGeneration(null);
+    publishDataOwnerGeneration(null);
     await authServiceRef.current!.logout();
     sessionsStore.reset();
     clearWorkersCache();
   }, []);
 
   const enterLocalMode = useCallback(async () => {
-    setDataOwnerGeneration(null);
+    publishDataOwnerGeneration(null);
     const state = await authServiceRef.current!.enterLocalMode();
-    setDataOwnerGeneration(state.dataOwnerId);
+    publishDataOwnerGeneration(state.dataOwnerId);
     setComposerDraftOwner(state.dataOwnerId);
     setPendingHandoffOwner(state.dataOwnerId);
     setMode(state.mode);
@@ -296,9 +306,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const exitLocalMode = useCallback(async () => {
-    setDataOwnerGeneration(null);
+    publishDataOwnerGeneration(null);
     const state = await authServiceRef.current!.exitLocalMode();
-    setDataOwnerGeneration(state.dataOwnerId);
+    publishDataOwnerGeneration(state.dataOwnerId);
     setComposerDraftOwner(state.dataOwnerId);
     setPendingHandoffOwner(state.dataOwnerId);
     setMode(state.mode);

--- a/apps/desktop/src/renderer/contexts/AuthContext.tsx
+++ b/apps/desktop/src/renderer/contexts/AuthContext.tsx
@@ -34,6 +34,7 @@ import { setNewMakerDraftOwner } from '@/state/newMakerDraft';
 import { setComposerDraftOwner } from '@/lib/composerDraftStore';
 import { setPendingHandoffOwner } from '@/state/pendingFirstMessage';
 import { invalidateProvidersSnapshot } from '@/lib/providersSnapshotStore';
+import { preloadLocalCatalogSnapshot } from '@/lib/localCatalogSnapshot';
 import {
   getDataOwnerGeneration,
   setDataOwnerGeneration,
@@ -108,6 +109,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const activeUserIdRef = useRef<string | null>(null);
   const activeDataOwnerIdRef = useRef<string | null>(null);
   const authStateVersionRef = useRef(0);
+
+  // Auth mutations invalidate owner-bound in-flight reads before crossing IPC. If Main rejects
+  // the transition, restore the single authoritative owner ref (which successful siblings and
+  // newer pushes both update), then rebuild the cache because React state may never have changed.
+  const runDataOwnerBoundary = useCallback(async <T,>(operation: () => Promise<T>): Promise<T> => {
+    publishDataOwnerGeneration(null);
+    try {
+      return await operation();
+    } catch (error) {
+      publishDataOwnerGeneration(activeDataOwnerIdRef.current);
+      void preloadLocalCatalogSnapshot();
+      throw error;
+    }
+  }, []);
 
   /**
    * 身份即 auth-server membership(产品 role 水合已随 /api/me 退役,2026-07)。
@@ -286,16 +301,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 
   const logout = useCallback(async () => {
-    publishDataOwnerGeneration(null);
-    await authServiceRef.current!.logout();
+    await runDataOwnerBoundary(() => authServiceRef.current!.logout());
     sessionsStore.reset();
     clearWorkersCache();
-  }, []);
+  }, [runDataOwnerBoundary]);
 
   const enterLocalMode = useCallback(async () => {
-    publishDataOwnerGeneration(null);
-    const state = await authServiceRef.current!.enterLocalMode();
+    const state = await runDataOwnerBoundary(() => authServiceRef.current!.enterLocalMode());
     publishDataOwnerGeneration(state.dataOwnerId);
+    activeDataOwnerIdRef.current = state.dataOwnerId;
     setComposerDraftOwner(state.dataOwnerId);
     setPendingHandoffOwner(state.dataOwnerId);
     setMode(state.mode);
@@ -303,12 +317,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCanEnterApp(state.canEnterApp);
     setIsAuthenticated(state.isAuthenticated);
     setUser(state.user);
-  }, []);
+  }, [runDataOwnerBoundary]);
 
   const exitLocalMode = useCallback(async () => {
-    publishDataOwnerGeneration(null);
-    const state = await authServiceRef.current!.exitLocalMode();
+    const state = await runDataOwnerBoundary(() => authServiceRef.current!.exitLocalMode());
     publishDataOwnerGeneration(state.dataOwnerId);
+    activeDataOwnerIdRef.current = state.dataOwnerId;
     setComposerDraftOwner(state.dataOwnerId);
     setPendingHandoffOwner(state.dataOwnerId);
     setMode(state.mode);
@@ -316,7 +330,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCanEnterApp(state.canEnterApp);
     setIsAuthenticated(state.isAuthenticated);
     setUser(state.user);
-  }, []);
+  }, [runDataOwnerBoundary]);
 
   const getAccountDeletionAvailability = useCallback(
     () => authServiceRef.current!.getAccountDeletionAvailability(),

--- a/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
+++ b/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
@@ -7,10 +7,12 @@ import type { ProviderView } from '@cindy/model-providers';
 const mocks = vi.hoisted(() => ({
   authState: { dataOwnerId: 'owner-a' as string | null },
   cachedOwnerId: 'owner-a' as string | null,
+  cachedOwnerGeneration: 1,
   cachedProviders: [] as ProviderView[],
   cachedProviderOrder: [] as string[],
   latestListener: null as null | ((snapshot: {
     dataOwnerId: string | null;
+    ownerGeneration: number;
     providers: ProviderView[];
     providerOrder: string[];
   } | null) => void),
@@ -39,6 +41,7 @@ describe('useProviders', () => {
     vi.clearAllMocks();
     mocks.authState.dataOwnerId = 'owner-a';
     mocks.cachedOwnerId = 'owner-a';
+    mocks.cachedOwnerGeneration = 1;
     mocks.cachedProviders = [];
     mocks.cachedProviderOrder = [];
     mocks.latestListener = null;
@@ -46,6 +49,7 @@ describe('useProviders', () => {
       mocks.cachedOwnerId === mocks.authState.dataOwnerId
         ? {
             dataOwnerId: mocks.cachedOwnerId,
+            ownerGeneration: mocks.cachedOwnerGeneration,
             providers: mocks.cachedProviders,
             providerOrder: mocks.cachedProviderOrder,
           }
@@ -76,6 +80,7 @@ describe('useProviders', () => {
     const { result } = renderHook(() => useProviders());
     expect(result.current.providers).toEqual([ownerAProvider]);
     expect(result.current.providerOrder).toEqual([]);
+    expect(result.current.ownerGeneration).toBe(1);
     expect(result.current.loading).toBe(false);
 
     act(() => {
@@ -83,20 +88,24 @@ describe('useProviders', () => {
       mocks.latestListener?.(null);
     });
     expect(result.current.providers).toEqual([]);
+    expect(result.current.ownerGeneration).toBeNull();
     expect(result.current.loading).toBe(true);
 
     act(() => {
       mocks.cachedOwnerId = 'owner-b';
+      mocks.cachedOwnerGeneration = 2;
       mocks.cachedProviders = [ownerBProvider];
       mocks.cachedProviderOrder = ['owner-b-provider'];
       mocks.latestListener?.({
         dataOwnerId: 'owner-b',
+        ownerGeneration: 2,
         providers: [ownerBProvider],
         providerOrder: ['owner-b-provider'],
       });
     });
     expect(result.current.providers).toEqual([ownerBProvider]);
     expect(result.current.providerOrder).toEqual(['owner-b-provider']);
+    expect(result.current.ownerGeneration).toBe(2);
     expect(result.current.loading).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
+++ b/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
@@ -13,7 +13,7 @@ const mocks = vi.hoisted(() => ({
     dataOwnerId: string | null;
     providers: ProviderView[];
     providerOrder: string[];
-  }) => void),
+  } | null) => void),
   refreshLocalCatalogSnapshot: vi.fn(async () => true),
   getCachedProvidersSnapshot: vi.fn(),
   subscribeProvidersSnapshot: vi.fn(),
@@ -73,14 +73,14 @@ describe('useProviders', () => {
     const ownerAProvider = { id: 'owner-a-provider' } as ProviderView;
     const ownerBProvider = { id: 'owner-b-provider' } as ProviderView;
     mocks.cachedProviders = [ownerAProvider];
-    const { result, rerender } = renderHook(() => useProviders());
+    const { result } = renderHook(() => useProviders());
     expect(result.current.providers).toEqual([ownerAProvider]);
     expect(result.current.providerOrder).toEqual([]);
     expect(result.current.loading).toBe(false);
 
     act(() => {
       mocks.authState.dataOwnerId = 'owner-b';
-      rerender();
+      mocks.latestListener?.(null);
     });
     expect(result.current.providers).toEqual([]);
     expect(result.current.loading).toBe(true);

--- a/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
+++ b/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
@@ -8,7 +8,12 @@ const mocks = vi.hoisted(() => ({
   authState: { dataOwnerId: 'owner-a' as string | null },
   cachedOwnerId: 'owner-a' as string | null,
   cachedProviders: [] as ProviderView[],
-  latestListener: null as null | ((providers: ProviderView[]) => void),
+  cachedProviderOrder: [] as string[],
+  latestListener: null as null | ((snapshot: {
+    dataOwnerId: string | null;
+    providers: ProviderView[];
+    providerOrder: string[];
+  }) => void),
   refreshLocalCatalogSnapshot: vi.fn(async () => true),
   getCachedProvidersSnapshot: vi.fn(),
   subscribeProvidersSnapshot: vi.fn(),
@@ -35,12 +40,19 @@ describe('useProviders', () => {
     mocks.authState.dataOwnerId = 'owner-a';
     mocks.cachedOwnerId = 'owner-a';
     mocks.cachedProviders = [];
+    mocks.cachedProviderOrder = [];
     mocks.latestListener = null;
     mocks.getCachedProvidersSnapshot.mockImplementation(() =>
-      mocks.cachedOwnerId === mocks.authState.dataOwnerId ? mocks.cachedProviders : null,
+      mocks.cachedOwnerId === mocks.authState.dataOwnerId
+        ? {
+            dataOwnerId: mocks.cachedOwnerId,
+            providers: mocks.cachedProviders,
+            providerOrder: mocks.cachedProviderOrder,
+          }
+        : null,
     );
     mocks.subscribeProvidersSnapshot.mockImplementation(
-      (listener: (providers: ProviderView[]) => void) => {
+      (listener: typeof mocks.latestListener) => {
         mocks.latestListener = listener;
         return () => {
           if (mocks.latestListener === listener) mocks.latestListener = null;
@@ -63,6 +75,7 @@ describe('useProviders', () => {
     mocks.cachedProviders = [ownerAProvider];
     const { result, rerender } = renderHook(() => useProviders());
     expect(result.current.providers).toEqual([ownerAProvider]);
+    expect(result.current.providerOrder).toEqual([]);
     expect(result.current.loading).toBe(false);
 
     act(() => {
@@ -75,9 +88,15 @@ describe('useProviders', () => {
     act(() => {
       mocks.cachedOwnerId = 'owner-b';
       mocks.cachedProviders = [ownerBProvider];
-      mocks.latestListener?.([ownerBProvider]);
+      mocks.cachedProviderOrder = ['owner-b-provider'];
+      mocks.latestListener?.({
+        dataOwnerId: 'owner-b',
+        providers: [ownerBProvider],
+        providerOrder: ['owner-b-provider'],
+      });
     });
     expect(result.current.providers).toEqual([ownerBProvider]);
+    expect(result.current.providerOrder).toEqual(['owner-b-provider']);
     expect(result.current.loading).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
+++ b/apps/desktop/src/renderer/hooks/__tests__/useProviders.test.tsx
@@ -1,12 +1,21 @@
 /** @vitest-environment jsdom */
 
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
+import type { ProviderView } from '@cindy/model-providers';
 
 const mocks = vi.hoisted(() => ({
+  authState: { dataOwnerId: 'owner-a' as string | null },
+  cachedOwnerId: 'owner-a' as string | null,
+  cachedProviders: [] as ProviderView[],
+  latestListener: null as null | ((providers: ProviderView[]) => void),
   refreshLocalCatalogSnapshot: vi.fn(async () => true),
-  getCachedProvidersSnapshot: vi.fn(() => []),
-  subscribeProvidersSnapshot: vi.fn(() => () => {}),
+  getCachedProvidersSnapshot: vi.fn(),
+  subscribeProvidersSnapshot: vi.fn(),
+}));
+
+vi.mock('@/contexts/dataOwnerGeneration', () => ({
+  getDataOwnerGeneration: () => ({ dataOwnerId: mocks.authState.dataOwnerId, generation: 1 }),
 }));
 
 vi.mock('@/lib/localCatalogSnapshot', () => ({
@@ -21,11 +30,54 @@ vi.mock('@/lib/providersSnapshotStore', () => ({
 import { useProviders } from '../useProviders';
 
 describe('useProviders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.authState.dataOwnerId = 'owner-a';
+    mocks.cachedOwnerId = 'owner-a';
+    mocks.cachedProviders = [];
+    mocks.latestListener = null;
+    mocks.getCachedProvidersSnapshot.mockImplementation(() =>
+      mocks.cachedOwnerId === mocks.authState.dataOwnerId ? mocks.cachedProviders : null,
+    );
+    mocks.subscribeProvidersSnapshot.mockImplementation(
+      (listener: (providers: ProviderView[]) => void) => {
+        mocks.latestListener = listener;
+        return () => {
+          if (mocks.latestListener === listener) mocks.latestListener = null;
+        };
+      },
+    );
+  });
+
   it('refetches the atomic providers and capabilities snapshot', () => {
     const { result } = renderHook(() => useProviders());
 
     act(() => result.current.refetch());
 
     expect(mocks.refreshLocalCatalogSnapshot).toHaveBeenCalledOnce();
+  });
+
+  it('does not expose the previous owner snapshot while the new owner is loading', () => {
+    const ownerAProvider = { id: 'owner-a-provider' } as ProviderView;
+    const ownerBProvider = { id: 'owner-b-provider' } as ProviderView;
+    mocks.cachedProviders = [ownerAProvider];
+    const { result, rerender } = renderHook(() => useProviders());
+    expect(result.current.providers).toEqual([ownerAProvider]);
+    expect(result.current.loading).toBe(false);
+
+    act(() => {
+      mocks.authState.dataOwnerId = 'owner-b';
+      rerender();
+    });
+    expect(result.current.providers).toEqual([]);
+    expect(result.current.loading).toBe(true);
+
+    act(() => {
+      mocks.cachedOwnerId = 'owner-b';
+      mocks.cachedProviders = [ownerBProvider];
+      mocks.latestListener?.([ownerBProvider]);
+    });
+    expect(result.current.providers).toEqual([ownerBProvider]);
+    expect(result.current.loading).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/hooks/useProviderOnboarding.ts
+++ b/apps/desktop/src/renderer/hooks/useProviderOnboarding.ts
@@ -34,8 +34,8 @@ import {
 // 连上又断开、期间从未回到首屏/会话视图时,dismiss 也必须被清,否则回到零连接后
 // 引导永远不再出现(Codex P1,2026-07-24)。与 hook 内 effect 并存:effect 覆盖
 // 挂载中的即时清理(含测试 mock 场景),此处覆盖未挂载窗口;reset 为幂等 no-op。
-const unsubscribeAutoReset = subscribeProvidersSnapshot(({ providers }) => {
-  if (providers.some((p) => p.connected)) resetProviderOnboardingDismissal();
+const unsubscribeAutoReset = subscribeProvidersSnapshot((snapshot) => {
+  if (snapshot?.providers.some((p) => p.connected)) resetProviderOnboardingDismissal();
 });
 // HMR 下本模块会被重复执行:不 dispose 会累积 listener(reset 幂等,功能无害,
 // 但 dev 长跑会泄漏)。生产构建无 import.meta.hot,整段被摇树掉。

--- a/apps/desktop/src/renderer/hooks/useProviderOnboarding.ts
+++ b/apps/desktop/src/renderer/hooks/useProviderOnboarding.ts
@@ -34,7 +34,7 @@ import {
 // 连上又断开、期间从未回到首屏/会话视图时,dismiss 也必须被清,否则回到零连接后
 // 引导永远不再出现(Codex P1,2026-07-24)。与 hook 内 effect 并存:effect 覆盖
 // 挂载中的即时清理(含测试 mock 场景),此处覆盖未挂载窗口;reset 为幂等 no-op。
-const unsubscribeAutoReset = subscribeProvidersSnapshot((providers) => {
+const unsubscribeAutoReset = subscribeProvidersSnapshot(({ providers }) => {
   if (providers.some((p) => p.connected)) resetProviderOnboardingDismissal();
 });
 // HMR 下本模块会被重复执行:不 dispose 会累积 listener(reset 幂等,功能无害,

--- a/apps/desktop/src/renderer/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/hooks/useProviders.ts
@@ -14,6 +14,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import type { ProviderView } from '@cindy/model-providers';
+import { getDataOwnerGeneration } from '@/contexts/dataOwnerGeneration';
 import { refreshLocalCatalogSnapshot } from '@/lib/localCatalogSnapshot';
 import {
   getCachedProvidersSnapshot,
@@ -39,23 +40,34 @@ export interface UseProvidersReturn {
  * 只缓存"快照"不缓存"是否在拉取中",故不破坏 refetch 的现有刷新语义。
  */
 export function useProviders(): UseProvidersReturn {
-  const [providers, setProviders] = useState<ProviderView[]>(
-    () => getCachedProvidersSnapshot() ?? [],
-  );
-  // 有缓存即视为已就绪:重开时第一帧就有可用数据,不再走 loading 态。
-  const [loading, setLoading] = useState(getCachedProvidersSnapshot() == null);
+  const { dataOwnerId } = getDataOwnerGeneration();
+  const [snapshot, setSnapshot] = useState<{
+    dataOwnerId: string | null;
+    providers: ProviderView[] | null;
+  }>(() => ({ dataOwnerId, providers: getCachedProvidersSnapshot() }));
+
+  // AuthContext 会先同步切换全局 data owner 代际、再提交 React state。owner 改变后的
+  // 首次 render 不能继续暴露旧 state；只接受同 owner state 或 owner-scoped 模块缓存。
+  const currentProviders =
+    snapshot.dataOwnerId === dataOwnerId
+      ? snapshot.providers
+      : getCachedProvidersSnapshot();
 
   const refetch = useCallback(() => {
     void refreshLocalCatalogSnapshot();
   }, []);
 
   useEffect(() => {
+    setSnapshot({ dataOwnerId, providers: getCachedProvidersSnapshot() });
     const onRefresh = (next: ProviderView[]): void => {
-      setProviders(next);
-      setLoading(false);
+      setSnapshot({ dataOwnerId, providers: next });
     };
     return subscribeProvidersSnapshot(onRefresh);
-  }, []);
+  }, [dataOwnerId]);
 
-  return { providers, loading, refetch };
+  return {
+    providers: currentProviders ?? [],
+    loading: currentProviders == null,
+    refetch,
+  };
 }

--- a/apps/desktop/src/renderer/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/hooks/useProviders.ts
@@ -60,7 +60,7 @@ export function useProviders(): UseProvidersReturn {
 
   useEffect(() => {
     setSnapshot(getCachedProvidersSnapshot());
-    const onRefresh = (next: ProvidersSnapshot): void => setSnapshot(next);
+    const onRefresh = (next: ProvidersSnapshot | null): void => setSnapshot(next);
     return subscribeProvidersSnapshot(onRefresh);
   }, [dataOwnerId]);
 

--- a/apps/desktop/src/renderer/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/hooks/useProviders.ts
@@ -19,10 +19,12 @@ import { refreshLocalCatalogSnapshot } from '@/lib/localCatalogSnapshot';
 import {
   getCachedProvidersSnapshot,
   subscribeProvidersSnapshot,
+  type ProvidersSnapshot,
 } from '@/lib/providersSnapshotStore';
 
 export interface UseProvidersReturn {
   providers: ProviderView[];
+  providerOrder: string[];
   loading: boolean;
   refetch: () => void;
 }
@@ -41,16 +43,15 @@ export interface UseProvidersReturn {
  */
 export function useProviders(): UseProvidersReturn {
   const { dataOwnerId } = getDataOwnerGeneration();
-  const [snapshot, setSnapshot] = useState<{
-    dataOwnerId: string | null;
-    providers: ProviderView[] | null;
-  }>(() => ({ dataOwnerId, providers: getCachedProvidersSnapshot() }));
+  const [snapshot, setSnapshot] = useState<ProvidersSnapshot | null>(() =>
+    getCachedProvidersSnapshot(),
+  );
 
   // AuthContext 会先同步切换全局 data owner 代际、再提交 React state。owner 改变后的
   // 首次 render 不能继续暴露旧 state；只接受同 owner state 或 owner-scoped 模块缓存。
-  const currentProviders =
-    snapshot.dataOwnerId === dataOwnerId
-      ? snapshot.providers
+  const currentSnapshot =
+    snapshot?.dataOwnerId === dataOwnerId
+      ? snapshot
       : getCachedProvidersSnapshot();
 
   const refetch = useCallback(() => {
@@ -58,16 +59,15 @@ export function useProviders(): UseProvidersReturn {
   }, []);
 
   useEffect(() => {
-    setSnapshot({ dataOwnerId, providers: getCachedProvidersSnapshot() });
-    const onRefresh = (next: ProviderView[]): void => {
-      setSnapshot({ dataOwnerId, providers: next });
-    };
+    setSnapshot(getCachedProvidersSnapshot());
+    const onRefresh = (next: ProvidersSnapshot): void => setSnapshot(next);
     return subscribeProvidersSnapshot(onRefresh);
   }, [dataOwnerId]);
 
   return {
-    providers: currentProviders ?? [],
-    loading: currentProviders == null,
+    providers: currentSnapshot?.providers ?? [],
+    providerOrder: currentSnapshot?.providerOrder ?? [],
+    loading: currentSnapshot == null,
     refetch,
   };
 }

--- a/apps/desktop/src/renderer/hooks/useProviders.ts
+++ b/apps/desktop/src/renderer/hooks/useProviders.ts
@@ -25,6 +25,7 @@ import {
 export interface UseProvidersReturn {
   providers: ProviderView[];
   providerOrder: string[];
+  ownerGeneration: number | null;
   loading: boolean;
   refetch: () => void;
 }
@@ -67,6 +68,7 @@ export function useProviders(): UseProvidersReturn {
   return {
     providers: currentSnapshot?.providers ?? [],
     providerOrder: currentSnapshot?.providerOrder ?? [],
+    ownerGeneration: currentSnapshot?.ownerGeneration ?? null,
     loading: currentSnapshot == null,
     refetch,
   };

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1216,7 +1216,7 @@
         "hint": "Drag to reorder",
         "handle": "Reorder {{provider}}, position {{position}} of {{total}}. Use the arrow keys to move.",
         "moved": "{{provider}} moved to position {{position}} of {{total}}.",
-        "saveFailed": "Provider order wasn’t saved. Try again."
+        "saveFailed": "Provider order wasn't saved. Try again."
       },
       "pill": {
         "connected": "Connected",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1212,6 +1212,12 @@
     "providers": {
       "title": "Providers",
       "subtitle": "The source used when picking a model. Each source offers its own models and billing, switchable per session.",
+      "order": {
+        "hint": "Drag to reorder",
+        "handle": "Reorder {{provider}}, position {{position}} of {{total}}. Use the arrow keys to move.",
+        "moved": "{{provider}} moved to position {{position}} of {{total}}.",
+        "saveFailed": "Provider order wasn’t saved. Try again."
+      },
       "pill": {
         "connected": "Connected",
         "suspended": "Disabled"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1212,6 +1212,12 @@
     "providers": {
       "title": "モデルプロバイダー",
       "subtitle": "モデルを選ぶときのソースです。各ソースは対応するモデルと課金方式を提供し、セッションごとに切り替えられます。",
+      "order": {
+        "hint": "ドラッグして並べ替え",
+        "handle": "{{provider}}を並べ替えます。現在{{total}}件中{{position}}番目です。矢印キーで移動できます。",
+        "moved": "{{provider}}を{{total}}件中{{position}}番目に移動しました。",
+        "saveFailed": "プロバイダーの順序を保存できませんでした。もう一度お試しください。"
+      },
       "pill": {
         "connected": "接続済み",
         "suspended": "無効"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1212,6 +1212,12 @@
     "providers": {
       "title": "모델 제공자",
       "subtitle": "모델을 선택할 때의 소스입니다. 각 소스는 지원하는 모델과 과금 방식을 제공하며, 세션별로 전환할 수 있습니다.",
+      "order": {
+        "hint": "드래그하여 순서 변경",
+        "handle": "{{provider}} 순서를 변경합니다. 현재 {{total}}개 중 {{position}}번째입니다. 화살표 키로 이동할 수 있습니다.",
+        "moved": "{{provider}}을(를) {{total}}개 중 {{position}}번째로 이동했습니다.",
+        "saveFailed": "제공자 순서를 저장하지 못했습니다. 다시 시도하세요."
+      },
       "pill": {
         "connected": "연결됨",
         "suspended": "비활성화됨"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1212,6 +1212,12 @@
     "providers": {
       "title": "模型供应商",
       "subtitle": "选择模型时的来源。每个来源提供它支持的模型与计费方式，可按任务分别切换。",
+      "order": {
+        "hint": "拖动排序",
+        "handle": "调整 {{provider}} 顺序，当前第 {{position}} 项，共 {{total}} 项。使用方向键移动。",
+        "moved": "已将 {{provider}} 移至第 {{position}} 项，共 {{total}} 项。",
+        "saveFailed": "未能保存供应商顺序，请重试。"
+      },
       "pill": {
         "connected": "已连接",
         "suspended": "已停用"

--- a/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
@@ -25,17 +25,44 @@ describe('providersSnapshotStore owner isolation', () => {
 
     setDataOwnerGeneration('owner-a');
     const ownerAToken = beginProvidersRefresh();
-    expect(commitProvidersSnapshot(ownerAToken, [ownerAProvider])).toBe(true);
-    expect(getCachedProvidersSnapshot()).toEqual([ownerAProvider]);
+    expect(commitProvidersSnapshot(ownerAToken, {
+      dataOwnerId: 'owner-a',
+      providers: [ownerAProvider],
+      providerOrder: ['owner-a-provider'],
+    })).toBe(true);
+    expect(getCachedProvidersSnapshot()).toEqual({
+      dataOwnerId: 'owner-a',
+      providers: [ownerAProvider],
+      providerOrder: ['owner-a-provider'],
+    });
 
     const staleOwnerAToken = beginProvidersRefresh();
     setDataOwnerGeneration('owner-b');
     expect(getCachedProvidersSnapshot()).toBeNull();
     expect(isProvidersRefreshCurrent(staleOwnerAToken)).toBe(false);
-    expect(commitProvidersSnapshot(staleOwnerAToken, [ownerAProvider])).toBe(false);
+    expect(commitProvidersSnapshot(staleOwnerAToken, {
+      dataOwnerId: 'owner-a',
+      providers: [ownerAProvider],
+      providerOrder: ['owner-a-provider'],
+    })).toBe(false);
 
     const ownerBToken = beginProvidersRefresh();
-    expect(commitProvidersSnapshot(ownerBToken, [ownerBProvider])).toBe(true);
-    expect(getCachedProvidersSnapshot()).toEqual([ownerBProvider]);
+    const mismatchedOwnerSnapshot = {
+      dataOwnerId: 'owner-a',
+      providers: [ownerBProvider],
+      providerOrder: ['owner-b-provider'],
+    };
+    expect(isProvidersRefreshCurrent(ownerBToken, mismatchedOwnerSnapshot)).toBe(false);
+    expect(commitProvidersSnapshot(ownerBToken, mismatchedOwnerSnapshot)).toBe(false);
+    expect(commitProvidersSnapshot(ownerBToken, {
+      dataOwnerId: 'owner-b',
+      providers: [ownerBProvider],
+      providerOrder: ['owner-b-provider'],
+    })).toBe(true);
+    expect(getCachedProvidersSnapshot()).toEqual({
+      dataOwnerId: 'owner-b',
+      providers: [ownerBProvider],
+      providerOrder: ['owner-b-provider'],
+    });
   });
 });

--- a/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
@@ -29,11 +29,13 @@ describe('providersSnapshotStore owner isolation', () => {
     const ownerAToken = beginProvidersRefresh();
     expect(commitProvidersSnapshot(ownerAToken, {
       dataOwnerId: 'owner-a',
+      ownerGeneration: 1,
       providers: [ownerAProvider],
       providerOrder: ['owner-a-provider'],
     })).toBe(true);
     expect(getCachedProvidersSnapshot()).toEqual({
       dataOwnerId: 'owner-a',
+      ownerGeneration: 1,
       providers: [ownerAProvider],
       providerOrder: ['owner-a-provider'],
     });
@@ -49,6 +51,7 @@ describe('providersSnapshotStore owner isolation', () => {
     expect(isProvidersRefreshCurrent(staleOwnerAToken)).toBe(false);
     expect(commitProvidersSnapshot(staleOwnerAToken, {
       dataOwnerId: 'owner-a',
+      ownerGeneration: 1,
       providers: [ownerAProvider],
       providerOrder: ['owner-a-provider'],
     })).toBe(false);
@@ -56,6 +59,7 @@ describe('providersSnapshotStore owner isolation', () => {
     const ownerBToken = beginProvidersRefresh();
     const mismatchedOwnerSnapshot = {
       dataOwnerId: 'owner-a',
+      ownerGeneration: 1,
       providers: [ownerBProvider],
       providerOrder: ['owner-b-provider'],
     };
@@ -63,11 +67,13 @@ describe('providersSnapshotStore owner isolation', () => {
     expect(commitProvidersSnapshot(ownerBToken, mismatchedOwnerSnapshot)).toBe(false);
     expect(commitProvidersSnapshot(ownerBToken, {
       dataOwnerId: 'owner-b',
+      ownerGeneration: 2,
       providers: [ownerBProvider],
       providerOrder: ['owner-b-provider'],
     })).toBe(true);
     expect(getCachedProvidersSnapshot()).toEqual({
       dataOwnerId: 'owner-b',
+      ownerGeneration: 2,
       providers: [ownerBProvider],
       providerOrder: ['owner-b-provider'],
     });

--- a/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ProviderView } from '@cindy/model-providers';
 import {
@@ -10,7 +10,9 @@ import {
   beginProvidersRefresh,
   commitProvidersSnapshot,
   getCachedProvidersSnapshot,
+  invalidateProvidersSnapshot,
   isProvidersRefreshCurrent,
+  subscribeProvidersSnapshot,
 } from '@/lib/providersSnapshotStore';
 
 describe('providersSnapshotStore owner isolation', () => {
@@ -36,8 +38,13 @@ describe('providersSnapshotStore owner isolation', () => {
       providerOrder: ['owner-a-provider'],
     });
 
+    const listener = vi.fn();
+    const unsubscribe = subscribeProvidersSnapshot(listener);
     const staleOwnerAToken = beginProvidersRefresh();
     setDataOwnerGeneration('owner-b');
+    invalidateProvidersSnapshot();
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(null);
     expect(getCachedProvidersSnapshot()).toBeNull();
     expect(isProvidersRefreshCurrent(staleOwnerAToken)).toBe(false);
     expect(commitProvidersSnapshot(staleOwnerAToken, {
@@ -64,5 +71,6 @@ describe('providersSnapshotStore owner isolation', () => {
       providers: [ownerBProvider],
       providerOrder: ['owner-b-provider'],
     });
+    unsubscribe();
   });
 });

--- a/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/providersSnapshotStore.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import type { ProviderView } from '@cindy/model-providers';
+import {
+  __testing as dataOwnerTesting,
+  setDataOwnerGeneration,
+} from '@/contexts/dataOwnerGeneration';
+import {
+  __testing,
+  beginProvidersRefresh,
+  commitProvidersSnapshot,
+  getCachedProvidersSnapshot,
+  isProvidersRefreshCurrent,
+} from '@/lib/providersSnapshotStore';
+
+describe('providersSnapshotStore owner isolation', () => {
+  beforeEach(() => {
+    dataOwnerTesting.reset();
+    __testing.reset();
+  });
+
+  it('hides another owner cache and rejects an in-flight result after owner changes', () => {
+    const ownerAProvider = { id: 'owner-a-provider' } as ProviderView;
+    const ownerBProvider = { id: 'owner-b-provider' } as ProviderView;
+
+    setDataOwnerGeneration('owner-a');
+    const ownerAToken = beginProvidersRefresh();
+    expect(commitProvidersSnapshot(ownerAToken, [ownerAProvider])).toBe(true);
+    expect(getCachedProvidersSnapshot()).toEqual([ownerAProvider]);
+
+    const staleOwnerAToken = beginProvidersRefresh();
+    setDataOwnerGeneration('owner-b');
+    expect(getCachedProvidersSnapshot()).toBeNull();
+    expect(isProvidersRefreshCurrent(staleOwnerAToken)).toBe(false);
+    expect(commitProvidersSnapshot(staleOwnerAToken, [ownerAProvider])).toBe(false);
+
+    const ownerBToken = beginProvidersRefresh();
+    expect(commitProvidersSnapshot(ownerBToken, [ownerBProvider])).toBe(true);
+    expect(getCachedProvidersSnapshot()).toEqual([ownerBProvider]);
+  });
+});

--- a/apps/desktop/src/renderer/lib/localCatalogSnapshot.ts
+++ b/apps/desktop/src/renderer/lib/localCatalogSnapshot.ts
@@ -35,7 +35,7 @@ export async function refreshLocalCatalogSnapshot(): Promise<boolean> {
     ]);
     if (
       refreshGeneration !== generation
-      || !isProvidersRefreshCurrent(providersGeneration)
+      || !isProvidersRefreshCurrent(providersGeneration, providers)
       || !isLocalCapabilitiesRefreshCurrent(capabilitiesGeneration)
     ) {
       return false;

--- a/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
+++ b/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
@@ -16,19 +16,25 @@ interface ProvidersRefreshToken {
   owner: DataOwnerGeneration;
 }
 
-let cachedProviders: { dataOwnerId: string | null; providers: ProviderView[] } | null = null;
+export interface ProvidersSnapshot {
+  dataOwnerId: string | null;
+  providers: ProviderView[];
+  providerOrder: string[];
+}
+
+let cachedProviders: ProvidersSnapshot | null = null;
 let providersGeneration = 0;
-const providerListeners = new Set<(providers: ProviderView[]) => void>();
+const providerListeners = new Set<(snapshot: ProvidersSnapshot) => void>();
 
 /** 返回当前 data owner 最近一次完整 provider 快照；未加载或归属不符时为 null。 */
-export function getCachedProvidersSnapshot(): ProviderView[] | null {
+export function getCachedProvidersSnapshot(): ProvidersSnapshot | null {
   const { dataOwnerId } = getDataOwnerGeneration();
-  return cachedProviders?.dataOwnerId === dataOwnerId ? cachedProviders.providers : null;
+  return cachedProviders?.dataOwnerId === dataOwnerId ? cachedProviders : null;
 }
 
 /** 订阅完整 provider 快照提交。 */
 export function subscribeProvidersSnapshot(
-  listener: (providers: ProviderView[]) => void,
+  listener: (snapshot: ProvidersSnapshot) => void,
 ): () => void {
   providerListeners.add(listener);
   return () => providerListeners.delete(listener);
@@ -44,25 +50,33 @@ export function beginProvidersRefresh(): ProvidersRefreshToken {
 }
 
 /** 读取 provider 快照。失败向上抛，由联合刷新保留上一份有效缓存。 */
-export async function loadProvidersSnapshot(): Promise<ProviderView[]> {
+export async function loadProvidersSnapshot(): Promise<ProvidersSnapshot> {
   const result = await window.electronAPI.maker.listProviders();
-  return result.providers;
+  return {
+    dataOwnerId: result.dataOwnerId,
+    providers: result.providers,
+    providerOrder: result.providerOrder,
+  };
 }
 
-export function isProvidersRefreshCurrent(token: ProvidersRefreshToken): boolean {
+export function isProvidersRefreshCurrent(
+  token: ProvidersRefreshToken,
+  snapshot?: ProvidersSnapshot,
+): boolean {
   return (
     providersGeneration === token.generation
     && isDataOwnerGenerationCurrent(token.owner)
+    && (snapshot === undefined || snapshot.dataOwnerId === token.owner.dataOwnerId)
   );
 }
 
 /** 仅提交当前代际的完整快照，并一次通知所有 mounted hooks。 */
 export function commitProvidersSnapshot(
   token: ProvidersRefreshToken,
-  next: ProviderView[],
+  next: ProvidersSnapshot,
 ): boolean {
-  if (!isProvidersRefreshCurrent(token)) return false;
-  cachedProviders = { dataOwnerId: token.owner.dataOwnerId, providers: next };
+  if (!isProvidersRefreshCurrent(token, next)) return false;
+  cachedProviders = next;
   for (const listener of providerListeners) listener(next);
   return true;
 }

--- a/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
+++ b/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
@@ -5,14 +5,25 @@
  * agent capabilities；这样 useProviders.refetch 可以复用联合刷新而不形成循环依赖。
  */
 import type { ProviderView } from '@cindy/model-providers';
+import {
+  getDataOwnerGeneration,
+  isDataOwnerGenerationCurrent,
+  type DataOwnerGeneration,
+} from '@/contexts/dataOwnerGeneration';
 
-let cachedProviders: ProviderView[] | null = null;
+interface ProvidersRefreshToken {
+  generation: number;
+  owner: DataOwnerGeneration;
+}
+
+let cachedProviders: { dataOwnerId: string | null; providers: ProviderView[] } | null = null;
 let providersGeneration = 0;
 const providerListeners = new Set<(providers: ProviderView[]) => void>();
 
-/** 返回最近一次完整 provider 快照；尚未成功加载时为 null。 */
+/** 返回当前 data owner 最近一次完整 provider 快照；未加载或归属不符时为 null。 */
 export function getCachedProvidersSnapshot(): ProviderView[] | null {
-  return cachedProviders;
+  const { dataOwnerId } = getDataOwnerGeneration();
+  return cachedProviders?.dataOwnerId === dataOwnerId ? cachedProviders.providers : null;
 }
 
 /** 订阅完整 provider 快照提交。 */
@@ -24,9 +35,12 @@ export function subscribeProvidersSnapshot(
 }
 
 /** 为一次 provider 快照读取分配代际；更早请求完成后不得再覆盖缓存。 */
-export function beginProvidersRefresh(): number {
+export function beginProvidersRefresh(): ProvidersRefreshToken {
   providersGeneration += 1;
-  return providersGeneration;
+  return {
+    generation: providersGeneration,
+    owner: getDataOwnerGeneration(),
+  };
 }
 
 /** 读取 provider 快照。失败向上抛，由联合刷新保留上一份有效缓存。 */
@@ -35,17 +49,27 @@ export async function loadProvidersSnapshot(): Promise<ProviderView[]> {
   return result.providers;
 }
 
-export function isProvidersRefreshCurrent(generation: number): boolean {
-  return providersGeneration === generation;
+export function isProvidersRefreshCurrent(token: ProvidersRefreshToken): boolean {
+  return (
+    providersGeneration === token.generation
+    && isDataOwnerGenerationCurrent(token.owner)
+  );
 }
 
 /** 仅提交当前代际的完整快照，并一次通知所有 mounted hooks。 */
 export function commitProvidersSnapshot(
-  generation: number,
+  token: ProvidersRefreshToken,
   next: ProviderView[],
 ): boolean {
-  if (!isProvidersRefreshCurrent(generation)) return false;
-  cachedProviders = next;
+  if (!isProvidersRefreshCurrent(token)) return false;
+  cachedProviders = { dataOwnerId: token.owner.dataOwnerId, providers: next };
   for (const listener of providerListeners) listener(next);
   return true;
 }
+
+export const __testing = {
+  reset(): void {
+    cachedProviders = null;
+    providersGeneration = 0;
+  },
+};

--- a/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
+++ b/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
@@ -24,7 +24,7 @@ export interface ProvidersSnapshot {
 
 let cachedProviders: ProvidersSnapshot | null = null;
 let providersGeneration = 0;
-const providerListeners = new Set<(snapshot: ProvidersSnapshot) => void>();
+const providerListeners = new Set<(snapshot: ProvidersSnapshot | null) => void>();
 
 /** 返回当前 data owner 最近一次完整 provider 快照；未加载或归属不符时为 null。 */
 export function getCachedProvidersSnapshot(): ProvidersSnapshot | null {
@@ -34,10 +34,17 @@ export function getCachedProvidersSnapshot(): ProvidersSnapshot | null {
 
 /** 订阅完整 provider 快照提交。 */
 export function subscribeProvidersSnapshot(
-  listener: (snapshot: ProvidersSnapshot) => void,
+  listener: (snapshot: ProvidersSnapshot | null) => void,
 ): () => void {
   providerListeners.add(listener);
   return () => providerListeners.delete(listener);
+}
+
+/** Owner 切换时同步清空旧快照，并通知已挂载的消费者立即隐藏旧 owner 数据。 */
+export function invalidateProvidersSnapshot(): void {
+  cachedProviders = null;
+  providersGeneration += 1;
+  for (const listener of providerListeners) listener(null);
 }
 
 /** 为一次 provider 快照读取分配代际；更早请求完成后不得再覆盖缓存。 */

--- a/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
+++ b/apps/desktop/src/renderer/lib/providersSnapshotStore.ts
@@ -18,6 +18,8 @@ interface ProvidersRefreshToken {
 
 export interface ProvidersSnapshot {
   dataOwnerId: string | null;
+  /** Main app-session generation that leases owner-scoped provider writes. */
+  ownerGeneration: number;
   providers: ProviderView[];
   providerOrder: string[];
 }
@@ -61,6 +63,7 @@ export async function loadProvidersSnapshot(): Promise<ProvidersSnapshot> {
   const result = await window.electronAPI.maker.listProviders();
   return {
     dataOwnerId: result.dataOwnerId,
+    ownerGeneration: result.ownerGeneration,
     providers: result.providers,
     providerOrder: result.providerOrder,
   };

--- a/apps/desktop/src/renderer/styles/sortable.css
+++ b/apps/desktop/src/renderer/styles/sortable.css
@@ -83,6 +83,33 @@
   border-radius: 8px;
 }
 
+/* 设置页供应商行的浮起 clone 脱离卡片后补回卡片背景；阴影只使用主题语义 token，
+   Light / Dark 同源，不另写模式补丁。 */
+.provider-settings-sortable-row.xdt-sortable-drag {
+  background-color: var(--settings-theme-card-bg);
+  border-radius: 8px;
+  box-shadow: var(--shadow-menu);
+}
+
+/* 供应商列表整行都是拖动热区，紧凑手柄只作为 hover / keyboard 的辅助提示。
+   手柄绝对定位在选中背景内部，仅在左缘保留最小固定间距；显隐不会引发布局跳动。 */
+.provider-settings-sortable-row .provider-order-handle {
+  opacity: 0;
+  transition: opacity var(--motion-fast) var(--motion-ease-move);
+}
+.provider-settings-sortable-row:hover .provider-order-handle,
+.provider-settings-sortable-row:focus-within .provider-order-handle,
+.provider-settings-sortable-row.xdt-sortable-ghost .provider-order-handle,
+.provider-settings-sortable-row.xdt-sortable-drag .provider-order-handle {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .provider-settings-sortable-row .provider-order-handle {
+    transition: none;
+  }
+}
+
 /* 右侧栏 tab strip 是面板 chrome,不继承普通 sidebar 行的浮卡背景 / 阴影。
    clone 挂到 body 后补 panel 背景,保持与原 tab 同一视觉层;docs/design-rules/cindy-design-system.md 的 chrome
    仍是纯平面,拖动只靠位置与原位 ghost 表达,不额外制造阴影。 */

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3925,6 +3925,7 @@ interface ElectronAPI {
     // 模型供应商目录（只读）—— 内置目录元数据 + 各供应商实时连接状态。
     listProviders: () => Promise<{
       dataOwnerId: string | null;
+      ownerGeneration: number;
       providers: import('@cindy/model-providers').ProviderView[];
       providerOrder: string[];
     }>;
@@ -4101,6 +4102,7 @@ interface ElectronAPI {
     /** Persist the visible provider order only if the active owner still matches. */
     setProviderOrder: (
       dataOwnerId: string | null,
+      ownerGeneration: number,
       providerIds: string[],
     ) => Promise<{ ok: true }>;
     getModelPriceOverride: (

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -4098,8 +4098,11 @@ interface ElectronAPI {
         // reset = 恢复默认:删除该供应商整组停用 override(含指向已下架模型的陈旧条目)。
         | { kind: 'reset'; providerId: string },
     ) => Promise<{ ok: true }>;
-    /** Persist the currently visible provider order for the active owner. */
-    setProviderOrder: (providerIds: string[]) => Promise<{ ok: true }>;
+    /** Persist the visible provider order only if the active owner still matches. */
+    setProviderOrder: (
+      dataOwnerId: string | null,
+      providerIds: string[],
+    ) => Promise<{ ok: true }>;
     getModelPriceOverride: (
       target: import('../shared/modelPriceOverride').ModelPriceOverrideTarget,
     ) => Promise<import('../shared/modelPriceOverride').ModelPriceOverrideView>;

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -4094,6 +4094,8 @@ interface ElectronAPI {
         // reset = 恢复默认:删除该供应商整组停用 override(含指向已下架模型的陈旧条目)。
         | { kind: 'reset'; providerId: string },
     ) => Promise<{ ok: true }>;
+    /** Persist the currently visible provider order for the active owner. */
+    setProviderOrder: (providerIds: string[]) => Promise<{ ok: true }>;
     getModelPriceOverride: (
       target: import('../shared/modelPriceOverride').ModelPriceOverrideTarget,
     ) => Promise<import('../shared/modelPriceOverride').ModelPriceOverrideView>;

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3923,7 +3923,11 @@ interface ElectronAPI {
     ) => Promise<import('../shared/workflow-progress').WorkflowProgress | null>;
 
     // 模型供应商目录（只读）—— 内置目录元数据 + 各供应商实时连接状态。
-    listProviders: () => Promise<{ providers: import('@cindy/model-providers').ProviderView[] }>;
+    listProviders: () => Promise<{
+      dataOwnerId: string | null;
+      providers: import('@cindy/model-providers').ProviderView[];
+      providerOrder: string[];
+    }>;
     /** 复用各内置供应商既有真源刷新模型清单。 */
     refreshBuiltinProviderModels: (
       providerId: import('../shared/providerModelRefresh').BuiltinRefreshableProviderId,

--- a/apps/desktop/src/shared/__tests__/providerOrder.test.ts
+++ b/apps/desktop/src/shared/__tests__/providerOrder.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyProviderOrder,
+  mergeObservedProviderOrder,
+  mergeVisibleProviderOrder,
+  normalizeProviderOrder,
+} from '../providerOrder.js';
+
+describe('provider display order', () => {
+  it('normalizes persisted values to bounded unique non-empty ids', () => {
+    expect(normalizeProviderOrder(['openai', '', 'openai', 42, 'anthropic'])).toEqual([
+      'openai',
+      'anthropic',
+    ]);
+  });
+
+  it('applies known ids first and appends newly introduced providers in source order', () => {
+    const providers = [{ id: 'xd' }, { id: 'anthropic' }, { id: 'openai' }, { id: 'xai' }];
+    expect(
+      applyProviderOrder(providers, ['openai', 'missing', 'xd']).map((provider) => provider.id),
+    ).toEqual(['openai', 'xd', 'anthropic', 'xai']);
+  });
+
+  it('reorders visible providers without moving hidden provider slots', () => {
+    expect(
+      mergeVisibleProviderOrder(
+        ['xd', 'hidden-anthropic', 'openai', 'hidden-xai', 'custom'],
+        ['custom', 'xd', 'openai'],
+      ),
+    ).toEqual(['custom', 'hidden-anthropic', 'xd', 'hidden-xai', 'openai']);
+  });
+
+  it('rejects an invalid visible permutation by preserving the current order', () => {
+    expect(mergeVisibleProviderOrder(['xd', 'openai'], ['xd', 'unknown'])).toEqual([
+      'xd',
+      'openai',
+    ]);
+  });
+
+  it('appends newly observed providers before applying the visible order', () => {
+    expect(
+      mergeObservedProviderOrder(['xd', 'hidden-anthropic'], ['custom', 'xd', 'openai']),
+    ).toEqual(['custom', 'hidden-anthropic', 'xd', 'openai']);
+  });
+});

--- a/apps/desktop/src/shared/providerOrder.ts
+++ b/apps/desktop/src/shared/providerOrder.ts
@@ -1,0 +1,93 @@
+/**
+ * Provider display-order helpers shared by Main and Renderer.
+ *
+ * The persisted value is an override, not a catalog snapshot: known ids follow the
+ * user's explicit order and providers introduced later append in catalog order.
+ */
+
+export const MAX_PROVIDER_ORDER_ITEMS = 4096;
+export const MAX_PROVIDER_ORDER_ID_LENGTH = 256;
+
+/** Normalize untrusted persisted data without allowing duplicate or unbounded ids. */
+export function normalizeProviderOrder(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  const order: string[] = [];
+  const seen = new Set<string>();
+  for (const value of raw) {
+    if (
+      typeof value !== 'string' ||
+      value.length === 0 ||
+      value.length > MAX_PROVIDER_ORDER_ID_LENGTH ||
+      seen.has(value)
+    ) {
+      continue;
+    }
+    seen.add(value);
+    order.push(value);
+    if (order.length >= MAX_PROVIDER_ORDER_ITEMS) break;
+  }
+  return order;
+}
+
+/** Apply an explicit display order while appending unseen providers in source order. */
+export function applyProviderOrder<T extends { id: string }>(
+  providers: readonly T[],
+  order: readonly string[],
+): T[] {
+  const byId = new Map(providers.map((provider) => [provider.id, provider]));
+  const result: T[] = [];
+  const included = new Set<string>();
+  for (const id of order) {
+    const provider = byId.get(id);
+    if (!provider || included.has(id)) continue;
+    included.add(id);
+    result.push(provider);
+  }
+  for (const provider of providers) {
+    if (included.has(provider.id)) continue;
+    included.add(provider.id);
+    result.push(provider);
+  }
+  return result;
+}
+
+/**
+ * Replace only the visible providers' slots in a full catalog order. This keeps
+ * currently hidden/disconnected providers stable when the settings list is reordered.
+ */
+export function mergeVisibleProviderOrder(
+  currentOrder: readonly string[],
+  reorderedVisibleIds: readonly string[],
+): string[] {
+  const reorderedSet = new Set(reorderedVisibleIds);
+  if (reorderedSet.size !== reorderedVisibleIds.length) return [...currentOrder];
+  const currentSet = new Set(currentOrder);
+  if (reorderedVisibleIds.some((id) => !currentSet.has(id))) {
+    return [...currentOrder];
+  }
+  let visibleIndex = 0;
+  return currentOrder.map((id) =>
+    reorderedSet.has(id) ? reorderedVisibleIds[visibleIndex++]! : id,
+  );
+}
+
+/**
+ * Add providers the first time they appear, then apply the visible-list order while
+ * retaining previously observed providers that are currently hidden.
+ */
+export function mergeObservedProviderOrder(
+  currentOrder: readonly string[],
+  reorderedVisibleIds: readonly string[],
+): string[] {
+  if (new Set(reorderedVisibleIds).size !== reorderedVisibleIds.length) {
+    return [...currentOrder];
+  }
+  const expanded = [...currentOrder];
+  const seen = new Set(currentOrder);
+  for (const id of reorderedVisibleIds) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    expanded.push(id);
+  }
+  return mergeVisibleProviderOrder(expanded, reorderedVisibleIds);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

在 Desktop「设置 → 模型供应商」左栏加入整行拖动排序，并将用户顺序作为 owner-scoped 本地偏好持久化。默认顺序以 Cindy AI 开头；新添加或首次识别到的供应商依次追加；暂时断开或隐藏的供应商保留原来的排序槽位。

供应商显示顺序通过 `provider:list` 下发给 Renderer，而 Main 内部的默认模型解析与 first-match 路由继续使用目录原序，不受拖动影响。Desktop 本地模型选择器现有数据源同样消费这份显示顺序；#1332 合入后，本地供应商分组会直接跟随本 PR 的排序。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1335；兼容 #1332 的供应商分组展示
- 本 PR 包含：整行拖动与键盘排序、hover/focus 拖动提示、owner-scoped 顺序存储、受信任 IPC 写入、显示投影、四语言文案及单元测试
- 明确不包含：#1332 的模型选择器分组 UI、云端跨设备同步、恢复默认顺序入口、供应商内部模型排序
- 用户可见变化：左栏可直接拖动供应商行；六点提示仅在 hover/focus/拖动时出现；排序重启后保留
- 是否存在 breaking change：无

### 远程与手机版适配

- SSH 远程工作区：已适配，无需 SSH 专用通道。SSH 会话的设置与模型选择器仍运行在本机 Desktop Renderer，并直接消费当前 owner 的本地显示顺序；偏好只写入本机 userData 的 `provider-order-prefs.json`，不读取 workdir、不控制远端 agent 进程，也不读写远端会话数据。
- 设备互联远程控制：不开放排序写入。`maker:provider:order:set` 属于被控端全局设置写，按 device-link 默认拒绝和“远程不可修改被控端全局设置”的准入规则不加入 invoke allowlist。远程只读 `maker:provider:list` 仍用于镜像供应商目录，但隧道投影会剥除本地 `providerOrder` 与 owner lease；Desktop 远程模型选择器在 `deviceId` 非空时明确保留被控端目录原序。
- 手机版：不新增入口或 UI。手机版是被控 Desktop 会话的控制端；供应商配置仍引导用户在电脑端完成。手机模型选择器只消费隧道返回的供应商目录和模型可见性，并按目录原序分段，不提供修改被控端全局供应商排序的入口。

### UI 变化

macOS 开发版已实机验证拖动、点击选中、重启保留顺序、hover 提示和紧凑间距；本 PR 未上传用户测试截图。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §5 Spacing System / Whitespace Philosophy（紧凑手柄与等距留白）、§10 Light / Dark Dual-Mode Delivery Gate 与 Token Selection Rules（全部颜色复用语义 token）、§14.2 Focus Management、§14.3 Keyboard（方向键排序）、§14.4 Motion & Transitions（复用 motion token，并支持 reduced motion）

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-provider-drag-order
结果：GATE_EXIT=0；全仓 18,650 passed，2 skipped

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/__tests__/providersSectionDeepLink.test.tsx src/renderer/__tests__/providersSectionUnavailableModels.test.tsx src/main/maker-host/__tests__/provider-order-store.test.ts src/main/maker-host/__tests__/providerService.test.ts src/main/maker-ipc/__tests__/providerHandlers.test.ts src/shared/__tests__/providerOrder.test.ts
结果：6 files / 119 tests passed

pnpm check:i18n-glossary
结果：通过

pnpm check:dco
结果：1 commit signed off

git diff --check
结果：通过
```

### 手工验证

- 平台：macOS，Global 开发版，直接运行功能 worktree
- 已验证：整行拖动排序、点击仍可选中、重启后顺序保留、拖动提示 hover 时出现、手柄位于选中背景内且左右留白紧凑
- 已由维护者在本轮开发过程中实机确认视觉效果

### 未执行的验证

- Dark 模式未单独实机目检；实现只使用现有语义 token
- `pnpm --filter desktop lint` 当前在 `origin/main` 基线上已有 149 个 ESLint errors / 3 warnings；本 PR 定向 lint 仅命中 `providerHandlers.ts` 与 `register.ts` 的 5 个既有、未改行错误，未混入无关修复

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：owner-scoped 本地显示偏好持久化

### 影响与回滚

- 影响范围：Desktop 本机供应商设置左栏与本地模型选择器的显示顺序；Main 内部路由顺序、device-link 控制端与手机版均保持目录原序。写入 IPC 仅允许受信任的本地主 Renderer，未加入 device-link 写 allowlist
- 回滚 / 降级方式：revert 本提交即可；已经生成的 `provider-order-prefs.json` 会成为无害的未消费偏好文件
- 存量插件影响：无
- SQLite / migration、system prompt、协议、原生层、fingerprint / OTA：均不涉及

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；无需新增共享文档
- [x] 已确认测试结果或说明未执行原因
