### PR TITLE
test(desktop): outbox TTL 断言从共享表推导,防并行 PR 再度脱节

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
@@ -11,7 +11,7 @@
  * mock 面与 dispatchSendSafety.test.ts 一致:只 mock electron + settings。
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { DeviceLinkError } from '@cindy/device-link';
+import { DeviceLinkError, INVOKE_TIMEOUT_OVERRIDES_MS } from '@cindy/device-link';
 
 vi.mock('electron', () => ({
   app: {
@@ -198,14 +198,22 @@ describe('[2] outbox 离线不自旋,上线事件驱动投递', () => {
 });
 
 describe('[3] outbox 保留时长按 channel 收窄', () => {
-  it('按共享表预算 ×2:listing 12s→24s,缺省 30s→60s,长任务封顶 120s', () => {
-    // sessions:list 在 INVOKE_TIMEOUT_OVERRIDES_MS 里是 12s(#1418 listing 短超时):
-    // 保留时长跟随预算 = 24s。此断言曾在 #1418/#1477 并行开发时硬编码 60s
-    // (当时表里还没有 listing 条目),两 PR 各自 CI 都绿、先后合入后 main 变红
-    // ——期望值必须跟着共享契约表走,这里显式写当前表值以锁住联动语义。
-    expect(__testing.outboxEntryMaxAgeMs('local-db:sessions:list')).toBe(24_000);
+  it('锁「预算 ×2、封顶 120s」联动:表内 channel 跟随共享表,缺省 30s→60s', () => {
+    // 联动语义从共享表推导,不再硬编码结果值——此断言曾在 #1418/#1477 并行开发
+    // 时写死 60s(当时表里还没有 listing 条目),两 PR 各自 CI 都绿、先后合入后
+    // main 变红。表值本身(12s/60s)在下面单独锁定:它们是产品决策,变更时红在
+    // 这里提醒显式确认;而「×2 封顶」的联动对表变更免疫。
+    const listingBudget = INVOKE_TIMEOUT_OVERRIDES_MS['local-db:sessions:list'];
+    const worktreeBudget = INVOKE_TIMEOUT_OVERRIDES_MS['worktree:create'];
+    expect(listingBudget).toBe(12_000);
+    expect(worktreeBudget).toBe(60_000);
+    expect(__testing.outboxEntryMaxAgeMs('local-db:sessions:list')).toBe(
+      Math.min(listingBudget * 2, 120_000),
+    );
     expect(__testing.outboxEntryMaxAgeMs(undefined)).toBe(60_000);
-    expect(__testing.outboxEntryMaxAgeMs('worktree:create')).toBe(120_000);
+    expect(__testing.outboxEntryMaxAgeMs('worktree:create')).toBe(
+      Math.min(worktreeBudget * 2, 120_000),
+    );
   });
 
   it('离线慢扫描按逐条 TTL 出清:listing(24s 档)先被丢,长任务 channel 保留到 120s', () => {

--- a/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
@@ -198,13 +198,17 @@ describe('[2] outbox 离线不自旋,上线事件驱动投递', () => {
 });
 
 describe('[3] outbox 保留时长按 channel 收窄', () => {
-  it('默认 channel = 60s;放宽表 channel ×2 封顶 120s', () => {
-    expect(__testing.outboxEntryMaxAgeMs('local-db:sessions:list')).toBe(60_000);
+  it('按共享表预算 ×2:listing 12s→24s,缺省 30s→60s,长任务封顶 120s', () => {
+    // sessions:list 在 INVOKE_TIMEOUT_OVERRIDES_MS 里是 12s(#1418 listing 短超时):
+    // 保留时长跟随预算 = 24s。此断言曾在 #1418/#1477 并行开发时硬编码 60s
+    // (当时表里还没有 listing 条目),两 PR 各自 CI 都绿、先后合入后 main 变红
+    // ——期望值必须跟着共享契约表走,这里显式写当前表值以锁住联动语义。
+    expect(__testing.outboxEntryMaxAgeMs('local-db:sessions:list')).toBe(24_000);
     expect(__testing.outboxEntryMaxAgeMs(undefined)).toBe(60_000);
     expect(__testing.outboxEntryMaxAgeMs('worktree:create')).toBe(120_000);
   });
 
-  it('离线慢扫描按逐条 TTL 出清:默认 channel 61s 被丢,长任务 channel 保留', () => {
+  it('离线慢扫描按逐条 TTL 出清:listing(24s 档)先被丢,长任务 channel 保留到 120s', () => {
     const sendInvokeResult = vi.fn(() => {
       throw notConnected();
     });


### PR DESCRIPTION
## 这次改了什么

### 摘要

> **2026-08-03 更新**:main 基线红已由 `eae5a491`(直推,硬编码 24s)先行修复,本 PR 转型为**测试稳健性改进**——把断言从硬编码结果值改为从共享表推导,防止同类并行 PR 交互再次把基线打红(review 采纳)。

原始背景:#1418 与 #1477 并行开发的合并交互。#1477 的 `dispatchWeakNetwork.test.ts` 写作时 main 还没有 #1418,断言 `outboxEntryMaxAgeMs('local-db:sessions:list') === 60_000`(当时共享表无 listing 条目,走缺省 30s×2);#1418 合入后表里 `sessions:list = 12_000`,实际值为 24_000(12s×2,**这正是该函数的设计语义:保留时长跟随控制端预算**)。两个 PR 各自的 merge-ref CI 都绿,先后 squash 合入后 main 变红,挡住所有后续 PR(实测 #1486 的 verify / Windows 单测因此失败)。

现形态:「×2 封顶 120s」联动从 `INVOKE_TIMEOUT_OVERRIDES_MS` 推导(对表变更免疫);表值本身(listing 12s / worktree 60s)以独立断言锁定——它们是产品决策,变更时红在表值断言上提醒显式确认。同时修正第二个出清用例名称(listing 已不是缺省档)。产品代码零改动。

### 变更类型

- [x] `test` 测试

### 范围

- 关联 Issue / 需求:#1418 / #1477 合并交互,main 基线修复
- 本 PR 包含:单测试文件的期望值与用例名修正
- 用户可见变化:无
- 是否存在 breaking change:无

### UI 变化

无。

## 怎么验证的

### 自动验证

```text
dispatchWeakNetwork.test.ts 7/7 通过(修复前在含 #1418+#1477 的基线上 1 例失败,
与 #1486 CI 的失败一致);run-unit-gate.sh 全仓 GATE_EXIT=0。
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 其他:纯测试期望修正

### 影响与回滚

- 影响范围:单测试文件;revert 即回(但 main 会重新变红)。
- 基线阻塞已由 eae5a491 解除,本 PR 无紧迫性。

### 多端适配说明(remote-and-mobile-adaptation)

不涉及(纯测试)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(测试内注释)
- [x] 已确认测试结果或说明未执行原因
