### PR TITLE
fix(maker-core): 上下文超限终态识别与自锁解除 (#1429)

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-context-overflow.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-context-overflow.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAsyncQueue } from '../../shared/async-queue.js';
+import { UsageTracker } from '../../shared/usage-tracker.js';
+import { CONTEXT_OVERFLOW_REASON } from '../../shared/context-overflow-error.js';
+import {
+  newRuntimeState,
+  translateSdkMessage,
+  type TurnState,
+} from '../translator.js';
+import type { AgentEvent } from '../../../types/events.js';
+
+/**
+ * 上下文超限终态(#1429)的翻译层行为:
+ *  (a) error 事件带 CONTEXT_OVERFLOW_REASON(renderer 隐藏必败 Retry 的依据);
+ *  (b) tracker 锁到窗口满载 → status Done / done 的 endSnapshot 如实显示"已超限",
+ *      onUsageUpdate 拿到 ratio=1.0(turn end 的 auto-compact 判定由此触发);
+ *  (c) 失败轮的 0 增量 usage 不得把 (b) 刚锁上的值又冲回 0(replaceLastApi 守卫)。
+ */
+
+// #1429 实踩的 litellm/Azure 原文(经 xd 网关)。
+const OVERFLOW_ERROR_TEXT =
+  'API Error: 400 litellm.BadRequestError: AzureException BadRequestError - { "error": { "message": "Your input exceeds the context window of this model. Please adjust your input and try again.", "type": "invalid_request_error", "param": "input", "code": "context_length_exceeded" } }';
+
+function createTurnState(): TurnState {
+  return {
+    text: '',
+    toolUses: 0,
+    apiCalls: 0,
+    sawCompactBoundary: false,
+    hasEmittedText: false,
+    uiEmittedText: '',
+    pendingApiError: null,
+    interruptRequested: false,
+    generation: 0,
+    interruptGeneration: 0,
+    lastAssistantMsgHadSubstance: true,
+  };
+}
+
+function createCtx(tracker: UsageTracker) {
+  return {
+    rt: newRuntimeState(),
+    turn: createTurnState(),
+    log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn() },
+    getModel: () => 'gpt-5.6-sol',
+    getEffort: () => 'high' as const,
+    getPermissionMode: () => 'auto' as const,
+    onSessionId: vi.fn(),
+    getSdkSessionId: () => undefined,
+    getLogTitle: () => undefined,
+    tracker,
+    getModelContextWindow: () => 272_000,
+    onUsageUpdate: vi.fn(),
+  };
+}
+
+async function drain(queue: ReturnType<typeof createAsyncQueue<AgentEvent>>): Promise<AgentEvent[]> {
+  queue.end();
+  const events: AgentEvent[] = [];
+  for await (const event of queue) events.push(event);
+  return events;
+}
+
+describe('Claude Code translator context-overflow terminal result', () => {
+  it('tags the terminal error with the stable reason and locks the tracker to a full window', async () => {
+    const tracker = new UsageTracker();
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+    // 会话重启后首轮就失败的最坏形态: tracker 全新, lastApi=0(圆环本来会一直 0%)。
+    ctx.turn.apiCalls = 1;
+
+    translateSdkMessage(
+      {
+        type: 'result',
+        is_error: true,
+        result: OVERFLOW_ERROR_TEXT,
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        // 400 被上游整体拒绝: SDK 的 result.usage 停在会话累计旧值, 本轮 delta 为 0。
+        usage: { input_tokens: 0, output_tokens: 0 },
+        modelUsage: {
+          'gpt-5.6-sol': { inputTokens: 0, outputTokens: 0, costUSD: 0, contextWindow: 272_000 },
+        },
+      },
+      queue,
+      ctx,
+    );
+
+    const events = await drain(queue);
+    const error = events.find((e) => e.type === 'error');
+    expect(error).toBeDefined();
+    expect(error!.data).toMatchObject({ isTerminal: true, reason: CONTEXT_OVERFLOW_REASON });
+
+    // (b) endSnapshot 如实显示满载 —— status Done 事件与 tracker 本体一致
+    const done = events.find((e) => e.type === 'status');
+    expect(done!.data).toMatchObject({ contextTokens: 272_000, contextWindow: 272_000 });
+    expect(tracker.snapshot().contextTokens).toBe(272_000);
+
+    // auto-compact / memory-flush 观察到 ratio=1.0
+    expect(ctx.onUsageUpdate).toHaveBeenCalledWith(272_000, 272_000);
+  });
+
+  it('detects overflow that is only present in the pending API-error envelope', async () => {
+    const tracker = new UsageTracker();
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+    ctx.turn.apiCalls = 1;
+    ctx.turn.pendingApiError = {
+      message: OVERFLOW_ERROR_TEXT,
+      sdkError: 'api_error',
+    };
+
+    translateSdkMessage(
+      {
+        type: 'result',
+        is_error: true,
+        result: '',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+      },
+      queue,
+      ctx,
+    );
+
+    const events = await drain(queue);
+    const error = events.find((e) => e.type === 'error');
+    expect(error!.data).toMatchObject({ isTerminal: true, reason: CONTEXT_OVERFLOW_REASON });
+    expect(tracker.snapshot().contextTokens).toBe(272_000);
+  });
+
+  it('does NOT tag ordinary terminal errors and does NOT touch the tracker', async () => {
+    const tracker = new UsageTracker();
+    tracker.setContextWindow(272_000);
+    tracker.ingestApiCallUsage({ inputTokens: 50_000, outputTokens: 10 });
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+    ctx.turn.apiCalls = 1;
+
+    translateSdkMessage(
+      {
+        type: 'result',
+        is_error: true,
+        result: 'Internal server error, please retry later.',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+      },
+      queue,
+      ctx,
+    );
+
+    const events = await drain(queue);
+    const error = events.find((e) => e.type === 'error');
+    expect(error).toBeDefined();
+    expect((error!.data as { reason?: string }).reason).toBeUndefined();
+    // 普通失败不伪造读数
+    expect(tracker.snapshot().contextTokens).toBe(50_000);
+  });
+
+  it('does NOT mark an interrupted turn even when the drained result text matches', async () => {
+    // interrupt 后 drain 出的 result 不是上游失败(is_error 兜底同款排除),
+    // 不能借它把圆环推到 100%。
+    const tracker = new UsageTracker();
+    tracker.setContextWindow(272_000);
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+    ctx.turn.apiCalls = 1;
+    ctx.turn.interruptRequested = true;
+
+    translateSdkMessage(
+      {
+        type: 'result',
+        is_error: true,
+        result: OVERFLOW_ERROR_TEXT,
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+      },
+      queue,
+      ctx,
+    );
+
+    await drain(queue);
+    expect(tracker.snapshot().contextTokens).toBe(0);
+  });
+
+  it('keeps the locked value when the failed turn carries a real (non-zero) usage delta', async () => {
+    // 单 API 轮的 replaceLastApi 语义对正常轮保留; 超限轮守卫 !isContextOverflowTurn
+    // 确保失败轮 usage(常为 0 或残缺)不覆盖满载标记。
+    const tracker = new UsageTracker();
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+    ctx.turn.apiCalls = 1;
+
+    translateSdkMessage(
+      {
+        type: 'result',
+        is_error: true,
+        result: OVERFLOW_ERROR_TEXT,
+        stop_reason: 'end_turn',
+        total_cost_usd: 0,
+        usage: { input_tokens: 1_234, output_tokens: 0 },
+      },
+      queue,
+      ctx,
+    );
+
+    await drain(queue);
+    expect(tracker.snapshot().contextTokens).toBe(272_000);
+  });
+});

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -24,6 +24,10 @@ import {
 import type { createAsyncQueue } from '../shared/async-queue.js';
 import { stripTerminalControlSequences } from '../shared/terminal-output.js';
 import { formatOverloadRetryMessage, parseOverloadError } from '../shared/overload-error.js';
+import {
+  CONTEXT_OVERFLOW_REASON,
+  isContextOverflowErrorMessage,
+} from '../shared/context-overflow-error.js';
 import type { UsageTracker } from '../shared/usage-tracker.js';
 
 // ── 共享 turn / runtime 状态 ─────────────────────────────────────────────────
@@ -1474,6 +1478,31 @@ function handleResult(
     ctx.turn.apiCalls > 0 &&
     turnUsageDeltaAllZero;
 
+  // 上下文超限终态判定(提前到 endTurn 之前算, #1429): 超限请求被上游 400 整体拒绝,
+  // 不返回 usage —— tracker.lastApi 停在上一次成功值(会话重启后首轮就失败则是 0),
+  // 圆环显示低占用甚至 0%, auto-compact 的 ratio 永远到不了阈值, 会话进入
+  // "超限 → 无 usage → 不压缩 → 重试再超限"的自锁。提前算的原因(与 isEmptyResponseTurn
+  // 的提前同构):
+  //  (a) 在 endTurn 前 markContextOverflow() 把 tracker 锁到窗口满载, endSnapshot 的
+  //      contextTokens 如实反映"已超限"(status Done / done 事件跟随);
+  //  (b) 下方 ctx.onUsageUpdate 用该 endSnapshot 把 ratio=1.0 喂给 auto-compact /
+  //      memory-flush, turn end 即触发一次静默 /compact。best-effort: 压缩请求自身
+  //      发送全量历史, 真超限时可能同样失败; 失败轮不产生 compact_boundary,
+  //      AutoCompactController.fired 保持置位, 不会循环重压;
+  //  (c) endTurn 的 replaceLastApi 守卫加 !isContextOverflowTurn: 失败轮的 usage delta
+  //      通常为 0, 放任覆盖会把 (a) 刚锁上的满载值又冲回 0;
+  //  (d) is_error 分支给 error 事件带 CONTEXT_OVERFLOW_REASON, renderer 按稳定 key
+  //      隐藏必败的 Retry 并给出压缩 / 新开会话入口。
+  // 判定文本 = result 原文 + pendingApiError.message(信息可能只在其一; pattern 只认
+  // 错误措辞形态, 与 provider 无关)。interruptRequested 排除与下方 is_error 分支一致。
+  const isContextOverflowTurn =
+    Boolean(msg.is_error) &&
+    !ctx.turn.interruptRequested &&
+    isContextOverflowErrorMessage(
+      `${typeof msg.result === 'string' ? msg.result : ''}\n${ctx.turn.pendingApiError?.message ?? ''}`,
+    );
+  if (isContextOverflowTurn) ctx.tracker.markContextOverflow();
+
   // turn 桶快照 — endTurn 会清掉 turn 桶, 必须在调用之前先取出来给后面日志用
   const preTurnEndCacheStats = ctx.tracker.getCacheStats();
   const finalTextForLogs = msg.is_error ? redactSensitiveText(finalText) : finalText;
@@ -1489,8 +1518,12 @@ function handleResult(
           cacheCreateTokens: resultUsage.cacheCreateTokens,
           costUsd: msg.total_cost_usd,
           // 空响应轮不 replaceLastApi: 否则用本轮 0 增量覆盖 lastApi, 丢掉上一轮真实 context。
+          // 超限轮同理: markContextOverflow 刚锁上的满载值不能被失败轮的 0 增量冲掉。
           replaceLastApi:
-            ctx.turn.apiCalls === 1 && !ctx.turn.sawCompactBoundary && !isEmptyResponseTurn,
+            ctx.turn.apiCalls === 1 &&
+            !ctx.turn.sawCompactBoundary &&
+            !isEmptyResponseTurn &&
+            !isContextOverflowTurn,
         }
       : undefined,
   );
@@ -1670,6 +1703,10 @@ function handleResult(
     const errorMessage = pendingApiError?.agentMeta
       ? pendingApiError.message
       : errDetail || pendingApiError?.message;
+    // 上下文超限带稳定 reason key(判定在上方 endTurn 前已算好): renderer 靠它
+    // 隐藏必败的 Retry(原样重发必然再撞同一个 4xx)并给出压缩 / 新开会话入口;
+    // 文案匹配仅作历史持久化错误行的兜底(overload reason 同款分层)。
+    const overflowReason = isContextOverflowTurn ? { reason: CONTEXT_OVERFLOW_REASON } : {};
     queue.push({
       type: 'error',
       data: pendingApiError
@@ -1677,6 +1714,7 @@ function handleResult(
             message: errorMessage,
             sdkError: pendingApiError.sdkError,
             isTerminal: true,
+            ...overflowReason,
             ...(errorStatus !== undefined ? { errorStatus } : {}),
             ...(usageLimit ? { usageLimit: true } : {}),
             ...(pendingApiError.retryAttempt !== undefined
@@ -1690,6 +1728,7 @@ function handleResult(
         ? {
             message: errDetail,
             isTerminal: true,
+            ...overflowReason,
             ...(errorStatus !== undefined ? { errorStatus } : {}),
             ...(usageLimit ? { usageLimit: true } : {}),
           }

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -378,6 +378,25 @@ describe('translateErrorNotification', () => {
     expect(events[0]!.data).not.toHaveProperty('reason');
   });
 
+  it('上下文超限终止错误带 context-overflow reason(#1429): 原样重试必败, renderer 靠它换恢复动作', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message:
+          '400 Bad Request: {"error": {"message": "Your input exceeds the context window of this model.", "code": "context_length_exceeded"}}',
+      }),
+      q,
+      makeCtx(rt),
+    );
+    const events = await collect(q);
+    expect(events[0]!.data).toMatchObject({
+      reason: 'context-overflow',
+      isTerminal: true,
+    });
+  });
+
   it('容量拒绝改了文案措辞时，结构化 tag 仍触发接管重投', async () => {
     // 本用例锁的是这次改动的核心目标: 重投不再依赖 codex 的英文文案。
     // message 故意完全不含 "at capacity" —— 模拟 codex 升级改了措辞。若判定回退到

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -397,6 +397,46 @@ describe('translateErrorNotification', () => {
     });
   });
 
+  it('Codex 结构化 contextWindowExceeded tag 不依赖错误文案措辞', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message: 'The request cannot be processed.',
+        codexErrorInfo: 'contextWindowExceeded',
+      }),
+      q,
+      makeCtx(rt),
+    );
+    const events = await collect(q);
+    expect(events[0]!.data).toMatchObject({
+      codexErrorInfo: 'contextWindowExceeded',
+      reason: 'context-overflow',
+      isTerminal: true,
+    });
+  });
+
+  it('serverOverloaded tag 优先于文案里的上下文超限信号', async () => {
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    translateErrorNotification(
+      makeParams({
+        willRetry: false,
+        message: 'Your input exceeds the context window of this model.',
+        codexErrorInfo: 'serverOverloaded',
+      }),
+      q,
+      { ...makeCtx(rt), tryTakeOverOverload: () => null },
+    );
+    const events = await collect(q);
+    expect(events[0]!.data).toMatchObject({
+      codexErrorInfo: 'serverOverloaded',
+      reason: 'upstream-overload',
+      isTerminal: true,
+    });
+  });
+
   it('容量拒绝改了文案措辞时，结构化 tag 仍触发接管重投', async () => {
     // 本用例锁的是这次改动的核心目标: 重投不再依赖 codex 的英文文案。
     // message 故意完全不含 "at capacity" —— 模拟 codex 升级改了措辞。若判定回退到

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -37,6 +37,10 @@ import {
   formatOverloadRetryMessage,
   parseOverloadError,
 } from '../shared/overload-error.js';
+import {
+  CONTEXT_OVERFLOW_REASON,
+  isContextOverflowErrorMessage,
+} from '../shared/context-overflow-error.js';
 import { commandExecutionDisplayInput, type CommandExecutionDisplayInput } from './command-display.js';
 import { codexErrorInfoTag } from './app-server/protocol.js';
 import type {
@@ -337,6 +341,13 @@ export function translateErrorNotification(
   // 驱动)。不带的话 renderer 只能回退到文案匹配 —— codex 改一次措辞, 用户就会在整段
   // 重试窗口里看到英文原文, 也就是本次改动要消除的那个依赖在 UI 侧原样残留。
   const overloadReason = isCapacityError ? { reason: UPSTREAM_OVERLOAD_REASON } : {};
+  // 上下文超限同样带稳定 reason key(#1429): 原样重试必然再撞同一个 4xx, renderer 靠
+  // 它隐藏 Retry 并给出压缩 / 新开会话入口。与 capacity 互斥时 overload 优先 —— 它
+  // 还驱动退避重投接管, 语义更具体; pattern 上两者措辞集合不相交, 实际不会同时命中。
+  const contextOverflowReason =
+    !isCapacityError && isContextOverflowErrorMessage(safeMessage)
+      ? { reason: CONTEXT_OVERFLOW_REASON }
+      : {};
   if (!params.willRetry && isCapacityError) {
     const progress = ctx.tryTakeOverOverload?.();
     if (progress) {
@@ -360,6 +371,7 @@ export function translateErrorNotification(
     data: {
       ...safeErrorData,
       ...overloadReason,
+      ...contextOverflowReason,
       isTerminal: !params.willRetry,
       willRetry: params.willRetry,
     },

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -342,10 +342,12 @@ export function translateErrorNotification(
   // 重试窗口里看到英文原文, 也就是本次改动要消除的那个依赖在 UI 侧原样残留。
   const overloadReason = isCapacityError ? { reason: UPSTREAM_OVERLOAD_REASON } : {};
   // 上下文超限同样带稳定 reason key(#1429): 原样重试必然再撞同一个 4xx, renderer 靠
-  // 它隐藏 Retry 并给出压缩 / 新开会话入口。与 capacity 互斥时 overload 优先 —— 它
-  // 还驱动退避重投接管, 语义更具体; pattern 上两者措辞集合不相交, 实际不会同时命中。
+  // 它隐藏 Retry 并给出压缩 / 新开会话入口。结构化 contextWindowExceeded 优先，
+  // 文案匹配仅兼容旧版 app-server；与 capacity 互斥时 overload 优先 —— 它还驱动
+  // 退避重投接管，语义更具体。
   const contextOverflowReason =
-    !isCapacityError && isContextOverflowErrorMessage(safeMessage)
+    !isCapacityError &&
+    (errorInfoTag === 'contextWindowExceeded' || isContextOverflowErrorMessage(safeMessage))
       ? { reason: CONTEXT_OVERFLOW_REASON }
       : {};
   if (!params.willRetry && isCapacityError) {

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -48,6 +48,13 @@ export {
   type OverloadError,
   type OverloadErrorKind,
 } from './shared/overload-error.js';
+// 同上理由(同 bundle 直接复用): desktop main 的错误投影 / IM 渠道要认「上下文超限」
+// 这一类 —— 原样重试必败, 恢复动作是压缩上下文或新开会话, 与过载 / 网络类的自动
+// 重试语义相反。详见 shared/context-overflow-error.ts 的模块注释(#1429)。
+export {
+  CONTEXT_OVERFLOW_REASON,
+  isContextOverflowErrorMessage,
+} from './shared/context-overflow-error.js';
 // 同上理由(同 bundle 直接复用,不造第三份):desktop 的中断自愈判据要认「网络到不了
 // 上游」这一类 —— 那类同样是"连不上"而不是"请求有问题",续跑一次就能过去。
 export { isNetworkishErrorMessage } from './shared/network-error.js';

--- a/packages/maker-core/src/agents/shared/context-overflow-error.test.ts
+++ b/packages/maker-core/src/agents/shared/context-overflow-error.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { isContextOverflowErrorMessage } from './context-overflow-error';
+
+/**
+ * Pattern 与 desktop providerErrors.ts 的 CONTEXT_TOO_LONG_RE、renderer 镜像判定
+ * 同语义(三处同步, 见模块注释)。正例覆盖四类真实供应商措辞, 反例守住与
+ * overload / network 判定的互斥边界。
+ */
+describe('isContextOverflowErrorMessage', () => {
+  it('matches the litellm/Azure phrasing from #1429 (with and without the error code)', () => {
+    // 实踩原文: 结构化 code 字段随 JSON 一起出现
+    expect(
+      isContextOverflowErrorMessage(
+        'API Error: 400 litellm.BadRequestError: AzureException BadRequestError - { "error": { "message": "Your input exceeds the context window of this model. Please adjust your input and try again.", "type": "invalid_request_error", "param": "input", "code": "context_length_exceeded" } }',
+      ),
+    ).toBe(true);
+    // 只透出 message 正文、code 字段被裁掉时, 语序补条("exceeds ... context window")仍须命中
+    expect(
+      isContextOverflowErrorMessage(
+        'Your input exceeds the context window of this model. Please adjust your input and try again.',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches Anthropic / OpenAI / generic gateway phrasings', () => {
+    expect(
+      isContextOverflowErrorMessage('prompt is too long: 250000 tokens > 200000 maximum'),
+    ).toBe(true);
+    expect(
+      isContextOverflowErrorMessage(
+        "This model's maximum context length is 128000 tokens. However, your messages resulted in 131072 tokens.",
+      ),
+    ).toBe(true);
+    expect(isContextOverflowErrorMessage('Request rejected: too many tokens')).toBe(true);
+    expect(isContextOverflowErrorMessage('input length exceeds limit for this deployment')).toBe(
+      true,
+    );
+    expect(isContextOverflowErrorMessage('{"code": "context_length_exceeded"}')).toBe(true);
+  });
+
+  it('does NOT match overload / network / auth errors (disjoint recovery semantics)', () => {
+    expect(
+      isContextOverflowErrorMessage('Selected model is at capacity. Please try a different model.'),
+    ).toBe(false);
+    expect(isContextOverflowErrorMessage('overloaded_error: 529')).toBe(false);
+    expect(isContextOverflowErrorMessage('fetch failed: ECONNREFUSED 127.0.0.1:443')).toBe(false);
+    expect(isContextOverflowErrorMessage('401 Unauthorized: Missing bearer token')).toBe(false);
+  });
+
+  it('does NOT match ordinary text that merely mentions context or tokens', () => {
+    expect(isContextOverflowErrorMessage('reading the context window documentation')).toBe(false);
+    expect(isContextOverflowErrorMessage('token usage: 1200 input, 300 output')).toBe(false);
+    expect(isContextOverflowErrorMessage('')).toBe(false);
+  });
+});

--- a/packages/maker-core/src/agents/shared/context-overflow-error.test.ts
+++ b/packages/maker-core/src/agents/shared/context-overflow-error.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isContextOverflowErrorMessage } from './context-overflow-error';
+import { isContextOverflowErrorMessage } from './context-overflow-error.js';
 
 /**
  * Pattern 与 desktop providerErrors.ts 的 CONTEXT_TOO_LONG_RE、renderer 镜像判定
@@ -23,7 +23,7 @@ describe('isContextOverflowErrorMessage', () => {
     ).toBe(true);
   });
 
-  it('matches Anthropic / OpenAI / generic gateway phrasings', () => {
+  it('matches Anthropic / OpenAI / structured gateway phrasings', () => {
     expect(
       isContextOverflowErrorMessage('prompt is too long: 250000 tokens > 200000 maximum'),
     ).toBe(true);
@@ -32,11 +32,21 @@ describe('isContextOverflowErrorMessage', () => {
         "This model's maximum context length is 128000 tokens. However, your messages resulted in 131072 tokens.",
       ),
     ).toBe(true);
-    expect(isContextOverflowErrorMessage('Request rejected: too many tokens')).toBe(true);
-    expect(isContextOverflowErrorMessage('input length exceeds limit for this deployment')).toBe(
-      true,
-    );
     expect(isContextOverflowErrorMessage('{"code": "context_length_exceeded"}')).toBe(true);
+  });
+
+  it('does NOT confuse rate, output, or tool argument limits with context overflow', () => {
+    expect(
+      isContextOverflowErrorMessage('Rate limit exceeded: too many tokens per minute'),
+    ).toBe(false);
+    expect(
+      isContextOverflowErrorMessage('Maximum output tokens reached: too many tokens'),
+    ).toBe(false);
+    expect(
+      isContextOverflowErrorMessage(
+        'Tool argument validation failed: input length exceeds 1000 characters',
+      ),
+    ).toBe(false);
   });
 
   it('does NOT match overload / network / auth errors (disjoint recovery semantics)', () => {

--- a/packages/maker-core/src/agents/shared/context-overflow-error.ts
+++ b/packages/maker-core/src/agents/shared/context-overflow-error.ts
@@ -1,0 +1,61 @@
+/**
+ * 上下文超限类错误识别 — 判断报错是不是"请求输入超出了模型 / 网关的上下文窗口上限"。
+ *
+ * **与 overload-error.ts / network-error.ts 的分工**：那两份分别管"上游没容量"与
+ * "网络到不了上游"，都可能重试自愈；本份管"请求本身太大被上游拒绝"——重试**必然**
+ * 原样再撞同一个 4xx，属于不可重试错误。三类驱动的 UI 文案与恢复动作完全不同
+ * （过载 → 自动退避重投；网络 → 自动重连；超限 → 压缩上下文 / 新开会话），
+ * 所以刻意不合并判定。
+ *
+ * 已知措辞形态（pattern 逐条对应，只认错误文本形态、与 provider 无关）：
+ *  - Anthropic:        `prompt is too long: 250000 tokens > 200000 maximum`
+ *  - OpenAI:           `This model's maximum context length is 128000 tokens...`
+ *  - litellm / Azure:  `{"code": "context_length_exceeded"}` /
+ *                      `Your input exceeds the context window of this model.`（#1429 实踩）
+ *  - 通用网关:          token limit / too many tokens / input length exceeds 等变体
+ *
+ * 为什么会走到这一步（防线失效链，见 #1429）：声明窗口大于路由真实上限时，
+ * SDK 内部与 host 侧两层 auto-compact 的阈值都建立在错误的分母上，永远触发不了；
+ * 撞上限被 400 拒绝后请求拿不到 usage，tracker 的 contextTokens 停在旧值甚至 0，
+ * ratio 判定进一步失效——会话自锁。本模块的 reason key 就是解锁链的起点：
+ * translator 终态识别 → tracker 锁满窗口 → auto-compact 触发 + renderer 按 key
+ * 隐藏必败的 Retry。
+ *
+ * 消费方：
+ *  - claude-code / codex translator：终态 error 事件附带 `CONTEXT_OVERFLOW_REASON`。
+ *  - claude-code translator：命中时调 `tracker.markContextOverflow()`（见 usage-tracker.ts）。
+ *  - renderer ErrorBanner 有一份**语义一致**的同名判定
+ *    （apps/desktop/src/renderer/utils/contextOverflowError.ts，不跨 bundle 共享代码，
+ *    与 overload / network 两端一致性同款惯例）。修改 pattern 时两处同步。
+ *  - desktop main 的 providerErrors.ts `CONTEXT_TOO_LONG_RE` 是第三份同语义 pattern
+ *    （供应商上游错误分类，作用域是 proxy 层响应体而非 turn error）。三处的措辞
+ *    集合保持同步。
+ */
+
+/**
+ * 上下文超限 error 事件上带的**稳定 reason key**。
+ *
+ * 走 `reason` 这个既有通道而不是新增字段：`reason` 本就是「maker-core 用稳定 key 告诉
+ * renderer 这是什么错误」的现成语义（`empty-response` / `upstream-overload` 同款）。
+ * renderer 隔着 IPC 投影拿不到结构化的 provider 分类，靠这个 key 驱动 ErrorBanner 的
+ * 本地化文案、hideRetry 与恢复动作；文案匹配仅作历史持久化错误行的兜底。
+ */
+export const CONTEXT_OVERFLOW_REASON = 'context-overflow';
+
+/**
+ * Pattern 与 desktop `providerErrors.ts` 的 `CONTEXT_TOO_LONG_RE` 同源，另补两条：
+ *  - `(input|request|message).{0,20}exceed.{0,40}context`：litellm/Azure 的
+ *    "Your input exceeds the context window of this model"（exceed 在 context **前**，
+ *    原正则只覆盖 exceed 在后的语序）。
+ *  - `context_length_exceeded` 的字面错误码在 message 未附带错误码 JSON 时可能缺席，
+ *    上一条语序补齐正是为此。
+ * 大小写不敏感。判定对象是 redact 后的 API 错误 envelope 文本，不是工具输出，
+ * 误伤面与既有 overload / network pattern 同级。
+ */
+const CONTEXT_OVERFLOW_RE =
+  /prompt is too long|maximum context length|context.{0,20}(length|window).{0,40}(exceed|too)|(input|request|message).{0,20}exceeds?.{0,40}context.{0,20}(length|window)|too many tokens|input length.{0,20}exceed|context_length_exceeded/i;
+
+/** 是否是上下文超限类错误。命中 = 不可原样重试，恢复动作是压缩上下文或新开会话。 */
+export function isContextOverflowErrorMessage(message: string): boolean {
+  return CONTEXT_OVERFLOW_RE.test(message);
+}

--- a/packages/maker-core/src/agents/shared/context-overflow-error.ts
+++ b/packages/maker-core/src/agents/shared/context-overflow-error.ts
@@ -12,7 +12,10 @@
  *  - OpenAI:           `This model's maximum context length is 128000 tokens...`
  *  - litellm / Azure:  `{"code": "context_length_exceeded"}` /
  *                      `Your input exceeds the context window of this model.`（#1429 实踩）
- *  - 通用网关:          token limit / too many tokens / input length exceeds 等变体
+ *
+ * 裸 `too many tokens` / `input length exceeds` 不足以证明是上下文窗口超限：它们也会
+ * 出现在 token 速率限制、输出上限与工具参数长度错误中。只有文本明确提到 context
+ * window / context length，或携带稳定错误码时才归为本类。
  *
  * 为什么会走到这一步（防线失效链，见 #1429）：声明窗口大于路由真实上限时，
  * SDK 内部与 host 侧两层 auto-compact 的阈值都建立在错误的分母上，永远触发不了；
@@ -53,7 +56,7 @@ export const CONTEXT_OVERFLOW_REASON = 'context-overflow';
  * 误伤面与既有 overload / network pattern 同级。
  */
 const CONTEXT_OVERFLOW_RE =
-  /prompt is too long|maximum context length|context.{0,20}(length|window).{0,40}(exceed|too)|(input|request|message).{0,20}exceeds?.{0,40}context.{0,20}(length|window)|too many tokens|input length.{0,20}exceed|context_length_exceeded/i;
+  /prompt is too long|maximum context length|context.{0,20}(length|window).{0,40}(exceed|too)|(input|request|message).{0,20}exceeds?.{0,40}context.{0,20}(length|window)|context_length_exceeded/i;
 
 /** 是否是上下文超限类错误。命中 = 不可原样重试，恢复动作是压缩上下文或新开会话。 */
 export function isContextOverflowErrorMessage(message: string): boolean {

--- a/packages/maker-core/src/agents/shared/usage-tracker.test.ts
+++ b/packages/maker-core/src/agents/shared/usage-tracker.test.ts
@@ -71,3 +71,59 @@ describe('UsageTracker.getTurnUsage', () => {
     });
   });
 });
+
+/**
+ * markContextOverflow — 上下文超限终态的自锁解除(#1429)。
+ * 超限请求被 400 整体拒绝、不返回 usage 时, lastApi 停在旧值(重启后是 0):
+ * 圆环显示 0%、auto-compact 的 ratio 永远到不了阈值。锁到窗口满载后
+ * snapshot().contextTokens = contextWindow, ratio=1.0 让 turn end 压缩得以触发。
+ */
+describe('UsageTracker.markContextOverflow', () => {
+  it('locks contextTokens to the window when below it (fresh tracker after restart)', () => {
+    const tracker = new UsageTracker();
+    tracker.setContextWindow(272_000);
+    expect(tracker.snapshot().contextTokens).toBe(0);
+
+    tracker.markContextOverflow();
+    expect(tracker.snapshot()).toMatchObject({ contextTokens: 272_000, contextWindow: 272_000 });
+  });
+
+  it('locks contextTokens to the window when a previous successful turn left a lower value', () => {
+    const tracker = new UsageTracker();
+    tracker.setContextWindow(272_000);
+    tracker.ingestApiCallUsage({ inputTokens: 1_000, outputTokens: 10, cacheReadTokens: 199_000 });
+    expect(tracker.snapshot().contextTokens).toBe(200_000);
+
+    tracker.markContextOverflow();
+    expect(tracker.snapshot().contextTokens).toBe(272_000);
+  });
+
+  it('keeps the real reading when it already meets/exceeds the window', () => {
+    const tracker = new UsageTracker();
+    tracker.setContextWindow(272_000);
+    tracker.ingestApiCallUsage({ inputTokens: 280_000, outputTokens: 10 });
+
+    tracker.markContextOverflow();
+    // 真实读数比伪造值更诚实 —— 不动
+    expect(tracker.snapshot().contextTokens).toBe(280_000);
+  });
+
+  it('is a no-op when the window is unknown ("无估算" principle)', () => {
+    const tracker = new UsageTracker();
+    tracker.ingestApiCallUsage({ inputTokens: 5_000, outputTokens: 10 });
+
+    tracker.markContextOverflow();
+    expect(tracker.snapshot()).toMatchObject({ contextTokens: 5_000, contextWindow: 0 });
+  });
+
+  it('survives endTurn without replaceLastApi (the failed-turn zero delta must not wipe it)', () => {
+    const tracker = new UsageTracker();
+    tracker.setContextWindow(272_000);
+    tracker.markContextOverflow();
+
+    // 超限失败轮: translator 对 overflow 轮传 replaceLastApi:false(守卫加 !isContextOverflowTurn)
+    const snap = tracker.endTurn({ inputTokens: 0, outputTokens: 0, replaceLastApi: false });
+    expect(snap.contextTokens).toBe(272_000);
+    expect(tracker.snapshot().contextTokens).toBe(272_000);
+  });
+});

--- a/packages/maker-core/src/agents/shared/usage-tracker.ts
+++ b/packages/maker-core/src/agents/shared/usage-tracker.ts
@@ -162,6 +162,25 @@ export class UsageTracker {
   }
 
   /**
+   * 上下文超限错误(400 context_length_exceeded / prompt is too long 等)终态时调。
+   *
+   * 超限请求被上游整体拒绝, 不返回任何 usage —— lastApi 停在上一次成功值(会话重启后
+   * 首轮就失败则是 0), snapshot().contextTokens 会把"已经溢出"显示成低占用甚至 0%,
+   * 且 auto-compact 的 ratio 判定永远走不到阈值, 会话进入"超限 → 无 usage → 不压缩 →
+   * 重试再超限"的自锁(#1429)。这里把 lastApi 锁到窗口满载, 让圆环如实显示 100%、
+   * ratio 达到 1.0, turn end 的 auto-compact 判定得以触发。
+   *
+   * 窗口未知(0)时 no-op —— 与 setContextWindow / AutoCompactController.onUsageUpdate
+   * 一致的"无估算"原则; 已 ≥ 窗口(上一轮真实值本就超了)时也不动, 保留真实读数。
+   */
+  markContextOverflow(): void {
+    if (this.contextWindow <= 0) return;
+    const current = this.lastApi.input + this.lastApi.cacheRead + this.lastApi.cacheCreate;
+    if (current >= this.contextWindow) return;
+    this.lastApi = { input: this.contextWindow, cacheRead: 0, cacheCreate: 0 };
+  }
+
+  /**
    * 当前 turn 已累计的真实用量 (copy, 只读)。
    *
    * 与 endTurn 的关系: endTurn(turnUsage) 会用调用方给的 aggregate **覆盖**


### PR DESCRIPTION
## 这次改了什么

### 摘要

#1429 的核心失效链:上下文超限被上游 400(`context_length_exceeded`)拒绝的请求**不返回 usage**,tracker 的 contextTokens 停在旧值甚至 0 —— 圆环显示 0%、auto-compact 的 ratio 永远到不了阈值,会话进入「超限 → 无 usage → 不压缩 → 重试再超限」的自锁。本 PR 在 maker-core 打断这条链:

- 新增 `shared/context-overflow-error.ts`:`CONTEXT_OVERFLOW_REASON` 稳定 reason key + 措辞判定(Anthropic `prompt is too long` / OpenAI `maximum context length` / litellm·Azure `context_length_exceeded` 与 `input exceeds the context window` 语序 / 通用 token-limit;与 desktop `providerErrors.ts` 及 renderer 镜像三处同步,惯例同 `overload-error.ts`)。
- `UsageTracker.markContextOverflow()`:超限终态把 lastApi 锁到窗口满载 —— 圆环如实显示 100%,ratio=1.0 让 turn end 的既有 auto-compact 判定得以触发(best-effort:压缩请求自身发送全量历史,真超限时可能同样失败;失败轮不产生 compact_boundary,`AutoCompactController.fired` 保持置位,不会循环重压)。窗口未知(0)时 no-op,守「无估算」原则。
- cc translator:endTurn 前判定并锁定(endSnapshot / status Done / onUsageUpdate 全部跟随),`replaceLastApi` 守卫加 `!isContextOverflowTurn` 防失败轮 0 增量冲掉满载值,is_error 终态 error 事件附带 reason。
- codex translator:终态 error 同步附带 reason(与 overload reason 互斥,overload 优先——它还驱动退避重投接管)。

renderer 消费该 reason 的呈现改动在配套 desktop PR(分支 `fix/1429-desktop-context-overflow-banner`),两者无编译依赖、可独立合并。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#1429(下游逃生口修复见 #934 / PR #940;本 PR 修撞顶前后的自锁本体)
- 本 PR 包含:maker-core 的超限识别、tracker 锁定、cc/codex translator reason 附带,及 22 例单测中的 14 例
- 明确不包含:renderer 呈现(配套 desktop PR)、registry 窗口数据修正(需网关侧确认真实上限)、route 级 contextWindow 协议扩展(需服务端同步,另行立项)
- 用户可见变化:超限后上下文圆环显示 100%(此前恒 0%);达到 host 压缩阈值配置时 turn end 自动尝试一次静默压缩
- 是否存在 breaking change:无(error 事件新增可选 `reason` 值,`AgentErrorEventData.reason` 为既有字段;老消费方按未知 reason 走原兜底)

### UI 变化

不涉及(maker-core 数据层;圆环读数变化经既有 UsageSnapshot 通道透出,无组件改动)。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit                                    → 56 个 workspace 全 PASS(exit 0)
packages/maker-core: pnpm exec vitest run          → 1560 passed | 1 skipped
新增用例:context-overflow-error.test.ts(4)、usage-tracker.test.ts +5、
  translator-context-overflow.test.ts(5,含 #1429 实踩 litellm 原文/envelope-only/
  interrupt 排除/非超限不误伤/usage 不覆盖锁定值)、codex translator.test.ts +1
pnpm --filter desktop run typecheck                → 通过(维持)
```

### 手工验证

不涉及(判定与状态机行为已由翻译层单测锁定事件流;端到端撞真实网关上限的实机复现依赖超长会话,未执行,见下)。

### 未执行的验证

- 实机复现「真实网关 400 → 圆环 100% → 自动压缩触发」:需把会话真实跑到 27 万+ tokens,成本高;事件流语义已被 5 例翻译层单测按实踩报文锁定。
- maker-core 无 typecheck script(门禁 `--if-present` 跳过);直接 `tsc --noEmit` 的报错清单与改动前逐字节一致(均为 plan-mode.test.ts / codex index.test.ts 存量 mock 类型问题)。

### 核心指标自评(maker-core 规则 §3.4)

- 缓存率:不触碰 prompt 拼接 / tool·MCP 暴露 / 拼接顺序,前缀零变化 → 无影响。
- 性能:判定只在 turn-error 冷路径执行(每 turn ≤1 次正则,对象为错误 envelope 短文本),热路径(每事件/每 token)零新增。
- 返回内容准确性:translator 只在既有 error data 上附加可选 reason 字段,不增删改任何事件、不改事件序;新增单测断言 error → status Done → done 序列不变。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅超限终态错误的 turn(判定不命中时所有路径行为逐字节不变);误判的代价上限 = 圆环显示满 + 多做一次静默压缩,无数据风险。
- 回滚 / 降级方式:revert 本 PR 即回到修复前行为,无持久化格式变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(模块注释即文档,三处 pattern 同步关系已写明)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)