### PR TITLE
perf(desktop): 提前放行启动任务列表

### DIFF
--- a/apps/desktop/src/main/__tests__/modelPricingPrewarmOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/modelPricingPrewarmOrdering.test.ts
@@ -23,7 +23,7 @@ describe('model pricing prewarm ordering', () => {
     const failedGuard = source.indexOf("dbClientTakeover.mode === 'failed'");
     const earlyUsageIpc = source.indexOf('registerMakerUsageIpc(ipcMaker);');
     const prewarm = source.indexOf('void prewarmModelPricing();');
-    const refreshCatalog = source.indexOf('void refreshCustomProvidersIntoCatalog();');
+    const refreshCatalog = source.indexOf('await refreshCustomProvidersIntoCatalog(');
 
     expect(localDbReady).toBeGreaterThanOrEqual(0);
     expect(failedGuard).toBeGreaterThan(localDbReady);

--- a/apps/desktop/src/main/__tests__/sessionsListIncludePinned.test.ts
+++ b/apps/desktop/src/main/__tests__/sessionsListIncludePinned.test.ts
@@ -38,6 +38,8 @@ const h = vi.hoisted(() => {
 
   return {
     ipcHandle: vi.fn(),
+    logDebug: vi.fn(),
+    logInfo: vi.fn(),
     queryResults,
     listQuery: withFn,
     fakeDb: {
@@ -53,7 +55,7 @@ vi.mock('electron', () => ({
   BrowserWindow: { getAllWindows: () => [] },
 }));
 vi.mock('../logger', () => ({
-  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  createLogger: () => ({ debug: h.logDebug, info: h.logInfo, warn: vi.fn(), error: vi.fn() }),
 }));
 vi.mock('../localDb/client/current', () => ({ getDbClient: () => ({ drizzle: h.fakeDb }) }));
 vi.mock('../localDb/dialogueWorkspace', () => ({ ensureDialogueWorkspaceDir: vi.fn() }));
@@ -119,8 +121,8 @@ function listRow(id: string, patch: Record<string, unknown> = {}) {
   };
 }
 
-function sessionsListHandler() {
-  registerSessionIpc();
+function sessionsListHandler(readLogScope?: () => string | null) {
+  registerSessionIpc(readLogScope);
   const call = h.ipcHandle.mock.calls.find(([channel]) => channel === 'local-db:sessions:list');
   if (!call) throw new Error('local-db:sessions:list handler not registered');
   return call[1] as (
@@ -188,6 +190,29 @@ describe('local-db:sessions:list includePinned', () => {
     ]);
     expect(h.listQuery).toHaveBeenCalledTimes(2);
     expect(h.queryResults).toHaveLength(0);
+  });
+
+  it('logs the first list at info level for each DbClient owner', async () => {
+    let owner = 'session-list-log-owner-a';
+    const handler = sessionsListHandler(() => owner);
+    const now = vi.spyOn(performance, 'now').mockReturnValue(100);
+    h.queryResults.push(
+      [listRow('owner-a-first')],
+      [listRow('owner-a-again')],
+      [listRow('owner-b-first')],
+    );
+
+    try {
+      await handler({}, 20, 'active');
+      await handler({}, 20, 'active');
+      owner = 'session-list-log-owner-b';
+      await handler({}, 20, 'active');
+    } finally {
+      now.mockRestore();
+    }
+
+    expect(h.logInfo).toHaveBeenCalledTimes(2);
+    expect(h.logDebug).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -352,6 +352,7 @@ import {
   ensureActiveCatalogLoaded,
   refreshCustomProvidersIntoCatalog,
 } from './maker-host/createDesktopProviderService.js';
+import { setCustomProviders } from './maker-host/active-catalog.js';
 import { setClaudeSupportedModelsListener } from '@cindy/maker-core';
 import {
   noteAnthropicSdkSupportedModels,
@@ -420,6 +421,7 @@ import {
   resetProviderModelAutoRefreshCooldowns,
 } from './maker-host/provider-model-auto-refresh.js';
 import { refreshProviderModelsAfterAccountReady } from './maker-host/account-provider-model-refresh.js';
+import { accountProviderReadinessBarrier } from './maker-host/account-provider-readiness-barrier.js';
 import {
   readImDefaultSettingsState,
   resetImDefaultSettings,
@@ -664,6 +666,27 @@ import { registerLearnIpc, broadcastLearnEvent } from './learn-host/registerIpc.
 import { registerGoalHandlers, broadcastGoalStatus } from './maker-ipc/goal.js';
 import { createLogger as createSchedulerLogger } from './logger.js';
 
+let makerProviderRefreshConfigured = false;
+let startPendingAccountProviderReadiness: (() => void) | null = null;
+
+function markMakerProviderRefreshConfigured(): void {
+  makerProviderRefreshConfigured = true;
+  const startPending = startPendingAccountProviderReadiness;
+  startPendingAccountProviderReadiness = null;
+  startPending?.();
+}
+
+async function waitForCurrentAccountProviderModelsReady(): Promise<void> {
+  const scopeKey = activeOwnerScopeKey();
+  const ready = await accountProviderReadinessBarrier.waitForScope(scopeKey);
+  if (!ready || activeOwnerScopeKey() !== scopeKey || isAppSessionBoundaryPending()) {
+    throwIpcError(
+      'PRECONDITION_FAILED',
+      'Account provider models are not ready for this app session; retry.',
+    );
+  }
+}
+
 /**
  * Phase 4: 不再用 `_schedulerStarted` flag —— `startScheduler()` 内部以 `_scheduler`
  * 单例为权威 source of truth（已 set 时直接返回原实例）。本函数只负责"两个前置就绪
@@ -675,10 +698,9 @@ import { createLogger as createSchedulerLogger } from './logger.js';
  * 本函数拿到 scheduler 后只调 `attachSchedulerEventListeners(scheduler, storage)`
  * 把 scheduler.on 挂上 + setSchedulerReady 喂入实例 + broadcast 'ready'。
  *
- * 重复 attempt 去重:本函数被 splash 和 localDb onReady 各调一次,startScheduler
- * 第二次返回同一实例,WeakSet 防止 scheduler.on 重复挂第二份 listener。切账号
- * 后 resetScheduler 把 _scheduler 置 null,下一次拿到新实例,WeakSet 里没有,
- * 自然会重新 attach 一次。
+ * 重复 attempt 去重:localDb onReady 可因重试或同 scope 复用再次触发，
+ * startScheduler 返回同一实例，WeakSet 防止 scheduler.on 重复挂 listener。切账号后
+ * resetScheduler 把 _scheduler 置 null，新实例不在 WeakSet 里，会重新 attach 一次。
  */
 async function attemptStartScheduler(): Promise<void> {
   // 两个前置条件必须满足才能启动：
@@ -720,8 +742,8 @@ async function attemptStartScheduler(): Promise<void> {
       ...automationGitBaselineHooks,
     });
     // scheduler 真正 ready 后挂 listener + 喂入 readiness holder。WeakSet 按实例
-    // 去重:splash + localDb onReady 各调一次,同实例第二次 no-op;切账号后新实例
-    // 不在 set 里,会重新 attach。
+    // 去重:localDb onReady 重试可能再次拿到同实例，此时 no-op；
+    // 切账号后新实例不在 set 里，会重新 attach。
     // 注意:schedule:* IPC handler 不在这里注册 — 它们在 registerMakerIpcsAfterSplash
     // 内通过 registerScheduleHandlers() 提前挂好,handler 内部 awaitReady 等本行
     // setSchedulerReady 调用。
@@ -888,6 +910,11 @@ async function ensureLifecycleDbClient(userId: string) {
 
 async function teardownAuthAccountBoundary(reason: string): Promise<void> {
   skillhubAutoSyncService.cancelInFlight();
+  // Custom provider routes are owner-scoped but the active catalog is process-global.
+  // Clear synchronously at the boundary; the next owner's tracked readiness reloads them
+  // before any Agent route can start. A failed DB read therefore stays fail-closed (empty)
+  // instead of retaining the previous owner's endpoint or model entries.
+  setCustomProviders([]);
   // 远程会话的镜像冷缓存里是别的设备的聊天内容。owner 命名空间已经保证下一个账号读不到
   // 它,但登出后不该在盘上留着 —— 这里 owner 还指向**旧账号**(commitActiveAppSession 在
   // teardown 之后才切),正是唯一能清准的时机。
@@ -3885,6 +3912,8 @@ const registerIpcHandlers = () => {
           notifyUpdateAutoRelaunchBusyStateChanged();
         },
         refreshXdGatewayModels,
+        waitForAccountProviderModelsReady: waitForCurrentAccountProviderModelsReady,
+        onProviderModelAutoRefreshConfigured: markMakerProviderRefreshConfigured,
       });
       registerMakerTitleIpc();
       registerMakerHelpIpc(ipcMaker);
@@ -4002,10 +4031,9 @@ const registerIpcHandlers = () => {
       console.error('[bootstrap-electron] worktree reconcile failed (non-fatal):', err);
     });
 
-    // Phase 4 Scheduler 启动尝试 —— attemptStartScheduler 是幂等的，
-    // 若 localDb 还没 ready (splash 跑得早于 user login)，本次 no-op；
-    // 等 'local-db:ensure-ready' IPC onReady 回调时会再触发一次。
-    await attemptStartScheduler();
+    // Scheduler / Goal / Learn 统一由 localDb onReady 在 provider readiness settle 后启动。
+    // DB 与 splash 无论谁先完成，上方 configured 信号都会解开同一条后台链；
+    // 这里不再直启，避免 scheduler 在账号模型发现完成前抢先选路由。
   };
 
   // Environment check IPC handler — 顺序检查 claude → codex 两个 vendor binary。
@@ -5698,9 +5726,8 @@ app.on('ready', async () => {
   registerMyIssuesIpc();
   // chat-data-localization F2/F5：注册 localDb IPC + 干净退出快照钩子。
   // 不立即开 db；ensureReady 由 AuthContext 在登录成功后通过 IPC 触发。
-  // onReady 回调 → scheduler-host 启动重试入口 (Phase 3)：splash 跑早于 user login
-  // 的话第一次 startScheduler 会因为 localDb 未 ready 而失败；这里在 ensureReady
-  // 完成后再触发一次幂等的 startScheduler，谁后到谁负责真正启动。
+  // onReady 回调是 owner DB 权威就绪点；它先放行本地读，再与 splash 端的
+  // provider coordinator 会合，后台完成账号路由初始化后才启动 scheduler。
   // 首登轻量数据迁移(mToc)的确认弹窗 IPC —— 必须先于 registerLocalDbIpc 注册,
   // 保证 beforeEnsureReady 推送 confirm 态时 renderer 已能 invoke 确认通道。
   registerLegacyMigrationIpc();
@@ -5710,6 +5737,16 @@ app.on('ready', async () => {
     discardStaleOwner: (userId) =>
       lifecycleDbClientManager.dispose(`stale-owner-after-ready:${userId}`),
     beforeEnsureReady: async (userId) => {
+      // Provider discovery is detached from DB read readiness for the same owner, but a
+      // different owner must not replace the DB while the previous account task can still
+      // update owner-scoped catalogs or agent environments.
+      const previousProviderTaskSettled = await accountProviderReadinessBarrier.waitForPreviousScope(
+        activeOwnerScopeKey(),
+      );
+      // The old task may have completed its owner-scoped DB read after teardown cleared the
+      // process-global catalog. Clear once more after joining it so a failed next-owner reload
+      // cannot inherit the old endpoint/model snapshot. Same-scope ensure retries skip this.
+      if (previousProviderTaskSettled) setCustomProviders([]);
       const user = authManager.getAuthState().user;
       if (user == null || user.id !== userId) return;
       // 首登轻量迁移(老 xdt-maker userData → Cindy):内部自带 marker 防重入与
@@ -5717,6 +5754,20 @@ app.on('ready', async () => {
       await runLegacyUserDataMigrationForUser(user.id);
     },
     onReady: async (userId) => {
+      const startupHooksStartedAt = performance.now();
+      let startupPhaseStartedAt = startupHooksStartedAt;
+      const logStartupPhase = (phase: string): void => {
+        const now = performance.now();
+        dbClientLog.info(
+          JSON.stringify({
+            event: 'localDb.startup.phase.done',
+            phase,
+            elapsedMs: Math.round(now - startupPhaseStartedAt),
+            totalElapsedMs: Math.round(now - startupHooksStartedAt),
+          }),
+        );
+        startupPhaseStartedAt = now;
+      };
       // 必须先 await ensureLifecycleDbClient(内部 await createDbClient → worker
       // spawn + db open + migration scan + smoke,约 1-2s),把 client 经
       // setCurrentDbClient 暴露给全局 getDbClient() 之后,后续 attemptStartScheduler /
@@ -5727,6 +5778,7 @@ app.on('ready', async () => {
       // attempt 全部撞 "DbClient not ready",scheduler/embedding 永不启动 → renderer
       // 卡在 IPC 等待 → 白屏。
       const dbClientTakeover = await ensureLifecycleDbClient(userId);
+      logStartupPhase('db-client-takeover');
       if (dbClientTakeover.mode === 'failed' || dbClientTakeover.mode === 'skipped') {
         dbClientLog.warn('[DbClient] lifecycle client unavailable; skip db-client startup hooks', {
           userId,
@@ -5743,19 +5795,7 @@ app.on('ready', async () => {
         localDbCloseDb({ preserveSchemaMigrationLease: true });
         dbClientLog.info('[DbClient] main-side _db released after worker takeover');
       }
-      // 自定义 MCP：先 await 刷新 provider 数组，确保 scheduler 启动时能看到已保存的
-      // custom MCP 配置。cold start 场景：getMaker 构造时 DB 未就绪，初始 refresh 为
-      // no-op，waitForInitialCustomMcpRefresh 立即 resolve；此处补刷，保证第一个
-      // scheduler fire / 用户会话都能拿到完整的 mcpProviders 数组。best-effort：失败仅
-      // warn，不阻塞后续初始化。
       const accountSwitchLog = createLogger('custom-mcp-account-switch');
-      try {
-        await refreshCustomMcpProviders();
-      } catch (err) {
-        accountSwitchLog.warn('refreshCustomMcpProviders on account switch failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
       // 身份翻转遗留的 dialogue 工作目录自愈:把 legacy userData 前缀的
       // sessions.working_dir 批量改写到当前 userData(详见 dialogueWorkdirSelfHeal.ts)。
       // 必须 await:ensure-ready IPC 返回后 renderer 才拉会话列表,在此之前改写完
@@ -5774,21 +5814,7 @@ app.on('ready', async () => {
           error: err instanceof Error ? err.message : String(err),
         });
       }
-      // Hook and personal IM both require the current owner's DbClient. Start
-      // them from this authoritative Main-side readiness point instead of
-      // relying only on the renderer's later fire-and-forget
-      // app:ready-for-bot signal. That signal can be lost during cold-start
-      // auto-login or an owner remount, leaving a saved Feishu bot disconnected
-      // and unable to claim the owner from its first p2p message.
-      startAccountIntegrationsAfterOwnerDbReady(userId, {
-        isOwnerCurrent: (ownerId) =>
-          isLocalDbOwnerCurrent(authManager.getAuthState(), ownerId, isAppSessionBoundaryPending()),
-        startHookControlAccount,
-        startImConnection,
-        log: dbClientLog,
-      });
-      attemptStartScheduler();
-      attemptStartEmbeddingHost();
+      logStartupPhase('dialogue-workdir-sweep');
       // 旧「资料本地覆写」方案退役(2026-07)的一次性清理:清当前账号名下的
       // profile-avatar 媒体引用与 override 条目(文件条目即幂等标记,失败下次登录重试)。
       void (async () => {
@@ -5822,49 +5848,115 @@ app.on('ready', async () => {
       });
       // 价格表作用域依赖当前 localDb 用户与 provider-secret owner;必须等用户 DB ready 后再预热。
       void prewarmModelPricing();
-      // 自定义供应商配置在按 userId 切片的 localDb 里：DB ready / 换账号后重新加载并
-      // 注入 active-catalog（让路由 / 来源栏 / 模型选择器跟随当前账号）。best-effort，不阻塞。
-      void refreshCustomProvidersIntoCatalog();
-      // 自定义 MCP：provider 数组已在上方刷新完成，失效 Codex cached spawn 配置，
-      // 使下一会话按新数组重建。
-      // 顺序约束与模型发现都保持 best-effort，但这里必须 await 到 settle：LocalDbGate
-      // 只有随后才放行主界面。否则用户能在 Anthropic 清单尚未回来时发送 Opus，
-      // 草稿会按 XD 默认路由建成 provider_id=NULL（issue #1196）。
+      // DB 可读与 Agent 可启动是两个不同的 readiness：现有任务列表只依赖前者，不能
+      // 被网络模型发现阻塞；新建 / 发送则经 registerMakerIpc 的中心入口等待下方 barrier，
+      // 保留 issue #1196 的路由正确性（Anthropic 清单回来前不能先按 XD 默认建 Opus）。
       //
       // 模型发现必须排在 Codex 重启序列之后：后者末尾会按 auth 边界重读
       // models_cache（cache miss 即清空防串号），并发跑会让刚发现的清单被空快照覆盖。
-      await refreshProviderModelsAfterAccountReady({
-        restartCodex: restartCodexAfterAuthModeChange,
-        shutdownCodexEnvironment,
-        refreshProviderModels: requestProviderModelAutoRefresh,
-        log: accountSwitchLog,
-      });
-      // Pi bridge 与 Codex 同源（HTTP bridge + gateway key），账号切换后也必须
-      // 清掉旧账号环境，让下一次 Pi 会话按新账号凭证重建。
-      try {
-        await shutdownPiEnvironment();
-      } catch (err) {
-        accountSwitchLog.warn('shutdownPiEnvironment on account switch failed', {
-          error: err instanceof Error ? err.message : String(err),
-        });
-      }
-      void sweepStartupDraftImages({
-        dbClient: getDbClient(),
-        processStartedAtMs: PROCESS_STARTED_AT_MS,
-      })
-        .then((result) => {
-          if (result.removed === 0 && result.removedDanglingMeta === 0 && result.errors === 0)
-            return;
-          createLogger('image-cache-orphan-sweep').info(
-            'startup draft image sweep completed',
-            result,
-          );
-        })
-        .catch((err) => {
-          createLogger('image-cache-orphan-sweep').warn('startup draft image sweep failed', {
-            error: err instanceof Error ? err.message : String(err),
+      const providerScopeKey = activeOwnerScopeKey();
+      const startProviderReadiness = (): void => {
+        if (activeOwnerScopeKey() !== providerScopeKey || isAppSessionBoundaryPending()) return;
+        const providerReadiness = accountProviderReadinessBarrier.start(
+          providerScopeKey,
+          async () => {
+            const startedAt = performance.now();
+            try {
+              // 自定义 MCP 与自定义供应商都只服务 Agent 路由，不应该阻塞任务列表。
+              // 二者在内置模型发现前完成，确保后续 route consumer 只看当前账号。
+              try {
+                // 切号 teardown 会 reset Maker 和 MCP registry。先重建 Maker 以重新注册
+                // provider arrays，再等它的初始刷新；冷启动时初始刷新可能早于
+                // DB ready 而空跑，所以随后还要显式补刷一次当前 owner。
+                getMakerCore();
+                await waitForInitialCustomMcpRefresh();
+                await refreshCustomMcpProviders();
+              } catch (err) {
+                accountSwitchLog.warn('refreshCustomMcpProviders on account switch failed', {
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              }
+              await refreshCustomProvidersIntoCatalog(
+                () =>
+                  activeOwnerScopeKey() === providerScopeKey &&
+                  !isAppSessionBoundaryPending(),
+              );
+              await refreshProviderModelsAfterAccountReady({
+                restartCodex: restartCodexAfterAuthModeChange,
+                shutdownCodexEnvironment,
+                refreshProviderModels: requestProviderModelAutoRefresh,
+                log: accountSwitchLog,
+              });
+              // Pi bridge 与 Codex 同源（HTTP bridge + gateway key），账号切换后也必须
+              // 清掉旧账号环境，让下一次 Pi 会话按新账号凭证重建。
+              try {
+                await shutdownPiEnvironment();
+              } catch (err) {
+                accountSwitchLog.warn('shutdownPiEnvironment on account switch failed', {
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              }
+            } catch (err) {
+              // 与旧 LocalDbGate 屏障一致：provider readiness 是 best-effort；意外失败只记账，
+              // 不把已经可读的本地 DB 误报成启动失败，也不让发送入口永久悬挂。
+              accountSwitchLog.warn('account provider readiness task failed (non-fatal)', {
+                error: err instanceof Error ? err.message : String(err),
+              });
+            } finally {
+              accountSwitchLog.info('account provider readiness settled', {
+                elapsedMs: Math.round(performance.now() - startedAt),
+              });
+            }
+            void sweepStartupDraftImages({
+              dbClient: getDbClient(),
+              processStartedAtMs: PROCESS_STARTED_AT_MS,
+            })
+              .then((result) => {
+                if (result.removed === 0 && result.removedDanglingMeta === 0 && result.errors === 0)
+                  return;
+                createLogger('image-cache-orphan-sweep').info(
+                  'startup draft image sweep completed',
+                  result,
+                );
+              })
+              .catch((err) => {
+                createLogger('image-cache-orphan-sweep').warn('startup draft image sweep failed', {
+                  error: err instanceof Error ? err.message : String(err),
+                });
+              });
+          },
+          (err) => {
+            accountSwitchLog.warn('account provider readiness rejected unexpectedly', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+          },
+        );
+        // Hook / personal IM / scheduler can resolve routes before maker.createSession, so arm
+        // them only after discovery settles. The Maker lifecycle hook remains the final guard for
+        // every direct create path. The scope check prevents an old completion from reviving hosts
+        // after an account boundary.
+        void providerReadiness.then(() => {
+          if (activeOwnerScopeKey() !== providerScopeKey || isAppSessionBoundaryPending()) return;
+          startAccountIntegrationsAfterOwnerDbReady(userId, {
+            isOwnerCurrent: (ownerId) =>
+              isLocalDbOwnerCurrent(
+                authManager.getAuthState(),
+                ownerId,
+                isAppSessionBoundaryPending(),
+              ),
+            startHookControlAccount,
+            startImConnection,
+            log: dbClientLog,
           });
+          attemptStartScheduler();
+          attemptStartEmbeddingHost();
         });
+      };
+      // localDb 与 splash 可以任意先后完成。协调器已配置就立即开后台任务；
+      // 否则只登记当前 scope 的启动闭包，不创建一个可能永久 pending 的 Promise。
+      if (makerProviderRefreshConfigured) startProviderReadiness();
+      else startPendingAccountProviderReadiness = startProviderReadiness;
+      logStartupPhase('post-db-hooks-scheduled');
     },
   });
   // dev-only IPC for embedding-host smoke testing (status + sync embed). 安全:
@@ -5941,10 +6033,12 @@ app.on('ready', async () => {
   // handler。FeishuBot 的 WS 长连接必须等当前用户 localDb ready 后再启动。
   startImOrchestrators();
   // Renderer → main 的 "应用真正就绪" 兼容信号。LocalDbGate 在
-  // localDb.ensureReady 成功之后调一次。Hook 与 FeishuBot 已在 localDb onReady
-  // 的 Main 权威时点激活，这里为旧时序与瞬时失败保留幂等重试。
-  ipcMain.handle('app:ready-for-bot', (event) => {
+  // localDb.ensureReady 成功之后调一次。Hook 与 FeishuBot 的权威启动已由
+  // localDb onReady 排到 provider readiness 之后；这里同样等待屏障，再为旧时序
+  // 与瞬时失败保留幂等重试。
+  ipcMain.handle('app:ready-for-bot', async (event) => {
     assertTrustedAppRendererEvent(event);
+    await waitForCurrentAccountProviderModelsReady();
     startHookControlAccount();
     startImConnection();
     return { ok: true };

--- a/apps/desktop/src/main/localDb/ipc/registerAll.ts
+++ b/apps/desktop/src/main/localDb/ipc/registerAll.ts
@@ -10,6 +10,7 @@
 import { ipcMain } from 'electron';
 
 import { closeDb, ensureReady, getCurrentUserId } from '../index';
+import { getCurrentDbClientUserId } from '../client/current';
 import { registerSessionIpc } from './sessions';
 import { registerMessageIpc } from './messages';
 import { registerOrcaWorkflowIpc } from './orcaTeams';
@@ -120,7 +121,7 @@ export function registerLocalDbIpc(opts: RegisterLocalDbIpcOpts = {}): void {
     return result;
   });
 
-  registerSessionIpc();
+  registerSessionIpc(getCurrentDbClientUserId);
   registerMessageIpc();
   registerRemoteHistoryIpc();
   registerSessionImportIpc();

--- a/apps/desktop/src/main/localDb/ipc/registerAll.ts
+++ b/apps/desktop/src/main/localDb/ipc/registerAll.ts
@@ -71,6 +71,7 @@ export function registerLocalDbIpc(opts: RegisterLocalDbIpcOpts = {}): void {
     },
   });
   ipcMain.handle('local-db:ensure-ready', async (_e, userId: unknown) => {
+    const startedAt = performance.now();
     log.info(
       JSON.stringify({
         event: 'localDb.ipc.ensure-ready.recv',
@@ -112,6 +113,7 @@ export function registerLocalDbIpc(opts: RegisterLocalDbIpcOpts = {}): void {
         event: 'localDb.ipc.ensure-ready.done',
         userId,
         ready: result.ready,
+        elapsedMs: Math.round(performance.now() - startedAt),
         ...(result.ready ? {} : { error: result.error }),
       }),
     );

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -689,7 +689,9 @@ export async function clearSessionContextInDb(sessionId: string, atMs?: number):
   });
 }
 
-export function registerSessionIpc(): void {
+export function registerSessionIpc(
+  readSessionListLogScope: () => string | null = () => null,
+): void {
   // interrupted-turn-resume 假阳性修复:每次 last_turn_ended_at 真正落库(正常收尾 /
   // barrier 版收尾 / ack)都广播 lastTurnEndedAt patch —— renderer 的 session 快照可能
   // 是在 turn 飞行中或「done → ended 落库」空窗里取的(startedAt > endedAt),此前
@@ -756,7 +758,8 @@ export function registerSessionIpc(): void {
         mapElapsedMs: Math.round(finishedAt - queryFinishedAt),
         elapsedMs,
       });
-      const logKey = `${filter}:${includePinned ? 'pinned' : 'plain'}`;
+      const logScope = readSessionListLogScope() ?? 'unscoped';
+      const logKey = `${logScope}:${filter}:${includePinned ? 'pinned' : 'plain'}`;
       if (!initialSessionListLogged.has(logKey) || elapsedMs >= SLOW_SESSION_LIST_MS) {
         initialSessionListLogged.add(logKey);
         log.info(fields);

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -58,6 +58,8 @@ import { assertTrustedAppRendererEvent } from '../../security/trustedAppRenderer
 
 const log = createLogger('sessions');
 const REMOTE_EDITABLE_META = new Set(['status', 'title', 'pinnedAt']);
+const initialSessionListLogged = new Set<string>();
+const SLOW_SESSION_LIST_MS = 250;
 
 /**
  * 广播 sessions:patched 到本机所有窗口 + device-link tap。tap 让该 patch 经 topic 路由
@@ -700,6 +702,7 @@ export function registerSessionIpc(): void {
   ipcMain.handle(
     'local-db:sessions:list',
     async (_e, limit: unknown, status: unknown, options: unknown) => {
+      const startedAt = performance.now();
       const db = getDbClient().drizzle;
       // sidebar-card-mode: 首次 list(db 必然 ready)触发一次置顶摘要回填——
       // 老置顶会话没有 turn-done 触发点。模块内部 once 守卫 + 串行 + swallow。
@@ -731,7 +734,8 @@ export function registerSessionIpc(): void {
         mergedRows = mergeSessionListRows(rows, pinnedRows);
       }
 
-      return mergedRows.map((r) =>
+      const queryFinishedAt = performance.now();
+      const result = mergedRows.map((r) =>
         sessionToCamel({
           ...r.session,
           messageCount: r.messageCount,
@@ -739,6 +743,27 @@ export function registerSessionIpc(): void {
           latestMessageRole: r.latestMessageRole,
         }),
       );
+      const finishedAt = performance.now();
+      const filter = statusFilter ?? 'all';
+      const elapsedMs = Math.round(finishedAt - startedAt);
+      const fields = JSON.stringify({
+        event: 'localDb.sessions.list.done',
+        filter,
+        cap,
+        includePinned,
+        rows: result.length,
+        queryElapsedMs: Math.round(queryFinishedAt - startedAt),
+        mapElapsedMs: Math.round(finishedAt - queryFinishedAt),
+        elapsedMs,
+      });
+      const logKey = `${filter}:${includePinned ? 'pinned' : 'plain'}`;
+      if (!initialSessionListLogged.has(logKey) || elapsedMs >= SLOW_SESSION_LIST_MS) {
+        initialSessionListLogged.add(logKey);
+        log.info(fields);
+      } else {
+        log.debug(fields);
+      }
+      return result;
     },
   );
 

--- a/apps/desktop/src/main/maker-host/__tests__/accountProviderModelRefresh.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/accountProviderModelRefresh.test.ts
@@ -11,7 +11,7 @@ function deferred() {
 }
 
 describe('refreshProviderModelsAfterAccountReady', () => {
-  it('waits for Anthropic discovery but not unrelated provider refreshes', async () => {
+  it('keeps all account-scoped provider refreshes inside readiness', async () => {
     const anthropicRefresh = deferred();
     const backgroundRefresh = deferred();
     const events: string[] = [];
@@ -35,15 +35,21 @@ describe('refreshProviderModelsAfterAccountReady', () => {
     void operation.then(() => {
       settled = true;
     });
-    await vi.waitFor(() => expect(events).toEqual([
-      'restart',
-      'shutdown',
-      'refresh:startup:xd,openai,xai',
-      'refresh:startup:anthropic',
-    ]));
+    await vi.waitFor(() =>
+      expect(events).toEqual([
+        'restart',
+        'shutdown',
+        'refresh:startup:xd,openai,xai',
+        'refresh:startup:anthropic',
+      ]),
+    );
     expect(settled).toBe(false);
 
     anthropicRefresh.resolve();
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    backgroundRefresh.resolve();
     await operation;
     expect(settled).toBe(true);
   });
@@ -83,6 +89,9 @@ describe('refreshProviderModelsAfterAccountReady', () => {
       }),
     ).resolves.toBeUndefined();
 
+    expect(warn).toHaveBeenCalledWith('background provider model startup refresh failed', {
+      error: 'discovery unavailable',
+    });
     expect(warn).toHaveBeenCalledWith('Anthropic model startup refresh failed', {
       error: 'discovery unavailable',
     });

--- a/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessBarrier.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessBarrier.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAccountProviderReadinessBarrier } from '../account-provider-readiness-barrier.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('createAccountProviderReadinessBarrier', () => {
+  it('blocks only work belonging to the active readiness scope', async () => {
+    const task = deferred();
+    const barrier = createAccountProviderReadinessBarrier();
+    barrier.start('cloud:owner-a:1', () => task.promise, vi.fn());
+
+    let scopeAReady = false;
+    void barrier.waitForScope('cloud:owner-a:1').then(() => {
+      scopeAReady = true;
+    });
+
+    await expect(barrier.waitForScope('cloud:owner-b:2')).resolves.toBe(false);
+    expect(scopeAReady).toBe(false);
+
+    task.resolve();
+    await vi.waitFor(() => expect(scopeAReady).toBe(true));
+  });
+
+  it('fails closed before readiness has been registered for a scope', async () => {
+    const barrier = createAccountProviderReadinessBarrier();
+
+    await expect(barrier.waitForScope('cloud:owner-a:1')).resolves.toBe(false);
+  });
+
+  it('keeps a new scope behind the previous scope task, including the same owner relogin', async () => {
+    const task = deferred();
+    const barrier = createAccountProviderReadinessBarrier();
+    barrier.start('cloud:owner-a:1', () => task.promise, vi.fn());
+
+    let switched = false;
+    const waiting = barrier.waitForPreviousScope('cloud:owner-a:3').then((waited) => {
+      expect(waited).toBe(true);
+      switched = true;
+    });
+    await Promise.resolve();
+    expect(switched).toBe(false);
+
+    task.resolve();
+    await waiting;
+    expect(switched).toBe(true);
+  });
+
+  it('joins duplicate starts for the same scope', async () => {
+    const task = deferred();
+    const runTask = vi.fn(() => task.promise);
+    const barrier = createAccountProviderReadinessBarrier();
+
+    const first = barrier.start('cloud:owner-a:1', runTask, vi.fn());
+    const second = barrier.start('cloud:owner-a:1', runTask, vi.fn());
+    expect(second).toBe(first);
+    await vi.waitFor(() => expect(runTask).toHaveBeenCalledOnce());
+
+    task.resolve();
+    await first;
+  });
+
+  it('settles rejected work after reporting it', async () => {
+    const failure = new Error('discovery failed');
+    const onError = vi.fn();
+    const barrier = createAccountProviderReadinessBarrier();
+
+    const readiness = barrier.start(
+      'cloud:owner-a:1',
+      async () => {
+        throw failure;
+      },
+      onError,
+    );
+
+    await expect(readiness).resolves.toBeUndefined();
+    expect(onError).toHaveBeenCalledWith(failure);
+    await expect(barrier.waitForPreviousScope('cloud:owner-b:2')).resolves.toBe(true);
+  });
+
+  it('does not let an older completion clear a newer scope task', async () => {
+    const first = deferred();
+    const second = deferred();
+    const barrier = createAccountProviderReadinessBarrier();
+    barrier.start('cloud:owner-a:1', () => first.promise, vi.fn());
+    barrier.start('cloud:owner-b:2', () => second.promise, vi.fn());
+
+    first.resolve();
+    await first.promise;
+
+    let scopeBReady = false;
+    void barrier.waitForScope('cloud:owner-b:2').then(() => {
+      scopeBReady = true;
+    });
+    await Promise.resolve();
+    expect(scopeBReady).toBe(false);
+
+    second.resolve();
+    await vi.waitFor(() => expect(scopeBReady).toBe(true));
+  });
+
+  it('fails a waiter whose scope was replaced before its task settled', async () => {
+    const first = deferred();
+    const second = deferred();
+    const barrier = createAccountProviderReadinessBarrier();
+    barrier.start('cloud:owner-a:1', () => first.promise, vi.fn());
+    const firstWaiter = barrier.waitForScope('cloud:owner-a:1');
+
+    barrier.start('cloud:owner-b:2', () => second.promise, vi.fn());
+    first.resolve();
+    await expect(firstWaiter).resolves.toBe(false);
+
+    second.resolve();
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const bootstrapSource = readFileSync(
+  resolve(__dirname, '..', '..', 'bootstrap-electron.ts'),
+  'utf8',
+);
+const makerIpcSource = readFileSync(
+  resolve(__dirname, '..', '..', 'maker-ipc', 'register.ts'),
+  'utf8',
+);
+const makerHostSource = readFileSync(resolve(__dirname, '..', 'index.ts'), 'utf8');
+const compactBootstrapSource = bootstrapSource.replace(/\s+/g, ' ');
+
+describe('account provider readiness wiring', () => {
+  it('arms provider discovery without keeping local-db ensure-ready behind it', () => {
+    const workdirSweep = bootstrapSource.indexOf("logStartupPhase('dialogue-workdir-sweep')");
+    const barrierStart = compactBootstrapSource.indexOf('accountProviderReadinessBarrier.start(');
+    const readableDone = compactBootstrapSource.indexOf(
+      "logStartupPhase('post-db-hooks-scheduled')",
+    );
+    const compactWorkdirSweep = compactBootstrapSource.indexOf(
+      "logStartupPhase('dialogue-workdir-sweep')",
+    );
+
+    expect(workdirSweep).toBeGreaterThanOrEqual(0);
+    expect(compactWorkdirSweep).toBeGreaterThanOrEqual(0);
+    expect(barrierStart).toBeGreaterThan(compactWorkdirSweep);
+    expect(readableDone).toBeGreaterThan(barrierStart);
+    expect(compactBootstrapSource).not.toContain('await accountProviderReadinessBarrier.start(');
+  });
+
+  it('publishes Maker provider configuration immediately and orders account route refreshes', () => {
+    const configureCoordinator = makerIpcSource.indexOf('configureProviderModelAutoRefresh({');
+    const configuredCallback = makerIpcSource.indexOf(
+      'options.onProviderModelAutoRefreshConfigured()',
+      configureCoordinator,
+    );
+    const providerHandlers = makerIpcSource.indexOf(
+      'registerProviderHandlers(',
+      configuredCallback,
+    );
+    expect(configureCoordinator).toBeGreaterThanOrEqual(0);
+    expect(configuredCallback).toBeGreaterThan(configureCoordinator);
+    expect(providerHandlers).toBeGreaterThan(configuredCallback);
+    expect(bootstrapSource).toContain(
+      'onProviderModelAutoRefreshConfigured: markMakerProviderRefreshConfigured',
+    );
+    expect(bootstrapSource).not.toContain('await makerProviderRefreshConfigured');
+    expect(bootstrapSource).toContain(
+      'else startPendingAccountProviderReadiness = startProviderReadiness',
+    );
+
+    const barrierStart = bootstrapSource.indexOf('accountProviderReadinessBarrier.start(');
+    const makerRecreated = bootstrapSource.indexOf('getMakerCore();', barrierStart);
+    const initialMcpRefresh = bootstrapSource.indexOf(
+      'await waitForInitialCustomMcpRefresh()',
+      makerRecreated,
+    );
+    const customMcpRefresh = bootstrapSource.indexOf(
+      'await refreshCustomMcpProviders()',
+      initialMcpRefresh,
+    );
+    const customProviderRefresh = bootstrapSource.indexOf(
+      'await refreshCustomProvidersIntoCatalog(',
+      customMcpRefresh,
+    );
+    const providerRefresh = bootstrapSource.indexOf(
+      'await refreshProviderModelsAfterAccountReady',
+      customProviderRefresh,
+    );
+    const piShutdown = bootstrapSource.indexOf('await shutdownPiEnvironment()', providerRefresh);
+
+    expect(makerRecreated).toBeGreaterThanOrEqual(0);
+    expect(initialMcpRefresh).toBeGreaterThan(makerRecreated);
+    expect(customMcpRefresh).toBeGreaterThan(initialMcpRefresh);
+    expect(customProviderRefresh).toBeGreaterThan(customMcpRefresh);
+    expect(providerRefresh).toBeGreaterThan(customProviderRefresh);
+    expect(piShutdown).toBeGreaterThan(providerRefresh);
+  });
+
+  it('gates route resolution and the final Maker start hook', () => {
+    const bootstrapSession = makerIpcSource.indexOf('async function bootstrapSession');
+    const routeGate = makerIpcSource.indexOf(
+      'await options.waitForAccountProviderModelsReady()',
+      bootstrapSession,
+    );
+    const routeResolution = makerIpcSource.indexOf(
+      'const didInjectOrcaInstructions',
+      bootstrapSession,
+    );
+    expect(routeGate).toBeGreaterThan(bootstrapSession);
+    expect(routeResolution).toBeGreaterThan(routeGate);
+
+    const prepareStartOptions = makerHostSource.indexOf('prepareStartOptions: async');
+    const hostGate = makerHostSource.indexOf(
+      'await accountProviderReadinessBarrier.waitForScope(providerScopeKey)',
+      prepareStartOptions,
+    );
+    const failClosed = makerHostSource.indexOf('!providerReady', hostGate);
+    const persistedOrca = makerHostSource.indexOf(
+      'await preparePersistedOrcaSessionStart',
+      prepareStartOptions,
+    );
+    expect(hostGate).toBeGreaterThan(prepareStartOptions);
+    expect(failClosed).toBeGreaterThan(hostGate);
+    expect(persistedOrca).toBeGreaterThan(hostGate);
+  });
+
+  it('starts autonomous route consumers only after provider readiness settles', () => {
+    const settledContinuation = bootstrapSource.indexOf('void providerReadiness.then(() =>');
+    const integrations = bootstrapSource.indexOf(
+      'startAccountIntegrationsAfterOwnerDbReady',
+      settledContinuation,
+    );
+    const scheduler = bootstrapSource.indexOf('attemptStartScheduler()', settledContinuation);
+
+    expect(settledContinuation).toBeGreaterThanOrEqual(0);
+    expect(integrations).toBeGreaterThan(settledContinuation);
+    expect(scheduler).toBeGreaterThan(settledContinuation);
+    expect(bootstrapSource).not.toContain('await attemptStartScheduler()');
+  });
+
+  it('clears owner-scoped custom routes before replacing account runtimes', () => {
+    const teardown = bootstrapSource.indexOf('async function teardownAuthAccountBoundary');
+    const clearCustomProviders = bootstrapSource.indexOf('setCustomProviders([])', teardown);
+    const makerShutdown = bootstrapSource.indexOf('await maker.shutdown()', teardown);
+    const joinPrevious = bootstrapSource.indexOf(
+      'waitForPreviousScope(',
+      makerShutdown,
+    );
+    const clearAfterJoin = bootstrapSource.indexOf(
+      'if (previousProviderTaskSettled) setCustomProviders([])',
+      joinPrevious,
+    );
+
+    expect(teardown).toBeGreaterThanOrEqual(0);
+    expect(clearCustomProviders).toBeGreaterThan(teardown);
+    expect(makerShutdown).toBeGreaterThan(clearCustomProviders);
+    expect(joinPrevious).toBeGreaterThan(makerShutdown);
+    expect(clearAfterJoin).toBeGreaterThan(joinPrevious);
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
@@ -16,6 +16,7 @@ const h = vi.hoisted(() => ({
     source: Record<string, unknown>;
     resolve: (result: unknown) => void;
   }>,
+  customProviderRead: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -113,13 +114,22 @@ vi.mock('../model-discovery/anthropic.js', () => ({
   loadAnthropicModelsFromDiskCache: async () => undefined,
   refreshAnthropicModelsFromHttp: async () => undefined,
 }));
+vi.mock('../custom-provider-header-secrets.js', () => ({
+  listCustomProvidersWithSecureHeaders: () => h.customProviderRead(),
+}));
 
-import { BUNDLED_CATALOG, type Catalog } from '@cindy/model-providers';
-import { getActiveCatalog } from '../active-catalog.js';
+import {
+  BUNDLED_CATALOG,
+  buildUserProvider,
+  type Catalog,
+  type CustomProviderConfig,
+} from '@cindy/model-providers';
+import { getActiveCatalog, setCustomProviders } from '../active-catalog.js';
 import {
   __testing,
   ensureActiveCatalogLoaded,
   refreshActiveCatalogFromSource,
+  refreshCustomProvidersIntoCatalog,
   reloadActiveCatalogForEndpointChange,
   shouldDisableCatalogFetch,
 } from '../createDesktopProviderService.js';
@@ -141,6 +151,38 @@ function activeMarker(): string | undefined {
 }
 
 describe('provider catalog realm reload', () => {
+  it('drops a stale owner custom-provider read and clears the current snapshot on failure', async () => {
+    const provider: CustomProviderConfig = {
+      id: 'owner-a-provider',
+      name: 'Owner A Provider',
+      runtimes: {
+        'claude-code': {
+          baseUrl: 'https://owner-a.example/anthropic',
+          models: [{ id: 'owner-a-model', name: 'Owner A Model' }],
+        },
+      },
+    };
+    let resolveOwnerA!: (configs: CustomProviderConfig[]) => void;
+    const ownerALoad = new Promise<CustomProviderConfig[]>((resolve) => {
+      resolveOwnerA = resolve;
+    });
+    h.customProviderRead.mockReturnValueOnce(ownerALoad);
+    let ownerAIsCurrent = true;
+    const staleRefresh = refreshCustomProvidersIntoCatalog(() => ownerAIsCurrent);
+
+    setCustomProviders([]);
+    ownerAIsCurrent = false;
+    resolveOwnerA([provider]);
+    await staleRefresh;
+    expect(getActiveCatalog().providers.some((entry) => entry.id === provider.id)).toBe(false);
+
+    setCustomProviders([buildUserProvider(provider)]);
+    h.customProviderRead.mockRejectedValueOnce(new Error('owner B DB read failed'));
+    await refreshCustomProvidersIntoCatalog();
+    expect(getActiveCatalog().providers.some((entry) => entry.id === provider.id)).toBe(false);
+    h.customProviderRead.mockReset();
+  });
+
   it('persists only a digest of a catalog scope that may contain URL credentials', () => {
     const scope = 'https://catalog.example/models?access_token=do-not-persist';
     const envelope = __testing.catalogLkgEnvelope(scope, '{"schemaVersion":1}');

--- a/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
@@ -177,6 +177,10 @@ describe('provider catalog realm reload', () => {
     expect(getActiveCatalog().providers.some((entry) => entry.id === provider.id)).toBe(false);
 
     setCustomProviders([buildUserProvider(provider)]);
+    h.customProviderRead.mockRejectedValueOnce(new Error('stale owner A DB read failed'));
+    await refreshCustomProvidersIntoCatalog(() => false);
+    expect(getActiveCatalog().providers.some((entry) => entry.id === provider.id)).toBe(true);
+
     h.customProviderRead.mockRejectedValueOnce(new Error('owner B DB read failed'));
     await refreshCustomProvidersIntoCatalog();
     expect(getActiveCatalog().providers.some((entry) => entry.id === provider.id)).toBe(false);

--- a/apps/desktop/src/main/maker-host/account-provider-model-refresh.ts
+++ b/apps/desktop/src/main/maker-host/account-provider-model-refresh.ts
@@ -18,12 +18,12 @@ export interface AccountProviderModelRefreshDeps {
 }
 
 /**
- * 账号 DB 就绪后的模型发现屏障。
+ * 账号 DB 就绪后的模型发现任务。
  *
- * Renderer 只有在本函数 settle 后才越过 LocalDbGate，因此新对话拿到的是本次账号
- * 已经完成 Anthropic 发现的 provider catalog，不会在其清单还没回来时先按 XD
- * 默认路由建出 provider_id=NULL 的 Opus 对话。其余来源仍强制刷新，但不阻塞主界面；
- * 各步骤保持 best-effort，失败会留日志而不会把可用的本地 DB 误判成初始化失败。
+ * LocalDbGate 不再等待它，因此现有任务列表可以先显示；Desktop Maker 的创建 /
+ * 启动入口另外等待 account provider readiness barrier，确保 Anthropic 清单回来前
+ * 不会先按 XD 默认路由建出 provider_id=NULL 的 Opus 任务。其余来源仍强制
+ * 刷新；各步骤保持 best-effort，失败会留日志，不会把可用的本地 DB 误判成初始化失败。
  */
 export async function refreshProviderModelsAfterAccountReady(
   deps: AccountProviderModelRefreshDeps,

--- a/apps/desktop/src/main/maker-host/account-provider-model-refresh.ts
+++ b/apps/desktop/src/main/maker-host/account-provider-model-refresh.ts
@@ -23,7 +23,8 @@ export interface AccountProviderModelRefreshDeps {
  * LocalDbGate 不再等待它，因此现有任务列表可以先显示；Desktop Maker 的创建 /
  * 启动入口另外等待 account provider readiness barrier，确保 Anthropic 清单回来前
  * 不会先按 XD 默认路由建出 provider_id=NULL 的 Opus 任务。其余来源仍强制
- * 刷新；各步骤保持 best-effort，失败会留日志，不会把可用的本地 DB 误判成初始化失败。
+ * 刷新且纳入同一账号 barrier，防止切号后旧账号的迟到结果覆盖全局目录；各步骤保持
+ * best-effort，失败会留日志，不会把可用的本地 DB 误判成初始化失败。
  */
 export async function refreshProviderModelsAfterAccountReady(
   deps: AccountProviderModelRefreshDeps,
@@ -48,17 +49,19 @@ export async function refreshProviderModelsAfterAccountReady(
     }
   }
 
-  void deps.refreshProviderModels('startup', ['xd', 'openai', 'xai']).catch((error) => {
-    deps.log.warn('background provider model startup refresh failed', {
+  const backgroundRefresh = deps
+    .refreshProviderModels('startup', ['xd', 'openai', 'xai'])
+    .catch((error) => {
+      deps.log.warn('background provider model startup refresh failed', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+  const anthropicRefresh = deps.refreshProviderModels('startup', ['anthropic']).catch((error) => {
+    deps.log.warn('Anthropic model startup refresh failed', {
       error: error instanceof Error ? error.message : String(error),
     });
   });
 
-  try {
-    await deps.refreshProviderModels('startup', ['anthropic']);
-  } catch (error) {
-    deps.log.warn('Anthropic model startup refresh failed', {
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
+  await Promise.all([backgroundRefresh, anthropicRefresh]);
 }

--- a/apps/desktop/src/main/maker-host/account-provider-readiness-barrier.ts
+++ b/apps/desktop/src/main/maker-host/account-provider-readiness-barrier.ts
@@ -1,0 +1,54 @@
+/**
+ * Tracks the account-scoped provider/model refresh that may outlive DB read readiness.
+ *
+ * Existing task lists may render before this barrier settles, while any path that can
+ * create or send to an agent waits for the current app-session scope. A new generation
+ * also waits for the previous scope before replacing the DB, so detached refresh work
+ * cannot write account-scoped catalog state after the ownership boundary has moved on.
+ */
+export function createAccountProviderReadinessBarrier() {
+  let current: { scopeKey: string; promise: Promise<void> } | null = null;
+
+  return {
+    start(
+      scopeKey: string,
+      task: () => Promise<void>,
+      onError: (error: unknown) => void,
+    ): Promise<void> {
+      if (current?.scopeKey === scopeKey) return current.promise;
+
+      const promise = Promise.resolve()
+        .then(task)
+        .catch((error) => {
+          try {
+            onError(error);
+          } catch {
+            // The barrier must always settle: logging failure cannot block future owners.
+          }
+        });
+      current = { scopeKey, promise };
+      return promise;
+    },
+
+    async waitForScope(scopeKey: string): Promise<boolean> {
+      const snapshot = current;
+      if (snapshot?.scopeKey !== scopeKey) return false;
+      await snapshot.promise;
+      return current === snapshot;
+    },
+
+    async waitForPreviousScope(nextScopeKey: string): Promise<boolean> {
+      let waited = false;
+      while (current && current.scopeKey !== nextScopeKey) {
+        waited = true;
+        const snapshot = current;
+        await snapshot.promise;
+        if (current === snapshot) return waited;
+      }
+      return waited;
+    },
+  };
+}
+
+/** Process-lifetime barrier shared by bootstrap and every Desktop Maker instance. */
+export const accountProviderReadinessBarrier = createAccountProviderReadinessBarrier();

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -617,7 +617,13 @@ export async function refreshCustomProvidersIntoCatalog(
     setCustomProviders(configs.map((c) => buildUserProvider(c)));
     log.info('custom providers merged into active catalog', { count: configs.length });
   } catch (err) {
-    if (shouldApply()) setCustomProviders([]);
+    if (!shouldApply()) {
+      log.info('discarded stale custom provider catalog refresh failure', {
+        err: String(err),
+      });
+      return;
+    }
+    setCustomProviders([]);
     log.warn('failed to load custom providers; cleared current owner catalog snapshot', {
       err: String(err),
     });

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -605,13 +605,20 @@ export async function refreshDiscoveredCodexModels(
  *
  * best-effort：localDb 未就绪 / 读失败时清空 custom（不抛），不影响内置供应商与路由默认行为。
  */
-export async function refreshCustomProvidersIntoCatalog(): Promise<void> {
+export async function refreshCustomProvidersIntoCatalog(
+  shouldApply: () => boolean = () => true,
+): Promise<void> {
   try {
     const configs = await listCustomProvidersWithSecureHeaders();
+    if (!shouldApply()) {
+      log.info('discarded stale custom provider catalog refresh');
+      return;
+    }
     setCustomProviders(configs.map((c) => buildUserProvider(c)));
     log.info('custom providers merged into active catalog', { count: configs.length });
   } catch (err) {
-    log.warn('failed to load custom providers; keeping last valid active catalog snapshot', {
+    if (shouldApply()) setCustomProviders([]);
+    log.warn('failed to load custom providers; cleared current owner catalog snapshot', {
       err: String(err),
     });
   }

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -50,6 +50,7 @@ import { tapWindowBroadcast } from '../device-link/broadcast-tap.js';
 import { remoteInvoke } from '../device-link/index.js';
 import { WorktreePool } from '../worktree/index.js';
 import { getReadyBinaryPath, getCachedBinaryStatus } from '../agent-binaries/index.js';
+import { activeOwnerScopeKey, isAppSessionBoundaryPending } from '../appSessionState.js';
 import {
   desktopClaudeAuthAdapter,
   desktopCodexAuthAdapter,
@@ -104,6 +105,7 @@ import { resolveRemoteClaudeRoute } from './remote-claude-route.js';
 import { claudeSubagentUsageBridge } from './claude-subagent-usage-bridge.js';
 import { createAutoPermissionReviewer } from './auto-permission-reviewer.js';
 import { requestUtilityText } from '../utility-model/oneShotCandidates.js';
+import { accountProviderReadinessBarrier } from './account-provider-readiness-barrier.js';
 import { hasClaudeAiOAuth } from './claude-credentials-store.js';
 import {
   armCodexHttpRecovery,
@@ -1334,6 +1336,17 @@ export function getMaker(): Maker {
       // 启动前的 Skill 共享与关闭后的清理都由 desktop host 注入。
       lifecycleHooks: {
         prepareStartOptions: async (sessionId, opts) => {
+          const providerScopeKey = activeOwnerScopeKey();
+          const providerReady = await accountProviderReadinessBarrier.waitForScope(providerScopeKey);
+          if (
+            !providerReady ||
+            activeOwnerScopeKey() !== providerScopeKey ||
+            isAppSessionBoundaryPending()
+          ) {
+            throw new Error(
+              'Account provider models are not ready for this app session; retry.',
+            );
+          }
           await preparePersistedOrcaSessionStart(sessionId, opts as MakerSessionCreateOpts);
         },
         onBeforeStart: async ({ agentKind, workingDir, remoteHostId }) => {

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4067,6 +4067,10 @@ export interface RegisterMakerIpcOptions {
   onAnySessionTurnKeepaliveChange?: (isRunning: boolean) => void;
   /** 由 bootstrap 注入，避免 maker-ipc → model-access → maker-host 的循环依赖。 */
   refreshXdGatewayModels(): Promise<void>;
+  /** DB 可读后仍在后台运行的账号模型发现；新建 / 懒恢复路由前必须等待。 */
+  waitForAccountProviderModelsReady(): Promise<void>;
+  /** Provider 刷新协调器已可用；紧跟 configure 发出，避免后续 handler 失败造成永久等待。 */
+  onProviderModelAutoRefreshConfigured(): void;
 }
 
 export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions): void {
@@ -4429,6 +4433,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         },
       }),
   });
+  options.onProviderModelAutoRefreshConfigured();
 
   registerProviderHandlers(createElectronIpcHandlerRegistry(), {
     listProviders: (opts) => getDesktopProviderService().listProviders(opts),
@@ -4991,6 +4996,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     didInjectOrcaInstructions: boolean;
     didInjectProjectContext: boolean;
   }> {
+    await options.waitForAccountProviderModelsReady();
     const didInjectOrcaInstructions = applyOrcaInstructions(o);
     const didInjectProjectContext = await applyProjectContextInjection(o);
 

--- a/apps/desktop/src/renderer/components/auth/LocalDbGate.tsx
+++ b/apps/desktop/src/renderer/components/auth/LocalDbGate.tsx
@@ -61,6 +61,7 @@ export function LocalDbGate() {
     }
 
     (async () => {
+     const attemptStartedAt = performance.now();
      try {
       // ensureReady（按 userId 切换 db；失败 main 已弹对话框）
       const ready = await window.electronAPI.localDb.ensureReady(ownerId);
@@ -71,9 +72,15 @@ export function LocalDbGate() {
         return;
       }
 
-      // Signal main "user logged in + localDb is open" so the FeishuBot WS
-      // connection can come online safely. Gated and idempotent in main —
-      // re-mounts and account switches are no-ops after the first call.
+      log.info('startup readiness reached', {
+        event: 'renderer.local-db-gate.ready',
+        elapsedMs: Math.round(performance.now() - attemptStartedAt),
+        rendererUptimeMs: Math.round(performance.now()),
+      });
+
+      // Signal main "user logged in + localDb is open" so account integrations can
+      // come online after provider discovery. Gated and idempotent in main — re-mounts
+      // and account switches are no-ops after the first call.
       // Fire-and-forget: the gate decision below MUST NOT block on bot startup.
       void window.electronAPI.appReadyForBot().catch((err) => {
         log.warn('appReadyForBot signal failed (non-fatal)', err);

--- a/apps/desktop/src/renderer/lib/sessionsStore.ts
+++ b/apps/desktop/src/renderer/lib/sessionsStore.ts
@@ -45,6 +45,7 @@
 import type { Session } from '@/lib/ccAgent.types';
 import * as sessionService from '@/lib/sessionService';
 import type { ListStatusFilter } from '@/lib/sessionService';
+import { createLogger } from '@/lib/logger';
 import {
   DEFAULT_DRAFT_SESSION_TITLE,
   isDefaultDraftSessionTitle,
@@ -60,6 +61,8 @@ import {
 // V1.7：取消 16 条上限，全量拉取由 Sidebar 中部滚动条承载。
 // 后端硬上限 1000，覆盖几乎所有真实用户的 Session 总数。
 const DEFAULT_LIMIT = 1000;
+const startupPerfLog = createLogger('perf/startup');
+const initialFetchLogged = new Set<ListStatusFilter>();
 
 const cache = new Map<ListStatusFilter, Session[]>();
 const inflight = new Map<ListStatusFilter, Promise<Session[]>>();
@@ -243,15 +246,29 @@ async function fetchFilter(filter: ListStatusFilter): Promise<Session[]> {
   // 不一致，必须把 filter 原样透传，由 IPC handler 决定过滤语义。
   const spendRevisionAtStart = sessionSpendRevision;
   const titleRevisionAtStart = sessionTitleRevision;
+  const startedAt = performance.now();
   const sessions = await sessionService.list(DEFAULT_LIMIT, filter);
   // 顺序:先把「请求发起之后到达的权威标题」补回去,再叠乐观预览。反过来的话预览会先
   // 盖在旧标题上、随后又被权威值挤掉,中间多一次跳变。
-  return applyAutoTitlePreviews(
+  const result = applyAutoTitlePreviews(
     applySessionTitleOverrides(
       applySessionSpendOverrides(sessions, spendRevisionAtStart),
       titleRevisionAtStart,
     ),
   );
+  const fields = {
+    event: 'renderer.sessions.initial-fetch.done',
+    filter,
+    rows: result.length,
+    elapsedMs: Math.round(performance.now() - startedAt),
+    rendererUptimeMs: Math.round(performance.now()),
+  };
+  if (initialFetchLogged.has(filter)) startupPerfLog.debug(fields);
+  else {
+    initialFetchLogged.add(filter);
+    startupPerfLog.info(fields);
+  }
+  return result;
 }
 
 export const sessionsStore = {
@@ -497,6 +514,7 @@ export const sessionsStore = {
     sessionSpendOverrides.clear();
     autoTitlePreviews.clear();
     sessionTitleOverrides.clear();
+    initialFetchLogged.clear();
     notify('reset');
   },
 };


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 Desktop 首次启动的就绪条件拆成两层：本地数据库可读后立即放行已有任务列表；自定义 MCP、供应商目录和模型发现继续在后台完成。新建任务、发送消息、Scheduler 等依赖模型路由的入口仍统一等待账号级 provider readiness，避免为了提速牺牲 #1196 要求的路由正确性。

同时补充主进程与 renderer 的分阶段耗时日志，便于继续定位真实冷启动瓶颈。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1196（作为账号模型路由正确性约束，不自动关闭）；首次启动任务列表性能排查
- 本 PR 包含：两阶段 readiness、账号 scope 屏障、Maker 中心入口保护、自定义供应商跨账号防串、启动耗时日志及回归测试
- 明确不包含：任务列表 SQL 改写、数据库 schema / migration、视觉或交互调整、Mobile 改动
- 用户可见变化：已有任务列表不再等待联网模型发现完成；依赖模型路由的操作仍等待后台初始化
- 是否存在 breaking change：无

### UI 变化

不涉及：renderer 仅增加 LocalDbGate 与任务筛选首刷的结构化耗时日志，不改变布局、样式、交互或文案。

- 引用的设计规范：不涉及视觉、交互或文案变化

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-task-list-startup-readiness
结果：通过（GATE_EXIT=0）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/__tests__/modelPricingPrewarmOrdering.test.ts
结果：3 个测试通过

pnpm check:dco
结果：2 个提交通过 DCO 检查
```

### 手工验证

不涉及：未启动新的 Desktop 实例，避免干扰当时正在使用同一 shared userData 的多个开发实例。

### 未执行的验证

- 未做真实冷启动计时；当前收益判断来自启动依赖链审计与新增结构化日志，合并前可在空闲的独立 userData 环境补测。
- 未跑全量 lint；相关改动文件已做定向 lint，两个既有大文件仍有仓库基线 unused-import 报错，本 PR 未新增对应问题。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop 启动与切账号时序

### 影响与回滚

- 影响范围：Desktop 登录后 localDb 就绪、首次任务列表读取、账号切换、Maker 创建入口及依赖 provider/model 的后台服务启动顺序。
- 安全措施：屏障按账号 owner generation 隔离；未 armed、scope 不匹配或切号中的请求 fail closed；旧账号自定义 provider 的延迟结果会被丢弃，当前账号读取失败时清空快照。
- 回滚 / 降级方式：revert 本 PR 的单一提交，恢复原先由严格 provider/model readiness 阻塞 localDb ensure-ready 的行为。
- 不涉及 SQLite migration、system prompt、协议、插件、Mobile fingerprint 或存量数据格式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认无需补充文档：没有新增配置、协议或用户操作方式
- [x] 已确认测试结果或说明未执行原因
