### PR TITLE
fix(desktop): 修复断开供应商后的同名模型切换

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
@@ -11,8 +11,12 @@ const chatInputSource = readFileSync(
 describe('ChatInput model source switching wiring', () => {
   it('lets a disconnected source reselect the highlighted fallback provider row', () => {
     const selectorStart = chatInputSource.lastIndexOf('<ModelSelector');
+    expect(selectorStart).toBeGreaterThanOrEqual(0);
+
     const selectorEnd = chatInputSource.indexOf('/>', selectorStart);
-    const selectorBlock = chatInputSource.slice(selectorStart, selectorEnd);
+    expect(selectorEnd).toBeGreaterThan(selectorStart);
+
+    const selectorBlock = chatInputSource.slice(selectorStart, selectorEnd + 2);
 
     expect(selectorBlock).toContain('sourceDisconnected={selectedSourceDisconnected}');
     expect(selectorBlock).toContain('reselectEmitsChange={selectedSourceDisconnected}');

--- a/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputModelSelectorRouting.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const chatInputSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'new-chat', 'ChatInput.tsx'),
+  'utf8',
+);
+
+describe('ChatInput model source switching wiring', () => {
+  it('lets a disconnected source reselect the highlighted fallback provider row', () => {
+    const selectorStart = chatInputSource.lastIndexOf('<ModelSelector');
+    const selectorEnd = chatInputSource.indexOf('/>', selectorStart);
+    const selectorBlock = chatInputSource.slice(selectorStart, selectorEnd);
+
+    expect(selectorBlock).toContain('sourceDisconnected={selectedSourceDisconnected}');
+    expect(selectorBlock).toContain('reselectEmitsChange={selectedSourceDisconnected}');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -241,6 +241,60 @@ describe('ModelSelector provider groups', () => {
     expect(within(dashscopeGroup).queryByText('Opus 4.8')).toBeNull();
   });
 
+  it('reselects the connected fallback source when the stored source is disconnected', async () => {
+    const modelId = 'claude-fable-5';
+    const model = {
+      id: modelId,
+      name: 'Fable 5',
+      contextWindow: 200000,
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+    };
+    providersRef.providers = [
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'oauth' },
+        routing: { 'claude-code': {} },
+        connected: false,
+        models: { 'claude-code': [model] },
+      },
+      {
+        id: 'xd',
+        name: 'Cindy AI',
+        source: 'builtin',
+        agents: ['claude-code'],
+        auth: { method: 'api-key' },
+        routing: { 'claude-code': {} },
+        connected: true,
+        models: { 'claude-code': [model] },
+      },
+    ] as unknown[];
+    const onProviderChange = vi.fn();
+
+    renderSelector({
+      modelId,
+      effort: 'high',
+      currentProviderId: 'anthropic',
+      sourceDisconnected: true,
+      reselectEmitsChange: true,
+      onProviderChange,
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /已断开/ }));
+    });
+
+    const popover = screen.getByTestId('model-options-popover');
+    const xdGroup = within(popover).getByRole('group', { name: 'Cindy AI' });
+    const fallbackRow = within(xdGroup).getByRole('option', { name: /Fable 5/ });
+    expect(fallbackRow.getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.click(fallbackRow);
+    expect(onProviderChange).toHaveBeenCalledWith('xd', modelId);
+  });
+
   it('does not render group headings in flat mode (no onProviderChange)', async () => {
     renderSelector({ currentProviderId: undefined, onProviderChange: undefined });
     await openDropdown();

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5743,6 +5743,9 @@ export function ChatInput({
                     // 意图期显示用户在浏览态选中的来源(null = flat 退化行,跟随默认路由)。
                     currentProviderId={activeProviderId}
                     sourceDisconnected={selectedSourceDisconnected}
+                    // 断开来源回落到默认来源后,面板会高亮同模型的回落行;点击该行必须重新
+                    // 发出来源选择,把显示中的默认来源钉回会话的显式来源。
+                    reselectEmitsChange={selectedSourceDisconnected}
                     // 已建会话按实际路由口径解析当前来源(含停用拷贝,跟真实扣费路由);
                     // 草稿是新路由选择,保持准入口径(PR #744 review 第十轮)。
                     actualRoute={!!sessionId}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复模型供应商断开后的同名模型切换问题：Anthropic 的 Fable 5 断开后，列表会把 Cindy AI 的 Fable 5 作为回落来源高亮；点击该行现在会正常触发供应商切换，不再只是收起选择器。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：用户反馈：Anthropic Fable 5 断开后无法直接切回 Cindy AI Fable 5
- 本 PR 包含：ChatInput 的断开来源重选接线；供应商回落行交互回归测试；接线契约测试
- 明确不包含：供应商目录、路由解析、持久化 schema 或其它模型选择行为
- 用户可见变化：断开来源状态下，点击同名的 Cindy AI 模型会立即切换供应商
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14「交互约定」；本次仅修复已有模型选择器的供应商切换交互，不改变布局、样式、颜色或文案。
- 仅修复交互行为，不改变布局、样式、颜色或文案；遵循 `docs/design-rules/DESIGN.md` 的语义状态与现有模型选择器交互约束。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/chatInputModelSelectorRouting.test.ts src/renderer/__tests__/modelSelectorProviderGroups.test.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：3 个测试文件、55 个测试全部通过

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-model-provider-switch
结果：GATE_EXIT=0
```

### 手工验证

未执行：本 PR 未启动 Desktop 实机；交互路径由 jsdom 回归测试覆盖。

### 未执行的验证

未进行 Desktop 实机目检；本次无视觉改动。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅影响已建任务中“显式供应商已断开、同模型存在可用回落供应商”的模型选择行为。
- 回滚 / 降级方式：回滚提交 `108484e58` 即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及视觉变化）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

