### PR TITLE
test(maker-core): 钉住 MCP fail-closed 闸绑定 resolver 而非界面

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -11,6 +11,8 @@
  *  - prompt-each-time → 照常弹窗, 但 suggestion 被剥掉(不许持久化授权)
  *  - 策略抛错 / 返回非法值 → 按最保守的 prompt-each-time 处理, 绝不 fail-open
  *  - 非 MCP 内置工具不查策略; MCP 工具名按 `mcp__<server>__<tool>` 正确拆分
+ *  - fail-closed 闸绑定的是「resolver 在不在」而非「有没有界面」: 裸 handle 下(含 auto 档)
+ *    连可信 MCP 也 deny, 而有 resolver 的无界面会话照旧静默放行
  */
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
@@ -863,6 +865,19 @@ describe('a custom server cannot take over a builtin name', () => {
   });
 });
 
+/**
+ * 这道闸绑定的是「resolver 在不在」，**不是**「有没有界面」。两者常被混为一谈，所以
+ * 正反两面都要钉住（见 issue #1577）：
+ *
+ * - 无 resolver（misconfiguration / 不经 Session 直用裸 handle）→ 连可信 MCP 也 deny。
+ *   `canReviewWithoutUi` 刻意只对内建工具成立：host 策略回答的是「值不值得打扰用户」，
+ *   不代表「没有人在场也可以跑」，而裸 handle 下没有任何人能撤销误判。Auto 档不例外。
+ * - 有 resolver 但没有界面（Telegram / 飞书 bot、scheduler 定时任务、Orca headless
+ *   worker）→ 可信 MCP 在 dispatch **之前**就短路放行。这类会话恒有 resolver：
+ *   `Session` 构造函数必定注入（`session.ts:355`，没接 listener 时该 resolver 自身
+ *   返回 deny），所以它们走的从来不是上面那条 fail-closed 分支。少了这条用例，很容易
+ *   把「headless 下 orca_worker_bridge 会被拒」当成缺陷去改，反而把裸 handle 的边界拆了。
+ */
 describe('fail-closed still precedes the MCP policy', () => {
   it('denies trusted MCP tools when no interaction resolver is attached', async () => {
     const { handle, canUseTool } = await startSession(() => 'auto-approve', { bare: true });
@@ -871,6 +886,32 @@ describe('fail-closed still precedes the MCP policy', () => {
 
     // host 策略说的是"值不值得打扰用户"，不代表"没有用户在场也能跑"。
     expect(result.behavior).toBe('deny');
+    await handle.close();
+  });
+
+  it('denies trusted MCP tools in auto mode too when no resolver is attached', async () => {
+    const { handle, canUseTool } = await startSession(() => 'auto-approve', {
+      bare: true,
+      permissionMode: 'auto',
+    });
+
+    // Auto 只让**内建**工具在无 UI 下由本地规则/轻量 reviewer 自决;mcp__* 被刻意排除。
+    const result = await canUseTool('mcp__cindy_browser__call_tool', {}, { toolUseID: 't-bare-auto' });
+
+    expect(result.behavior).toBe('deny');
+    await handle.close();
+  });
+
+  it('auto-approves trusted MCP tools in auto mode without dispatching an interaction', async () => {
+    const { handle, canUseTool, seen } = await startSession(() => 'auto-approve', {
+      permissionMode: 'auto',
+    });
+
+    const result = await canUseTool('mcp__cindy_browser__call_tool', {}, { toolUseID: 't-auto-trusted' });
+
+    // 无界面会话靠这条短路:逐次弹窗只会让远端 daemon 等审批超时、回报断链。
+    expect(result.behavior).toBe('allow');
+    expect(permissionRequests(seen)).toHaveLength(0);
     await handle.close();
   });
 });

--- a/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
@@ -874,7 +874,8 @@ describe('a custom server cannot take over a builtin name', () => {
  *   不代表「没有人在场也可以跑」，而裸 handle 下没有任何人能撤销误判。Auto 档不例外。
  * - 有 resolver 但没有界面（Telegram / 飞书 bot、scheduler 定时任务、Orca headless
  *   worker）→ 可信 MCP 在 dispatch **之前**就短路放行。这类会话恒有 resolver：
- *   `Session` 构造函数必定注入（`session.ts:355`，没接 listener 时该 resolver 自身
+ *   `Session` 构造函数里那次 `handle.setInteractionResolver(...)` 必定注入（没接
+ *   listener 时该 resolver 自身
  *   返回 deny），所以它们走的从来不是上面那条 fail-closed 分支。少了这条用例，很容易
  *   把「headless 下 orca_worker_bridge 会被拒」当成缺陷去改，反而把裸 handle 的边界拆了。
  */
@@ -911,7 +912,9 @@ describe('fail-closed still precedes the MCP policy', () => {
 
     // 无界面会话靠这条短路:逐次弹窗只会让远端 daemon 等审批超时、回报断链。
     expect(result.behavior).toBe('allow');
-    expect(permissionRequests(seen)).toHaveLength(0);
+    // 断言 seen 整体为空,而不只是 permission 类:用例声称的是「完全不 dispatch」,
+    // 只查 permission 会让将来改成发 plan_review / ask_user_question 的实现误通过。
+    expect(seen).toHaveLength(0);
     await handle.close();
   });
 });

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -94,6 +94,33 @@ function makeSession(handle: AgentSessionHandle): Session {
 const SCHED_ORIGIN: SendOrigin = { kind: 'scheduler', scheduleId: 's1', scheduleName: 'PR 跟进' };
 
 describe('Session interaction fallback', () => {
+  /**
+   * `Session` 构造函数**必定**注入 interaction resolver(session.ts:355)。这是 harness
+   * 侧 fail-closed 分支的前提:`canUseTool` 里 `interactionResolver === null` 只可能是
+   * misconfiguration / 裸 handle 直用,**不是**「这个会话没有界面」。
+   *
+   * Telegram / 飞书 bot、scheduler 定时任务、Orca headless worker 都经 Session 创建,
+   * 所以都**有** resolver;它们缺的是 interactionListener,安全默认由这一层给出 deny。
+   * 两件事分清楚,才不会把 harness 的裸 handle 边界误当成 headless 缺陷去改
+   * (见 issue #1577)。
+   */
+  it('injects a resolver at construction and denies listenerless permission requests', async () => {
+    const { handle, resolveInteraction } = createControllableHandle();
+    makeSession(handle);
+
+    // 这里没抛 'missing interaction resolver' 本身就是断言:构造时已经注入。
+    await expect(resolveInteraction({
+      kind: 'permission',
+      requestId: 'perm-1',
+      toolName: 'mcp__cindy_memory__call_tool',
+      input: {},
+    })).resolves.toEqual({
+      kind: 'permission',
+      behavior: 'deny',
+      reason: 'no_listener_attached',
+    });
+  });
+
   it('marks listenerless plan review denial as dismissed', async () => {
     const { handle, resolveInteraction } = createControllableHandle();
     makeSession(handle);

--- a/packages/maker-core/src/session.origin.test.ts
+++ b/packages/maker-core/src/session.origin.test.ts
@@ -95,7 +95,8 @@ const SCHED_ORIGIN: SendOrigin = { kind: 'scheduler', scheduleId: 's1', schedule
 
 describe('Session interaction fallback', () => {
   /**
-   * `Session` 构造函数**必定**注入 interaction resolver(session.ts:355)。这是 harness
+   * `Session` 构造函数**必定**注入 interaction resolver(构造函数里那次
+   * `this.handle.setInteractionResolver(...)`)。这是 harness
    * 侧 fail-closed 分支的前提:`canUseTool` 里 `interactionResolver === null` 只可能是
    * misconfiguration / 裸 handle 直用,**不是**「这个会话没有界面」。
    *


### PR DESCRIPTION
## 这次改了什么

### 摘要

issue #1577 报「无交互界面场景（Telegram / 飞书 bot、scheduler、Orca headless worker）下 Auto 档的
MCP 工具无条件 fail-closed deny，连策略表都不查」，并提议把 `canReviewWithoutUi` 放宽到
`auto-approve` 的 MCP。核实后**归因不成立**，所以本 PR 不改行为，改为把被混淆的那条边界钉成测试。

核实过程：

1. 那段 early return（`claude-code/index.ts:1600`）的前提是 `interactionResolver === null`，而
   **`Session` 构造函数必定注入 resolver**（`session.ts:355`；没接 listener 时该 resolver 自身
   返回 `deny: no_listener_attached`）。上述三类会话都经 `Session` 创建，因此都**有** resolver，
   走的从来不是这条分支 —— 它们缺的是 `interactionListener`，落到
   `hook-control/session-runner.ts:756` 的 `headless_interaction_unavailable`。
2. 更关键的是，`auto-approve` 的 MCP 在 `claude-code/index.ts:1650` 就 `return allow` 了，
   **不经 `dispatchInteraction`**。所以 `orca_worker_bridge` / `cindy_memory` / `cindy_browser`
   这批可信 server 在无界面会话里本来就是静默放行的，issue 说的「有 UI 时静默放行、无 UI 时反而
   被拒，语义正好反了」并不存在。本 PR 新增的第三条用例就是这个事实的实证。
3. 真正被拒的只有策略表判 `prompt` / `prompt-each-time` 的那批（第三方 server、`cindy_ssh`、
   `ghost_call`），而 issue 自己也认为「无人可问，拒绝是对的」。

那段 early return 的现有注释已经写明了设计意图 —— 「host 策略描述的是『这个工具值不值得打扰
用户』，不代表『没有用户在场也可以跑』；裸 handle 场景下没有任何人能撤销误判，可信 MCP 同样落到
deny」。按 issue 放宽它，等于在 misconfiguration / 裸 handle 直用的场景下把可信 MCP 放开，而那正是
这道闸存在的理由。所以选择锁定它，而不是改它。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1577（结论是证伪 + 补不变量测试，不是按 issue 的建议改法实现）
- 本 PR 包含：三条边界用例 —— ① Auto 档 + 裸 handle 下可信 MCP 仍 deny；② Auto 档 + 有 resolver
  时可信 MCP 静默放行且不 dispatch；③ `Session` 构造即注入 resolver、无 listener 时 permission
  安全默认为 deny。外加一处文件头注释的覆盖清单更新
- 明确不包含：任何运行期行为改动；`canReviewWithoutUi` 的判定调整；无界面场景下第三方 server /
  `cindy_ssh` / `ghost_call` 的处理（那需要 #1576 的 MCP 灰区送审才能真正解决，本 PR 不碰）
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/claude-code/__tests__/mcp-approval-policy.test.ts
结果：32 tests 全部通过（新增 2）

pnpm --filter @cindy/maker-core exec vitest run src/session.origin.test.ts
结果：22 tests 全部通过（新增 1）

pnpm --filter @cindy/maker-core run typecheck
结果：通过

pnpm test:unit
结果：全部 workspace PASS（含 cindy-protocol 子包）
```

**Mutation 验证**（两个方向各来一次）：

1. 按 issue 的建议把 `canReviewWithoutUi` 放宽到 `auto-approve` 的 MCP：

```text
× fail-closed still precedes the MCP policy > denies trusted MCP tools in auto mode too when no resolver is attached
  → expected 'allow' to be 'deny'
同文件其余 31 条全部保持绿色。
```

2. 移除 `Session` 构造函数里的 `setInteractionResolver` 注入：

```text
× Session interaction fallback > injects a resolver at construction and denies listenerless permission requests
  → missing interaction resolver
× Session interaction fallback > marks listenerless plan review denial as dismissed
  → missing interaction resolver
```

两次验证后源文件均已还原（diff 里只有测试文件）。

### 手工验证

不涉及（纯测试改动，无运行期行为变化）。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `packages/maker-core` 的两个测试文件，无运行期代码改动。
- 回滚 / 降级方式：revert 本 PR 即可，不影响任何运行期行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（边界的理由写在 describe 注释里，与相邻块同款）
- [x] 已确认测试结果或说明未执行原因
