### PR TITLE
fix(orca): 补上「Orca Worker 不能替代 subagent」的对称规则

### DIFF
--- a/packages/lizi-mcps/src/__tests__/createWorkerTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/createWorkerTool.test.ts
@@ -54,7 +54,8 @@ describe('create_worker tool', () => {
     const { registry } = setup();
 
     expect(registry.get('create_worker')?.description).toContain(
-      '注:create_worker 建的是 Orca worker(session 级、持久、UI 可见),不是 subagent。若用户要的是 subagent(一次性、用完即弃),请用原生 subagent 机制(Codex:spawn_agent;Claude Code:Task 工具),不要用 create_worker。',
+      '注:create_worker 建的是 Orca worker(session 级、持久、UI 可见),不是 subagent。若用户要的是 subagent(一次性、用完即弃),请用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task 工具),不要用 create_worker。'
+        + 'Orca worker 永远不是 subagent 的替代品;你没有原生 subagent 机制时,如实告知用户并请他决定,不要拿 worker 顶替。',
     );
     expect(registry.get('create_worker')?.description).toContain(
       '用户一次要求创建 2 个及以上 Worker 时必须改用 create_workers；不要并行或连续多次调用 create_worker。',
@@ -197,7 +198,7 @@ describe('create_worker tool', () => {
       ok: false,
       errorCode: 'WORKER_CANNOT_NEST',
       data: {
-        hint: 'create_worker 是 Orca Lead 创建 worker session 的入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(Codex:spawn_agent;Claude Code:Task/Agent 工具),不要使用 Orca create_worker / start_team。',
+        hint: 'create_worker 是 Orca Lead 创建 worker session 的入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task/Agent 工具),不要使用 Orca create_worker / start_team。没有原生 subagent 机制时如实告知用户,Orca worker 不是它的替代品。',
       },
     });
     expect(createWorker).not.toHaveBeenCalled();

--- a/packages/lizi-mcps/src/__tests__/startTeamTool.test.ts
+++ b/packages/lizi-mcps/src/__tests__/startTeamTool.test.ts
@@ -22,7 +22,8 @@ describe('start_team tool', () => {
     });
 
     expect(registry.get('start_team')?.description).toContain(
-      '注:start_team 开启的是 session 级、持久、UI 可见的多 worker 协同。若用户要的是一个 subagent(一次性、用完即弃的子任务执行体),请用你自己的原生 subagent 机制(Codex:spawn_agent;Claude Code:Task 工具),不要为此 start_team 开协同。',
+      '注:start_team 开启的是 session 级、持久、UI 可见的多 worker 协同。若用户要的是一个 subagent(一次性、用完即弃的子任务执行体),请用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task 工具),不要为此 start_team 开协同。'
+        + 'Orca 协同永远不是 subagent 的替代品;你没有原生 subagent 机制时,如实告知用户并请他决定,不要拿 Orca 顶替,也不要自己起进程冒充。',
     );
   });
 
@@ -45,7 +46,7 @@ describe('start_team tool', () => {
       ok: false,
       errorCode: 'WORKER_CANNOT_NEST',
       data: {
-        hint: 'start_team 是 Orca worker 协同入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(Codex:spawn_agent;Claude Code:Task/Agent 工具),不要使用 Orca start_team / create_worker。',
+        hint: 'start_team 是 Orca worker 协同入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task/Agent 工具),不要使用 Orca start_team / create_worker。没有原生 subagent 机制时如实告知用户,Orca 协同不是它的替代品。',
       },
     });
     expect(startTeam).not.toHaveBeenCalled();

--- a/packages/lizi-mcps/src/xdt-helper/create_worker.ts
+++ b/packages/lizi-mcps/src/xdt-helper/create_worker.ts
@@ -110,7 +110,8 @@ export function toWorkerLimitPayload(limit: WorkerLimitSnapshot | undefined): Re
 
 const DESCRIPTION = [
   '在当前 workflow 内创建新 worker session。',
-  '注:create_worker 建的是 Orca worker(session 级、持久、UI 可见),不是 subagent。若用户要的是 subagent(一次性、用完即弃),请用原生 subagent 机制(Codex:spawn_agent;Claude Code:Task 工具),不要用 create_worker。',
+  '注:create_worker 建的是 Orca worker(session 级、持久、UI 可见),不是 subagent。若用户要的是 subagent(一次性、用完即弃),请用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task 工具),不要用 create_worker。' +
+  'Orca worker 永远不是 subagent 的替代品;你没有原生 subagent 机制时,如实告知用户并请他决定,不要拿 worker 顶替。',
   '用户一次要求创建 2 个及以上 Worker 时必须改用 create_workers；不要并行或连续多次调用 create_worker。',
   '',
   '参数:',
@@ -151,7 +152,7 @@ export function registerCreateWorkerTool(
       if (ctx.vendorOptions?.orcaRole === 'worker') {
         return errorPayload(
           'WORKER_CANNOT_NEST',
-          'create_worker 是 Orca Lead 创建 worker session 的入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(Codex:spawn_agent;Claude Code:Task/Agent 工具),不要使用 Orca create_worker / start_team。',
+          'create_worker 是 Orca Lead 创建 worker session 的入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task/Agent 工具),不要使用 Orca create_worker / start_team。没有原生 subagent 机制时如实告知用户,Orca worker 不是它的替代品。',
         );
       }
       const result = await deps.createWorker({

--- a/packages/lizi-mcps/src/xdt-helper/start_team.ts
+++ b/packages/lizi-mcps/src/xdt-helper/start_team.ts
@@ -26,7 +26,8 @@ export interface StartTeamDeps {
 const DESCRIPTION =
   '为当前 session 创建 orca team, 进入多 worker 协同模式。' +
   '失败码: LEAD_NOT_SUPPORTED / WORKER_CANNOT_NEST / ALREADY_ENABLED。' +
-  '注:start_team 开启的是 session 级、持久、UI 可见的多 worker 协同。若用户要的是一个 subagent(一次性、用完即弃的子任务执行体),请用你自己的原生 subagent 机制(Codex:spawn_agent;Claude Code:Task 工具),不要为此 start_team 开协同。';
+  '注:start_team 开启的是 session 级、持久、UI 可见的多 worker 协同。若用户要的是一个 subagent(一次性、用完即弃的子任务执行体),请用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task 工具),不要为此 start_team 开协同。' +
+  'Orca 协同永远不是 subagent 的替代品;你没有原生 subagent 机制时,如实告知用户并请他决定,不要拿 Orca 顶替,也不要自己起进程冒充。';
 
 export function registerStartTeamTool(
   registry: XdtHelperToolRegistry,
@@ -49,7 +50,7 @@ export function registerStartTeamTool(
       if (role === 'worker') {
         return errorPayload(
           'WORKER_CANNOT_NEST',
-          'start_team 是 Orca worker 协同入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(Codex:spawn_agent;Claude Code:Task/Agent 工具),不要使用 Orca start_team / create_worker。',
+          'start_team 是 Orca worker 协同入口,不是 subagent 入口。若用户明确要求 subagent / 子代理,请使用你自己的原生 subagent 机制(如 Codex 的 spawn_agent、Claude Code 的 Task/Agent 工具),不要使用 Orca start_team / create_worker。没有原生 subagent 机制时如实告知用户,Orca 协同不是它的替代品。',
         );
       }
       if (role === 'lead') {

--- a/packages/orca-workflow/src/__tests__/orca-bridge-prompt.test.ts
+++ b/packages/orca-workflow/src/__tests__/orca-bridge-prompt.test.ts
@@ -33,9 +33,25 @@ describe('renderOrcaLeadSystemPrompt', () => {
 
     expect(prompt).toContain(workerRoutingRule);
     expect(prompt).toContain(nativeSubagentBoundary);
-    expect(prompt).toContain('Codex: spawn_agent; Claude Code: the Agent/Task tool');
+    expect(prompt).toContain('for example Codex spawn_agent, or the Claude Code Agent/Task tool');
     expect(prompt).not.toContain('followup_task');
     expect(prompt.indexOf(workerRoutingRule)).toBeLessThan(prompt.indexOf(nativeSubagentBoundary));
+  });
+
+  it('forbids substituting an Orca Worker for a subagent, and demands honesty when the harness has none', () => {
+    // Orca Worker 是 session 级协同者,subagent 是 agent 内部的一次性执行体 —— 两者
+    // 不可互换。此前引导只写了「native subagent 不满足 Orca 派单」这一半,缺了反方向,
+    // 且只列举 Codex / Claude Code 两家机制;没有原生机制的 harness(如 pi)因此被推向
+    // 它唯一看得见的 Orca 工具,表现为「误开协同模式」。
+    const prompt = renderOrcaLeadSystemPrompt(null);
+
+    expect(prompt).toContain('An Orca Worker is NEVER a substitute for a subagent.');
+    expect(prompt).toContain(
+      'If you have no native subagent mechanism, say so plainly and ask the user how to proceed',
+    );
+    expect(prompt).toContain('do NOT open or reuse an Orca Worker to satisfy a subagent request');
+    // 兜底路径也不许自己起进程冒充 subagent。
+    expect(prompt).toContain('do NOT improvise one by spawning processes yourself');
   });
 
   it('requires execution-channel disclosure and terminal-state verification', () => {
@@ -110,7 +126,7 @@ describe('renderOrcaLeadSystemPrompt', () => {
 
 describe('renderOrcaWorkerSystemPrompt', () => {
   const subagentHint =
-    'If the user asks for a "subagent" / "子代理", use your native subagent mechanism (Codex: spawn_agent; Claude Code: the Agent/Task tool) to handle it yourself — do NOT escalate to the lead for it, and do NOT call start_team / create_worker (you cannot create Orca workers).';
+    'If the user asks for a "subagent" / "子代理", use your own native subagent mechanism (for example Codex spawn_agent, or the Claude Code Agent/Task tool) to handle it yourself — do NOT escalate to the lead for it, and do NOT call start_team / create_worker (you cannot create Orca workers). If you have no native subagent mechanism, tell the user so instead of substituting an Orca Worker or spawning processes yourself; an Orca Worker is never a substitute for a subagent.';
 
   const workerMeta = {
     workerId: 'worker-1',
@@ -130,5 +146,15 @@ describe('renderOrcaWorkerSystemPrompt', () => {
 
     expect(prompt).toContain('worker_id=worker-1');
     expect(prompt).toContain(subagentHint);
+  });
+
+  it('tells a worker without a native subagent mechanism to be honest rather than substitute Orca', () => {
+    // worker 侧同规:没有原生机制时如实告知,不拿 Orca 顶替、不自己起进程。
+    const prompt = renderOrcaWorkerSystemPrompt(workerMeta);
+
+    expect(prompt).toContain(
+      'If you have no native subagent mechanism, tell the user so instead of substituting an Orca Worker or spawning processes yourself',
+    );
+    expect(prompt).toContain('an Orca Worker is never a substitute for a subagent');
   });
 });

--- a/packages/orca-workflow/src/orca-bridge-prompt.ts
+++ b/packages/orca-workflow/src/orca-bridge-prompt.ts
@@ -25,7 +25,8 @@ export function renderOrcaLeadSystemPrompt(initialWorker?: OrcaInitialWorkerRef 
   const lines = [
     'You are the lead agent in an Orca multi-agent workflow. Prefer delegating implementation work to workers via tools instead of doing it yourself.',
     'An assignment to an Orca Worker MUST use the Orca tools below. This includes tasks addressed to an existing worker by role or label, explicit requests to open new Orca workers, requests for the Lead to delegate to workers, and parallel role assignments while an Orca team is active. Native subagents do not satisfy an Orca Worker assignment.',
-    'Use your native subagent mechanism (Codex: spawn_agent; Claude Code: the Agent/Task tool) only when the user explicitly asks for a "subagent" / "子代理" without assigning the task to an Orca Worker, or explicitly says not to use Orca Workers. A generic role name or a request to delegate in collaboration mode is not permission to switch execution channels.',
+    'Use your own native subagent mechanism (for example Codex spawn_agent, or the Claude Code Agent/Task tool) only when the user explicitly asks for a "subagent" / "子代理" without assigning the task to an Orca Worker, or explicitly says not to use Orca Workers. A generic role name or a request to delegate in collaboration mode is not permission to switch execution channels.',
+    'An Orca Worker is NEVER a substitute for a subagent. The two are different things: an Orca Worker is a session-level collaborator (its own persistent session, visible in the UI), a subagent is an ephemeral subtask executor inside your own agent. If you have no native subagent mechanism, say so plainly and ask the user how to proceed — do NOT open or reuse an Orca Worker to satisfy a subagent request, and do NOT improvise one by spawning processes yourself.',
     'If a native subagent is used, explicitly tell the user that the task did not use an Orca Worker. Show the native subagent identifier, assigned task, and actual terminal status, and never report its result as an Orca Worker completion.',
     '',
     'Tools: get_workspace_info, create_worker, create_workers, send_to_worker.',
@@ -104,7 +105,7 @@ export function renderOrcaWorkerSystemPrompt(meta: OrcaWorkerPromptMeta): string
     '7. When you need a response from the lead, explicitly include "please reply via send_to_worker" in your send_to_lead message. Otherwise the lead may not know to reply.',
     '8. Do not commit changes unless the lead explicitly asks you to. Leave diffs for lead/user review.',
     '9. When first created, wait for the lead to assign a task. Do not proactively message the lead.',
-    '10. If the user asks for a "subagent" / "子代理", use your native subagent mechanism (Codex: spawn_agent; Claude Code: the Agent/Task tool) to handle it yourself — do NOT escalate to the lead for it, and do NOT call start_team / create_worker (you cannot create Orca workers).',
+    '10. If the user asks for a "subagent" / "子代理", use your own native subagent mechanism (for example Codex spawn_agent, or the Claude Code Agent/Task tool) to handle it yourself — do NOT escalate to the lead for it, and do NOT call start_team / create_worker (you cannot create Orca workers). If you have no native subagent mechanism, tell the user so instead of substituting an Orca Worker or spawning processes yourself; an Orca Worker is never a substitute for a subagent.',
   ];
 
   return lines.join('\n');


### PR DESCRIPTION
## 这次改了什么

### 摘要

Orca 的引导文案此前只写了一半的边界:明确「native subagent 不满足 Orca Worker 派单」,却没有写反方向——**Orca Worker 也永远不是 subagent 的替代品**。两者是不同东西:Worker 是 session 级协同者(独立持久会话、UI 可见、完整工具),subagent 是 agent 内部的一次性子任务执行体。

同时,引导把可用机制硬编码成「Codex: spawn_agent;Claude Code: Agent/Task」这份两家名单(lead 引导、worker 规则 10、`start_team` 与 `create_worker` 的工具描述与拒绝 hint 共 6 处)。**名单外的 harness 照做时找不到被点名的工具**——pi 上游刻意不内置 subagent(`README`: "No sub-agents.")——于是只能退而去抓它唯一看得见的 Orca 工具。用户侧的现象就是「明明要 subagent,却被开了协同模式」。

本 PR 补齐这条对称规则,并把机制名从「名单」改成「举例」,让没有原生机制的 harness 走一条如实告知的路径,而不是自行改道。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联需求:与 #1438(Codex 子代理卡实时状态)同一批排查产出,但两者**无代码耦合**、文件面零重叠,可独立合并。
- 本 PR 包含:Orca 引导与 Orca 工具文案里 subagent / Worker 边界的对称补齐。
- 明确不包含:
  - **不做 agentKind 管道**。理由是硬事实:`providers.ts` 的 `cindy_orca` provider 注释写明「Codex HTTP bridge 的 server factory 初始 ctx 是空的,但 tool handler 会通过 AsyncLocalStorage 在调用时解析真实 session ctx」——即构造工具描述时,恰恰是 codex 与 pi 这两个目标 harness 拿不到可靠 `agentKind`。harness-neutral 措辞既覆盖它们,也不会在 pi 将来获得原生 subagent 后过期(否则「pi 没有 subagent」这句话会立刻变成错的)。
  - 不给 pi 增加 subagent 能力(独立需求)。
  - 不动 `create_workers.ts` 与 `capabilities.ts`:它们只说「不是 subagent 入口」、没有枚举机制名单,方向本来就对,不在本次误导面内。
- 用户可见变化:间接——没有原生 subagent 机制的 harness 收到「开个子代理」时,会如实说明并请用户决定,而不是擅自开 Orca 协同。
- 是否存在 breaking change:无。

### UI 变化

不涉及。本 PR 只改下发给模型的引导文本与 MCP 工具描述/错误 hint,没有任何界面、组件、样式或用户可见文案改动。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:EXIT=0,0 个 FAIL(packages/orca-workflow、packages/lizi-mcps、apps/desktop 等全部 PASS)

pnpm --filter @cindy/orca-workflow run typecheck  → 通过
pnpm --filter @cindy/mcps run typecheck           → 通过

定向:
pnpm --filter @cindy/orca-workflow exec vitest run src/__tests__/orca-bridge-prompt.test.ts   → 10 passed
pnpm --filter @cindy/mcps exec vitest run src/__tests__/{startTeamTool,createWorkerTool,createWorkersTool}.test.ts → 18 passed
```

这些文案被测试逐字钉住,本 PR 同步更新了断言,并新增 2 例把新规则钉死:

1. `orca-bridge-prompt.test.ts` — lead 侧:断言含「An Orca Worker is NEVER a substitute for a subagent.」、无原生机制时如实告知、不得开/复用 Worker 顶替、不得自己起进程冒充。
2. 同文件 — worker 侧:规则 10 的同规兜底。

### 手工验证

不涉及(纯引导文本改动,无可操作界面)。行为面的真实验证需要一个没有原生 subagent 的 harness 会话去撞这条路径,见下。

### 运行时评估(2026-08-03 补做,回应 review)

按 `orca-team-architecture.md` 不变量 7 / `maker-core-and-agent-behavior.md` §3.4 补做了代表性运行时评估(headless claude CLI + stub MCP 暴露真实 cindy_orca 工具面、禁用全部原生 subagent 工具,即「缺原生 subagent、只见 Orca 工具」的结构条件):

- **不误路由**:新 prompt 下「帮我开一个 subagent」3/3 采样 `start_team`/`create_worker` 调用数 = 0,回复明确告知无原生 subagent 机制并交回用户决定;
- **既有路由不回归**:显式 Orca 派单正确走 `get_workspace_info → create_worker`,参数无损;
- **缓存**:prompt 会话期常量、渲染确定(逐字节相等),改动为稳定前缀 +480 字节静态文本,无 per-turn 易变内容;
- **性能**:渲染每会话一次,10k 次合计 20.1ms,非热路径。

完整矩阵与调用日志见 review thread 回复。PI harness 二进制实机复核仍如下节所述留给有宿主环境者执行(结构条件已由上述评估覆盖)。

### 未执行的验证

- **实机验证「pi 会话收到 subagent 请求后如实告知而非误开协同」**:未执行。需要重启桌面端加载 packages 改动,而本机正式实例正在被用户使用。用户可执行的验证步骤:从本 worktree 起 dev(建议 `--isolated=<名字>` 沙箱)→ 开一个 pi 会话并进入 Orca(lead 或 worker)→ 说「开两个子代理并行做」→ 期望它说明自己没有原生 subagent 机制并询问如何继续,而不是调 `start_team` / `create_worker`。
- LLM 侧行为改动无法靠静态检查证明,只能靠实机抽查;本 PR 用测试保证文本已下发,不声称已实测模型行为改变。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

**system prompt 门禁说明**(`docs/dev-rules/maker-core-and-agent-behavior.md` §4):

- 严格说,`renderOrcaLeadSystemPrompt` / `renderOrcaWorkerSystemPrompt` 的产物经 `applyOrcaInstructions` 追加到 `o.userPrompt`(`orcaSessionStartOptions.ts:132-134`),**不进 Claude/Codex 的 system 段**;但它是「随每个 Orca 会话下发、决定 agent 全局行为」的文本,函数名也自称 SystemPrompt,按 §4 从严归入本类申报,不自行豁免。
- **改动动因来自仓库 owner 的明确要求**:原文案把 Orca Worker 摆成 subagent 的可选出口是错的(「Orca 从来不能代替 subagent」),要求不要在引导里继续这样误导 agent。
- 缓存率(§3.1):无影响。改的是 per-session 的 userPrompt 段,不在 Anthropic prompt cache 的稳定前缀内;system 段各段内容与拼接顺序均未触碰。
- 行为漂移(§3.3):有意为之,即本 PR 的目的。方向是**收紧**而非放宽——新增的都是禁止项(不得拿 Worker 顶替、不得自己起进程)与一条如实告知要求;没有新增任何工具、权限或可用路径。Codex / Claude Code 的既有行为不变(机制名仍在,只是改为举例式措辞,原「只在用户显式要求 subagent 时才用」的边界与派单优先级规则逐字保留,对应断言仍在)。
- 请放行人重点看两段新增文本的措辞是否符合产品口径(diff 很小,核心就是 lead 新增一行 + worker 规则 10 补一句)。

### 影响与回滚

- 影响范围:仅 Orca 协同会话(lead / worker)的引导文本,以及 `start_team` / `create_worker` 两个工具的描述与拒绝 hint。非 Orca 会话不下发这些文本,零影响。
- 回滚 / 降级方式:整体 revert 即恢复原文案,无状态、无数据、无迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明(不涉及 UI)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(不做 agentKind 管道的理由写在 commit message 与本描述里)
- [x] 已确认测试结果或说明未执行原因

