### PR TITLE
fix(desktop): 修复子代理思考强度设置

### DIFF
--- a/apps/desktop/src/renderer/components/settings/SubagentModelSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SubagentModelSection.tsx
@@ -10,7 +10,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { connectedProvidersForAgent, getModel, isAgentSelectableModel, visibleModelUnion } from '@cindy/model-providers';
+import { connectedProvidersForAgent, effectiveSourceIdForModel, getModel, isAgentSelectableModel, visibleModelUnion } from '@cindy/model-providers';
 
 import { ClaudeMark } from '@/components/icons/ClaudeMark';
 import { CodexMark } from '@/components/icons/CodexMark';
@@ -246,12 +246,19 @@ export function SubagentModelSection() {
       if (!isCodexSubagentEffort(effort) || effort === current.codexEffort) return;
       const saved = await persistPatch({ codexEffort: effort });
       // 活跃行编辑走 onEffortChange,ModelSelector 不会代写 modelMemory。保存成功后
-      // 同步全局模型预设,否则切走再切回会恢复旧档位。
-      if (saved && current.codexProviderId) {
-        setProviderModelEffort('codex', current.codexProviderId, current.codex, effort);
+      // 按选择器同一准入口径解析实际来源并同步全局模型预设;providerId=null 是合法
+      // 隐式来源,不能因此漏写,否则切走再切回会恢复旧档位。
+      const memoryProviderId = effectiveSourceIdForModel(
+        providers,
+        current.codexProviderId,
+        current.codex,
+        'codex',
+      );
+      if (saved && memoryProviderId) {
+        setProviderModelEffort('codex', memoryProviderId, current.codex, effort);
       }
     },
-    [persistPatch],
+    [persistPatch, providers],
   );
 
   const resetCard = useCallback(

--- a/apps/desktop/src/renderer/components/settings/SubagentModelSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/SubagentModelSection.tsx
@@ -14,7 +14,7 @@ import { connectedProvidersForAgent, getModel, isAgentSelectableModel, visibleMo
 
 import { ClaudeMark } from '@/components/icons/ClaudeMark';
 import { CodexMark } from '@/components/icons/CodexMark';
-import { ModelSelector } from '@/components/new-chat/ModelSelector';
+import { ModelSelector, type ModelMemoryAccessors } from '@/components/new-chat/ModelSelector';
 import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { useAgentCapabilities } from '@/hooks/useAgentCapabilities';
@@ -22,6 +22,12 @@ import { useProviders } from '@/hooks/useProviders';
 import { createLogger } from '@/lib/logger';
 import { deriveModelsFromProviders } from '@/lib/providerModels';
 import { toast } from '@/lib/toast';
+import {
+  getProviderModelEffort,
+  getProviderModelFast,
+  setProviderModelEffort,
+  setProviderModelFast,
+} from '@/state/providerModelMemory';
 import {
   CODEX_SUBAGENT_CONCURRENCY_INITIAL,
   CODEX_SUBAGENT_CONCURRENCY_MAX,
@@ -37,6 +43,17 @@ import {
 import { DefaultOverrideControls } from './DefaultOverrideControls';
 
 const log = createLogger('SubagentModelSection');
+
+/**
+ * 标准模型面板把非选中行的配置写进模型级全局预设;Subagent 仍把实际派发值
+ * 原子落进自己的 settings store。Fast 回调未开启,这里只复用完整适配器契约。
+ */
+const CODEX_SUBAGENT_MODEL_MEMORY: ModelMemoryAccessors = {
+  getEffort: getProviderModelEffort,
+  setEffort: setProviderModelEffort,
+  getFast: getProviderModelFast,
+  setFast: setProviderModelFast,
+};
 
 type SubagentAgentKind = 'claude-code' | 'codex';
 
@@ -201,7 +218,15 @@ export function SubagentModelSection() {
         return;
       }
       const nextProviderId = providerId;
-      const nextEffort = resolveCodexEffort(model, current.codexEffort);
+      // 标准面板编辑非选中行时会先写模型级预设,再回调选中该行。这里必须优先
+      // 读取刚写入的 effort,才能把 (model, providerId, effort) 收敛成一次原子 patch。
+      const rememberedEffort = nextProviderId
+        ? getProviderModelEffort('codex', nextProviderId, model)
+        : undefined;
+      const nextEffort = resolveCodexEffort(
+        model,
+        isCodexSubagentEffort(rememberedEffort) ? rememberedEffort : current.codexEffort,
+      );
       if (
         model === current.codex &&
         nextProviderId === current.codexProviderId &&
@@ -219,7 +244,12 @@ export function SubagentModelSection() {
       const current = settingsRef.current;
       if (!current || !current.codex) return;
       if (!isCodexSubagentEffort(effort) || effort === current.codexEffort) return;
-      await persistPatch({ codexEffort: effort });
+      const saved = await persistPatch({ codexEffort: effort });
+      // 活跃行编辑走 onEffortChange,ModelSelector 不会代写 modelMemory。保存成功后
+      // 同步全局模型预设,否则切走再切回会恢复旧档位。
+      if (saved && current.codexProviderId) {
+        setProviderModelEffort('codex', current.codexProviderId, current.codex, effort);
+      }
     },
     [persistPatch],
   );
@@ -472,6 +502,7 @@ export function SubagentModelSection() {
             <ModelSelector
               modelId={settings.codex ?? ''}
               effort={settings.codexEffort ?? ''}
+              modelMemory={CODEX_SUBAGENT_MODEL_MEMORY}
               onModelChange={(modelId) => {
                 void setCodexModel(modelId, settings.codexProviderId);
               }}

--- a/apps/desktop/src/renderer/components/settings/__tests__/SubagentModelSectionRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SubagentModelSectionRendering.test.tsx
@@ -543,6 +543,23 @@ describe('SubagentModelSection Codex row', () => {
     });
   });
 
+  it('restores the target model preset instead of inheriting the current model effort', async () => {
+    // providerModelMemory 的 SSoT 语义是 per-model preset:当前模型受 live settings
+    // 保护,切到另一模型时必须采用目标行展示的 preset,否则非选中行编辑会被丢弃。
+    settingsGet.mockResolvedValue(
+      makeState({ codex: 'gpt-5.6-terra', codexProviderId: 'openai', codexEffort: 'high' }),
+    );
+    modelMemoryMock.effortByModel.set('gpt-5.5', 'medium');
+    render(<SubagentModelSection />);
+    fireEvent.click(await screen.findByTestId('codex:pick-model-flat'));
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1));
+    expect(settingsSet).toHaveBeenCalledWith({
+      codex: 'gpt-5.5',
+      codexProviderId: 'openai',
+      codexEffort: 'medium',
+    });
+  });
+
   it('narrows an unavailable codex provider to null instead of persisting it', async () => {
     render(<SubagentModelSection />);
     fireEvent.click(await screen.findByTestId('codex:pick-stale-provider-row'));
@@ -573,6 +590,22 @@ describe('SubagentModelSection Codex row', () => {
   it('persists an effort-only change for the stored model', async () => {
     settingsGet.mockResolvedValue(
       makeState({ codex: 'gpt-5.6-terra', codexProviderId: 'openai', codexEffort: 'medium' }),
+    );
+    render(<SubagentModelSection />);
+    fireEvent.click(await screen.findByTestId('codex:pick-effort-high'));
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1));
+    expect(settingsSet).toHaveBeenCalledWith({ codexEffort: 'high' });
+    expect(modelMemoryMock.setEffort).toHaveBeenCalledWith(
+      'codex',
+      'openai',
+      'gpt-5.6-terra',
+      'high',
+    );
+  });
+
+  it('syncs an effort-only change through the effective source when provider is implicit', async () => {
+    settingsGet.mockResolvedValue(
+      makeState({ codex: 'gpt-5.6-terra', codexProviderId: null, codexEffort: 'medium' }),
     );
     render(<SubagentModelSection />);
     fireEvent.click(await screen.findByTestId('codex:pick-effort-high'));

--- a/apps/desktop/src/renderer/components/settings/__tests__/SubagentModelSectionRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/SubagentModelSectionRendering.test.tsx
@@ -13,6 +13,7 @@
  *   5. 护栏三行写对 patch key;总开关关闭时其余护栏行禁用(值保留);
  *   6. codexRestartDeferred=true 时提示延迟生效;
  *   7. 两张卡的 DefaultOverrideControls 按各自键组判 isCustomized、恢复只写本卡键。
+ *   8. Codex 未选中模型行复用全局模型预设适配器,可直接修改 effort 并原子选中。
  */
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -48,6 +49,27 @@ vi.mock('@/lib/toast', () => ({ toast: toastMock }));
 // codex review)——若未来改回可见并集口径,下方多数 CTA 断言会在这里翻红。
 vi.mock('@/state/modelVisibilityPrefs', () => ({
   isModelEnabled: () => false,
+}));
+
+const modelMemoryMock = vi.hoisted(() => {
+  const effortByModel = new Map<string, string>();
+  return {
+    effortByModel,
+    getEffort: vi.fn((_agent: string, _providerId: string, modelId: string) =>
+      effortByModel.get(modelId),
+    ),
+    setEffort: vi.fn((_agent: string, _providerId: string, modelId: string, effort: string) => {
+      effortByModel.set(modelId, effort);
+    }),
+    getFast: vi.fn(),
+    setFast: vi.fn(),
+  };
+});
+vi.mock('@/state/providerModelMemory', () => ({
+  getProviderModelEffort: modelMemoryMock.getEffort,
+  setProviderModelEffort: modelMemoryMock.setEffort,
+  getProviderModelFast: modelMemoryMock.getFast,
+  setProviderModelFast: modelMemoryMock.setFast,
 }));
 
 // 已连接 anthropic(claude)与 openai(codex);ghost-provider 不存在。
@@ -135,6 +157,10 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
     onProviderChange?: (providerId: string | null, modelId?: string) => void;
     onModelChange: (modelId: string) => void;
     onEffortChange?: (effort: string) => void;
+    modelMemory?: {
+      getEffort: (agent: string, providerId: string, modelId: string) => string | undefined;
+      setEffort: (agent: string, providerId: string, modelId: string, effort: string) => void;
+    };
     configurationEnabled?: boolean;
     disabled?: boolean;
     excludeChatBridgedCodex?: boolean;
@@ -158,6 +184,7 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
         // sourcesEnabled = !!onProviderChange),这里暴露出来供断言。
         data-sources-enabled={String(props.onProviderChange !== undefined)}
         data-configuration-enabled={String(props.configurationEnabled !== false)}
+        data-model-memory={String(props.modelMemory !== undefined)}
         data-disabled={String(props.disabled === true)}
         data-exclude-bridged={String(props.excludeChatBridgedCodex === true)}
         data-unknown-label={props.unknownModelLabel?.('ghost-model-1') ?? ''}
@@ -191,6 +218,19 @@ vi.mock('@/components/new-chat/ModelSelector', () => ({
           type="button"
           data-testid={`${vendor}:pick-effort-high`}
           onClick={() => props.onEffortChange?.('high')}
+        />
+        <button
+          type="button"
+          data-testid={`${vendor}:configure-unselected-high`}
+          onClick={() => {
+            props.modelMemory?.setEffort(
+              vendor === 'codex' ? 'codex' : 'claude-code',
+              providerId,
+              modelId,
+              'high',
+            );
+            props.onProviderChange?.(providerId, modelId);
+          }}
         />
       </div>
     );
@@ -246,6 +286,7 @@ afterEach(() => {
   providersMock.loading = false;
   providersMock.claudeModels = [{ id: 'claude-opus-5' }, { id: 'claude-haiku-4-5' }];
   providersMock.codexModels = [{ id: 'gpt-5.6-terra' }, { id: 'gpt-5.5' }];
+  modelMemoryMock.effortByModel.clear();
   vi.clearAllMocks();
 });
 
@@ -444,6 +485,7 @@ describe('SubagentModelSection Codex row', () => {
     // Codex 派发通道有 effort 维度(agents.default_subagent_reasoning_effort):
     // 配置列必须开启,effort 回显已存档位。
     expect(selector.dataset.configurationEnabled).toBe('true');
+    expect(selector.dataset.modelMemory).toBe('true');
     expect(selector.dataset.effort).toBe('high');
     expect(selector.dataset.currentProvider).toBe('openai');
     expect(selector.dataset.model).toBe('gpt-5.6-terra');
@@ -464,6 +506,26 @@ describe('SubagentModelSection Codex row', () => {
       codex: 'gpt-5.6-terra',
       codexProviderId: 'openai',
       codexEffort: 'medium',
+    });
+  });
+
+  it('configures and selects an unselected model effort through the shared panel', async () => {
+    // ModelSelector #1280 后,未选中行只在注入 modelMemory 时打开配置列;
+    // 点 effort 会先写预设、再选中该行。Subagent 必须把这两步收敛成
+    // 一次 (model, providerId, effort) patch,否则「不指定」状态下永远只能看档位、不能改。
+    render(<SubagentModelSection />);
+    fireEvent.click(await screen.findByTestId('codex:configure-unselected-high'));
+    await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1));
+    expect(modelMemoryMock.setEffort).toHaveBeenCalledWith(
+      'codex',
+      'openai',
+      'gpt-5.6-terra',
+      'high',
+    );
+    expect(settingsSet).toHaveBeenCalledWith({
+      codex: 'gpt-5.6-terra',
+      codexProviderId: 'openai',
+      codexEffort: 'high',
     });
   });
 
@@ -516,6 +578,12 @@ describe('SubagentModelSection Codex row', () => {
     fireEvent.click(await screen.findByTestId('codex:pick-effort-high'));
     await waitFor(() => expect(settingsSet).toHaveBeenCalledTimes(1));
     expect(settingsSet).toHaveBeenCalledWith({ codexEffort: 'high' });
+    expect(modelMemoryMock.setEffort).toHaveBeenCalledWith(
+      'codex',
+      'openai',
+      'gpt-5.6-terra',
+      'high',
+    );
   });
 
   it('ignores effort changes while no codex model is stored', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Settings → Subagent 的 Codex 模型选择面板无法修改思考强度的问题。

该入口本来已经复用标准 `ModelSelector`，但没有注入非选中模型配置所需的 `modelMemory` 适配器；当当前值为“不指定”时，所有模型行都属于非选中状态，因此只显示 effort 标签、无法打开配置。现在补齐共用模型 preset 接线，并在选择模型时原子保存 `(model, providerId, effort)`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无，用户现场反馈
- 本 PR 包含：Subagent Codex 模型 preset 适配、effort 原子落库、活跃行 effort preset 同步、回归测试
- 明确不包含：共用模型面板视觉重构、Claude Code 子代理 effort、Fast Mode
- 用户可见变化：在“不指定”状态下也能直接为 Codex 模型选择思考强度；切换模型后不会恢复旧 preset
- 是否存在 breaking change：无

### UI 变化

- 未附截图：复用既有标准模型选择面板，没有布局、样式、颜色或文案变化；仅恢复原本缺失的 effort 配置交互
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4「Select & Dropdown」——继续复用标准 `ModelSelector`；§10「Light / Dark Dual-Mode Delivery Gate」——没有新增样式或硬编码颜色，两种模式继续走既有组件与语义 token

## 怎么验证的

### 自动验证

```text
/Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-subagent-reasoning-effort
结果：GATE_EXIT=0，全仓 unit gate 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm exec eslint src/renderer/components/settings/SubagentModelSection.tsx src/renderer/components/settings/__tests__/SubagentModelSectionRendering.test.tsx
结果：通过
```

### 手工验证

- macOS Desktop Global 开发版
- Settings → Subagent → Codex，在“不指定”状态下打开模型面板并修改模型思考强度
- 用户确认修改可以正常保存并生效

### 未执行的验证

- 未单独目检 Light 模式；本次没有视觉样式变化，交互复用同一标准组件

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Renderer 的 Subagent Codex 默认模型设置；既有 main/store/spawn 契约不变
- 回滚 / 降级方式：回滚本 PR commit 即恢复原行为；无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需产品文档更新）
- [x] 已确认测试结果或说明未执行原因
