### PR TITLE
fix(mobile): 修复 Android 横屏任务抽屉点击崩溃

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1944,14 +1944,22 @@ export default function SessionScreen() {
   // 抽屉里的导航动作必须等退场动画结束、GestureDetector/Reanimated overlay 真正
   // 卸载后再执行。Android 原生 Screen 换页与该子树卸载同帧存在 native crash 竞态。
   const pendingDrawerNavigationRef = useRef<(() => void) | null>(null);
+  // pending 只能拦住「首击本身就是导航」的连点;遮罩/back/左滑/当前任务先关闭时 pending
+  // 仍为空。closing 从任一关闭入口同步置 true,完整覆盖退场 commit 前的快速二次点击。
+  const sessionListDrawerClosingRef = useRef(false);
   // 非导航关闭的焦点归还必须晚于父级 overlayMounted=false commit:否则按钮仍在
   // no-hide-descendants 子树里,VoiceOver/TalkBack 会忽略聚焦并丢失焦点。
   const returnDrawerFocusAfterCloseRef = useRef(false);
   const sessionListButtonRef = useRef<View>(null);
+  const closeSessionListDrawer = useCallback(() => {
+    if (sessionListDrawerClosingRef.current) return;
+    sessionListDrawerClosingRef.current = true;
+    setSessionListDrawerOpen(false);
+  }, []);
   // 旋转 / 分屏收窄回到窄屏形态时,抽屉没有入口也没有意义,直接关掉。
   useEffect(() => {
-    if (!wideSessionNav.enabled) setSessionListDrawerOpen(false);
-  }, [wideSessionNav.enabled]);
+    if (!wideSessionNav.enabled && sessionListDrawerOverlayMounted) closeSessionListDrawer();
+  }, [closeSessionListDrawer, sessionListDrawerOverlayMounted, wideSessionNav.enabled]);
   // 抽屉打开时由 SessionListDrawer 消费 Android back 并发起关闭;open=false 后该监听会
   // 卸载,但 overlay 仍要退场约 motionDuration.exit。这个窗口临时吞掉 back,避免原生
   // Screen 返回与 GestureDetector/Reanimated 子树卸载再次挤进同一帧。onClosed 提交
@@ -1963,20 +1971,22 @@ export default function SessionScreen() {
   }, [sessionListDrawerOpen, sessionListDrawerOverlayMounted]);
   const openSessionListDrawer = useCallback(() => {
     pendingDrawerNavigationRef.current = null;
+    sessionListDrawerClosingRef.current = false;
     returnDrawerFocusAfterCloseRef.current = false;
     Keyboard.dismiss();
     setSessionListDrawerOverlayMounted(true);
     setSessionListDrawerOpen(true);
   }, []);
-  const closeSessionListDrawer = useCallback(() => setSessionListDrawerOpen(false), []);
   const queueDrawerNavigation = useCallback((action: () => void) => {
-    // 关闭动画期间 overlay 仍拦截点击;首个动作获胜,后续连点不覆盖目的地。
-    if (pendingDrawerNavigationRef.current) return;
+    // closing 覆盖所有关闭来源,包括 pending 为空的纯关闭;首个意图获胜。
+    if (sessionListDrawerClosingRef.current || pendingDrawerNavigationRef.current) return;
+    sessionListDrawerClosingRef.current = true;
     pendingDrawerNavigationRef.current = action;
     setSessionListDrawerOpen(false);
   }, []);
   const handleSessionListDrawerClosed = useCallback(() => {
     const action = pendingDrawerNavigationRef.current;
+    sessionListDrawerClosingRef.current = false;
     if (!action) returnDrawerFocusAfterCloseRef.current = true;
     setSessionListDrawerOverlayMounted(false);
     if (!action) return;
@@ -1994,7 +2004,7 @@ export default function SessionScreen() {
   const handleDrawerSelectSession = useCallback((item: RemoteSessionListItem) => {
     const targetSession = item.session as RemoteSession;
     if (targetSession.id === sessionId) {
-      setSessionListDrawerOpen(false);
+      closeSessionListDrawer();
       return;
     }
     // 可达优先,与首页 openSession 同口径:被认领的 stale 会话优先 canonicalDeviceId,
@@ -2019,7 +2029,7 @@ export default function SessionScreen() {
         },
       });
     });
-  }, [queueDrawerNavigation, router, sessionId, t]);
+  }, [closeSessionListDrawer, queueDrawerNavigation, router, sessionId, t]);
   // 前进导航防连点:快速双击「新建」会把 /sessions/new 压栈两层(返回要退两次),
   // 与首页各入口同一把 guardedPush 锁。
   const guardedPush = useGuardedPush();

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -39,6 +39,7 @@ import {
   AccessibilityInfo,
   Alert,
   AppState,
+  BackHandler,
   Keyboard,
   KeyboardAvoidingView,
   Linking,
@@ -1951,6 +1952,15 @@ export default function SessionScreen() {
   useEffect(() => {
     if (!wideSessionNav.enabled) setSessionListDrawerOpen(false);
   }, [wideSessionNav.enabled]);
+  // 抽屉打开时由 SessionListDrawer 消费 Android back 并发起关闭;open=false 后该监听会
+  // 卸载,但 overlay 仍要退场约 motionDuration.exit。这个窗口临时吞掉 back,避免原生
+  // Screen 返回与 GestureDetector/Reanimated 子树卸载再次挤进同一帧。onClosed 提交
+  // overlayMounted=false 后自动移除,正常返回链(含 useGuardedBack)随即恢复。
+  useEffect(() => {
+    if (Platform.OS !== 'android' || !sessionListDrawerOverlayMounted || sessionListDrawerOpen) return;
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => true);
+    return () => subscription.remove();
+  }, [sessionListDrawerOpen, sessionListDrawerOverlayMounted]);
   const openSessionListDrawer = useCallback(() => {
     pendingDrawerNavigationRef.current = null;
     returnDrawerFocusAfterCloseRef.current = false;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1930,6 +1930,13 @@ export default function SessionScreen() {
     windowWidth: windowDimensions.width,
   }), [windowDimensions.height, windowDimensions.width]);
   const [sessionListDrawerOpen, setSessionListDrawerOpen] = useState(false);
+  // 父级镜像 overlay 的真实存续期:打开时立即 true,退场动画完成 + native 子树卸载后的
+  // onClosed 才 false。它同时保证退场期 TalkBack 背景隔离,以及旋转/收窄退出宽屏时
+  // 不会提前卸载 Drawer 而吞掉 pending 导航。
+  const [sessionListDrawerOverlayMounted, setSessionListDrawerOverlayMounted] = useState(false);
+  // 退出宽屏后 layout.drawerWidth 会变 0;退场期间继续用最后一个有效宽度,避免面板几何跳变。
+  const sessionListDrawerWidthRef = useRef(wideSessionNav.drawerWidth);
+  if (wideSessionNav.enabled) sessionListDrawerWidthRef.current = wideSessionNav.drawerWidth;
   // 抽屉里的导航动作必须等退场动画结束、GestureDetector/Reanimated overlay 真正
   // 卸载后再执行。Android 原生 Screen 换页与该子树卸载同帧存在 native crash 竞态。
   const pendingDrawerNavigationRef = useRef<(() => void) | null>(null);
@@ -1942,6 +1949,7 @@ export default function SessionScreen() {
   const openSessionListDrawer = useCallback(() => {
     pendingDrawerNavigationRef.current = null;
     Keyboard.dismiss();
+    setSessionListDrawerOverlayMounted(true);
     setSessionListDrawerOpen(true);
   }, []);
   const closeSessionListDrawer = useCallback(() => setSessionListDrawerOpen(false), []);
@@ -1952,6 +1960,7 @@ export default function SessionScreen() {
     setSessionListDrawerOpen(false);
   }, []);
   const handleSessionListDrawerClosed = useCallback(() => {
+    setSessionListDrawerOverlayMounted(false);
     const action = pendingDrawerNavigationRef.current;
     if (!action) return false;
     pendingDrawerNavigationRef.current = null;
@@ -7615,9 +7624,9 @@ export default function SessionScreen() {
         // 抽屉开着时把背后内容从读屏树里摘掉:iOS 用 accessibilityElementsHidden
         // (与抽屉侧 accessibilityViewIsModal 配对),Android 用 importantForAccessibility
         // ——后者才对 TalkBack 生效(与 ComposerRichInput 的双平台配对惯例一致)。
-        accessibilityElementsHidden={sessionListDrawerOpen}
+        accessibilityElementsHidden={sessionListDrawerOverlayMounted}
         behavior={nativeShellLayout.keyboardAvoidingBehavior}
-        importantForAccessibility={sessionListDrawerOpen ? 'no-hide-descendants' : 'auto'}
+        importantForAccessibility={sessionListDrawerOverlayMounted ? 'no-hide-descendants' : 'auto'}
         keyboardVerticalOffset={nativeShellLayout.keyboardVerticalOffset}
         style={styles.keyboard}
       >
@@ -8436,9 +8445,10 @@ export default function SessionScreen() {
           </View>
         </View>
       </KeyboardAvoidingView>
-      {wideSessionNav.enabled ? (
+      {wideSessionNav.enabled || sessionListDrawerOverlayMounted ? (
         // 树内 overlay(zIndex 40)盖住顶部 chrome 与底部 composer;树内层叠而非 Modal 的
-        // 取舍见 SessionListDrawer 头注释。
+        // 取舍见 SessionListDrawer 头注释。退出宽屏时也保留到 onClosed,否则退场期旋转/
+        // 收窄会直接卸载组件并吞掉已登记的导航动作。
         <SessionListDrawer
           currentSessionId={sessionId}
           onClose={closeSessionListDrawer}
@@ -8448,7 +8458,7 @@ export default function SessionScreen() {
           onSelectSession={handleDrawerSelectSession}
           open={sessionListDrawerOpen}
           returnFocusRef={sessionListButtonRef}
-          width={wideSessionNav.drawerWidth}
+          width={sessionListDrawerWidthRef.current}
         />
       ) : null}
     </View>

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1930,6 +1930,9 @@ export default function SessionScreen() {
     windowWidth: windowDimensions.width,
   }), [windowDimensions.height, windowDimensions.width]);
   const [sessionListDrawerOpen, setSessionListDrawerOpen] = useState(false);
+  // 抽屉里的导航动作必须等退场动画结束、GestureDetector/Reanimated overlay 真正
+  // 卸载后再执行。Android 原生 Screen 换页与该子树卸载同帧存在 native crash 竞态。
+  const pendingDrawerNavigationRef = useRef<(() => void) | null>(null);
   // 三条杠按钮 ref:抽屉关闭后读屏焦点归还的锚点(SessionListDrawer.returnFocusRef)。
   const sessionListButtonRef = useRef<View>(null);
   // 旋转 / 分屏收窄回到窄屏形态时,抽屉没有入口也没有意义,直接关掉。
@@ -1937,10 +1940,24 @@ export default function SessionScreen() {
     if (!wideSessionNav.enabled) setSessionListDrawerOpen(false);
   }, [wideSessionNav.enabled]);
   const openSessionListDrawer = useCallback(() => {
+    pendingDrawerNavigationRef.current = null;
     Keyboard.dismiss();
     setSessionListDrawerOpen(true);
   }, []);
   const closeSessionListDrawer = useCallback(() => setSessionListDrawerOpen(false), []);
+  const queueDrawerNavigation = useCallback((action: () => void) => {
+    // 关闭动画期间 overlay 仍拦截点击;首个动作获胜,后续连点不覆盖目的地。
+    if (pendingDrawerNavigationRef.current) return;
+    pendingDrawerNavigationRef.current = action;
+    setSessionListDrawerOpen(false);
+  }, []);
+  const handleSessionListDrawerClosed = useCallback(() => {
+    const action = pendingDrawerNavigationRef.current;
+    if (!action) return false;
+    pendingDrawerNavigationRef.current = null;
+    action();
+    return true;
+  }, []);
   const handleDrawerSelectSession = useCallback((item: RemoteSessionListItem) => {
     const targetSession = item.session as RemoteSession;
     if (targetSession.id === sessionId) {
@@ -1958,30 +1975,31 @@ export default function SessionScreen() {
       Alert.alert(t('devices.list.error.sessionDeviceNotFound'));
       return;
     }
-    setSessionListDrawerOpen(false);
     // replace 而非 push:抽屉是「原地切换」语义,栈保持 [主页, 会话],返回手势仍回主页。
-    router.replace({
-      pathname: '/sessions/[sessionId]',
-      params: {
-        deviceId: targetDeviceId,
-        deviceName: targetSession.deviceLinkDeviceName ?? targetDeviceId,
-        sessionId: targetSession.id,
-      },
+    queueDrawerNavigation(() => {
+      router.replace({
+        pathname: '/sessions/[sessionId]',
+        params: {
+          deviceId: targetDeviceId,
+          deviceName: targetSession.deviceLinkDeviceName ?? targetDeviceId,
+          sessionId: targetSession.id,
+        },
+      });
     });
-  }, [router, sessionId, t]);
+  }, [queueDrawerNavigation, router, sessionId, t]);
   // 前进导航防连点:快速双击「新建」会把 /sessions/new 压栈两层(返回要退两次),
   // 与首页各入口同一把 guardedPush 锁。
   const guardedPush = useGuardedPush();
   const handleDrawerNewSession = useCallback(() => {
-    setSessionListDrawerOpen(false);
-    guardedPush({ pathname: '/sessions/new', params: { deviceId, deviceName } });
-  }, [deviceId, deviceName, guardedPush]);
+    queueDrawerNavigation(() => {
+      guardedPush({ pathname: '/sessions/new', params: { deviceId, deviceName } });
+    });
+  }, [deviceId, deviceName, guardedPush, queueDrawerNavigation]);
   // 抽屉「主页」是显式的去处承诺,不是「返回」:从设备详情/自动化页进来时 back 只退一层,
   // 会落在中间页。dismissTo 沿当前栈一路退到根页,栈里没有根页(深链冷启动)则推入。
   const handleDrawerGoHome = useCallback(() => {
-    setSessionListDrawerOpen(false);
-    router.dismissTo('/');
-  }, [router]);
+    queueDrawerNavigation(() => router.dismissTo('/'));
+  }, [queueDrawerNavigation, router]);
   // 聚焦 / 面板打开 / 语音中呈现卡片形态（输入区全宽 + 底部工具排），其余保持单行简洁态。
   // 注意不看 composerLayout.density：有草稿 / 会话运行中未聚焦时也应收回简洁态，
   // 否则「拖回单行退出激活态」永远收不回去。
@@ -8424,6 +8442,7 @@ export default function SessionScreen() {
         <SessionListDrawer
           currentSessionId={sessionId}
           onClose={closeSessionListDrawer}
+          onClosed={handleSessionListDrawerClosed}
           onGoHome={handleDrawerGoHome}
           onNewSession={handleDrawerNewSession}
           onSelectSession={handleDrawerSelectSession}

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -32,10 +32,11 @@ import {
   requestRecordingPermissionsAsync,
   setAudioModeAsync,
 } from 'expo-audio';
-import { useFocusEffect, useLocalSearchParams, useRouter } from 'expo-router';
+import { useFocusEffect, useLocalSearchParams, useNavigation, useRouter } from 'expo-router';
 import { forwardRef, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore, type ReactNode, type RefObject, type SetStateAction } from 'react';
 import {
   ActivityIndicator,
+  AccessibilityInfo,
   Alert,
   AppState,
   Keyboard,
@@ -46,6 +47,7 @@ import {
   ScrollView,
   StyleSheet,
   View,
+  findNodeHandle,
   useWindowDimensions,
   type GestureResponderEvent,
   type LayoutChangeEvent,
@@ -747,6 +749,7 @@ export default function SessionScreen() {
   const visualFocusComposer = MOBILE_VISUAL_MOCK_ENABLED && readRouteParam(params.visualFocusComposer) === '1';
   const visualOpenSearch = MOBILE_VISUAL_MOCK_ENABLED && readRouteParam(params.visualOpenSearch) === '1';
   const visualSearchQuery = MOBILE_VISUAL_MOCK_ENABLED ? readRouteParam(params.visualSearchQuery) : null;
+  const navigation = useNavigation();
   const router = useRouter();
   const auth = useAuth();
   const windowDimensions = useWindowDimensions();
@@ -1940,7 +1943,9 @@ export default function SessionScreen() {
   // 抽屉里的导航动作必须等退场动画结束、GestureDetector/Reanimated overlay 真正
   // 卸载后再执行。Android 原生 Screen 换页与该子树卸载同帧存在 native crash 竞态。
   const pendingDrawerNavigationRef = useRef<(() => void) | null>(null);
-  // 三条杠按钮 ref:抽屉关闭后读屏焦点归还的锚点(SessionListDrawer.returnFocusRef)。
+  // 非导航关闭的焦点归还必须晚于父级 overlayMounted=false commit:否则按钮仍在
+  // no-hide-descendants 子树里,VoiceOver/TalkBack 会忽略聚焦并丢失焦点。
+  const returnDrawerFocusAfterCloseRef = useRef(false);
   const sessionListButtonRef = useRef<View>(null);
   // 旋转 / 分屏收窄回到窄屏形态时,抽屉没有入口也没有意义,直接关掉。
   useEffect(() => {
@@ -1948,6 +1953,7 @@ export default function SessionScreen() {
   }, [wideSessionNav.enabled]);
   const openSessionListDrawer = useCallback(() => {
     pendingDrawerNavigationRef.current = null;
+    returnDrawerFocusAfterCloseRef.current = false;
     Keyboard.dismiss();
     setSessionListDrawerOverlayMounted(true);
     setSessionListDrawerOpen(true);
@@ -1960,13 +1966,21 @@ export default function SessionScreen() {
     setSessionListDrawerOpen(false);
   }, []);
   const handleSessionListDrawerClosed = useCallback(() => {
-    setSessionListDrawerOverlayMounted(false);
     const action = pendingDrawerNavigationRef.current;
-    if (!action) return false;
+    if (!action) returnDrawerFocusAfterCloseRef.current = true;
+    setSessionListDrawerOverlayMounted(false);
+    if (!action) return;
     pendingDrawerNavigationRef.current = null;
     action();
-    return true;
   }, []);
+  useEffect(() => {
+    if (sessionListDrawerOverlayMounted || !returnDrawerFocusAfterCloseRef.current) return;
+    returnDrawerFocusAfterCloseRef.current = false;
+    // 导航型关闭不会登记归还请求;外部导航已让本页失焦时也不抢新屏焦点。
+    if (!navigation.isFocused()) return;
+    const returnNode = sessionListButtonRef.current ? findNodeHandle(sessionListButtonRef.current) : null;
+    if (returnNode != null) AccessibilityInfo.setAccessibilityFocus(returnNode);
+  }, [navigation, sessionListDrawerOverlayMounted]);
   const handleDrawerSelectSession = useCallback((item: RemoteSessionListItem) => {
     const targetSession = item.session as RemoteSession;
     if (targetSession.id === sessionId) {
@@ -8457,7 +8471,6 @@ export default function SessionScreen() {
           onNewSession={handleDrawerNewSession}
           onSelectSession={handleDrawerSelectSession}
           open={sessionListDrawerOpen}
-          returnFocusRef={sessionListButtonRef}
           width={sessionListDrawerWidthRef.current}
         />
       ) : null}

--- a/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
@@ -88,17 +88,23 @@ describe('mobile session header desktop-first surface', () => {
     expect(source).toContain('router.replace({');
     // Android 原生换屏必须等 drawer overlay 完整卸载;三个导航入口共用同一延后队列。
     expect(source).toContain('const pendingDrawerNavigationRef = useRef<(() => void) | null>(null);');
+    expect(source).toContain('const sessionListDrawerClosingRef = useRef(false);');
     expect(source).toContain('const [sessionListDrawerOverlayMounted, setSessionListDrawerOverlayMounted] = useState(false);');
     expect(source).toContain('const queueDrawerNavigation = useCallback((action: () => void) => {');
-    expect(source).toContain('if (pendingDrawerNavigationRef.current) return;');
+    // 纯关闭(遮罩/back/左滑/当前任务)的 pending 仍为空,必须由独立 closing 闸门
+    // 同步锁住约 200ms 退场期;快速二次导航不能登记或改写首次关闭意图。
+    expect(source).toContain('if (sessionListDrawerClosingRef.current || pendingDrawerNavigationRef.current) return;');
+    expect(source).toContain('sessionListDrawerClosingRef.current = true;\n    pendingDrawerNavigationRef.current = action;');
+    expect(source).toContain('const closeSessionListDrawer = useCallback(() => {\n    if (sessionListDrawerClosingRef.current) return;\n    sessionListDrawerClosingRef.current = true;');
+    expect(source).toContain('if (targetSession.id === sessionId) {\n      closeSessionListDrawer();');
     expect(source).toContain('onClosed={handleSessionListDrawerClosed}');
-    expect(source).toContain('const action = pendingDrawerNavigationRef.current;\n    if (!action) returnDrawerFocusAfterCloseRef.current = true;\n    setSessionListDrawerOverlayMounted(false);');
+    expect(source).toContain('const action = pendingDrawerNavigationRef.current;\n    sessionListDrawerClosingRef.current = false;\n    if (!action) returnDrawerFocusAfterCloseRef.current = true;\n    setSessionListDrawerOverlayMounted(false);');
     expect(source).toContain('pendingDrawerNavigationRef.current = null;\n    action();');
     expect(source).toContain('queueDrawerNavigation(() => {\n      router.replace({');
     expect(source).toContain('queueDrawerNavigation(() => {\n      guardedPush({');
     expect(source).toContain("queueDrawerNavigation(() => router.dismissTo('/'));");
     // 旋转 / 分屏收窄回窄屏时抽屉必须自动收起(没有入口的悬空 overlay)。
-    expect(source).toContain('if (!wideSessionNav.enabled) setSessionListDrawerOpen(false);');
+    expect(source).toContain('if (!wideSessionNav.enabled && sessionListDrawerOverlayMounted) closeSessionListDrawer();');
     // Android 退场期(open=false 但 overlay 仍 mounted)必须临时吞掉系统返回;
     // onClosed 解除 mounted 后 effect cleanup 恢复 useGuardedBack 等正常返回链。
     expect(source).toContain("if (Platform.OS !== 'android' || !sessionListDrawerOverlayMounted || sessionListDrawerOpen) return;");

--- a/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
@@ -88,20 +88,28 @@ describe('mobile session header desktop-first surface', () => {
     expect(source).toContain('router.replace({');
     // Android 原生换屏必须等 drawer overlay 完整卸载;三个导航入口共用同一延后队列。
     expect(source).toContain('const pendingDrawerNavigationRef = useRef<(() => void) | null>(null);');
+    expect(source).toContain('const [sessionListDrawerOverlayMounted, setSessionListDrawerOverlayMounted] = useState(false);');
     expect(source).toContain('const queueDrawerNavigation = useCallback((action: () => void) => {');
     expect(source).toContain('if (pendingDrawerNavigationRef.current) return;');
     expect(source).toContain('onClosed={handleSessionListDrawerClosed}');
+    expect(source).toContain('setSessionListDrawerOverlayMounted(false);\n    const action = pendingDrawerNavigationRef.current;');
+    expect(source).toContain('pendingDrawerNavigationRef.current = null;\n    action();\n    return true;');
     expect(source).toContain('queueDrawerNavigation(() => {\n      router.replace({');
     expect(source).toContain('queueDrawerNavigation(() => {\n      guardedPush({');
     expect(source).toContain("queueDrawerNavigation(() => router.dismissTo('/'));");
     // 旋转 / 分屏收窄回窄屏时抽屉必须自动收起(没有入口的悬空 overlay)。
     expect(source).toContain('if (!wideSessionNav.enabled) setSessionListDrawerOpen(false);');
     // 打开抽屉先收键盘(树内 overlay 盖不住键盘)。
-    expect(source).toContain('Keyboard.dismiss();\n    setSessionListDrawerOpen(true);');
+    expect(source).toContain('Keyboard.dismiss();\n    setSessionListDrawerOverlayMounted(true);\n    setSessionListDrawerOpen(true);');
     // 读屏模态语义双平台配对:iOS accessibilityElementsHidden + Android importantForAccessibility
-    // (accessibilityViewIsModal 只对 iOS 生效,安卓优先发布不能漏 TalkBack)。
-    expect(source).toContain('accessibilityElementsHidden={sessionListDrawerOpen}');
-    expect(source).toContain("importantForAccessibility={sessionListDrawerOpen ? 'no-hide-descendants' : 'auto'}");
+    // (accessibilityViewIsModal 只对 iOS 生效,安卓优先发布不能漏 TalkBack);必须覆盖完整退场期。
+    expect(source).toContain('accessibilityElementsHidden={sessionListDrawerOverlayMounted}');
+    expect(source).toContain("importantForAccessibility={sessionListDrawerOverlayMounted ? 'no-hide-descendants' : 'auto'}");
+    // 退场期间旋转/折叠/收窄不能直接卸载 Drawer:保留到 onClosed,三类 pending 导航
+    // 才都能执行;宽屏 layout 失效后 drawerWidth=0,退场继续用最后有效宽度。
+    expect(source).toContain('{wideSessionNav.enabled || sessionListDrawerOverlayMounted ? (');
+    expect(source).toContain('if (wideSessionNav.enabled) sessionListDrawerWidthRef.current = wideSessionNav.drawerWidth;');
+    expect(source).toContain('width={sessionListDrawerWidthRef.current}');
     // 选任务失败路径:校验先于关闭动画——先关再弹 Alert 会让焦点归还抢走弹窗焦点。
     expect(source).toContain("Alert.alert(t('devices.list.error.sessionDeviceNotFound'));\n      return;\n    }\n    // replace");
   });

--- a/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
@@ -92,8 +92,8 @@ describe('mobile session header desktop-first surface', () => {
     expect(source).toContain('const queueDrawerNavigation = useCallback((action: () => void) => {');
     expect(source).toContain('if (pendingDrawerNavigationRef.current) return;');
     expect(source).toContain('onClosed={handleSessionListDrawerClosed}');
-    expect(source).toContain('setSessionListDrawerOverlayMounted(false);\n    const action = pendingDrawerNavigationRef.current;');
-    expect(source).toContain('pendingDrawerNavigationRef.current = null;\n    action();\n    return true;');
+    expect(source).toContain('const action = pendingDrawerNavigationRef.current;\n    if (!action) returnDrawerFocusAfterCloseRef.current = true;\n    setSessionListDrawerOverlayMounted(false);');
+    expect(source).toContain('pendingDrawerNavigationRef.current = null;\n    action();');
     expect(source).toContain('queueDrawerNavigation(() => {\n      router.replace({');
     expect(source).toContain('queueDrawerNavigation(() => {\n      guardedPush({');
     expect(source).toContain("queueDrawerNavigation(() => router.dismissTo('/'));");
@@ -105,6 +105,11 @@ describe('mobile session header desktop-first surface', () => {
     // (accessibilityViewIsModal 只对 iOS 生效,安卓优先发布不能漏 TalkBack);必须覆盖完整退场期。
     expect(source).toContain('accessibilityElementsHidden={sessionListDrawerOverlayMounted}');
     expect(source).toContain("importantForAccessibility={sessionListDrawerOverlayMounted ? 'no-hide-descendants' : 'auto'}");
+    // 非导航关闭的焦点归还必须由父级在背景隔离解除后的 commit effect 执行;
+    // 导航型关闭及页面已失焦时都不能把焦点抢回旧页面。
+    expect(source).toContain('if (sessionListDrawerOverlayMounted || !returnDrawerFocusAfterCloseRef.current) return;');
+    expect(source).toContain('if (!navigation.isFocused()) return;');
+    expect(source).toContain('AccessibilityInfo.setAccessibilityFocus(returnNode)');
     // 退场期间旋转/折叠/收窄不能直接卸载 Drawer:保留到 onClosed,三类 pending 导航
     // 才都能执行;宽屏 layout 失效后 drawerWidth=0,退场继续用最后有效宽度。
     expect(source).toContain('{wideSessionNav.enabled || sessionListDrawerOverlayMounted ? (');

--- a/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
@@ -86,6 +86,14 @@ describe('mobile session header desktop-first surface', () => {
     expect(source).toContain("pathname: '/sessions/[sessionId]'");
     expect(source).toContain('const handleDrawerSelectSession = useCallback((item: RemoteSessionListItem) => {');
     expect(source).toContain('router.replace({');
+    // Android 原生换屏必须等 drawer overlay 完整卸载;三个导航入口共用同一延后队列。
+    expect(source).toContain('const pendingDrawerNavigationRef = useRef<(() => void) | null>(null);');
+    expect(source).toContain('const queueDrawerNavigation = useCallback((action: () => void) => {');
+    expect(source).toContain('if (pendingDrawerNavigationRef.current) return;');
+    expect(source).toContain('onClosed={handleSessionListDrawerClosed}');
+    expect(source).toContain('queueDrawerNavigation(() => {\n      router.replace({');
+    expect(source).toContain('queueDrawerNavigation(() => {\n      guardedPush({');
+    expect(source).toContain("queueDrawerNavigation(() => router.dismissTo('/'));");
     // 旋转 / 分屏收窄回窄屏时抽屉必须自动收起(没有入口的悬空 overlay)。
     expect(source).toContain('if (!wideSessionNav.enabled) setSessionListDrawerOpen(false);');
     // 打开抽屉先收键盘(树内 overlay 盖不住键盘)。
@@ -95,7 +103,7 @@ describe('mobile session header desktop-first surface', () => {
     expect(source).toContain('accessibilityElementsHidden={sessionListDrawerOpen}');
     expect(source).toContain("importantForAccessibility={sessionListDrawerOpen ? 'no-hide-descendants' : 'auto'}");
     // 选任务失败路径:校验先于关闭动画——先关再弹 Alert 会让焦点归还抢走弹窗焦点。
-    expect(source).toContain("Alert.alert(t('devices.list.error.sessionDeviceNotFound'));\n      return;\n    }\n    setSessionListDrawerOpen(false);");
+    expect(source).toContain("Alert.alert(t('devices.list.error.sessionDeviceNotFound'));\n      return;\n    }\n    // replace");
   });
 
   it('keeps pending history access as a lightweight control without message counters', () => {

--- a/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
@@ -99,6 +99,11 @@ describe('mobile session header desktop-first surface', () => {
     expect(source).toContain("queueDrawerNavigation(() => router.dismissTo('/'));");
     // 旋转 / 分屏收窄回窄屏时抽屉必须自动收起(没有入口的悬空 overlay)。
     expect(source).toContain('if (!wideSessionNav.enabled) setSessionListDrawerOpen(false);');
+    // Android 退场期(open=false 但 overlay 仍 mounted)必须临时吞掉系统返回;
+    // onClosed 解除 mounted 后 effect cleanup 恢复 useGuardedBack 等正常返回链。
+    expect(source).toContain("if (Platform.OS !== 'android' || !sessionListDrawerOverlayMounted || sessionListDrawerOpen) return;");
+    expect(source).toContain("BackHandler.addEventListener('hardwareBackPress', () => true)");
+    expect(source).toContain('}, [sessionListDrawerOpen, sessionListDrawerOverlayMounted]);');
     // 打开抽屉先收键盘(树内 overlay 盖不住键盘)。
     expect(source).toContain('Keyboard.dismiss();\n    setSessionListDrawerOverlayMounted(true);\n    setSessionListDrawerOpen(true);');
     // 读屏模态语义双平台配对:iOS accessibilityElementsHidden + Android importantForAccessibility

--- a/apps/mobile/src/__tests__/sessionListDrawer.test.ts
+++ b/apps/mobile/src/__tests__/sessionListDrawer.test.ts
@@ -92,13 +92,15 @@ describe('mobile session list drawer', () => {
     ]) {
       expect(text).toContain(`testID="${testId}"`);
     }
-    expect(text).toContain('accessibilityViewIsModal={open}');
+    expect(text).toContain('accessibilityViewIsModal={mounted}');
     expect(text).toContain("t('home.drawer.closeA11y')");
     // 读屏焦点管理(review #1328):打开移焦到面板首控件,关闭归还三条杠;
     // 导航型关闭(本屏已失焦)不归还,不抢新屏焦点。
     expect(text).toContain('AccessibilityInfo.setAccessibilityFocus(node)');
     expect(text).toContain('AccessibilityInfo.setAccessibilityFocus(returnNode)');
     expect(text).toContain('ref={newSessionButtonRef}');
+    // 导航动作必须等 overlay 的 mounted=false commit 后执行,不能与 Android 原生换屏同帧。
+    expect(text).toContain('if (onClosedRef.current?.() === true) return;');
     expect(text).toContain('if (!navigation.isFocused()) return;');
   });
 });

--- a/apps/mobile/src/__tests__/sessionListDrawer.test.ts
+++ b/apps/mobile/src/__tests__/sessionListDrawer.test.ts
@@ -94,13 +94,12 @@ describe('mobile session list drawer', () => {
     }
     expect(text).toContain('accessibilityViewIsModal={mounted}');
     expect(text).toContain("t('home.drawer.closeA11y')");
-    // 读屏焦点管理(review #1328):打开移焦到面板首控件,关闭归还三条杠;
-    // 导航型关闭(本屏已失焦)不归还,不抢新屏焦点。
+    // 打开时把读屏焦点移到面板首控件;关闭后的背景焦点归还由父级在解除
+    // accessibility 隔离后的 commit effect 负责。
     expect(text).toContain('AccessibilityInfo.setAccessibilityFocus(node)');
-    expect(text).toContain('AccessibilityInfo.setAccessibilityFocus(returnNode)');
     expect(text).toContain('ref={newSessionButtonRef}');
     // 导航动作必须等 overlay 的 mounted=false commit 后执行,不能与 Android 原生换屏同帧。
-    expect(text).toContain('if (onClosedRef.current?.() === true) return;');
-    expect(text).toContain('if (!navigation.isFocused()) return;');
+    expect(text).toContain('onClosedRef.current?.();');
+    expect(text).not.toContain('returnFocusRef');
   });
 });

--- a/apps/mobile/src/session/SessionListDrawer.tsx
+++ b/apps/mobile/src/session/SessionListDrawer.tsx
@@ -6,8 +6,9 @@
  *
  * 结构取舍:
  * - **树内 overlay 而非 RN Modal**:会话页已有多个 sheet Modal,iOS 同级双 Modal
- *   有 present/dismiss 竞态(见 SheetSurface 头注释);树内层叠没有这些约束,选中任务
- *   后可立即导航(replace 卸载整屏,无需等 Modal 关闭动画)。代价是盖不住原生弹层,
+ *   有 present/dismiss 竞态(见 SheetSurface 头注释);树内层叠没有这些约束。导航动作
+ *   仍必须等 overlay 退场并真正卸载后执行:Android 原生 Screen 换页若与
+ *   GestureDetector/Reanimated 子树卸载挤在同一帧存在崩溃竞态。代价是盖不住原生弹层,
  *   但抽屉打开前页面会先收键盘,且其它 sheet 与抽屉互斥(都由页面状态驱动)。
  * - **数据直读全局 remoteSessionStore**:与首页同一份 store(进会话页前已水合,
  *   设备订阅继续推增量),经共享层 buildMobileHomePresentation 复用首页的排序 /
@@ -79,6 +80,7 @@ const DRAWER_CLOSE_VELOCITY = -800;
 export function SessionListDrawer({
   currentSessionId,
   onClose,
+  onClosed,
   onGoHome,
   onNewSession,
   onSelectSession,
@@ -88,6 +90,8 @@ export function SessionListDrawer({
 }: {
   currentSessionId: string;
   onClose(): void;
+  /** 关闭动画完成、overlay 真正卸载后触发;返回 true 表示将导航,此时不归还背景焦点。 */
+  onClosed?(): boolean | void;
   onGoHome(): void;
   onNewSession(): void;
   onSelectSession(item: RemoteSessionListItem): void;
@@ -114,19 +118,27 @@ export function SessionListDrawer({
   // progress 0→1 = 收起→展开;dragX(≤0)是手势拖拽的临时位移,松手后归零或并入 progress。
   const progress = useSharedValue(open ? 1 : 0);
   const dragX = useSharedValue(0);
-  // 关闭收尾统一走这里(动画完成回调 / reduce-motion 直跳两条路径):卸载 overlay 并把
-  // 读屏焦点还给触发钮——三条杠在抽屉打开期间被遮罩挡住,不还焦点会落在任意节点。
+  // 关闭收尾统一走这里(动画完成回调 / reduce-motion 直跳两条路径):先只卸载 overlay。
+  // onClosed 与焦点归还必须等 mounted=false 的 commit 完成,否则导航会和
+  // GestureDetector/Reanimated 子树卸载挤进同一帧(Android 原生 Screen 存在崩溃竞态)。
   const navigation = useNavigation();
   const finishClose = useCallback(() => {
     if (openRef.current) return;
     setMounted(false);
-    // 只有「原地关闭」(本屏仍聚焦)才归还焦点:导航型关闭(新建 push / 深链下
-    // dismissTo 推入主页)收尾时本屏已失焦,把读屏焦点拉回背景页的三条杠会抢走
-    // 新屏焦点。isFocused 是确定性信号,不用枚举关闭原因。
+  }, []);
+  const onClosedRef = useRef(onClosed);
+  onClosedRef.current = onClosed;
+  const wasMountedRef = useRef(mounted);
+  useEffect(() => {
+    const wasMounted = wasMountedRef.current;
+    wasMountedRef.current = mounted;
+    if (!wasMounted || mounted) return;
+    // 父级先消费待执行导航;导航型关闭不把焦点拉回马上要离开的背景页。
+    if (onClosedRef.current?.() === true) return;
     if (!navigation.isFocused()) return;
     const returnNode = returnFocusRef?.current ? findNodeHandle(returnFocusRef.current) : null;
     if (returnNode != null) AccessibilityInfo.setAccessibilityFocus(returnNode);
-  }, [navigation, returnFocusRef]);
+  }, [mounted, navigation, returnFocusRef]);
   // 打开后把读屏焦点移进面板首控件(新建任务):背后内容已按模态摘出读屏树,不移焦
   // VoiceOver/TalkBack 会停在已隐藏的节点上。延到入场动画结束再移,避免读出滑动中的几何。
   const newSessionButtonRef = useRef<View>(null);
@@ -310,7 +322,7 @@ export function SessionListDrawer({
   return (
     <View
       // iOS VoiceOver:抽屉开着时按模态处理,不让焦点跑到被遮住的会话内容上。
-      accessibilityViewIsModal={open}
+      accessibilityViewIsModal={mounted}
       // mounted 期间恒拦截(含 200ms 关闭动画):此时 scrim 仍半透明盖着内容,放行
       // 点击会穿透误触;落在 scrim 上的点击只是幂等地再触发一次 onClose。
       pointerEvents="auto"

--- a/apps/mobile/src/session/SessionListDrawer.tsx
+++ b/apps/mobile/src/session/SessionListDrawer.tsx
@@ -17,7 +17,7 @@
  *   (useReduceMotionEnabled === false 才播)。
  */
 import { House, LoaderCircle, SquarePen } from 'lucide-react-native';
-import { memo, useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   AccessibilityInfo,
   BackHandler,
@@ -37,7 +37,6 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useNavigation } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { Text } from '@/components/AppText';
 import { Gesture, GestureDetector } from '@/platform/gestureHandler';
@@ -85,19 +84,16 @@ export function SessionListDrawer({
   onNewSession,
   onSelectSession,
   open,
-  returnFocusRef,
   width,
 }: {
   currentSessionId: string;
   onClose(): void;
-  /** 关闭动画完成、overlay 真正卸载后触发;返回 true 表示将导航,此时不归还背景焦点。 */
-  onClosed?(): boolean | void;
+  /** 关闭动画完成、overlay 真正卸载后触发。 */
+  onClosed?(): void;
   onGoHome(): void;
   onNewSession(): void;
   onSelectSession(item: RemoteSessionListItem): void;
   open: boolean;
-  /** 关闭后读屏焦点归还的触发钮(左上角三条杠);切任务导航整屏卸载时不消费。 */
-  returnFocusRef?: RefObject<View | null>;
   width: number;
 }) {
   const styles = useThemedStyles(makeStyles);
@@ -119,9 +115,9 @@ export function SessionListDrawer({
   const progress = useSharedValue(open ? 1 : 0);
   const dragX = useSharedValue(0);
   // 关闭收尾统一走这里(动画完成回调 / reduce-motion 直跳两条路径):先只卸载 overlay。
-  // onClosed 与焦点归还必须等 mounted=false 的 commit 完成,否则导航会和
-  // GestureDetector/Reanimated 子树卸载挤进同一帧(Android 原生 Screen 存在崩溃竞态)。
-  const navigation = useNavigation();
+  // onClosed 必须等 mounted=false 的 commit 完成,否则导航会和 GestureDetector/
+  // Reanimated 子树卸载挤进同一帧(Android 原生 Screen 存在崩溃竞态)。背景焦点归还
+  // 则由父级在 accessibility 隔离解除后的 commit effect 中完成。
   const finishClose = useCallback(() => {
     if (openRef.current) return;
     setMounted(false);
@@ -133,12 +129,8 @@ export function SessionListDrawer({
     const wasMounted = wasMountedRef.current;
     wasMountedRef.current = mounted;
     if (!wasMounted || mounted) return;
-    // 父级先消费待执行导航;导航型关闭不把焦点拉回马上要离开的背景页。
-    if (onClosedRef.current?.() === true) return;
-    if (!navigation.isFocused()) return;
-    const returnNode = returnFocusRef?.current ? findNodeHandle(returnFocusRef.current) : null;
-    if (returnNode != null) AccessibilityInfo.setAccessibilityFocus(returnNode);
-  }, [mounted, navigation, returnFocusRef]);
+    onClosedRef.current?.();
+  }, [mounted]);
   // 打开后把读屏焦点移进面板首控件(新建任务):背后内容已按模态摘出读屏树,不移焦
   // VoiceOver/TalkBack 会停在已隐藏的节点上。延到入场动画结束再移,避免读出滑动中的几何。
   const newSessionButtonRef = useRef<View>(null);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Android 横屏宽屏任务抽屉点击任务、新建任务或回主页时可能发生的原生崩溃。

根因是点击处理会在抽屉的 Reanimated 退场动画与 GestureDetector 子树仍挂载时立即触发 Expo Router 换屏，使 Android 原生 Screen 切换和 overlay 卸载挤进同一帧。现在三个导航入口统一先登记目标，等抽屉退场并在 `mounted=false` 的 commit 中真正移除 native overlay 后再导航；关闭期间首个点击获胜，后续连点不会覆盖目的地。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Android 横屏宽屏任务抽屉点击后崩溃的用户反馈
- 本 PR 包含：任务切换、新建任务、回主页三条抽屉导航路径的关闭后导航；关闭期连点去重；导航型关闭的读屏焦点保护；回归源码门
- 明确不包含：抽屉视觉、宽屏断点、导航栈语义、原生依赖或 runtime fingerprint 变更
- 用户可见变化：点击抽屉操作后先完成短退场动画，再进入目标页面；不再在 overlay 卸载期间立即换屏
- 是否存在 breaking change：无

意图契约：目标是消除 Android 横屏抽屉导航与 overlay 卸载的竞态；不改变现有入口和导航目的地。待执行动作在抽屉重新打开时失效，每轮关闭只消费首个动作。完成标准为三条入口统一走关闭后导航、相关回归测试与 Mobile typecheck 通过；Android 真机复测见未执行验证。

### UI 变化

不涉及视觉、布局或文案变化。引用 `docs/design-rules/DESIGN.md` §14.4 动效约束：保留现有 `motionDuration.exit`、`motionEasing.in` 与 reduce-motion 分支，仅把导航动作延后到退场和卸载完成后。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4 动效约束；本 PR 不改视觉、布局或文案，仅保持退场动画完成后再导航。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（全部 required unit workspaces）

pnpm --filter mobile run typecheck
结果：通过

pnpm --dir apps/mobile exec vitest run src/__tests__/sessionListDrawer.test.ts src/__tests__/sessionHeaderDesktopFirst.test.ts src/__tests__/wideSessionNav.test.ts
结果：通过（3 files，19 tests）

git diff --check upstream/main...HEAD
结果：通过
```

### 手工验证

不涉及可见样式变化；已逐项检查任务切换、新建任务、回主页与当前任务原地关闭的代码路径和关闭期连点边界。

### 未执行的验证

未执行 Android 横屏真机/模拟器复测：当前机器没有连接 Android 设备，也没有可用的已启动 Android 模拟器。可执行验证步骤：在 Android 横屏会话页打开左侧任务抽屉，依次验证切换到另一任务、新建任务、回主页以及快速双击不同入口，确认退场后只进入首个目标且应用不崩溃。

Mobile 本地验证位于 branch `android-landscape-drawer-crash`、worktree `/Users/chris/Code/Github/cindy-android-landscape-drawer-crash`；未启动 Metro，因此无 `__DEV__` build label 证据。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：抽屉导航增加一个既有退场动画时长的延迟

### 影响与回滚

- 影响范围：Mobile 宽屏会话页任务抽屉的三个导航入口；iPad 与 Android 共用关闭后导航时序，视觉和目的地不变
- 回滚 / 降级方式：回滚本 PR 可恢复立即导航；不涉及数据、协议、原生依赖、runtime fingerprint 或 migration

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
