### PR TITLE
fix(mobile): reuse remembered Full Access choice

### DIFF
--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -677,12 +677,15 @@ export default function NewRemoteSessionScreen() {
         visibilityOverrides: deviceProviders.modelVisibilityOverrides,
       }).sections,
     );
-    const rememberedPermissionMode =
-      newSessionPreferences?.permissionModeByAgent[storedAgentKind] ??
+    const storedPermissionMode = newSessionPreferences?.permissionModeByAgent[storedAgentKind];
+    const nextPermissionMode =
+      storedPermissionMode ??
       defaultPermissionModeForNewSessionAgent(storedAgentKind);
     let cancelled = false;
     void (async () => {
-      const confirmed = await confirmFullAccessChange(draft.permissionMode, rememberedPermissionMode);
+      const confirmed = await confirmFullAccessChange(draft.permissionMode, nextPermissionMode, {
+        restoringRememberedChoice: storedPermissionMode !== undefined,
+      });
       if (cancelled) return;
       setDraft((current) => {
         const next = pickAgentDefaultRuntime({
@@ -697,8 +700,8 @@ export default function NewRemoteSessionScreen() {
           agentKind: next.agentKind,
           model: next.model,
           effort: next.effort,
-          // 记忆的 Full access 必须经过一次明确确认；取消时保留当前安全档。
-          permissionMode: confirmed ? rememberedPermissionMode : current.permissionMode,
+          // 上次明确选择过的权限直接沿用；内置默认若升级到 Full access 仍需确认。
+          permissionMode: confirmed ? nextPermissionMode : current.permissionMode,
           providerId: null,
         };
       });
@@ -707,7 +710,6 @@ export default function NewRemoteSessionScreen() {
       cancelled = true;
     };
   }, [
-    confirmFullAccessChange,
     draft.permissionMode,
     deviceProviders.loading,
     deviceProviders.providers,
@@ -730,7 +732,9 @@ export default function NewRemoteSessionScreen() {
     const remembered = newSessionPreferences?.permissionModeByAgent[draft.agentKind];
     if (!remembered || remembered === draft.permissionMode) return;
     let cancelled = false;
-    void confirmFullAccessChange(draft.permissionMode, remembered).then((confirmed) => {
+    void confirmFullAccessChange(draft.permissionMode, remembered, {
+      restoringRememberedChoice: true,
+    }).then((confirmed) => {
       if (cancelled || !confirmed) return;
       setDraft((current) => ({ ...current, permissionMode: remembered }));
     });
@@ -756,19 +760,22 @@ export default function NewRemoteSessionScreen() {
     if (!result) return;
     autoDefaultDeviceRef.current = result.appliedDeviceId;
     const nextAgentKind = result.patch.agentKind ?? draft.agentKind;
-    const rememberedPermissionMode =
-      appliedPermissionMemoryRef.current
-        ? draft.permissionMode
-        : newSessionPreferences?.permissionModeByAgent[nextAgentKind] ??
-          defaultPermissionModeForNewSessionAgent(nextAgentKind);
+    const storedPermissionMode = appliedPermissionMemoryRef.current
+      ? undefined
+      : newSessionPreferences?.permissionModeByAgent[nextAgentKind];
+    const nextPermissionMode = appliedPermissionMemoryRef.current
+      ? draft.permissionMode
+      : storedPermissionMode ?? defaultPermissionModeForNewSessionAgent(nextAgentKind);
     let cancelled = false;
-    void confirmFullAccessChange(draft.permissionMode, rememberedPermissionMode).then((confirmed) => {
+    void confirmFullAccessChange(draft.permissionMode, nextPermissionMode, {
+      restoringRememberedChoice: storedPermissionMode !== undefined,
+    }).then((confirmed) => {
       if (cancelled || userTouchedRuntimeRef.current) return;
       setDraft((current) => ({
         ...current,
         ...result.patch,
-        // 自动恢复历史 Full access 也必须经过明确确认；取消时保留当前档位。
-        permissionMode: confirmed ? rememberedPermissionMode : current.permissionMode,
+        // 自动恢复上次明确选择的权限不再重复确认；内置默认仍按升级规则确认。
+        permissionMode: confirmed ? nextPermissionMode : current.permissionMode,
       }));
     });
     return () => {
@@ -2238,10 +2245,13 @@ export default function NewRemoteSessionScreen() {
         visibilityOverrides: deviceProviders.modelVisibilityOverrides,
       }).sections,
     );
-    const rememberedPermissionMode =
-      newSessionPreferences?.permissionModeByAgent[nextKind] ??
+    const storedPermissionMode = newSessionPreferences?.permissionModeByAgent[nextKind];
+    const nextPermissionMode =
+      storedPermissionMode ??
       defaultPermissionModeForNewSessionAgent(nextKind);
-    void confirmFullAccessChange(draft.permissionMode, rememberedPermissionMode).then((confirmed) => {
+    void confirmFullAccessChange(draft.permissionMode, nextPermissionMode, {
+      restoringRememberedChoice: storedPermissionMode !== undefined,
+    }).then((confirmed) => {
       setDraft((current) => {
         const next = pickAgentDefaultRuntime({
           agentKind: nextKind,
@@ -2255,8 +2265,8 @@ export default function NewRemoteSessionScreen() {
           agentKind: next.agentKind,
           model: next.model,
           effort: next.effort,
-          // 目标 agent 的记忆档若是 Full access，先经过明确确认；取消时保留当前档。
-          permissionMode: confirmed ? rememberedPermissionMode : current.permissionMode,
+          // 切到该 agent 时沿用其上次明确选择；无记忆的内置默认仍按升级规则确认。
+          permissionMode: confirmed ? nextPermissionMode : current.permissionMode,
           providerId: null,
         };
       });

--- a/apps/mobile/src/__tests__/fullAccessConfirmation.test.ts
+++ b/apps/mobile/src/__tests__/fullAccessConfirmation.test.ts
@@ -5,6 +5,12 @@ vi.mock('expo-localization', () => ({ getLocales: vi.fn(() => [{ languageCode: '
 
 import { confirmFullAccessChange, getFullAccessConfirmationCopy } from '@/session/fullAccessConfirmation';
 
+function confirmingAlert() {
+  return vi.fn((_title, _message, buttons) => {
+    buttons?.[1]?.onPress?.();
+  });
+}
+
 describe('getFullAccessConfirmationCopy', () => {
   it('selects the supported system language and falls back to English', () => {
     expect(getFullAccessConfirmationCopy('ja').confirm).toBe('Full access を有効にする');
@@ -18,8 +24,26 @@ describe('confirmFullAccessChange', () => {
   it('does not show an alert when the change does not enter Full access', async () => {
     const showAlert = vi.fn();
 
-    await expect(confirmFullAccessChange('auto', 'ask', showAlert)).resolves.toBe(true);
+    await expect(confirmFullAccessChange('auto', 'ask', { showAlert })).resolves.toBe(true);
     expect(showAlert).not.toHaveBeenCalled();
+  });
+
+  it('restores a remembered Full access default without showing an alert', async () => {
+    const showAlert = vi.fn();
+
+    await expect(confirmFullAccessChange('ask', 'bypassPermissions', {
+      restoringRememberedChoice: true,
+      showAlert,
+    })).resolves.toBe(true);
+    expect(showAlert).not.toHaveBeenCalled();
+  });
+
+  it('asks on every explicit transition into Full access', async () => {
+    const showAlert = confirmingAlert();
+
+    await expect(confirmFullAccessChange('ask', 'bypassPermissions', { showAlert })).resolves.toBe(true);
+    await expect(confirmFullAccessChange('auto', 'bypassPermissions', { showAlert })).resolves.toBe(true);
+    expect(showAlert).toHaveBeenCalledTimes(2);
   });
 
   it('keeps the previous mode when the user cancels', async () => {
@@ -27,17 +51,9 @@ describe('confirmFullAccessChange', () => {
       buttons?.[0]?.onPress?.();
     });
 
-    await expect(confirmFullAccessChange('auto', 'bypassPermissions', showAlert)).resolves.toBe(false);
+    await expect(confirmFullAccessChange('auto', 'bypassPermissions', { showAlert })).resolves.toBe(false);
     expect(showAlert).toHaveBeenCalledOnce();
     expect(showAlert.mock.calls[0]?.[2]?.[1]).toMatchObject({ style: 'destructive' });
-  });
-
-  it('allows the change only after explicit confirmation', async () => {
-    const showAlert = vi.fn((_title, _message, buttons) => {
-      buttons?.[1]?.onPress?.();
-    });
-
-    await expect(confirmFullAccessChange('ask', 'bypassPermissions', showAlert)).resolves.toBe(true);
   });
 
   it('treats dismiss as cancellation', async () => {
@@ -45,6 +61,6 @@ describe('confirmFullAccessChange', () => {
       options?.onDismiss?.();
     });
 
-    await expect(confirmFullAccessChange(undefined, 'bypassPermissions', showAlert)).resolves.toBe(false);
+    await expect(confirmFullAccessChange(undefined, 'bypassPermissions', { showAlert })).resolves.toBe(false);
   });
 });

--- a/apps/mobile/src/session/fullAccessConfirmation.ts
+++ b/apps/mobile/src/session/fullAccessConfirmation.ts
@@ -32,16 +32,22 @@ type ShowAlert = (
   options?: AlertOptions,
 ) => void;
 
+export interface FullAccessConfirmationOptions {
+  /** 仅用于把新建任务默认权限恢复为该 agent 上一次明确选过的档位。 */
+  restoringRememberedChoice?: boolean;
+  showAlert?: ShowAlert;
+}
+
 /**
- * 手机端进入 Full access 的一次性确认。
- * 取消、系统 dismiss 或重复回调都保持原权限；不需要升级时直接放行。
+ * 手机端进入 Full access 的确认。只有新建任务恢复该 agent 上一次明确选择的权限时
+ * 直接沿用；其它从非 Full access 进入 Full access 的操作每次都确认。
  */
 export function confirmFullAccessChange(
   currentMode: unknown,
   nextMode: unknown,
-  showAlert: ShowAlert = Alert.alert,
+  options: FullAccessConfirmationOptions = {},
 ): Promise<boolean> {
-  if (!requiresFullAccessConfirmation(currentMode, nextMode)) {
+  if (options.restoringRememberedChoice || !requiresFullAccessConfirmation(currentMode, nextMode)) {
     return Promise.resolve(true);
   }
 
@@ -54,7 +60,7 @@ export function confirmFullAccessChange(
     };
 
     const copy = getFullAccessConfirmationCopy();
-    showAlert(
+    (options.showAlert ?? Alert.alert)(
       copy.title,
       copy.description,
       [


### PR DESCRIPTION
## 这次改了什么

本 PR 将“恢复每个 agent 最近一次明确选择的权限模式”和“用户显式切换到 Full Access”分成两条路径：新建任务自动恢复已记忆的 Full Access 时不重复弹提醒；用户手动切换到 Full Access 时仍然每次确认。范围仅限 Mobile 新建 session 的权限模式恢复与 Full Access 确认入口。

## 怎么验证的

- 产品负责人已用 iOS simulator 与已连接的 Desktop client 完成人工联调。
- 已覆盖自动恢复不弹窗、显式切换仍弹窗的回归测试代码路径。
- 本地自动化测试未在提交前运行；GitHub Actions 负责执行 PR 门禁。

## 风险

风险集中在 Mobile 新建 session 的权限确认分支：只有自动恢复路径跳过提醒，显式 Full Access 仍保留 destructive confirm；回滚可直接 revert 本 PR commit。

## What changed

- Restore the last permission mode explicitly chosen for each agent when opening a new task.
- Skip the Full Access warning only for that automatic restoration path.
- Keep the warning for every explicit transition from another permission mode into Full Access.

## Why

The previous implementation treated confirmation as a persistent account-and-device acknowledgement. After one confirmation, later explicit Full Access selections could stop prompting permanently. That was broader than intended: the default should inherit the user's last choice, while explicit permission changes should continue to ask for confirmation.

## Impact

Users whose last choice for an agent was Full Access can open a new task without seeing a redundant warning. Manually selecting Full Access still shows the warning each time.

## Root cause

The remembered permission preference and the Full Access safety acknowledgement were modeled as the same persistent decision instead of two distinct interaction paths.

## Validation

- Manually verified by the product owner using the iOS simulator and a linked desktop client.
- Automated tests were not run, per request.

- 引用的设计规范：`docs/design-rules/DESIGN.md` 的 Full Access danger semantics；保留现有 destructive confirm 与显式权限切换提醒。