### PR TITLE
fix(desktop): 过滤 Codex 内部模型别名

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
@@ -43,6 +43,53 @@ describe('mapCodexModelsToCatalog', () => {
     expect(out.find((m) => m.id.includes('auto-review'))).toBeUndefined();
   });
 
+  it('cache 即使把内部 ID 标成 list/api:true 也过滤 codex-auto-review', () => {
+    const out = mapCodexModelsToCatalog({
+      models: [
+        {
+          slug: 'codex-auto-review',
+          display_name: 'GPT-5.6-Luna',
+          visibility: 'list',
+          supported_in_api: true,
+          supported_reasoning_levels: [{ effort: 'medium' }],
+        },
+      ],
+    });
+
+    expect(out).toEqual([]);
+  });
+
+  it('真实 gpt-5.6-luna 即使与内部别名同展示名也在 cache/live 两路保留', () => {
+    const cache = mapCodexModelsToCatalog({
+      models: [
+        {
+          slug: 'gpt-5.6-luna',
+          display_name: 'GPT-5.6-Luna',
+          visibility: 'list',
+          supported_in_api: true,
+          supported_reasoning_levels: [{ effort: 'high' }],
+        },
+      ],
+    });
+    const live = mapCodexAppServerModelsToCatalog([
+      {
+        id: 'gpt-5.6-luna',
+        model: 'gpt-5.6-luna',
+        displayName: 'GPT-5.6-Luna',
+        description: '',
+        hidden: false,
+        supportedReasoningEfforts: [{ reasoningEffort: 'high', description: '' }],
+        defaultReasoningEffort: 'high',
+        additionalSpeedTiers: [],
+        serviceTiers: [],
+        isDefault: false,
+      },
+    ] as CodexModelListItem[]);
+
+    expect(cache.map((model) => model.id)).toEqual(['gpt-5.6-luna']);
+    expect(live.map((model) => model.id)).toEqual(['gpt-5.6-luna']);
+  });
+
   it('未来新模型(gpt-5.6)自动纳入并带正确 capability —— 印证"下周出 5.6 零手改"', () => {
     const m56 = mapCodexModelsToCatalog(SAMPLE).find((m) => m.id === 'gpt-5.6');
     expect(m56).toBeDefined();
@@ -116,6 +163,25 @@ describe('mapCodexModelsToCatalog', () => {
 });
 
 describe('mapCodexAppServerModelsToCatalog', () => {
+  it('live 即使把内部 ID 标成 hidden:false 也过滤 codex-auto-review', () => {
+    const out = mapCodexAppServerModelsToCatalog([
+      {
+        id: 'codex-auto-review',
+        model: 'codex-auto-review',
+        displayName: 'GPT-5.6-Luna',
+        description: '',
+        hidden: false,
+        supportedReasoningEfforts: [{ reasoningEffort: 'medium', description: '' }],
+        defaultReasoningEffort: 'medium',
+        additionalSpeedTiers: [],
+        serviceTiers: [],
+        isDefault: false,
+      },
+    ] as CodexModelListItem[]);
+
+    expect(out).toEqual([]);
+  });
+
   it('保留 app-server 顺序、过滤隐藏/重复项并映射 effort 与 fast tier', () => {
     const out = mapCodexAppServerModelsToCatalog([
       {

--- a/apps/desktop/src/main/maker-host/codex-model-discovery.ts
+++ b/apps/desktop/src/main/maker-host/codex-model-discovery.ts
@@ -3,9 +3,8 @@
  * active-catalog 再把同一份快照投影到 Codex 与 Claude bridge,避免两边名称、排序各维护一套。
  *
  * 数据源:codex app-server / CLI 维护的 `<codexHome>/models_cache.json`(与 live 端点
- * `chatgpt.com/backend-api/codex/models` 同结构)。筛选完全依赖后端自带的可见性字段:
- *   visibility === 'list' && supported_in_api === true
- * ——自动挡掉内部 / 隐藏模型(codex-auto-review=hide、gpt-5.3-codex-spark=api:false)。
+ * `chatgpt.com/backend-api/codex/models` 同结构)。筛选同时依赖后端可见性字段与客户端维护的
+ * 内部模型 ID 集合，避免上游把内部别名标成可见时泄漏到用户模型列表。
  *
  * 只读、纯派生。读取失败返回 null(保留上次快照 / 静态兜底),合法空 cache 返回 []。
  * mapper 与 fs 读分离:`mapCodexModelsToCatalog` 是纯函数(单测覆盖),`readCodexDiscoveredModels`
@@ -58,6 +57,13 @@ const CODEX_EFFORTS = new Set(['low', 'medium', 'high', 'xhigh', 'max', 'ultra']
  */
 const DEFAULT_HIDDEN_SLUGS: ReadonlySet<string> = new Set(['gpt-5.4-mini']);
 
+/** Cindy 内部路由专用的 Codex 模型 ID，不应出现在任何用户可见模型目录。 */
+const INTERNAL_CODEX_MODEL_IDS: ReadonlySet<string> = new Set(['codex-auto-review']);
+
+function isInternalCodexModelId(id: string): boolean {
+  return INTERNAL_CODEX_MODEL_IDS.has(id);
+}
+
 function str(v: unknown): string | null {
   return typeof v === 'string' && v.length > 0 ? v : null;
 }
@@ -91,7 +97,7 @@ function sortOrderForPriority(priority: number): number {
 /**
  * codex models_cache 原始 JSON → 规范化的 Codex CatalogModel[]。纯函数。
  *
- * 只收 visibility:'list' && supported_in_api:true 的模型;缺关键字段(slug / efforts)则跳过。
+ * 只收 visibility:'list' && supported_in_api:true 且不在内部 ID 集合的模型；缺 slug 则跳过。
  * sortOrder 由 codex 的 priority 派生到 gpt 分组的一个子带内(纯展示,不影响路由 / 去重)。
  */
 export function mapCodexModelsToCatalog(raw: unknown): CatalogModel[] {
@@ -104,7 +110,7 @@ export function mapCodexModelsToCatalog(raw: unknown): CatalogModel[] {
     if (!m || typeof m !== 'object') continue;
     if (m.visibility !== 'list' || m.supported_in_api !== true) continue;
     const slug = str(m.slug);
-    if (!slug) continue;
+    if (!slug || isInternalCodexModelId(slug)) continue;
     const efforts = Array.isArray(m.supported_reasoning_levels)
       ? m.supported_reasoning_levels
           .map((e) => (e && typeof e === 'object' ? str((e as { effort?: unknown }).effort) : null))
@@ -158,7 +164,15 @@ export function mapCodexAppServerModelsToCatalog(
   const seen = new Set<string>();
   for (const [index, raw] of models.entries()) {
     if (!raw || raw.hidden === true) continue;
-    const slug = str(raw.model) ?? str(raw.id);
+    const modelId = str(raw.model);
+    const itemId = str(raw.id);
+    if (
+      (modelId && isInternalCodexModelId(modelId)) ||
+      (itemId && isInternalCodexModelId(itemId))
+    ) {
+      continue;
+    }
+    const slug = modelId ?? itemId;
     if (!slug || seen.has(slug)) continue;
     seen.add(slug);
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 的磁盘 cache 与实时 app-server 模型清单现在共用一份内部模型 ID 过滤策略，显式排除仅供内部路由使用的 `codex-auto-review`。过滤只依据规范 ID，不依据展示名，因此真实的 `gpt-5.6-luna` 仍会正常进入用户模型列表。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：客户端模型列表泄漏内部 ID `codex-auto-review`
- 本 PR 包含：Desktop Codex cache/live 两条 mapper 的共享内部 ID 过滤；对应回归测试
- 明确不包含：server #292、Registry wire、XD、Pi 底座及其它模型目录改造
- 用户可见变化：内部别名不再以 `GPT-5.6-Luna` 展示名混入模型列表；真实 `gpt-5.6-luna` 保留
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修改 Desktop main 进程的模型目录纯映射逻辑，没有 renderer、布局、交互或文案变化。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexModelDiscovery.test.ts
结果：通过，1 个测试文件 / 16 个测试

pnpm test:unit
结果：通过，全部 required workspace 单元测试通过

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

不涉及：纯 mapper 逻辑由 cache/live 两种协议形状的回归测试覆盖，包括内部 ID 在上游可见字段放行时仍被过滤、真实 Luna 同展示名仍保留。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Codex 动态模型发现结果；macOS / Windows 共用同一纯数据过滤逻辑
- 回滚 / 降级方式：回退本 PR commit 即恢复原行为；不涉及持久化、协议或用户数据

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
