### PR TITLE
fix(maker-core): 避免强制退役误广播空闲会话

### DIFF
--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -121,6 +121,8 @@ function extractThreadId(method: string, params: unknown): string | null {
 }
 
 export interface ThreadEventHandlers {
+  /** Host 被永久替换；订阅者按自身是否仍有真实工作决定是否需要用户可见终态。 */
+  hostForcedRetire?: (signal: { reason: string }) => void;
   threadStarted?: (params: ThreadStartedNotification['params']) => void;
   descendantThreadStarted?: (params: ThreadStartedNotification['params']) => void;
   turnStarted?: (params: TurnStartedNotification['params']) => void;
@@ -615,22 +617,29 @@ export class AppServerHost {
   }
 
   /**
-   * 强制收割前把终态 transport error 广播给仍在订阅的 session。
+   * 强制收割前向仍在订阅的 session 发结构化生命周期信号。
    *
-   * retire()/shutdown() 会静默清空 subscribers —— 常规路径(凭证切换/app 退出)由
-   * 上层先 Session.close 收尾,这是对的;但 auth 失效等强制路径会带着 in-flight turn
-   * 直接收割 host,不先叫醒订阅者的话,session 的 isTurnRunning 永远不翻 false,上层
-   * 的输入队列 / Stop 的 queueAbortPending 锁 / 凭证切换 busy 判定全部永久卡死
-   * (2026-07-19 实排:auth app_session_terminated 触发 retire 后会话假 busy 数小时)。
-   * 只广播、不清订阅 —— 紧随其后的 retire() 负责清理。
+   * retire()/shutdown() 会静默清空 subscribers；带着真实工作的订阅者必须先收口，
+   * 否则 isTurnRunning 会永久残留。空闲订阅者只需失效旧 handle，不应把一次内部
+   * host 替换渲染成历史会话的终止错误。
+   * 这里只通知、不清订阅 —— 紧随其后的 retire() 负责清理。
    */
   notifySubscribersOfForcedRetire(reason: string): void {
     if (this.subscribers.size === 0) return;
-    this.logger.warn('forced retire with live subscribers — broadcasting terminal transport error', {
+    this.logger.warn('forced retire with live subscribers — notifying session lifecycles', {
       subscribers: this.subscribers.size,
       reason,
     });
-    this.broadcastTransportErrorToSubscribers(`app-server force-retired: ${reason}`);
+    for (const [threadId, handlers] of this.subscribers) {
+      try {
+        handlers.hostForcedRetire?.({ reason });
+      } catch (e) {
+        this.logger.warn('forced retire handler threw', {
+          threadId,
+          message: (e as Error).message,
+        });
+      }
+    }
   }
 
   // ── 订阅 / 路由 ───────────────────────────────────────────────────────────

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -23,6 +23,7 @@ const { MockCodexTransport, createdTransports } = vi.hoisted(() => {
     static dropModelList = false;
     static dropInitialize = false;
     static beforeThreadStartResponse: ((transport: MockCodexTransport) => Promise<void> | void) | null = null;
+    static beforeTurnStartResponse: ((transport: MockCodexTransport) => Promise<void> | void) | null = null;
     static onCreate: ((transport: MockCodexTransport) => void) | null = null;
 
     readonly lines: string[] = [];
@@ -93,6 +94,14 @@ const { MockCodexTransport, createdTransports } = vi.hoisted(() => {
             modelProvider: 'openai',
             cwd: '/repo',
           },
+        });
+        return;
+      }
+      if (req.method === 'turn/start' && MockCodexTransport.beforeTurnStartResponse) {
+        await MockCodexTransport.beforeTurnStartResponse(this);
+        this.emitLine({
+          id: req.id,
+          result: { turn: { id: `turn-${MockCodexTransport.threadSeq++}` } },
         });
         return;
       }
@@ -235,6 +244,7 @@ beforeEach(() => {
   MockCodexTransport.dropModelList = false;
   MockCodexTransport.dropInitialize = false;
   MockCodexTransport.beforeThreadStartResponse = null;
+  MockCodexTransport.beforeTurnStartResponse = null;
   MockCodexTransport.onCreate = null;
 });
 
@@ -3850,6 +3860,70 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('silently invalidates idle and completed sessions when their shared host is force-retired', async () => {
+    const agent = new CodexAgent(createDeps());
+    const idleHandle = await agent.startSession({
+      sessionId: 'session-forced-retire-idle',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    const completedHandle = await agent.startSession({
+      sessionId: 'session-forced-retire-completed',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    const idleEvents: AgentEvent[] = [];
+    const completedEvents: AgentEvent[] = [];
+    const collectIdle = (async () => {
+      for await (const event of idleHandle.events()) idleEvents.push(event);
+    })();
+    const collectCompleted = (async () => {
+      for await (const event of completedHandle.events()) completedEvents.push(event);
+    })();
+    const transport = createdTransports[0];
+
+    transport.emitMockLine({
+      method: 'turn/started',
+      params: { threadId: 'thread-2', turn: { id: 'turn-before-forced-retire' } },
+    });
+    transport.emitMockLine({
+      method: 'turn/completed',
+      params: {
+        threadId: 'thread-2',
+        turn: { id: 'turn-before-forced-retire', status: 'completed' },
+      },
+    });
+    await waitForExpectation(() => {
+      expect(completedHandle.isTurnRunning?.()).toBe(false);
+      expect(completedEvents.some((event) => event.type === 'done')).toBe(true);
+    });
+
+    await agent.forceDisposeLocalHostForAuthChange('test idle forced retire');
+
+    expect(transport.closed).toBe(true);
+    expect(idleEvents.filter((event) => event.type === 'error')).toEqual([]);
+    expect(completedEvents.filter((event) => event.type === 'error')).toEqual([]);
+    await Promise.all([collectIdle, collectCompleted]);
+    await expect(idleHandle.send({ type: 'user', content: 'use the replacement host' })).rejects.toThrow(
+      /app-server was replaced/,
+    );
+
+    MockCodexTransport.beforeTurnStartResponse = () => undefined;
+    const rebuiltHandle = await agent.startSession({
+      sessionId: 'session-after-forced-retire',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    await rebuiltHandle.send({ type: 'user', content: 'continue after rebuild' });
+    expect(createdTransports).toHaveLength(2);
+    expect(createdTransports[1].lines.some((line) => line.includes('turn/start'))).toBe(true);
+
+    await idleHandle.close();
+    await completedHandle.close();
+    await rebuiltHandle.close();
+    await agent.dispose();
+  });
+
   it('collapses in-flight turn state with a terminal transport error when the local host is force-retired', async () => {
     // 回归 2026-07-19:auth 失效触发 retiring host with active sessions 时,原实现
     // 静默清 subscribers 再杀进程,session 收不到任何终态事件 → isTurnRunning 永久
@@ -3888,6 +3962,63 @@ describe('CodexAgent MCP thread context hooks', () => {
       type: 'status',
       data: expect.objectContaining({ status: 'Done', isRunning: false }),
     });
+    await expect(iterator.next()).resolves.toMatchObject({ done: true });
+
+    await handle.close();
+    await agent.dispose();
+  });
+
+  it('terminally settles a pending turn/start exactly once when its host is force-retired', async () => {
+    const turnStartGate = deferred<void>();
+    MockCodexTransport.beforeTurnStartResponse = () => turnStartGate.promise;
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({
+      sessionId: 'session-forced-retire-pending-turn-start',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    const events: AgentEvent[] = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event);
+    })();
+    const transport = createdTransports[0];
+    const sendPromise = handle.send({ type: 'user', content: 'pending turn start' });
+    await waitForExpectation(() => {
+      expect(transport.lines.some((line) => line.includes('turn/start'))).toBe(true);
+    });
+
+    await agent.forceDisposeLocalHostForAuthChange('test pending turn/start forced retire');
+    turnStartGate.resolve();
+    await sendPromise;
+
+    await waitForExpectation(() => {
+      expect(
+        events.filter(
+          (event) => event.type === 'error'
+            && (event.data as { isTerminal?: unknown }).isTerminal === true,
+        ),
+      ).toHaveLength(1);
+      expect(
+        events.filter(
+          (event) => event.type === 'status'
+            && (event.data as { status?: unknown; isRunning?: unknown }).status === 'Done'
+            && (event.data as { status?: unknown; isRunning?: unknown }).isRunning === false,
+        ),
+      ).toHaveLength(1);
+    });
+    expect(events.find((event) => event.type === 'error')).toMatchObject({
+      type: 'error',
+      data: {
+        isTerminal: true,
+        reason: 'app-server-force-retired',
+      },
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(transport.closed).toBe(true);
+    await collectEvents;
+    await expect(handle.send({ type: 'user', content: 'must rebuild first' })).rejects.toThrow(
+      /app-server was replaced/,
+    );
 
     await handle.close();
     await agent.dispose();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2150,6 +2150,11 @@ export class CodexAgent extends BaseAgent {
       let resolved = false;
 
       subscription = host.subscribeThread(threadId, {
+        hostForcedRetire: ({ reason }) => {
+          if (resolved) return;
+          resolved = true;
+          resolve({ kind: 'error', message: `app-server force-retired: ${reason}` });
+        },
         turnStarted: (params) => {
           currentTurnId = params.turn.id;
         },
@@ -2600,6 +2605,7 @@ export class CodexAgent extends BaseAgent {
     }
 
     let closed = false;
+    let sessionHostForceRetired = false;
     let subscriptionInvalidatedByTransport = false;
     let subscription: ThreadSubscription | null = null;
     let interactionResolver: InteractionResolver | null = null;
@@ -2819,6 +2825,7 @@ export class CodexAgent extends BaseAgent {
     const capturedHostWasRegistered = this.hosts.get(currentHostKey) === host;
     const connectionId = host.getConnectionId();
     const isCurrentHost = (): boolean => {
+      if (sessionHostForceRetired) return false;
       const currentHost = this.hosts.get(currentHostKey);
       if ((this.hostGenerations.get(currentHostKey) ?? 0) !== hostGeneration) return false;
       return capturedHostWasRegistered ? currentHost === host : currentHost === undefined;
@@ -6656,6 +6663,60 @@ export class CodexAgent extends BaseAgent {
 
     // ── subscribeThread: notification 路由 + approval handlers ─────────────
     const handlers: ThreadEventHandlers = {
+      hostForcedRetire: ({ reason }) => {
+        // 先在 handle 内部失效旧 host；retireHostKey 紧接着才会删除共享 map，
+        // 这道本地闸也覆盖同一同步栈里抢跑的下一次 send。
+        sessionHostForceRetired = true;
+        subscriptionInvalidatedByTransport = false;
+
+        const hadPendingWork =
+          isTurnInFlight
+          || isTurnStartPending
+          || overloadRetryPending();
+        if (!hadPendingWork) {
+          log.info('idle Codex session invalidated by forced host retirement', { threadId });
+          eventQueue.end();
+          return;
+        }
+
+        // turn/start 可能尚未返回 id。先把所有在途请求标为已收口并隔离，随后 RPC
+        // reject/迟到 resolve 时复用既有 finally/墓碑路径，不再发第二组终态，也不会
+        // 把一个已向用户报终止的 turn 重新激活。
+        markInFlightStartsTerminallySettled();
+        quarantineAllInFlightStarts();
+        discardOverloadRetry('app-server force-retired');
+        dismissAllPending('app_server_force_retired', 'deny');
+        dismissAllPendingUserInput('transport_error');
+        activeToolContexts.clear();
+        stopActiveRolloutPlanFallback();
+        resetUpstreamIdleForTurnEnd();
+        if (currentTurnId) terminalErroredTurnIds.add(currentTurnId);
+        currentTurnId = null;
+        isTurnInFlight = false;
+        isTurnStartPending = false;
+        currentTurnPlanModeActive = false;
+        pendingTurnStartPlanMode = null;
+
+        eventQueue.push({
+          type: 'error',
+          data: {
+            message: `app-server force-retired: ${reason}`,
+            isTerminal: true,
+            willRetry: false,
+            reason: 'app-server-force-retired',
+          },
+          source: 'codex',
+        });
+        eventQueue.push({
+          type: 'status',
+          data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+          source: 'codex',
+        });
+        // 该 host 已被永久替换，handle 不可能原地恢复。结束内部事件流，让已启动的
+        // Session 走既有 auto-close → Maker lazy create；尚未启动 event loop 的
+        // Session 会在下一次 send 明确失败后 drain 到这里并重建。
+        eventQueue.end();
+      },
       threadStarted: (params) => {
         const sid = params.thread?.id;
         if (sid && sid !== sdkSessionId) sdkSessionId = sid;


### PR DESCRIPTION
## 这次改了什么

### 摘要

共享 Codex app-server 被强制退役时，旧实现会把同一个终止错误广播给所有订阅会话。即使会话早已空闲或完成，界面仍会留下永久红色失败提示；而 `turn/start` 尚未返回时，还可能出现重复终态或无法收口。

本 PR 把 Host 的强制退役改为结构化生命周期信号，并由每个 Session 按自身真实状态收口：

- 空闲或已完成会话静默失效并结束旧事件流，不制造新的失败提示；
- 正在运行、启动中或等待重试的真实工作只收到一次 terminal error 和一次 `Done`；
- 旧 handle 明确失效，后续新 Session 仍沿既有路径重建 Host。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无直接关联；与 #832、#944 涉及的 Codex app-server 生命周期背景相关，但不是同一缺陷。
- 本 PR 包含：Codex 本地 app-server Host 强制退役信号、Session 终态收口，以及空闲/已完成/运行中/`turn/start` pending 回归测试。
- 明确不包含：UI、SQLite、远端 Codex 服务、普通关闭流程、自动更新、发布或其他 Agent provider。
- 用户可见变化：空闲或已完成对话不再因共享 Host 被替换而突然出现 `app-server force-retired` 红色失败；真实进行中的工作仍会明确失败并可由新 Session 重建。
- 是否存在 breaking change：无。变化限于 maker-core 内部生命周期分发。

### UI 变化

不涉及：没有改动 UI 代码、视觉、交互或文案。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts -t force-retired
结果：3 passed，354 skipped

pnpm --filter @cindy/maker-core exec vitest run
结果：75 files passed，2 skipped；1521 tests passed，26 skipped

# 在 packages/maker-core 下
pnpm exec eslint src/agents/codex/index.ts src/agents/codex/app-server/host.ts
结果：通过

pnpm check:dco
结果：1 commit passed（基线 59a9cef6，提交 dc61541e）

git diff --check origin/main...HEAD
结果：通过
```

补充仓库级验证：根测试 runner 为 341 passed / 1 skipped；非 Desktop workspace 测试全部通过。Desktop 的同一组测试在 `maxWorkers=4` 下为 1547 files passed、18910 tests passed、2 skipped。

### 手工验证

不涉及：本 PR 没有构建或安装修改后的 Desktop 应用；生命周期分支由可复现的 fake transport 回归测试覆盖。

### 未执行的验证

- 官方根命令在本机按 Desktop 默认 `maxWorkers=8` 运行时，测试断言未失败，但 Vitest 进程最终触发一次 `SIGSEGV`，因此没有把该次根命令记为通过；降低为 `maxWorkers=4` 后同一 Desktop 测试集全部通过。请以 PR CI 的标准并发结果为最终门禁。
- `@cindy/maker-core` 当前没有独立 `typecheck` script；`pnpm --filter @cindy/maker-core run --if-present typecheck` 正常退出但没有实际检查项。
- `pnpm --filter @cindy/maker-core lint` 在最新 `main` 的未改文件中有 55 个既有 lint 错误；本 PR 改动的两个生产文件已单独通过 ESLint。本次新增测试位于既有超大测试文件中，整文件也受既有错误影响。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Codex app-server 强制退役时的 Session 生命周期收口

### 影响与回滚

- 影响范围：只影响罕见的本地 Codex app-server force-retire 路径；正常 turn、普通 close 和其他 provider 不变。缓存行为不变，没有新增网络调用、阻塞 I/O、定时轮询或事件循环常驻工作。
- 失败语义：空闲/已完成订阅静默失效；运行中、启动中或 overload retry 中的订阅仍失败关闭，并且最多产生一次 terminal error 与一次 `Done`。
- 回滚 / 降级方式：revert 单个提交 `dc61541e` 即可恢复原广播行为；无数据迁移或持久状态清理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次内部缺陷无需用户文档）
- [x] 已确认测试结果或说明未执行原因
