### PR TITLE
fix(desktop): 优化任务标题行内改名布局

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sessionRenameAiFill.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionRenameAiFill.test.ts
@@ -117,6 +117,35 @@ describe('SessionRenameInput AI rename fills edit state', () => {
     expect(button.classList.contains('hover:text-sidebar-item-active-foreground')).toBe(true);
   });
 
+  it('clears a stale pointer-focus marker when the input blurs before pointerup', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      createElement(SessionRenameInput, {
+        sessionId: 's1',
+        value: '旧标题',
+        onValueChange: () => {},
+        onCommit,
+        onCancel: () => {},
+      }),
+    );
+
+    const input = container.querySelector('input')!;
+    const button = container.querySelector('button')!;
+
+    // 指针在 input 按下后拖出，pointerup 不再落回 input；Tab 到 Magic 时的 blur
+    // 必须清掉该标记，Shift+Tab 回来仍应识别为键盘聚焦并显示蓝环。
+    fireEvent.pointerDown(input);
+    fireEvent.blur(input, { relatedTarget: button });
+    fireEvent.focus(button);
+    fireEvent.pointerUp(button);
+    fireEvent.blur(button, { relatedTarget: input });
+    fireEvent.focus(input);
+
+    expect(input.classList.contains('ring-2')).toBe(true);
+    expect(input.classList.contains('ring-[var(--focus-ring-soft)]')).toBe(true);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
   it('generated title fills the input without committing; Enter commits it', async () => {
     const onCommit = vi.fn();
     const { input, container } = await renderAndGenerate(onCommit, () => {});

--- a/apps/desktop/src/renderer/__tests__/sessionRenameAiFill.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionRenameAiFill.test.ts
@@ -51,6 +51,47 @@ async function renderAndGenerate(onCommit: (raw: string) => void, onCancel: () =
 }
 
 describe('SessionRenameInput AI rename fills edit state', () => {
+  it('uses a neutral pill editor and reserves blue focus for keyboard navigation', () => {
+    const onCommit = vi.fn();
+    const { container } = render(
+      createElement(SessionRenameInput, {
+        sessionId: 's1',
+        value: '旧标题',
+        onValueChange: () => {},
+        onCommit,
+        onCancel: () => {},
+      }),
+    );
+
+    const input = container.querySelector('input')!;
+    const button = container.querySelector('button')!;
+    expect(input.classList.contains('rounded-full')).toBe(true);
+    expect(input.classList.contains('border')).toBe(true);
+    expect(input.classList.contains('border-[var(--border-default)]')).toBe(true);
+    expect(input.classList.contains('border-[1.5px]')).toBe(false);
+    expect(input.classList.contains('border-[var(--focus-ring)]')).toBe(false);
+    expect(input.classList.contains('ring-2')).toBe(false);
+
+    // Tab 到 Magic 后 Shift+Tab 回到 input：这是键盘聚焦，应出现蓝色软环。
+    fireEvent.blur(input, { relatedTarget: button });
+    fireEvent.focus(button);
+    fireEvent.blur(button, { relatedTarget: input });
+    fireEvent.focus(input);
+    expect(input.classList.contains('ring-2')).toBe(true);
+    expect(input.classList.contains('ring-[var(--focus-ring-soft)]')).toBe(true);
+    expect(onCommit).not.toHaveBeenCalled();
+
+    // 鼠标在输入框或 Magic 上继续操作时隐去蓝环，保留中性描边。
+    fireEvent.pointerDown(button);
+    expect(input.classList.contains('ring-2')).toBe(false);
+
+    // Magic 保留原有的小圆角几何，只补键盘 focus-visible 反馈。
+    expect(button.classList.contains('rounded')).toBe(true);
+    expect(button.classList.contains('rounded-full')).toBe(false);
+    expect(button.classList.contains('focus-visible:ring-2')).toBe(true);
+    expect(button.classList.contains('focus-visible:ring-[var(--focus-ring-soft)]')).toBe(true);
+  });
+
   it('uses the active foreground for both rename controls on an active sidebar row', () => {
     const { container } = render(createElement(SessionRenameInput, {
       sessionId: 's1',
@@ -66,6 +107,12 @@ describe('SessionRenameInput AI rename fills edit state', () => {
     const button = container.querySelector('button')!;
     expect(input.classList.contains('text-sidebar-item-active-foreground')).toBe(true);
     expect(input.classList.contains('text-foreground')).toBe(false);
+    expect(input.classList.contains('border-[var(--border-default)]')).toBe(false);
+    expect(
+      input.classList.contains(
+        'border-[color-mix(in_srgb,var(--sidebar-item-active-foreground)_28%,transparent)]',
+      ),
+    ).toBe(true);
     expect(button.classList.contains('text-sidebar-item-active-foreground')).toBe(true);
     expect(button.classList.contains('hover:text-sidebar-item-active-foreground')).toBe(true);
   });

--- a/apps/desktop/src/renderer/features/cc-agent/SessionRenameInput.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionRenameInput.tsx
@@ -17,8 +17,9 @@
  *     路由由 makerTransport.regenerateSessionTitleFor 决定;老被控端不识别该
  *     channel 时 invoke 被拒,走同一条失败 toast
  *
- * 视觉:边框 / 圆角 / 透明底等共有部分内置;字号字重(各处不同)与布局定位
- * (flex-1 / 固定宽)分别由 inputClassName / containerClassName 传入。
+ * 视觉:中性胶囊描边 / 透明底 / 键盘聚焦环等共有部分内置;
+ * 字号字重(各处不同)与布局定位(flex-1 / 固定宽)分别由
+ * inputClassName / containerClassName 传入。
  */
 
 import { useEffect, useRef, useState } from 'react';
@@ -67,7 +68,7 @@ interface SessionRenameInputProps {
   inputClassName?: string;
   /** 外层容器布局类:min-w-0 flex-1 或固定宽度。 */
   containerClassName?: string;
-  /** 位于侧栏 active 反相底色上时，input 与 Magic 按钮都切到配套前景色。 */
+  /** 位于侧栏 active 反相底色上时，input / 描边 / Magic 按钮都切到配套色系。 */
   activeForeground?: boolean;
 }
 
@@ -85,13 +86,22 @@ export function SessionRenameInput({
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [generating, setGenerating] = useState(false);
+  const [keyboardFocusVisible, setKeyboardFocusVisible] = useState(false);
+  // input 是程序化聚焦的文本控件，Chromium 会在鼠标双击进入编辑时也将它
+  // 匹配为 :focus-visible。记住首次聚焦与后续 pointer 聚焦，只在键盘路径上显示
+  // Focus Blue；鼠标进入编辑时只保留中性描边。
+  const applyingInitialFocusRef = useRef(true);
+  const pointerFocusRef = useRef(false);
   // 卸载 = 编辑态已终结(提交/取消)。迟到的 AI 结果(成功或失败)据此丢弃:
   // 不再填入输入框、不再 toast、不再 setState,避免污染用户的下一轮编辑。
   const mountedRef = useRef(true);
 
   useEffect(() => {
+    const origin = document.activeElement;
+    setKeyboardFocusVisible(origin instanceof HTMLElement && origin.matches(':focus-visible'));
     inputRef.current?.focus();
     inputRef.current?.select();
+    applyingInitialFocusRef.current = false;
     return () => {
       mountedRef.current = false;
     };
@@ -168,6 +178,21 @@ export function SessionRenameInput({
         ref={inputRef}
         value={value}
         onChange={(e) => onValueChange(e.target.value)}
+        onFocus={() => {
+          if (applyingInitialFocusRef.current) return;
+          setKeyboardFocusVisible(!pointerFocusRef.current);
+        }}
+        onBlur={() => setKeyboardFocusVisible(false)}
+        onPointerDown={() => {
+          pointerFocusRef.current = true;
+          setKeyboardFocusVisible(false);
+        }}
+        onPointerUp={() => {
+          pointerFocusRef.current = false;
+        }}
+        onPointerCancel={() => {
+          pointerFocusRef.current = false;
+        }}
         onKeyDown={(e) => {
           e.stopPropagation();
           // IME 组合中的 Enter 是确认候选词,不是提交
@@ -186,10 +211,11 @@ export function SessionRenameInput({
         // 吃掉浏览器默认的双击选词。stopPropagation 不影响默认选词行为。
         onDoubleClick={(e) => e.stopPropagation()}
         className={cn(
-          'w-full min-w-0 px-1.5 rounded',
-          'bg-transparent outline-none',
-          'border-[1.5px] border-[var(--focus-ring)]',
-          'pr-7',
+          'w-full min-w-0 rounded-full border bg-transparent px-1.5 pr-7 outline-none',
+          activeForeground
+            ? 'border-[color-mix(in_srgb,var(--sidebar-item-active-foreground)_28%,transparent)]'
+            : 'border-[var(--border-default)]',
+          keyboardFocusVisible && 'ring-2 ring-[var(--focus-ring-soft)]',
           inputClassName,
           activeForeground && 'text-sidebar-item-active-foreground',
         )}
@@ -209,7 +235,10 @@ export function SessionRenameInput({
           e.preventDefault();
           e.stopPropagation();
         }}
-        onPointerDown={(e) => e.stopPropagation()}
+        onPointerDown={(e) => {
+          setKeyboardFocusVisible(false);
+          e.stopPropagation();
+        }}
         onDoubleClick={(e) => e.stopPropagation()}
         onClick={(e) => {
           e.stopPropagation();
@@ -221,7 +250,7 @@ export function SessionRenameInput({
           activeForeground
             ? 'text-sidebar-item-active-foreground hover:text-sidebar-item-active-foreground hover:bg-[color-mix(in_srgb,var(--sidebar-item-active-foreground)_14%,transparent)]'
             : 'text-[var(--cmd-palette-item-meta)] hover:bg-titlebar-button-hover hover:text-foreground',
-          'focus:outline-none',
+          'focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]',
         )}
       >
         {generating ? <Spinner size={13} /> : <Sparkles size={13} />}

--- a/apps/desktop/src/renderer/features/cc-agent/SessionRenameInput.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionRenameInput.tsx
@@ -182,7 +182,12 @@ export function SessionRenameInput({
           if (applyingInitialFocusRef.current) return;
           setKeyboardFocusVisible(!pointerFocusRef.current);
         }}
-        onBlur={() => setKeyboardFocusVisible(false)}
+        onBlur={() => {
+          // pointerup 可能落在 input 外（例如按下后拖出再松开），因此不能只靠
+          // onPointerUp / onPointerCancel 清理；否则后续 Shift+Tab 回来会被误判为鼠标聚焦。
+          pointerFocusRef.current = false;
+          setKeyboardFocusVisible(false);
+        }}
         onPointerDown={() => {
           pointerFocusRef.current = true;
           setKeyboardFocusVisible(false);

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -2,10 +2,9 @@
  * SessionCard — sidebar-card-mode 下的单条会话卡片（SessionItem 的瀑布流形态）
  * ---------------------------------------------------------------------------
  * 设计来源：用户 Claude design 稿（XDT-sidebar-redesign，xdtsb-card 系）。
- * 视觉：白底 Card + 1px Board 圆角 12；标题左侧保留与 SessionItem 同源的
- *   SessionStatusIcon（agent 标识 + running 呼吸 + attention 状态点 + 草稿铅笔），
- *   标题最多 2 行，摘要 / 最近消息随内容最多 1~3 行；底部 metadata 槽放短进度条、
- *   worktree 标识和时间。
+ * 视觉：白底 Card + 1px Board 圆角 12；标题最多 2 行且保持纯文字，摘要 / 最近消息
+ *   随内容最多 1~3 行；SessionStatusIcon（agent 标识 + running 呼吸 + attention
+ *   状态点 + 草稿铅笔）、自动化 / 远程 / worktree 标识与时间统一放在底部 metadata 槽。
  *
  * 交互 100% 对齐 SessionItem（props 签名完全一致，sections 内按 cardMode 二选一渲染）：
  *   - 单击导航 / 双击重命名（标题原位变 input）
@@ -13,8 +12,8 @@
  *     archived / draft 变体同款分支）
  *   - hover 右上角仅 More（⋮）快捷钮；存档收进 ⋮ / 右键展开菜单的 Archive 项
  *     （卡片不再出现独立的存档快捷钮）。已归档卡片保留"取消归档"快捷钮。
- *   - card / list 变体:标题左侧复用 SessionStatusIcon(含 agent 图标、运行呼吸、草稿铅笔)
- *     list 的状态点 / spinner 与文字模式同口径，统一放在右下角
+ *   - list 变体保留标题左侧 SessionStatusIcon / 自动化前缀；card 变体标题不带前缀，
+ *     状态 / Agent / 自动化图标留在底部 meta 行
  *   - remote 会话标识复用 RemoteProjectIcon,继续区分 device-link / ssh
  *   - matchIndices 模糊搜索高亮沿用 highlightSegments
  *
@@ -569,54 +568,59 @@ export function SessionCard({
             />
           )}
           <div className="flex items-center gap-1.5">
-            {isEditing ? (
-              <SessionRenameInput
-                sessionId={session.id}
-                value={editValue}
-                onValueChange={setEditValue}
-                onCommit={commitTitle}
-                onCancel={() => {
-                  // Esc 取消视为终态:置 committedRef 拦掉 input 卸载触发的 blur 提交
-                  // 与生成中迟到的 AI 结果(Codex review P2:取消后不应再被 AI 改名)。
-                  committedRef.current = true;
-                  setIsEditing(false);
-                }}
-                containerClassName="min-w-0 flex-1"
-                inputClassName="h-6 text-13 font-semibold text-foreground"
-                activeForeground={isActive}
-              />
-            ) : (
-              <div className="flex min-w-0 flex-1 items-center gap-1">
-                <span
-                  className={cn(
-                    'min-w-0 truncate',
-                    'text-13 font-semibold leading-[1.3] tracking-[-0.005em]',
-                    isActive ? 'text-sidebar-item-active-foreground' : 'text-foreground',
+            {/* 标题槽固定沿用常态时间槽的 20px 高度。改名框本身是 24px，编辑时
+                绝对定位居中覆盖文字槽位，不参与布局计算，避免整条置顶任务被撑高。
+                状态 / Agent / 自动化图标始终留在文字槽左侧，编辑态也不改变标题起点。 */}
+            <div className="relative flex h-5 min-w-0 flex-1 items-center gap-0">
+              <span className="flex shrink-0 items-center">{titlePrefixNode}</span>
+              {isEditing ? (
+                <SessionRenameInput
+                  sessionId={session.id}
+                  value={editValue}
+                  onValueChange={setEditValue}
+                  onCommit={commitTitle}
+                  onCancel={() => {
+                    // Esc 取消视为终态:置 committedRef 拦掉 input 卸载触发的 blur 提交
+                    // 与生成中迟到的 AI 结果(Codex review P2:取消后不应再被 AI 改名)。
+                    committedRef.current = true;
+                    setIsEditing(false);
+                  }}
+                  containerClassName="relative min-w-0 flex-1 self-stretch"
+                  inputClassName="absolute inset-x-0 top-1/2 h-6 -translate-y-1/2 text-13 font-semibold text-foreground"
+                  activeForeground={isActive}
+                />
+              ) : (
+                <div className="flex min-w-0 flex-1 items-center gap-1">
+                  <span
+                    className={cn(
+                      'min-w-0 truncate',
+                      'text-13 font-semibold leading-[1.3] tracking-[-0.005em]',
+                      isActive ? 'text-sidebar-item-active-foreground' : 'text-foreground',
+                    )}
+                  >
+                    {matchIndices && matchIndices.length > 0 && canHighlightDisplayTitle
+                      ? highlightSegments(session.title, matchIndices, {
+                          highlightClassName: cn(
+                            'bg-transparent font-semibold',
+                            isActive
+                              ? 'text-[var(--sidebar-item-active-foreground)]'
+                              : 'text-[var(--msg-assistant-text)]',
+                          ),
+                        })
+                      : displayTitle}
+                  </span>
+                  {remoteIconKind && (
+                    <RemoteProjectIcon
+                      kind={remoteIconKind}
+                      size={11}
+                      strokeWidth={1.8}
+                      connectionStatus={remoteIconConnectionStatus}
+                      className={isActive ? 'text-sidebar-item-active-foreground' : 'text-[var(--text-tertiary)]'}
+                    />
                   )}
-                >
-                  {titlePrefixNode}
-                  {matchIndices && matchIndices.length > 0 && canHighlightDisplayTitle
-                    ? highlightSegments(session.title, matchIndices, {
-                        highlightClassName: cn(
-                          'bg-transparent font-semibold',
-                          isActive
-                            ? 'text-[var(--sidebar-item-active-foreground)]'
-                            : 'text-[var(--msg-assistant-text)]',
-                        ),
-                      })
-                    : displayTitle}
-                </span>
-                {remoteIconKind && (
-                  <RemoteProjectIcon
-                    kind={remoteIconKind}
-                    size={11}
-                    strokeWidth={1.8}
-                    connectionStatus={remoteIconConnectionStatus}
-                    className={isActive ? 'text-sidebar-item-active-foreground' : 'text-[var(--text-tertiary)]'}
-                  />
-                )}
-              </div>
-            )}
+                </div>
+              )}
+            </div>
 
             {/* 时间槽位:hover/菜单打开让位给 More/Archive(逻辑同对话列表)。
                 Agent 身份图标留在标题左侧，状态指示器改由下方右下角承担。 */}
@@ -732,41 +736,15 @@ export function SessionCard({
           </button>
         )}
 
-        {/* 第 1 行:状态 / 自动化前缀在 list 与 card 变体共用同一段 titlePrefixNode，
-            保证 SessionStatusIcon、Timer 与标题在不同模式下的横向间距和基线一致。 */}
-        {isEditing ? (
-          <div className="flex items-start gap-1.5">
-            <span className="mt-[2px] shrink-0">
-              <SessionStatusIcon
-                session={session}
-                isRunning={isRunning}
-                isAttached={isAttached}
-                hasAttentionNotification={hasAttentionNotification}
-                isActive={isActive}
-              />
-            </span>
-            <SessionRenameInput
-              sessionId={session.id}
-              value={editValue}
-              onValueChange={setEditValue}
-              onCommit={commitTitle}
-              onCancel={() => {
-                // Esc 取消视为终态:置 committedRef 拦掉 input 卸载触发的 blur 提交
-                // 与生成中迟到的 AI 结果(Codex review P2:取消后不应再被 AI 改名)。
-                committedRef.current = true;
-                setIsEditing(false);
-              }}
-              containerClassName="min-w-0 flex-1"
-              inputClassName="h-6 text-[12.5px] font-bold text-foreground"
-              activeForeground={isActive}
-            />
-          </div>
-        ) : (
+        {/* 卡片标题始终保留原来的流式盒子；编辑时只把原标题隐藏，并以绝对定位的
+            24px 输入框覆盖。这样一行 / 两行标题都维持原高度，也不会凭空多出状态图标。 */}
+        <div className="relative">
           <div
             className={cn(
               'min-w-0 text-[12.5px] font-bold leading-[1.22] tracking-[-0.005em]',
               '[display:-webkit-box] [-webkit-box-orient:vertical] [-webkit-line-clamp:2] overflow-hidden',
               isActive ? 'text-sidebar-item-active-foreground' : 'text-foreground',
+              isEditing && 'invisible',
             )}
             style={{ textIndent: 0, paddingLeft: 0 }}
           >
@@ -781,7 +759,24 @@ export function SessionCard({
                 })
               : displayTitle}
           </div>
-        )}
+          {isEditing && (
+            <SessionRenameInput
+              sessionId={session.id}
+              value={editValue}
+              onValueChange={setEditValue}
+              onCommit={commitTitle}
+              onCancel={() => {
+                // Esc 取消视为终态:置 committedRef 拦掉 input 卸载触发的 blur 提交
+                // 与生成中迟到的 AI 结果(Codex review P2:取消后不应再被 AI 改名)。
+                committedRef.current = true;
+                setIsEditing(false);
+              }}
+              containerClassName="absolute inset-x-0 top-1/2 -translate-y-1/2"
+              inputClassName="h-6 text-[12.5px] font-bold text-foreground"
+              activeForeground={isActive}
+            />
+          )}
+        </div>
 
         {/* 预览:等待交互文案优先,否则显示稳定任务总结 / 最近消息。图标全部下沉到底部 meta 行,
             此处只放正文文字。 */}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -342,11 +342,105 @@ describe('SessionCard visual cases', () => {
 
     // list 变体保持原有标题前缀契约不变:自动化图标仍在标题里。
     const { container: listContainer } = render(createElement(SessionCard, { ...commonProps, variant: 'list' }));
-    const listTitle = Array.from(listContainer.querySelectorAll('span')).find((node) =>
-      node.className.includes('truncate') && node.textContent?.includes('自动化日报巡检'),
+    const listTitleRow = Array.from(listContainer.querySelectorAll<HTMLElement>('div')).find(
+      (node) =>
+        node.classList.contains('h-5') &&
+        node.textContent?.includes('自动化日报巡检') &&
+        node.querySelector('[aria-label="查看自动化任务"]'),
     );
-    expect(listTitle?.textContent).toContain('自动化日报巡检');
-    expect(listTitle?.querySelector('[aria-label="查看自动化任务"]')).not.toBeNull();
+    expect(listTitleRow?.textContent).toContain('自动化日报巡检');
+    expect(listTitleRow?.querySelector('[aria-label="查看自动化任务"]')).not.toBeNull();
+  });
+
+  it('keeps the list title row height stable while the rename editor overlays it', () => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'short-idle-cc');
+    if (!visualCase) throw new Error('Missing idle visual case');
+
+    const { container } = render(
+      createElement(SessionCard, {
+        session: visualCase.session,
+        variant: 'list',
+        isActive: false,
+        isRunning: false,
+        isAttached: false,
+        hasAttentionNotification: false,
+        isSelected: false,
+        onClick: vi.fn(),
+        onAction: vi.fn(),
+        onRename: vi.fn(),
+        onTogglePin: vi.fn(),
+        projectOptions: [],
+      }),
+    );
+
+    const card = container.querySelector<HTMLElement>('[data-sidebar-session-row="true"]')!;
+    const titleRow = Array.from(card.querySelectorAll<HTMLElement>('div')).find(
+      (node) =>
+        node.classList.contains('h-5') && node.textContent?.includes(visualCase.session.title),
+    );
+    expect(titleRow).toBeTruthy();
+    const statusIconSlot = Array.from(titleRow!.querySelectorAll<HTMLElement>('span')).find(
+      (node) => node.className.includes('w-3') && node.querySelector('svg'),
+    );
+    expect(statusIconSlot).toBeTruthy();
+
+    fireEvent.doubleClick(card);
+
+    const input = card.querySelector<HTMLInputElement>('input')!;
+    const editor = input.parentElement!;
+    expect(editor.parentElement).toBe(titleRow);
+    expect(editor.classList.contains('relative')).toBe(true);
+    expect(editor.classList.contains('self-stretch')).toBe(true);
+    expect(input.classList.contains('absolute')).toBe(true);
+    expect(input.classList.contains('inset-x-0')).toBe(true);
+    expect(input.classList.contains('top-1/2')).toBe(true);
+    expect(input.classList.contains('-translate-y-1/2')).toBe(true);
+    expect(input.classList.contains('h-6')).toBe(true);
+    expect(titleRow!.contains(statusIconSlot!)).toBe(true);
+  });
+
+  it('keeps the card title flow box mounted while the rename editor overlays it without a duplicate status icon', () => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'short-idle-cc');
+    if (!visualCase) throw new Error('Missing idle visual case');
+
+    const { container } = render(
+      createElement(SessionCard, {
+        session: visualCase.session,
+        isActive: false,
+        isRunning: false,
+        isAttached: false,
+        hasAttentionNotification: false,
+        isSelected: false,
+        onClick: vi.fn(),
+        onAction: vi.fn(),
+        onRename: vi.fn(),
+        onTogglePin: vi.fn(),
+        projectOptions: [],
+      }),
+    );
+
+    const card = container.querySelector<HTMLElement>('[data-sidebar-session-row="true"]')!;
+    const title = Array.from(card.querySelectorAll<HTMLElement>('div')).find((node) =>
+      node.className.includes('[-webkit-line-clamp:2]'),
+    )!;
+    expect(title.classList.contains('invisible')).toBe(false);
+
+    fireEvent.doubleClick(card);
+
+    const input = card.querySelector<HTMLInputElement>('input')!;
+    const overlay = input.parentElement!;
+    const titleSlot = title.parentElement!;
+    expect(card.contains(title)).toBe(true);
+    expect(title.classList.contains('invisible')).toBe(true);
+    expect(titleSlot).toBe(overlay.parentElement);
+    expect(titleSlot.classList.contains('relative')).toBe(true);
+    expect(overlay.classList.contains('absolute')).toBe(true);
+    expect(overlay.classList.contains('inset-x-0')).toBe(true);
+    expect(overlay.classList.contains('top-1/2')).toBe(true);
+    expect(overlay.classList.contains('-translate-y-1/2')).toBe(true);
+    expect(titleSlot.querySelectorAll('svg')).toHaveLength(1);
+    expect(titleSlot.querySelector('.lucide-sparkles')).not.toBeNull();
+    expect(input.classList.contains('h-6')).toBe(true);
   });
 
   it('keeps archived sessions on the archive visual branch', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

统一优化任务标题的行内改名体验：把常驻蓝色矩形输入框改为中性胶囊输入框，蓝色只在键盘焦点路径出现；同时消除置顶任务在列表和卡片模式下进入改名时的高度跳变与图标错位。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈——双击任务标题改名时视觉不符合规范，置顶任务列表 / 卡片布局会跳变或出现错误图标。
- 本 PR 包含：共享任务改名输入框的视觉与焦点行为；`SessionCard` 列表 / 卡片两种改名布局；对应回归测试。
- 明确不包含：Project、自动化任务列表、workdir 标签页等其它独立改名控件的统一改造。
- 用户可见变化：输入框改为中性 pill；鼠标进入编辑不再显示蓝框；列表编辑保留左侧原有图标且高度稳定；卡片编辑不再新增状态图标且高度稳定。
- 是否存在 breaking change：无。

### UI 变化

- 未附截图：开发版中包含真实任务内容，不适合公开上传；主要交互已由用户在 macOS 开发版直接验收。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §2 Semantic & Accent：Focus Blue 只用于键盘可访问焦点，不在普通鼠标交互中常驻。
  - `docs/design-rules/DESIGN.md` §4 Inputs & Forms、§5 Border Radius Scale：单行输入使用 pill 几何与 `--border-default` 中性 Board 描边。
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：颜色全部使用语义 token，Light / Dark 共用同一实现。
  - `docs/dev-rules/engineering-conventions.md` §7：编辑态输入框绝对覆盖原标题槽，避免列表 / 卡片高度跳变。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/sessionRenameOutsidePointerDown.test.ts \
  src/renderer/__tests__/imeEnterCompositionGuard.test.ts \
  src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts \
  src/renderer/__tests__/sessionRenameAiFill.test.ts
结果：6 个测试文件、78 项测试全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter desktop exec eslint \
  src/renderer/features/cc-agent/SessionRenameInput.tsx \
  src/renderer/features/cc-agent/sidebar/SessionCard.tsx \
  src/renderer/__tests__/sessionRenameAiFill.test.ts \
  src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
结果：通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh \
  /Users/dash/Code/Cindy/cindy-refine-session-title-inline-edit
结果：GATE_EXIT=0，全仓 unit gate 通过。

git diff --check
结果：通过。

pnpm check:dco
结果：1 个提交签名通过。
```

### 手工验证

- macOS 开发版：用户已直接验收共享改名框、置顶任务列表模式和卡片模式的主要视觉与交互结果。

### 未执行的验证

- 最终提交未重新启动开发版逐项复测；rebase 后按已验收语义重施最小补丁，并以定向回归测试覆盖最终 DOM / class 不变量。
- 未在 Windows 实机目检。
- 未分别切换 Light / Dark 做实机目检；实现仅使用现有语义 token，未加入单模式硬编码。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 的任务标题行内改名视觉与 `SessionCard` 布局。
- 回滚 / 降级方式：回退本 PR 即恢复原改名框与原布局；不涉及数据迁移、协议或持久化状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本改动无需新增长期产品文档）
- [x] 已确认测试结果或说明未执行原因
