### PR TITLE
fix(plugin-market): 修复权限差异导致的批量更新卡住

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/marketPackagePermissionReview.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketPackagePermissionReview.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GhostManifest } from '../../../shared/ghost.js';
+import {
+  assertMarketPackagePermissionsReviewed,
+  MarketPackagePermissionReviewRequiredError,
+} from '../marketPackagePermissionReview.js';
+
+function manifest(toolNames: string[]): GhostManifest {
+  return {
+    schemaVersion: 2,
+    id: 'test-plugin',
+    name: 'Test Plugin',
+    version: '2.0.0',
+    kind: 'chip',
+    entry: 'main.js',
+    slots: toolNames.length > 0 ? ['tool'] : [],
+    ...(toolNames.length > 0
+      ? {
+          tools: toolNames.map((name) => ({
+            name,
+            description: `${name} description`,
+          })),
+        }
+      : {}),
+  };
+}
+
+describe('assertMarketPackagePermissionsReviewed', () => {
+  it('throws an error carrying the real package manifest when metadata omitted a new permission', () => {
+    const packageManifest = manifest(['existing_tool', 'new_tool']);
+
+    expect(() =>
+      assertMarketPackagePermissionsReviewed({
+        reviewedManifest: manifest([]),
+        packageManifest,
+        installedManifest: manifest(['existing_tool']),
+      }),
+    ).toThrow(MarketPackagePermissionReviewRequiredError);
+
+    try {
+      assertMarketPackagePermissionsReviewed({
+        reviewedManifest: manifest([]),
+        packageManifest,
+        installedManifest: manifest(['existing_tool']),
+      });
+    } catch (error) {
+      expect(error).toMatchObject({
+        manifest: packageManifest,
+        unreviewedPermissionKeys: ['tool:existing_tool', 'tool:new_tool'],
+      });
+    }
+  });
+
+  it('allows an update when the omitted package permissions were already installed', () => {
+    expect(() =>
+      assertMarketPackagePermissionsReviewed({
+        reviewedManifest: manifest([]),
+        packageManifest: manifest(['existing_tool']),
+        installedManifest: manifest(['existing_tool']),
+      }),
+    ).not.toThrow();
+  });
+
+  it('requires the real package manifest to be reviewed for a first install', () => {
+    expect(() =>
+      assertMarketPackagePermissionsReviewed({
+        reviewedManifest: manifest([]),
+        packageManifest: manifest(['new_tool']),
+        installedManifest: null,
+      }),
+    ).toThrow(MarketPackagePermissionReviewRequiredError);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -13,7 +13,6 @@ import {
   GHOST_CARD_HEIGHT_MIN,
   GHOST_NETWORK_MAX_CONNECTIONS_PER_DECL,
   GHOST_NOTIFY_MIN_INTERVAL_MS,
-  diffGhostPermissionItems,
   ghostWebviewEntryPaths,
   isCindyAccountGhostId,
   isOfficialGhostId,
@@ -38,6 +37,10 @@ import {
 } from '../appSessionState.js';
 import { getLayoutStore } from '../layout/index.js';
 import { GhostManager, type InstallRejection, type UninstallRejection } from './GhostManager.js';
+import {
+  assertMarketPackagePermissionsReviewed,
+  isMarketPackagePermissionReviewRequiredError,
+} from './marketPackagePermissionReview.js';
 import { exportGhostPackage } from './exportGhostPackage.js';
 import { GhostMutationCoordinator } from './ghostMutationCoordinator.js';
 import { withGhostInstallLock } from './ghostInstallLock.js';
@@ -3167,7 +3170,8 @@ export async function installOrUpdateMarketGhostPackage(
     version: string;
     /**
      * 装入确认框实际展示给用户的那份 manifest(来源方给的)。给了就逐项比对:
-     * 包里多出来的权限一律拒装(见 Locked 版里的说明)。两条市场路径都必须给;
+     * 包里多出来且会扩张当前权限面的条目必须重新审阅(见 Locked 版里的说明)。
+     * 两条市场路径都必须给;
      * 本地 `.cindy` 装入不经此出口,确认框读的就是包本身,没有这层漂移。
      */
     reviewedManifest?: GhostManifest;
@@ -3215,29 +3219,29 @@ async function installOrUpdateMarketGhostPackageLocked(
      * 未知槽名,投影时会被丢掉或整份拒绝。结果:确认框漏列该项权限,包却原样带着
      * 它装进来,用户**从没审过就多出一个常驻能力面**。
      *
-     * 这里按权限项逐项比对,包里多出来的一律拒装——不是只挡 badge,是把这一整类
-     * 「来源投影漏字段」的洞一次封死。落在 inspect 之后、任何落地动作之前,所以
-     * 拒绝时磁盘上什么都没动,不需要回滚。
+     * 这里按权限项逐项比对。包里多出且相对已装版本确属扩权的条目，返回真实
+     * manifest 交给 Renderer 重新审阅；若只是来源投影漏掉了用户早已持有的权限，
+     * 则不重复打扰。不是只挡 badge，而是把这一整类「来源投影漏字段」的洞一次
+     * 封死。检查落在 inspect 之后、任何落地动作之前，需审阅时磁盘上什么都没动。
      */
+    const installed = manager.list().find((ghost) => ghost.manifest.id === expected.ghostId);
     if (expected.reviewedManifest) {
-      const unreviewed = diffGhostPermissionItems(
-        expected.reviewedManifest,
-        inspected.manifest,
-      ).added;
-      if (unreviewed.length > 0) {
+      try {
+        assertMarketPackagePermissionsReviewed({
+          reviewedManifest: expected.reviewedManifest,
+          packageManifest: inspected.manifest,
+          installedManifest: installed?.manifest ?? null,
+        });
+      } catch (error) {
+        if (!isMarketPackagePermissionReviewRequiredError(error)) throw error;
         log.warn('market package declares unreviewed permissions', {
           ghostId: expected.ghostId,
-          keys: unreviewed.map((item) => item.key),
+          keys: error.unreviewedPermissionKeys,
         });
-        throwIpcError(
-          'PRECONDITION_FAILED',
-          '下载包申请的权限多于安装确认框展示的内容,已阻止安装(请向插件来源反馈)',
-        );
+        throw error;
       }
     }
     rejectUnauthorizedTokenBroker(inspected.manifest);
-
-    const installed = manager.list().find((ghost) => ghost.manifest.id === expected.ghostId);
     // Node 高风险条目由 renderer 装入确认卡权限清单如实展示;
     // 2026-07-24 Lizi 定案:不再有 Main 侧原生二次确认弹窗(PR #333,本处为其
     // 漏删的市场安装路径调用点,一并对齐)。

--- a/apps/desktop/src/main/cindy-brain/marketPackagePermissionReview.ts
+++ b/apps/desktop/src/main/cindy-brain/marketPackagePermissionReview.ts
@@ -1,0 +1,54 @@
+/**
+ * Bridges a marketplace metadata/package permission mismatch without weakening
+ * the install boundary.
+ *
+ * The marketplace detail manifest is what Renderer displayed. The downloaded
+ * package manifest is what would actually run. When the package contains
+ * permissions that were not displayed, updates may continue only if those
+ * permissions are already present in the installed plugin; otherwise Renderer
+ * must explicitly review the real package manifest first.
+ */
+
+import { diffGhostPermissionItems, type GhostManifest } from '../../shared/ghost.js';
+
+export class MarketPackagePermissionReviewRequiredError extends Error {
+  readonly manifest: GhostManifest;
+  readonly unreviewedPermissionKeys: string[];
+
+  constructor(manifest: GhostManifest, unreviewedPermissionKeys: string[]) {
+    super('Downloaded Plugin package permissions require review');
+    this.name = 'MarketPackagePermissionReviewRequiredError';
+    this.manifest = manifest;
+    this.unreviewedPermissionKeys = unreviewedPermissionKeys;
+  }
+}
+
+export function assertMarketPackagePermissionsReviewed(input: {
+  reviewedManifest: GhostManifest;
+  packageManifest: GhostManifest;
+  installedManifest: GhostManifest | null;
+}): void {
+  const unreviewed = diffGhostPermissionItems(input.reviewedManifest, input.packageManifest).added;
+  if (unreviewed.length === 0) return;
+
+  // A metadata projection may omit permissions that the installed version
+  // already has. That mismatch is worth logging, but it is not an expansion
+  // and therefore needs no additional user approval.
+  if (
+    input.installedManifest &&
+    diffGhostPermissionItems(input.installedManifest, input.packageManifest).added.length === 0
+  ) {
+    return;
+  }
+
+  throw new MarketPackagePermissionReviewRequiredError(
+    input.packageManifest,
+    unreviewed.map((item) => item.key),
+  );
+}
+
+export function isMarketPackagePermissionReviewRequiredError(
+  error: unknown,
+): error is MarketPackagePermissionReviewRequiredError {
+  return error instanceof MarketPackagePermissionReviewRequiredError;
+}

--- a/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
@@ -412,6 +412,8 @@ describe('PluginMarketService 自定义市场 detail/install', () => {
       expectedReleaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
       expectedManifest: reviewed.manifest,
     });
+    expect(result.status).toBe('installed');
+    if (result.status !== 'installed') throw new Error('expected installed result');
     expect(result.ghost.manifest.id).toBe('alpha');
     expect(runtime.install).toHaveBeenCalledTimes(1);
     // 打包产物是临时文件，装完即删

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -60,6 +60,7 @@ vi.mock('../download.js', () => ({
 import type { VisiblePluginDetail, VisiblePluginSummary } from '@cindy/plugin-protocol';
 
 import { withGhostInstallLock } from '../../cindy-brain/ghostInstallLock';
+import { MarketPackagePermissionReviewRequiredError } from '../../cindy-brain/marketPackagePermissionReview';
 import { PluginMarketLedger } from '../ledger';
 import { PluginMarketService } from '../service';
 import type { PluginMarketApi } from '../api';
@@ -412,7 +413,11 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
     const h = harness([item]);
 
-    const { ghost } = await h.service.install(item.id, { expectedReleaseId: item.currentRelease.id });
+    const result = await h.service.install(item.id, {
+      expectedReleaseId: item.currentRelease.id,
+    });
+    expect(result.status).toBe('installed');
+    if (result.status !== 'installed') throw new Error('expected installed result');
 
     expect(runtime.install).toHaveBeenCalledWith(
       expect.stringMatching(/\.cindy$/),
@@ -423,7 +428,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
       },
     );
     // 锁定装完即开的最终结果:装入入口返回的 ghost 必须是启用态。
-    expect(ghost.enabled).toBe(true);
+    expect(result.ghost.enabled).toBe(true);
   });
 
   // 装入确认框渲染的是**服务端给的** manifest,真正落地的是 .cindy 包里的
@@ -448,6 +453,88 @@ describe('PluginMarketService migration and defaultInstall', () => {
       id: item.ghostId,
       version: item.currentRelease.version,
     });
+  });
+
+  it('returns the verified package manifest for review, then installs that reviewed manifest', async () => {
+    const item = summary({
+      currentRelease: {
+        ...summary().currentRelease,
+        id: 'release-2',
+        version: '2.0.0',
+      },
+    });
+    const installedManifest = manifest('cindy-test', '1.0.0', ['notify']);
+    const packageManifest = manifest('cindy-test', '2.0.0', ['notify', 'fs']);
+    runtime.ghosts = [
+      {
+        manifest: installedManifest,
+        dir: '/userData/cindy-brain/cindy-test',
+        enabled: true,
+      },
+    ];
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      ...recordForTest(item),
+      releaseId: 'release-1',
+      version: '1.0.0',
+    });
+    // 市场详情仍只投影 notify；真实下载包新增了 fs。
+    h.api.detail.mockResolvedValue(detail(item, ['notify']));
+    runtime.install.mockRejectedValueOnce(
+      new MarketPackagePermissionReviewRequiredError(packageManifest, ['slot:fs']),
+    );
+
+    await expect(
+      h.service.install(item.id, { expectedReleaseId: item.currentRelease.id }),
+    ).resolves.toEqual({
+      status: 'permission-review-required',
+      manifest: packageManifest,
+    });
+
+    runtime.install.mockResolvedValueOnce({
+      manifest: packageManifest,
+      dir: '/userData/cindy-brain/cindy-test',
+      enabled: true,
+    });
+    await expect(
+      h.service.install(item.id, {
+        expectedReleaseId: item.currentRelease.id,
+        expectedManifest: packageManifest,
+        allowPermissionExpansion: true,
+        reviewedBaseline: ghostPermissionBaselineKey(installedManifest),
+      }),
+    ).resolves.toMatchObject({
+      status: 'installed',
+      ghost: { manifest: packageManifest },
+    });
+    expect(runtime.install).toHaveBeenLastCalledWith(
+      expect.stringMatching(/\.cindy$/),
+      expect.objectContaining({ reviewedManifest: packageManifest }),
+    );
+  });
+
+  it('does not return a permission-review manifest after the active owner changes', async () => {
+    const item = summary({
+      currentRelease: {
+        ...summary().currentRelease,
+        id: 'release-2',
+        version: '2.0.0',
+      },
+    });
+    const packageManifest = manifest('cindy-test', '2.0.0', ['notify', 'fs']);
+    const h = harness([item]);
+    runtime.install.mockImplementationOnce(async () => {
+      runtime.session = {
+        mode: 'cloud',
+        dataOwnerId: 'user-2',
+        generation: 2,
+      };
+      throw new MarketPackagePermissionReviewRequiredError(packageManifest, ['slot:fs']);
+    });
+
+    await expect(
+      h.service.install(item.id, { expectedReleaseId: item.currentRelease.id }),
+    ).rejects.toThrow('[PRECONDITION_FAILED]');
   });
 
   it('installs and enables a public defaultInstall package in local mode', async () => {
@@ -967,6 +1054,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
 
     await expect(h.service.install(item.id, { expectedReleaseId: item.currentRelease.id })).resolves.toEqual({
+      status: 'installed',
       ghost: installedGhost,
     });
     expect(h.ledger.installationForGhost(item.ghostId)).toMatchObject({

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -21,6 +21,7 @@ import type {
   MarketSourceConfig,
   MarketSourceSummary,
   PluginMarketDetail,
+  PluginMarketInstallResult,
   PluginMarketItem,
   PluginMarketSnapshot,
 } from '../../shared/pluginMarket.js';
@@ -52,6 +53,7 @@ import {
   readBoundedFileNoFollowSync,
 } from '../utils/readBoundedFile.js';
 import { withGhostInstallLock } from '../cindy-brain/ghostInstallLock.js';
+import { isMarketPackagePermissionReviewRequiredError } from '../cindy-brain/marketPackagePermissionReview.js';
 import { PluginMarketApi } from './api.js';
 import { downloadVerifiedPlugin } from './download.js';
 import { installCustomMarketPlugin } from './install.js';
@@ -409,7 +411,7 @@ export class PluginMarketService {
       /** Renderer 确认框实际展示过的 release。Main 重拉详情后必须仍一致,
        *  否则用户审阅 A、实际安装/启用 B(review P1)。 */
       expectedReleaseId: string;
-      /** 自定义市场插件：Renderer 确认框实际审阅过的完整 manifest。 */
+      /** Renderer 确认框实际审阅过的完整包 manifest。 */
       expectedManifest?: GhostManifest;
       allowPermissionExpansion?: boolean;
       /**
@@ -421,13 +423,17 @@ export class PluginMarketService {
        */
       reviewedBaseline?: string;
     },
-  ): Promise<{ ghost: InstalledGhost }> {
+  ): Promise<PluginMarketInstallResult> {
     const customRef = parseCustomMarketPluginId(pluginId);
     if (customRef) {
       if (!options.expectedManifest) {
         throwIpcError('INVALID_PARAMS', 'The reviewed Plugin manifest is required');
       }
-      return this.customInstall(customRef, options as typeof options & { expectedManifest: GhostManifest });
+      const result = await this.customInstall(
+        customRef,
+        options as typeof options & { expectedManifest: GhostManifest },
+      );
+      return { status: 'installed', ghost: result.ghost };
     }
     if (!isValidPluginResourceId(pluginId)) {
       throwIpcError('INVALID_PARAMS', 'Invalid Plugin ID');
@@ -456,6 +462,23 @@ export class PluginMarketService {
           'Plugin release changed after permission review',
         );
       }
+      let reviewedPackageManifest: GhostManifest | undefined;
+      if (options.expectedManifest) {
+        const validated = validateGhostManifest(options.expectedManifest);
+        if (!validated.ok) {
+          throwIpcError('GHOST_FILE_INVALID', 'The reviewed Plugin manifest is invalid');
+        }
+        if (
+          validated.manifest.id !== plugin.ghostId ||
+          validated.manifest.version !== plugin.currentRelease.version
+        ) {
+          throwIpcError(
+            'PRECONDITION_FAILED',
+            'The reviewed Plugin manifest does not match the current release',
+          );
+        }
+        reviewedPackageManifest = validated.manifest;
+      }
       const existing = getGhostManager()
         .list()
         .some((ghost) => ghost.manifest.id === plugin.ghostId);
@@ -475,12 +498,15 @@ export class PluginMarketService {
           knownServerPlugins: catalog,
         });
       await assertOwnership();
-      return {
-        ghost: await this.installDetail(
+      try {
+        const ghost = await this.installDetail(
           plugin,
           {
             expectedInstalled: existing,
             allowPermissionExpansion: options.allowPermissionExpansion === true,
+            ...(reviewedPackageManifest
+              ? { reviewedManifest: reviewedPackageManifest }
+              : {}),
             ...(options.reviewedBaseline !== undefined
               ? { reviewedBaseline: options.reviewedBaseline }
               : {}),
@@ -489,8 +515,21 @@ export class PluginMarketService {
           },
           owner,
           ledger,
-        ),
-      };
+        );
+        return { status: 'installed', ghost };
+      } catch (error) {
+        if (isMarketPackagePermissionReviewRequiredError(error)) {
+          // The package manifest came from an owner-bound download. Re-check
+          // before returning it so an account switch during inspect/download
+          // cannot disclose the previous owner's package metadata.
+          requireSameMarketOwner(owner);
+          return {
+            status: 'permission-review-required',
+            manifest: error.manifest,
+          };
+        }
+        throw error;
+      }
     });
   }
 
@@ -1082,6 +1121,8 @@ export class PluginMarketService {
     plugin: VisiblePluginDetail,
     options: {
       allowPermissionExpansion?: boolean;
+      /** Renderer 实际展示过的包 manifest；缺席时沿用市场详情 manifest。 */
+      reviewedManifest?: GhostManifest;
       /** 扩权批准所依据的已装权限指纹;安装锁内复核,详见 install() 的说明。 */
       reviewedBaseline?: string;
       /** 确认操作时的安装意图;下载窗口期目标被另一窗口卸载时拒绝滑入首装。 */
@@ -1111,6 +1152,7 @@ export class PluginMarketService {
     if (!compatible.ok) {
       throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
     }
+    const reviewedManifest = options.reviewedManifest ?? compatible.manifest;
     /**
      * 扩权闸门:按**传入时刻的**已装 manifest 判定。下面调用两次——
      *  1. 锁外一次:快速失败,不为注定被拒的更新白下载几十 MB;
@@ -1121,7 +1163,7 @@ export class PluginMarketService {
      */
     const assertExpansionApproved = (installedNow: GhostManifest | null): void => {
       if (!installedNow) return;
-      if (diffGhostPermissionItems(installedNow, compatible.manifest).added.length === 0) return;
+      if (diffGhostPermissionItems(installedNow, reviewedManifest).added.length === 0) return;
       if (options.allowPermissionExpansion !== true) {
         throwIpcError('PRECONDITION_FAILED', 'Plugin permissions changed and require review');
       }
@@ -1188,10 +1230,10 @@ export class PluginMarketService {
           const installed = await installOrUpdateMarketGhostPackage(tempPath, {
             ghostId: plugin.ghostId,
             version: plugin.currentRelease.version,
-            // 确认框渲染的就是这份服务端 manifest;包里若多出权限项,出口处拒装
-            // ——服务端投影层与客户端清单契约漂移时,用户会在没审过的情况下多拿
-            // 一个能力面(codex review P1)。
-            reviewedManifest: compatible.manifest,
+            // 确认框渲染的就是这份 reviewed manifest；包里若多出会扩张当前
+            // 权限面的条目，出口返回真实包 manifest 重新审阅，绝不让用户在
+            // 没看过的情况下多拿一个能力面(codex review P1)。
+            reviewedManifest,
           });
           // Once the package directory is committed, finish provenance against
           // the owner captured at operation start even if the active session

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1090,7 +1090,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         /** 扩权批准所依据的已装权限指纹;Main 在安装锁内复核后才放行扩权。 */
         reviewedBaseline?: string;
       },
-    ): Promise<{ ghost: import('../shared/ghost').InstalledGhost }> =>
+    ): Promise<import('../shared/pluginMarket').PluginMarketInstallResult> =>
       ipcRenderer.invoke('plugin-market:install', pluginId, options),
     uninstall: (pluginId: string): Promise<{ ok: true }> =>
       ipcRenderer.invoke('plugin-market:uninstall', pluginId),

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -662,6 +662,14 @@ export function GhostPluginPage() {
       // 列表每张卡都有直达入口,同步互斥防止并发更新互相覆盖忙碌状态。
       const marketBusyLease = acquireMarketBusy(marketItem.pluginId);
       if (!marketBusyLease) return;
+      if (!installedGhost) {
+        if (isMarketBusyLeaseActive(marketBusyLease)) {
+          toast.error(t('settings.ghosts.market.errors.stateChanged'));
+        }
+        releaseMarketBusy(marketBusyLease);
+        await refreshMarket();
+        return;
+      }
       try {
         const next = await window.electronAPI.pluginMarket.detail(marketItem.pluginId);
         if (!isMarketBusyLeaseActive(marketBusyLease)) return;
@@ -681,7 +689,7 @@ export function GhostPluginPage() {
           cancelText: t('settings.ghosts.updateConfirm.cancel'),
         });
         if (!approved || !isMarketBusyLeaseActive(marketBusyLease)) return;
-        const result = await window.electronAPI.pluginMarket.install(marketItem.pluginId, {
+        let result = await window.electronAPI.pluginMarket.install(marketItem.pluginId, {
           expectedReleaseId: next.releaseId,
           ...(next.sourceType !== 'server' ? { expectedManifest: next.manifest } : {}),
           allowPermissionExpansion: diff.added.length > 0,
@@ -691,6 +699,43 @@ export function GhostPluginPage() {
             ? { reviewedBaseline: ghostPermissionBaselineKey(installedGhost.manifest) }
             : {}),
         });
+        if (result.status !== 'installed') {
+          const packageDiff = diffGhostPermissionItems(
+            installedGhost?.manifest ?? next.manifest,
+            result.manifest,
+          );
+          if (packageDiff.added.length > 0) {
+            const packageApproved = await confirm({
+              title: t('settings.ghosts.updateConfirm.title', { name: next.name }),
+              description: t('settings.ghosts.updateConfirm.body', {
+                from: installedGhost?.manifest.version ?? next.version,
+                to: next.version,
+              }),
+              content: <GhostUpdateReview diff={packageDiff} />,
+              maxWidth: 520,
+              confirmText: t('settings.ghosts.updateConfirm.confirm'),
+              cancelText: t('settings.ghosts.updateConfirm.cancel'),
+            });
+            if (!packageApproved || !isMarketBusyLeaseActive(marketBusyLease)) return;
+          }
+          result = await window.electronAPI.pluginMarket.install(marketItem.pluginId, {
+            expectedReleaseId: next.releaseId,
+            expectedManifest: result.manifest,
+            ...(packageDiff.added.length > 0
+              ? {
+                  allowPermissionExpansion: true,
+                  ...(installedGhost
+                    ? { reviewedBaseline: ghostPermissionBaselineKey(installedGhost.manifest) }
+                    : {}),
+                }
+              : {}),
+          });
+          if (result.status !== 'installed') {
+            throw new Error(
+              '[PRECONDITION_FAILED] Plugin package permissions require review',
+            );
+          }
+        }
         if (!isMarketBusyLeaseActive(marketBusyLease)) return;
         toast.success(
           t('settings.ghosts.toast.updated', {
@@ -1056,7 +1101,7 @@ export function GhostPluginPage() {
         autoFocusConfirm: true,
       });
       if (!confirmed || !isMarketBusyLeaseActive(marketBusyLease)) return;
-      const result = await window.electronAPI.pluginMarket.install(marketDetail.pluginId, {
+      let result = await window.electronAPI.pluginMarket.install(marketDetail.pluginId, {
         expectedReleaseId: marketDetail.releaseId,
         ...(marketDetail.sourceType !== 'server'
           ? { expectedManifest: marketDetail.manifest }
@@ -1072,6 +1117,53 @@ export function GhostPluginPage() {
             }
           : {}),
       });
+      if (result.status !== 'installed') {
+        const packageDiff = diffGhostPermissionItems(
+          installedGhost?.manifest ?? marketDetail.manifest,
+          result.manifest,
+        );
+        if (packageDiff.added.length > 0) {
+          const packageApproved = await confirm({
+            title: isUpdate
+              ? t('settings.ghosts.updateConfirm.title', { name: marketDetail.name })
+              : t('settings.ghosts.market.installConfirmTitle', {
+                  name: marketDetail.name,
+                }),
+            description: isUpdate
+              ? t('settings.ghosts.market.updateConfirmDescription')
+              : marketDetail.sourceType !== 'server'
+                ? t('settings.ghosts.market.customInstallConfirmDescription')
+                : t('settings.ghosts.market.installConfirmDescription'),
+            content: <GhostUpdateReview diff={packageDiff} />,
+            maxWidth: 520,
+            confirmText: isUpdate
+              ? t('settings.ghosts.updateConfirm.confirm')
+              : t('settings.ghosts.market.install'),
+            cancelText: isUpdate
+              ? t('settings.ghosts.updateConfirm.cancel')
+              : t('settings.ghosts.installConfirm.cancel'),
+            autoFocusConfirm: true,
+          });
+          if (!packageApproved || !isMarketBusyLeaseActive(marketBusyLease)) return;
+        }
+        result = await window.electronAPI.pluginMarket.install(marketDetail.pluginId, {
+          expectedReleaseId: marketDetail.releaseId,
+          expectedManifest: result.manifest,
+          ...(packageDiff.added.length > 0 && isUpdate
+            ? {
+                allowPermissionExpansion: true,
+                ...(installedGhost
+                  ? { reviewedBaseline: ghostPermissionBaselineKey(installedGhost.manifest) }
+                  : {}),
+              }
+            : {}),
+        });
+        if (result.status !== 'installed') {
+          throw new Error(
+            '[PRECONDITION_FAILED] Plugin package permissions require review',
+          );
+        }
+      }
       if (!isMarketBusyLeaseActive(marketBusyLease)) return;
       // 市场首装装完即开(2026-07-26 定案),toast 用"已安装";更新路径如实
       // 用"已更新"(生效状态未被改变)。

--- a/apps/desktop/src/renderer/features/plugin/__tests__/updateAllController.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/updateAllController.test.ts
@@ -65,7 +65,9 @@ function marketItem(overrides: Partial<PluginMarketItem>): PluginMarketItem {
 }
 
 const detailMock = vi.fn<(pluginId: string) => Promise<PluginMarketDetail>>();
-const installMock = vi.fn(async () => ({ ghost: { manifest: manifest({}) } }) as never);
+const installMock = vi.fn(
+  async () => ({ status: 'installed', ghost: { manifest: manifest({}) } }) as never,
+);
 
 function stubDetail(overrides: {
   manifest: GhostManifest;
@@ -94,7 +96,10 @@ beforeEach(() => {
   // mockReset 而非 mockClear:用例可能装过"卡住不 resolve"的实现(并发编排),
   // 只清调用记录会让它泄漏到后面的用例里把 waitFor 全部拖超时。
   installMock.mockReset();
-  installMock.mockResolvedValue({ ghost: { manifest: manifest({}) } } as never);
+  installMock.mockResolvedValue({
+    status: 'installed',
+    ghost: { manifest: manifest({}) },
+  } as never);
   vi.mocked(toast.success).mockClear();
   installedGhosts = [{ manifest: manifest({ version: '1.0.0' }) }];
   (window as unknown as { electronAPI: unknown }).electronAPI = {
@@ -475,7 +480,7 @@ describe('updateAllController', () => {
           concurrentPeak = Math.max(concurrentPeak, active);
           installGate.push(() => {
             active -= 1;
-            resolve({ ghost: { manifest: expanding } } as never);
+            resolve({ status: 'installed', ghost: { manifest: expanding } } as never);
           });
         }),
     );
@@ -544,6 +549,52 @@ describe('updateAllController', () => {
     expect(row).toMatchObject({ status: 'needs-confirm', staleReview: true });
     expect(row?.errorText).toBeUndefined();
     expect(row?.permissionDiff).toBeUndefined();
+  });
+
+  it('reviews the verified package manifest when server metadata omitted permissions', async () => {
+    const existingTool = { name: 'existing_tool', description: 'Existing tool' };
+    const newTool = { name: 'new_tool', description: 'New tool' };
+    installedGhosts = [
+      {
+        manifest: manifest({
+          version: '1.0.0',
+          slots: ['tool'],
+          tools: [existingTool],
+        }),
+      },
+    ];
+    // 市场详情投影漏了 tools；真实包仍包含旧工具并新增一个工具。
+    stubDetail({ manifest: manifest({ slots: [] }), sourceType: 'server' });
+    const packageManifest = manifest({
+      slots: ['tool'],
+      tools: [existingTool, newTool],
+    });
+    installMock.mockResolvedValueOnce({
+      status: 'permission-review-required',
+      manifest: packageManifest,
+    } as never);
+
+    startUpdateAllBatch([marketItem({})]);
+    await waitForSettledBatch();
+
+    const held = getUpdateAllBatchState().rows?.[0];
+    expect(held).toMatchObject({
+      status: 'needs-confirm',
+      staleReview: false,
+      expectedManifest: packageManifest,
+    });
+    // 只提示相对已装版本真正新增的权限，不把市场投影漏掉的全部旧工具都算新增。
+    expect(held?.permissionDiff?.added.map((item) => item.key)).toEqual(['tool:new_tool']);
+
+    await approveUpdateExpansion('plugin-a');
+
+    expect(installMock).toHaveBeenLastCalledWith('plugin-a', {
+      expectedReleaseId: 'release-2',
+      expectedManifest: packageManifest,
+      allowPermissionExpansion: true,
+      reviewedBaseline: expect.any(String),
+    });
+    expect(getUpdateAllBatchState().rows?.[0]?.status).toBe('done');
   });
 
   it('lets a held runner row be re-reviewed and approved through to completion', async () => {
@@ -766,6 +817,57 @@ describe('updateAllController', () => {
     expect(getUpdateAllBatchState().rows).toBeNull();
   });
 
+  it('does not retry package review after the account switches during automatic install', async () => {
+    const packageManifest = manifest({ network: { hosts: ['api.example.com'] } });
+    stubDetail({ manifest: manifest({}), sourceType: 'server' });
+    let releaseInstall: ((result: unknown) => void) | undefined;
+    installMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseInstall = resolve;
+        }) as never,
+    );
+
+    startUpdateAllBatch([marketItem({})]);
+    await vi.waitFor(() => expect(installMock).toHaveBeenCalledTimes(1));
+
+    // The old batch is invalidated before Main returns the real package manifest.
+    setDataOwnerGeneration('owner-b');
+    reconcileUpdateAllBatch();
+    releaseInstall?.({ status: 'permission-review-required', manifest: packageManifest });
+    await vi.waitFor(() => expect(getUpdateAllBatchState().rows).toBeNull());
+
+    expect(installMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry package review after the account switches during approval', async () => {
+    const packageManifest = manifest({ network: { hosts: ['api.example.com'] } });
+    stubDetail({
+      manifest: manifest({ network: { hosts: ['api.example.com'] } }),
+      sourceType: 'server',
+    });
+    startUpdateAllBatch([marketItem({})]);
+    await waitForSettledBatch();
+
+    let releaseInstall: ((result: unknown) => void) | undefined;
+    installMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseInstall = resolve;
+        }) as never,
+    );
+    const approval = approveUpdateExpansion('plugin-a');
+    await vi.waitFor(() => expect(installMock).toHaveBeenCalledTimes(1));
+
+    setDataOwnerGeneration('owner-b');
+    reconcileUpdateAllBatch();
+    releaseInstall?.({ status: 'permission-review-required', manifest: packageManifest });
+    await approval;
+
+    expect(installMock).toHaveBeenCalledTimes(1);
+    expect(getUpdateAllBatchState().rows).toBeNull();
+  });
+
   it('does not make a new generation approval wait behind the previous one', async () => {
     const expanding = manifest({ network: { hosts: ['api.example.com'] } });
     detailMock.mockImplementation(async (pluginId) =>
@@ -784,7 +886,9 @@ describe('updateAllController', () => {
     installMock.mockImplementation(
       () =>
         new Promise((resolve) => {
-          stuck.push(() => resolve({ ghost: { manifest: expanding } } as never));
+          stuck.push(() =>
+            resolve({ status: 'installed', ghost: { manifest: expanding } } as never),
+          );
         }),
     );
     const oldApproval = approveUpdateExpansion('plugin-a');
@@ -836,7 +940,9 @@ describe('updateAllController', () => {
     installMock.mockImplementation(
       () =>
         new Promise((resolve) => {
-          gate.push(() => resolve({ ghost: { manifest: expanding } } as never));
+          gate.push(() =>
+            resolve({ status: 'installed', ghost: { manifest: expanding } } as never),
+          );
         }),
     );
     const first = approveUpdateExpansion('plugin-a');

--- a/apps/desktop/src/renderer/features/plugin/lib/updateAllController.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/updateAllController.ts
@@ -129,6 +129,20 @@ function batchOwnerCurrent(): boolean {
 }
 
 /**
+ * Await 之后、再次发安装 IPC 之前的最后一道批次归属检查。
+ *
+ * 仅靠 patchRow 不够：代际已失效时它会丢弃写入，但调用方若继续执行，
+ * 仍可能把旧账号/旧批次的安装意图发给当前账号。归属失效时主动作废批次，
+ * 与 detail await 后的检查保持同一语义。
+ */
+function ensureGenerationCurrent(generation: number): boolean {
+  if (batchGeneration !== generation) return false;
+  if (batchOwnerCurrent()) return true;
+  voidStaleBatch();
+  return false;
+}
+
+/**
  * 把一行退回「待重新审阅」——前置条件变化的统一收敛(runner 与批准共用)。
  *
  * 清掉旧的 permissionDiff 并打 staleReview:弹窗据此显示「权限差异已过期 /
@@ -155,6 +169,45 @@ function holdRowForReReview(
     ...patch,
     releaseId,
   });
+}
+
+/**
+ * Main inspected the verified package and found permissions missing from the
+ * marketplace detail projection. Review the real package manifest instead of
+ * repeatedly fetching the same stale metadata.
+ *
+ * `unchanged` is a race-safe fallback: another path may already have granted
+ * the package permissions by the time the result reaches Renderer, so no new
+ * confirmation is needed and the caller may retry with this manifest bound.
+ */
+function holdRowForPackageReview(
+  generation: number,
+  pluginId: string,
+  packageManifest: GhostManifest,
+  releaseId: string,
+): 'held' | 'skipped' | 'unchanged' {
+  const row = state.rows?.find((candidate) => candidate.pluginId === pluginId);
+  if (!row) return 'skipped';
+  const installed = installedManifestOf(row.ghostId);
+  if (!installed) {
+    patchRow(generation, pluginId, { status: 'skipped' });
+    return 'skipped';
+  }
+  const permissionDiff = diffGhostPermissionItems(installed, packageManifest);
+  if (permissionDiff.added.length === 0) return 'unchanged';
+  patchRow(generation, pluginId, {
+    status: 'needs-confirm',
+    fromVersion: installed.version,
+    toVersion: packageManifest.version,
+    releaseId,
+    permissionDiff,
+    staleReview: false,
+    reviewedBaseline: ghostPermissionBaselineKey(installed),
+    // 包已经过 Main 的 SHA/体积/manifest 校验；批准时原样回传，Main 会在
+    // 重新下载后再次确认真实包没有超出这份用户看过的权限面。
+    expectedManifest: packageManifest,
+  });
+  return 'held';
 }
 
 /** 账号/模式切换后作废整个批次(旧代际的 runner 在下一个检查点自行退出)。 */
@@ -285,10 +338,36 @@ async function runQueue(generation: number): Promise<void> {
           });
           continue;
         }
-        await window.electronAPI.pluginMarket.install(next.pluginId, {
+        let installResult = await window.electronAPI.pluginMarket.install(next.pluginId, {
           expectedReleaseId: detail.releaseId,
           ...(detail.sourceType !== 'server' ? { expectedManifest: detail.manifest } : {}),
         });
+        if (!ensureGenerationCurrent(generation)) return;
+        if (installResult.status === 'permission-review-required') {
+          const disposition = holdRowForPackageReview(
+            generation,
+            next.pluginId,
+            installResult.manifest,
+            detail.releaseId,
+          );
+          if (disposition !== 'unchanged') continue;
+          if (!ensureGenerationCurrent(generation)) return;
+          installResult = await window.electronAPI.pluginMarket.install(next.pluginId, {
+            expectedReleaseId: detail.releaseId,
+            expectedManifest: installResult.manifest,
+          });
+          if (!ensureGenerationCurrent(generation)) return;
+          if (installResult.status === 'permission-review-required') {
+            const retryDisposition = holdRowForPackageReview(
+              generation,
+              next.pluginId,
+              installResult.manifest,
+              detail.releaseId,
+            );
+            if (retryDisposition !== 'unchanged') continue;
+            throw new Error('Package permission review did not converge');
+          }
+        }
         patchRow(generation, next.pluginId, { status: 'done' });
       } catch (error) {
         if (batchGeneration !== generation) return;
@@ -478,8 +557,31 @@ async function runApprovalBody(pluginId: string, generation: number): Promise<vo
       options: Parameters<typeof window.electronAPI.pluginMarket.install>[1],
     ): Promise<boolean> => {
       try {
-        await window.electronAPI.pluginMarket.install(pluginId, options);
-        return true;
+        let result = await window.electronAPI.pluginMarket.install(pluginId, options);
+        if (!ensureGenerationCurrent(generation)) return false;
+        if (result.status === 'installed') return true;
+        const disposition = holdRowForPackageReview(
+          generation,
+          pluginId,
+          result.manifest,
+          detail.releaseId,
+        );
+        if (disposition !== 'unchanged') return false;
+        if (!ensureGenerationCurrent(generation)) return false;
+        result = await window.electronAPI.pluginMarket.install(pluginId, {
+          expectedReleaseId: detail.releaseId,
+          expectedManifest: result.manifest,
+        });
+        if (!ensureGenerationCurrent(generation)) return false;
+        if (result.status === 'installed') return true;
+        const retryDisposition = holdRowForPackageReview(
+          generation,
+          pluginId,
+          result.manifest,
+          detail.releaseId,
+        );
+        if (retryDisposition !== 'unchanged') return false;
+        throw new Error('Package permission review did not converge');
       } catch (error) {
         if (batchGeneration !== generation) return false;
         if (extractIpcError(error)?.code === 'PRECONDITION_FAILED') {

--- a/apps/desktop/src/renderer/features/plugin/lib/updateAllModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/updateAllModel.ts
@@ -47,8 +47,9 @@ export interface UpdateAllRow {
    */
   reviewedBaseline?: string;
   /**
-   * 非 server 源在审阅时取得的 manifest:主进程对这类来源强制要求安装时
-   * 传回同一份 reviewed manifest,approve 必须原样带上,否则 INVALID_PARAMS。
+   * 用户实际审阅过的目标 manifest。自定义源始终填写；服务端市场详情与
+   * 下载包权限不一致时，也由 Main 返回真实包 manifest 填入。批准时原样
+   * 回传，Main 复核真实包不得超出这份权限面。
    */
   expectedManifest?: GhostManifest;
   /** status 为 failed 时的用户可读错误(已经过 i18n 映射)。 */

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1415,8 +1415,9 @@ interface ElectronAPI {
         expectedReleaseId: string;
         expectedManifest?: import('../shared/ghost').GhostManifest;
         allowPermissionExpansion?: boolean;
+        reviewedBaseline?: string;
       },
-    ) => Promise<{ ghost: import('../shared/ghost').InstalledGhost }>;
+    ) => Promise<import('../shared/pluginMarket').PluginMarketInstallResult>;
     uninstall: (pluginId: string) => Promise<{ ok: true }>;
     listSources: () => Promise<import('../shared/pluginMarket').MarketSourceSummary[]>;
     pickLocalSource: (

--- a/apps/desktop/src/shared/pluginMarket.ts
+++ b/apps/desktop/src/shared/pluginMarket.ts
@@ -1,4 +1,4 @@
-import type { GhostManifest } from './ghost';
+import type { GhostManifest, InstalledGhost } from './ghost';
 import type { PluginIconMetadata } from '@cindy/plugin-protocol';
 
 export type PluginMarketScope = 'public' | 'organization' | 'personal';
@@ -44,6 +44,17 @@ export interface PluginMarketSnapshot {
 export interface PluginMarketDetail extends PluginMarketItem {
   manifest: GhostManifest;
 }
+
+/**
+ * A package may contain permissions omitted by the marketplace detail
+ * projection. When that omission expands the installed permission surface,
+ * Main returns the real manifest so Renderer can show the missing permission
+ * diff and retry with an explicit review bound to the same release. Permissions
+ * already held by the installed version do not require another approval.
+ */
+export type PluginMarketInstallResult =
+  | { status: 'installed'; ghost: InstalledGhost }
+  | { status: 'permission-review-required'; manifest: GhostManifest };
 
 /* ------------------------------------------------------------------------ */
 /* 自定义市场源（Git / 本地文件夹）                                           */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 插件市场执行 Update All 时，市场详情 manifest 与真实下载包权限不一致会让某个插件无法继续更新、队列卡住的问题。

客户端在 Main 校验真实下载包后，将需要补充审阅的 package manifest 返回现有权限复核流程；用户处理该插件后，批量队列继续处理其余插件。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联问题：某个插件的真实包权限与市场详情投影不一致时，Update All 无法正常收敛。
- 本 PR 包含：客户端真实包权限差异识别、现有权限复核流程接续、批次代际失效保护及回归测试。
- 明确不包含：服务端市场 manifest 投影修复；权限 receipt、存量迁移或批准体系重构；新增 UI。
- 用户可见变化：需要补充审阅的插件会停在现有复核状态，不再拖死整个批量更新队列。
- 是否存在 breaking change：无。

### UI 变化

不涉及：复用现有插件权限复核界面，没有新增布局、样式、颜色、动效或 UI 文案。

## 怎么验证的

### 自动验证

- 定向运行 marketPackagePermissionReview、server/custom market service、updateAllController。
- 结果：4 个测试文件通过，113 tests passed。

### 手工验证

未执行。

### 未执行的验证

本轮未运行全仓 `pnpm test:unit`；仅执行直接覆盖核心 bug 的定向测试，完整门禁以 CI 为准。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：Desktop 插件市场的批量安装/更新权限复核路径。
- 存量插件影响：无；本 PR 不新增本地批准状态或迁移。
- 回滚方式：回滚提交 `1141b688b`。

### 提交前检查

- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认定向测试结果并如实说明未执行项