### PR TITLE
feat(desktop): Git 安全保存点改为隐藏引用 shadow savepoint,不再污染用户分支

### DIFF
--- a/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Shadow file-restore executor tests with real temporary repositories.
+ *
+ * shadow 链用 createShadowSavepoint 手工构造(turn-start / after-edit),
+ * 校验 restore 只改工作区受影响文件,HEAD / 分支 / 用户 index 永不变,
+ * dirty 工作区不再被拒绝,失败时自动补偿回执行前状态。
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { TestDirectoryTemplate } from '../../test/vitest/testDirectoryTemplate';
+import {
+  executeCodexFileRestorePlan,
+  executeCodexFileRestorePlanWithThreadRollback,
+} from '../git-snapshot/codexFileRestoreExecutor';
+import type { CodexFileRestorePlan } from '../git-snapshot/codexFileRewindPlanner';
+import { enqueueGitRepoWrite } from '../git-snapshot/gitRepoWriteQueue';
+import { createShadowSavepoint, listShadowSavepoints } from '../git-snapshot/gitSnapshotService';
+import { readSavepointTip, savepointRefForSession } from '../git-snapshot/savepointRefs';
+import { parseSnapshotCommit } from '../git-snapshot/snapshotTrailers';
+import { gitExec } from '../worktree/gitExec';
+
+const REAL_GIT_TEST_TIMEOUT_MS = process.platform === 'win32' ? 60_000 : 20_000;
+const SESSION = 'sess-1';
+
+let repoPath: string;
+
+const repoTemplate = new TestDirectoryTemplate('xdt-codex-restore-', async (dir) => {
+  await gitExec(['init'], dir);
+  await gitExec(['config', 'user.email', 'test@xdt.local'], dir);
+  await gitExec(['config', 'user.name', 'XDT Test'], dir);
+  await gitExec(['config', 'commit.gpgsign', 'false'], dir);
+  await gitExec(['config', 'core.autocrlf', 'false'], dir);
+});
+
+async function initRepo(): Promise<string> {
+  const dir = await repoTemplate.createCopy();
+  // 仓库级覆写 core.excludesFile:宿主机全局 gitignore(常见如 *.tmp)会吞掉
+  // 未跟踪文件,让 status 断言在部分开发机上失真。
+  const excludesOverride = path.join(dir, '.git', 'xdt-test-empty-excludes');
+  await fs.writeFile(excludesOverride, '', 'utf8');
+  await gitExec(['config', 'core.excludesFile', excludesOverride], dir);
+  return dir;
+}
+
+async function writeFile(gitPath: string, content: string): Promise<void> {
+  const file = path.join(repoPath, ...gitPath.split('/'));
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, content, 'utf8');
+}
+
+async function readFile(gitPath: string): Promise<string> {
+  return fs.readFile(path.join(repoPath, ...gitPath.split('/')), 'utf8');
+}
+
+async function gitStdout(args: string[]): Promise<string> {
+  return (await gitExec(args, repoPath)).stdout;
+}
+
+async function head(): Promise<string> {
+  return (await gitStdout(['rev-parse', 'HEAD'])).trim();
+}
+
+async function gitInternalPath(gitPath: string): Promise<string> {
+  const resolved = (await gitStdout(['rev-parse', '--git-path', gitPath])).trim();
+  return path.isAbsolute(resolved) ? resolved : path.resolve(repoPath, resolved);
+}
+
+async function commitAll(message: string): Promise<string> {
+  await gitExec(['add', '-A'], repoPath);
+  await gitExec(['commit', '--no-gpg-sign', '-m', message], repoPath);
+  return head();
+}
+
+async function shadowSavepoint(
+  kind: 'turn-start' | 'after-edit',
+  extraMeta: { baselineCommit?: string } = {},
+): Promise<string> {
+  const result = await createShadowSavepoint(repoPath, {
+    sessionId: SESSION,
+    label: kind === 'turn-start' ? '本轮开始时的工作区基线' : 'after m1',
+    meta: { kind, anchor: 'm1', ...extraMeta },
+  });
+  if (!result.commit) throw new Error(`expected ${kind} savepoint commit`);
+  return result.commit;
+}
+
+function buildPlan(
+  turns: Array<{ commit: string; baselineCommit: string }>,
+  currentHead: string,
+): CodexFileRestorePlan {
+  return {
+    mode: 'file-restore',
+    sessionId: SESSION,
+    targetMessageClientId: 'm1',
+    targetMessageCreatedAt: 100,
+    tailTurnsToDrop: turns.length,
+    conversationWillRewind: true,
+    repoRoot: repoPath,
+    currentHead,
+    baselineCommit: turns[turns.length - 1].baselineCommit,
+    restoreCommitsNewestFirst: turns.map((turn) => ({ ...turn, anchor: 'm1' })),
+  };
+}
+
+/**
+ * 标准转场:seed 三个文件 → 无关 dirty 改动(keep.txt,staged)→ turn-start
+ * → 本轮改 app.txt、新建 nested/new.txt、删 gone.txt → after-edit。
+ */
+async function seedTurnFixture(): Promise<{
+  turnStart: string;
+  afterEdit: string;
+  plan: CodexFileRestorePlan;
+}> {
+  await writeFile('app.txt', 'base\n');
+  await writeFile('keep.txt', 'keep base\n');
+  await writeFile('gone.txt', 'gone base\n');
+  await commitAll('seed');
+
+  await writeFile('keep.txt', 'keep dirty\n');
+  await gitExec(['add', 'keep.txt'], repoPath);
+
+  const turnStart = await shadowSavepoint('turn-start');
+  await writeFile('app.txt', 'edited\n');
+  await writeFile('nested/new.txt', 'created\n');
+  await fs.rm(path.join(repoPath, 'gone.txt'));
+  const afterEdit = await shadowSavepoint('after-edit', { baselineCommit: turnStart });
+
+  return {
+    turnStart,
+    afterEdit,
+    plan: buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head()),
+  };
+}
+
+async function chainTip(): Promise<string | null> {
+  return readSavepointTip(repoPath, SESSION);
+}
+
+async function commitMessageOf(commitish: string): Promise<string> {
+  return gitStdout(['log', '-1', '--format=%B', commitish]);
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  throw new Error('condition was not met');
+}
+
+beforeEach(async () => {
+  repoPath = await initRepo();
+});
+
+afterEach(async () => {
+  await fs.rm(repoPath, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+});
+
+afterAll(async () => {
+  await repoTemplate.dispose();
+});
+
+describe('executeCodexFileRestorePlan', () => {
+  it('restores edits, deletes turn-created files, recreates missing baseline files and keeps unrelated dirty state', async () => {
+    const { turnStart, afterEdit, plan } = await seedTurnFixture();
+    const headBefore = await head();
+    const branchBefore = await gitStdout(['branch', '--show-current']);
+    const cachedDiffBefore = await gitStdout(['diff', '--cached']);
+    expect(cachedDiffBefore).toContain('keep dirty');
+
+    const result = await executeCodexFileRestorePlan(plan, {
+      createRollbackId: () => 'rb-restore',
+    });
+
+    // 受影响文件回到 turn-start 基线。
+    expect(await readFile('app.txt')).toBe('base\n');
+    expect(await readFile('gone.txt')).toBe('gone base\n');
+    // 本轮新建的 untracked 文件被删,空目录被清。
+    await expect(readFile('nested/new.txt')).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.lstat(path.join(repoPath, 'nested'))).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+    // dirty worktree 不再被拒绝,非受影响的 dirty 改动原样保留。
+    expect(await readFile('keep.txt')).toBe('keep dirty\n');
+
+    // HEAD / 分支 / 用户 index 全程不变。
+    expect(await head()).toBe(headBefore);
+    expect(await gitStdout(['branch', '--show-current'])).toBe(branchBefore);
+    expect(await gitStdout(['diff', '--cached'])).toBe(cachedDiffBefore);
+
+    expect(result).toBeTruthy();
+    expect(result?.rollbackId).toBe('rb-restore');
+    expect([...(result?.restoredFiles ?? [])].sort()).toEqual(['app.txt', 'gone.txt']);
+    expect(result?.deletedFiles).toEqual(['nested/new.txt']);
+    expect([...(result?.affectedPaths ?? [])].sort()).toEqual([
+      'app.txt',
+      'gone.txt',
+      'nested/new.txt',
+    ]);
+    expect(result?.preRollbackCommit).toBeTruthy();
+    expect(result?.rollbackCommit).toBeTruthy();
+    expect(result?.preRollbackCommit).not.toBe(turnStart);
+    expect(result?.preRollbackCommit).not.toBe(afterEdit);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('puts a pre-rollback savepoint on the chain whose tree equals the pre-restore worktree', async () => {
+    const { plan } = await seedTurnFixture();
+    // 参照 tree:执行前用另一条 session 链把当前工作区独立快照一次。
+    const probe = await createShadowSavepoint(repoPath, {
+      sessionId: 'ref-probe',
+      label: 'pre-exec reference',
+      meta: { kind: 'turn-start' },
+    });
+    const expectedTree = probe.tree;
+
+    const result = await executeCodexFileRestorePlan(plan, {
+      createRollbackId: () => 'rb-pre',
+    });
+
+    const preRollbackCommit = result?.preRollbackCommit as string;
+    expect((await gitStdout(['rev-parse', `${preRollbackCommit}^{tree}`])).trim()).toBe(
+      expectedTree,
+    );
+    const entries = await listShadowSavepoints(repoPath, SESSION);
+    expect(entries.map((entry) => entry.kind)).toContain('pre-rollback');
+    expect(entries.find((entry) => entry.kind === 'pre-rollback')?.commit).toBe(
+      preRollbackCommit,
+    );
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('records a rollback marker with preRollbackCommit and reverts trailers as the chain tip', async () => {
+    const { afterEdit, plan } = await seedTurnFixture();
+
+    const result = await executeCodexFileRestorePlan(plan, {
+      createRollbackId: () => 'rb-marker',
+    });
+
+    expect(result?.rollbackCommit).toBeTruthy();
+    expect(await chainTip()).toBe(result?.rollbackCommit);
+    const parsed = parseSnapshotCommit(await commitMessageOf(result?.rollbackCommit as string));
+    expect(parsed).toMatchObject({
+      source: 'cindy',
+      sessionId: SESSION,
+      kind: 'rollback',
+      rollbackId: 'rb-marker',
+      preRollbackCommit: result?.preRollbackCommit,
+      reverts: [afterEdit],
+    });
+    // rollback marker 是链上纯记账,不进 listShadowSavepoints 可回退列表。
+    const entries = await listShadowSavepoints(repoPath, SESSION);
+    expect(entries.map((entry) => entry.commit)).not.toContain(result?.rollbackCommit);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('compensates files back to the pre-restore state when thread rollback fails', async () => {
+    const { plan } = await seedTurnFixture();
+    const headBefore = await head();
+
+    await expect(
+      executeCodexFileRestorePlanWithThreadRollback(
+        plan,
+        SESSION,
+        {
+          commitThreadRollback: async () => {
+            // 文件已被恢复到基线后,thread rollback 失败。
+            expect(await readFile('app.txt')).toBe('base\n');
+            throw new Error('thread rollback failed');
+          },
+        },
+        { createRollbackId: () => 'rb-comp' },
+      ),
+    ).rejects.toThrow('thread rollback failed');
+
+    // 补偿把受影响文件恢复回执行前状态:编辑内容回来、被删的新文件补回来、
+    // 本就删除的基线文件重新删掉。
+    expect(await readFile('app.txt')).toBe('edited\n');
+    expect(await readFile('nested/new.txt')).toBe('created\n');
+    await expect(readFile('gone.txt')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await readFile('keep.txt')).toBe('keep dirty\n');
+    expect(await head()).toBe(headBefore);
+
+    // 链 tip 是 rollback-undo marker,记录补偿锚点。
+    const tip = await chainTip();
+    const parsedTip = parseSnapshotCommit(await commitMessageOf(tip as string));
+    expect(parsedTip).toMatchObject({
+      source: 'cindy',
+      sessionId: SESSION,
+      kind: 'rollback-undo',
+    });
+    expect(parsedTip?.preRollbackCommit).toBeTruthy();
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('rejects while a merge is in progress and leaves the worktree and chain untouched', async () => {
+    const { plan } = await seedTurnFixture();
+    const tipBefore = await chainTip();
+    const mergeHeadPath = await gitInternalPath('MERGE_HEAD');
+    await fs.writeFile(mergeHeadPath, `${await head()}\n`, 'utf8');
+
+    await expect(
+      executeCodexFileRestorePlan(plan, { createRollbackId: () => 'rb-merge' }),
+    ).rejects.toMatchObject({ code: 'REWIND_GIT_FAILED' });
+
+    expect(await readFile('app.txt')).toBe('edited\n');
+    expect(await readFile('nested/new.txt')).toBe('created\n');
+    await expect(readFile('gone.txt')).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await chainTip()).toBe(tipBefore);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('waits for the shared repo write queue before mutating any state', async () => {
+    const { plan } = await seedTurnFixture();
+    const tipBefore = await chainTip();
+    let release: (() => void) | undefined;
+    const blocker = enqueueGitRepoWrite(repoPath, () =>
+      new Promise<void>((resolve) => {
+        release = resolve;
+      }),
+    );
+    await waitFor(() => Boolean(release));
+
+    const resultPromise = executeCodexFileRestorePlan(plan, {
+      createRollbackId: () => 'rb-queued',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // 队列被占用期间:链不动,文件不动。
+    expect(await chainTip()).toBe(tipBefore);
+    expect(await readFile('app.txt')).toBe('edited\n');
+
+    release?.();
+    await blocker;
+    const result = await resultPromise;
+    expect(result?.rollbackCommit).toBeTruthy();
+    expect(await chainTip()).toBe(result?.rollbackCommit);
+    expect(await readFile('app.txt')).toBe('base\n');
+    // ref 名健全性:链一直挂在本 session 的隐藏引用上。
+    await expect(
+      gitExec(['show-ref', '--verify', '--quiet', savepointRefForSession(SESSION)], repoPath),
+    ).resolves.toBeTruthy();
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+});

--- a/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
@@ -278,6 +278,85 @@ describe('executeCodexFileRestorePlan', () => {
     expect(result?.deletedFiles).toContain('swap/child.txt');
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
+  it('rewinds a turn that replaced a directory with a file (reverse D/F conversion)', async () => {
+    await writeFile('swap/child.txt', 'child base\n');
+    await commitAll('seed dir');
+    const turnStart = await shadowSavepoint('turn-start');
+    // 本轮把目录 swap 替换成同名文件。
+    await fs.rm(path.join(repoPath, 'swap'), { recursive: true });
+    await writeFile('swap', 'now a file\n');
+    const afterEdit = await shadowSavepoint('after-edit', { baselineCommit: turnStart });
+    const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
+
+    const result = await executeCodexFileRestorePlan(plan, {
+      createRollbackId: () => 'rb-swap-back',
+    });
+
+    // 删除必须先于恢复:文件 swap 先删掉,再重建基线目录及后代——
+    // 否则刚恢复的目录会被随后的递归删除整个抹掉。
+    expect(await readFile('swap/child.txt')).toBe('child base\n');
+    expect(result?.deletedFiles).toContain('swap');
+    expect(result?.restoredFiles).toContain('swap/child.txt');
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('never deletes through a symlinked parent that escapes the repository', async () => {
+    if (process.platform === 'win32') return; // 符号链接在 Windows CI 上需要特权
+    await writeFile('a.txt', 'base\n');
+    await commitAll('seed');
+    const turnStart = await shadowSavepoint('turn-start');
+    // 本轮创建真实目录 evil/target.txt。
+    await writeFile('evil/target.txt', 'turn created\n');
+    const afterEdit = await shadowSavepoint('after-edit', { baselineCommit: turnStart });
+    // 用户随后把 evil 换成指向仓库外的符号链接,外部目录里有同名文件。
+    const outside = await fs.mkdtemp(path.join(path.dirname(repoPath), 'outside-'));
+    try {
+      await fs.writeFile(path.join(outside, 'target.txt'), 'precious external data\n', 'utf8');
+      await fs.rm(path.join(repoPath, 'evil'), { recursive: true });
+      await fs.symlink(outside, path.join(repoPath, 'evil'));
+
+      const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
+      const result = await executeCodexFileRestorePlan(plan, {
+        createRollbackId: () => 'rb-symlink',
+      });
+
+      // 越过符号链接的路径在构建当前工作区树时即按"不存在"处理:不产生
+      // 删除动作,外部数据毫发无损,符号链接本身原样保留。
+      expect(result?.deletedFiles).toEqual([]);
+      expect(result?.restoredFiles).toEqual([]);
+      expect(await fs.readFile(path.join(outside, 'target.txt'), 'utf8')).toBe(
+        'precious external data\n',
+      );
+      const evilStats = await fs.lstat(path.join(repoPath, 'evil'));
+      expect(evilStats.isSymbolicLink()).toBe(true);
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('aborts before mutating when an affected file is currently skipped by the safety filter', async () => {
+    await writeFile('grow.txt', 'base\n');
+    await commitAll('seed grow');
+    const turnStart = await shadowSavepoint('turn-start');
+    await writeFile('grow.txt', 'edited by turn\n');
+    const afterEdit = await shadowSavepoint('after-edit', { baselineCommit: turnStart });
+    // 用户随后把该文件撑大到超过安全过滤上限:pre-rollback 快照保护不了它。
+    const bigContent = 'x'.repeat(128);
+    await writeFile('grow.txt', bigContent);
+    const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
+
+    await expect(
+      executeCodexFileRestorePlan(plan, {
+        createRollbackId: () => 'rb-skip',
+        // 注入收紧过滤上限的包装,模拟真实 10MB 上限被超过的情形。
+        createShadowSavepoint: (repo, input) =>
+          createShadowSavepoint(repo, { ...input, fileFilter: { maxFileBytes: 64 } }),
+      }),
+    ).rejects.toMatchObject({ code: 'REWIND_GIT_FAILED' });
+
+    // 中止发生在任何文件改动之前:超限文件原样保留。
+    expect(await readFile('grow.txt')).toBe(bigContent);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
   it('compensates files back to the pre-restore state when thread rollback fails', async () => {
     const { plan } = await seedTurnFixture();
     const headBefore = await head();

--- a/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
@@ -348,14 +348,16 @@ describe('executeCodexFileRestorePlan', () => {
       await fs.symlink(outside, path.join(repoPath, 'evil'));
 
       const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
-      const result = await executeCodexFileRestorePlan(plan, {
-        createRollbackId: () => 'rb-restore-symlink',
-      });
+      // 恢复目标的最近存在祖先(evil)真实路径在仓库外 → 改动前中止:
+      // 既不把基线 blob 写到仓库外,也不允许"跳过后报成功"造成对话与
+      // 工作区不一致。外部文件与符号链接均原样。
+      await expect(
+        executeCodexFileRestorePlan(plan, { createRollbackId: () => 'rb-restore-symlink' }),
+      ).rejects.toMatchObject({ code: 'REWIND_GIT_FAILED' });
 
-      // 恢复目标的最近存在祖先(evil)真实路径在仓库外 → 跳过恢复,
-      // 基线 blob 绝不写到仓库外;外部文件原样。
-      expect(result?.restoredFiles).toEqual([]);
       expect(await fs.readFile(path.join(outside, 'target.txt'), 'utf8')).toBe('external data\n');
+      const evilStats = await fs.lstat(path.join(repoPath, 'evil'));
+      expect(evilStats.isSymbolicLink()).toBe(true);
     } finally {
       await fs.rm(outside, { recursive: true, force: true });
     }

--- a/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
@@ -333,6 +333,53 @@ describe('executeCodexFileRestorePlan', () => {
     }
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
+  it('never restores through a symlinked parent that escapes the repository', async () => {
+    if (process.platform === 'win32') return; // 符号链接在 Windows CI 上需要特权
+    await writeFile('evil/target.txt', 'baseline\n');
+    await commitAll('seed evil');
+    const turnStart = await shadowSavepoint('turn-start');
+    // 本轮删除该文件(基线有 → 回退方向是恢复)。
+    await fs.rm(path.join(repoPath, 'evil'), { recursive: true });
+    const afterEdit = await shadowSavepoint('after-edit', { baselineCommit: turnStart });
+    // 用户把 evil 换成指向仓库外的符号链接,外部目录里有同名文件。
+    const outside = await fs.mkdtemp(path.join(path.dirname(repoPath), 'outside-'));
+    try {
+      await fs.writeFile(path.join(outside, 'target.txt'), 'external data\n', 'utf8');
+      await fs.symlink(outside, path.join(repoPath, 'evil'));
+
+      const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
+      const result = await executeCodexFileRestorePlan(plan, {
+        createRollbackId: () => 'rb-restore-symlink',
+      });
+
+      // 恢复目标的最近存在祖先(evil)真实路径在仓库外 → 跳过恢复,
+      // 基线 blob 绝不写到仓库外;外部文件原样。
+      expect(result?.restoredFiles).toEqual([]);
+      expect(await fs.readFile(path.join(outside, 'target.txt'), 'utf8')).toBe('external data\n');
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('aborts when a collision directory contains files outside the rewind scope', async () => {
+    await writeFile('swap', 'base\n');
+    await commitAll('seed swap file');
+    const turnStart = await shadowSavepoint('turn-start');
+    await writeFile('swap', 'edited\n');
+    const afterEdit = await shadowSavepoint('after-edit', { baselineCommit: turnStart });
+    // 保存点之后,用户把 swap 换成目录并放入未被任何 turn 记录的手工文件。
+    await fs.rm(path.join(repoPath, 'swap'));
+    await writeFile('swap/notes.txt', 'manual notes\n');
+    const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
+
+    await expect(
+      executeCodexFileRestorePlan(plan, { createRollbackId: () => 'rb-scope' }),
+    ).rejects.toMatchObject({ code: 'REWIND_GIT_FAILED' });
+
+    // 中止且自愈:范围外的手工文件原样保留,目录未被清空。
+    expect(await readFile('swap/notes.txt')).toBe('manual notes\n');
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
   it('aborts before mutating when an affected file is currently skipped by the safety filter', async () => {
     await writeFile('grow.txt', 'base\n');
     await commitAll('seed grow');

--- a/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRestoreExecutor.git-integration.test.ts
@@ -225,7 +225,7 @@ describe('executeCodexFileRestorePlan', () => {
     expect((await gitStdout(['rev-parse', `${preRollbackCommit}^{tree}`])).trim()).toBe(
       expectedTree,
     );
-    const entries = await listShadowSavepoints(repoPath, SESSION);
+    const { entries } = await listShadowSavepoints(repoPath, SESSION);
     expect(entries.map((entry) => entry.kind)).toContain('pre-rollback');
     expect(entries.find((entry) => entry.kind === 'pre-rollback')?.commit).toBe(
       preRollbackCommit,
@@ -251,8 +251,31 @@ describe('executeCodexFileRestorePlan', () => {
       reverts: [afterEdit],
     });
     // rollback marker 是链上纯记账,不进 listShadowSavepoints 可回退列表。
-    const entries = await listShadowSavepoints(repoPath, SESSION);
+    const { entries } = await listShadowSavepoints(repoPath, SESSION);
     expect(entries.map((entry) => entry.commit)).not.toContain(result?.rollbackCommit);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('rewinds a turn that replaced a file with a directory', async () => {
+    await writeFile('swap', 'was a file\n');
+    await commitAll('seed swap');
+    const turnStart = await shadowSavepoint('turn-start');
+    // 本轮把文件 swap 替换成同名目录及子文件。
+    await fs.rm(path.join(repoPath, 'swap'));
+    await writeFile('swap/child.txt', 'child\n');
+    const afterEdit = await shadowSavepoint('after-edit', { baselineCommit: turnStart });
+    const plan = buildPlan([{ commit: afterEdit, baselineCommit: turnStart }], await head());
+
+    const result = await executeCodexFileRestorePlan(plan, {
+      createRollbackId: () => 'rb-swap',
+    });
+
+    // 目录被清掉,原文件按基线内容重建。swap 已是文件,子路径 lstat 报 ENOTDIR。
+    expect(await readFile('swap')).toBe('was a file\n');
+    await expect(fs.lstat(path.join(repoPath, 'swap/child.txt'))).rejects.toMatchObject({
+      code: 'ENOTDIR',
+    });
+    expect(result?.restoredFiles).toContain('swap');
+    expect(result?.deletedFiles).toContain('swap/child.txt');
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it('compensates files back to the pre-restore state when thread rollback fails', async () => {

--- a/apps/desktop/src/main/__tests__/codexFileRewindPlanner.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRewindPlanner.test.ts
@@ -15,10 +15,10 @@ const USER_MESSAGES: CodexRewindUserMessage[] = [
 ];
 
 function savepoint(
-  input: Omit<CodexRewindSavepoint, 'branch' | 'parentCount'> &
-    Partial<Pick<CodexRewindSavepoint, 'branch' | 'parentCount'>>,
+  input: Omit<CodexRewindSavepoint, 'branch' | 'parentCount' | 'source'> &
+    Partial<Pick<CodexRewindSavepoint, 'branch' | 'parentCount' | 'source'>>,
 ): CodexRewindSavepoint {
-  return { branch: 'main', parentCount: 1, ...input };
+  return { branch: 'main', parentCount: 1, source: 'legacy', ...input };
 }
 
 const SAVEPOINTS: CodexRewindSavepoint[] = [
@@ -326,7 +326,7 @@ describe('buildCodexFileRewindPlan', () => {
         currentHead: 'head',
         currentBranch: 'main',
         savepointsNewestFirst: [
-          { commit: 'unknown-parent', sessionId: 's1', kind: 'after-edit', branch: 'main', anchor: 'm2' } as CodexRewindSavepoint,
+          { commit: 'unknown-parent', sessionId: 's1', kind: 'after-edit', source: 'legacy', branch: 'main', anchor: 'm2' } as CodexRewindSavepoint,
         ],
       },
     }, 'MALFORMED_SAVEPOINT');
@@ -334,5 +334,166 @@ describe('buildCodexFileRewindPlan', () => {
 
   it('rejects missing target messages', () => {
     expectPlanError({ targetMessageClientId: 'missing' }, 'MESSAGE_NOT_FOUND');
+  });
+
+  describe('shadow savepoints (refs/cindy 链)', () => {
+    it('builds a file-restore plan from selected shadow after-edit savepoints', () => {
+      const result = plan({
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          savepointsNewestFirst: [
+            savepoint({ commit: 'sc3', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm3', baselineCommit: 'ts3', label: 'third' }),
+            savepoint({ commit: 'foreign', sessionId: 's2', kind: 'after-edit', source: 'shadow', anchor: 'm3', baselineCommit: 'tsx' }),
+            savepoint({ commit: 'sc2', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm2', baselineCommit: 'ts2', label: 'second' }),
+            savepoint({ commit: 'sc1', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm1', baselineCommit: 'ts1' }),
+          ],
+        },
+      });
+
+      expect(result.mode).toBe('file-restore');
+      if (result.mode !== 'file-restore') throw new Error('expected file-restore plan');
+      expect(result.repoRoot).toBe('/repo');
+      expect(result.currentHead).toBe('head');
+      // 文件回到区间内最老一轮 (m2) 的 turn-start 基线。
+      expect(result.baselineCommit).toBe('ts2');
+      expect(result.restoreCommitsNewestFirst).toEqual([
+        { commit: 'sc3', baselineCommit: 'ts3', anchor: 'm3', label: 'third' },
+        { commit: 'sc2', baselineCommit: 'ts2', anchor: 'm2', label: 'second' },
+      ]);
+      expect(result.tailTurnsToDrop).toBe(2);
+    });
+
+    it('selects shadow savepoints regardless of branch (no branch filter)', () => {
+      const result = plan({
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          savepointsNewestFirst: [
+            savepoint({ commit: 'sb', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm2', baselineCommit: 'tsb', branch: 'feature' }),
+          ],
+        },
+      });
+
+      expect(result.mode).toBe('file-restore');
+      if (result.mode !== 'file-restore') throw new Error('expected file-restore plan');
+      expect(result.baselineCommit).toBe('tsb');
+      expect(result.restoreCommitsNewestFirst).toEqual([
+        { commit: 'sb', baselineCommit: 'tsb', anchor: 'm2' },
+      ]);
+    });
+
+    it('falls back with savepoint-gap when a shadow blocking marker lands in the target range', () => {
+      const result = plan({
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          savepointsNewestFirst: [
+            savepoint({ commit: 'sc3', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm3', baselineCommit: 'ts3' }),
+            savepoint({ commit: 'gap', sessionId: 's1', kind: 'rewind-blocked', source: 'shadow', anchor: 'm2' }),
+          ],
+        },
+      });
+
+      expect(result).toMatchObject({
+        mode: 'conversation-only',
+        fallbackReason: 'savepoint-gap',
+        tailTurnsToDrop: 2,
+      });
+    });
+
+    it('allows file restore when the shadow blocking marker is before the target range', () => {
+      const result = plan({
+        targetMessageClientId: 'm3',
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          savepointsNewestFirst: [
+            savepoint({ commit: 'sc3', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm3', baselineCommit: 'ts3' }),
+            savepoint({ commit: 'gap', sessionId: 's1', kind: 'rewind-blocked', source: 'shadow', anchor: 'm2' }),
+          ],
+        },
+      });
+
+      expect(result.mode).toBe('file-restore');
+      if (result.mode !== 'file-restore') throw new Error('expected file-restore plan');
+      expect(result.baselineCommit).toBe('ts3');
+      expect(result.restoreCommitsNewestFirst).toEqual([
+        { commit: 'sc3', baselineCommit: 'ts3', anchor: 'm3' },
+      ]);
+    });
+
+    it('falls back with mixed-savepoint-formats when both generations select (upgrade window)', () => {
+      const result = plan({
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          savepointsNewestFirst: [
+            savepoint({ commit: 'sc3', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm3', baselineCommit: 'ts3' }),
+            savepoint({ commit: 'c2', sessionId: 's1', kind: 'after-edit', anchor: 'm2' }),
+          ],
+        },
+      });
+
+      expect(result).toMatchObject({
+        mode: 'conversation-only',
+        fallbackReason: 'mixed-savepoint-formats',
+        tailTurnsToDrop: 2,
+      });
+    });
+
+    it('falls back when a selected shadow after-edit lacks its turn-start baseline', () => {
+      const result = plan({
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          savepointsNewestFirst: [
+            savepoint({ commit: 'sc3', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm3', baselineCommit: 'ts3' }),
+            savepoint({ commit: 'sc2', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm2' }),
+          ],
+        },
+      });
+
+      expect(result).toMatchObject({
+        mode: 'conversation-only',
+        fallbackReason: 'missing-turn-start-baseline',
+        tailTurnsToDrop: 2,
+      });
+    });
+
+    it('keeps the legacy file-rewind plan when only legacy savepoints select (regression)', () => {
+      const result = plan({
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          savepointsNewestFirst: [
+            // 区间外的 shadow 保存点不入选, 不该触发 mixed-savepoint-formats。
+            savepoint({ commit: 'sc1', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm1', baselineCommit: 'ts1' }),
+            savepoint({ commit: 'c3', sessionId: 's1', kind: 'after-edit', anchor: 'm3' }),
+            savepoint({ commit: 'c2', sessionId: 's1', kind: 'after-edit', anchor: 'm2' }),
+          ],
+        },
+      });
+
+      expect(result.mode).toBe('file-rewind');
+      if (result.mode !== 'file-rewind') throw new Error('expected file-rewind plan');
+      expect(result.revertCommitsNewestFirst).toEqual(['c3', 'c2']);
+      // legacy commits 快照只覆盖 legacy 桶, shadow 保存点不混入。
+      expect(result.commits.map((commit) => commit.commit)).toEqual(['c3', 'c2']);
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/codexFileRewindPlanner.test.ts
+++ b/apps/desktop/src/main/__tests__/codexFileRewindPlanner.test.ts
@@ -366,6 +366,27 @@ describe('buildCodexFileRewindPlan', () => {
       expect(result.tailTurnsToDrop).toBe(2);
     });
 
+    it('falls back to conversation-only when the shadow chain read was truncated', () => {
+      const result = plan({
+        repo: {
+          kind: 'local-git',
+          repoRoot: '/repo',
+          currentHead: 'head',
+          currentBranch: 'main',
+          shadowSavepointsTruncated: true,
+          // 窗口内仍有可入选的 after-edit,但窗口外的历史未知 → 不得部分回退。
+          savepointsNewestFirst: [
+            savepoint({ commit: 'sc2', sessionId: 's1', kind: 'after-edit', source: 'shadow', anchor: 'm2', baselineCommit: 'ts2' }),
+          ],
+        },
+      });
+
+      expect(result).toMatchObject({
+        mode: 'conversation-only',
+        fallbackReason: 'savepoint-history-truncated',
+      });
+    });
+
     it('selects shadow savepoints regardless of branch (no branch filter)', () => {
       const result = plan({
         repo: {

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -16,6 +16,7 @@ function savepointResult(
   commit: string | null,
   skippedPaths: string[] = [],
   fingerprintSeed = 1,
+  ctimeSeed = fingerprintSeed,
 ): ShadowSavepointResult {
   return {
     commit,
@@ -29,8 +30,8 @@ function savepointResult(
       path,
       sizeBytes: 100 * fingerprintSeed,
       mtimeMs: 1_000 * fingerprintSeed,
-      ctimeMs: 2_000 * fingerprintSeed,
-      ino: 10 * fingerprintSeed,
+      ctimeMs: 2_000 * ctimeSeed,
+      ino: 10 * ctimeSeed,
     })),
   };
 }
@@ -329,6 +330,87 @@ describe('GitSnapshotCoordinator', () => {
     await coordinator.onTurnStart('s1');
     await coordinator.onTurnEnd('s1');
 
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+  });
+
+  it('appends a rewind gap marker when a persistent filter entry changes only ctime/inode', async () => {
+    // 等长且保留 mtime 的改写(或 replace-by-rename):size/mtime 全同,
+    // 只有 ctime/inode 变——必须同样打 gap。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1', ['big.bin'], 1, 1))
+        .mockResolvedValueOnce(savepointResult('hash2', ['big.bin'], 1, 2)),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn changes were partially filtered',
+      meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
+    });
+  });
+
+  it('degrades overlapping turns of different sessions on the same repo to gaps', async () => {
+    // 同一仓库上两个 session 并发跑 turn:全工作区树无法归属改动,
+    // 双方的 after-edit 都必须降级为 gap 标记。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnStart('s2');
+    await coordinator.onTurnEnd('s2');
+    await coordinator.onTurnEnd('s1');
+
+    // 只有两次 turn-start,零 after-edit。
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(2);
+    expect(deps.createShadowMarker).toHaveBeenCalledTimes(2);
+    for (const sid of ['s1', 's2']) {
+      expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+        sessionId: sid,
+        label: 'File rewind gap: concurrent session activity in the same repository',
+        meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
+      });
+    }
+  });
+
+  it('keeps sequential turns of different sessions on the same repo unaffected', async () => {
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+    await coordinator.onTurnStart('s2');
+    await coordinator.onTurnEnd('s2');
+
+    // 两轮各自 turn-start + after-edit,无 gap。
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(4);
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+  });
+
+  it('does not treat concurrent turns on different repos as overlapping', async () => {
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockImplementation(async (sessionId: string) => ({
+        workingDir: sessionId === 's1' ? '/repo-a' : '/repo-b',
+        agentKind: 'codex',
+      })),
+      detectRepoRoot: vi.fn().mockImplementation(async (dir: string) => dir),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnStart('s2');
+    await coordinator.onTurnEnd('s1');
+    await coordinator.onTurnEnd('s2');
+
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(4);
     expect(deps.createShadowMarker).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -15,6 +15,7 @@ const logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
 function savepointResult(
   commit: string | null,
   skippedPaths: string[] = [],
+  fingerprintSeed = 1,
 ): ShadowSavepointResult {
   return {
     commit,
@@ -23,6 +24,11 @@ function savepointResult(
     skippedFiles: skippedPaths.map((path) => ({
       path,
       reason: 'sensitive-path' as const,
+    })),
+    skippedFingerprints: skippedPaths.map((path) => ({
+      path,
+      sizeBytes: 100 * fingerprintSeed,
+      mtimeMs: 1_000 * fingerprintSeed,
     })),
   };
 }
@@ -272,8 +278,8 @@ describe('GitSnapshotCoordinator', () => {
     });
   });
 
-  it('does not append a gap marker for filtered paths that predate the turn', async () => {
-    // session 全程躺着一个大文件/敏感文件(turn-start 与 after-edit 都 skip):
+  it('does not append a gap marker for filtered paths that predate the turn unchanged', async () => {
+    // session 全程躺着一个大文件/敏感文件(两端都 skip 且 lstat 指纹一致):
     // 不是本轮改动,不打 gap,否则常驻 dirty 的过滤文件会永久禁用文件回退。
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
@@ -287,6 +293,27 @@ describe('GitSnapshotCoordinator', () => {
     await coordinator.onTurnEnd('s1');
 
     expect(deps.createShadowMarker).not.toHaveBeenCalled();
+  });
+
+  it('appends a rewind gap marker when a persistently filtered file changes fingerprint', async () => {
+    // 两端都被过滤但 lstat 指纹变化(如超限文件被 Agent 重写后仍超限):
+    // 该轮改动没有任何快照可恢复,必须打 gap。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1', ['big.bin'], 1))
+        .mockResolvedValueOnce(savepointResult('hash2', ['big.bin'], 2)),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn changes were partially filtered',
+      meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
+    });
   });
 
   it('skips the filtered-paths gap marker for agents that do not consume the chain', async () => {

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -29,6 +29,8 @@ function savepointResult(
       path,
       sizeBytes: 100 * fingerprintSeed,
       mtimeMs: 1_000 * fingerprintSeed,
+      ctimeMs: 2_000 * fingerprintSeed,
+      ino: 10 * fingerprintSeed,
     })),
   };
 }

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -5,20 +5,26 @@ import {
   type GitSnapshotCoordinatorDeps,
 } from '../git-snapshot/gitSnapshotCoordinator';
 import { enqueueGitRepoWrite } from '../git-snapshot/gitRepoWriteQueue';
-import type { CreateSnapshotInput } from '../git-snapshot/gitSnapshotService';
+import type {
+  CreateShadowSavepointInput,
+  ShadowSavepointResult,
+} from '../git-snapshot/gitSnapshotService';
 
 const logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
+function savepointResult(commit: string | null): ShadowSavepointResult {
+  return { commit, tree: 'tree1', includedFiles: [], skippedFiles: [] };
+}
 
 function makeDeps(overrides: Partial<GitSnapshotCoordinatorDeps> = {}): GitSnapshotCoordinatorDeps {
   return {
     readAutoSnapshotEnabled: () => true,
     detectRepoRoot: vi.fn().mockResolvedValue('/repo'),
-    isWorktreeDirty: vi.fn().mockResolvedValue(true),
     getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'claude-code' }),
     resolveAnchor: vi.fn().mockResolvedValue('msg-1'),
     getLastUserPrompt: vi.fn().mockResolvedValue('update login'),
-    createSnapshot: vi.fn().mockResolvedValue('hash1'),
-    createSnapshotMarker: vi.fn().mockResolvedValue('marker1'),
+    createShadowSavepoint: vi.fn().mockResolvedValue(savepointResult('hash1')),
+    createShadowMarker: vi.fn().mockResolvedValue('marker1'),
     oneShot: vi.fn().mockResolvedValue('实现登录校验'),
     logger,
     ...overrides,
@@ -36,46 +42,51 @@ async function waitFor(condition: () => boolean): Promise<void> {
 }
 
 describe('GitSnapshotCoordinator', () => {
-  it('creates an after-edit snapshot for a dirty git repo', async () => {
+  it('creates a turn-start baseline and an after-edit savepoint for a full turn', async () => {
     const deps = makeDeps();
-    await new GitSnapshotCoordinator(deps).onTurnEnd('s1');
+    const coordinator = new GitSnapshotCoordinator(deps);
 
-    expect(deps.createSnapshot).toHaveBeenCalledOnce();
-    const [repoPath, input] = vi.mocked(deps.createSnapshot).mock.calls[0] as [
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(2);
+    expect(deps.createShadowSavepoint).toHaveBeenNthCalledWith(1, '/repo', {
+      sessionId: 's1',
+      label: '本轮开始时的工作区基线',
+      meta: { kind: 'turn-start', anchor: 'msg-1' },
+    });
+    const [repoPath, afterEditInput] = vi.mocked(deps.createShadowSavepoint).mock.calls[1] as [
       string,
-      CreateSnapshotInput,
+      CreateShadowSavepointInput,
     ];
     expect(repoPath).toBe('/repo');
-    expect(input.meta).toMatchObject({ sessionId: 's1', kind: 'after-edit', anchor: 'msg-1' });
-    expect(typeof input.label).toBe('function');
+    expect(afterEditInput.sessionId).toBe('s1');
+    expect(afterEditInput.meta).toMatchObject({
+      kind: 'after-edit',
+      anchor: 'msg-1',
+      baselineCommit: 'hash1',
+    });
+    expect(afterEditInput.skipIfTreeEquals).toBe('hash1');
+    expect(typeof afterEditInput.label).toBe('function');
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
   });
 
-  it('creates a before-edit baseline when the repo is dirty at turn start', async () => {
+  it('unconditionally creates a turn-start baseline even without pending changes', async () => {
+    // Shadow 链上的 turn-start 是每轮统一的恢复基线:clean 工作区也要建。
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn().mockResolvedValue(true),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
     await coordinator.onTurnStart('s1');
     await coordinator.onTurnEnd('s1');
 
-    expect(deps.createSnapshot).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshot).toHaveBeenNthCalledWith(1, '/repo', {
-      label: '本轮开始前的未提交改动',
-      meta: { sessionId: 's1', kind: 'before-edit', anchor: 'msg-1' },
-    });
-    const [, afterEditInput] = vi.mocked(deps.createSnapshot).mock.calls[1] as [
-      string,
-      CreateSnapshotInput,
-    ];
-    expect(afterEditInput.meta).toMatchObject({ sessionId: 's1', kind: 'after-edit', anchor: 'msg-1' });
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
-    expect(deps.isWorktreeDirty).toHaveBeenCalledTimes(2);
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(2);
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
     expect(deps.resolveAnchor).toHaveBeenCalledOnce();
     expect(deps.getLastUserPrompt).toHaveBeenCalledOnce();
     expect(deps.logger.info).toHaveBeenCalledWith(
-      '[git-snapshot] before-edit baseline created',
+      '[git-snapshot] turn-start baseline created',
       expect.objectContaining({ sessionId: 's1', repoRoot: '/repo', commit: 'hash1', anchor: 'msg-1' }),
     );
   });
@@ -95,7 +106,6 @@ describe('GitSnapshotCoordinator', () => {
         status: 'initialized',
         repoRoot: '/new-project',
       }),
-      isWorktreeDirty: vi.fn().mockResolvedValue(false),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
@@ -111,8 +121,13 @@ describe('GitSnapshotCoordinator', () => {
       { autoSnapshotEnabled: true },
     );
     expect(deps.detectRepoRoot).toHaveBeenCalledOnce();
-    expect(deps.isWorktreeDirty).toHaveBeenCalledWith('/new-project');
-    expect(deps.createSnapshot).not.toHaveBeenCalled();
+    expect(deps.createShadowSavepoint).toHaveBeenCalledWith(
+      '/new-project',
+      expect.objectContaining({
+        sessionId: 's1',
+        meta: expect.objectContaining({ kind: 'turn-start' }),
+      }),
+    );
     expect(coordinator.hasPendingTurnStart('s1')).toBe(true);
   });
 
@@ -130,9 +145,8 @@ describe('GitSnapshotCoordinator', () => {
 
     expect(deps.readAutoSnapshotEnabled).toHaveBeenCalledOnce();
     expect(deps.detectRepoRoot).not.toHaveBeenCalled();
-    expect(deps.isWorktreeDirty).not.toHaveBeenCalled();
-    expect(deps.createSnapshot).not.toHaveBeenCalled();
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
+    expect(deps.createShadowSavepoint).not.toHaveBeenCalled();
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
   });
 
   it('does not retroactively disable after-edit snapshots for a turn that started enabled', async () => {
@@ -140,7 +154,6 @@ describe('GitSnapshotCoordinator', () => {
     const deps = makeDeps({
       readAutoSnapshotEnabled: vi.fn(() => enabled),
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
@@ -149,64 +162,61 @@ describe('GitSnapshotCoordinator', () => {
     await coordinator.onTurnEnd('s1');
 
     expect(deps.readAutoSnapshotEnabled).toHaveBeenCalledOnce();
-    expect(deps.isWorktreeDirty).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshot).toHaveBeenCalledOnce();
-    const [, input] = vi.mocked(deps.createSnapshot).mock.calls[0] as [
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(2);
+    const [, input] = vi.mocked(deps.createShadowSavepoint).mock.calls[1] as [
       string,
-      CreateSnapshotInput,
+      CreateShadowSavepointInput,
     ];
-    expect(input.meta).toMatchObject({ sessionId: 's1', kind: 'after-edit', anchor: 'msg-1' });
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
+    expect(input.sessionId).toBe('s1');
+    expect(input.meta).toMatchObject({ kind: 'after-edit', anchor: 'msg-1', baselineCommit: 'hash1' });
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
   });
 
-  it('blocks Codex file rewind when a dirty turn-start baseline fails', async () => {
+  it('appends a rewind gap marker when the Codex turn-start baseline fails', async () => {
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn().mockResolvedValue(true),
-      createSnapshot: vi.fn()
+      createShadowSavepoint: vi.fn()
         .mockRejectedValueOnce(new Error('git conflict'))
-        .mockResolvedValueOnce('hash-after'),
+        .mockResolvedValueOnce(savepointResult('hash-after')),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
     await coordinator.onTurnStart('s1');
     await coordinator.onTurnEnd('s1');
 
-    expect(deps.createSnapshot).toHaveBeenCalledOnce();
-    expect(deps.createSnapshotMarker).toHaveBeenCalledWith('/repo', {
-      label: 'Codex rewind unavailable: turn-start baseline failed',
-      meta: { sessionId: 's1', kind: 'rewind-blocked', anchor: 'msg-1' },
+    // turn-start 失败即缺基线:after-edit 不再尝试,只补 gap marker。
+    expect(deps.createShadowSavepoint).toHaveBeenCalledOnce();
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn-start baseline unavailable',
+      meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
     });
     expect(deps.logger.debug).toHaveBeenCalledWith(
-      '[git-snapshot] before-edit baseline failed, skip',
+      '[git-snapshot] missing turn-start baseline, skip',
       { sessionId: 's1', repoRoot: '/repo' },
     );
   });
 
-  it('continues when dirty turn-start files are all skipped by the safety filter', async () => {
+  it('treats a turn-start savepoint without a commit as a missing baseline', async () => {
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn().mockResolvedValue(true),
-      createSnapshot: vi.fn()
-        .mockResolvedValueOnce(null)
-        .mockResolvedValueOnce('hash-after'),
+      createShadowSavepoint: vi.fn().mockResolvedValue(savepointResult(null)),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
     await coordinator.onTurnStart('s1');
     await coordinator.onTurnEnd('s1');
 
-    expect(deps.createSnapshot).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
-    const [, afterEditInput] = vi.mocked(deps.createSnapshot).mock.calls[1] as [
-      string,
-      CreateSnapshotInput,
-    ];
-    expect(afterEditInput.meta.kind).toBe('after-edit');
-    expect(deps.logger.debug).toHaveBeenCalledWith(
-      '[git-snapshot] no staged turn-start changes after add, skip',
+    expect(deps.createShadowSavepoint).toHaveBeenCalledOnce();
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      '[git-snapshot] turn-start baseline missing commit',
       { sessionId: 's1', repoRoot: '/repo' },
     );
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn-start baseline unavailable',
+      meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
+    });
   });
 
   it('marks Codex turns as rewind-blocked when the turn-start baseline is missing', async () => {
@@ -216,14 +226,49 @@ describe('GitSnapshotCoordinator', () => {
 
     await new GitSnapshotCoordinator(deps).onTurnEnd('s1');
 
-    expect(deps.createSnapshot).not.toHaveBeenCalled();
-    expect(deps.createSnapshotMarker).toHaveBeenCalledWith('/repo', {
-      label: 'Codex rewind unavailable: missing turn-start baseline',
-      meta: { sessionId: 's1', kind: 'rewind-blocked' },
+    expect(deps.createShadowSavepoint).not.toHaveBeenCalled();
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn-start baseline unavailable',
+      meta: { kind: 'rewind-blocked' },
     });
-    expect(deps.isWorktreeDirty).not.toHaveBeenCalled();
     expect(deps.resolveAnchor).not.toHaveBeenCalled();
     expect(deps.getLastUserPrompt).not.toHaveBeenCalled();
+    expect(deps.logger.debug).toHaveBeenCalledWith(
+      '[git-snapshot] missing turn-start baseline, skip',
+      { sessionId: 's1', repoRoot: '/repo' },
+    );
+    expect(deps.logger.info).toHaveBeenCalledWith(
+      '[git-snapshot] rewind gap marker created',
+      expect.objectContaining({ sessionId: 's1', repoRoot: '/repo', commit: 'marker1' }),
+    );
+  });
+
+  it('marks pi turns as rewind-blocked when the turn-start baseline is missing', async () => {
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'pi' }),
+    });
+
+    await new GitSnapshotCoordinator(deps).onTurnEnd('s1');
+
+    expect(deps.createShadowSavepoint).not.toHaveBeenCalled();
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn-start baseline unavailable',
+      meta: { kind: 'rewind-blocked' },
+    });
+  });
+
+  it('skips the rewind gap marker for agents that do not consume the savepoint chain', async () => {
+    // 默认 agentKind 为 claude-code:缺基线只打 debug 日志,不建 marker,
+    // 也不提前解析可选 metadata。
+    const deps = makeDeps();
+
+    await new GitSnapshotCoordinator(deps).onTurnEnd('s1');
+
+    expect(deps.createShadowSavepoint).not.toHaveBeenCalled();
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+    expect(deps.resolveAnchor).not.toHaveBeenCalled();
     expect(deps.logger.debug).toHaveBeenCalledWith(
       '[git-snapshot] missing turn-start baseline, skip',
       { sessionId: 's1', repoRoot: '/repo' },
@@ -240,7 +285,6 @@ describe('GitSnapshotCoordinator', () => {
           }),
         )
         .mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn().mockResolvedValue(true),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
@@ -249,32 +293,32 @@ describe('GitSnapshotCoordinator', () => {
     const turnEnd = coordinator.onTurnEnd('s1');
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    expect(deps.createSnapshot).not.toHaveBeenCalled();
+    expect(deps.createShadowSavepoint).not.toHaveBeenCalled();
     releaseContext?.();
     await Promise.all([turnStart, turnEnd]);
 
-    expect(deps.isWorktreeDirty).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshot).toHaveBeenCalledTimes(2);
-    const [, afterEditInput] = vi.mocked(deps.createSnapshot).mock.calls[1] as [
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(2);
+    const [, afterEditInput] = vi.mocked(deps.createShadowSavepoint).mock.calls[1] as [
       string,
-      CreateSnapshotInput,
+      CreateShadowSavepointInput,
     ];
     expect(afterEditInput.meta.kind).toBe('after-edit');
+    expect(afterEditInput.meta.baselineCommit).toBe('hash1');
   });
 
   it('keeps overlapping turn-start baselines isolated by turn order', async () => {
     let releaseFirstBaseline: (() => void) | undefined;
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn()
+      createShadowSavepoint: vi.fn()
         .mockImplementationOnce(() =>
-          new Promise<boolean>((resolve) => {
-            releaseFirstBaseline = () => resolve(false);
+          new Promise<ShadowSavepointResult>((resolve) => {
+            releaseFirstBaseline = () => resolve(savepointResult('hash-t1'));
           }),
         )
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true),
+        .mockResolvedValueOnce(savepointResult('hash-a1'))
+        .mockResolvedValueOnce(savepointResult('hash-t2'))
+        .mockResolvedValue(savepointResult('hash-a2')),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
@@ -284,29 +328,38 @@ describe('GitSnapshotCoordinator', () => {
     const turnStart2 = coordinator.onTurnStart('s1');
 
     await new Promise((resolve) => setTimeout(resolve, 20));
-    expect(deps.createSnapshot).not.toHaveBeenCalled();
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
+    // 第一轮 turn-start 尚未完成:同 repo 写队列挡住后续所有保存点写入。
+    expect(deps.createShadowSavepoint).toHaveBeenCalledOnce();
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
 
     releaseFirstBaseline?.();
     await Promise.all([turnStart1, turnStart2, turnEnd1]);
 
-    expect(deps.createSnapshot).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(3);
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
 
     await coordinator.onTurnEnd('s1');
 
-    expect(deps.createSnapshot).toHaveBeenCalledTimes(3);
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
-    expect(deps.isWorktreeDirty).toHaveBeenCalledTimes(4);
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(4);
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+    const calls = vi.mocked(deps.createShadowSavepoint).mock.calls as unknown as [
+      string,
+      CreateShadowSavepointInput,
+    ][];
+    // 两个 after-edit 各自绑定所属轮次的 turn-start 基线。
+    expect(calls[1][1].meta).toMatchObject({ kind: 'after-edit', baselineCommit: 'hash-t1' });
+    expect(calls[1][1].skipIfTreeEquals).toBe('hash-t1');
+    expect(calls[3][1].meta).toMatchObject({ kind: 'after-edit', baselineCommit: 'hash-t2' });
+    expect(calls[3][1].skipIfTreeEquals).toBe('hash-t2');
   });
 
   it('consumes an aborted turn baseline before the next successful turn', async () => {
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn()
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash-t1'))
+        .mockResolvedValueOnce(savepointResult('hash-t2'))
+        .mockResolvedValue(savepointResult('hash-a')),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
@@ -315,23 +368,29 @@ describe('GitSnapshotCoordinator', () => {
     await coordinator.onTurnStart('s1');
     await coordinator.onTurnEnd('s1');
 
-    expect(deps.createSnapshot).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshotMarker).not.toHaveBeenCalled();
-    expect(deps.isWorktreeDirty).toHaveBeenCalledTimes(3);
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(3);
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+    const [, afterEditInput] = vi.mocked(deps.createShadowSavepoint).mock.calls[2] as [
+      string,
+      CreateShadowSavepointInput,
+    ];
+    // 被中止轮次的基线已消费:after-edit 绑定第二轮的 turn-start。
+    expect(afterEditInput.meta).toMatchObject({ kind: 'after-edit', baselineCommit: 'hash-t2' });
   });
 
-  it('uses the turn-start anchor and prompt for the matching after-edit snapshot', async () => {
+  it('uses the turn-start anchor and prompt for the matching after-edit savepoint', async () => {
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
-      isWorktreeDirty: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
       resolveAnchor: vi.fn().mockResolvedValueOnce('msg-1').mockResolvedValueOnce('msg-2'),
       getLastUserPrompt: vi.fn().mockResolvedValueOnce('first prompt').mockResolvedValueOnce('second prompt'),
-      createSnapshot: vi.fn().mockImplementation(async (_repo: string, input: CreateSnapshotInput) => {
-        if (typeof input.label === 'function') {
-          await input.label({ diffStat: ' a.ts | 1 +', diffText: '+x' });
-        }
-        return 'hash';
-      }),
+      createShadowSavepoint: vi.fn().mockImplementation(
+        async (_repo: string, input: CreateShadowSavepointInput) => {
+          if (typeof input.label === 'function') {
+            await input.label({ diffStat: ' a.ts | 1 +', diffText: '+x' });
+          }
+          return savepointResult('hash');
+        },
+      ),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
@@ -340,34 +399,42 @@ describe('GitSnapshotCoordinator', () => {
 
     expect(deps.resolveAnchor).toHaveBeenCalledOnce();
     expect(deps.getLastUserPrompt).toHaveBeenCalledOnce();
-    const [, input] = vi.mocked(deps.createSnapshot).mock.calls[0] as [
+    const [, afterEditInput] = vi.mocked(deps.createShadowSavepoint).mock.calls[1] as [
       string,
-      CreateSnapshotInput,
+      CreateShadowSavepointInput,
     ];
-    expect(input.meta).toMatchObject({ sessionId: 's1', kind: 'after-edit', anchor: 'msg-1' });
+    expect(afterEditInput.sessionId).toBe('s1');
+    expect(afterEditInput.meta).toMatchObject({ kind: 'after-edit', anchor: 'msg-1' });
     expect(deps.oneShot).toHaveBeenCalledWith('codex', expect.stringContaining('first prompt'));
     expect(deps.oneShot).not.toHaveBeenCalledWith('codex', expect.stringContaining('second prompt'));
   });
 
-  it('creates a snapshot when the repo becomes dirty after a clean turn start', async () => {
+  it('only logs a debug skip when the worktree is unchanged since turn start', async () => {
     const deps = makeDeps({
-      isWorktreeDirty: vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash-t1'))
+        .mockResolvedValueOnce(savepointResult(null)),
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
     await coordinator.onTurnStart('s1');
     await coordinator.onTurnEnd('s1');
 
-    expect(deps.isWorktreeDirty).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshot).toHaveBeenCalledOnce();
-  });
-
-  it('skips clean repos before resolving optional metadata', async () => {
-    const deps = makeDeps({ isWorktreeDirty: vi.fn().mockResolvedValue(false) });
-    await new GitSnapshotCoordinator(deps).onTurnEnd('s1');
-
-    expect(deps.createSnapshot).not.toHaveBeenCalled();
-    expect(deps.resolveAnchor).not.toHaveBeenCalled();
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(2);
+    const [, afterEditInput] = vi.mocked(deps.createShadowSavepoint).mock.calls[1] as [
+      string,
+      CreateShadowSavepointInput,
+    ];
+    expect(afterEditInput.skipIfTreeEquals).toBe('hash-t1');
+    expect(deps.logger.debug).toHaveBeenCalledWith(
+      '[git-snapshot] worktree unchanged since turn start, skip',
+      { sessionId: 's1', repoRoot: '/repo' },
+    );
+    expect(deps.logger.info).not.toHaveBeenCalledWith(
+      '[git-snapshot] after-edit savepoint created',
+      expect.anything(),
+    );
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
   });
 
   it('treats non-git dirs as best-effort no-op and does not cache null roots', async () => {
@@ -376,16 +443,23 @@ describe('GitSnapshotCoordinator', () => {
     });
     const coordinator = new GitSnapshotCoordinator(deps);
 
-    await expect(coordinator.onTurnEnd('s1')).resolves.toBeUndefined();
-    await expect(coordinator.onTurnEnd('s1')).resolves.toBeUndefined();
+    await expect(coordinator.onTurnStart('s1')).resolves.toBeUndefined();
+    await expect(coordinator.onTurnStart('s1')).resolves.toBeUndefined();
 
     expect(deps.detectRepoRoot).toHaveBeenCalledTimes(2);
-    expect(deps.createSnapshot).toHaveBeenCalledOnce();
+    expect(deps.createShadowSavepoint).toHaveBeenCalledOnce();
   });
 
-  it('swallows snapshot failures and logs a warning', async () => {
-    const deps = makeDeps({ createSnapshot: vi.fn().mockRejectedValue(new Error('git lock')) });
-    await expect(new GitSnapshotCoordinator(deps).onTurnEnd('s1')).resolves.toBeUndefined();
+  it('swallows savepoint failures and logs a warning', async () => {
+    const deps = makeDeps({
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash-t1'))
+        .mockRejectedValueOnce(new Error('git lock')),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await expect(coordinator.onTurnEnd('s1')).resolves.toBeUndefined();
 
     expect(deps.logger.warn).toHaveBeenCalledWith(
       '[git-snapshot] onTurnEnd failed (swallowed)',
@@ -393,28 +467,28 @@ describe('GitSnapshotCoordinator', () => {
     );
   });
 
-  it('serializes concurrent snapshots for the same repo', async () => {
+  it('serializes concurrent savepoints for the same repo', async () => {
     let active = 0;
     let maxActive = 0;
     const deps = makeDeps({
-      createSnapshot: vi.fn().mockImplementation(async () => {
+      createShadowSavepoint: vi.fn().mockImplementation(async () => {
         active += 1;
         maxActive = Math.max(maxActive, active);
         await new Promise((resolve) => setTimeout(resolve, 20));
         active -= 1;
-        return 'hash';
+        return savepointResult('hash');
       }),
     });
 
     const coordinator = new GitSnapshotCoordinator(deps);
     await Promise.all([
-      coordinator.onTurnEnd('s1'),
-      coordinator.onTurnEnd('s2'),
-      coordinator.onTurnEnd('s3'),
+      coordinator.onTurnStart('s1'),
+      coordinator.onTurnStart('s2'),
+      coordinator.onTurnStart('s3'),
     ]);
 
     expect(maxActive).toBe(1);
-    expect(deps.createSnapshot).toHaveBeenCalledTimes(3);
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(3);
   });
 
   it('shares the repo write queue with external git write tasks', async () => {
@@ -427,28 +501,35 @@ describe('GitSnapshotCoordinator', () => {
     await waitFor(() => Boolean(release));
 
     const deps = makeDeps();
-    const turnEnd = new GitSnapshotCoordinator(deps).onTurnEnd('s1');
+    const turnStart = new GitSnapshotCoordinator(deps).onTurnStart('s1');
     await new Promise((resolve) => setTimeout(resolve, 20));
 
-    expect(deps.isWorktreeDirty).not.toHaveBeenCalled();
+    expect(deps.createShadowSavepoint).not.toHaveBeenCalled();
     release?.();
-    await Promise.all([blocker, turnEnd]);
-    expect(deps.createSnapshot).toHaveBeenCalledOnce();
+    await Promise.all([blocker, turnStart]);
+    expect(deps.createShadowSavepoint).toHaveBeenCalledOnce();
   });
 
-  it('keeps label generation delayed inside createSnapshot', async () => {
+  it('passes the label factory into createShadowSavepoint without eager evaluation', async () => {
     let label = '';
     const deps = makeDeps({
-      createSnapshot: vi
+      createShadowSavepoint: vi
         .fn()
-        .mockImplementation(async (_repo: string, input: CreateSnapshotInput) => {
-          if (typeof input.label === 'function') {
-            label = await input.label({ diffStat: ' a.ts | 1 +', diffText: '+x' });
+        .mockImplementation(async (_repo: string, input: CreateShadowSavepointInput) => {
+          if (typeof input.label !== 'function') {
+            return savepointResult('hash-t1');
           }
-          return 'hash';
+          // after-edit 的 label 是 factory:oneShot 延迟到内核调用时才发生。
+          expect(deps.oneShot).not.toHaveBeenCalled();
+          label = await input.label({ diffStat: ' a.ts | 1 +', diffText: '+x' });
+          return savepointResult('hash-after');
         }),
     });
-    await new GitSnapshotCoordinator(deps).onTurnEnd('s1');
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    expect(deps.oneShot).not.toHaveBeenCalled();
+    await coordinator.onTurnEnd('s1');
 
     expect(label).toBe('实现登录校验');
     expect(deps.oneShot).toHaveBeenCalledWith('claude-code', expect.stringContaining('a.ts'));

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -251,6 +251,27 @@ describe('GitSnapshotCoordinator', () => {
     });
   });
 
+  it('appends a rewind gap marker when a baseline-filtered path leaves the filter set', async () => {
+    // turn-start 时被过滤的文件(如 11MB untracked)本轮被缩小到可纳入快照:
+    // 基线树里没有它的原始内容,回退会删掉/覆盖它且无法恢复 → 必须打 gap。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1', ['big.bin']))
+        .mockResolvedValueOnce(savepointResult('hash2')),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn changes were partially filtered',
+      meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
+    });
+  });
+
   it('does not append a gap marker for filtered paths that predate the turn', async () => {
     // session 全程躺着一个大文件/敏感文件(turn-start 与 after-edit 都 skip):
     // 不是本轮改动,不打 gap,否则常驻 dirty 的过滤文件会永久禁用文件回退。

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -219,6 +219,46 @@ describe('GitSnapshotCoordinator', () => {
     });
   });
 
+  it('appends a rewind gap marker when the after-edit savepoint itself fails', async () => {
+    // turn-start 成功、after-edit 失败:该轮增量没有记录,后续轮次的回退会用
+    // 更晚的 baseline 做部分恢复——必须像缺基线一样在链上截断。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1'))
+        .mockRejectedValueOnce(new Error('index locked')),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(2);
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: after-edit savepoint failed',
+      meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
+    });
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      '[git-snapshot] after-edit savepoint failed',
+      expect.objectContaining({ sessionId: 's1', repoRoot: '/repo', error: 'index locked' }),
+    );
+  });
+
+  it('skips the after-edit failure gap marker for agents that do not consume the chain', async () => {
+    const deps = makeDeps({
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1'))
+        .mockRejectedValueOnce(new Error('index locked')),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+  });
+
   it('marks Codex turns as rewind-blocked when the turn-start baseline is missing', async () => {
     const deps = makeDeps({
       getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
@@ -462,8 +502,28 @@ describe('GitSnapshotCoordinator', () => {
     await expect(coordinator.onTurnEnd('s1')).resolves.toBeUndefined();
 
     expect(deps.logger.warn).toHaveBeenCalledWith(
-      '[git-snapshot] onTurnEnd failed (swallowed)',
+      '[git-snapshot] after-edit savepoint failed',
       expect.objectContaining({ sessionId: 's1', error: 'git lock' }),
+    );
+  });
+
+  it('swallows gap marker failures without breaking the turn', async () => {
+    // after-edit 失败 → 补 gap marker,marker 也失败 → 由外层 onTurnEnd 吞掉。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash-t1'))
+        .mockRejectedValueOnce(new Error('git lock')),
+      createShadowMarker: vi.fn().mockRejectedValue(new Error('marker failed')),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await expect(coordinator.onTurnEnd('s1')).resolves.toBeUndefined();
+
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      '[git-snapshot] onTurnEnd failed (swallowed)',
+      expect.objectContaining({ sessionId: 's1', error: 'marker failed' }),
     );
   });
 

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -395,6 +395,25 @@ describe('GitSnapshotCoordinator', () => {
     expect(deps.createShadowMarker).not.toHaveBeenCalled();
   });
 
+  it('unregisters in-flight turn records when the session is closed mid-turn', async () => {
+    // s1 开了 turn 却在 done/error 前被关闭(运行中切 Agent / 宿主回收):
+    // onSessionClosed 必须注销同仓并发记账,否则悬空 record 会让 s2 之后的
+    // 每一轮都被误判为并发、永久降级为 gap。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    coordinator.onSessionClosed('s1');
+    await coordinator.onTurnStart('s2');
+    await coordinator.onTurnEnd('s2');
+
+    // s1 turn-start + s2 turn-start + s2 after-edit,零 gap 标记。
+    expect(deps.createShadowSavepoint).toHaveBeenCalledTimes(3);
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+  });
+
   it('does not treat concurrent turns on different repos as overlapping', async () => {
     const deps = makeDeps({
       getSessionContext: vi.fn().mockImplementation(async (sessionId: string) => ({

--- a/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotCoordinator.test.ts
@@ -12,8 +12,19 @@ import type {
 
 const logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
 
-function savepointResult(commit: string | null): ShadowSavepointResult {
-  return { commit, tree: 'tree1', includedFiles: [], skippedFiles: [] };
+function savepointResult(
+  commit: string | null,
+  skippedPaths: string[] = [],
+): ShadowSavepointResult {
+  return {
+    commit,
+    tree: 'tree1',
+    includedFiles: [],
+    skippedFiles: skippedPaths.map((path) => ({
+      path,
+      reason: 'sensitive-path' as const,
+    })),
+  };
 }
 
 function makeDeps(overrides: Partial<GitSnapshotCoordinatorDeps> = {}): GitSnapshotCoordinatorDeps {
@@ -217,6 +228,58 @@ describe('GitSnapshotCoordinator', () => {
       label: 'File rewind gap: turn-start baseline unavailable',
       meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
     });
+  });
+
+  it('appends a rewind gap marker when the turn introduces newly filtered paths', async () => {
+    // 本轮新出现的被过滤文件(如 Agent 写入 .env):其改动没进任何快照,
+    // 覆盖本轮的回退必须降级,链上补 gap 标记。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1'))
+        .mockResolvedValueOnce(savepointResult('hash2', ['.env'])),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowMarker).toHaveBeenCalledWith('/repo', {
+      sessionId: 's1',
+      label: 'File rewind gap: turn changes were partially filtered',
+      meta: { kind: 'rewind-blocked', anchor: 'msg-1' },
+    });
+  });
+
+  it('does not append a gap marker for filtered paths that predate the turn', async () => {
+    // session 全程躺着一个大文件/敏感文件(turn-start 与 after-edit 都 skip):
+    // 不是本轮改动,不打 gap,否则常驻 dirty 的过滤文件会永久禁用文件回退。
+    const deps = makeDeps({
+      getSessionContext: vi.fn().mockResolvedValue({ workingDir: '/repo', agentKind: 'codex' }),
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1', ['big.bin']))
+        .mockResolvedValueOnce(savepointResult('hash2', ['big.bin'])),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
+  });
+
+  it('skips the filtered-paths gap marker for agents that do not consume the chain', async () => {
+    const deps = makeDeps({
+      createShadowSavepoint: vi.fn()
+        .mockResolvedValueOnce(savepointResult('hash1'))
+        .mockResolvedValueOnce(savepointResult('hash2', ['.env'])),
+    });
+    const coordinator = new GitSnapshotCoordinator(deps);
+
+    await coordinator.onTurnStart('s1');
+    await coordinator.onTurnEnd('s1');
+
+    expect(deps.createShadowMarker).not.toHaveBeenCalled();
   });
 
   it('appends a rewind gap marker when the after-edit savepoint itself fails', async () => {

--- a/apps/desktop/src/main/__tests__/gitSnapshotHost.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotHost.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createGitSnapshotCoordinator } from '../maker-host/git-snapshot-host';
-import type { CreateShadowSavepointInput } from '../git-snapshot/gitSnapshotService';
+import type {
+  CreateShadowSavepointInput,
+  ShadowSavepointResult,
+} from '../git-snapshot/gitSnapshotService';
 
 const logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
 
@@ -32,11 +35,17 @@ describe('createGitSnapshotCoordinator', () => {
       text: 'please update login',
     });
     const createShadowSavepoint = vi.fn().mockImplementation(
-      async (_repo: string, input: CreateShadowSavepointInput) => {
+      async (_repo: string, input: CreateShadowSavepointInput): Promise<ShadowSavepointResult> => {
         if (typeof input.label === 'function') {
           await input.label({ diffStat: ' src/a.ts | 1 +', diffText: '+x' });
         }
-        return { commit: 'hash123', tree: 'tree123', includedFiles: [], skippedFiles: [] };
+        return {
+          commit: 'hash123',
+          tree: 'tree123',
+          includedFiles: [],
+          skippedFiles: [],
+          skippedFingerprints: [],
+        };
       },
     );
     const coordinator = createGitSnapshotCoordinator(maker, {
@@ -120,7 +129,8 @@ describe('createGitSnapshotCoordinator', () => {
       tree: 'tree-t1',
       includedFiles: [],
       skippedFiles: [],
-    });
+      skippedFingerprints: [],
+    } satisfies ShadowSavepointResult);
     const coordinator = createGitSnapshotCoordinator(maker, {
       readAutoSnapshotEnabled: vi.fn(() => enabled),
       detectRepoRoot: vi.fn().mockResolvedValue(null),

--- a/apps/desktop/src/main/__tests__/gitSnapshotHost.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotHost.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { createGitSnapshotCoordinator } from '../maker-host/git-snapshot-host';
-import type { CreateSnapshotInput } from '../git-snapshot/gitSnapshotService';
+import type { CreateShadowSavepointInput } from '../git-snapshot/gitSnapshotService';
 
 const logger = { info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
 
@@ -25,38 +25,45 @@ function makeMaker(overrides: Partial<{
 }
 
 describe('createGitSnapshotCoordinator', () => {
-  it('creates a local after-edit snapshot with anchor and prompt context', async () => {
+  it('creates a local after-edit savepoint with anchor and prompt context', async () => {
     const maker = makeMaker();
     const getLatestUserMessage = vi.fn().mockResolvedValue({
       clientId: 'msg-1',
       text: 'please update login',
     });
-    const createSnapshot = vi.fn().mockImplementation(
-      async (_repo: string, input: CreateSnapshotInput) => {
+    const createShadowSavepoint = vi.fn().mockImplementation(
+      async (_repo: string, input: CreateShadowSavepointInput) => {
         if (typeof input.label === 'function') {
           await input.label({ diffStat: ' src/a.ts | 1 +', diffText: '+x' });
         }
-        return 'hash123';
+        return { commit: 'hash123', tree: 'tree123', includedFiles: [], skippedFiles: [] };
       },
     );
-    const isWorktreeDirty = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true);
     const coordinator = createGitSnapshotCoordinator(maker, {
       readAutoSnapshotEnabled: () => true,
       detectRepoRoot: vi.fn().mockResolvedValue('/workspace/project'),
-      isWorktreeDirty,
       getLatestUserMessage,
-      createSnapshot,
+      createShadowSavepoint,
       logger,
     });
 
     await coordinator.onTurnStart('s1');
     await coordinator.onTurnEnd('s1');
 
-    expect(isWorktreeDirty).toHaveBeenCalledTimes(2);
-    expect(createSnapshot).toHaveBeenCalledOnce();
-    const [repoRoot, input] = createSnapshot.mock.calls[0] as [string, CreateSnapshotInput];
+    // turn-start 基线 + after-edit 各一次。
+    expect(createShadowSavepoint).toHaveBeenCalledTimes(2);
+    const [repoRoot, input] = createShadowSavepoint.mock.calls[1] as [
+      string,
+      CreateShadowSavepointInput,
+    ];
     expect(repoRoot).toBe('/workspace/project');
-    expect(input.meta).toMatchObject({ sessionId: 's1', kind: 'after-edit', anchor: 'msg-1' });
+    expect(input.sessionId).toBe('s1');
+    expect(input.meta).toMatchObject({
+      kind: 'after-edit',
+      anchor: 'msg-1',
+      baselineCommit: 'hash123',
+    });
+    expect(input.skipIfTreeEquals).toBe('hash123');
     expect(getLatestUserMessage).toHaveBeenCalledOnce();
     expect(maker.oneShot).toHaveBeenCalledWith('codex', expect.stringContaining('please update login'), {
       maxTokens: 80,
@@ -73,17 +80,17 @@ describe('createGitSnapshotCoordinator', () => {
       }),
     });
     const detectRepoRoot = vi.fn().mockResolvedValue('/remote/repo');
-    const createSnapshot = vi.fn();
+    const createShadowSavepoint = vi.fn();
 
     await createGitSnapshotCoordinator(maker, {
       readAutoSnapshotEnabled: () => true,
       detectRepoRoot,
-      createSnapshot,
+      createShadowSavepoint,
       logger,
     }).onTurnEnd('s1');
 
     expect(detectRepoRoot).not.toHaveBeenCalled();
-    expect(createSnapshot).not.toHaveBeenCalled();
+    expect(createShadowSavepoint).not.toHaveBeenCalled();
   });
 
   it('skips sessions without a working directory', async () => {
@@ -91,29 +98,34 @@ describe('createGitSnapshotCoordinator', () => {
       getSessionMeta: vi.fn().mockResolvedValue({ agentKind: 'claude-code', workDir: '' }),
     });
     const detectRepoRoot = vi.fn().mockResolvedValue('/repo');
-    const createSnapshot = vi.fn();
+    const createShadowSavepoint = vi.fn();
 
     await createGitSnapshotCoordinator(maker, {
       readAutoSnapshotEnabled: () => true,
       detectRepoRoot,
-      createSnapshot,
+      createShadowSavepoint,
       logger,
     }).onTurnEnd('s1');
 
     expect(detectRepoRoot).not.toHaveBeenCalled();
-    expect(createSnapshot).not.toHaveBeenCalled();
+    expect(createShadowSavepoint).not.toHaveBeenCalled();
   });
 
   it('passes the turn-start Git safety decision into project bootstrap', async () => {
     let enabled = true;
     const maker = makeMaker();
     const initializeProjectGit = vi.fn().mockResolvedValue({ repoRoot: '/workspace/project' });
-    const isWorktreeDirty = vi.fn().mockResolvedValue(false);
+    const createShadowSavepoint = vi.fn().mockResolvedValue({
+      commit: 'hash-t1',
+      tree: 'tree-t1',
+      includedFiles: [],
+      skippedFiles: [],
+    });
     const coordinator = createGitSnapshotCoordinator(maker, {
       readAutoSnapshotEnabled: vi.fn(() => enabled),
       detectRepoRoot: vi.fn().mockResolvedValue(null),
       initializeProjectGit,
-      isWorktreeDirty,
+      createShadowSavepoint,
       logger,
     });
 
@@ -129,19 +141,25 @@ describe('createGitSnapshotCoordinator', () => {
       }),
       { autoSnapshotEnabled: true },
     );
-    expect(isWorktreeDirty).toHaveBeenCalledWith('/workspace/project');
+    expect(createShadowSavepoint).toHaveBeenCalledWith(
+      '/workspace/project',
+      expect.objectContaining({
+        sessionId: 's1',
+        meta: expect.objectContaining({ kind: 'turn-start' }),
+      }),
+    );
   });
 
   it('defaults to disabled until a host setting enables it', async () => {
     const maker = makeMaker();
-    const createSnapshot = vi.fn();
+    const createShadowSavepoint = vi.fn();
 
     await createGitSnapshotCoordinator(maker, {
-      createSnapshot,
+      createShadowSavepoint,
       logger,
     }).onTurnEnd('s1');
 
     expect(maker.getSessionMeta).not.toHaveBeenCalled();
-    expect(createSnapshot).not.toHaveBeenCalled();
+    expect(createShadowSavepoint).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
@@ -226,6 +226,39 @@ describe('createShadowSavepoint', () => {
     expect(entries[0]?.baseHead).toBeUndefined();
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
+  it('treats tracked files behind an out-of-repo symlinked parent as deleted', async () => {
+    if (process.platform === 'win32') return; // 符号链接在 Windows CI 上需要特权
+    await commitSeed();
+    await writeRepoFile('evil/target.txt', 'tracked base\n');
+    await gitExec(['add', '-A'], repoPath);
+    await gitExec(['commit', '--no-gpg-sign', '-m', 'seed evil dir'], repoPath);
+    // 用户把 evil 换成指向仓库外的符号链接,外部目录里有同名文件:
+    // status 会报 `D evil/target.txt` + 未跟踪的 evil(符号链接)。
+    const outside = await fs.mkdtemp(path.join(path.dirname(repoPath), 'outside-'));
+    try {
+      await fs.writeFile(path.join(outside, 'target.txt'), 'external secret\n', 'utf8');
+      await fs.rm(path.join(repoPath, 'evil'), { recursive: true });
+      await fs.symlink(outside, path.join(repoPath, 'evil'));
+
+      const result = await createShadowSavepoint(repoPath, {
+        sessionId: SESSION,
+        label: 'symlinked parent',
+        meta: { kind: 'turn-start' },
+      });
+
+      expect(result.commit).toBeTruthy();
+      const commit = result.commit as string;
+      // 真实父目录在仓库外 → 按删除记录,绝不把外部内容写进保存点树;
+      // 符号链接本身以 link 对象入树。
+      await expect(gitExec(['show', `${commit}:evil/target.txt`], repoPath)).rejects.toThrow();
+      const evilEntry = await gitStdout(['ls-tree', commit, 'evil']);
+      expect(evilEntry).toContain('120000');
+      expect(await gitStdout(['show', `${commit}:seed.txt`])).toBe('seed\n');
+    } finally {
+      await fs.rm(outside, { recursive: true, force: true });
+    }
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
   it('tolerates a path staged in the user index but deleted from the worktree (status AD)', async () => {
     await commitSeed();
     // 用户自己 git add 了新文件,然后又从工作区删掉:status 为 `AD`,

--- a/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
@@ -220,10 +220,36 @@ describe('createShadowSavepoint', () => {
     await expect(gitExec(['rev-parse', '--verify', 'HEAD'], repoPath)).rejects.toThrow();
     expect((await gitStdout(['rev-list', '--count', result.commit as string])).trim()).toBe('1');
 
-    const entries = await listShadowSavepoints(repoPath, SESSION);
+    const { entries } = await listShadowSavepoints(repoPath, SESSION);
     expect(entries).toHaveLength(1);
     expect(entries[0]).toMatchObject({ commit: result.commit, parentCount: 0 });
     expect(entries[0]?.baseHead).toBeUndefined();
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('tolerates a path staged in the user index but deleted from the worktree (status AD)', async () => {
+    await commitSeed();
+    // 用户自己 git add 了新文件,然后又从工作区删掉:status 为 `AD`,
+    // 该路径既不在 HEAD 也不在工作区,git add 会 fatal,必须走 force-remove。
+    await writeRepoFile('staged-then-deleted.txt', 'gone\n');
+    await gitExec(['add', 'staged-then-deleted.txt'], repoPath);
+    await fs.rm(path.join(repoPath, 'staged-then-deleted.txt'));
+    await writeRepoFile('normal.txt', 'normal\n');
+    const before = await captureUserVisibleState();
+    expect(before.status).toContain('AD staged-then-deleted.txt');
+
+    const result = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'AD baseline',
+      meta: { kind: 'turn-start' },
+    });
+
+    expect(result.commit).toBeTruthy();
+    expect(await captureUserVisibleState()).toEqual(before);
+    const listed = (await gitStdout(['ls-tree', '-r', '--name-only', result.tree]))
+      .split('\n')
+      .filter(Boolean);
+    expect(listed).not.toContain('staged-then-deleted.txt');
+    expect(listed).toContain('normal.txt');
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it('keeps sensitive and oversized file contents out of the savepoint tree', async () => {
@@ -296,8 +322,39 @@ describe('createShadowMarker', () => {
 describe('listShadowSavepoints', () => {
   it('returns [] when the session ref does not exist or the session id is invalid', async () => {
     await commitSeed();
-    expect(await listShadowSavepoints(repoPath, 'no-such-session')).toEqual([]);
-    expect(await listShadowSavepoints(repoPath, 'bad session id!')).toEqual([]);
+    expect(await listShadowSavepoints(repoPath, 'no-such-session')).toEqual({
+      entries: [],
+      truncated: false,
+    });
+    expect(await listShadowSavepoints(repoPath, 'bad session id!')).toEqual({
+      entries: [],
+      truncated: false,
+    });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('reports truncation when the chain exceeds the traversal window', async () => {
+    await commitSeed();
+    const commits: string[] = [];
+    for (let i = 0; i < 3; i += 1) {
+      await writeRepoFile('a.txt', `v${i}\n`);
+      const result = await createShadowSavepoint(repoPath, {
+        sessionId: SESSION,
+        label: `turn ${i}`,
+        meta: { kind: 'turn-start' },
+      });
+      commits.push(result.commit as string);
+    }
+
+    const truncatedView = await listShadowSavepoints(repoPath, SESSION, { maxCount: 2 });
+    expect(truncatedView.truncated).toBe(true);
+    expect(truncatedView.entries.map((entry) => entry.commit)).toEqual([
+      commits[2],
+      commits[1],
+    ]);
+
+    const fullView = await listShadowSavepoints(repoPath, SESSION, { maxCount: 10 });
+    expect(fullView.truncated).toBe(false);
+    expect(fullView.entries).toHaveLength(3);
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it('lists chain savepoints newest-first without X-XDT commits from the HEAD branch', async () => {
@@ -321,7 +378,7 @@ describe('listShadowSavepoints', () => {
       meta: { kind: 'after-edit', anchor: 'm1', baselineCommit: first.commit as string },
     });
 
-    const entries = await listShadowSavepoints(repoPath, SESSION);
+    const { entries } = await listShadowSavepoints(repoPath, SESSION);
 
     expect(entries.map((entry) => entry.commit)).toEqual([second.commit, first.commit]);
     expect(entries.map((entry) => entry.commit)).not.toContain(legacyMarker);
@@ -352,7 +409,7 @@ describe('listShadowSavepoints', () => {
     });
     expect(rollbackMarker).toBeTruthy();
 
-    const entries = await listShadowSavepoints(repoPath, SESSION);
+    const { entries } = await listShadowSavepoints(repoPath, SESSION);
 
     expect(entries.map((entry) => entry.commit)).toEqual([savepoint.commit]);
     expect(entries[0]?.kind).toBe('turn-start');
@@ -373,7 +430,7 @@ describe('listShadowSavepoints', () => {
       meta: { kind: 'turn-start' },
     });
 
-    const entries = await listShadowSavepoints(repoPath, SESSION);
+    const { entries } = await listShadowSavepoints(repoPath, SESSION);
     expect(entries.map((entry) => entry.commit)).toEqual([mine.commit]);
   }, REAL_GIT_TEST_TIMEOUT_MS);
 });
@@ -443,5 +500,23 @@ describe('writeWorktreeTreeForPaths', () => {
     expect(listed).not.toContain('del.txt');
     // 未列入 paths 的 HEAD 文件保持 HEAD 版本(临时 index 以 HEAD 播种)。
     expect(await gitStdout(['show', `${tree}:other.txt`])).toBe('other base\n');
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('treats a file replaced by a directory as absent instead of failing', async () => {
+    await writeRepoFile('swap', 'was a file\n');
+    await gitExec(['add', '-A'], repoPath);
+    await gitExec(['commit', '--no-gpg-sign', '-m', 'seed swap fixture'], repoPath);
+    // 某轮把文件 swap 换成了同名目录及其子文件:路径集合里旧文件路径仍在。
+    await fs.rm(path.join(repoPath, 'swap'));
+    await writeRepoFile('swap/child.txt', 'child\n');
+
+    const tree = await writeWorktreeTreeForPaths(repoPath, ['swap', 'swap/child.txt']);
+
+    const listed = (await gitStdout(['ls-tree', '-r', '--name-only', tree]))
+      .split('\n')
+      .filter(Boolean);
+    expect(listed).toContain('swap/child.txt');
+    expect(listed).not.toContain('swap');
+    expect(await gitStdout(['show', `${tree}:swap/child.txt`])).toBe('child\n');
   }, REAL_GIT_TEST_TIMEOUT_MS);
 });

--- a/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
@@ -1,0 +1,447 @@
+/**
+ * Shadow savepoint kernel tests with real temporary repositories.
+ *
+ * 核心不变量:createShadowSavepoint / createShadowMarker 只写
+ * refs/cindy/savepoints/<sessionId> 隐藏链,HEAD、当前分支、用户 index、
+ * 工作区在保存点前后必须逐字节不变。
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { TestDirectoryTemplate } from '../../test/vitest/testDirectoryTemplate';
+import {
+  createShadowMarker,
+  createShadowSavepoint,
+  createSnapshotMarker,
+  listShadowSavepoints,
+  writeWorktreeTreeForPaths,
+} from '../git-snapshot/gitSnapshotService';
+import {
+  deleteSavepointRef,
+  InvalidSavepointSessionIdError,
+  listSavepointRefs,
+  readSavepointTip,
+  savepointRefForSession,
+  SAVEPOINT_REF_NAMESPACE,
+} from '../git-snapshot/savepointRefs';
+import { parseSnapshotCommit } from '../git-snapshot/snapshotTrailers';
+import { gitExec } from '../worktree/gitExec';
+
+const REAL_GIT_TEST_TIMEOUT_MS = process.platform === 'win32' ? 60_000 : 20_000;
+const SESSION = 'shadow-sess-1';
+
+let repoPath: string;
+const originalGitLocaleEnv = {
+  LC_ALL: process.env.LC_ALL,
+  LANG: process.env.LANG,
+  LANGUAGE: process.env.LANGUAGE,
+};
+
+const repoTemplate = new TestDirectoryTemplate('xdt-shadow-savepoint-', async (dir) => {
+  await gitExec(['init'], dir);
+  await gitExec(['config', 'user.email', 'test@xdt.local'], dir);
+  await gitExec(['config', 'user.name', 'XDT Test'], dir);
+  await gitExec(['config', 'commit.gpgsign', 'false'], dir);
+  await gitExec(['config', 'core.autocrlf', 'false'], dir);
+});
+
+async function initRepo(): Promise<string> {
+  const dir = await repoTemplate.createCopy();
+  // 仓库级覆写 core.excludesFile:宿主机全局 gitignore 会吞掉未跟踪文件,
+  // 让 status 逐字节断言在部分开发机上失真。复制后再写绝对路径。
+  const excludesOverride = path.join(dir, '.git', 'xdt-test-empty-excludes');
+  await fs.writeFile(excludesOverride, '', 'utf8');
+  await gitExec(['config', 'core.excludesFile', excludesOverride], dir);
+  return dir;
+}
+
+async function writeRepoFile(gitPath: string, content: string | Buffer): Promise<void> {
+  const filePath = path.join(repoPath, ...gitPath.split('/'));
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+}
+
+async function gitStdout(args: string[]): Promise<string> {
+  return (await gitExec(args, repoPath)).stdout;
+}
+
+async function head(): Promise<string> {
+  return (await gitStdout(['rev-parse', 'HEAD'])).trim();
+}
+
+async function commitSeed(): Promise<string> {
+  await writeRepoFile('seed.txt', 'seed\n');
+  await gitExec(['add', '-A'], repoPath);
+  await gitExec(['commit', '--no-gpg-sign', '-m', 'seed'], repoPath);
+  return head();
+}
+
+async function treeOf(commitish: string): Promise<string> {
+  return (await gitStdout(['rev-parse', `${commitish}^{tree}`])).trim();
+}
+
+async function commitMessage(commitish: string): Promise<string> {
+  return (await gitStdout(['log', '-1', '--format=%B', commitish])).replace(/\n+$/, '\n');
+}
+
+/** Raw byte-level view of everything a shadow savepoint must never change. */
+async function captureUserVisibleState(): Promise<{
+  head: string;
+  branch: string;
+  status: string;
+  cachedDiff: string;
+}> {
+  const [headOut, branchOut, statusOut, cachedOut] = [
+    await gitStdout(['rev-parse', 'HEAD']),
+    await gitStdout(['branch', '--show-current']),
+    await gitStdout(['status', '--porcelain=v1']),
+    await gitStdout(['diff', '--cached']),
+  ];
+  return { head: headOut, branch: branchOut, status: statusOut, cachedDiff: cachedOut };
+}
+
+beforeEach(async () => {
+  process.env.LC_ALL = 'C';
+  process.env.LANG = 'C';
+  delete process.env.LANGUAGE;
+  repoPath = await initRepo();
+});
+
+afterEach(async () => {
+  await fs.rm(repoPath, { recursive: true, force: true, maxRetries: 20, retryDelay: 100 });
+  if (originalGitLocaleEnv.LC_ALL === undefined) delete process.env.LC_ALL;
+  else process.env.LC_ALL = originalGitLocaleEnv.LC_ALL;
+  if (originalGitLocaleEnv.LANG === undefined) delete process.env.LANG;
+  else process.env.LANG = originalGitLocaleEnv.LANG;
+  if (originalGitLocaleEnv.LANGUAGE === undefined) delete process.env.LANGUAGE;
+  else process.env.LANGUAGE = originalGitLocaleEnv.LANGUAGE;
+});
+
+afterAll(async () => {
+  await repoTemplate.dispose();
+});
+
+describe('createShadowSavepoint', () => {
+  it('never changes HEAD, branch, status or the cached diff', async () => {
+    await commitSeed();
+    await writeRepoFile('staged.txt', 'staged change\n');
+    await gitExec(['add', 'staged.txt'], repoPath);
+    await writeRepoFile('seed.txt', 'unstaged change\n');
+    await writeRepoFile('untracked.txt', 'untracked\n');
+    const before = await captureUserVisibleState();
+    expect(before.status).not.toBe('');
+    expect(before.cachedDiff).not.toBe('');
+
+    const result = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: '本轮开始时的工作区基线',
+      meta: { kind: 'turn-start', anchor: 'm1' },
+    });
+
+    expect(result.commit).toBeTruthy();
+    expect(await captureUserVisibleState()).toEqual(before);
+
+    // 工作区内容全部进了 tree,且 trailer 是 X-Cindy 代际。
+    const commit = result.commit as string;
+    expect(await gitStdout(['show', `${commit}:staged.txt`])).toBe('staged change\n');
+    expect(await gitStdout(['show', `${commit}:seed.txt`])).toBe('unstaged change\n');
+    expect(await gitStdout(['show', `${commit}:untracked.txt`])).toBe('untracked\n');
+    const parsed = parseSnapshotCommit(await commitMessage(commit));
+    expect(parsed).toMatchObject({
+      source: 'cindy',
+      sessionId: SESSION,
+      kind: 'turn-start',
+      anchor: 'm1',
+      label: '本轮开始时的工作区基线',
+      baseHead: before.head.trim(),
+      branch: before.branch.trim(),
+    });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('chains savepoints: the second commit parents the first, ref tracks the tip', async () => {
+    await commitSeed();
+    await writeRepoFile('a.txt', 'v1\n');
+    const first = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'first',
+      meta: { kind: 'turn-start' },
+    });
+    await writeRepoFile('a.txt', 'v2\n');
+    const second = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'second',
+      meta: { kind: 'after-edit', baselineCommit: first.commit as string },
+    });
+
+    expect(first.commit).toBeTruthy();
+    expect(second.commit).toBeTruthy();
+    expect((await gitStdout(['rev-parse', `${second.commit}^`])).trim()).toBe(first.commit);
+    expect(await readSavepointTip(repoPath, SESSION)).toBe(second.commit);
+    expect(
+      (await gitStdout(['rev-parse', savepointRefForSession(SESSION)])).trim(),
+    ).toBe(second.commit);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('skipIfTreeEquals returns null and keeps the ref untouched', async () => {
+    await commitSeed();
+    await writeRepoFile('a.txt', 'v1\n');
+    const baseline = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'baseline',
+      meta: { kind: 'turn-start' },
+    });
+
+    const result = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'unchanged turn',
+      meta: { kind: 'after-edit', baselineCommit: baseline.commit as string },
+      skipIfTreeEquals: baseline.commit as string,
+    });
+
+    expect(result.commit).toBeNull();
+    expect(result.tree).toBe(await treeOf(baseline.commit as string));
+    expect(await readSavepointTip(repoPath, SESSION)).toBe(baseline.commit);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('creates a parentless savepoint with no baseHead in an unborn repository', async () => {
+    await writeRepoFile('first.txt', 'first\n');
+
+    const result = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'unborn baseline',
+      meta: { kind: 'turn-start' },
+    });
+
+    expect(result.commit).toBeTruthy();
+    // HEAD 仍然 unborn:保存点没有替用户创建首个分支提交。
+    await expect(gitExec(['rev-parse', '--verify', 'HEAD'], repoPath)).rejects.toThrow();
+    expect((await gitStdout(['rev-list', '--count', result.commit as string])).trim()).toBe('1');
+
+    const entries = await listShadowSavepoints(repoPath, SESSION);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({ commit: result.commit, parentCount: 0 });
+    expect(entries[0]?.baseHead).toBeUndefined();
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('keeps sensitive and oversized file contents out of the savepoint tree', async () => {
+    await writeRepoFile('big.txt', 'small\n');
+    await gitExec(['add', '-A'], repoPath);
+    await gitExec(['commit', '--no-gpg-sign', '-m', 'seed big'], repoPath);
+    await writeRepoFile('big.txt', Buffer.alloc(64, 'x'));
+    await writeRepoFile('.env', 'SECRET=abc123\n');
+    await writeRepoFile('safe.txt', 'safe\n');
+
+    const result = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'filtered',
+      meta: { kind: 'turn-start' },
+      fileFilter: { maxFileBytes: 32 },
+    });
+
+    expect(result.commit).toBeTruthy();
+    expect(result.includedFiles).toEqual(['safe.txt']);
+    expect(result.skippedFiles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ path: '.env', reason: 'sensitive-path' }),
+        expect.objectContaining({ path: 'big.txt', reason: 'large-file' }),
+      ]),
+    );
+    const commit = result.commit as string;
+    // 被 skip 的 tracked 文件保留 HEAD 版本,未跟踪的敏感文件完全缺失。
+    expect(await gitStdout(['show', `${commit}:big.txt`])).toBe('small\n');
+    await expect(gitExec(['show', `${commit}:.env`], repoPath)).rejects.toThrow();
+    expect(await gitStdout(['show', `${commit}:safe.txt`])).toBe('safe\n');
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+});
+
+describe('createShadowMarker', () => {
+  it('returns null on an empty chain and leaves no ref behind', async () => {
+    await commitSeed();
+
+    const marker = await createShadowMarker(repoPath, {
+      sessionId: SESSION,
+      label: 'gap marker',
+      meta: { kind: 'rewind-blocked' },
+    });
+
+    expect(marker).toBeNull();
+    expect(await readSavepointTip(repoPath, SESSION)).toBeNull();
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('reuses the chain tip tree and parents the tip on a non-empty chain', async () => {
+    await commitSeed();
+    await writeRepoFile('a.txt', 'v1\n');
+    const savepoint = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'baseline',
+      meta: { kind: 'turn-start' },
+    });
+
+    const marker = await createShadowMarker(repoPath, {
+      sessionId: SESSION,
+      label: 'rollback marker',
+      meta: { kind: 'rollback', rollbackId: 'rb-1' },
+    });
+
+    expect(marker).toBeTruthy();
+    expect(await treeOf(marker as string)).toBe(await treeOf(savepoint.commit as string));
+    expect((await gitStdout(['rev-parse', `${marker}^`])).trim()).toBe(savepoint.commit);
+    expect(await readSavepointTip(repoPath, SESSION)).toBe(marker);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+});
+
+describe('listShadowSavepoints', () => {
+  it('returns [] when the session ref does not exist or the session id is invalid', async () => {
+    await commitSeed();
+    expect(await listShadowSavepoints(repoPath, 'no-such-session')).toEqual([]);
+    expect(await listShadowSavepoints(repoPath, 'bad session id!')).toEqual([]);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('lists chain savepoints newest-first without X-XDT commits from the HEAD branch', async () => {
+    await commitSeed();
+    // HEAD 分支上的 legacy X-XDT commit(同 session)绝不能混进 shadow 链。
+    const legacyMarker = await createSnapshotMarker(repoPath, {
+      label: 'legacy on branch',
+      meta: { sessionId: SESSION, kind: 'after-edit', anchor: 'm0' },
+    });
+
+    await writeRepoFile('a.txt', 'v1\n');
+    const first = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'turn start',
+      meta: { kind: 'turn-start', anchor: 'm1' },
+    });
+    await writeRepoFile('a.txt', 'v2\n');
+    const second = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'after edit',
+      meta: { kind: 'after-edit', anchor: 'm1', baselineCommit: first.commit as string },
+    });
+
+    const entries = await listShadowSavepoints(repoPath, SESSION);
+
+    expect(entries.map((entry) => entry.commit)).toEqual([second.commit, first.commit]);
+    expect(entries.map((entry) => entry.commit)).not.toContain(legacyMarker);
+    expect(entries[0]).toMatchObject({
+      kind: 'after-edit',
+      source: 'cindy',
+      sessionId: SESSION,
+      anchor: 'm1',
+      baselineCommit: first.commit,
+      parentCount: 1,
+    });
+    expect(entries[0]?.baseHead).toBeTruthy();
+    expect(entries[1]).toMatchObject({ kind: 'turn-start', source: 'cindy', parentCount: 0 });
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('filters non-listable kinds such as rollback markers', async () => {
+    await commitSeed();
+    await writeRepoFile('a.txt', 'v1\n');
+    const savepoint = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'baseline',
+      meta: { kind: 'turn-start' },
+    });
+    const rollbackMarker = await createShadowMarker(repoPath, {
+      sessionId: SESSION,
+      label: 'rollback',
+      meta: { kind: 'rollback', rollbackId: 'rb-1' },
+    });
+    expect(rollbackMarker).toBeTruthy();
+
+    const entries = await listShadowSavepoints(repoPath, SESSION);
+
+    expect(entries.map((entry) => entry.commit)).toEqual([savepoint.commit]);
+    expect(entries[0]?.kind).toBe('turn-start');
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+
+  it('does not leak savepoints across sessions', async () => {
+    await commitSeed();
+    await writeRepoFile('a.txt', 'v1\n');
+    const mine = await createShadowSavepoint(repoPath, {
+      sessionId: SESSION,
+      label: 'mine',
+      meta: { kind: 'turn-start' },
+    });
+    await writeRepoFile('a.txt', 'v2\n');
+    await createShadowSavepoint(repoPath, {
+      sessionId: 'other-session',
+      label: 'theirs',
+      meta: { kind: 'turn-start' },
+    });
+
+    const entries = await listShadowSavepoints(repoPath, SESSION);
+    expect(entries.map((entry) => entry.commit)).toEqual([mine.commit]);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+});
+
+describe('savepointRefs', () => {
+  it('rejects session ids that cannot be embedded into a refname', () => {
+    for (const sessionId of ['has space', 'a/../b', 'dot.dot', '', 'x'.repeat(129)]) {
+      expect(() => savepointRefForSession(sessionId)).toThrow(InvalidSavepointSessionIdError);
+    }
+    expect(savepointRefForSession('Ok_id-123')).toBe(`${SAVEPOINT_REF_NAMESPACE}Ok_id-123`);
+  });
+
+  it('lists refs for multiple sessions and deletes them idempotently', async () => {
+    await commitSeed();
+    await writeRepoFile('a.txt', 'v1\n');
+    const a = await createShadowSavepoint(repoPath, {
+      sessionId: 'sess-a',
+      label: 'a',
+      meta: { kind: 'turn-start' },
+    });
+    await writeRepoFile('a.txt', 'v2\n');
+    const b = await createShadowSavepoint(repoPath, {
+      sessionId: 'sess-b',
+      label: 'b',
+      meta: { kind: 'turn-start' },
+    });
+
+    const refs = await listSavepointRefs(repoPath);
+    expect(refs).toEqual(
+      expect.arrayContaining([
+        { sessionId: 'sess-a', sha: a.commit },
+        { sessionId: 'sess-b', sha: b.commit },
+      ]),
+    );
+    expect(refs).toHaveLength(2);
+
+    await deleteSavepointRef(repoPath, 'sess-a');
+    // 幂等:重复删除与删除非法 id 都静默成功。
+    await deleteSavepointRef(repoPath, 'sess-a');
+    await deleteSavepointRef(repoPath, 'bad id!');
+
+    expect(await readSavepointTip(repoPath, 'sess-a')).toBeNull();
+    expect(await listSavepointRefs(repoPath)).toEqual([{ sessionId: 'sess-b', sha: b.commit }]);
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+});
+
+describe('writeWorktreeTreeForPaths', () => {
+  it('writes current worktree state and tolerates paths deleted and absent from HEAD', async () => {
+    await writeRepoFile('a.txt', 'base\n');
+    await writeRepoFile('del.txt', 'delete me\n');
+    await writeRepoFile('other.txt', 'other base\n');
+    await gitExec(['add', '-A'], repoPath);
+    await gitExec(['commit', '--no-gpg-sign', '-m', 'seed tree fixture'], repoPath);
+    await writeRepoFile('a.txt', 'work\n');
+    await fs.rm(path.join(repoPath, 'del.txt'));
+
+    // ghost.txt 从未存在(等价于"某轮创建、后续轮删除"后的终态):
+    // 不报错,也不出现在结果树里。
+    const tree = await writeWorktreeTreeForPaths(repoPath, ['a.txt', 'del.txt', 'ghost.txt']);
+
+    expect(tree).toMatch(/^[0-9a-f]{40}$/);
+    expect(await gitStdout(['show', `${tree}:a.txt`])).toBe('work\n');
+    const listed = (await gitStdout(['ls-tree', '-r', '--name-only', tree]))
+      .split('\n')
+      .filter(Boolean);
+    expect(listed).not.toContain('ghost.txt');
+    expect(listed).not.toContain('del.txt');
+    // 未列入 paths 的 HEAD 文件保持 HEAD 版本(临时 index 以 HEAD 播种)。
+    expect(await gitStdout(['show', `${tree}:other.txt`])).toBe('other base\n');
+  }, REAL_GIT_TEST_TIMEOUT_MS);
+});

--- a/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotShadow.git-integration.test.ts
@@ -317,17 +317,24 @@ describe('createShadowSavepoint', () => {
 });
 
 describe('createShadowMarker', () => {
-  it('returns null on an empty chain and leaves no ref behind', async () => {
+  it('creates a root marker with the empty tree on an empty chain', async () => {
+    // 首轮 turn-start 失败时链还是空的:缺口必须作为根提交持久化,否则
+    // 后续轮次正常建链后 planner 永远看不到首轮缺口。
     await commitSeed();
 
     const marker = await createShadowMarker(repoPath, {
       sessionId: SESSION,
       label: 'gap marker',
-      meta: { kind: 'rewind-blocked' },
+      meta: { kind: 'rewind-blocked', anchor: 'm1' },
     });
 
-    expect(marker).toBeNull();
-    expect(await readSavepointTip(repoPath, SESSION)).toBeNull();
+    expect(marker).toBeTruthy();
+    expect(await readSavepointTip(repoPath, SESSION)).toBe(marker);
+    // 空树根提交:无父、树为 canonical empty tree。
+    expect((await gitStdout(['rev-list', '--count', marker as string])).trim()).toBe('1');
+    expect(await treeOf(marker as string)).toBe('4b825dc642cb6eb9a060e54bf8d69288fbee4904');
+    const { entries } = await listShadowSavepoints(repoPath, SESSION);
+    expect(entries.map((entry) => entry.kind)).toContain('rewind-blocked');
   }, REAL_GIT_TEST_TIMEOUT_MS);
 
   it('reuses the chain tip tree and parents the tip on a non-empty chain', async () => {

--- a/apps/desktop/src/main/__tests__/gitSnapshotTrailers.test.ts
+++ b/apps/desktop/src/main/__tests__/gitSnapshotTrailers.test.ts
@@ -1,13 +1,18 @@
 /**
  * git-snapshot: commit message ⇄ 保存点元数据 的序列化/解析单测。
  *
- * 保存点用 git 原生 trailer (X-XDT-*) 把 {sessionId, kind, anchor} 落进 commit message,
+ * 保存点用 git 原生 trailer 把 {sessionId, kind, anchor, ...} 落进 commit message,
  * git log 就是唯一事实源。非保存点 commit 必须被识别为 null。
+ *
+ * 两代前缀并存: X-XDT-*(legacy, 直接 commit 到用户分支)与 X-Cindy-*
+ * (shadow savepoint 隐藏引用链)。parse 结果必带 source 区分代际,
+ * 两种前缀同现时 X-Cindy 优先。
  */
 
 import { describe, it, expect } from 'vitest';
 
 import {
+  buildCindyCommitMessage,
   buildCommitMessage,
   parseSnapshotCommit,
 } from '../git-snapshot/snapshotTrailers';
@@ -26,6 +31,7 @@ describe('snapshotTrailers', () => {
       sessionId: 'sess-123',
       kind: 'after-edit',
       anchor: 'msg-456',
+      source: 'legacy-xdt',
     });
   });
 
@@ -171,6 +177,107 @@ describe('snapshotTrailers', () => {
       reverts: ['c3', 'c2'],
       protectRef: 'refs/xdt/pre-rollback/rb-1',
       branch: 'main',
+      source: 'legacy-xdt',
+    });
+  });
+
+  it('buildCindyCommitMessage 往返: turn-start kind + baseHead', () => {
+    const msg = buildCindyCommitMessage('本轮开始时的工作区基线', {
+      sessionId: 'sess-9',
+      kind: 'turn-start',
+      anchor: 'msg-9',
+      branch: 'main',
+      baseHead: 'headsha0001',
+    });
+
+    expect(msg).toContain('X-Cindy-Session: sess-9');
+    expect(msg).not.toContain('X-XDT-');
+    expect(parseSnapshotCommit(msg)).toMatchObject({
+      label: '本轮开始时的工作区基线',
+      sessionId: 'sess-9',
+      kind: 'turn-start',
+      anchor: 'msg-9',
+      branch: 'main',
+      baseHead: 'headsha0001',
+      source: 'cindy',
+    });
+  });
+
+  it('buildCindyCommitMessage 往返: after-edit 带 baselineCommit → source=cindy', () => {
+    const msg = buildCindyCommitMessage('AI 修改后', {
+      sessionId: 'sess-9',
+      kind: 'after-edit',
+      anchor: 'msg-10',
+      baselineCommit: 'turnstart0001',
+    });
+
+    const parsed = parseSnapshotCommit(msg);
+    expect(parsed).toMatchObject({
+      label: 'AI 修改后',
+      sessionId: 'sess-9',
+      kind: 'after-edit',
+      anchor: 'msg-10',
+      baselineCommit: 'turnstart0001',
+      source: 'cindy',
+    });
+  });
+
+  it('buildCindyCommitMessage 往返: rollback marker 带 preRollbackCommit/reverts', () => {
+    const msg = buildCindyCommitMessage('rollback marker', {
+      sessionId: 'sess-9',
+      kind: 'rollback',
+      rollbackId: 'rb-9',
+      rollbackTarget: 'msg-2',
+      reverts: ['s3', 's2'],
+      preRollbackCommit: 'prerollback01',
+    });
+
+    expect(parseSnapshotCommit(msg)).toMatchObject({
+      label: 'rollback marker',
+      sessionId: 'sess-9',
+      kind: 'rollback',
+      rollbackId: 'rb-9',
+      rollbackTarget: 'msg-2',
+      reverts: ['s3', 's2'],
+      preRollbackCommit: 'prerollback01',
+      source: 'cindy',
+    });
+  });
+
+  it('两种前缀同现时 X-Cindy 优先 (构造性用例, 实际不会发生)', () => {
+    const msg = [
+      'mixed prefixes',
+      '',
+      'X-XDT-Session: legacy-sess',
+      'X-XDT-Kind: manual',
+      'X-Cindy-Session: cindy-sess',
+      'X-Cindy-Kind: after-edit',
+      'X-Cindy-Baseline: base-1',
+    ].join('\n');
+
+    expect(parseSnapshotCommit(msg)).toMatchObject({
+      label: 'mixed prefixes',
+      sessionId: 'cindy-sess',
+      kind: 'after-edit',
+      baselineCommit: 'base-1',
+      source: 'cindy',
+    });
+  });
+
+  it('X-Cindy 字段不完整时回退到同 commit 的合法 X-XDT 块', () => {
+    const msg = [
+      'partial cindy',
+      '',
+      'X-XDT-Session: legacy-sess',
+      'X-XDT-Kind: manual',
+      'X-Cindy-Baseline: base-1',
+    ].join('\n');
+
+    expect(parseSnapshotCommit(msg)).toMatchObject({
+      label: 'partial cindy',
+      sessionId: 'legacy-sess',
+      kind: 'manual',
+      source: 'legacy-xdt',
     });
   });
 });

--- a/apps/desktop/src/main/__tests__/rewind.test.ts
+++ b/apps/desktop/src/main/__tests__/rewind.test.ts
@@ -32,10 +32,13 @@ const commitRewindFilesMock = vi.fn();
 const isTurnRunningMock = vi.fn(() => false);
 const recomputePrRefsForSessionMock = vi.fn();
 const executeCodexFileRewindPlanWithThreadRollbackMock = vi.fn();
+const executeCodexFileRestorePlanWithThreadRollbackMock = vi.fn();
 const detectCwdMock = vi.fn();
 const getHeadMock = vi.fn();
 const getCurrentBranchMock = vi.fn();
 const listSnapshotsMock = vi.fn();
+const listShadowSavepointsMock = vi.fn();
+const writeWorktreeTreeForPathsMock = vi.fn();
 const gitExecMock = vi.fn();
 
 type FakeSession = {
@@ -90,6 +93,10 @@ vi.mock('../git-snapshot/codexFileRewindExecutor', () => ({
   executeCodexFileRewindPlanWithThreadRollback: executeCodexFileRewindPlanWithThreadRollbackMock,
 }));
 
+vi.mock('../git-snapshot/codexFileRestoreExecutor', () => ({
+  executeCodexFileRestorePlanWithThreadRollback: executeCodexFileRestorePlanWithThreadRollbackMock,
+}));
+
 vi.mock('../worktree/WorktreeManager.js', () => ({
   detectCwd: detectCwdMock,
 }));
@@ -98,6 +105,11 @@ vi.mock('../git-snapshot/gitSnapshotService', () => ({
   getHead: getHeadMock,
   getCurrentBranch: getCurrentBranchMock,
   listSnapshots: listSnapshotsMock,
+  listShadowSavepoints: listShadowSavepointsMock,
+  writeWorktreeTreeForPaths: writeWorktreeTreeForPathsMock,
+  // 单测里不需要真实拆块: preview 的 pathspec 数量远小于命令行上限。
+  chunkPathspecArgs: (pathspecs: readonly string[]) =>
+    pathspecs.length > 0 ? [Array.from(pathspecs)] : [],
 }));
 
 vi.mock('../worktree/gitExec', () => ({ gitExec: gitExecMock }));
@@ -168,6 +180,17 @@ beforeEach(async () => {
       threadRollback: await hooks.commitThreadRollback(null),
     }),
   );
+  executeCodexFileRestorePlanWithThreadRollbackMock.mockReset();
+  executeCodexFileRestorePlanWithThreadRollbackMock.mockImplementation(
+    async (
+      _plan: unknown,
+      _sessionId: string,
+      hooks: { commitThreadRollback: (execution: unknown) => Promise<unknown> },
+    ) => ({
+      fileRestore: null,
+      threadRollback: await hooks.commitThreadRollback(null),
+    }),
+  );
   detectCwdMock.mockReset();
   detectCwdMock.mockResolvedValue({ gitInstalled: true, isGitRepo: false, isInsideWorktree: false });
   getHeadMock.mockReset();
@@ -176,6 +199,9 @@ beforeEach(async () => {
   getCurrentBranchMock.mockResolvedValue('main');
   listSnapshotsMock.mockReset();
   listSnapshotsMock.mockResolvedValue([]);
+  listShadowSavepointsMock.mockReset();
+  listShadowSavepointsMock.mockResolvedValue([]);
+  writeWorktreeTreeForPathsMock.mockReset();
   gitExecMock.mockReset();
   recomputePrRefsForSessionMock.mockReset();
   recomputePrRefsForSessionMock.mockResolvedValue(undefined);
@@ -881,14 +907,60 @@ describe('commitRewindAtMessage', () => {
     expect(result.id).toBe('sess-1');
   });
 
-  it('Codex: previews file rewind savepoints before commit', async () => {
+  it('Codex: previews file rewind savepoints before commit (legacy numstat 方向对调)', async () => {
     useFakeSession('codex');
     detectCwdMock.mockResolvedValueOnce({ gitInstalled: true, isGitRepo: true, repoRoot: '/repo', isInsideWorktree: false });
-    listSnapshotsMock.mockResolvedValueOnce([{ commit: 'sp1', sessionId: 'sess-1', kind: 'after-edit', branch: 'main', parentCount: 1, anchor: 'client-id' }]);
+    listSnapshotsMock.mockResolvedValueOnce([{ commit: 'sp1', sessionId: 'sess-1', kind: 'after-edit', source: 'legacy-xdt', branch: 'main', parentCount: 1, anchor: 'client-id' }]);
     gitExecMock.mockResolvedValueOnce({ stdout: '3\t1\tsrc/a.ts\n-\t-\tbin.dat\n', stderr: '' });
     selectQueue.push([makeUserMessageRow({ agentMeta: null })], [], [makeUserMessageRow({ clientId: 'client-id', createdAt: 3000 })]);
 
+    // legacy revert 预览: numstat 是正向 diff, 回退方向的 insertions/deletions 要对调。
     await expect(previewRewindAtMessage('sess-1', 'client-id')).resolves.toEqual({ canRewind: true, filesChanged: ['src/a.ts', 'bin.dat'], insertions: 1, deletions: 3 });
+    expect(listShadowSavepointsMock).toHaveBeenCalledWith('/repo', 'sess-1');
+  });
+
+  it('Codex: previews shadow file-restore plan (numstat 不对调, untracked 新建文件删除计入)', async () => {
+    useFakeSession('codex');
+    detectCwdMock.mockResolvedValueOnce({ gitInstalled: true, isGitRepo: true, repoRoot: '/repo', isInsideWorktree: false });
+    listShadowSavepointsMock.mockResolvedValueOnce([
+      {
+        commit: 'sc1',
+        sessionId: 'sess-1',
+        kind: 'after-edit',
+        source: 'cindy',
+        parentCount: 1,
+        anchor: 'client-id',
+        baselineCommit: 'base1',
+        label: '本轮修改',
+        time: '2026-08-04T00:00:00+08:00',
+      },
+    ]);
+    writeWorktreeTreeForPathsMock.mockResolvedValueOnce('wtree-sha');
+    gitExecMock.mockImplementation(async (args: readonly string[]) => {
+      if (args.includes('--name-only')) {
+        // affected = diff(baselineCommit, after-edit commit)
+        expect(Array.from(args)).toEqual(['diff', '--name-only', '--no-renames', '-z', 'base1', 'sc1']);
+        return { stdout: ['src/a.ts', 'new-file.txt', ''].join('\0'), stderr: '' };
+      }
+      // W 树 → 基线树, 方向即回退方向。new-file.txt 是本轮新建的 untracked 文件:
+      // 基线里不存在 → 记 5 行删除。
+      expect(Array.from(args)).toEqual([
+        'diff', '--numstat', '--no-renames', '-z', 'wtree-sha', 'base1', '--',
+        ':(literal)src/a.ts', ':(literal)new-file.txt',
+      ]);
+      return { stdout: ['2\t7\tsrc/a.ts', '0\t5\tnew-file.txt', ''].join('\0'), stderr: '' };
+    });
+    selectQueue.push([makeUserMessageRow({ agentMeta: null })], [], [makeUserMessageRow({ clientId: 'client-id', createdAt: 3000 })]);
+
+    // 数字不对调: insertions=Σadded, deletions=Σdeleted (含 untracked 新建文件的 5 行删除)。
+    await expect(previewRewindAtMessage('sess-1', 'client-id')).resolves.toEqual({
+      canRewind: true,
+      filesChanged: ['src/a.ts', 'new-file.txt'],
+      insertions: 2,
+      deletions: 12,
+    });
+    expect(writeWorktreeTreeForPathsMock).toHaveBeenCalledWith('/repo', ['src/a.ts', 'new-file.txt']);
+    expect(gitExecMock).toHaveBeenCalledTimes(2);
   });
 
   it('Codex: treats unborn Git histories as no-savepoints conversation-only rewind', async () => {
@@ -906,6 +978,9 @@ describe('commitRewindAtMessage', () => {
       'sess-1',
       expect.objectContaining({ commitThreadRollback: expect.any(Function) }),
     );
+    // conversation-only 不进 restore 执行器, 也不动任何文件相关 git 操作。
+    expect(executeCodexFileRestorePlanWithThreadRollbackMock).not.toHaveBeenCalled();
+    expect(writeWorktreeTreeForPathsMock).not.toHaveBeenCalled();
     expect(commitRewindFilesMock).toHaveBeenCalledWith('', '', { tailTurnsToDrop: 1 });
   });
 
@@ -972,6 +1047,108 @@ describe('commitRewindAtMessage', () => {
     );
     expect(commitRewindFilesMock).toHaveBeenCalledWith('', '', { tailTurnsToDrop: 1 });
   });
+
+  it('Codex commit: shadow file-restore 计划分发给 restore 执行器', async () => {
+    useFakeSession('codex');
+    detectCwdMock.mockResolvedValueOnce({ gitInstalled: true, isGitRepo: true, repoRoot: '/repo', isInsideWorktree: false });
+    listShadowSavepointsMock.mockResolvedValueOnce([
+      {
+        commit: 'sc1',
+        sessionId: 'sess-1',
+        kind: 'after-edit',
+        source: 'cindy',
+        parentCount: 1,
+        anchor: 'client-id',
+        baselineCommit: 'base1',
+        label: '本轮修改',
+        time: '2026-08-04T00:00:00+08:00',
+      },
+    ]);
+    commitRewindFilesMock.mockResolvedValueOnce({ sdkSessionId: 'restore-thread-id' });
+    selectQueue.push(
+      [makeUserMessageRow({ agentMeta: null })],
+      [], // agent_switch 边界守卫:无边界
+      [makeUserMessageRow({ clientId: 'client-id', createdAt: 3000 })],
+      [makeSessionRow({ agentKind: 'codex' })],
+    );
+
+    const result = await commitRewindAtMessage('sess-1', 'client-id');
+
+    expect(executeCodexFileRestorePlanWithThreadRollbackMock).toHaveBeenCalledTimes(1);
+    expect(executeCodexFileRestorePlanWithThreadRollbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mode: 'file-restore',
+        repoRoot: '/repo',
+        baselineCommit: 'base1',
+        restoreCommitsNewestFirst: [
+          { commit: 'sc1', baselineCommit: 'base1', anchor: 'client-id', label: '本轮修改' },
+        ],
+      }),
+      'sess-1',
+      expect.objectContaining({ commitThreadRollback: expect.any(Function), onCompensationError: expect.any(Function) }),
+    );
+    expect(executeCodexFileRewindPlanWithThreadRollbackMock).not.toHaveBeenCalled();
+    expect(commitRewindFilesMock).toHaveBeenCalledWith('', '', { tailTurnsToDrop: 1 });
+    const txCall = txCalls.find((c) => c.name === 'rewind.commit');
+    if (!txCall) throw new Error('缺少 rewind.commit tx 调用');
+    expect(txCall.args).toMatchObject({ sdkSessionId: 'restore-thread-id' });
+    expect(result.id).toBe('sess-1');
+  });
+
+  it('Codex commit: legacy file-rewind 计划仍分发给 revert 执行器', async () => {
+    useFakeSession('codex');
+    detectCwdMock.mockResolvedValueOnce({ gitInstalled: true, isGitRepo: true, repoRoot: '/repo', isInsideWorktree: false });
+    listSnapshotsMock.mockResolvedValueOnce([
+      { commit: 'sp1', sessionId: 'sess-1', kind: 'after-edit', source: 'legacy-xdt', branch: 'main', parentCount: 1, anchor: 'client-id' },
+    ]);
+    selectQueue.push(
+      [makeUserMessageRow({ agentMeta: null })],
+      [], // agent_switch 边界守卫:无边界
+      [makeUserMessageRow({ clientId: 'client-id', createdAt: 3000 })],
+      [makeSessionRow({ agentKind: 'codex' })],
+    );
+
+    await commitRewindAtMessage('sess-1', 'client-id');
+
+    expect(executeCodexFileRewindPlanWithThreadRollbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'file-rewind', revertCommitsNewestFirst: ['sp1'] }),
+      'sess-1',
+      expect.objectContaining({ commitThreadRollback: expect.any(Function), onCompensationError: expect.any(Function) }),
+    );
+    expect(executeCodexFileRestorePlanWithThreadRollbackMock).not.toHaveBeenCalled();
+    expect(commitRewindFilesMock).toHaveBeenCalledWith('', '', { tailTurnsToDrop: 1 });
+  });
+
+  it('Codex commit: restore 执行器内 thread rollback 失败 → 错误传播, DB 事务不执行', async () => {
+    useFakeSession('codex');
+    detectCwdMock.mockResolvedValueOnce({ gitInstalled: true, isGitRepo: true, repoRoot: '/repo', isInsideWorktree: false });
+    listShadowSavepointsMock.mockResolvedValueOnce([
+      {
+        commit: 'sc1',
+        sessionId: 'sess-1',
+        kind: 'after-edit',
+        source: 'cindy',
+        parentCount: 1,
+        anchor: 'client-id',
+        baselineCommit: 'base1',
+        label: '本轮修改',
+        time: '2026-08-04T00:00:00+08:00',
+      },
+    ]);
+    commitRewindFilesMock.mockRejectedValueOnce(new Error('thread rollback failed'));
+    selectQueue.push(
+      [makeUserMessageRow({ agentMeta: null })],
+      [], // agent_switch 边界守卫:无边界
+      [makeUserMessageRow({ clientId: 'client-id', createdAt: 3000 })],
+    );
+
+    await expect(commitRewindAtMessage('sess-1', 'client-id')).rejects.toThrow('thread rollback failed');
+
+    expect(executeCodexFileRestorePlanWithThreadRollbackMock).toHaveBeenCalledTimes(1);
+    expect(commitRewindFilesMock).toHaveBeenCalledWith('', '', { tailTurnsToDrop: 1 });
+    expect(txCalls).toHaveLength(0);
+  });
+
   it('目标在 agent_switch 边界之前 → REWIND_UNSUPPORTED_HISTORY,SDK 与 DB 均未执行', async () => {
     selectQueue.push([makeUserMessageRow()]);   // target user msg
     selectQueue.push([{ rowid: 11 }]);   // agent_switch 边界守卫:同毫秒也按插入顺序识别

--- a/apps/desktop/src/main/__tests__/rewind.test.ts
+++ b/apps/desktop/src/main/__tests__/rewind.test.ts
@@ -38,6 +38,7 @@ const getHeadMock = vi.fn();
 const getCurrentBranchMock = vi.fn();
 const listSnapshotsMock = vi.fn();
 const listShadowSavepointsMock = vi.fn();
+const listUnprotectedPathsMock = vi.fn();
 const writeWorktreeTreeForPathsMock = vi.fn();
 const gitExecMock = vi.fn();
 
@@ -111,6 +112,7 @@ vi.mock('../git-snapshot/gitSnapshotService', () => ({
     const value = await listShadowSavepointsMock(...args);
     return Array.isArray(value) ? { entries: value, truncated: false } : value;
   },
+  listUnprotectedPaths: listUnprotectedPathsMock,
   writeWorktreeTreeForPaths: writeWorktreeTreeForPathsMock,
   // 单测里不需要真实拆块: preview 的 pathspec 数量远小于命令行上限。
   chunkPathspecArgs: (pathspecs: readonly string[]) =>
@@ -206,6 +208,8 @@ beforeEach(async () => {
   listSnapshotsMock.mockResolvedValue([]);
   listShadowSavepointsMock.mockReset();
   listShadowSavepointsMock.mockResolvedValue([]);
+  listUnprotectedPathsMock.mockReset();
+  listUnprotectedPathsMock.mockResolvedValue([]);
   writeWorktreeTreeForPathsMock.mockReset();
   gitExecMock.mockReset();
   recomputePrRefsForSessionMock.mockReset();
@@ -966,6 +970,39 @@ describe('commitRewindAtMessage', () => {
     });
     expect(writeWorktreeTreeForPathsMock).toHaveBeenCalledWith('/repo', ['src/a.ts', 'new-file.txt']);
     expect(gitExecMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('Codex: preview refuses file-restore when affected files are currently filtered', async () => {
+    useFakeSession('codex');
+    detectCwdMock.mockResolvedValueOnce({ gitInstalled: true, isGitRepo: true, repoRoot: '/repo', isInsideWorktree: false });
+    listShadowSavepointsMock.mockResolvedValueOnce([
+      {
+        commit: 'sc1',
+        sessionId: 'sess-1',
+        kind: 'after-edit',
+        source: 'cindy',
+        parentCount: 1,
+        anchor: 'client-id',
+        baselineCommit: 'base1',
+        time: '2026-08-04T00:00:00+08:00',
+      },
+    ]);
+    gitExecMock.mockImplementation(async (args: readonly string[]) => {
+      if (args.includes('--name-only')) {
+        return { stdout: ['big.bin', ''].join('\0'), stderr: '' };
+      }
+      throw new Error(`unexpected git call: ${args.join(' ')}`);
+    });
+    // 受影响文件当前处于安全过滤范围:预览必须拒绝,且不把字节写进对象库。
+    listUnprotectedPathsMock.mockResolvedValueOnce(['big.bin']);
+    selectQueue.push([makeUserMessageRow({ agentMeta: null })], [], [makeUserMessageRow({ clientId: 'client-id', createdAt: 3000 })]);
+
+    const preview = await previewRewindAtMessage('sess-1', 'client-id');
+
+    expect(preview.canRewind).toBe(false);
+    expect(preview.error).toContain('big.bin');
+    expect(listUnprotectedPathsMock).toHaveBeenCalledWith('/repo', ['big.bin']);
+    expect(writeWorktreeTreeForPathsMock).not.toHaveBeenCalled();
   });
 
   it('Codex: treats unborn Git histories as no-savepoints conversation-only rewind', async () => {

--- a/apps/desktop/src/main/__tests__/rewind.test.ts
+++ b/apps/desktop/src/main/__tests__/rewind.test.ts
@@ -105,7 +105,12 @@ vi.mock('../git-snapshot/gitSnapshotService', () => ({
   getHead: getHeadMock,
   getCurrentBranch: getCurrentBranchMock,
   listSnapshots: listSnapshotsMock,
-  listShadowSavepoints: listShadowSavepointsMock,
+  // 真实实现返回 { entries, truncated };mock 站点允许直接给数组(默认不截断),
+  // 截断用例返回完整对象。
+  listShadowSavepoints: async (...args: unknown[]) => {
+    const value = await listShadowSavepointsMock(...args);
+    return Array.isArray(value) ? { entries: value, truncated: false } : value;
+  },
   writeWorktreeTreeForPaths: writeWorktreeTreeForPathsMock,
   // 单测里不需要真实拆块: preview 的 pathspec 数量远小于命令行上限。
   chunkPathspecArgs: (pathspecs: readonly string[]) =>
@@ -982,6 +987,39 @@ describe('commitRewindAtMessage', () => {
     expect(executeCodexFileRestorePlanWithThreadRollbackMock).not.toHaveBeenCalled();
     expect(writeWorktreeTreeForPathsMock).not.toHaveBeenCalled();
     expect(commitRewindFilesMock).toHaveBeenCalledWith('', '', { tailTurnsToDrop: 1 });
+  });
+
+  it('Codex commit: shadow 链被截断 → 降级 conversation-only(不做部分文件回退)', async () => {
+    useFakeSession('codex');
+    detectCwdMock.mockResolvedValueOnce({ gitInstalled: true, isGitRepo: true, repoRoot: '/repo', isInsideWorktree: false });
+    // 截断窗口内仍能看到可入选的 after-edit,但历史不完整 → 不得据此部分回退。
+    listShadowSavepointsMock.mockResolvedValueOnce({
+      entries: [
+        {
+          commit: 'sc1',
+          sessionId: 'sess-1',
+          kind: 'after-edit',
+          source: 'cindy',
+          parentCount: 1,
+          anchor: 'client-id',
+          baselineCommit: 'base1',
+          label: '本轮修改',
+          time: '2026-08-04T00:00:00+08:00',
+        },
+      ],
+      truncated: true,
+    });
+    selectQueue.push([makeUserMessageRow({ agentMeta: null })], [], [makeUserMessageRow({ clientId: 'client-id', createdAt: 3000 })], [makeSessionRow({ agentKind: 'codex' })]);
+
+    await commitRewindAtMessage('sess-1', 'client-id');
+
+    expect(executeCodexFileRewindPlanWithThreadRollbackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'conversation-only', fallbackReason: 'savepoint-history-truncated' }),
+      'sess-1',
+      expect.objectContaining({ commitThreadRollback: expect.any(Function) }),
+    );
+    expect(executeCodexFileRestorePlanWithThreadRollbackMock).not.toHaveBeenCalled();
+    expect(writeWorktreeTreeForPathsMock).not.toHaveBeenCalled();
   });
 
   it('Codex: waits for pending snapshot writes before reading savepoints', async () => {

--- a/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
@@ -3,7 +3,9 @@
  *
  * 启动期对账是保存点 ref 的**唯一**删除驱动(会话删除不做即时清理:瞬态软删
  * 流程会回滚,status 触发的删除与之竞态,见 savepointCleanup.ts 模块注释):
- *   - 孤儿 ref(owner 行缺失或已删除)删除,存活 / archived owner 保留;
+ *   - 只删当前账号 DB 里 status='deleted' 的 owner 的 ref;存活 / archived
+ *     保留;**行缺失也保留**(localDb 按账号隔离,可能是另一账号的链,无法
+ *     证明是孤儿);
  *   - 非 git 目录、linked worktree 内目录跳过,同一 repoRoot 去重;
  *   - DB 查询失败整体跳过(零删除),单个 repo 失败不阻断其余。
  *
@@ -85,7 +87,7 @@ beforeEach(() => {
 });
 
 describe('reconcileSavepointRefsForDeletedSessions', () => {
-  it('removes orphan refs and keeps refs owned by live sessions', async () => {
+  it('removes only refs provably deleted in this DB; missing rows are kept', async () => {
     selectQueue.push([
       { id: 's-active', status: 'active', workingDir: '/work/dir' },
     ]);
@@ -94,9 +96,10 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
       { sessionId: 's-active', sha: 'a'.repeat(40) },
       { sessionId: 's-archived', sha: 'b'.repeat(40) },
       { sessionId: 's-deleted', sha: 'c'.repeat(40) },
-      { sessionId: 's-vanished', sha: 'd'.repeat(40) },
+      { sessionId: 's-foreign', sha: 'd'.repeat(40) },
     ]);
-    // owners 查询:s-vanished 行已物理缺失。
+    // owners 查询:s-foreign 行缺失——可能是本机另一账号的会话(localDb 按
+    // 账号隔离),不是孤儿证据,必须保留。
     selectQueue.push([
       { id: 's-active', status: 'active' },
       { id: 's-archived', status: 'archived' },
@@ -106,10 +109,8 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
     await reconcileSavepointRefsForDeletedSessions();
 
     expect(listRefsMock).toHaveBeenCalledWith('/repo/root');
-    const deleted = deleteRefMock.mock.calls.map((call) => call[1]).sort();
-    expect(deleted).toEqual(['s-deleted', 's-vanished']);
+    expect(deleteRefMock).toHaveBeenCalledTimes(1);
     expect(deleteRefMock).toHaveBeenCalledWith('/repo/root', 's-deleted');
-    expect(deleteRefMock).toHaveBeenCalledWith('/repo/root', 's-vanished');
   });
 
   it('skips entirely when the session query fails', async () => {
@@ -133,7 +134,7 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
     repoByCwd.set('/plain/dir', 'non-git');
     listRefsMock.mockResolvedValue([{ sessionId: 's1', sha: 'a'.repeat(40) }]);
     // 同一 repoRoot 只对账一次 → 只消费一次 owners 查询。
-    selectQueue.push([]);
+    selectQueue.push([{ id: 's1', status: 'deleted' }]);
 
     await reconcileSavepointRefsForDeletedSessions();
 
@@ -161,7 +162,7 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
     repoByCwd.set('/broken/dir', new Error('detect failed'));
     repoByCwd.set('/ok/dir', { repoRoot: '/ok/repo' });
     listRefsMock.mockResolvedValue([{ sessionId: 's2', sha: 'a'.repeat(40) }]);
-    selectQueue.push([]);
+    selectQueue.push([{ id: 's2', status: 'deleted' }]);
 
     await expect(reconcileSavepointRefsForDeletedSessions()).resolves.toBeUndefined();
 

--- a/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
@@ -1,0 +1,239 @@
+/**
+ * savepointCleanup 单元测试(mock DB / detectCwd / savepointRefs):
+ *   - 会话删除清理:只有 status='deleted' 且能定位到 git repoRoot 才删 ref;
+ *     行缺失(无 workingDir 可定位)/ archived / active / 非 git / worktree 内
+ *     一律不删;任何失败吞掉不抛。
+ *   - 启动期对账:孤儿 ref(owner 行缺失或已删除)删除,存活 owner 保留,
+ *     DB 查询失败整体跳过(零删除)。
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const deleteRefMock = vi.fn();
+const listRefsMock = vi.fn();
+const detectCwdMock = vi.fn();
+
+/** select().from().where() 每次调用按序消费一个结果;Error 表示该次查询抛错。 */
+const selectQueue: Array<unknown[] | Error> = [];
+let getDbClientError: Error | null = null;
+
+vi.mock('../git-snapshot/savepointRefs', () => ({
+  deleteSavepointRef: (...args: unknown[]) => deleteRefMock(...args),
+  listSavepointRefs: (...args: unknown[]) => listRefsMock(...args),
+}));
+
+vi.mock('../worktree/WorktreeManager', () => ({
+  detectCwd: (...args: unknown[]) => detectCwdMock(...args),
+}));
+
+vi.mock('../localDb/client/current', () => ({
+  getDbClient: () => {
+    if (getDbClientError) throw getDbClientError;
+    return {
+      drizzle: {
+        select: () => ({
+          from: () => ({
+            where: () => {
+              const next = selectQueue.shift();
+              if (next === undefined) return [];
+              if (next instanceof Error) throw next;
+              return next;
+            },
+          }),
+        }),
+      },
+    };
+  },
+}));
+
+import {
+  cleanupSavepointsForRemovedSession,
+  reconcileSavepointRefsForDeletedSessions,
+} from '../git-snapshot/savepointCleanup';
+
+function gitRepoInfo(repoRoot: string) {
+  return { gitInstalled: true, isGitRepo: true, isInsideWorktree: false, repoRoot };
+}
+
+beforeEach(() => {
+  deleteRefMock.mockReset().mockResolvedValue(undefined);
+  listRefsMock.mockReset().mockResolvedValue([]);
+  detectCwdMock.mockReset().mockResolvedValue(gitRepoInfo('/repo'));
+  selectQueue.length = 0;
+  getDbClientError = null;
+});
+
+describe('cleanupSavepointsForRemovedSession', () => {
+  it('deletes the savepoint ref when the session row is deleted', async () => {
+    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
+    detectCwdMock.mockResolvedValue(gitRepoInfo('/repo/root'));
+
+    await cleanupSavepointsForRemovedSession('s1');
+
+    expect(detectCwdMock).toHaveBeenCalledWith('/work/dir');
+    expect(deleteRefMock).toHaveBeenCalledTimes(1);
+    expect(deleteRefMock).toHaveBeenCalledWith('/repo/root', 's1');
+  });
+
+  it('skips when the session row is missing (no workingDir to resolve)', async () => {
+    selectQueue.push([]);
+
+    await cleanupSavepointsForRemovedSession('s-missing');
+
+    expect(detectCwdMock).not.toHaveBeenCalled();
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['archived', 'active'])('keeps the ref when status is %s', async (status) => {
+    selectQueue.push([{ status, workingDir: '/work/dir' }]);
+
+    await cleanupSavepointsForRemovedSession('s1');
+
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+
+  it('skips when the deleted session has no workingDir', async () => {
+    selectQueue.push([{ status: 'deleted', workingDir: null }]);
+
+    await cleanupSavepointsForRemovedSession('s1');
+
+    expect(detectCwdMock).not.toHaveBeenCalled();
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+
+  it('skips when the workingDir is not a git repository', async () => {
+    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
+    detectCwdMock.mockResolvedValue({
+      gitInstalled: true,
+      isGitRepo: false,
+      isInsideWorktree: false,
+    });
+
+    await cleanupSavepointsForRemovedSession('s1');
+
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+
+  it('skips when the workingDir is inside a managed worktree', async () => {
+    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
+    detectCwdMock.mockResolvedValue({
+      gitInstalled: true,
+      isGitRepo: true,
+      isInsideWorktree: true,
+      repoRoot: '/repo/root',
+    });
+
+    await cleanupSavepointsForRemovedSession('s1');
+
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows DB failures without deleting or throwing', async () => {
+    selectQueue.push(new Error('db exploded'));
+
+    await expect(cleanupSavepointsForRemovedSession('s1')).resolves.toBeUndefined();
+
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows detectCwd failures without throwing', async () => {
+    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
+    detectCwdMock.mockRejectedValue(new Error('git missing'));
+
+    await expect(cleanupSavepointsForRemovedSession('s1')).resolves.toBeUndefined();
+
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('reconcileSavepointRefsForDeletedSessions', () => {
+  it('removes orphan refs and keeps refs owned by live sessions', async () => {
+    selectQueue.push([
+      { id: 's-active', status: 'active', workingDir: '/work/dir' },
+    ]);
+    detectCwdMock.mockResolvedValue(gitRepoInfo('/repo/root'));
+    listRefsMock.mockResolvedValue([
+      { sessionId: 's-active', sha: 'a'.repeat(40) },
+      { sessionId: 's-archived', sha: 'b'.repeat(40) },
+      { sessionId: 's-deleted', sha: 'c'.repeat(40) },
+      { sessionId: 's-vanished', sha: 'd'.repeat(40) },
+    ]);
+    // owners 查询:s-vanished 行已物理缺失。
+    selectQueue.push([
+      { id: 's-active', status: 'active' },
+      { id: 's-archived', status: 'archived' },
+      { id: 's-deleted', status: 'deleted' },
+    ]);
+
+    await reconcileSavepointRefsForDeletedSessions();
+
+    expect(listRefsMock).toHaveBeenCalledWith('/repo/root');
+    const deleted = deleteRefMock.mock.calls.map((call) => call[1]).sort();
+    expect(deleted).toEqual(['s-deleted', 's-vanished']);
+    expect(deleteRefMock).toHaveBeenCalledWith('/repo/root', 's-deleted');
+    expect(deleteRefMock).toHaveBeenCalledWith('/repo/root', 's-vanished');
+  });
+
+  it('skips entirely when the session query fails', async () => {
+    selectQueue.push(new Error('db exploded'));
+
+    await expect(reconcileSavepointRefsForDeletedSessions()).resolves.toBeUndefined();
+
+    expect(detectCwdMock).not.toHaveBeenCalled();
+    expect(listRefsMock).not.toHaveBeenCalled();
+    expect(deleteRefMock).not.toHaveBeenCalled();
+  });
+
+  it('skips non-git workdirs and dedupes repeated repo roots', async () => {
+    selectQueue.push([
+      { id: 's1', status: 'deleted', workingDir: '/repo/sub-a' },
+      { id: 's2', status: 'deleted', workingDir: '/repo/sub-b' },
+      { id: 's3', status: 'deleted', workingDir: '/plain/dir' },
+    ]);
+    detectCwdMock.mockImplementation(async (workingDir: string) =>
+      workingDir === '/plain/dir'
+        ? { gitInstalled: true, isGitRepo: false, isInsideWorktree: false }
+        : gitRepoInfo('/repo'),
+    );
+    listRefsMock.mockResolvedValue([{ sessionId: 's1', sha: 'a'.repeat(40) }]);
+    // 同一 repoRoot 只对账一次 → 只消费一次 owners 查询。
+    selectQueue.push([]);
+
+    await reconcileSavepointRefsForDeletedSessions();
+
+    expect(listRefsMock).toHaveBeenCalledTimes(1);
+    expect(listRefsMock).toHaveBeenCalledWith('/repo');
+    expect(deleteRefMock).toHaveBeenCalledTimes(1);
+    expect(deleteRefMock).toHaveBeenCalledWith('/repo', 's1');
+  });
+
+  it('continues with the next workdir when one repo fails', async () => {
+    selectQueue.push([
+      { id: 's1', status: 'deleted', workingDir: '/broken/dir' },
+      { id: 's2', status: 'deleted', workingDir: '/ok/dir' },
+    ]);
+    detectCwdMock.mockImplementation(async (workingDir: string) => {
+      if (workingDir === '/broken/dir') throw new Error('detect failed');
+      return gitRepoInfo('/ok/repo');
+    });
+    listRefsMock.mockResolvedValue([{ sessionId: 's2', sha: 'a'.repeat(40) }]);
+    selectQueue.push([]);
+
+    await expect(reconcileSavepointRefsForDeletedSessions()).resolves.toBeUndefined();
+
+    expect(deleteRefMock).toHaveBeenCalledTimes(1);
+    expect(deleteRefMock).toHaveBeenCalledWith('/ok/repo', 's2');
+  });
+
+  it('does not query owners when a repo has no savepoint refs', async () => {
+    selectQueue.push([{ id: 's1', status: 'active', workingDir: '/work/dir' }]);
+    listRefsMock.mockResolvedValue([]);
+
+    await reconcileSavepointRefsForDeletedSessions();
+
+    expect(deleteRefMock).not.toHaveBeenCalled();
+    // owners 查询未发生:队列里没有第二个结果,若发生会拿到 [] 也无碍,
+    // 这里用 selectQueue 是否被清空来断言只消费了首个查询。
+    expect(selectQueue).toHaveLength(0);
+  });
+});

--- a/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
@@ -1,17 +1,26 @@
 /**
- * savepointCleanup 单元测试(mock DB / detectCwd / savepointRefs):
+ * savepointCleanup 单元测试(mock DB / gitExec / savepointRefs):
  *   - 会话删除清理:只有 status='deleted' 且能定位到 git repoRoot 才删 ref;
  *     行缺失(无 workingDir 可定位)/ archived / active / 非 git / worktree 内
  *     一律不删;任何失败吞掉不抛。
  *   - 启动期对账:孤儿 ref(owner 行缺失或已删除)删除,存活 owner 保留,
  *     DB 查询失败整体跳过(零删除)。
+ *
+ * 仓库判定经 gitExec 的 rev-parse 而非 WorktreeManager.detectCwd:清理模块被
+ * localDb/ipc/sessions 静态导入,不能引入 WorktreeManager → worktreeStore →
+ * sessions 的模块环。
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const deleteRefMock = vi.fn();
 const listRefsMock = vi.fn();
-const detectCwdMock = vi.fn();
+const gitExecMock = vi.fn();
+
+/** 每个 workingDir 的仓库形态;Error 表示 git 调用抛错(git 缺失等)。 */
+type RepoBehavior = { repoRoot: string; insideWorktree?: boolean } | 'non-git' | Error;
+const repoByCwd = new Map<string, RepoBehavior>();
+let defaultRepoBehavior: RepoBehavior = { repoRoot: '/repo' };
 
 /** select().from().where() 每次调用按序消费一个结果;Error 表示该次查询抛错。 */
 const selectQueue: Array<unknown[] | Error> = [];
@@ -22,8 +31,8 @@ vi.mock('../git-snapshot/savepointRefs', () => ({
   listSavepointRefs: (...args: unknown[]) => listRefsMock(...args),
 }));
 
-vi.mock('../worktree/WorktreeManager', () => ({
-  detectCwd: (...args: unknown[]) => detectCwdMock(...args),
+vi.mock('../worktree/gitExec', () => ({
+  gitExec: (...args: unknown[]) => gitExecMock(...args),
 }));
 
 vi.mock('../localDb/client/current', () => ({
@@ -51,14 +60,28 @@ import {
   reconcileSavepointRefsForDeletedSessions,
 } from '../git-snapshot/savepointCleanup';
 
-function gitRepoInfo(repoRoot: string) {
-  return { gitInstalled: true, isGitRepo: true, isInsideWorktree: false, repoRoot };
+function installGitExecImpl(): void {
+  gitExecMock.mockImplementation(async (args: readonly string[], cwd: string) => {
+    const behavior = repoByCwd.get(cwd) ?? defaultRepoBehavior;
+    if (behavior instanceof Error) throw behavior;
+    if (behavior === 'non-git') throw new Error('fatal: not a git repository');
+    if (args.includes('--show-toplevel')) return { stdout: `${behavior.repoRoot}\n`, stderr: '' };
+    if (args.includes('--git-dir')) return { stdout: '.git\n', stderr: '' };
+    if (args.includes('--git-common-dir')) {
+      // linked worktree 的 common dir 指向主仓 .git,与 --git-dir 不同。
+      return { stdout: behavior.insideWorktree ? '/primary/.git\n' : '.git\n', stderr: '' };
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`);
+  });
 }
 
 beforeEach(() => {
   deleteRefMock.mockReset().mockResolvedValue(undefined);
   listRefsMock.mockReset().mockResolvedValue([]);
-  detectCwdMock.mockReset().mockResolvedValue(gitRepoInfo('/repo'));
+  gitExecMock.mockReset();
+  repoByCwd.clear();
+  defaultRepoBehavior = { repoRoot: '/repo' };
+  installGitExecImpl();
   selectQueue.length = 0;
   getDbClientError = null;
 });
@@ -66,11 +89,14 @@ beforeEach(() => {
 describe('cleanupSavepointsForRemovedSession', () => {
   it('deletes the savepoint ref when the session row is deleted', async () => {
     selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    detectCwdMock.mockResolvedValue(gitRepoInfo('/repo/root'));
+    repoByCwd.set('/work/dir', { repoRoot: '/repo/root' });
 
     await cleanupSavepointsForRemovedSession('s1');
 
-    expect(detectCwdMock).toHaveBeenCalledWith('/work/dir');
+    expect(gitExecMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['--show-toplevel']),
+      '/work/dir',
+    );
     expect(deleteRefMock).toHaveBeenCalledTimes(1);
     expect(deleteRefMock).toHaveBeenCalledWith('/repo/root', 's1');
   });
@@ -80,7 +106,7 @@ describe('cleanupSavepointsForRemovedSession', () => {
 
     await cleanupSavepointsForRemovedSession('s-missing');
 
-    expect(detectCwdMock).not.toHaveBeenCalled();
+    expect(gitExecMock).not.toHaveBeenCalled();
     expect(deleteRefMock).not.toHaveBeenCalled();
   });
 
@@ -97,17 +123,13 @@ describe('cleanupSavepointsForRemovedSession', () => {
 
     await cleanupSavepointsForRemovedSession('s1');
 
-    expect(detectCwdMock).not.toHaveBeenCalled();
+    expect(gitExecMock).not.toHaveBeenCalled();
     expect(deleteRefMock).not.toHaveBeenCalled();
   });
 
   it('skips when the workingDir is not a git repository', async () => {
     selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    detectCwdMock.mockResolvedValue({
-      gitInstalled: true,
-      isGitRepo: false,
-      isInsideWorktree: false,
-    });
+    repoByCwd.set('/work/dir', 'non-git');
 
     await cleanupSavepointsForRemovedSession('s1');
 
@@ -116,12 +138,7 @@ describe('cleanupSavepointsForRemovedSession', () => {
 
   it('skips when the workingDir is inside a managed worktree', async () => {
     selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    detectCwdMock.mockResolvedValue({
-      gitInstalled: true,
-      isGitRepo: true,
-      isInsideWorktree: true,
-      repoRoot: '/repo/root',
-    });
+    repoByCwd.set('/work/dir', { repoRoot: '/repo/root', insideWorktree: true });
 
     await cleanupSavepointsForRemovedSession('s1');
 
@@ -136,9 +153,9 @@ describe('cleanupSavepointsForRemovedSession', () => {
     expect(deleteRefMock).not.toHaveBeenCalled();
   });
 
-  it('swallows detectCwd failures without throwing', async () => {
+  it('swallows git detection failures without throwing', async () => {
     selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    detectCwdMock.mockRejectedValue(new Error('git missing'));
+    repoByCwd.set('/work/dir', new Error('git missing'));
 
     await expect(cleanupSavepointsForRemovedSession('s1')).resolves.toBeUndefined();
 
@@ -151,7 +168,7 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
     selectQueue.push([
       { id: 's-active', status: 'active', workingDir: '/work/dir' },
     ]);
-    detectCwdMock.mockResolvedValue(gitRepoInfo('/repo/root'));
+    repoByCwd.set('/work/dir', { repoRoot: '/repo/root' });
     listRefsMock.mockResolvedValue([
       { sessionId: 's-active', sha: 'a'.repeat(40) },
       { sessionId: 's-archived', sha: 'b'.repeat(40) },
@@ -179,7 +196,7 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
 
     await expect(reconcileSavepointRefsForDeletedSessions()).resolves.toBeUndefined();
 
-    expect(detectCwdMock).not.toHaveBeenCalled();
+    expect(gitExecMock).not.toHaveBeenCalled();
     expect(listRefsMock).not.toHaveBeenCalled();
     expect(deleteRefMock).not.toHaveBeenCalled();
   });
@@ -190,11 +207,9 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
       { id: 's2', status: 'deleted', workingDir: '/repo/sub-b' },
       { id: 's3', status: 'deleted', workingDir: '/plain/dir' },
     ]);
-    detectCwdMock.mockImplementation(async (workingDir: string) =>
-      workingDir === '/plain/dir'
-        ? { gitInstalled: true, isGitRepo: false, isInsideWorktree: false }
-        : gitRepoInfo('/repo'),
-    );
+    repoByCwd.set('/repo/sub-a', { repoRoot: '/repo' });
+    repoByCwd.set('/repo/sub-b', { repoRoot: '/repo' });
+    repoByCwd.set('/plain/dir', 'non-git');
     listRefsMock.mockResolvedValue([{ sessionId: 's1', sha: 'a'.repeat(40) }]);
     // 同一 repoRoot 只对账一次 → 只消费一次 owners 查询。
     selectQueue.push([]);
@@ -212,10 +227,8 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
       { id: 's1', status: 'deleted', workingDir: '/broken/dir' },
       { id: 's2', status: 'deleted', workingDir: '/ok/dir' },
     ]);
-    detectCwdMock.mockImplementation(async (workingDir: string) => {
-      if (workingDir === '/broken/dir') throw new Error('detect failed');
-      return gitRepoInfo('/ok/repo');
-    });
+    repoByCwd.set('/broken/dir', new Error('detect failed'));
+    repoByCwd.set('/ok/dir', { repoRoot: '/ok/repo' });
     listRefsMock.mockResolvedValue([{ sessionId: 's2', sha: 'a'.repeat(40) }]);
     selectQueue.push([]);
 

--- a/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/savepointCleanup.test.ts
@@ -1,10 +1,11 @@
 /**
- * savepointCleanup 单元测试(mock DB / gitExec / savepointRefs):
- *   - 会话删除清理:只有 status='deleted' 且能定位到 git repoRoot 才删 ref;
- *     行缺失(无 workingDir 可定位)/ archived / active / 非 git / worktree 内
- *     一律不删;任何失败吞掉不抛。
- *   - 启动期对账:孤儿 ref(owner 行缺失或已删除)删除,存活 owner 保留,
- *     DB 查询失败整体跳过(零删除)。
+ * savepointCleanup 单元测试(mock DB / gitExec / savepointRefs)。
+ *
+ * 启动期对账是保存点 ref 的**唯一**删除驱动(会话删除不做即时清理:瞬态软删
+ * 流程会回滚,status 触发的删除与之竞态,见 savepointCleanup.ts 模块注释):
+ *   - 孤儿 ref(owner 行缺失或已删除)删除,存活 / archived owner 保留;
+ *   - 非 git 目录、linked worktree 内目录跳过,同一 repoRoot 去重;
+ *   - DB 查询失败整体跳过(零删除),单个 repo 失败不阻断其余。
  *
  * 仓库判定经 gitExec 的 rev-parse 而非 WorktreeManager.detectCwd:清理模块被
  * localDb/ipc/sessions 静态导入,不能引入 WorktreeManager → worktreeStore →
@@ -55,10 +56,7 @@ vi.mock('../localDb/client/current', () => ({
   },
 }));
 
-import {
-  cleanupSavepointsForRemovedSession,
-  reconcileSavepointRefsForDeletedSessions,
-} from '../git-snapshot/savepointCleanup';
+import { reconcileSavepointRefsForDeletedSessions } from '../git-snapshot/savepointCleanup';
 
 function installGitExecImpl(): void {
   gitExecMock.mockImplementation(async (args: readonly string[], cwd: string) => {
@@ -84,83 +82,6 @@ beforeEach(() => {
   installGitExecImpl();
   selectQueue.length = 0;
   getDbClientError = null;
-});
-
-describe('cleanupSavepointsForRemovedSession', () => {
-  it('deletes the savepoint ref when the session row is deleted', async () => {
-    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    repoByCwd.set('/work/dir', { repoRoot: '/repo/root' });
-
-    await cleanupSavepointsForRemovedSession('s1');
-
-    expect(gitExecMock).toHaveBeenCalledWith(
-      expect.arrayContaining(['--show-toplevel']),
-      '/work/dir',
-    );
-    expect(deleteRefMock).toHaveBeenCalledTimes(1);
-    expect(deleteRefMock).toHaveBeenCalledWith('/repo/root', 's1');
-  });
-
-  it('skips when the session row is missing (no workingDir to resolve)', async () => {
-    selectQueue.push([]);
-
-    await cleanupSavepointsForRemovedSession('s-missing');
-
-    expect(gitExecMock).not.toHaveBeenCalled();
-    expect(deleteRefMock).not.toHaveBeenCalled();
-  });
-
-  it.each(['archived', 'active'])('keeps the ref when status is %s', async (status) => {
-    selectQueue.push([{ status, workingDir: '/work/dir' }]);
-
-    await cleanupSavepointsForRemovedSession('s1');
-
-    expect(deleteRefMock).not.toHaveBeenCalled();
-  });
-
-  it('skips when the deleted session has no workingDir', async () => {
-    selectQueue.push([{ status: 'deleted', workingDir: null }]);
-
-    await cleanupSavepointsForRemovedSession('s1');
-
-    expect(gitExecMock).not.toHaveBeenCalled();
-    expect(deleteRefMock).not.toHaveBeenCalled();
-  });
-
-  it('skips when the workingDir is not a git repository', async () => {
-    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    repoByCwd.set('/work/dir', 'non-git');
-
-    await cleanupSavepointsForRemovedSession('s1');
-
-    expect(deleteRefMock).not.toHaveBeenCalled();
-  });
-
-  it('skips when the workingDir is inside a managed worktree', async () => {
-    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    repoByCwd.set('/work/dir', { repoRoot: '/repo/root', insideWorktree: true });
-
-    await cleanupSavepointsForRemovedSession('s1');
-
-    expect(deleteRefMock).not.toHaveBeenCalled();
-  });
-
-  it('swallows DB failures without deleting or throwing', async () => {
-    selectQueue.push(new Error('db exploded'));
-
-    await expect(cleanupSavepointsForRemovedSession('s1')).resolves.toBeUndefined();
-
-    expect(deleteRefMock).not.toHaveBeenCalled();
-  });
-
-  it('swallows git detection failures without throwing', async () => {
-    selectQueue.push([{ status: 'deleted', workingDir: '/work/dir' }]);
-    repoByCwd.set('/work/dir', new Error('git missing'));
-
-    await expect(cleanupSavepointsForRemovedSession('s1')).resolves.toBeUndefined();
-
-    expect(deleteRefMock).not.toHaveBeenCalled();
-  });
 });
 
 describe('reconcileSavepointRefsForDeletedSessions', () => {
@@ -220,6 +141,16 @@ describe('reconcileSavepointRefsForDeletedSessions', () => {
     expect(listRefsMock).toHaveBeenCalledWith('/repo');
     expect(deleteRefMock).toHaveBeenCalledTimes(1);
     expect(deleteRefMock).toHaveBeenCalledWith('/repo', 's1');
+  });
+
+  it('skips workdirs inside a managed worktree', async () => {
+    selectQueue.push([{ id: 's1', status: 'deleted', workingDir: '/work/dir' }]);
+    repoByCwd.set('/work/dir', { repoRoot: '/repo/root', insideWorktree: true });
+
+    await reconcileSavepointRefsForDeletedSessions();
+
+    expect(listRefsMock).not.toHaveBeenCalled();
+    expect(deleteRefMock).not.toHaveBeenCalled();
   });
 
   it('continues with the next workdir when one repo fails', async () => {

--- a/apps/desktop/src/main/__tests__/snapshotFilterOverflow.test.ts
+++ b/apps/desktop/src/main/__tests__/snapshotFilterOverflow.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `git status` 输出溢出 exec 缓冲时的失败关闭语义(unit,mock git 执行层):
+ * - buildSnapshotFilePlan 标记 statusTruncated(脏文件视图未知 ≠ 无脏文件);
+ * - listUnprotectedPaths 返回 null(读侧必须失败关闭);
+ * - createShadowSavepoint 直接抛 status-overflow(不拍静默漏文件的基线)。
+ * legacy 分支提交路径保留历史上的静默降级行为,不在本文件覆盖范围。
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const gitExecMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../worktree/gitExec', () => {
+  class GitExecError extends Error {
+    stderr = '';
+    stdout = '';
+    exitCode: number | null = null;
+    cause: unknown;
+    constructor(_input: unknown) {
+      super('mock git exec error');
+    }
+  }
+  return {
+    GitExecError,
+    gitExec: (...args: unknown[]) => gitExecMock(...args),
+  };
+});
+
+import { GitExecError } from '../worktree/gitExec';
+import { buildSnapshotFilePlan } from '../git-snapshot/snapshotFileFilter';
+import {
+  createShadowSavepoint,
+  listUnprotectedPaths,
+  SnapshotBlockedByGitStateError,
+} from '../git-snapshot/gitSnapshotService';
+
+// 不存在的路径:detectBlockedGitState 的 rev-parse 输出解析后 lstat 失败,
+// 视为没有进行中的 git 操作。
+const REPO = path.join(os.tmpdir(), 'snapshot-overflow-nonexistent-repo');
+
+function installOverflowGitExec(): void {
+  gitExecMock.mockImplementation(async (args: readonly string[]) => {
+    if (args.includes('status')) {
+      const err = new GitExecError({ args: [...args], exitCode: null, stderr: '', stdout: '' });
+      err.message = 'spawn maxBuffer length exceeded';
+      throw err;
+    }
+    if (args.includes('--git-path')) {
+      return { stdout: 'no-such-marker\n', stderr: '' };
+    }
+    throw new Error(`unexpected git call: ${args.join(' ')}`);
+  });
+}
+
+beforeEach(() => {
+  gitExecMock.mockReset();
+  installOverflowGitExec();
+});
+
+describe('git status overflow fails closed for shadow consumers', () => {
+  it('buildSnapshotFilePlan marks the plan as statusTruncated with empty views', async () => {
+    const plan = await buildSnapshotFilePlan(REPO);
+
+    expect(plan.statusTruncated).toBe(true);
+    expect(plan.includedFiles).toEqual([]);
+    expect(plan.skippedFiles).toEqual([]);
+  });
+
+  it('listUnprotectedPaths returns null instead of pretending paths are protected', async () => {
+    await expect(listUnprotectedPaths(REPO, ['src/a.ts'])).resolves.toBeNull();
+  });
+
+  it('createShadowSavepoint refuses to record a baseline on an unknown dirty view', async () => {
+    await expect(
+      createShadowSavepoint(REPO, {
+        sessionId: 's1',
+        label: 'baseline',
+        meta: { kind: 'turn-start' },
+      }),
+    ).rejects.toMatchObject({
+      name: 'SnapshotBlockedByGitStateError',
+      state: { reason: 'status-overflow' },
+    });
+    expect(SnapshotBlockedByGitStateError).toBeDefined();
+  });
+});

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -4058,6 +4058,13 @@ const registerIpcHandlers = () => {
     void reconcileWorktreesForDeletedSessions().catch((err) => {
       console.error('[bootstrap-electron] worktree reconcile failed (non-fatal):', err);
     });
+    // 同窗口的 shadow savepoint 对账:owning session 已删除的孤儿保存点链
+    // (refs/cindy/savepoints/<sid>)启动期补删。fire-and-forget,不阻塞启动。
+    void import('./git-snapshot/savepointCleanup.js')
+      .then((m) => m.reconcileSavepointRefsForDeletedSessions())
+      .catch((err) => {
+        console.error('[bootstrap-electron] savepoint reconcile failed (non-fatal):', err);
+      });
 
     // Scheduler / Goal / Learn 统一由 localDb onReady 在 provider readiness settle 后启动。
     // DB 与 splash 无论谁先完成，上方 configured 信号都会解开同一条后台链；

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -323,6 +323,8 @@ import {
   WorktreePool,
   reconcileWorktreesForDeletedSessions,
 } from './worktree';
+// shadow savepoint 链的启动期对账(孤儿 refs/cindy/savepoints/* 清理)
+import { reconcileSavepointRefsForDeletedSessions } from './git-snapshot/savepointCleanup';
 // session-git-pr-context: 会话分支感知 + PR 关联状态 IPC
 import { registerGitContextIpc, disposeGitContext } from './git-context';
 import { registerGitReviewIpc } from './git-review';
@@ -4060,11 +4062,9 @@ const registerIpcHandlers = () => {
     });
     // 同窗口的 shadow savepoint 对账:owning session 已删除的孤儿保存点链
     // (refs/cindy/savepoints/<sid>)启动期补删。fire-and-forget,不阻塞启动。
-    void import('./git-snapshot/savepointCleanup.js')
-      .then((m) => m.reconcileSavepointRefsForDeletedSessions())
-      .catch((err) => {
-        console.error('[bootstrap-electron] savepoint reconcile failed (non-fatal):', err);
-      });
+    void reconcileSavepointRefsForDeletedSessions().catch((err) => {
+      console.error('[bootstrap-electron] savepoint reconcile failed (non-fatal):', err);
+    });
 
     // Scheduler / Goal / Learn 统一由 localDb onReady 在 provider readiness settle 后启动。
     // DB 与 splash 无论谁先完成，上方 configured 信号都会解开同一条后台链；

--- a/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
+++ b/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
@@ -362,26 +362,60 @@ async function makeWorktreeMatchCommit(
     }
   }
 
-  // realpath 围栏:受影响路径来自 Git diff,词法上都在仓库内,但工作区当前
-  // 状态可能把某个父目录换成了指向仓库外的符号链接;所有 fs 删除都必须先
-  // 确认真实父目录仍在仓库内,否则跳过并告警(内容可从 pre-rollback 恢复)。
+  // ── 阶段一:全量校验,零改动 ──
+  // 不变量:回退报成功 ⇒ 受影响文件全部回到目标状态。任何围栏命中都必须
+  // 在动第一个文件之前中止(REWIND_GIT_FAILED),而不是跳过后报成功——
+  // 否则对话被裁掉、文件却没回去,形成静默的不一致。
   const repoReal = await fs.realpath(repoRoot);
+  const affectedSet = new Set(paths);
 
+  const deletions: Array<{ filePath: string; realAbs: string }> = [];
+  for (const filePath of toDelete) {
+    const abs = resolveSnapshotGitPath(repoRoot, filePath);
+    if (!abs) continue;
+    const resolved = await resolveRealPathInsideRepo(repoReal, abs);
+    if (resolved.kind === 'missing') continue; // 目标本就不存在,删除是 no-op
+    if (resolved.kind === 'escaped') {
+      throw fenceAbort(filePath, '待删除路径的真实父目录已在仓库外(符号链接)');
+    }
+    deletions.push({ filePath, realAbs: resolved.realAbs });
+  }
+
+  // git restore 会写穿指向仓库外的符号链接父目录(创建前导目录时 stat 跟随
+  // 链接):最近存在祖先的真实路径必须仍在仓库内;缺失祖先向上追溯,保住
+  // 「恢复进尚不存在的目录」的合法场景。
+  const collisionsToClear: Array<{ filePath: string; realAbs: string }> = [];
+  for (const filePath of toRestore) {
+    const abs = resolveSnapshotGitPath(repoRoot, filePath);
+    if (!abs) continue;
+    if (await nearestExistingAncestorEscapes(repoReal, abs)) {
+      throw fenceAbort(filePath, '恢复目标的真实父目录已在仓库外(符号链接)');
+    }
+    const stats = await fs.lstat(abs).catch(() => null);
+    if (!stats?.isDirectory()) continue;
+    const resolved = await resolveRealPathInsideRepo(repoReal, abs);
+    if (resolved.kind !== 'ok') {
+      throw fenceAbort(filePath, '碰撞目录的真实路径已离开仓库');
+    }
+    // 碰撞目录里可能有用户在保存点之后手工放入、未被任何 turn 记录的文件:
+    // 它们不在受影响集合里,成功路径不会恢复、补偿也不覆盖。发现即中止,
+    // 交用户先处理该目录。
+    const outOfScope = await listDescendantsOutsideScope(resolved.realAbs, filePath, affectedSet);
+    if (outOfScope.length > 0) {
+      throw new CodexFileRewindExecutionError(
+        'REWIND_GIT_FAILED',
+        `文件回退已中止:${filePath} 现在是目录,且包含本次回退范围之外的文件(如 ${outOfScope.slice(0, 3).join('、')}),请先移出或删除这些文件后重试`,
+      );
+    }
+    collisionsToClear.push({ filePath, realAbs: resolved.realAbs });
+  }
+
+  // ── 阶段二:执行 ──
   // Deletions first: a turn that converted a directory into a file makes the
   // reverse diff delete the file (`swap`) and restore its former descendants
   // (`swap/child.txt`); deleting after the restore would wipe what was just
   // recreated.
-  for (const filePath of toDelete) {
-    const abs = resolveSnapshotGitPath(repoRoot, filePath);
-    if (!abs) continue;
-    const realAbs = await resolveRealPathInsideRepo(repoReal, abs);
-    if (!realAbs) {
-      log.warn('[file-restore] delete skipped: real path escapes the repository', {
-        repoRoot,
-        filePath,
-      });
-      continue;
-    }
+  for (const { realAbs } of deletions) {
     // recursive: the path may be a directory in the worktree (e.g. a file →
     // directory conversion the target tree does not have). ENOTDIR means a
     // parent segment is a file again, so the old nested path is already gone.
@@ -393,74 +427,38 @@ async function makeWorktreeMatchCommit(
   }
 
   if (toRestore.length > 0) {
-    // git restore 会写穿指向仓库外的符号链接父目录(创建前导目录时 stat 跟随
-    // 链接),所以恢复目标也要过 realpath 围栏:最近存在祖先的真实路径必须
-    // 仍在仓库内,否则跳过该路径并告警(基线内容仍在保存点树里,不丢)。
-    const restorable: string[] = [];
-    for (const filePath of toRestore) {
-      const abs = resolveSnapshotGitPath(repoRoot, filePath);
-      if (!abs) continue;
-      if (await nearestExistingAncestorEscapes(repoReal, abs)) {
-        log.warn('[file-restore] restore skipped: real parent escapes the repository', {
-          repoRoot,
-          filePath,
-        });
-        continue;
-      }
-      restorable.push(filePath);
-    }
-    toRestore.length = 0;
-    toRestore.push(...restorable);
-
     // A turn may have replaced a file with a directory; git restore cannot
-    // write a blob over an existing directory, so clear such collisions
-    // first (contents are recoverable from the pre-rollback savepoint).
-    const affectedSet = new Set(paths);
-    for (const filePath of toRestore) {
-      const abs = resolveSnapshotGitPath(repoRoot, filePath);
-      if (!abs) continue;
-      const stats = await fs.lstat(abs).catch(() => null);
-      if (!stats?.isDirectory()) continue;
-      const realAbs = await resolveRealPathInsideRepo(repoReal, abs);
-      if (!realAbs) {
-        log.warn('[file-restore] collision cleanup skipped: real path escapes the repository', {
-          repoRoot,
-          filePath,
-        });
-        continue;
-      }
-      // 碰撞目录里可能有用户在保存点之后手工放入、未被任何 turn 记录的文件:
-      // 它们不在受影响集合里,成功路径不会恢复、补偿也不覆盖。发现即在改动
-      // 任何文件前中止(与安全过滤盲区同款语义),交用户先处理该目录。
-      const outOfScope = await listDescendantsOutsideScope(realAbs, filePath, affectedSet);
-      if (outOfScope.length > 0) {
-        throw new CodexFileRewindExecutionError(
-          'REWIND_GIT_FAILED',
-          `文件回退已中止:${filePath} 现在是目录,且包含本次回退范围之外的文件(如 ${outOfScope.slice(0, 3).join('、')}),请先移出或删除这些文件后重试`,
-        );
-      }
+    // write a blob over an existing directory, so clear such (validated)
+    // collisions first — contents are recoverable from the pre-rollback
+    // savepoint.
+    for (const { realAbs } of collisionsToClear) {
       await fs.rm(realAbs, { recursive: true, force: true });
     }
-    if (toRestore.length > 0) {
-      await withPathspecFile(
-        toRestore.map((p) => `:(literal)${p}`),
-        (pathspecFile) =>
-          deps.gitExec(
-            [
-              'restore',
-              `--source=${targetCommit}`,
-              '--worktree',
-              '--pathspec-from-file',
-              pathspecFile,
-              '--pathspec-file-nul',
-            ],
-            repoRoot,
-          ),
-      );
-    }
+    await withPathspecFile(
+      toRestore.map((p) => `:(literal)${p}`),
+      (pathspecFile) =>
+        deps.gitExec(
+          [
+            'restore',
+            `--source=${targetCommit}`,
+            '--worktree',
+            '--pathspec-from-file',
+            pathspecFile,
+            '--pathspec-file-nul',
+          ],
+          repoRoot,
+        ),
+    );
   }
 
   return { restored: toRestore, deleted: toDelete };
+}
+
+function fenceAbort(filePath: string, reason: string): CodexFileRewindExecutionError {
+  return new CodexFileRewindExecutionError(
+    'REWIND_GIT_FAILED',
+    `文件回退已中止:${filePath} 未通过安全围栏(${reason}),为避免对话与文件不一致,本次未修改任何文件,请先处理该路径后重试`,
+  );
 }
 
 /**
@@ -513,21 +511,28 @@ async function listDescendantsOutsideScope(
   return outOfScope.sort();
 }
 
+type RealPathResolution =
+  | { kind: 'ok'; realAbs: string }
+  | { kind: 'missing' }
+  | { kind: 'escaped' };
+
 /**
- * Resolves the deletion target with intermediate symlinks flattened, and
- * refuses paths whose real parent directory left the repository. The final
- * component itself is never followed (fs.rm removes a symlink, not its
- * target), so only the parent needs the realpath check.
+ * Resolves the mutation target with intermediate symlinks flattened. The
+ * final component itself is never followed (fs.rm removes a symlink, not
+ * its target), so only the parent needs the realpath check. `missing` means
+ * the parent (hence the target) does not exist; `escaped` means the real
+ * parent directory left the repository — callers must abort, not skip.
  */
 async function resolveRealPathInsideRepo(
   repoReal: string,
   absPath: string,
-): Promise<string | null> {
+): Promise<RealPathResolution> {
   const parentReal = await fs.realpath(path.dirname(absPath)).catch(() => null);
-  // 父目录不存在 → 目标必然不存在,调用方的 force 删除本来就是 no-op。
-  if (!parentReal) return null;
-  if (parentReal !== repoReal && !parentReal.startsWith(repoReal + path.sep)) return null;
-  return path.join(parentReal, path.basename(absPath));
+  if (!parentReal) return { kind: 'missing' };
+  if (parentReal !== repoReal && !parentReal.startsWith(repoReal + path.sep)) {
+    return { kind: 'escaped' };
+  }
+  return { kind: 'ok', realAbs: path.join(parentReal, path.basename(absPath)) };
 }
 
 /** Removes now-empty real parent directories left behind by file deletion. */

--- a/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
+++ b/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
@@ -1,0 +1,424 @@
+/**
+ * Executes shadow savepoint file-restore plans.
+ *
+ * Unlike the legacy revert executor, this path never commits to the user's
+ * branch and never requires a clean worktree: affected files are rewritten in
+ * place to the target turn-start tree, a pre-rollback savepoint on the hidden
+ * chain provides the compensation anchor, and the user's index stays intact.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import { createLogger } from '../logger';
+import { gitExec, GitExecError, type GitExecResult } from '../worktree/gitExec';
+import { CodexFileRewindExecutionError } from './codexFileRewindExecutor';
+import type { CodexRewindPlan, CodexFileRestorePlan } from './codexFileRewindPlanner';
+import { enqueueGitRepoWrite } from './gitRepoWriteQueue';
+import {
+  chunkPathspecArgs,
+  createShadowMarker,
+  createShadowSavepoint,
+  withPathspecFile,
+  writeWorktreeTreeForPaths,
+  type CreateShadowMarkerInput,
+  type CreateShadowSavepointInput,
+  type ShadowSavepointResult,
+} from './gitSnapshotService';
+import { resolveSnapshotGitPath } from './snapshotFileFilter';
+
+const log = createLogger('git-snapshot');
+
+export interface CodexFileRestoreExecutionResult {
+  repoRoot: string;
+  rollbackId: string;
+  /** Full worktree savepoint taken right before the restore, on the chain. */
+  preRollbackCommit: string;
+  /** Chain marker recording the rollback, or null when nothing changed. */
+  rollbackCommit: string | null;
+  /** Paths rewritten to the baseline tree content. */
+  restoredFiles: string[];
+  /** Paths deleted because the baseline tree does not contain them. */
+  deletedFiles: string[];
+  /** Union of paths touched by the undone turns; compensation scope. */
+  affectedPaths: string[];
+}
+
+interface CodexFileRestoreExecutorDeps {
+  gitExec: (args: readonly string[], cwd?: string) => Promise<GitExecResult>;
+  createRollbackId: () => string;
+  createShadowSavepoint: (
+    repoPath: string,
+    input: CreateShadowSavepointInput,
+  ) => Promise<ShadowSavepointResult>;
+  createShadowMarker: (
+    repoPath: string,
+    input: CreateShadowMarkerInput,
+  ) => Promise<string | null>;
+  writeWorktreeTree: (repoPath: string, pathspecs: readonly string[]) => Promise<string>;
+}
+
+export interface CodexFileRestoreLockedRollbackHooks<T> {
+  commitThreadRollback: (execution: CodexFileRestoreExecutionResult | null) => Promise<T>;
+  onCompensationError?: (error: unknown, execution: CodexFileRestoreExecutionResult) => void;
+}
+
+const defaultDeps: CodexFileRestoreExecutorDeps = {
+  gitExec,
+  createRollbackId: randomUUID,
+  createShadowSavepoint,
+  createShadowMarker,
+  writeWorktreeTree: writeWorktreeTreeForPaths,
+};
+
+const BLOCKED_GIT_STATE_MARKERS = [
+  'MERGE_HEAD',
+  'rebase-merge',
+  'rebase-apply',
+  'CHERRY_PICK_HEAD',
+  'REVERT_HEAD',
+] as const;
+
+export async function executeCodexFileRestorePlan(
+  plan: CodexRewindPlan,
+  deps: Partial<CodexFileRestoreExecutorDeps> = {},
+): Promise<CodexFileRestoreExecutionResult | null> {
+  if (plan.mode !== 'file-restore') return null;
+  return enqueueGitRepoWrite(plan.repoRoot, () => executeCodexFileRestorePlanLocked(plan, deps));
+}
+
+export async function executeCodexFileRestorePlanWithThreadRollback<T>(
+  plan: CodexRewindPlan,
+  sessionId: string,
+  hooks: CodexFileRestoreLockedRollbackHooks<T>,
+  deps: Partial<CodexFileRestoreExecutorDeps> = {},
+): Promise<{ fileRestore: CodexFileRestoreExecutionResult | null; threadRollback: T }> {
+  if (plan.mode !== 'file-restore') {
+    return { fileRestore: null, threadRollback: await hooks.commitThreadRollback(null) };
+  }
+
+  return enqueueGitRepoWrite(plan.repoRoot, async () => {
+    const fileRestore = await executeCodexFileRestorePlanLocked(plan, deps);
+    try {
+      return { fileRestore, threadRollback: await hooks.commitThreadRollback(fileRestore) };
+    } catch (err) {
+      if (fileRestore.restoredFiles.length > 0 || fileRestore.deletedFiles.length > 0) {
+        try {
+          await compensateCodexFileRestoreExecutionLocked(fileRestore, sessionId, deps);
+        } catch (compErr) {
+          hooks.onCompensationError?.(compErr, fileRestore);
+        }
+      }
+      throw err;
+    }
+  });
+}
+
+export async function compensateCodexFileRestoreExecution(
+  execution: CodexFileRestoreExecutionResult | null,
+  sessionId: string,
+  deps: Partial<CodexFileRestoreExecutorDeps> = {},
+): Promise<void> {
+  if (!execution) return;
+  if (execution.restoredFiles.length === 0 && execution.deletedFiles.length === 0) return;
+  await enqueueGitRepoWrite(execution.repoRoot, () =>
+    compensateCodexFileRestoreExecutionLocked(execution, sessionId, deps),
+  );
+}
+
+async function executeCodexFileRestorePlanLocked(
+  plan: CodexFileRestorePlan,
+  deps: Partial<CodexFileRestoreExecutorDeps>,
+): Promise<CodexFileRestoreExecutionResult> {
+  const d = { ...defaultDeps, ...deps };
+  const rollbackId = d.createRollbackId();
+
+  await ensureNoActiveGitOperation(plan.repoRoot, d);
+
+  let preRollbackCommit: string | null;
+  try {
+    // Full worktree snapshot first: every byte the restore may overwrite is
+    // reachable from the chain before any file changes.
+    ({ commit: preRollbackCommit } = await d.createShadowSavepoint(plan.repoRoot, {
+      sessionId: plan.sessionId,
+      label: '回退前的工作区快照',
+      meta: {
+        kind: 'pre-rollback',
+        rollbackId,
+        rollbackTarget: plan.targetMessageClientId,
+      },
+    }));
+  } catch (err) {
+    throw toRewindGitFailed(err);
+  }
+  if (!preRollbackCommit) {
+    throw new CodexFileRewindExecutionError(
+      'REWIND_GIT_FAILED',
+      '回退前快照未产生提交，已中止文件回退',
+    );
+  }
+
+  const affectedPaths = await collectAffectedPaths(plan, d);
+  const base: CodexFileRestoreExecutionResult = {
+    repoRoot: plan.repoRoot,
+    rollbackId,
+    preRollbackCommit,
+    rollbackCommit: null,
+    restoredFiles: [],
+    deletedFiles: [],
+    affectedPaths,
+  };
+  if (affectedPaths.length === 0) {
+    return base;
+  }
+
+  let applied: WorktreeApplyResult;
+  try {
+    applied = await makeWorktreeMatchCommit(plan.repoRoot, plan.baselineCommit, affectedPaths, d);
+  } catch (err) {
+    // Best-effort self-heal: put the affected files back to the pre-rollback
+    // state so a partial apply never leaves a half-restored worktree.
+    await makeWorktreeMatchCommit(plan.repoRoot, preRollbackCommit, affectedPaths, d).catch(
+      (healErr) => {
+        log.warn('[file-restore] self-heal after failed restore also failed', {
+          repoRoot: plan.repoRoot,
+          rollbackId,
+          error: healErr instanceof Error ? healErr.message : String(healErr),
+        });
+      },
+    );
+    throw toRewindGitFailed(err);
+  }
+
+  if (applied.restored.length === 0 && applied.deleted.length === 0) {
+    return base;
+  }
+
+  // The marker is bookkeeping only; its failure must not undo a successful
+  // restore. Compensation is keyed on restored/deleted files, not on it.
+  const rollbackCommit = await d
+    .createShadowMarker(plan.repoRoot, {
+      sessionId: plan.sessionId,
+      label: 'Codex rewind files',
+      meta: {
+        kind: 'rollback',
+        rollbackId,
+        rollbackTarget: plan.targetMessageClientId,
+        reverts: plan.restoreCommitsNewestFirst.map((entry) => entry.commit),
+        preRollbackCommit,
+      },
+    })
+    .catch((err) => {
+      log.warn('[file-restore] rollback marker failed (restore already applied)', {
+        repoRoot: plan.repoRoot,
+        rollbackId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    });
+
+  return {
+    ...base,
+    rollbackCommit,
+    restoredFiles: applied.restored,
+    deletedFiles: applied.deleted,
+  };
+}
+
+async function compensateCodexFileRestoreExecutionLocked(
+  execution: CodexFileRestoreExecutionResult,
+  sessionId: string,
+  deps: Partial<CodexFileRestoreExecutorDeps>,
+): Promise<void> {
+  const d = { ...defaultDeps, ...deps };
+  await ensureNoActiveGitOperation(execution.repoRoot, d);
+  try {
+    await makeWorktreeMatchCommit(
+      execution.repoRoot,
+      execution.preRollbackCommit,
+      execution.affectedPaths,
+      d,
+    );
+  } catch (err) {
+    throw toRewindGitFailed(err);
+  }
+  await d
+    .createShadowMarker(execution.repoRoot, {
+      sessionId,
+      label: 'Codex rewind compensation',
+      meta: {
+        kind: 'rollback-undo',
+        rollbackId: d.createRollbackId(),
+        rollbackTarget: execution.preRollbackCommit,
+        ...(execution.rollbackCommit ? { reverts: [execution.rollbackCommit] } : {}),
+        preRollbackCommit: execution.preRollbackCommit,
+      },
+    })
+    .catch((err) => {
+      log.warn('[file-restore] compensation marker failed (files already recovered)', {
+        repoRoot: execution.repoRoot,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    });
+}
+
+/** Union of files each undone turn touched (turn-start → after-edit diff). */
+async function collectAffectedPaths(
+  plan: CodexFileRestorePlan,
+  deps: CodexFileRestoreExecutorDeps,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of plan.restoreCommitsNewestFirst) {
+    let stdout: string;
+    try {
+      ({ stdout } = await deps.gitExec(
+        ['diff', '--name-only', '--no-renames', '-z', entry.baselineCommit, entry.commit],
+        plan.repoRoot,
+      ));
+    } catch (err) {
+      throw toRewindGitFailed(err);
+    }
+    for (const rawPath of stdout.split('\0')) {
+      if (!rawPath || seen.has(rawPath)) continue;
+      seen.add(rawPath);
+      out.push(rawPath);
+    }
+  }
+  return out;
+}
+
+interface WorktreeApplyResult {
+  restored: string[];
+  deleted: string[];
+}
+
+/**
+ * Rewrites the worktree so the given paths match the target commit's tree:
+ * differing/missing files are checked out from the target, files absent from
+ * the target are removed. The user's index is never touched (`git restore
+ * --worktree` + direct fs deletion), so `git status` keeps telling the truth.
+ */
+async function makeWorktreeMatchCommit(
+  repoRoot: string,
+  targetCommit: string,
+  paths: readonly string[],
+  deps: CodexFileRestoreExecutorDeps,
+): Promise<WorktreeApplyResult> {
+  const pathspecs = paths.map((p) => `:(literal)${p}`);
+  const worktreeTree = await deps.writeWorktreeTree(repoRoot, paths);
+
+  const toRestore: string[] = [];
+  const toDelete: string[] = [];
+  for (const chunk of chunkPathspecArgs(pathspecs)) {
+    const { stdout } = await deps.gitExec(
+      [
+        'diff',
+        '--name-status',
+        '--no-renames',
+        '-z',
+        worktreeTree,
+        targetCommit,
+        '--',
+        ...chunk,
+      ],
+      repoRoot,
+    );
+    const tokens = stdout.split('\0');
+    for (let i = 0; i + 1 < tokens.length; i += 2) {
+      const status = tokens[i];
+      const filePath = tokens[i + 1];
+      if (!status || !filePath) continue;
+      // Direction is current worktree → target: D means the target tree does
+      // not have the file, everything else means it must match the target.
+      if (status.startsWith('D')) toDelete.push(filePath);
+      else toRestore.push(filePath);
+    }
+  }
+
+  if (toRestore.length > 0) {
+    await withPathspecFile(
+      toRestore.map((p) => `:(literal)${p}`),
+      (pathspecFile) =>
+        deps.gitExec(
+          [
+            'restore',
+            `--source=${targetCommit}`,
+            '--worktree',
+            '--pathspec-from-file',
+            pathspecFile,
+            '--pathspec-file-nul',
+          ],
+          repoRoot,
+        ),
+    );
+  }
+  for (const filePath of toDelete) {
+    const abs = resolveSnapshotGitPath(repoRoot, filePath);
+    if (!abs) continue;
+    await fs.rm(abs, { force: true });
+    await pruneEmptyParents(repoRoot, abs);
+  }
+
+  return { restored: toRestore, deleted: toDelete };
+}
+
+/** Removes now-empty parent directories left behind by file deletion. */
+async function pruneEmptyParents(repoRoot: string, absFilePath: string): Promise<void> {
+  const root = path.resolve(repoRoot);
+  let dir = path.dirname(absFilePath);
+  while (dir !== root && dir.startsWith(root + path.sep)) {
+    try {
+      await fs.rmdir(dir);
+    } catch {
+      return;
+    }
+    dir = path.dirname(dir);
+  }
+}
+
+async function ensureNoActiveGitOperation(
+  repoRoot: string,
+  deps: CodexFileRestoreExecutorDeps,
+): Promise<void> {
+  for (const marker of BLOCKED_GIT_STATE_MARKERS) {
+    const markerPath = await resolveGitInternalPath(repoRoot, marker, deps);
+    if (markerPath && (await pathExists(markerPath))) {
+      throw new CodexFileRewindExecutionError(
+        'REWIND_GIT_FAILED',
+        '文件回退需要 Git 仓库没有进行中的 merge/rebase/cherry-pick/revert，请先完成或中止当前 Git 操作',
+      );
+    }
+  }
+}
+
+async function resolveGitInternalPath(
+  repoRoot: string,
+  marker: string,
+  deps: CodexFileRestoreExecutorDeps,
+): Promise<string | null> {
+  const { stdout } = await deps.gitExec(['rev-parse', '--git-path', marker], repoRoot);
+  const gitPath = stdout.trim();
+  if (!gitPath) return null;
+  return path.isAbsolute(gitPath) ? gitPath : path.resolve(repoRoot, gitPath);
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  return fs.lstat(filePath).then(
+    () => true,
+    () => false,
+  );
+}
+
+function toRewindGitFailed(err: unknown): CodexFileRewindExecutionError {
+  if (err instanceof CodexFileRewindExecutionError) return err;
+  if (err instanceof GitExecError) {
+    return new CodexFileRewindExecutionError('REWIND_GIT_FAILED', err.message);
+  }
+  return new CodexFileRewindExecutionError(
+    'REWIND_GIT_FAILED',
+    err instanceof Error ? err.message : String(err),
+  );
+}

--- a/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
+++ b/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
@@ -339,6 +339,17 @@ async function makeWorktreeMatchCommit(
   }
 
   if (toRestore.length > 0) {
+    // A turn may have replaced a file with a directory; git restore cannot
+    // write a blob over an existing directory, so clear such collisions
+    // first (contents are recoverable from the pre-rollback savepoint).
+    for (const filePath of toRestore) {
+      const abs = resolveSnapshotGitPath(repoRoot, filePath);
+      if (!abs) continue;
+      const stats = await fs.lstat(abs).catch(() => null);
+      if (stats?.isDirectory()) {
+        await fs.rm(abs, { recursive: true, force: true });
+      }
+    }
     await withPathspecFile(
       toRestore.map((p) => `:(literal)${p}`),
       (pathspecFile) =>
@@ -358,7 +369,13 @@ async function makeWorktreeMatchCommit(
   for (const filePath of toDelete) {
     const abs = resolveSnapshotGitPath(repoRoot, filePath);
     if (!abs) continue;
-    await fs.rm(abs, { force: true });
+    // recursive: the path may be a directory in the worktree (e.g. a file →
+    // directory conversion the target tree does not have). ENOTDIR means a
+    // parent segment is a file again, so the old nested path is already gone.
+    await fs.rm(abs, { recursive: true, force: true }).catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') return;
+      throw err;
+    });
     await pruneEmptyParents(repoRoot, abs);
   }
 

--- a/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
+++ b/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
@@ -393,9 +393,29 @@ async function makeWorktreeMatchCommit(
   }
 
   if (toRestore.length > 0) {
+    // git restore 会写穿指向仓库外的符号链接父目录(创建前导目录时 stat 跟随
+    // 链接),所以恢复目标也要过 realpath 围栏:最近存在祖先的真实路径必须
+    // 仍在仓库内,否则跳过该路径并告警(基线内容仍在保存点树里,不丢)。
+    const restorable: string[] = [];
+    for (const filePath of toRestore) {
+      const abs = resolveSnapshotGitPath(repoRoot, filePath);
+      if (!abs) continue;
+      if (await nearestExistingAncestorEscapes(repoReal, abs)) {
+        log.warn('[file-restore] restore skipped: real parent escapes the repository', {
+          repoRoot,
+          filePath,
+        });
+        continue;
+      }
+      restorable.push(filePath);
+    }
+    toRestore.length = 0;
+    toRestore.push(...restorable);
+
     // A turn may have replaced a file with a directory; git restore cannot
     // write a blob over an existing directory, so clear such collisions
     // first (contents are recoverable from the pre-rollback savepoint).
+    const affectedSet = new Set(paths);
     for (const filePath of toRestore) {
       const abs = resolveSnapshotGitPath(repoRoot, filePath);
       if (!abs) continue;
@@ -409,26 +429,88 @@ async function makeWorktreeMatchCommit(
         });
         continue;
       }
+      // 碰撞目录里可能有用户在保存点之后手工放入、未被任何 turn 记录的文件:
+      // 它们不在受影响集合里,成功路径不会恢复、补偿也不覆盖。发现即在改动
+      // 任何文件前中止(与安全过滤盲区同款语义),交用户先处理该目录。
+      const outOfScope = await listDescendantsOutsideScope(realAbs, filePath, affectedSet);
+      if (outOfScope.length > 0) {
+        throw new CodexFileRewindExecutionError(
+          'REWIND_GIT_FAILED',
+          `文件回退已中止:${filePath} 现在是目录,且包含本次回退范围之外的文件(如 ${outOfScope.slice(0, 3).join('、')}),请先移出或删除这些文件后重试`,
+        );
+      }
       await fs.rm(realAbs, { recursive: true, force: true });
     }
-    await withPathspecFile(
-      toRestore.map((p) => `:(literal)${p}`),
-      (pathspecFile) =>
-        deps.gitExec(
-          [
-            'restore',
-            `--source=${targetCommit}`,
-            '--worktree',
-            '--pathspec-from-file',
-            pathspecFile,
-            '--pathspec-file-nul',
-          ],
-          repoRoot,
-        ),
-    );
+    if (toRestore.length > 0) {
+      await withPathspecFile(
+        toRestore.map((p) => `:(literal)${p}`),
+        (pathspecFile) =>
+          deps.gitExec(
+            [
+              'restore',
+              `--source=${targetCommit}`,
+              '--worktree',
+              '--pathspec-from-file',
+              pathspecFile,
+              '--pathspec-file-nul',
+            ],
+            repoRoot,
+          ),
+      );
+    }
   }
 
   return { restored: toRestore, deleted: toDelete };
+}
+
+/**
+ * True when the closest existing ancestor of the (lexically in-repo) path
+ * resolves outside the repository — i.e. a parent segment is currently a
+ * symlink escaping the repo. Missing ancestors are walked upward so that
+ * restoring into not-yet-existing directories stays allowed.
+ */
+async function nearestExistingAncestorEscapes(
+  repoReal: string,
+  absPath: string,
+): Promise<boolean> {
+  let dir = path.dirname(absPath);
+  for (;;) {
+    const real = await fs.realpath(dir).catch(() => null);
+    if (real) {
+      return real !== repoReal && !real.startsWith(repoReal + path.sep);
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) return true;
+    dir = parent;
+  }
+}
+
+/**
+ * Lists files under a collision directory whose repo paths are NOT part of
+ * the restore scope. Symlink entries are treated as files (never followed).
+ */
+async function listDescendantsOutsideScope(
+  realDirPath: string,
+  gitDirPath: string,
+  affectedSet: ReadonlySet<string>,
+): Promise<string[]> {
+  const outOfScope: string[] = [];
+  const stack: Array<{ realPath: string; gitPath: string }> = [
+    { realPath: realDirPath, gitPath: gitDirPath },
+  ];
+  while (stack.length > 0) {
+    const { realPath, gitPath } = stack.pop() as { realPath: string; gitPath: string };
+    const entries = await fs.readdir(realPath, { withFileTypes: true }).catch(() => []);
+    for (const entry of entries) {
+      const childGitPath = `${gitPath}/${entry.name}`;
+      if (entry.isDirectory()) {
+        stack.push({ realPath: path.join(realPath, entry.name), gitPath: childGitPath });
+        continue;
+      }
+      if (!affectedSet.has(childGitPath)) outOfScope.push(childGitPath);
+    }
+  }
+  return outOfScope.sort();
 }
 
 /**

--- a/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
+++ b/apps/desktop/src/main/git-snapshot/codexFileRestoreExecutor.ts
@@ -136,11 +136,11 @@ async function executeCodexFileRestorePlanLocked(
 
   await ensureNoActiveGitOperation(plan.repoRoot, d);
 
-  let preRollbackCommit: string | null;
+  let preRollback: ShadowSavepointResult;
   try {
     // Full worktree snapshot first: every byte the restore may overwrite is
     // reachable from the chain before any file changes.
-    ({ commit: preRollbackCommit } = await d.createShadowSavepoint(plan.repoRoot, {
+    preRollback = await d.createShadowSavepoint(plan.repoRoot, {
       sessionId: plan.sessionId,
       label: '回退前的工作区快照',
       meta: {
@@ -148,10 +148,11 @@ async function executeCodexFileRestorePlanLocked(
         rollbackId,
         rollbackTarget: plan.targetMessageClientId,
       },
-    }));
+    });
   } catch (err) {
     throw toRewindGitFailed(err);
   }
+  const preRollbackCommit = preRollback.commit;
   if (!preRollbackCommit) {
     throw new CodexFileRewindExecutionError(
       'REWIND_GIT_FAILED',
@@ -171,6 +172,29 @@ async function executeCodexFileRestorePlanLocked(
   };
   if (affectedPaths.length === 0) {
     return base;
+  }
+
+  // Affected files whose *current* content the safety filter kept out of the
+  // pre-rollback snapshot (sensitive, oversized, nested repo …) would be
+  // overwritten or deleted with no way to compensate — the snapshot simply
+  // does not hold their bytes. Abort before touching anything. Only paths
+  // that still exist as regular files carry bytes at risk: a skipped entry
+  // for an already-deleted path (e.g. the file side of a D/F conversion) has
+  // nothing to protect.
+  const unprotectedSkips = new Set(preRollback.skippedFiles.map((file) => file.path));
+  const unprotected: string[] = [];
+  for (const p of affectedPaths) {
+    if (!unprotectedSkips.has(p)) continue;
+    const abs = resolveSnapshotGitPath(plan.repoRoot, p);
+    if (!abs) continue;
+    const stats = await fs.lstat(abs).catch(() => null);
+    if (stats && !stats.isDirectory()) unprotected.push(p);
+  }
+  if (unprotected.length > 0) {
+    throw new CodexFileRewindExecutionError(
+      'REWIND_GIT_FAILED',
+      `文件回退已中止:${unprotected.slice(0, 5).join('、')}${unprotected.length > 5 ? ' 等' : ''} 当前处于安全过滤范围(敏感路径/超大文件/嵌套仓库),回退前快照无法完整保护其内容,请先手动备份或移出这些文件后重试`,
+    );
   }
 
   let applied: WorktreeApplyResult;
@@ -338,6 +362,36 @@ async function makeWorktreeMatchCommit(
     }
   }
 
+  // realpath 围栏:受影响路径来自 Git diff,词法上都在仓库内,但工作区当前
+  // 状态可能把某个父目录换成了指向仓库外的符号链接;所有 fs 删除都必须先
+  // 确认真实父目录仍在仓库内,否则跳过并告警(内容可从 pre-rollback 恢复)。
+  const repoReal = await fs.realpath(repoRoot);
+
+  // Deletions first: a turn that converted a directory into a file makes the
+  // reverse diff delete the file (`swap`) and restore its former descendants
+  // (`swap/child.txt`); deleting after the restore would wipe what was just
+  // recreated.
+  for (const filePath of toDelete) {
+    const abs = resolveSnapshotGitPath(repoRoot, filePath);
+    if (!abs) continue;
+    const realAbs = await resolveRealPathInsideRepo(repoReal, abs);
+    if (!realAbs) {
+      log.warn('[file-restore] delete skipped: real path escapes the repository', {
+        repoRoot,
+        filePath,
+      });
+      continue;
+    }
+    // recursive: the path may be a directory in the worktree (e.g. a file →
+    // directory conversion the target tree does not have). ENOTDIR means a
+    // parent segment is a file again, so the old nested path is already gone.
+    await fs.rm(realAbs, { recursive: true, force: true }).catch((err: unknown) => {
+      if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') return;
+      throw err;
+    });
+    await pruneEmptyParents(repoReal, realAbs);
+  }
+
   if (toRestore.length > 0) {
     // A turn may have replaced a file with a directory; git restore cannot
     // write a blob over an existing directory, so clear such collisions
@@ -346,9 +400,16 @@ async function makeWorktreeMatchCommit(
       const abs = resolveSnapshotGitPath(repoRoot, filePath);
       if (!abs) continue;
       const stats = await fs.lstat(abs).catch(() => null);
-      if (stats?.isDirectory()) {
-        await fs.rm(abs, { recursive: true, force: true });
+      if (!stats?.isDirectory()) continue;
+      const realAbs = await resolveRealPathInsideRepo(repoReal, abs);
+      if (!realAbs) {
+        log.warn('[file-restore] collision cleanup skipped: real path escapes the repository', {
+          repoRoot,
+          filePath,
+        });
+        continue;
       }
+      await fs.rm(realAbs, { recursive: true, force: true });
     }
     await withPathspecFile(
       toRestore.map((p) => `:(literal)${p}`),
@@ -366,27 +427,31 @@ async function makeWorktreeMatchCommit(
         ),
     );
   }
-  for (const filePath of toDelete) {
-    const abs = resolveSnapshotGitPath(repoRoot, filePath);
-    if (!abs) continue;
-    // recursive: the path may be a directory in the worktree (e.g. a file →
-    // directory conversion the target tree does not have). ENOTDIR means a
-    // parent segment is a file again, so the old nested path is already gone.
-    await fs.rm(abs, { recursive: true, force: true }).catch((err: unknown) => {
-      if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') return;
-      throw err;
-    });
-    await pruneEmptyParents(repoRoot, abs);
-  }
 
   return { restored: toRestore, deleted: toDelete };
 }
 
-/** Removes now-empty parent directories left behind by file deletion. */
-async function pruneEmptyParents(repoRoot: string, absFilePath: string): Promise<void> {
-  const root = path.resolve(repoRoot);
-  let dir = path.dirname(absFilePath);
-  while (dir !== root && dir.startsWith(root + path.sep)) {
+/**
+ * Resolves the deletion target with intermediate symlinks flattened, and
+ * refuses paths whose real parent directory left the repository. The final
+ * component itself is never followed (fs.rm removes a symlink, not its
+ * target), so only the parent needs the realpath check.
+ */
+async function resolveRealPathInsideRepo(
+  repoReal: string,
+  absPath: string,
+): Promise<string | null> {
+  const parentReal = await fs.realpath(path.dirname(absPath)).catch(() => null);
+  // 父目录不存在 → 目标必然不存在,调用方的 force 删除本来就是 no-op。
+  if (!parentReal) return null;
+  if (parentReal !== repoReal && !parentReal.startsWith(repoReal + path.sep)) return null;
+  return path.join(parentReal, path.basename(absPath));
+}
+
+/** Removes now-empty real parent directories left behind by file deletion. */
+async function pruneEmptyParents(repoReal: string, realFilePath: string): Promise<void> {
+  let dir = path.dirname(realFilePath);
+  while (dir !== repoReal && dir.startsWith(repoReal + path.sep)) {
     try {
       await fs.rmdir(dir);
     } catch {

--- a/apps/desktop/src/main/git-snapshot/codexFileRewindPlanner.ts
+++ b/apps/desktop/src/main/git-snapshot/codexFileRewindPlanner.ts
@@ -41,6 +41,12 @@ export type CodexFileRewindRepoContext =
       currentHead: string;
       currentBranch: string;
       savepointsNewestFirst: readonly CodexRewindSavepoint[];
+      /**
+       * The shadow chain read hit its traversal window: history beyond the
+       * window is unknown and any file plan built on it could silently skip
+       * truncated-away turns.
+       */
+      shadowSavepointsTruncated?: boolean;
     }
   | { kind: 'remote-session' }
   | { kind: 'non-git-workdir' };
@@ -53,7 +59,8 @@ export type CodexFileRewindFallbackReason =
   | 'blocked-by-dirty-start'
   | 'savepoint-gap'
   | 'mixed-savepoint-formats'
-  | 'missing-turn-start-baseline';
+  | 'missing-turn-start-baseline'
+  | 'savepoint-history-truncated';
 
 export interface BuildCodexFileRewindPlanInput {
   sessionId: string;
@@ -174,6 +181,12 @@ export function buildCodexFileRewindPlan(
   }
   if (input.repo.kind === 'non-git-workdir') {
     return { ...base, mode: 'conversation-only', fallbackReason: 'non-git-workdir' };
+  }
+  if (input.repo.shadowSavepointsTruncated) {
+    // The chain window is not the full history: turns beyond it may carry
+    // file changes we cannot see, so a partial restore would be silent data
+    // loss. Conversation rewind still proceeds.
+    return { ...base, mode: 'conversation-only', fallbackReason: 'savepoint-history-truncated' };
   }
 
   const repo = input.repo;

--- a/apps/desktop/src/main/git-snapshot/codexFileRewindPlanner.ts
+++ b/apps/desktop/src/main/git-snapshot/codexFileRewindPlanner.ts
@@ -14,15 +14,23 @@ export interface CodexRewindUserMessage {
   createdAt: number;
 }
 
-/** A parsed savepoint from current branch history, newest first. */
+/** A parsed savepoint, newest first within its own source bucket. */
 export interface CodexRewindSavepoint {
   commit: string;
   sessionId: string;
   kind: SnapshotKind;
+  /**
+   * `legacy`: old-format savepoint committed onto the user's branch (X-XDT
+   * trailers, rewound via git revert). `shadow`: savepoint on the hidden
+   * refs/cindy/savepoints chain (rewound via worktree file restore).
+   */
+  source: 'legacy' | 'shadow';
   branch: string;
   parentCount: number;
   anchor?: string;
   label?: string;
+  /** Shadow after-edit only: turn-start savepoint the delta is based on. */
+  baselineCommit?: string;
 }
 
 /** Repository context known before planning file rewind. */
@@ -42,7 +50,10 @@ export type CodexFileRewindFallbackReason =
   | 'remote-session'
   | 'non-git-workdir'
   | 'no-savepoints'
-  | 'blocked-by-dirty-start';
+  | 'blocked-by-dirty-start'
+  | 'savepoint-gap'
+  | 'mixed-savepoint-formats'
+  | 'missing-turn-start-baseline';
 
 export interface BuildCodexFileRewindPlanInput {
   sessionId: string;
@@ -69,7 +80,7 @@ interface CodexFileRewindPlanBase {
   conversationWillRewind: true;
 }
 
-/** Plan with file savepoints selected for revert by the later executor. */
+/** Plan with legacy file savepoints selected for revert by the later executor. */
 export interface CodexFileRewindPlan extends CodexFileRewindPlanBase {
   mode: 'file-rewind';
   repoRoot: string;
@@ -79,13 +90,35 @@ export interface CodexFileRewindPlan extends CodexFileRewindPlanBase {
   commits: CodexFileRewindPlanCommit[];
 }
 
+/** One shadow after-edit savepoint whose turn will be undone by file restore. */
+export interface CodexShadowRestoreCommit {
+  commit: string;
+  /** Turn-start savepoint the after-edit delta is based on. */
+  baselineCommit: string;
+  anchor?: string;
+  label?: string;
+}
+
+/** Plan that restores affected files to the target turn's baseline tree. */
+export interface CodexFileRestorePlan extends CodexFileRewindPlanBase {
+  mode: 'file-restore';
+  repoRoot: string;
+  currentHead: string;
+  /** Turn-start tree of the oldest turn being undone; files return to it. */
+  baselineCommit: string;
+  restoreCommitsNewestFirst: CodexShadowRestoreCommit[];
+}
+
 /** Plan used when file rewind is unavailable but Codex conversation rewind can proceed. */
 export interface CodexConversationOnlyRewindPlan extends CodexFileRewindPlanBase {
   mode: 'conversation-only';
   fallbackReason: CodexFileRewindFallbackReason;
 }
 
-export type CodexRewindPlan = CodexFileRewindPlan | CodexConversationOnlyRewindPlan;
+export type CodexRewindPlan =
+  | CodexFileRewindPlan
+  | CodexFileRestorePlan
+  | CodexConversationOnlyRewindPlan;
 
 export type CodexFileRewindPlanErrorCode =
   | 'MESSAGE_NOT_FOUND'
@@ -105,6 +138,13 @@ export class CodexFileRewindPlanError extends Error {
 
 const REVERTIBLE_KINDS: ReadonlySet<SnapshotKind> = new Set(['after-edit']);
 const BLOCKING_KINDS: ReadonlySet<SnapshotKind> = new Set(['rewind-blocked']);
+
+interface BucketScanResult {
+  /** Selected after-edit savepoints in the target range, newest first. */
+  selected: CodexRewindSavepoint[];
+  /** A blocking marker landed inside the target range. */
+  blocked: boolean;
+}
 
 /** Builds a Codex message rewind plan without executing Git operations. */
 export function buildCodexFileRewindPlan(
@@ -136,58 +176,145 @@ export function buildCodexFileRewindPlan(
     return { ...base, mode: 'conversation-only', fallbackReason: 'non-git-workdir' };
   }
 
+  const repo = input.repo;
   const anchorsToRevert = new Set(
     input.userMessages.slice(targetIdx).map((message) => message.clientId),
   );
   const userMessageIndexByClientId = new Map(
     input.userMessages.map((message, index) => [message.clientId, index]),
   );
-  const revertSet = new Set<string>();
-  let nearestNewerAnchorIndex: number | undefined;
 
-  for (const savepoint of input.repo.savepointsNewestFirst) {
-    if (!isCurrentSessionBranch(savepoint, input.sessionId, input.repo.currentBranch)) {
-      continue;
-    }
-    if (
-      BLOCKING_KINDS.has(savepoint.kind) &&
-      isBlockingSavepointInTargetRange(savepoint, anchorsToRevert, targetIdx, nearestNewerAnchorIndex)
-    ) {
-      return { ...base, mode: 'conversation-only', fallbackReason: 'blocked-by-dirty-start' };
-    }
-    if (savepoint.anchor) {
-      nearestNewerAnchorIndex = userMessageIndexByClientId.get(savepoint.anchor) ?? nearestNewerAnchorIndex;
-    }
-    if (!REVERTIBLE_KINDS.has(savepoint.kind)) continue;
-    if (!savepoint.anchor || !anchorsToRevert.has(savepoint.anchor)) continue;
-    assertRevertibleSavepoint(savepoint);
-    revertSet.add(savepoint.commit);
+  // The two savepoint generations are scanned independently: each bucket is
+  // newest-first on its own timeline (branch history vs hidden ref chain),
+  // and blocking-marker position math must not mix the two.
+  const shadow = scanBucket(
+    repo.savepointsNewestFirst.filter(
+      (savepoint) => savepoint.source === 'shadow' && savepoint.sessionId === input.sessionId,
+    ),
+    anchorsToRevert,
+    targetIdx,
+    userMessageIndexByClientId,
+  );
+  if (shadow.blocked) {
+    return { ...base, mode: 'conversation-only', fallbackReason: 'savepoint-gap' };
   }
 
-  if (revertSet.size === 0) {
+  const legacy = scanBucket(
+    repo.savepointsNewestFirst.filter(
+      (savepoint) =>
+        savepoint.source === 'legacy' &&
+        isCurrentSessionBranch(savepoint, input.sessionId, repo.currentBranch),
+    ),
+    anchorsToRevert,
+    targetIdx,
+    userMessageIndexByClientId,
+  );
+  if (legacy.blocked) {
+    return { ...base, mode: 'conversation-only', fallbackReason: 'blocked-by-dirty-start' };
+  }
+
+  if (shadow.selected.length > 0 && legacy.selected.length > 0) {
+    // Upgrade window: part of the range predates the shadow chain. Reverting
+    // one half with git revert and restoring the other from trees cannot be
+    // made atomic, so fall back to conversation-only.
+    return { ...base, mode: 'conversation-only', fallbackReason: 'mixed-savepoint-formats' };
+  }
+
+  if (shadow.selected.length > 0) {
+    return buildRestorePlan(base, repo, shadow.selected);
+  }
+
+  if (legacy.selected.length === 0) {
     return { ...base, mode: 'conversation-only', fallbackReason: 'no-savepoints' };
   }
 
-  const commits = input.repo.savepointsNewestFirst.map((savepoint) => ({
-    commit: savepoint.commit,
-    sessionId: savepoint.sessionId,
-    kind: savepoint.kind,
-    branch: savepoint.branch,
-    ...(savepoint.anchor ? { anchor: savepoint.anchor } : {}),
-    ...(savepoint.label ? { label: savepoint.label } : {}),
-    action: revertSet.has(savepoint.commit) ? 'revert' as const : 'keep' as const,
-  }));
+  const revertSet = new Set(legacy.selected.map((savepoint) => savepoint.commit));
+  const commits = repo.savepointsNewestFirst
+    .filter((savepoint) => savepoint.source === 'legacy')
+    .map((savepoint) => ({
+      commit: savepoint.commit,
+      sessionId: savepoint.sessionId,
+      kind: savepoint.kind,
+      branch: savepoint.branch,
+      ...(savepoint.anchor ? { anchor: savepoint.anchor } : {}),
+      ...(savepoint.label ? { label: savepoint.label } : {}),
+      action: revertSet.has(savepoint.commit) ? 'revert' as const : 'keep' as const,
+    }));
 
   return {
     ...base,
     mode: 'file-rewind',
-    repoRoot: input.repo.repoRoot,
-    currentHead: input.repo.currentHead,
-    currentBranch: input.repo.currentBranch,
+    repoRoot: repo.repoRoot,
+    currentHead: repo.currentHead,
+    currentBranch: repo.currentBranch,
     revertCommitsNewestFirst: commits
       .filter((commit) => commit.action === 'revert')
       .map((commit) => commit.commit),
     commits,
+  };
+}
+
+function scanBucket(
+  savepointsNewestFirst: readonly CodexRewindSavepoint[],
+  anchorsToRevert: ReadonlySet<string>,
+  targetIdx: number,
+  userMessageIndexByClientId: ReadonlyMap<string, number>,
+): BucketScanResult {
+  const selected: CodexRewindSavepoint[] = [];
+  let nearestNewerAnchorIndex: number | undefined;
+
+  for (const savepoint of savepointsNewestFirst) {
+    if (
+      BLOCKING_KINDS.has(savepoint.kind) &&
+      isBlockingSavepointInTargetRange(savepoint, anchorsToRevert, targetIdx, nearestNewerAnchorIndex)
+    ) {
+      return { selected, blocked: true };
+    }
+    if (savepoint.anchor) {
+      nearestNewerAnchorIndex =
+        userMessageIndexByClientId.get(savepoint.anchor) ?? nearestNewerAnchorIndex;
+    }
+    if (!REVERTIBLE_KINDS.has(savepoint.kind)) continue;
+    if (!savepoint.anchor || !anchorsToRevert.has(savepoint.anchor)) continue;
+    assertRevertibleSavepoint(savepoint);
+    selected.push(savepoint);
+  }
+  return { selected, blocked: false };
+}
+
+function buildRestorePlan(
+  base: CodexFileRewindPlanBase,
+  repo: Extract<CodexFileRewindRepoContext, { kind: 'local-git' }>,
+  selectedNewestFirst: readonly CodexRewindSavepoint[],
+): CodexRewindPlan {
+  const restoreCommits: CodexShadowRestoreCommit[] = [];
+  for (const savepoint of selectedNewestFirst) {
+    if (!savepoint.baselineCommit) {
+      // A shadow after-edit without its turn-start pointer cannot express
+      // "state before this turn"; treat the whole range as non-restorable.
+      return {
+        ...base,
+        mode: 'conversation-only',
+        fallbackReason: 'missing-turn-start-baseline',
+      };
+    }
+    restoreCommits.push({
+      commit: savepoint.commit,
+      baselineCommit: savepoint.baselineCommit,
+      ...(savepoint.anchor ? { anchor: savepoint.anchor } : {}),
+      ...(savepoint.label ? { label: savepoint.label } : {}),
+    });
+  }
+
+  // Files return to the turn-start tree of the oldest turn being undone.
+  const baselineCommit = restoreCommits[restoreCommits.length - 1].baselineCommit;
+  return {
+    ...base,
+    mode: 'file-restore',
+    repoRoot: repo.repoRoot,
+    currentHead: repo.currentHead,
+    baselineCommit,
+    restoreCommitsNewestFirst: restoreCommits,
   };
 }
 

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
@@ -13,6 +13,7 @@ import type {
   CreateShadowMarkerInput,
   CreateShadowSavepointInput,
   ShadowSavepointResult,
+  SkippedFileFingerprint,
 } from './gitSnapshotService';
 
 interface CoordinatorLogger {
@@ -69,8 +70,8 @@ interface TurnStartState {
   repoRoot: string;
   /** Turn-start savepoint on the shadow chain; unset when creation failed. */
   turnStartCommit: string;
-  /** Paths the safety filter excluded from the turn-start snapshot. */
-  turnStartSkippedPaths: string[];
+  /** Content-free fingerprints of paths the filter excluded at turn start. */
+  turnStartSkippedFingerprints: SkippedFileFingerprint[];
   metadata: TurnStartMetadata;
 }
 
@@ -130,7 +131,7 @@ export class GitSnapshotCoordinator {
           metadata,
         );
         record.turnStartCommit = turnStart.commit;
-        record.turnStartSkippedPaths = turnStart.skippedPaths;
+        record.turnStartSkippedFingerprints = turnStart.skippedFingerprints;
       });
       record.metadata ??= await metadataPromise;
     } catch (err) {
@@ -287,21 +288,28 @@ export class GitSnapshotCoordinator {
       });
     }
 
-    // 被过滤路径集合在本 turn 两端**不一致**时补 gap 标记,两个方向都算:
+    // 被过滤路径在本 turn 两端不一致时补 gap 标记,覆盖三种情形:
     // - after 新增(Agent 写入 .env、生成超限文件):本轮改动没进快照;
-    // - baseline 消失(turn-start 时被过滤的文件本轮被缩小到可纳入或被删):
-    //   它在基线树里缺失,回退会把它删掉/改掉,而 turn-start 时的原始内容
-    //   从未被记录,无法恢复。
-    // 两侧都过滤(常驻 dirty 的过滤文件)不打 gap,否则文件回退会被永久
-    // 禁用;这留下的已知残余限制是「整轮处于过滤范围的既存文件被修改」,
-    // 完备方案需要给被过滤文件记指纹,留作后续增强。
+    // - baseline 消失(被过滤文件本轮被缩小到可纳入或被删):它在基线树里
+    //   缺失,回退会删掉/改掉它,而 turn-start 时的原始内容从未被记录;
+    // - 两端都被过滤但 lstat 指纹(大小/mtime,不含内容)变化:文件本轮被
+    //   改写(如超限文件被 Agent 重写后仍超限),同样没有任何快照可恢复。
+    // 指纹完全一致的常驻过滤文件不打 gap,否则文件回退会被永久禁用。
     if (agentKind === 'codex' || agentKind === 'pi') {
-      const baselineSkips = new Set(turnStart?.turnStartSkippedPaths ?? []);
-      const afterSkips = new Set(result.skippedFiles.map((file) => file.path));
-      const changedSkips = [
-        ...[...afterSkips].filter((skippedPath) => !baselineSkips.has(skippedPath)),
-        ...[...baselineSkips].filter((skippedPath) => !afterSkips.has(skippedPath)),
-      ];
+      const baseline = new Map(
+        (turnStart?.turnStartSkippedFingerprints ?? []).map((fp) => [fp.path, fp]),
+      );
+      const after = new Map(result.skippedFingerprints.map((fp) => [fp.path, fp]));
+      const changedSkips: string[] = [];
+      for (const [skippedPath, fp] of after) {
+        const base = baseline.get(skippedPath);
+        if (!base || base.sizeBytes !== fp.sizeBytes || base.mtimeMs !== fp.mtimeMs) {
+          changedSkips.push(skippedPath);
+        }
+      }
+      for (const skippedPath of baseline.keys()) {
+        if (!after.has(skippedPath)) changedSkips.push(skippedPath);
+      }
       if (changedSkips.length > 0) {
         this.deps.logger.warn('[git-snapshot] turn changes partially filtered', {
           sessionId,
@@ -323,7 +331,7 @@ export class GitSnapshotCoordinator {
     sessionId: string,
     repoRoot: string,
     metadata: TurnStartMetadata,
-  ): Promise<{ commit: string | undefined; skippedPaths: string[] }> {
+  ): Promise<{ commit: string | undefined; skippedFingerprints: SkippedFileFingerprint[] }> {
     // Always created, dirty or clean, so every turn has a uniform restore
     // baseline; an unchanged tree costs almost nothing thanks to object reuse.
     const result = await this.deps.createShadowSavepoint(repoRoot, {
@@ -334,7 +342,6 @@ export class GitSnapshotCoordinator {
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       },
     });
-    const skippedPaths = result.skippedFiles.map((file) => file.path);
 
     if (result.commit) {
       this.deps.logger.info('[git-snapshot] turn-start baseline created', {
@@ -343,14 +350,14 @@ export class GitSnapshotCoordinator {
         commit: result.commit.slice(0, 8),
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       });
-      return { commit: result.commit, skippedPaths };
+      return { commit: result.commit, skippedFingerprints: result.skippedFingerprints };
     }
 
     this.deps.logger.warn('[git-snapshot] turn-start baseline missing commit', {
       sessionId,
       repoRoot,
     });
-    return { commit: undefined, skippedPaths };
+    return { commit: undefined, skippedFingerprints: result.skippedFingerprints };
   }
 
   private async resolveTurnStartMetadata(sessionId: string): Promise<TurnStartMetadata> {
@@ -398,8 +405,8 @@ export class GitSnapshotCoordinator {
       },
     });
     if (!commit) {
-      // Empty chain: nothing to truncate, the planner already falls back when
-      // it finds no savepoints for the range.
+      // Marker tree could not be built (git fully unavailable); the failure
+      // is logged by the kernel and the outer swallow keeps the turn alive.
       return;
     }
     this.deps.logger.info(logMessage, {

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
@@ -287,22 +287,26 @@ export class GitSnapshotCoordinator {
       });
     }
 
-    // 本轮**新出现**的被过滤路径(相对 turn-start 的 skipped 集合):这些文件
-    // 的本轮改动没有进任何快照,回退无法恢复它们——在链上补 gap 标记,让
-    // 覆盖本轮的回退降级为 conversation-only,而不是静默留下半截修改。
-    // 已知残余限制:整个 turn 期间都处于过滤范围的既存文件(两侧集合都有)
-    // 若被 Agent 修改,这里判不出来;完备方案需要给被过滤文件记指纹,留作
-    // 后续增强。
+    // 被过滤路径集合在本 turn 两端**不一致**时补 gap 标记,两个方向都算:
+    // - after 新增(Agent 写入 .env、生成超限文件):本轮改动没进快照;
+    // - baseline 消失(turn-start 时被过滤的文件本轮被缩小到可纳入或被删):
+    //   它在基线树里缺失,回退会把它删掉/改掉,而 turn-start 时的原始内容
+    //   从未被记录,无法恢复。
+    // 两侧都过滤(常驻 dirty 的过滤文件)不打 gap,否则文件回退会被永久
+    // 禁用;这留下的已知残余限制是「整轮处于过滤范围的既存文件被修改」,
+    // 完备方案需要给被过滤文件记指纹,留作后续增强。
     if (agentKind === 'codex' || agentKind === 'pi') {
       const baselineSkips = new Set(turnStart?.turnStartSkippedPaths ?? []);
-      const newlySkipped = result.skippedFiles
-        .map((file) => file.path)
-        .filter((skippedPath) => !baselineSkips.has(skippedPath));
-      if (newlySkipped.length > 0) {
+      const afterSkips = new Set(result.skippedFiles.map((file) => file.path));
+      const changedSkips = [
+        ...[...afterSkips].filter((skippedPath) => !baselineSkips.has(skippedPath)),
+        ...[...baselineSkips].filter((skippedPath) => !afterSkips.has(skippedPath)),
+      ];
+      if (changedSkips.length > 0) {
         this.deps.logger.warn('[git-snapshot] turn changes partially filtered', {
           sessionId,
           repoRoot,
-          skipped: newlySkipped.slice(0, 5),
+          skipped: changedSkips.slice(0, 5),
         });
         await this.createRewindBlockedMarker(
           sessionId,

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
@@ -69,6 +69,8 @@ interface TurnStartState {
   repoRoot: string;
   /** Turn-start savepoint on the shadow chain; unset when creation failed. */
   turnStartCommit: string;
+  /** Paths the safety filter excluded from the turn-start snapshot. */
+  turnStartSkippedPaths: string[];
   metadata: TurnStartMetadata;
 }
 
@@ -122,11 +124,13 @@ export class GitSnapshotCoordinator {
       await enqueueGitRepoWrite(resolved.repoRoot, async () => {
         const metadata = await metadataPromise;
         record.metadata = metadata;
-        record.turnStartCommit = await this.createTurnStartSavepoint(
+        const turnStart = await this.createTurnStartSavepoint(
           sessionId,
           resolved.repoRoot,
           metadata,
         );
+        record.turnStartCommit = turnStart.commit;
+        record.turnStartSkippedPaths = turnStart.skippedPaths;
       });
       record.metadata ??= await metadataPromise;
     } catch (err) {
@@ -282,13 +286,40 @@ export class GitSnapshotCoordinator {
         repoRoot,
       });
     }
+
+    // 本轮**新出现**的被过滤路径(相对 turn-start 的 skipped 集合):这些文件
+    // 的本轮改动没有进任何快照,回退无法恢复它们——在链上补 gap 标记,让
+    // 覆盖本轮的回退降级为 conversation-only,而不是静默留下半截修改。
+    // 已知残余限制:整个 turn 期间都处于过滤范围的既存文件(两侧集合都有)
+    // 若被 Agent 修改,这里判不出来;完备方案需要给被过滤文件记指纹,留作
+    // 后续增强。
+    if (agentKind === 'codex' || agentKind === 'pi') {
+      const baselineSkips = new Set(turnStart?.turnStartSkippedPaths ?? []);
+      const newlySkipped = result.skippedFiles
+        .map((file) => file.path)
+        .filter((skippedPath) => !baselineSkips.has(skippedPath));
+      if (newlySkipped.length > 0) {
+        this.deps.logger.warn('[git-snapshot] turn changes partially filtered', {
+          sessionId,
+          repoRoot,
+          skipped: newlySkipped.slice(0, 5),
+        });
+        await this.createRewindBlockedMarker(
+          sessionId,
+          repoRoot,
+          'File rewind gap: turn changes were partially filtered',
+          '[git-snapshot] rewind gap marker created',
+          metadata,
+        );
+      }
+    }
   }
 
   private async createTurnStartSavepoint(
     sessionId: string,
     repoRoot: string,
     metadata: TurnStartMetadata,
-  ): Promise<string | undefined> {
+  ): Promise<{ commit: string | undefined; skippedPaths: string[] }> {
     // Always created, dirty or clean, so every turn has a uniform restore
     // baseline; an unchanged tree costs almost nothing thanks to object reuse.
     const result = await this.deps.createShadowSavepoint(repoRoot, {
@@ -299,6 +330,7 @@ export class GitSnapshotCoordinator {
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       },
     });
+    const skippedPaths = result.skippedFiles.map((file) => file.path);
 
     if (result.commit) {
       this.deps.logger.info('[git-snapshot] turn-start baseline created', {
@@ -307,14 +339,14 @@ export class GitSnapshotCoordinator {
         commit: result.commit.slice(0, 8),
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       });
-      return result.commit;
+      return { commit: result.commit, skippedPaths };
     }
 
     this.deps.logger.warn('[git-snapshot] turn-start baseline missing commit', {
       sessionId,
       repoRoot,
     });
-    return undefined;
+    return { commit: undefined, skippedPaths };
   }
 
   private async resolveTurnStartMetadata(sessionId: string): Promise<TurnStartMetadata> {

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
@@ -233,20 +233,42 @@ export class GitSnapshotCoordinator {
     // Dirty detection is tree equality against the turn-start baseline: with
     // shadow savepoints the worktree stays dirty relative to HEAD, so a
     // status-based check would create an empty after-edit every turn.
-    const result = await this.deps.createShadowSavepoint(repoRoot, {
-      sessionId,
-      label: (diff) =>
-        createAfterEditLabel(
-          { diff, userPrompt: metadata.userPrompt },
-          { oneShot: (prompt) => this.deps.oneShot(agentKind, prompt) },
-        ),
-      meta: {
-        kind: 'after-edit',
-        baselineCommit: baseline,
-        ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
-      },
-      skipIfTreeEquals: baseline,
-    });
+    let result: ShadowSavepointResult;
+    try {
+      result = await this.deps.createShadowSavepoint(repoRoot, {
+        sessionId,
+        label: (diff) =>
+          createAfterEditLabel(
+            { diff, userPrompt: metadata.userPrompt },
+            { oneShot: (prompt) => this.deps.oneShot(agentKind, prompt) },
+          ),
+        meta: {
+          kind: 'after-edit',
+          baselineCommit: baseline,
+          ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
+        },
+        skipIfTreeEquals: baseline,
+      });
+    } catch (err) {
+      this.deps.logger.warn('[git-snapshot] after-edit savepoint failed', {
+        sessionId,
+        repoRoot,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      // This turn's delta is unrecorded; without a gap marker a later rewind
+      // across this turn would restore to a newer baseline and silently keep
+      // the failed turn's file changes while dropping its conversation.
+      if (agentKind === 'codex' || agentKind === 'pi') {
+        await this.createRewindBlockedMarker(
+          sessionId,
+          repoRoot,
+          'File rewind gap: after-edit savepoint failed',
+          '[git-snapshot] rewind gap marker created',
+          metadata,
+        );
+      }
+      return;
+    }
 
     if (result.commit) {
       this.deps.logger.info('[git-snapshot] after-edit savepoint created', {

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
@@ -9,7 +9,11 @@ import type { AgentKind } from '@cindy/maker-core';
 
 import { createAfterEditLabel } from './gitSnapshotLabeler';
 import { enqueueGitRepoWrite } from './gitRepoWriteQueue';
-import type { CreateSnapshotInput, CreateSnapshotMarkerInput } from './gitSnapshotService';
+import type {
+  CreateShadowMarkerInput,
+  CreateShadowSavepointInput,
+  ShadowSavepointResult,
+} from './gitSnapshotService';
 
 interface CoordinatorLogger {
   info: (msg: string, meta?: Record<string, unknown>) => void;
@@ -35,18 +39,22 @@ export interface GitSnapshotCoordinatorDeps {
     context: GitSnapshotSessionContext,
     opts: { autoSnapshotEnabled: boolean },
   ) => Promise<{ repoRoot?: string | null } | null>;
-  /** Cheap dirty check used before createSnapshot does heavier staging work. */
-  isWorktreeDirty: (repoRoot: string) => Promise<boolean>;
   /** Session lookup used for workingDir detection and label-agent routing. */
   getSessionContext: (sessionId: string) => Promise<GitSnapshotSessionContext | null>;
-  /** Optional message anchor attached to the XDT trailer metadata. */
+  /** Optional message anchor attached to the savepoint trailer metadata. */
   resolveAnchor?: (sessionId: string) => Promise<string | undefined>;
   /** Optional last user prompt, used only as label context. */
   getLastUserPrompt?: (sessionId: string) => Promise<string | undefined>;
-  /** Snapshot kernel dependency, injected for tests. */
-  createSnapshot: (repoPath: string, input: CreateSnapshotInput) => Promise<string | null>;
-  /** Metadata-only snapshot marker dependency, injected for tests. */
-  createSnapshotMarker: (repoPath: string, input: CreateSnapshotMarkerInput) => Promise<string>;
+  /** Shadow savepoint kernel dependency, injected for tests. */
+  createShadowSavepoint: (
+    repoPath: string,
+    input: CreateShadowSavepointInput,
+  ) => Promise<ShadowSavepointResult>;
+  /** Metadata-only chain marker dependency, injected for tests. */
+  createShadowMarker: (
+    repoPath: string,
+    input: CreateShadowMarkerInput,
+  ) => Promise<string | null>;
   /** Out-of-band label generation dependency. */
   oneShot: (agentKind: AgentKind, prompt: string) => Promise<string>;
   logger: CoordinatorLogger;
@@ -59,8 +67,8 @@ interface ResolvedSnapshotSession {
 
 interface TurnStartState {
   repoRoot: string;
-  wasDirty: boolean;
-  beforeEditFailed: boolean;
+  /** Turn-start savepoint on the shadow chain; unset when creation failed. */
+  turnStartCommit: string;
   metadata: TurnStartMetadata;
 }
 
@@ -81,8 +89,8 @@ export class GitSnapshotCoordinator {
   constructor(private readonly deps: GitSnapshotCoordinatorDeps) {}
 
   /**
-   * Turn-start hook. Captures whether the repo was already dirty before the
-   * agent turn and snapshots safe pre-existing work before the agent can edit.
+   * Turn-start hook. Snapshots the current worktree state onto the session's
+   * shadow savepoint chain as the baseline for this turn's file rewind.
    */
   async onTurnStart(sessionId: string): Promise<void> {
     const record: TurnStartRecord = {
@@ -110,24 +118,18 @@ export class GitSnapshotCoordinator {
       }
 
       record.repoRoot = resolved.repoRoot;
-      record.beforeEditFailed = false;
       const metadataPromise = this.resolveTurnStartMetadata(sessionId);
       await enqueueGitRepoWrite(resolved.repoRoot, async () => {
-        const wasDirty = await this.deps.isWorktreeDirty(resolved.repoRoot);
-        record.wasDirty = wasDirty;
-        if (!wasDirty) {
-          return;
-        }
-
         const metadata = await metadataPromise;
         record.metadata = metadata;
-        await this.createBeforeEditSnapshot(sessionId, resolved.repoRoot, metadata);
+        record.turnStartCommit = await this.createTurnStartSavepoint(
+          sessionId,
+          resolved.repoRoot,
+          metadata,
+        );
       });
       record.metadata ??= await metadataPromise;
     } catch (err) {
-      if (record.wasDirty) {
-        record.beforeEditFailed = true;
-      }
       this.deps.logger.warn('[git-snapshot] onTurnStart failed (swallowed)', {
         sessionId,
         error: err instanceof Error ? err.message : String(err),
@@ -204,102 +206,93 @@ export class GitSnapshotCoordinator {
     { repoRoot, agentKind }: ResolvedSnapshotSession,
     turnStart: TurnStartRecord | undefined,
   ): Promise<void> {
-    const hasTurnStartBaseline = turnStart?.repoRoot === repoRoot && typeof turnStart.wasDirty === 'boolean';
-    if (!hasTurnStartBaseline && agentKind === 'codex') {
+    const baseline =
+      turnStart?.repoRoot === repoRoot ? turnStart.turnStartCommit : undefined;
+    if (!baseline) {
       this.deps.logger.debug('[git-snapshot] missing turn-start baseline, skip', {
         sessionId,
         repoRoot,
       });
-      // No baseline means no reliable turn anchor; the planner scopes this marker by history position.
-      await this.createRewindBlockedMarker(
-        sessionId,
-        repoRoot,
-        'Codex rewind unavailable: missing turn-start baseline',
-        '[git-snapshot] missing-baseline rewind marker created',
-        {},
-      );
-      return;
-    }
-
-    if (hasTurnStartBaseline && turnStart.beforeEditFailed) {
-      this.deps.logger.debug('[git-snapshot] before-edit baseline failed, skip', {
-        sessionId,
-        repoRoot,
-      });
-      if (agentKind === 'codex') {
+      // Without a baseline this turn's delta is unrecoverable; append a gap
+      // marker so the file-rewind planner truncates ranges that cross it.
+      // Only codex/pi consume the savepoint chain for file rewind.
+      if (agentKind === 'codex' || agentKind === 'pi') {
         await this.createRewindBlockedMarker(
           sessionId,
           repoRoot,
-          'Codex rewind unavailable: turn-start baseline failed',
-          '[git-snapshot] failed-baseline rewind marker created',
-          turnStart.metadata ?? {},
+          'File rewind gap: turn-start baseline unavailable',
+          '[git-snapshot] rewind gap marker created',
+          turnStart?.metadata ?? {},
         );
       }
       return;
     }
 
-    if (!(await this.deps.isWorktreeDirty(repoRoot))) {
-      this.deps.logger.debug('[git-snapshot] worktree clean, skip', { sessionId, repoRoot });
-      return;
-    }
-
     const metadata = turnStart?.metadata ?? await this.resolveTurnStartMetadata(sessionId);
 
-    const commit = await this.deps.createSnapshot(repoRoot, {
+    // Dirty detection is tree equality against the turn-start baseline: with
+    // shadow savepoints the worktree stays dirty relative to HEAD, so a
+    // status-based check would create an empty after-edit every turn.
+    const result = await this.deps.createShadowSavepoint(repoRoot, {
+      sessionId,
       label: (diff) =>
         createAfterEditLabel(
           { diff, userPrompt: metadata.userPrompt },
           { oneShot: (prompt) => this.deps.oneShot(agentKind, prompt) },
         ),
       meta: {
-        sessionId,
         kind: 'after-edit',
+        baselineCommit: baseline,
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       },
+      skipIfTreeEquals: baseline,
     });
 
-    if (commit) {
+    if (result.commit) {
       this.deps.logger.info('[git-snapshot] after-edit savepoint created', {
         sessionId,
         repoRoot,
-        commit: commit.slice(0, 8),
+        commit: result.commit.slice(0, 8),
       });
     } else {
-      this.deps.logger.debug('[git-snapshot] no staged changes after add, skip', {
+      this.deps.logger.debug('[git-snapshot] worktree unchanged since turn start, skip', {
         sessionId,
         repoRoot,
       });
     }
   }
 
-  private async createBeforeEditSnapshot(
+  private async createTurnStartSavepoint(
     sessionId: string,
     repoRoot: string,
     metadata: TurnStartMetadata,
-  ): Promise<void> {
-    const commit = await this.deps.createSnapshot(repoRoot, {
-      label: '本轮开始前的未提交改动',
+  ): Promise<string | undefined> {
+    // Always created, dirty or clean, so every turn has a uniform restore
+    // baseline; an unchanged tree costs almost nothing thanks to object reuse.
+    const result = await this.deps.createShadowSavepoint(repoRoot, {
+      sessionId,
+      label: '本轮开始时的工作区基线',
       meta: {
-        sessionId,
-        kind: 'before-edit',
+        kind: 'turn-start',
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       },
     });
 
-    if (commit) {
-      this.deps.logger.info('[git-snapshot] before-edit baseline created', {
+    if (result.commit) {
+      this.deps.logger.info('[git-snapshot] turn-start baseline created', {
         sessionId,
         repoRoot,
-        commit: commit.slice(0, 8),
+        commit: result.commit.slice(0, 8),
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       });
-      return;
+      return result.commit;
     }
 
-    this.deps.logger.debug('[git-snapshot] no staged turn-start changes after add, skip', {
+    this.deps.logger.warn('[git-snapshot] turn-start baseline missing commit', {
       sessionId,
       repoRoot,
     });
+    return undefined;
   }
 
   private async resolveTurnStartMetadata(sessionId: string): Promise<TurnStartMetadata> {
@@ -338,14 +331,19 @@ export class GitSnapshotCoordinator {
     logMessage: string,
     metadata: TurnStartMetadata,
   ): Promise<void> {
-    const commit = await this.deps.createSnapshotMarker(repoRoot, {
+    const commit = await this.deps.createShadowMarker(repoRoot, {
+      sessionId,
       label,
       meta: {
-        sessionId,
         kind: 'rewind-blocked',
         ...(metadata.anchor ? { anchor: metadata.anchor } : {}),
       },
     });
+    if (!commit) {
+      // Empty chain: nothing to truncate, the planner already falls back when
+      // it finds no savepoints for the range.
+      return;
+    }
     this.deps.logger.info(logMessage, {
       sessionId,
       repoRoot,

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
@@ -78,6 +78,17 @@ interface TurnStartState {
 interface TurnStartRecord extends Partial<TurnStartState> {
   autoSnapshotEnabled: boolean;
   promise: Promise<void>;
+  /** Owning session, for same-repo concurrency checks across sessions. */
+  ownerSessionId?: string;
+  /**
+   * Another session ran a turn on the same repository while this turn was in
+   * flight. Full-worktree trees cannot attribute changes to sessions, so an
+   * after-edit here would swallow the peer's files; the turn degrades to a
+   * rewind gap instead. Overlapping turns of the *same* session stay fine:
+   * their after-edits share one chain and conversation rewind drops them
+   * together, so attribution is consistent by construction.
+   */
+  overlappedWithPeer?: boolean;
 }
 
 interface TurnStartMetadata {
@@ -88,6 +99,8 @@ interface TurnStartMetadata {
 export class GitSnapshotCoordinator {
   private readonly sessionCache = new Map<string, ResolvedSnapshotSession>();
   private readonly turnStartQueues = new Map<string, TurnStartRecord[]>();
+  /** In-flight turn records per repo root, for same-repo concurrency checks. */
+  private readonly activeTurnRecordsByRepo = new Map<string, Set<TurnStartRecord>>();
 
   constructor(private readonly deps: GitSnapshotCoordinatorDeps) {}
 
@@ -99,6 +112,7 @@ export class GitSnapshotCoordinator {
     const record: TurnStartRecord = {
       autoSnapshotEnabled: this.deps.readAutoSnapshotEnabled(),
       promise: Promise.resolve(),
+      ownerSessionId: sessionId,
     };
     this.pushTurnStartRecord(sessionId, record);
     record.promise = this.captureTurnStart(sessionId, record);
@@ -121,6 +135,7 @@ export class GitSnapshotCoordinator {
       }
 
       record.repoRoot = resolved.repoRoot;
+      this.registerActiveTurn(resolved.repoRoot, record);
       const metadataPromise = this.resolveTurnStartMetadata(sessionId);
       await enqueueGitRepoWrite(resolved.repoRoot, async () => {
         const metadata = await metadataPromise;
@@ -235,6 +250,26 @@ export class GitSnapshotCoordinator {
 
     const metadata = turnStart?.metadata ?? await this.resolveTurnStartMetadata(sessionId);
 
+    if (turnStart?.overlappedWithPeer) {
+      // 另一个 session 在同一仓库上与本轮并发跑了 turn:全工作区树无法把
+      // 改动归属到 session,after-edit 会把对方的文件吞进本轮增量,回退时
+      // 再把对方的文件退回本轮基线。降级为 gap,而不是记错账。
+      this.deps.logger.warn('[git-snapshot] concurrent session turn on the same repo', {
+        sessionId,
+        repoRoot,
+      });
+      if (agentKind === 'codex' || agentKind === 'pi') {
+        await this.createRewindBlockedMarker(
+          sessionId,
+          repoRoot,
+          'File rewind gap: concurrent session activity in the same repository',
+          '[git-snapshot] rewind gap marker created',
+          metadata,
+        );
+      }
+      return;
+    }
+
     // Dirty detection is tree equality against the turn-start baseline: with
     // shadow savepoints the worktree stays dirty relative to HEAD, so a
     // status-based check would create an empty after-edit every turn.
@@ -303,7 +338,15 @@ export class GitSnapshotCoordinator {
       const changedSkips: string[] = [];
       for (const [skippedPath, fp] of after) {
         const base = baseline.get(skippedPath);
-        if (!base || base.sizeBytes !== fp.sizeBytes || base.mtimeMs !== fp.mtimeMs) {
+        if (
+          !base ||
+          base.sizeBytes !== fp.sizeBytes ||
+          base.mtimeMs !== fp.mtimeMs ||
+          // ctime 无法从用户态设定、inode 捕获 replace-by-rename:保留 mtime
+          // 的等长改写靠这两个字段识别。
+          base.ctimeMs !== fp.ctimeMs ||
+          base.ino !== fp.ino
+        ) {
           changedSkips.push(skippedPath);
         }
       }
@@ -432,6 +475,41 @@ export class GitSnapshotCoordinator {
     if (queue && queue.length === 0) {
       this.turnStartQueues.delete(sessionId);
     }
+    if (record?.repoRoot) {
+      this.unregisterActiveTurn(record.repoRoot, record);
+    }
     return record;
+  }
+
+  /**
+   * Same-repo concurrency bookkeeping: two sessions running turns against one
+   * repository make full-worktree trees unattributable, so every overlapping
+   * in-flight turn (existing peers included) is flagged for gap degradation.
+   */
+  private registerActiveTurn(repoRoot: string, record: TurnStartRecord): void {
+    const peers = this.activeTurnRecordsByRepo.get(repoRoot);
+    if (!peers) {
+      this.activeTurnRecordsByRepo.set(repoRoot, new Set([record]));
+      return;
+    }
+    const foreignPeers = [...peers].filter(
+      (peer) => peer.ownerSessionId !== record.ownerSessionId,
+    );
+    if (foreignPeers.length > 0) {
+      record.overlappedWithPeer = true;
+      for (const peer of foreignPeers) {
+        peer.overlappedWithPeer = true;
+      }
+    }
+    peers.add(record);
+  }
+
+  private unregisterActiveTurn(repoRoot: string, record: TurnStartRecord): void {
+    const peers = this.activeTurnRecordsByRepo.get(repoRoot);
+    if (!peers) return;
+    peers.delete(record);
+    if (peers.size === 0) {
+      this.activeTurnRecordsByRepo.delete(repoRoot);
+    }
   }
 }

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotCoordinator.ts
@@ -193,6 +193,16 @@ export class GitSnapshotCoordinator {
   /** Clears per-session repo detection when the session is closed. */
   onSessionClosed(sessionId: string): void {
     this.sessionCache.delete(sessionId);
+    // 未被 turn-end/abort 消费的 record(运行中关会话)必须逐条注销同仓并发
+    // 记账,否则悬空 record 会让同仓其它会话的后续每一轮都被误判为并发。
+    const queue = this.turnStartQueues.get(sessionId);
+    if (queue) {
+      for (const record of queue) {
+        if (record.repoRoot) {
+          this.unregisterActiveTurn(record.repoRoot, record);
+        }
+      }
+    }
     this.turnStartQueues.delete(sessionId);
   }
 

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -446,13 +446,26 @@ export async function createShadowSavepoint(
   // directory that replaced a file) go through `git add`, missing paths are
   // recorded as deletions via `update-index --force-remove`, which is a
   // silent no-op when the temporary index does not contain them either.
+  // Same realpath fence as the restore side: a path whose real parent left
+  // the repository (a parent segment became a symlink pointing outside) must
+  // be treated as deleted — never handed to `git add`, which would either
+  // refuse it or, worse, snapshot out-of-repo content.
+  const repoReal = await fs.realpath(repoPath);
   const presentFiles: SnapshotIncludedFile[] = [];
   const missingPaths: string[] = [];
   for (const file of plan.includedFiles) {
     const abs = resolveSnapshotGitPath(repoPath, file.path);
     if (!abs) continue;
-    if (await pathExists(abs)) presentFiles.push(file);
-    else missingPaths.push(file.path);
+    if (!(await pathExists(abs))) {
+      missingPaths.push(file.path);
+      continue;
+    }
+    const parentReal = await fs.realpath(path.dirname(abs)).catch(() => null);
+    if (!parentReal || (parentReal !== repoReal && !parentReal.startsWith(repoReal + path.sep))) {
+      missingPaths.push(file.path);
+      continue;
+    }
+    presentFiles.push(file);
   }
   const stagePathspecs = uniquePathspecs(presentFiles.flatMap((file) => file.pathsForPathspec));
   const commitPathspecs = uniquePathspecs(plan.includedFiles.flatMap(commitPathspecsFor));

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -718,6 +718,31 @@ export async function writeWorktreeTreeForPaths(
   });
 }
 
+/**
+ * Returns the subset of the given repo paths whose *current* content the
+ * snapshot safety filter excludes (sensitive / oversized / nested repo) and
+ * which still exist as regular files. Readers use this to refuse building
+ * worktree trees or restore plans over bytes the savepoint system is not
+ * allowed to persist or protect.
+ */
+export async function listUnprotectedPaths(
+  repoPath: string,
+  paths: readonly string[],
+): Promise<string[]> {
+  if (paths.length === 0) return [];
+  const plan = await buildSnapshotFilePlan(repoPath);
+  const skipped = new Set(plan.skippedFiles.map((file) => file.path));
+  const out: string[] = [];
+  for (const rawPath of uniqueRawPaths(paths)) {
+    if (!skipped.has(rawPath)) continue;
+    const abs = resolveSnapshotGitPath(repoPath, rawPath);
+    if (!abs) continue;
+    const stats = await fs.lstat(abs).catch(() => null);
+    if (stats && !stats.isDirectory()) out.push(rawPath);
+  }
+  return out;
+}
+
 async function resolveTreeOf(repoPath: string, commitish: string): Promise<string | null> {
   try {
     const { stdout } = await gitExec(['rev-parse', `${commitish}^{tree}`], repoPath);

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -406,6 +406,13 @@ export interface CreateShadowSavepointInput {
   fileFilter?: Partial<SnapshotFileFilterOptions>;
 }
 
+/** Content-free lstat fingerprint of a safety-filtered path. */
+export interface SkippedFileFingerprint {
+  path: string;
+  sizeBytes: number;
+  mtimeMs: number;
+}
+
 /** Result of a shadow savepoint attempt. */
 export interface ShadowSavepointResult {
   /** Created commit, or null when skipIfTreeEquals matched. */
@@ -414,6 +421,12 @@ export interface ShadowSavepointResult {
   tree: string;
   includedFiles: string[];
   skippedFiles: SnapshotSkippedFile[];
+  /**
+   * lstat fingerprints (size + mtime, never content) for skipped paths that
+   * still exist as regular files. Turn-boundary readers compare these to
+   * detect changes to files the snapshot is not allowed to record.
+   */
+  skippedFingerprints: SkippedFileFingerprint[];
 }
 
 /**
@@ -450,6 +463,8 @@ export async function createShadowSavepoint(
   // the repository (a parent segment became a symlink pointing outside) must
   // be treated as deleted — never handed to `git add`, which would either
   // refuse it or, worse, snapshot out-of-repo content.
+  const skippedFingerprints = await collectSkippedFingerprints(repoPath, skippedFiles);
+
   const repoReal = await fs.realpath(repoPath);
   const presentFiles: SnapshotIncludedFile[] = [];
   const missingPaths: string[] = [];
@@ -500,6 +515,7 @@ export async function createShadowSavepoint(
           tree,
           includedFiles: plan.includedFiles.map((file) => file.path),
           skippedFiles,
+          skippedFingerprints,
         };
       }
     }
@@ -536,8 +552,25 @@ export async function createShadowSavepoint(
       tree,
       includedFiles: plan.includedFiles.map((file) => file.path),
       skippedFiles,
+      skippedFingerprints,
     };
   });
+}
+
+/** lstat fingerprints (no content) for skipped paths that exist as files. */
+async function collectSkippedFingerprints(
+  repoPath: string,
+  skippedFiles: readonly SnapshotSkippedFile[],
+): Promise<SkippedFileFingerprint[]> {
+  const out: SkippedFileFingerprint[] = [];
+  for (const file of skippedFiles) {
+    const abs = resolveSnapshotGitPath(repoPath, file.path);
+    if (!abs) continue;
+    const stats = await fs.lstat(abs).catch(() => null);
+    if (!stats || stats.isDirectory()) continue;
+    out.push({ path: file.path, sizeBytes: stats.size, mtimeMs: stats.mtimeMs });
+  }
+  return out;
 }
 
 /** Input for metadata-only shadow markers (gap / rollback records on the chain). */
@@ -549,24 +582,19 @@ export interface CreateShadowMarkerInput {
 
 /**
  * Appends a metadata-only marker to the session's savepoint chain, reusing the
- * chain tip's tree. Returns null when the chain is still empty (a marker with
- * no baseline carries no rewind value; readers treat the absence as a gap).
+ * chain tip's tree. An empty chain gets a root marker with the empty tree —
+ * a first-turn gap must survive later successful savepoints, otherwise the
+ * planner would never see it and a rewind to the first message would silently
+ * keep that turn's file changes.
  */
 export async function createShadowMarker(
   repoPath: string,
   input: CreateShadowMarkerInput,
 ): Promise<string | null> {
   const parent = await readSavepointTip(repoPath, input.sessionId);
-  if (!parent) {
-    log.warn('[createShadowMarker] empty savepoint chain, marker skipped', {
-      sessionId: input.sessionId,
-      kind: input.meta.kind,
-    });
-    return null;
-  }
-  const tree = await resolveTreeOf(repoPath, parent);
+  const tree = parent ? await resolveTreeOf(repoPath, parent) : await writeEmptyTree(repoPath);
   if (!tree) {
-    log.warn('[createShadowMarker] chain tip tree unresolved, marker skipped', {
+    log.warn('[createShadowMarker] marker tree unresolved, marker skipped', {
       sessionId: input.sessionId,
     });
     return null;
@@ -741,6 +769,18 @@ export async function listUnprotectedPaths(
     if (stats && !stats.isDirectory()) out.push(rawPath);
   }
   return out;
+}
+
+/** Writes (or reuses) the canonical empty tree object for root gap markers. */
+async function writeEmptyTree(repoPath: string): Promise<string | null> {
+  try {
+    return await withTemporaryIndex(repoPath, async (extraEnv) => {
+      await gitExec(['read-tree', '--empty'], repoPath, { extraEnv });
+      return (await gitExec(['write-tree'], repoPath, { extraEnv })).stdout.trim();
+    });
+  } catch {
+    return null;
+  }
 }
 
 async function resolveTreeOf(repoPath: string, commitish: string): Promise<string | null> {

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -439,7 +439,22 @@ export async function createShadowSavepoint(
     throw new SnapshotBlockedByGitStateError({ reason: 'conflict', conflictedFiles });
   }
 
-  const stagePathspecs = uniquePathspecs(plan.includedFiles.flatMap((file) => file.pathsForPathspec));
+  // `git add -- <path>` is fatal for a path that exists neither in the
+  // worktree nor in the temporary index (seeded from HEAD) — e.g. a file the
+  // user staged in their own index and then deleted from the worktree
+  // (status `AD`). Partition by lstat: present paths (files, symlinks, or a
+  // directory that replaced a file) go through `git add`, missing paths are
+  // recorded as deletions via `update-index --force-remove`, which is a
+  // silent no-op when the temporary index does not contain them either.
+  const presentFiles: SnapshotIncludedFile[] = [];
+  const missingPaths: string[] = [];
+  for (const file of plan.includedFiles) {
+    const abs = resolveSnapshotGitPath(repoPath, file.path);
+    if (!abs) continue;
+    if (await pathExists(abs)) presentFiles.push(file);
+    else missingPaths.push(file.path);
+  }
+  const stagePathspecs = uniquePathspecs(presentFiles.flatMap((file) => file.pathsForPathspec));
   const commitPathspecs = uniquePathspecs(plan.includedFiles.flatMap(commitPathspecsFor));
   const renameOldPaths = renameOldPathsToRemove(plan.includedFiles);
 
@@ -452,6 +467,9 @@ export async function createShadowSavepoint(
           { extraEnv },
         ),
       );
+    }
+    for (const chunk of chunkRawPaths(missingPaths)) {
+      await gitExec(['update-index', '--force-remove', '--', ...chunk], repoPath, { extraEnv });
     }
     await removeRenameOldPaths(repoPath, renameOldPaths, extraEnv);
 
@@ -558,41 +576,59 @@ export async function createShadowMarker(
   });
 }
 
+/** Result of reading one session's shadow savepoint chain. */
+export interface ListShadowSavepointsResult {
+  /** Listable savepoints, newest first. */
+  entries: SnapshotEntry[];
+  /**
+   * True when the chain holds more commits than the traversal window. Readers
+   * must not treat the window as the full history (a rewind planned on a
+   * truncated view would silently skip the truncated-away turns).
+   */
+  truncated: boolean;
+}
+
 /** Lists the session's shadow savepoint chain newest-first. Missing ref yields []. */
 export async function listShadowSavepoints(
   repoPath: string,
   sessionId: string,
   options: { maxCount?: number } = {},
-): Promise<SnapshotEntry[]> {
+): Promise<ListShadowSavepointsResult> {
   let ref: string;
   try {
     ref = savepointRefForSession(sessionId);
   } catch (err) {
-    if (err instanceof InvalidSavepointSessionIdError) return [];
+    if (err instanceof InvalidSavepointSessionIdError) return { entries: [], truncated: false };
     throw err;
   }
 
+  const maxCount = normalizeListSnapshotsMaxCount(options.maxCount);
   let stdout: string;
   try {
-    const maxCount = normalizeListSnapshotsMaxCount(options.maxCount);
+    // Fetch one extra record purely to detect truncation.
     ({ stdout } = await gitExec(
       [
         'log',
-        `--max-count=${maxCount}`,
+        `--max-count=${maxCount + 1}`,
         `--format=%H${FIELD_SEP}%P${FIELD_SEP}%cI${FIELD_SEP}%B${RECORD_SEP}`,
         ref,
       ],
       repoPath,
     ));
   } catch (err) {
-    if (err instanceof GitExecError && isUnbornHeadError(err)) return [];
+    if (err instanceof GitExecError && isUnbornHeadError(err)) {
+      return { entries: [], truncated: false };
+    }
     throw err;
   }
 
   const entries: SnapshotEntry[] = [];
+  let rawRecordCount = 0;
   for (const record of stdout.split(RECORD_SEP)) {
     const trimmed = record.replace(/^\s+/, '');
     if (!trimmed) continue;
+    rawRecordCount += 1;
+    if (rawRecordCount > maxCount) break;
     const [commit, parentsRaw, time, ...bodyParts] = trimmed.split(FIELD_SEP);
     if (!commit || !time) continue;
     const parsed = parseSnapshotCommit(bodyParts.join(FIELD_SEP));
@@ -613,7 +649,7 @@ export async function listShadowSavepoints(
       ...(parsed.baseHead ? { baseHead: parsed.baseHead } : {}),
     });
   }
-  return entries;
+  return { entries, truncated: rawRecordCount > maxCount };
 }
 
 /**
@@ -635,14 +671,22 @@ export async function writeWorktreeTreeForPaths(
     for (const rawPath of uniqueRawPaths(paths)) {
       const abs = resolveSnapshotGitPath(repoPath, rawPath);
       if (!abs) continue;
-      if (await pathExists(abs)) present.push(rawPath);
+      // A directory means the *file* at this path is gone (e.g. a turn
+      // replaced a file with a directory); update-index --add would be fatal
+      // on it, and tree-wise the right record is "absent" — the directory's
+      // children are their own paths in the affected set.
+      const stats = await fs.lstat(abs).catch(() => null);
+      if (stats && !stats.isDirectory()) present.push(rawPath);
       else absent.push(rawPath);
+    }
+    // Removals first: file ↔ directory conversions leave a conflicting stale
+    // entry in the HEAD-seeded index (e.g. blob `swap` vs `swap/child.txt`),
+    // and update-index --add refuses D/F conflicts it did not clear itself.
+    for (const chunk of chunkRawPaths(absent)) {
+      await gitExec(['update-index', '--force-remove', '--', ...chunk], repoPath, { extraEnv });
     }
     for (const chunk of chunkRawPaths(present)) {
       await gitExec(['update-index', '--add', '--', ...chunk], repoPath, { extraEnv });
-    }
-    for (const chunk of chunkRawPaths(absent)) {
-      await gitExec(['update-index', '--force-remove', '--', ...chunk], repoPath, { extraEnv });
     }
     return (await gitExec(['write-tree'], repoPath, { extraEnv })).stdout.trim();
   });

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -429,9 +429,10 @@ export interface ShadowSavepointResult {
   includedFiles: string[];
   skippedFiles: SnapshotSkippedFile[];
   /**
-   * lstat fingerprints (size + mtime, never content) for skipped paths that
-   * still exist as regular files. Turn-boundary readers compare these to
-   * detect changes to files the snapshot is not allowed to record.
+   * lstat fingerprints (size + mtime + ctime + inode, never content) for
+   * skipped paths that still exist as regular files. Turn-boundary readers
+   * compare these to detect changes to files the snapshot is not allowed to
+   * record.
    */
   skippedFingerprints: SkippedFileFingerprint[];
 }

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -55,7 +55,8 @@ export type SnapshotBlockedGitStateReason =
   | 'rebase'
   | 'cherry-pick'
   | 'revert'
-  | 'conflict';
+  | 'conflict'
+  | 'status-overflow';
 
 /** Details for a repository state that blocks automatic snapshot commits. */
 export interface SnapshotBlockedGitState {
@@ -406,11 +407,17 @@ export interface CreateShadowSavepointInput {
   fileFilter?: Partial<SnapshotFileFilterOptions>;
 }
 
-/** Content-free lstat fingerprint of a safety-filtered path. */
+/**
+ * Content-free lstat fingerprint of a safety-filtered path. ctime cannot be
+ * set from userland (any write or utimes call bumps it) and the inode changes
+ * on replace-by-rename, so mtime-preserving rewrites are still detected.
+ */
 export interface SkippedFileFingerprint {
   path: string;
   sizeBytes: number;
   mtimeMs: number;
+  ctimeMs: number;
+  ino: number;
 }
 
 /** Result of a shadow savepoint attempt. */
@@ -446,6 +453,12 @@ export async function createShadowSavepoint(
   }
 
   const plan = await buildSnapshotFilePlan(repoPath, input.fileFilter);
+  if (plan.statusTruncated) {
+    // status 溢出时脏文件视图未知:空计划会拍出一个静默漏掉全部脏文件的
+    // 基线/pre-rollback,读侧还会据此把未受保护的路径当成安全。失败关闭
+    // (legacy 分支提交路径保留其历史上的静默降级行为,不受影响)。
+    throw new SnapshotBlockedByGitStateError({ reason: 'status-overflow' });
+  }
   const skippedFiles = plan.skippedFiles;
   const conflictedFiles = skippedFiles.filter((file) => file.reason === 'conflict');
   if (conflictedFiles.length > 0) {
@@ -568,7 +581,13 @@ async function collectSkippedFingerprints(
     if (!abs) continue;
     const stats = await fs.lstat(abs).catch(() => null);
     if (!stats || stats.isDirectory()) continue;
-    out.push({ path: file.path, sizeBytes: stats.size, mtimeMs: stats.mtimeMs });
+    out.push({
+      path: file.path,
+      sizeBytes: stats.size,
+      mtimeMs: stats.mtimeMs,
+      ctimeMs: stats.ctimeMs,
+      ino: stats.ino,
+    });
   }
   return out;
 }
@@ -751,14 +770,17 @@ export async function writeWorktreeTreeForPaths(
  * snapshot safety filter excludes (sensitive / oversized / nested repo) and
  * which still exist as regular files. Readers use this to refuse building
  * worktree trees or restore plans over bytes the savepoint system is not
- * allowed to persist or protect.
+ * allowed to persist or protect. Returns null when the dirty-file view is
+ * unknown (`git status` overflow) — callers must fail closed, not treat the
+ * paths as protected.
  */
 export async function listUnprotectedPaths(
   repoPath: string,
   paths: readonly string[],
-): Promise<string[]> {
+): Promise<string[] | null> {
   if (paths.length === 0) return [];
   const plan = await buildSnapshotFilePlan(repoPath);
+  if (plan.statusTruncated) return null;
   const skipped = new Set(plan.skippedFiles.map((file) => file.path));
   const out: string[] = [];
   for (const rawPath of uniqueRawPaths(paths)) {

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -666,6 +666,7 @@ export async function writeWorktreeTreeForPaths(
   paths: readonly string[],
 ): Promise<string> {
   return withTemporaryIndex(repoPath, async (extraEnv) => {
+    const repoReal = await fs.realpath(repoPath);
     const present: string[] = [];
     const absent: string[] = [];
     for (const rawPath of uniqueRawPaths(paths)) {
@@ -676,8 +677,20 @@ export async function writeWorktreeTreeForPaths(
       // on it, and tree-wise the right record is "absent" — the directory's
       // children are their own paths in the affected set.
       const stats = await fs.lstat(abs).catch(() => null);
-      if (stats && !stats.isDirectory()) present.push(rawPath);
-      else absent.push(rawPath);
+      if (!stats || stats.isDirectory()) {
+        absent.push(rawPath);
+        continue;
+      }
+      // A path whose real parent left the repository (a parent segment became
+      // a symlink pointing outside) is also "absent" as a repo file:
+      // update-index refuses paths beyond a symbolic link, and readers must
+      // never act on out-of-repo content.
+      const parentReal = await fs.realpath(path.dirname(abs)).catch(() => null);
+      if (!parentReal || (parentReal !== repoReal && !parentReal.startsWith(repoReal + path.sep))) {
+        absent.push(rawPath);
+        continue;
+      }
+      present.push(rawPath);
     }
     // Removals first: file ↔ directory conversions leave a conflicting stale
     // entry in the HEAD-seeded index (e.g. blob `swap` vs `swap/child.txt`),

--- a/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
+++ b/apps/desktop/src/main/git-snapshot/gitSnapshotService.ts
@@ -14,16 +14,24 @@ import { createLogger } from '../logger';
 import { gitExec, GitExecError } from '../worktree/gitExec';
 import {
   buildSnapshotFilePlan,
+  resolveSnapshotGitPath,
   type SnapshotIncludedFile,
   type SnapshotFileFilterOptions,
   type SnapshotSkippedFile,
 } from './snapshotFileFilter';
 import {
+  buildCindyCommitMessage,
   buildCommitMessage,
   parseSnapshotCommit,
   type SnapshotKind,
   type SnapshotMeta,
+  type SnapshotTrailerSource,
 } from './snapshotTrailers';
+import {
+  InvalidSavepointSessionIdError,
+  readSavepointTip,
+  savepointRefForSession,
+} from './savepointRefs';
 
 const log = createLogger('git-snapshot');
 
@@ -104,7 +112,7 @@ export interface CreateSnapshotDetailedResult {
   skippedFiles: SnapshotSkippedFile[];
 }
 
-/** One XDT savepoint parsed from the reachable Git history. */
+/** One savepoint parsed from Git history (HEAD log for legacy, hidden ref chain for shadow). */
 export interface SnapshotEntry {
   commit: string;
   label: string;
@@ -112,8 +120,14 @@ export interface SnapshotEntry {
   sessionId: string;
   time: string;
   parentCount: number;
+  /** Trailer generation the savepoint was written with. */
+  source: SnapshotTrailerSource;
   anchor?: string;
   branch?: string;
+  /** Shadow after-edit only: the turn-start savepoint this delta is based on. */
+  baselineCommit?: string;
+  /** Shadow only: HEAD commit at savepoint time, for audit. */
+  baseHead?: string;
 }
 
 /** Filters applied while reading XDT savepoints from Git history. */
@@ -352,11 +366,321 @@ export async function listSnapshots(
       sessionId: parsed.sessionId,
       time: time.trim(),
       parentCount: parents.length,
+      source: parsed.source,
       ...(parsed.anchor ? { anchor: parsed.anchor } : {}),
       ...(parsed.branch ? { branch: parsed.branch } : {}),
     });
   }
   return entries;
+}
+
+/** Snapshot kinds that appear on a shadow savepoint chain and matter to readers. */
+const SHADOW_LISTABLE_KINDS: ReadonlySet<SnapshotKind> = new Set([
+  'turn-start',
+  'after-edit',
+  'pre-rollback',
+  'rewind-blocked',
+]);
+
+/** Fixed identity for shadow savepoint commits so plumbing never depends on user git config. */
+const SHADOW_IDENTITY_ENV: Record<string, string> = {
+  GIT_AUTHOR_NAME: 'Cindy',
+  GIT_AUTHOR_EMAIL: 'savepoint@cindy.local',
+  GIT_COMMITTER_NAME: 'Cindy',
+  GIT_COMMITTER_EMAIL: 'savepoint@cindy.local',
+};
+
+/** Input for shadow savepoints written to the session's hidden ref chain. */
+export interface CreateShadowSavepointInput {
+  sessionId: string;
+  /** Commit label or a factory used after staging when diff context is needed. */
+  label: string | SnapshotLabelFactory;
+  /** Trailer metadata; sessionId/branch/baseHead are filled in by the kernel. */
+  meta: Omit<SnapshotMeta, 'sessionId' | 'branch' | 'baseHead'>;
+  /**
+   * Skip commit creation when the staged worktree tree equals this commit's
+   * tree (used by after-edit against the turn-start baseline).
+   */
+  skipIfTreeEquals?: string;
+  /** Optional safety filter limit overrides, mainly for tests. */
+  fileFilter?: Partial<SnapshotFileFilterOptions>;
+}
+
+/** Result of a shadow savepoint attempt. */
+export interface ShadowSavepointResult {
+  /** Created commit, or null when skipIfTreeEquals matched. */
+  commit: string | null;
+  /** Tree written from the current worktree state. */
+  tree: string;
+  includedFiles: string[];
+  skippedFiles: SnapshotSkippedFile[];
+}
+
+/**
+ * Creates a shadow savepoint on refs/cindy/savepoints/<sessionId>.
+ *
+ * Uses plumbing only (temporary index + write-tree + commit-tree + update-ref),
+ * so HEAD, the current branch, the user's index and the worktree are never
+ * touched, and no git hooks run.
+ */
+export async function createShadowSavepoint(
+  repoPath: string,
+  input: CreateShadowSavepointInput,
+): Promise<ShadowSavepointResult> {
+  const blockedState = await detectBlockedGitState(repoPath);
+  if (blockedState) {
+    throw new SnapshotBlockedByGitStateError(blockedState);
+  }
+
+  const plan = await buildSnapshotFilePlan(repoPath, input.fileFilter);
+  const skippedFiles = plan.skippedFiles;
+  const conflictedFiles = skippedFiles.filter((file) => file.reason === 'conflict');
+  if (conflictedFiles.length > 0) {
+    throw new SnapshotBlockedByGitStateError({ reason: 'conflict', conflictedFiles });
+  }
+
+  const stagePathspecs = uniquePathspecs(plan.includedFiles.flatMap((file) => file.pathsForPathspec));
+  const commitPathspecs = uniquePathspecs(plan.includedFiles.flatMap(commitPathspecsFor));
+  const renameOldPaths = renameOldPathsToRemove(plan.includedFiles);
+
+  return withTemporaryIndex(repoPath, async (extraEnv) => {
+    if (stagePathspecs.length > 0) {
+      await withPathspecFile(stagePathspecs, (pathspecFile) =>
+        gitExec(
+          ['add', '-A', '--pathspec-from-file', pathspecFile, '--pathspec-file-nul'],
+          repoPath,
+          { extraEnv },
+        ),
+      );
+    }
+    await removeRenameOldPaths(repoPath, renameOldPaths, extraEnv);
+
+    const tree = (await gitExec(['write-tree'], repoPath, { extraEnv })).stdout.trim();
+
+    if (input.skipIfTreeEquals) {
+      const baselineTree = await resolveTreeOf(repoPath, input.skipIfTreeEquals);
+      if (baselineTree && baselineTree === tree) {
+        log.debug('[createShadowSavepoint] tree unchanged, skip', {
+          sessionId: input.sessionId,
+          baseline: input.skipIfTreeEquals.slice(0, 8),
+        });
+        return {
+          commit: null,
+          tree,
+          includedFiles: plan.includedFiles.map((file) => file.path),
+          skippedFiles,
+        };
+      }
+    }
+
+    const label =
+      typeof input.label === 'function'
+        ? await input.label(
+            // Diff against the turn baseline, not HEAD: the worktree stays
+            // dirty across turns now, so a HEAD-based diff would describe the
+            // cumulative session delta instead of this turn's changes.
+            await collectStagedDiff(repoPath, commitPathspecs, extraEnv, input.skipIfTreeEquals),
+          )
+        : input.label;
+    const [branch, baseHead, parent] = await Promise.all([
+      getCurrentBranch(repoPath).catch(() => undefined),
+      getHead(repoPath).catch(() => undefined),
+      readSavepointTip(repoPath, input.sessionId),
+    ]);
+    const message = buildCindyCommitMessage(label, {
+      ...input.meta,
+      sessionId: input.sessionId,
+      ...(branch ? { branch } : {}),
+      ...(baseHead ? { baseHead } : {}),
+    });
+
+    const commit = await commitTreeToSavepointRef(repoPath, {
+      sessionId: input.sessionId,
+      tree,
+      parent,
+      message,
+    });
+    return {
+      commit,
+      tree,
+      includedFiles: plan.includedFiles.map((file) => file.path),
+      skippedFiles,
+    };
+  });
+}
+
+/** Input for metadata-only shadow markers (gap / rollback records on the chain). */
+export interface CreateShadowMarkerInput {
+  sessionId: string;
+  label: string;
+  meta: Omit<SnapshotMeta, 'sessionId' | 'branch' | 'baseHead'>;
+}
+
+/**
+ * Appends a metadata-only marker to the session's savepoint chain, reusing the
+ * chain tip's tree. Returns null when the chain is still empty (a marker with
+ * no baseline carries no rewind value; readers treat the absence as a gap).
+ */
+export async function createShadowMarker(
+  repoPath: string,
+  input: CreateShadowMarkerInput,
+): Promise<string | null> {
+  const parent = await readSavepointTip(repoPath, input.sessionId);
+  if (!parent) {
+    log.warn('[createShadowMarker] empty savepoint chain, marker skipped', {
+      sessionId: input.sessionId,
+      kind: input.meta.kind,
+    });
+    return null;
+  }
+  const tree = await resolveTreeOf(repoPath, parent);
+  if (!tree) {
+    log.warn('[createShadowMarker] chain tip tree unresolved, marker skipped', {
+      sessionId: input.sessionId,
+    });
+    return null;
+  }
+  const [branch, baseHead] = await Promise.all([
+    getCurrentBranch(repoPath).catch(() => undefined),
+    getHead(repoPath).catch(() => undefined),
+  ]);
+  const message = buildCindyCommitMessage(input.label, {
+    ...input.meta,
+    sessionId: input.sessionId,
+    ...(branch ? { branch } : {}),
+    ...(baseHead ? { baseHead } : {}),
+  });
+  return commitTreeToSavepointRef(repoPath, {
+    sessionId: input.sessionId,
+    tree,
+    parent,
+    message,
+  });
+}
+
+/** Lists the session's shadow savepoint chain newest-first. Missing ref yields []. */
+export async function listShadowSavepoints(
+  repoPath: string,
+  sessionId: string,
+  options: { maxCount?: number } = {},
+): Promise<SnapshotEntry[]> {
+  let ref: string;
+  try {
+    ref = savepointRefForSession(sessionId);
+  } catch (err) {
+    if (err instanceof InvalidSavepointSessionIdError) return [];
+    throw err;
+  }
+
+  let stdout: string;
+  try {
+    const maxCount = normalizeListSnapshotsMaxCount(options.maxCount);
+    ({ stdout } = await gitExec(
+      [
+        'log',
+        `--max-count=${maxCount}`,
+        `--format=%H${FIELD_SEP}%P${FIELD_SEP}%cI${FIELD_SEP}%B${RECORD_SEP}`,
+        ref,
+      ],
+      repoPath,
+    ));
+  } catch (err) {
+    if (err instanceof GitExecError && isUnbornHeadError(err)) return [];
+    throw err;
+  }
+
+  const entries: SnapshotEntry[] = [];
+  for (const record of stdout.split(RECORD_SEP)) {
+    const trimmed = record.replace(/^\s+/, '');
+    if (!trimmed) continue;
+    const [commit, parentsRaw, time, ...bodyParts] = trimmed.split(FIELD_SEP);
+    if (!commit || !time) continue;
+    const parsed = parseSnapshotCommit(bodyParts.join(FIELD_SEP));
+    if (!parsed || parsed.source !== 'cindy' || !SHADOW_LISTABLE_KINDS.has(parsed.kind)) continue;
+    if (parsed.sessionId !== sessionId) continue;
+    const parents = parentsRaw.trim() ? parentsRaw.trim().split(/\s+/) : [];
+    entries.push({
+      commit: commit.trim(),
+      label: parsed.label,
+      kind: parsed.kind,
+      sessionId: parsed.sessionId,
+      time: time.trim(),
+      parentCount: parents.length,
+      source: 'cindy',
+      ...(parsed.anchor ? { anchor: parsed.anchor } : {}),
+      ...(parsed.branch ? { branch: parsed.branch } : {}),
+      ...(parsed.baselineCommit ? { baselineCommit: parsed.baselineCommit } : {}),
+      ...(parsed.baseHead ? { baseHead: parsed.baseHead } : {}),
+    });
+  }
+  return entries;
+}
+
+/**
+ * Writes the current worktree state of the given repo-relative paths into a
+ * tree object (used by restore preview and the restore executor). Paths are
+ * literal file paths, not pathspecs. The dangling tree is gc-collectable.
+ *
+ * Uses update-index instead of `git add` because `git add -- <path>` is fatal
+ * for a path that neither exists in the worktree nor in the index — exactly
+ * the state of a file one turn created and a later turn deleted.
+ */
+export async function writeWorktreeTreeForPaths(
+  repoPath: string,
+  paths: readonly string[],
+): Promise<string> {
+  return withTemporaryIndex(repoPath, async (extraEnv) => {
+    const present: string[] = [];
+    const absent: string[] = [];
+    for (const rawPath of uniqueRawPaths(paths)) {
+      const abs = resolveSnapshotGitPath(repoPath, rawPath);
+      if (!abs) continue;
+      if (await pathExists(abs)) present.push(rawPath);
+      else absent.push(rawPath);
+    }
+    for (const chunk of chunkRawPaths(present)) {
+      await gitExec(['update-index', '--add', '--', ...chunk], repoPath, { extraEnv });
+    }
+    for (const chunk of chunkRawPaths(absent)) {
+      await gitExec(['update-index', '--force-remove', '--', ...chunk], repoPath, { extraEnv });
+    }
+    return (await gitExec(['write-tree'], repoPath, { extraEnv })).stdout.trim();
+  });
+}
+
+async function resolveTreeOf(repoPath: string, commitish: string): Promise<string | null> {
+  try {
+    const { stdout } = await gitExec(['rev-parse', `${commitish}^{tree}`], repoPath);
+    return stdout.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+async function commitTreeToSavepointRef(
+  repoPath: string,
+  input: { sessionId: string; tree: string; parent: string | null; message: string },
+): Promise<string> {
+  const { stdout } = await gitExec(
+    [
+      '-c',
+      'commit.gpgsign=false',
+      'commit-tree',
+      input.tree,
+      ...(input.parent ? ['-p', input.parent] : []),
+      '-m',
+      input.message,
+    ],
+    repoPath,
+    { extraEnv: SHADOW_IDENTITY_ENV },
+  );
+  const commit = stdout.trim();
+  // CAS on the chain tip: an empty old value means "must not exist yet".
+  await gitExec(
+    ['update-ref', savepointRefForSession(input.sessionId), commit, input.parent ?? ''],
+    repoPath,
+  );
+  return commit;
 }
 
 function normalizeListSnapshotsMaxCount(maxCount: number | undefined): number {
@@ -370,10 +694,12 @@ async function collectStagedDiff(
   repoPath: string,
   pathspecs: readonly string[],
   extraEnv: Record<string, string>,
+  diffBase?: string,
 ): Promise<StagedDiff> {
+  const baseArgs = diffBase ? ['diff', '--cached', diffBase] : ['diff', '--cached'];
   const [diffStat, rawDiffText] = await Promise.all([
-    safeGitStdoutForPathspecs(['diff', '--cached', '--stat'], repoPath, pathspecs, extraEnv),
-    safeGitStdoutForPathspecs(['diff', '--cached'], repoPath, pathspecs, extraEnv),
+    safeGitStdoutForPathspecs([...baseArgs, '--stat'], repoPath, pathspecs, extraEnv),
+    safeGitStdoutForPathspecs([...baseArgs], repoPath, pathspecs, extraEnv),
   ]);
   const diffText =
     rawDiffText.length > STAGED_DIFF_TEXT_MAX_BYTES
@@ -540,7 +866,8 @@ async function resetCommittedPaths(repoPath: string, pathspecs: readonly string[
   }
 }
 
-function chunkPathspecArgs(pathspecs: readonly string[]): string[][] {
+/** Splits literal pathspecs into command-line sized chunks. */
+export function chunkPathspecArgs(pathspecs: readonly string[]): string[][] {
   const unique = uniquePathspecs(pathspecs);
   const chunks: string[][] = [];
   for (let i = 0; i < unique.length; i += PATHSPEC_CHUNK_SIZE) {
@@ -580,7 +907,8 @@ function uniqueRawPaths(paths: readonly (string | undefined)[]): string[] {
   return out;
 }
 
-async function withPathspecFile<T>(
+/** Writes NUL-separated pathspecs to a temp file for --pathspec-from-file. */
+export async function withPathspecFile<T>(
   pathspecs: readonly string[],
   fn: (pathspecFile: string) => Promise<T>,
 ): Promise<T> {

--- a/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
+++ b/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
@@ -11,12 +11,14 @@
  * 回收;后续增强再考虑对空闲 repo 触发 git gc --auto。
  */
 
+import path from 'node:path';
+
 import { eq, inArray, isNotNull } from 'drizzle-orm';
 
 import { getDbClient } from '../localDb/client/current';
 import { sessions } from '../localDb/schema';
 import { createLogger } from '../logger';
-import { detectCwd } from '../worktree/WorktreeManager';
+import { gitExec } from '../worktree/gitExec';
 import { deleteSavepointRef, listSavepointRefs } from './savepointRefs';
 
 const log = createLogger('git-snapshot');
@@ -24,12 +26,29 @@ const log = createLogger('git-snapshot');
 /** 启动期对账最多探测的 distinct 工作目录数,避免超大会话库拖慢启动。 */
 const RECONCILE_MAX_WORKDIRS = 200;
 
+/**
+ * 判定与 maker-host 的 defaultDetectRepoRoot 同口径:git 可用、是仓库、
+ * 非 linked worktree(linked worktree 会话全链路不产生保存点链)。
+ * 刻意不用 WorktreeManager.detectCwd:本模块被 localDb/ipc/sessions 静态
+ * 导入,经 WorktreeManager → worktreeStore 会绕回 sessions 形成模块环。
+ */
 async function resolveSavepointRepoRoot(workingDir: string): Promise<string | null> {
-  const info = await detectCwd(workingDir);
-  if (!info.gitInstalled || !info.isGitRepo || !info.repoRoot || info.isInsideWorktree) {
+  try {
+    const repoRoot = (await gitExec(['rev-parse', '--show-toplevel'], workingDir)).stdout.trim();
+    if (!repoRoot) return null;
+    const [gitDir, commonDir] = await Promise.all([
+      gitExec(['rev-parse', '--git-dir'], workingDir),
+      gitExec(['rev-parse', '--git-common-dir'], workingDir),
+    ]);
+    const isInsideWorktree =
+      path.resolve(repoRoot, gitDir.stdout.trim()) !==
+      path.resolve(repoRoot, commonDir.stdout.trim());
+    if (isInsideWorktree) return null;
+    return repoRoot;
+  } catch {
+    // git 不可用 / 非仓库 / 目录已被删除:都视为无可清理的保存点。
     return null;
   }
-  return info.repoRoot;
 }
 
 /**

--- a/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
+++ b/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
@@ -40,9 +40,12 @@ async function resolveSavepointRepoRoot(workingDir: string): Promise<string | nu
       gitExec(['rev-parse', '--git-dir'], workingDir),
       gitExec(['rev-parse', '--git-common-dir'], workingDir),
     ]);
+    // rev-parse 输出的相对路径以命令的 cwd(workingDir)为基准,与
+    // WorktreeManager.detectCwd 同口径;用 repoRoot 作基准会在子目录场景
+    // 下解析错。
     const isInsideWorktree =
-      path.resolve(repoRoot, gitDir.stdout.trim()) !==
-      path.resolve(repoRoot, commonDir.stdout.trim());
+      path.resolve(workingDir, gitDir.stdout.trim()) !==
+      path.resolve(workingDir, commonDir.stdout.trim());
     if (isInsideWorktree) return null;
     return repoRoot;
   } catch {

--- a/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
+++ b/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
@@ -1,8 +1,8 @@
 /**
  * shadow savepoint 链的生命周期清理。
  *
- * 唯一删除驱动是启动期对账:遍历会话工作目录对应的 repo,清掉 owning session
- * 已删除或行已缺失的孤儿 ref。刻意**没有**会话删除时的即时清理——覆盖导入等
+ * 唯一删除驱动是启动期对账:遍历会话工作目录对应的 repo,清掉当前账号 DB 里
+ * status='deleted' 的会话的 ref。刻意**没有**会话删除时的即时清理——覆盖导入等
  * 流程会把旧会话瞬态置为 deleted、失败后经 journal 恢复原状态,任何由 status
  * 变化触发的 ref 删除都与这类回滚竞态(ref 删了即不可逆);启动期不存在进行中
  * 的瞬态软删流程,对账时的 deleted 才是稳定终态。归档会话的 ref 保留:归档可
@@ -56,11 +56,12 @@ async function resolveSavepointRepoRoot(workingDir: string): Promise<string | nu
 }
 
 /**
- * 启动期对账:清掉 owning session 已删除/行已缺失的孤儿保存点 ref。
+ * 启动期对账:清掉 owning session 在当前账号 DB 里已标记 deleted 的保存点 ref。
  *
- * 只扫描当前会话表里仍出现的工作目录;所有会话行都已物理清除的 repo 无从定位,
- * 其残留 ref 留待该目录再次被会话使用时的下一轮对账。DB 查询失败整体跳过,
- * 宁可保留也不误删。
+ * 行缺失的 ref 保留(可能属于本机另一账号的会话,localDb 按账号隔离,无法证明
+ * 是孤儿)。只扫描当前会话表里仍出现的工作目录;所有会话行都已物理清除的 repo
+ * 无从定位,其残留 ref 留待该目录再次被会话使用时的下一轮对账。DB 查询失败
+ * 整体跳过,宁可保留也不误删。
  */
 export async function reconcileSavepointRefsForDeletedSessions(): Promise<void> {
   let rows: Array<{ id: string; status: string | null; workingDir: string | null }>;
@@ -101,12 +102,16 @@ export async function reconcileSavepointRefsForDeletedSessions(): Promise<void> 
         .select({ id: sessions.id, status: sessions.status })
         .from(sessions)
         .where(inArray(sessions.id, refs.map((ref) => ref.sessionId)));
-      const aliveIds = new Set(
-        owners.filter((owner) => owner.status !== 'deleted').map((owner) => owner.id),
+      // 只删当前账号 DB 里能证明 status='deleted' 的 ref。行缺失**不是**孤儿
+      // 证据:localDb 按账号隔离,同一仓库可能挂着另一账号会话的链,误删即
+      // 永久丢那个账号的回退历史。代价是行被物理清除的会话 ref 无人回收——
+      // 与"宁可保留也不误删"的模块口径一致。
+      const deletableIds = new Set(
+        owners.filter((owner) => owner.status === 'deleted').map((owner) => owner.id),
       );
 
       for (const ref of refs) {
-        if (aliveIds.has(ref.sessionId)) continue;
+        if (!deletableIds.has(ref.sessionId)) continue;
         await deleteSavepointRef(repoRoot, ref.sessionId);
         log.info('[savepoint-cleanup] orphan savepoint chain removed', {
           sessionId: ref.sessionId,

--- a/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
+++ b/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
@@ -1,0 +1,130 @@
+/**
+ * shadow savepoint 链的生命周期清理。
+ *
+ * - 会话显式删除后删除其 refs/cindy/savepoints/<sessionId>(归档保留:归档可
+ *   恢复,恢复后文件回退仍要可用;与 worktree 启动期对账"archived 不回收"的
+ *   保守口径一致)。
+ * - 启动期对账:遍历会话工作目录对应的 repo,清掉 owning session 已删除或行
+ *   已缺失的孤儿 ref(删除动作与清理之间的崩溃窗口兜底)。
+ *
+ * v1 不主动跑 git gc:删 ref 后保存点对象不可达,由用户仓库自身的 gc 策略
+ * 回收;后续增强再考虑对空闲 repo 触发 git gc --auto。
+ */
+
+import { eq, inArray, isNotNull } from 'drizzle-orm';
+
+import { getDbClient } from '../localDb/client/current';
+import { sessions } from '../localDb/schema';
+import { createLogger } from '../logger';
+import { detectCwd } from '../worktree/WorktreeManager';
+import { deleteSavepointRef, listSavepointRefs } from './savepointRefs';
+
+const log = createLogger('git-snapshot');
+
+/** 启动期对账最多探测的 distinct 工作目录数,避免超大会话库拖慢启动。 */
+const RECONCILE_MAX_WORKDIRS = 200;
+
+async function resolveSavepointRepoRoot(workingDir: string): Promise<string | null> {
+  const info = await detectCwd(workingDir);
+  if (!info.gitInstalled || !info.isGitRepo || !info.repoRoot || info.isInsideWorktree) {
+    return null;
+  }
+  return info.repoRoot;
+}
+
+/**
+ * 会话删除后的保存点链清理。fire-and-forget 语义:任何失败只记日志,由启动期
+ * reconcileSavepointRefsForDeletedSessions() 兜底。
+ */
+export async function cleanupSavepointsForRemovedSession(sessionId: string): Promise<void> {
+  try {
+    const db = getDbClient().drizzle;
+    const [row] = await db
+      .select({ status: sessions.status, workingDir: sessions.workingDir })
+      .from(sessions)
+      .where(eq(sessions.id, sessionId));
+    // 行已缺失同样视为已删除;状态被并发改回非 deleted 时保留保存点。
+    if (row && row.status !== 'deleted') return;
+    if (!row?.workingDir) return;
+
+    const repoRoot = await resolveSavepointRepoRoot(row.workingDir);
+    if (!repoRoot) return;
+    await deleteSavepointRef(repoRoot, sessionId);
+    log.info('[savepoint-cleanup] savepoint chain removed for deleted session', {
+      sessionId,
+      repoRoot,
+    });
+  } catch (err) {
+    log.warn('[savepoint-cleanup] cleanup after session delete failed (swallowed)', {
+      sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * 启动期对账:清掉 owning session 已删除/行已缺失的孤儿保存点 ref。
+ *
+ * 只扫描当前会话表里仍出现的工作目录;所有会话行都已物理清除的 repo 无从定位,
+ * 其残留 ref 留待该目录再次被会话使用时的下一轮对账。DB 查询失败整体跳过,
+ * 宁可保留也不误删。
+ */
+export async function reconcileSavepointRefsForDeletedSessions(): Promise<void> {
+  let rows: Array<{ id: string; status: string | null; workingDir: string | null }>;
+  try {
+    const db = getDbClient().drizzle;
+    rows = await db
+      .select({ id: sessions.id, status: sessions.status, workingDir: sessions.workingDir })
+      .from(sessions)
+      .where(isNotNull(sessions.workingDir));
+  } catch (err) {
+    log.warn('[savepoint-cleanup] reconcile skipped: session query failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return;
+  }
+
+  const workDirs: string[] = [];
+  const seenDirs = new Set<string>();
+  for (const row of rows) {
+    if (!row.workingDir || seenDirs.has(row.workingDir)) continue;
+    seenDirs.add(row.workingDir);
+    workDirs.push(row.workingDir);
+    if (workDirs.length >= RECONCILE_MAX_WORKDIRS) break;
+  }
+
+  const seenRepoRoots = new Set<string>();
+  for (const workingDir of workDirs) {
+    try {
+      const repoRoot = await resolveSavepointRepoRoot(workingDir);
+      if (!repoRoot || seenRepoRoots.has(repoRoot)) continue;
+      seenRepoRoots.add(repoRoot);
+
+      const refs = await listSavepointRefs(repoRoot);
+      if (refs.length === 0) continue;
+
+      const db = getDbClient().drizzle;
+      const owners = await db
+        .select({ id: sessions.id, status: sessions.status })
+        .from(sessions)
+        .where(inArray(sessions.id, refs.map((ref) => ref.sessionId)));
+      const aliveIds = new Set(
+        owners.filter((owner) => owner.status !== 'deleted').map((owner) => owner.id),
+      );
+
+      for (const ref of refs) {
+        if (aliveIds.has(ref.sessionId)) continue;
+        await deleteSavepointRef(repoRoot, ref.sessionId);
+        log.info('[savepoint-cleanup] orphan savepoint chain removed', {
+          sessionId: ref.sessionId,
+          repoRoot,
+        });
+      }
+    } catch (err) {
+      log.debug('[savepoint-cleanup] reconcile for workdir failed (continuing)', {
+        workingDir,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
+++ b/apps/desktop/src/main/git-snapshot/savepointCleanup.ts
@@ -1,11 +1,12 @@
 /**
  * shadow savepoint 链的生命周期清理。
  *
- * - 会话显式删除后删除其 refs/cindy/savepoints/<sessionId>(归档保留:归档可
- *   恢复,恢复后文件回退仍要可用;与 worktree 启动期对账"archived 不回收"的
- *   保守口径一致)。
- * - 启动期对账:遍历会话工作目录对应的 repo,清掉 owning session 已删除或行
- *   已缺失的孤儿 ref(删除动作与清理之间的崩溃窗口兜底)。
+ * 唯一删除驱动是启动期对账:遍历会话工作目录对应的 repo,清掉 owning session
+ * 已删除或行已缺失的孤儿 ref。刻意**没有**会话删除时的即时清理——覆盖导入等
+ * 流程会把旧会话瞬态置为 deleted、失败后经 journal 恢复原状态,任何由 status
+ * 变化触发的 ref 删除都与这类回滚竞态(ref 删了即不可逆);启动期不存在进行中
+ * 的瞬态软删流程,对账时的 deleted 才是稳定终态。归档会话的 ref 保留:归档可
+ * 恢复,恢复后文件回退仍要可用(与 worktree 对账"archived 不回收"同口径)。
  *
  * v1 不主动跑 git gc:删 ref 后保存点对象不可达,由用户仓库自身的 gc 策略
  * 回收;后续增强再考虑对空闲 repo 触发 git gc --auto。
@@ -13,7 +14,7 @@
 
 import path from 'node:path';
 
-import { eq, inArray, isNotNull } from 'drizzle-orm';
+import { inArray, isNotNull } from 'drizzle-orm';
 
 import { getDbClient } from '../localDb/client/current';
 import { sessions } from '../localDb/schema';
@@ -29,8 +30,8 @@ const RECONCILE_MAX_WORKDIRS = 200;
 /**
  * 判定与 maker-host 的 defaultDetectRepoRoot 同口径:git 可用、是仓库、
  * 非 linked worktree(linked worktree 会话全链路不产生保存点链)。
- * 刻意不用 WorktreeManager.detectCwd:本模块被 localDb/ipc/sessions 静态
- * 导入,经 WorktreeManager → worktreeStore 会绕回 sessions 形成模块环。
+ * 刻意不用 WorktreeManager.detectCwd:保持只依赖 gitExec / localDb 叶子模块,
+ * 避免经 WorktreeManager → worktreeStore 绕回 localDb/ipc/sessions 的模块环。
  */
 async function resolveSavepointRepoRoot(workingDir: string): Promise<string | null> {
   try {
@@ -51,36 +52,6 @@ async function resolveSavepointRepoRoot(workingDir: string): Promise<string | nu
   } catch {
     // git 不可用 / 非仓库 / 目录已被删除:都视为无可清理的保存点。
     return null;
-  }
-}
-
-/**
- * 会话删除后的保存点链清理。fire-and-forget 语义:任何失败只记日志,由启动期
- * reconcileSavepointRefsForDeletedSessions() 兜底。
- */
-export async function cleanupSavepointsForRemovedSession(sessionId: string): Promise<void> {
-  try {
-    const db = getDbClient().drizzle;
-    const [row] = await db
-      .select({ status: sessions.status, workingDir: sessions.workingDir })
-      .from(sessions)
-      .where(eq(sessions.id, sessionId));
-    // 行已缺失同样视为已删除;状态被并发改回非 deleted 时保留保存点。
-    if (row && row.status !== 'deleted') return;
-    if (!row?.workingDir) return;
-
-    const repoRoot = await resolveSavepointRepoRoot(row.workingDir);
-    if (!repoRoot) return;
-    await deleteSavepointRef(repoRoot, sessionId);
-    log.info('[savepoint-cleanup] savepoint chain removed for deleted session', {
-      sessionId,
-      repoRoot,
-    });
-  } catch (err) {
-    log.warn('[savepoint-cleanup] cleanup after session delete failed (swallowed)', {
-      sessionId,
-      error: err instanceof Error ? err.message : String(err),
-    });
   }
 }
 

--- a/apps/desktop/src/main/git-snapshot/savepointRefs.ts
+++ b/apps/desktop/src/main/git-snapshot/savepointRefs.ts
@@ -1,0 +1,84 @@
+/**
+ * git-snapshot: shadow savepoint 的隐藏引用管理。
+ *
+ * 每个 session 一条保存点链, 挂在 refs/cindy/savepoints/<sessionId> 下。
+ * 该命名空间不在 refs/heads / refs/tags 内, clone、push、git log 都不会带上,
+ * 因此保存点对用户的分支历史完全不可见。
+ */
+
+import { createLogger } from '../logger';
+import { gitExec, GitExecError } from '../worktree/gitExec';
+
+const log = createLogger('git-snapshot');
+
+export const SAVEPOINT_REF_NAMESPACE = 'refs/cindy/savepoints/';
+
+/** session id 允许进入 refname 的字符集(UUID / cuid 都覆盖)。 */
+const SAFE_SESSION_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** Raised when a session id cannot be embedded into a git refname. */
+export class InvalidSavepointSessionIdError extends Error {
+  constructor(readonly sessionId: string) {
+    super('session id is not a valid savepoint ref component');
+    this.name = 'InvalidSavepointSessionIdError';
+  }
+}
+
+/** Full ref name for one session's savepoint chain. */
+export function savepointRefForSession(sessionId: string): string {
+  if (!SAFE_SESSION_ID_RE.test(sessionId)) {
+    throw new InvalidSavepointSessionIdError(sessionId);
+  }
+  return `${SAVEPOINT_REF_NAMESPACE}${sessionId}`;
+}
+
+/** Current tip commit of the session's savepoint chain, or null when absent. */
+export async function readSavepointTip(
+  repoRoot: string,
+  sessionId: string,
+): Promise<string | null> {
+  const ref = savepointRefForSession(sessionId);
+  try {
+    const { stdout } = await gitExec(['rev-parse', '--verify', '--quiet', ref], repoRoot);
+    return stdout.trim() || null;
+  } catch (err) {
+    if (err instanceof GitExecError && err.exitCode === 1) return null;
+    throw err;
+  }
+}
+
+/** Deletes the session's savepoint chain ref. Best-effort and silent. */
+export async function deleteSavepointRef(repoRoot: string, sessionId: string): Promise<void> {
+  let ref: string;
+  try {
+    ref = savepointRefForSession(sessionId);
+  } catch {
+    return;
+  }
+  try {
+    await gitExec(['update-ref', '-d', ref], repoRoot);
+  } catch (err) {
+    log.debug('[savepoint-refs] delete ref failed (ignored)', {
+      sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/** Lists all savepoint chain refs in the repository. */
+export async function listSavepointRefs(
+  repoRoot: string,
+): Promise<Array<{ sessionId: string; sha: string }>> {
+  const { stdout } = await gitExec(
+    ['for-each-ref', '--format=%(refname)%00%(objectname)', SAVEPOINT_REF_NAMESPACE],
+    repoRoot,
+  );
+  const out: Array<{ sessionId: string; sha: string }> = [];
+  for (const line of stdout.split('\n')) {
+    if (!line) continue;
+    const [refname, sha] = line.split('\0');
+    if (!refname?.startsWith(SAVEPOINT_REF_NAMESPACE) || !sha) continue;
+    out.push({ sessionId: refname.slice(SAVEPOINT_REF_NAMESPACE.length), sha });
+  }
+  return out;
+}

--- a/apps/desktop/src/main/git-snapshot/snapshotFileFilter.ts
+++ b/apps/desktop/src/main/git-snapshot/snapshotFileFilter.ts
@@ -54,6 +54,14 @@ export interface SnapshotStatusEntry {
 export interface SnapshotFilePlan {
   includedFiles: SnapshotIncludedFile[];
   skippedFiles: SnapshotSkippedFile[];
+  /**
+   * `git status` output overflowed the exec buffer: the dirty-file view is
+   * unknown, not empty. Legacy branch-commit snapshots keep their historical
+   * "degrade to no-op" behavior, but shadow savepoint consumers must fail
+   * closed — an empty plan here would record a baseline that silently misses
+   * every dirty file and let readers treat unprotected paths as safe.
+   */
+  statusTruncated?: true;
 }
 
 function withDefaults(opts?: Partial<SnapshotFileFilterOptions>): SnapshotFileFilterOptions {
@@ -145,15 +153,17 @@ export function parseStatusPorcelainZ(output: string): SnapshotStatusEntry[] {
   return entries;
 }
 
-async function readStatusEntries(repoPath: string): Promise<SnapshotStatusEntry[]> {
+async function readStatusEntries(
+  repoPath: string,
+): Promise<{ entries: SnapshotStatusEntry[]; truncated: boolean }> {
   try {
     const { stdout } = await gitExec(
       ['status', '--porcelain=v1', '-z', '--untracked-files=all'],
       repoPath,
     );
-    return parseStatusPorcelainZ(stdout);
+    return { entries: parseStatusPorcelainZ(stdout), truncated: false };
   } catch (err) {
-    if (isGitStatusOutputTooLargeError(err)) return [];
+    if (isGitStatusOutputTooLargeError(err)) return { entries: [], truncated: true };
     throw err;
   }
 }
@@ -284,6 +294,7 @@ export async function buildSnapshotFilePlan(
   repoPath: string,
   opts?: Partial<SnapshotFileFilterOptions>,
 ): Promise<SnapshotFilePlan> {
-  const entries = await readStatusEntries(repoPath);
-  return buildSnapshotFilePlanFromEntries(repoPath, entries, opts);
+  const { entries, truncated } = await readStatusEntries(repoPath);
+  const plan = await buildSnapshotFilePlanFromEntries(repoPath, entries, opts);
+  return truncated ? { ...plan, statusTruncated: true } : plan;
 }

--- a/apps/desktop/src/main/git-snapshot/snapshotTrailers.ts
+++ b/apps/desktop/src/main/git-snapshot/snapshotTrailers.ts
@@ -5,12 +5,19 @@
  * 不另起 SQLite 表。每个保存点把受控元数据用 git 原生 trailer
  * (commit message 末尾的 `Key: value` 脚注)写进 commit, 时间线 = 解析 git log。
  *
- * 纯函数, 无 IO。trailer 私有前缀 X-XDT-* 保证不和用户自己的 commit 混淆,
+ * 纯函数, 无 IO。trailer 私有前缀保证不和用户自己的 commit 混淆,
  * 非保存点 commit 一律 parse 成 null(时间线只认我们建的点)。
+ *
+ * 两代格式并存:
+ * - X-XDT-*(legacy): 旧版把保存点直接 commit 到用户当前分支时写入的前缀。
+ *   仅保留解析与旧执行器路径, 不再产生新提交。
+ * - X-Cindy-*: shadow savepoint(挂在 refs/cindy/savepoints/<sessionId>
+ *   隐藏引用下, 不移动 HEAD)使用的前缀。
  */
 
 /** 保存点 / rollback 提交的受控来源。 */
 const SNAPSHOT_KIND_VALUES = [
+  'turn-start',
   'before-edit',
   'after-edit',
   'manual',
@@ -37,29 +44,48 @@ export interface SnapshotMeta {
   rollbackTarget?: string;
   /** 本次 rollback 撤销的原始 commit, 按执行顺序记录。 */
   reverts?: string[];
-  /** 回退前保护 ref, 用于审计或灾难恢复。 */
+  /** 回退前保护 ref, 用于审计或灾难恢复(仅 legacy)。 */
   protectRef?: string;
-  /** 创建保存点时所在分支, 后续用于隔离时间线。 */
+  /** 创建保存点时所在分支, legacy 用于隔离时间线, shadow 仅作展示/审计。 */
   branch?: string;
+  /** 创建保存点时的 HEAD commit(shadow), unborn HEAD 时缺省。仅审计。 */
+  baseHead?: string;
+  /** after-edit 对应的本 turn turn-start 保存点 commit(shadow)。 */
+  baselineCommit?: string;
+  /** rollback marker 记录的 pre-rollback 保存点 commit(shadow), 补偿/审计锚点。 */
+  preRollbackCommit?: string;
 }
+
+/** 保存点 trailer 前缀代际。 */
+export type SnapshotTrailerSource = 'legacy-xdt' | 'cindy';
 
 /** 从 commit message 解析回来的保存点。 */
 export interface ParsedSnapshot extends SnapshotMeta {
   /** commit message 的正文(trailer 之前的部分), 即时间线展示名。 */
   label: string;
+  /** 该保存点使用的 trailer 前缀代际。 */
+  source: SnapshotTrailerSource;
 }
 
-const TRAILER_SESSION = 'X-XDT-Session';
-const TRAILER_KIND = 'X-XDT-Kind';
-const TRAILER_ANCHOR = 'X-XDT-Anchor';
-const TRAILER_ROLLBACK_ID = 'X-XDT-RollbackId';
-const TRAILER_ROLLBACK_TARGET = 'X-XDT-RollbackTarget';
-const TRAILER_REVERTS = 'X-XDT-Reverts';
-const TRAILER_PROTECT_REF = 'X-XDT-ProtectRef';
-const TRAILER_BRANCH = 'X-XDT-Branch';
+const KEY_SESSION = 'Session';
+const KEY_KIND = 'Kind';
+const KEY_ANCHOR = 'Anchor';
+const KEY_ROLLBACK_ID = 'RollbackId';
+const KEY_ROLLBACK_TARGET = 'RollbackTarget';
+const KEY_REVERTS = 'Reverts';
+const KEY_PROTECT_REF = 'ProtectRef';
+const KEY_BRANCH = 'Branch';
+const KEY_BASE_HEAD = 'BaseHead';
+const KEY_BASELINE = 'Baseline';
+const KEY_PRE_ROLLBACK = 'PreRollback';
 
-/** 一行 XDT trailer 的匹配: `X-XDT-Xxx: value`。 */
-const XDT_TRAILER_RE = /^X-XDT-[A-Za-z0-9]+:\s?(.*)$/;
+const PREFIX_BY_SOURCE: Record<SnapshotTrailerSource, string> = {
+  'legacy-xdt': 'X-XDT',
+  cindy: 'X-Cindy',
+};
+
+/** 一行保存点 trailer 的匹配: `X-XDT-Xxx: value` 或 `X-Cindy-Xxx: value`。 */
+const SNAPSHOT_TRAILER_RE = /^X-(XDT|Cindy)-([A-Za-z0-9]+):\s?(.*)$/;
 
 /** 一行 git trailer 的粗匹配, 用于识别混合 trailer block 的边界。 */
 const GIT_TRAILER_RE = /^[A-Za-z0-9][A-Za-z0-9-]*:\s?.*$/;
@@ -81,41 +107,114 @@ function unfoldTrailerLines(lines: readonly string[]): string[] {
   return unfolded;
 }
 
-/**
- * 组装 commit message: 正文 label + 空行 + X-XDT-* trailer 块。
- * anchor 缺省时不产生空 trailer 行。
- */
-export function buildCommitMessage(label: string, meta: SnapshotMeta): string {
+function buildTrailerBlock(prefix: string, meta: SnapshotMeta): string {
   const trailers: string[] = [
-    `${TRAILER_SESSION}: ${meta.sessionId}`,
-    `${TRAILER_KIND}: ${meta.kind}`,
+    `${prefix}-${KEY_SESSION}: ${meta.sessionId}`,
+    `${prefix}-${KEY_KIND}: ${meta.kind}`,
   ];
   if (meta.anchor) {
-    trailers.push(`${TRAILER_ANCHOR}: ${meta.anchor}`);
+    trailers.push(`${prefix}-${KEY_ANCHOR}: ${meta.anchor}`);
   }
   if (meta.rollbackId) {
-    trailers.push(`${TRAILER_ROLLBACK_ID}: ${meta.rollbackId}`);
+    trailers.push(`${prefix}-${KEY_ROLLBACK_ID}: ${meta.rollbackId}`);
   }
   if (meta.rollbackTarget) {
-    trailers.push(`${TRAILER_ROLLBACK_TARGET}: ${meta.rollbackTarget}`);
+    trailers.push(`${prefix}-${KEY_ROLLBACK_TARGET}: ${meta.rollbackTarget}`);
   }
   if (meta.reverts?.length) {
-    trailers.push(`${TRAILER_REVERTS}: ${meta.reverts.join(',')}`);
+    trailers.push(`${prefix}-${KEY_REVERTS}: ${meta.reverts.join(',')}`);
   }
   if (meta.protectRef) {
-    trailers.push(`${TRAILER_PROTECT_REF}: ${meta.protectRef}`);
+    trailers.push(`${prefix}-${KEY_PROTECT_REF}: ${meta.protectRef}`);
   }
   if (meta.branch) {
-    trailers.push(`${TRAILER_BRANCH}: ${meta.branch}`);
+    trailers.push(`${prefix}-${KEY_BRANCH}: ${meta.branch}`);
   }
-  return `${label}\n\n${trailers.join('\n')}`;
+  if (meta.baseHead) {
+    trailers.push(`${prefix}-${KEY_BASE_HEAD}: ${meta.baseHead}`);
+  }
+  if (meta.baselineCommit) {
+    trailers.push(`${prefix}-${KEY_BASELINE}: ${meta.baselineCommit}`);
+  }
+  if (meta.preRollbackCommit) {
+    trailers.push(`${prefix}-${KEY_PRE_ROLLBACK}: ${meta.preRollbackCommit}`);
+  }
+  return trailers.join('\n');
+}
+
+/**
+ * 组装 legacy commit message: 正文 label + 空行 + X-XDT-* trailer 块。
+ * 仅供旧格式(直接 commit 到用户分支)的既有路径使用, 新代码用
+ * buildCindyCommitMessage。anchor 等缺省时不产生空 trailer 行。
+ */
+export function buildCommitMessage(label: string, meta: SnapshotMeta): string {
+  return `${label}\n\n${buildTrailerBlock(PREFIX_BY_SOURCE['legacy-xdt'], meta)}`;
+}
+
+/** 组装 shadow savepoint 的 commit message(X-Cindy-* trailer 块)。 */
+export function buildCindyCommitMessage(label: string, meta: SnapshotMeta): string {
+  return `${label}\n\n${buildTrailerBlock(PREFIX_BY_SOURCE.cindy, meta)}`;
+}
+
+interface CollectedTrailerFields {
+  sessionId?: string;
+  kind?: string;
+  anchor?: string;
+  rollbackId?: string;
+  rollbackTarget?: string;
+  reverts?: string[];
+  protectRef?: string;
+  branch?: string;
+  baseHead?: string;
+  baselineCommit?: string;
+  preRollbackCommit?: string;
+}
+
+function assignTrailerField(fields: CollectedTrailerFields, key: string, value: string): void {
+  if (key === KEY_SESSION) fields.sessionId = value;
+  else if (key === KEY_KIND) fields.kind = value;
+  else if (key === KEY_ANCHOR) fields.anchor = value;
+  else if (key === KEY_ROLLBACK_ID) fields.rollbackId = value;
+  else if (key === KEY_ROLLBACK_TARGET) fields.rollbackTarget = value;
+  else if (key === KEY_REVERTS) {
+    fields.reverts = value.split(',').map((s) => s.trim()).filter(Boolean);
+  } else if (key === KEY_PROTECT_REF) fields.protectRef = value;
+  else if (key === KEY_BRANCH) fields.branch = value;
+  else if (key === KEY_BASE_HEAD) fields.baseHead = value;
+  else if (key === KEY_BASELINE) fields.baselineCommit = value;
+  else if (key === KEY_PRE_ROLLBACK) fields.preRollbackCommit = value;
+}
+
+function toParsedSnapshot(
+  fields: CollectedTrailerFields,
+  label: string,
+  source: SnapshotTrailerSource,
+): ParsedSnapshot | null {
+  const { sessionId, kind } = fields;
+  if (!sessionId || !kind || !VALID_KINDS.has(kind)) return null;
+  return {
+    label,
+    source,
+    sessionId,
+    kind: kind as SnapshotKind,
+    ...(fields.anchor ? { anchor: fields.anchor } : {}),
+    ...(fields.rollbackId ? { rollbackId: fields.rollbackId } : {}),
+    ...(fields.rollbackTarget ? { rollbackTarget: fields.rollbackTarget } : {}),
+    ...(fields.reverts?.length ? { reverts: fields.reverts } : {}),
+    ...(fields.protectRef ? { protectRef: fields.protectRef } : {}),
+    ...(fields.branch ? { branch: fields.branch } : {}),
+    ...(fields.baseHead ? { baseHead: fields.baseHead } : {}),
+    ...(fields.baselineCommit ? { baselineCommit: fields.baselineCommit } : {}),
+    ...(fields.preRollbackCommit ? { preRollbackCommit: fields.preRollbackCommit } : {}),
+  };
 }
 
 /**
  * 解析 commit message(通常来自 git log %B)。
  *
- * 策略: 从末尾向上收集"连续的 git trailer 行"作为 trailer 块, 再筛 X-XDT-*。
- * 因为 label 行不会以 `X-XDT-` 开头, 即使 label 含冒号/换行也不会误判。
+ * 策略: 从末尾向上收集"连续的 git trailer 行"作为 trailer 块, 再筛
+ * X-XDT-* / X-Cindy-*。因为 label 行不会以这两个前缀开头, 即使 label 含
+ * 冒号/换行也不会误判。两种前缀同时出现时(实际不会发生)X-Cindy 优先。
  * 缺 Session / 缺 Kind / Kind 非法 → 返回 null(不是合法保存点)。
  */
 export function parseSnapshotCommit(rawMessage: string): ParsedSnapshot | null {
@@ -131,44 +230,21 @@ export function parseSnapshotCommit(rawMessage: string): ParsedSnapshot | null {
   }
   if (trailerLines.length === 0) return null;
 
-  let sessionId: string | undefined;
-  let kind: string | undefined;
-  let anchor: string | undefined;
-  let rollbackId: string | undefined;
-  let rollbackTarget: string | undefined;
-  let reverts: string[] | undefined;
-  let protectRef: string | undefined;
-  let branch: string | undefined;
+  const cindyFields: CollectedTrailerFields = {};
+  const legacyFields: CollectedTrailerFields = {};
   for (const line of unfoldTrailerLines(trailerLines)) {
-    if (!XDT_TRAILER_RE.test(line)) continue;
-    const idx = line.indexOf(':');
-    const key = line.slice(0, idx);
-    const value = line.slice(idx + 1).trim();
-    if (key === TRAILER_SESSION) sessionId = value;
-    else if (key === TRAILER_KIND) kind = value;
-    else if (key === TRAILER_ANCHOR) anchor = value;
-    else if (key === TRAILER_ROLLBACK_ID) rollbackId = value;
-    else if (key === TRAILER_ROLLBACK_TARGET) rollbackTarget = value;
-    else if (key === TRAILER_REVERTS) {
-      reverts = value.split(',').map((s) => s.trim()).filter(Boolean);
-    } else if (key === TRAILER_PROTECT_REF) protectRef = value;
-    else if (key === TRAILER_BRANCH) branch = value;
+    const match = SNAPSHOT_TRAILER_RE.exec(line);
+    if (!match) continue;
+    const [, prefixTag, key, rawValue] = match;
+    const fields = prefixTag === 'Cindy' ? cindyFields : legacyFields;
+    assignTrailerField(fields, key, rawValue.trim());
   }
-
-  if (!sessionId || !kind || !VALID_KINDS.has(kind)) return null;
 
   // label = trailer 块之前的内容, 去掉中间分隔的尾随空行。
   const label = lines.slice(0, i + 1).join('\n').replace(/\n+$/, '');
 
-  return {
-    label,
-    sessionId,
-    kind: kind as SnapshotKind,
-    ...(anchor ? { anchor } : {}),
-    ...(rollbackId ? { rollbackId } : {}),
-    ...(rollbackTarget ? { rollbackTarget } : {}),
-    ...(reverts?.length ? { reverts } : {}),
-    ...(protectRef ? { protectRef } : {}),
-    ...(branch ? { branch } : {}),
-  };
+  return (
+    toParsedSnapshot(cindyFields, label, 'cindy') ??
+    toParsedSnapshot(legacyFields, label, 'legacy-xdt')
+  );
 }

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -32,7 +32,6 @@ import {
 import { ensureDialogueWorkspaceDir } from '../dialogueWorkspace';
 import { recomputePrRefsForSession } from '../../git-context/prRefsStore';
 import { ensureProjectGitInitialized } from '../../git-snapshot/projectGitBootstrap';
-import { cleanupSavepointsForRemovedSession } from '../../git-snapshot/savepointCleanup';
 import { readGitSafetySettings } from '../../maker-host/git-safety-settings-store';
 import * as imageCacheStore from '../../imageCacheStore';
 import { removeSessionRefs as removeSessionMediaRefs } from '../../cindy-media/ledger';
@@ -110,7 +109,6 @@ function broadcastWorktreeChanged(sessionId: string): void {
  * 时条目仍在 store 里,重拉拿到的就是"徽标还在"这个真实状态,同样是对的。
  */
 function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unknown): void {
-  scheduleSavepointCleanupForStatusChange(sessionId, status);
   if (status !== 'deleted' && status !== 'archived') return;
   void (async () => {
     const [mh, recycle, routeLock] = await Promise.all([
@@ -139,21 +137,11 @@ function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unkno
     });
 }
 
-/**
- * 会话删除后的 shadow savepoint 链清理(refs/cindy/savepoints/<sid>)。
- * 只处理 deleted:归档可恢复,恢复后文件回退仍要可用,归档会话的保存点保留。
- * fire-and-forget;失败由启动期 reconcile 兜底。savepointCleanup 只依赖
- * gitExec / localDb 叶子模块,静态导入不构成本文件顶部注释警告的模块环。
- */
-function scheduleSavepointCleanupForStatusChange(sessionId: string, status: unknown): void {
-  if (status !== 'deleted') return;
-  void cleanupSavepointsForRemovedSession(sessionId).catch((err) => {
-    log.warn('savepoint cleanup after session delete failed', {
-      sessionId,
-      err: err instanceof Error ? err.message : String(err),
-    });
-  });
-}
+// shadow savepoint 链(refs/cindy/savepoints/<sid>)刻意**不**挂 status 变化
+// 即时清理:覆盖导入等流程会把旧会话瞬态置为 deleted、失败后经 journal 恢复,
+// status 触发的 ref 删除与这类回滚天然竞态(删了就不可逆)。孤儿 ref 隐藏且
+// 极小,统一由启动期 reconcileSavepointRefsForDeletedSessions() 清理——启动期
+// 不存在进行中的瞬态软删流程。
 
 /**
  * 会话 status 变化的订阅槽①旁路通知(archived → did-session-archived)。

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -109,6 +109,7 @@ function broadcastWorktreeChanged(sessionId: string): void {
  * 时条目仍在 store 里,重拉拿到的就是"徽标还在"这个真实状态,同样是对的。
  */
 function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unknown): void {
+  scheduleSavepointCleanupForStatusChange(sessionId, status);
   if (status !== 'deleted' && status !== 'archived') return;
   void (async () => {
     const [mh, recycle, routeLock] = await Promise.all([
@@ -134,6 +135,23 @@ function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unkno
     })
     .finally(() => {
       broadcastWorktreeChanged(sessionId);
+    });
+}
+
+/**
+ * 会话删除后的 shadow savepoint 链清理(refs/cindy/savepoints/<sid>)。
+ * 只处理 deleted:归档可恢复,恢复后文件回退仍要可用,归档会话的保存点保留。
+ * fire-and-forget + 动态 import 防环;失败由启动期 reconcile 兜底。
+ */
+function scheduleSavepointCleanupForStatusChange(sessionId: string, status: unknown): void {
+  if (status !== 'deleted') return;
+  void import('../../git-snapshot/savepointCleanup.js')
+    .then((m) => m.cleanupSavepointsForRemovedSession(sessionId))
+    .catch((err) => {
+      log.warn('savepoint cleanup after session delete failed', {
+        sessionId,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
 }
 

--- a/apps/desktop/src/main/localDb/ipc/sessions.ts
+++ b/apps/desktop/src/main/localDb/ipc/sessions.ts
@@ -32,6 +32,7 @@ import {
 import { ensureDialogueWorkspaceDir } from '../dialogueWorkspace';
 import { recomputePrRefsForSession } from '../../git-context/prRefsStore';
 import { ensureProjectGitInitialized } from '../../git-snapshot/projectGitBootstrap';
+import { cleanupSavepointsForRemovedSession } from '../../git-snapshot/savepointCleanup';
 import { readGitSafetySettings } from '../../maker-host/git-safety-settings-store';
 import * as imageCacheStore from '../../imageCacheStore';
 import { removeSessionRefs as removeSessionMediaRefs } from '../../cindy-media/ledger';
@@ -141,18 +142,17 @@ function scheduleWorktreeRecycleForStatusChange(sessionId: string, status: unkno
 /**
  * 会话删除后的 shadow savepoint 链清理(refs/cindy/savepoints/<sid>)。
  * 只处理 deleted:归档可恢复,恢复后文件回退仍要可用,归档会话的保存点保留。
- * fire-and-forget + 动态 import 防环;失败由启动期 reconcile 兜底。
+ * fire-and-forget;失败由启动期 reconcile 兜底。savepointCleanup 只依赖
+ * gitExec / localDb 叶子模块,静态导入不构成本文件顶部注释警告的模块环。
  */
 function scheduleSavepointCleanupForStatusChange(sessionId: string, status: unknown): void {
   if (status !== 'deleted') return;
-  void import('../../git-snapshot/savepointCleanup.js')
-    .then((m) => m.cleanupSavepointsForRemovedSession(sessionId))
-    .catch((err) => {
-      log.warn('savepoint cleanup after session delete failed', {
-        sessionId,
-        err: err instanceof Error ? err.message : String(err),
-      });
+  void cleanupSavepointsForRemovedSession(sessionId).catch((err) => {
+    log.warn('savepoint cleanup after session delete failed', {
+      sessionId,
+      err: err instanceof Error ? err.message : String(err),
     });
+  });
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/git-snapshot-host.ts
+++ b/apps/desktop/src/main/maker-host/git-snapshot-host.ts
@@ -3,7 +3,7 @@
  *
  * This file wires the pure GitSnapshotCoordinator to desktop main-process
  * dependencies: maker session metadata, repo detection, local message lookup,
- * worktree dirty checks, and oneShot label generation.
+ * and oneShot label generation.
  */
 
 import type { AgentKind, Maker } from '@cindy/maker-core';
@@ -11,13 +11,12 @@ import { and, desc, eq, isNull } from 'drizzle-orm';
 
 import { GitSnapshotCoordinator } from '../git-snapshot/gitSnapshotCoordinator.js';
 import { ensureProjectGitInitialized } from '../git-snapshot/projectGitBootstrap.js';
-import { createSnapshot, createSnapshotMarker } from '../git-snapshot/gitSnapshotService.js';
+import { createShadowMarker, createShadowSavepoint } from '../git-snapshot/gitSnapshotService.js';
 import { extractUserPromptText } from '../git-snapshot/userPromptText.js';
 import { getDbClient } from '../localDb/client/current.js';
 import { messages } from '../localDb/schema.js';
 import { createLogger } from '../logger.js';
 import { detectCwd } from '../worktree/WorktreeManager.js';
-import { isWorktreeDirty } from '../worktree/dirty.js';
 import { readGitSafetySettings } from './git-safety-settings-store.js';
 import { isAgentOneShotRouteDisabled } from './model-route-guard-live.js';
 
@@ -35,10 +34,9 @@ export interface GitSnapshotCoordinatorHostDeps {
   readAutoSnapshotEnabled?: () => boolean;
   detectRepoRoot?: (workingDir: string) => Promise<string | null>;
   initializeProjectGit?: ConstructorParameters<typeof GitSnapshotCoordinator>[0]['initializeProjectGit'];
-  isWorktreeDirty?: (repoRoot: string) => Promise<boolean>;
   getLatestUserMessage?: (sessionId: string) => Promise<LatestUserMessage | null>;
-  createSnapshot?: ConstructorParameters<typeof GitSnapshotCoordinator>[0]['createSnapshot'];
-  createSnapshotMarker?: ConstructorParameters<typeof GitSnapshotCoordinator>[0]['createSnapshotMarker'];
+  createShadowSavepoint?: ConstructorParameters<typeof GitSnapshotCoordinator>[0]['createShadowSavepoint'];
+  createShadowMarker?: ConstructorParameters<typeof GitSnapshotCoordinator>[0]['createShadowMarker'];
   logger?: ConstructorParameters<typeof GitSnapshotCoordinator>[0]['logger'];
 }
 
@@ -107,7 +105,6 @@ export function createGitSnapshotCoordinator(
           autoSnapshotEnabled: opts.autoSnapshotEnabled,
           source: 'git-snapshot:on-turn',
         })),
-    isWorktreeDirty: deps.isWorktreeDirty ?? isWorktreeDirty,
     getSessionContext: async (sessionId) => {
       const meta = await maker.getSessionMeta(sessionId);
       if (!meta?.workDir || meta.remoteHostId) return null;
@@ -120,8 +117,8 @@ export function createGitSnapshotCoordinator(
     },
     resolveAnchor: async (sessionId) => (await getLatestUserMessageOnce(sessionId))?.clientId,
     getLastUserPrompt: async (sessionId) => (await getLatestUserMessageOnce(sessionId))?.text,
-    createSnapshot: deps.createSnapshot ?? createSnapshot,
-    createSnapshotMarker: deps.createSnapshotMarker ?? createSnapshotMarker,
+    createShadowSavepoint: deps.createShadowSavepoint ?? createShadowSavepoint,
+    createShadowMarker: deps.createShadowMarker ?? createShadowMarker,
     oneShot: async (agentKind, prompt) => {
       // 停用轴:快照标签是新的付费 one-shot,该 agent 的默认路由被停用时不派发 ——
       // 抛错让 labeler 走既有的确定性兜底标签(gitSnapshotLabeler:oneShot 失败即

--- a/apps/desktop/src/main/maker-orchestration/rewind.ts
+++ b/apps/desktop/src/main/maker-orchestration/rewind.ts
@@ -421,8 +421,15 @@ async function previewCodexFileRestorePlan(plan: CodexFileRestorePlan): Promise<
     }
     // 与执行侧同款的安全过滤前置:受影响文件当前若处于过滤范围(敏感/超限/
     // 嵌套仓库),预览直接报不可回退,不把这些字节写进 Git 对象库(下面的
-    // 临时 worktree 树会 hash 受影响路径的当前内容)。
+    // 临时 worktree 树会 hash 受影响路径的当前内容)。null = status 溢出、
+    // 脏文件视图未知,同样失败关闭。
     const unprotected = await listUnprotectedPaths(plan.repoRoot, affectedPaths);
+    if (unprotected === null) {
+      return {
+        canRewind: false,
+        error: '仓库脏文件过多,无法核实回退安全性(git status 输出超限),请先清理或提交部分改动',
+      };
+    }
     if (unprotected.length > 0) {
       return {
         canRewind: false,

--- a/apps/desktop/src/main/maker-orchestration/rewind.ts
+++ b/apps/desktop/src/main/maker-orchestration/rewind.ts
@@ -493,15 +493,15 @@ async function loadCodexFileRewindRepoContext(makerSession: { workDir: string; r
     // 两个来源:隐藏引用链上的 shadow savepoint(新)+ 分支历史里的 legacy
     // savepoint(旧版本写进用户分支的,升级后仍要可回退)。planner 分桶处理,
     // 不要求两者之间有全局时间序。
-    const [shadowSnapshots, legacySnapshots] = await Promise.all([
+    const [shadowResult, legacySnapshots] = await Promise.all([
       listShadowSavepoints(repoRoot, sessionId),
       listSnapshots(repoRoot),
     ]);
     const savepointsNewestFirst = [
-      ...shadowSnapshots.map(toPlannerSavepoint),
+      ...shadowResult.entries.map(toPlannerSavepoint),
       ...legacySnapshots.map(toPlannerSavepoint),
     ];
-    if (savepointsNewestFirst.length === 0) return { kind: 'local-git' as const, repoRoot, currentHead: '', currentBranch: '', savepointsNewestFirst: [] };
+    if (savepointsNewestFirst.length === 0 && !shadowResult.truncated) return { kind: 'local-git' as const, repoRoot, currentHead: '', currentBranch: '', savepointsNewestFirst: [] };
 
     // unborn HEAD(空仓库首轮)下 shadow 链可能已存在;HEAD/branch 只影响 legacy
     // 桶的过滤与展示,取不到就退化为空串。
@@ -516,6 +516,7 @@ async function loadCodexFileRewindRepoContext(makerSession: { workDir: string; r
       currentHead,
       currentBranch,
       savepointsNewestFirst,
+      ...(shadowResult.truncated ? { shadowSavepointsTruncated: true } : {}),
     };
   });
 }

--- a/apps/desktop/src/main/maker-orchestration/rewind.ts
+++ b/apps/desktop/src/main/maker-orchestration/rewind.ts
@@ -54,6 +54,7 @@ import {
   getHead,
   listShadowSavepoints,
   listSnapshots,
+  listUnprotectedPaths,
   writeWorktreeTreeForPaths,
   type SnapshotEntry,
 } from '../git-snapshot/gitSnapshotService';
@@ -417,6 +418,16 @@ async function previewCodexFileRestorePlan(plan: CodexFileRestorePlan): Promise<
     const affectedPaths = await collectRestoreAffectedPaths(plan);
     if (affectedPaths.length === 0) {
       return { canRewind: true, filesChanged: [], insertions: 0, deletions: 0 };
+    }
+    // 与执行侧同款的安全过滤前置:受影响文件当前若处于过滤范围(敏感/超限/
+    // 嵌套仓库),预览直接报不可回退,不把这些字节写进 Git 对象库(下面的
+    // 临时 worktree 树会 hash 受影响路径的当前内容)。
+    const unprotected = await listUnprotectedPaths(plan.repoRoot, affectedPaths);
+    if (unprotected.length > 0) {
+      return {
+        canRewind: false,
+        error: `受影响文件 ${unprotected.slice(0, 3).join('、')}${unprotected.length > 3 ? ' 等' : ''} 当前处于安全过滤范围(敏感路径/超大文件/嵌套仓库),回退前快照无法完整保护其内容,请先手动备份或移出这些文件`,
+      };
     }
     const affectedPathspecs = affectedPaths.map((p) => `:(literal)${p}`);
     const worktreeTree = await writeWorktreeTreeForPaths(plan.repoRoot, affectedPaths);

--- a/apps/desktop/src/main/maker-orchestration/rewind.ts
+++ b/apps/desktop/src/main/maker-orchestration/rewind.ts
@@ -36,14 +36,27 @@ import { recomputePrRefsForSession } from '../git-context/prRefsStore.js';
 import {
   buildCodexFileRewindPlan,
   CodexFileRewindPlanError,
+  type CodexFileRestorePlan,
   type CodexRewindPlan,
+  type CodexRewindSavepoint,
   type CodexRewindUserMessage,
 } from '../git-snapshot/codexFileRewindPlanner';
 import {
   executeCodexFileRewindPlanWithThreadRollback,
 } from '../git-snapshot/codexFileRewindExecutor';
+import {
+  executeCodexFileRestorePlanWithThreadRollback,
+} from '../git-snapshot/codexFileRestoreExecutor';
 import { enqueueGitRepoWrite } from '../git-snapshot/gitRepoWriteQueue';
-import { getCurrentBranch, getHead, listSnapshots } from '../git-snapshot/gitSnapshotService';
+import {
+  chunkPathspecArgs,
+  getCurrentBranch,
+  getHead,
+  listShadowSavepoints,
+  listSnapshots,
+  writeWorktreeTreeForPaths,
+  type SnapshotEntry,
+} from '../git-snapshot/gitSnapshotService';
 import { detectCwd } from '../worktree/WorktreeManager.js';
 import { gitExec } from '../worktree/gitExec';
 import {
@@ -380,6 +393,7 @@ export async function previewRewindAtMessage(
 }
 
 async function previewCodexFileRewindPlan(plan: CodexRewindPlan): Promise<RewindFilesResult> {
+  if (plan.mode === 'file-restore') return previewCodexFileRestorePlan(plan);
   if (plan.mode !== 'file-rewind') return { canRewind: true, filesChanged: [], insertions: 0, deletions: 0 };
   const files = new Set<string>(); let insertions = 0; let deletions = 0;
   for (const commit of plan.revertCommitsNewestFirst) {
@@ -393,13 +407,59 @@ async function previewCodexFileRewindPlan(plan: CodexRewindPlan): Promise<Rewind
   return { canRewind: true, filesChanged: [...files], insertions, deletions };
 }
 
+/**
+ * Restore preview: diff 当前工作区(受影响文件子集写成临时 tree)→ 目标基线树。
+ * 方向就是 rewind 将执行的方向,数字无需对调;经临时 tree 而非 commit-vs-worktree
+ * 的 diff,是为了把 untracked 新建文件的删除也计入。
+ */
+async function previewCodexFileRestorePlan(plan: CodexFileRestorePlan): Promise<RewindFilesResult> {
+  return enqueueGitRepoWrite(plan.repoRoot, async () => {
+    const affectedPaths = await collectRestoreAffectedPaths(plan);
+    if (affectedPaths.length === 0) {
+      return { canRewind: true, filesChanged: [], insertions: 0, deletions: 0 };
+    }
+    const affectedPathspecs = affectedPaths.map((p) => `:(literal)${p}`);
+    const worktreeTree = await writeWorktreeTreeForPaths(plan.repoRoot, affectedPaths);
+    const files = new Set<string>(); let insertions = 0; let deletions = 0;
+    for (const chunk of chunkPathspecArgs(affectedPathspecs)) {
+      const { stdout } = await gitExec(
+        ['diff', '--numstat', '--no-renames', '-z', worktreeTree, plan.baselineCommit, '--', ...chunk],
+        plan.repoRoot,
+      );
+      for (const record of stdout.split('\0')) {
+        const [added, deleted, file] = record.split('\t');
+        if (!file) continue;
+        files.add(file); insertions += parseNumstat(added); deletions += parseNumstat(deleted);
+      }
+    }
+    return { canRewind: true, filesChanged: [...files], insertions, deletions };
+  });
+}
+
+async function collectRestoreAffectedPaths(plan: CodexFileRestorePlan): Promise<string[]> {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const entry of plan.restoreCommitsNewestFirst) {
+    const { stdout } = await gitExec(
+      ['diff', '--name-only', '--no-renames', '-z', entry.baselineCommit, entry.commit],
+      plan.repoRoot,
+    );
+    for (const rawPath of stdout.split('\0')) {
+      if (!rawPath || seen.has(rawPath)) continue;
+      seen.add(rawPath);
+      out.push(rawPath);
+    }
+  }
+  return out;
+}
+
 function parseNumstat(value: string): number {
   const n = Number.parseInt(value, 10); return Number.isFinite(n) ? n : 0;
 }
 
 async function buildCodexFilePlanForSession(sessionId: string, targetMessageClientId: string, userMessages: readonly CodexRewindUserMessage[], makerSession: { workDir: string; remoteHostId?: string | null }) {
   try {
-    return buildCodexFileRewindPlan({ sessionId, targetMessageClientId, userMessages, repo: await loadCodexFileRewindRepoContext(makerSession) });
+    return buildCodexFileRewindPlan({ sessionId, targetMessageClientId, userMessages, repo: await loadCodexFileRewindRepoContext(makerSession, sessionId) });
   } catch (err) {
     if (err instanceof CodexFileRewindPlanError) {
       if (err.code === 'MESSAGE_NOT_FOUND') throw rewindError('MESSAGE_NOT_FOUND', err.message);
@@ -409,24 +469,53 @@ async function buildCodexFilePlanForSession(sessionId: string, targetMessageClie
   }
 }
 
-async function loadCodexFileRewindRepoContext(makerSession: { workDir: string; remoteHostId?: string | null }) {
+function toPlannerSavepoint(snapshot: SnapshotEntry): CodexRewindSavepoint {
+  return {
+    commit: snapshot.commit,
+    sessionId: snapshot.sessionId,
+    kind: snapshot.kind,
+    source: snapshot.source === 'cindy' ? 'shadow' : 'legacy',
+    branch: snapshot.branch ?? '',
+    parentCount: snapshot.parentCount,
+    ...(snapshot.anchor ? { anchor: snapshot.anchor } : {}),
+    ...(snapshot.label ? { label: snapshot.label } : {}),
+    ...(snapshot.baselineCommit ? { baselineCommit: snapshot.baselineCommit } : {}),
+  };
+}
+
+async function loadCodexFileRewindRepoContext(makerSession: { workDir: string; remoteHostId?: string | null }, sessionId: string) {
   if (makerSession.remoteHostId) return { kind: 'remote-session' as const };
   const cwd = await detectCwd(makerSession.workDir);
   if (!cwd.gitInstalled || !cwd.isGitRepo || !cwd.repoRoot || cwd.isInsideWorktree) return { kind: 'non-git-workdir' as const };
 
   const repoRoot = cwd.repoRoot;
   return enqueueGitRepoWrite(repoRoot, async () => {
-    const snapshots = await listSnapshots(repoRoot);
-    if (snapshots.length === 0) return { kind: 'local-git' as const, repoRoot, currentHead: '', currentBranch: '', savepointsNewestFirst: [] };
+    // 两个来源:隐藏引用链上的 shadow savepoint(新)+ 分支历史里的 legacy
+    // savepoint(旧版本写进用户分支的,升级后仍要可回退)。planner 分桶处理,
+    // 不要求两者之间有全局时间序。
+    const [shadowSnapshots, legacySnapshots] = await Promise.all([
+      listShadowSavepoints(repoRoot, sessionId),
+      listSnapshots(repoRoot),
+    ]);
+    const savepointsNewestFirst = [
+      ...shadowSnapshots.map(toPlannerSavepoint),
+      ...legacySnapshots.map(toPlannerSavepoint),
+    ];
+    if (savepointsNewestFirst.length === 0) return { kind: 'local-git' as const, repoRoot, currentHead: '', currentBranch: '', savepointsNewestFirst: [] };
 
-    const [currentHead, currentBranch] = await Promise.all([getHead(repoRoot), getCurrentBranch(repoRoot)]);
+    // unborn HEAD(空仓库首轮)下 shadow 链可能已存在;HEAD/branch 只影响 legacy
+    // 桶的过滤与展示,取不到就退化为空串。
+    const [currentHead, currentBranch] = await Promise.all([
+      getHead(repoRoot).catch(() => ''),
+      getCurrentBranch(repoRoot).catch(() => ''),
+    ]);
 
     return {
       kind: 'local-git' as const,
       repoRoot,
       currentHead,
       currentBranch,
-      savepointsNewestFirst: snapshots.map((snapshot) => ({ commit: snapshot.commit, sessionId: snapshot.sessionId, kind: snapshot.kind, branch: snapshot.branch ?? '', parentCount: snapshot.parentCount, ...(snapshot.anchor ? { anchor: snapshot.anchor } : {}), ...(snapshot.label ? { label: snapshot.label } : {}) })),
+      savepointsNewestFirst,
     };
   });
 }
@@ -468,17 +557,29 @@ export async function commitRewindAtMessage(
   let rewindResult: Awaited<ReturnType<typeof makerSession.commitRewindFiles>> | undefined;
   if (ctx.agentKind === 'codex' || ctx.agentKind === 'pi') {
     const filePlan = await buildCodexFilePlanForSession(sessionId, clientId, ctx.codexUserMessages ?? [], makerSession);
-    const result = await executeCodexFileRewindPlanWithThreadRollback(filePlan, sessionId, {
-      commitThreadRollback: () =>
-        makerSession.commitRewindFiles('', '', { tailTurnsToDrop: ctx.tailTurnsToDrop }),
-      onCompensationError: (compErr, execution) => {
-        log.error(`[rewind commit] ${ctx.agentKind} file rewind compensation failed`, {
-          sessionId,
-          rollbackCommit: execution.rollbackCommit,
-          error: compErr instanceof Error ? compErr.message : String(compErr),
-        });
-      },
-    });
+    const commitThreadRollback = () =>
+      makerSession.commitRewindFiles('', '', { tailTurnsToDrop: ctx.tailTurnsToDrop });
+    const logCompensationError = (compErr: unknown, rollbackCommit: string | null) => {
+      log.error(`[rewind commit] ${ctx.agentKind} file rewind compensation failed`, {
+        sessionId,
+        rollbackCommit,
+        error: compErr instanceof Error ? compErr.message : String(compErr),
+      });
+    };
+    // shadow 保存点走文件恢复执行器,legacy 保存点走原 revert 执行器;
+    // conversation-only 计划两个执行器都会直接透传 thread rollback。
+    const result =
+      filePlan.mode === 'file-restore'
+        ? await executeCodexFileRestorePlanWithThreadRollback(filePlan, sessionId, {
+            commitThreadRollback,
+            onCompensationError: (compErr, execution) =>
+              logCompensationError(compErr, execution.rollbackCommit),
+          })
+        : await executeCodexFileRewindPlanWithThreadRollback(filePlan, sessionId, {
+            commitThreadRollback,
+            onCompensationError: (compErr, execution) =>
+              logCompensationError(compErr, execution.rollbackCommit),
+          });
     rewindResult = result.threadRollback;
   } else if (ctx.userUuid) {
     rewindResult = await makerSession.commitRewindFiles(ctx.userUuid, ctx.assistantUuid!);

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1640,7 +1640,7 @@
     "gitSafety": {
       "title": "Git Safety",
       "autoSnapshotTitle": "Git safety snapshots",
-      "description": "Create automatic savepoint commits after agent edits. Codex rewind is shown only when this is enabled.",
+      "description": "Automatically record hidden savepoints in the project's Git repository after agent edits — no commits are added to your branch. Codex rewind is shown only when this is enabled.",
       "toggleAria": "Toggle Git safety snapshots",
       "saveFailed": "Failed to save Git safety setting"
     },

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1639,7 +1639,7 @@
     "gitSafety": {
       "title": "Git セーフティ",
       "autoSnapshotTitle": "Git セーフティ保存点",
-      "description": "Agent の編集後に保存点 commit を自動作成します。有効な場合のみ Codex rewind を表示します。",
+      "description": "Agent の編集後にプロジェクトの Git リポジトリへ隠し保存点を自動記録します。ブランチに commit は追加されません。有効な場合のみ Codex rewind を表示します。",
       "toggleAria": "Git セーフティ保存点を切り替え",
       "saveFailed": "Git セーフティ設定の保存に失敗しました"
     },

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1639,7 +1639,7 @@
     "gitSafety": {
       "title": "Git 안전",
       "autoSnapshotTitle": "Git 안전 저장점",
-      "description": "Agent 편집 후 저장점 commit을 자동으로 만듭니다. 켜져 있을 때만 Codex rewind를 표시합니다.",
+      "description": "Agent 편집 후 프로젝트 Git 저장소에 숨겨진 저장점을 자동으로 기록합니다. 브랜치에 commit이 추가되지 않습니다. 켜져 있을 때만 Codex rewind를 표시합니다.",
       "toggleAria": "Git 안전 저장점 전환",
       "saveFailed": "Git 안전 설정 저장에 실패했습니다"
     },

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1639,7 +1639,7 @@
     "gitSafety": {
       "title": "Git 安全",
       "autoSnapshotTitle": "Git 安全保存点",
-      "description": "Agent 修改后自动创建保存点 commit。只有开启后才显示 Codex rewind 入口。",
+      "description": "Agent 修改后自动在项目 Git 仓库里记录隐藏保存点，不会在你的分支上产生 commit。只有开启后才显示 Codex rewind 入口。",
       "toggleAria": "切换 Git 安全保存点",
       "saveFailed": "保存 Git 安全设置失败"
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

「Git 安全保存点」原实现把自动保存点作为真实 `git commit` 提交到用户当前分支:开启开关后,Agent 每轮修改都会推进用户分支的 HEAD,把 `main` 等分支历史弄脏(实际事故:本仓维护者的本地 `main` 被两个自动保存点提交污染,无法快进同步)。

本 PR 把保存点改为 **shadow savepoint**:保存点 commit 仍写入项目自己的 `.git` 对象库(复用 Git 的去重、diff、恢复能力),但只挂在 `refs/cindy/savepoints/<sessionId>` 隐藏引用下,全程用 plumbing(临时 index → `write-tree` → `commit-tree` → `update-ref` CAS)构建——**HEAD、分支历史、`git log`、`git status`、用户 index 从此不被自动保存点改动**。该架构与 Cline / Docker Agent 等业界 checkpoint 方案同型(shadow 存储 + 文件恢复),Claude Code 的 SDK 原生 checkpoint 路径不受影响。

关键设计:

- **写侧**:turn-start 无条件记录全量工作区基线(clean 也建,统一恢复基准);turn-end 以「tree 相等性」判断本轮是否有改动(工作区现在长期 dirty,基于 `git status` 的判据已失效),有改动才建 after-edit,trailer `X-Cindy-Baseline` 显式指向本轮基线(兼容同 session 重叠 turn,不依赖链上父子顺序)。基线缺失/失败时在链上补 `rewind-blocked` gap 标记(codex/pi)。
- **读侧(文件回退)**:计划三态。旧格式保存点(`X-XDT-*`、分支上的 commit)仍走原 `git revert` 执行器;shadow 保存点走新 **file-restore** 执行器——不要求 clean worktree、不向用户分支写任何 commit:先在链上建 pre-rollback 全量快照(补偿/撤销锚点),再把受影响文件(被回退各轮 baseline→after diff 的并集)恢复为目标 turn-start 树(含删除本轮新建文件、重建被删文件),对话回退失败自动按同一文件集补偿。新旧混合区间(升级窗口)降级为 conversation-only。
- **清理**:启动期对账是链 ref 的唯一删除驱动(owning session 已删除或行缺失才清;归档保留——归档可恢复,恢复后回退仍可用)。刻意不做会话删除时的即时清理:覆盖导入等流程会把旧会话瞬态置为 deleted、失败后回滚恢复,status 触发的 ref 删除与回滚竞态且不可逆;启动期不存在进行中的瞬态软删流程。v1 不主动 `git gc`(删 ref 后对象不可达,由用户仓库自身回收;后续增强再考虑)。
- **文案**:设置项描述从「自动创建保存点 commit」改为「记录隐藏保存点,不会在你的分支上产生 commit」(四语言)。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:本地 `main` 被自动保存点提交污染的实报(维护者本机复现)
- 本 PR 包含:shadow savepoint 写入内核与隐藏引用管理、coordinator turn 语义切换、回退计划三态与 file-restore 执行器、preview 适配、启动期 ref 对账清理、设置描述文案、全部配套测试
- 明确不包含:`git gc` / 链内裁剪等磁盘回收增强;`UserMessage.tsx` 中 pi 回退入口未被 Git safety 开关 gate 的存量不一致(与本改动无关的既有行为);projectGitBootstrap 的空项目初始化 commit(那是给用户建仓的第一个真实 commit,语义正确,保留)
- 用户可见变化:①开启开关后,Agent 修改不再在用户分支上产生任何 commit,工作区改动保持为普通未提交状态;②回退不再要求先 stash/提交无关改动(shadow 保存点区间),且不再产生 rollback commit;③设置项描述文案更新
- 是否存在 breaking change:无。设置 key(`autoSnapshotEnabled`)、settings 文件、IPC channel(`maker:git-safety:*`、`maker:rewind:*`)、device-link allowlist、`RewindFilesResult` 结构全部不变;升级前已写到分支上的旧保存点仍可回退(保留完整 legacy revert 路径与其回归测试);无数据库 migration,用户无需任何重新配置

### UI 变化

仅设置页「Git 安全」描述文案更新(四语言),无视觉/交互变化,无新增组件或样式,Light/Dark 不受影响。

- 引用的设计规范:不涉及视觉/布局改动;文案遵循 `i18n/GLOSSARY.md` 术语裁决与全角标点规则,`pnpm check:i18n-glossary` 通过(32 条已裁决无新增违规)

## 怎么验证的

### 自动验证

- `bash run-unit-gate.sh <worktree>`(仓库根 `pnpm test:unit` 全量单测)→ **GATE_EXIT=0**
- `node scripts/test-workspaces.mjs --tier git-integration` → **PASS apps/desktop git-integration**(含本 PR 新增的 20 个真实 git 仓库用例)
- `pnpm --filter desktop typecheck` → 通过(注:本机默认 4GB 堆下 tsc OOM,`--max-old-space-size=8192` 后干净通过,与本改动无关)
- `pnpm check:i18n-glossary` → 通过;`pnpm check:dco` → 通过

新增/迁移的测试(全部真实跑过):

- `gitSnapshotShadow.git-integration.test.ts`(新,14 例):核心不变量——保存点前后 HEAD/分支/`git status`/`git diff --cached` 逐字节不变;链式 parent 与 CAS;`skipIfTreeEquals`;unborn HEAD;敏感/超限文件不入树;跨 session/跨代际不串台;非法 sessionId 拒绝
- `codexFileRestoreExecutor.git-integration.test.ts`(新,6 例):恢复修改/重建被删/删除新建(含 untracked 与空目录);dirty worktree 不拒绝且无关改动保留;pre-rollback tree=执行前工作区;thread rollback 失败自动补偿;merge 进行中拒绝;写锁时序
- `savepointCleanup.test.ts`(新,14 例):deleted 删 ref、archived/active 保留、DB 失败整体跳过等
- `gitSnapshotCoordinator.test.ts`(21 例)/`gitSnapshotHost.test.ts`(5 例)/`codexFileRewindPlanner.test.ts`(24 例)/`gitSnapshotTrailers.test.ts`(18 例)/`rewind.test.ts`(29 例):按新语义迁移并新增 shadow 分桶、三态分发、mixed/gap fallback、preview 数字方向等用例
- `codexFileRewindExecutor.git-integration.test.ts` 与 `gitSnapshotService.git-integration.test.ts` **零改动原样通过**(legacy 回退与旧格式解析的回归门禁)

### 手动验证

- 用临时仓库对整套 plumbing 语义做了脚本冒烟(HEAD/status 不变、隐藏链可 log、`git restore --source` 恢复、删除新建文件),并据此修掉一个真实 bug:`git add -- <path>` 对「已删除且不在 HEAD」的路径会 fatal,`writeWorktreeTreeForPaths` 改用 `update-index --add/--force-remove`
- 未做实机 App 内端到端目检(worktree 会话无法重启宿主 dev 实例);行为核心均有真实 git 仓库集成测试覆盖

## 风险

- **行为变化(预期内)**:①Agent 修改后工作区保持 dirty,不再被自动 commit「隐藏」——`git status` 从此反映真实状态,这是本次改造的目标本身;②旧格式保存点区间的回退仍要求 clean worktree(保留原语义),升级后新常态是 dirty,用户对旧区间回退会更常见到「请先提交或 stash」提示,属过渡期现象
- **turn-start 失败窗口**:极端情况下(git 全程不可用)gap 标记也可能失败,该轮文件回退按 no-savepoints 降级为仅对话回退,不会误恢复
- **`.git` 对象增长**:保存点对象随 turn 数线性增长(同内容 tree/blob 天然去重,单文件 >10MB 不入快照);session 删除与启动期对账会删 ref 使对象可回收,主动 gc 留作后续增强
- **跨进程并发**:同 repo 的保存点/回退写操作在进程内经 `enqueueGitRepoWrite` 串行;跨进程由 `update-ref` CAS 兜底,失败按保存点失败吞掉(与现有 swallow 语义一致)
- 无 SQLite migration、无 system prompt 改动、无协议/wire 变化;Windows 路径已走既有 `resolveSnapshotGitPath` 防逃逸与 `:(literal)` pathspec 约定

## Self-review Checklist

- [x] 改动保持单一目标,无无关修改混入
- [x] 已阅读并遵循相关 `docs/dev-rules/` 规则(media/credentials 不涉及;架构不变量:未新增 package 依赖方向变化)
- [x] 本地跑过与风险匹配的验证(全量单测 + git-integration + typecheck + 术语门禁)
- [x] 向下兼容已验证:旧保存点回退回归测试零改动通过;设置/IPC/协议面零变化
- [x] 测试未被跳过、删除或弱化(legacy 回归测试原样保留)
- [x] commit 带 DCO 签名(`pnpm check:dco` 通过)

