### PR TITLE
docs: fix dangling internal links and widen the link gate

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -33,5 +33,4 @@
 | [desktop-login-hosted-callback.md](./desktop-login-hosted-callback.md) | 跨仓契约 | 参考 | Desktop 系统浏览器登录的托管回调链路：auth-server 路由契约、结果页模板交付、灰度开关与回滚 | — |
 | [auth-realm-routing.md](./auth-realm-routing.md) | 跨仓契约 | 参考 | 组织 SSO 双区域发现、会话区域持久化与 token 消费端点路由 | — |
 | [legal/README.md](./legal/README.md) | 法律/合规索引 | authoritative | 法律合规资料归档边界与固定路径例外 | — |
-| [legal/wechat-open-sdk-compliance.md](./legal/wechat-open-sdk-compliance.md) | 合规记录 | restricted-review-required | Mobile 微信 Open SDK 版本、隐私披露和发布前签核 | — |
 | [legal/notices/README.md](./legal/notices/README.md) | 第三方许可/SBOM | generated | `pnpm licenses:generate`、Desktop/Mobile 随包声明 | — |

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -14,13 +14,6 @@
 - [项目版权与归属声明](../../NOTICE)：仓库根目录固定文件；其中的第三方材料入口
   指向本目录的 `notices/`。
 
-### 人工维护的合规记录
-
-- [微信 Open SDK 合规记录](./wechat-open-sdk-compliance.md)：版本、隐私披露、用户
-  同意和发布前复核记录。
-- [个人微信 IM 合规与发布记录](./wechat-personal-im-compliance.md)：iLink 协议来源、
-  数据处理、腾讯接入授权与 GA 门禁。
-
 ### 第三方许可、受限组件与 SBOM
 
 - [第三方声明与 SBOM 说明](./notices/README.md)：生成命令、覆盖范围、审计门禁和

--- a/docs/openai-chat-dual-channel-plan.md
+++ b/docs/openai-chat-dual-channel-plan.md
@@ -2,7 +2,7 @@
 
 > 状态：待实施。
 > 范围：当前只落地 Phase 1——把 Codex 的 OpenAI Responses 请求桥接到供应商的 OpenAI Chat Completions 接口；Phase 2 及其它协议按真实需求后续实施。
-> 相关现状：[`subscription-bridge.md`](./subscription-bridge.md) 记录了 Claude Code 侧已有 Anthropic Messages → OpenAI Responses bridge；本文补齐 Codex 访问 Chat-only 上游的方向。
+> 相关现状：`packages/anthropic-responses-bridge` 实现了 Claude Code 侧已有的 Anthropic Messages → OpenAI Responses bridge；本文补齐 Codex 访问 Chat-only 上游的方向。
 
 ## 1. 目标与最终结论
 
@@ -149,7 +149,7 @@ export type ProviderWireProtocol =
 - `providerViewToConfig`、wizard、DB JSON normalize 不能在创建、编辑、重启后丢字段；
 - device-link 对执行字段做剥离，只保留展示所需的兼容类型。
 
-配置语义遵守 [`configuration-design-principles.md`](./configuration-design-principles.md)：Codex 上游协议是创建自定义端点时必须理解的常规字段，系统默认 Responses；存量用户未设置 override 时行为完全不变，恢复默认即清除 override、重新跟随 Responses 默认。
+配置语义遵守 [`configuration-and-overrides.md`](./dev-rules/configuration-and-overrides.md)：Codex 上游协议是创建自定义端点时必须理解的常规字段，系统默认 Responses；存量用户未设置 override 时行为完全不变，恢复默认即清除 override、重新跟随 Responses 默认。
 
 ### 4.2 native fast path 与 bridge path
 

--- a/scripts/__tests__/dev-docs-contract.test.mjs
+++ b/scripts/__tests__/dev-docs-contract.test.mjs
@@ -82,7 +82,17 @@ function assertPnpmCommandExists(line, rootPackage) {
  * 变成 [](./foo.md),目标仍在括号里,正则照常命中。
  */
 function stripCodeSpans(text) {
-	return text.replace(/^```[\s\S]*?^```/gm, "").replace(/`[^`\n]*`/g, "");
+	return (
+		text
+			// 围栏允许带缩进 —— 列表项里的围栏本就是缩进的(docs/design-rules/DESIGN.md
+			// 与 docs/dev-rules/pi-remaining-work.md 各有一处)。只认行首 ``` 会漏掉它们,
+			// 块内的示例链接就会被当成真链接。
+			.replace(/^[ \t]*```[\s\S]*?^[ \t]*```/gm, "")
+			// inline code 用「等长反引号串」配对,这样内容本身含反引号的写法也能整段剥掉
+			// (docs/product-rules/task-and-conversation-naming.md 有 `` `${n} 个会话` ``)。
+			// 刻意不跨行:落单的反引号不应该让后面整篇文档漏检。
+			.replace(/(`+)(?:(?!\1)[^\n])*?\1/g, "")
+	);
 }
 
 function localMarkdownLinks(relativePath) {

--- a/scripts/__tests__/dev-docs-contract.test.mjs
+++ b/scripts/__tests__/dev-docs-contract.test.mjs
@@ -73,10 +73,42 @@ function assertPnpmCommandExists(line, rootPackage) {
 	assert.ok(rootPackage.scripts?.[command], `documented root script is missing: ${line}`);
 }
 
+/**
+ * 去掉 fenced code block 与 inline code span,再抽链接。顺序不能反 —— fenced block
+ * 内部含反引号,先剥 inline 会把围栏本身吃掉。
+ *
+ * 这样 `[x](y)` 这类**演示 markdown 语法**的写法不会被当成真链接(design-rules/DESIGN.md
+ * 里有多处);而 [`foo.md`](./foo.md) 这种「链接文本本身是 inline code」的常见写法,剥完
+ * 变成 [](./foo.md),目标仍在括号里,正则照常命中。
+ */
+function stripCodeSpans(text) {
+	return text.replace(/^```[\s\S]*?^```/gm, "").replace(/`[^`\n]*`/g, "");
+}
+
 function localMarkdownLinks(relativePath) {
-	return [...readText(relativePath).matchAll(/\[[^\]]*\]\(([^)]+)\)/g)]
+	return [...stripCodeSpans(readText(relativePath)).matchAll(/\[[^\]]*\]\(([^)]+)\)/g)]
 		.map((match) => match[1].trim())
 		.filter((target) => !/^(?:https?:|mailto:|#)/.test(target));
+}
+
+/**
+ * 需要做内链体检的全部文档:根目录规则文件 + `docs/` 下所有 markdown(递归)。
+ *
+ * 覆盖面刻意做全 —— 悬空内链最容易出现在深层目录里:文档被删除时,引用它的索引
+ * (如 `docs/legal/README.md`、`docs/README.md`)常常漏改。只体检 CHECKED_DOCS 那几篇
+ * canonical 文档挡不住这类回归。
+ */
+function listLinkCheckedDocs() {
+	const out = ["AGENTS.md", ...CONTRIBUTING_DOCS];
+	const walk = (relativeDir) => {
+		for (const entry of fs.readdirSync(path.join(ROOT, relativeDir), { withFileTypes: true })) {
+			const relativePath = path.join(relativeDir, entry.name);
+			if (entry.isDirectory()) walk(relativePath);
+			else if (entry.name.endsWith(".md")) out.push(relativePath);
+		}
+	};
+	walk("docs");
+	return [...new Set(out)].sort();
 }
 
 test("developer docs only document pnpm commands that exist", () => {
@@ -117,7 +149,7 @@ test("AGENTS and CONTRIBUTING route to the canonical developer docs", () => {
 });
 
 test("developer documentation links resolve", () => {
-	for (const relativePath of CHECKED_DOCS) {
+	for (const relativePath of listLinkCheckedDocs()) {
 		const sourceDir = path.dirname(path.join(ROOT, relativePath));
 		for (const target of localMarkdownLinks(relativePath)) {
 			const fileTarget = decodeURIComponent(target.split("#", 1)[0]);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 4 处悬空内链，并把已有的内链门禁扩到覆盖全部文档。

`docs/legal/README.md` 和 `docs/README.md` 仍然链向 `1260b7c4`（`chore(docs): remove wechat related documents`）已经删掉的两份微信合规记录；`docs/openai-chat-dual-channel-plan.md` 链向的两个文件在本仓 git 历史里从未存在过。

现有的 `developer documentation links resolve` 测试只覆盖 CONTRIBUTING 两份 + 3 篇 canonical 文档，所以这 4 条一条都没被拦住。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：无（自查发现）
- 本 PR 包含：
  - `docs/legal/README.md`：删掉整节「人工维护的合规记录」—— 两条 bullet 的目标都已删除，移除后该节为空。
  - `docs/README.md`：删掉索引表里指向已删除合规记录的那一行。
  - `docs/openai-chat-dual-channel-plan.md`：`subscription-bridge.md` 没有继任文档，改为引用 `packages/anthropic-responses-bridge`（其 package description 正是 “translates Anthropic Messages API <-> OpenAI Responses API … ChatGPT-subscription (Codex)”，与原句所指一致）；`configuration-design-principles.md` 重指到继任文档 `dev-rules/configuration-and-overrides.md`，原句依赖的 override / 恢复默认语义正是该文档 §2 与 §4 的内容。
  - `scripts/__tests__/dev-docs-contract.test.mjs`：`developer documentation links resolve` 覆盖面从 5 篇扩到 47 篇（`AGENTS.md` + 两份 CONTRIBUTING + `docs/` 下全部 markdown，递归）。
- 明确不包含：
  - 不恢复那两份微信合规记录。微信连接器本身仍在仓库里（`packages/wechat-ilink`），本 PR 只移除对已删除文件的引用，不做任何合规判断 —— 合规记录该不该恢复是维护者/法务的决定。
  - 不动其它文档的内容，只动坏链本身。
- 用户可见变化：无（纯文档与测试）
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
node --test scripts/__tests__/dev-docs-contract.test.mjs
结果：# pass 6 / # fail 0

pnpm test:unit
结果：56 workspaces PASS，0 FAIL（exit 0）
```

负向验证（确认扩面后的门禁真的能拦住回归）：往 `docs/legal/README.md` 追加一条指向已删除文件的链接，门禁报错

```text
not ok 4 - developer documentation links resolve
  error: 'broken local link in docs/legal/README.md: ./wechat-open-sdk-compliance.md'
```

还原该行后恢复 `# pass 6 / # fail 0`。

关于扩面必须忽略代码的原因：`docs/design-rules/DESIGN.md` 有多处在行内反引号里**演示 markdown 链接语法**（`` `[x](y)` ``），直接扩面会把它们误判成坏链。新增的 `stripCodeSpans` 先剥 fenced block 再剥 inline span —— 顺序不能反，fenced block 内部含反引号，先剥 inline 会把围栏本身吃掉。写成 ``[`foo.md`](./foo.md)`` 的链接不受影响：剥完是 `[](./foo.md)`，目标仍在括号里，正则照常命中。

### 手工验证

不涉及。

### 未执行的验证

无。本次改动只涉及 `docs/` 与根目录 `scripts/` 下的测试，没有触及任何带 `typecheck` script 的 package（根 package `cindy` 没有该 script），因此按 `--if-present` 逐包 typecheck 那一步为空操作。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅文档内容与一条已有测试的覆盖面。不改任何运行时代码。
- 回滚 / 降级方式：revert 本 PR 即可，无数据或状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
