### PR TITLE
fix(plugin): preserve custom marketplace icons

### DIFF
--- a/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
@@ -181,12 +181,25 @@ describe('ghostPluginViewModel', () => {
     ]);
   });
 
-  it('treats a market null icon as an explicit presentation override', () => {
+  it('treats a server market null icon as an explicit presentation override', () => {
     const ghost = installed({ iconDataUrl: 'data:image/png;base64,OLD' });
     const presentation = marketPresentationForInstalledGhost(ghost, marketItem({ icon: null }));
 
     expect(presentation).not.toBeNull();
     expect(toGhostPluginListItem(ghost, presentation)).not.toHaveProperty('iconDataUrl');
+  });
+
+  it('keeps the installed icon when a custom market has no icon projection', () => {
+    const ghost = installed({ iconDataUrl: 'data:image/png;base64,LOCAL' });
+    const presentation = marketPresentationForInstalledGhost(
+      ghost,
+      marketItem({ sourceType: 'git-market', icon: null }),
+    );
+
+    expect(presentation).not.toBeNull();
+    expect(toGhostPluginListItem(ghost, presentation)).toMatchObject({
+      iconDataUrl: 'data:image/png;base64,LOCAL',
+    });
   });
 
   it.each([

--- a/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
@@ -62,8 +62,8 @@ export interface GhostPluginDetail extends GhostPluginListItem {
 /**
  * 展示投影只覆盖用户能看到的四个字段；运行时仍完全来自本地安装包。
  *
- * `iconDataUrl` 是有意要求存在的字段：市场项的 `icon: null` 也必须覆盖本地
- * 包图标，而不是因为缺少 URL 又显示旧图标。
+ * 服务器市场的 `icon: null` 是明确覆写。自定义市场目前不投影图标，因而要
+ * 保留已安装包的图标。
  */
 export interface GhostPluginMarketPresentation {
   name: string;
@@ -78,11 +78,18 @@ export interface GhostPluginMarketPresentation {
  * market item, or a pending version update must keep using its local manifest.
  */
 export function marketPresentationForInstalledGhost(
-  ghost: Pick<InstalledGhost, 'manifest'>,
+  ghost: Pick<InstalledGhost, 'manifest' | 'iconDataUrl'>,
   marketItem:
     | Pick<
         PluginMarketItem,
-        'ghostId' | 'installState' | 'version' | 'name' | 'description' | 'author' | 'icon'
+        | 'ghostId'
+        | 'installState'
+        | 'version'
+        | 'name'
+        | 'description'
+        | 'author'
+        | 'icon'
+        | 'sourceType'
       >
     | null
     | undefined,
@@ -99,7 +106,8 @@ export function marketPresentationForInstalledGhost(
     name: marketItem.name,
     description: marketItem.description ?? '',
     author: marketItem.author,
-    iconDataUrl: marketItem.icon?.url,
+    iconDataUrl:
+      marketItem.icon?.url ?? (marketItem.sourceType === 'server' ? undefined : ghost.iconDataUrl),
   };
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复自定义 Git/本地 marketplace 中，已安装且版本一致的插件图标被市场 `icon: null` 清空的问题。自定义市场尚未投影图标时，保留已安装包内的本地图标；服务器市场的 `icon: null` 仍维持显式隐藏语义。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：自定义 marketplace 已安装插件图标缺失
- 本 PR 包含：插件列表展示投影的自定义市场图标回退；定向回归测试
- 明确不包含：市场图标上传/下载协议、安装流程、manifest 或运行时变更
- 用户可见变化：同版本的自定义 marketplace 插件会继续显示安装包内图标
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：DESIGN.md §1 Visual Theme & Atmosphere。未新增视觉样式或交互；仅在现有插件列表图标槽位恢复已安装包原有图标，亮/暗主题沿用既有渲染。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
结果：1 文件、20 测试通过

git diff --check
结果：通过

pnpm check:dco
结果：通过（1 个提交已签名）
```

### 手工验证

不涉及：此改动由视图模型定向测试覆盖。

### 未执行的验证

- 未执行全量单测：按需求限制为相关域验证。
- `pnpm --filter desktop run typecheck` 已执行但未通过，原因是最新主干已有缺失工作区依赖及其他文件的 implicit-any 错误；本改动初次出现的 `ghostPluginViewModel.ts` 类型错误已修正，复跑输出不再包含该文件。

## 风险

### 风险分类

- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）

### 影响与回滚

- 影响范围：同版本、来自 Git/本地自定义 marketplace 的已安装插件展示图标。
- 存量插件影响：无；不改变批准状态、指纹、manifest 校验、安装布局或包格式。
- 回滚 / 降级方式：回退本 PR 的单个提交即可恢复原展示投影。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因