### PR TITLE
fix(desktop): keep providers available when optional Pi is unavailable

### DIFF
--- a/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
@@ -41,6 +41,33 @@ function stubElectron() {
   return { getCapabilities, invoke };
 }
 
+function stubLocalCatalog() {
+  let providerId = 'provider-old';
+  let capabilityRevision = 'old';
+  let unavailableAgent: string | null = null;
+  const getCapabilities = vi.fn(async (agent: string) => {
+    if (agent === unavailableAgent) throw new Error(`Agent '${agent}' is not registered`);
+    return caps(`${capabilityRevision}:${agent}`);
+  });
+  const listProviders = vi.fn(async () => ({
+    dataOwnerId: null,
+    ownerGeneration: 0,
+    providers: [{ id: providerId }],
+    providerOrder: [providerId],
+  }));
+  vi.stubGlobal('window', { electronAPI: { maker: { getCapabilities, listProviders } } });
+  return {
+    getCapabilities,
+    setSnapshot(nextProviderId: string, nextCapabilityRevision: string): void {
+      providerId = nextProviderId;
+      capabilityRevision = nextCapabilityRevision;
+    },
+    setUnavailableAgent(agent: string | null): void {
+      unavailableAgent = agent;
+    },
+  };
+}
+
 describe('useAgentCapabilities deviceId-aware cache', () => {
   it('本机路径:preload 命中 maker.getCapabilities,不碰 deviceLink', async () => {
     const { getCapabilities, invoke } = stubElectron();
@@ -96,6 +123,66 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
 
     await expect(mod.loadLocalCapabilitiesSnapshot()).rejects.toThrow(
       "Agent 'codex' is not registered",
+    );
+  });
+
+  it('Pi 不可用且没有旧快照时仍联合提交 provider 与核心能力', async () => {
+    const harness = stubLocalCatalog();
+    harness.setSnapshot('provider-initial', 'initial');
+    harness.setUnavailableAgent('pi');
+    const catalog = await import('@/lib/localCatalogSnapshot');
+    const providers = await import('@/lib/providersSnapshotStore');
+    const capabilities = await import('@/hooks/useAgentCapabilities');
+
+    await expect(catalog.refreshLocalCatalogSnapshot()).resolves.toBe(true);
+
+    expect(providers.getCachedProvidersSnapshot()?.providers).toEqual([{ id: 'provider-initial' }]);
+    expect(capabilities.getCachedCapabilities('claude-code')?.availableModels[0].displayName).toBe(
+      'initial:claude-code',
+    );
+    expect(capabilities.getCachedCapabilities('codex')?.availableModels[0].displayName).toBe(
+      'initial:codex',
+    );
+    expect(capabilities.getCachedCapabilities('pi')).toBeNull();
+  });
+
+  it('Pi 不可用时用新 provider 快照替换 last-valid snapshot', async () => {
+    const harness = stubLocalCatalog();
+    const catalog = await import('@/lib/localCatalogSnapshot');
+    const providers = await import('@/lib/providersSnapshotStore');
+    const capabilities = await import('@/hooks/useAgentCapabilities');
+    await expect(catalog.refreshLocalCatalogSnapshot()).resolves.toBe(true);
+
+    harness.setSnapshot('provider-new', 'new');
+    harness.setUnavailableAgent('pi');
+    await expect(catalog.refreshLocalCatalogSnapshot()).resolves.toBe(true);
+
+    expect(providers.getCachedProvidersSnapshot()?.providers).toEqual([{ id: 'provider-new' }]);
+    expect(capabilities.getCachedCapabilities('claude-code')?.availableModels[0].displayName).toBe(
+      'new:claude-code',
+    );
+    expect(capabilities.getCachedCapabilities('codex')?.availableModels[0].displayName).toBe(
+      'new:codex',
+    );
+  });
+
+  it('核心 agent 失败时联合刷新保留 last-valid provider 与能力快照', async () => {
+    const harness = stubLocalCatalog();
+    const catalog = await import('@/lib/localCatalogSnapshot');
+    const providers = await import('@/lib/providersSnapshotStore');
+    const capabilities = await import('@/hooks/useAgentCapabilities');
+    await expect(catalog.refreshLocalCatalogSnapshot()).resolves.toBe(true);
+
+    harness.setSnapshot('provider-rejected', 'rejected');
+    harness.setUnavailableAgent('codex');
+    await expect(catalog.refreshLocalCatalogSnapshot()).resolves.toBe(false);
+
+    expect(providers.getCachedProvidersSnapshot()?.providers).toEqual([{ id: 'provider-old' }]);
+    expect(capabilities.getCachedCapabilities('claude-code')?.availableModels[0].displayName).toBe(
+      'old:claude-code',
+    );
+    expect(capabilities.getCachedCapabilities('codex')?.availableModels[0].displayName).toBe(
+      'old:codex',
     );
   });
 

--- a/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
@@ -55,7 +55,7 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
     );
   });
 
-  it('本机目录热刷新会原子替换两个 agent 的缓存快照', async () => {
+  it('本机目录热刷新会原子替换核心 agent 的缓存快照', async () => {
     const { getCapabilities } = stubElectron();
     const mod = await import('@/hooks/useAgentCapabilities');
     await mod.preloadAllCapabilities();
@@ -68,6 +68,34 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
     );
     expect(mod.getCachedCapabilities('codex')?.availableModels[0].displayName).toBe(
       'refreshed:codex',
+    );
+  });
+
+  it('本机目录快照在可选 Pi 不可用时仍返回 Claude Code 与 Codex 能力', async () => {
+    const { getCapabilities } = stubElectron();
+    getCapabilities.mockImplementation(async (agent: string) => {
+      if (agent === 'pi') throw new Error("Agent 'pi' is not registered");
+      return caps(`local:${agent}`);
+    });
+    const mod = await import('@/hooks/useAgentCapabilities');
+
+    await expect(mod.loadLocalCapabilitiesSnapshot()).resolves.toEqual([
+      ['claude-code', caps('local:claude-code')],
+      ['codex', caps('local:codex')],
+    ]);
+    expect(getCapabilities).toHaveBeenCalledWith('pi');
+  });
+
+  it('本机目录快照在核心 agent 不可用时仍拒绝提交部分能力', async () => {
+    const { getCapabilities } = stubElectron();
+    getCapabilities.mockImplementation(async (agent: string) => {
+      if (agent === 'codex') throw new Error("Agent 'codex' is not registered");
+      return caps(`local:${agent}`);
+    });
+    const mod = await import('@/hooks/useAgentCapabilities');
+
+    await expect(mod.loadLocalCapabilitiesSnapshot()).rejects.toThrow(
+      "Agent 'codex' is not registered",
     );
   });
 

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -493,12 +493,25 @@ export function beginLocalCapabilitiesRefresh(): number {
   return localGen;
 }
 
-/** 读取两种 agent 的完整能力快照；失败向上抛，不触碰现有缓存。 */
+/**
+ * 读取本地 agent 能力快照；核心 agent 失败向上抛，未注册的可选 Pi 不阻断 provider 目录。
+ */
 export async function loadLocalCapabilitiesSnapshot(): Promise<LocalCapabilitiesSnapshot> {
   const api = getMakerApi();
   if (!api) throw new Error('maker IPC not available');
-  return Promise.all(
-    ALL_AGENT_KINDS.map(async (agent) => [agent, await api.getCapabilities(agent)] as const),
+  const entries = await Promise.all(
+    ALL_AGENT_KINDS.map(async (agent): Promise<readonly [AgentKind, AgentCapabilities] | null> => {
+      try {
+        return [agent, await api.getCapabilities(agent)] as const;
+      } catch (error) {
+        if (agent !== 'pi') throw error;
+        log.warn('optional Pi capabilities unavailable; continuing with core agents:', error);
+        return null;
+      }
+    }),
+  );
+  return entries.filter(
+    (entry): entry is readonly [AgentKind, AgentCapabilities] => entry !== null,
   );
 }
 
@@ -506,7 +519,7 @@ export function isLocalCapabilitiesRefreshCurrent(generation: number): boolean {
   return localGen === generation;
 }
 
-/** 仅提交当前代际的完整能力快照，并在提交后统一通知 mounted hooks。 */
+/** 仅提交当前代际的可用能力快照，并在提交后统一通知 mounted hooks。 */
 export function commitLocalCapabilitiesSnapshot(
   generation: number,
   entries: LocalCapabilitiesSnapshot,
@@ -520,8 +533,8 @@ export function commitLocalCapabilitiesSnapshot(
 }
 
 /**
- * Codex auth/discovery 广播后的本地热刷新。旧 cache 在两个 IPC 都成功前继续可读；完成后同时
- * 替换 cache 并通知 mounted hooks，避免 provider:list 已更新而 scheduler/selector 仍用旧能力。
+ * Codex auth/discovery 广播后的本地热刷新。旧 cache 在核心 IPC 都成功前继续可读；完成后
+ * 同时替换 cache 并通知 mounted hooks，避免 provider:list 已更新而 scheduler/selector 仍用旧能力。
  */
 export async function refreshLocalCapabilities(): Promise<void> {
   const generation = beginLocalCapabilitiesRefresh();

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -494,7 +494,7 @@ export function beginLocalCapabilitiesRefresh(): number {
 }
 
 /**
- * 读取本地 agent 能力快照；核心 agent 失败向上抛，未注册的可选 Pi 不阻断 provider 目录。
+ * 读取本地 agent 能力快照；核心 agent 失败向上抛，可选 Pi 的能力读取失败不阻断 provider 目录。
  */
 export async function loadLocalCapabilitiesSnapshot(): Promise<LocalCapabilitiesSnapshot> {
   const api = getMakerApi();

--- a/apps/desktop/src/renderer/lib/localCatalogSnapshot.ts
+++ b/apps/desktop/src/renderer/lib/localCatalogSnapshot.ts
@@ -1,8 +1,9 @@
 /**
  * 本地 provider catalog 的 renderer 原子刷新协调器。
  *
- * providers 与两份 agent capabilities 必须来自同一轮 main 快照：三次 IPC 全部成功、
- * 且期间没有更新一代目录时才同步提交。失败或乱序结果一律保留上一份有效快照。
+ * providers 与核心 agent capabilities 必须来自同一轮 main 快照：核心 IPC 全部成功、
+ * 且期间没有更新一代目录时才同步提交。可选 Pi 未注册时提交核心能力；其它失败或乱序
+ * 结果一律保留上一份有效快照。
  * device-link 的远端 capabilities 不经过这里，继续按 deviceId 独立缓存。
  */
 import { createLogger } from '@/lib/logger';
@@ -22,7 +23,7 @@ import {
 const log = createLogger('localCatalogSnapshot');
 let refreshGeneration = 0;
 
-/** 联合刷新 providers + Claude/Codex capabilities，并只提交最新的完整结果。 */
+/** 联合刷新 providers + 已注册 agent capabilities，并只提交最新的完整结果。 */
 export async function refreshLocalCatalogSnapshot(): Promise<boolean> {
   const generation = ++refreshGeneration;
   const providersGeneration = beginProvidersRefresh();
@@ -34,9 +35,9 @@ export async function refreshLocalCatalogSnapshot(): Promise<boolean> {
       loadLocalCapabilitiesSnapshot(),
     ]);
     if (
-      refreshGeneration !== generation
-      || !isProvidersRefreshCurrent(providersGeneration, providers)
-      || !isLocalCapabilitiesRefreshCurrent(capabilitiesGeneration)
+      refreshGeneration !== generation ||
+      !isProvidersRefreshCurrent(providersGeneration, providers) ||
+      !isLocalCapabilitiesRefreshCurrent(capabilitiesGeneration)
     ) {
       return false;
     }
@@ -53,7 +54,7 @@ export async function refreshLocalCatalogSnapshot(): Promise<boolean> {
   }
 }
 
-/** 启动预热保留原有三次瞬时 IPC 重试语义；每次仍按完整快照原子提交。 */
+/** 启动预热保留原有三次瞬时 IPC 重试语义；每次仍按可用快照原子提交。 */
 export async function preloadLocalCatalogSnapshot(): Promise<void> {
   for (let attempt = 0; attempt < 3; attempt += 1) {
     if (await refreshLocalCatalogSnapshot()) return;

--- a/apps/desktop/src/renderer/lib/localCatalogSnapshot.ts
+++ b/apps/desktop/src/renderer/lib/localCatalogSnapshot.ts
@@ -2,8 +2,8 @@
  * 本地 provider catalog 的 renderer 原子刷新协调器。
  *
  * providers 与核心 agent capabilities 必须来自同一轮 main 快照：核心 IPC 全部成功、
- * 且期间没有更新一代目录时才同步提交。可选 Pi 未注册时提交核心能力；其它失败或乱序
- * 结果一律保留上一份有效快照。
+ * 且期间没有更新一代目录时才同步提交。可选 Pi 的能力读取失败时提交核心能力；其它失败
+ * 或乱序结果一律保留上一份有效快照。
  * device-link 的远端 capabilities 不经过这里，继续按 deviceId 独立缓存。
  */
 import { createLogger } from '@/lib/logger';
@@ -23,7 +23,7 @@ import {
 const log = createLogger('localCatalogSnapshot');
 let refreshGeneration = 0;
 
-/** 联合刷新 providers + 已注册 agent capabilities，并只提交最新的完整结果。 */
+/** 联合刷新 providers + 可用 agent capabilities，并只提交最新的完整结果。 */
 export async function refreshLocalCatalogSnapshot(): Promise<boolean> {
   const generation = ++refreshGeneration;
   const providersGeneration = beginProvidersRefresh();


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 是可选 runtime：首次下载超时或当前平台没有可用二进制时，main 会继续启动并只注册 Claude Code / Codex。此前 renderer 把三种 agent capabilities 放在同一个 `Promise.all` 中，Pi 未注册的 rejection 会连带丢弃已经成功读取的 provider snapshot，最终让「模型供应商」页面显示为空。

本 PR 保留 Claude Code / Codex 的原子失败语义，只把 Pi 能力读取作为可选结果。Pi 不可用时 provider catalog 仍会提交，Pi 自身仍由 runtime 注册状态控制可用性。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1467
- 本 PR 包含：renderer 本地 capability snapshot 的 Pi 容错；Pi 失败与核心 agent 失败的回归测试；相关原子快照注释校正。
- 明确不包含：不修改 Pi 60 秒启动下载 deadline，不修改 provider 存储、migration、IPC 协议或模型目录。
- 用户可见变化：Pi runtime 不可用时，「设置 → 模型供应商」仍显示可用供应商；Pi 继续保持不可用。
- 是否存在 breaking change：无。

### UI 变化

不涉及：只修改 renderer 数据预加载容错，不改视觉、交互结构或 UI 文案。

- 引用的设计规范：不涉及；未修改 UI 组件或样式。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts \
  src/renderer/__tests__/localCatalogSnapshot.test.ts \
  src/renderer/lib/__tests__/providersSnapshotStore.test.ts
结果：3 files passed，24 tests passed。

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：runner 341 passed / 1 skipped / 0 failed；Desktop、Mobile、packages 与 cindy-protocol 的全部配置 workspace 均通过。

pnpm exec prettier --check \
  apps/desktop/src/renderer/hooks/useAgentCapabilities.ts \
  apps/desktop/src/renderer/lib/localCatalogSnapshot.ts \
  apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
结果：通过。

pnpm check:dco
结果：2 commits signed off，检查通过。

git diff --check
结果：通过。
```

### 手工验证

在 macOS 26.3.1 arm64、Cindy 0.1.27 自动更新场景核对原始故障日志：provider catalog 与 14 个 gateway models 已成功加载；Pi 32,481,355-byte 下载在 60 秒时仅完成 18,693,766 bytes，随后 Pi 未注册导致 renderer 联合快照失败。日志链与本回归测试一致。

### 未执行的验证

未启动修改后源码构建的 Desktop GUI：本次没有视觉改动，修复行为由 renderer 联合快照与 capability cache 回归测试覆盖。未在 Windows 实机验证；改动只使用平台无关的 Promise/数组逻辑。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响本机 provider catalog 刷新时 Pi capability IPC 失败的路径。Claude Code / Codex 任一失败仍拒绝整轮提交，保留原有原子性。
- 回滚 / 降级方式：回退本提交即可恢复旧行为；无数据迁移、协议或持久化变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需用户文档变更）
- [x] 已确认测试结果或说明未执行原因
