### PR TITLE
fix: 收口 Codex 静默重连卡住

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/interruptedTurnAutoResume.test.ts
@@ -56,6 +56,15 @@ describe('isInterruptedTurnError', () => {
     ).toBe(true);
   });
 
+  it('accepts the classified Codex reconnect-stalled reason', () => {
+    expect(
+      isInterruptedTurnError({
+        reason: 'codex_reconnect_stalled',
+        message: 'Codex app-server stopped making progress while reconnecting.',
+      }),
+    ).toBe(true);
+  });
+
   it('rejects errors that carry a stable reason (已分类,另有处置路径)', () => {
     for (const reason of ['empty-response', 'turn-failed', 'silent-stop-exhausted']) {
       expect(

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -648,6 +648,37 @@ describe('maker SEND transaction', () => {
     expect(session.send).not.toHaveBeenCalled();
   });
 
+  it('rebuilds an error session through lazy bootstrap before dispatch', async () => {
+    const failedSession = createSession({
+      getStatus: vi.fn(() => 'error'),
+    });
+    const recoveredSession = createSession({ id: 'session-1', workDir: 'C:\\repo' });
+    const createOpts: MakerSessionCreateOpts = {
+      id: 'session-1',
+      agentKind: 'codex',
+      workingDir: 'C:\\repo',
+      model: 'gpt-5.4',
+    };
+    const { deps } = createDeps({
+      getSession: vi.fn(() => failedSession),
+      bootstrapSession: vi.fn(async () => ({
+        session: recoveredSession,
+        didInjectOrcaInstructions: false,
+        didInjectProjectContext: false,
+      })),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await expect(transaction.sendToAgentAccepted('session-1', 'hello', createOpts)).resolves.toMatchObject({
+      accepted: true,
+      outcome: { kind: 'session-dispatch', dispatched: true },
+    });
+
+    expect(failedSession.send).not.toHaveBeenCalled();
+    expect(deps.bootstrapSession).toHaveBeenCalledWith(createOpts);
+    expect(recoveredSession.send).toHaveBeenCalled();
+  });
+
   it('lazy-create adopts the DB working_dir when the caller-provided one is stale', async () => {
     // 场景:输入队列崩溃快照回放,createOpts 内嵌启动 sweep 改写前的老路径。
     const staleDir = '/data/xdt-maker/dialogues/2026-06-22/lazy-1';

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -650,7 +650,7 @@ describe('maker SEND transaction', () => {
 
   it('rebuilds an error session through lazy bootstrap before dispatch', async () => {
     const failedSession = createSession({
-      getStatus: vi.fn(() => 'error'),
+      getStatus: vi.fn(() => 'error' as const),
     });
     const recoveredSession = createSession({ id: 'session-1', workDir: 'C:\\repo' });
     const createOpts: MakerSessionCreateOpts = {

--- a/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
+++ b/apps/desktop/src/main/maker-ipc/interruptedTurnAutoResume.ts
@@ -105,7 +105,7 @@ export function isInterruptedTurnError(signals: InterruptedTurnErrorSignals): bo
   const reason = typeof signals.reason === 'string' ? signals.reason : '';
   // 例外先行：`upstream-overload` 是**已归类为可重试**的 reason，它本身就是比文案更可靠的
   // 权威判据（结构化优先于文案，与 overload-error.ts 的论证同源），直接放行、不再看文案。
-  if (reason === UPSTREAM_OVERLOAD_REASON) return true;
+  if (reason === UPSTREAM_OVERLOAD_REASON || reason === 'codex_reconnect_stalled') return true;
   if (reason.length > 0) return false;
   if (isStreamTruncationError(signals)) return true;
   const message = signals.message;

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -66,6 +66,8 @@ export interface MakerSendTransactionSession {
   agentKind: AgentKind;
   workDir: string;
   remoteHostId: string | null;
+  /** Error sessions stay registered while their underlying handle cleanup is retried. */
+  getStatus?(): 'active' | 'aborting' | 'closed' | 'error';
   isTurnRunning(): boolean;
   send(message: UserMessage | string, opts?: SessionSendOptions): Promise<SessionSendResult>;
 }
@@ -437,6 +439,14 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       // 让下方走 lazy-create 按 DB 新值 spawn 新引擎。
       await deps.applyPendingAgentSwitch?.(sessionId);
       let sess = deps.getSession(sessionId);
+      // Maker keeps a failed Session registered until its real handle cleanup
+      // succeeds. It is not a reusable send target: route it through the
+      // existing lazy bootstrap path so Maker.createSession() can retry close
+      // and rebuild the handle before dispatching the message.
+      if (sess?.getStatus?.() === 'error') {
+        deps.log.info('send: error session requires recovery before dispatch', { sessionId });
+        sess = undefined;
+      }
       if (sess?.isTurnRunning()) {
         throwIpcError('SESSION_RUNNING', `Session ${sessionId} is already running a turn`);
       }

--- a/apps/desktop/src/renderer/__tests__/errorMessageRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/errorMessageRestore.test.ts
@@ -46,6 +46,16 @@ describe('mapServerMessages — persisted terminal error rows', () => {
     );
   });
 
+  it('maps Codex reconnect stalls to the existing upstream timeout copy', () => {
+    expect(ERROR_REASON_I18N_KEYS.codex_reconnect_stalled).toBe(
+      'logic.errors.upstreamResponseIdleTimeout',
+    );
+  });
+
+  it('maps an event-loop crash to the generic terminal failure copy', () => {
+    expect(ERROR_REASON_I18N_KEYS.session_event_loop_crashed).toBe('logic.errors.turnFailed');
+  });
+
   it('restores the overload reason from persisted rows so history can localize it', () => {
     const mapped = makerChatStore.__mapServerMessagesForTest([
       errorRow('e-overload', {

--- a/apps/desktop/src/renderer/__tests__/errorMessageRestore.test.ts
+++ b/apps/desktop/src/renderer/__tests__/errorMessageRestore.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect } from 'vitest';
 
 import { makerChatStore } from '@/lib/makerChatStore';
 import type { Message } from '@/lib/ccAgent.types';
-import { ERROR_REASON_I18N_KEYS } from '@/components/chat/ErrorMessageCard';
+import { ERROR_REASON_I18N_KEYS } from '@/components/chat/errorReasonI18n';
 import { UPSTREAM_OVERLOAD_REASON } from '@/utils/overloadError';
 
 const SESSION_ID = 's-err';

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -41,6 +41,7 @@ import { isInvalidEncryptedContentError } from '@/utils/encryptedContentError';
 import { isNetworkishErrorMessage, parseReconnectAttemptMessage } from '@/utils/networkError';
 import { isOverloadErrorMessage, parseOverloadRetryProgress } from '@/utils/overloadError';
 import { isQuotaExhaustedErrorMessage } from '@/utils/quotaError';
+import { ERROR_REASON_I18N_KEYS } from './errorReasonI18n';
 import { CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON } from '../../../shared/claudeGatewayError';
 import { isPiImageInputUnsupportedError } from '../../../shared/inputError';
 
@@ -252,6 +253,7 @@ export function ErrorBanner({
   // (老 daemon / Anthropic 侧 / 历史持久化错误行 —— 后者只有文案可用)。
   const isOverloadError = isOverloadErrorMessage(error, undefined, errorReason);
   const overloadRetryProgress = parseOverloadRetryProgress(error);
+  const errorReasonI18nKey = errorReason ? ERROR_REASON_I18N_KEYS[errorReason] : undefined;
   // Retry 的显示条件与网络错误文案必须共用同一个判定。外部发起的 turn（例如
   // scheduler / goal）失败时没有安全的 recovery target，errorRetryText 会是 null；
   // 此时不能一边隐藏按钮，一边仍提示用户“点击重试”。
@@ -341,7 +343,11 @@ export function ErrorBanner({
             : 'chat.errorBanner.networkUnreachableNoRetry',
         );
   } else {
-    displayError = error;
+    // Keep the raw message available to every specialized gate above. Only
+    // the final fallback uses the stable reason map, so auth/network/overload
+    // recovery behavior keeps its existing priority while generic maker-core
+    // English fallbacks are localized in both the live and tail banner.
+    displayError = errorReasonI18nKey ? t(errorReasonI18nKey) : error;
     hasSpecialGuidance = false;
   }
 

--- a/apps/desktop/src/renderer/components/chat/ErrorMessageCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorMessageCard.tsx
@@ -20,29 +20,7 @@
 import { AlertCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { decodeRemoteErrorMessage } from '../../lib/makerChatStore';
-import { UPSTREAM_OVERLOAD_REASON } from '@/utils/overloadError';
-import { CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON } from '../../../shared/claudeGatewayError';
-
-/** 稳定 reason key → i18n。error-tail-banner(CCAgentSessionView)复用同一映射,
- *  保证尾部可操作红条与历史静态卡展示同一段文案。 */
-export const ERROR_REASON_I18N_KEYS: Record<string, string> = {
-  'empty-response': 'logic.errors.emptyResponse',
-  'turn-failed': 'logic.errors.turnFailed',
-  'silent-stop-exhausted': 'logic.errors.silentStopExhausted',
-  'permission-tighten-interrupt-failed': 'logic.errors.permissionTightenInterruptFailed',
-  'codex-auto-review-unavailable': 'logic.errors.codexAutoReviewUnavailable',
-  // 卡死自愈的两层看门狗(agent 层上游静默 / Session 层 turn 零事件)。两者的
-  // maker-core 侧 message 是英文兜底,renderer 一律走这里的本地化文案。
-  upstream_response_idle_timeout: 'logic.errors.upstreamResponseIdleTimeout',
-  codex_reconnect_stalled: 'logic.errors.upstreamResponseIdleTimeout',
-  session_event_loop_crashed: 'logic.errors.turnFailed',
-  turn_no_event_timeout: 'logic.errors.turnNoEventTimeout',
-  // 上游过载(重投预算耗尽后的终态)。**复用尾部 banner 的同一条文案**, 正是本表
-  // 注释说的那个一致性: 不映射的话同一条过载错误会出现「尾部红条本地化、历史静态
-  // 卡英文原文」的分裂 —— 而 codex 的过载原文还会随版本改措辞。
-  [UPSTREAM_OVERLOAD_REASON]: 'chat.errorBanner.overloadBusyNoRetry',
-  [CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON]: 'chat.errorBanner.claudeGatewayOpusPlanMismatch',
-};
+import { ERROR_REASON_I18N_KEYS } from './errorReasonI18n';
 
 export function ErrorMessageCard({ message, reason }: { message: string; reason?: string }) {
   const { t } = useTranslation();

--- a/apps/desktop/src/renderer/components/chat/ErrorMessageCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorMessageCard.tsx
@@ -34,6 +34,8 @@ export const ERROR_REASON_I18N_KEYS: Record<string, string> = {
   // 卡死自愈的两层看门狗(agent 层上游静默 / Session 层 turn 零事件)。两者的
   // maker-core 侧 message 是英文兜底,renderer 一律走这里的本地化文案。
   upstream_response_idle_timeout: 'logic.errors.upstreamResponseIdleTimeout',
+  codex_reconnect_stalled: 'logic.errors.upstreamResponseIdleTimeout',
+  session_event_loop_crashed: 'logic.errors.turnFailed',
   turn_no_event_timeout: 'logic.errors.turnNoEventTimeout',
   // 上游过载(重投预算耗尽后的终态)。**复用尾部 banner 的同一条文案**, 正是本表
   // 注释说的那个一致性: 不映射的话同一条过载错误会出现「尾部红条本地化、历史静态

--- a/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
@@ -764,6 +764,22 @@ describe('ErrorBanner OpenAI connection recovery', () => {
     expect(mocks.triggerLogin).not.toHaveBeenCalled();
   });
 
+  it('localizes event-loop terminal errors from the stable reason key', () => {
+    render(
+      <ErrorBanner
+        error="Session event loop stopped unexpectedly without a terminal event"
+        errorReason="session_event_loop_crashed"
+        retryText="retry this turn"
+        onRetry={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('logic.errors.turnFailed')).toBeTruthy();
+    expect(
+      screen.queryByText('Session event loop stopped unexpectedly without a terminal event'),
+    ).toBeNull();
+  });
+
   it('exposes the explicit Continue After Reset action only when provided', () => {
     const onContinueAfterUsageReset = vi.fn();
     const { rerender } = render(

--- a/apps/desktop/src/renderer/components/chat/errorReasonI18n.ts
+++ b/apps/desktop/src/renderer/components/chat/errorReasonI18n.ts
@@ -1,0 +1,23 @@
+import { CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON } from '../../../shared/claudeGatewayError';
+import { UPSTREAM_OVERLOAD_REASON } from '@/utils/overloadError';
+
+/**
+ * Stable maker-core error reason -> renderer i18n key.
+ *
+ * Both the live ErrorBanner and persisted ErrorMessageCard consume this
+ * side-effect-free map so the same terminal reason cannot drift between the
+ * active and historical views.
+ */
+export const ERROR_REASON_I18N_KEYS: Record<string, string> = {
+  'empty-response': 'logic.errors.emptyResponse',
+  'turn-failed': 'logic.errors.turnFailed',
+  'silent-stop-exhausted': 'logic.errors.silentStopExhausted',
+  'permission-tighten-interrupt-failed': 'logic.errors.permissionTightenInterruptFailed',
+  'codex-auto-review-unavailable': 'logic.errors.codexAutoReviewUnavailable',
+  upstream_response_idle_timeout: 'logic.errors.upstreamResponseIdleTimeout',
+  codex_reconnect_stalled: 'logic.errors.upstreamResponseIdleTimeout',
+  session_event_loop_crashed: 'logic.errors.turnFailed',
+  turn_no_event_timeout: 'logic.errors.turnNoEventTimeout',
+  [UPSTREAM_OVERLOAD_REASON]: 'chat.errorBanner.overloadBusyNoRetry',
+  [CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON]: 'chat.errorBanner.claudeGatewayOpusPlanMismatch',
+};

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16804,6 +16804,40 @@ describe('CodexAgent reconnect-stall watchdog', () => {
     }
   });
 
+  it('系统休眠期间不消耗重连额度，醒来后只等待剩余清醒时间', async () => {
+    vi.useFakeTimers();
+    try {
+      const startAt = Date.now();
+      vi.setSystemTime(startAt);
+      const agent = new CodexAgent(createDeps());
+      const { handle, handlers, seen } = await startReconnectTurn(
+        agent,
+        'session-reconnect-suspend',
+      );
+      emitReconnect(handlers, 1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      vi.setSystemTime(startAt + 8 * 60 * 60_000);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(seen.some(
+        (event) =>
+          event.type === 'error' &&
+          (event.data as { reason?: unknown }).reason === 'codex_reconnect_stalled',
+      )).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(60_001);
+      expect(seen.some(
+        (event) =>
+          event.type === 'error' &&
+          (event.data as { reason?: unknown }).reason === 'codex_reconnect_stalled',
+      )).toBe(true);
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('deadline 内重新收到 thinking 或工具产出后不再触发', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16710,19 +16710,28 @@ describe('CodexAgent reconnect-stall watchdog', () => {
     vi.unstubAllEnvs();
   });
 
-  function installReconnectHost(agent: CodexAgent, interruptHangs = false) {
+  function installReconnectHost(
+    agent: CodexAgent,
+    interruptHangs = false,
+    interruptAck?: Promise<unknown>,
+  ) {
     let turnSeq = 0;
     return installFakeHost(agent, (method) => {
       if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
       if (method === Method.TurnInterrupt) {
+        if (interruptAck) return interruptAck;
         return interruptHangs ? new Promise<never>(() => {}) : {};
       }
       return undefined;
     });
   }
 
-  async function startReconnectTurn(agent: CodexAgent, sessionId: string) {
-    const host = installReconnectHost(agent);
+  async function startReconnectTurn(
+    agent: CodexAgent,
+    sessionId: string,
+    interruptAck?: Promise<unknown>,
+  ) {
+    const host = installReconnectHost(agent, false, interruptAck);
     const handle = await agent.startSession({ sessionId, model: 'gpt-5.4', workingDir: '/repo' });
     const seen: AgentEvent[] = [];
     void (async () => {
@@ -16862,6 +16871,46 @@ describe('CodexAgent reconnect-stall watchdog', () => {
           (event.data as { reason?: unknown }).reason === 'codex_reconnect_stalled',
       )).toBe(false);
       expect(handle.isTurnRunning?.()).toBe(true);
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('重连停滞的 interrupt ACK 未到前保持 busy，迟到 completed 不得提前放行续跑', async () => {
+    vi.useFakeTimers();
+    try {
+      const interruptAck = deferred<Record<string, never>>();
+      const agent = new CodexAgent(createDeps());
+      const { handle, handlers, seen } = await startReconnectTurn(
+        agent,
+        'session-reconnect-deferred-ack',
+        interruptAck.promise,
+      );
+      emitReconnect(handlers, 1);
+
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS + 1);
+
+      expect(seen).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({
+          reason: 'codex_reconnect_stalled',
+          isTerminal: true,
+        }),
+      }));
+      expect(handle.isTurnRunning?.()).toBe(true);
+
+      // Codex may report the old turn's terminal notification before the
+      // interrupt RPC response. It must not release the admission guard.
+      handlers.turnCompleted?.({
+        threadId: 'start-thread-id',
+        turn: { id: 'turn-1', status: 'failed' },
+      } as never);
+      expect(handle.isTurnRunning?.()).toBe(true);
+
+      interruptAck.resolve({});
+      await vi.advanceTimersByTimeAsync(0);
+      expect(handle.isTurnRunning?.()).toBe(false);
       await handle.close();
     } finally {
       vi.useRealTimers();

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -17023,7 +17023,7 @@ describe('CodexAgent reconnect-stall watchdog', () => {
 
       expect(host.request.mock.calls.filter(([method]) => method === Method.TurnInterrupt)).toHaveLength(2);
       expect(retireHostKey).toHaveBeenCalledTimes(1);
-      expect(retireHostKey.mock.calls[0]?.[2]).toMatchObject({ failIfActive: false });
+      expect(retireHostKey.mock.calls[0]?.[2]).toMatchObject({ failIfActive: true });
 
       pendingStart.resolve({ turn: { id: 'turn-1' } });
       await sendPromise;

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16983,6 +16983,10 @@ describe('CodexAgent reconnect-stall watchdog', () => {
         model: 'gpt-5.4',
         workingDir: '/repo',
       });
+      const subscription = host.subscribeThread.mock.results[0]?.value;
+      const release = subscription?.release;
+      if (!release) throw new Error('expected pending-turn subscription');
+      release.mockRejectedValueOnce(new Error('thread/unsubscribe failed'));
       const seen: AgentEvent[] = [];
       void (async () => {
         for await (const event of handle.events()) seen.push(event);
@@ -17049,6 +17053,10 @@ describe('CodexAgent reconnect-stall watchdog', () => {
         model: 'gpt-5.4',
         workingDir: '/repo',
       });
+      const subscription = host.subscribeThread.mock.results[0]?.value;
+      const release = subscription?.release;
+      if (!release) throw new Error('expected pending-turn subscription');
+      release.mockRejectedValueOnce(new Error('thread/unsubscribe failed'));
       void (async () => {
         for await (const event of handle.events()) void event;
       })();

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16697,6 +16697,309 @@ describe('CodexAgent upstream-response-idle watchdog', () => {
   });
 });
 
+describe('CodexAgent reconnect-stall watchdog', () => {
+  const RECONNECT_STALL_MS = 120_000;
+
+  beforeEach(() => {
+    // 本组只验证显式 `Reconnecting... N/M` deadline，不让 30min upstream-idle
+    // 看门狗参与计时与收口。
+    vi.stubEnv('XDT_CODEX_IDLE_TIMEOUT_MS', '0');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  function installReconnectHost(agent: CodexAgent, interruptHangs = false) {
+    let turnSeq = 0;
+    return installFakeHost(agent, (method) => {
+      if (method === Method.TurnStart) return { turn: { id: `turn-${++turnSeq}` } };
+      if (method === Method.TurnInterrupt) {
+        return interruptHangs ? new Promise<never>(() => {}) : {};
+      }
+      return undefined;
+    });
+  }
+
+  async function startReconnectTurn(agent: CodexAgent, sessionId: string) {
+    const host = installReconnectHost(agent);
+    const handle = await agent.startSession({ sessionId, model: 'gpt-5.4', workingDir: '/repo' });
+    const seen: AgentEvent[] = [];
+    void (async () => {
+      for await (const event of handle.events()) seen.push(event);
+    })();
+    await handle.send({ type: 'user', content: 'go' });
+    const handlers = host.getThreadHandlers();
+    if (!handlers) throw new Error('expected thread handlers');
+    handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-1' } } as never);
+    return { host, handle, handlers, seen };
+  }
+
+  function emitReconnect(
+    handlers: ThreadEventHandlers,
+    attempt: number,
+    maxAttempts = 5,
+  ): void {
+    handlers.error?.({
+      threadId: 'start-thread-id',
+      turnId: 'turn-1',
+      error: { message: `Reconnecting... ${attempt}/${maxAttempts}` },
+      willRetry: true,
+    } as never);
+  }
+
+  it('首次重连提示后 120s 无进展 → 收口为 codex_reconnect_stalled', async () => {
+    vi.useFakeTimers();
+    try {
+      const agent = new CodexAgent(createDeps());
+      const { host, handle, handlers, seen } = await startReconnectTurn(
+        agent,
+        'session-reconnect-stalled',
+      );
+      emitReconnect(handlers, 1);
+
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS + 1);
+
+      expect(seen).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({
+          reason: 'codex_reconnect_stalled',
+          isTerminal: true,
+        }),
+      }));
+      expect(handle.isTurnRunning?.()).toBe(false);
+      expect(host.request.mock.calls).toContainEqual([
+        Method.TurnInterrupt,
+        expect.objectContaining({ turnId: 'turn-1' }),
+      ]);
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('后续 2/5、3/5 只更新进度，不延长首次提示建立的总 deadline', async () => {
+    vi.useFakeTimers();
+    try {
+      const agent = new CodexAgent(createDeps());
+      const { handle, handlers, seen } = await startReconnectTurn(
+        agent,
+        'session-reconnect-deadline',
+      );
+      emitReconnect(handlers, 1);
+      await vi.advanceTimersByTimeAsync(60_000);
+      emitReconnect(handlers, 2);
+      await vi.advanceTimersByTimeAsync(30_000);
+      emitReconnect(handlers, 3);
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      expect(seen.some(
+        (event) =>
+          event.type === 'error' &&
+          (event.data as { reason?: unknown }).reason === 'codex_reconnect_stalled',
+      )).toBe(true);
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('deadline 内重新收到 thinking 或工具产出后不再触发', async () => {
+    vi.useFakeTimers();
+    try {
+      const agent = new CodexAgent(createDeps());
+      const { handle, handlers, seen } = await startReconnectTurn(
+        agent,
+        'session-reconnect-recovered',
+      );
+      emitReconnect(handlers, 1);
+      await vi.advanceTimersByTimeAsync(60_000);
+      handlers.reasoningTextDelta?.({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        itemId: 'reasoning-1',
+        delta: 'recovered',
+      } as never);
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS * 2);
+
+      expect(seen.some(
+        (event) =>
+          event.type === 'error' &&
+          (event.data as { reason?: unknown }).reason === 'codex_reconnect_stalled',
+      )).toBe(false);
+      expect(handle.isTurnRunning?.()).toBe(true);
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('interrupt 不响应时关闭 handle 并退役坏 host，下一次发送可重建', async () => {
+    vi.useFakeTimers();
+    try {
+      const agent = new CodexAgent(createDeps());
+      const host = installReconnectHost(agent, true);
+      const retireHostKey = vi
+        .spyOn(
+          agent as unknown as { retireHostKey: (...args: unknown[]) => Promise<void> },
+          'retireHostKey',
+        )
+        .mockResolvedValue(undefined);
+      const handle = await agent.startSession({
+        sessionId: 'session-reconnect-retire',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      let eventsEnded = false;
+      void (async () => {
+        for await (const event of handle.events()) void event;
+        eventsEnded = true;
+      })();
+      await handle.send({ type: 'user', content: 'go' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers) throw new Error('expected thread handlers');
+      handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-1' } } as never);
+      emitReconnect(handlers, 1);
+
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS + 20_010);
+
+      expect(eventsEnded).toBe(true);
+      expect(retireHostKey).toHaveBeenCalledTimes(1);
+      expect(retireHostKey.mock.calls[0]?.[2]).toMatchObject({ failIfActive: false });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('重连提示早于 turnStarted 且 turn/start 仍 pending 时也会收口并隔离迟到 turn', async () => {
+    vi.useFakeTimers();
+    try {
+      const pendingStart = deferred<{ turn: { id: string } }>();
+      const startEntered = deferred<void>();
+      const interruptEntered = deferred<void>();
+      const agent = new CodexAgent(createDeps());
+      const retireHostKey = vi
+        .spyOn(
+          agent as unknown as { retireHostKey: (...args: unknown[]) => Promise<void> },
+          'retireHostKey',
+        )
+        .mockResolvedValue(undefined);
+      const host = installFakeHost(agent, (method) => {
+        if (method === Method.TurnStart) {
+          startEntered.resolve();
+          return pendingStart.promise;
+        }
+        if (method === Method.TurnInterrupt) {
+          interruptEntered.resolve();
+          return {};
+        }
+        return undefined;
+      });
+      const handle = await agent.startSession({
+        sessionId: 'session-reconnect-before-started',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const seen: AgentEvent[] = [];
+      void (async () => {
+        for await (const event of handle.events()) seen.push(event);
+      })();
+      const sendPromise = handle.send({ type: 'user', content: 'go' });
+      await startEntered.promise;
+      expect(host.request.mock.calls.filter(([method]) => method === Method.TurnStart)).toHaveLength(1);
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error) throw new Error('expected thread handlers');
+      handlers.error({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        error: { message: 'Reconnecting... 1/5' },
+        willRetry: true,
+      } as never);
+
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS + 1);
+      await interruptEntered.promise;
+
+      expect(seen).toContainEqual(expect.objectContaining({
+        type: 'error',
+        data: expect.objectContaining({
+          reason: 'codex_reconnect_stalled',
+          isTerminal: true,
+        }),
+      }));
+      expect(host.request.mock.calls).toContainEqual([
+        Method.TurnInterrupt,
+        expect.objectContaining({ turnId: 'turn-1' }),
+      ]);
+
+      pendingStart.resolve({ turn: { id: 'turn-1' } });
+      await sendPromise;
+      expect(handle.isTurnRunning?.()).toBe(false);
+      expect(retireHostKey).not.toHaveBeenCalled();
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('pending turn/start 的中断两次都不响应时才退役共享 host', async () => {
+    vi.useFakeTimers();
+    try {
+      const pendingStart = deferred<{ turn: { id: string } }>();
+      const startEntered = deferred<void>();
+      const agent = new CodexAgent(createDeps());
+      const retireHostKey = vi
+        .spyOn(
+          agent as unknown as { retireHostKey: (...args: unknown[]) => Promise<void> },
+          'retireHostKey',
+        )
+        .mockResolvedValue(undefined);
+      const host = installFakeHost(agent, (method) => {
+        if (method === Method.TurnStart) {
+          startEntered.resolve();
+          return pendingStart.promise;
+        }
+        if (method === Method.TurnInterrupt) return new Promise<never>(() => {});
+        return undefined;
+      });
+      const handle = await agent.startSession({
+        sessionId: 'session-reconnect-before-started-retire',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      void (async () => {
+        for await (const event of handle.events()) void event;
+      })();
+      const sendPromise = handle.send({ type: 'user', content: 'go' });
+      await startEntered.promise;
+      const handlers = host.getThreadHandlers();
+      if (!handlers?.error) throw new Error('expected thread handlers');
+      handlers.error({
+        threadId: 'start-thread-id',
+        turnId: 'turn-1',
+        error: { message: 'Reconnecting... 1/5' },
+        willRetry: true,
+      } as never);
+
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS + 1);
+      // handle.close() 立即释放本 thread；共享 host 只有在两次 interrupt ack 都超时后
+      // 才允许退役。
+      expect(handle.isTurnRunning?.()).toBe(false);
+      expect(retireHostKey).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(10_000 * 2 + 10);
+
+      expect(host.request.mock.calls.filter(([method]) => method === Method.TurnInterrupt)).toHaveLength(2);
+      expect(retireHostKey).toHaveBeenCalledTimes(1);
+      expect(retireHostKey.mock.calls[0]?.[2]).toMatchObject({ failIfActive: false });
+
+      pendingStart.resolve({ turn: { id: 'turn-1' } });
+      await sendPromise;
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('CodexAgent context window reporting', () => {
   // agent 侧只负责两件事:按 turn 归属模型、把 host 给的已核实上限与上报值取小。
   // 「目录里这个窗口算不算已核实、该用哪条路由的」判定在 host

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16917,6 +16917,128 @@ describe('CodexAgent reconnect-stall watchdog', () => {
     }
   });
 
+  it('迟到 completed 证明旧 turn 已结束时，即使两次 interrupt 都 reject 也不退役共享 host', async () => {
+    vi.useFakeTimers();
+    try {
+      const firstInterrupt = deferred<never>();
+      const secondInterrupt = deferred<never>();
+      const agent = new CodexAgent(createDeps());
+      const retireHostKey = vi
+        .spyOn(
+          agent as unknown as { retireHostKey: (...args: unknown[]) => Promise<void> },
+          'retireHostKey',
+        )
+        .mockResolvedValue(undefined);
+      let interruptCall = 0;
+      const host = installFakeHost(agent, (method) => {
+        if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+        if (method === Method.TurnInterrupt) {
+          interruptCall += 1;
+          return interruptCall === 1 ? firstInterrupt.promise : secondInterrupt.promise;
+        }
+        return undefined;
+      });
+      const handle = await agent.startSession({
+        sessionId: 'session-reconnect-completed-before-interrupt-rejects',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      let eventsEnded = false;
+      void (async () => {
+        for await (const event of handle.events()) void event;
+        eventsEnded = true;
+      })();
+      await handle.send({ type: 'user', content: 'go' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers) throw new Error('expected thread handlers');
+      handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-1' } } as never);
+      emitReconnect(handlers, 1);
+
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS + 1);
+      expect(handle.isTurnRunning?.()).toBe(true);
+
+      handlers.turnCompleted?.({
+        threadId: 'start-thread-id',
+        turn: { id: 'turn-1', status: 'failed' },
+      } as never);
+      firstInterrupt.reject(new Error('turn already completed'));
+      await vi.advanceTimersByTimeAsync(0);
+      secondInterrupt.reject(new Error('turn already completed'));
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(handle.isTurnRunning?.()).toBe(false);
+      expect(eventsEnded).toBe(false);
+      expect(retireHostKey).not.toHaveBeenCalled();
+      await handle.close();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('handle close 等待期间到达的 completed 也会阻止退役共享 host', async () => {
+    vi.useFakeTimers();
+    try {
+      const firstInterrupt = deferred<never>();
+      const secondInterrupt = deferred<never>();
+      const closeRelease = deferred<void>();
+      const agent = new CodexAgent(createDeps());
+      const retireHostKey = vi
+        .spyOn(
+          agent as unknown as { retireHostKey: (...args: unknown[]) => Promise<void> },
+          'retireHostKey',
+        )
+        .mockResolvedValue(undefined);
+      let interruptCall = 0;
+      const host = installFakeHost(agent, (method) => {
+        if (method === Method.TurnStart) return { turn: { id: 'turn-1' } };
+        if (method === Method.TurnInterrupt) {
+          interruptCall += 1;
+          return interruptCall === 1 ? firstInterrupt.promise : secondInterrupt.promise;
+        }
+        return undefined;
+      });
+      const handle = await agent.startSession({
+        sessionId: 'session-reconnect-completed-during-close',
+        model: 'gpt-5.4',
+        workingDir: '/repo',
+      });
+      const subscription = host.subscribeThread.mock.results[0]?.value;
+      const release = subscription?.release;
+      if (!release) throw new Error('expected reconnect-stall subscription');
+      const closeReleasePromise = closeRelease.promise;
+      release.mockImplementationOnce(() => closeReleasePromise);
+      let eventsEnded = false;
+      void (async () => {
+        for await (const event of handle.events()) void event;
+        eventsEnded = true;
+      })();
+      await handle.send({ type: 'user', content: 'go' });
+      const handlers = host.getThreadHandlers();
+      if (!handlers) throw new Error('expected thread handlers');
+      handlers.turnStarted?.({ threadId: 'start-thread-id', turn: { id: 'turn-1' } } as never);
+      emitReconnect(handlers, 1);
+
+      await vi.advanceTimersByTimeAsync(RECONNECT_STALL_MS + 1);
+      firstInterrupt.reject(new Error('turn already completed'));
+      await vi.advanceTimersByTimeAsync(0);
+      secondInterrupt.reject(new Error('turn already completed'));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(release).toHaveBeenCalledOnce();
+
+      handlers.turnCompleted?.({
+        threadId: 'start-thread-id',
+        turn: { id: 'turn-1', status: 'failed' },
+      } as never);
+      closeRelease.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(eventsEnded).toBe(true);
+      expect(retireHostKey).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('interrupt 不响应时关闭 handle 并退役坏 host，下一次发送可重建', async () => {
     vi.useFakeTimers();
     try {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -16975,7 +16975,7 @@ describe('CodexAgent reconnect-stall watchdog', () => {
     }
   });
 
-  it('handle close 等待期间到达的 completed 也会阻止退役共享 host', async () => {
+  it('handle close 的 subscription release 失败时，等待期间到达的 completed 仍会阻止退役共享 host', async () => {
     vi.useFakeTimers();
     try {
       const firstInterrupt = deferred<never>();
@@ -17029,7 +17029,7 @@ describe('CodexAgent reconnect-stall watchdog', () => {
         threadId: 'start-thread-id',
         turn: { id: 'turn-1', status: 'failed' },
       } as never);
-      closeRelease.resolve();
+      closeRelease.reject(new Error('thread/unsubscribe failed'));
       await vi.advanceTimersByTimeAsync(0);
 
       expect(eventsEnded).toBe(true);
@@ -17055,6 +17055,10 @@ describe('CodexAgent reconnect-stall watchdog', () => {
         model: 'gpt-5.4',
         workingDir: '/repo',
       });
+      const subscription = host.subscribeThread.mock.results[0]?.value;
+      const release = subscription?.release;
+      if (!release) throw new Error('expected reconnect-stall subscription');
+      release.mockRejectedValueOnce(new Error('thread/unsubscribe failed'));
       let eventsEnded = false;
       void (async () => {
         for await (const event of handle.events()) void event;
@@ -17070,7 +17074,10 @@ describe('CodexAgent reconnect-stall watchdog', () => {
 
       expect(eventsEnded).toBe(true);
       expect(retireHostKey).toHaveBeenCalledTimes(1);
-      expect(retireHostKey.mock.calls[0]?.[2]).toMatchObject({ failIfActive: false });
+      expect(retireHostKey.mock.calls[0]?.[2]).toMatchObject({
+        failIfActive: false,
+        logPrefix: 'codex upstream-idle watchdog',
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4337,6 +4337,10 @@ export class CodexAgent extends BaseAgent {
     let reconnectStallTimer: ReturnType<typeof setTimeout> | null = null;
     let reconnectStallTurnId: string | null = null;
     let reconnectStallTurnGeneration = 0;
+    /** 还需要清醒等待的重连额度；系统挂起的片段不扣除。 */
+    let reconnectStallRemainingMs = 0;
+    /** 当前重连计时分片的起始壁钟时刻，用于识别系统挂起。 */
+    let reconnectStallSliceStartedAt = 0;
     /** 还需要"清醒地"静默多久才判上游哑火;按分片递减(见 armUpstreamIdleSlice)。 */
     let upstreamIdleRemainingMs = 0;
     /** 当前分片的起始壁钟时刻;片尾据此识别系统挂起。 */
@@ -4356,6 +4360,8 @@ export class CodexAgent extends BaseAgent {
       }
       reconnectStallTurnId = null;
       reconnectStallTurnGeneration = 0;
+      reconnectStallRemainingMs = 0;
+      reconnectStallSliceStartedAt = 0;
     }
     function armUpstreamIdle(): void {
       clearUpstreamIdle();
@@ -4445,25 +4451,45 @@ export class CodexAgent extends BaseAgent {
       armUpstreamIdle();
     }
 
-    function armReconnectStall(turnId = currentTurnId): void {
-      if (closed || (!isTurnInFlight && !isTurnStartPending) || !turnId) return;
-      // 同一 turn 的后续 `2/5`、`3/5` 只更新 UI，不重置整个重连序列的 deadline。
-      if (reconnectStallTimer) return;
-      reconnectStallTurnId = turnId;
-      reconnectStallTurnGeneration = turnStartGeneration;
+    function isReconnectStallCurrent(): boolean {
+      const pendingTurnStart =
+        !isTurnInFlight &&
+        isTurnStartPending &&
+        currentTurnId === null &&
+        reconnectStallTurnId !== null;
+      return (
+        !closed &&
+        turnStartGeneration === reconnectStallTurnGeneration &&
+        ((isTurnInFlight && currentTurnId === reconnectStallTurnId) || pendingTurnStart)
+      );
+    }
+
+    function armReconnectStallSlice(): void {
+      if (!isReconnectStallCurrent() || reconnectStallRemainingMs <= 0) {
+        clearReconnectStall();
+        return;
+      }
+      const slice = Math.min(reconnectStallRemainingMs, CODEX_UPSTREAM_IDLE_SLICE_MS);
+      reconnectStallSliceStartedAt = Date.now();
       reconnectStallTimer = setTimeout(() => {
         reconnectStallTimer = null;
-        const pendingTurnStart =
-          !isTurnInFlight &&
-          isTurnStartPending &&
-          currentTurnId === null &&
-          reconnectStallTurnId !== null;
-        if (
-          closed ||
-          (!isTurnInFlight && !pendingTurnStart) ||
-          (isTurnInFlight && currentTurnId !== reconnectStallTurnId) ||
-          turnStartGeneration !== reconnectStallTurnGeneration
-        ) {
+        const elapsed = Date.now() - reconnectStallSliceStartedAt;
+        if (elapsed > slice + CODEX_UPSTREAM_IDLE_SUSPEND_GAP_MS) {
+          log.info('codex reconnect watchdog skipped a suspended slice', {
+            threadId,
+            sliceMs: slice,
+            elapsedMs: elapsed,
+          });
+          // 系统挂起的时间不计入总 deadline；只重开当前分片，不能重新装满 120s。
+          armReconnectStallSlice();
+          return;
+        }
+        reconnectStallRemainingMs -= Math.max(0, elapsed);
+        if (reconnectStallRemainingMs > 0) {
+          armReconnectStallSlice();
+          return;
+        }
+        if (!isReconnectStallCurrent()) {
           clearReconnectStall();
           return;
         }
@@ -4471,15 +4497,25 @@ export class CodexAgent extends BaseAgent {
           reason: 'codex_reconnect_stalled',
           timeoutMs: CODEX_RECONNECT_STALL_TIMEOUT_MS,
           ignorePendingTools: true,
-          allowPendingTurnStart: pendingTurnStart,
+          allowPendingTurnStart: !isTurnInFlight,
           logLabel: 'codex reconnect watchdog tripped — interrupting stalled turn',
           message:
             `Codex app-server has been reconnecting for ${Math.round(CODEX_RECONNECT_STALL_TIMEOUT_MS / 1000)}s ` +
             'without making progress; the turn was interrupted automatically. ' +
             'You can send the next message to continue.',
         });
-      }, CODEX_RECONNECT_STALL_TIMEOUT_MS);
+      }, slice);
       (reconnectStallTimer as unknown as { unref?: () => void }).unref?.();
+    }
+
+    function armReconnectStall(turnId = currentTurnId): void {
+      if (closed || (!isTurnInFlight && !isTurnStartPending) || !turnId) return;
+      // 同一 turn 的后续 `2/5`、`3/5` 只更新 UI，不重置整个重连序列的 deadline。
+      if (reconnectStallTimer || reconnectStallRemainingMs > 0) return;
+      reconnectStallTurnId = turnId;
+      reconnectStallTurnGeneration = turnStartGeneration;
+      reconnectStallRemainingMs = CODEX_RECONNECT_STALL_TIMEOUT_MS;
+      armReconnectStallSlice();
     }
 
     function isReconnectRecoveryEvent(event: AgentEvent): boolean {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3114,36 +3114,44 @@ export class CodexAgent extends BaseAgent {
       cleanupThreadId: string;
       reason: string;
       cleanup: () => Promise<void>;
+      retireHostOnFailure?: boolean;
     }): Promise<boolean> => {
       try {
         await params.cleanup();
         return true;
       } catch (error) {
-        log.warn('Codex thread cleanup failed; retiring captured app-server', {
+        log.warn('Codex thread cleanup failed', {
           threadId: params.cleanupThreadId,
           reason: params.reason,
           error: error instanceof Error ? error.message : String(error),
+          retireHostOnFailure: params.retireHostOnFailure ?? true,
         });
-        try {
-          await retireCapturedHostAfterThreadCleanupFailure(params.reason);
-        } catch (retireError) {
-          log.warn('Codex host retire after thread cleanup failure threw', {
-            threadId: params.cleanupThreadId,
-            reason: params.reason,
-            error: retireError instanceof Error ? retireError.message : String(retireError),
-          });
+        if (params.retireHostOnFailure !== false) {
+          try {
+            await retireCapturedHostAfterThreadCleanupFailure(params.reason);
+          } catch (retireError) {
+            log.warn('Codex host retire after thread cleanup failure threw', {
+              threadId: params.cleanupThreadId,
+              reason: params.reason,
+              error: retireError instanceof Error ? retireError.message : String(retireError),
+            });
+          }
         }
         terminateHandleAfterThreadCleanupFailure(params.reason);
         return false;
       }
     };
-    const releaseCurrentThreadSubscription = async (reason: string): Promise<boolean> => {
+    const releaseCurrentThreadSubscription = async (
+      reason: string,
+      opts: { retireHostOnFailure?: boolean } = {},
+    ): Promise<boolean> => {
       const currentSubscription = subscription;
       if (!currentSubscription) return true;
       const released = await runThreadCleanupOrRetire({
         cleanupThreadId: threadId,
         reason,
         cleanup: () => currentSubscription.release(),
+        retireHostOnFailure: opts.retireHostOnFailure ?? true,
       });
       if (subscription === currentSubscription) subscription = null;
       return released;
@@ -4655,7 +4663,10 @@ export class CodexAgent extends BaseAgent {
             suppressFailureEvent: true,
           });
           try {
-            await handle.close();
+            // thread/unsubscribe 失败不能在 interrupt 结果尚未确认时强退共享 host：
+            // 同 host 上可能还有健康 session。这里只关闭当前 handle，不让 cleanup
+            // 失败提前退役 host；最终 host 退役仍由下面的双 ACK 失败分支决定。
+            await closeSessionHandle({ retireHostOnCleanupFailure: false });
           } catch (error: unknown) {
             log.warn('codex reconnect watchdog pending turn close threw', {
               turnId: pendingTurnId,
@@ -7559,6 +7570,36 @@ export class CodexAgent extends BaseAgent {
       subscriptionInvalidatedByTransport = false;
     }
 
+    async function closeSessionHandle(
+      opts: { retireHostOnCleanupFailure?: boolean } = {},
+    ): Promise<void> {
+      if (closed) return;
+      closed = true;
+      clearReconnectStall();
+      resetUpstreamIdleForTurnEnd();
+      unregisterCodexMcpContext(threadId);
+      unregisterDescendantCodexMcpContexts();
+      // close 时 buffer 里可能还有等对账的挂起请求 (codex R17 P2):
+      // 统一按拒绝释放, 否则 handler 永远悬挂, dispatchServerRequest
+      // 永不返回, server 侧请求卡死。
+      abandonBufferedTurns('session closed');
+      abandonPendingCapabilitySteers();
+      // 把挂起的 approval 强制 deny + emit interaction_dismissed (UI 关 dialog),
+      // 否则 server 那边没回 response 会卡; UI 上的 PermissionPrompt 也会留尸
+      try { dismissAllPending('session_closed', 'deny'); } catch (e) { log.warn('dismissAllPending threw', { error: String(e) }); }
+      try { dismissAllPendingUserInput('session_closed'); } catch (e) { log.warn('dismissAllPendingUserInput threw', { error: String(e) }); }
+      try { clearAllPendingUserInputInteractions(); } catch (e) { log.warn('clear pending user input threw', { error: String(e) }); }
+      try { stopActiveRolloutPlanFallback(); } catch (e) { log.warn('stop rollout plan fallback threw', { error: String(e) }); }
+      // 挂起的过载重投计时器必须清掉：否则会话已关，计时器到点仍会对已释放的
+      // thread 发 turn/start（assertCurrentHost 会抛，但那是在无人接收的
+      // setTimeout 回调里，白留一次失败与一条误导日志）。
+      try { discardOverloadRetry('session_closed'); } catch (e) { log.warn('cancel overload retry threw', { error: String(e) }); }
+      await releaseCurrentThreadSubscription('session close subscription release', {
+        retireHostOnFailure: opts.retireHostOnCleanupFailure ?? true,
+      });
+      try { eventQueue.end(); } catch (e) { log.warn('eventQueue.end threw', { error: String(e) }); }
+    }
+
     // ── AgentSessionHandle ──────────────────────────────────────────────────
     const handle: AgentSessionHandle = {
       get id() { return sdkSessionId ?? '<pending>'; },
@@ -8479,29 +8520,7 @@ export class CodexAgent extends BaseAgent {
       },
 
       async close() {
-        if (closed) return;
-        closed = true;
-        clearReconnectStall();
-        resetUpstreamIdleForTurnEnd();
-        unregisterCodexMcpContext(threadId);
-        unregisterDescendantCodexMcpContexts();
-        // close 时 buffer 里可能还有等对账的挂起请求 (codex R17 P2):
-        // 统一按拒绝释放, 否则 handler 永远悬挂, dispatchServerRequest
-        // 永不返回, server 侧请求卡死。
-        abandonBufferedTurns('session closed');
-        abandonPendingCapabilitySteers();
-        // 把挂起的 approval 强制 deny + emit interaction_dismissed (UI 关 dialog),
-        // 否则 server 那边没回 response 会卡; UI 上的 PermissionPrompt 也会留尸
-        try { dismissAllPending('session_closed', 'deny'); } catch (e) { log.warn('dismissAllPending threw', { error: String(e) }); }
-        try { dismissAllPendingUserInput('session_closed'); } catch (e) { log.warn('dismissAllPendingUserInput threw', { error: String(e) }); }
-        try { clearAllPendingUserInputInteractions(); } catch (e) { log.warn('clear pending user input threw', { error: String(e) }); }
-        try { stopActiveRolloutPlanFallback(); } catch (e) { log.warn('stop rollout plan fallback threw', { error: String(e) }); }
-        // 挂起的过载重投计时器必须清掉：否则会话已关，计时器到点仍会对已释放的
-        // thread 发 turn/start（assertCurrentHost 会抛，但那是在无人接收的
-        // setTimeout 回调里，白留一次失败与一条误导日志）。
-        try { discardOverloadRetry('session_closed'); } catch (e) { log.warn('cancel overload retry threw', { error: String(e) }); }
-        await releaseCurrentThreadSubscription('session close subscription release');
-        try { eventQueue.end(); } catch (e) { log.warn('eventQueue.end threw', { error: String(e) }); }
+        await closeSessionHandle();
       },
 
       events(): AsyncIterable<AgentEvent> {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4414,7 +4414,10 @@ export class CodexAgent extends BaseAgent {
      * 干活的会话(review #944 第九轮 P1)。isCurrentHost 同时校验实例身份与
      * hostGeneration,与 skipIfStaleHost 同款判据。
      */
-    const retireUnresponsiveHost = async (reason: string): Promise<void> => {
+    const retireUnresponsiveHost = async (
+      reason: string,
+      opts: { failIfActive?: boolean } = {},
+    ): Promise<void> => {
       if (!isCurrentHost()) {
         log.warn('upstream-idle watchdog: host already replaced, skipping retire', {
           threadId,
@@ -4423,7 +4426,7 @@ export class CodexAgent extends BaseAgent {
         return;
       }
       await this.retireHostKey(currentHostKey, reason, {
-        failIfActive: false,
+        failIfActive: opts.failIfActive ?? false,
         logPrefix: 'codex upstream-idle watchdog',
         ...(capturedHostWasRegistered ? { expectedHost: host } : {}),
         expectedGeneration: hostGeneration,
@@ -4646,6 +4649,10 @@ export class CodexAgent extends BaseAgent {
           try {
             await retireUnresponsiveHost(
               `codex app-server unresponsive: reconnecting for ${Math.round(idleMs / 1000)}s before turn/start completed`,
+              // pending turn/start 只证明当前 admission 卡住。两次 ACK 等待期间，
+              // 同一个共享 host 可能已被新 Session 复用；在真正退役点重新检查
+              // active use，避免把新会话一起强杀。
+              { failIfActive: true },
             );
           } catch (error: unknown) {
             log.warn('codex reconnect watchdog pending host retire threw', {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4351,6 +4351,7 @@ export class CodexAgent extends BaseAgent {
     // auto-resume backoff can admit a new turn while the old server turn is
     // still running (PR #1410).
     let reconnectStallCleanupTurnId: string | null = null;
+    let reconnectStallDeferredTurnCompletion: TurnCompletedParams | null = null;
     /** 还需要清醒等待的重连额度；系统挂起的片段不扣除。 */
     let reconnectStallRemainingMs = 0;
     /** 当前重连计时分片的起始壁钟时刻，用于识别系统挂起。 */
@@ -4376,6 +4377,22 @@ export class CodexAgent extends BaseAgent {
       reconnectStallTurnGeneration = 0;
       reconnectStallRemainingMs = 0;
       reconnectStallSliceStartedAt = 0;
+    }
+    function clearReconnectStallCleanup(turnId?: string): void {
+      if (turnId && reconnectStallCleanupTurnId !== turnId) return;
+      reconnectStallCleanupTurnId = null;
+      reconnectStallDeferredTurnCompletion = null;
+    }
+    function settleReconnectStallCleanup(
+      turnId: string,
+      fallback?: TurnCompletedParams,
+    ): boolean {
+      if (reconnectStallCleanupTurnId !== turnId) return false;
+      const completion = reconnectStallDeferredTurnCompletion ?? fallback;
+      if (!completion) return false;
+      clearReconnectStallCleanup(turnId);
+      if (!closed) handleTurnCompleted(completion);
+      return true;
     }
     function armUpstreamIdle(): void {
       clearUpstreamIdle();
@@ -4612,6 +4629,7 @@ export class CodexAgent extends BaseAgent {
         // close/retire fallback) settles. Desktop may already have received
         // the terminal error and queued a continuation by then.
         reconnectStallCleanupTurnId = turnId;
+        reconnectStallDeferredTurnCompletion = null;
       }
       log.warn(opts?.logLabel ?? 'upstream-response-idle watchdog tripped — interrupting current turn', {
         idleMs,
@@ -4711,19 +4729,21 @@ export class CodexAgent extends BaseAgent {
           suppressFailureEvent: true,
         });
         if (interrupted) {
-          if (!closed && reconnectStallCleanupTurnId === turnId) {
-            reconnectStallCleanupTurnId = null;
-            handleTurnCompleted({
+          if (!settleReconnectStallCleanup(turnId, {
               threadId,
               turn: { id: turnId, status: 'failed' },
-            } as TurnCompletedParams);
-          } else {
-            reconnectStallCleanupTurnId = null;
-          }
+            } as TurnCompletedParams)) clearReconnectStallCleanup(turnId);
+          return;
+        }
+        if (settleReconnectStallCleanup(turnId)) {
+          log.info('reconnect-stall turn completed while interrupt was settling; keeping shared host', {
+            threadId,
+            turnId,
+          });
           return;
         }
         if (closed) {
-          reconnectStallCleanupTurnId = null;
+          clearReconnectStallCleanup(turnId);
           return;
         }
         // 重连路径在等待窗口内仍保持原 turn busy；generation / turn 身份复核
@@ -4742,7 +4762,7 @@ export class CodexAgent extends BaseAgent {
               turnStartGeneration,
             },
           );
-          reconnectStallCleanupTurnId = null;
+          clearReconnectStallCleanup(turnId);
           return;
         }
         // 走到这里有两种可能,处置相同:两次 ack 都超时(daemon 哑火),或 host 已被
@@ -4756,6 +4776,13 @@ export class CodexAgent extends BaseAgent {
           await handle.close();
         } catch (e) {
           log.warn('upstream-idle watchdog close threw', { error: String(e) });
+        }
+        if (settleReconnectStallCleanup(turnId)) {
+          log.info('reconnect-stall turn completed during handle close; keeping shared host', {
+            threadId,
+            turnId,
+          });
+          return;
         }
         // close() 只放掉本 thread 的订阅并结束自己的事件队列,**共享的 AppServerHost 仍
         // 留在 this.hosts 缓存里** —— 下一次 lazy create 会经 getHost 拿到同一个已确诊
@@ -4773,7 +4800,7 @@ export class CodexAgent extends BaseAgent {
         } catch (e) {
           log.warn('upstream-idle watchdog host retire threw', { error: String(e) });
         } finally {
-          reconnectStallCleanupTurnId = null;
+          clearReconnectStallCleanup(turnId);
         }
       })();
     }
@@ -6074,8 +6101,11 @@ export class CodexAgent extends BaseAgent {
       const turn = params.turn;
       if (reconnectStallCleanupTurnId === turn.id) {
         // The watchdog already published the terminal error and is still
-        // waiting for turn/interrupt. A late turn/completed must not clear
-        // the local busy guard before the ACK is known.
+        // waiting for turn/interrupt. Keep the local busy guard until the
+        // handshake settles, but retain this authoritative completion: it
+        // proves the old turn ended and the host event path is alive, so a
+        // double interrupt rejection must not retire healthy sibling sessions.
+        reconnectStallDeferredTurnCompletion ??= params;
         log.debug('deferring reconnect-stall turn completion until interrupt settles', {
           threadId,
           turnId: turn.id,

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -114,9 +114,11 @@ import {
 } from './translator.js';
 import {
   TurnRetryTracker,
+  RETRY_ESCALATION_MAX_ELAPSED_MS,
   buildBackendUnreachableMessage,
   type OutboundPathFact,
 } from './retry-escalation.js';
+import { parseReconnectAttemptMessage } from '../shared/network-error.js';
 import { extractNonSecretErrorSignals } from '@cindy/maker-shared/error-redaction';
 import { AppServerHost, type ThreadEventHandlers, type ThreadSubscription } from './app-server/host.js';
 import { AppServerRequestTimeoutError } from './app-server/client.js';
@@ -813,6 +815,20 @@ const CODEX_UPSTREAM_IDLE_SLICE_MS = 60_000;
 
 /** 分片实际耗时超出片长这么多 → 判为进程被系统挂起过,该片不计入额度。 */
 const CODEX_UPSTREAM_IDLE_SUSPEND_GAP_MS = 30_000;
+
+/**
+ * Codex app-server `Reconnecting... N/M` 的总等待上限。复用 retry-escalation
+ * 的 120s 语义，避免有限重连提示在最后一档之后静默卡住；这是整个重连序列的
+ * deadline，不会因为后续的 `2/5`、`3/5` 提示重新计时。
+ */
+const CODEX_RECONNECT_STALL_TIMEOUT_MS = RETRY_ESCALATION_MAX_ELAPSED_MS;
+
+/** 只含空白、格式字符或控制字符的 text delta 不算重连已经恢复。 */
+const CODEX_INVISIBLE_TEXT_PATTERN = /[\s\p{Cf}\p{Cc}]/gu;
+
+function hasVisibleCodexText(text: unknown): boolean {
+  return typeof text === 'string' && text.replace(CODEX_INVISIBLE_TEXT_PATTERN, '').length > 0;
+}
 
 function parseCodexIdleTimeoutMs(raw: string | undefined): number {
   if (raw === undefined || raw === '') return CODEX_UPSTREAM_IDLE_TIMEOUT_DEFAULT_MS;
@@ -4314,6 +4330,13 @@ export class CodexAgent extends BaseAgent {
     let upstreamIdleTimer: ReturnType<typeof setTimeout> | null = null;
     let upstreamIdleLastEventType: string | null = null;
     let upstreamIdleLastEventAt = 0;
+    /**
+     * 当前 `Reconnecting... N/M` 序列的总 deadline。这个看门狗与 upstream-idle
+     * 不同：它只在 Codex 明确上报有限重连时启动，后续 attempt 不延长同一轮总时限。
+     */
+    let reconnectStallTimer: ReturnType<typeof setTimeout> | null = null;
+    let reconnectStallTurnId: string | null = null;
+    let reconnectStallTurnGeneration = 0;
     /** 还需要"清醒地"静默多久才判上游哑火;按分片递减(见 armUpstreamIdleSlice)。 */
     let upstreamIdleRemainingMs = 0;
     /** 当前分片的起始壁钟时刻;片尾据此识别系统挂起。 */
@@ -4325,6 +4348,14 @@ export class CodexAgent extends BaseAgent {
       }
       upstreamIdleRemainingMs = 0;
       upstreamIdleSliceStartedAt = 0;
+    }
+    function clearReconnectStall(): void {
+      if (reconnectStallTimer) {
+        clearTimeout(reconnectStallTimer);
+        reconnectStallTimer = null;
+      }
+      reconnectStallTurnId = null;
+      reconnectStallTurnGeneration = 0;
     }
     function armUpstreamIdle(): void {
       clearUpstreamIdle();
@@ -4395,6 +4426,7 @@ export class CodexAgent extends BaseAgent {
     /** turn 结束 / 中断时收表并清工具项(终态可能先于 item completed 到达)。 */
     function resetUpstreamIdleForTurnEnd(): void {
       clearUpstreamIdle();
+      clearReconnectStall();
       pendingToolItemIds.clear();
     }
     /**
@@ -4412,19 +4444,111 @@ export class CodexAgent extends BaseAgent {
       // 停/起表边界变了,立即重算(最后一个工具收工 → 球回上游,开始计时)。
       armUpstreamIdle();
     }
+
+    function armReconnectStall(turnId = currentTurnId): void {
+      if (closed || (!isTurnInFlight && !isTurnStartPending) || !turnId) return;
+      // 同一 turn 的后续 `2/5`、`3/5` 只更新 UI，不重置整个重连序列的 deadline。
+      if (reconnectStallTimer) return;
+      reconnectStallTurnId = turnId;
+      reconnectStallTurnGeneration = turnStartGeneration;
+      reconnectStallTimer = setTimeout(() => {
+        reconnectStallTimer = null;
+        const pendingTurnStart =
+          !isTurnInFlight &&
+          isTurnStartPending &&
+          currentTurnId === null &&
+          reconnectStallTurnId !== null;
+        if (
+          closed ||
+          (!isTurnInFlight && !pendingTurnStart) ||
+          (isTurnInFlight && currentTurnId !== reconnectStallTurnId) ||
+          turnStartGeneration !== reconnectStallTurnGeneration
+        ) {
+          clearReconnectStall();
+          return;
+        }
+        onUpstreamIdleTimeout({
+          reason: 'codex_reconnect_stalled',
+          timeoutMs: CODEX_RECONNECT_STALL_TIMEOUT_MS,
+          ignorePendingTools: true,
+          allowPendingTurnStart: pendingTurnStart,
+          logLabel: 'codex reconnect watchdog tripped — interrupting stalled turn',
+          message:
+            `Codex app-server has been reconnecting for ${Math.round(CODEX_RECONNECT_STALL_TIMEOUT_MS / 1000)}s ` +
+            'without making progress; the turn was interrupted automatically. ' +
+            'You can send the next message to continue.',
+        });
+      }, CODEX_RECONNECT_STALL_TIMEOUT_MS);
+      (reconnectStallTimer as unknown as { unref?: () => void }).unref?.();
+    }
+
+    function isReconnectRecoveryEvent(event: AgentEvent): boolean {
+      if (event.type === 'text') {
+        const text = (event.data as { text?: unknown } | null | undefined)?.text;
+        return hasVisibleCodexText(text);
+      }
+      if (
+        event.type === 'thinking' ||
+        event.type === 'tool_use' ||
+        event.type === 'tool_result' ||
+        event.type === 'tool_result_full' ||
+        event.type === 'agent_task_update' ||
+        event.type === 'image' ||
+        event.type === 'done'
+      ) {
+        return true;
+      }
+      if (event.type === 'status') {
+        return (event.data as { isRunning?: unknown } | null | undefined)?.isRunning === false;
+      }
+      if (event.type !== 'error') return false;
+      const data = event.data as { isTerminal?: unknown; willRetry?: unknown } | null | undefined;
+      return data?.isTerminal === true || data?.willRetry === false ||
+        (data?.isTerminal === undefined && data?.willRetry === undefined);
+    }
+
+    function observeReconnectStallEvent(event: AgentEvent): void {
+      const data = event.data as { message?: unknown; isTerminal?: unknown; willRetry?: unknown } | null | undefined;
+      const message = typeof data?.message === 'string' ? data.message : null;
+      const isReconnectNotice =
+        event.type === 'error' &&
+        data?.isTerminal !== true &&
+        data?.willRetry !== false &&
+        message !== null &&
+        parseReconnectAttemptMessage(message) !== null;
+      if (isReconnectNotice) {
+        armReconnectStall();
+        return;
+      }
+      if (reconnectStallTimer && isReconnectRecoveryEvent(event)) {
+        clearReconnectStall();
+      }
+    }
     /**
      * 上游连续静默超阈值:daemon 对我们彻底哑火。推一条终态 error 收口(renderer 停
      * 转圈 / scheduler 把 run 记 failed / IM 转播 finalize),再 turn/interrupt 让
      * daemon 侧那个 turn 停掉(与用户手动 Stop 同路径,thread 保持可用)。
      */
-    function onUpstreamIdleTimeout(): void {
-      if (closed || !isTurnInFlight) return;
-      if (pendingToolItemIds.size > 0) return;
-      const idleMs = upstreamIdleTimeoutMs;
+    function onUpstreamIdleTimeout(opts?: {
+      reason?: string;
+      timeoutMs?: number;
+      message?: string;
+      logLabel?: string;
+      ignorePendingTools?: boolean;
+      allowPendingTurnStart?: boolean;
+    }): void {
+      if (closed) return;
+      const pendingTurnId =
+        opts?.allowPendingTurnStart && !isTurnInFlight && isTurnStartPending
+          ? reconnectStallTurnId
+          : null;
+      if (!isTurnInFlight && !pendingTurnId) return;
+      if (!opts?.ignorePendingTools && pendingToolItemIds.size > 0) return;
+      const idleMs = opts?.timeoutMs ?? upstreamIdleTimeoutMs;
       const msSinceLast =
         upstreamIdleLastEventAt > 0 ? Date.now() - upstreamIdleLastEventAt : null;
-      const turnId = currentTurnId;
-      log.warn('upstream-response-idle watchdog tripped — interrupting current turn', {
+      const turnId = currentTurnId ?? pendingTurnId;
+      log.warn(opts?.logLabel ?? 'upstream-response-idle watchdog tripped — interrupting current turn', {
         idleMs,
         threadId,
         turnId,
@@ -4439,11 +4563,11 @@ export class CodexAgent extends BaseAgent {
         data: {
           // reason 与 claude-code 侧共用同一稳定 key(renderer i18n 映射,规则 18);
           // message 仅作非 renderer 消费方(IM / orca / 日志)的英文兜底。
-          reason: 'upstream_response_idle_timeout',
-          message:
-            `The upstream response has been silent for ${Math.round(idleMs / 1000)}s; ` +
-            'the turn was interrupted automatically to avoid hanging forever. ' +
-            'You can send the next message to continue.',
+          reason: opts?.reason ?? 'upstream_response_idle_timeout',
+          message: opts?.message ??
+            (`The upstream response has been silent for ${Math.round(idleMs / 1000)}s; ` +
+              'the turn was interrupted automatically to avoid hanging forever. ' +
+              'You can send the next message to continue.'),
           isTerminal: true,
           idleMs,
           lastEventType: upstreamIdleLastEventType,
@@ -4451,6 +4575,51 @@ export class CodexAgent extends BaseAgent {
         },
         source: 'codex',
       });
+      if (pendingTurnId) {
+        // 重连提示可能早于 turnStarted 到达。此时 turn/start 仍在飞，不能只清掉
+        // 看门狗：迟到的 response / turnStarted 必须被隔离，否则用户已经看到终态后
+        // server 侧的 turn 仍可能被重新激活；同时关闭当前 handle，让下一次 send
+        // 通过 Maker 的 lazy create 重建 transport。
+        terminalErroredTurnIds.add(pendingTurnId);
+        markInFlightStartsTerminallySettled();
+        quarantineAllInFlightStarts();
+        resetUpstreamIdleForTurnEnd();
+        eventQueue.push({
+          type: 'status',
+          data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+          source: 'codex',
+        });
+        void (async () => {
+          // pending turn/start 只证明这一轮 admission 卡住，不等于共享 app-server
+          // 控制面已经死掉。沿用 active-turn watchdog 的双次有界 interrupt 判据：
+          // ACK 成功时只关闭本 handle；只有两次 ACK 都失败才退役共享 host，避免连带
+          // 杀掉同 host 上其它健康 session。
+          const interruptPromise = interruptTurnForPermissionTighten(pendingTurnId, {
+            suppressFailureEvent: true,
+          });
+          try {
+            await handle.close();
+          } catch (error: unknown) {
+            log.warn('codex reconnect watchdog pending turn close threw', {
+              turnId: pendingTurnId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+          const interrupted = await interruptPromise;
+          if (interrupted) return;
+          try {
+            await retireUnresponsiveHost(
+              `codex app-server unresponsive: reconnecting for ${Math.round(idleMs / 1000)}s before turn/start completed`,
+            );
+          } catch (error: unknown) {
+            log.warn('codex reconnect watchdog pending host retire threw', {
+              turnId: pendingTurnId,
+              error: error instanceof Error ? error.message : String(error),
+            });
+          }
+        })();
+        return;
+      }
       resetUpstreamIdleForTurnEnd();
       if (!turnId) return;
       // **先把本地 turn 状态收干净,再去 interrupt**(review #944 第二轮 P1)。
@@ -4552,6 +4721,7 @@ export class CodexAgent extends BaseAgent {
       upstreamIdleLastEventType = ev.type;
       upstreamIdleLastEventAt = Date.now();
       armUpstreamIdle();
+      observeReconnectStallEvent(ev);
       return rawEventQueuePush(ev);
     };
 
@@ -5840,6 +6010,7 @@ export class CodexAgent extends BaseAgent {
 
     function handleTurnCompleted(params: TurnCompletedParams): void {
       const turn = params.turn;
+      if (reconnectStallTurnId === turn.id) clearReconnectStall();
       let recoveryState = overloadRetry;
       let pendingRecovery =
         recoveryState?.pendingHttpRecovery?.deadTurnId === turn.id
@@ -6833,6 +7004,13 @@ export class CodexAgent extends BaseAgent {
         currentTurnId = params.turn.id;
         isTurnInFlight = true;
         turnStartGeneration += 1; // 见声明处:延迟善后靠它判断"期间起过新 turn"
+        if (!wasSameTurn) {
+          if (reconnectStallTimer && reconnectStallTurnId === params.turn.id) {
+            reconnectStallTurnGeneration = turnStartGeneration;
+          } else {
+            clearReconnectStall();
+          }
+        }
         // turn 开始 → 球在上游,起 idle 表(后续任何事件都会重置它)。
         armUpstreamIdle();
         // turn/start 在飞期间权限被收紧 (turnStarted 通知可能先于 turn/start resp
@@ -7142,6 +7320,16 @@ export class CodexAgent extends BaseAgent {
             && (!idLessCapacityError || idLessCapacityTargetsActiveTurn))
           || targetsPendingTurn
           || targetsIdLessPendingStart;
+        if (
+          !isTerminalError &&
+          targetsCurrentTurn &&
+          parseReconnectAttemptMessage(params.error?.message ?? '') !== null
+        ) {
+          // error notification 可能抢在 turnStarted / turn/start response 前到达；这里
+          // 先按 params.turnId 绑定 deadline，turnStarted 随后会把 generation 重新绑定
+          // 到已接受的 turn，不让这类乱序事件漏掉静默重连卡死。
+          armReconnectStall(params.turnId || currentTurnId);
+        }
         if (isTerminalError && isTransportError && !targetsCurrentTurn) {
           translateErrorNotification(effectiveParams, eventQueue, { rt: translatorRt, log });
           return;
@@ -7334,6 +7522,8 @@ export class CodexAgent extends BaseAgent {
         if (rejectClosedOrCancelledSend(sendOpts, 'before start')) {
           return;
         }
+        // 用户开启新 turn = 旧重连序列作废；deadline 不得跨 turn 误伤新请求。
+        clearReconnectStall();
         if (sendOpts) handle.validateSendOptions?.(sendOpts);
         activeTurnPermissionPolicy = sendOpts?.turnPermissionPolicy ?? null;
         const capabilitySelectionText =
@@ -7611,6 +7801,11 @@ export class CodexAgent extends BaseAgent {
               currentTurnId = resp.turn.id;
               isTurnInFlight = true;
               turnStartGeneration += 1; // 见声明处:延迟善后靠它判断"期间起过新 turn"
+              if (reconnectStallTimer && reconnectStallTurnId === resp.turn.id) {
+                reconnectStallTurnGeneration = turnStartGeneration;
+              } else {
+                clearReconnectStall();
+              }
               currentTurnPlanModeActive = turnStartsInPlanMode;
               pendingTurnStartPlanMode = null;
               startRolloutPlanFallback(resp.turn.id);
@@ -8164,6 +8359,7 @@ export class CodexAgent extends BaseAgent {
       },
 
       async abort() {
+        clearReconnectStall();
         // 用户点 Stop = 明确不想继续这一轮，挂起的过载重投必须一起撤掉。
         // 放在 currentTurnId 判空之前：重投等待期间 turn 已死、currentTurnId 为
         // null，此时正是最需要响应 Stop 的时刻（否则计时器到点又发一个新 turn）。
@@ -8224,6 +8420,7 @@ export class CodexAgent extends BaseAgent {
       async close() {
         if (closed) return;
         closed = true;
+        clearReconnectStall();
         resetUpstreamIdleForTurnEnd();
         unregisterCodexMcpContext(threadId);
         unregisterDescendantCodexMcpContexts();

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4337,6 +4337,12 @@ export class CodexAgent extends BaseAgent {
     let reconnectStallTimer: ReturnType<typeof setTimeout> | null = null;
     let reconnectStallTurnId: string | null = null;
     let reconnectStallTurnGeneration = 0;
+    // `codex_reconnect_stalled` is surfaced before the bounded interrupt
+    // handshake so Desktop can show the reconnect state immediately. Keep the
+    // provider turn busy until that handshake settles; otherwise the Desktop
+    // auto-resume backoff can admit a new turn while the old server turn is
+    // still running (PR #1410).
+    let reconnectStallCleanupTurnId: string | null = null;
     /** 还需要清醒等待的重连额度；系统挂起的片段不扣除。 */
     let reconnectStallRemainingMs = 0;
     /** 当前重连计时分片的起始壁钟时刻，用于识别系统挂起。 */
@@ -4512,7 +4518,12 @@ export class CodexAgent extends BaseAgent {
     }
 
     function armReconnectStall(turnId = currentTurnId): void {
-      if (closed || (!isTurnInFlight && !isTurnStartPending) || !turnId) return;
+      if (
+        closed ||
+        reconnectStallCleanupTurnId !== null ||
+        (!isTurnInFlight && !isTurnStartPending) ||
+        !turnId
+      ) return;
       // 同一 turn 的后续 `2/5`、`3/5` 只更新 UI，不重置整个重连序列的 deadline。
       if (reconnectStallTimer || reconnectStallRemainingMs > 0) return;
       reconnectStallTurnId = turnId;
@@ -4587,6 +4598,13 @@ export class CodexAgent extends BaseAgent {
       const msSinceLast =
         upstreamIdleLastEventAt > 0 ? Date.now() - upstreamIdleLastEventAt : null;
       const turnId = currentTurnId ?? pendingTurnId;
+      const deferTurnCleanupUntilInterrupt = opts?.reason === 'codex_reconnect_stalled';
+      if (deferTurnCleanupUntilInterrupt && !pendingTurnId && turnId) {
+        // Keep Session.isTurnRunning() true until the interrupt ACK (or the
+        // close/retire fallback) settles. Desktop may already have received
+        // the terminal error and queued a continuation by then.
+        reconnectStallCleanupTurnId = turnId;
+      }
       log.warn(opts?.logLabel ?? 'upstream-response-idle watchdog tripped — interrupting current turn', {
         idleMs,
         threadId,
@@ -4665,57 +4683,44 @@ export class CodexAgent extends BaseAgent {
       }
       resetUpstreamIdleForTurnEnd();
       if (!turnId) return;
-      // **先把本地 turn 状态收干净,再去 interrupt**(review #944 第二轮 P1)。
-      // interruptTurnForPermissionTighten 在 app-server 彻底哑火时会两次 ack 超时
-      // 后放弃,而它按设计不动 isTurnInFlight / currentTurnId —— 那对权限收紧场景是
-      // 对的(turn 还在正常跑),但对这里是致命的:我们刚推了终态 error 让上层收口,
-      // 若本地仍认为 turn 在跑,handle.isTurnRunning() 恒 true,之后每一条 send 都被
-      // in-flight guard 拒掉,会话彻底不可用 —— watchdog 报告"已恢复"实际没有。
-      //
-      // 合成一次本地 turn 收口:上面已立墓碑,故走 suppressTerminalUi 分支,只清
-      // isTurnInFlight / currentTurnId / plan 态并做 usage 收尾,不重复推终态 UI。
-      // 同步完成,会话立刻恢复可发。
-      handleTurnCompleted({
-        threadId,
-        turn: { id: turnId, status: 'failed' },
-      } as TurnCompletedParams);
-      // 再让 daemon 侧那个 turn 也停下。**必须看结果**:上面的本地收口把
-      // isTurnInFlight 清成 false,于是 handle.isTurnRunning() 变 false —— Session 层
-      // 的 recoverIfTurnStillRunning 正是以它为判据,现在会认为"abort 生效了,会话
-      // 仍可用"而放过这个 host。若中断其实没成功,这个已经哑火 30 分钟的 app-server
-      // 就被留下来给下一条 send 复用:要么再次超时,要么撞上服务端那个还在跑的 turn
-      // (review #944 第五轮 P1)。
-      //
-      // 所以中断确认失败 = daemon 确诊不可用 → 自己 close():eventQueue.end() 让
-      // Session 的事件循环自然收尾 → setStatus('closed') → Maker 摘掉 activeSessions
-      // → 下一条 send 走 lazy create 重建 handle 并按 sdkSessionId resume。这条路径
-      // 与 Session.recoverIfTurnStillRunning 用的是同一套恢复机制(见 session.ts
-      // "handle.events() 自然结束"注释),不需要各 agent 另造一套。
-      // 中断成功时什么都不做:daemon 既然 ack 了就还活着,会话继续可用。
-      // 在进入 interrupt 等待窗口**之前**取一次快照:窗口里起过的新 turn 即使已经正常
-      // 结束(瞬时状态被复位),也要靠它认出来(见 turnStartGeneration 声明处)。
+      // 普通 upstream-idle watchdog 仍立即收本地 turn；只有明确的重连停滞
+      // 路径延后这一步，直到 interrupt ACK 成功。
+      if (!deferTurnCleanupUntilInterrupt) {
+        handleTurnCompleted({
+          threadId,
+          turn: { id: turnId, status: 'failed' },
+        } as TurnCompletedParams);
+      }
+      // 再让 daemon 侧那个 turn 也停下。ACK 成功时才清本地 busy；两次 ACK
+      // 都失败则关闭当前 handle 并退役共享 host，期间排队的自动续跑不会
+      // 进入旧 transport。
       const turnGenBeforeInterrupt = turnStartGeneration;
       void (async () => {
         const interrupted = await interruptTurnForPermissionTighten(turnId, {
           suppressFailureEvent: true,
         });
-        if (interrupted || closed) return;
-        // **两次 ack 要等 20s,期间用户完全可能已经起了新 turn** —— 上面那次合成收口把
-        // isTurnInFlight 清成了 false,所以新的 send 不会被 in-flight guard 拒掉。此时
-        // 无条件 close 会掐死一条完全健康的新 turn,紧随其后的 host 退役还会连带终止同
-        // host 上的其它会话。isCurrentHost 只认得出"host 被换掉",认不出"同一 handle 上
-        // 起了新 turn"(review #944 第十七轮 P1;与第七轮 Session 的 turnGeneration、
-        // 第九轮的 host 身份闸是同一类错误:善后动作没绑定到发起它的那个实体)。
-        //
-        // 判据有两半,缺一不可:
-        // ① isTurnInFlight / currentTurnId —— 我们自己那次合成收口已把它们清空,所以
-        //    非空就一定是新活儿(新 turn 此刻仍在跑)。
-        // ② turnStartGeneration 与窗口前的快照不一致 —— 新 turn 在这 20s 里起来又**正常
-        //    结束**时,①的两个瞬时量会被 handleTurnCompleted 双双复位,只看①会误判成
-        //    "没人用了",照样关掉一个刚刚证明自己健康的 host,并连带退役同 host 上的其它
-        //    会话(review #944 第十八轮 P1)。单调计数器答得了"期间有没有发生过新活儿"。
-        // 两半都不成立才继续善后。留着这个 host 的风险由新 turn 自己的看门狗兜。
-        if (isTurnInFlight || currentTurnId !== null || turnStartGeneration !== turnGenBeforeInterrupt) {
+        if (interrupted) {
+          if (!closed && reconnectStallCleanupTurnId === turnId) {
+            reconnectStallCleanupTurnId = null;
+            handleTurnCompleted({
+              threadId,
+              turn: { id: turnId, status: 'failed' },
+            } as TurnCompletedParams);
+          } else {
+            reconnectStallCleanupTurnId = null;
+          }
+          return;
+        }
+        if (closed) {
+          reconnectStallCleanupTurnId = null;
+          return;
+        }
+        // 重连路径在等待窗口内仍保持原 turn busy；generation / turn 身份复核
+        // 仍保留，防止其它内部路径真的换了 turn 后误关健康 handle。
+        const reconnectCleanupTurnChanged = deferTurnCleanupUntilInterrupt
+          ? !isTurnInFlight || currentTurnId !== turnId || turnStartGeneration !== turnGenBeforeInterrupt
+          : isTurnInFlight || currentTurnId !== null || turnStartGeneration !== turnGenBeforeInterrupt;
+        if (reconnectCleanupTurnChanged) {
           log.warn(
             'upstream-idle watchdog: this handle served a newer turn during the interrupt window — skipping close/retire',
             {
@@ -4726,6 +4731,7 @@ export class CodexAgent extends BaseAgent {
               turnStartGeneration,
             },
           );
+          reconnectStallCleanupTurnId = null;
           return;
         }
         // 走到这里有两种可能,处置相同:两次 ack 都超时(daemon 哑火),或 host 已被
@@ -4755,6 +4761,8 @@ export class CodexAgent extends BaseAgent {
           );
         } catch (e) {
           log.warn('upstream-idle watchdog host retire threw', { error: String(e) });
+        } finally {
+          reconnectStallCleanupTurnId = null;
         }
       })();
     }
@@ -6053,6 +6061,16 @@ export class CodexAgent extends BaseAgent {
 
     function handleTurnCompleted(params: TurnCompletedParams): void {
       const turn = params.turn;
+      if (reconnectStallCleanupTurnId === turn.id) {
+        // The watchdog already published the terminal error and is still
+        // waiting for turn/interrupt. A late turn/completed must not clear
+        // the local busy guard before the ACK is known.
+        log.debug('deferring reconnect-stall turn completion until interrupt settles', {
+          threadId,
+          turnId: turn.id,
+        });
+        return;
+      }
       if (reconnectStallTurnId === turn.id) clearReconnectStall();
       let recoveryState = overloadRetry;
       let pendingRecovery =

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -4773,7 +4773,10 @@ export class CodexAgent extends BaseAgent {
           { threadId, turnId },
         );
         try {
-          await handle.close();
+          // thread/unsubscribe 失败本身不能先强退共享 host：同 turn 的权威
+          // completion 仍可能在 close 等待期间到达。先只终止当前 handle，等下方
+          // completion 复核后再决定是否显式退役 host。
+          await closeSessionHandle({ retireHostOnCleanupFailure: false });
         } catch (e) {
           log.warn('upstream-idle watchdog close threw', { error: String(e) });
         }
@@ -4784,9 +4787,10 @@ export class CodexAgent extends BaseAgent {
           });
           return;
         }
-        // close() 只放掉本 thread 的订阅并结束自己的事件队列,**共享的 AppServerHost 仍
-        // 留在 this.hosts 缓存里** —— 下一次 lazy create 会经 getHost 拿到同一个已确诊
-        // 无响应的 app-server,立刻再卡一遍,等于没恢复(review #944 第八轮 P1)。
+        // closeSessionHandle(...false) 只放掉本 thread 的订阅并结束自己的事件队列,
+        // **共享的 AppServerHost 仍留在 this.hosts 缓存里** —— 下一次 lazy create
+        // 会经 getHost 拿到同一个已确诊无响应的 app-server,立刻再卡一遍,等于没恢复
+        // (review #944 第八轮 P1)。
         // turn/interrupt 是控制面 RPC,两次 ack 都超时说明整个 host 而不只是这个 thread
         // 出了问题,所以要连 host 一起退役。
         //

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -1977,6 +1977,95 @@ describe('Session turn send guard', () => {
     expect(terminalReasons).toEqual(['original_terminal']);
   });
 
+  it('does not attribute a queued prior-turn error to a newer non-Codex dispatch', async () => {
+    let releasePriorError!: () => void;
+    const priorErrorReady = new Promise<void>((resolve) => {
+      releasePriorError = resolve;
+    });
+    let releaseCrash!: () => void;
+    const crashReady = new Promise<void>((resolve) => {
+      releaseCrash = resolve;
+    });
+    let sendEntered!: () => void;
+    const sendReady = new Promise<void>((resolve) => {
+      sendEntered = resolve;
+    });
+    let running = false;
+    const handle = createHandle({ id: 'thread-queued-prior-error', agentKind: 'claude-code' });
+    handle.isTurnRunning = () => running;
+    handle.send = vi.fn(async (message, opts) => {
+      if (message.content === 'first') {
+        running = false;
+        return;
+      }
+      sendEntered();
+      await new Promise<void>((resolve) => {
+        if (opts?.signal?.aborted) {
+          resolve();
+          return;
+        }
+        opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+    handle.events = () => ({
+      [Symbol.asyncIterator]() {
+        let first = true;
+        return {
+          async next(): Promise<IteratorResult<AgentEvent>> {
+            if (first) {
+              first = false;
+              await priorErrorReady;
+              return {
+                done: false,
+                value: {
+                  type: 'error',
+                  data: {
+                    message: 'queued prior-turn terminal error',
+                    reason: 'prior_terminal',
+                    isTerminal: true,
+                  },
+                  source: 'claude-code',
+                },
+              };
+            }
+            await crashReady;
+            throw new Error('events crashed during newer dispatch');
+          },
+        };
+      },
+    });
+    const session = new Session({
+      id: 'session-queued-prior-error',
+      agentKind: 'claude-code',
+      workDir: '/repo',
+      handle,
+      capabilities: createAgent(async () => handle, 'claude-code').capabilities,
+      logger: createLogger(),
+    });
+    const terminalReasons: Array<string | undefined> = [];
+    session.onEvent((event) => {
+      if (event.type === 'error') {
+        terminalReasons.push((event.data as { reason?: string }).reason);
+      }
+    });
+    const closed = new Promise<void>((resolve) => {
+      session.onStatusChange((status) => {
+        if (status === 'closed') resolve();
+      });
+    });
+
+    await session.send('first');
+    const secondSend = session.send('second');
+    await sendReady;
+    releasePriorError();
+    await Promise.resolve();
+    releaseCrash();
+    await closed;
+
+    await expect(secondSend).resolves.toEqual({ accepted: false, reason: 'cancelled-before-dispatch' });
+    expect(terminalReasons).toEqual(['prior_terminal', 'session_event_loop_crashed']);
+  });
+
   it('reports a crash after a queued prior-turn terminal event when a newer turn is running', async () => {
     let releasePriorDone!: () => void;
     const priorDoneReady = new Promise<void>((resolve) => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -499,6 +499,49 @@ describe('Maker session close events', () => {
     expect(rebuilt.sdkSessionId).toBe('thread-rebuilt');
     expect(startSession).toHaveBeenCalledTimes(2);
   });
+
+  it('retries a failed crash cleanup before recreating the session', async () => {
+    const crashingHandle = createHandle({ id: 'thread-crashed-close-retry' });
+    crashingHandle.events = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<AgentEvent>> {
+            throw new Error('iterator crashed');
+          },
+        };
+      },
+    });
+    let closeAttempts = 0;
+    crashingHandle.close = vi.fn(async () => {
+      closeAttempts += 1;
+      if (closeAttempts === 1) throw new Error('transport close failed');
+    });
+    const healthyHandle = createHandle({ id: 'thread-rebuilt-after-close-retry' });
+    const startSession = vi.fn()
+      .mockResolvedValueOnce(crashingHandle)
+      .mockResolvedValueOnce(healthyHandle);
+    const maker = new Maker({
+      agents: { codex: createAgent(startSession) },
+      storage: createStorage(),
+      logger: createLogger(),
+    });
+    const options: CreateSessionOptions = {
+      id: 'session-crash-close-retry',
+      agentKind: 'codex',
+      workingDir: '/repo',
+      model: 'gpt-5.4',
+    };
+
+    const crashed = await maker.createSession(options);
+    await vi.waitFor(() => expect(crashed.getStatus()).toBe('error'));
+    expect(maker.getSession('session-crash-close-retry')).toBe(crashed);
+
+    const rebuilt = await maker.createSession(options);
+    expect(rebuilt.sdkSessionId).toBe('thread-rebuilt-after-close-retry');
+    expect(maker.getSession('session-crash-close-retry')).toBe(rebuilt);
+    expect(closeAttempts).toBe(2);
+    expect(startSession).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('Maker before-start lifecycle hook', () => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -1585,6 +1585,67 @@ describe('Session turn send guard', () => {
     expect(handle.close).toHaveBeenCalledTimes(1);
   });
 
+  it('emits a terminal error before closing when the event iterator ends during an active turn', async () => {
+    let releaseEnd!: () => void;
+    const endReady = new Promise<void>((resolve) => {
+      releaseEnd = resolve;
+    });
+    let running = false;
+    const handle = createHandle({ id: 'thread-natural-end-active-turn' });
+    handle.send = vi.fn(async () => {
+      running = true;
+    });
+    handle.isTurnRunning = () => running;
+    handle.events = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<never>> {
+            await endReady;
+            return { done: true, value: undefined as never };
+          },
+        };
+      },
+    });
+    const session = new Session({
+      id: 'session-natural-end-active-turn',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: createAgent(async () => handle).capabilities,
+      logger: createLogger(),
+    });
+    const order: string[] = [];
+    const terminalErrors: AgentEvent[] = [];
+    session.onEvent((event) => {
+      if (event.type === 'error') {
+        terminalErrors.push(event);
+        order.push('error');
+      }
+    });
+    const closed = new Promise<void>((resolve) => {
+      session.onStatusChange((status) => {
+        if (status === 'closed') {
+          order.push('closed');
+          resolve();
+        }
+      });
+    });
+
+    await session.send('first');
+    releaseEnd();
+    await closed;
+
+    expect(terminalErrors).toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        reason: 'session_event_loop_crashed',
+        isTerminal: true,
+      }),
+    }));
+    expect(order).toEqual(['error', 'closed']);
+    expect(session.getStatus()).toBe('closed');
+  });
+
   it('clears the turn stall watchdog when the event iterator ends naturally', async () => {
     vi.useFakeTimers();
     try {
@@ -1600,12 +1661,13 @@ describe('Session turn send guard', () => {
       handle.isTurnRunning = () => running;
       handle.events = () => ({
         [Symbol.asyncIterator]() {
-          let first = true;
+          let ended = false;
           return {
-            async next(): Promise<IteratorResult<never>> {
-              if (first) {
-                first = false;
+            async next(): Promise<IteratorResult<AgentEvent>> {
+              if (!ended) {
+                ended = true;
                 await endReady;
+                return { done: false, value: { type: 'done', data: {}, source: 'codex' } };
               }
               return { done: true, value: undefined as never };
             },
@@ -1627,14 +1689,18 @@ describe('Session turn send guard', () => {
         });
       });
 
-      session.onEvent(() => undefined);
       await session.send('first');
+      const terminalErrors: AgentEvent[] = [];
+      session.onEvent((event) => {
+        if (event.type === 'error') terminalErrors.push(event);
+      });
       expect(vi.getTimerCount()).toBeGreaterThan(0);
 
       running = false;
       releaseEnd();
       await closed;
       expect(vi.getTimerCount()).toBe(0);
+      expect(terminalErrors).toEqual([]);
     } finally {
       vi.useRealTimers();
     }
@@ -1683,15 +1749,73 @@ describe('Session turn send guard', () => {
         if (status === 'closed') resolve();
       });
     });
+    const terminalErrors: AgentEvent[] = [];
 
-    session.onEvent(() => undefined);
+    session.onEvent((event) => {
+      if (event.type === 'error') terminalErrors.push(event);
+    });
     const sendPromise = session.send('first');
     await sendEntered;
     releaseEnd();
     await closed;
 
     await expect(sendPromise).resolves.toEqual({ accepted: false, reason: 'cancelled-before-dispatch' });
+    expect(terminalErrors).toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        reason: 'session_event_loop_crashed',
+        isTerminal: true,
+      }),
+    }));
     expect(session.getStatus()).toBe('closed');
+  });
+
+  it('lets an explicit close own the closed status when the event iterator ends first', async () => {
+    let releaseEnd!: () => void;
+    const endReady = new Promise<void>((resolve) => {
+      releaseEnd = resolve;
+    });
+    let releaseClose!: () => void;
+    const closeReady = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    const handle = createHandle({ id: 'thread-natural-end-during-close' });
+    handle.close = vi.fn(async () => closeReady);
+    handle.events = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<never>> {
+            await endReady;
+            return { done: true, value: undefined as never };
+          },
+        };
+      },
+    });
+    const session = new Session({
+      id: 'session-natural-end-during-close',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: createAgent(async () => handle).capabilities,
+      logger: createLogger(),
+    });
+    const terminalErrors: AgentEvent[] = [];
+    session.onEvent((event) => {
+      if (event.type === 'error') terminalErrors.push(event);
+    });
+
+    const closePromise = session.close();
+    releaseEnd();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(session.getStatus()).toBe('active');
+    expect(terminalErrors).toEqual([]);
+
+    releaseClose();
+    await closePromise;
+    expect(session.getStatus()).toBe('closed');
+    expect(handle.close).toHaveBeenCalledTimes(1);
   });
 
   it('does not revive a closed session when abort is called after the event iterator crashes', async () => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -1497,6 +1497,51 @@ describe('Session turn send guard', () => {
     expect(handle.close).toHaveBeenCalledTimes(1);
   });
 
+  it('does not publish closed when an iterator crash cannot close the handle', async () => {
+    const handle = createHandle({ id: 'thread-crash-close-failed' });
+    handle.close = vi.fn(async () => {
+      throw new Error('transport close failed');
+    });
+    handle.events = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<never>> {
+            throw new Error('events crashed');
+          },
+        };
+      },
+    });
+    const session = new Session({
+      id: 'session-crash-close-failed',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: createAgent(async () => handle).capabilities,
+      logger: createLogger(),
+    });
+    const terminalErrors: AgentEvent[] = [];
+    session.onEvent((event) => {
+      if (event.type === 'error') terminalErrors.push(event);
+    });
+    const statusChanged = new Promise<void>((resolve) => {
+      session.onStatusChange((status) => {
+        if (status === 'error') resolve();
+      });
+    });
+
+    await statusChanged;
+
+    expect(terminalErrors).toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        reason: 'session_event_loop_crashed',
+        isTerminal: true,
+      }),
+    }));
+    expect(session.getStatus()).toBe('error');
+    expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
   it('clears the turn stall watchdog when the event iterator ends naturally', async () => {
     vi.useFakeTimers();
     try {
@@ -1550,6 +1595,60 @@ describe('Session turn send guard', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('cancels an in-flight send when the event iterator ends naturally', async () => {
+    let releaseEnd!: () => void;
+    const endReady = new Promise<void>((resolve) => {
+      releaseEnd = resolve;
+    });
+    let sendEntered!: () => void;
+    const sendReady = new Promise<void>((resolve) => {
+      sendEntered = resolve;
+    });
+    const handle = createHandle({ id: 'thread-natural-end-pending-send' });
+    handle.send = vi.fn(async (_message, opts) => {
+      sendEntered();
+      await new Promise<void>((resolve) => {
+        if (opts?.signal?.aborted) {
+          resolve();
+          return;
+        }
+        opts?.signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+    });
+    handle.events = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<never>> {
+            await endReady;
+            return { done: true, value: undefined as never };
+          },
+        };
+      },
+    });
+    const session = new Session({
+      id: 'session-natural-end-pending-send',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: createAgent(async () => handle).capabilities,
+      logger: createLogger(),
+    });
+    const closed = new Promise<void>((resolve) => {
+      session.onStatusChange((status) => {
+        if (status === 'closed') resolve();
+      });
+    });
+
+    session.onEvent(() => undefined);
+    const sendPromise = session.send('first');
+    await sendEntered;
+    releaseEnd();
+    await closed;
+
+    await expect(sendPromise).resolves.toEqual({ accepted: false, reason: 'cancelled-before-dispatch' });
+    expect(session.getStatus()).toBe('closed');
   });
 
   it('does not revive a closed session when abort is called after the event iterator crashes', async () => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -451,6 +451,54 @@ describe('Maker session close events', () => {
       reason: 'agent-switch',
     });
   });
+
+  it('removes a session whose event iterator crashes and recreates it on the next request', async () => {
+    const crashingHandle = createHandle({ id: 'thread-crashed' });
+    crashingHandle.events = () => ({
+      [Symbol.asyncIterator]() {
+        return {
+          async next(): Promise<IteratorResult<AgentEvent>> {
+            throw new Error('iterator crashed');
+          },
+        };
+      },
+    });
+    crashingHandle.close = vi.fn(async () => undefined);
+    const healthyHandle = createHandle({ id: 'thread-rebuilt' });
+    const startSession = vi.fn()
+      .mockResolvedValueOnce(crashingHandle)
+      .mockResolvedValueOnce(healthyHandle);
+    const maker = new Maker({
+      agents: { codex: createAgent(startSession) },
+      storage: createStorage(),
+      logger: createLogger(),
+    });
+    let resolveClosed!: () => void;
+    const closed = new Promise<void>((resolve) => {
+      resolveClosed = resolve;
+    });
+    maker.on((event) => {
+      if (event.type === 'session:closed' && event.sessionId === 'session-crash') {
+        expect(event.reason).toBe('unexpected');
+        resolveClosed();
+      }
+    });
+    const options: CreateSessionOptions = {
+      id: 'session-crash',
+      agentKind: 'codex',
+      workingDir: '/repo',
+      model: 'gpt-5.4',
+    };
+
+    await maker.createSession(options);
+    await closed;
+    expect(maker.getSession('session-crash')).toBeUndefined();
+    expect(maker.listActiveSessions()).toEqual([]);
+
+    const rebuilt = await maker.createSession(options);
+    expect(rebuilt.sdkSessionId).toBe('thread-rebuilt');
+    expect(startSession).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('Maker before-start lifecycle hook', () => {
@@ -1371,14 +1419,20 @@ describe('Session turn send guard', () => {
     expect(handle.send).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects sends after the event iterator crashes', async () => {
+  it('emits a terminal error and closes the session after the event iterator crashes', async () => {
     const crash = new Error('events crashed');
+    let crashIterator!: () => void;
+    const crashReady = new Promise<void>((resolve) => {
+      crashIterator = resolve;
+    });
     const handle = createHandle({ id: 'thread-1' });
     handle.send = vi.fn(async () => undefined);
+    handle.close = vi.fn(async () => undefined);
     const crashingEvents: AsyncIterable<never> = {
       [Symbol.asyncIterator]() {
         return {
           async next(): Promise<IteratorResult<never>> {
+            await crashReady;
             throw crash;
           },
         };
@@ -1393,20 +1447,43 @@ describe('Session turn send guard', () => {
       capabilities: createAgent(async () => handle).capabilities,
       logger: createLogger(),
     });
+    const order: string[] = [];
+    const terminalEvents: AgentEvent[] = [];
+    session.onEvent((event) => {
+      if (event.type === 'error') {
+        terminalEvents.push(event);
+        order.push('error');
+      }
+    });
     const statusChanged = new Promise<void>((resolve) => {
       session.onStatusChange((status) => {
-        if (status === 'error') resolve();
+        if (status === 'closed') {
+          order.push('closed');
+          resolve();
+        }
       });
     });
 
     await session.send('first');
+    crashIterator();
     await statusChanged;
 
-    await expect(session.send('second')).rejects.toThrow('is in error state');
+    expect(terminalEvents).toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        reason: 'session_event_loop_crashed',
+        isTerminal: true,
+      }),
+    }));
+    expect(order).toEqual(['error', 'closed']);
+    expect(session.getStatus()).toBe('closed');
+    await expect(session.send('second')).rejects.toThrow('is closed');
     expect(handle.send).toHaveBeenCalledTimes(1);
+    await Promise.resolve();
+    expect(handle.close).toHaveBeenCalledTimes(1);
   });
 
-  it('does not revive an error session when abort is called after the event iterator crashes', async () => {
+  it('does not revive a closed session when abort is called after the event iterator crashes', async () => {
     const crash = new Error('events crashed');
     const handle = createHandle({ id: 'thread-1' });
     handle.send = vi.fn(async () => undefined);
@@ -1431,7 +1508,7 @@ describe('Session turn send guard', () => {
     });
     const statusChanged = new Promise<void>((resolve) => {
       session.onStatusChange((status) => {
-        if (status === 'error') resolve();
+        if (status === 'closed') resolve();
       });
     });
 
@@ -1439,12 +1516,12 @@ describe('Session turn send guard', () => {
     await statusChanged;
     await session.abort();
 
-    expect(session.getStatus()).toBe('error');
-    await expect(session.send('second')).rejects.toThrow('is in error state');
+    expect(session.getStatus()).toBe('closed');
+    await expect(session.send('second')).rejects.toThrow('is closed');
     expect(handle.send).toHaveBeenCalledTimes(1);
   });
 
-  it('does not revive an error session when the event iterator crashes while abort is awaiting', async () => {
+  it('does not revive a closed session when the event iterator crashes while abort is awaiting', async () => {
     let releaseAbort!: () => void;
     const abortReady = new Promise<void>((resolve) => {
       releaseAbort = resolve;
@@ -1479,7 +1556,7 @@ describe('Session turn send guard', () => {
     });
     const statusChanged = new Promise<void>((resolve) => {
       session.onStatusChange((status) => {
-        if (status === 'error') resolve();
+        if (status === 'closed') resolve();
       });
     });
 
@@ -1490,9 +1567,146 @@ describe('Session turn send guard', () => {
     releaseAbort();
     await abortPromise;
 
-    expect(session.getStatus()).toBe('error');
-    await expect(session.send('second')).rejects.toThrow('is in error state');
+    expect(session.getStatus()).toBe('closed');
+    await expect(session.send('second')).rejects.toThrow('is closed');
     expect(handle.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not duplicate a current terminal error when the iterator crashes while provider send is pending', async () => {
+    let markSendEntered!: () => void;
+    const sendEntered = new Promise<void>((resolve) => {
+      markSendEntered = resolve;
+    });
+    let releaseSend!: () => void;
+    const sendReady = new Promise<void>((resolve) => {
+      releaseSend = resolve;
+    });
+    const handle = createHandle({ id: 'thread-1' });
+    handle.send = vi.fn(async () => {
+      markSendEntered();
+      await sendReady;
+    });
+    handle.isTurnRunning = () => false;
+    handle.close = vi.fn(async () => undefined);
+    handle.events = () => ({
+      [Symbol.asyncIterator]() {
+        let first = true;
+        return {
+          async next(): Promise<IteratorResult<AgentEvent>> {
+            if (first) {
+              first = false;
+              await sendEntered;
+              return {
+                done: false,
+                value: {
+                  type: 'error',
+                  data: {
+                    message: 'terminal error before provider send settled',
+                    reason: 'original_terminal',
+                    isTerminal: true,
+                  },
+                  source: 'codex',
+                },
+              };
+            }
+            throw new Error('events crashed after terminal error');
+          },
+        };
+      },
+    });
+    const session = new Session({
+      id: 'session-1',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: createAgent(async () => handle).capabilities,
+      logger: createLogger(),
+    });
+    const terminalReasons: Array<string | undefined> = [];
+    session.onEvent((event) => {
+      if (event.type === 'error') {
+        terminalReasons.push((event.data as { reason?: string }).reason);
+      }
+    });
+    const closed = new Promise<void>((resolve) => {
+      session.onStatusChange((status) => {
+        if (status === 'closed') resolve();
+      });
+    });
+
+    const sendPromise = session.send('first');
+    await closed;
+    releaseSend();
+    await sendPromise;
+
+    expect(terminalReasons).toEqual(['original_terminal']);
+  });
+
+  it('reports a crash after a queued prior-turn terminal event when a newer turn is running', async () => {
+    let releasePriorDone!: () => void;
+    const priorDoneReady = new Promise<void>((resolve) => {
+      releasePriorDone = resolve;
+    });
+    let releaseCrash!: () => void;
+    const crashReady = new Promise<void>((resolve) => {
+      releaseCrash = resolve;
+    });
+    let running = false;
+    const handle = createHandle({ id: 'thread-1' });
+    handle.isTurnRunning = () => running;
+    handle.send = vi.fn(async (message) => {
+      running = message.content === 'second';
+    });
+    handle.close = vi.fn(async () => undefined);
+    handle.events = () => ({
+      [Symbol.asyncIterator]() {
+        let first = true;
+        return {
+          async next(): Promise<IteratorResult<AgentEvent>> {
+            if (first) {
+              first = false;
+              await priorDoneReady;
+              return { done: false, value: { type: 'done', data: {}, source: 'codex' } };
+            }
+            await crashReady;
+            throw new Error('events crashed during newer turn');
+          },
+        };
+      },
+    });
+    const session = new Session({
+      id: 'session-1',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: createAgent(async () => handle).capabilities,
+      logger: createLogger(),
+    });
+    const terminalErrors: AgentEvent[] = [];
+    session.onEvent((event) => {
+      if (event.type === 'error') terminalErrors.push(event);
+    });
+    const closed = new Promise<void>((resolve) => {
+      session.onStatusChange((status) => {
+        if (status === 'closed') resolve();
+      });
+    });
+
+    await session.send('first');
+    running = false;
+    await session.send('second');
+    releasePriorDone();
+    await Promise.resolve();
+    releaseCrash();
+    await closed;
+
+    expect(terminalErrors).toContainEqual(expect.objectContaining({
+      type: 'error',
+      data: expect.objectContaining({
+        reason: 'session_event_loop_crashed',
+        isTerminal: true,
+      }),
+    }));
   });
 
   it('does not call handle.send when close happens during onAccepted', async () => {

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -1425,9 +1425,13 @@ describe('Session turn send guard', () => {
     const crashReady = new Promise<void>((resolve) => {
       crashIterator = resolve;
     });
+    let releaseClose!: () => void;
+    const closeReady = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
     const handle = createHandle({ id: 'thread-1' });
     handle.send = vi.fn(async () => undefined);
-    handle.close = vi.fn(async () => undefined);
+    handle.close = vi.fn(async () => closeReady);
     const crashingEvents: AsyncIterable<never> = {
       [Symbol.asyncIterator]() {
         return {
@@ -1455,9 +1459,11 @@ describe('Session turn send guard', () => {
         order.push('error');
       }
     });
+    let closedObserved = false;
     const statusChanged = new Promise<void>((resolve) => {
       session.onStatusChange((status) => {
         if (status === 'closed') {
+          closedObserved = true;
           order.push('closed');
           resolve();
         }
@@ -1466,7 +1472,8 @@ describe('Session turn send guard', () => {
 
     await session.send('first');
     crashIterator();
-    await statusChanged;
+    await Promise.resolve();
+    await Promise.resolve();
 
     expect(terminalEvents).toContainEqual(expect.objectContaining({
       type: 'error',
@@ -1475,12 +1482,74 @@ describe('Session turn send guard', () => {
         isTerminal: true,
       }),
     }));
+    expect(order).toEqual(['error']);
+    expect(closedObserved).toBe(false);
+    expect(handle.close).toHaveBeenCalledTimes(1);
+    expect(session.getStatus()).toBe('active');
+    await expect(session.send('second')).rejects.toThrow('is closing');
+
+    releaseClose();
+    await statusChanged;
     expect(order).toEqual(['error', 'closed']);
     expect(session.getStatus()).toBe('closed');
-    await expect(session.send('second')).rejects.toThrow('is closed');
+    await expect(session.send('third')).rejects.toThrow('is closed');
     expect(handle.send).toHaveBeenCalledTimes(1);
-    await Promise.resolve();
     expect(handle.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears the turn stall watchdog when the event iterator ends naturally', async () => {
+    vi.useFakeTimers();
+    try {
+      let releaseEnd!: () => void;
+      const endReady = new Promise<void>((resolve) => {
+        releaseEnd = resolve;
+      });
+      let running = false;
+      const handle = createHandle({ id: 'thread-natural-end' });
+      handle.send = vi.fn(async () => {
+        running = true;
+      });
+      handle.isTurnRunning = () => running;
+      handle.events = () => ({
+        [Symbol.asyncIterator]() {
+          let first = true;
+          return {
+            async next(): Promise<IteratorResult<never>> {
+              if (first) {
+                first = false;
+                await endReady;
+              }
+              return { done: true, value: undefined as never };
+            },
+          };
+        },
+      });
+      const session = new Session({
+        id: 'session-natural-end',
+        agentKind: 'codex',
+        workDir: '/repo',
+        handle,
+        capabilities: createAgent(async () => handle).capabilities,
+        logger: createLogger(),
+        turnStallMs: 1_000,
+      });
+      const closed = new Promise<void>((resolve) => {
+        session.onStatusChange((status) => {
+          if (status === 'closed') resolve();
+        });
+      });
+
+      session.onEvent(() => undefined);
+      await session.send('first');
+      expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+      running = false;
+      releaseEnd();
+      await closed;
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not revive a closed session when abort is called after the event iterator crashes', async () => {

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -289,8 +289,15 @@ export class Maker {
     }
 
     // 进程内已经活着或正在启动的 session, 直接复用 (避免 spawn 第二个 SDK)。
+    // close() 失败的 Session 不能继续收消息，但也不能立刻从 activeSessions
+    // 摘掉并与可能仍存活的底层 transport 并存。先重试同一个 close；只有真实
+    // 关闭成功、status listener 将其移除后，才允许创建新的 handle。
     const existing = this.activeSessions.get(opts.id);
-    if (existing) return existing;
+    if (existing?.getStatus() === 'error') {
+      await existing.close();
+    }
+    const reusable = this.activeSessions.get(opts.id);
+    if (reusable) return reusable;
 
     const inFlight = this.inFlightSessionCreations.get(opts.id);
     if (inFlight) return inFlight.promise;

--- a/packages/maker-core/src/session.close.test.ts
+++ b/packages/maker-core/src/session.close.test.ts
@@ -59,4 +59,33 @@ describe('Session close lifecycle', () => {
     expect(session.getStatus()).toBe('closed');
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  it('does not publish closed when transport shutdown fails', async () => {
+    const close = vi.fn(async () => {
+      throw new Error('transport close failed');
+    });
+    const handle = {
+      id: 'thread-close-failed',
+      agentKind: 'codex',
+      model: 'gpt-5.4',
+      close,
+      setInteractionResolver() {},
+    } as unknown as AgentSessionHandle;
+    const session = new Session({
+      id: 'session-close-failed',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: {} as never,
+      logger: createLogger() as never,
+    });
+    const statuses: string[] = [];
+    session.onStatusChange((status) => statuses.push(status));
+
+    await expect(session.close()).rejects.toThrow('transport close failed');
+
+    expect(statuses).toEqual(['error']);
+    expect(session.getStatus()).toBe('error');
+    expect(close).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/maker-core/src/session.close.test.ts
+++ b/packages/maker-core/src/session.close.test.ts
@@ -88,4 +88,37 @@ describe('Session close lifecycle', () => {
     expect(session.getStatus()).toBe('error');
     expect(close).toHaveBeenCalledTimes(1);
   });
+
+  it('retries a failed transport shutdown before publishing closed', async () => {
+    let attempts = 0;
+    const close = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('transport close failed');
+    });
+    const handle = {
+      id: 'thread-close-retry',
+      agentKind: 'codex',
+      model: 'gpt-5.4',
+      close,
+      setInteractionResolver() {},
+    } as unknown as AgentSessionHandle;
+    const session = new Session({
+      id: 'session-close-retry',
+      agentKind: 'codex',
+      workDir: '/repo',
+      handle,
+      capabilities: {} as never,
+      logger: createLogger() as never,
+    });
+    const statuses: string[] = [];
+    session.onStatusChange((status) => statuses.push(status));
+
+    await expect(session.close()).rejects.toThrow('transport close failed');
+    expect(session.getStatus()).toBe('error');
+
+    await expect(session.close()).resolves.toBeUndefined();
+    expect(statuses).toEqual(['error', 'closed']);
+    expect(session.getStatus()).toBe('closed');
+    expect(close).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -614,14 +614,16 @@ export class Session {
   }
 
   private async performClose(): Promise<void> {
+    let closeSucceeded = false;
     try {
       this.clearTurnStallWatchdog();
       this.cancelSendReservation(this.sendReservation);
       await this.handle.close();
+      closeSucceeded = true;
     } finally {
       this.sendReservation = null;
       this.currentTurnOrigin = null;
-      this.setStatus('closed');
+      this.setStatus(closeSucceeded ? 'closed' : 'error');
       this.eventListeners.clear();
       this.statusListeners.clear();
       this.interactionListener = null;
@@ -1378,9 +1380,7 @@ export class Session {
       // 先占住 closing gate：terminal error 的 listener 可能同步尝试 send，不能让它
       // 在底层 iterator 已经崩掉的窗口里重新进入 provider。复用 performClose，让
       // closePromise 代表真实的 handle.close()，并在底层资源释放后再发布 closed。
-      this.closePromise = this.performClose().catch((closeError) => {
-        this.logger.warn('event-loop crash handle close failed', { error: String(closeError) });
-      });
+      this.closePromise = this.performClose();
       // 终态事件可能属于已结束的上一轮，但新 turn 已经在 event loop 崩溃前被
       // Session 接受。此时不能因为上一轮的 done/error 已观察过就吞掉本轮的
       // `session_event_loop_crashed`，否则新 turn 只有 closed 没有终态 error。
@@ -1395,7 +1395,11 @@ export class Session {
           source: this.agentKind,
         });
       }
-      await this.closePromise;
+      try {
+        await this.closePromise;
+      } catch (closeError) {
+        this.logger.warn('event-loop crash handle close failed', { error: String(closeError) });
+      }
       return;
     }
     // handle.events() 自然结束 (iterator return) = 底层 handle 已死、不会再发任何事件。
@@ -1417,6 +1421,7 @@ export class Session {
       this.logger.debug('event loop ended (handle dead), auto-closing session');
       this.clearTurnStallWatchdog();
       this.closePromise ??= Promise.resolve();
+      this.cancelSendReservation(this.sendReservation);
       this.sendReservation = null;
       this.currentTurnOrigin = null;
       this.setStatus('closed');

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1376,8 +1376,11 @@ export class Session {
       this.logger.error('event loop crashed', { error: String(e) });
       if (this.closePromise || this.status === 'closed') return;
       // 先占住 closing gate：terminal error 的 listener 可能同步尝试 send，不能让它
-      // 在底层 iterator 已经崩掉的窗口里重新进入 provider。
-      this.closePromise = Promise.resolve();
+      // 在底层 iterator 已经崩掉的窗口里重新进入 provider。复用 performClose，让
+      // closePromise 代表真实的 handle.close()，并在底层资源释放后再发布 closed。
+      this.closePromise = this.performClose().catch((closeError) => {
+        this.logger.warn('event-loop crash handle close failed', { error: String(closeError) });
+      });
       // 终态事件可能属于已结束的上一轮，但新 turn 已经在 event loop 崩溃前被
       // Session 接受。此时不能因为上一轮的 done/error 已观察过就吞掉本轮的
       // `session_event_loop_crashed`，否则新 turn 只有 closed 没有终态 error。
@@ -1392,20 +1395,7 @@ export class Session {
           source: this.agentKind,
         });
       }
-      // transport close 不能阻塞生命周期收口：某些 app-server / remote handle 的 close
-      // 本身也可能悬挂。Maker 只需要看到 closed，下一次 send 就会重建 handle。
-      void Promise.resolve()
-        .then(() => this.handle.close())
-        .catch((closeError) => {
-          this.logger.warn('event-loop crash handle close failed', { error: String(closeError) });
-        });
-      this.sendReservation = null;
-      this.currentTurnOrigin = null;
-      this.clearTurnStallWatchdog();
-      this.setStatus('closed');
-      this.eventListeners.clear();
-      this.statusListeners.clear();
-      this.interactionListener = null;
+      await this.closePromise;
       return;
     }
     // handle.events() 自然结束 (iterator return) = 底层 handle 已死、不会再发任何事件。
@@ -1425,6 +1415,7 @@ export class Session {
     // 的同时 iterator return，不能让 abort finally 把已经死掉的 Session 改回 active。
     if (this.status !== 'closed' && this.status !== 'error') {
       this.logger.debug('event loop ended (handle dead), auto-closing session');
+      this.clearTurnStallWatchdog();
       this.closePromise ??= Promise.resolve();
       this.sendReservation = null;
       this.currentTurnOrigin = null;

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1117,10 +1117,12 @@ export class Session {
     if (isTerminal) {
       // 事件迭代器可能早在上一轮就已开始等待，上一轮排队的 done/error 会在新
       // turn dispatch 后才返回。默认按 next() 开始等待时的 generation 归属；唯一
-      // 例外是 provider send 仍 pending、handle 尚未置 running 时先到的 terminal
-      // error（Codex 允许 error 早于 turn/start response），它明确属于当前 reservation。
+      // 例外是 Codex provider send 仍 pending、handle 尚未置 running 时先到的 terminal
+      // error。Codex adapter 已按 turnId 过滤迟到错误，只有它允许 error 早于 turn/start
+      // response；其它 provider 不能靠 Session 的 reservation 瞬时状态推断归属。
       const terminalBeforeProviderStartSettled =
         event.type === 'error' &&
+        event.source === 'codex' &&
         this.sendReservation?.phase === 'dispatching' &&
         !this.isHandleTurnRunning();
       if (observedGeneration === this.turnGeneration || terminalBeforeProviderStartSettled) {

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -623,10 +623,20 @@ export class Session {
     } finally {
       this.sendReservation = null;
       this.currentTurnOrigin = null;
-      this.setStatus(closeSucceeded ? 'closed' : 'error');
       this.eventListeners.clear();
-      this.statusListeners.clear();
       this.interactionListener = null;
+      if (closeSucceeded) {
+        this.setStatus('closed');
+        this.statusListeners.clear();
+      } else {
+        // handle.close() rejected: keep the Session in error rather than
+        // claiming the underlying transport is gone.  Clear the rejected
+        // close promise so Maker can retry the same close before rebuilding
+        // this id; retain status listeners so a later successful retry still
+        // removes the Session from Maker.activeSessions.
+        this.closePromise = null;
+        this.setStatus('error');
+      }
     }
   }
 

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -301,6 +301,12 @@ export class Session {
   /** close/detach 一进入同步入口就置位，早于底层 handle 的异步关闭完成。 */
   private terminationStarted = false;
   private eventLoopStarted = false;
+  /**
+   * 最近一次已观察到的终态事件属于哪个 Session turn generation；用于 iterator
+   * 崩溃时避免重复收口。不能只存一个 bool：上一轮已排队的 done 可能在新 turn
+   * 开始后才从 iterator 返回，不能拿它覆盖新 turn 的终态判据。
+   */
+  private terminalEventObservedGeneration: number | null = null;
   private sendReservation: SendReservation | null = null;
   /**
    * 当前进行中 turn 的发起来源(来自 send 的 opts.origin)。事件 fan-out 前打到
@@ -470,6 +476,7 @@ export class Session {
       // 关联到具体 turn 事件而非单槽位(maker-core 热路径重构,规则 10),留作独立后续。
       previousTurnOrigin = this.currentTurnOrigin;
       this.currentTurnOrigin = handleOpts.origin ?? null;
+      this.terminalEventObservedGeneration = null;
       originInstalled = true;
       this.startEventLoopIfNeeded();
       try {
@@ -1086,7 +1093,7 @@ export class Session {
    * 并像用户插话一样暂停 goal,scheduler 的 IM 转播则直接忽略,卡片永不 finalize
    * (review #944 第二轮)。
    */
-  private fanOutEvent(event: AgentEvent): void {
+  private fanOutEvent(event: AgentEvent, observedGeneration = this.turnGeneration): void {
     this.lastEventAt = Date.now();
     this.lastEventType = event.type;
     // fan-out 前打 turn origin(所有 listener 拿到同一份);事件对象由 translator
@@ -1094,11 +1101,24 @@ export class Session {
     if (this.currentTurnOrigin && event.turnOrigin === undefined) {
       event.turnOrigin = this.currentTurnOrigin;
     }
+    const isTerminal = event.type === 'done' || isTerminalAgentErrorEvent(event);
+    if (isTerminal) {
+      // 事件迭代器可能早在上一轮就已开始等待，上一轮排队的 done/error 会在新
+      // turn dispatch 后才返回。默认按 next() 开始等待时的 generation 归属；唯一
+      // 例外是 provider send 仍 pending、handle 尚未置 running 时先到的 terminal
+      // error（Codex 允许 error 早于 turn/start response），它明确属于当前 reservation。
+      const terminalBeforeProviderStartSettled =
+        event.type === 'error' &&
+        this.sendReservation?.phase === 'dispatching' &&
+        !this.isHandleTurnRunning();
+      if (observedGeneration === this.turnGeneration || terminalBeforeProviderStartSettled) {
+        this.terminalEventObservedGeneration = this.turnGeneration;
+      }
+    }
     const listenerEvent = redactEventForListeners(event);
     for (const listener of this.eventListeners) {
       try { listener(listenerEvent); } catch (e) { this.logger.error('event listener threw', { error: String(e) }); }
     }
-    const isTerminal = event.type === 'done' || isTerminalAgentErrorEvent(event);
     // turn 真正结束后清 origin,下一轮无 origin 的 turn 不被污染。
     // 关键:**只**在 done / 终止型 error 上清,**不要**在 status(isRunning=false)
     // 上清 —— translator 收尾是先 push end-status(isRunning=false)、紧接着 push
@@ -1341,18 +1361,51 @@ export class Session {
 
   private async runEventLoop(): Promise<void> {
     try {
-      for await (const event of this.handle.events()) {
+      const iterator = this.handle.events()[Symbol.asyncIterator]();
+      while (true) {
+        const awaitingGeneration = this.turnGeneration;
+        const result = await iterator.next();
+        if (result.done) break;
+        const event = result.value;
         this.releaseSendReservationIfObserved();
         // origin 打标与终态清理都收在 fanOutEvent 里（看门狗合成的事件共用同一语义，
         // 见那里的注释）。
-        this.fanOutEvent(event);
+        this.fanOutEvent(event, awaitingGeneration);
       }
     } catch (e) {
       this.logger.error('event loop crashed', { error: String(e) });
+      if (this.closePromise || this.status === 'closed') return;
+      // 先占住 closing gate：terminal error 的 listener 可能同步尝试 send，不能让它
+      // 在底层 iterator 已经崩掉的窗口里重新进入 provider。
+      this.closePromise = Promise.resolve();
+      // 终态事件可能属于已结束的上一轮，但新 turn 已经在 event loop 崩溃前被
+      // Session 接受。此时不能因为上一轮的 done/error 已观察过就吞掉本轮的
+      // `session_event_loop_crashed`，否则新 turn 只有 closed 没有终态 error。
+      if (this.terminalEventObservedGeneration !== this.turnGeneration) {
+        this.fanOutEvent({
+          type: 'error',
+          data: {
+            message: `Session event loop stopped unexpectedly: ${String(e)}`,
+            isTerminal: true,
+            reason: 'session_event_loop_crashed',
+          },
+          source: this.agentKind,
+        });
+      }
+      // transport close 不能阻塞生命周期收口：某些 app-server / remote handle 的 close
+      // 本身也可能悬挂。Maker 只需要看到 closed，下一次 send 就会重建 handle。
+      void Promise.resolve()
+        .then(() => this.handle.close())
+        .catch((closeError) => {
+          this.logger.warn('event-loop crash handle close failed', { error: String(closeError) });
+        });
       this.sendReservation = null;
       this.currentTurnOrigin = null;
       this.clearTurnStallWatchdog();
-      this.setStatus('error');
+      this.setStatus('closed');
+      this.eventListeners.clear();
+      this.statusListeners.clear();
+      this.interactionListener = null;
       return;
     }
     // handle.events() 自然结束 (iterator return) = 底层 handle 已死、不会再发任何事件。
@@ -1368,12 +1421,17 @@ export class Session {
     // activeSessions.delete + emit 'session:closed' + lifecycleHooks.onClose → 下次
     // send 自然走 IPC lazy create-session 路径, 重建 handle / transport / 远端连接。
     //
-    // 仅当当前 status 还是 'active' 时切 — 'closed' / 'error' 已经表达终态, 不覆盖。
-    if (this.status === 'active') {
+    // iterator 自然结束同样表示底层 handle 已死。覆盖 aborting 竞态：若用户按 Stop
+    // 的同时 iterator return，不能让 abort finally 把已经死掉的 Session 改回 active。
+    if (this.status !== 'closed' && this.status !== 'error') {
       this.logger.debug('event loop ended (handle dead), auto-closing session');
+      this.closePromise ??= Promise.resolve();
       this.sendReservation = null;
       this.currentTurnOrigin = null;
       this.setStatus('closed');
+      this.eventListeners.clear();
+      this.statusListeners.clear();
+      this.interactionListener = null;
     }
   }
 

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -1425,20 +1425,39 @@ export class Session {
     // activeSessions.delete + emit 'session:closed' + lifecycleHooks.onClose → 下次
     // send 自然走 IPC lazy create-session 路径, 重建 handle / transport / 远端连接。
     //
-    // iterator 自然结束同样表示底层 handle 已死。覆盖 aborting 竞态：若用户按 Stop
-    // 的同时 iterator return，不能让 abort finally 把已经死掉的 Session 改回 active。
-    if (this.status !== 'closed' && this.status !== 'error') {
-      this.logger.debug('event loop ended (handle dead), auto-closing session');
-      this.clearTurnStallWatchdog();
-      this.closePromise ??= Promise.resolve();
-      this.cancelSendReservation(this.sendReservation);
-      this.sendReservation = null;
-      this.currentTurnOrigin = null;
-      this.setStatus('closed');
-      this.eventListeners.clear();
-      this.statusListeners.clear();
-      this.interactionListener = null;
+    // iterator 自然结束同样表示底层 handle 已死。显式 close/detach 已经占有收口权时，
+    // 不能让这里提前发布 closed:performClose 必须等 transport 真正关闭后再发布，失败
+    // 则保持 error 以便调用方重试。若活跃 turn 还没有观察到终态，先补一条与 crash
+    // 分支一致的 terminal error，避免 Desktop 把这一轮静默丢掉。
+    if (this.terminationStarted || this.status === 'closed' || this.status === 'error') return;
+    const unfinishedTurn =
+      this.status === 'active' &&
+      this.isTurnRunning() &&
+      this.terminalEventObservedGeneration !== this.turnGeneration;
+    this.logger.debug('event loop ended (handle dead), auto-closing session', { unfinishedTurn });
+    this.terminationStarted = true;
+    // 先占住 closing gate：terminal error 的 listener 可能同步尝试 send，不能让它在
+    // 底层 iterator 已经结束的窗口里重新进入 provider。
+    this.closePromise = Promise.resolve();
+    if (unfinishedTurn) {
+      this.fanOutEvent({
+        type: 'error',
+        data: {
+          message: 'Session event loop stopped unexpectedly without a terminal event',
+          isTerminal: true,
+          reason: 'session_event_loop_crashed',
+        },
+        source: this.agentKind,
+      });
     }
+    this.clearTurnStallWatchdog();
+    this.cancelSendReservation(this.sendReservation);
+    this.sendReservation = null;
+    this.currentTurnOrigin = null;
+    this.setStatus('closed');
+    this.eventListeners.clear();
+    this.statusListeners.clear();
+    this.interactionListener = null;
   }
 
   private isHandleTurnRunning(): boolean {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex app-server 在输出 `Reconnecting... N/M` 后可能一直没有真实进展，Desktop 只显示重连状态而不结束当前任务，最终表现为“静默重连卡住”。本 PR 为这条明确的有限重连序列增加有界收口，并补齐乱序事件与 Session 崩溃后的生命周期清理。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 回归测试

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：
  - 仅对 Codex 明确上报的 `Reconnecting... N/M` 启动 120 秒总 deadline；后续 `2/5`、`3/5` 不会重新计时。
  - 一旦收到可见文本、thinking、工具事件、完成事件或其它明确恢复信号，立即取消该 deadline；恢复后不再受这次时间限制。
  - deadline 到期后发出稳定 reason `codex_reconnect_stalled`，沿现有中断/自动续跑链路收口。
  - 覆盖 `turn/start` 尚未返回时重连提示先到达的乱序：隔离迟到的 turn，先关闭当前 handle；只有两次有界 interrupt ACK 都失败才退役共享 host，避免误伤同 host 的健康 Session。
  - 迟到的同 turn `turn/completed` 作为权威完成证据：即使两次 interrupt reject，也结算本地 busy 并保留共享 host；completion 在 `handle.close()` 等待期间到达时同样阻止共享 host 退役。
  - Session event iterator 崩溃时先发 terminal error，再关闭并移除 Session，避免重复终态和无法重建。
  - 自动续跑沿用“有真实产出才发送继续提示、零产出不重放原请求”的安全判定。
- 明确不包含：普通网络瞬断的全局重试策略、relay/device-link 修复、移动端行为改动。
- 用户可见变化：Codex 长时间卡在有限重连阶段时，120 秒后会明确结束并提示可继续；成功恢复并产生输出后不会触发该超时。
- 是否存在 breaking change：无

### 远程与多端结论

- SSH 远程工作区：不涉及 workdir 文件、远程文件服务或 SSH 通道；改动只在 maker-core 的 Codex Session 生命周期中，未新增本机文件访问。
- 设备互联 / IPC：不涉及新的 IPC channel、push event、wire protocol 或 device-link allowlist；沿用现有 Session error/status 事件，relay/device-link 本身不变。
- 手机版：不涉及 `apps/mobile` 代码、入口或布局；手机继续消费现有任务终态事件，本 PR 不增加移动端专属语义。

### maker-core 指标评估

- 缓存率：未修改 system prompt、tool/MCP 注册、model 路由或 prompt 前缀，缓存前缀保持不变。
- 热路径性能：`eventQueue.push` 只增加已有事件上的轻量 reason/可见输出判定；没有同步 I/O、额外网络往返或串行 await。定向和 maker-core 全包测试实测事件流无丢失/错序，状态机交错均按预期收口。
- 返回内容准确性：新增回归覆盖真实输出取消 deadline、pending turn/start 乱序、迟到 completion、双 ACK 失败与 Session iterator crash；未改变非 Codex provider 的事件映射。

### UI 变化

- 不涉及布局、样式或交互结构；仅将已有稳定 error reason 映射到既有 i18n 文案，实时 ErrorBanner 与历史 ErrorMessageCard 共用无副作用映射源。
- 引用的设计规范：`docs/design-rules/DESIGN.md §11 Voice & Content`（错误文案说明发生了什么并保持可行动；本 PR 复用既有本地化 key，不新增文案）。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core test
结果：75 个测试文件通过，1,559 passed / 26 skipped。

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts -t "CodexAgent reconnect-stall watchdog"
结果：10 passed。

pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx src/renderer/__tests__/errorMessageRestore.test.ts
结果：38 passed。

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco
结果：10 commits signed off。

git diff --check
结果：通过。
```

统一全仓门禁：

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-codex-reconnect-stall
结果：GATE_EXIT=1；19,406 项通过、2 skipped，唯一失败为 origin/main 已存在的
apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts：期望 60,000、实际 24,000。
该文件与本 PR diff 无关，远端 CI 在本 PR rebase 前也同样失败；无关 TTL 修复由独立 PR #1498 处理，不混入本 PR。
```

`@cindy/maker-core` 没有 `typecheck` script，`run --if-present typecheck` 按规则跳过；额外 `build` 尝试命中最新 main 已有的测试类型错误（`plan-mode.test.ts` 与既有 `codex/index.test.ts` 行），不在本 PR 新增行，未混入无关修复。

### 手工验证

不涉及：本 PR 通过单元测试覆盖重连收口、恢复取消 deadline、pending `turn/start` 乱序、共享 host 退役条件及 Session iterator crash。

### 未执行的验证

未执行真实 Codex app-server 网络故障注入、真实 relay/device-link 故障注入、SSH 远程实机和移动端实机验证；这些场景没有新增通道或移动端代码，需在集成环境继续观察真实 app-server 重连日志。Windows 行为由 client-ci 的 Windows unit shards 负责验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异：异步 timer / Date.now suspend-gap 在 macOS 与 Windows 共用同一 TypeScript 路径，未引入平台分支；本地 macOS 已验证，Windows 交由 CI。
- [x] 其他：异步生命周期与重连 watchdog

### 影响与回滚

- 影响范围：Codex provider 的有限重连提示、Maker Session 的 event-loop 异常收口；其它 provider 和普通网络错误路径保持原逻辑。
- 回滚 / 降级方式：回滚本 PR 即恢复原有行为；无需数据库或配置迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
