### PR TITLE
test(desktop): 修复 Windows 路径断言

### DIFF
--- a/apps/desktop/src/main/__tests__/installCliCommand.test.ts
+++ b/apps/desktop/src/main/__tests__/installCliCommand.test.ts
@@ -36,15 +36,13 @@ describe('CLI_COMMAND_NAME 跟随 edition 品牌', () => {
 
 describe('resolveBundledCliPath', () => {
   it('由 resourcesPath 推出包内 cli/cindy', () => {
-    expect(resolveBundledCliPath('/Applications/Cindy.app/Contents/Resources')).toBe(
-      '/Applications/Cindy.app/Contents/Resources/cli/cindy',
-    );
+    const resourcesPath = '/Applications/Cindy.app/Contents/Resources';
+    expect(resolveBundledCliPath(resourcesPath)).toBe(path.join(resourcesPath, 'cli', 'cindy'));
   });
 
   it('路径含空格也正确', () => {
-    expect(resolveBundledCliPath('/Users/a/My Apps/Cindy.app/Contents/Resources')).toBe(
-      '/Users/a/My Apps/Cindy.app/Contents/Resources/cli/cindy',
-    );
+    const resourcesPath = '/Users/a/My Apps/Cindy.app/Contents/Resources';
+    expect(resolveBundledCliPath(resourcesPath)).toBe(path.join(resourcesPath, 'cli', 'cindy'));
   });
 });
 

--- a/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -1123,7 +1124,7 @@ describe('PluginMarketService 自定义市场 detail/install', () => {
     // 已安装目录同样可能被外部进程/同步盘改动,且摘要读取在每次市场快照都会
     // 执行;所有此类读取必须走 readBoundedFileNoFollow 系列(单句柄限量闸)。
     const source = await fs.promises.readFile(
-      path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'service.ts'),
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'service.ts'),
       'utf8',
     );
     expect(source).not.toMatch(/fs\.promises\.readFile\(/);

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
@@ -316,7 +316,7 @@ describe('discoverMarketplace', () => {
     expect(result.marketplace.skippedCount).toBe(1);
   });
 
-  it('validates and reads ghost.json through one file handle, never by pathname', async () => {
+  it('validates and reads ghost.json through one file handle', async () => {
     const root = makeRoot();
     writePlugin(root, 'plugins/good', 'good-one');
     writeManifest(root, { name: 'lib', plugins: [{ name: 'good', source: 'plugins/good' }] });
@@ -335,10 +335,12 @@ describe('discoverMarketplace', () => {
     try {
       const result = await discoverMarketplace(root);
       expect(result.ok).toBe(true);
-      expect(pathReads.some((target) => target.endsWith('ghost.json'))).toBe(false);
-      expect(
-        lstatSpy.mock.calls.some((call) => String(call[0]).endsWith('ghost.json')),
-      ).toBe(false);
+      expect(pathReads.some((target) => path.basename(target) === 'ghost.json')).toBe(false);
+      const lstatByPath = lstatSpy.mock.calls.some(
+        (call) => path.basename(String(call[0])) === 'ghost.json',
+      );
+      // Windows 没有 O_NOFOLLOW，安全读取器必须用 lstat + inode 对账回退。
+      expect(lstatByPath).toBe(fs.constants.O_NOFOLLOW == null);
     } finally {
       readSpy.mockRestore();
       lstatSpy.mockRestore();

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-parse.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-parse.test.ts
@@ -1,8 +1,10 @@
+import path from 'node:path';
+
 import { describe, expect, it } from 'vitest';
 
 import { parseMarketSource, resolveLocalSourcePath } from '../sources/parse';
 
-const HOME = '/home/tester';
+const HOME = path.join(path.parse(process.cwd()).root, 'home', 'tester');
 
 function parse(input: { source: string; ref?: string; sparsePaths?: string[] }) {
   return parseMarketSource(input, HOME);
@@ -72,7 +74,7 @@ describe('parseMarketSource', () => {
     const result = parse({ source: '~/team/plugins' });
     expect(result).toEqual({
       ok: true,
-      source: { type: 'local', path: `${HOME}/team/plugins` },
+      source: { type: 'local', path: path.join(HOME, 'team', 'plugins') },
     });
   });
 
@@ -140,7 +142,7 @@ describe('parseMarketSource', () => {
   });
 
   it('resolves local paths without touching the filesystem', () => {
-    expect(resolveLocalSourcePath('~/a/b', HOME)).toBe(`${HOME}/a/b`);
+    expect(resolveLocalSourcePath('~/a/b', HOME)).toBe(path.join(HOME, 'a', 'b'));
   });
 
   it('rejects backslash in git URL authority (WHATWG/git 分歧,凭证闸失明)', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 6 个仅在 Windows 失败的 Desktop 单元测试。测试现在使用平台原生路径构造、`fileURLToPath(import.meta.url)`，并按 Windows 缺少 `O_NOFOLLOW` 时的既有安全回退行为断言。

本 PR **仅修改测试用例，不修改生产代码或插件基座**。虽然 3 个文件位于 `plugin-market/__tests__`，但没有改变插件运行时、沙箱、批准状态、能力 slot、manifest 契约、安装布局、权限确认 UI 或已装列表投影，因此不应触发插件基座白名单审核。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Windows 单元测试失败
- 本 PR 包含：
  - 用 `path.join` 构造平台原生期望路径
  - 用 `fileURLToPath` 正确解析 Windows 文件 URL
  - 让单句柄读取测试覆盖 Windows 的 `lstat + inode` 安全回退
- 明确不包含：生产实现、插件基座、插件兼容逻辑、UI 或文案
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/installCliCommand.test.ts src/main/plugin-market/__tests__/sources-parse.test.ts src/main/plugin-market/__tests__/sources-discover.test.ts src/main/plugin-market/__tests__/service-custom-sources.test.ts
结果：4 个文件、110 个测试全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过
```

### 手工验证

不涉及；本 PR 仅修复自动化测试断言。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 单元测试；生产代码不变
- 存量插件影响：无；仅修改测试文件
- 插件基座白名单：不涉及，不需要白名单审核
- 回滚 / 降级方式：回退本提交即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及文档变更）
- [x] 已确认测试结果或说明未执行原因
