### PR TITLE
fix(device-link): prevent stale pushes from starving invoke-results in reliable transport buffer

### DIFF
--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -8,7 +8,9 @@ import { PROTOCOL_VERSION, DeviceLinkError, type Envelope } from '../protocol.js
 import {
   DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
   DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+  MAX_TRANSPORT_PENDING_MESSAGES,
   MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES,
+  TRANSPORT_PENDING_PUSH_MAX_AGE_MS,
   encodeReliableFrames,
   makeTransportSkipPayload,
   parseTransportPayload,
@@ -1207,6 +1209,142 @@ describe('DeviceLinkClient', () => {
     h.client.sendPush('dev-b', 'maker:event', { text: 'sent' });
     const sent = h.current().sent.filter((e) => e.kind === 'push' && e.dst === 'dev-b');
     expect(parseTransportPayload(sent.at(-1)!.payload)?.meta.seq).toBe(1);
+    h.client.stop();
+  });
+
+  it('缓冲被未 ACK 的 push 占满时，invoke-result 按最旧优先驱逐 push 腾位，不被饿死', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'starved-stream');
+
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    // push 之间不互相驱逐：溢出的 push 仍按原语义被背压拒绝
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+
+    // invoke-result 是控制端的存活凭据：驱逐最旧 push 腾位，立即入队发出
+    expect(() =>
+      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('to make room for invoke-result'),
+    );
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    const meta = parseTransportPayload(resultFrame.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    // 只驱逐了最旧的 seq=1：baseSeq 前移到 2，其余未过期 push 保留等待 ACK
+    expect(meta.baseSeq).toBe(2);
+    h.client.stop();
+  });
+
+  it('建链即清扫：离线期间过期的 push 不再重放，link-accept 的 baseSeq 直接跳过它们', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'stale-stream');
+
+    h.client.sendPush('dev-b', 'maker:event', { text: 'stale-1' });
+    h.client.sendPush('dev-b', 'maker:event', { text: 'stale-2' });
+    h.client.sendPush('dev-b', 'maker:event', { text: 'stale-3' });
+
+    // 静默断连(无 link-close,如对端失联/中继断开):push 留在 pending 等待重放
+    h.current().emit('close', 1006, 'network lost');
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
+    h.current().ack();
+    await tick();
+
+    // 离线时长超过 push 最大滞留时长后控制端重新建链
+    const realNow = Date.now;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(
+      () => realNow() + TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1_000,
+    );
+    try {
+      const before = h.current().sent.length;
+      await establishInboundReliableLink(h, 'stale-stream-reopen');
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('swept 3 expired push frame(s)'),
+      );
+      // accept 直接宣告新基线：过期 push 的 seq 1..3 被接收端整体跳过
+      const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
+      expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq).toBe(4);
+      // 过期 push 一条都不重放
+      const replayedPushes = h.current().sent.slice(before).filter((env) =>
+        env.kind === 'push' && env.dst === 'dev-b' && parseTransportPayload(env.payload) !== null,
+      );
+      expect(replayedPushes).toHaveLength(0);
+
+      // 建链后 invoke-result 立即发出，不再排在陈旧 push 的重放洪峰后面
+      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+      const resultFrame = h.current().sent.find(
+        (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+      )!;
+      expect(parseTransportPayload(resultFrame.payload)!.meta.seq).toBe(4);
+    } finally {
+      nowSpy.mockRestore();
+    }
+    h.client.stop();
+  });
+
+  it('腾位只驱逐 push：队头是未完成 invoke 时不驱逐，invoke-result 保持原背压语义', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, requestTimeoutMs: 5_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+
+    const open = h.client.openLink('dev-b', {
+      controllerName: 'Test',
+      protocolVersion: 1,
+      appVersion: '1',
+    });
+    const sentOpen = h.current().sent.find((e) => e.kind === 'link-open')!;
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-accept',
+      id: sentOpen.id,
+      src: 'dev-b',
+      payload: {
+        appVersion: '1',
+        allowlistHash: 'hash',
+        capabilities: [DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT],
+        transportStreamId: 'remote-stream',
+      },
+    });
+    await open;
+
+    // 队头 seq=1 是等待响应的 invoke，其后被 push 填满
+    const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
+    p.catch(() => {});
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 1; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    expect(() => h.client.sendInvokeResult('dev-b', 'r1', { ok: true, result: [] })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('to make room for invoke-result'),
+    );
     h.client.stop();
   });
 

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -107,6 +107,7 @@ async function establishInboundReliableLink(
   h: Harness,
   streamId: string,
   transportBaseSeq = 1,
+  src = 'dev-b',
 ): Promise<void> {
   const id = `inbound-link-${++inboundLinkId}`;
   const off = h.client.onFrame((env) => {
@@ -120,7 +121,7 @@ async function establishInboundReliableLink(
     v: PROTOCOL_VERSION,
     kind: 'link-open',
     id,
-    src: 'dev-b',
+    src,
     payload: {
       controllerName: 'Remote',
       protocolVersion: 1,
@@ -1651,6 +1652,129 @@ describe('DeviceLinkClient', () => {
 
     host.stop();
     controller.stop();
+  });
+
+  it('被驱逐 seq 的迟到 ACK 幂等无害：不误删存活的 result、不抛错、不错推状态', async () => {
+    const h = makeHarness({ timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 } });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'stale-ack-stream');
+
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    // 驱逐 seq 1..64，result 以 seq=65 入队
+    h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    const streamId = parseTransportPayload(resultFrame.payload)!.meta.streamId;
+
+    // 驱逐×ACK 竞态：接收端对早已被驱逐的 seq=3 的迟到累计 ACK 现在才到
+    const sendAck = (ackSeq: number) => h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: {
+        channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+        payload: { streamId, ackSeq },
+      },
+    });
+    sendAck(3);
+    // 越界的未知 ACK（超过 nextSeq-1）同样幂等忽略
+    sendAck(999);
+    await tick();
+
+    // result 仍在 pending 队头：后续帧的 baseSeq 仍指向 65，未被误删
+    h.client.sendPush('dev-b', 'maker:event', { text: 'after-stale-ack' });
+    const pushFrames = h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    const afterStale = parseTransportPayload(pushFrames[pushFrames.length - 1].payload)!.meta;
+    expect(afterStale.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 2);
+    expect(afterStale.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+
+    // 真正的 ACK(65) 只清掉 result：再下一帧 baseSeq 前移到 66
+    sendAck(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    await tick();
+    h.client.sendPush('dev-b', 'maker:event', { text: 'after-real-ack' });
+    const pushFrames2 = h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    const afterReal = parseTransportPayload(pushFrames2[pushFrames2.length - 1].payload)!.meta;
+    expect(afterReal.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 3);
+    expect(afterReal.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 2);
+    h.client.stop();
+  });
+
+  it('单 FIFO 固有极限：live invoke 卡在中段时，result 只跨过其前的可丢弃前缀，语义一致不死锁', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'mid-live-stream');
+
+    // 队形：[push(1), live-invoke(2), push×62] → 满 64
+    h.client.sendPush('dev-b', 'maker:event', { text: 'head-discardable' });
+    const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
+    p.catch(() => {});
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    // 前缀清扫停在 live invoke：只丢 seq=1，result 入队但排在 invoke+push 之后。
+    // 这是维护者确认的单 FIFO 极限：live 帧之后的 push 不可跨越（会留 seq 空洞）
+    expect(() =>
+      h.client.sendInvokeResult('dev-b', 'queued-result', { ok: true, result: [] }),
+    ).not.toThrow();
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'queued-result',
+    )!;
+    const meta = parseTransportPayload(resultFrame.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    expect(meta.baseSeq).toBe(2);
+
+    // 再次满员且队头已是 live invoke：前缀为空，维持 BACKPRESSURE，不死循环不死锁
+    expect(() => h.client.sendInvokeResult('dev-b', 'r2', { ok: true, result: [] })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    h.client.stop();
+  });
+
+  it('驱逐只作用于目标 peer：另一控制端的 pending 不受影响', async () => {
+    const h = makeHarness({ timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 } });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'iso-b');
+    await establishInboundReliableLink(h, 'iso-c', 1, 'dev-c');
+
+    h.client.sendPush('dev-c', 'maker:event', { keep: true });
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    // dev-b 的 result 驱逐 dev-b 全部 64 条 push
+    h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+    const resultMeta = parseTransportPayload(
+      h.current().sent.find((env) => env.kind === 'invoke-result' && env.id === 'probe-result')!.payload,
+    )!.meta;
+    expect(resultMeta.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+
+    // dev-c 的缓冲丝毫未动：seq=1 仍在 pending，新帧 baseSeq 仍为 1
+    h.client.sendPush('dev-c', 'maker:event', { second: true });
+    const devCFrames = h.current().sent.filter(
+      (env) => env.kind === 'push' && env.dst === 'dev-c' && parseTransportPayload(env.payload) !== null,
+    );
+    const devCMeta = parseTransportPayload(devCFrames[devCFrames.length - 1].payload)!.meta;
+    expect(devCMeta.seq).toBe(2);
+    // 线上格式在 baseSeq === 1 时省略该字段：基线仍为 1 即未发生任何驱逐
+    expect(devCMeta.baseSeq ?? 1).toBe(1);
+    h.client.stop();
   });
 
   it('invoke request id 在没有 global crypto 的运行时仍可生成', async () => {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -134,6 +134,143 @@ async function establishInboundReliableLink(
   off();
 }
 
+/** 接入内存中继的 fake socket：send 时把帧交给中继按 dst 保序路由。 */
+class RelayWs extends FakeWs {
+  constructor(
+    private readonly relay: MemoryRelay,
+    readonly ownerId: string,
+  ) {
+    super();
+  }
+
+  override send(data: string): void {
+    super.send(data);
+    this.relay.route(this.ownerId, this, JSON.parse(data) as Envelope);
+  }
+}
+
+/**
+ * 双客户端内存中继：单队列按帧到达顺序逐帧投递，验证接收端的「实际交付」
+ * 顺序而不只是发送端 emit。与真实 relay 一致：目的地离线的帧在入口处丢弃
+ *（发送端的可靠层靠未 ACK 的 pending 自行保留）。
+ */
+class MemoryRelay {
+  /** 按目的地记录实际投递给对端的帧（不含 hello-ack/pong 控制帧）。 */
+  readonly deliveredTo = new Map<string, Envelope[]>();
+  private readonly members = new Map<string, { ws: RelayWs | null }>();
+  private readonly queue: Array<
+    | { kind: 'direct'; ws: RelayWs; env: Envelope }
+    | { kind: 'routed'; dstId: string; env: Envelope }
+  > = [];
+
+  makeWebSocket(deviceId: string): RelayWs {
+    const member = this.members.get(deviceId) ?? { ws: null };
+    this.members.set(deviceId, member);
+    const ws = new RelayWs(this, deviceId);
+    member.ws = ws;
+    // 客户端在 createWebSocket 返回后才挂 handler：延到下一个宏任务再 open
+    setTimeout(() => {
+      if (this.members.get(deviceId)?.ws === ws) ws.emit('open');
+    }, 0);
+    return ws;
+  }
+
+  /** 静默掉线（无 link-close）：之后发往该设备的帧在入口处被丢弃。 */
+  disconnect(deviceId: string): void {
+    const member = this.members.get(deviceId);
+    if (!member?.ws) return;
+    const ws = member.ws;
+    member.ws = null;
+    ws.emit('close', 1006, 'network lost');
+  }
+
+  route(senderId: string, ws: RelayWs, env: Envelope): void {
+    if (env.kind === 'hello') {
+      this.queue.push({
+        kind: 'direct',
+        ws,
+        env: {
+          v: PROTOCOL_VERSION,
+          kind: 'hello-ack',
+          payload: { serverProtocolVersion: PROTOCOL_VERSION, deviceId: senderId, userId: 'u1' },
+        },
+      });
+      return;
+    }
+    if (env.kind === 'ping') {
+      this.queue.push({ kind: 'direct', ws, env: { v: PROTOCOL_VERSION, kind: 'pong' } });
+      return;
+    }
+    if (!env.dst) return;
+    // 入口即判定在线与否：离线目的地直接丢帧，不缓存、不重排
+    if (!this.members.get(env.dst)?.ws) return;
+    this.queue.push({ kind: 'routed', dstId: env.dst, env: { ...env, src: senderId } });
+  }
+
+  /** 按顺序逐帧投递直到静默；每帧之间让微任务（drain/ACK）跑完。 */
+  async settle(): Promise<void> {
+    let idle = 0;
+    while (idle < 3) {
+      const entry = this.queue.shift();
+      if (!entry) {
+        idle += 1;
+        await tick();
+        continue;
+      }
+      idle = 0;
+      if (entry.kind === 'direct') {
+        if (this.members.get(entry.ws.ownerId)?.ws === entry.ws) entry.ws.push(entry.env);
+      } else {
+        const member = this.members.get(entry.dstId);
+        if (member?.ws) {
+          let log = this.deliveredTo.get(entry.dstId);
+          if (!log) {
+            log = [];
+            this.deliveredTo.set(entry.dstId, log);
+          }
+          log.push(entry.env);
+          member.ws.push(entry.env);
+        }
+      }
+      await tick();
+    }
+  }
+
+  /** 持续泵送直到条件成立（如等待重连退避计时器触发）。 */
+  async settleUntil(condition: () => boolean, timeoutMs = 3_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      await this.settle();
+      if (condition()) return;
+      if (Date.now() > deadline) throw new Error('MemoryRelay.settleUntil timed out');
+      await tick(5);
+    }
+  }
+}
+
+function makeRelayClient(relay: MemoryRelay, deviceId: string): DeviceLinkClient {
+  return new DeviceLinkClient({
+    getWsUrl: () => 'ws://test/api/device-link/ws',
+    getToken: async () => 'jwt-token',
+    getHello: () => ({
+      deviceName: deviceId,
+      platform: 'darwin',
+      appVersion: '1.0.0',
+      remoteControlEnabled: true,
+      busy: false,
+    }),
+    createWebSocket: () => relay.makeWebSocket(deviceId),
+    timing: {
+      reconnectBaseMs: 5,
+      reconnectMaxMs: 20,
+      pingIntervalMs: 60_000,
+      pongMissLimit: 4,
+      requestTimeoutMs: 2_000,
+      transportRetryIntervalMs: 60_000,
+    },
+  });
+}
+
 describe('DeviceLinkClient', () => {
   it('start → open 后第一帧是 hello,hello-ack 后 online', async () => {
     const h = makeHarness();
@@ -517,7 +654,7 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
-  it('可靠消息重试耗尽后主动重连，并在新 link 上重放同一 seq', async () => {
+  it('可靠消息重试耗尽后主动重连，并在新 link 上重放同一 seq（用不可丢弃的 invoke-result 验证；队头 push 重连时作为可丢弃前缀被放弃）', async () => {
     const h = makeHarness({
       timing: {
         pingIntervalMs: 1_000,
@@ -552,9 +689,9 @@ describe('DeviceLinkClient', () => {
     await firstOpen;
 
     const firstSocket = h.current();
-    h.client.sendPush('dev-b', 'maker:event', { text: 'replay me' });
+    h.client.sendInvokeResult('dev-b', 'replay-me', { ok: true, result: [] });
     const firstReliable = firstSocket.sent.find((env) => (
-      env.kind === 'push' && parseTransportPayload(env.payload)
+      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
     ))!;
     const firstMeta = parseTransportPayload(firstReliable.payload)!.meta;
 
@@ -583,7 +720,7 @@ describe('DeviceLinkClient', () => {
     await secondOpen;
 
     const replays = h.current().sent.filter((env) => (
-      env.kind === 'push' && parseTransportPayload(env.payload)
+      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
     ));
     expect(replays).toHaveLength(1);
     const replay = replays[0];
@@ -1212,7 +1349,7 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
-  it('缓冲被未 ACK 的 push 占满时，invoke-result 按最旧优先驱逐 push 腾位，不被饿死', async () => {
+  it('缓冲被未 ACK 的 push 占满时，invoke-result 丢弃整个可丢弃前缀，成为最早的 live seq', async () => {
     const warn = vi.fn();
     const h = makeHarness({
       timing: { pingIntervalMs: 10_000 },
@@ -1226,12 +1363,13 @@ describe('DeviceLinkClient', () => {
     for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
       h.client.sendPush('dev-b', 'maker:event', { i });
     }
-    // push 之间不互相驱逐：溢出的 push 仍按原语义被背压拒绝
+    // push 之间不互相驱逐：新鲜 push 溢出仍按原语义被背压拒绝
     expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
       expect.objectContaining({ code: 'BACKPRESSURE' }),
     );
 
-    // invoke-result 是控制端的存活凭据：驱逐最旧 push 腾位，立即入队发出
+    // invoke-result 是控制端的存活凭据：丢弃整个队头可丢弃前缀（fresh push
+    // 一并放弃），立即入队发出，不留任何 push 排在 result 之前
     expect(() =>
       h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] }),
     ).not.toThrow();
@@ -1243,12 +1381,13 @@ describe('DeviceLinkClient', () => {
     )!;
     const meta = parseTransportPayload(resultFrame.payload)!.meta;
     expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
-    // 只驱逐了最旧的 seq=1：baseSeq 前移到 2，其余未过期 push 保留等待 ACK
-    expect(meta.baseSeq).toBe(2);
+    // 整个 push 前缀被丢弃：baseSeq 直接前移到 result 自身，接收端不再等任何
+    // 被丢弃的 seq，result 就是下一条可交付的 live 帧
+    expect(meta.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
     h.client.stop();
   });
 
-  it('建链即清扫：离线期间过期的 push 不再重放，link-accept 的 baseSeq 直接跳过它们', async () => {
+  it('建链即丢弃可丢弃前缀：离线期间堆积的 push 不分新旧都不重放，link-accept 的 baseSeq 直接跳过它们', async () => {
     const warn = vi.fn();
     const h = makeHarness({
       timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
@@ -1259,6 +1398,8 @@ describe('DeviceLinkClient', () => {
     h.current().ack();
     await establishInboundReliableLink(h, 'stale-stream');
 
+    // 三条均为新鲜 push：重连重放路径不看 TTL，单 FIFO 无法同时保证 push 无损
+    // 与 invoke-result 抢占，重建链路时整个可丢弃前缀一律放弃
     h.client.sendPush('dev-b', 'maker:event', { text: 'stale-1' });
     h.client.sendPush('dev-b', 'maker:event', { text: 'stale-2' });
     h.client.sendPush('dev-b', 'maker:event', { text: 'stale-3' });
@@ -1269,40 +1410,137 @@ describe('DeviceLinkClient', () => {
     h.current().ack();
     await tick();
 
-    // 离线时长超过 push 最大滞留时长后控制端重新建链
-    const realNow = Date.now;
-    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(
-      () => realNow() + TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1_000,
+    const before = h.current().sent.length;
+    await establishInboundReliableLink(h, 'stale-stream-reopen');
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('dropped 3 discardable pending frame(s)'),
     );
-    try {
-      const before = h.current().sent.length;
-      await establishInboundReliableLink(h, 'stale-stream-reopen');
+    // accept 直接宣告新基线：被丢弃 push 的 seq 1..3 被接收端整体跳过
+    const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
+    expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq).toBe(4);
+    // 堆积的 push 一条都不重放
+    const replayedPushes = h.current().sent.slice(before).filter((env) =>
+      env.kind === 'push' && env.dst === 'dev-b' && parseTransportPayload(env.payload) !== null,
+    );
+    expect(replayedPushes).toHaveLength(0);
 
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('swept 3 expired push frame(s)'),
-      );
-      // accept 直接宣告新基线：过期 push 的 seq 1..3 被接收端整体跳过
-      const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
-      expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq).toBe(4);
-      // 过期 push 一条都不重放
-      const replayedPushes = h.current().sent.slice(before).filter((env) =>
-        env.kind === 'push' && env.dst === 'dev-b' && parseTransportPayload(env.payload) !== null,
-      );
-      expect(replayedPushes).toHaveLength(0);
-
-      // 建链后 invoke-result 立即发出，不再排在陈旧 push 的重放洪峰后面
-      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
-      const resultFrame = h.current().sent.find(
-        (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
-      )!;
-      expect(parseTransportPayload(resultFrame.payload)!.meta.seq).toBe(4);
-    } finally {
-      nowSpy.mockRestore();
-    }
+    // 建链后 invoke-result 立即发出，不再排在陈旧 push 的重放洪峰后面
+    h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    expect(parseTransportPayload(resultFrame.payload)!.meta.seq).toBe(4);
     h.client.stop();
   });
 
-  it('腾位只驱逐 push：队头是未完成 invoke 时不驱逐，invoke-result 保持原背压语义', async () => {
+  it('push 入队压力只做 TTL 兜底清扫（单调时钟计量），新鲜 push 之间仍互相背压', async () => {
+    // TTL 用单调时钟：墙钟被 NTP 向前校正超过 TTL 时，刚入队的 push 不得被误判过期
+    const proto = DeviceLinkClient.prototype as unknown as { monotonicNow(): number };
+    let nowMs = 10_000;
+    const clock = vi.spyOn(proto, 'monotonicNow').mockImplementation(() => nowMs);
+    try {
+      const warn = vi.fn();
+      const h = makeHarness({
+        timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+        logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+      });
+      h.client.start();
+      await tick();
+      h.current().ack();
+      await establishInboundReliableLink(h, 'ttl-stream');
+
+      h.client.sendPush('dev-b', 'maker:event', { text: 'old-1' });
+      h.client.sendPush('dev-b', 'maker:event', { text: 'old-2' });
+      // 只推进单调时钟：前两条 push 超龄，后续 push 保持新鲜
+      nowMs += TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1;
+      for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
+        h.client.sendPush('dev-b', 'maker:event', { i });
+      }
+
+      // 缓冲满：新 push 触发 TTL 兜底清扫，只有 2 条过期 push 出队，新 push 入队
+      expect(() =>
+        h.client.sendPush('dev-b', 'maker:event', { text: 'fresh-after-sweep' }),
+      ).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('dropped 2 discardable pending frame(s)'),
+      );
+      const frames = h.current().sent.filter(
+        (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+      );
+      const meta = parseTransportPayload(frames[frames.length - 1].payload)!.meta;
+      expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+      expect(meta.baseSeq).toBe(3);
+
+      // 填回满员后队头是新鲜 push：不互相驱逐，仍按原语义背压
+      h.client.sendPush('dev-b', 'maker:event', { text: 'refill' });
+      expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
+        expect.objectContaining({ code: 'BACKPRESSURE' }),
+      );
+      h.client.stop();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('队头 skip 占位不再挡住腾位：invoke 超时成 skip 后，invoke-result 跨过 skip 与 push 入队，重连后第一个重放', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'skip-head-stream');
+
+    // seq=1：invoke 超时后被 dropReliablePendingForRequest 换成 transport-skip
+    // 占位：外层 kind 仍是 invoke，但已无业务副作用
+    const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 20);
+    await expect(p).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
+
+    // skip 之后队列被 push 填满
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 1; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    // 旧判据按外层 kind === 'invoke' 会在队头 skip 上停下→BACKPRESSURE；
+    // 新判据（push || isTransportSkipPayload）跨过 skip 与全部 push
+    expect(() =>
+      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('to make room for invoke-result'),
+    );
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    const meta = parseTransportPayload(resultFrame.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    expect(meta.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+
+    // 静默断连后重建链路：重放的第一帧就是这条 result，没有 skip/push 挡在前面
+    h.current().emit('close', 1006, 'network lost');
+    await vi.waitFor(() => expect(h.sockets.length).toBeGreaterThanOrEqual(2));
+    h.current().ack();
+    await tick();
+    const before = h.current().sent.length;
+    await establishInboundReliableLink(h, 'skip-head-stream-reopen');
+
+    const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
+    expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq)
+      .toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    const replayed = h.current().sent.slice(before).filter(
+      (env) => parseTransportPayload(env.payload) !== null,
+    );
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0].kind).toBe('invoke-result');
+    expect(parseTransportPayload(replayed[0].payload)!.meta.baseSeq)
+      .toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    h.client.stop();
+  });
+
+  it('腾位只跨过可丢弃帧：队头是 live invoke 时不驱逐，invoke-result 保持原背压语义', async () => {
     const warn = vi.fn();
     const h = makeHarness({
       timing: { pingIntervalMs: 10_000, requestTimeoutMs: 5_000 },
@@ -1332,7 +1570,8 @@ describe('DeviceLinkClient', () => {
     });
     await open;
 
-    // 队头 seq=1 是等待响应的 invoke，其后被 push 填满
+    // 队头 seq=1 是仍在等待响应的 live invoke（未超时、未被换成 skip），其后被 push 填满；
+    // live invoke 是可丢弃前缀的边界，其后的 push 不可跨越（否则留下 seq 空洞）
     const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
     p.catch(() => {});
     for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 1; i++) {
@@ -1346,6 +1585,72 @@ describe('DeviceLinkClient', () => {
       expect.stringContaining('to make room for invoke-result'),
     );
     h.client.stop();
+  });
+
+  it('双端有序中继：64 条 fresh push 灌满后重连，探测 invoke 的 result 先于任何重放 push 实际交付并在超时前 resolve', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'dev-a');
+    const controller = makeRelayClient(relay, 'dev-b');
+    // host 侧应用逻辑：自动接受 link-open，即时应答 invoke（存活探测）
+    host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+      if (env.kind === 'invoke' && env.src && env.id) {
+        host.sendInvokeResult(env.src, env.id, { ok: true, result: ['alive'] });
+      }
+    });
+    host.start();
+    controller.start();
+    await relay.settleUntil(
+      () => host.getStatus() === 'online' && controller.getStatus() === 'online',
+    );
+
+    const open = controller.openLink('dev-a', {
+      controllerName: 'Ctrl',
+      protocolVersion: 1,
+      appVersion: '1',
+    });
+    await relay.settle();
+    await open;
+
+    // 控制端整夜离线：host 同步灌满 64 条 fresh push（入口即丢，但全部滞留
+    // 在 host 的可靠 pending 里等 ACK，与线上事故的堆积形态一致）
+    relay.disconnect('dev-b');
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      host.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    // 控制端重连、重新建链，立即发存活探测
+    await relay.settleUntil(() => controller.getStatus() === 'online');
+    const reopen = controller.openLink('dev-a', {
+      controllerName: 'Ctrl',
+      protocolVersion: 1,
+      appVersion: '1',
+    });
+    await relay.settle();
+    await reopen;
+    const probe = controller.invoke(
+      'dev-a',
+      { channel: 'maker:list-active', args: [] },
+      2_000,
+    );
+    await relay.settle();
+
+    // 关键断言 1：探测在超时窗口内真实 resolve（交付验证，非发送端 emit）
+    await expect(probe).resolves.toMatchObject({ ok: true });
+
+    // 关键断言 2：控制端收到的可靠传输帧里，result 排第一，前面没有任何
+    // 重放的 push（旧实现会先把 64 条 push 写进 WS FIFO，result 只能排尾）
+    const transportFrames = (relay.deliveredTo.get('dev-b') ?? []).filter(
+      (env) => parseTransportPayload(env.payload) !== null,
+    );
+    expect(transportFrames.length).toBeGreaterThan(0);
+    expect(transportFrames[0].kind).toBe('invoke-result');
+    expect(transportFrames.some((env) => env.kind === 'push')).toBe(false);
+
+    host.stop();
+    controller.stop();
   });
 
   it('invoke request id 在没有 global crypto 的运行时仍可生成', async () => {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -28,6 +28,7 @@ import {
   MAX_TRANSPORT_SEQUENCE_WINDOW,
   MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES,
   TRANSPORT_MAX_RETRY_ATTEMPTS,
+  TRANSPORT_PENDING_PUSH_MAX_AGE_MS,
   TRANSPORT_RETRY_INTERVAL_MS,
   decodeTransportJson,
   encodeReliableFrames,
@@ -249,6 +250,8 @@ interface PendingReliableMessage {
   attempts: number;
   lastSentAt: number;
   sent: boolean;
+  /** 入队时刻；push 帧按 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 判定过期。 */
+  enqueuedAt: number;
 }
 
 interface PeerTransportState {
@@ -597,6 +600,11 @@ export class DeviceLinkClient {
       && matchingOffer.capabilities.includes(DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT)
     );
     const peer = this.getPeerTransport(dst);
+    // 建链即清扫：过期 push 先出队，让 accept 携带的 transportBaseSeq 直接跳过
+    // 它们，对端从一开始就不等这些陈旧 seq，随后的重放也不再灌回离线期间堆积
+    // 的过期实时镜像（v0.1.25 线上曾出现建链后 250ms invoke-result 仍被离线期
+    // 间堆满的 push 挤在缓冲外，控制端的存活探测因此超时，熔断持续 open）。
+    if (peerSupportsReliable) this.sweepExpiredPendingPushes(dst, peer);
     this.sendEnvelope({
       v: PROTOCOL_VERSION,
       kind: 'link-accept',
@@ -1677,10 +1685,16 @@ export class DeviceLinkClient {
         err instanceof Error ? err.message : String(err),
       );
     }
-    if (
-      peer.pending.size >= MAX_TRANSPORT_PENDING_MESSAGES ||
-      peer.pendingBytes + reservedBytes > MAX_TRANSPORT_PENDING_BYTES
-    ) {
+    const hasPendingCapacity = (): boolean => (
+      peer.pending.size < MAX_TRANSPORT_PENDING_MESSAGES
+      && peer.pendingBytes + reservedBytes <= MAX_TRANSPORT_PENDING_BYTES
+    );
+    if (!hasPendingCapacity() && env.kind === 'invoke-result') {
+      // invoke-result 是控制端确认被控端存活的唯一凭据，绝不能被堆积的 push
+      // 饿死：先清扫过期 push，仍不够则按最旧优先继续驱逐队头 push 腾位。
+      this.evictPendingPushesForInvokeResult(env.dst, peer, hasPendingCapacity);
+    }
+    if (!hasPendingCapacity()) {
       throw new DeviceLinkError(
         'BACKPRESSURE',
         `reliable transport buffer is full for peer ${env.dst.slice(0, 8)}`,
@@ -1699,6 +1713,7 @@ export class DeviceLinkClient {
       attempts: 0,
       lastSentAt: 0,
       sent: false,
+      enqueuedAt: Date.now(),
     };
     peer.pending.set(seq, pending);
     peer.pendingBytes += reservedBytes;
@@ -1978,6 +1993,68 @@ export class DeviceLinkClient {
     }
   }
 
+  /**
+   * 清扫 pending 队头连续的过期 push 帧。只能从队头连续删除：队头出队后
+   * baseSeq（最小 pending seq）随之前移，后续帧携带的 baseSeq 会让接收端整体
+   * 跳过这些 seq；若删除中段条目则会留下 seq 空洞，接收端累计 ACK 永久停住。
+   * 队内 seq 即入队顺序，队头最老，所以「过期段」天然是队头连续前缀。
+   */
+  private sweepExpiredPendingPushes(dst: string, peer: PeerTransportState): number {
+    const now = Date.now();
+    let evicted = 0;
+    for (const [seq, pending] of peer.pending) {
+      if (pending.envelope.kind !== 'push') break;
+      if (now - pending.enqueuedAt < TRANSPORT_PENDING_PUSH_MAX_AGE_MS) break;
+      this.removePendingEntry(peer, seq, pending);
+      evicted += 1;
+    }
+    if (evicted > 0) {
+      this.log.warn(
+        `swept ${evicted} expired push frame(s) from reliable buffer for peer ${dst.slice(0, 8)}`,
+      );
+    }
+    return evicted;
+  }
+
+  /**
+   * invoke-result 入队时缓冲已满：先清扫过期 push，仍满则按最旧优先继续驱逐
+   * 队头 push，直到腾出容量或队头不再是 push（invoke / invoke-result 绝不驱逐）。
+   * push 本就是尽力而为的旁路（见 desktop 侧 forwardPush），而 invoke-result
+   * 一旦被饿死，控制端会把被控端判定为无响应并保持熔断，形成死锁。
+   */
+  private evictPendingPushesForInvokeResult(
+    dst: string,
+    peer: PeerTransportState,
+    hasCapacity: () => boolean,
+  ): void {
+    this.sweepExpiredPendingPushes(dst, peer);
+    let evicted = 0;
+    for (const [seq, pending] of peer.pending) {
+      if (hasCapacity()) break;
+      if (pending.envelope.kind !== 'push') break;
+      this.removePendingEntry(peer, seq, pending);
+      evicted += 1;
+    }
+    if (evicted > 0) {
+      this.log.warn(
+        `evicted ${evicted} pending push frame(s) for peer ${dst.slice(0, 8)} to make room for invoke-result`,
+      );
+    }
+  }
+
+  private removePendingEntry(
+    peer: PeerTransportState,
+    seq: number,
+    pending: PendingReliableMessage,
+  ): void {
+    peer.pending.delete(seq);
+    peer.pendingBytes -= pending.bytes;
+    if (peer.pending.size === 0 && peer.retryTimer) {
+      clearInterval(peer.retryTimer);
+      peer.retryTimer = null;
+    }
+  }
+
   private ensureRetryTimer(dst: string): void {
     const peer = this.getPeerTransport(dst);
     if (peer.retryTimer) return;
@@ -2015,6 +2092,10 @@ export class DeviceLinkClient {
   private replayPending(dst: string, resumedLink = false): void {
     const peer = this.peerTransport.get(dst);
     if (!peer || !peer.reliable || !peer.linkReady || peer.pending.size === 0) return;
+    // 链路恢复先清扫过期 push：对端离线期间堆积的陈旧实时镜像不值得重放，只会
+    // 占满重放窗口，把紧随建链而来的 invoke-result 挤到数秒之后。
+    this.sweepExpiredPendingPushes(dst, peer);
+    if (peer.pending.size === 0) return;
     if (resumedLink || peer.lastReplayEpoch !== this.connEpoch) {
       peer.lastReplayEpoch = this.connEpoch;
       for (const pending of peer.pending.values()) {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -1991,6 +1991,9 @@ export class DeviceLinkClient {
   private handleTransportAck(src: string, streamId: string, ackSeq: number): void {
     const peer = this.peerTransport.get(src);
     if (!peer || !peer.reliable || !peer.linkReady || peer.streamId !== streamId) return;
+    // 迟到/陈旧 ACK 幂等无害（含指向已被驱逐 seq 的 ACK）：驱逐后该 seq 已不在
+    // map 里，累计删除循环遇到更高的队头 live seq 直接 break，不会误删、不抛错、
+    // 不错误推进状态；高于 nextSeq-1 的未知 ACK 与倒退的 ACK 直接忽略。
     if (ackSeq > peer.nextSeq - 1 || ackSeq <= peer.highestAckSeq) return;
     peer.highestAckSeq = ackSeq;
     for (const [seq, pending] of peer.pending) {
@@ -2036,6 +2039,24 @@ export class DeviceLinkClient {
    * 用于普通入队压力下的兜底清扫；expiredOnly=false 丢弃整个可丢弃前缀
    * （fresh push 一并放弃），用于重连重放前与 invoke-result 腾位——保证剩余
    * 队头就是最早的 live 帧，invoke-result 不会排在任何可丢弃帧之后。
+   *
+   * 不变量的作用域（刻意从窄）：「result 成为最早可交付的 live seq」只在两个
+   * 清扫时点成立——重连重放写入 socket 之前、新帧入队之前。已写进 WebSocket
+   * FIFO 的帧无法撤回，本方法不承诺全时态抢占；队头是 live 帧时前缀为空，
+   * 维持原 BACKPRESSURE 语义。这也是单 FIFO 的固有极限：live 帧之后的 push
+   * 不可跨越（会留 seq 空洞），例如 [push, live-invoke, push…] 只能丢掉第一段，
+   * result 仍排在 live-invoke 之后——「push 无损」与「result 抢占」在单流上
+   * 不可兼得（需独立优先 stream 才能同时满足）。
+   *
+   * 终止性与计数：每轮迭代要么删除当前队头、要么 break（队头 live / 未过期），
+   * 至多 pending.size 轮；removePendingEntry 同步扣减 pendingBytes 并在队空时
+   * 回收 retryTimer，不产生计数漂移。只触碰参数 peer（按 dst 隔离）的缓冲。
+   *
+   * 数据完整性：被丢弃的 push 不是静默丢数据——push 是尽力而为的状态镜像，
+   * 控制端在重连/回前台时会整体 resync + 重新订阅（mobile 侧 reconnect
+   * reseed），最新状态由下一次全量拉取补偿。传输层没有 push 的离线持久队列
+   * （invoke-result 的 outbox 在 host 层且与 push 无关），驱逐回填既无宿主也无
+   * 必要，故不做。
    */
   private dropDiscardablePendingPrefix(
     dst: string,

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -250,7 +250,7 @@ interface PendingReliableMessage {
   attempts: number;
   lastSentAt: number;
   sent: boolean;
-  /** 入队时刻；push 帧按 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 判定过期。 */
+  /** 入队时刻（monotonicNow 单调时钟）；push 帧按 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 判定过期。 */
   enqueuedAt: number;
 }
 
@@ -600,11 +600,15 @@ export class DeviceLinkClient {
       && matchingOffer.capabilities.includes(DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT)
     );
     const peer = this.getPeerTransport(dst);
-    // 建链即清扫：过期 push 先出队，让 accept 携带的 transportBaseSeq 直接跳过
-    // 它们，对端从一开始就不等这些陈旧 seq，随后的重放也不再灌回离线期间堆积
-    // 的过期实时镜像（v0.1.25 线上曾出现建链后 250ms invoke-result 仍被离线期
-    // 间堆满的 push 挤在缓冲外，控制端的存活探测因此超时，熔断持续 open）。
-    if (peerSupportsReliable) this.sweepExpiredPendingPushes(dst, peer);
+    // 建链即丢弃队头连续的可丢弃前缀（push 不分新旧 + skip 占位）：让 accept
+    // 携带的 transportBaseSeq 直接跳过它们，对端从一开始就不等这些 seq，随后的
+    // 重放不再灌回离线期间堆积的实时镜像，紧随建链而来的 invoke-result 成为最
+    // 早可交付的 live seq（v0.1.25 线上曾出现建链后 250ms invoke-result 仍被离
+    // 线期间堆满的 push 重放洪峰挤在后面，控制端的存活探测因此超时，熔断持续
+    // open）。
+    if (peerSupportsReliable) {
+      this.dropDiscardablePendingPrefix(dst, peer, false, 'before link re-establishment replay');
+    }
     this.sendEnvelope({
       v: PROTOCOL_VERSION,
       kind: 'link-accept',
@@ -1689,10 +1693,17 @@ export class DeviceLinkClient {
       peer.pending.size < MAX_TRANSPORT_PENDING_MESSAGES
       && peer.pendingBytes + reservedBytes <= MAX_TRANSPORT_PENDING_BYTES
     );
-    if (!hasPendingCapacity() && env.kind === 'invoke-result') {
-      // invoke-result 是控制端确认被控端存活的唯一凭据，绝不能被堆积的 push
-      // 饿死：先清扫过期 push，仍不够则按最旧优先继续驱逐队头 push 腾位。
-      this.evictPendingPushesForInvokeResult(env.dst, peer, hasPendingCapacity);
+    if (!hasPendingCapacity()) {
+      if (env.kind === 'invoke-result') {
+        // invoke-result 是控制端确认被控端存活的唯一凭据，绝不能被堆积的可丢弃
+        // 帧饿死：丢弃整个队头可丢弃前缀（fresh push 一并放弃——单 FIFO 无法同时
+        // 做到 push 无损与 result 抢占），让 result 成为最早可交付的 live seq。
+        this.dropDiscardablePendingPrefix(env.dst, peer, false, 'to make room for invoke-result');
+      } else {
+        // 其它帧的入队压力只做 TTL 兜底清扫：过期 push 已无实时价值，先出队腾位；
+        // 新鲜 push 之间维持原有 BACKPRESSURE 语义，不互相驱逐。
+        this.dropDiscardablePendingPrefix(env.dst, peer, true, 'after pending push TTL expiry');
+      }
     }
     if (!hasPendingCapacity()) {
       throw new DeviceLinkError(
@@ -1713,7 +1724,7 @@ export class DeviceLinkClient {
       attempts: 0,
       lastSentAt: 0,
       sent: false,
-      enqueuedAt: Date.now(),
+      enqueuedAt: this.monotonicNow(),
     };
     peer.pending.set(seq, pending);
     peer.pendingBytes += reservedBytes;
@@ -1994,52 +2005,62 @@ export class DeviceLinkClient {
   }
 
   /**
-   * 清扫 pending 队头连续的过期 push 帧。只能从队头连续删除：队头出队后
-   * baseSeq（最小 pending seq）随之前移，后续帧携带的 baseSeq 会让接收端整体
-   * 跳过这些 seq；若删除中段条目则会留下 seq 空洞，接收端累计 ACK 永久停住。
-   * 队内 seq 即入队顺序，队头最老，所以「过期段」天然是队头连续前缀。
+   * 单调时钟。pending 帧的滞留时长（TTL）必须用不受墙钟校正影响的时源计量：
+   * Date.now() 在系统时间被向前校正超过 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 时，
+   * 会把刚入队的 push 误判为过期。测试通过 stub 本方法模拟老化。
    */
-  private sweepExpiredPendingPushes(dst: string, peer: PeerTransportState): number {
-    const now = Date.now();
-    let evicted = 0;
-    for (const [seq, pending] of peer.pending) {
-      if (pending.envelope.kind !== 'push') break;
-      if (now - pending.enqueuedAt < TRANSPORT_PENDING_PUSH_MAX_AGE_MS) break;
-      this.removePendingEntry(peer, seq, pending);
-      evicted += 1;
-    }
-    if (evicted > 0) {
-      this.log.warn(
-        `swept ${evicted} expired push frame(s) from reliable buffer for peer ${dst.slice(0, 8)}`,
-      );
-    }
-    return evicted;
+  private monotonicNow(): number {
+    return performance.now();
   }
 
   /**
-   * invoke-result 入队时缓冲已满：先清扫过期 push，仍满则按最旧优先继续驱逐
-   * 队头 push，直到腾出容量或队头不再是 push（invoke / invoke-result 绝不驱逐）。
-   * push 本就是尽力而为的旁路（见 desktop 侧 forwardPush），而 invoke-result
-   * 一旦被饿死，控制端会把被控端判定为无响应并保持熔断，形成死锁。
+   * 可丢弃帧判据（重连重放与 invoke-result 腾位两条路径共用的不变量）：
+   * best-effort push，以及 timeout / relay-error 后被 dropReliablePendingForRequest
+   * 换成 transport-skip 占位 payload 的帧——其外层 kind 仍是原 invoke /
+   * invoke-result，但已无任何业务副作用。两者都可以通过推进 baseSeq 让接收端
+   * 整体跳过；live invoke / invoke-result 永不可丢弃，是丢弃前缀的边界。
    */
-  private evictPendingPushesForInvokeResult(
+  private isDiscardablePending(pending: PendingReliableMessage): boolean {
+    return (
+      pending.envelope.kind === 'push'
+      || isTransportSkipPayload(pending.envelope.payload)
+    );
+  }
+
+  /**
+   * 丢弃 pending 队头连续的可丢弃前缀。只能从队头连续删除：队头出队后
+   * baseSeq（最小 pending seq）随之前移，后续帧携带的 baseSeq 会让接收端整体
+   * 跳过这些 seq；若删除中段条目则会留下 seq 空洞，接收端累计 ACK 永久停住。
+   *
+   * expiredOnly=true 只删过期 push（skip 占位没有任何交付价值，始终可删），
+   * 用于普通入队压力下的兜底清扫；expiredOnly=false 丢弃整个可丢弃前缀
+   * （fresh push 一并放弃），用于重连重放前与 invoke-result 腾位——保证剩余
+   * 队头就是最早的 live 帧，invoke-result 不会排在任何可丢弃帧之后。
+   */
+  private dropDiscardablePendingPrefix(
     dst: string,
     peer: PeerTransportState,
-    hasCapacity: () => boolean,
-  ): void {
-    this.sweepExpiredPendingPushes(dst, peer);
-    let evicted = 0;
+    expiredOnly: boolean,
+    reason: string,
+  ): number {
+    const now = this.monotonicNow();
+    let dropped = 0;
     for (const [seq, pending] of peer.pending) {
-      if (hasCapacity()) break;
-      if (pending.envelope.kind !== 'push') break;
+      if (!this.isDiscardablePending(pending)) break;
+      if (
+        expiredOnly
+        && pending.envelope.kind === 'push'
+        && now - pending.enqueuedAt < TRANSPORT_PENDING_PUSH_MAX_AGE_MS
+      ) break;
       this.removePendingEntry(peer, seq, pending);
-      evicted += 1;
+      dropped += 1;
     }
-    if (evicted > 0) {
+    if (dropped > 0) {
       this.log.warn(
-        `evicted ${evicted} pending push frame(s) for peer ${dst.slice(0, 8)} to make room for invoke-result`,
+        `dropped ${dropped} discardable pending frame(s) (best-effort push / transport-skip) for peer ${dst.slice(0, 8)} ${reason}`,
       );
     }
+    return dropped;
   }
 
   private removePendingEntry(
@@ -2092,9 +2113,11 @@ export class DeviceLinkClient {
   private replayPending(dst: string, resumedLink = false): void {
     const peer = this.peerTransport.get(dst);
     if (!peer || !peer.reliable || !peer.linkReady || peer.pending.size === 0) return;
-    // 链路恢复先清扫过期 push：对端离线期间堆积的陈旧实时镜像不值得重放，只会
-    // 占满重放窗口，把紧随建链而来的 invoke-result 挤到数秒之后。
-    this.sweepExpiredPendingPushes(dst, peer);
+    // 重放前先丢弃队头连续的可丢弃前缀（push 不分新旧 + skip 占位）：重放一旦把
+    // 它们写进 WebSocket FIFO 就无法撤回，之后的 invoke-result 驱逐救不回已发出
+    // 的帧，接收端仍会按 seq 顺序先消化整段重放洪峰。丢弃后重放的第一帧就是最
+    // 早的 live 帧。
+    this.dropDiscardablePendingPrefix(dst, peer, false, 'before link re-establishment replay');
     if (peer.pending.size === 0) return;
     if (resumedLink || peer.lastReplayEpoch !== this.connEpoch) {
       peer.lastReplayEpoch = this.connEpoch;

--- a/packages/device-link/src/transport.ts
+++ b/packages/device-link/src/transport.ts
@@ -35,9 +35,11 @@ export const TRANSPORT_RETRY_INTERVAL_MS = 2_000;
 /** 连续重发上限；之后保留消息等待重连，避免弱网下无限制造流量。 */
 export const TRANSPORT_MAX_RETRY_ATTEMPTS = 5;
 /**
- * pending 里 push 帧的最大滞留时长。push 是尽力而为的实时镜像旁路，对端长时间
- * 未 ACK（典型是离线）后这些帧只剩历史价值；超龄后视为过期，在链路恢复重放前
- * 与 invoke-result 需要腾位时清扫，避免陈旧 push 独占有界 pending 缓冲。
+ * pending 里 push 帧的最大滞留时长（按单调时钟计量，不受墙钟校正影响）。push 是
+ * 尽力而为的实时镜像旁路，长时间未被 ACK（典型是对端离线）后只剩历史价值；
+ * 超龄后在普通入队压力下被兜底清扫，避免陈旧 push 独占有界 pending 缓冲。
+ * 重连重放前与 invoke-result 腾位不看此 TTL：这两条路径直接丢弃队头整个可丢弃
+ * 前缀（含新鲜 push 与 transport-skip 占位），保证 invoke-result 是最早的 live seq。
  */
 export const TRANSPORT_PENDING_PUSH_MAX_AGE_MS = 5 * 60_000;
 

--- a/packages/device-link/src/transport.ts
+++ b/packages/device-link/src/transport.ts
@@ -34,6 +34,12 @@ export const MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES = 8 * 1024 * 1024;
 export const TRANSPORT_RETRY_INTERVAL_MS = 2_000;
 /** 连续重发上限；之后保留消息等待重连，避免弱网下无限制造流量。 */
 export const TRANSPORT_MAX_RETRY_ATTEMPTS = 5;
+/**
+ * pending 里 push 帧的最大滞留时长。push 是尽力而为的实时镜像旁路，对端长时间
+ * 未 ACK（典型是离线）后这些帧只剩历史价值；超龄后视为过期，在链路恢复重放前
+ * 与 invoke-result 需要腾位时清扫，避免陈旧 push 独占有界 pending 缓冲。
+ */
+export const TRANSPORT_PENDING_PUSH_MAX_AGE_MS = 5 * 60_000;
 
 const TRANSPORT_MARKER = '__cindyDeviceLinkTransport';
 const TRANSPORT_SKIP_MARKER = '__cindyDeviceLinkTransportSkip';


### PR DESCRIPTION
## 这次改了什么

### 摘要

**Fixes a production deadlock on v0.1.25 where a phone controller permanently shows "电脑端未响应" (desktop unresponsive).** Root cause: while a controller peer is offline, best-effort `push` frames accumulate in the per-peer reliable transport pending buffer (bounded at 64 messages) until it is full. `invoke-result` frames compete for the same buffer with **no priority and no room-making**, so once the buffer is saturated by stale pushes the host can no longer answer any invoke. The controller side treats a real reply as the only signal to close its "device unresponsive" circuit breaker — with every reply stuck behind stale pushes, the breaker never closes and the UI deadlocks.

中文摘要：手机离线期间，桌面端堆积的 push 帧占满 per-peer 可靠传输缓冲；invoke-result（手机端熔断器关闭的唯一凭据）与这些低价值 push 竞争同一缓冲且无优先级，被彻底饿死 → 手机熔断持续 open，一直显示"电脑端未响应"。本 PR 在可靠传输层给 invoke-result 腾位优先权，并在建链时清扫过期 push。

### Incident timeline (from production desktop logs, v0.1.25)

Desktop logs `main-2026-08-01.log` / `main-2026-08-02.log`, peer `cdb54c31` (iPhone):

- From `2026-08-01 06:00:49` (after a desktop restart), while the phone was offline, pushes piled up until the buffer filled — then all day long:
  ```
  forwardPush to cdb54c31 failed (maker:event): DeviceLinkError: reliable transport buffer is full for peer cdb54c31
  ```
  (305 occurrences on 08-01, 276 more before dawn on 08-02.)
- `2026-08-02 02:57:36` — a batch of `dropping expired invoke-result outbox entry` across a dozen channels: invoke-results had been stuck in the dispatch outbox until they expired.
- `03:07:08.769` — `control link opened by cdb54c31 (iPhone)`: phone reconnects; the ~64 stale pushes queued overnight start replaying.
- `03:07:09.019` (250 ms after link open) — the phone's circuit-breaker probe (`local-db:sessions:list`) is answered by the host, but the reply hits `invoke-result send failed ... buffer is full` → `queued invoke-result after local send backpressure`.
- `03:07:17` — the queued reply is finally `flushed` (8 s later, after the replay flood drained).
- `03:07:19.999` — relay reports `DEVICE_OFFLINE`: the phone had already given up. Its breaker stays open forever.

### Fix (inside the reliable transport layer, `packages/device-link`)

1. **Invoke-result priority** (`sendPeerEnvelope`): when the pending buffer is full and the frame is an `invoke-result`, first sweep expired pushes, then evict oldest-first `push` frames from the *head* of the queue until the result fits. `invoke` / `invoke-result` entries are never evicted; push-vs-push behaviour is unchanged (new pushes still get `BACKPRESSURE` when full). Evictions log a WARN.
2. **Sweep on link establishment** (`sendLinkAccept` + `replayPending`): pushes older than `TRANSPORT_PENDING_PUSH_MAX_AGE_MS` (5 min) are swept when a link is (re)opened — before `link-accept` advertises `transportBaseSeq` and before pending replay. A reconnecting controller no longer waits behind a replay flood of stale pushes, and its first probe reply goes out immediately.

**Why head-only eviction is protocol-safe:** the cumulative-ACK stream cannot tolerate seq holes in the middle, but dropping a contiguous prefix advances `getTransportBaseSeq` (smallest live pending seq); every reliable frame (and `link-accept`) carries that `baseSeq`, and the receiver's `advanceReceiveStreamBase` already skips everything below it (same mechanism used for process-restart recovery). Eviction stops at the first non-push entry.

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：production incident on v0.1.25 (logs above); no pre-existing issue.
- 本 PR 包含：`packages/device-link` transport-layer starvation fix + unit tests.
- 明确不包含：desktop `dispatch.ts` outbox changes (its link-open flush + expiry sweep already exist and remain the second line of defense); no protocol/envelope changes.
- 用户可见变化：controller no longer gets stuck on "电脑端未响应" after reconnecting to a host whose push buffer filled while the controller was offline.
- 是否存在 breaking change：无（wire format unchanged; `baseSeq` skipping is an existing receiver capability）.

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
cd packages/device-link && pnpm exec vitest run
结果：Test Files 6 passed (6), Tests 136 passed (136) — includes 3 new tests:
  ✓ 缓冲被未 ACK 的 push 占满时，invoke-result 按最旧优先驱逐 push 腾位，不被饿死
  ✓ 建链即清扫：离线期间过期的 push 不再重放，link-accept 的 baseSeq 直接跳过它们
  ✓ 腾位只驱逐 push：队头是未完成 invoke 时不驱逐，invoke-result 保持原背压语义

cd packages/device-link && pnpm exec tsc --noEmit
结果：exit 0

cd apps/desktop && pnpm exec vitest run src/main/__tests__/deviceLinkDispatch.test.ts \
  src/main/__tests__/deviceLinkHostDispatch.test.ts \
  src/main/device-link/__tests__/dispatchSendSafety.test.ts
结果：Test Files 3 passed (3), Tests 119 passed (119)

pnpm check:dco
结果：DCO check passed: 1 commit signed off
```

### 手工验证

不涉及（transport 状态机行为由 fake-WebSocket 单测覆盖，含事故复现场景：静默断连 → push 滞留 → 重建链）。

### 未执行的验证

Full desktop/mobile e2e suites not run — change is confined to `packages/device-link`; its full unit suite plus the desktop device-link dispatch suites were run as listed above.

## 风险

### 风险分类

- [x] 协议兼容

### 影响与回滚

- 影响范围：per-peer reliable transport send buffer only. Worst case, best-effort pushes older than 5 min (or the oldest pushes, when an invoke-result would otherwise be dropped) are discarded — same class of loss as today's `forwardPush ... buffer is full`, but now biased toward keeping the frames that matter. Receivers already handle `baseSeq` advancement, so no cross-version incompatibility.
- 回滚 / 降级方式：revert this single commit; no data or schema involved.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（行为变化以代码内中文注释与本 PR 说明为准）
- [x] 已确认测试结果或说明未执行原因
