### PR TITLE
fix(desktop): 让原生分类器故障观察器的漏检在日志里可见

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -296,6 +296,119 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
     ]);
   });
 
+  /**
+   * 漏检可观测性(issue #1579):这条链路是 Auto 档唯一的自救通道,它的两个前置条件
+   * (会话请求头、id 反解)任一不满足就整条静默失效。以前两处 early return 什么都不记,
+   * 排障时日志里没有任何线索指向这里。
+   */
+  describe('missed-detection visibility', () => {
+    function createObserver(resolve: (sdkSessionId: string) => string | null, t: () => number) {
+      const logger = { debug: vi.fn(), warn: vi.fn() };
+      return { logger, observer: createClaudeAutoClassifierFailureObserver(resolve, { now: t, logger }) };
+    }
+
+    /** 取某条 warn 携带的计数快照。 */
+    function warnCounters(logger: { warn: ReturnType<typeof vi.fn> }, callIndex = 0) {
+      return (logger.warn.mock.calls[callIndex]?.[1] as { counters?: Record<string, number> })?.counters;
+    }
+
+    it('warns when an error response carries no session header', () => {
+      const listener = vi.fn();
+      setClaudeAutoClassifierUnavailableListener(listener);
+      const { logger, observer } = createObserver(() => 'session-1', () => 0);
+
+      expect(observer(ctx({ status: 429, requestHeaders: {} }))).toBeUndefined();
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn.mock.calls[0][0]).toContain('without session header');
+      expect(warnCounters(logger)).toMatchObject({
+        errorsMissingSessionHeader: 1,
+        classifierFailures: 0,
+      });
+    });
+
+    it('warns when the sdk session id cannot be resolved', () => {
+      const { logger, observer } = createObserver(() => null, () => 0);
+
+      expect(observer(ctx({ status: 500 }))).toBeUndefined();
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn.mock.calls[0][0]).toContain('unresolvable sdk session id');
+      expect(warnCounters(logger)).toMatchObject({ errorsUnresolvedSession: 1 });
+    });
+
+    it('counts non-classifier error responses without warning about them', () => {
+      // 普通 turn 的错误响应也流经这里,是正常大头 —— 只计数,不刷 warn。
+      const { logger, observer } = createObserver(() => 'session-1', () => 0);
+
+      observer(ctx({ status: 429, requestBody: requestBody({ system: 'ordinary assistant' }) }));
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      // 让它随下一条真漏检的 warn 一起显形,充当识别率的分母。
+      observer(ctx({ status: 429, requestHeaders: {} }));
+      expect(warnCounters(logger)).toMatchObject({
+        errorsNotClassifier: 1,
+        errorsMissingSessionHeader: 1,
+      });
+    });
+
+    it('throttles the same reason but keeps different reasons independent', () => {
+      let t = 0;
+      const { logger, observer } = createObserver(
+        (sdkId) => (sdkId === 'sdk-known' ? 'session-1' : null),
+        () => t,
+      );
+
+      // 同一原因连发:60s 窗口内只出一条。
+      for (let i = 0; i < 5; i += 1) {
+        t += 1_000;
+        observer(ctx({ status: 429, requestHeaders: {} }));
+      }
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+
+      // 另一个原因不被前者的限流窗口饿死。
+      observer(ctx({ status: 429, requestHeaders: { 'x-claude-code-session-id': 'sdk-unknown' } }));
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+
+      // 越过窗口后同一原因重新可见 —— 持续故障不能只报一次就消失。
+      t += 60_000; // OBSERVER_WARN_THROTTLE_MS(与 TRANSIENT_* 同款:常量不导出,测试写字面量)
+      observer(ctx({ status: 429, requestHeaders: {} }));
+      expect(logger.warn).toHaveBeenCalledTimes(3);
+      expect(warnCounters(logger, 2)).toMatchObject({ errorsMissingSessionHeader: 6 });
+    });
+
+    it('warns when a success response cannot clear an existing transient tally', () => {
+      let t = 0;
+      const { logger, observer } = createObserver(() => 'session-1', () => t);
+
+      observer(ctx({ status: 429 })); // 建立一条记账
+      t += 1_000;
+      // 恢复响应缺 header → 找不到要清哪一条账。
+      expect(observer(ctx({ status: 200, requestHeaders: {} }))).toBeUndefined();
+
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn.mock.calls[0][0]).toContain('recovery reset skipped');
+      expect(warnCounters(logger)).toMatchObject({ recoveryMissingSessionHeader: 1 });
+    });
+
+    it('logs the escalation with the full tally and stays silent without a logger', () => {
+      const signals: unknown[] = [];
+      setClaudeAutoClassifierUnavailableListener((signal) => signals.push(signal));
+      const { logger, observer } = createObserver(() => 'session-1', () => 0);
+
+      observer(ctx({ status: 400 })); // 确定性 4xx → 立即升级
+      expect(signals).toHaveLength(1);
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+      expect((logger.debug.mock.calls[0][1] as { counters?: Record<string, number> }).counters)
+        .toMatchObject({ classifierFailures: 1 });
+
+      // 不注入 logger 时整段退化为纯计数,不得抛。
+      const silent = createClaudeAutoClassifierFailureObserver(() => null);
+      expect(() => silent(ctx({ status: 429, requestHeaders: {} }))).not.toThrow();
+    });
+  });
+
   it('does not parse/report success, redirects, non-classifier bodies, or unresolved sessions', () => {
     const listener = vi.fn();
     setClaudeAutoClassifierUnavailableListener(listener);

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -359,32 +359,43 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
      * (它们在身份判据之后)、也没有升级 debug(永远识别不出来),整条链路重新全静默。
      * 所以这个计数要有自己的周期性快照(codex P2)。
      */
-    it('periodically snapshots the unmatched-identity tally on its own', () => {
+    it('warns at a production-visible level once identity never matches', () => {
       let t = 0;
       const { logger, observer } = createObserver(() => 'session-1', () => t);
       const notClassifier = requestBody({ system: 'ordinary assistant' });
 
-      observer(ctx({ status: 429, requestBody: notClassifier }));
-      // 不刷 warn —— 正常运行时这是大头。
+      // 样本不足 → 不报(普通 turn 的稀疏错误不该触发告警)。
+      for (let i = 0; i < 49; i += 1) observer(ctx({ status: 429, requestBody: notClassifier }));
       expect(logger.warn).not.toHaveBeenCalled();
-      // 但必须自己落一条 debug 快照,不能只等后续 warn 捎带。
-      expect(logger.debug).toHaveBeenCalledTimes(1);
-      expect(logger.debug.mock.calls[0][0]).toContain('identity did not match');
 
-      // 同一窗口内限流,不刷屏。
-      for (let i = 0; i < 5; i += 1) {
-        t += 1_000;
-        observer(ctx({ status: 429, requestBody: notClassifier }));
-      }
-      expect(logger.debug).toHaveBeenCalledTimes(1);
+      // 攒到阈值且一条都没识别出来 → 报,且必须是 warn:打包版默认 level=info,
+      // debug 会被 logger 的 shouldLog 直接丢掉,在生产环境等于没落盘。
+      observer(ctx({ status: 429, requestBody: notClassifier }));
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn.mock.calls[0][0]).toContain('has matched the classifier identity');
+      expect(warnCounters(logger)).toMatchObject({
+        classifierFailures: 0,
+        errorsNotClassifier: 50,
+      });
 
-      // 越窗后重新可见,且快照里 classifierFailures 恒为 0 —— 识别率归零的信号。
+      // 同窗口限流,越窗后重新可见。
+      observer(ctx({ status: 429, requestBody: notClassifier }));
+      expect(logger.warn).toHaveBeenCalledTimes(1);
       t += 60_000;
       observer(ctx({ status: 429, requestBody: notClassifier }));
-      expect(logger.debug).toHaveBeenCalledTimes(2);
-      const snapshot = (logger.debug.mock.calls[1]?.[1] as { counters?: Record<string, number> })
-        ?.counters;
-      expect(snapshot).toMatchObject({ classifierFailures: 0, errorsNotClassifier: 7 });
+      expect(logger.warn).toHaveBeenCalledTimes(2);
+    });
+
+    it('stays silent once the classifier has been recognised at least once', () => {
+      const { logger, observer } = createObserver(() => 'session-1', () => 0);
+
+      observer(ctx({ status: 429 })); // 识别成功一次 → classifierFailures = 1
+      for (let i = 0; i < 60; i += 1) {
+        observer(ctx({ status: 429, requestBody: requestBody({ system: 'ordinary assistant' }) }));
+      }
+
+      // 识别链路是好的,只是这些响应不是分类器的 —— 不该报。
+      expect(logger.warn).not.toHaveBeenCalled();
     });
 
     /**

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -353,6 +353,63 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
       });
     });
 
+    /**
+     * observer 挂在**共享**的 anthropic-compat-proxy 上(见 anthropic-compat-proxy-host
+     * 的 composeResponseObservers):普通 turn、PI 以及其它复用该 proxy 的 runtime 的响应
+     * 全都流经这里。身份判据必须最先过,否则这些无关响应会把漏检计数顶满,而那两个计数
+     * 存在的唯一目的就是回答「分类器在报错但我们没识别出来吗」。
+     */
+    describe('does not let unrelated runtimes pollute the tallies', () => {
+      /** PI 等其它 runtime 的请求:既不是分类器身份,也不带 cc 会话头。 */
+      const foreignBody = Buffer.from(JSON.stringify({
+        model: 'gpt-5.5',
+        max_tokens: 64_000,
+        messages: [],
+      }));
+
+      it('ignores a headerless error response that is not a classifier request', () => {
+        const { logger, observer } = createObserver(() => 'session-1', () => 0);
+
+        observer(ctx({ status: 429, requestHeaders: {}, requestBody: foreignBody }));
+        observer(ctx({ status: 500, requestHeaders: {}, requestBody: foreignBody }));
+
+        // 只算分母,不算漏检、不刷 warn。
+        expect(logger.warn).not.toHaveBeenCalled();
+        // 用一条真漏检把计数带出来核对。
+        observer(ctx({ status: 429, requestHeaders: {} }));
+        expect(warnCounters(logger)).toMatchObject({
+          errorsNotClassifier: 2,
+          errorsMissingSessionHeader: 1,
+          errorsUnresolvedSession: 0,
+        });
+      });
+
+      it('ignores an error response whose session id is unresolvable but is not a classifier request', () => {
+        const { logger, observer } = createObserver(() => null, () => 0);
+
+        observer(ctx({ status: 429, requestBody: foreignBody }));
+
+        expect(logger.warn).not.toHaveBeenCalled();
+      });
+
+      it('ignores headerless success responses from other runtimes while a Claude tally exists', () => {
+        let t = 0;
+        const { logger, observer } = createObserver(() => 'session-1', () => t);
+
+        observer(ctx({ status: 429 })); // 某个 Claude 会话留下记账 → observer 级 size 非零
+        t += 1_000;
+
+        // 混合运行时:PI 的 SSE 成功响应不带 cc 会话头,不得记成「恢复漏检」。
+        observer(ctx({ status: 200, requestHeaders: {}, requestBody: foreignBody }));
+        expect(logger.warn).not.toHaveBeenCalled();
+
+        // 真正的分类器 2xx 缺头才算。
+        observer(ctx({ status: 200, requestHeaders: {} }));
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(warnCounters(logger)).toMatchObject({ recoveryMissingSessionHeader: 1 });
+      });
+    });
+
     it('throttles the same reason but keeps different reasons independent', () => {
       let t = 0;
       const { logger, observer } = createObserver(

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -376,6 +376,10 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
       // info 级:打包版默认 level=info,debug 会被 logger 的 shouldLog 丢掉。
       expect(logger.info).toHaveBeenCalledTimes(1);
       expect(logger.info.mock.calls[0][0]).toContain('observation snapshot');
+      // **首条快照必须带上触发它的样本** —— 放在分类之前的话这里会是全零,而后续样本
+      // 又都被限流吞掉,短时故障等于什么都没留下(codex P2)。
+      expect((logger.info.mock.calls[0][1] as { counters?: Record<string, number> })?.counters)
+        .toMatchObject({ errorsNotClassifier: 1 });
 
       // 30 分钟窗口内限流,不刷屏。
       for (let i = 0; i < 20; i += 1) {
@@ -389,9 +393,8 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
       t += 30 * 60_000;
       observer(ctx({ status: 429, requestBody: notClassifier }));
       expect(logger.info).toHaveBeenCalledTimes(2);
-      // 快照在身份判据之前落 → 本次的 errorsNotClassifier 还没 +1。
       expect((logger.info.mock.calls[1]?.[1] as { counters?: Record<string, number> })?.counters)
-        .toMatchObject({ classifierFailures: 0, errorsNotClassifier: 21 });
+        .toMatchObject({ classifierFailures: 0, errorsNotClassifier: 22 });
       // 全程不刷 warn —— 它只留给真正的归属漏检。
       expect(logger.warn).not.toHaveBeenCalled();
     });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -359,7 +359,7 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
      * (它们在身份判据之后)、也没有升级 debug(永远识别不出来),整条链路重新全静默。
      * 所以这个计数要有自己的周期性快照(codex P2)。
      */
-    it('warns at a production-visible level once identity never matches', () => {
+    it('warns at a production-visible level after a long unmatched streak', () => {
       let t = 0;
       const { logger, observer } = createObserver(() => 'session-1', () => t);
       const notClassifier = requestBody({ system: 'ordinary assistant' });
@@ -372,7 +372,7 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
       // debug 会被 logger 的 shouldLog 直接丢掉,在生产环境等于没落盘。
       observer(ctx({ status: 429, requestBody: notClassifier }));
       expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn.mock.calls[0][0]).toContain('has matched the classifier identity');
+      expect(logger.warn.mock.calls[0][0]).toContain('has not matched for a long streak');
       expect(warnCounters(logger)).toMatchObject({
         classifierFailures: 0,
         errorsNotClassifier: 50,
@@ -386,16 +386,32 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
       expect(logger.warn).toHaveBeenCalledTimes(2);
     });
 
-    it('stays silent once the classifier has been recognised at least once', () => {
+    it('resets the streak on every successful match instead of silencing forever', () => {
       const { logger, observer } = createObserver(() => 'session-1', () => 0);
+      const notClassifier = requestBody({ system: 'ordinary assistant' });
 
-      observer(ctx({ status: 429 })); // 识别成功一次 → classifierFailures = 1
-      for (let i = 0; i < 60; i += 1) {
-        observer(ctx({ status: 429, requestBody: requestBody({ system: 'ordinary assistant' }) }));
-      }
-
-      // 识别链路是好的,只是这些响应不是分类器的 —— 不该报。
+      // 攒到 49 条,然后成功识别一次 → 连续计数归零。
+      for (let i = 0; i < 49; i += 1) observer(ctx({ status: 429, requestBody: notClassifier }));
+      observer(ctx({ status: 429 }));
+      // 归零后再来 49 条仍不到阈值 —— 证明计数真的重置了,不是累计总数。
+      for (let i = 0; i < 49; i += 1) observer(ctx({ status: 429, requestBody: notClassifier }));
       expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('still detects drift of one classifier shape after another shape matched', () => {
+      // 分类器有 fast / 2-stage / thinking 三种形态。判据若是「进程内从未命中」,任意
+      // 一种命中过就永久关闭告警,另一种形态漂移永远发现不了(codex P1)。
+      const { logger, observer } = createObserver(() => 'session-1', () => 0);
+      const drifted = requestBody({ system: 'You are a NEW security monitor prefix.' });
+
+      observer(ctx({ status: 429 })); // 某一形态仍能命中
+      expect(logger.warn).not.toHaveBeenCalled();
+
+      // 另一形态持续漂移 → 必须报出来。
+      for (let i = 0; i < 50; i += 1) observer(ctx({ status: 429, requestBody: drifted }));
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+      expect(logger.warn.mock.calls[0][0]).toContain('has not matched for a long streak');
+      expect(logger.warn.mock.calls[0][1]).toMatchObject({ missesSinceLastMatch: 50 });
     });
 
     /**

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -303,7 +303,7 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
    */
   describe('missed-detection visibility', () => {
     function createObserver(resolve: (sdkSessionId: string) => string | null, t: () => number) {
-      const logger = { debug: vi.fn(), warn: vi.fn() };
+      const logger = { info: vi.fn(), warn: vi.fn() };
       return { logger, observer: createClaudeAutoClassifierFailureObserver(resolve, { now: t, logger }) };
     }
 
@@ -359,91 +359,41 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
      * (它们在身份判据之后)、也没有升级 debug(永远识别不出来),整条链路重新全静默。
      * 所以这个计数要有自己的周期性快照(codex P2)。
      */
-    it('warns at a production-visible level after a long unmatched streak', () => {
+    /**
+     * 三条漏检 warn 都可能不触发(比如分类器前缀变了 → 全部落 errorsNotClassifier),
+     * 那时只有这条周期快照能保证「分类器在报错但我们没识别出来」在日志里留下痕迹。
+     *
+     * **刻意不做自动判定** —— 判定需要「本该被识别的请求数」作分母,而漏检时这个分母
+     * 拿不到:连续计数会被任意形态的命中清零、比例判据对部分形态漂移不敏感、全局计数又会
+     * 被共享 proxy 上无关 runtime 的错误推进。改为只落原始计数,判断交给看日志的人。
+     */
+    it('periodically snapshots the raw tallies at a production-visible level', () => {
       let t = 0;
       const { logger, observer } = createObserver(() => 'session-1', () => t);
       const notClassifier = requestBody({ system: 'ordinary assistant' });
 
-      // 样本不足 → 不报(普通 turn 的稀疏错误不该触发告警)。
-      for (let i = 0; i < 49; i += 1) observer(ctx({ status: 429, requestBody: notClassifier }));
-      expect(logger.warn).not.toHaveBeenCalled();
-
-      // 攒到阈值且一条都没识别出来 → 报,且必须是 warn:打包版默认 level=info,
-      // debug 会被 logger 的 shouldLog 直接丢掉,在生产环境等于没落盘。
       observer(ctx({ status: 429, requestBody: notClassifier }));
-      expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn.mock.calls[0][0]).toContain('has not matched for a long streak');
-      expect(warnCounters(logger)).toMatchObject({
-        classifierFailures: 0,
-        errorsNotClassifier: 50,
-      });
+      // info 级:打包版默认 level=info,debug 会被 logger 的 shouldLog 丢掉。
+      expect(logger.info).toHaveBeenCalledTimes(1);
+      expect(logger.info.mock.calls[0][0]).toContain('observation snapshot');
 
-      // 同窗口限流,越窗后重新可见。
-      observer(ctx({ status: 429, requestBody: notClassifier }));
-      expect(logger.warn).toHaveBeenCalledTimes(1);
-      t += 60_000;
-      observer(ctx({ status: 429, requestBody: notClassifier }));
-      expect(logger.warn).toHaveBeenCalledTimes(2);
-    });
-
-    it('only lets Claude-attributable responses advance the drift streak', () => {
-      // observer 挂在共享 proxy 上。PI 只带 x-cindy-pi-session-id,拿它的故障推进 Claude
-      // 分类器的漂移判据 = 一次上游抖动就误报(codex P2)。
-      const { logger, observer } = createObserver(() => 'session-1', () => 0);
-      const foreign = Buffer.from(JSON.stringify({ model: 'gpt-5.5', max_tokens: 64_000 }));
-
-      for (let i = 0; i < 80; i += 1) {
-        observer(ctx({
-          status: 500,
-          requestHeaders: { 'x-cindy-pi-session-id': 'pi-1' },
-          requestBody: foreign,
-        }));
-      }
-      expect(logger.warn).not.toHaveBeenCalled();
-    });
-
-    it('restarts the streak after a long quiet gap', () => {
-      // 计数没有时效的话,进程跑得够久、稀疏的普通 turn 错误最终也会攒满阈值。
-      let t = 0;
-      const { logger, observer } = createObserver(() => 'session-1', () => t);
-      const notClassifier = requestBody({ system: 'ordinary assistant' });
-
-      for (let i = 0; i < 49; i += 1) {
-        t += 1_000;
+      // 30 分钟窗口内限流,不刷屏。
+      for (let i = 0; i < 20; i += 1) {
+        t += 60_000;
         observer(ctx({ status: 429, requestBody: notClassifier }));
       }
-      // 静默超过 streak 窗口 → 重新起算,不该被历史累计推过阈值。
-      t += 30 * 60_000 + 1;
+      expect(logger.info).toHaveBeenCalledTimes(1);
+
+      // 越窗后再落一条,快照里 classifierFailures 恒为 0 而 errorsNotClassifier 在涨 ——
+      // 这就是排障时判断「身份判据变了」的依据,不需要代码替他判定。
+      t += 30 * 60_000;
       observer(ctx({ status: 429, requestBody: notClassifier }));
+      expect(logger.info).toHaveBeenCalledTimes(2);
+      // 快照在身份判据之前落 → 本次的 errorsNotClassifier 还没 +1。
+      expect((logger.info.mock.calls[1]?.[1] as { counters?: Record<string, number> })?.counters)
+        .toMatchObject({ classifierFailures: 0, errorsNotClassifier: 21 });
+      // 全程不刷 warn —— 它只留给真正的归属漏检。
       expect(logger.warn).not.toHaveBeenCalled();
-    });
-
-    it('resets the streak on every successful match instead of silencing forever', () => {
-      const { logger, observer } = createObserver(() => 'session-1', () => 0);
-      const notClassifier = requestBody({ system: 'ordinary assistant' });
-
-      // 攒到 49 条,然后成功识别一次 → 连续计数归零。
-      for (let i = 0; i < 49; i += 1) observer(ctx({ status: 429, requestBody: notClassifier }));
-      observer(ctx({ status: 429 }));
-      // 归零后再来 49 条仍不到阈值 —— 证明计数真的重置了,不是累计总数。
-      for (let i = 0; i < 49; i += 1) observer(ctx({ status: 429, requestBody: notClassifier }));
-      expect(logger.warn).not.toHaveBeenCalled();
-    });
-
-    it('still detects drift of one classifier shape after another shape matched', () => {
-      // 分类器有 fast / 2-stage / thinking 三种形态。判据若是「进程内从未命中」,任意
-      // 一种命中过就永久关闭告警,另一种形态漂移永远发现不了(codex P1)。
-      const { logger, observer } = createObserver(() => 'session-1', () => 0);
-      const drifted = requestBody({ system: 'You are a NEW security monitor prefix.' });
-
-      observer(ctx({ status: 429 })); // 某一形态仍能命中
-      expect(logger.warn).not.toHaveBeenCalled();
-
-      // 另一形态持续漂移 → 必须报出来。
-      for (let i = 0; i < 50; i += 1) observer(ctx({ status: 429, requestBody: drifted }));
-      expect(logger.warn).toHaveBeenCalledTimes(1);
-      expect(logger.warn.mock.calls[0][0]).toContain('has not matched for a long streak');
-      expect(logger.warn.mock.calls[0][1]).toMatchObject({ missesSinceLastMatch: 50 });
     });
 
     /**
@@ -549,8 +499,12 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
 
       observer(ctx({ status: 400 })); // 确定性 4xx → 立即升级
       expect(signals).toHaveLength(1);
-      expect(logger.debug).toHaveBeenCalledTimes(1);
-      expect((logger.debug.mock.calls[0][1] as { counters?: Record<string, number> }).counters)
+      // info 上现在有两类:入口的周期快照 + 这条升级记录。按消息挑出升级那条。
+      const escalation = logger.info.mock.calls.find(
+        ([message]) => String(message).includes('escalated'),
+      );
+      expect(escalation).toBeDefined();
+      expect((escalation?.[1] as { counters?: Record<string, number> })?.counters)
         .toMatchObject({ classifierFailures: 1 });
 
       // 不注入 logger 时整段退化为纯计数,不得抛。

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -354,6 +354,40 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
     });
 
     /**
+     * 「识别规则本身失效」必须能独立发现:CC 若改了分类器的 system 前缀或 max_tokens
+     * 上界,所有真实分类器请求都会掉进 errorsNotClassifier —— 那时既没有漏检 warn
+     * (它们在身份判据之后)、也没有升级 debug(永远识别不出来),整条链路重新全静默。
+     * 所以这个计数要有自己的周期性快照(codex P2)。
+     */
+    it('periodically snapshots the unmatched-identity tally on its own', () => {
+      let t = 0;
+      const { logger, observer } = createObserver(() => 'session-1', () => t);
+      const notClassifier = requestBody({ system: 'ordinary assistant' });
+
+      observer(ctx({ status: 429, requestBody: notClassifier }));
+      // 不刷 warn —— 正常运行时这是大头。
+      expect(logger.warn).not.toHaveBeenCalled();
+      // 但必须自己落一条 debug 快照,不能只等后续 warn 捎带。
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+      expect(logger.debug.mock.calls[0][0]).toContain('identity did not match');
+
+      // 同一窗口内限流,不刷屏。
+      for (let i = 0; i < 5; i += 1) {
+        t += 1_000;
+        observer(ctx({ status: 429, requestBody: notClassifier }));
+      }
+      expect(logger.debug).toHaveBeenCalledTimes(1);
+
+      // 越窗后重新可见,且快照里 classifierFailures 恒为 0 —— 识别率归零的信号。
+      t += 60_000;
+      observer(ctx({ status: 429, requestBody: notClassifier }));
+      expect(logger.debug).toHaveBeenCalledTimes(2);
+      const snapshot = (logger.debug.mock.calls[1]?.[1] as { counters?: Record<string, number> })
+        ?.counters;
+      expect(snapshot).toMatchObject({ classifierFailures: 0, errorsNotClassifier: 7 });
+    });
+
+    /**
      * observer 挂在**共享**的 anthropic-compat-proxy 上(见 anthropic-compat-proxy-host
      * 的 composeResponseObservers):普通 turn、PI 以及其它复用该 proxy 的 runtime 的响应
      * 全都流经这里。身份判据必须最先过,否则这些无关响应会把漏检计数顶满,而那两个计数

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
@@ -386,6 +386,38 @@ describe('createClaudeAutoClassifierFailureObserver', () => {
       expect(logger.warn).toHaveBeenCalledTimes(2);
     });
 
+    it('only lets Claude-attributable responses advance the drift streak', () => {
+      // observer 挂在共享 proxy 上。PI 只带 x-cindy-pi-session-id,拿它的故障推进 Claude
+      // 分类器的漂移判据 = 一次上游抖动就误报(codex P2)。
+      const { logger, observer } = createObserver(() => 'session-1', () => 0);
+      const foreign = Buffer.from(JSON.stringify({ model: 'gpt-5.5', max_tokens: 64_000 }));
+
+      for (let i = 0; i < 80; i += 1) {
+        observer(ctx({
+          status: 500,
+          requestHeaders: { 'x-cindy-pi-session-id': 'pi-1' },
+          requestBody: foreign,
+        }));
+      }
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('restarts the streak after a long quiet gap', () => {
+      // 计数没有时效的话,进程跑得够久、稀疏的普通 turn 错误最终也会攒满阈值。
+      let t = 0;
+      const { logger, observer } = createObserver(() => 'session-1', () => t);
+      const notClassifier = requestBody({ system: 'ordinary assistant' });
+
+      for (let i = 0; i < 49; i += 1) {
+        t += 1_000;
+        observer(ctx({ status: 429, requestBody: notClassifier }));
+      }
+      // 静默超过 streak 窗口 → 重新起算,不该被历史累计推过阈值。
+      t += 30 * 60_000 + 1;
+      observer(ctx({ status: 429, requestBody: notClassifier }));
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
     it('resets the streak on every successful match instead of silencing forever', () => {
       const { logger, observer } = createObserver(() => 'session-1', () => 0);
       const notClassifier = requestBody({ system: 'ordinary assistant' });

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -367,7 +367,8 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       //   - Auto 权限分类器错误检测:确定性 4xx 立即通知 coordinator 降级到 ask;
       //     瞬时 408/429/5xx 按 episode 阈值记账、持续故障才降级(见
       //     claude-auto-permission-fallback.ts);只在错误路径与「该会话有瞬时记账」的
-      //     成功路径解析 request body;不 tee/改写响应;
+      //     成功路径解析 request body;不 tee/改写响应;缺会话头 / id 反解失败这两类
+      //     漏检走限流 warn + 识别记账落到同一份 log(否则自救通道静默失效无线索);
       //   - 自定义供应商上游错误分类广播(status≥400 且会话路由到 user 供应商时才 tee,
       //     成功路径零开销;30s 节流,见 provider-upstream-error-observer)。
       responseObserver: composeResponseObservers(
@@ -379,8 +380,9 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
         createClaudeSessionActivityResponseObserver((sdkSessionId) =>
           _resolveCcSessionId ? _resolveCcSessionId(sdkSessionId) : null,
         ),
-        createClaudeAutoClassifierFailureObserver((sdkSessionId) =>
-          _resolveCcSessionId ? _resolveCcSessionId(sdkSessionId) : null,
+        createClaudeAutoClassifierFailureObserver(
+          (sdkSessionId) => (_resolveCcSessionId ? _resolveCcSessionId(sdkSessionId) : null),
+          { logger: log },
         ),
         createProviderUpstreamErrorObserver({
           agent: 'claude-code',

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -247,6 +247,17 @@ export function createClaudeAutoClassifierFailureObserver(
     logThrottled('warn', reason, fields);
   const infoThrottled = (reason: string, fields: Record<string, unknown>, intervalMs: number): void =>
     logThrottled('info', reason, fields, intervalMs);
+  /**
+   * 周期性把原始计数落盘。**必须在本次响应的计数已经递增之后调用** —— 放在分类之前的话,
+   * 首条快照恒为全零,而后续样本又都被限流吞掉,短时故障等于没留下有效计数(codex P2)。
+   */
+  const snapshotTallies = (status: number): void => {
+    infoThrottled(
+      'classifier observation snapshot',
+      { status },
+      OBSERVER_SNAPSHOT_INTERVAL_MS,
+    );
+  };
 
   return (ctx: ResponseObserverCtx) => {
     if (ctx.status < 400) {
@@ -287,22 +298,16 @@ export function createClaudeAutoClassifierFailureObserver(
       }
       return undefined;
     }
-    // 周期性把原始计数落盘(见 OBSERVER_SNAPSHOT_INTERVAL_MS):漏检时三条 warn 都可能
-    // 不触发,只有这条能保证「分类器在报错但我们没识别出来」在日志里留下痕迹。
-    infoThrottled(
-      'classifier observation snapshot',
-      { status: ctx.status },
-      OBSERVER_SNAPSHOT_INTERVAL_MS,
-    );
     // 身份判据必须**最先**过:observer 挂在共享的 anthropic-compat-proxy 上,普通 turn、
     // PI 以及其它复用该 proxy 的 runtime 的 4xx/5xx 全都流经这里。若先按「缺会话头 /
     // 反解失败」记漏检,这些无关错误会把 errorsMissingSessionHeader / errorsUnresolvedSession
     // 顶满,识别率信号彻底失效 —— 而这两个计数存在的唯一目的就是回答「分类器在报错但我们
     // 没识别出来吗」。代价是错误响应一律 parse 一次 body(原注释已认定该成本可忽略)。
     if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
-      // 正常大头:非分类器的错误响应。只计数当分母 —— 判定交给上面 OBSERVER_SNAPSHOT
-      // 注释说明的周期快照,这里不做推断。
+      // 正常大头:非分类器的错误响应。只计数当分母 —— 判定交给周期快照(见
+      // OBSERVER_SNAPSHOT_INTERVAL_MS 注释),这里不做推断。
       counters.errorsNotClassifier += 1;
+      snapshotTallies(ctx.status);
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
@@ -326,6 +331,7 @@ export function createClaudeAutoClassifierFailureObserver(
       return undefined;
     }
     counters.classifierFailures += 1;
+    snapshotTallies(ctx.status);
 
     if (isTransientClassifierStatus(ctx.status)) {
       const ts = now();

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -185,8 +185,16 @@ const OBSERVER_WARN_THROTTLE_MS = 60_000;
  * 连续计数在每次成功识别时归零,所以既能发现整体失效,也能发现局部漂移。
  *
  * 取 50:普通 turn 的错误响应本就稀疏,连续 50 条都不是分类器才值得当信号。
+ *
+ * 两条收窄,防止无关流量把它推到误报(codex P2):
+ * - **只有带 `x-claude-code-session-id` 的响应才推进**。observer 挂在共享 proxy 上,PI 只带
+ *   `x-cindy-pi-session-id`(pi/index.ts),用它的 4xx 推进计数等于拿别的 runtime 的故障
+ *   报 Claude 分类器漂移;
+ * - **streak 有滑动窗口**。计数没有时效的话,进程跑得够久,稀疏的普通 turn 错误最终也会
+ *   攒满阈值。超过 IDENTITY_MISS_STREAK_WINDOW_MS 没有新的未命中就重新起算。
  */
 const IDENTITY_MISS_ALERT_THRESHOLD = 50;
+const IDENTITY_MISS_STREAK_WINDOW_MS = 30 * 60_000;
 
 /**
  * 创建只读响应观察器。成功路径(status < 400,含 2xx/3xx)几乎恒为 O(1) 短路——
@@ -223,6 +231,8 @@ export function createClaudeAutoClassifierFailureObserver(
    * IDENTITY_MISS_ALERT_THRESHOLD 注释里的「一次历史命中不该永久关闭告警」。
    */
   let missesSinceLastMatch = 0;
+  /** 上一次未命中的时刻;超过 streak 窗口没有新增就把连续计数重新起算。 */
+  let lastIdentityMissAt = 0;
   /** 每个 reason 各自限流,免得高频的那个把另一个饿死。 */
   const lastLogAt = new Map<string, number>();
   const logThrottled = (
@@ -289,7 +299,6 @@ export function createClaudeAutoClassifierFailureObserver(
     // 没识别出来吗」。代价是错误响应一律 parse 一次 body(原注释已认定该成本可忽略)。
     if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
       counters.errorsNotClassifier += 1;
-      missesSinceLastMatch += 1;
       // 「识别规则本身失效」必须能独立落盘:一旦 CC 改了分类器的 system 前缀或 max_tokens
       // 上界,所有真实分类器请求都会掉进这个分支 —— 那时既没有漏检 warn(它们在身份判据
       // 之后)、也没有升级日志(永远识别不出来),整条链路重新完全静默,而这恰恰是这套记账
@@ -301,11 +310,19 @@ export function createClaudeAutoClassifierFailureObserver(
       //
       // 用阈值门控把噪音压住:只有「一条都没识别出来」且样本已经够多时才报。正常运行下
       // 只要分类器真的报过一次错,classifierFailures 就 > 0,这条永远不触发。
-      if (missesSinceLastMatch >= IDENTITY_MISS_ALERT_THRESHOLD) {
-        warnThrottled('classifier identity has not matched for a long streak', {
-          status: ctx.status,
-          missesSinceLastMatch,
-        });
+      // 只有「本来就该带 cc 会话头」的响应才算候选分类器请求 —— 其它 runtime 的故障
+      // 不能拿来推进 Claude 分类器的漂移判据。
+      if (ctx.requestHeaders['x-claude-code-session-id']) {
+        const missAt = now();
+        if (missAt - lastIdentityMissAt > IDENTITY_MISS_STREAK_WINDOW_MS) missesSinceLastMatch = 0;
+        lastIdentityMissAt = missAt;
+        missesSinceLastMatch += 1;
+        if (missesSinceLastMatch >= IDENTITY_MISS_ALERT_THRESHOLD) {
+          warnThrottled('classifier identity has not matched for a long streak', {
+            status: ctx.status,
+            missesSinceLastMatch,
+          });
+        }
       }
       return undefined;
     }

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -177,11 +177,14 @@ interface ClassifierObserverCounters {
 const OBSERVER_WARN_THROTTLE_MS = 60_000;
 
 /**
- * 「一条都没识别出来」的告警样本下限。
+ * 身份漂移告警的样本下限 —— 判据是「**自上次成功识别以来**连续这么多条都没命中」,
+ * 不是「进程启动至今一次都没命中」。
  *
- * 正常运行下分类器只要报过一次错,`classifierFailures` 就 > 0,这条永不触发;真正的
- * 识别规则失效会让 errorsNotClassifier 单边快速累积。取 50:普通 turn 的错误响应本就
- * 稀疏,攒到 50 条而分类器一次都没识别出来,才值得当信号报。
+ * 后者会被一次历史命中永久关闭:分类器有 fast / 2-stage / thinking 三种形态,只要任意
+ * 一种曾命中过,另一种形态因前缀或 max_tokens 变化而持续漏检就永远报不出来(codex P1)。
+ * 连续计数在每次成功识别时归零,所以既能发现整体失效,也能发现局部漂移。
+ *
+ * 取 50:普通 turn 的错误响应本就稀疏,连续 50 条都不是分类器才值得当信号。
  */
 const IDENTITY_MISS_ALERT_THRESHOLD = 50;
 
@@ -215,6 +218,11 @@ export function createClaudeAutoClassifierFailureObserver(
     errorsNotClassifier: 0,
     recoveryMissingSessionHeader: 0,
   };
+  /**
+   * 自上次成功识别以来的连续未命中数(命中即归零)。用它判断身份漂移 —— 见
+   * IDENTITY_MISS_ALERT_THRESHOLD 注释里的「一次历史命中不该永久关闭告警」。
+   */
+  let missesSinceLastMatch = 0;
   /** 每个 reason 各自限流,免得高频的那个把另一个饿死。 */
   const lastLogAt = new Map<string, number>();
   const logThrottled = (
@@ -281,6 +289,7 @@ export function createClaudeAutoClassifierFailureObserver(
     // 没识别出来吗」。代价是错误响应一律 parse 一次 body(原注释已认定该成本可忽略)。
     if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
       counters.errorsNotClassifier += 1;
+      missesSinceLastMatch += 1;
       // 「识别规则本身失效」必须能独立落盘:一旦 CC 改了分类器的 system 前缀或 max_tokens
       // 上界,所有真实分类器请求都会掉进这个分支 —— 那时既没有漏检 warn(它们在身份判据
       // 之后)、也没有升级日志(永远识别不出来),整条链路重新完全静默,而这恰恰是这套记账
@@ -292,12 +301,10 @@ export function createClaudeAutoClassifierFailureObserver(
       //
       // 用阈值门控把噪音压住:只有「一条都没识别出来」且样本已经够多时才报。正常运行下
       // 只要分类器真的报过一次错,classifierFailures 就 > 0,这条永远不触发。
-      if (
-        counters.classifierFailures === 0
-        && counters.errorsNotClassifier >= IDENTITY_MISS_ALERT_THRESHOLD
-      ) {
-        warnThrottled('no error response has matched the classifier identity yet', {
+      if (missesSinceLastMatch >= IDENTITY_MISS_ALERT_THRESHOLD) {
+        warnThrottled('classifier identity has not matched for a long streak', {
           status: ctx.status,
+          missesSinceLastMatch,
         });
       }
       return undefined;
@@ -323,6 +330,8 @@ export function createClaudeAutoClassifierFailureObserver(
       return undefined;
     }
     counters.classifierFailures += 1;
+    // 命中即归零:连续漏检才是漂移信号,累计总数会被一次历史命中永久淹掉。
+    missesSinceLastMatch = 0;
 
     if (isTransientClassifierStatus(ctx.status)) {
       const ts = now();

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -177,6 +177,15 @@ interface ClassifierObserverCounters {
 const OBSERVER_WARN_THROTTLE_MS = 60_000;
 
 /**
+ * 「一条都没识别出来」的告警样本下限。
+ *
+ * 正常运行下分类器只要报过一次错,`classifierFailures` 就 > 0,这条永不触发;真正的
+ * 识别规则失效会让 errorsNotClassifier 单边快速累积。取 50:普通 turn 的错误响应本就
+ * 稀疏,攒到 50 条而分类器一次都没识别出来,才值得当信号报。
+ */
+const IDENTITY_MISS_ALERT_THRESHOLD = 50;
+
+/**
  * 创建只读响应观察器。成功路径(status < 400,含 2xx/3xx)几乎恒为 O(1) 短路——
  * 仅当**该会话已有瞬时故障记账**时才 parse body 确认「分类器已恢复」并清零计数;
  * 无记账时不 parse、不返回 sink,不碰 SSE 热路径。
@@ -225,9 +234,6 @@ export function createClaudeAutoClassifierFailureObserver(
   };
   const warnThrottled = (reason: string, fields: Record<string, unknown>): void =>
     logThrottled('warn', reason, fields);
-  /** 周期性快照用 debug —— 正常运行时它每窗口一条,不该当告警刷 warn。 */
-  const debugThrottled = (reason: string, fields: Record<string, unknown>): void =>
-    logThrottled('debug', reason, fields);
 
   return (ctx: ResponseObserverCtx) => {
     if (ctx.status < 400) {
@@ -275,15 +281,25 @@ export function createClaudeAutoClassifierFailureObserver(
     // 没识别出来吗」。代价是错误响应一律 parse 一次 body(原注释已认定该成本可忽略)。
     if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
       counters.errorsNotClassifier += 1;
-      // 这个计数必须能**独立**落盘,不能只搭后续 warn / 升级 debug 的便车:一旦 CC 改了
-      // 分类器的 system 前缀或 max_tokens 上界,所有真实分类器请求都会掉进这个分支 ——
-      // 那时既没有漏检 warn(它们在身份判据之后)、也没有升级 debug(永远识别不出来),
-      // 整条链路重新变成完全静默,而「识别规则失效」恰恰是这套记账最该发现的事(codex P2)。
-      // 所以按同一套 per-reason 限流打一条周期性快照:`classifierFailures: 0` 配上持续
-      // 增长的 errorsNotClassifier,就是识别率归零的信号。用 debug 级,正常运行时不吵。
-      debugThrottled('classifier identity did not match any error response in this window', {
-        status: ctx.status,
-      });
+      // 「识别规则本身失效」必须能独立落盘:一旦 CC 改了分类器的 system 前缀或 max_tokens
+      // 上界,所有真实分类器请求都会掉进这个分支 —— 那时既没有漏检 warn(它们在身份判据
+      // 之后)、也没有升级日志(永远识别不出来),整条链路重新完全静默,而这恰恰是这套记账
+      // 最该发现的事(codex P2)。
+      //
+      // 级别必须是 **warn**:打包版默认 level=info(logger.ts 的 initLogger),而 emit() 前的
+      // shouldLog 会直接丢掉 debug —— 用 debug 等于在生产环境里根本不落盘,要排查的场景
+      // 依旧查不到。
+      //
+      // 用阈值门控把噪音压住:只有「一条都没识别出来」且样本已经够多时才报。正常运行下
+      // 只要分类器真的报过一次错,classifierFailures 就 > 0,这条永远不触发。
+      if (
+        counters.classifierFailures === 0
+        && counters.errorsNotClassifier >= IDENTITY_MISS_ALERT_THRESHOLD
+      ) {
+        warnThrottled('no error response has matched the classifier identity yet', {
+          status: ctx.status,
+        });
+      }
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -140,6 +140,39 @@ function isTransientClassifierStatus(status: number): boolean {
   return status === 408 || status === 429 || status >= 500;
 }
 
+/** 观察器只需要这两级;coordinator 的 FallbackLogger 用 info/warn,两者刻意不共用。 */
+interface ClassifierObserverLogger {
+  debug(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+}
+
+/**
+ * 观察器生命周期内的识别记账。挂在限流日志上,用来回答一个排障时问不出来的问题:
+ * 「分类器正在报错,但我们到底有没有识别出来?」
+ *
+ * `classifierFailures` 是识别成功数;它与两个漏检计数的比例才是识别率信号。
+ * `errorsNotClassifier` 是**正常**的大头(普通 turn 的错误响应也会流经这里),不参与
+ * 漏检判断,单列出来只为让另外两个计数有分母。
+ */
+interface ClassifierObserverCounters {
+  /** 有 header + 反解成功 + body 判定为分类器 → 真正识别出的分类器故障。 */
+  classifierFailures: number;
+  /** 错误响应缺 x-claude-code-session-id → 无法归属会话,漏检。 */
+  errorsMissingSessionHeader: number;
+  /** 错误响应有 header 但反解不出业务会话 id → 漏检。 */
+  errorsUnresolvedSession: number;
+  /** 有 header + 反解成功,但 body 不是分类器请求 → 正常,普通 turn 的错误。 */
+  errorsNotClassifier: number;
+  /** 已有瞬时记账的成功响应缺 header → 这一轮「恢复即清零」不会发生。 */
+  recoveryMissingSessionHeader: number;
+}
+
+/**
+ * 同一漏检原因的 warn 限流间隔。漏检是**每个**错误响应都可能触发的,不限流会在上游
+ * 持续故障时把日志刷爆;但也不能只报一次 —— 排障的人需要知道它还在持续发生。
+ */
+const OBSERVER_WARN_THROTTLE_MS = 60_000;
+
 /**
  * 创建只读响应观察器。成功路径(status < 400,含 2xx/3xx)几乎恒为 O(1) 短路——
  * 仅当**该会话已有瞬时故障记账**时才 parse body 确认「分类器已恢复」并清零计数;
@@ -148,22 +181,57 @@ function isTransientClassifierStatus(status: number): boolean {
  * fallback 信号分两类:
  * - 非瞬时 4xx(400/401/403/404/422 等确定性错误)→ 立即通知协调器(与 #596 前一致);
  * - 瞬时 408/429/5xx → 按上方 episode 阈值记账,持续故障才通知。
+ *
+ * 这条链路是 Auto 档唯一的自救通道,而它的两个前置条件(会话请求头、id 反解)任一不满足
+ * 就整条静默失效 —— 会话被留在无限 fail-closed,而日志里没有任何线索指向这里。所以两处
+ * 提前返回都带限流 warn 与识别记账(见 ClassifierObserverCounters,issue #1579)。记账与
+ * 日志都是旁路的:不改判定、不改短路顺序,logger 缺省时整段退化为纯计数。
  */
 export function createClaudeAutoClassifierFailureObserver(
   resolveSessionId: (sdkSessionId: string) => string | null,
-  opts: { now?: () => number } = {},
+  opts: { now?: () => number; logger?: ClassifierObserverLogger } = {},
 ): ResponseObserver {
   const now = opts.now ?? Date.now;
+  const logger = opts.logger;
   // key = sdkSessionId(cc 侧会话 id,请求头自带,成功路径无需反解);
   // value = 各 episode 的起始时间戳,升序。
   const transientEpisodes = new Map<string, number[]>();
+  const counters: ClassifierObserverCounters = {
+    classifierFailures: 0,
+    errorsMissingSessionHeader: 0,
+    errorsUnresolvedSession: 0,
+    errorsNotClassifier: 0,
+    recoveryMissingSessionHeader: 0,
+  };
+  /** 每个 reason 各自限流,免得高频的那个把另一个饿死。 */
+  const lastWarnAt = new Map<string, number>();
+  const warnThrottled = (reason: string, fields: Record<string, unknown>): void => {
+    if (!logger) return;
+    const ts = now();
+    const last = lastWarnAt.get(reason);
+    if (last !== undefined && ts - last < OBSERVER_WARN_THROTTLE_MS) return;
+    lastWarnAt.set(reason, ts);
+    logger.warn(`auto classifier failure observer: ${reason}`, {
+      ...fields,
+      counters: { ...counters },
+    });
+  };
 
   return (ctx: ResponseObserverCtx) => {
     if (ctx.status < 400) {
       // 分类器恢复 → 清零该会话的瞬时故障记账。仅在有记账时才 parse body。
       if (transientEpisodes.size === 0) return undefined;
       const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
-      if (!sdkSessionId) return undefined;
+      if (!sdkSessionId) {
+        // 拿不到 header 就找不到要清哪一条账。后果有界(记账最终会因窗口过期被弃),
+        // 但期间该会话可能被残账提前推过升级阈值,值得在日志里可见。
+        counters.recoveryMissingSessionHeader += 1;
+        warnThrottled('success response without session header; recovery reset skipped', {
+          status: ctx.status,
+          trackedSessions: transientEpisodes.size,
+        });
+        return undefined;
+      }
       const episodes = transientEpisodes.get(sdkSessionId);
       if (!episodes) return undefined;
       // 过期即弃:记账已整体滑出窗口 → 直接删,该会话的后续成功响应回到零开销
@@ -182,9 +250,32 @@ export function createClaudeAutoClassifierFailureObserver(
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
-    if (!sdkSessionId) return undefined;
+    if (!sdkSessionId) {
+      // 上游未回传原请求头(SDK 版本差异、代理链改写、部分错误响应本就不带)→ 无法归属,
+      // 该会话的分类器故障永远不会升级到 Cindy fallback。
+      counters.errorsMissingSessionHeader += 1;
+      warnThrottled('error response without session header; classifier failure unattributable', {
+        status: ctx.status,
+      });
+      return undefined;
+    }
     const sessionId = resolveSessionId(sdkSessionId);
-    if (!sessionId || !isClaudeAutoClassifierRequest(ctx.requestBody)) return undefined;
+    if (!sessionId) {
+      // 映射尚未建立 / 会话刚 resume / 映射表已清理。同样导致故障不会升级。
+      counters.errorsUnresolvedSession += 1;
+      warnThrottled('error response with unresolvable sdk session id', {
+        status: ctx.status,
+        sdkSessionId,
+      });
+      return undefined;
+    }
+    // 先判 sessionId 再 parse body —— 保持原有短路顺序,不为无法归属的响应付 parse 成本。
+    if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
+      // 正常大头:普通 turn 的错误响应也流经这里。只计数,不 warn。
+      counters.errorsNotClassifier += 1;
+      return undefined;
+    }
+    counters.classifierFailures += 1;
 
     if (isTransientClassifierStatus(ctx.status)) {
       const ts = now();
@@ -218,6 +309,14 @@ export function createClaudeAutoClassifierFailureObserver(
     // 用户重开 Auto 时从零累计,不因残账被单次偶发失败提前推过阈值。协调器自身有
     // in-flight 去重 + 持久态 CAS,重复信号安全。
     transientEpisodes.delete(sdkSessionId);
+
+    // 识别成功且已过阈值的那一刻记一条,带完整计数 —— coordinator 侧的日志只覆盖
+    // 「切换成功/失败」,看不到「识别到了但被 episode 阈值挡住」的那些。
+    logger?.debug('auto classifier failure escalated; notifying fallback coordinator', {
+      sessionId,
+      status: ctx.status,
+      counters: { ...counters },
+    });
 
     try {
       notifyAutoPermissionClassifierUnavailable({

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -207,18 +207,27 @@ export function createClaudeAutoClassifierFailureObserver(
     recoveryMissingSessionHeader: 0,
   };
   /** 每个 reason 各自限流,免得高频的那个把另一个饿死。 */
-  const lastWarnAt = new Map<string, number>();
-  const warnThrottled = (reason: string, fields: Record<string, unknown>): void => {
+  const lastLogAt = new Map<string, number>();
+  const logThrottled = (
+    level: 'warn' | 'debug',
+    reason: string,
+    fields: Record<string, unknown>,
+  ): void => {
     if (!logger) return;
     const ts = now();
-    const last = lastWarnAt.get(reason);
+    const last = lastLogAt.get(reason);
     if (last !== undefined && ts - last < OBSERVER_WARN_THROTTLE_MS) return;
-    lastWarnAt.set(reason, ts);
-    logger.warn(`auto classifier failure observer: ${reason}`, {
+    lastLogAt.set(reason, ts);
+    logger[level](`auto classifier failure observer: ${reason}`, {
       ...fields,
       counters: { ...counters },
     });
   };
+  const warnThrottled = (reason: string, fields: Record<string, unknown>): void =>
+    logThrottled('warn', reason, fields);
+  /** 周期性快照用 debug —— 正常运行时它每窗口一条,不该当告警刷 warn。 */
+  const debugThrottled = (reason: string, fields: Record<string, unknown>): void =>
+    logThrottled('debug', reason, fields);
 
   return (ctx: ResponseObserverCtx) => {
     if (ctx.status < 400) {
@@ -265,8 +274,16 @@ export function createClaudeAutoClassifierFailureObserver(
     // 顶满,识别率信号彻底失效 —— 而这两个计数存在的唯一目的就是回答「分类器在报错但我们
     // 没识别出来吗」。代价是错误响应一律 parse 一次 body(原注释已认定该成本可忽略)。
     if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
-      // 正常大头:非分类器的错误响应。只计数当分母,不 warn。
       counters.errorsNotClassifier += 1;
+      // 这个计数必须能**独立**落盘,不能只搭后续 warn / 升级 debug 的便车:一旦 CC 改了
+      // 分类器的 system 前缀或 max_tokens 上界,所有真实分类器请求都会掉进这个分支 ——
+      // 那时既没有漏检 warn(它们在身份判据之后)、也没有升级 debug(永远识别不出来),
+      // 整条链路重新变成完全静默,而「识别规则失效」恰恰是这套记账最该发现的事(codex P2)。
+      // 所以按同一套 per-reason 限流打一条周期性快照:`classifierFailures: 0` 配上持续
+      // 增长的 errorsNotClassifier,就是识别率归零的信号。用 debug 级,正常运行时不吵。
+      debugThrottled('classifier identity did not match any error response in this window', {
+        status: ctx.status,
+      });
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -140,9 +140,13 @@ function isTransientClassifierStatus(status: number): boolean {
   return status === 408 || status === 429 || status >= 500;
 }
 
-/** 观察器只需要这两级;coordinator 的 FallbackLogger 用 info/warn,两者刻意不共用。 */
+/**
+ * 观察器需要的日志面:warn 报漏检、info 落周期快照。两级都在打包版默认 level=info 下会
+ * 落盘(debug 会被 logger 的 shouldLog 丢掉,故不用)。与 coordinator 的 FallbackLogger
+ * 刻意不共用 —— 那边还需要 debug。
+ */
 interface ClassifierObserverLogger {
-  debug(message: string, fields?: Record<string, unknown>): void;
+  info(message: string, fields?: Record<string, unknown>): void;
   warn(message: string, fields?: Record<string, unknown>): void;
 }
 
@@ -177,24 +181,19 @@ interface ClassifierObserverCounters {
 const OBSERVER_WARN_THROTTLE_MS = 60_000;
 
 /**
- * 身份漂移告警的样本下限 —— 判据是「**自上次成功识别以来**连续这么多条都没命中」,
- * 不是「进程启动至今一次都没命中」。
+ * 观测快照间隔。
  *
- * 后者会被一次历史命中永久关闭:分类器有 fast / 2-stage / thinking 三种形态,只要任意
- * 一种曾命中过,另一种形态因前缀或 max_tokens 变化而持续漏检就永远报不出来(codex P1)。
- * 连续计数在每次成功识别时归零,所以既能发现整体失效,也能发现局部漂移。
+ * **刻意不做「识别规则是否失效」的自动判定。** 那需要「本该被识别的请求数」当分母,而漏检
+ * 时这个分母恰恰拿不到 —— 前几轮 review 反复在这个精度上打转都是同一个原因:连续计数会被
+ * 任意一种形态的命中清零(交错到达时另一形态 100% 漂移也报不出来)、比例判据对部分形态漂移
+ * 不敏感、全局计数又会被共享 proxy 上无关 runtime 的错误推进。
  *
- * 取 50:普通 turn 的错误响应本就稀疏,连续 50 条都不是分类器才值得当信号。
- *
- * 两条收窄,防止无关流量把它推到误报(codex P2):
- * - **只有带 `x-claude-code-session-id` 的响应才推进**。observer 挂在共享 proxy 上,PI 只带
- *   `x-cindy-pi-session-id`(pi/index.ts),用它的 4xx 推进计数等于拿别的 runtime 的故障
- *   报 Claude 分类器漂移;
- * - **streak 有滑动窗口**。计数没有时效的话,进程跑得够久,稀疏的普通 turn 错误最终也会
- *   攒满阈值。超过 IDENTITY_MISS_STREAK_WINDOW_MS 没有新的未命中就重新起算。
+ * 所以改成只把原始计数定期落盘,判断交给看日志的人:`classifierFailures` 长期为 0 而
+ * `errorsNotClassifier` 在涨,就该怀疑身份判据(system 前缀 / max_tokens 上界)变了。
+ * 用 **info** 级 —— 打包版默认 level=info,debug 会被 logger 的 shouldLog 直接丢掉。
+ * 只在处理过错误响应时输出,30 分钟一条,正常运行噪音可忽略。
  */
-const IDENTITY_MISS_ALERT_THRESHOLD = 50;
-const IDENTITY_MISS_STREAK_WINDOW_MS = 30 * 60_000;
+const OBSERVER_SNAPSHOT_INTERVAL_MS = 30 * 60_000;
 
 /**
  * 创建只读响应观察器。成功路径(status < 400,含 2xx/3xx)几乎恒为 O(1) 短路——
@@ -226,24 +225,18 @@ export function createClaudeAutoClassifierFailureObserver(
     errorsNotClassifier: 0,
     recoveryMissingSessionHeader: 0,
   };
-  /**
-   * 自上次成功识别以来的连续未命中数(命中即归零)。用它判断身份漂移 —— 见
-   * IDENTITY_MISS_ALERT_THRESHOLD 注释里的「一次历史命中不该永久关闭告警」。
-   */
-  let missesSinceLastMatch = 0;
-  /** 上一次未命中的时刻;超过 streak 窗口没有新增就把连续计数重新起算。 */
-  let lastIdentityMissAt = 0;
   /** 每个 reason 各自限流,免得高频的那个把另一个饿死。 */
   const lastLogAt = new Map<string, number>();
   const logThrottled = (
-    level: 'warn' | 'debug',
+    level: 'warn' | 'info',
     reason: string,
     fields: Record<string, unknown>,
+    intervalMs: number = OBSERVER_WARN_THROTTLE_MS,
   ): void => {
     if (!logger) return;
     const ts = now();
     const last = lastLogAt.get(reason);
-    if (last !== undefined && ts - last < OBSERVER_WARN_THROTTLE_MS) return;
+    if (last !== undefined && ts - last < intervalMs) return;
     lastLogAt.set(reason, ts);
     logger[level](`auto classifier failure observer: ${reason}`, {
       ...fields,
@@ -252,6 +245,8 @@ export function createClaudeAutoClassifierFailureObserver(
   };
   const warnThrottled = (reason: string, fields: Record<string, unknown>): void =>
     logThrottled('warn', reason, fields);
+  const infoThrottled = (reason: string, fields: Record<string, unknown>, intervalMs: number): void =>
+    logThrottled('info', reason, fields, intervalMs);
 
   return (ctx: ResponseObserverCtx) => {
     if (ctx.status < 400) {
@@ -292,38 +287,22 @@ export function createClaudeAutoClassifierFailureObserver(
       }
       return undefined;
     }
+    // 周期性把原始计数落盘(见 OBSERVER_SNAPSHOT_INTERVAL_MS):漏检时三条 warn 都可能
+    // 不触发,只有这条能保证「分类器在报错但我们没识别出来」在日志里留下痕迹。
+    infoThrottled(
+      'classifier observation snapshot',
+      { status: ctx.status },
+      OBSERVER_SNAPSHOT_INTERVAL_MS,
+    );
     // 身份判据必须**最先**过:observer 挂在共享的 anthropic-compat-proxy 上,普通 turn、
     // PI 以及其它复用该 proxy 的 runtime 的 4xx/5xx 全都流经这里。若先按「缺会话头 /
     // 反解失败」记漏检,这些无关错误会把 errorsMissingSessionHeader / errorsUnresolvedSession
     // 顶满,识别率信号彻底失效 —— 而这两个计数存在的唯一目的就是回答「分类器在报错但我们
     // 没识别出来吗」。代价是错误响应一律 parse 一次 body(原注释已认定该成本可忽略)。
     if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
+      // 正常大头:非分类器的错误响应。只计数当分母 —— 判定交给上面 OBSERVER_SNAPSHOT
+      // 注释说明的周期快照,这里不做推断。
       counters.errorsNotClassifier += 1;
-      // 「识别规则本身失效」必须能独立落盘:一旦 CC 改了分类器的 system 前缀或 max_tokens
-      // 上界,所有真实分类器请求都会掉进这个分支 —— 那时既没有漏检 warn(它们在身份判据
-      // 之后)、也没有升级日志(永远识别不出来),整条链路重新完全静默,而这恰恰是这套记账
-      // 最该发现的事(codex P2)。
-      //
-      // 级别必须是 **warn**:打包版默认 level=info(logger.ts 的 initLogger),而 emit() 前的
-      // shouldLog 会直接丢掉 debug —— 用 debug 等于在生产环境里根本不落盘,要排查的场景
-      // 依旧查不到。
-      //
-      // 用阈值门控把噪音压住:只有「一条都没识别出来」且样本已经够多时才报。正常运行下
-      // 只要分类器真的报过一次错,classifierFailures 就 > 0,这条永远不触发。
-      // 只有「本来就该带 cc 会话头」的响应才算候选分类器请求 —— 其它 runtime 的故障
-      // 不能拿来推进 Claude 分类器的漂移判据。
-      if (ctx.requestHeaders['x-claude-code-session-id']) {
-        const missAt = now();
-        if (missAt - lastIdentityMissAt > IDENTITY_MISS_STREAK_WINDOW_MS) missesSinceLastMatch = 0;
-        lastIdentityMissAt = missAt;
-        missesSinceLastMatch += 1;
-        if (missesSinceLastMatch >= IDENTITY_MISS_ALERT_THRESHOLD) {
-          warnThrottled('classifier identity has not matched for a long streak', {
-            status: ctx.status,
-            missesSinceLastMatch,
-          });
-        }
-      }
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
@@ -347,8 +326,6 @@ export function createClaudeAutoClassifierFailureObserver(
       return undefined;
     }
     counters.classifierFailures += 1;
-    // 命中即归零:连续漏检才是漂移信号,累计总数会被一次历史命中永久淹掉。
-    missesSinceLastMatch = 0;
 
     if (isTransientClassifierStatus(ctx.status)) {
       const ts = now();
@@ -385,7 +362,8 @@ export function createClaudeAutoClassifierFailureObserver(
 
     // 识别成功且已过阈值的那一刻记一条,带完整计数 —— coordinator 侧的日志只覆盖
     // 「切换成功/失败」,看不到「识别到了但被 episode 阈值挡住」的那些。
-    logger?.debug('auto classifier failure escalated; notifying fallback coordinator', {
+    // info 级:这一刻本就低频(真的持续故障才走到),且打包版默认 level=info 会落盘。
+    logger?.info('auto classifier failure escalated; notifying fallback coordinator', {
       sessionId,
       status: ctx.status,
       counters: { ...counters },

--- a/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
+++ b/apps/desktop/src/main/maker-host/claude-auto-permission-fallback.ts
@@ -151,19 +151,22 @@ interface ClassifierObserverLogger {
  * 「分类器正在报错,但我们到底有没有识别出来?」
  *
  * `classifierFailures` 是识别成功数;它与两个漏检计数的比例才是识别率信号。
- * `errorsNotClassifier` 是**正常**的大头(普通 turn 的错误响应也会流经这里),不参与
- * 漏检判断,单列出来只为让另外两个计数有分母。
+ * `errorsNotClassifier` 是**正常**的大头,不参与漏检判断,单列出来只为让另外两个计数有分母。
+ *
+ * **所有计数都在「已确认是 Auto 分类器请求」之后才累加。** observer 挂在共享的
+ * anthropic-compat-proxy 上,普通 turn、PI 与其它复用该 proxy 的 runtime 的响应同样流经
+ * 这里;若先按归属失败记账,那些无关响应会把漏检计数顶满,识别率信号就废了。
  */
 interface ClassifierObserverCounters {
-  /** 有 header + 反解成功 + body 判定为分类器 → 真正识别出的分类器故障。 */
+  /** 分类器请求 + 有 header + 反解成功 → 真正识别出的分类器故障。 */
   classifierFailures: number;
-  /** 错误响应缺 x-claude-code-session-id → 无法归属会话,漏检。 */
+  /** **分类器请求**的错误响应缺 x-claude-code-session-id → 无法归属会话,漏检。 */
   errorsMissingSessionHeader: number;
-  /** 错误响应有 header 但反解不出业务会话 id → 漏检。 */
+  /** **分类器请求**的错误响应有 header 但反解不出业务会话 id → 漏检。 */
   errorsUnresolvedSession: number;
-  /** 有 header + 反解成功,但 body 不是分类器请求 → 正常,普通 turn 的错误。 */
+  /** 错误响应的 body 不是分类器请求 → 正常(普通 turn / PI / 其它 runtime)。 */
   errorsNotClassifier: number;
-  /** 已有瞬时记账的成功响应缺 header → 这一轮「恢复即清零」不会发生。 */
+  /** 有瞬时记账时,**分类器请求**的 2xx 缺 header → 这一轮「恢复即清零」不会发生。 */
   recoveryMissingSessionHeader: number;
 }
 
@@ -225,11 +228,18 @@ export function createClaudeAutoClassifierFailureObserver(
       if (!sdkSessionId) {
         // 拿不到 header 就找不到要清哪一条账。后果有界(记账最终会因窗口过期被弃),
         // 但期间该会话可能被残账提前推过升级阈值,值得在日志里可见。
-        counters.recoveryMissingSessionHeader += 1;
-        warnThrottled('success response without session header; recovery reset skipped', {
-          status: ctx.status,
-          trackedSessions: transientEpisodes.size,
-        });
+        //
+        // 只有**确认是分类器请求**才算漏检:observer 挂在共享的 anthropic-compat-proxy 上,
+        // PI 与其它 runtime 的成功响应同样不带这个头,不先过滤会让混合运行时持续制造假告警
+        // (`transientEpisodes.size` 是整个 observer 级的,任意一个 Claude 会话有记账就非零)。
+        // 判据顺序按成本排:先 2xx(3xx 本就不清账)、再 parse —— 只有走到这里的少数响应付这笔。
+        if (ctx.status >= 200 && ctx.status < 300 && isClaudeAutoClassifierRequest(ctx.requestBody)) {
+          counters.recoveryMissingSessionHeader += 1;
+          warnThrottled('success response without session header; recovery reset skipped', {
+            status: ctx.status,
+            trackedSessions: transientEpisodes.size,
+          });
+        }
         return undefined;
       }
       const episodes = transientEpisodes.get(sdkSessionId);
@@ -247,6 +257,16 @@ export function createClaudeAutoClassifierFailureObserver(
       if (ctx.status >= 200 && ctx.status < 300 && isClaudeAutoClassifierRequest(ctx.requestBody)) {
         transientEpisodes.delete(sdkSessionId);
       }
+      return undefined;
+    }
+    // 身份判据必须**最先**过:observer 挂在共享的 anthropic-compat-proxy 上,普通 turn、
+    // PI 以及其它复用该 proxy 的 runtime 的 4xx/5xx 全都流经这里。若先按「缺会话头 /
+    // 反解失败」记漏检,这些无关错误会把 errorsMissingSessionHeader / errorsUnresolvedSession
+    // 顶满,识别率信号彻底失效 —— 而这两个计数存在的唯一目的就是回答「分类器在报错但我们
+    // 没识别出来吗」。代价是错误响应一律 parse 一次 body(原注释已认定该成本可忽略)。
+    if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
+      // 正常大头:非分类器的错误响应。只计数当分母,不 warn。
+      counters.errorsNotClassifier += 1;
       return undefined;
     }
     const sdkSessionId = ctx.requestHeaders['x-claude-code-session-id'];
@@ -267,12 +287,6 @@ export function createClaudeAutoClassifierFailureObserver(
         status: ctx.status,
         sdkSessionId,
       });
-      return undefined;
-    }
-    // 先判 sessionId 再 parse body —— 保持原有短路顺序,不为无法归属的响应付 parse 成本。
-    if (!isClaudeAutoClassifierRequest(ctx.requestBody)) {
-      // 正常大头:普通 turn 的错误响应也流经这里。只计数,不 warn。
-      counters.errorsNotClassifier += 1;
       return undefined;
     }
     counters.classifierFailures += 1;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Auto 档唯一的自救通道是「原生分类器故障 → 切 Cindy fallback」，而这条链路有两个前置条件：
错误响应带 `x-claude-code-session-id`、该 id 能反解出业务会话。任一不满足，原来都是**静默
return** —— 故障永远不会升级，会话被留在无限 fail-closed，而日志里没有任何线索指向这里
（issue #1579）。用户侧看到的就是「工具一直被拒、没有弹窗、重启无效」，排障时却查不到原因。

加两样纯旁路的东西，**零行为变化**：

1. **三处提前返回补限流 warn** —— 错误响应缺会话头、id 反解失败、以及成功响应缺会话头导致
   「恢复即清零」跳过。同一原因 60s 一条，不同原因各自计时（免得高频那个把另一个饿死）；
   既不刷屏，也不会「只报一次就消失」。
2. **观察器生命周期的识别记账**（`ClassifierObserverCounters`），随每条 warn / debug 一起输出。
   `classifierFailures` 是识别成功数，它与两个漏检计数的比例就是 issue 要的识别率信号；
   `errorsNotClassifier` 单列出来充当分母（普通 turn 的错误响应也流经这里，是正常大头，
   只计数不 warn）。

顺带把原先合并的 `!sessionId || !isClaudeAutoClassifierRequest(...)` 拆成两个判断，以便分别
计数 —— **短路顺序不变**（仍先判 `sessionId` 再 parse body），parse 次数也不变。

`logger` 由 `anthropic-compat-proxy-host` 注入（与 `createClaudeFastModeResponseObserver` 同款）；
缺省时整段退化为纯计数，不抛。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1579（只做 issue 的第 1、3 条 —— 它们本身就标注了「纯属可观测性，
  零行为变化，可以先合」）
- 本 PR 包含：三处漏检点的限流 warn + 识别记账 + 升级时刻的 debug 快照；logger 注入；
  6 条新测试
- 明确不包含：issue 第 2 条建议（反解失败时按「唯一活跃 Auto 会话」兜底归属）—— 那会改变
  **归属判定**，不属于可观测性范围，需要单独设计与验证。其它 auto-review issue
  （#1574 / #1576 / #1578）也不在本 PR
- 用户可见变化：无（只影响 `apps/desktop/logs/` 的内容）
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/main/maker-host/__tests__/claudeAutoPermissionFallback.test.ts
结果：25 tests 全部通过（新增 6）

pnpm --filter desktop run typecheck
结果：通过

pnpm test:unit
结果：56 workspace PASS / 0 FAIL
```

新增的 6 条覆盖：缺会话头 warn、反解失败 warn、非分类器响应只计数不 warn、同原因限流 +
跨原因独立 + 越窗后重新可见、成功响应无法清账、升级时刻的 debug 快照 + 无 logger 时不抛。

**Mutation 验证**（限流是这个 PR 里唯一有逻辑的部分，必须证明测试能捕获它失效）：把
`ts - last < OBSERVER_WARN_THROTTLE_MS` 改成 `ts - last < 0`（等于关掉限流）后重跑：

```text
× createClaudeAutoClassifierFailureObserver > missed-detection visibility > throttles the same reason but keeps different reasons independent
  → expected "spy" to be called 1 times, but got 5 times
其余 24 条保持绿色。
```

验证后源文件已还原。

### 手工验证

未做实机注入。这条链路要真实触发需要让上游分类器返回错误且**同时**剥掉
`x-claude-code-session-id` 请求头，本地没有便捷的注入手段；改动本身是纯旁路计数与日志，
判定分支未变（见下「未执行的验证」）。

### 未执行的验证

- 未用 proxy 实机注入「缺会话头的分类器错误响应」验证日志形态。判定逻辑由单测覆盖
  （直接构造 `ResponseObserverCtx`，与真实 observer 入参同形），且改动不触碰任何判定分支，
  风险限于日志内容本身。
- 未验证 issue 第 3 条提到的「偏差过大即说明识别规则失效」在真实运行数据上的阈值 —— 本 PR
  只把数据暴露出来，没有设定告警阈值。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

说明：改动落在权限链路**附近**，但没有改变任何权限判定 —— 三处提前返回的条件、短路顺序、
episode 记账与升级阈值全部原样保留，新增代码只有计数器自增与日志。

### 影响与回滚

- 影响范围：`apps/desktop` 的分类器故障观察器。运行期行为不变；额外开销是每个错误响应
  一次整数自增，以及漏检时每 60s 一条日志。成功路径（SSE 热路径）仍保持
  `transientEpisodes.size === 0` 的 O(1) 短路，未新增 parse。
- 回滚 / 降级方式：revert 本 PR 即可；也可以在接线处不传 `logger`，整段退化为纯计数。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（计数器语义与限流理由写在类型/常量的注释里）
- [x] 已确认测试结果或说明未执行原因
