### PR TITLE
fix(mobile): clarify queued message status

### DIFF
--- a/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
+++ b/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
@@ -31,6 +31,10 @@ describe('mobile sending queue badge', () => {
     expect(bubble).toContain('testID={`pendingSend.queuedStatus.${item.clientId}`}');
     expect(bubble).toContain("{t('message.queue.queuedStatus')}");
     expect(bubble).not.toContain('<ListEnd color={colors.textTertiary}');
+    // 状态徽标悬挂在 86% 气泡外,不能挤窄长消息并让落定前后重新换行。
+    expect(bubble).toContain("bubbleShell: { alignItems: 'flex-end', flexShrink: 1, maxWidth: '86%', position: 'relative' }");
+    expect(bubble).toContain("position: 'absolute',\n    right: '100%',");
+    expect(bubble).toContain("maxWidth: '100%',\n    opacity: 0.62,");
     // 在途条目的无障碍播报不能说「排队中第 N 条」。
     expect(bubble).toContain("t('message.queue.sendingMessage', { text: bubbleLabel })");
   });

--- a/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
+++ b/apps/mobile/src/__tests__/sendingQueueBadge.test.ts
@@ -1,7 +1,7 @@
 /**
  * 未确认发出的消息:徽标必须是转圈,不是「排入队尾」。
  *
- * 「排入队尾 list-end」是一句事实断言(被控端已收下这条消息);enqueue RPC 在途、已出队等
+ * 「已排队」是一句事实断言(被控端已收下这条消息);enqueue RPC 在途、已出队等
  * 回流、附件上传中都还没有这个事实,弱网下这段窗口可达数秒且可能回滚。
  *
  * 气泡本身已经是消息流的渲染项(pending_send),判定集中在 pendingSendItems.ts 的纯函数里
@@ -24,10 +24,13 @@ describe('mobile sending queue badge', () => {
     expect(items).toContain("return phase === 'sending' || phase === 'settling' || phase === 'uploading';");
 
     const bubble = readSource('src/session/PendingSendBubble.tsx');
-    // 失败优先画 ⚠,其余未确认态转圈,已确认入队才画排队 icon。
+    // 失败优先画 ⚠,其余未确认态转圈,已确认入队才画「时钟 + 已排队」明确标记。
     expect(bubble).toContain('const spinning = pendingSendSpins(item.phase);');
     expect(bubble).toContain('<ActivityIndicator color={colors.textTertiary} size="small" />');
-    expect(bubble).toContain('<ListEnd color={colors.textTertiary}');
+    expect(bubble).toContain('<Clock3 color={colors.textTertiary}');
+    expect(bubble).toContain('testID={`pendingSend.queuedStatus.${item.clientId}`}');
+    expect(bubble).toContain("{t('message.queue.queuedStatus')}");
+    expect(bubble).not.toContain('<ListEnd color={colors.textTertiary}');
     // 在途条目的无障碍播报不能说「排队中第 N 条」。
     expect(bubble).toContain("t('message.queue.sendingMessage', { text: bubbleLabel })");
   });

--- a/apps/mobile/src/i18n/locales/en/message.json
+++ b/apps/mobile/src/i18n/locales/en/message.json
@@ -157,6 +157,7 @@
     "attachmentCount": "{{n}} attachments",
     "attachmentMessage": "Attachment message",
     "steeringLabel": "Interjecting: {{text}}",
+    "queuedStatus": "Queued",
     "queuedMessageLabel": "Queued message {{index}}: {{text}}",
     "editingInComposer": "Editing in the input box below…",
     "cancel": "Cancel",

--- a/apps/mobile/src/i18n/locales/ja/message.json
+++ b/apps/mobile/src/i18n/locales/ja/message.json
@@ -157,6 +157,7 @@
     "attachmentCount": "添付ファイル {{n}} 件",
     "attachmentMessage": "添付ファイルのメッセージ",
     "steeringLabel": "割り込み送信中:{{text}}",
+    "queuedStatus": "キュー内",
     "queuedMessageLabel": "キュー内メッセージ {{index}}:{{text}}",
     "editingInComposer": "下の入力欄で編集中…",
     "cancel": "キャンセル",

--- a/apps/mobile/src/i18n/locales/ko/message.json
+++ b/apps/mobile/src/i18n/locales/ko/message.json
@@ -157,6 +157,7 @@
     "attachmentCount": "첨부파일 {{n}}개",
     "attachmentMessage": "첨부파일 메시지",
     "steeringLabel": "끼어들어 전송 중:{{text}}",
+    "queuedStatus": "대기 중",
     "queuedMessageLabel": "대기 중인 메시지 {{index}}:{{text}}",
     "editingInComposer": "아래 입력창에서 편집 중…",
     "cancel": "취소",

--- a/apps/mobile/src/i18n/locales/zh-CN/message.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/message.json
@@ -157,6 +157,7 @@
     "attachmentCount": "{{n}} 个附件",
     "attachmentMessage": "附件消息",
     "steeringLabel": "插话发送中：{{text}}",
+    "queuedStatus": "已排队",
     "queuedMessageLabel": "排队消息 {{index}}:{{text}}",
     "editingInComposer": "正在下方输入框编辑…",
     "cancel": "取消",

--- a/apps/mobile/src/session/PendingSendBubble.tsx
+++ b/apps/mobile/src/session/PendingSendBubble.tsx
@@ -199,93 +199,95 @@ export function PendingSendBubble({
   return (
     <View style={styles.rowWrap} testID={`pendingSend.row.${item.clientId}`}>
       <View style={styles.bubbleRow}>
-        <View
-          accessibilityElementsHidden
-          importantForAccessibility="no-hide-descendants"
-          style={styles.badge}
-          testID={`pendingSend.badge.${item.phase}`}
-        >
-          {failed ? (
-            <AlertCircle color={colors.errorText} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-          ) : spinning ? (
-            <ActivityIndicator color={colors.textTertiary} size="small" />
-          ) : editing ? (
-            <Pencil color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-          ) : (
-            // 暂停态不换 ⏸:组顶横幅已表达暂停,逐条再换会重复;行内恒用明确的排队标记。
-            <>
-              <Clock3 color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-              <Text
-                numberOfLines={1}
-                style={styles.queuedStatusText}
-                testID={`pendingSend.queuedStatus.${item.clientId}`}
-              >
-                {t('message.queue.queuedStatus')}
+        <View style={styles.bubbleShell}>
+          <View
+            accessibilityElementsHidden
+            importantForAccessibility="no-hide-descendants"
+            style={styles.badge}
+            testID={`pendingSend.badge.${item.phase}`}
+          >
+            {failed ? (
+              <AlertCircle color={colors.errorText} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+            ) : spinning ? (
+              <ActivityIndicator color={colors.textTertiary} size="small" />
+            ) : editing ? (
+              <Pencil color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+            ) : (
+              // 暂停态不换 ⏸:组顶横幅已表达暂停,逐条再换会重复;行内恒用明确的排队标记。
+              <>
+                <Clock3 color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+                <Text
+                  numberOfLines={1}
+                  style={styles.queuedStatusText}
+                  testID={`pendingSend.queuedStatus.${item.clientId}`}
+                >
+                  {t('message.queue.queuedStatus')}
+                </Text>
+              </>
+            )}
+          </View>
+          <Pressable
+            accessibilityHint={item.hint ?? undefined}
+            accessibilityLabel={failed
+              ? t('message.queue.sendFailedMessage', { text: bubbleLabel })
+              : spinning
+                ? t('message.queue.sendingMessage', { text: bubbleLabel })
+                : item.queueIndex !== null
+                  ? t('message.queue.queuedMessageLabel', { index: item.queueIndex, text: bubbleLabel })
+                  : t('message.queue.sendingMessage', { text: bubbleLabel })}
+            accessibilityRole="button"
+            accessibilityState={{ expanded: selected, disabled: !interactive }}
+            disabled={!interactive}
+            onPress={() => actions.onSelect(selected ? null : item.clientId)}
+            style={({ pressed }) => [
+              styles.bubble,
+              item.phase === 'settling' && styles.bubbleSettling,
+              selected && styles.bubbleSelected,
+              editing && styles.bubbleEditing,
+              pressed && styles.pressed,
+            ]}
+            testID={`pendingSend.bubble.${item.clientId}`}
+          >
+            {rendersSentInlineBody ? (
+              <SentInlineAtomBody
+                interactiveAtoms={false}
+                maxVisibleLines={selected ? undefined : 6}
+                numberOfLines={selected ? undefined : 6}
+                testID="pendingSend.sentInlineAtoms"
+                textStyle={styles.bubbleText}
+                tokens={item.sentInlineTokens}
+              />
+            ) : item.text ? (
+              <Text numberOfLines={selected ? undefined : 6} style={styles.bubbleText}>
+                {item.text}
               </Text>
-            </>
-          )}
+            ) : null}
+            <AttachmentThumbStrip resolveRemoteMedia={resolveRemoteMedia} thumbs={item.thumbs} />
+            {item.fileCount > 0 || uploadsPending ? (
+              <View style={styles.attachmentLine}>
+                <Paperclip color={colors.textTertiary} size={iconSize.xs} strokeWidth={iconStroke.regular} />
+                <Text style={styles.attachmentLineText}>
+                  {uploadsPending
+                    ? t('message.queue.uploadingAttachments', {
+                        uploaded: item.uploadedCount,
+                        total: item.attachmentCount,
+                      })
+                    : t('message.queue.attachmentCount', { n: item.fileCount })}
+                </Text>
+              </View>
+            ) : null}
+            {editing ? (
+              <Text style={styles.editingHint} testID={`pendingSend.editingHint.${item.clientId}`}>
+                {t('message.queue.editingInComposer')}
+              </Text>
+            ) : null}
+            {item.errorText ? (
+              <Text style={styles.errorText} testID={`pendingSend.error.${item.clientId}`}>
+                {item.errorText}
+              </Text>
+            ) : null}
+          </Pressable>
         </View>
-        <Pressable
-          accessibilityHint={item.hint ?? undefined}
-          accessibilityLabel={failed
-            ? t('message.queue.sendFailedMessage', { text: bubbleLabel })
-            : spinning
-              ? t('message.queue.sendingMessage', { text: bubbleLabel })
-              : item.queueIndex !== null
-                ? t('message.queue.queuedMessageLabel', { index: item.queueIndex, text: bubbleLabel })
-                : t('message.queue.sendingMessage', { text: bubbleLabel })}
-          accessibilityRole="button"
-          accessibilityState={{ expanded: selected, disabled: !interactive }}
-          disabled={!interactive}
-          onPress={() => actions.onSelect(selected ? null : item.clientId)}
-          style={({ pressed }) => [
-            styles.bubble,
-            item.phase === 'settling' && styles.bubbleSettling,
-            selected && styles.bubbleSelected,
-            editing && styles.bubbleEditing,
-            pressed && styles.pressed,
-          ]}
-          testID={`pendingSend.bubble.${item.clientId}`}
-        >
-          {rendersSentInlineBody ? (
-            <SentInlineAtomBody
-              interactiveAtoms={false}
-              maxVisibleLines={selected ? undefined : 6}
-              numberOfLines={selected ? undefined : 6}
-              testID="pendingSend.sentInlineAtoms"
-              textStyle={styles.bubbleText}
-              tokens={item.sentInlineTokens}
-            />
-          ) : item.text ? (
-            <Text numberOfLines={selected ? undefined : 6} style={styles.bubbleText}>
-              {item.text}
-            </Text>
-          ) : null}
-          <AttachmentThumbStrip resolveRemoteMedia={resolveRemoteMedia} thumbs={item.thumbs} />
-          {item.fileCount > 0 || uploadsPending ? (
-            <View style={styles.attachmentLine}>
-              <Paperclip color={colors.textTertiary} size={iconSize.xs} strokeWidth={iconStroke.regular} />
-              <Text style={styles.attachmentLineText}>
-                {uploadsPending
-                  ? t('message.queue.uploadingAttachments', {
-                      uploaded: item.uploadedCount,
-                      total: item.attachmentCount,
-                    })
-                  : t('message.queue.attachmentCount', { n: item.fileCount })}
-              </Text>
-            </View>
-          ) : null}
-          {editing ? (
-            <Text style={styles.editingHint} testID={`pendingSend.editingHint.${item.clientId}`}>
-              {t('message.queue.editingInComposer')}
-            </Text>
-          ) : null}
-          {item.errorText ? (
-            <Text style={styles.errorText} testID={`pendingSend.error.${item.clientId}`}>
-              {item.errorText}
-            </Text>
-          ) : null}
-        </Pressable>
       </View>
       {selected && item.hint ? (
         <Text style={styles.rowHint} testID={`pendingSend.hint.${item.clientId}`}>{item.hint}</Text>
@@ -394,11 +396,23 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   bubbleRow: {
     alignItems: 'center',
     flexDirection: 'row',
-    gap: spacing.sm,
     justifyContent: 'flex-end',
     width: '100%',
   },
-  badge: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
+  // 徽标绝对定位在气泡外,不参与横向排版:长待发消息与落定后的 86% 正式气泡保持同宽,
+  // 文本不会因「已排队」标签出现/消失而重新换行。
+  bubbleShell: { alignItems: 'flex-end', flexShrink: 1, maxWidth: '86%', position: 'relative' },
+  badge: {
+    alignItems: 'center',
+    bottom: 0,
+    flexDirection: 'row',
+    gap: spacing.xs,
+    justifyContent: 'center',
+    marginRight: spacing.sm,
+    position: 'absolute',
+    right: '100%',
+    top: 0,
+  },
   queuedStatusText: {
     color: colors.textTertiary,
     fontSize: typeScale.caption,
@@ -411,9 +425,8 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     borderColor: colors.borderStrong,
     borderRadius: radius.container,
     borderWidth: StyleSheet.hairlineWidth,
-    flexShrink: 1,
     gap: spacing.xs,
-    maxWidth: '86%',
+    maxWidth: '100%',
     opacity: 0.62,
     padding: spacing.md,
   },

--- a/apps/mobile/src/session/PendingSendBubble.tsx
+++ b/apps/mobile/src/session/PendingSendBubble.tsx
@@ -5,10 +5,10 @@
  * 「这就是你的消息,只是还没生效」;落定时提高不透明度,回流后同一个列表位置换成正式
  * 消息,原地变实。徽标语义:
  *  - 转圈 = 还没有「已被收下」这个事实(enqueue 在途 / 已出队待回流 / 附件上传中);
- *  - 「排入队尾 list-end」= 已确认入队,顺序由排列先后表达,不标数字;
+ *  - 「时钟 + 已排队」= 已确认入队,顺序由排列先后表达,不标数字;
  *  - ✎ = 正在底部 composer 编辑这一条;
  *  - ⚠ = 失败,可重试 / 删除。
- * 「排入队尾」是个事实断言,未确认时画它就是谎报,所以未确认一律转圈。
+ * 「已排队」是个事实断言,未确认时画它就是谎报,所以未确认一律转圈。
  */
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -19,7 +19,7 @@ import { SentInlineAtomBody } from '@/session/SentInlineAtomBody';
 import {
   AlertCircle,
   ArrowUp,
-  ListEnd,
+  Clock3,
   Paperclip,
   Pencil,
   RotateCcw,
@@ -199,7 +199,12 @@ export function PendingSendBubble({
   return (
     <View style={styles.rowWrap} testID={`pendingSend.row.${item.clientId}`}>
       <View style={styles.bubbleRow}>
-        <View style={styles.badge} testID={`pendingSend.badge.${item.phase}`}>
+        <View
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={styles.badge}
+          testID={`pendingSend.badge.${item.phase}`}
+        >
           {failed ? (
             <AlertCircle color={colors.errorText} size={iconSize.sm} strokeWidth={iconStroke.regular} />
           ) : spinning ? (
@@ -207,8 +212,17 @@ export function PendingSendBubble({
           ) : editing ? (
             <Pencil color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
           ) : (
-            // 暂停态不换 ⏸:组顶横幅已表达暂停,逐条再换会重复;行内恒用排队 icon。
-            <ListEnd color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+            // 暂停态不换 ⏸:组顶横幅已表达暂停,逐条再换会重复;行内恒用明确的排队标记。
+            <>
+              <Clock3 color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+              <Text
+                numberOfLines={1}
+                style={styles.queuedStatusText}
+                testID={`pendingSend.queuedStatus.${item.clientId}`}
+              >
+                {t('message.queue.queuedStatus')}
+              </Text>
+            </>
           )}
         </View>
         <Pressable
@@ -384,13 +398,20 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     justifyContent: 'flex-end',
     width: '100%',
   },
-  badge: { alignItems: 'center', flexDirection: 'row' },
+  badge: { alignItems: 'center', flexDirection: 'row', gap: spacing.xs },
+  queuedStatusText: {
+    color: colors.textTertiary,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
+    lineHeight: lineHeight.caption,
+  },
   // 与已发送用户气泡同款,但整体半透明:「这就是你的消息,只是还没生效」。
   bubble: {
     backgroundColor: colors.surfaceElevated,
     borderColor: colors.borderStrong,
     borderRadius: radius.container,
     borderWidth: StyleSheet.hairlineWidth,
+    flexShrink: 1,
     gap: spacing.xs,
     maxWidth: '86%',
     opacity: 0.62,


### PR DESCRIPTION
## Summary

- replace the icon-only queued marker with a clock icon and an explicit localized status label
- keep sending, settling, uploading, editing, failed, and sent-state behavior unchanged
- add English, Simplified Chinese, Japanese, and Korean copy plus regression coverage

## Root cause

Confirmed queued messages used only a `ListEnd` glyph. On mobile, that icon could be read as a transmission or processing indicator, so users could mistake a successfully queued message for one that had not been sent.

## User impact

Confirmed queue entries now show a clear `Clock3 + Queued` marker while unconfirmed sends continue to use the spinner. The existing translucent-to-solid settling transition is preserved.

## Validation

- `pnpm test:unit`
- `pnpm --filter mobile run --if-present typecheck`
- focused Mobile queue, i18n parity, design-token, and typography-token tests
- `pnpm check:i18n`
- `pnpm check:i18n-glossary`
- `node scripts/hardcoded-color-audit.mjs --base-ref origin/main`
- `git diff --check`

Simulator Light/Dark visual QA was not run locally; the changed styles use existing semantic theme tokens.

Closes #899
