### PR TITLE
fix(desktop): 列表模式任务操作按钮对齐文字模式

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -1011,13 +1011,13 @@ function TimeActionsSlot({
 }) {
   const { t } = useTranslation();
   return (
-    <div className="relative ml-auto flex h-5 shrink-0 items-center justify-end">
+    <div className="group/slot relative ml-auto flex h-5 shrink-0 items-center justify-end">
       {/* 默认内容:worktree + 时间;hover / 菜单打开 / archivePending 时淡出让位给操作钮。 */}
       <div
         className={cn(
           // duration 与操作钮的渐显同拍(120ms),让位/回归一进一出同步。
           'flex items-center gap-1 transition-opacity duration-[120ms]',
-          !archivePending && 'group-hover/card:opacity-0',
+          !archivePending && 'group-hover/card:opacity-0 group-focus-within/slot:opacity-0',
           (menuOpen || yieldToOrdinalBadge) && 'opacity-0',
           // 确认胶囊覆盖同一槽位时立即隐藏日期，避免 120ms 淡出期间文字叠在一起。
           archivePending && 'invisible opacity-0',
@@ -1069,22 +1069,34 @@ function TimeActionsSlot({
             'transition-opacity duration-[120ms]',
             menuOpen
               ? 'opacity-100'
-              : 'pointer-events-none opacity-0 group-hover/card:pointer-events-auto group-hover/card:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100',
+              : 'pointer-events-none opacity-0 group-hover/card:pointer-events-auto group-hover/card:opacity-100 group-focus-within/slot:pointer-events-auto group-focus-within/slot:opacity-100',
           )}
         >
-          <CardAction label={t('ccAgent.sidebar.sessionMenu.moreActions')} onClick={onOpenMenu}>
-            <EllipsisVertical size={13} strokeWidth={2} />
+          <CardAction
+            variant="list"
+            isActive={isActive}
+            label={t('ccAgent.sidebar.sessionMenu.moreActions')}
+            onClick={onOpenMenu}
+          >
+            <EllipsisVertical size={14} strokeWidth={2} />
           </CardAction>
           {isArchived && canUnarchive ? (
-            <CardAction label={t('ccAgent.sidebar.sessionMenu.unarchive')} onClick={() => onUnarchive()}>
-              <Undo size={13} strokeWidth={2} />
+            <CardAction
+              variant="list"
+              isActive={isActive}
+              label={t('ccAgent.sidebar.sessionMenu.unarchive')}
+              onClick={() => onUnarchive()}
+            >
+              <Undo size={14} strokeWidth={2} />
             </CardAction>
           ) : canQuickArchive ? (
             <CardAction
+              variant="list"
+              isActive={isActive}
               label={t('ccAgent.sidebar.sessionMenu.archived')}
               onClick={() => setArchivePending(true)}
             >
-              <Archive size={13} strokeWidth={2} />
+              <Archive size={14} strokeWidth={2} />
             </CardAction>
           ) : null}
         </div>
@@ -1093,12 +1105,16 @@ function TimeActionsSlot({
   );
 }
 
-/** 卡片右上角 hover action 钮——白底小方钮，对照 redesign 稿 .xdtsb-act。 */
+/** 卡片右上角 hover action 钮；list 变体复用文字模式的轻量行内按钮。 */
 function CardAction({
+  variant = 'card',
+  isActive = false,
   label,
   onClick,
   children,
 }: {
+  variant?: 'card' | 'list';
+  isActive?: boolean;
   label: string;
   onClick: (e: ReactMouseEvent<HTMLButtonElement>) => void;
   children: ReactNode;
@@ -1114,10 +1130,20 @@ function CardAction({
       onPointerDown={(e) => e.stopPropagation()}
       onDoubleClick={(e) => e.stopPropagation()}
       className={cn(
-        'flex size-6 items-center justify-center rounded-[7px]',
-        'bg-[var(--cmd-palette-bg)] text-[var(--text-tertiary)]',
-        'border border-sidebar-border',
-        'hover:bg-sidebar-item-hover hover:text-foreground focus:outline-none',
+        variant === 'list'
+          ? cn(
+              'shrink-0 size-5 flex items-center justify-center rounded-md',
+              'focus:outline-none',
+              isActive
+                ? 'text-sidebar-item-active-foreground hover:text-sidebar-item-active-foreground hover:bg-[color-mix(in_srgb,var(--sidebar-item-active-foreground)_14%,transparent)]'
+                : 'text-sidebar-action-icon hover:bg-sidebar-item-hover hover:text-foreground',
+            )
+          : cn(
+              'flex size-6 items-center justify-center rounded-[7px]',
+              'bg-[var(--cmd-palette-bg)] text-[var(--text-tertiary)]',
+              'border border-sidebar-border',
+              'hover:bg-sidebar-item-hover hover:text-foreground focus:outline-none',
+            ),
       )}
     >
       {children}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -465,12 +465,13 @@ describe('SessionCard visual cases', () => {
       onTogglePin: vi.fn(),
       projectOptions: [],
     };
+    const moreActionsName = /^(?:更多操作|ccAgent\.sidebar\.sessionMenu\.moreActions)$/;
 
     const { container: listContainer } = render(
       createElement(SessionCard, { ...commonProps, variant: 'list' }),
     );
     const listMore = within(listContainer).getByRole('button', {
-      name: 'ccAgent.sidebar.sessionMenu.moreActions',
+      name: moreActionsName,
     });
     const listArchive = within(listContainer).getByRole('button', { name: '归档' });
     for (const action of [listMore, listArchive]) {
@@ -491,7 +492,7 @@ describe('SessionCard visual cases', () => {
       createElement(SessionCard, { ...commonProps, variant: 'list', isActive: true }),
     );
     const activeListMore = within(activeListContainer).getByRole('button', {
-      name: 'ccAgent.sidebar.sessionMenu.moreActions',
+      name: moreActionsName,
     });
     expect(activeListMore.className).toContain('text-sidebar-item-active-foreground');
     expect(activeListMore.className).toContain(
@@ -501,7 +502,7 @@ describe('SessionCard visual cases', () => {
 
     const { container: cardContainer } = render(createElement(SessionCard, commonProps));
     const cardMore = within(cardContainer).getByRole('button', {
-      name: 'ccAgent.sidebar.sessionMenu.moreActions',
+      name: moreActionsName,
     });
     expect(cardMore.className).toContain('size-6');
     expect(cardMore.className).toContain('bg-[var(--cmd-palette-bg)]');

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -448,6 +448,68 @@ describe('SessionCard visual cases', () => {
     expect(screen.getByText('已归档的历史分析任务')).toBeTruthy();
   });
 
+  it('matches text-mode action chrome in list mode while preserving card buttons', () => {
+    const visualCase = sessionCardVisualCases.find((item) => item.id === 'short-idle-cc');
+    if (!visualCase) throw new Error('Missing idle visual case');
+
+    const commonProps = {
+      session: visualCase.session,
+      isActive: false,
+      isRunning: false,
+      isAttached: false,
+      hasAttentionNotification: false,
+      isSelected: false,
+      onClick: vi.fn(),
+      onAction: vi.fn(),
+      onRename: vi.fn(),
+      onTogglePin: vi.fn(),
+      projectOptions: [],
+    };
+
+    const { container: listContainer } = render(
+      createElement(SessionCard, { ...commonProps, variant: 'list' }),
+    );
+    const listMore = within(listContainer).getByRole('button', {
+      name: 'ccAgent.sidebar.sessionMenu.moreActions',
+    });
+    const listArchive = within(listContainer).getByRole('button', { name: '归档' });
+    for (const action of [listMore, listArchive]) {
+      expect(action.className).toContain('size-5');
+      expect(action.className).toContain('rounded-md');
+      expect(action.className).toContain('text-sidebar-action-icon');
+      expect(action.className).not.toContain('size-6');
+      expect(action.className).not.toContain('bg-[var(--cmd-palette-bg)]');
+      expect(action.className).not.toContain('border-sidebar-border');
+      expect(action.querySelector('svg')?.getAttribute('width')).toBe('14');
+    }
+    const listTimeFade = listContainer.querySelector('time')?.parentElement;
+    expect(listTimeFade?.className).toContain('group-focus-within/slot:opacity-0');
+    expect(listTimeFade?.parentElement?.className).toContain('group/slot');
+    cleanup();
+
+    const { container: activeListContainer } = render(
+      createElement(SessionCard, { ...commonProps, variant: 'list', isActive: true }),
+    );
+    const activeListMore = within(activeListContainer).getByRole('button', {
+      name: 'ccAgent.sidebar.sessionMenu.moreActions',
+    });
+    expect(activeListMore.className).toContain('text-sidebar-item-active-foreground');
+    expect(activeListMore.className).toContain(
+      'hover:bg-[color-mix(in_srgb,var(--sidebar-item-active-foreground)_14%,transparent)]',
+    );
+    cleanup();
+
+    const { container: cardContainer } = render(createElement(SessionCard, commonProps));
+    const cardMore = within(cardContainer).getByRole('button', {
+      name: 'ccAgent.sidebar.sessionMenu.moreActions',
+    });
+    expect(cardMore.className).toContain('size-6');
+    expect(cardMore.className).toContain('bg-[var(--cmd-palette-bg)]');
+    expect(cardMore.className).toContain('border-sidebar-border');
+    expect(cardMore.className).not.toContain('size-5');
+    expect(cardMore.querySelector('svg')?.getAttribute('width')).toBe('13');
+  });
+
   it.each(['list', 'card'] as const)('keeps the %s archive confirmation pill on one line', (variant) => {
     const visualCase = sessionCardVisualCases.find((item) => item.id === 'short-idle-cc');
     if (!visualCase) throw new Error('Missing idle visual case');


### PR DESCRIPTION
## 这次改了什么

### 摘要

列表模式下，任务卡片右侧的「更多」与「归档 / 撤销归档」按钮改为复用文字模式的轻量行内处理：20px、无常驻背景与边框，仅在 hover / active 状态显示语义化反馈。键盘聚焦时，时间信息会让位给操作按钮，避免控件与时间重叠；卡片瀑布模式继续保留原有按钮样式。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore`

### 范围

- 关联 Issue / 需求：用户反馈：列表模式右侧悬浮按钮相比文字模式处理突兀
- 本 PR 包含：`SessionCard` 列表模式操作按钮样式、焦点让位行为及视觉回归测试
- 明确不包含：卡片瀑布模式按钮、操作语义与数据逻辑
- 用户可见变化：列表模式的操作按钮与文字模式视觉一致，交互更克制
- 是否存在 breaking change：无

## UI 变化

- 平台：macOS Desktop（global remote 开发版）
- 设计验证：已在开发版目检列表模式与文字模式，用户确认无问题
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md §10 Theme System & Token Reference`：颜色使用语义 token，不引入主题无关的硬编码
  - `docs/design-rules/DESIGN.md §Light / Dark Dual-Mode Delivery Gate`：hover、active、focus 状态均通过现有主题 token 实现，兼容 Light / Dark
- 未附截图：本 PR 为本地开发版交互确认，代码与回归测试已覆盖状态差异

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-refine-task-list-actions
结果：GATE_EXIT=0

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
结果：1 个文件、36 个测试通过

pnpm --filter desktop exec eslint src/renderer/features/cc-agent/sidebar/SessionCard.tsx src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
结果：通过

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

在功能 worktree 的 macOS global remote 开发版中查看左侧任务列表，比较列表模式与文字模式的「更多」及「归档 / 撤销归档」按钮；用户已确认表现符合预期。

### 未执行的验证

未单独切换并目检另一套 Light / Dark 主题；样式仅使用现有语义 token，自动测试覆盖 list / card、active / inactive 与 focus 让位契约。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：仅 Desktop 左侧任务列表的列表模式操作按钮视觉与焦点交互
- 回滚 / 降级方式：回滚本 PR 的两个提交即可恢复原样

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已注明设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果及未执行项