### PR TITLE
fix(desktop): 避免浏览器健康检查阻塞自动化设置

### DIFF
--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -410,6 +410,10 @@ export function ComputerUseSection({
   const [browserBackendPending, setBrowserBackendPending] = useState(false);
   const [browserBackendRecovering, setBrowserBackendRecovering] = useState(false);
   const [browserBackendHealth, setBrowserBackendHealth] = useState<BrowserBackendHealth | null>(null);
+  // Health can include an automatic embedded-browser recovery and therefore
+  // take several seconds. Track the latest health owner so a late initial
+  // probe cannot overwrite a newer user-initiated switch or recovery result.
+  const browserBackendHealthSeqRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -492,9 +496,24 @@ export function ComputerUseSection({
 
   useEffect(() => {
     let cancelled = false;
+    const backendHealthSeq = ++browserBackendHealthSeqRef.current;
+    // Start the slow health/recovery path alongside the base reads, but do not
+    // include it in their render gate. The Automation cards are useful while
+    // this result is pending and BrowserBackendSubsection already supports a
+    // null health state.
+    const backendHealthPromise = (async () => {
+      try {
+        return {
+          health: await (window.electronAPI.browserBackend?.getHealth?.() ?? null),
+          error: null,
+        };
+      } catch (error) {
+        log.warn('browserBackend.getHealth failed', error);
+        return { health: null, error };
+      }
+    })();
     void (async () => {
-      let backendHealthError: unknown;
-      const [browserState, computerState, avail, computer, backendState, backendHealth] = await Promise.all([
+      const [browserState, computerState, avail, computer, backendState] = await Promise.all([
         // `browser` is hidden from plugins.list() (HOSTED_ELSEWHERE), so read its
         // enable state directly by id — list().find() would always be undefined
         // and the toggle would wrongly reset to enabled on every remount.
@@ -535,11 +554,6 @@ export function ComputerUseSection({
           log.warn('browserBackend.getState failed', err);
           return null;
         }) ?? Promise.resolve(null),
-        window.electronAPI.browserBackend?.getHealth?.().catch((err) => {
-          backendHealthError = err;
-          log.warn('browserBackend.getHealth failed', err);
-          return null;
-        }) ?? Promise.resolve(null),
       ]);
       if (cancelled) return;
       // Browser keeps the builtin default-on behavior. Direct computer control
@@ -555,6 +569,8 @@ export function ComputerUseSection({
       // 让卡片整张瘫成内置态强。
       const activeBackend = backendState?.active ?? 'external';
       setBrowserBackendKind(activeBackend);
+      const { health: backendHealth, error: backendHealthError } = await backendHealthPromise;
+      if (cancelled || browserBackendHealthSeqRef.current !== backendHealthSeq) return;
       setBrowserBackendHealth(
         backendHealth?.active === activeBackend
           ? backendHealth
@@ -581,11 +597,17 @@ export function ComputerUseSection({
         // main 返回 active 是权威 — 万一同一次 swap 失败 router 拒了我们 fallback
         // 到 main 端的真实值。
         setBrowserBackendKind(res.active);
+        const backendHealthSeq = ++browserBackendHealthSeqRef.current;
         try {
-          setBrowserBackendHealth(await window.electronAPI.browserBackend.getHealth());
+          const health = await window.electronAPI.browserBackend.getHealth();
+          if (browserBackendHealthSeqRef.current === backendHealthSeq) {
+            setBrowserBackendHealth(health);
+          }
         } catch (healthErr) {
           log.warn('browserBackend.getHealth after setKind failed', healthErr);
-          setBrowserBackendHealth(browserBackendHealthFallback(res.active));
+          if (browserBackendHealthSeqRef.current === backendHealthSeq) {
+            setBrowserBackendHealth(browserBackendHealthFallback(res.active));
+          }
         }
       } catch (err) {
         log.error('browserBackend.setKind failed', err);
@@ -603,6 +625,7 @@ export function ComputerUseSection({
     setBrowserBackendRecovering(true);
     try {
       const result = await window.electronAPI.browserBackend.recover();
+      browserBackendHealthSeqRef.current += 1;
       setBrowserBackendKind(result.health.active);
       setBrowserBackendHealth(result.health);
       if (result.ok) {
@@ -612,6 +635,7 @@ export function ComputerUseSection({
       }
     } catch (err) {
       log.error('browserBackend.recover failed', err);
+      browserBackendHealthSeqRef.current += 1;
       setBrowserBackendHealth(browserBackendHealthFallback('rsb-webview'));
       toast.error(t('settings.computerUse.browserBackend.health.recoverFailed'));
     } finally {

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BrowserBackendHealth } from '../../../../shared/browserBackend';
+
+const api = vi.hoisted(() => ({
+  getPluginState: vi.fn(),
+  setPluginEnabled: vi.fn(),
+  getBrowserStatus: vi.fn(),
+  getComputerStatus: vi.fn(),
+  getAndroidConfig: vi.fn(),
+  getAndroidStatus: vi.fn(),
+  getBackendState: vi.fn(),
+  getBackendHealth: vi.fn(),
+  setBackendKind: vi.fn(),
+  recoverBackend: vi.fn(),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ComputerUseSection } from '../ComputerUseSection';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+const computerUnavailable: ComputerDriverStatus = {
+  installed: false,
+  executablePath: null,
+  version: null,
+  daemonRunning: false,
+  installCommand: 'install cua-driver',
+  docsUrl: 'https://cua.ai/docs/cua-driver',
+};
+
+const androidUnavailable: AndroidStatusSummary = {
+  adb_available: false,
+  adb_path: null,
+  version: null,
+  devices: [],
+  issue: 'ADB_NOT_FOUND',
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  api.getPluginState.mockImplementation(async (id: string) => ({
+    effectiveEnabled: id === 'browser',
+  }));
+  api.setPluginEnabled.mockResolvedValue({ codexMcpRefreshed: true });
+  api.getBrowserStatus.mockResolvedValue({
+    detected: false,
+    browserKind: null,
+    executablePath: null,
+  });
+  api.getComputerStatus.mockResolvedValue(computerUnavailable);
+  api.getAndroidConfig.mockResolvedValue({
+    value: { defaultDeviceSerial: null, adbPathOverride: null },
+    defaults: { defaultDeviceSerial: null, adbPathOverride: null },
+    isCustomized: false,
+    customizedKeys: [],
+  });
+  api.getAndroidStatus.mockResolvedValue(androidUnavailable);
+  api.getBackendState.mockResolvedValue({ active: 'rsb-webview' });
+  api.setBackendKind.mockImplementation(async (kind: 'external' | 'rsb-webview') => ({
+    active: kind,
+  }));
+  api.recoverBackend.mockResolvedValue({
+    ok: true,
+    health: { active: 'rsb-webview', status: 'ready', canRecover: true },
+  });
+
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      platform: 'linux',
+      openExternal: vi.fn().mockResolvedValue({ success: true }),
+      maker: {
+        plugins: {
+          getState: api.getPluginState,
+          setEnabled: api.setPluginEnabled,
+          setProjectEnabled: vi.fn(),
+        },
+        browser: {
+          status: api.getBrowserStatus,
+          openForLogin: vi.fn(),
+        },
+        computer: {
+          status: api.getComputerStatus,
+          cancelPermissionGrant: vi.fn().mockResolvedValue({ cancelled: true }),
+          onPermissionGuideStatusChanged: vi.fn(() => () => undefined),
+          onPermissionGuideCancelled: vi.fn(() => () => undefined),
+          onUpdateProgress: vi.fn(() => () => undefined),
+          checkUpdate: vi.fn(),
+        },
+        android: {
+          getConfig: api.getAndroidConfig,
+          status: api.getAndroidStatus,
+          prepareAdb: vi.fn(),
+        },
+      },
+      browserBackend: {
+        getState: api.getBackendState,
+        getHealth: api.getBackendHealth,
+        setKind: api.setBackendKind,
+        recover: api.recoverBackend,
+      },
+    },
+  });
+});
+
+afterEach(cleanup);
+
+describe('ComputerUseSection browser backend health loading', () => {
+  it('renders the Automation settings while the recoverable health probe is still pending', async () => {
+    const initialHealth = deferred<BrowserBackendHealth>();
+    api.getBackendHealth.mockReturnValueOnce(initialHealth.promise);
+
+    render(<ComputerUseSection workingDir="/tmp/project" />);
+
+    expect(await screen.findByText('settings.computerUse.title')).toBeTruthy();
+    expect(screen.getByRole('tab', {
+      name: 'settings.computerUse.browserBackend.rsbWebview.title',
+    })).toBeTruthy();
+    expect(screen.queryByRole('status')).toBeNull();
+
+    await act(async () => {
+      initialHealth.resolve({
+        active: 'rsb-webview',
+        status: 'ready',
+        canRecover: true,
+      });
+      await initialHealth.promise;
+    });
+
+    expect((await screen.findByRole('status')).textContent).toContain(
+      'settings.computerUse.browserBackend.health.ready',
+    );
+  });
+
+  it('does not let a late initial health result overwrite a newer backend selection', async () => {
+    const initialHealth = deferred<BrowserBackendHealth>();
+    api.getBackendHealth
+      .mockReturnValueOnce(initialHealth.promise)
+      .mockResolvedValueOnce({ active: 'external', status: 'ready', canRecover: false })
+      .mockResolvedValueOnce({ active: 'rsb-webview', status: 'ready', canRecover: true });
+
+    render(<ComputerUseSection workingDir="/tmp/project" />);
+
+    fireEvent.click(await screen.findByRole('tab', {
+      name: 'settings.computerUse.browserBackend.external.title',
+    }));
+    await waitFor(() => expect(api.setBackendKind).toHaveBeenCalledWith('external'));
+    await waitFor(() => expect(
+      screen.getByRole('tab', {
+        name: 'settings.computerUse.browserBackend.external.title',
+      }).getAttribute('aria-selected'),
+    ).toBe('true'));
+
+    fireEvent.click(screen.getByRole('tab', {
+      name: 'settings.computerUse.browserBackend.rsbWebview.title',
+    }));
+    await waitFor(() => expect(api.setBackendKind).toHaveBeenCalledWith('rsb-webview'));
+    expect((await screen.findByRole('status')).textContent).toContain(
+      'settings.computerUse.browserBackend.health.ready',
+    );
+
+    await act(async () => {
+      initialHealth.resolve({
+        active: 'rsb-webview',
+        status: 'error',
+        canRecover: true,
+        reason: 'disposing',
+      });
+      await initialHealth.promise;
+    });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain(
+      'settings.computerUse.browserBackend.health.ready',
+    );
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

PR #1396 合并后，自动 review 补交了一条有效意见：内置浏览器异常时，`getHealth()` 会包含探测和自动恢复，最坏可能等待多个超时；它原本与基础设置读取放在同一个 `Promise.all`，导致整个「自动化」设置页在故障场景下长时间空白。

本 PR 将健康检查从初始渲染门槛中解耦：基础开关、浏览器类型和电脑状态就绪后立即显示，健康／恢复结果随后补充；同时增加异步结果序列保护，避免较晚返回的初始健康检查覆盖用户后续完成的浏览器切换或恢复状态。

### 变更类型

- [x] Bug 修复（不改变既有对外行为）
- [ ] 新功能
- [ ] 重构 / 工程改进
- [ ] 文档
- [ ] 其他

### 范围

- 关联 Issue / 需求：follow-up to #1396；处理合并后的 [review 意见](https://github.com/makecindy/cindy/pull/1396#discussion_r3703419649)
- 本 PR 包含：非阻塞浏览器健康检查加载；过期异步结果保护；对应回归测试
- 明确不包含：浏览器健康检查／恢复实现本身的改动；Chrome 会话复用（#1394）；新 UI、样式或文案
- 用户可见变化：慢速健康检查或自动恢复期间，「自动化」设置内容不再整体空白；既有健康状态和恢复入口会在检查完成后补充显示
- Breaking change：无

### UI 变化

- 不涉及视觉、样式、文案或交互结构变化；仅调整现有设置页的数据加载顺序。
- [UI 证据](https://github.com/makecindy/cindy/pull/1580#issuecomment-5175532797) 使用真实 `ComputerUseSection` 和与回归测试一致的 Electron API mock：`getHealth()` 持续 pending 时基础「自动操作」设置已完整显示；ready 后仅补充健康状态行。另已目检 Light / Dark ready 状态。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10。未新增样式或颜色，继续复用既有语义 token；Light / Dark 均已目检。其余视觉规范不涉及，因为本 PR 未改变视觉、文案或交互结构。

## 验证

### 自动验证

```text
XDT_UNIT_TEST_SHARD=1/2 pnpm test:unit
XDT_UNIT_TEST_SHARD=2/2 pnpm test:unit
```

结果：两片均通过，并集完整覆盖根目录 `pnpm test:unit`。

```text
pnpm --filter desktop run --if-present typecheck
```

结果：通过。

```text
pnpm --filter desktop exec vitest run \
  src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx \
  src/renderer/components/settings/__tests__/BrowserBackendSubsection.test.tsx
```

结果：2 个测试文件、6 个测试全部通过；覆盖健康检查未完成时先渲染设置页，以及初始旧结果不会覆盖用户后续选择这两个回归场景。

```text
pnpm --filter desktop exec eslint \
  src/renderer/components/settings/ComputerUseSection.tsx \
  src/renderer/components/settings/__tests__/ComputerUseSection.browserHealth.test.tsx
git diff --check
pnpm check:dco
```

结果：全部通过；DCO 检查确认本 PR 的 1 个提交已签名。

说明：首次以单进程全并发运行根测试时，3 个无关既有用例出现 5 秒超时；三者单独复跑均通过，随后使用仓库 CI 同构的两分片方式完成全量单元测试门禁，两片均通过。

### 手动验证

- 使用真实 `ComputerUseSection` 和与回归测试一致的 Electron API mock 验证：健康检查持续 pending 时基础设置仍立即显示；ready 后健康状态行正常补充。
- Light / Dark ready 状态均已目检；截图见上述 UI 证据评论。

### 未执行的验证

- 未在需接受服务条款的完整 Desktop 登录态中取图；本次采用无账号、无用户数据的真实组件验证页，避免代用户作出法律确认。

## 风险与回滚

- [x] 无已知风险
- 影响范围：仅 Desktop Renderer 中「自动化」设置页的初始化顺序，不改变 IPC、健康检查、恢复、持久化或错误文案契约。
- 主要风险：并发健康检查的旧结果覆盖较新的用户操作；已通过序列保护和定向回归测试覆盖。
- 回滚方式：回退本 PR 的单个提交即可恢复原行为。

## 提交前检查

- [x] 改动范围最小，未混入无关修改
- [x] 已补充或更新测试
- [x] 已完成与风险匹配的验证
- [x] 已检查 Light / Dark 影响（未改样式或 token，既有双模式外观保持不变）
- [x] 已确认无凭证、令牌或用户数据进入仓库
- [x] 已确认不涉及协议、数据库 migration、插件权限、系统提示词或更新器边界
