### PR TITLE
test(maker-core): 锁定 auto-review 送审用目录模型 id 而非 wire 串

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -6,6 +6,7 @@
  *   - auto + 安全内置(只读 / 区内写 / 只读 shell)→ 静默 allow,不惊动 resolver
  *   - auto + 灰区 → lightweight reviewer 的 allow/block 静默处理，只有 ask 才弹窗
  *   - auto + 确定危险命令 → 弹窗且 suggestion 被剥(不可持久化授权)
+ *   - 送审阅器的 model 恒为目录 id(不是 [1m] wire 串),切模后仍然如此
  *   - default 档 → 内置工具不走 auto-review 策略(照旧弹窗),证明只作用于 auto
  */
 import { promises as fs } from 'node:fs';
@@ -15,6 +16,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { AgentDeps } from '../../base-agent.js';
+import type { AutoReviewRequest } from '../../shared/auto-review-decision.js';
 import type { PermissionMode } from '../../../types/common.js';
 import type { AuthAdapter } from '../../../interfaces/auth-adapter.js';
 import type { InteractionDecision, InteractionRequest } from '../../../types/events.js';
@@ -93,6 +95,7 @@ async function startSession(
     reviewVerdict?: 'allow' | 'block' | 'ask';
     reviewer?: AgentDeps['reviewAutoPermissionAction'];
     attachResolver?: boolean;
+    model?: string;
   } = {},
 ) {
   const configDir = await makeTempDir();
@@ -111,13 +114,13 @@ async function startSession(
   }));
   const handle = await agent.startSession({
     sessionId: 'session-auto-review',
-    model: 'claude-opus-4-6',
+    model: options.model ?? 'claude-opus-4-6',
     providerId: options.providerId ?? 'xd',
     workingDir,
     permissionMode,
   });
   const queryOptions = sdkMock.query.mock.calls.at(-1)?.[0]?.options as
-    | { canUseTool?: CanUseToolFn; permissionMode?: string }
+    | { canUseTool?: CanUseToolFn; permissionMode?: string; model?: string }
     | undefined;
   if (!queryOptions?.canUseTool) throw new Error('expected sdk query canUseTool');
 
@@ -135,10 +138,21 @@ async function startSession(
     canUseTool: queryOptions.canUseTool,
     fakeQuery,
     queryPermissionMode: queryOptions.permissionMode,
+    querySdkModel: queryOptions.model,
     reviewAutoPermissionAction,
     seen,
     workingDir,
   };
+}
+
+/** 取 reviewer 第 n 次调用收到的 AutoReviewRequest。 */
+function reviewedRequest(
+  reviewer: AgentDeps['reviewAutoPermissionAction'],
+  callIndex = 0,
+): AutoReviewRequest {
+  const request = vi.mocked(reviewer!).mock.calls[callIndex]?.[0];
+  if (!request) throw new Error(`expected reviewer call #${callIndex}`);
+  return request;
 }
 
 function permissionRequests(seen: InteractionRequest[]) {
@@ -323,6 +337,55 @@ describe('Auto-review wiring: lightweight reviewer controls gray actions', () =>
     expect(reqs).toHaveLength(1);
     expect(reqs[0]?.suggestions).toBeUndefined();
     expect(reviewAutoPermissionAction).not.toHaveBeenCalled();
+    await handle.close();
+  });
+});
+
+/**
+ * 送审阅器的是**用户选中的目录模型 id**,不是送 SDK 的 wire 串。
+ *
+ * host 侧 reviewer 按 (providerId, model) 精确查目录条目定路由,查不到就 fail closed
+ * (oneShotCandidates 的 no_candidate)—— 灰区动作会退化成没有 UI 提示的永久 block。
+ * Claude 的 wire 串带 [1m] beta 通道后缀(toSdkModelString),而目录条目不带,所以这两个
+ * 值必须始终分离:`mutableModel` 只跟随用户选择,wire 串在送 SDK 前单独派生、不回写。
+ *
+ * Codex 侧的同一约束靠 mutableCatalogModel 兜(它的 app-server 会把规范化后的 wire id
+ * **回带**覆盖运行期 model);Claude 没有那条回带路径,不变量由下面两个用例守住 —— 任何
+ * 把 wire 串写回 mutableModel 的改动都会让它们变红。见 issue #1575。
+ */
+describe('Auto-review wiring: the reviewer routes through the catalog model id', () => {
+  it('reviews through the catalog id while the SDK receives the [1m] wire id', async () => {
+    const { handle, canUseTool, querySdkModel, reviewAutoPermissionAction } = await startSession('auto', {
+      model: 'claude-opus-4-6',
+      reviewVerdict: 'allow',
+    });
+    expect(querySdkModel).toBe('claude-opus-4-6[1m]');
+
+    const r = await canUseTool(
+      'Write',
+      { file_path: '/tmp/catalog-model.conf' },
+      { toolUseID: 'catalog-model' },
+    );
+    expect(r.behavior).toBe('allow');
+    expect(reviewedRequest(reviewAutoPermissionAction).model).toBe('claude-opus-4-6');
+    await handle.close();
+  });
+
+  it('keeps reviewing through the catalog id after setModel switches the route', async () => {
+    const { handle, canUseTool, fakeQuery, reviewAutoPermissionAction } = await startSession('auto', {
+      model: 'claude-opus-4-6',
+      reviewVerdict: 'allow',
+    });
+
+    await handle.setModel?.('claude-sonnet-5');
+    expect(fakeQuery.setModel).toHaveBeenCalledWith('claude-sonnet-5[1m]');
+
+    await canUseTool(
+      'Write',
+      { file_path: '/tmp/catalog-model-switched.conf' },
+      { toolUseID: 'catalog-model-switched' },
+    );
+    expect(reviewedRequest(reviewAutoPermissionAction).model).toBe('claude-sonnet-5');
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -147,10 +147,10 @@ async function startSession(
 
 /** 取 reviewer 第 n 次调用收到的 AutoReviewRequest。 */
 function reviewedRequest(
-  reviewer: AgentDeps['reviewAutoPermissionAction'],
+  reviewer: NonNullable<AgentDeps['reviewAutoPermissionAction']>,
   callIndex = 0,
 ): AutoReviewRequest {
-  const request = vi.mocked(reviewer!).mock.calls[callIndex]?.[0];
+  const request = vi.mocked(reviewer).mock.calls[callIndex]?.[0];
   if (!request) throw new Error(`expected reviewer call #${callIndex}`);
   return request;
 }

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -7,7 +7,8 @@
  *   3. auto 档:区内写静默 confirmed:true;灰区交当前模型 reviewer,仅 reviewer 明确
  *      ask / 本地红线才弹 resolver;reviewer 缺失时 fail-closed deny;
  *   4. ask 档:区内写照旧弹 resolver(auto 的差异只在 auto 档生效);
- *   5. 送审阅器的 model 与 spawn 的 `--model` 同源(都是用户选中的目录 id)。
+ *   5. 送审阅器的 model 与 Pi 当前运行模型同源:启动取 `--model`,热切换取成功的
+ *      `set_model` id(都是用户选中的目录 id)。
  */
 
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -19,6 +20,7 @@ const captured = vi.hoisted(() => ({
   args: [] as string[],
   env: {} as Record<string, string | undefined>,
   onEvent: null as ((event: unknown) => void) | null,
+  requests: [] as Array<Record<string, unknown>>,
   sent: [] as Array<Record<string, unknown>>,
   proxyRegistration: null as { sessionId: string; token: string } | null,
 }));
@@ -35,7 +37,10 @@ vi.mock('../rpc-client.js', () => ({
       captured.env = opts.env;
       captured.onEvent = opts.onEvent;
     }
-    async request(cmd: { type: string }): Promise<{ success: boolean; data?: unknown }> {
+    async request(
+      cmd: Record<string, unknown> & { type: string },
+    ): Promise<{ success: boolean; data?: unknown }> {
+      captured.requests.push(cmd);
       if (cmd.type === 'get_state') {
         return { success: true, data: { sessionFile: '/mock/session.jsonl', model: { contextWindow: 200000 } } };
       }
@@ -71,6 +76,7 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     captured.args = [];
     captured.env = {};
     captured.onEvent = null;
+    captured.requests = [];
     captured.sent = [];
     captured.proxyRegistration = null;
     agentHome = mkdtempSync(path.join(tmpdir(), 'pi-dispatch-home-'));
@@ -88,6 +94,7 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
 
   function buildDeps(
     reviewAutoPermissionAction?: AgentDeps['reviewAutoPermissionAction'],
+    includeNextModel = false,
   ): AgentDeps {
     return {
       auth: {
@@ -110,6 +117,15 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
             cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
             maxOutputTokens: 64_000,
           },
+          ...(includeNextModel ? [{
+            id: 'm-next',
+            displayName: 'M Next',
+            contextWindow: 200_000,
+            efforts: [],
+            defaultEffort: null,
+            cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+            maxOutputTokens: 64_000,
+          }] : []),
         ],
       },
       resolvePiAgentHome: () => agentHome,
@@ -123,8 +139,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
   async function start(
     permissionMode?: string,
     reviewAutoPermissionAction?: AgentDeps['reviewAutoPermissionAction'],
+    includeNextModel = false,
   ): Promise<AgentSessionHandle> {
-    const agent = new PiAgent(buildDeps(reviewAutoPermissionAction));
+    const agent = new PiAgent(buildDeps(reviewAutoPermissionAction, includeNextModel));
     return agent.startSession({
       sessionId: 's1',
       workingDir: cwd,
@@ -321,7 +338,8 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
   });
 
   /**
-   * 送审阅器的 model 必须与送给 pi 进程的 `--model` 是同一个目录 id。
+   * 送审阅器的 model 必须与 Pi 当前运行模型是同一个目录 id:启动时来自 `--model`,
+   * 热切换后来自成功的 `set_model` 请求。
    *
    * host reviewer 按 (providerId, model) 精确查目录条目定路由,查不到即 fail closed
    * (oneShotCandidates 的 no_candidate),灰区动作退化成没有 UI 提示的永久 block。
@@ -329,15 +347,29 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
    * 这条用例把「两者同源」钉成不变量:将来若给 pi 引入 wire 派生,必须像 Claude 那样
    * 单独派生、不回写运行期 model。见 issue #1575。
    */
-  it('reviews through the same catalog model id it spawned pi with', async () => {
+  it('keeps review routing aligned with the initial and hot-switched catalog model ids', async () => {
     const review = vi.fn(async () => ({ verdict: 'allow' as const }));
-    const handle = await start('auto', review);
+    const handle = await start('auto', review, true);
     await handle.send({ type: 'user', content: 'Touch a scratch file outside the workspace.' });
     firePermissionRequest('r8', 'write', { path: '/tmp/catalog-model.txt' });
     await flush();
-    const spawnedModel = captured.args[captured.args.indexOf('--model') + 1];
+    const modelArgIndex = captured.args.indexOf('--model');
+    expect(modelArgIndex).toBeGreaterThan(-1);
+    const spawnedModel = captured.args[modelArgIndex + 1];
     expect(spawnedModel).toBe('m');
-    expect(review).toHaveBeenCalledWith(expect.objectContaining({ model: spawnedModel }));
+    expect(review).toHaveBeenNthCalledWith(1, expect.objectContaining({ model: spawnedModel }));
+
+    await handle.setModel?.('m-next');
+    expect(captured.requests).toContainEqual({
+      type: 'set_model',
+      provider: 'cindy',
+      modelId: 'm-next',
+    });
+    await handle.send({ type: 'user', content: 'Touch another scratch file after switching models.' });
+    firePermissionRequest('r9', 'write', { path: '/tmp/catalog-model-switched.txt' });
+    await flush();
+    expect(review).toHaveBeenNthCalledWith(2, expect.objectContaining({ model: 'm-next' }));
+    await handle.close();
   });
 
   it('auto mode prompts only when the current-model reviewer explicitly asks', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -6,7 +6,8 @@
  *      NO_PROXY 含 loopback 且吞并小写 no_proxy;
  *   3. auto 档:区内写静默 confirmed:true;灰区交当前模型 reviewer,仅 reviewer 明确
  *      ask / 本地红线才弹 resolver;reviewer 缺失时 fail-closed deny;
- *   4. ask 档:区内写照旧弹 resolver(auto 的差异只在 auto 档生效)。
+ *   4. ask 档:区内写照旧弹 resolver(auto 的差异只在 auto 档生效);
+ *   5. 送审阅器的 model 与 spawn 的 `--model` 同源(都是用户选中的目录 id)。
  */
 
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
@@ -317,6 +318,26 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       },
     }));
     expect(captured.sent).toContainEqual({ type: 'extension_ui_response', id: 'r3', confirmed: true });
+  });
+
+  /**
+   * 送审阅器的 model 必须与送给 pi 进程的 `--model` 是同一个目录 id。
+   *
+   * host reviewer 按 (providerId, model) 精确查目录条目定路由,查不到即 fail closed
+   * (oneShotCandidates 的 no_candidate),灰区动作退化成没有 UI 提示的永久 block。
+   * pi 当前不做 wire 改写(不同于 Claude 的 [1m] 后缀、Codex 的 app-server 回带别名),
+   * 这条用例把「两者同源」钉成不变量:将来若给 pi 引入 wire 派生,必须像 Claude 那样
+   * 单独派生、不回写运行期 model。见 issue #1575。
+   */
+  it('reviews through the same catalog model id it spawned pi with', async () => {
+    const review = vi.fn(async () => ({ verdict: 'allow' as const }));
+    const handle = await start('auto', review);
+    await handle.send({ type: 'user', content: 'Touch a scratch file outside the workspace.' });
+    firePermissionRequest('r8', 'write', { path: '/tmp/catalog-model.txt' });
+    await flush();
+    const spawnedModel = captured.args[captured.args.indexOf('--model') + 1];
+    expect(spawnedModel).toBe('m');
+    expect(review).toHaveBeenCalledWith(expect.objectContaining({ model: spawnedModel }));
   });
 
   it('auto mode prompts only when the current-model reviewer explicitly asks', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

issue #1575 报「Claude / Pi 的 auto-review 未做 catalog model 归一（Codex 已做），导致审阅路由
`no_candidate`」。逐条核实后，当前 `main` 上这个运行期前提并不成立，因此本 PR 不引入一层
实际为 no-op 的 catalog 状态，而是把真正需要守住的不变量钉成回归测试。

核实过程：

- Claude 的 `mutableModel` 只由 `startSession` 的目录模型与成功的 `setModel` 更新；送 SDK 的
  `[1m]` wire 串由 `sdkModelFor()` 单独派生，不会回写 `mutableModel`。
- Pi 的 `mutableModel` 同时驱动启动 `--model`、成功热切模后的 `set_model` id 与 host reviewer；
  它当前不做 wire 改写。Pi 的运行 provider 与宿主鉴权/审阅 provider 也是两套独立状态，不能
  机械复制 Codex 的字段设计。
- Codex 之所以需要 `mutableCatalogModel`，是因为 app-server 会回带规范化后的 wire alias 并
  覆盖运行期 model；Claude / Pi 没有这条回带路径。

结论：保留现有 fail-closed 语义，不回落默认 utility chain；补三条防御性回归，确保将来若引入
wire 派生或改动切模接线，host reviewer 始终收到当前用户目录中可解析的 model id。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1575
- 本 PR 包含：Claude 两条回归（启动 wire/catalog 分离、成功热切模后仍用目录 id）；Pi 一条回归
  （启动 `--model` 与 reviewer 同源、成功 `set_model` 热切换后 reviewer 跟随新目录 id）；两处
  测试覆盖清单更新；review 提出的测试类型与资源释放加固
- 明确不包含：任何运行期行为改动；`AutoReviewDecision` 语义调整；默认 utility chain 回落；
  其它 auto-review issue（#1574 / #1576 / #1577 / #1578 / #1579）
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/claude-code/__tests__/auto-review-wiring.test.ts \
  src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
结果：2 files / 28 tests 全部通过（新增 3 条，其中 Pi 用例覆盖启动与热切模）

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过

pnpm test:unit
结果：全部 workspace PASS（含 Desktop、Mobile、maker-core 与 cindy-protocol 子包）

pnpm check:dco
结果：2 commits 全部通过 DCO 校验
```

**Mutation 验证**（防御性测试必须证明它能失效）：把 Claude 的 `reviewAutoAction` 临时改为把
`sdkModelFor(mutableModel)` 送给 reviewer 后重跑，新增两条 Claude 用例精确变红，同文件其它用例
保持绿色。验证后源文件已还原，最终 diff 只有测试文件。

### 手工验证

不涉及（纯测试改动，无运行期行为变化）。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `packages/maker-core` 的两个测试文件，无运行期代码改动。
- 回滚 / 降级方式：revert 本 PR 即可，不影响任何运行期行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不变量理由写在测试注释中，与相邻覆盖清单同款）
- [x] 已确认测试结果或说明未执行原因
