### PR TITLE
fix(desktop): 统一任务列表状态与布局

### DIFF
--- a/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
+++ b/apps/desktop/src/renderer/__tests__/automationGeneratedSessions.test.ts
@@ -761,10 +761,10 @@ describe('automation-generated sessions', () => {
     );
     expect(source).toContain("menuOpen && 'opacity-0'");
     expect(source).toContain('disabled={!latestSession}');
-    // 自动任务组头首图标必须复用普通 SessionItem 的 15px 槽与 vendor 尺寸规则，
-    // 否则裸 VendorIcon 会比其它会话向左偏约 1.5px，Claude mark 还会小 1px。
+    // 自动任务组头首图标按模式复用普通任务槽:list 对齐 SessionCard 的 12px，
+    // text 对齐 SessionItem 的 15px；vendor 尺寸规则保持一致。
     // vendor 经 agentKindToVendor 归一(pi 会话显示 π,而非 Claude 脸);尺寸规则:cc=13,其余(codex/pi)=12。
-    expect(source).toContain('className="flex w-[15px] shrink-0 items-center justify-center"');
+    expect(source).toContain("sessionVariant === 'list' ? 'w-3' : 'w-[15px]'");
     expect(source).toContain('vendor={agentKindToVendor(latestSession?.agentKind)}');
     expect(source).toContain("size={agentKindToVendor(latestSession?.agentKind) === 'cc' ? 13 : 12}");
     // 所有自动任务统一 Timer；暂停只叠角标，主图标和 12px 槽位不替换。
@@ -772,11 +772,13 @@ describe('automation-generated sessions', () => {
     expect(source).toContain('paused={isScheduleStopped}');
     expect(source).not.toContain('<Clock');
     expect(source).not.toContain('<Pause');
-    // 沿用原 Clock 的紧凑节奏：vendor → Timer、Timer → 标题均为 6px。
+    // text 沿用 vendor → Timer → 标题的 6px 节奏；list 把 Timer 排到标题后，
+    // 标题与普通列表任务落在同一列。
     expect(source).toContain(
       'className="flex min-w-0 items-center gap-1.5 text-left disabled:cursor-default"',
     );
     expect(source).toContain('className="flex min-w-0 items-center gap-1.5"');
+    expect(source).toContain("sessionVariant === 'list' && 'order-2'");
     expect(source).toContain('runningSessionIds,');
   });
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/AutomationSessionGroupItem.tsx
@@ -311,10 +311,14 @@ export function AutomationSessionGroupItem({
         <div
           onClick={openLatestSession}
           className={cn(
-            // rounded-full + 22px 缩进:与同列表的 SessionItem 行同款药丸形/缩进
-            // (2026-07 侧栏视觉统一)。
+            // list 组头与普通 SessionCard 共用 10px 内容边距；只有展开后的子任务
+            // 由下方 pl-3 容器额外缩进。text 模式继续沿用 SessionItem 的树形缩进。
             'group relative flex h-8 w-full items-center gap-1.5 rounded-full',
-            indented ? 'pl-[22px] pr-2' : 'pl-3 pr-2',
+            sessionVariant === 'list'
+              ? 'px-2.5'
+              : indented
+                ? 'pl-[22px] pr-2'
+                : 'pl-3 pr-2',
             'text-left text-sm font-medium',
             hasActiveHidden
               ? 'bg-sidebar-item-active text-[var(--sidebar-item-active-foreground)]'
@@ -331,11 +335,16 @@ export function AutomationSessionGroupItem({
             disabled={!latestSession}
             className="flex min-w-0 items-center gap-1.5 text-left disabled:cursor-default"
           >
-            {/* 引擎 logo(vendor mark)——复用 SessionItem 左侧 15px 定宽槽与尺寸规则,
-                保证自动任务组头和普通会话的首图标落在同一列。分组 agentKind 取
+            {/* list 复用 SessionCard 的 12px 状态槽，text 复用 SessionItem 的 15px 槽；
+                这样首图标和标题都能落在各自模式的普通任务列上。分组 agentKind 取
                 最新一条 run(同一 schedule 所有 run 走同一 agent),缺失时退化为
                 'cc'。isRunning 只看最新那条,与其子行一致。 */}
-            <span className="flex w-[15px] shrink-0 items-center justify-center">
+            <span
+              className={cn(
+                'flex shrink-0 items-center justify-center',
+                sessionVariant === 'list' ? 'w-3' : 'w-[15px]',
+              )}
+            >
               <VendorIcon
                 vendor={agentKindToVendor(latestSession?.agentKind)}
                 size={agentKindToVendor(latestSession?.agentKind) === 'cc' ? 13 : 12}
@@ -343,7 +352,8 @@ export function AutomationSessionGroupItem({
                 colorClassName={hasActiveHidden ? 'text-[var(--sidebar-item-active-foreground)]' : undefined}
               />
             </span>
-            {/* 延续原 Clock 的紧凑节奏:vendor → Timer 与 Timer → 标题均留 6px。 */}
+            {/* text 延续 vendor → Timer → 标题；list 把 Timer 排到标题右侧，避免它
+                被误读成一层缩进，同时保留自动任务身份和点击入口。 */}
             <span className="flex min-w-0 items-center gap-1.5">
               {/* Timer 点击跳自动化页对应条目。宿主已是 title <button>,不能嵌套
                   button,用 span role="button" + stopPropagation 拦下行点击。 */}
@@ -361,7 +371,10 @@ export function AutomationSessionGroupItem({
                   );
                 }}
                 onPointerDown={(e) => e.stopPropagation()}
-                className="relative inline-flex size-3 shrink-0 cursor-pointer items-center justify-center"
+                className={cn(
+                  'relative inline-flex size-3 shrink-0 cursor-pointer items-center justify-center',
+                  sessionVariant === 'list' && 'order-2',
+                )}
               >
                 {/* Timer 始终占同一个 12px 槽；暂停/过期只叠状态角标，不替换主图标。 */}
                 <AutomationTimerIcon

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -13,7 +13,8 @@
  *     archived / draft 变体同款分支）
  *   - hover 右上角仅 More（⋮）快捷钮；存档收进 ⋮ / 右键展开菜单的 Archive 项
  *     （卡片不再出现独立的存档快捷钮）。已归档卡片保留"取消归档"快捷钮。
- *   - card / list 变体:标题左侧复用 SessionStatusIcon(含 agent 图标、运行呼吸、状态点、草稿铅笔)
+ *   - card / list 变体:标题左侧复用 SessionStatusIcon(含 agent 图标、运行呼吸、草稿铅笔)
+ *     list 的状态点 / spinner 与文字模式同口径，统一放在右下角
  *   - remote 会话标识复用 RemoteProjectIcon,继续区分 device-link / ssh
  *   - matchIndices 模糊搜索高亮沿用 highlightSegments
  *
@@ -70,8 +71,13 @@ import type { SessionItemProps } from './SessionItem';
 import { RemoteProjectIcon } from './RemoteProjectIcon';
 import { isRemoteSessionWriteBlocked } from '../lib/remoteSessionWriteGuard';
 import { prefetchDirtyWorktreeForRemoval } from '@/lib/worktreeRemovalWarning';
+import { useSessionAttentionKind } from '@/lib/sessionAttentionStore';
+import { useSessionAttentionUrgency } from '../contexts/SessionAttentionUrgencyContext';
+import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionActivityStore';
 import { useSessionBoundSchedules, scheduleFocusPath } from '@/features/scheduler/lib/scheduleSessionBinding';
 import { loadScheduleSidebarIndexRuns } from '@/features/scheduler/lib/scheduleSidebarIndexRuns';
+import { resolveSidebarRightStatus } from './sidebarRightStatus';
+import { SidebarRightStatusIndicator } from './SidebarRightStatusIndicator';
 
 const log = createLogger('SessionCard');
 
@@ -132,6 +138,28 @@ export function SessionCard({
   const ordinalBadgeLabel = useSessionOrdinalBadge(session.id);
   // 灵动岛同源的 per-session 实时活动(执行中逐步活动 + 等待交互态)。
   const islandActivity = useAgentIslandActivity(session.id);
+  // list 变体与文字模式共用右侧状态优先级:
+  // error > awaiting > running > done > time。远程会话由被控端活动镜像覆盖
+  // 本地 attention 链路，与 SessionItem 完全一致。
+  const attentionKind = useSessionAttentionKind(session.id);
+  const isUrgentFromContext = useSessionAttentionUrgency(session.id);
+  const remoteActivity = useRemoteSessionActivity(session.id);
+  const remoteRightStatus =
+    remoteActivity == null
+      ? null
+      : remoteActivity.phase === 'error'
+        ? ('error' as const)
+        : remoteActivity.phase === 'needs-interaction'
+          ? ('awaiting' as const)
+          : remoteActivity.phase === 'running'
+            ? ('running' as const)
+            : ('done' as const);
+  const rightStatusKind = remoteRightStatus ?? resolveSidebarRightStatus({
+    attentionKind,
+    isUrgentFromContext,
+    isRunning,
+    hasAttentionNotification,
+  });
   const isPinned = session.pinnedAt != null;
   const isEmpty = isEmptyDraftSession(session);
   const activityIso = session.updatedAt;
@@ -217,9 +245,6 @@ export function SessionCard({
     const timer = setTimeout(() => setIsSettling(false), 900);
     return () => clearTimeout(timer);
   }, [isRunning]);
-  // muted:运行中整卡变灰(文字 0.5s 过渡回正常)。
-  const isMuted = isRunning && !isActive;
-
   // ── rename（与 SessionItem 同款防重复提交 ref） ──
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(displayTitle);
@@ -430,6 +455,7 @@ export function SessionCard({
         isAttached={isAttached}
         hasAttentionNotification={hasAttentionNotification}
         isActive={isActive}
+        showAttentionDot={false}
       />
     </span>
   );
@@ -565,8 +591,7 @@ export function SessionCard({
                   className={cn(
                     'min-w-0 truncate',
                     'text-13 font-semibold leading-[1.3] tracking-[-0.005em]',
-                    'transition-[color] duration-500',
-                    isActive ? 'text-sidebar-item-active-foreground' : isMuted ? 'text-[var(--cmd-palette-item-meta)]' : 'text-foreground',
+                    isActive ? 'text-sidebar-item-active-foreground' : 'text-foreground',
                   )}
                 >
                   {titlePrefixNode}
@@ -587,19 +612,18 @@ export function SessionCard({
                     size={11}
                     strokeWidth={1.8}
                     connectionStatus={remoteIconConnectionStatus}
-                    className={isActive ? 'text-sidebar-item-active-foreground' : isMuted ? 'text-[var(--text-disabled)]' : 'text-[var(--text-tertiary)]'}
+                    className={isActive ? 'text-sidebar-item-active-foreground' : 'text-[var(--text-tertiary)]'}
                   />
                 )}
               </div>
             )}
 
-            {/* 时间槽位:hover/菜单打开让位给 More/Archive(逻辑同对话列表)。agent /
-                自动任务状态图标已移到本行左上角(标题左侧)。 */}
+            {/* 时间槽位:hover/菜单打开让位给 More/Archive(逻辑同对话列表)。
+                Agent 身份图标留在标题左侧，状态指示器改由下方右下角承担。 */}
             {!isEditing && (
               <TimeActionsSlot
                 sessionId={session.id}
                 activityIso={activityIso}
-                isMuted={isMuted}
                 isActive={isActive}
                 isArchived={isArchived}
                 canQuickArchive={canQuickArchive}
@@ -622,24 +646,29 @@ export function SessionCard({
 
           {/* 预览区——固定 1 行高度(标题 1 行 + 此 1 行 = 列表行统一两行高;运行 /
               非运行、内容长短都不变,始终渲染占位)。等待交互 TapTap 蓝高亮
-              (--card-status-awaiting),运行/空闲走 muted/次级色。 */}
+              (--card-status-awaiting),其余状态统一走次级色。 */}
           <p
             className={cn(
               'mt-1 overflow-hidden text-11 leading-[1.45]',
               '[display:-webkit-box] [-webkit-line-clamp:1] [-webkit-box-orient:vertical]',
-              'transition-[color] duration-500',
+              rightStatusKind !== 'time' && 'pr-5',
               awaitingText
                 ? isActive
                   ? 'text-[var(--sidebar-item-active-foreground)] font-medium'
                   : 'text-[var(--card-status-awaiting)] font-medium'
-                : isMuted
-                  ? 'text-[var(--text-disabled)]'
-                  : 'text-[var(--text-secondary)]',
+                : 'text-[var(--text-secondary)]',
             )}
             style={{ height: '1.45em' }}
           >
             {listPreview}
           </p>
+          {rightStatusKind !== 'time' && (
+            <SidebarRightStatusIndicator
+              kind={rightStatusKind}
+              isActive={isActive}
+              className="absolute right-2.5 bottom-2"
+            />
+          )}
         </div>
       ) : (
       <div className="relative flex h-full flex-col px-[10px] pt-[8px] pb-[8px]">
@@ -691,10 +720,10 @@ export function SessionCard({
             onPointerDown={(e) => e.stopPropagation()}
             onDoubleClick={(e) => e.stopPropagation()}
             className={cn(
-              'absolute right-[6px] top-[6px] z-10 flex h-[22px] items-center justify-center rounded-full px-[9px]',
-              'text-11 font-semibold',
-              'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,transparent)] text-[hsl(var(--destructive))]',
-              'hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,transparent)]',
+              'absolute right-[6px] top-[6px] z-20 flex h-[22px] w-max min-w-14 items-center justify-center rounded-full px-[9px]',
+              'whitespace-nowrap text-11 font-semibold',
+              'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,var(--surface-elevated))] text-[hsl(var(--destructive))]',
+              'hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,var(--surface-elevated))]',
               'transition-colors focus:outline-none',
             )}
             aria-label={t('ccAgent.sidebar.sessionMenu.archived')}
@@ -737,8 +766,7 @@ export function SessionCard({
             className={cn(
               'min-w-0 text-[12.5px] font-bold leading-[1.22] tracking-[-0.005em]',
               '[display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] overflow-hidden',
-              'transition-[color] duration-500',
-              isActive ? 'text-sidebar-item-active-foreground' : isMuted ? 'text-[var(--cmd-palette-item-meta)]' : 'text-foreground',
+              isActive ? 'text-sidebar-item-active-foreground' : 'text-foreground',
             )}
             style={{ textIndent: 0, paddingLeft: 0 }}
           >
@@ -762,9 +790,7 @@ export function SessionCard({
             className={cn(
               'mt-[4px] text-11 leading-[1.4]',
               '[display:-webkit-box] [-webkit-box-orient:vertical] overflow-hidden',
-              'transition-[color] duration-500',
-              // 评审:等待决策不再额外多出一种黄色,与 running 同口径走 muted/次级色。
-              isMuted ? 'text-[var(--text-disabled)]' : 'text-[var(--text-secondary)]',
+              'text-[var(--text-secondary)]',
             )}
             style={{ WebkitLineClamp: cardPreviewLineClamp }}
           >
@@ -779,8 +805,7 @@ export function SessionCard({
           className={cn(
             'mt-[6px] flex items-center gap-1.5',
             'text-11 font-medium leading-none tabular-nums',
-            'transition-[color] duration-500',
-            isActive ? 'text-sidebar-item-active-foreground' : isMuted ? 'text-[var(--text-disabled)]' : 'text-[var(--text-tertiary)]',
+            isActive ? 'text-sidebar-item-active-foreground' : 'text-[var(--text-tertiary)]',
           )}
         >
           <SessionStatusIcon
@@ -798,7 +823,7 @@ export function SessionCard({
               size={11}
               strokeWidth={1.8}
               connectionStatus={remoteIconConnectionStatus}
-              className={isActive ? 'text-sidebar-item-active-foreground' : isMuted ? 'text-[var(--text-disabled)]' : 'text-[var(--text-tertiary)]'}
+              className={isActive ? 'text-sidebar-item-active-foreground' : 'text-[var(--text-tertiary)]'}
             />
           )}
           <WorktreeBadge sessionId={session.id} size={11} className="size-3.5" />
@@ -818,15 +843,13 @@ export function SessionCard({
           压过 hover 操作钮,pointer-events-none 不挡点击。前景色与时间同色系,
           kbd 内 text-current + currentColor 底自动跟随。编辑态让位给重命名
           输入框。 */}
-      {!isEditing && ordinalBadgeLabel != null && (
+      {!isEditing && !archivePending && ordinalBadgeLabel != null && (
         <span
           className={cn(
             'pointer-events-none absolute right-2 top-2 z-20 flex',
             isActive
               ? 'text-sidebar-item-active-foreground'
-              : isMuted
-                ? 'text-[var(--text-disabled)]'
-                : 'text-[var(--text-tertiary)]',
+              : 'text-[var(--text-tertiary)]',
           )}
         >
           <SessionOrdinalBadgeKbd label={ordinalBadgeLabel} />
@@ -957,12 +980,11 @@ export function SessionCard({
 
 /** 右上角时间槽位——card / list 变体共用。默认显示 [worktree + 时间];hover/菜单打开
  *  时整组让位给操作按钮(More + Archive/Undo),archivePending 时显示红色二次确认胶囊。
- *  交互逻辑与对话列表(SessionItem)一致。agent / 运行 / 完成 / 草稿等状态由槽位左侧常驻
- *  的 SessionStatusIcon 承担(card 在标题左、list 在时间左),不在本组件内、不随 hover 淡出。 */
+ *  交互逻辑与对话列表(SessionItem)一致。Agent 身份 / 草稿由左侧 SessionStatusIcon 承担；
+ *  list 的右下状态指示器由 SidebarRightStatusIndicator 单独承担。 */
 function TimeActionsSlot({
   sessionId,
   activityIso,
-  isMuted,
   isActive,
   isArchived,
   canQuickArchive,
@@ -978,7 +1000,6 @@ function TimeActionsSlot({
 }: {
   sessionId: string;
   activityIso: string;
-  isMuted: boolean;
   isActive: boolean;
   isArchived: boolean;
   canQuickArchive: boolean;
@@ -1002,7 +1023,9 @@ function TimeActionsSlot({
           // duration 与操作钮的渐显同拍(120ms),让位/回归一进一出同步。
           'flex items-center gap-1 transition-opacity duration-[120ms]',
           !archivePending && 'group-hover/card:opacity-0',
-          (menuOpen || archivePending || yieldToOrdinalBadge) && 'opacity-0',
+          (menuOpen || yieldToOrdinalBadge) && 'opacity-0',
+          // 确认胶囊覆盖同一槽位时立即隐藏日期，避免 120ms 淡出期间文字叠在一起。
+          archivePending && 'invisible opacity-0',
         )}
       >
         <WorktreeBadge sessionId={sessionId} size={11} className="size-3.5" />
@@ -1011,7 +1034,7 @@ function TimeActionsSlot({
           title={formatSidebarTimeAbsolute(activityIso)}
           className={cn(
             'text-[10.5px] font-medium leading-none tabular-nums',
-            isActive ? 'text-sidebar-item-active-foreground' : isMuted ? 'text-[var(--text-disabled)]' : 'text-[var(--text-tertiary)]',
+            isActive ? 'text-sidebar-item-active-foreground' : 'text-[var(--text-tertiary)]',
           )}
         >
           {formatSidebarTime(activityIso, t)}
@@ -1030,10 +1053,10 @@ function TimeActionsSlot({
           onPointerDown={(e) => e.stopPropagation()}
           onDoubleClick={(e) => e.stopPropagation()}
           className={cn(
-            'absolute right-0 top-1/2 flex h-[22px] -translate-y-1/2 items-center justify-center rounded-full px-[9px]',
-            'text-11 font-semibold',
-            'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,transparent)] text-[hsl(var(--destructive))]',
-            'hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,transparent)]',
+            'absolute right-0 top-1/2 z-20 flex h-[22px] w-max min-w-14 -translate-y-1/2 items-center justify-center rounded-full px-[9px]',
+            'whitespace-nowrap text-11 font-semibold',
+            'bg-[color-mix(in_srgb,hsl(var(--destructive))_15%,var(--surface-elevated))] text-[hsl(var(--destructive))]',
+            'hover:bg-[color-mix(in_srgb,hsl(var(--destructive))_25%,var(--surface-elevated))]',
             'transition-colors focus:outline-none',
           )}
           aria-label={t('ccAgent.sidebar.sessionMenu.archived')}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -36,7 +36,6 @@ import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
-import { Spinner } from '@/components/ui/spinner';
 import type { Session } from '@/lib/ccAgent.types';
 import { WorktreeBadge } from '@/components/sidebar/WorktreeBadge';
 import { SessionStatusIcon } from './SessionStatusIcon';
@@ -90,6 +89,7 @@ import { useSessionAttentionUrgency } from '../contexts/SessionAttentionUrgencyC
 import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionActivityStore';
 import { resolveSidebarRightStatus } from './sidebarRightStatus';
 import { AutomationTimerIcon } from './AutomationTimerIcon';
+import { SidebarRightStatusIndicator } from './SidebarRightStatusIndicator';
 
 // Module-level dedup cache for loadScheduleSidebarIndexRuns.
 // When many ungrouped automation rows mount simultaneously they all need the
@@ -774,58 +774,7 @@ export const SessionItem = memo(function SessionItem({
           >
             <WorktreeBadge sessionId={session.id} size={12} className="size-4" />
             {showRightStatus ? (
-              rightStatusKind === 'error' ? (
-                <span
-                  role="img"
-                  className="inline-flex size-4 items-center justify-center"
-                  aria-label={t('ccAgent.sidebar.status.error', 'Failed — click to view')}
-                  title={t('ccAgent.sidebar.status.error', 'Failed — click to view')}
-                >
-                  <span
-                    className="size-2 rounded-full"
-                    style={{ backgroundColor: isActive ? 'var(--sidebar-item-active-foreground)' : 'var(--card-status-error)' }}
-                    aria-hidden
-                  />
-                </span>
-              ) : rightStatusKind === 'awaiting' ? (
-                <span
-                  role="img"
-                  className="inline-flex size-4 items-center justify-center"
-                  aria-label={t('ccAgent.sidebar.status.needsAttention', 'Awaiting your input')}
-                  title={t('ccAgent.sidebar.status.needsAttention', 'Awaiting your input')}
-                >
-                  <span
-                    className="size-2 rounded-full"
-                    style={{ backgroundColor: isActive ? 'var(--sidebar-item-active-foreground)' : 'var(--card-status-awaiting)' }}
-                    aria-hidden
-                  />
-                </span>
-              ) : rightStatusKind === 'running' ? (
-                <Spinner
-                  role="img"
-                  size={12}
-                  strokeWidth={2}
-                  className={cn(
-                    'size-4',
-                    isActive ? 'text-sidebar-item-active-foreground' : 'text-sidebar-action-icon',
-                  )}
-                  aria-label={t('ccAgent.sidebar.status.running', 'Running')}
-                  title={t('ccAgent.sidebar.status.running', 'Running')}
-                />
-              ) : (
-                <span
-                  role="img"
-                  className="inline-flex size-4 items-center justify-center"
-                  aria-label={t('ccAgent.sidebar.status.done', 'Completed — click to view')}
-                  title={t('ccAgent.sidebar.status.done', 'Completed — click to view')}
-                >
-                  <span
-                    className="size-2 rounded-full"
-                    style={{ backgroundColor: isActive ? 'var(--sidebar-item-active-foreground)' : 'var(--card-status-done)' }}
-                    aria-hidden
-                  />
-                </span>
-              )
+              <SidebarRightStatusIndicator kind={rightStatusKind} isActive={isActive} />
             ) : (
               <time
                 dateTime={activityIso}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarRightStatusIndicator.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SidebarRightStatusIndicator.tsx
@@ -1,0 +1,68 @@
+import { useTranslation } from 'react-i18next';
+
+import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils';
+import type { SidebarRightStatusKind } from './sidebarRightStatus';
+
+/**
+ * 会话行的右侧状态指示器。文字模式与列表模式共用这一份
+ * 颜色、文案和选中反白规则，各宿主只决定定位。
+ */
+export function SidebarRightStatusIndicator({
+  kind,
+  isActive,
+  className,
+}: {
+  kind: Exclude<SidebarRightStatusKind, 'time'>;
+  isActive: boolean;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+
+  if (kind === 'running') {
+    return (
+      <Spinner
+        data-sidebar-right-status={kind}
+        role="img"
+        size={12}
+        strokeWidth={2}
+        className={cn(
+          'size-4',
+          isActive ? 'text-sidebar-item-active-foreground' : 'text-sidebar-action-icon',
+          className,
+        )}
+        aria-label={t('ccAgent.sidebar.status.running', 'Running')}
+        title={t('ccAgent.sidebar.status.running', 'Running')}
+      />
+    );
+  }
+
+  const label =
+    kind === 'error'
+      ? t('ccAgent.sidebar.status.error', 'Failed — click to view')
+      : kind === 'awaiting'
+        ? t('ccAgent.sidebar.status.needsAttention', 'Awaiting your input')
+        : t('ccAgent.sidebar.status.done', 'Completed — click to view');
+  const color =
+    kind === 'error'
+      ? 'var(--card-status-error)'
+      : kind === 'awaiting'
+        ? 'var(--card-status-awaiting)'
+        : 'var(--card-status-done)';
+
+  return (
+    <span
+      data-sidebar-right-status={kind}
+      role="img"
+      className={cn('inline-flex size-4 items-center justify-center', className)}
+      aria-label={label}
+      title={label}
+    >
+      <span
+        className="size-2 rounded-full"
+        style={{ backgroundColor: isActive ? 'var(--sidebar-item-active-foreground)' : color }}
+        aria-hidden
+      />
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   worktreeSessionIds: new Set<string>(),
   runningDetailBySession: new Map<string, string>(),
   pendingPluginSetupSessionIds: new Set<string>(),
+  attentionKindBySession: new Map<string, 'done' | 'awaiting' | 'error'>(),
 }));
 
 vi.mock('react-router-dom', () => ({
@@ -113,6 +114,10 @@ vi.mock('@/hooks/useSessionPausedQueue', () => ({
   useSessionPausedQueue: () => false,
 }));
 
+vi.mock('@/lib/sessionAttentionStore', () => ({
+  useSessionAttentionKind: (sessionId: string) => mocks.attentionKindBySession.get(sessionId),
+}));
+
 vi.mock('../../lib/scrollIntoNearestView', () => ({
   scrollIntoNearestView: vi.fn(),
 }));
@@ -181,6 +186,7 @@ describe('SessionCard visual cases', () => {
     mocks.worktreeSessionIds.clear();
     mocks.runningDetailBySession.clear();
     mocks.pendingPluginSetupSessionIds.clear();
+    mocks.attentionKindBySession.clear();
   });
 
   afterEach(() => {
@@ -348,6 +354,39 @@ describe('SessionCard visual cases', () => {
     expect(screen.getByText('已归档的历史分析任务')).toBeTruthy();
   });
 
+  it.each(['list', 'card'] as const)('keeps the %s archive confirmation pill on one line', (variant) => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'short-idle-cc');
+    if (!visualCase) throw new Error('Missing idle visual case');
+
+    const { container } = render(
+      createElement(SessionCard, {
+        session: visualCase.session,
+        variant: variant === 'list' ? 'list' : undefined,
+        isActive: false,
+        isRunning: false,
+        isAttached: false,
+        hasAttentionNotification: false,
+        isSelected: false,
+        onClick: vi.fn(),
+        onAction: vi.fn(),
+        onRename: vi.fn(),
+        onTogglePin: vi.fn(),
+        projectOptions: [],
+      }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '归档' }));
+    const confirmPill = screen.getByRole('button', { name: '归档' });
+    expect(confirmPill.className).toContain('w-max');
+    expect(confirmPill.className).toContain('min-w-14');
+    expect(confirmPill.className).toContain('whitespace-nowrap');
+    expect(confirmPill.className).toContain('var(--surface-elevated)');
+    expect(confirmPill.className).not.toContain('transparent');
+    if (variant === 'list') {
+      expect(container.querySelector('time')?.parentElement?.className).toContain('invisible');
+    }
+  });
+
   it('keeps running card mode on the stable preview while list mode can show live detail', () => {
     const visualCase = sessionCardVisualCases.find((item) => item.id === 'running-loading');
     if (!visualCase) throw new Error('Missing running visual case');
@@ -374,5 +413,153 @@ describe('SessionCard visual cases', () => {
 
     const { container: listContainer } = render(createElement(SessionCard, { ...commonProps, variant: 'list' }));
     expect(listContainer.textContent).toContain('正在实时扫描并刷新当前执行步骤');
+  });
+
+  it.each(['list', 'card'] as const)('keeps running %s text colors identical to idle', (variant) => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'running-loading');
+    if (!visualCase) throw new Error('Missing running visual case');
+
+    const renderColors = (isRunning: boolean) => {
+      const { container } = render(
+        createElement(SessionCard, {
+          session: visualCase.session,
+          variant: variant === 'list' ? 'list' : undefined,
+          isActive: false,
+          isRunning,
+          isAttached: false,
+          hasAttentionNotification: false,
+          isSelected: false,
+          onClick: vi.fn(),
+          onAction: vi.fn(),
+          onRename: vi.fn(),
+          onTogglePin: vi.fn(),
+          projectOptions: [],
+        }),
+      );
+      const title =
+        variant === 'list'
+          ? Array.from(container.querySelectorAll('span')).find(
+              (node) => node.className.includes('truncate') && node.textContent?.includes(visualCase.session.title),
+            )
+          : Array.from(container.querySelectorAll('div')).find((node) =>
+              node.className.includes('[-webkit-line-clamp:2]'),
+            );
+      const preview = Array.from(container.querySelectorAll('p')).find((node) =>
+        node.textContent?.includes('正在分析本周项目数据与异常波动。'),
+      );
+      const time = container.querySelector('time');
+      const colors = [title, preview, time].map((node) =>
+        node?.className
+          .split(' ')
+          .filter(
+            (className) =>
+              className === 'text-foreground' ||
+              className.startsWith('text-[var(--text-') ||
+              className === 'text-[var(--cmd-palette-item-meta)]',
+          ),
+      );
+      cleanup();
+      return colors;
+    };
+
+    expect(renderColors(true)).toEqual(renderColors(false));
+  });
+
+  it.each([
+    ['done', 'var(--card-status-done)'],
+    ['awaiting', 'var(--card-status-awaiting)'],
+    ['error', 'var(--card-status-error)'],
+  ] as const)('moves the %s attention dot to the list bottom-right corner', (kind, color) => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'attention-dot');
+    if (!visualCase) throw new Error('Missing attention visual case');
+    mocks.attentionKindBySession.set(visualCase.session.id, kind);
+
+    const { container } = render(
+      createElement(SessionCard, {
+        session: visualCase.session,
+        variant: 'list',
+        isActive: false,
+        isRunning: false,
+        isAttached: false,
+        hasAttentionNotification: true,
+        isSelected: false,
+        onClick: vi.fn(),
+        onAction: vi.fn(),
+        onRename: vi.fn(),
+        onTogglePin: vi.fn(),
+        projectOptions: [],
+      }),
+    );
+
+    const rightStatus = container.querySelector(`[data-sidebar-right-status="${kind}"]`);
+    expect(rightStatus?.className).toContain('right-2.5');
+    expect(rightStatus?.className).toContain('bottom-2');
+    expect((rightStatus?.firstElementChild as HTMLElement | null)?.style.backgroundColor).toBe(color);
+
+    const title = Array.from(container.querySelectorAll('span')).find((node) =>
+      node.className.includes('truncate') && node.textContent?.includes(visualCase.session.title),
+    );
+    expect(
+      Array.from(title?.querySelectorAll('span') ?? []).some((node) =>
+        node.className.includes('bg-[var(--card-status-'),
+      ),
+    ).toBe(false);
+  });
+
+  it('uses the text-mode priority when a list session is both running and unread-done', () => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'attention-dot');
+    if (!visualCase) throw new Error('Missing attention visual case');
+    mocks.attentionKindBySession.set(visualCase.session.id, 'done');
+
+    const { container } = render(
+      createElement(SessionCard, {
+        session: visualCase.session,
+        variant: 'list',
+        isActive: false,
+        isRunning: true,
+        isAttached: false,
+        hasAttentionNotification: true,
+        isSelected: false,
+        onClick: vi.fn(),
+        onAction: vi.fn(),
+        onRename: vi.fn(),
+        onTogglePin: vi.fn(),
+        projectOptions: [],
+      }),
+    );
+
+    const rightStatus = container.querySelector('[data-sidebar-right-status="running"]');
+    expect(rightStatus?.className).toContain('right-2.5');
+    expect(rightStatus?.className).toContain('bottom-2');
+    expect(container.querySelector('[data-sidebar-right-status="done"]')).toBeNull();
+  });
+
+  it('keeps the attention dot on the status icon in card mode', () => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'attention-dot');
+    if (!visualCase) throw new Error('Missing attention visual case');
+    mocks.attentionKindBySession.set(visualCase.session.id, 'done');
+
+    const { container } = render(
+      createElement(SessionCard, {
+        session: visualCase.session,
+        isActive: false,
+        isRunning: false,
+        isAttached: false,
+        hasAttentionNotification: true,
+        isSelected: false,
+        onClick: vi.fn(),
+        onAction: vi.fn(),
+        onRename: vi.fn(),
+        onTogglePin: vi.fn(),
+        projectOptions: [],
+      }),
+    );
+
+    expect(container.querySelector('[data-sidebar-right-status]')).toBeNull();
+    expect(
+      Array.from(container.querySelectorAll('span')).some((node) =>
+        node.className.includes('bg-[var(--card-status-done)]'),
+      ),
+    ).toBe(true);
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -73,6 +73,15 @@ describe('SessionCard review regressions', () => {
     expect(sessionCardSource).toContain('ml-auto shrink-0'); // E1D 侧栏层级:time 色 conditional via cn,ml-auto shrink-0 保留
   });
 
+  it('keeps archive confirmation pills clear of time and ordinal overlays', () => {
+    expect(sessionCardSource).toContain('w-max min-w-14');
+    expect(sessionCardSource).toContain('whitespace-nowrap text-11 font-semibold');
+    expect(sessionCardSource).toContain(
+      '!isEditing && !archivePending && ordinalBadgeLabel != null',
+    );
+    expect(sessionCardSource).toContain("archivePending && 'invisible opacity-0'");
+  });
+
   it('keeps running card previews stable instead of streaming compact activity text', () => {
     expect(sessionCardSource).toContain('const listPreview = awaitingText ?? runningDetail ?? summaryPreview');
     expect(sessionCardSource).toContain('const cardPreview = awaitingText ?? summaryPreview');
@@ -84,12 +93,19 @@ describe('SessionCard review regressions', () => {
     expect(sessionCardSource).not.toContain("'h-full rounded-xl bg-[var(--surface-elevated)] border'");
   });
 
-  it('E1D 任务C: SessionCard active 反白链收全(title/time/RemoteProjectIcon 全切 sidebar-item-active-foreground)', () => {
-    // 阿梅 SIDEBAR-R 打回:SessionCard 漏网(title 700 + RemoteProjectIcon 556/735/753/941)未切反白,现收全
+  it('E1D 任务C: SessionCard active 反白链完整且运行态不降级文字颜色', () => {
     const re = /isActive \? 'text-sidebar-item-active-foreground'/g;
     const count = (sessionCardSource.match(re) || []).length;
     expect(count, 'isActive conditional active-foreground ≥7(title×2+time+RemoteProjectIcon×4)').toBeGreaterThanOrEqual(7);
-    expect(sessionCardSource).toContain("isActive ? 'text-sidebar-item-active-foreground' : isMuted ? 'text-[var(--text-disabled)]' : 'text-[var(--text-tertiary)]'");
+
+    // Running is already expressed by the status indicator, so its text keeps
+    // the same semantic colors as other non-active tasks.
+    expect(sessionCardSource).not.toContain('const isMuted = isRunning && !isActive');
+    expect(sessionCardSource).not.toContain("isMuted ? 'text-[var(--text-disabled)]'");
+    expect(sessionCardSource).not.toContain('transition-[color] duration-500');
+    expect(sessionCardSource).toContain(
+      "isActive ? 'text-sidebar-item-active-foreground' : 'text-[var(--text-tertiary)]'",
+    );
   });
 
   it('keeps selected sidebar text bound to the active foreground token', () => {
@@ -193,6 +209,21 @@ describe('SessionCard review regressions', () => {
     );
     expect(automationGroupSource).toContain(
       ": 'text-foreground hover:bg-sidebar-item-hover'",
+    );
+  });
+
+  it('aligns list automation headers with regular tasks and indents only expanded children', () => {
+    expect(automationGroupSource).toMatch(
+      /sessionVariant === 'list'\s*\? 'px-2\.5'\s*: indented\s*\? 'pl-\[22px\] pr-2'\s*: 'pl-3 pr-2'/,
+    );
+    expect(automationGroupSource).toContain(
+      '<div className="flex flex-col gap-0.5 pl-3">',
+    );
+    expect(automationGroupSource).toContain(
+      "sessionVariant === 'list' ? 'w-3' : 'w-[15px]'",
+    );
+    expect(automationGroupSource).toContain(
+      "sessionVariant === 'list' && 'order-2'",
     );
   });
 });


### PR DESCRIPTION
## 这次改了什么

### 摘要

统一 Desktop 任务列表模式的状态与布局表现：状态点和运行 spinner 与文字模式一致放到右下角；运行中任务不再单独降低标题、摘要和时间颜色，也移除选中时 500ms 的文字颜色渐变；折叠的自动任务与普通任务左对齐，仅展开后的子任务缩进；归档确认胶囊改为不透明单行覆盖，避免与标题、时间或序号叠字。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：本次会话内的任务列表模式体验修复
- 本 PR 包含：列表/card 任务卡的状态、文字颜色、自动任务对齐、归档确认遮挡，以及对应回归测试
- 明确不包含：任务状态判定规则变更、数据库/协议/移动端改动
- 用户可见变化：列表状态提示位置统一；运行中与普通任务文字颜色一致；自动任务折叠行对齐；归档确认不再叠字
- 是否存在 breaking change：无

### UI 变化

- macOS Desktop 开发版已由用户手工确认本次列表模式交互正常；未附公开截图。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark Dual-Mode Delivery Gate」——颜色继续使用既有语义 token，覆盖选中、运行、完成、等待和错误状态；§14.4「Motion & Transitions」——移除不符合即时选择反馈的 500ms 硬编码颜色过渡；§15.10「Sidebar color hierarchy」——任务标题保持正文层级，次要信息保持 secondary/tertiary 层级，选中态使用 active foreground。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-pinned-task-status-dot-position
结果：GATE_EXIT=0（全仓单元测试通过）

pnpm --filter desktop run --if-present typecheck
结果：通过（提交前及 rebase 后各执行一次）

pnpm --filter desktop exec eslint <本次 7 个 TS/TSX 文件>
结果：通过

pnpm check:dco
结果：通过，1 个 commit 均有 DCO 签名

git diff origin/main...HEAD --check
结果：通过
```

### 手工验证

- macOS Desktop 功能 worktree，`worklouder` 隔离测试沙箱。
- 用户验证了列表模式状态点位置、运行中文字颜色、选中即时变色、自动任务折叠/展开对齐和归档确认遮挡，并确认无问题。

### 未执行的验证

- 未单独目检 Dark 模式；实现复用语义 token，但不将其表述为 Dark 实机验证。
- 未验证 Windows/Linux 实机；改动仅涉及 Renderer 布局与样式。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Renderer 的任务列表/card 展示，不改变状态数据或持久化。
- 回滚 / 降级方式：回退本 PR 即可恢复原有布局与样式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试；无需额外产品文档
- [x] 已确认测试结果并说明未执行项
