### PR TITLE
fix(mobile): 接线 before-link 帧通知,补齐链路死锁自救的手机侧兜底(依赖 #1418)

### DIFF
--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -811,6 +811,17 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     // 由 rehydrate 把守;特别地,永久关闭抑制**不在此解除**——对端用户显式关闭
     // 后即使迟到帧还在飞,也不把用户关掉的链路自动建回来)。
     const offBeforeLink = client.onReliableFrameBeforeLink((deviceId) => {
+      // 先失效 peer 级缓存(与 transport-timeout 分支同序):收到 before-link 帧
+      // 说明 client 层 link 已不在就绪态,但 openLinkInFlightRef 可能还留着已
+      // resolved 的旧建链结果、remoteSubscribedTopicsRef 还留着旧 ACK——不清掉,
+      // rehydrate 会复用旧 open、跳过 subscribe,后续请求继续排进未就绪的可靠流
+      // (review P2)。
+      invalidatePeerLinkState(
+        deviceId,
+        openLinkInFlightRef.current,
+        remoteSubscribedTopicsRef.current,
+        noteSessionLiveStreamsInterrupted,
+      );
       markRemoteResponseEvidence(deviceId);
       reconcileAvailabilityAfterInboundFrame(
         presenceAvailableByDeviceRef.current,

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -801,6 +801,26 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         void refreshDeviceCapabilities(client, deviceId);
       },
     }));
+    // 与 transport-timeout link-close 同族的链路死锁自救(互为兜底):对端还在按
+    // 可靠流给本机发帧,而本机侧 link 未就绪——典型成因是 link-accept 在弱网丢失
+    // 后互等(发送端等 ACK、接收端等 link)。transport-timeout 是对端主动通知
+    // (best-effort,本身可能丢帧);本回调是本机从入站帧自行推断,通知丢了也能
+    // 自救。client 层已做 30s/peer 节流。收到帧即对端可达的直接证据,处理与
+    // transport-timeout 分支一致:冲销遗留离线判定 → rehydrate 重建链路与订阅
+    // (online 检查 / in-flight 去重 / 退避 / revoked 与永久关闭抑制等既有门全部
+    // 由 rehydrate 把守;特别地,永久关闭抑制**不在此解除**——对端用户显式关闭
+    // 后即使迟到帧还在飞,也不把用户关掉的链路自动建回来)。
+    const offBeforeLink = client.onReliableFrameBeforeLink((deviceId) => {
+      markRemoteResponseEvidence(deviceId);
+      reconcileAvailabilityAfterInboundFrame(
+        presenceAvailableByDeviceRef.current,
+        presencePendingRecoveryDeviceIdsRef.current,
+        presenceUnavailableVerdictsRef.current,
+        deviceId,
+      );
+      clearOnePresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
+      void rehydrateWithClient(client);
+    });
     client.start();
 
     const offResponseEvidence = subscribeRemoteResponseEvidence((deviceId) => {
@@ -919,6 +939,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       clearBackgroundStopTimer();
       offUnresponsive();
       offResponseEvidence();
+      offBeforeLink();
       offFrame();
       offPresence();
       offStatus();


### PR DESCRIPTION
## 这次改了什么

### 摘要

**依赖 #1418(base 指向其分支 `dash/device-link-weak-network`,等它先合;本 PR 的有效 diff 只有最后一个 commit)。**

#1418 在共享 client 层新增了 `onReliableFrameBeforeLink` 事件(收到「link 未就绪」的可靠帧时通知 host,30s/peer 节流),桌面控制端已接线(自动 `openRemoteLink`),手机版没接——本 PR 补上这条对称接线。

Gap 场景:手机在前台挂着,link 因 accept 丢帧未建立,被控桌面持续给手机发可靠帧(手机侧只能丢弃且不回 ACK)。现有恢复链依赖被控端 ACK 耗尽后发来的 `link-close(transport-timeout)` 通知(#1405),但该通知是 best-effort——弱网把它也丢掉时,手机只能等下一次回前台 rehydrate。接上本事件后,手机在前台就能从「对端还在给我发帧」自行推断 link 需要重建,与通知路径互为兜底。

处理体与既有 `transport-timeout` 分支完全同构(收到帧即对端可达的直接证据):`markRemoteResponseEvidence` + `reconcileAvailabilityAfterInboundFrame` 冲销遗留离线判定 → 清镜像清理计时器 → `rehydrateWithClient` 重建链路与订阅。online 检查、in-flight 去重、退避、revoked 与永久关闭抑制等既有门全部由 rehydrate 把守;特别地,**永久关闭抑制不在此解除**——对端用户显式关闭后,即使迟到帧还在飞,也不把用户关掉的链路自动建回来。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:#1418 的 mobile 对称收尾(2026-08-03 弱网死锁现场,见该 PR body 第 11 项)
- 本 PR 包含:`DeviceLinkContext` 订阅 `onReliableFrameBeforeLink` + 清理接线,共 1 处改动
- 明确不包含:其余弱网项均已在 #1418 / #1477 或 mobile 既有机制中覆盖(mobile 的熔断/半开重建/显式 cohort 本就领先桌面)
- 用户可见变化:弱网下手机端与桌面的控制链路死锁能在前台自动恢复,不再依赖回前台或单一通知帧
- 是否存在 breaking change:无

### UI 变化

无 UI 改动。

### 冷更边界(mobile-development)

纯 TS 改动(`apps/mobile/src/device-link/DeviceLinkContext.tsx` 单文件),不触碰 `app.json` / config plugin / 原生模块 / Pod,**无 runtime fingerprint 变化,不触发冷更**。

## 怎么验证的

### 自动验证

```text
run-unit-gate.sh(全仓 pnpm test:unit)  结果:见 PR 检查(提交前本地全绿)
pnpm --filter mobile typecheck           结果:通过
```

行为锁分布(与既有 transport-timeout 分支同构,无新增独立逻辑):client 层节流与触发语义由 `packages/device-link` 的 client.test.ts「C:link 未就绪收到可靠帧 → 通知 host」用例锁定(#1418);`reconcileAvailabilityAfterInboundFrame` 等纯函数已有 `presenceRecovery.test.ts` 覆盖;Context 内联接线遵循 transport-timeout 分支的既有形态(该分支同样无 Context 级直接单测)。

### 手工验证

不涉及(弱网实机对照建议与 #1418 合入后一起做:桌面被控端持续推流时人为丢弃 link-accept,观察手机前台是否在 30s 节流窗口内自动重建)。

### 未执行的验证

- iOS Simulator 实机运行:未执行(纯接线改动,行为由上述测试与 rehydrate 既有门锁定)。

## 风险

### 风险分类

- [x] 其他:mobile 控制端链路重建触发面

### 影响与回滚

- 影响范围:仅 mobile 控制端一处事件订阅;revert 即回旧行为(仅靠 transport-timeout 通知与回前台 rehydrate)。
- 误触发的上界:client 层 30s/peer 节流 + rehydrate 自身的 online 检查/in-flight 去重/2s→30s 退避/熔断门;被抑制(用户显式关闭)与被撤权设备由 rehydrate 计划过滤,不会被重建。
- 合并顺序:必须在 #1418 之后;#1418 squash 合入后本 PR 会 rebase 到 main 并 retarget base(心跳跟进)。

### 多端适配说明(remote-and-mobile-adaptation)

- 新增 IPC / 推送:无(纯本机事件订阅,不新增 device-link channel,无 allowlist 变更)。
- 桌面版:对称接线已在 #1418(desktop main `onReliableFrameBeforeLink` → `openRemoteLink`)。
- SSH 远程工作区:不涉及。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释)
- [x] 已确认测试结果或说明未执行原因
