### PR TITLE
fix(mac): 签名覆盖 Contents/Resources 全部 Mach-O,公证失败不再吞结论

### DIFF
--- a/apps/desktop/scripts/ci/lib.mjs
+++ b/apps/desktop/scripts/ci/lib.mjs
@@ -602,13 +602,23 @@ export function signMacAppWithIdentity(appPath, helperEntitlementsPath, mainEnti
     exec(`find "${asarUnpackedDir}" -type f | while IFS= read -r f; do if file "$f" | grep -qE "Mach-O"; then ${signBase} "$f"; fi; done`);
   }
 
-  // 0b. Contents/Resources/tools/ 下的 CLI 工具(extraResource 拷入,公证要求显式签)。
-  const resourceToolsDir = path.join(appPath, 'Contents', 'Resources', 'tools');
-  if (fs.existsSync(resourceToolsDir)) {
-    console.log('    Signing bundled CLI tools in Contents/Resources/tools/...');
-    exec(`find "${resourceToolsDir}" -type f | while IFS= read -r f; do if file "$f" | grep -qE "Mach-O"; then ${signBase} "$f"; fi; done`);
+  // 0b. Contents/Resources/ 下 extraResource 拷入的第三方产物(CLI 工具、Pi 目录分发
+  //     等)公证要求逐个显式签。这里扫**整个 Resources**而不是逐目录白名单:此前只签
+  //     tools/,漏了 resources/pi/ —— Pi 是目录分发(pi 主执行文件 + 3 个 .node),
+  //     bun 产物只自带 adhoc/linker 签名,Apple 公证对主执行文件报 "signature is
+  //     invalid"、对 .node 报 "not signed with a valid Developer ID",直接 Invalid。
+  //     (Windows 侧 forge.config.ts 已单独递归签 resources/pi,mac 这条链路没跟上。)
+  //     注意 codesign --verify --deep --strict 拦不住这类问题:--deep 只递归嵌套
+  //     bundle,不校验 Resources 下散装的 Mach-O,公证才严格。extraResource 里还有
+  //     cc-manager / anthropic-compat-proxy / remote-file-service /
+  //     android-platform-tools,任一将来带上原生产物都会重演,故整体扫描、新增资源
+  //     免维护。app.asar.unpacked 已在上一步签过,prune 掉避免重复签。
+  const resourcesDir = path.join(appPath, 'Contents', 'Resources');
+  if (fs.existsSync(resourcesDir)) {
+    console.log('    Signing bundled Mach-O in Contents/Resources/...');
+    exec(`find "${resourcesDir}" -name app.asar.unpacked -prune -o -type f -print | while IFS= read -r f; do if file "$f" | grep -qE "Mach-O"; then ${signBase} "$f"; fi; done`);
     console.log('    Signing bundled resource app bundles...');
-    exec(`find "${resourceToolsDir}" -depth -type d -name "*.app" -exec ${signBase} "{}" \\;`);
+    exec(`find "${resourcesDir}" -depth -type d -name "*.app" -exec ${signBase} "{}" \\;`);
   }
 
   // 1. 全部 Mach-O(库、chrome_crashpad_handler、ShipIt 等)
@@ -661,15 +671,31 @@ export function notarizeMacApp(appPath, identity) {
     '--team-id',
     identity.teamId,
     '--wait',
+    // JSON 输出换取"可判定的最终结论":notarytool submit --wait 对「提交成功但结论
+    // Invalid」同样返回 exit 0,只判 exit code 会放过公证失败、继续往下 staple,最终
+    // 报成一句莫名的 stapler "Record not found" / Error 65,真实原因(哪些二进制没签)
+    // 被完全掩盖。代价是 --wait 期间不再打进度点,输出改为结束后一次性回显。
+    '--output-format',
+    'json',
   ];
   console.log(
     `    $ /usr/bin/xcrun notarytool submit "${zipPath}" ` +
-      `--apple-id "${identity.appleId}" --password "****" --team-id "${identity.teamId}" --wait`,
+      `--apple-id "${identity.appleId}" --password "****" --team-id "${identity.teamId}" --wait --output-format json`,
   );
   const submitResult = spawnSync('/usr/bin/xcrun', submitArgs, {
-    stdio: 'inherit',
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 1800000, // 30 min
   });
+  const submitOutput = `${submitResult.stdout ?? ''}${submitResult.stderr ?? ''}`.trim();
+  if (submitOutput) {
+    console.log(
+      submitOutput
+        .split('\n')
+        .map((line) => `    ${line}`)
+        .join('\n'),
+    );
+  }
   if (submitResult.error) {
     throw new Error(`notarytool submit 无法执行:${submitResult.error.message}`);
   }
@@ -680,6 +706,42 @@ export function notarizeMacApp(appPath, identity) {
   }
   if (submitResult.status !== 0) {
     throw new Error(`notarytool submit 失败(exit ${submitResult.status});公证未通过。`);
+  }
+
+  // exit 0 只代表"提交与轮询本身成功",结论还得看 status:Accepted / Invalid /
+  // Rejected。非 Accepted 一律在此中止,并自动把 Apple 的逐文件裁决(notarytool log)
+  // 打进构建日志——公证失败十有八九是某个第三方二进制没签 Developer ID,日志里直接
+  // 给出路径,不必再手工拿 submission id 去捞。
+  let submission;
+  try {
+    submission = JSON.parse(submitResult.stdout ?? '');
+  } catch {
+    throw new Error(`notarytool submit 输出无法解析为 JSON,公证结论未知:\n${submitOutput}`);
+  }
+  if (submission.status !== 'Accepted') {
+    if (submission.id) {
+      console.log(`    Fetching notarization log for ${submission.id} ...`);
+      spawnSync(
+        '/usr/bin/xcrun',
+        [
+          'notarytool',
+          'log',
+          submission.id,
+          '--apple-id',
+          identity.appleId,
+          '--password',
+          identity.applePassword,
+          '--team-id',
+          identity.teamId,
+        ],
+        { stdio: 'inherit', timeout: 300000 },
+      );
+    }
+    throw new Error(
+      `公证未通过:status=${submission.status ?? '(unknown)'}` +
+        `${submission.id ? `,submission id=${submission.id}` : ''}。` +
+        '常见原因是 Contents/Resources 下某个第三方二进制未签 Developer ID(见上方 notarytool log)。',
+    );
   }
 
   fs.unlinkSync(zipPath);


### PR DESCRIPTION
## 问题

mac 打包在公证阶段失败,`notarytool` 返回 `status: Invalid`,但日志里报出来的却是一句莫名的 stapler 错误:

```
Current status: Invalid...........Processing complete
  status: Invalid
    Stapling notarization ticket...
CloudKit query for Cindy.app ... failed due to "Record not found".
The staple and validate action failed! Error 65.
```

拉 `notarytool log` 后确认:9 条 error **全部**指向 `Contents/Resources/pi/**` —— Pi 主执行文件 + 3 个 `.node` 都没签 Developer ID。

## 根因

`signMacAppWithIdentity()` 只签三处:`Contents/Resources/app.asar.unpacked`、`Contents/Resources/tools`、`Contents/Frameworks`。Pi 是**目录分发**,`stagePi` 把它放在 `Resources/pi/<platform>/` 而不是 `tools/` 下,于是整份漏签。bun 产物只自带 adhoc/linker 签名,Apple 对主执行文件判 `signature is invalid`、对 `.node` 判 `not signed with a valid Developer ID`。

Windows 侧 `forge.config.ts` 已经专门处理过(`collectExeFilesRecursively(resources/pi)`,注释写明「不在 tools/ 下,必须一并签名」),mac 这条链路没跟上。

`codesign --verify --deep --strict` 为什么放行:`--deep` 只递归嵌套 bundle(.app/.framework),不校验 `Resources/` 下散装的 Mach-O —— 那些只被 CodeResources 哈希封存,不要求自带签名。公证比 codesign 严。

## 改动

**1. 补签范围扩到整个 `Contents/Resources`**(prune 掉上一步已签的 `app.asar.unpacked`),而不是只补一行 `Resources/pi`。`extraResource` 里还有 `cc-manager` / `anthropic-compat-proxy` / `remote-file-service` / `android-platform-tools`(`adb` 即 Mach-O,这次只是恰好 missing 没进包),任一将来带上原生产物都会重演同一次事故。

按实测结论,pi **不需要** `allow-jit` 等 entitlements,所以与 `tools/` 完全同构:`--force --timestamp --options runtime --sign <identity>`。

**2. 公证结论不再被吞。** `notarytool submit --wait` 对「提交成功但结论 Invalid」同样返回 exit 0,原代码只判 exit code,于是继续 staple,真实原因被掩盖成 Error 65。改为 `--output-format json` 解析 `status`,非 `Accepted` 立即中止,并自动打印 `notarytool log` 把 Apple 的逐文件裁决写进构建日志。

代价:`--wait` 期间不再打进度点,输出改为结束后一次性回显 JSON。

## 验证

打包机上对失败产物做等价手工操作,端到端跑通(用的是 `out/` 里现存的 global 身份产物,cn 路径仅身份串不同,同一处函数):

| 步骤 | 结果 |
|---|---|
| `notarytool log` | 9 条 error 全部指向 `Resources/pi/**`,无其他路径 |
| 只读核对 | pi 的 4 个 Mach-O 为 `adhoc, linker-signed`;`tools/` 5 个均 Developer ID + runtime + timestamp |
| 补签 pi(裸签) | 4 个文件 → Developer ID + `flags=0x10000(runtime)` |
| 签后 pi 可用性 | `pi --version` / `--help` 均 exit 0 —— **无需 entitlements** |
| 重签主 bundle | `codesign --verify --deep --strict` 通过 |
| 端到端公证 | notarytool **Accepted** → `stapler` worked → `spctl` `source=Notarized Developer ID` |

`find` 的 prune 语义另用 fixture 目录单独验证:`app.asar.unpacked/` 被正确跳过、`Resources/pi/**` 全部进入枚举、`.app` bundle 那一支不受影响。

`node --check` 通过。这两个函数只有 `package-desktop.mjs:356/358` 一处调用,函数签名未变。

## 未包含

Windows 侧 `tools/pi/update.mjs` 的 zip 解压问题(`extractArchive()` 对所有平台统一用 `tar -xf -`,而 pi 的 Windows 产物是 zip;Git-Bash 环境下 `tar` 解析到 GNU tar,不认 zip,pi 下载必失败)是同一条 pi 分发链上的另一处疏漏,已在打包机侧用 bsdtar shim 临时绕开,正解(照 `tools/ripgrep/update.mjs` 的 `extractZip` 兜底链)另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)