### PR TITLE
fix(desktop): 冷启动同步默认插件

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -2578,16 +2578,18 @@ const createWindow = () => {
 let disposeSkillhubAutoSyncAuthListener: (() => void) | null = null;
 let disposeProviderAccessAuthListener: (() => void) | null = null;
 let disposePluginMarketAuthListener: (() => void) | null = null;
-let lastDefaultPluginSyncScope: string | null = null;
+let defaultPluginSyncInFlightScope: string | null = null;
 
 /** Run the existing market reconciliation once for each stable app owner. */
 function syncDefaultPluginsForActiveOwner(): void {
   const session = getActiveAppSession();
   if (!session.dataOwnerId || isAppSessionBoundaryPending()) return;
   const scope = activeOwnerScopeKey();
-  if (scope === lastDefaultPluginSyncScope) return;
-  lastDefaultPluginSyncScope = scope;
-  void syncDefaultMarketPlugins();
+  if (scope === defaultPluginSyncInFlightScope) return;
+  defaultPluginSyncInFlightScope = scope;
+  void syncDefaultMarketPlugins().finally(() => {
+    if (defaultPluginSyncInFlightScope === scope) defaultPluginSyncInFlightScope = null;
+  });
 }
 
 const registerIpcHandlers = () => {

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -656,7 +656,10 @@ import { listActiveClaudeBackgroundActivitySessions } from './maker-host/claude-
 import { registerRelaunchBusyActivityIpc } from './relaunchBusyActivityIpc.js';
 import { getGhostSetupChangeBus } from './cindy-brain/ghostSetupChangeBus.js';
 import { getGhostSetupInteractionBridge } from './cindy-brain/ghostSetupInteractionBridge.js';
-import { registerPluginMarketIpc } from './plugin-market/registerIpc.js';
+import {
+  registerPluginMarketIpc,
+  syncDefaultMarketPlugins,
+} from './plugin-market/registerIpc.js';
 import { findCindyFileInArgv } from './cindy-brain/argv.js';
 import { handleIncomingCindyFile } from './cindy-brain/openFileInstall.js';
 import { registerCindyFileAssociation } from './cindy-brain/fileAssociation.js';
@@ -2574,6 +2577,18 @@ const createWindow = () => {
 
 let disposeSkillhubAutoSyncAuthListener: (() => void) | null = null;
 let disposeProviderAccessAuthListener: (() => void) | null = null;
+let disposePluginMarketAuthListener: (() => void) | null = null;
+let lastDefaultPluginSyncScope: string | null = null;
+
+/** Run the existing market reconciliation once for each stable app owner. */
+function syncDefaultPluginsForActiveOwner(): void {
+  const session = getActiveAppSession();
+  if (!session.dataOwnerId || isAppSessionBoundaryPending()) return;
+  const scope = activeOwnerScopeKey();
+  if (scope === lastDefaultPluginSyncScope) return;
+  lastDefaultPluginSyncScope = scope;
+  void syncDefaultMarketPlugins();
+}
 
 const registerIpcHandlers = () => {
   // Find the primary app window, skipping transient utility BrowserWindows like
@@ -4572,6 +4587,13 @@ const registerIpcHandlers = () => {
   disposeProviderAccessAuthListener = authManager.onAuthStateChange(() => {
     refreshProviderAccessAfterAuthChange();
   });
+  // 默认插件同步不能依赖用户先打开插件页。启动时本地 owner 已经稳定则立刻
+  // 复用市场快照；云端登录/切号的通知可能早于 owner boundary 释放，因此
+  // 延迟到当前调用栈结束后再按已提交的新 owner 补跑一次。
+  disposePluginMarketAuthListener = authManager.onAuthStateChange(() => {
+    queueMicrotask(syncDefaultPluginsForActiveOwner);
+  });
+  syncDefaultPluginsForActiveOwner();
 
   // ── Dialog: 目录选择器（v0.6 新增，与旧 show-open-directory-dialog 并存） ──
   ipcMain.handle(
@@ -6358,6 +6380,14 @@ onQuit(
   () => {
     disposeProviderAccessAuthListener?.();
     disposeProviderAccessAuthListener = null;
+  },
+  'sync',
+);
+onQuit(
+  'plugin-market-auth-listener',
+  () => {
+    disposePluginMarketAuthListener?.();
+    disposePluginMarketAuthListener = null;
   },
   'sync',
 );

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -65,7 +65,9 @@ describe('Plugin Market IPC error boundary', () => {
     expect(ownerSyncBody).toContain(
       'if (!session.dataOwnerId || isAppSessionBoundaryPending()) return;',
     );
-    expect(ownerSyncBody).toContain('void syncDefaultMarketPlugins();');
+    expect(ownerSyncBody).toContain('if (scope === defaultPluginSyncInFlightScope) return;');
+    expect(ownerSyncBody).toContain('void syncDefaultMarketPlugins().finally(() => {');
+    expect(ownerSyncBody).toContain('defaultPluginSyncInFlightScope = null;');
 
     const listenerStart = bootstrapSource.indexOf(
       'disposePluginMarketAuthListener = authManager.onAuthStateChange',

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -17,6 +17,10 @@ describe('Plugin Market IPC error boundary', () => {
     resolve(process.cwd(), 'src/main/plugin-market/service.ts'),
     'utf8',
   ).replace(/\r\n/g, '\n');
+  const bootstrapSource = readFileSync(
+    resolve(process.cwd(), 'src/main/bootstrap-electron.ts'),
+    'utf8',
+  ).replace(/\r\n/g, '\n');
 
   it('preserves structured errors and normalizes unexpected failures', () => {
     const start = registerSource.indexOf('async function invokePluginMarket');
@@ -42,5 +46,37 @@ describe('Plugin Market IPC error boundary', () => {
     expect(serviceSource).not.toContain('throw new Error(');
     expect(serviceSource).toContain("throwIpcError('PRECONDITION_FAILED'");
     expect(serviceSource).toContain("throwIpcError('PERMISSION_DENIED'");
+  });
+
+  it('runs default plugin reconciliation on cold start and stable owner changes', () => {
+    const syncStart = registerSource.indexOf(
+      'export async function syncDefaultMarketPlugins(): Promise<void>',
+    );
+    const syncEnd = registerSource.indexOf('\n}\n\n/**\n * Preserve stable IPC errors', syncStart);
+    const syncBody = registerSource.slice(syncStart, syncEnd);
+    expect(syncBody).toContain('await service().snapshot();');
+    expect(syncBody).toContain("log.warn('default plugin startup sync failed'");
+
+    const ownerSyncStart = bootstrapSource.indexOf(
+      'function syncDefaultPluginsForActiveOwner(): void',
+    );
+    const ownerSyncEnd = bootstrapSource.indexOf('\n}\n\nconst registerIpcHandlers', ownerSyncStart);
+    const ownerSyncBody = bootstrapSource.slice(ownerSyncStart, ownerSyncEnd);
+    expect(ownerSyncBody).toContain(
+      'if (!session.dataOwnerId || isAppSessionBoundaryPending()) return;',
+    );
+    expect(ownerSyncBody).toContain('void syncDefaultMarketPlugins();');
+
+    const listenerStart = bootstrapSource.indexOf(
+      'disposePluginMarketAuthListener = authManager.onAuthStateChange',
+    );
+    expect(listenerStart).toBeGreaterThan(-1);
+    expect(
+      bootstrapSource.indexOf(
+        'queueMicrotask(syncDefaultPluginsForActiveOwner);',
+        listenerStart,
+      ),
+    ).toBeGreaterThan(listenerStart);
+    expect(bootstrapSource).toContain("'plugin-market-auth-listener'");
   });
 });

--- a/apps/desktop/src/main/plugin-market/registerIpc.ts
+++ b/apps/desktop/src/main/plugin-market/registerIpc.ts
@@ -21,6 +21,21 @@ function service(): PluginMarketService {
 }
 
 /**
+ * Reuse the market snapshot reconciliation outside the Plugins page so
+ * default-install plugins are provisioned as soon as an app owner is ready.
+ * The Plugins page keeps the same call as a later retry path.
+ */
+export async function syncDefaultMarketPlugins(): Promise<void> {
+  try {
+    await service().snapshot();
+  } catch (error) {
+    log.warn('default plugin startup sync failed', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+/**
  * Preserve stable IPC errors and hide internal/network messages from the
  * renderer. Detailed failures stay in main logs; the renderer localizes by
  * code and uses a generic fallback for INTERNAL.


### PR DESCRIPTION
## 这次改了什么

### 摘要

Desktop 冷启动时主动复用插件市场已有的 `snapshot()` 对账流程，让默认安装插件不再依赖用户先打开插件市场。登录或切换账号时，等待稳定 owner 提交完成后再触发同一流程。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 TapTap Maker 在 Codex 链路下冷启动后不可用
- 本 PR 包含：冷启动默认插件同步、稳定 owner 变更后的补同步、回归测试
- 明确不包含：安装状态中心、下载进度协议、Agent 协议和插件 UI 改动
- 用户可见变化：无需打开插件市场，默认插件会在冷启动登录完成后自动安装
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts src/main/plugin-market/__tests__/service.test.ts
结果：2 个文件、39 项测试通过

pnpm exec eslint src/main/plugin-market/registerIpc.ts src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
结果：通过

node --max-old-space-size=8192 ../../node_modules/typescript/bin/tsc --noEmit -p tsconfig.json
结果：合并最新 main 后通过

pnpm test:unit
结果：合并最新 main 后全部 workspace 单元测试通过
```

### 手工验证

不涉及；未在真实账号环境执行冷启动端到端验证。

### 未执行的验证

- 未执行真实账号冷启动与断网恢复的手工验证；现有插件市场页面仍保留原有 `snapshot()` 入口作为后续重试路径。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：插件基座的默认安装触发时机前移

### 影响与回滚

- 影响范围：Desktop 冷启动及登录/切号后的插件市场默认安装对账。存量插件影响：无；未修改批准状态、指纹、manifest、安装布局或包格式。
- 回滚 / 降级方式：回滚本提交即可恢复为仅打开插件市场时触发；插件页原有同步入口保持不变。
- 合并门槛：命中插件基座，需白名单放行人明确 Approve。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无文档契约变化）
- [x] 已确认测试结果或说明未执行原因
