### PR TITLE
feat(desktop): support DeepSeek Flash native Responses API

### DIFF
--- a/apps/desktop/src/main/__tests__/updateScriptMacOS.test.ts
+++ b/apps/desktop/src/main/__tests__/updateScriptMacOS.test.ts
@@ -35,6 +35,19 @@ import { MACOS_UPDATE_RELAUNCH_ARG } from '../updateRelaunchSafety';
 
 const isDarwin = process.platform === 'darwin';
 
+function canInspectProcessesWithPgrep(): boolean {
+  if (!isDarwin) return false;
+  try {
+    execFileSync('/usr/bin/pgrep', ['-f', `cindy-pgrep-capability-${process.pid}`], { stdio: 'ignore' });
+    return true;
+  } catch (err) {
+    // status 1 = pgrep 正常工作、只是没有匹配；status 3 = 当前沙箱/系统无法读取进程表。
+    return (err as { status?: number }).status === 1;
+  }
+}
+
+const canRunMacProcessBehavior = canInspectProcessesWithPgrep();
+
 function makeParams(overrides: Partial<MacUpdateScriptParams> = {}): MacUpdateScriptParams {
   return {
     pid: 12345,
@@ -147,14 +160,23 @@ function shellScript(body: string): string {
  *   'noop'    — stub open does nothing (verification-failure path)
  */
 function makeSandbox(openBehavior: 'launch' | 'noop'): Sandbox {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'xdt-upd-test-'));
+  // macOS 把 /var 规范化成 /private/var 后写进进程命令行；生成脚本的 pgrep
+  // 使用字面路径匹配，因此 fixture 也必须先取真实路径，避免测试误判 helper 不存在。
+  const root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'xdt-upd-test-')));
   const appPath = path.join(root, 'Installed', 'fake (2).app');
   const helperDir = path.join(appPath, 'Contents', 'Frameworks', 'fake Helper (Renderer).app', 'Contents', 'MacOS');
   const mainDir = path.join(appPath, 'Contents', 'MacOS');
   fs.mkdirSync(helperDir, { recursive: true });
   fs.mkdirSync(mainDir, { recursive: true });
-  fs.writeFileSync(path.join(mainDir, 'fakemain'), shellScript('sleep 300'), { mode: 0o755 });
-  fs.writeFileSync(path.join(helperDir, 'fakehelper'), shellScript('sleep 300'), { mode: 0o755 });
+  // 保持解释器进程的 argv 中带 bundle 路径；单条 `sleep 300` 会被 bash 尾调用
+  // 优化成 sleep，pgrep -f 无法再识别它来自哪个 .app。
+  const persistentProcess = 'while true; do sleep 1; done';
+  fs.writeFileSync(path.join(mainDir, 'fakemain'), shellScript(persistentProcess), { mode: 0o755 });
+  fs.writeFileSync(
+    path.join(helperDir, 'fakehelper'),
+    shellScript(`trap '' TERM\n${persistentProcess}`),
+    { mode: 0o755 },
+  );
   fs.writeFileSync(path.join(appPath, 'Contents', 'version.txt'), 'old');
 
   // New bundle → zip (ditto -c -k, same tool the real flow unpacks with).
@@ -163,7 +185,7 @@ function makeSandbox(openBehavior: 'launch' | 'noop'): Sandbox {
   fs.mkdirSync(path.join(newApp, 'Contents', 'MacOS'), { recursive: true });
   fs.writeFileSync(
     path.join(newApp, 'Contents', 'MacOS', 'fakemain'),
-    shellScript('sleep 300'),
+    shellScript(persistentProcess),
     { mode: 0o755 },
   );
   fs.writeFileSync(path.join(newApp, 'Contents', 'version.txt'), 'new');
@@ -219,7 +241,7 @@ function pidAlive(pid: number): boolean {
   try { process.kill(pid, 0); return true; } catch { return false; }
 }
 
-describe.runIf(isDarwin)('generated script behavior (darwin)', () => {
+describe.runIf(canRunMacProcessBehavior)('generated script behavior (darwin)', () => {
   it('SIGKILLs a hung app PID, clears a surviving Frameworks helper, swaps and verifies', async () => {
     const sb = makeSandbox('launch');
     try {

--- a/apps/desktop/src/main/cindy-media/__tests__/attachmentGrantGate.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/attachmentGrantGate.test.ts
@@ -13,6 +13,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/never-used-here' },
@@ -23,10 +24,9 @@ const ledger = await import('../ledger');
 const { chatAttachmentOrigin } = await import('../attachmentGrantGate');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 const HASH = 'a'.repeat(64);
 

--- a/apps/desktop/src/main/cindy-media/__tests__/chatAttachments.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/chatAttachments.test.ts
@@ -14,6 +14,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 let tmpUserData = '';
 
@@ -25,10 +26,9 @@ const schema = await import('../../localDb/schema');
 const chatAttachments = await import('../chatAttachments');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 42]);
 const PNG_HASH = createHash('sha256').update(PNG_BYTES).digest('hex');

--- a/apps/desktop/src/main/cindy-media/__tests__/generatedMedia.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/generatedMedia.test.ts
@@ -14,6 +14,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 let tmpUserData = '';
 
@@ -25,10 +26,9 @@ const schema = await import('../../localDb/schema');
 const generatedMedia = await import('../generatedMedia');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 9]);
 const PNG_HASH = createHash('sha256').update(PNG_BYTES).digest('hex');

--- a/apps/desktop/src/main/cindy-media/__tests__/ingest.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/ingest.test.ts
@@ -14,6 +14,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 let tmpUserData = '';
 
@@ -25,10 +26,9 @@ const schema = await import('../../localDb/schema');
 const ingest = await import('../ingest');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 7, 7]);
 const PNG_HASH = createHash('sha256').update(PNG_BYTES).digest('hex');

--- a/apps/desktop/src/main/cindy-media/__tests__/integrationCache.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/integrationCache.test.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createHash } from 'node:crypto';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 let tmpUserData = '';
 
@@ -24,10 +25,9 @@ const schema = await import('../../localDb/schema');
 const integrationCache = await import('../integrationCache');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 const BYTES_A = Buffer.from('feishu-image-bytes-a');
 const HASH_A = createHash('sha256').update(BYTES_A).digest('hex');

--- a/apps/desktop/src/main/cindy-media/__tests__/ledger.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/ledger.test.ts
@@ -12,6 +12,7 @@ import { drizzle } from 'drizzle-orm/better-sqlite3';
 import fs from 'node:fs';
 import path from 'node:path';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/never-used-here' },
@@ -21,11 +22,10 @@ const schema = await import('../../localDb/schema');
 const ledger = await import('../ledger');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// 0071 的加列在配套脚本里(SQL 是占位),与生产同源经 CommonJS require 加载。
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+// 0071 的加列在配套脚本里(SQL 是占位),测试从冻结的生产源文件内存转译后加载。
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 const HASH_A = 'a'.repeat(64);
 const HASH_B = 'b'.repeat(64);

--- a/apps/desktop/src/main/cindy-media/__tests__/recycler.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/recycler.test.ts
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 let tmpUserData = '';
 
@@ -28,10 +29,9 @@ const blobStore = await import('../blobStore');
 const recycler = await import('../recycler');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 function freshDb(): LedgerDb {
   const raw = new Database(':memory:');

--- a/apps/desktop/src/main/cindy-media/__tests__/storageIpc.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/storageIpc.test.ts
@@ -12,6 +12,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { LedgerDb } from '../ledger';
+import { loadCompanionMigrationForTest } from '../../localDb/__tests__/companionMigrationTestLoader';
 
 let tmpUserData = '';
 
@@ -25,10 +26,9 @@ const blobStore = await import('../blobStore');
 const { createStorageIpcHandlers } = await import('../storageIpc');
 
 const MIGRATION_0070 = path.resolve(__dirname, '../../../../drizzle/0070_woozy_harpoon.sql');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const migration0071 = require('../../../../drizzle/scripts/0071_bright_ultron.ts') as {
-  run: (db: Database.Database) => void;
-};
+const migration0071 = loadCompanionMigrationForTest(
+  path.resolve(__dirname, '../../../../drizzle/scripts/0071_bright_ultron.ts'),
+);
 
 function freshDb(): LedgerDb {
   const raw = new Database(':memory:');

--- a/apps/desktop/src/main/localDb/__tests__/companionMigrationTestLoader.ts
+++ b/apps/desktop/src/main/localDb/__tests__/companionMigrationTestLoader.ts
@@ -1,0 +1,55 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import ts from 'typescript';
+
+import type Database from 'better-sqlite3';
+
+interface CompanionMigration {
+  run(db: Database.Database): void;
+}
+
+/**
+ * Companion migrations are frozen raw TypeScript loaded by production with Node type stripping.
+ * The repository's supported test Node may require an opt-in process flag that Vitest cannot add
+ * after startup, so tests transpile the exact frozen source in memory and execute its CommonJS body.
+ */
+export function loadCompanionMigrationForTest(scriptPath: string): CompanionMigration {
+  const source = fs.readFileSync(scriptPath, 'utf8');
+  const output = ts.transpileModule(source, {
+    fileName: scriptPath,
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+      esModuleInterop: true,
+    },
+  }).outputText;
+  const moduleRecord: { exports: unknown } = { exports: {} };
+  const localRequire = createRequire(scriptPath);
+  const execute = new Function(
+    'module',
+    'exports',
+    'require',
+    '__filename',
+    '__dirname',
+    output,
+  ) as (
+    module: { exports: unknown },
+    exports: unknown,
+    require: NodeJS.Require,
+    filename: string,
+    dirname: string,
+  ) => void;
+  execute(
+    moduleRecord,
+    moduleRecord.exports,
+    localRequire,
+    scriptPath,
+    path.dirname(scriptPath),
+  );
+  const migration = moduleRecord.exports as Partial<CompanionMigration>;
+  if (typeof migration.run !== 'function') {
+    throw new Error(`companion migration did not export run(): ${scriptPath}`);
+  }
+  return migration as CompanionMigration;
+}

--- a/apps/desktop/src/main/localDb/__tests__/migrationReplay.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/migrationReplay.test.ts
@@ -6,7 +6,11 @@ import type Database from 'better-sqlite3';
 import { describe, expect, it } from 'vitest';
 
 import { createBetterSqliteDatabase } from '../betterSqliteFactory';
-import { listMigrations, runMigrationReplay } from '../migrationRunner';
+import {
+  listMigrations,
+  runMigrationReplay as runMigrationReplayRaw,
+} from '../migrationRunner';
+import { loadCompanionMigrationForTest } from './companionMigrationTestLoader';
 
 const canRunMigrationReplay = process.platform === 'win32' || process.platform === 'darwin';
 const describeMigrationReplay = canRunMigrationReplay ? describe : describe.skip;
@@ -17,6 +21,16 @@ function desktopRoot(): string {
 
 function drizzleDir(): string {
   return path.join(desktopRoot(), 'drizzle');
+}
+
+function runMigrationReplay(
+  db: Database.Database,
+  options: Parameters<typeof runMigrationReplayRaw>[1],
+): ReturnType<typeof runMigrationReplayRaw> {
+  return runMigrationReplayRaw(db, {
+    scriptLoader: loadCompanionMigrationForTest,
+    ...options,
+  });
 }
 
 function sqliteVecFilename(): string {

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1413,6 +1413,49 @@ describe('createModelRoutingTransform —— session-less 控制面请求(桶③
       .toEqual({ headerOverride: { authorization: 'Bearer gw' } });
   });
 
+  it('首个 Responses 请求尚无 session 映射时仍按模型路由到已连接的 user provider', async () => {
+    const host = await import('../codex-proxy-host.js');
+    const { buildRegistry, buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders, getActiveCatalog } = await import('../active-catalog.js');
+    const {
+      setCustomProviderKeyReader,
+      setProviderViewsReader,
+    } = await import('../provider-route.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'deepseek',
+        name: 'DeepSeek',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://api.deepseek.com',
+            wireProtocol: 'openai-responses',
+            models: [{ id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'sk-deepseek');
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { deepseek: true }, {}),
+    );
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    try {
+      await expect(Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'deepseek-v4-flash', input: [] },
+        { reqId: 1, method: 'POST', url: '/responses', headers: {} },
+      ))).resolves.toEqual({
+        upstreamOverride: 'https://api.deepseek.com',
+        headerOverride: { authorization: 'Bearer sk-deepseek' },
+        headerDelete: ['chatgpt-account-id', 'openai-beta', 'originator', 'session_id'],
+      });
+    } finally {
+      setCustomProviders([]);
+      setCustomProviderKeyReader(() => null);
+      setProviderViewsReader(async () => []);
+    }
+  });
+
   it('env-key host + xAI session still routes through provider OAuth instead of falling back to gateway', async () => {
     const host = await import('../codex-proxy-host.js');
     const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');

--- a/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/custom-provider-store.test.ts
@@ -190,6 +190,24 @@ describe('validateCustomProviderConfig (per-runtime)', () => {
       }).ok,
     ).toBe(false);
   });
+
+  it('rejects Anthropic Messages as a user model-level Codex compatibility override', () => {
+    const config = {
+      ...valid,
+      runtimes: {
+        codex: {
+          ...valid.runtimes.codex!,
+          wireProtocol: 'openai-responses',
+          models: [{
+            id: 'm',
+            name: 'M',
+            codexCompatibilityWireProtocol: 'anthropic-messages',
+          }],
+        },
+      },
+    } as unknown as CustomProviderConfig;
+    expect(validateCustomProviderConfig(config).ok).toBe(false);
+  });
 });
 
 describe('custom-provider-store CRUD (per-runtime)', () => {
@@ -336,6 +354,35 @@ describe('custom-provider-store CRUD (per-runtime)', () => {
       },
     });
     expect((await getCustomProvider('openrouter'))?.runtimes.codex?.wireProtocol).toBe('anthropic-messages');
+  });
+
+  it('round-trips a model-level Codex compatibility bridge override', async () => {
+    mountDb();
+    await createCustomProvider({
+      ...valid,
+      runtimes: {
+        codex: {
+          ...valid.runtimes.codex!,
+          wireProtocol: 'openai-responses',
+          models: [
+            { id: 'native', name: 'Native' },
+            {
+              id: 'chat-only',
+              name: 'Chat only',
+              codexCompatibilityWireProtocol: 'openai-chat',
+            },
+          ],
+        },
+      },
+    });
+    expect((await getCustomProvider('openrouter'))?.runtimes.codex?.models).toEqual([
+      { id: 'native', name: 'Native' },
+      {
+        id: 'chat-only',
+        name: 'Chat only',
+        codexCompatibilityWireProtocol: 'openai-chat',
+      },
+    ]);
   });
 
   it('preserves legacy remote auth:none records for repair without deleting them', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/model-route-guard.test.ts
@@ -7,10 +7,16 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { buildRegistry, type Catalog, type CatalogModel, type Provider } from '@cindy/model-providers';
+import {
+  buildRegistry,
+  type Catalog,
+  type CatalogModel,
+  type Provider,
+} from '@cindy/model-providers';
 
 import {
   checkModelRoute,
+  implicitUserProviderIdForResume,
   pickEnabledFallbackModel,
   resolveLenientRoute,
 } from '../model-route-guard.js';
@@ -30,7 +36,9 @@ function provider(
     source,
     agents: ['claude-code'],
     auth: { method: 'apiKey' },
-    routing: { 'claude-code': { wireProtocol: 'anthropic-messages', authStrategy: 'api_key' } as never },
+    routing: {
+      'claude-code': { wireProtocol: 'anthropic-messages', authStrategy: 'api_key' } as never,
+    },
     models: { 'claude-code': models },
   };
 }
@@ -52,8 +60,12 @@ function views(
 
 describe('checkModelRoute', () => {
   it('无停用条目 / 目录不认识该模型 ⇒ pass(不新增拒绝面)', () => {
-    expect(checkModelRoute(views(), 'claude-code', 'claude-opus-5', null)).toEqual({ kind: 'pass' });
-    expect(checkModelRoute(views(), 'claude-code', 'unknown-model', null)).toEqual({ kind: 'pass' });
+    expect(checkModelRoute(views(), 'claude-code', 'claude-opus-5', null)).toEqual({
+      kind: 'pass',
+    });
+    expect(checkModelRoute(views(), 'claude-code', 'unknown-model', null)).toEqual({
+      kind: 'pass',
+    });
   });
 
   it('显式点名:停用的来源 reject;启用的来源 pass;未知来源按隐式口径裁决', () => {
@@ -62,7 +74,9 @@ describe('checkModelRoute', () => {
       kind: 'reject',
       reason: 'explicit-source-disabled',
     });
-    expect(checkModelRoute(v, 'claude-code', 'claude-opus-5', 'anthropic')).toEqual({ kind: 'pass' });
+    expect(checkModelRoute(v, 'claude-code', 'claude-opus-5', 'anthropic')).toEqual({
+      kind: 'pass',
+    });
     // 未知/陈旧的显式来源:实际路由层查不到 routing 会回退原生默认(xd,已停用)——
     // 不 pass-through,按隐式口径裁决 ⇒ 改道到启用替代拷贝(R23)。
     expect(checkModelRoute(v, 'claude-code', 'claude-opus-5', 'nonexistent')).toEqual({
@@ -101,6 +115,48 @@ describe('checkModelRoute', () => {
     expect(checkModelRoute(v, 'claude-code', 'claude-opus-5', null)).toEqual({ kind: 'pass' });
   });
 
+  it('隐式来源:默认落点是 user provider ⇒ 显式物化来源，避免第三方模型落到原生上游', () => {
+    const catalog = {
+      providers: [
+        {
+          id: 'deepseek',
+          name: 'DeepSeek',
+          source: 'user',
+          agents: ['codex'],
+          auth: { method: 'apiKey' },
+          routing: {
+            codex: {
+              upstream: 'https://api.deepseek.com',
+              wireProtocol: 'openai-responses',
+              authStrategy: 'api-key-header',
+            },
+          },
+          models: { codex: [model('deepseek-v4-flash')] },
+        },
+      ],
+    } as Catalog;
+    const v = buildRegistry(catalog, { deepseek: true }, {});
+    expect(checkModelRoute(v, 'codex', 'deepseek-v4-flash', null)).toEqual({
+      kind: 'reroute',
+      providerId: 'deepseek',
+    });
+    expect(implicitUserProviderIdForResume(v, 'codex', 'deepseek-v4-flash')).toBe('deepseek');
+
+    // resume 保留已经运行的停用路由，但仍需物化 user provider，避免 transport 回落。
+    const disabled = buildRegistry(
+      catalog,
+      { deepseek: true },
+      {},
+      {
+        disabledProviders: { deepseek: true },
+      },
+    );
+    expect(implicitUserProviderIdForResume(disabled, 'codex', 'deepseek-v4-flash')).toBe(
+      'deepseek',
+    );
+    expect(implicitUserProviderIdForResume(views(), 'claude-code', 'claude-opus-5')).toBeNull();
+  });
+
   it('零已连接来源 ⇒ pass(连接域问题,交给既有错误路径)', () => {
     const v = views(
       { disabledModels: { 'xd:claude-opus-5': true, 'anthropic:claude-opus-5': true } },
@@ -129,10 +185,7 @@ describe('checkModelRoute', () => {
   it('retired tombstone 拒绝新路由、跳过 fallback；同 id 有有效他源时仅隐式改道', () => {
     const catalog = {
       providers: [
-        provider('xd', [
-          model('claude-opus-5', { status: 'retired' }),
-          model('claude-sonnet-4-6'),
-        ]),
+        provider('xd', [model('claude-opus-5', { status: 'retired' }), model('claude-sonnet-4-6')]),
         provider('anthropic', [model('claude-opus-5')]),
       ],
     } as Catalog;
@@ -175,9 +228,9 @@ describe('checkModelRoute', () => {
         isRetiredTombstone,
       }),
     ).toEqual({ kind: 'reject', reason: 'model-retired' });
-    expect(
-      checkModelRoute([], 'claude-code', 'claude-gone', null, { isRetiredTombstone }),
-    ).toEqual({ kind: 'reject', reason: 'model-retired' });
+    expect(checkModelRoute([], 'claude-code', 'claude-gone', null, { isRetiredTombstone })).toEqual(
+      { kind: 'reject', reason: 'model-retired' },
+    );
     expect(
       resolveLenientRoute([], 'claude-code', 'claude-gone', 'anthropic', {
         isRetiredTombstone,
@@ -270,7 +323,12 @@ describe('checkModelRoute', () => {
 
   it('供应商级停用与模型级同语义:点名 suspended 来源 reject;默认落点 suspended 且无替代 ⇒ reject', () => {
     expect(
-      checkModelRoute(views({ disabledProviders: { xd: true } }), 'claude-code', 'claude-opus-5', 'xd'),
+      checkModelRoute(
+        views({ disabledProviders: { xd: true } }),
+        'claude-code',
+        'claude-opus-5',
+        'xd',
+      ),
     ).toEqual({ kind: 'reject', reason: 'explicit-source-disabled' });
     expect(
       checkModelRoute(
@@ -282,7 +340,12 @@ describe('checkModelRoute', () => {
     ).toEqual({ kind: 'reject', reason: 'model-disabled' });
     // suspended 默认落点 + 启用替代 ⇒ reroute。
     expect(
-      checkModelRoute(views({ disabledProviders: { xd: true } }), 'claude-code', 'claude-opus-5', null),
+      checkModelRoute(
+        views({ disabledProviders: { xd: true } }),
+        'claude-code',
+        'claude-opus-5',
+        null,
+      ),
     ).toEqual({ kind: 'reroute', providerId: 'anthropic' });
   });
 });
@@ -331,7 +394,10 @@ describe('resolveLenientRoute(自动化直建会话的宽松降级)', () => {
     const catalog: Catalog = {
       providers: [
         provider('xd', [
-          model('claude-opus-5', { efforts: ['low', 'medium', 'high', 'max'], defaultEffort: 'high' }),
+          model('claude-opus-5', {
+            efforts: ['low', 'medium', 'high', 'max'],
+            defaultEffort: 'high',
+          }),
         ]),
         provider('anthropic', [
           model('claude-opus-5', { efforts: ['low', 'medium', 'high'], defaultEffort: 'high' }),
@@ -350,8 +416,15 @@ describe('resolveLenientRoute(自动化直建会话的宽松降级)', () => {
     ).toEqual({ model: 'claude-opus-5', providerId: 'anthropic', degraded: false, effort: 'high' });
     // 落地拷贝仍支持 desiredEffort ⇒ 保留原档。
     expect(
-      resolveLenientRoute(rerouted, 'claude-code', 'claude-opus-5', null, { desiredEffort: 'medium' }),
-    ).toEqual({ model: 'claude-opus-5', providerId: 'anthropic', degraded: false, effort: 'medium' });
+      resolveLenientRoute(rerouted, 'claude-code', 'claude-opus-5', null, {
+        desiredEffort: 'medium',
+      }),
+    ).toEqual({
+      model: 'claude-opus-5',
+      providerId: 'anthropic',
+      degraded: false,
+      effort: 'medium',
+    });
     // 丢弃停用显式来源落隐式默认(xd 拷贝支持 max)⇒ effort 保留。
     const dropped = buildRegistry(
       catalog,
@@ -360,7 +433,9 @@ describe('resolveLenientRoute(自动化直建会话的宽松降级)', () => {
       { disabledModels: { 'anthropic:claude-opus-5': true } },
     );
     expect(
-      resolveLenientRoute(dropped, 'claude-code', 'claude-opus-5', 'anthropic', { desiredEffort: 'max' }),
+      resolveLenientRoute(dropped, 'claude-code', 'claude-opus-5', 'anthropic', {
+        desiredEffort: 'max',
+      }),
     ).toEqual({ model: 'claude-opus-5', providerId: null, degraded: true, effort: 'max' });
   });
 
@@ -393,7 +468,9 @@ describe('resolveLenientRoute(自动化直建会话的宽松降级)', () => {
     } as Catalog;
     const mk = (access?: Parameters<typeof buildRegistry>[3]) =>
       buildRegistry(catalog, { xd: true, anthropic: true }, {}, access);
-    const opusDead = { disabledModels: { 'xd:claude-opus-5': true, 'anthropic:claude-opus-5': true } };
+    const opusDead = {
+      disabledModels: { 'xd:claude-opus-5': true, 'anthropic:claude-opus-5': true },
+    };
 
     // 入口默认(haiku)启用 ⇒ 兜底走它(经裁决,隐式路由可用则不强制显式来源)。
     expect(
@@ -404,9 +481,11 @@ describe('resolveLenientRoute(自动化直建会话的宽松降级)', () => {
 
     // 不带入口默认 ⇒ 直接退到目录第一份启用对话模型(显式带上来源,防同 id 隐式
     // 默认又落回停用拷贝)。
-    expect(
-      resolveLenientRoute(mk(opusDead), 'claude-code', 'claude-opus-5', null),
-    ).toEqual({ model: 'claude-haiku-4-5', providerId: 'anthropic', degraded: true });
+    expect(resolveLenientRoute(mk(opusDead), 'claude-code', 'claude-opus-5', null)).toEqual({
+      model: 'claude-haiku-4-5',
+      providerId: 'anthropic',
+      degraded: true,
+    });
 
     // 入口默认自己也被停用、目录再无启用对话模型 ⇒ model undefined(调用方失败收口),
     // 绝不把未经裁决的模型漏回去(PR #744 review 第六轮)。

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -24,6 +24,7 @@ import {
   resolveSessionRoute,
   resolveSessionRouteDecision,
   resolveImplicitLocalBridgeRoute,
+  resolveImplicitUserProviderRouteDecision,
   inferProviderIdForModel,
   isUserProviderSession,
   setCustomProviderKeyReader,
@@ -101,6 +102,86 @@ describe('implicit local bridge resume routing', () => {
         providerId: 'anthropic',
         routing: { wireProtocol: 'anthropic-messages' },
       });
+  });
+});
+
+describe('model-level Codex compatibility routing', () => {
+  afterEach(() => {
+    clearSessionProvider('s-mixed-wire');
+    setCustomProviders([]);
+    setCustomProviderKeyReader(() => null);
+  });
+
+  it('keeps the native Responses model direct and bridges only the Chat-only model', async () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'mixed-wire',
+        name: 'Mixed wire',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://api.example.com',
+            wireProtocol: 'openai-responses',
+            requestPath: '/responses',
+            models: [
+              { id: 'native', name: 'Native' },
+              {
+                id: 'chat-only',
+                name: 'Chat only',
+                codexCompatibilityWireProtocol: 'openai-chat',
+              },
+            ],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'sk-mixed-wire');
+    setSessionProvider('s-mixed-wire', 'mixed-wire');
+
+    expect(getSessionRoutingDescriptor('s-mixed-wire', 'codex', 'native')).toMatchObject({
+      upstream: 'https://api.example.com',
+      authStrategy: 'api-key-header',
+      requestPath: '/responses',
+    });
+    expect(getSessionRoutingDescriptor('s-mixed-wire', 'codex', 'native')?.wireProtocol)
+      .toBeUndefined();
+    const chatRoute = await resolveSessionRoute('s-mixed-wire', 'codex', 'chat-only');
+    expect(chatRoute).toMatchObject({
+      providerId: 'mixed-wire',
+      routing: {
+        upstream: 'https://api.example.com',
+        authStrategy: 'api-key-header',
+        wireProtocol: 'openai-chat',
+      },
+    });
+    expect(chatRoute?.routing).not.toHaveProperty('requestPath');
+  });
+
+  it('routes an implicit native Responses model through its connected user provider', async () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'deepseek',
+        name: 'DeepSeek',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://api.deepseek.com',
+            wireProtocol: 'openai-responses',
+            models: [{ id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'sk-deepseek');
+    setProviderViewsReader(async () =>
+      buildRegistry(getActiveCatalog(), { deepseek: true }, {}),
+    );
+
+    await expect(
+      resolveImplicitUserProviderRouteDecision('deepseek-v4-flash', 'codex', KEY),
+    ).resolves.toEqual({
+      upstreamOverride: 'https://api.deepseek.com',
+      headerOverride: { authorization: 'Bearer sk-deepseek' },
+      headerDelete: CODEX_ACCOUNT_HEADER_DELETE,
+    });
   });
 });
 

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -56,6 +56,7 @@ import {
   readProviderOAuthToken,
   providerRoutingServesWireModel,
   resolveImplicitLocalBridgeRoute,
+  resolveImplicitUserProviderRouteDecision,
   resolveImplicitProviderOAuthRouteDecision,
   resolveProviderOAuthControlRouteDecision,
   rewriteImplicitModelIdForRoute,
@@ -2153,6 +2154,7 @@ export function createModelRoutingTransform(
 
     // ①.5 隐式来源(providerId/sessionProvider=null):
     //   - Chat / Anthropic Messages wire 按模型选择器相同的默认来源进入本地 bridge;
+    //   - user provider 的原生 Responses 路由补回 endpoint + API key（兼容历史 null 会话）；
     //   - xai/grok-* 等唯一 provider-oauth 来源仍注入对应 OAuth 并透明转发。
     // 两者都必须先于 Codex 默认 ChatGPT/XD 分支，避免协议或凭证落错上游。
     if (!explicitProviderId && model) {
@@ -2167,14 +2169,41 @@ export function createModelRoutingTransform(
               threadId,
             );
           }
-          const implicitProviderOAuth = resolveImplicitProviderOAuthRouteDecision(
-            model,
-            'codex',
-            gatewayKey,
+          return Promise.resolve(resolveImplicitUserProviderRouteDecision(model, 'codex', gatewayKey)).then(
+            (implicitUserProvider) => {
+              if (implicitUserProvider) return implicitUserProvider;
+              const implicitProviderOAuth = resolveImplicitProviderOAuthRouteDecision(
+                model,
+                'codex',
+                gatewayKey,
+              );
+              if (implicitProviderOAuth) return implicitProviderOAuth;
+              return decideCodexRoute({ model, authInjection, gatewayKey });
+            },
           );
-          if (implicitProviderOAuth) return implicitProviderOAuth;
-          return decideCodexRoute({ model, authInjection, gatewayKey });
         });
+      }
+      // 首个 /responses 可能早于 thread/started 回调，尚不能通过 thread-id 反查业务
+      // session。原生 user provider 的透明路由只依赖 model + 当前连接态，不需要等待
+      // 会话映射；否则冷恢复任务的第一请求会误落 ChatGPT，且失败后永远没有机会登记。
+      if (!sessionId && ctx.method === 'POST') {
+        const implicitUserProvider = resolveImplicitUserProviderRouteDecision(
+          model,
+          'codex',
+          gatewayKey,
+        );
+        if (implicitUserProvider) {
+          return Promise.resolve(implicitUserProvider).then((decision) => {
+            if (decision) return decision;
+            const implicitProviderOAuth = resolveImplicitProviderOAuthRouteDecision(
+              model,
+              'codex',
+              gatewayKey,
+            );
+            if (implicitProviderOAuth) return implicitProviderOAuth;
+            return decideCodexRoute({ model, authInjection, gatewayKey });
+          });
+        }
       }
       const implicitProviderOAuth = resolveImplicitProviderOAuthRouteDecision(model, 'codex', gatewayKey);
       if (implicitProviderOAuth) return implicitProviderOAuth;

--- a/apps/desktop/src/main/maker-host/custom-provider-store.ts
+++ b/apps/desktop/src/main/maker-host/custom-provider-store.ts
@@ -20,6 +20,7 @@ import type {
   CustomProviderConfig,
   CustomProviderRuntimeConfig,
   OAuthProviderDescriptor,
+  ProviderRuntimeModelConfig,
 } from '@cindy/model-providers';
 import {
   findReservedOAuthExtraParam,
@@ -114,6 +115,15 @@ function validateRuntime(agent: string, rt: unknown): ValidationResult {
     }
     if (mm.supportsImageInput !== undefined && typeof mm.supportsImageInput !== 'boolean') {
       return invalid(`runtime '${agent}' model.supportsImageInput must be a boolean`);
+    }
+    if (
+      mm.codexCompatibilityWireProtocol !== undefined
+      && (
+        agent !== 'codex'
+        || mm.codexCompatibilityWireProtocol !== 'openai-chat'
+      )
+    ) {
+      return invalid(`runtime '${agent}' model.codexCompatibilityWireProtocol invalid`);
     }
   }
   if (r.wireProtocol !== undefined) {
@@ -326,6 +336,9 @@ function normalizeRuntime(rt: CustomProviderRuntimeConfig): CustomProviderRuntim
       id: m.id.trim(),
       name: m.name.trim(),
       ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+      ...(m.codexCompatibilityWireProtocol
+        ? { codexCompatibilityWireProtocol: m.codexCompatibilityWireProtocol }
+        : {}),
       ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
       ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
     }))
@@ -458,17 +471,26 @@ function parseRuntimes(raw: string): Partial<Record<AgentKind, CustomProviderRun
           .filter((m): m is Record<string, unknown> =>
             !!m && typeof m === 'object' && typeof (m as { id?: unknown }).id === 'string',
           )
-          .map((m) => ({
-            id: String(m.id),
-            name: String(m.name ?? ''),
-            ...(typeof m.contextWindow === 'number'
-              && Number.isFinite(m.contextWindow)
-              && m.contextWindow > 0
-              ? { contextWindow: m.contextWindow }
-              : {}),
-            ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
-            ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
-          }))
+          .map<ProviderRuntimeModelConfig>((m) => {
+            const compatibilityWire = agent === 'codex'
+              && m.codexCompatibilityWireProtocol === 'openai-chat'
+              ? m.codexCompatibilityWireProtocol
+              : undefined;
+            return {
+              id: String(m.id),
+              name: String(m.name ?? ''),
+              ...(typeof m.contextWindow === 'number'
+                && Number.isFinite(m.contextWindow)
+                && m.contextWindow > 0
+                ? { contextWindow: m.contextWindow }
+                : {}),
+              ...(compatibilityWire
+                ? { codexCompatibilityWireProtocol: compatibilityWire }
+                : {}),
+              ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
+              ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
+            };
+          })
       : [];
     const entry: CustomProviderRuntimeConfig = {
       baseUrl: typeof r.baseUrl === 'string' ? r.baseUrl : '',

--- a/apps/desktop/src/main/maker-host/model-route-guard-live.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard-live.ts
@@ -33,6 +33,7 @@ import {
 } from './model-plane/modelPlanePolicy.js';
 import {
   checkModelRoute,
+  implicitUserProviderIdForResume,
   resolveLenientRoute,
   type ModelRouteGuardOptions,
   type ModelRouteVerdict,
@@ -43,9 +44,7 @@ import {
  * projections intentionally hide. Otherwise an old controller can name a
  * hidden media model and make checkModelRoute treat it as catalog-unknown.
  */
-async function listRouteGuardProviders(
-  catalog = getActiveCatalog(),
-): Promise<ProviderView[]> {
+async function listRouteGuardProviders(catalog = getActiveCatalog()): Promise<ProviderView[]> {
   return getDesktopProviderService().listProviders({ catalog });
 }
 
@@ -78,7 +77,8 @@ export async function resolveDefaultScheduleRoute(
     : connected;
   for (const provider of candidates) {
     for (const model of provider.models[agent] ?? []) {
-      if (!isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' })) continue;
+      if (!isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' }))
+        continue;
       return { model: model.id, providerId: provider.id };
     }
   }
@@ -146,6 +146,22 @@ export async function verdictForModelRoute(
     return overrideOnlyVerdict(agent, model, providerId);
   }
   return checkModelRoute(views, agent, model, providerId, guardOptions);
+}
+
+/**
+ * 恢复 provider_id=NULL 的历史会话时，补回其隐式命中的用户来源。目录读取失败保持
+ * null，沿用既有恢复行为；本 helper 不执行新路由停用裁决，避免打断运行中会话。
+ */
+export async function resolveImplicitUserProviderForResume(
+  agent: AgentKind,
+  model: string,
+): Promise<string | null> {
+  try {
+    const views = await listRouteGuardProviders();
+    return implicitUserProviderIdForResume(views, agent, model);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/model-route-guard.ts
+++ b/apps/desktop/src/main/maker-host/model-route-guard.ts
@@ -1,5 +1,5 @@
 /**
- * model-route-guard —— 本地停用与 Registry retired 在 main 新会话路由边界的准入判定。
+ * model-route-guard —— main 新会话路由边界的来源物化、停用与 Registry retired 判定。
  *
  * 背景(PR #744 review):停用标志烘焙进 ProviderView 后,renderer 选择器不会再列出
  * 停用模型,但 `maker:create-session` / `maker:set-model` / `maker:switch-session-agent`
@@ -28,6 +28,7 @@
  */
 
 import {
+  actualSourceIdForModel,
   connectedProvidersForAgent,
   effectiveSourceIdForModel,
   getModel,
@@ -51,6 +52,25 @@ export type ModelRouteVerdict =
 export interface ModelRouteGuardOptions {
   /** Active Registry tombstones have no CatalogModel entity, so the live shell supplies this. */
   isRetiredTombstone?: (providerId: string | null, modelId: string, agent: AgentKind) => boolean;
+}
+
+/**
+ * 旧会话可能把「当时的隐式默认来源」持久化成 null。对原生 agent 来源这仍有稳定
+ * 语义，但用户自定义来源必须在恢复、创建 agent 子进程前显式物化，否则 Codex 会
+ * 按当前登录态选择 OpenAI subscription transport（含 WebSocket），代理甚至没有
+ * 机会把请求改送到第三方上游。resume 口径保留 disabled/retired 的既有路由，因此
+ * 使用 actualSourceIdForModel，而不是新路由准入使用的 effectiveSourceIdForModel。
+ */
+export function implicitUserProviderIdForResume(
+  views: readonly ProviderView[],
+  agent: AgentKind,
+  modelId: string,
+): string | null {
+  const providerId = actualSourceIdForModel([...views], null, modelId, agent);
+  if (!providerId) return null;
+  return views.find((provider) => provider.id === providerId)?.source === 'user'
+    ? providerId
+    : null;
 }
 
 /** 该来源下这份 (model, agent) 拷贝是否被停用(含供应商级)。 */
@@ -127,16 +147,16 @@ export function checkModelRoute(
 
   // 隐式来源:推演「不考虑停用时会路由到谁」(原生默认口径,与 provider-route 的
   // 实际落点一致;rail 只含已连接来源,零已连接 ⇒ pass 交给既有错误路径)。
-  const preDisableRail = [...sourcesForModel([...views], modelId, agent, { includeDisabled: true })];
+  const preDisableRail = [
+    ...sourcesForModel([...views], modelId, agent, { includeDisabled: true }),
+  ];
   const wouldRouteId = nativeDefaultSourceId(preDisableRail, agent);
   if (!wouldRouteId) return { kind: 'pass' };
   const wouldRoute = preDisableRail.find((p) => p.id === wouldRouteId);
   if (!wouldRoute) return { kind: 'pass' };
   if (copyRetired(wouldRoute, modelId, agent)) {
     const alternative = effectiveSourceIdForModel([...views], null, modelId, agent);
-    const alternativeProvider = alternative
-      ? views.find((p) => p.id === alternative)
-      : undefined;
+    const alternativeProvider = alternative ? views.find((p) => p.id === alternative) : undefined;
     return alternative &&
       alternativeProvider &&
       copySelectableForNewRoute(alternativeProvider, modelId, agent)
@@ -162,14 +182,23 @@ export function checkModelRoute(
       ? { kind: 'reroute', providerId: chatAlternative }
       : { kind: 'reject', reason: 'capability-model' };
   }
-  if (!copyDisabled(wouldRoute, modelId, agent)) return { kind: 'pass' };
+  if (!copyDisabled(wouldRoute, modelId, agent)) {
+    // providerId=null 在 agent 原生默认来源(openai/xd)有稳定语义；user provider 却必须
+    // 显式物化，否则代理无法知道应注入哪家的 endpoint/key，会把第三方模型发往原生上游。
+    // Renderer 会把“当前选择等于默认来源”压成 null，因此在 main 边界统一补回。
+    return wouldRoute.source === 'user'
+      ? { kind: 'reroute', providerId: wouldRoute.id }
+      : { kind: 'pass' };
+  }
 
   // 原生默认落点被停用:解析一份启用且已连接的替代拷贝(effectiveSourceIdForModel
   // 走过滤后的 rail),且那份拷贝也必须是对话模型条目,有 ⇒ 显式改路由;
   // 无 ⇒ 该模型在停用语义下不可用。
   const alternative = effectiveSourceIdForModel([...views], null, modelId, agent);
   const alternativeProvider = alternative ? views.find((p) => p.id === alternative) : undefined;
-  return alternative && alternativeProvider && copySelectableForNewRoute(alternativeProvider, modelId, agent)
+  return alternative &&
+    alternativeProvider &&
+    copySelectableForNewRoute(alternativeProvider, modelId, agent)
     ? { kind: 'reroute', providerId: alternative }
     : { kind: 'reject', reason: 'model-disabled' };
 }

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -30,7 +30,6 @@ import type { RoutingDecision } from '@cindy/anthropic-compat-proxy';
 
 import {
   getActiveCatalog,
-  isXdCodexAnthropicBridgeModel,
 } from './active-catalog.js';
 import { getAppCapabilities } from '../appCapabilities.js';
 import { getSessionProvider } from './session-provider-store.js';
@@ -404,21 +403,25 @@ function routingServesWireModel(routing: RoutingDescriptor, wireModel: string | 
 /**
  * 解析 provider × agent × model 的最终 wire。
  *
- * 绝大多数路由直接使用 provider 级描述符；XD 是一个 provider 内同时存在两种 Codex wire
- * 的特例：服务端原生声明 codex 的模型走 Responses，只声明 claude-code 的模型由客户端
- * 投影给 Codex，并复用同一 provider 的 Claude Messages 路由进入本地 bridge。
+ * 绝大多数路由直接使用 provider 级描述符；同一 Provider 内同时存在多种 Codex wire 时，
+ * 模型可用 codexCompatibilityWireProtocol 覆盖。内置目录的 Anthropic Messages 覆盖复用
+ * 该 Provider 的 Claude 路由；用户 Provider 的 Chat Completions 覆盖沿用 Codex 路由的
+ * 上游与鉴权，但不继承 Responses 专属 requestPath。
  */
 function providerRoutingForModel(
   provider: Provider,
   agent: AgentKind,
   wireModel: string | undefined,
 ): RoutingDescriptor | null {
-  if (
-    provider.id === 'xd'
-    && agent === 'codex'
-    && wireModel
-    && isXdCodexAnthropicBridgeModel(wireModel)
-  ) {
+  const routing = provider.routing[agent] ?? null;
+  if (agent !== 'codex' || !wireModel) return routing;
+
+  const modelId = wireModel.replace(/\[1m\]$/, '');
+  const modelWire = provider.models.codex?.find((model) => model.id === modelId)
+    ?.codexCompatibilityWireProtocol;
+  if (!modelWire) return routing;
+
+  if (modelWire === 'anthropic-messages') {
     const claudeRouting = provider.routing['claude-code'];
     if (!claudeRouting) return null;
     return {
@@ -426,7 +429,9 @@ function providerRoutingForModel(
       wireProtocol: 'anthropic-messages',
     };
   }
-  return provider.routing[agent] ?? null;
+  if (!routing) return null;
+  const { requestPath: _responsesRequestPath, ...sharedRouting } = routing;
+  return { ...sharedRouting, wireProtocol: modelWire };
 }
 
 /**
@@ -732,6 +737,48 @@ export function resolveImplicitLocalBridgeRoute(
       return null;
     }
     return resolveProviderRouteById(provider.id, agent, modelId);
+  });
+}
+
+/**
+ * 隐式自定义 Responses 来源：历史会话可能已把 providerId 持久化为 null，但模型选择器
+ * 的默认来源仍是已连接的 user provider。原生 Responses 不经过本地协议 bridge，必须在
+ * 透明代理层补回该来源的 endpoint 与 API key，否则 Codex 会把第三方模型名发往
+ * ChatGPT/XD 默认上游。
+ *
+ * 只接管 user + 原生 Responses；内置默认来源保持既有 no-break 行为，Chat / Anthropic
+ * Messages 则继续由 resolveImplicitLocalBridgeRoute 处理。
+ */
+export function resolveImplicitUserProviderRouteDecision(
+  modelId: string,
+  agent: AgentKind,
+  gatewayKey: string | null,
+): RoutingDecision | null | Promise<RoutingDecision | null> {
+  const catalogModelId = modelId.replace(/\[1m\]$/, '');
+  const hasNativeUserCandidate = providersForModel(catalogModelId, agent).some((candidate) => {
+    if (candidate.source !== 'user') return false;
+    const wireProtocol = providerRoutingForModel(candidate, agent, catalogModelId)?.wireProtocol;
+    return !wireProtocol || wireProtocol === 'openai-responses';
+  });
+  // 绝大多数 Codex 原生模型属于内置来源；先用内存 catalog 快筛，避免每个请求都读取
+  // 凭证连接态。只有确有 user Responses 候选时才进入异步默认来源解析。
+  if (!hasNativeUserCandidate) return null;
+  return connectedDefaultProviderForModel(catalogModelId, agent).then(async (provider) => {
+    if (!provider || provider.source !== 'user') return null;
+    const route = await resolveProviderRouteById(provider.id, agent, modelId);
+    if (!route) return null;
+    const wireProtocol = route.routing.wireProtocol;
+    if (wireProtocol && wireProtocol !== 'openai-responses') return null;
+    const decision = buildRouteDecision(
+      route.routing,
+      gatewayKey,
+      agent,
+      route.apiKey,
+      route.oauthToken,
+    );
+    return decision && route.routing.requestPath
+      ? { ...decision, pathOverride: route.routing.requestPath }
+      : decision;
   });
 }
 

--- a/apps/desktop/src/main/maker-ipc/__tests__/resumeSessionProvider.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/resumeSessionProvider.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createVerifiedResumeSession } from '../resumeSessionProvider.js';
+
+describe('createVerifiedResumeSession', () => {
+  it('materializes the implicit DeepSeek provider before Maker resumes a historical null route', async () => {
+    const opts = {
+      id: 'historical-deepseek-task',
+      resumeSessionId: 'codex-thread-id',
+      agentKind: 'codex' as const,
+      model: 'deepseek-v4-flash',
+      providerId: null,
+    };
+    const resolveImplicitUserProvider = vi.fn(async () => 'deepseek');
+    const createSession = vi.fn(async (received: typeof opts) => ({ id: received.id }));
+
+    await expect(createVerifiedResumeSession(opts, true, {
+      resolveImplicitUserProvider,
+      createSession,
+    })).resolves.toEqual({ id: 'historical-deepseek-task' });
+
+    expect(resolveImplicitUserProvider).toHaveBeenCalledWith('codex', 'deepseek-v4-flash');
+    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
+      providerId: 'deepseek',
+    }));
+    expect(resolveImplicitUserProvider.mock.invocationCallOrder[0]).toBeLessThan(
+      createSession.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('does not reinterpret a new session or an explicit provider route', async () => {
+    const resolveImplicitUserProvider = vi.fn(async () => 'deepseek');
+    const createSession = vi.fn(async (opts: {
+      agentKind: 'codex';
+      model: string;
+      providerId: string | null;
+    }) => opts.providerId);
+
+    await expect(createVerifiedResumeSession({
+      agentKind: 'codex',
+      model: 'deepseek-v4-flash',
+      providerId: null,
+    }, false, {
+      resolveImplicitUserProvider,
+      createSession,
+    })).resolves.toBeNull();
+    await expect(createVerifiedResumeSession({
+      agentKind: 'codex',
+      model: 'deepseek-v4-flash',
+      providerId: 'deepseek-secondary',
+    }, true, {
+      resolveImplicitUserProvider,
+      createSession,
+    })).resolves.toBe('deepseek-secondary');
+
+    expect(resolveImplicitUserProvider).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionTreeProviderResume.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionTreeProviderResume.test.ts
@@ -50,4 +50,17 @@ describe('Pi session-tree lazy resume provider route', () => {
     expect(registerSource).not.toContain('providerId: row?.providerId ?? undefined,');
     expect(registerSource).not.toContain('providerId: inherited.providerId ?? undefined,');
   });
+
+  it('materializes an implicit user provider before resuming a persisted null route', () => {
+    const bootstrap = sourceBetween(
+      'async function bootstrapSession',
+      'async function resumeOrcaWorkerSessionIfMissing',
+    );
+
+    expect(bootstrap).toContain('createVerifiedResumeSession(o, verifiedResume, {');
+    expect(bootstrap).toContain(
+      'resolveImplicitUserProvider: resolveImplicitUserProviderForResume,',
+    );
+    expect(bootstrap).toContain('createSession: (opts) => maker.createSession(opts),');
+  });
 });

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -442,6 +442,7 @@ import {
 import { hydrateQueuedAgentReferences } from './agentInputReferences.js';
 import { agentHandoffPending } from './agentHandoffPendingSingleton.js';
 import { type MakerSessionCreateOpts, withCreateSessionStderr } from './sessionRequest.js';
+import { createVerifiedResumeSession } from './resumeSessionProvider.js';
 import { persistAndHydrateSessionProvider } from './sessionProviderBootstrap.js';
 import { registerMakerSessionSendHandler } from './sessionSendHandler.js';
 import { registerStopAgentTaskHandler } from './stopAgentTaskHandler.js';
@@ -527,6 +528,7 @@ import {
 } from '../maker-host/model-disable-store.js';
 import { readProviderOrder, setProviderOrder } from '../maker-host/provider-order-store.js';
 import {
+  resolveImplicitUserProviderForResume,
   resolveLenientSessionRoute,
   verdictForModelRoute,
 } from '../maker-host/model-route-guard-live.js';
@@ -5147,8 +5149,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     // 隐式来源的原生默认落点被停用而有启用替代拷贝时,把会话显式改路由过去(下方
     // persistAndHydrateSessionProvider 会把它落库):实际路由层对隐式来源走原生
     // 默认、不查停用标志,仅放行等于继续用停用拷贝付费。
+    let verifiedResume = false;
     if (typeof o.model === 'string' && o.model) {
-      let verifiedResume = false;
       if (o.resumeSessionId && typeof o.id === 'string' && o.id) {
         try {
           const [row] = await getDbClient()
@@ -5169,7 +5171,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
         if (reroute && !o.providerId) o.providerId = reroute;
       }
     }
-    const session = await maker.createSession(o);
+    const session = await createVerifiedResumeSession(o, verifiedResume, {
+      resolveImplicitUserProvider: resolveImplicitUserProviderForResume,
+      createSession: (opts) => maker.createSession(opts),
+    });
     await markProjectContextIfNeeded(session.id, didInjectProjectContext);
     wireSessionToIpc(session);
     markOrcaMcpHydratedIfNeeded(session.id, o);

--- a/apps/desktop/src/main/maker-ipc/resumeSessionProvider.ts
+++ b/apps/desktop/src/main/maker-ipc/resumeSessionProvider.ts
@@ -1,0 +1,32 @@
+import type { AgentKind } from '@cindy/maker-core';
+
+export interface ResumeSessionProviderOpts {
+  agentKind: AgentKind;
+  model?: string;
+  providerId?: string | null;
+}
+
+export interface ResumeSessionProviderDeps<TOpts extends ResumeSessionProviderOpts, TSession> {
+  resolveImplicitUserProvider(agent: AgentKind, model: string): Promise<string | null>;
+  createSession(opts: TOpts): Promise<TSession>;
+}
+
+/**
+ * A verified resume may carry the historical `provider_id = NULL` representation of an
+ * implicit user provider. Materialize that provider before handing the options to Maker so
+ * Codex chooses the API-key transport instead of the ChatGPT subscription transport.
+ */
+export async function createVerifiedResumeSession<
+  TOpts extends ResumeSessionProviderOpts,
+  TSession,
+>(
+  opts: TOpts,
+  verifiedResume: boolean,
+  deps: ResumeSessionProviderDeps<TOpts, TSession>,
+): Promise<TSession> {
+  if (verifiedResume && !opts.providerId && typeof opts.model === 'string' && opts.model) {
+    const providerId = await deps.resolveImplicitUserProvider(opts.agentKind, opts.model);
+    if (providerId) opts.providerId = providerId;
+  }
+  return deps.createSession(opts);
+}

--- a/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx
@@ -67,7 +67,21 @@ const anthropicProvider = {
 const deepseekPreset = {
   id: 'deepseek',
   name: 'DeepSeek',
-  runtimes: { 'claude-code': { baseUrl: 'https://api.deepseek.com/anthropic', models: [] } },
+  runtimes: {
+    'claude-code': { baseUrl: 'https://api.deepseek.com/anthropic', models: [] },
+    codex: {
+      baseUrl: 'https://api.deepseek.com',
+      wireProtocol: 'openai-responses' as const,
+      models: [
+        { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+        {
+          id: 'deepseek-v4-pro',
+          name: 'DeepSeek V4 Pro',
+          codexCompatibilityWireProtocol: 'openai-chat' as const,
+        },
+      ],
+    },
+  },
 };
 const liteLlmPreset = {
   id: 'litellm',
@@ -176,6 +190,28 @@ describe('AddProviderWizard — preset 直达', () => {
     expect(screen.getByPlaceholderText('sk-…')).not.toBeNull();
     // 不在目录步(搜索框只在 step 1)。
     expect(screen.queryByPlaceholderText('settings.providers.wizard.searchPlaceholder')).toBeNull();
+  });
+
+  it('DeepSeek 预设保存时保留 Flash 原生 Responses 与 Pro 模型级 Chat bridge', async () => {
+    renderWizard('deepseek');
+
+    await waitFor(() => expect(screen.getByDisplayValue('DeepSeek')).not.toBeNull());
+    fireEvent.change(screen.getByPlaceholderText('sk-…'), { target: { value: 'sk-test' } });
+    fireEvent.click(screen.getByText('settings.providers.wizard.next'));
+    await waitFor(() => expect(screen.getByText('DeepSeek V4 Flash')).not.toBeNull());
+    fireEvent.click(screen.getByText('settings.providers.wizard.finish'));
+
+    await waitFor(() => expect(createCustomProvider).toHaveBeenCalledTimes(1));
+    const codex = vi.mocked(createCustomProvider).mock.calls[0][0].runtimes.codex;
+    expect(codex?.wireProtocol).toBe('openai-responses');
+    expect(codex?.models).toEqual([
+      { id: 'deepseek-v4-flash', name: 'DeepSeek V4 Flash' },
+      {
+        id: 'deepseek-v4-pro',
+        name: 'DeepSeek V4 Pro',
+        codexCompatibilityWireProtocol: 'openai-chat',
+      },
+    ]);
   });
 
   it('API Key 默认遮罩,eye 能切明文再切回(粘贴后核对)', async () => {

--- a/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
+++ b/apps/desktop/src/renderer/components/settings/AddProviderWizard.tsx
@@ -782,6 +782,12 @@ export function AddProviderWizard({
               id: m.id,
               name: m.name,
               ...(contextWindow !== undefined ? { contextWindow } : {}),
+              ...(presetModel?.codexCompatibilityWireProtocol
+                ? {
+                    codexCompatibilityWireProtocol:
+                      presetModel.codexCompatibilityWireProtocol,
+                  }
+                : {}),
               ...(presetModel?.supportsImageInput === true ? { supportsImageInput: true } : {}),
             };
           });

--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -656,6 +656,9 @@ export function CustomProviderDialog({
             id: m.id.trim(),
             name: m.name.trim(),
             ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+            ...(m.codexCompatibilityWireProtocol
+              ? { codexCompatibilityWireProtocol: m.codexCompatibilityWireProtocol }
+              : {}),
             ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
             ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
           }))
@@ -731,10 +734,13 @@ export function CustomProviderDialog({
       const contextWindow = latest?.contextWindow ?? m.contextWindow;
       const defaultEnabled = latest?.defaultEnabled ?? m.defaultEnabled;
       const supportsImageInput = latest ? latest.supportsImageInput : m.supportsImageInput;
+      const codexCompatibilityWireProtocol = latest?.codexCompatibilityWireProtocol
+        ?? m.codexCompatibilityWireProtocol;
       return {
         id: m.id,
         name: latest?.name.trim() ? latest.name.trim() : m.name,
         ...(contextWindow !== undefined ? { contextWindow } : {}),
+        ...(codexCompatibilityWireProtocol ? { codexCompatibilityWireProtocol } : {}),
         ...(defaultEnabled === false ? { defaultEnabled: false } : {}),
         ...(supportsImageInput === true ? { supportsImageInput: true } : {}),
       };
@@ -746,6 +752,9 @@ export function CustomProviderDialog({
           id,
           name: m.name.trim() || id,
           ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+          ...(m.codexCompatibilityWireProtocol
+            ? { codexCompatibilityWireProtocol: m.codexCompatibilityWireProtocol }
+            : {}),
           ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
           ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
         });
@@ -848,6 +857,9 @@ export function CustomProviderDialog({
           id: m.id.trim(),
           name: m.name.trim(),
           ...(m.contextWindow !== undefined ? { contextWindow: m.contextWindow } : {}),
+          ...(m.codexCompatibilityWireProtocol
+            ? { codexCompatibilityWireProtocol: m.codexCompatibilityWireProtocol }
+            : {}),
           ...(m.defaultEnabled === false ? { defaultEnabled: false } : {}),
           ...(m.supportsImageInput === true ? { supportsImageInput: true } : {}),
         }))

--- a/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/customProviders.test.ts
@@ -20,6 +20,7 @@ describe('replaceCustomProviderModelId', () => {
       id: 'MiniMax-M3',
       name: 'MiniMax M3',
       contextWindow: 1_000_000,
+      codexCompatibilityWireProtocol: 'openai-chat',
       supportsImageInput: true,
     }, 'another-model')).toEqual({
       id: 'another-model',
@@ -99,6 +100,20 @@ describe('customProviderModelConfigFromCatalogModel', () => {
       id: 'discovered',
       name: 'Discovered',
       defaultEnabled: false,
+    });
+  });
+
+  it('preserves a model-level Codex compatibility bridge through the edit round trip', () => {
+    expect(customProviderModelConfigFromCatalogModel({
+      id: 'chat-only',
+      name: 'Chat only',
+      contextWindow: 1_000_000,
+      codexCompatibilityWireProtocol: 'openai-chat',
+    })).toEqual({
+      id: 'chat-only',
+      name: 'Chat only',
+      contextWindow: 1_000_000,
+      codexCompatibilityWireProtocol: 'openai-chat',
     });
   });
 

--- a/apps/desktop/src/renderer/lib/customProviders.ts
+++ b/apps/desktop/src/renderer/lib/customProviders.ts
@@ -59,6 +59,7 @@ export function customProviderModelConfigFromCatalogModel(
     | 'name'
     | 'contextWindow'
     | 'contextWindowExplicit'
+    | 'codexCompatibilityWireProtocol'
     | 'defaultEnabled'
     | 'supportsImageInput'
   >,
@@ -68,6 +69,9 @@ export function customProviderModelConfigFromCatalogModel(
     name: model.name,
     ...(model.contextWindowExplicit === true || model.contextWindow !== DEFAULT_CUSTOM_CONTEXT_WINDOW
       ? { contextWindow: model.contextWindow }
+      : {}),
+    ...(model.codexCompatibilityWireProtocol === 'openai-chat'
+      ? { codexCompatibilityWireProtocol: 'openai-chat' as const }
       : {}),
     ...(model.defaultEnabled === false ? { defaultEnabled: false } : {}),
     ...(model.supportsImageInput === true ? { supportsImageInput: true } : {}),

--- a/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
@@ -166,29 +166,37 @@ describe('anthropic-compat-proxy outbound proxy wiring', () => {
   });
 
   it('falls back to direct connection when the resolver throws or returns unsupported urls', async () => {
+    const upstream = createHttpServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ direct: true }));
+    });
+    const upstreamPort = await listenOnAvailableLoopbackPort(upstream);
+    cleanups.push(() => new Promise<void>((r) => upstream.close(() => r())));
+    // 0.0.0.0 不属于代理 bypass 的 loopback hostname，但作为连接目标仍指向本机。
+    // 这样既会执行 resolver，又能确定性验证回落直连，不依赖外部 DNS 超时。
+    const directUpstream = `http://0.0.0.0:${upstreamPort}`;
     const warns: string[] = [];
     proxy = await createAnthropicCompatProxy({
-      upstream: 'http://upstream.invalid:8080',
+      upstream: directUpstream,
       transformRequest: [],
       resolveOutboundProxy: () => { throw new Error('resolver boom'); },
       logger: { warn: (msg) => { warns.push(msg); } },
     });
 
-    // 直连假域必然失败，但必须是上游连接的 502，而非 resolver 异常炸掉请求链路。
     const res = await fetch(`${proxy.url}/v1/messages`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ model: 'x', messages: [] }),
     });
-    expect(res.status).toBe(502);
-    expect((await res.json() as { error: { message: string } }).error.message).toContain('upstream unreachable');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ direct: true });
     expect(warns.some((m) => m.includes('outbound proxy resolver threw'))).toBe(true);
 
     await proxy.dispose();
 
     const warns2: string[] = [];
     proxy = await createAnthropicCompatProxy({
-      upstream: 'http://upstream.invalid:8080',
+      upstream: directUpstream,
       transformRequest: [],
       // socks4 仍不支持(无认证、无 IPv6),按不支持的形态回落直连。
       resolveOutboundProxy: () => 'socks4://127.0.0.1:1080',
@@ -199,8 +207,8 @@ describe('anthropic-compat-proxy outbound proxy wiring', () => {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ model: 'x', messages: [] }),
     });
-    expect(res2.status).toBe(502);
-    expect((await res2.json() as { error: { message: string } }).error.message).toContain('upstream unreachable');
+    expect(res2.status).toBe(200);
+    expect(await res2.json()).toEqual({ direct: true });
     expect(warns2.some((m) => m.includes('unsupported outbound proxy url'))).toBe(true);
   });
 });

--- a/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-outbound-proxy.test.ts
@@ -2,7 +2,7 @@ import { createServer as createHttpServer } from 'node:http';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createAnthropicCompatProxy } from './server.js';
-import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
+import { listenOnAvailableLoopbackPort, listenOnAvailablePort } from './test-loopback-server.js';
 import { startSocks5Stub } from './test-socks5-stub.js';
 import type { ProxyHandle } from './types.js';
 
@@ -170,11 +170,14 @@ describe('anthropic-compat-proxy outbound proxy wiring', () => {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({ direct: true }));
     });
-    const upstreamPort = await listenOnAvailableLoopbackPort(upstream);
+    // 0.0.0.0 is intentionally non-loopback here so the resolver path is exercised;
+    // bind the test server to the same address so the fallback remains a local connection.
+    const directHost = '0.0.0.0';
+    const upstreamPort = await listenOnAvailablePort(upstream, directHost);
     cleanups.push(() => new Promise<void>((r) => upstream.close(() => r())));
     // 0.0.0.0 不属于代理 bypass 的 loopback hostname，但作为连接目标仍指向本机。
     // 这样既会执行 resolver，又能确定性验证回落直连，不依赖外部 DNS 超时。
-    const directUpstream = `http://0.0.0.0:${upstreamPort}`;
+    const directUpstream = `http://${directHost}:${upstreamPort}`;
     const warns: string[] = [];
     proxy = await createAnthropicCompatProxy({
       upstream: directUpstream,

--- a/packages/anthropic-compat-proxy/src/test-loopback-server.ts
+++ b/packages/anthropic-compat-proxy/src/test-loopback-server.ts
@@ -1,6 +1,6 @@
 import type { Server } from 'node:http';
 
-const LOOPBACK_LISTEN_MAX_ATTEMPTS = 32;
+const LISTEN_MAX_ATTEMPTS = 32;
 
 function isRetryableListenError(error: unknown): boolean {
   if (!error || typeof error !== 'object' || !('code' in error)) return false;
@@ -8,7 +8,7 @@ function isRetryableListenError(error: unknown): boolean {
   return code === 'EADDRINUSE' || code === 'EACCES';
 }
 
-function listenOnce(server: Server): Promise<number> {
+function listenOnce(server: Server, host: string): Promise<number> {
   return new Promise<number>((resolve, reject) => {
     const cleanup = (): void => {
       server.removeListener('error', onError);
@@ -32,7 +32,7 @@ function listenOnce(server: Server): Promise<number> {
     server.once('error', onError);
     server.once('listening', onListening);
     try {
-      server.listen(0, '127.0.0.1');
+      server.listen(0, host);
     } catch (error) {
       cleanup();
       reject(error);
@@ -41,16 +41,16 @@ function listenOnce(server: Server): Promise<number> {
 }
 
 /**
- * Starts a test-only HTTP server while tolerating Windows excluded-port races.
- * Windows can occasionally assign an unavailable excluded port for listen(0),
- * surfacing EACCES even though another ephemeral port is available.
+ * Starts a test-only HTTP server on the requested host while tolerating Windows
+ * excluded-port races. Windows can occasionally assign an unavailable excluded
+ * port for listen(0), surfacing EACCES even though another ephemeral port is available.
  */
-export async function listenOnAvailableLoopbackPort(server: Server): Promise<number> {
+export async function listenOnAvailablePort(server: Server, host: string): Promise<number> {
   let lastRetryableError: Error | null = null;
 
-  for (let attempt = 1; attempt <= LOOPBACK_LISTEN_MAX_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= LISTEN_MAX_ATTEMPTS; attempt += 1) {
     try {
-      return await listenOnce(server);
+      return await listenOnce(server, host);
     } catch (error) {
       if (!isRetryableListenError(error)) throw error;
       lastRetryableError = error instanceof Error ? error : new Error(String(error));
@@ -58,7 +58,11 @@ export async function listenOnAvailableLoopbackPort(server: Server): Promise<num
   }
 
   throw new Error(
-    `test loopback server failed to bind after ${LOOPBACK_LISTEN_MAX_ATTEMPTS} attempts` +
+    `test loopback server failed to bind after ${LISTEN_MAX_ATTEMPTS} attempts` +
       (lastRetryableError === null ? '' : `; last error ${lastRetryableError.message}`),
   );
+}
+
+export async function listenOnAvailableLoopbackPort(server: Server): Promise<number> {
+  return listenOnAvailablePort(server, '127.0.0.1');
 }

--- a/packages/model-providers/catalog/providers.json
+++ b/packages/model-providers/catalog/providers.json
@@ -298,7 +298,7 @@
         },
         "codex": {
           "baseUrl": "https://api.deepseek.com",
-          "wireProtocol": "openai-chat",
+          "wireProtocol": "openai-responses",
           "models": [
             {
               "id": "deepseek-v4-flash",
@@ -308,7 +308,8 @@
             {
               "id": "deepseek-v4-pro",
               "name": "DeepSeek V4 Pro",
-              "contextWindow": 1000000
+              "contextWindow": 1000000,
+              "codexCompatibilityWireProtocol": "openai-chat"
             }
           ],
           "modelsUrl": "https://api.deepseek.com/models"

--- a/packages/model-providers/src/__tests__/catalog.test.ts
+++ b/packages/model-providers/src/__tests__/catalog.test.ts
@@ -197,6 +197,27 @@ describe('bundled catalog validity (dynamic-first contract)', () => {
     ).toBe(1_000_000);
   });
 
+  it('DeepSeek V4 Flash uses native Responses while V4 Pro keeps the Chat bridge', () => {
+    const codex = BUNDLED_CATALOG.presets
+      ?.find((preset) => preset.id === 'deepseek')
+      ?.runtimes.codex;
+    expect(codex?.wireProtocol).toBe('openai-responses');
+    expect(codex?.models.find((model) => model.id === 'deepseek-v4-flash')
+      ?.codexCompatibilityWireProtocol).toBeUndefined();
+    expect(codex?.models.find((model) => model.id === 'deepseek-v4-pro')
+      ?.codexCompatibilityWireProtocol).toBe('openai-chat');
+  });
+
+  it('rejects Anthropic Messages as a user preset model-level Codex override', () => {
+    const bad = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
+    const model = bad.presets
+      ?.find((preset) => preset.id === 'deepseek')
+      ?.runtimes.codex?.models[0];
+    expect(model).toBeDefined();
+    (model as unknown as Record<string, unknown>).codexCompatibilityWireProtocol = 'anthropic-messages';
+    expect(parseCatalog(bad).presets?.some((preset) => preset.id === 'deepseek')).toBe(false);
+  });
+
   it('Kimi Code(编程计划)预设的每个模型都带 contextWindow(k3 缺失曾回落 200K)', () => {
     // k3 此前没带 contextWindow → buildUserProvider 回落 200K 保守默认:选择器
     // 显示 200K 且压缩阈值过早触发(用户反馈「动不动就压缩」)。取 262144 与同

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -77,6 +77,30 @@ describe('buildUserProvider (per-runtime)', () => {
     });
   });
 
+  it('preserves a model-level Codex compatibility bridge override', () => {
+    const p = buildUserProvider({
+      ...codexOnly,
+      runtimes: {
+        codex: {
+          ...codexOnly.runtimes.codex!,
+          wireProtocol: 'openai-responses',
+          models: [
+            { id: 'native', name: 'Native' },
+            {
+              id: 'chat-only',
+              name: 'Chat only',
+              codexCompatibilityWireProtocol: 'openai-chat',
+            },
+          ],
+        },
+      },
+    });
+    expect(p.models.codex?.find((model) => model.id === 'native')
+      ?.codexCompatibilityWireProtocol).toBeUndefined();
+    expect(p.models.codex?.find((model) => model.id === 'chat-only')
+      ?.codexCompatibilityWireProtocol).toBe('openai-chat');
+  });
+
   it('preserves a non-standard inference request path in routing', () => {
     const p = buildUserProvider({
       ...codexOnly,

--- a/packages/model-providers/src/catalog.ts
+++ b/packages/model-providers/src/catalog.ts
@@ -381,6 +381,13 @@ function isValidPreset(v: unknown): v is ProviderPreset {
       if (mm.supportsImageInput !== undefined && typeof mm.supportsImageInput !== 'boolean') {
         return false;
       }
+      if (
+        mm.codexCompatibilityWireProtocol !== undefined
+        && (
+          agent !== 'codex'
+          || mm.codexCompatibilityWireProtocol !== 'openai-chat'
+        )
+      ) return false;
     }
     if (r.wireProtocol !== undefined && !isWireProtocol(r.wireProtocol)) return false;
     if (agent === 'claude-code' && r.wireProtocol === 'openai-chat') return false;

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -436,6 +436,12 @@ export interface ProviderRuntimeModelConfig {
   id: string;
   name: string;
   contextWindow?: number;
+  /**
+   * 用户 Provider 的 Codex 模型级兼容协议覆盖。仅用于同一 runtime 同时包含原生
+   * Responses 与 Chat-only 模型：缺省继承 runtime wireProtocol；设置后该模型进入
+   * Cindy 的 Responses→Chat bridge。
+   */
+  codexCompatibilityWireProtocol?: Extract<CodexCompatibilityWireProtocol, 'openai-chat'>;
   /** 模型未被用户显式开关时的可见性；缺省保持历史行为（默认可见）。 */
   defaultEnabled?: boolean;
   /** Pi 自定义模型是否支持原生图片输入；缺省保守视为不支持。 */

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -68,6 +68,9 @@ function toCatalogModel(
     defaultEffort: efforts.length > 0 ? DEFAULT_CUSTOM_EFFORT : null,
     // 选择器右栏按 group 聚合：同一自定义来源的模型聚成一组（渲染层用 provider 名兜底标签）。
     group: `custom:${providerId}`,
+    ...(agent === 'codex' && m.codexCompatibilityWireProtocol
+      ? { codexCompatibilityWireProtocol: m.codexCompatibilityWireProtocol }
+      : {}),
     // 手填模型保持历史默认可见；刷新发现的模型可显式声明默认隐藏。
     defaultEnabled: m.defaultEnabled ?? true,
     // 图片能力必须由用户/预设明确确认；缺省不猜，防止 Pi 静默把截图降级成占位文本。

--- a/packages/remote-file-service/src/watch.ts
+++ b/packages/remote-file-service/src/watch.ts
@@ -43,9 +43,15 @@ interface WatchEntry {
   /** coalesce 缓冲:key = `${type}::${relPath}`。 */
   pending: Map<string, RemoteFileTreeEvent>;
   flushTimer: NodeJS.Timeout | null;
+  pollTimer: NodeJS.Timeout | null;
+  pollSnapshot: Map<string, string> | null;
+  polling: boolean;
+  pollInFlight: boolean;
 }
 
 const COALESCE_MS = 50;
+const FALLBACK_POLL_MS = 250;
+const WATCH_RESOURCE_ERRORS = new Set(['EMFILE', 'ENFILE', 'ENOSPC']);
 
 export class WorkdirWatchManager {
   private readonly entries = new Map<string, WatchEntry>();
@@ -84,13 +90,28 @@ export class WorkdirWatchManager {
       honorVcsIgnore: false,
     });
 
-    const entry: WatchEntry = { watcher: null as unknown as FSWatcher, matcher, pending: new Map(), flushTimer: null };
+    const entry: WatchEntry = {
+      watcher: null as unknown as FSWatcher,
+      matcher,
+      pending: new Map(),
+      flushTimer: null,
+      pollTimer: null,
+      pollSnapshot: null,
+      polling: false,
+      pollInFlight: false,
+    };
     const watcher = fsWatch(workdir, { recursive: true }, (eventType, filename) => {
       // filename 偶发 null(平台边缘情况),无法定位目标 — 丢弃,聚焦刷新兜底。
       if (!filename) return;
       void this.handleRaw(workdir, entry, eventType, filename.toString());
     });
     watcher.on('error', (err) => {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code && WATCH_RESOURCE_ERRORS.has(code)) {
+        log.warn('fs.watch resource exhausted, switching to polling', workdir, code);
+        void this.startPollingFallback(workdir, entry);
+        return;
+      }
       // watcher 挂了(权限 / 目录被删):log 后移除,消费端靠手动刷新。
       log.warn('fs.watch error, dropping watcher', workdir, String(err));
       this.stop(workdir);
@@ -117,12 +138,91 @@ export class WorkdirWatchManager {
     if (!entry) return;
     this.entries.delete(workdir);
     if (entry.flushTimer) clearTimeout(entry.flushTimer);
+    if (entry.pollTimer) clearInterval(entry.pollTimer);
     try {
       entry.watcher.close();
     } catch {
       // already closed
     }
     log.info('watch stopped', workdir);
+  }
+
+  /**
+   * macOS FSEvents / Linux inotify 的进程或系统额度耗尽时，fs.watch 会在构造成功后
+   * 异步报 EMFILE/ENFILE/ENOSPC。旧实现只移除 watcher，客户端却已经收到 start 成功，
+   * 随后文件树永久不刷新。资源类错误改为低频快照 diff；正常环境仍走原生事件。
+   */
+  private async startPollingFallback(workdir: string, entry: WatchEntry): Promise<void> {
+    if (this.entries.get(workdir) !== entry || entry.polling) return;
+    entry.polling = true;
+    try {
+      entry.watcher.close();
+    } catch {
+      // already closed
+    }
+    try {
+      entry.pollSnapshot = await this.scanSnapshot(workdir, entry.matcher);
+    } catch (err) {
+      log.warn('polling fallback initial scan failed, dropping watcher', workdir, String(err));
+      this.stop(workdir);
+      return;
+    }
+    if (this.entries.get(workdir) !== entry) return;
+    entry.pollTimer = setInterval(() => {
+      if (entry.pollInFlight) return;
+      entry.pollInFlight = true;
+      void this.pollOnce(workdir, entry).finally(() => {
+        entry.pollInFlight = false;
+      });
+    }, FALLBACK_POLL_MS);
+    entry.pollTimer.unref?.();
+    log.info('polling fallback started', workdir);
+  }
+
+  private async pollOnce(workdir: string, entry: WatchEntry): Promise<void> {
+    if (this.entries.get(workdir) !== entry || !entry.pollSnapshot) return;
+    let next: Map<string, string>;
+    try {
+      next = await this.scanSnapshot(workdir, entry.matcher);
+    } catch (err) {
+      log.warn('polling fallback scan failed', workdir, String(err));
+      return;
+    }
+    if (this.entries.get(workdir) !== entry) return;
+    const previous = entry.pollSnapshot;
+    entry.pollSnapshot = next;
+    for (const [relPath, signature] of next) {
+      const oldSignature = previous.get(relPath);
+      if (oldSignature === undefined) this.enqueue(entry, { workdir, type: 'add', relPath });
+      else if (oldSignature !== signature) this.enqueue(entry, { workdir, type: 'change', relPath });
+    }
+    for (const relPath of previous.keys()) {
+      if (!next.has(relPath)) this.enqueue(entry, { workdir, type: 'unlink', relPath });
+    }
+  }
+
+  private async scanSnapshot(workdir: string, matcher: Matcher): Promise<Map<string, string>> {
+    const snapshot = new Map<string, string>();
+    const visit = async (relativeDir: string): Promise<void> => {
+      const absoluteDir = relativeDir ? path.join(workdir, relativeDir) : workdir;
+      const dirents = await fs.readdir(absoluteDir, { withFileTypes: true });
+      for (const dirent of dirents) {
+        const relPath = relativeDir
+          ? `${relativeDir.split(path.sep).join('/')}/${dirent.name}`
+          : dirent.name;
+        if (relPath.endsWith(XDT_TMP_SUFFIX)) continue;
+        if (matcher.ignores(relPath, dirent.isDirectory())) continue;
+        if (dirent.isDirectory()) {
+          await visit(relPath);
+          continue;
+        }
+        if (!dirent.isFile()) continue;
+        const stat = await fs.stat(path.join(workdir, relPath));
+        snapshot.set(relPath, `${stat.mtimeMs}:${stat.size}`);
+      }
+    };
+    await visit('');
+    return snapshot;
   }
 
   stopAll(): void {


### PR DESCRIPTION
## 这次改了什么

### 摘要

DeepSeek V4 Flash 已经原生支持 OpenAI Responses API，但 Cindy 之前把 DeepSeek 的 Codex runtime 整体标记为 `openai-chat`，因此所有模型都经过 Responses→Chat 桥接。将 Flash 改为原生 Responses 后，历史任务还会因 `provider_id = NULL` 误选 ChatGPT OAuth transport，出现“the model is not supported when using Codex with a ChatGPT account”。

本 PR：

- 让 DeepSeek V4 Flash 直接调用 `POST https://api.deepseek.com/responses`。
- 保持 DeepSeek V4 Pro 继续走 Responses→Chat 桥接。
- 增加 Codex 模型级 `openai-chat` 兼容协议覆盖，用于同一 Provider 同时包含原生 Responses 和 Chat-only 模型。
- 新建任务和历史 `provider_id = NULL` 任务在启动 Codex 前会物化已连接的用户 Provider，避免误走 ChatGPT WebSocket/OAuth transport。
- 代理层增加无 session/thread 映射时的原生 Responses 防御性路由，保证首个请求也使用用户的 endpoint 和 API key。
- 增加行为级恢复回归测试，直接断言 `maker.createSession` 收到 `providerId: "deepseek"`。

另有一个独立提交 `test: stabilize local unit gate`，用于修复当前主干在本机支持环境中的硬门禁失败：Node 22.17 无法直接 require 冻结的 TypeScript companion migration、macOS sandbox 不允许 `pgrep` 查询进程表、代理直连回退测试依赖 DNS 超时，以及 `fs.watch` 资源耗尽后文件树永久不再刷新。正常 `fs.watch` 路径不变，仅 `EMFILE` / `ENFILE` / `ENOSPC` 时回退为有界轮询。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：暂无对应 Issue，来自 DeepSeek V4 Flash 原生 Responses API 的实际兼容性验证。
- 本 PR 包含：DeepSeek Provider 目录、用户 Provider 模型级协议覆盖、Desktop Codex 路由、历史任务恢复及回归测试；本地硬门禁稳定性修复。
- 明确不包含：服务端修改、DeepSeek API 协议转换、Mobile UI 变更。
- 用户可见变化：DeepSeek V4 Flash 在 Codex 中可正常建立新任务并恢复旧任务，不再显示 ChatGPT account 不支持该模型的错误。
- 是否存在 breaking change：无。

### UI 变化

不涉及：Settings 相关改动仅在现有 Provider 表单的序列化/回填链路中保留内部模型协议字段，没有新增视觉、交互或 UI 文案。

- 引用的设计规范：不涉及，无可见 UI 变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部可运行 workspace PASS；Desktop 1,597 个测试文件、19,5xx 条测试通过。

env NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：PASS。

pnpm --filter desktop exec vitest run \
  src/main/maker-ipc/__tests__/resumeSessionProvider.test.ts \
  src/main/maker-ipc/__tests__/sessionTreeProviderResume.test.ts \
  src/main/maker-host/__tests__/model-route-guard.test.ts \
  src/main/maker-host/__tests__/providerRoute.test.ts \
  src/main/maker-host/__tests__/codexProxyHost.test.ts \
  src/main/maker-host/__tests__/custom-provider-store.test.ts \
  src/renderer/__tests__/addProviderWizardPresetEntry.test.tsx \
  src/renderer/lib/__tests__/customProviders.test.ts
结果：269 tests PASS。

pnpm --filter @cindy/model-providers exec vitest run \
  src/__tests__/catalog.test.ts src/__tests__/user-provider.test.ts
结果：64 tests PASS。

pnpm check:dco
结果：2 commits PASS。
```

### 手工验证

- macOS，Global Remote Dev，当前 fork 分支。
- 使用已连接的 DeepSeek Provider 新建 V4 Flash 任务，连续对话多轮成功。
- 恢复之前 `provider_id = NULL` 且曾报 ChatGPT account 错误的旧任务，继续对话成功。
- 实际上游为 `POST https://api.deepseek.com/responses`，HTTP 200 SSE，未经 Responses→Chat bridge。

### 未执行的验证

- 未在 Windows 实机启动 Desktop；文件路径、协议路由均使用现有跨平台抽象，Windows 由 CI 的完整单测分片继续验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：旧任务恢复时的 Provider 来源物化。

### 影响与回滚

- 影响范围：DeepSeek Codex runtime 及用户 Provider 的 Codex 模型级 Chat 兼容覆盖；历史隐式用户 Provider 任务恢复；文件监听资源耗尽时的回退。
- 协议兼容：Flash 使用原生 Responses，Pro 通过模型级 `openai-chat` 覆盖保持原桥接；用户可配置覆盖只接受 `openai-chat`，不开放 `anthropic-messages`。
- 凭证边界：API key 仍由 Main 侧现有 credential store 读取，不落盘新明文、不下放 Renderer，不记录鉴权头。
- 跨平台：`fs.watch` 正常路径不变；只在 macOS/Linux/Windows 对应的资源错误码上进入轮询。Windows 未实机验证。
- 回滚 / 降级方式：回滚目录的 DeepSeek runtime 协议、模型级覆盖及历史任务物化路由，即恢复为所有 DeepSeek Codex 模型经 Chat bridge；门禁稳定性提交可独立回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及可见 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码内 schema / 路由注释；无独立用户文档变更）
- [x] 已确认测试结果或说明未执行原因
