### PR TITLE
fix(auto-review): 降级后 SDK 档位缺补推点,故障窗口里会与逻辑状态分叉

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -242,6 +242,9 @@ describe('Auto-review wiring: native first, Cindy fallback', () => {
 
     fakeQuery.setPermissionMode.mockRejectedValueOnce(new Error('transport not ready'));
     await handle.useCindyAutoReviewFallback?.();
+    // 收敛推送排在串行队列里,轮到它执行要过一个 microtask;这一次会被拒。
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(fakeQuery.setPermissionMode).toHaveBeenCalledWith('default');
     // 状态本身不受推送失败影响:审批已经落到 Cindy reviewer 上。
     await canUseTool('Bash', { command: 'npx tsc --noEmit' }, { toolUseID: 'after-failed-push' });
     expect(reviewAutoPermissionAction).toHaveBeenCalledOnce();
@@ -249,7 +252,154 @@ describe('Auto-review wiring: native first, Cindy fallback', () => {
     // 欠账留着 → 下一个 turn 起点补推,SDK 与状态重新对齐。
     fakeQuery.setPermissionMode.mockClear();
     await handle.send({ type: 'user', content: 'next turn' });
+    // 收敛推送排在串行队列里,轮到它执行要过一个 microtask。
+    await new Promise((resolve) => setImmediate(resolve));
     expect(fakeQuery.setPermissionMode).toHaveBeenCalledWith('default');
+    await handle.close();
+  });
+
+  /**
+   * 档位写入的并发探针:记录写入顺序、同时在飞的写入数,并把每次写入挂住由测试逐个放行。
+   * `maxLive` 是这批用例的核心断言 —— 「同一时刻只有一个控制写入」。
+   */
+  function instrumentModeWrites(fakeQuery: { setPermissionMode: ReturnType<typeof vi.fn> }) {
+    const order: string[] = [];
+    const releases: Array<(err?: Error) => void> = [];
+    let live = 0;
+    let maxLive = 0;
+    fakeQuery.setPermissionMode.mockImplementation(async (mode: string) => {
+      live += 1;
+      maxLive = Math.max(maxLive, live);
+      order.push(mode);
+      try {
+        await new Promise<void>((resolve, reject) => {
+          releases.push((err) => (err ? reject(err) : resolve()));
+        });
+      } finally {
+        live -= 1;
+      }
+    });
+    return {
+      order,
+      releaseNext: (err?: Error) => releases.shift()?.(err),
+      pending: () => releases.length,
+      maxLive: () => maxLive,
+    };
+  }
+  const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+  it('never runs two mode writes at once, even from two different call sites', async () => {
+    // 第一版把「串行域」做成了一个布尔量,只有收敛推送查它,而且先完成的请求会把它提前
+    // 清零 —— 两个调用点照旧并发,旧请求晚落地就会盖掉最新档位(greptile/copilot/codex P1)。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+    const writes = instrumentModeWrites(fakeQuery);
+
+    const userChange = handle.setPermissionMode?.('acceptEdits');
+    await tick();
+    // 用户那次写入还挂着,降级信号到达 —— 它不得并发发出第二个控制请求。
+    void handle.useCindyAutoReviewFallback?.();
+    await tick();
+    expect(writes.order).toEqual(['acceptEdits']);
+    expect(writes.maxLive()).toBe(1);
+
+    writes.releaseNext();
+    await userChange;
+    await tick();
+    await tick();
+    // 用户已经不在 Auto 档 → auto-review 不该把档位推回 Auto 对应的值,这次收敛整个作废。
+    expect(writes.order).toEqual(['acceptEdits']);
+    expect(writes.maxLive()).toBe(1);
+    expect(writes.pending()).toBe(0);
+    await handle.close();
+  });
+
+  it('drops an already-queued convergence when the user leaves Auto before it runs', async () => {
+    // 收敛推送入队时还在 Auto,轮到它执行前用户切走了档位。此时它必须整个作废 —— 否则会在
+    // 用户档位与它之间插进一次「Auto 对应的档位」,那一瞬间的权限面不是用户选的那个。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+    const writes = instrumentModeWrites(fakeQuery);
+
+    // 先占住队列,让后面两个意图都只能排队。
+    const firstChange = handle.setPermissionMode?.('auto');
+    await tick();
+    expect(writes.order).toEqual(['auto']);
+    // 队列被占住期间:先降级(此刻仍在 Auto,收敛入队),再让用户切走档位。
+    void handle.useCindyAutoReviewFallback?.();
+    await tick();
+    void handle.setPermissionMode?.('acceptEdits');
+    await tick();
+    expect(writes.order).toEqual(['auto']);
+
+    // 逐个放行,直到队列排空。
+    for (let i = 0; i < 5 && writes.pending() > 0; i += 1) {
+      writes.releaseNext();
+      await tick();
+      await tick();
+    }
+    await firstChange;
+    // 中间**不得**出现 'default':那次收敛在轮到自己时发现已不在 Auto,整个作废。
+    expect(writes.order).toEqual(['auto', 'acceptEdits']);
+    expect(writes.maxLive()).toBe(1);
+    await handle.close();
+  });
+
+  it('keeps the queue alive after a failed write and still converges', async () => {
+    // 队列不能被一次失败毒化:失败的那次留欠账,排在它后面的写入照常执行,
+    // 最终 SDK 档位仍等于当前逻辑状态。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+    const writes = instrumentModeWrites(fakeQuery);
+
+    void handle.useCindyAutoReviewFallback?.();
+    await tick();
+    expect(writes.order).toEqual(['default']);
+    // 第一次写入失败。
+    writes.releaseNext(new Error('transport not ready'));
+    await tick();
+    await tick();
+
+    // 队列仍可用:下一个 turn 起点兑欠账,重新推 default。
+    await Promise.all([
+      handle.send({ type: 'user', content: 'next turn' }),
+      (async () => {
+        await tick();
+        while (writes.pending() > 0) {
+          writes.releaseNext();
+          await tick();
+        }
+      })(),
+    ]);
+    expect(writes.order).toEqual(['default', 'default']);
+    expect(writes.maxLive()).toBe(1);
+    await handle.close();
+  });
+
+  it('holds the owed convergence through a plan window and lands it on exit', async () => {
+    // plan 档恒在 plan:降级只能记欠账。退出 plan 是补推点,此时必须把 default 收口,
+    // 而不是留下「逻辑已 fallback、SDK 仍是 auto」的分叉。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+    await handle.setPlanMode?.(true);
+    fakeQuery.setPermissionMode.mockClear();
+
+    await handle.useCindyAutoReviewFallback?.();
+    // plan 窗口里一次都不推。
+    expect(fakeQuery.setPermissionMode).not.toHaveBeenCalled();
+
+    await handle.setPlanMode?.(false);
+    await new Promise((resolve) => setImmediate(resolve));
+    // 退出 plan 自己推的那次已经现算含 auto-review 状态,收口在 default。
+    expect(fakeQuery.setPermissionMode).toHaveBeenLastCalledWith('default');
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -433,6 +433,39 @@ describe('Auto-review wiring: native first, Cindy fallback', () => {
     await handle.close();
   });
 
+  it('holds the turn until an owed mode write has actually landed', async () => {
+    // 补推只"排进队列"不代表已生效。若本轮输入能抢在档位之前入队,这一轮就会先以旧档起跑,
+    // 前几个工具照旧撞在故障中的原生分类器上(codex P2)。这里钉住顺序:欠着一次收敛时,
+    // send 必须等它落地才继续。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+
+    // 先制造欠账:第一次写入失败。
+    fakeQuery.setPermissionMode.mockRejectedValueOnce(new Error('transport not ready'));
+    await handle.useCindyAutoReviewFallback?.();
+    await tick();
+
+    // 下一 turn 的补推挂住,send 不得先行返回。
+    let releaseOwedWrite!: () => void;
+    const owedGate = new Promise<void>((resolve) => { releaseOwedWrite = resolve; });
+    fakeQuery.setPermissionMode.mockImplementationOnce(async () => { await owedGate; });
+
+    let sendSettled = false;
+    const sendPromise = handle.send({ type: 'user', content: 'next turn' })
+      .then(() => { sendSettled = true; });
+    await tick();
+    await tick();
+    expect(fakeQuery.setPermissionMode).toHaveBeenCalledWith('default');
+    expect(sendSettled).toBe(false);
+
+    releaseOwedWrite();
+    await sendPromise;
+    expect(sendSettled).toBe(true);
+    await handle.close();
+  });
+
   it('does not touch the SDK mode on a turn with nothing owed', async () => {
     // 补推点必须是「有欠账才动」:每个 turn 无条件推一次档会给 send 入口加一个控制请求,
     // 也会掩盖真正的状态分叉。

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -230,6 +230,71 @@ describe('Auto-review wiring: native first, Cindy fallback', () => {
     expect(permissionRequests(seen)).toHaveLength(0);
     await handle.close();
   });
+
+  it('retries the owed mode push on the next turn when the control request failed', async () => {
+    // 这是 main 上的真实缺陷:降级把状态置成「走 Cindy 审阅」,但档位推送失败后没有任何
+    // 补推点 —— SDK 留在 auto,工具继续进**故障中的**原生分类器,正是降级要消除的硬拒绝。
+    const { handle, canUseTool, fakeQuery, reviewAutoPermissionAction } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+      reviewVerdict: 'allow',
+    });
+
+    fakeQuery.setPermissionMode.mockRejectedValueOnce(new Error('transport not ready'));
+    await handle.useCindyAutoReviewFallback?.();
+    // 状态本身不受推送失败影响:审批已经落到 Cindy reviewer 上。
+    await canUseTool('Bash', { command: 'npx tsc --noEmit' }, { toolUseID: 'after-failed-push' });
+    expect(reviewAutoPermissionAction).toHaveBeenCalledOnce();
+
+    // 欠账留着 → 下一个 turn 起点补推,SDK 与状态重新对齐。
+    fakeQuery.setPermissionMode.mockClear();
+    await handle.send({ type: 'user', content: 'next turn' });
+    expect(fakeQuery.setPermissionMode).toHaveBeenCalledWith('default');
+    await handle.close();
+  });
+
+  it('serializes the fallback push behind an in-flight user mode change', async () => {
+    // 两个并发的档位控制请求,落地顺序不由 harness 保证,后到的会盖掉先到的。这里的不变量
+    // 是:同一时刻只有一个在飞,且最后落地的一定是**当前状态**现算出来的档位。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+
+    let releaseUserPush!: () => void;
+    const userPushGate = new Promise<void>((resolve) => { releaseUserPush = resolve; });
+    fakeQuery.setPermissionMode.mockClear();
+    fakeQuery.setPermissionMode.mockReturnValueOnce(userPushGate);
+
+    const userChange = handle.setPermissionMode?.('auto');
+    await new Promise((resolve) => setImmediate(resolve));
+    // 用户那次 push 还在飞 → 降级只记欠账,不并发推第二个控制请求。
+    await handle.useCindyAutoReviewFallback?.();
+    expect(fakeQuery.setPermissionMode).toHaveBeenCalledTimes(1);
+    expect(fakeQuery.setPermissionMode).toHaveBeenCalledWith('auto');
+
+    releaseUserPush();
+    await userChange;
+    await new Promise((resolve) => setImmediate(resolve));
+    // 收尾时兑欠账,现算出的目标是 default(降级已落地),顺序确定。
+    expect(fakeQuery.setPermissionMode).toHaveBeenCalledTimes(2);
+    expect(fakeQuery.setPermissionMode).toHaveBeenNthCalledWith(1, 'auto');
+    expect(fakeQuery.setPermissionMode).toHaveBeenNthCalledWith(2, 'default');
+    await handle.close();
+  });
+
+  it('does not touch the SDK mode on a turn with nothing owed', async () => {
+    // 补推点必须是「有欠账才动」:每个 turn 无条件推一次档会给 send 入口加一个控制请求,
+    // 也会掩盖真正的状态分叉。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+    fakeQuery.setPermissionMode.mockClear();
+    await handle.send({ type: 'user', content: 'nothing owed' });
+    expect(fakeQuery.setPermissionMode).not.toHaveBeenCalled();
+    await handle.close();
+  });
 });
 
 describe('Auto-review wiring: safe builtin tools auto-approve silently', () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -377,7 +377,9 @@ describe('Auto-review wiring: native first, Cindy fallback', () => {
         }
       })(),
     ]);
-    expect(writes.order).toEqual(['default', 'default']);
+    // 三次:失败的那次 + turn 起点兑欠账 + 输入入队前按本轮意图的复核(队列非空时无条件做,
+    // 目标已一致时也重复 push 一次 —— 换来的是"输入之前最后落地的档位恒等于本轮意图")。
+    expect(writes.order).toEqual(['default', 'default', 'default']);
     expect(writes.maxLive()).toBe(1);
     await handle.close();
   });
@@ -463,6 +465,49 @@ describe('Auto-review wiring: native first, Cindy fallback', () => {
     releaseOwedWrite();
     await sendPromise;
     expect(sendSettled).toBe(true);
+    await handle.close();
+  });
+
+  it('does not let a queued plan write leak into an explicit normal turn', async () => {
+    // 上一轮加的"等队列排空"把一个随机竞态变成了确定性 bug:setPlanMode(true) 的 'plan'
+    // 写入被前面的请求卡在队列里时 sdkInPlanMode 仍是 false,send 头部那条"显式普通消息
+    // 要降档"的分支不触发;等队列排空恰好保证那条**过期的** plan literal 一定在输入之前
+    // 落地,这一轮就整轮跑在 Plan 档上(codex P2)。所以等完必须按本轮意图再收一次口。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+    const writes = instrumentModeWrites(fakeQuery);
+
+    // ① 占住队列,后面的意图只能排队。
+    const occupying = handle.setPermissionMode?.('auto');
+    await tick();
+    expect(writes.order).toEqual(['auto']);
+
+    // ② plan 写入排队(还没落地,所以 sdkInPlanMode 仍是 false)。
+    const planOn = handle.setPlanMode?.(true);
+    await tick();
+    expect(writes.order).toEqual(['auto']);
+
+    // ③ 本轮是**显式普通消息**。
+    const sendPromise = handle.send({ type: 'user', content: 'normal turn' }, { planMode: false });
+    await tick();
+
+    // 逐个放行,直到 send 收尾(复核写入是在等待之后才入队的,所以不能只按 pending 判停)。
+    for (let i = 0; i < 10; i += 1) {
+      if (writes.pending() > 0) writes.releaseNext();
+      await tick();
+      await tick();
+    }
+    await sendPromise;
+    await occupying;
+    await planOn;
+
+    // 那条排队的 'plan' 确实执行过(它是队列里的旧意图)……
+    expect(writes.order).toContain('plan');
+    // ……但输入入队之前**最后落地**的档位必须是本轮意图对应的档,不是 plan。
+    expect(writes.order[writes.order.length - 1]).toBe('auto');
+    expect(writes.maxLive()).toBe(1);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/auto-review-wiring.test.ts
@@ -508,6 +508,67 @@ describe('Auto-review wiring: native first, Cindy fallback', () => {
     // ……但输入入队之前**最后落地**的档位必须是本轮意图对应的档,不是 plan。
     expect(writes.order[writes.order.length - 1]).toBe('auto');
     expect(writes.maxLive()).toBe(1);
+
+    // 复核落地后 sdkInPlanMode 必须同步成 false。否则那条仍在等待的 setPlanMode(true) 会把
+    // 它置成 true,而 SDK 实际已被复核写回普通档 —— 下一条**真正的** plan 消息就会因为
+    // 「标记说已在 plan」而跳过补推,整轮按普通权限档跑(codex P2)。
+    const planTurn = handle.send({ type: 'user', content: 'real plan turn' }, { planMode: true });
+    for (let i = 0; i < 6; i += 1) {
+      if (writes.pending() > 0) writes.releaseNext();
+      await tick();
+      await tick();
+    }
+    await planTurn;
+    expect(writes.order).toContain('plan');
+    expect(writes.order.filter((m) => m === 'plan')).toHaveLength(2);
+    await handle.close();
+  });
+
+  it('pushes the rolled-back mode to the SDK when a user mode change fails', async () => {
+    // 目标档是现算的,所以队列里排在前面的写入可能已经把 SDK 推到了**更新的**那一档。若后一次
+    // 改档随后失败,只回滚 mutablePermissionMode 会让 SDK 长期停在那个更宽的档上(典型:停在
+    // Full access),与界面和本地权限状态不符(codex P1)。
+    const { handle, fakeQuery } = await startSession('auto', {
+      providerId: 'anthropic',
+      authSource: 'oauth',
+    });
+    const writes = instrumentModeWrites(fakeQuery);
+
+    // ① 占住队列。
+    const occupying = handle.setPermissionMode?.('auto');
+    await tick();
+    expect(writes.order).toEqual(['auto']);
+    // ② 两次改档都只能排队;后者先把 mutablePermissionMode 推到 bypassPermissions。
+    const toAcceptEdits = handle.setPermissionMode?.('acceptEdits');
+    await tick();
+    const toFullAccess = handle.setPermissionMode?.('bypassPermissions').catch(() => {});
+    await tick();
+    expect(writes.order).toEqual(['auto']);
+
+    // ③ 放行 ①;②-前一条现算出的是最新的 bypassPermissions,落地。
+    writes.releaseNext();
+    await tick();
+    await tick();
+    writes.releaseNext();
+    await tick();
+    await tick();
+    // 两次排队的改档都现算成最新那一档;放行两次之后第三条已经起跑。
+    expect(writes.order.slice(0, 3)).toEqual(['auto', 'bypassPermissions', 'bypassPermissions']);
+    // ④ ②-后一条(bypassPermissions 那次调用自己的写入)失败 → 触发回滚。
+    writes.releaseNext(new Error('transport not ready'));
+    await tick();
+    await tick();
+    // ⑤ 回滚不只改本地:必须把 SDK 也收回去。
+    for (let i = 0; i < 4; i += 1) {
+      if (writes.pending() > 0) writes.releaseNext();
+      await tick();
+      await tick();
+    }
+    await occupying;
+    await toAcceptEdits;
+    await toFullAccess;
+    expect(writes.order[writes.order.length - 1]).toBe('acceptEdits');
+    expect(writes.maxLive()).toBe(1);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -305,6 +305,48 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     await handle.close();
   });
 
+  it('drops a queued permission-mode write when the query was replaced while it waited', async () => {
+    // 档位写入是串行队列,排队期间 `q` 可能被换掉(invalid-resume 自救 / rewind 重建)。新
+    // Query 的起档已由 buildQuery 用 effectiveSdkPermissionMode() 按**最新状态**初始化,旧
+    // Query 排的那条写入若落到新 Query 上,就用一个为旧上下文算出的档位盖掉它 —— SDK 档位
+    // 与逻辑状态重新分叉(copilot / codex P1 of #1612)。这里钉住:换过 Query 就丢弃。
+    const { handle, firstQuery } = await startRewindableSession();
+
+    // ① 用一次挂住的写入占住队列,后面的意图只能排队(而不是立刻执行)。
+    let releaseFirstWrite!: () => void;
+    const firstWriteGate = new Promise<void>((resolve) => { releaseFirstWrite = resolve; });
+    firstQuery.setPermissionMode.mockImplementationOnce(async () => { await firstWriteGate; });
+    const occupying = handle.setPermissionMode?.('auto');
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(firstQuery.setPermissionMode).toHaveBeenCalledTimes(1);
+
+    // ② 队列被占住期间进 plan:入队一条 literal 'plan'(为旧 Query 算出的目标档)。
+    const planOn = handle.setPlanMode?.(true);
+    await new Promise((resolve) => setImmediate(resolve));
+    // ③ 再退出 plan:逻辑状态已回到非 plan,队列里那条 'plan' 就成了**过期 literal**。
+    const planOff = handle.setPlanMode?.(false);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // ④ 换 Query:旧 q 被 close,新 q 的起档由 buildQuery 按当前(非 plan)状态算出。
+    await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');
+    const secondQuery = createFakeQuery();
+    sdkMock.query.mockReturnValue(secondQuery);
+
+    const sendPromise = handle.send({ type: 'user', content: 'after rewind' });
+    await new Promise((resolve) => setImmediate(resolve));
+    releaseFirstWrite();
+    await sendPromise;
+    await occupying;
+    await planOn;
+    await planOff;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    // 关键断言:那条为旧 Query 排的 'plan' 不得落到新 Query 上 —— 否则这一轮普通 turn 会以
+    // plan 档跑,工具权限面与 mutablePlanMode / sdkInPlanMode 分叉。
+    expect(secondQuery.setPermissionMode).not.toHaveBeenCalledWith('plan');
+    await handle.close();
+  });
+
   it('replays max without downgrading it when effort changes during query rebuild', async () => {
     const { handle } = await startRewindableSession();
     await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3832,10 +3832,16 @@ export class ClaudeCodeAgent extends BaseAgent {
           replayed = true;
           const targetSdkMode = sdkMode;
           try {
-            await pushSdkPermissionMode(targetSdkMode);
-            sdkInPlanMode = targetSdkMode === 'plan';
-            snapshot.sdkPermissionMode = targetSdkMode;
-            log.debug(`${label}: replayed setPermissionMode`, { sdkMode: targetSdkMode });
+            // 只有真的落地才回写本地记账:队列在 Query 已被替换时返回 null(那次写入被丢弃),
+            // 无条件回写会把"没落地"记成"已落地",后续 plan 补推会被错误跳过(copilot)。
+            const applied = await enqueueSdkPermissionModePush(targetSdkMode);
+            if (applied !== null) {
+              sdkInPlanMode = applied === 'plan';
+              snapshot.sdkPermissionMode = applied;
+              log.debug(`${label}: replayed setPermissionMode`, { sdkMode: applied });
+            } else {
+              log.debug(`${label}: setPermissionMode replay dropped (query replaced)`, { sdkMode: targetSdkMode });
+            }
           } catch (e) {
             log.warn(`${label}: replay setPermissionMode failed`, { error: String(e) });
           }
@@ -3907,8 +3913,8 @@ export class ClaudeCodeAgent extends BaseAgent {
           // effectiveSdkPermissionMode()(planTurnActive 已置 true → 'plan') 起档。
           if (!sdkInPlanMode && !controlRequestsBlocked()) {
             try {
-              await pushSdkPermissionMode('plan');
-              sdkInPlanMode = true;
+              // 同上:被丢弃的写入不得把 sdkInPlanMode 记成 true(copilot)。
+              if (await enqueueSdkPermissionModePush('plan') !== null) sdkInPlanMode = true;
             } catch (e) {
               log.warn('deferred plan-mode SDK switch failed — sending as a normal turn', { error: String(e) });
             }
@@ -4201,7 +4207,11 @@ export class ClaudeCodeAgent extends BaseAgent {
           if (sdkPermissionModeQueueDepth > 0) {
             await sdkPermissionModeQueue;
             try {
-              await enqueueSdkPermissionModePush(() => currentTurnSdkPermissionMode());
+              // 复核落地后必须同步 sdkInPlanMode:否则那条仍在等待的 setPlanMode(true) 之后会把
+              // 它置成 true,而 SDK 实际已被复核写回普通档 —— 下一条真正的 plan 消息会因为
+              // 「标记说已在 plan」而跳过补推,整轮按普通权限档跑(codex P2)。
+              const applied = await enqueueSdkPermissionModePush(() => currentTurnSdkPermissionMode());
+              if (applied !== null) sdkInPlanMode = applied === 'plan';
             } catch (e) {
               // 复核失败不该把用户这条消息毙掉(与既有的 best-effort 档位调用点同款);记欠账,
               // 下一个补推点重试。这一轮可能跑在旧档上,已在日志里留痕。
@@ -4722,6 +4732,20 @@ export class ClaudeCodeAgent extends BaseAgent {
             // 推送失败保持 main 的语义:本次改档视为未生效。只在没人在此期间改过档时才回滚,
             // 否则会把别人刚设好的档抹掉。
             if (mutablePermissionMode === newMode) mutablePermissionMode = previousMode;
+            // **回滚本地状态还不够,SDK 也要收回去。** 目标档是现算的,所以队列里排在前面的
+            // 写入可能已经把 SDK 推到了这次(更新的)档位;这次失败只把 mutablePermissionMode
+            // 回滚,SDK 就会长期停在那个更宽的档上(典型:停在 Full access),与界面和本地状态
+            // 不符(codex P1)。这里排一次现算写入把它收回去,并记欠账兜住这次也失败的情况。
+            sdkPermissionModeSyncOwed = true;
+            void enqueueSdkPermissionModePush(() => toSdkPermissionMode(mutablePermissionMode))
+              .then(
+                (applied) => { if (applied !== null) sdkPermissionModeSyncOwed = false; },
+                (revertError: unknown) => {
+                  log.warn('permission mode rollback push failed; owed for the next opportunity', {
+                    error: String(revertError),
+                  });
+                },
+              );
             throw e;
           }
         }
@@ -4767,8 +4791,10 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 重建时 buildQuery 以 effectiveSdkPermissionMode() 起档并回写 sdkInPlanMode
           return;
         }
-        await pushSdkPermissionMode(sdkMode);
-        sdkInPlanMode = sdkMode === 'plan';
+        // 被丢弃的写入不得回写记账(copilot);重建路径本就会按 effectiveSdkPermissionMode()
+        // 起档并自行回写。
+        const appliedPlanMode = await enqueueSdkPermissionModePush(sdkMode);
+        if (appliedPlanMode !== null) sdkInPlanMode = appliedPlanMode === 'plan';
         // 退出 plan 时补推点:plan 档期间 auto-review 状态变过的话,欠账在这里兑。
         if (!enabled) flushOwedSdkPermissionModeSync('plan-mode-disabled');
       },

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3684,11 +3684,24 @@ export class ClaudeCodeAgent extends BaseAgent {
       target: SdkPermissionMode | (() => SdkPermissionMode | null),
     ): Promise<SdkPermissionMode | null> => {
       sdkPermissionModeQueueDepth += 1;
+      // **入队时钉住 Query 身份。** 排队期间 `q` 可能被换掉(invalid-resume 自救、rewind /
+      // bridge 重建),而新 Query 的起档已经由 `buildQuery` 用 `effectiveSdkPermissionMode()`
+      // 按**最新状态**初始化好了。旧 Query 的那次写入若落到新 Query 上,就会用一个为旧
+      // 上下文算出的档位盖掉这个已经正确的起档 —— 又造出「SDK 档位与逻辑状态分叉」,正是
+      // 本 PR 要消除的东西(copilot / codex P1)。所以换过 Query 就丢弃,不改成"现算后再写":
+      // 新 Query 本来就已经是现算的结果,再写一次只是多发一个控制请求。
+      const enqueuedQuery = q;
       const run = (async (): Promise<SdkPermissionMode | null> => {
         // 等前一个写入落地。成功或失败都算落地 —— 一次失败不该毒化整条队列。
         await sdkPermissionModeQueue;
+        // 先求值再判身份:取值函数自己带记账(收敛推送要在这里清"已排队"标记、必要时留欠账),
+        // 提前 return 会把那份记账永久卡住。身份不符时只丢弃**写入**。
         const resolved = typeof target === 'function' ? target() : target;
         if (resolved === null) return null;
+        if (q !== enqueuedQuery) {
+          log.debug('sdk permission mode write dropped: query was replaced while queued', { resolved });
+          return null;
+        }
         await q.setPermissionMode(resolved);
         return resolved;
       })();

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3654,47 +3654,100 @@ export class ClaudeCodeAgent extends BaseAgent {
      * 标记、不推档,而且没有任何补推点,于是留下「标记说走 Cindy 审阅、SDK 实际还在 auto
      * 档」的分叉:工具继续进故障中的原生分类器,正是降级本身要消除的硬拒绝。
      *
-     * 串行(`sdkPermissionModePushInFlight`)不是性能考虑:两个并发 push 的落地顺序不由这里
-     * 保证,后到的会盖掉先到的,而"谁后到"不可知。串行 + 现算之后,完成顺序不再进入判据。
+     * 串行不是性能考虑:两个并发 push 的落地顺序不由这里保证,后到的会盖掉先到的,而
+     * "谁后到"不可知。串行 + 现算之后,完成顺序不再进入判据。
      */
     let sdkPermissionModeSyncOwed = false;
-    let sdkPermissionModePushInFlight = false;
     /**
-     * 把一次档位控制请求纳入串行域。各调用点自己的 await / fire-and-forget 与错误处理都
-     * 不变,只是在飞期间挡住收敛推送(反之亦然)。
+     * 档位写入的**真串行队列**:所有调用点都排进这一条 promise chain,**执行顺序 == 入队
+     * 顺序**,所以最后入队的意图一定最后落地。
+     *
+     * 第一版只用一个布尔 `pushSdkPermissionModePushInFlight` 标记"有在飞",既没让调用点排队
+     * (只有收敛推送查它),又会被先完成的那个请求提前清零 —— 两个并发写入照旧发生,而且
+     * 队列状态还会说谎(greptile / copilot / codex P1 of #1612)。改成 chain + 计数。
+     *
+     * `sdkPermissionModeQueueDepth` 是**排队中 + 在飞**的写入数,只有全部落地才归零;
+     * 用它判断"是否仍有控制写入未 settle",不会被任一请求提前清掉。
      */
-    const pushSdkPermissionMode = async (target: SdkPermissionMode): Promise<void> => {
-      sdkPermissionModePushInFlight = true;
-      try {
-        await q.setPermissionMode(target);
-      } finally {
-        sdkPermissionModePushInFlight = false;
-      }
+    let sdkPermissionModeQueue: Promise<void> = Promise.resolve();
+    let sdkPermissionModeQueueDepth = 0;
+    /**
+     * 把一次档位控制请求排进串行队列。各调用点自己的 await / fire-and-forget 与错误处理、
+     * `sdkInPlanMode` 回写都不变。
+     *
+     * `target` 可以是**取值函数**:轮到自己执行时才现算,并可返回 `null` 表示"此刻已无事
+     * 可做"(收敛推送用它 —— 排队期间用户可能已改档、或又进了推不动的窗口)。传字面量的
+     * 调用点保持原语义:它们的目标档由各自的上下文算出(如 plan turn 起档恒为 `'plan'`、
+     * replay 用 `currentTurnSdkPermissionMode()` 刻意排除 arm 态),**不能**被统一现算覆盖。
+     */
+    const enqueueSdkPermissionModePush = (
+      target: SdkPermissionMode | (() => SdkPermissionMode | null),
+    ): Promise<SdkPermissionMode | null> => {
+      sdkPermissionModeQueueDepth += 1;
+      const run = (async (): Promise<SdkPermissionMode | null> => {
+        // 等前一个写入落地。成功或失败都算落地 —— 一次失败不该毒化整条队列。
+        await sdkPermissionModeQueue;
+        const resolved = typeof target === 'function' ? target() : target;
+        if (resolved === null) return null;
+        await q.setPermissionMode(resolved);
+        return resolved;
+      })();
+      // 队列本身永不 reject,否则后续所有写入都会被前一次失败带走。
+      sdkPermissionModeQueue = run.then(() => {}, () => {});
+      return run.finally(() => {
+        sdkPermissionModeQueueDepth -= 1;
+      });
     };
+    /** 兼容既有调用点的窄签名:目标档由调用点算好,行为与直接 `q.setPermissionMode` 一致。 */
+    const pushSdkPermissionMode = async (target: SdkPermissionMode): Promise<void> => {
+      await enqueueSdkPermissionModePush(target);
+    };
+    /** 已排队但还没执行的收敛推送:它轮到时会现算,所以不必再排第二个。 */
+    let sdkPermissionModeSyncQueued = false;
     /**
      * 状态变更后请求一次收敛。**同步返回、不 await** —— 它可能在 canUseTool 回调里被调用
      * (SDK 正等这个回调返回),也在 send 入口被调用(`docs/dev-rules/maker-core-and-agent-
      * behavior.md` §3.2 禁止在 send 路径上加串行等待)。
      */
     const syncSdkPermissionMode = (reason: string): void => {
+      // auto-review 只在 Auto 档决定 SDK 档位。用户在 Ask / acceptEdits / Full access 上时
+      // 这里**既不记欠账也不推档** —— 推了就是把用户当前选择改回去。等他切回 Auto,
+      // `setPermissionMode` 自己推的目标档已经含 auto-review 状态(`toSdkPermissionMode`)。
+      if (mutablePermissionMode !== 'auto') return;
       sdkPermissionModeSyncOwed = true;
-      // 推不动的窗口:留着欠账,由下一个补推点(turn 起点 / 用户改档收尾 / 在飞 push 收尾)兑。
-      if (sdkPermissionModePushInFlight) return;
+      // 已有一次收敛在队列里等 → 它轮到时会现算,重复入队只是白发控制请求。
+      if (sdkPermissionModeSyncQueued) return;
+      // 推不动的窗口:留着欠账,由下一个补推点(turn 起点 / 用户改档收尾 / 退出 plan)兑。
+      // 注意这里**不**因为"有写入在飞"就放弃 —— 队列会替我们排在它后面,而且轮到时现算。
       if (mutablePlanMode || planTurnActive || controlRequestsBlocked()) return;
       sdkPermissionModeSyncOwed = false;
-      const target = effectiveSdkPermissionMode();
-      void pushSdkPermissionMode(target).then(
-        () => {
-          sdkInPlanMode = target === 'plan';
-          // 在飞期间状态又变了 → 再收敛一次。**只有成功路径自我重试**:控制通道持续故障
-          // 时自我重试会变成紧循环,所以失败只留欠账、等外部补推点。
+      sdkPermissionModeSyncQueued = true;
+      void enqueueSdkPermissionModePush(() => {
+        sdkPermissionModeSyncQueued = false;
+        // 轮到自己时才现算。排队期间用户可能已经切走了档位 —— 那这次收敛就该整个作废,
+        // 而不是把 SDK 推回 Auto 对应的档位(codex 在 #1590 上指出的同一类分叉)。
+        if (mutablePermissionMode !== 'auto') return null;
+        // 又进了推不动的窗口:什么都不推,把欠账留给下一个补推点。
+        if (mutablePlanMode || planTurnActive || controlRequestsBlocked()) {
+          sdkPermissionModeSyncOwed = true;
+          return null;
+        }
+        return effectiveSdkPermissionMode();
+      }).then(
+        (applied) => {
+          if (applied !== null) sdkInPlanMode = applied === 'plan';
+          // 排队/在飞期间状态又变了 → 再收敛一次。**只有成功路径自我重试**:控制通道持续
+          // 故障时自我重试会变成紧循环,所以失败只留欠账、等外部补推点。
           if (sdkPermissionModeSyncOwed) syncSdkPermissionMode(`${reason}:follow-up`);
         },
         (e: unknown) => {
+          sdkPermissionModeSyncQueued = false;
           sdkPermissionModeSyncOwed = true;
           log.warn('sdk permission mode sync failed; will retry at the next opportunity', {
             reason,
-            target,
+            // 排障用:此刻还有多少档位写入排队/在飞。它只在全部落地后归零,不会被
+            // 任一请求提前清掉,所以能如实反映"是不是还有控制写入没 settle"。
+            queueDepth: sdkPermissionModeQueueDepth,
             error: String(e),
           });
         },
@@ -4610,12 +4663,25 @@ export class ClaudeCodeAgent extends BaseAgent {
         const sdkMode = toSdkPermissionMode(newMode);
         const isControlBlocked = controlRequestsBlocked();
         log.debug('setPermissionMode', { from: mutablePermissionMode, to: newMode, sdk: sdkMode, dismissedAs: moreOpen ? 'allow' : 'deny', controlRequestsBlocked: isControlBlocked });
-        if (!isControlBlocked) {
-          await pushSdkPermissionMode(sdkMode);
-        }
+        // **意图先同步落地**,再排队推档。顺序反过来(main 的写法)会留一个窄窗口:排在
+        // 我们后面的收敛推送轮到时现算,读到的还是旧档 —— 用户切到 bypassPermissions /
+        // acceptEdits 的同一瞬间来了第一条分类器故障信号,就会把档位算回旧值。意图先落地
+        // 之后,任何并发现算看到的都是用户要的那一档。
+        const previousMode = mutablePermissionMode;
         mutablePermissionMode = newMode;
-        // 用户改档期间落下的 auto-review 欠账在这里兑:此刻 `mutablePermissionMode` 已是新值,
-        // 收敛推送现算出的目标档才是用户要的那个(不会把刚被改掉的旧档推回去)。
+        if (!isControlBlocked) {
+          try {
+            // 目标档在轮到自己时现算,而不是用入队时的 `sdkMode` 快照:排队期间若又发生
+            // 一次改档,现算出的就是最新那一档,旧意图不会覆盖新意图。
+            await enqueueSdkPermissionModePush(() => toSdkPermissionMode(mutablePermissionMode));
+          } catch (e) {
+            // 推送失败保持 main 的语义:本次改档视为未生效。只在没人在此期间改过档时才回滚,
+            // 否则会把别人刚设好的档抹掉。
+            if (mutablePermissionMode === newMode) mutablePermissionMode = previousMode;
+            throw e;
+          }
+        }
+        // 用户改档期间落下的 auto-review 欠账在这里兑。
         flushOwedSdkPermissionModeSync('permission-mode-change');
       },
 

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4187,9 +4187,30 @@ export class ClaudeCodeAgent extends BaseAgent {
           //
           // 不违反 §3.2 的"send 路径不加串行等待":没有欠账、也没有在飞的档位写入时
           // `sdkPermissionModeQueueDepth` 为 0,这里一个 await 都不产生 —— 常态零开销。
-          // 队列本身永不 reject(见 enqueueSdkPermissionModePush),失败已在各自 settle
-          // 分支记了欠账,turn 照常继续,所以不需要 catch。
-          if (sdkPermissionModeQueueDepth > 0) await sdkPermissionModeQueue;
+          //
+          // **等完还要按本轮意图再收一次口。** 只等不复核会把一个随机竞态变成确定性 bug:
+          // `setPlanMode(true)` 的 `'plan'` 写入被前面的请求卡在队列里时,`sdkInPlanMode`
+          // 仍是 false,于是 send 头部那条"显式普通消息要降档"的分支不会触发;等队列排空
+          // 恰好保证那条**过期的** plan literal 一定在输入之前落地,这一轮就整轮跑在 Plan
+          // 档上,而 arm 还留给下一条消息(codex P2 —— 上一轮我加的等待引入的反例)。
+          //
+          // 复核写入用 `currentTurnSdkPermissionMode()`(**本轮**目标档:只看 planTurnActive,
+          // 不含 arm 态),并让它在轮到自己时现算 —— 于是"输入之前最后落地的档位"恒等于本轮
+          // 意图,无论队列里躺着谁的旧意图。已经一致时也只是对同一档位重复 push 一次(SDK 侧
+          // 幂等),代价只发生在"队列非空"这条少见路径上。
+          if (sdkPermissionModeQueueDepth > 0) {
+            await sdkPermissionModeQueue;
+            try {
+              await enqueueSdkPermissionModePush(() => currentTurnSdkPermissionMode());
+            } catch (e) {
+              // 复核失败不该把用户这条消息毙掉(与既有的 best-effort 档位调用点同款);记欠账,
+              // 下一个补推点重试。这一轮可能跑在旧档上,已在日志里留痕。
+              sdkPermissionModeSyncOwed = true;
+              log.warn('turn permission-mode reconcile before input failed; sending anyway', {
+                error: String(e),
+              });
+            }
+          }
           const accepted = inputQueue.push(sdkInput);
           if (!accepted) {
             // close() can win while content conversion is still preparing files or

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4180,6 +4180,16 @@ export class ClaudeCodeAgent extends BaseAgent {
             parent_tool_use_id: null,
             ...(sendOpts?.messageUuid ? { uuid: sendOpts.messageUuid } : {}),
           };
+          // 档位写入必须**先于本轮输入落地**。补推只是"排进队列"并不代表已生效;两者没有
+          // 先后约束时,这一轮可能先以旧档起跑、档位随后才到,前几个工具照旧撞在故障中的
+          // 原生分类器上(codex P2)。等待点刻意放在这里而不是 turn 起点:此刻 rewind /
+          // bridge 重建已经完成,队列里剩下的写入面向的是**当前**这个 Query。
+          //
+          // 不违反 §3.2 的"send 路径不加串行等待":没有欠账、也没有在飞的档位写入时
+          // `sdkPermissionModeQueueDepth` 为 0,这里一个 await 都不产生 —— 常态零开销。
+          // 队列本身永不 reject(见 enqueueSdkPermissionModePush),失败已在各自 settle
+          // 分支记了欠账,turn 照常继续,所以不需要 catch。
+          if (sdkPermissionModeQueueDepth > 0) await sdkPermissionModeQueue;
           const accepted = inputQueue.push(sdkInput);
           if (!accepted) {
             // close() can win while content conversion is still preparing files or

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1553,7 +1553,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             eventQueue.push({ type: 'plan_mode_changed', data: { enabled: false }, source: 'claude-code' });
           }
           sdkInPlanMode = false;
-          void q.setPermissionMode(effectiveSdkPermissionMode()).catch((e) => {
+          void pushSdkPermissionMode(effectiveSdkPermissionMode()).catch((e) => {
             log.warn('post-plan-approval setPermissionMode failed', { error: String(e) });
           });
         }
@@ -3074,7 +3074,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         planTurnActive = false;
         if (!mutablePlanMode) {
           sdkInPlanMode = false;
-          void q.setPermissionMode(effectiveSdkPermissionMode()).catch((e) => {
+          void pushSdkPermissionMode(effectiveSdkPermissionMode()).catch((e) => {
             log.warn('plan turn end setPermissionMode failed', { error: String(e) });
           });
         }
@@ -3641,6 +3641,73 @@ export class ClaudeCodeAgent extends BaseAgent {
     // 主动 close 并登记到 canceledBridgeQueries 时才阻塞 control request。
     const controlRequestsBlocked = (): boolean =>
       pendingRewindTo !== undefined || acceptingRebuiltSend || idleResumeRebuildGate !== null || canceledBridgeQueries.has(q);
+    /**
+     * ── SDK 权限档的收敛推送 ────────────────────────────────────────────────
+     *
+     * 目标档**永远现算**:`effectiveSdkPermissionMode()` 已经把 auto-review 状态算进去了
+     * (`toSdkPermissionMode` 读 `usesNativeClaudeAutoReview()`)。所以这里不记"要推成什么",
+     * 只记"还欠一次推送"。欠账 + 现算 = 不管中间发生过什么,最后落地的一定是**当前**状态
+     * 对应的档位,不需要任何人去追认"我这次的结果还算不算最新"。
+     *
+     * 为什么需要它:auto-review 状态可以在**推不动档的窗口里**改变 —— rewind / bridge 重建
+     * / invalid-resume 期间 control request 不可写,plan 档恒在 plan。原先这些窗口里只改
+     * 标记、不推档,而且没有任何补推点,于是留下「标记说走 Cindy 审阅、SDK 实际还在 auto
+     * 档」的分叉:工具继续进故障中的原生分类器,正是降级本身要消除的硬拒绝。
+     *
+     * 串行(`sdkPermissionModePushInFlight`)不是性能考虑:两个并发 push 的落地顺序不由这里
+     * 保证,后到的会盖掉先到的,而"谁后到"不可知。串行 + 现算之后,完成顺序不再进入判据。
+     */
+    let sdkPermissionModeSyncOwed = false;
+    let sdkPermissionModePushInFlight = false;
+    /**
+     * 把一次档位控制请求纳入串行域。各调用点自己的 await / fire-and-forget 与错误处理都
+     * 不变,只是在飞期间挡住收敛推送(反之亦然)。
+     */
+    const pushSdkPermissionMode = async (target: SdkPermissionMode): Promise<void> => {
+      sdkPermissionModePushInFlight = true;
+      try {
+        await q.setPermissionMode(target);
+      } finally {
+        sdkPermissionModePushInFlight = false;
+      }
+    };
+    /**
+     * 状态变更后请求一次收敛。**同步返回、不 await** —— 它可能在 canUseTool 回调里被调用
+     * (SDK 正等这个回调返回),也在 send 入口被调用(`docs/dev-rules/maker-core-and-agent-
+     * behavior.md` §3.2 禁止在 send 路径上加串行等待)。
+     */
+    const syncSdkPermissionMode = (reason: string): void => {
+      sdkPermissionModeSyncOwed = true;
+      // 推不动的窗口:留着欠账,由下一个补推点(turn 起点 / 用户改档收尾 / 在飞 push 收尾)兑。
+      if (sdkPermissionModePushInFlight) return;
+      if (mutablePlanMode || planTurnActive || controlRequestsBlocked()) return;
+      sdkPermissionModeSyncOwed = false;
+      const target = effectiveSdkPermissionMode();
+      void pushSdkPermissionMode(target).then(
+        () => {
+          sdkInPlanMode = target === 'plan';
+          // 在飞期间状态又变了 → 再收敛一次。**只有成功路径自我重试**:控制通道持续故障
+          // 时自我重试会变成紧循环,所以失败只留欠账、等外部补推点。
+          if (sdkPermissionModeSyncOwed) syncSdkPermissionMode(`${reason}:follow-up`);
+        },
+        (e: unknown) => {
+          sdkPermissionModeSyncOwed = true;
+          log.warn('sdk permission mode sync failed; will retry at the next opportunity', {
+            reason,
+            target,
+            error: String(e),
+          });
+        },
+      );
+    };
+    /**
+     * 到了能推档的时机时兑掉欠账。没有欠账时**同步 no-op** —— 不新增 await、不多让一个
+     * microtask tick(send 入口的 tick 数是 rewind / bridge 重建窗口判据的基础)。
+     */
+    const flushOwedSdkPermissionModeSync = (reason: string): void => {
+      if (!sdkPermissionModeSyncOwed) return;
+      syncSdkPermissionMode(reason);
+    };
     type QueryRuntimeSnapshot = {
       model: string;
       effort: Effort;
@@ -3699,7 +3766,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           replayed = true;
           const targetSdkMode = sdkMode;
           try {
-            await q.setPermissionMode(targetSdkMode);
+            await pushSdkPermissionMode(targetSdkMode);
             sdkInPlanMode = targetSdkMode === 'plan';
             snapshot.sdkPermissionMode = targetSdkMode;
             log.debug(`${label}: replayed setPermissionMode`, { sdkMode: targetSdkMode });
@@ -3753,7 +3820,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             sdkInPlanMode = false;
             // rewind 窗口期旧 q 不可写, 跳过 — 档位由下方重建的 buildQuery 决定。
             if (!controlRequestsBlocked()) {
-              void q.setPermissionMode(effectiveSdkPermissionMode()).catch((e) => {
+              void pushSdkPermissionMode(effectiveSdkPermissionMode()).catch((e) => {
                 log.warn('stale plan turn cleanup setPermissionMode failed', { error: String(e) });
               });
             }
@@ -3774,7 +3841,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // effectiveSdkPermissionMode()(planTurnActive 已置 true → 'plan') 起档。
           if (!sdkInPlanMode && !controlRequestsBlocked()) {
             try {
-              await q.setPermissionMode('plan');
+              await pushSdkPermissionMode('plan');
               sdkInPlanMode = true;
             } catch (e) {
               log.warn('deferred plan-mode SDK switch failed — sending as a normal turn', { error: String(e) });
@@ -3787,12 +3854,17 @@ export class ClaudeCodeAgent extends BaseAgent {
           sdkInPlanMode = false;
           if (!controlRequestsBlocked()) {
             try {
-              await q.setPermissionMode(toSdkPermissionMode(mutablePermissionMode));
+              await pushSdkPermissionMode(toSdkPermissionMode(mutablePermissionMode));
             } catch (e) {
               log.warn('plan-armed SDK downgrade for explicit normal turn failed', { error: String(e) });
             }
           }
         }
+        // turn 起点是最可靠的补推点:此刻 plan 归属已定、上一轮的重建窗口通常已关。若上一
+        // 个 turn 里 auto-review 状态在推不动档的窗口中变过,欠账在这里兑上,不让 SDK 与
+        // 逻辑状态跨 turn 分叉。**没有欠账时是同步 no-op**,不给 send 入口新增 microtask
+        // tick(那个 tick 数是 rewind / bridge 重建窗口判据的基础)。
+        flushOwedSdkPermissionModeSync('turn-start');
         // turn 入口先打一行参数快照, 让日志能从一句 "send" 看清这轮是用哪个 model/effort/mode 跑的;
         // 不打消息全文 (Session.send 已经打过 summary 了, 这里只补 runtime params)
         log.debug('send ▶ user message', {
@@ -4432,7 +4504,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 路由错配。与其它 post-hoc setPermissionMode 调用点(plan 审批后 / plan turn 结束)
           // 同款 best-effort:失败只 warn,不回退已成功的切模,让持久配置与运行态保持一致
           // (codex review)。
-          await q.setPermissionMode(toSdkPermissionMode('auto')).catch((e) => {
+          await pushSdkPermissionMode(toSdkPermissionMode('auto')).catch((e) => {
             log.warn('setModel: auto-review permission-mode reapply failed; model switch kept', {
               model: newModel,
               error: String(e),
@@ -4539,23 +4611,24 @@ export class ClaudeCodeAgent extends BaseAgent {
         const isControlBlocked = controlRequestsBlocked();
         log.debug('setPermissionMode', { from: mutablePermissionMode, to: newMode, sdk: sdkMode, dismissedAs: moreOpen ? 'allow' : 'deny', controlRequestsBlocked: isControlBlocked });
         if (!isControlBlocked) {
-          await q.setPermissionMode(sdkMode);
+          await pushSdkPermissionMode(sdkMode);
         }
         mutablePermissionMode = newMode;
+        // 用户改档期间落下的 auto-review 欠账在这里兑:此刻 `mutablePermissionMode` 已是新值,
+        // 收敛推送现算出的目标档才是用户要的那个(不会把刚被改掉的旧档推回去)。
+        flushOwedSdkPermissionModeSync('permission-mode-change');
       },
 
       async useCindyAutoReviewFallback() {
         if (nativeAutoReviewUnavailable) return;
+        // **状态先落地、档位交给收敛推送**。原先是在这里就地 `await q.setPermissionMode`,
+        // 而推不动的窗口(plan 档、rewind / bridge 重建、invalid-resume)只改标记不推档、
+        // 又没有补推点 —— SDK 留在 `auto` 而标记说走 Cindy 审阅,工具继续进故障中的原生
+        // 分类器,正是降级要消除的硬拒绝。现在标记是唯一真相,SDK 由 syncSdkPermissionMode
+        // 收敛过去;推不动就记欠账,下一个补推点兑。
         nativeAutoReviewUnavailable = true;
         autoReviewDecisionCache.clear();
-        if (
-          mutablePermissionMode === 'auto'
-          && !mutablePlanMode
-          && !planTurnActive
-          && !controlRequestsBlocked()
-        ) {
-          await q.setPermissionMode('default');
-        }
+        syncSdkPermissionMode('auto-review-fallback');
         log.warn('Claude native Auto reviewer unavailable; keeping Auto with Cindy fallback', {
           providerId: mutableProviderId,
           model: mutableModel,
@@ -4584,8 +4657,10 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 重建时 buildQuery 以 effectiveSdkPermissionMode() 起档并回写 sdkInPlanMode
           return;
         }
-        await q.setPermissionMode(sdkMode);
+        await pushSdkPermissionMode(sdkMode);
         sdkInPlanMode = sdkMode === 'plan';
+        // 退出 plan 时补推点:plan 档期间 auto-review 状态变过的话,欠账在这里兑。
+        if (!enabled) flushOwedSdkPermissionModeSync('plan-mode-disabled');
       },
 
       getPlanMode() {


### PR DESCRIPTION
## 这次改了什么

### 意图契约

- **目标**：让「Auto 档该用哪个审阅器」这个状态成为唯一真相，SDK 权限档收敛到它，故障窗口里不留分叉。
- **非目标**：不改降级/恢复的**触发条件**（阈值、退避、观察器判据一律不动），不加恢复入口（那是 #1590），不动 turn 级降级（那是 #1581），不碰 Codex / Pi。
- **行为契约**：降级发生后，只要会话仍在 Auto 且控制通道可用，SDK 最终一定在 `default` 档；推不动或推送失败时下一个可推时机自动补上，用户不会因为一次 transport 抖动就被永久送回**正在故障的**原生分类器。
- **失效契约**：用户改档 / 进出 plan / rewind 与 bridge 重建期间，目标档一律**现算**，不使用任何跨 `await` 的快照；在飞的档位推送与用户改档互斥（同一时刻只有一个控制请求）。
- **验收清单**：见下方「怎么验证的」，3 个新用例均做变异验证。

### 摘要

`useCindyAutoReviewFallback` 就地 `await q.setPermissionMode('default')`，并且在**推不动档的窗口**里只改标记、不推档：

- plan 档恒在 `plan`（`mutablePlanMode || planTurnActive`）；
- rewind / bridge 重建 / invalid-resume 期间 `controlRequestsBlocked()`。

而这些窗口过去之后**没有任何补推点**。推送失败（transport 抖动）同样**没有重试**。两种情况留下同一个分叉：

> 标记说「走 Cindy 审阅」，SDK 实际还在 `auto` 档 → 工具继续被送进**正在故障的**原生分类器 → 吃 `... is temporarily unavailable, so auto mode cannot determine the safety of Bash right now.`

也就是降级本身要消除的那个窗口，被降级路径自己的失败模式放回来了。

### 修法：把「谁负责把 SDK 推到位」收成一件事

- **目标档永远现算。** `effectiveSdkPermissionMode()` 本来就把 auto-review 状态算进去了（`toSdkPermissionMode` 读 `usesNativeClaudeAutoReview()`，`index.ts:1820-1823`）。所以新增的 `syncSdkPermissionMode` **不记「要推成什么」，只记「还欠一次推送」**。欠账 + 现算 = 不管中间发生过什么，最后落地的一定是**当前**状态对应的档位，不需要任何回调去追认「我这次的结果还算不算最新」。
- **补推点**：turn 起点、用户改档收尾、退出 plan、在飞 push 收尾。**没有欠账时全部是同步 no-op** —— send 入口不新增 `await`、不多让一个 microtask tick（那个 tick 数是 rewind / bridge 重建窗口判据的基础，`docs/dev-rules/maker-core-and-agent-behavior.md` §3.2）。
- **失败只留欠账、不自我重试**：控制通道持续故障时自我重试会变成紧循环，改由下一个补推点兑。
- **所有档位控制请求统一走 `pushSdkPermissionMode` 进串行域**（各调用点自己的 await / fire-and-forget 与错误处理**都不变**，只是在飞期间互斥）。两个并发 push 的落地顺序不由这里保证、后到的会盖掉先到的，而「谁后到」不可知；串行 + 现算之后，**完成顺序不再进入判据**。

`useCindyAutoReviewFallback` 因此不再 await 档位推送：状态是唯一真相，SDK 收敛过去。

### Review 轮次记录

**第 1 轮（3 条意见，同一根因，已全部修复并 resolve）** — 修复 commit `189a94d3`：

greptile P1 /​ copilot /​ codex P2 都指向同一处，而且**是第一版的实现缺陷**：它被命名成「串行域」，实际只有一个布尔 `sdkPermissionModePushInFlight` ——

- **只有收敛推送查它**，`pushSdkPermissionMode` 只是前后翻标记，并不让调用点排队；用户改档 / plan 切换 / setModel 的重配照旧并发发控制请求；
- 它会被**先完成**的那个请求提前清零，于是「是否仍有写入在飞」本身就在说谎。

后果：旧请求晚落地会盖掉最新档位（新的 `plan` 先落地、旧的 `default` 随后落地 → SDK 在 plan 消息开始后被切回普通档，与 `mutablePlanMode` / `sdkInPlanMode` 分叉）。

改成真队列：

- `enqueueSdkPermissionModePush` 把所有写入排进一条 promise chain，**执行顺序 == 入队顺序**，最后入队的意图一定最后落地；队列自己吞掉失败（`then(ok, err)`），一次失败不毒化后续写入。
- `sdkPermissionModeQueueDepth` 记「排队中 + 在飞」，只有全部落地才归零，不会被任一请求提前清掉；失败日志带上它。
- 目标档支持**取值函数**，收敛推送轮到自己时现算：排队期间用户已改档、或又进了推不动的窗口 → 整个作废，不把 SDK 推到旧意图对应的档位。传字面量的调用点保持原语义（plan turn 起档恒为 `'plan'`、replay 用 `currentTurnSdkPermissionMode()` 刻意排除 arm 态）。
- `setPermissionMode` 改成**意图先同步落地、再排队推档**（失败回滚，且只在没人在此期间改过档时才回滚）。原顺序留了一个窄窗口：排在后面的收敛推送现算时读到旧档 —— 用户切到 `bypassPermissions` / `acceptEdits` 的同一瞬间来第一条故障信号，就会把档位算回旧值。
- 收敛推送在 `mutablePermissionMode !== 'auto'` 时**既不记欠账也不推档**：auto-review 只在 Auto 档决定 SDK 档位，推了就是把用户当前选择改回去。

新增 3 个用例（共 27），覆盖转交清单要求的并发场景：两个调用点并发进入且同一时刻只有一个控制写入；第二个请求在第一个未完成时到达；用户在 Auto fallback 推送期间切到 acceptEdits；已入队的收敛在轮到自己前用户切走档位 → 作废且中间不插入 `'default'`；任一请求失败后队列仍可用并在下一 turn 兑欠账收口。

**Mutation 验证 4 处**（各自精确翻红对应用例，其余保持绿色，验证后源文件已还原）：

| 去掉的东西 | 翻红的用例 |
|---|---|
| 队列的 `await sdkPermissionModeQueue` | serializes the fallback push behind an in-flight user mode change |
| 轮到时的「是否仍在 Auto 档」核对 | drops an already-queued convergence when the user leaves Auto before it runs |
| 队列吞失败（`then(ok, err)` → `then(ok)`） | retries the owed…／keeps the queue alive after a failed write |
| turn 起点补推 | retries the owed…／keeps the queue alive after a failed write |

本轮验证：`pnpm test:unit` 退出码 0（56 workspace PASS / 0 FAIL）、`pnpm --filter desktop run typecheck` 0、`auto-review-wiring.test.ts` 27 passed、`pnpm check:dco` 通过、maker-core `tsc --noEmit` 错误分布与基线完全一致（本次改动的两个文件零新增）。

**第 2 轮（2 条意见，同一根因，已修复并 resolve）** — 修复 commit `296d9818`：

copilot 与 codex 都指向 `enqueueSdkPermissionModePush` 在 `await sdkPermissionModeQueue` 之后才读**可变的** `q`。排队期间 `q` 可能已被换掉（invalid-resume 自救、rewind / bridge 重建），而新 Query 的起档已由 `buildQuery` 用 `effectiveSdkPermissionMode()` 按最新状态初始化好 —— 旧 Query 排的写入落到新 Query 上，就用一个为旧上下文算出的档位盖掉这个已经正确的起档，重新造出本 PR 要消除的分叉。

最尖锐的形态是**过期 literal**：队列被占住期间进 plan（入队 literal `'plan'`）又退出 plan，逻辑状态已回到非 plan；那条 `'plan'` 若落到重建后的新 Query 上，这一轮普通 turn 会以 plan 档跑，工具权限面与 `mutablePlanMode` / `sdkInPlanMode` 分叉。

修法：入队时 `const enqueuedQuery = q`，执行时身份不符即丢弃这次**写入**。没有改成「按当前状态重新计算后再写」—— 新 Query 的起档本来就是现算的结果，再写一次只是多发一个控制请求。

一处实现细节：**身份核对放在求值之后**。取值函数自带记账（收敛推送要在函数体里清「已排队」标记、必要时留欠账），在求值前 `return` 会把那份记账永久卡住，之后所有收敛都被误判成「已有一次在排队」而静默跳过 —— 那是个比原问题更隐蔽的卡死。

新增回归用例 1 个，放在 `rewind-runtime-settings.test.ts`（该文件本来就 owns 重建 harness）。**变异验证**：去掉身份核对后翻红（`expected "spy" to not be called with arguments: [ 'plan' ]`）。第一版用例靶心写错了（占住队列的那次写入才是 `'plan'`、当时已在执行；排队的那条值又正好等于新 Query 起档），变异不翻红，已重写成「占位写入 + 排队的过期 literal」三步序列。

本轮验证：`pnpm test:unit` 退出码 0（56 workspace PASS / 0 FAIL）、`pnpm --filter desktop run typecheck` 0、`rewind-runtime-settings.test.ts` 37 passed、`auto-review-wiring.test.ts` 27 passed、maker-core `tsc --noEmit` 错误分布与基线完全一致、`pnpm check:dco` 通过。

**规模说明**：`pr-drift-check` 第 [2] 项报 WARN（review 阶段 +138%，其余 4 项全 PASS，绝对规模 +374 −18 / 3 文件）。核对结论**不属于漂移**：文件仍全部落在「auto-review 的 SDK 档位写入」这一处，增量是真队列实现 + 5 个并发/重建回归用例，没有蔓延到任何新模块、没有新增功能面。

**已知 CI 噪音（与本 PR 无关）**：`189a94d3` 的 `Windows unit tests (1/2)` 挂在 `packages/device-link/src/__tests__/client.test.ts` 的「心跳:连续无 pong 超限 → terminate + 重连」（`expected false to be true`）。本 PR diff 只含 `packages/maker-core/src/agents/claude-code/` 三个文件，**未碰 device-link**；本地该文件 100 passed。它属于 [#1606](https://github.com/makecindy/cindy/issues/1606) 记的那个族（Windows 分片时序/IO 余量不足，已把 3 个不相关 PR 判红 6 次、涉及 5 个文件），其中 device-link 的另一条另有 [#1599](https://github.com/makecindy/cindy/issues/1599)。按 AGENTS.md「与 diff 无关的失败 = 基线问题」处理：不并进本 PR 修；本轮换了新 head，CI 重新取。

**第 3 轮（1 条意见，已修复并 resolve）** — 修复 commit `74080949`：

**codex P2「在发送下一轮前确保欠账档位已经生效」——成立，而且我第 2 轮的用例确实没钉住这一点**（只等一个 tick 并断言"调用发生过"）。`flushOwedSdkPermissionModeSync('turn-start')` 是 fire-and-forget，同一次 `send` 随后就把输入推进 `inputQueue`，两者之间没有先后约束 → transport 抖动后重试的下一轮仍可能先以旧 `auto` 档起跑、`default` 稍后才到，前几个工具照旧撞在故障中的原生分类器上，等于把本 PR 要消除的窗口在"补推之后"又开了一次。

修法：输入真正 `inputQueue.push` 之前，若档位队列还有未落地的写入就等它排空。

**等待点的位置是这轮的关键，第一版放错了**：按字面放在 turn 起点，rewind 用例直接翻红（`ProcessTransport is not ready for writing`）—— turn 起点在 rewind / bridge 重建**之前**，那里等到的是面向即将被替换掉的旧 Query 的写入，而 `commitRewindFiles` 已经 close 了它。放到入队前，重建已完成，队列里剩下的写入面向的是当前这个 Query。

§3.2（send 路径不加串行等待）：没有欠账、也没有在飞的档位写入时 `sdkPermissionModeQueueDepth` 为 0，**一个 await 都不产生** —— 常态零开销，只有真的欠着一次收敛才等一个控制请求。队列永不 reject，失败已在各自 settle 分支记了欠账，turn 照常继续。

关于远端路径：remote manager 的 `void this.dispatch(...)` 并发分派的是**不同 RPC**；本 PR 的欠账补推与输入入队都发生在 host 侧同一个 `handle.send()` 内，所以这个 await 对本地与远端是同一条顺序保证。客户端两个 RPC 之间的竞态（用户在发消息的同一瞬间改档）是另一件事，不属于本 PR 改动面。

新增用例 1 个（欠账时 `send` 必须等档位落地才 resolve），**变异验证**：去掉顺序约束后翻红（`expected true to be false`）。

本轮验证：`pnpm test:unit` 退出码 0（56 workspace PASS / 0 FAIL）、`pnpm --filter desktop run typecheck` 0、`auto-review-wiring.test.ts` 28 passed、`rewind-runtime-settings.test.ts` 37 passed、maker-core `tsc --noEmit` 与基线完全一致、`pnpm check:dco` 通过。

**规模说明（drift STOP 已用收尾豁免）**：`pr-drift-check` 第 [2] 项本轮报 **STOP**（review 阶段 +173%），其余 4 项全 PASS，绝对规模 +429 −18 / **3 文件**。**已收尾，drift STOP 不适用**：本轮意见修完后 unresolved 归零、不再新增功能面、只等 CI 与 approve。判据是文件全程落在「auto-review 的 SDK 档位写入」这一处、未蔓延到任何新模块，三轮增量逐笔可追溯到本 PR 的一条 bot 意见（真串行 → Query 身份 → 档位先于输入），属于"量大但在原目标内"，不是目标错配。

**一句自我提醒**：这是同一机制的第 3 轮。与 #1581 的区别是那边**我的修复引入了下一轮的 P1**，而这里第 2、3 轮指的都是第一版就存在的缺口（第 1 轮那条布尔量才是我引入的）。若第 4 轮仍落在这套队列语义上，我会停下重估而不是继续补。

**第 4 轮（1 条意见，已修复并 resolve）** — 修复 commit `e7879dc3`：

**codex P2「等队列后重新校验普通 turn 的权限档」——成立，而且是第 3 轮我加的那个等待引入的反例。** 等队列排空把一个随机竞态变成了确定性 bug：`setPlanMode(true)` 的 `'plan'` 写入被前面的请求卡在队列里时 `sdkInPlanMode` 仍是 false，于是 send 头部那条「显式普通消息要降档」的分支不触发；而"等队列排空"恰好**保证**那条过期的 plan literal 一定在输入之前落地 —— 这一轮整轮跑在 Plan 档上，arm 还留给下一条消息。

修法：等完队列后**无条件按 `currentTurnSdkPermissionMode()` 再写一次**（本轮目标档：只看 `planTurnActive`、不含 arm 态），目标在轮到自己时现算。于是「输入之前最后落地的档位」恒等于本轮意图，不管队列里躺着谁的旧意图。

没有取「丢弃过期 literal」那条路：判定"哪条算过期"要引入"谁为哪一轮排的"这类新状态，而这套设计的立足点恰恰是**不记忆、只现算**；现算复核不需要记任何东西，而且顺带覆盖同类的其它旧意图（不只是 plan）。

代价如实说：目标已一致时也会重复 push 一次（SDK 侧对同档位幂等），且只发生在"队列非空"这条少见路径上 —— 常态（`sdkPermissionModeQueueDepth === 0`）这里一个 await 都不产生。复核失败不毙掉用户这条消息（与既有 best-effort 档位调用点同款）：记欠账 + warn 留痕，下一个补推点重试。

新增用例 1 个（plan 写入排队期间发 `send(..., { planMode: false })` → 那条 `'plan'` 确实执行过，但输入入队前最后落地的是 `'auto'`），**变异验证**：去掉复核后翻红（`expected 'plan' to be 'auto'`）。同批更新一条既有用例的预期：队列非空路径现在多一次幂等复核写入（`['default','default','default']`），注释写明原因。

本轮验证：`pnpm test:unit` 退出码 0（56 workspace PASS / 0 FAIL）、`pnpm --filter desktop run typecheck` 0、`auto-review-wiring.test.ts` 29 passed、`rewind-runtime-settings.test.ts` 37 passed、`plan-mode.test.ts` 全绿（三文件合计 90 passed）、maker-core `tsc --noEmit` 与基线完全一致、`pnpm check:dco` 通过（5 commits signed off）。上一个 head `74080949` 的 client-ci 是 **8/8 全绿**。

**关于"第 4 轮"这件事（上一轮我给自己立的判据）**：我说过"若第 4 轮仍落在这套队列语义上，会停下重估而不是继续补"。这一轮我判断**不适用停下**，理由是它不是队列语义又出了新缺口，而是**第 3 轮那个修复本身的直接反例**——等待改变了执行时序，把原先概率性的旧意图落地变成了必然，修法就是给那个等待补上它缺的那半句（等完要复核本轮意图）。判据上它和第 1 轮那条布尔量同类：我引入的、有明确边界、一次改完。若下一轮再出的是**新的**竞态面（而不是本轮修复的直接后果），我会停下重估。

**第 5 轮（3 条意见，同一条规则的三个位置，已全部修复并 resolve）** — 修复 commit `cd3d70bd`：

三条都是前几轮改动的直接后果：队列会**丢弃**换过 Query 的写入、会**现算**目标档，而各调用点的本地记账仍按"我请求的那个值"无条件回写。统一成一条规则：**本地记账只跟随 `enqueueSdkPermissionModePush` 的返回值**（`null` = 这次写入被丢弃）。

- **codex P1「回滚失败改档时同步收紧 SDK 档位」** — 目标档改成现算之后，队列里排在前面的写入轮到执行会先把 SDK 推到最新的 `bypassPermissions`；后一次写入失败时只回滚 `mutablePermissionMode`，SDK 就长期停在 Full access，与界面和本地权限状态不符，且队列清空后不会再校正。现在回滚同时排一次现算写入把 SDK 收回去，并先记欠账、只在收回真的落地后才清。
- **codex P2「收口后同步更新 sdkInPlanMode」** — 第 4 轮的输入前复核把 SDK 写回普通档但没同步标记；那条仍在等待的 `setPlanMode(true)` 之后会把它置成 `true`，下一条**真正的** plan 消息因此跳过补推、整轮按普通权限档跑。现在按复核实际落地的档位同步。
- **copilot「被丢弃的写入不得回写记账」** — replay / plan turn 起档 / `setPlanMode` 三处改为只在 `applied !== null` 时回写 `sdkInPlanMode` 与 `snapshot.sdkPermissionMode`。

新增用例 2 个，**均做变异验证（各自精确翻红）**：改档失败后最后落地的档位是回滚后的那一档；复核之后下一条真正的 plan 消息仍会推 plan（`'plan'` 共出现 2 次）。

**copilot 那条如实标注：没有配用例。** 变异（改回无条件回写）后 claude-code 测试目录 410 条全绿；构造用例时确认它当前**结构上不可达** —— `q` 只在 `buildQuery` 里被替换，而 `buildQuery` 自己会按 `effectiveSdkPermissionMode()` 重新回写 `sdkInPlanMode`，过期回写立刻被覆盖。改动保留是因为依赖这个巧合很脆（新增调用点不一定还有这层兜底），但不计作有覆盖的修复。

本轮验证：`pnpm test:unit` 退出码 0（56 workspace PASS / 0 FAIL）、`pnpm --filter desktop run typecheck` 0、claude-code 测试目录 **410 passed**、maker-core `tsc --noEmit` 错误分布与基线完全一致、`pnpm check:dco` 通过（6 commits signed off）。上一个 head `e7879dc3` 的两个 Windows 分片均 pass。

**关于轮次（第 4 轮我立的判据在这一轮的应用）**：我说过"若下一轮出的是**新的**竞态面就停下重估"。这一轮三条**都不是新竞态面**，而是同一条记账规则在我改过的位置上没跟上 —— 所以按"一次覆盖全部入口"合成一条规则改完，而不是逐条补。但我把它记在这里：**这套机制已经连续 5 轮出意见，全部由本 PR 自身的改动引出。** 若第 6 轮仍落在它身上，我的建议会是转 draft、把「SDK 档位单一写者」这件事连同 #1581 / #1590 一起重新设计，而不是继续在这个 PR 里推进。

### 为什么单独开这个 PR

#1581（turn 级试探性降级）与 #1590（原生审阅的对称恢复入口）在 review 中各自出了 4 条 P1，**全部是同一类**：跨 `await` 持状态快照，再用 token / 代际事后追认「我这次还算不算最新」。#1581 上我按那个思路补了三轮，其中一轮的修复**引入了下一轮的 P1**，第四轮 bot 直接指出新增的回归用例「只钉了一种完成顺序」。

两边的收敛点是同一个东西，就是本 PR：**SDK 档位由唯一一条串行通道推、目标现算**。各自实现一遍会在同一文件里留两套互相冲突的档位写入模型。所以先把这层落地，#1581 / #1590 再基于它重做（届时代际号与 `'blocked'` 这类中间态整段消失）。

**它不是无消费者的地基**：`useCindyAutoReviewFallback` 已在 `main` 上运行，上面那个分叉是 `main` 当下的真实缺陷，本 PR 自带修复与回归用例。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 本 PR 包含：`enqueueSdkPermissionModePush`（串行队列）/ `syncSdkPermissionMode` / `pushSdkPermissionMode` / `flushOwedSdkPermissionModeSync` + 8 个既有档位写入点改走串行域 + `useCindyAutoReviewFallback` 改为「状态先落地、档位收敛」+ 3 个用例。
- 明确不包含：恢复入口（#1590）、turn 级降级（#1581）、观察器与退避策略、Codex / Pi。
- 用户可见变化：Auto 档下原生分类器故障降级后，不再因为「降级发生在 plan / 重建窗口」或「一次 transport 抖动」而继续撞硬拒绝。权限档显示、用户偏好、弹窗行为均不变。
- 是否存在 breaking change：无。对外接口签名未变（`useCindyAutoReviewFallback` 仍是 `Promise<void>`，只是不再等待档位推送）。

### UI 变化

不涉及（纯 agent 运行期逻辑，无界面、无文案）。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit                                    # 退出码 0；56 workspace PASS / 0 FAIL
pnpm --filter desktop run typecheck               # 通过
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/claude-code/__tests__/auto-review-wiring.test.ts   # 23 passed（新增 3）
pnpm check:dco                                    # 1 commit signed off
```

新增用例：

1. **推送失败后下一 turn 补推** —— 这是 `main` 上那个缺陷的直接回归测试：push 被拒后状态仍落到 Cindy reviewer（审批已经走 Cindy），下一个 turn 起点把 `default` 补上。
2. **在飞的用户改档期间降级只记欠账** —— 用户那次 push 未 settle 时降级不并发推第二个控制请求；用户 push 收尾后按**新档**现算，`setPermissionMode` 的调用序列恰为 `['auto', 'default']`。
3. **没有欠账的 turn 不碰 SDK 档位** —— 防止「每个 turn 无条件推一次」把真实分叉掩盖掉，也避免给 send 入口白加一个控制请求。

**Mutation 验证**（三处核心逻辑各一次，各自精确翻红一条、其余 22 条保持绿色，验证后源文件已还原）：

| 去掉的东西 | 翻红的用例 |
|---|---|
| turn 起点补推 | retries the owed mode push on the next turn… |
| 串行闸 `if (sdkPermissionModePushInFlight) return` | serializes the fallback push behind an in-flight user mode change |
| 失败路径的 `sdkPermissionModeSyncOwed = true` | retries the owed mode push on the next turn… |

### 手工验证

未做实机验证。要真实触发需要让官方分类器连续故障并恰好落在 plan / rewind 窗口或让控制请求抖动一次，本地没有稳定复现手段。判定路径全部是纯状态机，已由上述用例逐条固定。

### maker-core 性能／指标评估（dev-rules §3.4）

- **(a) 可能影响的指标**：3.2 性能／返回速度（send 入口是否被拖慢）。不涉及 3.1 缓存率（未动 system prompt 任何段、未改 tool / MCP 注册），不涉及 3.3 内容准确性（未动 translator、未引入模型别名）。
- **(b) 实测方法**：send 入口**新增的 await 次数与 microtask tick 数**。`rewind-runtime-settings.test.ts` 的用例正是按 send 头部 tick 数判定「哪些运行时切换落在重建窗口内」，对多让一个 tick 都敏感。
- **(c) 实测结论**：`flushOwedSdkPermissionModeSync` 在无欠账时第一行 `return`，**新增 0 个 await、0 个额外 tick**；`rewind-runtime-settings` 全绿。有欠账时也只同步发起 fire-and-forget，不等待控制请求返回。

### 未执行的验证

- 未实机验证「plan / rewind 窗口里降级 → 窗口结束后补推」的端到端时序（原因见上）。
- `packages/maker-core` 无 `typecheck` script（按 AGENTS.md 该步自动跳过）。改用它的 `run build`（`tsc --noEmit`）核对：**本次改动的两个文件零新增错误**（`auto-review-wiring.test.ts` 保持 4 条基线、`claude-code/index.ts` 0 条）。该命令另有既有错误 `codex/index.test.ts` 50 条、`pi-auto-review-dispatch.test.ts` 11 条、`plan-mode.test.ts` 3 条、`auto-review-wiring.test.ts` 4 条（后者来自 #1597 的测试 helper，已记在 #1605），均为 `main` 基线、CI 不闸这条命令。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

勾权限的理由：改的是**权限档控制请求的推送路径**。但本 PR 不新增任何放行路径、不改判据、不动用户偏好：降级/恢复的触发条件一字未改，改的只是「状态变了之后 SDK 什么时候被推到与状态一致的档位」。修复方向是**收紧**（把该在 `default` 的会话真正推到 `default`），fail-closed 语义不受影响。

### 影响与回滚

- 影响范围：Claude harness 的档位推送路径（`packages/maker-core/src/agents/claude-code/index.ts`）。Codex / Pi 不受影响。
- 回滚方式：`git revert` 单个 commit，回到「降级就地 await 推档、失败与阻塞窗口不补推」的既有行为。无迁移、无持久化状态、无协议字段。

### 需要 reviewer 重点看的两点

1. **8 个既有写入点改走 `pushSdkPermissionMode` 是否改变了各自语义** —— 我的意图是**不改**：每个点自己的 `await` / fire-and-forget、`sdkInPlanMode` 回写与错误处理都原样保留，包装只做「在飞期间互斥」。请特别看 plan turn 起/收尾（`send` 内两处）与 rebuild replay 那处。
2. **补推点是否够** —— 目前是 turn 起点 / 用户改档收尾 / 退出 plan / 在飞 push 收尾。我判断这四个覆盖了全部「从推不动变成能推」的转变（rewind 与 bridge 重建结束后必然经过一次 turn 起点或 buildQuery 起档）。如果你能想到第五种转变，那就是漏的。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不变量与理由写进代码注释）
- [x] 已确认测试结果或说明未执行原因

---

> **发版时序建议**：这是权限推送路径的改动，建议**不要在今天 09:00 那班发版前合**，等发版窗口过去再进 `main`，给它完整一轮 CI 与 review。它不修任何阻塞发版的问题。




