### PR TITLE
fix(desktop): 自动续跑 API operation timeout

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
@@ -115,6 +115,7 @@ describe('isInterruptedTurnError', () => {
       'connect ECONNREFUSED 127.0.0.1:9',
       'socket hang up',
       'Request timed out',
+      'API Error: The operation timed out.',
       'Connection error',
       'upstream unreachable',
       '502 Bad Gateway',

--- a/apps/desktop/src/renderer/__tests__/networkError.test.ts
+++ b/apps/desktop/src/renderer/__tests__/networkError.test.ts
@@ -15,6 +15,7 @@ describe('isNetworkishErrorMessage', () => {
   it.each([
     // Anthropic SDK 重试耗尽后透传的终止型错误原文
     'Request timed out.',
+    'API Error: The operation timed out.',
     'Connection error.',
     // 网关 / errno / fetch 存量场景抽查
     'unexpected status 502 Bad Gateway: upstream unreachable: AggregateError',
@@ -31,6 +32,7 @@ describe('isNetworkishErrorMessage', () => {
     'Invalid API key',
     'thread not found',
     'context window exceeded',
+    'Local tool operation timed out.',
     // 长数字不因包含 502 片段误伤(\b 词边界)
     'order id 15024 rejected',
   ])('does not match non-network message: %s', (msg) => {

--- a/apps/desktop/src/renderer/__tests__/networkError.test.ts
+++ b/apps/desktop/src/renderer/__tests__/networkError.test.ts
@@ -33,6 +33,7 @@ describe('isNetworkishErrorMessage', () => {
     'thread not found',
     'context window exceeded',
     'Local tool operation timed out.',
+    'Wrapped error: API Error: The operation timed out.',
     // 长数字不因包含 502 片段误伤(\b 词边界)
     'order id 15024 rejected',
   ])('does not match non-network message: %s', (msg) => {

--- a/apps/desktop/src/renderer/utils/networkError.ts
+++ b/apps/desktop/src/renderer/utils/networkError.ts
@@ -39,7 +39,7 @@ export function parseReconnectAttemptMessage(message: string): ReconnectAttempt 
 export function isNetworkishErrorMessage(message: string): boolean {
   return (
     parseReconnectAttemptMessage(message) !== null ||
-    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|API Error:\s*The operation timed out|Connection error/i.test(
+    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|^API Error:\s*The operation timed out|Connection error/i.test(
       message,
     )
   );

--- a/apps/desktop/src/renderer/utils/networkError.ts
+++ b/apps/desktop/src/renderer/utils/networkError.ts
@@ -11,7 +11,7 @@
  *
  * `Reconnecting... N/M` 是 Codex streaming response 的有限重连状态；解析后的
  * attempt/maxAttempts 会显示在 recoverable banner。`Request timed out` /
- * `Connection error` 是 Anthropic SDK 的
+ * `API Error: The operation timed out` / `Connection error` 是 Anthropic SDK 的
  * APIConnectionTimeoutError / APIConnectionError 原文(SDK 重试耗尽后透传成
  * 终止型 turn error),同属重试可自愈的网络类(2026-07-13 超时横幅裸英文实锤)。
  */
@@ -39,7 +39,7 @@ export function parseReconnectAttemptMessage(message: string): ReconnectAttempt 
 export function isNetworkishErrorMessage(message: string): boolean {
   return (
     parseReconnectAttemptMessage(message) !== null ||
-    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|Connection error/i.test(
+    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|API Error:\s*The operation timed out|Connection error/i.test(
       message,
     )
   );

--- a/packages/maker-core/src/agents/shared/network-error.test.ts
+++ b/packages/maker-core/src/agents/shared/network-error.test.ts
@@ -18,6 +18,7 @@ describe('isNetworkishErrorMessage', () => {
   it.each([
     // Anthropic SDK 重试耗尽后透传的终止型错误原文
     'Request timed out.',
+    'API Error: The operation timed out.',
     'Connection error.',
     // 网关 / errno / fetch 存量场景抽查
     'unexpected status 502 Bad Gateway: upstream unreachable: AggregateError',
@@ -34,6 +35,7 @@ describe('isNetworkishErrorMessage', () => {
     'Invalid API key',
     'thread not found',
     'context window exceeded',
+    'Local tool operation timed out.',
     // 长数字不因包含 502 片段误伤(\b 词边界)
     'order id 15024 rejected',
   ])('does not match non-network message: %s', (msg) => {

--- a/packages/maker-core/src/agents/shared/network-error.test.ts
+++ b/packages/maker-core/src/agents/shared/network-error.test.ts
@@ -36,6 +36,7 @@ describe('isNetworkishErrorMessage', () => {
     'thread not found',
     'context window exceeded',
     'Local tool operation timed out.',
+    'Wrapped error: API Error: The operation timed out.',
     // 长数字不因包含 502 片段误伤(\b 词边界)
     'order id 15024 rejected',
   ])('does not match non-network message: %s', (msg) => {

--- a/packages/maker-core/src/agents/shared/network-error.ts
+++ b/packages/maker-core/src/agents/shared/network-error.ts
@@ -48,7 +48,7 @@ export function parseReconnectAttemptMessage(message: string): ReconnectAttempt 
 export function isNetworkishErrorMessage(message: string): boolean {
   return (
     parseReconnectAttemptMessage(message) !== null ||
-    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|API Error:\s*The operation timed out|Connection error/i.test(
+    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|^API Error:\s*The operation timed out|Connection error/i.test(
       message,
     )
   );

--- a/packages/maker-core/src/agents/shared/network-error.ts
+++ b/packages/maker-core/src/agents/shared/network-error.ts
@@ -16,7 +16,8 @@
  * 网关标准短语、Node 网络 errno(ECONNREFUSED 等)、undici/fetch 失败短语、
  * AggregateError(Node 并发连接尝试全失败的聚合错误,几乎只出现在网络场景)、
  * Anthropic SDK 的 APIConnectionTimeoutError / APIConnectionError 原文
- * ("Request timed out" / "Connection error",SDK 重试耗尽后透传成终止型 turn error)。
+ * ("Request timed out" / "API Error: The operation timed out" / "Connection error",
+ * SDK 重试耗尽后透传成终止型 turn error)。
  */
 export interface ReconnectAttempt {
   attempt: number;
@@ -47,7 +48,7 @@ export function parseReconnectAttemptMessage(message: string): ReconnectAttempt 
 export function isNetworkishErrorMessage(message: string): boolean {
   return (
     parseReconnectAttemptMessage(message) !== null ||
-    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|Connection error/i.test(
+    /\b50[234]\b|Bad Gateway|Service Unavailable|Gateway Time-?out|upstream unreachable|ECONNREFUSED|ECONNRESET|ETIMEDOUT|ENOTFOUND|ENETUNREACH|EHOSTUNREACH|EPIPE|EAI_AGAIN|fetch failed|network error|socket hang up|AggregateError|Request timed out|API Error:\s*The operation timed out|Connection error/i.test(
       message,
     )
   );


### PR DESCRIPTION
## 这次改了什么

### 摘要

将终态错误 `API Error: The operation timed out.` 精确归类为 network-ish interruption，使任务已经产生 assistant 文本或工具调用后被该错误中断时，接入现有的 interrupted-turn 自动续跑机制。

这个机制不是 SDK 内部的 `api_retry`：它由 Desktop main 在终态错误后启动一个隐藏的继续回合。零输出错误仍保持手动重试，避免在请求是否已被服务端接受不明确时自动重放。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈，无关联 Issue
- 本 PR 包含：maker-core 与 renderer 镜像错误分类器；interrupted-turn 自动续跑白名单；对应正反例单测
- 明确不包含：SDK `api_retry` 策略；零输出错误的自动重放；重试次数或退避策略调整
- 用户可见变化：已有进展的任务遇到该终态超时后，会复用现有的重连提示并自动继续；零输出情况不变
- 是否存在 breaking change：无

### UI 变化

不涉及：仅复用现有错误横幅和自动续跑交互，没有新增或修改视觉、布局、动效或 UI 文案。

- 引用的设计规范：不涉及：纯错误分类逻辑调整，无视觉、交互或 UI 文案变化

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-include-operation-timeout-retry
结果：GATE_EXIT=0，仓库根 pnpm test:unit 全量通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core exec vitest run src/agents/shared/network-error.test.ts
结果：19 tests passed

pnpm --filter desktop exec vitest run src/renderer/__tests__/networkError.test.ts src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
结果：50 tests passed

pnpm --filter desktop exec vitest run src/main/maker-ipc/__tests__/agentEventCoordinator.test.ts -t autoRetryLastError
结果：3 tests passed，237 tests skipped

pnpm check:dco
结果：1 commit signed off
```

`@cindy/maker-core` 没有 `typecheck` script，按仓库规则跳过。

### 手工验证

不涉及：未用真实上游超时做端到端断流复现。

### 未执行的验证

未执行真实 SDK 超时端到端复现；本次通过精确错误分类单测和既有自动续跑协调器单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：错误分类范围

### 影响与回滚

- 影响范围：只匹配精确前缀 `API Error:` 下的 `The operation timed out`；保留 `Local tool operation timed out.` 反例，避免将本地工具超时泛化为网络中断。纯正则分类逻辑在 macOS / Windows 共用，但未单独做 Windows 实机验证。无新 IPC、协议、system prompt、缓存、token 计量或正常热路径影响；远程 / mobile 控制 Desktop 时复用同一 main 层终态分类。
- 回滚 / 降级方式：revert 本 PR commit，恢复该错误的手动重试行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
