### PR TITLE
perf(desktop): 收敛 Orca Worker 投影刷新并修复 Sidebar 卡死

### DIFF
--- a/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerSendToSessionOrdering.test.ts
@@ -37,6 +37,8 @@ const orcaLifecycleServiceSourcePath = resolve(__dirname, '..', 'maker-ipc', 'or
 const orcaLifecycleServiceSource = readFileSync(orcaLifecycleServiceSourcePath, 'utf8').replace(/\r\n?/g, '\n');
 const useWorkersSourcePath = resolve(__dirname, '..', '..', 'renderer', 'features', 'cc-agent', 'hooks', 'useWorkers.ts');
 const useWorkersSource = readFileSync(useWorkersSourcePath, 'utf8').replace(/\r\n?/g, '\n');
+const workerProjectionStoreSourcePath = resolve(__dirname, '..', '..', 'renderer', 'features', 'cc-agent', 'hooks', 'workerProjectionStore.ts');
+const workerProjectionStoreSource = readFileSync(workerProjectionStoreSourcePath, 'utf8').replace(/\r\n?/g, '\n');
 const preloadSourcePath = resolve(__dirname, '..', '..', 'preload', 'preload.ts');
 const preloadSource = readFileSync(preloadSourcePath, 'utf8').replace(/\r\n?/g, '\n');
 const useOrcaWorkerSelectionSourcePath = resolve(__dirname, '..', '..', 'renderer', 'features', 'cc-agent', 'hooks', 'useOrcaWorkerSelection.ts');
@@ -835,9 +837,10 @@ describe('sendToSession ordering', () => {
   });
 
   it('uses active slot occupancy for renderer worker-limit gating', () => {
-    expect(useWorkersSource).toContain('isActiveWorkerStatus');
+    expect(workerProjectionStoreSource).toContain('isActiveWorkerStatus');
     expect(useWorkersSource).not.toContain('isRunningWorkerStatus');
-    expect(useWorkersSource).toContain('const activeWorkerCount = workers.filter((w) => isActiveWorkerStatus(w.status)).length;');
+    expect(useWorkersSource).toContain('const activeWorkerCount = getActiveWorkerCount(workers);');
+    expect(workerProjectionStoreSource).toContain('return workers.filter((w) => isActiveWorkerStatus(w.status)).length;');
   });
 });
 

--- a/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/orcaTeamStore.test.ts
@@ -116,6 +116,40 @@ describe('orcaTeamStore', () => {
       .toBe('pi');
   });
 
+  it('returns complete active worker projections grouped by lead in one batch', async () => {
+    const { listWorkersByLeads } = await import('../orcaTeamStore.js');
+    const client = createTestDbClient();
+    setCurrentDbClient(client, 'test-user');
+
+    await seedOrcaWorkers(client);
+    const now = Date.now();
+    await client.exec(
+      'INSERT INTO sessions (id, title, agent_kind, orca_role, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      ['lead-session-2', 'Lead 2', 'codex', 'lead', now, now],
+    );
+    await client.exec(
+      'INSERT INTO sessions (id, title, agent_kind, orca_role, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
+      ['worker-session-3', 'Worker 3', 'claude-code', 'worker', now, now],
+    );
+    await client.exec(
+      'INSERT INTO orca_teams (id, lead_session_id, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      ['team-2', 'lead-session-2', 'active', now, now],
+    );
+    await client.exec(
+      'INSERT INTO orca_workers (id, team_id, session_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+      ['worker-3', 'team-2', 'worker-session-3', now, now],
+    );
+
+    const grouped = await listWorkersByLeads(['lead-session-1', 'lead-session-2', 'lead-empty']);
+
+    expect(grouped['lead-session-1'].map((worker) => worker.id).sort()).toEqual([
+      'worker-1',
+      'worker-2',
+    ]);
+    expect(grouped['lead-session-2'].map((worker) => worker.id)).toEqual(['worker-3']);
+    expect(grouped['lead-empty']).toEqual([]);
+  });
+
   it('executes worker status CAS updates and only rolls back idle acknowledgements', async () => {
     const { markWorkerIdleIfStatus, restoreWorkerDoneIfIdle } = await import('../orcaTeamStore.js');
     const client = createTestDbClient();

--- a/apps/desktop/src/main/localDb/ipc/__tests__/orcaTeams.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/orcaTeams.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listWorkersByLeads: vi.fn(),
+  getAllWindows: vi.fn(),
+  ipcHandle: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: mocks.getAllWindows },
+  ipcMain: { handle: mocks.ipcHandle },
+}));
+
+vi.mock('../../orcaTeamStore.js', () => ({
+  getTeamByLeadSession: vi.fn(),
+  getTeamByWorkerSession: vi.fn(),
+  listWorkersByLeads: mocks.listWorkersByLeads,
+  updateWorkerStatus: vi.fn(),
+}));
+
+import {
+  __resetOrcaWorkflowIpcForTest,
+  listWorkersByLeadSingleFlight,
+  listWorkersByLeadsSingleFlight,
+  registerOrcaWorkflowIpc,
+} from '../orcaTeams';
+import { broadcastOrcaWorkerChanged } from '../../../maker-host/orcaWorkerBroadcast';
+
+type BatchHandler = (event: unknown, leadSessionIds: unknown) => Promise<unknown>;
+
+function batchHandler(): BatchHandler {
+  registerOrcaWorkflowIpc();
+  const call = mocks.ipcHandle.mock.calls.find(
+    ([channel]) => channel === 'local-db:orca-workflows:list-workers-by-leads',
+  );
+  if (!call) throw new Error('list-workers-by-leads handler was not registered');
+  return call[1] as BatchHandler;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('orca workflow IPC helpers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetOrcaWorkflowIpcForTest();
+    mocks.getAllWindows.mockReturnValue([]);
+  });
+
+  it('merges concurrent list-workers requests for the same lead', async () => {
+    const pending = deferred<Record<string, unknown[]>>();
+    mocks.listWorkersByLeads.mockReturnValueOnce(pending.promise);
+
+    const first = listWorkersByLeadSingleFlight('lead-1');
+    const second = listWorkersByLeadSingleFlight('lead-1');
+
+    expect(first).toBe(second);
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledOnce();
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-1']);
+
+    pending.resolve({ 'lead-1': [{ id: 'worker-1' }] });
+    await expect(first).resolves.toEqual([{ id: 'worker-1' }]);
+  });
+
+  it('does not share in-flight requests across different leads', async () => {
+    mocks.listWorkersByLeads.mockImplementation(async (ids: string[]) =>
+      Object.fromEntries(ids.map((id) => [id, []])),
+    );
+
+    await Promise.all([
+      listWorkersByLeadSingleFlight('lead-1'),
+      listWorkersByLeadSingleFlight('lead-2'),
+    ]);
+
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(2);
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-1']);
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-2']);
+  });
+
+  it('keeps a new multi-lead request to one store batch', async () => {
+    mocks.listWorkersByLeads.mockResolvedValue({
+      'lead-1': [{ id: 'worker-1' }],
+      'lead-2': [{ id: 'worker-2' }],
+    });
+
+    await expect(listWorkersByLeadsSingleFlight(['lead-1', 'lead-2'])).resolves.toEqual({
+      'lead-1': [{ id: 'worker-1' }],
+      'lead-2': [{ id: 'worker-2' }],
+    });
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledOnce();
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-1', 'lead-2']);
+  });
+
+  it('reuses overlapping leads across batch and single requests', async () => {
+    const firstBatch = deferred<Record<string, unknown[]>>();
+    const secondBatch = deferred<Record<string, unknown[]>>();
+    mocks.listWorkersByLeads
+      .mockReturnValueOnce(firstBatch.promise)
+      .mockReturnValueOnce(secondBatch.promise);
+
+    const first = listWorkersByLeadsSingleFlight(['lead-1', 'lead-2']);
+    const overlapping = listWorkersByLeadsSingleFlight(['lead-2', 'lead-3']);
+    const single = listWorkersByLeadSingleFlight('lead-1');
+
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(2);
+    expect(mocks.listWorkersByLeads).toHaveBeenNthCalledWith(1, ['lead-1', 'lead-2']);
+    expect(mocks.listWorkersByLeads).toHaveBeenNthCalledWith(2, ['lead-3']);
+
+    firstBatch.resolve({
+      'lead-1': [{ id: 'worker-1' }],
+      'lead-2': [{ id: 'worker-2' }],
+    });
+    secondBatch.resolve({ 'lead-3': [{ id: 'worker-3' }] });
+
+    await expect(single).resolves.toEqual([{ id: 'worker-1' }]);
+    await expect(first).resolves.toEqual({
+      'lead-1': [{ id: 'worker-1' }],
+      'lead-2': [{ id: 'worker-2' }],
+    });
+    await expect(overlapping).resolves.toEqual({
+      'lead-2': [{ id: 'worker-2' }],
+      'lead-3': [{ id: 'worker-3' }],
+    });
+  });
+
+  it('does not join an old in-flight list after a worker change broadcast invalidates the lead', async () => {
+    const stale = deferred<Record<string, unknown[]>>();
+    mocks.listWorkersByLeads
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce({ 'lead-1': [{ id: 'worker-new' }] });
+
+    const beforeWrite = listWorkersByLeadSingleFlight('lead-1');
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledOnce();
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-1']);
+
+    broadcastOrcaWorkerChanged('lead-1');
+    const afterBroadcast = listWorkersByLeadSingleFlight('lead-1');
+
+    expect(afterBroadcast).not.toBe(beforeWrite);
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(2);
+    expect(mocks.listWorkersByLeads).toHaveBeenNthCalledWith(2, ['lead-1']);
+    await expect(afterBroadcast).resolves.toEqual([{ id: 'worker-new' }]);
+
+    stale.resolve({ 'lead-1': [{ id: 'worker-old' }] });
+    await expect(beforeWrite).resolves.toEqual([{ id: 'worker-old' }]);
+  });
+
+  it('validates and deduplicates the local batch IPC input', async () => {
+    mocks.listWorkersByLeads.mockResolvedValue({
+      'lead-1': [{ id: 'worker-1' }],
+      'lead-2': [],
+    });
+
+    await expect(batchHandler()(null, ['lead-1', 'lead-1', 'lead-2'])).resolves.toEqual({
+      'lead-1': [{ id: 'worker-1' }],
+      'lead-2': [],
+    });
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-1', 'lead-2']);
+  });
+
+  it('rejects non-array and oversized local batch IPC input', async () => {
+    const invoke = batchHandler();
+
+    await expect(invoke(null, { leadSessionIds: ['lead-1'] })).rejects.toThrow(/INVALID_PARAMS/);
+    await expect(
+      invoke(null, Array.from({ length: 201 }, (_, index) => `lead-${index}`)),
+    ).rejects.toThrow(/INVALID_PARAMS/);
+    expect(mocks.listWorkersByLeads).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/localDb/ipc/orcaTeams.ts
+++ b/apps/desktop/src/main/localDb/ipc/orcaTeams.ts
@@ -3,16 +3,39 @@ import { ipcMain } from 'electron';
 import {
   getTeamByLeadSession,
   getTeamByWorkerSession,
-  listWorkersByLead,
   updateWorkerStatus,
   type OrcaWorkerStatus,
 } from '../orcaTeamStore.js';
 import {
+  __resetOrcaWorkerListSingleFlightForTest,
+  listWorkersByLeadSingleFlight,
+  listWorkersByLeadsSingleFlight,
+} from './orcaWorkerListSingleFlight.js';
+import {
+  throwIpcError,
   requireString,
   requireEnum,
 } from '../../utils/ipcValidate.js';
 
+export {
+  invalidateWorkersByLeadSingleFlight,
+  listWorkersByLeadSingleFlight,
+  listWorkersByLeadsSingleFlight,
+} from './orcaWorkerListSingleFlight.js';
+
 const WORKER_STATUSES = ['idle', 'running', 'done', 'error'] as const;
+const MAX_BATCH_LEAD_IDS = 200;
+
+function requireLeadSessionIdArray(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length > MAX_BATCH_LEAD_IDS) {
+    throwIpcError('INVALID_PARAMS', 'leadSessionIds must be an array');
+  }
+  return [...new Set(value.map((item, index) => requireString(item, `leadSessionIds[${index}]`)))];
+}
+
+export function __resetOrcaWorkflowIpcForTest(): void {
+  __resetOrcaWorkerListSingleFlightForTest();
+}
 
 export function registerOrcaWorkflowIpc(): void {
   ipcMain.handle(
@@ -32,7 +55,16 @@ export function registerOrcaWorkflowIpc(): void {
   ipcMain.handle(
     'local-db:orca-workflows:list-workers-by-lead',
     async (_e, leadSessionId: unknown) => {
-      return listWorkersByLead(requireString(leadSessionId, 'leadSessionId'));
+      const normalizedLeadSessionId = requireString(leadSessionId, 'leadSessionId');
+      return listWorkersByLeadSingleFlight(normalizedLeadSessionId);
+    },
+  );
+
+  ipcMain.handle(
+    'local-db:orca-workflows:list-workers-by-leads',
+    async (_e, leadSessionIds: unknown) => {
+      const normalizedLeadSessionIds = requireLeadSessionIdArray(leadSessionIds);
+      return listWorkersByLeadsSingleFlight(normalizedLeadSessionIds);
     },
   );
 

--- a/apps/desktop/src/main/localDb/ipc/orcaWorkerListSingleFlight.ts
+++ b/apps/desktop/src/main/localDb/ipc/orcaWorkerListSingleFlight.ts
@@ -1,0 +1,57 @@
+import {
+  listWorkersByLeads,
+  type OrcaWorkerRecord,
+} from '../orcaTeamStore.js';
+
+const listWorkersByLeadInflight = new Map<string, Promise<OrcaWorkerRecord[]>>();
+
+function ensureWorkersByLeadRequests(leadSessionIds: readonly string[]): void {
+  const missingLeadSessionIds = leadSessionIds.filter(
+    (leadSessionId) => !listWorkersByLeadInflight.has(leadSessionId),
+  );
+  if (missingLeadSessionIds.length === 0) return;
+
+  const batchRequest = listWorkersByLeads(missingLeadSessionIds);
+  for (const leadSessionId of missingLeadSessionIds) {
+    const promise = batchRequest.then((grouped) => grouped[leadSessionId] ?? []);
+    listWorkersByLeadInflight.set(leadSessionId, promise);
+    void promise
+      .finally(() => {
+        if (listWorkersByLeadInflight.get(leadSessionId) === promise) {
+          listWorkersByLeadInflight.delete(leadSessionId);
+        }
+      })
+      .catch(() => undefined);
+  }
+}
+
+export function invalidateWorkersByLeadSingleFlight(leadSessionId: string): void {
+  listWorkersByLeadInflight.delete(leadSessionId);
+}
+
+export function listWorkersByLeadSingleFlight(
+  leadSessionId: string,
+): Promise<OrcaWorkerRecord[]> {
+  const existing = listWorkersByLeadInflight.get(leadSessionId);
+  if (existing) return existing;
+  ensureWorkersByLeadRequests([leadSessionId]);
+  return listWorkersByLeadInflight.get(leadSessionId)!;
+}
+
+export async function listWorkersByLeadsSingleFlight(
+  leadSessionIds: readonly string[],
+): Promise<Record<string, OrcaWorkerRecord[]>> {
+  const uniqueLeadSessionIds = [...new Set(leadSessionIds)];
+  ensureWorkersByLeadRequests(uniqueLeadSessionIds);
+  const entries = await Promise.all(
+    uniqueLeadSessionIds.map(async (leadSessionId) => [
+      leadSessionId,
+      await listWorkersByLeadInflight.get(leadSessionId)!,
+    ] as const),
+  );
+  return Object.fromEntries(entries);
+}
+
+export function __resetOrcaWorkerListSingleFlightForTest(): void {
+  listWorkersByLeadInflight.clear();
+}

--- a/apps/desktop/src/main/localDb/orcaTeamStore.ts
+++ b/apps/desktop/src/main/localDb/orcaTeamStore.ts
@@ -386,6 +386,18 @@ export async function addOrUpdateWorker(input: {
 export async function listWorkersByLead(
   leadSessionId: string,
 ): Promise<OrcaWorkerRecord[]> {
+  const grouped = await listWorkersByLeads([leadSessionId]);
+  return grouped[leadSessionId] ?? [];
+}
+
+export async function listWorkersByLeads(
+  leadSessionIds: readonly string[],
+): Promise<Record<string, OrcaWorkerRecord[]>> {
+  const uniqueLeadSessionIds = [...new Set(leadSessionIds)];
+  const grouped = Object.fromEntries(uniqueLeadSessionIds.map((id) => [id, [] as OrcaWorkerRecord[]]));
+  if (uniqueLeadSessionIds.length === 0) {
+    return grouped;
+  }
   const db = getDbClient().drizzle;
   const rows = await db
     .select({ worker: orcaWorkers, team: orcaTeams, session: sessions })
@@ -393,12 +405,15 @@ export async function listWorkersByLead(
     .innerJoin(orcaTeams, eq(orcaTeams.id, orcaWorkers.teamId))
     .innerJoin(sessions, eq(sessions.id, orcaWorkers.sessionId))
     .where(and(
-      eq(orcaTeams.leadSessionId, leadSessionId),
+      inArray(orcaTeams.leadSessionId, uniqueLeadSessionIds),
       eq(orcaTeams.status, 'active'),
       eq(sessions.status, 'active'),
     ))
-    .orderBy(desc(orcaWorkers.createdAt));
-  return rows.map((r) => workerToRecord(r.worker, r.team, r.session));
+    .orderBy(orcaTeams.leadSessionId, desc(orcaWorkers.createdAt));
+  for (const row of rows) {
+    grouped[row.team.leadSessionId]?.push(workerToRecord(row.worker, row.team, row.session));
+  }
+  return grouped;
 }
 
 export async function getWorkerLink(input: {

--- a/apps/desktop/src/main/maker-host/orcaWorkerBroadcast.ts
+++ b/apps/desktop/src/main/maker-host/orcaWorkerBroadcast.ts
@@ -1,5 +1,6 @@
 import { BrowserWindow } from 'electron';
 
+import { invalidateWorkersByLeadSingleFlight } from '../localDb/ipc/orcaWorkerListSingleFlight.js';
 import { MAKER_PUSH } from '../maker-ipc/channels.js';
 
 export interface OrcaWorkerBroadcastWindow {
@@ -25,5 +26,6 @@ export function broadcastOrcaWorkerChangedToWindows(
 }
 
 export function broadcastOrcaWorkerChanged(leadSessionId: string): void {
+  invalidateWorkersByLeadSingleFlight(leadSessionId);
   broadcastOrcaWorkerChangedToWindows(BrowserWindow.getAllWindows(), leadSessionId);
 }

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -147,6 +147,7 @@ import {
   patchMessageAgentMeta,
   supersedeRetriedUserTurn,
 } from '../localDb/ipc/messages.js';
+import { invalidateWorkersByLeadSingleFlight } from '../localDb/ipc/orcaWorkerListSingleFlight.js';
 import { messageToCamel } from '../localDb/mapper.js';
 import { visibleMessageTextForConversationSearch } from '../localDb/conversationSearch.pure.js';
 import {
@@ -10664,6 +10665,14 @@ function redactEventForRenderer(event: AgentEvent): AgentEvent {
 }
 
 function broadcastToAllWindows(channel: string, payload: unknown): void {
+  if (
+    channel === MAKER_PUSH.ORCA_WORKER_CHANGED &&
+    payload &&
+    typeof payload === 'object' &&
+    typeof (payload as { leadSessionId?: unknown }).leadSessionId === 'string'
+  ) {
+    invalidateWorkersByLeadSingleFlight((payload as { leadSessionId: string }).leadSessionId);
+  }
   // device-link 被控端旁路:命中转发白名单且存在控制链路时,把事件转发给控制端
   // (无 link 时 O(1) no-op,不进 maker-core 热路径成本)
   // 旁路永远不能反向阻断本机生命周期。owner boundary 切换期间远端链路

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -4067,6 +4067,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
         ),
       listWorkersByLead: (leadSessionId: string): Promise<unknown> =>
         ipcRenderer.invoke('local-db:orca-workflows:list-workers-by-lead', leadSessionId),
+      listWorkersByLeads: (leadSessionIds: string[]): Promise<unknown> =>
+        ipcRenderer.invoke('local-db:orca-workflows:list-workers-by-leads', leadSessionIds),
       updateWorkerStatus: (workerId: string, status: string): Promise<void> =>
         ipcRenderer.invoke(
           'local-db:orca-workflows:update-worker-status',

--- a/apps/desktop/src/renderer/__tests__/makerTransportOrcaRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerTransportOrcaRouting.test.ts
@@ -130,4 +130,29 @@ describe('subscribeOrcaWorkerChanged 分流', () => {
     handler({ deviceId: 'dev-1', channel: 'maker:orca:worker-changed', payload: { leadSessionId: 'other' } }); // wrong lead
     expect(cb).toHaveBeenCalledTimes(1);
   });
+
+  it('远程 lead 的映射短暂消失时，worker-changed 订阅仍留在被控端', async () => {
+    const { orcaSpies, onRemotePush } = stubElectron();
+    const { subscribeOrcaWorkerChanged } = await import('@/lib/makerTransport');
+    const { remoteProjectsStore } = await import('@/features/device-link/remoteProjectsStore');
+    const { getStickySessionDeviceId } = await import(
+      '@/features/device-link/stickySessionOrigin'
+    );
+    remoteProjectsStore.setDeviceSessions('dev-sticky', 'Mac', [sess('sticky-lead')]);
+    expect(getStickySessionDeviceId('sticky-lead')).toBe('dev-sticky');
+    remoteProjectsStore.setDeviceSessions('dev-sticky', 'Mac', []);
+
+    const cb = vi.fn();
+    subscribeOrcaWorkerChanged('sticky-lead', cb);
+
+    expect(onRemotePush).toHaveBeenCalled();
+    expect(orcaSpies.onOrcaWorkerChanged).not.toHaveBeenCalled();
+    const handler = onRemotePush.mock.calls[0][0];
+    handler({
+      deviceId: 'dev-sticky',
+      channel: 'maker:orca:worker-changed',
+      payload: { leadSessionId: 'sticky-lead' },
+    });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/desktop/src/renderer/__tests__/orcaRemoteRoutingInvariants.test.ts
+++ b/apps/desktop/src/renderer/__tests__/orcaRemoteRoutingInvariants.test.ts
@@ -4,7 +4,8 @@
  * (按 ctx session 来源分流本机 / 隧道),不得再直连 `window.electronAPI.localDb.orcaWorkflows`
  * —— 否则远程 lead 的团队会查控制端空库、worker 变更收不到推送(真机实测的「浏览不出来」)。
  *
- * 唯一允许直连的是 makerTransport 自己(路由器本体,含本机分支 + onOrcaWorkerChanged 订阅)。
+ * 唯一允许直连的是 makerTransport 自己(路由器本体,含本机分支 + onOrcaWorkerChanged 订阅),
+ * 以及 workerProjectionStore 的本机批量只读入口；远程 Lead 仍必须经 orcaWorkflowsFor。
  */
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -35,9 +36,8 @@ describe('orca 远程路由接线不变式', () => {
 
   it('读 / 管理消费点用 orcaWorkflowsFor(ctx) 路由', () => {
     for (const f of [
-      'features/cc-agent/hooks/useWorkers.ts',
       'features/cc-agent/hooks/useOrcaWorkerSelection.ts',
-      'features/cc-agent/hooks/useOrcaLeadWorkerMap.ts',
+      'features/cc-agent/hooks/workerProjectionStore.ts',
       'features/cc-agent/CCAgentSessionView.tsx',
       'features/cc-agent/CCAgentIndexRedirect.tsx',
       'lib/orcaSessionIdentity.ts',
@@ -47,7 +47,9 @@ describe('orca 远程路由接线不变式', () => {
   });
 
   it('useWorkers worker 变更经 subscribeOrcaWorkerChanged(本机/远程分流),不直订本机 IPC', () => {
-    const src = read('features/cc-agent/hooks/useWorkers.ts');
+    const useWorkers = read('features/cc-agent/hooks/useWorkers.ts');
+    expect(useWorkers).toContain("from './workerProjectionStore'");
+    const src = read('features/cc-agent/hooks/workerProjectionStore.ts');
     expect(src).toContain('subscribeOrcaWorkerChanged(');
     expect(src).not.toContain('onOrcaWorkerChanged');
   });

--- a/apps/desktop/src/renderer/__tests__/orcaWorkerAttentionWatcher.test.ts
+++ b/apps/desktop/src/renderer/__tests__/orcaWorkerAttentionWatcher.test.ts
@@ -73,6 +73,16 @@ describe('computeWorkerAttentionUpdates', () => {
     expect(doneAgain.toMark).toEqual([WORKER_ID]);
   });
 
+  it('keeps unread completion attention when the worker starts new work', () => {
+    const result = computeWorkerAttentionUpdates(
+      new Map([[WORKER_ID, 'done']]),
+      [worker(WORKER_ID, 'idle')],
+      undefined,
+    );
+
+    expect(result.toPrune).not.toContain(WORKER_ID);
+  });
+
   it('does not mark when the focused worker finishes in the active lead', () => {
     const result = computeWorkerAttentionUpdates(
       new Map(),

--- a/apps/desktop/src/renderer/__tests__/orcaWorkerAttentionWatcherMount.test.ts
+++ b/apps/desktop/src/renderer/__tests__/orcaWorkerAttentionWatcherMount.test.ts
@@ -13,6 +13,11 @@ const watcherSource = readFileSync(
   'utf8',
 ).replace(/\r\n?/g, '\n');
 
+const projectionSource = readFileSync(
+  resolve(__dirname, '..', 'features', 'cc-agent', 'hooks', 'workerProjectionStore.ts'),
+  'utf8',
+).replace(/\r\n?/g, '\n');
+
 const orcaSplitViewSource = readFileSync(
   resolve(__dirname, '..', 'features', 'cc-agent', 'OrcaSplitView.tsx'),
   'utf8',
@@ -31,12 +36,12 @@ describe('Orca worker attention watcher mount', () => {
     expect(expandedBlock).not.toContain('useOrcaWorkerAttentionWatcher(');
   });
 
-  it('ignores refresh results older than the latest applied refresh', () => {
-    expect(watcherSource).toContain('const refreshGenerationRef = useRef(0);');
-    expect(watcherSource).toContain('const appliedRefreshGenerationRef = useRef(0);');
-    expect(watcherSource).toContain('const generation = ++refreshGenerationRef.current;');
-    expect(watcherSource).toContain('if (cancelled || generation < appliedRefreshGenerationRef.current) return;');
-    expect(watcherSource).toContain('appliedRefreshGenerationRef.current = generation;');
+  it('derives attention from the projection store, whose request sequence rejects stale results', () => {
+    expect(watcherSource).toContain('useWorkerProjectionVersion()');
+    expect(watcherSource).toContain('getWorkerProjectionSnapshot(leadSessionId)');
+    expect(watcherSource).not.toContain('listWorkersByLead(');
+    expect(projectionSource).toContain('if (item.entry.requestSeq !== item.requestId)');
+    expect(projectionSource).toContain('if (entry.requestSeq !== requestId)');
   });
 
   it('clears only visible non-done worker attention before paint in doc-mode toggle layout', () => {

--- a/apps/desktop/src/renderer/__tests__/orcaWorkerProjectionContracts.test.ts
+++ b/apps/desktop/src/renderer/__tests__/orcaWorkerProjectionContracts.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(__dirname, '..', '..', '..');
+const pluginSource = readFileSync(
+  resolve(repoRoot, 'src/renderer/features/right-sidebar/plugins/orca-workers/index.tsx'),
+  'utf8',
+);
+const selectionSource = readFileSync(
+  resolve(repoRoot, 'src/renderer/features/cc-agent/hooks/useOrcaWorkerSelection.ts'),
+  'utf8',
+);
+const sessionViewSource = readFileSync(
+  resolve(repoRoot, 'src/renderer/features/cc-agent/CCAgentSessionView.tsx'),
+  'utf8',
+);
+const sessionHeaderSource = readFileSync(
+  resolve(repoRoot, 'src/renderer/features/cc-agent/SessionContentHeader.tsx'),
+  'utf8',
+);
+
+describe('Orca worker projection integration contracts', () => {
+  it('keeps inactive right-sidebar pills on the read-only projection path', () => {
+    const attentionDotBlock = extractBetween(
+      pluginSource,
+      'function OrcaWorkersAttentionDot',
+      'function OrcaWorkersTabBody',
+    );
+
+    expect(attentionDotBlock).toContain('useWorkerProjection(sessionId)');
+    expect(attentionDotBlock).not.toContain('useWorkers(');
+    expect(attentionDotBlock).not.toContain('revalidate');
+  });
+
+  it('keeps right-sidebar tab bodies owning projections across active and detached lifetimes', () => {
+    const tabBodyBlock = extractBetween(
+      pluginSource,
+      'function OrcaWorkersTabBody',
+      'const plugin: TabKindPlugin',
+    );
+
+    expect(tabBodyBlock).toContain('useWorkerProjectionOwner(ctx.sessionId);');
+    expect(tabBodyBlock).toContain('revalidateActiveWorkersProjection(ctx.sessionId)');
+    expect(tabBodyBlock).toContain('revalidateActiveWorkerSettings(ctx.sessionId)');
+    expect(tabBodyBlock).toContain('if (!active || !shellVisible || !windowVisible) return;');
+  });
+
+  it('runs the attention projection inside the detached sidebar renderer', () => {
+    const tabBodyBlock = extractBetween(
+      pluginSource,
+      'function OrcaWorkersTabBody',
+      'const plugin: TabKindPlugin',
+    );
+
+    expect(tabBodyBlock).toContain('isSidebarWindow() ? [ctx.sessionId] : []');
+    expect(tabBodyBlock).toContain('useOrcaWorkerAttentionByLeadIds(');
+    expect(tabBodyBlock).toContain('viewVisible ? ctx.sessionId : undefined');
+  });
+
+  it('keeps doc rail worker selection on useWorkers so it still receives live projection updates', () => {
+    expect(selectionSource).toContain("import { useWorkers } from './useWorkers';");
+    expect(selectionSource).toContain('} = useWorkers(leadSessionId);');
+  });
+
+  it('keeps renderer worker reads behind the shared projection store', () => {
+    expect(sessionViewSource).toContain('useWorkerProjection(collabProjectionLeadId)');
+    expect(sessionViewSource).not.toContain('.listWorkersByLead(collabSessionId)');
+    expect(sessionHeaderSource).toContain('revalidateWorkersProjection(session.id)');
+    expect(sessionHeaderSource).not.toContain('.listWorkersByLead(session.id)');
+  });
+});
+
+function extractBetween(source: string, start: string, end: string): string {
+  const startIndex = source.indexOf(start);
+  const endIndex = source.indexOf(end, startIndex + start.length);
+  if (startIndex < 0 || endIndex < 0) {
+    throw new Error(`missing source block ${start}..${end}`);
+  }
+  return source.slice(startIndex, endIndex);
+}

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -56,6 +56,10 @@ import { GoalIndicator } from '@/components/new-chat/GoalIndicator';
 import { PinnedPlanPanel } from '@/components/new-chat/PinnedPlanPanel';
 import { sessionsStore } from '@/lib/sessionsStore';
 import { useStopOrcaCollab } from './hooks/useStopOrcaCollab';
+import {
+  useWorkerProjection,
+  useWorkerProjectionOwner,
+} from './hooks/workerProjectionStore';
 import { CreateWorkerPopover, type CreateWorkerForm } from './CreateWorkerPopover';
 import { createWorkerLabel } from './workerLabel';
 import { TakeoverMask } from '@/components/new-chat/TakeoverMask';
@@ -1935,23 +1939,17 @@ export function CCAgentSessionView({
   const allowCollabToggle = !orcaMode && collabPolicyEligible;
   // 把 sessionId 抽出来给 useEffect 用 (linter 偏好稳定的标量依赖)
   const collabSessionId = sessionId;
+  const collabProjectionLeadId = collabEnabled ? collabSessionId : undefined;
+  useWorkerProjectionOwner(collabProjectionLeadId);
+  const collabWorkerProjection = useWorkerProjection(collabProjectionLeadId);
   useEffect(() => {
-    if (!collabSessionId || !collabEnabled) return;
-    let cancelled = false;
-    void orcaWorkflowsFor(collabSessionId)
-      .listWorkersByLead(collabSessionId)
-      .then((workers) => {
-        if (cancelled || workers.length === 0) return;
-        const activeWorker = workers[0]; // MVP: 假设最多 1 个 active Worker
-        // orca worker 创建面未开 pi;万一读到脏值也按 codex 收敛,不撑开 toggle 契约。
-        const normalizedKind = normalizeDbAgentKind(activeWorker.session?.agentKind);
-        setCollabWorker(normalizedKind === 'cc' ? 'cc' : 'codex');
-      })
-      .catch(() => undefined);
-    return () => {
-      cancelled = true;
-    };
-  }, [collabSessionId, collabEnabled]);
+    if (!collabProjectionLeadId) return;
+    const activeWorker = collabWorkerProjection.workers[0]; // MVP: 假设最多 1 个 active Worker
+    if (!activeWorker) return;
+    // orca worker 创建面未开 pi;万一读到脏值也按 codex 收敛,不撑开 toggle 契约。
+    const normalizedKind = normalizeDbAgentKind(activeWorker.agent);
+    setCollabWorker(normalizedKind === 'cc' ? 'cc' : 'codex');
+  }, [collabProjectionLeadId, collabWorkerProjection.workers]);
 
   // F-COLLAB: "外部触发" 协同状态变化时自动打开协同 tab (典型场景: MCP team
   // 工具, 未来也覆盖飞书等其它入口)。

--- a/apps/desktop/src/renderer/features/cc-agent/OrcaWorkerPanel.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/OrcaWorkerPanel.tsx
@@ -6,7 +6,7 @@
  * 双栏布局与独立 resize/maximize。
  */
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
@@ -90,6 +90,19 @@ export function OrcaWorkerPanel({
   });
   const lastAgentIslandPayloadRef = useRef<string | string[] | null>(null);
 
+  const handleOpenCreate = useCallback(async () => {
+    const result = await refreshCreationState();
+    if (result.status !== 'applied') {
+      toast.error(t('newChat.collaboration.createWorkerRefreshFailed'));
+      return;
+    }
+    const activeCount = result.workers.filter((worker) =>
+      isActiveWorkerStatus(worker.status),
+    ).length;
+    if (result.hardLimit !== null && activeCount >= result.hardLimit) return;
+    setCreateOpen(true);
+  }, [refreshCreationState, setCreateOpen, t]);
+
   useEffect(() => {
     if (!viewVisible) return;
     let active = true;
@@ -151,7 +164,7 @@ export function OrcaWorkerPanel({
           softLimit={softLimit}
           hardLimit={hardLimit}
           onSwitchFocus={handleSwitchFocus}
-          onOpenCreate={() => setCreateOpen(true)}
+          onOpenCreate={() => void handleOpenCreate()}
           onOpenSettings={() => navigate('/settings?section=collaboration')}
           settingsEnabled={!isSidebarWindow()}
           onArchiveWorker={handleArchiveWorker}

--- a/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/SessionContentHeader.tsx
@@ -62,7 +62,7 @@ import {
   pickSessionIdAfterRemoval,
 } from './lib/sessionRemovalNavigation';
 import { isOrcaLeadSession, resolveSessionRoute } from '@/lib/orcaSessionIdentity';
-import { orcaWorkflowsFor } from '@/lib/makerTransport';
+import { revalidateWorkersProjection } from './hooks/workerProjectionStore';
 import { GitContextBadge } from './GitContextBadge';
 import { SessionRenameInput } from './SessionRenameInput';
 import { useSessionBoundSchedules } from '@/features/scheduler/lib/scheduleSessionBinding';
@@ -319,8 +319,8 @@ export function SessionContentHeader({
       // worker 列表,避免依赖挂载初期尚未加载完成的订阅态(Codex review P2)。
       // 查询失败时不阻断,与 sidebar map 拉取失败(空集合)的行为一致。
       if (isOrcaLeadSession(session)) {
-        const workers = await orcaWorkflowsFor(session.id)
-          .listWorkersByLead(session.id)
+        const workers = await revalidateWorkersProjection(session.id)
+          .then((result) => (result.status === 'applied' ? result.workers : []))
           .catch(() => []);
         if (workers.some((worker) => runningSessionIds.has(worker.sessionId))) {
           toast.warning(t('ccAgent.sidebar.sessionMenu.moveToProjectRunningBlocked'));

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useWorkers.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useWorkers.test.tsx
@@ -411,6 +411,73 @@ describe('useWorkers / worker projection store', () => {
     expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
   });
 
+  it('applies a legal empty batch entry but keeps old workers and attention when a lead entry is missing', async () => {
+    vi.useFakeTimers();
+    mocks.listWorkersByLeads.mockResolvedValueOnce({
+      'lead-1': [workerRecord('worker-done', 'session-done', false, 'done')],
+    });
+    const hook = renderHook(() => {
+      useOrcaWorkerAttentionWatcher([leadSession('lead-1')], undefined);
+      return useWorkers('lead-1');
+    });
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual([
+      'session-done',
+    ]);
+    expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
+
+    mocks.listWorkersByLeads.mockResolvedValueOnce({ 'lead-1': [] });
+    let emptyResult!: Awaited<ReturnType<typeof hook.result.current.refresh>>;
+    await act(async () => {
+      const refresh = hook.result.current.refresh();
+      await vi.runOnlyPendingTimersAsync();
+      emptyResult = await refresh;
+    });
+    expect(emptyResult).toMatchObject({ status: 'applied', workers: [] });
+    expect(hook.result.current.workers).toEqual([]);
+    expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(false);
+
+    mocks.listWorkersByLeads.mockResolvedValueOnce({
+      'lead-1': [workerRecord('worker-done', 'session-done', false, 'done')],
+    });
+    await act(async () => {
+      const refresh = hook.result.current.refresh();
+      await vi.runOnlyPendingTimersAsync();
+      await refresh;
+    });
+    expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual([
+      'session-done',
+    ]);
+    expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
+
+    mocks.listWorkersByLeads.mockResolvedValueOnce({});
+    let missingResult!: Awaited<ReturnType<typeof hook.result.current.refresh>>;
+    await act(async () => {
+      const refresh = hook.result.current.refresh();
+      await vi.runOnlyPendingTimersAsync();
+      missingResult = await refresh;
+    });
+    expect(missingResult).toMatchObject({ status: 'failed' });
+    expect(missingResult?.workers.map((worker) => worker.sessionId)).toEqual(['session-done']);
+    expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual([
+      'session-done',
+    ]);
+    expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
+
+    mocks.listWorkersByLeads.mockResolvedValueOnce({ 'lead-1': null });
+    let malformedResult!: Awaited<ReturnType<typeof hook.result.current.refresh>>;
+    await act(async () => {
+      const refresh = hook.result.current.refresh();
+      await vi.runOnlyPendingTimersAsync();
+      malformedResult = await refresh;
+    });
+    expect(malformedResult).toMatchObject({ status: 'failed' });
+    expect(malformedResult?.workers.map((worker) => worker.sessionId)).toEqual(['session-done']);
+    expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
+  });
+
   it('lets a detached renderer derive attention from its owned lead projection', async () => {
     mocks.listWorkersByLeads.mockResolvedValueOnce({
       'lead-1': [workerRecord('worker-done', 'session-done', false, 'done')],

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useWorkers.test.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/__tests__/useWorkers.test.tsx
@@ -1,23 +1,47 @@
 // @vitest-environment jsdom
 
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   listWorkersByLead: vi.fn(),
+  listWorkersByLeads: vi.fn(),
   getCollaborationSettings: vi.fn(),
   subscribeOrcaWorkerChanged: vi.fn(),
+  isRemoteSessionSticky: vi.fn(),
 }));
 
 vi.mock('@/lib/makerTransport', () => ({
+  isRemoteSessionSticky: (leadSessionId: string) => mocks.isRemoteSessionSticky(leadSessionId),
   orcaWorkflowsFor: (leadSessionId: string) => ({
     listWorkersByLead: (...args: unknown[]) => mocks.listWorkersByLead(leadSessionId, ...args),
     getCollaborationSettings: () => mocks.getCollaborationSettings(leadSessionId),
   }),
+  orcaWorkflowsForDevice: (deviceId: string) => ({
+    listWorkersByLead: (...args: unknown[]) => mocks.listWorkersByLead(deviceId, ...args),
+    getCollaborationSettings: () => mocks.getCollaborationSettings(deviceId),
+  }),
   subscribeOrcaWorkerChanged: mocks.subscribeOrcaWorkerChanged,
 }));
 
+import type { Session } from '@/lib/ccAgent.types';
+import { useOrcaLeadWorkerMap } from '../useOrcaLeadWorkerMap';
+import {
+  useOrcaWorkerAttentionByLeadIds,
+  useOrcaWorkerAttentionWatcher,
+} from '../useOrcaWorkerAttentionWatcher';
 import { clearWorkersCache, useWorkers } from '../useWorkers';
+import {
+  __getWorkerProjectionOwnerCountForTest,
+  __setWorkerProjectionCoalesceMsForTest,
+  retainWorkerProjection,
+  revalidateActiveWorkerSettings,
+  revalidateActiveWorkersProjection,
+} from '../workerProjectionStore';
+import {
+  __getWorkerAttentionSnapshotForTest,
+  __resetWorkerAttentionStoreForTest,
+} from '../../lib/workerAttentionStore';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -26,8 +50,6 @@ function deferred<T>() {
   });
   return { promise, resolve };
 }
-
-const flushAsyncUpdates = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
 
 function workerRecord(
   workerId: string,
@@ -51,214 +73,392 @@ function workerRecord(
   };
 }
 
-describe('useWorkers', () => {
+function leadSession(id: string): Session {
+  return { id, orcaRole: 'lead' } as Session;
+}
+
+describe('useWorkers / worker projection store', () => {
+  let callbacks: Map<string, () => void>;
+
   beforeEach(() => {
     clearWorkersCache();
     vi.clearAllMocks();
+    vi.useRealTimers();
+    __setWorkerProjectionCoalesceMsForTest(100);
+    __resetWorkerAttentionStoreForTest();
+    callbacks = new Map();
+    mocks.isRemoteSessionSticky.mockReturnValue(false);
     mocks.listWorkersByLead.mockResolvedValue([workerRecord('worker-a', 'session-a', true)]);
+    mocks.listWorkersByLeads.mockImplementation(async (leadSessionIds: string[]) =>
+      Object.fromEntries(
+        leadSessionIds.map((leadSessionId) => [
+          leadSessionId,
+          [workerRecord(`worker-${leadSessionId}`, `session-${leadSessionId}`, true)],
+        ]),
+      ),
+    );
     mocks.getCollaborationSettings.mockResolvedValue({
       workerSoftLimit: 3,
       workerHardLimit: 6,
     });
-    mocks.subscribeOrcaWorkerChanged.mockReturnValue(() => undefined);
+    mocks.subscribeOrcaWorkerChanged.mockImplementation((leadSessionId: string, cb: () => void) => {
+      callbacks.set(leadSessionId, cb);
+      return () => callbacks.delete(leadSessionId);
+    });
+    (window as unknown as {
+      electronAPI: {
+        localDb: {
+          orcaWorkflows: {
+            listWorkersByLead: typeof mocks.listWorkersByLead;
+            listWorkersByLeads: typeof mocks.listWorkersByLeads;
+          };
+        };
+      };
+    }).electronAPI = {
+      localDb: {
+        orcaWorkflows: {
+          listWorkersByLead: mocks.listWorkersByLead,
+          listWorkersByLeads: mocks.listWorkersByLeads,
+        },
+      },
+    };
   });
 
   afterEach(() => {
+    cleanup();
     act(() => clearWorkersCache());
+    __resetWorkerAttentionStoreForTest();
+    vi.useRealTimers();
   });
 
-  it('caches the worker snapshot so remount starts with the previous list instead of an empty frame', async () => {
-    const first = renderHook(() => useWorkers('lead-1'));
+  it('hydrates local N lead projections through one batch IPC', async () => {
+    const sessions = [leadSession('lead-1'), leadSession('lead-2')];
+    const hook = renderHook(() => useOrcaLeadWorkerMap(sessions));
 
-    expect(first.result.current.workers).toEqual([]);
     await waitFor(() => {
-      expect(first.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-a']);
+      expect(Array.from(hook.result.current.get('lead-1') ?? [])).toEqual(['session-lead-1']);
+      expect(Array.from(hook.result.current.get('lead-2') ?? [])).toEqual(['session-lead-2']);
     });
-    await waitFor(() => {
-      expect(first.result.current.softLimit).toBe(3);
-      expect(first.result.current.hardLimit).toBe(6);
-    });
-    first.unmount();
 
-    mocks.listWorkersByLead.mockClear();
-    mocks.getCollaborationSettings.mockClear();
-    const second = renderHook(() => useWorkers('lead-1'));
-
-    expect(second.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-a']);
-    expect(second.result.current.focusedWorker?.sessionId).toBe('session-a');
-    expect(second.result.current.softLimit).toBe(3);
-    expect(second.result.current.hardLimit).toBe(6);
-    await waitFor(() => {
-      expect(mocks.listWorkersByLead).toHaveBeenCalledOnce();
-      expect(mocks.getCollaborationSettings).toHaveBeenCalledOnce();
-    });
-    second.unmount();
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(1);
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-1', 'lead-2']);
+    expect(mocks.listWorkersByLead).not.toHaveBeenCalled();
   });
 
-  it('keeps terminal workers occupying hard-limit slots across remounts', async () => {
-    mocks.listWorkersByLead.mockResolvedValue([
-      workerRecord('worker-a', 'session-a', true, 'running'),
-      workerRecord('worker-b', 'session-b', false, 'done'),
-      workerRecord('worker-c', 'session-c', false, 'error'),
-    ]);
-    mocks.getCollaborationSettings.mockResolvedValue({
-      workerSoftLimit: 2,
-      workerHardLimit: 3,
+  it('keeps projection owners when the lead collection is only reordered', async () => {
+    vi.useFakeTimers();
+    const hook = renderHook(({ sessions }) => useOrcaLeadWorkerMap(sessions), {
+      initialProps: { sessions: [leadSession('lead-1'), leadSession('lead-2')] },
     });
-    const first = renderHook(() => useWorkers('lead-1'));
-
-    await waitFor(() => {
-      expect(first.result.current.activeWorkerCount).toBe(3);
-      expect(first.result.current.hardLimit).toBe(3);
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
     });
-    first.unmount();
+    expect(hook.result.current.get('lead-1')?.has('session-lead-1')).toBe(true);
+    expect(hook.result.current.get('lead-2')?.has('session-lead-2')).toBe(true);
+    expect(__getWorkerProjectionOwnerCountForTest('lead-1')).toBe(1);
+    expect(__getWorkerProjectionOwnerCountForTest('lead-2')).toBe(1);
 
-    mocks.listWorkersByLead.mockClear();
-    mocks.getCollaborationSettings.mockClear();
-    const remount = renderHook(() => useWorkers('lead-1'));
-
-    expect(remount.result.current.activeWorkerCount).toBe(3);
-    expect(remount.result.current.hardLimit).toBe(3);
-    await waitFor(() => {
-      expect(mocks.listWorkersByLead).toHaveBeenCalledOnce();
-      expect(mocks.getCollaborationSettings).toHaveBeenCalledOnce();
+    mocks.listWorkersByLeads.mockClear();
+    mocks.subscribeOrcaWorkerChanged.mockClear();
+    hook.rerender({ sessions: [leadSession('lead-2'), leadSession('lead-1')] });
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
     });
-    remount.unmount();
+
+    expect(mocks.listWorkersByLeads).not.toHaveBeenCalled();
+    expect(mocks.subscribeOrcaWorkerChanged).not.toHaveBeenCalled();
+    expect(__getWorkerProjectionOwnerCountForTest('lead-1')).toBe(1);
+    expect(__getWorkerProjectionOwnerCountForTest('lead-2')).toBe(1);
   });
 
-  it('refreshes the cache when an ORCA_WORKER_CHANGED event arrives', async () => {
-    let onWorkerChanged: (() => void) | null = null;
-    mocks.subscribeOrcaWorkerChanged.mockImplementation(
-      (_leadSessionId: string, cb: () => void) => {
-        onWorkerChanged = cb;
-        return () => undefined;
-      },
+  it('retains and releases only lead owner diffs when the lead collection changes', async () => {
+    vi.useFakeTimers();
+    const hook = renderHook(({ sessions }) => useOrcaLeadWorkerMap(sessions), {
+      initialProps: { sessions: [leadSession('lead-1'), leadSession('lead-2')] },
+    });
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(callbacks.has('lead-1')).toBe(true);
+    expect(callbacks.has('lead-2')).toBe(true);
+
+    mocks.listWorkersByLeads.mockClear();
+    mocks.subscribeOrcaWorkerChanged.mockClear();
+    hook.rerender({ sessions: [leadSession('lead-2'), leadSession('lead-3')] });
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledOnce();
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-3']);
+    expect(mocks.subscribeOrcaWorkerChanged).toHaveBeenCalledOnce();
+    expect(mocks.subscribeOrcaWorkerChanged).toHaveBeenCalledWith('lead-3', expect.any(Function));
+    expect(callbacks.has('lead-1')).toBe(false);
+    expect(callbacks.has('lead-2')).toBe(true);
+    expect(callbacks.has('lead-3')).toBe(true);
+    expect(__getWorkerProjectionOwnerCountForTest('lead-1')).toBe(0);
+    expect(__getWorkerProjectionOwnerCountForTest('lead-2')).toBe(1);
+    expect(__getWorkerProjectionOwnerCountForTest('lead-3')).toBe(1);
+  });
+
+  it('chunks local projection hydration at the main IPC batch limit', async () => {
+    const releases = Array.from({ length: 201 }, (_, index) =>
+      retainWorkerProjection(`large-lead-${index}`),
     );
+
+    await waitFor(() => expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(2));
+    expect(mocks.listWorkersByLeads.mock.calls.map(([ids]) => ids.length)).toEqual([200, 1]);
+    expect(mocks.listWorkersByLead).not.toHaveBeenCalled();
+
+    for (const release of releases) release();
+  });
+
+  it('keeps one query and one subscription for multiple consumers of the same lead', async () => {
+    renderHook(() => {
+      useWorkers('lead-1');
+      useWorkers('lead-1');
+      return null;
+    });
+
+    await waitFor(() => expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(1));
+    expect(mocks.subscribeOrcaWorkerChanged).toHaveBeenCalledTimes(1);
+    expect(__getWorkerProjectionOwnerCountForTest('lead-1')).toBe(2);
+  });
+
+  it('does not fetch collaboration settings on mount and reads them for creation refresh', async () => {
     const hook = renderHook(() => useWorkers('lead-1'));
 
     await waitFor(() => {
-      expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-a']);
-    });
-
-    mocks.listWorkersByLead.mockResolvedValueOnce([workerRecord('worker-b', 'session-b', true)]);
-    await act(async () => {
-      onWorkerChanged?.();
-    });
-
-    await waitFor(() => {
-      expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-b']);
-    });
-    hook.unmount();
-
-    mocks.listWorkersByLead.mockResolvedValue([workerRecord('worker-b', 'session-b', true)]);
-    const remount = renderHook(() => useWorkers('lead-1'));
-    expect(remount.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-b']);
-    await waitFor(() => {
-      expect(remount.result.current.workers.map((worker) => worker.sessionId)).toEqual([
-        'session-b',
+      expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual([
+        'session-lead-1',
       ]);
     });
-    remount.unmount();
+    expect(mocks.getCollaborationSettings).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await revalidateActiveWorkerSettings('lead-1');
+    });
+    expect(mocks.getCollaborationSettings).toHaveBeenCalledOnce();
+    expect(hook.result.current.softLimit).toBe(3);
+    expect(hook.result.current.hardLimit).toBe(6);
+
+    let result!: Awaited<ReturnType<typeof hook.result.current.refreshCreationState>>;
+    await act(async () => {
+      result = await hook.result.current.refreshCreationState();
+    });
+
+    expect(mocks.getCollaborationSettings).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ status: 'applied', hardLimit: 6 });
+    expect(hook.result.current.hardLimit).toBe(6);
   });
 
-  it('refreshes workers and the authoritative hard limit together for creation checks', async () => {
+  it('joins the initial in-flight request when the tab becomes active', async () => {
+    vi.useFakeTimers();
+    const first = deferred<Record<string, unknown[]>>();
+    mocks.listWorkersByLeads.mockReturnValueOnce(first.promise);
+    renderHook(() => useWorkers('lead-1'));
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledOnce();
+
+    const activeRefresh = revalidateActiveWorkersProjection('lead-1');
+    first.resolve({ 'lead-1': [workerRecord('worker-a', 'session-a', true)] });
+    await act(async () => {
+      await activeRefresh;
+      await vi.advanceTimersByTimeAsync(101);
+    });
+
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledOnce();
+  });
+
+  it('refreshes only the changed lead and coalesces a burst of worker events', async () => {
+    vi.useFakeTimers();
+    __setWorkerProjectionCoalesceMsForTest(100);
+    const hook = renderHook(() => useOrcaLeadWorkerMap([
+      leadSession('lead-1'),
+      leadSession('lead-2'),
+    ]));
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(hook.result.current.get('lead-1')?.has('session-lead-1')).toBe(true);
+    mocks.listWorkersByLeads.mockClear();
+    mocks.listWorkersByLeads.mockResolvedValueOnce({
+      'lead-1': [workerRecord('worker-new', 'session-new', true)],
+    });
+
+    act(() => {
+      callbacks.get('lead-1')?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+    act(() => {
+      callbacks.get('lead-1')?.();
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(99);
+    });
+    expect(mocks.listWorkersByLeads).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.runOnlyPendingTimersAsync();
+    });
+    expect(hook.result.current.get('lead-1')?.has('session-new')).toBe(true);
+
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(1);
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledWith(['lead-1']);
+  });
+
+  it('single-flights active settings refreshes for one lead', async () => {
+    const settings = deferred<unknown>();
+    mocks.getCollaborationSettings.mockReturnValueOnce(settings.promise);
+
+    const first = revalidateActiveWorkerSettings('lead-1');
+    const second = revalidateActiveWorkerSettings('lead-1');
+    expect(first).toBe(second);
+    expect(mocks.getCollaborationSettings).toHaveBeenCalledOnce();
+
+    settings.resolve({ workerSoftLimit: 4, workerHardLimit: 7 });
+    await expect(first).resolves.toEqual({ status: 'applied', hardLimit: 7 });
+  });
+
+  it('makes an authoritative refresh wait for the final trailing request', async () => {
+    const first = deferred<Record<string, unknown[]>>();
+    const second = deferred<Record<string, unknown[]>>();
+    mocks.listWorkersByLeads.mockReturnValueOnce(first.promise);
     const hook = renderHook(() => useWorkers('lead-1'));
-    await waitFor(() => expect(hook.result.current.hardLimit).toBe(6));
+    await waitFor(() => expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(1));
 
-    mocks.listWorkersByLead.mockResolvedValue([
-      { ...workerRecord('worker-b', 'session-b', true), status: 'running' },
-    ]);
-    mocks.getCollaborationSettings.mockResolvedValue({
-      workerSoftLimit: 1,
-      workerHardLimit: 1,
+    let refreshPromise!: ReturnType<typeof hook.result.current.refresh>;
+    act(() => {
+      refreshPromise = hook.result.current.refresh();
+      callbacks.get('lead-1')?.();
     });
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(1);
 
-    let creationState!: Awaited<ReturnType<typeof hook.result.current.refreshCreationState>>;
-    await act(async () => {
-      creationState = await hook.result.current.refreshCreationState();
-    });
-
-    expect(creationState).toMatchObject({
-      status: 'applied',
-      hardLimit: 1,
-      workers: [{ sessionId: 'session-b', status: 'running' }],
-    });
-  });
-
-  it('only applies the latest out-of-order worker refresh for a lead', async () => {
-    const first = deferred<unknown[]>();
-    const second = deferred<unknown[]>();
-    mocks.listWorkersByLead
-      .mockReset()
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise);
-    mocks.getCollaborationSettings.mockReturnValue(new Promise(() => undefined));
-    const hook = renderHook(() => useWorkers('lead-1'));
-
-    let latestRefresh!: ReturnType<typeof hook.result.current.refresh>;
-    await act(async () => {
-      latestRefresh = hook.result.current.refresh();
+    mocks.listWorkersByLeads.mockReturnValueOnce(second.promise);
+    let refreshSettled = false;
+    void refreshPromise.then(() => {
+      refreshSettled = true;
     });
     await act(async () => {
-      second.resolve([workerRecord('worker-b', 'session-b', true)]);
-      await latestRefresh;
+      first.resolve({ 'lead-1': [workerRecord('worker-a', 'session-a', true)] });
     });
-    expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-b']);
+    await waitFor(() => expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(2));
+    expect(refreshSettled).toBe(false);
 
+    let result!: Awaited<typeof refreshPromise>;
     await act(async () => {
-      first.resolve([workerRecord('worker-a', 'session-a', true)]);
-      await flushAsyncUpdates();
+      second.resolve({ 'lead-1': [workerRecord('worker-b', 'session-b', true)] });
+      result = await refreshPromise;
     });
+    expect(result?.workers.map((worker) => worker.sessionId)).toEqual(['session-b']);
     expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-b']);
   });
 
-  it('does not let old lead worker or settings requests pollute the current hook snapshot', async () => {
-    const lead1Workers = deferred<unknown[]>();
-    const lead2Workers = deferred<unknown[]>();
-    const lead1Settings = deferred<unknown>();
-    const lead2Settings = deferred<unknown>();
-    mocks.listWorkersByLead.mockImplementation((leadSessionId: string) =>
-      leadSessionId === 'lead-1' ? lead1Workers.promise : lead2Workers.promise,
-    );
-    mocks.getCollaborationSettings.mockImplementation((leadSessionId: string) =>
-      leadSessionId === 'lead-1' ? lead1Settings.promise : lead2Settings.promise,
-    );
+  it('routes remote leads through per-lead listWorkersByLead without the local batch channel', async () => {
+    mocks.isRemoteSessionSticky.mockImplementation((leadSessionId: string) => leadSessionId === 'remote-lead');
+    const hook = renderHook(() => useWorkers('remote-lead'));
 
-    const hook = renderHook(({ lead }) => useWorkers(lead), {
-      initialProps: { lead: 'lead-1' },
-    });
-    hook.rerender({ lead: 'lead-2' });
-    expect(hook.result.current.workers).toEqual([]);
-
-    await act(async () => {
-      lead1Workers.resolve([workerRecord('worker-a', 'session-a', true)]);
-      lead1Settings.resolve({ workerSoftLimit: 1, workerHardLimit: 2 });
-      await flushAsyncUpdates();
-    });
-    expect(hook.result.current.workers).toEqual([]);
-    expect(hook.result.current.softLimit).toBe(5);
-    expect(hook.result.current.hardLimit).toBe(8);
-
-    await act(async () => {
-      lead2Workers.resolve([workerRecord('worker-b', 'session-b', true)]);
-      lead2Settings.resolve({ workerSoftLimit: 4, workerHardLimit: 7 });
-      await flushAsyncUpdates();
-    });
     await waitFor(() => {
-      expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-b']);
-      expect(hook.result.current.softLimit).toBe(4);
-      expect(hook.result.current.hardLimit).toBe(7);
+      expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-a']);
+    });
+
+    expect(mocks.listWorkersByLead).toHaveBeenCalledWith('remote-lead', 'remote-lead');
+    expect(mocks.listWorkersByLeads).not.toHaveBeenCalled();
+  });
+
+  it('keeps remote projection reads on the sticky device during a relay mapping gap', async () => {
+    const { remoteProjectsStore } = await import('@/features/device-link/remoteProjectsStore');
+    remoteProjectsStore.setDeviceSessions('dev-sticky', 'Mac', [leadSession('remote-sticky')]);
+    mocks.isRemoteSessionSticky.mockReturnValue(true);
+
+    const hook = renderHook(() => useWorkers('remote-sticky'));
+    await waitFor(() => expect(hook.result.current.workers).toHaveLength(1));
+
+    remoteProjectsStore.setDeviceSessions('dev-sticky', 'Mac', []);
+    mocks.listWorkersByLead.mockClear();
+    await act(async () => {
+      await hook.result.current.refresh();
+    });
+    expect(mocks.listWorkersByLead).toHaveBeenCalledWith('dev-sticky', 'remote-sticky');
+    expect(mocks.listWorkersByLeads).not.toHaveBeenCalled();
+  });
+
+  it('keeps old attention when a changed lead refresh fails', async () => {
+    vi.useFakeTimers();
+    mocks.listWorkersByLeads.mockResolvedValueOnce({
+      'lead-1': [workerRecord('worker-done', 'session-done', false, 'done')],
+    });
+    renderHook(() => useOrcaWorkerAttentionWatcher([leadSession('lead-1')], undefined));
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
+
+    mocks.listWorkersByLeads.mockRejectedValueOnce(new Error('db busy'));
+    act(() => callbacks.get('lead-1')?.());
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    expect(mocks.listWorkersByLeads).toHaveBeenCalledTimes(2);
+    expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
+  });
+
+  it('lets a detached renderer derive attention from its owned lead projection', async () => {
+    mocks.listWorkersByLeads.mockResolvedValueOnce({
+      'lead-1': [workerRecord('worker-done', 'session-done', false, 'done')],
+    });
+    renderHook(() => useOrcaWorkerAttentionByLeadIds(['lead-1'], undefined));
+
+    await waitFor(() => {
+      expect(__getWorkerAttentionSnapshotForTest().has('worker-done')).toBe(true);
     });
   });
 
-  it('does not render the previous lead cache on the first render after a lead switch', async () => {
-    const lead2Workers = deferred<unknown[]>();
-    mocks.listWorkersByLead.mockImplementation((leadSessionId: string) =>
-      leadSessionId === 'lead-1'
-        ? Promise.resolve([workerRecord('worker-a', 'session-a', true)])
-        : lead2Workers.promise,
-    );
-    mocks.getCollaborationSettings.mockReturnValue(new Promise(() => undefined));
+  it('keeps mounted consumers live after clearing an in-flight projection', async () => {
+    vi.useFakeTimers();
+    const stale = deferred<Record<string, unknown[]>>();
+    mocks.listWorkersByLeads
+      .mockReturnValueOnce(stale.promise)
+      .mockResolvedValueOnce({
+        'lead-1': [workerRecord('worker-new', 'session-new', true)],
+      });
+    const hook = renderHook(() => useWorkers('lead-1'));
+    await act(async () => {
+      await vi.runOnlyPendingTimersAsync();
+    });
+
+    const refresh = hook.result.current.refresh();
+    act(() => clearWorkersCache('lead-1'));
+    await expect(refresh).resolves.toMatchObject({ status: 'failed' });
+    await act(async () => {
+      await vi.runAllTimersAsync();
+      await Promise.resolve();
+    });
+    expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-new']);
+
+    await act(async () => {
+      stale.resolve({ 'lead-1': [workerRecord('worker-stale', 'session-stale', true)] });
+      await Promise.resolve();
+    });
+    expect(hook.result.current.workers.map((worker) => worker.sessionId)).toEqual(['session-new']);
+  });
+
+  it('does not render the previous lead projection on the first frame after a lead switch', async () => {
+    const lead2 = deferred<Record<string, unknown[]>>();
+    mocks.listWorkersByLeads.mockImplementation((leadSessionIds: string[]) => {
+      if (leadSessionIds.includes('lead-2')) return lead2.promise;
+      return Promise.resolve({
+        'lead-1': [workerRecord('worker-a', 'session-a', true)],
+      });
+    });
     const hook = renderHook(({ lead }) => useWorkers(lead), {
       initialProps: { lead: 'lead-1' },
     });
@@ -268,34 +468,6 @@ describe('useWorkers', () => {
 
     hook.rerender({ lead: 'lead-2' });
     expect(hook.result.current.workers).toEqual([]);
-  });
-
-  it('only applies the latest collaboration settings request for a lead', async () => {
-    const first = deferred<unknown>();
-    const second = deferred<unknown>();
-    mocks.getCollaborationSettings
-      .mockReset()
-      .mockReturnValueOnce(first.promise)
-      .mockReturnValueOnce(second.promise);
-    mocks.listWorkersByLead.mockReturnValue(new Promise(() => undefined));
-    const hook = renderHook(() => {
-      const left = useWorkers('lead-1');
-      useWorkers('lead-1');
-      return left;
-    });
-
-    await act(async () => {
-      second.resolve({ workerSoftLimit: 4, workerHardLimit: 7 });
-      await flushAsyncUpdates();
-    });
-    expect(hook.result.current.softLimit).toBe(4);
-    expect(hook.result.current.hardLimit).toBe(7);
-
-    await act(async () => {
-      first.resolve({ workerSoftLimit: 1, workerHardLimit: 2 });
-      await flushAsyncUpdates();
-    });
-    expect(hook.result.current.softLimit).toBe(4);
-    expect(hook.result.current.hardLimit).toBe(7);
+    lead2.resolve({ 'lead-2': [workerRecord('worker-b', 'session-b', true)] });
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaLeadWorkerMap.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaLeadWorkerMap.ts
@@ -1,8 +1,12 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import type { Session } from '@/lib/ccAgent.types';
 import { isOrcaLeadSession } from '@/lib/orcaSessionIdentity';
-import { orcaWorkflowsFor, subscribeOrcaWorkerChanged } from '@/lib/makerTransport';
+import {
+  getWorkerProjectionSnapshot,
+  useWorkerProjectionOwners,
+  useWorkerProjectionVersion,
+} from './workerProjectionStore';
 
 export function useOrcaLeadWorkerMap(
   sessions: readonly Session[],
@@ -15,43 +19,17 @@ export function useOrcaLeadWorkerMap(
     () => leadSessionIds.join('\0'),
     [leadSessionIds],
   );
-  const [map, setMap] = useState<Map<string, ReadonlySet<string>>>(() => new Map());
+  useWorkerProjectionOwners(leadSessionIds);
+  const version = useWorkerProjectionVersion();
 
-  useEffect(() => {
-    if (leadSessionIds.length === 0) {
-      setMap(new Map());
-      return;
-    }
-
-    let cancelled = false;
-    const refresh = () => void Promise.all(
-      leadSessionIds.map(async (leadSessionId) => {
-        const workers = await orcaWorkflowsFor(leadSessionId)
-          .listWorkersByLead(leadSessionId)
-          .catch(() => []);
-        return [leadSessionId, workers.map((worker) => worker.sessionId)] as const;
-      }),
-    ).then((entries) => {
-      if (cancelled) return;
-      setMap(new Map(entries.map(([leadSessionId, workerIds]) => [
+  return useMemo(() => {
+    return new Map(
+      leadSessionIds.map((leadSessionId) => [
         leadSessionId,
-        new Set(workerIds),
-      ])));
-    });
-    refresh();
-
-    // 每个 lead 按来源路由订阅 worker 变更:本机 lead → 本地 onOrcaWorkerChanged;
-    // 远程(device-link)lead → 被控端 maker:orca:worker-changed 经隧道转发。
-    // subscribeOrcaWorkerChanged 内部已按 leadSessionId 过滤,命中即重拉该批映射。
-    const unsubscribes = leadSessionIds.map((leadSessionId) =>
-      subscribeOrcaWorkerChanged(leadSessionId, refresh),
+        new Set(
+          getWorkerProjectionSnapshot(leadSessionId).workers.map((worker) => worker.sessionId),
+        ),
+      ]),
     );
-
-    return () => {
-      cancelled = true;
-      for (const unsubscribe of unsubscribes) unsubscribe();
-    };
-  }, [leadSessionKey]);
-
-  return map;
+  }, [leadSessionKey, version]);
 }

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerAttentionWatcher.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useOrcaWorkerAttentionWatcher.ts
@@ -4,6 +4,11 @@ import type { Session } from '@/lib/ccAgent.types';
 import { isOrcaLeadSession } from '@/lib/orcaSessionIdentity';
 import type { OrcaWorkerStatus } from '../../../../shared/orca-worker-status';
 import {
+  getWorkerProjectionSnapshot,
+  useWorkerProjectionOwners,
+  useWorkerProjectionVersion,
+} from './workerProjectionStore';
+import {
   clearWorkerAttentionMany,
   markWorkerAttention,
 } from '../lib/workerAttentionStore';
@@ -29,6 +34,7 @@ export function computeWorkerAttentionUpdates(
   const currentWorkerIds = new Set<string>();
   const nextStatusByWorkerId = new Map<string, OrcaWorkerStatus>();
   const toMark: string[] = [];
+  const toPrune: string[] = [];
 
   for (const worker of currentWorkers) {
     currentWorkerIds.add(worker.workerId);
@@ -44,7 +50,6 @@ export function computeWorkerAttentionUpdates(
     }
   }
 
-  const toPrune: string[] = [];
   for (const workerId of prevStatusByWorkerId.keys()) {
     if (!currentWorkerIds.has(workerId)) toPrune.push(workerId);
   }
@@ -52,42 +57,18 @@ export function computeWorkerAttentionUpdates(
   return { toMark, toPrune, nextStatusByWorkerId };
 }
 
-function toWorkerAttentionRecord(raw: unknown): WorkerAttentionRecord | null {
-  if (!raw || typeof raw !== 'object') return null;
-  const item = raw as Record<string, unknown>;
-  const workerId = item.id;
-  const leadSessionId = item.leadSessionId;
-  const status = item.status;
-  if (
-    typeof workerId !== 'string' ||
-    typeof leadSessionId !== 'string' ||
-    (status !== 'idle' && status !== 'running' && status !== 'done' && status !== 'error')
-  ) {
-    return null;
-  }
-  return {
-    workerId,
-    leadSessionId,
-    status,
-    focused: item.focused === true,
-  };
-}
-
-export function useOrcaWorkerAttentionWatcher(
-  sessions: readonly Session[],
+export function useOrcaWorkerAttentionByLeadIds(
+  rawLeadSessionIds: readonly string[],
   activeSessionId: string | undefined,
 ): void {
+  const leadSessionKey = [...new Set(rawLeadSessionIds)].join('\0');
   const leadSessionIds = useMemo(
-    () => sessions.filter(isOrcaLeadSession).map((s) => s.id),
-    [sessions],
+    () => (leadSessionKey ? leadSessionKey.split('\0') : []),
+    [leadSessionKey],
   );
-  const leadSessionKey = useMemo(
-    () => leadSessionIds.join('\0'),
-    [leadSessionIds],
-  );
+  useWorkerProjectionOwners(leadSessionIds);
+  const projectionVersion = useWorkerProjectionVersion();
   const prevStatusByWorkerIdRef = useRef<Map<string, OrcaWorkerStatus>>(new Map());
-  const refreshGenerationRef = useRef(0);
-  const appliedRefreshGenerationRef = useRef(0);
 
   useEffect(() => {
     if (leadSessionIds.length === 0) {
@@ -96,48 +77,33 @@ export function useOrcaWorkerAttentionWatcher(
       return;
     }
 
-    let cancelled = false;
-    const leadSessionIdSet = new Set(leadSessionIds);
-    const refresh = () => {
-      const generation = ++refreshGenerationRef.current;
-      void Promise.all(
-        leadSessionIds.map(async (leadSessionId) => {
-          const workers = await window.electronAPI.localDb.orcaWorkflows
-            .listWorkersByLead(leadSessionId)
-            .catch(() => []);
-          return workers;
-        }),
-      ).then((entries) => {
-        if (cancelled || generation < appliedRefreshGenerationRef.current) return;
-        const currentWorkers = entries
-          .flat()
-          .map(toWorkerAttentionRecord)
-          .filter((worker): worker is WorkerAttentionRecord => worker !== null);
-        const updates = computeWorkerAttentionUpdates(
-          prevStatusByWorkerIdRef.current,
-          currentWorkers,
-          activeSessionId,
-        );
-        for (const workerId of updates.toMark) markWorkerAttention(workerId);
-        clearWorkerAttentionMany(updates.toPrune);
-        prevStatusByWorkerIdRef.current = updates.nextStatusByWorkerId;
-        appliedRefreshGenerationRef.current = generation;
-      });
-    };
-    refresh();
-
-    const unsubscribe = window.electronAPI.localDb.orcaWorkflows.onOrcaWorkerChanged?.(
-      (payload: unknown) => {
-        const p = payload as { leadSessionId?: unknown };
-        if (typeof p.leadSessionId === 'string' && leadSessionIdSet.has(p.leadSessionId)) {
-          refresh();
-        }
-      },
+    const currentWorkers = leadSessionIds
+      .flatMap((leadSessionId) =>
+        getWorkerProjectionSnapshot(leadSessionId).workers.map((worker): WorkerAttentionRecord => ({
+          workerId: worker.workerId,
+          leadSessionId,
+          status: worker.status,
+          focused: worker.focused,
+        })),
+      );
+    const updates = computeWorkerAttentionUpdates(
+      prevStatusByWorkerIdRef.current,
+      currentWorkers,
+      activeSessionId,
     );
+    for (const workerId of updates.toMark) markWorkerAttention(workerId);
+    clearWorkerAttentionMany(updates.toPrune);
+    prevStatusByWorkerIdRef.current = updates.nextStatusByWorkerId;
+  }, [activeSessionId, leadSessionKey, projectionVersion]);
+}
 
-    return () => {
-      cancelled = true;
-      unsubscribe?.();
-    };
-  }, [activeSessionId, leadSessionKey]);
+export function useOrcaWorkerAttentionWatcher(
+  sessions: readonly Session[],
+  activeSessionId: string | undefined,
+): void {
+  const leadSessionIds = useMemo(
+    () => sessions.filter(isOrcaLeadSession).map((session) => session.id),
+    [sessions],
+  );
+  useOrcaWorkerAttentionByLeadIds(leadSessionIds, activeSessionId);
 }

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/useWorkers.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/useWorkers.ts
@@ -1,282 +1,47 @@
 /**
- * useWorkers — 封装 listWorkersByLead + ORCA_WORKER_CHANGED 实时刷新。
+ * useWorkers — 读取 renderer 进程内唯一的 Orca worker 投影。
  */
 
-import { useCallback, useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
-import { createLogger } from '@/lib/logger';
-import { orcaWorkflowsFor, subscribeOrcaWorkerChanged } from '@/lib/makerTransport';
-import { isActiveWorkerStatus, type OrcaWorkerStatus } from '../../../../shared/orca-worker-status';
+import { useCallback } from 'react';
 
-const log = createLogger('useWorkers');
+import {
+  clearWorkerProjectionStore,
+  getActiveWorkerCount,
+  refreshWorkerCreationState,
+  revalidateWorkersProjection,
+  useWorkerProjection,
+  useWorkerProjectionOwner,
+  type WorkerCreationRefreshResult,
+  type WorkersRefreshResult,
+} from './workerProjectionStore';
 
-export interface WorkerInfo {
-  workerId: string;
-  sessionId: string;
-  role: string;
-  agent: 'claude-code' | 'codex' | 'pi';
-  model: string;
-  effort: string | null;
-  label: string | null;
-  status: OrcaWorkerStatus;
-  focused: boolean;
-  idleSince: string | null;
-}
-
-const DEFAULT_SOFT_LIMIT = 5;
-const DEFAULT_HARD_LIMIT = 8;
-
-interface WorkersSnapshot {
-  workers: WorkerInfo[];
-  softLimit: number;
-  hardLimit: number;
-}
-
-export interface WorkersRefreshResult {
-  leadSessionId: string;
-  requestId: number;
-  status: 'applied' | 'failed';
-  workers: WorkerInfo[];
-}
-
-export interface WorkerCreationRefreshResult {
-  status: 'applied' | 'failed';
-  workers: WorkerInfo[];
-  hardLimit: number | null;
-}
-
-const DEFAULT_SNAPSHOT: WorkersSnapshot = {
-  workers: [],
-  softLimit: DEFAULT_SOFT_LIMIT,
-  hardLimit: DEFAULT_HARD_LIMIT,
-};
-const workersCache = new Map<string, WorkersSnapshot>();
-const workersRequestSeq = new Map<string, number>();
-const settingsRequestSeq = new Map<string, number>();
-const latestWorkersRequest = new Map<string, Promise<WorkersRefreshResult>>();
-const latestWorkersResult = new Map<string, WorkersRefreshResult>();
-const cacheSubscribers = new Map<string, Set<() => void>>();
-
-function mapWorkerRecord(raw: Record<string, unknown>): WorkerInfo {
-  const session = raw.session as Record<string, unknown> | undefined;
-  return {
-    workerId: raw.id as string,
-    sessionId: raw.sessionId as string,
-    role: (raw.role as string) ?? 'developer',
-    agent:
-      session?.agentKind === 'codex' ? 'codex' : session?.agentKind === 'pi' ? 'pi' : 'claude-code',
-    model: (session?.model as string) ?? 'claude-sonnet-4-6',
-    effort: (session?.effort as string | null) ?? null,
-    label: (raw.label as string | null) ?? null,
-    status: (raw.status as WorkerInfo['status']) ?? 'idle',
-    focused: (raw.focused as boolean) ?? false,
-    idleSince: (raw.idleSince as string | null) ?? null,
-  };
-}
-
-function readCachedSnapshot(leadSessionId: string | undefined): WorkersSnapshot {
-  if (!leadSessionId) return DEFAULT_SNAPSHOT;
-  return workersCache.get(leadSessionId) ?? DEFAULT_SNAPSHOT;
-}
-
-function writeCachedSnapshot(
-  leadSessionId: string,
-  patch: Partial<WorkersSnapshot>,
-): WorkersSnapshot {
-  const current = workersCache.get(leadSessionId) ?? DEFAULT_SNAPSHOT;
-  const next = { ...current, ...patch };
-  workersCache.set(leadSessionId, next);
-  cacheSubscribers.get(leadSessionId)?.forEach((listener) => listener());
-  return next;
-}
-
-function nextRequestId(sequences: Map<string, number>, leadSessionId: string): number {
-  const next = (sequences.get(leadSessionId) ?? 0) + 1;
-  sequences.set(leadSessionId, next);
-  return next;
-}
-
-function subscribeCachedSnapshot(leadSessionId: string, listener: () => void): () => void {
-  const listeners = cacheSubscribers.get(leadSessionId) ?? new Set<() => void>();
-  listeners.add(listener);
-  cacheSubscribers.set(leadSessionId, listeners);
-  return () => {
-    listeners.delete(listener);
-    if (listeners.size === 0) cacheSubscribers.delete(leadSessionId);
-  };
-}
-
-async function refreshWorkersSnapshot(leadSessionId: string): Promise<WorkersRefreshResult> {
-  const requestId = nextRequestId(workersRequestSeq, leadSessionId);
-  const request = orcaWorkflowsFor(leadSessionId)
-    .listWorkersByLead(leadSessionId)
-    .then((records) => {
-      const workers = (records as unknown as Array<Record<string, unknown>>).map(mapWorkerRecord);
-      if (workersRequestSeq.get(leadSessionId) === requestId) {
-        writeCachedSnapshot(leadSessionId, { workers });
-        const result = { leadSessionId, requestId, status: 'applied' as const, workers };
-        latestWorkersResult.set(leadSessionId, result);
-        return result;
-      }
-      return null;
-    })
-    .catch((err) => {
-      if (workersRequestSeq.get(leadSessionId) === requestId) {
-        log.warn('listWorkersByLead failed', err instanceof Error ? err.message : String(err));
-        const result = {
-          leadSessionId,
-          requestId,
-          status: 'failed' as const,
-          workers: readCachedSnapshot(leadSessionId).workers,
-        };
-        latestWorkersResult.set(leadSessionId, result);
-        return result;
-      }
-      return null;
-    })
-    .then(async (result): Promise<WorkersRefreshResult> => {
-      if (result) return result;
-      // 本请求已被同 Lead 的更新请求 supersede。等待当前最新请求收敛后返回其明确
-      // 结果，让调用方不会把 stale 完成误当成“最新列表确认不含目标 worker”。
-      const latest = latestWorkersRequest.get(leadSessionId);
-      if (latest && latest !== request) return latest;
-      return (
-        latestWorkersResult.get(leadSessionId) ?? {
-          leadSessionId,
-          requestId: workersRequestSeq.get(leadSessionId) ?? requestId,
-          status: 'failed',
-          workers: readCachedSnapshot(leadSessionId).workers,
-        }
-      );
-    });
-  latestWorkersRequest.set(leadSessionId, request);
-  void request.finally(() => {
-    if (latestWorkersRequest.get(leadSessionId) === request) {
-      latestWorkersRequest.delete(leadSessionId);
-    }
-  });
-  return request;
-}
-
-async function refreshSettingsSnapshot(leadSessionId: string): Promise<void> {
-  const requestId = nextRequestId(settingsRequestSeq, leadSessionId);
-  try {
-    const settings = await orcaWorkflowsFor(leadSessionId).getCollaborationSettings();
-    if (settingsRequestSeq.get(leadSessionId) !== requestId) return;
-    const s = settings as Record<string, unknown> | undefined;
-    if (!s) return;
-    const patch: Partial<WorkersSnapshot> = {};
-    if (typeof s.workerSoftLimit === 'number') patch.softLimit = s.workerSoftLimit;
-    if (typeof s.workerHardLimit === 'number') patch.hardLimit = s.workerHardLimit;
-    if (Object.keys(patch).length > 0) writeCachedSnapshot(leadSessionId, patch);
-  } catch {
-    // 设置读取失败沿用缓存 / 默认限额，不影响 worker 主视图。
-  }
-}
+export type {
+  WorkerCreationRefreshResult,
+  WorkerInfo,
+  WorkersRefreshResult,
+} from './workerProjectionStore';
 
 export function clearWorkersCache(leadSessionId?: string): void {
-  if (leadSessionId) {
-    workersCache.delete(leadSessionId);
-    workersRequestSeq.delete(leadSessionId);
-    settingsRequestSeq.delete(leadSessionId);
-    latestWorkersRequest.delete(leadSessionId);
-    latestWorkersResult.delete(leadSessionId);
-    cacheSubscribers.get(leadSessionId)?.forEach((listener) => listener());
-  } else {
-    workersCache.clear();
-    workersRequestSeq.clear();
-    settingsRequestSeq.clear();
-    latestWorkersRequest.clear();
-    latestWorkersResult.clear();
-    cacheSubscribers.forEach((listeners) => listeners.forEach((listener) => listener()));
-  }
-}
-
-function updateHookSnapshot(
-  setHookSnapshot: Dispatch<SetStateAction<{
-    leadSessionId: string | undefined;
-    snapshot: WorkersSnapshot;
-  }>>,
-  leadSessionId: string | undefined,
-): void {
-  setHookSnapshot((previous) => {
-    const snapshot = readCachedSnapshot(leadSessionId);
-    return previous.leadSessionId === leadSessionId && previous.snapshot === snapshot
-      ? previous
-      : { leadSessionId, snapshot };
-  });
+  clearWorkerProjectionStore(leadSessionId);
 }
 
 export function useWorkers(leadSessionId: string | undefined) {
-  const [hookSnapshot, setHookSnapshot] = useState<{
-    leadSessionId: string | undefined;
-    snapshot: WorkersSnapshot;
-  }>(() => ({ leadSessionId, snapshot: readCachedSnapshot(leadSessionId) }));
-  const currentLeadSessionIdRef = useRef(leadSessionId);
-  currentLeadSessionIdRef.current = leadSessionId;
+  useWorkerProjectionOwner(leadSessionId);
+  const snapshot = useWorkerProjection(leadSessionId);
 
   const refresh = useCallback(async (): Promise<WorkersRefreshResult | null> => {
-    if (!leadSessionId) {
-      updateHookSnapshot(setHookSnapshot, undefined);
-      return null;
-    }
-    // device-link:远程 lead 走隧道读被控端团队;本机 lead 原样走本机 DB(orcaWorkflowsFor 分流)。
-    return refreshWorkersSnapshot(leadSessionId);
+    if (!leadSessionId) return null;
+    return revalidateWorkersProjection(leadSessionId);
   }, [leadSessionId]);
 
   const refreshCreationState = useCallback(async (): Promise<WorkerCreationRefreshResult> => {
     if (!leadSessionId) return { status: 'failed', workers: [], hardLimit: null };
-    const [workersResult, settings] = await Promise.all([
-      refreshWorkersSnapshot(leadSessionId),
-      orcaWorkflowsFor(leadSessionId)
-        .getCollaborationSettings()
-        .catch(() => null),
-    ]);
-    const rawHardLimit = (settings as Record<string, unknown> | null)?.workerHardLimit;
-    const hardLimit =
-      typeof rawHardLimit === 'number' && Number.isFinite(rawHardLimit) && rawHardLimit >= 0
-        ? rawHardLimit
-        : null;
-    if (workersResult.status !== 'applied' || hardLimit === null) {
-      return { status: 'failed', workers: workersResult.workers, hardLimit };
-    }
-    return { status: 'applied', workers: workersResult.workers, hardLimit };
+    return refreshWorkerCreationState(leadSessionId);
   }, [leadSessionId]);
 
-  useEffect(() => {
-    updateHookSnapshot(setHookSnapshot, leadSessionId);
-    if (!leadSessionId) return;
-    return subscribeCachedSnapshot(leadSessionId, () => {
-      // lead 切换 render 与旧 effect cleanup 之间仍可能收到旧 Lead 通知；同步 ref
-      // 守住最后一道边界，旧 Lead 永远不能 set 当前 hook snapshot。
-      if (currentLeadSessionIdRef.current !== leadSessionId) return;
-      updateHookSnapshot(setHookSnapshot, leadSessionId);
-    });
-  }, [leadSessionId]);
-
-  useEffect(() => {
-    if (!leadSessionId) return;
-    void refresh();
-    void refreshSettingsSnapshot(leadSessionId);
-  }, [leadSessionId, refresh]);
-
-  // worker 变更实时刷新:按 lead 来源分流(本机 IPC 推送 / device-link 远程推送),
-  // 被控端 worker-changed 经隧道转发并按 leadSessionId 过滤。见 subscribeOrcaWorkerChanged。
-  useEffect(() => {
-    if (!leadSessionId) return;
-    return subscribeOrcaWorkerChanged(leadSessionId, refresh);
-  }, [refresh, leadSessionId]);
-
-  // lead prop 切换发生在 effect cleanup 之前；render 阶段若 state 仍属于旧 Lead，
-  // 同步改读新 Lead cache，绝不把旧 worker 列表闪到新会话首帧。
-  const currentSnapshot =
-    hookSnapshot.leadSessionId === leadSessionId
-      ? hookSnapshot.snapshot
-      : readCachedSnapshot(leadSessionId);
-  const { workers, softLimit, hardLimit } = currentSnapshot;
+  const { workers, softLimit, hardLimit } = snapshot;
   const focusedWorker = workers.find((w) => w.focused) ?? workers[0] ?? null;
-  // 与后端 activeCount 共用 shared/orca-worker-status 的判定, 避免漂移 (F6)。
-  // primitive 返回值不需要 useMemo 稳定身份。
-  const activeWorkerCount = workers.filter((w) => isActiveWorkerStatus(w.status)).length;
+  const activeWorkerCount = getActiveWorkerCount(workers);
 
   return {
     workers,

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/workerProjectionStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/workerProjectionStore.ts
@@ -1,0 +1,721 @@
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+
+import { getStickySessionDeviceId } from '@/features/device-link/stickySessionOrigin';
+import { createLogger } from '@/lib/logger';
+import {
+  isRemoteSessionSticky,
+  orcaWorkflowsFor,
+  orcaWorkflowsForDevice,
+  subscribeOrcaWorkerChanged,
+} from '@/lib/makerTransport';
+import { isActiveWorkerStatus, type OrcaWorkerStatus } from '../../../../shared/orca-worker-status';
+
+const log = createLogger('workerProjectionStore');
+
+export interface WorkerInfo {
+  workerId: string;
+  sessionId: string;
+  role: string;
+  agent: 'claude-code' | 'codex' | 'pi';
+  model: string;
+  effort: string | null;
+  label: string | null;
+  status: OrcaWorkerStatus;
+  focused: boolean;
+  idleSince: string | null;
+}
+
+export interface WorkersSnapshot {
+  workers: WorkerInfo[];
+  softLimit: number;
+  hardLimit: number;
+  workerStatus: 'idle' | 'applied' | 'failed';
+  requestId: number;
+  updatedAt: number;
+}
+
+export interface WorkersRefreshResult {
+  leadSessionId: string;
+  requestId: number;
+  status: 'applied' | 'failed';
+  workers: WorkerInfo[];
+}
+
+export interface WorkerCreationRefreshResult {
+  status: 'applied' | 'failed';
+  workers: WorkerInfo[];
+  hardLimit: number | null;
+}
+
+const DEFAULT_SOFT_LIMIT = 5;
+const DEFAULT_HARD_LIMIT = 8;
+const DEFAULT_SNAPSHOT: WorkersSnapshot = {
+  workers: [],
+  softLimit: DEFAULT_SOFT_LIMIT,
+  hardLimit: DEFAULT_HARD_LIMIT,
+  workerStatus: 'idle',
+  requestId: 0,
+  updatedAt: 0,
+};
+const DEFAULT_COALESCE_MS = 100;
+const ACTIVE_REVALIDATE_FRESH_MS = 1_000;
+const LOCAL_BATCH_CHUNK_SIZE = 200;
+
+interface LeadEntry {
+  snapshot: WorkersSnapshot;
+  listeners: Set<() => void>;
+  ownerCount: number;
+  unsubscribe: (() => void) | null;
+  requestSeq: number;
+  settingsSeq: number;
+  inFlight: Promise<WorkersRefreshResult> | null;
+  queuedRefresh: QueuedRefresh | null;
+  authoritativeWaiters: Set<(value: WorkersRefreshResult) => void>;
+  settingsInFlight: Promise<WorkerSettingsRefreshResult> | null;
+  settingsUpdatedAt: number;
+}
+
+interface QueuedRefresh {
+  promise: Promise<WorkersRefreshResult>;
+  resolve: (value: WorkersRefreshResult) => void;
+  timer: number | null;
+  ready: boolean;
+}
+
+interface WorkerSettingsRefreshResult {
+  status: 'applied' | 'failed';
+  hardLimit: number | null;
+}
+
+interface LocalBatchItem {
+  leadSessionId: string;
+  requestId: number;
+  entry: LeadEntry;
+  resolve: (value: WorkersRefreshResult) => void;
+}
+
+let coalesceMs = DEFAULT_COALESCE_MS;
+const entries = new Map<string, LeadEntry>();
+let globalVersion = 0;
+const globalListeners = new Set<() => void>();
+let localBatchTimer: number | null = null;
+const localBatchQueue = new Map<string, LocalBatchItem>();
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function scheduleTimer(cb: () => void, delayMs: number): number {
+  return window.setTimeout(cb, delayMs);
+}
+
+function clearTimer(timer: number): void {
+  window.clearTimeout(timer);
+}
+
+function stableLeadSessionIds(leadSessionIds: readonly string[]): string[] {
+  return [...new Set(leadSessionIds)].sort();
+}
+
+function stableLeadSessionIdsKey(leadSessionIds: readonly string[]): string {
+  return stableLeadSessionIds(leadSessionIds).join('\0');
+}
+
+function emitGlobal(): void {
+  globalVersion += 1;
+  for (const listener of globalListeners) listener();
+}
+
+function emitEntry(entry: LeadEntry): void {
+  for (const listener of entry.listeners) listener();
+  emitGlobal();
+}
+
+function getEntry(leadSessionId: string): LeadEntry {
+  let entry = entries.get(leadSessionId);
+  if (!entry) {
+    entry = {
+      snapshot: DEFAULT_SNAPSHOT,
+      listeners: new Set(),
+      ownerCount: 0,
+      unsubscribe: null,
+      requestSeq: 0,
+      settingsSeq: 0,
+      inFlight: null,
+      queuedRefresh: null,
+      authoritativeWaiters: new Set(),
+      settingsInFlight: null,
+      settingsUpdatedAt: 0,
+    };
+    entries.set(leadSessionId, entry);
+  }
+  return entry;
+}
+
+function mapWorkerRecord(raw: Record<string, unknown>): WorkerInfo {
+  const session = raw.session as Record<string, unknown> | undefined;
+  return {
+    workerId: raw.id as string,
+    sessionId: raw.sessionId as string,
+    role: (raw.role as string) ?? 'developer',
+    agent:
+      session?.agentKind === 'codex' ? 'codex' : session?.agentKind === 'pi' ? 'pi' : 'claude-code',
+    model: (session?.model as string) ?? 'claude-sonnet-4-6',
+    effort: (session?.effort as string | null) ?? null,
+    label: (raw.label as string | null) ?? null,
+    status: (raw.status as WorkerInfo['status']) ?? 'idle',
+    focused: (raw.focused as boolean) ?? false,
+    idleSince: (raw.idleSince as string | null) ?? null,
+  };
+}
+
+function writeWorkersSnapshot(
+  leadSessionId: string,
+  entry: LeadEntry,
+  requestId: number,
+  status: WorkersSnapshot['workerStatus'],
+  workers: WorkerInfo[],
+): WorkersRefreshResult {
+  entry.snapshot = {
+    ...entry.snapshot,
+    workers,
+    workerStatus: status,
+    requestId,
+    updatedAt: nowMs(),
+  };
+  emitEntry(entry);
+  return { leadSessionId, requestId, status: status === 'applied' ? 'applied' : 'failed', workers };
+}
+
+function failedWorkersResult(leadSessionId: string, entry: LeadEntry): WorkersRefreshResult {
+  return {
+    leadSessionId,
+    requestId: entry.requestSeq,
+    status: 'failed',
+    workers: entry.snapshot.workers,
+  };
+}
+
+function resolveAuthoritativeWaiters(entry: LeadEntry, result: WorkersRefreshResult): void {
+  if (entry.inFlight || entry.queuedRefresh || entry.authoritativeWaiters.size === 0) return;
+  const waiters = [...entry.authoritativeWaiters];
+  entry.authoritativeWaiters.clear();
+  for (const resolve of waiters) resolve(result);
+}
+
+function maybeStartQueuedRefresh(leadSessionId: string, entry: LeadEntry): void {
+  const queued = entry.queuedRefresh;
+  if (!queued?.ready || entry.inFlight) return;
+  entry.queuedRefresh = null;
+  if (queued.timer !== null) clearTimer(queued.timer);
+  const request = startLeadRequest(leadSessionId, entry);
+  void request.then(queued.resolve);
+}
+
+function finishLeadRequest(
+  leadSessionId: string,
+  entry: LeadEntry,
+  request: Promise<WorkersRefreshResult>,
+): void {
+  void request.then((result) => {
+    if (entry.inFlight !== request) return;
+    entry.inFlight = null;
+    maybeStartQueuedRefresh(leadSessionId, entry);
+    resolveAuthoritativeWaiters(entry, result);
+  });
+}
+
+function normalizeBatchResponse(
+  response: unknown,
+): Record<string, Array<Record<string, unknown>>> {
+  if (!response || typeof response !== 'object') return {};
+  return response as Record<string, Array<Record<string, unknown>>>;
+}
+
+function projectionWorkflowsFor(leadSessionId: string) {
+  const deviceId = getStickySessionDeviceId(leadSessionId);
+  return deviceId ? orcaWorkflowsForDevice(deviceId) : orcaWorkflowsFor(leadSessionId);
+}
+
+async function listLocalWorkersByLeads(
+  leadSessionIds: readonly string[],
+): Promise<Record<string, Array<Record<string, unknown>>>> {
+  const batchApi = window.electronAPI.localDb.orcaWorkflows.listWorkersByLeads;
+  if (!batchApi) {
+    const rows = await Promise.all(
+      leadSessionIds.map(async (leadSessionId) => {
+        const workers = await window.electronAPI.localDb.orcaWorkflows.listWorkersByLead(
+          leadSessionId,
+        );
+        return [
+          leadSessionId,
+          workers as unknown as Array<Record<string, unknown>>,
+        ] as const;
+      }),
+    );
+    return Object.fromEntries(rows);
+  }
+
+  const chunks: string[][] = [];
+  for (let index = 0; index < leadSessionIds.length; index += LOCAL_BATCH_CHUNK_SIZE) {
+    chunks.push(leadSessionIds.slice(index, index + LOCAL_BATCH_CHUNK_SIZE));
+  }
+  const responses = await Promise.all(chunks.map((chunk) => batchApi(chunk)));
+  return Object.assign({}, ...responses.map(normalizeBatchResponse));
+}
+
+function flushLocalBatch(): void {
+  localBatchTimer = null;
+  const batch = [...localBatchQueue.values()];
+  localBatchQueue.clear();
+  if (batch.length === 0) return;
+  const leadSessionIds = batch.map((item) => item.leadSessionId);
+  const request = listLocalWorkersByLeads(leadSessionIds);
+  void request
+    .then((raw) => {
+      const grouped = normalizeBatchResponse(raw);
+      for (const item of batch) {
+        if (item.entry.requestSeq !== item.requestId) {
+          item.resolve({
+            leadSessionId: item.leadSessionId,
+            requestId: item.entry.requestSeq,
+            status: 'failed',
+            workers: item.entry.snapshot.workers,
+          });
+        } else {
+          const workers = (grouped[item.leadSessionId] ?? []).map(mapWorkerRecord);
+          item.resolve(writeWorkersSnapshot(
+            item.leadSessionId,
+            item.entry,
+            item.requestId,
+            'applied',
+            workers,
+          ));
+        }
+      }
+    })
+    .catch((err) => {
+      log.warn('listWorkersByLeads failed', err instanceof Error ? err.message : String(err));
+      for (const item of batch) {
+        item.resolve(
+          item.entry.requestSeq === item.requestId
+            ? writeWorkersSnapshot(
+                item.leadSessionId,
+                item.entry,
+                item.requestId,
+                'failed',
+                item.entry.snapshot.workers,
+              )
+            : failedWorkersResult(item.leadSessionId, item.entry),
+        );
+      }
+    });
+}
+
+function enqueueLocalBatch(
+  leadSessionId: string,
+  entry: LeadEntry,
+  requestId: number,
+): Promise<WorkersRefreshResult> {
+  const request = new Promise<WorkersRefreshResult>((resolve) => {
+    localBatchQueue.set(leadSessionId, { leadSessionId, requestId, entry, resolve });
+    if (localBatchTimer === null) {
+      localBatchTimer = scheduleTimer(flushLocalBatch, 0);
+    }
+  });
+  entry.inFlight = request;
+  finishLeadRequest(leadSessionId, entry, request);
+  return request;
+}
+
+function startRemoteLeadRequest(
+  leadSessionId: string,
+  entry: LeadEntry,
+  requestId: number,
+): Promise<WorkersRefreshResult> {
+  const request = projectionWorkflowsFor(leadSessionId)
+    .listWorkersByLead(leadSessionId)
+    .then((records) => {
+      if (entry.requestSeq !== requestId) {
+        return {
+          leadSessionId,
+          requestId: entry.requestSeq,
+          status: 'failed' as const,
+          workers: entry.snapshot.workers,
+        };
+      }
+      const workers = (records as unknown as Array<Record<string, unknown>>).map(mapWorkerRecord);
+      return writeWorkersSnapshot(leadSessionId, entry, requestId, 'applied', workers);
+    })
+    .catch((err) => {
+      if (entry.requestSeq === requestId) {
+        log.warn('listWorkersByLead failed', err instanceof Error ? err.message : String(err));
+        return writeWorkersSnapshot(
+          leadSessionId,
+          entry,
+          requestId,
+          'failed',
+          entry.snapshot.workers,
+        );
+      }
+      return {
+        leadSessionId,
+        requestId: entry.requestSeq,
+        status: 'failed' as const,
+        workers: entry.snapshot.workers,
+      };
+    });
+  entry.inFlight = request;
+  finishLeadRequest(leadSessionId, entry, request);
+  return request;
+}
+
+function requestWorkersProjection(
+  leadSessionId: string,
+  options: {
+    mode?: 'join' | 'active' | 'authoritative' | 'event';
+    minFreshMs?: number;
+  } = {},
+): Promise<WorkersRefreshResult> {
+  const entry = getEntry(leadSessionId);
+  const mode = options.mode ?? 'join';
+  const minFreshMs = options.minFreshMs ?? 0;
+  if (
+    mode === 'active' &&
+    minFreshMs > 0 &&
+    entry.snapshot.workerStatus === 'applied' &&
+    nowMs() - entry.snapshot.updatedAt <= minFreshMs
+  ) {
+    return Promise.resolve({
+      leadSessionId,
+      requestId: entry.snapshot.requestId,
+      status: 'applied',
+      workers: entry.snapshot.workers,
+    });
+  }
+
+  if (mode === 'event') {
+    return queueWorkersRefresh(leadSessionId, entry, coalesceMs);
+  }
+
+  if (mode === 'authoritative') {
+    const settled = new Promise<WorkersRefreshResult>((resolve) => {
+      entry.authoritativeWaiters.add(resolve);
+    });
+    if (entry.inFlight || entry.queuedRefresh) {
+      void queueWorkersRefresh(leadSessionId, entry, 0);
+    } else {
+      startLeadRequest(leadSessionId, entry);
+    }
+    return settled;
+  }
+
+  if (entry.inFlight) return entry.inFlight;
+  if (entry.queuedRefresh) return entry.queuedRefresh.promise;
+  return startLeadRequest(leadSessionId, entry);
+}
+
+function queueWorkersRefresh(
+  leadSessionId: string,
+  entry: LeadEntry,
+  delayMs: number,
+): Promise<WorkersRefreshResult> {
+  const existing = entry.queuedRefresh;
+  if (existing) {
+    if (delayMs === 0 && !existing.ready) {
+      if (existing.timer !== null) clearTimer(existing.timer);
+      existing.timer = null;
+      existing.ready = true;
+      maybeStartQueuedRefresh(leadSessionId, entry);
+    } else if (delayMs > 0 && !existing.ready) {
+      if (existing.timer !== null) clearTimer(existing.timer);
+      existing.timer = scheduleTimer(() => {
+        existing.timer = null;
+        existing.ready = true;
+        maybeStartQueuedRefresh(leadSessionId, entry);
+      }, delayMs);
+    }
+    return existing.promise;
+  }
+
+  let resolveQueued!: (value: WorkersRefreshResult) => void;
+  const queued: QueuedRefresh = {
+    promise: new Promise<WorkersRefreshResult>((resolve) => {
+      resolveQueued = resolve;
+    }),
+    resolve: (value) => resolveQueued(value),
+    timer: null,
+    ready: delayMs === 0,
+  };
+  entry.queuedRefresh = queued;
+  if (delayMs > 0) {
+    queued.timer = scheduleTimer(() => {
+      queued.timer = null;
+      queued.ready = true;
+      maybeStartQueuedRefresh(leadSessionId, entry);
+    }, delayMs);
+  }
+  maybeStartQueuedRefresh(leadSessionId, entry);
+  return queued.promise;
+}
+
+function startLeadRequest(
+  leadSessionId: string,
+  entry: LeadEntry,
+): Promise<WorkersRefreshResult> {
+  const requestId = entry.requestSeq + 1;
+  entry.requestSeq = requestId;
+  if (isRemoteSessionSticky(leadSessionId)) {
+    return startRemoteLeadRequest(leadSessionId, entry, requestId);
+  }
+  return enqueueLocalBatch(leadSessionId, entry, requestId);
+}
+
+function invalidateLead(leadSessionId: string): void {
+  const entry = getEntry(leadSessionId);
+  if (entry.ownerCount <= 0) return;
+  void requestWorkersProjection(leadSessionId, { mode: 'event' });
+}
+
+export function retainWorkerProjection(leadSessionId: string | undefined): () => void {
+  if (!leadSessionId) return () => undefined;
+  const entry = getEntry(leadSessionId);
+  entry.ownerCount += 1;
+  if (entry.ownerCount === 1) {
+    entry.unsubscribe = subscribeOrcaWorkerChanged(leadSessionId, () => invalidateLead(leadSessionId));
+    void requestWorkersProjection(leadSessionId);
+  }
+  return () => {
+    entry.ownerCount = Math.max(0, entry.ownerCount - 1);
+    if (entry.ownerCount !== 0) return;
+    entry.unsubscribe?.();
+    entry.unsubscribe = null;
+    if (entry.queuedRefresh && entry.authoritativeWaiters.size === 0) {
+      if (entry.queuedRefresh.timer !== null) clearTimer(entry.queuedRefresh.timer);
+      entry.queuedRefresh.resolve(failedWorkersResult(leadSessionId, entry));
+      entry.queuedRefresh = null;
+    }
+  };
+}
+
+export function useWorkerProjectionOwner(leadSessionId: string | undefined): void {
+  useEffect(() => retainWorkerProjection(leadSessionId), [leadSessionId]);
+}
+
+export function useWorkerProjectionOwners(leadSessionIds: readonly string[]): void {
+  const key = stableLeadSessionIdsKey(leadSessionIds);
+  const retainedRef = useRef<Map<string, () => void>>(new Map());
+  const stableIds = useMemo(() => (key.length > 0 ? key.split('\0') : []), [key]);
+
+  useEffect(() => {
+    const retained = retainedRef.current;
+    const next = new Set(stableIds);
+    for (const [leadSessionId, release] of retained) {
+      if (!next.has(leadSessionId)) {
+        release();
+        retained.delete(leadSessionId);
+      }
+    }
+    for (const leadSessionId of stableIds) {
+      if (!retained.has(leadSessionId)) {
+        retained.set(leadSessionId, retainWorkerProjection(leadSessionId));
+      }
+    }
+  }, [stableIds]);
+
+  useEffect(() => {
+    return () => {
+      const retained = retainedRef.current;
+      for (const release of retained.values()) release();
+      retained.clear();
+    };
+  }, []);
+}
+
+export function getWorkerProjectionSnapshot(
+  leadSessionId: string | undefined,
+): WorkersSnapshot {
+  if (!leadSessionId) return DEFAULT_SNAPSHOT;
+  return entries.get(leadSessionId)?.snapshot ?? DEFAULT_SNAPSHOT;
+}
+
+export function subscribeWorkerProjection(
+  leadSessionId: string | undefined,
+  listener: () => void,
+): () => void {
+  if (!leadSessionId) return () => undefined;
+  const entry = getEntry(leadSessionId);
+  entry.listeners.add(listener);
+  return () => {
+    entry.listeners.delete(listener);
+  };
+}
+
+export function useWorkerProjection(leadSessionId: string | undefined): WorkersSnapshot {
+  return useSyncExternalStore(
+    (listener) => subscribeWorkerProjection(leadSessionId, listener),
+    () => getWorkerProjectionSnapshot(leadSessionId),
+    () => getWorkerProjectionSnapshot(leadSessionId),
+  );
+}
+
+export function subscribeAllWorkerProjections(listener: () => void): () => void {
+  globalListeners.add(listener);
+  return () => {
+    globalListeners.delete(listener);
+  };
+}
+
+export function getAllWorkerProjectionVersion(): number {
+  return globalVersion;
+}
+
+export function useWorkerProjectionVersion(): number {
+  return useSyncExternalStore(
+    subscribeAllWorkerProjections,
+    getAllWorkerProjectionVersion,
+    getAllWorkerProjectionVersion,
+  );
+}
+
+export function revalidateWorkersProjection(
+  leadSessionId: string,
+): Promise<WorkersRefreshResult> {
+  return requestWorkersProjection(leadSessionId, { mode: 'authoritative' });
+}
+
+export function revalidateActiveWorkersProjection(leadSessionId: string): Promise<WorkersRefreshResult> {
+  return requestWorkersProjection(leadSessionId, {
+    mode: 'active',
+    minFreshMs: ACTIVE_REVALIDATE_FRESH_MS,
+  });
+}
+
+function requestWorkerSettings(
+  leadSessionId: string,
+  minFreshMs = 0,
+): Promise<WorkerSettingsRefreshResult> {
+  const entry = getEntry(leadSessionId);
+  if (minFreshMs > 0 && nowMs() - entry.settingsUpdatedAt <= minFreshMs) {
+    return Promise.resolve({ status: 'applied', hardLimit: entry.snapshot.hardLimit });
+  }
+  if (entry.settingsInFlight) return entry.settingsInFlight;
+
+  const requestId = entry.settingsSeq + 1;
+  entry.settingsSeq = requestId;
+  const request = projectionWorkflowsFor(leadSessionId)
+    .getCollaborationSettings()
+    .then((settings) => {
+      if (entry.settingsSeq !== requestId) return { status: 'failed' as const, hardLimit: null };
+      const raw = settings as Record<string, unknown> | null;
+      const rawHardLimit = raw?.workerHardLimit;
+      const rawSoftLimit = raw?.workerSoftLimit;
+      const hardLimit =
+        typeof rawHardLimit === 'number' && Number.isFinite(rawHardLimit) && rawHardLimit >= 0
+          ? rawHardLimit
+          : null;
+      const softLimit =
+        typeof rawSoftLimit === 'number' && Number.isFinite(rawSoftLimit) && rawSoftLimit >= 0
+          ? rawSoftLimit
+          : null;
+      if (hardLimit === null) return { status: 'failed' as const, hardLimit: null };
+      entry.snapshot = {
+        ...entry.snapshot,
+        hardLimit,
+        ...(softLimit !== null ? { softLimit } : {}),
+      };
+      entry.settingsUpdatedAt = nowMs();
+      emitEntry(entry);
+      return { status: 'applied' as const, hardLimit };
+    })
+    .catch(() => ({ status: 'failed' as const, hardLimit: null }));
+  entry.settingsInFlight = request;
+  void request.finally(() => {
+    if (entry.settingsInFlight === request) entry.settingsInFlight = null;
+  });
+  return request;
+}
+
+export function revalidateActiveWorkerSettings(
+  leadSessionId: string,
+): Promise<WorkerSettingsRefreshResult> {
+  return requestWorkerSettings(leadSessionId, ACTIVE_REVALIDATE_FRESH_MS);
+}
+
+export async function refreshWorkerCreationState(
+  leadSessionId: string,
+): Promise<WorkerCreationRefreshResult> {
+  const [workersResult, settingsResult] = await Promise.all([
+    requestWorkersProjection(leadSessionId, { mode: 'authoritative' }),
+    requestWorkerSettings(leadSessionId),
+  ]);
+  if (workersResult.status !== 'applied' || settingsResult.status !== 'applied') {
+    return {
+      status: 'failed',
+      workers: workersResult.workers,
+      hardLimit: settingsResult.hardLimit,
+    };
+  }
+  return {
+    status: 'applied',
+    workers: workersResult.workers,
+    hardLimit: settingsResult.hardLimit,
+  };
+}
+
+export function getActiveWorkerCount(workers: readonly WorkerInfo[]): number {
+  return workers.filter((w) => isActiveWorkerStatus(w.status)).length;
+}
+
+export function clearWorkerProjectionStore(leadSessionId?: string): void {
+  const clearEntry = (id: string, entry: LeadEntry) => {
+    entry.requestSeq += 1;
+    entry.settingsSeq += 1;
+    entry.inFlight = null;
+    entry.settingsInFlight = null;
+    const failed = failedWorkersResult(id, entry);
+    const queuedBatchItem = localBatchQueue.get(id);
+    if (queuedBatchItem?.entry === entry) {
+      localBatchQueue.delete(id);
+      queuedBatchItem.resolve(failed);
+    }
+    if (entry.queuedRefresh) {
+      if (entry.queuedRefresh.timer !== null) clearTimer(entry.queuedRefresh.timer);
+      entry.queuedRefresh.resolve(failed);
+      entry.queuedRefresh = null;
+    }
+    for (const resolve of entry.authoritativeWaiters) resolve(failed);
+    entry.authoritativeWaiters.clear();
+    entry.unsubscribe?.();
+    entry.unsubscribe = null;
+    entry.snapshot = { ...DEFAULT_SNAPSHOT };
+    entry.settingsUpdatedAt = 0;
+    emitEntry(entry);
+
+    if (entry.ownerCount > 0) {
+      entry.unsubscribe = subscribeOrcaWorkerChanged(id, () => invalidateLead(id));
+      void requestWorkersProjection(id);
+    } else if (entry.listeners.size === 0) {
+      entries.delete(id);
+    }
+  };
+  if (leadSessionId) {
+    const entry = entries.get(leadSessionId);
+    if (entry) clearEntry(leadSessionId, entry);
+  } else {
+    for (const [id, entry] of entries) clearEntry(id, entry);
+  }
+  if (localBatchQueue.size === 0 && localBatchTimer !== null) {
+    clearTimer(localBatchTimer);
+    localBatchTimer = null;
+  }
+  emitGlobal();
+}
+
+export function __setWorkerProjectionCoalesceMsForTest(value: number): void {
+  coalesceMs = value;
+}
+
+export function __getWorkerProjectionOwnerCountForTest(leadSessionId: string): number {
+  return entries.get(leadSessionId)?.ownerCount ?? 0;
+}

--- a/apps/desktop/src/renderer/features/cc-agent/hooks/workerProjectionStore.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/hooks/workerProjectionStore.ts
@@ -232,6 +232,10 @@ function normalizeBatchResponse(
   return response as Record<string, Array<Record<string, unknown>>>;
 }
 
+function hasOwnKey(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
 function projectionWorkflowsFor(leadSessionId: string) {
   const deviceId = getStickySessionDeviceId(leadSessionId);
   return deviceId ? orcaWorkflowsForDevice(deviceId) : orcaWorkflowsFor(leadSessionId);
@@ -283,7 +287,21 @@ function flushLocalBatch(): void {
             workers: item.entry.snapshot.workers,
           });
         } else {
-          const workers = (grouped[item.leadSessionId] ?? []).map(mapWorkerRecord);
+          const records = grouped[item.leadSessionId];
+          if (!hasOwnKey(grouped, item.leadSessionId) || !Array.isArray(records)) {
+            log.warn('listWorkersByLeads returned invalid lead entry', {
+              leadSessionId: item.leadSessionId,
+            });
+            item.resolve(writeWorkersSnapshot(
+              item.leadSessionId,
+              item.entry,
+              item.requestId,
+              'failed',
+              item.entry.snapshot.workers,
+            ));
+            continue;
+          }
+          const workers = records.map(mapWorkerRecord);
           item.resolve(writeWorkersSnapshot(
             item.leadSessionId,
             item.entry,

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/orca-workers/index.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/orca-workers/index.tsx
@@ -6,7 +6,7 @@
  * disableOrca；body 未挂载时 onBeforeClose fail-closed,拒绝误关协同。
  */
 
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 import { UsersRound } from 'lucide-react';
 import type { TFunction } from 'i18next';
 
@@ -14,12 +14,19 @@ import { AttentionDot } from '@/components/sidebar/AttentionDot';
 import { useCCSessions } from '@/hooks/useCCSessions';
 import { useRemoteProjectSessions } from '@/features/device-link/remoteProjectsStore';
 import { OrcaWorkerPanel } from '@/features/cc-agent/OrcaWorkerPanel';
+import { useOrcaWorkerAttentionByLeadIds } from '@/features/cc-agent/hooks/useOrcaWorkerAttentionWatcher';
 import { useStopOrcaCollab } from '@/features/cc-agent/hooks/useStopOrcaCollab';
-import { useWorkers } from '@/features/cc-agent/hooks/useWorkers';
+import {
+  revalidateActiveWorkerSettings,
+  revalidateActiveWorkersProjection,
+  useWorkerProjection,
+  useWorkerProjectionOwner,
+} from '@/features/cc-agent/hooks/workerProjectionStore';
 import { mergeSessionSources } from '@/features/cc-agent/lib/mergeSessionSources';
 import { useWorkerAttentionSnapshot } from '@/features/cc-agent/lib/workerAttentionStore';
 import { useDocumentVisible, useWindowVisible } from '@/hooks/useWindowVisible';
 import { isOrcaLeadSession } from '@/lib/orcaSessionIdentity';
+import { isSidebarWindow } from '@/lib/sidebarWindow';
 import * as sessionService from '@/lib/sessionService';
 import { createLogger } from '@/lib/logger';
 import { registerTabKind } from '../../registry';
@@ -58,8 +65,8 @@ function OrcaWorkersTabPillIcon({
 
 function OrcaWorkersAttentionDot({ sessionId }: { sessionId: string }) {
   const attention = useWorkerAttentionSnapshot();
-  const { workers } = useWorkers(sessionId);
-  const hasAttention = workers.some((worker) => attention.has(worker.workerId));
+  const projection = useWorkerProjection(sessionId);
+  const hasAttention = projection.workers.some((worker) => attention.has(worker.workerId));
   if (!hasAttention) return null;
 
   return (
@@ -84,10 +91,19 @@ function OrcaWorkersTabBody({
   active?: boolean;
   shellVisible?: boolean;
 }) {
+  useWorkerProjectionOwner(ctx.sessionId);
   const windowVisible = useWindowVisible(Boolean(active && shellVisible));
   const documentVisible = useDocumentVisible(Boolean(active && shellVisible));
   const viewVisible = Boolean(active && shellVisible && windowVisible);
   const chatRealtime = Boolean(active && shellVisible && documentVisible);
+  const detachedLeadSessionIds = useMemo(
+    () => (isSidebarWindow() ? [ctx.sessionId] : []),
+    [ctx.sessionId],
+  );
+  useOrcaWorkerAttentionByLeadIds(
+    detachedLeadSessionIds,
+    viewVisible ? ctx.sessionId : undefined,
+  );
   const { sessions, isLoading } = useCCSessions();
   const remoteSessions = useRemoteProjectSessions();
   const leadSession =
@@ -106,6 +122,11 @@ function OrcaWorkersTabBody({
   }, [closeDecision, requestStop]);
 
   useEffect(() => ctx.setCloseInterceptor(closeHandler), [closeHandler, ctx]);
+  useEffect(() => {
+    if (!active || !shellVisible || !windowVisible) return;
+    void revalidateActiveWorkersProjection(ctx.sessionId);
+    void revalidateActiveWorkerSettings(ctx.sessionId);
+  }, [active, ctx.sessionId, shellVisible, windowVisible]);
 
   const handleFocusWorkerSessionIdConsumed = useCallback(
     (revision: number) => {

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -690,7 +690,9 @@ export function orcaWorkflowsForDevice(deviceId: string): RoutableOrcaWorkflows 
  * 返回 unsubscribe。
  */
 export function subscribeOrcaWorkerChanged(leadSessionId: string, cb: () => void): () => void {
-  const deviceId = getSessionDeviceId(leadSessionId);
+  // 订阅与 Orca 投影查询一样使用粘滞归属。relay 瞬时重连会清空
+  // remoteProjectsStore；此时不能把仍属于被控端的 Lead 改订到控制端本机事件源。
+  const deviceId = getStickySessionDeviceId(leadSessionId);
   if (!deviceId) {
     return (
       window.electronAPI.localDb.orcaWorkflows.onOrcaWorkerChanged?.((payload: unknown) => {

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3771,6 +3771,7 @@ interface ElectronAPI {
       getByLeadSession: (leadSessionId: string) => Promise<OrcaTeamRecord | null>;
       getByWorkerSession: (workerSessionId: string) => Promise<OrcaTeamRecord | null>;
       listWorkersByLead: (leadSessionId: string) => Promise<OrcaWorkerRecord[]>;
+      listWorkersByLeads?: (leadSessionIds: string[]) => Promise<Record<string, OrcaWorkerRecord[]>>;
       updateWorkerStatus: (
         workerId: string,
         status: 'idle' | 'running' | 'done' | 'error',

--- a/packages/device-link/src/__tests__/allowlist.test.ts
+++ b/packages/device-link/src/__tests__/allowlist.test.ts
@@ -71,6 +71,7 @@ describe('REMOTE_INVOKE_ALLOWLIST', () => {
     ]) {
       expect(REMOTE_INVOKE_ALLOWLIST.has(ch)).toBe(true);
     }
+    expect(REMOTE_INVOKE_ALLOWLIST.has('local-db:orca-workflows:list-workers-by-leads')).toBe(false);
   });
 
   it('放行 workflow 逐 agent 进度树只读(记录文件真相在被控端 HOME,控制端本机读必落空)', () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Sidebar Worker Tab 在 Orca Team 较多时点击无响应、Worker 呼吸灯不更新的问题。

根因不是 Worker Tab 的点击事件本身，而是多个常驻组件分别监听同一 Worker 事件，并对所有 Lead 重复执行 `listWorkersByLead`。这些查询共同进入同一个 DB worker transport，现场曾持续打满 `inFlight=128 / queued=512`，从而阻塞 Worker 切换和其他数据库查询。

本次将 Worker 状态收敛到 renderer 内唯一的共享投影：

- 同一 Lead 的多个消费者共享快照、订阅和查询。
- 本地首次加载使用只读批量 IPC；远程 Lead 继续走原有逐 Lead 路由。
- `ORCA_WORKER_CHANGED` 只刷新发生变化的 Lead。
- 100ms 内连续事件合并为一次尾随刷新。
- renderer 和 main 两侧均合并同 Lead 并发查询。
- Worker 写入广播时使旧的在途查询失效，避免写后加入旧查询。
- 查询失败时保留旧快照，不错误清除未读通知。
- 主窗口、rail 和 detached Sidebar 继续使用相同的状态语义。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Sidebar Worker Tab IPC 队列过载与状态刷新延迟
- 本 PR 包含：Worker 投影共享、本地批量只读 IPC、事件按 Lead 刷新、single-flight、trailing coalescing、detached Sidebar 状态同步。
- 明确不包含：Lead 列表虚拟化、逐行可见性、远程批量协议、数据库 schema、Worker 数量文案调整。
- 用户可见变化：Worker Tab 不再因 DB 队列过载卡死；派发后无需切换主任务即可看到呼吸灯和 Worker 状态。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及。没有修改视觉、布局、样式或文案，仅替换 Worker 数据读取和刷新策略。

## 怎么验证的

### 性能对比

真实 Desktop A/B 使用同一共享 userData、中国区、同一 Playground Lead，各执行三轮。baseline 为 clean `main`，feature 为本分支实现。

| 指标 | 优化前 clean main | 优化后 feature | 结果 |
| --- | ---: | ---: | ---: |
| `list-workers-by-lead` / `rawAll` 队列过载或拒绝 | 1124 / 311 / 241，合计 **1676** 次 | 0 / 0 / 0，合计 **0** 次 | **下降 100%** |
| DB worker 峰值 | 反复达到 `inFlight=128 / queued=512` | 未观察到队列打满 | 队列饱和消失 |
| Renderer long task（固定样本窗口） | 4 / 2 / 4，合计 **10** 次 | 0 / 0 / 0，合计 **0** 次 | **下降 100%** |
| Worker 点击到 first paint | 47ms / 未记录 / 未记录；另有一次窗口外 31.6s 记录 | 17ms / 16ms / 17ms，中位数 **17ms** | feature 完整且稳定；baseline 样本不完整，不计算百分比 |
| `switchFocus` IPC | baseline 无同口径日志 | 1ms / 1ms / 1ms | feature 稳定返回 |

自动化 harness 对查询放大进行了直接计数：

| 场景 | 优化前 | 优化后 |
| --- | ---: | ---: |
| 2 个本地 Lead 首次水合 | 2 次单 Lead IPC | 1 次 batch IPC |
| 同一 Lead 的 2 个 `useWorkers` 消费者 | 2 次查询、2 个订阅、2 次 settings 读取 | 1 次查询、1 个订阅、0 次 mount settings 读取 |
| 同一 Lead 100ms 内连续 2 个事件 | 每个事件触发多套全量 Lead 刷新 | 1 次 changed-Lead 刷新 |
| main 同 Lead 并发读取 | 各自进入底层查询 | 合并为 1 次底层读取 |

### 自动验证

```text
pnpm test:unit
结果：通过

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/device-link run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/renderer/features/cc-agent/hooks/__tests__/useWorkers.test.tsx \
  src/main/localDb/__tests__/orcaTeamStore.test.ts \
  src/main/localDb/ipc/__tests__/orcaTeams.test.ts \
  src/main/maker-host/__tests__/orcaWorkerBroadcast.test.ts \
  src/renderer/__tests__/orcaWorkerProjectionContracts.test.ts \
  src/renderer/__tests__/orcaWorkerAttentionWatcher.test.ts \
  src/renderer/__tests__/orcaWorkerAttentionWatcherMount.test.ts \
  src/renderer/__tests__/orcaRemoteRoutingInvariants.test.ts \
  src/renderer/__tests__/makerTransportOrcaRouting.test.ts \
  src/main/__tests__/makerSendToSessionOrdering.test.ts
结果：10 files / 96 tests passed

改动文件 ESLint（不含存在主干既有 4 个 unused 错误的 register.ts）
结果：通过

git diff --check
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

2026-08-03，在 macOS、中国区、共享 userData 的 remote dev 模式下使用 `agent-browser` 验证主窗口和 detached Sidebar：

- 派发后不切换主任务，约 407ms 可见 Worker running 状态。
- 主任务呼吸灯自动更新。
- detached Sidebar 同步显示 Worker 状态和内容。
- Worker Tab 点击及 Worker 切换无卡死、无空白等待。
- 测试窗口内未出现 DB worker overload、`INVALID_PARAMS` 或 `DEVICE_LINK_NOT_CONNECTED`。

### 未执行的验证

- 未在 Windows 上执行真实 Desktop E2E；跨平台路径不涉及新增平台相关逻辑，Windows 由 CI 单元测试矩阵继续覆盖。
- inactive Worker Tab 的真实红点流程未单独重跑；相关历史语义保持不变并由单元测试覆盖。
- 上述真实 E2E 在最终同步最新 `main` 前完成；本分支重放到最新主干时无冲突，最终提交已重新通过全量单测、定向测试和 typecheck。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Renderer 共享投影与本地只读批量 IPC

### 影响与回滚

- 影响范围：Desktop Renderer 的 Orca Worker 状态投影，以及 main 侧只读 Worker list IPC。
- 不修改 SQLite schema 或 migration。
- 不修改 device-link wire protocol；批量 channel 明确不进入远程 allowlist。
- 远程 Lead 继续使用原有逐 Lead channel 和粘滞设备路由。
- SSH remote 不新增本地 workdir 或文件读取。
- Mobile 不新增入口或 UI；控制端继续复用既有远程 channel。
- 主窗口和 detached Sidebar 是独立 renderer，各自维护投影；main 侧 single-flight 合并同 Lead 的跨窗口并发读取。
- 回滚 / 降级方式：整体恢复原 `useWorkers`、`useOrcaLeadWorkerMap` 和 attention watcher 的独立查询实现，并移除本地 batch IPC。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明不涉及视觉变化
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认本次无需新增说明文档
- [x] 已确认测试结果或说明未执行原因
