### PR TITLE
fix(pi): 工具调用展示按 harness 归一化,不再只显示裸工具名

### DIFF
--- a/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
@@ -302,6 +302,29 @@ describe('AgentActionRow — 行主文案', () => {
     expect(document.body.textContent).toContain('"newString":"new"');
   });
 
+  // pi 0.83.0 的 edit 同时接受 legacy 顶层单段(LegacyEditToolInput);只认 edits[]
+  // 会让这种事件退化成空 diff 与 +0 -0。
+  it('pi edit:legacy 顶层 oldText/newText 也给出真实统计与非空 diff', () => {
+    render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'edit', {
+          path: '/repo/src/app.ts',
+          oldText: 'old A\nold B',
+          newText: 'new A',
+        }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.edited')).toBeTruthy();
+    expect(screen.getByText('app.ts')).toBeTruthy();
+    expect(screen.getByText('+1')).toBeTruthy();
+    expect(screen.getByText('-2')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button'));
+    expect(document.body.textContent).toContain('"oldString":"old A\\nold B"');
+    expect(document.body.textContent).toContain('"newString":"new A"');
+    // 空 diffs 数组会渲染成 "diffs":[] —— 明确断死它没退化。
+    expect(document.body.textContent).not.toContain('"diffs":[]');
+  });
+
   it('状态图标:running / done 经 aria-label 可达,缺省为 done', () => {
     const { rerender } = render(
       createElement(AgentActionRow, {

--- a/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts
@@ -221,6 +221,87 @@ describe('AgentActionRow — 行主文案', () => {
     expect(document.querySelector('[data-agent-action-file-chip="true"]')).toBeTruthy();
   });
 
+  it('pi bash:小写工具名照样解析出意图动词,不再是「调用 bash」', () => {
+    render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'bash', { command: 'git status' }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.gitStatus')).toBeTruthy();
+    expect(screen.queryByText('chat.agentActionRow.verb.used')).toBeNull();
+    expect(screen.queryByText('bash')).toBeNull();
+  });
+
+  it('pi bash:无法分类的命令回退为运行动词 + 命令原文', () => {
+    render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'bash', { command: 'docker ps' }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.ran')).toBeTruthy();
+    expect(screen.getByText('docker ps')).toBeTruthy();
+  });
+
+  it('pi read:path 字段渲染成文件 chip 与读取动词', () => {
+    render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'read', { path: '/repo/src/app.ts' }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.read')).toBeTruthy();
+    expect(screen.getByText('app.ts')).toBeTruthy();
+    expect(document.querySelector('[data-agent-action-file-chip="true"]')).toBeTruthy();
+  });
+
+  it('pi grep / find:搜索动词 + 搜索目标', () => {
+    const { rerender } = render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'grep', { pattern: 'TODO', path: 'src/' }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.searched')).toBeTruthy();
+    expect(screen.getByText('TODO')).toBeTruthy();
+    rerender(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'find', { pattern: '**/*.spec.ts' }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.searched')).toBeTruthy();
+    expect(screen.getByText('**/*.spec.ts')).toBeTruthy();
+  });
+
+  it('pi write:创建动词 + 行内 +N 统计,点击进共享 diff lightbox', () => {
+    render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'write', { path: '/repo/src/new.ts', content: 'a\nb' }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.created')).toBeTruthy();
+    expect(screen.getByText('new.ts')).toBeTruthy();
+    expect(screen.getByText('+2')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button'));
+    expect(document.body.textContent).toContain('"kind":"diff"');
+    expect(document.body.textContent).toContain('"filePath":"/repo/src/new.ts"');
+  });
+
+  it('pi edit:edits[].oldText/newText 汇成编辑动词与 diff lightbox', () => {
+    render(
+      createElement(AgentActionRow, {
+        message: mkTool('t1', 'edit', {
+          path: '/repo/src/app.ts',
+          edits: [{ oldText: 'old', newText: 'new' }],
+        }),
+      }),
+    );
+    expect(screen.getByText('chat.agentActionRow.verb.edited')).toBeTruthy();
+    expect(screen.getByText('app.ts')).toBeTruthy();
+    expect(screen.getByText('+1')).toBeTruthy();
+    expect(screen.getByText('-1')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button'));
+    expect(document.body.textContent).toContain('"oldString":"old"');
+    expect(document.body.textContent).toContain('"newString":"new"');
+  });
+
   it('状态图标:running / done 经 aria-label 可达,缺省为 done', () => {
     const { rerender } = render(
       createElement(AgentActionRow, {

--- a/apps/desktop/src/renderer/__tests__/diffStats.test.ts
+++ b/apps/desktop/src/renderer/__tests__/diffStats.test.ts
@@ -115,6 +115,27 @@ describe('statsForToolCall', () => {
     expect(stats).toEqual({ add: 3, del: 1 });
   });
 
+  it('pi edit: legacy top-level oldText/newText yields real counts, not +0 -0', () => {
+    expect(statsForToolCall('edit', {
+      path: '/foo',
+      oldText: 'old A\nold B',
+      newText: 'new A',
+    })).toEqual({ add: 1, del: 2 });
+  });
+
+  it('pi edit: top-level pair is counted after edits[] when both are present', () => {
+    expect(statsForToolCall('edit', {
+      path: '/foo',
+      edits: [{ oldText: 'a', newText: 'b' }], // +1 -1
+      oldText: 'c',
+      newText: 'd',                            // +1 -1
+    })).toEqual({ add: 2, del: 2 });
+  });
+
+  it('pi edit: no usable replacement returns +0 -0 (not null)', () => {
+    expect(statsForToolCall('edit', { path: '/foo' })).toEqual({ add: 0, del: 0 });
+  });
+
   it('pi write: full content as +N -0', () => {
     expect(statsForToolCall('write', { path: '/foo', content: 'a\nb' })).toEqual({
       add: 2,

--- a/apps/desktop/src/renderer/__tests__/diffStats.test.ts
+++ b/apps/desktop/src/renderer/__tests__/diffStats.test.ts
@@ -104,6 +104,30 @@ describe('statsForToolCall', () => {
     expect(statsForToolCall('MultiEdit', { edits: [] })).toEqual({ add: 0, del: 0 });
   });
 
+  it('pi edit: sums edits[].oldText/newText like MultiEdit', () => {
+    const stats = statsForToolCall('edit', {
+      path: '/foo',
+      edits: [
+        { oldText: 'a', newText: 'b' },       // +1 -1
+        { oldText: '', newText: 'x\ny' },     // +2 -0
+      ],
+    });
+    expect(stats).toEqual({ add: 3, del: 1 });
+  });
+
+  it('pi write: full content as +N -0', () => {
+    expect(statsForToolCall('write', { path: '/foo', content: 'a\nb' })).toEqual({
+      add: 2,
+      del: 0,
+    });
+  });
+
+  it('pi read-only tools stay null', () => {
+    expect(statsForToolCall('read', { path: '/foo' })).toBeNull();
+    expect(statsForToolCall('bash', { command: 'ls' })).toBeNull();
+    expect(statsForToolCall('grep', { pattern: 'foo' })).toBeNull();
+  });
+
   it('file_change: sums unified diffs across all changed files', () => {
     expect(statsForToolCall('file_change', {
       changes: [

--- a/apps/desktop/src/renderer/__tests__/verbAggregator.test.ts
+++ b/apps/desktop/src/renderer/__tests__/verbAggregator.test.ts
@@ -71,6 +71,16 @@ describe('verbForTool', () => {
     expect(verbForTool('web_search')).toBe('fetched');
   });
 
+  it('maps pi builtin lowercase tools', () => {
+    expect(verbForTool('bash')).toBe('ran');
+    expect(verbForTool('read')).toBe('read');
+    expect(verbForTool('ls')).toBe('read');
+    expect(verbForTool('edit')).toBe('edited');
+    expect(verbForTool('write')).toBe('created');
+    expect(verbForTool('grep')).toBe('searched');
+    expect(verbForTool('find')).toBe('searched');
+  });
+
   it('falls back to "used" for unknown tools', () => {
     expect(verbForTool('FooBar')).toBe('used');
     expect(verbForTool('')).toBe('used');

--- a/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
@@ -69,7 +69,8 @@ import { TextLightbox } from './TextLightbox';
 import { ToolPayloadLightbox, type ToolPayloadMode } from './ToolPayloadLightbox';
 import { useFileChipContextMenu } from './useFileChipContextMenu';
 
-const FILE_PATH_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'Read']);
+// CC 大写 + pi 小写(pi 内置工具名全小写、文件字段为 path,见 toolUseDescriptor.ts)。
+const FILE_PATH_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'Read', 'edit', 'write', 'read']);
 
 /**
  * v10 (2026-04-20): 命令类工具(Bash/Grep/Glob/WebFetch/WebSearch/...)的
@@ -451,6 +452,7 @@ function formatInlineInput(
   if (!inp) return '';
   switch (toolName) {
     case 'Bash':
+    case 'bash':
     case 'exec': {
       // description 已上移为行主文案(issue #450),这里只展示命令原文 + cwd,
       // 避免同一句话在折叠行和展开区重复出现。
@@ -458,7 +460,8 @@ function formatInlineInput(
       const cwd = typeof inp.cwd === 'string' && inp.cwd ? `cwd: ${inp.cwd}` : '';
       return cwd ? `${cmd}\n${cwd}` : cmd;
     }
-    case 'Grep': {
+    case 'Grep':
+    case 'grep': {
       const pattern = typeof inp.pattern === 'string' ? inp.pattern : '';
       const path = typeof inp.path === 'string' ? inp.path : '';
       const glob = typeof inp.glob === 'string' ? inp.glob : '';
@@ -474,10 +477,16 @@ function formatInlineInput(
         .filter(Boolean)
         .join('\n');
     }
-    case 'Glob': {
+    case 'Glob':
+    case 'find': {
       const pattern = typeof inp.pattern === 'string' ? inp.pattern : '';
       const path = typeof inp.path === 'string' ? inp.path : '';
       return path ? `${pattern}\nin: ${path}` : pattern;
+    }
+    case 'ls': {
+      // pi ls:path 可缺省(默认当前目录)。
+      const path = typeof inp.path === 'string' ? inp.path : '';
+      return path;
     }
     case 'WebFetch': {
       const url = typeof inp.url === 'string' ? inp.url : '';
@@ -536,7 +545,7 @@ function buildDiffPayload(
       ],
     };
   }
-  if (toolName === 'Write') {
+  if (toolName === 'Write' || toolName === 'write') {
     const c = typeof inp.content === 'string' ? inp.content : '';
     return {
       kind: 'diff',
@@ -545,6 +554,25 @@ function buildDiffPayload(
           key: filePath,
           filePath,
           diffs: [{ key: 'write:0', oldString: '', newString: c }],
+        },
+      ],
+    };
+  }
+  // pi edit:edits[].oldText/newText,与 MultiEdit 同款多段 diff 呈现。
+  if (toolName === 'edit') {
+    const edits = Array.isArray(inp.edits) ? inp.edits : [];
+    return {
+      kind: 'diff',
+      files: [
+        {
+          key: filePath,
+          filePath,
+          diffs: edits.map((e, index) => {
+            const er = e as Record<string, unknown> | null;
+            const o = er && typeof er.oldText === 'string' ? er.oldText : '';
+            const n = er && typeof er.newText === 'string' ? er.newText : '';
+            return { key: `edit:${index}`, oldString: String(o), newString: String(n) };
+          }),
         },
       ],
     };
@@ -719,7 +747,7 @@ export function AgentActionRow({
       return;
     }
     triggerRef.current = anchor;
-    if (toolName === 'Read' && filePath) {
+    if ((toolName === 'Read' || toolName === 'read') && filePath) {
       // 模型可能给相对路径(runtime 按会话工作目录解析后 Read 照样成功),而
       // 预览 / 定位 IPC 一律要求绝对路径 —— 先按 workingDir 补齐,镜像 runtime
       // 语义,保证 chip 打开的就是 agent 实际读到的那个文件。

--- a/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentActionRow.tsx
@@ -45,6 +45,7 @@ import { useTranslation } from 'react-i18next';
 import {
   describeToolUse,
   normalizeDisplayCommand,
+  piEditReplacements,
   type CommandIntent,
   type ToolUseDescriptor,
 } from '@cindy/maker-shared';
@@ -69,7 +70,16 @@ import { TextLightbox } from './TextLightbox';
 import { ToolPayloadLightbox, type ToolPayloadMode } from './ToolPayloadLightbox';
 import { useFileChipContextMenu } from './useFileChipContextMenu';
 
-// CC 大写 + pi 小写(pi 内置工具名全小写、文件字段为 path,见 toolUseDescriptor.ts)。
+/**
+ * 点击走「文件类」交互(diff / 文稿 / 图片 lightbox)的工具:CC 大写 + pi 小写
+ * (pi 内置工具名全小写、文件字段为 path,见 toolUseDescriptor.ts)。
+ *
+ * 注意这**不是**「所有 kind='file' 描述符」的集合:pi 的 `ls` 也被归一化成
+ * kind='file'(读取语义)并渲染文件 chip,但**刻意不列入本集合** —— 它的目标是
+ * 目录,开文稿/图片 lightbox 没有意义,因此点击仍走命令类的就地展开路径
+ * (isInlineExpand)。新增工具时按「点击后该看到什么」判断是否入列,别按
+ * 描述符 kind 判断。
+ */
 const FILE_PATH_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'Read', 'edit', 'write', 'read']);
 
 /**
@@ -558,21 +568,20 @@ function buildDiffPayload(
       ],
     };
   }
-  // pi edit:edits[].oldText/newText,与 MultiEdit 同款多段 diff 呈现。
+  // pi edit:声明 schema 的 edits[] 与 legacy 顶层 {oldText,newText} 两种形态,
+  // 由共享的 piEditReplacements 归一化(只认一种会让另一种退化成空 diff)。
   if (toolName === 'edit') {
-    const edits = Array.isArray(inp.edits) ? inp.edits : [];
     return {
       kind: 'diff',
       files: [
         {
           key: filePath,
           filePath,
-          diffs: edits.map((e, index) => {
-            const er = e as Record<string, unknown> | null;
-            const o = er && typeof er.oldText === 'string' ? er.oldText : '';
-            const n = er && typeof er.newText === 'string' ? er.newText : '';
-            return { key: `edit:${index}`, oldString: String(o), newString: String(n) };
-          }),
+          diffs: piEditReplacements(inp).map((edit, index) => ({
+            key: `edit:${index}`,
+            oldString: edit.oldText,
+            newString: edit.newText,
+          })),
         },
       ],
     };

--- a/apps/desktop/src/renderer/features/right-sidebar/lib/lastTurnChangedFiles.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/lib/lastTurnChangedFiles.ts
@@ -7,7 +7,8 @@
 
 import type { ChatMessage } from '@/lib/makerChatStore';
 
-const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+// CC 大写(file_path 字段)+ pi 小写(path 字段,见 toolUseDescriptor.ts 数据来源约定)。
+const EDIT_TOOL_NAMES = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit', 'edit', 'write']);
 
 function slashPath(p: string): string {
   return p.replace(/\\/g, '/').replace(/\/+/g, '/');
@@ -75,7 +76,7 @@ function extractToolFilePaths(msg: ChatMessage): string[] {
   const input = (msg.toolInput as Record<string, unknown> | null) ?? null;
   if (msg.toolName === 'file_change') return collectCodexFileChangePaths(input);
   if (!EDIT_TOOL_NAMES.has(msg.toolName)) return [];
-  const filePath = input?.file_path;
+  const filePath = input?.file_path ?? input?.path;
   return typeof filePath === 'string' && filePath ? [filePath] : [];
 }
 

--- a/apps/desktop/src/renderer/lib/agent-actions/diffStats.ts
+++ b/apps/desktop/src/renderer/lib/agent-actions/diffStats.ts
@@ -14,6 +14,7 @@
  */
 
 import { diffLines } from 'diff';
+import { piEditReplacements } from '@cindy/maker-shared';
 
 export interface DiffStat {
   add: number;
@@ -77,16 +78,12 @@ export function statsForToolCall(
     return computeDiffStats('', c);
   }
 
-  // pi edit:edits[].oldText/newText,逐条求和(与 MultiEdit 同形态)。
+  // pi edit:两种入参形态(edits[] + legacy 顶层单段)由共享归一化器抹平后逐段求和。
   if (toolName === 'edit') {
-    const edits = Array.isArray(inp.edits) ? inp.edits : [];
     let add = 0;
     let del = 0;
-    for (const e of edits) {
-      const er = e as Record<string, unknown> | null;
-      const o = er && typeof er.oldText === 'string' ? er.oldText : '';
-      const n = er && typeof er.newText === 'string' ? er.newText : '';
-      const s = computeDiffStats(o, n);
+    for (const edit of piEditReplacements(inp)) {
+      const s = computeDiffStats(edit.oldText, edit.newText);
       add += s.add;
       del += s.del;
     }

--- a/apps/desktop/src/renderer/lib/agent-actions/diffStats.ts
+++ b/apps/desktop/src/renderer/lib/agent-actions/diffStats.ts
@@ -71,10 +71,26 @@ export function statsForToolCall(
     return computeDiffStats(o, n);
   }
 
-  if (toolName === 'Write') {
+  if (toolName === 'Write' || toolName === 'write') {
     const c = typeof inp.content === 'string' ? inp.content : '';
     // All-add: oldStr = ''. Surface as `+N -0` per ADR-5.
     return computeDiffStats('', c);
+  }
+
+  // pi edit:edits[].oldText/newText,逐条求和(与 MultiEdit 同形态)。
+  if (toolName === 'edit') {
+    const edits = Array.isArray(inp.edits) ? inp.edits : [];
+    let add = 0;
+    let del = 0;
+    for (const e of edits) {
+      const er = e as Record<string, unknown> | null;
+      const o = er && typeof er.oldText === 'string' ? er.oldText : '';
+      const n = er && typeof er.newText === 'string' ? er.newText : '';
+      const s = computeDiffStats(o, n);
+      add += s.add;
+      del += s.del;
+    }
+    return { add, del };
   }
 
   if (toolName === 'MultiEdit') {

--- a/apps/desktop/src/renderer/lib/agent-actions/verbAggregator.ts
+++ b/apps/desktop/src/renderer/lib/agent-actions/verbAggregator.ts
@@ -71,6 +71,14 @@ const TOOL_TO_VERB: Record<string, Verb> = {
   WebFetch: 'fetched',
   WebSearch: 'fetched',
   web_search: 'fetched',
+  // pi 内置工具(全小写,见 toolUseDescriptor.ts 数据来源约定)。
+  bash: 'ran',
+  read: 'read',
+  ls: 'read',
+  edit: 'edited',
+  write: 'created',
+  grep: 'searched',
+  find: 'searched',
 };
 
 const ORDER: Verb[] = [

--- a/packages/maker-shared/src/__tests__/payloadSummary.test.ts
+++ b/packages/maker-shared/src/__tests__/payloadSummary.test.ts
@@ -142,6 +142,48 @@ describe('payloadSummary', () => {
     expect(buildPayloadToolDiff('Edit', { old_string: 'a', new_string: 'b' })).toBeUndefined();
   });
 
+  it('builds pi edit diffs from both the declared edits[] and the legacy top-level shape', () => {
+    // 声明 schema 形态:{ path, edits: [{ oldText, newText }] }。
+    expect(buildPayloadToolDiff('edit', {
+      path: '/repo/app.ts',
+      edits: [
+        { oldText: 'a', newText: 'b' },
+        { oldText: '', newText: 'c\nd' },
+      ],
+    })).toEqual({
+      deletions: 1,
+      filePath: '/repo/app.ts',
+      insertions: 3,
+      segments: [
+        { key: 'edit:0', oldString: 'a', newString: 'b', label: 'Edit 1/2' },
+        { key: 'edit:1', oldString: '', newString: 'c\nd', label: 'Edit 2/2' },
+      ],
+    });
+
+    // legacy 顶层单段:{ path, oldText, newText } —— 必须产出真实 diff 而非空段。
+    expect(buildPayloadToolDiff('edit', {
+      path: '/repo/app.ts',
+      oldText: 'old A\nold B',
+      newText: 'new A',
+    })).toEqual({
+      deletions: 2,
+      filePath: '/repo/app.ts',
+      insertions: 1,
+      segments: [{ key: 'edit:0', oldString: 'old A\nold B', newString: 'new A' }],
+    });
+
+    // pi write 用 path + content。
+    expect(buildPayloadToolDiff('write', {
+      path: '/repo/new.ts',
+      content: 'line A\nline B',
+    })).toEqual({
+      deletions: 0,
+      filePath: '/repo/new.ts',
+      insertions: 2,
+      segments: [{ key: 'write:0', oldString: '', newString: 'line A\nline B' }],
+    });
+  });
+
   it('summarizes payload chrome data without UI dependencies', () => {
     expect(summarizeMessagePayload(buildDiffPayload(diff))).toEqual({
       kind: 'diff',

--- a/packages/maker-shared/src/__tests__/toolUseDescriptor.test.ts
+++ b/packages/maker-shared/src/__tests__/toolUseDescriptor.test.ts
@@ -184,6 +184,68 @@ describe('describeToolUse — file tools', () => {
   });
 });
 
+describe('describeToolUse — pi builtin tools (lowercase, path field)', () => {
+  it('maps pi bash to command with local intent (schema has no description field)', () => {
+    expect(describeToolUse('bash', { command: 'git status' })).toEqual({
+      kind: 'command',
+      toolName: 'bash',
+      command: 'git status',
+      intent: { action: 'gitStatus' },
+    });
+    expect(describeToolUse('bash', { command: 'docker ps' })).toEqual({
+      kind: 'command',
+      toolName: 'bash',
+      command: 'docker ps',
+    });
+  });
+
+  it('maps pi read/edit/write/ls to file actions via the path field', () => {
+    expect(describeToolUse('read', { path: '/repo/src/app.ts' })).toEqual({
+      kind: 'file',
+      toolName: 'read',
+      action: 'read',
+      filePath: '/repo/src/app.ts',
+      fileName: 'app.ts',
+    });
+    expect(describeToolUse('edit', {
+      path: '/repo/a.ts',
+      edits: [{ oldText: 'a', newText: 'b' }],
+    })).toMatchObject({ kind: 'file', action: 'edit', fileName: 'a.ts' });
+    expect(describeToolUse('write', { path: '/repo/new.ts', content: 'x' })).toMatchObject({
+      kind: 'file',
+      action: 'create',
+      fileName: 'new.ts',
+    });
+    expect(describeToolUse('ls', { path: '/repo/src' })).toMatchObject({
+      kind: 'file',
+      action: 'read',
+      fileName: 'src',
+    });
+  });
+
+  it('degrades pi ls without path (defaults to cwd) to generic', () => {
+    expect(describeToolUse('ls', {})).toEqual({ kind: 'generic', toolName: 'ls' });
+  });
+
+  it('maps pi grep to grep-mode and pi find (glob pattern) to glob-mode search', () => {
+    expect(describeToolUse('grep', { pattern: 'TODO', path: 'src/', glob: '*.ts' })).toEqual({
+      kind: 'search',
+      toolName: 'grep',
+      mode: 'grep',
+      pattern: 'TODO',
+      path: 'src/',
+      glob: '*.ts',
+    });
+    expect(describeToolUse('find', { pattern: '**/*.spec.ts' })).toEqual({
+      kind: 'search',
+      toolName: 'find',
+      mode: 'glob',
+      pattern: '**/*.spec.ts',
+    });
+    expect(describeToolUse('grep', {})).toEqual({ kind: 'generic', toolName: 'grep' });
+  });
+});
+
 describe('describeToolUse — Codex file_change', () => {
   it('normalizes add/update/delete and rename changes', () => {
     expect(describeToolUse('file_change', {

--- a/packages/maker-shared/src/__tests__/toolUseDescriptor.test.ts
+++ b/packages/maker-shared/src/__tests__/toolUseDescriptor.test.ts
@@ -3,6 +3,7 @@ import {
   describeToolUse,
   humanizeToolToken,
   parseToolName,
+  piEditReplacements,
   truncateToolText,
 } from '../toolUseDescriptor';
 
@@ -227,6 +228,15 @@ describe('describeToolUse — pi builtin tools (lowercase, path field)', () => {
     expect(describeToolUse('ls', {})).toEqual({ kind: 'generic', toolName: 'ls' });
   });
 
+  it('maps pi read/edit/write/ls to file actions regardless of edit input shape', () => {
+    // legacy 顶层形态也必须仍然是 file/edit 描述符(路径来自 path)。
+    expect(describeToolUse('edit', {
+      path: '/repo/a.ts',
+      oldText: 'x',
+      newText: 'y',
+    })).toMatchObject({ kind: 'file', action: 'edit', fileName: 'a.ts' });
+  });
+
   it('maps pi grep to grep-mode and pi find (glob pattern) to glob-mode search', () => {
     expect(describeToolUse('grep', { pattern: 'TODO', path: 'src/', glob: '*.ts' })).toEqual({
       kind: 'search',
@@ -439,5 +449,53 @@ describe('helpers', () => {
   it('truncates display text with ellipsis', () => {
     expect(truncateToolText('short', 10)).toBe('short');
     expect(truncateToolText('a'.repeat(12), 10)).toBe(`${'a'.repeat(7)}...`);
+  });
+});
+
+describe('piEditReplacements', () => {
+  it('reads the declared edits[] shape in order', () => {
+    expect(piEditReplacements({
+      path: '/repo/a.ts',
+      edits: [{ oldText: 'a', newText: 'b' }, { oldText: 'c', newText: 'd' }],
+    })).toEqual([
+      { oldText: 'a', newText: 'b' },
+      { oldText: 'c', newText: 'd' },
+    ]);
+  });
+
+  it('reads the legacy top-level { oldText, newText } single replacement', () => {
+    expect(piEditReplacements({ path: '/repo/a.ts', oldText: 'x', newText: 'y' })).toEqual([
+      { oldText: 'x', newText: 'y' },
+    ]);
+  });
+
+  it('appends the top-level pair after edits[], mirroring pi normalizeEditInput', () => {
+    expect(piEditReplacements({
+      path: '/repo/a.ts',
+      edits: [{ oldText: 'a', newText: 'b' }],
+      oldText: 'x',
+      newText: 'y',
+    })).toEqual([
+      { oldText: 'a', newText: 'b' },
+      { oldText: 'x', newText: 'y' },
+    ]);
+  });
+
+  it('keeps pure insert/delete segments and fills the missing side with an empty string', () => {
+    expect(piEditReplacements({ edits: [{ newText: 'added' }, { oldText: 'removed' }] })).toEqual([
+      { oldText: '', newText: 'added' },
+      { oldText: 'removed', newText: '' },
+    ]);
+  });
+
+  it('ignores unusable input instead of throwing', () => {
+    expect(piEditReplacements(null)).toEqual([]);
+    expect(piEditReplacements('oops')).toEqual([]);
+    expect(piEditReplacements({ path: '/repo/a.ts' })).toEqual([]);
+    expect(piEditReplacements({ edits: 'nope' })).toEqual([]);
+    expect(piEditReplacements({ edits: [null, 42, {}] })).toEqual([]);
+    // 顶层只给一半不成段(pi 自己也要求两侧都是字符串才归一化)。
+    expect(piEditReplacements({ oldText: 'x' })).toEqual([]);
+    expect(piEditReplacements({ newText: 'y' })).toEqual([]);
   });
 });

--- a/packages/maker-shared/src/payloadSummary.ts
+++ b/packages/maker-shared/src/payloadSummary.ts
@@ -1,3 +1,5 @@
+import { piEditReplacements } from './toolUseDescriptor.js';
+
 export type PayloadKind = 'text' | 'diff' | 'media' | 'mermaid' | 'file';
 
 export interface PayloadToolDiffLike {
@@ -252,18 +254,16 @@ export function buildPayloadToolDiff(toolName: string, input: unknown): PayloadT
     const newString = typeof inp.content === 'string' ? inp.content : '';
     return createPayloadToolDiff(filePath, [{ key: 'write:0', oldString: '', newString }]);
   }
-  // pi edit:edits[].oldText/newText(与 MultiEdit 同款多段 diff)。
+  // pi edit:两种入参形态由 piEditReplacements 统一归一化(edits[] + legacy 顶层单段)。
   if (toolName === 'edit') {
-    const edits = Array.isArray(inp.edits) ? inp.edits : [];
-    return createPayloadToolDiff(filePath, edits.map((edit, index) => {
-      const record = readPayloadRecord(edit);
-      return {
-        key: `edit:${index}`,
-        oldString: typeof record?.oldText === 'string' ? record.oldText : '',
-        newString: typeof record?.newText === 'string' ? record.newText : '',
-        label: `Edit ${index + 1}/${edits.length}`,
-      };
-    }));
+    const replacements = piEditReplacements(inp);
+    return createPayloadToolDiff(filePath, replacements.map((edit, index) => ({
+      key: `edit:${index}`,
+      oldString: edit.oldText,
+      newString: edit.newText,
+      // 单段时不标 1/1 —— 顶层 legacy 形态就是单段,标号只是噪音。
+      ...(replacements.length > 1 ? { label: `Edit ${index + 1}/${replacements.length}` } : {}),
+    })));
   }
   if (toolName === 'MultiEdit') {
     const edits = Array.isArray(inp.edits) ? inp.edits : [];

--- a/packages/maker-shared/src/payloadSummary.ts
+++ b/packages/maker-shared/src/payloadSummary.ts
@@ -216,6 +216,14 @@ export function formatPayloadToolUseSummary(toolName: string, input: unknown): s
     Bash: ['command'],
     Glob: ['pattern'],
     Grep: ['pattern'],
+    // pi 内置工具:名字全小写、文件参数为 path(见 toolUseDescriptor.ts 数据来源约定)。
+    read: ['path'],
+    edit: ['path'],
+    write: ['path'],
+    ls: ['path'],
+    bash: ['command'],
+    grep: ['pattern'],
+    find: ['pattern'],
   };
   const keys = keyParamMap[toolName];
   if (!keys) return `${toolName}()`;
@@ -240,9 +248,22 @@ export function buildPayloadToolDiff(toolName: string, input: unknown): PayloadT
     const newString = typeof inp.new_string === 'string' ? inp.new_string : '';
     return createPayloadToolDiff(filePath, [{ key: 'edit:0', oldString, newString }]);
   }
-  if (toolName === 'Write') {
+  if (toolName === 'Write' || toolName === 'write') {
     const newString = typeof inp.content === 'string' ? inp.content : '';
     return createPayloadToolDiff(filePath, [{ key: 'write:0', oldString: '', newString }]);
+  }
+  // pi edit:edits[].oldText/newText(与 MultiEdit 同款多段 diff)。
+  if (toolName === 'edit') {
+    const edits = Array.isArray(inp.edits) ? inp.edits : [];
+    return createPayloadToolDiff(filePath, edits.map((edit, index) => {
+      const record = readPayloadRecord(edit);
+      return {
+        key: `edit:${index}`,
+        oldString: typeof record?.oldText === 'string' ? record.oldText : '',
+        newString: typeof record?.newText === 'string' ? record.newText : '',
+        label: `Edit ${index + 1}/${edits.length}`,
+      };
+    }));
   }
   if (toolName === 'MultiEdit') {
     const edits = Array.isArray(inp.edits) ? inp.edits : [];

--- a/packages/maker-shared/src/toolUseDescriptor.ts
+++ b/packages/maker-shared/src/toolUseDescriptor.ts
@@ -19,6 +19,9 @@ import {
  * - Codex：shell 工具 toolName='exec'（input 无 description，`displayCommand`
  *   是解包 POSIX / PowerShell wrapper 后的展示命令）；MCP 为 `mcp:server:tool`，另有
  *   `dynamic:ns:tool` / `collab:tool` / `web_search`。
+ * - pi：内置工具名全小写（bash/read/edit/write/grep/find/ls），文件参数字段为
+ *   `path`（fileDescriptor 已双认 file_path/path）；bash 无 description 字段，
+ *   桥接 MCP 复用 Claude Code 的 `mcp__server__tool` 形态。
  */
 
 // ── 工具名拆解 ───────────────────────────────────────────────────────────────
@@ -221,10 +224,13 @@ export function describeToolUse(toolName: string, input: unknown): ToolUseDescri
   }
 
   switch (toolName) {
-    case 'Bash': {
+    // pi 内置 bash 与 Claude Code Bash 同构:input.command 必有,description
+    // 仅 CC 会填(pi schema 无此字段,自然走 intent 兜底),共用一条路径。
+    case 'Bash':
+    case 'bash': {
       const description = readNonEmptyString(inp?.description);
       const command = readNonEmptyString(inp?.command) ?? '';
-      // description 缺失（模型漏填 / codex exec 无此字段）才兜底算 intent。
+      // description 缺失（模型漏填 / pi bash 无此字段）才兜底算 intent。
       const intent = description ? undefined : commandIntentFromCommand(command);
       return {
         kind: 'command',
@@ -251,14 +257,24 @@ export function describeToolUse(toolName: string, input: unknown): ToolUseDescri
     case 'file_change':
       return fileChangeDescriptor(toolName, inp);
     case 'Read':
+    case 'read':
+    // pi ls 目标是目录,读取语义与 read 同档;path 可缺省(默认当前目录),
+    // 缺省时 fileDescriptor 自然降级 generic。
+    case 'ls':
       return fileDescriptor(toolName, 'read', inp);
     case 'Edit':
     case 'MultiEdit':
+    case 'edit':
       return fileDescriptor(toolName, 'edit', inp);
     case 'Write':
+    case 'write':
       return fileDescriptor(toolName, 'create', inp);
+    // pi grep/find 与 CC Grep/Glob 同构:pattern 必有,path/glob 可选;
+    // find 的 pattern 是 glob 表达式,归 glob 模式。
     case 'Grep':
-    case 'Glob': {
+    case 'Glob':
+    case 'grep':
+    case 'find': {
       const pattern = readNonEmptyString(inp?.pattern);
       if (!pattern) return genericDescriptor(toolName, inp);
       const path = readNonEmptyString(inp?.path);
@@ -266,7 +282,7 @@ export function describeToolUse(toolName: string, input: unknown): ToolUseDescri
       return {
         kind: 'search',
         toolName,
-        mode: toolName === 'Grep' ? 'grep' : 'glob',
+        mode: toolName === 'Grep' || toolName === 'grep' ? 'grep' : 'glob',
         pattern,
         ...(path ? { path } : {}),
         ...(glob ? { glob } : {}),

--- a/packages/maker-shared/src/toolUseDescriptor.ts
+++ b/packages/maker-shared/src/toolUseDescriptor.ts
@@ -164,6 +164,44 @@ export type ToolUseDescriptor =
     }
   | { kind: 'generic'; toolName: string; detail?: string };
 
+/** pi `edit` 的一段定向替换。 */
+export interface PiEditReplacement {
+  oldText: string;
+  newText: string;
+}
+
+/**
+ * 归一化 pi `edit` 工具的替换段。
+ *
+ * pi v0.83.0 的 `edit` 有**两种**入参形态，展示层必须都认（`edit.ts` 的
+ * `editSchema` 与 `LegacyEditToolInput` / `normalizeEditInput`）：
+ *  - 声明 schema（模型被要求产出的形态）：`{ path, edits: [{ oldText, newText }] }`；
+ *  - legacy 顶层单段：`{ path, oldText, newText }` —— pi 自己仍接受并归一化。
+ *
+ * 顺序与 pi 的 `normalizeEditInput` 对齐：先取 `edits[]`，再把顶层
+ * `oldText`/`newText`（两者都是字符串才认）作为**最后一段**追加。只认其中之一
+ * 会让另一种形态退化成空 diff 与 `+0 -0`。
+ */
+export function piEditReplacements(input: unknown): PiEditReplacement[] {
+  const inp = readRecord(input);
+  if (!inp) return [];
+  const out: PiEditReplacement[] = [];
+  if (Array.isArray(inp.edits)) {
+    for (const raw of inp.edits) {
+      const rec = readRecord(raw);
+      // 单段内只要有一侧是字符串就成段(另一侧按空串)，纯增/纯删才不会被丢掉。
+      const oldText = typeof rec?.oldText === 'string' ? rec.oldText : undefined;
+      const newText = typeof rec?.newText === 'string' ? rec.newText : undefined;
+      if (oldText === undefined && newText === undefined) continue;
+      out.push({ oldText: oldText ?? '', newText: newText ?? '' });
+    }
+  }
+  if (typeof inp.oldText === 'string' && typeof inp.newText === 'string') {
+    out.push({ oldText: inp.oldText, newText: inp.newText });
+  }
+  return out;
+}
+
 /** 下划线（含双下划线）转空格并收敛连续空白，得到可读的 token。 */
 export function humanizeToolToken(token: string): string {
   return token.replace(/_+/g, ' ').replace(/\s+/g, ' ').trim();


### PR DESCRIPTION
## 这次改了什么

### 摘要

PI harness 会话里的工具调用在界面上只显示裸工具名（每行都是「调用 bash」「调用 read」），
看不到命令原文、文件名和搜索模式，可读性明显低于 Claude Code 与 Codex 会话。

根因不在 PI 事件层——`translator.ts` 已经把 `toolName + input` 原样发成 `tool_use` 事件；
问题在展示层的共享解析器 `describeToolUse`：它的 switch 只认 Claude Code 的大写工具名
（`Bash`/`Read`/`Edit`…）和 Codex 的名字（`exec`/`file_change`…），而 PI 内置工具名**全小写**
（`bash`/`read`/`edit`/`write`/`grep`/`find`/`ls`）、文件参数字段是 `path` 而不是 `file_path`。
对不上就全部落进 `generic` 分支，行级动词兜底成「调用」，参数位只剩工具名。

本 PR 把 PI 内置工具接进同一条展示产线，不再为 PI 单开一套渲染。

顺带说明：权限弹窗那侧早就踩过并修过同一个坑（`PermissionPrompt.formatToolInput` 专门做了
harness 无关归一化，`docs/dev-rules/pi-harness.md` 维护不变量第 6 条还明文要求它 harness 无关），
只是这条归一化当时没有推广到聊天流的工具行展示层。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（使用 PI 会话时发现）
- 本 PR 包含：把 PI 内置工具名与参数字段接入现有工具调用展示产线（解析、动词、diff 统计、
  行内详情与 diff 预览、最近一轮改动路径、mobile payload 六处消费端同一口径）；其中 PI `edit`
  的两种入参形态由新增的共享归一化器 `piEditReplacements` 统一处理，三处 diff 消费端共用它
- 明确不包含：不改 PI 事件翻译层，不改权限弹窗，不新增任何 UI 组件、样式、token 或 i18n 文案，
  不动 Claude Code / Codex 既有行为
- 用户可见变化：PI 会话的工具行从「调用 bash」变成与其它 harness 一致的人话摘要——
  `bash` 走意图解析（`git status` → 「查看 git 状态」，无法分类时「运行」+ 命令原文）、
  `read`/`ls` → 「读取」+ 文件 chip、`edit`/`write` → 「编辑」/「创建」+ `+N -N` 与 diff 预览、
  `grep`/`find` → 「搜索」+ 搜索目标；灵动岛与手机端同款收益
- 是否存在 breaking change：无

#### PI `edit` 的两种入参形态（review 中确认的关键事实）

pi v0.83.0 的 `packages/coding-agent/src/core/tools/edit.ts` **同时**存在两种形态，展示层必须
都认，只认一种会让另一种退化成空 diff 与 `+0 -0`：

- 声明 schema（`editSchema`，模型被要求产出的形态）：`{ path, edits: [{ oldText, newText }] }`
- legacy 顶层单段（`LegacyEditToolInput`，pi 自己仍接受）：`{ path, oldText, newText }`

pi 的 `normalizeEditInput` 在顶层两侧都是字符串时，把它作为**最后一段**追加到 `edits[]` 之后。
`piEditReplacements` 严格对齐这个顺序，避免展示层与 pi 自身的解释产生分歧。

### UI 变化

PI 会话工具行的**文案与参数位内容**变化（见上方「用户可见变化」）；行的布局、颜色、间距、
圆角、动效一律不变，复用现有 `AgentActionRow` 组件与现有 i18n key，未新增任何字符串或样式。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 Typography（层级由字号+字重承担）与
  §7 Do「Use monospace for terminal commands and code — it's primary content, not decoration」——
  PI 的命令原文现在和 CC/Codex 一样进入既有等宽命令区展示，而不是以裸工具名混在正文里；
  §2 调色板与 §5 间距未触及，无新增 token。双模式交付门槛不触发：本 PR 不含任何新样式或
  颜色分支，PI 行走的就是 CC/Codex 行已通过双模式的同一套 themed 样式。

## 怎么验证的

### 自动验证

在合入最新 `upstream/main` 后的最终树上执行：

```text
pnpm test:unit
结果：通过（EXIT=0）

pnpm --filter @cindy/maker-shared test
结果：52 文件 / 772 用例 全部通过

pnpm --filter desktop test
结果：1654 文件 / 20161 用例通过、2 skipped（首轮全量；二轮定向跑受影响的 3 个文件 57 用例全通过）

pnpm --filter @cindy/maker-shared run --if-present typecheck
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过（需 NODE_OPTIONS=--max-old-space-size=8192；见下方「未执行的验证」）

pnpm check:dco
结果：通过

pnpm check:i18n-glossary
结果：en / zh-CN / ja / ko 无新增违规（本 PR 未新增 UI 文案）
```

新增回归覆盖：

- `packages/maker-shared/src/__tests__/toolUseDescriptor.test.ts`：PI 小写工具名 → 各 descriptor
  形态（`bash` 意图解析、`path` 取文件名、`find` 归 glob 模式、`ls` 无 path 时降级 generic）；
  另有 `piEditReplacements` 专项：`edits[]` 形态、legacy 顶层形态、两者并存时的追加顺序、
  纯增/纯删单段保留、残缺输入不抛异常
- `apps/desktop/src/renderer/__tests__/diffStats.test.ts`：PI `edit` 两种形态的统计（顶层形态
  必须给出真实 `+1 -2` 而不是 `+0 -0`）、并存时顶层段计入、无可用段返回 `+0 -0`
- `apps/desktop/src/renderer/__tests__/verbAggregator.test.ts`：PI 工具的行级动词映射
- `apps/desktop/src/renderer/__tests__/agentActionRowRendering.test.ts`：7 条 **DOM 级**断言，
  直接验证 PI 行渲染出的用户可见文案与交互（动词 label、文件 chip、`+N -N`、点击进 diff
  lightbox），含 legacy 顶层形态显式断死不出现 `"diffs":[]`
- `packages/maker-shared/src/__tests__/payloadSummary.test.ts`：mobile payload 侧两种 `edit`
  形态与 `write` 的 diff 段落

### 手工验证

未在实机 PI 会话中目检。本次改动是工具名/字段的映射，无视觉与布局变化，因此改用上面的
DOM 级渲染断言直接验证用户可见输出（动词文案、文件 chip、diff 统计、点击后的 diff 预览
内容），比肉眼看单行文案更能锁住回归。

### 未执行的验证

- **实机 PI 会话目检**：未做，理由同上（无视觉变化 + 已有 DOM 级断言覆盖用户可见输出）。
  复核步骤很短：开一个 PI 会话，让它跑一次 `bash`、读一个文件、改一个文件，确认工具行显示
  人话摘要而不是「调用 bash」，且编辑行能点开非空 diff。
- **手机端实机**：未做。mobile 侧改动只有 `payloadSummary.ts` 的 PI `write`/`edit` diff 与
  工具摘要取值，与桌面端共用同一份 `describeToolUse` / `piEditReplacements`，由上述单测覆盖。
- **desktop typecheck 的默认堆**：`pnpm --filter desktop typecheck` 在本机默认 Node 堆
  （~4GB）下 OOM，抬到 8GB 后通过。这是仓库规模的既有容量问题，不是本 PR 引入（本 PR 只改
  11 个文件），**未在本 PR 内改动任何工程配置**去处理它。

### 关于 Windows CI 红（非本 PR 引入，已定位）

首轮 head 上的 Windows unit tests 失败共三处，全部与本 PR 无关，已逐个定性：

| 失败 | 定性 | 证据 |
| --- | --- | --- |
| `voice-input/__tests__/VoiceInputSection.recordingGate.test.ts` 源码正则断言 | **main 基线稳定失败**，已有 issue #1448，修复 PR #1440 已并入 main | main 自己的 client-ci（head `227dabf8`）以同一用例、同一断言失败；本 PR 未触碰 `voice-input/**` |
| `maker-host/__tests__/grokOauthCallbackListener.test.ts`（`listen EACCES 127.0.0.1:56121`） | Windows runner 端口权限 flake | 零代码改动重跑后该 shard 转绿 |
| `packages/device-link/src/__tests__/client.test.ts:2835`（8ms ping 周期计时断言） | 计时 flake | 同上，零改动重跑转绿 |

处理方式：**没有在本 PR 内改这三个文件**（均属其它模块，改进来只会扩大本 PR 的评审面）。
本轮已合入最新 `upstream/main`，带上 #1440 的 CRLF 断言修复，基线那条随之解决。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：纯展示层。只新增小写工具名分支，Claude Code / Codex 的既有分支一字未改，
  历史消息也只是渲染路径变化（数据未迁移、未改写）。新增分支只在工具名精确等于 PI 内置
  名时命中：MCP / dynamic / collab 工具在 switch 之前就已按命名空间前缀解析掉，不受影响。
  最坏情况是某个非 PI harness 恰好也用同名小写工具但字段语义不同——此时降级表现与今天
  一致（走 generic 兜底），不会报错或丢信息。
- 回滚 / 降级方式：`git revert` 功能提交即可完全恢复原展示行为，无数据或配置残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
