### PR TITLE
fix(codex): 修复 spawn_agent 首请求 Provider 继承

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1110,6 +1110,285 @@ describe('chatBridgeCapabilitiesForRoute', () => {
     }
   });
 
+  it('routes the first collab_spawn request through its parent custom Responses provider', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'collab-spawn-provider',
+        name: 'Collab Spawn Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://collab-spawn.invalid/v1',
+            models: [{ id: 'collab-spawn-model', name: 'Collab Spawn Model' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader(() => 'test-invalid-collab-spawn-key');
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-collab-parent', 'thread-collab-parent', 'PRODUCT_PROMPT');
+    setSessionProvider('session-collab-parent', 'collab-spawn-provider');
+    host.setCodexProxyAuthInjection('env-key');
+
+    try {
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'collab-spawn-model', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: {
+            'thread-id': 'thread-collab-child',
+            'x-openai-subagent': 'collab_spawn',
+            'x-codex-parent-thread-id': 'thread-collab-parent',
+          },
+        },
+      ));
+
+      expect(decision).toEqual({
+        upstreamOverride: 'https://collab-spawn.invalid/v1',
+        headerOverride: { authorization: 'Bearer test-invalid-collab-spawn-key' },
+        headerDelete: ['chatgpt-account-id', 'openai-beta', 'originator', 'session_id'],
+      });
+      expect(mockState.capturedRegistry?.get('thread-collab-child')).toBe('PRODUCT_PROMPT');
+    } finally {
+      host.unregister('session-collab-parent');
+      clearSessionProvider('session-collab-parent');
+      setCustomProviderKeyReader(() => null);
+      setCustomProviders([]);
+    }
+  });
+
+  it('fails closed when a collab_spawn request cannot resolve its parent route', async () => {
+    const host = await freshCodexProxyHost();
+    const ctx = {
+      reqId: 1,
+      method: 'POST',
+      url: '/responses',
+      headers: {
+        'thread-id': 'thread-collab-orphan',
+        'x-openai-subagent': 'collab_spawn',
+        'x-codex-parent-thread-id': 'thread-collab-missing-parent',
+      },
+    };
+
+    const decision = await Promise.resolve(host.createModelRoutingTransform()(
+      { model: 'collab-spawn-model', input: [] },
+      ctx,
+    ));
+
+    expect(decision).toEqual({ localHandler: expect.any(Function) });
+    if (!decision?.localHandler) throw new Error('missing unresolved collab_spawn route handler');
+
+    const writeHead = vi.fn();
+    const end = vi.fn();
+    await decision.localHandler({
+      rawBody: Buffer.alloc(0),
+      parsedBody: { model: 'collab-spawn-model', input: [] },
+      ctx,
+      res: { writeHead, end } as never,
+    });
+
+    expect(writeHead).toHaveBeenCalledWith(503, {
+      'content-type': 'application/json; charset=utf-8',
+      'cache-control': 'no-store',
+    });
+    expect(JSON.parse(String(end.mock.calls[0]?.[0]))).toEqual({
+      error: {
+        type: 'server_error',
+        code: 'cindy_codex_parent_route_unavailable',
+        message: 'Cindy could not resolve the parent Provider route for this spawned Codex agent.',
+      },
+    });
+    expect(mockState.capturedRegistry?.get('thread-collab-orphan')).toBeUndefined();
+  });
+
+  it('does not use a matching x-client-request-id as a collab_spawn child identity', async () => {
+    const host = await freshCodexProxyHost();
+    host.registerComposed('session-collab-parent', 'thread-collab-parent', 'PARENT_PROMPT');
+    host.registerComposed('session-request-owner', 'request-collab-child', 'OWNER_PROMPT');
+
+    try {
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'collab-spawn-model', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: {
+            'x-client-request-id': 'request-collab-child',
+            'x-openai-subagent': 'collab_spawn',
+            'x-codex-parent-thread-id': 'thread-collab-parent',
+          },
+        },
+      ));
+
+      expect(decision).toEqual({ localHandler: expect.any(Function) });
+      expect(host.registerChildThread('thread-collab-parent', 'request-collab-child')).toBe(false);
+    } finally {
+      host.unregister('session-collab-parent');
+      host.unregister('session-request-owner');
+    }
+  });
+
+  it('keeps an already-owned collab_spawn child on its existing session route', async () => {
+    const host = await freshCodexProxyHost();
+    const { buildUserProvider } = await import('@cindy/model-providers');
+    const { setCustomProviders } = await import('../active-catalog.js');
+    const { setCustomProviderKeyReader } = await import('../provider-route.js');
+    const { setSessionProvider, clearSessionProvider } = await import('../session-provider-store.js');
+    setCustomProviders([
+      buildUserProvider({
+        id: 'collab-parent-provider',
+        name: 'Collab Parent Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://collab-parent.invalid/v1',
+            models: [{ id: 'shared-collab-model', name: 'Shared Collab Model' }],
+          },
+        },
+      }),
+      buildUserProvider({
+        id: 'collab-owner-provider',
+        name: 'Collab Owner Provider',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://collab-owner.invalid/v1',
+            models: [{ id: 'shared-collab-model', name: 'Shared Collab Model' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader((providerId) => `test-invalid-${providerId}-key`);
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-collab-parent', 'thread-collab-parent', 'PARENT_PROMPT');
+    host.registerComposed('session-collab-owner', 'thread-collab-owned', 'OWNER_PROMPT');
+    setSessionProvider('session-collab-parent', 'collab-parent-provider');
+    setSessionProvider('session-collab-owner', 'collab-owner-provider');
+    host.setCodexProxyAuthInjection('env-key');
+
+    try {
+      const decision = await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'shared-collab-model', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: {
+            'thread-id': 'thread-collab-owned',
+            'x-openai-subagent': 'collab_spawn',
+            'x-codex-parent-thread-id': 'thread-collab-parent',
+          },
+        },
+      ));
+
+      expect(decision).toEqual({
+        upstreamOverride: 'https://collab-owner.invalid/v1',
+        headerOverride: { authorization: 'Bearer test-invalid-collab-owner-provider-key' },
+        headerDelete: ['chatgpt-account-id', 'openai-beta', 'originator', 'session_id'],
+      });
+      expect(mockState.capturedRegistry?.get('thread-collab-owned')).toBe('OWNER_PROMPT');
+    } finally {
+      host.unregister('session-collab-parent');
+      host.unregister('session-collab-owner');
+      clearSessionProvider('session-collab-parent');
+      clearSessionProvider('session-collab-owner');
+      setCustomProviderKeyReader(() => null);
+      setCustomProviders([]);
+    }
+  });
+
+  const rejectedLazyInheritanceRequests: Array<{
+    name: string;
+    childThreadId: string;
+    headers: Readonly<Record<string, string>>;
+  }> = [
+    {
+      name: 'non-spawn request',
+      childThreadId: 'thread-review-child',
+      headers: {
+        'thread-id': 'thread-review-child',
+        'x-openai-subagent': 'review',
+        'x-codex-parent-thread-id': 'thread-collab-parent',
+      },
+    },
+    {
+      name: 'request id without a thread id',
+      childThreadId: 'request-collab-child',
+      headers: {
+        'x-client-request-id': 'request-collab-child',
+        'x-openai-subagent': 'collab_spawn',
+        'x-codex-parent-thread-id': 'thread-collab-parent',
+      },
+    },
+  ];
+
+  it.each(rejectedLazyInheritanceRequests)(
+    'does not lazily inherit the parent for a $name',
+    async ({ childThreadId, headers }) => {
+      const host = await freshCodexProxyHost();
+      mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+        url: 'http://127.0.0.1:43210',
+        dispose: vi.fn(async () => undefined),
+      });
+      await host.ensureCodexProxyReady();
+      host.registerComposed('session-collab-parent', 'thread-collab-parent', 'PARENT_PROMPT');
+
+      try {
+        await Promise.resolve(host.createModelRoutingTransform()(
+          { model: 'gpt-5.6', input: [] },
+          { reqId: 1, method: 'POST', url: '/responses', headers },
+        ));
+
+        expect(mockState.capturedRegistry?.get(childThreadId)).toBeUndefined();
+      } finally {
+        host.unregister('session-collab-parent');
+      }
+    },
+  );
+
+  it('does not register a Guardian request as a prompt-inheriting child thread', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:43210',
+      dispose: vi.fn(async () => undefined),
+    });
+    await host.ensureCodexProxyReady();
+    host.registerComposed('session-guardian-parent', 'thread-guardian-parent', 'PRODUCT_PROMPT');
+
+    try {
+      await Promise.resolve(host.createModelRoutingTransform()(
+        { model: 'codex-auto-review', input: [] },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: {
+            'thread-id': 'thread-guardian-child',
+            'x-openai-subagent': 'guardian',
+            'x-codex-parent-thread-id': 'thread-guardian-parent',
+          },
+        },
+      ));
+
+      expect(mockState.capturedRegistry?.get('thread-guardian-child')).toBeUndefined();
+    } finally {
+      host.unregister('session-guardian-parent');
+    }
+  });
+
   it('does not overwrite a child thread that is already owned by another session', async () => {
     const host = await freshCodexProxyHost();
     host.registerComposed('session-parent', 'thread-parent', 'PARENT_PROMPT');

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -87,6 +87,8 @@ const httpRecoveryReasonByThread = new Map<string, string>();
 
 const CODEX_AUTO_REVIEW_MODEL = 'codex-auto-review';
 const CODEX_GUARDIAN_SUBAGENT = 'guardian';
+const CODEX_COLLAB_SPAWN_SUBAGENT = 'collab_spawn';
+const CODEX_COLLAB_ROUTE_UNAVAILABLE_CODE = 'cindy_codex_parent_route_unavailable';
 
 let _handle: ProxyHandle | null = null;
 let _startPromise: Promise<void> | null = null;
@@ -242,12 +244,53 @@ function guardianParentThreadIdFromHeaders(
   return headerValue(headers, 'x-codex-parent-thread-id');
 }
 
+function isCollabSpawnRequest(headers: Readonly<Record<string, string>>): boolean {
+  return headerValue(headers, 'x-openai-subagent').toLowerCase() === CODEX_COLLAB_SPAWN_SUBAGENT;
+}
+
 function sessionIdFromHeaders(
   headers: Readonly<Record<string, string>>,
 ): string | undefined {
   const parentThreadId = guardianParentThreadIdFromHeaders(headers);
   if (parentThreadId) return threadToSession.get(parentThreadId);
-  return threadToSession.get(selectedThreadIdFromHeaders(headers));
+
+  const collabSpawn = isCollabSpawnRequest(headers);
+  const selectedThreadId = collabSpawn
+    ? headerValue(headers, 'thread-id')
+    : selectedThreadIdFromHeaders(headers);
+  const existingSessionId = threadToSession.get(selectedThreadId);
+  if (existingSessionId) return existingSessionId;
+
+  // Codex can send a spawned child's first request before thread/started reaches
+  // the host. Only that explicit spawn request may lazily inherit its parent;
+  // request ids and unrelated parent headers are not stable thread identities.
+  if (!collabSpawn) {
+    return undefined;
+  }
+  const childThreadId = selectedThreadId;
+  const collabParentThreadId = headerValue(headers, 'x-codex-parent-thread-id');
+  if (!childThreadId || !collabParentThreadId) return undefined;
+
+  registerChildThread(collabParentThreadId, childThreadId);
+  return threadToSession.get(childThreadId);
+}
+
+function unresolvedCollabSpawnRouteDecision(): RoutingDecision {
+  return {
+    localHandler: async ({ res }) => {
+      res.writeHead(503, {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      });
+      res.end(JSON.stringify({
+        error: {
+          type: 'server_error',
+          code: CODEX_COLLAB_ROUTE_UNAVAILABLE_CODE,
+          message: 'Cindy could not resolve the parent Provider route for this spawned Codex agent.',
+        },
+      }));
+    },
+  };
 }
 
 function safeDumpName(threadId: string): string {
@@ -2102,6 +2145,9 @@ export function createModelRoutingTransform(
       requestModel;
     const threadId = selectedThreadIdFromHeaders(ctx.headers);
     const sessionId = sessionIdFromHeaders(ctx.headers);
+    if (!sessionId && isCollabSpawnRequest(ctx.headers)) {
+      return unresolvedCollabSpawnRouteDecision();
+    }
     const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
     const selectedRouting = sessionId
       ? getSessionRoutingDescriptor(sessionId, 'codex', model || undefined)
@@ -2569,7 +2615,8 @@ export function registerReviewerRouteContext(
 
 /**
  * 让 Codex 子 Agent thread 继承父 thread 的业务 session、桥接路由和产品 prompt。
- * app-server 的 thread/started 通知在子 thread 首个请求前同步调用这里。
+ * app-server 的 thread/started 通知和子 thread 首个 collab_spawn 请求都可以
+ * 幂等地调用这里，避免两者乱序时丢失路由。
  */
 export function registerChildThread(parentThreadId: string, childThreadId: string): boolean {
   if (!parentThreadId || !childThreadId || parentThreadId === childThreadId) return false;


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 原生 `spawn_agent` 启动子线程时，首个 `/responses` 请求可能早于 `thread/started` 通知到达 Desktop host。这个乱序窗口会让 child thread 暂时没有 Cindy session 归属，从而丢失父会话的自定义 Provider 路由并回落到默认 Gateway。

本 PR 让代理在严格识别到 `x-openai-subagent: collab_spawn`、真实 `thread-id` 和 `x-codex-parent-thread-id` 时，幂等地复用现有 `registerChildThread()` 建立子线程归属。已归属其他 Cindy session 的 child 不会被覆盖，`x-client-request-id` 不作为 child 身份。无法建立可信父路由时返回明确的 `cindy_codex_parent_route_unavailable`，不再静默回落。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1569
- 本 PR 包含：Desktop Codex loopback proxy 的 `collab_spawn` 父路由惰性继承、fail-closed 错误，以及时序/跨会话/身份边界回归测试。
- 明确不包含：模型映射、Provider 配置、wire protocol、system prompt 文本或任何 UI 改动。
- 用户可见变化：自定义 Responses Provider 下的原生子代理从首请求起正确工作；父路由不可信时显示明确路由错误，而非无关的“模型不存在”。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/codexProxyHost.test.ts
结果：139/139 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：根仓完整 unit tier 通过。

PATH=/tmp/cindy-node22.VeC1Eu/node-v22.23.2-darwin-arm64/bin:$PATH \
pnpm package:desktop -- --platform=darwin --arch=arm64
结果：完整 macOS arm64 本地打包通过；DB migration validate、Vite / Electron Forge、drizzle packaged 校验、packaged smoke 与 ad-hoc 签名均通过。
产物：apps/desktop/release/artifacts/global/unversioned/darwin-arm64/cindy-unversioned-arm64.zip
SHA256：b28b32379342a94d86ac12c5be3e172d6d951dfbd266362d7057b039565e5309
```

回归用例覆盖：

- 首个 `collab_spawn` 请求早于 `thread/started` 时，继承父 session 的自定义 Responses Provider、假 key 和产品 prompt。
- 子线程已由另一 Cindy session 拥有时不覆盖。
- 非 `collab_spawn`、缺少真实 `thread-id`、仅 `x-client-request-id` 或 Guardian 请求不发生错误继承。
- 父路由无法解析时返回 503 + `cindy_codex_parent_route_unavailable`。

### 手工验证

- macOS 上当前已安装、未包含补丁的 Cindy 中，原生 reviewer/subagent 分别显式使用 `gpt-5.6-sol` 和 `gpt-5.6-terra` 均复现同一 `Invalid model name` 回落错误。
- 已从 PR 精确 commit `9aaf1992be8278059243dc9c840c9d03e985ba6e` 启动 Global Desktop 隔离实例（独立 userData，未读取或复制正式 profile / Provider 凭证）；`pnpm desktop:whoami --all` 确认运行实例源码与 checkout 匹配，main / renderer 启动正常。
- 完整打包必须使用仓库要求的 Node 22；本机 Node 26 下 Electron Forge 产物缺失 drizzle，切换 Node `v22.23.2` 后所有 packaged 校验通过，该环境差异不属于本 PR 代码回归。

### 真实父/子/孙链路验证

- 从 PR 精确 commit `9aaf1992be8278059243dc9c840c9d03e985ba6e` 启动隔离 Desktop，并使用仅存在于该隔离 profile 的本地 fake Responses Provider；使用明显无效的测试 key，未读取或复制正式凭据。
- Parent thread `019fcb0b-5102-7d90-9c59-69b344cb5f05` 显式以 `model: gpt-5.6-sol`、`reasoning_effort: low`、`fork_turns: none` 调用原生 `spawn_agent`。
- Child thread `019fcb0b-5242-70c3-8355-6cd6e1127fca` 首请求直接命中同一 fake Provider，并在不传 `model` 的情况下继续 spawn grandchild；grandchild thread 为 `019fcb0b-5297-7ff1-b03a-3eae9261cc56`。
- 三层 `/responses` 请求的 model 均为 `gpt-5.6-sol`、鉴权均命中 fake key；child / grandchild 均带 `x-openai-subagent: collab_spawn`，且 `x-codex-parent-thread-id` 分别正确指向 parent / child。
- Desktop 日志记录了两次 `registered codex child thread route`，三层均完成并返回 `PARENT_DONE` / `CHILD_DONE` / `GRANDCHILD_DONE`；本次新链路未出现 `Invalid model name` 或 `cindy_codex_parent_route_unavailable`。

### 未执行的验证

- 未在 Windows 实机启动 UI；PR CI 的 Windows 两个 unit 分片和汇总检查均已通过。本次仅修改 HTTP header 解析与进程内 Map 绑定，不依赖平台 API。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 本地 Codex loopback proxy 中的原生 `collab_spawn` 请求。SSH 远程工作区的 agent 进程不经过本地 proxy，行为不变；设备互联/手机只是控制 Desktop 会话，会自动复用同一修复后的 Desktop 执行路径，不需要新 IPC、allowlist 或 Mobile UI 改动。
- 核心指标：不改 prompt 文本、拼接顺序、tool/MCP 或 usage 计量逻辑；只在乱序路径的首个 child 请求中恢复原本应继承的稳定产品 prompt，因此该请求的 input token 会包含以前被错误遗漏的部分；缓存前缀字节与正常 `thread/started` 顺序一致。热路径只新增若干 Map 查找/绑定，无 I/O、网络往返或持久化。
- 回滚 / 降级方式：revert 本 PR 的单一 commit，恢复原有路由行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

