### PR TITLE
feat(mobile): 强更从「不可取消弹窗」改为阻断式闸门

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -55,6 +55,7 @@ import {
   useForcedUpdate,
   type ForcedUpdateTarget,
 } from '@/update/forcedUpdateStore';
+import { useForcedUpdateRecheck } from '@/update/useForcedUpdateRecheck';
 import { useResumeUpdateCheck } from '@/update/useResumeUpdateCheck';
 import {
   markStartupOtaLaunchSuccess,
@@ -472,6 +473,10 @@ function StartupGateBlockedContent({
  */
 function ForcedUpdateGateContent({ target }: { target: ForcedUpdateTarget }) {
   const { t } = useTranslation();
+  // 阻断期间业务树不挂载 → useResumeUpdateCheck 也停了,本进程不会再拉 /latest。
+  // 所以阻断屏自带一次"回前台重新核对":服务端撤回误下发的门槛后,用户切出去再回来
+  // 即自动解除,不必杀进程冷启动。拉取失败一律维持阻断(不能靠断网绕过)。
+  useForcedUpdateRecheck();
   const notes = target.releaseNotes?.trim();
   const subtitle = [
     t('update.bundleAvailableBody'),

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,6 +8,7 @@ import {
 } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useCallback, useEffect, useMemo, useRef, type ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Alert, AppState, Platform, Pressable, StyleSheet, View } from 'react-native';
 import { Text } from '@/components/AppText';
 import {
@@ -46,7 +47,14 @@ import {
 import { registerDevCacheMenu } from '@/debug/devCacheMenu';
 import { startJsStallWatchdog } from '@/debug/jsStallWatchdog';
 import { initMobileTapdb } from '@/analytics/mobileTapdb';
-import { useBundleUpdatePrompt } from '@/update/useBundleUpdatePrompt';
+import {
+  openBundleInstall,
+  useBundleUpdatePrompt,
+} from '@/update/useBundleUpdatePrompt';
+import {
+  useForcedUpdate,
+  type ForcedUpdateTarget,
+} from '@/update/forcedUpdateStore';
 import { useResumeUpdateCheck } from '@/update/useResumeUpdateCheck';
 import {
   markStartupOtaLaunchSuccess,
@@ -356,6 +364,9 @@ function RootLayout() {
   // 回写 env live binding。拉不到 / 清单非法 → 错误屏等用户重试,无缓存与超时兜底;
   // __DEV__ 直接放行。ready 前 RootAfterEndpoints(含 OTA 门与业务树)不挂载。
   const endpointGate = useStartupEndpointGate();
+  // 强更阻断态(自建线整包更新命中 minVersion 门槛):模块级 store,启动检查 / 设置页手动
+  // 检查 / resume 静默检查三条路径中任一命中即置位。置位后整棵业务树不挂载。
+  const forcedUpdate = useForcedUpdate();
   // 所有 hook 已在上方调用,下面条件返回不违反 hooks 规则。
   // GestureHandlerRootView 必须在根部常驻(RNGH 官方要求;缺失时 Android 手势整体不响应)。
   // 各分支都包同一层,避免闸门状态切换时 root 重挂。
@@ -371,9 +382,19 @@ function RootLayout() {
             '{reason}',
             endpointGate.reason ?? 'unknown',
           )}
-          retryLabel={loginText('retry')}
-          onRetry={endpointGate.retry}
+          actionLabel={loginText('retry')}
+          onAction={endpointGate.retry}
         />
+      </MobileLoginHandoffStage>
+    );
+  } else if (forcedUpdate) {
+    // 强更闸门:与端点错误屏同一套阻断体系(白底品牌宿主 + 唯一出口),没有"稍后 / 跳过"
+    // ——点「去更新」跳出去安装,回到 App 仍是这一屏,直到装上不低于门槛的版本。
+    // 业务树整体不挂载,含 AuthProvider / DeviceLinkProvider / 预创建 worktree 恢复桥:
+    // 强更期间不该发起任何 Device Link 调用;恢复账本是持久化的,阻断解除后下次启动照常补偿。
+    body = (
+      <MobileLoginHandoffStage>
+        <ForcedUpdateGateContent target={forcedUpdate} />
       </MobileLoginHandoffStage>
     );
   } else if (endpointGate.status === 'pending') {
@@ -391,8 +412,11 @@ function RootLayout() {
             {/* handoff Provider 常驻 root(PR4b):闸门屏切换不重置衔接状态机 */}
             <MobileLoginHandoffProvider>
               <EndpointHandoffBridge status={endpointGate.status} />
-              {/* 启动闸门全程共用这一个 splash 实例;端点错误屏需要交互时才隐藏它 */}
-              <StartupSplashOverlay hidden={endpointGate.status === 'error'}>
+              {/* 启动闸门全程共用这一个 splash 实例;需要用户交互的闸门屏
+                  (端点错误 / 强更阻断)才隐藏它 */}
+              <StartupSplashOverlay
+                hidden={endpointGate.status === 'error' || forcedUpdate !== null}
+              >
                 {body}
               </StartupSplashOverlay>
             </MobileLoginHandoffProvider>
@@ -404,21 +428,22 @@ function RootLayout() {
 }
 
 /**
- * 端点闸门阻断内容层(StartupBlockedScreen 的白底体系消费变体,PR4a):
+ * 启动闸门阻断内容层(StartupBlockedScreen 的白底体系消费变体,PR4a):
  * 品牌视觉由 MobileLoginHandoffStage 宿主拥有,本层背景透明、内容沉到下半屏
- * (避开品牌三要素),仅承载标题/原因/重试。文案 key 化契约不变
- * (endpointGateTitle / endpointGateSubtitle{reason} / retry)。
+ * (避开品牌三要素),仅承载标题/说明/唯一动作。端点闸门与强更闸门共用本层
+ * ——阻断语义一致:没有"跳过 / 稍后再说",只有一个出口。端点错误屏的文案 key 化
+ * 契约不变(endpointGateTitle / endpointGateSubtitle{reason} / retry)。
  */
 function StartupGateBlockedContent({
   title,
   subtitle,
-  retryLabel,
-  onRetry,
+  actionLabel,
+  onAction,
 }: {
   title: string;
   subtitle?: string;
-  retryLabel: string;
-  onRetry: () => void;
+  actionLabel: string;
+  onAction: () => void;
 }) {
   const gateStyles = useThemedStyles(makeGateStyles);
   return (
@@ -427,15 +452,38 @@ function StartupGateBlockedContent({
       {subtitle ? <Text style={gateStyles.subtitle}>{subtitle}</Text> : null}
       <Pressable
         accessibilityRole="button"
-        onPress={onRetry}
+        onPress={onAction}
         style={({ pressed }) => [
           gateStyles.retryButton,
           pressed && gateStyles.retryButtonPressed,
         ]}
       >
-        <Text style={gateStyles.retryLabel}>{retryLabel}</Text>
+        <Text style={gateStyles.retryLabel}>{actionLabel}</Text>
       </Pressable>
     </View>
+  );
+}
+
+/**
+ * 强更闸门内容层:命中 minVersion 门槛时的阻断屏,唯一出口是「去更新」
+ * (iOS 跳 itms-services / App Store,Android 跳应用商店或 APK 直下)。
+ * 复用既有 update.* 文案(forcedTitle / bundleAvailableBody / releaseNotes / goUpdate),
+ * 不新增术语;t() 在此消费,保证语言切换即时生效。
+ */
+function ForcedUpdateGateContent({ target }: { target: ForcedUpdateTarget }) {
+  const { t } = useTranslation();
+  const notes = target.releaseNotes?.trim();
+  const subtitle = [
+    t('update.bundleAvailableBody'),
+    notes ? t('update.releaseNotes', { notes }) : '',
+  ].join('');
+  return (
+    <StartupGateBlockedContent
+      title={t('update.forcedTitle')}
+      subtitle={subtitle}
+      actionLabel={t('update.goUpdate')}
+      onAction={() => openBundleInstall(target)}
+    />
   );
 }
 

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -79,6 +79,8 @@ describe('强更阻断闸门', () => {
     const recheckHook = readCode('src/update/useForcedUpdateRecheck.ts');
     expect(recheckHook).toContain('rechecker.handleTick()');
     expect(recheckHook).toContain('clearInterval(timer)');
+    // 但兜底只在前台敲门:后台定时器仍可能触发,那会白发 /latest(耗电 + 后台网络)。
+    expect(recheckHook).toContain("if (AppState.currentState !== 'active') return;");
     // 在途期间若有更新的观察写入 store,本次旧结论必须作废(compare-and-set)。
     expect(recheck).toContain('const startRevision = deps.getRevision?.();');
     expect(recheck).toContain('deps.onCleared(startRevision)');

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -67,11 +67,12 @@ describe('强更阻断闸门', () => {
     expect(recheck).toContain("return 'error'");
     // 仍强更时必须刷新 target:服务端可能只修正了坏掉的安装地址。
     expect(recheck).toContain('deps.onStillForced(evaluation.target, startRevision)');
-    // 放行决定不能读缓存:/latest 是可变指针,minVersion 会被原地改(set-mobile-min-version),
-    // 同 version 的边缘旧副本证明不了新鲜度,所以核对这条请求必须绕缓存。
-    const recheckHook = read('src/update/useForcedUpdateRecheck.ts');
-    expect(recheckHook).toContain('fetchLatestRelease(');
-    expect(recheckHook).toMatch(/isCanary,\n\s*(\/\/[^\n]*\n\s*)*true,/);
+    // /latest 是可变指针,minVersion 还会被原地改(set-mobile-min-version):边缘旧副本
+    // 两个方向都会错判(旧记录带门槛 → 误挡;旧记录无门槛 → 误放行),所以所有 /latest
+    // 读取都必须绕缓存,不是只有核对这一条。
+    const fetchLatest = readCode('src/update/fetchLatestRelease.ts');
+    expect(fetchLatest).toContain("'cache-control': 'no-cache'");
+    expect(fetchLatest).toContain('&t=${Date.now()}');
     // 在途期间若有更新的观察写入 store,本次旧结论必须作废(compare-and-set)。
     expect(recheck).toContain('const startRevision = deps.getRevision?.();');
     expect(recheck).toContain('deps.onCleared(startRevision)');

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -63,7 +63,9 @@ describe('强更阻断闸门', () => {
     expect(layout).toContain('useForcedUpdateRecheck();');
     // 解除方向 fail-closed:只有成功拉到 /latest 且判定不再强更才解除,
     // 拉取失败 / 记录解析不出 / 拿不到本机 version 一律维持阻断,不能靠断网绕过。
-    expect(recheck).toContain("if (!record || !currentVersion) return 'error';");
+    expect(recheck).toContain(
+      "if (!record || !currentRuntimeVersion || !currentVersion) return 'error';",
+    );
     expect(recheck).toContain("return 'error'");
     // 仍强更时必须刷新 target:服务端可能只修正了坏掉的安装地址。
     expect(recheck).toContain('deps.onStillForced(evaluation.target, startRevision)');

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -67,6 +67,11 @@ describe('强更阻断闸门', () => {
     expect(recheck).toContain("return 'error'");
     // 仍强更时必须刷新 target:服务端可能只修正了坏掉的安装地址。
     expect(recheck).toContain('deps.onStillForced(evaluation.target, startRevision)');
+    // 放行决定不能读缓存:/latest 是可变指针,minVersion 会被原地改(set-mobile-min-version),
+    // 同 version 的边缘旧副本证明不了新鲜度,所以核对这条请求必须绕缓存。
+    const recheckHook = read('src/update/useForcedUpdateRecheck.ts');
+    expect(recheckHook).toContain('fetchLatestRelease(');
+    expect(recheckHook).toMatch(/isCanary,\n\s*(\/\/[^\n]*\n\s*)*true,/);
     // 在途期间若有更新的观察写入 store,本次旧结论必须作废(compare-and-set)。
     expect(recheck).toContain('const startRevision = deps.getRevision?.();');
     expect(recheck).toContain('deps.onCleared(startRevision)');

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -14,6 +14,18 @@ describe('强更阻断闸门', () => {
   const read = (rel: string) =>
     readFileSync(resolve(process.cwd(), rel), 'utf8').replace(/\r\n/g, '\n');
 
+  /**
+   * 去掉行注释与块注释后再断言"某段代码不存在"。
+   * 直接搜关键字会误伤解释这段历史的注释;搜 `{ cancelable:` 又依赖空格写法
+   * (`{cancelable:` 就漏检)。剥注释后按关键字断言,两个问题一起消掉。
+   */
+  const readCode = (rel: string) =>
+    read(rel)
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .map((line) => line.replace(/(^|\s)\/\/.*$/, '$1'))
+      .join('\n');
+
   it('root layout 用 forcedUpdate 状态阻断业务树,唯一出口是「去更新」', () => {
     const layout = read('app/_layout.tsx');
 
@@ -32,14 +44,27 @@ describe('强更阻断闸门', () => {
 
   it('强更路径不再走 Alert:promptBundleUpdate 直接进入阻断态', () => {
     const prompt = read('src/update/useBundleUpdatePrompt.ts');
+    const promptCode = readCode('src/update/useBundleUpdatePrompt.ts');
 
     expect(prompt).toContain('enterForcedUpdate(evaluation.target)');
-    // 不可取消弹窗是被替换掉的旧实现,不允许回归(匹配 Alert 的 options 对象写法,
-    // 不误伤注释里解释这段历史的文字)。
-    expect(prompt).not.toContain('{ cancelable:');
-    expect(prompt).not.toContain("i18n.t('update.forcedTitle')");
+    // 不可取消弹窗是被替换掉的旧实现,不允许以任何写法回归。
+    expect(promptCode).not.toMatch(/cancelable/);
+    expect(promptCode).not.toContain("i18n.t('update.forcedTitle')");
     // 拿不到安装地址时不得进入阻断态(否则把用户关进没有出口的屏)。
     expect(prompt).toContain('if (!url) return;');
+  });
+
+  it('阻断屏自带回前台重新核对:服务端撤回门槛后不必杀进程', () => {
+    const layout = read('app/_layout.tsx');
+    const recheck = read('src/update/forcedUpdateRecheck.ts');
+
+    // 阻断期间业务树不挂载 → resume 通道停摆,恢复入口必须挂在阻断屏自己身上。
+    expect(layout).toContain("from '@/update/useForcedUpdateRecheck'");
+    expect(layout).toContain('useForcedUpdateRecheck();');
+    // 解除方向 fail-closed:只有成功拉到 /latest 且判定不再强更才解除,
+    // 拉取失败维持阻断,不能靠断网 / 飞行模式绕过。
+    expect(recheck).toContain('if (evaluation.forced) return \'still-forced\';');
+    expect(recheck).toContain("return 'error'");
   });
 
   it('阻断态只存内存,不持久化(服务端撤回门槛后用户不能被本地缓存锁死)', () => {

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -62,9 +62,11 @@ describe('强更阻断闸门', () => {
     expect(layout).toContain("from '@/update/useForcedUpdateRecheck'");
     expect(layout).toContain('useForcedUpdateRecheck();');
     // 解除方向 fail-closed:只有成功拉到 /latest 且判定不再强更才解除,
-    // 拉取失败维持阻断,不能靠断网 / 飞行模式绕过。
-    expect(recheck).toContain('if (evaluation.forced) return \'still-forced\';');
+    // 拉取失败 / 记录解析不出 / 拿不到本机 version 一律维持阻断,不能靠断网绕过。
+    expect(recheck).toContain("if (!record || !currentVersion) return 'error';");
     expect(recheck).toContain("return 'error'");
+    // 仍强更时必须刷新 target:服务端可能只修正了坏掉的安装地址。
+    expect(recheck).toContain('deps.onStillForced(evaluation.target)');
   });
 
   it('阻断态只存内存,不持久化(服务端撤回门槛后用户不能被本地缓存锁死)', () => {

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * 强更阻断契约(读源码断言)。
+ *
+ * 回归背景:强更曾经是一个 `cancelable: false` 的单按钮 Alert —— 但 RN Alert 的按钮
+ * 点一下就关(cancelable 只挡点外部 / 返回键),弹窗消失后底下的 App 照旧可用,且模块级
+ * 去重让本进程内不再弹。那是"强提醒"而非"强制"。现在强更必须是 root 层的阻断屏:
+ * 命中门槛就不挂业务树。
+ */
+describe('强更阻断闸门', () => {
+  const read = (rel: string) =>
+    readFileSync(resolve(process.cwd(), rel), 'utf8').replace(/\r\n/g, '\n');
+
+  it('root layout 用 forcedUpdate 状态阻断业务树,唯一出口是「去更新」', () => {
+    const layout = read('app/_layout.tsx');
+
+    expect(layout).toContain("from '@/update/forcedUpdateStore'");
+    expect(layout).toContain('const forcedUpdate = useForcedUpdate();');
+    // 阻断分支必须先于 ready 分支(ready 才会挂 RootAfterEndpoints 业务树)。
+    expect(layout.indexOf('} else if (forcedUpdate) {')).toBeGreaterThan(0);
+    expect(layout.indexOf('} else if (forcedUpdate) {')).toBeLessThan(
+      layout.indexOf('body = <RootAfterEndpoints />;'),
+    );
+    expect(layout).toContain('<ForcedUpdateGateContent target={forcedUpdate} />');
+    expect(layout).toContain("actionLabel={t('update.goUpdate')}");
+    // 阻断屏不得有"稍后 / 跳过"出口。
+    expect(layout).not.toContain('update.later');
+  });
+
+  it('强更路径不再走 Alert:promptBundleUpdate 直接进入阻断态', () => {
+    const prompt = read('src/update/useBundleUpdatePrompt.ts');
+
+    expect(prompt).toContain('enterForcedUpdate(evaluation.target)');
+    // 不可取消弹窗是被替换掉的旧实现,不允许回归(匹配 Alert 的 options 对象写法,
+    // 不误伤注释里解释这段历史的文字)。
+    expect(prompt).not.toContain('{ cancelable:');
+    expect(prompt).not.toContain("i18n.t('update.forcedTitle')");
+    // 拿不到安装地址时不得进入阻断态(否则把用户关进没有出口的屏)。
+    expect(prompt).toContain('if (!url) return;');
+  });
+
+  it('阻断态只存内存,不持久化(服务端撤回门槛后用户不能被本地缓存锁死)', () => {
+    const store = read('src/update/forcedUpdateStore.ts');
+
+    // 与 otaReloadGuard 的关键区别:那是防故障循环、必须落盘计数并自带放弃条件;
+    // 这是产品意图的阻断,不落盘本身就是自愈路径。
+    expect(store).not.toContain('AsyncStorage');
+    expect(store).toContain('export function enterForcedUpdate');
+  });
+});

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -66,7 +66,10 @@ describe('强更阻断闸门', () => {
     expect(recheck).toContain("if (!record || !currentVersion) return 'error';");
     expect(recheck).toContain("return 'error'");
     // 仍强更时必须刷新 target:服务端可能只修正了坏掉的安装地址。
-    expect(recheck).toContain('deps.onStillForced(evaluation.target)');
+    expect(recheck).toContain('deps.onStillForced(evaluation.target, startRevision)');
+    // 在途期间若有更新的观察写入 store,本次旧结论必须作废(compare-and-set)。
+    expect(recheck).toContain('const startRevision = deps.getRevision?.();');
+    expect(recheck).toContain('deps.onCleared(startRevision)');
   });
 
   it('阻断态只存内存,不持久化(服务端撤回门槛后用户不能被本地缓存锁死)', () => {

--- a/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
+++ b/apps/mobile/src/__tests__/forcedUpdateGate.test.ts
@@ -75,6 +75,10 @@ describe('强更阻断闸门', () => {
     const fetchLatest = readCode('src/update/fetchLatestRelease.ts');
     expect(fetchLatest).toContain("'cache-control': 'no-cache'");
     expect(fetchLatest).toContain('&t=${Date.now()}');
+    // 光靠 AppState 跳变不够:用户停在阻断屏上不动时没有任何跳变,必须有定时兜底。
+    const recheckHook = readCode('src/update/useForcedUpdateRecheck.ts');
+    expect(recheckHook).toContain('rechecker.handleTick()');
+    expect(recheckHook).toContain('clearInterval(timer)');
     // 在途期间若有更新的观察写入 store,本次旧结论必须作废(compare-and-set)。
     expect(recheck).toContain('const startRevision = deps.getRevision?.();');
     expect(recheck).toContain('deps.onCleared(startRevision)');

--- a/apps/mobile/src/__tests__/startupSplashOverlay.test.ts
+++ b/apps/mobile/src/__tests__/startupSplashOverlay.test.ts
@@ -21,9 +21,11 @@ describe("startup splash overlay", () => {
     const layout = read("app/_layout.tsx");
 
     expect(layout).toContain("from '@/components/StartupSplashOverlay'");
-    expect(layout).toContain(
-      "<StartupSplashOverlay hidden={endpointGate.status === 'error'}>",
-    );
+    // 常驻实例只能有一个;需要用户交互的闸门屏才隐藏它(端点错误 / 强更阻断)。
+    // 这里不锁死整个表达式字面量,避免后续增删闸门时连带改断言。
+    expect(layout.match(/<StartupSplashOverlay/g)).toHaveLength(1);
+    expect(layout).toMatch(/hidden=\{endpointGate\.status === 'error'/);
+    expect(layout).toMatch(/hidden=\{[^}]*forcedUpdate !== null\}/);
     // 闸门链各关不许再各自渲染 splash 实例(splash-preview 路由是唯一例外)。
     expect(layout).not.toContain('variant="splash"');
   });

--- a/apps/mobile/src/auth/__tests__/loginHandoffState.test.ts
+++ b/apps/mobile/src/auth/__tests__/loginHandoffState.test.ts
@@ -214,7 +214,9 @@ describe('loginHandoff 接线(Provider/reporter 拓扑 + 清理,读源码断言)
 
   it('gate 屏内容层退化:endpoint error 层可交互 retry(错误层文案 key 化不变)', () => {
     expect(layoutSource).toContain('<MobileLoginHandoffStage>');
-    expect(layoutSource).toContain('onRetry={endpointGate.retry}');
+    // 内容层的动作 prop 已从 retry 专用改为通用 action(端点重试 / 强更去更新共用同一层),
+    // 端点错误屏的接线与文案 key 化契约不变。
+    expect(layoutSource).toContain('onAction={endpointGate.retry}');
     expect(layoutSource).toContain("loginText('endpointGateTitle')");
   });
 

--- a/apps/mobile/src/update/bundleUpdate.test.ts
+++ b/apps/mobile/src/update/bundleUpdate.test.ts
@@ -88,6 +88,40 @@ describe('evaluateBundleUpdate', () => {
     expect(r.forced).toBe(false);
   });
 
+  it('runtimeVersion 相同但低于 minVersion → 仍然强更(门槛不经指纹门闸)', () => {
+    // 服务端可以对某个已发布版本事后下发门槛;此时装机指纹与 /latest 一致,但 version
+    // 低于门槛 —— 必须命中强更,否则发布链写了 minVersion 也拦不住同指纹的旧构建。
+    const r = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-new',
+      currentVersion: '1.0.0',
+      latest: { ...VALID, minVersion: '1.2.0' },
+    });
+    expect(r.needsUpdate).toBe(true);
+    expect(r.forced).toBe(true);
+    // 同指纹强更时 target.runtimeVersion 就等于当前值,消费方不得据此判断"换了指纹"。
+    expect(r.target?.runtimeVersion).toBe('rtv-new');
+  });
+
+  it('runtimeVersion 相同且不低于 minVersion → 无更新', () => {
+    const r = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-new',
+      currentVersion: '1.2.0',
+      latest: { ...VALID, minVersion: '1.2.0' },
+    });
+    expect(r.needsUpdate).toBe(false);
+    expect(r.target).toBeNull();
+  });
+
+  it('缺 currentVersion → 不强更(无法比较,fail-open)', () => {
+    const r = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-new',
+      currentVersion: null,
+      latest: { ...VALID, minVersion: '1.2.0' },
+    });
+    expect(r.needsUpdate).toBe(false);
+    expect(r.forced).toBe(false);
+  });
+
   it('拿不到当前 runtimeVersion(dev / 未启用)→ 无更新', () => {
     expect(evaluateBundleUpdate({ currentRuntimeVersion: null, currentVersion: '1.0.0', latest: VALID }).needsUpdate).toBe(false);
     expect(evaluateBundleUpdate({ currentRuntimeVersion: '', currentVersion: '1.0.0', latest: VALID }).needsUpdate).toBe(false);

--- a/apps/mobile/src/update/bundleUpdate.test.ts
+++ b/apps/mobile/src/update/bundleUpdate.test.ts
@@ -124,6 +124,26 @@ describe('evaluateBundleUpdate', () => {
     expect(r.needsUpdate).toBe(true); // runtimeVersion 不同 → 仍是可跳过的普通更新
   });
 
+  it('minVersion 高于该记录自己的 version → 不强更(装完仍低于门槛,阻断屏会没有出口)', () => {
+    // 发布链侧 assertMinVersionUsable 已禁止这种记录;客户端兜底手工改过 / 历史遗留的指针。
+    const r = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion: '1.0.0',
+      latest: { ...VALID, version: '1.1.0', minVersion: '1.2.0' },
+    });
+    expect(r.forced).toBe(false);
+    expect(r.needsUpdate).toBe(true); // 仍是可跳过的普通更新
+  });
+
+  it('minVersion 等于该记录的 version → 正常强更(边界)', () => {
+    const r = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion: '1.0.0',
+      latest: { ...VALID, version: '1.2.0', minVersion: '1.2.0' },
+    });
+    expect(r.forced).toBe(true);
+  });
+
   it('缺 currentVersion → 不强更(无法比较,fail-open)', () => {
     const r = evaluateBundleUpdate({
       currentRuntimeVersion: 'rtv-new',

--- a/apps/mobile/src/update/bundleUpdate.test.ts
+++ b/apps/mobile/src/update/bundleUpdate.test.ts
@@ -112,6 +112,18 @@ describe('evaluateBundleUpdate', () => {
     expect(r.target).toBeNull();
   });
 
+  it('record 缺 version 但带 minVersion → 不强更(退化成普通提示,不造无法自愈的阻断)', () => {
+    // 无目标版本就无法证明"装上它能解除阻断",阻断态的自愈也失去比较基准。
+    // 发布链侧 assertMinVersionUsable 已保证有 minVersion 必有 version,这里是客户端兜底。
+    const r = evaluateBundleUpdate({
+      currentRuntimeVersion: 'rtv-old',
+      currentVersion: '1.0.0',
+      latest: { ...VALID, version: '', minVersion: '1.2.0' },
+    });
+    expect(r.forced).toBe(false);
+    expect(r.needsUpdate).toBe(true); // runtimeVersion 不同 → 仍是可跳过的普通更新
+  });
+
   it('缺 currentVersion → 不强更(无法比较,fail-open)', () => {
     const r = evaluateBundleUpdate({
       currentRuntimeVersion: 'rtv-new',

--- a/apps/mobile/src/update/bundleUpdate.ts
+++ b/apps/mobile/src/update/bundleUpdate.ts
@@ -120,8 +120,13 @@ export function evaluateBundleUpdate({
   const current = String(currentRuntimeVersion ?? '').trim();
   if (!current) return NO_UPDATE;
 
+  // 强更额外要求 record 自己带 version:拿不到目标版本就无法证明"装上它就能解除阻断"
+  // (阻断态的自愈全靠这个可比较的版本:见 forcedUpdateRecheck 的新鲜度门)。
+  // 发布链侧 assertMinVersionUsable 已保证"有 minVersion 必有 version",这里是客户端兜底:
+  // 记录异常时退化成可跳过的普通更新提示,而不是把用户关进一个无法自愈的阻断屏。
   const forced = Boolean(
     record.minVersion &&
+    record.version &&
     currentVersion &&
     compareVersions(String(currentVersion), record.minVersion) < 0,
   );

--- a/apps/mobile/src/update/bundleUpdate.ts
+++ b/apps/mobile/src/update/bundleUpdate.ts
@@ -6,6 +6,8 @@
 //     · latest.runtimeVersion === 当前 runtimeVersion → 无需整包(JS OTA 通道会处理);
 //     · 不同 → 原生层变了,JS OTA 覆盖不到 → 引导用户打开 release record 的正常安装入口。
 // - minVersion(可选)用于强制更新:当前 version 低于它则阻断使用、只留"去更新"。
+//   强更判定**不经过 runtimeVersion 门闸**:门槛由服务端按 version 下发,同 runtimeVersion
+//   的旧构建也必须能被强更(否则"发布链写了 minVersion 却对同指纹装机无效")。
 
 /** mobile-update-server `/latest` 返回的整包版本记录(release.json 透传)。 */
 export interface LatestReleaseRecord {
@@ -98,8 +100,14 @@ export function compareVersions(a: string, b: string): number {
 }
 
 /**
- * 判定是否需要引导整包更新。核心信号是 runtimeVersion 不一致。
- * 拿不到当前 runtimeVersion(dev / expo-updates 未启用)或 `/latest` 无效 → 一律视为无更新。
+ * 判定是否需要引导整包更新。两条独立信号:
+ * - runtimeVersion 不一致 → 有整包更新(可跳过的普通提示);
+ * - 当前 version < minVersion → 强更,**与 runtimeVersion 是否一致无关**。
+ *   服务端可以对某个已发布版本事后下发门槛,把同指纹的问题构建也挡住;
+ *   反过来说,同 runtimeVersion 命中强更时 target.runtimeVersion 就等于当前值,
+ *   消费方不得把它当作"换了指纹"的证据。
+ * 拿不到当前 runtimeVersion(dev / expo-updates 未启用)、拿不到当前 version 或
+ * `/latest` 无效 → 一律视为无更新(比不出来就不挡人,fail-open)。
  */
 export function evaluateBundleUpdate({
   currentRuntimeVersion,
@@ -112,13 +120,13 @@ export function evaluateBundleUpdate({
   const current = String(currentRuntimeVersion ?? '').trim();
   if (!current) return NO_UPDATE;
 
-  if (record.runtimeVersion === current) return NO_UPDATE;
-
   const forced = Boolean(
     record.minVersion &&
     currentVersion &&
     compareVersions(String(currentVersion), record.minVersion) < 0,
   );
+
+  if (!forced && record.runtimeVersion === current) return NO_UPDATE;
 
   return {
     needsUpdate: true,

--- a/apps/mobile/src/update/bundleUpdate.ts
+++ b/apps/mobile/src/update/bundleUpdate.ts
@@ -120,15 +120,19 @@ export function evaluateBundleUpdate({
   const current = String(currentRuntimeVersion ?? '').trim();
   if (!current) return NO_UPDATE;
 
-  // 强更额外要求 record 自己带 version:拿不到目标版本就无法证明"装上它就能解除阻断"
-  // (阻断态的自愈全靠这个可比较的版本:见 forcedUpdateRecheck 的新鲜度门)。
-  // 发布链侧 assertMinVersionUsable 已保证"有 minVersion 必有 version",这里是客户端兜底:
-  // 记录异常时退化成可跳过的普通更新提示,而不是把用户关进一个无法自愈的阻断屏。
+  // 强更要求这条记录本身**能被满足**:
+  // - 带 version:拿不到目标版本就无法证明"装上它就能解除阻断"(阻断态自愈全靠这个
+  //   可比较的版本,见 forcedUpdateRecheck 的新鲜度门);
+  // - minVersion ≤ version:否则唯一提供的安装目标仍低于门槛,用户装完照旧被强更,
+  //   阻断屏成了没有出口的死屋,只能等运维改指针。
+  // 发布链侧 assertMinVersionUsable 已经保证这两条,这里是客户端兜底(手工改过的 / 历史
+  // 遗留的指针也不能把人关死):记录不自洽时退化成可跳过的普通更新提示。
   const forced = Boolean(
     record.minVersion &&
     record.version &&
     currentVersion &&
-    compareVersions(String(currentVersion), record.minVersion) < 0,
+    compareVersions(String(currentVersion), record.minVersion) < 0 &&
+    compareVersions(record.version, record.minVersion) >= 0,
   );
 
   if (!forced && record.runtimeVersion === current) return NO_UPDATE;

--- a/apps/mobile/src/update/fetchLatestRelease.test.ts
+++ b/apps/mobile/src/update/fetchLatestRelease.test.ts
@@ -37,6 +37,24 @@ describe('fetchLatestRelease —— 区分"无更新"与"连不上"', () => {
     );
   });
 
+  it('noCache=true → 追加 cache-buster + no-cache 头(放行决定不能读边缘旧记录)', async () => {
+    const fetchMock = vi.fn(async () => resp(200, { runtimeVersion: 'rtv1' }));
+    vi.stubGlobal('fetch', fetchMock);
+    await fetchLatestRelease('ios', 8000, BASE, false, true);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toMatch(new RegExp(`^${BASE}/latest\\?platform=ios&t=\\d+$`));
+    expect(init.headers).toMatchObject({ 'cache-control': 'no-cache' });
+  });
+
+  it('默认不绕缓存:常规路径的 URL 与请求头保持旧契约', async () => {
+    const fetchMock = vi.fn(async () => resp(200, { runtimeVersion: 'rtv1' }));
+    vi.stubGlobal('fetch', fetchMock);
+    await fetchLatestRelease('ios', 8000, BASE);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`${BASE}/latest?platform=ios`);
+    expect(init.headers).toEqual({ accept: 'application/json' });
+  });
+
   it('404(服务端确认暂无记录)→ null(= 无更新)', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => resp(404)));
     await expect(fetchLatestRelease('ios', 8000, BASE)).resolves.toBeNull();

--- a/apps/mobile/src/update/fetchLatestRelease.test.ts
+++ b/apps/mobile/src/update/fetchLatestRelease.test.ts
@@ -12,6 +12,18 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+/**
+ * 断言请求 URL = 期望前缀 + `&t=<时间戳>`。
+ * 刻意不用 `new RegExp` 拼含 host 的字符串:URL 里的 `.` 在正则里是通配,
+ * 会匹配到别的主机(CodeQL js/incomplete-hostname-regexp)。
+ */
+function expectCacheBustedUrl(url: unknown, prefix: string): void {
+  expect(typeof url).toBe('string');
+  const bustPrefix = `${prefix}&t=`;
+  expect(String(url).startsWith(bustPrefix)).toBe(true);
+  expect(String(url).slice(bustPrefix.length)).toMatch(/^\d+$/);
+}
+
 describe('fetchLatestRelease —— 区分"无更新"与"连不上"', () => {
   it('非自建变体(baseUrl 为空)→ null,不发请求', async () => {
     const fetchMock = vi.fn();
@@ -24,22 +36,16 @@ describe('fetchLatestRelease —— 区分"无更新"与"连不上"', () => {
     const fetchMock = vi.fn(async () => resp(200, { runtimeVersion: 'rtv1', version: '1.2.0' }));
     vi.stubGlobal('fetch', fetchMock);
     await expect(fetchLatestRelease('ios', 8000, BASE)).resolves.toEqual({ runtimeVersion: 'rtv1', version: '1.2.0' });
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringMatching(new RegExp(`^${BASE}/latest\\?platform=ios&t=\\d+$`)),
-      expect.any(Object),
-    );
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expectCacheBustedUrl(url, `${BASE}/latest?platform=ios`);
   });
 
   it('canary 显式追加 channel，stable URL 保持旧契约', async () => {
     const fetchMock = vi.fn(async () => resp(200, { runtimeVersion: 'rtv1' }));
     vi.stubGlobal('fetch', fetchMock);
     await fetchLatestRelease('android', 8000, BASE, true);
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringMatching(
-        new RegExp(`^${BASE}/latest\\?platform=android&channel=canary&t=\\d+$`),
-      ),
-      expect.any(Object),
-    );
+    const [url] = fetchMock.mock.calls[0] as unknown as [string];
+    expectCacheBustedUrl(url, `${BASE}/latest?platform=android&channel=canary`);
   });
 
   it('一律绕缓存:每次请求都带 cache-buster + no-cache 头', async () => {
@@ -49,7 +55,7 @@ describe('fetchLatestRelease —— 区分"无更新"与"连不上"', () => {
     vi.stubGlobal('fetch', fetchMock);
     await fetchLatestRelease('ios', 8000, BASE);
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-    expect(url).toMatch(new RegExp(`^${BASE}/latest\\?platform=ios&t=\\d+$`));
+    expectCacheBustedUrl(url, `${BASE}/latest?platform=ios`);
     expect(init.headers).toEqual({ accept: 'application/json', 'cache-control': 'no-cache' });
   });
 

--- a/apps/mobile/src/update/fetchLatestRelease.test.ts
+++ b/apps/mobile/src/update/fetchLatestRelease.test.ts
@@ -24,7 +24,10 @@ describe('fetchLatestRelease —— 区分"无更新"与"连不上"', () => {
     const fetchMock = vi.fn(async () => resp(200, { runtimeVersion: 'rtv1', version: '1.2.0' }));
     vi.stubGlobal('fetch', fetchMock);
     await expect(fetchLatestRelease('ios', 8000, BASE)).resolves.toEqual({ runtimeVersion: 'rtv1', version: '1.2.0' });
-    expect(fetchMock).toHaveBeenCalledWith(`${BASE}/latest?platform=ios`, expect.any(Object));
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(new RegExp(`^${BASE}/latest\\?platform=ios&t=\\d+$`)),
+      expect.any(Object),
+    );
   });
 
   it('canary 显式追加 channel，stable URL 保持旧契约', async () => {
@@ -32,27 +35,22 @@ describe('fetchLatestRelease —— 区分"无更新"与"连不上"', () => {
     vi.stubGlobal('fetch', fetchMock);
     await fetchLatestRelease('android', 8000, BASE, true);
     expect(fetchMock).toHaveBeenCalledWith(
-      `${BASE}/latest?platform=android&channel=canary`,
+      expect.stringMatching(
+        new RegExp(`^${BASE}/latest\\?platform=android&channel=canary&t=\\d+$`),
+      ),
       expect.any(Object),
     );
   });
 
-  it('noCache=true → 追加 cache-buster + no-cache 头(放行决定不能读边缘旧记录)', async () => {
-    const fetchMock = vi.fn(async () => resp(200, { runtimeVersion: 'rtv1' }));
-    vi.stubGlobal('fetch', fetchMock);
-    await fetchLatestRelease('ios', 8000, BASE, false, true);
-    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-    expect(url).toMatch(new RegExp(`^${BASE}/latest\\?platform=ios&t=\\d+$`));
-    expect(init.headers).toMatchObject({ 'cache-control': 'no-cache' });
-  });
-
-  it('默认不绕缓存:常规路径的 URL 与请求头保持旧契约', async () => {
+  it('一律绕缓存:每次请求都带 cache-buster + no-cache 头', async () => {
+    // 可变指针 + 原地改 minVersion:边缘旧副本两个方向都会错判(误挡 / 误放行),
+    // 所以四条调用路径统一不吃缓存。
     const fetchMock = vi.fn(async () => resp(200, { runtimeVersion: 'rtv1' }));
     vi.stubGlobal('fetch', fetchMock);
     await fetchLatestRelease('ios', 8000, BASE);
     const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-    expect(url).toBe(`${BASE}/latest?platform=ios`);
-    expect(init.headers).toEqual({ accept: 'application/json' });
+    expect(url).toMatch(new RegExp(`^${BASE}/latest\\?platform=ios&t=\\d+$`));
+    expect(init.headers).toEqual({ accept: 'application/json', 'cache-control': 'no-cache' });
   });
 
   it('404(服务端确认暂无记录)→ null(= 无更新)', async () => {

--- a/apps/mobile/src/update/fetchLatestRelease.ts
+++ b/apps/mobile/src/update/fetchLatestRelease.ts
@@ -10,30 +10,28 @@ const DEFAULT_TIMEOUT_MS = 8000;
  * - 网络失败 / 超时 / 5xx 等服务异常 → **抛错**(连不上,调用方需区分于"无更新",
  *   否则手动检查会误报"已是最新")。
  * baseUrl 可注入,便于单测。
+ *
+ * **一律绕开缓存**(cache-buster + no-cache 头,与发布链侧读同一指针的 fetchJsonPointer
+ * 同口径):`/latest` 背后是可变指针,`minVersion` 还会被原地改(set-mobile-min-version
+ * 读改写同一个 key),边缘旧副本会造成两个方向的错判 —— 旧记录还带门槛时把用户**误挡**在
+ * 强更闸门外,旧记录没门槛时又把该挡的用户**放行**。两者都不可接受,所以四条调用路径
+ * (启动 / resume / 设置页 / 阻断屏核对)统一不吃缓存,代价只是每次多一个小 JSON 请求。
  * @param platform 目标平台(默认 ios)
- * @param noCache 绕开缓存(cache-buster + no-cache 头)。`/latest` 背后是**可变指针**,
- *   边缘缓存可能返回旧记录 —— 判定"是否还需要强更"这类**放行**决定不能建立在旧记录上
- *   (发布链侧读同一指针的 fetchJsonPointer 一直是这么做的)。默认 false:启动 / resume /
- *   设置页三条常规路径的缓存行为保持不变,它们读到旧记录最多是少提示一次更新。
  */
 export async function fetchLatestRelease(
   platform = 'ios',
   timeoutMs = DEFAULT_TIMEOUT_MS,
   baseUrl = OTA_SERVER_BASE_URL,
   isCanary = false,
-  noCache = false,
 ): Promise<unknown | null> {
   if (!baseUrl) return null; // 非自建变体,无自托管服务
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const channelQuery = isCanary ? '&channel=canary' : '';
-    const cacheQuery = noCache ? `&t=${Date.now()}` : '';
-    const res = await fetch(`${baseUrl}/latest?platform=${encodeURIComponent(platform)}${channelQuery}${cacheQuery}`, {
+    const res = await fetch(`${baseUrl}/latest?platform=${encodeURIComponent(platform)}${channelQuery}&t=${Date.now()}`, {
       signal: controller.signal,
-      headers: noCache
-        ? { accept: 'application/json', 'cache-control': 'no-cache' }
-        : { accept: 'application/json' },
+      headers: { accept: 'application/json', 'cache-control': 'no-cache' },
     });
     if (res.status === 404) return null; // 服务端确认暂无记录 = 无更新
     if (!res.ok) throw new Error(i18n.t('update.latestRequestFailed', { status: res.status })); // 5xx 等服务异常,不能当成"无更新"

--- a/apps/mobile/src/update/fetchLatestRelease.ts
+++ b/apps/mobile/src/update/fetchLatestRelease.ts
@@ -11,21 +11,29 @@ const DEFAULT_TIMEOUT_MS = 8000;
  *   否则手动检查会误报"已是最新")。
  * baseUrl 可注入,便于单测。
  * @param platform 目标平台(默认 ios)
+ * @param noCache 绕开缓存(cache-buster + no-cache 头)。`/latest` 背后是**可变指针**,
+ *   边缘缓存可能返回旧记录 —— 判定"是否还需要强更"这类**放行**决定不能建立在旧记录上
+ *   (发布链侧读同一指针的 fetchJsonPointer 一直是这么做的)。默认 false:启动 / resume /
+ *   设置页三条常规路径的缓存行为保持不变,它们读到旧记录最多是少提示一次更新。
  */
 export async function fetchLatestRelease(
   platform = 'ios',
   timeoutMs = DEFAULT_TIMEOUT_MS,
   baseUrl = OTA_SERVER_BASE_URL,
   isCanary = false,
+  noCache = false,
 ): Promise<unknown | null> {
   if (!baseUrl) return null; // 非自建变体,无自托管服务
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const channelQuery = isCanary ? '&channel=canary' : '';
-    const res = await fetch(`${baseUrl}/latest?platform=${encodeURIComponent(platform)}${channelQuery}`, {
+    const cacheQuery = noCache ? `&t=${Date.now()}` : '';
+    const res = await fetch(`${baseUrl}/latest?platform=${encodeURIComponent(platform)}${channelQuery}${cacheQuery}`, {
       signal: controller.signal,
-      headers: { accept: 'application/json' },
+      headers: noCache
+        ? { accept: 'application/json', 'cache-control': 'no-cache' }
+        : { accept: 'application/json' },
     });
     if (res.status === 404) return null; // 服务端确认暂无记录 = 无更新
     if (!res.ok) throw new Error(i18n.t('update.latestRequestFailed', { status: res.status })); // 5xx 等服务异常,不能当成"无更新"

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -171,6 +171,44 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     }), 7);
   });
 
+  it('读到比阻断目标更旧的记录(CDN 边缘旧值)→ 维持阻断,不解除', async () => {
+    // /latest 背后是可变指针且请求不带 cache-buster,边缘可能回一条旧记录;
+    // 旧记录没有 minVersion,若照它解除就会把仍需强更的用户放进业务树。
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ version: '1.5.0', minVersion: undefined })),
+      getHeldTarget: () => ({ version: '2.0.0' }),
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
+  });
+
+  it('记录缺 version → 证明不了新鲜度,维持阻断', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ version: '', minVersion: undefined })),
+      getHeldTarget: () => ({ version: '2.0.0' }),
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
+  it('同版本记录撤回门槛(最常见的撤回形态)→ 正常解除', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ version: '2.0.0', minVersion: undefined })),
+      getHeldTarget: () => ({ version: '2.0.0' }),
+    });
+    await expect(runOnce(deps)).resolves.toBe('cleared');
+    expect(deps.onCleared).toHaveBeenCalledOnce();
+  });
+
+  it('更新版本的记录且不再强更 → 正常解除', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ version: '2.1.0', minVersion: undefined })),
+      getHeldTarget: () => ({ version: '2.0.0' }),
+    });
+    await expect(runOnce(deps)).resolves.toBe('cleared');
+  });
+
   it('/latest 拉取失败 → 维持阻断(不能靠断网绕过强更)', async () => {
     const deps = makeDeps({ fetchLatest: vi.fn(async () => { throw new Error('offline'); }) });
     await expect(runOnce(deps)).resolves.toBe('error');

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -220,15 +220,16 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     expect(deps.onStillForced).not.toHaveBeenCalled();
   });
 
-  it('阻断目标本身缺 version → 证明不了新鲜度,维持阻断', async () => {
-    // 触发阻断的那条记录可能没写 version(parseLatestRelease 容许空串),此时任何
-    // 带正常 version 的旧记录都会"看起来更新",不能据此放行。
+  it('阻断目标缺 version(理论不可达)→ 不做版本比较,也不死锁', async () => {
+    // evaluateBundleUpdate 要求 record 带 version 才判 forced,所以正常路径下 held.version
+    // 必然非空。万一为空,也不能靠"维持阻断"兜着 —— 那会把用户永久钉在阻断屏上,
+    // 定时与回前台核对都过不去。此时退化成无新鲜度约束,照常评估门槛。
     const deps = makeDeps({
       fetchLatest: vi.fn(async () => latestRecord({ version: '1.5.0', minVersion: undefined })),
       getHeldTarget: () => ({ version: '' }),
     });
-    await expect(runOnce(deps)).resolves.toBe('error');
-    expect(deps.onCleared).not.toHaveBeenCalled();
+    await expect(runOnce(deps)).resolves.toBe('cleared');
+    expect(deps.onCleared).toHaveBeenCalledOnce();
   });
 
   it('记录缺 version → 证明不了新鲜度,维持阻断', async () => {

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -25,6 +25,7 @@ function makeDeps(overrides: Partial<ForcedUpdateRecheckDeps> = {}) {
     getCurrentVersion: () => '1.0.0',
     onCleared: vi.fn(),
     onStillForced: vi.fn(),
+    getRevision: () => 7,
     now: () => nowMs,
     advance: (ms: number) => { nowMs += ms; },
     ...overrides,
@@ -128,6 +129,23 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     expect(deps.onStillForced).toHaveBeenCalledOnce();
   });
 
+  it('落地时回传发起时的 revision(compare-and-set 的依据)', async () => {
+    // 发起后 store 被更新的观察改写时,revision 会变;这里断言回传的是**发起时**读到的值。
+    let rev = 7;
+    const deps = makeDeps({
+      getRevision: () => rev,
+      fetchLatest: vi.fn(async () => { rev = 9; return latestRecord({ minVersion: undefined }); }),
+    });
+    await expect(runOnce(deps)).resolves.toBe('cleared');
+    expect(deps.onCleared).toHaveBeenCalledWith(7);
+  });
+
+  it('仍强更时刷新 target 也带上发起时的 revision', async () => {
+    const deps = makeDeps();
+    await expect(runOnce(deps)).resolves.toBe('still-forced');
+    expect(deps.onStillForced).toHaveBeenCalledWith(expect.objectContaining({ version: '2.0.0' }), 7);
+  });
+
   it('门槛仍在但服务端修正了安装地址 → 刷新 target(否则按钮一直打开旧链接)', async () => {
     const deps = makeDeps({
       fetchLatest: vi.fn(async () => latestRecord({
@@ -139,7 +157,7 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     expect(deps.onStillForced).toHaveBeenCalledWith(expect.objectContaining({
       installUrl: 'https://cdn.example/fixed',
       itmsUrl: 'itms-services://?action=download-manifest&url=https://cdn.example/fixed.plist',
-    }));
+    }), 7);
   });
 
   it('门槛仍在且换了更高的强更目标 → 刷新 target', async () => {
@@ -150,7 +168,7 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     expect(deps.onStillForced).toHaveBeenCalledWith(expect.objectContaining({
       version: '3.0.0',
       runtimeVersion: '3',
-    }));
+    }), 7);
   });
 
   it('/latest 拉取失败 → 维持阻断(不能靠断网绕过强更)', async () => {

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -220,6 +220,24 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     await expect(runOnce(deps)).resolves.toBe('cleared');
   });
 
+  it('服务端 404(整包记录被撤下)→ 解除阻断(冷启动同样不会阻断,运行中不该更严)', async () => {
+    // fetchLatestRelease 只在 404 时返回 null(网络 / 5xx 都抛错),这是服务端明确声明
+    // "该平台当前没有整包记录" —— 记录不存在,门槛也不存在。
+    const deps = makeDeps({ fetchLatest: vi.fn(async () => null) });
+    await expect(runOnce(deps)).resolves.toBe('cleared');
+    expect(deps.onCleared).toHaveBeenCalledWith(7);
+  });
+
+  it('拿不到本机 runtimeVersion → 维持阻断(不能靠 expo-updates 异常绕过)', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ minVersion: undefined })),
+      getCurrentRuntimeVersion: () => null,
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
+  });
+
   it('/latest 拉取失败 → 维持阻断(不能靠断网绕过强更)', async () => {
     const deps = makeDeps({ fetchLatest: vi.fn(async () => { throw new Error('offline'); }) });
     await expect(runOnce(deps)).resolves.toBe('error');

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -24,6 +24,7 @@ function makeDeps(overrides: Partial<ForcedUpdateRecheckDeps> = {}) {
     getCurrentRuntimeVersion: () => '1',
     getCurrentVersion: () => '1.0.0',
     onCleared: vi.fn(),
+    onStillForced: vi.fn(),
     now: () => nowMs,
     advance: (ms: number) => { nowMs += ms; },
     ...overrides,
@@ -86,22 +87,50 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     expect(deps.onCleared).toHaveBeenCalledOnce();
   });
 
-  it('门槛仍在 → 维持阻断', async () => {
+  it('门槛仍在 → 维持阻断,并把最新 target 写回', async () => {
     const deps = makeDeps();
     await expect(runOnce(deps)).resolves.toBe('still-forced');
     expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).toHaveBeenCalledOnce();
+  });
+
+  it('门槛仍在但服务端修正了安装地址 → 刷新 target(否则按钮一直打开旧链接)', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({
+        installUrl: 'https://cdn.example/fixed',
+        itmsUrl: 'itms-services://?action=download-manifest&url=https://cdn.example/fixed.plist',
+      })),
+    });
+    await expect(runOnce(deps)).resolves.toBe('still-forced');
+    expect(deps.onStillForced).toHaveBeenCalledWith(expect.objectContaining({
+      installUrl: 'https://cdn.example/fixed',
+      itmsUrl: 'itms-services://?action=download-manifest&url=https://cdn.example/fixed.plist',
+    }));
+  });
+
+  it('门槛仍在且换了更高的强更目标 → 刷新 target', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ version: '3.0.0', runtimeVersion: '3', minVersion: '3.0.0' })),
+    });
+    await expect(runOnce(deps)).resolves.toBe('still-forced');
+    expect(deps.onStillForced).toHaveBeenCalledWith(expect.objectContaining({
+      version: '3.0.0',
+      runtimeVersion: '3',
+    }));
   });
 
   it('/latest 拉取失败 → 维持阻断(不能靠断网绕过强更)', async () => {
     const deps = makeDeps({ fetchLatest: vi.fn(async () => { throw new Error('offline'); }) });
     await expect(runOnce(deps)).resolves.toBe('error');
     expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
   });
 
   it('/latest 记录解析不出 → 维持阻断(一条坏记录不得放行所有被强更装机)', async () => {
     const deps = makeDeps({ fetchLatest: vi.fn(async () => ({})) });
     await expect(runOnce(deps)).resolves.toBe('error');
     expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
   });
 
   it('记录有效但缺 runtimeVersion / 安装地址 → 维持阻断', async () => {
@@ -110,6 +139,7 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     });
     await expect(runOnce(deps)).resolves.toBe('error');
     expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
   });
 
   it('拿不到本机 version → 维持阻断(比不出来不放行)', async () => {
@@ -119,6 +149,7 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     });
     await expect(runOnce(deps)).resolves.toBe('error');
     expect(deps.onCleared).not.toHaveBeenCalled();
+    expect(deps.onStillForced).not.toHaveBeenCalled();
   });
 
   it('/latest 挂起 → withTimeout 兜底为 error,维持阻断', async () => {

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -183,6 +183,17 @@ describe('createForcedUpdateRechecker 解除判定', () => {
     expect(deps.onStillForced).not.toHaveBeenCalled();
   });
 
+  it('阻断目标本身缺 version → 证明不了新鲜度,维持阻断', async () => {
+    // 触发阻断的那条记录可能没写 version(parseLatestRelease 容许空串),此时任何
+    // 带正常 version 的旧记录都会"看起来更新",不能据此放行。
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ version: '1.5.0', minVersion: undefined })),
+      getHeldTarget: () => ({ version: '' }),
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
   it('记录缺 version → 证明不了新鲜度,维持阻断', async () => {
     const deps = makeDeps({
       fetchLatest: vi.fn(async () => latestRecord({ version: '', minVersion: undefined })),

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createForcedUpdateRechecker,
+  type ForcedUpdateRecheckDeps,
+} from './forcedUpdateRecheck';
+
+/** 有效的 /latest 记录;默认带门槛(当前 version 1.0.0 < 2.0.0 → 仍强更)。 */
+function latestRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    version: '2.0.0',
+    buildNumber: 20,
+    runtimeVersion: '2',
+    installUrl: 'https://cdn.example/install',
+    itmsUrl: 'itms-services://?action=download-manifest&url=https://cdn.example/m.plist',
+    minVersion: '2.0.0',
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<ForcedUpdateRecheckDeps> = {}) {
+  let nowMs = 1_000_000;
+  const deps: ForcedUpdateRecheckDeps & { advance: (ms: number) => void } = {
+    fetchLatest: vi.fn(async () => latestRecord()),
+    getCurrentRuntimeVersion: () => '1',
+    getCurrentVersion: () => '1.0.0',
+    onCleared: vi.fn(),
+    now: () => nowMs,
+    advance: (ms: number) => { nowMs += ms; },
+    ...overrides,
+  };
+  return deps;
+}
+
+/** 模拟一次「切后台再回前台」。 */
+function resume(rechecker: ReturnType<typeof createForcedUpdateRechecker>) {
+  rechecker.handleAppStateChange('background');
+  return rechecker.handleAppStateChange('active');
+}
+
+describe('createForcedUpdateRechecker 触发条件', () => {
+  it('创建后立刻回前台:间隔不足 → 不检查(阻断屏刚挂载时那次检查刚跑完)', () => {
+    const deps = makeDeps();
+    const rechecker = createForcedUpdateRechecker(deps);
+    expect(resume(rechecker)).toBeNull();
+    expect(deps.fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it('没进过后台的 active 抖动 → 不检查', () => {
+    const deps = makeDeps();
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0 });
+    deps.advance(1);
+    expect(rechecker.handleAppStateChange('inactive')).toBeNull();
+    expect(rechecker.handleAppStateChange('active')).toBeNull();
+    expect(deps.fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it('间隔不足的连续回前台 → 只检查一次(节流)', async () => {
+    const deps = makeDeps();
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 1000 });
+    deps.advance(1001);
+    await resume(rechecker);
+    deps.advance(1); // 远小于间隔
+    expect(resume(rechecker)).toBeNull();
+    expect(deps.fetchLatest).toHaveBeenCalledOnce();
+  });
+});
+
+describe('createForcedUpdateRechecker 解除判定', () => {
+  const runOnce = (deps: ReturnType<typeof makeDeps>) => {
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0 });
+    deps.advance(1);
+    const result = resume(rechecker);
+    expect(result).not.toBeNull();
+    return result!;
+  };
+
+  it('门槛已撤回 → 解除阻断', async () => {
+    const deps = makeDeps({ fetchLatest: vi.fn(async () => latestRecord({ minVersion: undefined })) });
+    await expect(runOnce(deps)).resolves.toBe('cleared');
+    expect(deps.onCleared).toHaveBeenCalledOnce();
+  });
+
+  it('门槛降到当前 version 之下 → 解除阻断', async () => {
+    const deps = makeDeps({ fetchLatest: vi.fn(async () => latestRecord({ minVersion: '1.0.0' })) });
+    await expect(runOnce(deps)).resolves.toBe('cleared');
+    expect(deps.onCleared).toHaveBeenCalledOnce();
+  });
+
+  it('门槛仍在 → 维持阻断', async () => {
+    const deps = makeDeps();
+    await expect(runOnce(deps)).resolves.toBe('still-forced');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
+  it('/latest 拉取失败 → 维持阻断(不能靠断网绕过强更)', async () => {
+    const deps = makeDeps({ fetchLatest: vi.fn(async () => { throw new Error('offline'); }) });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
+  it('/latest 记录解析不出 → 维持阻断(一条坏记录不得放行所有被强更装机)', async () => {
+    const deps = makeDeps({ fetchLatest: vi.fn(async () => ({})) });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
+  it('记录有效但缺 runtimeVersion / 安装地址 → 维持阻断', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ installUrl: '', itmsUrl: '', minVersion: undefined })),
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
+  it('拿不到本机 version → 维持阻断(比不出来不放行)', async () => {
+    const deps = makeDeps({
+      fetchLatest: vi.fn(async () => latestRecord({ minVersion: undefined })),
+      getCurrentVersion: () => null,
+    });
+    await expect(runOnce(deps)).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
+  it('/latest 挂起 → withTimeout 兜底为 error,维持阻断', async () => {
+    const deps = makeDeps({ fetchLatest: vi.fn((): Promise<unknown> => new Promise(() => {})) });
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0, latestTimeoutMs: 20 });
+    deps.advance(1);
+    const result = resume(rechecker);
+    expect(result).not.toBeNull();
+    await expect(result!).resolves.toBe('error');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+
+  it('阻断屏已卸载(isCurrent=false)→ 迟到结果不解除', async () => {
+    let current = true;
+    let release!: (value: unknown) => void;
+    const deps = makeDeps({
+      fetchLatest: vi.fn(() => new Promise((resolve) => { release = resolve; })),
+      isCurrent: () => current,
+    });
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0 });
+    deps.advance(1);
+    const pending = resume(rechecker);
+    expect(pending).not.toBeNull();
+    current = false;
+    release(latestRecord({ minVersion: undefined })); // 已不再强更,但屏已卸载
+    await expect(pending!).resolves.toBe('still-forced');
+    expect(deps.onCleared).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -101,6 +101,43 @@ describe('createForcedUpdateRechecker 触发条件', () => {
   });
 });
 
+describe('createForcedUpdateRechecker 定时兜底', () => {
+  it('挂载后立刻 tick:间隔不足 → 不检查', () => {
+    const deps = makeDeps();
+    const rechecker = createForcedUpdateRechecker(deps);
+    expect(rechecker.handleTick()).toBeNull();
+    expect(deps.fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it('用户停在阻断屏不动(无任何 AppState 跳变)→ 间隔满足后 tick 会核对', async () => {
+    const deps = makeDeps();
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 1000 });
+    deps.advance(1001);
+    const result = rechecker.handleTick();
+    expect(result).not.toBeNull();
+    await result;
+    expect(deps.fetchLatest).toHaveBeenCalledOnce();
+  });
+
+  it('在后台被置位、用户在节流窗口内回来 → 那次 active 被丢掉,但 tick 随后补上', async () => {
+    const deps = makeDeps({ getAppState: () => 'background' });
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 1000 });
+    deps.advance(500); // 窗口内回前台
+    expect(rechecker.handleAppStateChange('active')).toBeNull();
+    deps.advance(600); // 窗口过去
+    expect(rechecker.handleTick()).not.toBeNull();
+  });
+
+  it('tick 与 AppState 共用节流:刚查过就 tick → 不重复发起', async () => {
+    const deps = makeDeps();
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 1000 });
+    deps.advance(1001);
+    await resume(rechecker);
+    expect(rechecker.handleTick()).toBeNull();
+    expect(deps.fetchLatest).toHaveBeenCalledOnce();
+  });
+});
+
 describe('createForcedUpdateRechecker 解除判定', () => {
   const runOnce = (deps: ReturnType<typeof makeDeps>) => {
     const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0 });

--- a/apps/mobile/src/update/forcedUpdateRecheck.test.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.test.ts
@@ -55,6 +55,40 @@ describe('createForcedUpdateRechecker 触发条件', () => {
     expect(deps.fetchLatest).not.toHaveBeenCalled();
   });
 
+  it('挂载时已在后台(阻断态被迟到的 /latest 置位)→ 回前台第一次就核对', async () => {
+    // 没有这条 seeding,本实例见不到 'background' 事件,回前台首次会被 wasBackground
+    // 门挡掉,用户得再走一个完整的切后台→回前台周期才自愈。
+    const deps = makeDeps({ getAppState: () => 'background' });
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0 });
+    deps.advance(1);
+    const result = rechecker.handleAppStateChange('active');
+    expect(result).not.toBeNull();
+    await result;
+    expect(deps.fetchLatest).toHaveBeenCalledOnce();
+  });
+
+  it('挂载时处于 inactive(iOS 抖动 / 系统弹框)→ 同样按已离开前台处理', async () => {
+    const deps = makeDeps({ getAppState: () => 'inactive' });
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0 });
+    deps.advance(1);
+    expect(rechecker.handleAppStateChange('active')).not.toBeNull();
+  });
+
+  it('挂载时在前台 → 维持原行为(首次 active 不检查)', () => {
+    const deps = makeDeps({ getAppState: () => 'active' });
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 0 });
+    deps.advance(1);
+    expect(rechecker.handleAppStateChange('active')).toBeNull();
+    expect(deps.fetchLatest).not.toHaveBeenCalled();
+  });
+
+  it('挂载时已在后台但用户很快回来 → 节流仍然生效(刚查过,重查冗余)', () => {
+    const deps = makeDeps({ getAppState: () => 'background' });
+    const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 30_000 });
+    deps.advance(1000); // 远小于节流间隔
+    expect(rechecker.handleAppStateChange('active')).toBeNull();
+  });
+
   it('间隔不足的连续回前台 → 只检查一次(节流)', async () => {
     const deps = makeDeps();
     const rechecker = createForcedUpdateRechecker(deps, { minIntervalMs: 1000 });

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -25,6 +25,18 @@ export interface ForcedUpdateRecheckDeps {
   getCurrentVersion: () => string | null | undefined;
   /** 判定不再强更时调用(实参为 clearForcedUpdate),之后业务树重新挂载。 */
   onCleared: () => void;
+  /**
+   * 仍然强更时把**最新**目标写回(实参为 enterForcedUpdate,对等值目标幂等)。
+   * 必须刷新而不是原样保留:服务端修正 installUrl / itmsUrl(坏链接正是最需要救的那种
+   * 故障),或发布更高的强更目标时,阻断屏的「去更新」不能继续打开旧链接。
+   */
+  onStillForced: (target: {
+    version: string;
+    runtimeVersion: string;
+    installUrl: string;
+    itmsUrl: string;
+    releaseNotes?: string;
+  }) => void;
   now: () => number;
   /** 阻断屏卸载后使迟到结果失效。 */
   isCurrent?: () => boolean;
@@ -78,9 +90,13 @@ export function createForcedUpdateRechecker(
         currentVersion,
         latest,
       });
-      // 仍然强更(门槛还在,或换了更高的目标)→ 维持阻断,不动 store:
-      // 目标信息的刷新交给下次冷启动,阻断屏本身不需要热更文案。
-      if (evaluation.forced) return 'still-forced';
+      // 仍然强更(门槛还在,或换了更高的目标)→ 维持阻断,但把最新 target 写回:
+      // 服务端可能只修正了 installUrl / itmsUrl(坏链接恰恰是最需要救的故障),
+      // 或发布了更高的强更目标 —— 继续用旧 target 会让「去更新」一直打开旧链接。
+      if (evaluation.forced) {
+        if (evaluation.target) deps.onStillForced(evaluation.target);
+        return 'still-forced';
+      }
       deps.onCleared();
       return 'cleared';
     } catch {

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -1,0 +1,106 @@
+// 阻断屏的"回前台重新核对" —— 纯逻辑(依赖可注入,便于单测)。
+//
+// 为什么需要:进入强更阻断态后业务树整体不挂载,useResumeUpdateCheck 随之卸载,
+// 于是本进程再也不会拉 /latest。服务端撤回误下发的 minVersion 后,用户只能杀进程
+// 冷启动才能恢复 —— 普通用户不会想到这一步。所以阻断屏自己补一次检查。
+//
+// 方向不对称,这是刻意的:
+// - **进入**阻断态要求成功拉到 /latest 且判定强更(拉不到就 fail-open 放行,更新服务
+//   故障不该锁死用户);
+// - **解除**阻断态同样要求成功拉到 /latest 且判定不再强更 —— 拉取失败一律维持阻断,
+//   否则断网(飞行模式)就能绕过强更。
+//
+// 节流比 resume 通道(5 分钟)短得多:用户此刻正被挡在门外,恢复延迟直接可感;
+// 但仍要节流,避免在阻断屏上反复切前后台把 /latest 打成高频请求。
+
+import { evaluateBundleUpdate, parseLatestRelease } from './bundleUpdate';
+import { withTimeout } from './startupOtaUpdate';
+
+export type ForcedUpdateRecheckOutcome = 'still-forced' | 'cleared' | 'error';
+
+export interface ForcedUpdateRecheckDeps {
+  /** 拉 /latest(平台与 channel 已由调用方绑定);返回原始 JSON。 */
+  fetchLatest: () => Promise<unknown>;
+  getCurrentRuntimeVersion: () => string | null | undefined;
+  getCurrentVersion: () => string | null | undefined;
+  /** 判定不再强更时调用(实参为 clearForcedUpdate),之后业务树重新挂载。 */
+  onCleared: () => void;
+  now: () => number;
+  /** 阻断屏卸载后使迟到结果失效。 */
+  isCurrent?: () => boolean;
+}
+
+export interface ForcedUpdateRecheckOptions {
+  /** 两次核对的最小间隔(默认 30s)。 */
+  minIntervalMs?: number;
+  /** /latest 拉取超时(默认 10s,与 resume 通道同口径)。 */
+  latestTimeoutMs?: number;
+}
+
+const DEFAULT_MIN_INTERVAL_MS = 30_000;
+const DEFAULT_LATEST_TIMEOUT_MS = 10_000;
+
+export interface ForcedUpdateRechecker {
+  /**
+   * AppState 'change' 入口。命中「从后台回到前台 + 间隔满足 + 无在途」才发起;
+   * 未触发时返回 null(便于测试断言),触发时返回本次核对的 Promise(永不 reject)。
+   */
+  handleAppStateChange: (next: string) => Promise<ForcedUpdateRecheckOutcome> | null;
+}
+
+/** 创建阻断屏核对器(持有节流/在途状态;阻断屏挂载期间一个实例)。 */
+export function createForcedUpdateRechecker(
+  deps: ForcedUpdateRecheckDeps,
+  {
+    minIntervalMs = DEFAULT_MIN_INTERVAL_MS,
+    latestTimeoutMs = DEFAULT_LATEST_TIMEOUT_MS,
+  }: ForcedUpdateRecheckOptions = {},
+): ForcedUpdateRechecker {
+  // 与 resume 通道不同:阻断屏刚挂载时那次检查刚跑完,所以创建时刻同样视为"刚查过"。
+  let lastRunAt = deps.now();
+  let wasBackground = false;
+  let inFlight = false;
+
+  async function run(): Promise<ForcedUpdateRecheckOutcome> {
+    inFlight = true;
+    try {
+      const latest = await withTimeout(deps.fetchLatest(), latestTimeoutMs);
+      if (deps.isCurrent && !deps.isCurrent()) return 'still-forced';
+      // 解除必须建立在"真的比出来了不再低于门槛"之上。record 解析不出(指针损坏 /
+      // 被中间层改坏)或拿不到本机 version 时,evaluateBundleUpdate 会 fail-open 报
+      // 无更新 —— 那是**进入**方向的正确取向,拿到解除方向就成了漏洞:一条坏记录
+      // 就能放行所有被强更的装机。这里显式挡掉,按拉取失败处理。
+      const record = parseLatestRelease(latest);
+      const currentVersion = String(deps.getCurrentVersion() ?? '').trim();
+      if (!record || !currentVersion) return 'error';
+      const evaluation = evaluateBundleUpdate({
+        currentRuntimeVersion: deps.getCurrentRuntimeVersion(),
+        currentVersion,
+        latest,
+      });
+      // 仍然强更(门槛还在,或换了更高的目标)→ 维持阻断,不动 store:
+      // 目标信息的刷新交给下次冷启动,阻断屏本身不需要热更文案。
+      if (evaluation.forced) return 'still-forced';
+      deps.onCleared();
+      return 'cleared';
+    } catch {
+      return 'error'; // 拉不到就维持阻断(见文件头:解除方向 fail-closed)
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  return {
+    handleAppStateChange(next: string): Promise<ForcedUpdateRecheckOutcome> | null {
+      if (next === 'background') {
+        wasBackground = true;
+        return null;
+      }
+      if (next !== 'active' || !wasBackground) return null;
+      wasBackground = false;
+      if (inFlight || deps.now() - lastRunAt < minIntervalMs) return null;
+      lastRunAt = deps.now();
+      return run();
+    },
+  };
+}

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -121,8 +121,10 @@ export function createForcedUpdateRechecker(
       // 新鲜度门:读到的记录不得比正在阻断的目标更旧。可变指针 + 无 cache-buster 的请求
       // 会撞上 CDN 边缘的旧记录,那条记录没有 minVersion → 会把仍需强更的用户放出去。
       // 记录缺 version(parseLatestRelease 容许空串)同样证明不了新鲜度,一并挡掉。
+      // held.version 为空(触发阻断的那条记录本身缺 version)时同样比不出新鲜度,一并挡掉。
       const held = deps.getHeldTarget?.();
-      if (held && (!record.version || compareVersions(record.version, held.version) < 0)) {
+      if (held && (!record.version || !held.version
+        || compareVersions(record.version, held.version) < 0)) {
         return 'error';
       }
       const evaluation = evaluateBundleUpdate({

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -86,6 +86,15 @@ export interface ForcedUpdateRechecker {
    * 未触发时返回 null(便于测试断言),触发时返回本次核对的 Promise(永不 reject)。
    */
   handleAppStateChange: (next: string) => Promise<ForcedUpdateRecheckOutcome> | null;
+  /**
+   * 定时兜底入口(阻断屏挂载期间周期性调用)。只受节流与在途约束,不看 AppState。
+   *
+   * 为什么必须有:光靠 AppState 跳变不够 —— (1) 用户就坐在阻断屏上不动时没有任何跳变;
+   * (2) 阻断态在后台被置位、用户在节流窗口内就回来时,那次 'active' 会被节流丢掉,
+   * 而后再没有事件来重试。两种情况下运维撤回门槛 / 修正安装地址都不会被观察到,
+   * 阻断屏会一直停在旧状态。
+   */
+  handleTick: () => Promise<ForcedUpdateRecheckOutcome> | null;
 }
 
 /** 创建阻断屏核对器(持有节流/在途状态;阻断屏挂载期间一个实例)。 */
@@ -160,6 +169,13 @@ export function createForcedUpdateRechecker(
     }
   }
 
+  /** 节流 + 在途门:两个入口共用,通过则占用本轮并发起。 */
+  function tryRun(): Promise<ForcedUpdateRecheckOutcome> | null {
+    if (inFlight || deps.now() - lastRunAt < minIntervalMs) return null;
+    lastRunAt = deps.now();
+    return run();
+  }
+
   return {
     handleAppStateChange(next: string): Promise<ForcedUpdateRecheckOutcome> | null {
       if (next === 'background') {
@@ -168,9 +184,10 @@ export function createForcedUpdateRechecker(
       }
       if (next !== 'active' || !wasBackground) return null;
       wasBackground = false;
-      if (inFlight || deps.now() - lastRunAt < minIntervalMs) return null;
-      lastRunAt = deps.now();
-      return run();
+      return tryRun();
+    },
+    handleTick(): Promise<ForcedUpdateRecheckOutcome> | null {
+      return tryRun();
     },
   };
 }

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -111,13 +111,25 @@ export function createForcedUpdateRechecker(
     try {
       const latest = await withTimeout(deps.fetchLatest(), latestTimeoutMs);
       if (deps.isCurrent && !deps.isCurrent()) return 'still-forced';
+      // null 只在服务端 404 时出现(网络 / 5xx 都抛错),是服务端**明确声明**该平台当前
+      // 没有整包记录 —— 记录不存在,门槛也就不存在。必须解除:同样的 404 在冷启动路径上
+      // 根本不会进入阻断(evaluateBundleUpdate 对 null 返回无更新),运行中的进程不该比
+      // 冷启动更严,否则用户被卡到杀进程为止。
+      if (latest === null) {
+        deps.onCleared(startRevision);
+        return 'cleared';
+      }
       // 解除必须建立在"真的比出来了不再低于门槛"之上。record 解析不出(指针损坏 /
       // 被中间层改坏)或拿不到本机 version 时,evaluateBundleUpdate 会 fail-open 报
       // 无更新 —— 那是**进入**方向的正确取向,拿到解除方向就成了漏洞:一条坏记录
       // 就能放行所有被强更的装机。这里显式挡掉,按拉取失败处理。
+      // currentRuntimeVersion 同样是必需条件:拿不到它(expo-updates 未启用 / 返回空)时
+      // evaluateBundleUpdate 会 fail-open 报无更新 —— 那是进入方向的取向,用在解除方向
+      // 就成了绕过强更的口子。
       const record = parseLatestRelease(latest);
+      const currentRuntimeVersion = String(deps.getCurrentRuntimeVersion() ?? '').trim();
       const currentVersion = String(deps.getCurrentVersion() ?? '').trim();
-      if (!record || !currentVersion) return 'error';
+      if (!record || !currentRuntimeVersion || !currentVersion) return 'error';
       // 新鲜度门:读到的记录不得比正在阻断的目标更旧。可变指针 + 无 cache-buster 的请求
       // 会撞上 CDN 边缘的旧记录,那条记录没有 minVersion → 会把仍需强更的用户放出去。
       // 记录缺 version(parseLatestRelease 容许空串)同样证明不了新鲜度,一并挡掉。
@@ -128,7 +140,7 @@ export function createForcedUpdateRechecker(
         return 'error';
       }
       const evaluation = evaluateBundleUpdate({
-        currentRuntimeVersion: deps.getCurrentRuntimeVersion(),
+        currentRuntimeVersion,
         currentVersion,
         latest,
       });

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -23,20 +23,27 @@ export interface ForcedUpdateRecheckDeps {
   fetchLatest: () => Promise<unknown>;
   getCurrentRuntimeVersion: () => string | null | undefined;
   getCurrentVersion: () => string | null | undefined;
-  /** 判定不再强更时调用(实参为 clearForcedUpdate),之后业务树重新挂载。 */
-  onCleared: () => void;
+  /**
+   * 判定不再强更时调用(实参为 clearForcedUpdate),之后业务树重新挂载。
+   * 回传发起时的 revision 做 compare-and-clear:核对期间若有更新的观察写入了强更目标,
+   * 这条旧结论必须作废,不能把用户放进业务树。
+   */
+  onCleared: (expectedRevision?: number) => void;
   /**
    * 仍然强更时把**最新**目标写回(实参为 enterForcedUpdate,对等值目标幂等)。
    * 必须刷新而不是原样保留:服务端修正 installUrl / itmsUrl(坏链接正是最需要救的那种
    * 故障),或发布更高的强更目标时,阻断屏的「去更新」不能继续打开旧链接。
    */
-  onStillForced: (target: {
-    version: string;
-    runtimeVersion: string;
-    installUrl: string;
-    itmsUrl: string;
-    releaseNotes?: string;
-  }) => void;
+  onStillForced: (
+    target: {
+      version: string;
+      runtimeVersion: string;
+      installUrl: string;
+      itmsUrl: string;
+      releaseNotes?: string;
+    },
+    expectedRevision?: number,
+  ) => void;
   now: () => number;
   /** 阻断屏卸载后使迟到结果失效。 */
   isCurrent?: () => boolean;
@@ -48,6 +55,11 @@ export interface ForcedUpdateRecheckDeps {
    * 用户回来还要再切一次后台才自愈。省略则按 'active' 处理(维持旧行为)。
    */
   getAppState?: () => string;
+  /**
+   * 发起时读一次 store revision(实参为 getForcedUpdateRevision),落地时回传。
+   * 省略则不做 compare-and-set(维持旧行为)。
+   */
+  getRevision?: () => number;
 }
 
 export interface ForcedUpdateRecheckOptions {
@@ -86,6 +98,8 @@ export function createForcedUpdateRechecker(
 
   async function run(): Promise<ForcedUpdateRecheckOutcome> {
     inFlight = true;
+    // 必须在 await 之前读:这是"本次核对看到的世界"的版本号。
+    const startRevision = deps.getRevision?.();
     try {
       const latest = await withTimeout(deps.fetchLatest(), latestTimeoutMs);
       if (deps.isCurrent && !deps.isCurrent()) return 'still-forced';
@@ -105,10 +119,10 @@ export function createForcedUpdateRechecker(
       // 服务端可能只修正了 installUrl / itmsUrl(坏链接恰恰是最需要救的故障),
       // 或发布了更高的强更目标 —— 继续用旧 target 会让「去更新」一直打开旧链接。
       if (evaluation.forced) {
-        if (evaluation.target) deps.onStillForced(evaluation.target);
+        if (evaluation.target) deps.onStillForced(evaluation.target, startRevision);
         return 'still-forced';
       }
-      deps.onCleared();
+      deps.onCleared(startRevision);
       return 'cleared';
     } catch {
       return 'error'; // 拉不到就维持阻断(见文件头:解除方向 fail-closed)

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -142,9 +142,12 @@ export function createForcedUpdateRechecker(
       // 新鲜度门:读到的记录不得比正在阻断的目标更旧。可变指针 + 无 cache-buster 的请求
       // 会撞上 CDN 边缘的旧记录,那条记录没有 minVersion → 会把仍需强更的用户放出去。
       // 记录缺 version(parseLatestRelease 容许空串)同样证明不了新鲜度,一并挡掉。
-      // held.version 为空(触发阻断的那条记录本身缺 version)时同样比不出新鲜度,一并挡掉。
+      // 只有两边都有版本号时才比较。held.version 为空按"无新鲜度约束"处理而不是维持阻断
+      // ——否则一条无 version 的记录会把用户永久钉在阻断屏上(定时与回前台核对都过不去)。
+      // 这种情况现在不可达:evaluateBundleUpdate 要求 record 带 version 才判 forced,
+      // 所以能进入阻断的目标必然有版本号。此处只是不给自己留死锁的余地。
       const held = deps.getHeldTarget?.();
-      if (held && (!record.version || !held.version
+      if (held?.version && (!record.version
         || compareVersions(record.version, held.version) < 0)) {
         return 'error';
       }

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -13,7 +13,7 @@
 // 节流比 resume 通道(5 分钟)短得多:用户此刻正被挡在门外,恢复延迟直接可感;
 // 但仍要节流,避免在阻断屏上反复切前后台把 /latest 打成高频请求。
 
-import { evaluateBundleUpdate, parseLatestRelease } from './bundleUpdate';
+import { compareVersions, evaluateBundleUpdate, parseLatestRelease } from './bundleUpdate';
 import { withTimeout } from './startupOtaUpdate';
 
 export type ForcedUpdateRecheckOutcome = 'still-forced' | 'cleared' | 'error';
@@ -60,6 +60,14 @@ export interface ForcedUpdateRecheckDeps {
    * 省略则不做 compare-and-set(维持旧行为)。
    */
   getRevision?: () => number;
+  /**
+   * 当前阻断中的目标(实参为 getForcedUpdateTarget),用于证明本次读到的记录不比它旧。
+   * 必要性:`/latest` 背后是**可变指针**,且客户端这条请求既不带 cache-buster 也不发
+   * no-cache(见 fetchLatestRelease),CDN 边缘完全可能返回一条更旧的 release 记录
+   * (发布链侧对同一现象有明确记载:lib/ios-local.mjs 的 CDN 缓存注释)。旧记录里没有
+   * minVersion,就会把仍需强更的用户放进业务树。省略则不做新鲜度校验(维持旧行为)。
+   */
+  getHeldTarget?: () => { version: string } | null;
 }
 
 export interface ForcedUpdateRecheckOptions {
@@ -110,6 +118,13 @@ export function createForcedUpdateRechecker(
       const record = parseLatestRelease(latest);
       const currentVersion = String(deps.getCurrentVersion() ?? '').trim();
       if (!record || !currentVersion) return 'error';
+      // 新鲜度门:读到的记录不得比正在阻断的目标更旧。可变指针 + 无 cache-buster 的请求
+      // 会撞上 CDN 边缘的旧记录,那条记录没有 minVersion → 会把仍需强更的用户放出去。
+      // 记录缺 version(parseLatestRelease 容许空串)同样证明不了新鲜度,一并挡掉。
+      const held = deps.getHeldTarget?.();
+      if (held && (!record.version || compareVersions(record.version, held.version) < 0)) {
+        return 'error';
+      }
       const evaluation = evaluateBundleUpdate({
         currentRuntimeVersion: deps.getCurrentRuntimeVersion(),
         currentVersion,

--- a/apps/mobile/src/update/forcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/forcedUpdateRecheck.ts
@@ -40,6 +40,14 @@ export interface ForcedUpdateRecheckDeps {
   now: () => number;
   /** 阻断屏卸载后使迟到结果失效。 */
   isCurrent?: () => boolean;
+  /**
+   * 创建时读一次当前 AppState(实参为 () => AppState.currentState)。
+   * 必要性:阻断态可能在 App **已经切到后台之后**才被置位(启动 / resume 检查的
+   * /latest 迟到返回),此时本实例从未见过 'background' 事件,回前台的第一次
+   * 'active' 会被 wasBackground 门挡掉 —— 运维撤回门槛正好发生在用户离开期间时,
+   * 用户回来还要再切一次后台才自愈。省略则按 'active' 处理(维持旧行为)。
+   */
+  getAppState?: () => string;
 }
 
 export interface ForcedUpdateRecheckOptions {
@@ -68,9 +76,12 @@ export function createForcedUpdateRechecker(
     latestTimeoutMs = DEFAULT_LATEST_TIMEOUT_MS,
   }: ForcedUpdateRecheckOptions = {},
 ): ForcedUpdateRechecker {
-  // 与 resume 通道不同:阻断屏刚挂载时那次检查刚跑完,所以创建时刻同样视为"刚查过"。
+  // 与 resume 通道不同:阻断屏刚挂载时那次检查刚跑完,所以创建时刻同样视为"刚查过"
+  // (节流仍然生效:用户离开不足 minIntervalMs 就回来时,重查是冗余的)。
   let lastRunAt = deps.now();
-  let wasBackground = false;
+  // 挂载时若 App 已不在前台,视同"已经进过后台":下一次回前台就该核对,
+  // 不必等用户再走一个完整的切后台→回前台周期。
+  let wasBackground = deps.getAppState ? deps.getAppState() !== 'active' : false;
   let inFlight = false;
 
   async function run(): Promise<ForcedUpdateRecheckOutcome> {

--- a/apps/mobile/src/update/forcedUpdateStore.test.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   __testing,
+  clearForcedUpdate,
   enterForcedUpdate,
   getForcedUpdateTarget,
   subscribeForcedUpdate,
@@ -59,6 +60,29 @@ describe('forcedUpdateStore', () => {
     enterForcedUpdate(target());
     expect(listener).not.toHaveBeenCalled();
     expect(getForcedUpdateTarget()).not.toBeNull();
+  });
+
+  it('解除阻断态 → 目标清空并通知(服务端撤回门槛后的恢复入口)', () => {
+    enterForcedUpdate(target());
+    const listener = vi.fn();
+    subscribeForcedUpdate(listener);
+    clearForcedUpdate();
+    expect(getForcedUpdateTarget()).toBeNull();
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('本来就没阻断时解除 → 幂等,不通知', () => {
+    const listener = vi.fn();
+    subscribeForcedUpdate(listener);
+    clearForcedUpdate();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('解除后可再次进入(下一轮门槛)', () => {
+    enterForcedUpdate(target());
+    clearForcedUpdate();
+    enterForcedUpdate(target());
+    expect(getForcedUpdateTarget()).toEqual(target());
   });
 
   it('单个订阅者抛错不影响其它订阅者', () => {

--- a/apps/mobile/src/update/forcedUpdateStore.test.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.test.ts
@@ -3,6 +3,7 @@ import {
   __testing,
   clearForcedUpdate,
   enterForcedUpdate,
+  getForcedUpdateRevision,
   getForcedUpdateTarget,
   subscribeForcedUpdate,
   type ForcedUpdateTarget,
@@ -83,6 +84,38 @@ describe('forcedUpdateStore', () => {
     clearForcedUpdate();
     enterForcedUpdate(target());
     expect(getForcedUpdateTarget()).toEqual(target());
+  });
+
+  it('compare-and-clear:revision 已前进 → 旧结论作废,不解除', () => {
+    // 竞态:核对发起时读到 revision=1,在途期间另一条路径写入更新的强更目标(revision=2),
+    // 旧结论带着 1 回来时不得把用户放进业务树。
+    enterForcedUpdate(target());
+    const stale = getForcedUpdateRevision();
+    enterForcedUpdate(target({ version: '2.1.0' })); // 更新的观察落地
+    clearForcedUpdate(stale);
+    expect(getForcedUpdateTarget()?.version).toBe('2.1.0');
+  });
+
+  it('compare-and-clear:revision 未变 → 正常解除', () => {
+    enterForcedUpdate(target());
+    clearForcedUpdate(getForcedUpdateRevision());
+    expect(getForcedUpdateTarget()).toBeNull();
+  });
+
+  it('compare-and-set:revision 已前进 → 旧 target 不回写(按钮不退回旧链接)', () => {
+    enterForcedUpdate(target());
+    const stale = getForcedUpdateRevision();
+    enterForcedUpdate(target({ installUrl: 'https://cdn.example/fixed' }));
+    enterForcedUpdate(target({ installUrl: 'https://cdn.example/old' }), stale);
+    expect(getForcedUpdateTarget()?.installUrl).toBe('https://cdn.example/fixed');
+  });
+
+  it('不传 revision 的调用不受 compare 影响(首次进入 / 旧调用点)', () => {
+    enterForcedUpdate(target());
+    enterForcedUpdate(target({ version: '3.0.0' }));
+    expect(getForcedUpdateTarget()?.version).toBe('3.0.0');
+    clearForcedUpdate();
+    expect(getForcedUpdateTarget()).toBeNull();
   });
 
   it('单个订阅者抛错不影响其它订阅者', () => {

--- a/apps/mobile/src/update/forcedUpdateStore.test.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  __testing,
+  enterForcedUpdate,
+  getForcedUpdateTarget,
+  subscribeForcedUpdate,
+  type ForcedUpdateTarget,
+} from './forcedUpdateStore';
+
+function target(overrides: Partial<ForcedUpdateTarget> = {}): ForcedUpdateTarget {
+  return {
+    version: '2.0.0',
+    runtimeVersion: 'rtv-new',
+    installUrl: 'https://cdn.example/install',
+    itmsUrl: 'itms-services://?action=download-manifest&url=https://cdn.example/m.plist',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  __testing.reset();
+});
+
+describe('forcedUpdateStore', () => {
+  it('初始无阻断目标', () => {
+    expect(getForcedUpdateTarget()).toBeNull();
+  });
+
+  it('进入阻断态后可读取目标并通知订阅者', () => {
+    const listener = vi.fn();
+    subscribeForcedUpdate(listener);
+    enterForcedUpdate(target());
+    expect(getForcedUpdateTarget()).toEqual(target());
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('同一目标重复进入 → 幂等,不重复通知(resume 每 5 分钟命中一次也不会重渲染)', () => {
+    const listener = vi.fn();
+    subscribeForcedUpdate(listener);
+    enterForcedUpdate(target());
+    enterForcedUpdate(target());
+    enterForcedUpdate({ ...target() });
+    expect(listener).toHaveBeenCalledOnce();
+  });
+
+  it('目标变化(更高版本)→ 更新并通知', () => {
+    const listener = vi.fn();
+    subscribeForcedUpdate(listener);
+    enterForcedUpdate(target());
+    enterForcedUpdate(target({ version: '2.1.0' }));
+    expect(getForcedUpdateTarget()?.version).toBe('2.1.0');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('取消订阅后不再收到通知', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeForcedUpdate(listener);
+    unsubscribe();
+    enterForcedUpdate(target());
+    expect(listener).not.toHaveBeenCalled();
+    expect(getForcedUpdateTarget()).not.toBeNull();
+  });
+
+  it('单个订阅者抛错不影响其它订阅者', () => {
+    const bad = vi.fn(() => { throw new Error('boom'); });
+    const good = vi.fn();
+    subscribeForcedUpdate(bad);
+    subscribeForcedUpdate(good);
+    expect(() => enterForcedUpdate(target())).not.toThrow();
+    expect(good).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mobile/src/update/forcedUpdateStore.test.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.test.ts
@@ -96,6 +96,24 @@ describe('forcedUpdateStore', () => {
     expect(getForcedUpdateTarget()?.version).toBe('2.1.0');
   });
 
+  it('等值目标的无守卫写入也推进 revision → 在途旧结论作废', () => {
+    // 另一条检查路径的迟到响应写入**相同**目标时,状态没变但确实是一次新观察落地;
+    // 若不推进 revision,在途核对基于旧 revision 的"解除"结论仍会通过 compare。
+    enterForcedUpdate(target());
+    const stale = getForcedUpdateRevision();
+    enterForcedUpdate(target()); // 等值、无 expectedRevision
+    expect(getForcedUpdateRevision()).not.toBe(stale);
+    clearForcedUpdate(stale);
+    expect(getForcedUpdateTarget()).not.toBeNull();
+  });
+
+  it('等值目标的带守卫写入不推进 revision(自己的刷新不该作废自己)', () => {
+    enterForcedUpdate(target());
+    const rev = getForcedUpdateRevision();
+    enterForcedUpdate(target(), rev); // 核对回来发现目标没变
+    expect(getForcedUpdateRevision()).toBe(rev);
+  });
+
   it('compare-and-clear:revision 未变 → 正常解除', () => {
     enterForcedUpdate(target());
     clearForcedUpdate(getForcedUpdateRevision());

--- a/apps/mobile/src/update/forcedUpdateStore.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.ts
@@ -13,11 +13,14 @@
  *   就再也救不回被误挡的装机。
  * 而"杀进程绕过"并不成立:下次启动会重新拉 /latest 并立刻命中同一个门槛。
  *
- * 三层保证"不会把人永久挡在门外":
+ * 四层保证"不会把人永久挡在门外":
  * 1. 拉不到 /latest(离线 / 超时 / 5xx)→ 调用方 fail-open,不进入阻断态;
  * 2. 拿不到可跳转的安装地址 → 不进入阻断态(见 promptBundleUpdate),不造无出口的屏;
  * 3. 门槛必须 ≤ 该 record 宣告的 version(发布链 assertMinVersionUsable fail closed),
- *    所以装上被广播的那个版本必然解除阻断。
+ *    所以装上被广播的那个版本必然解除阻断;
+ * 4. 阻断期间业务树整体不挂载 —— resume 检查也随之停摆,所以阻断屏自带一次
+ *    "回前台重新核对"(见 forcedUpdateRecheck):服务端撤回门槛后不必杀进程冷启动,
+ *    切出去再回来即自动解除。
  */
 import { useSyncExternalStore } from 'react';
 
@@ -61,6 +64,17 @@ function isSameTarget(a: ForcedUpdateTarget | null, b: ForcedUpdateTarget | null
 export function enterForcedUpdate(target: ForcedUpdateTarget): void {
   if (isSameTarget(forcedTarget, target)) return;
   forcedTarget = target;
+  notifyListeners();
+}
+
+/**
+ * 解除阻断态(生产入口,不是测试专用)。
+ * 唯一调用方是阻断屏的重新核对:**成功**拉到 /latest 且判定不再强更时才解除
+ * —— 不能在拉取失败时解除,否则断网就能绕过强更。
+ */
+export function clearForcedUpdate(): void {
+  if (forcedTarget === null) return;
+  forcedTarget = null;
   notifyListeners();
 }
 

--- a/apps/mobile/src/update/forcedUpdateStore.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.ts
@@ -34,6 +34,13 @@ export interface ForcedUpdateTarget {
 }
 
 let forcedTarget: ForcedUpdateTarget | null = null;
+/**
+ * 每次目标真正变化(含解除)自增。用于 compare-and-set:
+ * 检查是异步的,一次检查发起后到落地前,别的路径(启动检查的迟到响应、阻断屏重挂后的
+ * 新一轮核对)可能已经写入更新的观察。带着"发起时的 revision"回来的旧结论必须作废,
+ * 否则会出现「旧响应清掉新版强更状态」——业务树在最新观察仍要求强更时重新挂载。
+ */
+let revision = 0;
 const listeners = new Set<() => void>();
 
 function notifyListeners(): void {
@@ -60,10 +67,15 @@ function isSameTarget(a: ForcedUpdateTarget | null, b: ForcedUpdateTarget | null
 /**
  * 进入强更阻断态。幂等:同一目标重复调用不通知订阅者(三条检查路径都可能反复命中,
  * 尤其 resume 每 5 分钟一次;不做等值判断会引发无意义重渲染)。
+ *
+ * expectedRevision 可选:传入则做 compare-and-set —— 只有 store 自本次检查发起以来
+ * 没被更新的观察改写过才生效。首次进入(promptBundleUpdate)不传,它就是最新观察。
  */
-export function enterForcedUpdate(target: ForcedUpdateTarget): void {
+export function enterForcedUpdate(target: ForcedUpdateTarget, expectedRevision?: number): void {
+  if (expectedRevision !== undefined && expectedRevision !== revision) return;
   if (isSameTarget(forcedTarget, target)) return;
   forcedTarget = target;
+  revision += 1;
   notifyListeners();
 }
 
@@ -71,11 +83,21 @@ export function enterForcedUpdate(target: ForcedUpdateTarget): void {
  * 解除阻断态(生产入口,不是测试专用)。
  * 唯一调用方是阻断屏的重新核对:**成功**拉到 /latest 且判定不再强更时才解除
  * —— 不能在拉取失败时解除,否则断网就能绕过强更。
+ *
+ * expectedRevision 可选:传入则做 compare-and-clear —— 本次核对发起后若有更新的观察
+ * 写入了强更目标,这条旧结论作废,不得把用户放进业务树。
  */
-export function clearForcedUpdate(): void {
+export function clearForcedUpdate(expectedRevision?: number): void {
+  if (expectedRevision !== undefined && expectedRevision !== revision) return;
   if (forcedTarget === null) return;
   forcedTarget = null;
+  revision += 1;
   notifyListeners();
+}
+
+/** 当前 revision;检查发起时读一次,落地时回传做 compare-and-set。 */
+export function getForcedUpdateRevision(): number {
+  return revision;
 }
 
 /** 当前阻断目标;null = 未命中强更。 */
@@ -99,6 +121,7 @@ export function useForcedUpdate(): ForcedUpdateTarget | null {
 export const __testing = {
   reset(): void {
     forcedTarget = null;
+    revision = 0;
     listeners.clear();
   },
 };

--- a/apps/mobile/src/update/forcedUpdateStore.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.ts
@@ -73,7 +73,14 @@ function isSameTarget(a: ForcedUpdateTarget | null, b: ForcedUpdateTarget | null
  */
 export function enterForcedUpdate(target: ForcedUpdateTarget, expectedRevision?: number): void {
   if (expectedRevision !== undefined && expectedRevision !== revision) return;
-  if (isSameTarget(forcedTarget, target)) return;
+  if (isSameTarget(forcedTarget, target)) {
+    // 不带 expectedRevision 的调用代表**另一条检查路径的一次新观察**落地。即使目标等值、
+    // 没有状态变化,也必须推进 revision:否则在途重新核对基于旧 revision 得出的"解除"
+    // 结论仍能通过 compare-and-clear,把最新观察仍要求强更的阻断态清掉。
+    // 不通知订阅者 —— 状态确实没变,幂等语义不受影响。
+    if (expectedRevision === undefined) revision += 1;
+    return;
+  }
   forcedTarget = target;
   revision += 1;
   notifyListeners();

--- a/apps/mobile/src/update/forcedUpdateStore.ts
+++ b/apps/mobile/src/update/forcedUpdateStore.ts
@@ -1,0 +1,90 @@
+/**
+ * 强更阻断态 —— 模块级单例 + 订阅。
+ *
+ * 强更不是"弹一次提示",而是**阻断使用**:命中门槛后 root 层不再挂载业务树,只渲染
+ * 一个唯一出口是「去更新」的闸门屏(见 app/_layout.tsx)。因此状态不能挂在某个 hook 里
+ * (启动检查、设置页手动检查、resume 静默检查三条路径都能命中),必须放模块级共享。
+ *
+ * **不持久化,只存内存**——这是与 otaReloadGuard 的关键区别,别把两者混为一谈:
+ * - otaReloadGuard 挡的是**故障循环**(bundle 装不上却反复 reload),它必须落盘计数,
+ *   并且必须自带放弃条件(满 2 次就放弃热更直接进 App);
+ * - 本模块是**产品意图**的阻断,不是故障。不落盘本身就是自愈路径:服务端撤回门槛
+ *   (发布链 set-mobile-min-version --clear)后,用户下次冷启动即恢复;若落盘,撤回
+ *   就再也救不回被误挡的装机。
+ * 而"杀进程绕过"并不成立:下次启动会重新拉 /latest 并立刻命中同一个门槛。
+ *
+ * 三层保证"不会把人永久挡在门外":
+ * 1. 拉不到 /latest(离线 / 超时 / 5xx)→ 调用方 fail-open,不进入阻断态;
+ * 2. 拿不到可跳转的安装地址 → 不进入阻断态(见 promptBundleUpdate),不造无出口的屏;
+ * 3. 门槛必须 ≤ 该 record 宣告的 version(发布链 assertMinVersionUsable fail closed),
+ *    所以装上被广播的那个版本必然解除阻断。
+ */
+import { useSyncExternalStore } from 'react';
+
+/** 阻断屏需要的目标信息(evaluateBundleUpdate 的 target 子集)。 */
+export interface ForcedUpdateTarget {
+  version: string;
+  runtimeVersion: string;
+  installUrl: string;
+  itmsUrl: string;
+  releaseNotes?: string;
+}
+
+let forcedTarget: ForcedUpdateTarget | null = null;
+const listeners = new Set<() => void>();
+
+function notifyListeners(): void {
+  // 单个订阅者异常不能影响其它订阅者(与 canaryChannelStore 同口径)。
+  for (const listener of [...listeners]) {
+    try {
+      listener();
+    } catch {
+      // ignore listener failures
+    }
+  }
+}
+
+function isSameTarget(a: ForcedUpdateTarget | null, b: ForcedUpdateTarget | null): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.version === b.version
+    && a.runtimeVersion === b.runtimeVersion
+    && a.installUrl === b.installUrl
+    && a.itmsUrl === b.itmsUrl
+    && a.releaseNotes === b.releaseNotes;
+}
+
+/**
+ * 进入强更阻断态。幂等:同一目标重复调用不通知订阅者(三条检查路径都可能反复命中,
+ * 尤其 resume 每 5 分钟一次;不做等值判断会引发无意义重渲染)。
+ */
+export function enterForcedUpdate(target: ForcedUpdateTarget): void {
+  if (isSameTarget(forcedTarget, target)) return;
+  forcedTarget = target;
+  notifyListeners();
+}
+
+/** 当前阻断目标;null = 未命中强更。 */
+export function getForcedUpdateTarget(): ForcedUpdateTarget | null {
+  return forcedTarget;
+}
+
+/** 订阅阻断态变化;返回取消订阅函数。 */
+export function subscribeForcedUpdate(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** root 层消费:命中强更时返回目标,用于渲染阻断屏。 */
+export function useForcedUpdate(): ForcedUpdateTarget | null {
+  return useSyncExternalStore(subscribeForcedUpdate, getForcedUpdateTarget, getForcedUpdateTarget);
+}
+
+export const __testing = {
+  reset(): void {
+    forcedTarget = null;
+    listeners.clear();
+  },
+};

--- a/apps/mobile/src/update/resumeUpdateCheck.test.ts
+++ b/apps/mobile/src/update/resumeUpdateCheck.test.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createResumeUpdateChecker, markForcedPrompted, resetForcedPromptedForTest, type ResumeUpdateCheckDeps } from './resumeUpdateCheck';
+import { describe, expect, it, vi } from 'vitest';
+import { createResumeUpdateChecker, type ResumeUpdateCheckDeps } from './resumeUpdateCheck';
 
 /** 有效的 /latest 记录(runtimeVersion 与当前 '1' 不同 → 有整包更新)。 */
 function latestRecord(overrides: Record<string, unknown> = {}) {
@@ -23,10 +23,8 @@ function makeDeps(overrides: Partial<ResumeUpdateCheckDeps> = {}) {
     fetchLatest: vi.fn(async () => null),
     getCurrentRuntimeVersion: () => '1',
     getCurrentVersion: () => '1.0.0',
-    // 模拟真实 callback(promptBundleUpdate)的契约:实际展示后标记去重。
-    onForcedUpdate: vi.fn((e: Parameters<ResumeUpdateCheckDeps['onForcedUpdate']>[0]) => {
-      if (e.target) markForcedPrompted(e.target.runtimeVersion);
-    }),
+    // 真实 callback 是 promptBundleUpdate → enterForcedUpdate(幂等,不需要去重)。
+    onForcedUpdate: vi.fn(),
     now: () => nowMs,
     advance: (ms: number) => { nowMs += ms; },
     ...overrides,
@@ -39,10 +37,6 @@ function resume(checker: ReturnType<typeof createResumeUpdateChecker>) {
   checker.handleAppStateChange('background');
   return checker.handleAppStateChange('active');
 }
-
-afterEach(() => {
-  resetForcedPromptedForTest();
-});
 
 describe('createResumeUpdateChecker 触发条件', () => {
   it('创建后立刻 resume:间隔不足 → 不检查(冷启动刚查过)', () => {
@@ -184,30 +178,27 @@ describe('createResumeUpdateChecker 整包路径', () => {
     expect(deps.onForcedUpdate).toHaveBeenCalledOnce();
   });
 
-  it('同一强更目标多次 resume → 只提示一次(去重)', async () => {
+  it('同一强更目标多次 resume → 每次都上报(阻断态幂等,本层不去重)', async () => {
+    // 去重曾是必需的(强更是一次性 Alert);改成阻断态后 enterForcedUpdate 幂等,
+    // 本层不再持有"已提示过"状态 —— 也就不会因为一次未展示而让强更永久失声。
     const deps = makeDeps({ fetchLatest: vi.fn(async () => latestRecord({ minVersion: '2.0.0' })) });
     const checker = createResumeUpdateChecker(deps, { minIntervalMs: 0 });
     deps.advance(1);
     await resume(checker);
     deps.advance(1);
     await resume(checker);
-    expect(deps.onForcedUpdate).toHaveBeenCalledOnce();
+    expect(deps.onForcedUpdate).toHaveBeenCalledTimes(2);
   });
 
-  it('onForcedUpdate 未标记(模拟无 URL 静默失败)→ 下次 resume 重试,不永久失声', async () => {
-    // callback 不调 markForcedPrompted,模拟 promptBundleUpdate 因无安装 URL 提前 return。
-    const onForcedUpdate = vi.fn();
+  it('同 runtimeVersion 但低于 minVersion → 依旧上报强更', async () => {
+    // 服务端事后给某个已发布版本下发门槛时,装机 runtimeVersion 与 /latest 相同,
+    // 但 version 低于门槛 —— 不能因为"指纹没变"就放过。
     const deps = makeDeps({
-      fetchLatest: vi.fn(async () => latestRecord({ minVersion: '2.0.0' })),
-      onForcedUpdate,
+      fetchLatest: vi.fn(async () => latestRecord({ runtimeVersion: '1', minVersion: '2.0.0' })),
     });
-    const checker = createResumeUpdateChecker(deps, { minIntervalMs: 0 });
-    deps.advance(1);
-    await resume(checker);
-    deps.advance(1);
-    await resume(checker);
-    // 未标记 → guard 每次都放行,强更不会因一次未展示而永久失声。
-    expect(onForcedUpdate).toHaveBeenCalledTimes(2);
+    const { bundle } = await runOnce(deps);
+    expect(bundle).toBe('forced');
+    expect(deps.onForcedUpdate).toHaveBeenCalledOnce();
   });
 
   it('/latest 拉取失败 → error(fail-open),不影响 OTA 结果', async () => {
@@ -215,15 +206,6 @@ describe('createResumeUpdateChecker 整包路径', () => {
     const { ota, bundle } = await runOnce(deps);
     expect(bundle).toBe('error');
     expect(ota).toBe('up-to-date');
-  });
-
-  it('启动路径已标记强更 → resume 不再弹(跨路径去重)', async () => {
-    // 模拟启动路径弹过强更:直接调用模块级 markForcedPrompted
-    markForcedPrompted('2');
-    const deps = makeDeps({ fetchLatest: vi.fn(async () => latestRecord({ minVersion: '2.0.0' })) });
-    const { bundle } = await runOnce(deps);
-    expect(bundle).toBe('forced');
-    expect(deps.onForcedUpdate).not.toHaveBeenCalled(); // 已标记过,不再回调
   });
 
   it('/latest 挂起 → withTimeout backstop 触发 error(fail-open),不影响 OTA', async () => {

--- a/apps/mobile/src/update/resumeUpdateCheck.ts
+++ b/apps/mobile/src/update/resumeUpdateCheck.ts
@@ -5,7 +5,7 @@
 // - JS OTA:静默 check → fetch,**绝不 reload**(reload 会闪屏断状态);下载好的 bundle
 //   由 expo-updates 在下次冷启动自动生效。
 // - 整包(runtimeVersion 变化):静默拉 /latest 比对;唯一允许出 UI 的情况是命中
-//   minVersion 强更(强更本身无法无感),且同一目标 runtimeVersion 进程内只回调一次;
+//   minVersion 强更(强更本身无法无感),此时上报给 onForcedUpdate 进入阻断态;
 //   非强更完全静默(启动路径已有一次性提示,不在每次切回时骚扰)。
 // - 节流:只认真正的 background → active(iOS 通知中心/来电导致的 inactive 抖动不算),
 //   两次检查最小间隔 minIntervalMs;创建时间视为"刚检查过"(冷启动路径刚跑完,首次
@@ -15,25 +15,9 @@
 import { evaluateBundleUpdate, type BundleUpdateEvaluation } from './bundleUpdate';
 import { withTimeout } from './startupOtaUpdate';
 
-// 模块级强更提示去重:同一 runtimeVersion 进程内只弹一次,跨启动路径和 resume 路径共享。
-// 启动路径(useBundleUpdatePrompt)弹强更时调 markForcedPrompted 写入,resume 路径检查前
-// 先查 hasForcedPrompted,避免冷启动已弹过的强更在 5 分钟后 resume 时再弹一次。
-const promptedForcedRuntimes = new Set<string>();
-
-/** 标记某 runtimeVersion 的强更已提示过(启动路径弹窗后调用)。 */
-export function markForcedPrompted(runtimeVersion: string): void {
-  promptedForcedRuntimes.add(runtimeVersion);
-}
-
-/** 查询某 runtimeVersion 是否已提示过强更。 */
-export function hasForcedPrompted(runtimeVersion: string): boolean {
-  return promptedForcedRuntimes.has(runtimeVersion);
-}
-
-/** 仅供单测重置模块级状态。 */
-export function resetForcedPromptedForTest(): void {
-  promptedForcedRuntimes.clear();
-}
+// 强更不再需要"是否已提示过"的去重:它现在是阻断态而不是一次性弹窗,onForcedUpdate
+// (promptBundleUpdate → enterForcedUpdate)对同一目标幂等,重复上报不会产生重复 UI。
+// 反过来说,去重曾经引入过风险:标记了却没展示,强更就对本进程永久失声。
 
 export type ResumeOtaOutcome = 'skipped' | 'up-to-date' | 'fetched' | 'error';
 export type ResumeBundleOutcome = 'skipped' | 'up-to-date' | 'update-available' | 'forced' | 'error';
@@ -55,9 +39,9 @@ export interface ResumeUpdateCheckDeps {
   getCurrentRuntimeVersion: () => string | null | undefined;
   getCurrentVersion: () => string | null | undefined;
   /**
-   * 强更时的唯一 UI 出口。契约:实现必须在**实际展示**强更提示后调用 markForcedPrompted
-   * 标记该 runtimeVersion(见 promptBundleUpdate),本层据此跨路径去重、且只在确认展示后才标记
-   * ——若实现因故未展示(如无安装 URL)则不应标记,以便下次 resume 重试。
+   * 强更时的唯一 UI 出口(实参是 promptBundleUpdate → 进入模块级阻断态)。
+   * 契约:实现必须幂等 —— 本层每次命中强更都会上报,不做去重;
+   * 实现因故无法给出出口(如拿不到安装地址)时应自行 no-op,不要留下无出口的阻断屏。
    */
   onForcedUpdate: (evaluation: BundleUpdateEvaluation) => void;
   now: () => number;
@@ -93,7 +77,7 @@ export interface ResumeUpdateChecker {
   handleAppStateChange: (next: string) => Promise<ResumeUpdateOutcome> | null;
 }
 
-/** 创建 resume 检查器(持有节流/在途/已提示状态;一个 App 进程一个实例)。 */
+/** 创建 resume 检查器(持有节流/在途状态;一个 App 进程一个实例)。 */
 export function createResumeUpdateChecker(
   deps: ResumeUpdateCheckDeps,
   {
@@ -136,10 +120,8 @@ export function createResumeUpdateChecker(
       });
       if (!evaluation.needsUpdate || !evaluation.target) return 'up-to-date';
       if (!evaluation.forced) return 'update-available'; // 非强更静默:启动路径已负责提示
-      // 去重标记由 onForcedUpdate(promptBundleUpdate)在确认展示弹窗后统一负责,
-      // 这里只做 guard、不预先标记,避免"caller 已标记但 callee 未展示"竞态。
       if (deps.isCurrent && !deps.isCurrent()) return 'skipped';
-      if (!hasForcedPrompted(evaluation.target.runtimeVersion)) deps.onForcedUpdate(evaluation);
+      deps.onForcedUpdate(evaluation); // 幂等,不去重:阻断态重复上报无副作用
       return 'forced';
     } catch {
       return 'error'; // fail-open:连不上更新服务静默放过

--- a/apps/mobile/src/update/useBundleUpdatePrompt.ts
+++ b/apps/mobile/src/update/useBundleUpdatePrompt.ts
@@ -22,7 +22,7 @@ import {
   shouldCheckBundleUpdate,
 } from './bundleUpdate';
 import type { BundleUpdateCheckOutcome } from './manualUpdateCheck';
-import { markForcedPrompted } from './resumeUpdateCheck';
+import { enterForcedUpdate } from './forcedUpdateStore';
 import { isCanaryChannel } from './canaryChannelStore';
 
 type CheckState = 'idle' | 'checking' | 'up-to-date' | 'update-available' | 'error';
@@ -52,26 +52,36 @@ async function openInstall(url: string): Promise<void> {
   }
 }
 
-/** 弹出整包更新引导(强更不可取消)。启动/设置页检查与 resume 静默检查的强更路径共用。 */
+/** 阻断屏的「去更新」出口:解析安装地址并交给系统。无可用地址则 no-op。 */
+export function openBundleInstall(target: { itmsUrl?: string; installUrl?: string }): void {
+  const url = preferredInstallUrl(target);
+  if (url) void openInstall(url);
+}
+
+/**
+ * 整包更新的统一出口。启动/设置页检查与 resume 静默检查共用。
+ * - 强更:不弹窗,进入模块级阻断态,由 root 层渲染只有「去更新」的闸门屏。
+ *   弹窗做不到阻断——RN Alert 的按钮点一下就关(cancelable: false 只挡点外部/返回键),
+ *   弹窗消失后底下的 App 照旧可用,那是"强提醒"不是"强制"。
+ * - 非强更:可跳过的普通提示,行为不变。
+ * 两种情况都要求先解析出可跳转的安装地址:拿不到地址就什么都不做,
+ * 尤其不能把用户关进一个没有出口的阻断屏(见 forcedUpdateStore 的三层保证)。
+ */
 export function promptBundleUpdate(evaluation: ReturnType<typeof evaluateBundleUpdate>): void {
   if (!evaluation.target) return;
   const url = preferredInstallUrl(evaluation.target);
   if (!url) return;
+
+  if (evaluation.forced) {
+    enterForcedUpdate(evaluation.target);
+    return;
+  }
+
   const notes = evaluation.target.releaseNotes?.trim();
   const message = [
     i18n.t('update.bundleAvailableBody'),
     notes ? i18n.t('update.releaseNotes', { notes }) : '',
   ].join('');
-
-  if (evaluation.forced) {
-    // 确认有可跳转 URL、即将展示强更弹窗时才标记去重(模块级 Set,跨启动/resume 路径共享)。
-    // 必须在 url 校验之后标记:若无 URL 提前 return 则不标记,下次 resume 仍会重试,
-    // 避免"已标记但未展示"导致强更对本进程永久失声。
-    markForcedPrompted(evaluation.target.runtimeVersion);
-    // 强制更新:不可取消,只留"去更新"。
-    Alert.alert(i18n.t('update.forcedTitle'), message, [{ text: i18n.t('update.goUpdate'), onPress: () => void openInstall(url) }], { cancelable: false });
-    return;
-  }
   Alert.alert(i18n.t('update.newVersionTitle'), message, [
     { text: i18n.t('update.later'), style: 'cancel' },
     { text: i18n.t('update.goUpdate'), onPress: () => void openInstall(url) },

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -18,6 +18,9 @@ import {
 } from './forcedUpdateStore';
 import { isCanaryChannel } from './canaryChannelStore';
 
+/** 定时敲门间隔;真实请求频率仍由核对器内部节流决定(默认 30s)。 */
+const RECHECK_TICK_MS = 30_000;
+
 export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
   useEffect(() => {
     let current = true;
@@ -47,9 +50,16 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
     const subscription = AppState.addEventListener('change', (next) => {
       void rechecker.handleAppStateChange(next);
     });
+    // 定时兜底:光靠 AppState 跳变不够 —— 用户就停在阻断屏上不动时没有任何跳变,
+    // 而在后台被置位又在节流窗口内回前台的那次 'active' 也会被节流丢掉。
+    // 实际请求频率由核对器内部节流(默认 30s)决定,这里只负责按时敲门。
+    const timer = setInterval(() => {
+      void rechecker.handleTick();
+    }, RECHECK_TICK_MS);
     return () => {
       current = false;
       subscription.remove();
+      clearInterval(timer);
     };
   }, [isCanary]);
 }

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -27,6 +27,9 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
         undefined,
         undefined,
         isCanary,
+        // 绕开缓存:同一条记录被原地改过 minVersion 时,"同 version"证明不了新鲜度
+        // (set-mobile-min-version 就是原地改)。**放行**用户的决定不能读边缘旧记录。
+        true,
       ),
       getCurrentRuntimeVersion: () => Updates.runtimeVersion,
       getCurrentVersion: () => Constants.expoConfig?.version ?? null,

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -10,7 +10,11 @@ import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
 import { fetchLatestRelease } from './fetchLatestRelease';
 import { createForcedUpdateRechecker } from './forcedUpdateRecheck';
-import { clearForcedUpdate, enterForcedUpdate } from './forcedUpdateStore';
+import {
+  clearForcedUpdate,
+  enterForcedUpdate,
+  getForcedUpdateRevision,
+} from './forcedUpdateStore';
 import { isCanaryChannel } from './canaryChannelStore';
 
 export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
@@ -28,6 +32,8 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
       onCleared: clearForcedUpdate,
       // 仍强更时刷新目标(等值时 enterForcedUpdate 幂等,不会引发重渲染)。
       onStillForced: enterForcedUpdate,
+      // compare-and-set:核对期间若有更新的观察写入 store,本次旧结论作废。
+      getRevision: getForcedUpdateRevision,
       now: () => Date.now(),
       isCurrent: () => current,
       // 阻断态可能在 App 已切后台后才被置位(检查的 /latest 迟到返回),

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -1,0 +1,41 @@
+// 阻断屏的"回前台重新核对" hook:订阅 AppState,把真实 IO 绑进
+// createForcedUpdateRechecker(判定/节流逻辑在 forcedUpdateRecheck.ts,纯函数已单测)。
+//
+// 只在强更阻断屏挂载期间存在(见 app/_layout.tsx 的 ForcedUpdateGateContent):
+// 阻断态解除后业务树重新挂载,后续检查回到 useResumeUpdateCheck 那条常规通道。
+
+import { useEffect } from 'react';
+import { AppState, Platform } from 'react-native';
+import Constants from 'expo-constants';
+import * as Updates from 'expo-updates';
+import { fetchLatestRelease } from './fetchLatestRelease';
+import { createForcedUpdateRechecker } from './forcedUpdateRecheck';
+import { clearForcedUpdate } from './forcedUpdateStore';
+import { isCanaryChannel } from './canaryChannelStore';
+
+export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
+  useEffect(() => {
+    let current = true;
+    const rechecker = createForcedUpdateRechecker({
+      fetchLatest: () => fetchLatestRelease(
+        Platform.OS === 'android' ? 'android' : 'ios',
+        undefined,
+        undefined,
+        isCanary,
+      ),
+      getCurrentRuntimeVersion: () => Updates.runtimeVersion,
+      getCurrentVersion: () => Constants.expoConfig?.version ?? null,
+      onCleared: clearForcedUpdate,
+      now: () => Date.now(),
+      isCurrent: () => current,
+    });
+
+    const subscription = AppState.addEventListener('change', (next) => {
+      void rechecker.handleAppStateChange(next);
+    });
+    return () => {
+      current = false;
+      subscription.remove();
+    };
+  }, [isCanary]);
+}

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -14,6 +14,7 @@ import {
   clearForcedUpdate,
   enterForcedUpdate,
   getForcedUpdateRevision,
+  getForcedUpdateTarget,
 } from './forcedUpdateStore';
 import { isCanaryChannel } from './canaryChannelStore';
 
@@ -34,6 +35,8 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
       onStillForced: enterForcedUpdate,
       // compare-and-set:核对期间若有更新的观察写入 store,本次旧结论作废。
       getRevision: getForcedUpdateRevision,
+      // 新鲜度门:CDN 边缘可能返回比当前阻断目标更旧的记录,那种记录不得用来解除。
+      getHeldTarget: getForcedUpdateTarget,
       now: () => Date.now(),
       isCurrent: () => current,
       // 阻断态可能在 App 已切后台后才被置位(检查的 /latest 迟到返回),

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -10,7 +10,7 @@ import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
 import { fetchLatestRelease } from './fetchLatestRelease';
 import { createForcedUpdateRechecker } from './forcedUpdateRecheck';
-import { clearForcedUpdate } from './forcedUpdateStore';
+import { clearForcedUpdate, enterForcedUpdate } from './forcedUpdateStore';
 import { isCanaryChannel } from './canaryChannelStore';
 
 export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
@@ -26,6 +26,8 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
       getCurrentRuntimeVersion: () => Updates.runtimeVersion,
       getCurrentVersion: () => Constants.expoConfig?.version ?? null,
       onCleared: clearForcedUpdate,
+      // 仍强更时刷新目标(等值时 enterForcedUpdate 幂等,不会引发重渲染)。
+      onStillForced: enterForcedUpdate,
       now: () => Date.now(),
       isCurrent: () => current,
     });

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -30,6 +30,9 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
       onStillForced: enterForcedUpdate,
       now: () => Date.now(),
       isCurrent: () => current,
+      // 阻断态可能在 App 已切后台后才被置位(检查的 /latest 迟到返回),
+      // 那时本实例见不到 'background' 事件;这里补种当前状态。
+      getAppState: () => AppState.currentState,
     });
 
     const subscription = AppState.addEventListener('change', (next) => {

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -54,6 +54,10 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
     // 而在后台被置位又在节流窗口内回前台的那次 'active' 也会被节流丢掉。
     // 实际请求频率由核对器内部节流(默认 30s)决定,这里只负责按时敲门。
     const timer = setInterval(() => {
+      // 只在前台敲门:部分平台 / 配置下定时器在后台仍会触发,那会白发 /latest
+      // (耗电 + 无谓的后台网络)。回前台那一刻由 AppState 通道负责,
+      // 定时兜底只需要覆盖"用户停在前台的阻断屏上、没有任何跳变"这一种场景。
+      if (AppState.currentState !== 'active') return;
       void rechecker.handleTick();
     }, RECHECK_TICK_MS);
     return () => {

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -27,9 +27,6 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
         undefined,
         undefined,
         isCanary,
-        // 绕开缓存:同一条记录被原地改过 minVersion 时,"同 version"证明不了新鲜度
-        // (set-mobile-min-version 就是原地改)。**放行**用户的决定不能读边缘旧记录。
-        true,
       ),
       getCurrentRuntimeVersion: () => Updates.runtimeVersion,
       getCurrentVersion: () => Constants.expoConfig?.version ?? null,


### PR DESCRIPTION
## 这次改了什么

### 摘要

强更从「不可取消的弹窗」改成真正的阻断式闸门。

强更此前是一个 `cancelable: false` 的单按钮 Alert。但 RN Alert 的按钮点一下就关(`cancelable` 只挡点外部 / 返回键),弹窗消失后 App 照旧可用,而且模块级去重让本进程内不再弹 —— 实际效果是「强提醒」而不是「强制」。同时 `forced` 判定被压在 runtimeVersion 门闸之下:同指纹的旧构建即便 version 低于 `minVersion` 也判不出强更,发布链写下的门槛对它们完全无效。

本 PR 把强更改为:命中门槛 → root 层不再挂载业务树 → 渲染一个唯一出口是「去更新」的闸门屏。

发布链一侧下发 `minVersion` 的能力已在 cindy-build-scripts 落地(`release-{ios,android}-local.mjs --min-version`、`set-mobile-min-version.mjs` 事后改门槛不重发包),本 PR 是客户端对应的消费侧。

> 说明:本 PR 取代已关闭的 #1024 —— 那条基于 c30fcb62,与后续 main 上的更新链改动(`otaReloadGuard`、iOS 状态栏改造、`PrecreatedWorktreeRecoveryBridge`)脱节,故在最新 main 上重做。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(线下讨论);取代 #1024
- 本 PR 包含:
  - `bundleUpdate.ts`:`forced` 与 runtimeVersion 解耦。先算 `forced`,为真即 `needsUpdate`,与指纹是否变化无关;非 forced 仍要求 runtimeVersion 不同。同指纹强更时 `target.runtimeVersion` 等于当前值,已在注释与测试里钉明「不得据此判断换了指纹」。
  - `forcedUpdateStore.ts`(新):模块级阻断态 + 订阅 + `useForcedUpdate()` + `clearForcedUpdate()`。启动检查 / 设置页手动检查 / resume 静默检查三条路径都能置位,所以状态不能挂在某个 hook 上。
  - `forcedUpdateRecheck.ts` + `useForcedUpdateRecheck.ts`(新,review 反馈后补):阻断期间业务树整体不挂载,`useResumeUpdateCheck` 随之停摆 —— 所以阻断屏自带一次「回前台重新核对」(`background → active`,节流 30s):门槛被撤回即自动解除,服务端修正了安装地址 / 换了更高目标则刷新 target。**方向不对称是刻意的**:进入阻断 fail-open(拉不到 `/latest` 就放行,更新服务故障不该锁死用户),解除阻断 fail-closed(拉取失败 / 记录解析不出 / 拿不到本机 version 一律维持阻断,不能靠飞行模式绕过)。
  - `useBundleUpdatePrompt.ts`:forced 分支不再弹窗,改为 `enterForcedUpdate`;保留「拿不到安装地址就 no-op」。新增 `openBundleInstall` 给闸门用。
  - `app/_layout.tsx`:`forcedUpdate` 置位即 short-circuit 业务树,复用端点错误屏那套阻断内容层(`retryLabel/onRetry` 泛化为 `actionLabel/onAction`,两个闸门共用),并隐藏常驻 splash。
  - `resumeUpdateCheck.ts`:删掉强更去重(`markForcedPrompted` / `hasForcedPrompted`)。阻断态幂等,去重反而带来「标记了却没展示就永久失声」的风险。
- 明确不包含:
  - **`app.json` 的 `expo.version` 仍是 `0.1.0`**。门槛只比 version,启用前需把它校准到真实发布序列并纳入「每次冷更前 bump」的流程;该改动会移动 EAS / TestFlight 线的 runtime fingerprint,按维护者要求单独处理。
  - 因此在校准之前,门槛只能一刀切:现网四条 stable 记录(cn/global × iOS/Android)的装机 version 全是 `0.1.0`,设成任何 > 0.1.0 的值都等于全量强更。
  - 审核模式包与 TestFlight 包仍收不到强更(`shouldCheckBundleUpdate` 排除,不能展示外部安装入口),这层不动。
  - 不动 `manualUpdateCheck.ts`:强更命中时设置页手动检查仍返回 `bundle-update-available`,阻断屏随即盖上;强更的 UI 归属是 root 闸门,不是设置页的结果文案。
- 用户可见变化:自建线用户在命中 `minVersion` 门槛时看到阻断屏而不是弹窗;**未下发 `minVersion` 时行为完全不变**(可跳过的普通更新提示原样保留)。现网四条 stable 记录目前都没有该字段(逐条确认过),所以合并后立即的用户可见变化为零。
- 是否存在 breaking change:无

### UI 变化

新增一个阻断屏,但**没有新组件、新样式、新文案**:直接复用 `app/_layout.tsx` 里端点闸门已有的阻断内容层(白底品牌宿主 `MobileLoginHandoffStage` + 唯一出口),把它的 `retryLabel` / `onRetry` 泛化成 `actionLabel` / `onAction`。文案复用既有 `update.*` key(`forcedTitle` / `bundleAvailableBody` / `releaseNotes` / `goUpdate`),四语已齐,未新增术语(`pnpm check:i18n-glossary` 通过)。

一处需要 reviewer 知情、但**本 PR 刻意不改**的既有行为:阻断屏不挂 `Stack`,而 iOS 状态栏样式现在由 `Stack.screenOptions.statusBarStyle` 提供(main 上的 iOS 27 改造),所以闸门屏期间 iOS 状态栏跟 VC 默认。这与端点错误屏**完全相同**,不是本 PR 引入的回归;若要让闸门屏也控状态栏,那是两个闸门一起改的独立议题。

- 引用的设计规范:
  - `docs/design-rules/DESIGN.md` §10 Theme System & Token Reference —— 「always write tokens, never hex」:阻断层沿用 `makeGateStyles(colors)`,颜色全部走 `colors.textPrimary` / `colors.textSecondary` / `colors.surface` 语义 token,本次未引入任何 hex / rgba。
  - `apps/mobile/docs/mobile-design-guide.md` §2 颜色 token、§3 字体与排版、§4 主题接入模式(强制)—— 复用 `useThemedStyles`,字号 `typeScale.title` / `typeScale.body`,字重 `fontWeight.medium`,圆角 `radius.control`,间距 `spacing.*`,无阶梯外字面量。
  - 双模式:light / dark 均由上述 token 覆盖,无单模式硬编码或条件补丁;**实机目检未做**(理由见下)。
  - 阻断语义与既有端点错误屏一致(该层原注释):没有「跳过 / 稍后再说」,只有一个出口。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run
结果:282 文件 / 3022 项全部通过

pnpm --filter mobile run --if-present typecheck
结果:通过(tsc --noEmit 无输出)

pnpm --filter mobile run test:scope
结果:mobile-scope-guard passed

pnpm check:i18n-glossary
结果:✅ 术语表 32 条已裁决 / 35 条待讨论,en / zh-CN / ja / ko 无新增违规

pnpm check:dco
结果:DCO check passed: 3 commits signed off

pnpm test:unit
结果:54 个 workspace 全绿,apps/desktop 那条以 SIGSEGV 崩溃(详见「未执行的验证」)
```

新增 / 调整的测试:

- `src/update/forcedUpdateStore.test.ts`(新,9 项):幂等重复进入不通知、目标变化通知、解除后可再次进入、解除幂等、取消订阅、单订阅者抛错隔离。
- `src/update/forcedUpdateRecheck.test.ts`(新,14 项):节流与 inactive 抖动、门槛撤回 / 降低 → 解除、门槛仍在 → 维持并刷新 target、服务端修正安装地址 / 换更高目标 → 刷新 target、拉取失败 / 超时 / 记录解析不出 / 缺本机 version → 维持阻断且不误刷新、阻断屏卸载后迟到结果不解除。
- `src/__tests__/forcedUpdateGate.test.ts`(新,4 项,读源码断言):阻断分支必须先于业务树分支、闸门无「稍后」出口、forced 不再走 Alert(剥掉注释后 `not.toMatch(/cancelable/)`,按 review 建议改成与格式无关的写法)、store 不落盘、阻断屏挂了回前台核对且解除方向 fail-closed。
- `src/update/bundleUpdate.test.ts` 补 3 项:同指纹低于门槛 → 仍强更且 `target.runtimeVersion` 等于当前值;同指纹达标 → 无更新;缺 `currentVersion` → fail-open 不强更。
- `src/update/resumeUpdateCheck.test.ts`:去重相关的 3 项按新契约重写(「每次 resume 都上报」+ 新增「同 runtimeVersion 但低于门槛仍上报」)。
- 两处受影响的既有读源码契约测试:`startupSplashOverlay.test.ts` 的 splash 断言改为「只挂载一个实例 + hidden 覆盖两个交互闸门」的宽松形式(不再锁死整个表达式字面量,后续增删闸门不必连带改);`loginHandoffState.test.ts` 的 prop 名跟随泛化。两者 intent 未变。

### 手工验证

不涉及。

### 未执行的验证

- **模拟器实机目检(light / dark 各一次)未做**:阻断屏只在命中 `minVersion` 门槛时出现,需要起模拟器并 mock 一次带 `minVersion` 的 `/latest`。颜色全部走语义 token、复用已有 themed 样式,但按 `DESIGN.md` 双模式交付门槛的要求,这里如实声明「两种模式均未实机目检」,不把「复用了 themed 样式」当成「双模式已验证」。
- **`apps/desktop` 的 unit 套件在本机以 SIGSEGV 崩溃**(vitest worker 段错误,不是断言失败)。已在未改动的干净 main(133cb012)worktree 上复现同一崩溃,确认属本机环境问题、与本次改动无关;本 PR 只改 `apps/mobile`。以 CI 结果为准。
- 端到端强更链路(发布链写 `minVersion` → 客户端阻断 → 跳商店 → 装新版本解除阻断)未跑:依赖发布链侧改动上线 + 一次 dev 渠道真实发版。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- **不触发冷更**:本 PR 只改 `apps/mobile/src` 与 `apps/mobile/app`(纯 JS/TS),不碰 `app.json` / `app.config.js` / `eas.json` / `plugins/` / `modules/` / `apps/mobile/package.json`,runtime fingerprint 不变,可热更下发。会移动指纹的 `expo.version` 校准被刻意排除。
- 影响范围:归类 OTA 是因为改的是更新链的判定与 UI 出口。只在 `release.json` 带 `minVersion` 时才有行为差异。
- 阻断期间整棵业务树不挂载(含 `AuthProvider` / `DeviceLinkProvider` / `PrecreatedWorktreeRecoveryBridge`)。这是刻意的:强更期间不该发起任何 Device Link 调用;预创建 worktree 的恢复账本是持久化的,阻断解除后下次启动照常补偿,不会丢。
- 最坏情况:误下发的门槛把用户挡在阻断屏外。五层缓解 ——
  1. 客户端 fail-open:`/latest` 拉不到(离线 / 超时 / 5xx)不进入阻断态,更新服务故障不会锁死用户;
  2. 拿不到可跳转安装地址不进入阻断态,不造无出口的屏;
  3. 门槛必须 ≤ 该 record 的 version(发布链 `assertMinVersionUsable` fail closed),装了被广播的版本必然解除;
  4. 阻断态不持久化 —— 与 `otaReloadGuard` 的关键区别:那道门挡的是故障循环,必须落盘计数并自带放弃条件;本模块是产品意图的阻断,不落盘本身就是自愈路径;
  5. 阻断屏自带回前台重新核对(review 反馈后补):门槛被撤回后**切出去再回来即自动解除,不必杀进程冷启动**;服务端修正安装地址后按钮指向也会刷新,不会一直打开旧链接。
- 回滚 / 降级方式:两条独立路径 —— 运维侧 `set-mobile-min-version --clear`(不重发包,被阻断的用户切后台再回前台即恢复);代码侧 revert 本 PR 后走 JS 热更下发。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
