### PR TITLE
fix(device-link): 断链后恢复远程控制链路

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/linkRecovery.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/linkRecovery.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest';
+import { DeviceLinkError } from '@cindy/device-link';
+import {
+  invokeWithClosedLinkRecovery,
+  requiresSessionLink,
+} from '../linkRecovery.js';
+
+describe('device-link closed link recovery', () => {
+  it('正常成功或不可重试错误不会触发 reopen', async () => {
+    const successInvoke = vi.fn().mockResolvedValue({ ok: true });
+    const reopen = vi.fn();
+
+    await expect(invokeWithClosedLinkRecovery(successInvoke, reopen)).resolves.toEqual({ ok: true });
+    expect(successInvoke).toHaveBeenCalledTimes(1);
+    expect(reopen).not.toHaveBeenCalled();
+
+    for (const code of ['NOT_CONNECTED', 'INVOKE_TIMEOUT', 'BACKPRESSURE'] as const) {
+      const err = new DeviceLinkError(code, code);
+      const failedInvoke = vi.fn().mockRejectedValue(err);
+      await expect(invokeWithClosedLinkRecovery(failedInvoke, reopen)).rejects.toBe(err);
+      expect(failedInvoke).toHaveBeenCalledTimes(1);
+    }
+    expect(reopen).not.toHaveBeenCalled();
+  });
+
+  it('发送前 LINK_NOT_OPEN 会先 reopen，再且只再 invoke 一次', async () => {
+    const closed = new DeviceLinkError('LINK_NOT_OPEN', 'control link is closed');
+    const invoke = vi.fn()
+      .mockRejectedValueOnce(closed)
+      .mockResolvedValueOnce({ ok: true });
+    const reopen = vi.fn().mockResolvedValue(undefined);
+
+    await expect(invokeWithClosedLinkRecovery(invoke, reopen)).resolves.toEqual({ ok: true });
+    expect(reopen).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(invoke.mock.invocationCallOrder[0]).toBeLessThan(reopen.mock.invocationCallOrder[0]);
+    expect(reopen.mock.invocationCallOrder[0]).toBeLessThan(invoke.mock.invocationCallOrder[1]);
+  });
+
+  it('已发出的请求即使标成 LINK_NOT_OPEN 也不重试', async () => {
+    const closed = new DeviceLinkError('LINK_NOT_OPEN', 'late close');
+    closed.inFlight = true;
+    const invoke = vi.fn().mockRejectedValue(closed);
+    const reopen = vi.fn();
+
+    await expect(invokeWithClosedLinkRecovery(invoke, reopen)).rejects.toBe(closed);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(reopen).not.toHaveBeenCalled();
+  });
+
+  it('reopen 的撤权错误原样返回，不发送第二次业务 invoke', async () => {
+    const closed = new DeviceLinkError('LINK_NOT_OPEN', 'control link is closed');
+    const revoked = new DeviceLinkError('ACCESS_REVOKED', 'access revoked');
+    const invoke = vi.fn().mockRejectedValue(closed);
+    const reopen = vi.fn().mockRejectedValue(revoked);
+
+    await expect(invokeWithClosedLinkRecovery(invoke, reopen)).rejects.toBe(revoked);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(reopen).toHaveBeenCalledTimes(1);
+  });
+
+  it('第二次 invoke 失败时不循环 reopen', async () => {
+    const firstClosed = new DeviceLinkError('LINK_NOT_OPEN', 'first close');
+    const secondClosed = new DeviceLinkError('LINK_NOT_OPEN', 'second close');
+    const invoke = vi.fn()
+      .mockRejectedValueOnce(firstClosed)
+      .mockRejectedValueOnce(secondClosed);
+    const reopen = vi.fn().mockResolvedValue(undefined);
+
+    await expect(invokeWithClosedLinkRecovery(invoke, reopen)).rejects.toBe(secondClosed);
+    expect(invoke).toHaveBeenCalledTimes(2);
+    expect(reopen).toHaveBeenCalledTimes(1);
+  });
+
+  it('reopen 后、第二次 invoke 前会重新执行本地控制守卫', async () => {
+    const closed = new DeviceLinkError('LINK_NOT_OPEN', 'control link is closed');
+    const disabled = new Error('[DEVICE_LINK_CONTROL_DISABLED] disabled while reopening');
+    const invoke = vi.fn().mockRejectedValueOnce(closed);
+    const reopen = vi.fn().mockResolvedValue(undefined);
+    const beforeRetry = vi.fn(() => {
+      throw disabled;
+    });
+
+    await expect(
+      invokeWithClosedLinkRecovery(invoke, reopen, beforeRetry),
+    ).rejects.toBe(disabled);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(reopen).toHaveBeenCalledTimes(1);
+    expect(beforeRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('只把具体会话 topic 识别为需要 streaming link', () => {
+    expect(requiresSessionLink(['sessions'])).toBe(false);
+    expect(requiresSessionLink(['session:'])).toBe(false);
+    expect(requiresSessionLink(['fs-watch:C:\\repo'])).toBe(false);
+    expect(requiresSessionLink(['sessions', 'session:s1'])).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/device-link/__tests__/linkRecovery.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/linkRecovery.test.ts
@@ -72,7 +72,7 @@ describe('device-link closed link recovery', () => {
     expect(reopen).toHaveBeenCalledTimes(1);
   });
 
-  it('reopen 后、第二次 invoke 前会重新执行本地控制守卫', async () => {
+  it('reopen 后守卫失败会清理链路且不发送第二次 invoke', async () => {
     const closed = new DeviceLinkError('LINK_NOT_OPEN', 'control link is closed');
     const disabled = new Error('[DEVICE_LINK_CONTROL_DISABLED] disabled while reopening');
     const invoke = vi.fn().mockRejectedValueOnce(closed);
@@ -80,19 +80,22 @@ describe('device-link closed link recovery', () => {
     const beforeRetry = vi.fn(() => {
       throw disabled;
     });
+    const cleanup = vi.fn();
 
     await expect(
-      invokeWithClosedLinkRecovery(invoke, reopen, beforeRetry),
+      invokeWithClosedLinkRecovery(invoke, reopen, beforeRetry, cleanup),
     ).rejects.toBe(disabled);
     expect(invoke).toHaveBeenCalledTimes(1);
     expect(reopen).toHaveBeenCalledTimes(1);
     expect(beforeRetry).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
-  it('只把具体会话 topic 识别为需要 streaming link', () => {
+  it('只把具体会话或有效文件树 topic 识别为需要 streaming link', () => {
     expect(requiresSessionLink(['sessions'])).toBe(false);
     expect(requiresSessionLink(['session:'])).toBe(false);
-    expect(requiresSessionLink(['fs-watch:C:\\repo'])).toBe(false);
+    expect(requiresSessionLink(['fs-watch:'])).toBe(false);
     expect(requiresSessionLink(['sessions', 'session:s1'])).toBe(true);
+    expect(requiresSessionLink(['fs-watch:C:\\repo'])).toBe(true);
   });
 });

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -912,6 +912,16 @@ export function closeRemoteLink(deviceId: string): void {
   client?.closeLink(deviceId, 'user');
 }
 
+/** 重开期间本地撤权时，撤销已成功建立的临时控制链路，保持 fail-closed。 */
+function assertRemoteControlTargetEnabledAfterReopen(deviceId: string): void {
+  try {
+    assertRemoteControlTargetEnabled(deviceId);
+  } catch (err) {
+    closeRemoteLink(deviceId);
+    throw err;
+  }
+}
+
 /**
  * 本机在 device-link 网络中的设备 id(relay ack 下发);未连接 / 未 ack 时 null。
  * 供会话引用解析等消费方识别「指向本机自己的 deviceId」——深链是可复制的字符串,
@@ -939,6 +949,7 @@ export async function remoteInvoke(
     invoke,
     () => openRemoteLink(deviceId),
     () => assertRemoteControlTargetEnabled(deviceId),
+    () => closeRemoteLink(deviceId),
   );
 }
 
@@ -956,7 +967,7 @@ export async function remoteSubscribe(
   if (requiresSessionLink(topics) && !client.isLinkReady(deviceId)) {
     await openRemoteLink(deviceId);
   }
-  assertRemoteControlTargetEnabled(deviceId);
+  assertRemoteControlTargetEnabledAfterReopen(deviceId);
   if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
   return client.invoke(deviceId, {
     channel: DL_SUBSCRIBE_CHANNEL,

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -87,6 +87,10 @@ import {
   pollContactsDeviceSyncSettingChange,
   setContactsDeviceLinkOwnerActive,
 } from '../contacts-sync/driver';
+import {
+  invokeWithClosedLinkRecovery,
+  requiresSessionLink,
+} from './linkRecovery';
 
 // register.ts 从 device-link/index 导入 setBusyProbe;改用 busyReporter 后在此 re-export 保持其导入不变。
 export { setBusyProbe };
@@ -873,9 +877,17 @@ function assertNotStandby(): void {
   }
 }
 
+/** 本机主动关闭对某设备的控制后，所有新建链路与业务调用都必须继续 fail closed。 */
+function assertRemoteControlTargetEnabled(deviceId: string): void {
+  if (readDeviceLinkSettings().disabledControlDeviceIds.includes(deviceId)) {
+    throw new Error('[DEVICE_LINK_CONTROL_DISABLED] device control is disabled locally');
+  }
+}
+
 /** 控制端:向目标设备发起控制链路(link-open → link-accept) */
 export async function openRemoteLink(deviceId: string): Promise<LinkAcceptPayload> {
   assertNotStandby();
+  assertRemoteControlTargetEnabled(deviceId);
   if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
   const existing = openLinkInFlight.get(deviceId);
   if (existing) return existing;
@@ -918,8 +930,16 @@ export async function remoteInvoke(
   args: unknown[],
 ): Promise<InvokeResultPayload> {
   assertNotStandby();
-  if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
-  return client.invoke(deviceId, { channel, args }, INVOKE_TIMEOUT_OVERRIDES_MS[channel]);
+  assertRemoteControlTargetEnabled(deviceId);
+  const invoke = (): Promise<InvokeResultPayload> => {
+    if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
+    return client.invoke(deviceId, { channel, args }, INVOKE_TIMEOUT_OVERRIDES_MS[channel]);
+  };
+  return invokeWithClosedLinkRecovery(
+    invoke,
+    () => openRemoteLink(deviceId),
+    () => assertRemoteControlTargetEnabled(deviceId),
+  );
 }
 
 /**
@@ -931,6 +951,12 @@ export async function remoteSubscribe(
   topics: string[],
 ): Promise<InvokeResultPayload> {
   assertNotStandby();
+  assertRemoteControlTargetEnabled(deviceId);
+  if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
+  if (requiresSessionLink(topics) && !client.isLinkReady(deviceId)) {
+    await openRemoteLink(deviceId);
+  }
+  assertRemoteControlTargetEnabled(deviceId);
   if (!client) throw new Error('[DEVICE_LINK_NOT_CONNECTED] device-link client not initialized');
   return client.invoke(deviceId, {
     channel: DL_SUBSCRIBE_CHANNEL,

--- a/apps/desktop/src/main/device-link/linkRecovery.ts
+++ b/apps/desktop/src/main/device-link/linkRecovery.ts
@@ -1,0 +1,34 @@
+import { DeviceLinkError } from '@cindy/device-link';
+
+/** 打开具体远程会话时必须先建立 streaming link；轻量 sessions 列表订阅不依赖。 */
+export function requiresSessionLink(topics: readonly string[]): boolean {
+  return topics.some((topic) => (
+    topic.startsWith('session:') && topic.length > 'session:'.length
+  ));
+}
+
+/**
+ * LINK_NOT_OPEN 由 DeviceLinkClient 在真正发帧前抛出，因此可先重开链路再重试一次。
+ * 已经发出的请求或其它错误绝不重试，避免 enqueue / send 等写操作重复执行。
+ */
+export async function invokeWithClosedLinkRecovery<T>(
+  invoke: () => Promise<T>,
+  reopen: () => Promise<unknown>,
+  beforeRetry?: () => void,
+): Promise<T> {
+  try {
+    return await invoke();
+  } catch (err) {
+    if (
+      !(err instanceof DeviceLinkError)
+      || err.code !== 'LINK_NOT_OPEN'
+      || err.inFlight === true
+    ) {
+      throw err;
+    }
+  }
+
+  await reopen();
+  beforeRetry?.();
+  return invoke();
+}

--- a/apps/desktop/src/main/device-link/linkRecovery.ts
+++ b/apps/desktop/src/main/device-link/linkRecovery.ts
@@ -1,9 +1,10 @@
-import { DeviceLinkError } from '@cindy/device-link';
+import { DeviceLinkError, parseFsWatchTopic } from '@cindy/device-link';
 
-/** 打开具体远程会话时必须先建立 streaming link；轻量 sessions 列表订阅不依赖。 */
+/** 打开具体远程会话或文件树监听时必须先建立 streaming link；轻量 sessions 列表订阅不依赖。 */
 export function requiresSessionLink(topics: readonly string[]): boolean {
   return topics.some((topic) => (
-    topic.startsWith('session:') && topic.length > 'session:'.length
+    (topic.startsWith('session:') && topic.length > 'session:'.length)
+    || parseFsWatchTopic(topic) !== null
   ));
 }
 
@@ -15,6 +16,7 @@ export async function invokeWithClosedLinkRecovery<T>(
   invoke: () => Promise<T>,
   reopen: () => Promise<unknown>,
   beforeRetry?: () => void,
+  onRetryGuardFailure?: () => void,
 ): Promise<T> {
   try {
     return await invoke();
@@ -29,6 +31,15 @@ export async function invokeWithClosedLinkRecovery<T>(
   }
 
   await reopen();
-  beforeRetry?.();
+  try {
+    beforeRetry?.();
+  } catch (err) {
+    try {
+      onRetryGuardFailure?.();
+    } catch {
+      // 清理是 best-effort；保留撤权守卫错误作为调用方可见结果。
+    }
+    throw err;
+  }
   return invoke();
 }

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -894,7 +894,18 @@ describe('DeviceLinkClient', () => {
       },
     });
     await open;
+    expect(h.client.isLinkReady('dev-b')).toBe(true);
     h.client.closeLink('dev-b', 'user');
+    expect(h.client.isLinkReady('dev-b')).toBe(false);
+
+    const sentBeforeBlockedInvoke = h.current().sent.length;
+    const blockedInvoke = await h.client.invoke(
+      'dev-b',
+      { channel: 'maker:send', args: [] },
+    ).catch((err: unknown) => err);
+    expect(blockedInvoke).toMatchObject({ code: 'LINK_NOT_OPEN' });
+    expect((blockedInvoke as DeviceLinkError).inFlight).not.toBe(true);
+    expect(h.current().sent).toHaveLength(sentBeforeBlockedInvoke);
 
     const listing = h.client.invoke('dev-b', { channel: 'local-db:sessions:list', args: [] });
     const sentListing = h.current().sent.at(-1)!;
@@ -913,6 +924,54 @@ describe('DeviceLinkClient', () => {
       payload: { ok: true, result: ['session-1'] },
     });
     await expect(listing).resolves.toMatchObject({ ok: true, result: ['session-1'] });
+    h.client.stop();
+  });
+
+  it('显式 close 后只放行已接收的 legacy listing invoke-result 回程', async () => {
+    const h = makeHarness({ timing: { pingIntervalMs: 1_000 } });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'controller-stream');
+    h.client.closeLink('dev-b', 'toggle-off');
+
+    h.client.onFrame((env) => {
+      if (
+        env.kind !== 'invoke'
+        || env.id !== 'listing-after-close'
+        || env.src !== 'dev-b'
+      ) return;
+      h.client.sendInvokeResult(env.src, env.id, {
+        ok: true,
+        result: ['session-after-close'],
+      });
+    });
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'invoke',
+      id: 'listing-after-close',
+      src: 'dev-b',
+      payload: { channel: 'local-db:sessions:list', args: [] },
+    });
+    await tick();
+
+    const response = h.current().sent.find((env) => (
+      env.kind === 'invoke-result' && env.id === 'listing-after-close'
+    ));
+    expect(response).toMatchObject({
+      kind: 'invoke-result',
+      dst: 'dev-b',
+      payload: { ok: true, result: ['session-after-close'] },
+    });
+    expect(parseTransportPayload(response?.payload)).toBeNull();
+    expect(() => h.client.sendInvokeResult('dev-b', 'unknown-request', {
+      ok: true,
+      result: null,
+    })).toThrow(expect.objectContaining({ code: 'LINK_NOT_OPEN' }));
+    expect(() => h.client.sendInvokeResult('dev-b', 'listing-after-close', {
+      ok: true,
+      result: null,
+    })).toThrow(expect.objectContaining({ code: 'LINK_NOT_OPEN' }));
     h.client.stop();
   });
 

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -45,6 +45,7 @@ const SLOW_REQUEST_WARN_MS = 1_000;
 const MAX_LEGACY_INBOUND_FRAMES = 128;
 const MAX_LEGACY_INBOUND_BYTES = 16 * 1024 * 1024;
 const MAX_PENDING_INBOUND_LINK_OFFERS = 64;
+const MAX_UNLINKED_LEGACY_RESPONSE_IDS = 128;
 
 type DeviceLinkCrypto = {
   randomUUID?: () => string;
@@ -262,6 +263,8 @@ interface PeerTransportState {
   reliable: boolean;
   linkReady: boolean;
   explicitlyClosed: boolean;
+  /** 显式关闭后收到的 allowlisted legacy invoke；只放行与 requestId 配对的一次回程。 */
+  unlinkedLegacyResponseIds: Set<string>;
   pending: Map<number, PendingReliableMessage>;
   pendingBytes: number;
   retryTimer: ReturnType<typeof setInterval> | null;
@@ -462,6 +465,11 @@ export class DeviceLinkClient {
     return this.status;
   }
 
+  /** 目标设备是否已完成 link-open / link-accept，可安全进入 streaming tier。 */
+  isLinkReady(dst: string): boolean {
+    return this.peerTransport.get(dst)?.linkReady === true;
+  }
+
   onStatusChange(cb: (s: DeviceLinkStatus) => void): () => void {
     this.statusHandlers.add(cb);
     return () => this.statusHandlers.delete(cb);
@@ -550,6 +558,7 @@ export class DeviceLinkClient {
     if (peer) {
       peer.linkReady = false;
       peer.explicitlyClosed = true;
+      peer.unlinkedLegacyResponseIds.clear();
       // 显式关闭只撤掉 streaming 可靠层。listing / topic 控制帧仍不依赖
       // link-open，后续应回退到 legacy，而不是被统一挡成 LINK_NOT_OPEN。
       peer.reliable = false;
@@ -586,7 +595,13 @@ export class DeviceLinkClient {
 
   /** 被控端:回 invoke-result(对应入站 invoke 的 id) */
   sendInvokeResult(dst: string, requestId: string, payload: InvokeResultPayload): void {
-    this.sendPeerEnvelope({ v: PROTOCOL_VERSION, kind: 'invoke-result', id: requestId, dst, payload });
+    const peer = this.peerTransport.get(dst);
+    const allowClosedLegacyResponse = peer?.unlinkedLegacyResponseIds.has(requestId) === true;
+    this.sendPeerEnvelope(
+      { v: PROTOCOL_VERSION, kind: 'invoke-result', id: requestId, dst, payload },
+      allowClosedLegacyResponse,
+    );
+    if (allowClosedLegacyResponse) peer?.unlinkedLegacyResponseIds.delete(requestId);
   }
 
   /** 被控端:回 link-accept */
@@ -1355,6 +1370,7 @@ export class DeviceLinkClient {
           const peer = this.getPeerTransport(env.src);
           peer.linkReady = false;
           peer.explicitlyClosed = true;
+          peer.unlinkedLegacyResponseIds.clear();
           // 对端关闭与本地 closeLink 语义对称：撤掉 streaming 可靠层，
           // 后续不依赖 link-open 的 listing/control invoke 可回退 legacy。
           peer.reliable = false;
@@ -1362,6 +1378,16 @@ export class DeviceLinkClient {
           peer.remoteBaseSeq = 1;
           peer.receive.clear();
           this.abandonReliablePending(env.src, 'control link closed by peer');
+        } else if (
+          env.kind === 'invoke'
+          && env.src
+          && env.id
+          && isUnlinkedLegacyEnvelope(env)
+        ) {
+          const peer = this.getPeerTransport(env.src);
+          if (peer.explicitlyClosed && !peer.linkReady) {
+            this.rememberUnlinkedLegacyResponse(peer, env.id);
+          }
         }
         return this.emitFrame(env);
     }
@@ -1668,13 +1694,18 @@ export class DeviceLinkClient {
     );
   }
 
-  private sendPeerEnvelope(env: Envelope): boolean {
+  private sendPeerEnvelope(env: Envelope, allowClosedLegacyResponse = false): boolean {
     if (!env.dst || !isReliableKind(env.kind)) {
       this.sendEnvelope(env);
       return false;
     }
     const peer = this.getPeerTransport(env.dst);
-    if (peer.explicitlyClosed && !peer.linkReady && !isUnlinkedLegacyEnvelope(env)) {
+    if (
+      peer.explicitlyClosed
+      && !peer.linkReady
+      && !isUnlinkedLegacyEnvelope(env)
+      && !allowClosedLegacyResponse
+    ) {
       throw new DeviceLinkError('LINK_NOT_OPEN', 'control link is closed');
     }
     if (!peer.reliable) {
@@ -1848,6 +1879,7 @@ export class DeviceLinkClient {
         reliable: false,
         linkReady: false,
         explicitlyClosed: false,
+        unlinkedLegacyResponseIds: new Set(),
         pending: new Map(),
         pendingBytes: 0,
         retryTimer: null,
@@ -1858,6 +1890,16 @@ export class DeviceLinkClient {
       this.peerTransport.set(dst, peer);
     }
     return peer;
+  }
+
+  private rememberUnlinkedLegacyResponse(peer: PeerTransportState, requestId: string): void {
+    peer.unlinkedLegacyResponseIds.delete(requestId);
+    peer.unlinkedLegacyResponseIds.add(requestId);
+    while (peer.unlinkedLegacyResponseIds.size > MAX_UNLINKED_LEGACY_RESPONSE_IDS) {
+      const oldest = peer.unlinkedLegacyResponseIds.values().next().value as string | undefined;
+      if (!oldest) break;
+      peer.unlinkedLegacyResponseIds.delete(oldest);
+    }
   }
 
   private getReceiveStream(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复显式关闭 control link 后，Desktop 仍把后续远程调用永久留在 `LINK_NOT_OPEN` 状态的问题。根因是关闭状态只在传输层生效，但 Desktop 没有在下一次业务调用前重新建立 link-open / link-accept 生命周期。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护（补充回归测试）

### 范围

- 关联 Issue / 需求：Fixes #1324
- 本 PR 包含：
  - 发送前遇到 `LINK_NOT_OPEN` 时，通过已有并发去重的 `openRemoteLink()` 重开链路，并且只重试一次。
  - 重开等待期间重新检查本地禁用设备列表，保持撤权后的 fail-closed 语义。
  - 具体 session topic 的订阅在 link 未 ready 时先建立 streaming link。
  - 显式 close 后，legacy listing 的 `invoke-result` 仅按精确 request ID 放行一次，未知或重复 ID 仍拒绝。
- 明确不包含：
  - 不重试 `NOT_CONNECTED` / `relay connection lost`、timeout、backpressure 或已进入 `inFlight` 的请求；这些请求可能已经到达 relay/目标端，盲目重试会造成远程写操作重复执行。
  - 不修改 relay 服务端或 wire payload。
- 用户可见变化：重新授权或重新打开远程控制后，普通远程调用可以自动恢复；无新增 UI。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：仅修改 Desktop main、共享 device-link client 及其单测，没有界面、交互或文案变化。
- 引用的设计规范：不涉及 UI。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/device-link build
结果：通过

pnpm --filter @cindy/device-link test
结果：6 个测试文件、143 个测试通过

pnpm --filter desktop exec vitest run src/main/device-link/__tests__/linkRecovery.test.ts
结果：7 个测试通过

NODE_OPTIONS='--max-old-space-size=8192' pnpm --filter desktop typecheck
结果：通过

pnpm check:dco
结果：通过（1 个 commit，含 Signed-off-by）

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-device-link-reopen
结果：278/279 个测试文件、2998/2999 个测试通过；唯一失败为 apps/mobile/src/__tests__/startupSplashOverlay.test.ts 的 Expo introspect 子进程超过 5 秒超时。
```

### 手工验证

不涉及：本次未进行两台真实设备的远程控制手测。

### 未执行的验证

- 未执行真实 relay 断线/重连场景的手测；本 PR 对 `relay connection lost`（已 in-flight）保持不重试。
- 上述 mobile splash 测试失败已在未修改 mobile 文件的基线 checkout（HEAD `267f0a001`）单独复现，未将无关 mobile 修复混入本 PR。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 跨平台差异
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）

### 影响与回滚

- 影响范围：Desktop device-link 控制端调用路径与共享客户端的 closed-link legacy 回程；没有新增 wire 字段，旧端仍可按原 legacy/reliable 能力工作。已知边界是 `remoteSubscribe` 在重开完成后到实际发送之间再次断链时仍可能返回 `LINK_NOT_OPEN`，作为后续收敛项，不改变本 PR 的单次重试安全边界。
- 回滚 / 降级方式：回滚本 PR 即可恢复原行为；无需数据迁移。发生 relay 断线时仍沿用原有 `NOT_CONNECTED` / `inFlight` 错误语义，避免重复执行远程写操作。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
