### PR TITLE
feat(desktop): marquee truncated sidebar task titles

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
@@ -53,7 +53,7 @@ describe('sidebar remote project icon', () => {
 
   it('keeps remote session icons next to titles instead of in the right-side time slots', () => {
     expect(sessionItemSource).toMatch(
-      /<span className="min-w-0 flex flex-1 items-center gap-1\.5">[\s\S]*?<span className="min-w-0 truncate">[\s\S]*?\{remoteIconKind && \([\s\S]*?<RemoteProjectIcon/,
+      /<span className="min-w-0 flex flex-1 items-center gap-1\.5">[\s\S]*?<SidebarTitleMarquee[\s\S]*?\{remoteIconKind && \([\s\S]*?<RemoteProjectIcon/,
     );
     expect(sessionItemSource).toMatch(
       /<div className="group\/slot relative ml-auto flex h-6 shrink-0 items-center justify-end min-w-14">[\s\S]*?<WorktreeBadge[\s\S]*?<time/,
@@ -63,7 +63,9 @@ describe('sidebar remote project icon', () => {
   });
 
   it('lets the title text shrink before the adjacent remote icon instead of pushing the icon to the row edge', () => {
-    expect(sessionItemSource).toContain('<span className="min-w-0 truncate">');
+    expect(sessionItemSource).toContain(
+      'className="sidebar-title-marquee min-w-0 flex-1 overflow-hidden"',
+    );
     expect(sessionItemSource).not.toContain('<span className="min-w-0 flex-1 truncate">');
     expect(sessionCardSource).not.toContain("'min-w-0 flex-1 truncate'");
   });

--- a/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
@@ -64,7 +64,7 @@ describe('sidebar remote project icon', () => {
 
   it('lets the title text shrink before the adjacent remote icon instead of pushing the icon to the row edge', () => {
     expect(sessionItemSource).toContain(
-      'className="sidebar-title-marquee min-w-0 flex-1 overflow-hidden"',
+      'className="sidebar-title-marquee min-w-0 max-w-full shrink overflow-hidden"',
     );
     expect(sessionItemSource).not.toContain('<span className="min-w-0 flex-1 truncate">');
     expect(sessionCardSource).not.toContain("'min-w-0 flex-1 truncate'");

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -130,6 +130,7 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
     if (!container) return;
     delete container.dataset.titleOverflowing;
     container.style.removeProperty('--sidebar-title-marquee-shift');
+    container.style.removeProperty('--sidebar-title-marquee-duration');
   }, []);
 
   const startMarquee = useCallback(() => {
@@ -139,11 +140,20 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
 
     delete container.dataset.titleOverflowing;
     container.style.removeProperty('--sidebar-title-marquee-shift');
+    container.style.removeProperty('--sidebar-title-marquee-duration');
     if (track.scrollWidth <= container.clientWidth + 1) return;
 
+    const viewportCount = Math.max(
+      1,
+      Math.ceil(track.scrollWidth / Math.max(container.clientWidth, 1)),
+    );
     container.style.setProperty(
       '--sidebar-title-marquee-shift',
       `${container.clientWidth - track.scrollWidth}px`,
+    );
+    container.style.setProperty(
+      '--sidebar-title-marquee-duration',
+      `calc(var(--motion-base) * ${viewportCount * 12})`,
     );
     container.dataset.titleOverflowing = 'true';
   }, []);
@@ -151,6 +161,19 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
   useLayoutEffect(() => {
     if (isHoveredRef.current) startMarquee();
   }, [startMarquee, title]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    const track = trackRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(() => {
+      if (isHoveredRef.current) startMarquee();
+    });
+    observer.observe(container);
+    if (track) observer.observe(track);
+    return () => observer.disconnect();
+  }, [startMarquee]);
 
   return (
     <span

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -110,6 +110,59 @@ function loadScheduleSidebarIndexRunsCached(): Promise<ScheduleSidebarIndexRun[]
 
 const log = createLogger('SessionItem');
 
+interface SidebarTitleMarqueeProps {
+  children: ReactNode;
+  className?: string;
+  title: string;
+}
+
+/**
+ * 标题保持原生省略号，只有实际溢出且鼠标停留在标题区域时才播放一次横向滚动。
+ * 通过 DOM 属性和 CSS 变量驱动，避免给高密度侧栏行增加 React 状态订阅。
+ */
+function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarqueeProps) {
+  const containerRef = useRef<HTMLSpanElement>(null);
+  const trackRef = useRef<HTMLSpanElement>(null);
+
+  const stopMarquee = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    delete container.dataset.titleOverflowing;
+    container.style.removeProperty('--sidebar-title-marquee-shift');
+  }, []);
+
+  const startMarquee = useCallback(() => {
+    const container = containerRef.current;
+    const track = trackRef.current;
+    if (!container || !track || track.scrollWidth <= container.clientWidth + 1) return;
+
+    container.style.setProperty(
+      '--sidebar-title-marquee-shift',
+      `${container.clientWidth - track.scrollWidth}px`,
+    );
+    container.dataset.titleOverflowing = 'true';
+  }, []);
+
+  return (
+    <span
+      ref={containerRef}
+      className="sidebar-title-marquee min-w-0 flex-1 overflow-hidden"
+      title={title}
+      onMouseEnter={startMarquee}
+      onMouseLeave={stopMarquee}
+    >
+      <span className={cn('sidebar-title-marquee__ellipsis', className)}>{children}</span>
+      <span
+        ref={trackRef}
+        aria-hidden="true"
+        className={cn('sidebar-title-marquee__track', className)}
+      >
+        {children}
+      </span>
+    </span>
+  );
+}
+
 export interface SessionItemProps {
   session: Session;
   isActive: boolean;
@@ -332,6 +385,17 @@ export const SessionItem = memo(function SessionItem({
   }, [effectiveScheduleId, t]);
   const displayTitle = getSessionDisplayTitle(session, t('ccAgent.common.unnamedSession'));
   const canHighlightDisplayTitle = canHighlightSessionDisplayTitle(session);
+  const titleContent =
+    matchIndices && matchIndices.length > 0 && canHighlightDisplayTitle
+      ? highlightSegments(session.title, matchIndices, {
+          highlightClassName: cn(
+            'bg-transparent font-semibold',
+            isActive
+              ? 'text-[var(--sidebar-item-active-foreground)]'
+              : 'text-[var(--msg-assistant-text)]',
+          ),
+        })
+      : displayTitle;
   // F-PJ-10：archived 视图下的 session 走特殊视觉/菜单分支
   //   - 左侧 status icon 由 CircleDashed 换成 Archive
   //   - 右侧 ⋮ 菜单只显示 Rename + Unarchive（屏蔽 Pin/Delete/Archive 等无意义项）
@@ -718,18 +782,12 @@ export const SessionItem = memo(function SessionItem({
               <AutomationTimerIcon size={10} activeForeground={isActive} />
             </button>
           ) : null}
-          <span className="min-w-0 truncate">
-            {matchIndices && matchIndices.length > 0 && canHighlightDisplayTitle
-              ? highlightSegments(session.title, matchIndices, {
-                  highlightClassName: cn(
-                    'bg-transparent font-semibold',
-                    isActive
-                      ? 'text-[var(--sidebar-item-active-foreground)]'
-                      : 'text-[var(--msg-assistant-text)]',
-                  ),
-                })
-              : displayTitle}
-          </span>
+          <SidebarTitleMarquee
+            title={displayTitle}
+            className={isActive ? 'text-sidebar-item-active-foreground' : 'text-foreground'}
+          >
+            {titleContent}
+          </SidebarTitleMarquee>
           {remoteIconKind && (
             <RemoteProjectIcon
               kind={remoteIconKind}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -29,7 +29,7 @@
  *   Agent → Timer 沿用原 Clock 的 gap-1.5(6px),Timer → 标题同为 6px。
  */
 
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { MouseEvent as ReactMouseEvent, ReactNode } from 'react';
 import { Archive, ChevronRight, EllipsisVertical, Play, Undo } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
@@ -123,6 +123,7 @@ interface SidebarTitleMarqueeProps {
 function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarqueeProps) {
   const containerRef = useRef<HTMLSpanElement>(null);
   const trackRef = useRef<HTMLSpanElement>(null);
+  const isHoveredRef = useRef(false);
 
   const stopMarquee = useCallback(() => {
     const container = containerRef.current;
@@ -134,7 +135,11 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
   const startMarquee = useCallback(() => {
     const container = containerRef.current;
     const track = trackRef.current;
-    if (!container || !track || track.scrollWidth <= container.clientWidth + 1) return;
+    if (!container || !track) return;
+
+    delete container.dataset.titleOverflowing;
+    container.style.removeProperty('--sidebar-title-marquee-shift');
+    if (track.scrollWidth <= container.clientWidth + 1) return;
 
     container.style.setProperty(
       '--sidebar-title-marquee-shift',
@@ -143,13 +148,23 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
     container.dataset.titleOverflowing = 'true';
   }, []);
 
+  useLayoutEffect(() => {
+    if (isHoveredRef.current) startMarquee();
+  }, [startMarquee, title]);
+
   return (
     <span
       ref={containerRef}
       className="sidebar-title-marquee min-w-0 flex-1 overflow-hidden"
       title={title}
-      onMouseEnter={startMarquee}
-      onMouseLeave={stopMarquee}
+      onMouseEnter={() => {
+        isHoveredRef.current = true;
+        startMarquee();
+      }}
+      onMouseLeave={() => {
+        isHoveredRef.current = false;
+        stopMarquee();
+      }}
     >
       <span className={cn('sidebar-title-marquee__ellipsis', className)}>{children}</span>
       <span

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -124,6 +124,7 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
   const containerRef = useRef<HTMLSpanElement>(null);
   const trackRef = useRef<HTMLSpanElement>(null);
   const isHoveredRef = useRef(false);
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
 
   const stopMarquee = useCallback(() => {
     const container = containerRef.current;
@@ -153,16 +154,18 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
     );
     container.style.setProperty(
       '--sidebar-title-marquee-duration',
-      `calc(var(--motion-base) * ${viewportCount * 12})`,
+      `calc(var(--motion-sidebar-title-marquee-per-viewport) * ${viewportCount})`,
     );
     container.dataset.titleOverflowing = 'true';
   }, []);
 
-  useLayoutEffect(() => {
-    if (isHoveredRef.current) startMarquee();
-  }, [startMarquee, title]);
+  const stopObserving = useCallback(() => {
+    resizeObserverRef.current?.disconnect();
+    resizeObserverRef.current = null;
+  }, []);
 
-  useEffect(() => {
+  const startObserving = useCallback(() => {
+    stopObserving();
     const container = containerRef.current;
     const track = trackRef.current;
     if (!container || typeof ResizeObserver === 'undefined') return;
@@ -172,8 +175,14 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
     });
     observer.observe(container);
     if (track) observer.observe(track);
-    return () => observer.disconnect();
-  }, [startMarquee]);
+    resizeObserverRef.current = observer;
+  }, [startMarquee, stopObserving]);
+
+  useLayoutEffect(() => {
+    if (isHoveredRef.current) startMarquee();
+  }, [startMarquee, title]);
+
+  useEffect(() => () => stopObserving(), [stopObserving]);
 
   return (
     <span
@@ -183,9 +192,11 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
       onMouseEnter={() => {
         isHoveredRef.current = true;
         startMarquee();
+        startObserving();
       }}
       onMouseLeave={() => {
         isHoveredRef.current = false;
+        stopObserving();
         stopMarquee();
       }}
     >

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -178,7 +178,7 @@ function SidebarTitleMarquee({ children, className, title }: SidebarTitleMarquee
   return (
     <span
       ref={containerRef}
-      className="sidebar-title-marquee min-w-0 flex-1 overflow-hidden"
+      className="sidebar-title-marquee min-w-0 max-w-full shrink overflow-hidden"
       title={title}
       onMouseEnter={() => {
         isHoveredRef.current = true;

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -62,12 +62,20 @@ describe('SessionCard review regressions', () => {
       "container.style.removeProperty('--sidebar-title-marquee-duration');",
     );
     expect(sessionItemSource).toContain('const viewportCount = Math.max(');
+    expect(sessionItemSource).toContain(
+      'calc(var(--motion-sidebar-title-marquee-per-viewport) * ${viewportCount})',
+    );
+    expect(sessionItemSource).not.toContain('var(--motion-base) * ${viewportCount * 12}');
   });
 
-  it('remeasures hovered titles when the sidebar or highlighted content resizes', () => {
+  it('observes layout changes only while the title is hovered', () => {
+    expect(sessionItemSource).toContain('const resizeObserverRef = useRef<ResizeObserver | null>(null);');
     expect(sessionItemSource).toContain("typeof ResizeObserver === 'undefined'");
     expect(sessionItemSource).toContain('observer.observe(container);');
     expect(sessionItemSource).toContain('observer.observe(track);');
+    expect(sessionItemSource).toContain('resizeObserverRef.current?.disconnect();');
+    expect(sessionItemSource).toContain('startObserving();');
+    expect(sessionItemSource).toContain('stopObserving();');
     expect(sessionItemSource).toContain('if (isHoveredRef.current) startMarquee();');
   });
 

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -46,6 +46,17 @@ describe('SessionCard review regressions', () => {
     );
   });
 
+  it('recalculates the marquee when a hovered title changes', () => {
+    expect(sessionItemSource).toContain('const isHoveredRef = useRef(false);');
+    expect(sessionItemSource).toContain('useLayoutEffect(() => {');
+    expect(sessionItemSource).toContain('if (isHoveredRef.current) startMarquee();');
+    expect(sessionItemSource).toContain('}, [startMarquee, title]);');
+    expect(sessionItemSource).toContain('delete container.dataset.titleOverflowing;');
+    expect(sessionItemSource).toContain(
+      "container.style.removeProperty('--sidebar-title-marquee-shift');",
+    );
+  });
+
   it('keeps card titles to two lines with shared inline prefix alignment', () => {
     expect(sessionCardSource).toContain('[-webkit-line-clamp:2] overflow-hidden');
     expect(sessionCardSource).toContain('style={{ textIndent: 0, paddingLeft: 0 }}');

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -33,6 +33,19 @@ describe('SessionCard review regressions', () => {
     );
   });
 
+  it('plays overflowing sidebar titles only while hovered', () => {
+    expect(sessionItemSource).toContain('function SidebarTitleMarquee');
+    expect(sessionItemSource).toContain("container.dataset.titleOverflowing = 'true'");
+    expect(sessionItemSource).toContain("delete container.dataset.titleOverflowing");
+    expect(globalsSource).toContain('@keyframes sidebar-title-marquee');
+    expect(globalsSource).toContain(
+      "sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__track",
+    );
+    expect(globalsSource).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*\.sidebar-title-marquee\[data-title-overflowing='true'\][\s\S]*animation: none;/,
+    );
+  });
+
   it('keeps card titles to two lines with shared inline prefix alignment', () => {
     expect(sessionCardSource).toContain('[-webkit-line-clamp:2] overflow-hidden');
     expect(sessionCardSource).toContain('style={{ textIndent: 0, paddingLeft: 0 }}');

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -72,8 +72,8 @@ describe('SessionCard review regressions', () => {
   });
 
   it('keeps the original accessible title visible when reduced motion is enabled', () => {
-    expect(globalsSource).toContain(
-      ".sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__ellipsis {\n  opacity: 0;\n}",
+    expect(globalsSource).toMatch(
+      /\.sidebar-title-marquee\[data-title-overflowing='true'\] \.sidebar-title-marquee__ellipsis \{\r?\n {2}opacity: 0;\r?\n\}/,
     );
     expect(globalsSource).toMatch(
       /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*\.sidebar-title-marquee\[data-title-overflowing='true'\] \.sidebar-title-marquee__ellipsis \{[\s\S]*opacity: 1;/,

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
@@ -44,6 +44,9 @@ describe('SessionCard review regressions', () => {
     expect(globalsSource).toMatch(
       /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*\.sidebar-title-marquee\[data-title-overflowing='true'\][\s\S]*animation: none;/,
     );
+    expect(globalsSource).toContain(
+      'animation: sidebar-title-marquee var(--sidebar-title-marquee-duration)',
+    );
   });
 
   it('recalculates the marquee when a hovered title changes', () => {
@@ -54,6 +57,26 @@ describe('SessionCard review regressions', () => {
     expect(sessionItemSource).toContain('delete container.dataset.titleOverflowing;');
     expect(sessionItemSource).toContain(
       "container.style.removeProperty('--sidebar-title-marquee-shift');",
+    );
+    expect(sessionItemSource).toContain(
+      "container.style.removeProperty('--sidebar-title-marquee-duration');",
+    );
+    expect(sessionItemSource).toContain('const viewportCount = Math.max(');
+  });
+
+  it('remeasures hovered titles when the sidebar or highlighted content resizes', () => {
+    expect(sessionItemSource).toContain("typeof ResizeObserver === 'undefined'");
+    expect(sessionItemSource).toContain('observer.observe(container);');
+    expect(sessionItemSource).toContain('observer.observe(track);');
+    expect(sessionItemSource).toContain('if (isHoveredRef.current) startMarquee();');
+  });
+
+  it('keeps the original accessible title visible when reduced motion is enabled', () => {
+    expect(globalsSource).toContain(
+      ".sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__ellipsis {\n  opacity: 0;\n}",
+    );
+    expect(globalsSource).toMatch(
+      /@media \(prefers-reduced-motion: reduce\) \{[\s\S]*\.sidebar-title-marquee\[data-title-overflowing='true'\] \.sidebar-title-marquee__ellipsis \{[\s\S]*opacity: 1;/,
     );
   });
 

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -1816,19 +1816,25 @@ body.resizing-pane [data-ghost-webview] {
 }
 
 .sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__ellipsis {
-  visibility: hidden;
+  opacity: 0;
 }
 
 .sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__track {
   visibility: visible;
   opacity: 1;
-  animation: sidebar-title-marquee calc(var(--motion-base) * 12) var(--motion-ease-move) forwards;
+  animation: sidebar-title-marquee var(--sidebar-title-marquee-duration) var(--motion-ease-move)
+    forwards;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__track {
     animation: none;
-    transform: translateX(var(--sidebar-title-marquee-shift));
+    visibility: hidden;
+    opacity: 0;
+  }
+
+  .sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__ellipsis {
+    opacity: 1;
   }
 }
 

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -1777,6 +1777,61 @@ body.resizing-pane [data-ghost-webview] {
   }
 }
 
+/* 侧栏超长任务标题：只在实际溢出且 hover 时把完整标题横向带过视口。
+   轨道是 HTML 元素，动效只改 transform/opacity，离开标题区域立即恢复省略号。 */
+@keyframes sidebar-title-marquee {
+  0%,
+  12% {
+    transform: translateX(0);
+  }
+  88%,
+  100% {
+    transform: translateX(var(--sidebar-title-marquee-shift));
+  }
+}
+
+.sidebar-title-marquee {
+  position: relative;
+  display: block;
+}
+
+.sidebar-title-marquee__ellipsis {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-title-marquee__track {
+  position: absolute;
+  inset: 0 auto auto 0;
+  width: max-content;
+  max-width: none;
+  white-space: nowrap;
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(0);
+}
+
+.sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__ellipsis {
+  visibility: hidden;
+}
+
+.sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__track {
+  visibility: visible;
+  opacity: 1;
+  animation: sidebar-title-marquee calc(var(--motion-base) * 12) var(--motion-ease-move) forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-title-marquee[data-title-overflowing='true'] .sidebar-title-marquee__track {
+    animation: none;
+    transform: translateX(var(--sidebar-title-marquee-shift));
+  }
+}
+
 /* 布局树引擎分割线(C1,LayoutRoot 渲染)——面板之间的 1px 缝由引擎统一画,
    面板自己不再画侧边框(两块时代"各画一侧"的做法在 N 块布局下会漏缝)。
    未来统一拖宽把手也落位在这条缝上。颜色走 token(规则 16)。

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -48,13 +48,14 @@
 
     /* Motion token(全局动效档位,规范见 DESIGN.md §14.4):新增过渡/动画一律
        引用这些 token,不要再各处硬编码时长和 cubic-bezier。5 档交互时长 +
-       spinner 语义循环例外 + 3 条曲线,与三档圆角同一哲学。 */
+       spinner 语义循环例外、侧栏标题阅读例外 + 3 条曲线,与三档圆角同一哲学。 */
     --motion-instant: 80ms; /* hover 即时反馈、轻浮层退场 */
     --motion-fast: 150ms; /* 颜色/透明度状态切换、轻浮层入场(§14.4 功能性过渡上限) */
     --motion-base: 200ms; /* 尺寸变化:展开折叠、面板收展 */
     --motion-enter: 250ms; /* 重浮层(弹窗)入场 */
     --motion-exit: 150ms; /* 重浮层(弹窗)退场 */
     --motion-spinner-cycle: 1000ms; /* 功能性 loading spinner 完整一圈(§14.4 窄例外) */
+    --motion-sidebar-title-marquee-per-viewport: 2400ms; /* 溢出标题每个可视宽度的阅读时长(§14.4 窄例外) */
     --motion-ease-out: cubic-bezier(0.16, 1, 0.3, 1); /* 入场/展开 */
     --motion-ease-in: cubic-bezier(0.4, 0, 1, 1); /* 退场 */
     --motion-ease-move: cubic-bezier(0.4, 0, 0.2, 1); /* 位置/尺寸插值 */
@@ -145,6 +146,7 @@
       --motion-enter: 0ms;
       --motion-exit: 0ms;
       --motion-spinner-cycle: 0ms;
+      --motion-sidebar-title-marquee-per-viewport: 0ms;
     }
 
     [class*='animate-spinner'] {

--- a/apps/mobile/src/__tests__/themeTokens.test.ts
+++ b/apps/mobile/src/__tests__/themeTokens.test.ts
@@ -44,8 +44,9 @@ describe('theme tokens', () => {
     expect(palettes.dark).toBe(darkColors);
   });
 
-  it('spinner 语义循环例外与 DESIGN.md §14.4 保持一致', () => {
+  it('语义动效例外与 DESIGN.md §14.4 保持一致', () => {
     expect(motionDuration.spinnerCycle).toBe(1000);
+    expect(motionDuration.sidebarTitleMarqueePerViewport).toBe(2400);
   });
 
   it('每个颜色 token 都是非空字符串(login 登录皮嵌套组下钻)', () => {

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -700,7 +700,8 @@ export const loginSizes = {
 /**
  * Motion token(全局动效档位,ms)——与桌面端 DESIGN.md §14.4 的 --motion-* 同名
  * 同值,双端同构。新增动效一律引用这些档位,不要在组件里硬编码时长。
- * spinnerCycle 是功能性 loading spinner 的语义循环例外,不是第六档交互时长。
+ * spinnerCycle 与 sidebarTitleMarqueePerViewport 是 §14.4 登记的语义例外,
+ * 不是额外交互时长档位。
  */
 export const motionDuration = {
   /** hover / 即时反馈、轻浮层退场 */
@@ -715,6 +716,8 @@ export const motionDuration = {
   exit: 150,
   /** 功能性 loading spinner 完整一圈(§14.4 窄例外) */
   spinnerCycle: 1000,
+  /** Desktop 侧栏溢出标题每个可视宽度的阅读时长(双端 token 同构,移动端不消费) */
+  sidebarTitleMarqueePerViewport: 2400,
 } as const;
 
 /**

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -552,7 +552,7 @@ Applies to submit-on-Enter fields: the chat composer, goal input, ask input, etc
 
 #### Motion tokens (the only tier source)
 
-Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`; mobile (`apps/mobile`) mirrors same-name same-value constants in `src/theme/tokens.ts` (dual-platform isomorphism, same policy as color tokens, landing with the mobile motion overhaul). **New transitions/animations must reference tokens — no hardcoded durations or cubic-beziers**; 5 interaction-duration tiers + 3 curves, the same philosophy as the §5 three-tier radius. Values outside the tiers require design review first. The single semantic loop-cycle exception is recorded directly below.
+Global tokens live in `:root` of `apps/desktop/src/renderer/styles/globals.css`; mobile (`apps/mobile`) mirrors same-name same-value constants in `src/theme/tokens.ts` (dual-platform isomorphism, same policy as color tokens, landing with the mobile motion overhaul). **New transitions/animations must reference tokens — no hardcoded durations or cubic-beziers**; 5 interaction-duration tiers + 3 curves, the same philosophy as the §5 three-tier radius. Values outside the tiers require design review first. Narrow semantic exceptions are recorded directly below.
 
 | Token | Value | Use |
 |---|---|---|
@@ -572,6 +572,17 @@ Spinner rotation remains linear, transform-only, mounted on an HTML wrapper, and
 must become static under reduced motion. This exception keeps loading rotation
 readable without coupling it to dialog timing or copying a hardcoded Tailwind
 default into components.
+
+**Sidebar title reading exception:** `--motion-sidebar-title-marquee-per-viewport`
+= `2400ms` is the reading time for each visible-width span of an overflowing
+Desktop sidebar task title. It is not an interaction-duration tier and is confined
+to `SidebarTitleMarquee` in `SessionItem.tsx`: actual-overflow only, pointer hover
+only, one-shot, reset immediately on pointer leave, and proportional to the number
+of viewport spans needed to reveal the full title. The track may animate only
+`transform` / `opacity`; `prefers-reduced-motion` keeps the original static
+ellipsis (with the native full-title tooltip) and disables the track. This narrow
+exception preserves readable, constant-paced title playback without allowing the
+long duration to leak into any other hover or transition.
 
 #### Semantics → motion prototypes (one semantic, one motion, app-wide)
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Desktop 左侧会话/项目任务标题增加 Codex 风格的 hover marquee：只有标题实际被省略号截断时，鼠标停留在标题区域才会横向播放完整标题；移出后立即恢复省略号。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：侧边栏过长任务标题 hover 自动播放
- 本 PR 包含：标题溢出检测、横向 marquee、离开恢复、reduced-motion 退化、相关静态回归契约
- 明确不包含：其他侧栏条目、数据模型、导航、标题生成逻辑
- 用户可见变化：可直接读取被截断的完整任务标题
- 是否存在 breaking change：无

## UI 变化

- 仅 Desktop 侧栏任务标题交互变化，不改变布局和其他条目。
- 引用的设计规范：`docs/design-rules/DESIGN.md` 动效约束；动画只使用 `transform` / `opacity`，并遵守 `prefers-reduced-motion`。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts --pool=forks --maxWorkers=2 --minWorkers=1
结果：29 tests passed

pnpm --dir apps/desktop exec eslint src/renderer/features/cc-agent/sidebar/SessionItem.tsx src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts src/renderer/__tests__/sidebarRemoteProjectIcon.test.ts
结果：通过（globals.css 由 ESLint 忽略）

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=2 --minWorkers=1
结果：1649 test files passed，20106 tests passed，2 skipped；9 个 SQLite 测试因本机缺失 apps/desktop/native/sqlite-vec/darwin-arm64/vec0.dylib.dylib 失败，与本 PR 无关
```

### 手工验证

未执行：当前环境未启动 Desktop 图形界面；交互由定向静态契约测试覆盖。

### 未执行的验证

未执行本机图形化 hover 录屏验证，原因是当前会话未启动 Desktop GUI。

## 风险

### 风险分类

- [x] 跨平台差异
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：Desktop renderer 侧栏标题展示；无持久化或协议影响。
- 回滚 / 降级方式：回滚本 PR commit 即可恢复原省略号行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
