### PR TITLE
fix(desktop): 过滤 Claude 内部审查会话导入

### DIFF
--- a/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
@@ -526,6 +526,55 @@ describe('parseClaudeCodeMessageLine', () => {
     }
   });
 
+  it('rejects internal review-channel sessions from scan and full summaries', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-review-channel-'));
+    const file = path.join(dir, `${sdkSessionId}.jsonl`);
+    fs.writeFileSync(
+      file,
+      `${line({
+        type: 'user',
+        uuid: 'user-review-channel',
+        cwd: '/tmp/project',
+        message: {
+          role: 'user',
+          content:
+            '<channel source="review-session-channel" source="local-review" id="review-1">\nReview this change',
+        },
+      })}\n`,
+    );
+
+    try {
+      expect(await readClaudeCodeSessionScanSummary(file)).toBeNull();
+      expect(await readClaudeCodeSessionSummary(file)).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps ordinary user-facing channel sessions importable', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-user-channel-'));
+    const file = path.join(dir, `${sdkSessionId}.jsonl`);
+    fs.writeFileSync(
+      file,
+      `${line({
+        type: 'user',
+        uuid: 'user-feishu-channel',
+        cwd: '/tmp/project',
+        message: {
+          role: 'user',
+          content: '<channel source="feishu" chat_id="chat-1">\nPlease summarize this conversation',
+        },
+      })}\n`,
+    );
+
+    try {
+      expect(await readClaudeCodeSessionScanSummary(file)).toMatchObject({ sdkSessionId });
+      expect(await readClaudeCodeSessionSummary(file)).toMatchObject({ sdkSessionId });
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('skips unchanged Claude JSONL files after importing them once', async () => {
     const home = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-local-home-'));
     const projectsDir = path.join(home, '.claude', 'projects', '-tmp-project');
@@ -874,6 +923,42 @@ describe('parseClaudeCodeMessageLine', () => {
       expect(result).toMatchObject({ scanned: 1, inserted: 1, updated: 0 });
       const rows = db.prepare('SELECT id, title FROM sessions ORDER BY id').all();
       expect(rows).toEqual([{ id: `claude-${sdkSessionId}`, title: 'import me' }]);
+    } finally {
+      homedir.mockRestore();
+      resetLocalDb();
+      db.close();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('revalidates and rejects internal review sessions imported directly by id', async () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-local-home-'));
+    const projectsDir = path.join(home, '.claude', 'projects', '-tmp-project');
+    fs.mkdirSync(projectsDir, { recursive: true });
+    const file = path.join(projectsDir, `${sdkSessionId}.jsonl`);
+    fs.writeFileSync(
+      file,
+      `${line({
+        type: 'user',
+        uuid: 'user-local-review',
+        cwd: '/tmp/project',
+        message: {
+          role: 'user',
+          content: '<channel source="local-review" id="review-1">\nReview this change',
+        },
+      })}\n`,
+    );
+
+    const db = createLocalDb();
+    const homedir = vi.spyOn(os, 'homedir').mockReturnValue(home);
+    setLocalDb(db);
+
+    try {
+      const result = await importExternalClaudeCodeSessions([sdkSessionId]);
+
+      expect(result).toMatchObject({ scanned: 1, inserted: 0, updated: 0 });
+      const rows = db.prepare('SELECT id FROM sessions').all();
+      expect(rows).toEqual([]);
     } finally {
       homedir.mockRestore();
       resetLocalDb();

--- a/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/claudeLocalSessions.test.ts
@@ -1161,6 +1161,47 @@ describe('parseClaudeCodeMessageLine', () => {
     }
   });
 
+  it('does not surface an unresolved candidate when the first real user input is past the line cap', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-scan-unresolved-cap-'));
+    const file = path.join(dir, `${sdkSessionId}.jsonl`);
+    const noiseRows = Array.from({ length: 399 }, (_, index) =>
+      line({
+        type: 'system',
+        subtype: 'noise',
+        cwd: '/tmp/project',
+        seq: index,
+      }),
+    );
+    fs.writeFileSync(
+      file,
+      [
+        line({
+          type: 'user',
+          uuid: 'user-synthetic',
+          cwd: '/tmp/project',
+          message: { role: 'user', content: '<local-command-caveat>ignore</local-command-caveat>' },
+        }),
+        ...noiseRows,
+        line({
+          type: 'user',
+          uuid: 'user-review-after-cap',
+          cwd: '/tmp/project',
+          message: {
+            role: 'user',
+            content: '<channel source="review-session-channel">\nReview this change',
+          },
+        }),
+      ].join('\n'),
+    );
+
+    try {
+      expect(await readClaudeCodeSessionScanSummary(file)).toBeNull();
+      expect(await readClaudeCodeSessionSummary(file)).toBeNull();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it('scan summary is cached by (mtime, size) and re-parsed when the file changes', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-scan-cache-'));
     const file = path.join(dir, `${sdkSessionId}.jsonl`);

--- a/apps/desktop/src/main/maker-host/claude-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/claude-local-sessions.ts
@@ -422,6 +422,7 @@ async function readScanSummaryFromHead(file: string, mtimeMs: number): Promise<C
       if (type === 'user' && !title && isRecord(obj.message)) {
         const content = obj.message.content;
         const text = extractUserText(content).trim();
+        if (text && isInternalClaudeReviewChannelText(text)) return null;
         if (text) title = makeTitle(text);
         else if (hasCompleteIdeOpenedFileBlock(content)) removedIdeContextWithoutTitle = true;
       }
@@ -483,6 +484,7 @@ export async function readClaudeCodeSessionSummary(file: string): Promise<Claude
 
     if (type === 'user' && !title && isRecord(obj.message)) {
       const text = extractUserText(obj.message.content).trim();
+      if (text && isInternalClaudeReviewChannelText(text)) return null;
       if (text) title = makeTitle(text);
     }
     if (type === 'assistant' && isRecord(obj.message)) {
@@ -815,6 +817,18 @@ function hasCompleteIdeOpenedFileBlock(content: unknown): boolean {
     typeof block.text === 'string' &&
     stripCompleteIdeOpenedFileBlocks(block.text) !== block.text
   ));
+}
+
+/** Whether the first real user message belongs to Cindy's internal review runtime. */
+function isInternalClaudeReviewChannelText(text: string): boolean {
+  const openingTag = text.trimStart().match(/^<channel\b[^>]*>/i)?.[0];
+  if (!openingTag) return false;
+
+  for (const match of openingTag.matchAll(/\bsource\s*=\s*(["'])([^"']+)\1/gi)) {
+    const source = match[2]?.trim().toLowerCase();
+    if (source === 'review-session-channel' || source === 'local-review') return true;
+  }
+  return false;
 }
 
 /** Whether a scan-limit boundary row is a removable IDE-only user record. */

--- a/apps/desktop/src/main/maker-host/claude-local-sessions.ts
+++ b/apps/desktop/src/main/maker-host/claude-local-sessions.ts
@@ -396,6 +396,7 @@ async function readScanSummaryFromHead(file: string, mtimeMs: number): Promise<C
   let cwd = projectDirFromClaudeStorageDir(path.basename(path.dirname(file))) ?? '';
   let sawTopLevelEvent = false;
   let removedIdeContextWithoutTitle = false;
+  let hitLineLimitBeforeTitle = false;
   let lineCount = 0;
 
   try {
@@ -407,6 +408,7 @@ async function readScanSummaryFromHead(file: string, mtimeMs: number): Promise<C
         !removedIdeContextWithoutTitle &&
         !isIdeOnlyUserRecord(obj)
       ) {
+        hitLineLimitBeforeTitle = true;
         break;
       }
       if (!obj || obj.isSidechain === true) continue;
@@ -436,7 +438,7 @@ async function readScanSummaryFromHead(file: string, mtimeMs: number): Promise<C
     input.destroy();
   }
 
-  if (!sawTopLevelEvent || !isLikelySessionId(sdkSessionId)) return null;
+  if (!sawTopLevelEvent || hitLineLimitBeforeTitle || !isLikelySessionId(sdkSessionId)) return null;
   return {
     sdkSessionId,
     title: title || 'Claude Code Session',


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 的内部审查任务不再混进“本地任务导入”列表，也不能绕过列表直接按会话 ID 导入。过滤只匹配首条有效用户消息中的明确内部来源 review-session-channel 或 local-review；普通飞书等 channel 会话保持可导入。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1374
- 本 PR 包含：扫描候选过滤；导入时重新校验；精确来源匹配及回归测试。
- 明确不包含：清理或归档已经导入的历史任务；不修改 Claude 源 JSONL。
- 用户可见变化：内部审查执行记录不再出现在新的 Claude Code 导入候选中。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/claudeLocalSessions.test.ts
结果：31 tests passed

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop typecheck
结果：passed

pnpm --filter desktop exec eslint src/main/maker-host/claude-local-sessions.ts src/main/__tests__/claudeLocalSessions.test.ts
结果：passed

NODE_OPTIONS=--max-old-space-size=8192 pnpm test:unit
结果：all required workspaces passed
```

### 手工验证

不涉及 UI；在 macOS 本地工作树中完成目标测试、类型检查、lint 和仓库完整单元测试。

### 未执行的验证

未用真实用户数据库执行导入，以避免改动本地任务数据；扫描和按 ID 导入路径由临时目录及内存数据库回归测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响 Claude Code 外部会话候选与显式导入；仅精确内部来源标记会被拒绝。
- 回滚 / 降级方式：回退本提交即可恢复原导入行为；源会话文件和现有 Cindy 数据均未修改。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在“UI 变化”注明引用的设计规范（不涉及）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无额外文档需要）
- [x] 已确认测试结果或说明未执行原因