### PR TITLE
fix(desktop): 修复计划胶囊交互与完成态残留

### DIFF
--- a/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreTextDeltaBatching.test.ts
@@ -464,6 +464,48 @@ describe('makerChatStore text delta batching', () => {
     });
   });
 
+  it('refreshes the plan update timestamp when update_plan completes in place', () => {
+    const startedAt = 1_700_000_000_000;
+    vi.setSystemTime(startedAt);
+    onEvent?.({
+      sessionId: SESSION_ID,
+      event: {
+        type: 'tool_use',
+        source: 'codex',
+        data: {
+          toolUseId: 'plan-1',
+          toolName: 'update_plan',
+          input: { plan: [{ step: 'Finish work', status: 'in_progress' }] },
+        },
+      },
+      persistId: 'plan-message-1',
+    });
+
+    vi.setSystemTime(startedAt + 5_000);
+    onEvent?.({
+      sessionId: SESSION_ID,
+      event: {
+        type: 'tool_use',
+        source: 'codex',
+        data: {
+          toolUseId: 'plan-1',
+          toolName: 'update_plan',
+          input: { plan: [{ step: 'Finish work', status: 'completed' }] },
+        },
+      },
+      persistId: 'plan-message-1',
+    });
+
+    const messages = makerChatStore.getSnapshot(SESSION_ID).messages;
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatchObject({
+      clientId: 'plan-message-1',
+      createdAt: new Date(startedAt).toISOString(),
+      planUpdatedAtMs: startedAt + 5_000,
+      toolInput: { plan: [{ step: 'Finish work', status: 'completed' }] },
+    });
+  });
+
   it('flushes pending text before a permission interaction request on the separate IPC channel', () => {
     const snapshots: Array<{ roles: string[]; pendingPermission: string | null }> = [];
     const unsubscribe = makerChatStore.subscribe(SESSION_ID, () => {

--- a/apps/desktop/src/renderer/__tests__/planReviewDoneRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planReviewDoneRace.test.ts
@@ -234,6 +234,7 @@ describe('plan_review 与 done 的时序', () => {
   afterEach(() => {
     makerChatStore.__teardownGlobalListeners();
     makerChatStore.purgeSession(SESSION_ID);
+    vi.restoreAllMocks();
   });
 
   it('codex:done 使用携带的权威快照收口最新结构化计划', () => {
@@ -269,12 +270,22 @@ describe('plan_review 与 done 的时序', () => {
   });
 
   it('codex:成功完成但缺少最终 plan 快照时收口计划卡片', () => {
+    const startedAtMs = 1_700_000_000_000;
+    const completedAtMs = startedAtMs + 5_000;
+    const now = vi.spyOn(Date, 'now').mockReturnValue(startedAtMs);
     makerChatStore.setSessionRuntime(SESSION_ID, { agentKind: 'codex' });
     emitPlanUpdate('codex', ['in_progress', 'pending']);
 
+    now.mockReturnValue(completedAtMs);
     emitDone('codex', undefined, 'turn-1', 'completed');
 
     expect(latestPlanStatuses()).toEqual(['completed', 'completed']);
+    const completedPlan = makerChatStore
+      .getSnapshot(SESSION_ID)
+      .messages.findLast(
+        (message) => message.role === 'tool_use' && message.toolName === 'update_plan',
+      );
+    expect(completedPlan).toMatchObject({ planUpdatedAtMs: completedAtMs });
   });
 
   it('claude:done 不改 Codex update_plan 展示状态', () => {

--- a/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
@@ -5,7 +5,7 @@
  *
  * 交互与形态 1:1 对齐 Codex IDE 扩展:
  *   - 收起态:居中小胶囊 `[进度 icon] Step N / M`,不占整行宽度;
- *   - 鼠标悬停(或点击/Enter)时,完整清单以浮层形式向上展开;移开即收起。
+ *   - 鼠标悬停时临时展开,移开即收起;点击/Enter 后固定展开,再次触发立即收起。
  *     浮层绝对定位(bottom-full),不改变 composer overlay 的实测高度,
  *     消息流不会因 hover 抖动。
  *   - 浮层行:completed 灰(check 圆圈),in_progress 高亮(虚线圆圈 + 旋转),
@@ -30,6 +30,8 @@ import { Spinner } from '@/components/ui/spinner';
 
 export type TodoItem = MessageRenderTodoItem;
 
+type FlyoutOpenMode = 'closed' | 'hover' | 'pinned';
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -48,10 +50,9 @@ export function TodoListCard({
 }) {
   const { t } = useTranslation();
   const flyoutId = useId();
-  const [hovered, setHovered] = useState(false);
-  const [pinnedOpen, setPinnedOpen] = useState(false);
+  const [openMode, setOpenMode] = useState<FlyoutOpenMode>('closed');
   const [renderFlyout, setRenderFlyout] = useState(false);
-  const revealed = hovered || pinnedOpen;
+  const revealed = openMode !== 'closed';
 
   useEffect(() => {
     if (revealed) setRenderFlyout(true);
@@ -65,7 +66,11 @@ export function TodoListCard({
   const activeIndex = todos.findIndex((todo) => todo.status === 'in_progress');
   const pendingIndex = todos.findIndex((todo) => todo.status === 'pending');
   const currentIndex =
-    activeIndex >= 0 ? activeIndex : pendingIndex >= 0 ? pendingIndex : Math.min(completed, total - 1);
+    activeIndex >= 0
+      ? activeIndex
+      : pendingIndex >= 0
+        ? pendingIndex
+        : Math.min(completed, total - 1);
   const currentStep = allDone ? total : currentIndex + 1;
   const hasActive = todos.some((todo) => todo.status === 'in_progress');
   const flyoutMaxWidth =
@@ -77,18 +82,18 @@ export function TodoListCard({
     <div className="flex w-full justify-center">
       <div
         className="relative inline-flex items-center justify-center"
-        onMouseEnter={() => setHovered(true)}
-        onMouseLeave={() => setHovered(false)}
+        onMouseEnter={() => {
+          setOpenMode((current) => (current === 'closed' ? 'hover' : current));
+        }}
+        onMouseLeave={() => {
+          setOpenMode((current) => (current === 'hover' ? 'closed' : current));
+        }}
       >
         {/* Collapsed pill — `[icon] Step N / M`,点击/Enter 也可切换浮层(键盘可达)。 */}
         <button
           type="button"
-          onClick={(event) => {
-            if (event.detail === 0) {
-              setPinnedOpen((prev) => !prev);
-              return;
-            }
-            setPinnedOpen((prev) => !prev);
+          onClick={() => {
+            setOpenMode((current) => (current === 'pinned' ? 'closed' : 'pinned'));
           }}
           aria-controls={flyoutId}
           aria-expanded={revealed}
@@ -102,7 +107,11 @@ export function TodoListCard({
           )}
         >
           {allDone ? (
-            <CircleCheck size={14} strokeWidth={2} className="shrink-0 text-[var(--msg-tool-card-text)]" />
+            <CircleCheck
+              size={14}
+              strokeWidth={2}
+              className="shrink-0 text-[var(--msg-tool-card-text)]"
+            />
           ) : (
             <Spinner
               icon={CircleDashed}
@@ -120,17 +129,16 @@ export function TodoListCard({
         {/* Hover flyout — 完整清单向上浮出;绝对定位不占布局高度,消息流不抖动。 */}
         {renderFlyout && (
           <>
-            <div className="absolute bottom-full left-1/2 h-2 min-w-full -translate-x-1/2" aria-hidden="true" />
+            <div
+              className="absolute bottom-full left-1/2 h-2 min-w-full -translate-x-1/2"
+              aria-hidden="true"
+            />
             <div
               id={flyoutId}
               className={cn(
                 'absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2',
                 'w-max',
                 flyoutMaxWidth === null && 'min-w-[220px] max-w-[min(420px,calc(100vw-32px))]',
-                'origin-bottom overflow-hidden rounded-[12px]',
-                'border border-[var(--msg-tool-card-border)]',
-                'bg-[var(--msg-tool-card-bg)]',
-                revealed ? 'animate-float-in' : 'animate-float-out',
               )}
               style={
                 flyoutMaxWidth === null
@@ -140,49 +148,69 @@ export function TodoListCard({
                       maxWidth: `min(420px, ${flyoutMaxWidth}, calc(100vw - 32px))`,
                     }
               }
-              onAnimationEnd={() => {
-                if (!revealed) setRenderFlyout(false);
-              }}
             >
-              <div className="flex max-h-[280px] flex-col gap-[2px] overflow-y-auto px-[14px] py-[10px]">
-                {todos.map((todo, i) => (
-                  <div
-                    key={i}
-                    className={cn(
-                      'flex h-[30px] items-center gap-[10px]',
-                      todo.status === 'in_progress' && animated && 'animate-pulse',
-                    )}
-                  >
-                    {/* Icon */}
-                    {todo.status === 'completed' && (
-                      <CircleCheck size={18} strokeWidth={1.5} className="shrink-0 text-[var(--msg-tool-card-chevron)]" />
-                    )}
-                    {todo.status === 'in_progress' && (
-                      <Spinner
-                        icon={CircleDashed}
-                        size={18}
-                        strokeWidth={1.5}
-                        spinning={animated}
-                        className="text-[var(--msg-tool-card-text)]"
-                      />
-                    )}
-                    {todo.status === 'pending' && (
-                      <Circle size={18} strokeWidth={1.5} className="shrink-0 text-[var(--msg-tool-card-text)]" />
-                    )}
-
-                    {/* Text — 对齐 Codex:completed 置灰,in_progress 高亮,pending 正常。 */}
-                    <span
+              <div
+                className={cn(
+                  'w-full origin-bottom overflow-hidden rounded-[12px]',
+                  'border border-[var(--msg-tool-card-border)]',
+                  'bg-[var(--msg-tool-card-bg)]',
+                  revealed ? 'animate-float-in' : 'animate-float-out',
+                )}
+                onAnimationEnd={() => {
+                  if (!revealed) setRenderFlyout(false);
+                }}
+              >
+                <div className="flex max-h-[280px] flex-col gap-[2px] overflow-y-auto px-[14px] py-[10px]">
+                  {todos.map((todo, i) => (
+                    <div
+                      key={i}
                       className={cn(
-                        'mt-px truncate text-13',
-                        todo.status === 'completed' && 'font-normal text-[var(--msg-tool-card-chevron)]',
-                        todo.status === 'in_progress' && 'font-semibold text-[var(--msg-tool-card-text)]',
-                        todo.status === 'pending' && 'font-normal text-[var(--msg-tool-card-text)]',
+                        'flex h-[30px] items-center gap-[10px]',
+                        todo.status === 'in_progress' && animated && 'animate-pulse',
                       )}
                     >
-                      {todo.content}
-                    </span>
-                  </div>
-                ))}
+                      {/* Icon */}
+                      {todo.status === 'completed' && (
+                        <CircleCheck
+                          size={18}
+                          strokeWidth={1.5}
+                          className="shrink-0 text-[var(--msg-tool-card-chevron)]"
+                        />
+                      )}
+                      {todo.status === 'in_progress' && (
+                        <Spinner
+                          icon={CircleDashed}
+                          size={18}
+                          strokeWidth={1.5}
+                          spinning={animated}
+                          className="text-[var(--msg-tool-card-text)]"
+                        />
+                      )}
+                      {todo.status === 'pending' && (
+                        <Circle
+                          size={18}
+                          strokeWidth={1.5}
+                          className="shrink-0 text-[var(--msg-tool-card-text)]"
+                        />
+                      )}
+
+                      {/* Text — 对齐 Codex:completed 置灰,in_progress 高亮,pending 正常。 */}
+                      <span
+                        className={cn(
+                          'mt-px truncate text-13',
+                          todo.status === 'completed' &&
+                            'font-normal text-[var(--msg-tool-card-chevron)]',
+                          todo.status === 'in_progress' &&
+                            'font-semibold text-[var(--msg-tool-card-text)]',
+                          todo.status === 'pending' &&
+                            'font-normal text-[var(--msg-tool-card-text)]',
+                        )}
+                      >
+                        {todo.content}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           </>

--- a/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
@@ -150,6 +150,7 @@ export function TodoListCard({
               }
             >
               <div
+                aria-hidden={!revealed}
                 className={cn(
                   'w-full origin-bottom overflow-hidden rounded-[12px]',
                   'border border-[var(--msg-tool-card-border)]',

--- a/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { TodoListCard } from '../TodoListCard';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, values: { current: number; total: number }) =>
+      `Step ${values.current} / ${values.total}`,
+  }),
+}));
+
+const TODOS = [
+  { content: 'Inspect interaction state', status: 'in_progress' as const },
+  { content: 'Verify toggle behavior', status: 'pending' as const },
+];
+
+afterEach(cleanup);
+
+describe('TodoListCard flyout interaction', () => {
+  it('opens transiently on hover and closes when the pointer leaves', () => {
+    render(<TodoListCard todos={TODOS} animated={false} />);
+
+    const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
+    const hoverRegion = trigger.parentElement as HTMLElement;
+
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.mouseEnter(hoverRegion);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.mouseLeave(hoverRegion);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('pins the hover flyout on click and closes it immediately on the second click', () => {
+    render(<TodoListCard todos={TODOS} animated={false} />);
+
+    const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
+    const hoverRegion = trigger.parentElement as HTMLElement;
+
+    fireEvent.mouseEnter(hoverRegion);
+    fireEvent.click(trigger);
+    fireEvent.mouseLeave(hoverRegion);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.mouseEnter(hoverRegion);
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    fireEvent.mouseLeave(hoverRegion);
+    fireEvent.mouseEnter(hoverRegion);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('toggles the pinned flyout for keyboard-generated clicks', () => {
+    render(<TodoListCard todos={TODOS} animated={false} />);
+
+    const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
+
+    fireEvent.click(trigger, { detail: 0 });
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+
+    fireEvent.click(trigger, { detail: 0 });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps centering and entrance animation transforms on separate elements', () => {
+    render(<TodoListCard todos={TODOS} animated={false} />);
+
+    const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
+    const hoverRegion = trigger.parentElement as HTMLElement;
+
+    fireEvent.mouseEnter(hoverRegion);
+
+    const flyoutId = trigger.getAttribute('aria-controls') as string;
+    const positioner = document.getElementById(flyoutId) as HTMLElement;
+    const animatedContent = positioner.firstElementChild as HTMLElement;
+
+    expect(positioner.classList.contains('-translate-x-1/2')).toBe(true);
+    expect(positioner.className).not.toContain('animate-float-');
+    expect(animatedContent.classList.contains('animate-float-in')).toBe(true);
+    expect(animatedContent.classList.contains('-translate-x-1/2')).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
@@ -84,4 +84,24 @@ describe('TodoListCard flyout interaction', () => {
     expect(animatedContent.classList.contains('animate-float-in')).toBe(true);
     expect(animatedContent.classList.contains('-translate-x-1/2')).toBe(false);
   });
+
+  it('hides the flyout from assistive technology while its exit animation remains mounted', () => {
+    render(<TodoListCard todos={TODOS} animated={false} />);
+
+    const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
+    const hoverRegion = trigger.parentElement as HTMLElement;
+
+    fireEvent.mouseEnter(hoverRegion);
+
+    const flyoutId = trigger.getAttribute('aria-controls') as string;
+    const positioner = document.getElementById(flyoutId) as HTMLElement;
+    const animatedContent = positioner.firstElementChild as HTMLElement;
+
+    expect(animatedContent.getAttribute('aria-hidden')).toBe('false');
+
+    fireEvent.mouseLeave(hoverRegion);
+
+    expect(document.getElementById(flyoutId)).toBe(positioner);
+    expect(animatedContent.getAttribute('aria-hidden')).toBe('true');
+  });
 });

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -17,12 +17,23 @@ import type { ChatMessage } from '@/lib/makerChatStore';
 
 const COMPLETED_PLAN_VISIBLE_MS = 2_000;
 
+interface CompletedPlanVisibility {
+  insertionKey: string;
+  deadlineMs: number;
+}
+
+// Session views remount when the user switches sessions. Keep the short completed-plan
+// lifetime outside the component so remounting cannot restart the full two-second window.
+const completedPlanVisibilityBySession = new Map<string, CompletedPlanVisibility>();
+
 export function PinnedPlanPanel({
+  sessionId,
   messages,
   animated,
   width,
   visible = true,
 }: {
+  sessionId: string | null;
   messages: readonly ChatMessage[];
   /** 会话仍在流式时进行中项呼吸/旋转;停止后冻结。 */
   animated: boolean;
@@ -33,30 +44,77 @@ export function PinnedPlanPanel({
 }): React.ReactElement | null {
   const insertion = useMemo(() => findLatestMessageTodoInsertion(messages), [messages]);
   const allDone = Boolean(
-    insertion
-    && insertion.todos.length > 0
-    && insertion.todos.every((todo) => todo.status === 'completed'),
+    insertion &&
+    insertion.todos.length > 0 &&
+    insertion.todos.every((todo) => todo.status === 'completed'),
+  );
+  const visibilityKey = insertion ? (sessionId ?? insertion.key) : null;
+  const cachedVisibility = visibilityKey
+    ? completedPlanVisibilityBySession.get(visibilityKey)
+    : undefined;
+  const completedPlanExpired = Boolean(
+    allDone &&
+    insertion &&
+    cachedVisibility?.insertionKey === insertion.key &&
+    cachedVisibility.deadlineMs <= Date.now(),
   );
   const [hiddenInsertionKey, setHiddenInsertionKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!insertion || !allDone) {
       setHiddenInsertionKey(null);
+      if (insertion && visibilityKey) {
+        const current = completedPlanVisibilityBySession.get(visibilityKey);
+        if (current?.insertionKey === insertion.key) {
+          completedPlanVisibilityBySession.delete(visibilityKey);
+        }
+      }
       return;
     }
 
+    const current = visibilityKey ? completedPlanVisibilityBySession.get(visibilityKey) : undefined;
+    const visibility =
+      current?.insertionKey === insertion.key
+        ? current
+        : {
+            insertionKey: insertion.key,
+            deadlineMs: Date.now() + COMPLETED_PLAN_VISIBLE_MS,
+          };
+    if (visibilityKey && visibility !== current) {
+      completedPlanVisibilityBySession.set(visibilityKey, visibility);
+    }
+
+    const remainingMs = Math.max(0, visibility.deadlineMs - Date.now());
+    if (remainingMs === 0) {
+      setHiddenInsertionKey(insertion.key);
+      return;
+    }
+
+    setHiddenInsertionKey(null);
     const timer = window.setTimeout(() => {
       setHiddenInsertionKey(insertion.key);
-    }, COMPLETED_PLAN_VISIBLE_MS);
+    }, remainingMs);
     return () => window.clearTimeout(timer);
-  }, [allDone, insertion?.key]);
+  }, [allDone, insertion?.key, visibilityKey]);
 
-  if (!visible || !insertion || insertion.todos.length === 0 || hiddenInsertionKey === insertion.key) return null;
+  if (
+    !visible ||
+    !insertion ||
+    insertion.todos.length === 0 ||
+    completedPlanExpired ||
+    hiddenInsertionKey === insertion.key
+  )
+    return null;
 
   return (
     <div className="mb-1.5 max-w-full" style={{ width }}>
       {/* key 按 plan session 锚定:新计划重挂载,浮层/进度从头开始。 */}
-      <TodoListCard key={insertion.key} todos={insertion.todos} animated={animated} maxWidth={width} />
+      <TodoListCard
+        key={insertion.key}
+        todos={insertion.todos}
+        animated={animated}
+        maxWidth={width}
+      />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -39,7 +39,7 @@ export function PinnedPlanPanel({
     insertion.todos.length > 0 &&
     insertion.todos.every((todo) => todo.status === 'completed'),
   );
-  const completedAtMs = Date.parse(insertion?.createdAt ?? '');
+  const completedAtMs = insertion?.updatedAtMs ?? Date.parse(insertion?.createdAt ?? '');
   const persistedCompletionDeadlineMs =
     allDone && Number.isFinite(completedAtMs)
       ? completedAtMs + COMPLETED_PLAN_VISIBLE_MS

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -17,15 +17,6 @@ import type { ChatMessage } from '@/lib/makerChatStore';
 
 const COMPLETED_PLAN_VISIBLE_MS = 2_000;
 
-interface CompletedPlanVisibility {
-  insertionKey: string;
-  deadlineMs: number;
-}
-
-// Session views remount when the user switches sessions. Keep the short completed-plan
-// lifetime outside the component so remounting cannot restart the full two-second window.
-const completedPlanVisibilityBySession = new Map<string, CompletedPlanVisibility>();
-
 export function PinnedPlanPanel({
   sessionId,
   messages,
@@ -48,43 +39,43 @@ export function PinnedPlanPanel({
     insertion.todos.length > 0 &&
     insertion.todos.every((todo) => todo.status === 'completed'),
   );
-  const visibilityKey = insertion ? (sessionId ?? insertion.key) : null;
-  const cachedVisibility = visibilityKey
-    ? completedPlanVisibilityBySession.get(visibilityKey)
-    : undefined;
+  const completedAtMs = Date.parse(insertion?.createdAt ?? '');
+  const persistedCompletionDeadlineMs =
+    allDone && Number.isFinite(completedAtMs)
+      ? completedAtMs + COMPLETED_PLAN_VISIBLE_MS
+      : null;
+  const [fallbackCompletionVisibility, setFallbackCompletionVisibility] = useState<{
+    identity: string;
+    deadlineMs: number;
+  } | null>(null);
+  const completionIdentity = insertion ? `${sessionId ?? 'unknown'}:${insertion.key}` : null;
+  const completionDeadlineMs =
+    persistedCompletionDeadlineMs ??
+    (allDone && fallbackCompletionVisibility?.identity === completionIdentity
+      ? fallbackCompletionVisibility.deadlineMs
+      : null);
   const completedPlanExpired = Boolean(
-    allDone &&
-    insertion &&
-    cachedVisibility?.insertionKey === insertion.key &&
-    cachedVisibility.deadlineMs <= Date.now(),
+    completionDeadlineMs !== null && completionDeadlineMs <= Date.now(),
   );
   const [hiddenInsertionKey, setHiddenInsertionKey] = useState<string | null>(null);
 
   useEffect(() => {
     if (!insertion || !allDone) {
       setHiddenInsertionKey(null);
-      if (insertion && visibilityKey) {
-        const current = completedPlanVisibilityBySession.get(visibilityKey);
-        if (current?.insertionKey === insertion.key) {
-          completedPlanVisibilityBySession.delete(visibilityKey);
-        }
-      }
+      setFallbackCompletionVisibility(null);
       return;
     }
 
-    const current = visibilityKey ? completedPlanVisibilityBySession.get(visibilityKey) : undefined;
-    const visibility =
-      current?.insertionKey === insertion.key
-        ? current
-        : {
-            insertionKey: insertion.key,
-            deadlineMs: Date.now() + COMPLETED_PLAN_VISIBLE_MS,
-          };
-    if (visibilityKey && visibility !== current) {
-      completedPlanVisibilityBySession.set(visibilityKey, visibility);
+    if (completionDeadlineMs === null) {
+      setHiddenInsertionKey(null);
+      setFallbackCompletionVisibility({
+        identity: completionIdentity ?? insertion.key,
+        deadlineMs: Date.now() + COMPLETED_PLAN_VISIBLE_MS,
+      });
+      return;
     }
 
-    const remainingMs = Math.max(0, visibility.deadlineMs - Date.now());
+    const remainingMs = Math.max(0, completionDeadlineMs - Date.now());
     if (remainingMs === 0) {
       setHiddenInsertionKey(insertion.key);
       return;
@@ -95,7 +86,7 @@ export function PinnedPlanPanel({
       setHiddenInsertionKey(insertion.key);
     }, remainingMs);
     return () => window.clearTimeout(timer);
-  }, [allDone, insertion?.key, visibilityKey]);
+  }, [allDone, completionDeadlineMs, completionIdentity, insertion?.key]);
 
   if (
     !visible ||

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -17,6 +17,7 @@ const T0 = 1_700_000_000_000;
 function planMessage(
   status: 'pending' | 'in_progress' | 'completed',
   createdAtMs: number | null = T0,
+  planUpdatedAtMs?: number,
 ): ChatMessage {
   return {
     clientId: 'plan-1',
@@ -26,6 +27,7 @@ function planMessage(
     toolUseId: 'plan:turn-1',
     toolInput: { plan: [{ step: 'Finish work', status }] },
     ...(createdAtMs === null ? {} : { createdAt: new Date(createdAtMs).toISOString() }),
+    ...(planUpdatedAtMs === undefined ? {} : { planUpdatedAtMs }),
   };
 }
 
@@ -117,7 +119,7 @@ describe('PinnedPlanPanel completed plan lifetime', () => {
     view.rerender(
       <PinnedPlanPanel
         sessionId="running-completes"
-        messages={[planMessage('completed', T0 + 5_000)]}
+        messages={[planMessage('completed', T0, T0 + 5_000)]}
         animated={false}
         width={400}
       />,

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -38,7 +38,14 @@ afterEach(() => {
 
 describe('PinnedPlanPanel completed plan lifetime', () => {
   it('keeps a completed plan visible for 2 seconds, then hides it', () => {
-    render(<PinnedPlanPanel messages={[planMessage('completed')]} animated={false} width={400} />);
+    render(
+      <PinnedPlanPanel
+        sessionId="completed-lifetime"
+        messages={[planMessage('completed')]}
+        animated={false}
+        width={400}
+      />,
+    );
 
     expect(screen.queryByTestId('plan-pill')).not.toBeNull();
     act(() => vi.advanceTimersByTime(1_999));
@@ -48,7 +55,14 @@ describe('PinnedPlanPanel completed plan lifetime', () => {
   });
 
   it('does not hide a plan that is still running', () => {
-    render(<PinnedPlanPanel messages={[planMessage('in_progress')]} animated width={400} />);
+    render(
+      <PinnedPlanPanel
+        sessionId="running-plan"
+        messages={[planMessage('in_progress')]}
+        animated
+        width={400}
+      />,
+    );
 
     act(() => vi.advanceTimersByTime(10_000));
     expect(screen.queryByTestId('plan-pill')).not.toBeNull();
@@ -57,30 +71,97 @@ describe('PinnedPlanPanel completed plan lifetime', () => {
   it('stays hidden after an interaction card temporarily hides the panel', () => {
     const completed = planMessage('completed');
     const view = render(
-      <PinnedPlanPanel messages={[completed]} animated={false} width={400} visible />,
+      <PinnedPlanPanel
+        sessionId="interaction-hidden"
+        messages={[completed]}
+        animated={false}
+        width={400}
+        visible
+      />,
     );
 
     act(() => vi.advanceTimersByTime(2_000));
     expect(screen.queryByTestId('plan-pill')).toBeNull();
 
     view.rerender(
-      <PinnedPlanPanel messages={[completed]} animated={false} width={400} visible={false} />,
+      <PinnedPlanPanel
+        sessionId="interaction-hidden"
+        messages={[completed]}
+        animated={false}
+        width={400}
+        visible={false}
+      />,
     );
     view.rerender(
-      <PinnedPlanPanel messages={[completed]} animated={false} width={400} visible />,
+      <PinnedPlanPanel
+        sessionId="interaction-hidden"
+        messages={[completed]}
+        animated={false}
+        width={400}
+        visible
+      />,
     );
     expect(screen.queryByTestId('plan-pill')).toBeNull();
   });
 
   it('starts a fresh 2-second wait when a running plan completes', () => {
     const running = planMessage('in_progress');
-    const view = render(<PinnedPlanPanel messages={[running]} animated width={400} />);
+    const view = render(
+      <PinnedPlanPanel sessionId="running-completes" messages={[running]} animated width={400} />,
+    );
 
     act(() => vi.advanceTimersByTime(5_000));
-    view.rerender(<PinnedPlanPanel messages={[planMessage('completed')]} animated={false} width={400} />);
+    view.rerender(
+      <PinnedPlanPanel
+        sessionId="running-completes"
+        messages={[planMessage('completed')]}
+        animated={false}
+        width={400}
+      />,
+    );
     act(() => vi.advanceTimersByTime(1_999));
     expect(screen.queryByTestId('plan-pill')).not.toBeNull();
     act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('does not restart the completion lifetime after the session view remounts', () => {
+    const completed = planMessage('completed');
+    const view = render(
+      <PinnedPlanPanel
+        sessionId="session-remount"
+        messages={[completed]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(1_000));
+    view.unmount();
+
+    render(
+      <PinnedPlanPanel
+        sessionId="session-remount"
+        messages={[completed]}
+        animated={false}
+        width={400}
+      />,
+    );
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(999));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+
+    cleanup();
+    render(
+      <PinnedPlanPanel
+        sessionId="session-remount"
+        messages={[completed]}
+        animated={false}
+        width={400}
+      />,
+    );
     expect(screen.queryByTestId('plan-pill')).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -14,7 +14,10 @@ vi.mock('@/components/chat/TodoListCard', () => ({
 
 const T0 = 1_700_000_000_000;
 
-function planMessage(status: 'pending' | 'in_progress' | 'completed'): ChatMessage {
+function planMessage(
+  status: 'pending' | 'in_progress' | 'completed',
+  createdAtMs: number | null = T0,
+): ChatMessage {
   return {
     clientId: 'plan-1',
     role: 'tool_use',
@@ -22,7 +25,7 @@ function planMessage(status: 'pending' | 'in_progress' | 'completed'): ChatMessa
     toolName: 'update_plan',
     toolUseId: 'plan:turn-1',
     toolInput: { plan: [{ step: 'Finish work', status }] },
-    createdAt: new Date(T0).toISOString(),
+    ...(createdAtMs === null ? {} : { createdAt: new Date(createdAtMs).toISOString() }),
   };
 }
 
@@ -114,7 +117,7 @@ describe('PinnedPlanPanel completed plan lifetime', () => {
     view.rerender(
       <PinnedPlanPanel
         sessionId="running-completes"
-        messages={[planMessage('completed')]}
+        messages={[planMessage('completed', T0 + 5_000)]}
         animated={false}
         width={400}
       />,
@@ -162,6 +165,36 @@ describe('PinnedPlanPanel completed plan lifetime', () => {
         width={400}
       />,
     );
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('keeps an already-expired historical completion hidden without retaining session state', () => {
+    vi.setSystemTime(T0 + 10_000);
+
+    render(
+      <PinnedPlanPanel
+        sessionId="historical-completion"
+        messages={[planMessage('completed')]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('falls back to a component-local lifetime when the completion timestamp is missing', () => {
+    render(
+      <PinnedPlanPanel
+        sessionId="missing-completion-timestamp"
+        messages={[planMessage('completed', null)]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(2_000));
     expect(screen.queryByTestId('plan-pill')).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3528,6 +3528,7 @@ export function CCAgentSessionView({
                  胶囊的悬停浮层向上展开,会盖住交互卡内容(条件集与下方 ternary
                  的静默判定保持一致)。 */}
               <PinnedPlanPanel
+                sessionId={sessionId ?? null}
                 messages={messages}
                 animated={isStreaming}
                 width={inputWidth}

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -2745,6 +2745,7 @@ export function handleStreamEvent(
             terminalData?.plan,
             terminalTurnId,
             terminalTurnStatus,
+            Date.now(),
            ).messages
          : cleanedMessages;
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -272,6 +272,12 @@ export interface ChatMessage {
   toolName?: string;
   toolInput?: unknown;
   /**
+   * Renderer-local timestamp for the latest in-place `update_plan` payload.
+   * `createdAt` remains the persisted message creation time and must not be
+   * rewritten because it also participates in message ordering.
+   */
+  planUpdatedAtMs?: number;
+  /**
    * 产生这条消息的模型 raw id(读自 agentMeta.model)。对 subagent 子消息而言
    * 即子代理实际跑的模型(如 'claude-haiku-4-5-20251001')。仅 SDK 带 model 的
    * 消息有值。用于在 Agent/Task 工具行上反查并渲染子代理模型 chip。
@@ -2618,6 +2624,7 @@ export function handleStreamEvent(
           ...messages[existingUpdatableToolIdx],
           content: formatToolUseSummary(toolName, input),
           toolInput: input,
+          ...(toolName === 'update_plan' ? { planUpdatedAtMs: Date.now() } : {}),
         };
         return {
           ...finalized,
@@ -2636,6 +2643,7 @@ export function handleStreamEvent(
             toolUseId,
             toolName,
             toolInput: input,
+            ...(toolName === 'update_plan' ? { planUpdatedAtMs: Date.now() } : {}),
             isStreaming: false,
             createdAt: new Date().toISOString(),
             // subagent-model-chip: 透传 SDK model / parent_tool_use_id,让

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -90,6 +90,7 @@ describe('applyCodexPlanSnapshotOnDone', () => {
   });
 
   it('marks the matching plan complete when a successful turn has no final snapshot', () => {
+    const completedAtMs = 1_700_000_005_000;
     const message = planMessage('plan:done', [
       { step: 'Inspect', status: 'in_progress' },
       { step: 'Patch', status: 'pending' },
@@ -99,11 +100,13 @@ describe('applyCodexPlanSnapshotOnDone', () => {
       null,
       'done',
       'completed',
+      completedAtMs,
     );
 
     expect(result.changed).toBe(true);
     expect(result.toolUseId).toBe('plan:done');
     expect(result.messages[0]).toMatchObject({
+      planUpdatedAtMs: completedAtMs,
       toolInput: {
         plan: [
           { step: 'Inspect', status: 'completed' },

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -541,6 +541,7 @@ export function applyCodexPlanSnapshotOnDone<
   snapshot: unknown,
   turnId?: string | null,
   terminalStatus?: unknown,
+  planUpdatedAtMs?: number,
 ): CodexPlanSnapshotApplyResult<TMessage> {
   const authoritativeSnapshot = Array.isArray(snapshot) ? snapshot : null;
   const hasAuthoritativeSnapshot = authoritativeSnapshot !== null;
@@ -588,6 +589,9 @@ export function applyCodexPlanSnapshotOnDone<
     const next = [...messages];
     next[index] = {
       ...message,
+      ...(typeof planUpdatedAtMs === 'number' && Number.isFinite(planUpdatedAtMs)
+        ? { planUpdatedAtMs }
+        : {}),
       ...(message.toolInput !== undefined
         ? { toolInput: { ...input, plan: nextSnapshot } }
         : {}),

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -11,6 +11,8 @@ export interface MessageRenderSourceMessageLike {
   role?: string | null;
   content?: unknown;
   createdAt?: string;
+  /** Renderer-local time of the latest in-place plan payload update. */
+  planUpdatedAtMs?: number;
   toolName?: string | null;
   toolInput?: unknown;
   /** SDK tool-use id — used to link a Task/collab tool-call to its live `agent_task_update`. */
@@ -187,6 +189,7 @@ export interface MessageRenderTodoInsertion {
   key: string;
   todos: MessageRenderTodoItem[];
   createdAt?: string;
+  updatedAtMs?: number;
   source: MessageRenderTodoSource;
 }
 
@@ -467,6 +470,7 @@ export function findMessageTodoInsertions<TMessage extends MessageRenderSourceMe
       key: `${keyPrefix}-${sourceClientId(first)}`,
       todos: session.todos,
       createdAt: messages[session.lastIndex]?.createdAt,
+      updatedAtMs: messages[session.lastIndex]?.planUpdatedAtMs,
       source: session.source,
     });
   }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 计划胶囊的三处关联交互问题：

- 将浮层状态统一为 hover 临时打开、点击固定打开、再次点击立即关闭，避免 hover 与 click 状态叠加后无法关闭。
- 拆分浮层定位层与入场动画层，避免 `translateX(-50%)` 被 `animate-float-in` 的 scale transform 覆盖，确保浮层首帧即水平居中。
- 在 session 维度保留已完成计划的短暂展示截止时间，避免切换 session 后组件重挂载导致 `步骤 5/5` 重新展示 2 秒。
- 增加 TodoListCard 与 PinnedPlanPanel 回归测试，覆盖 hover、鼠标/键盘点击、定位动画分层和 session 重挂载。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户实测反馈（无公开 Issue）
- 本 PR 包含：Desktop composer 上方计划胶囊的打开/关闭、浮层定位、完成态生命周期及回归测试。
- 明确不包含：不改变未完成计划在 Agent 停止或应用重启后继续保留的现行设计；不修改计划数据持久化或状态语义。
- 用户可见变化：二次点击可立即关闭；浮层首次出现即居中；已完成计划切换 session 后不再重新出现。
- 是否存在 breaking change：无。

### UI 变化

- Windows isolated dev sandbox `plan-pill-toggle` 已实机验收；本 PR 未单独上传截图。
- Light 模式已目检；Dark 模式未独立目检。本次未修改颜色，继续使用现有语义 token。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4 Motion & Transitions。继续复用 light overlay 的 `animate-float-in` / `animate-float-out`，并将居中定位 transform 与 scale 动画拆到不同 DOM 层，避免 transform 互相覆盖；交互保持快速、直接且可二次触发关闭。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx src/renderer/components/chat/__tests__/TodoListCard.test.tsx src/renderer/__tests__/controlledBannerPlacement.test.ts src/renderer/__tests__/orcaWorkflowRoute.test.ts
结果：4 个测试文件、46 条测试全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：rebase 到 origin/main a74cec2d 后完整门禁通过，全部 unit workspace 通过。

pnpm check:dco
结果：1 个提交签名检查通过。
```

### 手工验证

- Windows isolated dev sandbox `plan-pill-toggle`。
- 验证 hover 临时展开、点击固定展开、二次点击关闭。
- 验证浮层首帧水平居中，不再先显示在错误位置后回正。
- 验证已完成计划隐藏后切换 session 再返回，不重新显示。
- 确认未完成计划在 Agent 停止或应用重启后继续显示，保持现有产品设计。

### 未执行的验证

- Dark 模式未独立实机目检；本次未修改颜色或主题 token。
- 未执行 Mobile 验证：改动仅涉及 Desktop Renderer。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop Renderer 瞬态交互状态。

### 影响与回滚

- 影响范围：仅 Desktop 计划胶囊的交互、浮层渲染和已完成计划的 session 内展示截止时间；不涉及数据库、协议、权限、凭证或用户数据。
- 回滚 / 降级方式：回退本 PR commit 即恢复原交互与生命周期逻辑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因