### PR TITLE
ci: 并行拆分 Windows 单测门禁

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,18 @@ jobs:
       - name: Run mobile scope guard
         run: pnpm --filter mobile test:scope
 
-  # Linux 全绿不能覆盖 path separator、盘符、大小写和文件系统能力差异。Windows
-  # 单测独立并行运行，避免重复 typecheck / i18n 等平台无关检查；完整 test:unit
-  # 是工程规范中的跨平台可执行契约，不能缩成少量 smoke。
-  windows-unit:
-    name: Windows unit tests
+  # Linux 全绿不能覆盖 path separator、盘符、大小写和文件系统能力差异。两个
+  # Windows 分片并行运行，分片并集仍完整覆盖 test:unit，不能缩成少量 smoke。
+  windows-unit-shards:
+    name: Windows unit tests (${{ matrix.shard }}/2)
     runs-on: windows-latest
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    env:
+      XDT_UNIT_TEST_SHARD: ${{ matrix.shard }}/2
 
     steps:
       - name: Checkout client
@@ -177,6 +182,18 @@ jobs:
 
       - name: Run client and package unit tests
         run: pnpm test:unit
+
+  # 保留稳定的必需检查名，并确保任一分片失败或取消都会阻断汇总门禁。
+  windows-unit:
+    name: Windows unit tests
+    if: ${{ always() }}
+    needs: windows-unit-shards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require both Windows unit shards
+        env:
+          WINDOWS_UNIT_SHARDS_RESULT: ${{ needs.windows-unit-shards.result }}
+        run: test "$WINDOWS_UNIT_SHARDS_RESULT" = "success"
 
   git-integration:
     name: Desktop Git integration

--- a/docs/dev-rules/engineering-conventions.md
+++ b/docs/dev-rules/engineering-conventions.md
@@ -111,9 +111,10 @@ UI 文案的语气与措辞另见 [`DESIGN.md`](../design-rules/DESIGN.md) 的 V
   依赖注入／纯函数用例保留等价覆盖；禁止按 `process.platform` 大面积跳过后让整个 CI 矩阵
   失去相应回归保护。
 
-PR 门禁必须在 Windows 上运行完整 `pnpm test:unit`；`scripts/__tests__/dev-docs-contract.test.mjs`
-锁住该 CI 契约。不能用静态扫描“测试字符串是否含斜杠”代替 Windows 实跑，因为它无法可靠区分
-宿主路径与逻辑路径。
+PR 门禁必须在 Windows 上用两个并行分片完整覆盖 `pnpm test:unit`；两个分片的并集必须等价于
+未分片的全量测试，且由稳定的汇总检查统一阻断。`scripts/__tests__/dev-docs-contract.test.mjs` 锁住
+该 CI 契约。不能用静态扫描“测试字符串是否含斜杠”代替 Windows 实跑，因为它无法可靠区分宿主
+路径与逻辑路径。
 
 ## 4. 跨平台双端兼容（macOS / Windows）
 

--- a/scripts/__tests__/dev-docs-contract.test.mjs
+++ b/scripts/__tests__/dev-docs-contract.test.mjs
@@ -137,11 +137,22 @@ test("runtime versions and the docs contract are code-owned", () => {
 	assert.match(rootPackage.scripts["test:runner"], /scripts\/__tests__\/dev-docs-contract\.test\.mjs/);
 });
 
-test("client CI keeps the complete unit gate on Windows", () => {
+test("client CI keeps the complete two-shard unit gate on Windows", () => {
 	const workflow = readText(".github/workflows/ci.yml");
-	const job = workflowJob(workflow, "windows-unit");
-	assert.ok(job, "client CI must define a windows-unit job");
-	assert.match(job, /^    runs-on: windows-latest$/m);
-	assert.match(job, /^        run: pnpm test:unit$/m);
-	assert.doesNotMatch(job, /pnpm test:unit\s+--/);
+	const shards = workflowJob(workflow, "windows-unit-shards");
+	assert.ok(shards, "client CI must define Windows unit shards");
+	assert.match(shards, /^    runs-on: windows-latest$/m);
+	assert.match(shards, /^      fail-fast: false$/m);
+	assert.match(shards, /^        shard: \[1, 2\]$/m);
+	assert.match(shards, /^      XDT_UNIT_TEST_SHARD: \$\{\{ matrix\.shard \}\}\/2$/m);
+	assert.match(shards, /^        run: pnpm test:unit$/m);
+	assert.doesNotMatch(shards, /pnpm test:unit\s+--/);
+
+	const gate = workflowJob(workflow, "windows-unit");
+	assert.ok(gate, "client CI must preserve the stable Windows unit check");
+	assert.match(gate, /^    name: Windows unit tests$/m);
+	assert.match(gate, /^    if: \$\{\{ always\(\) \}\}$/m);
+	assert.match(gate, /^    needs: windows-unit-shards$/m);
+	assert.match(gate, /^          WINDOWS_UNIT_SHARDS_RESULT: \$\{\{ needs\.windows-unit-shards\.result \}\}$/m);
+	assert.match(gate, /^        run: test "\$WINDOWS_UNIT_SHARDS_RESULT" = "success"$/m);
 });

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -837,14 +837,8 @@ test("workspace concurrency defaults to a bounded CPU count and accepts both CLI
 
 test("unit CI shard arguments cover valid halves and reject malformed input", () => {
 	assert.deepEqual(unitTestShardArgs(""), []);
-	assert.deepEqual(unitTestShardArgs(" 1/2 "), [
-		"--shard=1/2",
-		"--passWithNoTests",
-	]);
-	assert.deepEqual(unitTestShardArgs("2/2"), [
-		"--shard=2/2",
-		"--passWithNoTests",
-	]);
+	assert.deepEqual(unitTestShardArgs(" 1/2 "), ["--shard=1/2"]);
+	assert.deepEqual(unitTestShardArgs("2/2"), ["--shard=2/2"]);
 	for (const value of ["1", "0/2", "3/2", "1/0", "a/b"]) {
 		assert.throws(() => unitTestShardArgs(value), /XDT_UNIT_TEST_SHARD/);
 	}
@@ -1821,6 +1815,30 @@ test("buildPnpmArgs rejects selected files outside the workspace", () => {
 				["packages/other/src/foo.test.ts"],
 			),
 		/Selected test file is outside workspace packages\/orca-workflow: packages\/other\/src\/foo\.test\.ts/,
+	);
+});
+
+test("buildPnpmArgs only loosens Vitest sharding for undersized workspaces", () => {
+	const root = "F:/repo";
+	const workspace = { cwd: "packages/example" };
+	const oneSelectedFile = ["packages/example/src/only.test.ts"];
+	const buildShard = (shard, selectedFiles = oneSelectedFile) =>
+		buildPnpmArgs(
+			root,
+			workspace,
+			{ type: "packageBin", bin: "vitest", args: ["run", `--shard=${shard}`] },
+			{},
+			selectedFiles,
+		);
+
+	assert.equal(buildShard("1/2").includes("--passWithNoTests"), true);
+	assert.equal(buildShard("2/2").includes("--passWithNoTests"), true);
+	assert.equal(
+		buildShard("2/2", [
+			"packages/example/src/first.test.ts",
+			"packages/example/src/second.test.ts",
+		]).includes("--passWithNoTests"),
+		false,
 	);
 });
 

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -7,6 +7,7 @@ import test from "node:test";
 import { fileURLToPath } from "node:url";
 import manifest, {
 	desktopUnitWorkerCount,
+	unitTestShardArgs,
 } from "../test-workspaces.config.mjs";
 import { nodeWebstorageEnabled } from "../shared/node-webstorage.mjs";
 import {
@@ -155,7 +156,7 @@ test("orca workflow unit tier uses its own declared test runner", () => {
 	assert.deepEqual(orcaWorkspace.tiers.unit.command, {
 		type: "packageBin",
 		bin: "vitest",
-		args: ["run", "--pool=threads", "--maxWorkers=1"],
+		args: ["run", "--pool=threads", "--maxWorkers=1", ...unitTestShardArgs()],
 	});
 });
 
@@ -176,6 +177,7 @@ test("unit workspace concurrency reserves the full worker budget for heavy works
 		// LaunchServices churn that threads exists to avoid is macOS-only.
 		`--pool=${nodeWebstorageEnabled() || process.platform === "win32" ? "forks" : "threads"}`,
 		`--maxWorkers=${desktopUnitWorkerCount()}`,
+		...unitTestShardArgs(),
 	]);
 	assert.equal(desktopUnitWorkerCount(1), 1);
 	assert.equal(desktopUnitWorkerCount(4), 4);
@@ -186,12 +188,13 @@ test("unit workspace concurrency reserves the full worker budget for heavy works
 		"run",
 		"--pool=threads",
 		"--maxWorkers=4",
+		...unitTestShardArgs(),
 	]);
 	assert.equal(makerCore.tiers.unit.execution, undefined);
 	assert.deepEqual(makerCore.tiers.unit.command, {
 		type: "packageBin",
 		bin: "vitest",
-		args: ["run", "--pool=forks", "--maxWorkers=1"],
+		args: ["run", "--pool=forks", "--maxWorkers=1", ...unitTestShardArgs()],
 	});
 });
 
@@ -830,6 +833,21 @@ test("workspace concurrency defaults to a bounded CPU count and accepts both CLI
 		/requires a positive integer/,
 	);
 	assert.equal(parseCliOptions(["--no-lock"]).noLock, true);
+});
+
+test("unit CI shard arguments cover valid halves and reject malformed input", () => {
+	assert.deepEqual(unitTestShardArgs(""), []);
+	assert.deepEqual(unitTestShardArgs(" 1/2 "), [
+		"--shard=1/2",
+		"--passWithNoTests",
+	]);
+	assert.deepEqual(unitTestShardArgs("2/2"), [
+		"--shard=2/2",
+		"--passWithNoTests",
+	]);
+	for (const value of ["1", "0/2", "3/2", "1/0", "a/b"]) {
+		assert.throws(() => unitTestShardArgs(value), /XDT_UNIT_TEST_SHARD/);
+	}
 });
 
 test("test gate lock covers heavy local tiers but skips guard, CI, and explicit bypass", () => {

--- a/scripts/test-workspaces.config.mjs
+++ b/scripts/test-workspaces.config.mjs
@@ -40,10 +40,8 @@ const UNIT_TEST_SHARD_ENV = 'XDT_UNIT_TEST_SHARD';
 
 /**
  * Split every Vitest workspace by the same CI shard so the two Windows jobs
- * still form one complete unit gate. `passWithNoTests` is shard-local only:
- * the outer runner continues to reject workspaces that have no test files at
- * all, while a workspace with fewer files than shards may legitimately have
- * an empty half.
+ * still form one complete unit gate. The runner adds `passWithNoTests` only
+ * when a workspace has fewer selected files than the configured shard count.
  */
 export function unitTestShardArgs(value = process.env[UNIT_TEST_SHARD_ENV]) {
   if (value == null || String(value).trim() === '') return [];
@@ -55,7 +53,7 @@ export function unitTestShardArgs(value = process.env[UNIT_TEST_SHARD_ENV]) {
   if (!Number.isSafeInteger(index) || !Number.isSafeInteger(count) || index < 1 || count < 1 || index > count) {
     throw new Error(`${UNIT_TEST_SHARD_ENV} must satisfy 1 <= index <= count`);
   }
-  return [`--shard=${index}/${count}`, '--passWithNoTests'];
+  return [`--shard=${index}/${count}`];
 }
 
 // Workspace-level parallelism owns the global process budget. Keep ordinary

--- a/scripts/test-workspaces.config.mjs
+++ b/scripts/test-workspaces.config.mjs
@@ -36,11 +36,33 @@ const vitestBin = (...args) => ({ type: 'packageBin', bin: 'vitest', args });
 // short: at 1330 of this tier's 1845 files, desktop alone decides whether the
 // churn is a trickle or back to where it started.
 const UNIT_POOL_DEFAULT = 'threads';
+const UNIT_TEST_SHARD_ENV = 'XDT_UNIT_TEST_SHARD';
+
+/**
+ * Split every Vitest workspace by the same CI shard so the two Windows jobs
+ * still form one complete unit gate. `passWithNoTests` is shard-local only:
+ * the outer runner continues to reject workspaces that have no test files at
+ * all, while a workspace with fewer files than shards may legitimately have
+ * an empty half.
+ */
+export function unitTestShardArgs(value = process.env[UNIT_TEST_SHARD_ENV]) {
+  if (value == null || String(value).trim() === '') return [];
+  const normalized = String(value).trim();
+  const match = /^(\d+)\/(\d+)$/.exec(normalized);
+  if (!match) throw new Error(`${UNIT_TEST_SHARD_ENV} must use <index>/<count>`);
+  const index = Number(match[1]);
+  const count = Number(match[2]);
+  if (!Number.isSafeInteger(index) || !Number.isSafeInteger(count) || index < 1 || count < 1 || index > count) {
+    throw new Error(`${UNIT_TEST_SHARD_ENV} must satisfy 1 <= index <= count`);
+  }
+  return [`--shard=${index}/${count}`, '--passWithNoTests'];
+}
+
 // Workspace-level parallelism owns the global process budget. Keep ordinary
 // Vitest workspaces at one worker each so outer concurrency cannot multiply
 // every child process's default CPU-sized pool.
 const unitVitestCommand = (workers = 1, pool = UNIT_POOL_DEFAULT) =>
-  vitestBin('run', `--pool=${pool}`, `--maxWorkers=${workers}`);
+  vitestBin('run', `--pool=${pool}`, `--maxWorkers=${workers}`, ...unitTestShardArgs());
 const noCollectableTestsReason = 'No collectable tests yet. Add tests and mark a tier required when this workspace gains testable logic.';
 const desktopDbInclude = [
   'src/main/localDb/**/__tests__/*.test.ts',

--- a/scripts/test-workspaces.mjs
+++ b/scripts/test-workspaces.mjs
@@ -441,6 +441,30 @@ export function classifyFailure({ stage, exitCode, output }) {
 	return "COMMAND_FAILED";
 }
 
+function undersizedVitestShardArgs(commandSpec, selectedFiles) {
+	if (commandSpec.type !== "packageBin" || commandSpec.bin !== "vitest")
+		return [];
+	const shardArg = (commandSpec.args ?? []).find((arg) =>
+		arg.startsWith("--shard="),
+	);
+	const match = /^--shard=(\d+)\/(\d+)$/.exec(shardArg ?? "");
+	if (!match) return [];
+	const index = Number(match[1]);
+	const count = Number(match[2]);
+	if (
+		!Number.isSafeInteger(index) ||
+		!Number.isSafeInteger(count) ||
+		index < 1 ||
+		count < 1 ||
+		index > count
+	)
+		return [];
+
+	// Vitest rejects every shard when there are fewer files than shards, before
+	// it assigns the files. Limit the compatibility flag to that known case.
+	return selectedFiles.length < count ? ["--passWithNoTests"] : [];
+}
+
 export function buildPnpmArgs(
 	root,
 	workspace,
@@ -470,6 +494,7 @@ export function buildPnpmArgs(
 			"exec",
 			commandSpec.bin,
 			...(commandSpec.args ?? []),
+			...undersizedVitestShardArgs(commandSpec, selectedFiles),
 			...selectedArgs,
 		];
 		for (const pattern of tierConfig.exclude ?? []) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

将每个 PR 的 Windows 全量单测从单个 job 拆成两个 Vitest 文件分片并行执行。两个 job 仍执行同一个 `pnpm test:unit` 入口，分片并集等价于未分片全量测试。

同时保留稳定的 `Windows unit tests` 汇总门禁，任一分片失败或取消都会阻断，避免必需检查名发生变化。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：PR #1348 合入后的 Windows CI 耗时优化
- 本 PR 包含：Windows 两分片矩阵、稳定汇总检查、runner 分片参数校验、CI 契约测试及工程规则更新
- 明确不包含：缩减测试覆盖、调整 Vitest pool / isolation、修改业务代码
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
XDT_UNIT_TEST_SHARD=1/2 pnpm test:unit
结果：通过，本机用时 1 分 43 秒

XDT_UNIT_TEST_SHARD=2/2 pnpm test:unit
结果：通过，本机用时 1 分 32 秒

pnpm test:unit
结果：未分片全量通过，本机用时 2 分 59 秒

pnpm test:runner
结果：335 项，327 通过、8 跳过、0 失败

node -e "使用 yaml 包解析 .github/workflows/ci.yml"
结果：通过

pnpm check:dco
结果：1 个提交签名通过
```

### 手工验证

不涉及。

### 未执行的验证

未执行 package typecheck：本次只修改 CI YAML、根测试 runner、runner 自测和工程文档，没有改动 TypeScript package。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：CI 调度与耗时

### 影响与回滚

- 影响范围：仅 PR 的 Windows 单元测试 CI。完整测试覆盖不变；两个 runner 会重复固定的 checkout / install 开销，总计算时长可能小幅增加，但 PR 等待的关键路径预计显著缩短，准确耗时以本 PR 首次 GitHub Actions 实测为准。
- 回滚 / 降级方式：回退本提交即可恢复单个 Windows 全量 job。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果