### PR TITLE
test(desktop): 修复 saveDeposit 完整性测试的 Windows mock

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/saveDeposit.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/saveDeposit.test.ts
@@ -90,9 +90,13 @@ describe('SaveDepositVault', () => {
     const originalStatSync = fs.statSync.bind(fs);
     const statSpy = vi.spyOn(fs, 'statSync').mockImplementationOnce((filePath) => {
       const stat = originalStatSync(filePath);
-      return Object.assign(Object.create(Object.getPrototypeOf(stat)), stat, {
-        ino: stat.ino + 1,
-      }) as fs.Stats;
+      const tamperedIno = stat.ino === 0 ? 1 : 0;
+      return new Proxy(stat, {
+        get(target, property, receiver) {
+          if (property === 'ino') return tamperedIno;
+          return Reflect.get(target, property, receiver);
+        },
+      });
     });
     try {
       await expect(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 saveDeposit 完整性测试在 Windows 上无法可靠制造 inode 不一致的问题。Windows 的 `fs.Stats.ino` 可能超过 JavaScript 安全整数范围，原测试使用 `ino + 1` 时可能仍得到相同数值，导致预期的篡改未生效。

改用 `Proxy` 在读取 `ino` 时返回确定不同的 0/1 值，保留原 `Stats` 对象的其它行为。仅修改测试，不改运行时代码。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：修正 saveDeposit 写入前完整性校验用例的 inode mock
- 明确不包含：device-link 或 saveDeposit 运行时代码改动
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test -- src/main/cindy-brain/__tests__/saveDeposit.test.ts
结果：14 个测试通过

pnpm test:unit
结果：全仓单元测试通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

未单独执行 macOS / Linux 实机测试；本改动仅调整测试 mock，且不再依赖 `fs.Stats` 属性写入或不安全整数加法。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 的 saveDeposit 单元测试；不影响运行时行为。
- 回滚 / 降级方式：回退本 PR 的测试提交即可。
- 移动端冷更判断：不涉及 `apps/mobile` 原生配置、原生依赖或 runtime fingerprint 输入，不会触发冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本改动无需文档）
- [x] 已确认测试结果或说明未执行原因