### PR TITLE
fix(desktop): 修复 Claude Opus 套餐错误提示

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/claudeGatewayErrorObserver.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeGatewayErrorObserver.test.ts
@@ -3,9 +3,12 @@ import { gzipSync } from 'node:zlib';
 import type { ResponseObserverCtx } from '@cindy/anthropic-compat-proxy';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON } from '../../../shared/claudeGatewayError.js';
 import {
-  consumeClaudeGatewayOpusPlanMismatch,
+  CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
+  CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON,
+} from '../../../shared/claudeGatewayError.js';
+import {
+  consumeClaudeOpusPlanMismatch,
   createClaudeGatewayErrorObserver,
   resetClaudeGatewayErrorObserverForTest,
 } from '../claude-gateway-error-observer.js';
@@ -55,42 +58,49 @@ describe('Claude gateway error observer', () => {
     recordClaudeRequestRoute(1, 's1', 'gateway');
 
     expect(drive(ctx(), Buffer.from(planError))).toBe(true);
-    expect(consumeClaudeGatewayOpusPlanMismatch('s1')).toBe(
-      CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
-    );
-    expect(consumeClaudeGatewayOpusPlanMismatch('s1')).toBeNull();
+    expect(consumeClaudeOpusPlanMismatch('s1')).toBe(CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON);
+    expect(consumeClaudeOpusPlanMismatch('s1')).toBeNull();
   });
 
   it('decodes compressed gateway error bodies', () => {
     recordClaudeRequestRoute(1, 's1', 'gateway');
 
-    expect(drive(ctx({ responseHeaders: { 'content-encoding': 'gzip' } }), gzipSync(planError))).toBe(true);
-    expect(consumeClaudeGatewayOpusPlanMismatch('s1')).toBe(
-      CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
-    );
+    expect(
+      drive(ctx({ responseHeaders: { 'content-encoding': 'gzip' } }), gzipSync(planError)),
+    ).toBe(true);
+    expect(consumeClaudeOpusPlanMismatch('s1')).toBe(CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON);
+  });
+
+  it('records evidence from the exact direct Claude.ai subscription Opus 400 response', () => {
+    recordClaudeRequestRoute(1, 's1', 'subscription');
+
+    expect(drive(ctx(), Buffer.from(planError))).toBe(true);
+    expect(consumeClaudeOpusPlanMismatch('s1')).toBe(CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON);
   });
 
   it.each([
-    { label: 'subscription route', route: 'subscription' as const },
     { label: 'non-400 response', route: 'gateway' as const, status: 429 },
     { label: 'non-Opus request', route: 'gateway' as const, model: 'claude-sonnet-5' },
     { label: 'unrelated error', route: 'gateway' as const, body: '{"error":"busy"}' },
-  ])('does not record evidence for $label', ({ route, status = 400, model = 'claude-opus-5', body = planError }) => {
-    recordClaudeRequestRoute(1, 's1', route);
+  ])(
+    'does not record evidence for $label',
+    ({ route, status = 400, model = 'claude-opus-5', body = planError }) => {
+      recordClaudeRequestRoute(1, 's1', route);
 
-    drive(
-      ctx({ status, requestBody: Buffer.from(JSON.stringify({ model })) }),
-      Buffer.from(body),
-    );
-    expect(consumeClaudeGatewayOpusPlanMismatch('s1')).toBeNull();
-  });
+      drive(
+        ctx({ status, requestBody: Buffer.from(JSON.stringify({ model })) }),
+        Buffer.from(body),
+      );
+      expect(consumeClaudeOpusPlanMismatch('s1')).toBeNull();
+    },
+  );
 
   it('invalidates old evidence when a later session request starts', () => {
     recordClaudeRequestRoute(1, 's1', 'gateway');
     drive(ctx(), Buffer.from(planError));
     noteClaudeSessionRequest('s1', 2);
 
-    expect(consumeClaudeGatewayOpusPlanMismatch('s1')).toBeNull();
+    expect(consumeClaudeOpusPlanMismatch('s1')).toBeNull();
   });
 
   it('does not record a response that becomes stale before its body completes', () => {
@@ -101,6 +111,6 @@ describe('Claude gateway error observer', () => {
     noteClaudeSessionRequest('s1', 2);
     sink?.onEnd?.();
 
-    expect(consumeClaudeGatewayOpusPlanMismatch('s1')).toBeNull();
+    expect(consumeClaudeOpusPlanMismatch('s1')).toBeNull();
   });
 });

--- a/apps/desktop/src/main/maker-host/claude-gateway-error-observer.ts
+++ b/apps/desktop/src/main/maker-host/claude-gateway-error-observer.ts
@@ -1,5 +1,5 @@
 /**
- * Claude XD Gateway 错误观察器。
+ * Claude Opus 套餐错误观察器。
  *
  * 路由 transform 与响应 observer 通过 proxy reqId 关联，只有同一个 Opus 请求
  * 确认走 Gateway 或 Claude.ai 订阅且收到特定 400 套餐错误时才留下待消费证据。

--- a/apps/desktop/src/main/maker-host/claude-gateway-error-observer.ts
+++ b/apps/desktop/src/main/maker-host/claude-gateway-error-observer.ts
@@ -2,15 +2,16 @@
  * Claude XD Gateway 错误观察器。
  *
  * 路由 transform 与响应 observer 通过 proxy reqId 关联，只有同一个 Opus 请求
- * 确认走 XD Gateway 且收到特定 400 套餐错误时才留下待消费证据。terminal event
- * 到达时还要求它仍是该会话最新请求；后续 retry / tool 请求会使旧证据失效。
+ * 确认走 Gateway 或 Claude.ai 订阅且收到特定 400 套餐错误时才留下待消费证据。
+ * terminal event 到达时还要求它仍是该会话最新请求；后续 retry / tool 请求会使旧证据失效。
  */
 
 import type { ResponseObserver, ResponseObserverCtx } from '@cindy/anthropic-compat-proxy';
 
 import {
-  CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
   classifyClaudeGatewayError,
+  classifyClaudeSubscriptionError,
+  type ClaudeOpusPlanMismatchReason,
 } from '../../shared/claudeGatewayError.js';
 import {
   readLatestClaudeSessionRequestId,
@@ -23,7 +24,7 @@ const MAX_PENDING_SESSIONS = 128;
 
 interface PendingMismatch {
   reqId: number;
-  reason: typeof CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON;
+  reason: ClaudeOpusPlanMismatchReason;
 }
 
 const pendingMismatches = new Map<string, PendingMismatch>();
@@ -50,7 +51,7 @@ function recordPendingMismatch(sessionId: string, mismatch: PendingMismatch): vo
 export function createClaudeGatewayErrorObserver(): ResponseObserver {
   return (ctx: ResponseObserverCtx) => {
     const requestRoute = takeClaudeRequestRoute(ctx.reqId);
-    if (!requestRoute || requestRoute.route !== 'gateway' || ctx.status !== 400) return null;
+    if (!requestRoute || ctx.status !== 400) return null;
 
     const modelId = requestModel(ctx.requestBody);
     if (!modelId.startsWith('claude-opus-')) return null;
@@ -70,16 +71,15 @@ export function createClaudeGatewayErrorObserver(): ResponseObserver {
           Buffer.concat(chunks, size),
           typeof encoding === 'string' ? encoding : undefined,
         );
-        const reason = classifyClaudeGatewayError({
+        const context = {
           modelId,
           requestRoute: requestRoute.route,
           status: ctx.status,
           error: bodyText,
-        });
-        if (
-          reason &&
-          readLatestClaudeSessionRequestId(requestRoute.sessionId) === ctx.reqId
-        ) {
+        } as const;
+        const reason =
+          classifyClaudeGatewayError(context) ?? classifyClaudeSubscriptionError(context);
+        if (reason && readLatestClaudeSessionRequestId(requestRoute.sessionId) === ctx.reqId) {
           recordPendingMismatch(requestRoute.sessionId, { reqId: ctx.reqId, reason });
         }
       },
@@ -89,9 +89,9 @@ export function createClaudeGatewayErrorObserver(): ResponseObserver {
 }
 
 /** terminal error 转发点一次性消费；后续请求已开始时保守放弃旧证据。 */
-export function consumeClaudeGatewayOpusPlanMismatch(
+export function consumeClaudeOpusPlanMismatch(
   sessionId: string,
-): typeof CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON | null {
+): ClaudeOpusPlanMismatchReason | null {
   const pending = pendingMismatches.get(sessionId) ?? null;
   pendingMismatches.delete(sessionId);
   if (!pending || readLatestClaudeSessionRequestId(sessionId) !== pending.reqId) return null;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -553,7 +553,7 @@ import {
   setClaudeBackgroundActivityBroadcaster,
 } from '../maker-host/claude-session-background-activity.js';
 import { readClaudeSessionRoute } from '../maker-host/claude-session-route-registry.js';
-import { consumeClaudeGatewayOpusPlanMismatch } from '../maker-host/claude-gateway-error-observer.js';
+import { consumeClaudeOpusPlanMismatch } from '../maker-host/claude-gateway-error-observer.js';
 import { setLiveCcSessionBridge } from '../maker-host/claude-transcript-relocation.js';
 import {
   CredentialModeSwitchBusyError,
@@ -3064,7 +3064,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
     let attributedEvent = event;
     if (event.type === 'error' && isTerminalTurnErrorEvent(event)) {
       const reason = !session.remoteHostId && session.agentKind === 'claude-code'
-        ? consumeClaudeGatewayOpusPlanMismatch(session.id)
+        ? consumeClaudeOpusPlanMismatch(session.id)
         : null;
       if (reason) {
         const eventData = event.data && typeof event.data === 'object' && !Array.isArray(event.data)
@@ -3074,7 +3074,7 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           ...event,
           data: { ...eventData, reason },
         };
-        log.warn('Claude Opus plan error attributed to XD Gateway route', {
+        log.warn('Claude Opus plan error normalized for renderer', {
           sessionId: session.id,
           model: session.model,
           reason,

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -43,7 +43,10 @@ import { isOverloadErrorMessage, parseOverloadRetryProgress } from '@/utils/over
 import { isQuotaExhaustedErrorMessage } from '@/utils/quotaError';
 import { parseTerminalRateLimitRetryProgress } from '@/utils/rateLimitRetry';
 import { ERROR_REASON_I18N_KEYS } from './errorReasonI18n';
-import { CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON } from '../../../shared/claudeGatewayError';
+import {
+  CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
+  CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON,
+} from '../../../shared/claudeGatewayError';
 import { isPiImageInputUnsupportedError } from '../../../shared/inputError';
 
 interface ErrorBannerProps {
@@ -261,6 +264,8 @@ export function ErrorBanner({
   // 此时不能一边隐藏按钮，一边仍提示用户“点击重试”。
   const isSilentStopExhausted = errorReason === 'silent-stop-exhausted';
   const isClaudeGatewayOpusPlanMismatch = errorReason === CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON;
+  const isClaudeSubscriptionOpusPlanMismatch =
+    errorReason === CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON;
   const hideRetry =
     isSilentStopExhausted ||
     isClaudeGatewayOpusPlanMismatch ||
@@ -308,6 +313,8 @@ export function ErrorBanner({
     displayError = t('chat.errorBanner.codexAuthMissingLocal');
   } else if (isClaudeGatewayOpusPlanMismatch) {
     displayError = t('chat.errorBanner.claudeGatewayOpusPlanMismatch');
+  } else if (isClaudeSubscriptionOpusPlanMismatch) {
+    displayError = t('chat.errorBanner.claudeSubscriptionOpusPlanMismatch');
   } else if (isGatewayQuotaExhausted) {
     // 「配额或余额不足，请检查供应商账户」对网关用户是半句话:账户就在 Cindy 里,
     // 该说的是「去充值」而不是「去检查」。右端的内联出口负责「去哪充」。
@@ -505,7 +512,8 @@ export function ErrorBanner({
         {(isNetworkishError ||
           isOverloadError ||
           terminalRateLimitRetryProgress ||
-          isClaudeGatewayOpusPlanMismatch) && (
+          isClaudeGatewayOpusPlanMismatch ||
+          isClaudeSubscriptionOpusPlanMismatch) && (
           // 网络类与过载类的原始错误折叠可查:友好文案替换了原文,但排障(端口/URL/
           // errno/上游原话)仍需要原文,点击展开。新增控件走 --error-fg token(规则 16;
           // 本组件其余 red-600/400 为历史存量,error 属语义豁免色但新代码仍走 token)。

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -266,6 +266,8 @@ export function ErrorBanner({
   const isClaudeGatewayOpusPlanMismatch = errorReason === CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON;
   const isClaudeSubscriptionOpusPlanMismatch =
     errorReason === CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON;
+  // 订阅套餐错误保留 Retry：用户重新连接 Anthropic 后可从当前错误卡片重试；
+  // Gateway 错误则隐藏 Retry，改走切换到 Claude.ai 的明确恢复动作。
   const hideRetry =
     isSilentStopExhausted ||
     isClaudeGatewayOpusPlanMismatch ||

--- a/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
@@ -838,6 +838,7 @@ describe('ErrorBanner OpenAI connection recovery', () => {
 
     expect(screen.getByText('chat.errorBanner.claudeSubscriptionOpusPlanMismatch')).toBeTruthy();
     expect(screen.queryByText(/logout|login/i)).toBeNull();
+    expect(screen.getByRole('button', { name: 'chat.errorBanner.retry' })).toBeTruthy();
   });
 
   it('switches the conversation to Claude.ai through the explicit recovery action', async () => {

--- a/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
@@ -6,7 +6,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ErrorBanner } from '../ErrorBanner';
 import { useCodexAuth } from '@/hooks/useCodexAuth';
 import { useCodexSessionExpiredPrompt } from '@/hooks/useCodexSessionExpiredPrompt';
-import { CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON } from '../../../../shared/claudeGatewayError';
+import {
+  CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
+  CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON,
+} from '../../../../shared/claudeGatewayError';
 
 type AuthStateChangedPayload = {
   agentKind: 'claude-code' | 'codex';
@@ -819,6 +822,22 @@ describe('ErrorBanner OpenAI connection recovery', () => {
     expect(
       screen.queryByRole('button', { name: 'chat.errorBanner.switchClaudeSubscription' }),
     ).toBeNull();
+  });
+
+  it('replaces unsupported Claude slash-command advice for subscription errors', () => {
+    render(
+      <ErrorBanner
+        error="Claude Opus is not available with the Claude Pro plan. Run /logout and /login."
+        errorReason={CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON}
+        retryText="retry this turn"
+        onRetry={vi.fn()}
+        agentKind="cc"
+        modelId="claude-opus-5"
+      />,
+    );
+
+    expect(screen.getByText('chat.errorBanner.claudeSubscriptionOpusPlanMismatch')).toBeTruthy();
+    expect(screen.queryByText(/logout|login/i)).toBeNull();
   });
 
   it('switches the conversation to Claude.ai through the explicit recovery action', async () => {

--- a/apps/desktop/src/renderer/components/chat/errorReasonI18n.ts
+++ b/apps/desktop/src/renderer/components/chat/errorReasonI18n.ts
@@ -1,4 +1,7 @@
-import { CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON } from '../../../shared/claudeGatewayError';
+import {
+  CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
+  CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON,
+} from '../../../shared/claudeGatewayError';
 import { UPSTREAM_OVERLOAD_REASON } from '@/utils/overloadError';
 
 /**
@@ -20,4 +23,6 @@ export const ERROR_REASON_I18N_KEYS: Record<string, string> = {
   turn_no_event_timeout: 'logic.errors.turnNoEventTimeout',
   [UPSTREAM_OVERLOAD_REASON]: 'chat.errorBanner.overloadBusyNoRetry',
   [CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON]: 'chat.errorBanner.claudeGatewayOpusPlanMismatch',
+  [CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON]:
+    'chat.errorBanner.claudeSubscriptionOpusPlanMismatch',
 };

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -87,6 +87,7 @@ import {
   CONTINUE_AFTER_APP_EXIT_PROMPT,
   CONTINUE_AFTER_ERROR_PROMPT,
 } from '../../../shared/interruptedTurn';
+import { CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON } from '../../../shared/claudeGatewayError';
 import { refreshPendingAlerts } from '@/hooks/usePendingAlertAttention';
 import { CredentialSwitchWaitBanner } from '@/components/chat/CredentialSwitchWaitBanner';
 import { UpgradeBanner } from '@/components/chat/UpgradeBanner';
@@ -1392,6 +1393,26 @@ export function CCAgentSessionView({
   const [errorTailBannerHiddenFor, setErrorTailBannerHiddenFor] = useState<string | null>(null);
   const errorTailBannerHidden =
     errorTailBannerHiddenFor !== null && errorTailBannerHiddenFor === errorTailMsg?.clientId;
+  /**
+   * Claude Code captures the subscription token and plan metadata when its process is spawned.
+   * Settings auth changes only affect future sessions, so a subscription-plan retry must first
+   * use the existing soft-close path; the next dispatch then lazy-creates Claude with fresh auth.
+   * preserveWorkspace keeps this recovery from triggering worktree cleanup, and makerApiFor
+   * keeps the same behavior for device-link sessions.
+   */
+  const rebuildClaudeSubscriptionSessionBeforeRetry = useCallback(
+    async (reason: string | null | undefined): Promise<void> => {
+      if (
+        !sessionId ||
+        session?.agentKind !== 'cc' ||
+        reason !== CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON
+      ) {
+        return;
+      }
+      await makerApiFor(sessionId).closeSession(sessionId, { preserveWorkspace: true });
+    },
+    [session?.agentKind, sessionId],
+  );
   // 抑制交棒(review P2):本地 hidden 态只服务「点击 → enqueue 被接受」的短窗口;
   // 合成续跑项进入队列或 coordinator dispatch 边界后就释放 hidden 态，由
   // main projection 接管抑制。排队项被取消 / dispatch 前被 Ghost block 时，
@@ -1409,6 +1430,9 @@ export function CCAgentSessionView({
       // 隐藏的英文续跑指令([UI_ACTION_TRIGGER] 前缀,消息流不渲染)——用户视角
       // 就是任务继续跑了。transcript 里已有原任务与(可能的)部分进展,模型自查
       // 进度接着做。send 失败恢复红条让用户能重试。
+      await rebuildClaudeSubscriptionSessionBeforeRetry(
+        errorTailKind === 'error' ? errorTailMsg.errorReason : null,
+      );
       await makerChatStore.sendUiTrigger(
         sessionId,
         errorTailKind === 'interrupted'
@@ -1427,7 +1451,7 @@ export function CCAgentSessionView({
       setErrorTailBannerHiddenFor(null);
       toast.error(err instanceof Error ? err.message : String(err));
     }
-  }, [errorTailKind, errorTailMsg, sessionId]);
+  }, [errorTailKind, errorTailMsg, rebuildClaudeSubscriptionSessionBeforeRetry, sessionId]);
   const handleErrorTailDismiss = useCallback(() => {
     if (!sessionId || !errorTailMsg) return;
     // store 乐观置 errorDismissed(banner 即刻熄灭、切会话回来不复现)+ 持久化
@@ -2629,10 +2653,12 @@ export function CCAgentSessionView({
   // useSessionRunningStatus 在 running 上升沿把 orphan 的 error 角标 explicit 清掉。
   // 失败路径则天然保留红点,与仍在展示的横幅一致。
   const handleRetry = useCallback(() => {
-    void retryLastError().catch((error) => {
-      log.warn('retryLastError failed', error);
-    });
-  }, [retryLastError]);
+    void rebuildClaudeSubscriptionSessionBeforeRetry(errorReason)
+      .then(() => retryLastError())
+      .catch((error) => {
+        log.warn('retryLastError failed', error);
+      });
+  }, [errorReason, rebuildClaudeSubscriptionSessionBeforeRetry, retryLastError]);
 
   const handleSwitchToClaudeSubscription = useCallback(async (): Promise<void> => {
     if (!sessionId || !session || !canSwitchToClaudeSubscription) return;

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5572,6 +5572,7 @@
       "credentialSwitchBusy": "Another Codex task is still running, so the provider for this session can't be applied yet (the shared Codex process needs a restart). Retry after those tasks finish.",
       "codexThreadStale": "Codex auth mode changed — this session can't continue. Start a new session to apply it.",
       "claudeGatewayOpusPlanMismatch": "This Opus request went through XD Gateway, not your Claude.ai subscription. That gateway route rejected the model. Switch to your Claude.ai subscription and retry, or choose another model.",
+      "claudeSubscriptionOpusPlanMismatch": "Opus isn't available on the connected Claude Pro plan. Switch to a model included in your plan. If you recently upgraded, reconnect Anthropic in Settings, then retry.",
       "switchClaudeSubscription": "Switch to Claude.ai & Retry",
       "switchClaudeSubscriptionTitle": "Switch this session to the Claude.ai subscription and retry",
       "switchingClaudeSubscription": "Switching to Claude.ai…",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5570,6 +5570,7 @@
       "credentialSwitchBusy": "他の Codex タスクが実行中のため、このセッションで選択したプロバイダーへまだ切り替えられません（共有 Codex プロセスの再起動が必要です）。他のタスクの終了後に「再試行」を押してください。",
       "codexThreadStale": "Codex の認証モードが切り替わりました。このセッションは続行できません。新しいセッションを開始してください。",
       "claudeGatewayOpusPlanMismatch": "この Opus リクエストは Claude.ai サブスクリプションではなく、XD Gateway 経由で送信され、このモデルが拒否されました。Claude.ai サブスクリプションに切り替えて再試行するか、別のモデルを選択してください。",
+      "claudeSubscriptionOpusPlanMismatch": "接続中の Claude Pro プランでは Opus を利用できません。プランに含まれるモデルに切り替えてください。最近プランを変更した場合は、設定で Anthropic を再接続してから再試行してください。",
       "switchClaudeSubscription": "Claude.ai に切り替えて再試行",
       "switchClaudeSubscriptionTitle": "このセッションを Claude.ai サブスクリプションに切り替えて再試行",
       "switchingClaudeSubscription": "Claude.ai に切り替え中…",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5570,6 +5570,7 @@
       "credentialSwitchBusy": "다른 Codex 작업이 실행 중이어서 이 세션에서 선택한 제공자로 아직 전환할 수 없습니다(공유 Codex 프로세스 재시작 필요). 다른 작업이 끝난 후 ‘재시도’를 눌러 주세요.",
       "codexThreadStale": "Codex 인증 모드가 변경되었습니다. 이 세션은 계속할 수 없습니다. 새 세션을 시작하세요.",
       "claudeGatewayOpusPlanMismatch": "이 Opus 요청은 Claude.ai 구독이 아니라 XD Gateway를 통해 전송되었고, 해당 게이트웨이 경로에서 모델을 거부했습니다. Claude.ai 구독으로 전환해 다시 시도하거나 다른 모델을 선택하세요.",
+      "claudeSubscriptionOpusPlanMismatch": "현재 연결된 Claude Pro 요금제에서는 Opus를 사용할 수 없습니다. 요금제에 포함된 모델로 전환하세요. 최근 요금제를 업그레이드했다면 설정에서 Anthropic을 다시 연결한 후 재시도하세요.",
       "switchClaudeSubscription": "Claude.ai로 전환 후 재시도",
       "switchClaudeSubscriptionTitle": "이 세션을 Claude.ai 구독으로 전환하고 다시 시도",
       "switchingClaudeSubscription": "Claude.ai로 전환하는 중…",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5570,6 +5570,7 @@
       "credentialSwitchBusy": "Codex 正在其它任务中运行，暂时无法按本任务选择的模型来源切换（需要重启共享的 Codex 后台进程）。等它结束后点「重试」即可。",
       "codexThreadStale": "Codex 鉴权模式已切换，当前任务无法继续 —— 请新建任务后生效。",
       "claudeGatewayOpusPlanMismatch": "这次 Opus 请求实际走的是 XD Gateway，不是你的 Claude.ai 订阅；该网关路由拒绝了此模型。可切换到 Claude.ai 订阅后重试，或换一个模型。",
+      "claudeSubscriptionOpusPlanMismatch": "当前连接的 Claude Pro 套餐不支持 Opus。请切换到套餐支持的模型；如果刚升级套餐，请在设置中重新连接 Anthropic 后重试。",
       "switchClaudeSubscription": "切换到 Claude.ai 并重试",
       "switchClaudeSubscriptionTitle": "把当前任务切换到 Claude.ai 订阅并重试",
       "switchingClaudeSubscription": "正在切换到 Claude.ai…",

--- a/apps/desktop/src/shared/__tests__/claudeGatewayError.test.ts
+++ b/apps/desktop/src/shared/__tests__/claudeGatewayError.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON,
+  CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON,
   classifyClaudeGatewayError,
+  classifyClaudeSubscriptionError,
   type ClaudeGatewayErrorContext,
 } from '../claudeGatewayError';
 
@@ -29,7 +31,31 @@ describe('classifyClaudeGatewayError', () => {
     { label: 'non-400 response', status: 429 },
     { label: 'non-Opus model', modelId: 'claude-sonnet-5' },
     { label: 'unrelated error', error: 'model unavailable' },
-  ])('does not guess for $label', ({ label: _label, ...overrides }) => {
+  ])('does not guess for $label', (overrides) => {
     expect(classify(overrides)).toBeNull();
+  });
+});
+
+describe('classifyClaudeSubscriptionError', () => {
+  it('attributes the direct subscription Opus 400 to the Claude.ai plan', () => {
+    expect(
+      classifyClaudeSubscriptionError({
+        modelId: 'claude-opus-5',
+        requestRoute: 'subscription',
+        status: 400,
+        error: planError,
+      }),
+    ).toBe(CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON);
+  });
+
+  it('does not attribute a Gateway response to the Claude.ai plan', () => {
+    expect(
+      classifyClaudeSubscriptionError({
+        modelId: 'claude-opus-5',
+        requestRoute: 'gateway',
+        status: 400,
+        error: planError,
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/shared/claudeGatewayError.ts
+++ b/apps/desktop/src/shared/claudeGatewayError.ts
@@ -1,6 +1,6 @@
 /**
  * Claude Code 会把部分上游 400 统一翻译成 Claude.ai 套餐提示。Cindy 必须按实际
- * 请求路由归因：Gateway 路由的 Pro/Max 判断不属于用户的 Claude.ai 账号，而订阅
+ * 请求路由归因：Gateway 路由的 Pro 判断不属于用户的 Claude.ai 账号，而订阅
  * 直连路由则确实反映 Claude.ai 账号的套餐限制。
  */
 

--- a/apps/desktop/src/shared/claudeGatewayError.ts
+++ b/apps/desktop/src/shared/claudeGatewayError.ts
@@ -1,10 +1,16 @@
 /**
- * Claude Code 会把部分上游 400 统一翻译成 Claude.ai 套餐提示。若请求实际走的是
- * XD Gateway，这段提示里的 Pro/Max 判断并不属于用户的 Claude.ai 账号，不能原样
- * 展示成“重新登录 Claude.ai”建议。
+ * Claude Code 会把部分上游 400 统一翻译成 Claude.ai 套餐提示。Cindy 必须按实际
+ * 请求路由归因：Gateway 路由的 Pro/Max 判断不属于用户的 Claude.ai 账号，而订阅
+ * 直连路由则确实反映 Claude.ai 账号的套餐限制。
  */
 
 export const CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON = 'claude-gateway-opus-plan-mismatch';
+export const CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON =
+  'claude-subscription-opus-plan-mismatch';
+
+export type ClaudeOpusPlanMismatchReason =
+  | typeof CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON
+  | typeof CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON;
 
 const CLAUDE_PRO_OPUS_ERROR = /Claude Opus is not available with the Claude Pro plan/i;
 
@@ -15,6 +21,14 @@ export interface ClaudeGatewayErrorContext {
   error: string;
 }
 
+function isClaudeProOpusPlanMismatch(context: ClaudeGatewayErrorContext): boolean {
+  return (
+    context.status === 400 &&
+    context.modelId.startsWith('claude-opus-') &&
+    CLAUDE_PRO_OPUS_ERROR.test(context.error)
+  );
+}
+
 /**
  * 只按同一个 proxy 请求的精确路由与上游响应归因。会话 provider、最近路由或
  * terminal event 到达时的活性状态都不是请求级证据，不能参与这个判定。
@@ -22,13 +36,16 @@ export interface ClaudeGatewayErrorContext {
 export function classifyClaudeGatewayError(
   context: ClaudeGatewayErrorContext,
 ): typeof CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON | null {
-  if (
-    context.requestRoute !== 'gateway' ||
-    context.status !== 400 ||
-    !context.modelId.startsWith('claude-opus-') ||
-    !CLAUDE_PRO_OPUS_ERROR.test(context.error)
-  ) {
-    return null;
-  }
-  return CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON;
+  return context.requestRoute === 'gateway' && isClaudeProOpusPlanMismatch(context)
+    ? CLAUDE_GATEWAY_OPUS_PLAN_MISMATCH_REASON
+    : null;
+}
+
+/** 直连 Claude.ai 订阅时，错误确实代表当前账号的套餐不支持 Opus。 */
+export function classifyClaudeSubscriptionError(
+  context: ClaudeGatewayErrorContext,
+): typeof CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON | null {
+  return context.requestRoute === 'subscription' && isClaudeProOpusPlanMismatch(context)
+    ? CLAUDE_SUBSCRIPTION_OPUS_PLAN_MISMATCH_REASON
+    : null;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 对 Opus 套餐限制返回的原始错误会建议执行 `/logout`、`/login`，但这两个命令在 Cindy 环境不可用。PR #1311 已修复错误路由问题；本 PR 补齐真实 Claude.ai 订阅直连场景下的错误归因，并将提示改成 Cindy 内可执行的操作。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PR #1311 的后续错误提示处理
- 本 PR 包含：
  - 区分 Cindy Gateway 与 Claude.ai 订阅直连的 Opus 套餐错误原因。
  - 订阅直连命中同类 400 错误时，使用 Cindy 本地化提示。
  - 提示用户切换套餐支持的模型；近期升级套餐时，可在设置中重新连接 Anthropic 后重试。
  - 保留原始上游错误的展开查看能力，并补充两种路由的回归测试。
- 明确不包含：
  - 不修改 PR #1311 已完成的 provider 路由校准逻辑，也不重复实现路由修复。
  - 不新增 `/logout`、`/login` 命令，不修改服务端、数据库或认证协议。
- 用户可见变化：不再默认显示当前环境不可用的 `/logout`、`/login` 建议；改为显示可在 Cindy 内完成的处理方式。
- 是否存在 breaking change：无

### UI 变化

- 错误卡片的用户可见文案有变化；布局、交互结构和主题样式不变。未附朋友设备截图，本 PR 未操作朋友电脑或真实账号。
- 引用的设计规范：`docs/design-rules/DESIGN.md §10 Theme System & Token Reference`（Light / Dark Dual-Mode Delivery Gate）与 `§11 Voice & Content`。文案覆盖 en / zh-CN / ja / ko，复用现有 ErrorBanner 的主题语义 token，并保留原始错误展开入口。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-claude-routing-error-copy
结果：GATE_EXIT=0，全量 pnpm test:unit 通过。

pnpm --filter desktop exec vitest run --config vitest.config.ts src/renderer/__tests__/draftModelCalibration.test.ts src/shared/__tests__/claudeGatewayError.test.ts src/main/maker-host/__tests__/claudeGatewayErrorObserver.test.ts src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
结果：4 个测试文件、77 个测试全部通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm check:i18n-glossary && pnpm check:i18n
结果：通过；四种语言 key parity 通过。

pnpm check:dco
结果：通过；1 个 commit 带 DCO 签名。

git diff --check、定向 ESLint 与 Prettier 检查
结果：通过。register.ts 的全文件 ESLint 仍存在基线中的 4 个 unused-import 问题，本 PR 未扩大范围处理。
```

### 手工验证

不涉及真实账号手工验证：本次没有操作朋友的电脑或授权状态；通过路由分类、observer、ErrorBanner 和持久化错误文案测试覆盖行为。

### 未执行的验证

未在朋友设备上做真实 Claude.ai 套餐 E2E，原因是该设备和账号不在本地工作区范围内；建议合入后由有问题的账号验证“切换模型”和“设置中重新连接 Anthropic”两条路径。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Claude Code 的 Opus 套餐错误归因和错误提示；不影响正常请求路由或认证状态。
- 回滚 / 降级方式：回滚 commit `99eedea605475b3df111e31e798ab77074b55f98` 即可恢复原有错误提示逻辑；PR #1311 的路由修复不在本 PR 回滚范围内。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认本次无需新增文档
- [x] 已确认测试结果或说明未执行原因
