### PR TITLE
fix(desktop): sync pinned sessions to mobile

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -22,6 +22,7 @@ const h = vi.hoisted(() => ({
     persistedSdkSessionId: null,
   })),
   tapWindowBroadcast: vi.fn(),
+  summarizeSession: vi.fn(async () => undefined),
 }));
 
 vi.mock('electron', () => ({
@@ -46,6 +47,9 @@ vi.mock('../../../imageCacheStore', () => ({ removeSession: vi.fn(async () => un
 vi.mock('../recentWorkdirs', () => ({ upsertRecentWorkdir: vi.fn(async () => undefined) }));
 vi.mock('../../../device-link/broadcast-tap.js', () => ({
   tapWindowBroadcast: h.tapWindowBroadcast,
+}));
+vi.mock('../../../sessionTaskSummary.js', () => ({
+  maybeGenerateSessionTaskSummary: h.summarizeSession,
 }));
 vi.mock('../../agentIslandSessionPatch', () => ({ notifyAgentIslandSessionPatch: vi.fn() }));
 vi.mock('../../../messagePersistBroadcaster', () => ({ noteSessionClearBoundary: vi.fn() }));
@@ -169,6 +173,47 @@ describe('local-db:sessions:update handler wiring', () => {
         patch: { permissionMode: 'ask' },
       }),
     );
+  });
+
+  it('broadcasts pin and unpin patches to device-link subscribers', async () => {
+    const pinnedAt = '2026-08-03T04:08:26.000Z';
+    await invokeUpdate('codex-local', { pinnedAt });
+
+    const pinned = h
+      .sqlite!.prepare('SELECT pinned_at AS pinnedAt FROM sessions WHERE id = ?')
+      .get('codex-local') as { pinnedAt: number | null };
+    expect(pinned.pinnedAt).toBe(Date.parse(pinnedAt));
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { pinnedAt },
+    });
+
+    h.tapWindowBroadcast.mockClear();
+    await invokeUpdate('codex-local', { pinnedAt: null });
+
+    const unpinned = h
+      .sqlite!.prepare('SELECT pinned_at AS pinnedAt FROM sessions WHERE id = ?')
+      .get('codex-local') as { pinnedAt: number | null };
+    expect(unpinned.pinnedAt).toBeNull();
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { pinnedAt: null },
+    });
+  });
+
+  it('broadcasts the stored value and skips summary generation for an invalid pin date', async () => {
+    await invokeUpdate('codex-local', { pinnedAt: 'not-a-date' });
+    await vi.dynamicImportSettled();
+
+    const persisted = h
+      .sqlite!.prepare('SELECT pinned_at AS pinnedAt FROM sessions WHERE id = ?')
+      .get('codex-local') as { pinnedAt: number | null };
+    expect(persisted.pinnedAt).toBeNull();
+    expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
+      sessionId: 'codex-local',
+      patch: { pinnedAt: null },
+    });
+    expect(h.summarizeSession).not.toHaveBeenCalled();
   });
 
   it('relocates transcripts when workingDir actually changes on a local cc session', async () => {

--- a/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
@@ -178,6 +178,7 @@ describe('local-db:sessions:update handler wiring', () => {
   it('broadcasts pin and unpin patches to device-link subscribers', async () => {
     const pinnedAt = '2026-08-03T04:08:26.000Z';
     await invokeUpdate('codex-local', { pinnedAt });
+    await vi.dynamicImportSettled();
 
     const pinned = h
       .sqlite!.prepare('SELECT pinned_at AS pinnedAt FROM sessions WHERE id = ?')
@@ -185,10 +186,12 @@ describe('local-db:sessions:update handler wiring', () => {
     expect(pinned.pinnedAt).toBe(Date.parse(pinnedAt));
     expect(h.tapWindowBroadcast).toHaveBeenCalledWith('local-db:sessions:patched', {
       sessionId: 'codex-local',
-      patch: { pinnedAt },
+      patch: { pinnedAt, status: 'active' },
     });
+    expect(h.summarizeSession).toHaveBeenCalledWith('codex-local');
 
     h.tapWindowBroadcast.mockClear();
+    h.summarizeSession.mockClear();
     await invokeUpdate('codex-local', { pinnedAt: null });
 
     const unpinned = h
@@ -199,6 +202,7 @@ describe('local-db:sessions:update handler wiring', () => {
       sessionId: 'codex-local',
       patch: { pinnedAt: null },
     });
+    expect(h.summarizeSession).not.toHaveBeenCalled();
   });
 
   it('broadcasts the stored value and skips summary generation for an invalid pin date', async () => {

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1184,7 +1184,13 @@ export function registerSessionIpc(
     if (!row) throwIpcError('NOT_FOUND', 'Session 不存在');
     const updated = sessionToCamel(row);
     const broadcastPatch =
-      p.pinnedAt === undefined ? p : { ...p, pinnedAt: updated.pinnedAt };
+      p.pinnedAt === undefined
+        ? p
+        : {
+            ...p,
+            pinnedAt: updated.pinnedAt,
+            ...(updated.pinnedAt === null ? {} : { status: updated.status }),
+          };
     const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
     const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
     const titleChanged = p.title !== undefined;

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -1182,6 +1182,9 @@ export function registerSessionIpc(
     }
     const row = await selectSessionWithCount(db, sid);
     if (!row) throwIpcError('NOT_FOUND', 'Session 不存在');
+    const updated = sessionToCamel(row);
+    const broadcastPatch =
+      p.pinnedAt === undefined ? p : { ...p, pinnedAt: updated.pinnedAt };
     const projectTargetChanged = p.workspaceKind !== undefined || p.workingDir !== undefined;
     const settingsChanged = Object.keys(p).some((key) => REMOTE_PERSIST_FIELDS.has(key));
     const titleChanged = p.title !== undefined;
@@ -1193,18 +1196,17 @@ export function registerSessionIpc(
     ) {
       await upsertRecentWorkdir(row.workingDir, Date.now());
     }
-    if (projectTargetChanged || settingsChanged || titleChanged) {
-      broadcastSessionPatched(sid, p);
+    if (projectTargetChanged || settingsChanged || titleChanged || p.pinnedAt !== undefined) {
+      broadcastSessionPatched(sid, broadcastPatch);
     }
     // sidebar-card-mode: 会话被置顶那一刻补生成任务摘要(turn-done 路径只覆盖
     // "置顶后又跑过 turn"的会话)。动态 import 避免 localDb → maker-host 的静态
     // 模块环;fire-and-forget,模块内部自带置顶/节流守卫。
-    if (p.pinnedAt != null) {
+    if (p.pinnedAt !== undefined && updated.pinnedAt !== null) {
       void import('../../sessionTaskSummary.js').then((m) =>
         m.maybeGenerateSessionTaskSummary(sid),
       );
     }
-    const updated = sessionToCamel(row);
     notifyAgentIslandSessionPatch(updated.id, {
       status: updated.status,
       title: updated.title,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Broadcast local pin changes to connected clients.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #1433
- Included: Include pinnedAt in the existing session patch path.
- Not included: UI, schema, migration, dependency, or wire-protocol changes.
- User-visible change: Broadcast local pin changes to connected clients.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected. This change does not access workdir files or agent processes.
- Device link: Uses the existing allowlisted `local-db:sessions:patched` push. No channel or protocol change.
- Mobile: Existing remote-session patch handling applies `pinnedAt`. No mobile code or UI change.

### UI 变化

Not applicable. No UI, interaction, or copy changes.

- Referenced design rules: Not applicable.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/localDb/ipc/__tests__/sessionsUpdate.test.ts
Result: passed.

pnpm test:unit
Result: passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

Desktop-to-mobile end-to-end flow.

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Desktop session patch broadcasts only.
- Risk: No known risks.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
