### PR TITLE
fix: 清理 Codex Web Search 内部引用标记

### DIFF
--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -1025,7 +1025,7 @@ describe('importExternalCodexMessagesForSession', () => {
     expect(rows.map((r) => JSON.parse(r.content))).toEqual(['first', 'third']);
   });
 
-  it('normalizes codex file citations in imported assistant messages (#785)', async () => {
+  it('normalizes codex file and Web citations in imported assistant messages (#785)', async () => {
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);
     fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
@@ -1036,7 +1036,7 @@ describe('importExternalCodexMessagesForSession', () => {
         rolloutLine(
           'm2',
           'assistant',
-          '已保存::codex-file-citation{path="/tmp/报告.docx" purpose="output"},请查收。',
+          '已保存::codex-file-citation{path="/tmp/报告.docx" purpose="output"},请查收。\uE200cite\uE202turn17search1\uE201',
           '2026-05-13T00:00:02.000Z',
         ),
         '',

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -913,7 +913,13 @@ describe('进度快照(turn.progress 链路)', () => {
       // agent 的常态: 先说一句要去看看 -> 干活 -> 给结论。
       cb({ type: 'text', data: { text: '我先看看这个链接。', isFinal: true } });
       cb({ type: 'tool_use', data: { toolName: 'WebFetch', toolUseId: 'u1', input: {} } });
-      cb({ type: 'text', data: { text: '结论: 该库已停止维护。', isFinal: true } });
+      cb({
+        type: 'text',
+        data: {
+          text: '结论: 该库已停止维护。\uE200cite\uE202turn17search1\uE202turn17search2\uE201',
+          isFinal: true,
+        },
+      });
       cb({ type: 'done', data: null });
 
       const outcome = await p;
@@ -922,6 +928,7 @@ describe('进度快照(turn.progress 链路)', () => {
       // 发到公开时间线, 稀释最终结论 —— X 只发最后一条。
       expect(outcome.finalText).toBe('结论: 该库已停止维护。');
       expect(outcome.finalText).not.toContain('我先看看');
+      expect(outcome.finalText).not.toContain('\uE200');
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -32,6 +32,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 
 import { app, BrowserWindow } from 'electron';
+import { stripInternalWebCitations } from '@cindy/maker-shared/internal-citation';
 
 import type {
   AgentKind,
@@ -367,7 +368,11 @@ async function collectOutboundForFinalText(
   allowedFileRoots: string[],
   log: { warn(msg: string): void },
 ): Promise<{ finalText: string; attachments?: HookRunOutcome['attachments'] }> {
-  const { publicText, wholeTurn } = texts;
+  // Defense in depth for X/Slack/Telegram: live Codex traffic is normalized in
+  // maker-core, but older persisted/continuation text and future adapters must
+  // never forward private Web citation delimiters to an external channel.
+  const publicText = stripInternalWebCitations(texts.publicText);
+  const wholeTurn = stripInternalWebCitations(texts.wholeTurn);
   if (!hasOutboundRefs(wholeTurn) && extraImageAbsPaths.length === 0) {
     return { finalText: publicText };
   }

--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -1279,7 +1279,13 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
       const { turnPromise } = await startDefaultTurn();
       await turnPromise;
 
-      h.emit({ type: 'text', data: { text: 'complete text only', isFinal: true } });
+      h.emit({
+        type: 'text',
+        data: {
+          text: 'complete text only\uE200cite\uE202turn17search1\uE202turn17search2\uE201',
+          isFinal: true,
+        },
+      });
       h.emit({ type: 'done', data: {} });
       await flushMicrotasks();
 

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -34,6 +34,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import path from 'node:path';
 
 import { eq } from 'drizzle-orm';
+import { stripInternalWebCitations } from '@cindy/maker-shared/internal-citation';
 import { getMaker } from '../../maker-host';
 import { getDesktopProviderService } from '../../maker-host/createDesktopProviderService';
 import { isCredentialModeSwitchBusyError } from '../../maker-host/codex-credential-switch';
@@ -1734,7 +1735,10 @@ export function createTurnRunner(
    * 纯文本快答没有 tool_use, renderActivity 返回空串, 视图与旧行为逐字一致。
    */
   function composeStreamingView(turn: TurnState): string {
-    const body = turn.outputCardPrefix ? turn.outputCardPrefix + turn.buffer : turn.buffer;
+    const rawBody = turn.outputCardPrefix ? turn.outputCardPrefix + turn.buffer : turn.buffer;
+    // External-channel safeguard: maker-core normally strips these tokens,
+    // while this boundary also protects old continuations and future adapters.
+    const body = stripInternalWebCitations(rawBody);
     if (turn.done) return body;
     const act = renderActivity(turn.activity, Date.now());
     if (!act) return body;

--- a/apps/desktop/src/main/localDb/__tests__/conversationSearch.pure.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/conversationSearch.pure.test.ts
@@ -252,6 +252,13 @@ describe('conversationSearch.pure', () => {
     });
   });
 
+  it('removes internal Web citation markers from assistant search previews', () => {
+    const marker = '\uE200cite\uE202turn17search1\uE202turn17search2\uE201';
+    expect(
+      visibleMessageTextForConversationSearch('assistant', `结论。${marker}`),
+    ).toBe('结论。');
+  });
+
   it('hides synthetic UI trigger rows from search previews and keyword matching', async () => {
     const { UI_ACTION_TRIGGER_PREFIX } = await import('../../../shared/interruptedTurn.js');
     // 隐藏续跑指令(合成 user 行)对用户不可见,搜索 preview/snippet 也不能露出,

--- a/apps/desktop/src/main/localDb/__tests__/mapperCitation.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/mapperCitation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractMessagePreview, messageToCamel } from '../mapper.js';
+
+const marker = '\uE200cite\uE202turn17search1\uE202turn17search2\uE201';
+
+describe('message mapper internal citation compatibility', () => {
+  it('hides persisted Web citation markers from message history', () => {
+    const row = {
+      id: 'message-1',
+      clientId: 'client-1',
+      sessionId: 'session-1',
+      role: 'assistant',
+      content: JSON.stringify(`结论。${marker}`),
+      toolUseId: null,
+      agentMeta: null,
+      agentKind: 'codex',
+      createdAt: 1,
+      rewindAt: null,
+    } as Parameters<typeof messageToCamel>[0];
+
+    expect(messageToCamel(row).content).toBe('结论。');
+  });
+
+  it('hides persisted markers from sidebar previews without touching user text', () => {
+    expect(extractMessagePreview(JSON.stringify(`结论。${marker}`), 'assistant')).toBe('结论。');
+    expect(extractMessagePreview(JSON.stringify(`用户引用 ${marker}`), 'user')).toBe(
+      `用户引用 ${marker}`,
+    );
+  });
+});

--- a/apps/desktop/src/main/localDb/conversationSearch.pure.ts
+++ b/apps/desktop/src/main/localDb/conversationSearch.pure.ts
@@ -4,6 +4,7 @@ import type {
   ConversationSearchSessionSummary,
   ConversationSearchSortBy,
 } from '../../shared/conversationSearch.js';
+import { stripInternalWebCitations } from '@cindy/maker-shared/internal-citation';
 import { isSyntheticTriggerText } from '../../shared/interruptedTurn.js';
 
 const Bonus = {
@@ -254,7 +255,8 @@ export function normalizeConversationContentPreview(
 
 export function visibleMessageTextForConversationSearch(role: string, content: unknown): string {
   const parsed = typeof content === 'string' ? tryParseJsonLike(content) : content;
-  const text = roleVisibleText(role, parsed);
+  const rawText = roleVisibleText(role, parsed);
+  const text = role === 'assistant' ? stripInternalWebCitations(rawText) : rawText;
   return text.replace(/\s+/g, ' ').trim();
 }
 

--- a/apps/desktop/src/main/localDb/mapper.ts
+++ b/apps/desktop/src/main/localDb/mapper.ts
@@ -8,6 +8,7 @@
  */
 
 import { DEFAULT_DRAFT_SESSION_TITLE } from '@cindy/maker-shared/session-title';
+import { stripInternalWebCitations } from '@cindy/maker-shared/internal-citation';
 
 import type {
   sessions,
@@ -114,6 +115,7 @@ export function extractMessagePreview(
   // role='user' 的正常落库行,但对用户不可见 —— 预览显示隐藏英文指令会暴露
   // 实现细节。返回 null 与"无预览"同渲染语义。
   if (isSyntheticTriggerText(text)) return null;
+  if (role === 'assistant') text = stripInternalWebCitations(text);
   const collapsed = text.replace(/\s+/g, ' ').trim();
   if (!collapsed) return null;
   return collapsed.length > PREVIEW_MAX_CHARS ? collapsed.slice(0, PREVIEW_MAX_CHARS) : collapsed;
@@ -199,6 +201,9 @@ export function messageToCamel(row: MessageRow): Message {
   } catch {
     // 容错：极端情况下 content 可能不是合法 JSON（例如旧手工写入），保留原字符串
     content = row.content;
+  }
+  if (row.role === 'assistant' && typeof content === 'string') {
+    content = stripInternalWebCitations(content);
   }
   // agent_meta 列存的是 JSON.stringify 后的字符串，老消息为 NULL。
   // 解析失败时返回 null 而非抛——容错保证历史消息能正常加载。

--- a/packages/maker-core/src/agents/codex/translator.test.ts
+++ b/packages/maker-core/src/agents/codex/translator.test.ts
@@ -1300,7 +1300,7 @@ describe('extractRolloutUpdatePlanFunctionCallEvent', () => {
   });
 });
 
-describe('codex file citation 归一化 (#785)', () => {
+describe('codex internal citation 归一化 (#785)', () => {
   it('normalizeCodexFileCitations 把标记换成行内代码路径,畸形标记整个剥掉', async () => {
     const { normalizeCodexFileCitations } = await import('./translator.js');
     expect(
@@ -1405,6 +1405,50 @@ describe('codex file citation 归一化 (#785)', () => {
     expect(stableCitationBoundary(braceInQuote)).toBe(4);
     const braceComplete = 'abc :codex-file-citation{path="/tmp/a{b}.md"}';
     expect(stableCitationBoundary(braceComplete)).toBe(braceComplete.length);
+  });
+
+  it('Web Search 引用标记被剥离,普通 cite 文本与相邻标点不变', async () => {
+    const { finalizeCodexCitationText } = await import('./translator.js');
+    const one = '\uE200cite\uE202turn17search1\uE201';
+    const many = '\uE200cite\uE202turn17search1\uE202turn17search2\uE201';
+    expect(finalizeCodexCitationText(`结论。${one}`)).toBe('结论。');
+    expect(finalizeCodexCitationText(`A ${one}；B ${many}。`)).toBe('A ；B 。');
+    expect(finalizeCodexCitationText('Please cite the source.')).toBe('Please cite the source.');
+  });
+
+  it('Web Search 引用跨 update 到达时不进入 delta,completed 截断残尾也不泄漏', async () => {
+    const { newCodexRuntimeState } = await import('./translator.js');
+    const rt = newCodexRuntimeState();
+    const q = createAsyncQueue<AgentEvent>();
+    const push = (phase: 'started' | 'updated' | 'completed', text: string): void => {
+      translateItemNotification(
+        phase,
+        {
+          threadId: 'thread-web-citation',
+          turnId: 'turn-web-citation',
+          item: { type: 'agentMessage', id: 'msg-web-citation', text },
+        },
+        q,
+        makeCtx(rt),
+      );
+    };
+
+    push('started', '结论。');
+    push('updated', '结论。 \uE200ci');
+    push('updated', '结论。 \uE200cite\uE202turn17search1');
+    push('updated', '结论。 \uE200cite\uE202turn17search1\uE201 后续');
+    push('completed', '结论。 \uE200cite\uE202turn17search1\uE201 后续。\uE200cite\uE202turn18sea');
+
+    const events = await collect(q);
+    const deltas = events
+      .filter((event) => event.type === 'text' && !(event.data as { isFinal: boolean }).isFinal)
+      .map((event) => (event.data as { text: string }).text);
+    expect(deltas.join('')).toBe('结论。  后续');
+    expect(deltas.join('')).not.toContain('\uE200');
+    const final = events.find(
+      (event) => event.type === 'text' && (event.data as { isFinal: boolean }).isFinal,
+    );
+    expect((final?.data as { text: string }).text).toBe('结论。  后续。');
   });
 
   it('路径本身含标记开头字面量:完整标记结构化消费,不被误认成新的未闭合开头', async () => {

--- a/packages/maker-core/src/agents/codex/translator.ts
+++ b/packages/maker-core/src/agents/codex/translator.ts
@@ -26,6 +26,10 @@ import {
   extractNonSecretErrorSignals,
   redactSensitiveText,
 } from '@cindy/maker-shared/error-redaction';
+import {
+  stableInternalWebCitationBoundary,
+  stripInternalWebCitations,
+} from '@cindy/maker-shared/internal-citation';
 
 import type { AgentEvent, AgentTaskStatus, AgentTaskUpdateEventData } from '../../types/events.js';
 import { normalizeAccountRateLimitSnapshot } from '../../types/account-rate-limits.js';
@@ -744,20 +748,24 @@ function findUnfinishedCitationOpen(text: string): number {
  * 规范形(见 localDb worker 的 canonicalizeCodexCitations)。
  */
 export function finalizeCodexCitationText(text: string): string {
-  const openAt = findUnfinishedCitationOpen(text);
-  return normalizeCodexFileCitations(openAt === -1 ? text : text.slice(0, openAt));
+  const fileOpenAt = findUnfinishedCitationOpen(text);
+  const fileStableEnd = fileOpenAt === -1 ? text.length : fileOpenAt;
+  const stableEnd = Math.min(fileStableEnd, stableInternalWebCitationBoundary(text));
+  return stripInternalWebCitations(normalizeCodexFileCitations(text.slice(0, stableEnd)));
 }
 
 export function stableCitationBoundary(text: string): number {
   const open = findUnfinishedCitationOpen(text);
   if (open !== -1) {
-    return open;
+    return Math.min(open, stableInternalWebCitationBoundary(text));
   }
   const maxProbe = Math.min(text.length, CODEX_FILE_CITATION_OPEN.length - 1);
   for (let k = maxProbe; k > 0; k -= 1) {
-    if (text.endsWith(CODEX_FILE_CITATION_OPEN.slice(0, k))) return text.length - k;
+    if (text.endsWith(CODEX_FILE_CITATION_OPEN.slice(0, k))) {
+      return Math.min(text.length - k, stableInternalWebCitationBoundary(text));
+    }
   }
-  return text.length;
+  return stableInternalWebCitationBoundary(text);
 }
 
 function handleAgentMessage(
@@ -789,7 +797,9 @@ function handleAgentMessage(
     return;
   }
 
-  const emitted = normalizeCodexFileCitations(rawText.slice(0, stableCitationBoundary(rawText)));
+  const emitted = stripInternalWebCitations(
+    normalizeCodexFileCitations(rawText.slice(0, stableCitationBoundary(rawText))),
+  );
   const delta = emitted.slice(prevLen);
   ctx.rt.itemTextLen.set(item.id, emitted.length);
   if (delta.length === 0) return;

--- a/packages/maker-shared/package.json
+++ b/packages/maker-shared/package.json
@@ -28,6 +28,7 @@
     "./fixtures": "./src/fixtures.ts",
     "./history-gap": "./src/historyGap.ts",
     "./interaction": "./src/interaction.ts",
+    "./internal-citation": "./src/internalCitation.ts",
     "./math-markdown": "./src/mathMarkdown.ts",
     "./mention-ref": "./src/mentionRef.ts",
     "./mermaid-autofix": "./src/mermaidAutofix.ts",

--- a/packages/maker-shared/src/index.ts
+++ b/packages/maker-shared/src/index.ts
@@ -15,6 +15,7 @@ export * from './deviceLinkContract.js';
 export * from './errorRedaction.js';
 export * from './expandedBlockMemory.js';
 export * from './interaction.js';
+export * from './internalCitation.js';
 export * from './mathMarkdown.js';
 export * from './mermaidAutofix.js';
 export * from './messageRender.js';

--- a/packages/maker-shared/src/internalCitation.test.ts
+++ b/packages/maker-shared/src/internalCitation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  stableInternalWebCitationBoundary,
+  stripInternalWebCitations,
+} from './internalCitation.js';
+
+const source1 = '\uE200cite\uE202turn17search1\uE201';
+const source2 = '\uE200cite\uE202turn17search1\uE202turn17search2\uE201';
+
+describe('internal Web citation normalization', () => {
+  it('strips single and multiple-source markers without changing punctuation', () => {
+    expect(stripInternalWebCitations(`结论。${source1}`)).toBe('结论。');
+    expect(stripInternalWebCitations(`A ${source1}；B ${source2}。`)).toBe('A ；B 。');
+  });
+
+  it('leaves ordinary cite text and unrelated private-use text untouched', () => {
+    expect(stripInternalWebCitations('Please cite the source.')).toBe('Please cite the source.');
+    expect(stripInternalWebCitations('ordinary \uE200 text')).toBe('ordinary \uE200 text');
+  });
+
+  it('is idempotent and strips unfinished final tails', () => {
+    expect(stripInternalWebCitations(`done ${source1}`)).toBe('done ');
+    expect(stripInternalWebCitations(stripInternalWebCitations(`done ${source1}`))).toBe('done ');
+    expect(stripInternalWebCitations('done \uE200cite\uE202turn17sea')).toBe('done ');
+    expect(stripInternalWebCitations('done \uE200ci')).toBe('done ');
+  });
+
+  it('holds split streaming prefixes and incomplete markers until they are complete', () => {
+    expect(stableInternalWebCitationBoundary('done')).toBe(4);
+    expect(stableInternalWebCitationBoundary('done \uE200ci')).toBe(5);
+    expect(stableInternalWebCitationBoundary('done \uE200cite\uE202turn17sea')).toBe(5);
+    expect(stableInternalWebCitationBoundary(`done ${source2}`)).toBe(`done ${source2}`.length);
+  });
+});

--- a/packages/maker-shared/src/internalCitation.ts
+++ b/packages/maker-shared/src/internalCitation.ts
@@ -1,0 +1,63 @@
+/**
+ * OpenAI Web Search may encode source references in assistant text with
+ * private-use delimiters such as `\uE200cite\uE202...\uE201`. Those tokens are
+ * transport metadata, not user-facing prose. Some Codex app-server versions
+ * expose only the flattened text and omit the structured URL annotations, so
+ * client boundaries must remove the opaque marker deterministically.
+ */
+const WEB_CITATION_OPEN = '\uE200cite\uE202';
+const WEB_CITATION_CLOSE = '\uE201';
+
+function unfinishedWebCitationOpen(text: string): number {
+  let from = 0;
+  for (;;) {
+    const open = text.indexOf(WEB_CITATION_OPEN, from);
+    if (open === -1) return -1;
+    const close = text.indexOf(WEB_CITATION_CLOSE, open + WEB_CITATION_OPEN.length);
+    if (close === -1) return open;
+    from = close + WEB_CITATION_CLOSE.length;
+  }
+}
+
+function partialWebCitationPrefixStart(text: string): number {
+  const maxProbe = Math.min(text.length, WEB_CITATION_OPEN.length - 1);
+  for (let length = maxProbe; length > 0; length -= 1) {
+    if (text.endsWith(WEB_CITATION_OPEN.slice(0, length))) return text.length - length;
+  }
+  return text.length;
+}
+
+/**
+ * Return the append-only prefix of a streaming assistant snapshot. A Web
+ * citation tail is withheld until its closing delimiter arrives, because the
+ * whole marker will disappear from the visible text once complete.
+ */
+export function stableInternalWebCitationBoundary(text: string): number {
+  const unfinished = unfinishedWebCitationOpen(text);
+  return unfinished === -1 ? partialWebCitationPrefixStart(text) : unfinished;
+}
+
+/**
+ * Strip complete Web citation markers plus an unfinished final marker/prefix.
+ * The payload is intentionally treated as opaque: private-use delimiters are
+ * the exact compatibility boundary, while ordinary words such as "cite" are
+ * left untouched. The transform is idempotent.
+ */
+export function stripInternalWebCitations(text: string): string {
+  if (!text.includes('\uE200')) return text;
+
+  const stableEnd = stableInternalWebCitationBoundary(text);
+  const stable = stableEnd === text.length ? text : text.slice(0, stableEnd);
+  if (!stable.includes(WEB_CITATION_OPEN)) return stable;
+
+  let output = '';
+  let from = 0;
+  for (;;) {
+    const open = stable.indexOf(WEB_CITATION_OPEN, from);
+    if (open === -1) return output + stable.slice(from);
+    const close = stable.indexOf(WEB_CITATION_CLOSE, open + WEB_CITATION_OPEN.length);
+    if (close === -1) return output + stable.slice(from, open);
+    output += stable.slice(from, open);
+    from = close + WEB_CITATION_CLOSE.length;
+  }
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Codex 经 Cindy Gateway 使用 OpenAI Responses 原生 `web_search` 时，内部 Web 引用占位符被当作正文展示并发送到 X / IM 渠道的问题。

根因是部分 Codex app-server 版本只返回扁平文本，没有保留结构化 URL/title annotations；内部引用分隔符因此进入客户端文本链路。本 PR 在客户端做确定性兼容清洗，不伪造上游未提供的来源链接。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：X 用户反馈内部引用标记出现在公开回复
- 本 PR 包含：
  - 新增共享的内部 Web 引用识别与清洗函数
  - Codex 实时流与 rollout 历史导入统一清洗，兼容跨 delta 拆分及残缺尾标记
  - 旧数据库消息、侧栏预览、任务搜索摘要读取时清洗
  - X Hook 以及 Slack / Telegram / Feishu 等 IM 流式与最终发送前兜底
  - 覆盖实时、历史、搜索预览与外部渠道的回归测试
- 明确不包含：
  - 不改变 `web_search` 的启用和路由逻辑
  - 不从内部引用编号猜测或伪造来源 URL；结构化来源链接需 Codex 协议后续保留 annotations
- 用户可见变化：回答中不再显示或发送内部 Web 引用占位符；历史存量消息无需迁移即可正常显示
- 是否存在 breaking change：无

### UI 变化

不涉及：未修改 renderer UI、布局、视觉样式或 UI 文案，仅在文本转换、历史读取和渠道出口边界清理内部元数据。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：完整 workspace 单元测试全部通过。当前 Node 24 的 Desktop threads 池会发生原生 SIGSEGV；按仓库既有 WebStorage/forks 兼容路径重跑后全绿。

pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/maker-core run --if-present typecheck
pnpm --filter @cindy/maker-shared run --if-present typecheck
结果：全部通过；后两个 package 当前无 typecheck script，按 --if-present 正常跳过。

相关定向 Vitest
结果：242 tests passed。

修改文件定向 ESLint
结果：全部通过。

pnpm check:dco
结果：本地提交 DCO 检查通过；远端发布提交的 author / committer 与 Signed-off-by 已核对一致。
```

### maker-core 核心指标实测

- 影响指标：本次触及 Codex translator，每个 `agentMessage` snapshot 会增加内部 Web citation 边界识别与清洗，因此重点实测性能/返回速度与返回内容准确性；未修改 prompt、tool/MCP、model 路由、usage 计量或权限分支，缓存率及其余核心指标不受影响。
- 方法：Apple M4 Pro、Node 24.18.1，直接调用真实 `translateItemNotification` 热路径；模拟一个最终 256 KiB 的长流式回复，按 128 字符增长产生 2,048 个 full-snapshot `updated` 通知，再发 1 个 `completed`。分别测无 citation，以及含 8 个内部 Web citation、且标记可能跨 update 边界拆分的场景；no-op queue 隔离 translator CPU 开销，预热 3 轮后采样 12 轮。
- 结果：无 citation 场景整轮 p50 8.327 ms、p95 8.439 ms，折合 p50 4.064 µs/notification；含 citation 场景整轮 p50 73.303 ms、p95 73.896 ms，折合 p50 35.775 µs/notification。
- 结论：代表性长 turn 的较重场景 p95 总 CPU 时间约 73.9 ms，摊到单次通知约 36 µs；实现不含同步 IO、网络往返或串行 await，不会阻塞流式返回。跨 update 残缺标记会在闭合前按住，闭合后整体移除；final 与历史导入口径一致，相关回归测试覆盖拆分、残尾与最终文本，未观察到事件丢失、错序或类型错配。

### 手工验证

未启动独立 Desktop dev 实例进行实际 X 回帖。建议合入前用 GPT-5.6 发起多来源 Web Search，并分别检查实时流、最终回复、历史任务及 X / IM 出口不再出现内部引用占位符。

### 未执行的验证

未执行打包构建和真实 X / IM 发送；本次无构建配置、协议 schema、原生层或 UI 改动，相关边界由单元测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Codex 输出文本兼容

### 影响与回滚

- 影响范围：Codex assistant 文本的实时显示和持久化、历史消息读取、侧栏/搜索预览，以及 X / IM 外部发送。
- 主要风险：若上游未来把相同私有分隔符用于用户可见正文，该段内容会被清理；当前匹配范围限定为完整的内部 `cite` 结构及流式残尾，普通 `cite` 文本和无关私有字符保持不变。
- 回滚 / 降级方式：回滚本 PR 单一提交即可；不涉及数据库 migration 或用户数据改写。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（本 PR 不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本 PR 无需新增用户文档，代码注释说明兼容边界）
- [x] 已确认测试结果或说明未执行原因
