### PR TITLE
test(desktop): composerSendSnapshot fixture 跟上类型演进(修 main 基线 typecheck 红)

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerSendSnapshot.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerSendSnapshot.test.ts
@@ -10,7 +10,7 @@ const attachment = {
   id: 'file-1',
   name: 'one.txt',
   path: '/tmp/one.txt',
-  ext: 'txt',
+  ext: '.txt',
   size: 3,
   category: 'text' as const,
   mimeType: 'text/plain',

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/composerSendSnapshot.test.ts
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/composerSendSnapshot.test.ts
@@ -12,13 +12,31 @@ const attachment = {
   path: '/tmp/one.txt',
   ext: 'txt',
   size: 3,
-  category: 'document' as const,
+  category: 'text' as const,
+  mimeType: 'text/plain',
 };
 const comment = {
   id: 'comment-1',
   markerNumber: 1,
+  pageUrl: 'https://example.com/page',
+  target: {
+    kind: 'element' as const,
+    point: { x: 10, y: 10 },
+    viewport: { width: 1280, height: 800 },
+    region: null,
+    selectedText: null,
+    immediate: false,
+    targetTag: 'div',
+    targetLabel: null,
+    targetRole: null,
+    targetSelector: '#one',
+    targetPath: null,
+    nearbyText: null,
+    themeVariant: null,
+    designBaseline: null,
+    markerNumber: 1,
+  },
   comment: 'keep this',
-  selector: { type: 'element' as const, value: '#one' },
   screenshot: attachment,
 };
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 main 基线 typecheck 红(正在挡所有 PR 的 verify,实测 #1520 因此失败):`composerSendSnapshot.test.ts` 与「`AttachedFile` 增加必填 `mimeType`、`FileCategory` 枚举重构(`document`→`text` 等)、`BrowserCommentDraftItem` 增加 `pageUrl`/`target`」的类型演进并行合入后 fixture 全面过时——与 #1498 修的 outbox TTL 断言脱节同型的并行 PR 合并交互。按当前类型补齐 fixture,产品代码零改动。

### 变更类型

- [x] `test` 测试

### 范围

- 本 PR 包含:单测试文件 fixture 补齐
- 用户可见变化:无;breaking change:无

### UI 变化

- 引用的设计规范:不涉及:纯测试 fixture 修正(路径命中 renderer/components 但无任何视觉/交互/文案变化,产品代码零改动)。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck:0 错误(修复前 6+ 处)
composerSendSnapshot.test.ts 2/2 通过;run-unit-gate.sh 全仓 GATE_EXIT=0
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 其他:纯测试 fixture 修正

### 影响与回滚

- 单测试文件;revert 即回(main 重新变红)。建议尽快合入解除 CI 阻塞。

### 多端适配说明(remote-and-mobile-adaptation)

不涉及(纯测试)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(不适用)
- [x] 已确认测试结果或说明未执行原因
