### PR TITLE
ci: verify Typecheck desktop 步骤 heap 提升到 8GB,修全 PR 稳定 OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,10 @@ env:
   XDT_SKIP_AGENT_BIN_INSTALL: '1'
   ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
   ELECTRON_OVERRIDE_DIST_PATH: '${{ github.workspace }}/.electron-stub-dist'
-  NODE_OPTIONS: '--max-old-space-size=4096'
+  # 8192: desktop tsc 全量 typecheck 峰值内存随仓体增长已突破 4GB(2026-08-02 起
+  # 所有 PR 的 verify 在 Typecheck desktop 步骤稳定 OOM,含纯 mobile 改动);
+  # 公开仓 ubuntu-latest runner 内存 16GB,8GB heap 安全。
+  NODE_OPTIONS: '--max-old-space-size=8192'
 
 jobs:
   verify:


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 CI 基线故障:`verify` 的 Typecheck desktop 步骤自 2026-08-02 起对**所有 PR** 稳定 OOM(node heap 4GB 上限,exit 134),包括纯 mobile 改动的 PR——#1401 与 `android-landscape-drawer-crash` 分支双重复现,失败栈一致(`node::OOMErrorHandler`)。desktop tsc 全量 typecheck 的峰值内存随仓体增长已突破 4GB。

修法:workflow 级 `NODE_OPTIONS` 从 4096 提到 8192。公开仓 `ubuntu-latest` runner 内存 16GB,8GB heap 安全;本地同款修法已验证 typecheck 通过。

不修就没有任何 PR 能过机器门禁。

### 变更类型

- [x] `ci` 工程维护(勾选「文档、测试或工程维护」)

### 范围

- 关联 Issue / 需求:无(CI 基线故障,阻塞全部 PR 合并)
- 本 PR 包含:`.github/workflows/ci.yml` 的 NODE_OPTIONS heap 上限 + 注释
- 明确不包含:tsc 内存占用本身的优化(增量 typecheck / project references 属后续工程优化)
- 用户可见变化:无(纯 CI)
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit(仓库根,完整)
结果:exit=0,0 FAIL

NODE_OPTIONS="--max-old-space-size=8192" pnpm --filter desktop run typecheck(本地)
结果:通过(4GB 默认下同样 OOM,与 CI 失败一致,证明修法对症)
```

本 PR 自身的 verify 运行即是最终验证。

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅 CI runner 的 node heap 上限;不改任何构建产物与代码路径
- 回滚 / 降级方式:revert 即回 4096

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(workflow 内注释)
- [x] 已确认测试结果或说明未执行原因
