### PR TITLE
test(device-link): fix outbox TTL expectation for the narrowed listing tier

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
@@ -198,13 +198,18 @@ describe('[2] outbox 离线不自旋,上线事件驱动投递', () => {
 });
 
 describe('[3] outbox 保留时长按 channel 收窄', () => {
-  it('默认 channel = 60s;放宽表 channel ×2 封顶 120s', () => {
-    expect(__testing.outboxEntryMaxAgeMs('local-db:sessions:list')).toBe(60_000);
+  it('无 override 的 channel = 60s;listing tier 收窄到 24s;长任务 ×2 封顶 120s', () => {
+    // 缺省预算 30s × 2。INVOKE_TIMEOUT_OVERRIDES_MS 里没有条目的 channel 走这一档。
     expect(__testing.outboxEntryMaxAgeMs(undefined)).toBe(60_000);
+    expect(__testing.outboxEntryMaxAgeMs('local-db:messages:around-client-id')).toBe(60_000);
+    // listing tier 在 allowlist 侧被显式收紧到 12s(见 INVOKE_TIMEOUT_OVERRIDES_MS 的
+    // 「收紧」段),×2 = 24s —— 这是「逐 channel 收窄」的正例,不是默认档。
+    expect(__testing.outboxEntryMaxAgeMs('local-db:sessions:list')).toBe(24_000);
+    // 60s 预算 × 2 = 120s,正好压在全局上限 REMOTE_INVOKE_RESULT_OUTBOX_MAX_AGE_MS 上。
     expect(__testing.outboxEntryMaxAgeMs('worktree:create')).toBe(120_000);
   });
 
-  it('离线慢扫描按逐条 TTL 出清:默认 channel 61s 被丢,长任务 channel 保留', () => {
+  it('离线慢扫描按逐条 TTL 出清:listing channel 61s 被丢,长任务 channel 保留', () => {
     const sendInvokeResult = vi.fn(() => {
       throw notConnected();
     });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 `main` 的基线红。`[3] outbox 保留时长按 channel 收窄 > 默认 channel = 60s` 断言 `outboxEntryMaxAgeMs('local-db:sessions:list')` 是 `60000`，但这个 channel 并不是默认档：`INVOKE_TIMEOUT_OVERRIDES_MS` 把 listing tier 收紧到了 `12000`（「listing tier 轻量 DB 读:毫秒级查询,12s 仍等不到只能是链路问题」），所以 `min(12000 * 2, 60000)` = `24000`。

**实现是对的，是测试挑错了示例 channel。** 收紧 listing 回包正是这张 TTL 表存在的目的 —— `outboxEntryMaxAgeMs` 自己的注释就写着「listing 类回包在弱网时段最多占 outbox 两分钟纯属浪费配额」。因此本 PR 只改测试，不动实现，也没有通过 skip / 删除 / 放宽断言达成（#1501 验收标准明确禁止）。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Fixes #1503、Fixes #1501（同一根因）
- 本 PR 包含（仅 `apps/desktop/src/main/device-link/__tests__/dispatchWeakNetwork.test.ts`，+8/−3）：
  - 用 `local-db:messages:around-client-id`（在 `REMOTE_INVOKE_ALLOWLIST` 内、不在 override 表内）加上 `undefined` 表示真正的 60s 默认档；
  - 对 `local-db:sessions:list` 断言 `24000`，把「逐 channel 收窄」作为**正例**覆盖，而不是误当默认档；
  - `worktree:create` 保持 `120000`，并注明它正好压在全局上限 `REMOTE_INVOKE_RESULT_OUTBOX_MAX_AGE_MS` 上；
  - 修正同 describe 内另一个用例的标题 —— 它同样把 `local-db:sessions:list` 叫「默认 channel」。该用例只因 61s 也超过 24s 才碰巧通过，命名源于同一个错误假设。
- 明确不包含：不改任何生产代码；不调整 `INVOKE_TIMEOUT_OVERRIDES_MS` 的取值；不碰 #1501 里提到的另外两条独立基线红。
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
npx vitest run src/main/device-link/__tests__/dispatchWeakNetwork.test.ts
结果：Tests 7 passed (7)   —— 修前为 Tests 1 failed | 6 passed (7)

pnpm test:unit
结果：56 workspaces PASS，0 FAIL（exit 0）

pnpm --filter desktop run --if-present typecheck
结果：exit 0
```

关于 typecheck 的环境注记：`tsc --noEmit` 在 node 默认堆上限下会 OOM（`FATAL ERROR: Ineffective mark-compacts near heap limit`），需要 `NODE_OPTIONS=--max-old-space-size=12288` 才能跑完。与本次改动无关，仅作记录。

### 手工验证

不涉及。

### 未执行的验证

无。

## 补充：对 #1501 归因的一点更正

#1501 推测该用例「疑为 Windows 上的计时或表值口径差异,不排除 timer fake 与真实时钟混用」，并把验收标准写成「该用例在 Windows 上不再依赖真实时钟」。

实测不是这个原因：**该失败是确定性的、与平台无关**。我在 macOS/arm64、`cae539da` 上直接复现，断言值逐字相同（`expected 24000 to be 60000`）。这与 #1503 的分析一致 —— `acac14a6`（#1477）带红合入，`verify`(Linux) 与 Windows 两个分片红在同一条断言。该用例本身用的是 fake timers，不依赖真实时钟。

#1501 顺带列出的另外两条 Windows 分片基线红与本条不同根因，也不在本 PR 范围内：

- `VoiceInputSection` 源码正则断言（#1448）**已经被 #1440 修掉**（`2ce6bcd9`）。我把 `apps/desktop/src` 下全部 `.ts/.tsx/.swift/.css/.md`（3892 个文件）转成 CRLF 模拟 Windows autocrlf 检出后跑了完整 desktop 套件，**1654 个测试文件 / 20162 个测试全部通过**，未发现残留的 CRLF 敏感断言。#1448 应可关闭。
- `packages/maker-core` SQLite 迁移用例超时（#1416）是独立问题。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅一个测试文件的断言与用例标题。无生产代码改动。
- 回滚 / 降级方式：revert 本 PR 即可，`main` 会回到当前的基线红状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
