### PR TITLE
fix: 把「审阅器不可用」与「模型判定危险」拆开，前者提示一次

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -92,6 +92,7 @@ vi.mock('electron', () => ({
 vi.mock('@cindy/maker-core', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@cindy/maker-core')>();
   return {
+    isAutoReviewUnavailableNotice: actual.isAutoReviewUnavailableNotice,
     isTerminalAgentErrorEvent: actual.isTerminalAgentErrorEvent,
     parseOverloadError: actual.parseOverloadError,
     parseOverloadRetryProgress: actual.parseOverloadRetryProgress,

--- a/apps/desktop/src/main/im/shared/__tests__/turnRetryNotice.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRetryNotice.test.ts
@@ -198,6 +198,32 @@ describe('terminalErrorText', () => {
     expect(terminalErrorText({})).toBe('[object Object]');
   });
 
+  /**
+   * Auto 档审阅器故障同样走非终止 error。渠道侧原来对这类一律静默 —— Slack /
+   * Telegram 上的用户只看到工具接连被拒、没有原因(codex P1 of #1574)。
+   */
+  it('Auto 档审阅器不可用 → 渠道侧说明 + 可执行动作', () => {
+    const notice = turnRetryNotice({
+      message: '[AUTO_REVIEW_UNAVAILABLE] Auto-review is temporarily unavailable, so actions '
+        + 'that need review are being denied. Switch this task to Default permissions if you '
+        + 'want to approve them yourself.',
+      isTerminal: false,
+    });
+    expect(notice).toContain('自动审批暂时不可用');
+    // 必须给出用户能做的事,否则等于只说"又失败了"。
+    expect(notice).toContain('默认权限');
+    // 不得把 [CODE] 前缀或英文原文推给渠道用户。
+    expect(notice).not.toContain('AUTO_REVIEW_UNAVAILABLE');
+    expect(notice).not.toContain('Auto-review is temporarily');
+  });
+
+  it('其它带 bracket code 的非终止 error 仍保持静默', () => {
+    // 只放开有明确渠道文案的那一条,不是所有 [CODE] 都外发。
+    expect(turnRetryNotice({
+      message: '[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] Local attachments are not accessible.',
+    })).toBeNull();
+  });
+
   it('message 为 undefined / null 时不得把字面量 "undefined" 给用户看', () => {
     // 判 key 是否存在('message' in record)会让 message: undefined 也走进去, String() 出
     // 字面量 "undefined"; 过载文案映射也会跟着取决于这个意外字符串(copilot 低置信提示)。

--- a/apps/desktop/src/main/im/shared/turnRetryNotice.ts
+++ b/apps/desktop/src/main/im/shared/turnRetryNotice.ts
@@ -17,8 +17,8 @@
  * currentTurnProducedOutput 守卫), 于是那段退避窗口(交互式约 22-38s)里过程区
  * 与正文都是空的, 渠道那条占位消息一个字都不变 —— 用户看到的就是"卡死了"。
  *
- * 只认已有本地化契约的过载与终态 429 外层重投；其它非终止 error(普通 429 /
- * 5xx / 网络重连等)保持既有静默行为:
+ * 只认已有本地化契约的过载、终态 429 外层重投与 Auto 档审阅器不可用；其它非终止
+ * error(普通 429 / 5xx / 网络重连等)保持既有静默行为:
  * 它们的 message 是内部英文串, 渠道侧没有对应的中文表达, 贸然透出等于把裸英文
  * 推给用户(这也是 maker-core 侧 claude translator 只透过载类的同一条理由)。
  * 将来要放开某一类, 在这里按 kind 补一条文案即可, 不要直接外发原文。
@@ -29,10 +29,27 @@
  */
 
 import {
+  isAutoReviewUnavailableNotice,
   parseOverloadError,
   parseOverloadRetryProgress,
   parseTerminalRateLimitRetryProgress,
 } from '@cindy/maker-core';
+
+/**
+ * Auto 档「自动审批不可用」-> 渠道说明。
+ *
+ * 这不是自动重试,但同样是**非终止** error 携带的会话级状态,渠道侧此前对非终止 error
+ * 一律静默 —— 于是 Slack / Telegram 上的用户只会看到工具一个接一个被拒、没有任何原因
+ * (codex P1 of #1574)。它有明确的用户动作可给(切到默认权限自己确认),所以必须透出。
+ *
+ * 判据走 maker-core 的单点函数,不在这里匹配英文原文或自己拼 `[CODE]` 前缀;文案硬编码
+ * 中文、不进 renderer locale(与本文件其它渠道文案同规)。
+ */
+function autoReviewUnavailableNotice(message: string): string | null {
+  return isAutoReviewUnavailableNotice(message)
+    ? '自动审批暂时不可用，需要审批的操作会被拒绝。想自己确认这些操作，可以把这个任务切到「默认权限」。'
+    : null;
+}
 
 /** 已知的非终止自动重试事件 -> 渠道侧本地化进度；其它错误保持静默。 */
 export function turnRetryNotice(data: unknown): string | null {
@@ -40,6 +57,8 @@ export function turnRetryNotice(data: unknown): string | null {
   const record = data as { message?: unknown; reason?: unknown };
   const message = typeof record.message === 'string' ? record.message : '';
   const reason = typeof record.reason === 'string' ? record.reason : undefined;
+  const autoReviewNotice = autoReviewUnavailableNotice(message);
+  if (autoReviewNotice) return autoReviewNotice;
   const rateLimitProgress = parseTerminalRateLimitRetryProgress(message, reason);
   if (rateLimitProgress) {
     return `请求受到限流，正在自动重试（${rateLimitProgress.attempt}/${rateLimitProgress.maxAttempts}）…`;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -27,7 +27,6 @@ import type {
   SessionSendResult,
   UserMessage,
 } from '@cindy/maker-core';
-import { isAutoReviewUnavailableNotice } from '@cindy/maker-core';
 import { createId } from '@paralleldrive/cuid2';
 import { redactSensitiveText } from '@cindy/maker-shared/error-redaction';
 import { permissionModeOrAsk } from '@cindy/maker-shared/permission-mode';
@@ -3534,23 +3533,6 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           });
         } catch { /* non-fatal */ }
       })();
-    }
-    // 「自动审批不可用」提示要留在时间线上。它是**非终止** error,因此不进上面那个
-    // done/terminal 持久化块 —— 而 renderer 的 handleStreamEvent 会在下一条非 error
-    // 事件(text / tool_result / status …)到达时清掉 recoverableError,harness 侧的
-    // 会话级一次性门又阻止它重现:两者叠加等于用户可能一眼都没看到就没了
-    // (codex P1 of #1574)。所以单独落一条持久 error 行,由消息流的 ErrorMessageCard
-    // 承载。判据走 maker-core 的单点函数,不在这里拼 `[CODE]` 前缀。
-    if (
-      event.type === 'error' &&
-      !isTerminalTurnErrorEvent(event) &&
-      isAutoReviewUnavailableNotice((attributedEvent.data as { message?: unknown } | null)?.message)
-    ) {
-      onTurnErrorEvent(
-        session.id,
-        attributedEvent.data as { message?: unknown; reason?: unknown; sdkError?: unknown } | null,
-        eventAgentMeta,
-      );
     }
     if (pendingContextSnapshot) {
       recordSessionContextSnapshot(

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -27,6 +27,7 @@ import type {
   SessionSendResult,
   UserMessage,
 } from '@cindy/maker-core';
+import { isAutoReviewUnavailableNotice } from '@cindy/maker-core';
 import { createId } from '@paralleldrive/cuid2';
 import { redactSensitiveText } from '@cindy/maker-shared/error-redaction';
 import { permissionModeOrAsk } from '@cindy/maker-shared/permission-mode';
@@ -3533,6 +3534,23 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           });
         } catch { /* non-fatal */ }
       })();
+    }
+    // 「自动审批不可用」提示要留在时间线上。它是**非终止** error,因此不进上面那个
+    // done/terminal 持久化块 —— 而 renderer 的 handleStreamEvent 会在下一条非 error
+    // 事件(text / tool_result / status …)到达时清掉 recoverableError,harness 侧的
+    // 会话级一次性门又阻止它重现:两者叠加等于用户可能一眼都没看到就没了
+    // (codex P1 of #1574)。所以单独落一条持久 error 行,由消息流的 ErrorMessageCard
+    // 承载。判据走 maker-core 的单点函数,不在这里拼 `[CODE]` 前缀。
+    if (
+      event.type === 'error' &&
+      !isTerminalTurnErrorEvent(event) &&
+      isAutoReviewUnavailableNotice((attributedEvent.data as { message?: unknown } | null)?.message)
+    ) {
+      onTurnErrorEvent(
+        session.id,
+        attributedEvent.data as { message?: unknown; reason?: unknown; sdkError?: unknown } | null,
+        eventAgentMeta,
+      );
     }
     if (pendingContextSnapshot) {
       recordSessionContextSnapshot(

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6046,6 +6046,7 @@
     "remoteError": {
       "REMOTE_DAEMON_CLOSED": "Remote connection interrupted (the daemon may be upgrading or restarting). The turn has ended — please resend.",
       "REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED": "Local file/image attachments aren't accessible in remote sessions. Paste the content directly instead.",
+      "AUTO_REVIEW_UNAVAILABLE": "Auto-review is temporarily unavailable, so actions that need review are being denied. Switch this task to Default permissions if you want to approve them yourself.",
       "REMOTE_COMPAT_MODE_UNSUPPORTED": "Remote Claude Code sessions can't route through the local compat proxy (internal error).",
       "REMOTE_GATEWAY_ENDPOINT_UNAVAILABLE": "Cindy AI credentials are not ready yet (issued automatically after sign-in). Please retry shortly; if this persists, check the Cindy AI status in Settings → Model Providers.",
       "DEVICE_LINK_CONTROL_DISABLED": "Control for this device is off; the message was not sent.",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6044,6 +6044,7 @@
     "remoteError": {
       "REMOTE_DAEMON_CLOSED": "リモート接続が中断されました（daemon がアップグレードまたは再起動中の可能性があります）。ターンが終了しました — 再送信してください。",
       "REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED": "リモートセッションではローカルのファイル/画像の添付にアクセスできません。内容を直接貼り付けてください。",
+      "AUTO_REVIEW_UNAVAILABLE": "自動レビューが一時的に利用できないため、レビューが必要な操作は拒否されます。ご自身で承認する場合は、このセッションをデフォルト権限に切り替えてください。",
       "REMOTE_COMPAT_MODE_UNSUPPORTED": "リモート Claude Code セッションはローカル互換プロキシ経由でルーティングできません(内部エラー)。",
       "REMOTE_GATEWAY_ENDPOINT_UNAVAILABLE": "Cindy AI の資格情報がまだ準備できていません(サインイン後に自動発行されます)。しばらくしてから再試行してください。続く場合は 設定 → モデルプロバイダー で Cindy AI の接続状態を確認してください。",
       "DEVICE_LINK_CONTROL_DISABLED": "このデバイスの操作はオフです。メッセージは送信されていません。",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6044,6 +6044,7 @@
     "remoteError": {
       "REMOTE_DAEMON_CLOSED": "원격 연결이 중단되었습니다(daemon이 업그레이드 또는 재시작 중일 수 있습니다). 턴이 종료되었습니다 — 다시 전송하세요.",
       "REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED": "원격 세션에서는 로컬 파일/이미지 첨부에 접근할 수 없습니다. 내용을 직접 붙여넣으세요.",
+      "AUTO_REVIEW_UNAVAILABLE": "자동 리뷰를 일시적으로 사용할 수 없어 검토가 필요한 작업이 거부됩니다. 직접 승인하려면 이 세션을 기본 권한으로 전환하세요.",
       "REMOTE_COMPAT_MODE_UNSUPPORTED": "원격 Claude Code 세션은 로컬 호환 프록시를 통해 라우팅할 수 없습니다(내부 오류).",
       "REMOTE_GATEWAY_ENDPOINT_UNAVAILABLE": "Cindy AI 자격 증명이 아직 준비되지 않았습니다(로그인 후 자동 발급됩니다). 잠시 후 다시 시도해 주세요. 계속되면 설정 → 모델 제공자에서 Cindy AI 연결 상태를 확인하세요.",
       "DEVICE_LINK_CONTROL_DISABLED": "이 기기의 제어가 꺼져 있어 메시지가 전송되지 않았습니다.",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6044,6 +6044,7 @@
     "remoteError": {
       "REMOTE_DAEMON_CLOSED": "远端连接已中断（daemon 可能正在升级或重启）。本轮已结束 — 请重新发送。",
       "REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED": "远端任务无法访问本地文件/图片附件。请直接粘贴内容。",
+      "AUTO_REVIEW_UNAVAILABLE": "自动审批暂时不可用，需要审批的操作会被拒绝。想自己确认这些操作，可以把任务切到「默认权限」。",
       "REMOTE_COMPAT_MODE_UNSUPPORTED": "远端 Claude Code 会话无法通过本地兼容 Proxy 路由(内部错误，请反馈)。",
       "REMOTE_GATEWAY_ENDPOINT_UNAVAILABLE": "Cindy AI 凭据尚未就绪(登录后由服务端自动下发)。请稍候重试；若持续出现，请到 设置 → 模型供应商 检查 Cindy AI 连接状态。",
       "DEVICE_LINK_CONTROL_DISABLED": "已关闭对该设备的控制，消息未发送。",

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -162,6 +162,15 @@ const DEVICE_LINK_CHAT_ERROR_CODES: ReadonlySet<string> = new Set([
   'DEVICE_LINK_CONTROL_DISABLED',
   'DEVICE_LINK_MEDIA_TRANSFER_FAILED',
 ] as const);
+/**
+ * 非 `REMOTE_*` / 非 device-link 的会话级提示码 —— agent runtime 用同一套
+ * `[CODE] fallback text` 约定把「这件事用户该知道」告诉 renderer,不新增事件类型。
+ * 未登记的 code 仍然回退到英文兜底文案(绝不把 `[CODE]` 裸露给用户)。
+ */
+const AGENT_RUNTIME_CHAT_ERROR_CODES: ReadonlySet<string> = new Set([
+  // Auto 档下审阅器没跑起来(与「模型判定动作危险」不同,后者刻意保持静默)。
+  'AUTO_REVIEW_UNAVAILABLE',
+] as const);
 const REMOTE_HEAVY_INBOUND_CHANNELS: ReadonlySet<string> = new Set([
   'maker:event',
   'maker:status-changed',
@@ -193,7 +202,11 @@ function resolveEstimatedTurnCostUsd(
 export function decodeRemoteErrorMessage(msg: string): string {
   const bracketMatch = BRACKET_ERROR_CODE_RE.exec(msg);
   const bracketCode = bracketMatch?.[1];
-  if (bracketCode && DEVICE_LINK_CHAT_ERROR_CODES.has(bracketCode)) {
+  if (
+    bracketCode
+    && (DEVICE_LINK_CHAT_ERROR_CODES.has(bracketCode)
+      || AGENT_RUNTIME_CHAT_ERROR_CODES.has(bracketCode))
+  ) {
     return i18n.t(`chat.remoteError.${bracketCode}`, {
       defaultValue: bracketMatch[2] || msg,
     });

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -463,6 +463,38 @@ describe('Auto-review wiring: reviewer outages surface once per session', () => 
     await handle.close();
   });
 
+  /**
+   * 裁决缓存的 key 不含 permissionMode。用户切离 Auto、等审阅器恢复、再切回 Auto 时,
+   * 同一个动作会命中先前那条 `unavailable` block —— 审阅器早就好了,动作还是被拒
+   * (greptile P1 of #1574)。切档必须连缓存一起清。
+   */
+  it('drops cached unavailable verdicts when the permission mode changes', async () => {
+    let reviewerBroken = true;
+    const reviewer = vi.fn(async () => {
+      if (reviewerBroken) throw new Error('reviewer offline');
+      return { verdict: 'allow' as const };
+    });
+    const { handle, canUseTool } = await startSession('auto', {
+      reviewer,
+      attachResolver: false,
+    });
+
+    const sameAction = { file_path: '/tmp/cached.conf' };
+    const denied = await canUseTool('Write', sameAction, { toolUseID: 'cache-1' });
+    expect(denied.behavior).toBe('deny');
+
+    // 用户接管 → 审阅器恢复 → 切回 Auto。
+    await handle.setPermissionMode?.('ask');
+    reviewerBroken = false;
+    await handle.setPermissionMode?.('auto');
+
+    const allowed = await canUseTool('Write', sameAction, { toolUseID: 'cache-2' });
+    expect(allowed.behavior).toBe('allow');
+    // 缓存真的清了才会有第二次 reviewer 调用。
+    expect(reviewer).toHaveBeenCalledTimes(2);
+    await handle.close();
+  });
+
   it('re-arms the notice after the user changes the permission mode', async () => {
     const { handle, canUseTool } = await startSession('auto', {
       reviewer: async () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -495,6 +495,32 @@ describe('Auto-review wiring: reviewer outages surface once per session', () => 
     await handle.close();
   });
 
+  /**
+   * ErrorBanner 那份提示只活到下一条非 error 事件(renderer 的 handleStreamEvent 会清
+   * recoverableError),所以「整个会话只说一次」会让用户在后续轮次里完全看不到。每轮
+   * 至多一条:不刷屏,又保证每一轮遇到时都有机会看见。
+   */
+  it('re-arms the notice on each new user turn', async () => {
+    const { handle, canUseTool } = await startSession('auto', {
+      reviewer: async () => {
+        throw new Error('reviewer offline');
+      },
+      attachResolver: false,
+    });
+    const { notices } = startNoticeCollector(handle);
+
+    await canUseTool('Write', { file_path: '/tmp/t1.conf' }, { toolUseID: 'turn1-a' });
+    await canUseTool('Write', { file_path: '/tmp/t2.conf' }, { toolUseID: 'turn1-b' });
+    await settle();
+    expect(notices).toHaveLength(1); // 同一轮内两次被拒 → 仍只一条
+
+    await handle.send({ type: 'user', content: 'Try something else then.' });
+    await canUseTool('Write', { file_path: '/tmp/t3.conf' }, { toolUseID: 'turn2-a' });
+    await settle();
+    expect(notices).toHaveLength(2); // 新一轮 → 重新武装
+    await handle.close();
+  });
+
   it('re-arms the notice after the user changes the permission mode', async () => {
     const { handle, canUseTool } = await startSession('auto', {
       reviewer: async () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -327,6 +327,101 @@ describe('Auto-review wiring: lightweight reviewer controls gray actions', () =>
   });
 });
 
+/**
+ * 「审阅器不可用」要在会话里说一次(issue #1574)。
+ *
+ * 以前 delegate 缺失 / 超时 / 抛错和「模型判定动作危险」在上层都是同一个 `block`,
+ * UI 层零呈现 —— 用户看到的是「工具一直被拒、没有弹窗、重启无效」,却拿不到任何原因。
+ * 现在前者额外发一条会话级**一次性**提示(走既有的非终止 error 事件 + `[CODE]` 约定),
+ * 动作本身仍然 deny,安全边界不变。
+ */
+describe('Auto-review wiring: reviewer outages surface once per session', () => {
+  /**
+   * 单一后台消费者收集会话级提示(非终止 error)。
+   *
+   * 事件流是**单消费者** AsyncQueue:如果改用「每次断言时新建 iterator + 超时丢弃」的
+   * 写法,被超时丢弃的那个 pending `next()` 仍挂在 waiters 里,下一条 push 会被它吃掉,
+   * 断言就会莫名少一条。所以整个用例只订阅一次。
+   */
+  function startNoticeCollector(
+    handle: { events(): AsyncIterable<{ type: string; data?: { message?: unknown } }> },
+  ) {
+    const notices: string[] = [];
+    // 刻意不返回这个 promise:fakeQuery 的消息流永远挂起,forward loop 不退出,close()
+    // 之后事件流也不会 end —— await 它就是等到测试超时。收集器随测试进程一起结束。
+    void (async () => {
+      for await (const event of handle.events()) {
+        if (event.type === 'error' && typeof event.data?.message === 'string') {
+          notices.push(event.data.message);
+        }
+      }
+    })().catch(() => {
+      /* 队列在 teardown 时被丢弃,不是测试失败 */
+    });
+    return { notices };
+  }
+
+  /** 让 push 进队列的事件 fan-out 到收集器。 */
+  const settle = () => new Promise((resolve) => setTimeout(resolve, 10));
+
+  it('emits one notice for a broken reviewer, not one per blocked action', async () => {
+    // reviewer 抛错 = resolveAutoReviewDecision 走 unavailable 兜底 block。
+    const { handle, canUseTool } = await startSession('auto', {
+      reviewer: async () => {
+        throw new Error('reviewer offline');
+      },
+      attachResolver: false,
+    });
+    const { notices } = startNoticeCollector(handle);
+
+    const first = await canUseTool('Write', { file_path: '/tmp/a.conf' }, { toolUseID: 'n1' });
+    const second = await canUseTool('Write', { file_path: '/tmp/b.conf' }, { toolUseID: 'n2' });
+    expect(first.behavior).toBe('deny');
+    expect(second.behavior).toBe('deny');
+    await settle();
+
+    // 两次都被拒,但只说一次 —— 逐条提示会把 Auto 退化成比 Ask 更烦的东西。
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain('[AUTO_REVIEW_UNAVAILABLE]');
+    await handle.close();
+  });
+
+  it('stays silent when the model itself blocks the action', async () => {
+    const { handle, canUseTool } = await startSession('auto', { reviewVerdict: 'block' });
+    const { notices } = startNoticeCollector(handle);
+
+    const result = await canUseTool('Bash', { command: 'npm install left-pad' }, { toolUseID: 'n3' });
+    expect(result).toMatchObject({ behavior: 'deny', message: 'reviewed' });
+    await settle();
+
+    // 模型判定的 block 按 Auto 本意保持静默 —— 只把 reason 喂给模型,不打扰用户。
+    expect(notices).toHaveLength(0);
+    await handle.close();
+  });
+
+  it('re-arms the notice after the user changes the permission mode', async () => {
+    const { handle, canUseTool } = await startSession('auto', {
+      reviewer: async () => {
+        throw new Error('reviewer offline');
+      },
+      attachResolver: false,
+    });
+    const { notices } = startNoticeCollector(handle);
+
+    await canUseTool('Write', { file_path: '/tmp/c.conf' }, { toolUseID: 'n4' });
+    await settle();
+    expect(notices).toHaveLength(1);
+
+    // 用户自己动过档位之后又回到 Auto、又不可用 → 有权再看到一次。
+    await handle.setPermissionMode?.('ask');
+    await handle.setPermissionMode?.('auto');
+    await canUseTool('Write', { file_path: '/tmp/d.conf' }, { toolUseID: 'n5' });
+    await settle();
+    expect(notices).toHaveLength(2);
+    await handle.close();
+  });
+});
+
 describe('Auto-review wiring: only affects the auto mode', () => {
   it('default mode does not apply the auto-review policy (safe shell still prompts)', async () => {
     const { handle, canUseTool, seen } = await startSession('default');

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1758,6 +1758,11 @@ export class ClaudeCodeAgent extends BaseAgent {
     const setAutoReviewIntent = (content: UserMessage['content']): void => {
       currentAutoReviewIntent = extractAutoReviewUserIntent(content);
       autoReviewDecisionCache.clear();
+    // 每条新用户消息 = 新一轮,提示重新武装。ErrorBanner 那份只活到下一条非 error 事件
+    // (renderer 的 handleStreamEvent 会清 recoverableError),所以「整个会话只说一次」
+    // 会让用户在后续轮次里完全看不到;改为每轮至多一条 —— 不刷屏,又保证每一轮遇到时
+    // 都有机会看见。持久呈现需要一条真正的会话级 notice 通道,见 issue 外推。
+      autoReviewUnavailableNotice.reset();
     };
     // 「自动审核不可用」的会话级一次性提示(issue #1574)。走既有的非终止 error 事件 +
     // `[CODE]` 约定,不新增事件类型;逐条提示会把 Auto 退化成比 Ask 更烦的东西,所以去重。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -107,6 +107,7 @@ import { normalizeBuiltinToolForAutoReview } from './auto-review-policy.js';
 import {
   composeAutoReviewIntentWithApprovedPlan,
   composeAutoReviewIntentWithClarification,
+  createAutoReviewUnavailableNotice,
   extractAutoReviewUserIntent,
   resolveAutoReviewDecision,
   type AutoReviewDecision,
@@ -1634,6 +1635,9 @@ export class ClaudeCodeAgent extends BaseAgent {
         } else if (!turnPolicyForcePrompt && autoDecision.verdict === 'allow') {
           return { behavior: 'allow', updatedInput: input };
         } else if (!turnPolicyForcePrompt && autoDecision.verdict === 'block') {
+          // 审阅器没跑起来 ≠ 模型判定危险:前者是基础设施故障,用户有权知道并接管,
+          // 后者按 Auto 本意保持静默(只把 reason 喂给模型)。动作两种都仍然 deny。
+          if (autoDecision.unavailable) autoReviewUnavailableNotice.notify();
           return {
             behavior: 'deny',
             message: autoDecision.reason ?? 'Cindy Auto Review blocked this action. Choose a safer alternative.',
@@ -1755,6 +1759,15 @@ export class ClaudeCodeAgent extends BaseAgent {
       currentAutoReviewIntent = extractAutoReviewUserIntent(content);
       autoReviewDecisionCache.clear();
     };
+    // 「自动审核不可用」的会话级一次性提示(issue #1574)。走既有的非终止 error 事件 +
+    // `[CODE]` 约定,不新增事件类型;逐条提示会把 Auto 退化成比 Ask 更烦的东西,所以去重。
+    const autoReviewUnavailableNotice = createAutoReviewUnavailableNotice((message) => {
+      eventQueue.push({
+        type: 'error',
+        data: { message, isTerminal: false },
+        source: 'claude-code',
+      });
+    });
     const reviewAutoAction = (
       action: ReviewableAction,
       workspaceRoots: string[],
@@ -2524,6 +2537,8 @@ export class ClaudeCodeAgent extends BaseAgent {
                 return { kind: 'permission', behavior: 'allow' };
               }
               if (!remoteTurnPolicyForcePrompt && autoDecision.verdict === 'block') {
+                // 与本地分支同口径:审阅器故障要提示一次,模型判定保持静默。
+                if (autoDecision.unavailable) autoReviewUnavailableNotice.notify();
                 return {
                   kind: 'permission',
                   behavior: 'deny',
@@ -4398,6 +4413,9 @@ export class ClaudeCodeAgent extends BaseAgent {
         );
         mutableModel = newModel;
         autoReviewDecisionCache.clear();
+        // 换模型 / 换路由可能正好修掉了审阅器不可用的原因(目录解析失败、provider 被停用
+        // 等);若换完又不可用,值得再提醒一次。
+        autoReviewUnavailableNotice.reset();
         if (
           !isControlBlocked
           && mutablePermissionMode === 'auto'
@@ -4485,6 +4503,9 @@ export class ClaudeCodeAgent extends BaseAgent {
       },
 
       async setPermissionMode(newMode) {
+        // 用户自己动过权限档之后,「自动审核不可用」这条一次性提示重新武装:再回到 Auto
+        // 又不可用时,他有权再看到一次(否则一个会话里只提示一次会显得像偶发)。
+        if (newMode !== mutablePermissionMode) autoReviewUnavailableNotice.reset();
         // 计划模式武装中 / 本轮 plan turn 进行中 SDK 恒在 plan 档: 只记录底层权限档
         // (循环收尾切回时生效), 不 push SDK、不动挂起交互(挂着的多半是 plan_review)。
         if (mutablePlanMode || planTurnActive) {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4505,7 +4505,14 @@ export class ClaudeCodeAgent extends BaseAgent {
       async setPermissionMode(newMode) {
         // 用户自己动过权限档之后,「自动审核不可用」这条一次性提示重新武装:再回到 Auto
         // 又不可用时,他有权再看到一次(否则一个会话里只提示一次会显得像偶发)。
-        if (newMode !== mutablePermissionMode) autoReviewUnavailableNotice.reset();
+        // 档位变了 → 连**裁决缓存**一起清。缓存 key 不含 permissionMode,切离 Auto 再切回时
+        // 会命中先前那条 `unavailable` block —— 审阅器早就恢复了,同一个动作还是被拒
+        // (greptile P1 of #1574)。一次性提示同步重新武装:用户既然接管过,之后又不可用
+        // 值得再提醒一次。
+        if (newMode !== mutablePermissionMode) {
+          autoReviewDecisionCache.clear();
+          autoReviewUnavailableNotice.reset();
+        }
         // 计划模式武装中 / 本轮 plan turn 进行中 SDK 恒在 plan 档: 只记录底层权限档
         // (循环收尾切回时生效), 不 push SDK、不动挂起交互(挂着的多半是 plan_review)。
         if (mutablePlanMode || planTurnActive) {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -82,6 +82,7 @@ import { createAsyncQueue, type AsyncQueue } from '../shared/async-queue.js';
 import {
   composeAutoReviewIntentWithApprovedPlan,
   composeAutoReviewIntentWithClarification,
+  createAutoReviewUnavailableNotice,
   extractAutoReviewUserIntent,
   resolveAutoReviewDecision,
   type AutoReviewDecision,
@@ -2781,6 +2782,15 @@ export class CodexAgent extends BaseAgent {
       currentAutoReviewIntent = extractAutoReviewUserIntent(content);
       autoReviewDecisionCache.clear();
     };
+    // 「自动审核不可用」的会话级一次性提示(issue #1574);与 Claude / Pi 同口径,走既有的
+    // 非终止 error 事件 + `[CODE]` 约定,不新增事件类型。
+    const autoReviewUnavailableNotice = createAutoReviewUnavailableNotice((message) => {
+      eventQueue.push({
+        type: 'error',
+        data: { message, isTerminal: false },
+        source: 'codex',
+      });
+    });
     /**
      * 用于**目录查找**的模型 id —— 与 mutableModel(送上游的 wire 值)刻意分开。
      *
@@ -4159,6 +4169,9 @@ export class CodexAgent extends BaseAgent {
         } else if (decision.verdict === 'allow') {
           return 'accept';
         } else if (decision.verdict === 'block') {
+          // 审阅器没跑起来 ≠ 模型判定危险:前者是基础设施故障,提示一次让用户能接管;
+          // 后者按 Auto 本意保持静默。动作两种都仍然 decline。
+          if (decision.unavailable) autoReviewUnavailableNotice.notify();
           return 'decline';
         } else {
           // Only red-line decisions reach the user and they cannot be remembered.
@@ -8653,6 +8666,7 @@ export class CodexAgent extends BaseAgent {
         if (newModel === mutableModel) {
           if (mutableProviderId !== prevProviderId) {
             autoReviewDecisionCache.clear();
+            autoReviewUnavailableNotice.reset();
             refreshCodexAutoReviewerRoute(threadId);
           }
           return;
@@ -8662,6 +8676,8 @@ export class CodexAgent extends BaseAgent {
         log.debug('setModel', { from: mutableModel, to: newModel, providerId: mutableProviderId ?? null });
         mutableModel = newModel;
         autoReviewDecisionCache.clear();
+        // 换模型 / 换路由可能正好修掉了审阅器不可用的原因;换完又不可用值得再提醒一次。
+        autoReviewUnavailableNotice.reset();
         // 用户显式选的一定是目录 id(选择器就是从目录渲染的)。
         mutableCatalogModel = newModel;
         try {
@@ -8698,6 +8714,8 @@ export class CodexAgent extends BaseAgent {
 
       async setPermissionMode(newMode: PermissionMode) {
         log.debug('setPermissionMode', { from: mutablePermissionMode, to: newMode });
+        // 用户自己动过权限档 → 一次性提示重新武装(与 Claude 同口径)。
+        if (newMode !== mutablePermissionMode) autoReviewUnavailableNotice.reset();
         // Full access 才能批量放行挂起的 ask。切到 Auto 时，已有请求不能绕过
         // reviewer / 人工降级审批，先 fail-closed 关闭；后续重试按当前路由能力
         // 选择 auto_review 或 user reviewer。

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2785,6 +2785,11 @@ export class CodexAgent extends BaseAgent {
     const setAutoReviewIntent = (content: UserMessage['content']): void => {
       currentAutoReviewIntent = extractAutoReviewUserIntent(content);
       autoReviewDecisionCache.clear();
+    // 每条新用户消息 = 新一轮,提示重新武装。ErrorBanner 那份只活到下一条非 error 事件
+    // (renderer 的 handleStreamEvent 会清 recoverableError),所以「整个会话只说一次」
+    // 会让用户在后续轮次里完全看不到;改为每轮至多一条 —— 不刷屏,又保证每一轮遇到时
+    // 都有机会看见。持久呈现需要一条真正的会话级 notice 通道,见 issue 外推。
+      autoReviewUnavailableNotice.reset();
     };
     // 「自动审核不可用」的会话级一次性提示(issue #1574);与 Claude / Pi 同口径,走既有的
     // 非终止 error 事件 + `[CODE]` 约定,不新增事件类型。

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -8829,7 +8829,14 @@ export class CodexAgent extends BaseAgent {
       async setPermissionMode(newMode: PermissionMode) {
         log.debug('setPermissionMode', { from: mutablePermissionMode, to: newMode });
         // 用户自己动过权限档 → 一次性提示重新武装(与 Claude 同口径)。
-        if (newMode !== mutablePermissionMode) autoReviewUnavailableNotice.reset();
+        // 档位变了 → 连**裁决缓存**一起清。缓存 key 不含 permissionMode,切离 Auto 再切回时
+        // 会命中先前那条 `unavailable` block —— 审阅器早就恢复了,同一个动作还是被拒
+        // (greptile P1 of #1574)。一次性提示同步重新武装:用户既然接管过,之后又不可用
+        // 值得再提醒一次。
+        if (newMode !== mutablePermissionMode) {
+          autoReviewDecisionCache.clear();
+          autoReviewUnavailableNotice.reset();
+        }
         // Full access 才能批量放行挂起的 ask。切到 Auto 时，已有请求不能绕过
         // reviewer / 人工降级审批，先 fail-closed 关闭；后续重试按当前路由能力
         // 选择 auto_review 或 user reviewer。

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -65,7 +65,9 @@ export {
 // 上游」这一类 —— 那类同样是"连不上"而不是"请求有问题",续跑一次就能过去。
 export { isNetworkishErrorMessage } from './shared/network-error.js';
 export {
+  AUTO_REVIEW_UNAVAILABLE_CODE,
   getAutoReviewActionTextLength,
+  isAutoReviewUnavailableNotice,
   MAX_AUTO_REVIEW_ACTION_TEXT_CHARS,
   type AutoReviewDecision,
   type AutoReviewDelegate,

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -892,6 +892,11 @@ export class PiAgent extends BaseAgent {
     const setAutoReviewIntent = (content: UserMessage['content']): void => {
       currentAutoReviewIntent = extractAutoReviewUserIntent(content);
       autoReviewDecisionCache.clear();
+    // 每条新用户消息 = 新一轮,提示重新武装。ErrorBanner 那份只活到下一条非 error 事件
+    // (renderer 的 handleStreamEvent 会清 recoverableError),所以「整个会话只说一次」
+    // 会让用户在后续轮次里完全看不到;改为每轮至多一条 —— 不刷屏,又保证每一轮遇到时
+    // 都有机会看见。持久呈现需要一条真正的会话级 notice 通道,见 issue 外推。
+      autoReviewUnavailableNotice.reset();
     };
     // 「自动审核不可用」的会话级一次性提示(issue #1574);与 Claude / Codex 同口径,走既有的
     // 非终止 error 事件 + `[CODE]` 约定,不新增事件类型。

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1414,7 +1414,14 @@ export class PiAgent extends BaseAgent {
         // auto 的差异在 Cindy 侧 dispatcher(handleExtensionUiRequest),bridge 无感知。
         const nextMode = normalizePermissionMode(mode);
         // 用户自己动过权限档 → 一次性提示重新武装(与 Claude / Codex 同口径)。
-        if (nextMode !== requestedPermissionSnapshot.mode) autoReviewUnavailableNotice.reset();
+        // 档位变了 → 连**裁决缓存**一起清。缓存 key 不含 permissionMode,切离 Auto 再切回时
+        // 会命中先前那条 `unavailable` block —— 审阅器早就恢复了,同一个动作还是被拒
+        // (greptile P1 of #1574)。一次性提示同步重新武装:用户既然接管过,之后又不可用
+        // 值得再提醒一次。
+        if (nextMode !== requestedPermissionSnapshot.mode) {
+          autoReviewDecisionCache.clear();
+          autoReviewUnavailableNotice.reset();
+        }
         await writePermissionSnapshotOrFailClosed({
           ...requestedPermissionSnapshot,
           mode: nextMode,

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -42,6 +42,7 @@ import {
 } from './cindy-bridge-source.js';
 import { normalizePiToolForAutoReview } from './auto-review-policy.js';
 import {
+  createAutoReviewUnavailableNotice,
   extractAutoReviewUserIntent,
   resolveAutoReviewDecision,
   type AutoReviewDecision,
@@ -892,6 +893,15 @@ export class PiAgent extends BaseAgent {
       currentAutoReviewIntent = extractAutoReviewUserIntent(content);
       autoReviewDecisionCache.clear();
     };
+    // 「自动审核不可用」的会话级一次性提示(issue #1574);与 Claude / Codex 同口径,走既有的
+    // 非终止 error 事件 + `[CODE]` 约定,不新增事件类型。
+    const autoReviewUnavailableNotice = createAutoReviewUnavailableNotice((message) => {
+      queue.push({
+        type: 'error',
+        data: { message, isTerminal: false },
+        source: 'pi',
+      });
+    });
     const reviewAutoAction = (action: ReviewableAction): Promise<AutoReviewDecision> => {
       const request = {
         sessionId: opts.sessionId,
@@ -995,6 +1005,7 @@ export class PiAgent extends BaseAgent {
               workspaceRoots: [opts.workingDir],
               readRoots: [opts.workingDir, ...mutableExtraDirs],
               reviewAutoAction,
+              notifyAutoReviewUnavailable: () => autoReviewUnavailableNotice.notify(),
             }));
             return;
           }
@@ -1380,6 +1391,8 @@ export class PiAgent extends BaseAgent {
         activeEffortSnapshot = nextEffortSnapshot;
         if (setOpts && Object.hasOwn(setOpts, 'providerId')) mutableProviderId = setOpts.providerId;
         autoReviewDecisionCache.clear();
+        // 换模型 / 换路由可能正好修掉了审阅器不可用的原因;换完又不可用值得再提醒一次。
+        autoReviewUnavailableNotice.reset();
         const data = (resp.data ?? {}) as { contextWindow?: number };
         if (typeof data.contextWindow === 'number' && data.contextWindow > 0) {
           ctx.contextWindow = data.contextWindow;
@@ -1399,9 +1412,12 @@ export class PiAgent extends BaseAgent {
       async setPermissionMode(mode): Promise<void> {
         // ask/auto/bypass 三档;extension 每次 tool_call 现读,写完即生效。
         // auto 的差异在 Cindy 侧 dispatcher(handleExtensionUiRequest),bridge 无感知。
+        const nextMode = normalizePermissionMode(mode);
+        // 用户自己动过权限档 → 一次性提示重新武装(与 Claude / Codex 同口径)。
+        if (nextMode !== requestedPermissionSnapshot.mode) autoReviewUnavailableNotice.reset();
         await writePermissionSnapshotOrFailClosed({
           ...requestedPermissionSnapshot,
-          mode: normalizePermissionMode(mode),
+          mode: nextMode,
         });
       },
 
@@ -1837,6 +1853,8 @@ export class PiAgent extends BaseAgent {
       workspaceRoots: string[];
       readRoots: string[];
       reviewAutoAction: (action: ReviewableAction) => Promise<AutoReviewDecision>;
+      /** 审阅器不可用时的会话级一次性提示;去重与重置由会话侧持有(issue #1574)。 */
+      notifyAutoReviewUnavailable: () => void;
     },
   ): void {
     const method = typeof event.method === 'string' ? event.method : '';
@@ -1862,6 +1880,7 @@ export class PiAgent extends BaseAgent {
         workspaceRoots,
         readRoots,
         reviewAutoAction,
+        notifyAutoReviewUnavailable,
       } = getPermissionCtx();
       const requestUserConfirmation = async (): Promise<boolean> => {
         if (!resolver) {
@@ -1929,9 +1948,13 @@ export class PiAgent extends BaseAgent {
             return;
           }
           if (decision.verdict === 'block') {
+            // 审阅器没跑起来 ≠ 模型判定危险:前者是基础设施故障,提示一次让用户能接管;
+            // 后者按 Auto 本意保持静默。动作两种都仍然 confirmed:false。
+            if (decision.unavailable) notifyAutoReviewUnavailable();
             this.deps.logger.debug('pi auto-review blocked tool call', {
               toolName,
               reason: decision.reason,
+              unavailable: decision.unavailable === true,
             });
           }
           proc.send({

--- a/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   AUTO_REVIEW_UNAVAILABLE_CODE,
   classifyLocalAutoReviewTier,
+  isAutoReviewUnavailableNotice,
   composeAutoReviewIntentWithApprovedPlan,
   composeAutoReviewIntentWithClarification,
   createAutoReviewUnavailableNotice,
@@ -243,6 +244,27 @@ describe('resolveAutoReviewDecision', () => {
       );
       expect(decision.unavailable).toBeUndefined();
     });
+  });
+});
+
+describe('isAutoReviewUnavailableNotice', () => {
+  it('只认本提示的 code 前缀,不误伤其它 bracket code', () => {
+    const notice = createAutoReviewUnavailableNotice(() => {});
+    let emitted = '';
+    createAutoReviewUnavailableNotice((m) => { emitted = m; }).notify();
+    void notice;
+
+    // 真实 emit 出来的那条必须被自己的判据认出来(消费方有 desktop 落库 / IM 渠道 /
+    // renderer i18n 三处,判据错位就会漏投)。
+    expect(isAutoReviewUnavailableNotice(emitted)).toBe(true);
+    expect(isAutoReviewUnavailableNotice(`[${AUTO_REVIEW_UNAVAILABLE_CODE}] anything`)).toBe(true);
+
+    expect(isAutoReviewUnavailableNotice('[REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED] nope')).toBe(false);
+    // 前缀必须在开头,不接受夹在中间。
+    expect(isAutoReviewUnavailableNotice(`prefixed [${AUTO_REVIEW_UNAVAILABLE_CODE}]`)).toBe(false);
+    expect(isAutoReviewUnavailableNotice(undefined)).toBe(false);
+    expect(isAutoReviewUnavailableNotice(null)).toBe(false);
+    expect(isAutoReviewUnavailableNotice(123)).toBe(false);
   });
 });
 

--- a/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
@@ -1,9 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  AUTO_REVIEW_UNAVAILABLE_CODE,
   classifyLocalAutoReviewTier,
   composeAutoReviewIntentWithApprovedPlan,
   composeAutoReviewIntentWithClarification,
+  createAutoReviewUnavailableNotice,
   extractAutoReviewUserIntent,
   resolveAutoReviewDecision,
   type AutoReviewRequest,
@@ -172,6 +174,95 @@ describe('resolveAutoReviewDecision', () => {
       verdict: 'block',
       reason: expect.stringContaining('could not complete'),
     });
+  });
+
+  /**
+   * 「审阅器没跑起来」与「模型判定动作危险」以前被压成同一个 `block`(issue #1574),
+   * 上层无法区分 —— 前者是基础设施故障、用户有权知道并接管,却和后者一样对 UI 静默。
+   */
+  describe('marks infrastructure failures apart from model verdicts', () => {
+    const gray = request({ kind: 'exec', command: 'npx tsc --noEmit' });
+
+    it('flags a missing reviewer as unavailable', async () => {
+      await expect(resolveAutoReviewDecision(gray, undefined)).resolves.toMatchObject({
+        verdict: 'block',
+        unavailable: true,
+      });
+    });
+
+    it('flags a throwing reviewer as unavailable', async () => {
+      await expect(resolveAutoReviewDecision(gray, async () => {
+        throw new Error('offline');
+      })).resolves.toMatchObject({ verdict: 'block', unavailable: true });
+    });
+
+    it('flags invalid reviewer output as unavailable', async () => {
+      await expect(resolveAutoReviewDecision(
+        gray,
+        async () => ({ verdict: 'unknown' } as never),
+      )).resolves.toMatchObject({ verdict: 'block', unavailable: true });
+    });
+
+    it('flags a reviewer timeout as unavailable', async () => {
+      vi.useFakeTimers();
+      const pending = resolveAutoReviewDecision(gray, async () => new Promise<never>(() => {}));
+      await vi.advanceTimersByTimeAsync(8_000);
+      await expect(pending).resolves.toMatchObject({ verdict: 'block', unavailable: true });
+    });
+
+    it('does NOT flag a model block — that one stays silent by design', async () => {
+      const decision = await resolveAutoReviewDecision(
+        gray,
+        async () => ({ verdict: 'block', reason: 'ambiguous install target' }),
+      );
+      expect(decision).toEqual({ verdict: 'block', reason: 'ambiguous install target' });
+      expect(decision.unavailable).toBeUndefined();
+    });
+
+    it('does NOT flag under-specified or oversized actions — the reviewer is fine, the evidence is not', async () => {
+      const noEvidence = await resolveAutoReviewDecision(
+        request({ kind: 'exec', command: '   ' }),
+        async () => ({ verdict: 'allow' }),
+      );
+      expect(noEvidence.verdict).toBe('block');
+      expect(noEvidence.unavailable).toBeUndefined();
+
+      const oversized = await resolveAutoReviewDecision(
+        request({ kind: 'exec', command: `npm run build -- ${'x'.repeat(4_100)}` }),
+        async () => ({ verdict: 'allow' }),
+      );
+      expect(oversized.verdict).toBe('block');
+      expect(oversized.unavailable).toBeUndefined();
+    });
+
+    it('ignores an unavailable flag claimed by a delegate that did answer', async () => {
+      // delegate 给出了合法 verdict 就说明它跑起来了;它无权自称 unavailable。
+      const decision = await resolveAutoReviewDecision(
+        gray,
+        async () => ({ verdict: 'block', reason: 'nope', unavailable: true }),
+      );
+      expect(decision.unavailable).toBeUndefined();
+    });
+  });
+});
+
+describe('createAutoReviewUnavailableNotice', () => {
+  it('emits once per session and re-arms only after reset', () => {
+    const emitted: string[] = [];
+    const notice = createAutoReviewUnavailableNotice((message) => emitted.push(message));
+
+    notice.notify();
+    notice.notify();
+    notice.notify();
+    // 逐条提示会把 Auto 退化成比 Ask 更烦的东西 —— 一个会话只说一次。
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toContain(`[${AUTO_REVIEW_UNAVAILABLE_CODE}]`);
+    // 兜底英文必须跟在 code 后面:未落地 i18n 的宿主(远端 / IM)直接显示它。
+    expect(emitted[0]).toContain('Auto-review is temporarily unavailable');
+
+    notice.reset();
+    notice.notify();
+    expect(emitted).toHaveLength(2);
   });
 });
 

--- a/packages/maker-core/src/agents/shared/auto-review-decision.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.ts
@@ -35,12 +35,28 @@ export type AutoReviewDecision = {
 export const AUTO_REVIEW_UNAVAILABLE_CODE = 'AUTO_REVIEW_UNAVAILABLE';
 
 /**
- * 未落地 i18n 的宿主（远端 / IM 通道）看到的兜底英文。用词与 desktop 权限选择器的
- * 档位标签对齐（Auto-review / Default permissions），避免同一件事在两处叫不同名字。
+ * 未落地 i18n 的宿主看到的兜底英文。用词与 desktop 权限选择器的档位标签对齐
+ * （Auto-review / Default permissions），避免同一件事在两处叫不同名字。
+ *
+ * IM 渠道（Slack / Telegram / 飞书）**不**读它 —— 渠道文案硬编码中文、不进 renderer
+ * 的 locale（见 docs/dev-rules/engineering-conventions.md §5），映射在
+ * apps/desktop/src/main/im/shared/turnRetryNotice.ts。
  */
 const AUTO_REVIEW_UNAVAILABLE_FALLBACK_TEXT =
   'Auto-review is temporarily unavailable, so actions that need review are being denied. '
   + 'Switch this task to Default permissions if you want to approve them yourself.';
+
+/**
+ * 判定一条 AgentEvent 的 error message 是否就是「自动审批不可用」提示。
+ *
+ * 消费方有三处、判据必须单点:desktop 需要把它**额外落库**成持久的 error 行(非终止
+ * error 默认只进 ErrorBanner,会被下一条事件清掉);IM 渠道需要把它翻成渠道文案;
+ * renderer 需要把它翻成 i18n。谁都不该自己去拼 `[CODE]` 前缀。
+ */
+export function isAutoReviewUnavailableNotice(message: unknown): boolean {
+  return typeof message === 'string'
+    && message.startsWith(`[${AUTO_REVIEW_UNAVAILABLE_CODE}]`);
+}
 
 /**
  * 会话级**一次性**提示的去重器 —— 逐条提示会把 Auto 档退化成比 Ask 更烦的东西，

--- a/packages/maker-core/src/agents/shared/auto-review-decision.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.ts
@@ -10,7 +10,60 @@ import {
 export type AutoReviewDecision = {
   verdict: 'allow' | 'block' | 'ask';
   reason?: string;
+  /**
+   * `true` = 这个 `block` 来自**审阅器没跑起来**（delegate 缺失 / 超时 / 抛错 / 返回非法），
+   * 不是模型判定动作危险。
+   *
+   * 两件事以前被压成同一个 `block`（issue #1574），于是「模型让我换个安全做法」和
+   * 「基础设施故障，Auto 档整个不工作了」在上层完全无法区分 —— 后者是用户有权知道并接管的，
+   * 却和前者一样对 UI 静默。区分之后：
+   * - 模型判定的 `block` 继续静默，只把 reason 喂给模型（Auto 档的本意就是不打扰）；
+   * - `unavailable` 的 `block` 额外触发一条**会话级一次性**提示（见
+   *   createAutoReviewUnavailableNotice），动作本身仍然 deny —— 安全边界不变。
+   *
+   * 注意：证据不足（缺路径 / 命令、动作文本超限）**不算** unavailable。那时审阅器是好的，
+   * 是这次请求没法审，属于正常判定。
+   */
+  unavailable?: boolean;
 };
+
+/**
+ * 「自动审核不可用」的会话级提示错误码。走既有的 `[CODE] fallback text` 约定：
+ * harness emit 非终止 error 事件，renderer 的 decodeRemoteErrorMessage 翻成 i18n 文案
+ * （见 apps/desktop 的 chat.remoteError.*），不新增协议、不新增事件类型。
+ */
+export const AUTO_REVIEW_UNAVAILABLE_CODE = 'AUTO_REVIEW_UNAVAILABLE';
+
+/**
+ * 未落地 i18n 的宿主（远端 / IM 通道）看到的兜底英文。用词与 desktop 权限选择器的
+ * 档位标签对齐（Auto-review / Default permissions），避免同一件事在两处叫不同名字。
+ */
+const AUTO_REVIEW_UNAVAILABLE_FALLBACK_TEXT =
+  'Auto-review is temporarily unavailable, so actions that need review are being denied. '
+  + 'Switch this task to Default permissions if you want to approve them yourself.';
+
+/**
+ * 会话级**一次性**提示的去重器 —— 逐条提示会把 Auto 档退化成比 Ask 更烦的东西，
+ * 而完全不提示就是 issue #1574 报的「静默永久拒绝」。所以一个会话只说一次。
+ *
+ * `reset()` 用在换模型 / 换路由 / 用户主动改权限档之后：那些动作可能已经修好了问题，
+ * 若之后**又**不可用，值得再提醒一次。
+ */
+export function createAutoReviewUnavailableNotice(
+  emit: (message: string) => void,
+): { notify(): void; reset(): void } {
+  let sent = false;
+  return {
+    notify(): void {
+      if (sent) return;
+      sent = true;
+      emit(`[${AUTO_REVIEW_UNAVAILABLE_CODE}] ${AUTO_REVIEW_UNAVAILABLE_FALLBACK_TEXT}`);
+    },
+    reset(): void {
+      sent = false;
+    },
+  };
+}
 
 /** 交给 host 侧轻量 reviewer 的最小上下文；不含历史、工具结果、Skill 或 Memory。 */
 export interface AutoReviewRequest {
@@ -134,6 +187,7 @@ export async function resolveAutoReviewDecision(
     return {
       verdict: 'block',
       reason: 'Automatic review is unavailable. Choose a safer, workspace-scoped alternative.',
+      unavailable: true,
     };
   }
   let timeout: ReturnType<typeof setTimeout> | undefined;
@@ -170,9 +224,12 @@ export async function resolveAutoReviewDecision(
   } finally {
     if (timeout) clearTimeout(timeout);
   }
+  // 走到这里 = delegate 存在但没给出可用结果(超时 / 抛错 / 返回非法)。与「模型判定危险」
+  // 不同,这是审阅器本身没跑起来,必须让上层能区分出来。
   return {
     verdict: 'block',
     reason: 'Automatic review could not complete. Choose a safer, workspace-scoped alternative.',
+    unavailable: true,
   };
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

`resolveAutoReviewDecision` 把两件性质完全不同的事压成了同一个 `block`：

1. **模型判定这个动作危险** —— 静默 block 是对的，给模型一个 reason 让它换安全做法（Auto 档
   的本意就是不打扰用户）；
2. **审阅器压根没跑起来**（delegate 缺失 / 8s 超时 / 抛错 / 返回非法）—— 这不是安全判断，是
   基础设施故障，用户有权知道并接管。

第 2 类以前和第 1 类一样对 UI 完全静默。用户看到的就是 issue #1574 里那句反馈：「怎么都掉不起
工具，说被拒绝了，但是我一直都没看到过权限批准的弹窗，怎么重启 app 都不行」。

本 PR 在 `AutoReviewDecision` 上加 `unavailable?: boolean` 区分两者，`unavailable` 的 block 额外
触发一条**会话级一次性**提示。动作本身仍然 deny —— 安全边界不变。

> **Review 后的重要修订**：原先还额外把提示落库成持久的 `role="error"` 行，review 指出
> `onTurnErrorEvent` 的 per-turn dedup 会**吃掉同一轮真正的终止 error**（数据丢失），
> 且它 `shouldBroadcast: false`、打开中的会话看不到。已整段撤回，改为**每轮重置**。
> 持久呈现需要一条独立的会话级 notice 通道，外推 **#1603**。下面的「呈现」描述已按撤回后
> 的实际行为改写。

### 为什么用 `[CODE]` + 非终止 error 事件

仓库已有一套现成的「会话级提示」约定：harness emit `error` 事件（`isTerminal: false`）、message
带 `[CODE] 英文兜底文案`，renderer 的 `decodeRemoteErrorMessage` 翻成 i18n 文案
（`chat.remoteError.*`）。既有先例是 `REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED`。

沿用它意味着：**不新增事件类型、不新增 IPC channel、不碰 device-link payload**，也不需要动
`cindy-protocol`。

呈现落在输入框上方的 **ErrorBanner**（`recoverableError`）。**它的局限要说清**：
`makerChatStore.ts:2321` 会在下一条非 error 事件（`text` / `tool_result` / `status`）到达时
清掉 `recoverableError`，所以这条提示不是持久的。落库那条路（`role="error"` 行 +
`ErrorMessageCard`）已验证不可用 —— 见上方修订说明与 #1603。

**IM 渠道不受这个局限影响**：`turnRetryNotice.ts` 的映射把它刷进渠道进度区，Slack /
Telegram / 飞书都能稳定看到。

### 每轮一次 + 可重新武装

逐条提示会把 Auto 档退化成比 Ask 更烦的东西，完全不提示就是 issue 报的静默永久拒绝。所以
**每轮至多一条**（`createAutoReviewUnavailableNotice` 的去重），并在这些动作之后重新武装：

- **每条新用户消息**（`setAutoReviewIntent`）—— 因为 ErrorBanner 那份只活到下一条事件，
  「整个会话只说一次」会让用户在后续轮次完全看不到；每轮一次既不刷屏，又保证每一轮遇到
  时都有机会看见；
- 换模型 / 换路由（可能正好修掉了目录解析失败、provider 被停用之类的原因）；
- 用户自己动过权限档（他既然接管过，之后又不可用值得再提醒一次）—— 这一路同时清掉
  `autoReviewDecisionCache`，否则切离 Auto 再切回会命中先前那条 `unavailable` 裁决。

三个 harness（Claude / Codex / Pi）用同一个 helper、同一个错误码，行为口径一致。

### 顺手发现的一处死代码（未在本 PR 处理）

`maker:auto-permission:fallback` 这条 IPC channel 在 main 侧**已经没有任何发送端**了 ——
channel 常量（`channels.ts:752`）、preload fanOut、renderer 的
`autoPermissionFallbackToast.ts` + 四语文案 `newChat.permissionSelector.autoFallback` 全都还在，
但没人发。它是 #596 把行为从「Auto→Ask 广播降级」改成「保持 Auto、只切运行期 reviewer」之后
留下的残留，也从侧面印证了 issue 说的「零用户可见提示」。

本 PR **没有**复活或清理它：复活要改它的 payload 语义（`to: 'ask'` 已经不成立），而这条 channel
经 device-link 转发，属于跨端 wire —— 按 `docs/dev-rules/protocol-and-submodules.md` 要走专项
审查，与本 PR 的改动面无关。已在 issue #1574 下记录，建议单独处理。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1574
- 本 PR 包含：`AutoReviewDecision.unavailable` + `resolveAutoReviewDecision` 的标记 +
  `createAutoReviewUnavailableNotice` 去重器 + 三个 harness 的接线与重置点 + renderer 错误码
  白名单 + 四语文案 + 12 条测试
- 明确不包含：
  - **「一键切到询问档」按钮** —— issue 建议里的这一条需要给 `ErrorMessageCard` 加 action 槽位，
    是独立的 UI 能力；用户现在看到提示后可以用已有的权限选择器自己切。
  - **「连续 N 次 unavailable 后自动降级到 Ask」** —— 那会替用户改权限档，属于产品决策，需要
    先定清楚 N 和降级是否持久化。
  - **持久呈现**：需要一条独立的会话级 notice 通道（不能与 `onTurnErrorEvent` 共用 turn
    身份、且要能被 live 流看到），连同那条死代码 channel 的去向裁决一起外推 **#1603**。

### 外推清单

- **#1603 — 会话级 notice 的持久呈现通道**。修好之前用户会遇到什么：desktop 上这条提示
  出现在 ErrorBanner，但下一条 agent 事件就会清掉它；本 PR 的每轮重置让每一轮都有一次
  机会看到，但如果 block 发生在某轮早期、后面还有大量输出，仍可能错过 —— 错过后原因只
  留在模型的转述里。IM 渠道不受影响。
- 用户可见变化：Auto 档下审阅器故障时，对话流里出现一条提示，说明自动审批暂时不可用、可以切到
  「默认权限」自己确认。模型判定危险导致的 block 行为**完全不变**（仍然静默）。
- 是否存在 breaking change：无。`unavailable` 是可选字段，不读它的调用方行为不变。

### UI 变化

复用既有的 `ErrorMessageCard`（对话流里的错误卡片），**没有新增或修改任何组件、布局、样式或
动效** —— 只是往既有的错误码 → i18n 文案映射表里加了一条。

- 引用的设计规范：不涉及新视觉决策。文案用词按 `i18n/GLOSSARY.md` 对齐：Session 面向用户叫
  「任务」（zh-CN）/ 音译 `セッション`・`세션`（ja/ko）；权限档沿用权限选择器里的既有标签
  —— 「自动审批」/ Auto-review /「自動レビュー」/「자동 리뷰」与「默认权限」/ Default
  permissions /「デフォルト権限」/「기본 권한」，不自造新说法。`pnpm check:i18n-glossary` 与
  `pnpm check:i18n` 均通过。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/shared/auto-review-decision.test.ts \
  src/agents/claude-code/__tests__/auto-review-wiring.test.ts \
  src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
结果：3 files / 57 tests 全部通过（新增 12）

pnpm --filter desktop run typecheck
结果：通过（@cindy/maker-core 没有 typecheck script，--if-present 跳过）

pnpm check:i18n
结果：zh-CN / en / ja / ko 共 6634 个 key 全部一致

pnpm check:i18n-glossary
结果：无新增违规

pnpm check:brand-terminology
结果：PASS

pnpm test:unit
结果：56 workspace PASS / 0 FAIL（并入最新 upstream/main 后重跑，同样 56 PASS / 0 FAIL）
```

基底刷新：开 PR 前合入了 `upstream/main`（#1555 / #1502），因为它们同样改了四个 locale 文件。
合并无冲突，四语条目完好，上述 i18n / typecheck / test:unit 均在合并后的基底上复跑通过。

覆盖：delegate 缺失 / 抛错 / 返回非法 / 超时 → 都标 `unavailable`；模型 block **不标**；
证据不足与动作超限**不标**（审阅器是好的，是这次请求没法审）；delegate 自称 `unavailable`
被忽略（它给出了合法 verdict 就说明它跑起来了）；去重器一次性 + reset 后重新武装；
harness 层：两次被拒只发一条提示、模型 block 时零提示、切档后重新武装。

**Mutation 验证**：去掉 delegate 失败路径的 `unavailable: true` 后：

```text
× flags a throwing reviewer as unavailable
× flags invalid reviewer output as unavailable
× flags a reviewer timeout as unavailable
```

验证后源文件已还原。

### 手工验证

**未在 dev 实例里目检这条提示卡片。** 要真实触发需要让 host 侧轻量审阅器故障（停用当前会话的
provider，或让 `requestUtilityText` 返回 `no_candidate`），本轮没有搭这个环境。

呈现路径本身是复用的：`error` 事件（`isTerminal: false`）→ `decodeRemoteErrorMessage` →
ErrorBanner，与既有的 `REMOTE_LOCAL_ATTACHMENT_UNSUPPORTED` 走完全相同的代码路径，
只多一条映射表条目。

### 未执行的验证

- 未在 dev 实例目检提示的实际呈现（原因见上）。**Light / Dark 双模式因此都未实机目检** ——
  组件与样式零改动，双模式表现完全由既有 ErrorBanner 决定；按
  `docs/design-rules/DESIGN.md` 的双模式交付门槛，这里如实写明未验证，不把「复用了 themed
  组件」当成「双模式已验证」。
- 未实机验证 IM 渠道（Slack / Telegram / 飞书）里这条提示的呈现位置与文案换行。映射逻辑
  由单测覆盖，但没有起真实 bot 走一遍。
- 未验证远端会话 / IM 通道（Telegram、飞书）里这条提示的落地形态。那些宿主不走 renderer 的
  i18n 映射，会显示 `[AUTO_REVIEW_UNAVAILABLE]` 后面的英文兜底文案 —— 这是设计如此
  （与既有 `REMOTE_*` 码同款行为），但没有实际跑过。
- 未验证 Codex / Pi 的接线在真实会话里的触发（它们的 block 分支由单测覆盖，但没有起真实
  app-server / pi 进程走一遍）。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

勾权限的理由：改动落在 Auto 档的审阅裁决路径上。但**没有放宽任何判定** —— `unavailable` 的
block 仍然 deny，模型判定的 block 行为逐字不变，`allow` / `ask` 路径未触碰。新增的只有一条
用户可见提示。反过来说，它让「Auto 档实际上已经不工作了」这件事第一次对用户可见，这是安全方向
的改善。

一个诚实的边界：提示文案会告诉用户「可以切到默认权限自己确认」。这是**建议**，不是自动执行 ——
本 PR 不替用户改任何权限设置。

### 影响与回滚

- 影响范围：`packages/maker-core` 的 auto-review 裁决与三个 harness 的 block 分支；
  `apps/desktop` 的 renderer 错误码映射与四语文案。不涉及主进程逻辑、IPC、数据库、协议。
- 回滚 / 降级方式：revert 本 PR 即可，回到「审阅器故障与模型判定都静默」的既有行为。也可以只
  回滚 renderer 白名单那一处 —— 那样提示会退化成显示 `[AUTO_REVIEW_UNAVAILABLE]` 后面的英文
  兜底文案，不会崩、不会裸露错误码给用户（`decodeRemoteErrorMessage` 对未登记的 code 本就会
  剥掉前缀回退英文原文）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（区分理由、一次性语义、重置时机都写在类型与 helper 的注释里）
- [x] 已确认测试结果或说明未执行原因
