### PR TITLE
feat(device-link): keyed latest-wins activity buffer + targeted replay

### DIFF
--- a/apps/desktop/src/main/agent-island/__tests__/service.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/service.test.ts
@@ -76,6 +76,7 @@ const mocks = vi.hoisted(() => ({
   readLayoutPreferences: vi.fn<() => Map<number, AgentIslandLayoutPreference>>(() => new Map()),
   writeLayoutPreference: vi.fn(),
   tapWindowBroadcast: vi.fn(),
+  pushSessionActivityToController: vi.fn(),
   showMessageBox: vi.fn(),
   openExternal: vi.fn(),
   readdir: vi.fn<(...args: unknown[]) => Promise<string[]>>(() => Promise.resolve([])),
@@ -128,6 +129,12 @@ vi.mock('../../device-link/broadcast-tap.js', () => ({
   tapWindowBroadcast: mocks.tapWindowBroadcast,
 }));
 
+// 定向 replay 出口(L3):service 只依赖这一个函数,mock 掉避免把整个 dispatch
+// 隔离层(electron app / settings-store / invoke 链)拖进灵动岛单测。
+vi.mock('../../device-link/dispatch.js', () => ({
+  pushSessionActivityToController: mocks.pushSessionActivityToController,
+}));
+
 import { resetEpermGuidanceForTest } from '../../file-access/permissions.js';
 
 beforeEach(() => {
@@ -158,6 +165,7 @@ beforeEach(() => {
   mocks.readLayoutPreferences.mockReturnValue(new Map());
   mocks.writeLayoutPreference.mockReset();
   mocks.tapWindowBroadcast.mockReset();
+  mocks.pushSessionActivityToController.mockReset();
   mocks.showMessageBox.mockReset();
   mocks.showMessageBox.mockResolvedValue({ response: 1, checkboxChecked: false });
   mocks.openExternal.mockReset();
@@ -561,16 +569,18 @@ describe('AgentIslandService native publishing', () => {
     service.handleUserPrompt({ sessionId: 's1', agentKind: 'codex' }, 'run tests');
     mocks.tapWindowBroadcast.mockClear();
 
-    service.replaySessionActivity();
+    service.replaySessionActivity('controller-a');
 
-    expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
-      SESSION_ACTIVITY_CHANNEL,
+    // 定向 replay(L3):只补给刚订阅的那台,不再经 broadcast-tap 扇出给全部控制端。
+    expect(mocks.pushSessionActivityToController).toHaveBeenCalledWith(
+      'controller-a',
       expect.objectContaining({
         sessionId: 's1',
         phase: 'running',
         compactDetail: 'run tests',
       }),
     );
+    expect(mocks.tapWindowBroadcast).not.toHaveBeenCalled();
   });
 
   it('replays unread terminal activity for late sessions subscribers', async () => {
@@ -590,19 +600,20 @@ describe('AgentIslandService native publishing', () => {
     service.handleAgentEvent({ sessionId: 's1', agentKind: 'codex' }, doneEvent());
     mocks.tapWindowBroadcast.mockClear();
 
-    service.replaySessionActivity();
+    service.replaySessionActivity('controller-a');
 
     // 完成但未读(attention=true)对迟到订阅者重放完整快照,而不是收尾清除包 ——
     // 手机端会话行右侧的完成绿点靠 phase+attention 点亮;已读后 attention 翻 false
     // 才降级为 terminal clear(由 relay isPublishableActivity 判定)。
-    expect(mocks.tapWindowBroadcast).toHaveBeenCalledWith(
-      SESSION_ACTIVITY_CHANNEL,
+    expect(mocks.pushSessionActivityToController).toHaveBeenCalledWith(
+      'controller-a',
       expect.objectContaining({
         sessionId: 's1',
         phase: 'completed',
         attention: true,
       }),
     );
+    expect(mocks.tapWindowBroadcast).not.toHaveBeenCalled();
   });
 
   it('broadcasts a terminal clear for read receipts even when the session is unknown to state', async () => {

--- a/apps/desktop/src/main/agent-island/__tests__/sessionActivityRelay.test.ts
+++ b/apps/desktop/src/main/agent-island/__tests__/sessionActivityRelay.test.ts
@@ -136,6 +136,36 @@ describe('SessionActivityRelay', () => {
     }));
   });
 
+  it('threads the target controller through every replay emit (targeted replay, L3)', () => {
+    const emit = vi.fn();
+    const relay = new SessionActivityRelay(emit, { minIntervalMs: 0 });
+
+    // 先留下一个 terminal replay 条目(未被 list 覆盖的会话)
+    relay.publish([activity('s-done', 'finishing')]);
+    relay.publish([]);
+    emit.mockClear();
+
+    relay.replay([activity('s1', 'Thinking')], 'controller-a');
+
+    // 活跃帧与 terminal 补发帧都必须带上同一目标控制端 —— 定向 replay 不惊扰其它设备
+    expect(emit).toHaveBeenCalledTimes(2);
+    expect(emit).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ sessionId: 's1', compactDetail: 'Thinking' }),
+      'controller-a',
+    );
+    expect(emit).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ sessionId: 's-done', phase: 'completed' }),
+      'controller-a',
+    );
+
+    // 无 target 的 replay 保持单参 emit(历史广播语义不变)
+    emit.mockClear();
+    relay.replay([activity('s1', 'Thinking')]);
+    expect(emit.mock.calls.every((call) => call.length === 1)).toBe(true);
+  });
+
   it('replays terminal clears that late subscribers may have missed', () => {
     const emit = vi.fn();
     const relay = new SessionActivityRelay(emit, { minIntervalMs: 1_500 });

--- a/apps/desktop/src/main/agent-island/service.ts
+++ b/apps/desktop/src/main/agent-island/service.ts
@@ -110,6 +110,7 @@ import {
 } from './layoutPreferenceStore.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
 import { tapWindowBroadcast } from '../device-link/broadcast-tap.js';
+import { pushSessionActivityToController } from '../device-link/dispatch.js';
 import {
   beginProtectedFolderCheck,
   detectProtectedFolderEperm,
@@ -274,7 +275,13 @@ export class AgentIslandService {
     sessionId: string;
     request: Extract<InteractionRequest, { kind: 'permission' }>;
   }>();
-  private readonly sessionActivityRelay = new SessionActivityRelay((payload) => {
+  private readonly sessionActivityRelay = new SessionActivityRelay((payload, target) => {
+    if (target !== undefined) {
+      // 定向 replay(某控制端刚完成 sessions 订阅):只补给那一台,走 dispatch 的
+      // 键控 latest-wins 缓冲 —— 不经 broadcast-tap 扇出,其它控制端与本机 renderer 零打扰。
+      pushSessionActivityToController(target, payload);
+      return;
+    }
     tapWindowBroadcast(SESSION_ACTIVITY_CHANNEL, payload);
   });
   private permissionResolver: ((requestId: string, decision: AgentIslandPermissionDecision) => boolean) | null = null;
@@ -1160,8 +1167,8 @@ export class AgentIslandService {
     this.commitMetadata(sessionId, next);
   }
 
-  replaySessionActivity(): void {
-    this.sessionActivityRelay.replay(this.buildSessionActivityPayload());
+  replaySessionActivity(controllerDeviceId: string): void {
+    this.sessionActivityRelay.replay(this.buildSessionActivityPayload(), controllerDeviceId);
   }
 
   /**

--- a/apps/desktop/src/main/agent-island/sessionActivityRelay.ts
+++ b/apps/desktop/src/main/agent-island/sessionActivityRelay.ts
@@ -34,7 +34,12 @@ export class SessionActivityRelay {
   private readonly terminalReplayPayloads = new Map<string, SessionActivityPayload>();
 
   constructor(
-    private readonly emit: (payload: SessionActivityPayload) => void,
+    /**
+     * 出帧回调。target 缺省(publish / clear 路径)= 广播语义,由消费方扇出给全部
+     * 订阅者;target 指定(replay 路径)= 只投递给该控制端 —— replay 是新订阅者的
+     * 补课,其它控制端状态本就新鲜,摇给全员只会在重连窗口制造结构性洪峰。
+     */
+    private readonly emit: (payload: SessionActivityPayload, target?: string) => void,
     options: SessionActivityRelayOptions = {},
   ) {
     this.minIntervalMs = Math.max(0, options.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS);
@@ -98,18 +103,31 @@ export class SessionActivityRelay {
     this.emit(payload);
   }
 
-  /** Replays current list activity without changing throttle state. */
-  replay(list: readonly AgentIslandSessionActivity[]): void {
+  /**
+   * Replays current list activity without changing throttle state.
+   * target 透传给 emit:指定时整轮 replay 只定向投递给该控制端(订阅触发的补课),
+   * 缺省保持历史广播语义。
+   */
+  replay(list: readonly AgentIslandSessionActivity[], target?: string): void {
     const seenSessionIds = new Set<string>();
     for (const activity of list) {
       if (!activity.sessionId) continue;
       seenSessionIds.add(activity.sessionId);
       const payload = toSessionActivityPayload(activity);
-      this.emit(isPublishableActivity(payload) ? payload : toTerminalActivityPayload(activity.sessionId));
+      this.emitTo(
+        isPublishableActivity(payload) ? payload : toTerminalActivityPayload(activity.sessionId),
+        target,
+      );
     }
     for (const [sessionId, payload] of this.terminalReplayPayloads) {
-      if (!seenSessionIds.has(sessionId)) this.emit(payload);
+      if (!seenSessionIds.has(sessionId)) this.emitTo(payload, target);
     }
+  }
+
+  /** 无 target 时保持与 publish/clear 路径完全同形的单参 emit(不附带 trailing undefined)。 */
+  private emitTo(payload: SessionActivityPayload, target: string | undefined): void {
+    if (target === undefined) this.emit(payload);
+    else this.emit(payload, target);
   }
 
   private publishOne(payload: SessionActivityPayload): void {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -2606,8 +2606,10 @@ const registerIpcHandlers = () => {
     getMainWindow: () => getWindow() ?? null,
     isPlannedRemoteDaemonClose: isCcMgrUpgradeInFlight,
   })?.setAppFocused(hasFocusedAppWindow());
-  setSessionsSubscribedListener(() => {
-    getAgentIslandService()?.replaySessionActivity();
+  setSessionsSubscribedListener((controllerDeviceId) => {
+    // 定向 replay:只补给刚完成 sessions 订阅的那台(经 dispatch 键控缓冲),
+    // 不再全员扇出 —— 多设备重连窗口互相陀螺式放大 push 洪峰是 #1375 取证的病根之一。
+    getAgentIslandService()?.replaySessionActivity(controllerDeviceId);
   });
 
   // 「在新窗口打开」会话多开 —— 新建一个完整窗口定位到该 session, 初始 bounds 取主窗。

--- a/apps/desktop/src/main/device-link/__tests__/dispatchActivityBuffer.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchActivityBuffer.test.ts
@@ -1,0 +1,269 @@
+/**
+ * dispatchActivityBuffer.test.ts — dispatch 层对 `sessions:activity` 的收编契约(L2+L3)。
+ * -------------------------------------------------------------------------------------
+ * 生产取证(2026-08-02,单 iPhone 配对):重连窗口 forwardPush 失败 466 次中
+ * sessions:activity 占 113;activity replay 是重连窗口秒满 per-peer 64 槽 pending
+ * 的主要载体,挤掉 invoke-result(#1375 病根链)。本文件钉死两层修复的 dispatch 行为:
+ *  [L2] forwardPush 把 sessions:activity 分流进键控 latest-wins 缓冲:洪峰坍缩成
+ *       O(会话数)、每窗口 ≤8 帧自钟控;真事件流(maker:event / sessions:patched 等)
+ *       路径零改动,逐帧直发。
+ *  [L3] pushSessionActivityToController 只发给指定控制端(定向 replay 出口),
+ *       其它控制端零帧;非 sessions 订阅者丢弃。
+ *  清理钩子:掉线 / 撤权 / 退订 sessions → 该 peer 暂存区清空,不给幽灵设备留定时器。
+ * 只 mock electron(app)+ settings-store;subscriptions 用真实模块。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeviceLinkError, SESSION_ACTIVITY_CHANNEL } from '@cindy/device-link';
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: () => '/tmp/xdt-maker-test/app',
+    getPath: () => '/tmp/xdt-maker-test',
+    getVersion: () => '0.0.0-test',
+  },
+  powerSaveBlocker: { start: () => 0, stop: () => {}, isStarted: () => false },
+  nativeImage: { createFromPath: () => ({ isEmpty: () => true }) },
+}));
+const deviceLinkSettings = vi.hoisted(() => ({
+  value: {
+    remoteControlEnabled: true,
+    revokedControllers: [] as string[],
+  },
+}));
+
+vi.mock('../settings-store', () => ({
+  readDeviceLinkSettings: () => deviceLinkSettings.value,
+}));
+
+import {
+  __testing,
+  handleControllerOffline,
+  pushSessionActivityToController,
+  setSessionsSubscribedListener,
+} from '../dispatch';
+import * as subscriptions from '../subscriptions';
+
+interface PushCall {
+  dst: string;
+  channel: string;
+  payload: unknown;
+}
+
+function mkClient() {
+  const pushes: PushCall[] = [];
+  const client = {
+    getStatus: vi.fn(() => 'online'),
+    sendInvokeResult: vi.fn(),
+    sendLinkAccept: vi.fn(),
+    closeLink: vi.fn(),
+    onFrame: vi.fn(),
+    sendPush: vi.fn((dst: string, channel: string, payload: unknown) => {
+      pushes.push({ dst, channel, payload });
+    }),
+  };
+  return { client, pushes };
+}
+
+const activity = (sessionId: string, detail: string) => ({
+  sessionId,
+  phase: 'running',
+  compactDetail: detail,
+  attention: false,
+});
+
+const activityFor = (pushes: PushCall[], dst: string) =>
+  pushes.filter((p) => p.dst === dst && p.channel === SESSION_ACTIVITY_CHANNEL);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  deviceLinkSettings.value = {
+    remoteControlEnabled: true,
+    revokedControllers: [],
+  };
+  __testing.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('[L2] forwardPush — sessions:activity 走键控 latest-wins 缓冲', () => {
+  it('collapses an activity storm to one latest frame per session per controller', () => {
+    const { client, pushes } = mkClient();
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions']);
+    subscriptions.subscribe('ctrl-b', ['sessions']);
+
+    // 60 帧洪峰打散在 3 个会话上(接收端 last-write-wins,中间帧无交付价值)
+    for (let i = 0; i < 60; i++) {
+      const sessionId = `s${i % 3}`;
+      __testing.forwardPush(SESSION_ACTIVITY_CHANNEL, activity(sessionId, `u${i}`));
+    }
+    vi.advanceTimersByTime(2_000);
+
+    for (const dst of ['ctrl-a', 'ctrl-b']) {
+      const got = activityFor(pushes, dst);
+      expect(got).toHaveLength(3); // O(事件数) → O(会话数)
+      const s2 = got.find((p) => (p.payload as { sessionId: string }).sessionId === 's2');
+      expect((s2?.payload as { compactDetail: string }).compactDetail).toBe('u59'); // 只发最新值
+    }
+  });
+
+  it('hands the transport at most 8 activity frames per pump window per controller', () => {
+    const { client, pushes } = mkClient();
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions']);
+
+    for (let i = 0; i < 20; i++) {
+      __testing.forwardPush(SESSION_ACTIVITY_CHANNEL, activity(`s${i}`, 'x'));
+    }
+    vi.advanceTimersByTime(0);
+    // 单窗口 ≤8:对 64 槽 per-peer pending 的侵占有硬上限,invoke-result 永远有余量
+    expect(activityFor(pushes, 'ctrl-a')).toHaveLength(8);
+    vi.advanceTimersByTime(250);
+    expect(activityFor(pushes, 'ctrl-a')).toHaveLength(16);
+    vi.advanceTimersByTime(250);
+    expect(activityFor(pushes, 'ctrl-a')).toHaveLength(20);
+  });
+
+  it('keeps real event channels on the direct per-frame path (zero behavior change)', () => {
+    const { client, pushes } = mkClient();
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions', 'session:s1']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', seq: 1 });
+    __testing.forwardPush('maker:event', { sessionId: 's1', seq: 2 });
+    __testing.forwardPush('local-db:sessions:patched', { sessionId: 's1', patch: {} });
+
+    // 不经缓冲、不等定时器、逐帧直发,帧序与到达序一致
+    expect(pushes.map((p) => p.channel)).toEqual([
+      'maker:event',
+      'maker:event',
+      'local-db:sessions:patched',
+    ]);
+  });
+
+  it('retains frames under BACKPRESSURE and delivers the latest value after backoff', () => {
+    const { client, pushes } = mkClient();
+    let pressured = true;
+    client.sendPush.mockImplementation((dst: string, channel: string, payload: unknown) => {
+      if (pressured) throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+      pushes.push({ dst, channel, payload });
+    });
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions']);
+
+    __testing.forwardPush(SESSION_ACTIVITY_CHANNEL, activity('s1', 'v1'));
+    vi.advanceTimersByTime(0);
+    expect(pushes).toHaveLength(0);
+    // 退避期间状态继续演进:同 key 覆盖,不堆积
+    __testing.forwardPush(SESSION_ACTIVITY_CHANNEL, activity('s1', 'v2'));
+    pressured = false;
+    vi.advanceTimersByTime(250);
+    expect(activityFor(pushes, 'ctrl-a')).toHaveLength(1);
+    expect((pushes[0].payload as { compactDetail: string }).compactDetail).toBe('v2');
+  });
+});
+
+describe('[L3] pushSessionActivityToController — 定向 replay 出口', () => {
+  it('delivers replay frames only to the subscribing controller; others get zero frames', () => {
+    const { client, pushes } = mkClient();
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions']);
+    subscriptions.subscribe('ctrl-b', ['sessions']);
+
+    pushSessionActivityToController('ctrl-a', activity('s1', 'replay') as never);
+    pushSessionActivityToController('ctrl-a', activity('s2', 'replay') as never);
+    vi.advanceTimersByTime(2_000);
+
+    expect(activityFor(pushes, 'ctrl-a')).toHaveLength(2);
+    expect(activityFor(pushes, 'ctrl-b')).toHaveLength(0); // 三端场景:B 不再陪吃 A 的 replay
+  });
+
+  it('compresses a replay burst through the same keyed buffer', () => {
+    const { client, pushes } = mkClient();
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions']);
+
+    // 200 条 replay(terminalReplayPayloads 上限)只压成 ≤ 会话数帧
+    for (let i = 0; i < 200; i++) {
+      pushSessionActivityToController('ctrl-a', activity(`s${i % 3}`, `r${i}`) as never);
+    }
+    vi.advanceTimersByTime(2_000);
+    expect(activityFor(pushes, 'ctrl-a')).toHaveLength(3);
+  });
+
+  it('coalesces replay with concurrent live publish for the same session (signature dedup)', () => {
+    const { client, pushes } = mkClient();
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions']);
+
+    // 订阅触发的 replay 与紧随的 live publish 同帧同 key → 只出一帧
+    pushSessionActivityToController('ctrl-a', activity('s1', 'same') as never);
+    __testing.forwardPush(SESSION_ACTIVITY_CHANNEL, activity('s1', 'same'));
+    vi.advanceTimersByTime(2_000);
+    expect(activityFor(pushes, 'ctrl-a')).toHaveLength(1);
+  });
+
+  it('drops frames for controllers without a sessions subscription', () => {
+    const { client, pushes } = mkClient();
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-heavy', ['session:s1']); // 只订了单会话流
+
+    pushSessionActivityToController('ctrl-heavy', activity('s1', 'x') as never);
+    pushSessionActivityToController('ctrl-unknown', activity('s1', 'x') as never);
+    vi.advanceTimersByTime(2_000);
+    expect(pushes).toHaveLength(0);
+  });
+
+  it('still passes the subscribing controller id to the replay listener', () => {
+    const { client } = mkClient();
+    __testing.setActiveClient(client as never);
+    const seen: string[] = [];
+    setSessionsSubscribedListener((controllerDeviceId) => {
+      seen.push(controllerDeviceId);
+    });
+    __testing.handleSubscriptionFrame('ctrl-a', {
+      channel: 'device-link:subscribe',
+      args: [{ topics: ['sessions'] }],
+    } as never);
+    expect(seen).toEqual(['ctrl-a']); // L3 链路的第一跳:src 一路透传到 replay
+    setSessionsSubscribedListener(null);
+  });
+});
+
+describe('清理钩子 — 幽灵设备不留缓冲与定时器', () => {
+  it('clears buffered frames when the controller goes offline / is revoked / unsubscribes', () => {
+    const { client, pushes } = mkClient();
+    client.sendPush.mockImplementation(() => {
+      throw new DeviceLinkError('BACKPRESSURE', 'full'); // 压住,让帧滞留暂存区
+    });
+    __testing.setActiveClient(client as never);
+    subscriptions.subscribe('ctrl-a', ['sessions']);
+    subscriptions.subscribe('ctrl-b', ['sessions']);
+    subscriptions.subscribe('ctrl-c', ['sessions']);
+
+    for (const dst of ['ctrl-a', 'ctrl-b', 'ctrl-c']) {
+      pushSessionActivityToController(dst, activity('s1', 'x') as never);
+    }
+    vi.advanceTimersByTime(0);
+    expect(__testing.sessionActivityOutbox.pendingCount('ctrl-a')).toBe(1);
+
+    handleControllerOffline('ctrl-a');
+    __testing.purgeRevokedController('ctrl-b');
+    __testing.handleSubscriptionFrame('ctrl-c', {
+      channel: 'device-link:unsubscribe',
+      args: [{ topics: ['sessions'] }],
+    } as never);
+
+    expect(__testing.sessionActivityOutbox.pendingCount('ctrl-a')).toBe(0);
+    expect(__testing.sessionActivityOutbox.pendingCount('ctrl-b')).toBe(0);
+    expect(__testing.sessionActivityOutbox.pendingCount('ctrl-c')).toBe(0);
+
+    client.sendPush.mockImplementation((dst: string, channel: string, payload: unknown) => {
+      pushes.push({ dst, channel, payload });
+    });
+    vi.advanceTimersByTime(10_000);
+    expect(pushes).toHaveLength(0); // 清理后没有任何残留定时器再出帧
+  });
+});

--- a/apps/desktop/src/main/device-link/__tests__/sessionActivityOutbox.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/sessionActivityOutbox.test.ts
@@ -1,0 +1,223 @@
+/**
+ * sessionActivityOutbox.test.ts — 键控 latest-wins 出站缓冲的行为契约(L2)。
+ * ---------------------------------------------------------------------------
+ * 核心不变量:
+ *  1. 洪峰坍缩:任意长的 activity 更新风暴,出站帧数 = 不同 key 数(O(会话数)),
+ *     且每个 key 只发**最新值**(接收端 last-write-wins,中间帧无交付价值)。
+ *  2. 自钟控:每 peer 单个泵窗口 ≤ maxBurst 帧,剩余按 pacing 续泵 —— 单次爆发
+ *     对 per-peer 可靠传输 pending(64 槽)的侵占有硬上限,invoke-result 与真
+ *     事件流永远有余量(与 PR #1375 的 invoke-result 抢占协同)。
+ *  3. BACKPRESSURE / 瞬态失败:条目保留,指数退避重试(250ms → 2s 封顶),
+ *     恢复后续发的仍是**最新值**;PAYLOAD_TOO_LARGE 丢 key 防毒帧卡泵。
+ *  4. relay 离线(canSend=false):缓冲保留、退避轮询,恢复在线自动续发 ——
+ *     覆盖 client.sendPush 离线静默 no-op 的假成功空洞。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { DeviceLinkError } from '@cindy/device-link';
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: () => '/tmp/xdt-maker-test/app',
+    getPath: () => '/tmp/xdt-maker-test',
+    getVersion: () => '0.0.0-test',
+  },
+}));
+
+import { SessionActivityOutbox } from '../sessionActivityOutbox';
+
+interface SentFrame {
+  dst: string;
+  channel: string;
+  payload: unknown;
+}
+
+const CH = 'local-db:sessions:activity';
+const key = (sessionId: string) => `${CH}:${sessionId}`;
+const frame = (sessionId: string, detail: string) => ({ sessionId, phase: 'running', compactDetail: detail });
+
+function makeOutbox(opts: {
+  sendImpl?: (dst: string, channel: string, payload: unknown) => void;
+  canSend?: () => boolean;
+} = {}) {
+  const sent: SentFrame[] = [];
+  const send = vi.fn((dst: string, channel: string, payload: unknown) => {
+    opts.sendImpl?.(dst, channel, payload);
+    sent.push({ dst, channel, payload });
+  });
+  const outbox = new SessionActivityOutbox({
+    send,
+    canSend: opts.canSend ?? (() => true),
+    maxBurst: 8,
+    pacingMs: 250,
+    backoffInitialMs: 250,
+    backoffMaxMs: 2_000,
+  });
+  return { outbox, send, sent };
+}
+
+describe('SessionActivityOutbox — 键控 latest-wins', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('collapses a 200-frame mixed-session storm into one latest frame per key', () => {
+    const { outbox, sent } = makeOutbox();
+    // 200 条更新打散在 10 个会话上(每会话 20 连发)
+    for (let i = 0; i < 200; i++) {
+      const sessionId = `s${i % 10}`;
+      outbox.enqueue('dev-a', key(sessionId), CH, frame(sessionId, `update-${i}`));
+    }
+    vi.advanceTimersByTime(2_000);
+    expect(sent).toHaveLength(10);
+    // 每个 key 只出最新值:s3 的末次更新是 i=193
+    const s3 = sent.find((f) => (f.payload as { sessionId: string }).sessionId === 's3');
+    expect((s3?.payload as { compactDetail: string }).compactDetail).toBe('update-193');
+    expect(outbox.pendingCount('dev-a')).toBe(0);
+  });
+
+  it('sends only the latest value for rapid same-key updates', () => {
+    const { outbox, sent } = makeOutbox();
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v1'));
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v2'));
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v3'));
+    vi.advanceTimersByTime(0);
+    expect(sent).toHaveLength(1);
+    expect((sent[0].payload as { compactDetail: string }).compactDetail).toBe('v3');
+  });
+
+  it('respects the per-window burst cap and drains the rest on pacing ticks', () => {
+    const { outbox, sent } = makeOutbox();
+    for (let i = 0; i < 20; i++) {
+      outbox.enqueue('dev-a', key(`s${i}`), CH, frame(`s${i}`, 'x'));
+    }
+    vi.advanceTimersByTime(0);
+    expect(sent).toHaveLength(8); // 首窗 ≤ maxBurst,64 槽 pending 永远吃不满
+    vi.advanceTimersByTime(250);
+    expect(sent).toHaveLength(16);
+    vi.advanceTimersByTime(250);
+    expect(sent).toHaveLength(20);
+    expect(outbox.pendingCount('dev-a')).toBe(0);
+  });
+
+  it('keeps burst windows independent per peer', () => {
+    const { outbox, sent } = makeOutbox();
+    for (let i = 0; i < 10; i++) {
+      outbox.enqueue('dev-a', key(`s${i}`), CH, frame(`s${i}`, 'a'));
+      outbox.enqueue('dev-b', key(`s${i}`), CH, frame(`s${i}`, 'b'));
+    }
+    vi.advanceTimersByTime(0);
+    expect(sent.filter((f) => f.dst === 'dev-a')).toHaveLength(8);
+    expect(sent.filter((f) => f.dst === 'dev-b')).toHaveLength(8);
+    vi.advanceTimersByTime(250);
+    expect(sent).toHaveLength(20);
+  });
+
+  it('retains entries on BACKPRESSURE and retries with the latest value after backoff', () => {
+    let pressured = true;
+    const { outbox, sent, send } = makeOutbox({
+      sendImpl: () => {
+        if (pressured) throw new DeviceLinkError('BACKPRESSURE', 'buffer full');
+      },
+    });
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v1'));
+    vi.advanceTimersByTime(0);
+    expect(sent).toHaveLength(0);
+    expect(outbox.pendingCount('dev-a')).toBe(1); // 保留,没有丢
+    // 退避期间新值覆盖同 key
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v2'));
+    pressured = false;
+    vi.advanceTimersByTime(250); // 首档退避
+    expect(sent).toHaveLength(1);
+    expect((sent[0].payload as { compactDetail: string }).compactDetail).toBe('v2');
+    expect(send).toHaveBeenCalledTimes(2); // 1 次失败 + 1 次成功
+  });
+
+  it('grows backoff exponentially up to the cap and resets after success', () => {
+    let failures = 0;
+    let pressured = true;
+    const { outbox, sent } = makeOutbox({
+      sendImpl: () => {
+        if (pressured) {
+          failures += 1;
+          throw new DeviceLinkError('BACKPRESSURE', 'buffer full');
+        }
+      },
+    });
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v'));
+    vi.advanceTimersByTime(0); // 失败#1 → 退避 250
+    vi.advanceTimersByTime(250); // 失败#2 → 500
+    vi.advanceTimersByTime(500); // 失败#3 → 1000
+    vi.advanceTimersByTime(1_000); // 失败#4 → 2000
+    vi.advanceTimersByTime(2_000); // 失败#5 → 封顶 2000
+    expect(failures).toBe(5);
+    vi.advanceTimersByTime(1_999);
+    expect(failures).toBe(5); // 封顶后仍按 2s 节奏,不提前
+    pressured = false;
+    vi.advanceTimersByTime(1);
+    expect(sent).toHaveLength(1);
+    expect(outbox.pendingCount('dev-a')).toBe(0);
+  });
+
+  it('drops the key on PAYLOAD_TOO_LARGE and keeps pumping the rest', () => {
+    const { outbox, sent } = makeOutbox({
+      sendImpl: (_dst, _channel, payload) => {
+        if ((payload as { sessionId: string }).sessionId === 's1') {
+          throw new DeviceLinkError('PAYLOAD_TOO_LARGE', 'too big');
+        }
+      },
+    });
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'poison'));
+    outbox.enqueue('dev-a', key('s2'), CH, frame('s2', 'ok'));
+    vi.advanceTimersByTime(0);
+    expect(sent).toHaveLength(1);
+    expect((sent[0].payload as { sessionId: string }).sessionId).toBe('s2');
+    expect(outbox.pendingCount('dev-a')).toBe(0); // 毒帧被丢弃,不卡泵
+  });
+
+  it('holds frames while offline and resends the latest once canSend flips back', () => {
+    let online = false;
+    const { outbox, sent } = makeOutbox({ canSend: () => online });
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v1'));
+    vi.advanceTimersByTime(3_000);
+    expect(sent).toHaveLength(0);
+    expect(outbox.pendingCount('dev-a')).toBe(1); // 断开期间缓冲保留
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'v2')); // 断开期间仍可覆盖
+    online = true;
+    vi.advanceTimersByTime(2_000); // 封顶退避内必然再泵一次
+    expect(sent).toHaveLength(1);
+    expect((sent[0].payload as { compactDetail: string }).compactDetail).toBe('v2');
+  });
+
+  it('clears per-peer state on clear() and everything on clearAll()', () => {
+    const { outbox, sent } = makeOutbox({ canSend: () => false });
+    outbox.enqueue('dev-a', key('s1'), CH, frame('s1', 'a'));
+    outbox.enqueue('dev-b', key('s1'), CH, frame('s1', 'b'));
+    outbox.clear('dev-a');
+    expect(outbox.pendingCount('dev-a')).toBe(0);
+    expect(outbox.pendingCount('dev-b')).toBe(1);
+    outbox.clearAll();
+    expect(outbox.pendingCount('dev-b')).toBe(0);
+    vi.advanceTimersByTime(10_000);
+    expect(sent).toHaveLength(0); // 清理后不再有任何定时器出帧
+  });
+
+  it('preserves oldest-first ordering and does not let overwrites starve older keys', () => {
+    const { outbox, sent } = makeOutbox();
+    for (let i = 0; i < 9; i++) {
+      outbox.enqueue('dev-a', key(`s${i}`), CH, frame(`s${i}`, 'v0'));
+    }
+    // s0 在首窗发出前被反复覆盖:不改变它的队首位置
+    outbox.enqueue('dev-a', key('s0'), CH, frame('s0', 'v1'));
+    vi.advanceTimersByTime(0);
+    expect(sent).toHaveLength(8);
+    expect((sent[0].payload as { sessionId: string }).sessionId).toBe('s0');
+    expect((sent[0].payload as { compactDetail: string }).compactDetail).toBe('v1');
+    // 第 9 个 key(s8)在下一个 pacing 窗口补上
+    vi.advanceTimersByTime(250);
+    expect(sent).toHaveLength(9);
+    expect((sent[8].payload as { sessionId: string }).sessionId).toBe('s8');
+  });
+});

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -38,6 +38,7 @@ import {
   DL_TELEGRAM_SET_ONLINE_CHANNEL,
   DeviceLinkError,
   parseFsWatchTopic,
+  SESSION_ACTIVITY_CHANNEL,
   type Envelope,
   type InvokePayload,
   type InvokeResultPayload,
@@ -67,6 +68,7 @@ import { adviseAndRecordVoiceInputDictionaryLearning } from '../voice-input/inde
 import { readDictionaryProjectionForMobile } from '../voice-input/dictionarySyncDriver.js';
 import { setBroadcastTapListener } from './broadcast-tap';
 import { createOfflinePushQueue } from './offlinePushQueue';
+import { SessionActivityOutbox } from './sessionActivityOutbox';
 import * as subscriptions from './subscriptions';
 import { LEGACY_TOPIC, type ActiveController } from './subscriptions';
 import { MAKER_PUSH } from '../maker-ipc/channels.js';
@@ -120,6 +122,32 @@ const UPDATE_RELAUNCH_NON_BLOCKING_INVOKE_CHANNELS: ReadonlySet<string> = new Se
 ]);
 const textEncoder = new TextEncoder();
 const offlinePushQueue = createOfflinePushQueue();
+
+/**
+ * `sessions:activity` 的键控 latest-wins 出站缓冲(结构性削峰,见模块头注释)。
+ * send 直接走 activeClient.sendPush(错误按 DeviceLinkError 分类);canSend 预判
+ * relay 在线,避开 sendPush 离线静默 no-op 导致的假成功。
+ */
+const sessionActivityOutbox = new SessionActivityOutbox({
+  send: (dst, channel, payload) => {
+    if (!activeClient) throw new DeviceLinkError('NOT_CONNECTED', 'device-link client not wired');
+    activeClient.sendPush(dst, channel, payload);
+  },
+  canSend: () => activeClient?.getStatus() === 'online',
+});
+
+/**
+ * 状态通道帧的缓冲 key;非 activity 通道 / 形状异常(无 sessionId)返回 null,
+ * 调用方回落 sendPushBestEffort 直发路径。只有 `sessions:activity` 被收编:
+ * 它是接收端 last-write-wins 的状态镜像;maker:event 等真事件流每帧有语义,不可合并。
+ */
+function sessionActivityOutboxKey(channel: string, payload: unknown): string | null {
+  if (channel !== SESSION_ACTIVITY_CHANNEL) return null;
+  if (!payload || typeof payload !== 'object') return null;
+  const sessionId = (payload as { sessionId?: unknown }).sessionId;
+  if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
+  return `${channel}:${sessionId}`;
+}
 
 /** 只排队可由 session snapshot 对账、且不携带权限终态的会话域事件。 */
 const OFFLINE_QUEUEABLE_PUSH_CHANNELS: ReadonlySet<string> = new Set([
@@ -575,12 +603,20 @@ function forwardPush(channel: string, payload: unknown): void {
     }
   }
   for (const dst of liveTargets) {
+    // 状态通道(sessions:activity)走键控 latest-wins 缓冲:洪峰压成 O(会话数) 且自钟控,
+    // 不再与 invoke-result / 真事件流抢 per-peer 可靠传输 pending 槽位(PR #1375 病根链)。
+    const activityKey = sessionActivityOutboxKey(channel, remotePayload);
+    if (activityKey !== null) {
+      sessionActivityOutbox.enqueue(dst, activityKey, channel, remotePayload);
+      continue;
+    }
     // 转发是尽力而为的旁路:单个控制端的帧超限(PAYLOAD_TOO_LARGE,如大 tool 输出)/ 连接异常
     // 绝不能冒泡——它会经 tapWindowBroadcast 回到 broadcastToAllWindows,让被控端**本机** renderer
     // 漏收该事件(本地 UI 是第一优先);per-dst 接住也避免一个控制端坏帧拖垮其它控制端的转发。
     sendPushBestEffort(dst, channel, remotePayload);
   }
 }
+
 
 /**
  * 被控端主动产生的 topic 域推送(不经 broadcast-tap 的路径):当前消费方是远程
@@ -735,6 +771,7 @@ export function dropAllControllers(
   topicSubscriptionControllers.clear();
   acceptedLinkControllers.clear();
   offlinePushQueue.clear();
+  sessionActivityOutbox.clearAll();
   syncForwarding();
 }
 
@@ -746,6 +783,9 @@ export function dropAllControllers(
  */
 export function handleControllerOffline(deviceId: string): void {
   acceptedLinkControllers.delete(deviceId);
+  // 活跃订阅已清,缓冲的 activity 帧失去投递对象;控制端恢复后重新 subscribe
+  // 会触发定向 replay 重新播种最新状态,不需要为离线设备留存退避重试定时器。
+  sessionActivityOutbox.clear(deviceId);
   if (subscriptions.clearController(deviceId)) {
     syncForwarding();
   }
@@ -759,6 +799,7 @@ export function forgetControllerInvokeState(deviceId: string): void {
 /** 显式撤销时清理短时离线队列与 remembered topic，避免恢复后重放撤权期间数据。 */
 export function purgeRevokedController(deviceId: string): void {
   offlinePushQueue.clear(deviceId);
+  sessionActivityOutbox.clear(deviceId);
   subscriptions.forgetKnownController(deviceId);
   topicSubscriptionControllers.delete(deviceId);
   acceptedLinkControllers.delete(deviceId);
@@ -792,6 +833,7 @@ async function handleFrame(client: DeviceLinkClient, env: Envelope): Promise<voi
       if (!src) return;
       clearRemoteInvokeStateFor(src);
       offlinePushQueue.clear(src);
+      sessionActivityOutbox.clear(src);
       acceptedLinkControllers.delete(src);
       // Keep the protocol-capability marker, but discard all remembered routing.
       // A modern controller must reconnect and explicitly subscribe; restoring the
@@ -1721,6 +1763,8 @@ function handleSubscriptionFrame(src: string, payload: InvokePayload): InvokeRes
     }
   } else {
     subscriptions.unsubscribe(src, topics);
+    // 退订 sessions 即不再欠该控制端列表级状态,丢弃其暂存区里尚未泵出的 activity 帧。
+    if (topics.includes('sessions')) sessionActivityOutbox.clear(src);
   }
   syncForwarding();
   if (isSub && topics.includes('sessions')) {
@@ -1992,6 +2036,7 @@ export const __testing = {
     onSessionsSubscribed = null;
     activeClient = null;
     offlinePushQueue.clear();
+    sessionActivityOutbox.clearAll();
     setBroadcastTapListener(null);
   },
   getActiveControllers,
@@ -2009,6 +2054,7 @@ export const __testing = {
   remoteInvokeResultOutboxSize: () => remoteInvokeResultOutbox.size,
   flushRemoteInvokeResultOutbox,
   forwardPush,
+  sessionActivityOutbox,
   queuedPushesFor(deviceId: string) {
     return offlinePushQueue.snapshot(deviceId);
   },

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -43,6 +43,7 @@ import {
   type InvokePayload,
   type InvokeResultPayload,
   type LinkOpenPayload,
+  type SessionActivityPayload,
   type Topic,
 } from '@cindy/device-link';
 import {
@@ -617,6 +618,22 @@ function forwardPush(channel: string, payload: unknown): void {
   }
 }
 
+/**
+ * L3 定向 replay 出口:把一帧 activity 只发给**指定控制端**(刚完成 `sessions` 订阅
+ * 的那台),不经 broadcast-tap 扇出惊扰其它控制端。走同一键控缓冲 —— replay 与
+ * 并发 publish 的同 key 帧自动合并,重连窗口的 replay 洪峰同样被压成 O(会话数)。
+ * 控制端已不在 `sessions` 订阅者集合(极短窗口内退订/断链)则丢弃,不为幽灵设备缓冲。
+ */
+export function pushSessionActivityToController(
+  controllerDeviceId: string,
+  payload: SessionActivityPayload,
+): void {
+  if (!activeClient) return;
+  if (!subscriptions.getControllersForTopic('sessions').includes(controllerDeviceId)) return;
+  const key = sessionActivityOutboxKey(SESSION_ACTIVITY_CHANNEL, payload);
+  if (key === null) return;
+  sessionActivityOutbox.enqueue(controllerDeviceId, key, SESSION_ACTIVITY_CHANNEL, payload);
+}
 
 /**
  * 被控端主动产生的 topic 域推送(不经 broadcast-tap 的路径):当前消费方是远程
@@ -2054,6 +2071,7 @@ export const __testing = {
   remoteInvokeResultOutboxSize: () => remoteInvokeResultOutbox.size,
   flushRemoteInvokeResultOutbox,
   forwardPush,
+  pushSessionActivityToController,
   sessionActivityOutbox,
   queuedPushesFor(deviceId: string) {
     return offlinePushQueue.snapshot(deviceId);

--- a/apps/desktop/src/main/device-link/sessionActivityOutbox.ts
+++ b/apps/desktop/src/main/device-link/sessionActivityOutbox.ts
@@ -1,0 +1,176 @@
+/**
+ * sessionActivityOutbox —— `sessions:activity` 状态通道的键控 latest-wins 出站缓冲。
+ * ---------------------------------------------------------------------------
+ * 动机(PR #1375 取证的结构性病根之一):活动摘要是**状态镜像**而非事件流——
+ * 接收端(mobile remoteSessionStore.applySessionActivity / desktop
+ * remoteSessionActivityStore)对同一 sessionId 严格 last-write-wins,中间帧没有
+ * 任何交付价值。把它按事件逐帧塞进 per-peer 可靠传输缓冲(64 槽),爆发期(重连
+ * replay / 多会话并发翻状态)会挤占 invoke-result 与真事件流的位置,是「push 洪流
+ * 塞死 pending → invoke-result could not be queued → 手机熔断」链路的主要载荷。
+ *
+ * 本缓冲把出站量从 O(事件数) 收敛到 O(会话数),并自钟控:
+ *  - 键控暂存:key = `channel:sessionId`,同 key 新帧**覆盖**旧帧(latest-wins),
+ *    任意长的同会话更新风暴至多占一个槽;签名相同的重复入队自然合并。
+ *  - 泵循环:每 peer 每个泵窗口最多 {@link DEFAULT_MAX_BURST} 帧交给传输层,
+ *    剩余条目按 {@link DEFAULT_PACING_MS} 间隔续泵——单次爆发对 64 槽 pending
+ *    的最大侵占恒为 maxBurst,给 invoke-result / maker:event 留出绝对余量。
+ *  - BACKPRESSURE / 瞬态发送失败:条目**保留**在暂存区,指数退避重试
+ *    (初始 {@link DEFAULT_BACKOFF_INITIAL_MS},上限 {@link DEFAULT_BACKOFF_MAX_MS});
+ *    退避期间新帧照常覆盖同 key,恢复后只发每个 key 的最新值。
+ *  - PAYLOAD_TOO_LARGE:丢弃该 key(活动帧是固定小结构,重试永不可能成功,
+ *    不能让毒帧卡死整个 peer 的泵)。
+ *  - peer link 断开/重建:缓冲保留(重连后自动续发最新值);peer 被移除
+ *    (link-close / 撤权 / presence 离线清订阅 / 显式退订 sessions)时由 dispatch
+ *    调 {@link SessionActivityOutbox.clear} 清理。
+ *
+ * 只收编 `sessions:activity` 这一个通道:maker:event 等真事件流每帧都有语义,
+ * 绝不能 latest-wins,继续走原 forwardPush 直发路径。
+ */
+
+import { DeviceLinkError } from '@cindy/device-link';
+import { createLogger } from '../logger';
+
+const log = createLogger('device-link-activity-outbox');
+
+/** 每 peer 单个泵窗口最多交给传输层的帧数(64 槽 pending 的侵占上限)。 */
+const DEFAULT_MAX_BURST = 8;
+/** 一个泵窗口发满后,续泵的间隔(自钟控节奏)。 */
+const DEFAULT_PACING_MS = 250;
+/** BACKPRESSURE / 瞬态失败后的首次重试延迟。 */
+const DEFAULT_BACKOFF_INITIAL_MS = 250;
+/** 指数退避上限。 */
+const DEFAULT_BACKOFF_MAX_MS = 2_000;
+
+type Timer = ReturnType<typeof setTimeout>;
+
+export interface SessionActivityOutboxOptions {
+  /** 把一帧交给传输层;失败以 DeviceLinkError 抛出(BACKPRESSURE 等)。 */
+  send: (dst: string, channel: string, payload: unknown) => void;
+  /**
+   * 泵之前的可发送判定(activeClient 存在且 relay online)。false → 条目保留、
+   * 按退避节奏轮询——覆盖 client.sendPush 在离线时**静默 no-op** 的空洞:若不
+   * 预判,离线期的"成功"会错误清掉 key,断开/重建就丢了最新值。
+   */
+  canSend: () => boolean;
+  maxBurst?: number;
+  pacingMs?: number;
+  backoffInitialMs?: number;
+  backoffMaxMs?: number;
+  setTimer?: (fn: () => void, ms: number) => Timer;
+  clearTimer?: (timer: Timer) => void;
+}
+
+interface PeerOutboxState {
+  /** key → 最新帧。Map 保序 = 先入队的 key 先泵出;覆盖不改变位置,无饥饿。 */
+  entries: Map<string, { channel: string; payload: unknown }>;
+  timer: Timer | null;
+  /** 0 = 健康;>0 = 当前退避档位(毫秒)。 */
+  backoffMs: number;
+}
+
+export class SessionActivityOutbox {
+  private readonly send: (dst: string, channel: string, payload: unknown) => void;
+  private readonly canSend: () => boolean;
+  private readonly maxBurst: number;
+  private readonly pacingMs: number;
+  private readonly backoffInitialMs: number;
+  private readonly backoffMaxMs: number;
+  private readonly setTimer: (fn: () => void, ms: number) => Timer;
+  private readonly clearTimer: (timer: Timer) => void;
+  private readonly peers = new Map<string, PeerOutboxState>();
+
+  constructor(options: SessionActivityOutboxOptions) {
+    this.send = options.send;
+    this.canSend = options.canSend;
+    this.maxBurst = Math.max(1, options.maxBurst ?? DEFAULT_MAX_BURST);
+    this.pacingMs = Math.max(0, options.pacingMs ?? DEFAULT_PACING_MS);
+    this.backoffInitialMs = Math.max(1, options.backoffInitialMs ?? DEFAULT_BACKOFF_INITIAL_MS);
+    this.backoffMaxMs = Math.max(this.backoffInitialMs, options.backoffMaxMs ?? DEFAULT_BACKOFF_MAX_MS);
+    this.setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clearTimer = options.clearTimer ?? ((timer) => clearTimeout(timer));
+  }
+
+  /**
+   * 入队(同 key 覆盖)。已有定时器时不抢跑:pacing 定时器代表节奏配额已用完,
+   * 退避定时器代表传输层拥塞——两种情况下插队都只会放大洪峰。
+   */
+  enqueue(dst: string, key: string, channel: string, payload: unknown): void {
+    let peer = this.peers.get(dst);
+    if (!peer) {
+      peer = { entries: new Map(), timer: null, backoffMs: 0 };
+      this.peers.set(dst, peer);
+    }
+    // Map.set 对已存在 key 保持插入位置:覆盖不插队、不饥饿更早入队的 key。
+    peer.entries.set(key, { channel, payload });
+    if (!peer.timer) this.schedulePump(dst, peer, 0);
+  }
+
+  /** peer 被移除(link-close / 撤权 / 掉线清订阅 / 退订 sessions)时清理。 */
+  clear(dst: string): void {
+    const peer = this.peers.get(dst);
+    if (!peer) return;
+    if (peer.timer) this.clearTimer(peer.timer);
+    this.peers.delete(dst);
+  }
+
+  clearAll(): void {
+    for (const dst of [...this.peers.keys()]) this.clear(dst);
+  }
+
+  /** 测试/诊断:该 peer 暂存区当前缓冲的帧数(= 不同 key 数)。 */
+  pendingCount(dst: string): number {
+    return this.peers.get(dst)?.entries.size ?? 0;
+  }
+
+  private schedulePump(dst: string, peer: PeerOutboxState, delayMs: number): void {
+    peer.timer = this.setTimer(() => {
+      peer.timer = null;
+      this.pump(dst, peer);
+    }, delayMs);
+  }
+
+  private pump(dst: string, peer: PeerOutboxState): void {
+    if (this.peers.get(dst) !== peer) return;
+    if (peer.entries.size === 0) {
+      this.peers.delete(dst);
+      return;
+    }
+    if (!this.canSend()) {
+      // relay 离线:保留全部条目,退避轮询等恢复(不能靠 send 的静默 no-op)。
+      this.backoffAndReschedule(dst, peer);
+      return;
+    }
+    let sent = 0;
+    for (const [key, entry] of peer.entries) {
+      if (sent >= this.maxBurst) break;
+      try {
+        this.send(dst, entry.channel, entry.payload);
+      } catch (err) {
+        if (err instanceof DeviceLinkError && err.code === 'PAYLOAD_TOO_LARGE') {
+          // 固定小结构不可能超限;真发生只能是异常帧,重试永不收敛 → 丢弃防毒帧卡泵。
+          log.warn(`dropping oversized activity frame for ${dst.slice(0, 8)} (${key})`);
+          peer.entries.delete(key);
+          continue;
+        }
+        // BACKPRESSURE / NOT_CONNECTED / socket 竞态:条目保留(含当前 key),退避重试。
+        this.backoffAndReschedule(dst, peer);
+        return;
+      }
+      peer.entries.delete(key);
+      sent += 1;
+    }
+    peer.backoffMs = 0;
+    if (peer.entries.size === 0) {
+      this.peers.delete(dst);
+      return;
+    }
+    this.schedulePump(dst, peer, this.pacingMs);
+  }
+
+  private backoffAndReschedule(dst: string, peer: PeerOutboxState): void {
+    peer.backoffMs = peer.backoffMs === 0
+      ? this.backoffInitialMs
+      : Math.min(peer.backoffMs * 2, this.backoffMaxMs);
+    this.schedulePump(dst, peer, peer.backoffMs);
+  }
+}

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -8,7 +8,9 @@ import { PROTOCOL_VERSION, DeviceLinkError, type Envelope } from '../protocol.js
 import {
   DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT,
   DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+  MAX_TRANSPORT_PENDING_MESSAGES,
   MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES,
+  TRANSPORT_PENDING_PUSH_MAX_AGE_MS,
   encodeReliableFrames,
   makeTransportSkipPayload,
   parseTransportPayload,
@@ -1207,6 +1209,142 @@ describe('DeviceLinkClient', () => {
     h.client.sendPush('dev-b', 'maker:event', { text: 'sent' });
     const sent = h.current().sent.filter((e) => e.kind === 'push' && e.dst === 'dev-b');
     expect(parseTransportPayload(sent.at(-1)!.payload)?.meta.seq).toBe(1);
+    h.client.stop();
+  });
+
+  it('缓冲被未 ACK 的 push 占满时，invoke-result 按最旧优先驱逐 push 腾位，不被饿死', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'starved-stream');
+
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    // push 之间不互相驱逐：溢出的 push 仍按原语义被背压拒绝
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+
+    // invoke-result 是控制端的存活凭据：驱逐最旧 push 腾位，立即入队发出
+    expect(() =>
+      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('to make room for invoke-result'),
+    );
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    const meta = parseTransportPayload(resultFrame.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    // 只驱逐了最旧的 seq=1：baseSeq 前移到 2，其余未过期 push 保留等待 ACK
+    expect(meta.baseSeq).toBe(2);
+    h.client.stop();
+  });
+
+  it('建链即清扫：离线期间过期的 push 不再重放，link-accept 的 baseSeq 直接跳过它们', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'stale-stream');
+
+    h.client.sendPush('dev-b', 'maker:event', { text: 'stale-1' });
+    h.client.sendPush('dev-b', 'maker:event', { text: 'stale-2' });
+    h.client.sendPush('dev-b', 'maker:event', { text: 'stale-3' });
+
+    // 静默断连(无 link-close,如对端失联/中继断开):push 留在 pending 等待重放
+    h.current().emit('close', 1006, 'network lost');
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
+    h.current().ack();
+    await tick();
+
+    // 离线时长超过 push 最大滞留时长后控制端重新建链
+    const realNow = Date.now;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(
+      () => realNow() + TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1_000,
+    );
+    try {
+      const before = h.current().sent.length;
+      await establishInboundReliableLink(h, 'stale-stream-reopen');
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('swept 3 expired push frame(s)'),
+      );
+      // accept 直接宣告新基线：过期 push 的 seq 1..3 被接收端整体跳过
+      const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
+      expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq).toBe(4);
+      // 过期 push 一条都不重放
+      const replayedPushes = h.current().sent.slice(before).filter((env) =>
+        env.kind === 'push' && env.dst === 'dev-b' && parseTransportPayload(env.payload) !== null,
+      );
+      expect(replayedPushes).toHaveLength(0);
+
+      // 建链后 invoke-result 立即发出，不再排在陈旧 push 的重放洪峰后面
+      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+      const resultFrame = h.current().sent.find(
+        (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+      )!;
+      expect(parseTransportPayload(resultFrame.payload)!.meta.seq).toBe(4);
+    } finally {
+      nowSpy.mockRestore();
+    }
+    h.client.stop();
+  });
+
+  it('腾位只驱逐 push：队头是未完成 invoke 时不驱逐，invoke-result 保持原背压语义', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, requestTimeoutMs: 5_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+
+    const open = h.client.openLink('dev-b', {
+      controllerName: 'Test',
+      protocolVersion: 1,
+      appVersion: '1',
+    });
+    const sentOpen = h.current().sent.find((e) => e.kind === 'link-open')!;
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-accept',
+      id: sentOpen.id,
+      src: 'dev-b',
+      payload: {
+        appVersion: '1',
+        allowlistHash: 'hash',
+        capabilities: [DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT],
+        transportStreamId: 'remote-stream',
+      },
+    });
+    await open;
+
+    // 队头 seq=1 是等待响应的 invoke，其后被 push 填满
+    const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
+    p.catch(() => {});
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 1; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    expect(() => h.client.sendInvokeResult('dev-b', 'r1', { ok: true, result: [] })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('to make room for invoke-result'),
+    );
     h.client.stop();
   });
 

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -107,6 +107,7 @@ async function establishInboundReliableLink(
   h: Harness,
   streamId: string,
   transportBaseSeq = 1,
+  src = 'dev-b',
 ): Promise<void> {
   const id = `inbound-link-${++inboundLinkId}`;
   const off = h.client.onFrame((env) => {
@@ -120,7 +121,7 @@ async function establishInboundReliableLink(
     v: PROTOCOL_VERSION,
     kind: 'link-open',
     id,
-    src: 'dev-b',
+    src,
     payload: {
       controllerName: 'Remote',
       protocolVersion: 1,
@@ -1651,6 +1652,129 @@ describe('DeviceLinkClient', () => {
 
     host.stop();
     controller.stop();
+  });
+
+  it('被驱逐 seq 的迟到 ACK 幂等无害：不误删存活的 result、不抛错、不错推状态', async () => {
+    const h = makeHarness({ timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 } });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'stale-ack-stream');
+
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    // 驱逐 seq 1..64，result 以 seq=65 入队
+    h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    const streamId = parseTransportPayload(resultFrame.payload)!.meta.streamId;
+
+    // 驱逐×ACK 竞态：接收端对早已被驱逐的 seq=3 的迟到累计 ACK 现在才到
+    const sendAck = (ackSeq: number) => h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'push',
+      src: 'dev-b',
+      payload: {
+        channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+        payload: { streamId, ackSeq },
+      },
+    });
+    sendAck(3);
+    // 越界的未知 ACK（超过 nextSeq-1）同样幂等忽略
+    sendAck(999);
+    await tick();
+
+    // result 仍在 pending 队头：后续帧的 baseSeq 仍指向 65，未被误删
+    h.client.sendPush('dev-b', 'maker:event', { text: 'after-stale-ack' });
+    const pushFrames = h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    const afterStale = parseTransportPayload(pushFrames[pushFrames.length - 1].payload)!.meta;
+    expect(afterStale.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 2);
+    expect(afterStale.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+
+    // 真正的 ACK(65) 只清掉 result：再下一帧 baseSeq 前移到 66
+    sendAck(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    await tick();
+    h.client.sendPush('dev-b', 'maker:event', { text: 'after-real-ack' });
+    const pushFrames2 = h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    const afterReal = parseTransportPayload(pushFrames2[pushFrames2.length - 1].payload)!.meta;
+    expect(afterReal.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 3);
+    expect(afterReal.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 2);
+    h.client.stop();
+  });
+
+  it('单 FIFO 固有极限：live invoke 卡在中段时，result 只跨过其前的可丢弃前缀，语义一致不死锁', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'mid-live-stream');
+
+    // 队形：[push(1), live-invoke(2), push×62] → 满 64
+    h.client.sendPush('dev-b', 'maker:event', { text: 'head-discardable' });
+    const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
+    p.catch(() => {});
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    // 前缀清扫停在 live invoke：只丢 seq=1，result 入队但排在 invoke+push 之后。
+    // 这是维护者确认的单 FIFO 极限：live 帧之后的 push 不可跨越（会留 seq 空洞）
+    expect(() =>
+      h.client.sendInvokeResult('dev-b', 'queued-result', { ok: true, result: [] }),
+    ).not.toThrow();
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'queued-result',
+    )!;
+    const meta = parseTransportPayload(resultFrame.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    expect(meta.baseSeq).toBe(2);
+
+    // 再次满员且队头已是 live invoke：前缀为空，维持 BACKPRESSURE，不死循环不死锁
+    expect(() => h.client.sendInvokeResult('dev-b', 'r2', { ok: true, result: [] })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    h.client.stop();
+  });
+
+  it('驱逐只作用于目标 peer：另一控制端的 pending 不受影响', async () => {
+    const h = makeHarness({ timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 } });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'iso-b');
+    await establishInboundReliableLink(h, 'iso-c', 1, 'dev-c');
+
+    h.client.sendPush('dev-c', 'maker:event', { keep: true });
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    // dev-b 的 result 驱逐 dev-b 全部 64 条 push
+    h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+    const resultMeta = parseTransportPayload(
+      h.current().sent.find((env) => env.kind === 'invoke-result' && env.id === 'probe-result')!.payload,
+    )!.meta;
+    expect(resultMeta.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+
+    // dev-c 的缓冲丝毫未动：seq=1 仍在 pending，新帧 baseSeq 仍为 1
+    h.client.sendPush('dev-c', 'maker:event', { second: true });
+    const devCFrames = h.current().sent.filter(
+      (env) => env.kind === 'push' && env.dst === 'dev-c' && parseTransportPayload(env.payload) !== null,
+    );
+    const devCMeta = parseTransportPayload(devCFrames[devCFrames.length - 1].payload)!.meta;
+    expect(devCMeta.seq).toBe(2);
+    // 线上格式在 baseSeq === 1 时省略该字段：基线仍为 1 即未发生任何驱逐
+    expect(devCMeta.baseSeq ?? 1).toBe(1);
+    h.client.stop();
   });
 
   it('invoke request id 在没有 global crypto 的运行时仍可生成', async () => {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -134,6 +134,143 @@ async function establishInboundReliableLink(
   off();
 }
 
+/** 接入内存中继的 fake socket：send 时把帧交给中继按 dst 保序路由。 */
+class RelayWs extends FakeWs {
+  constructor(
+    private readonly relay: MemoryRelay,
+    readonly ownerId: string,
+  ) {
+    super();
+  }
+
+  override send(data: string): void {
+    super.send(data);
+    this.relay.route(this.ownerId, this, JSON.parse(data) as Envelope);
+  }
+}
+
+/**
+ * 双客户端内存中继：单队列按帧到达顺序逐帧投递，验证接收端的「实际交付」
+ * 顺序而不只是发送端 emit。与真实 relay 一致：目的地离线的帧在入口处丢弃
+ *（发送端的可靠层靠未 ACK 的 pending 自行保留）。
+ */
+class MemoryRelay {
+  /** 按目的地记录实际投递给对端的帧（不含 hello-ack/pong 控制帧）。 */
+  readonly deliveredTo = new Map<string, Envelope[]>();
+  private readonly members = new Map<string, { ws: RelayWs | null }>();
+  private readonly queue: Array<
+    | { kind: 'direct'; ws: RelayWs; env: Envelope }
+    | { kind: 'routed'; dstId: string; env: Envelope }
+  > = [];
+
+  makeWebSocket(deviceId: string): RelayWs {
+    const member = this.members.get(deviceId) ?? { ws: null };
+    this.members.set(deviceId, member);
+    const ws = new RelayWs(this, deviceId);
+    member.ws = ws;
+    // 客户端在 createWebSocket 返回后才挂 handler：延到下一个宏任务再 open
+    setTimeout(() => {
+      if (this.members.get(deviceId)?.ws === ws) ws.emit('open');
+    }, 0);
+    return ws;
+  }
+
+  /** 静默掉线（无 link-close）：之后发往该设备的帧在入口处被丢弃。 */
+  disconnect(deviceId: string): void {
+    const member = this.members.get(deviceId);
+    if (!member?.ws) return;
+    const ws = member.ws;
+    member.ws = null;
+    ws.emit('close', 1006, 'network lost');
+  }
+
+  route(senderId: string, ws: RelayWs, env: Envelope): void {
+    if (env.kind === 'hello') {
+      this.queue.push({
+        kind: 'direct',
+        ws,
+        env: {
+          v: PROTOCOL_VERSION,
+          kind: 'hello-ack',
+          payload: { serverProtocolVersion: PROTOCOL_VERSION, deviceId: senderId, userId: 'u1' },
+        },
+      });
+      return;
+    }
+    if (env.kind === 'ping') {
+      this.queue.push({ kind: 'direct', ws, env: { v: PROTOCOL_VERSION, kind: 'pong' } });
+      return;
+    }
+    if (!env.dst) return;
+    // 入口即判定在线与否：离线目的地直接丢帧，不缓存、不重排
+    if (!this.members.get(env.dst)?.ws) return;
+    this.queue.push({ kind: 'routed', dstId: env.dst, env: { ...env, src: senderId } });
+  }
+
+  /** 按顺序逐帧投递直到静默；每帧之间让微任务（drain/ACK）跑完。 */
+  async settle(): Promise<void> {
+    let idle = 0;
+    while (idle < 3) {
+      const entry = this.queue.shift();
+      if (!entry) {
+        idle += 1;
+        await tick();
+        continue;
+      }
+      idle = 0;
+      if (entry.kind === 'direct') {
+        if (this.members.get(entry.ws.ownerId)?.ws === entry.ws) entry.ws.push(entry.env);
+      } else {
+        const member = this.members.get(entry.dstId);
+        if (member?.ws) {
+          let log = this.deliveredTo.get(entry.dstId);
+          if (!log) {
+            log = [];
+            this.deliveredTo.set(entry.dstId, log);
+          }
+          log.push(entry.env);
+          member.ws.push(entry.env);
+        }
+      }
+      await tick();
+    }
+  }
+
+  /** 持续泵送直到条件成立（如等待重连退避计时器触发）。 */
+  async settleUntil(condition: () => boolean, timeoutMs = 3_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      await this.settle();
+      if (condition()) return;
+      if (Date.now() > deadline) throw new Error('MemoryRelay.settleUntil timed out');
+      await tick(5);
+    }
+  }
+}
+
+function makeRelayClient(relay: MemoryRelay, deviceId: string): DeviceLinkClient {
+  return new DeviceLinkClient({
+    getWsUrl: () => 'ws://test/api/device-link/ws',
+    getToken: async () => 'jwt-token',
+    getHello: () => ({
+      deviceName: deviceId,
+      platform: 'darwin',
+      appVersion: '1.0.0',
+      remoteControlEnabled: true,
+      busy: false,
+    }),
+    createWebSocket: () => relay.makeWebSocket(deviceId),
+    timing: {
+      reconnectBaseMs: 5,
+      reconnectMaxMs: 20,
+      pingIntervalMs: 60_000,
+      pongMissLimit: 4,
+      requestTimeoutMs: 2_000,
+      transportRetryIntervalMs: 60_000,
+    },
+  });
+}
+
 describe('DeviceLinkClient', () => {
   it('start → open 后第一帧是 hello,hello-ack 后 online', async () => {
     const h = makeHarness();
@@ -517,7 +654,7 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
-  it('可靠消息重试耗尽后主动重连，并在新 link 上重放同一 seq', async () => {
+  it('可靠消息重试耗尽后主动重连，并在新 link 上重放同一 seq（用不可丢弃的 invoke-result 验证；队头 push 重连时作为可丢弃前缀被放弃）', async () => {
     const h = makeHarness({
       timing: {
         pingIntervalMs: 1_000,
@@ -552,9 +689,9 @@ describe('DeviceLinkClient', () => {
     await firstOpen;
 
     const firstSocket = h.current();
-    h.client.sendPush('dev-b', 'maker:event', { text: 'replay me' });
+    h.client.sendInvokeResult('dev-b', 'replay-me', { ok: true, result: [] });
     const firstReliable = firstSocket.sent.find((env) => (
-      env.kind === 'push' && parseTransportPayload(env.payload)
+      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
     ))!;
     const firstMeta = parseTransportPayload(firstReliable.payload)!.meta;
 
@@ -583,7 +720,7 @@ describe('DeviceLinkClient', () => {
     await secondOpen;
 
     const replays = h.current().sent.filter((env) => (
-      env.kind === 'push' && parseTransportPayload(env.payload)
+      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
     ));
     expect(replays).toHaveLength(1);
     const replay = replays[0];
@@ -1212,7 +1349,7 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
-  it('缓冲被未 ACK 的 push 占满时，invoke-result 按最旧优先驱逐 push 腾位，不被饿死', async () => {
+  it('缓冲被未 ACK 的 push 占满时，invoke-result 丢弃整个可丢弃前缀，成为最早的 live seq', async () => {
     const warn = vi.fn();
     const h = makeHarness({
       timing: { pingIntervalMs: 10_000 },
@@ -1226,12 +1363,13 @@ describe('DeviceLinkClient', () => {
     for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
       h.client.sendPush('dev-b', 'maker:event', { i });
     }
-    // push 之间不互相驱逐：溢出的 push 仍按原语义被背压拒绝
+    // push 之间不互相驱逐：新鲜 push 溢出仍按原语义被背压拒绝
     expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
       expect.objectContaining({ code: 'BACKPRESSURE' }),
     );
 
-    // invoke-result 是控制端的存活凭据：驱逐最旧 push 腾位，立即入队发出
+    // invoke-result 是控制端的存活凭据：丢弃整个队头可丢弃前缀（fresh push
+    // 一并放弃），立即入队发出，不留任何 push 排在 result 之前
     expect(() =>
       h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] }),
     ).not.toThrow();
@@ -1243,12 +1381,13 @@ describe('DeviceLinkClient', () => {
     )!;
     const meta = parseTransportPayload(resultFrame.payload)!.meta;
     expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
-    // 只驱逐了最旧的 seq=1：baseSeq 前移到 2，其余未过期 push 保留等待 ACK
-    expect(meta.baseSeq).toBe(2);
+    // 整个 push 前缀被丢弃：baseSeq 直接前移到 result 自身，接收端不再等任何
+    // 被丢弃的 seq，result 就是下一条可交付的 live 帧
+    expect(meta.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
     h.client.stop();
   });
 
-  it('建链即清扫：离线期间过期的 push 不再重放，link-accept 的 baseSeq 直接跳过它们', async () => {
+  it('建链即丢弃可丢弃前缀：离线期间堆积的 push 不分新旧都不重放，link-accept 的 baseSeq 直接跳过它们', async () => {
     const warn = vi.fn();
     const h = makeHarness({
       timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
@@ -1259,6 +1398,8 @@ describe('DeviceLinkClient', () => {
     h.current().ack();
     await establishInboundReliableLink(h, 'stale-stream');
 
+    // 三条均为新鲜 push：重连重放路径不看 TTL，单 FIFO 无法同时保证 push 无损
+    // 与 invoke-result 抢占，重建链路时整个可丢弃前缀一律放弃
     h.client.sendPush('dev-b', 'maker:event', { text: 'stale-1' });
     h.client.sendPush('dev-b', 'maker:event', { text: 'stale-2' });
     h.client.sendPush('dev-b', 'maker:event', { text: 'stale-3' });
@@ -1269,40 +1410,137 @@ describe('DeviceLinkClient', () => {
     h.current().ack();
     await tick();
 
-    // 离线时长超过 push 最大滞留时长后控制端重新建链
-    const realNow = Date.now;
-    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(
-      () => realNow() + TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1_000,
+    const before = h.current().sent.length;
+    await establishInboundReliableLink(h, 'stale-stream-reopen');
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('dropped 3 discardable pending frame(s)'),
     );
-    try {
-      const before = h.current().sent.length;
-      await establishInboundReliableLink(h, 'stale-stream-reopen');
+    // accept 直接宣告新基线：被丢弃 push 的 seq 1..3 被接收端整体跳过
+    const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
+    expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq).toBe(4);
+    // 堆积的 push 一条都不重放
+    const replayedPushes = h.current().sent.slice(before).filter((env) =>
+      env.kind === 'push' && env.dst === 'dev-b' && parseTransportPayload(env.payload) !== null,
+    );
+    expect(replayedPushes).toHaveLength(0);
 
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('swept 3 expired push frame(s)'),
-      );
-      // accept 直接宣告新基线：过期 push 的 seq 1..3 被接收端整体跳过
-      const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
-      expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq).toBe(4);
-      // 过期 push 一条都不重放
-      const replayedPushes = h.current().sent.slice(before).filter((env) =>
-        env.kind === 'push' && env.dst === 'dev-b' && parseTransportPayload(env.payload) !== null,
-      );
-      expect(replayedPushes).toHaveLength(0);
-
-      // 建链后 invoke-result 立即发出，不再排在陈旧 push 的重放洪峰后面
-      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
-      const resultFrame = h.current().sent.find(
-        (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
-      )!;
-      expect(parseTransportPayload(resultFrame.payload)!.meta.seq).toBe(4);
-    } finally {
-      nowSpy.mockRestore();
-    }
+    // 建链后 invoke-result 立即发出，不再排在陈旧 push 的重放洪峰后面
+    h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] });
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    expect(parseTransportPayload(resultFrame.payload)!.meta.seq).toBe(4);
     h.client.stop();
   });
 
-  it('腾位只驱逐 push：队头是未完成 invoke 时不驱逐，invoke-result 保持原背压语义', async () => {
+  it('push 入队压力只做 TTL 兜底清扫（单调时钟计量），新鲜 push 之间仍互相背压', async () => {
+    // TTL 用单调时钟：墙钟被 NTP 向前校正超过 TTL 时，刚入队的 push 不得被误判过期
+    const proto = DeviceLinkClient.prototype as unknown as { monotonicNow(): number };
+    let nowMs = 10_000;
+    const clock = vi.spyOn(proto, 'monotonicNow').mockImplementation(() => nowMs);
+    try {
+      const warn = vi.fn();
+      const h = makeHarness({
+        timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+        logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+      });
+      h.client.start();
+      await tick();
+      h.current().ack();
+      await establishInboundReliableLink(h, 'ttl-stream');
+
+      h.client.sendPush('dev-b', 'maker:event', { text: 'old-1' });
+      h.client.sendPush('dev-b', 'maker:event', { text: 'old-2' });
+      // 只推进单调时钟：前两条 push 超龄，后续 push 保持新鲜
+      nowMs += TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1;
+      for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
+        h.client.sendPush('dev-b', 'maker:event', { i });
+      }
+
+      // 缓冲满：新 push 触发 TTL 兜底清扫，只有 2 条过期 push 出队，新 push 入队
+      expect(() =>
+        h.client.sendPush('dev-b', 'maker:event', { text: 'fresh-after-sweep' }),
+      ).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('dropped 2 discardable pending frame(s)'),
+      );
+      const frames = h.current().sent.filter(
+        (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+      );
+      const meta = parseTransportPayload(frames[frames.length - 1].payload)!.meta;
+      expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+      expect(meta.baseSeq).toBe(3);
+
+      // 填回满员后队头是新鲜 push：不互相驱逐，仍按原语义背压
+      h.client.sendPush('dev-b', 'maker:event', { text: 'refill' });
+      expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
+        expect.objectContaining({ code: 'BACKPRESSURE' }),
+      );
+      h.client.stop();
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('队头 skip 占位不再挡住腾位：invoke 超时成 skip 后，invoke-result 跨过 skip 与 push 入队，重连后第一个重放', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'skip-head-stream');
+
+    // seq=1：invoke 超时后被 dropReliablePendingForRequest 换成 transport-skip
+    // 占位：外层 kind 仍是 invoke，但已无业务副作用
+    const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 20);
+    await expect(p).rejects.toMatchObject({ code: 'INVOKE_TIMEOUT' });
+
+    // skip 之后队列被 push 填满
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 1; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    // 旧判据按外层 kind === 'invoke' 会在队头 skip 上停下→BACKPRESSURE；
+    // 新判据（push || isTransportSkipPayload）跨过 skip 与全部 push
+    expect(() =>
+      h.client.sendInvokeResult('dev-b', 'probe-result', { ok: true, result: [] }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('to make room for invoke-result'),
+    );
+    const resultFrame = h.current().sent.find(
+      (env) => env.kind === 'invoke-result' && env.id === 'probe-result',
+    )!;
+    const meta = parseTransportPayload(resultFrame.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    expect(meta.baseSeq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+
+    // 静默断连后重建链路：重放的第一帧就是这条 result，没有 skip/push 挡在前面
+    h.current().emit('close', 1006, 'network lost');
+    await vi.waitFor(() => expect(h.sockets.length).toBeGreaterThanOrEqual(2));
+    h.current().ack();
+    await tick();
+    const before = h.current().sent.length;
+    await establishInboundReliableLink(h, 'skip-head-stream-reopen');
+
+    const accept = h.current().sent.slice(before).find((env) => env.kind === 'link-accept')!;
+    expect((accept.payload as { transportBaseSeq?: number }).transportBaseSeq)
+      .toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    const replayed = h.current().sent.slice(before).filter(
+      (env) => parseTransportPayload(env.payload) !== null,
+    );
+    expect(replayed).toHaveLength(1);
+    expect(replayed[0].kind).toBe('invoke-result');
+    expect(parseTransportPayload(replayed[0].payload)!.meta.baseSeq)
+      .toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    h.client.stop();
+  });
+
+  it('腾位只跨过可丢弃帧：队头是 live invoke 时不驱逐，invoke-result 保持原背压语义', async () => {
     const warn = vi.fn();
     const h = makeHarness({
       timing: { pingIntervalMs: 10_000, requestTimeoutMs: 5_000 },
@@ -1332,7 +1570,8 @@ describe('DeviceLinkClient', () => {
     });
     await open;
 
-    // 队头 seq=1 是等待响应的 invoke，其后被 push 填满
+    // 队头 seq=1 是仍在等待响应的 live invoke（未超时、未被换成 skip），其后被 push 填满；
+    // live invoke 是可丢弃前缀的边界，其后的 push 不可跨越（否则留下 seq 空洞）
     const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
     p.catch(() => {});
     for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 1; i++) {
@@ -1346,6 +1585,72 @@ describe('DeviceLinkClient', () => {
       expect.stringContaining('to make room for invoke-result'),
     );
     h.client.stop();
+  });
+
+  it('双端有序中继：64 条 fresh push 灌满后重连，探测 invoke 的 result 先于任何重放 push 实际交付并在超时前 resolve', async () => {
+    const relay = new MemoryRelay();
+    const host = makeRelayClient(relay, 'dev-a');
+    const controller = makeRelayClient(relay, 'dev-b');
+    // host 侧应用逻辑：自动接受 link-open，即时应答 invoke（存活探测）
+    host.onFrame((env) => {
+      if (env.kind === 'link-open' && env.src && env.id) {
+        host.sendLinkAccept(env.src, env.id, { appVersion: '1', allowlistHash: 'hash' });
+      }
+      if (env.kind === 'invoke' && env.src && env.id) {
+        host.sendInvokeResult(env.src, env.id, { ok: true, result: ['alive'] });
+      }
+    });
+    host.start();
+    controller.start();
+    await relay.settleUntil(
+      () => host.getStatus() === 'online' && controller.getStatus() === 'online',
+    );
+
+    const open = controller.openLink('dev-a', {
+      controllerName: 'Ctrl',
+      protocolVersion: 1,
+      appVersion: '1',
+    });
+    await relay.settle();
+    await open;
+
+    // 控制端整夜离线：host 同步灌满 64 条 fresh push（入口即丢，但全部滞留
+    // 在 host 的可靠 pending 里等 ACK，与线上事故的堆积形态一致）
+    relay.disconnect('dev-b');
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      host.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    // 控制端重连、重新建链，立即发存活探测
+    await relay.settleUntil(() => controller.getStatus() === 'online');
+    const reopen = controller.openLink('dev-a', {
+      controllerName: 'Ctrl',
+      protocolVersion: 1,
+      appVersion: '1',
+    });
+    await relay.settle();
+    await reopen;
+    const probe = controller.invoke(
+      'dev-a',
+      { channel: 'maker:list-active', args: [] },
+      2_000,
+    );
+    await relay.settle();
+
+    // 关键断言 1：探测在超时窗口内真实 resolve（交付验证，非发送端 emit）
+    await expect(probe).resolves.toMatchObject({ ok: true });
+
+    // 关键断言 2：控制端收到的可靠传输帧里，result 排第一，前面没有任何
+    // 重放的 push（旧实现会先把 64 条 push 写进 WS FIFO，result 只能排尾）
+    const transportFrames = (relay.deliveredTo.get('dev-b') ?? []).filter(
+      (env) => parseTransportPayload(env.payload) !== null,
+    );
+    expect(transportFrames.length).toBeGreaterThan(0);
+    expect(transportFrames[0].kind).toBe('invoke-result');
+    expect(transportFrames.some((env) => env.kind === 'push')).toBe(false);
+
+    host.stop();
+    controller.stop();
   });
 
   it('invoke request id 在没有 global crypto 的运行时仍可生成', async () => {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -28,6 +28,7 @@ import {
   MAX_TRANSPORT_SEQUENCE_WINDOW,
   MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES,
   TRANSPORT_MAX_RETRY_ATTEMPTS,
+  TRANSPORT_PENDING_PUSH_MAX_AGE_MS,
   TRANSPORT_RETRY_INTERVAL_MS,
   decodeTransportJson,
   encodeReliableFrames,
@@ -249,6 +250,8 @@ interface PendingReliableMessage {
   attempts: number;
   lastSentAt: number;
   sent: boolean;
+  /** 入队时刻；push 帧按 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 判定过期。 */
+  enqueuedAt: number;
 }
 
 interface PeerTransportState {
@@ -597,6 +600,11 @@ export class DeviceLinkClient {
       && matchingOffer.capabilities.includes(DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT)
     );
     const peer = this.getPeerTransport(dst);
+    // 建链即清扫：过期 push 先出队，让 accept 携带的 transportBaseSeq 直接跳过
+    // 它们，对端从一开始就不等这些陈旧 seq，随后的重放也不再灌回离线期间堆积
+    // 的过期实时镜像（v0.1.25 线上曾出现建链后 250ms invoke-result 仍被离线期
+    // 间堆满的 push 挤在缓冲外，控制端的存活探测因此超时，熔断持续 open）。
+    if (peerSupportsReliable) this.sweepExpiredPendingPushes(dst, peer);
     this.sendEnvelope({
       v: PROTOCOL_VERSION,
       kind: 'link-accept',
@@ -1677,10 +1685,16 @@ export class DeviceLinkClient {
         err instanceof Error ? err.message : String(err),
       );
     }
-    if (
-      peer.pending.size >= MAX_TRANSPORT_PENDING_MESSAGES ||
-      peer.pendingBytes + reservedBytes > MAX_TRANSPORT_PENDING_BYTES
-    ) {
+    const hasPendingCapacity = (): boolean => (
+      peer.pending.size < MAX_TRANSPORT_PENDING_MESSAGES
+      && peer.pendingBytes + reservedBytes <= MAX_TRANSPORT_PENDING_BYTES
+    );
+    if (!hasPendingCapacity() && env.kind === 'invoke-result') {
+      // invoke-result 是控制端确认被控端存活的唯一凭据，绝不能被堆积的 push
+      // 饿死：先清扫过期 push，仍不够则按最旧优先继续驱逐队头 push 腾位。
+      this.evictPendingPushesForInvokeResult(env.dst, peer, hasPendingCapacity);
+    }
+    if (!hasPendingCapacity()) {
       throw new DeviceLinkError(
         'BACKPRESSURE',
         `reliable transport buffer is full for peer ${env.dst.slice(0, 8)}`,
@@ -1699,6 +1713,7 @@ export class DeviceLinkClient {
       attempts: 0,
       lastSentAt: 0,
       sent: false,
+      enqueuedAt: Date.now(),
     };
     peer.pending.set(seq, pending);
     peer.pendingBytes += reservedBytes;
@@ -1978,6 +1993,68 @@ export class DeviceLinkClient {
     }
   }
 
+  /**
+   * 清扫 pending 队头连续的过期 push 帧。只能从队头连续删除：队头出队后
+   * baseSeq（最小 pending seq）随之前移，后续帧携带的 baseSeq 会让接收端整体
+   * 跳过这些 seq；若删除中段条目则会留下 seq 空洞，接收端累计 ACK 永久停住。
+   * 队内 seq 即入队顺序，队头最老，所以「过期段」天然是队头连续前缀。
+   */
+  private sweepExpiredPendingPushes(dst: string, peer: PeerTransportState): number {
+    const now = Date.now();
+    let evicted = 0;
+    for (const [seq, pending] of peer.pending) {
+      if (pending.envelope.kind !== 'push') break;
+      if (now - pending.enqueuedAt < TRANSPORT_PENDING_PUSH_MAX_AGE_MS) break;
+      this.removePendingEntry(peer, seq, pending);
+      evicted += 1;
+    }
+    if (evicted > 0) {
+      this.log.warn(
+        `swept ${evicted} expired push frame(s) from reliable buffer for peer ${dst.slice(0, 8)}`,
+      );
+    }
+    return evicted;
+  }
+
+  /**
+   * invoke-result 入队时缓冲已满：先清扫过期 push，仍满则按最旧优先继续驱逐
+   * 队头 push，直到腾出容量或队头不再是 push（invoke / invoke-result 绝不驱逐）。
+   * push 本就是尽力而为的旁路（见 desktop 侧 forwardPush），而 invoke-result
+   * 一旦被饿死，控制端会把被控端判定为无响应并保持熔断，形成死锁。
+   */
+  private evictPendingPushesForInvokeResult(
+    dst: string,
+    peer: PeerTransportState,
+    hasCapacity: () => boolean,
+  ): void {
+    this.sweepExpiredPendingPushes(dst, peer);
+    let evicted = 0;
+    for (const [seq, pending] of peer.pending) {
+      if (hasCapacity()) break;
+      if (pending.envelope.kind !== 'push') break;
+      this.removePendingEntry(peer, seq, pending);
+      evicted += 1;
+    }
+    if (evicted > 0) {
+      this.log.warn(
+        `evicted ${evicted} pending push frame(s) for peer ${dst.slice(0, 8)} to make room for invoke-result`,
+      );
+    }
+  }
+
+  private removePendingEntry(
+    peer: PeerTransportState,
+    seq: number,
+    pending: PendingReliableMessage,
+  ): void {
+    peer.pending.delete(seq);
+    peer.pendingBytes -= pending.bytes;
+    if (peer.pending.size === 0 && peer.retryTimer) {
+      clearInterval(peer.retryTimer);
+      peer.retryTimer = null;
+    }
+  }
+
   private ensureRetryTimer(dst: string): void {
     const peer = this.getPeerTransport(dst);
     if (peer.retryTimer) return;
@@ -2015,6 +2092,10 @@ export class DeviceLinkClient {
   private replayPending(dst: string, resumedLink = false): void {
     const peer = this.peerTransport.get(dst);
     if (!peer || !peer.reliable || !peer.linkReady || peer.pending.size === 0) return;
+    // 链路恢复先清扫过期 push：对端离线期间堆积的陈旧实时镜像不值得重放，只会
+    // 占满重放窗口，把紧随建链而来的 invoke-result 挤到数秒之后。
+    this.sweepExpiredPendingPushes(dst, peer);
+    if (peer.pending.size === 0) return;
     if (resumedLink || peer.lastReplayEpoch !== this.connEpoch) {
       peer.lastReplayEpoch = this.connEpoch;
       for (const pending of peer.pending.values()) {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -1991,6 +1991,9 @@ export class DeviceLinkClient {
   private handleTransportAck(src: string, streamId: string, ackSeq: number): void {
     const peer = this.peerTransport.get(src);
     if (!peer || !peer.reliable || !peer.linkReady || peer.streamId !== streamId) return;
+    // 迟到/陈旧 ACK 幂等无害（含指向已被驱逐 seq 的 ACK）：驱逐后该 seq 已不在
+    // map 里，累计删除循环遇到更高的队头 live seq 直接 break，不会误删、不抛错、
+    // 不错误推进状态；高于 nextSeq-1 的未知 ACK 与倒退的 ACK 直接忽略。
     if (ackSeq > peer.nextSeq - 1 || ackSeq <= peer.highestAckSeq) return;
     peer.highestAckSeq = ackSeq;
     for (const [seq, pending] of peer.pending) {
@@ -2036,6 +2039,24 @@ export class DeviceLinkClient {
    * 用于普通入队压力下的兜底清扫；expiredOnly=false 丢弃整个可丢弃前缀
    * （fresh push 一并放弃），用于重连重放前与 invoke-result 腾位——保证剩余
    * 队头就是最早的 live 帧，invoke-result 不会排在任何可丢弃帧之后。
+   *
+   * 不变量的作用域（刻意从窄）：「result 成为最早可交付的 live seq」只在两个
+   * 清扫时点成立——重连重放写入 socket 之前、新帧入队之前。已写进 WebSocket
+   * FIFO 的帧无法撤回，本方法不承诺全时态抢占；队头是 live 帧时前缀为空，
+   * 维持原 BACKPRESSURE 语义。这也是单 FIFO 的固有极限：live 帧之后的 push
+   * 不可跨越（会留 seq 空洞），例如 [push, live-invoke, push…] 只能丢掉第一段，
+   * result 仍排在 live-invoke 之后——「push 无损」与「result 抢占」在单流上
+   * 不可兼得（需独立优先 stream 才能同时满足）。
+   *
+   * 终止性与计数：每轮迭代要么删除当前队头、要么 break（队头 live / 未过期），
+   * 至多 pending.size 轮；removePendingEntry 同步扣减 pendingBytes 并在队空时
+   * 回收 retryTimer，不产生计数漂移。只触碰参数 peer（按 dst 隔离）的缓冲。
+   *
+   * 数据完整性：被丢弃的 push 不是静默丢数据——push 是尽力而为的状态镜像，
+   * 控制端在重连/回前台时会整体 resync + 重新订阅（mobile 侧 reconnect
+   * reseed），最新状态由下一次全量拉取补偿。传输层没有 push 的离线持久队列
+   * （invoke-result 的 outbox 在 host 层且与 push 无关），驱逐回填既无宿主也无
+   * 必要，故不做。
    */
   private dropDiscardablePendingPrefix(
     dst: string,

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -250,7 +250,7 @@ interface PendingReliableMessage {
   attempts: number;
   lastSentAt: number;
   sent: boolean;
-  /** 入队时刻；push 帧按 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 判定过期。 */
+  /** 入队时刻（monotonicNow 单调时钟）；push 帧按 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 判定过期。 */
   enqueuedAt: number;
 }
 
@@ -600,11 +600,15 @@ export class DeviceLinkClient {
       && matchingOffer.capabilities.includes(DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT)
     );
     const peer = this.getPeerTransport(dst);
-    // 建链即清扫：过期 push 先出队，让 accept 携带的 transportBaseSeq 直接跳过
-    // 它们，对端从一开始就不等这些陈旧 seq，随后的重放也不再灌回离线期间堆积
-    // 的过期实时镜像（v0.1.25 线上曾出现建链后 250ms invoke-result 仍被离线期
-    // 间堆满的 push 挤在缓冲外，控制端的存活探测因此超时，熔断持续 open）。
-    if (peerSupportsReliable) this.sweepExpiredPendingPushes(dst, peer);
+    // 建链即丢弃队头连续的可丢弃前缀（push 不分新旧 + skip 占位）：让 accept
+    // 携带的 transportBaseSeq 直接跳过它们，对端从一开始就不等这些 seq，随后的
+    // 重放不再灌回离线期间堆积的实时镜像，紧随建链而来的 invoke-result 成为最
+    // 早可交付的 live seq（v0.1.25 线上曾出现建链后 250ms invoke-result 仍被离
+    // 线期间堆满的 push 重放洪峰挤在后面，控制端的存活探测因此超时，熔断持续
+    // open）。
+    if (peerSupportsReliable) {
+      this.dropDiscardablePendingPrefix(dst, peer, false, 'before link re-establishment replay');
+    }
     this.sendEnvelope({
       v: PROTOCOL_VERSION,
       kind: 'link-accept',
@@ -1689,10 +1693,17 @@ export class DeviceLinkClient {
       peer.pending.size < MAX_TRANSPORT_PENDING_MESSAGES
       && peer.pendingBytes + reservedBytes <= MAX_TRANSPORT_PENDING_BYTES
     );
-    if (!hasPendingCapacity() && env.kind === 'invoke-result') {
-      // invoke-result 是控制端确认被控端存活的唯一凭据，绝不能被堆积的 push
-      // 饿死：先清扫过期 push，仍不够则按最旧优先继续驱逐队头 push 腾位。
-      this.evictPendingPushesForInvokeResult(env.dst, peer, hasPendingCapacity);
+    if (!hasPendingCapacity()) {
+      if (env.kind === 'invoke-result') {
+        // invoke-result 是控制端确认被控端存活的唯一凭据，绝不能被堆积的可丢弃
+        // 帧饿死：丢弃整个队头可丢弃前缀（fresh push 一并放弃——单 FIFO 无法同时
+        // 做到 push 无损与 result 抢占），让 result 成为最早可交付的 live seq。
+        this.dropDiscardablePendingPrefix(env.dst, peer, false, 'to make room for invoke-result');
+      } else {
+        // 其它帧的入队压力只做 TTL 兜底清扫：过期 push 已无实时价值，先出队腾位；
+        // 新鲜 push 之间维持原有 BACKPRESSURE 语义，不互相驱逐。
+        this.dropDiscardablePendingPrefix(env.dst, peer, true, 'after pending push TTL expiry');
+      }
     }
     if (!hasPendingCapacity()) {
       throw new DeviceLinkError(
@@ -1713,7 +1724,7 @@ export class DeviceLinkClient {
       attempts: 0,
       lastSentAt: 0,
       sent: false,
-      enqueuedAt: Date.now(),
+      enqueuedAt: this.monotonicNow(),
     };
     peer.pending.set(seq, pending);
     peer.pendingBytes += reservedBytes;
@@ -1994,52 +2005,62 @@ export class DeviceLinkClient {
   }
 
   /**
-   * 清扫 pending 队头连续的过期 push 帧。只能从队头连续删除：队头出队后
-   * baseSeq（最小 pending seq）随之前移，后续帧携带的 baseSeq 会让接收端整体
-   * 跳过这些 seq；若删除中段条目则会留下 seq 空洞，接收端累计 ACK 永久停住。
-   * 队内 seq 即入队顺序，队头最老，所以「过期段」天然是队头连续前缀。
+   * 单调时钟。pending 帧的滞留时长（TTL）必须用不受墙钟校正影响的时源计量：
+   * Date.now() 在系统时间被向前校正超过 TRANSPORT_PENDING_PUSH_MAX_AGE_MS 时，
+   * 会把刚入队的 push 误判为过期。测试通过 stub 本方法模拟老化。
    */
-  private sweepExpiredPendingPushes(dst: string, peer: PeerTransportState): number {
-    const now = Date.now();
-    let evicted = 0;
-    for (const [seq, pending] of peer.pending) {
-      if (pending.envelope.kind !== 'push') break;
-      if (now - pending.enqueuedAt < TRANSPORT_PENDING_PUSH_MAX_AGE_MS) break;
-      this.removePendingEntry(peer, seq, pending);
-      evicted += 1;
-    }
-    if (evicted > 0) {
-      this.log.warn(
-        `swept ${evicted} expired push frame(s) from reliable buffer for peer ${dst.slice(0, 8)}`,
-      );
-    }
-    return evicted;
+  private monotonicNow(): number {
+    return performance.now();
   }
 
   /**
-   * invoke-result 入队时缓冲已满：先清扫过期 push，仍满则按最旧优先继续驱逐
-   * 队头 push，直到腾出容量或队头不再是 push（invoke / invoke-result 绝不驱逐）。
-   * push 本就是尽力而为的旁路（见 desktop 侧 forwardPush），而 invoke-result
-   * 一旦被饿死，控制端会把被控端判定为无响应并保持熔断，形成死锁。
+   * 可丢弃帧判据（重连重放与 invoke-result 腾位两条路径共用的不变量）：
+   * best-effort push，以及 timeout / relay-error 后被 dropReliablePendingForRequest
+   * 换成 transport-skip 占位 payload 的帧——其外层 kind 仍是原 invoke /
+   * invoke-result，但已无任何业务副作用。两者都可以通过推进 baseSeq 让接收端
+   * 整体跳过；live invoke / invoke-result 永不可丢弃，是丢弃前缀的边界。
    */
-  private evictPendingPushesForInvokeResult(
+  private isDiscardablePending(pending: PendingReliableMessage): boolean {
+    return (
+      pending.envelope.kind === 'push'
+      || isTransportSkipPayload(pending.envelope.payload)
+    );
+  }
+
+  /**
+   * 丢弃 pending 队头连续的可丢弃前缀。只能从队头连续删除：队头出队后
+   * baseSeq（最小 pending seq）随之前移，后续帧携带的 baseSeq 会让接收端整体
+   * 跳过这些 seq；若删除中段条目则会留下 seq 空洞，接收端累计 ACK 永久停住。
+   *
+   * expiredOnly=true 只删过期 push（skip 占位没有任何交付价值，始终可删），
+   * 用于普通入队压力下的兜底清扫；expiredOnly=false 丢弃整个可丢弃前缀
+   * （fresh push 一并放弃），用于重连重放前与 invoke-result 腾位——保证剩余
+   * 队头就是最早的 live 帧，invoke-result 不会排在任何可丢弃帧之后。
+   */
+  private dropDiscardablePendingPrefix(
     dst: string,
     peer: PeerTransportState,
-    hasCapacity: () => boolean,
-  ): void {
-    this.sweepExpiredPendingPushes(dst, peer);
-    let evicted = 0;
+    expiredOnly: boolean,
+    reason: string,
+  ): number {
+    const now = this.monotonicNow();
+    let dropped = 0;
     for (const [seq, pending] of peer.pending) {
-      if (hasCapacity()) break;
-      if (pending.envelope.kind !== 'push') break;
+      if (!this.isDiscardablePending(pending)) break;
+      if (
+        expiredOnly
+        && pending.envelope.kind === 'push'
+        && now - pending.enqueuedAt < TRANSPORT_PENDING_PUSH_MAX_AGE_MS
+      ) break;
       this.removePendingEntry(peer, seq, pending);
-      evicted += 1;
+      dropped += 1;
     }
-    if (evicted > 0) {
+    if (dropped > 0) {
       this.log.warn(
-        `evicted ${evicted} pending push frame(s) for peer ${dst.slice(0, 8)} to make room for invoke-result`,
+        `dropped ${dropped} discardable pending frame(s) (best-effort push / transport-skip) for peer ${dst.slice(0, 8)} ${reason}`,
       );
     }
+    return dropped;
   }
 
   private removePendingEntry(
@@ -2092,9 +2113,11 @@ export class DeviceLinkClient {
   private replayPending(dst: string, resumedLink = false): void {
     const peer = this.peerTransport.get(dst);
     if (!peer || !peer.reliable || !peer.linkReady || peer.pending.size === 0) return;
-    // 链路恢复先清扫过期 push：对端离线期间堆积的陈旧实时镜像不值得重放，只会
-    // 占满重放窗口，把紧随建链而来的 invoke-result 挤到数秒之后。
-    this.sweepExpiredPendingPushes(dst, peer);
+    // 重放前先丢弃队头连续的可丢弃前缀（push 不分新旧 + skip 占位）：重放一旦把
+    // 它们写进 WebSocket FIFO 就无法撤回，之后的 invoke-result 驱逐救不回已发出
+    // 的帧，接收端仍会按 seq 顺序先消化整段重放洪峰。丢弃后重放的第一帧就是最
+    // 早的 live 帧。
+    this.dropDiscardablePendingPrefix(dst, peer, false, 'before link re-establishment replay');
     if (peer.pending.size === 0) return;
     if (resumedLink || peer.lastReplayEpoch !== this.connEpoch) {
       peer.lastReplayEpoch = this.connEpoch;

--- a/packages/device-link/src/transport.ts
+++ b/packages/device-link/src/transport.ts
@@ -35,9 +35,11 @@ export const TRANSPORT_RETRY_INTERVAL_MS = 2_000;
 /** 连续重发上限；之后保留消息等待重连，避免弱网下无限制造流量。 */
 export const TRANSPORT_MAX_RETRY_ATTEMPTS = 5;
 /**
- * pending 里 push 帧的最大滞留时长。push 是尽力而为的实时镜像旁路，对端长时间
- * 未 ACK（典型是离线）后这些帧只剩历史价值；超龄后视为过期，在链路恢复重放前
- * 与 invoke-result 需要腾位时清扫，避免陈旧 push 独占有界 pending 缓冲。
+ * pending 里 push 帧的最大滞留时长（按单调时钟计量，不受墙钟校正影响）。push 是
+ * 尽力而为的实时镜像旁路，长时间未被 ACK（典型是对端离线）后只剩历史价值；
+ * 超龄后在普通入队压力下被兜底清扫，避免陈旧 push 独占有界 pending 缓冲。
+ * 重连重放前与 invoke-result 腾位不看此 TTL：这两条路径直接丢弃队头整个可丢弃
+ * 前缀（含新鲜 push 与 transport-skip 占位），保证 invoke-result 是最早的 live seq。
  */
 export const TRANSPORT_PENDING_PUSH_MAX_AGE_MS = 5 * 60_000;
 

--- a/packages/device-link/src/transport.ts
+++ b/packages/device-link/src/transport.ts
@@ -34,6 +34,12 @@ export const MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES = 8 * 1024 * 1024;
 export const TRANSPORT_RETRY_INTERVAL_MS = 2_000;
 /** 连续重发上限；之后保留消息等待重连，避免弱网下无限制造流量。 */
 export const TRANSPORT_MAX_RETRY_ATTEMPTS = 5;
+/**
+ * pending 里 push 帧的最大滞留时长。push 是尽力而为的实时镜像旁路，对端长时间
+ * 未 ACK（典型是离线）后这些帧只剩历史价值；超龄后视为过期，在链路恢复重放前
+ * 与 invoke-result 需要腾位时清扫，避免陈旧 push 独占有界 pending 缓冲。
+ */
+export const TRANSPORT_PENDING_PUSH_MAX_AGE_MS = 5 * 60_000;
 
 const TRANSPORT_MARKER = '__cindyDeviceLinkTransport';
 const TRANSPORT_SKIP_MARKER = '__cindyDeviceLinkTransportSkip';


### PR DESCRIPTION
## 动机

#1375 钉死了病根链的末端:per-peer 可靠传输缓冲(16/64 槽)被 push 洪流塞死 → `invoke-result could not be queued` → 控制端拿不到回执熔断。该 PR 已让 invoke-result 获得抢占权、过期 push 被驱逐——但洪流本身还在。生产取证(2026-08-02,单 iPhone 配对)给出了洪流的结构性来源:

- 重连窗口 forwardPush 失败 466 次,其中 `sessions:activity` 113 次——activity 是重连窗口秒满缓冲的主要载体;
- `sessionActivityRelay.replay()` 绕过 `publishOne` 的 1.5s 节流,`terminalReplayPayloads` 上限 200 条 > `MAX_TRANSPORT_PENDING_MESSAGES = 64`,重连必溢出;
- replay 扇出丢 `controllerDeviceId`:一台设备重连,**所有**设备陪吃全量 replay,多设备重连窗口互相打断握手(`device-link:subscribe` 回执失败 36 次、排队 47 次)。

本 PR 是四层根治方案的 L2+L3:把状态通道的爆发量从 **O(事件数) 收敛到 O(会话数)** 且自钟控(L2),把 replay 从全员广播改成**只发给刚订阅的那台**(L3)。

> **Stacked on #1375**:base 分支为 `fix/device-link-invoke-result-starvation`,前 3 个 commit 属于 #1375;#1375 合入后本分支 rebase 到 main,届时只剩本 PR 的 2 个 commit。

## L2 — `sessions:activity` 键控 latest-wins 出站缓冲(commit 1)

`sessions:activity` 是**状态镜像**而非事件流:接收端(mobile `remoteSessionStore.applySessionActivity` / desktop `remoteSessionActivityStore`)对同一 `sessionId` 严格 last-write-wins——新值整体覆盖旧值,无序列依赖,中间帧没有任何交付价值(已逐处核实,见下"不变量")。

新增 `SessionActivityOutbox`(dispatch 层),`forwardPush` 把该通道分流进去:

- **键控暂存**:key = `channel:sessionId`,同 key 覆盖;任意长的更新风暴至多占一个槽。Map 保序、覆盖不改位置,先入队的 key 不被饿死。
- **自钟控泵**:每控制端每窗口最多 8 帧交给传输层,剩余按 250ms 续泵——单次爆发对 64 槽 pending 的侵占有硬上限,invoke-result 与真事件流永远有余量(与 #1375 的抢占驱逐协同)。
- **BACKPRESSURE / 瞬态失败**:条目保留,指数退避重试(250ms → 2s 封顶);恢复后只发每个 key 的最新值。`PAYLOAD_TOO_LARGE` 丢 key 防毒帧卡泵。`canSend` 预判 relay 在线,堵住 `client.sendPush` 离线静默 no-op 造成的假成功。
- **生命周期**:link 断开/重建缓冲保留(恢复自动续发最新值);presence 掉线清订阅 / link-close / 撤权 / 退订 `sessions` 时清空该 peer 暂存区,不给幽灵设备留定时器。

## L3 — replay 定向化(commit 2)

`notifySessionsSubscribed` 一直携带 `controllerDeviceId`,但 bootstrap 的监听器把它丢了,replay 经 broadcast-tap 扇出给全部 `sessions` 订阅者。改动把参数传到底:

- dispatch 新增 `pushSessionActivityToController(controllerDeviceId, payload)`:定向 replay 唯一出口,走同一个 L2 键控缓冲——replay 与并发 publish 的同 key 帧自动合并(signature 相同即去重),200 条 replay 压成 ≤ 会话数;目标已不在 `sessions` 订阅者集合(极短窗口退订/断链)则丢弃。
- `SessionActivityRelay.replay(list, target?)`:target 透传到 emit;无 target 时保持单参 emit,publish / clear 的历史广播语义零改动。
- `AgentIslandService`:targeted emit 改走 `pushSessionActivityToController`,不再经 `tapWindowBroadcast` 扇出;本机 renderer 与其它控制端零打扰。
- bootstrap:把 `controllerDeviceId` 真正传给 `replaySessionActivity`(此前在这一跳丢参)。

## 不变量

- **真事件流零改动**:只有 `sessions:activity` 一个通道被收编;`maker:event` / `sessions:patched` / `messages:created` 等每帧有语义,继续逐帧直发(有测试钉死)。
- **wire 协议零变化**:帧格式、channel 名、topic 路由、订阅语义都不动;变的只是被控端出站的排队与目标选择。
- **mobile 零改动**,L2 前提已核实:`applySessionActivity` 对每个 sessionId 直接覆盖 live-activity 条目、run status 由最新帧整体导出(`isRunning`、`attention`、`startedAt ?? Date.now()`),无增量/序列依赖 → 跳过中间帧无损。desktop 控制端镜像 store 同语义(文件头注明"与手机端完全一致")。
- **本地 UI 不受影响**:renderer 的会话快照走 `AGENT_ISLAND_SESSION_SNAPSHOTS_CHANNEL` 独立路径,不经本缓冲。
- **legacy `'*'` 控制端**:本就不触发 subscribe replay,行为不变;其 live activity 帧同样经键控缓冲限流。

## 测试

新增 21 个,全套回归绿:

- `sessionActivityOutbox.test.ts`(10,L2 单元):200 帧洪峰坍缩成每 key 一帧最新值;同 key 连发只出最新;每窗口 ≤8 + pacing 续泵;per-peer 窗口独立;BACKPRESSURE 保留+退避后发最新值;指数退避封顶+成功复位;毒帧丢弃不卡泵;离线保留、恢复续发;clear/clearAll 不留定时器;覆盖不插队不饿死。
- `dispatchActivityBuffer.test.ts`(10,dispatch 集成):activity 风暴对两控制端各坍缩至会话数;单窗口 ≤8 进传输层;真事件流逐帧直发零改动;BACKPRESSURE 退避重试;**A/B 双控制端 replay 只到 A、B 零帧**;200 条 replay 压成 3 帧;replay+publish 同帧去重;非 sessions 订阅者丢弃;subscribe 监听器收到 controllerDeviceId;掉线/撤权/退订三路清理不留幽灵定时器。
- `sessionActivityRelay.test.ts` +1:target 透传每一帧(活跃+terminal 补发),无 target 保持单参。
- `service.test.ts` 2 处更新:replay 断言从 tapWindowBroadcast 换到定向出口,并断言 broadcast-tap 零调用。
- 回归:`apps/desktop` device-link + agent-island 32 文件 **718 通过**;`packages/device-link` **142 通过**(含 #1375 的 invoke-result 抢占套件);两处 `tsc --noEmit` 零错。

## 风险与边界

- activity 帧的端到端时延上限从"立即入队"变为泵节奏(healthy 路径首帧仍是 0ms 定时器,基本无感;20+ 会话并发翻状态时尾部会话最多晚 ~250ms×⌈n/8⌉);换来的是重连窗口不再溢出。
- "in-flight ≤8" 是每泵窗口交给传输层的帧数上限(dispatch 层看不到 per-frame ACK),配合 pacing 是节流语义而非严格滑动窗;上限 8 恒 < 64 槽,目标(invoke-result 永远有余量)成立。
- 退避不带抖动(确定性、可测试);单被控端对多控制端各自独立退避,互不放大。
- `handleControllerOffline` 现在会清该 peer 的暂存区:恢复后由重订阅触发的定向 replay 重新播种,不依赖残留缓冲。
