### PR TITLE
fix(desktop): carry the typecheck heap ceiling in the script itself

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -26,7 +26,7 @@
     "gen:help-kb": "node scripts/gen-help-kb.mjs",
     "gen:help-kb:check": "node scripts/help-kb-guard.mjs",
     "lint": "eslint src/",
-    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "typecheck": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit -p tsconfig.json",
     "format": "prettier --write src/",
     "ensure-deps": "node ../../scripts/ensure-deps.mjs",
     "ensure-dev-runtime-assets": "node ../../scripts/ensure-dev-runtime-assets.mjs",


### PR DESCRIPTION
## 这次改了什么

### 摘要

`apps/desktop` 的 typecheck 峰值内存已超过 Node 默认堆上限（`ci.yml` 自己记录了这一点）。围绕这个上限有两处不一致，本 PR 把它收敛到一个真源。

**1. 本地脚本没有堆设置，而它是 AGENTS.md 的硬性提交门禁。** 按文档执行会直接崩：

```text
> tsc --noEmit -p tsconfig.json
[370:0x110008000] 56724 ms: Mark-Compact 4041.3 (4136.0) -> 4028.4 (4138.8) MB
  allocation failure; scavenge might not succeed
FATAL ERROR: Ineffective mark-compacts near heap limit
ELIFECYCLE  Command failed with signal "SIGABRT"   # exit 134
```

macOS 15 / arm64、**32 GB 物理内存**、Node 22.22.3（`.nvmrc`）。不是机器内存不足 —— Node 的上限与物理内存无关（`v8.getHeapStatistics().heap_size_limit` = 4288 MB），上面的峰值正贴着它。即 CI 绕过了这个上限，本地没有。

**2. CI 的步骤级覆盖把 #1403 的意图抵消了。** 按提交顺序：

| 时间 | commit | 动作 |
|---|---|---|
| 08-03 00:50 | `45cbd39f` | 给 `Typecheck desktop` 加 step 级 `NODE_OPTIONS: 6144`（当时 workflow 级是 `4096`，6144 确实更大，与其注释一致） |
| 08-03 02:10 | `ca09428a` (#1403) | 标题「verify 的 **Typecheck desktop 步骤** heap 提升到 8GB」，但只把 workflow 级改成 `8192`，未动 step 级覆盖 |

GitHub Actions 中 step 级 `env` 覆盖 workflow 级，所以那一步实际仍跑在 **6144** —— #1403 唯一想抬的步骤是唯一没被抬到的，而其它不需要 8GB 的步骤都拿到了。step 注释也自相矛盾（写着「这一步单独给更大的堆」，而 6144 < 8192）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #1559
- 本 PR 包含（1 文件，+1/−1）：
  - `apps/desktop/package.json`：堆上限写进 typecheck script 本身，用已有的 `cross-env`（devDependency `^7.0.3`，`dev:inspect` / `test:db-proxy-perf` 已在用）→ Windows 安全、**不新增依赖**、本地与 CI 同值。
- 明确**不**包含 `.github/workflows/ci.yml` 的清理：推送 `.github/workflows/**` 需要 `workflow` OAuth scope，本贡献者 token 没有。见下方「关于 CI 的那一半」。
- 明确不包含：不动 `tsconfig.json`、不试图降低类型规模（`ci.yml` 原注释已记录排查过单点热点：移走最大测试文件只省 ~5MB、移走 1400 行插件页组件只省 ~14MB，`skipLibCheck` 早已开启 —— 是整仓类型规模的自然结果）；不动 mobile typecheck。
- 用户可见变化：无（仅开发者工具链）
- 是否存在 breaking change：无

### 关于 CI 的那一半

`cross-env` 是给 tsc 子进程**设置** `NODE_OPTIONS`，因此也会覆盖该步骤继承到的值。副作用是它顺带纠正了上面第 2 点：脚本里的 8192 会盖掉 step 级的 6144，所以 CI 的 `Typecheck desktop` 从此按 8192 跑（这本就是 #1403 的既定意图）。

也就是说 **本 PR 单独就修好了本地与 CI 两侧**；`ci.yml` 里那个 step 级覆盖变成死配置，删掉属于清理。清理没放进本 PR：推送 workflow 文件需要 `workflow` scope，我的 token 没有。建议的删法写在 #1559 里，有权限的人可以顺手带走 —— 或者留着也不影响正确性，只是容易在下次调整时再制造一次数值打架。

### 关于取值

脚本里用 `8192`，与 `ci.yml` workflow 级已记录的数字一致。实测峰值约 4.2 GB，`6144` 也够用；`8192` 只是上限不是预留，Node 按需增长，所以低内存开发机不会因此多占内存。若维护者倾向更保守，改成 `6144` 即可，我可以直接调。

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

关键验证是**不带任何外部 `NODE_OPTIONS`** 跑一次，直接对应贡献者按 AGENTS.md 执行的场景：

```text
$ unset NODE_OPTIONS
$ pnpm --filter desktop run --if-present typecheck
> cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit -p tsconfig.json
exit=0    (~48s)
```

同一台机器上，改动前同一条命令是 `exit 134` / SIGABRT（见上方摘要里的堆日志）。

```text
pnpm test:unit
结果：56 workspaces PASS，0 FAIL（exit 0）
```

改动前后 script 的实际展开（`pnpm` 会回显）：

```text
改动前： > tsc --noEmit -p tsconfig.json                                            -> exit 134 (SIGABRT)
改动后： > cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc --noEmit -p ...     -> exit 0
```

### 手工验证

不涉及。

### 未执行的验证

- `apps/mobile` 的 typecheck 未测，不清楚它是否也接近默认上限。它没有 step 级覆盖、仍跑在 workflow 级值下，本 PR 不影响它。
- 没有观测某次真实 CI run 内该步骤的实际 `NODE_OPTIONS` 取值。第 2 点是依据 GitHub Actions 已文档化的 env 优先级（step > job > workflow）与提交历史推断得出。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅开发者工具链（一个 npm script，1 行）。不改任何产品代码、类型定义或 CI 配置。
  - 本地侧净效果：由必然 OOM 变为可通过。
  - CI 侧净效果：`Typecheck desktop` 由实际 6144 变为脚本携带的 8192（本就是 #1403 的既定意图），其余步骤不受影响 —— 因为 `cross-env` 只作用于该 script 启动的 tsc 子进程。
- 回滚 / 降级方式：revert 本 PR 即可。回滚后本地恢复为无堆参数（即重新回到 OOM 状态），CI 恢复为 step 级 6144。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
