### PR TITLE
fix(device-link): stop a failing busy probe from killing the main process

### DIFF
--- a/apps/desktop/src/main/__tests__/busyReporter.test.ts
+++ b/apps/desktop/src/main/__tests__/busyReporter.test.ts
@@ -78,3 +78,66 @@ describe('busyReporter', () => {
     expect(__testing.getLastReported()).toBe(false);
   });
 });
+
+/**
+ * probe 抛错(账号 / owner 边界切换期 maker facade 抛 PRECONDITION_FAILED)。
+ * 修复前:异常从 pollBusyChange 逃到 5s setInterval,成为主进程 uncaughtException →
+ * beginShutdown → exitCode=1,冷启动崩溃循环(issue #1358)。
+ */
+describe('busyReporter · probe 不可用(issue #1358)', () => {
+  const boundaryError = () =>
+    new Error('[PRECONDITION_FAILED] App session is switching; retry after the owner boundary settles.');
+
+  it('pollBusyChange 不外抛,返回 null(不上报)', () => {
+    setBusyProbe(() => {
+      throw boundaryError();
+    });
+    expect(() => pollBusyChange()).not.toThrow();
+    expect(pollBusyChange()).toBeNull();
+  });
+
+  it('probe 抛错时基线保持不动 —— 不退化成「不忙」', () => {
+    // turn 正在跑并已上报过 → 基线 true。
+    let probe: () => boolean = () => true;
+    setBusyProbe(() => probe());
+    expect(pollBusyChange()).toBe(true);
+    expect(__testing.getLastReported()).toBe(true);
+
+    // 边界切换:probe 开始抛错。若把未知当 false,基线会被推成 false,
+    // turn 仍在跑时其它设备整轮把本机看成空闲(同 New-F 那个坑)。
+    probe = () => {
+      throw boundaryError();
+    };
+    expect(pollBusyChange()).toBeNull();
+    expect(__testing.getLastReported()).toBe(true);
+  });
+
+  it('probe 恢复后照常工作:未错过的翻转仍会上报', () => {
+    let probe: () => boolean = () => {
+      throw boundaryError();
+    };
+    setBusyProbe(() => probe());
+    expect(pollBusyChange()).toBeNull(); // 边界期:跳过,基线仍 false
+    expect(__testing.getLastReported()).toBe(false);
+
+    // 边界稳定,期间 turn 已经起来了 → 恢复后第一拍就补报 true。
+    probe = () => true;
+    expect(pollBusyChange()).toBe(true);
+    expect(__testing.getLastReported()).toBe(true);
+  });
+
+  it('currentBusy / helloBusy 在 probe 不可用时按 false,且能自我纠正', () => {
+    let probe: () => boolean = () => {
+      throw boundaryError();
+    };
+    setBusyProbe(() => probe());
+    // hello 帧必须带一个具体值,未知只能按 false 发;基线随之为 false。
+    expect(currentBusy()).toBe(false);
+    expect(helloBusy()).toBe(false);
+    expect(__testing.getLastReported()).toBe(false);
+
+    // 边界稳定后若实际在跑 turn,下一拍轮询就把它补正回 true(不会被 dedupe 压掉)。
+    probe = () => true;
+    expect(pollBusyChange()).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/busyReporter.test.ts
+++ b/apps/desktop/src/main/__tests__/busyReporter.test.ts
@@ -2,7 +2,20 @@
  * busyReporter 单测 —— 被控端 busy presence 的 dedupe 与重连补正(PR #166 review New-F)。
  * 核心:hello 必须报当前真实 busy 并同步 dedupe 基线,否则 turn 进行中重连会让其它设备整轮看成空闲。
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const logSpies = vi.hoisted(() => ({ warn: vi.fn() }));
+vi.mock('../logger', () => ({
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: logSpies.warn,
+    error: vi.fn(),
+    fatal: vi.fn(),
+  }),
+}));
+
 import {
   setBusyProbe,
   currentBusy,
@@ -12,7 +25,10 @@ import {
   __testing,
 } from '../device-link/busyReporter';
 
-beforeEach(() => __testing.reset());
+beforeEach(() => {
+  __testing.reset();
+  logSpies.warn.mockClear();
+});
 
 describe('busyReporter', () => {
   it('无 probe → currentBusy=false', () => {
@@ -124,6 +140,41 @@ describe('busyReporter · probe 不可用(issue #1358)', () => {
     probe = () => true;
     expect(pollBusyChange()).toBe(true);
     expect(__testing.getLastReported()).toBe(true);
+  });
+
+  it('同一段连续失败只记一条 warn,probe 恢复后重新武装', () => {
+    let probe: () => boolean = () => {
+      throw boundaryError();
+    };
+    setBusyProbe(() => probe());
+    pollBusyChange();
+    pollBusyChange();
+    pollBusyChange();
+    expect(logSpies.warn).toHaveBeenCalledTimes(1); // 边界期每 5s 一条纯噪音,抑制掉
+
+    probe = () => true;
+    expect(pollBusyChange()).toBe(true); // 恢复 → 抑制解除
+    probe = () => {
+      throw boundaryError();
+    };
+    pollBusyChange();
+    expect(logSpies.warn).toHaveBeenCalledTimes(2); // 新一段失败重新记一条
+  });
+
+  it('换 probe 会重置失败日志抑制 —— 新一段的首条 warn 不被上一段吃掉', () => {
+    const throwing = () => {
+      throw boundaryError();
+    };
+    setBusyProbe(throwing);
+    pollBusyChange();
+    expect(logSpies.warn).toHaveBeenCalledTimes(1);
+
+    // 账号切换后重建 maker 会走「解绑 → 重新注入」;若不在这里重置抑制标志,
+    // 新 probe 仍不可用时的首条 warn 会被上一段的标志静默吃掉。
+    setBusyProbe(null);
+    setBusyProbe(throwing);
+    pollBusyChange();
+    expect(logSpies.warn).toHaveBeenCalledTimes(2);
   });
 
   it('currentBusy / helloBusy 在 probe 不可用时按 false,且能自我纠正', () => {

--- a/apps/desktop/src/main/device-link/busyReporter.ts
+++ b/apps/desktop/src/main/device-link/busyReporter.ts
@@ -11,19 +11,55 @@
  * 登出 / 断连时 `resetBusyDedupe()` 把基线清回 false。
  *
  * probe 由 register.ts 在 maker 就绪后注入(返回本机当前是否有任意 session 在 turn 中)。
+ *
+ * **probe 抛错 = 未知,不等于 false**:注入的 probe 走 `anySessionInTurn(maker)`,而那个
+ * maker 是 bootstrap 的动态 facade —— 账号/owner 边界切换期间它按契约抛
+ * `PRECONDITION_FAILED: App session is switching`。此处必须把它当「这一拍问不出来」处理:
+ *  - 不能让它逃出去:调用方是 5s `setInterval`,异常会成为主进程 uncaughtException 并触发
+ *    beginShutdown(冷启动崩溃循环,见 issue #1358);
+ *  - 也不能退化成 false:那会把 dedupe 基线推成「不忙」,turn 正在跑时其它设备整轮把本机
+ *    看成空闲(本文件开头 PR #166 review New-F 记的就是这个坑)。
+ * 因此 `probeBusy()` 用 null 表示未知,轮询遇到 null 直接跳过本拍、基线保持不动。
  */
+
+import { createLogger } from '../logger';
+
+const log = createLogger('device-link-busy');
 
 let busyProbe: (() => boolean) | null = null;
 let lastReportedBusy = false;
+/** 是否已为当前这段连续 probe 失败记过日志(边界切换期每 5s 一条纯噪音)。 */
+let probeFailureLogged = false;
 
 /** register.ts 注入:返回本机当前是否有任意 session 在 turn 中。传 null 解绑。 */
 export function setBusyProbe(probe: (() => boolean) | null): void {
   busyProbe = probe;
 }
 
-/** 当前真实 busy(无 probe 时按 false)。 */
+/**
+ * 探一次 busy:无 probe 按 false;probe 抛错返回 null(未知,见文件头)。
+ * 同一段连续失败只记一条 warn,恢复后重新武装。
+ */
+function probeBusy(): boolean | null {
+  if (!busyProbe) return false;
+  try {
+    const busy = busyProbe();
+    probeFailureLogged = false;
+    return busy;
+  } catch (err) {
+    if (!probeFailureLogged) {
+      probeFailureLogged = true;
+      log.warn('busy probe unavailable; skipping presence ticks until it recovers', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return null;
+  }
+}
+
+/** 当前真实 busy(无 probe 或 probe 不可用时按 false)。 */
 export function currentBusy(): boolean {
-  return busyProbe?.() ?? false;
+  return probeBusy() ?? false;
 }
 
 /**
@@ -38,9 +74,11 @@ export function helloBusy(): boolean {
 
 /**
  * 轮询用:当前 busy 与基线不同 → 更新基线并返回新值(需上报);相同 → 返回 null(无需上报)。
+ * probe 不可用(边界切换期)同样返回 null,且**不动基线** —— 等下一拍问得出来再说。
  */
 export function pollBusyChange(): boolean | null {
-  const busy = currentBusy();
+  const busy = probeBusy();
+  if (busy === null) return null;
   if (busy === lastReportedBusy) return null;
   lastReportedBusy = busy;
   return busy;
@@ -55,6 +93,7 @@ export const __testing = {
   reset(): void {
     busyProbe = null;
     lastReportedBusy = false;
+    probeFailureLogged = false;
   },
   getLastReported: (): boolean => lastReportedBusy,
 };

--- a/apps/desktop/src/main/device-link/busyReporter.ts
+++ b/apps/desktop/src/main/device-link/busyReporter.ts
@@ -31,9 +31,16 @@ let lastReportedBusy = false;
 /** 是否已为当前这段连续 probe 失败记过日志(边界切换期每 5s 一条纯噪音)。 */
 let probeFailureLogged = false;
 
-/** register.ts 注入:返回本机当前是否有任意 session 在 turn 中。传 null 解绑。 */
+/**
+ * register.ts 注入:返回本机当前是否有任意 session 在 turn 中。传 null 解绑。
+ *
+ * 换 probe 一并重置失败日志抑制:抑制只应作用于**同一段**连续失败。否则解绑后再注入
+ * 一个仍会抛错的 probe(账号切换后重建 maker 即走这条路),新一段的首条 warn 会被上一
+ * 段的标志吃掉,排障时看不到它曾经不可用。
+ */
 export function setBusyProbe(probe: (() => boolean) | null): void {
   busyProbe = probe;
+  probeFailureLogged = false;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

修冷启动崩溃循环。busy presence 探针在账号 / owner 边界切换期间会抛错，异常从 5s `setInterval` 逃出，成为主进程 `uncaughtException` 并触发 `beginShutdown`，进程以 `exitCode=1` 退出。#1358 的报告人统计 2026-07-28 至 2026-08-02 共 **21 次**同款致命异常，形成多个连续启动 5～9 次的重启簇；用户表现是「冷启动经常进不去，要重启好几次」。

调用链（逐段核对过源码）：

1. `apps/desktop/src/main/bootstrap-electron.ts` 把 IPC maker 建成动态 facade，按契约在 `isAppSessionBoundaryPending()` 期间抛 `PRECONDITION_FAILED: App session is switching; retry after the owner boundary settles.`
2. `apps/desktop/src/main/maker-ipc/register.ts` 把 device-link busy 探针注入成 `() => anySessionInTurn(maker)`，用的是**同一个** facade
3. `anySessionInTurn` 内部调 `maker.listActiveSessions()`，于是探针抛错
4. `currentBusy` → `pollBusyChange` → `device-link/index.ts` 的 presence `setInterval` 没有守卫 → 异常逃出

与 issue 里的堆栈一致：`anySessionInTurn` → `currentBusy` → `pollBusyChange` → `Timeout._onTimeout`。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #1358
- 本 PR 包含（2 文件，+105/−3）：
  - `busyReporter.ts`：新增 `probeBusy()`，探针抛错返回 `null` 表示「未知」。`pollBusyChange()` 遇 `null` 跳过本拍且**不动 dedupe 基线**；`currentBusy()` / `helloBusy()` 保持返回 boolean。同一段连续失败只记一条 warn，恢复后重新武装。
  - `busyReporter.test.ts`：新增 4 个用例覆盖探针不可用的行为。
- 明确不包含：不给整个 tick 加兜底 `try/catch`（理由见下）；不改探针注入方式；不改 facade 的抛错契约。
- 用户可见变化：冷启动不再因这条路径崩溃退出。
- 是否存在 breaking change：无

### 为什么「未知」不能压成 `false`

探针失败意味着「这一拍问不出来」，与「不忙」是两件事：

- **退化成 `false`** 会把 dedupe 基线推成「不忙」。turn 仍在跑时，其它设备整轮把本机看成空闲 —— 这正是本文件头部已经记录过的 PR #166 review New-F 的坑，不能在修一个 bug 的同时把它踩回去。
- **让它逃出去**就是当前的崩溃。

所以用 `null` 表示未知：轮询跳过、基线保持，下一拍问得出来时直接补报真实值（有专门用例覆盖「边界期错过的翻转在恢复后仍会上报」）。`helloBusy()` 因为 hello 帧必须带一个具体值，未知只能按 `false` 发并同步基线，随后第一拍轮询即自我纠正。

### 为什么只守探针，不守整个 tick

我核对了该 `setInterval` 里的其它调用，它们不会抛：

- `client.sendPresence()` → `flushPendingPresence()` 在 `packages/device-link/src/client.ts` 内部已有 `try/catch`，发送失败（含背压）不外抛；
- `pollExternalKeepAwakeChange()` / `pollExternalSettingsChange()` 读共享 settings，不经由会抛的 facade。

因此加一圈 `try/catch` 只会掩盖将来真正该暴露的回归，收益为负。

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
npx vitest run src/main/__tests__/busyReporter.test.ts
结果：Tests 10 passed (10)   —— 6 个既有 + 4 个新增

npx vitest run src/main/device-link
结果：Test Files 29 passed (29) / Tests 497 passed (497)

pnpm test:unit
结果：56 workspaces PASS，0 FAIL（exit 0）

pnpm --filter desktop run --if-present typecheck
结果：exit 0
```

**回归证明**（确认新用例真的能抓到这个 bug）：只还原 `busyReporter.ts`、保留新测试后重跑，4 个新用例全部失败，且失败原因就是真实的异常逃逸：

```text
× pollBusyChange 不外抛,返回 null(不上报)
  → expected [Function] to not throw an error but 'Error: [PRECONDITION_FAILED] App sess…' was thrown
× probe 抛错时基线保持不动 —— 不退化成「不忙」
  → [PRECONDITION_FAILED] App session is switching; retry after the owner boundary settles.
× probe 恢复后照常工作:未错过的翻转仍会上报
  → [PRECONDITION_FAILED] App session is switching; retry after the owner boundary settles.
× currentBusy / helloBusy 在 probe 不可用时按 false,且能自我纠正
  → [PRECONDITION_FAILED] App session is switching; retry after the owner boundary settles.
```

环境注记：`tsc --noEmit` 在 node 默认堆上限下会 OOM（`FATAL ERROR: Ineffective mark-compacts near heap limit`），需要 `NODE_OPTIONS=--max-old-space-size=12288`。与本次改动无关，仅作记录。

### 手工验证

不涉及。崩溃触发条件是「冷启动认证较慢 + 期间发生 `runtime-replacement-account-switch`」，属于时序竞态，本地不稳定复现；因此改成用单测直接锁住「探针抛错不外抛、基线不漂移」这两条不变量，并附上上面的回归证明。

### 未执行的验证

- 未在真实冷启动竞态下复现原崩溃（原因同上：需要认证慢 + 账号切换恰好同拍）。issue 提供了 21 次实机日志与完整堆栈，本 PR 按该堆栈逐段核对源码后修复，并用单测覆盖抛错路径。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 device-link busy presence 上报。行为差异只在「探针抛错」这一条原本必然崩溃的路径上：由崩溃改为跳过本拍。探针正常时逐字保持原行为（`pollBusyChange` 的 dedupe 语义、`helloBusy` 的基线同步都不变，既有 6 个用例全部原样通过）。
- 回滚 / 降级方式：revert 本 PR 即可，无持久化状态或数据变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
