### PR TITLE
feat(desktop): 新建对话工具条的引擎切换改用下拉选择器

### DIFF
--- a/apps/desktop/src/renderer/__tests__/agentSelect.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/agentSelect.test.tsx
@@ -36,20 +36,44 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-// MorphPopover 的形变动画依赖 getBoundingClientRect / rAF 测量,jsdom 下无意义。
-// 这里替换成「open 时直接渲染 children」的最小实现,只验证菜单语义与交互。
-vi.mock('@/components/ui/morph-popover', () => ({
-  MorphPopover: ({ open, trigger, children }: {
-    open: boolean;
-    trigger: React.ReactNode;
-    children: React.ReactNode;
-  }) => (
-    <div>
-      {trigger}
-      {open ? <div data-testid="agent-select-panel">{children}</div> : null}
-    </div>
-  ),
-}));
+// MorphPopover 的形变动画依赖 getBoundingClientRect / rAF 测量,jsdom 下无意义;
+// 但它的**聚焦优先级**是本组件的关键契约,必须如实复刻:形变结束后聚焦
+// [data-morph-autofocus] → input → 面板内第一个可交互项。只把动画摘掉、聚焦
+// 照搬,漏标记 data-morph-autofocus 时焦点会落到第一行,测试即刻失败
+// (真实实现见 components/ui/morph-popover.tsx 的 focus target 选择)。
+vi.mock('@/components/ui/morph-popover', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+  return {
+    MorphPopover: ({ open, trigger, children }: {
+      open: boolean;
+      trigger: React.ReactNode;
+      children: React.ReactNode;
+    }) => {
+      const panelRef = React.useRef<HTMLDivElement>(null);
+      React.useEffect(() => {
+        if (!open) return;
+        const panel = panelRef.current;
+        if (!panel) return;
+        const target =
+          panel.querySelector<HTMLElement>('[data-morph-autofocus]:not([disabled])') ??
+          panel.querySelector<HTMLElement>('input, textarea') ??
+          panel.querySelector<HTMLElement>('button:not([disabled]), [role="option"]') ??
+          panel;
+        target.focus({ preventScroll: true });
+      }, [open]);
+      return (
+        <div>
+          {trigger}
+          {open ? (
+            <div ref={panelRef} data-testid="agent-select-panel">
+              {children}
+            </div>
+          ) : null}
+        </div>
+      );
+    },
+  };
+});
 
 describe('AgentSelect', () => {
   it('trigger 显示当前引擎;展开后每个引擎一行,当前项打勾', () => {
@@ -83,7 +107,7 @@ describe('AgentSelect', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('打开时初始焦点落在当前选中行,不是第一行', async () => {
+  it('打开时初始焦点落在当前选中行,不是第一行(经 data-morph-autofocus)', async () => {
     render(<AgentSelect value="codex" onChange={() => {}} />);
     fireEvent.click(screen.getByRole('button', { name: '选择引擎：Codex' }));
 
@@ -91,6 +115,27 @@ describe('AgentSelect', () => {
       expect(document.activeElement).toBe(screen.getByTestId('agent-select-option-codex'));
     });
     expect(document.activeElement).not.toBe(screen.getByTestId('agent-select-option-cc'));
+    // 标记必须落在选中行上 —— MorphPopover 只认它,缺了就回落到第一行
+    expect(
+      screen.getByTestId('agent-select-option-codex').getAttribute('data-morph-autofocus'),
+    ).toBe('true');
+    expect(
+      screen.getByTestId('agent-select-option-cc').getAttribute('data-morph-autofocus'),
+    ).toBeNull();
+  });
+
+  it('中途 disabled 会收敛 open 状态,恢复可用后不会自己弹回来', () => {
+    const { rerender } = render(<AgentSelect value="cc" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: '选择引擎：Claude' }));
+    expect(screen.getByTestId('agent-select-panel')).toBeTruthy();
+
+    // worktree 创建中等场景:disabled 中途变 true
+    rerender(<AgentSelect value="cc" onChange={() => {}} disabled />);
+    expect(screen.queryByTestId('agent-select-panel')).toBeNull();
+
+    // 恢复可用 —— 面板不应未经点击自己打开
+    rerender(<AgentSelect value="cc" onChange={() => {}} />);
+    expect(screen.queryByTestId('agent-select-panel')).toBeNull();
   });
 
   it('↑↓ 在选项间循环移动,末项回首项', async () => {

--- a/apps/desktop/src/renderer/__tests__/agentSelect.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/agentSelect.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+
+/**
+ * agentSelect.test.tsx
+ * ---------------------------------------------------------------------------
+ * 覆盖引擎(harness)选择器的三层约定:
+ *
+ *   A. AgentSelect 控件
+ *      1. trigger 显示当前引擎,展开后每个引擎一行、当前项打勾
+ *      2. 选中另一个引擎 → onChange 带新 vendor;选中当前项不重复回调
+ *      3. 打开时初始焦点落在**当前选中行**(不是第一行)——键盘用户上来就站在
+ *         「上次用的引擎」上
+ *      4. disabled 时点击不展开
+ *
+ *   B. 选项表单一来源
+ *      AGENT_OPTIONS 由 lib/agentVendors 的 SELECTABLE_VENDORS 派生,顺序一致、
+ *      每项都有 label 与 Mark —— 新增引擎时两个控件同时生效,不会漏一处。
+ *
+ * 「引擎选择跨重启保留」的回归在 newMakerDraft.test.ts(它持有 localStorage stub)。
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AgentSelect } from '@/components/new-chat/AgentSelect';
+import { AGENT_OPTIONS } from '@/components/new-chat/agentOptions';
+import { SELECTABLE_VENDORS, isSelectableVendor } from '@/lib/agentVendors';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      if (key === 'newChat.agentSelect.label') return '引擎';
+      if (key === 'newChat.agentSelect.trigger.aria') return `选择引擎：${options?.agent ?? ''}`;
+      return key;
+    },
+  }),
+}));
+
+// MorphPopover 的形变动画依赖 getBoundingClientRect / rAF 测量,jsdom 下无意义。
+// 这里替换成「open 时直接渲染 children」的最小实现,只验证菜单语义与交互。
+vi.mock('@/components/ui/morph-popover', () => ({
+  MorphPopover: ({ open, trigger, children }: {
+    open: boolean;
+    trigger: React.ReactNode;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      {trigger}
+      {open ? <div data-testid="agent-select-panel">{children}</div> : null}
+    </div>
+  ),
+}));
+
+describe('AgentSelect', () => {
+  it('trigger 显示当前引擎;展开后每个引擎一行,当前项打勾', () => {
+    render(<AgentSelect value="codex" onChange={() => {}} />);
+
+    const trigger = screen.getByRole('button', { name: '选择引擎：Codex' });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(trigger);
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(AGENT_OPTIONS.length);
+    expect(options.map((o) => o.textContent)).toEqual(AGENT_OPTIONS.map((o) => o.label));
+
+    const selected = options.filter((o) => o.getAttribute('aria-selected') === 'true');
+    expect(selected).toHaveLength(1);
+    expect(selected[0].getAttribute('data-testid')).toBe('agent-select-option-codex');
+  });
+
+  it('选中另一个引擎 → onChange 带新 vendor;选中当前项不重复回调', () => {
+    const onChange = vi.fn();
+    render(<AgentSelect value="codex" onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '选择引擎：Codex' }));
+    fireEvent.click(screen.getByTestId('agent-select-option-cc'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('cc');
+
+    onChange.mockClear();
+    fireEvent.click(screen.getByRole('button', { name: '选择引擎：Codex' }));
+    fireEvent.click(screen.getByTestId('agent-select-option-codex'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('打开时初始焦点落在当前选中行,不是第一行', async () => {
+    render(<AgentSelect value="codex" onChange={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: '选择引擎：Codex' }));
+
+    await waitFor(() => {
+      expect(document.activeElement).toBe(screen.getByTestId('agent-select-option-codex'));
+    });
+    expect(document.activeElement).not.toBe(screen.getByTestId('agent-select-option-cc'));
+  });
+
+  it('↑↓ 在选项间循环移动,末项回首项', async () => {
+    render(<AgentSelect value={AGENT_OPTIONS[0].vendor} onChange={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: `选择引擎：${AGENT_OPTIONS[0].label}` }));
+
+    const idOf = (i: number) => screen.getByTestId(`agent-select-option-${AGENT_OPTIONS[i].vendor}`);
+    await waitFor(() => expect(document.activeElement).toBe(idOf(0)));
+
+    // 依次 ↓ 走完全部选项,最后一项再 ↓ 回到首项(引擎数量无关)
+    for (let i = 1; i < AGENT_OPTIONS.length; i += 1) {
+      fireEvent.keyDown(screen.getByRole('listbox'), { key: 'ArrowDown' });
+      expect(document.activeElement).toBe(idOf(i));
+    }
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(idOf(0));
+
+    // ↑ 从首项回到末项
+    fireEvent.keyDown(screen.getByRole('listbox'), { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(idOf(AGENT_OPTIONS.length - 1));
+  });
+
+  it('hiddenVendors 隐藏未注册的引擎,但当前选中值始终保留', () => {
+    // Pi 二进制缺失时创建入口要隐藏,否则会建出 `Agent 'pi' is not registered` 的会话
+    render(<AgentSelect value="cc" onChange={() => {}} hiddenVendors={['pi']} />);
+    fireEvent.click(screen.getByRole('button', { name: '选择引擎：Claude' }));
+    expect(screen.queryByTestId('agent-select-option-pi')).toBeNull();
+    expect(screen.getAllByRole('option')).toHaveLength(AGENT_OPTIONS.length - 1);
+  });
+
+  it('hiddenVendors 含当前值时不隐藏它(否则触发器显示列表里没有的引擎)', () => {
+    render(<AgentSelect value="pi" onChange={() => {}} hiddenVendors={['pi']} />);
+    fireEvent.click(screen.getByRole('button', { name: '选择引擎：Pi' }));
+    expect(screen.getByTestId('agent-select-option-pi')).toBeTruthy();
+  });
+
+  it('disabled 时点击不展开', () => {
+    render(<AgentSelect value="cc" onChange={() => {}} disabled />);
+    fireEvent.click(screen.getByRole('button', { name: '选择引擎：Claude' }));
+    expect(screen.queryByTestId('agent-select-panel')).toBeNull();
+  });
+
+  it('iconOnly 窄态不渲染名称,可访问名仍来自 aria-label', () => {
+    render(<AgentSelect value="cc" onChange={() => {}} iconOnly />);
+    const trigger = screen.getByRole('button', { name: '选择引擎：Claude' });
+    expect(trigger.textContent).toBe('');
+  });
+});
+
+describe('引擎选项表(单一来源)', () => {
+  it('AGENT_OPTIONS 与 SELECTABLE_VENDORS 同序同长,且每项都有 label / Mark', () => {
+    expect(AGENT_OPTIONS.map((o) => o.vendor)).toEqual([...SELECTABLE_VENDORS]);
+    for (const opt of AGENT_OPTIONS) {
+      expect(opt.label.length).toBeGreaterThan(0);
+      expect(typeof opt.Mark).toBe('function');
+    }
+  });
+
+  it('isSelectableVendor 只认表内的引擎', () => {
+    for (const v of SELECTABLE_VENDORS) expect(isSelectableVendor(v)).toBe(true);
+    // 'orca' 不是用户可选引擎(已被协同 toggle 取代);其余非法输入一律拒绝
+    for (const v of ['orca', '', 'claude-code', 42, null, undefined]) {
+      expect(isSelectableVendor(v)).toBe(false);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -8,6 +8,7 @@ const brandLockupSource = readFileSync(resolve(__dirname, '..', 'components', 'b
 const chatInputSource = readFileSync(resolve(__dirname, '..', 'components', 'new-chat', 'ChatInput.tsx'), 'utf8');
 const sendButtonSource = readFileSync(resolve(__dirname, '..', 'components', 'new-chat', 'SendButton.tsx'), 'utf8');
 const vendorSwitcherSource = readFileSync(resolve(__dirname, '..', 'components', 'new-chat', 'VendorSegmentedSwitcher.tsx'), 'utf8');
+const agentSelectSource = readFileSync(resolve(__dirname, '..', 'components', 'new-chat', 'AgentSelect.tsx'), 'utf8');
 const permissionSelectorSource = readFileSync(resolve(__dirname, '..', 'components', 'new-chat', 'PermissionSelector.tsx'), 'utf8');
 const modelSelectorSource = readFileSync(resolve(__dirname, '..', 'components', 'new-chat', 'ModelSelector.tsx'), 'utf8');
 const worktreeChipsRowSource = readFileSync(resolve(__dirname, '..', 'components', 'new-chat', 'WorktreeChipsRow.tsx'), 'utf8');
@@ -27,7 +28,9 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(source).toContain('data-testid="create-agent-quick-starts"');
     expect(source).toContain('createAgentQuickStarts.map');
     expect(source).toContain('<ChatInput');
-    expect(source).toContain('<VendorSegmentedSwitcher');
+    expect(source).toContain('<AgentSelect');
+    // 引擎切换在工具条上已由分段器换成下拉(定宽触发器,引擎数量不影响布局)
+    expect(source).not.toContain('<VendorSegmentedSwitcher');
     expect(source).toContain('middleToolbarSlot={');
     expect(source).not.toContain('<HomeUsageDashboard');
     expect(source).not.toContain('newChat.createAgent.more');
@@ -213,6 +216,17 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
     expect(vendorSwitcherSource).toContain('bg-[var(--create-agent-segment-track-bg)]');
     expect(vendorSwitcherSource).toContain('text-[var(--create-agent-segment-inactive-text)]');
     expect(vendorSwitcherSource).toContain('border-[var(--create-agent-control-border)]');
+
+    // 引擎下拉:trigger 是描边控件(与协同按钮同族,区别于裸态的权限/模型 trigger),
+    // 面板走 model dropdown 规格;定宽 h-30,引擎数量增加不改工具条布局。
+    expect(agentSelectSource).toContain("'h-[30px]'");
+    expect(agentSelectSource).toContain('border-[var(--create-agent-control-border)]');
+    expect(agentSelectSource).toContain('bg-[var(--create-agent-control-bg)]');
+    expect(agentSelectSource).toContain('text-[var(--model-item-text)]');
+    expect(agentSelectSource).toContain('text-[var(--model-section-label)]');
+    // 选项表来自单一来源,新增引擎不需要改控件;隐藏未注册引擎的语义与分段器一致
+    expect(agentSelectSource).toContain('visibleOptions.map');
+    expect(agentSelectSource).toContain('hiddenVendors');
 
     // 权限/模型 trigger 已统一为裸态无框(create-agent 与会话内共用同一套),不再用 create-agent-control 边框
     expect(permissionSelectorSource).not.toContain('border-[var(--create-agent-control-border)]');

--- a/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerDraft.test.ts
@@ -251,6 +251,37 @@ describe('newMakerDraft store', () => {
     expect(d.lastByVendor.codex.permissionMode).toBe('auto');
   });
 
+  it('switchVendor:选中的引擎跨重启保留(模拟 app 重启后仍是上次选的)', async () => {
+    const m1 = await loadModule();
+    expect(m1.getDraft().vendor).toBe('cc');
+    m1.switchVendor('codex', m1.getDraft().lastByVendor.cc);
+    expect(m1.getDraft().vendor).toBe('codex');
+
+    vi.resetModules();
+    const m2 = await loadModule();
+    expect(m2.getDraft().vendor).toBe('codex');
+  });
+
+  it('sanitize:引擎白名单按 SELECTABLE_VENDORS 校验,表内的值一律保留', async () => {
+    const { SELECTABLE_VENDORS } = await import('@/lib/agentVendors');
+    for (const vendor of SELECTABLE_VENDORS) {
+      memStorage.setItem('xdt:newMakerDraft:v1', JSON.stringify({ vendor }));
+      vi.resetModules();
+      const { getDraft } = await loadModule();
+      // 逐个写死白名单时,新上线的引擎在这里会被静默重置回 'cc' —— 用户选中后重启就丢。
+      expect(getDraft().vendor).toBe(vendor);
+    }
+  });
+
+  it("sanitize:表外的引擎值(历史 'orca' / 未知 / 非字符串)回退默认", async () => {
+    for (const vendor of ['orca', 'unknown-engine', '', 42, null]) {
+      memStorage.setItem('xdt:newMakerDraft:v1', JSON.stringify({ vendor }));
+      vi.resetModules();
+      const { getDraft } = await loadModule();
+      expect(getDraft().vendor).toBe('cc');
+    }
+  });
+
   it('switchVendor:相同 vendor 不变(no-op,避免误覆盖)', async () => {
     const { getDraft, switchVendor } = await loadModule();
     const before = getDraft().lastByVendor.cc;

--- a/apps/desktop/src/renderer/components/new-chat/AgentSelect.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AgentSelect.tsx
@@ -16,6 +16,8 @@
  * 选中态是持久的:调用方(NewMakerDraftRoute)把 vendor 存在 newMakerDraft 的
  * localStorage 快照里,切换即写盘,重启后 sanitize 读回 —— 打开菜单时初始焦点
  * 落在**当前选中项**而非第一项,与「记住上次用的引擎」是同一件事的两面。
+ * 该焦点由选中行上的 `data-morph-autofocus` 单点决定(MorphPopover 在形变结束后
+ * 按它聚焦);不要再叠一层自己的 rAF focus —— 两层会打架,后跑的那层说了算。
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -73,16 +75,12 @@ export function AgentSelect({
       ? AGENT_OPTIONS.filter((opt) => opt.vendor === value || !hiddenVendors.includes(opt.vendor))
       : AGENT_OPTIONS;
 
-  // 打开时焦点落在当前选中行(不是第一行)——键盘用户上来就站在「上次用的引擎」上,
-  // 与鼠标用户看到的勾选位置一致。
+  // disabled 中途变 true(如 worktree 创建中)时把 open 收敛掉 —— 只靠
+  // `open={open && !disabled}` 只是不渲染面板,本地 open 仍是 true,disabled
+  // 恢复后面板会自己弹回来(copilot review)。
   useEffect(() => {
-    if (!open) return;
-    const raf = requestAnimationFrame(() => {
-      const el = listRef.current?.querySelector<HTMLElement>('[data-agent-selected="true"]');
-      (el ?? listRef.current?.querySelector<HTMLElement>('[role="option"]'))?.focus();
-    });
-    return () => cancelAnimationFrame(raf);
-  }, [open]);
+    if (disabled) setOpen(false);
+  }, [disabled]);
 
   const select = (next: MakerVendor) => {
     setOpen(false);
@@ -136,7 +134,20 @@ export function AgentSelect({
               'bg-[var(--composer-pill-bg,#FCFCFC)] dark:bg-[var(--composer-pill-bg,#393838)]',
               'text-[var(--text-primary)]',
             ],
-        'hover:bg-[var(--model-trigger-hover)]',
+        // 交互态按变体取:create-agent 有自己的 hover/pressed token(某些主题下
+        // 静止底色与 --model-trigger-hover 同色,共用会导致 hover 无反馈,codex review)。
+        isCreateAgent
+          ? [
+              'hover:bg-[var(--create-agent-control-bg-hover)]',
+              'active:bg-[var(--create-agent-control-bg-pressed)]',
+            ]
+          : ['hover:bg-[var(--model-trigger-hover)]', 'active:bg-[var(--surface-hover)]'],
+        // globals.css 全局移除了非输入控件的 outline,焦点反馈必须自己给
+        // (被替换的分段器原本靠 focus-within:ring-2 提供)。
+        'focus-visible:outline-none focus-visible:ring-2',
+        isCreateAgent
+          ? 'focus-visible:ring-[var(--create-agent-focus-ring)]'
+          : 'focus-visible:ring-[var(--focus-ring)]',
         disabled && 'pointer-events-none opacity-50',
         className,
       )}
@@ -200,6 +211,9 @@ export function AgentSelect({
               role="option"
               aria-selected={selected}
               data-agent-selected={selected ? 'true' : undefined}
+              // MorphPopover 形变结束后按此标记聚焦 —— 缺它会回落到"面板内第一个
+              // 可交互项",焦点跳到 Claude,回车就选错引擎(3 个 reviewer 同时指出)。
+              data-morph-autofocus={selected ? 'true' : undefined}
               data-testid={`agent-select-option-${opt.vendor}`}
               onClick={() => select(opt.vendor)}
               className={cn(

--- a/apps/desktop/src/renderer/components/new-chat/AgentSelect.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AgentSelect.tsx
@@ -1,0 +1,225 @@
+/**
+ * AgentSelect —— 新建对话工具条的 Agent 引擎(harness)选择器。
+ * ---------------------------------------------------------------------------
+ * 取代 VendorSegmentedSwitcher 在 New Maker 工具条上的位置。分段器是定宽等分,
+ * 每加一个引擎每段就窄一截(2 段 150px 时每段 75px 刚好放下 13px 图标 + 6px 间隙
+ * + 43px 文字;3 段就必须截断,再多只能退成 icon-only)。改成下拉后触发器定宽,
+ * 引擎数量不再影响工具条布局。
+ *
+ * 视觉规格:
+ *   - trigger: pill h-30,px-2.5,gap-1.5;13px 引擎 mark + 12px/500 名称 +
+ *     8px chevron(右对齐)。默认描边态(与协同按钮同族:有框 = 可操作控件),
+ *     与右侧裸态的模型触发器区分。
+ *   - 面板: MorphPopover,panelWidth 196,p-2;标题行「引擎」+ 单行选项 +
+ *     15px Check。行 rounded-8 px-3 py-2,13px/500。
+ *
+ * 选中态是持久的:调用方(NewMakerDraftRoute)把 vendor 存在 newMakerDraft 的
+ * localStorage 快照里,切换即写盘,重启后 sanitize 读回 —— 打开菜单时初始焦点
+ * 落在**当前选中项**而非第一项,与「记住上次用的引擎」是同一件事的两面。
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Check, ChevronDown } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+import { MorphPopover } from '@/components/ui/morph-popover';
+import type { MakerVendor } from '@/lib/ccAgent.types';
+
+import { AGENT_OPTIONS, agentOptionOf } from './agentOptions';
+
+interface AgentSelectProps {
+  value: MakerVendor;
+  onChange: (next: MakerVendor) => void;
+  /** disabled 状态(worktree 创建中等);整体降透明且不响应点击。 */
+  disabled?: boolean;
+  className?: string;
+  /** 触发器定宽(px)。引擎数量不影响它 —— 只需容纳最长的引擎名。 */
+  width?: number;
+  /** 窄态工具栏只保留引擎 mark,名称通过 title / aria-label 提供。 */
+  iconOnly?: boolean;
+  /**
+   * CREATE AGENT 首页复用该页的私有控件 token(与权限选择器、协同按钮同族);
+   * default 走 composer 通用 pill token。
+   */
+  visualVariant?: 'default' | 'create-agent';
+  /**
+   * 从列表里**隐藏**的引擎(如 runtime 未注册的 Pi、SSH 远程草稿下的 Pi)。
+   * 创建入口据 `maker:list-available-agents` 计算,避免用户创建出最终
+   * `Agent 'pi' is not registered` 的会话。当前 `value` 始终保留可见,
+   * 否则触发器会显示一个列表里不存在的引擎。
+   */
+  hiddenVendors?: readonly MakerVendor[];
+}
+
+export function AgentSelect({
+  value,
+  onChange,
+  disabled = false,
+  className,
+  width = 112,
+  iconOnly = false,
+  visualVariant = 'default',
+  hiddenVendors,
+}: AgentSelectProps) {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const listRef = useRef<HTMLDivElement>(null);
+  const isCreateAgent = visualVariant === 'create-agent';
+  const current = agentOptionOf(value);
+  // 当前值始终保留 —— 隐藏它会让触发器显示一个列表里不存在的引擎。
+  const visibleOptions =
+    hiddenVendors && hiddenVendors.length > 0
+      ? AGENT_OPTIONS.filter((opt) => opt.vendor === value || !hiddenVendors.includes(opt.vendor))
+      : AGENT_OPTIONS;
+
+  // 打开时焦点落在当前选中行(不是第一行)——键盘用户上来就站在「上次用的引擎」上,
+  // 与鼠标用户看到的勾选位置一致。
+  useEffect(() => {
+    if (!open) return;
+    const raf = requestAnimationFrame(() => {
+      const el = listRef.current?.querySelector<HTMLElement>('[data-agent-selected="true"]');
+      (el ?? listRef.current?.querySelector<HTMLElement>('[role="option"]'))?.focus();
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [open]);
+
+  const select = (next: MakerVendor) => {
+    setOpen(false);
+    if (next !== value) onChange(next);
+  };
+
+  // ↑↓ 在选项间移动(菜单语义);Home/End 跳首尾。Esc / 外部点击由 MorphPopover 兜。
+  const onListKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    const keys = ['ArrowDown', 'ArrowUp', 'Home', 'End'];
+    if (!keys.includes(event.key)) return;
+    event.preventDefault();
+    const items = Array.from(
+      listRef.current?.querySelectorAll<HTMLElement>('[role="option"]') ?? [],
+    );
+    if (items.length === 0) return;
+    const at = items.indexOf(document.activeElement as HTMLElement);
+    const next =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? items.length - 1
+          : event.key === 'ArrowDown'
+            ? (at + 1 + items.length) % items.length
+            : (at - 1 + items.length) % items.length;
+    items[next]?.focus();
+  };
+
+  const trigger = (
+    <button
+      type="button"
+      disabled={disabled}
+      // 阻 mousedown 抢焦点 —— 否则点击时下方 ChatInput 的 :focus-within 边框会瞬间掉色。
+      // 键盘 Tab 仍可正常 focus(preventDefault 只阻断鼠标路径)。
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => setOpen((prev) => (disabled ? false : !prev))}
+      aria-expanded={open && !disabled}
+      aria-haspopup="listbox"
+      aria-label={t('newChat.agentSelect.trigger.aria', { agent: current.label })}
+      title={current.label}
+      className={cn(
+        'flex shrink-0 items-center gap-1.5 rounded-full transition-colors',
+        'h-[30px]',
+        iconOnly ? 'w-[34px] min-w-[34px] justify-center px-0' : 'px-2.5',
+        isCreateAgent
+          ? [
+              'border border-[var(--create-agent-control-border)]',
+              'bg-[var(--create-agent-control-bg)] text-[var(--create-agent-control-text)]',
+            ]
+          : [
+              'border border-[var(--border-default)]',
+              'bg-[var(--composer-pill-bg,#FCFCFC)] dark:bg-[var(--composer-pill-bg,#393838)]',
+              'text-[var(--text-primary)]',
+            ],
+        'hover:bg-[var(--model-trigger-hover)]',
+        disabled && 'pointer-events-none opacity-50',
+        className,
+      )}
+      style={iconOnly ? undefined : { width }}
+    >
+      <current.Mark size={13} className="shrink-0" />
+      {!iconOnly && (
+        <>
+          {/* 文字下沉 0.5px —— Inter 在 leading-none 下视觉重心偏上,与 mark 光学居中对齐 */}
+          <span className="min-w-0 flex-1 truncate text-left text-[12px] font-medium leading-none">
+            <span className="inline-block translate-y-[0.5px]">{current.label}</span>
+          </span>
+          <ChevronDown
+            size={8}
+            className={cn(
+              'shrink-0',
+              isCreateAgent
+                ? 'text-[var(--create-agent-control-icon)]'
+                : 'text-[var(--composer-pill-icon,#3C3F43)] dark:text-[var(--composer-pill-icon,#D9D9D9)]',
+            )}
+          />
+        </>
+      )}
+    </button>
+  );
+
+  return (
+    <MorphPopover
+      open={open && !disabled}
+      onOpenChange={(next) => setOpen(disabled ? false : next)}
+      side="top"
+      align="start"
+      panelWidth={196}
+      panelClassName="p-2"
+      panelAriaLabel={t('newChat.agentSelect.label')}
+      startBg={
+        isCreateAgent ? 'var(--create-agent-control-bg)' : 'var(--composer-pill-bg, #FCFCFC)'
+      }
+      startBorderColor={
+        isCreateAgent ? 'var(--create-agent-control-border)' : 'var(--border-default)'
+      }
+      wrapperClassName="shrink-0"
+      trigger={trigger}
+    >
+      <div
+        ref={listRef}
+        role="listbox"
+        aria-label={t('newChat.agentSelect.label')}
+        onKeyDown={onListKeyDown}
+        className="flex flex-col gap-0.5"
+      >
+        <div className="px-2.5 pb-2 pt-1.5 text-11 leading-none text-[var(--model-section-label)]">
+          {t('newChat.agentSelect.label')}
+        </div>
+        {visibleOptions.map((opt) => {
+          const selected = opt.vendor === value;
+          return (
+            <button
+              key={opt.vendor}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              data-agent-selected={selected ? 'true' : undefined}
+              data-testid={`agent-select-option-${opt.vendor}`}
+              onClick={() => select(opt.vendor)}
+              className={cn(
+                'flex w-full items-center gap-2.5 rounded-[8px] px-3 py-2 text-left',
+                'transition-colors duration-100 hover:bg-[var(--model-item-hover)]',
+                'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                selected && 'bg-[var(--model-item-hover)]',
+              )}
+            >
+              <opt.Mark size={14} className="shrink-0 text-[var(--text-secondary)]" />
+              <span className="min-w-0 flex-1 truncate text-[13px] font-medium text-[var(--model-item-text)]">
+                {opt.label}
+              </span>
+              {selected && (
+                <Check size={15} className="shrink-0 text-[var(--model-item-check)]" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </MorphPopover>
+  );
+}

--- a/apps/desktop/src/renderer/components/new-chat/VendorSegmentedSwitcher.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/VendorSegmentedSwitcher.tsx
@@ -1,5 +1,9 @@
 /**
- * VendorSegmentedSwitcher —— NewMaker 主区域内的 Agent 引擎切换控件。
+ * VendorSegmentedSwitcher —— Agent 引擎切换分段(定宽等分)。
+ *
+ * 2026-08:New Maker 工具条上的引擎切换已改用 AgentSelect(下拉,触发器定宽)——
+ * 本控件宽度被引擎数量整除,引擎多了每段就放不下文字。它现在服务模型面板内的
+ * 两步切换(ModelSelector 的 agentSwitch)与设置页 IM 目录偏好等定值场景。
  * ---------------------------------------------------------------------------
  * 视觉规格:
  *   - 容器:pill (9999px),宽 220,padding 3,gap 2
@@ -15,12 +19,10 @@
  * 召集 Worker。删 tab 后整体回到 2-tab 220 宽,与历史版本视觉对齐。
  */
 
-import type { ComponentType } from 'react';
 import { cn } from '@/lib/utils';
 import type { MakerVendor } from '@/lib/ccAgent.types';
-import { CodexMark } from '@/components/icons/CodexMark';
-import { ClaudeMark } from '@/components/icons/ClaudeMark';
-import { PiMark } from '@/components/icons/PiMark';
+
+import { AGENT_OPTIONS } from './agentOptions';
 
 interface VendorSegmentedSwitcherProps {
   value: MakerVendor;
@@ -59,18 +61,9 @@ interface VendorSegmentedSwitcherProps {
   hiddenVendors?: readonly MakerVendor[];
 }
 
-interface SegmentOption {
-  vendor: MakerVendor;
-  label: string;
-  Mark: ComponentType<{ size?: number; className?: string }>;
-  iconClassName?: string;
-}
-
-const OPTIONS: readonly SegmentOption[] = [
-  { vendor: 'cc', label: 'Claude', Mark: ClaudeMark },
-  { vendor: 'codex', label: 'Codex', Mark: CodexMark },
-  { vendor: 'pi', label: 'Pi', Mark: PiMark },
-] as const;
+// 引擎条目(vendor / label / mark)的单一来源在 ./agentOptions —— 与 AgentSelect
+// 共用一张表,新增引擎只改那里。
+const OPTIONS = AGENT_OPTIONS;
 
 export function VendorSegmentedSwitcher({
   value,
@@ -162,7 +155,7 @@ export function VendorSegmentedSwitcher({
                   ),
             )}
           >
-            <opt.Mark size={dense ? 13 : 14} className={cn('shrink-0', opt.iconClassName)} />
+            <opt.Mark size={dense ? 13 : 14} className="shrink-0" />
             {/* 文字下沉 0.5px —— Inter 在 leading-none 下视觉重心偏上,与 vendor mark
                 光学居中对齐微调,见 NewChat 视觉走查 2026-05-03。 */}
             {!iconOnly && <span className="translate-y-[0.5px] whitespace-nowrap">{opt.label}</span>}

--- a/apps/desktop/src/renderer/components/new-chat/agentOptions.ts
+++ b/apps/desktop/src/renderer/components/new-chat/agentOptions.ts
@@ -1,0 +1,43 @@
+/**
+ * agentOptions —— Agent 引擎(harness)的**展示元数据**,由 lib/agentVendors 的
+ * SELECTABLE_VENDORS 派生。
+ *
+ * 同一份表被两个控件消费:
+ *   · AgentSelect(新建对话工具条的引擎下拉)
+ *   · VendorSegmentedSwitcher(模型面板内的两步切换分段等定值场景)
+ * 两处各自维护会漂移出「一个控件有、另一个没有」的引擎,所以集中在这里。
+ *
+ * 新增引擎的流程:在 lib/agentVendors 的 SELECTABLE_VENDORS 里加一项 —— 下面的
+ * VENDOR_PRESENTATION 是 Record<SelectableVendor, …>,漏补名称 / mark 会**编译报错**,
+ * 不会出现「列表里多了个没图标的引擎」。
+ */
+
+import type { ComponentType } from 'react';
+
+import { ClaudeMark } from '@/components/icons/ClaudeMark';
+import { CodexMark } from '@/components/icons/CodexMark';
+import { PiMark } from '@/components/icons/PiMark';
+import { SELECTABLE_VENDORS, type SelectableVendor } from '@/lib/agentVendors';
+
+export interface AgentOption {
+  vendor: SelectableVendor;
+  /** 品牌名,不进 i18n(产品名跨语言不翻译)。 */
+  label: string;
+  Mark: ComponentType<{ size?: number; className?: string }>;
+}
+
+const VENDOR_PRESENTATION: Record<SelectableVendor, Omit<AgentOption, 'vendor'>> = {
+  cc: { label: 'Claude', Mark: ClaudeMark },
+  codex: { label: 'Codex', Mark: CodexMark },
+  pi: { label: 'Pi', Mark: PiMark },
+};
+
+export const AGENT_OPTIONS: readonly AgentOption[] = SELECTABLE_VENDORS.map((vendor) => ({
+  vendor,
+  ...VENDOR_PRESENTATION[vendor],
+}));
+
+/** 找不到时回落第一项 —— 调用方拿到的永远是可渲染的选项。 */
+export function agentOptionOf(vendor: string): AgentOption {
+  return AGENT_OPTIONS.find((o) => o.vendor === vendor) ?? AGENT_OPTIONS[0];
+}

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -63,7 +63,7 @@ import { ConnectProviderCard } from '@/components/onboarding/ConnectProviderCard
 import { InheritedSubscriptionNotice } from '@/components/onboarding/InheritedSubscriptionNotice';
 import { resolveDeviceLinkSubmission } from './deviceLinkCreateArgs';
 import { commitRemoteSessionHandoff } from './remoteSessionHandoff';
-import { VendorSegmentedSwitcher } from '@/components/new-chat/VendorSegmentedSwitcher';
+import { AgentSelect } from '@/components/new-chat/AgentSelect';
 import { dbToMakerAgentKind, normalizeDbAgentKind } from '../../../shared/agentKindConversion';
 import { TopRightChipStack, TopRightChipStackProvider } from '@/components/chat/TopRightChipStack';
 import { useProportionalWidth } from '@/hooks/useProportionalWidth';
@@ -3497,11 +3497,10 @@ export function NewMakerDraftRoute() {
                     onFolderPickerOpenChange={handleFolderPickerOpenChange}
                     showFolderPicker={false}
                     middleToolbarSlot={
-                      <VendorSegmentedSwitcher
+                      <AgentSelect
                         value={draft.vendor}
                         onChange={handleVendorChange}
-                        width={225}
-                        dense
+                        width={112}
                         visualVariant="create-agent"
                         className="shrink-0"
                         disabled={wtCreating}
@@ -3554,11 +3553,9 @@ export function NewMakerDraftRoute() {
                         : undefined
                     }
                     compactMiddleToolbarSlot={
-                      <VendorSegmentedSwitcher
+                      <AgentSelect
                         value={draft.vendor}
                         onChange={handleVendorChange}
-                        width={108}
-                        dense
                         iconOnly
                         visualVariant="create-agent"
                         className="shrink-0"

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2735,14 +2735,22 @@
           "behavior": {
             "title": "Reactions & quoting",
             "emojiLabel": "Emoji reactions",
-            "emojiOption": { "off": "Off", "minimal": "Basic", "expressive": "Lively" },
+            "emojiOption": {
+              "off": "Off",
+              "minimal": "Basic",
+              "expressive": "Lively"
+            },
             "emojiHint": {
               "off": "No emoji reactions at all.",
               "minimal": "👀 on receipt, 👍 on success, 👎 on failure.",
               "expressive": "Completed tasks pick randomly from separate positive and negative reaction pools."
             },
             "groupQuoteLabel": "Quote the question in groups",
-            "quoteOption": { "off": "Never", "first": "First reply", "all": "Every reply" },
+            "quoteOption": {
+              "off": "Never",
+              "first": "First reply",
+              "all": "Every reply"
+            },
             "groupQuoteHint": {
               "off": "Group answers are not attached to the question.",
               "first": "The first reply quotes the question (recommended).",
@@ -2771,7 +2779,10 @@
               "save": "The group mode was not saved. The last confirmed mode was restored.",
               "retry": "Retry loading"
             },
-            "mode": { "mention": "@ only", "always": "Active" }
+            "mode": {
+              "mention": "@ only",
+              "always": "Active"
+            }
           }
         },
         "x": {
@@ -5168,6 +5179,12 @@
         }
       }
     },
+    "agentSelect": {
+      "label": "Engine",
+      "trigger": {
+        "aria": "Select engine: {{agent}}"
+      }
+    },
     "atMention": {
       "scanFailed": "Failed to scan working directory",
       "retry": "Retry",
@@ -6402,7 +6419,13 @@
         "filesWarning": "Switching changes conversation context only; workspace files are not rolled back.",
         "summarize": "Summarize the branch you leave (uses the model)",
         "summaryFocus": "Optional summary focus, e.g. preserve error-handling conclusions",
-        "role": { "user": "User", "assistant": "Agent", "tool": "Tool", "summary": "Branch summary", "system": "State" }
+        "role": {
+          "user": "User",
+          "assistant": "Agent",
+          "tool": "Tool",
+          "summary": "Branch summary",
+          "system": "State"
+        }
       },
       "projectAction": {
         "rename": "Rename project",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2734,14 +2734,22 @@
           "behavior": {
             "title": "リアクションと引用",
             "emojiLabel": "絵文字リアクション",
-            "emojiOption": { "off": "オフ", "minimal": "ベーシック", "expressive": "生き生き" },
+            "emojiOption": {
+              "off": "オフ",
+              "minimal": "ベーシック",
+              "expressive": "生き生き"
+            },
             "emojiHint": {
               "off": "絵文字リアクションを付けません。",
               "minimal": "受信時 👀、成功 👍、失敗 👎。",
               "expressive": "成功と失敗で分けたリアクションプールからランダムに選びます。"
             },
             "groupQuoteLabel": "グループで質問を引用して返信",
-            "quoteOption": { "off": "しない", "first": "最初のみ", "all": "毎回" },
+            "quoteOption": {
+              "off": "しない",
+              "first": "最初のみ",
+              "all": "毎回"
+            },
             "groupQuoteHint": {
               "off": "グループの回答を質問に紐付けません。",
               "first": "回答の最初のメッセージが質問を引用します（推奨）。",
@@ -2770,7 +2778,10 @@
               "save": "グループ参加モードを保存できませんでした。最後に確認されたモードへ戻しました。",
               "retry": "再読み込み"
             },
-            "mode": { "mention": "@ のみ", "always": "アクティブ" }
+            "mode": {
+              "mention": "@ のみ",
+              "always": "アクティブ"
+            }
           }
         },
         "x": {
@@ -5166,6 +5177,12 @@
         }
       }
     },
+    "agentSelect": {
+      "label": "エンジン",
+      "trigger": {
+        "aria": "エンジンを選択：{{agent}}"
+      }
+    },
     "atMention": {
       "scanFailed": "作業ディレクトリのスキャンに失敗しました",
       "retry": "再試行",
@@ -6391,7 +6408,13 @@
         "filesWarning": "切り替わるのは会話コンテキストだけで、作業ファイルは巻き戻りません。",
         "summarize": "離れる分岐を要約する（モデルを使用）",
         "summaryFocus": "任意：要約の重点（例：エラー処理の結論を残す）",
-        "role": { "user": "ユーザー", "assistant": "Agent", "tool": "ツール", "summary": "分岐要約", "system": "状態" }
+        "role": {
+          "user": "ユーザー",
+          "assistant": "Agent",
+          "tool": "ツール",
+          "summary": "分岐要約",
+          "system": "状態"
+        }
       },
       "projectAction": {
         "rename": "プロジェクト名を変更",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2734,14 +2734,22 @@
           "behavior": {
             "title": "리액션과 인용",
             "emojiLabel": "이모지 리액션",
-            "emojiOption": { "off": "끄기", "minimal": "기본", "expressive": "생동감" },
+            "emojiOption": {
+              "off": "끄기",
+              "minimal": "기본",
+              "expressive": "생동감"
+            },
             "emojiHint": {
               "off": "이모지 리액션을 달지 않습니다.",
               "minimal": "수신 시 👀, 성공 👍, 실패 👎.",
               "expressive": "성공과 실패로 나눈 리액션 풀에서 무작위로 선택합니다."
             },
             "groupQuoteLabel": "그룹에서 질문 인용해 답장",
-            "quoteOption": { "off": "안 함", "first": "첫 답장만", "all": "매번" },
+            "quoteOption": {
+              "off": "안 함",
+              "first": "첫 답장만",
+              "all": "매번"
+            },
             "groupQuoteHint": {
               "off": "그룹 답변을 질문에 연결하지 않습니다.",
               "first": "각 답변의 첫 메시지가 질문을 인용합니다(권장).",
@@ -2770,7 +2778,10 @@
               "save": "그룹 참여 모드를 저장하지 못했습니다. 마지막으로 확인된 모드로 복원했습니다.",
               "retry": "다시 불러오기"
             },
-            "mode": { "mention": "@만", "always": "활성" }
+            "mode": {
+              "mention": "@만",
+              "always": "활성"
+            }
           }
         },
         "x": {
@@ -5166,6 +5177,12 @@
         }
       }
     },
+    "agentSelect": {
+      "label": "엔진",
+      "trigger": {
+        "aria": "엔진 선택: {{agent}}"
+      }
+    },
     "atMention": {
       "scanFailed": "작업 디렉터리 스캔 실패",
       "retry": "재시도",
@@ -6391,7 +6408,13 @@
         "filesWarning": "전환은 대화 컨텍스트만 변경하며 작업 파일은 되돌리지 않습니다.",
         "summarize": "떠나는 분기 요약 생성(모델 사용)",
         "summaryFocus": "선택 사항: 요약 초점(예: 오류 처리 결론 유지)",
-        "role": { "user": "사용자", "assistant": "Agent", "tool": "도구", "summary": "분기 요약", "system": "상태" }
+        "role": {
+          "user": "사용자",
+          "assistant": "Agent",
+          "tool": "도구",
+          "summary": "분기 요약",
+          "system": "상태"
+        }
       },
       "projectAction": {
         "rename": "프로젝트 이름 변경",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2734,14 +2734,22 @@
           "behavior": {
             "title": "回应与引用",
             "emojiLabel": "表情回应",
-            "emojiOption": { "off": "关闭", "minimal": "基础", "expressive": "生动" },
+            "emojiOption": {
+              "off": "关闭",
+              "minimal": "基础",
+              "expressive": "生动"
+            },
             "emojiHint": {
               "off": "不放任何表情回应。",
               "minimal": "收到消息 👀，完成 👍，失败 👎。",
               "expressive": "完成与失败分别从正向、负向表情池随机选择。"
             },
             "groupQuoteLabel": "群里回复时引用提问",
-            "quoteOption": { "off": "不引用", "first": "首条引用", "all": "每条引用" },
+            "quoteOption": {
+              "off": "不引用",
+              "first": "首条引用",
+              "all": "每条引用"
+            },
             "groupQuoteHint": {
               "off": "群里的回答不挂回提问消息。",
               "first": "每次触发的第一条回答挂回提问（推荐）。",
@@ -2770,7 +2778,10 @@
               "save": "群参与模式未保存，已恢复上次确认的模式。",
               "retry": "重新读取"
             },
-            "mode": { "mention": "仅 @", "always": "全响应" }
+            "mode": {
+              "mention": "仅 @",
+              "always": "全响应"
+            }
           }
         },
         "x": {
@@ -5166,6 +5177,12 @@
         }
       }
     },
+    "agentSelect": {
+      "label": "引擎",
+      "trigger": {
+        "aria": "选择引擎：{{agent}}"
+      }
+    },
     "atMention": {
       "scanFailed": "扫描工作目录失败",
       "retry": "重试",
@@ -6391,7 +6408,13 @@
         "filesWarning": "切换只改变对话上下文，不会回滚工作区文件。",
         "summarize": "离开当前分支时生成摘要（会调用模型）",
         "summaryFocus": "可选：摘要重点，例如保留错误处理结论",
-        "role": { "user": "用户", "assistant": "Agent", "tool": "工具", "summary": "分支摘要", "system": "状态" }
+        "role": {
+          "user": "用户",
+          "assistant": "Agent",
+          "tool": "工具",
+          "summary": "分支摘要",
+          "system": "状态"
+        }
       },
       "projectAction": {
         "rename": "重命名项目",

--- a/apps/desktop/src/renderer/lib/agentVendors.ts
+++ b/apps/desktop/src/renderer/lib/agentVendors.ts
@@ -1,0 +1,24 @@
+/**
+ * agentVendors —— 「用户可选的 Agent 引擎(harness)」列表,纯数据。
+ *
+ * 放在 lib 而不是组件层:state(newMakerDraft 的 localStorage 校验)也要用它,
+ * 而 state 不能反向依赖组件。展示元数据(名称 / 品牌 mark)在
+ * `components/new-chat/agentOptions.ts`,由本表派生并用类型强制补齐。
+ *
+ * 顺序即展示顺序。**新增引擎只改这一行**:选择器会自动多出条目,
+ * localStorage 校验也会自动放行(否则用户选中新引擎、重启后会被静默重置)。
+ *
+ * 注意 MakerVendor 还含 'orca',但它不是用户可选的引擎(已被 ChatInput 底部的
+ * 协同 toggle 取代),故不在此表内。
+ */
+
+import type { MakerVendor } from './ccAgent.types';
+
+export const SELECTABLE_VENDORS = ['cc', 'codex', 'pi'] as const satisfies readonly MakerVendor[];
+
+export type SelectableVendor = (typeof SELECTABLE_VENDORS)[number];
+
+/** localStorage / IPC 等外部输入的引擎值校验(不认识的一律交给调用方回退默认)。 */
+export function isSelectableVendor(value: unknown): value is SelectableVendor {
+  return typeof value === 'string' && (SELECTABLE_VENDORS as readonly string[]).includes(value);
+}

--- a/apps/desktop/src/renderer/state/newMakerDraft.ts
+++ b/apps/desktop/src/renderer/state/newMakerDraft.ts
@@ -21,6 +21,7 @@
 import { useSyncExternalStore } from 'react';
 
 import type { MakerVendor } from '@/lib/ccAgent.types';
+import { isSelectableVendor } from '@/lib/agentVendors';
 import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
 import { getDefaultModelForVendor } from '@/lib/modelDefinitions';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir';
@@ -241,10 +242,12 @@ function sanitize(raw: unknown): NewMakerDraft {
   const def = makeDefault();
   if (!raw || typeof raw !== 'object') return def;
   const r = raw as Partial<NewMakerDraft>;
-  // F-COLLAB (2026-05): 'orca' vendor 已被 ChatInput 底部的 toggle 取代,
-  // sanitize 时把历史 localStorage 残留的 'orca' 自动迁移到 'cc',避免空白入口。
-  const vendor: MakerVendor =
-    r.vendor === 'codex' || r.vendor === 'pi' ? r.vendor : 'cc';
+  // 引擎白名单按 SELECTABLE_VENDORS(选择器同一张表的来源)校验 —— 新增引擎时这里零改动。
+  // 曾经是逐个写死的三元(`r.vendor === 'codex' || r.vendor === 'pi' ? … : 'cc'`),
+  // 每上线一个引擎都得手工补一次;漏补则用户选中新引擎、重启后被静默重置回 Claude。
+  // F-COLLAB (2026-05): 'orca' 不在表内,历史 localStorage 残留会走同一条回退路径
+  // 迁到 'cc'(它已被 ChatInput 底部的协同 toggle 取代),避免空白入口。
+  const vendor: MakerVendor = isSelectableVendor(r.vendor) ? r.vendor : def.vendor;
   const workingDir = normalizeDraftWorkingDir(r.workingDir);
   const remoteHostId =
     typeof r.remoteHostId === 'string' && r.remoteHostId.trim().length > 0


### PR DESCRIPTION
## 这次改了什么

### 摘要

新建对话工具条上的引擎（harness）切换控件从**定宽等分分段器**换成**下拉选择器**。

分段器的宽度是被引擎数量整除的。Pi 上线后它已经是 3 段（225px，每段 75px 恰好放下
13px 图标 + 6px 间隙 + 43px 文字），再加一个引擎就必须截断，窄态更是只能退成 icon-only。
换成下拉后触发器定宽 112px（窄态 34px 圆钮），引擎数量不再影响工具条布局。

顺带把「引擎选项表」下沉成单一来源，并把 `sanitize` 里逐个写死的引擎白名单改成按表校验
——那里每上线一个引擎都要手工补一次，漏补则用户选中新引擎、重启后被静默重置回 Claude。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（Pi 上线后分段器已到宽度上限，为后续新增引擎做准备）
- 本 PR 包含：
  - 新增 `AgentSelect`：`h-30` 描边 pill 触发器 + `MorphPopover` 面板（196px，标题「引擎」+ 单行选项 + 15px Check）
    - 打开时初始焦点落在**当前选中行**而非第一行；↑↓/Home/End 在选项间循环移动
    - 沿用分段器的 `hiddenVendors` 语义：runtime 未注册的引擎（如 Pi 二进制缺失、SSH 远程草稿）不出现在列表里，但**当前选中值始终保留**，否则触发器会显示一个列表里不存在的引擎
  - `NewMakerDraftRoute` 的 `middleToolbarSlot` / `compactMiddleToolbarSlot` 两处改用新控件（`hiddenSwitcherVendors` 原样透传）
  - 引擎选项表下沉为单一来源：`lib/agentVendors`（纯数据，state 层也要用，不能反向依赖组件）+ `components/new-chat/agentOptions`（由它派生展示元数据，`Record<SelectableVendor, …>` 让漏补 mark 编译报错）；`VendorSegmentedSwitcher` 改用同一张表
  - `newMakerDraft` 的 `sanitize` 引擎白名单改按 `SELECTABLE_VENDORS` 校验
  - 三个测试文件的新增/更新（见「怎么验证的」）
- 明确不包含：模型选择器面板、协同（Collaboration）入口、移动端、`ModelSelector` 面板顶部的两步切换分段（`agentSwitch`）、引擎的连接态展示
- 用户可见变化：
  - 新建对话工具条上的 `Claude | Codex | Pi` 分段变成一枚 `Codex ⌄` 下拉，点开选择
  - 切换引擎后右侧模型触发器仍按各引擎上次用的模型/强度自动恢复（`lastByVendor`，行为不变）
  - 引擎选择跨重启保留（行为不变，本次补测试钉住）
- 是否存在 breaking change：无

### UI 变化

工具条上的引擎切换控件形态变化（分段器 → 下拉），位置不变（仍在协同按钮左侧）。

- 引用的设计规范：
  - `DESIGN.md` §5「Border Radius Scale」三档圆角：触发器走 **pill**；浮层容器 **12px**（`MorphPopover` 面板）；浮层内选项行 **8px**（`rounded-[8px]`，即规范里"塞不进胶囊的小控件"那一档）。没有引入第四档圆角。
  - `DESIGN.md` §6「Depth & Elevation」：触发器为 Bordered（1px `--create-agent-control-border`）；浮层为 Lifted（`--model-dropdown-bg` + 1px `--model-dropdown-border` + `--shadow-menu`），与既有 `ModelSelector` / `ExtraDirsButton` 浮层同规格。
  - `DESIGN.md` §10「Light / Dark 双模式交付门槛」：颜色全部走语义 token，无单模式硬编码分支——触发器用 `--create-agent-control-*`（与同排的权限选择器、协同按钮同族），面板用 `--model-dropdown-*` / `--model-item-*`，分组标题用 `--model-section-label`。
  - 文字层级沿用被替换控件的既有参数：引擎名 12px/500、选项行 13px/500、标题行 11px。
  - 视觉契约测试（`newMakerCreateAgentVisualContract.test.ts`）已加上述 token 的断言。

截图：**未提供**，原因见「未执行的验证」。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：exit=0（PASS apps/desktop / apps/mobile / 全部 packages）
备注：其中一次执行 packages/remote-file-service 的
"watchStart streams fileTree events for real fs changes" 失败（Error: no event yet），
单独重跑该包 14 passed，全量重跑 exit=0 —— 依赖真实 fs 事件时序的 flaky，
与本 PR 无关（本 PR 未触碰 packages/）。

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/agentSelect.test.tsx \
  src/renderer/__tests__/newMakerDraft.test.ts \
  src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
结果：74 passed（10 + 49 + 15）

pnpm --filter desktop typecheck
结果：tsc --noEmit 通过

pnpm --filter desktop exec eslint <本次改动的 6 个源文件>
结果：exit=0

pnpm check:i18n
结果：zh-CN / en / ja / ko 共 6509 个 key 全部一致

pnpm check:i18n-glossary / node scripts/brand-terminology-guard.mjs
结果：均 PASS
```

新增/更新的测试覆盖：

- `agentSelect.test.tsx`（新增 10 条）：trigger 显示当前引擎、展开后每项一行且当前项打勾、切换回调、选中当前项不重复回调、**打开时焦点落在当前选中行**、↑↓ 循环移动（数量无关，遍历 `AGENT_OPTIONS`）、`hiddenVendors` 隐藏未注册引擎、`hiddenVendors` 含当前值时不隐藏它、disabled 不展开、iconOnly 可访问名；另有两条钉住「`AGENT_OPTIONS` 与 `SELECTABLE_VENDORS` 同序同长且每项有 label/Mark」「`isSelectableVendor` 只认表内引擎」
- `newMakerDraft.test.ts`（新增 3 条）：切引擎后重新加载 module（模拟 app 重启）仍是上次选的引擎；`sanitize` 对表内引擎（含 pi）一律保留；对表外值（历史 `'orca'` / 未知 / 非字符串）回退默认
- `newMakerCreateAgentVisualContract.test.ts`（更新）：首页工具条断言改为 `<AgentSelect>` 且不再出现 `<VendorSegmentedSwitcher>`；新增 `AgentSelect` 的 token、`visibleOptions` 与 `hiddenVendors` 断言

### 手工验证

不涉及（原因见下）。

### 未执行的验证

- **Light / Dark 实机目检未执行**：本 PR 在 Cindy 内嵌 worktree 会话中开发，`docs/dev-rules/development-workflow.md` §1 明确该环境下的编辑对运行中的 dev 实例既不热更也不随重启生效，而启动包装 `pnpm restart:desktop:remote` 会停掉开发者当前正在使用的实例。双模式合规以语义 token + 视觉契约测试断言保证，**建议 reviewer 在自己的 dev 实例上过一眼两种模式**（重点看触发器描边与浮层在 Dark 下的层次）。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅新建对话页工具条上的引擎切换控件，以及 `newMakerDraft` 读取 localStorage 时的引擎白名单校验。`VendorSegmentedSwitcher` 保留原样（继续服务模型面板内的两步切换与设置页 IM 目录偏好），模型路由、会话创建、协同、`hiddenVendors` 的计算逻辑均未触碰。
- 回滚 / 降级方式：revert 本 commit 即可，无数据变更。localStorage 的 `vendor` 字段语义未变，回滚后旧值照常读取。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（新增模块的职责与「新增引擎改哪里」写在文件头注释）
- [x] 已确认测试结果或说明未执行原因
