### PR TITLE
feat(desktop): Full access 确认弹窗改为分类权限清单

### DIFF
--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -5129,6 +5129,8 @@ export function ChatInput({
           description: t('newChat.chatInput.fullAccessConfirmation.description'),
           // 逐类权限清单(文件 / 终端命令 / 网络)+ 高风险操作仍确认的脚注。
           content: <FullAccessConfirmContent />,
+          // 高风险授权:开场朗读必须覆盖清单全文,SR 用户听全权限再确认。
+          describeContent: true,
           // 带清单的确认框放宽到 440(§4:普通确认 400,富内容可适度放宽)。
           maxWidth: 440,
           confirmText: t('newChat.chatInput.fullAccessConfirmation.confirm'),

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -21,6 +21,7 @@ import { ImageLightbox } from '@/components/chat/ImageLightbox';
 import { ImageHoverPreview } from '@/components/chat/ImageHoverPreview';
 import { formatBytes, TextLightbox } from '@/components/chat/TextLightbox';
 import { AttachmentTypeThumb } from './AttachmentTypeThumb';
+import { FullAccessConfirmContent } from './FullAccessConfirmContent';
 import { useEditor, EditorContent } from '@tiptap/react';
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
@@ -5126,8 +5127,14 @@ export function ChatInput({
         const confirmed = await confirmDialog({
           title: t('newChat.chatInput.fullAccessConfirmation.title'),
           description: t('newChat.chatInput.fullAccessConfirmation.description'),
+          // 逐类权限清单(文件 / 终端命令 / 网络)+ 高风险操作仍确认的脚注。
+          content: <FullAccessConfirmContent />,
+          // 带清单的确认框放宽到 440(§4:普通确认 400,富内容可适度放宽)。
+          maxWidth: 440,
           confirmText: t('newChat.chatInput.fullAccessConfirmation.confirm'),
           cancelText: t('newChat.chatInput.fullAccessConfirmation.cancel'),
+          // 警示三角跟随按钮文字颜色,不引入新语义色;高风险升级的视觉提醒。
+          confirmIcon: <TriangleAlert size={14} />,
         });
         if (!confirmed) return;
       }

--- a/apps/desktop/src/renderer/components/new-chat/FullAccessConfirmContent.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/FullAccessConfirmContent.tsx
@@ -1,9 +1,9 @@
 /**
  * Full access 升级确认弹窗的富内容区(ChatInput 切换权限档时经 useConfirmDialog 弹出)。
  *
- * 把原先一整段权限说明拆成逐类可扫读的清单(文件 / 终端命令 / 网络),行排版与
- * 装入确认的权限清单(cindy-brain/GhostPermissionList.tsx)同款 token,让两处
- * "授权前的知情确认"读起来是同一套语言。文案在
+ * 把原先一整段权限说明拆成逐类可扫读的清单(文件 / 终端命令 / 网络),行结构与
+ * 装入确认的权限清单(cindy-brain/GhostPermissionList.tsx)同构;标题/说明的
+ * 文字色阶改用 --text-primary / --text-secondary(原因见行内注释)。文案在
  * newChat.chatInput.fullAccessConfirmation.*,此处只负责排版。
  */
 import { FolderOpen, Globe, Terminal, type LucideIcon } from 'lucide-react';
@@ -36,10 +36,14 @@ export function FullAccessConfirmContent() {
               aria-hidden="true"
             />
             <div className="min-w-0">
-              <p className="break-words text-13 font-medium leading-5 text-[var(--confirm-desc)]">
+              {/* 标题/说明用 --text-primary / --text-secondary:两档在明暗两模式都有
+                  色阶差。不沿用 GhostPermissionList 的 --confirm-desc / --text-tertiary
+                  —— 那对 token 在 Dark 下同为 #737373,两级层级会塌成同色,
+                  只剩字号差(2026-08 产品门 review 定的取舍)。 */}
+              <p className="break-words text-13 font-medium leading-5 text-[var(--text-primary)]">
                 {t(`newChat.chatInput.fullAccessConfirmation.items.${key}.title`)}
               </p>
-              <p className="break-words text-12 leading-[1.5] text-[var(--text-tertiary)]">
+              <p className="break-words text-12 leading-[1.5] text-[var(--text-secondary)]">
                 {t(`newChat.chatInput.fullAccessConfirmation.items.${key}.description`)}
               </p>
             </div>

--- a/apps/desktop/src/renderer/components/new-chat/FullAccessConfirmContent.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/FullAccessConfirmContent.tsx
@@ -1,0 +1,56 @@
+/**
+ * Full access 升级确认弹窗的富内容区(ChatInput 切换权限档时经 useConfirmDialog 弹出)。
+ *
+ * 把原先一整段权限说明拆成逐类可扫读的清单(文件 / 终端命令 / 网络),行排版与
+ * 装入确认的权限清单(cindy-brain/GhostPermissionList.tsx)同款 token,让两处
+ * "授权前的知情确认"读起来是同一套语言。文案在
+ * newChat.chatInput.fullAccessConfirmation.*,此处只负责排版。
+ */
+import { FolderOpen, Globe, Terminal, type LucideIcon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import { cn } from '@/lib/utils';
+
+const ITEMS: Array<{ key: 'files' | 'commands' | 'network'; icon: LucideIcon }> = [
+  { key: 'files', icon: FolderOpen },
+  { key: 'commands', icon: Terminal },
+  { key: 'network', icon: Globe },
+];
+
+export function FullAccessConfirmContent() {
+  const { t } = useTranslation();
+  return (
+    <div>
+      <div className="rounded-xl border border-[var(--border-default)]">
+        {ITEMS.map(({ key, icon: Icon }, index) => (
+          <div
+            key={key}
+            className={cn(
+              'flex items-start gap-2.5 px-3 py-2.5',
+              index > 0 && 'border-t border-[var(--border-default)]',
+            )}
+          >
+            <Icon
+              size={16}
+              className="mt-0.5 shrink-0 text-[var(--text-secondary)]"
+              aria-hidden="true"
+            />
+            <div className="min-w-0">
+              <p className="break-words text-13 font-medium leading-5 text-[var(--confirm-desc)]">
+                {t(`newChat.chatInput.fullAccessConfirmation.items.${key}.title`)}
+              </p>
+              <p className="break-words text-12 leading-[1.5] text-[var(--text-tertiary)]">
+                {t(`newChat.chatInput.fullAccessConfirmation.items.${key}.description`)}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+      {/* 兜底边界的宽心话:内置高风险操作仍会确认。作为脚注而非清单项 ——
+          它不是"将被放开"的权限,混进清单会削弱上面三条的警示语义。 */}
+      <p className="mt-3 text-12 leading-[1.5] text-[var(--text-tertiary)]">
+        {t('newChat.chatInput.fullAccessConfirmation.note')}
+      </p>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/ui/__tests__/confirmDialogA11y.test.tsx
+++ b/apps/desktop/src/renderer/components/ui/__tests__/confirmDialogA11y.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+/**
+ * confirmDialogA11y.test.tsx — ConfirmDialog 无障碍关联的契约。
+ *
+ * 锁两件事(都来自 Full access 确认弹窗的 review,PR #1586):
+ * 1. describeContent 开启时 aria-describedby 指向「description + 富内容」整个
+ *    滚动区 —— 授权确认的开场朗读必须覆盖权限清单全文,否则屏幕阅读器用户
+ *    在没听到实际权限的情况下就能确认;缺省关闭时保持 Radix 原生行为不变。
+ * 2. confirmIcon 是纯装饰:必须 aria-hidden,且按钮的可访问名称仍等于
+ *    confirmText —— 图标不得混进读屏输出或破坏按名称查询。
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ConfirmDialog } from '../confirm-dialog';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/lib/scrollbarAutoHide', () => ({
+  flashScrollbar: () => {},
+}));
+
+afterEach(cleanup);
+
+const permissionList = (
+  <div>
+    <p>文件与文件夹:读取和修改工作区外的文件</p>
+    <p>终端命令:直接执行终端命令与脚本</p>
+  </div>
+);
+
+describe('ConfirmDialog describeContent', () => {
+  it('开启时 aria-describedby 指向含 description 与富内容的滚动区', () => {
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="开启 Full access？"
+        description="Full access 会关闭工作区沙箱:"
+        content={permissionList}
+        describeContent
+        confirmText="开启 Full access"
+      />,
+    );
+    const dialog = screen.getByRole('alertdialog');
+    const describedBy = dialog.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const target = document.getElementById(describedBy as string) as HTMLElement;
+    // 指向的是滚动区本体:开场朗读同时覆盖引导句与逐条权限。
+    expect(target.className).toContain('overflow-y-auto');
+    expect(target.textContent).toContain('Full access 会关闭工作区沙箱:');
+    expect(target.textContent).toContain('终端命令:直接执行终端命令与脚本');
+  });
+
+  it('缺省关闭时保持 Radix 原生行为:描述仅覆盖 description,不含富内容', () => {
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="更新确认"
+        description="从 1.0.0 更新到 2.0.0"
+        content={permissionList}
+        confirmText="更新"
+      />,
+    );
+    const dialog = screen.getByRole('alertdialog');
+    const describedBy = dialog.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const target = document.getElementById(describedBy as string) as HTMLElement;
+    expect(target.textContent).toBe('从 1.0.0 更新到 2.0.0');
+  });
+
+  it('无 description 且未开启 describeContent 时不带 aria-describedby(既有行为)', () => {
+    render(
+      <ConfirmDialog open onOpenChange={() => {}} title="确定退出？" confirmText="退出" />,
+    );
+    expect(screen.getByRole('alertdialog').getAttribute('aria-describedby')).toBeNull();
+  });
+});
+
+describe('ConfirmDialog confirmIcon', () => {
+  it('图标 aria-hidden,按钮可访问名称仍等于 confirmText', () => {
+    render(
+      <ConfirmDialog
+        open
+        onOpenChange={() => {}}
+        title="开启 Full access？"
+        description="说明"
+        confirmIcon={<svg data-testid="warn-icon" />}
+        confirmText="开启 Full access"
+      />,
+    );
+    // 图标不计入可访问名称:按 confirmText 原文查询必须命中。
+    const confirmBtn = screen.getByRole('button', { name: '开启 Full access' });
+    const iconWrapper = confirmBtn.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(iconWrapper).not.toBeNull();
+    expect(iconWrapper.querySelector('[data-testid="warn-icon"]')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/ui/confirm-dialog-provider.tsx
+++ b/apps/desktop/src/renderer/components/ui/confirm-dialog-provider.tsx
@@ -13,6 +13,10 @@ export interface ConfirmOptions {
   maxWidth?: number;
   confirmText?: string;
   cancelText?: string;
+  /** 主按钮变体;destructive 走语义 destructive token(见 ConfirmDialogProps)。 */
+  confirmVariant?: 'default' | 'destructive';
+  /** 主按钮文字前的小图标(见 ConfirmDialogProps.confirmIcon)。 */
+  confirmIcon?: ReactNode;
   showCancel?: boolean;
   /**
    * 设了就在弹窗底部加一个"下次不再提示"复选框,并把勾选状态以 '1' 写入
@@ -242,6 +246,10 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
           maxWidth={currentItem.options.maxWidth}
           confirmText={currentItem.options.confirmText}
           cancelText={currentItem.options.cancelText}
+          // confirmVariant 此前没有透传:GhostConfirmDialogHost 的 danger 分支
+          // 一直被静默丢掉(spread 绕过了多余属性检查),这里补上。
+          confirmVariant={currentItem.options.confirmVariant}
+          confirmIcon={currentItem.options.confirmIcon}
           showCancel={currentItem.options.showCancel}
           tertiaryText={currentItem.options.tertiaryText}
           autoFocusConfirm={currentItem.options.autoFocusConfirm}

--- a/apps/desktop/src/renderer/components/ui/confirm-dialog-provider.tsx
+++ b/apps/desktop/src/renderer/components/ui/confirm-dialog-provider.tsx
@@ -17,6 +17,8 @@ export interface ConfirmOptions {
   confirmVariant?: 'default' | 'destructive';
   /** 主按钮文字前的小图标(见 ConfirmDialogProps.confirmIcon)。 */
   confirmIcon?: ReactNode;
+  /** 让屏幕阅读器开场朗读覆盖 content 清单(见 ConfirmDialogProps.describeContent)。 */
+  describeContent?: boolean;
   showCancel?: boolean;
   /**
    * 设了就在弹窗底部加一个"下次不再提示"复选框,并把勾选状态以 '1' 写入
@@ -250,6 +252,7 @@ export function ConfirmDialogProvider({ children }: { children: ReactNode }) {
           // 一直被静默丢掉(spread 绕过了多余属性检查),这里补上。
           confirmVariant={currentItem.options.confirmVariant}
           confirmIcon={currentItem.options.confirmIcon}
+          describeContent={currentItem.options.describeContent}
           showCancel={currentItem.options.showCancel}
           tertiaryText={currentItem.options.tertiaryText}
           autoFocusConfirm={currentItem.options.autoFocusConfirm}

--- a/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
@@ -54,6 +54,11 @@ export interface ConfirmDialogProps {
   /** Destructive actions use the semantic destructive theme tokens. */
   confirmVariant?: 'default' | 'destructive';
   /**
+   * 主按钮文字前的小图标(如 Full access 确认的警示三角)。跟随按钮文字颜色,
+   * 不引入新的语义色;loading 时与文字一起被 spinner 顶掉。
+   */
+  confirmIcon?: ReactNode;
+  /**
    * 进入"操作进行中"态:主按钮内容换成 spinner、所有按钮禁用,
    * 同时 ESC 和点击外部都不再关弹框。典型场景:用户点了确认后触发的
    * 不可逆操作(如关闭应用),期间不应再让用户操作 UI。
@@ -83,6 +88,7 @@ export function ConfirmDialog({
   autoFocusConfirm,
   confirmDisabled = false,
   confirmVariant = 'default',
+  confirmIcon,
   loading = false,
   onConfirm,
   onCancel,
@@ -225,7 +231,14 @@ export function ConfirmDialog({
                 {loading ? (
                   <Spinner size={14} />
                 ) : (
-                  resolvedConfirmText
+                  <>
+                    {confirmIcon && (
+                      <span className="mr-1.5 inline-flex shrink-0" aria-hidden="true">
+                        {confirmIcon}
+                      </span>
+                    )}
+                    {resolvedConfirmText}
+                  </>
                 )}
               </button>
             </AlertDialog.Action>

--- a/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
+++ b/apps/desktop/src/renderer/components/ui/confirm-dialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useEffect, useId, useRef, useState, type ReactNode } from 'react';
 import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import { useTranslation } from 'react-i18next';
 
@@ -59,6 +59,14 @@ export interface ConfirmDialogProps {
    */
   confirmIcon?: ReactNode;
   /**
+   * 把 aria-describedby 指向「description + 富内容」整个滚动区,让屏幕阅读器在
+   * 弹窗打开时把 content 里的清单一并朗读出来。授权类确认(如 Full access 的
+   * 权限清单)应开启 —— 否则开场朗读止于 description,SR 用户在没听到实际权限
+   * 的情况下就能确认。缺省关闭:长清单弹窗(如装意识的逐项权限)开场全文朗读
+   * 反而淹没用户,是否开启由调用方按内容长度决定。
+   */
+  describeContent?: boolean;
+  /**
    * 进入"操作进行中"态:主按钮内容换成 spinner、所有按钮禁用,
    * 同时 ESC 和点击外部都不再关弹框。典型场景:用户点了确认后触发的
    * 不可逆操作(如关闭应用),期间不应再让用户操作 UI。
@@ -89,6 +97,7 @@ export function ConfirmDialog({
   confirmDisabled = false,
   confirmVariant = 'default',
   confirmIcon,
+  describeContent = false,
   loading = false,
   onConfirm,
   onCancel,
@@ -96,6 +105,8 @@ export function ConfirmDialog({
   zIndex = 10000,
 }: ConfirmDialogProps) {
   const { t } = useTranslation();
+  // describeContent 用:让 aria-describedby 覆盖整个「description + content」滚动区。
+  const bodyId = useId();
   const resolvedConfirmText = confirmText ?? t('commonUi.confirmDialog.confirm');
   const resolvedCancelText = cancelText ?? t('commonUi.confirmDialog.cancel');
   // 每次打开复位到初始勾选态,避免上一轮的勾选残留到下一次弹窗。
@@ -144,7 +155,12 @@ export function ConfirmDialog({
             'data-[state=closed]:animate-confirm-content-out',
           )}
           style={{ WebkitAppRegion: 'no-drag', maxWidth: maxWidth ?? 400, zIndex } as React.CSSProperties}
-          {...(!description ? { 'aria-describedby': undefined } : {})}
+          {...(describeContent && content
+            ? // 指向滚动区(含 description 与 content):开场朗读覆盖清单全文。
+              { 'aria-describedby': bodyId }
+            : !description
+              ? { 'aria-describedby': undefined }
+              : {})}
           onEscapeKeyDown={(e) => {
             if (loading) e.preventDefault();
           }}
@@ -170,6 +186,7 @@ export function ConfirmDialog({
             // (典型:插件更新确认框的权限变更清单)。
             <div
               ref={scrollRef}
+              id={describeContent && content ? bodyId : undefined}
               // 内容里的折叠区(如权限清单的工具组)展开后高度会变,capture 阶段
               // 收一次点击、下一帧重新判定是否可滚,让滚动条跟着新高度再闪一下。
               onClickCapture={revealScrollbar}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5238,9 +5238,24 @@
       "permissionSwitchFailed": "Permission mode change failed; the previous setting was kept",
       "fullAccessConfirmation": {
         "title": "Enable Full access?",
-        "description": "Full access disables the workspace sandbox and skips routine approvals. Cindy can modify files outside the workspace and run network commands without asking; built-in high-risk operations will still require confirmation.",
+        "description": "Full access disables the workspace sandbox and skips routine approvals. Cindy can then do the following without asking:",
+        "items": {
+          "files": {
+            "title": "Files and Folders",
+            "description": "Read and modify files outside the workspace"
+          },
+          "commands": {
+            "title": "Terminal Commands",
+            "description": "Run terminal commands and scripts directly"
+          },
+          "network": {
+            "title": "Network Access",
+            "description": "Run network commands and access the internet"
+          }
+        },
+        "note": "Built-in high-risk operations will still require confirmation.",
         "confirm": "Enable Full access",
-        "cancel": "Keep current permissions"
+        "cancel": "Cancel"
       },
       "attachmentRejection": {
         "dismiss": "Dismiss"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5236,9 +5236,24 @@
       "permissionSwitchFailed": "権限モードの変更に失敗したため、以前の設定を維持しました",
       "fullAccessConfirmation": {
         "title": "Full access を有効にしますか？",
-        "description": "Full access はワークスペースのサンドボックスを無効にし、通常の承認を省略します。Cindy はワークスペース外のファイル変更やネットワークコマンドを確認なしで実行できます。組み込みの高リスク操作では引き続き確認が必要です。",
+        "description": "Full access はワークスペースのサンドボックスを無効にし、通常の承認を省略します。Cindy は確認なしで次の操作ができるようになります:",
+        "items": {
+          "files": {
+            "title": "ファイルとフォルダ",
+            "description": "ワークスペース外のファイルの読み取りと変更"
+          },
+          "commands": {
+            "title": "ターミナルコマンド",
+            "description": "ターミナルコマンドやスクリプトを直接実行"
+          },
+          "network": {
+            "title": "ネットワークアクセス",
+            "description": "ネットワークコマンドの実行とインターネットへのアクセス"
+          }
+        },
+        "note": "組み込みの高リスク操作では引き続き確認が必要です。",
         "confirm": "Full access を有効にする",
-        "cancel": "現在の権限を維持"
+        "cancel": "キャンセル"
       },
       "attachmentRejection": {
         "dismiss": "閉じる"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5236,9 +5236,24 @@
       "permissionSwitchFailed": "권한 모드 변경에 실패해 이전 설정을 유지했습니다",
       "fullAccessConfirmation": {
         "title": "Full access를 활성화할까요?",
-        "description": "Full access는 작업 공간 샌드박스를 비활성화하고 일반 승인을 건너뜁니다. Cindy가 작업 공간 밖의 파일을 수정하고 네트워크 명령을 묻지 않고 실행할 수 있습니다. 기본 제공 고위험 작업은 계속 확인을 요청합니다.",
+        "description": "Full access는 작업 공간 샌드박스를 비활성화하고 일반 승인을 건너뜁니다. Cindy는 확인 없이 다음 작업을 할 수 있습니다:",
+        "items": {
+          "files": {
+            "title": "파일 및 폴더",
+            "description": "작업 공간 밖의 파일 읽기 및 수정"
+          },
+          "commands": {
+            "title": "터미널 명령",
+            "description": "터미널 명령과 스크립트를 직접 실행"
+          },
+          "network": {
+            "title": "네트워크 액세스",
+            "description": "네트워크 명령 실행 및 인터넷 접근"
+          }
+        },
+        "note": "기본 제공 고위험 작업은 계속 확인을 요청합니다.",
         "confirm": "Full access 활성화",
-        "cancel": "현재 권한 유지"
+        "cancel": "취소"
       },
       "attachmentRejection": {
         "dismiss": "닫기"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5236,9 +5236,24 @@
       "permissionSwitchFailed": "权限模式切换失败，已保留原设置",
       "fullAccessConfirmation": {
         "title": "开启 Full access？",
-        "description": "Full access 会关闭工作区沙箱并跳过常规审批。Cindy 可以修改工作区外的文件、执行联网命令且不再询问；内置高风险操作仍会要求确认。",
+        "description": "Full access 会关闭工作区沙箱并跳过常规审批，Cindy 无需询问即可：",
+        "items": {
+          "files": {
+            "title": "文件与文件夹",
+            "description": "读取和修改工作区外的文件"
+          },
+          "commands": {
+            "title": "终端命令",
+            "description": "直接执行终端命令与脚本"
+          },
+          "network": {
+            "title": "网络访问",
+            "description": "执行联网命令、访问网络资源"
+          }
+        },
+        "note": "内置高风险操作仍会要求确认。",
         "confirm": "开启 Full access",
-        "cancel": "保留当前权限"
+        "cancel": "取消"
       },
       "attachmentRejection": {
         "dismiss": "关闭"


### PR DESCRIPTION
## 这次改了什么

### 摘要

Full access 升级确认弹窗原先是一整段长说明 + 两个长按钮(「开启 Full access」/「保留当前权限」),信息密度高、可读性差,按钮文案不利于多语言。本次改为逐类可扫读的权限清单排版:文件与文件夹 / 终端命令 / 网络访问三类(图标 + 标题 + 说明),底部保留「内置高风险操作仍会要求确认」脚注;确认按钮带警示三角图标,取消按钮缩短为「取消」。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求:无(体验优化);维护者确认门 #1589
- 本 PR 包含:桌面端 Full access 确认弹窗排版与四语文案重构;共享 `ConfirmDialog` 新增可选 `confirmIcon` 属性;`ConfirmDialogProvider` 补上 `confirmVariant` 透传(存量 bug:`GhostConfirmDialogHost` 传的 danger 变体被 spread 静默丢弃,红色主按钮从未生效)。review 后追加:`describeContent` 无障碍关联(Codex P1,07d7488c)、清单标题/说明色阶 token 修正(产品门 review,d24b98b3)、ConfirmDialog 无障碍契约单测(Copilot 建议,8ce77a27)
- 明确不包含:mobile 的 `fullAccessConfirmationCopy` 影子 catalog 与 IM 卡片(feishu / telegram 等 uiText)的同名文案——它们是独立文案面,后续可单独对齐
- 用户可见变化:Full access 确认弹窗新排版、按钮文案变短;插件 danger 确认框主按钮恢复红色(见「UI 变化」单列条)
- 是否存在 breaking change:无

### UI 变化

桌面端(macOS dev 实机验证)。

- 引用的设计规范:
  - `DESIGN.md` §4 Dialog & Modal:复用共享 ConfirmDialog 结构;富内容确认弹窗宽度放宽到 440px(普通确认 400)
  - `DESIGN.md` §5 半径三档:清单容器 `rounded-xl`(12px)+ 1px `--border-default` 描边
  - `DESIGN.md` §10 双模式交付门槛:颜色全部走语义 token,Light/Dark 自动跟随,无硬编码色值。产品门 review 指出清单标题(`--confirm-desc`)与说明(`--text-tertiary`)在 Dark 下同为 `#737373`、两级层级塌成同色,已改为 `--text-primary` / `--text-secondary`(Dark `#d4d4d4` / `#a3a3a3`,Light `#262626` / `#737373`),两模式均有色阶且对 `--confirm-bg` 对比度回到正文基线以上(d24b98b3);双模式实机截图已发在 PR 评论
  - `DESIGN.md` §11.1:确认按钮保留「动词+宾语」(开启 Full access),不使用裸「确认」;警示三角继承按钮文字颜色,未新增语义色消费
  - 行结构与插件装入确认的权限清单(`GhostPermissionList`)同构,两处「授权前知情确认」读法一致
- **标题范围之外的用户可见变化(单列)**:`confirmVariant` 透传修复会使插件经管子传 `danger: true` 弹出的确认框主按钮恢复红色(provider 路径唯一调用点 `GhostConfirmDialogHost.tsx`)。这是恢复组件本就设计的行为,符合 `DESIGN.md` §2「ConfirmDialog Danger」豁免;请插件面把关人过目。
- 无障碍:`ConfirmDialog` 新增 `describeContent`,Full access 确认开启后屏幕阅读器开场朗读覆盖权限清单全文(Codex review P1,07d7488c);两条契约已锁单测(8ce77a27)

## 怎么验证的

### 自动验证

每个 commit 提交前均在本分支树上重跑,以下为最新(8ce77a27):

```text
node scripts/check-i18n.mjs
结果:✅ zh-CN / en / ja / ko key 全部一致

node scripts/check-i18n-glossary.mjs
结果:✅ 无新增术语违规

pnpm --filter desktop typecheck
结果:0 错误

pnpm test:unit
结果:56 个 workspace 全 PASS / 0 FAIL(含新增 confirmDialogA11y.test.tsx)

pnpm check:dco
结果:4 commits signed off ✅
```

### 手工验证

macOS dev(`restart:desktop:local`)实机:输入框权限档选择器切换到 Full access,确认新弹窗排版、按钮与取消/确认行为;Light / Dark 双模式截图见 PR 评论(d24b98b3 后复检)。

### 未执行的验证

- Windows 未实测:纯 renderer 样式与文案改动,无平台分支逻辑
- 屏幕阅读器未实机验证:`describeContent` 按 aria-describedby 语义实现并有单测锁定,VoiceOver 实测未做

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:桌面端 Full access 确认弹窗;共享 ConfirmDialog 新增三个可选属性(`confirmIcon` / `describeContent` / provider 侧 `confirmVariant` 透传,缺省行为不变,不影响既有调用方);插件 danger 确认框恢复红色主按钮(见 UI 变化单列条)
- 回滚 / 降级方式:revert 本 PR 的 commits 即可,无数据 / 协议 / migration 影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,本地 `pnpm check:dco` 通过)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(无需新增文档)
- [x] 已确认测试结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)