### PR TITLE
test(model-providers): model-registry 数据自一致性门禁 (#1429)

### DIFF
--- a/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
+++ b/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+
+import modelRegistryJson from "../../catalog/model-registry.json" with { type: "json" };
+import type {
+  ModelAgent,
+  ModelRegistry,
+  ModelRegistryEntry,
+  ModelRegistryRoute,
+  ModelReferencePrice,
+} from "@cindy/model-access-protocol";
+
+/**
+ * model-registry.json 数据自一致性门禁(#1429 跟进)。
+ *
+ * 背景:声明窗口与路由真实上限脱节时,SDK 内部与 host 侧两层 auto-compact 的阈值
+ * 都建立在错误分母上,会话会一路冲到上游硬顶被 400 拒绝(context_length_exceeded),
+ * 然后进入"超限 → 无 usage → 不压缩 → 重试再超限"的自锁。Registry 没有 route 级
+ * 窗口字段,真实上限只能靠数据维护纪律保证 —— 本测试把 registry **内部**可判定的
+ * 矛盾挡在 CI:窗口上调 / 价档修订(#909、#1189 同类改动)引入的结构性错误在
+ * 合入前暴露,而不是等用户撞 400。
+ *
+ * 判定语义与 modelRegistry.ts 的价档选择一致:band 覆盖 [minInputTokens ?? 0,
+ * maxInputTokens) —— max 为排他上界(`inputTokens >= max` 不命中)。
+ */
+
+const registry = modelRegistryJson as unknown as ModelRegistry;
+
+function effectiveWindow(
+  entry: ModelRegistryEntry,
+  agent: ModelAgent,
+): number | undefined {
+  return entry.perAgent?.[agent]?.contextWindow ?? entry.contextWindow;
+}
+
+/** 按 (currency, variant, effectiveFrom) 分组 —— 组内 band 构成一条完整价格轴。 */
+function bandGroups(route: ModelRegistryRoute): ModelReferencePrice[][] {
+  const groups = new Map<string, ModelReferencePrice[]>();
+  for (const price of route.referencePrices ?? []) {
+    const key = `${price.currency}|${price.variant ?? "standard"}|${price.effectiveFrom}`;
+    const group = groups.get(key);
+    if (group) group.push(price);
+    else groups.set(key, [price]);
+  }
+  return Array.from(groups.values()).map((group) =>
+    group.slice().sort((a, b) => (a.minInputTokens ?? 0) - (b.minInputTokens ?? 0)),
+  );
+}
+
+describe("model registry data consistency", () => {
+  it("window / output declarations are positive and mutually sane", () => {
+    for (const entry of registry.models) {
+      if (entry.contextWindow !== undefined) {
+        expect(entry.contextWindow, `${entry.id} contextWindow`).toBeGreaterThan(0);
+      }
+      if (entry.maxOutputTokens !== undefined) {
+        expect(entry.maxOutputTokens, `${entry.id} maxOutputTokens`).toBeGreaterThan(0);
+      }
+      if (entry.contextWindow !== undefined && entry.maxOutputTokens !== undefined) {
+        expect(
+          entry.maxOutputTokens,
+          `${entry.id}: maxOutputTokens exceeds contextWindow`,
+        ).toBeLessThanOrEqual(entry.contextWindow);
+      }
+      for (const [agent, override] of Object.entries(entry.perAgent ?? {})) {
+        if (override?.contextWindow !== undefined) {
+          expect(
+            override.contextWindow,
+            `${entry.id} perAgent.${agent}.contextWindow`,
+          ).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it("price bands tile the input axis without gaps or overlaps", () => {
+    for (const entry of registry.models) {
+      for (const route of entry.routes) {
+        for (const group of bandGroups(route)) {
+          const label = `${entry.id} @ ${route.providerId}`;
+          // 第一条必须从 0 起 —— 否则低输入段无价可循
+          expect(group[0]!.minInputTokens ?? 0, `${label}: first band must start at 0`).toBe(0);
+          for (let i = 1; i < group.length; i += 1) {
+            const prev = group[i - 1]!;
+            const cur = group[i]!;
+            // 相邻 band 首尾相接(max 排他 = 下一条的 min):留缝 = 区间无价,
+            // 重叠 = 命中歧义(排序副作用决定价格)
+            expect(
+              prev.maxInputTokens,
+              `${label}: band boundary gap/overlap at ${cur.minInputTokens}`,
+            ).toBe(cur.minInputTokens);
+          }
+        }
+      }
+    }
+  });
+
+  it("every tier boundary is reachable by at least one agent's declared window", () => {
+    // band 起点 ≥ 该路由所有 agent 的声明窗口 = 这条价档永不可达,
+    // 说明窗口或价档必有一边写错(#1429 的窗口下调修正会先撞到这里)。
+    for (const entry of registry.models) {
+      for (const route of entry.routes) {
+        for (const group of bandGroups(route)) {
+          for (const band of group) {
+            const lo = band.minInputTokens ?? 0;
+            if (lo === 0) continue;
+            const reachable = route.agents.some((agent) => {
+              const window = effectiveWindow(entry, agent);
+              return window === undefined || window > lo;
+            });
+            expect(
+              reachable,
+              `${entry.id} @ ${route.providerId}: band starting at ${lo} is unreachable for every agent window`,
+            ).toBe(true);
+          }
+        }
+      }
+    }
+  });
+
+  it("declared windows never extend past the priced input range", () => {
+    // 顶档封了上界(maxInputTokens)而某 agent 窗口声明超出 = 超出段没有任何参考价,
+    // 要么窗口虚高(#1429 主形态),要么漏了长上下文价档 —— 两者都必须在数据层修。
+    for (const entry of registry.models) {
+      for (const route of entry.routes) {
+        for (const group of bandGroups(route)) {
+          const top = group[group.length - 1]!;
+          if (top.maxInputTokens === undefined) continue;
+          for (const agent of route.agents) {
+            const window = effectiveWindow(entry, agent);
+            if (window === undefined) continue;
+            expect(
+              window,
+              `${entry.id} @ ${route.providerId} (${agent}): window ${window} exceeds priced range ${top.maxInputTokens}`,
+            ).toBeLessThanOrEqual(top.maxInputTokens);
+          }
+        }
+      }
+    }
+  });
+});

--- a/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
+++ b/packages/model-providers/src/__tests__/modelRegistryConsistency.test.ts
@@ -36,7 +36,7 @@ function effectiveWindow(
 function bandGroups(route: ModelRegistryRoute): ModelReferencePrice[][] {
   const groups = new Map<string, ModelReferencePrice[]>();
   for (const price of route.referencePrices ?? []) {
-    const key = `${price.currency}|${price.variant ?? "standard"}|${price.effectiveFrom}`;
+    const key = `${price.currency}|${price.variant}|${price.effectiveFrom}`;
     const group = groups.get(key);
     if (group) group.push(price);
     else groups.set(key, [price]);
@@ -62,11 +62,16 @@ describe("model registry data consistency", () => {
         ).toBeLessThanOrEqual(entry.contextWindow);
       }
       for (const [agent, override] of Object.entries(entry.perAgent ?? {})) {
-        if (override?.contextWindow !== undefined) {
+        if (override?.contextWindow === undefined) continue;
+        expect(
+          override.contextWindow,
+          `${entry.id} perAgent.${agent}.contextWindow`,
+        ).toBeGreaterThan(0);
+        if (entry.maxOutputTokens !== undefined) {
           expect(
-            override.contextWindow,
-            `${entry.id} perAgent.${agent}.contextWindow`,
-          ).toBeGreaterThan(0);
+            entry.maxOutputTokens,
+            `${entry.id}: maxOutputTokens exceeds perAgent.${agent}.contextWindow`,
+          ).toBeLessThanOrEqual(override.contextWindow);
         }
       }
     }


### PR DESCRIPTION
## 这次改了什么

### 摘要

#1429 的根因之一是声明窗口与路由真实上限脱节(如 `gpt-5.5` 同一模型 cc 侧 1.05M vs codex 侧 272K),两层 auto-compact 的阈值都建在错误分母上。Registry 没有 route 级窗口字段,真实上限只能靠数据维护纪律保证——本 PR 把 registry **内部**可判定的矛盾挡在 CI,让窗口上调/价档修订(#909、#1189 同类改动)引入的结构错误在合入前暴露,而不是等用户撞 400。

四条断言(判定语义与 `modelRegistry.ts` 价档选择一致:band 覆盖 `[min, max)`,max 排他):

1. 窗口/输出上限为正且互洽(maxOutputTokens ≤ contextWindow);
2. 价档区间无缝无重叠地铺满输入轴(首档从 0 起、相邻首尾相接);
3. 每个分档边界至少被一个 agent 的声明窗口可达(永不可达档 = 窗口或价档必有一边写错);
4. 声明窗口不超出有价区间(顶档封顶时超出段无价可循,要么窗口虚高——#1429 主形态——要么漏了长上下文价档)。

当前目录数据零违规,门禁只拦未来的坏数据,不改变任何运行时行为。

route 级真实窗口的结构解(cindy-protocol route contextWindow)需服务端同步,另行立项;xd 路由下 GPT 系模型真实上限的确认与远端 catalog 下发在网关侧跟进。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#1429;与 PR #1476(maker-core)、#1478(desktop)同属一组,彼此独立可合
- 本 PR 包含:一个新测试文件 `modelRegistryConsistency.test.ts`(140 行)
- 明确不包含:registry 数据本身的修正、协议扩展
- 用户可见变化:无(纯 CI 门禁)
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
packages/model-providers: pnpm exec vitest run src/__tests__/modelRegistryConsistency.test.ts
  → 4 passed(当前目录零违规)
pnpm test:unit → 56 个 workspace 全 PASS(exit 0)
pnpm --filter @cindy/model-providers run --if-present typecheck → 通过
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 CI;未来若有合法例外(如刻意的分段定价空洞)可在测试内加白名单条目并注明理由。
- 回滚 / 降级方式:删除该测试文件即可,无任何运行时影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(测试文件头注释写明背景与判定语义来源)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)