### PR TITLE
fix(mobile): dedupe default permission options

### DIFF
--- a/apps/mobile/src/__tests__/mobilePermissionPickerList.test.ts
+++ b/apps/mobile/src/__tests__/mobilePermissionPickerList.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { permissionOptionsForDisplay } from '@/session/mobilePermissionPickerOptions';
+
+const fallbackOptions = [
+  { id: 'default', label: 'default' },
+  { id: 'ask', label: 'ask' },
+  { id: 'acceptEdits', label: 'acceptEdits' },
+  { id: 'plan', label: 'plan' },
+  { id: 'bypassPermissions', label: 'bypassPermissions' },
+];
+
+describe('permissionOptionsForDisplay', () => {
+  it('合并 default/ask 同义项并隐藏 plan', () => {
+    expect(permissionOptionsForDisplay(fallbackOptions, 'ask').map((option) => option.id))
+      .toEqual(['ask', 'acceptEdits', 'bypassPermissions']);
+  });
+
+  it('当前仍是 legacy default 时保留当前 id', () => {
+    expect(permissionOptionsForDisplay(fallbackOptions, 'default')[0]?.id).toBe('default');
+  });
+});

--- a/apps/mobile/src/__tests__/mobilePermissionPickerList.test.ts
+++ b/apps/mobile/src/__tests__/mobilePermissionPickerList.test.ts
@@ -19,4 +19,18 @@ describe('permissionOptionsForDisplay', () => {
   it('当前仍是 legacy default 时保留当前 id', () => {
     expect(permissionOptionsForDisplay(fallbackOptions, 'default')[0]?.id).toBe('default');
   });
+
+  it('两个同义项都非 active 时优先保留 modern ask', () => {
+    expect(permissionOptionsForDisplay(fallbackOptions, 'acceptEdits')[0]?.id).toBe('ask');
+  });
+
+  it('不去重 default/ask 以外的选项', () => {
+    const duplicatedOtherOption = [
+      ...fallbackOptions,
+      { id: 'acceptEdits', label: 'acceptEdits duplicate' },
+    ];
+
+    expect(permissionOptionsForDisplay(duplicatedOtherOption, 'ask').map((option) => option.id))
+      .toEqual(['ask', 'acceptEdits', 'bypassPermissions', 'acceptEdits']);
+  });
 });

--- a/apps/mobile/src/session/MobilePermissionPickerList.tsx
+++ b/apps/mobile/src/session/MobilePermissionPickerList.tsx
@@ -11,6 +11,7 @@ import { Text } from '@/components/AppText';
 import { Check } from 'lucide-react-native';
 
 import type { MobileChoiceOption } from '@/session/agentCapabilities';
+import { permissionOptionsForDisplay } from '@/session/mobilePermissionPickerOptions';
 import { permissionAccentColor, permissionPresentation } from '@/session/permissionPresentation';
 import { fontWeight, iconSize, iconStroke, lineHeight, useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import { radius, spacing, typeScale } from '@/theme/tokens';
@@ -60,7 +61,7 @@ export function MobilePermissionPickerList({
   const { t } = useTranslation();
   // 计划模式已迁移到 + 号 Context 面板的专属入口(点击即进入),权限下拉不再展示 plan;
   // 当前模式为 plan 时列表无高亮行,从这里选任意模式即退出计划模式。
-  const visibleOptions = options.filter((option) => option.id !== 'plan');
+  const visibleOptions = permissionOptionsForDisplay(options, activeMode);
   return (
     <>
       {visibleOptions.map((option) => {

--- a/apps/mobile/src/session/mobilePermissionPickerOptions.ts
+++ b/apps/mobile/src/session/mobilePermissionPickerOptions.ts
@@ -1,0 +1,36 @@
+import type { MobileChoiceOption } from '@/session/agentCapabilities';
+
+/**
+ * `default` 是旧协议权限 id，`ask` 是当前协议里相同的“默认权限”语义。能力拉取
+ * 失败时兼容列表可能同时带回两者；展示层必须合并，否则用户会看到两个完全相同
+ * 的选项。若当前值正好是其中一个，保留当前 id；否则优先保留现代 `ask`。
+ */
+export function permissionOptionsForDisplay(
+  options: readonly MobileChoiceOption[],
+  activeMode: string,
+): MobileChoiceOption[] {
+  const result: MobileChoiceOption[] = [];
+  const indexBySemanticId = new Map<string, number>();
+
+  for (const option of options) {
+    if (option.id === 'plan') continue;
+    const semanticId = option.id === 'default' || option.id === 'ask'
+      ? 'default-permissions'
+      : option.id;
+    const existingIndex = indexBySemanticId.get(semanticId);
+    if (existingIndex === undefined) {
+      indexBySemanticId.set(semanticId, result.length);
+      result.push(option);
+      continue;
+    }
+
+    const existing = result[existingIndex];
+    const existingIsActive = existing.id === activeMode;
+    const candidateIsActive = option.id === activeMode;
+    if (candidateIsActive || (!existingIsActive && existing.id === 'default' && option.id === 'ask')) {
+      result[existingIndex] = option;
+    }
+  }
+
+  return result;
+}

--- a/apps/mobile/src/session/mobilePermissionPickerOptions.ts
+++ b/apps/mobile/src/session/mobilePermissionPickerOptions.ts
@@ -10,25 +10,26 @@ export function permissionOptionsForDisplay(
   activeMode: string,
 ): MobileChoiceOption[] {
   const result: MobileChoiceOption[] = [];
-  const indexBySemanticId = new Map<string, number>();
+  let defaultPermissionsIndex: number | undefined;
 
   for (const option of options) {
     if (option.id === 'plan') continue;
-    const semanticId = option.id === 'default' || option.id === 'ask'
-      ? 'default-permissions'
-      : option.id;
-    const existingIndex = indexBySemanticId.get(semanticId);
-    if (existingIndex === undefined) {
-      indexBySemanticId.set(semanticId, result.length);
+    if (option.id !== 'default' && option.id !== 'ask') {
       result.push(option);
       continue;
     }
 
-    const existing = result[existingIndex];
+    if (defaultPermissionsIndex === undefined) {
+      defaultPermissionsIndex = result.length;
+      result.push(option);
+      continue;
+    }
+
+    const existing = result[defaultPermissionsIndex];
     const existingIsActive = existing.id === activeMode;
     const candidateIsActive = option.id === activeMode;
     if (candidateIsActive || (!existingIsActive && existing.id === 'default' && option.id === 'ask')) {
-      result[existingIndex] = option;
+      result[defaultPermissionsIndex] = option;
     }
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要（What / Why）

修复 Mobile 权限选择器里出现两个“默认权限”的问题。

当兼容选项同时包含 legacy `default` 和 modern `ask` 时，两者会被展示层渲染为相同的默认权限文案和图标。本 PR 只在 Mobile picker 的展示列表中把这两个同义项合并成一项：若当前 active id 是其中之一，则保留当前 id；否则优先展示 modern `ask`。`plan` 继续按既有产品约定隐藏。

根因是兼容 fallback 可能同时提供 `default` 与 `ask`，而原组件只过滤 `plan`，没有按展示语义去重。规范化现在严格限制在展示层，不改写原始 options、active mode 或选择回调参数。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围（Impact / Non-goals）

本 PR 包含：

- 合并 legacy `default` 与 modern `ask` 的可见选项；
- active 是 `default` 或 `ask` 时保留真实 active id；
- 两者均非 active 时优先展示 `ask`；
- 继续隐藏 `plan`；
- 增加定向单元测试。

明确不包含：

- 不修改权限协议、能力数据或任何 id；
- 不改变权限默认值、草稿状态、持久化或历史恢复；
- 不改变 `onSelect`、会话 payload、运行时权限或 sandbox；
- 不改变 Full Access 确认和 Plan mode 机制；
- 不修改 Desktop 权限选择器。

> Review boundary：本 PR 只审查 Mobile 展示层是否正确合并 `default` / `ask`、保留 active id 并隐藏 `plan`。协议统一、默认值、执行、持久化和其它权限问题应单独处理，不在本 PR 扩散。

### UI 变化

兼容列表同时包含 `default` / `ask` 时，两个相同的“默认权限”行变为一个。没有修改行高、颜色、图标、选中样式、动画或文案。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1；一个权限语义只保留一个可见选择。

## 怎么验证的（Test Plan）

使用 Node `22.22.3` / pnpm `10.33.2`：

```text
pnpm test:unit
PASS：全部 required workspaces。

Mobile workspace unit suite
PASS：280 files / 3001 tests。

pnpm --filter mobile run --if-present typecheck
PASS

pnpm --filter mobile exec vitest run src/__tests__/mobilePermissionPickerList.test.ts
PASS：1 file / 4 tests。

git diff --check HEAD^ HEAD
PASS

pnpm check:dco
PASS：2 signed-off commits，range 513d02b2..972b3db4。
```

拆分前的 Mobile 联调已现场确认重复行问题；独立 PR worktree 未重新启动专属 Metro，因此不把该现场验收冒充为当前 commit 的独占手工证据。

## 风险（Risk and rollback）

- 风险只在 Mobile picker 展示选择；协议值和执行语义不变。
- active id 优先规则避免选中态消失或提交不同 id。
- 回滚：revert 本 PR 最终 merge/squash commit。无 migration、用户数据或协议回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] commit 带 DCO 签名
- [x] UI 变化已注明设计依据
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果与未执行项
