### PR TITLE
fix(pi): connect external HTTP MCP providers

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
@@ -39,6 +39,25 @@ function noopLogger(): Logger {
   return logger;
 }
 
+function recordingLogger(): { logger: Logger; entries: Array<{ message: string; ctx?: Record<string, unknown> }> } {
+  const entries: Array<{ message: string; ctx?: Record<string, unknown> }> = [];
+  const record = (message: string, ctx?: Record<string, unknown>): void => {
+    entries.push({ message, ...(ctx ? { ctx } : {}) });
+  };
+  const logger: Logger = {
+    trace: record,
+    debug: record,
+    info: record,
+    warn: record,
+    error: record,
+    fatal: record,
+    child() {
+      return logger;
+    },
+  };
+  return { logger, entries };
+}
+
 /** 暴露一个回报当前 lizi MCP session ctx 的 sessionId 的工具,用于断言 ctx 是否流通。 */
 function createTestServer(name: string): McpServer {
   const server = new McpServer({ name, version: '1.0.0' });
@@ -288,6 +307,177 @@ describe('piEnvironment per-session identity', () => {
 
     oldConfig!.disposeSessionCtx!();
     newConfig!.disposeSessionCtx!();
+  });
+
+  it('assembles authenticated remote HTTP MCPs with env references and no secret values in the descriptor or logs', async () => {
+    const bearerSecret = 'bearer-secret-must-not-leak';
+    const headerSecret = 'header-secret-must-not-leak';
+    const { logger, entries } = recordingLogger();
+    const provider: McpProvider = {
+      name: 'custom_exa',
+      toCodexMcpConfig: () => ({
+        type: 'http',
+        url: 'https://mcp.example.test/v1?source=pi',
+        bearerTokenEnvVar: 'UPSTREAM_BEARER',
+        envHttpHeaders: { 'X-Api-Key': 'UPSTREAM_API_KEY' },
+      }),
+      getExtraEnv: () => ({
+        UPSTREAM_BEARER: bearerSecret,
+        UPSTREAM_API_KEY: headerSecret,
+      }),
+    };
+
+    const config = await getPiExtraSpawnConfig([provider], logger, {
+      sessionId: 'pi-remote-1',
+      workingDir: '/repo',
+    });
+    const server = config!.mcpBridge!.servers[0]!;
+    expect(config!.mcpBridge!.token).toBe('');
+    expect(server).toMatchObject({
+      name: 'custom_exa',
+      url: 'https://mcp.example.test/v1?source=pi',
+      remote: { requestTimeoutMs: 600_000 },
+    });
+    // 外部 endpoint 不能被误加 localhost bridge 的 session identity。
+    expect(new URL(server.url).searchParams.has('session')).toBe(false);
+
+    const authorizationEnv = server.remote!.headerEnvVars.authorization!;
+    const apiKeyEnv = server.remote!.headerEnvVars['x-api-key']!;
+    expect(authorizationEnv).toMatch(/^CINDY_PI_REMOTE_MCP_SECRET_\d+$/);
+    expect(apiKeyEnv).toMatch(/^CINDY_PI_REMOTE_MCP_SECRET_\d+$/);
+    expect(authorizationEnv).not.toBe(apiKeyEnv);
+    expect(config!.mcpEnv).toMatchObject({
+      [authorizationEnv]: `Bearer ${bearerSecret}`,
+      [apiKeyEnv]: headerSecret,
+    });
+
+    const descriptor = JSON.stringify(config!.mcpBridge);
+    const logs = JSON.stringify(entries);
+    for (const secret of [bearerSecret, headerSecret]) {
+      expect(descriptor).not.toContain(secret);
+      expect(logs).not.toContain(secret);
+    }
+    config!.disposeSessionCtx!();
+  });
+
+  it('fail-closes malformed or incomplete remote HTTP providers without hiding a valid provider', async () => {
+    const logCanary = 'remote-secret-log-canary';
+    const { logger, entries } = recordingLogger();
+    const valid: McpProvider = {
+      name: 'valid_remote',
+      toCodexMcpConfig: () => ({ type: 'http', url: 'https://valid.example.test/mcp' }),
+    };
+    const validLoopback: McpProvider = {
+      name: 'valid_loopback',
+      toCodexMcpConfig: () => ({ type: 'http', url: 'http://127.0.0.2:4321/mcp' }),
+    };
+    const providers: McpProvider[] = [
+      {
+        name: 'missing_bearer',
+        toCodexMcpConfig: () => ({
+          type: 'http', url: 'https://missing.example.test/mcp', bearerTokenEnvVar: 'MISSING',
+        }),
+        getExtraEnv: () => ({ UNUSED: logCanary }),
+      },
+      {
+        name: 'missing_header',
+        toCodexMcpConfig: () => ({
+          type: 'http',
+          url: 'https://missing-header.example.test/mcp',
+          envHttpHeaders: { 'X-Api-Key': 'MISSING_HEADER' },
+        }),
+      },
+      {
+        name: 'invalid_scheme',
+        toCodexMcpConfig: () => ({ type: 'http', url: 'file:///tmp/not-an-http-mcp' }),
+      },
+      {
+        name: 'insecure_non_loopback',
+        toCodexMcpConfig: () => ({ type: 'http', url: 'http://public.example.test/mcp' }),
+      },
+      {
+        name: 'embedded_credentials',
+        toCodexMcpConfig: () => ({ type: 'http', url: 'https://user:secret@example.test/mcp' }),
+      },
+      {
+        name: 'invalid_header',
+        toCodexMcpConfig: () => ({
+          type: 'http',
+          url: 'https://bad-header.example.test/mcp',
+          envHttpHeaders: { 'bad\nname': 'BAD_HEADER' },
+        }),
+        getExtraEnv: () => ({ BAD_HEADER: logCanary }),
+      },
+      {
+        name: 'throwing_environment',
+        toCodexMcpConfig: () => ({ type: 'http', url: 'https://throw-env.example.test/mcp' }),
+        getExtraEnv: () => { throw new Error(logCanary); },
+      },
+      {
+        name: 'throwing_config',
+        toCodexMcpConfig: () => { throw new Error(logCanary); },
+      },
+      valid,
+      validLoopback,
+    ];
+
+    const config = await getPiExtraSpawnConfig(providers, logger);
+    expect(config!.mcpBridge!.servers.map((server) => server.name)).toEqual([
+      'valid_remote',
+      'valid_loopback',
+    ]);
+    const logs = JSON.stringify(entries);
+    expect(logs).not.toContain(logCanary);
+    expect(logs).not.toContain('user:secret');
+    config!.disposeSessionCtx!();
+  });
+
+  it('snapshots remote MCP lifecycle changes for new sessions while old leases keep their startup config', async () => {
+    let enabled = true;
+    let url = 'https://old.example.test/mcp';
+    let secret = 'old-generation-secret';
+    const provider: McpProvider = {
+      name: 'mutable_remote',
+      isEnabled: () => enabled,
+      toCodexMcpConfig: () => ({
+        type: 'http',
+        url,
+        envHttpHeaders: { 'X-Api-Key': 'MUTABLE_SECRET' },
+      }),
+      getExtraEnv: () => ({ MUTABLE_SECRET: secret }),
+    };
+
+    // 启动前已配置：首个 Pi session 直接拿到 remote server 快照。
+    const oldConfig = await getPiExtraSpawnConfig([provider], noopLogger());
+    expect(oldConfig!.mcpBridge!.servers[0]!.url).toBe(url);
+    expect(Object.values(oldConfig!.mcpEnv!)).toContain('old-generation-secret');
+
+    // 运行中修改 + 重复触发 invalidation：下一新会话/重启使用新值，旧 lease 不漂移。
+    url = 'https://new.example.test/mcp';
+    secret = 'new-generation-secret';
+    invalidatePiEnvironment();
+    invalidatePiEnvironment();
+    const newConfig = await getPiExtraSpawnConfig([provider], noopLogger());
+    expect(newConfig!.mcpBridge!.servers[0]!.url).toBe(url);
+    expect(Object.values(newConfig!.mcpEnv!)).toContain('new-generation-secret');
+    expect(oldConfig!.mcpBridge!.servers[0]!.url).toBe('https://old.example.test/mcp');
+    expect(Object.values(oldConfig!.mcpEnv!)).toContain('old-generation-secret');
+
+    // 禁用和删除都在下一 generation 撤销；再次新增后可恢复，无需重启应用。
+    enabled = false;
+    invalidatePiEnvironment();
+    expect(await getPiExtraSpawnConfig([provider], noopLogger())).toBeNull();
+    invalidatePiEnvironment();
+    expect(await getPiExtraSpawnConfig([], noopLogger())).toBeNull();
+    enabled = true;
+    secret = 'readded-secret';
+    invalidatePiEnvironment();
+    const readded = await getPiExtraSpawnConfig([provider], noopLogger());
+    expect(Object.values(readded!.mcpEnv!)).toContain('readded-secret');
+
+    oldConfig!.disposeSessionCtx!();
+    newConfig!.disposeSessionCtx!();
+    readded!.disposeSessionCtx!();
   });
 
   it('fail-closes policy-controlled builtins for an anonymous session (no workdir-bound policy)', async () => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
@@ -336,7 +336,7 @@ describe('piEnvironment per-session identity', () => {
     expect(server).toMatchObject({
       name: 'custom_exa',
       url: 'https://mcp.example.test/v1?source=pi',
-      remote: { requestTimeoutMs: 600_000 },
+      remote: { startupTimeoutMs: 10_000, requestTimeoutMs: 600_000 },
     });
     // 外部 endpoint 不能被误加 localhost bridge 的 session identity。
     expect(new URL(server.url).searchParams.has('session')).toBe(false);
@@ -369,7 +369,11 @@ describe('piEnvironment per-session identity', () => {
     };
     const validLoopback: McpProvider = {
       name: 'valid_loopback',
-      toCodexMcpConfig: () => ({ type: 'http', url: 'http://127.0.0.2:4321/mcp' }),
+      toCodexMcpConfig: () => ({ type: 'http', url: 'http://127.0.0.1:4321/mcp' }),
+    };
+    const validIpv6Loopback: McpProvider = {
+      name: 'valid_ipv6_loopback',
+      toCodexMcpConfig: () => ({ type: 'http', url: 'http://[::1]:4321/mcp' }),
     };
     const providers: McpProvider[] = [
       {
@@ -396,6 +400,12 @@ describe('piEnvironment per-session identity', () => {
         toCodexMcpConfig: () => ({ type: 'http', url: 'http://public.example.test/mcp' }),
       },
       {
+        // 127/8 都由 OS 视为 loopback，但 Pi 的 NO_PROXY 只保证 127.0.0.1；其余地址
+        // 不得明文携带认证 header，以免被全局 HTTP_PROXY 接走。
+        name: 'loopback_outside_no_proxy',
+        toCodexMcpConfig: () => ({ type: 'http', url: 'http://127.0.0.2:4321/mcp' }),
+      },
+      {
         name: 'embedded_credentials',
         toCodexMcpConfig: () => ({ type: 'http', url: 'https://user:secret@example.test/mcp' }),
       },
@@ -419,12 +429,14 @@ describe('piEnvironment per-session identity', () => {
       },
       valid,
       validLoopback,
+      validIpv6Loopback,
     ];
 
     const config = await getPiExtraSpawnConfig(providers, logger);
     expect(config!.mcpBridge!.servers.map((server) => server.name)).toEqual([
       'valid_remote',
       'valid_loopback',
+      'valid_ipv6_loopback',
     ]);
     const logs = JSON.stringify(entries);
     expect(logs).not.toContain(logCanary);

--- a/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
+++ b/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
@@ -65,6 +65,8 @@ let activeGeneration: StartedPiBridge | null = null;
 let environmentEpoch = 0;
 let nextGeneration = 0;
 const generations = new Set<StartedPiBridge>();
+const REMOTE_MCP_STARTUP_TIMEOUT_MS = 10_000;
+const REMOTE_MCP_REQUEST_TIMEOUT_MS = 600_000;
 
 function cloneRemoteServers(
   servers: StartedPiBridge['remoteServers'],
@@ -80,8 +82,8 @@ function cloneRemoteServers(
 function isLoopbackMcpHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
   return normalized === 'localhost'
-    || normalized.endsWith('.localhost')
-    || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+    || normalized === '127.0.0.1'
+    || normalized === '::1'
     || normalized === '[::1]';
 }
 
@@ -363,7 +365,9 @@ async function doStart(
       }
       // 自定义 MCP 的 host allowlist 是用户显式保存的 endpoint；不复用 SSH 入站 bridge
       // 的 server-name allowlist。公网/局域网必须 HTTPS，HTTP 仅放行明确 loopback，避免
-      // bearer / API-key 与 MCP 内容在链路上明文；同时拒绝 URL 内嵌凭证和非 web 协议。
+      // bearer / API-key 与 MCP 内容在链路上明文。明文 allowlist 与 Pi spawn 的
+      // mergeLoopbackNoProxy 完全一致，避免 127/8 中其它地址经 HTTP_PROXY 泄密；同时
+      // 拒绝 URL 内嵌凭证和非 web 协议。
       if (!isAllowedRemoteMcpUrl(parsedUrl)) {
         logger.warn('pi bridge: skipping remote HTTP MCP provider outside the URL security boundary', {
           providerName: provider.name,
@@ -413,7 +417,10 @@ async function doStart(
         url: parsedUrl.href,
         remote: {
           headerEnvVars,
-          requestTimeoutMs: 600_000,
+          // Pi RPC 的 ready 请求预算是 30s；extension 会并行探测全部 server，故任一
+          // 黑洞 provider 最多占 10s。探测成功后工具调用仍保留长请求预算。
+          startupTimeoutMs: REMOTE_MCP_STARTUP_TIMEOUT_MS,
+          requestTimeoutMs: REMOTE_MCP_REQUEST_TIMEOUT_MS,
         },
       });
       continue;

--- a/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
+++ b/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
@@ -17,11 +17,13 @@
  *    该会话全部 pi 工具。故"注册"与"打 query"必须成对:register-before-return /
  *    dispose-on-close,二者其一缺失即 401 或 ctx 泄漏。
  *
- * 差异:
- *  - 远程 HTTP 型 MCP(toCodexMcpConfig type='http',如 Slack 官方):P0 先跳过
- *    并记日志 —— pi extension 侧尚未实现远程鉴权头透传;后续补。
+ * 外部 HTTP MCP:
+ *  - host 解析 provider 的 env 引用，把 header 真值重映射到 Pi 专用 env 名；
+ *    CINDY_PI_MCP_BRIDGE 只携带 env 引用，extension 再直连用户显式配置的 URL。
+ *  - 认证值不从 host assembly 回传 renderer，也不进入 process args 或日志。
  *
- * 生命周期:bridge 懒启动单例。挂了(端口被占等)返回 null,pi 跑纯内置工具。
+ * 生命周期:environment 懒启动单例。本地 bridge 挂了时仍保留有效 remote servers；
+ * 两类 server 都不可用才返回 null，让 pi 跑纯内置工具。
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -48,8 +50,10 @@ import { pluginIdForKnownProviderName } from '../maker-host/plugins/builtin-plug
 import { createPluginRegistry } from '../maker-host/plugins/index.js';
 
 interface StartedPiBridge {
-  bridge: CodexHttpBridge;
+  bridge: CodexHttpBridge | null;
   serverNames: string[];
+  remoteServers: NonNullable<PiExtraSpawnConfig['mcpBridge']>['servers'];
+  mcpEnv: Record<string, string>;
   generation: number;
   refs: number;
   retired: boolean;
@@ -62,9 +66,34 @@ let environmentEpoch = 0;
 let nextGeneration = 0;
 const generations = new Set<StartedPiBridge>();
 
+function cloneRemoteServers(
+  servers: StartedPiBridge['remoteServers'],
+): StartedPiBridge['remoteServers'] {
+  return servers.map((server) => ({
+    ...server,
+    ...(server.remote
+      ? { remote: { ...server.remote, headerEnvVars: { ...server.remote.headerEnvVars } } }
+      : {}),
+  }));
+}
+
+function isLoopbackMcpHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'localhost'
+    || normalized.endsWith('.localhost')
+    || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+    || normalized === '[::1]';
+}
+
+function isAllowedRemoteMcpUrl(url: URL): boolean {
+  if (url.username || url.password) return false;
+  if (url.protocol === 'https:') return true;
+  return url.protocol === 'http:' && isLoopbackMcpHostname(url.hostname);
+}
+
 function shutdownGeneration(started: StartedPiBridge): Promise<void> {
   if (!started.shutdownPromise) {
-    started.shutdownPromise = started.bridge.shutdown().catch(() => {}).finally(() => {
+    started.shutdownPromise = (started.bridge?.shutdown() ?? Promise.resolve()).catch(() => {}).finally(() => {
       generations.delete(started);
     });
   }
@@ -98,7 +127,7 @@ export async function getPiExtraSpawnConfig(
   if (started.retired) return getPiExtraSpawnConfig(providers, logger, sessionCtx);
   started.refs += 1;
 
-  const { bridge, serverNames } = started;
+  const { bridge, serverNames, remoteServers, mcpEnv } = started;
   const sessionId = sessionCtx?.sessionId?.trim();
   let disposed = false;
   const disposeLease = (): void => {
@@ -112,9 +141,23 @@ export async function getPiExtraSpawnConfig(
   if (!sessionId) {
     return {
       mcpBridge: {
-        token: bridge.token,
-        servers: serverNames.map((name) => ({ name, url: bridge.url(name) })),
+        token: bridge?.token ?? '',
+        servers: [
+          ...(bridge ? serverNames.map((name) => ({ name, url: bridge.url(name) })) : []),
+          ...cloneRemoteServers(remoteServers),
+        ],
       },
+      mcpEnv: { ...mcpEnv },
+      disposeSessionCtx: disposeLease,
+    };
+  }
+
+  // 纯外部 HTTP generation 不需要 localhost bridge 的 session 路由；仍持 lease，
+  // 让配置变更后的旧活动会话继续使用其启动时快照。
+  if (!bridge) {
+    return {
+      mcpBridge: { token: '', servers: cloneRemoteServers(remoteServers) },
+      mcpEnv: { ...mcpEnv },
       disposeSessionCtx: disposeLease,
     };
   }
@@ -148,15 +191,19 @@ export async function getPiExtraSpawnConfig(
     throw error;
   }
   try {
-    const servers = serverNames.map((name) => ({
-      name,
-      url: withMcpRouteIdentity(bridge.url(name), {
-        sessionId,
-        sessionInstanceId: sessionCtx?.sessionInstanceId,
-      }),
-    }));
+    const servers = [
+      ...serverNames.map((name) => ({
+        name,
+        url: withMcpRouteIdentity(bridge.url(name), {
+          sessionId,
+          sessionInstanceId: sessionCtx?.sessionInstanceId,
+        }),
+      })),
+      ...cloneRemoteServers(remoteServers),
+    ];
     return {
       mcpBridge: { token: bridge.token, servers },
+      mcpEnv: { ...mcpEnv },
       // expectedCtx 代际比较由 bridge.unregisterSessionCtx 内部按引用做:同
       // session 覆盖注册后,旧 close 的迟到 dispose 不误删新 ctx。
       disposeSessionCtx: () => {
@@ -244,7 +291,7 @@ async function ensureBridge(providers: McpProvider[], logger: MakerLogger): Prom
 async function doStart(
   providers: McpProvider[],
   logger: MakerLogger,
-): Promise<Pick<StartedPiBridge, 'bridge' | 'serverNames'> | null> {
+): Promise<Pick<StartedPiBridge, 'bridge' | 'serverNames' | 'remoteServers' | 'mcpEnv'> | null> {
   // factory 阶段没有 per-session 信息,控制类工具通过 getSessionContext 在
   // tool-call 时读当前 session ctx —— 该 ctx 由 bridge 的 `?session=` 路由在
   // runWithLiziMcpSessionContext 里注入(见本文件顶部说明)。
@@ -276,16 +323,98 @@ async function doStart(
 
   const serverFactories: Record<string, () => McpServer> = Object.create(null);
   const pluginIdByServerName: Record<string, string> = Object.create(null);
+  const remoteServers: NonNullable<PiExtraSpawnConfig['mcpBridge']>['servers'] = [];
+  const mcpEnv: Record<string, string> = Object.create(null);
+  let nextRemoteSecret = 0;
   for (const provider of providers) {
     // 空 workdir 快照下,普通工具的项目级 gate 已在 mcp-providers 的 isEnabled 里对
     // pi 延迟(deferOrdinaryGate),此处 isEnabled 只剔掉结构性不可用(如未登录/无 source)
     // 的 provider;项目级启停改由 bridge 按会话 workdir 冻结策略在每次 tools/call 复核。
     if (provider.isEnabled && !provider.isEnabled(ctx)) continue;
 
-    const codexConfig = provider.toCodexMcpConfig?.(ctx);
-    if (codexConfig?.type === 'http') {
-      logger.warn('pi bridge: remote HTTP MCP provider not supported yet; skipping', {
+    let codexConfig: ReturnType<NonNullable<McpProvider['toCodexMcpConfig']>> | undefined;
+    try {
+      codexConfig = provider.toCodexMcpConfig?.(ctx);
+    } catch {
+      logger.warn('pi bridge: skipping provider whose MCP config could not be built', {
         providerName: provider.name,
+      });
+      continue;
+    }
+    if (codexConfig?.type === 'http') {
+      let providerEnv: Record<string, string> | null | undefined;
+      try {
+        providerEnv = await provider.getExtraEnv?.(ctx);
+      } catch {
+        logger.warn('pi bridge: skipping remote HTTP MCP provider whose environment could not be built', {
+          providerName: provider.name,
+        });
+        continue;
+      }
+
+      let parsedUrl: URL;
+      try {
+        parsedUrl = new URL(codexConfig.url);
+      } catch {
+        logger.warn('pi bridge: skipping remote HTTP MCP provider with invalid URL', {
+          providerName: provider.name,
+        });
+        continue;
+      }
+      // 自定义 MCP 的 host allowlist 是用户显式保存的 endpoint；不复用 SSH 入站 bridge
+      // 的 server-name allowlist。公网/局域网必须 HTTPS，HTTP 仅放行明确 loopback，避免
+      // bearer / API-key 与 MCP 内容在链路上明文；同时拒绝 URL 内嵌凭证和非 web 协议。
+      if (!isAllowedRemoteMcpUrl(parsedUrl)) {
+        logger.warn('pi bridge: skipping remote HTTP MCP provider outside the URL security boundary', {
+          providerName: provider.name,
+        });
+        continue;
+      }
+
+      const resolvedHeaders = new Headers();
+      let invalidReason: 'missing-bearer' | 'missing-header' | 'invalid-header' | null = null;
+      if (codexConfig.bearerTokenEnvVar) {
+        const token = providerEnv?.[codexConfig.bearerTokenEnvVar];
+        if (!token) invalidReason = 'missing-bearer';
+        else resolvedHeaders.set('authorization', `Bearer ${token}`);
+      }
+      if (!invalidReason) {
+        for (const [headerName, envName] of Object.entries(codexConfig.envHttpHeaders ?? {})) {
+          if (!providerEnv || !Object.prototype.hasOwnProperty.call(providerEnv, envName)) {
+            invalidReason = 'missing-header';
+            break;
+          }
+          try {
+            // Headers validates both the field name and CR/LF in its secret value. Explicit
+            // Authorization headers intentionally override bearer, matching CustomMcpProvider.
+            resolvedHeaders.set(headerName, providerEnv[envName]!);
+          } catch {
+            invalidReason = 'invalid-header';
+            break;
+          }
+        }
+      }
+      if (invalidReason) {
+        logger.warn('pi bridge: skipping remote HTTP MCP provider with incomplete authentication', {
+          providerName: provider.name,
+          reason: invalidReason,
+        });
+        continue;
+      }
+
+      const headerEnvVars: Record<string, string> = Object.create(null);
+      for (const [headerName, value] of resolvedHeaders.entries()) {
+        const envName = `CINDY_PI_REMOTE_MCP_SECRET_${nextRemoteSecret++}`;
+        headerEnvVars[headerName] = envName;
+        mcpEnv[envName] = value;
+      }
+      remoteServers.push({
+        name: provider.name,
+        url: parsedUrl.href,
+        remote: {
+          headerEnvVars,
+          requestTimeoutMs: 600_000,
+        },
       });
       continue;
     }
@@ -325,14 +454,27 @@ async function doStart(
   }
 
   const names = Object.keys(serverFactories);
-  if (names.length === 0) {
+  if (names.length === 0 && remoteServers.length === 0) {
     logger.warn('pi bridge: no MCP providers available; pi runs with builtin tools only');
     return null;
   }
 
   // pluginIdByServerName 让 bridge 对策略工具启用 per-call gate:按会话 ctx 里冻结的
   // disabled 列表(getPiExtraSpawnConfig 注入)阻断项目停用的工具(codex review)。
-  const bridge = await startCodexHttpBridge({ serverFactories, pluginIdByServerName, logger });
-  logger.info('pi MCP bridge ready', { port: bridge.port, servers: names.length });
-  return { bridge, serverNames: names };
+  let bridge: CodexHttpBridge | null = null;
+  if (names.length > 0) {
+    try {
+      bridge = await startCodexHttpBridge({ serverFactories, pluginIdByServerName, logger });
+    } catch {
+      logger.error('pi bridge: local MCP bridge start failed', { providers: names.length });
+      if (remoteServers.length === 0) return null;
+    }
+  }
+  const serverNames = bridge ? names : [];
+  logger.info('pi MCP environment ready', {
+    localServers: serverNames.length,
+    remoteServers: remoteServers.length,
+    ...(bridge ? { port: bridge.port } : {}),
+  });
+  return { bridge, serverNames, remoteServers, mcpEnv };
 }

--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -39,12 +39,15 @@ Cindy 以 `pi --mode rpc` spawn pi 二进制(JSONL/stdio),`translator.ts` 把 pi
   注册表不匹配时返回 401。旧 URL 缺 instance 时可兼容普通会话工具，但必须向工具隐藏
   instance，使 Full Access 自动交接保持 fail closed。
 - **MCP 桥**:`piEnvironment.ts` 把 in-process MCP providers 暴露成 localhost streamable-HTTP，
-  并把用户显式配置的外部 HTTP / Streamable HTTP MCP 作为 direct remote server 装入；SSE
-  不在此链支持。外部 URL 要求 HTTPS，只有明确 loopback endpoint 可用 HTTP；认证 header
+  并把用户显式配置的外部 HTTP / Streamable HTTP MCP 作为 direct remote server 装入；旧式
+  SSE transport 不在此链支持（但 Streamable HTTP 的 SSE response framing 受支持）。外部 URL
+  要求 HTTPS，只有明确 loopback endpoint 可用 HTTP；认证 header
   真值仅经 Pi 父进程专用 env 传递，`CINDY_PI_MCP_BRIDGE` 只存 env 引用；这些 env 与描述符
-  都会在 bash spawn 边界剥离。bridge 用极简 client `tools/list` + `registerTool` 成
-  `mcp__<server>__<tool>`。配置新增、修改、禁用或删除对下一新建/重启会话生效；旧活动会话
-  保留启动时 generation 快照至 close。
+  都会在 bash spawn 边界剥离。bridge 并行执行外部 server 启动探测，每个 server 的
+  `initialize + tools/list` 总预算为 10s（低于 Pi RPC 30s ready 门槛）；探测完成后实际工具
+  调用保留 600s 长预算。SSE response 按 event 增量消费，不等待 server 关闭持续流。工具注册
+  为 `mcp__<server>__<tool>`。配置新增、修改、禁用或删除对下一新建/重启会话生效；旧活动
+  会话保留启动时 generation 快照至 close。
 - **plan 模式**:挂 pi 自带 plan-mode 扩展,`/plan` toggle 驱动;Cindy 维护镜像态并在 resume
   时从 `get_entries` 校正。
 

--- a/docs/dev-rules/pi-harness.md
+++ b/docs/dev-rules/pi-harness.md
@@ -25,7 +25,7 @@ Cindy 以 `pi --mode rpc` spawn pi 二进制(JSONL/stdio),`translator.ts` 把 pi
   **不是**受隔离的凭证安全边界。bridge 里的凭证路径/`/proc/*/environ` 文本硬拦只是
   **defense-in-depth**,可被变形绕过(`ps eww -p $PPID`、`find /proc -exec`、变量拼接 /
   base64 / heredoc、重定向/`tee`/`cp`/`mv`/`python` 写文件等)。因此在 Full access 下:
-  - Pi 父进程环境里的代理 token / 网关 key / BYOM key **可能被读取**;
+  - Pi 父进程环境里的代理 token / 网关 key / BYOM key / 外部 MCP header **可能被读取**;
   - `readOnlyRoots`(Extra Dirs)**可能被写入**——只读语义靠 auto-review 提示与文本拦截,
     非 OS 强制。
   真正的强隔离需要 OS 级手段(macOS `sandbox-exec`、Linux 只读 bind mount / seccomp),
@@ -38,8 +38,13 @@ Cindy 以 `pi --mode rpc` spawn pi 二进制(JSONL/stdio),`translator.ts` 把 pi
   Secret／凭证等其它授权面。instance 仅作为 opaque query 写入 Host 生成的 Pi MCP URL；桥接
   注册表不匹配时返回 401。旧 URL 缺 instance 时可兼容普通会话工具，但必须向工具隐藏
   instance，使 Full Access 自动交接保持 fail closed。
-- **MCP 桥**:`piEnvironment.ts` 把 in-process MCP providers 暴露成 localhost streamable-HTTP,
-  bridge 用极简 client `tools/list` + `registerTool` 成 `mcp__<server>__<tool>`。
+- **MCP 桥**:`piEnvironment.ts` 把 in-process MCP providers 暴露成 localhost streamable-HTTP，
+  并把用户显式配置的外部 HTTP / Streamable HTTP MCP 作为 direct remote server 装入；SSE
+  不在此链支持。外部 URL 要求 HTTPS，只有明确 loopback endpoint 可用 HTTP；认证 header
+  真值仅经 Pi 父进程专用 env 传递，`CINDY_PI_MCP_BRIDGE` 只存 env 引用；这些 env 与描述符
+  都会在 bash spawn 边界剥离。bridge 用极简 client `tools/list` + `registerTool` 成
+  `mcp__<server>__<tool>`。配置新增、修改、禁用或删除对下一新建/重启会话生效；旧活动会话
+  保留启动时 generation 快照至 close。
 - **plan 模式**:挂 pi 自带 plan-mode 扩展,`/plan` toggle 驱动;Cindy 维护镜像态并在 resume
   时从 `get_entries` 校正。
 
@@ -48,7 +53,8 @@ Cindy 以 `pi --mode rpc` spawn pi 二进制(JSONL/stdio),`translator.ts` 把 pi
 Cindy 显式设置:models.json、`--append-system-prompt`、`--session-dir`、启动时 RPC
 `set_auto_compaction{enabled:true}` / `set_thinking_level`。env:`CINDY_PI_API_KEY`、
 `CINDY_PI_SESSION_ID`、`PI_CODING_AGENT_DIR`、`CINDY_PI_PERMISSION_FILE`、`CINDY_PI_MCP_BRIDGE`、
-`PI_OFFLINE=1`(关启动期联网)、`NO_PROXY` 兜底 loopback(防全局代理打穿本地 proxy 与 MCP bridge)。
+外部 MCP 专用动态 env、`PI_OFFLINE=1`(关启动期联网)、`NO_PROXY` 兜底 loopback(防全局代理
+打穿本地 proxy 与 MCP bridge)。
 
 放任 pi 默认(未写 settings.json):`retry.*`(agent 级 3 次退避、provider 级 0)、
 `httpIdleTimeoutMs=300000`、`websocketConnectTimeoutMs`、`compaction.reserveTokens/keepRecentTokens`、

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -120,6 +120,9 @@ export interface PiMcpServerRef {
   remote?: {
     /** HTTP header 名 → Pi 父进程 env var 名；描述符里绝不放 header 真值。 */
     headerEnvVars: Record<string, string>;
+    /** extension 启动时 initialize + tools/list 的总预算；必须短于 Pi RPC ready 超时。 */
+    startupTimeoutMs: number;
+    /** 完成启动探测后的单次工具调用预算。 */
     requestTimeoutMs: number;
   };
 }

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -113,12 +113,25 @@ export type McpToolApprovalPolicy =
   | 'prompt'
   | 'prompt-each-time';
 
-/** pi spawn 附加配置:host 的 MCP HTTP bridge 出口(见 AgentDeps.preparePiExtraSpawnConfig)。 */
+/** Pi 内 MCP client 的 server 描述；remote 存在时直接访问外部 Streamable HTTP MCP。 */
+export interface PiMcpServerRef {
+  name: string;
+  url: string;
+  remote?: {
+    /** HTTP header 名 → Pi 父进程 env var 名；描述符里绝不放 header 真值。 */
+    headerEnvVars: Record<string, string>;
+    requestTimeoutMs: number;
+  };
+}
+
+/** pi spawn 附加配置:host 的 MCP HTTP bridge / 外部 HTTP MCP 出口。 */
 export interface PiExtraSpawnConfig {
   mcpBridge?: {
     token: string;
-    servers: Array<{ name: string; url: string }>;
+    servers: PiMcpServerRef[];
   } | null;
+  /** 外部 MCP header 真值；只进 Pi 父进程 env，并在 bash spawn 边界剥离。 */
+  mcpEnv?: Record<string, string>;
   /**
    * 释放本 session 的 bridge lease；带 sessionId 时同时注销身份 ctx。PiAgent 在
    * close() 时调用且要求幂等。只要拿到 bridge（包括匿名会话）就应提供。

--- a/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
@@ -862,8 +862,9 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
     workingDir: string;
     permissionMode: 'ask' | 'auto' | 'bypassPermissions';
     resolverBehavior: 'allow' | 'deny';
+    deps?: AgentDeps;
   }): Promise<{ resolverTools: string[]; finalText: string }> {
-    const agent = new PiAgent(buildDeps());
+    const agent = new PiAgent(opts.deps ?? buildDeps());
     const resolverTools: string[] = [];
     let handle: AgentSessionHandle | null = null;
     try {
@@ -936,12 +937,18 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
     async () => {
       const workingDir = mkdtempSync(path.join(tmpdir(), 'pi-env-isolation-'));
       try {
+        const deps = buildDeps();
+        deps.preparePiExtraSpawnConfig = async () => ({
+          mcpBridge: { token: '', servers: [] },
+          mcpEnv: { CINDY_PI_REMOTE_MCP_SECRET_0: 'remote-mcp-secret-canary' },
+        });
         scriptedResponses.length = 0;
         scriptedResponses.push(
           anthropicToolUseBody('bash', {
             command: [
               'for n in CINDY_PI_API_KEY CINDY_PI_SESSION_ID CINDY_PI_SESSION_TOKEN',
-              'CINDY_PI_MCP_BRIDGE CINDY_PI_KEY_LOCALBYOM CINDY_PI_SECRET_ENV_NAMES',
+              'CINDY_PI_MCP_BRIDGE CINDY_PI_KEY_LOCALBYOM CINDY_PI_REMOTE_MCP_SECRET_0',
+              'CINDY_PI_SECRET_ENV_NAMES',
               'CINDY_PI_PERMISSION_FILE PI_CODING_AGENT_DIR PI_SESSION_ID PI_SESSION_FILE; do',
               '  if [ -n "$(printenv "$n")" ]; then printf "PI_ENV_LEAK:%s\\n" "$n"; fi;',
               'done; printf "PI_ENV_CLEAN\\n"',
@@ -955,6 +962,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
           workingDir,
           permissionMode: 'ask',
           resolverBehavior: 'allow',
+          deps,
         });
         const lastBody = JSON.parse(seenRequests.slice(reqBefore).at(-1)?.body ?? '{}') as {
           messages?: Array<{ role?: string; content?: Array<{ type?: string; content?: string }> }>;
@@ -965,6 +973,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
         expect(toolResult).toContain('PI_ENV_CLEAN');
         expect(toolResult).not.toContain('PI_ENV_LEAK:');
         expect(toolResult).not.toContain('test-key-123');
+        expect(toolResult).not.toContain('remote-mcp-secret-canary');
       } finally {
         rmSync(workingDir, { recursive: true, force: true });
         scriptedResponses.length = 0;

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -170,7 +170,7 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       ]),
     );
     const noProxy = (captured.env.NO_PROXY ?? '').split(',');
-    for (const entry of ['corp.internal', '127.0.0.1', 'localhost', '::1']) {
+    for (const entry of ['corp.internal', '127.0.0.1', 'localhost', '::1', '[::1]']) {
       expect(noProxy).toContain(entry);
     }
     expect(captured.env.no_proxy).toBeUndefined();

--- a/packages/maker-core/src/agents/pi/__tests__/pi-mcp-bridge.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-mcp-bridge.integration.test.ts
@@ -173,6 +173,56 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
           ...(apiKey ? { apiKey } : {}),
         });
       }
+      if (req.url?.includes('/persistent-sse')) {
+        if (auth !== `Bearer ${REMOTE_BEARER}` || apiKey !== REMOTE_API_KEY) {
+          res.writeHead(401).end('unauthorized');
+          return;
+        }
+        const body = JSON.parse(await readBody(req)) as {
+          id?: number;
+          method?: string;
+          params?: { arguments?: { text?: unknown } };
+        };
+        if (body.id === undefined) {
+          res.writeHead(202).end();
+          return;
+        }
+        let result: unknown;
+        if (body.method === 'initialize') {
+          result = {
+            protocolVersion: '2025-03-26',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'persistent-sse', version: '1.0.0' },
+          };
+        } else if (body.method === 'tools/list') {
+          result = {
+            tools: [{
+              name: 'echo',
+              description: 'Echo text back',
+              inputSchema: {
+                type: 'object',
+                properties: { text: { type: 'string' } },
+                required: ['text'],
+              },
+            }],
+          };
+        } else if (body.method === 'tools/call') {
+          // 超过 50ms startup budget 后才回工具结果，证明探测完成后切回长 request budget。
+          await new Promise((resolve) => setTimeout(resolve, 120));
+          const text = body.params?.arguments?.text;
+          echoCalls.push({ text });
+          result = { content: [{ type: 'text', text: `ECHO[${String(text)}]` }] };
+        } else {
+          result = {};
+        }
+        res.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' });
+        res.write(`event: message\r\ndata: ${JSON.stringify({ jsonrpc: '2.0', id: body.id, result })}\r\n\r\n`);
+        // 合法 Streamable HTTP server 可在返回当前 response 后继续保持 SSE 流；client
+        // 必须在 event 到达时返回并取消流，而不是等待这里结束。
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        if (!res.destroyed && !res.writableEnded) res.end();
+        return;
+      }
       if (req.url?.includes('/reject')) {
         res.writeHead(401, { 'content-type': 'text/plain' });
         res.end(REMOTE_ERROR_CANARY);
@@ -223,7 +273,7 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   });
 
   function buildDeps(
-    bridgeMode: 'local' | 'remote' | 'remote-failures' = 'local',
+    bridgeMode: 'local' | 'remote' | 'remote-sse' | 'remote-failures' = 'local',
     logger: Logger = noopLogger,
   ): AgentDeps {
     return {
@@ -259,7 +309,31 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
                     authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0',
                     'x-api-key': 'CINDY_PI_REMOTE_MCP_SECRET_1',
                   },
+                  startupTimeoutMs: 1_000,
                   requestTimeoutMs: 5_000,
+                },
+              }],
+            },
+            mcpEnv: {
+              CINDY_PI_REMOTE_MCP_SECRET_0: `Bearer ${REMOTE_BEARER}`,
+              CINDY_PI_REMOTE_MCP_SECRET_1: REMOTE_API_KEY,
+            },
+          };
+        }
+        if (bridgeMode === 'remote-sse') {
+          return {
+            mcpBridge: {
+              token: '',
+              servers: [{
+                name: 'cindy_echo',
+                url: `${mcpUrl}/persistent-sse`,
+                remote: {
+                  headerEnvVars: {
+                    authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0',
+                    'x-api-key': 'CINDY_PI_REMOTE_MCP_SECRET_1',
+                  },
+                  startupTimeoutMs: 50,
+                  requestTimeoutMs: 1_000,
                 },
               }],
             },
@@ -279,6 +353,7 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
                   url: `${mcpUrl}/reject`,
                   remote: {
                     headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
+                    startupTimeoutMs: 1_000,
                     requestTimeoutMs: 1_000,
                   },
                 },
@@ -287,7 +362,8 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
                   url: `${mcpUrl}/slow`,
                   remote: {
                     headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
-                    requestTimeoutMs: 50,
+                    startupTimeoutMs: 50,
+                    requestTimeoutMs: 5_000,
                   },
                 },
                 {
@@ -295,7 +371,8 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
                   url: `${mcpUrl}/stall-body`,
                   remote: {
                     headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
-                    requestTimeoutMs: 50,
+                    startupTimeoutMs: 50,
+                    requestTimeoutMs: 5_000,
                   },
                 },
               ],
@@ -323,7 +400,7 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   async function runOneTurn(
     permissionMode: 'ask' | 'bypassPermissions',
     resolver: (req: InteractionRequest) => Promise<InteractionDecision>,
-    bridgeMode: 'local' | 'remote' = 'local',
+    bridgeMode: 'local' | 'remote' | 'remote-sse' = 'local',
   ): Promise<{ events: AgentEvent[]; permissionAsked: boolean }> {
     const agent = new PiAgent(buildDeps(bridgeMode));
     const cwd = mkdtempSync(path.join(tmpdir(), 'pi-mcp-cwd-'));
@@ -396,12 +473,42 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
       echoCalls.length = 0;
       seenMcpUrls.length = 0;
       seenRemoteHeaders.length = 0;
-      const { events, permissionAsked } = await runOneTurn(
-        'bypassPermissions',
-        async () => ({ kind: 'permission', behavior: 'deny' }),
-        'remote',
-      );
+      let proxyHits = 0;
+      const proxy = createServer((_req, res) => {
+        proxyHits += 1;
+        res.writeHead(502).end('loopback traffic must not reach HTTP_PROXY');
+      });
+      await new Promise<void>((resolve) => proxy.listen(0, '127.0.0.1', resolve));
+      const proxyAddress = proxy.address();
+      if (typeof proxyAddress !== 'object' || !proxyAddress) throw new Error('proxy did not listen');
+      const previous = {
+        HTTP_PROXY: process.env.HTTP_PROXY,
+        http_proxy: process.env.http_proxy,
+        NO_PROXY: process.env.NO_PROXY,
+        no_proxy: process.env.no_proxy,
+      };
+      process.env.HTTP_PROXY = `http://127.0.0.1:${proxyAddress.port}`;
+      delete process.env.http_proxy;
+      process.env.NO_PROXY = '';
+      delete process.env.no_proxy;
+      let turn: Awaited<ReturnType<typeof runOneTurn>> | undefined;
+      try {
+        turn = await runOneTurn(
+          'bypassPermissions',
+          async () => ({ kind: 'permission', behavior: 'deny' }),
+          'remote',
+        );
+      } finally {
+        for (const name of Object.keys(previous)) delete process.env[name];
+        for (const [name, value] of Object.entries(previous)) {
+          if (value !== undefined) process.env[name] = value;
+        }
+        await new Promise<void>((resolve) => proxy.close(() => resolve()));
+      }
 
+      expect(turn).toBeDefined();
+      const { events, permissionAsked } = turn!;
+      expect(proxyHits).toBe(0);
       expect(permissionAsked).toBe(false);
       expect(echoCalls).toEqual([{ text: 'hello-pi' }]);
       expect(seenRemoteHeaders.length).toBeGreaterThan(0);
@@ -409,6 +516,29 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
         headers.authorization === `Bearer ${REMOTE_BEARER}` && headers.apiKey === REMOTE_API_KEY
       )).toBe(true);
       expect(seenMcpUrls.every((url) => !url.includes('session='))).toBe(true);
+      const finalText = events
+        .filter((event) => event.type === 'text')
+        .map((event) => event.data as { text: string; isFinal?: boolean })
+        .filter((data) => data.isFinal)
+        .map((data) => data.text)
+        .join('');
+      expect(finalText).toContain('ECHO[hello-pi]');
+    },
+  );
+
+  it(
+    'persistent SSE: registers on the matching event without waiting for stream close, then uses the long tool timeout',
+    { timeout: 90_000 },
+    async () => {
+      echoCalls.length = 0;
+      const { events, permissionAsked } = await runOneTurn(
+        'bypassPermissions',
+        async () => ({ kind: 'permission', behavior: 'deny' }),
+        'remote-sse',
+      );
+
+      expect(permissionAsked).toBe(false);
+      expect(echoCalls).toEqual([{ text: 'hello-pi' }]);
       const finalText = events
         .filter((event) => event.type === 'text')
         .map((event) => event.data as { text: string; isFinal?: boolean })

--- a/packages/maker-core/src/agents/pi/__tests__/pi-mcp-bridge.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-mcp-bridge.integration.test.ts
@@ -28,7 +28,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 
 import { PiAgent } from '../index.js';
-import type { AgentDeps, AgentSessionHandle } from '../../base-agent.js';
+import type { AgentDeps, AgentSessionHandle, PiExtraSpawnConfig } from '../../base-agent.js';
 import type { AgentEvent, InteractionRequest, InteractionDecision } from '../../../types/events.js';
 import type { Logger } from '../../../interfaces/logger.js';
 
@@ -52,6 +52,22 @@ const noopLogger: Logger = {
   fatal: () => {},
   child: () => noopLogger,
 };
+
+function recordingLogger(entries: Array<{ message: string; ctx?: Record<string, unknown> }>): Logger {
+  const record = (message: string, ctx?: Record<string, unknown>): void => {
+    entries.push({ message, ...(ctx ? { ctx } : {}) });
+  };
+  const logger: Logger = {
+    trace: record,
+    debug: record,
+    info: record,
+    warn: record,
+    error: record,
+    fatal: record,
+    child: () => logger,
+  };
+  return logger;
+}
 
 function readBody(req: IncomingMessage): Promise<string> {
   return new Promise((resolve) => {
@@ -120,11 +136,15 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   let mcpHttp: Server;
   let mcpUrl = '';
   const MCP_TOKEN = 'bridge-token-xyz';
+  const REMOTE_BEARER = 'remote-bearer-secret';
+  const REMOTE_API_KEY = 'remote-api-key-secret';
+  const REMOTE_ERROR_CANARY = 'remote-error-body-secret-canary';
   let agentHome = '';
   const echoCalls: Array<{ text: unknown }> = [];
   // 记录假 MCP server 收到的请求 URL —— 断言真 pi(经 cindy-bridge fetch)把
   // host 下发的 `?session=<id>` 原样带到每个 MCP 请求上(orca 身份路由的 pi 侧半)。
   const seenMcpUrls: string[] = [];
+  const seenRemoteHeaders: Array<{ authorization?: string; apiKey?: string }> = [];
 
   beforeAll(async () => {
     agentHome = mkdtempSync(path.join(tmpdir(), 'pi-mcp-int-'));
@@ -144,7 +164,35 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
     mcpHttp = createServer(async (req: IncomingMessage, res: ServerResponse) => {
       seenMcpUrls.push(req.url ?? '');
       const auth = req.headers.authorization ?? '';
-      if (auth !== `Bearer ${MCP_TOKEN}`) {
+      const apiKey = Array.isArray(req.headers['x-api-key'])
+        ? req.headers['x-api-key'][0]
+        : req.headers['x-api-key'];
+      if (auth === `Bearer ${REMOTE_BEARER}` || apiKey) {
+        seenRemoteHeaders.push({
+          ...(auth ? { authorization: auth } : {}),
+          ...(apiKey ? { apiKey } : {}),
+        });
+      }
+      if (req.url?.includes('/reject')) {
+        res.writeHead(401, { 'content-type': 'text/plain' });
+        res.end(REMOTE_ERROR_CANARY);
+        return;
+      }
+      if (req.url?.includes('/slow')) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        if (!res.destroyed && !res.writableEnded) res.writeHead(504).end('late response');
+        return;
+      }
+      if (req.url?.includes('/stall-body')) {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.write('{"jsonrpc":"2.0","id":1');
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        if (!res.destroyed && !res.writableEnded) res.end('}');
+        return;
+      }
+      const localAuthorized = auth === `Bearer ${MCP_TOKEN}`;
+      const remoteAuthorized = auth === `Bearer ${REMOTE_BEARER}` && apiKey === REMOTE_API_KEY;
+      if (!localAuthorized && !remoteAuthorized) {
         res.writeHead(401).end('unauthorized');
         return;
       }
@@ -174,7 +222,10 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
     rmSync(agentHome, { recursive: true, force: true });
   });
 
-  function buildDeps(): AgentDeps {
+  function buildDeps(
+    bridgeMode: 'local' | 'remote' | 'remote-failures' = 'local',
+    logger: Logger = noopLogger,
+  ): AgentDeps {
     return {
       auth: {
         getState: async () => ({ authenticated: true, identity: 'test', authSource: 'api-key' as const }),
@@ -184,7 +235,7 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
       },
       runtimeConfig: { endpoint: gatewayUrl },
       binaryPath: PI_BINARY,
-      logger: noopLogger,
+      logger,
       capabilityAdditions: {
         availableModels: [
           { id: 'pi-test-model', displayName: 'Pi Test', contextWindow: 200_000, efforts: [], defaultEffort: null },
@@ -194,27 +245,87 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
       // host MCP bridge 出口:指向本测试的假 MCP server。把 ctx.sessionId 打进
       // `?session=` —— 既验 PiAgent.startSession 把 opts.sessionId 透传进 ctx,
       // 又让假 server 能观察到真 pi 是否原样转发该 query(见 seenMcpUrls 断言)。
-      preparePiExtraSpawnConfig: async (_providers, ctx) => ({
-        mcpBridge: {
-          token: MCP_TOKEN,
-          servers: [
-            {
-              name: 'cindy_echo',
-              url: ctx?.sessionId
-                ? `${mcpUrl}?session=${encodeURIComponent(ctx.sessionId)}`
-                : mcpUrl,
+      preparePiExtraSpawnConfig: async (_providers, ctx): Promise<PiExtraSpawnConfig> => {
+        if (bridgeMode === 'remote') {
+          return {
+            mcpBridge: {
+              // 故意给一个错误的 local token，证明 direct remote 不会把它当 Authorization。
+              token: 'must-not-be-sent-to-remote',
+              servers: [{
+                name: 'cindy_echo',
+                url: mcpUrl,
+                remote: {
+                  headerEnvVars: {
+                    authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0',
+                    'x-api-key': 'CINDY_PI_REMOTE_MCP_SECRET_1',
+                  },
+                  requestTimeoutMs: 5_000,
+                },
+              }],
             },
-          ],
-        },
-      }),
+            mcpEnv: {
+              CINDY_PI_REMOTE_MCP_SECRET_0: `Bearer ${REMOTE_BEARER}`,
+              CINDY_PI_REMOTE_MCP_SECRET_1: REMOTE_API_KEY,
+            },
+          };
+        }
+        if (bridgeMode === 'remote-failures') {
+          return {
+            mcpBridge: {
+              token: '',
+              servers: [
+                {
+                  name: 'rejecting_remote',
+                  url: `${mcpUrl}/reject`,
+                  remote: {
+                    headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
+                    requestTimeoutMs: 1_000,
+                  },
+                },
+                {
+                  name: 'slow_remote',
+                  url: `${mcpUrl}/slow`,
+                  remote: {
+                    headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
+                    requestTimeoutMs: 50,
+                  },
+                },
+                {
+                  name: 'stalling_body_remote',
+                  url: `${mcpUrl}/stall-body`,
+                  remote: {
+                    headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
+                    requestTimeoutMs: 50,
+                  },
+                },
+              ],
+            },
+            mcpEnv: { CINDY_PI_REMOTE_MCP_SECRET_0: `Bearer ${REMOTE_BEARER}` },
+          };
+        }
+        return {
+          mcpBridge: {
+            token: MCP_TOKEN,
+            servers: [
+              {
+                name: 'cindy_echo',
+                url: ctx?.sessionId
+                  ? `${mcpUrl}?session=${encodeURIComponent(ctx.sessionId)}`
+                  : mcpUrl,
+              },
+            ],
+          },
+        };
+      },
     };
   }
 
   async function runOneTurn(
     permissionMode: 'ask' | 'bypassPermissions',
     resolver: (req: InteractionRequest) => Promise<InteractionDecision>,
+    bridgeMode: 'local' | 'remote' = 'local',
   ): Promise<{ events: AgentEvent[]; permissionAsked: boolean }> {
-    const agent = new PiAgent(buildDeps());
+    const agent = new PiAgent(buildDeps(bridgeMode));
     const cwd = mkdtempSync(path.join(tmpdir(), 'pi-mcp-cwd-'));
     let handle: AgentSessionHandle | null = null;
     let permissionAsked = false;
@@ -279,6 +390,72 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   );
 
   it(
+    'direct remote HTTP: uses env-backed bearer/custom headers instead of the localhost bridge token',
+    { timeout: 90_000 },
+    async () => {
+      echoCalls.length = 0;
+      seenMcpUrls.length = 0;
+      seenRemoteHeaders.length = 0;
+      const { events, permissionAsked } = await runOneTurn(
+        'bypassPermissions',
+        async () => ({ kind: 'permission', behavior: 'deny' }),
+        'remote',
+      );
+
+      expect(permissionAsked).toBe(false);
+      expect(echoCalls).toEqual([{ text: 'hello-pi' }]);
+      expect(seenRemoteHeaders.length).toBeGreaterThan(0);
+      expect(seenRemoteHeaders.every((headers) =>
+        headers.authorization === `Bearer ${REMOTE_BEARER}` && headers.apiKey === REMOTE_API_KEY
+      )).toBe(true);
+      expect(seenMcpUrls.every((url) => !url.includes('session='))).toBe(true);
+      const finalText = events
+        .filter((event) => event.type === 'text')
+        .map((event) => event.data as { text: string; isFinal?: boolean })
+        .filter((data) => data.isFinal)
+        .map((data) => data.text)
+        .join('');
+      expect(finalText).toContain('ECHO[hello-pi]');
+    },
+  );
+
+  it(
+    'remote startup failures and timeouts are visible without logging URL, response body, or auth secrets',
+    { timeout: 30_000 },
+    async () => {
+      const entries: Array<{ message: string; ctx?: Record<string, unknown> }> = [];
+      const logger = recordingLogger(entries);
+      const agent = new PiAgent(buildDeps('remote-failures', logger));
+      const cwd = mkdtempSync(path.join(tmpdir(), 'pi-mcp-failure-cwd-'));
+      let handle: AgentSessionHandle | null = null;
+      try {
+        handle = await agent.startSession({
+          sessionId: 'mcp-remote-failure-itest',
+          workingDir: cwd,
+          model: 'pi-test-model',
+          permissionMode: 'bypassPermissions',
+        });
+        await waitFor(() => {
+          const logs = JSON.stringify(entries);
+          return logs.includes('HTTP 401')
+            && logs.includes('connect slow_remote failed: request timed out')
+            && logs.includes('connect stalling_body_remote failed: request timed out');
+        });
+        const logs = JSON.stringify(entries);
+        expect(logs).toContain('connect rejecting_remote failed: HTTP 401');
+        expect(logs).toContain('connect slow_remote failed: request timed out');
+        expect(logs).toContain('connect stalling_body_remote failed: request timed out');
+        for (const forbidden of [REMOTE_BEARER, REMOTE_API_KEY, REMOTE_ERROR_CANARY, mcpUrl]) {
+          expect(logs).not.toContain(forbidden);
+        }
+      } finally {
+        await handle?.close();
+        rmSync(cwd, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it(
     'ask + deny: 权限拒绝 → cindy 工具不执行(MCP server 未被命中)',
     { timeout: 90_000 },
     async () => {
@@ -293,3 +470,11 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
     },
   );
 });
+
+async function waitFor(condition: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const started = Date.now();
+  while (!condition()) {
+    if (Date.now() - started > timeoutMs) throw new Error('waitFor timed out');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}

--- a/packages/maker-core/src/agents/pi/__tests__/pi-mcp-bridge.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-mcp-bridge.integration.test.ts
@@ -145,6 +145,8 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   // host 下发的 `?session=<id>` 原样带到每个 MCP 请求上(orca 身份路由的 pi 侧半)。
   const seenMcpUrls: string[] = [];
   const seenRemoteHeaders: Array<{ authorization?: string; apiKey?: string }> = [];
+  const paginatedListCursors: Array<string | undefined> = [];
+  const timedOutPaginationCursors: Array<string | undefined> = [];
 
   beforeAll(async () => {
     agentHome = mkdtempSync(path.join(tmpdir(), 'pi-mcp-int-'));
@@ -172,6 +174,93 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
           ...(auth ? { authorization: auth } : {}),
           ...(apiKey ? { apiKey } : {}),
         });
+      }
+      if (req.url?.includes('/paginated-timeout')) {
+        if (auth !== `Bearer ${REMOTE_BEARER}`) {
+          res.writeHead(401).end('unauthorized');
+          return;
+        }
+        const body = JSON.parse(await readBody(req)) as {
+          id?: number;
+          method?: string;
+          params?: { cursor?: string };
+        };
+        if (body.id === undefined) {
+          res.writeHead(202).end();
+          return;
+        }
+        let result: unknown;
+        if (body.method === 'initialize') {
+          result = {
+            protocolVersion: '2025-03-26',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'paginated-timeout', version: '1.0.0' },
+          };
+        } else if (body.method === 'tools/list') {
+          timedOutPaginationCursors.push(body.params?.cursor);
+          if (body.params?.cursor === 'slow-page') {
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          }
+          result = body.params?.cursor === undefined
+            ? { tools: [], nextCursor: 'slow-page' }
+            : { tools: [] };
+        } else {
+          result = {};
+        }
+        if (!res.destroyed && !res.writableEnded) {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id, result }));
+        }
+        return;
+      }
+      if (req.url?.includes('/paginated')) {
+        if (auth !== `Bearer ${REMOTE_BEARER}` || apiKey !== REMOTE_API_KEY) {
+          res.writeHead(401).end('unauthorized');
+          return;
+        }
+        const body = JSON.parse(await readBody(req)) as {
+          id?: number;
+          method?: string;
+          params?: { cursor?: string; arguments?: { text?: unknown } };
+        };
+        if (body.id === undefined) {
+          res.writeHead(202).end();
+          return;
+        }
+        const tool = (name: string) => ({
+          name,
+          description: `Tool from ${name}`,
+          inputSchema: {
+            type: 'object',
+            properties: { text: { type: 'string' } },
+            required: ['text'],
+          },
+        });
+        let result: unknown;
+        if (body.method === 'initialize') {
+          result = {
+            protocolVersion: '2025-03-26',
+            capabilities: { tools: {} },
+            serverInfo: { name: 'paginated', version: '1.0.0' },
+          };
+        } else if (body.method === 'tools/list') {
+          const cursor = body.params?.cursor;
+          paginatedListCursors.push(cursor);
+          result = cursor === undefined
+            ? { tools: [tool('page_one')], nextCursor: 'page-2' }
+            : cursor === 'page-2'
+              ? { tools: [tool('page_two')], nextCursor: 'page-3' }
+              : { tools: [tool('echo')] };
+        } else if (body.method === 'tools/call') {
+          const text = body.params?.arguments?.text;
+          echoCalls.push({ text });
+          result = { content: [{ type: 'text', text: `ECHO[${String(text)}]` }] };
+        } else {
+          result = {};
+        }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ jsonrpc: '2.0', id: body.id, result }));
+        return;
       }
       if (req.url?.includes('/persistent-sse')) {
         if (auth !== `Bearer ${REMOTE_BEARER}` || apiKey !== REMOTE_API_KEY) {
@@ -273,7 +362,7 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   });
 
   function buildDeps(
-    bridgeMode: 'local' | 'remote' | 'remote-sse' | 'remote-failures' = 'local',
+    bridgeMode: 'local' | 'remote' | 'remote-sse' | 'remote-paginated' | 'remote-failures' = 'local',
     logger: Logger = noopLogger,
   ): AgentDeps {
     return {
@@ -343,6 +432,29 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
             },
           };
         }
+        if (bridgeMode === 'remote-paginated') {
+          return {
+            mcpBridge: {
+              token: '',
+              servers: [{
+                name: 'cindy_echo',
+                url: `${mcpUrl}/paginated`,
+                remote: {
+                  headerEnvVars: {
+                    authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0',
+                    'x-api-key': 'CINDY_PI_REMOTE_MCP_SECRET_1',
+                  },
+                  startupTimeoutMs: 1_000,
+                  requestTimeoutMs: 1_000,
+                },
+              }],
+            },
+            mcpEnv: {
+              CINDY_PI_REMOTE_MCP_SECRET_0: `Bearer ${REMOTE_BEARER}`,
+              CINDY_PI_REMOTE_MCP_SECRET_1: REMOTE_API_KEY,
+            },
+          };
+        }
         if (bridgeMode === 'remote-failures') {
           return {
             mcpBridge: {
@@ -375,6 +487,15 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
                     requestTimeoutMs: 5_000,
                   },
                 },
+                {
+                  name: 'paginated_timeout_remote',
+                  url: `${mcpUrl}/paginated-timeout`,
+                  remote: {
+                    headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
+                    startupTimeoutMs: 200,
+                    requestTimeoutMs: 5_000,
+                  },
+                },
               ],
             },
             mcpEnv: { CINDY_PI_REMOTE_MCP_SECRET_0: `Bearer ${REMOTE_BEARER}` },
@@ -400,7 +521,7 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   async function runOneTurn(
     permissionMode: 'ask' | 'bypassPermissions',
     resolver: (req: InteractionRequest) => Promise<InteractionDecision>,
-    bridgeMode: 'local' | 'remote' | 'remote-sse' = 'local',
+    bridgeMode: 'local' | 'remote' | 'remote-sse' | 'remote-paginated' = 'local',
   ): Promise<{ events: AgentEvent[]; permissionAsked: boolean }> {
     const agent = new PiAgent(buildDeps(bridgeMode));
     const cwd = mkdtempSync(path.join(tmpdir(), 'pi-mcp-cwd-'));
@@ -550,11 +671,37 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
   );
 
   it(
+    'paginated tools/list: follows every cursor within startup and registers a tool from the final page',
+    { timeout: 90_000 },
+    async () => {
+      echoCalls.length = 0;
+      paginatedListCursors.length = 0;
+      const { events, permissionAsked } = await runOneTurn(
+        'bypassPermissions',
+        async () => ({ kind: 'permission', behavior: 'deny' }),
+        'remote-paginated',
+      );
+
+      expect(permissionAsked).toBe(false);
+      expect(paginatedListCursors).toEqual([undefined, 'page-2', 'page-3']);
+      expect(echoCalls).toEqual([{ text: 'hello-pi' }]);
+      const finalText = events
+        .filter((event) => event.type === 'text')
+        .map((event) => event.data as { text: string; isFinal?: boolean })
+        .filter((data) => data.isFinal)
+        .map((data) => data.text)
+        .join('');
+      expect(finalText).toContain('ECHO[hello-pi]');
+    },
+  );
+
+  it(
     'remote startup failures and timeouts are visible without logging URL, response body, or auth secrets',
     { timeout: 30_000 },
     async () => {
       const entries: Array<{ message: string; ctx?: Record<string, unknown> }> = [];
       const logger = recordingLogger(entries);
+      timedOutPaginationCursors.length = 0;
       const agent = new PiAgent(buildDeps('remote-failures', logger));
       const cwd = mkdtempSync(path.join(tmpdir(), 'pi-mcp-failure-cwd-'));
       let handle: AgentSessionHandle | null = null;
@@ -569,12 +716,15 @@ describe.skipIf(!piAvailable)('PiAgent × cindy-bridge (real pi + MCP bridge + p
           const logs = JSON.stringify(entries);
           return logs.includes('HTTP 401')
             && logs.includes('connect slow_remote failed: request timed out')
-            && logs.includes('connect stalling_body_remote failed: request timed out');
+            && logs.includes('connect stalling_body_remote failed: request timed out')
+            && logs.includes('connect paginated_timeout_remote failed: request timed out');
         });
         const logs = JSON.stringify(entries);
         expect(logs).toContain('connect rejecting_remote failed: HTTP 401');
         expect(logs).toContain('connect slow_remote failed: request timed out');
         expect(logs).toContain('connect stalling_body_remote failed: request timed out');
+        expect(logs).toContain('connect paginated_timeout_remote failed: request timed out');
+        expect(timedOutPaginationCursors).toEqual([undefined, 'slow-page']);
         for (const forbidden of [REMOTE_BEARER, REMOTE_API_KEY, REMOTE_ERROR_CANARY, mcpUrl]) {
           expect(logs).not.toContain(forbidden);
         }

--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -24,6 +24,7 @@ const knobs = vi.hoisted(() => ({
   closeCount: 0,
   onExit: null as null | ((info: { code: number | null; signal: string | null }) => void),
   spawnedEnvs: [] as Array<Record<string, string | undefined>>,
+  spawnedArgs: [] as string[][],
 }));
 
 vi.mock('../rpc-client.js', () => ({
@@ -32,10 +33,11 @@ vi.mock('../rpc-client.js', () => ({
     constructor(opts: unknown) {
       // 捕获 onExit 以便单测模拟进程异常退出(crash);捕获 env 以断言每会话隔离 configHome。
       const o = opts as
-        | { onExit?: typeof knobs.onExit; env?: Record<string, string | undefined> }
+        | { onExit?: typeof knobs.onExit; env?: Record<string, string | undefined>; args?: string[] }
         | undefined;
       knobs.onExit = o?.onExit ?? null;
       knobs.spawnedEnvs.push({ ...(o?.env ?? {}) });
+      knobs.spawnedArgs.push([...(o?.args ?? [])]);
       if (knobs.ctorThrows) throw new Error('spawn failed (mock)');
     }
     async request(cmd: { type: string }): Promise<{ success: boolean; data?: unknown; error?: string }> {
@@ -77,6 +79,7 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     knobs.closeCount = 0;
     knobs.onExit = null;
     knobs.spawnedEnvs = [];
+    knobs.spawnedArgs = [];
     disposed = 0;
     proxyDisposed = 0;
     preparedMcpContext = undefined;
@@ -108,11 +111,23 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
       },
       resolvePiAgentHome: () => agentHome,
       registerPiProxySession: () => () => { proxyDisposed++; },
-      // 注册身份并回传 disposeSessionCtx 探针(servers 空,无需真桥)。
+      // 注册身份并回传 disposeSessionCtx 探针；外部 MCP 描述只放 env 引用，真值
+      // 单独放 mcpEnv，供本文件断言 spawn / bash 隔离契约。
       preparePiExtraSpawnConfig: async (_providers, context) => {
         preparedMcpContext = context;
         return {
-          mcpBridge: { token: 'itest', servers: [] },
+          mcpBridge: {
+            token: '',
+            servers: [{
+              name: 'custom_remote',
+              url: 'https://mcp.example.test/',
+              remote: {
+                headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
+                requestTimeoutMs: 600_000,
+              },
+            }],
+          },
+          mcpEnv: { CINDY_PI_REMOTE_MCP_SECRET_0: 'Bearer spawn-secret-canary' },
           disposeSessionCtx: () => { disposed++; },
         };
       },
@@ -157,6 +172,29 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
     await handle.close();
     expect(disposed).toBe(1); // close() 才注销
     expect(proxyDisposed).toBe(1);
+  });
+
+  it('injects remote MCP secrets only through env and marks them for bash-child stripping', async () => {
+    const agent = new PiAgent(buildDeps());
+    const handle = await agent.startSession(opts());
+    const env = knobs.spawnedEnvs[0]!;
+    const secret = 'Bearer spawn-secret-canary';
+    expect(env.CINDY_PI_REMOTE_MCP_SECRET_0).toBe(secret);
+
+    const descriptorRaw = env.CINDY_PI_MCP_BRIDGE!;
+    expect(descriptorRaw).not.toContain(secret);
+    expect(JSON.parse(descriptorRaw)).toMatchObject({
+      servers: [{
+        name: 'custom_remote',
+        remote: { headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' } },
+      }],
+    });
+    expect(JSON.parse(env.CINDY_PI_SECRET_ENV_NAMES!)).toEqual(expect.arrayContaining([
+      'CINDY_PI_REMOTE_MCP_SECRET_0',
+      'CINDY_PI_MCP_BRIDGE',
+    ]));
+    expect(JSON.stringify(knobs.spawnedArgs[0])).not.toContain(secret);
+    await handle.close();
   });
 
   it('disposes proxy token + MCP ctx when the pi process exits unexpectedly (crash), idempotent with close()', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -123,6 +123,7 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
               url: 'https://mcp.example.test/',
               remote: {
                 headerEnvVars: { authorization: 'CINDY_PI_REMOTE_MCP_SECRET_0' },
+                startupTimeoutMs: 10_000,
                 requestTimeoutMs: 600_000,
               },
             }],

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -151,6 +151,7 @@ interface McpServerRef {
   url: string;
   remote?: {
     headerEnvVars: Record<string, string>;
+    startupTimeoutMs: number;
     requestTimeoutMs: number;
   };
 }
@@ -164,8 +165,8 @@ function safeMcpFailure(error: unknown): string {
 function isLoopbackMcpHostname(hostname: string): boolean {
   const normalized = hostname.toLowerCase();
   return normalized === 'localhost'
-    || normalized.endsWith('.localhost')
-    || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+    || normalized === '127.0.0.1'
+    || normalized === '::1'
     || normalized === '[::1]';
 }
 
@@ -180,6 +181,7 @@ class McpHttpClient {
   private sessionId: string | null = null;
   private readonly requestUrl: string;
   private readonly requestTimeoutMs: number;
+  private startupDeadlineAt: number | null;
 
   constructor(
     private readonly server: McpServerRef,
@@ -204,6 +206,24 @@ class McpHttpClient {
       && configuredTimeout! <= 600_000
       ? configuredTimeout!
       : 600_000;
+    const configuredStartupTimeout = server.remote?.startupTimeoutMs;
+    const startupTimeoutMs = Number.isInteger(configuredStartupTimeout)
+      && configuredStartupTimeout! > 0
+      && configuredStartupTimeout! < 30_000
+      ? configuredStartupTimeout!
+      : 10_000;
+    this.startupDeadlineAt = Date.now() + startupTimeoutMs;
+  }
+
+  private nextRequestTimeoutMs(): number {
+    if (this.startupDeadlineAt === null) return this.requestTimeoutMs;
+    const remaining = this.startupDeadlineAt - Date.now();
+    if (remaining <= 0) throw new McpBridgeError('startup timed out');
+    return Math.max(1, Math.min(this.requestTimeoutMs, remaining));
+  }
+
+  finishStartup(): void {
+    this.startupDeadlineAt = null;
   }
 
   private headers(): Headers {
@@ -235,8 +255,9 @@ class McpHttpClient {
   }
 
   private async post<T>(body: unknown, consume: (response: Response) => Promise<T>): Promise<T> {
+    const requestTimeoutMs = this.nextRequestTimeoutMs();
     const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
     try {
       const res = await fetch(this.requestUrl, {
         method: 'POST',
@@ -260,6 +281,60 @@ class McpHttpClient {
     }
   }
 
+  /** 按 SSE event 增量取当前 JSON-RPC response；server 保持流打开也不阻塞。 */
+  private async readSseResponse(res: Response, id: number): Promise<any> {
+    const reader = res.body?.getReader();
+    if (!reader) throw new McpBridgeError('invalid SSE response');
+    const decoder = new TextDecoder();
+    let buffered = '';
+    const parseEvent = (eventText: string): any | null => {
+      const data = eventText
+        .split(/\r\n|\r|\n/)
+        .filter((line) => line.startsWith('data:'))
+        .map((line) => {
+          const value = line.slice(5);
+          return value.startsWith(' ') ? value.slice(1) : value;
+        })
+        .join('\n');
+      if (!data) return null;
+      try {
+        const msg = JSON.parse(data);
+        if (msg && msg.id === id && ('result' in msg || 'error' in msg)) return msg;
+      } catch {
+        // 其它 event / 非 JSON data 不属于当前 response，继续读流。
+      }
+      return null;
+    };
+
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (value) buffered += decoder.decode(value, { stream: true });
+        if (done) buffered += decoder.decode();
+
+        for (;;) {
+          const boundary = /\r\n\r\n|\n\n|\r\r/.exec(buffered);
+          if (!boundary) break;
+          const eventText = buffered.slice(0, boundary.index);
+          buffered = buffered.slice(boundary.index + boundary[0].length);
+          const msg = parseEvent(eventText);
+          if (msg) return msg;
+        }
+        if (buffered.length > 1_048_576) {
+          throw new McpBridgeError('invalid SSE response');
+        }
+        if (done) {
+          const msg = parseEvent(buffered);
+          if (msg) return msg;
+          throw new McpBridgeError('invalid SSE response');
+        }
+      }
+    } finally {
+      // 找到当前 response 后不等待 server 关闭持续流，立即释放连接。
+      void reader.cancel().catch(() => {});
+    }
+  }
+
   /** 解析 application/json 或 SSE 响应体里 id 匹配的 JSON-RPC response。 */
   private async readResponse(res: Response, id: number): Promise<any> {
     const contentType = res.headers.get('content-type') ?? '';
@@ -269,19 +344,7 @@ class McpHttpClient {
       throw new McpBridgeError('HTTP ' + res.status);
     }
     if (contentType.includes('text/event-stream')) {
-      const text = await res.text();
-      for (const chunk of text.split('\n\n')) {
-        for (const line of chunk.split('\n')) {
-          if (!line.startsWith('data:')) continue;
-          try {
-            const msg = JSON.parse(line.slice(5).trim());
-            if (msg && msg.id === id && ('result' in msg || 'error' in msg)) return msg;
-          } catch {
-            /* keep scanning */
-          }
-        }
-      }
-      throw new McpBridgeError('invalid SSE response');
+      return this.readSseResponse(res, id);
     }
     return res.json();
   }
@@ -338,6 +401,7 @@ async function connectServer(pi: any, server: McpServerRef, token: string): Prom
   const client = new McpHttpClient(server, token);
   await client.initialize();
   const listed = await client.request('tools/list', {});
+  client.finishStartup();
   const tools: any[] = Array.isArray(listed?.tools) ? listed.tools : [];
   for (const tool of tools) {
     const qualifiedName = 'mcp__' + server.name + '__' + tool.name;
@@ -486,13 +550,15 @@ export default async function cindyBridge(pi: any) {
     return;
   }
   const token = cfg.token ?? '';
-  for (const server of cfg.servers ?? []) {
+  // 全部 server 并行启动：每个 remote 有独立短预算，多个黑洞 provider 也只占一份
+  // startup window，不会串行叠加到 Pi RPC 的 30s ready 超时。
+  await Promise.all((cfg.servers ?? []).map(async (server) => {
     try {
       const count = await connectServer(pi, server, token);
       console.error('[cindy-bridge] connected ' + server.name + ' (' + count + ' tools)');
     } catch (err) {
       console.error('[cindy-bridge] connect ' + server.name + ' failed: ' + safeMcpFailure(err));
     }
-  }
+  }));
 }
 `;

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -8,10 +8,10 @@
  *     (RPC 模式 → extension_ui_request → PiAgent → interactionResolver)。
  *     权限档从 CINDY_PI_PERMISSION_FILE 每次现读 —— setPermissionMode 热切换生效;
  *     读不到一律按 ask(fail-closed)。
- *  2. MCP 桥:CINDY_PI_MCP_BRIDGE(JSON {token, servers[{name,url}]})指向 host 的
- *     localhost streamable-HTTP MCP bridge;对每个 server 走 initialize →
- *     tools/list,把工具注册成 pi 工具(mcp__<server>__<tool>),execute 转发
- *     tools/call。
+ *  2. MCP 桥:CINDY_PI_MCP_BRIDGE 指向 host 的 localhost bridge，或用户显式配置的
+ *     外部 Streamable HTTP MCP。外部认证只保存 env 引用，真值留在 Pi 父进程 env；
+ *     对每个 server 走 initialize → tools/list,把工具注册成 pi 工具
+ *     (mcp__<server>__<tool>),execute 转发 tools/call。
  *  3. 会话树:注册 Cindy 私有 command，把 RPC prompt 桥到 ctx.navigateTree。
  *
  * 协议说明(@modelcontextprotocol/sdk StreamableHTTPServerTransport):
@@ -149,44 +149,124 @@ function isInsideRoot(candidate: string, root: string): boolean {
 interface McpServerRef {
   name: string;
   url: string;
+  remote?: {
+    headerEnvVars: Record<string, string>;
+    requestTimeoutMs: number;
+  };
+}
+
+class McpBridgeError extends Error {}
+
+function safeMcpFailure(error: unknown): string {
+  return error instanceof McpBridgeError ? error.message : 'unexpected error';
+}
+
+function isLoopbackMcpHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === 'localhost'
+    || normalized.endsWith('.localhost')
+    || /^127(?:\.\d{1,3}){3}$/.test(normalized)
+    || normalized === '[::1]';
+}
+
+function isAllowedMcpUrl(url: URL): boolean {
+  if (url.username || url.password) return false;
+  if (url.protocol === 'https:') return true;
+  return url.protocol === 'http:' && isLoopbackMcpHostname(url.hostname);
 }
 
 class McpHttpClient {
   private nextId = 1;
   private sessionId: string | null = null;
+  private readonly requestUrl: string;
+  private readonly requestTimeoutMs: number;
 
   constructor(
     private readonly server: McpServerRef,
     private readonly token: string,
-  ) {}
+  ) {
+    let parsed: URL;
+    try {
+      parsed = new URL(server.url);
+    } catch {
+      throw new McpBridgeError('invalid URL');
+    }
+    // 外部 URL 的 host 边界由用户保存的 endpoint 决定；这里再做 web-only fail-closed，
+    // 防描述符损坏后把 Pi 变成 file/data 等协议读取器。非 loopback 必须 HTTPS；URL
+    // 内嵌凭证也禁止，避免它们进入 bridge JSON，认证必须走专用 env。
+    if (!isAllowedMcpUrl(parsed)) {
+      throw new McpBridgeError('URL outside security boundary');
+    }
+    this.requestUrl = parsed.href;
+    const configuredTimeout = server.remote?.requestTimeoutMs;
+    this.requestTimeoutMs = Number.isInteger(configuredTimeout)
+      && configuredTimeout! > 0
+      && configuredTimeout! <= 600_000
+      ? configuredTimeout!
+      : 600_000;
+  }
 
-  private headers(): Record<string, string> {
-    const h: Record<string, string> = {
-      'content-type': 'application/json',
-      accept: 'application/json, text/event-stream',
-      authorization: 'Bearer ' + this.token,
-    };
-    if (this.sessionId) h['mcp-session-id'] = this.sessionId;
+  private headers(): Headers {
+    const h = new Headers();
+    try {
+      if (this.server.remote) {
+        for (const [headerName, envName] of Object.entries(this.server.remote.headerEnvVars ?? {})) {
+          if (typeof envName !== 'string' || !envName) {
+            throw new McpBridgeError('invalid authentication configuration');
+          }
+          const value = process.env[envName];
+          if (value === undefined) throw new McpBridgeError('missing authentication environment');
+          h.set(headerName, value);
+        }
+      } else {
+        if (!this.token) throw new McpBridgeError('missing local bridge token');
+        h.set('authorization', 'Bearer ' + this.token);
+      }
+      // 协议 header 与 server 颁发的 session id 由 client 掌控，不能被自定义 header 覆盖。
+      h.set('content-type', 'application/json');
+      h.set('accept', 'application/json, text/event-stream');
+      h.delete('mcp-session-id');
+      if (this.sessionId) h.set('mcp-session-id', this.sessionId);
+    } catch (error) {
+      if (error instanceof McpBridgeError) throw error;
+      throw new McpBridgeError('invalid authentication header');
+    }
     return h;
   }
 
-  private async post(body: unknown): Promise<Response> {
-    const res = await fetch(this.server.url, {
-      method: 'POST',
-      headers: this.headers(),
-      body: JSON.stringify(body),
-    });
-    const sid = res.headers.get('mcp-session-id');
-    if (sid) this.sessionId = sid;
-    return res;
+  private async post<T>(body: unknown, consume: (response: Response) => Promise<T>): Promise<T> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    try {
+      const res = await fetch(this.requestUrl, {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify(body),
+        redirect: 'error',
+        signal: controller.signal,
+      });
+      const sid = res.headers.get('mcp-session-id');
+      if (sid) this.sessionId = sid;
+      // consume 在同一个 AbortController 生命周期内完成，故 200/SSE 响应头后卡住的
+      // body 也会按 requestTimeoutMs 中止，不会无限阻塞后续 server 注册。
+      return await consume(res);
+    } catch (error) {
+      if (controller.signal.aborted) throw new McpBridgeError('request timed out');
+      if (error instanceof McpBridgeError) throw error;
+      if (error instanceof SyntaxError) throw new McpBridgeError('invalid JSON response');
+      throw new McpBridgeError('request failed');
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   /** 解析 application/json 或 SSE 响应体里 id 匹配的 JSON-RPC response。 */
   private async readResponse(res: Response, id: number): Promise<any> {
     const contentType = res.headers.get('content-type') ?? '';
     if (!res.ok) {
-      const text = await res.text().catch(() => '');
-      throw new Error('MCP HTTP ' + res.status + ': ' + text.slice(0, 300));
+      // 远端错误体可能回显 Authorization / API key，绝不拼进 Pi stderr。
+      void res.body?.cancel().catch(() => {});
+      throw new McpBridgeError('HTTP ' + res.status);
     }
     if (contentType.includes('text/event-stream')) {
       const text = await res.text();
@@ -201,23 +281,28 @@ class McpHttpClient {
           }
         }
       }
-      throw new Error('MCP SSE response missing id=' + id);
+      throw new McpBridgeError('invalid SSE response');
     }
     return res.json();
   }
 
   async request(method: string, params?: unknown): Promise<any> {
     const id = this.nextId++;
-    const res = await this.post({ jsonrpc: '2.0', id, method, ...(params !== undefined ? { params } : {}) });
-    const msg = await this.readResponse(res, id);
+    const msg = await this.post(
+      { jsonrpc: '2.0', id, method, ...(params !== undefined ? { params } : {}) },
+      (res) => this.readResponse(res, id),
+    );
     if (msg.error) {
-      throw new Error('MCP ' + method + ' failed: ' + (msg.error.message ?? JSON.stringify(msg.error)));
+      throw new McpBridgeError('MCP ' + method + ' returned an error');
     }
     return msg.result;
   }
 
   async notify(method: string, params?: unknown): Promise<void> {
-    await this.post({ jsonrpc: '2.0', method, ...(params !== undefined ? { params } : {}) }).catch(() => {});
+    await this.post(
+      { jsonrpc: '2.0', method, ...(params !== undefined ? { params } : {}) },
+      async (res) => { await res.body?.cancel(); },
+    ).catch(() => {});
   }
 
   async initialize(): Promise<void> {
@@ -406,7 +491,7 @@ export default async function cindyBridge(pi: any) {
       const count = await connectServer(pi, server, token);
       console.error('[cindy-bridge] connected ' + server.name + ' (' + count + ' tools)');
     } catch (err) {
-      console.error('[cindy-bridge] connect ' + server.name + ' failed: ' + String(err));
+      console.error('[cindy-bridge] connect ' + server.name + ' failed: ' + safeMcpFailure(err));
     }
   }
 }

--- a/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-bridge-source.ts
@@ -10,7 +10,7 @@
  *     读不到一律按 ask(fail-closed)。
  *  2. MCP 桥:CINDY_PI_MCP_BRIDGE 指向 host 的 localhost bridge，或用户显式配置的
  *     外部 Streamable HTTP MCP。外部认证只保存 env 引用，真值留在 Pi 父进程 env；
- *     对每个 server 走 initialize → tools/list,把工具注册成 pi 工具
+ *     对每个 server 走 initialize → 分页 tools/list,把工具注册成 pi 工具
  *     (mcp__<server>__<tool>),execute 转发 tools/call。
  *  3. 会话树:注册 Cindy 私有 command，把 RPC prompt 桥到 ctx.navigateTree。
  *
@@ -400,9 +400,21 @@ function mcpContentToPi(content: unknown): Array<Record<string, unknown>> {
 async function connectServer(pi: any, server: McpServerRef, token: string): Promise<number> {
   const client = new McpHttpClient(server, token);
   await client.initialize();
-  const listed = await client.request('tools/list', {});
+  const tools: any[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | undefined;
+  for (;;) {
+    const listed = await client.request('tools/list', cursor === undefined ? {} : { cursor });
+    if (Array.isArray(listed?.tools)) tools.push(...listed.tools);
+    if (!listed || typeof listed !== 'object' || !('nextCursor' in listed)) break;
+    const nextCursor = listed.nextCursor;
+    if (typeof nextCursor !== 'string' || seenCursors.has(nextCursor)) {
+      throw new McpBridgeError('invalid tools pagination');
+    }
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
   client.finishStartup();
-  const tools: any[] = Array.isArray(listed?.tools) ? listed.tools : [];
   for (const tool of tools) {
     const qualifiedName = 'mcp__' + server.name + '__' + tool.name;
     const parameters =

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -684,11 +684,13 @@ export class PiAgent extends BaseAgent {
     };
     await writePermissionFile(requestedPermissionSnapshot);
 
-    // MCP 桥:host 把 in-process MCP providers 暴露成 localhost streamable-HTTP。
+    // MCP:host 把 in-process providers 暴露成 localhost streamable-HTTP，也可给出
+    // 外部 HTTP server 描述（header 真值另走 mcpEnv，不进入描述符）。
     // 传 session 身份(sessionId/workingDir/vendorOptions)让 host 在 bridge 上注册
     // 身份 ctx + 给 server URL 打 `?session=` 路由 —— orca/会话身份类工具据此绑定
     // 当前 pi 会话。disposeSessionCtx 在 close() 注销该注册(幂等)。
     let mcpBridge: PiExtraSpawnConfig['mcpBridge'] = null;
+    let mcpEnv: PiExtraSpawnConfig['mcpEnv'] = {};
     let disposeSessionCtx: (() => void) | undefined;
     if (this.deps.preparePiExtraSpawnConfig) {
       try {
@@ -699,6 +701,7 @@ export class PiAgent extends BaseAgent {
           vendorOptions: opts.vendorOptions,
         });
         mcpBridge = extra?.mcpBridge ?? null;
+        mcpEnv = extra?.mcpEnv ?? {};
         disposeSessionCtx = extra?.disposeSessionCtx;
       } catch (err) {
         this.deps.logger.error('pi MCP bridge prep failed, continuing without cindy tools', {
@@ -850,6 +853,7 @@ export class PiAgent extends BaseAgent {
         PI_SESSION_TOKEN_ENV,
         ...Object.keys(authEnv),
         ...Object.keys(nativeEnv),
+        ...Object.keys(mcpEnv),
         ...(mcpBridge && mcpBridge.servers.length > 0 ? [PI_MCP_BRIDGE_ENV] : []),
       ]));
       const spawnEnv: NodeJS.ProcessEnv = {
@@ -857,6 +861,9 @@ export class PiAgent extends BaseAgent {
         ...authEnv,
         // BYOM 原生 provider 的 api keys(键名对应 spec.apiKeyEnvVar,models.json 用 $ENV 引用)。
         ...nativeEnv,
+        // 外部 MCP header 真值只经 env 交给 bridge extension；host 生成独立名字，
+        // 且这些键已进入 piSecretEnvNames，LLM 可调用的 bash 子进程拿不到。
+        ...mcpEnv,
         [PI_SESSION_ID_ENV]: opts.sessionId ?? '',
         [PI_SESSION_TOKEN_ENV]: proxySessionToken,
         [PI_SECRET_ENV_NAMES_ENV]: JSON.stringify(piSecretEnvNames),

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -160,7 +160,13 @@ function mergeLoopbackNoProxy(env: NodeJS.ProcessEnv): void {
     .flatMap((s) => s.split(','))
     .map((s) => s.trim())
     .filter(Boolean);
-  env.NO_PROXY = Array.from(new Set([...existing, '127.0.0.1', 'localhost', '::1'])).join(',');
+  env.NO_PROXY = Array.from(new Set([
+    ...existing,
+    '127.0.0.1',
+    'localhost',
+    '::1',
+    '[::1]',
+  ])).join(',');
   delete env.no_proxy;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi now assembles user-configured HTTP / Streamable HTTP MCP servers alongside the existing localhost MCP bridge. Remote authentication headers are resolved in the Desktop main process, remapped to Pi-only environment variables, and referenced by name from the bridge descriptor so their values never enter renderer data, process arguments, or logs.

The Pi extension connects directly to each configured endpoint, fails visibly with sanitized errors, enforces request timeouts across both response headers and body consumption, rejects redirects and embedded URL credentials, and requires HTTPS except for explicit loopback endpoints.

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1473
- 本 PR 包含：Pi environment remote HTTP assembly, env-backed authentication headers, direct Streamable HTTP transport, sanitized failure reporting, lifecycle/security regression coverage, and Pi harness documentation.
- 明确不包含：SSE transport, OAuth flows, Settings/UI changes, or changes to the existing Codex MCP path.
- 用户可见变化：A newly started or restarted Pi session exposes tools from enabled external HTTP MCP providers. Invalid, unreachable, or timed-out providers are skipped with a visible sanitized failure instead of silently disappearing.
- 是否存在 breaking change：无。Non-loopback external MCP endpoints must use HTTPS; loopback HTTP remains supported.

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；Desktop、Mobile、maker-core 及所有纳入 unit gate 的 workspace 全绿。

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过；该 package 当前无 typecheck script，按门禁规则跳过。

pnpm --dir apps/desktop exec vitest run --pool=threads --maxWorkers=4 src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts src/main/maker-ipc/__tests__/mcpHandlers.test.ts
结果：3 files / 20 tests 通过。

Desktop piEnvironment targeted regression
结果：9 tests 通过，覆盖启动前配置、运行中新增/修改/禁用/删除、重复失效、新 session/restart、缺失 secret、无效 URL/header 与安全日志。

Real Pi MCP bridge integration
结果：5 tests 通过，覆盖 direct remote bearer/custom headers、HTTP_PROXY loopback bypass、持续 SSE 增量响应、启动总预算与长工具调用预算、401 脱敏及 body stall 超时。

Real Pi Bash environment-isolation regression
结果：目标用例通过，remote MCP secret 与 bridge descriptor 均不进入模型可调用的 Bash 子进程。

pnpm check:dco
结果：通过；1 commit signed off。
```

### 手工验证

不涉及 UI。使用仓库下载的 Pi 0.83.0 二进制和本地 fake Streamable HTTP MCP server 完成真实进程集成验证。

### 未执行的验证

- 未在 Windows 实机上手工连接真实第三方 MCP；实现位于跨平台 Electron main / Node Pi bridge，且使用真实 Pi 进程覆盖了协议和认证路径。
- 未执行第三方 OAuth 或 SSE 验证；两者不在本 PR 范围。
- 当前 upstream/main 的 package-wide lint / maker-core build 存在与本改动无关的既有失败；本次变更文件已做定向 lint/typecheck，并通过提交前全量 unit gate。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Pi session 启动时的 MCP server assembly 与 Pi bridge extension。配置新增、修改、禁用或删除对下一新建/重启 session 生效；已运行 session 保留其启动 generation 直到关闭，沿用现有 bridge lifecycle。外部 header 只存在于 Pi 父进程 env；Full access 模式并非 OS 级 secret 隔离边界，文档已明确这一限制。
- 安全边界：公网/局域网 endpoint 必须 HTTPS；HTTP 仅允许 loopback。拒绝 URL credentials 和 redirects；remote 不接收 localhost bridge token；错误正文、URL 与 header 值不进入日志。
- 回滚 / 降级方式：Revert this commit. 用户也可禁用或删除对应 provider 并新建/重启 Pi session。
- system prompt / cache prefix：未改变。
- event loop、model mapping、usage accounting：未改变。
- MCP/tool surface：仅在 Pi session 初始化时增加已启用 external HTTP MCP 返回的工具。
- 存量插件影响：无；未修改插件 runtime、manifest、批准状态或安装布局。

### Review follow-up（fb1f71f5）

- IPv6 loopback 同时接受 `::1` / `[::1]`，并补 `http://[::1]` 组装回归。
- 明文 HTTP allowlist 收窄到与 `NO_PROXY` 一致的 `localhost / 127.0.0.1 / ::1`；带认证 header 的真实 Pi 请求在 fake `HTTP_PROXY` 下零代理命中。
- Streamable HTTP 的 SSE response 按 event 增量解析，匹配当前 JSON-RPC id 后立即取消持续流。
- 外部 server 并行启动；每个 provider 的 `initialize + tools/list` 共用 10s deadline，成功后工具调用恢复 600s 预算。
- 原红 CI 的 Desktop TTL 断言已在 PR base run 同样失败，独立主干修复为 #1498；Windows contacts 5s 超时为单次基线抖动，未把无关修改带入本 PR。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因