### PR TITLE
test: 建立 Windows 路径单测门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,66 @@ jobs:
       - name: Run mobile scope guard
         run: pnpm --filter mobile test:scope
 
+  # Linux 全绿不能覆盖 path separator、盘符、大小写和文件系统能力差异。Windows
+  # 单测独立并行运行，避免重复 typecheck / i18n 等平台无关检查；完整 test:unit
+  # 是工程规范中的跨平台可执行契约，不能缩成少量 smoke。
+  windows-unit:
+    name: Windows unit tests
+    runs-on: windows-latest
+    timeout-minutes: 40
+
+    steps:
+      - name: Checkout client
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      # GitHub-hosted Windows 带 Git Bash；复用 Linux job 的 fail-closed 来源校验，
+      # 同时保留 win32 Node / 文件系统语义供后续单测覆盖。
+      - name: Verify cindy-protocol submodule source
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected_url='https://github.com/makecindy/cindy-protocol.git'
+          expected_path='cindy-protocol'
+          actual_url="$(git config -f .gitmodules --get submodule.cindy-protocol.url || true)"
+          actual_path="$(git config -f .gitmodules --get submodule.cindy-protocol.path || true)"
+          if [ "$actual_url" != "$expected_url" ] || [ "$actual_path" != "$expected_path" ]; then
+            echo "::error file=.gitmodules::cindy-protocol source mismatch: url='$actual_url' path='$actual_path' (expected url='$expected_url' path='$expected_path')"
+            exit 1
+          fi
+          echo "cindy-protocol submodule source verified: $actual_url"
+
+      - name: Fetch cindy-protocol submodule
+        shell: bash
+        run: |
+          git submodule sync -- cindy-protocol
+          git submodule update --init --force --recursive -- cindy-protocol
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install bundled ripgrep
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm install:ripgrep
+
+      - name: Run client and package unit tests
+        run: pnpm test:unit
+
   git-integration:
     name: Desktop Git integration
     runs-on: ubuntu-latest

--- a/apps/desktop/src/main/__tests__/installCliCommand.test.ts
+++ b/apps/desktop/src/main/__tests__/installCliCommand.test.ts
@@ -145,7 +145,8 @@ describe('随包分发的启动器脚本 resources/cli/cindy', () => {
     fileURLToPath(import.meta.url),
     '../../../../resources/cli/cindy',
   );
-  const script = readFileSync(scriptPath, 'utf8');
+  // Git checkout 可能按平台写成 CRLF；这里验证的是 shell 内容，不是工作区换行策略。
+  const script = readFileSync(scriptPath, 'utf8').replaceAll('\r\n', '\n');
 
   it('是 sh 脚本', () => {
     expect(script.startsWith('#!/bin/sh\n')).toBe(true);

--- a/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
@@ -22,6 +22,22 @@ import {
 } from '../forge';
 import { GhostManager } from '../GhostManager';
 
+const canSymlink = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-forge-symlink-probe-'));
+  try {
+    const target = path.join(probeDir, 'target.txt');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(probeDir, 'link.txt'));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
+const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir';
+
 let workDir: string;
 
 beforeEach(async () => {
@@ -109,8 +125,8 @@ describe('packGhostDir', () => {
     }
   });
 
-  it('ghost.json 为符号链接或超限 → MANIFEST_INVALID(与市场发现/安装同一把闸)', async () => {
-    // 符号链接:目标是合法清单也不放行——"符号链接一律不穿透"覆盖身份卡本身,
+  it.skipIf(!canSymlink)('ghost.json 为符号链接 → MANIFEST_INVALID(与市场发现/安装同一把闸)', async () => {
+    // 符号链接:目标是合法清单也不放行——“符号链接一律不穿透”覆盖身份卡本身,
     // 否则打包输入目录里一根链接就能把目录外的文件读进打包管道。
     const outside = path.join(workDir, 'outside-ghost.json');
     await fs.promises.writeFile(outside, JSON.stringify(GOOD_MANIFEST));
@@ -122,7 +138,9 @@ describe('packGhostDir', () => {
       ok: false,
       errorCode: 'MANIFEST_INVALID',
     });
+  });
 
+  it('ghost.json 超限 → MANIFEST_INVALID(与市场发现/安装同一把闸)', async () => {
     // 超限:JSON 本身合法(合法清单 + 尾随空白撑体积),必须在读取层按大小拒,
     // 不能等到 JSON.parse/validate——那时数 GB 的文件已经进内存了。
     const big = path.join(workDir, 'src-big');
@@ -189,7 +207,11 @@ describe('packGhostDir', () => {
     const expectedRealDir = await fs.promises.realpath(pluginDir);
     // 校验之后被换成指向外部目录的链接(外部目录留着同样的 ghost.json)。
     await fs.promises.rm(pluginDir, { recursive: true, force: true });
-    await fs.promises.symlink(await fs.promises.realpath(outside), pluginDir);
+    await fs.promises.symlink(
+      await fs.promises.realpath(outside),
+      pluginDir,
+      directoryLinkType,
+    );
 
     const dest = path.join(workDir, 'out.cindy');
     const r = await packGhostDirToFile(pluginDir, dest, expectedRealDir);

--- a/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/handoffWorkingDir.test.ts
@@ -10,7 +10,7 @@ import { afterAll, describe, expect, it } from 'vitest';
 import { validateHandoffWorkingDir } from '../handoffWorkingDir.js';
 
 const dir = mkdtempSync(path.join(tmpdir(), 'cindy-handoff-wd-'));
-const realpathSyncDir = (await import('node:fs')).realpathSync(dir);
+const realDir = await (await import('node:fs')).promises.realpath(dir);
 const file = path.join(dir, 'plain.txt');
 writeFileSync(file, 'x');
 
@@ -20,13 +20,13 @@ afterAll(() => {
 
 describe('validateHandoffWorkingDir', () => {
   it('已存在目录(绝对路径)→ ok 且返回规范化路径', async () => {
-    expect(await validateHandoffWorkingDir(dir)).toEqual({ ok: true, dir: realpathSyncDir });
+    expect(await validateHandoffWorkingDir(dir)).toEqual({ ok: true, dir: realDir });
   });
 
   it('带前后空白的合法路径 → trim 后通过,返回规范化路径(review 反馈)', async () => {
     expect(await validateHandoffWorkingDir(`  ${dir}  `)).toEqual({
       ok: true,
-      dir: realpathSyncDir,
+      dir: realDir,
     });
   });
 
@@ -51,7 +51,7 @@ describe('validateHandoffWorkingDir', () => {
   it('软链目录 → 返回真身路径(review 反馈:base repo 解析看真身)', async () => {
     const linkPath = path.join(dir, 'link-to-dir');
     const target = path.join(dir, 'real-target');
-    const { mkdirSync, symlinkSync, realpathSync } = await import('node:fs');
+    const { mkdirSync, promises, symlinkSync } = await import('node:fs');
     mkdirSync(target);
     try {
       symlinkSync(target, linkPath, 'dir');
@@ -60,7 +60,7 @@ describe('validateHandoffWorkingDir', () => {
     }
     expect(await validateHandoffWorkingDir(linkPath)).toEqual({
       ok: true,
-      dir: realpathSync(target),
+      dir: await promises.realpath(target),
     });
   });
 

--- a/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
@@ -997,7 +997,7 @@ describe('PluginMarketService 自定义市场 detail/install', () => {
     // 的目录"这种永久错误,按内容非法跳过才对(否则这类市场永久阻塞默认安装)。
     // 路径必须按 realpath 拼:发现层用的是 realpath(macOS 上 /var → /private/var),
     // 用 mkdtemp 原样路径做匹配会让 mock 永不命中。
-    const target = path.join(fs.realpathSync(dir), 'plugins', 'srv', 'ghost.json');
+    const target = path.join(await fs.promises.realpath(dir), 'plugins', 'srv', 'ghost.json');
     const realOpen = fs.promises.open;
     const spy = vi.spyOn(fs.promises, 'open').mockImplementation((async (
       ...args: Parameters<typeof fs.promises.open>

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
@@ -7,6 +7,21 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { discoverMarketplace } from '../sources/discover';
 
 const roots: string[] = [];
+const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir';
+
+const canSymlink = (() => {
+  const probeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-symlink-probe-'));
+  try {
+    const target = path.join(probeDir, 'target.txt');
+    fs.writeFileSync(target, 'probe');
+    fs.symlinkSync(target, path.join(probeDir, 'link.txt'));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    fs.rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
 
 afterEach(() => {
   for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
@@ -137,7 +152,7 @@ describe('discoverMarketplace', () => {
     const outside = makeRoot();
     writePlugin(outside, 'escaped', 'escaped');
     writePlugin(root, 'plugins/good', 'good-one');
-    fs.symlinkSync(outside, path.join(root, 'plugins', 'linked-out'), 'dir');
+    fs.symlinkSync(outside, path.join(root, 'plugins', 'linked-out'), directoryLinkType);
     writeManifest(root, {
       name: 'linked',
       plugins: [
@@ -287,7 +302,7 @@ describe('discoverMarketplace', () => {
     expect(result.marketplace.displayName).toBeNull();
   });
 
-  it('skips a plugin whose ghost.json is a symlink, even to a valid manifest outside', async () => {
+  it.skipIf(!canSymlink)('skips a plugin whose ghost.json is a symlink, even to a valid manifest outside', async () => {
     const root = makeRoot();
     const outside = makeRoot();
     // 市场外放一份**内容完全合法**的身份卡:只断言"被跳过"才有区分度——
@@ -351,10 +366,18 @@ describe('discoverMarketplace', () => {
     const root = makeRoot();
     const outside = makeRoot();
     // 恶意市场把清单做成指向根目录外的 symlink,借宿主之手读任意路径。
-    const secret = path.join(outside, 'secret.json');
-    fs.writeFileSync(secret, JSON.stringify({ name: 'stolen', plugins: [] }));
-    fs.mkdirSync(path.join(root, '.agents', 'plugins'), { recursive: true });
-    fs.symlinkSync(secret, path.join(root, '.agents', 'plugins', 'marketplace.json'));
+    const outsideManifestDir = path.join(outside, 'manifest');
+    fs.mkdirSync(outsideManifestDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(outsideManifestDir, 'marketplace.json'),
+      JSON.stringify({ name: 'stolen', plugins: [] }),
+    );
+    fs.mkdirSync(path.join(root, '.agents'), { recursive: true });
+    fs.symlinkSync(
+      outsideManifestDir,
+      path.join(root, '.agents', 'plugins'),
+      directoryLinkType,
+    );
 
     const result = await discoverMarketplace(root);
     expect(result.ok).toBe(false);

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-discover.test.ts
@@ -302,6 +302,8 @@ describe('discoverMarketplace', () => {
     expect(result.marketplace.displayName).toBeNull();
   });
 
+  // 无宿主 symlink 权限时跳过集成夹具；Windows lstat 回退由 readBoundedFile.test.ts
+  // 的注入用例继续覆盖，不会随这里的 capability skip 一起消失。
   it.skipIf(!canSymlink)('skips a plugin whose ghost.json is a symlink, even to a valid manifest outside', async () => {
     const root = makeRoot();
     const outside = makeRoot();

--- a/apps/desktop/src/main/plugin-market/__tests__/sources-manager.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/sources-manager.test.ts
@@ -478,7 +478,7 @@ describe('MarketSourceManager git sources', () => {
         ? discovered.result.marketplace.plugins[0]!.dir
         : '';
       // discover 返回 realpath(macOS 下 /var → /private/var),按 realpath 比对。
-      expect(pluginDir.startsWith(fs.realpathSync(heldDir))).toBe(true);
+      expect(pluginDir.startsWith(await fs.promises.realpath(heldDir))).toBe(true);
 
       await refresher.refreshSource('hub');
       const switched = fs.readFileSync(path.join(slot, 'current'), 'utf8').trim();

--- a/apps/desktop/src/main/skillhub/__tests__/installService.test.ts
+++ b/apps/desktop/src/main/skillhub/__tests__/installService.test.ts
@@ -750,7 +750,7 @@ describe('skillhub/installService', () => {
     fs.writeFileSync(path.join(externalDir, 'SKILL.md'), 'external content');
     makeDirectoryLink(physicalDir, externalDir);
     makeDirectoryLink(logicalDir, physicalDir);
-    const externalRegistryPath = fs.realpathSync(physicalDir);
+    const externalRegistryPath = await fs.promises.realpath(physicalDir);
 
     const zipBuf = await makeZip({ 'SKILL.md': 'new content' });
     await setupInstallDownload(skillName, zipBuf);
@@ -842,7 +842,7 @@ describe('skillhub/installService', () => {
     fs.mkdirSync(physicalDir, { recursive: true });
     fs.writeFileSync(path.join(physicalDir, 'SKILL.md'), 'old content');
     makeDirectoryLink(logicalDir, physicalDir);
-    const physicalRegistryPath = fs.realpathSync(physicalDir);
+    const physicalRegistryPath = await fs.promises.realpath(physicalDir);
 
     const zipBuf = await makeZip({ 'SKILL.md': 'new content' });
     await setupInstallDownload(skillName, zipBuf);

--- a/apps/desktop/src/main/usage/__tests__/accountCurrencyStore.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/accountCurrencyStore.test.ts
@@ -24,6 +24,7 @@ vi.mock('../../localDb/client/current', () => ({
 }));
 
 import {
+  __flushAccountCurrencyStoreForTesting,
   __resetAccountCurrencyStoreForTesting,
   hydrateAccountCurrency,
   noteActiveAccount,
@@ -50,8 +51,7 @@ async function writeStore(entries: Record<string, string>): Promise<void> {
 
 /** 等 rememberAccountCurrency 的串行写链跑完（它是 fire-and-forget）。 */
 async function flushWrites(): Promise<void> {
-  for (let i = 0; i < 20; i += 1) await Promise.resolve();
-  await new Promise((resolve) => setTimeout(resolve, 10));
+  await __flushAccountCurrencyStoreForTesting();
 }
 
 beforeEach(async () => {

--- a/apps/desktop/src/main/usage/accountCurrencyStore.ts
+++ b/apps/desktop/src/main/usage/accountCurrencyStore.ts
@@ -187,3 +187,8 @@ export function __resetAccountCurrencyStoreForTesting(): void {
   writeChain = Promise.resolve();
   hydratedUserId = null;
 }
+
+/** 仅测试：等待 fire-and-forget 的串行写链完成，避免用固定延时猜测磁盘时序。 */
+export async function __flushAccountCurrencyStoreForTesting(): Promise<void> {
+  await writeChain;
+}

--- a/apps/desktop/src/main/utils/__tests__/readBoundedFile.test.ts
+++ b/apps/desktop/src/main/utils/__tests__/readBoundedFile.test.ts
@@ -62,6 +62,25 @@ describe('readBoundedFileNoFollow', () => {
     expect((await readBoundedFileNoFollow(file, 1024, { noFollowFlag: null }))?.toString('utf8')).toBe('{"ok":1}');
   });
 
+  it('无 O_NOFOLLOW 的平台:lstat 报告符号链接时拒绝,不依赖宿主 symlink 权限', async () => {
+    const file = path.join(workDir, 'link-shaped.json');
+    await fs.promises.writeFile(file, '{"ok":1}');
+    const realStat = await fs.promises.lstat(file, { bigint: true });
+    const linkStat = new Proxy(realStat, {
+      get(target, key) {
+        if (key === 'isSymbolicLink') return () => true;
+        const value = Reflect.get(target, key);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
+    const lstatSpy = vi.spyOn(fs.promises, 'lstat').mockResolvedValue(linkStat as never);
+    try {
+      expect(await readBoundedFileNoFollow(file, 1024, { noFollowFlag: null })).toBeNull();
+    } finally {
+      lstatSpy.mockRestore();
+    }
+  });
+
   it.runIf(process.platform !== 'win32')(
     'containWithin:中间目录被换成根外链接时拒绝(最终分量是普通文件,O_NOFOLLOW 拦不住)',
     async () => {

--- a/apps/mobile/src/__tests__/historyWindowBackfillWiring.test.ts
+++ b/apps/mobile/src/__tests__/historyWindowBackfillWiring.test.ts
@@ -22,8 +22,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
+function readSource(...segments: string[]): string {
+  return readFileSync(resolve(process.cwd(), ...segments), 'utf8').replaceAll('\r\n', '\n');
+}
+
 describe('history window backfill wiring', () => {
-  const source = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8');
+  const source = readSource('app/sessions/[sessionId].tsx');
 
   it('不变量 1：一轮的身份是单调 seq，取消不可撤销', () => {
     expect(source).toContain('const runSeq = backfillRunSeqRef.current + 1;');
@@ -110,7 +114,7 @@ describe('history window backfill wiring', () => {
  * (#1210 review)。
  */
 describe('live stream interruption wiring', () => {
-  const source = readFileSync(resolve(process.cwd(), 'src/device-link/DeviceLinkContext.tsx'), 'utf8');
+  const source = readSource('src/device-link/DeviceLinkContext.tsx');
 
   it('订阅被远端 ACK：按真正记进 ACK 表的 topic 生效', () => {
     const sendSubscribe = source.slice(

--- a/docs/dev-rules/engineering-conventions.md
+++ b/docs/dev-rules/engineering-conventions.md
@@ -89,6 +89,32 @@ UI 文案的语气与措辞另见 [`DESIGN.md`](../design-rules/DESIGN.md) 的 V
 `scripts/__tests__/test-workspaces.test.mjs` 是 tier 边界的可执行契约；调整测试命名、include
 或 exclude 时必须同步更新并运行 `pnpm test:runner`。
 
+### 3.2 路径断言的跨平台宪法
+
+测试必须先区分路径代表的语义，不能把当前开发机的路径表示误当成跨平台事实：
+
+- **宿主文件系统路径**：传给或来自 Node `fs`、Electron、子进程 `cwd` 等本机 API 的路径，
+  期望值必须用 `path.join`／`path.resolve`／`path.relative` 构造；按被测语义使用
+  `path.normalize`，涉及软链、junction 或物理文件身份时使用 `realpath` 后比较。禁止在这类
+  断言中把 `/` 或 `\` 写成固定期望，也禁止只为让断言通过而把整段输出统一
+  `replace(/\\/g, '/')`——整段替换会掩盖产品代码返回了错误路径格式，并可能误改 URL、转义
+  内容或其它非路径文本。
+- **逻辑路径**：URL／URI、远程 POSIX 路径、归档条目、wire protocol，以及契约明确规定用
+  `/` 的 repo-relative 路径，不跟随宿主分隔符。这类测试可以固定写 `/`，但测试名称、类型或
+  邻近注释必须明确它是稳定协议格式，不能仅凭字符串“看起来像路径”就归入例外。
+- **模拟目标平台**：验证 Windows／POSIX 路径算法时使用 `path.win32`／`path.posix`，或把目标
+  platform／path API 注入被测函数；禁止只 mock `process.platform` 后继续调用由宿主系统决定的
+  默认 `path` 实现。Windows 大小写折叠也只在被测契约明确需要时进行，不能作为所有路径断言的
+  通用归一化。
+- **平台能力差异**：symlink、junction、文件权限等能力先做 capability probe。宿主确实不支持
+  时可以跳过真实文件系统用例，但核心语义必须在支持该能力的受控 CI 平台继续实跑，或通过
+  依赖注入／纯函数用例保留等价覆盖；禁止按 `process.platform` 大面积跳过后让整个 CI 矩阵
+  失去相应回归保护。
+
+PR 门禁必须在 Windows 上运行完整 `pnpm test:unit`；`scripts/__tests__/dev-docs-contract.test.mjs`
+锁住该 CI 契约。不能用静态扫描“测试字符串是否含斜杠”代替 Windows 实跑，因为它无法可靠区分
+宿主路径与逻辑路径。
+
 ## 4. 跨平台双端兼容（macOS / Windows）
 
 任何功能都必须同时考虑 macOS / Windows，并在两端做到最优性能。

--- a/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
@@ -42,6 +42,24 @@ const PREVIOUS_PI_BINARY = path.join(
 
 const piAvailable = existsSync(PI_BINARY);
 
+const canSymlink = (() => {
+  const probeDir = mkdtempSync(path.join(tmpdir(), 'pi-symlink-probe-'));
+  try {
+    const target = path.join(probeDir, 'target.txt');
+    writeFileSync(target, 'probe');
+    symlinkSync(target, path.join(probeDir, 'link.txt'));
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true });
+  }
+})();
+
+function jsonStringContent(value: string): string {
+  return JSON.stringify(value).slice(1, -1);
+}
+
 const noopLogger: Logger = {
   trace: () => {},
   debug: () => {},
@@ -576,8 +594,9 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         });
         await done;
         const bodies = seenRequests.slice(before).map((request) => request.body).join('\n');
-        expect(bodies).toContain(filePath);
-        expect(bodies).toContain(referenceDir);
+        // 请求体是 JSON 文本；Windows 路径的反斜杠会按 JSON 规则转义。
+        expect(bodies).toContain(jsonStringContent(filePath));
+        expect(bodies).toContain(jsonStringContent(referenceDir));
         expect(agent.capabilities.multimodal.file.supported).toBe(true);
         expect(agent.capabilities.extraDirs.supported).toBe(true);
       } finally {
@@ -1075,7 +1094,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
     },
   );
 
-  it(
+  it.skipIf(!canSymlink)(
     'full access blocks credential reads reached through a workspace symlink',
     { timeout: 60_000 },
     async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -143,8 +143,13 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
   }
 
   it('spawns with --append-system-prompt (default pi prompt preserved) and offline/no-proxy env', async () => {
-    process.env.no_proxy = 'corp.internal';
-    delete process.env.NO_PROXY;
+    if (process.platform === 'win32') {
+      // Windows 的环境变量键不区分大小写，无法同时构造“仅有小写键”的进程环境。
+      process.env.NO_PROXY = 'corp.internal';
+    } else {
+      process.env.no_proxy = 'corp.internal';
+      delete process.env.NO_PROXY;
+    }
     await start();
     expect(captured.args).not.toContain('--system-prompt');
     const idx = captured.args.indexOf('--append-system-prompt');

--- a/scripts/__tests__/dev-docs-contract.test.mjs
+++ b/scripts/__tests__/dev-docs-contract.test.mjs
@@ -26,6 +26,17 @@ function readJson(relativePath) {
 	return JSON.parse(readText(relativePath));
 }
 
+function workflowJob(workflow, jobId) {
+	const lines = workflow.split(/\r?\n/);
+	const start = lines.findIndex((line) => line === `  ${jobId}:`);
+	if (start === -1) return undefined;
+	const endOffset = lines
+		.slice(start + 1)
+		.findIndex((line) => /^  [a-zA-Z0-9_-]+:$/.test(line));
+	const end = endOffset === -1 ? lines.length : start + 1 + endOffset;
+	return lines.slice(start + 1, end).join("\n");
+}
+
 function shellLines(relativePath) {
 	const markdown = readText(relativePath);
 	return [...markdown.matchAll(/```(?:bash|sh)?\r?\n([\s\S]*?)```/g)]
@@ -124,4 +135,13 @@ test("runtime versions and the docs contract are code-owned", () => {
 	assert.equal(rootPackage.engines.pnpm, ">=10.7 <11");
 	assert.match(rootPackage.packageManager, /^pnpm@10\./);
 	assert.match(rootPackage.scripts["test:runner"], /scripts\/__tests__\/dev-docs-contract\.test\.mjs/);
+});
+
+test("client CI keeps the complete unit gate on Windows", () => {
+	const workflow = readText(".github/workflows/ci.yml");
+	const job = workflowJob(workflow, "windows-unit");
+	assert.ok(job, "client CI must define a windows-unit job");
+	assert.match(job, /^    runs-on: windows-latest$/m);
+	assert.match(job, /^        run: pnpm test:unit$/m);
+	assert.doesNotMatch(job, /pnpm test:unit\s+--/);
 });

--- a/scripts/__tests__/ensure-agent-binaries.test.mjs
+++ b/scripts/__tests__/ensure-agent-binaries.test.mjs
@@ -220,7 +220,7 @@ test('listSiblingWorktreeRoots: lists other worktrees of the same repo, excludin
   git('worktree', 'add', wt, '-b', 'wt-a');
 
   const fromMain = listSiblingWorktreeRoots(repo);
-  assert.deepEqual(fromMain, [fs.realpathSync(wt)]);
+  assert.deepEqual(fromMain, [fs.realpathSync.native(wt)]);
   const fromWt = listSiblingWorktreeRoots(wt);
-  assert.deepEqual(fromWt, [fs.realpathSync(repo)]);
+  assert.deepEqual(fromWt, [fs.realpathSync.native(repo)]);
 });

--- a/scripts/ensure-agent-binaries.mjs
+++ b/scripts/ensure-agent-binaries.mjs
@@ -107,7 +107,9 @@ export function listSiblingWorktreeRoots(rootDir) {
   }
   let selfReal = rootDir;
   try {
-    selfReal = fs.realpathSync(rootDir);
+    // Windows 的 TEMP 可能是 8.3 短路径，而 git worktree 输出长路径。native
+    // realpath 会把两种表示解析到同一物理目录，避免把当前 worktree 当成兄弟项。
+    selfReal = fs.realpathSync.native(rootDir);
   } catch {
     /* keep rootDir as-is */
   }
@@ -118,7 +120,7 @@ export function listSiblingWorktreeRoots(rootDir) {
     if (!raw) continue;
     let real;
     try {
-      real = fs.realpathSync(raw); // stale 的 worktree 条目（目录已删）直接跳过
+      real = fs.realpathSync.native(raw); // stale 的 worktree 条目（目录已删）直接跳过
     } catch {
       continue;
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 Windows 路径兼容从“开发者拉取后才发现”升级为 PR 门禁：补充路径断言跨平台宪法，在 `client-ci` 新增 Windows 上完整 `pnpm test:unit` job，并用文档契约测试防止门禁被悄悄缩减。同时修复 #1342 未覆盖的 CRLF、JSON 路径转义、环境变量大小写、symlink/junction 能力差异，以及全量并发下依赖固定延时的写盘测试抖动。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Windows 路径问题反复导致 macOS/Linux 全绿、Windows 开发者拉取后出现无关单测失败
- 本 PR 包含：路径语义与断言规则；Windows 全量单测 CI；可执行 workflow 守卫；Desktop/Mobile/Maker Core 的剩余跨平台单测修复；持久化测试的确定性写链等待
- 明确不包含：产品功能、UI、插件运行时/沙箱/manifest 契约、数据库 schema/migration、Mobile 原生配置或 runtime fingerprint
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：Windows + Node 22 下根 runner 与全部 unit workspace 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/__tests__/installCliCommand.test.ts src/main/plugin-market/__tests__/sources-parse.test.ts src/main/plugin-market/__tests__/sources-discover.test.ts src/main/plugin-market/__tests__/service-custom-sources.test.ts src/main/cindy-brain/__tests__/forge.test.ts --pool=forks --maxWorkers=1
结果：5 个文件通过，133 个测试通过，2 个按宿主 symlink 能力跳过

pnpm --filter mobile exec vitest run src/__tests__/historyWindowBackfillWiring.test.ts --pool=forks --maxWorkers=1
结果：11 个测试通过

pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts src/agents/pi/__tests__/pi-agent.integration.test.ts --pool=forks --maxWorkers=1
结果：32 个测试通过，2 个按二进制/宿主 symlink 能力跳过

GitHub client-ci
结果：Windows unit tests（windows-latest，15m40s）、Linux verify、Desktop Git integration 全部通过

pnpm check:dco
git diff --cached --check
结果：4 个提交 DCO 签名与 diff 检查通过
```

首次全量运行暴露 `accountCurrencyStore` 用固定 10ms 等待异步写盘的既有抖动；改为等待真实串行写链后，定向测试和完整 `pnpm test:unit` 均复跑通过。

### 手工验证

不涉及；本 PR 只修改工程规则、CI 与自动化测试可靠性。

### 未执行的验证

- 本机未安装 `actionlint`；workflow 的关键 Windows job 契约已由 `scripts/__tests__/dev-docs-contract.test.mjs` 覆盖，并随完整 `pnpm test:unit` 通过。
- GitHub-hosted `windows-latest` 已完整执行 `pnpm test:unit` 并通过；无待执行的平台验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：每个 PR 和 main push 新增一个并行 Windows 全量单测 job；部分文件 symlink 用例在宿主无权限时明确 skip，但 Ubuntu CI 继续保留真实 symlink 覆盖，Windows 可用的目录逃逸场景改用 junction 实跑。
- 存量插件影响：无；仅调整插件市场测试夹具，不修改插件基座或兼容逻辑。
- 回滚 / 降级方式：回退本提交即可；若 Windows runner 出现基础设施故障，应修复 runner/缓存问题，不把完整门禁静默缩成 smoke。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因