### PR TITLE
fix(desktop): 会话切换时不再让忙闲轮询导致主进程退出

### DIFF
--- a/apps/desktop/src/main/__tests__/busyReporter.test.ts
+++ b/apps/desktop/src/main/__tests__/busyReporter.test.ts
@@ -2,12 +2,13 @@
  * busyReporter 单测 —— 被控端 busy presence 的 dedupe 与重连补正(PR #166 review New-F)。
  * 核心:hello 必须报当前真实 busy 并同步 dedupe 基线,否则 turn 进行中重连会让其它设备整轮看成空闲。
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   setBusyProbe,
   currentBusy,
   helloBusy,
   pollBusyChange,
+  pollBusyChangeSafely,
   resetBusyDedupe,
   __testing,
 } from '../device-link/busyReporter';
@@ -28,6 +29,24 @@ describe('busyReporter', () => {
     expect(pollBusyChange()).toBeNull(); // 再探仍 true → 不上报
     busy = false;
     expect(pollBusyChange()).toBe(false); // 翻回 → 上报
+  });
+
+  it('pollBusyChangeSafely:probe 在会话切换期间失败时保留基线,下一轮恢复上报', () => {
+    const switchingError = Object.assign(new Error('App session is switching'), {
+      code: 'PRECONDITION_FAILED',
+    });
+    const onError = vi.fn();
+    setBusyProbe(() => {
+      throw switchingError;
+    });
+
+    expect(pollBusyChangeSafely(onError)).toBeNull();
+    expect(onError).toHaveBeenCalledWith(switchingError);
+    expect(__testing.getLastReported()).toBe(false);
+
+    setBusyProbe(() => true);
+    expect(pollBusyChangeSafely(onError)).toBe(true);
+    expect(__testing.getLastReported()).toBe(true);
   });
 
   it('helloBusy:返回当前 busy 并把它设成 dedupe 基线', () => {

--- a/apps/desktop/src/main/device-link/busyReporter.ts
+++ b/apps/desktop/src/main/device-link/busyReporter.ts
@@ -46,6 +46,19 @@ export function pollBusyChange(): boolean | null {
   return busy;
 }
 
+/**
+ * 定时轮询入口:probe 的瞬态失败不应逃逸到 Electron 主进程。
+ * 失败时保留上一份 dedupe 基线,下一轮会重新读取真实状态并补报变化。
+ */
+export function pollBusyChangeSafely(onError: (error: unknown) => void): boolean | null {
+  try {
+    return pollBusyChange();
+  } catch (error) {
+    onError(error);
+    return null;
+  }
+}
+
 /** 登出 / 断连:重置 dedupe 基线,避免重连后首个真实 busy 状态被旧值压掉。 */
 export function resetBusyDedupe(): void {
   lastReportedBusy = false;

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -63,7 +63,7 @@ import {
   handleControllerOffline,
   purgeRevokedController,
 } from './dispatch';
-import { setBusyProbe, helloBusy, pollBusyChange, resetBusyDedupe } from './busyReporter';
+import { setBusyProbe, helloBusy, pollBusyChangeSafely, resetBusyDedupe } from './busyReporter';
 import {
   DL_VOICE_DICTIONARY_SYNC_CHANNEL,
   broadcastDictionaryNow,
@@ -825,7 +825,10 @@ function startBusyReporting(): void {
     pollExternalKeepAwakeChange();
     if (!client) return;
     pollExternalSettingsChange();
-    const busy = pollBusyChange(); // 只在 busy 与 dedupe 基线翻转时返回新值,否则 null
+    // 只在 busy 与 dedupe 基线翻转时返回新值,否则 null。
+    const busy = pollBusyChangeSafely((err) => {
+      log.warn('busy presence probe failed (will retry next tick)', err);
+    });
     if (busy === null) return;
     client.sendPresence({ busy });
   }, 5_000);


### PR DESCRIPTION
## 这次改了什么

### 摘要

Device Link 的忙闲状态会每 5 秒探测一次。账号 / Owner 会话正在切换时，这次探测会收到瞬时的 `PRECONDITION_FAILED`，原先错误会逃逸成主进程 `uncaughtException`并导致 Cindy 退出。

本 PR 为定时探测增加错误边界：本轮失败时记录 warning、保留上一份去重基线，下一轮重新读取真实状态并补报变化。同时补了会话切换错误后恢复上报的回归测试。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1358
- 本 PR 包含：Device Link 忙闲轮询的错误边界与回归测试
- 明确不包含：调整账号切换流程，或改动 Renderer IPC 的重试策略
- 用户可见变化：冷启动的账号切换窗口内，忙闲轮询的瞬时失败不再使主进程退出
- 是否存在 breaking change：无
- 远程 / 手机适配：不新增 IPC、推送事件或 wire protocol；手机与远程控制端继续消费原有 busy presence，探测恢复后会正常补报

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/busyReporter.test.ts
结果：7 tests passed

pnpm --filter desktop exec eslint src/main/device-link/busyReporter.ts src/main/device-link/index.ts src/main/__tests__/busyReporter.test.ts
结果：通过

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：通过

NODE_OPTIONS=--max-old-space-size=8192 pnpm test:unit
结果：通过（Desktop、Mobile、共享 packages 与 protocol workspaces 全部通过）
```

### 手工验证

不涉及；回归用可注入的同步 probe 精确复现。

### 未执行的验证

未在 Windows 上手工制造冷启动账号切换时序；当前开发主机为 macOS。改动不含平台分支，Windows 全量单测交由 CI 验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Device Link 每 5 秒的忙闲状态探测；失败时记录日志并等待下一轮
- 回滚 / 降级方式：回退本 PR，恢复直接调用 `pollBusyChange`

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无额外文档变更；行为与测试已就地注释）
- [x] 已确认测试结果或说明未执行原因
