### PR TITLE
fix(mobile): bound Home startup cache reads

### DIFF
--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -518,7 +518,8 @@ export default function HomeScreen() {
       getCachedHomeListSnapshot(homeCacheUserId),
       [],
     );
-    const applySnapshot = (snapshot: Awaited<ReturnType<typeof getCachedHomeListSnapshot>>) => {
+    const applySnapshot = async (snapshot: Awaited<ReturnType<typeof getCachedHomeListSnapshot>>) => {
+      await syncInFlightRef.current;
       if (cancelled || lastSyncedAtRef.current !== null) return;
       for (const device of snapshot) {
         remoteSessionStore.hydrateDeviceSessionsIfEmpty(device.deviceId, device.deviceName, device.sessions);
@@ -527,9 +528,9 @@ export default function HomeScreen() {
     };
     void read.initial
       .then((initial) => {
-        applySnapshot(initial.value);
+        void applySnapshot(initial.value);
         if (initial.timedOut) void read.completion.then((late) => {
-          if (late.ok) applySnapshot(late.value);
+          if (late.ok) void applySnapshot(late.value);
         });
       })
       .catch(() => undefined)

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -199,6 +199,7 @@ export default function HomeScreen() {
   // A timed-out SecureStore read may still complete. Do not persist an empty/rebuilt
   // cache until that read settles and its stored identities have been reapplied.
   const deviceIdentityCachePersistReadyRef = useRef(false);
+  const deviceIdentityCachePersistPendingRef = useRef(false);
   // presence 补丁新鲜度:loadHome 用它判断哪些设备在 REST 快照发起后又收到过 presence-changed,
   // 避免用过期快照把它们改回离线(否则出现「会话都同步出来了、新建对话按钮却灰着」的卡死态)。
   const presenceFreshnessRef = useRef(createPresenceFreshnessTracker());
@@ -271,8 +272,9 @@ export default function HomeScreen() {
   const reconcileDeviceViews = useCallback((nextRawDevices: readonly DeviceView[]) => {
     const result = reconcileDeviceIdentities(nextRawDevices, deviceIdentityCacheRef.current);
     deviceIdentityCacheRef.current = result.cache;
-    if (result.cacheChanged && deviceIdentityCachePersistReadyRef.current) {
-      void saveDeviceIdentityCache(result.cache);
+    if (result.cacheChanged) {
+      if (deviceIdentityCachePersistReadyRef.current) void saveDeviceIdentityCache(result.cache);
+      else deviceIdentityCachePersistPendingRef.current = true;
     }
     return result;
   }, []);
@@ -516,13 +518,19 @@ export default function HomeScreen() {
       getCachedHomeListSnapshot(homeCacheUserId),
       [],
     );
+    const applySnapshot = (snapshot: Awaited<ReturnType<typeof getCachedHomeListSnapshot>>) => {
+      if (cancelled || lastSyncedAtRef.current !== null) return;
+      for (const device of snapshot) {
+        remoteSessionStore.hydrateDeviceSessionsIfEmpty(device.deviceId, device.deviceName, device.sessions);
+        updateDeviceConnectionState(device.deviceId, 'syncing');
+      }
+    };
     void read.initial
-      .then(({ value: snapshot }) => {
-        if (cancelled || lastSyncedAtRef.current !== null) return;
-        for (const device of snapshot) {
-          remoteSessionStore.hydrateDeviceSessionsIfEmpty(device.deviceId, device.deviceName, device.sessions);
-          updateDeviceConnectionState(device.deviceId, 'syncing');
-        }
+      .then((initial) => {
+        applySnapshot(initial.value);
+        if (initial.timedOut) void read.completion.then((late) => {
+          if (late.ok) applySnapshot(late.value);
+        });
       })
       .catch(() => undefined)
       .finally(() => {
@@ -551,16 +559,15 @@ export default function HomeScreen() {
         if (cancelled) return;
         if (late.ok) {
           deviceIdentityCacheRef.current = late.value;
+          deviceIdentityCachePersistReadyRef.current = true;
           const reconciled = reconcileDeviceViews(devicesRef.current);
           devicesRef.current = reconciled.devices;
           if (reconciled.viewsChanged) setDevices(reconciled.devices);
-          deviceIdentityCachePersistReadyRef.current = true;
-          if (reconciled.cacheChanged) void saveDeviceIdentityCache(reconciled.cache);
           return;
         }
 
         deviceIdentityCachePersistReadyRef.current = true;
-        void saveDeviceIdentityCache(deviceIdentityCacheRef.current);
+        if (deviceIdentityCachePersistPendingRef.current) void saveDeviceIdentityCache(deviceIdentityCacheRef.current);
       });
     return () => {
       cancelled = true;

--- a/apps/mobile/app/devices/index.tsx
+++ b/apps/mobile/app/devices/index.tsx
@@ -97,6 +97,7 @@ import {
   getCachedHomeListSnapshot,
   scheduleHomeListSnapshotPersist,
 } from '@/session/mobileHomeListCache';
+import { startBoundedStartupRead } from '@/session/mobileHomeStartup';
 import { serializeNewSessionDeviceOptions } from '@/session/newSession';
 import {
   buildRemoteSessionCardPreview,
@@ -195,6 +196,9 @@ export default function HomeScreen() {
   const scheduleIndexDeferRegistryRef = useRef(createScheduleIndexDeferRegistry());
   const scheduleEventVersionsRef = useRef(new Map<string, number>());
   const deviceIdentityCacheRef = useRef(createEmptyDeviceIdentityCache());
+  // A timed-out SecureStore read may still complete. Do not persist an empty/rebuilt
+  // cache until that read settles and its stored identities have been reapplied.
+  const deviceIdentityCachePersistReadyRef = useRef(false);
   // presence 补丁新鲜度:loadHome 用它判断哪些设备在 REST 快照发起后又收到过 presence-changed,
   // 避免用过期快照把它们改回离线(否则出现「会话都同步出来了、新建对话按钮却灰着」的卡死态)。
   const presenceFreshnessRef = useRef(createPresenceFreshnessTracker());
@@ -267,7 +271,9 @@ export default function HomeScreen() {
   const reconcileDeviceViews = useCallback((nextRawDevices: readonly DeviceView[]) => {
     const result = reconcileDeviceIdentities(nextRawDevices, deviceIdentityCacheRef.current);
     deviceIdentityCacheRef.current = result.cache;
-    if (result.cacheChanged) void saveDeviceIdentityCache(result.cache);
+    if (result.cacheChanged && deviceIdentityCachePersistReadyRef.current) {
+      void saveDeviceIdentityCache(result.cache);
+    }
     return result;
   }, []);
 
@@ -506,8 +512,12 @@ export default function HomeScreen() {
       return;
     }
     let cancelled = false;
-    void getCachedHomeListSnapshot(homeCacheUserId)
-      .then((snapshot) => {
+    const read = startBoundedStartupRead(
+      getCachedHomeListSnapshot(homeCacheUserId),
+      [],
+    );
+    void read.initial
+      .then(({ value: snapshot }) => {
         if (cancelled || lastSyncedAtRef.current !== null) return;
         for (const device of snapshot) {
           remoteSessionStore.hydrateDeviceSessionsIfEmpty(device.deviceId, device.deviceName, device.sessions);
@@ -525,18 +535,37 @@ export default function HomeScreen() {
 
   useEffect(() => {
     let cancelled = false;
-    void loadDeviceIdentityCache()
-      .then((cache) => {
+    const read = startBoundedStartupRead(
+      loadDeviceIdentityCache(),
+      createEmptyDeviceIdentityCache(),
+    );
+    void read.initial
+      .then(async (initial) => {
         if (cancelled) return;
-        deviceIdentityCacheRef.current = cache;
-      })
-      .finally(() => {
-        if (!cancelled) setDeviceIdentityCacheReady(true);
+        deviceIdentityCacheRef.current = initial.value;
+        deviceIdentityCachePersistReadyRef.current = !initial.timedOut;
+        setDeviceIdentityCacheReady(true);
+        if (!initial.timedOut) return;
+
+        const late = await read.completion;
+        if (cancelled) return;
+        if (late.ok) {
+          deviceIdentityCacheRef.current = late.value;
+          const reconciled = reconcileDeviceViews(devicesRef.current);
+          devicesRef.current = reconciled.devices;
+          if (reconciled.viewsChanged) setDevices(reconciled.devices);
+          deviceIdentityCachePersistReadyRef.current = true;
+          if (reconciled.cacheChanged) void saveDeviceIdentityCache(reconciled.cache);
+          return;
+        }
+
+        deviceIdentityCachePersistReadyRef.current = true;
+        void saveDeviceIdentityCache(deviceIdentityCacheRef.current);
       });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reconcileDeviceViews]);
 
   // 冷启动恢复上次的首页视图偏好(设备筛选 + 按项目分组);用户已手动操作过则不覆盖。
   useEffect(() => {

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -1,11 +1,55 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { i18n } from '@/i18n';
+import { startBoundedStartupRead } from '@/session/mobileHomeStartup';
 
 function readSource(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), 'utf8').replace(/\r\n/g, '\n');
 }
+
+describe('mobile Home startup reads', () => {
+  it('returns the local value when the read settles in time', async () => {
+    const read = startBoundedStartupRead(Promise.resolve('cached'), 'fallback', 100);
+
+    await expect(
+      read.initial,
+    ).resolves.toEqual({ timedOut: false, value: 'cached' });
+  });
+
+  it('falls back on read failure', async () => {
+    const read = startBoundedStartupRead(
+      Promise.reject(new Error('read failed')),
+      'fallback',
+      100,
+    );
+
+    await expect(
+      read.initial,
+    ).resolves.toEqual({ timedOut: false, value: 'fallback' });
+    await expect(read.completion).resolves.toEqual({ ok: false, value: 'fallback' });
+  });
+
+  it('falls back on timeout while preserving a late local value', async () => {
+    vi.useFakeTimers();
+    try {
+      let finishRead: ((value: string) => void) | undefined;
+      const pendingRead = new Promise<string>((resolveRead) => {
+        finishRead = resolveRead;
+      });
+      const read = startBoundedStartupRead(pendingRead, 'fallback', 100);
+
+      await vi.advanceTimersByTimeAsync(100);
+      await expect(read.initial).resolves.toEqual({ timedOut: true, value: 'fallback' });
+
+      finishRead?.('late-cache');
+      await Promise.resolve();
+      await expect(read.completion).resolves.toEqual({ ok: true, value: 'late-cache' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
 
 describe('mobile home desktop-first surface', () => {
   it('uses the desktop-sidebar Home as the authenticated root instead of a device picker route', () => {
@@ -341,6 +385,12 @@ describe('mobile home desktop-first surface', () => {
     const source = readSource('app/devices/index.tsx');
 
     expect(source).toContain('void loadHome({ visible: false });');
+    expect(source).toMatch(/startBoundedStartupRead\(\s*getCachedHomeListSnapshot\(homeCacheUserId\)/);
+    expect(source).toMatch(/startBoundedStartupRead\(\s*loadDeviceIdentityCache\(\)/);
+    expect(source).toContain('const deviceIdentityCachePersistReadyRef = useRef(false);');
+    expect(source).toContain('const late = await read.completion;');
+    expect(source).toContain('deviceIdentityCacheRef.current = late.value;');
+    expect(source).toContain('if (result.cacheChanged && deviceIdentityCachePersistReadyRef.current)');
     // 重连(connectionEpoch 变化)必须无条件全量刷新:presence 只在变化时广播、无全量重放,
     // 后台漏掉的上/下线事件只能靠重连重拉 REST 快照兜底,不能再用 hydrated 标记门控挡掉。
     // homeListCacheHydrated 是一次性 gate(缓存种入完成后永久为 true,种入失败也置 true),

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -12,17 +12,11 @@ describe('mobile Home startup reads', () => {
   it('returns the local value when the read settles in time', async () => {
     const read = startBoundedStartupRead(Promise.resolve('cached'), 'fallback', 100);
 
-    await expect(
-      read.initial,
-    ).resolves.toEqual({ timedOut: false, value: 'cached' });
+    await expect(read.initial).resolves.toEqual({ timedOut: false, value: 'cached' });
   });
 
   it('falls back on read failure', async () => {
-    const read = startBoundedStartupRead(
-      Promise.reject(new Error('read failed')),
-      'fallback',
-      100,
-    );
+    const read = startBoundedStartupRead(Promise.reject(new Error('read failed')), 'fallback', 100);
 
     await expect(
       read.initial,
@@ -386,11 +380,10 @@ describe('mobile home desktop-first surface', () => {
 
     expect(source).toContain('void loadHome({ visible: false });');
     expect(source).toMatch(/startBoundedStartupRead\(\s*getCachedHomeListSnapshot\(homeCacheUserId\)/);
+    expect(source).toContain('if (late.ok) applySnapshot(late.value);');
     expect(source).toMatch(/startBoundedStartupRead\(\s*loadDeviceIdentityCache\(\)/);
-    expect(source).toContain('const deviceIdentityCachePersistReadyRef = useRef(false);');
-    expect(source).toContain('const late = await read.completion;');
-    expect(source).toContain('deviceIdentityCacheRef.current = late.value;');
-    expect(source).toContain('if (result.cacheChanged && deviceIdentityCachePersistReadyRef.current)');
+    expect(source).toContain('const deviceIdentityCachePersistPendingRef = useRef(false);');
+    expect(source).toContain('if (result.cacheChanged)');
     // 重连(connectionEpoch 变化)必须无条件全量刷新:presence 只在变化时广播、无全量重放,
     // 后台漏掉的上/下线事件只能靠重连重拉 REST 快照兜底,不能再用 hydrated 标记门控挡掉。
     // homeListCacheHydrated 是一次性 gate(缓存种入完成后永久为 true,种入失败也置 true),

--- a/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/homeDesktopFirst.test.ts
@@ -380,10 +380,9 @@ describe('mobile home desktop-first surface', () => {
 
     expect(source).toContain('void loadHome({ visible: false });');
     expect(source).toMatch(/startBoundedStartupRead\(\s*getCachedHomeListSnapshot\(homeCacheUserId\)/);
-    expect(source).toContain('if (late.ok) applySnapshot(late.value);');
+    expect(source).toContain('await syncInFlightRef.current;');
     expect(source).toMatch(/startBoundedStartupRead\(\s*loadDeviceIdentityCache\(\)/);
     expect(source).toContain('const deviceIdentityCachePersistPendingRef = useRef(false);');
-    expect(source).toContain('if (result.cacheChanged)');
     // 重连(connectionEpoch 变化)必须无条件全量刷新:presence 只在变化时广播、无全量重放,
     // 后台漏掉的上/下线事件只能靠重连重拉 REST 快照兜底,不能再用 hydrated 标记门控挡掉。
     // homeListCacheHydrated 是一次性 gate(缓存种入完成后永久为 true,种入失败也置 true),

--- a/apps/mobile/src/session/mobileHomeStartup.ts
+++ b/apps/mobile/src/session/mobileHomeStartup.ts
@@ -1,0 +1,29 @@
+export const HOME_STARTUP_LOCAL_READ_TIMEOUT_MS = 2_000;
+
+/**
+ * Bounds best-effort local reads that must not block the first remote Home sync.
+ * The native operation is left alone after timeout and remains available through
+ * completion so callers can safely reconcile a late value.
+ */
+export function startBoundedStartupRead<T>(
+  operation: PromiseLike<T>,
+  fallback: T,
+  timeoutMs: number = HOME_STARTUP_LOCAL_READ_TIMEOUT_MS,
+) {
+  const completion = Promise.resolve(operation)
+    .then((value) => ({ ok: true as const, value }))
+    .catch(() => ({ ok: false as const, value: fallback }));
+  const initial = new Promise<{ timedOut: boolean; value: T }>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (result: { timedOut: boolean; value: T }) => {
+      if (settled) return;
+      settled = true;
+      if (timer !== undefined) clearTimeout(timer);
+      resolve(result);
+    };
+    timer = setTimeout(() => finish({ timedOut: true, value: fallback }), timeoutMs);
+    void completion.then((result) => finish({ timedOut: false, value: result.value }));
+  });
+  return { completion, initial };
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

Bound Mobile Home startup cache reads. Late Home snapshots wait for the current remote sync and are used only if that sync does not succeed. Failed identity reads no longer overwrite storage unless the fallback cache changed.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #1434
- Included: Bound Home cache reads, gate late Home snapshots against remote sync, apply late identities, and defer identity-cache writes safely.
- Not included: UI, protocol, native dependency, fingerprint, or server changes.
- User-visible change: Home can start remote sync while local storage is slow and still recover saved data after a failed sync.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: JavaScript-only startup logic. No native or runtime fingerprint change.

### UI 变化

Not applicable. Layout, interaction, styling, and copy are unchanged.

- 引用的设计规范：不涉及：Startup logic only; no visual, interaction, or copy changes.

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/homeDesktopFirst.test.ts
Result: 15 passed.

pnpm --filter mobile run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed for all three commits.

pnpm test:unit
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

No device run. Automated tests cover timeout and late-cache behavior; native and visual code are unchanged.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Mobile Home startup cache hydration and identity-cache persistence timing.
- Rollback: Revert all three commits. No migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
