### PR TITLE
fix(im): 修复 IM 机器人选 Pi 后标签错误且无法切换模型

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -6524,14 +6524,12 @@ function parseImDefaultSettingsPatch(raw: unknown): ImDefaultSettingsPatch {
     }
     const agentInput = input.agents as Record<string, unknown>;
     const agentsPatch: NonNullable<ImDefaultSettingsPatch['agents']> = {};
-    if ('claude-code' in agentInput) {
-      agentsPatch['claude-code'] = parseImDefaultAgentSettings(
-        'claude-code',
-        agentInput['claude-code'],
-      );
-    }
-    if ('codex' in agentInput) {
-      agentsPatch.codex = parseImDefaultAgentSettings('codex', agentInput.codex);
+    // 三个 harness 必须对称解析；漏掉 pi 会让 IM 设置页切 Pi 后改模型静默丢弃
+    // (store 本身支持 pi，见 defaultSettingsStore / IM_DEFAULT_SETTINGS.agents.pi)。
+    for (const kind of ['claude-code', 'codex', 'pi'] as const) {
+      if (kind in agentInput) {
+        agentsPatch[kind] = parseImDefaultAgentSettings(kind, agentInput[kind]);
+      }
     }
     patch.agents = agentsPatch;
   }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2965,7 +2965,8 @@
         "saveFailed": "Failed to save new conversation configuration",
         "agents": {
           "claude-code": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pi": "Pi"
         }
       }
     },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2964,7 +2964,8 @@
         "saveFailed": "新規会話設定を保存できませんでした",
         "agents": {
           "claude-code": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pi": "Pi"
         }
       }
     },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2964,7 +2964,8 @@
         "saveFailed": "새 대화 설정 저장에 실패했습니다",
         "agents": {
           "claude-code": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pi": "Pi"
         }
       }
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2964,7 +2964,8 @@
         "saveFailed": "保存新对话配置失败",
         "agents": {
           "claude-code": "Claude Code",
-          "codex": "Codex"
+          "codex": "Codex",
+          "pi": "Pi"
         }
       }
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

IM 机器人「新对话配置」选 **Pi** 时有两个缺陷：

1. Agent 分段 / 折叠行摘要标签显示成 i18n key（缺 `settings.imBot.defaults.agents.pi`）
2. 切换模型后无法持久化：main 侧 `parseImDefaultSettingsPatch` 只解析 `claude-code` / `codex`，丢掉 `agents.pi`；乐观更新后被服务端旧状态覆盖

store 本身已支持 Pi（`defaultSettingsStore` 有 Pi 单测），缺口在 IPC 解析层与文案。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 IM 机器人配置 Pi 渠道时标签错误且无法切换模型
- 本 PR 包含：
  - `parseImDefaultSettingsPatch` 对 `claude-code` / `codex` / `pi` 对称解析
  - 四语文案补 `settings.imBot.defaults.agents.pi` = `Pi`
- 明确不包含：模型目录、Pi runtime 下载、其他 harness 逻辑
- 用户可见变化：IM 机器人设置页选 Pi 时标签显示为「Pi」，模型选择可保存
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及布局/样式/交互结构；仅补全缺失 i18n agent 标签文案（产品名 `Pi` 不翻译，与 Claude Code / Codex 一致）

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过

# 与 unit tier 相同 exclude 集，forks 池（本机 Node 26 + 官方 threads/maxWorkers=8 会 SIGSEGV / mock 污染）
pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=2 \
  --exclude '**/*.git-integration.test.ts' \
  --exclude 'src/main/localDb/**' \
  --exclude 'src/main/__tests__/*Migration.test.ts' \
  --exclude 'src/main/__tests__/schemaDriftRepair.test.ts' \
  --exclude 'src/main/__tests__/betterSqliteFactory.test.ts' \
  --exclude 'src/main/__tests__/*LocalSessions.test.ts' \
  --exclude 'src/main/__tests__/codexHistoryPromptInit.test.ts' \
  --exclude 'src/main/__tests__/orcaStaleIndexCleanup.test.ts' \
  --exclude 'src/main/scheduler-host/__tests__/*.db.test.ts' \
  --exclude 'src/main/__tests__/directSessionSendGuard.test.ts' \
  --exclude 'src/main/__tests__/makerSendToSessionOrdering.test.ts' \
  --exclude '**/*.bench.ts'
结果：Test Files 1561 passed | Tests 19268 passed | 2 skipped

pnpm test:unit
结果：除 apps/desktop 外全部 workspace 通过；desktop 在官方 threads/maxWorkers=8 下本机 Node v26.5.0 失败（与改动无关的环境问题）。desktop 已用上式等价 exclude 的 forks 跑通。

pnpm check:dco
结果：通过（Signed-off-by: zhengru <github@zhengru.cloud>）
```

### 手工验证

未在本机起 Desktop UI 实机点选（冷环境 + 依赖/二进制首次安装耗时过长）。逻辑路径：`ImDefaultSettingsSection` → `imDefaultSettingsSet` → `parseImDefaultSettingsPatch` 现已接受 `agents.pi`。

### 未执行的验证

- Desktop 实机：设置 → IM 机器人 → 展开渠道 → 新对话配置选 Pi → 切换模型并确认折叠行摘要
- 官方形态 `pnpm test:unit` 中 desktop 的 threads 池：本机 Node 26 不稳定，已用 forks 等价覆盖；请以 CI 为准

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：IM 默认设置 IPC 写入（含各渠道 scope）与设置页 Pi 标签文案
- 回滚 / 降级方式：revert 本 PR 即可；无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
