### PR TITLE
fix(scheduler): schedule_update 改为真 partial 语义,不再隐式清空 intervalMs

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/scheduleIntervalJsonBoundary.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/scheduleIntervalJsonBoundary.test.ts
@@ -1,0 +1,72 @@
+/**
+ * schedule IPC 的 device-link JSON 边界翻译。
+ *
+ * Mobile 清空 intervalMs 只能用可序列化的 null 表达(device-link 经
+ * JSON.stringify,值为 undefined 的 key 会被丢掉),而引擎契约是
+ * 「带 key 的 undefined = 显式清空;省略 key = 不修改」。desktop IPC 入口的
+ * normalizeNullableIntervalMs 负责这一步翻译:null → 带 key 的 undefined,
+ * 数值与省略 key 两种形态原样透传。
+ *
+ * electron mock 头与 scheduleReadiness.test.ts 相同(import '../schedule'
+ * 的模块链需要这三个 mock 才能 collect)。
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getAllWindows: vi.fn(() => []) },
+  app: {
+    getPath: vi.fn(() => '/tmp/cindy-test-user-data'),
+    getAppPath: vi.fn(() => '/tmp/cindy-test-app'),
+    isPackaged: false,
+  },
+}));
+
+vi.mock('../../device-link/broadcast-tap.js', () => ({
+  tapWindowBroadcast: vi.fn(),
+}));
+
+vi.mock('../../agent-island/service.js', () => ({
+  getAgentIslandService: () => null,
+}));
+
+import { normalizeNullableIntervalMs } from '../schedule';
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+describe('normalizeNullableIntervalMs(device-link JSON 边界)', () => {
+  it('null 翻译成带 key 的 undefined(引擎的显式清空表达)', () => {
+    const out = normalizeNullableIntervalMs({ cronExpr: '0 9 * * *', intervalMs: null });
+    expect(hasOwn(out, 'intervalMs')).toBe(true);
+    expect(out.intervalMs).toBeUndefined();
+    expect(out.cronExpr).toBe('0 9 * * *');
+  });
+
+  it('数值原样透传(同一对象,不额外拷贝)', () => {
+    const patch = { intervalMs: 600_000 };
+    expect(normalizeNullableIntervalMs(patch)).toBe(patch);
+  });
+
+  it('省略 key 原样透传,不会被伪造成清空', () => {
+    const patch: { prompt: string; intervalMs?: number | null } = { prompt: 'p' };
+    const out = normalizeNullableIntervalMs(patch);
+    expect(out).toBe(patch);
+    expect(hasOwn(out, 'intervalMs')).toBe(false);
+  });
+
+  it('mobile 清空 patch 走完 JSON round-trip 后仍能翻译成清空表达', () => {
+    // 模拟 device-link 真实线上形态:mobile 发 null → JSON.stringify/parse →
+    // desktop 归一化。这条链任何一环丢 key,清空间隔就静默失效。
+    const wire = JSON.parse(
+      JSON.stringify({ cronExpr: '*/10 * * * *', recurring: true, intervalMs: null }),
+    ) as { cronExpr: string; recurring: boolean; intervalMs?: number | null };
+    expect(hasOwn(wire, 'intervalMs')).toBe(true);
+
+    const out = normalizeNullableIntervalMs(wire);
+    expect(hasOwn(out, 'intervalMs')).toBe(true);
+    expect(out.intervalMs).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/scheduleIntervalJsonBoundary.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/scheduleIntervalJsonBoundary.test.ts
@@ -31,7 +31,10 @@ vi.mock('../../agent-island/service.js', () => ({
   getAgentIslandService: () => null,
 }));
 
-import { normalizeNullableIntervalMs } from '../schedule';
+import {
+  normalizeLegacyDeviceLinkIntervalClear,
+  normalizeNullableIntervalMs,
+} from '../schedule';
 
 function hasOwn(value: object, key: string): boolean {
   return Object.prototype.hasOwnProperty.call(value, key);
@@ -68,5 +71,45 @@ describe('normalizeNullableIntervalMs(device-link JSON 边界)', () => {
     const out = normalizeNullableIntervalMs(wire);
     expect(hasOwn(out, 'intervalMs')).toBe(true);
     expect(out.intervalMs).toBeUndefined();
+  });
+});
+
+describe('normalizeLegacyDeviceLinkIntervalClear(旧版 mobile 的清空兼容)', () => {
+  // 旧版 mobile 全量表单的 wire 形态:带 cronExpr / manual / notify,清空间隔时
+  // 不带 intervalMs key(经 JSON 序列化被丢),靠旧引擎隐式清空表达语义。
+  const legacyForm = {
+    name: '巡检',
+    cronExpr: '0 9 * * *',
+    recurring: true,
+    manual: false,
+    notify: { desktop: true, feishu: false },
+  };
+
+  it('device-link 来源 + 旧全量表单缺 intervalMs key → 翻译成显式清空', () => {
+    const out = normalizeLegacyDeviceLinkIntervalClear({ ...legacyForm }, true);
+    expect(hasOwn(out, 'intervalMs')).toBe(true);
+    expect(out.intervalMs).toBeUndefined();
+  });
+
+  it('非 device-link 来源的同形态 patch 原样透传(MCP / renderer 的真 partial 不受影响)', () => {
+    const patch = { ...legacyForm };
+    expect(normalizeLegacyDeviceLinkIntervalClear(patch, false)).toBe(patch);
+  });
+
+  it('新版 mobile 恒带 intervalMs key(数值或 null 归一化后的 undefined),不会命中兼容分支', () => {
+    const withNumber = { ...legacyForm, intervalMs: 600_000 };
+    expect(normalizeLegacyDeviceLinkIntervalClear(withNumber, true)).toBe(withNumber);
+
+    const clearedByNull = normalizeLegacyDeviceLinkIntervalClear(
+      normalizeNullableIntervalMs({ ...legacyForm, intervalMs: null }),
+      true,
+    );
+    expect(hasOwn(clearedByNull, 'intervalMs')).toBe(true);
+    expect(clearedByNull.intervalMs).toBeUndefined();
+  });
+
+  it('device-link 的非全量 partial(缺 manual/notify 标记)不被伪造成清空', () => {
+    const partial = { cronExpr: '0 9 * * *' };
+    expect(normalizeLegacyDeviceLinkIntervalClear(partial, true)).toBe(partial);
   });
 });

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4318,6 +4318,11 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // v2 因果能力：同引擎 no-op 返回 revision，后续 SET_MODEL 在 session 锁内 CAS。
       // 新 desktop 控制端据此与只有基础切换能力的旧 host 做安全兼容门控。
       supportsSessionAgentSwitchCas: true,
+      // 调度更新支持 intervalMs:null 的显式清空表达(IPC 入口归一化成引擎的
+      // 「带 key 的 undefined」)。旧 desktop 缺省为 false——旧引擎会把 null 当
+      // 已设间隔算出 now+null 立即触发,mobile 必须据此回退旧 wire 形态(省略
+      // key,由旧引擎的隐式清空承担等价语义)。
+      supportsScheduleIntervalNullClear: true,
     };
   });
 

--- a/apps/desktop/src/main/maker-ipc/schedule.ts
+++ b/apps/desktop/src/main/maker-ipc/schedule.ts
@@ -215,6 +215,24 @@ async function withScheduler<T>(cb: (deps: SchedulerDeps) => Promise<T>): Promis
   }
 }
 
+/**
+ * Device-link JSON 边界翻译:mobile 清空 intervalMs 用可序列化的 null 表达
+ * (`JSON.stringify` 会丢掉值为 undefined 的 key,见 maker-shared
+ * scheduleTypes.RemoteScheduleWriteInput.intervalMs),而引擎契约是「带 key 的
+ * undefined = 显式清空;省略 key = 不修改」。在 IPC 入口把 null 归一化成带 key
+ * 的 undefined,与 MCP schedule_update 对 intervalMs:null 的翻译同一约定。
+ * 桌面 renderer 走 structured clone,undefined key 不会丢,不受影响。
+ * (export 仅供单测直接验证翻译语义。)
+ */
+export function normalizeNullableIntervalMs<T extends { intervalMs?: number | null }>(
+  input: T,
+): Omit<T, 'intervalMs'> & { intervalMs?: number } {
+  if (input.intervalMs !== null) {
+    return input as Omit<T, 'intervalMs'> & { intervalMs?: number };
+  }
+  return { ...input, intervalMs: undefined };
+}
+
 function listAllTemplates(): ScheduleTemplate[] {
   const projectTemplates: ScheduleTemplate[] = [];
   return [...BUILTIN_TEMPLATES, ...projectTemplates];
@@ -294,7 +312,7 @@ export function registerScheduleHandlers(getMaker?: () => Maker | null): void {
     requireObject(input, 'input');
     return withScheduler(async ({ scheduler }) => {
       const normalized = await stabilizePreRunHookForCreate(
-        input as CreateScheduleInput,
+        normalizeNullableIntervalMs(input as CreateScheduleInput & { intervalMs?: number | null }),
         hookPathDeps,
       );
       return scheduler.create(normalized);
@@ -308,7 +326,9 @@ export function registerScheduleHandlers(getMaker?: () => Maker | null): void {
       scheduler.updateFromCurrent(scheduleId, (existing) =>
         stabilizePreRunHookForUpdate(
           existing,
-          patch as UpdateScheduleInput,
+          normalizeNullableIntervalMs(
+            patch as UpdateScheduleInput & { intervalMs?: number | null },
+          ),
           hookPathDeps,
         ),
       ),
@@ -581,7 +601,9 @@ export function registerScheduleHandlers(getMaker?: () => Maker | null): void {
         : {};
     const overrides =
       body.overrides && typeof body.overrides === 'object'
-        ? (body.overrides as Partial<CreateScheduleInput>)
+        ? normalizeNullableIntervalMs(
+            body.overrides as Partial<CreateScheduleInput> & { intervalMs?: number | null },
+          )
         : {};
     return withScheduler(({ scheduler }) => {
       const template = findTemplate(templateId);

--- a/apps/desktop/src/main/maker-ipc/schedule.ts
+++ b/apps/desktop/src/main/maker-ipc/schedule.ts
@@ -68,6 +68,7 @@ import { resolveScriptCapabilityStatuses } from '../scheduler-host/script-capabi
 import { getGhostManager } from '../cindy-brain/index.js';
 import { throwIpcError, requireString, requireObject } from '../utils/ipcValidate.js';
 import { tapWindowBroadcast } from '../device-link/broadcast-tap.js';
+import { isDeviceLinkInvoke } from '../device-link/invoke-context.js';
 import { getAgentIslandService } from '../agent-island/service.js';
 import { getSessionProvider } from '../maker-host/session-provider-store.js';
 import { MAKER_INVOKE, MAKER_PUSH } from './channels.js';
@@ -233,6 +234,28 @@ export function normalizeNullableIntervalMs<T extends { intervalMs?: number | nu
   return { ...input, intervalMs: undefined };
 }
 
+/**
+ * 版本错位兼容的另一半:**旧版 mobile** 清空间隔靠「全量表单不带 intervalMs key +
+ * 引擎隐式清空」表达;真 partial 语义下省略 key 变成「不修改」,旧 mobile 的清空
+ * 就静默失效(codex review 发现)。这里在 update 入口把「device-link 来源 + 旧版
+ * 全量表单形态(带 cronExpr / manual / notify 却没有 intervalMs key)」翻译回
+ * 显式清空。新版 mobile 全量表单恒带 intervalMs key(数值或 null),永远不会命中
+ * 这条;MCP 与桌面 renderer 不走 device-link,partial patch 不受影响。来源判定用
+ * AsyncLocalStorage 的可信标记(isDeviceLinkInvoke),不信任 payload 自述。
+ */
+export function normalizeLegacyDeviceLinkIntervalClear<
+  T extends { intervalMs?: number; cronExpr?: string },
+>(patch: T, isRemoteInvoke: boolean): T & { intervalMs?: number } {
+  if (!isRemoteInvoke) return patch;
+  if (Object.prototype.hasOwnProperty.call(patch, 'intervalMs')) return patch;
+  const legacyFullForm =
+    typeof patch.cronExpr === 'string' &&
+    Object.prototype.hasOwnProperty.call(patch, 'manual') &&
+    Object.prototype.hasOwnProperty.call(patch, 'notify');
+  if (!legacyFullForm) return patch;
+  return { ...patch, intervalMs: undefined };
+}
+
 function listAllTemplates(): ScheduleTemplate[] {
   const projectTemplates: ScheduleTemplate[] = [];
   return [...BUILTIN_TEMPLATES, ...projectTemplates];
@@ -326,8 +349,11 @@ export function registerScheduleHandlers(getMaker?: () => Maker | null): void {
       scheduler.updateFromCurrent(scheduleId, (existing) =>
         stabilizePreRunHookForUpdate(
           existing,
-          normalizeNullableIntervalMs(
-            patch as UpdateScheduleInput & { intervalMs?: number | null },
+          normalizeLegacyDeviceLinkIntervalClear(
+            normalizeNullableIntervalMs(
+              patch as UpdateScheduleInput & { intervalMs?: number | null },
+            ),
+            isDeviceLinkInvoke(),
           ),
           hookPathDeps,
         ),

--- a/apps/mobile/app/automations/[deviceId].tsx
+++ b/apps/mobile/app/automations/[deviceId].tsx
@@ -68,8 +68,10 @@ import {
   MOBILE_SCHEDULE_PENDING_SESSION_ID,
   updateDraftAgentKind,
   updateDraftBoundSessionId,
+  updateDraftCronExpr,
   updateDraftIntervalMinutes,
   updateDraftRunMode,
+  updateDraftTimezone,
   updateDraftSessionMode,
   updateDraftWorkspaceKind,
   validateTemplateParamValues,
@@ -1234,7 +1236,7 @@ function ScheduleFormCard({
             <TextInput
               autoCapitalize="none"
               editable={!busy}
-              onChangeText={(value) => setField('cronExpr', value)}
+              onChangeText={(value) => onChange(updateDraftCronExpr(draft, value))}
               placeholder="0 9 * * *"
               placeholderTextColor={colors.textTertiary}
               style={styles.input}
@@ -1368,7 +1370,7 @@ function ScheduleFormCard({
         <TextInput
           autoCapitalize="none"
           editable={!busy}
-          onChangeText={(value) => setField('timezone', value)}
+          onChangeText={(value) => onChange(updateDraftTimezone(draft, value))}
           placeholder="Asia/Shanghai"
           placeholderTextColor={colors.textTertiary}
           style={styles.input}

--- a/apps/mobile/app/automations/[deviceId].tsx
+++ b/apps/mobile/app/automations/[deviceId].tsx
@@ -68,6 +68,7 @@ import {
   MOBILE_SCHEDULE_PENDING_SESSION_ID,
   updateDraftAgentKind,
   updateDraftBoundSessionId,
+  updateDraftIntervalMinutes,
   updateDraftRunMode,
   updateDraftSessionMode,
   updateDraftWorkspaceKind,
@@ -1220,7 +1221,7 @@ function ScheduleFormCard({
             <TextInput
               editable={!busy}
               keyboardType="number-pad"
-              onChangeText={(value) => setField('intervalMinutes', value)}
+              onChangeText={(value) => onChange(updateDraftIntervalMinutes(draft, value))}
               placeholder={t('devices.automations.form.intervalPlaceholder')}
               placeholderTextColor={colors.textTertiary}
               style={styles.input}

--- a/apps/mobile/app/automations/[deviceId].tsx
+++ b/apps/mobile/app/automations/[deviceId].tsx
@@ -58,6 +58,7 @@ import { shouldRefreshRunsForSchedule } from '@cindy/maker-shared/schedule-event
 import { projectDraftSessionTitle } from '@cindy/maker-shared/session-title';
 import {
   applyMobileTemplateParams,
+  applyScheduleWireCompat,
   applyTemplateToMobileScheduleDraft,
   buildMobileScheduleInput,
   createMobileScheduleDraft,
@@ -402,19 +403,30 @@ export default function AutomationsScreen() {
         await openLink(deviceId);
         await subscribe(`automations:${deviceId}`, deviceId, ['sessions']);
       });
+      // intervalMs:null 的清空表达只有新 desktop 认识(旧引擎会当成已设间隔立即
+      // 触发),发送前按 host 能力位降级 wire 形态;探测失败按不支持处理
+      // (失败方向的取舍见 applyScheduleWireCompat 注释)。
+      const wireInput = await (async () => {
+        if (input.intervalMs !== null) return input;
+        const caps = await maker.getCapabilities(formDraft.agentKind).catch(() => null);
+        const supportsIntervalNullClear = !!(
+          caps as { supportsScheduleIntervalNullClear?: boolean } | null
+        )?.supportsScheduleIntervalNullClear;
+        return applyScheduleWireCompat(input, { supportsIntervalNullClear });
+      })();
       const saved = await (async () => {
         if (formMode === 'edit' && formScheduleId) {
-          return withTransientRemoteRetry(() => maker.schedule.update(formScheduleId, input));
+          return withTransientRemoteRetry(() => maker.schedule.update(formScheduleId, wireInput));
         }
         if (selectedTemplate && !templatePromptDirty) {
-          const { prompt: _templatePrompt, ...overrides } = input;
+          const { prompt: _templatePrompt, ...overrides } = wireInput;
           return maker.schedule.createFromTemplate({
             templateId: selectedTemplate.id,
             paramValues: templateParamValues,
             overrides,
           });
         }
-        return maker.schedule.create(input);
+        return maker.schedule.create(wireInput);
       })();
       closeScheduleForm();
       if (saved?.id) {

--- a/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
@@ -1056,6 +1056,19 @@ describe('schedule_update — partial 语义的 JSON 边界翻译', () => {
     expect(env.ok).toBe(true);
     expect(updated.patch?.preRunHook).toEqual({ command: 'node /abs/old.mjs' });
   });
+
+  it('preRunHook.timeoutMs 带 key 的 undefined → 视作缺省沿用现有超时,不是清除', async () => {
+    // JSON 表达不出这个形态,但进程内调用能;只有 null 才是清除
+    // (copilot review 指出带 key undefined 曾漏进清空分支)。
+    const { updated, registry } = setup({
+      preRunHook: { command: 'node /abs/old.mjs', timeoutMs: 180_000 },
+    });
+    const env = await callUpdate(registry, {
+      preRunHook: { command: 'node /abs/new.mjs', timeoutMs: undefined },
+    });
+    expect(env.ok).toBe(true);
+    expect(updated.patch?.preRunHook).toEqual({ command: 'node /abs/new.mjs', timeoutMs: 180_000 });
+  });
 });
 
 // ── schedule_update: bindToCurrentSession 同 create 语义 ────────────────────────

--- a/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
@@ -992,6 +992,72 @@ describe('schedule_create — bindToCurrentSession', () => {
   });
 });
 
+// ── schedule_update: intervalMs / preRunHook.timeoutMs 的真 partial 边界翻译 ─────
+
+describe('schedule_update — partial 语义的 JSON 边界翻译', () => {
+  function setup(existing: Partial<Schedule> = {}) {
+    const updated: { id?: string; patch?: Record<string, unknown> } = {};
+    const fakeScheduler = {
+      updateFromCurrent: async (
+        id: string,
+        buildPatch: (current: Schedule) => Promise<Record<string, unknown>>,
+      ) => {
+        const patch = await buildPatch({ id, ...existing } as Schedule);
+        updated.id = id;
+        updated.patch = patch;
+        return { id, ...existing, ...patch };
+      },
+    };
+    const registry = new SchedulerToolRegistry();
+    registerScheduleUpdateTool(registry, {
+      getScheduler: () => fakeScheduler as never,
+      // 身份 stabilizer:hook 用例只验证 timeoutMs 的 partial 语义,不测路径固化
+      hookScript: { stabilizeCommand: async ({ command }: { command: string }) => command },
+    } as never);
+    return { updated, registry };
+  }
+
+  async function callUpdate(registry: SchedulerToolRegistry, extra: Record<string, unknown>) {
+    const res = await registry.call('schedule_update', { id: 'sch-1', ...extra });
+    return JSON.parse((res.content[0] as { text: string }).text) as { ok: boolean; code?: string };
+  }
+
+  it('只改 prompt → patch 不含 intervalMs key(真 partial,不再需要三件套)', async () => {
+    const { updated, registry } = setup({ intervalMs: 600_000 });
+    const env = await callUpdate(registry, { prompt: 'new prompt' });
+    expect(env.ok).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(updated.patch ?? {}, 'intervalMs')).toBe(false);
+  });
+
+  it('intervalMs: null → 翻译成带 key 的 undefined(显式清空,回到 cron 语义)', async () => {
+    const { updated, registry } = setup({ intervalMs: 600_000 });
+    const env = await callUpdate(registry, { intervalMs: null });
+    expect(env.ok).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(updated.patch ?? {}, 'intervalMs')).toBe(true);
+    expect(updated.patch?.intervalMs).toBeUndefined();
+  });
+
+  it('preRunHook 只改 command → 沿用任务现有 timeoutMs,不再静默清成不限时', async () => {
+    const { updated, registry } = setup({
+      preRunHook: { command: 'node /abs/old.mjs', timeoutMs: 180_000 },
+    });
+    const env = await callUpdate(registry, { preRunHook: { command: 'node /abs/new.mjs' } });
+    expect(env.ok).toBe(true);
+    expect(updated.patch?.preRunHook).toEqual({ command: 'node /abs/new.mjs', timeoutMs: 180_000 });
+  });
+
+  it('preRunHook.timeoutMs: null → 显式清除超时(patch 里不带 timeoutMs)', async () => {
+    const { updated, registry } = setup({
+      preRunHook: { command: 'node /abs/old.mjs', timeoutMs: 180_000 },
+    });
+    const env = await callUpdate(registry, {
+      preRunHook: { command: 'node /abs/old.mjs', timeoutMs: null },
+    });
+    expect(env.ok).toBe(true);
+    expect(updated.patch?.preRunHook).toEqual({ command: 'node /abs/old.mjs' });
+  });
+});
+
 // ── schedule_update: bindToCurrentSession 同 create 语义 ────────────────────────
 
 describe('schedule_update — bindToCurrentSession', () => {

--- a/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
+++ b/packages/lizi-mcps/src/__tests__/cindy_schedulerMcpServer.test.ts
@@ -1057,6 +1057,18 @@ describe('schedule_update — partial 语义的 JSON 边界翻译', () => {
     expect(updated.patch?.preRunHook).toEqual({ command: 'node /abs/old.mjs' });
   });
 
+  it('interval 任务只 patch cronExpr 也校验表达式,无效 cron 不被静默写入', async () => {
+    // 真 partial 保留原 interval → 引擎按 now + intervalMs 重排、不解析 cron;
+    // 工具层必须无条件校验显式提供的 cronExpr,否则坏表达式潜伏到切回 cron 才爆。
+    const { updated, registry } = setup({ intervalMs: 600_000 });
+    const env = await callUpdate(registry, { cronExpr: 'not-a-cron' });
+    expect(env.ok).toBe(false);
+    expect(updated.patch).toBeUndefined();
+
+    const okEnv = await callUpdate(registry, { cronExpr: '*/10 * * * *' });
+    expect(okEnv.ok).toBe(true);
+  });
+
   it('preRunHook.timeoutMs 带 key 的 undefined → 视作缺省沿用现有超时,不是清除', async () => {
     // JSON 表达不出这个形态,但进程内调用能;只有 null 才是清除
     // (copilot review 指出带 key undefined 曾漏进清空分支)。

--- a/packages/lizi-mcps/src/scheduler/update.ts
+++ b/packages/lizi-mcps/src/scheduler/update.ts
@@ -33,8 +33,9 @@ export function registerScheduleUpdateTool(
         .number()
         .int()
         .positive()
+        .nullable()
         .optional()
-        .describe('相对间隔毫秒。设置后优先于 cronExpr；显式传 null/undefined 不支持，清空请只改 cronExpr 让调度回到 cron 槽位语义。'),
+        .describe('相对间隔毫秒。设置后优先于 cronExpr。省略 = 不修改（真 partial：只改 prompt / cronExpr 不会动它）；传 null = 清空，调度回到 cronExpr 壁钟槽位语义。'),
       timezone: z.string().min(1).optional(),
       recurring: z.boolean().optional(),
       agentKind: z.enum(AGENT_KIND).optional(),
@@ -75,7 +76,13 @@ export function registerScheduleUpdateTool(
       preRunHook: z
         .object({
           command: z.string().min(1),
-          timeoutMs: z.number().int().positive().optional(),
+          timeoutMs: z
+            .number()
+            .int()
+            .positive()
+            .nullable()
+            .optional()
+            .describe('省略 = 沿用任务现有 timeoutMs(只改 command 不用重传超时);传 null = 显式清除超时(不限时)。'),
         })
         .nullable()
         .optional()
@@ -98,8 +105,14 @@ export function registerScheduleUpdateTool(
           // (schema 只收 string 或缺省,而缺省 = 不修改)。
           input = { ...input, targetSessionId: undefined };
         }
-        if (input.intervalMs !== undefined) {
-          // patch 带 intervalMs 时引擎按 now + intervalMs 重排、不解析 patch 里的
+        if ((patch as { intervalMs?: number | null }).intervalMs === null) {
+          // 同 targetSessionId:null → 带 key 的 undefined = 显式清空,调度回到
+          // cronExpr 壁钟槽位语义。引擎遵循真 partial 契约(没带 key 就不动),
+          // 这是 JSON 边界唯一的清空表达。
+          input = { ...input, intervalMs: undefined };
+        }
+        if (typeof input.intervalMs === 'number') {
+          // patch 带 intervalMs 数值时引擎按 now + intervalMs 重排、不解析 patch 里的
           // cronExpr / timezone,工具层补回校验(只校验本次 patch 显式带的字段)。
           assertCronAndTimezoneValid(input.cronExpr, input.timezone);
         }
@@ -115,6 +128,24 @@ export function registerScheduleUpdateTool(
           input = { ...input, targetSessionId: sessionId };
         }
         return scheduler.updateFromCurrent(id, async (existing) => {
+          // preRunHook.timeoutMs 的真 partial 表达:只改 command 时沿用任务现有超时
+          // (此前整对象替换会把省略的 timeoutMs 静默清成"不限时");传 null 才显式清除。
+          // null 在进入引擎前剥掉 —— 引擎/storage 只认 number | undefined。
+          const rawHook = (patch as { preRunHook?: { command: string; timeoutMs?: number | null } | null })
+            .preRunHook;
+          if (rawHook && typeof rawHook === 'object') {
+            if (rawHook.timeoutMs === null) {
+              input = { ...input, preRunHook: { command: rawHook.command } };
+            } else if (
+              !Object.prototype.hasOwnProperty.call(rawHook, 'timeoutMs') &&
+              existing.preRunHook?.timeoutMs !== undefined
+            ) {
+              input = {
+                ...input,
+                preRunHook: { command: rawHook.command, timeoutMs: existing.preRunHook.timeoutMs },
+              };
+            }
+          }
           const nextHook = Object.prototype.hasOwnProperty.call(input, 'preRunHook')
             ? input.preRunHook
             : existing.preRunHook;

--- a/packages/lizi-mcps/src/scheduler/update.ts
+++ b/packages/lizi-mcps/src/scheduler/update.ts
@@ -137,7 +137,10 @@ export function registerScheduleUpdateTool(
             if (rawHook.timeoutMs === null) {
               input = { ...input, preRunHook: { command: rawHook.command } };
             } else if (
-              !Object.prototype.hasOwnProperty.call(rawHook, 'timeoutMs') &&
+              // 「没提供」= 缺 key 或值为 undefined:MCP 走 JSON 表达不出带 key 的
+              // undefined,但进程内调用能;两种形态都视作缺省沿用现有超时,只有
+              // null 是清除(copilot review 指出带 key undefined 会漏进清空分支)。
+              rawHook.timeoutMs === undefined &&
               existing.preRunHook?.timeoutMs !== undefined
             ) {
               input = {

--- a/packages/lizi-mcps/src/scheduler/update.ts
+++ b/packages/lizi-mcps/src/scheduler/update.ts
@@ -111,11 +111,12 @@ export function registerScheduleUpdateTool(
           // 这是 JSON 边界唯一的清空表达。
           input = { ...input, intervalMs: undefined };
         }
-        if (typeof input.intervalMs === 'number') {
-          // patch 带 intervalMs 数值时引擎按 now + intervalMs 重排、不解析 patch 里的
-          // cronExpr / timezone,工具层补回校验(只校验本次 patch 显式带的字段)。
-          assertCronAndTimezoneValid(input.cronExpr, input.timezone);
-        }
+        // 无条件校验本次 patch 显式带的 cronExpr / timezone(函数对缺省字段是
+        // no-op)。不能只在 patch 带 intervalMs 数值时校验:任务已有 intervalMs、
+        // patch 只改 cronExpr 时,真 partial 语义保留原 interval,引擎按
+        // now + intervalMs 重排、全程不解析 cron——无效表达式会被静默写入,等
+        // 切回 cron 模式才爆(codex review 发现)。
+        assertCronAndTimezoneValid(input.cronExpr, input.timezone);
         if (bindToCurrentSession) {
           // 与 schedule_create 对称:把"改绑当前对话"翻成 targetSessionId,杜绝 agent
           // 复用上下文里过期的 session id。识别不到当前会话时报 INVALID_PARAMS,不静默绑错。

--- a/packages/maker-scheduler/src/__tests__/scheduler.test.ts
+++ b/packages/maker-scheduler/src/__tests__/scheduler.test.ts
@@ -806,32 +806,49 @@ describe('Scheduler', () => {
     expect(after?.intervalMs).toBeUndefined();
   });
 
-  // ── update(cronExpr) 不带 intervalMs 时一律清空、按字面壁钟语义执行 ──
-  // MCP 工具的 schema 不暴露 intervalMs，patch 只有 cronExpr。修复前旧 intervalMs
-  // 原样保留并继续获胜 → 改 cron 形同虚设（PR 跟进任务退避阶梯被永久冻结在 10min）。
-  // 注意**不做**"按形态推导 interval"：cron 就是 cron，interval 语义只属于显式
-  // 传 intervalMs 的调用方（与 create() 对称，避免壁钟意图被静默转 interval）。
+  // ── intervalMs 真 partial 契约：没带 key 就不动，显式带 key(undefined)才清空 ──
+  // 历史演进（两个方向都栽过，改这里前先读完）：
+  //   1. 最早：cronExpr-only patch 保留旧 intervalMs → interval 永远获胜，改 cron
+  //      形同虚设（当时 MCP schema 不暴露 intervalMs，调用方无法表达清空）。
+  //   2. 于是加了隐式清空：cronExpr 在场且没带 intervalMs key → 清。intervalMs 对
+  //      调用方开放后，它反过来成为静默事故源：只更新 prompt + cronExpr（cadence
+  //      展示对齐的常见形态）就把 interval 任务打回 cron 槽位语义（2026-07-29 #211
+  //      心跳实测），所有调用方被迫背「三件套一起带」。
+  //   3. 现在：真 partial。清空唯一表达 = 显式带 key 且值 undefined（JSON 边界为
+  //      null，由 MCP 工具层翻译）。GUI 表单恒带 key，行为不变。
+  // 仍然**不做**"按形态推导 interval"：cron 就是 cron，与 create() 对称。
 
-  it('update(cronExpr only) clears stale intervalMs when new cron is wall-clock', async () => {
+  it('update(cronExpr only) keeps interval authority and re-arms from now', async () => {
     const sch = await h.scheduler.create({ ...baseInput, cronExpr: '*/10 * * * *', intervalMs: 10 * 60_000 });
     h.clock.setTo(Date.UTC(2026, 0, 1, 0, 1, 0));
-    // 模拟 MCP patch：只带 cronExpr，没有 intervalMs key
-    await h.scheduler.update(sch.id, { cronExpr: '0 9 * * *' });
-    const after = await h.storage.get(sch.id);
-    expect(after?.intervalMs).toBeUndefined();
-    // 按新 cron 的壁钟槽位排，而不是 now + 旧10min = 00:11:00
-    expect(after?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 9, 0, 0));
-  });
-
-  it('update(cronExpr only) clears intervalMs even when new cron is interval-shaped', async () => {
-    const sch = await h.scheduler.create({ ...baseInput, cronExpr: '*/10 * * * *', intervalMs: 10 * 60_000 });
-    h.clock.setTo(Date.UTC(2026, 0, 1, 0, 1, 0));
+    // 模拟 MCP patch：只带 cronExpr（cadence 展示对齐），没有 intervalMs key
     await h.scheduler.update(sch.id, { cronExpr: '*/30 * * * *' });
     const after = await h.storage.get(sch.id);
-    // 不按形态推导：interval 形态的 cron 同样回到纯壁钟语义
+    // interval 语义保持权威，不被隐式清空
+    expect(after?.intervalMs).toBe(10 * 60_000);
+    // 触发字段变了 → 按 interval 冷启动重排：now + 10min = 00:11:00（不是 */30 壁钟槽位）
+    expect(after?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 0, 11, 0));
+  });
+
+  it('update(prompt only) leaves intervalMs and nextFireAt completely untouched', async () => {
+    // 2026-07-29 #211 事故形态的回归：改 prompt 绝不能动 interval 语义
+    const sch = await h.scheduler.create({ ...baseInput, cronExpr: '*/10 * * * *', intervalMs: 10 * 60_000 });
+    h.clock.setTo(Date.UTC(2026, 0, 1, 0, 1, 0));
+    await h.scheduler.update(sch.id, { prompt: 'new prompt' });
+    const after = await h.storage.get(sch.id);
+    expect(after?.intervalMs).toBe(10 * 60_000);
+    expect(after?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 0, 10, 30));
+  });
+
+  it('update with explicit intervalMs:undefined key alone clears and falls back to cron slots', async () => {
+    const sch = await h.scheduler.create({ ...baseInput, cronExpr: '*/10 * * * *', intervalMs: 10 * 60_000 });
+    h.clock.setTo(Date.UTC(2026, 0, 1, 0, 1, 0));
+    // 显式清空不需要同时改 cronExpr
+    await h.scheduler.update(sch.id, { intervalMs: undefined });
+    const after = await h.storage.get(sch.id);
     expect(after?.intervalMs).toBeUndefined();
-    // 下一个 */30 壁钟槽位 = 00:30:00（不是 now+30min=00:31:00，更不是 now+旧10min）
-    expect(after?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 0, 30, 0));
+    // 回到现有 cron 的壁钟槽位：下一个 */10 = 00:10:00
+    expect(after?.nextFireAt).toBe(Date.UTC(2026, 0, 1, 0, 10, 0));
   });
 
   it('update with explicit intervalMs key still wins over cron-derived value', async () => {

--- a/packages/maker-scheduler/src/engine/scheduler.ts
+++ b/packages/maker-scheduler/src/engine/scheduler.ts
@@ -1281,23 +1281,31 @@ export class Scheduler extends EventEmitter {
     //   - manual:true  → 强制清空 nextFireAt（不再自动 fire）
     //   - manual:false 且 触发字段变 → 按新表达式重算（intervalMs 优先于 cron）
     //   - manual:false 且 触发字段没动 → nextFireAt 保留（避免 update 副作用）
+    // intervalMs 按「key 是否在场」判定而不是「值是否 undefined」：显式清空
+    // （key 在、值 undefined）同样是触发字段变化，必须重算回 cron 槽位。
+    const intervalKeyPresent = Object.prototype.hasOwnProperty.call(patch, 'intervalMs');
     const needsRecompute =
       patch.cronExpr !== undefined ||
       patch.timezone !== undefined ||
       patch.manual !== undefined ||
-      patch.intervalMs !== undefined ||
+      intervalKeyPresent ||
       shouldReactivateExpired;
     let recomputeFromTo: { from: number | undefined; to: number | undefined } | null = null;
     if (needsRecompute) {
-      // cron 变更但 patch 未显式带 intervalMs（典型：MCP 工具只 patch cronExpr，
-      // 其 schema 不暴露 intervalMs）→ 一律清空 intervalMs（undefined，storage 落
-      // NULL），按字面壁钟语义执行。不清的话旧 intervalMs 永远获胜，改 cron 形同
-      // 虚设。也刻意**不做**"按形态推导 interval"：cron 就是 cron，interval 语义
-      // 只属于显式传 intervalMs 的调用方（GUI 表单）——推导会让 `0 */12 * * *`
-      // 这类壁钟意图被静默转成 interval，且与 create()（不推导）不对称。
-      if (patch.cronExpr !== undefined && !('intervalMs' in patch)) {
-        updates.intervalMs = undefined;
-      }
+      // intervalMs 遵循真 partial 契约：**patch 没带 key 就不动**。
+      //
+      // 历史上这里曾在「patch 带 cronExpr 但没带 intervalMs」时隐式清空 intervalMs——
+      // 那是 MCP 工具 schema 还不暴露 intervalMs 时代的权宜（不清的话旧 intervalMs
+      // 永远获胜，改 cron 形同虚设）。intervalMs 对所有调用方开放后，这个隐式清空
+      // 反过来成了静默事故源：调用方只更新 prompt + cronExpr（cadence 展示对齐的
+      // 常见形态）就把 interval 任务打回 cron 槽位语义（2026-07-29 #211 心跳实测
+      // 中招），所有调用方被迫记住「改 prompt 必须把 intervalMs 一起带上」。
+      //
+      // 现在清空只有一种表达：**显式带 key 且值为 undefined**（JSON 边界写 null，
+      // 由 MCP 工具层翻译成带 key 的 undefined），与 GUI 表单「恒带 key」的既有
+      // 行为一致。interval 任务只改 cronExpr 时，interval 语义保持权威（cron 仅作
+      // 展示），nextFireAt 按 now + intervalMs 重新起算。仍然刻意**不做**「按形态
+      // 推导 interval」：cron 就是 cron，与 create()（不推导）对称。
       const merged: Schedule = { ...existing, ...updates };
       if (merged.manual) {
         updates.nextFireAt = undefined;
@@ -1305,7 +1313,7 @@ export class Scheduler extends EventEmitter {
         patch.cronExpr !== undefined ||
         patch.timezone !== undefined ||
         patch.manual === false ||
-        patch.intervalMs !== undefined ||
+        intervalKeyPresent ||
         shouldReactivateExpired
       ) {
         // intervalMs 模式：把"修改"视作冷启动，从 now 起新一轮 N 倒计时。

--- a/packages/maker-shared/src/__tests__/scheduleForm.test.ts
+++ b/packages/maker-shared/src/__tests__/scheduleForm.test.ts
@@ -10,9 +10,11 @@ import {
   MOBILE_SCHEDULE_PENDING_SESSION_ID,
   updateDraftAgentKind,
   updateDraftBoundSessionId,
+  updateDraftCronExpr,
   updateDraftIntervalMinutes,
   updateDraftRunMode,
   updateDraftSessionMode,
+  updateDraftTimezone,
   validateTemplateParamValues,
   validateMobileScheduleDraft,
 } from '../scheduleForm.js';
@@ -142,6 +144,15 @@ describe('mobile schedule form model', () => {
     // 切 manual 是显式 cadence 操作:切回 recurring 也不复活旧间隔
     const manualRoundTrip = updateDraftRunMode(updateDraftRunMode(draft, 'manual'), 'recurring');
     expect(buildMobileScheduleInput(manualRoundTrip).intervalMs).toBeNull();
+
+    // 编辑可见 cron / 时区同样是显式 cadence 操作:隐藏 interval 不得继续权威,
+    // 否则用户刚改的排期完全不生效(codex review 发现)。
+    const cronEdited = buildMobileScheduleInput(updateDraftCronExpr(draft, '30 8 * * *'));
+    expect(cronEdited.intervalMs).toBeNull();
+    expect(cronEdited.cronExpr).toBe('30 8 * * *');
+    expect(
+      buildMobileScheduleInput(updateDraftTimezone(draft, 'America/New_York')).intervalMs,
+    ).toBeNull();
   });
 
   it('writes an explicit false when mobile disables WeCom group notifications', () => {

--- a/packages/maker-shared/src/__tests__/scheduleForm.test.ts
+++ b/packages/maker-shared/src/__tests__/scheduleForm.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   applyMobileTemplateParams,
+  applyScheduleWireCompat,
   applyTemplateToMobileScheduleDraft,
   buildMobileScheduleInput,
   createMobileScheduleDraft,
@@ -102,6 +103,24 @@ describe('mobile schedule form model', () => {
 
     const kept = buildMobileScheduleInput({ ...edited, intervalMinutes: '15' });
     expect(kept.intervalMs).toBe(15 * 60_000);
+  });
+
+  it('downgrades the null clear to key omission for hosts without the capability', () => {
+    const edited = createMobileScheduleDraft(schedule({ intervalMs: 900_000 }));
+    const cleared = buildMobileScheduleInput({ ...edited, intervalMinutes: '' });
+
+    // 旧 desktop:null 会被旧引擎当成已设间隔立即触发;省略 key 让旧引擎的
+    // 隐式清空(带 cronExpr 不带 intervalMs)承担等价语义。
+    const legacy = applyScheduleWireCompat(cleared, { supportsIntervalNullClear: false });
+    expect(hasOwn(legacy, 'intervalMs')).toBe(false);
+    expect(legacy.cronExpr).toBe(cleared.cronExpr);
+
+    // 新 desktop:null 原样过线,由 IPC 入口归一化。
+    expect(applyScheduleWireCompat(cleared, { supportsIntervalNullClear: true })).toBe(cleared);
+
+    // 数值间隔与能力无关,两种 host 都原样透传。
+    const kept = buildMobileScheduleInput({ ...edited, intervalMinutes: '15' });
+    expect(applyScheduleWireCompat(kept, { supportsIntervalNullClear: false })).toBe(kept);
   });
 
   it('writes an explicit false when mobile disables WeCom group notifications', () => {

--- a/packages/maker-shared/src/__tests__/scheduleForm.test.ts
+++ b/packages/maker-shared/src/__tests__/scheduleForm.test.ts
@@ -85,6 +85,25 @@ describe('mobile schedule form model', () => {
     });
   });
 
+  it('clears intervalMs with a serializable null that survives the JSON wire', () => {
+    const edited = createMobileScheduleDraft(schedule({ intervalMs: 900_000 }));
+
+    const cleared = buildMobileScheduleInput({ ...edited, intervalMinutes: '' });
+    expect(cleared.intervalMs).toBeNull();
+
+    const manual = buildMobileScheduleInput({ ...edited, runMode: 'manual', intervalMinutes: '' });
+    expect(manual.intervalMs).toBeNull();
+
+    // device-link 经 JSON.stringify 传输:undefined 的 key 会被丢掉(= 桌面端
+    // 视为「不修改」),清空语义必须以 null 原样过线,由桌面接收端归一化。
+    const wire = JSON.parse(JSON.stringify(cleared)) as Record<string, unknown>;
+    expect(hasOwn(wire, 'intervalMs')).toBe(true);
+    expect(wire.intervalMs).toBeNull();
+
+    const kept = buildMobileScheduleInput({ ...edited, intervalMinutes: '15' });
+    expect(kept.intervalMs).toBe(15 * 60_000);
+  });
+
   it('writes an explicit false when mobile disables WeCom group notifications', () => {
     const draft = createMobileScheduleDraft(schedule({
       notify: { desktop: true, feishu: false, wecomGroup: true },

--- a/packages/maker-shared/src/__tests__/scheduleForm.test.ts
+++ b/packages/maker-shared/src/__tests__/scheduleForm.test.ts
@@ -10,6 +10,8 @@ import {
   MOBILE_SCHEDULE_PENDING_SESSION_ID,
   updateDraftAgentKind,
   updateDraftBoundSessionId,
+  updateDraftIntervalMinutes,
+  updateDraftRunMode,
   updateDraftSessionMode,
   validateTemplateParamValues,
   validateMobileScheduleDraft,
@@ -89,7 +91,8 @@ describe('mobile schedule form model', () => {
   it('clears intervalMs with a serializable null that survives the JSON wire', () => {
     const edited = createMobileScheduleDraft(schedule({ intervalMs: 900_000 }));
 
-    const cleared = buildMobileScheduleInput({ ...edited, intervalMinutes: '' });
+    // 清空必须走编辑入口(标记 touched)——未触碰的空值是「表达不了」不是「清空」。
+    const cleared = buildMobileScheduleInput(updateDraftIntervalMinutes(edited, ''));
     expect(cleared.intervalMs).toBeNull();
 
     const manual = buildMobileScheduleInput({ ...edited, runMode: 'manual', intervalMinutes: '' });
@@ -107,7 +110,7 @@ describe('mobile schedule form model', () => {
 
   it('downgrades the null clear to key omission for hosts without the capability', () => {
     const edited = createMobileScheduleDraft(schedule({ intervalMs: 900_000 }));
-    const cleared = buildMobileScheduleInput({ ...edited, intervalMinutes: '' });
+    const cleared = buildMobileScheduleInput(updateDraftIntervalMinutes(edited, ''));
 
     // 旧 desktop:null 会被旧引擎当成已设间隔立即触发;省略 key 让旧引擎的
     // 隐式清空(带 cronExpr 不带 intervalMs)承担等价语义。
@@ -121,6 +124,24 @@ describe('mobile schedule form model', () => {
     // 数值间隔与能力无关,两种 host 都原样透传。
     const kept = buildMobileScheduleInput({ ...edited, intervalMinutes: '15' });
     expect(applyScheduleWireCompat(kept, { supportsIntervalNullClear: false })).toBe(kept);
+  });
+
+  it('preserves a form-inexpressible interval unless the user explicitly touches it', () => {
+    // 90 分钟表单表达不了(非 1-59 分钟/整点小时),intervalMinutes 折叠成 ''
+    const draft = createMobileScheduleDraft(schedule({ intervalMs: 90 * 60_000 }));
+    expect(draft.intervalMinutes).toBe('');
+
+    // 只改 prompt:间隔原值回传,不因「表单显示不了」被顺手清空
+    const untouched = buildMobileScheduleInput({ ...draft, prompt: 'new prompt' });
+    expect(untouched.intervalMs).toBe(90 * 60_000);
+
+    // 用户经编辑入口清空 → 明确清空
+    const cleared = buildMobileScheduleInput(updateDraftIntervalMinutes(draft, ''));
+    expect(cleared.intervalMs).toBeNull();
+
+    // 切 manual 是显式 cadence 操作:切回 recurring 也不复活旧间隔
+    const manualRoundTrip = updateDraftRunMode(updateDraftRunMode(draft, 'manual'), 'recurring');
+    expect(buildMobileScheduleInput(manualRoundTrip).intervalMs).toBeNull();
   });
 
   it('writes an explicit false when mobile disables WeCom group notifications', () => {

--- a/packages/maker-shared/src/scheduleForm.ts
+++ b/packages/maker-shared/src/scheduleForm.ts
@@ -35,6 +35,18 @@ export interface MobileScheduleDraft {
   cronExpr: string;
   timezone: string;
   intervalMinutes: string;
+  /**
+   * 原任务的 intervalMs。表单只表达得了 1-59 分钟 / 整点小时,MCP 可以设出
+   * 表单区间外的间隔(如 90 分钟),这时 intervalMinutes 折叠成 '' ——保存时
+   * 必须能区分「表达不了」和「用户清空」,否则只改 prompt 也会静默清掉间隔
+   * (copilot review 发现)。
+   */
+  sourceIntervalMs?: number;
+  /**
+   * 用户是否动过间隔(输入框编辑、切 manual、套模板都算)。动过且为空 =
+   * 明确清空;没动过为空 = 保留 sourceIntervalMs 原值。
+   */
+  intervalMinutesTouched?: boolean;
   agentKind: RemoteScheduleAgentKind;
   model: string;
   providerId: string;
@@ -100,6 +112,7 @@ export function createMobileScheduleDraft(
     cronExpr: schedule.cronExpr?.trim() || DEFAULT_CRON,
     timezone: schedule.timezone?.trim() || DEFAULT_TIMEZONE,
     intervalMinutes: intervalMsToSupportedMinutes(schedule.intervalMs),
+    ...(typeof schedule.intervalMs === 'number' ? { sourceIntervalMs: schedule.intervalMs } : {}),
     agentKind: schedule.agentKind ?? 'claude-code',
     model: schedule.model ?? defaultModelFor(schedule.agentKind ?? 'claude-code'),
     providerId: schedule.providerId ?? '',
@@ -140,7 +153,9 @@ export function applyTemplateToMobileScheduleDraft(
     runMode: template.recurring === false ? 'manual' : 'recurring',
     cronExpr: template.cronExpr?.trim() || draft.cronExpr,
     timezone: template.timezone?.trim() || draft.timezone,
+    // 模板显式定义 cadence:清空间隔是模板的意图,不是「表达不了」,按已触碰处理。
     intervalMinutes: '',
+    intervalMinutesTouched: true,
     agentKind,
     model: template.model ?? (draft.agentKind === agentKind ? draft.model : defaultModelFor(agentKind)),
     // 模板若固定了 provider，必须随模板一起落到新建任务；否则 Pi 的空模型会在
@@ -258,7 +273,16 @@ export function buildMobileScheduleInput(draft: MobileScheduleDraft): RemoteSche
     // 发 null 而不是 undefined——这个 input 经 device-link JSON.stringify 传输,
     // undefined 的 key 会被丢掉,desktop 端真 partial 语义下旧 intervalMs 会被
     // 保留,清空间隔 / manual 切回 recurring 就静默失效(codex review 发现)。
-    intervalMs: recurring && intervalMinutes ? intervalMinutes * 60_000 : null,
+    // 例外:表单区间表达不了的既有间隔(sourceIntervalMs 在、intervalMinutes 折叠
+    // 为 '' 且用户没动过)原值回传,只改 prompt 不得顺手清 cadence(copilot review
+    // 发现;touched 语义见 MobileScheduleDraft.intervalMinutesTouched)。
+    intervalMs: recurring && intervalMinutes
+      ? intervalMinutes * 60_000
+      : recurring
+          && !draft.intervalMinutesTouched
+          && typeof draft.sourceIntervalMs === 'number'
+        ? draft.sourceIntervalMs
+        : null,
     agentKind: draft.agentKind,
     workspaceKind: draft.workspaceKind,
     useWorktree: draft.workspaceKind === 'project' && draft.useWorktree,
@@ -348,6 +372,14 @@ export function updateDraftAgentKind(
   };
 }
 
+/** 间隔输入框的编辑入口:任何编辑(含清空)都标记 touched,与「表达不了被折叠成空」区分。 */
+export function updateDraftIntervalMinutes(
+  draft: MobileScheduleDraft,
+  intervalMinutes: string,
+): MobileScheduleDraft {
+  return { ...draft, intervalMinutes, intervalMinutesTouched: true };
+}
+
 export function updateDraftRunMode(
   draft: MobileScheduleDraft,
   runMode: MobileScheduleRunMode,
@@ -357,6 +389,9 @@ export function updateDraftRunMode(
     ...draft,
     runMode,
     intervalMinutes: runMode === 'manual' ? '' : draft.intervalMinutes,
+    // 切 manual 是对 cadence 的显式操作:之后切回 recurring 也不该复活旧间隔
+    // (2026-08-03 codex review:manual 切回 recurring 仍按旧间隔跑就是事故形态)。
+    ...(runMode === 'manual' ? { intervalMinutesTouched: true } : {}),
   };
 }
 

--- a/packages/maker-shared/src/scheduleForm.ts
+++ b/packages/maker-shared/src/scheduleForm.ts
@@ -254,7 +254,11 @@ export function buildMobileScheduleInput(draft: MobileScheduleDraft): RemoteSche
     timezone: draft.timezone.trim(),
     recurring,
     manual: !recurring,
-    intervalMs: recurring && intervalMinutes ? intervalMinutes * 60_000 : undefined,
+    // Mobile 表单是全量提交:没填间隔(或 manual 模式)就是要清空间隔。清空必须
+    // 发 null 而不是 undefined——这个 input 经 device-link JSON.stringify 传输,
+    // undefined 的 key 会被丢掉,desktop 端真 partial 语义下旧 intervalMs 会被
+    // 保留,清空间隔 / manual 切回 recurring 就静默失效(codex review 发现)。
+    intervalMs: recurring && intervalMinutes ? intervalMinutes * 60_000 : null,
     agentKind: draft.agentKind,
     workspaceKind: draft.workspaceKind,
     useWorktree: draft.workspaceKind === 'project' && draft.useWorktree,

--- a/packages/maker-shared/src/scheduleForm.ts
+++ b/packages/maker-shared/src/scheduleForm.ts
@@ -380,6 +380,28 @@ export function updateDraftIntervalMinutes(
   return { ...draft, intervalMinutes, intervalMinutesTouched: true };
 }
 
+/**
+ * cron 表达式输入的编辑入口:编辑任何可见 cadence 字段都是显式 cadence 操作,
+ * 一并丢弃表单表达不了的隐藏 interval——否则用户改了看得见的 cron,保存后隐藏
+ * interval 仍是权威,刚改的排期完全不生效(codex review 发现)。不变量:保存后
+ * 的 cadence 语义 = 用户在表单看到并确认的状态;隐藏 interval 只在编辑无关
+ * 字段(prompt / 名称 / 通知等)时保留。
+ */
+export function updateDraftCronExpr(
+  draft: MobileScheduleDraft,
+  cronExpr: string,
+): MobileScheduleDraft {
+  return { ...draft, cronExpr, intervalMinutesTouched: true };
+}
+
+/** 时区输入的编辑入口:与 updateDraftCronExpr 同一 cadence 不变量。 */
+export function updateDraftTimezone(
+  draft: MobileScheduleDraft,
+  timezone: string,
+): MobileScheduleDraft {
+  return { ...draft, timezone, intervalMinutesTouched: true };
+}
+
 export function updateDraftRunMode(
   draft: MobileScheduleDraft,
   runMode: MobileScheduleRunMode,

--- a/packages/maker-shared/src/scheduleForm.ts
+++ b/packages/maker-shared/src/scheduleForm.ts
@@ -312,6 +312,27 @@ export function buildMobileScheduleInput(draft: MobileScheduleDraft): RemoteSche
   return input;
 }
 
+/**
+ * 按被控端能力决定 intervalMs 清空的 wire 形态(device-link 两端版本会错位):
+ *
+ * - 新 desktop(capabilities.supportsScheduleIntervalNullClear)认识 null,
+ *   IPC 入口把它归一化成引擎的「带 key 的 undefined」显式清空;
+ * - 旧 desktop 没有归一化逻辑,null 会被旧引擎当成已设间隔算出 now + null
+ *   立即触发(codex review 发现);对它必须回退旧 wire 形态——**省略 key**,
+ *   旧引擎「带 cronExpr 不带 intervalMs = 隐式清空」恰好承担等价的清空语义。
+ *
+ * 能力探测失败按不支持处理:错发省略 key 到新 desktop 最坏是清空 no-op
+ * (重新保存可纠正),错发 null 到旧 desktop 是立即触发,失败方向必须朝前者。
+ */
+export function applyScheduleWireCompat(
+  input: RemoteScheduleWriteInput,
+  opts: { supportsIntervalNullClear: boolean },
+): RemoteScheduleWriteInput {
+  if (opts.supportsIntervalNullClear || input.intervalMs !== null) return input;
+  const { intervalMs: _legacyDropped, ...legacy } = input;
+  return legacy;
+}
+
 export function updateDraftAgentKind(
   draft: MobileScheduleDraft,
   agentKind: RemoteScheduleAgentKind,

--- a/packages/maker-shared/src/scheduleTypes.ts
+++ b/packages/maker-shared/src/scheduleTypes.ts
@@ -24,7 +24,9 @@ export interface RemoteScheduleWriteInput {
    * Interval 语义间隔(毫秒)。这个类型跨 device-link 的 JSON 边界传输,而
    * JSON.stringify 会丢掉值为 undefined 的 key——所以「清空间隔、退回 cron
    * 壁钟语义」必须用可序列化的 null 表达(desktop 接收端归一化成引擎的
-   * 「带 key 的 undefined」);省略 key = 不修改。
+   * 「带 key 的 undefined」)。省略 key 的含义随用途而不同:本类型同时服务
+   * create() 与 update() 的 patch(见 mobileMakerTransport 的 schedule 面),
+   * create 里省略 = 不设间隔(纯 cron 语义),update 里省略 = 不修改现有值。
    */
   intervalMs?: number | null;
   agentKind: RemoteScheduleAgentKind;

--- a/packages/maker-shared/src/scheduleTypes.ts
+++ b/packages/maker-shared/src/scheduleTypes.ts
@@ -20,7 +20,13 @@ export interface RemoteScheduleWriteInput {
   timezone: string;
   recurring: boolean;
   manual?: boolean;
-  intervalMs?: number;
+  /**
+   * Interval 语义间隔(毫秒)。这个类型跨 device-link 的 JSON 边界传输,而
+   * JSON.stringify 会丢掉值为 undefined 的 key——所以「清空间隔、退回 cron
+   * 壁钟语义」必须用可序列化的 null 表达(desktop 接收端归一化成引擎的
+   * 「带 key 的 undefined」);省略 key = 不修改。
+   */
+  intervalMs?: number | null;
   agentKind: RemoteScheduleAgentKind;
   model?: string;
   providerId?: string;


### PR DESCRIPTION
## 这次改了什么

### 摘要

`schedule_update` 此前不是真正的 partial 更新:patch 带 `cronExpr` 但没带 `intervalMs` 时,引擎会**隐式清空** `intervalMs`,把相对间隔任务静默打回 cron 槽位语义。这个隐式清空是 MCP schema 还不暴露 `intervalMs` 时代的权宜(当时不清的话改 cron 形同虚设);`intervalMs` 对调用方开放后,它反过来成了静默事故源——agent 只更新 prompt + cronExpr(cadence 展示对齐的常见形态)就会破坏任务的间隔语义(2026-07-29 一条 PR 心跳实测中招),所有调用方被迫记住「改 prompt 必须把 cronExpr + intervalMs + preRunHook 一起带上」的咒语。

本 PR 把更新语义改成**真 partial**:

- **没带 key 就不动**:只改 prompt / cronExpr 不再影响 `intervalMs`;interval 任务只改 cronExpr 时,interval 语义保持权威(cron 仅作展示),`nextFireAt` 按 now + intervalMs 重新起算。
- **清空只有一种表达**:显式带 key 且值为 undefined(JSON 边界写 `intervalMs: null`,由边界层翻译,与 `targetSessionId: null` 解绑同一约定)。
- **`preRunHook.timeoutMs` 同族修复**:MCP 更新 hook 只改 `command` 时沿用任务现有 `timeoutMs`(此前整对象替换会把省略的超时静默清成「不限时」);传 `timeoutMs: null` 才显式清除。「没提供」判定覆盖缺 key 与带 key undefined 两种形态(copilot review 指出后者曾漏进清空分支)。
- **Mobile 的 device-link JSON 边界同族修复**(codex review 发现):mobile 全量表单此前靠隐式清空实现「清空间隔 / manual 切回 recurring」,而 device-link 经 `JSON.stringify` 传输会丢掉值为 undefined 的 key,真 partial 语义下旧 `intervalMs` 会被静默保留。现在 mobile 清空发可序列化的 `intervalMs: null`,desktop IPC 入口(create / update / create-from-template overrides 三个 JSON 边界)统一归一化成引擎的「带 key 的 undefined」。
- **两端版本错位的能力门控**(codex review 发现):`intervalMs: null` 只有新 desktop 认识,旧引擎会把 null 当已设间隔算出 `now + null` 立即触发。desktop `maker:get-capabilities` 新增 `supportsScheduleIntervalNullClear` 能力位(沿用 `supportsSessionAgentSwitch` 的「旧端缺省 false」模式);mobile 发送前探测,能力缺失/探测失败时经 `applyScheduleWireCompat` 降级为省略 key 的旧 wire 形态——旧引擎「带 cronExpr 不带 intervalMs = 隐式清空」恰好承担等价的清空语义。
- **反方向兼容**(codex review 发现,对称另一半):旧版 mobile 清空只会发「全量表单不带 intervalMs key」,真 partial 下会变成「不修改」。desktop update 入口按可信来源标记(`isDeviceLinkInvoke`,AsyncLocalStorage,不信任 payload 自述)+ 旧全量表单形态(带 cronExpr/manual/notify 却无 intervalMs key)把省略翻译回显式清空;新版 mobile 恒带 key(数值或 null),永远不命中该分支,MCP 与桌面 renderer 不走 device-link 不受影响。
- **表单表达不了的间隔不再被顺手清空**(copilot review 发现):MCP 能设出表单区间外的间隔(如 90 分钟),mobile 表单把它折叠成空字符串,此前只改 prompt 保存也会连带清掉间隔(旧隐式清空时代即如此)。draft 现在记录 `sourceIntervalMs` 并用 `intervalMinutesTouched` 区分「表达不了」与「用户清空」:编辑无关字段(prompt/名称/通知等)→ 原值回传;任一显式 cadence 操作(编辑间隔、改 cron、改时区、切 manual、套模板)→ 明确清空,保证保存后的 cadence 语义 = 用户在表单看到并确认的状态,隐藏 interval 不会在用户改完 cron 后继续权威(codex review 补上 cron/时区这半边)。

**清空表达的版本兼容矩阵**(不变量:任意两端版本组合下,保存后的 interval 语义 = 用户在表单看到并确认的状态,不得意外清空/意外保留/立即触发):

| 控制端 → 被控端 | 清空表达 | 结果 |
|---|---|---|
| 新 mobile → 新 desktop | `intervalMs: null` → IPC 归一化 | ✅ 显式清空 |
| 新 mobile → 旧 desktop | 能力位缺失 → 降级省略 key | ✅ 旧引擎隐式清空 |
| 旧 mobile → 新 desktop | 省略 key + device-link 来源 + 全量表单形态 | ✅ 接收端翻译回显式清空 |
| 旧 mobile → 旧 desktop | 省略 key | ✅ 旧行为不变 |
| MCP / 桌面 GUI | `null` 由 MCP 层翻译 / structured clone 恒带 key | ✅ 真 partial |

仓内全部 `scheduler.update()` 调用方已逐一审计,无一依赖旧的隐式清空:GUI 表单与 project-automation-loader 均为「恒带 key」形态(桌面 renderer 走 structured clone,undefined key 不丢,行为不变);runner 内部调用不触碰 cadence 字段;mobile 全量表单曾依赖隐式清空实现清空间隔——初版审计漏了这条(只查了 `apps/mobile`,漏了 `packages/maker-shared` 的表单模型),由 codex review 补上,本 PR 内已闭环。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(来自 PR 心跳自动化的实际踩坑复盘)
- 本 PR 包含:`packages/maker-scheduler` 引擎 update 语义、`packages/lizi-mcps` schedule_update 工具的 JSON 边界翻译与 schema、`packages/maker-shared` mobile 表单清空表达(`intervalMs: null`)/wire 兼容降级(`applyScheduleWireCompat`)/表达不了的间隔保留(`sourceIntervalMs` + touched 三态)、`apps/desktop` maker-ipc schedule 入口的 null 归一化 + 旧版 mobile 省略 key 的清空翻译 + `supportsScheduleIntervalNullClear` 能力位、`apps/mobile` 自动化保存路径的能力门控与间隔编辑入口、各侧测试
- 明确不包含:GUI 表单交互改动(恒带 key,行为不变);preRunHook 在引擎层的整对象替换语义(保持不变,partial 表达只在 JSON 边界翻译)
- 用户可见变化:通过 MCP 更新调度的 agent 不再需要「三件套一起带」;`intervalMs: null` / `preRunHook.timeoutMs: null` 获得显式清空表达;mobile 清空间隔在新语义下仍然生效
- 是否存在 breaking change:有,说明:`schedule_update` 只带 `cronExpr` 时不再隐式清空 `intervalMs`。依赖旧行为清空的调用方需改为显式传 `intervalMs: null`。仓内调用方已全部审计(见摘要),mobile 路径已在本 PR 内同步迁移;工具 description 已同步新语义。

### UI 变化

不涉及。

- 引用的设计规范:不涉及:命中 UI 路径的 `apps/mobile/app/automations/[deviceId].tsx` 为纯逻辑改动(保存路径的 wire 兼容降级与 cadence 输入的 touched 标记),无视觉/交互/文案变化

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-scheduler exec vitest run src/__tests__/scheduler.test.ts
结果:133 passed(含 3 个新用例:cronExpr-only 保持 interval 权威并从 now 重排 /
prompt-only 完全不动 intervalMs 与 nextFireAt(2026-07-29 事故形态回归)/
显式 intervalMs:undefined 单独清空并回落 cron 槽位;原「隐式清空」两用例按新契约重写)

pnpm --filter @cindy/mcps exec vitest run src/__tests__/cindy_schedulerMcpServer.test.ts
结果:56 passed(含 6 个新用例:prompt-only patch 不含 intervalMs key /
intervalMs:null → 带 key 的 undefined / hook 只改 command 沿用现有 timeoutMs /
timeoutMs:null 显式清除 / timeoutMs 带 key undefined 视作缺省沿用现有超时 /
interval 任务只 patch cronExpr 也无条件校验表达式)

pnpm --filter @cindy/maker-shared exec vitest run src/__tests__/scheduleForm.test.ts
结果:19 passed(含新用例:清空/manual 形态发 intervalMs:null 且 JSON round-trip 不丢
key;applyScheduleWireCompat 按能力位降级;表达不了的间隔只在编辑无关字段时原值
回传——编辑间隔/切 manual/改 cron/改时区/套模板任一 cadence 操作后即明确清空)

desktop: vitest run scheduleIntervalJsonBoundary.test.ts(新文件,8 用例:null→带 key
undefined / 数值与省略 key 原样透传 / JSON round-trip 全链路 / 旧版 mobile 全量表单
省略 key 的接收端清空翻译与来源·形态双门控)+ scheduleReadiness、
makerSharedFixtureParity 回归通过;mobile: scheduleFormModel / mobileMakerTransport /
mobileRemoteFlowSmoke 27 passed

bash run-unit-gate.sh(仓库根 pnpm test:unit 全量)
结果:GATE_EXIT=0 全绿

pnpm --filter mobile run typecheck:通过
NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run typecheck
结果:通过,0 个 TS 错误(默认 4GB heap 下 tsc OOM,与本 diff 无关的环境限制)
```

### 手工验证

不涉及:行为变化全部由引擎、MCP 层、表单模型与 IPC 边界单测覆盖;GUI 路径(恒带 key)行为不变。

### 未执行的验证

- Desktop GUI 实机编辑调度回归:GUI 表单「恒带 key」形态在新旧契约下行为完全一致(引擎测试覆盖),未做实机点击验证。
- Mobile 实机清空间隔回归:链路各环(表单发 null → JSON round-trip 保 key → 能力位探测与降级 → desktop 归一化 → 引擎清空)均有单测,未做实机联调(含对旧版 desktop 的实机降级验证)。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他:调度 API 更新语义变化(详见影响与回滚)

### 影响与回滚

- 影响范围:所有经 `scheduler.update()` / MCP `schedule_update` / device-link 的调度更新。行为差异只在「patch 带 cronExpr 但不带 intervalMs 且任务是 interval 模式」这一形态:旧行为清空 interval(任务退回壁钟语义),新行为保留 interval(cron 仅作展示更新)。存量 DB 数据无 schema 变化、无迁移。
- 版本偏差窗口:四种版本组合已全部闭环(见摘要的兼容矩阵),无遗留偏差窗口。
- 回滚 / 降级方式:revert 本 PR 即回到旧语义;无数据迁移,随时可回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(引擎注释记录了两个方向的历史教训;工具 description 与跨端类型注释同步新语义)
- [x] 已确认测试结果或说明未执行原因
