### PR TITLE
fix(desktop): 优化任务快捷键提示显隐

### DIFF
--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -54,7 +54,11 @@ import { useAppShortcut } from '@/hooks/useAppShortcut';
 import { useModifierHold } from '@/hooks/useModifierHold';
 import { isSecondaryWindow } from '@/lib/secondaryWindow';
 import { getAppShortcutCombos, getAppShortcutPlatform } from '@/lib/appShortcutStore';
-import { formatAppShortcutCombo, SWITCH_SESSION_SHORTCUT_IDS } from '../../../shared/appShortcuts';
+import {
+  formatAppShortcutCombo,
+  matchesKeyboardEvent,
+  SWITCH_SESSION_SHORTCUT_IDS,
+} from '../../../shared/appShortcuts';
 import { setSessionOrdinalBadges } from './sidebar/sessionOrdinalBadges';
 import { useSidebarCollapsedState } from '../feature-context';
 import { stripTrailingPathSeparators } from '../../../shared/pathText';
@@ -1808,7 +1812,17 @@ function ExpandedView({
   // 重排前的行。标签取生效组合的显示形(mac '⌘1' / win 'Ctrl+1',跟随用户
   // 改绑),删除绑定或让位后的槽位无徽标。写入 sessionOrdinalBadges 模块
   // store,由 SessionItem / SessionCard 精准订阅。
-  const switchModifierHeld = useModifierHold({ enabled: sessionSwitchEnabled });
+  const preserveSwitchHintOnKeyDown = useCallback(
+    (event: KeyboardEvent) =>
+      SWITCH_SESSION_SHORTCUT_IDS.some((shortcutId) =>
+        getAppShortcutCombos(shortcutId).some((combo) => matchesKeyboardEvent(event, combo)),
+      ),
+    [],
+  );
+  const switchModifierHeld = useModifierHold({
+    enabled: sessionSwitchEnabled,
+    preserveOnKeyDown: preserveSwitchHintOnKeyDown,
+  });
   useEffect(() => {
     if (!switchModifierHeld) return;
     let lastSerialized: string | null = null;

--- a/apps/desktop/src/renderer/hooks/__tests__/useModifierHold.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useModifierHold.test.ts
@@ -90,8 +90,9 @@ describe('useModifierHold', () => {
     const disposeCapture = installEarlyKeyDownCapture();
     const blocker = (event: KeyboardEvent) => event.stopImmediatePropagation();
     window.addEventListener('keydown', blocker, true);
+    const preserveOnKeyDown = vi.fn(() => false);
 
-    const { result, unmount } = renderHook(() => useModifierHold());
+    const { result, unmount } = renderHook(() => useModifierHold({ preserveOnKeyDown }));
     try {
       dispatchKey('keydown', { key: 'Meta', metaKey: true });
       act(() => vi.advanceTimersByTime(500));
@@ -99,6 +100,7 @@ describe('useModifierHold', () => {
 
       dispatchKey('keydown', { key: 'f', metaKey: true });
       expect(result.current).toBe(false);
+      expect(preserveOnKeyDown).toHaveBeenCalledTimes(1);
     } finally {
       unmount();
       window.removeEventListener('keydown', blocker, true);
@@ -131,6 +133,73 @@ describe('useModifierHold', () => {
     expect(result.current).toBe(false);
   });
 
+  it('restores a qualified hold for an explicitly permitted shortcut with extra modifiers', () => {
+    const { result } = renderHook(() =>
+      useModifierHold({
+        preserveOnKeyDown: (event) =>
+          event.code === 'Digit1' &&
+          event.metaKey &&
+          event.shiftKey &&
+          !event.ctrlKey &&
+          !event.altKey,
+      }),
+    );
+    dispatchKey('keydown', { key: 'Meta', code: 'MetaLeft', metaKey: true });
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current).toBe(true);
+
+    dispatchKey('keydown', { key: 'Shift', metaKey: true, shiftKey: true });
+    expect(result.current).toBe(false);
+    dispatchKey('keydown', { key: '1', code: 'Digit1', metaKey: true, shiftKey: true });
+    expect(result.current).toBe(true);
+    dispatchKey('keyup', { key: '1', code: 'Digit1', metaKey: true, shiftKey: true });
+    dispatchKey('keyup', { key: 'Shift', metaKey: true, shiftKey: false });
+    expect(result.current).toBe(true);
+
+    dispatchKey('keydown', { key: 'x', code: 'KeyX', metaKey: true });
+    expect(result.current).toBe(false);
+  });
+
+  it('does not let a permitted extra-modifier shortcut bypass the hold delay', () => {
+    const { result } = renderHook(() =>
+      useModifierHold({
+        preserveOnKeyDown: (event) =>
+          event.code === 'Digit1' &&
+          event.metaKey &&
+          event.shiftKey &&
+          !event.ctrlKey &&
+          !event.altKey,
+      }),
+    );
+    dispatchKey('keydown', { key: 'Meta', code: 'MetaLeft', metaKey: true });
+    act(() => vi.advanceTimersByTime(250));
+    dispatchKey('keydown', { key: 'Shift', metaKey: true, shiftKey: true });
+    dispatchKey('keydown', { key: '1', code: 'Digit1', metaKey: true, shiftKey: true });
+    expect(result.current).toBe(false);
+    act(() => vi.advanceTimersByTime(249));
+    expect(result.current).toBe(false);
+    act(() => vi.advanceTimersByTime(1));
+    expect(result.current).toBe(true);
+  });
+
+  it('does not start the hold delay when the primary modifier was pressed into an existing chord', () => {
+    const { result } = renderHook(() =>
+      useModifierHold({
+        preserveOnKeyDown: (event) =>
+          event.code === 'Digit1' &&
+          event.metaKey &&
+          event.shiftKey &&
+          !event.ctrlKey &&
+          !event.altKey,
+      }),
+    );
+    dispatchKey('keydown', { key: 'Shift', shiftKey: true });
+    dispatchKey('keydown', { key: 'Meta', metaKey: true, shiftKey: true });
+    dispatchKey('keydown', { key: '1', code: 'Digit1', metaKey: true, shiftKey: true });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(false);
+  });
+
   it('keeps the macOS screenshot chord hidden when the OS swallows its keyup sequence', () => {
     const { result } = renderHook(() => useModifierHold());
     dispatchKey('keydown', { key: 'Meta', metaKey: true });
@@ -154,11 +223,15 @@ describe('useModifierHold', () => {
 
     act(() => vi.advanceTimersByTime(1000));
     expect(result.current).toBe(false);
-    act(() => {
-      window.dispatchEvent(new MouseEvent('pointermove'));
-    });
-    dispatchKey('keydown', { key: 'Meta', metaKey: true });
-    act(() => vi.advanceTimersByTime(500));
+
+    dispatchKey('keydown', { key: 'Meta', metaKey: true, repeat: true });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(false);
+
+    dispatchKey('keydown', { key: 'Meta', metaKey: true, repeat: false });
+    act(() => vi.advanceTimersByTime(499));
+    expect(result.current).toBe(false);
+    act(() => vi.advanceTimersByTime(1));
     expect(result.current).toBe(true);
   });
 
@@ -211,9 +284,9 @@ describe('useModifierHold', () => {
         preserveOnKeyDown: (event) =>
           event.code === 'Digit1' &&
           event.ctrlKey &&
+          event.shiftKey &&
           !event.metaKey &&
-          !event.altKey &&
-          !event.shiftKey,
+          !event.altKey,
       }),
     );
     dispatchKey('keydown', { key: 'Meta', metaKey: true });
@@ -224,13 +297,16 @@ describe('useModifierHold', () => {
     act(() => vi.advanceTimersByTime(500));
     expect(result.current).toBe(true);
 
-    dispatchKey('keydown', { key: '1', code: 'Digit1', ctrlKey: true });
-    dispatchKey('keyup', { key: '1', code: 'Digit1', ctrlKey: true });
-    expect(result.current).toBe(true);
-
     dispatchKey('keydown', { key: 'Shift', ctrlKey: true, shiftKey: true });
     expect(result.current).toBe(false);
-    dispatchKey('keyup', { key: 'Shift', ctrlKey: true });
+    dispatchKey('keydown', { key: '1', code: 'Digit1', ctrlKey: true, shiftKey: true });
+    dispatchKey('keyup', { key: '1', code: 'Digit1', ctrlKey: true, shiftKey: true });
+    dispatchKey('keyup', { key: 'Shift', ctrlKey: true, shiftKey: false });
+    expect(result.current).toBe(true);
+
+    dispatchKey('keydown', { key: 'Alt', ctrlKey: true, altKey: true });
+    expect(result.current).toBe(false);
+    dispatchKey('keyup', { key: 'Alt', ctrlKey: true });
     act(() => vi.advanceTimersByTime(1000));
     expect(result.current).toBe(false);
   });

--- a/apps/desktop/src/renderer/hooks/__tests__/useModifierHold.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useModifierHold.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 
+import { installEarlyKeyDownCapture } from '../../lib/earlyKeyDownCapture';
 import { useModifierHold } from '../useModifierHold';
 
 const platformMock = vi.hoisted(() => ({ value: 'darwin' }));
@@ -49,14 +50,126 @@ describe('useModifierHold', () => {
     expect(result.current).toBe(false);
   });
 
-  it('stays held while other keys are pressed with the modifier down', () => {
+  it.each([
+    ['control', { key: 'Control', ctrlKey: true }],
+    ['shift', { key: 'Shift', shiftKey: true }],
+    ['alt', { key: 'Alt', altKey: true }],
+    ['regular key', { key: '1' }],
+  ] satisfies Array<[string, KeyboardEventInit]>)(
+    'hides after %s joins the held modifier and waits for a fresh hold',
+    (_label, otherKey) => {
+      const { result } = renderHook(() => useModifierHold());
+      dispatchKey('keydown', { key: 'Meta', metaKey: true });
+      act(() => vi.advanceTimersByTime(500));
+      expect(result.current).toBe(true);
+
+      dispatchKey('keydown', { ...otherKey, metaKey: true });
+      expect(result.current).toBe(false);
+      dispatchKey('keyup', { ...otherKey, metaKey: true });
+      act(() => vi.advanceTimersByTime(1000));
+      expect(result.current).toBe(false);
+
+      dispatchKey('keyup', { key: 'Meta', metaKey: false });
+      dispatchKey('keydown', { key: 'Meta', metaKey: true });
+      act(() => vi.advanceTimersByTime(500));
+      expect(result.current).toBe(true);
+    },
+  );
+
+  it('cancels a pending hold as soon as another key is pressed', () => {
+    const { result } = renderHook(() => useModifierHold());
+    dispatchKey('keydown', { key: 'Meta', metaKey: true });
+    act(() => vi.advanceTimersByTime(250));
+    dispatchKey('keydown', { key: 'c', metaKey: true });
+    dispatchKey('keyup', { key: 'c', metaKey: true });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(false);
+  });
+
+  it('observes keydown before an earlier shortcut listener stops immediate propagation', () => {
+    const disposeCapture = installEarlyKeyDownCapture();
+    const blocker = (event: KeyboardEvent) => event.stopImmediatePropagation();
+    window.addEventListener('keydown', blocker, true);
+
+    const { result, unmount } = renderHook(() => useModifierHold());
+    try {
+      dispatchKey('keydown', { key: 'Meta', metaKey: true });
+      act(() => vi.advanceTimersByTime(500));
+      expect(result.current).toBe(true);
+
+      dispatchKey('keydown', { key: 'f', metaKey: true });
+      expect(result.current).toBe(false);
+    } finally {
+      unmount();
+      window.removeEventListener('keydown', blocker, true);
+      disposeCapture();
+    }
+  });
+
+  it('keeps the hold while explicitly permitted shortcut keys are pressed', () => {
+    const { result } = renderHook(() =>
+      useModifierHold({
+        preserveOnKeyDown: (event) =>
+          (event.code === 'Digit1' || event.code === 'Digit2') &&
+          event.metaKey &&
+          !event.ctrlKey &&
+          !event.altKey &&
+          !event.shiftKey,
+      }),
+    );
+    dispatchKey('keydown', { key: 'Meta', code: 'MetaLeft', metaKey: true });
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current).toBe(true);
+
+    dispatchKey('keydown', { key: '1', code: 'Digit1', metaKey: true });
+    dispatchKey('keyup', { key: '1', code: 'Digit1', metaKey: true });
+    dispatchKey('keydown', { key: '2', code: 'Digit2', metaKey: true });
+    dispatchKey('keyup', { key: '2', code: 'Digit2', metaKey: true });
+    expect(result.current).toBe(true);
+
+    dispatchKey('keydown', { key: '3', code: 'Digit3', metaKey: true });
+    expect(result.current).toBe(false);
+  });
+
+  it('keeps the macOS screenshot chord hidden when the OS swallows its keyup sequence', () => {
     const { result } = renderHook(() => useModifierHold());
     dispatchKey('keydown', { key: 'Meta', metaKey: true });
     act(() => vi.advanceTimersByTime(500));
     expect(result.current).toBe(true);
-    dispatchKey('keydown', { key: '1', metaKey: true });
-    dispatchKey('keyup', { key: '1', metaKey: true });
+
+    dispatchKey('keydown', { key: 'Shift', metaKey: true, shiftKey: true });
+    dispatchKey('keydown', {
+      key: 'Control',
+      metaKey: true,
+      shiftKey: true,
+      ctrlKey: true,
+    });
+    dispatchKey('keydown', {
+      key: '4',
+      metaKey: true,
+      shiftKey: true,
+      ctrlKey: true,
+    });
+    expect(result.current).toBe(false);
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(false);
+    act(() => {
+      window.dispatchEvent(new MouseEvent('pointermove'));
+    });
+    dispatchKey('keydown', { key: 'Meta', metaKey: true });
+    act(() => vi.advanceTimersByTime(500));
     expect(result.current).toBe(true);
+  });
+
+  it('treats primary-modifier keyup as released even when its modifier flag is stale', () => {
+    const { result } = renderHook(() => useModifierHold());
+    dispatchKey('keydown', { key: 'Meta', metaKey: true });
+    act(() => vi.advanceTimersByTime(500));
+    expect(result.current).toBe(true);
+
+    dispatchKey('keyup', { key: 'Meta', metaKey: true });
+    expect(result.current).toBe(false);
   });
 
   it('window blur resets the held state (lost keyup)', () => {
@@ -91,9 +204,18 @@ describe('useModifierHold', () => {
     expect(result.current).toBe(true);
   });
 
-  it('tracks ctrl instead of meta off darwin', () => {
+  it('uses the same exclusive-hold behavior for ctrl off darwin', () => {
     platformMock.value = 'win32';
-    const { result } = renderHook(() => useModifierHold());
+    const { result } = renderHook(() =>
+      useModifierHold({
+        preserveOnKeyDown: (event) =>
+          event.code === 'Digit1' &&
+          event.ctrlKey &&
+          !event.metaKey &&
+          !event.altKey &&
+          !event.shiftKey,
+      }),
+    );
     dispatchKey('keydown', { key: 'Meta', metaKey: true });
     act(() => vi.advanceTimersByTime(1000));
     expect(result.current).toBe(false);
@@ -101,6 +223,16 @@ describe('useModifierHold', () => {
     dispatchKey('keydown', { key: 'Control', ctrlKey: true });
     act(() => vi.advanceTimersByTime(500));
     expect(result.current).toBe(true);
+
+    dispatchKey('keydown', { key: '1', code: 'Digit1', ctrlKey: true });
+    dispatchKey('keyup', { key: '1', code: 'Digit1', ctrlKey: true });
+    expect(result.current).toBe(true);
+
+    dispatchKey('keydown', { key: 'Shift', ctrlKey: true, shiftKey: true });
+    expect(result.current).toBe(false);
+    dispatchKey('keyup', { key: 'Shift', ctrlKey: true });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(result.current).toBe(false);
   });
 
   it('is suppressed while the settings shortcut recorder is active', () => {

--- a/apps/desktop/src/renderer/hooks/useModifierHold.ts
+++ b/apps/desktop/src/renderer/hooks/useModifierHold.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { getAppShortcutPlatform } from '../lib/appShortcutStore';
-import { subscribeEarlyKeyDownCapture } from '../lib/earlyKeyDownCapture';
+import {
+  isEarlyKeyDownCaptureInstalled,
+  subscribeEarlyKeyDownCapture,
+} from '../lib/earlyKeyDownCapture';
 
 export interface UseModifierHoldOptions {
   /** false 时不挂监听且状态归零。默认 true。 */
@@ -45,28 +48,47 @@ export function useModifierHold(options: UseModifierHoldOptions = {}): boolean {
     const isDarwin = getAppShortcutPlatform() === 'darwin';
     const primaryModifierKey = isDarwin ? 'Meta' : 'Control';
     let timer: number | null = null;
-    let active = false;
-    let chorded = false;
+    let qualified = false;
+    let visible = false;
+    let blocked = false;
+    let modifierPrefix = false;
+    let preservingShortcut = false;
 
-    const sync = (modifierDown: boolean) => {
-      if (modifierDown) {
-        if (active || timer != null) return;
-        timer = window.setTimeout(() => {
-          timer = null;
-          active = true;
-          setHeld(true);
-        }, delayMs);
-        return;
-      }
-      if (timer != null) {
-        window.clearTimeout(timer);
-        timer = null;
-      }
-      if (active) {
-        active = false;
-        setHeld(false);
-      }
+    const setVisible = (nextVisible: boolean) => {
+      if (visible === nextVisible) return;
+      visible = nextVisible;
+      setHeld(nextVisible);
     };
+    const cancelTimer = () => {
+      if (timer == null) return;
+      window.clearTimeout(timer);
+      timer = null;
+    };
+    const resetGesture = () => {
+      cancelTimer();
+      qualified = false;
+      blocked = false;
+      modifierPrefix = false;
+      preservingShortcut = false;
+      setVisible(false);
+    };
+    const startHoldTimer = () => {
+      if (qualified || blocked || timer != null) return;
+      timer = window.setTimeout(() => {
+        timer = null;
+        qualified = true;
+        if (!blocked && (!modifierPrefix || preservingShortcut)) setVisible(true);
+      }, delayMs);
+    };
+    const blockGesture = () => {
+      blocked = true;
+      modifierPrefix = false;
+      preservingShortcut = false;
+      cancelTimer();
+      setVisible(false);
+    };
+    const isModifierKey = (key: string) =>
+      key === 'Meta' || key === 'Control' || key === 'Alt' || key === 'Shift';
 
     const isPrimaryModifierDown = (event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey'>) =>
       isDarwin ? event.metaKey : event.ctrlKey;
@@ -76,65 +98,105 @@ export function useModifierHold(options: UseModifierHoldOptions = {}): boolean {
       isDarwin
         ? event.ctrlKey || event.altKey || event.shiftKey
         : event.metaKey || event.altKey || event.shiftKey;
-    const reset = () => {
-      chorded = false;
-      sync(false);
-    };
     const probeKey = (event: KeyboardEvent) => {
       if (document.body.dataset.appShortcutRecording === '1') {
-        sync(false);
+        resetGesture();
         return;
       }
       // 主修饰键自身的 keyup 是最权威的释放信号。macOS 系统快捷键
       // (如 ⌘⇧⌃4 截图)可能让事件 flags 短暂滞后,不能因 metaKey / ctrlKey
       // 仍为 true 就把提示留在界面上。
       if (event.type === 'keyup' && event.key === primaryModifierKey) {
-        reset();
+        resetGesture();
         return;
       }
       if (!isPrimaryModifierDown(event)) {
-        reset();
+        resetGesture();
         return;
       }
-      const preservesHold =
-        event.type === 'keydown' && preserveOnKeyDownRef.current?.(event) === true;
-      if (
-        event.type === 'keydown' &&
-        !preservesHold &&
-        (event.key !== primaryModifierKey || hasOtherModifier(event))
-      ) {
-        chorded = true;
+
+      // 系统可能吞掉上一轮组合键的全部 keyup。新的非 repeat 主修饰键
+      // keydown 是可靠的新手势边界;repeat 仍属于旧手势,不能借此解除 blocked。
+      if (event.type === 'keydown' && event.key === primaryModifierKey && !event.repeat) {
+        resetGesture();
+        if (hasOtherModifier(event)) {
+          modifierPrefix = true;
+        } else {
+          startHoldTimer();
+        }
+        return;
       }
-      sync(!chorded && !hasOtherModifier(event));
+      if (event.type === 'keydown' && event.key === primaryModifierKey) {
+        return;
+      }
+
+      if (event.type === 'keyup') {
+        if (isModifierKey(event.key) && modifierPrefix) blockGesture();
+        else if (preservingShortcut && !hasOtherModifier(event)) preservingShortcut = false;
+        return;
+      }
+
+      const preservesHold = preserveOnKeyDownRef.current?.(event) === true;
+      if (preservesHold && !blocked) {
+        modifierPrefix = false;
+        preservingShortcut = hasOtherModifier(event);
+        if (qualified) setVisible(true);
+        return;
+      }
+      if (isModifierKey(event.key)) {
+        modifierPrefix = true;
+        preservingShortcut = false;
+        setVisible(false);
+        return;
+      }
+      blockGesture();
     };
     const probePointer = (event: PointerEvent) => {
       if (document.body.dataset.appShortcutRecording === '1') {
-        sync(false);
+        resetGesture();
         return;
       }
       if (!isPrimaryModifierDown(event)) {
-        reset();
+        resetGesture();
         return;
       }
-      if (hasOtherModifier(event)) chorded = true;
-      sync(!chorded);
+      if (blocked) {
+        setVisible(false);
+        return;
+      }
+      if (hasOtherModifier(event)) {
+        if (!preservingShortcut) {
+          modifierPrefix = true;
+          setVisible(false);
+        }
+        return;
+      }
+      if (modifierPrefix) {
+        blockGesture();
+        return;
+      }
+      preservingShortcut = false;
+      if (qualified) setVisible(true);
     };
 
-    const unsubscribeEarlyKeyDown = subscribeEarlyKeyDownCapture(probeKey);
+    const useEarlyCapture = isEarlyKeyDownCaptureInstalled();
+    const unsubscribeEarlyKeyDown = useEarlyCapture
+      ? subscribeEarlyKeyDownCapture(probeKey)
+      : (): void => {};
     // 直接监听保留给未经过 renderer index bootstrap 的独立测试/预览环境。
     // 正式窗口优先由 earlyKeyDownCapture 投递,避免被其它快捷键的
     // stopImmediatePropagation 按注册顺序截断。
-    window.addEventListener('keydown', probeKey, true);
+    if (!useEarlyCapture) window.addEventListener('keydown', probeKey, true);
     window.addEventListener('keyup', probeKey, true);
     window.addEventListener('pointermove', probePointer, true);
-    window.addEventListener('blur', reset);
+    window.addEventListener('blur', resetGesture);
     return () => {
       unsubscribeEarlyKeyDown();
-      window.removeEventListener('keydown', probeKey, true);
+      if (!useEarlyCapture) window.removeEventListener('keydown', probeKey, true);
       window.removeEventListener('keyup', probeKey, true);
       window.removeEventListener('pointermove', probePointer, true);
-      window.removeEventListener('blur', reset);
-      if (timer != null) window.clearTimeout(timer);
+      window.removeEventListener('blur', resetGesture);
+      cancelTimer();
       setHeld(false);
     };
   }, [enabled, delayMs]);

--- a/apps/desktop/src/renderer/hooks/useModifierHold.ts
+++ b/apps/desktop/src/renderer/hooks/useModifierHold.ts
@@ -1,32 +1,41 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { getAppShortcutPlatform } from '../lib/appShortcutStore';
+import { subscribeEarlyKeyDownCapture } from '../lib/earlyKeyDownCapture';
 
 export interface UseModifierHoldOptions {
   /** false 时不挂监听且状态归零。默认 true。 */
   enabled?: boolean;
   /** 按住多久才算 hold(ms)。默认 500。 */
   delayMs?: number;
+  /** 命中时该 keydown 属于当前提示快捷键,不中断长按态。 */
+  preserveOnKeyDown?: (event: KeyboardEvent) => boolean;
 }
 
 const DEFAULT_HOLD_DELAY_MS = 500;
 
 /**
- * 「按住主修饰键」检测: mac ⌘ / 其它平台 Ctrl 持续按住 delayMs 后返回 true,
- * 松开立即回落 false。给「按住修饰键浮现快捷键提示」类 UI 做门控 —— 延迟的
- * 意义是 ⌘C / ⌘1 等快速组合根本来不及触发提示, 只有真正按住犹豫的用户才看到。
+ * 「单独按住主修饰键」检测: mac ⌘ / 其它平台 Ctrl 持续按住 delayMs
+ * 后返回 true, 松开立即回落 false。给「按住修饰键浮现快捷键提示」类 UI
+ * 做门控 —— 延迟的意义是 ⌘C / ⌘1 等快速组合根本来不及触发提示,
+ * 只有真正按住犹豫的用户才看到。长按期间一旦按下任何其它键,
+ * 本次长按就被视为组合键手势:提示立即消失,且要等主修饰键松开后才能重新触发。
+ * 唯一例外是 preserveOnKeyDown 明确识别的当前提示快捷键
+ * (例如任务序号提示的 mod+1..9),连续使用它们时长按态保留。
  *
- * 修饰键状态直接读每次 keydown / keyup / pointermove 的 metaKey / ctrlKey
- * (松开修饰键的 keyup 里对应 flag 已为 false, 松开其它键不受影响), 不跟踪
- * 具体键位。pointermove 兜底覆盖「keyup 被吞」的场景 —— 按住修饰键期间打开
+ * 修饰键状态直接读每次 keydown / keyup / pointermove 的 modifier flags;
+ * keydown 额外用 key 判断是否已按下其它键。pointermove 兜底覆盖
+ * 「keyup 被吞」的场景 —— 按住修饰键期间打开
  * 原生上下文菜单再松开, keyup 不会投递到 renderer, 靠下一次鼠标移动的真实
  * flags 复位。window blur 兜底复位 —— mac 上按住 ⌘ 点别的窗口会丢 keyup,
  * 不兜底状态会卡在按住态。设置页快捷键录制期间(body dataset 旗标, 与
  * useAppShortcut 同口径)一律视为未按住, 录制时按修饰键是常态, 不该弹提示。
  */
 export function useModifierHold(options: UseModifierHoldOptions = {}): boolean {
-  const { enabled = true, delayMs = DEFAULT_HOLD_DELAY_MS } = options;
+  const { enabled = true, delayMs = DEFAULT_HOLD_DELAY_MS, preserveOnKeyDown } = options;
   const [held, setHeld] = useState(false);
+  const preserveOnKeyDownRef = useRef(preserveOnKeyDown);
+  preserveOnKeyDownRef.current = preserveOnKeyDown;
 
   useEffect(() => {
     if (!enabled) {
@@ -34,8 +43,10 @@ export function useModifierHold(options: UseModifierHoldOptions = {}): boolean {
       return;
     }
     const isDarwin = getAppShortcutPlatform() === 'darwin';
+    const primaryModifierKey = isDarwin ? 'Meta' : 'Control';
     let timer: number | null = null;
     let active = false;
+    let chorded = false;
 
     const sync = (modifierDown: boolean) => {
       if (modifierDown) {
@@ -57,23 +68,71 @@ export function useModifierHold(options: UseModifierHoldOptions = {}): boolean {
       }
     };
 
-    const probe = (event: { metaKey: boolean; ctrlKey: boolean }) => {
+    const isPrimaryModifierDown = (event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey'>) =>
+      isDarwin ? event.metaKey : event.ctrlKey;
+    const hasOtherModifier = (
+      event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+    ) =>
+      isDarwin
+        ? event.ctrlKey || event.altKey || event.shiftKey
+        : event.metaKey || event.altKey || event.shiftKey;
+    const reset = () => {
+      chorded = false;
+      sync(false);
+    };
+    const probeKey = (event: KeyboardEvent) => {
       if (document.body.dataset.appShortcutRecording === '1') {
         sync(false);
         return;
       }
-      sync(isDarwin ? event.metaKey : event.ctrlKey);
+      // 主修饰键自身的 keyup 是最权威的释放信号。macOS 系统快捷键
+      // (如 ⌘⇧⌃4 截图)可能让事件 flags 短暂滞后,不能因 metaKey / ctrlKey
+      // 仍为 true 就把提示留在界面上。
+      if (event.type === 'keyup' && event.key === primaryModifierKey) {
+        reset();
+        return;
+      }
+      if (!isPrimaryModifierDown(event)) {
+        reset();
+        return;
+      }
+      const preservesHold =
+        event.type === 'keydown' && preserveOnKeyDownRef.current?.(event) === true;
+      if (
+        event.type === 'keydown' &&
+        !preservesHold &&
+        (event.key !== primaryModifierKey || hasOtherModifier(event))
+      ) {
+        chorded = true;
+      }
+      sync(!chorded && !hasOtherModifier(event));
     };
-    const reset = () => sync(false);
+    const probePointer = (event: PointerEvent) => {
+      if (document.body.dataset.appShortcutRecording === '1') {
+        sync(false);
+        return;
+      }
+      if (!isPrimaryModifierDown(event)) {
+        reset();
+        return;
+      }
+      if (hasOtherModifier(event)) chorded = true;
+      sync(!chorded);
+    };
 
-    window.addEventListener('keydown', probe, true);
-    window.addEventListener('keyup', probe, true);
-    window.addEventListener('pointermove', probe, true);
+    const unsubscribeEarlyKeyDown = subscribeEarlyKeyDownCapture(probeKey);
+    // 直接监听保留给未经过 renderer index bootstrap 的独立测试/预览环境。
+    // 正式窗口优先由 earlyKeyDownCapture 投递,避免被其它快捷键的
+    // stopImmediatePropagation 按注册顺序截断。
+    window.addEventListener('keydown', probeKey, true);
+    window.addEventListener('keyup', probeKey, true);
+    window.addEventListener('pointermove', probePointer, true);
     window.addEventListener('blur', reset);
     return () => {
-      window.removeEventListener('keydown', probe, true);
-      window.removeEventListener('keyup', probe, true);
-      window.removeEventListener('pointermove', probe, true);
+      unsubscribeEarlyKeyDown();
+      window.removeEventListener('keydown', probeKey, true);
+      window.removeEventListener('keyup', probeKey, true);
+      window.removeEventListener('pointermove', probePointer, true);
       window.removeEventListener('blur', reset);
       if (timer != null) window.clearTimeout(timer);
       setHeld(false);

--- a/apps/desktop/src/renderer/index.tsx
+++ b/apps/desktop/src/renderer/index.tsx
@@ -46,12 +46,14 @@ import { installRenderLoopWatchdog } from './lib/renderLoopWatchdog';
 import { installHiddenAnimationGate } from './lib/hiddenAnimationGate';
 import { installInteractionJankProbe } from './lib/interactionJankProbe';
 import { installSwallowActivationClick } from './lib/swallowActivationClick';
+import { installEarlyKeyDownCapture } from './lib/earlyKeyDownCapture';
 import { getSwallowActivationClickEnabled } from './hooks/useSwallowActivationClickSettings';
 import { bootstrapLocalThemesSync } from './themes/local-themes';
 import { themeService } from './themes/theme-service';
 import './styles/globals.css';
 import './styles/sortable.css';
 
+const disposeEarlyKeyDownCapture = installEarlyKeyDownCapture();
 installScrollbarAutoHide();
 const disposeForegroundRecoveryDiagnostics = installForegroundRecoveryDiagnostics();
 // 睡醒白屏取证:主线程阻塞漂移 + 可见无帧探针,只记日志(见模块头注释)。
@@ -120,6 +122,7 @@ if (import.meta.env.DEV) {
     disposeForegroundRecoveryDiagnostics();
     disposeRenderLoopWatchdog();
     disposeHiddenAnimationGate();
+    disposeEarlyKeyDownCapture();
     disposePerformanceTimelineCleanupInterval();
     disposeSwallowActivationClick();
     disposeInteractionJankProbe();

--- a/apps/desktop/src/renderer/lib/earlyKeyDownCapture.ts
+++ b/apps/desktop/src/renderer/lib/earlyKeyDownCapture.ts
@@ -21,6 +21,10 @@ export function installEarlyKeyDownCapture(): () => void {
   return disposeInstalledCapture;
 }
 
+export function isEarlyKeyDownCaptureInstalled(): boolean {
+  return disposeInstalledCapture != null;
+}
+
 export function subscribeEarlyKeyDownCapture(listener: KeyDownListener): () => void {
   listeners.add(listener);
   return () => listeners.delete(listener);

--- a/apps/desktop/src/renderer/lib/earlyKeyDownCapture.ts
+++ b/apps/desktop/src/renderer/lib/earlyKeyDownCapture.ts
@@ -1,0 +1,27 @@
+type KeyDownListener = (event: KeyboardEvent) => void;
+
+const listeners = new Set<KeyDownListener>();
+let disposeInstalledCapture: (() => void) | null = null;
+
+/**
+ * 在 React 挂载前注册 window capture 监听,确保后注册的快捷键即使调用
+ * stopImmediatePropagation,也不会挡住需要观察所有 keydown 的状态机。
+ */
+export function installEarlyKeyDownCapture(): () => void {
+  if (disposeInstalledCapture) return disposeInstalledCapture;
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    for (const listener of listeners) listener(event);
+  };
+  window.addEventListener('keydown', handleKeyDown, true);
+  disposeInstalledCapture = () => {
+    window.removeEventListener('keydown', handleKeyDown, true);
+    disposeInstalledCapture = null;
+  };
+  return disposeInstalledCapture;
+}
+
+export function subscribeEarlyKeyDownCapture(listener: KeyDownListener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

优化任务面板序号快捷键提示的显隐状态：macOS 仅在单独长按 Command 时显示，其他平台仅在单独长按 Ctrl 时显示；加入其它修饰键或普通按键后立即隐藏，并避免系统截图或应用快捷键吞掉事件后提示常驻。连续使用当前实际生效的任务切换快捷键（如 Cmd/Ctrl+1…9）时保持提示显示。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：本次用户反馈，无公开 Issue
- 本 PR 包含：主修饰键独占长按状态机、任务切换快捷键豁免、早期 keydown 捕获、跨平台与事件丢失回归测试
- 明确不包含：快捷键默认绑定调整、任务切换行为调整、Mobile 改动
- 用户可见变化：提示只在单独长按主修饰键时出现；组合键会隐藏提示；连续 Cmd/Ctrl+数字切换任务时提示不消失
- 是否存在 breaking change：无

### UI 变化

仅调整已有快捷键提示的交互显隐，无布局、颜色或文案变化；macOS 开发版已手工验证。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §10 双模式交付门槛（未新增样式，沿用同一语义样式，Light/Dark 行为一致）；§14 Interaction Conventions（提示严格跟随当前键盘手势状态并及时复位）

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /tmp/cindy-pr1494-gate.povGgp
结果：GATE_EXIT=0（基于最新 origin/main 的最终代码树，完整 pnpm test:unit 通过）

pnpm --filter desktop exec vitest run src/renderer/hooks/__tests__/useModifierHold.test.ts
结果：20 tests passed

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
结果：通过

cd apps/desktop && pnpm exec eslint src/renderer/index.tsx src/renderer/lib/earlyKeyDownCapture.ts src/renderer/hooks/useModifierHold.ts src/renderer/hooks/__tests__/useModifierHold.test.ts
结果：通过

pnpm check:dco
结果：2 commits signed off
```

### 手工验证

macOS Global remote 开发版：用户确认单独长按 Cmd、Cmd+Shift+Ctrl+4 截图后的复位，以及连续 Cmd+数字切换任务的行为符合预期。

### 未执行的验证

未在 Windows / Linux 实机验证；非 macOS Ctrl 路径已通过单元测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 任务面板快捷键提示的键盘事件监听与显隐；不修改快捷键配置、协议或用户数据
- 回滚 / 降级方式：回滚本 PR 提交即可恢复原有提示逻辑；非 macOS 路径使用 Ctrl 并有对称测试覆盖

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
