### PR TITLE
test: 五条把 main 打红的 Windows 计时型用例改成断言行为

### DIFF
--- a/apps/desktop/src/main/skillhub/registry/__tests__/lock.test.ts
+++ b/apps/desktop/src/main/skillhub/registry/__tests__/lock.test.ts
@@ -38,19 +38,31 @@ describe('withLock', () => {
     expect(counter).toBe(100);
   });
 
-  it('不同 key 并行，耗时近似单次而非 N 倍', async () => {
-    const delay = 20; // ms
-    const start = Date.now();
+  it('不同 key 并行：三个临界区在某一刻同时开着（而非首尾相接）', async () => {
+    // **不断言墙钟耗时**。原来是 `elapsed < delay * 2.5`（20ms × 2.5 = 50ms），Windows CI
+    // 两分片并跑时 52ms 就把 main 打红了 —— 三个 20ms 的 sleep 串行才 60ms，阈值离"串行"
+    // 只差 10ms，等于拿调度抖动当被测行为。
+    //
+    // 改成直接量"并行"本身：记下每个临界区的进入 / 离开时刻，断言
+    // `max(进入) < min(离开)`，即存在一个瞬间三者同时在临界区内。串行执行下
+    // 第二个的进入必然晚于第一个的离开，这条一定不成立。与机器快慢无关。
+    const enter: number[] = [];
+    const leave: number[] = [];
+    const section = async (): Promise<void> => {
+      enter.push(Date.now());
+      await new Promise<void>((r) => setTimeout(r, 20));
+      leave.push(Date.now());
+    };
 
     await Promise.all([
-      withLock('key-a', () => new Promise<void>((r) => setTimeout(r, delay))),
-      withLock('key-b', () => new Promise<void>((r) => setTimeout(r, delay))),
-      withLock('key-c', () => new Promise<void>((r) => setTimeout(r, delay))),
+      withLock('key-a', section),
+      withLock('key-b', section),
+      withLock('key-c', section),
     ]);
 
-    const elapsed = Date.now() - start;
-    // 并行时应该约 delay ms 完成（而非 3*delay）
-    expect(elapsed).toBeLessThan(delay * 2.5);
+    expect(enter).toHaveLength(3);
+    expect(leave).toHaveLength(3);
+    expect(Math.max(...enter)).toBeLessThan(Math.min(...leave));
   });
 
   it('前一个 task 失败，后续 task 仍可执行', async () => {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -3139,7 +3139,10 @@ describe('DeviceLinkClient', () => {
     client.start();
     await tick(5);
     expect(sockets.length).toBe(0); // 第一轮卡在 getToken,没建 socket
-    await tick(30); // 10ms 超时 + ≤5ms 退避后第二轮拿到 token
+    // 负载下(Windows CI 分片并跑)事件循环调度可能远超名义毫秒数:单次固定 tick(30) 不足以
+    // 保证 10ms getToken 超时 + ≤5ms 退避 + 第二轮 getToken 都已落地。有界等待到 socket
+    // 出现,断言语义不变(挂死的第一轮必须被超时掀掉、第二轮必须真的建出连接)。
+    for (let i = 0; i < 40 && sockets.length < 1; i++) await tick(10);
     expect(sockets.length).toBe(1);
     sockets[0].ack();
     expect(client.getStatus()).toBe('online');

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -2830,8 +2830,10 @@ describe('DeviceLinkClient', () => {
     const first = h.current();
     first.ack();
 
-    // ping 周期 8ms,pongMissLimit=1:第 2 个周期(~16ms)触发僵死
-    await tick(40);
+    // ping 周期 8ms,pongMissLimit=1:第 2 个周期(~16ms)触发僵死。
+    // 负载下(Windows CI 分片并跑)固定 tick(40) 不足以保证两个 ping 周期都已跑完 ——
+    // 有界等待到 terminate 真的发生,断言语义不变(僵死必须被判出来并进重连)。
+    for (let i = 0; i < 40 && !first.terminated; i++) await tick(10);
     expect(first.terminated).toBe(true);
     // 已进入重连(新 socket 已创建或定时器排队中)
     expect(h.client.getStatus()).toBe('connecting');

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -3223,8 +3223,10 @@ describe('DeviceLinkClient', () => {
     await tick();
     const first = h.current();
     first.emit('open'); // upgrade 成功但对端不回 hello-ack(半开/服务假活)
-    await tick(50);
-    // watchdog 触发新建连接(测试窗口内后续连接可能再次超时,只断言 ≥2)
+    // 负载下(Windows CI 分片并跑)事件循环调度可能远超名义毫秒数:单次固定 tick(50)
+    // 不足以保证 15ms 握手看门狗 + 退避重连都已落地。有界等待到第二个 socket 出现,
+    // 断言语义不变(watchdog 必须触发新建连接;测试窗口内后续连接可能再次超时,只断言 ≥2)。
+    for (let i = 0; i < 40 && h.sockets.length < 2; i++) await tick(10);
     expect(h.sockets.length).toBeGreaterThanOrEqual(2);
     expect(first.terminated || first.closed !== null).toBe(true); // 旧 socket 被回收
     // 负载下(全量并跑)事件循环调度可能远超名义毫秒数:current() 拿到的

--- a/packages/maker-core/src/contacts/__tests__/manager.test.ts
+++ b/packages/maker-core/src/contacts/__tests__/manager.test.ts
@@ -4,8 +4,19 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import DatabaseCtor from 'better-sqlite3';
+
+// 本文件每个用例都在 os.tmpdir() 里真开 better-sqlite3 落库(建目录 → 建表 → v1→v2 迁移
+// → FTS5 重建 → 删目录)。Windows CI 上两个分片并跑,叠上 Defender 对新建文件的实时扫描,
+// 这些**同步** IO 会超过 vitest 默认的 5s —— 于是这个纯正确性用例以「Test timed out in
+// 5000ms」把 main 打红(2026-08-04 实测:manager.test.ts 的 v1→v2 迁移用例;此前值班日志
+// 也记过同一文件 4 个用例同时 5s 超时)。
+// packages/maker-core 没有自己的 vitest 配置,拿不到 apps/desktop 那份
+// `testTimeout: win32 ? 20_000 : 5_000`,所以在这里按仓内既有写法(git-integration 系列
+// 用例的 vi.setConfig)单独放宽。**只放宽时间,不放宽任何断言** —— 它测的是迁移正确性,
+// 从来不是"迁移够快"。
+vi.setConfig({ testTimeout: process.platform === 'win32' ? 30_000 : 5_000 });
 
 import { MakerContactsManager } from '../manager.js';
 import type { Logger } from '../../interfaces/logger.js';


### PR DESCRIPTION
## 改动内容

五条**用时间当判据**的用例改成断言被测行为本身。3 个测试文件,`+41 −13`,**纯测试改动,
不动任何产品代码,不放宽任何断言语义。**

| 用例 | 原判据 | 改成 |
|---|---|---|
| `device-link` 握手超时 → 退避重连 | `tick(50)` 后必须已有 2 个 socket | 有界等待到第 2 个 socket 出现 |
| `device-link` getToken 挂起 → 退避重连 | `tick(30)` 后必须已有 1 个 socket | 有界等待到 socket 出现 |
| `device-link` 心跳僵死 → terminate + 重连 | `tick(40)` 后必须已 terminate | 有界等待到 terminate 发生 |
| `desktop` skillhub 不同 key 并行 | `elapsed < 50ms` | 三个临界区在某一刻确实重叠 |
| `maker-core` contacts v1→v2 迁移 | vitest 默认 5s 超时 | 该文件 win32 放宽到 30s |

## 为什么

**这五条各自把 main 或别人的 PR 打红过,没有一条是产品代码的问题。**一天之内实测 5 次发作:

```
# ① e931a575（当时的 main HEAD）
FAIL client.test.ts > 握手超时(open 后 hello-ack 一直不来)→ 强制断开走退避重连
AssertionError: expected 1 to be greater than or equal to 2

# ② #1618 第一轮（diff 只碰 mobile HTML 预览,与 skillhub 毫无关系）
FAIL skillhub/registry/lock.test.ts > 不同 key 并行，耗时近似单次而非 N 倍
AssertionError: expected 52 to be less than 50

# ③ #1616 第一轮
FAIL client.test.ts > getToken 挂起超过 getTokenTimeoutMs → 走退避重连,不永久卡在 connecting
AssertionError: expected +0 to be 1

# ④ #1618 第二轮（同样与它的 diff 无关）
FAIL contacts/__tests__/manager.test.ts > v1 库升级到 v2
Error: Test timed out in 5000ms.

# ⑤ 0e1e7910（#1618 合并后的 main HEAD）
FAIL client.test.ts > 心跳:连续无 pong 超限 → terminate + 重连
AssertionError: expected false to be true
```

前四条里的 skillhub 那条最典型:断言 `elapsed < 20 × 2.5 = 50ms`,而三个 20ms sleep
**串行**是 60ms —— 阈值离「串行」只差 10ms,等于拿调度抖动当被测行为。改成记录每个临界区
的进入 / 离开时刻,断言 `max(进入) < min(离开)`(存在一个瞬间三者同时在临界区内):串行
执行下第二个的进入必然晚于第一个的离开,这条一定不成立;而机器多慢都不影响它成立。

第 ④ 条性质不同,**不是墙钟断言,是纯正确性用例被默认超时判死**。该文件每个用例都在
`os.tmpdir()` 里真开 better-sqlite3 落库(建目录 → 建表 → v1→v2 迁移 → FTS5 重建 → 删目录),
Windows 两分片并跑叠上 Defender 实时扫描,这些**同步** IO 会超过 vitest 默认的 5s。
根因是 `packages/maker-core` **没有自己的 vitest 配置**,拿不到 `apps/desktop/vitest.config.ts`
里那份 `testTimeout: win32 ? 20_000 : 5_000`;按仓内既有写法(git-integration 系列用例的
`vi.setConfig`)在该文件单独放宽到 win32 30s。**只放宽时间,不放宽任何断言** —— 它测的是
迁移正确性,从来不是「迁移够快」。

## 范围:只收正在发作的,存量另开 issue

顺手对 `client.test.ts` 做了一次全文件清扫,共 **35 处** `await tick(>=10)`,分两类:

- **类型 A**(约 15 处):固定等待后断言「某事已发生」—— 与本 PR 修的三条同型,可机械变换;
- **类型 B**(约 15 处):等一段时间断言「某事**没**发生」(如「退避 50ms 未到,不重连」)
  —— **不能用轮询修**,它要求真实经过的时间**小于**某阈值,慢机器上等越久越危险,只能调
  被测的时间参数,需要逐个理解被测语义。

完整清单(含行号)、修法配方,以及「补门禁防新增」的几个可选做法,记在 **#1625**。
本 PR 不把整份清扫塞进来 —— 那会从 3 个文件涨到十几个站点、两种修法混在一起。

## 为什么单开一个 PR 而不是各自修

这类失败**红灯落在谁的 PR 上纯看运气**。把五条收在一起,而不是塞进各自撞见它的功能 PR:
后者会把 device-link / skillhub / maker-core 三拨评审面拖进一个 mobile 预览 PR
(#1618 实际撞上了两次)。

## 验证

- `pnpm --filter @cindy/device-link test` → **163 passed**(6 文件)
- `pnpm --filter @cindy/maker-core exec vitest run src/contacts` → **122 passed**(6 文件)
- `pnpm --filter desktop exec vitest run src/main/skillhub` → **281 passed**(24 文件)
- `@cindy/device-link` / `@cindy/maker-core` / `desktop` 三个 package typecheck 均通过

## 风险

极低。3 个测试文件,没有触及产品代码。四条把判据从「跑得够快」换成「行为确实发生了」,
一条只放宽了单个文件在 Windows 上的超时。