### PR TITLE
fix(desktop): 保留远程断线后的本机切换入口

### DIFF
--- a/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // 每个用例必须拿一份全新模块状态,否则上一个用例的 started=true 会让后面的用例不再拉取。
 beforeEach(() => {
   vi.resetModules();
+  window.localStorage.clear();
 });
 
 afterEach(() => {
@@ -154,5 +155,55 @@ describe('useDeviceLinkDeviceList initial request', () => {
 
     await act(async () => resolveRelogin?.({ devices: [] }));
     await waitFor(() => expect(result.current).toEqual({ devices: [], settled: true }));
+  });
+
+  it('relay stop after selecting a remote device falls back visibly and keeps the local escape action', async () => {
+    let statusChanged:
+      ((payload: { status: 'stopped' | 'connecting' | 'online' }) => void) | undefined;
+    const listDevices = vi.fn().mockResolvedValue({
+      devices: [
+        {
+          deviceId: 'dev-a',
+          name: 'Mac A',
+          platform: 'darwin',
+          online: true,
+          remoteControlEnabled: true,
+          controlEnabled: true,
+          isSelf: false,
+        } as unknown as DeviceLinkDeviceView,
+      ],
+    });
+    vi.stubGlobal('electronAPI', {
+      deviceLink: {
+        listDevices,
+        onPresenceChanged: vi.fn(),
+        onStatusChanged: vi.fn(
+          (callback: (payload: { status: 'stopped' | 'connecting' | 'online' }) => void) => {
+            statusChanged = callback;
+          },
+        ),
+        onControlTargetChanged: vi.fn(),
+      },
+    });
+    window.localStorage.setItem('cc-agent.sidebar.selectedMachines', JSON.stringify(['dev-a']));
+
+    const { useMachineSwitcher } = await import('@/features/device-link/useMachineSwitcher');
+    const { MACHINE_ALL, MACHINE_LOCAL } =
+      await import('@/features/device-link/selectedMachineStore');
+    const { result } = renderHook(useMachineSwitcher);
+
+    await waitFor(() => expect(result.current.devices).toHaveLength(1));
+    expect(result.current.selectedDeviceId).toEqual(['dev-a']);
+    expect(result.current.hasRemote).toBe(true);
+
+    act(() => statusChanged?.({ status: 'stopped' }));
+    expect(result.current.devices).toEqual([]);
+    expect(result.current.selectedDeviceId).toBe(MACHINE_ALL);
+    // raw 仍记着 dev-a，因此入口保留；菜单中可显式选「本机」。
+    expect(result.current.hasRemote).toBe(true);
+
+    act(() => result.current.select([MACHINE_LOCAL]));
+    expect(result.current.selectedDeviceId).toEqual([MACHINE_LOCAL]);
+    expect(result.current.hasRemote).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcher.test.ts
@@ -14,6 +14,8 @@ import {
 } from '@/features/device-link/selectedMachineStore';
 import { remoteProjectsStore } from '@/features/device-link/remoteProjectsStore';
 import {
+  resolveSelectableIdsForNormalize,
+  shouldShowMachineSwitcher,
   shouldShowSelectedMachineConnectingPlaceholder,
   shouldWaitForRemoteSessionBootstrap,
 } from '@/features/device-link/useMachineSwitcher';
@@ -118,6 +120,30 @@ describe('normalizeSelectedMachineId', () => {
     const raw = ['dev-a', MACHINE_LOCAL];
     expect(normalizeSelectedMachineId(raw, null)).toBe(raw);
     expect(normalizeSelectedMachineId(MACHINE_ALL, null)).toBe(MACHINE_ALL);
+  });
+});
+
+describe('断网后远端选择的逃生路径', () => {
+  it('设备目录尚未结算时保留 raw 选择；终态不可用时回落「所有」', () => {
+    const raw = ['dev-a'];
+    const loadingSelectable = resolveSelectableIdsForNormalize(null, false, []);
+    const stoppedSelectable = resolveSelectableIdsForNormalize(null, true, []);
+
+    expect(loadingSelectable).toBeNull();
+    expect(normalizeSelectedMachineId(raw, loadingSelectable)).toBe(raw);
+    expect(stoppedSelectable).toEqual([]);
+    expect(normalizeSelectedMachineId(raw, stoppedSelectable)).toBe(MACHINE_ALL);
+  });
+
+  it('目录不可用但仍记着远端选择时保留切换入口，用户可显式切回本机', () => {
+    expect(shouldShowMachineSwitcher(['dev-a'], [])).toBe(true);
+    expect(shouldShowMachineSwitcher([MACHINE_LOCAL], [])).toBe(false);
+    expect(shouldShowMachineSwitcher(MACHINE_ALL, [])).toBe(false);
+    expect(
+      shouldShowMachineSwitcher(MACHINE_ALL, [
+        { deviceId: 'dev-a', name: 'Mac A', status: 'connecting' },
+      ]),
+    ).toBe(true);
   });
 });
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/MachineSwitcherMenu.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/MachineSwitcherMenu.tsx
@@ -7,7 +7,8 @@
  * 下拉 **hover 自动展开**(移上即开、移开即收,点击也可开且不误关,见 useHoverOpenMenu;
  * 2026-07-12 产品定稿恢复,推翻 d5a8d77c9 按 Codex P2 改的「点击展开」)。
  *
- * 仅当本机有 ≥1 台相关远程机器(已连接 / 连接中 / 被拒)时显示;否则 return null。
+ * 本机有 ≥1 台相关远程机器(已连接 / 连接中 / 被拒)时显示;若断网导致设备目录
+ * 与远端分片都清空,但 raw 选择仍指向远端,也必须保留入口让用户切回本机。
  *
  * 机器选择:**默认单选、多选框另走多选**(2026-07 用户定稿):
  *   - 「所有」→ 重置回默认(本机 + 全部远程),菜单关闭;
@@ -33,7 +34,7 @@
  * 风格(h-8 全宽、图标 15/1.8 meta 灰、文字 foreground、hover 灰底)——trigger 显示
  * 当前范围文字(所有 / 本机 / 设备名 / N 台机器)+ 下拉箭头。范围文字本身已表达
  * 过滤状态,trigger 不再叠常驻高亮底色(常亮易被误读为导航选中态,2026-07 用户定稿)。
- * 无任何相关远程机器时 return null,列表里不占行。
+ * 无任何相关远程机器且没有悬空远端选择时 return null,列表里不占行。
  *
  * 颜色全走主题 token(规则 16),文案全走 i18n(规则 18)。
  */
@@ -103,7 +104,7 @@ export function MachineSwitcherMenu(): ReactNode {
     ensureConversationListVisible();
   };
 
-  // 无任何相关远程机器 → 不渲染入口(可见性门控)。
+  // 无任何相关远程机器、也没有需要逃生的悬空远端选择 → 不渲染入口。
   if (!hasRemote) return null;
 
   const triggerLabel = t('ccAgent.sidebar.machineSwitcher.menuTrigger');
@@ -116,7 +117,7 @@ export function MachineSwitcherMenu(): ReactNode {
       triggerText =
         only === MACHINE_LOCAL
           ? t('ccAgent.sidebar.machineSwitcher.localMachine')
-          : (devices.find((device) => device.deviceId === only)?.name ?? '');
+          : (devices.find((device) => device.deviceId === only)?.name ?? triggerLabel);
     } else {
       triggerText = t('ccAgent.sidebar.machineSwitcher.selectedCount', {
         count: selectedDeviceId.length,

--- a/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
+++ b/apps/desktop/src/renderer/features/device-link/useMachineSwitcher.ts
@@ -14,8 +14,10 @@
  * (selectedMachineStore 落 localStorage)。**store 始终持有原始勾选集(raw),不做写时清理**:
  * 展示与过滤走读时归一化(useEffectiveSelectedMachineId)——勾选的设备掉线 / 被拒 / 消失时
  * 仅在展示层裁掉、裁空回落「所有」,raw 与持久化值保留完整勾选集,设备重连 / 重启后自动生效。
- * 归一化在全量设备列表尚未加载(null)时不裁剪:启动瞬间列表为空,裁剪会把持久化恢复的选择
- * 误判成「设备已消失」而清成「所有」——这正是「重启后恢复成全部」的坑。
+ * 归一化在全量设备列表尚未加载且请求未结算时不裁剪:启动瞬间列表为空,
+ * 裁剪会把持久化恢复的选择误判成「设备已消失」而清成「所有」。但 relay 已停止 /
+ * 本轮请求已失败结算时,null 是当前终态,必须用空可选集让悬空远端选择回落,
+ * 否则本地会话被过滤为空。
  * toggle 同样基于 raw:点选只改「可见半」,暂时不可选的持久化设备原样保留
  * (toggleMachineSelection 内部拆分,防止一次无关点选把离线设备从落盘值里冲掉)。
  * 各 hook 共用 useSwitcherDevices(),读同一份共享设备列表,无重复拉取。
@@ -136,12 +138,44 @@ export function useSwitcherDevices(): SwitcherDevice[] {
 }
 
 /**
- * 归一化可选中集:全量设备列表尚未加载(null)时返回 null(= 不裁剪,保留持久化恢复的选择,
- * 避免启动瞬间列表为空把选择误判成「设备已消失」)。
+ * 归一化可选中集:
+ * - 设备列表仍在首拉(null + unsettled)→ null,不裁剪持久化选择;
+ * - 列表已落地,或 null 已是终态(settled)→ 按当前 switcher 设备归一化。
+ * 后一条是断网逃生口:relay stop 会清掉设备目录与远端分片,此时只选中远端的 raw
+ * 必须在展示层回落「所有」,否则本地会话也会被过滤掉。
  */
-function useSelectableIdsForNormalize(devices: readonly SwitcherDevice[]): readonly string[] | null {
-  const loaded = useDeviceLinkDeviceList() !== null;
-  return useMemo(() => (loaded ? selectableDeviceIds(devices) : null), [loaded, devices]);
+export function resolveSelectableIdsForNormalize(
+  deviceList: readonly DeviceLinkDeviceView[] | null,
+  deviceListSettled: boolean,
+  devices: readonly SwitcherDevice[],
+): readonly string[] | null {
+  if (deviceList === null && !deviceListSettled) return null;
+  return selectableDeviceIds(devices);
+}
+
+function useSelectableIdsForNormalize(
+  devices: readonly SwitcherDevice[],
+): readonly string[] | null {
+  const deviceList = useDeviceLinkDeviceList();
+  const deviceListSettled = useDeviceLinkDeviceListSettled();
+  return useMemo(
+    () => resolveSelectableIdsForNormalize(deviceList, deviceListSettled, devices),
+    [deviceList, deviceListSettled, devices],
+  );
+}
+
+/**
+ * 除了当前仍有远端设备可展示,只要 raw 选择仍引用远端设备,切换入口就不能消失。
+ * 断网后设备目录 / 远端分片可能同时被清空,这个入口是用户显式切回本机的唯一逃生口。
+ */
+export function shouldShowMachineSwitcher(
+  rawSelection: MachineSelection,
+  devices: readonly SwitcherDevice[],
+): boolean {
+  return (
+    devices.length > 0 ||
+    (rawSelection !== MACHINE_ALL && rawSelection.some((id) => id !== MACHINE_LOCAL))
+  );
 }
 
 /** 勾选的设备仍可选中(已连接 / 连接中)则保留,否则从勾选集裁掉(裁空回落「所有」)。供侧边栏合并点过滤用。 */
@@ -199,7 +233,7 @@ export interface MachineSwitcherState {
   devices: SwitcherDevice[];
   /** 归一化后的选择(MACHINE_ALL 或勾选集:MACHINE_LOCAL / 可选中设备 deviceId)。 */
   selectedDeviceId: MachineSelection;
-  /** 是否有 ≥1 台相关远程机器(切换栏是否应显示)。 */
+  /** 是否应显示切换栏:有远端设备,或当前 raw 选择仍需要断网逃生口。 */
   hasRemote: boolean;
   /** 直接设置选择(菜单「所有」项 / 深链回落用)。 */
   select: (next: MachineSelection) => void;
@@ -232,7 +266,7 @@ export function useMachineSwitcher(): MachineSwitcherState {
   return {
     devices,
     selectedDeviceId: effective,
-    hasRemote: devices.length > 0,
+    hasRemote: shouldShowMachineSwitcher(raw, devices),
     select: setSelectedMachineId,
     toggle,
   };


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 选中远程设备后，对端或本机断网时侧边栏会过滤成空、且远程机器切换入口消失的问题。

- 区分「设备目录尚未加载」与「设备目录已结算但不可用」：后者将悬空远端选择在展示层回落到「所有」，让本机会话继续可见。
- raw 选择仍引用远端设备时，即使设备目录和远端分片都已清空，也保留机器切换入口，用户可明确选回「本机」。
- 悬空设备名不可用时，触发行回退为既有「远程机器」文案，不再出现空标签。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈——选中远程设备后任一端断网，侧边栏空白且无法切回本机。
- 本 PR 包含：Desktop renderer 机器选择归一化、切换入口可见性和回归测试。
- 明确不包含：device-link 协议、relay 重连策略、main/preload IPC 改动。
- 用户可见变化：断网后不再空白；切换入口保留，可选回本机。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark 双模式交付门槛」与 §14「交互约定」。本 PR 仅修正既有机器切换组件的状态与逃生路径，不新增布局、样式、颜色或文案；继续复用现有语义 token 和四语文案。
- 截图 / 录屏：未执行（未进行真实双机断网目检）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/machineSwitcher.test.ts src/renderer/__tests__/machineSwitcherMenu.test.ts src/renderer/__tests__/deviceLinkDeviceListLoading.test.tsx
结果：3 个测试文件、81 项测试全部通过。

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run typecheck
结果：通过。

pnpm --filter desktop exec eslint <4 个本次变更文件>
git diff --check
结果：通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：全量门禁未全绿。Desktop 的 2 个 5s 超时用例单独复跑均通过；Mobile startupSplashOverlay 用例单独复跑仍超时。该 Mobile 失败已在干净 origin/main 基线 worktree 复现，与本 PR diff 无关，交 CI 给出权威结论。

pnpm check:dco
结果：1 个 commit 签名通过。
```

### 手工验证

未执行真实双机断网验证。

### 未执行的验证

- 未进行 macOS 实机的「选中远端 → 对端断网 / 本机断网 → 切回本机」目检。
- 未单独目检 Light / Dark；本 PR 未改动任何样式或颜色。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Desktop renderer 设备选择状态的有限变更。

### 影响与回滚

- 影响范围：Desktop 侧边栏的 device-link 机器过滤与切换入口；不影响协议、远端会话存储或连接链路。
- 回滚 / 降级方式：回退本 PR commit，恢复旧的设备目录归一化与入口门控逻辑。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档（本次无独立文档变更）
- [x] 已确认测试结果或说明未执行原因
