### PR TITLE
fix(desktop): 修复导入外部 Codex 会话回写污染源会话 (#789)

### DIFF
--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -7,6 +7,12 @@ import path from 'node:path';
 
 const electronMock = vi.hoisted(() => ({ userData: '' }));
 const dbMock = vi.hoisted(() => ({ current: null as Database.Database | null }));
+// 门禁通过 spawn `codex --version` 取实际 runtime 版本;这里控制解析到的二进制路径与
+// `--version` 输出。path 唯一化避免命中模块内的 binaryPath→version 进程缓存。
+const codexBinMock = vi.hoisted(() => ({
+  path: null as string | null,
+  versionOutput: null as string | null,
+}));
 
 vi.mock('electron', () => ({
   app: {
@@ -29,6 +35,31 @@ vi.mock('../logger.js', () => ({
   }),
 }));
 
+vi.mock('../agent-binaries/index.js', () => ({
+  getReadyBinaryPath: vi.fn((kind: string) => (kind === 'codex' ? codexBinMock.path ?? undefined : undefined)),
+  getCachedBinaryStatus: vi.fn(() => ({
+    binaryReady: !!codexBinMock.path,
+    binaryPath: codexBinMock.path ?? undefined,
+  })),
+  isVettedAgentBinaryPath: vi.fn((_kind: string, candidate: string) => !!codexBinMock.path && candidate === codexBinMock.path),
+}));
+
+vi.mock('node:child_process', async (importActual) => ({
+  ...(await importActual<typeof import('node:child_process')>()),
+  execFile: vi.fn((
+    _bin: string,
+    _args: string[],
+    _opts: unknown,
+    cb: (err: Error | null, stdout: string, stderr: string) => void,
+  ) => {
+    if (codexBinMock.versionOutput === null) {
+      cb(new Error('spawn failed'), '', '');
+      return;
+    }
+    cb(null, `${codexBinMock.versionOutput}\n`, '');
+  }),
+}));
+
 import {
   importExternalCodexSessions,
   importExternalCodexMessagesForSession,
@@ -41,11 +72,6 @@ import { clearCurrentDbClient, setCurrentDbClient } from '../localDb/client/curr
 import type { DbClient } from '../localDb/client/DbClient';
 import * as schema from '../localDb/schema';
 import { tx as runInprocTx } from '../localDb/worker/opHandlers/tx';
-import codexRuntimeManifest from '../../../../../tools/codex/latest.json';
-
-// 门禁比对的「捆绑 runtime 版本」取自这份随包 manifest;测试用它派生「与捆绑版本一致 / 不一致」
-// 的源版本,避免把版本号写死(随版本 bump 自动跟随)。
-const BUNDLED_CODEX_VERSION = (codexRuntimeManifest as { version: string }).version;
 
 const threadId = '019dcd5a-6e54-7960-95e0-aa68117a28d1';
 const execThreadId = '019dcd5a-6e54-7960-95e0-aa68117a28d2';
@@ -1698,8 +1724,28 @@ describe('prepareExternalCodexSessionForResume orphan rollout synthesis', () => 
 
 describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () => {
   const desktopHome = () => path.join(targetUserData, 'codex-home');
-  // 保证与「捆绑版本」确定不同的源版本(不写死版本号,随 manifest bump 跟随)。
-  const MISMATCHED_VERSION = `${BUNDLED_CODEX_VERSION}-mismatch.test`;
+  let codexPathCounter = 0;
+
+  /**
+   * 设定门禁 spawn `codex --version` 得到的实际 runtime 版本。
+   * 传 null 模拟「二进制未就绪 / --version 失败」→ 门禁按「无法确认」不回写。
+   * binaryPath 每次唯一,避开模块内 binaryPath→version 缓存,保证各 case 相互独立。
+   */
+  function setActiveCodexRuntime(version: string | null): void {
+    if (version === null) {
+      codexBinMock.path = null;
+      codexBinMock.versionOutput = null;
+      return;
+    }
+    codexPathCounter += 1;
+    codexBinMock.path = path.join(rootDir, `vetted-codex-${codexPathCounter}`, 'codex');
+    codexBinMock.versionOutput = `codex-cli ${version}`;
+  }
+
+  afterEach(() => {
+    codexBinMock.path = null;
+    codexBinMock.versionOutput = null;
+  });
 
   /** 写一份含 session_meta 首行(带 cli_version)+ 一条消息的 rollout。 */
   function writeRolloutWithCliVersion(file: string, cliVersion: string, body: string): void {
@@ -1722,8 +1768,8 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
 
   /**
    * 建一个「外部会话已导入并在 Cindy 里续过一轮」现场:桌面端有 app-server 新写的 rollout,
-   * 外部源保留原 rollout(带创建它的 runtime cli_version)。门禁比对的是「捆绑 runtime 版本」
-   * (来自随包 manifest)与外部源 cli_version,故桌面端 rollout 自身的版本号无关紧要。
+   * 外部源保留原 rollout(带创建它的 runtime cli_version)。门禁比对的是「实际 runtime 版本」
+   * (spawn --version)与外部源 cli_version,故桌面端 rollout 自身的版本号无关紧要。
    */
   function setupLinkedThread(
     externalCliVersion: string,
@@ -1759,24 +1805,36 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     }
   }
 
-  it('does not overwrite the source ~/.codex rollout when the source version differs from bundled', async () => {
-    const { externalRollout, externalDbPath } = setupLinkedThread(MISMATCHED_VERSION);
+  it('does not overwrite the source ~/.codex rollout when the actual runtime version differs', async () => {
+    setActiveCodexRuntime('0.145.0');
+    const { externalRollout, externalDbPath } = setupLinkedThread('0.146.0-alpha.3.1');
     const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
     const rolloutPathBefore = readThreadRolloutPath(externalDbPath);
 
     await syncExternalCodexSessionFromDesktop(threadId);
 
-    // 源版本与捆绑 runtime 不一致 → 源 rollout 与源 state 都不被改写。
+    // 实际 runtime 与源版本不一致 → 源 rollout 与源 state 都不被改写。
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
     expect(readThreadRolloutPath(externalDbPath)).toBe(rolloutPathBefore);
   });
 
+  it('does not sync back when the runtime version cannot be determined', async () => {
+    setActiveCodexRuntime(null); // 二进制未就绪 / --version 失败 → 安全侧不回写
+    const { externalRollout } = setupLinkedThread('0.145.0');
+    const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
+
+    await syncExternalCodexSessionFromDesktop(threadId);
+
+    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
+  });
+
   it('does not sync back when the source rollout has no parseable cli_version', async () => {
+    setActiveCodexRuntime('0.145.0');
     const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
     const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
     writeRolloutWithCliVersion(
       desktopRollout,
-      BUNDLED_CODEX_VERSION,
+      '0.145.0',
       rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
     );
     // 外部 rollout 首行不是 session_meta(源 cli_version 无从判定)。
@@ -1791,12 +1849,13 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(externalContent);
   });
 
-  it('syncs the desktop rollout back when the source version matches the bundled runtime', async () => {
-    const { externalRollout, desktopRollout } = setupLinkedThread(BUNDLED_CODEX_VERSION);
+  it('syncs the desktop rollout back when the actual runtime version matches the source', async () => {
+    setActiveCodexRuntime('0.145.0');
+    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0');
 
     await syncExternalCodexSessionFromDesktop(threadId);
 
-    // 源版本 = 捆绑 runtime 版本(取自 manifest) → 回写照旧发生,源 rollout 被更新为桌面端内容。
+    // 实际 runtime 版本(spawn --version)= 源版本 → 回写照旧发生,源 rollout 被更新为桌面端内容。
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(fs.readFileSync(desktopRollout, 'utf-8'));
   });
 });

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -7,7 +7,6 @@ import path from 'node:path';
 
 const electronMock = vi.hoisted(() => ({ userData: '' }));
 const dbMock = vi.hoisted(() => ({ current: null as Database.Database | null }));
-const codexBinMock = vi.hoisted(() => ({ path: undefined as string | undefined }));
 
 vi.mock('electron', () => ({
   app: {
@@ -30,10 +29,6 @@ vi.mock('../logger.js', () => ({
   }),
 }));
 
-vi.mock('../agent-binaries/index.js', () => ({
-  getReadyBinaryPath: vi.fn((kind: string) => (kind === 'codex' ? codexBinMock.path : undefined)),
-}));
-
 import {
   importExternalCodexSessions,
   importExternalCodexMessagesForSession,
@@ -46,6 +41,11 @@ import { clearCurrentDbClient, setCurrentDbClient } from '../localDb/client/curr
 import type { DbClient } from '../localDb/client/DbClient';
 import * as schema from '../localDb/schema';
 import { tx as runInprocTx } from '../localDb/worker/opHandlers/tx';
+import codexRuntimeManifest from '../../../../../tools/codex/latest.json';
+
+// 门禁比对的「捆绑 runtime 版本」取自这份随包 manifest;测试用它派生「与捆绑版本一致 / 不一致」
+// 的源版本,避免把版本号写死(随版本 bump 自动跟随)。
+const BUNDLED_CODEX_VERSION = (codexRuntimeManifest as { version: string }).version;
 
 const threadId = '019dcd5a-6e54-7960-95e0-aa68117a28d1';
 const execThreadId = '019dcd5a-6e54-7960-95e0-aa68117a28d2';
@@ -1698,32 +1698,8 @@ describe('prepareExternalCodexSessionForResume orphan rollout synthesis', () => 
 
 describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () => {
   const desktopHome = () => path.join(targetUserData, 'codex-home');
-
-  /**
-   * 把 Cindy 捆绑的 codex runtime 版本设为 version(dev bundle 形态:二进制同级 .version);
-   * 传 null 模拟「二进制未就绪 / 版本无从判定」,getReadyBinaryPath 返回 undefined。
-   */
-  function setBundledCodexVersion(version: string | null): void {
-    if (version === null) {
-      codexBinMock.path = undefined;
-      return;
-    }
-    const binDir = path.join(rootDir, 'codex-bin', 'darwin-arm64');
-    fs.mkdirSync(binDir, { recursive: true });
-    fs.writeFileSync(path.join(binDir, '.version'), `${version}\n`, 'utf-8');
-    codexBinMock.path = path.join(binDir, 'codex');
-  }
-
-  /**
-   * Linux 受管 fallback 布局:二进制在 <root>/bin/codex,.version marker 在上一级 <root>/.version。
-   * 用于验证门禁能读到非同级 marker(#789 review P2)。
-   */
-  function setBundledCodexVersionLinuxFallback(version: string): void {
-    const root = path.join(rootDir, 'agent-runtime', 'codex');
-    fs.mkdirSync(path.join(root, 'bin'), { recursive: true });
-    fs.writeFileSync(path.join(root, '.version'), `${version}\n`, 'utf-8');
-    codexBinMock.path = path.join(root, 'bin', 'codex');
-  }
+  // 保证与「捆绑版本」确定不同的源版本(不写死版本号,随 manifest bump 跟随)。
+  const MISMATCHED_VERSION = `${BUNDLED_CODEX_VERSION}-mismatch.test`;
 
   /** 写一份含 session_meta 首行(带 cli_version)+ 一条消息的 rollout。 */
   function writeRolloutWithCliVersion(file: string, cliVersion: string, body: string): void {
@@ -1747,7 +1723,7 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
   /**
    * 建一个「外部会话已导入并在 Cindy 里续过一轮」现场:桌面端有 app-server 新写的 rollout,
    * 外部源保留原 rollout(带创建它的 runtime cli_version)。门禁比对的是「捆绑 runtime 版本」
-   * 与外部源 cli_version,故桌面端 rollout 自身的版本号无关紧要。
+   * (来自随包 manifest)与外部源 cli_version,故桌面端 rollout 自身的版本号无关紧要。
    */
   function setupLinkedThread(
     externalCliVersion: string,
@@ -1783,40 +1759,24 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     }
   }
 
-  afterEach(() => {
-    codexBinMock.path = undefined;
-  });
-
-  it('does not overwrite the source ~/.codex rollout when the bundled runtime version differs', async () => {
-    setBundledCodexVersion('0.145.0');
-    const { externalRollout, externalDbPath } = setupLinkedThread('0.146.0-alpha.3.1');
+  it('does not overwrite the source ~/.codex rollout when the source version differs from bundled', async () => {
+    const { externalRollout, externalDbPath } = setupLinkedThread(MISMATCHED_VERSION);
     const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
     const rolloutPathBefore = readThreadRolloutPath(externalDbPath);
 
     await syncExternalCodexSessionFromDesktop(threadId);
 
-    // 捆绑 runtime 与源版本不一致 → 源 rollout 与源 state 都不被改写。
+    // 源版本与捆绑 runtime 不一致 → 源 rollout 与源 state 都不被改写。
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
     expect(readThreadRolloutPath(externalDbPath)).toBe(rolloutPathBefore);
   });
 
-  it('does not sync back when the bundled runtime version is unknown', async () => {
-    setBundledCodexVersion(null); // 二进制未就绪 → 拿不到版本 → 安全侧不回写
-    const { externalRollout } = setupLinkedThread('0.145.0');
-    const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
-
-    await syncExternalCodexSessionFromDesktop(threadId);
-
-    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
-  });
-
   it('does not sync back when the source rollout has no parseable cli_version', async () => {
-    setBundledCodexVersion('0.145.0');
     const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
     const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
     writeRolloutWithCliVersion(
       desktopRollout,
-      '0.145.0',
+      BUNDLED_CODEX_VERSION,
       rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
     );
     // 外部 rollout 首行不是 session_meta(源 cli_version 无从判定)。
@@ -1831,25 +1791,12 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(externalContent);
   });
 
-  it('syncs the desktop rollout back when the bundled runtime matches the source version', async () => {
-    setBundledCodexVersion('0.145.0');
-    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0');
+  it('syncs the desktop rollout back when the source version matches the bundled runtime', async () => {
+    const { externalRollout, desktopRollout } = setupLinkedThread(BUNDLED_CODEX_VERSION);
 
     await syncExternalCodexSessionFromDesktop(threadId);
 
-    // 版本一致 → 回写照旧发生,源 rollout 被更新为桌面端内容。
-    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(fs.readFileSync(desktopRollout, 'utf-8'));
-  });
-
-  it('reads the version marker from the Linux managed-fallback layout (bin/ subdir)', async () => {
-    // 二进制在 <root>/bin/codex,.version 在上一级——门禁必须读到、不能误判为版本未知
-    // 而在 Linux 上永久禁用回写(#789 review P2)。
-    setBundledCodexVersionLinuxFallback('0.145.0');
-    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0');
-
-    await syncExternalCodexSessionFromDesktop(threadId);
-
-    // 成功读到上一级 marker、版本一致 → 回写照旧发生。
+    // 源版本 = 捆绑 runtime 版本(取自 manifest) → 回写照旧发生,源 rollout 被更新为桌面端内容。
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(fs.readFileSync(desktopRollout, 'utf-8'));
   });
 });

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -35,6 +35,7 @@ import {
   parseCodexRolloutMessageLine,
   scanExternalCodexSessions,
   prepareExternalCodexSessionForResume,
+  syncExternalCodexSessionFromDesktop,
 } from '../maker-host/codex-local-sessions';
 import { clearCurrentDbClient, setCurrentDbClient } from '../localDb/client/current';
 import type { DbClient } from '../localDb/client/DbClient';
@@ -1687,5 +1688,108 @@ describe('prepareExternalCodexSessionForResume orphan rollout synthesis', () => 
     await prepareExternalCodexSessionForResume(threadId);
 
     expect(fs.existsSync(missingRollout)).toBe(false);
+  });
+});
+
+describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () => {
+  const desktopHome = () => path.join(targetUserData, 'codex-home');
+
+  /** 写一份含 session_meta 首行(带 cli_version)+ 一条消息的 rollout。 */
+  function writeRolloutWithCliVersion(file: string, cliVersion: string, body: string): void {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    const meta = JSON.stringify({
+      timestamp: '2026-07-28T00:00:00.000Z',
+      type: 'session_meta',
+      payload: {
+        id: threadId,
+        session_id: threadId,
+        timestamp: '2026-07-28T00:00:00.000Z',
+        cwd: '/tmp/project',
+        originator: 'codex',
+        cli_version: cliVersion,
+        source: 'cli',
+      },
+    });
+    fs.writeFileSync(file, `${meta}\n${body}\n`, 'utf-8');
+  }
+
+  /**
+   * 建一个「外部会话已导入并在 Cindy 里续过一轮」的链接现场:桌面端与外部各有一份 rollout
+   * (可分别指定写出它的 runtime cli_version)与 threads 行。
+   */
+  function setupLinkedThread(
+    desktopCliVersion: string,
+    externalCliVersion: string,
+  ): { externalRollout: string; externalDbPath: string; desktopRollout: string } {
+    const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
+    const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
+    writeRolloutWithCliVersion(
+      desktopRollout,
+      desktopCliVersion,
+      rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
+    );
+    writeRolloutWithCliVersion(
+      externalRollout,
+      externalCliVersion,
+      rolloutLine('m-external', 'assistant', 'original external', '2026-07-27T00:00:01.000Z'),
+    );
+    const desktopDbPath = createStateDb(desktopHome());
+    insertThread(desktopDbPath, threadId, desktopRollout, { updatedAt: 3_000 });
+    const externalDbPath = createStateDb(externalHome);
+    insertThread(externalDbPath, threadId, externalRollout, { updatedAt: 2_000 });
+    return { externalRollout, externalDbPath, desktopRollout };
+  }
+
+  function readThreadRolloutPath(dbPath: string): string {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      const row = db
+        .prepare('SELECT rollout_path AS rolloutPath FROM threads WHERE id = ?')
+        .get(threadId) as { rolloutPath?: string } | undefined;
+      return row?.rolloutPath ?? '';
+    } finally {
+      db.close();
+    }
+  }
+
+  it('does not overwrite the source ~/.codex rollout when the runtime cli_version differs', async () => {
+    const { externalRollout, externalDbPath } = setupLinkedThread('0.145.0', '0.146.0-alpha.3.1');
+    const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
+    const rolloutPathBefore = readThreadRolloutPath(externalDbPath);
+
+    await syncExternalCodexSessionFromDesktop(threadId);
+
+    // 版本不一致 → 源 rollout 与源 state 都不被改写。
+    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
+    expect(readThreadRolloutPath(externalDbPath)).toBe(rolloutPathBefore);
+  });
+
+  it('does not sync back when the source rollout has no parseable cli_version', async () => {
+    const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
+    const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
+    writeRolloutWithCliVersion(
+      desktopRollout,
+      '0.145.0',
+      rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
+    );
+    // 外部 rollout 首行不是 session_meta(cli_version 无从判定)。
+    fs.mkdirSync(path.dirname(externalRollout), { recursive: true });
+    const externalContent = `${rolloutLine('m-external', 'assistant', 'original external', '2026-07-27T00:00:01.000Z')}\n`;
+    fs.writeFileSync(externalRollout, externalContent, 'utf-8');
+    insertThread(createStateDb(desktopHome()), threadId, desktopRollout, { updatedAt: 3_000 });
+    insertThread(createStateDb(externalHome), threadId, externalRollout, { updatedAt: 2_000 });
+
+    await syncExternalCodexSessionFromDesktop(threadId);
+
+    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(externalContent);
+  });
+
+  it('syncs the desktop rollout back when both runtimes share the same cli_version', async () => {
+    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0', '0.145.0');
+
+    await syncExternalCodexSessionFromDesktop(threadId);
+
+    // 版本一致 → 回写照旧发生,源 rollout 被更新为桌面端内容。
+    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(fs.readFileSync(desktopRollout, 'utf-8'));
   });
 });

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -7,12 +7,6 @@ import path from 'node:path';
 
 const electronMock = vi.hoisted(() => ({ userData: '' }));
 const dbMock = vi.hoisted(() => ({ current: null as Database.Database | null }));
-// 门禁通过 spawn `codex --version` 取实际 runtime 版本;这里控制解析到的二进制路径与
-// `--version` 输出。path 唯一化避免命中模块内的 binaryPath→version 进程缓存。
-const codexBinMock = vi.hoisted(() => ({
-  path: null as string | null,
-  versionOutput: null as string | null,
-}));
 
 vi.mock('electron', () => ({
   app: {
@@ -35,38 +29,12 @@ vi.mock('../logger.js', () => ({
   }),
 }));
 
-vi.mock('../agent-binaries/index.js', () => ({
-  getReadyBinaryPath: vi.fn((kind: string) => (kind === 'codex' ? codexBinMock.path ?? undefined : undefined)),
-  getCachedBinaryStatus: vi.fn(() => ({
-    binaryReady: !!codexBinMock.path,
-    binaryPath: codexBinMock.path ?? undefined,
-  })),
-  isVettedAgentBinaryPath: vi.fn((_kind: string, candidate: string) => !!codexBinMock.path && candidate === codexBinMock.path),
-}));
-
-vi.mock('node:child_process', async (importActual) => ({
-  ...(await importActual<typeof import('node:child_process')>()),
-  execFile: vi.fn((
-    _bin: string,
-    _args: string[],
-    _opts: unknown,
-    cb: (err: Error | null, stdout: string, stderr: string) => void,
-  ) => {
-    if (codexBinMock.versionOutput === null) {
-      cb(new Error('spawn failed'), '', '');
-      return;
-    }
-    cb(null, `${codexBinMock.versionOutput}\n`, '');
-  }),
-}));
-
 import {
   importExternalCodexSessions,
   importExternalCodexMessagesForSession,
   parseCodexRolloutMessageLine,
   scanExternalCodexSessions,
   prepareExternalCodexSessionForResume,
-  syncExternalCodexSessionFromDesktop,
 } from '../maker-host/codex-local-sessions';
 import { clearCurrentDbClient, setCurrentDbClient } from '../localDb/client/current';
 import type { DbClient } from '../localDb/client/DbClient';
@@ -1387,7 +1355,7 @@ describe('prepareExternalCodexSessionForResume orphan rollout synthesis', () => 
     expect(fs.readFileSync(targetRow.rolloutPath, 'utf-8')).toBe('LEGACY_ROLLOUT');
   });
 
-  it('keeps an explicitly configured external CODEX_HOME linked instead of adopting it', async () => {
+  it('adopts an explicitly configured external CODEX_HOME into a private copy (never links the source) (#789)', async () => {
     const sourceRollout = path.join(
       externalHome,
       'sessions',
@@ -1395,21 +1363,23 @@ describe('prepareExternalCodexSessionForResume orphan rollout synthesis', () => 
     );
     const sourceDbPath = createStateDb(externalHome);
     fs.mkdirSync(path.dirname(sourceRollout), { recursive: true });
-    fs.writeFileSync(sourceRollout, 'LINKED_EXTERNAL_ROLLOUT');
+    fs.writeFileSync(sourceRollout, 'EXTERNAL_ROLLOUT');
     insertThread(sourceDbPath, threadId, sourceRollout, { updatedAt: 2_000 });
     const targetDbPath = createStateDb(desktopHome());
 
     await prepareExternalCodexSessionForResume(threadId);
 
+    const adoptedRollout = path.join(desktopHome(), 'sessions', path.basename(sourceRollout));
     const targetDb = new Database(targetDbPath, { readonly: true });
     const targetRow = targetDb
       .prepare('SELECT rollout_path AS rolloutPath FROM threads WHERE id = ?')
       .get(threadId) as { rolloutPath: string };
     targetDb.close();
-    expect(targetRow.rolloutPath).toBe(sourceRollout);
-    expect(fs.existsSync(path.join(desktopHome(), 'sessions', path.basename(sourceRollout)))).toBe(
-      false,
-    );
+    // 方案 A:desktop state 指向私有副本,而非源 rollout;副本落盘、内容与源一致。
+    expect(targetRow.rolloutPath).toBe(adoptedRollout);
+    expect(fs.readFileSync(adoptedRollout, 'utf-8')).toBe('EXTERNAL_ROLLOUT');
+    // 源 rollout 原样不动——不再有任何回写通道。
+    expect(fs.readFileSync(sourceRollout, 'utf-8')).toBe('EXTERNAL_ROLLOUT');
   });
 
   it('synthesizes into the current HOME when legacy state survives but its rollout is missing', async () => {
@@ -1719,143 +1689,5 @@ describe('prepareExternalCodexSessionForResume orphan rollout synthesis', () => 
     await prepareExternalCodexSessionForResume(threadId);
 
     expect(fs.existsSync(missingRollout)).toBe(false);
-  });
-});
-
-describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () => {
-  const desktopHome = () => path.join(targetUserData, 'codex-home');
-  let codexPathCounter = 0;
-
-  /**
-   * 设定门禁 spawn `codex --version` 得到的实际 runtime 版本。
-   * 传 null 模拟「二进制未就绪 / --version 失败」→ 门禁按「无法确认」不回写。
-   * binaryPath 每次唯一,避开模块内 binaryPath→version 缓存,保证各 case 相互独立。
-   */
-  function setActiveCodexRuntime(version: string | null): void {
-    if (version === null) {
-      codexBinMock.path = null;
-      codexBinMock.versionOutput = null;
-      return;
-    }
-    codexPathCounter += 1;
-    codexBinMock.path = path.join(rootDir, `vetted-codex-${codexPathCounter}`, 'codex');
-    codexBinMock.versionOutput = `codex-cli ${version}`;
-  }
-
-  afterEach(() => {
-    codexBinMock.path = null;
-    codexBinMock.versionOutput = null;
-  });
-
-  /** 写一份含 session_meta 首行(带 cli_version)+ 一条消息的 rollout。 */
-  function writeRolloutWithCliVersion(file: string, cliVersion: string, body: string): void {
-    fs.mkdirSync(path.dirname(file), { recursive: true });
-    const meta = JSON.stringify({
-      timestamp: '2026-07-28T00:00:00.000Z',
-      type: 'session_meta',
-      payload: {
-        id: threadId,
-        session_id: threadId,
-        timestamp: '2026-07-28T00:00:00.000Z',
-        cwd: '/tmp/project',
-        originator: 'codex',
-        cli_version: cliVersion,
-        source: 'cli',
-      },
-    });
-    fs.writeFileSync(file, `${meta}\n${body}\n`, 'utf-8');
-  }
-
-  /**
-   * 建一个「外部会话已导入并在 Cindy 里续过一轮」现场:桌面端有 app-server 新写的 rollout,
-   * 外部源保留原 rollout(带创建它的 runtime cli_version)。门禁比对的是「实际 runtime 版本」
-   * (spawn --version)与外部源 cli_version,故桌面端 rollout 自身的版本号无关紧要。
-   */
-  function setupLinkedThread(
-    externalCliVersion: string,
-  ): { externalRollout: string; externalDbPath: string; desktopRollout: string } {
-    const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
-    const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
-    writeRolloutWithCliVersion(
-      desktopRollout,
-      externalCliVersion,
-      rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
-    );
-    writeRolloutWithCliVersion(
-      externalRollout,
-      externalCliVersion,
-      rolloutLine('m-external', 'assistant', 'original external', '2026-07-27T00:00:01.000Z'),
-    );
-    const desktopDbPath = createStateDb(desktopHome());
-    insertThread(desktopDbPath, threadId, desktopRollout, { updatedAt: 3_000 });
-    const externalDbPath = createStateDb(externalHome);
-    insertThread(externalDbPath, threadId, externalRollout, { updatedAt: 2_000 });
-    return { externalRollout, externalDbPath, desktopRollout };
-  }
-
-  function readThreadRolloutPath(dbPath: string): string {
-    const db = new Database(dbPath, { readonly: true });
-    try {
-      const row = db
-        .prepare('SELECT rollout_path AS rolloutPath FROM threads WHERE id = ?')
-        .get(threadId) as { rolloutPath?: string } | undefined;
-      return row?.rolloutPath ?? '';
-    } finally {
-      db.close();
-    }
-  }
-
-  it('does not overwrite the source ~/.codex rollout when the actual runtime version differs', async () => {
-    setActiveCodexRuntime('0.145.0');
-    const { externalRollout, externalDbPath } = setupLinkedThread('0.146.0-alpha.3.1');
-    const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
-    const rolloutPathBefore = readThreadRolloutPath(externalDbPath);
-
-    await syncExternalCodexSessionFromDesktop(threadId);
-
-    // 实际 runtime 与源版本不一致 → 源 rollout 与源 state 都不被改写。
-    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
-    expect(readThreadRolloutPath(externalDbPath)).toBe(rolloutPathBefore);
-  });
-
-  it('does not sync back when the runtime version cannot be determined', async () => {
-    setActiveCodexRuntime(null); // 二进制未就绪 / --version 失败 → 安全侧不回写
-    const { externalRollout } = setupLinkedThread('0.145.0');
-    const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
-
-    await syncExternalCodexSessionFromDesktop(threadId);
-
-    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
-  });
-
-  it('does not sync back when the source rollout has no parseable cli_version', async () => {
-    setActiveCodexRuntime('0.145.0');
-    const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
-    const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
-    writeRolloutWithCliVersion(
-      desktopRollout,
-      '0.145.0',
-      rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
-    );
-    // 外部 rollout 首行不是 session_meta(源 cli_version 无从判定)。
-    fs.mkdirSync(path.dirname(externalRollout), { recursive: true });
-    const externalContent = `${rolloutLine('m-external', 'assistant', 'original external', '2026-07-27T00:00:01.000Z')}\n`;
-    fs.writeFileSync(externalRollout, externalContent, 'utf-8');
-    insertThread(createStateDb(desktopHome()), threadId, desktopRollout, { updatedAt: 3_000 });
-    insertThread(createStateDb(externalHome), threadId, externalRollout, { updatedAt: 2_000 });
-
-    await syncExternalCodexSessionFromDesktop(threadId);
-
-    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(externalContent);
-  });
-
-  it('syncs the desktop rollout back when the actual runtime version matches the source', async () => {
-    setActiveCodexRuntime('0.145.0');
-    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0');
-
-    await syncExternalCodexSessionFromDesktop(threadId);
-
-    // 实际 runtime 版本(spawn --version)= 源版本 → 回写照旧发生,源 rollout 被更新为桌面端内容。
-    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(fs.readFileSync(desktopRollout, 'utf-8'));
   });
 });

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -1714,6 +1714,17 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     codexBinMock.path = path.join(binDir, 'codex');
   }
 
+  /**
+   * Linux 受管 fallback 布局:二进制在 <root>/bin/codex,.version marker 在上一级 <root>/.version。
+   * 用于验证门禁能读到非同级 marker(#789 review P2)。
+   */
+  function setBundledCodexVersionLinuxFallback(version: string): void {
+    const root = path.join(rootDir, 'agent-runtime', 'codex');
+    fs.mkdirSync(path.join(root, 'bin'), { recursive: true });
+    fs.writeFileSync(path.join(root, '.version'), `${version}\n`, 'utf-8');
+    codexBinMock.path = path.join(root, 'bin', 'codex');
+  }
+
   /** 写一份含 session_meta 首行(带 cli_version)+ 一条消息的 rollout。 */
   function writeRolloutWithCliVersion(file: string, cliVersion: string, body: string): void {
     fs.mkdirSync(path.dirname(file), { recursive: true });
@@ -1827,6 +1838,18 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     await syncExternalCodexSessionFromDesktop(threadId);
 
     // 版本一致 → 回写照旧发生,源 rollout 被更新为桌面端内容。
+    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(fs.readFileSync(desktopRollout, 'utf-8'));
+  });
+
+  it('reads the version marker from the Linux managed-fallback layout (bin/ subdir)', async () => {
+    // 二进制在 <root>/bin/codex,.version 在上一级——门禁必须读到、不能误判为版本未知
+    // 而在 Linux 上永久禁用回写(#789 review P2)。
+    setBundledCodexVersionLinuxFallback('0.145.0');
+    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0');
+
+    await syncExternalCodexSessionFromDesktop(threadId);
+
+    // 成功读到上一级 marker、版本一致 → 回写照旧发生。
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(fs.readFileSync(desktopRollout, 'utf-8'));
   });
 });

--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -7,6 +7,7 @@ import path from 'node:path';
 
 const electronMock = vi.hoisted(() => ({ userData: '' }));
 const dbMock = vi.hoisted(() => ({ current: null as Database.Database | null }));
+const codexBinMock = vi.hoisted(() => ({ path: undefined as string | undefined }));
 
 vi.mock('electron', () => ({
   app: {
@@ -27,6 +28,10 @@ vi.mock('../logger.js', () => ({
     info: vi.fn(),
     warn: vi.fn(),
   }),
+}));
+
+vi.mock('../agent-binaries/index.js', () => ({
+  getReadyBinaryPath: vi.fn((kind: string) => (kind === 'codex' ? codexBinMock.path : undefined)),
 }));
 
 import {
@@ -1694,6 +1699,21 @@ describe('prepareExternalCodexSessionForResume orphan rollout synthesis', () => 
 describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () => {
   const desktopHome = () => path.join(targetUserData, 'codex-home');
 
+  /**
+   * 把 Cindy 捆绑的 codex runtime 版本设为 version(dev bundle 形态:二进制同级 .version);
+   * 传 null 模拟「二进制未就绪 / 版本无从判定」,getReadyBinaryPath 返回 undefined。
+   */
+  function setBundledCodexVersion(version: string | null): void {
+    if (version === null) {
+      codexBinMock.path = undefined;
+      return;
+    }
+    const binDir = path.join(rootDir, 'codex-bin', 'darwin-arm64');
+    fs.mkdirSync(binDir, { recursive: true });
+    fs.writeFileSync(path.join(binDir, '.version'), `${version}\n`, 'utf-8');
+    codexBinMock.path = path.join(binDir, 'codex');
+  }
+
   /** 写一份含 session_meta 首行(带 cli_version)+ 一条消息的 rollout。 */
   function writeRolloutWithCliVersion(file: string, cliVersion: string, body: string): void {
     fs.mkdirSync(path.dirname(file), { recursive: true });
@@ -1714,18 +1734,18 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
   }
 
   /**
-   * 建一个「外部会话已导入并在 Cindy 里续过一轮」的链接现场:桌面端与外部各有一份 rollout
-   * (可分别指定写出它的 runtime cli_version)与 threads 行。
+   * 建一个「外部会话已导入并在 Cindy 里续过一轮」现场:桌面端有 app-server 新写的 rollout,
+   * 外部源保留原 rollout(带创建它的 runtime cli_version)。门禁比对的是「捆绑 runtime 版本」
+   * 与外部源 cli_version,故桌面端 rollout 自身的版本号无关紧要。
    */
   function setupLinkedThread(
-    desktopCliVersion: string,
     externalCliVersion: string,
   ): { externalRollout: string; externalDbPath: string; desktopRollout: string } {
     const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
     const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
     writeRolloutWithCliVersion(
       desktopRollout,
-      desktopCliVersion,
+      externalCliVersion,
       rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
     );
     writeRolloutWithCliVersion(
@@ -1752,19 +1772,35 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     }
   }
 
-  it('does not overwrite the source ~/.codex rollout when the runtime cli_version differs', async () => {
-    const { externalRollout, externalDbPath } = setupLinkedThread('0.145.0', '0.146.0-alpha.3.1');
+  afterEach(() => {
+    codexBinMock.path = undefined;
+  });
+
+  it('does not overwrite the source ~/.codex rollout when the bundled runtime version differs', async () => {
+    setBundledCodexVersion('0.145.0');
+    const { externalRollout, externalDbPath } = setupLinkedThread('0.146.0-alpha.3.1');
     const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
     const rolloutPathBefore = readThreadRolloutPath(externalDbPath);
 
     await syncExternalCodexSessionFromDesktop(threadId);
 
-    // 版本不一致 → 源 rollout 与源 state 都不被改写。
+    // 捆绑 runtime 与源版本不一致 → 源 rollout 与源 state 都不被改写。
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
     expect(readThreadRolloutPath(externalDbPath)).toBe(rolloutPathBefore);
   });
 
+  it('does not sync back when the bundled runtime version is unknown', async () => {
+    setBundledCodexVersion(null); // 二进制未就绪 → 拿不到版本 → 安全侧不回写
+    const { externalRollout } = setupLinkedThread('0.145.0');
+    const rolloutBefore = fs.readFileSync(externalRollout, 'utf-8');
+
+    await syncExternalCodexSessionFromDesktop(threadId);
+
+    expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(rolloutBefore);
+  });
+
   it('does not sync back when the source rollout has no parseable cli_version', async () => {
+    setBundledCodexVersion('0.145.0');
     const desktopRollout = path.join(desktopHome(), 'sessions', `rollout-desktop-${threadId}.jsonl`);
     const externalRollout = path.join(externalHome, 'sessions', `rollout-external-${threadId}.jsonl`);
     writeRolloutWithCliVersion(
@@ -1772,7 +1808,7 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
       '0.145.0',
       rolloutLine('m-desktop', 'assistant', 'edited in Cindy', '2026-07-28T00:00:01.000Z'),
     );
-    // 外部 rollout 首行不是 session_meta(cli_version 无从判定)。
+    // 外部 rollout 首行不是 session_meta(源 cli_version 无从判定)。
     fs.mkdirSync(path.dirname(externalRollout), { recursive: true });
     const externalContent = `${rolloutLine('m-external', 'assistant', 'original external', '2026-07-27T00:00:01.000Z')}\n`;
     fs.writeFileSync(externalRollout, externalContent, 'utf-8');
@@ -1784,8 +1820,9 @@ describe('syncExternalCodexSessionFromDesktop runtime version gate (#789)', () =
     expect(fs.readFileSync(externalRollout, 'utf-8')).toBe(externalContent);
   });
 
-  it('syncs the desktop rollout back when both runtimes share the same cli_version', async () => {
-    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0', '0.145.0');
+  it('syncs the desktop rollout back when the bundled runtime matches the source version', async () => {
+    setBundledCodexVersion('0.145.0');
+    const { externalRollout, desktopRollout } = setupLinkedThread('0.145.0');
 
     await syncExternalCodexSessionFromDesktop(threadId);
 

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -8,6 +8,7 @@
 
 import { app } from 'electron';
 import type Database from 'better-sqlite3';
+import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import { promises as fsp } from 'node:fs';
 import { createReadStream } from 'node:fs';
@@ -26,7 +27,7 @@ import { finalizeCodexCitationText } from '@cindy/maker-core';
 
 import { getCurrentDbClientUserId, getDbClient } from '../localDb/client/current.js';
 import { createBetterSqliteDatabase } from '../localDb/betterSqliteFactory.js';
-import codexRuntimeManifest from '../../../../../tools/codex/latest.json';
+import { getReadyBinaryPath, getCachedBinaryStatus, isVettedAgentBinaryPath } from '../agent-binaries/index.js';
 import { createLogger } from '../logger.js';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir.js';
 import { recordPrRefsForImportedMessages } from '../git-context/prRefsStore.js';
@@ -973,21 +974,21 @@ export async function syncExternalCodexSessionFromDesktop(threadId: string): Pro
     return;
   }
 
-  // 版本门禁(#789):desktop 侧新事件由 Cindy 当前捆绑的 codex runtime 写出(app-server 以
+  // 版本门禁(#789):desktop 侧新事件由 Cindy 实际跑的 codex runtime 写出(app-server 以
   // CODEX_HOME=desktop 运行,新 rollout 落在 desktop home——见 findRolloutPath),回写是唯一
-  // 触碰源 ~/.codex 的通道。当捆绑 runtime 与创建源会话的 runtime 版本不同时,事件格式(如
+  // 触碰源 ~/.codex 的通道。当该 runtime 与创建源会话的 runtime 版本不同时,事件格式(如
   // function_call.id 前缀:旧版 `call_*` vs 新版 `fc_*`)可能不兼容,覆盖回源会让原 Codex
   // 客户端后续重放历史被 API 拒(invalid_id_prefix),源会话就此无法继续。
-  // 判据用「捆绑 runtime 版本 vs 源 session_meta.cli_version」——不用 desktop rollout 自身的
-  // session_meta(它可能沿用源会话的旧版本号,无法反映真正写出事件的 runtime)。仅两者完全
-  // 一致(格式可证兼容)才回写;拿不到版本或不一致时降级为不回写、保源会话原样(用户仍可在
-  // Cindy 内继续该会话的私有副本)。
-  const bundledCliVersion = getBundledCodexRuntimeVersion();
+  // 判据用「实际 runtime 版本(spawn --version)vs 源 session_meta.cli_version」——不用 desktop
+  // rollout 自身的 session_meta(可能沿用源旧版本号),也不用编译期 pin(prod 会从 CDN 动态选到
+  // 不同版本)。仅两者完全一致(格式可证兼容)才回写;拿不到版本或不一致时降级为不回写、保源
+  // 会话原样(用户仍可在 Cindy 内继续该会话的私有副本)。
+  const runtimeCliVersion = await getActiveCodexRuntimeVersion();
   const externalCliVersion = readRolloutCliVersion(externalThread.rolloutPath);
-  if (!bundledCliVersion || !externalCliVersion || bundledCliVersion !== externalCliVersion) {
+  if (!runtimeCliVersion || !externalCliVersion || runtimeCliVersion !== externalCliVersion) {
     log.info('skip external Codex sync-back: runtime version mismatch or unknown', {
       threadId,
-      bundledCliVersion,
+      runtimeCliVersion,
       externalCliVersion,
       sourceHome: desktopThread.sourceHome,
       targetHome: externalThread.sourceHome,
@@ -1447,16 +1448,49 @@ function rolloutThreadRowFromFirstLine(
   };
 }
 
+/** binaryPath → 解析出的 semver;同一 binary 只 spawn 一次 `--version`。 */
+const codexRuntimeVersionCache = new Map<string, string>();
+
+/** 当前实际会被 spawn 的 codex 二进制路径(prepare 成功后回填;无则读受管缓存)。 */
+function resolveActiveCodexBinaryPath(): string | null {
+  const ready = getReadyBinaryPath('codex');
+  if (ready) return ready;
+  const cached = getCachedBinaryStatus('codex');
+  return cached.binaryReady && cached.binaryPath ? cached.binaryPath : null;
+}
+
+/** 从 `codex --version` 首行抽取 semver(如 "codex-cli 0.145.0" → "0.145.0")。 */
+function parseCodexVersionOutput(output: string): string | null {
+  const match = output.trim().match(/\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/i);
+  return match ? match[1] : null;
+}
+
 /**
- * Cindy 当前发行/管理的 codex runtime 版本(= 写出 desktop 侧新事件的那个 runtime)。
- * 取自随包固定的 tools/codex/latest.json——与 Linux runtime fallback 下载/校验所用的版本源
- * 同一份(见 linux-runtime-fallback.ts 的 codexLatest),因此对 dev bundle / prod 安装 /
- * Linux 受管 fallback(含 legacy standalone 布局)一律成立,无需再按二进制路径猜版本布局。
- * manifest 恒在;拿不到合法版本串时返回 null,回写门禁据此按「无法确认」降级为不写(安全侧)。
+ * 写出 desktop 侧新事件的那个 codex runtime 的**实际**版本——spawn 当前解析到的 codex
+ * 二进制 `--version` 得到,而非任何编译期 pin 或路径推断。这样才与真正跑的 runtime 一致:
+ * dev bundle(apps/codex-bin)、prod 从 CDN manifest 动态选中的版本、Linux 受管 fallback 各
+ * 布局都取到真值(#789 review:factory 按远端 asset.version 选二进制,pin/路径都可能与实际不符)。
+ * 结果按 binaryPath 进程内缓存。二进制未就绪 / 非受管路径 / --version 失败或无法解析 → null,
+ * 回写门禁据此按「无法确认」降级为不写(安全侧)。
  */
-function getBundledCodexRuntimeVersion(): string | null {
-  const version = (codexRuntimeManifest as { version?: unknown }).version;
-  return typeof version === 'string' && version.trim() ? version.trim() : null;
+async function getActiveCodexRuntimeVersion(): Promise<string | null> {
+  const binaryPath = resolveActiveCodexBinaryPath();
+  // 执行前复核确为受管二进制(与 binary-version.ts 同口径,CodeQL 命令注入防御纵深)。
+  if (!binaryPath || !isVettedAgentBinaryPath('codex', binaryPath)) return null;
+  const cached = codexRuntimeVersionCache.get(binaryPath);
+  if (cached) return cached;
+  const firstLine = await new Promise<string | null>((resolve) => {
+    execFile(binaryPath, ['--version'], { timeout: 5000, windowsHide: true }, (err, stdout, stderr) => {
+      if (err) {
+        resolve(null);
+        return;
+      }
+      resolve(((stdout || stderr || '').toString().split(/\r?\n/)[0] ?? '').trim() || null);
+    });
+  });
+  const version = firstLine ? parseCodexVersionOutput(firstLine) : null;
+  if (version) codexRuntimeVersionCache.set(binaryPath, version);
+  return version;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -26,7 +26,7 @@ import { finalizeCodexCitationText } from '@cindy/maker-core';
 
 import { getCurrentDbClientUserId, getDbClient } from '../localDb/client/current.js';
 import { createBetterSqliteDatabase } from '../localDb/betterSqliteFactory.js';
-import { getReadyBinaryPath } from '../agent-binaries/index.js';
+import codexRuntimeManifest from '../../../../../tools/codex/latest.json';
 import { createLogger } from '../logger.js';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir.js';
 import { recordPrRefsForImportedMessages } from '../git-context/prRefsStore.js';
@@ -1448,30 +1448,15 @@ function rolloutThreadRowFromFirstLine(
 }
 
 /**
- * Cindy 当前在用的 codex runtime 版本——写出 desktop 侧新事件的那个 runtime。
- * 覆盖各布局的 `.version` marker 位置:
- *   - dev bundle:二进制同级(apps/codex-bin/<platform>/.version);
- *   - Linux 受管 fallback:二进制上一级(userData/agent-runtime/codex/.version,bin 在 .../codex/bin/codex);
- *   - prod 安装:userData/codex/<version>/codex,无 marker 时取版本目录名。
- * 二进制未就绪、或系统 PATH codex 等拿不到版本标记的布局 → 返回 null,回写门禁据此按
- * 「无法确认」降级为不写(安全侧:宁可不回写,也不拿不确定版本覆盖源会话)。
+ * Cindy 当前发行/管理的 codex runtime 版本(= 写出 desktop 侧新事件的那个 runtime)。
+ * 取自随包固定的 tools/codex/latest.json——与 Linux runtime fallback 下载/校验所用的版本源
+ * 同一份(见 linux-runtime-fallback.ts 的 codexLatest),因此对 dev bundle / prod 安装 /
+ * Linux 受管 fallback(含 legacy standalone 布局)一律成立,无需再按二进制路径猜版本布局。
+ * manifest 恒在;拿不到合法版本串时返回 null,回写门禁据此按「无法确认」降级为不写(安全侧)。
  */
 function getBundledCodexRuntimeVersion(): string | null {
-  const binaryPath = getReadyBinaryPath('codex');
-  if (!binaryPath) return null;
-  const binDir = path.dirname(binaryPath);
-  // marker 可能在二进制同级(dev)或上一级(Linux 受管 fallback 的 <root>/bin/codex 布局)。
-  for (const markerDir of [binDir, path.dirname(binDir)]) {
-    try {
-      const marked = fs.readFileSync(path.join(markerDir, '.version'), 'utf-8').trim();
-      if (marked) return marked;
-    } catch {
-      /* 该布局此层无 .version marker,继续下一候选 */
-    }
-  }
-  // prod 安装:版本就是目录名(userData/codex/<version>/codex)。
-  const versionDir = path.basename(binDir);
-  return /^\d+\.\d+/.test(versionDir) ? versionDir : null;
+  const version = (codexRuntimeManifest as { version?: unknown }).version;
+  return typeof version === 'string' && version.trim() ? version.trim() : null;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -26,6 +26,7 @@ import { finalizeCodexCitationText } from '@cindy/maker-core';
 
 import { getCurrentDbClientUserId, getDbClient } from '../localDb/client/current.js';
 import { createBetterSqliteDatabase } from '../localDb/betterSqliteFactory.js';
+import { getReadyBinaryPath } from '../agent-binaries/index.js';
 import { createLogger } from '../logger.js';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir.js';
 import { recordPrRefsForImportedMessages } from '../git-context/prRefsStore.js';
@@ -972,18 +973,21 @@ export async function syncExternalCodexSessionFromDesktop(threadId: string): Pro
     return;
   }
 
-  // 版本门禁(#789):Cindy resume 生成的 desktop rollout 由 Cindy 捆绑的 Codex runtime 写出,
-  // 其事件格式(如 function_call.id 前缀:旧版 `call_*` vs 新版 `fc_*`)可能与创建这个外部
-  // 会话的 runtime 不兼容。把不兼容的 rollout 覆盖回源 ~/.codex,会让原 Codex 客户端后续重放
-  // 历史时被 API 拒(invalid_id_prefix),源会话就此无法继续。仅当两侧 rollout 的
-  // session_meta.cli_version 完全一致(= 同一 runtime 版本,格式可证兼容)时才回写;无法确认
-  // 一致时降级为不回写、保源会话原样(用户仍可在 Cindy 内继续该会话的私有副本)。
-  const desktopCliVersion = readRolloutCliVersion(desktopThread.rolloutPath);
+  // 版本门禁(#789):desktop 侧新事件由 Cindy 当前捆绑的 codex runtime 写出(app-server 以
+  // CODEX_HOME=desktop 运行,新 rollout 落在 desktop home——见 findRolloutPath),回写是唯一
+  // 触碰源 ~/.codex 的通道。当捆绑 runtime 与创建源会话的 runtime 版本不同时,事件格式(如
+  // function_call.id 前缀:旧版 `call_*` vs 新版 `fc_*`)可能不兼容,覆盖回源会让原 Codex
+  // 客户端后续重放历史被 API 拒(invalid_id_prefix),源会话就此无法继续。
+  // 判据用「捆绑 runtime 版本 vs 源 session_meta.cli_version」——不用 desktop rollout 自身的
+  // session_meta(它可能沿用源会话的旧版本号,无法反映真正写出事件的 runtime)。仅两者完全
+  // 一致(格式可证兼容)才回写;拿不到版本或不一致时降级为不回写、保源会话原样(用户仍可在
+  // Cindy 内继续该会话的私有副本)。
+  const bundledCliVersion = getBundledCodexRuntimeVersion();
   const externalCliVersion = readRolloutCliVersion(externalThread.rolloutPath);
-  if (!desktopCliVersion || !externalCliVersion || desktopCliVersion !== externalCliVersion) {
+  if (!bundledCliVersion || !externalCliVersion || bundledCliVersion !== externalCliVersion) {
     log.info('skip external Codex sync-back: runtime version mismatch or unknown', {
       threadId,
-      desktopCliVersion,
+      bundledCliVersion,
       externalCliVersion,
       sourceHome: desktopThread.sourceHome,
       targetHome: externalThread.sourceHome,
@@ -1441,6 +1445,25 @@ function rolloutThreadRowFromFirstLine(
     approval_mode: stringValue(payload.approval_mode),
     archived: isArchivedRolloutPath(file) ? 1 : 0,
   };
+}
+
+/**
+ * Cindy 当前在用的 codex runtime 版本——写出 desktop 侧新事件的那个 runtime。
+ * dev bundle:二进制同级 `.version`(apps/codex-bin/<platform>/.version);
+ * prod 安装:userData/codex/<version>/codex 的版本目录名。
+ * 二进制未就绪 / 版本推断不出时返回 null,回写门禁据此按「无法确认」降级为不写(安全侧)。
+ */
+function getBundledCodexRuntimeVersion(): string | null {
+  const binaryPath = getReadyBinaryPath('codex');
+  if (!binaryPath) return null;
+  try {
+    const sidecar = fs.readFileSync(path.join(path.dirname(binaryPath), '.version'), 'utf-8').trim();
+    if (sidecar) return sidecar;
+  } catch {
+    /* 非 dev bundle:无 .version 同级文件,回退到版本目录名 */
+  }
+  const versionDir = path.basename(path.dirname(binaryPath));
+  return /^\d+\.\d+/.test(versionDir) ? versionDir : null;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -8,7 +8,6 @@
 
 import { app } from 'electron';
 import type Database from 'better-sqlite3';
-import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import { promises as fsp } from 'node:fs';
 import { createReadStream } from 'node:fs';
@@ -27,7 +26,6 @@ import { finalizeCodexCitationText } from '@cindy/maker-core';
 
 import { getCurrentDbClientUserId, getDbClient } from '../localDb/client/current.js';
 import { createBetterSqliteDatabase } from '../localDb/betterSqliteFactory.js';
-import { getReadyBinaryPath, getCachedBinaryStatus, isVettedAgentBinaryPath } from '../agent-binaries/index.js';
 import { createLogger } from '../logger.js';
 import { normalizeWorkingDirForStorage } from '../../shared/workingDir.js';
 import { recordPrRefsForImportedMessages } from '../git-context/prRefsStore.js';
@@ -212,55 +210,45 @@ export async function prepareExternalCodexSessionForResume(threadId: string): Pr
     ?? findExternalThreadById(threadId)
     ?? (targetRollout ? findThreadByIdInHome(targetHome, threadId) : null);
   if (found) {
-    const isBrandMigration = isLegacyBrandedCodexLocation(targetHome, found.sourceHome)
-      || isLegacyBrandedCodexLocation(targetHome, found.rolloutPath);
-    if (isBrandMigration) {
-      const adoptedRolloutPath = targetRolloutPathForExternalThread(found, targetHome);
-      const sourceRolloutExists = !!found.rolloutPath && fs.existsSync(found.rolloutPath);
-      let adoptedRollout = false;
-      if (sourceRolloutExists) {
-        try {
-          adoptedRollout = await copyExternalRolloutAtomically(found.rolloutPath, adoptedRolloutPath);
-        } catch (err) {
-          log.warn('failed to adopt external Codex rollout into current home', {
-            threadId,
-            sourceRolloutPath: found.rolloutPath,
-            targetRolloutPath: adoptedRolloutPath,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
+    // 外部会话(~/.codex、Codex.app、历史品牌 HOME)一律**复制成 Cindy 私有副本**,
+    // 不再链接源 rollout(#789 方案 A:Dash 定稿)。Cindy 的续聊只写进 desktop CODEX_HOME
+    // 的这份副本,源会话零改动、也没有任何回写通道——彻底消除跨 runtime 版本回写污染源会话
+    // 的风险。接管进当前 HOME 还避免 state 长期指向可能被用户清理的外部目录。
+    const adoptedRolloutPath = targetRolloutPathForExternalThread(found, targetHome);
+    const sourceRolloutExists = !!found.rolloutPath && fs.existsSync(found.rolloutPath);
+    let adoptedRollout = false;
+    if (sourceRolloutExists) {
+      try {
+        adoptedRollout = await copyExternalRolloutAtomically(found.rolloutPath, adoptedRolloutPath);
+      } catch (err) {
+        log.warn('failed to adopt external Codex rollout into current home', {
+          threadId,
+          sourceRolloutPath: found.rolloutPath,
+          targetRolloutPath: adoptedRolloutPath,
+          error: err instanceof Error ? err.message : String(err),
+        });
       }
-
-      // 原文件存在但接管失败时仍指回原文件,保证本次 resume 不因迁移 IO 故障被阻断;
-      // 原文件本就缺失时则把 state 指向当前 HOME,随后由 localDb 历史合成兜底 rollout。
-      const preparedRolloutPath = adoptedRollout || !sourceRolloutExists
-        ? adoptedRolloutPath
-        : found.rolloutPath;
-      const copiedState = copyThreadStateToTarget(found, targetDbPath, {
-        rolloutPathOverride: preparedRolloutPath,
-      });
-      const linkedState = pointThreadAtRollout(targetDbPath, threadId, preparedRolloutPath);
-      targetRollout = readThreadRolloutPath(targetDbPath, threadId);
-      log.info('prepared legacy branded Codex thread for resume', {
-        threadId,
-        sourceHome: found.sourceHome,
-        copiedState,
-        linkedState,
-        adoptedRollout,
-        rolloutPath: targetRollout,
-      });
-    } else {
-      // 显式导入的 ~/.codex / Codex.app 会话保持链接语义,close 时仍同步回原 HOME。
-      const copiedState = copyThreadStateToTarget(found, targetDbPath);
-      targetRollout = readThreadRolloutPath(targetDbPath, threadId);
-      log.info('prepared linked external Codex thread for resume', {
-        threadId,
-        sourceHome: found.sourceHome,
-        copiedState,
-        rolloutPath: targetRollout,
-      });
     }
+
+    // 原文件存在但接管失败时仍指回原文件,保证本次 resume 不因迁移 IO 故障被阻断(此时
+    // app-server 仍以 CODEX_HOME=desktop 运行、新事件写进 desktop home,不改源);原文件
+    // 本就缺失时把 state 指向当前 HOME,随后由 localDb 历史合成兜底 rollout。
+    const preparedRolloutPath = adoptedRollout || !sourceRolloutExists
+      ? adoptedRolloutPath
+      : found.rolloutPath;
+    const copiedState = copyThreadStateToTarget(found, targetDbPath, {
+      rolloutPathOverride: preparedRolloutPath,
+    });
+    const pointedState = pointThreadAtRollout(targetDbPath, threadId, preparedRolloutPath);
     targetRollout = readThreadRolloutPath(targetDbPath, threadId);
+    log.info('prepared private-copy external Codex thread for resume', {
+      threadId,
+      sourceHome: found.sourceHome,
+      copiedState,
+      pointedState,
+      adoptedRollout,
+      rolloutPath: targetRollout,
+    });
     if (targetRollout && fs.existsSync(targetRollout)) return targetRollout;
   }
 
@@ -958,73 +946,6 @@ function dropUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return out;
 }
 
-/** Copy a linked Codex thread updated by xdt-maker back into the original Codex home. */
-export async function syncExternalCodexSessionFromDesktop(threadId: string): Promise<void> {
-  if (!isLikelyThreadId(threadId)) return;
-
-  const desktopThread = findThreadByIdInHome(getDesktopCodexHome(), threadId);
-  if (!desktopThread) {
-    log.debug('sync external skipped: desktop thread missing', { threadId });
-    return;
-  }
-
-  const externalThread = findExternalThreadById(threadId);
-  if (!externalThread) {
-    log.debug('sync external skipped: original external thread missing', { threadId });
-    return;
-  }
-
-  // 版本门禁(#789):desktop 侧新事件由 Cindy 实际跑的 codex runtime 写出(app-server 以
-  // CODEX_HOME=desktop 运行,新 rollout 落在 desktop home——见 findRolloutPath),回写是唯一
-  // 触碰源 ~/.codex 的通道。当该 runtime 与创建源会话的 runtime 版本不同时,事件格式(如
-  // function_call.id 前缀:旧版 `call_*` vs 新版 `fc_*`)可能不兼容,覆盖回源会让原 Codex
-  // 客户端后续重放历史被 API 拒(invalid_id_prefix),源会话就此无法继续。
-  // 判据用「实际 runtime 版本(spawn --version)vs 源 session_meta.cli_version」——不用 desktop
-  // rollout 自身的 session_meta(可能沿用源旧版本号),也不用编译期 pin(prod 会从 CDN 动态选到
-  // 不同版本)。仅两者完全一致(格式可证兼容)才回写;拿不到版本或不一致时降级为不回写、保源
-  // 会话原样(用户仍可在 Cindy 内继续该会话的私有副本)。
-  const runtimeCliVersion = await getActiveCodexRuntimeVersion();
-  const externalCliVersion = readRolloutCliVersion(externalThread.rolloutPath);
-  if (!runtimeCliVersion || !externalCliVersion || runtimeCliVersion !== externalCliVersion) {
-    log.info('skip external Codex sync-back: runtime version mismatch or unknown', {
-      threadId,
-      runtimeCliVersion,
-      externalCliVersion,
-      sourceHome: desktopThread.sourceHome,
-      targetHome: externalThread.sourceHome,
-    });
-    return;
-  }
-
-  let copiedRollout = false;
-  if (
-    desktopThread.rolloutPath &&
-    externalThread.rolloutPath &&
-    !samePath(desktopThread.rolloutPath, externalThread.rolloutPath) &&
-    fs.existsSync(desktopThread.rolloutPath)
-  ) {
-    await fsp.mkdir(path.dirname(externalThread.rolloutPath), { recursive: true });
-    await fsp.copyFile(desktopThread.rolloutPath, externalThread.rolloutPath);
-    copiedRollout = true;
-  }
-
-  const copiedState = externalThread.sourceDbPath
-    ? copyThreadStateToTarget(desktopThread, externalThread.sourceDbPath, {
-      replaceExisting: true,
-      rolloutPathOverride: externalThread.rolloutPath || desktopThread.rolloutPath,
-    })
-    : false;
-  await appendSessionIndexEntry(externalThread.sourceHome, desktopThread);
-
-  log.info('synced linked Codex thread back to external home', {
-    threadId,
-    sourceHome: desktopThread.sourceHome,
-    targetHome: externalThread.sourceHome,
-    copiedRollout,
-    copiedState,
-  });
-}
-
 /**
  * 为外部 Codex thread 创建的本地会话按需导入可读消息。
  * 源 rollout 文件未变化时直接短路；文件变化后按行号 upsert，刷新已导入行并追加新行。
@@ -1446,70 +1367,6 @@ function rolloutThreadRowFromFirstLine(
     approval_mode: stringValue(payload.approval_mode),
     archived: isArchivedRolloutPath(file) ? 1 : 0,
   };
-}
-
-/** binaryPath → 解析出的 semver;同一 binary 只 spawn 一次 `--version`。 */
-const codexRuntimeVersionCache = new Map<string, string>();
-
-/** 当前实际会被 spawn 的 codex 二进制路径(prepare 成功后回填;无则读受管缓存)。 */
-function resolveActiveCodexBinaryPath(): string | null {
-  const ready = getReadyBinaryPath('codex');
-  if (ready) return ready;
-  const cached = getCachedBinaryStatus('codex');
-  return cached.binaryReady && cached.binaryPath ? cached.binaryPath : null;
-}
-
-/** 从 `codex --version` 首行抽取 semver(如 "codex-cli 0.145.0" → "0.145.0")。 */
-function parseCodexVersionOutput(output: string): string | null {
-  const match = output.trim().match(/\bv?(\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?)\b/i);
-  return match ? match[1] : null;
-}
-
-/**
- * 写出 desktop 侧新事件的那个 codex runtime 的**实际**版本——spawn 当前解析到的 codex
- * 二进制 `--version` 得到,而非任何编译期 pin 或路径推断。这样才与真正跑的 runtime 一致:
- * dev bundle(apps/codex-bin)、prod 从 CDN manifest 动态选中的版本、Linux 受管 fallback 各
- * 布局都取到真值(#789 review:factory 按远端 asset.version 选二进制,pin/路径都可能与实际不符)。
- * 结果按 binaryPath 进程内缓存。二进制未就绪 / 非受管路径 / --version 失败或无法解析 → null,
- * 回写门禁据此按「无法确认」降级为不写(安全侧)。
- */
-async function getActiveCodexRuntimeVersion(): Promise<string | null> {
-  const binaryPath = resolveActiveCodexBinaryPath();
-  // 执行前复核确为受管二进制(与 binary-version.ts 同口径,CodeQL 命令注入防御纵深)。
-  if (!binaryPath || !isVettedAgentBinaryPath('codex', binaryPath)) return null;
-  const cached = codexRuntimeVersionCache.get(binaryPath);
-  if (cached) return cached;
-  const firstLine = await new Promise<string | null>((resolve) => {
-    execFile(binaryPath, ['--version'], { timeout: 5000, windowsHide: true }, (err, stdout, stderr) => {
-      if (err) {
-        resolve(null);
-        return;
-      }
-      resolve(((stdout || stderr || '').toString().split(/\r?\n/)[0] ?? '').trim() || null);
-    });
-  });
-  const version = firstLine ? parseCodexVersionOutput(firstLine) : null;
-  if (version) codexRuntimeVersionCache.set(binaryPath, version);
-  return version;
-}
-
-/**
- * 读取 rollout 首行 session_meta 里的 `cli_version`(写出这份 rollout 的 Codex runtime 版本)。
- * 文件缺失、首行非 session_meta、或 cli_version 缺失/为空 → null(调用方按「无法确认」处理)。
- */
-function readRolloutCliVersion(rolloutPath: string | null | undefined): string | null {
-  if (!rolloutPath) return null;
-  const line = readFirstLineSync(rolloutPath);
-  if (!line) return null;
-  let obj: unknown;
-  try {
-    obj = JSON.parse(line);
-  } catch {
-    return null;
-  }
-  if (!isRecord(obj) || obj.type !== 'session_meta' || !isRecord(obj.payload)) return null;
-  const version = stringValue(obj.payload.cli_version).trim();
-  return version || null;
 }
 
 function readFirstLineSync(file: string): string | null {

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -972,6 +972,25 @@ export async function syncExternalCodexSessionFromDesktop(threadId: string): Pro
     return;
   }
 
+  // 版本门禁(#789):Cindy resume 生成的 desktop rollout 由 Cindy 捆绑的 Codex runtime 写出,
+  // 其事件格式(如 function_call.id 前缀:旧版 `call_*` vs 新版 `fc_*`)可能与创建这个外部
+  // 会话的 runtime 不兼容。把不兼容的 rollout 覆盖回源 ~/.codex,会让原 Codex 客户端后续重放
+  // 历史时被 API 拒(invalid_id_prefix),源会话就此无法继续。仅当两侧 rollout 的
+  // session_meta.cli_version 完全一致(= 同一 runtime 版本,格式可证兼容)时才回写;无法确认
+  // 一致时降级为不回写、保源会话原样(用户仍可在 Cindy 内继续该会话的私有副本)。
+  const desktopCliVersion = readRolloutCliVersion(desktopThread.rolloutPath);
+  const externalCliVersion = readRolloutCliVersion(externalThread.rolloutPath);
+  if (!desktopCliVersion || !externalCliVersion || desktopCliVersion !== externalCliVersion) {
+    log.info('skip external Codex sync-back: runtime version mismatch or unknown', {
+      threadId,
+      desktopCliVersion,
+      externalCliVersion,
+      sourceHome: desktopThread.sourceHome,
+      targetHome: externalThread.sourceHome,
+    });
+    return;
+  }
+
   let copiedRollout = false;
   if (
     desktopThread.rolloutPath &&
@@ -1422,6 +1441,25 @@ function rolloutThreadRowFromFirstLine(
     approval_mode: stringValue(payload.approval_mode),
     archived: isArchivedRolloutPath(file) ? 1 : 0,
   };
+}
+
+/**
+ * 读取 rollout 首行 session_meta 里的 `cli_version`(写出这份 rollout 的 Codex runtime 版本)。
+ * 文件缺失、首行非 session_meta、或 cli_version 缺失/为空 → null(调用方按「无法确认」处理)。
+ */
+function readRolloutCliVersion(rolloutPath: string | null | undefined): string | null {
+  if (!rolloutPath) return null;
+  const line = readFirstLineSync(rolloutPath);
+  if (!line) return null;
+  let obj: unknown;
+  try {
+    obj = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!isRecord(obj) || obj.type !== 'session_meta' || !isRecord(obj.payload)) return null;
+  const version = stringValue(obj.payload.cli_version).trim();
+  return version || null;
 }
 
 function readFirstLineSync(file: string): string | null {

--- a/apps/desktop/src/main/maker-host/codex-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/codex-local-sessions.ts
@@ -1449,20 +1449,28 @@ function rolloutThreadRowFromFirstLine(
 
 /**
  * Cindy 当前在用的 codex runtime 版本——写出 desktop 侧新事件的那个 runtime。
- * dev bundle:二进制同级 `.version`(apps/codex-bin/<platform>/.version);
- * prod 安装:userData/codex/<version>/codex 的版本目录名。
- * 二进制未就绪 / 版本推断不出时返回 null,回写门禁据此按「无法确认」降级为不写(安全侧)。
+ * 覆盖各布局的 `.version` marker 位置:
+ *   - dev bundle:二进制同级(apps/codex-bin/<platform>/.version);
+ *   - Linux 受管 fallback:二进制上一级(userData/agent-runtime/codex/.version,bin 在 .../codex/bin/codex);
+ *   - prod 安装:userData/codex/<version>/codex,无 marker 时取版本目录名。
+ * 二进制未就绪、或系统 PATH codex 等拿不到版本标记的布局 → 返回 null,回写门禁据此按
+ * 「无法确认」降级为不写(安全侧:宁可不回写,也不拿不确定版本覆盖源会话)。
  */
 function getBundledCodexRuntimeVersion(): string | null {
   const binaryPath = getReadyBinaryPath('codex');
   if (!binaryPath) return null;
-  try {
-    const sidecar = fs.readFileSync(path.join(path.dirname(binaryPath), '.version'), 'utf-8').trim();
-    if (sidecar) return sidecar;
-  } catch {
-    /* 非 dev bundle:无 .version 同级文件,回退到版本目录名 */
+  const binDir = path.dirname(binaryPath);
+  // marker 可能在二进制同级(dev)或上一级(Linux 受管 fallback 的 <root>/bin/codex 布局)。
+  for (const markerDir of [binDir, path.dirname(binDir)]) {
+    try {
+      const marked = fs.readFileSync(path.join(markerDir, '.version'), 'utf-8').trim();
+      if (marked) return marked;
+    } catch {
+      /* 该布局此层无 .version marker,继续下一候选 */
+    }
   }
-  const versionDir = path.basename(path.dirname(binaryPath));
+  // prod 安装:版本就是目录名(userData/codex/<version>/codex)。
+  const versionDir = path.basename(binDir);
   return /^\d+\.\d+/.test(versionDir) ? versionDir : null;
 }
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -186,7 +186,6 @@ import { createLogger } from '../logger.js';
 import { desktopClaudeAuthAdapter, desktopCodexAuthAdapter, readClaudeApiKey } from '../maker-host/auth-adapters.js';
 import { prepareSharedProjectSkillLinks } from '../maker-host/shared-global-skills.js';
 import { setRemoteCodexLiveTurnChecker, setRemoteSessionStartEnsure, getRemoteCcTurnSettledHandler, getRemoteCcStaleQuery } from '../maker-host/remote-session-start-ensure.js';
-import { syncExternalCodexSessionFromDesktop } from '../maker-host/codex-local-sessions.js';
 import { getCodexProxyAuthInjection, getCodexProxyAuthInjectionState } from '../maker-host/codex-proxy-host.js';
 import {
   readCollaborationSettings,
@@ -3878,16 +3877,6 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
             void triggerClaudeAccountUsageRefresh();
           }
         });
-      if (session.id.startsWith('codex-')) {
-        const threadId = session.id.slice('codex-'.length);
-        void syncExternalCodexSessionFromDesktop(threadId).catch((err) => {
-          log.warn('failed to sync linked Codex session back to external home', {
-            sessionId: session.id,
-            threadId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        });
-      }
     }
     // Pi done 事件同样携带 per-turn token/cache 明细。Pi 复用 Cindy 的 provider
     // 路由，因此计费形态必须看 session provider，而不是把它当成一个新的计费方：


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 issue #789:从外部 `~/.codex` / Codex.app 导入 Codex 会话、在 Cindy 内续聊后,turn 结束会把 Cindy 侧 rollout **无条件回写覆盖源会话**;当 Cindy 实际跑的 Codex runtime 与创建源会话的 runtime 版本不同时,事件格式(如 `function_call.id` 前缀 `call_*` vs `fc_*`)不兼容,原 Codex 客户端后续重放历史被 API 拒(`invalid_id_prefix`),源会话彻底无法继续。

**最终方案(方案 A,维护者定稿):隔离,彻底不回写。** `prepareExternalCodexSessionForResume` 在 resume 时把导入的外部会话统一**复制成 Cindy 私有副本**(落在 desktop `CODEX_HOME`,合并原 legacy-branded 分支逻辑),Cindy 的续聊只写进这份私有副本,**源 `~/.codex` 会话零改动、且没有任何回写通道**。这从根上消除跨 runtime 版本回写污染,无需再做任何 runtime 版本判定。

> 演进说明:早期版本用「回写前加 runtime 版本门禁」的思路,但版本判据经 review 连续暴露多处边界(session_meta 恒等 / 路径 marker 布局 / 编译期 pin ≠ CDN 动态版本 / 长期复用的 app-server host)。维护者拍板改用隔离方案,一次性消除整类版本判定问题;代价是导入会话在 Cindy 内的续聊不再回流到用户本机独立 Codex Desktop 会话(此前刻意保留的链接语义)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#789
- 本 PR 包含:resume 时把外部导入会话 adopt 成私有副本(统一 legacy/显式两分支);删除 `syncExternalCodexSessionFromDesktop` 自动回写及其在 turn done 的调用;删除为回写加的整套 runtime 版本门禁与其依赖。
- 明确不包含:不做跨版本 rollout 事件迁移、不改写 `function_call.id` / `function_call_output.call_id` 关联(#789 划定范围外);不清理已被历史 bug 污染的存量源会话。
- 用户可见变化:导入的外部 Codex 会话在 Cindy 内的续聊**不再回流**到源 `~/.codex`(此前会回写,跨版本时会损坏源)。源会话保持原样。
- 是否存在 breaking change:无破坏性接口变化;行为收紧(移除自动回写)。

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
apps/desktop $ npx vitest run src/main/__tests__/codexLocalSessions.test.ts
结果:36 passed

单测硬门禁 run-unit-gate.sh:apps/desktop unit PASS;唯一失败是与本 diff 无关的
  apps/mobile > startupSplashOverlay 超时(桌面 codex 改动不涉及 mobile,CI 分套件跑)。
typecheck(tsc -p,与 CI 同档):0 error;改动文件 eslint 0 error。
```

新增/更新回归测试:显式外部导入用例翻转为断言「adopt 私有副本、desktop state 指向副本、源 rollout 原样不动」;删除版本门禁相关用例与 mock。

### 手工验证

不涉及自动化之外的手工步骤。

### 未执行的验证

未在真机复现跨版本活体链路(本机无第二套不同版本 Codex 安装);隔离方案不依赖版本判定,单测覆盖 adopt 私有副本 + 源不被写,活体行为交由 reviewer 与 CI 兜底。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅导入的外部 Codex 会话的 resume 与(已移除的)回写路径。对源 `~/.codex` 从「可能被覆盖(跨版本时损坏)」变为「永不触碰」。Cindy 侧会话续聊、历史不受影响。
- 回滚 / 降级方式:`git revert` 本 commit 即恢复原链接+回写行为(即 #789 的原始问题)。隔离本身是安全侧(源永不被写)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已注明(不涉及)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释说明隔离语义)
- [x] 已确认测试结果或说明未执行原因
