### PR TITLE
fix(telegram): clean expired personal bot interaction cards

### DIFF
--- a/apps/desktop/src/main/im/feishu/__tests__/controlPickerCard.test.ts
+++ b/apps/desktop/src/main/im/feishu/__tests__/controlPickerCard.test.ts
@@ -57,3 +57,23 @@ describe('buildControlPickerCard — 接管态换乘提示', () => {
     expect(b.body).toBe(a.body);
   });
 });
+
+describe('buildPermissionModePickerCard — 重试键隔离', () => {
+  it('不同权限模式使用不同 sentinel requestId, 不会重放另一项终态', () => {
+    const spec = cards.buildPermissionModePickerCard({
+      sessionId: 'sess-1',
+      agentKind: 'claude-code',
+      currentMode: 'auto',
+      modes: [
+        { id: 'auto', displayName: 'Auto' },
+        { id: 'bypassPermissions', displayName: 'Full access' },
+      ],
+    });
+
+    const requestIds = spec.buttons.map((button) => button.payload?.requestId);
+    expect(requestIds).toEqual([
+      'permmode-pick:sess-1:auto',
+      'permmode-pick:sess-1:bypassPermissions',
+    ]);
+  });
+});

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -258,6 +258,39 @@ describe('plan_review IM 卡片决策', () => {
     );
   });
 
+  it('已消费 interaction 但 resolved 卡收口失败时返回可重试结果', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    (resolvePending as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    attach(im)();
+
+    const result = await registeredHandler(handler)({
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'permission:allow:once',
+      payload: { requestId: 'resolved-card-retry' },
+    });
+
+    expect(resolvePending).toHaveBeenCalledWith('resolved-card-retry', {
+      kind: 'permission',
+      behavior: 'allow',
+    });
+    expect(result).toBe(false);
+  });
+
   it('keeps the complete async card callback inside the closing account scope', async () => {
     const updateGate = deferred();
     const im = makeIm();

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => ({
   readModelRouteSnapshot: vi.fn(
     async (): Promise<{ model: string; effort: string; providerId: string | null } | null> => null,
   ),
+  switchSessionWorkingDir: vi.fn(async () => {}),
   readPermissionMode: vi.fn(async () => 'auto'),
   updatePermissionMode: vi.fn(async () => {}),
   updateModelEffort: vi.fn(async () => {}),
@@ -78,6 +79,7 @@ vi.mock('../sessionRepo', () => ({
   readModelRouteSnapshot: mocks.readModelRouteSnapshot,
   readPermissionMode: mocks.readPermissionMode,
   touchUserSent: vi.fn(async () => {}),
+  switchSessionWorkingDir: mocks.switchSessionWorkingDir,
   updateModelEffort: mocks.updateModelEffort,
   updatePermissionMode: mocks.updatePermissionMode,
 }));
@@ -511,6 +513,53 @@ describe('control:session-pick 重复接管替换', () => {
     expect(mocks.executeDetach).not.toHaveBeenCalled();
     expect(mocks.bindingAttachWithResult).toHaveBeenCalled();
   });
+
+  it('普通接管业务成功但卡片收口失败后重试只重放终态卡', async () => {
+    const im = makeIm();
+    im.patchMarkdownCard
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      threadScoped: false,
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'control:session-pick',
+      payload: {
+        requestId: 'control-session-pick:sess-target',
+        botAppId: 'BOT1',
+        sessionId: 'sess-target',
+        sessionTitle: 'My Session',
+        displayName: 'proj',
+      },
+    } as unknown as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(mocks.bindingAttach).toHaveBeenCalledOnce();
+    expect(im.patchMarkdownCard).toHaveBeenCalledTimes(2);
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({
+        body: expect.stringContaining('brief'),
+        buttons: [],
+      }),
+    );
+  });
 });
 
 describe('control:start 按钮(免打字重新发起远程控制)', () => {
@@ -669,6 +718,153 @@ describe('Telegram 失效交互卡', () => {
       expect.objectContaining({ body: 'cancelled', buttons: [] }),
     );
   });
+
+  it('model:pick 业务成功但卡片收口失败后重试只重放终态卡', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'model:pick',
+      callbackToken: 'model-token-1',
+      payload: {
+        requestId: 'model-pick:sess-target:anthropic:claude-opus-4-7:high',
+        sessionId: 'sess-target',
+        modelId: 'claude-opus-4-7',
+        modelLabel: 'Opus 4.7',
+        effort: 'high',
+        providerId: 'anthropic',
+      },
+    } as unknown as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(mocks.updateModelEffort).toHaveBeenCalledTimes(1);
+    expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalledTimes(1);
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({ body: slackUi.cards.model.resolved('Opus 4.7', 'high') }),
+    );
+  });
+
+  it('Telegram 卡片重绘后相同 requestId 的新 token 不会命中旧终态缓存', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const baseEvent = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'model:pick',
+      payload: {
+        requestId: 'model-pick:sess-target:anthropic:claude-opus-4-7:high',
+        sessionId: 'sess-target',
+        modelId: 'claude-opus-4-7',
+        modelLabel: 'Opus 4.7',
+        effort: 'high',
+        providerId: 'anthropic',
+      },
+    } as const;
+
+    expect(await registeredHandler(handler)({ ...baseEvent, callbackToken: 'model-token-1' })).toBe(
+      false,
+    );
+    expect(await registeredHandler(handler)({ ...baseEvent, callbackToken: 'model-token-2' })).toBe(
+      true,
+    );
+    expect(mocks.updateModelEffort).toHaveBeenCalledTimes(2);
+    expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('project 切换业务成功但卡片收口失败后重试只重放终态卡', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const projectAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      projectSwitching: true,
+      sessions: { ensureWorkingDir: vi.fn(() => '/tmp/dialogue') },
+      ui: {
+        ...adapter.ui,
+        cards: {
+          ...adapter.ui.cards,
+          project: {
+            title: '项目',
+            hint: (name: string) => name,
+            emptyBody: 'empty',
+            btnDialogue: 'dialogue',
+            btnCancel: 'cancel',
+            resolvedPick: (name: string) => name,
+            resolvedDialogue: 'dialogue-resolved',
+            resolvedCancel: 'cancelled',
+            switchFailed: (reason: string) => reason,
+            attachedUnsupported: 'unsupported',
+            dialogueName: '对话',
+          },
+        },
+      },
+    } as unknown as ImChannelAdapter;
+    const resolveRouteTarget = vi.fn(async () => ({ row: { id: 'sess-target' } }));
+    const disposeOneSession = vi.fn(async () => {});
+    (turnRunner as unknown as { resolveRouteTarget: typeof resolveRouteTarget }).resolveRouteTarget =
+      resolveRouteTarget;
+    (turnRunner as unknown as { disposeOneSession: typeof disposeOneSession }).disposeOneSession =
+      disposeOneSession;
+    const attach = createCardActionHandler(projectAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'project:dialogue',
+      payload: { requestId: 'project-dialogue', botAppId: 'BOT1' },
+    } as unknown as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(resolveRouteTarget).toHaveBeenCalledOnce();
+    expect(disposeOneSession).toHaveBeenCalledOnce();
+    expect(mocks.switchSessionWorkingDir).toHaveBeenCalledOnce();
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({ body: 'dialogue-resolved', buttons: [] }),
+    );
+  });
 });
 
 describe('/permission Full access 确认', () => {
@@ -710,6 +906,7 @@ describe('/permission Full access 确认', () => {
           expect.objectContaining({
             id: 'permmode:confirm-full-access',
             type: 'danger',
+            payload: expect.objectContaining({ requestId: 'permmode-confirm:sess-target' }),
           }),
           expect.objectContaining({
             id: 'permmode:cancel-full-access',
@@ -782,6 +979,49 @@ describe('/permission Full access 确认', () => {
 
     expect(result).toBe(false);
     expect(mocks.updatePermissionMode).not.toHaveBeenCalled();
+  });
+
+  it('确认已生效但卡片收口失败后重试只重放终态卡', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'permmode:confirm-full-access',
+      payload: {
+        requestId: 'permmode-confirm:sess-target',
+        sessionId: 'sess-target',
+        mode: 'bypassPermissions',
+        modeLabel: 'Full access',
+        agentKind: 'codex',
+      },
+    } as unknown as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(mocks.updatePermissionMode).toHaveBeenCalledTimes(1);
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({
+        body: slackUi.cards.permissionMode.resolved('Full access'),
+        buttons: [],
+      }),
+    );
   });
 });
 
@@ -1134,6 +1374,92 @@ describe('control:new 新建会话来源持久化', () => {
       'picker-msg',
       expect.objectContaining({ body: slackUi.cards.control.attachFailed('db locked') }),
     );
+  });
+
+  it('新建业务成功但卡片收口失败后重试只重放终态卡', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      threadScoped: false,
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'control:new',
+      payload: {
+        requestId: 'control-new:E:\\proj',
+        botAppId: 'BOT1',
+        workingDir: 'E:\\proj',
+        displayName: 'proj',
+      },
+    } as unknown as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(mocks.getMaker().createSession).toHaveBeenCalledOnce();
+    expect(im.updateInteractiveCard).toHaveBeenCalledTimes(2);
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({ buttons: [] }),
+    );
+  });
+
+  it('thread 新建卡片收口失败仍完成 prewire, 重试只重放终态卡', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'control:new',
+      scopeKey: 'anchor-new.ts',
+      payload: {
+        requestId: 'control-new:E:\\proj',
+        botAppId: 'BOT1',
+        workingDir: 'E:\\proj',
+        displayName: 'proj',
+        anchorMessageId: 'anchor-new',
+      },
+    } as unknown as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(mocks.getMaker().createSession).toHaveBeenCalledOnce();
+    expect(turnRunner.prewireAttachedSession).toHaveBeenCalledWith(
+      'BOT1',
+      '111',
+      'anchor-new.ts',
+    );
+    expect(im.updateInteractiveCard).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -719,6 +719,42 @@ describe('Telegram 失效交互卡', () => {
     );
   });
 
+  it('control:exit 已退出但卡片收口失败后重试只重放终态卡', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      threadScoped: false,
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'control:exit',
+      callbackToken: 'control-exit-token',
+      payload: { requestId: 'control-exit', botAppId: 'BOT1' },
+    } as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(im.updateInteractiveCard).toHaveBeenCalledTimes(2);
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({ body: slackUi.cards.control.resolvedExit, buttons: [] }),
+    );
+  });
+
   it('model:pick 业务成功但卡片收口失败后重试只重放终态卡', async () => {
     const im = makeIm();
     im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -840,6 +840,60 @@ describe('Telegram 失效交互卡', () => {
     expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalledTimes(2);
   });
 
+  it('同一消息的新选择会清理旧终态重试缓存', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const eventA = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'model:pick',
+      callbackToken: 'model-token-a',
+      payload: {
+        requestId: 'model-pick-a',
+        sessionId: 'sess-target',
+        modelId: 'claude-opus-4-7',
+        modelLabel: 'Opus 4.7',
+        effort: 'high',
+        providerId: 'anthropic',
+      },
+    } as const;
+    const eventB = {
+      ...eventA,
+      callbackToken: 'model-token-b',
+      payload: {
+        ...eventA.payload,
+        requestId: 'model-pick-b',
+        modelId: 'claude-sonnet-4-5',
+        modelLabel: 'Sonnet 4.5',
+      },
+    } as const;
+
+    expect(await registeredHandler(handler)(eventA)).toBe(false);
+    expect(await registeredHandler(handler)(eventB)).toBe(true);
+    expect(await registeredHandler(handler)(eventA)).toBe(true);
+    expect(mocks.updateModelEffort).toHaveBeenCalledTimes(3);
+    expect(mocks.applyRuntimeSetModelChange).toHaveBeenCalledTimes(3);
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({ body: slackUi.cards.model.resolved('Opus 4.7', 'high') }),
+    );
+  });
+
   it('project 切换业务成功但卡片收口失败后重试只重放终态卡', async () => {
     const im = makeIm();
     im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -481,6 +481,42 @@ describe('control:start 按钮(免打字重新发起远程控制)', () => {
   });
 });
 
+describe('Telegram 失效交互卡', () => {
+  it('pending interaction 丢失时收口旧卡并显示过期提示', async () => {
+    const im = makeIm();
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    await registeredHandler(handler)({
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'permission:allow:once',
+      payload: { requestId: 'already-resolved' },
+    });
+
+    expect(resolvePending).toHaveBeenCalledWith('already-resolved', {
+      kind: 'permission',
+      behavior: 'allow',
+    });
+    expect(im.updateInteractiveCard).toHaveBeenCalledWith(
+      '111|42',
+      expect.objectContaining({ body: '卡片已过期', buttons: [] }),
+    );
+  });
+});
+
 describe('/permission Full access 确认', () => {
   async function pressPermission(
     im: ChannelIM,

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -291,6 +291,48 @@ describe('plan_review IM 卡片决策', () => {
     expect(result).toBe(false);
   });
 
+  it('resolved 卡首次收口失败后重试仍显示已完成结果', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    let resolveCalls = 0;
+    (resolvePending as ReturnType<typeof vi.fn>).mockImplementation(
+      () => resolveCalls++ === 0,
+    );
+    attach(im)();
+
+    const event = {
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'permission:allow:once',
+      payload: { requestId: 'resolved-card-retry' },
+    } as IMCardActionEvent;
+
+    expect(await registeredHandler(handler)(event)).toBe(false);
+    expect(await registeredHandler(handler)(event)).toBe(true);
+    expect(resolvePending).toHaveBeenCalledTimes(1);
+    expect(im.updateInteractiveCard).toHaveBeenLastCalledWith(
+      '111|42',
+      expect.objectContaining({ body: slackUi.cards.permission.resolvedAllowOnce, buttons: [] }),
+    );
+    expect(im.updateInteractiveCard).not.toHaveBeenCalledWith(
+      '111|42',
+      expect.objectContaining({ body: '卡片已过期' }),
+    );
+  });
+
   it('keeps the complete async card callback inside the closing account scope', async () => {
     const updateGate = deferred();
     const im = makeIm();
@@ -712,6 +754,28 @@ describe('/permission Full access 确认', () => {
       'permission-card',
       expect.objectContaining({ body: slackUi.cards.permissionMode.fullAccessCancelled }),
     );
+  });
+
+  it('returns a retryable result when cancel card patch fails', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const attach = createCardActionHandler(adapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const result = await registeredHandler(handler)({
+      messageId: 'permission-card',
+      senderId: 'U_NEW',
+      buttonId: 'permmode:cancel-full-access',
+      payload: { sessionId: 'sess-target' },
+    } as unknown as IMCardActionEvent);
+
+    expect(result).toBe(false);
+    expect(mocks.updatePermissionMode).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -707,8 +707,14 @@ describe('/permission Full access 确认', () => {
       expect.objectContaining({
         title: slackUi.cards.permissionMode.fullAccessConfirmTitle,
         buttons: expect.arrayContaining([
-          expect.objectContaining({ id: 'permmode:confirm-full-access', type: 'danger' }),
-          expect.objectContaining({ id: 'permmode:cancel-full-access' }),
+          expect.objectContaining({
+            id: 'permmode:confirm-full-access',
+            type: 'danger',
+          }),
+          expect.objectContaining({
+            id: 'permmode:cancel-full-access',
+            payload: expect.objectContaining({ requestId: 'permmode-confirm:sess-target' }),
+          }),
         ]),
       }),
     );

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -158,8 +158,8 @@ const adapter = {
 } as unknown as ImChannelAdapter;
 
 function registeredHandler(
-  handler: ((e: IMCardActionEvent) => Promise<void>) | null,
-): (e: IMCardActionEvent) => Promise<void> {
+  handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null,
+): (e: IMCardActionEvent) => Promise<void | boolean> {
   if (!handler) throw new Error('card action handler 未注册');
   return handler;
 }
@@ -513,6 +513,57 @@ describe('Telegram 失效交互卡', () => {
     expect(im.updateInteractiveCard).toHaveBeenCalledWith(
       '111|42',
       expect.objectContaining({ body: '卡片已过期', buttons: [] }),
+    );
+  });
+
+  it('project:cancel 在卡片收口失败时返回可重试结果', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const projectAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      projectSwitching: true,
+      ui: {
+        ...adapter.ui,
+        cards: {
+          ...adapter.ui.cards,
+          project: {
+            title: '项目',
+            hint: (name: string) => name,
+            emptyBody: 'empty',
+            btnDialogue: 'dialogue',
+            btnCancel: 'cancel',
+            resolvedPick: (name: string) => name,
+            resolvedDialogue: 'dialogue-resolved',
+            resolvedCancel: 'cancelled',
+            switchFailed: (reason: string) => reason,
+            attachedUnsupported: 'unsupported',
+            dialogueName: '对话',
+          },
+        },
+      },
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(projectAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const result = await registeredHandler(handler)({
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'project:cancel',
+      payload: { requestId: 'project-cancel-retry' },
+    });
+
+    expect(result).toBe(false);
+    expect(im.updateInteractiveCard).toHaveBeenCalledWith(
+      '111|42',
+      expect.objectContaining({ body: 'cancelled', buttons: [] }),
     );
   });
 });

--- a/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
@@ -516,6 +516,34 @@ describe('Telegram 失效交互卡', () => {
     );
   });
 
+  it('过期卡收口失败时返回可重试结果', async () => {
+    const im = makeIm();
+    im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));
+    const telegramAdapter = {
+      ...adapter,
+      channel: 'telegram',
+      interactionExpiredNotice: '卡片已过期',
+    } as ImChannelAdapter;
+    const attach = createCardActionHandler(telegramAdapter, cards, turnRunner);
+    let handler: ((e: IMCardActionEvent) => Promise<void | boolean>) | null = null;
+    (im.onCardAction as ReturnType<typeof vi.fn>).mockImplementation((cb) => {
+      handler = cb;
+      return () => {};
+    });
+    attach(im)();
+
+    const result = await registeredHandler(handler)({
+      channelName: 'telegram',
+      chatId: '111',
+      messageId: '111|42',
+      senderId: '111',
+      buttonId: 'permission:allow:once',
+      payload: { requestId: 'already-resolved' },
+    });
+
+    expect(result).toBe(false);
+  });
+
   it('project:cancel 在卡片收口失败时返回可重试结果', async () => {
     const im = makeIm();
     im.updateInteractiveCard.mockRejectedValueOnce(new Error('telegram 500'));

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -479,13 +479,13 @@ export function createCardActionHandler(
     }
   }
 
-  async function handleControlPick(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function handleControlPick(im: ChannelIM, event: IMCardActionEvent): Promise<boolean> {
     const botContextId = String(event.payload.botAppId ?? '');
     const workingDir = String(event.payload.workingDir ?? '');
     const displayName = String(event.payload.displayName ?? workingDir);
     if (!workingDir || !botContextId) {
       log.warn('control:pick missing workingDir/botAppId — ignoring');
-      return;
+      return true;
     }
     log.info(`control:pick workingDir=${workingDir} displayName=${displayName}`);
 
@@ -512,14 +512,16 @@ export function createCardActionHandler(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`control:pick card update failed (non-fatal): ${msg}`);
+      return false;
     }
+    return true;
   }
 
-  async function handleControlBack(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function handleControlBack(im: ChannelIM, event: IMCardActionEvent): Promise<boolean> {
     const botContextId = String(event.payload.botAppId ?? '');
     if (!botContextId) {
       log.warn('control:back missing botAppId — ignoring');
-      return;
+      return true;
     }
     log.info(`control:back (sender=...${event.senderId.slice(-8)})`);
     let projects: ControlProject[];
@@ -556,7 +558,9 @@ export function createCardActionHandler(
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`control:back card update failed (non-fatal): ${msg}`);
+      return false;
     }
+    return true;
   }
 
   async function handleControlSessionPick(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
@@ -1288,7 +1292,7 @@ export function createCardActionHandler(
         return;
       }
       try {
-        await runInImAccountGeneration(accountGeneration, async () => {
+        return await runInImAccountGeneration(accountGeneration, async () => {
           log.info(
             `card action sender=...${event.senderId.slice(-8)} button=${event.buttonId} payload=${JSON.stringify(event.payload).slice(0, 200)}`,
           );
@@ -1321,12 +1325,10 @@ export function createCardActionHandler(
           //   new             → 新建 session + attach
           //   exit            → patch 为 resolved 卡片, 不动 session
           if (event.buttonId === 'control:pick') {
-            await handleControlPick(im, event);
-            return;
+            return handleControlPick(im, event);
           }
           if (event.buttonId === 'control:back') {
-            await handleControlBack(im, event);
-            return;
+            return handleControlBack(im, event);
           }
           if (event.buttonId === 'control:session-pick') {
             await handleControlSessionPick(im, event);

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -1402,6 +1402,11 @@ export function createCardActionHandler(
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             log.warn(`updateInteractiveCard failed (non-fatal): ${msg}`);
+            // The pending decision has already been consumed, but the rendered card
+            // still exposes its callback. Let Telegram release its dedup key so a
+            // retry can at least run the stale-card cleanup instead of being ACKed
+            // and silently discarded for five minutes.
+            return false;
           }
         });
       } catch (err) {

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -123,7 +123,59 @@ export function createCardActionHandler(
   }
 
   function resolvedCardRetryKey(event: IMCardActionEvent, requestId: string): string {
-    return `${event.messageId}|${requestId}`;
+    const isTerminalDecision =
+      event.buttonId.startsWith('permission:') ||
+      event.buttonId.startsWith('plan:') ||
+      event.buttonId.startsWith('ask:') ||
+      event.buttonId === 'permmode:confirm-full-access' ||
+      event.buttonId === 'permmode:cancel-full-access';
+    const renderedToken = event.callbackToken?.trim();
+    const identity =
+      renderedToken && !isTerminalDecision ? `token:${renderedToken}` : `request:${requestId}`;
+    return `${event.messageId}|${identity}`;
+  }
+
+  function rememberResolvedCardRetry(
+    event: IMCardActionEvent,
+    accountGeneration: number,
+    label: string,
+  ): void {
+    const requestId = String(event.payload.requestId ?? '');
+    if (!requestId) return;
+    const key = resolvedCardRetryKey(event, requestId);
+    resolvedCardRetries.delete(key);
+    resolvedCardRetries.set(key, { label, accountGeneration, at: Date.now() });
+    while (resolvedCardRetries.size > MAX_RESOLVED_CARD_RETRIES) {
+      const oldest = resolvedCardRetries.keys().next().value;
+      if (oldest === undefined) break;
+      resolvedCardRetries.delete(oldest);
+    }
+  }
+
+  async function retryResolvedCardIfPending(
+    im: ChannelIM,
+    event: IMCardActionEvent,
+    accountGeneration: number,
+  ): Promise<boolean | null> {
+    const requestId = String(event.payload.requestId ?? '');
+    if (!requestId) return null;
+    const key = resolvedCardRetryKey(event, requestId);
+    pruneResolvedCardRetries(Date.now());
+    const retry = resolvedCardRetries.get(key);
+    if (!retry) return null;
+    if (retry.accountGeneration !== accountGeneration) {
+      resolvedCardRetries.delete(key);
+      return null;
+    }
+    try {
+      await im.updateInteractiveCard(event.messageId, cards.buildResolvedCard(retry.label));
+      resolvedCardRetries.delete(key);
+      return true;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`resolved interaction card retry failed (non-fatal): ${msg}`);
+      return false;
+    }
   }
 
   function requireThreadUi() {
@@ -268,7 +320,11 @@ export function createCardActionHandler(
     return { scopeKey, rootMessageId, displaced: attachResult.displaced };
   }
 
-  async function handleModelPick(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function handleModelPick(
+    im: ChannelIM,
+    event: IMCardActionEvent,
+    accountGeneration: number,
+  ): Promise<boolean> {
     const sessionId = String(event.payload.sessionId ?? '');
     const modelId = String(event.payload.modelId ?? '');
     const modelLabel = String(event.payload.modelLabel ?? modelId);
@@ -281,18 +337,20 @@ export function createCardActionHandler(
 
     if (!sessionId || !modelId) {
       log.warn('model:pick missing sessionId/modelId — ignoring');
-      return;
+      return true;
     }
 
-    const patchModelPickFailed = async (reason: string): Promise<void> => {
+    const patchModelPickFailed = async (reason: string): Promise<boolean> => {
       try {
         await im.updateInteractiveCard(
           event.messageId,
           cards.buildResolvedCard(ui.cards.model.failed(reason)),
         );
+        return true;
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.warn(`model:pick failure card patch failed (non-fatal): ${msg}`);
+        return false;
       }
     };
 
@@ -392,22 +450,29 @@ export function createCardActionHandler(
     });
 
     if (failureReason !== null) {
-      await patchModelPickFailed(failureReason);
-      return;
+      return patchModelPickFailed(failureReason);
     }
 
+    const resolvedLabel = ui.cards.model.resolved(modelLabel, effort);
     try {
       await im.updateInteractiveCard(
         event.messageId,
-        cards.buildResolvedCard(ui.cards.model.resolved(modelLabel, effort)),
+        cards.buildResolvedCard(resolvedLabel),
       );
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`model:pick card patch failed (non-fatal): ${msg}`);
+      rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
+      return false;
     }
   }
 
-  async function handlePermissionModePick(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function handlePermissionModePick(
+    im: ChannelIM,
+    event: IMCardActionEvent,
+    accountGeneration: number,
+  ): Promise<boolean> {
     const sessionId = String(event.payload.sessionId ?? '');
     const mode = String(event.payload.mode ?? '') as PermissionMode;
     const modeLabel = String(event.payload.modeLabel ?? mode);
@@ -416,7 +481,7 @@ export function createCardActionHandler(
 
     if (event.buttonId === 'permmode:confirm-full-access' && mode !== 'bypassPermissions') {
       log.warn(`permmode:confirm-full-access received non-full mode=${mode} — ignoring`);
-      return;
+      return true;
     }
 
     // Validate against the bound agent's actual capabilities — single source of
@@ -442,7 +507,13 @@ export function createCardActionHandler(
               id: 'permmode:confirm-full-access',
               label: ui.cards.permissionMode.btnConfirmFullAccess,
               type: 'danger',
-              payload: { sessionId, mode, modeLabel, agentKind },
+              payload: {
+                requestId: confirmationRequestId,
+                sessionId,
+                mode,
+                modeLabel,
+                agentKind,
+              },
             },
             {
               id: 'permmode:cancel-full-access',
@@ -455,13 +526,14 @@ export function createCardActionHandler(
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.warn(`permmode:pick confirmation card patch failed: ${msg}`);
+        return false;
       }
-      return;
+      return true;
     }
 
     if (result.kind === 'invalid') {
       log.warn(`permmode:pick invalid sessionId=${sessionId} mode=${mode}: ${result.reason}`);
-      return;
+      return true;
     }
 
     if (result.kind === 'failed') {
@@ -471,23 +543,28 @@ export function createCardActionHandler(
           event.messageId,
           cards.buildResolvedCard(ui.cards.permissionMode.failed(result.reason)),
         );
+        return true;
       } catch {
         /* non-fatal: update failure is already logged */
+        return false;
       }
-      return;
     }
 
     if (!result.live) {
       log.info(`permmode:pick: no live session for ${sessionId.slice(-8)} — DB updated only`);
     }
+    const resolvedLabel = ui.cards.permissionMode.resolved(modeLabel);
     try {
       await im.updateInteractiveCard(
         event.messageId,
-        cards.buildResolvedCard(ui.cards.permissionMode.resolved(modeLabel)),
+        cards.buildResolvedCard(resolvedLabel),
       );
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`permmode:pick card patch failed (non-fatal): ${msg}`);
+      rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
+      return false;
     }
   }
 
@@ -592,7 +669,11 @@ export function createCardActionHandler(
     return true;
   }
 
-  async function handleControlSessionPick(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function handleControlSessionPick(
+    im: ChannelIM,
+    event: IMCardActionEvent,
+    accountGeneration: number,
+  ): Promise<boolean> {
     // Terminal: 把 binding 写入, 之后该 (bot, owner) 在渠道发的消息会被 turnRunner
     // 入口的 binding.resolve 路由到这个 desktop sessionId。无论 attach 成败都解锁
     // controlState (失败时用户至少能继续别的操作)。
@@ -608,7 +689,7 @@ export function createCardActionHandler(
     const displayName = String(event.payload.displayName ?? '');
     if (!sessionId || !botContextId) {
       log.warn('control:session-pick missing sessionId/botAppId — ignoring');
-      return;
+      return true;
     }
     log.info(`control:session-pick sessionId=...${sessionId.slice(-8)} displayName=${displayName}`);
 
@@ -654,15 +735,19 @@ export function createCardActionHandler(
       }
       exitControl(botContextId, event.senderId);
       if (!established) {
+        const failedLabel = ui.cards.control.attachFailed('takeover failed');
         try {
           await im.updateInteractiveCard(
             event.messageId,
-            cards.buildResolvedCard(ui.cards.control.attachFailed('takeover failed')),
+            cards.buildResolvedCard(failedLabel),
           );
-        } catch {
-          /* swallow */
+          return true;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          log.warn(`session-pick takeover failure card patch failed (non-fatal): ${msg}`);
+          rememberResolvedCardRetry(event, accountGeneration, failedLabel);
+          return false;
         }
-        return;
       }
 
       // New binding is committed now. Only after that point may the old root
@@ -688,14 +773,18 @@ export function createCardActionHandler(
       }
 
       // picker 卡收口(顶层) — root 卡才是这次接管的"家"
+      const resolvedLabel = ui.cards.control.resolvedSessionPick(sessionTitle, displayName);
+      let pickerPatched = true;
       try {
         await im.updateInteractiveCard(
           event.messageId,
-          cards.buildResolvedCard(ui.cards.control.resolvedSessionPick(sessionTitle, displayName)),
+          cards.buildResolvedCard(resolvedLabel),
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.warn(`session-pick picker resolve patch failed (non-fatal): ${msg}`);
+        rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
+        pickerPatched = false;
       }
 
       // brief 总结发进新 thread — 失败 fallback 提示, 不阻塞
@@ -724,7 +813,7 @@ export function createCardActionHandler(
         const msg = err instanceof Error ? err.message : String(err);
         log.warn(`session-pick prewire failed (non-fatal): ${msg}`);
       }
-      return;
+      return pickerPatched;
     }
 
     // 立刻 patch loading 卡 — 抢在 attach 之前,目的有两个:
@@ -761,16 +850,19 @@ export function createCardActionHandler(
     // attach 失败: 走快速路径 — patch 卡片报错 + 立刻 exitControl, 没总结要等。
     if (attachErr) {
       exitControl(botContextId, event.senderId);
+      const failedLabel = ui.cards.control.attachFailed(attachErr);
       try {
         await im.updateInteractiveCard(
           event.messageId,
-          cards.buildResolvedCard(ui.cards.control.attachFailed(attachErr)),
+          cards.buildResolvedCard(failedLabel),
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.warn(`control:session-pick card patch failed (non-fatal): ${msg}`);
+        rememberResolvedCardRetry(event, accountGeneration, failedLabel);
+        return false;
       }
-      return;
+      return true;
     }
 
     // attach 成功路径: loading 卡已在前面 patch 上, 现在取该 session 最后一条
@@ -790,11 +882,14 @@ export function createCardActionHandler(
     const summaryBody = summary
       ? `${headerText}\n\n${summary}`
       : `${headerText}\n\n_(回顾失败了, 直接发消息接着聊就行)_`;
+    let pickerPatched = true;
     try {
       await im.patchMarkdownCard(event.messageId, summaryBody);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`control:session-pick final patch failed (non-fatal): ${msg}`);
+      rememberResolvedCardRetry(event, accountGeneration, summaryBody);
+      pickerPatched = false;
     }
 
     // 总结卡片 patch 完之后立刻 prewire — 把 setInteractionListener 切到本渠道
@@ -812,9 +907,14 @@ export function createCardActionHandler(
     }
 
     exitControl(botContextId, event.senderId);
+    return pickerPatched;
   }
 
-  async function handleControlNewSession(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function handleControlNewSession(
+    im: ChannelIM,
+    event: IMCardActionEvent,
+    accountGeneration: number,
+  ): Promise<boolean> {
     // Terminal: 在指定 workingDir 下用 desktop 默认参数新建一个 session,
     // 然后 attach binding 把后续渠道消息路由到这个新 session。
     // session 创建参数:
@@ -828,7 +928,7 @@ export function createCardActionHandler(
     const displayName = String(event.payload.displayName ?? workingDir);
     if (!botContextId || !workingDir) {
       log.warn('control:new missing botAppId/workingDir — ignoring');
-      return;
+      return true;
     }
     log.info(
       `control:new workingDir=${workingDir} displayName=${displayName} sender=...${event.senderId.slice(-8)}`,
@@ -946,18 +1046,21 @@ export function createCardActionHandler(
         }
       }
       exitControl(botContextId, event.senderId);
+      const resolvedLabel =
+        createErr || !established
+          ? ui.cards.control.attachFailed(createErr ?? 'takeover failed')
+          : ui.cards.control.resolvedNewSession(displayName);
+      let pickerPatched = true;
       try {
         await im.updateInteractiveCard(
           event.messageId,
-          cards.buildResolvedCard(
-            createErr || !established
-              ? ui.cards.control.attachFailed(createErr ?? 'takeover failed')
-              : ui.cards.control.resolvedNewSession(displayName),
-          ),
+          cards.buildResolvedCard(resolvedLabel),
         );
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         log.warn(`control:new(thread) picker patch failed (non-fatal): ${msg}`);
+        rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
+        pickerPatched = false;
       }
       if (established) {
         try {
@@ -971,7 +1074,7 @@ export function createCardActionHandler(
           log.warn(`control:new(thread) prewire failed (non-fatal): ${msg}`);
         }
       }
-      return;
+      return pickerPatched;
     }
 
     let newSessionId: string | null = null;
@@ -1032,19 +1135,21 @@ export function createCardActionHandler(
     }
 
     exitControl(botContextId, event.senderId);
+    const resolvedLabel = attachErr
+      ? ui.cards.control.attachFailed(attachErr)
+      : pickRandom(ui.cards.control.newSessionWelcomePrompts)(displayName);
     try {
       await im.updateInteractiveCard(
         event.messageId,
-        cards.buildResolvedCard(
-          attachErr
-            ? ui.cards.control.attachFailed(attachErr)
-            : pickRandom(ui.cards.control.newSessionWelcomePrompts)(displayName),
-        ),
+        cards.buildResolvedCard(resolvedLabel),
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`control:new card patch failed (non-fatal): ${msg}`);
+      rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
+      return false;
     }
+    return true;
   }
 
   /**
@@ -1132,13 +1237,14 @@ export function createCardActionHandler(
     im: ChannelIM,
     event: IMCardActionEvent,
     kind: 'project' | 'dialogue',
-  ): Promise<void> {
+    accountGeneration: number,
+  ): Promise<boolean> {
     const projectUi = adapter.ui.cards.project;
-    if (!projectUi) return;
+    if (!projectUi) return true;
     const botContextId = String(event.payload.botAppId ?? '');
     if (!botContextId) {
       log.warn('project switch missing botAppId — ignoring');
-      return;
+      return true;
     }
     // 接管期间语义冲突(slash 层已拦, 这里兜旧卡片迟到按压)。
     const attached = bindingStore.get({
@@ -1147,8 +1253,7 @@ export function createCardActionHandler(
       userId: event.senderId,
     });
     if (attached) {
-      await patchProjectCard(im, event.messageId, projectUi.attachedUnsupported);
-      return;
+      return patchProjectCard(im, event.messageId, projectUi.attachedUnsupported);
     }
 
     let workingDir: string;
@@ -1160,7 +1265,7 @@ export function createCardActionHandler(
       workspaceKind = 'project';
       if (!workingDir) {
         log.warn('project:pick missing workingDir — ignoring');
-        return;
+        return true;
       }
       // 项目清单来自历史会话行, 目录可能已被移动/删除/被同名文件顶替 —
       // 必须确认是目录才切(fail-closed), 否则会话会切进非法 cwd 难以排障。
@@ -1171,8 +1276,7 @@ export function createCardActionHandler(
         isDirectory = false;
       }
       if (!isDirectory) {
-        await patchProjectCard(im, event.messageId, projectUi.switchFailed(displayName));
-        return;
+        return patchProjectCard(im, event.messageId, projectUi.switchFailed(displayName));
       }
     } else {
       workingDir = adapter.sessions.ensureWorkingDir(botContextId);
@@ -1182,8 +1286,7 @@ export function createCardActionHandler(
 
     const target = await turnRunner.resolveRouteTarget(botContextId, event.senderId);
     if (!target) {
-      await patchProjectCard(im, event.messageId, projectUi.switchFailed(displayName));
-      return;
+      return patchProjectCard(im, event.messageId, projectUi.switchFailed(displayName));
     }
     log.info(
       `project switch session=...${target.row.id.slice(-8)} kind=${workspaceKind} sender=...${event.senderId.slice(-8)}`,
@@ -1191,11 +1294,11 @@ export function createCardActionHandler(
     await switchSessionWorkingDir(target.row.id, workingDir, workspaceKind);
     // 旧目录的 live session(含进行中 turn)必须丢弃 — 下一条消息在新目录重建。
     await turnRunner.disposeOneSession(target.row.id);
-    await patchProjectCard(
-      im,
-      event.messageId,
-      kind === 'project' ? projectUi.resolvedPick(displayName) : projectUi.resolvedDialogue,
-    );
+    const resolvedLabel =
+      kind === 'project' ? projectUi.resolvedPick(displayName) : projectUi.resolvedDialogue;
+    const patched = await patchProjectCard(im, event.messageId, resolvedLabel);
+    if (!patched) rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
+    return patched;
   }
 
   async function handleControlExit(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
@@ -1333,12 +1436,14 @@ export function createCardActionHandler(
             `card action sender=...${event.senderId.slice(-8)} button=${event.buttonId} payload=${JSON.stringify(event.payload).slice(0, 200)}`,
           );
 
+          const retryResult = await retryResolvedCardIfPending(im, event, accountGeneration);
+          if (retryResult !== null) return retryResult;
+
           // model:pick is NOT an InteractionRequest reply — it's a direct command
           // triggered by the /model slash command's picker card. Handle it
           // separately: update DB + live session, patch card to "已切换".
           if (event.buttonId === 'model:pick') {
-            await handleModelPick(im, event);
-            return;
+            return handleModelPick(im, event, accountGeneration);
           }
 
           // Same shape as model:pick — direct command from /permission picker card.
@@ -1346,8 +1451,7 @@ export function createCardActionHandler(
             event.buttonId === 'permmode:pick'
             || event.buttonId === 'permmode:confirm-full-access'
           ) {
-            await handlePermissionModePick(im, event);
-            return;
+            return handlePermissionModePick(im, event, accountGeneration);
           }
           if (event.buttonId === 'permmode:cancel-full-access') {
             return handlePermissionModeCancel(im, event);
@@ -1366,12 +1470,10 @@ export function createCardActionHandler(
             return handleControlBack(im, event);
           }
           if (event.buttonId === 'control:session-pick') {
-            await handleControlSessionPick(im, event);
-            return;
+            return handleControlSessionPick(im, event, accountGeneration);
           }
           if (event.buttonId === 'control:new') {
-            await handleControlNewSession(im, event);
-            return;
+            return handleControlNewSession(im, event, accountGeneration);
           }
           if (event.buttonId === 'control:exit') {
             await handleControlExit(im, event);
@@ -1388,12 +1490,10 @@ export function createCardActionHandler(
 
           // /project picker — pick(项目) / dialogue(回托管对话目录) / cancel
           if (event.buttonId === 'project:pick') {
-            await handleProjectSwitch(im, event, 'project');
-            return;
+            return handleProjectSwitch(im, event, 'project', accountGeneration);
           }
           if (event.buttonId === 'project:dialogue') {
-            await handleProjectSwitch(im, event, 'dialogue');
-            return;
+            return handleProjectSwitch(im, event, 'dialogue', accountGeneration);
           }
           if (event.buttonId === 'project:cancel') {
             const projectUi = adapter.ui.cards.project;
@@ -1416,24 +1516,6 @@ export function createCardActionHandler(
           }
 
           const retryKey = resolvedCardRetryKey(event, requestId);
-          const now = Date.now();
-          pruneResolvedCardRetries(now);
-          const retry = resolvedCardRetries.get(retryKey);
-          if (retry && retry.accountGeneration === accountGeneration) {
-            try {
-              await im.updateInteractiveCard(
-                event.messageId,
-                cards.buildResolvedCard(retry.label),
-              );
-              resolvedCardRetries.delete(retryKey);
-              return true;
-            } catch (err) {
-              const msg = err instanceof Error ? err.message : String(err);
-              log.warn(`resolved interaction card retry failed (non-fatal): ${msg}`);
-              return false;
-            }
-          }
-          if (retry) resolvedCardRetries.delete(retryKey);
 
           const resolved = resolvePending(requestId, decision);
           if (!resolved) {
@@ -1455,16 +1537,7 @@ export function createCardActionHandler(
             // still exposes its callback. Let Telegram release its dedup key and
             // remember the completed outcome so a retry can finish the same card
             // update instead of reporting the already-applied decision as expired.
-            resolvedCardRetries.set(retryKey, {
-              label: resolvedLabel,
-              accountGeneration,
-              at: Date.now(),
-            });
-            while (resolvedCardRetries.size > MAX_RESOLVED_CARD_RETRIES) {
-              const oldest = resolvedCardRetries.keys().next().value;
-              if (oldest === undefined) break;
-              resolvedCardRetries.delete(oldest);
-            }
+            rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
             return false;
           }
         });

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -91,6 +91,15 @@ const DESKTOP_CC_DEFAULTS: DesktopCcPrefs = {
   fastMode: false,
 };
 
+const RESOLVED_CARD_RETRY_TTL_MS = 5 * 60_000;
+const MAX_RESOLVED_CARD_RETRIES = 512;
+
+type ResolvedCardRetry = {
+  label: string;
+  accountGeneration: number;
+  at: number;
+};
+
 export function createCardActionHandler(
   adapter: ImChannelAdapter,
   cards: ImCardBuilders,
@@ -99,6 +108,23 @@ export function createCardActionHandler(
   const { ui, channel, threadScoped } = adapter;
   const log = createLogger(`im:${channel}:card`);
   const threadUi = ui.thread;
+  /**
+   * A pending interaction is consumed before its Telegram card can be edited.
+   * Keep the resolved label briefly when that edit fails so a retry can finish
+   * the same visible outcome instead of reporting an already-completed action
+   * as expired.
+   */
+  const resolvedCardRetries = new Map<string, ResolvedCardRetry>();
+
+  function pruneResolvedCardRetries(now: number): void {
+    for (const [key, entry] of resolvedCardRetries) {
+      if (now - entry.at > RESOLVED_CARD_RETRY_TTL_MS) resolvedCardRetries.delete(key);
+    }
+  }
+
+  function resolvedCardRetryKey(event: IMCardActionEvent, requestId: string): string {
+    return `${event.messageId}|${requestId}`;
+  }
 
   function requireThreadUi() {
     if (!threadUi)
@@ -467,15 +493,17 @@ export function createCardActionHandler(
   async function handlePermissionModeCancel(
     im: ChannelIM,
     event: IMCardActionEvent,
-  ): Promise<void> {
+  ): Promise<boolean> {
     try {
       await im.updateInteractiveCard(
         event.messageId,
         cards.buildResolvedCard(ui.cards.permissionMode.fullAccessCancelled),
       );
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`permmode:cancel card patch failed (non-fatal): ${msg}`);
+      return false;
     }
   }
 
@@ -1321,8 +1349,7 @@ export function createCardActionHandler(
             return;
           }
           if (event.buttonId === 'permmode:cancel-full-access') {
-            await handlePermissionModeCancel(im, event);
-            return;
+            return handlePermissionModeCancel(im, event);
           }
 
           // /ctr picker —
@@ -1387,6 +1414,26 @@ export function createCardActionHandler(
             return patchExpiredInteractionCard(im, event);
           }
 
+          const retryKey = resolvedCardRetryKey(event, requestId);
+          const now = Date.now();
+          pruneResolvedCardRetries(now);
+          const retry = resolvedCardRetries.get(retryKey);
+          if (retry && retry.accountGeneration === accountGeneration) {
+            try {
+              await im.updateInteractiveCard(
+                event.messageId,
+                cards.buildResolvedCard(retry.label),
+              );
+              resolvedCardRetries.delete(retryKey);
+              return true;
+            } catch (err) {
+              const msg = err instanceof Error ? err.message : String(err);
+              log.warn(`resolved interaction card retry failed (non-fatal): ${msg}`);
+              return false;
+            }
+          }
+          if (retry) resolvedCardRetries.delete(retryKey);
+
           const resolved = resolvePending(requestId, decision);
           if (!resolved) {
             log.warn(
@@ -1399,13 +1446,24 @@ export function createCardActionHandler(
           const resolvedLabel = describeDecision(decision);
           try {
             await im.updateInteractiveCard(event.messageId, cards.buildResolvedCard(resolvedLabel));
+            resolvedCardRetries.delete(retryKey);
           } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
             log.warn(`updateInteractiveCard failed (non-fatal): ${msg}`);
             // The pending decision has already been consumed, but the rendered card
-            // still exposes its callback. Let Telegram release its dedup key so a
-            // retry can at least run the stale-card cleanup instead of being ACKed
-            // and silently discarded for five minutes.
+            // still exposes its callback. Let Telegram release its dedup key and
+            // remember the completed outcome so a retry can finish the same card
+            // update instead of reporting the already-applied decision as expired.
+            resolvedCardRetries.set(retryKey, {
+              label: resolvedLabel,
+              accountGeneration,
+              at: Date.now(),
+            });
+            while (resolvedCardRetries.size > MAX_RESOLVED_CARD_RETRIES) {
+              const oldest = resolvedCardRetries.keys().next().value;
+              if (oldest === undefined) break;
+              resolvedCardRetries.delete(oldest);
+            }
             return false;
           }
         });

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -1275,14 +1275,19 @@ export function createCardActionHandler(
     }
   }
 
-  async function patchExpiredInteractionCard(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function patchExpiredInteractionCard(
+    im: ChannelIM,
+    event: IMCardActionEvent,
+  ): Promise<boolean> {
     const notice = adapter.interactionExpiredNotice;
-    if (!notice) return;
+    if (!notice) return true;
     try {
       await im.updateInteractiveCard(event.messageId, cards.buildResolvedCard(notice));
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`expired interaction card cleanup failed (non-fatal): ${msg}`);
+      return false;
     }
   }
 
@@ -1373,15 +1378,13 @@ export function createCardActionHandler(
           const decision = decisionFromPress(event);
           if (!decision) {
             log.warn(`unknown buttonId=${event.buttonId} — ignoring`);
-            await patchExpiredInteractionCard(im, event);
-            return;
+            return patchExpiredInteractionCard(im, event);
           }
 
           const requestId = String(event.payload.requestId ?? '');
           if (!requestId) {
             log.warn('no requestId in payload — ignoring');
-            await patchExpiredInteractionCard(im, event);
-            return;
+            return patchExpiredInteractionCard(im, event);
           }
 
           const resolved = resolvePending(requestId, decision);
@@ -1389,8 +1392,7 @@ export function createCardActionHandler(
             log.warn(
               `no pending interaction for requestId=...${requestId.slice(-8)} (already resolved? user double-tapped?)`,
             );
-            await patchExpiredInteractionCard(im, event);
-            return;
+            return patchExpiredInteractionCard(im, event);
           }
 
           // Patch the card to a resolved state so the user sees their choice took.

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -1301,23 +1301,30 @@ export function createCardActionHandler(
     return patched;
   }
 
-  async function handleControlExit(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+  async function handleControlExit(
+    im: ChannelIM,
+    event: IMCardActionEvent,
+    accountGeneration: number,
+  ): Promise<boolean> {
     // Terminal: 解锁 controlState。同 session-pick: card patch 失败也解锁。
     const botContextId = String(event.payload.botAppId ?? '');
     if (!botContextId) {
       log.warn('control:exit missing botAppId — ignoring');
-      return;
+      return true;
     }
     log.info(`control:exit (sender=...${event.senderId.slice(-8)})`);
     exitControl(botContextId, event.senderId);
+    const resolvedLabel = ui.cards.control.resolvedExit;
     try {
       await im.updateInteractiveCard(
         event.messageId,
-        cards.buildResolvedCard(ui.cards.control.resolvedExit),
+        cards.buildResolvedCard(resolvedLabel),
       );
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`control:exit card patch failed (non-fatal): ${msg}`);
+      rememberResolvedCardRetry(event, accountGeneration, resolvedLabel);
+      return false;
     }
     // thread 模型: 顶层锚点卡也收口成"已取消", 不留一张悬空的"接管对话"卡
     const anchorMessageId = String(event.payload.anchorMessageId ?? '');
@@ -1333,6 +1340,7 @@ export function createCardActionHandler(
         log.warn(`control:exit anchor patch failed (non-fatal): ${msg}`);
       }
     }
+    return true;
   }
 
   // ── press → decision ──────────────────────────────────────────────────────
@@ -1476,8 +1484,7 @@ export function createCardActionHandler(
             return handleControlNewSession(im, event, accountGeneration);
           }
           if (event.buttonId === 'control:exit') {
-            await handleControlExit(im, event);
-            return;
+            return handleControlExit(im, event, accountGeneration);
           }
           if (event.buttonId === 'control:thread-exit') {
             await handleControlThreadExit(im, event);

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -1269,6 +1269,17 @@ export function createCardActionHandler(
     }
   }
 
+  async function patchExpiredInteractionCard(im: ChannelIM, event: IMCardActionEvent): Promise<void> {
+    const notice = adapter.interactionExpiredNotice;
+    if (!notice) return;
+    try {
+      await im.updateInteractiveCard(event.messageId, cards.buildResolvedCard(notice));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(`expired interaction card cleanup failed (non-fatal): ${msg}`);
+    }
+  }
+
   return function attachCardActionHandler(im: ChannelIM): () => void {
     return im.onCardAction(async (event: IMCardActionEvent) => {
       const accountGeneration = captureImAccountGeneration();
@@ -1358,12 +1369,14 @@ export function createCardActionHandler(
           const decision = decisionFromPress(event);
           if (!decision) {
             log.warn(`unknown buttonId=${event.buttonId} — ignoring`);
+            await patchExpiredInteractionCard(im, event);
             return;
           }
 
           const requestId = String(event.payload.requestId ?? '');
           if (!requestId) {
             log.warn('no requestId in payload — ignoring');
+            await patchExpiredInteractionCard(im, event);
             return;
           }
 
@@ -1372,6 +1385,7 @@ export function createCardActionHandler(
             log.warn(
               `no pending interaction for requestId=...${requestId.slice(-8)} (already resolved? user double-tapped?)`,
             );
+            await patchExpiredInteractionCard(im, event);
             return;
           }
 

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -432,6 +432,7 @@ export function createCardActionHandler(
     });
 
     if (result.kind === 'confirmation-required') {
+      const confirmationRequestId = `permmode-confirm:${sessionId}`;
       try {
         await im.updateInteractiveCard(event.messageId, {
           title: ui.cards.permissionMode.fullAccessConfirmTitle,
@@ -447,7 +448,7 @@ export function createCardActionHandler(
               id: 'permmode:cancel-full-access',
               label: ui.cards.permissionMode.btnCancelFullAccess,
               type: 'default',
-              payload: { sessionId },
+              payload: { requestId: confirmationRequestId, sessionId },
             },
           ],
         });

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -115,6 +115,12 @@ export function createCardActionHandler(
    * as expired.
    */
   const resolvedCardRetries = new Map<string, ResolvedCardRetry>();
+  /**
+   * The latest callback identity rendered for each message. A card edit can
+   * fail after a newer callback has already replaced the same message; the
+   * older failure must not repopulate a retry entry for the superseded card.
+   */
+  const latestResolvedCardActions = new Map<string, string>();
 
   function pruneResolvedCardRetries(now: number): void {
     for (const [key, entry] of resolvedCardRetries) {
@@ -122,7 +128,7 @@ export function createCardActionHandler(
     }
   }
 
-  function resolvedCardRetryKey(event: IMCardActionEvent, requestId: string): string {
+  function resolvedCardRetryIdentity(event: IMCardActionEvent, requestId: string): string {
     const isTerminalDecision =
       event.buttonId.startsWith('permission:') ||
       event.buttonId.startsWith('plan:') ||
@@ -132,7 +138,32 @@ export function createCardActionHandler(
     const renderedToken = event.callbackToken?.trim();
     const identity =
       renderedToken && !isTerminalDecision ? `token:${renderedToken}` : `request:${requestId}`;
-    return `${event.messageId}|${identity}`;
+    return identity;
+  }
+
+  function resolvedCardRetryKey(event: IMCardActionEvent, requestId: string): string {
+    return `${event.messageId}|${resolvedCardRetryIdentity(event, requestId)}`;
+  }
+
+  function clearResolvedCardRetriesForMessage(messageId: string): void {
+    const prefix = `${messageId}|`;
+    for (const key of resolvedCardRetries.keys()) {
+      if (key.startsWith(prefix)) resolvedCardRetries.delete(key);
+    }
+  }
+
+  function beginResolvedCardAction(event: IMCardActionEvent): void {
+    const requestId = String(event.payload.requestId ?? '');
+    latestResolvedCardActions.set(
+      event.messageId,
+      resolvedCardRetryIdentity(event, requestId),
+    );
+    clearResolvedCardRetriesForMessage(event.messageId);
+    while (latestResolvedCardActions.size > MAX_RESOLVED_CARD_RETRIES) {
+      const oldest = latestResolvedCardActions.keys().next().value;
+      if (oldest === undefined) break;
+      latestResolvedCardActions.delete(oldest);
+    }
   }
 
   function rememberResolvedCardRetry(
@@ -142,8 +173,10 @@ export function createCardActionHandler(
   ): void {
     const requestId = String(event.payload.requestId ?? '');
     if (!requestId) return;
-    const key = resolvedCardRetryKey(event, requestId);
-    resolvedCardRetries.delete(key);
+    const identity = resolvedCardRetryIdentity(event, requestId);
+    if (latestResolvedCardActions.get(event.messageId) !== identity) return;
+    const key = `${event.messageId}|${identity}`;
+    clearResolvedCardRetriesForMessage(event.messageId);
     resolvedCardRetries.set(key, { label, accountGeneration, at: Date.now() });
     while (resolvedCardRetries.size > MAX_RESOLVED_CARD_RETRIES) {
       const oldest = resolvedCardRetries.keys().next().value;
@@ -1446,6 +1479,7 @@ export function createCardActionHandler(
 
           const retryResult = await retryResolvedCardIfPending(im, event, accountGeneration);
           if (retryResult !== null) return retryResult;
+          beginResolvedCardAction(event);
 
           // model:pick is NOT an InteractionRequest reply — it's a direct command
           // triggered by the /model slash command's picker card. Handle it

--- a/apps/desktop/src/main/im/shared/cardActionHandler.ts
+++ b/apps/desktop/src/main/im/shared/cardActionHandler.ts
@@ -1083,12 +1083,14 @@ export function createCardActionHandler(
 
   // ── /project 项目切换(projectSwitching 渠道专用)────────────────────────────
 
-  async function patchProjectCard(im: ChannelIM, messageId: string, label: string): Promise<void> {
+  async function patchProjectCard(im: ChannelIM, messageId: string, label: string): Promise<boolean> {
     try {
       await im.updateInteractiveCard(messageId, cards.buildResolvedCard(label));
+      return true;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(`project card patch failed (non-fatal): ${msg}`);
+      return false;
     }
   }
 
@@ -1363,7 +1365,7 @@ export function createCardActionHandler(
           if (event.buttonId === 'project:cancel') {
             const projectUi = adapter.ui.cards.project;
             if (projectUi) {
-              await patchProjectCard(im, event.messageId, projectUi.resolvedCancel);
+              return patchProjectCard(im, event.messageId, projectUi.resolvedCancel);
             }
             return;
           }

--- a/apps/desktop/src/main/im/shared/cardBuilders.ts
+++ b/apps/desktop/src/main/im/shared/cardBuilders.ts
@@ -250,7 +250,7 @@ export function createCardBuilders(
                 // requestId is only for InteractionRequest binding — model:pick
                 // doesn't go through pendingInteractions. Use a sentinel so card
                 // action parser still recognises it as a valid action.
-                requestId: `model-pick:${sessionId}`,
+                requestId: `model-pick:${sessionId}:${sec.provider.id}:${m.id}:${effort}`,
                 sessionId,
                 modelId: m.id,
                 modelLabel: m.displayName,
@@ -282,7 +282,7 @@ export function createCardBuilders(
           type: m.id === currentMode ? ('primary' as const) : ('default' as const),
           payload: {
             // Sentinel — permmode:pick doesn't go through pendingInteractions.
-            requestId: `permmode-pick:${sessionId}`,
+            requestId: `permmode-pick:${sessionId}:${m.id}`,
             sessionId,
             agentKind,
             mode: m.id,

--- a/apps/desktop/src/main/im/shared/types.ts
+++ b/apps/desktop/src/main/im/shared/types.ts
@@ -115,6 +115,8 @@ export interface ImChannelAdapter {
    * 缺省 = 全部按默认撤掉。仅真正跑过的 turn 生效, pre-dispatch 失败不放。
    */
   terminalReactionEmoji?(kind: 'done' | 'aborted' | 'error'): string | null;
+  /** Shown on a Telegram card whose callback survived transport but lost its pending interaction. */
+  interactionExpiredNotice?: string;
   /**
    * `/project` 项目切换开关(个人 Telegram: true)。开启后 slash 层放行
    * /project 命令: 列出 desktop 端项目工作区, 选中后把当前 (bot, user/lane)

--- a/apps/desktop/src/main/im/telegram/adapter.ts
+++ b/apps/desktop/src/main/im/telegram/adapter.ts
@@ -27,7 +27,7 @@ import { buildTelegramGroupContextPrefix, buildTelegramReplyContextBlock } from 
 import { readTelegramPersona } from './behaviorStore';
 import { autoRegisterTelegramSpeaker } from './contactsAutoRegister';
 import { createTelegramGuestTurnPermissionPolicy } from './permissionPolicy';
-import { ui, PROCESSING_EMOJI } from './uiText';
+import { telegramUiText, ui, PROCESSING_EMOJI } from './uiText';
 
 function ensureWorkingDir(botId: string): string {
   const dir = ownerScopedImUserDataPath('im-working-dir', `telegram-${botId}`);
@@ -69,6 +69,7 @@ export function buildTelegramAdapter(
     output: { kind: 'rich-card', im: telegramIm },
     config,
     ui,
+    interactionExpiredNotice: telegramUiText.expiredCardNotice,
     sessions: {
       source: 'telegram',
       sessionIdFor: (botId, userId) => `telegram_${botId}_${sessionSafeUserId(userId)}`,

--- a/packages/lizi-im/src/telegram/__tests__/components.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/components.test.ts
@@ -81,6 +81,7 @@ describe('parseCallbackQuery', () => {
       chatId: '111',
       messageId: '111|9',
       buttonId: 'perm:allow',
+      callbackToken: data,
       payload: { requestId: 'r1' },
     });
   });

--- a/packages/lizi-im/src/telegram/__tests__/components.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/components.test.ts
@@ -47,8 +47,10 @@ describe('buildCardPayload', () => {
     if (amp !== -1) expect(tail.slice(amp)).toContain(';');
   });
 
-  it('无按钮时不带 reply_markup', () => {
-    expect(buildCardPayload({ body: 'b', buttons: [] }).replyMarkup).toBeUndefined();
+  it('无按钮时显式发送空 reply_markup 以清除旧键盘', () => {
+    expect(buildCardPayload({ body: 'b', buttons: [] }).replyMarkup).toEqual({
+      inline_keyboard: [],
+    });
   });
 });
 

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -359,6 +359,42 @@ describe('TelegramIM', () => {
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
   });
 
+  it('卡片 handler 失败后允许同一 callback 重试', async () => {
+    await connect();
+    const handler = vi.fn().mockRejectedValueOnce(new Error('temporary handler failure'));
+    im.onCardAction(handler);
+    const callback = encodeCallbackData('control:back', {
+      requestId: 'retryable-request',
+    });
+    api.pushUpdates([
+      {
+        update_id: 905,
+        callback_query: {
+          id: 'retry-first',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 905, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+
+    api.pushUpdates([
+      {
+        update_id: 906,
+        callback_query: {
+          id: 'retry-second',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 905, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+  });
+
   it('同一终态 interaction 的不同决策按钮只派发一次', async () => {
     await connect();
     const handler = vi.fn();

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -426,6 +426,36 @@ describe('TelegramIM', () => {
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
   });
 
+  it('权限确认卡的取消 callback 带 requestId 时收口失败可重试', async () => {
+    await connect();
+    const handler = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(undefined);
+    im.onCardAction(handler);
+    const callback = encodeCallbackData('permmode:cancel-full-access', {
+      requestId: 'permmode-confirm:sess-target',
+      sessionId: 'sess-target',
+    });
+    const pushCallback = (updateId: number, callbackId: string) => {
+      api.pushUpdates([
+        {
+          update_id: updateId,
+          callback_query: {
+            id: callbackId,
+            from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+            data: callback,
+            message: { message_id: 909, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+          },
+        },
+      ]);
+    };
+
+    pushCallback(909, 'permission-cancel-first');
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    pushCallback(910, 'permission-cancel-second');
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+  });
+
   it('同一终态 interaction 的不同决策按钮只派发一次', async () => {
     await connect();
     const handler = vi.fn();

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -395,6 +395,35 @@ describe('TelegramIM', () => {
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
   });
 
+  it('卡片 handler 显式报告收口失败后允许同一 callback 重试', async () => {
+    await connect();
+    const handler = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(undefined);
+    im.onCardAction(handler);
+    const callback = encodeCallbackData('control:back', {
+      requestId: 'retryable-card-edit',
+    });
+    const pushCallback = (updateId: number, callbackId: string) => {
+      api.pushUpdates([
+        {
+          update_id: updateId,
+          callback_query: {
+            id: callbackId,
+            from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+            data: callback,
+            message: { message_id: 907, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+          },
+        },
+      ]);
+    };
+
+    pushCallback(907, 'retryable-card-edit-first');
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    pushCallback(908, 'retryable-card-edit-second');
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+  });
+
   it('同一终态 interaction 的不同决策按钮只派发一次', async () => {
     await connect();
     const handler = vi.fn();

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -326,13 +326,16 @@ describe('TelegramIM', () => {
     await connect();
     const handler = vi.fn();
     im.onCardAction(handler);
+    const callback = encodeCallbackData('permission:allow:once', {
+      requestId: 'duplicate-request',
+    });
     api.pushUpdates([
       {
         update_id: 904,
         callback_query: {
           id: 'duplicate-1',
           from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
-          data: encodeCallbackData('permission:allow:once', { requestId: 'duplicate-request' }),
+          data: callback,
           message: { message_id: 904, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
         },
       },
@@ -341,7 +344,7 @@ describe('TelegramIM', () => {
         callback_query: {
           id: 'duplicate-2',
           from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
-          data: encodeCallbackData('permission:deny', { requestId: 'duplicate-request' }),
+          data: callback,
           message: { message_id: 904, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
         },
       },
@@ -349,6 +352,47 @@ describe('TelegramIM', () => {
 
     await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+  });
+
+  it('同一消息重绘后相同 requestId 的新 callback token 仍可合法导航', async () => {
+    await connect();
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    const firstRender = encodeCallbackData('control-pick', {
+      requestId: 'navigation-request',
+      workingDir: 'repo',
+    });
+    const rebuiltRender = encodeCallbackData('control-pick', {
+      requestId: 'navigation-request',
+      workingDir: 'repo',
+    });
+    expect(rebuiltRender).not.toBe(firstRender);
+    api.pushUpdates([
+      {
+        update_id: 906,
+        callback_query: {
+          id: 'navigation-1',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: firstRender,
+          message: { message_id: 906, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+      {
+        update_id: 907,
+        callback_query: {
+          id: 'navigation-2',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: rebuiltRender,
+          message: { message_id: 906, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+    expect(handler.mock.calls.map(([event]) => event.payload.requestId)).toEqual([
+      'navigation-request',
+      'navigation-request',
+    ]);
   });
 
   it('set-config 失败(401): 状态 error 且凭证回滚', async () => {

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -354,6 +354,45 @@ describe('TelegramIM', () => {
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
   });
 
+  it('同一终态 interaction 的不同决策按钮只派发一次', async () => {
+    await connect();
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    const allow = encodeCallbackData('permission:allow:once', {
+      requestId: 'terminal-request',
+    });
+    const deny = encodeCallbackData('permission:deny', {
+      requestId: 'terminal-request',
+    });
+    expect(deny).not.toBe(allow);
+    api.pushUpdates([
+      {
+        update_id: 905,
+        callback_query: {
+          id: 'terminal-allow',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: allow,
+          message: { message_id: 905, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+      {
+        update_id: 906,
+        callback_query: {
+          id: 'terminal-deny',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: deny,
+          message: { message_id: 905, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toEqual([
+      { method: 'answerCallbackQuery', params: { callback_query_id: 'terminal-allow' } },
+      { method: 'answerCallbackQuery', params: { callback_query_id: 'terminal-deny' } },
+    ]);
+  });
+
   it('同一消息重绘后相同 requestId 的新 callback token 仍可合法导航', async () => {
     await connect();
     const handler = vi.fn();

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -306,6 +306,47 @@ describe('TelegramIM', () => {
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(1);
   });
 
+  it('卡片动作收口失败时恢复 callback 原键盘供重试', async () => {
+    await connect();
+    api.calls.length = 0;
+    const handler = vi.fn(async () => false);
+    im.onCardAction(handler);
+    const callbackData = encodeCallbackData('control:session-pick', {
+      requestId: 'retryable-card-action',
+    });
+    const replyMarkup = {
+      inline_keyboard: [[{ text: '接管', callback_data: callbackData }]],
+    };
+    api.pushUpdates([
+      {
+        update_id: 904,
+        callback_query: {
+          id: 'retryable-card-action-callback',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callbackData,
+          message: {
+            message_id: 904,
+            chat: { id: Number(OWNER_ID), type: 'private' },
+            date: 1,
+            reply_markup: replyMarkup,
+          },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    await vi.waitFor(() => {
+      expect(api.calls).toContainEqual({
+        method: 'editMessageReplyMarkup',
+        params: {
+          chat_id: Number(OWNER_ID),
+          message_id: 904,
+          reply_markup: replyMarkup,
+        },
+      });
+    });
+  });
+
   it('失效收口通过 editMessageText 显式发送空 reply_markup', async () => {
     await connect();
     const sent = await im.sendInteractiveCard(OWNER_ID, {

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -191,6 +191,11 @@ async function connect(): Promise<void> {
   await handler({ token: '999:secret-token-abcdefghijk', ownerUserId: OWNER_ID });
 }
 
+async function connectWithToken(token: string): Promise<void> {
+  const handler = ctx.handlers.get('telegramBot:set-config')!;
+  await handler({ token, ownerUserId: OWNER_ID });
+}
+
 describe('TelegramIM', () => {
   it('无 token 时 init 保持 idle, 不发任何请求', async () => {
     await im.init();
@@ -391,6 +396,82 @@ describe('TelegramIM', () => {
       { method: 'answerCallbackQuery', params: { callback_query_id: 'terminal-allow' } },
       { method: 'answerCallbackQuery', params: { callback_query_id: 'terminal-deny' } },
     ]);
+  });
+
+  it('同一 bot 重连后保留近期 callback 去重状态', async () => {
+    await connect();
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    const callback = encodeCallbackData('permission:allow:once', {
+      requestId: 'reconnect-request',
+    });
+    api.pushUpdates([
+      {
+        update_id: 907,
+        callback_query: {
+          id: 'reconnect-first',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 907, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+
+    await ctx.handlers.get('telegramBot:set-online')!({ online: false });
+    await ctx.handlers.get('telegramBot:set-online')!({ online: true });
+    api.pushUpdates([
+      {
+        update_id: 908,
+        callback_query: {
+          id: 'reconnect-duplicate',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 907, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => {
+      expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+    });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
+  it('切换 bot 账号后清除旧账号 callback 去重状态', async () => {
+    await connect();
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    const first = encodeCallbackData('permission:allow:once', {
+      requestId: 'account-switch-request',
+    });
+    api.pushUpdates([
+      {
+        update_id: 909,
+        callback_query: {
+          id: 'account-first',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: first,
+          message: { message_id: 909, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+
+    await connectWithToken('888:replacement-token-abcdefghijk');
+    api.pushUpdates([
+      {
+        update_id: 910,
+        callback_query: {
+          id: 'account-second',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: first,
+          message: { message_id: 909, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
   });
 
   it('同一消息重绘后相同 requestId 的新 callback token 仍可合法导航', async () => {

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -299,6 +299,58 @@ describe('TelegramIM', () => {
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(1);
   });
 
+  it('失效收口通过 editMessageText 显式发送空 reply_markup', async () => {
+    await connect();
+    const sent = await im.sendInteractiveCard(OWNER_ID, {
+      title: '需要确认',
+      body: '继续吗？',
+      buttons: [{ id: 'permission:allow:once', label: '允许', payload: { requestId: 'payload-1' } }],
+    });
+    api.calls.length = 0;
+
+    await im.updateInteractiveCard(sent.messageId, {
+      title: '卡片已过期',
+      body: '请重新发起操作。',
+      buttons: [],
+    });
+
+    expect(api.calls).toContainEqual({
+      method: 'editMessageText',
+      params: expect.objectContaining({
+        reply_markup: { inline_keyboard: [] },
+      }),
+    });
+  });
+
+  it('同一 interaction 的重复 callback 只派发一次', async () => {
+    await connect();
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    api.pushUpdates([
+      {
+        update_id: 904,
+        callback_query: {
+          id: 'duplicate-1',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: encodeCallbackData('permission:allow:once', { requestId: 'duplicate-request' }),
+          message: { message_id: 904, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+      {
+        update_id: 905,
+        callback_query: {
+          id: 'duplicate-2',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: encodeCallbackData('permission:deny', { requestId: 'duplicate-request' }),
+          message: { message_id: 904, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+  });
+
   it('set-config 失败(401): 状态 error 且凭证回滚', async () => {
     api = createFakeApi({ getMeError: new TelegramApiError('getMe', 401, 'Unauthorized') });
     ctx = createHost(tmpDir);

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -11,7 +11,7 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { IMHost, IMMessageEvent } from '../../types.js';
-import { TelegramApiError, type TelegramApiClient, type TgUpdate } from '../api.js';
+import { TelegramApiError, type TelegramApiClient, type TgUpdate, type TgUser } from '../api.js';
 import { TelegramIM, type TelegramGroupWindowEntry } from '../index.js';
 import { encodeCallbackData } from '../codec.js';
 
@@ -19,6 +19,7 @@ const BOT = { id: 999, is_bot: true, first_name: 'Cindy', username: 'my_cindy_bo
 const OWNER_ID = '111';
 
 interface FakeApi extends TelegramApiClient {
+  bot: TgUser;
   calls: Array<{ method: string; params: Record<string, unknown> }>;
   hangMethods: Set<string>;
   pushUpdates(updates: TgUpdate[]): void;
@@ -32,6 +33,7 @@ function createFakeApi(opts: { getMeError?: Error } = {}): FakeApi {
   let sentSeq = 1000;
 
   const api: FakeApi = {
+    bot: BOT,
     calls: [],
     hangMethods: new Set(),
     pushUpdates(updates) {
@@ -63,7 +65,7 @@ function createFakeApi(opts: { getMeError?: Error } = {}): FakeApi {
       if (api.hangMethods.has(method)) return new Promise(() => undefined) as never;
       if (method === 'getMe') {
         if (opts.getMeError) throw opts.getMeError;
-        return BOT as never;
+        return api.bot as never;
       }
       if (method === 'getUpdates') {
         if (nextFailure) {
@@ -503,6 +505,45 @@ describe('TelegramIM', () => {
     expect(handler).toHaveBeenCalledOnce();
   });
 
+  it('同一 bot 轮换 token 后保留近期 callback 去重状态', async () => {
+    await connect();
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    const callback = encodeCallbackData('permission:allow:once', {
+      requestId: 'token-rotation-request',
+    });
+    api.pushUpdates([
+      {
+        update_id: 908,
+        callback_query: {
+          id: 'token-rotation-first',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 908, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+
+    await connectWithToken('999:rotated-token-abcdefghijk');
+    api.pushUpdates([
+      {
+        update_id: 909,
+        callback_query: {
+          id: 'token-rotation-duplicate',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 908, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => {
+      expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+    });
+    expect(handler).toHaveBeenCalledOnce();
+  });
+
   it('切换 bot 账号后清除旧账号 callback 去重状态', async () => {
     await connect();
     const handler = vi.fn();
@@ -523,6 +564,7 @@ describe('TelegramIM', () => {
     ]);
     await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
 
+    api.bot = { ...BOT, id: 888, username: 'replacement_bot' };
     await connectWithToken('888:replacement-token-abcdefghijk');
     api.pushUpdates([
       {

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -329,6 +329,24 @@ describe('TelegramIM', () => {
     });
   });
 
+  it('Markdown 卡片收口也通过 editMessageText 显式清空旧键盘', async () => {
+    await connect();
+    const sent = await im.sendInteractiveCard(OWNER_ID, {
+      body: '继续吗？',
+      buttons: [{ id: 'control:pick', label: '继续', payload: { requestId: 'markdown-clear' } }],
+    });
+    api.calls.length = 0;
+
+    await im.patchMarkdownCard(sent.messageId, '已完成');
+
+    expect(api.calls).toContainEqual({
+      method: 'editMessageText',
+      params: expect.objectContaining({
+        reply_markup: { inline_keyboard: [] },
+      }),
+    });
+  });
+
   it('同一 interaction 的重复 callback 只派发一次', async () => {
     await connect();
     const handler = vi.fn();
@@ -426,6 +444,41 @@ describe('TelegramIM', () => {
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
   });
 
+  it('没有挂载 card handler 时不应把 callback 记为已处理', async () => {
+    await connect();
+    const callback = encodeCallbackData('control:back', { requestId: 'late-handler' });
+    api.pushUpdates([
+      {
+        update_id: 911,
+        callback_query: {
+          id: 'late-handler-first',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 911, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+    await vi.waitFor(() =>
+      expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(1),
+    );
+
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    api.pushUpdates([
+      {
+        update_id: 912,
+        callback_query: {
+          id: 'late-handler-retry',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: callback,
+          message: { message_id: 911, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+  });
+
   it('权限确认卡的取消 callback 带 requestId 时收口失败可重试', async () => {
     await connect();
     const handler = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(undefined);
@@ -453,6 +506,45 @@ describe('TelegramIM', () => {
     pushCallback(910, 'permission-cancel-second');
 
     await vi.waitFor(() => expect(handler).toHaveBeenCalledTimes(2));
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
+  });
+
+  it('Full access 确认与取消共享同一终态去重键', async () => {
+    await connect();
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    const confirm = encodeCallbackData('permmode:confirm-full-access', {
+      requestId: 'permmode-confirm:sess-target',
+      sessionId: 'sess-target',
+      mode: 'bypassPermissions',
+    });
+    const cancel = encodeCallbackData('permmode:cancel-full-access', {
+      requestId: 'permmode-confirm:sess-target',
+      sessionId: 'sess-target',
+    });
+    expect(cancel).not.toBe(confirm);
+    api.pushUpdates([
+      {
+        update_id: 913,
+        callback_query: {
+          id: 'full-access-confirm',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: confirm,
+          message: { message_id: 913, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+      {
+        update_id: 914,
+        callback_query: {
+          id: 'full-access-cancel',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: cancel,
+          message: { message_id: 913, chat: { id: Number(OWNER_ID), type: 'private' }, date: 1 },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
     expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(2);
   });
 

--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -13,12 +13,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IMHost, IMMessageEvent } from '../../types.js';
 import { TelegramApiError, type TelegramApiClient, type TgUpdate } from '../api.js';
 import { TelegramIM, type TelegramGroupWindowEntry } from '../index.js';
+import { encodeCallbackData } from '../codec.js';
 
 const BOT = { id: 999, is_bot: true, first_name: 'Cindy', username: 'my_cindy_bot' };
 const OWNER_ID = '111';
 
 interface FakeApi extends TelegramApiClient {
   calls: Array<{ method: string; params: Record<string, unknown> }>;
+  hangMethods: Set<string>;
   pushUpdates(updates: TgUpdate[]): void;
   failNextGetUpdates(err: Error): void;
 }
@@ -31,6 +33,7 @@ function createFakeApi(opts: { getMeError?: Error } = {}): FakeApi {
 
   const api: FakeApi = {
     calls: [],
+    hangMethods: new Set(),
     pushUpdates(updates) {
       if (waiter) {
         const w = waiter;
@@ -57,6 +60,7 @@ function createFakeApi(opts: { getMeError?: Error } = {}): FakeApi {
     },
     async call(method, params = {}, signal) {
       api.calls.push({ method, params });
+      if (api.hangMethods.has(method)) return new Promise(() => undefined) as never;
       if (method === 'getMe') {
         if (opts.getMeError) throw opts.getMeError;
         return BOT as never;
@@ -204,6 +208,95 @@ describe('TelegramIM', () => {
     });
     const linked = api.calls.find((c) => c.method === 'sendMessage');
     expect(linked?.params.chat_id).toBe(OWNER_ID);
+  });
+
+  it('有效 callback 只应答一次；失效 callback 显示提示并清掉旧键盘', async () => {
+    await connect();
+    api.calls.length = 0;
+    im.onCardAction(() => undefined);
+    const valid = encodeCallbackData('ask:pick', { requestId: 'pending-1' });
+    api.pushUpdates([
+      {
+        update_id: 901,
+        callback_query: {
+          id: 'valid-callback',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: valid,
+          message: {
+            message_id: 901,
+            chat: { id: Number(OWNER_ID), type: 'private' },
+            date: 1,
+          },
+        },
+      },
+    ]);
+    await vi.waitFor(() => {
+      expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(1);
+    });
+    expect(api.calls.find((call) => call.method === 'answerCallbackQuery')?.params).toEqual({
+      callback_query_id: 'valid-callback',
+    });
+
+    api.calls.length = 0;
+    api.pushUpdates([
+      {
+        update_id: 902,
+        callback_query: {
+          id: 'expired-callback',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: 'r:missing-after-restart',
+          message: {
+            message_id: 902,
+            chat: { id: Number(OWNER_ID), type: 'private' },
+            date: 1,
+          },
+        },
+      },
+    ]);
+    await vi.waitFor(() => {
+      expect(api.calls.filter((call) => call.method === 'editMessageReplyMarkup')).toHaveLength(1);
+    });
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toEqual([
+      {
+        method: 'answerCallbackQuery',
+        params: {
+          callback_query_id: 'expired-callback',
+          text: '卡片已过期',
+          show_alert: true,
+        },
+      },
+    ]);
+    expect(api.calls.find((call) => call.method === 'editMessageReplyMarkup')?.params).toEqual({
+      chat_id: Number(OWNER_ID),
+      message_id: 902,
+      reply_markup: { inline_keyboard: [] },
+    });
+  });
+
+  it('callback ACK 长时间未返回时仍立即派发卡片动作', async () => {
+    await connect();
+    api.calls.length = 0;
+    api.hangMethods.add('answerCallbackQuery');
+    const handler = vi.fn();
+    im.onCardAction(handler);
+    api.pushUpdates([
+      {
+        update_id: 903,
+        callback_query: {
+          id: 'slow-ack',
+          from: { id: Number(OWNER_ID), is_bot: false, first_name: 'Owner' },
+          data: encodeCallbackData('permission:allow:once', { requestId: 'pending-2' }),
+          message: {
+            message_id: 903,
+            chat: { id: Number(OWNER_ID), type: 'private' },
+            date: 1,
+          },
+        },
+      },
+    ]);
+
+    await vi.waitFor(() => expect(handler).toHaveBeenCalledOnce());
+    expect(api.calls.filter((call) => call.method === 'answerCallbackQuery')).toHaveLength(1);
   });
 
   it('set-config 失败(401): 状态 error 且凭证回滚', async () => {

--- a/packages/lizi-im/src/telegram/api.ts
+++ b/packages/lizi-im/src/telegram/api.ts
@@ -112,6 +112,10 @@ export interface TgMessageEntity {
   length: number;
 }
 
+export interface TgInlineKeyboardMarkup {
+  inline_keyboard: Array<Array<Record<string, unknown>>>;
+}
+
 export interface TgMessage {
   message_id: number;
   from?: TgUser;
@@ -137,6 +141,8 @@ export interface TgMessage {
   video_note?: { duration?: number };
   new_chat_members?: TgUser[];
   left_chat_member?: TgUser;
+  /** Inline keyboard attached to the message that produced a callback query. */
+  reply_markup?: TgInlineKeyboardMarkup;
 }
 
 export interface TgCallbackQuery {

--- a/packages/lizi-im/src/telegram/components.ts
+++ b/packages/lizi-im/src/telegram/components.ts
@@ -84,6 +84,7 @@ export function parseCallbackQuery(q: TgCallbackQuery): IMCardActionEvent | null
     chatId: String(chat.id),
     messageId: encodeMessageId(String(chat.id), String(q.message.message_id)),
     buttonId: decoded.buttonId,
+    callbackToken: q.data,
     payload: decoded.payload,
     threadTs: undefined,
     scopeKey: undefined,

--- a/packages/lizi-im/src/telegram/components.ts
+++ b/packages/lizi-im/src/telegram/components.ts
@@ -32,7 +32,10 @@ export function buildCardPayload(spec: InteractiveCardSpec): {
   const { html: body } = markdownToTelegramHtml(spec.body);
   const html = capCardText(`${title}${body}`);
 
-  if (spec.buttons.length === 0) return { html, replyMarkup: undefined };
+  // An empty keyboard must be sent explicitly when replacing a card. Omitting
+  // reply_markup only changes the text and leaves Telegram's old keyboard in
+  // place, so an expired/resolved card would still be clickable.
+  if (spec.buttons.length === 0) return { html, replyMarkup: { inline_keyboard: [] } };
 
   const rows: TelegramInlineKeyboardButton[][] = [];
   let pendingPair: TelegramInlineKeyboardButton | null = null;

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -122,7 +122,14 @@ const DEFAULT_OWNER_NOTICES = {
 
 type OwnerNoticePhase = keyof typeof DEFAULT_OWNER_NOTICES;
 type MessageHandler = (e: IMMessageEvent) => void;
-type CardActionHandler = (e: IMCardActionEvent) => void;
+/**
+ * Card handlers may return false when the action's visible card could not be
+ * updated and Telegram should allow the rendered callback to be retried.
+ * `undefined` keeps the legacy fire-and-forget success contract.
+ */
+type CardActionHandler = (
+  e: IMCardActionEvent,
+) => void | boolean | PromiseLike<void | boolean>;
 type StatusHandler = (s: IMStatus) => void;
 type GroupWindowHandler = (entry: TelegramGroupWindowEntry) => void;
 
@@ -1400,7 +1407,9 @@ export class TelegramIM extends BaseIM implements ChannelIM {
             Promise.resolve().then(() => handler(event)),
           ),
         );
-        const succeeded = results.every((result) => result.status === 'fulfilled');
+        const succeeded = results.every(
+          (result) => result.status === 'fulfilled' && result.value !== false,
+        );
         if (succeeded) {
           if (this.inFlightInteractionCallbacks.get(callbackKey)?.epoch !== dedupEpoch) return;
           this.inFlightInteractionCallbacks.delete(callbackKey);
@@ -1411,8 +1420,10 @@ export class TelegramIM extends BaseIM implements ChannelIM {
             this.handledInteractionCallbacks.delete(oldest);
           }
         } else {
-          // A transient handler failure must not make the rendered button
-          // permanently unresponsive; a later Telegram retry may try again.
+          // A transient handler failure, including an explicit retryable false
+          // result after a card-edit failure, must not make the rendered
+          // button permanently unresponsive; a later Telegram retry may try
+          // again.
           if (this.inFlightInteractionCallbacks.get(callbackKey)?.epoch === dedupEpoch) {
             this.inFlightInteractionCallbacks.delete(callbackKey);
           }

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -92,6 +92,21 @@ const TYPING_LOOP_MAX_MS = 5 * 60_000;
 const SECRET_WRITE_FAILED_REASON = '无法安全保存凭证(系统安全存储不可用)';
 const DEFAULT_EXPIRED_CARD_NOTICE = '卡片已过期';
 
+/**
+ * These buttons make a single decision for one pending interaction. Their
+ * individual callback tokens must share a deduplication key: a fast
+ * allow/deny (or two ask options) click must not dispatch two decisions for
+ * the same request. Navigation and direct-command cards are intentionally
+ * excluded because they can be rendered again with the same requestId.
+ */
+function isTerminalInteractionButton(buttonId: string): boolean {
+  return (
+    buttonId.startsWith('permission:') ||
+    buttonId.startsWith('plan:') ||
+    buttonId.startsWith('ask:')
+  );
+}
+
 /** 非 owner 显式召唤(私聊/群 @/reply)的礼貌回应 — per-user 冷却防刷屏。 */
 const STRANGER_NOTICE_COOLDOWN_MS = 60_000;
 const DEFAULT_STRANGER_NOTICE =
@@ -1338,11 +1353,13 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       for (const [key, at] of this.handledInteractionCallbacks) {
         if (now - at > 5 * 60_000) this.handledInteractionCallbacks.delete(key);
       }
-      // requestId identifies the underlying interaction, not this rendered
-      // button instance: /ctr can rebuild the same message with the same
-      // requestId while presenting a new callback token. Telegram retries of
-      // one button keep q.data unchanged, so the raw token is the dedup key.
-      const callbackKey = `${event.messageId}|${q.data}`;
+      // Terminal decision buttons share one requestId, so different choices
+      // (e.g. allow + deny) cannot race and overwrite the first resolution.
+      // Navigation/direct-command cards may reuse requestId when the message
+      // is rebuilt, so those remain scoped to the rendered callback token.
+      const callbackKey = isTerminalInteractionButton(event.buttonId)
+        ? `${event.messageId}|request:${requestId}`
+        : `${event.messageId}|token:${q.data}`;
       if (this.handledInteractionCallbacks.has(callbackKey)) return;
       this.handledInteractionCallbacks.set(callbackKey, now);
       while (this.handledInteractionCallbacks.size > 512) {

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -302,6 +302,8 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   private readonly ambientTriggerIds = new Set<string>();
   /** Recent rendered callback tokens already handed to desktop; suppress duplicate taps. */
   private readonly handledInteractionCallbacks = new Map<string, number>();
+  /** Callback keys whose async card handlers have not settled yet. */
+  private readonly inFlightInteractionCallbacks = new Map<string, { at: number; epoch: number }>();
   /** 进行中的 typing 续命循环(`chatId:threadId` → 状态)。 */
   private readonly typingLoops = new Map<
     string,
@@ -309,8 +311,12 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   >();
 
   /** Callback dedup survives polling restarts, but not a bot/owner boundary. */
+  private interactionCallbackDedupEpoch = 0;
+
   private clearInteractionCallbackDedup(): void {
+    this.interactionCallbackDedupEpoch += 1;
     this.handledInteractionCallbacks.clear();
+    this.inFlightInteractionCallbacks.clear();
   }
 
   constructor(
@@ -1365,6 +1371,9 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       for (const [key, at] of this.handledInteractionCallbacks) {
         if (now - at > 5 * 60_000) this.handledInteractionCallbacks.delete(key);
       }
+      for (const [key, entry] of this.inFlightInteractionCallbacks) {
+        if (now - entry.at > 5 * 60_000) this.inFlightInteractionCallbacks.delete(key);
+      }
       // Terminal decision buttons share one requestId, so different choices
       // (e.g. allow + deny) cannot race and overwrite the first resolution.
       // Navigation/direct-command cards may reuse requestId when the message
@@ -1372,17 +1381,49 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       const callbackKey = isTerminalInteractionButton(event.buttonId)
         ? `${event.messageId}|request:${requestId}`
         : `${event.messageId}|token:${q.data}`;
-      if (this.handledInteractionCallbacks.has(callbackKey)) return;
-      this.handledInteractionCallbacks.set(callbackKey, now);
-      while (this.handledInteractionCallbacks.size > 512) {
-        const oldest = this.handledInteractionCallbacks.keys().next().value;
-        if (oldest === undefined) break;
-        this.handledInteractionCallbacks.delete(oldest);
+      if (
+        this.handledInteractionCallbacks.has(callbackKey) ||
+        this.inFlightInteractionCallbacks.has(callbackKey)
+      ) {
+        return;
       }
+      const dedupEpoch = this.interactionCallbackDedupEpoch;
+      this.inFlightInteractionCallbacks.set(callbackKey, { at: now, epoch: dedupEpoch });
+      while (this.inFlightInteractionCallbacks.size > 512) {
+        const oldest = this.inFlightInteractionCallbacks.keys().next().value;
+        if (oldest === undefined) break;
+        this.inFlightInteractionCallbacks.delete(oldest);
+      }
+      const dispatch = async (): Promise<void> => {
+        const results = await Promise.allSettled(
+          [...this.cardActionHandlers].map((handler) =>
+            Promise.resolve().then(() => handler(event)),
+          ),
+        );
+        const succeeded = results.every((result) => result.status === 'fulfilled');
+        if (succeeded) {
+          if (this.inFlightInteractionCallbacks.get(callbackKey)?.epoch !== dedupEpoch) return;
+          this.inFlightInteractionCallbacks.delete(callbackKey);
+          this.handledInteractionCallbacks.set(callbackKey, Date.now());
+          while (this.handledInteractionCallbacks.size > 512) {
+            const oldest = this.handledInteractionCallbacks.keys().next().value;
+            if (oldest === undefined) break;
+            this.handledInteractionCallbacks.delete(oldest);
+          }
+        } else {
+          // A transient handler failure must not make the rendered button
+          // permanently unresponsive; a later Telegram retry may try again.
+          if (this.inFlightInteractionCallbacks.get(callbackKey)?.epoch === dedupEpoch) {
+            this.inFlightInteractionCallbacks.delete(callbackKey);
+          }
+        }
+      };
+      void dispatch();
+      return;
     }
     for (const h of this.cardActionHandlers) {
       try {
-        void Promise.resolve(h(event)).catch(() => undefined);
+        void Promise.resolve().then(() => h(event)).catch(() => undefined);
       } catch {
         /* swallow */
       }

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -308,6 +308,11 @@ export class TelegramIM extends BaseIM implements ChannelIM {
     { timer: ReturnType<typeof setInterval>; startedAt: number }
   >();
 
+  /** Callback dedup survives polling restarts, but not a bot/owner boundary. */
+  private clearInteractionCallbackDedup(): void {
+    this.handledInteractionCallbacks.clear();
+  }
+
   constructor(
     host: IMHost,
     private readonly opts: TelegramIMOptions = {},
@@ -500,6 +505,8 @@ export class TelegramIM extends BaseIM implements ChannelIM {
 
       const nextOwnerUserId = ownerUserId || this.ownerUserId;
       if (token) {
+        const accountChanged =
+          token !== (previousToken?.trim() ?? '') || nextOwnerUserId !== this.ownerUserId;
         this.configVersion += 1;
         await this.stopPolling();
         this.ownerUserId = nextOwnerUserId;
@@ -533,6 +540,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
           }
           return configResult(failedStatus);
         }
+        if (accountChanged) this.clearInteractionCallbackDedup();
         const noticeConfigVersion = this.configVersion;
         await this.sendOwnerNoticeWithTimeout(
           nextOwnerUserId,
@@ -543,6 +551,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       } else if (nextOwnerUserId !== this.ownerUserId) {
         this.configVersion += 1;
         this.ownerUserId = nextOwnerUserId;
+        this.clearInteractionCallbackDedup();
       }
       return configResult();
     });
@@ -614,6 +623,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       // offline, 表现为"填了 token 却不工作"。
       this.host.secrets.remove(OFFLINE_SECRET_KEY);
       await this.stopPolling();
+      this.clearInteractionCallbackDedup();
       this.setStatus({ kind: 'idle' });
       return { status: this.status };
     });
@@ -1062,7 +1072,9 @@ export class TelegramIM extends BaseIM implements ChannelIM {
 
   private async stopPolling(): Promise<void> {
     this.clearPendingAlbums();
-    this.handledInteractionCallbacks.clear();
+    // Polling can restart for the same bot after a transient offline/reconnect
+    // cycle. Keep recent callback keys so Telegram retries cannot redispatch a
+    // decision that was already consumed before the polling restart.
     this.pollAbort?.abort();
     this.pollAbort = null;
     if (this.pollLoop) {

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -103,7 +103,9 @@ function isTerminalInteractionButton(buttonId: string): boolean {
   return (
     buttonId.startsWith('permission:') ||
     buttonId.startsWith('plan:') ||
-    buttonId.startsWith('ask:')
+    buttonId.startsWith('ask:') ||
+    buttonId === 'permmode:confirm-full-access' ||
+    buttonId === 'permmode:cancel-full-access'
   );
 }
 
@@ -775,7 +777,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   async patchMarkdownCard(messageId: string, markdown: string): Promise<void> {
     const { chatId, messageId: nativeId } = decodeMessageId(messageId);
     const { html } = markdownToTelegramHtml(markdown);
-    await this.editHtml(chatId, nativeId, html, undefined);
+    await this.editHtml(chatId, nativeId, html, { inline_keyboard: [] });
   }
 
   async startStreamingText(userId: string, initial?: string): Promise<StreamingTextHandle> {
@@ -1414,7 +1416,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
             Promise.resolve().then(() => handler(event)),
           ),
         );
-        const succeeded = results.every(
+        const succeeded = results.length > 0 && results.every(
           (result) => result.status === 'fulfilled' && result.value !== false,
         );
         if (succeeded) {

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -285,6 +285,8 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   private readonly strangerNoticeAt = new Map<string, number>();
   /** ambient 触发的原生 messageId(`chatId|msgId`) — 表情回应抑制名单(FIFO 512)。 */
   private readonly ambientTriggerIds = new Set<string>();
+  /** Recent interaction callbacks already handed to desktop; suppress duplicate taps. */
+  private readonly handledInteractionCallbacks = new Map<string, number>();
   /** 进行中的 typing 续命循环(`chatId:threadId` → 状态)。 */
   private readonly typingLoops = new Map<
     string,
@@ -1045,6 +1047,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
 
   private async stopPolling(): Promise<void> {
     this.clearPendingAlbums();
+    this.handledInteractionCallbacks.clear();
     this.pollAbort?.abort();
     this.pollAbort = null;
     if (this.pollLoop) {
@@ -1329,9 +1332,24 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       return;
     }
     void answer({ callback_query_id: q.id });
+    const requestId = typeof event.payload.requestId === 'string' ? event.payload.requestId : '';
+    if (requestId) {
+      const now = Date.now();
+      for (const [key, at] of this.handledInteractionCallbacks) {
+        if (now - at > 5 * 60_000) this.handledInteractionCallbacks.delete(key);
+      }
+      const callbackKey = `${event.messageId}|${requestId}`;
+      if (this.handledInteractionCallbacks.has(callbackKey)) return;
+      this.handledInteractionCallbacks.set(callbackKey, now);
+      while (this.handledInteractionCallbacks.size > 512) {
+        const oldest = this.handledInteractionCallbacks.keys().next().value;
+        if (oldest === undefined) break;
+        this.handledInteractionCallbacks.delete(oldest);
+      }
+    }
     for (const h of this.cardActionHandlers) {
       try {
-        h(event);
+        void Promise.resolve(h(event)).catch(() => undefined);
       } catch {
         /* swallow */
       }
@@ -1656,6 +1674,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
           message_id: Number(nativeMessageId),
           text: stripTelegramHtmlTags(html) || '…',
           link_preview_options: { is_disabled: true },
+          ...(replyMarkup !== undefined ? { reply_markup: replyMarkup } : {}),
         }).catch((fallbackErr) => {
           if (fallbackErr instanceof TelegramApiError && /not modified/i.test(fallbackErr.message)) {
             return;

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -501,6 +501,11 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       const previousOwnerUserId =
         previousOwnerResult.kind === 'value' ? previousOwnerResult.value : null;
       const previousRuntimeOwnerUserId = this.ownerUserId;
+      // Callback deduplication follows the bot identity, not the secret string.
+      // BotFather can rotate a token without changing the bot that owns already
+      // queued callbacks. Keep the connected identity when available; the token
+      // prefix is the only safe fallback while this instance is offline.
+      const previousBotId = this.botId || botIdFromToken(previousToken?.trim() ?? '');
 
       const tokenSaved = token ? this.host.secrets.write(TOKEN_SECRET_KEY, token) : true;
       const ownerSaved = ownerUserId
@@ -518,8 +523,6 @@ export class TelegramIM extends BaseIM implements ChannelIM {
 
       const nextOwnerUserId = ownerUserId || this.ownerUserId;
       if (token) {
-        const accountChanged =
-          token !== (previousToken?.trim() ?? '') || nextOwnerUserId !== this.ownerUserId;
         this.configVersion += 1;
         await this.stopPolling();
         this.ownerUserId = nextOwnerUserId;
@@ -553,6 +556,10 @@ export class TelegramIM extends BaseIM implements ChannelIM {
           }
           return configResult(failedStatus);
         }
+        const botChanged = previousBotId !== 0
+          ? this.botId !== previousBotId
+          : (previousToken?.trim() ?? '') !== token;
+        const accountChanged = botChanged || nextOwnerUserId !== previousRuntimeOwnerUserId;
         if (accountChanged) this.clearInteractionCallbackDedup();
         const noticeConfigVersion = this.configVersion;
         await this.sendOwnerNoticeWithTimeout(

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -285,7 +285,7 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   private readonly strangerNoticeAt = new Map<string, number>();
   /** ambient 触发的原生 messageId(`chatId|msgId`) — 表情回应抑制名单(FIFO 512)。 */
   private readonly ambientTriggerIds = new Set<string>();
-  /** Recent interaction callbacks already handed to desktop; suppress duplicate taps. */
+  /** Recent rendered callback tokens already handed to desktop; suppress duplicate taps. */
   private readonly handledInteractionCallbacks = new Map<string, number>();
   /** 进行中的 typing 续命循环(`chatId:threadId` → 状态)。 */
   private readonly typingLoops = new Map<
@@ -1338,7 +1338,11 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       for (const [key, at] of this.handledInteractionCallbacks) {
         if (now - at > 5 * 60_000) this.handledInteractionCallbacks.delete(key);
       }
-      const callbackKey = `${event.messageId}|${requestId}`;
+      // requestId identifies the underlying interaction, not this rendered
+      // button instance: /ctr can rebuild the same message with the same
+      // requestId while presenting a new callback token. Telegram retries of
+      // one button keep q.data unchanged, so the raw token is the dedup key.
+      const callbackKey = `${event.messageId}|${q.data}`;
       if (this.handledInteractionCallbacks.has(callbackKey)) return;
       this.handledInteractionCallbacks.set(callbackKey, now);
       while (this.handledInteractionCallbacks.size > 512) {

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -1436,6 +1436,23 @@ export class TelegramIM extends BaseIM implements ChannelIM {
           if (this.inFlightInteractionCallbacks.get(callbackKey)?.epoch === dedupEpoch) {
             this.inFlightInteractionCallbacks.delete(callbackKey);
           }
+          // The card handler may have ACKed the callback and then failed while
+          // editing the card. Telegram will not replay an already-answered
+          // callback on its own, so restore the keyboard captured on the
+          // callback query as the retry entry. The loading edit is allowed to
+          // clear it; this puts the original controls back only on a genuine
+          // retryable failure.
+          const message = q.message;
+          const replyMarkup = message?.reply_markup;
+          if (message && replyMarkup !== undefined) {
+            void api
+              .call('editMessageReplyMarkup', {
+                chat_id: message.chat.id,
+                message_id: message.message_id,
+                reply_markup: replyMarkup,
+              })
+              .catch(() => undefined);
+          }
         }
       };
       void dispatch();

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -1307,17 +1307,28 @@ export class TelegramIM extends BaseIM implements ChannelIM {
   private async handleCallbackQuery(q: import('./api.js').TgCallbackQuery): Promise<void> {
     const api = this.api;
     if (!api) return;
-    // 无论结果如何都先应答, 消掉客户端 loading 态。
-    void api.call('answerCallbackQuery', { callback_query_id: q.id }).catch(() => undefined);
-    if (String(q.from.id) !== this.ownerUserId) return;
+    const answer = (params: Record<string, unknown>) =>
+      api.call('answerCallbackQuery', params).catch(() => undefined);
+    if (String(q.from.id) !== this.ownerUserId) {
+      void answer({ callback_query_id: q.id });
+      return;
+    }
     const event = parseCallbackQuery(q);
     if (!event) {
       const notice = this.opts.expiredCardNotice ?? DEFAULT_EXPIRED_CARD_NOTICE;
-      void api
-        .call('answerCallbackQuery', { callback_query_id: q.id, text: notice, show_alert: true })
-        .catch(() => undefined);
+      void answer({ callback_query_id: q.id, text: notice, show_alert: true });
+      if (q.message !== undefined) {
+        void api
+          .call('editMessageReplyMarkup', {
+            chat_id: q.message.chat.id,
+            message_id: q.message.message_id,
+            reply_markup: { inline_keyboard: [] },
+          })
+          .catch(() => undefined);
+      }
       return;
     }
+    void answer({ callback_query_id: q.id });
     for (const h of this.cardActionHandlers) {
       try {
         h(event);

--- a/packages/lizi-im/src/types.ts
+++ b/packages/lizi-im/src/types.ts
@@ -235,6 +235,8 @@ export interface IMCardActionEvent {
   messageId: string;
   /** The button id business code put into `button.value.id`. */
   buttonId: string;
+  /** Rendered callback token, when the channel exposes one (Telegram callback_data). */
+  callbackToken?: string;
   /** Remaining fields of the button's value JSON (business-defined payload). */
   payload: Record<string, unknown>;
   /** 卡片所在 thread root ts(卡片在 thread 内时有值)。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复个人 Telegram bot 的交互卡在 callback 失效或 pending interaction 丢失时显示“无效”但按钮仍留在原消息上的问题。有效 callback 只应答一次；失效 callback 会显示过期提示并清空旧键盘；桌面共享卡处理在 pending 丢失时也会把 Telegram 卡收口为过期状态。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 回归测试

### 范围

- 关联 Issue / 需求：用户报告；暂无关联 Issue。
- 本 PR 包含：个人 Telegram Bot API callback 反馈、Telegram 适配器过期卡文案注入、共享交互卡 pending 丢失收口及回归测试。
- 明确不包含：官方中继 Telegram bot；官方 bot 由配套 server PR 单独修复。
- 用户可见变化：点击有效按钮不会重复弹 callback 响应；重启、过期或重复点击时会提示“卡片已过期”并移除旧按钮。
- 是否存在 breaking change：无。

### UI 变化

不涉及桌面 UI 布局、样式或主题；仅涉及 Telegram Bot API 卡片状态和已有过期文案的反馈。

- 引用的设计规范：不涉及桌面 UI。

## 怎么验证的

### 自动验证

```text
env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_SESSION_ID pnpm test:unit
结果：PASS；desktop unit、mobile unit、全部 required unit workspace 通过。

pnpm --filter @cindy/im run build
结果：PASS；TypeScript 无错误。

pnpm --filter desktop typecheck
结果：PASS；TypeScript 无错误。

pnpm --filter @cindy/im test
结果：PASS 31 个测试文件、365 个测试通过。

pnpm --filter desktop exec vitest run src/main/im/shared/__tests__/cardActionTakeoverReplace.test.ts
结果：PASS 26/26。
```

### 手工验证

不涉及；本次验证使用注入的 Telegram API fake client 覆盖有效/失效 callback 与键盘清理。

### 未执行的验证

无真实 Telegram 账号端到端验证；需要正式版账号和 BotFather token，不能在 PR 环境使用真实凭证。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 影响范围：个人 Telegram bot 的交互卡 callback 处理；其他渠道未设置过期提示注入，保持原行为。
- 回滚 / 降级方式：回退本 PR commit；清键盘失败为 best-effort，不会阻止 callback 处理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
