### PR TITLE
fix(codex): xAI 回放加密 reasoning 时剥掉 codex 多序列化的键

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2326,7 +2326,9 @@ describe('codex proxy host', () => {
       ],
       input: [
         { type: 'message', role: 'system', content: 'BASE_PROMPT\n\nPRODUCT_PROMPT' },
-        { type: 'reasoning', id: 'rs_1', encrypted_content: 'gAAA' },
+        // summary 恒定补齐(缺省 []):xAI 要求回放的 reasoning 始终带 summary,
+        // 与 anthropic-responses-bridge 的回放形状同口径。
+        { type: 'reasoning', id: 'rs_1', summary: [], encrypted_content: 'gAAA' },
         {
           type: 'function_call',
           id: 'ctc_1',
@@ -2462,6 +2464,80 @@ describe('codex proxy host', () => {
         expect(out.tools).toEqual([{ type: 'function', name: 'read_file' }]);
       },
     );
+  });
+
+  // codex 的结构体会把自己没用上的 Option 字段一并序列化(实测 `content: null`),
+  // 那是 xAI 从没发过的键;带着它回放,上游判定「blob 被改过」→ 整轮 400
+  // "Could not decode the compaction blob. Ensure it is unmodified from the compact response."
+  // (2026-08-02 实测:新会话里首个把 reasoning 回放进 input[] 的请求必挂,重试同样挂。)
+  describe('xAI 加密 reasoning 回放形状', () => {
+    async function runXaiReasoningTransforms(
+      suffix: string,
+      body: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> {
+      const host = await freshCodexProxyHost();
+      const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+      mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+        url: 'http://127.0.0.1:43210',
+        dispose: vi.fn(async () => undefined),
+      });
+      await host.ensureCodexProxyReady();
+      const sessionId = `session-reasoning-shape-${suffix}`;
+      const threadId = `thread-reasoning-shape-${suffix}`;
+      host.registerComposed(sessionId, threadId, 'PRODUCT_PROMPT');
+      setSessionProvider(sessionId, 'xai');
+
+      const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+      const ctx = { method: 'POST', url: '/responses', headers: { 'thread-id': threadId } };
+      let current: unknown = body;
+      for (const transform of transforms) {
+        const next = transform(current, ctx);
+        if (next !== null && next !== undefined) current = next;
+      }
+      clearSessionProvider(sessionId);
+      return current as Record<string, unknown>;
+    }
+
+    const reasoningItemFrom = (input: unknown[]): Record<string, unknown> =>
+      input.find(
+        (item): item is Record<string, unknown> =>
+          typeof item === 'object' && item !== null && (item as { type?: unknown }).type === 'reasoning',
+      ) ?? {};
+
+    it('剥掉 codex 多序列化出来的键，只留 Responses 契约里的四个', async () => {
+      const out = await runXaiReasoningTransforms('strips-extra-keys', {
+        model: 'xai/grok-4.5',
+        input: [
+          {
+            type: 'reasoning',
+            id: 'rs_keep_me',
+            summary: [{ type: 'summary_text', text: 'thinking' }],
+            // codex 实际发出来的形态:自己没用上的 Option 字段照样序列化。
+            content: null,
+            internal_chat_message_metadata_passthrough: { turn_id: 't1' },
+            encrypted_content: 'BLOB-KEEP',
+          },
+        ],
+      });
+
+      const reasoning = reasoningItemFrom(out.input as unknown[]);
+      expect(Object.keys(reasoning).sort()).toEqual(['encrypted_content', 'id', 'summary', 'type']);
+      // blob 必须逐字不动 —— 改一个字节上游就解不开。
+      expect(reasoning.encrypted_content).toBe('BLOB-KEEP');
+      expect(reasoning.summary).toEqual([{ type: 'summary_text', text: 'thinking' }]);
+      expect(reasoning.id).toBe('rs_keep_me');
+    });
+
+    it('codex 不发 id 时不编造一个（实测 xAI 不需要 id 也能解开 blob）', async () => {
+      const out = await runXaiReasoningTransforms('no-id', {
+        model: 'xai/grok-4.5',
+        input: [{ type: 'reasoning', summary: [], content: null, encrypted_content: 'BLOB-NO-ID' }],
+      });
+
+      const reasoning = reasoningItemFrom(out.input as unknown[]);
+      expect(Object.keys(reasoning).sort()).toEqual(['encrypted_content', 'summary', 'type']);
+      expect(reasoning.encrypted_content).toBe('BLOB-NO-ID');
+    });
   });
 
   it('leaves custom_tool_call history untouched for non-xAI requests', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2528,6 +2528,19 @@ describe('codex proxy host', () => {
       expect(reasoning.id).toBe('rs_keep_me');
     });
 
+    // 键名都在允许列表里、但 id 的值是空串:只数键名会判定「没变」,把原对象原样
+    // 发出去 —— 等于算出了规范形状又扔掉。
+    it('id 是空串时也要真的剥掉，而不是当作“没变”原样透传', async () => {
+      const out = await runXaiReasoningTransforms('empty-id', {
+        model: 'xai/grok-4.5',
+        input: [{ type: 'reasoning', id: '', summary: [], encrypted_content: 'BLOB-EMPTY-ID' }],
+      });
+
+      const reasoning = reasoningItemFrom(out.input as unknown[]);
+      expect(Object.keys(reasoning).sort()).toEqual(['encrypted_content', 'summary', 'type']);
+      expect(reasoning.encrypted_content).toBe('BLOB-EMPTY-ID');
+    });
+
     it('codex 不发 id 时不编造一个（实测 xAI 不需要 id 也能解开 blob）', async () => {
       const out = await runXaiReasoningTransforms('no-id', {
         model: 'xai/grok-4.5',

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1165,6 +1165,25 @@ function normalizeXaiInputItem(item: unknown): { item: unknown; changed: boolean
     return changed ? { item: next, changed: true } : { item: base, changed: false };
   }
 
+  // 回放的 reasoning 项必须逐字回到上游签发时的形状 —— xAI 校验不过就整轮 400
+  // "Could not decode the compaction blob. Ensure it is unmodified from the compact response."
+  // codex 的结构体会把自己没用上的 `Option` 字段一并序列化(实测 `content: null`),
+  // 那是 xAI 从没发过的键;带着它回放等于「被改过」。这里收敛成 Responses 契约里
+  // reasoning 该有的四个键 —— 与 anthropic-responses-bridge 回放的形状同口径
+  // (那条路上的 grok-4.5 一直是通的)。
+  // encrypted_content / summary / id 原样搬,一个字节都不改写。
+  if (type === 'reasoning') {
+    const next: Record<string, unknown> = { type: 'reasoning' };
+    if (typeof base.id === 'string' && base.id.length > 0) next.id = base.id;
+    next.summary = Array.isArray(base.summary) ? base.summary : [];
+    if (typeof base.encrypted_content === 'string') next.encrypted_content = base.encrypted_content;
+    const changed =
+      typedFromEasy ||
+      !Array.isArray(base.summary) ||
+      Object.keys(base).some((key) => !['type', 'id', 'summary', 'encrypted_content'].includes(key));
+    return changed ? { item: next, changed: true } : { item: base, changed: false };
+  }
+
   if (type === 'message') {
     let changed = typedFromEasy;
     const next: Record<string, unknown> = { type: 'message' };

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1177,9 +1177,14 @@ function normalizeXaiInputItem(item: unknown): { item: unknown; changed: boolean
     if (typeof base.id === 'string' && base.id.length > 0) next.id = base.id;
     next.summary = Array.isArray(base.summary) ? base.summary : [];
     if (typeof base.encrypted_content === 'string') next.encrypted_content = base.encrypted_content;
+    // changed 必须覆盖「键在允许列表里、但值被上面丢掉了」的情况(如 id 是空串
+    // 或非 string):只数键名会让这些项拿着原值原样发出去 —— 等于算出了规范形状
+    // 又扔掉。逐字段比对 next 与 base,判定和构造才是同一套口径。
     const changed =
       typedFromEasy ||
       !Array.isArray(base.summary) ||
+      ('id' in base && next.id !== base.id) ||
+      ('encrypted_content' in base && next.encrypted_content !== base.encrypted_content) ||
       Object.keys(base).some((key) => !['type', 'id', 'summary', 'encrypted_content'].includes(key));
     return changed ? { item: next, changed: true } : { item: base, changed: false };
   }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 引擎 + `xai/grok-4.5` 的会话，在模型第一次调完工具、拿着工具结果继续推理时**必挂**，点重试同样挂，会话直接废掉：

```json
{"code":"invalid-argument","error":"Could not decode the compaction blob. Ensure it is unmodified from the compact response."}
```

根因是**回放形状**，不是压缩、不是鉴权、也不是 blob 本身。codex 的结构体会把自己没用上的 `Option` 字段一并序列化，发出去的 reasoning 项带着 `content: null` —— 而这个键 xAI 从来没发过。上游据此判定「这份密文被人动过」，整轮 400。报错文案里的 "unmodified" 就是字面意思。

同一约定在 Claude Code 那条路上早已处理：`anthropic-responses-bridge` 回放时重新构造 `{type, id?, summary, encrypted_content}`，不带任何多余键 —— 所以同一个 grok-4.5 在 CC 引擎下一直是通的，只有 Codex 这条路会挂。

本 PR 在 xAI 兼容改写（`normalizeXaiInputItem`）里把回放的 reasoning 项收敛成同样的四个键。`encrypted_content` / `summary` / `id` 原样搬，一个字节都不改写。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无 issue，来自用户反馈（Grok 4.5 + Codex 每轮报 compaction blob 解码失败）。仓外同类报告：[Wei-Shaw/sub2api#4223](https://github.com/Wei-Shaw/sub2api/issues/4223)、[chenyme/grok2api#688](https://github.com/chenyme/grok2api/issues/688)
- 本 PR 包含：`normalizeXaiInputItem` 的 `reasoning` 分支 + 3 条新回归用例。第二个 commit 是对自动 review 意见的回应：`changed` 的判定原本只数键名，会漏掉「键合法但值非法」（如 `id` 是空串）的情况，导致算出的规范形状被扔掉、原对象原样发出
- 明确不包含：
  - **`INVALID_ENCRYPTED_CONTENT_RE` 不动**。xAI 这句报错至今匹配不上那条正则，所以这类 400 拿不到透明重试。本 PR 修的是病因，兜底是另一件事（风险与验证方式都不同），单独开 PR
  - **不引入 reasoning item id 回填**。见下方实验，id 被证明非必要，不值得为它引入跨请求状态
  - 其它 provider 的回放形状不动
- 用户可见变化：Codex 引擎下的 grok 会话不再在首次工具往返后卡死
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：130 passed

pnpm test:unit
结果：EXIT=0，56 个 workspace 全 PASS，0 FAIL
```

第二个 commit 新增的用例 `id 是空串时也要真的剥掉` 已确认在修复前会红
（`AssertionError: expected [ 'encrypted_content', 'id', …(2) ]`），不是只跟着实现走的摆设断言。

### 手工验证

macOS，`pnpm restart:desktop:remote --region=global`，真实 SuperGrok 订阅。每轮均为**全新会话**（Codex 引擎 + `xai/grok-4.5` + effort high）+ 一次触发工具调用的提问，并用 `XDT_CODEX_PROXY_DUMP_TRANSFORMED_BODY=1` 抓取真正发往 `api.x.ai` 的 body 逐项核对：

| 发出去的 reasoning 形状 | 结果 |
| --- | --- |
| `content:null` + 无 id（改前基线） | ❌ 400 |
| `content:null` + **有 id** | ❌ 400 |
| 无 `content` + 有 id | ✅ 通过 |
| 无 `content` + **无 id** | ✅ 通过 |

**唯一起作用的变量是剥掉 `content`。** 第二行排除了 id 因素，第四行证明 id 非必要 —— 因此没有引入 id 回填（那需要一套「响应侧记忆 blob→id、请求侧回填」的跨请求状态，实测不需要，已删除）。

最后一轮为两个独立会话、各 3 次请求、各回放 2 条 reasoning，全程 0 报错。

排查过程中另外两项排除（均有 dump 佐证）：

- 同一 thread 两次请求的前缀逐字相同（2 条 system + 2 条 user、`tools`、`reasoning`、`prompt_cache_key`）→ 排除「blob 绑定请求前缀」
- 发出去的 blob 与 codex rollout 里记录的原文逐字相等（214/214）→ 排除「我们改坏了 blob」

### 未执行的验证

- 未在 Windows 上验证。改动是纯 JSON 形状归一化，无平台相关逻辑
- 未验证 `xai/grok-4.5` 以外的 xAI 模型。该分支对所有 xAI 路由生效，但只在 grok-4.5 上实测过
- `pnpm test:unit` 在本地会**偶发 SIGSEGV**：`apps/desktop` 那一档的 vitest worker
  （`--pool=threads --maxWorkers=8`，含原生模块）被 Segmentation fault 杀掉，runner 报成
  `TEST_ASSERTION_FAILED`，但日志里**没有任何失败用例名、没有断言输出**。四次全量执行中
  两次崩、两次 `EXIT=0`；单独跑 `apps/desktop` 那一档为 PASS（92.3s）；最后一次在确认无任何
  Electron 进程的情况下全量干净通过（EXIT=0，56 workspace 全 PASS）。崩溃与同机跑着 dev
  实例相关，但**只是相关性，未证实因果**（早先也有一次 dev 在跑却通过）。已排除与本 PR
  改动相关：崩溃点在 worker 进程层，不产生断言失败，且改前的 main 上同样存在。最终以 CI 为准

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 xAI 路由（`createXaiResponsesCompatTransform` 已按 provider + wire model 双重门控）下 Codex 请求体里 `input[]` 的 `reasoning` 项。不触碰服务端契约、不改 `cindy-protocol`、不影响 ChatGPT 订阅直连 / 网关 / 其它自定义供应商
- 回滚方式：revert 本 commit 即可，无数据面残留、无持久化状态
- **需要评审单独看一眼的一处**：`summary` 现在恒定补齐（缺省 `[]`）。这是 xAI 对回放 reasoning 的要求，与 bridge 侧同口径，但它超出了「只删 `content`」的最小改动，并改到了 `codexProxyHost.test.ts` 里一条既有用例的期望值（该用例的合成输入本来不带 `summary`）。改期望值是因为契约变了，不是为了让测试变绿而放宽断言

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动点的 why 写在代码注释里）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)

