### PR TITLE
fix(desktop): restore Telegram provider negotiation

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -2547,7 +2547,7 @@ describe('Telegram provider capability, binding and prefs', () => {
     });
   });
 
-  it('confirmed 绑定持久化、provider 偏好隔离读写，并可显式解绑', async () => {
+  it('hello 声明完整 Telegram 能力，confirmed 绑定持久化、偏好隔离读写并可显式解绑', async () => {
     const { wss, url } = await startServer();
     const store = memoryStore({ url, enabled: false, telegramEnabled: true });
     const notified: unknown[] = [];
@@ -2569,8 +2569,8 @@ describe('Telegram provider capability, binding and prefs', () => {
     const [sock] = await connPromise;
     const server = collectFrames(sock);
     const hello = await server.waitFor('hello');
-    expect(hello.type === 'hello' ? hello.payload.features : []).toContain(
-      HOOK_FEATURE_PROVIDER_BEHAVIOR,
+    expect(hello.type === 'hello' ? hello.payload.features : []).toEqual(
+      expect.arrayContaining(TELEGRAM_FEATURES),
     );
     sock.send(
       serializeHookMessage(

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -2569,7 +2569,8 @@ describe('Telegram provider capability, binding and prefs', () => {
     const [sock] = await connPromise;
     const server = collectFrames(sock);
     const hello = await server.waitFor('hello');
-    expect(hello.type === 'hello' ? hello.payload.features : []).toEqual(
+    if (hello.type !== 'hello') throw new Error('unreachable');
+    expect(hello.payload.features).toEqual(
       expect.arrayContaining(TELEGRAM_FEATURES),
     );
     sock.send(

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -639,7 +639,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
   /** (multi-team)在途授权状态(添加/重绑 workspace 的 pending 与其终止态)。 */
   let pendingBind: HookPendingBindView | null = null;
 
-  // ── provider-neutral 连接线注册表(目前仅 Telegram; 新 provider 在此追加) ────
+  // ── provider-neutral 连接线注册表(Telegram 与 X; 新 provider 在此追加) ────
 
   // 服务端用客户端 hello.features 判定 provider 协商结果，因此客户端要求
   // 服务端具备的基础能力也必须全部自报；共用一份清单避免双向契约再次漂移。

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -641,21 +641,23 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
 
   // ── provider-neutral 连接线注册表(目前仅 Telegram; 新 provider 在此追加) ────
 
+  // 服务端用客户端 hello.features 判定 provider 协商结果，因此客户端要求
+  // 服务端具备的基础能力也必须全部自报；共用一份清单避免双向契约再次漂移。
+  const telegramProviderBaseFeatures = [
+    HOOK_FEATURE_PROVIDER_BIND,
+    HOOK_FEATURE_PROVIDER_PREFS,
+    HOOK_FEATURE_SESSION_PICKER,
+    HOOK_FEATURE_PROVIDER_TELEGRAM,
+  ] as const;
+
   const telegramConfig: NeutralProviderConfig = {
     provider: 'telegram',
     label: 'Telegram',
     getUrl: getTelegramUrl,
     notConfiguredError: 'Telegram service endpoint is not configured',
-    requiredFeatures: [
-      HOOK_FEATURE_PROVIDER_BIND,
-      HOOK_FEATURE_PROVIDER_PREFS,
-      HOOK_FEATURE_SESSION_PICKER,
-      HOOK_FEATURE_PROVIDER_TELEGRAM,
-    ],
+    requiredFeatures: telegramProviderBaseFeatures,
     helloFeatures: [
-      HOOK_FEATURE_PROVIDER_BIND,
-      HOOK_FEATURE_PROVIDER_PREFS,
-      HOOK_FEATURE_SESSION_PICKER,
+      ...telegramProviderBaseFeatures,
       HOOK_FEATURE_GROUP_RELAY,
       HOOK_FEATURE_GROUP_RELAY_RECIPIENT,
       HOOK_FEATURE_PROVIDER_BEHAVIOR,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Telegram 官方 provider 已连接，但客户端仍无法读取行为设置和群列表的问题。

客户端原先把 `provider:telegram` 列为服务端必需能力，却没有在自己的 `hello.features` 中声明该能力。服务端因此不承认客户端完成 Telegram provider 协商，并丢弃后续偏好与行为请求。现在 Telegram 双向协商共用同一份基础能力清单，避免再次漂移；回归测试同时校验完整 Telegram hello 能力集合。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Telegram 官方 provider 行为设置与群列表读取失败
- 本 PR 包含：补齐客户端 Telegram provider hello 能力声明；补充真实 WebSocket 回归断言
- 明确不包含：服务端、协议 schema、UI 或持久化变更
- 用户可见变化：连接正常时可恢复读取 Telegram 行为设置和群列表
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/hook-control/__tests__/transport-manager.test.ts
结果：PASS，1 file / 93 tests

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：PASS

NODE_OPTIONS="--max-old-space-size=8192 --require=<temporary one-worker shim>" pnpm test:unit -- --workspace-concurrency=1
结果：PASS，所有 required unit workspaces 通过；Desktop 完整 unit suite 以 threads/maxWorkers=1 运行
```

本机在当前主干用 Desktop 默认 8-worker 运行时，Vitest 进程末段两次原生 SIGSEGV，均无测试断言失败；降低进程可见并行度后完整覆盖通过。

### 手工验证

不涉及；双向 hello 协商由真实 loopback WebSocket 测试覆盖。

### 未执行的验证

未连接生产 Telegram 账号做端到端手工验证，避免对线上绑定产生副作用。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Telegram hook-control 握手时的客户端能力声明
- 回滚 / 降级方式：回滚本提交即可；新增声明为既有协议常量，旧服务端可按既有未知能力处理，不改变 payload schema

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需文档变更）
- [x] 已确认测试结果或说明未执行原因