### PR TITLE
feat(desktop): add composer send shortcut preference

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/anthropicModelDiscovery.test.ts
@@ -42,6 +42,12 @@ const oauthRefreshMock = vi.hoisted(() => ({
 }));
 vi.mock('../claude-oauth-refresh.js', () => oauthRefreshMock);
 
+// HTTP discovery tests inject global fetch responses; keep the production
+// proxy-aware transport out of this unit's network boundary.
+vi.mock('../outbound-fetch.js', () => ({
+  outboundFetch: (input: RequestInfo | URL, init?: RequestInit) => globalThis.fetch(input, init),
+}));
+
 import {
   evaluateHttpShrink,
   isDegenerateModelListShrink,

--- a/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/grokAuthRejectionRecovery.test.ts
@@ -44,6 +44,12 @@ vi.mock('../nativeProviderAuthBinding.js', () => ({
   }),
 }));
 
+// The recovery tests inject global fetch responses; keep the production
+// proxy-aware transport out of this unit's network boundary.
+vi.mock('../outbound-fetch.js', () => ({
+  outboundFetch: (input: RequestInfo | URL, init?: RequestInit) => globalThis.fetch(input, init),
+}));
+
 import {
   logoutGrok,
   recoverGrokAuthAfterRejection,

--- a/apps/desktop/src/main/mcp-integrations/__tests__/android.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/android.test.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from 'node:events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { existsSyncMock, spawnMock } = vi.hoisted(() => ({
+const { existsSyncMock, outboundFetchMock, spawnMock } = vi.hoisted(() => ({
   existsSyncMock: vi.fn(),
+  outboundFetchMock: vi.fn(),
   spawnMock: vi.fn(),
 }));
 
@@ -39,6 +40,10 @@ vi.mock('electron', () => ({
     getPath: vi.fn((name: string) => (name === 'temp' ? '/tmp' : '/Users/tester')),
     getAppPath: vi.fn(() => '/repo/apps/desktop'),
   },
+}));
+
+vi.mock('../../maker-host/outbound-fetch.js', () => ({
+  outboundFetch: (...args: unknown[]) => outboundFetchMock(...args),
 }));
 
 import {
@@ -163,6 +168,7 @@ describe('android mcp integration', () => {
   beforeEach(() => {
     spawnMock.mockReset();
     existsSyncMock.mockReset();
+    outboundFetchMock.mockReset();
     existsSyncMock.mockReturnValue(false);
     clearAndroidStateSnapshotsForTest();
     setAndroidAutomationSettingsReaderForTest(null);
@@ -706,14 +712,13 @@ emulator-5554 device product:sdk_gphone64_arm64 model:Pixel_8 device:emu transpo
     const archSpy = vi.spyOn(process, 'arch', 'get').mockReturnValue('x64');
     setAndroidPlatformToolsDownloadTimeoutForTest(1);
     mockAdbSpawn({ error: Object.assign(new Error('spawn adb ENOENT'), { code: 'ENOENT' }) });
-    const fetchMock = vi.fn((_url: string, init?: { signal?: AbortSignal }) => (
+    outboundFetchMock.mockImplementation((_url: string, init?: { signal?: AbortSignal }) => (
       new Promise<Response>((_resolve, reject) => {
         init?.signal?.addEventListener('abort', () => {
           reject(Object.assign(new Error('download aborted'), { name: 'AbortError' }));
         }, { once: true });
       })
     ));
-    vi.stubGlobal('fetch', fetchMock);
 
     try {
       const result = await prepareAndroidAdb();
@@ -725,7 +730,7 @@ emulator-5554 device product:sdk_gphone64_arm64 model:Pixel_8 device:emu transpo
       });
       expect(slashPath(result.path)).toBe('/Users/tester/android-platform-tools/linux-x64/platform-tools/adb');
       expect(result.error).toContain('Android platform-tools download timed out after 1ms');
-      expect(fetchMock).toHaveBeenCalledWith(
+      expect(outboundFetchMock).toHaveBeenCalledWith(
         'https://dl.google.com/android/repository/platform-tools-latest-linux.zip',
         { signal: expect.any(AbortSignal) },
       );

--- a/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
+++ b/apps/desktop/src/main/utility-model/__tests__/oneShotCandidates.test.ts
@@ -51,9 +51,14 @@ vi.mock('../../secrets/providerSecretStore.js', () => ({
   readCustomProviderKey: vi.fn(),
 }));
 
-vi.mock('undici', () => ({
-  fetch: vi.fn(),
+vi.mock('../../maker-host/outbound-proxy-resolver.js', () => ({
+  resolveDesktopOutboundProxy: vi.fn(async () => null),
 }));
+
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, fetch: vi.fn() };
+});
 
 // SUT 链(maker-host/runtime-configs → effectiveXdGatewayBaseUrl)运行期读
 // model-access 下发的 endpoint;mock 成 fixture 值。

--- a/apps/desktop/src/main/voice-input/__tests__/CodexResponsesTextModelClient.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/CodexResponsesTextModelClient.test.ts
@@ -1,13 +1,16 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // CodexResponsesTextModelClient uses undici.fetch + Agent for the shared
-// keepalive pool. Stub them so the tests stay hermetic; Agent is a no-op since
-// we don't exercise pool behavior here.
+// keepalive pool. Keep the real Undici exports and replace only fetch so the
+// tests stay hermetic without changing the transport module's shape.
 const undiciFetchMock = vi.fn();
-vi.mock('undici', () => ({
-  fetch: (...args: unknown[]) => undiciFetchMock(...args),
-  Agent: class { /* no-op stub */ },
-}));
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    fetch: (...args: unknown[]) => undiciFetchMock(...args),
+  };
+});
 
 import { CodexResponsesTextModelClient } from '../CodexResponsesTextModelClient.js';
 

--- a/apps/desktop/src/main/voice-input/__tests__/LiteLlmTextModelClient.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/LiteLlmTextModelClient.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const undiciFetchMock = vi.fn();
-vi.mock('undici', () => ({
-  fetch: (...args: unknown[]) => undiciFetchMock(...args),
-  Agent: class { /* no-op stub */ },
-}));
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    fetch: (...args: unknown[]) => undiciFetchMock(...args),
+  };
+});
 
 import { LiteLlmTextModelClient } from '../LiteLlmTextModelClient.js';
 import { isRefinerModelOutputError } from '../refinerErrorKind.js';

--- a/apps/desktop/src/main/voice-input/__tests__/LiteLlmTranscriptionProvider.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/LiteLlmTranscriptionProvider.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+const outboundFetchMock = vi.hoisted(() => vi.fn());
+vi.mock('../../maker-host/outbound-fetch.js', () => ({
+  outboundFetch: (...args: unknown[]) => outboundFetchMock(...args),
+}));
+
 import {
   LiteLlmTranscriptionProvider,
   transcribeLiteLlmAudioFile,
@@ -8,13 +13,13 @@ import type { AsrEvent } from '@cindy/voice-input-core';
 
 describe('LiteLlmTranscriptionProvider', () => {
   afterEach(() => {
-    vi.unstubAllGlobals();
+    outboundFetchMock.mockReset();
   });
 
   it('posts captured audio to LiteLLM using ElevenLabs Scribe v2', async () => {
     let requestUrl = '';
     let requestInit: RequestInit | undefined;
-    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    outboundFetchMock.mockImplementation(async (url: string | URL | Request, init?: RequestInit) => {
       requestUrl = String(url);
       requestInit = init;
       return new Response(JSON.stringify({ text: 'hello world' }), {
@@ -22,7 +27,6 @@ describe('LiteLlmTranscriptionProvider', () => {
         headers: { 'Content-Type': 'application/json' },
       });
     });
-    vi.stubGlobal('fetch', fetchMock);
 
     const events: AsrEvent[] = [];
     const provider = new LiteLlmTranscriptionProvider({
@@ -47,14 +51,13 @@ describe('LiteLlmTranscriptionProvider', () => {
 
   it('posts an existing audio file to LiteLLM and returns trimmed text', async () => {
     let requestInit: RequestInit | undefined;
-    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    outboundFetchMock.mockImplementation(async (_url: string | URL | Request, init?: RequestInit) => {
       requestInit = init;
       return new Response(JSON.stringify({ text: '  mobile voice  ' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
       });
     });
-    vi.stubGlobal('fetch', fetchMock);
 
     const text = await transcribeLiteLlmAudioFile({
       proxyApiKey: 'sk-test',

--- a/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
@@ -10,8 +10,7 @@ const chatInputSource = readFileSync(
 /**
  * ChatInput 列表接续接线契约:
  * - Shift/Alt+Enter 优先处理结构化列表，再兼容旧纯文本列表;
- * - 普通 Enter 一律保持"发送"语义,绝不被列表接续拦截(2026-07 产品定案:
- *   Enter=发送的肌肉记忆优先);
+ * - 普通 Enter 不由列表接续拦截,发送或原生换行由共享快捷键 resolver 决定;
  * - 守住 IME composition 边界。
  * 结构化与旧纯文本接续行为由各自的编辑器测试覆盖。
  */
@@ -27,7 +26,7 @@ describe('ChatInput list continuation wiring contract', () => {
     const block = extractBetween(
       chatInputSource,
       '// Shift/Alt+Enter — split or exit a structured item.',
-      '// Plain Enter keeps the existing queue semantics.',
+      '// Resolve the configurable send shortcut after structured list handling.',
     );
     expect(block).toContain('(event.shiftKey || event.altKey) &&');
     expect(block).toContain('!event.metaKey');
@@ -65,14 +64,15 @@ describe('ChatInput list continuation wiring contract', () => {
     );
   });
 
-  it('never intercepts plain Enter — send semantics stay untouched', () => {
+  it('keeps plain Enter outside list continuation — the resolver owns its semantics', () => {
     const plainEnterBlock = extractBetween(
       chatInputSource,
-      '// Plain Enter keeps the existing queue semantics.',
-      "void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');",
+      '// Resolve the configurable send shortcut after structured list handling.',
+      "if (enterIntent === 'queue' || enterIntent === 'steer') {",
     );
     expect(plainEnterBlock).not.toContain('handleStructuredListBreak');
     expect(plainEnterBlock).not.toContain('applyListContinuation');
+    expect(plainEnterBlock).toContain('resolveComposerEnterIntent(');
   });
 
   it('keeps tabular-nums on the editor so multi-line list prefixes align', () => {

--- a/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputListContinuation.test.ts
@@ -35,6 +35,7 @@ describe('ChatInput list continuation wiring contract', () => {
     expect(block).toContain(
       'if (handleStructuredListBreak(view) || applyListContinuation(view)) {',
     );
+    expect(block).not.toContain('resolveComposerEnterIntent');
     // 非列表行必须放行给 ComposerHardBreak 默认换行
     expect(block).toContain('return false;');
   });

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -122,7 +122,8 @@ describe('ChatInput steer shortcut contract', () => {
     expect(modeB(makeEnterEvent({ shiftKey: true }))).toBeNull();
     expect(modeB(makeEnterEvent({ altKey: true }))).toBeNull();
     expect(modeB(makeEnterEvent({ isComposing: true }))).toBe('native');
-    expect(modeB(makeEnterEvent({ repeat: true }))).toBe('ignore');
+    expect(modeB(makeEnterEvent({ repeat: true }))).toBe('native');
+    expect(modeB(makeEnterEvent({ metaKey: true, repeat: true }))).toBe('ignore');
   });
 
   it('wires Settings preference updates to ChatInput copy while preserving row-level steer', () => {

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -41,10 +41,13 @@ describe('ChatInput steer shortcut contract', () => {
     expect(chatInputSource).toContain('const composerCanSubmitRef = useRef(false);');
     expect(chatInputSource).toContain('composerCanSubmitRef.current = !sendButtonDisabled;');
     expect(windowKeydownBlock).toContain('showStopButtonRef.current');
+    expect(windowKeydownBlock).toContain('const platform = window.electronAPI?.platform;');
     expect(windowKeydownBlock).toContain('isComposerEnterTarget(event.target)');
     expect(windowKeydownBlock).toContain('resolveComposerEnterIntent(');
     expect(windowKeydownBlock).toContain('getComposerSendShortcutPreference()');
-    expect(windowKeydownBlock).toContain('const isModifiedEnter = event.metaKey || event.ctrlKey;');
+    expect(windowKeydownBlock).toContain(
+      'const isModifiedEnter = hasComposerModifier(event, platform);',
+    );
     expect(windowKeydownBlock).toContain("(enterIntent === 'queue' || enterIntent === 'steer')");
     expect(windowKeydownBlock).toContain("currentState !== 'listening'");
     expect(windowKeydownBlock).toContain('void dispatchSendRef.current(enterIntent);');
@@ -55,6 +58,7 @@ describe('ChatInput steer shortcut contract', () => {
     expect(editorEnterBlock).toContain('resolveComposerEnterIntent(');
     expect(editorEnterBlock).toContain('getComposerSendShortcutPreference()');
     expect(editorEnterBlock).toContain('turnRunning: showStopButtonRef.current');
+    expect(editorEnterBlock).toContain('platform: window.electronAPI?.platform');
     expect(editorEnterBlock).toContain("if (enterIntent === 'native') return false;");
     expect(editorEnterBlock).toContain("if (enterIntent === 'ignore')");
     expect(editorEnterBlock).toContain('void dispatchSendRef.current(enterIntent);');
@@ -85,24 +89,32 @@ describe('ChatInput steer shortcut contract', () => {
   });
 
   it('keeps mode A queue and running-turn steer semantics on the Tiptap path', () => {
-    expect(resolveComposerEnterIntent(makeEnterEvent(), 'enter', { turnRunning: false })).toBe(
-      'queue',
-    );
+    expect(
+      resolveComposerEnterIntent(makeEnterEvent(), 'enter', {
+        turnRunning: false,
+        platform: 'darwin',
+      }),
+    ).toBe('queue');
     expect(
       resolveComposerEnterIntent(makeEnterEvent({ metaKey: true }), 'enter', {
         turnRunning: true,
+        platform: 'darwin',
       }),
     ).toBe('steer');
     expect(
       resolveComposerEnterIntent(makeEnterEvent({ ctrlKey: true }), 'enter', {
         turnRunning: false,
+        platform: 'darwin',
       }),
     ).toBe('queue');
   });
 
   it('maps mode B modifier send and native/boundary cases without list interception', () => {
     const modeB = (event: ComposerEnterEvent): ComposerEnterIntent =>
-      resolveComposerEnterIntent(event, 'modifier-enter', { turnRunning: true });
+      resolveComposerEnterIntent(event, 'modifier-enter', {
+        turnRunning: true,
+        platform: 'darwin',
+      });
 
     expect(modeB(makeEnterEvent())).toBe('native');
     expect(modeB(makeEnterEvent({ metaKey: true }))).toBe('queue');

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -2,6 +2,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+import {
+  resolveComposerEnterIntent,
+  type ComposerEnterEvent,
+  type ComposerEnterIntent,
+} from '@/hooks/useComposerSendShortcutPreference';
+
 const chatInputSource = readFileSync(
   resolve(__dirname, '..', 'components', 'new-chat', 'ChatInput.tsx'),
   'utf8',
@@ -72,7 +78,49 @@ describe('ChatInput steer shortcut contract', () => {
       "const base = t(turnRunning ? 'newChat.pendingQueue.steerRunningTip' : 'newChat.pendingQueue.steerPausedTip');",
     );
   });
+
+  it('keeps mode A queue and running-turn steer semantics on the Tiptap path', () => {
+    expect(resolveComposerEnterIntent(makeEnterEvent(), 'enter', { turnRunning: false })).toBe(
+      'queue',
+    );
+    expect(
+      resolveComposerEnterIntent(makeEnterEvent({ metaKey: true }), 'enter', {
+        turnRunning: true,
+      }),
+    ).toBe('steer');
+    expect(
+      resolveComposerEnterIntent(makeEnterEvent({ ctrlKey: true }), 'enter', {
+        turnRunning: false,
+      }),
+    ).toBe('queue');
+  });
+
+  it('maps mode B modifier send and native/boundary cases without list interception', () => {
+    const modeB = (event: ComposerEnterEvent): ComposerEnterIntent =>
+      resolveComposerEnterIntent(event, 'modifier-enter', { turnRunning: true });
+
+    expect(modeB(makeEnterEvent())).toBe('native');
+    expect(modeB(makeEnterEvent({ metaKey: true }))).toBe('queue');
+    expect(modeB(makeEnterEvent({ ctrlKey: true }))).toBe('queue');
+    expect(modeB(makeEnterEvent({ shiftKey: true }))).toBeNull();
+    expect(modeB(makeEnterEvent({ altKey: true }))).toBeNull();
+    expect(modeB(makeEnterEvent({ isComposing: true }))).toBe('native');
+    expect(modeB(makeEnterEvent({ repeat: true }))).toBe('ignore');
+  });
 });
+
+function makeEnterEvent(overrides: Partial<ComposerEnterEvent> = {}): ComposerEnterEvent {
+  return {
+    key: 'Enter',
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    repeat: false,
+    isComposing: false,
+    ...overrides,
+  };
+}
 
 function extractBetween(sourceBlock: string, startNeedle: string, endNeedle: string): string {
   const start = sourceBlock.indexOf(startNeedle);

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -16,6 +16,10 @@ const pendingQueuePanelSource = readFileSync(
   resolve(__dirname, '..', 'components', 'new-chat', 'PendingQueuePanel.tsx'),
   'utf8',
 ).replace(/\r\n?/g, '\n');
+const composerSettingsSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'settings', 'ComposerSendShortcutSection.tsx'),
+  'utf8',
+).replace(/\r\n?/g, '\n');
 
 describe('ChatInput steer shortcut contract', () => {
   it('routes Cmd/Ctrl+Enter in the composer through steer while a turn is running', () => {
@@ -29,20 +33,21 @@ describe('ChatInput steer shortcut contract', () => {
       '// Resolve the configurable send shortcut after structured list handling.',
       'return false;\n      },\n    },',
     );
-    const windowComposerSteerBlock = extractBetween(
+    const windowComposerCaptureBlock = extractBetween(
       windowKeydownBlock,
-      'if (\n        showStopButtonRef.current &&',
+      'const enterIntent = resolveComposerEnterIntent(',
       "if (\n        currentState === 'listening'",
     );
     expect(chatInputSource).toContain('const composerCanSubmitRef = useRef(false);');
     expect(chatInputSource).toContain('composerCanSubmitRef.current = !sendButtonDisabled;');
     expect(windowKeydownBlock).toContain('showStopButtonRef.current');
     expect(windowKeydownBlock).toContain('isComposerEnterTarget(event.target)');
-    expect(windowKeydownBlock).toContain("event.key === 'Enter'");
-    expect(windowKeydownBlock).toContain('event.metaKey || event.ctrlKey');
-    expect(windowKeydownBlock).toContain('!event.altKey');
+    expect(windowKeydownBlock).toContain('resolveComposerEnterIntent(');
+    expect(windowKeydownBlock).toContain('getComposerSendShortcutPreference()');
+    expect(windowKeydownBlock).toContain('const isModifiedEnter = event.metaKey || event.ctrlKey;');
+    expect(windowKeydownBlock).toContain("(enterIntent === 'queue' || enterIntent === 'steer')");
     expect(windowKeydownBlock).toContain("currentState !== 'listening'");
-    expect(windowKeydownBlock).toContain("void dispatchSendRef.current('steer');");
+    expect(windowKeydownBlock).toContain('void dispatchSendRef.current(enterIntent);');
     expect(chatInputSource).toContain("'Alt-Enter': () => this.editor.commands.setHardBreak()");
     expect(chatInputSource).toContain('ComposerHardBreak');
     expect(chatInputSource).toContain('turnRunning={showStopButton}');
@@ -55,7 +60,7 @@ describe('ChatInput steer shortcut contract', () => {
     expect(editorEnterBlock).toContain('void dispatchSendRef.current(enterIntent);');
     // Tiptap's document is current before React's send-button effect updates
     // composerCanSubmitRef. The resolver must not use that lagging UI mirror.
-    expect(windowComposerSteerBlock).not.toContain('composerCanSubmitRef.current');
+    expect(windowComposerCaptureBlock).not.toContain('composerCanSubmitRef.current');
     expect(editorEnterBlock).not.toContain('composerCanSubmitRef.current');
   });
 
@@ -106,6 +111,18 @@ describe('ChatInput steer shortcut contract', () => {
     expect(modeB(makeEnterEvent({ altKey: true }))).toBeNull();
     expect(modeB(makeEnterEvent({ isComposing: true }))).toBe('native');
     expect(modeB(makeEnterEvent({ repeat: true }))).toBe('ignore');
+  });
+
+  it('wires Settings preference updates to ChatInput copy while preserving row-level steer', () => {
+    expect(composerSettingsSource).toContain('useComposerSendShortcutPreference()');
+    expect(composerSettingsSource).toContain("setPreference(enabled ? 'modifier-enter' : 'enter')");
+    expect(composerSettingsSource).toContain("setPreference('enter');");
+    expect(chatInputSource).toContain('useComposerSendShortcutPreference()');
+    expect(chatInputSource).toContain('getComposerSendShortcutLabel(');
+    expect(chatInputSource).toContain("composerSendShortcutPreference === 'modifier-enter'");
+    expect(chatInputSource).toContain('newChat.sendButton.queueTooltipSendMode');
+    expect(pendingQueuePanelSource).toContain('isPendingQueueSteerShortcut');
+    expect(pendingQueuePanelSource).toContain('void onSteer(entry.clientId);');
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -20,20 +20,14 @@ describe('ChatInput steer shortcut contract', () => {
     );
     const editorEnterBlock = extractBetween(
       chatInputSource,
-      '// Plain Enter keeps the existing queue semantics.',
-      'return true;\n        }\n        return false;',
+      '// Resolve the configurable send shortcut after structured list handling.',
+      'return false;\n      },\n    },',
     );
     const windowComposerSteerBlock = extractBetween(
       windowKeydownBlock,
       'if (\n        showStopButtonRef.current &&',
       "if (\n        currentState === 'listening'",
     );
-    const editorSteerChoice = extractBetween(
-      editorEnterBlock,
-      'const wantsSteer =',
-      "void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');",
-    );
-
     expect(chatInputSource).toContain('const composerCanSubmitRef = useRef(false);');
     expect(chatInputSource).toContain('composerCanSubmitRef.current = !sendButtonDisabled;');
     expect(windowKeydownBlock).toContain('showStopButtonRef.current');
@@ -47,16 +41,16 @@ describe('ChatInput steer shortcut contract', () => {
     expect(chatInputSource).toContain('ComposerHardBreak');
     expect(chatInputSource).toContain('turnRunning={showStopButton}');
     expect(chatInputSource).toContain('onSteer={onQueueSteer ? handleQueueSteer : undefined}');
-    expect(editorEnterBlock).toContain("event.key === 'Enter' && !event.shiftKey && !event.altKey");
-    expect(editorEnterBlock).toContain("voiceInputStateRef.current !== 'listening'");
-    expect(editorEnterBlock).toContain(
-      "void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');",
-    );
+    expect(editorEnterBlock).toContain('resolveComposerEnterIntent(');
+    expect(editorEnterBlock).toContain('getComposerSendShortcutPreference()');
+    expect(editorEnterBlock).toContain('turnRunning: showStopButtonRef.current');
+    expect(editorEnterBlock).toContain("if (enterIntent === 'native') return false;");
+    expect(editorEnterBlock).toContain("if (enterIntent === 'ignore')");
+    expect(editorEnterBlock).toContain('void dispatchSendRef.current(enterIntent);');
     // Tiptap's document is current before React's send-button effect updates
-    // composerCanSubmitRef. The shortcut must not use that lagging UI mirror
-    // to choose between steer and normal queue delivery.
+    // composerCanSubmitRef. The resolver must not use that lagging UI mirror.
     expect(windowComposerSteerBlock).not.toContain('composerCanSubmitRef.current');
-    expect(editorSteerChoice).not.toContain('composerCanSubmitRef.current');
+    expect(editorEnterBlock).not.toContain('composerCanSubmitRef.current');
   });
 
   it('steers without an interrupt confirmation gate (same-turn injection)', () => {

--- a/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/emptyDocSelectionGuard.test.ts
@@ -54,8 +54,8 @@ describe('isBlankParagraphDoc', () => {
     expect(isBlankParagraphDoc(editor.state.doc)).toBe(false);
   });
 
-  // 多段落来自引用回填 / 历史草稿等程序化构造与多段粘贴;Shift/Alt/Mod+Enter 是
-  // hardBreak(留在同一 paragraph 内),plain Enter 是发送,都不产生新段落。
+  // 多段落来自引用回填 / 历史草稿等程序化构造与多段粘贴;Shift/Alt+Enter 是
+  // hardBreak(留在同一 paragraph 内),普通/修饰键 Enter 是否发送由快捷键 resolver 决定。
   it('多个空段落不是真空(多段结构本身是真实内容)', () => {
     const editor = makeEditor();
     editor.commands.setContent({

--- a/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
@@ -66,24 +66,22 @@ describe('ChatInput voice input Enter-to-send contract', () => {
     );
     const enterBlock = extractBetween(
       tiptapKeydownBlock,
-      "if (event.key === 'Enter' && !event.shiftKey && !event.altKey) {",
-      'const wantsSteer =',
+      '// Resolve the configurable send shortcut after structured list handling.',
+      'void voiceInputStopAndSendRef.current(enterIntent);',
     );
 
+    expect(enterBlock).toContain("if (enterIntent === 'queue' || enterIntent === 'steer') {");
     expect(enterBlock).toContain("voiceInputStateRef.current === 'listening'");
     expect(enterBlock).toContain('voiceInputCanStopAndSendRef.current');
     expect(enterBlock).toContain('const isEditorEnterTarget = event.target instanceof Node && view.dom.contains(event.target);');
     expect(enterBlock).toContain('isEditorEnterTarget');
     expect(enterBlock).not.toContain('isComposerEnterTarget(event.target)');
     expect(enterBlock).toContain('!isVoiceInputShortcutMatch(event, voiceShortcutRef.current)');
-    expect(enterBlock).toContain(
-      "(event.metaKey || event.ctrlKey) &&\n              showStopButtonRef.current &&\n              composerCanSubmitRef.current\n                ? 'steer'\n                : 'queue'",
-    );
-    expect(enterBlock).toContain('!event.altKey');
-    expect(enterBlock).toContain('!event.repeat');
-    expect(enterBlock).toContain('!event.isComposing');
+    expect(enterBlock).toContain('resolveComposerEnterIntent(');
+    expect(enterBlock).toContain('getComposerSendShortcutPreference()');
+    expect(enterBlock).toContain('turnRunning: showStopButtonRef.current');
     expect(enterBlock).toContain('event.stopPropagation();');
-    expect(enterBlock).toContain('void voiceInputStopAndSendRef.current(deliveryMode);');
+    expect(chatInputSource).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
   });
 
   it('shows Enter shortcuts in the same label-dot-shortcut tooltip style as the voice input button', () => {

--- a/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
@@ -28,14 +28,15 @@ describe('ChatInput voice input Enter-to-send contract', () => {
     expect(keydownBlock).toContain("currentState === 'listening'");
     expect(keydownBlock).toContain('voiceInputCanStopAndSendRef.current');
     expect(keydownBlock).toContain('isVoiceInputEnterTarget(event.target)');
-    expect(keydownBlock).toContain("event.key === 'Enter'");
+    expect(keydownBlock).toContain('resolveComposerEnterIntent(');
+    expect(keydownBlock).toContain('getComposerSendShortcutPreference()');
+    expect(keydownBlock).toContain('turnRunning: showStopButtonRef.current');
+    expect(keydownBlock).toContain("(enterIntent === 'queue' || enterIntent === 'steer')");
     expect(keydownBlock).toContain('!isVoiceInputShortcutMatch(event, voiceShortcutRef.current)');
-    expect(keydownBlock).toContain(
-      "(event.metaKey || event.ctrlKey) &&\n          showStopButtonRef.current &&\n          composerCanSubmitRef.current\n            ? 'steer'\n            : 'queue'",
-    );
     expect(keydownBlock).toContain('event.preventDefault();');
     expect(keydownBlock).toContain('event.stopPropagation();');
-    expect(keydownBlock).toContain('void voiceInputStopAndSendRef.current(deliveryMode);');
+    expect(keydownBlock).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
+    expect(keydownBlock).not.toContain('composerCanSubmitRef.current');
   });
 
   it('allows voice Enter-to-send only when the event target itself falls back to the document body', () => {
@@ -84,9 +85,26 @@ describe('ChatInput voice input Enter-to-send contract', () => {
     expect(chatInputSource).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
   });
 
-  it('shows Enter shortcuts in the same label-dot-shortcut tooltip style as the voice input button', () => {
-    expect(chatInputSource).toContain("`${t('newChat.chatInput.voiceInput.finishAndSend')} · Enter`");
-    expect(chatInputSource).toContain("`${t('newChat.sendButton.send')} · Enter`");
+  it('uses the configured composer shortcut in send and voice tooltips', () => {
+    expect(chatInputSource).toContain(
+      'const { preference: composerSendShortcutPreference } = useComposerSendShortcutPreference();',
+    );
+    expect(chatInputSource).toContain(
+      'const composerSendShortcutLabel = getComposerSendShortcutLabel(',
+    );
+    expect(chatInputSource).toContain('window.electronAPI?.platform');
+    expect(chatInputSource).toContain(
+      "`${t('newChat.chatInput.voiceInput.finishAndSend')} · ${composerSendShortcutLabel}`",
+    );
+    expect(chatInputSource).toContain(
+      "`${t('newChat.sendButton.send')} · ${composerSendShortcutLabel}`",
+    );
+    expect(chatInputSource).toContain("t('newChat.sendButton.queueTooltipSendMode', {");
+    expect(chatInputSource).toContain('shortcut: composerSendShortcutLabel');
+    expect(chatInputSource).not.toContain(
+      "`${t('newChat.chatInput.voiceInput.finishAndSend')} · Enter`",
+    );
+    expect(chatInputSource).not.toContain("`${t('newChat.sendButton.send')} · Enter`");
   });
 
   it('allows release-to-send while listening before ASR draft arrives', () => {

--- a/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputEnterToSend.test.ts
@@ -30,6 +30,7 @@ describe('ChatInput voice input Enter-to-send contract', () => {
     expect(keydownBlock).toContain('isVoiceInputEnterTarget(event.target)');
     expect(keydownBlock).toContain('resolveComposerEnterIntent(');
     expect(keydownBlock).toContain('getComposerSendShortcutPreference()');
+    expect(keydownBlock).toContain('const platform = window.electronAPI?.platform;');
     expect(keydownBlock).toContain('turnRunning: showStopButtonRef.current');
     expect(keydownBlock).toContain("(enterIntent === 'queue' || enterIntent === 'steer')");
     expect(keydownBlock).toContain('!isVoiceInputShortcutMatch(event, voiceShortcutRef.current)');
@@ -80,6 +81,7 @@ describe('ChatInput voice input Enter-to-send contract', () => {
     expect(enterBlock).toContain('!isVoiceInputShortcutMatch(event, voiceShortcutRef.current)');
     expect(enterBlock).toContain('resolveComposerEnterIntent(');
     expect(enterBlock).toContain('getComposerSendShortcutPreference()');
+    expect(enterBlock).toContain('platform: window.electronAPI?.platform');
     expect(enterBlock).toContain('turnRunning: showStopButtonRef.current');
     expect(enterBlock).toContain('event.stopPropagation();');
     expect(chatInputSource).toContain('void voiceInputStopAndSendRef.current(enterIntent);');

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -195,7 +195,9 @@ import { getNextPermissionMode } from '@/lib/permissionModeCycle';
 import { matchesKeyboardEvent } from '../../../shared/appShortcuts';
 import {
   getComposerSendShortcutPreference,
+  getComposerSendShortcutLabel,
   resolveComposerEnterIntent,
+  useComposerSendShortcutPreference,
 } from '@/hooks/useComposerSendShortcutPreference';
 import { createLogger } from '@/lib/logger';
 import { createComposerDraftSaveScheduler } from '@/lib/composerDraftSaveScheduler';
@@ -911,7 +913,12 @@ export function ChatInput({
 }: ChatInputProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { preference: composerSendShortcutPreference } = useComposerSendShortcutPreference();
   const resolvedPlaceholder = placeholder ?? t('newChat.chatInput.defaultPlaceholder');
+  const composerSendShortcutLabel = getComposerSendShortcutLabel(
+    composerSendShortcutPreference,
+    window.electronAPI?.platform,
+  );
   const steerShortcutLabel = useMemo(
     () => (window.electronAPI?.platform === 'darwin' ? '⌘↵' : 'Ctrl+Enter'),
     [],
@@ -2485,22 +2492,23 @@ export function ChatInput({
         }
       }
 
+      const enterIntent = resolveComposerEnterIntent(
+        event,
+        getComposerSendShortcutPreference(),
+        { turnRunning: showStopButtonRef.current },
+      );
+      const isModifiedEnter = event.metaKey || event.ctrlKey;
       if (
-        showStopButtonRef.current &&
         isComposerEnterTarget(event.target) &&
-        event.key === 'Enter' &&
-        (event.metaKey || event.ctrlKey) &&
-        !event.shiftKey &&
-        !event.altKey &&
-        !event.repeat &&
-        !event.isComposing &&
+        isModifiedEnter &&
+        (enterIntent === 'queue' || enterIntent === 'steer') &&
         currentState !== 'listening'
       ) {
         event.preventDefault();
         event.stopPropagation();
         clearPressTimer();
         voiceShortcutPressRef.current = null;
-        void dispatchSendRef.current('steer');
+        void dispatchSendRef.current(enterIntent);
         return;
       }
 
@@ -2508,24 +2516,14 @@ export function ChatInput({
         currentState === 'listening' &&
         voiceInputCanStopAndSendRef.current &&
         isVoiceInputEnterTarget(event.target) &&
-        event.key === 'Enter' &&
-        !event.shiftKey &&
-        !event.altKey &&
-        !event.repeat &&
-        !event.isComposing &&
+        (enterIntent === 'queue' || enterIntent === 'steer') &&
         !isVoiceInputShortcutMatch(event, voiceShortcutRef.current)
       ) {
         event.preventDefault();
         event.stopPropagation();
         clearPressTimer();
         voiceShortcutPressRef.current = null;
-        const deliveryMode =
-          (event.metaKey || event.ctrlKey) &&
-          showStopButtonRef.current &&
-          composerCanSubmitRef.current
-            ? 'steer'
-            : 'queue';
-        void voiceInputStopAndSendRef.current(deliveryMode);
+        void voiceInputStopAndSendRef.current(enterIntent);
         return;
       }
 
@@ -5784,13 +5782,17 @@ export function ChatInput({
                           voiceReleaseToSendActive
                             ? t('newChat.chatInput.voiceInput.releaseToSend')
                             : voiceInput.isListening && !sendButtonDisabled
-                              ? `${t('newChat.chatInput.voiceInput.finishAndSend')} · Enter`
+                              ? `${t('newChat.chatInput.voiceInput.finishAndSend')} · ${composerSendShortcutLabel}`
                               : showStopButton
-                                ? t('newChat.sendButton.queueTooltip', {
-                                    shortcut: steerShortcutLabel,
-                                  })
+                                ? composerSendShortcutPreference === 'modifier-enter'
+                                  ? t('newChat.sendButton.queueTooltipSendMode', {
+                                      shortcut: composerSendShortcutLabel,
+                                    })
+                                  : t('newChat.sendButton.queueTooltip', {
+                                      shortcut: steerShortcutLabel,
+                                    })
                                 : !sendButtonDisabled
-                                  ? `${t('newChat.sendButton.send')} · Enter`
+                                  ? `${t('newChat.sendButton.send')} · ${composerSendShortcutLabel}`
                                   : selectedSourceDisconnected
                                     ? t('newChat.sourceDisconnected.sendBlocked')
                                     : null

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -196,6 +196,7 @@ import { matchesKeyboardEvent } from '../../../shared/appShortcuts';
 import {
   getComposerSendShortcutPreference,
   getComposerSendShortcutLabel,
+  hasComposerModifier,
   resolveComposerEnterIntent,
   useComposerSendShortcutPreference,
 } from '@/hooks/useComposerSendShortcutPreference';
@@ -2026,7 +2027,7 @@ export function ChatInput({
         const enterIntent = resolveComposerEnterIntent(
           event,
           getComposerSendShortcutPreference(),
-          { turnRunning: showStopButtonRef.current },
+          { turnRunning: showStopButtonRef.current, platform: window.electronAPI?.platform },
         );
         if (enterIntent === 'native') return false;
         if (enterIntent === 'ignore') {
@@ -2478,6 +2479,7 @@ export function ChatInput({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const currentState = voiceInputStateRef.current;
+      const platform = window.electronAPI?.platform;
       if (event.key === 'Escape' && !event.repeat && !event.isComposing) {
         if (
           currentState === 'listening' ||
@@ -2495,9 +2497,9 @@ export function ChatInput({
       const enterIntent = resolveComposerEnterIntent(
         event,
         getComposerSendShortcutPreference(),
-        { turnRunning: showStopButtonRef.current },
+        { turnRunning: showStopButtonRef.current, platform },
       );
-      const isModifiedEnter = event.metaKey || event.ctrlKey;
+      const isModifiedEnter = hasComposerModifier(event, platform);
       if (
         isComposerEnterTarget(event.target) &&
         isModifiedEnter &&

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -193,6 +193,10 @@ import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
 import { getAppShortcutCombos } from '@/lib/appShortcutStore';
 import { getNextPermissionMode } from '@/lib/permissionModeCycle';
 import { matchesKeyboardEvent } from '../../../shared/appShortcuts';
+import {
+  getComposerSendShortcutPreference,
+  resolveComposerEnterIntent,
+} from '@/hooks/useComposerSendShortcutPreference';
 import { createLogger } from '@/lib/logger';
 import { createComposerDraftSaveScheduler } from '@/lib/composerDraftSaveScheduler';
 import {
@@ -2008,42 +2012,36 @@ export function ChatInput({
           return false;
         }
 
-        // Plain Enter keeps the existing queue semantics. Cmd/Ctrl+Enter is
-        // only treated as 插话 while a turn is actually running; otherwise it
-        // falls back to the normal send path so the shortcut never becomes a
-        // "no active turn" footgun on an idle composer.
-        if (event.key === 'Enter' && !event.shiftKey && !event.altKey) {
+        // Resolve the configurable send shortcut after structured list handling.
+        // Native mode keeps Enter available to Tiptap for paragraph breaks and
+        // IME composition; queue/steer modes continue through the existing
+        // send and voice state machines.
+        const enterIntent = resolveComposerEnterIntent(
+          event,
+          getComposerSendShortcutPreference(),
+          { turnRunning: showStopButtonRef.current },
+        );
+        if (enterIntent === 'native') return false;
+        if (enterIntent === 'ignore') {
           event.preventDefault();
+          return true;
+        }
+        if (enterIntent === null) return false;
+
+        event.preventDefault();
+        if (enterIntent === 'queue' || enterIntent === 'steer') {
           const isEditorEnterTarget = event.target instanceof Node && view.dom.contains(event.target);
           if (
             voiceInputStateRef.current === 'listening' &&
             voiceInputCanStopAndSendRef.current &&
             isEditorEnterTarget &&
-            !event.altKey &&
-            !event.repeat &&
-            !event.isComposing &&
             !isVoiceInputShortcutMatch(event, voiceShortcutRef.current)
           ) {
             event.stopPropagation();
-            const deliveryMode =
-              (event.metaKey || event.ctrlKey) &&
-              showStopButtonRef.current &&
-              composerCanSubmitRef.current
-                ? 'steer'
-                : 'queue';
-            void voiceInputStopAndSendRef.current(deliveryMode);
+            void voiceInputStopAndSendRef.current(enterIntent);
             return true;
           }
-          // Do not gate the delivery choice on composerCanSubmitRef here.
-          // Tiptap updates its document synchronously, while that ref mirrors
-          // sendButtonDisabled from a later React effect. A quick Cmd/Ctrl+Enter
-          // after typing could otherwise observe the previous empty state and
-          // incorrectly enqueue instead of steering the running turn.
-          const wantsSteer =
-            (event.metaKey || event.ctrlKey) &&
-            showStopButtonRef.current &&
-            voiceInputStateRef.current !== 'listening';
-          void dispatchSendRef.current(wantsSteer ? 'steer' : 'queue');
+          void dispatchSendRef.current(enterIntent);
           return true;
         }
         return false;

--- a/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Switch } from '@/components/ui/switch';
+import { useComposerSendShortcutPreference } from '@/hooks/useComposerSendShortcutPreference';
+import { toast } from '@/lib/toast';
+import { DefaultOverrideControls } from './DefaultOverrideControls';
+
+export function ComposerSendShortcutSection() {
+  const { t } = useTranslation();
+  const { preference, isCustomized, setPreference } = useComposerSendShortcutPreference();
+  const shortcut = window.electronAPI?.platform === 'darwin' ? '⌘+Enter' : 'Ctrl+Enter';
+
+  const onReset = useCallback(() => {
+    setPreference('enter');
+    toast.success(t('settings.defaults.restored'));
+  }, [setPreference, t]);
+
+  return (
+    <div className="flex flex-col gap-[14px]">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
+          {t('settings.composer.title')}
+        </h2>
+      </div>
+
+      <div className="flex flex-col gap-[14px] rounded-xl border border-[var(--settings-theme-card-border)] bg-[var(--settings-theme-card-bg)] p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-14 font-medium leading-[1.3] text-[var(--text-primary)]">
+              {t('settings.composer.sendShortcut.label', { shortcut })}
+            </p>
+            <p className="mt-1 text-12 leading-[1.5] text-[var(--text-secondary)]">
+              {t('settings.composer.sendShortcut.hint', { shortcut })}
+            </p>
+          </div>
+
+          <div className="flex shrink-0 items-center gap-2">
+            <DefaultOverrideControls isCustomized={isCustomized} onReset={onReset} />
+            <Switch
+              checked={preference === 'modifier-enter'}
+              onCheckedChange={(enabled) => setPreference(enabled ? 'modifier-enter' : 'enter')}
+              aria-label={t('settings.composer.sendShortcut.ariaLabel', { shortcut })}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
@@ -42,7 +42,12 @@ export function ComposerSendShortcutSection() {
             <DefaultOverrideControls isCustomized={isCustomized} onReset={onReset} />
             <Switch
               checked={preference === 'modifier-enter'}
-              onCheckedChange={(enabled) => setPreference(enabled ? 'modifier-enter' : 'enter')}
+              onCheckedChange={(enabled) => {
+                const result = setPreference(enabled ? 'modifier-enter' : 'enter');
+                if (!result.ok && result.conflict === 'composer-voice-input') {
+                  toast.error(t('settings.shortcuts.errors.composerVoiceConflict'));
+                }
+              }}
               aria-label={t('settings.composer.sendShortcut.ariaLabel', { shortcut })}
             />
           </div>

--- a/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComposerSendShortcutSection.tsx
@@ -2,14 +2,17 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Switch } from '@/components/ui/switch';
-import { useComposerSendShortcutPreference } from '@/hooks/useComposerSendShortcutPreference';
+import {
+  getComposerModifierShortcutLabel,
+  useComposerSendShortcutPreference,
+} from '@/hooks/useComposerSendShortcutPreference';
 import { toast } from '@/lib/toast';
 import { DefaultOverrideControls } from './DefaultOverrideControls';
 
 export function ComposerSendShortcutSection() {
   const { t } = useTranslation();
   const { preference, isCustomized, setPreference } = useComposerSendShortcutPreference();
-  const shortcut = window.electronAPI?.platform === 'darwin' ? '⌘+Enter' : 'Ctrl+Enter';
+  const shortcut = getComposerModifierShortcutLabel(window.electronAPI?.platform);
 
   const onReset = useCallback(() => {
     setPreference('enter');

--- a/apps/desktop/src/renderer/components/settings/SettingsView.tsx
+++ b/apps/desktop/src/renderer/components/settings/SettingsView.tsx
@@ -16,6 +16,7 @@ import { McpServersSection } from './McpServersSection';
 import { RemoteControlSection } from './RemoteControlSection';
 import { NotificationSection } from './NotificationSection';
 import { WindowBehaviorSection } from './WindowBehaviorSection';
+import { ComposerSendShortcutSection } from './ComposerSendShortcutSection';
 import { KeyboardShortcutsSection } from './KeyboardShortcutsSection';
 import { AgentIslandSection } from './AgentIslandSection';
 import { LanguageSection } from './LanguageSection';
@@ -290,6 +291,15 @@ export function SettingsView() {
                   aria-label={t('settings.sections.windowBehavior')}
                 >
                   <WindowBehaviorSection />
+                </section>
+
+                {/* Section — Composer send shortcut (应用级、本地输入偏好)。 */}
+                <section
+                  id="settings-composer"
+                  className="py-[18px]"
+                  aria-label={t('settings.sections.composer')}
+                >
+                  <ComposerSendShortcutSection />
                 </section>
 
                 {/* Section — Experimental (py 18)

--- a/apps/desktop/src/renderer/components/settings/VoiceInputSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/VoiceInputSection.tsx
@@ -27,6 +27,7 @@ import {
   type VoiceInputDictionaryEntrySource,
   type VoiceInputLanguage,
 } from '@/hooks/useVoiceInputSettings';
+import { getComposerSendShortcutPreference } from '@/hooks/useComposerSendShortcutPreference';
 import { useVoiceInputModelSelection } from '@/hooks/useVoiceInputModelSelection';
 import { useVoiceInputUsageStats } from '@/hooks/useVoiceInputUsageStats';
 import { useVoiceInputHistory } from '@/hooks/useVoiceInputHistory';
@@ -41,6 +42,7 @@ import {
   findVoiceInputAppShortcutConflict,
   type AppShortcutComboEntry,
 } from '@/voice-input/appShortcutConflict';
+import { findComposerVoiceInputConflict } from '@/voice-input/composerVoiceInputConflict';
 import { shouldShowInputMonitoringBadge } from '@/voice-input/inputMonitoringBadge';
 import {
   createVoiceInputModifierShortcut,
@@ -1342,6 +1344,20 @@ export function VoiceInputSection() {
     [t],
   );
 
+  const showComposerVoiceConflict = useCallback(() => {
+    toast.error(t('settings.shortcuts.errors.composerVoiceConflict'));
+  }, [t]);
+
+  const hasComposerVoiceConflict = useCallback(
+    (shortcut: VoiceInputShortcut | null): boolean =>
+      findComposerVoiceInputConflict(
+        getComposerSendShortcutPreference(),
+        shortcut,
+        window.electronAPI?.platform,
+      ) !== null,
+    [],
+  );
+
   const commitRecordedShortcut = useCallback(
     (shortcut: VoiceInputShortcut | null) => {
       // 提交代次。录制框在这次提交 await 期间仍然开着，用户可以再录一个键提交第二次；
@@ -1357,6 +1373,11 @@ export function VoiceInputSection() {
         if (isStaleSubmission()) return;
         // 被更晚的一轮顶掉：那一轮才决定最终结果，这里静默丢弃，不报错也不收口录制态。
         if (!result.ok && result.errorCode === 'superseded') return;
+        if (!result.ok && result.conflict === 'composer-voice-input') {
+          showComposerVoiceConflict();
+          if (shortcut) setRecordingShortcutPreview(shortcut);
+          return;
+        }
         if (!result.ok) {
           // 'failed' = 原生 listener 起不来。main 已把细节消毒成固定英文（原文含内部
           // 路径），所以这里改用自带下一步的中文文案，不再把那句英文插进模板。
@@ -1389,7 +1410,7 @@ export function VoiceInputSection() {
         if (shortcutCommitPromiseRef.current === commit) shortcutCommitPromiseRef.current = null;
       });
     },
-    [schedulePermissionRefresh, setShortcut, t],
+    [schedulePermissionRefresh, setShortcut, showComposerVoiceConflict, t],
   );
 
   const getAppShortcutEntries = useCallback((): AppShortcutComboEntry[] => {
@@ -1463,6 +1484,10 @@ export function VoiceInputSection() {
         toast.error(t('settings.voiceInput.shortcut.toast.systemReserved'));
         return;
       }
+      if (hasComposerVoiceConflict(shortcut)) {
+        showComposerVoiceConflict();
+        return;
+      }
       const conflictId = findVoiceInputAppShortcutConflict(shortcut, getAppShortcutEntries());
       if (conflictId) {
         showAppShortcutConflict(conflictId);
@@ -1472,7 +1497,15 @@ export function VoiceInputSection() {
       pendingKeyboardShortcutRef.current = shortcut;
       setRecordingShortcutPreview(shortcut);
     },
-    [commitRecordedShortcut, getAppShortcutEntries, recordingShortcut, showAppShortcutConflict, t],
+    [
+      commitRecordedShortcut,
+      getAppShortcutEntries,
+      hasComposerVoiceConflict,
+      recordingShortcut,
+      showAppShortcutConflict,
+      showComposerVoiceConflict,
+      t,
+    ],
   );
 
   const handleShortcutKeyUp = useCallback(
@@ -1527,6 +1560,10 @@ export function VoiceInputSection() {
         pendingKeyboardShortcutRef.current = null;
         setRecordingShortcutPreview(null);
         if (shortcut) {
+          if (hasComposerVoiceConflict(shortcut)) {
+            showComposerVoiceConflict();
+            return;
+          }
           const conflictId = findVoiceInputAppShortcutConflict(shortcut, getAppShortcutEntries());
           if (conflictId) {
             showAppShortcutConflict(conflictId);
@@ -1564,7 +1601,14 @@ export function VoiceInputSection() {
       pendingKeyboardShortcutRef.current = null;
       setRecordingShortcutPreview(null);
     },
-    [commitRecordedShortcut, getAppShortcutEntries, recordingShortcut, showAppShortcutConflict],
+    [
+      commitRecordedShortcut,
+      getAppShortcutEntries,
+      hasComposerVoiceConflict,
+      recordingShortcut,
+      showAppShortcutConflict,
+      showComposerVoiceConflict,
+    ],
   );
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComposerSendShortcutSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComposerSendShortcutSection.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
   success: vi.fn(),
 }));
 
@@ -19,6 +20,8 @@ vi.mock('react-i18next', () => ({
         'settings.defaults.customizedBadge': 'Customized',
         'settings.defaults.restore': 'Restore default',
         'settings.defaults.restored': 'Restored default',
+        'settings.shortcuts.errors.composerVoiceConflict':
+          'Conflicts with the voice input shortcut. Change either shortcut.',
       };
       return (translations[key] ?? key).replace('{{shortcut}}', options?.shortcut ?? '');
     },
@@ -46,10 +49,23 @@ function setPlatform(platform: string): void {
   });
 }
 
+function setVoiceInputShortcut(shortcut: object | null): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      platform: 'darwin',
+      voiceInput: {
+        getDataSnapshot: () => ({ settings: { shortcut } }),
+      },
+    },
+  });
+}
+
 describe('ComposerSendShortcutSection', () => {
   beforeEach(() => {
     localStorage.clear();
     _resetComposerSendShortcutPreferenceForTests();
+    toastMocks.error.mockReset();
     toastMocks.success.mockReset();
     setPlatform('win32');
   });
@@ -92,5 +108,25 @@ describe('ComposerSendShortcutSection', () => {
     expect(switches[0].getAttribute('data-state')).toBe('unchecked');
     expect(switches[1].getAttribute('data-state')).toBe('unchecked');
     expect(toastMocks.success).toHaveBeenCalledWith('Restored default');
+  });
+
+  it('rejects a Composer shortcut that is already used by Voice Input', () => {
+    setVoiceInputShortcut({
+      trigger: 'keyboard',
+      code: 'Enter',
+      key: 'Enter',
+      modifiers: { meta: true, ctrl: false, alt: false, shift: false, fn: false },
+    });
+
+    render(<ComposerSendShortcutSection />);
+
+    const switchControl = screen.getByRole('switch', { name: 'Use ⌘+Enter to send messages' });
+    fireEvent.click(switchControl);
+
+    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBeNull();
+    expect(switchControl.getAttribute('data-state')).toBe('unchecked');
+    expect(toastMocks.error).toHaveBeenCalledWith(
+      'Conflicts with the voice input shortcut. Change either shortcut.',
+    );
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComposerSendShortcutSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComposerSendShortcutSection.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const toastMocks = vi.hoisted(() => ({
+  success: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: { shortcut?: string }) => {
+      const translations: Record<string, string> = {
+        'settings.composer.title': 'Message input',
+        'settings.composer.sendShortcut.label': 'Use {{shortcut}} to send',
+        'settings.composer.sendShortcut.hint':
+          'When enabled, {{shortcut}} sends messages. When disabled, Enter sends messages and Shift+Enter inserts a new line.',
+        'settings.composer.sendShortcut.ariaLabel': 'Use {{shortcut}} to send messages',
+        'settings.defaults.customizedBadge': 'Customized',
+        'settings.defaults.restore': 'Restore default',
+        'settings.defaults.restored': 'Restored default',
+      };
+      return (translations[key] ?? key).replace('{{shortcut}}', options?.shortcut ?? '');
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: toastMocks,
+}));
+
+import {
+  COMPOSER_SEND_SHORTCUT_STORAGE_KEY,
+  _resetComposerSendShortcutPreferenceForTests,
+} from '@/hooks/useComposerSendShortcutPreference';
+import { ComposerSendShortcutSection } from '../ComposerSendShortcutSection';
+
+function setPlatform(platform: string): void {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: { platform },
+  });
+}
+
+describe('ComposerSendShortcutSection', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetComposerSendShortcutPreferenceForTests();
+    toastMocks.success.mockReset();
+    setPlatform('win32');
+  });
+
+  it('shows the default Enter mode and platform-specific shortcut copy', () => {
+    setPlatform('darwin');
+
+    render(<ComposerSendShortcutSection />);
+
+    expect(
+      screen.getByRole('switch', { name: 'Use ⌘+Enter to send messages' }).getAttribute('data-state'),
+    ).toBe('unchecked');
+    expect(screen.queryByText('Use ⌘+Enter to send')).not.toBeNull();
+    expect(
+      screen.queryByText(
+        'When enabled, ⌘+Enter sends messages. When disabled, Enter sends messages and Shift+Enter inserts a new line.',
+      ),
+    ).not.toBeNull();
+  });
+
+  it('synchronizes mode B across subscribers and restores the default override', () => {
+    render(
+      <>
+        <ComposerSendShortcutSection />
+        <ComposerSendShortcutSection />
+      </>,
+    );
+
+    const switches = screen.getAllByRole('switch', { name: 'Use Ctrl+Enter to send messages' });
+    fireEvent.click(switches[0]);
+
+    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBe('modifier-enter');
+    expect(switches[0].getAttribute('data-state')).toBe('checked');
+    expect(switches[1].getAttribute('data-state')).toBe('checked');
+    expect(screen.getAllByText('Customized')).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Restore default' })[0]);
+
+    expect(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY)).toBeNull();
+    expect(switches[0].getAttribute('data-state')).toBe('unchecked');
+    expect(switches[1].getAttribute('data-state')).toBe('unchecked');
+    expect(toastMocks.success).toHaveBeenCalledWith('Restored default');
+  });
+});

--- a/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
@@ -169,11 +169,19 @@ describe('useComposerSendShortcutPreference', () => {
         expected: 'native',
       },
       {
-        name: 'queues with Cmd/Ctrl+Enter in modifier-enter mode',
+        name: 'queues with Cmd+Enter in modifier-enter mode on macOS',
         preference: 'modifier-enter',
         platform: 'darwin',
         turnRunning: true,
         event: enterEvent({ metaKey: true }),
+        expected: 'queue',
+      },
+      {
+        name: 'queues with Ctrl+Enter in modifier-enter mode on macOS',
+        preference: 'modifier-enter',
+        platform: 'darwin',
+        turnRunning: true,
+        event: enterEvent({ ctrlKey: true }),
         expected: 'queue',
       },
       {

--- a/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
@@ -201,6 +201,22 @@ describe('useComposerSendShortcutPreference', () => {
         expected: 'ignore',
       },
       {
+        name: 'keeps a repeated plain Enter native in modifier-enter mode',
+        preference: 'modifier-enter',
+        platform: 'darwin',
+        turnRunning: false,
+        event: enterEvent({ repeat: true }),
+        expected: 'native',
+      },
+      {
+        name: 'ignores a repeated modifier Enter send in modifier-enter mode',
+        preference: 'modifier-enter',
+        platform: 'darwin',
+        turnRunning: false,
+        event: enterEvent({ metaKey: true, repeat: true }),
+        expected: 'ignore',
+      },
+      {
         name: 'leaves IME composition to the native editor path',
         preference: 'enter',
         platform: 'darwin',

--- a/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
@@ -6,6 +6,7 @@ import { act, renderHook } from '@testing-library/react';
 import {
   _resetComposerSendShortcutPreferenceForTests,
   getComposerSendShortcutPreference,
+  getComposerSendShortcutLabel,
   resolveComposerEnterIntent,
   useComposerSendShortcutPreference,
   type ComposerSendShortcutPreference,
@@ -23,6 +24,15 @@ describe('useComposerSendShortcutPreference', () => {
   beforeEach(() => {
     localStorage.clear();
     _resetComposerSendShortcutPreferenceForTests();
+  });
+
+  it.each([
+    ['enter', 'darwin', 'Enter'],
+    ['enter', 'win32', 'Enter'],
+    ['modifier-enter', 'darwin', '⌘+Enter'],
+    ['modifier-enter', 'linux', 'Ctrl+Enter'],
+  ] as const)('formats the send shortcut label for %s on %s', (preference, platform, expected) => {
+    expect(getComposerSendShortcutLabel(preference, platform)).toBe(expected);
   });
 
   it('defaults to Enter and treats the default as not customized', () => {

--- a/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import {
+  _resetComposerSendShortcutPreferenceForTests,
+  getComposerSendShortcutPreference,
+  resolveComposerEnterIntent,
+  useComposerSendShortcutPreference,
+  type ComposerSendShortcutPreference,
+} from '../useComposerSendShortcutPreference';
+
+const KEY = 'chat.sendShortcutPreference';
+
+function enterEvent(
+  overrides: Partial<Pick<KeyboardEvent, 'shiftKey' | 'altKey' | 'metaKey' | 'ctrlKey' | 'repeat' | 'isComposing'>> = {},
+): KeyboardEvent {
+  return new KeyboardEvent('keydown', { key: 'Enter', ...overrides });
+}
+
+describe('useComposerSendShortcutPreference', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetComposerSendShortcutPreferenceForTests();
+  });
+
+  it('defaults to Enter and treats the default as not customized', () => {
+    expect(getComposerSendShortcutPreference()).toBe('enter');
+
+    const { result } = renderHook(() => useComposerSendShortcutPreference());
+
+    expect(result.current.preference).toBe('enter');
+    expect(result.current.isCustomized).toBe(false);
+  });
+
+  it('only accepts the modifier-enter override from storage', () => {
+    localStorage.setItem(KEY, 'modifier-enter');
+    expect(getComposerSendShortcutPreference()).toBe('modifier-enter');
+
+    _resetComposerSendShortcutPreferenceForTests();
+    localStorage.setItem(KEY, 'enter');
+    expect(getComposerSendShortcutPreference()).toBe('enter');
+
+    _resetComposerSendShortcutPreferenceForTests();
+    localStorage.setItem(KEY, 'garbage');
+    expect(getComposerSendShortcutPreference()).toBe('enter');
+  });
+
+  it('persists the non-default override and removes it when reset', () => {
+    const { result } = renderHook(() => useComposerSendShortcutPreference());
+
+    act(() => result.current.setPreference('modifier-enter'));
+    expect(localStorage.getItem(KEY)).toBe('modifier-enter');
+    expect(getComposerSendShortcutPreference()).toBe('modifier-enter');
+    expect(result.current.isCustomized).toBe(true);
+
+    act(() => result.current.setPreference('enter'));
+    expect(localStorage.getItem(KEY)).toBeNull();
+    expect(getComposerSendShortcutPreference()).toBe('enter');
+    expect(result.current.isCustomized).toBe(false);
+  });
+
+  it('updates mounted hooks when another renderer changes the preference', () => {
+    const { result } = renderHook(() => useComposerSendShortcutPreference());
+
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: KEY,
+          newValue: 'modifier-enter',
+        }),
+      );
+    });
+
+    expect(result.current.preference).toBe('modifier-enter');
+    expect(result.current.isCustomized).toBe(true);
+  });
+
+  describe('resolveComposerEnterIntent', () => {
+    const cases: Array<{
+      name: string;
+      preference: ComposerSendShortcutPreference;
+      turnRunning: boolean;
+      event: KeyboardEvent;
+      expected: 'queue' | 'steer' | 'native' | 'ignore' | null;
+    }> = [
+      {
+        name: 'sends with plain Enter in Enter mode',
+        preference: 'enter',
+        turnRunning: false,
+        event: enterEvent(),
+        expected: 'queue',
+      },
+      {
+        name: 'steers with Cmd/Ctrl+Enter while a turn is running in Enter mode',
+        preference: 'enter',
+        turnRunning: true,
+        event: enterEvent({ metaKey: true }),
+        expected: 'steer',
+      },
+      {
+        name: 'queues with Cmd/Ctrl+Enter while idle in Enter mode',
+        preference: 'enter',
+        turnRunning: false,
+        event: enterEvent({ ctrlKey: true }),
+        expected: 'queue',
+      },
+      {
+        name: 'uses native Enter for a newline in modifier-enter mode',
+        preference: 'modifier-enter',
+        turnRunning: true,
+        event: enterEvent(),
+        expected: 'native',
+      },
+      {
+        name: 'queues with Cmd/Ctrl+Enter in modifier-enter mode',
+        preference: 'modifier-enter',
+        turnRunning: true,
+        event: enterEvent({ metaKey: true }),
+        expected: 'queue',
+      },
+      {
+        name: 'ignores a repeated Enter send',
+        preference: 'enter',
+        turnRunning: true,
+        event: enterEvent({ repeat: true }),
+        expected: 'ignore',
+      },
+      {
+        name: 'leaves IME composition to the native editor path',
+        preference: 'enter',
+        turnRunning: false,
+        event: enterEvent({ isComposing: true }),
+        expected: 'native',
+      },
+      {
+        name: 'ignores Shift+Enter so list and hard-break handling can run',
+        preference: 'enter',
+        turnRunning: false,
+        event: enterEvent({ shiftKey: true }),
+        expected: null,
+      },
+      {
+        name: 'ignores Alt+Enter so hard-break handling can run',
+        preference: 'modifier-enter',
+        turnRunning: false,
+        event: enterEvent({ altKey: true }),
+        expected: null,
+      },
+      {
+        name: 'ignores other keys',
+        preference: 'enter',
+        turnRunning: false,
+        event: new KeyboardEvent('keydown', { key: 'Escape' }),
+        expected: null,
+      },
+    ];
+
+    it.each(cases)('$name', ({ preference, turnRunning, event, expected }) => {
+      expect(resolveComposerEnterIntent(event, preference, { turnRunning })).toBe(expected);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
@@ -11,6 +11,7 @@ import {
   useComposerSendShortcutPreference,
   type ComposerSendShortcutPreference,
 } from '../useComposerSendShortcutPreference';
+import { getDefaultVoiceInputSettings } from '../../../shared/voiceInputData';
 
 const KEY = 'chat.sendShortcutPreference';
 
@@ -24,6 +25,15 @@ describe('useComposerSendShortcutPreference', () => {
   beforeEach(() => {
     localStorage.clear();
     _resetComposerSendShortcutPreferenceForTests();
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        platform: 'darwin',
+        voiceInput: {
+          getDataSnapshot: () => ({ settings: getDefaultVoiceInputSettings('darwin') }),
+        },
+      },
+    });
   });
 
   it.each([
@@ -69,6 +79,36 @@ describe('useComposerSendShortcutPreference', () => {
     expect(localStorage.getItem(KEY)).toBeNull();
     expect(getComposerSendShortcutPreference()).toBe('enter');
     expect(result.current.isCustomized).toBe(false);
+  });
+
+  it('keeps the Composer preference unchanged when Voice Input owns Cmd+Enter', () => {
+    const settings = {
+      ...getDefaultVoiceInputSettings('darwin'),
+      shortcut: {
+        trigger: 'keyboard' as const,
+        code: 'Enter',
+        key: 'Enter',
+        modifiers: { meta: true, ctrl: false, alt: false, shift: false, fn: false },
+      },
+    };
+    Object.defineProperty(window, 'electronAPI', {
+      configurable: true,
+      value: {
+        platform: 'darwin',
+        voiceInput: { getDataSnapshot: () => ({ settings }) },
+      },
+    });
+
+    const { result } = renderHook(() => useComposerSendShortcutPreference());
+    let updateResult: ReturnType<typeof result.current.setPreference> | undefined;
+
+    act(() => {
+      updateResult = result.current.setPreference('modifier-enter');
+    });
+
+    expect(updateResult).toEqual({ ok: false, conflict: 'composer-voice-input' });
+    expect(result.current.preference).toBe('enter');
+    expect(localStorage.getItem(KEY)).toBeNull();
   });
 
   it('updates mounted hooks when another renderer changes the preference', () => {

--- a/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts
@@ -131,6 +131,7 @@ describe('useComposerSendShortcutPreference', () => {
     const cases: Array<{
       name: string;
       preference: ComposerSendShortcutPreference;
+      platform: string;
       turnRunning: boolean;
       event: KeyboardEvent;
       expected: 'queue' | 'steer' | 'native' | 'ignore' | null;
@@ -138,6 +139,7 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'sends with plain Enter in Enter mode',
         preference: 'enter',
+        platform: 'darwin',
         turnRunning: false,
         event: enterEvent(),
         expected: 'queue',
@@ -145,6 +147,7 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'steers with Cmd/Ctrl+Enter while a turn is running in Enter mode',
         preference: 'enter',
+        platform: 'darwin',
         turnRunning: true,
         event: enterEvent({ metaKey: true }),
         expected: 'steer',
@@ -152,6 +155,7 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'queues with Cmd/Ctrl+Enter while idle in Enter mode',
         preference: 'enter',
+        platform: 'darwin',
         turnRunning: false,
         event: enterEvent({ ctrlKey: true }),
         expected: 'queue',
@@ -159,6 +163,7 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'uses native Enter for a newline in modifier-enter mode',
         preference: 'modifier-enter',
+        platform: 'darwin',
         turnRunning: true,
         event: enterEvent(),
         expected: 'native',
@@ -166,13 +171,31 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'queues with Cmd/Ctrl+Enter in modifier-enter mode',
         preference: 'modifier-enter',
+        platform: 'darwin',
         turnRunning: true,
         event: enterEvent({ metaKey: true }),
         expected: 'queue',
       },
       {
+        name: 'does not treat Win+Enter as the modifier shortcut on Windows',
+        preference: 'modifier-enter',
+        platform: 'win32',
+        turnRunning: true,
+        event: enterEvent({ metaKey: true }),
+        expected: 'native',
+      },
+      {
+        name: 'does not treat Meta+Enter as the modifier shortcut on Linux',
+        preference: 'modifier-enter',
+        platform: 'linux',
+        turnRunning: true,
+        event: enterEvent({ metaKey: true }),
+        expected: 'native',
+      },
+      {
         name: 'ignores a repeated Enter send',
         preference: 'enter',
+        platform: 'darwin',
         turnRunning: true,
         event: enterEvent({ repeat: true }),
         expected: 'ignore',
@@ -180,6 +203,7 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'leaves IME composition to the native editor path',
         preference: 'enter',
+        platform: 'darwin',
         turnRunning: false,
         event: enterEvent({ isComposing: true }),
         expected: 'native',
@@ -187,6 +211,7 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'ignores Shift+Enter so list and hard-break handling can run',
         preference: 'enter',
+        platform: 'darwin',
         turnRunning: false,
         event: enterEvent({ shiftKey: true }),
         expected: null,
@@ -194,6 +219,7 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'ignores Alt+Enter so hard-break handling can run',
         preference: 'modifier-enter',
+        platform: 'darwin',
         turnRunning: false,
         event: enterEvent({ altKey: true }),
         expected: null,
@@ -201,14 +227,17 @@ describe('useComposerSendShortcutPreference', () => {
       {
         name: 'ignores other keys',
         preference: 'enter',
+        platform: 'darwin',
         turnRunning: false,
         event: new KeyboardEvent('keydown', { key: 'Escape' }),
         expected: null,
       },
     ];
 
-    it.each(cases)('$name', ({ preference, turnRunning, event, expected }) => {
-      expect(resolveComposerEnterIntent(event, preference, { turnRunning })).toBe(expected);
+    it.each(cases)('$name', ({ preference, platform, turnRunning, event, expected }) => {
+      expect(resolveComposerEnterIntent(event, preference, { turnRunning, platform })).toBe(
+        expected,
+      );
     });
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useVoiceInputSettings.shortcutConflict.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useVoiceInputSettings.shortcutConflict.test.ts
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  getDefaultVoiceInputSettings,
+  type VoiceInputSettings,
+} from '../../../shared/voiceInputData';
+import {
+  COMPOSER_SEND_SHORTCUT_STORAGE_KEY,
+  _resetComposerSendShortcutPreferenceForTests,
+} from '../useComposerSendShortcutPreference';
+import { useVoiceInputSettings } from '../useVoiceInputSettings';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  createLogger: () => ({ warn: vi.fn(), debug: vi.fn() }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+const composerVoiceShortcut = {
+  trigger: 'keyboard' as const,
+  code: 'Enter',
+  key: 'Enter',
+  modifiers: { meta: true, ctrl: false, alt: false, shift: false, fn: false },
+};
+
+let settings: VoiceInputSettings;
+let updateShortcutSetting: ReturnType<typeof vi.fn>;
+
+function installElectronApi(): void {
+  updateShortcutSetting = vi.fn(async (shortcut) => {
+    settings = { ...settings, shortcut };
+    return { ok: true, settings };
+  });
+
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      platform: 'darwin',
+      voiceInput: {
+        getDataSnapshot: () => ({ settings }),
+        updateShortcutSetting,
+        updateSettings: vi.fn(),
+        setGlobalShortcut: vi.fn().mockResolvedValue({ ok: true }),
+        onDataChanged: vi.fn(() => () => {}),
+      },
+    },
+  });
+}
+
+describe('useVoiceInputSettings Composer conflict guard', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetComposerSendShortcutPreferenceForTests();
+    settings = { ...getDefaultVoiceInputSettings('darwin'), shortcut: null };
+    installElectronApi();
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'electronAPI');
+  });
+
+  it('rejects a conflicting shortcut before calling the persistence IPC', async () => {
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, 'modifier-enter');
+
+    const { result } = renderHook(() => useVoiceInputSettings());
+    let updateResult!: Awaited<ReturnType<typeof result.current.setShortcut>>;
+
+    await act(async () => {
+      updateResult = await result.current.setShortcut(composerVoiceShortcut);
+    });
+
+    expect(updateResult).toEqual({
+      ok: false,
+      conflict: 'composer-voice-input',
+      error: 'Voice Input shortcut conflicts with the Composer send shortcut',
+    });
+    expect(updateShortcutSetting).not.toHaveBeenCalled();
+    expect(settings.shortcut).toBeNull();
+  });
+
+  it('allows a non-conflicting shortcut through the existing persistence path', async () => {
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, 'modifier-enter');
+    const nonConflictingShortcut = {
+      ...composerVoiceShortcut,
+      modifiers: { meta: false, ctrl: true, alt: false, shift: true, fn: false },
+    };
+
+    const { result } = renderHook(() => useVoiceInputSettings());
+    await act(async () => {
+      await result.current.setShortcut(nonConflictingShortcut);
+    });
+
+    expect(updateShortcutSetting).toHaveBeenCalledWith(nonConflictingShortcut);
+    expect(settings.shortcut).toEqual(nonConflictingShortcut);
+  });
+
+  it('rechecks the current Composer preference when a recording commit is in flight', async () => {
+    const { result } = renderHook(() => useVoiceInputSettings());
+
+    localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, 'modifier-enter');
+    _resetComposerSendShortcutPreferenceForTests();
+
+    let updateResult!: Awaited<ReturnType<typeof result.current.setShortcut>>;
+    await act(async () => {
+      updateResult = await result.current.setShortcut(composerVoiceShortcut);
+    });
+
+    expect(updateResult).toMatchObject({ ok: false, conflict: 'composer-voice-input' });
+    expect(updateShortcutSetting).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
@@ -55,9 +55,13 @@ export function resolveComposerEnterIntent(
 ): ComposerEnterIntent {
   if (event.key !== 'Enter' || event.shiftKey || event.altKey) return null;
   if (event.isComposing) return 'native';
-  if (event.repeat) return 'ignore';
 
   const hasModifier = hasComposerModifier(event, options.platform);
+  if (event.repeat) {
+    const isSendShortcut = preference === 'enter' || hasModifier;
+    return isSendShortcut ? 'ignore' : 'native';
+  }
+
   if (preference === 'modifier-enter') {
     return hasModifier ? 'queue' : 'native';
   }

--- a/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { getVoiceInputSettings } from './useVoiceInputSettings';
 import { findComposerVoiceInputConflict } from '@/voice-input/composerVoiceInputConflict';
+import { hasComposerModifier } from '@/voice-input/composerShortcut';
+
+export { hasComposerModifier } from '@/voice-input/composerShortcut';
 
 export type ComposerSendShortcutPreference = 'enter' | 'modifier-enter';
 
@@ -18,13 +21,6 @@ export type ComposerSendShortcutUpdateResult =
 
 export const COMPOSER_SEND_SHORTCUT_STORAGE_KEY = 'chat.sendShortcutPreference';
 export const DEFAULT_COMPOSER_SEND_SHORTCUT: ComposerSendShortcutPreference = 'enter';
-
-export function hasComposerModifier(
-  event: Pick<ComposerEnterEvent, 'metaKey' | 'ctrlKey'>,
-  platform: string | undefined,
-): boolean {
-  return event.ctrlKey || (platform === 'darwin' && event.metaKey);
-}
 
 export function getComposerModifierShortcutLabel(platform: string | undefined): string {
   return platform === 'darwin' ? '⌘+Enter' : 'Ctrl+Enter';

--- a/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
@@ -19,6 +19,13 @@ export type ComposerSendShortcutUpdateResult =
 export const COMPOSER_SEND_SHORTCUT_STORAGE_KEY = 'chat.sendShortcutPreference';
 export const DEFAULT_COMPOSER_SEND_SHORTCUT: ComposerSendShortcutPreference = 'enter';
 
+export function hasComposerModifier(
+  event: Pick<ComposerEnterEvent, 'metaKey' | 'ctrlKey'>,
+  platform: string | undefined,
+): boolean {
+  return event.ctrlKey || (platform === 'darwin' && event.metaKey);
+}
+
 export function getComposerModifierShortcutLabel(platform: string | undefined): string {
   return platform === 'darwin' ? '⌘+Enter' : 'Ctrl+Enter';
 }
@@ -44,13 +51,13 @@ function parsePreference(raw: string | null): ComposerSendShortcutPreference | n
 export function resolveComposerEnterIntent(
   event: ComposerEnterEvent,
   preference: ComposerSendShortcutPreference,
-  options: { turnRunning: boolean },
+  options: { turnRunning: boolean; platform: string | undefined },
 ): ComposerEnterIntent {
   if (event.key !== 'Enter' || event.shiftKey || event.altKey) return null;
   if (event.isComposing) return 'native';
   if (event.repeat) return 'ignore';
 
-  const hasModifier = event.metaKey || event.ctrlKey;
+  const hasModifier = hasComposerModifier(event, options.platform);
   if (preference === 'modifier-enter') {
     return hasModifier ? 'queue' : 'native';
   }

--- a/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
@@ -1,5 +1,8 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { getVoiceInputSettings } from './useVoiceInputSettings';
+import { findComposerVoiceInputConflict } from '@/voice-input/composerVoiceInputConflict';
+
 export type ComposerSendShortcutPreference = 'enter' | 'modifier-enter';
 
 export type ComposerEnterIntent = 'queue' | 'steer' | 'native' | 'ignore' | null;
@@ -8,6 +11,10 @@ export type ComposerEnterEvent = Pick<
   KeyboardEvent,
   'key' | 'shiftKey' | 'altKey' | 'metaKey' | 'ctrlKey' | 'repeat' | 'isComposing'
 >;
+
+export type ComposerSendShortcutUpdateResult =
+  | { ok: true }
+  | { ok: false; conflict: 'composer-voice-input' };
 
 export const COMPOSER_SEND_SHORTCUT_STORAGE_KEY = 'chat.sendShortcutPreference';
 export const DEFAULT_COMPOSER_SEND_SHORTCUT: ComposerSendShortcutPreference = 'enter';
@@ -71,13 +78,23 @@ export function getComposerSendShortcutPreference(): ComposerSendShortcutPrefere
 export function useComposerSendShortcutPreference(): {
   preference: ComposerSendShortcutPreference;
   isCustomized: boolean;
-  setPreference: (next: ComposerSendShortcutPreference) => void;
+  setPreference: (next: ComposerSendShortcutPreference) => ComposerSendShortcutUpdateResult;
 } {
   const [preference, setState] = useState<ComposerSendShortcutPreference>(
     getComposerSendShortcutPreference,
   );
 
-  const setPreference = useCallback((next: ComposerSendShortcutPreference) => {
+  const setPreference = useCallback((next: ComposerSendShortcutPreference): ComposerSendShortcutUpdateResult => {
+    if (
+      findComposerVoiceInputConflict(
+        next,
+        getVoiceInputSettings().shortcut,
+        window.electronAPI?.platform,
+      )
+    ) {
+      return { ok: false, conflict: 'composer-voice-input' };
+    }
+
     memoryValue = next;
     setState(next);
     try {
@@ -90,6 +107,7 @@ export function useComposerSendShortcutPreference(): {
       // The in-memory value still applies for this renderer.
     }
     listeners.forEach((fn) => fn());
+    return { ok: true };
   }, []);
 
   useEffect(() => {

--- a/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type ComposerSendShortcutPreference = 'enter' | 'modifier-enter';
+
+export type ComposerEnterIntent = 'queue' | 'steer' | 'native' | 'ignore' | null;
+
+export type ComposerEnterEvent = Pick<
+  KeyboardEvent,
+  'key' | 'shiftKey' | 'altKey' | 'metaKey' | 'ctrlKey' | 'repeat' | 'isComposing'
+>;
+
+export const COMPOSER_SEND_SHORTCUT_STORAGE_KEY = 'chat.sendShortcutPreference';
+export const DEFAULT_COMPOSER_SEND_SHORTCUT: ComposerSendShortcutPreference = 'enter';
+
+function parsePreference(raw: string | null): ComposerSendShortcutPreference | null {
+  return raw === 'modifier-enter' ? raw : null;
+}
+
+/**
+ * Decide what the composer should do with an Enter keydown.
+ *
+ * The resolver deliberately does not perform any side effect. Callers can
+ * therefore share the same preference semantics while keeping their own
+ * event-target and delivery plumbing.
+ */
+export function resolveComposerEnterIntent(
+  event: ComposerEnterEvent,
+  preference: ComposerSendShortcutPreference,
+  options: { turnRunning: boolean },
+): ComposerEnterIntent {
+  if (event.key !== 'Enter' || event.shiftKey || event.altKey) return null;
+  if (event.isComposing) return 'native';
+  if (event.repeat) return 'ignore';
+
+  const hasModifier = event.metaKey || event.ctrlKey;
+  if (preference === 'modifier-enter') {
+    return hasModifier ? 'queue' : 'native';
+  }
+
+  if (!hasModifier) return 'queue';
+  return options.turnRunning ? 'steer' : 'queue';
+}
+
+/** Module-level memory is the synchronous source of truth for event handlers. */
+let memoryValue: ComposerSendShortcutPreference | null = null;
+
+const listeners = new Set<() => void>();
+
+export function getComposerSendShortcutPreference(): ComposerSendShortcutPreference {
+  if (memoryValue !== null) return memoryValue;
+  try {
+    const parsed = parsePreference(localStorage.getItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY));
+    if (parsed) return (memoryValue = parsed);
+  } catch {
+    // localStorage may be unavailable in a restricted renderer.
+  }
+  return DEFAULT_COMPOSER_SEND_SHORTCUT;
+}
+
+export function useComposerSendShortcutPreference(): {
+  preference: ComposerSendShortcutPreference;
+  isCustomized: boolean;
+  setPreference: (next: ComposerSendShortcutPreference) => void;
+} {
+  const [preference, setState] = useState<ComposerSendShortcutPreference>(
+    getComposerSendShortcutPreference,
+  );
+
+  const setPreference = useCallback((next: ComposerSendShortcutPreference) => {
+    memoryValue = next;
+    setState(next);
+    try {
+      if (next === DEFAULT_COMPOSER_SEND_SHORTCUT) {
+        localStorage.removeItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY);
+      } else {
+        localStorage.setItem(COMPOSER_SEND_SHORTCUT_STORAGE_KEY, next);
+      }
+    } catch {
+      // The in-memory value still applies for this renderer.
+    }
+    listeners.forEach((fn) => fn());
+  }, []);
+
+  useEffect(() => {
+    const sync = () => setState(getComposerSendShortcutPreference());
+    listeners.add(sync);
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== COMPOSER_SEND_SHORTCUT_STORAGE_KEY) return;
+      memoryValue = parsePreference(event.newValue) ?? DEFAULT_COMPOSER_SEND_SHORTCUT;
+      sync();
+    };
+    window.addEventListener('storage', onStorage);
+    return () => {
+      listeners.delete(sync);
+      window.removeEventListener('storage', onStorage);
+    };
+  }, []);
+
+  return {
+    preference,
+    isCustomized: preference !== DEFAULT_COMPOSER_SEND_SHORTCUT,
+    setPreference,
+  };
+}
+
+/** Test-only reset for the module-level source of truth. */
+export function _resetComposerSendShortcutPreferenceForTests(): void {
+  memoryValue = null;
+  listeners.clear();
+}

--- a/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
+++ b/apps/desktop/src/renderer/hooks/useComposerSendShortcutPreference.ts
@@ -12,6 +12,17 @@ export type ComposerEnterEvent = Pick<
 export const COMPOSER_SEND_SHORTCUT_STORAGE_KEY = 'chat.sendShortcutPreference';
 export const DEFAULT_COMPOSER_SEND_SHORTCUT: ComposerSendShortcutPreference = 'enter';
 
+export function getComposerModifierShortcutLabel(platform: string | undefined): string {
+  return platform === 'darwin' ? '⌘+Enter' : 'Ctrl+Enter';
+}
+
+export function getComposerSendShortcutLabel(
+  preference: ComposerSendShortcutPreference,
+  platform: string | undefined,
+): string {
+  return preference === 'modifier-enter' ? getComposerModifierShortcutLabel(platform) : 'Enter';
+}
+
 function parsePreference(raw: string | null): ComposerSendShortcutPreference | null {
   return raw === 'modifier-enter' ? raw : null;
 }

--- a/apps/desktop/src/renderer/hooks/useVoiceInputSettings.ts
+++ b/apps/desktop/src/renderer/hooks/useVoiceInputSettings.ts
@@ -30,6 +30,8 @@ import {
   type VoiceInputSettings,
 } from '../../shared/voiceInputData';
 import type { VoiceInputShortcut } from '@/voice-input/shortcut';
+import { findComposerVoiceInputConflict } from '@/voice-input/composerVoiceInputConflict';
+import { getComposerSendShortcutPreference } from './useComposerSendShortcutPreference';
 
 export {
   DEFAULT_VOICE_INPUT_REFINEMENT_INSTRUCTIONS,
@@ -145,7 +147,12 @@ export type VoiceInputShortcutUpdateResult =
     pendingInputMonitoring?: boolean;
   }
   // 用 IPC 契约的固定联合而不是裸 string，避免误传/误判不存在的 code。
-  | { ok: false; error: string; errorCode?: VoiceInputGlobalErrorCode };
+  | {
+    ok: false;
+    error: string;
+    errorCode?: VoiceInputGlobalErrorCode;
+    conflict?: 'composer-voice-input';
+  };
 
 /**
  * 录制期挂起全局快捷键。
@@ -314,6 +321,20 @@ export function useVoiceInputSettings(): {
 
   const setShortcut = useCallback(
     async (shortcut: VoiceInputShortcut | null): Promise<VoiceInputShortcutUpdateResult> => {
+      if (
+        findComposerVoiceInputConflict(
+          getComposerSendShortcutPreference(),
+          shortcut,
+          window.electronAPI?.platform,
+        )
+      ) {
+        return {
+          ok: false,
+          conflict: 'composer-voice-input',
+          error: 'Voice Input shortcut conflicts with the Composer send shortcut',
+        };
+      }
+
       try {
         const result = await window.electronAPI.voiceInput.updateShortcutSetting(shortcut);
         if (!result.ok) log.warn('voice input shortcut setting update failed:', result.error);

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -126,6 +126,7 @@
       "subagentModels": "Subagents",
       "compaction": "Context compaction",
       "terminalShell": "Default terminal shell",
+      "composer": "Message input",
       "linkOpen": "Link open behavior",
       "compatMode": "Tips",
       "voiceInput": "Voice input",
@@ -2247,6 +2248,14 @@
         "label": "Default shell",
         "description": "Changing the default only applies to new terminal tabs. Existing terminals are not affected.",
         "selectAria": "Select default terminal shell"
+      }
+    },
+    "composer": {
+      "title": "Message input",
+      "sendShortcut": {
+        "label": "Use {{shortcut}} to send",
+        "hint": "When enabled, {{shortcut}} sends messages. When disabled, Enter sends messages and Shift+Enter inserts a new line.",
+        "ariaLabel": "Use {{shortcut}} to send messages"
       }
     },
     "linkOpen": {
@@ -4722,6 +4731,7 @@
       "send": "Send message",
       "queue": "Queue message",
       "queueTooltip": "Click to queue; press {{shortcut}} to steer without interrupting the task",
+      "queueTooltipSendMode": "Click to queue; press {{shortcut}} to send this message",
       "stop": "Stop generating"
     },
     "pluginSetup": {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2943,6 +2943,7 @@
         "systemReserved": "Reserved by the operating system",
         "conflict": "Conflicts with \"{{name}}\"",
         "voiceConflict": "Conflicts with the voice input shortcut",
+        "composerVoiceConflict": "Conflicts with the voice input shortcut. Change either the composer send shortcut or the voice input shortcut.",
         "menuAccelerator": "This combination cannot be registered as a menu shortcut"
       },
       "items": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2942,7 +2942,7 @@
         "systemReserved": "OS によって予約されています",
         "conflict": "「{{name}}」と競合しています",
         "voiceConflict": "音声入力のショートカットと競合しています",
-        "composerVoiceConflict": "音声入力のショートカットと競合しています。Composer または音声入力のショートカットを変更してください。",
+        "composerVoiceConflict": "音声入力のショートカットと競合しています。メッセージ入力の送信ショートカットまたは音声入力のショートカットを変更してください。",
         "menuAccelerator": "この組み合わせはメニューショートカットとして登録できません"
       },
       "items": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -126,6 +126,7 @@
       "subagentModels": "サブエージェント",
       "compaction": "コンテキスト圧縮",
       "terminalShell": "デフォルトターミナルシェル",
+      "composer": "メッセージ入力",
       "linkOpen": "リンクの開き方",
       "compatMode": "ヒント",
       "voiceInput": "音声入力",
@@ -2246,6 +2247,14 @@
         "label": "デフォルトシェル",
         "description": "デフォルトの変更は新しいターミナルタブにのみ反映されます。既存のターミナルには影響しません。",
         "selectAria": "デフォルトターミナルシェルを選択"
+      }
+    },
+    "composer": {
+      "title": "メッセージ入力",
+      "sendShortcut": {
+        "label": "{{shortcut}}で送信",
+        "hint": "オンにすると{{shortcut}}でメッセージを送信します。オフにするとEnterで送信し、Shift+Enterで改行します。",
+        "ariaLabel": "{{shortcut}}でメッセージを送信"
       }
     },
     "linkOpen": {
@@ -4720,6 +4729,7 @@
       "send": "メッセージを送信",
       "queue": "キューに追加",
       "queueTooltip": "クリックでキューに追加。{{shortcut}} でタスクを中断せずに割り込み送信",
+      "queueTooltipSendMode": "クリックでキューに追加、{{shortcut}}でこのメッセージを送信",
       "stop": "生成を停止"
     },
     "pluginSetup": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2942,6 +2942,7 @@
         "systemReserved": "OS によって予約されています",
         "conflict": "「{{name}}」と競合しています",
         "voiceConflict": "音声入力のショートカットと競合しています",
+        "composerVoiceConflict": "音声入力のショートカットと競合しています。Composer または音声入力のショートカットを変更してください。",
         "menuAccelerator": "この組み合わせはメニューショートカットとして登録できません"
       },
       "items": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2942,7 +2942,7 @@
         "systemReserved": "운영 체제에서 예약된 조합입니다",
         "conflict": "\"{{name}}\"과(와) 충돌합니다",
         "voiceConflict": "음성 입력 단축키와 충돌합니다",
-        "composerVoiceConflict": "음성 입력 단축키와 충돌합니다. Composer 또는 음성 입력 단축키를 변경하세요.",
+        "composerVoiceConflict": "음성 입력 단축키와 충돌합니다. 메시지 입력의 보내기 단축키 또는 음성 입력 단축키를 변경하세요.",
         "menuAccelerator": "이 조합은 메뉴 단축키로 등록할 수 없습니다"
       },
       "items": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -126,6 +126,7 @@
       "subagentModels": "하위 에이전트",
       "compaction": "컨텍스트 압축",
       "terminalShell": "기본 터미널 셸",
+      "composer": "메시지 입력",
       "linkOpen": "링크 열기 방식",
       "compatMode": "팁",
       "voiceInput": "음성 입력",
@@ -2246,6 +2247,14 @@
         "label": "기본 셸",
         "description": "기본값을 변경해도 새 터미널 탭에만 적용되며 기존 터미널은 영향을 받지 않습니다.",
         "selectAria": "기본 터미널 셸 선택"
+      }
+    },
+    "composer": {
+      "title": "메시지 입력",
+      "sendShortcut": {
+        "label": "{{shortcut}}로 보내기",
+        "hint": "켜면 {{shortcut}}로 메시지를 보냅니다. 끄면 Enter로 보내고 Shift+Enter로 줄을 바꿉니다.",
+        "ariaLabel": "{{shortcut}}로 메시지 보내기"
       }
     },
     "linkOpen": {
@@ -4720,6 +4729,7 @@
       "send": "메시지 전송",
       "queue": "대기열에 추가",
       "queueTooltip": "클릭하면 대기열에 추가됩니다. {{shortcut}} 를 누르면 작업을 중단하지 않고 끼어듭니다",
+      "queueTooltipSendMode": "클릭하면 대기열에 추가하고, {{shortcut}}를 누르면 이 메시지를 보냅니다.",
       "stop": "생성 중지"
     },
     "pluginSetup": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2942,6 +2942,7 @@
         "systemReserved": "운영 체제에서 예약된 조합입니다",
         "conflict": "\"{{name}}\"과(와) 충돌합니다",
         "voiceConflict": "음성 입력 단축키와 충돌합니다",
+        "composerVoiceConflict": "음성 입력 단축키와 충돌합니다. Composer 또는 음성 입력 단축키를 변경하세요.",
         "menuAccelerator": "이 조합은 메뉴 단축키로 등록할 수 없습니다"
       },
       "items": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -126,6 +126,7 @@
       "subagentModels": "Subagent",
       "compaction": "上下文压缩",
       "terminalShell": "默认终端 shell",
+      "composer": "消息输入",
       "linkOpen": "链接打开方式",
       "compatMode": "小技巧",
       "voiceInput": "语音输入",
@@ -2211,6 +2212,14 @@
         "label": "默认 shell",
         "description": "修改默认只影响新建的终端 tab，已有 tab 不受影响。",
         "selectAria": "选择默认终端 shell"
+      }
+    },
+    "composer": {
+      "title": "消息输入",
+      "sendShortcut": {
+        "label": "使用 {{shortcut}} 发送",
+        "hint": "开启后按 {{shortcut}} 发送消息；关闭后按 Enter 发送消息，按 Shift+Enter 换行。",
+        "ariaLabel": "使用 {{shortcut}} 发送消息"
       }
     },
     "linkOpen": {
@@ -4720,6 +4729,7 @@
       "send": "发送消息",
       "queue": "排队发送",
       "queueTooltip": "点击排队发送；按 {{shortcut}} 插话，不打断当前任务",
+      "queueTooltipSendMode": "点击可排队；按 {{shortcut}} 发送此消息",
       "stop": "停止生成"
     },
     "pluginSetup": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2942,6 +2942,7 @@
         "systemReserved": "该组合键被系统保留",
         "conflict": "与「{{name}}」冲突",
         "voiceConflict": "与语音输入快捷键冲突",
+        "composerVoiceConflict": "与语音输入快捷键冲突，请修改发送或语音输入快捷键。",
         "menuAccelerator": "该组合键无法注册为菜单快捷键"
       },
       "items": {

--- a/apps/desktop/src/renderer/voice-input/__tests__/VoiceInputSection.recordingGate.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/VoiceInputSection.recordingGate.test.ts
@@ -15,6 +15,20 @@ describe('VoiceInputSection shortcut recording gate', () => {
     expect(source).toContain('window.electronAPI.appShortcuts.setRecording(false)');
   });
 
+  it('checks the active Composer binding before preview and persistence', () => {
+    const source = readFileSync(
+      new URL('../../components/settings/VoiceInputSection.tsx', import.meta.url),
+      'utf8',
+    );
+
+    expect(source).toContain('const hasComposerVoiceConflict = useCallback(');
+    expect(source).toContain('getComposerSendShortcutPreference()');
+    expect(source).toContain('findComposerVoiceInputConflict(');
+    expect(source).toContain("result.conflict === 'composer-voice-input'");
+    expect(source).toContain("settings.shortcuts.errors.composerVoiceConflict");
+    expect(source).toContain('findVoiceInputAppShortcutConflict(shortcut, getAppShortcutEntries())');
+  });
+
   it('waits for shortcut suspension before committing and restores the latest persisted shortcut', () => {
     const source = readFileSync(
       new URL('../../components/settings/VoiceInputSection.tsx', import.meta.url),
@@ -67,8 +81,12 @@ describe('VoiceInputSection shortcut recording gate', () => {
       'utf8',
     );
 
-    expect(source).toMatch(/const startFnKeyCapture = useCallback\([\s\S]*?\n {2}\}, \[\]\);/);
-    expect(source).not.toMatch(/const startFnKeyCapture = useCallback\([\s\S]*?\n {2}\}, \[t\]\);/);
+    expect(source).toMatch(
+      /const startFnKeyCapture = useCallback\([\s\S]*?\n {2}\}, \[\]\);\n\n  \/\//,
+    );
+    expect(source).not.toMatch(
+      /const startFnKeyCapture = useCallback\([\s\S]*?\n {2}\}, \[t\]\);\n\n  \/\//,
+    );
     expect(source).toContain('const translateRef = useRef(t);');
     expect(source).toContain('translateRef.current = t;');
   });

--- a/apps/desktop/src/renderer/voice-input/__tests__/composerVoiceInputConflict.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/composerVoiceInputConflict.test.ts
@@ -28,6 +28,7 @@ function shortcut(overrides: ShortcutOverrides = {}): VoiceInputShortcut {
 describe('findComposerVoiceInputConflict', () => {
   it.each([
     ['darwin', shortcut({ modifiers: { meta: true, ctrl: false } })],
+    ['darwin', shortcut()],
     ['win32', shortcut()],
     ['linux', shortcut()],
   ] as const)('detects the platform modifier+Enter conflict on %s', (platform, voiceShortcut) => {
@@ -64,13 +65,13 @@ describe('findComposerVoiceInputConflict', () => {
     expect(findComposerVoiceInputConflict(preference, voiceShortcut, platform)).toBeNull();
   });
 
-  it('requires the full platform modifier set', () => {
+  it('matches the Composer modifier logic when both platform modifiers are held', () => {
     expect(
       findComposerVoiceInputConflict(
         'modifier-enter',
         shortcut({ modifiers: { meta: true, ctrl: true } }),
         'darwin',
       ),
-    ).toBeNull();
+    ).toBe('composer-voice-input');
   });
 });

--- a/apps/desktop/src/renderer/voice-input/__tests__/composerVoiceInputConflict.test.ts
+++ b/apps/desktop/src/renderer/voice-input/__tests__/composerVoiceInputConflict.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import { findComposerVoiceInputConflict } from '../composerVoiceInputConflict';
+import type { VoiceInputShortcut } from '../shortcut';
+
+type ShortcutOverrides = Omit<Partial<VoiceInputShortcut>, 'modifiers'> & {
+  modifiers?: Partial<VoiceInputShortcut['modifiers']>;
+};
+
+function shortcut(overrides: ShortcutOverrides = {}): VoiceInputShortcut {
+  const { modifiers: overrideModifiers, ...shortcutOverrides } = overrides;
+  return {
+    trigger: 'keyboard',
+    code: 'Enter',
+    key: 'Enter',
+    ...shortcutOverrides,
+    modifiers: {
+      meta: false,
+      ctrl: true,
+      alt: false,
+      shift: false,
+      fn: false,
+      ...overrideModifiers,
+    },
+  };
+}
+
+describe('findComposerVoiceInputConflict', () => {
+  it.each([
+    ['darwin', shortcut({ modifiers: { meta: true, ctrl: false } })],
+    ['win32', shortcut()],
+    ['linux', shortcut()],
+  ] as const)('detects the platform modifier+Enter conflict on %s', (platform, voiceShortcut) => {
+    expect(findComposerVoiceInputConflict('modifier-enter', voiceShortcut, platform)).toBe(
+      'composer-voice-input',
+    );
+  });
+
+  it.each([
+    ['default Composer mode', 'enter', shortcut(), 'win32'],
+    [
+      'plain Enter',
+      'modifier-enter',
+      shortcut({ modifiers: { meta: false, ctrl: false } }),
+      'win32',
+    ],
+    [
+      'wrong platform modifier',
+      'modifier-enter',
+      shortcut({ modifiers: { meta: true, ctrl: false } }),
+      'win32',
+    ],
+    ['Alt+Enter', 'modifier-enter', shortcut({ modifiers: { alt: true } }), 'win32'],
+    ['Shift+Enter', 'modifier-enter', shortcut({ modifiers: { shift: true } }), 'win32'],
+    ['Fn+Enter', 'modifier-enter', shortcut({ modifiers: { fn: true } }), 'win32'],
+    [
+      'modifier-only shortcut',
+      'modifier-enter',
+      shortcut({ trigger: 'modifier', code: 'ControlLeft', key: 'ControlLeft' }),
+      'win32',
+    ],
+    ['empty Voice Input shortcut', 'modifier-enter', null, 'win32'],
+  ] as const)('does not flag %s', (_name, preference, voiceShortcut, platform) => {
+    expect(findComposerVoiceInputConflict(preference, voiceShortcut, platform)).toBeNull();
+  });
+
+  it('requires the full platform modifier set', () => {
+    expect(
+      findComposerVoiceInputConflict(
+        'modifier-enter',
+        shortcut({ modifiers: { meta: true, ctrl: true } }),
+        'darwin',
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/voice-input/composerShortcut.ts
+++ b/apps/desktop/src/renderer/voice-input/composerShortcut.ts
@@ -1,0 +1,6 @@
+export function hasComposerModifier(
+  event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey'>,
+  platform: string | undefined,
+): boolean {
+  return event.ctrlKey || (platform === 'darwin' && event.metaKey);
+}

--- a/apps/desktop/src/renderer/voice-input/composerVoiceInputConflict.ts
+++ b/apps/desktop/src/renderer/voice-input/composerVoiceInputConflict.ts
@@ -1,4 +1,5 @@
 import type { ComposerSendShortcutPreference } from '@/hooks/useComposerSendShortcutPreference';
+import { hasComposerModifier } from './composerShortcut';
 import type { VoiceInputShortcut } from './shortcut';
 
 export type ShortcutConflict = 'composer-voice-input' | null;
@@ -17,12 +18,17 @@ export function findComposerVoiceInputConflict(
   if (voiceShortcut.code !== 'Enter' || voiceShortcut.key !== 'Enter') return null;
   if (voiceShortcut.modifiers.alt || voiceShortcut.modifiers.shift) return null;
 
-  const isMac = platform === 'darwin';
-  const hasPlatformModifier = isMac ? voiceShortcut.modifiers.meta : voiceShortcut.modifiers.ctrl;
-  const hasOtherPlatformModifier = isMac
-    ? voiceShortcut.modifiers.ctrl
-    : voiceShortcut.modifiers.meta;
-  if (!hasPlatformModifier || hasOtherPlatformModifier) return null;
+  if (
+    !hasComposerModifier(
+      {
+        metaKey: voiceShortcut.modifiers.meta,
+        ctrlKey: voiceShortcut.modifiers.ctrl,
+      },
+      platform,
+    )
+  ) {
+    return null;
+  }
 
   return 'composer-voice-input';
 }

--- a/apps/desktop/src/renderer/voice-input/composerVoiceInputConflict.ts
+++ b/apps/desktop/src/renderer/voice-input/composerVoiceInputConflict.ts
@@ -1,0 +1,28 @@
+import type { ComposerSendShortcutPreference } from '@/hooks/useComposerSendShortcutPreference';
+import type { VoiceInputShortcut } from './shortcut';
+
+export type ShortcutConflict = 'composer-voice-input' | null;
+
+/**
+ * Return a conflict only when Voice Input owns the platform's complete
+ * modifier+Enter combination used by Composer's modifier-send mode.
+ */
+export function findComposerVoiceInputConflict(
+  preference: ComposerSendShortcutPreference,
+  voiceShortcut: VoiceInputShortcut | null,
+  platform: string | undefined,
+): ShortcutConflict {
+  if (preference !== 'modifier-enter' || !voiceShortcut) return null;
+  if (voiceShortcut.trigger === 'modifier' || voiceShortcut.modifiers.fn) return null;
+  if (voiceShortcut.code !== 'Enter' || voiceShortcut.key !== 'Enter') return null;
+  if (voiceShortcut.modifiers.alt || voiceShortcut.modifiers.shift) return null;
+
+  const isMac = platform === 'darwin';
+  const hasPlatformModifier = isMac ? voiceShortcut.modifiers.meta : voiceShortcut.modifiers.ctrl;
+  const hasOtherPlatformModifier = isMac
+    ? voiceShortcut.modifiers.ctrl
+    : voiceShortcut.modifiers.meta;
+  if (!hasPlatformModifier || hasOtherPlatformModifier) return null;
+
+  return 'composer-voice-input';
+}


### PR DESCRIPTION
<!-- PR Title: feat(desktop): 增加消息输入发送快捷键设置 -->

## 这次改了什么

### 摘要

新增桌面端消息输入框发送快捷键设置。用户可以选择默认使用 `Enter` 发送，或使用 macOS 的 `⌘+Enter`、Windows/Linux 的 `Ctrl+Enter` 发送，同时保留 `Shift+Enter` 换行行为。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1320
- 本 PR 包含：
  - 新增 Desktop 消息输入发送快捷键设置
  - 支持默认 `Enter` 发送和修饰键 `Enter` 发送两种模式
  - 更新发送按钮、排队发送和语音输入提示文案
  - 保留 `Shift+Enter` 换行、IME 输入和列表接续行为
  - 补充 en / zh-CN / ja / ko 文案及相关测试
- 明确不包含：
  - Mobile 端改动
  - 服务端、协议、数据库 schema 和 migration 改动
  - 其他全局快捷键调整
  - `specs/` 文档
- 用户可见变化：
  - 设置页新增「消息输入」发送快捷键开关
  - macOS 显示 `⌘+Enter`，Windows/Linux 显示 `Ctrl+Enter`
  - 发送按钮及相关提示会显示当前快捷键
  - 设置会持久化，并支持恢复默认
- 是否存在 breaking change：无

### UI 变化

- 涉及平台：Desktop，已覆盖 macOS / Windows / Linux 的快捷键文案分支
- 截图或录屏：
  - Light: 
<img width="1392" height="912" alt="image" src="https://github.com/user-attachments/assets/668e4137-5b81-43b1-8274-3f59679b53cc" />
  - Dark: 
<img width="1392" height="912" alt="image" src="https://github.com/user-attachments/assets/a2e2bb14-c9be-4ec8-8b23-c9fb39fdcd45" />

- 引用的设计规范：
  - `DESIGN.md §4 Cards & Containers`：设置项使用 12px 圆角卡片、语义化边框和背景 token。
  - `DESIGN.md §5 Spacing System`：使用规范间距，卡片内边距为 16px。
  - `DESIGN.md §10 Light / Dark Dual-Mode Delivery Gate`：复用设置页语义 token，支持 Light / Dark 两种模式，未新增单模式硬编码颜色。
  - `DESIGN.md §14.3 Keyboard & IME`：保留 `Shift+Enter` 换行和 IME composition 不发送；可配置发送模式仅改变普通 Enter 的提交方式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/hooks/__tests__/useComposerSendShortcutPreference.test.ts \
  src/renderer/components/settings/__tests__/ComposerSendShortcutSection.test.tsx \
  src/renderer/__tests__/chatInputSteerShortcut.test.ts \
  src/renderer/__tests__/chatInputListContinuation.test.ts \
  src/renderer/__tests__/voiceInputEnterToSend.test.ts

结果：5 个测试文件、40 个测试全部通过。

pnpm --filter desktop typecheck

结果：通过。

pnpm check:i18n-glossary

结果：通过；en / zh-CN / ja / ko 无新增术语违规。

pnpm check:dco

结果：通过；8 个 commit 均带 DCO 签名。

pnpm test:unit

结果：通过。

pnpm build

结果：通过；成功生成 macOS arm64 Desktop `.app` 和 `.zip` 产物。
```

### 手工验证

- 环境：macOS arm64，本地构建的 Desktop `.app`
- 路径：设置 → 消息输入
- 默认模式：
  - `Enter` 发送
  - `Shift+Enter` 换行
  - 执行中的任务使用 `⌘+Enter` 插话
- 修饰键发送模式：
  - 普通 `Enter` 换行
  - `⌘+Enter` 发送或排队
  - `Shift+Enter` 继续换行
- 重新打开应用，确认设置仍然保留。
- 点击「恢复默认」，确认恢复为 `Enter` 发送。

### 未执行的验证

- 尚未在 Windows/Linux 实机上进行手工按键验证；对应平台的快捷键文案和逻辑已由自动化测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
  - 仅影响 Desktop Renderer 的消息输入交互和相关提示文案。
  - 设置存储在 Renderer 的 `localStorage`，键名为 `chat.sendShortcutPreference`。
  - 不影响数据库、服务端、协议、Mobile 或已有会话数据。
- 回滚 / 降级方式：
  - 回滚本 PR 的提交即可恢复原有发送行为。
  - 旧版本会忽略该 localStorage 配置，不会造成数据损坏或迁移问题。

### 提交前检查

-  [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文案及四语言翻译
- [x] 已确认测试结果或说明未执行原因