### PR TITLE
fix: 补齐任务列表导出菜单

### DIFF
--- a/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionHeaderMenuParity.test.ts
@@ -4,8 +4,8 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * 顶部会话标题菜单(SessionContentHeader)与侧栏会话右键菜单(SessionItem)
- * 的条目一致性回归:两边必须使用同一组 sessionMenu.* 动作(产品要求两处菜单
+ * 顶部会话标题菜单(SessionContentHeader)与侧栏会话右键菜单(SessionItem / SessionCard)
+ * 的条目一致性回归:三处必须使用同一组 sessionMenu.* 动作(产品要求各处菜单
  * 保持一致)。任何一边单独增删菜单项都会让本测试失败,提醒同步另一边。
  */
 const ccAgentDir = resolve(__dirname, '..', 'features', 'cc-agent');
@@ -14,8 +14,12 @@ const sessionItemSource = readFileSync(
   resolve(ccAgentDir, 'sidebar', 'SessionItem.tsx'),
   'utf8',
 );
+const sessionCardSource = readFileSync(
+  resolve(ccAgentDir, 'sidebar', 'SessionCard.tsx'),
+  'utf8',
+);
 
-// 非菜单条目的 sessionMenu.* 用法,两边都排除后再比较:
+// 非菜单条目的 sessionMenu.* 用法,各处都排除后再比较:
 //   - moreActions:SessionItem 行内 ··· 按钮的 aria-label(header 用自己的
 //     ccAgent.sessionHeader.moreActions)
 //   - *Done / *Failed / *Blocked / *Unsupported / *Nothing:动作的 toast 反馈文案
@@ -42,17 +46,20 @@ function collectSessionMenuKeys(source: string): Set<string> {
   return keys;
 }
 
-describe('SessionContentHeader menu parity with SessionItem', () => {
-  it('uses the same sessionMenu action keys as the sidebar context menu', () => {
+describe('session menu parity across header and sidebar variants', () => {
+  it('uses the same sessionMenu action keys across all menu variants', () => {
     const headerKeys = collectSessionMenuKeys(headerSource);
     const sidebarKeys = collectSessionMenuKeys(sessionItemSource);
+    const cardKeys = collectSessionMenuKeys(sessionCardSource);
     expect([...headerKeys].sort()).toEqual([...sidebarKeys].sort());
+    expect([...headerKeys].sort()).toEqual([...cardKeys].sort());
   });
 
   it('reuses the shared submenu / export dialog / menu style modules', () => {
     expect(headerSource).toContain("from './sidebar/menuStyles'");
     expect(sessionItemSource).toContain("from './menuStyles'");
-    for (const source of [headerSource, sessionItemSource]) {
+    expect(sessionCardSource).toContain("from './menuStyles'");
+    for (const source of [headerSource, sessionItemSource, sessionCardSource]) {
       expect(source).toContain('SessionProjectMoveSubmenu');
       expect(source).toContain('SessionShareExportDialog');
     }

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -8,7 +8,7 @@
  *
  * 交互 100% 对齐 SessionItem（props 签名完全一致，sections 内按 cardMode 二选一渲染）：
  *   - 单击导航 / 双击重命名（标题原位变 input）
- *   - 右键 coordinate-anchored DropdownMenu（Pin/Rename/复制ID/新窗口/Archive/Delete，
+ *   - 右键 coordinate-anchored DropdownMenu（Pin/Rename/移动到项目/复制任务链接/新窗口/导出/Archive/Delete，
  *     archived / draft 变体同款分支）
  *   - hover 右上角仅 More（⋮）快捷钮；存档收进 ⋮ / 右键展开菜单的 Archive 项
  *     （卡片不再出现独立的存档快捷钮）。已归档卡片保留"取消归档"快捷钮。
@@ -65,6 +65,7 @@ import {
   isEmptyDraftSession,
 } from '../lib/sessionDisplayTitle';
 import { SessionProjectMoveSubmenu } from './SessionProjectMoveSubmenu';
+import { SessionShareExportDialog } from './SessionShareExportDialog';
 import { SessionRenameInput } from '../SessionRenameInput';
 import type { SessionItemProps } from './SessionItem';
 import { RemoteProjectIcon } from './RemoteProjectIcon';
@@ -210,6 +211,7 @@ export function SessionCard({
 
   const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
   const [archivePending, setArchivePending] = useState(false);
+  const [shareExportOpen, setShareExportOpen] = useState(false);
   const confirmPillRef = useRef<HTMLButtonElement>(null);
   const cardRef = useRef<HTMLDivElement>(null);
 
@@ -384,6 +386,12 @@ export function SessionCard({
     void window.electronAPI.maker.openSessionInNewWindow(session.id);
   }, [remoteWritesBlocked, session.id, t]);
 
+  // 「导出会话…」——打成 .cshare 分享给同事。空草稿、remote / orca / device-link 会话不显示此入口
+  // (转录在远端或协同关系不可移植，main 侧同样有双保险拒绝)。
+  const handleExportShareSelect = useCallback(() => {
+    setShareExportOpen(true);
+  }, []);
+
   const handleAutomationIconClick = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
     try {
@@ -415,6 +423,15 @@ export function SessionCard({
       {t('ccAgent.sidebar.sessionMenu.copySessionLink')}
     </DropdownMenuItem>
   );
+
+  const canExportShare =
+    !isEmpty && !session.remoteHostId && !session.orcaRole && !session.deviceLinkDeviceId;
+
+  const exportShareMenuItem = canExportShare ? (
+    <DropdownMenuItem onSelect={handleExportShareSelect} className={MENU_ITEM_CLASS}>
+      {t('ccAgent.sidebar.sessionMenu.exportShare')}
+    </DropdownMenuItem>
+  ) : null;
 
   // 「移动到项目」子菜单(main 既有功能;本次侧栏重设保留)。
   const canMoveToProject =
@@ -894,6 +911,7 @@ export function SessionCard({
                 >
                   {t('ccAgent.sidebar.sessionMenu.unarchive')}
                 </DropdownMenuItem>
+                {exportShareMenuItem}
                 {copySessionIdSubmenu}
                 <DropdownMenuSeparator className={MENU_SEPARATOR_CLASS} />
                 <DropdownMenuItem
@@ -949,6 +967,7 @@ export function SessionCard({
                 >
                   {t('ccAgent.sidebar.sessionMenu.openInNewWindow')}
                 </DropdownMenuItem>
+                {exportShareMenuItem}
                 <DropdownMenuSeparator className={MENU_SEPARATOR_CLASS} />
                 <DropdownMenuItem
                   disabled={remoteWritesBlocked}
@@ -968,6 +987,14 @@ export function SessionCard({
             )}
           </DropdownMenuContent>
         </DropdownMenu>
+      )}
+
+      {shareExportOpen && (
+        <SessionShareExportDialog
+          open={shareExportOpen}
+          sessionId={session.id}
+          onOpenChange={setShareExportOpen}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## 这次改了什么

### 摘要

补齐任务列表左侧 `SessionCard` 菜单中的“导出任务…”，使其与右侧标题栏和普通侧栏菜单保持一致。导出入口复用现有 `.cshare` 导出弹窗，并沿用本地非草稿、非远程、非 Orca、非 device-link 任务的能力门控。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈任务列表左侧菜单缺少导出任务
- 本 PR 包含：`SessionCard` 导出菜单项、导出弹窗挂载、三处菜单一致性回归测试
- 明确不包含：导出协议、导出弹窗内部流程、远程/协同任务的导出能力
- 用户可见变化：本地普通任务和已归档任务的左侧菜单出现“导出任务…”
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` 的语义化菜单样式与 Light/Dark 双模式约束；本次复用既有 `menuStyles` 和 `SessionShareExportDialog`，未新增颜色或主题分支。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/sessionHeaderMenuParity.test.ts src/renderer/features/cc-agent/sidebar/__tests__/sessionCardReviewRegressions.test.ts
结果：24/24 通过

pnpm --filter desktop typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-task-list-export-menu
结果：GATE_EXIT=0；Desktop、Mobile、各 workspace 单元测试通过
```

### 手工验证

不涉及：本次复用现有菜单和弹窗交互，未启动 Desktop 实机。

### 未执行的验证

未进行 Desktop 实机 Light/Dark 菜单目检；当前改动未新增主题样式，使用既有语义 token。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：任务列表右键菜单；远程、Orca、device-link 和草稿任务保持原有不可导出行为。
- 回滚 / 降级方式：回退本 PR commit `41c7f63c1` 即可恢复原菜单行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
