### PR TITLE
fix(codex): xAI 跨源回放时把协同 agent_message 归一成 message

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -2553,6 +2553,95 @@ describe('codex proxy host', () => {
     });
   });
 
+  // OpenAI/Codex collab 历史里的 agent_message 不是 xAI ModelInput 变体；跨源 resume
+  // 到 grok 时原样转发 → 422 "data did not match any variant of untagged enum ModelInput"。
+  // (2026-08-03 实测: gpt-5.6-sol collab 会话切 xai/grok-4.5 必挂;新建 grok 会话正常。)
+  describe('xAI collab agent_message 跨源回放', () => {
+    async function runXaiInputTransforms(
+      suffix: string,
+      body: Record<string, unknown>,
+    ): Promise<Record<string, unknown>> {
+      const host = await freshCodexProxyHost();
+      const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+      mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+        url: 'http://127.0.0.1:43210',
+        dispose: vi.fn(async () => undefined),
+      });
+      await host.ensureCodexProxyReady();
+      const sessionId = `session-agent-message-${suffix}`;
+      const threadId = `thread-agent-message-${suffix}`;
+      host.registerComposed(sessionId, threadId, 'PRODUCT_PROMPT');
+      setSessionProvider(sessionId, 'xai');
+
+      const transforms = mockState.createAnthropicCompatProxy.mock.calls[0]?.[0]?.transformRequest ?? [];
+      const ctx = { method: 'POST', url: '/responses', headers: { 'thread-id': threadId } };
+      let current: unknown = body;
+      for (const transform of transforms) {
+        const next = transform(current, ctx);
+        if (next !== null && next !== undefined) current = next;
+      }
+      clearSessionProvider(sessionId);
+      return current as Record<string, unknown>;
+    }
+
+    it('把 agent_message 降级成 assistant message，丢掉 content 里的 encrypted_content', async () => {
+      const out = await runXaiInputTransforms('collab-to-message', {
+        model: 'xai/grok-4.5',
+        input: [
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'go' }] },
+          {
+            type: 'agent_message',
+            author: '/root/official_pr_rules',
+            recipient: '/root',
+            content: [
+              {
+                type: 'input_text',
+                text: 'Message Type: FINAL_ANSWER\nTask name: /root\nPayload:\n已完成只读审查',
+              },
+              { type: 'encrypted_content', encrypted_content: 'gAAAAA-openai-collab-blob' },
+            ],
+            internal_chat_message_metadata_passthrough: { turn_id: 't1' },
+          },
+        ],
+      });
+
+      const input = out.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(2);
+      expect(input[0]).toMatchObject({ type: 'message', role: 'user' });
+      expect(input[1]).toEqual({
+        type: 'message',
+        role: 'assistant',
+        content: [
+          {
+            type: 'output_text',
+            text:
+              '[collab /root/official_pr_rules]\n'
+              + 'Message Type: FINAL_ANSWER\nTask name: /root\nPayload:\n已完成只读审查',
+          },
+        ],
+      });
+      // 不得残留 collab 专有键或 OpenAI 密文 part。
+      expect(JSON.stringify(input[1])).not.toContain('agent_message');
+      expect(JSON.stringify(input[1])).not.toContain('encrypted_content');
+      expect(JSON.stringify(input[1])).not.toContain('gAAAAA-openai-collab-blob');
+    });
+
+    it('未知 input type 直接丢掉，不原样透传给 xAI', async () => {
+      const out = await runXaiInputTransforms('drop-unknown', {
+        model: 'xai/grok-4.5',
+        input: [
+          { type: 'message', role: 'user', content: 'hi' },
+          { type: 'web_search_end', call_id: 'c1', query: 'x' },
+          { type: 'mcp_tool_call_end', call_id: 'c2' },
+        ],
+      });
+
+      const input = out.input as Array<Record<string, unknown>>;
+      expect(input).toHaveLength(1);
+      expect(input[0]).toMatchObject({ type: 'message', role: 'user' });
+    });
+  });
+
   it('leaves custom_tool_call history untouched for non-xAI requests', async () => {
     const host = await freshCodexProxyHost();
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1041,12 +1041,22 @@ function isXaiUnsupportedInputItem(item: unknown, opts: { supportsReasoning: boo
 }
 
 /**
- * Codex code-mode / app-server 历史里会回放 `custom_tool_call*`，且 tool output 常是
- * `[{type:"input_text",text}]` 数组。xAI Responses 的 untagged `ModelInput` 只认
- * message / function_call / function_call_output / reasoning 等标准变体；原样转发会 422:
+ * Codex code-mode / app-server 历史里会回放 `custom_tool_call*` / `agent_message` 等
+ * 非 Responses 标准 item，且 tool output 常是 `[{type:"input_text",text}]` 数组。
+ * xAI Responses 的 untagged `ModelInput` 只认 message / function_call /
+ * function_call_output / reasoning 等标准变体；原样转发会 422:
  * "data did not match any variant of untagged enum ModelInput"。
- * 仅在 xAI 路由里把这些历史 item 归一成 xAI 可反序列化的 function_call 形态。
+ * 仅在 xAI 路由里把这些历史 item 归一成 xAI 可反序列化的形态；未知 type 直接丢掉，
+ * 避免跨源 resume（如 OpenAI collab → Grok）整轮卡死。
  */
+/** xAI ModelInput 可反序列化的 input item type（归一化后的白名单）。 */
+const XAI_MODEL_INPUT_TYPES = new Set([
+  'message',
+  'function_call',
+  'function_call_output',
+  'reasoning',
+]);
+
 function textFromResponsesContent(value: unknown): string {
   if (typeof value === 'string') return value;
   if (typeof value === 'number' || typeof value === 'boolean') return String(value);
@@ -1127,6 +1137,28 @@ function normalizeXaiInputItem(item: unknown): { item: unknown; changed: boolean
         type: 'function_call_output',
         call_id: typeof base.call_id === 'string' ? base.call_id : '',
         output: textFromResponsesContent(base.output),
+      },
+      changed: true,
+    };
+  }
+
+  // Codex multi-agent collab 历史项。OpenAI 会话里的 agent_message 带着 author/
+  // recipient 和 content 里的 encrypted_content part；xAI ModelInput 不认这个 type，
+  // 跨源 resume 到 grok 时整轮 422。降级成 assistant message，只保留可读文本
+  // （collab 密文 part 解不开，丢掉）。
+  if (type === 'agent_message') {
+    const bodyText = textFromResponsesContent(base.content).trim();
+    const author = typeof base.author === 'string' && base.author.length > 0
+      ? base.author
+      : 'agent';
+    const text = bodyText.length > 0
+      ? `[collab ${author}]\n${bodyText}`
+      : `[collab message from ${author}; encrypted payload omitted]`;
+    return {
+      item: {
+        type: 'message',
+        role: 'assistant',
+        content: [{ type: 'output_text', text }],
       },
       changed: true,
     };
@@ -1244,14 +1276,16 @@ function normalizeXaiInputItem(item: unknown): { item: unknown; changed: boolean
     return changed ? { item: next, changed: true } : { item: base, changed: false };
   }
 
-  return { item: base, changed: typedFromEasy };
+  // 未知 type 不透传：xAI untagged ModelInput 任一 item 对不上就整包 422。
+  // 调用方按 changed=true + 非白名单 type 丢弃（见 normalizeXaiInputItems）。
+  return { item: base, changed: typedFromEasy || (typeof type === 'string' && !XAI_MODEL_INPUT_TYPES.has(type)) };
 }
 
 function normalizeXaiInputItems(body: Record<string, unknown>): Record<string, unknown> | null {
   if (!Array.isArray(body.input)) return null;
 
   // xAI supports encrypted reasoning replay, but not Codex/OpenAI image replay items in `input[]`.
-  // Codex custom_tool_call* must also be rewritten before xAI's ModelInput deserialize.
+  // Codex custom_tool_call* / agent_message 等必须在 ModelInput deserialize 前洗掉或改写。
   const supportsReasoning = supportsXaiReasoning(xaiRealModelId(body.model));
   let changed = false;
   const input: unknown[] = [];
@@ -1262,6 +1296,15 @@ function normalizeXaiInputItems(body: Record<string, unknown>): Record<string, u
     }
     const normalized = normalizeXaiInputItem(raw);
     if (normalized.changed) changed = true;
+    // 归一化后仍不在白名单（或未知 type 原样返回）→ 丢掉，别把 422 留给上游。
+    if (
+      !isPlainObject(normalized.item)
+      || typeof normalized.item.type !== 'string'
+      || !XAI_MODEL_INPUT_TYPES.has(normalized.item.type)
+    ) {
+      changed = true;
+      continue;
+    }
     input.push(normalized.item);
   }
   if (!changed) return null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 会话先跑在别的供应商上，之后按同一 thread resume 到 `xai/grok-4.5`，每一轮都挂：

```json
{"error":"Failed to deserialize the JSON body into the target type: data did not match any variant of untagged enum ModelInput"}
```

上游本身没问题 —— 同一时间窗内**新建**的 grok 会话是 200。挂的是**被重放的历史**。

根因：Codex 多 agent 协同会把 `agent_message` 写进 thread 历史：

```json
{
  "type": "agent_message",
  "author": "/root/official_pr_rules",
  "recipient": "/root",
  "content": [
    { "type": "input_text", "text": "..." },
    { "type": "encrypted_content", "encrypted_content": "gAAAAA..." }
  ]
}
```

`agent_message` 不是 xAI untagged `ModelInput` 的任何一个变体。**一条认不出的 item 就否掉整个请求**，于是会话被永久卡死 —— 点重试重放的还是同一份历史。

`normalizeXaiInputItem` 已经改写了 `custom_tool_call*`、`function_call*`、`reasoning` 与 `message`，`createCrossProviderCompactionCompatTransform` 也已经把 OpenAI 加密 `compaction` 换成明文占位。但未知 type 落到了最后一行 `return { item: base, changed: typedFromEasy }` —— 也就是**原样透传**。

本 PR：

1. 把 `agent_message` 降级成 `assistant` `message`，只保留可读文本并加 `[collab <author>]` 前缀。`encrypted_content` part 直接丢掉 —— 那是 OpenAI 的协同密文，xAI 解不开。
2. 归一化之后仍不在 xAI `ModelInput` 白名单里的 item 一律丢弃，不再透传。一条未知类型的代价是整轮请求，这里不能 fail-open。

不受影响：**Claude Code** 走 `anthropic-responses-bridge` 重放 Anthropic Messages 历史，只产出 `message` / `function_call*` / `reasoning`，根本不会有 `agent_message`；**Pi** 自己维护会话态，不重放 Codex rollout 里的历史项。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无 issue，来自用户反馈（Codex 会话在 `gpt-5.6-sol` 上跑过协同子任务，切到 `xai/grok-4.5` 后每轮 422，重试同样挂）
- 本 PR 包含：`normalizeXaiInputItem` / `normalizeXaiInputItems` 的 `agent_message` 分支 + 未知 type 兜底丢弃 + 2 条回归用例
- 明确不包含：
  - **不加这条 422 的恢复规则**。与 #1345 里提到的情况一样，这句报错文案匹配不上 `INVALID_ENCRYPTED_CONTENT_RE`，所以换个原因导致请求体被拒时，照样没有透明重试。那是另一件事，风险面也不同，单独开 PR
  - **不做 compaction blob 的 provenance 追踪**。#780 里点名的已知缺口（xAI 自己签发的 blob 也会被换成明文占位）本 PR 不动
  - 其它供应商的回放形状不动
- 用户可见变化：从别的供应商切到 Grok 的 Codex 会话不再报 `ModelInput` 422；此前供应商留下的协同消息会以可读的 assistant 文本形式保留，而不是让整个请求失败
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：EXIT=0，56 个 workspace 全 PASS，0 FAIL

node --max-old-space-size=8192 node_modules/typescript/bin/tsc -p apps/desktop/tsconfig.json --noEmit
结果：EXIT=0
（本机默认堆大小下直接跑 `pnpm --filter desktop typecheck` 会 OOM，调大
 --max-old-space-size 是本地绕行，不是代码问题）

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：132 passed

pnpm check:dco
结果：通过
```

### 手工验证

**用真实挂掉的那条会话的历史，离线跑了一遍真正的 transform 链。**

把实际 422 的那条会话（`019fc596-5495-...`，起于 `gpt-5.6-sol`，resume 到 `xai/grok-4.5`）rollout 里的 480 条 `response_item` 灌进 `input[]`，按 `model: xai/grok-4.5` + `upstreamBase: https://api.x.ai/v1` 走完整条 `transformRequest`：

| | 本 PR 之前 | 本 PR 之后 |
| --- | --- | --- |
| 出 wire 的 item 类型 | message 79、reasoning 159、function_call 118、function_call_output 118、**agent_message 7** | message 86、reasoning 159、function_call 118、function_call_output 118 |
| 落在 xAI `ModelInput` 白名单之外的 item | **7** | **0** |
| 协同 `encrypted_content` part 外泄 | **是** | **否** |

7 条 `agent_message` 变成 7 条 assistant message（78 → 86 里另外那 1 条是既有 transform 把 instructions 挪进 `input[]`）。

只把 `codex-proxy-host.ts` 换回修复前版本、同一份真实数据重跑，按预期变红：

```text
AssertionError: expected [ …(7) ] to deeply equal []
leaked collab encrypted_content part: true
```

所以断言盯的是真实缺陷，不是跟着实现走的摆设。临时脚本与导出的会话数据（含明文对话）事后已删除，不进本 PR。

### 未执行的验证

- **没有对 `api.x.ai` 做实机端到端验证**。测试账号的 Grok 订阅额度已用尽，无法确认上游对新 body 返回 200。上面证明的是：对那份确实在挂的历史，**造成 422 的原因（白名单外的 item）已经不会出现在 wire 上**。正式依赖本修复前，仍建议拿受影响的会话做一次实机复测
- 未在 Windows 上验证。改动是纯 JSON 形状归一化，无平台相关逻辑
- 只在 `xai/grok-4.5` 上跑过。该分支对所有 xAI 路由生效，但仅实测了这一个模型

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响 Codex proxy 中 **xAI 路由**下请求体 `input[]` 的 item。`createXaiResponsesCompatTransform` 已按 provider id **与** wire model 双重门控，ChatGPT 直连、网关、其它自定义供应商都不受影响
- **需要评审单独看一眼的一处**：未知 type 兜底丢弃是超出「只修 `agent_message`」的行为变化 —— 以前会原样透传的 item 现在会被丢掉。这是刻意的：untagged enum 下，一条认不出的 item 就是整轮请求的代价，透传未知类型从来不是更安全的默认。但副作用是，将来 xAI 新支持的 item type 必须先加进 `XAI_MODEL_INPUT_TYPES` 才能到达 wire
- 回滚 / 降级方式：revert 这一个 commit 即可，无持久化状态、无数据面残留

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（改动点的 why 写在代码注释里）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
