### PR TITLE
feat(codex): 子代理默认按需委托,补齐 spawn 可见性与模型徽标

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-subagent-config.test.ts
@@ -10,9 +10,47 @@ function settings(partial: Partial<SubagentModelSettings> = {}): SubagentModelSe
   return { ...SUBAGENT_MODEL_SETTINGS_DEFAULTS, ...partial };
 }
 
+// 子代理开启时恒注入的两个 features 段键(按需委托策略 + spawn 模型覆盖)。
+const DELEGATION_ARGS_PREFIXES = [
+  'features.multi_agent_v2.multi_agent_mode_hint_text="',
+  'features.multi_agent_v2.expose_spawn_agent_model_overrides=true',
+] as const;
+
+function expectDelegationArgs(args: string[]): void {
+  for (const prefix of DELEGATION_ARGS_PREFIXES) {
+    expect(args.some((arg) => arg.startsWith(prefix))).toBe(true);
+  }
+}
+
+/** 去掉恒注入的 delegation 键值对(连同配对的 '-c'),只留设置驱动的 agents.* 部分。 */
+function withoutDelegationArgs(args: string[]): string[] {
+  const out: string[] = [];
+  for (let i = 0; i < args.length; i += 2) {
+    const kv = args[i + 1] ?? '';
+    if (DELEGATION_ARGS_PREFIXES.some((prefix) => kv.startsWith(prefix))) continue;
+    out.push(args[i]!, kv);
+  }
+  return out;
+}
+
 describe('buildCodexSubagentSpawnArgs', () => {
-  it('emits nothing for all-default settings', () => {
-    expect(buildCodexSubagentSpawnArgs(settings())).toEqual([]);
+  it('emits only the delegation defaults for all-default settings', () => {
+    const args = buildCodexSubagentSpawnArgs(settings());
+    // 形态:两条 '-c' + 值的键值对,无 agents.* 键。
+    expect(args.filter((a) => a === '-c')).toHaveLength(2);
+    expectDelegationArgs(args);
+    for (const arg of args) {
+      expect(arg).not.toContain('agents.');
+    }
+  });
+
+  it('keeps the delegation hint within the upstream 400-token budget', () => {
+    // 上游 MULTI_AGENT_MODE_MAX_TOKENS=400;粗算 4 chars/token,留足余量。
+    const hintArg = buildCodexSubagentSpawnArgs(settings()).find((arg) =>
+      arg.startsWith('features.multi_agent_v2.multi_agent_mode_hint_text='),
+    );
+    expect(hintArg).toBeDefined();
+    expect(hintArg!.length).toBeLessThan(1400);
   });
 
   it('emits only agents.enabled=false when the master switch is off', () => {
@@ -31,15 +69,15 @@ describe('buildCodexSubagentSpawnArgs', () => {
   });
 
   it('quotes string values and keeps numbers bare (TOML forms)', () => {
-    expect(
-      buildCodexSubagentSpawnArgs(
-        settings({
-          codex: 'gpt-5.6-terra',
-          codexEffort: 'medium',
-          codexMaxConcurrentSubagents: 3,
-        }),
-      ),
-    ).toEqual([
+    const args = buildCodexSubagentSpawnArgs(
+      settings({
+        codex: 'gpt-5.6-terra',
+        codexEffort: 'medium',
+        codexMaxConcurrentSubagents: 3,
+      }),
+    );
+    expectDelegationArgs(args);
+    expect(withoutDelegationArgs(args)).toEqual([
       '-c',
       'agents.default_subagent_model="gpt-5.6-terra"',
       '-c',
@@ -51,31 +89,36 @@ describe('buildCodexSubagentSpawnArgs', () => {
 
   it('injects discounted-route model ids verbatim (no prefix stripping)', () => {
     // codex/ 前缀由 loopback proxy 在 HTTP 边界分流,剥前缀会把折扣路由静默改道。
-    expect(buildCodexSubagentSpawnArgs(settings({ codex: 'codex/gpt-5.5' }))).toEqual([
-      '-c',
-      'agents.default_subagent_model="codex/gpt-5.5"',
-    ]);
+    expect(
+      withoutDelegationArgs(buildCodexSubagentSpawnArgs(settings({ codex: 'codex/gpt-5.5' }))),
+    ).toEqual(['-c', 'agents.default_subagent_model="codex/gpt-5.5"']);
   });
 
   it('maps the nested-subagents switch to agents.max_depth=2', () => {
-    expect(buildCodexSubagentSpawnArgs(settings({ codexAllowNestedSubagents: true }))).toEqual([
-      '-c',
-      'agents.max_depth=2',
-    ]);
+    expect(
+      withoutDelegationArgs(
+        buildCodexSubagentSpawnArgs(settings({ codexAllowNestedSubagents: true })),
+      ),
+    ).toEqual(['-c', 'agents.max_depth=2']);
   });
 
   it('keeps concurrency bounds inclusive', () => {
     expect(
-      buildCodexSubagentSpawnArgs(settings({ codexMaxConcurrentSubagents: 1 })),
+      withoutDelegationArgs(
+        buildCodexSubagentSpawnArgs(settings({ codexMaxConcurrentSubagents: 1 })),
+      ),
     ).toEqual(['-c', 'agents.max_concurrent_threads_per_session=1']);
     expect(
-      buildCodexSubagentSpawnArgs(settings({ codexMaxConcurrentSubagents: 8 })),
+      withoutDelegationArgs(
+        buildCodexSubagentSpawnArgs(settings({ codexMaxConcurrentSubagents: 8 })),
+      ),
     ).toEqual(['-c', 'agents.max_concurrent_threads_per_session=8']);
   });
 
-  it('never emits features.multi_agent_v2.* keys (regression guard)', () => {
-    // 上游两个配置 struct 都 deny_unknown_fields,且 features 段与 agents 段的并发
-    // 键语义不同(总线程 vs 子代理数)——同时写会产生双重语义,永远只写 agents.*。
+  it('only emits the two allowlisted features.multi_agent_v2.* keys (regression guard)', () => {
+    // 上游两个配置 struct 都 deny_unknown_fields;并发键在 features 段语义为总线程
+    // (=N+1)且优先级更高——并发数永远只写 agents.*,features 段只允许 hint 与
+    // expose 两个无 agents 等价物的键。
     const exhaustive = buildCodexSubagentSpawnArgs(
       settings({
         codexSubagentsEnabled: true,
@@ -86,8 +129,16 @@ describe('buildCodexSubagentSpawnArgs', () => {
       }),
     );
     for (const arg of exhaustive) {
-      expect(arg).not.toContain('features.multi_agent_v2');
+      if (!arg.startsWith('features.multi_agent_v2')) continue;
+      expect(DELEGATION_ARGS_PREFIXES.some((prefix) => arg.startsWith(prefix))).toBe(true);
     }
+    expect(
+      exhaustive.some((arg) => arg.includes('features.multi_agent_v2.max_concurrent')),
+    ).toBe(false);
+  });
+
+  it('emits no features.multi_agent_v2.* keys when the master switch is off', () => {
+    // 总开关关闭 = agents.enabled=false 已压住一切,委托策略不再注入。
     const disabled = buildCodexSubagentSpawnArgs(settings({ codexSubagentsEnabled: false }));
     for (const arg of disabled) {
       expect(arg).not.toContain('features.multi_agent_v2');
@@ -95,9 +146,10 @@ describe('buildCodexSubagentSpawnArgs', () => {
   });
 
   it('escapes TOML-breaking characters defensively', () => {
-    expect(buildCodexSubagentSpawnArgs(settings({ codex: 'weird"model\\id' }))).toEqual([
-      '-c',
-      'agents.default_subagent_model="weird\\"model\\\\id"',
-    ]);
+    expect(
+      withoutDelegationArgs(
+        buildCodexSubagentSpawnArgs(settings({ codex: 'weird"model\\id' })),
+      ),
+    ).toEqual(['-c', 'agents.default_subagent_model="weird\\"model\\\\id"']);
   });
 });

--- a/apps/desktop/src/main/maker-host/codex-subagent-config.ts
+++ b/apps/desktop/src/main/maker-host/codex-subagent-config.ts
@@ -6,8 +6,12 @@
  *   配置闸——它在版本裁决链里排在模型元数据之前;`features.multi_agent_v2=false`
  *   会被模型元数据无视。
  * - `agents.max_concurrent_threads_per_session=N` 语义 = 同时 N 个子代理;V2 后端
- *   自动解析为 N+1 总线程(根+子)。**绝不写 `features.multi_agent_v2.*` 键**:
- *   两个配置 struct 都 deny_unknown_fields,且同时写两段会产生双重语义。
+ *   自动解析为 N+1 总线程(根+子)。**并发数绝不写 `features.multi_agent_v2.*`**:
+ *   features 段的同名键语义是总线程(=N+1)且解析优先级更高,双写会静默盖掉本段
+ *   注入并产生差 1 的双重语义;两个配置 struct 都 deny_unknown_fields。
+ * - 例外:`multi_agent_mode_hint_text` 与 `expose_spawn_agent_model_overrides` 只
+ *   存在于 features 段(resolve_multi_agent_v2_config 仅从该段读取,无 agents 段
+ *   等价键),按需委托策略只能经此注入,见 CODEX_ON_DEMAND_DELEGATION_HINT。
  * - `agents.max_depth` 仅旧版多代理(V1)生效,V2 忽略(UI hint 已注明)。
  * - `agents.default_subagent_model` 是兜底默认,模型仍可在 spawn 参数里显式覆盖。
  *   注入 Cindy 存储的 model id 原文:codex vendor 候选只有原生 slug 与 `codex/`
@@ -19,6 +23,28 @@
  */
 
 import type { SubagentModelSettings } from '../../shared/subagentModelSettings.js';
+
+/**
+ * 按需委托策略(Claude Code 式):替换上游按 effort 推导的内置 multi-agent 模式
+ * (非 ultra 档一律 explicitRequestOnly——模型被明确禁止自发 spawn 子代理)。设置
+ * 本文案后上游走 MultiAgentMode::Custom,任意 effort 档都按此策略自主委托探索。
+ *
+ * 上游以 <multi_agent_mode> developer 段逐 turn 注入,截断上限 400 token
+ * (MULTI_AGENT_MODE_MAX_TOKENS),增改内容时须留在限内。文案属于进入模型上下文
+ * 的提示词,改动前须按 docs/dev-rules/maker-core-and-agent-behavior.md 取得维护者
+ * 确认。
+ *
+ * 内部常量而非设置项:委托策略与子代理总开关(codexSubagentsEnabled)一体,总开关
+ * 关闭时本段不注入;不单独暴露配置面。
+ */
+const CODEX_ON_DEMAND_DELEGATION_HINT =
+  'Delegate on demand: for exploration whose intermediate output does not need to stay in ' +
+  'this thread — reading rule or design docs, surveying large or unfamiliar files, broad ' +
+  'code searches — spawn a sub-agent with a narrow task (state exactly what to read and ' +
+  'which question to answer; report conclusions only, no full-text quoting) and keep only ' +
+  'its findings here. Prefer delegating the initial repository-rules reading at task ' +
+  'start. Do implementation, code edits, and final verification yourself in the main ' +
+  'thread. Skip delegation for quick single-file lookups.';
 
 /** TOML basic string 转义(model id 理论上不含这些字符,防御性处理)。 */
 function tomlString(value: string): string {
@@ -32,6 +58,13 @@ export function buildCodexSubagentSpawnArgs(settings: SubagentModelSettings): st
     args.push('-c', 'agents.enabled=false');
     return args;
   }
+  // 子代理默认开启时恒注入:按需委托策略 + 允许 spawn 参数显式指定子代理模型
+  // (后者让模型能给轻探索自选低档模型,也让 UI 的模型徽标有显式值可显示)。
+  args.push(
+    '-c',
+    `features.multi_agent_v2.multi_agent_mode_hint_text=${tomlString(CODEX_ON_DEMAND_DELEGATION_HINT)}`,
+  );
+  args.push('-c', 'features.multi_agent_v2.expose_spawn_agent_model_overrides=true');
   if (settings.codex) {
     args.push('-c', `agents.default_subagent_model=${tomlString(settings.codex)}`);
   }

--- a/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentStatusI18n.test.ts
@@ -18,6 +18,7 @@ describe('localizeAgentStatus', () => {
     expect(localizeAgentStatus('Editing files...', i18n.t)).toBe('正在编辑文件…');
     expect(localizeAgentStatus('Working', i18n.t)).toBe('正在工作…');
     expect(localizeAgentStatus('Running', i18n.t)).toBe('运行中…');
+    expect(localizeAgentStatus('Spawning agent...', i18n.t)).toBe('正在启动 Subagent…');
     expect(localizeAgentStatus('Done', i18n.t)).toBe('已完成');
   });
 

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -28,6 +28,7 @@ import {
 import { useSidebarPanelReachable } from '@/features/cc-agent/embeddedSessionNavigation';
 import { cn } from '@/lib/utils';
 import { formatModelShortLabel } from '@/lib/modelShortLabel';
+import { isCodexSubagentEffort } from '../../../shared/subagentModelSettings';
 
 interface AgentTaskCardProps {
   toolCall?: ChatMessage;
@@ -127,9 +128,18 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
   const { t } = useTranslation();
   const blockId = `task:${toolCall?.clientId ?? update?.taskId ?? 'unknown'}`;
   // subagent-model-chip: 子代理模型 —— 实时态优先 update.model(progress 事件
-  // 带),历史重载(update 缺省)回退到从子消息反查的 subagentModel。两者皆无
-  // (如 codex collab 任务 / 旧数据)则不渲染 chip。
-  const modelLabel = formatModelShortLabel(update?.model ?? subagentModel);
+  // 带),历史重载(update 缺省)回退到从子消息反查的 subagentModel;两者皆无时
+  // 再回退 spawn 参数里显式指定的 model(codex collab 卡,translator 透传
+  // item.model)。默认继承主模型时 spawn 无 model 字段——不猜继承值,不渲染。
+  const modelLabel = formatModelShortLabel(
+    update?.model ?? subagentModel ?? readInputString(toolCall?.toolInput, ['model']),
+  );
+  // codex spawn 可为子代理显式指定思考强度(translator 透传 reasoningEffort);
+  // 已知档位才走 effortLevels 词表,未知值不显示。CC 无此参数,行为不变。
+  const effortRaw = readInputString(toolCall?.toolInput, ['reasoningEffort']);
+  const effortLabel =
+    effortRaw && isCodexSubagentEffort(effortRaw) ? t(`effortLevels.${effortRaw}`) : undefined;
+  const chipLabel = [modelLabel, effortLabel].filter(Boolean).join(' · ');
   const { expanded, setExpanded } = useExpandedBlockMemory(blockId);
   const toggle = useCallback(() => setExpanded((v) => !v), [setExpanded]);
 
@@ -331,16 +341,16 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
               {meta.map((part) => (
                 <Fragment key={part.key}>
                   <span>{part.text}</span>
-                  {/* subagent-model-chip: 模型 chip 紧跟在 provider(Claude Code)之后,
-                      与 meta 文本同处第二行。 */}
-                  {part.key === 'provider' && modelLabel && (
+                  {/* subagent-model-chip: 模型(codex 卡可另含思考强度)chip 紧跟在
+                      provider 之后,与 meta 文本同处第二行。 */}
+                  {part.key === 'provider' && chipLabel && (
                     <span
                       data-agent-task-model-chip="true"
                       // 字体不特殊处理:size / weight / color 全部继承 meta 行
                       // (text-12 / normal / --text-tertiary),只保留 chip 的底色与圆角。
                       className="inline-flex items-center rounded-[4px] bg-[var(--surface-chip)] px-1.5 py-0.5"
                     >
-                      {modelLabel}
+                      {chipLabel}
                     </span>
                   )}
                 </Fragment>

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -29,6 +29,7 @@ import { useSidebarPanelReachable } from '@/features/cc-agent/embeddedSessionNav
 import { cn } from '@/lib/utils';
 import { formatModelShortLabel } from '@/lib/modelShortLabel';
 import { isCodexSubagentEffort } from '../../../shared/subagentModelSettings';
+import { subagentSpawnReceiptName } from '@cindy/maker-shared/agent-task';
 
 interface AgentTaskCardProps {
   toolCall?: ChatMessage;
@@ -199,15 +200,13 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
     update?.description ??
       readInputString(toolCall?.toolInput, ['prompt', 'description', 'task']),
   );
-  const rawSummary = detailText(result, update?.summary);
-  // codex spawn 启动卡:translator 的 tool_result_full 只放结构化数据(fullText =
-  // agentPath 原文,恰等于 input.name),用户可见句子在这里按 locale 组装——判据
-  // result===input.name 由两端约定保证,未来富卡(agentsStates 摘要)不会命中。
-  const spawnName = readInputString(toolCall?.toolInput, ['name']);
-  const summary =
-    toolCall?.toolName === 'collab:spawn' && rawSummary && spawnName && rawSummary === spawnName
-      ? t('chat.agentTask.subagentStarted', { name: spawnName })
-      : rawSummary;
+  // codex spawn 启动卡:translator 的 tool_result_full 只放结构化数据(agentPath
+  // 原文),用户可见句子在这里按 locale 组装。判据与 mobile 卡模型共用
+  // maker-shared 的 subagentSpawnReceiptName,不在端上内联复制。
+  const spawnReceiptName = subagentSpawnReceiptName(toolCall?.toolName, toolCall?.toolInput, result);
+  const summary = spawnReceiptName
+    ? t('chat.agentTask.subagentStarted', { name: spawnReceiptName })
+    : detailText(result, update?.summary);
   const duration = formatDuration(update?.usage?.durationMs);
   const provider = update?.provider ?? (toolCall?.toolName?.startsWith('collab:') ? 'codex' : 'claude-code');
   const providerLabel = isWorkflow

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -199,7 +199,15 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
     update?.description ??
       readInputString(toolCall?.toolInput, ['prompt', 'description', 'task']),
   );
-  const summary = detailText(result, update?.summary);
+  const rawSummary = detailText(result, update?.summary);
+  // codex spawn 启动卡:translator 的 tool_result_full 只放结构化数据(fullText =
+  // agentPath 原文,恰等于 input.name),用户可见句子在这里按 locale 组装——判据
+  // result===input.name 由两端约定保证,未来富卡(agentsStates 摘要)不会命中。
+  const spawnName = readInputString(toolCall?.toolInput, ['name']);
+  const summary =
+    toolCall?.toolName === 'collab:spawn' && rawSummary && spawnName && rawSummary === spawnName
+      ? t('chat.agentTask.subagentStarted', { name: spawnName })
+      : rawSummary;
   const duration = formatDuration(update?.usage?.durationMs);
   const provider = update?.provider ?? (toolCall?.toolName?.startsWith('collab:') ? 'codex' : 'claude-code');
   const providerLabel = isWorkflow

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -28,8 +28,11 @@ import {
 import { useSidebarPanelReachable } from '@/features/cc-agent/embeddedSessionNavigation';
 import { cn } from '@/lib/utils';
 import { formatModelShortLabel } from '@/lib/modelShortLabel';
-import { isCodexSubagentEffort } from '../../../shared/subagentModelSettings';
+import { CODEX_SUBAGENT_EFFORTS } from '../../../shared/subagentModelSettings';
 import { subagentSpawnReceiptName } from '@cindy/maker-shared/agent-task';
+
+// 徽标可显示的思考强度档:协议全部合法档(效果词表 effortLevels 四语齐)。
+const EFFORT_BADGE_LEVELS = new Set<string>(['minimal', ...CODEX_SUBAGENT_EFFORTS]);
 
 interface AgentTaskCardProps {
   toolCall?: ChatMessage;
@@ -137,9 +140,11 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
   );
   // codex spawn 可为子代理显式指定思考强度(translator 透传 reasoningEffort);
   // 已知档位才走 effortLevels 词表,未知值不显示。CC 无此参数,行为不变。
+  // 显示集合含 minimal:设置页白名单(CODEX_SUBAGENT_EFFORTS)刻意不含它,但
+  // seed/glm 系模型的 spawn 参数可显式给 minimal(协议合法档),徽标不静默降级。
   const effortRaw = readInputString(toolCall?.toolInput, ['reasoningEffort']);
   const effortLabel =
-    effortRaw && isCodexSubagentEffort(effortRaw) ? t(`effortLevels.${effortRaw}`) : undefined;
+    effortRaw && EFFORT_BADGE_LEVELS.has(effortRaw) ? t(`effortLevels.${effortRaw}`) : undefined;
   const chipLabel = [modelLabel, effortLabel].filter(Boolean).join(' · ');
   const { expanded, setExpanded } = useExpandedBlockMemory(blockId);
   const toggle = useCallback(() => setExpanded((v) => !v), [setExpanded]);

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
@@ -95,6 +95,18 @@ describe('AgentTaskCard subagent model chip (codex collab)', () => {
     expect(chipText(container)).toBeNull();
   });
 
+  it('localizes the spawn receipt instead of echoing the raw agent path', () => {
+    // translator 的 fullText 是纯数据(=input.name);卡片按 locale 组装句子。
+    const { container } = render(
+      <AgentTaskCard
+        toolCall={collabToolCall({ name: '/root/survey_startup' })}
+        result="/root/survey_startup"
+      />,
+    );
+    expect(container.textContent).toContain('chat.agentTask.subagentStarted');
+    expect(container.textContent).not.toContain('/root/survey_startup started');
+  });
+
   it('keeps the claude-code path unchanged (subagentModel prop wins for cc cards)', () => {
     const ccToolCall = {
       clientId: 'c2',

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+
+import { render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/useExpandedBlockMemory', () => ({
+  useExpandedBlockMemory: () => ({ expanded: false, setExpanded: vi.fn() }),
+}));
+
+vi.mock('@/lib/makerTransport', () => ({
+  getWorkflowProgressFor: vi.fn(async () => null),
+  isRemoteSessionSticky: () => false,
+}));
+
+vi.mock('@/features/right-sidebar/lib/openBackgroundTasksTab', () => ({
+  openBackgroundTasksTab: vi.fn(),
+}));
+
+vi.mock('@/features/right-sidebar/plugins/background-tasks/listSessionTasks', () => ({
+  extractWorkflowTaskId: () => undefined,
+}));
+
+vi.mock('@/features/right-sidebar/plugins/background-tasks/WorkflowAgentStrip', () => ({
+  WorkflowAgentStrip: () => null,
+}));
+
+vi.mock('@/features/cc-agent/embeddedSessionNavigation', () => ({
+  useSidebarPanelReachable: () => false,
+}));
+
+vi.mock('@/components/ui/collapse', () => ({
+  Collapse: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+// chip 断言只关心 raw id 是否上屏,短名格式化规则由 modelShortLabel 自己的单测覆盖。
+vi.mock('@/lib/modelShortLabel', () => ({
+  formatModelShortLabel: (model?: string | null) => model ?? undefined,
+}));
+
+import { AgentTaskCard } from '../AgentTaskCard';
+import type { ChatMessage } from '@/hooks/useCCAgentChat';
+
+function collabToolCall(toolInput: Record<string, unknown>): ChatMessage {
+  return {
+    clientId: 'c1',
+    role: 'tool_use',
+    content: '',
+    toolUseId: 'item_1',
+    toolName: 'collab:spawn',
+    toolInput,
+  } as unknown as ChatMessage;
+}
+
+function chipText(container: HTMLElement): string | null {
+  const chip = container.querySelector('[data-agent-task-model-chip="true"]');
+  return chip ? chip.textContent : null;
+}
+
+describe('AgentTaskCard subagent model chip (codex collab)', () => {
+  it('shows model and localized effort from explicit spawn params', () => {
+    const { container } = render(
+      <AgentTaskCard
+        toolCall={collabToolCall({
+          prompt: 'survey startup path',
+          model: 'gpt-5.6-terra',
+          reasoningEffort: 'low',
+        })}
+      />,
+    );
+    expect(chipText(container)).toBe('gpt-5.6-terra · effortLevels.low');
+  });
+
+  it('shows an effort-only chip when spawn overrides effort but inherits the model', () => {
+    const { container } = render(
+      <AgentTaskCard toolCall={collabToolCall({ prompt: 'p', reasoningEffort: 'xhigh' })} />,
+    );
+    expect(chipText(container)).toBe('effortLevels.xhigh');
+  });
+
+  it('renders no chip when spawn params carry neither model nor effort (inherited defaults)', () => {
+    // 默认继承主模型时不猜继承值 —— 宁缺毋滥。
+    const { container } = render(<AgentTaskCard toolCall={collabToolCall({ prompt: 'p' })} />);
+    expect(chipText(container)).toBeNull();
+  });
+
+  it('ignores unknown effort values instead of leaking raw strings into the UI', () => {
+    const { container } = render(
+      <AgentTaskCard toolCall={collabToolCall({ prompt: 'p', reasoningEffort: 'bogus' })} />,
+    );
+    expect(chipText(container)).toBeNull();
+  });
+
+  it('keeps the claude-code path unchanged (subagentModel prop wins for cc cards)', () => {
+    const ccToolCall = {
+      clientId: 'c2',
+      role: 'tool_use',
+      content: '',
+      toolUseId: 'toolu_1',
+      toolName: 'Agent',
+      toolInput: { description: 'Explore repo' },
+    } as unknown as ChatMessage;
+    const { container } = render(
+      <AgentTaskCard toolCall={ccToolCall} subagentModel="claude-sonnet-5" />,
+    );
+    expect(chipText(container)).toBe('claude-sonnet-5');
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
@@ -88,6 +88,13 @@ describe('AgentTaskCard subagent model chip (codex collab)', () => {
     expect(chipText(container)).toBeNull();
   });
 
+  it('keeps the minimal effort badge (protocol-legal even though settings whitelist omits it)', () => {
+    const { container } = render(
+      <AgentTaskCard toolCall={collabToolCall({ prompt: 'p', reasoningEffort: 'minimal' })} />,
+    );
+    expect(chipText(container)).toBe('effortLevels.minimal');
+  });
+
   it('ignores unknown effort values instead of leaking raw strings into the UI', () => {
     const { container } = render(
       <AgentTaskCard toolCall={collabToolCall({ prompt: 'p', reasoningEffort: 'bogus' })} />,

--- a/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/localizeAgentStatus.ts
@@ -7,6 +7,7 @@ const STATUS_KEYS = new Map<string, string>([
   ['searching web', 'ccAgent.agentStatus.searchingWeb'],
   ['generating image', 'ccAgent.agentStatus.generatingImage'],
   ['compacting', 'ccAgent.agentStatus.compacting'],
+  ['spawning agent', 'ccAgent.agentStatus.spawningAgent'],
   ['done', 'ccAgent.agentStatus.done'],
   ['just wait', 'ccAgent.agentStatus.waiting'],
   ['working', 'ccAgent.agentStatus.working'],

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5365,6 +5365,7 @@
     },
     "agentTask": {
       "emptyTitle": "Subagent task",
+      "subagentStarted": "Subagent {{name}} started",
       "showDetails": "Show subagent details",
       "hideDetails": "Hide subagent details",
       "provider": {
@@ -6039,6 +6040,7 @@
       "searchingWeb": "Searching the web…",
       "generatingImage": "Generating an image…",
       "compacting": "Compacting context…",
+      "spawningAgent": "Spawning a subagent…",
       "done": "Done",
       "waiting": "Just wait…",
       "working": "Working…",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5363,6 +5363,7 @@
     },
     "agentTask": {
       "emptyTitle": "サブエージェントタスク",
+      "subagentStarted": "サブエージェント {{name}} を起動しました",
       "showDetails": "サブエージェント詳細を表示",
       "hideDetails": "サブエージェント詳細を隠す",
       "provider": {
@@ -6028,6 +6029,7 @@
       "searchingWeb": "ウェブを検索中…",
       "generatingImage": "画像を生成中…",
       "compacting": "コンテキストを圧縮中…",
+      "spawningAgent": "サブエージェントを起動中…",
       "done": "完了",
       "waiting": "少々お待ちください…",
       "working": "作業中…",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5363,6 +5363,7 @@
     },
     "agentTask": {
       "emptyTitle": "하위 에이전트 작업",
+      "subagentStarted": "하위 에이전트 {{name}} 시작됨",
       "showDetails": "하위 에이전트 세부 정보 보기",
       "hideDetails": "하위 에이전트 세부 정보 숨기기",
       "provider": {
@@ -6028,6 +6029,7 @@
       "searchingWeb": "웹 검색 중…",
       "generatingImage": "이미지 생성 중…",
       "compacting": "컨텍스트 압축 중…",
+      "spawningAgent": "하위 에이전트 시작 중…",
       "done": "완료",
       "waiting": "잠시만 기다려 주세요…",
       "working": "작업 중…",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5363,6 +5363,7 @@
     },
     "agentTask": {
       "emptyTitle": "Subagent 任务",
+      "subagentStarted": "Subagent {{name}} 已启动",
       "showDetails": "展开 Subagent 详情",
       "hideDetails": "收起 Subagent 详情",
       "provider": {
@@ -6028,6 +6029,7 @@
       "searchingWeb": "正在搜索网页…",
       "generatingImage": "正在生成图片…",
       "compacting": "正在压缩上下文…",
+      "spawningAgent": "正在启动 Subagent…",
       "done": "已完成",
       "waiting": "请稍候…",
       "working": "正在工作…",

--- a/apps/mobile/src/i18n/locales/en/message.json
+++ b/apps/mobile/src/i18n/locales/en/message.json
@@ -41,6 +41,7 @@
     "statusStopped": "Stopped",
     "toolUseCount": "{{n}} tool calls",
     "subagentTaskTitle": "Subagent task",
+    "subagentStarted": "Subagent {{name}} started",
     "recentTool": "Latest tool: {{name}}",
     "outputFile": "Output: {{file}}",
     "noMoreDetail": "No more details",

--- a/apps/mobile/src/i18n/locales/ja/message.json
+++ b/apps/mobile/src/i18n/locales/ja/message.json
@@ -41,6 +41,7 @@
     "statusStopped": "停止",
     "toolUseCount": "ツール呼び出し {{n}} 回",
     "subagentTaskTitle": "サブエージェントタスク",
+    "subagentStarted": "サブエージェント {{name}} を起動しました",
     "recentTool": "最近のツール：{{name}}",
     "outputFile": "出力：{{file}}",
     "noMoreDetail": "詳細はありません",

--- a/apps/mobile/src/i18n/locales/ko/message.json
+++ b/apps/mobile/src/i18n/locales/ko/message.json
@@ -41,6 +41,7 @@
     "statusStopped": "중지됨",
     "toolUseCount": "도구 호출 {{n}}회",
     "subagentTaskTitle": "하위 에이전트 작업",
+    "subagentStarted": "하위 에이전트 {{name}} 시작됨",
     "recentTool": "최근 도구: {{name}}",
     "outputFile": "출력: {{file}}",
     "noMoreDetail": "추가 세부 정보 없음",

--- a/apps/mobile/src/i18n/locales/zh-CN/message.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/message.json
@@ -41,6 +41,7 @@
     "statusStopped": "已停止",
     "toolUseCount": "{{n}} 次工具调用",
     "subagentTaskTitle": "Subagent 任务",
+    "subagentStarted": "Subagent {{name}} 已启动",
     "recentTool": "最近工具：{{name}}",
     "outputFile": "输出：{{file}}",
     "noMoreDetail": "暂无更多详情",

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -2577,7 +2577,9 @@ function AgentTaskCard({
     () => buildMessageHierarchyLayout({ screenWidth, summaryCount: 0 }),
     [screenWidth],
   );
-  const hasDetails = !!(model.description || model.summary || model.lastToolName || model.outputFile);
+  const hasDetails = !!(
+    model.description || model.summary || model.spawnedAgentName || model.lastToolName || model.outputFile
+  );
   return (
     <FoldablePanel
       blockId={item.key}
@@ -2593,6 +2595,12 @@ function AgentTaskCard({
       {hasDetails ? (
         <View style={[styles.stackSmall, { gap: layout.stackSmallGap }]}>
           {model.description ? <Text style={styles.detailText}>{model.description}</Text> : null}
+          {/* codex spawn 启动回执:shared model 只给结构化名字,句子按 locale 组装。 */}
+          {model.spawnedAgentName ? (
+            <Text style={styles.detailText}>
+              {t('message.renderer.subagentStarted', { name: model.spawnedAgentName })}
+            </Text>
+          ) : null}
           {model.summary ? <Text style={styles.detailText}>{model.summary}</Text> : null}
           {model.lastToolName ? <Text style={styles.detailText}>{t('message.renderer.recentTool', { name: model.lastToolName })}</Text> : null}
           {model.outputFile ? <Text style={styles.detailText}>{t('message.renderer.outputFile', { file: model.outputFile })}</Text> : null}

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -194,7 +194,7 @@ const CODEX_MINIMAL_EFFORT_MODELS = new Set([
  * item.type → chip status 文案 (对齐 claude-code 6 类). null = 该 item 不触发 chip 切换
  * (imageView/plan/userMessage/hookPrompt 等是 completed-only 或 UI 不暴露的 item)。
  */
-function statusTextForItem(item: { type?: string; command?: string; tool?: string }): string | null {
+function statusTextForItem(item: { type?: string; command?: string; tool?: string; kind?: string }): string | null {
   switch (item.type) {
     case 'reasoning':            return 'Thinking...';
     case 'agentMessage':         return 'Generating...';
@@ -211,7 +211,9 @@ function statusTextForItem(item: { type?: string; command?: string; tool?: strin
     case 'mcpToolCall':          return `${item.tool ?? 'mcp'} running...`;
     case 'dynamicToolCall':      return `${item.tool ?? 'tool'} running...`;
     case 'collabAgentToolCall':  return `${item.tool ?? 'agent'} running...`;
-    case 'subAgentActivity':     return 'Spawning agent...';
+    // interacted/interrupted 活动(followup/send/interrupt 的伴生事件)不是新代理
+    // 启动,不闪启动状态 —— itemStarted 在 translator 静默这些 kind 之前就会推 chip。
+    case 'subAgentActivity':     return item.kind === 'started' ? 'Spawning agent...' : null;
     case 'webSearch':            return 'Searching web...';
     case 'imageGeneration':      return 'Generating image...';
     case 'contextCompaction':    return 'Compacting...';

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -211,6 +211,7 @@ function statusTextForItem(item: { type?: string; command?: string; tool?: strin
     case 'mcpToolCall':          return `${item.tool ?? 'mcp'} running...`;
     case 'dynamicToolCall':      return `${item.tool ?? 'tool'} running...`;
     case 'collabAgentToolCall':  return `${item.tool ?? 'agent'} running...`;
+    case 'subAgentActivity':     return 'Spawning agent...';
     case 'webSearch':            return 'Searching web...';
     case 'imageGeneration':      return 'Generating image...';
     case 'contextCompaction':    return 'Compacting...';

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -1098,14 +1098,15 @@ describe('translateItemNotification subAgentActivity', () => {
       toolName: 'collab:spawn',
       input: { name: '/root/survey_startup', agentThreadId: 'thread-2' },
     });
+    // fullText 是纯数据(agentPath 原文),本地化句子由 renderer 组装,不持久化英文。
     expect(events[1].data).toMatchObject({
       toolUseId: 'spawn-1',
-      fullText: '/root/survey_startup started (thread thread-2)',
+      fullText: '/root/survey_startup',
       isError: false,
     });
   });
 
-  it('dedupes the started/completed phase pair to a single card', async () => {
+  it('dedupes the started/completed phase pair and releases the dedupe entry', async () => {
     const rt = newCodexRuntimeState();
     const q = createAsyncQueue<AgentEvent>();
     const ctx = makeCtx(rt);
@@ -1115,6 +1116,8 @@ describe('translateItemNotification subAgentActivity', () => {
 
     const events = await collect(q);
     expect(events.filter((event) => event.type === 'tool_use')).toHaveLength(1);
+    // completed 清理去重登记,长会话大量 spawn 不留内存增长(review r3698551514)。
+    expect(rt.emittedToolUse.has('spawn-1')).toBe(false);
   });
 
   it('stays silent for interacted/interrupted kinds', async () => {

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -1065,6 +1065,71 @@ describe('translateItemNotification collabAgentToolCall', () => {
   });
 });
 
+describe('translateItemNotification subAgentActivity', () => {
+  function activityParams(kind: string, id = 'spawn-1') {
+    return {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: {
+        type: 'subAgentActivity',
+        id,
+        kind,
+        agentThreadId: 'thread-2',
+        agentPath: '/root/survey_startup',
+      },
+    };
+  }
+
+  it('renders a self-closing spawn card for kind=started (0.145 v2 emits no collab item)', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(rt);
+
+    translateItemNotification('started', activityParams('started'), q, ctx);
+
+    const events = await collect(q);
+    expect(events.map((event) => event.type)).toEqual([
+      'tool_use',
+      'tool_result_full',
+      'tool_result',
+    ]);
+    expect(events[0].data).toMatchObject({
+      toolUseId: 'spawn-1',
+      toolName: 'collab:spawn',
+      input: { name: '/root/survey_startup', agentThreadId: 'thread-2' },
+    });
+    expect(events[1].data).toMatchObject({
+      toolUseId: 'spawn-1',
+      fullText: '/root/survey_startup started (thread thread-2)',
+      isError: false,
+    });
+  });
+
+  it('dedupes the started/completed phase pair to a single card', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(rt);
+
+    translateItemNotification('started', activityParams('started'), q, ctx);
+    translateItemNotification('completed', activityParams('started'), q, ctx);
+
+    const events = await collect(q);
+    expect(events.filter((event) => event.type === 'tool_use')).toHaveLength(1);
+  });
+
+  it('stays silent for interacted/interrupted kinds', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const ctx = makeCtx(rt);
+
+    translateItemNotification('completed', activityParams('interacted', 'act-1'), q, ctx);
+    translateItemNotification('completed', activityParams('interrupted', 'act-2'), q, ctx);
+
+    const events = await collect(q);
+    expect(events).toEqual([]);
+  });
+});
+
 describe('translateItemNotification plan', () => {
   it('emits update_plan on started and completed, with result only on completed', async () => {
     const rt = newCodexRuntimeState();

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -192,6 +192,9 @@ export function translateItemNotification(
     case 'contextCompaction':
       handleContextCompaction(phase, item as unknown as ContextCompactionItem, queue, ctx);
       return;
+    case 'subAgentActivity':
+      handleSubAgentActivity(phase, item as unknown as SubAgentActivityItem, queue, ctx);
+      return;
     // 以下 v2 item 类型故意不消费 (无 UI 对应概念, 不是 bug):
     //   userMessage:  SDK echo 用户输入, claude-code translator 也只挑 tool_result 包装的
     //   hookPrompt:   codex 用户配置 hook 注入的 prompt, UI 不展示
@@ -1500,6 +1503,59 @@ function handleCollabAgentToolCall(
   queue.push({
     type: 'agent_task_update',
     data: toCodexTaskUpdate(item, isError ? 'failed' : 'completed', fullText),
+    source: 'codex',
+  });
+}
+
+// ── subAgentActivity → tool_use + tool_result(spawn 可见性) ────────────────
+// codex 0.145 multi-agent v2:spawn_agent 不发 collabAgentToolCall,只发瞬时
+// SubAgentActivityItem(kind=started/interacted/interrupted,无完成事件——子代理
+// 的等待与收口由后续 wait_agent 的 collab 卡承载)。不处理它,子代理启动在 UI
+// 完全不可见(实测:探索型任务 spawn 3 个子代理,等待窗口内聊天流零卡片)。
+// started 渲染成一张即时收口的「子代理已启动」卡;interacted 是 followup/send
+// 调用的伴生事件、interrupted 由 interrupt 调用自身承载,均显式静默不再落
+// unhandled 告警。协议只给 id/kind/agentThreadId/agentPath,没有 prompt/model/
+// effort(上游 main 已改为 spawn 直发 collabAgentToolCall 富卡,vendored codex
+// 升级后自动走上面 handleCollabAgentToolCall,本函数届时按 id 去重自然让位)。
+
+interface SubAgentActivityItem {
+  type: 'subAgentActivity';
+  id: string;
+  kind: string;
+  agentThreadId?: string;
+  agentPath?: string;
+}
+
+function handleSubAgentActivity(
+  phase: ItemPhase,
+  item: SubAgentActivityItem,
+  queue: AsyncQueue<AgentEvent>,
+  ctx: CodexTranslateContext,
+): void {
+  if (item.kind !== 'started') return;
+  // 瞬时 item:started/completed phase 可能各到一次,按 item.id 去重只发一次。
+  if (phase === 'updated' || ctx.rt.emittedToolUse.has(item.id)) return;
+  ctx.rt.emittedToolUse.add(item.id);
+  const agentPath = typeof item.agentPath === 'string' ? item.agentPath : undefined;
+  const input: Record<string, unknown> = {};
+  if (agentPath) input.name = agentPath;
+  if (item.agentThreadId) input.agentThreadId = item.agentThreadId;
+  queue.push({
+    type: 'tool_use',
+    data: { toolUseId: item.id, toolName: 'collab:spawn', input },
+    source: 'codex',
+  });
+  const fullText = agentPath
+    ? `${agentPath} started${item.agentThreadId ? ` (thread ${item.agentThreadId})` : ''}`
+    : 'sub-agent started';
+  queue.push({
+    type: 'tool_result_full',
+    data: { toolUseId: item.id, fullText, isError: false },
+    source: 'codex',
+  });
+  queue.push({
+    type: 'tool_result',
+    data: { summary: 'started', toolUseIds: [item.id] },
     source: 'codex',
   });
 }

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -1532,10 +1532,15 @@ function handleSubAgentActivity(
   queue: AsyncQueue<AgentEvent>,
   ctx: CodexTranslateContext,
 ): void {
-  if (item.kind !== 'started') return;
-  // 瞬时 item:started/completed phase 可能各到一次,按 item.id 去重只发一次。
-  if (phase === 'updated' || ctx.rt.emittedToolUse.has(item.id)) return;
-  ctx.rt.emittedToolUse.add(item.id);
+  if (item.kind !== 'started' || phase === 'updated') return;
+  // 瞬时 item:started/completed phase 各到一次,按 item.id 去重只发一张卡;
+  // completed 到达即清 Set(与 collab handler 同规——不清会随 spawn 次数无限增长)。
+  if (ctx.rt.emittedToolUse.has(item.id)) {
+    if (phase === 'completed') ctx.rt.emittedToolUse.delete(item.id);
+    return;
+  }
+  // started phase 登记等 completed 清理;只收到 completed(防御)时无后续 phase,不登记。
+  if (phase === 'started') ctx.rt.emittedToolUse.add(item.id);
   const agentPath = typeof item.agentPath === 'string' ? item.agentPath : undefined;
   const input: Record<string, unknown> = {};
   if (agentPath) input.name = agentPath;
@@ -1545,12 +1550,12 @@ function handleSubAgentActivity(
     data: { toolUseId: item.id, toolName: 'collab:spawn', input },
     source: 'codex',
   });
-  const fullText = agentPath
-    ? `${agentPath} started${item.agentThreadId ? ` (thread ${item.agentThreadId})` : ''}`
-    : 'sub-agent started';
+  // fullText 只放结构化数据(agentPath 原文):用户可见的「已启动」句子由 renderer
+  // 按 locale 组装(AgentTaskCard 以 result===input.name 识别本卡),translator 不
+  // 合成任何语言的句子——否则英文回执会持久化进历史(review r3698558356)。
   queue.push({
     type: 'tool_result_full',
-    data: { toolUseId: item.id, fullText, isError: false },
+    data: { toolUseId: item.id, fullText: agentPath ?? '', isError: false },
     source: 'codex',
   });
   queue.push({

--- a/packages/maker-shared/src/__tests__/agentTask.test.ts
+++ b/packages/maker-shared/src/__tests__/agentTask.test.ts
@@ -297,4 +297,28 @@ describe('buildAgentTaskCardModel', () => {
     expect(model.status).toBe('running');
     expect(model.provider).toBe('claude-code');
   });
+
+  it('surfaces the codex spawn receipt as structured spawnedAgentName, not raw summary', () => {
+    // translator 约定:collab:spawn 的 tool_result 只放 agentPath(= input.name)。
+    const model = buildAgentTaskCardModel({
+      toolName: 'collab:spawn',
+      toolInput: { name: '/root/survey_startup', agentThreadId: 't-2' },
+      result: '/root/survey_startup',
+    });
+    expect(model.spawnedAgentName).toBe('/root/survey_startup');
+    // 裸路径不进 summary,各端用 spawnedAgentName 按 locale 组装句子。
+    expect(model.summary).toBeUndefined();
+    expect(model.status).toBe('completed');
+    expect(model.provider).toBe('codex');
+  });
+
+  it('leaves future rich collab:spawn results (agentsStates summaries) untouched', () => {
+    const model = buildAgentTaskCardModel({
+      toolName: 'collab:spawn',
+      toolInput: { name: '/root/survey_startup' },
+      result: 'thread-2: done',
+    });
+    expect(model.spawnedAgentName).toBeUndefined();
+    expect(model.summary).toBe('thread-2: done');
+  });
 });

--- a/packages/maker-shared/src/agentTask.ts
+++ b/packages/maker-shared/src/agentTask.ts
@@ -314,11 +314,35 @@ export interface AgentTaskCardModel {
   title: string | null;
   description?: string;
   summary?: string;
+  /**
+   * Codex `collab:spawn` 启动回执:translator 的 tool_result 只放 agentPath 原文
+   * (恰等于 input.name,见 subagentSpawnReceiptName 判据)。命中时 summary 不携带
+   * 裸路径,各端用本字段按自己的 locale 组装「Subagent 已启动」句子。
+   */
+  spawnedAgentName?: string;
   lastToolName?: string;
   outputFile?: string;
   totalTokens?: number;
   toolUses?: number;
   durationMs?: number;
+}
+
+/**
+ * codex spawn 启动回执判据:translator(maker-core codex)约定 `collab:spawn` 卡的
+ * tool_result fullText 只放 agentPath 原文、且与 `input.name` 逐字相等。命中即返回
+ * 该名字,供各端替换为本地化句子;未来 vendored Codex 升级后的富卡(agentsStates
+ * 摘要)不会与 input.name 相等,自然不命中。桌面 AgentTaskCard 与本文件的
+ * buildAgentTaskCardModel 共用本判据,不要各自内联复制。
+ */
+export function subagentSpawnReceiptName(
+  toolName: string | undefined,
+  toolInput: unknown,
+  result: string | undefined,
+): string | undefined {
+  if (toolName !== 'collab:spawn') return undefined;
+  const name = readInputString(toolInput, ['name']);
+  const trimmed = result?.trim();
+  return name && trimmed && trimmed === name ? name : undefined;
 }
 
 export function buildAgentTaskCardModel(input: {
@@ -340,13 +364,17 @@ export function buildAgentTaskCardModel(input: {
   const description = compactText(
     update?.description ?? readInputString(toolInput, ['prompt', 'description', 'task']),
   );
-  const summary = detailText(result, update?.summary);
+  const spawnedAgentName = subagentSpawnReceiptName(toolName, toolInput, result);
+  // 启动回执命中时 summary 不携带裸路径(路径已在 spawnedAgentName / title 中),
+  // 否则手机端会把 agentPath 原样当摘要展示。
+  const summary = spawnedAgentName ? detailText(update?.summary) : detailText(result, update?.summary);
   return {
     status,
     provider,
     title: title ?? null,
     ...(description ? { description } : {}),
     ...(summary ? { summary } : {}),
+    ...(spawnedAgentName ? { spawnedAgentName } : {}),
     ...(update?.lastToolName ? { lastToolName: update.lastToolName } : {}),
     ...(update?.outputFile ? { outputFile: update.outputFile } : {}),
     ...(typeof update?.usage?.totalTokens === 'number' ? { totalTokens: update.usage.totalTokens } : {}),


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Codex 子代理从「被禁止自发使用」变成「按需主动委托」,并补齐它在聊天界面的可见性:

1. **按需委托默认开启**:Codex 0.145 的 multi-agent v2 内置策略是非 ultra 思考档一律 `explicitRequestOnly`(模型被明确禁止自发 spawn 子代理)。实测(732 个本地 rollout 全量扫描)该策略下子代理从未被自发使用过,探索型任务把主线程 context 在 8 分钟内从 22k 吃到 245k(258k 窗口)触发压缩、压缩后重读刚读过的文件。本 PR 在 spawn codex 时恒注入 `features.multi_agent_v2.multi_agent_mode_hint_text`(Claude Code 式按需委托策略文案,上游走 `MultiAgentMode::Custom` 路径,任意思考档生效)与 `expose_spawn_agent_model_overrides=true`(允许模型给探索子代理自选低档模型)。随「Codex 子代理」总开关联动,关闭总开关即完全不注入;并发数继续只写 `agents.*` 段,避免 features 段双写产生差 1 的双重语义(模块注释同步改写为精确边界)。
2. **spawn 可见性修复**:0.145 v2 的 `spawn_agent` 不发 `collabAgentToolCall`,只发瞬时 `subAgentActivity` item,translator 此前当未知类型丢弃——子代理启动在 UI 完全不可见(实测:探索任务 spawn 3 个子代理,等待窗口内聊天流零卡片)。translator 新增该 item 处理:`kind=started` 渲染即时收口的「子代理已启动」卡(started/completed 双 phase 按 id 去重),`interacted`/`interrupted` 显式静默。
3. **子代理模型/思考强度徽标**:`AgentTaskCard` 模型 chip 来源链新增 spawn 参数兜底,codex 卡显示「模型 · 思考强度」(如 `gpt-5.6-terra · 低`);强度只认已知档位并复用 `effortLevels` 四语词表,零新增文案;spawn 未显式指定时不猜继承值、不渲染,Claude Code 卡片行为不变。受 0.145 协议限制,启动卡暂无模型数据可显示,升级 vendored Codex 后自动点亮,见 #1367。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#1367(后续:升级 vendored Codex 点亮启动卡模型徽标)
- 本 PR 包含:codex spawn 配置注入(`codex-subagent-config.ts`)、translator `subAgentActivity` 处理与状态文案、`AgentTaskCard` 徽标、对应单测
- 明确不包含:vendored Codex 版本升级(#1367);子代理运行中过程流/停止按钮;设置项新增(委托策略为内部常量,层级选择理由见下)
- 用户可见变化:Codex 探索型任务会自发出现「子代理已启动」与 `collab:wait` 卡片;子代理卡片可出现模型/思考强度徽标;Codex 总 token 用量预计上升(探索转移到子代理窗口,换主线程少触发压缩)
- 是否存在 breaking change:无

### UI 变化

聊天流子代理任务卡:新增「子代理已启动」卡(复用现有 AgentTaskCard,标题为子代理任务路径);模型 chip 在 codex 卡显示「模型 · 思考强度」。

- 引用的设计规范:不涉及新视觉:徽标完全复用现有 model chip 的容器与语义 token(`--surface-chip` 底色、字体继承 meta 行),无新增颜色/字号/间距;Light/Dark 随既有 token 生效(未实机双模式目检,如实注明)。

## 怎么验证的

### 自动验证

```text
bash run-unit-gate.sh <worktree>   # 仓库全量 pnpm test:unit
结果:GATE_EXIT=0(rebase 到最新 main 后重跑)
pnpm --filter desktop run typecheck && pnpm --filter @cindy/maker-core run typecheck
结果:通过
针对性单测:codex-subagent-config.test.ts 10 个(含 features 键白名单回归守卫、hint 400 token 预算)、
translator.test.ts 56 个(新增 subAgentActivity 3 个)、AgentTaskCardModelChip.test.tsx 5 个,全绿
```

### 手工验证

macOS 开发版实机(`pnpm restart:desktop:remote -- --preserve-running`,独立 dev userData,无手改 config 干扰):真实探索任务中 rollout `turn_context.multi_agent_mode` 为注入的 custom 文案(含仅产品文案有的判别句),模型自发 `spawn_agent` 3 个子代理并调 `wait_agent`;spawn 参数实测带差异化 `reasoningEffort`(high/ultra)。注入等价形态此前已在正式版 config.toml 手工验证一天:5 个真实任务自发 spawn 14 个子代理,任务名均为探索定位性质,实现均留在主线程,符合文案意图。

### 未执行的验证

- 徽标 Light/Dark 双模式实机目检未做(样式零新增,全部继承既有 chip 的语义 token);
- Windows 平台未实测(改动无平台分支,交 CI 门禁);
- translator 修复后的「子代理已启动」卡实机截图未拍(修复后实例已启动待用户验证,单测已覆盖事件形态)。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他:Codex token 用量上升(见下)

### 影响与回滚

- 影响范围:① **进入模型上下文的提示词**:hint 文案经上游 `<multi_agent_mode>` developer 段逐 turn 注入(上游截断上限 400 token,实际约 140 token,单测锁预算)。该改动已获维护者(@dashhuang)在会话中逐字确认文案并实测一天后拍板,按 `docs/dev-rules/maker-core-and-agent-behavior.md` 流程注明:**system prompt 改动已确认**。cache 影响:文案为会话内恒定常量,不破坏稳定前缀。② **用量**:子代理不省 token,只省主线程窗口;每个子代理约 22k 固定开销,总用量预计上升 10–30%,换取长任务不再因压缩丢失工作记忆(实测压缩前任务 8 分钟即触发 auto-compact 并重读文件)。③ 配置面:`deny_unknown_fields` 下两个注入键已逐字核对 0.145 源码,且在 0.146 / 0.147-alpha 均无 diff(#1367 有升级核对清单)。
- 回滚 / 降级方式:关闭设置页「Codex 子代理」总开关即用户侧完全回退(不注入任何相关键);代码回滚 revert 本 PR 即可,无持久化数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
