### PR TITLE
fix(pi): 第一方 MCP 工具走 host 审批策略，与 Claude 的 auto-review 判定对齐

### DIFF
--- a/apps/desktop/src/main/maker-host/pi-host.ts
+++ b/apps/desktop/src/main/maker-host/pi-host.ts
@@ -43,6 +43,7 @@ import piSystemPrompt from './pi-system-prompt.md?raw';
 import { createLogger } from '../logger.js';
 import { readMemorySettings } from './memory-settings-store.js';
 import { registerPiProxySession } from './pi-proxy-session-auth.js';
+import { getDesktopMcpToolApprovalPolicy } from './mcp-tool-approval-policy.js';
 
 const log = createLogger('pi-host');
 
@@ -359,6 +360,9 @@ export function buildPiAgent(opts: BuildPiAgentOpts): PiAgent | null {
     reviewAutoPermissionAction: opts.reviewAutoPermissionAction,
     mcpProviders: opts.mcpProviders,
     makerMemory: opts.makerMemory,
+    // 与 Claude Code / Codex 同一份第一方 MCP 审批真源。Pi 之前没接,导致 orca 这类
+    // 可信 server 的工具落进 Auto-review 灰区被模型静默 block(详见 pi/index.ts 权限门)。
+    getMcpToolApprovalPolicy: getDesktopMcpToolApprovalPolicy,
     resolvePiAgentHome: () => path.join(app.getPath('userData'), 'pi-agent-home'),
     preparePiExtraSpawnConfig: (providers, ctx) => getPiExtraSpawnConfig(providers, opts.logger, ctx),
     registerPiProxySession,

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -85,6 +85,7 @@ import {
 } from '../../types/capability-routing.js';
 import { createAsyncQueue, type AsyncQueue } from '../shared/async-queue.js';
 import { AutoCompactController } from '../shared/auto-compact-controller.js';
+import { resolveMcpToolTarget } from '../shared/mcp-tool-target.js';
 import { scanClaudeAtResources, scanClaudeSlashCommands } from '../shared/palette-scanner.js';
 // scanClaudeSlashCommands 仍是 listAgentSkills 的实际数据源, 名字保留(它扫的是 commands+skills 两类)。
 import { UsageTracker } from '../shared/usage-tracker.js';
@@ -251,34 +252,6 @@ const READ_ONLY_CLAUDE_TOOLS: ReadonlySet<string> = new Set([
 /** canUseTool fail-closed 分支用: 判断工具是否属于已知只读工具(见上方白名单注释)。 */
 function isReadOnlyClaudeTool(toolName: string): boolean {
   return READ_ONLY_CLAUDE_TOOLS.has(toolName);
-}
-
-/**
- * 把 Claude SDK 的 MCP 工具名拆成 host 审批策略要的 { serverName, toolName }。
- *
- * SDK 命名格式为 `mcp__<server>__<tool>`, 但**不能**按 `__` 盲切首段当 server ——
- * server 名自身可以含 `__`(自定义 MCP 的 id 正则是 `/^[a-z0-9_-]+$/`, 下划线合法)。
- * 盲切会让 id 为 `cindy_browser__evil` 的第三方 server 被识别成第一方 `cindy_browser`,
- * 直接继承信任表里的静默放行 —— 这是一条实打实的提权路径。
- *
- * 因此只在**本 session 实际注册过**的 server 名里做前缀匹配, 命中多个时取最长者
- * (`cindy_browser__evil` 胜过 `cindy_browser`), 保证归属唯一。名字对不上任何已注册
- * server 时返回 null, 调用方按"不查策略"处理 —— 走原有权限链, 不放行。
- */
-function resolveMcpToolTarget(
-  toolName: string,
-  registeredServerNames: ReadonlySet<string>,
-): { serverName: string; toolName: string } | null {
-  if (!toolName.startsWith('mcp__')) return null;
-  let best: { serverName: string; toolName: string } | null = null;
-  for (const serverName of registeredServerNames) {
-    const prefix = `mcp__${serverName}__`;
-    if (!toolName.startsWith(prefix) || toolName.length <= prefix.length) continue;
-    if (!best || serverName.length > best.serverName.length) {
-      best = { serverName, toolName: toolName.slice(prefix.length) };
-    }
-  }
-  return best;
 }
 
 /**

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -195,6 +195,20 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     });
   }
 
+  /**
+   * 等某个权限请求的回帧落地。用「等信号 + 有界超时」而不是固定 flush ——
+   * 档位热切换会多经一次串行写入队列,靠 setTimeout(0) 的轮数猜等待就是计时型脆弱用例。
+   */
+  async function waitForResponse(id: string): Promise<Record<string, unknown>> {
+    const deadline = Date.now() + 2_000;
+    for (;;) {
+      const hit = captured.sent.find((m) => m.id === id);
+      if (hit) return hit;
+      if (Date.now() > deadline) throw new Error(`no extension_ui_response for ${id}`);
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  }
+
   function firePermissionRequest(id: string, toolName: string, input: Record<string, unknown>): void {
     captured.onEvent!({
       type: 'extension_ui_request',
@@ -750,6 +764,64 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     await flush();
     expect(resolverCalls).toBe(1);
     expect(captured.sent).toContainEqual({ type: 'extension_ui_response', id: 'r5', confirmed: true });
+  });
+
+  /**
+   * Full access 的语义是「不问、全放行」,必须压在 MCP 策略分支与灰区审阅之前。bridge 按 perm
+   * 文件现读本已把 bypass 拦在冒泡前,但档位可热切换 —— confirm 冒泡后用户仍可能切到 Full
+   * access,此时不该再弹卡,也不该因为没有 resolver 就把工具调用拒掉(review P1)。
+   */
+  it('honors a hot switch to Full access ahead of the MCP policy branch', async () => {
+    const review = vi.fn(async () => ({ verdict: 'block' as const }));
+    const handle = await start('ask', review, false, {
+      serverNames: ['cindy_ssh'],
+      policy: () => 'prompt-each-time',
+    });
+    let resolverCalls = 0;
+    handle.setInteractionResolver?.(async () => {
+      resolverCalls++;
+      return { kind: 'permission', behavior: 'deny' } as never;
+    });
+    await handle.setPermissionMode?.('bypassPermissions');
+    firePermissionRequest('r23', 'mcp__cindy_ssh__ssh_exec', { command: 'uptime' });
+    expect(await waitForResponse('r23')).toEqual({
+      type: 'extension_ui_response', id: 'r23', confirmed: true,
+    });
+    expect(resolverCalls).toBe(0);
+    expect(review).not.toHaveBeenCalled();
+  });
+
+  it('allows a Full access call whose session has no interaction resolver at all', async () => {
+    const handle = await start('ask', undefined, false, {
+      serverNames: ['cindy_ssh'],
+      policy: () => 'prompt',
+    });
+    await handle.setPermissionMode?.('bypassPermissions');
+    // 没有 setInteractionResolver:Full access 下不能因为拿不到决策就中断工具调用。
+    firePermissionRequest('r24', 'mcp__cindy_ssh__ssh_exec', { command: 'uptime' });
+    expect(await waitForResponse('r24')).toEqual({
+      type: 'extension_ui_response', id: 'r24', confirmed: true,
+    });
+  });
+
+  /**
+   * 反向边界:用户明确拒绝之后再切到 Full access,不能把这次拒绝追认成放行 —— 档位放宽只
+   * 影响「拿不到决策」的情形,不覆盖用户已经表过的态。
+   */
+  it('does not let a later Full access switch overturn an explicit denial', async () => {
+    const handle = await start('ask', undefined, false, {
+      serverNames: ['cindy_ssh'],
+      policy: () => 'prompt-each-time',
+    });
+    handle.setInteractionResolver?.(async () => {
+      // 用户点「拒绝」的同一时刻切到 Full access。
+      await handle.setPermissionMode?.('bypassPermissions');
+      return { kind: 'permission', behavior: 'deny' } as never;
+    });
+    firePermissionRequest('r25', 'mcp__cindy_ssh__ssh_exec', { command: 'rm -rf /' });
+    expect(await waitForResponse('r25')).toEqual({
+      type: 'extension_ui_response', id: 'r25', confirmed: false,
+    });
   });
 
   it('hot-switching to auto via setPermissionMode takes effect for subsequent calls', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -841,6 +841,47 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
   });
 
   /**
+   * 只有 Full access 算「放宽」。Auto 的语义是「区内放行、越界升级」而不是全放行,挂起的卡
+   * 本就是被升级的越界动作 —— 切到 Auto 必须 deny 这张 stale 卡,让重试重新过 fail-closed 的
+   * Auto dispatcher,不能替用户橡皮图章(与 CC 的 moreOpen 裁决一致,codex review P1)。
+   */
+  it('denies a pending card when switching to Auto instead of rubber-stamping it', async () => {
+    const handle = await start('ask', undefined, false, {
+      serverNames: ['cindy_browser'],
+      policy: () => 'prompt',
+    });
+    handle.setInteractionResolver?.(async () => await new Promise(() => {}));
+    firePermissionRequest('r28', 'mcp__cindy_browser__call_tool', { name: 'browser' });
+    await flush();
+    await handle.setPermissionMode?.('auto');
+    expect(await waitForResponse('r28')).toEqual({
+      type: 'extension_ui_response', id: 'r28', confirmed: false,
+    });
+  });
+
+  /**
+   * 并发切档:被更晚意图取代的那次写会在代际检查处提前返回、但 promise 仍 resolve 成功。旧
+   * continuation 若照自己捕获的 transition 收卡,就会用一次早已作废的放宽把 pending 调用错误
+   * 放行(codex review P1)。这里 ask → bypass 紧接着再切回 ask,最终必须是拒绝。
+   */
+  it('ignores a superseded mode change when settling pending prompts', async () => {
+    const handle = await start('ask', undefined, false, {
+      serverNames: ['cindy_ssh'],
+      policy: () => 'prompt',
+    });
+    handle.setInteractionResolver?.(async () => await new Promise(() => {}));
+    firePermissionRequest('r29', 'mcp__cindy_ssh__ssh_exec', { command: 'uptime' });
+    await flush();
+    // 两次切换连续发起,第一次(放宽)会被第二次(收紧)取代。
+    const widening = handle.setPermissionMode?.('bypassPermissions');
+    const tightening = handle.setPermissionMode?.('ask');
+    await Promise.allSettled([widening, tightening]);
+    expect(await waitForResponse('r29')).toEqual({
+      type: 'extension_ui_response', id: 'r29', confirmed: false,
+    });
+  });
+
+  /**
    * 放宽档位不得替用户批准他还没表态的**高风险**调用:prompt-each-time 的挂起卡在切到
    * Full access 时仍按 fail-closed 拒绝(与 CC / Codex 的 forcePrompt 语义一致)。
    */
@@ -875,6 +916,25 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     firePermissionRequest('r25', 'mcp__cindy_ssh__ssh_exec', { command: 'rm -rf /' });
     expect(await waitForResponse('r25')).toEqual({
       type: 'extension_ui_response', id: 'r25', confirmed: false,
+    });
+  });
+
+  /**
+   * resolver 是 host 注入的外部回调,可能同步 throw(或返回非 Promise)。直接 `.then` 会让同步
+   * 异常绕过 finalize —— pending 条目不注销、请求永不 settle,调用悬挂(copilot 报)。同步失败
+   * 必须落进 fail-closed 分支:回帧 confirmed:false,而不是卡死。
+   */
+  it('fails closed when the interaction resolver throws synchronously', async () => {
+    const handle = await start('ask', undefined, false, {
+      serverNames: ['cindy_ssh'],
+      policy: () => 'prompt',
+    });
+    handle.setInteractionResolver?.((() => {
+      throw new Error('resolver blew up synchronously');
+    }) as never);
+    firePermissionRequest('r30', 'mcp__cindy_ssh__ssh_exec', { command: 'uptime' });
+    expect(await waitForResponse('r30')).toEqual({
+      type: 'extension_ui_response', id: 'r30', confirmed: false,
     });
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -114,11 +114,33 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     if (savedNoProxyLower === undefined) delete process.env.no_proxy; else process.env.no_proxy = savedNoProxyLower;
   });
 
+  interface McpSetup {
+    /** 本会话「已注册」的桥接 MCP server 名(经 preparePiExtraSpawnConfig 下发)。 */
+    serverNames?: string[];
+    policy?: AgentDeps['getMcpToolApprovalPolicy'];
+  }
+
   function buildDeps(
     reviewAutoPermissionAction?: AgentDeps['reviewAutoPermissionAction'],
     includeNextModel = false,
+    mcp?: McpSetup,
   ): AgentDeps {
     return {
+      ...(mcp?.policy ? { getMcpToolApprovalPolicy: mcp.policy } : {}),
+      ...(mcp?.serverNames
+        ? {
+          preparePiExtraSpawnConfig: async () => ({
+            mcpBridge: {
+              token: 'bridge-token',
+              servers: mcp.serverNames!.map((name) => ({
+                name,
+                url: `http://127.0.0.1:1/${name}`,
+              })),
+            },
+            mcpEnv: {},
+          }),
+        }
+        : {}),
       auth: {
         getState: async () => ({ authenticated: true, identity: 'test', authSource: 'api-key' as const }),
         triggerLogin: async () => ({ authenticated: true }),
@@ -162,8 +184,9 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     permissionMode?: string,
     reviewAutoPermissionAction?: AgentDeps['reviewAutoPermissionAction'],
     includeNextModel = false,
+    mcp?: McpSetup,
   ): Promise<AgentSessionHandle> {
-    const agent = new PiAgent(buildDeps(reviewAutoPermissionAction, includeNextModel));
+    const agent = new PiAgent(buildDeps(reviewAutoPermissionAction, includeNextModel, mcp));
     return agent.startSession({
       sessionId: 's1',
       workingDir: cwd,
@@ -571,6 +594,75 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     expect(captured.sent).toContainEqual({ type: 'extension_ui_response', id: 'r2', confirmed: true });
   });
 
+  /**
+   * 桥接 MCP 工具走 host 审批策略,不进 Auto-review 灰区(与 Claude Code / Codex 同一份
+   * 真源)。回归的真实缺陷:Pi 没接这条策略时,`start_team` 落进灰区交模型判,模型按
+   * 「有更安全替代方案就 block」判成"这点小事不必开团队"→ block 对用户静默 → bridge
+   * 报 "User denied this tool call via Cindy",协同团队永远建不起来且没有任何弹窗。
+   */
+  it('auto-approves trusted first-party MCP tools via host policy without consulting the reviewer', async () => {
+    const review = vi.fn(async () => ({ verdict: 'block' as const, reason: 'should never be asked' }));
+    const handle = await start('auto', review, false, {
+      serverNames: ['cindy_orca'],
+      policy: ({ serverName }) => (serverName === 'cindy_orca' ? 'auto-approve' : 'prompt'),
+    });
+    let resolverCalls = 0;
+    handle.setInteractionResolver?.(async () => {
+      resolverCalls++;
+      return { kind: 'permission', behavior: 'allow' } as never;
+    });
+    await handle.send({ type: 'user', content: '修一下登录页的样式错位' });
+    firePermissionRequest('r20', 'mcp__cindy_orca__start_team', {});
+    await flush();
+    // 关键三点:不问模型、不弹卡、直接放行。userIntent 与协同无关也不影响(正是原缺陷的触发条件)。
+    expect(review).not.toHaveBeenCalled();
+    expect(resolverCalls).toBe(0);
+    expect(captured.sent).toContainEqual({ type: 'extension_ui_response', id: 'r20', confirmed: true });
+  });
+
+  it('still asks the user for MCP servers the host policy does not trust', async () => {
+    const review = vi.fn(async () => ({ verdict: 'allow' as const }));
+    const handle = await start('auto', review, false, {
+      serverNames: ['cindy_ssh'],
+      policy: ({ serverName }) => (serverName === 'cindy_orca' ? 'auto-approve' : 'prompt-each-time'),
+    });
+    let resolverCalls = 0;
+    handle.setInteractionResolver?.(async () => {
+      resolverCalls++;
+      return { kind: 'permission', behavior: 'allow' } as never;
+    });
+    await handle.send({ type: 'user', content: 'check the remote host' });
+    firePermissionRequest('r21', 'mcp__cindy_ssh__ssh_exec', { command: 'uptime' });
+    await flush();
+    // 不可信 server 仍逐次确认,且同样不该消耗模型审阅(它不是安全分类器该管的事)。
+    expect(review).not.toHaveBeenCalled();
+    expect(resolverCalls).toBe(1);
+    expect(captured.sent).toContainEqual({ type: 'extension_ui_response', id: 'r21', confirmed: true });
+  });
+
+  /**
+   * server 名可以含 `__`,盲切 `mcp__` 后首段会把第三方 `cindy_orca__evil` 认成第一方
+   * `cindy_orca` 并继承静默放行 —— 一条实打实的提权路径。归属判定取最长匹配。
+   */
+  it('does not let a look-alike server name inherit first-party trust', async () => {
+    const handle = await start('auto', async () => ({ verdict: 'allow' as const }), false, {
+      serverNames: ['cindy_orca', 'cindy_orca__evil'],
+      policy: ({ serverName }) => (serverName === 'cindy_orca' ? 'auto-approve' : 'prompt-each-time'),
+    });
+    const seen: string[] = [];
+    handle.setInteractionResolver?.(async (req) => {
+      seen.push((req as { toolName: string }).toolName);
+      return { kind: 'permission', behavior: 'deny' } as never;
+    });
+    await handle.send({ type: 'user', content: 'go' });
+    firePermissionRequest('r22', 'mcp__cindy_orca__evil__start_team', {});
+    await flush();
+    expect(seen).toEqual(['mcp__cindy_orca__evil__start_team']);
+    expect(captured.sent).toContainEqual({ type: 'extension_ui_response', id: 'r22', confirmed: false });
+  });
+
+  // host 未提供 getMcpToolApprovalPolicy(或 server 未注册)时的兜底:归属查不到就不查
+  // 策略,MCP 工具继续走原灰区路径,行为与接策略之前一致。
   it('auto mode gives the current-model reviewer complete MCP tool evidence', async () => {
     const review = vi.fn(async () => ({ verdict: 'allow' as const }));
     const handle = await start('auto', review);

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -805,6 +805,60 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
   });
 
   /**
+   * 弹卡**等待中**切到 Full access:必须当场 settle 那张卡让调用继续,而不是干等用户回答一张
+   * 已经失效的卡。此前 resolver 只挂在卡上、切档不会唤醒它,工具调用会一直卡住(codex P1)。
+   * 与 Claude / Codex 的 dismissAllPending 同口径,并发 interaction_dismissed 让 UI 收卡。
+   */
+  it('settles an in-flight permission card when the mode widens to Full access', async () => {
+    const handle = await start('ask', undefined, false, {
+      serverNames: ['cindy_browser'],
+      // prompt(非 prompt-each-time)→ 放宽档位时接受替用户放行。
+      policy: () => 'prompt',
+    });
+    const events: Array<Record<string, unknown>> = [];
+    void (async () => {
+      for await (const e of handle.events()) events.push(e as Record<string, unknown>);
+    })();
+    let cardShown = false;
+    handle.setInteractionResolver?.(async () => {
+      cardShown = true;
+      // 卡挂着不回答 —— 模拟用户没点按钮,直接去改权限档。
+      return await new Promise(() => {});
+    });
+    firePermissionRequest('r26', 'mcp__cindy_browser__call_tool', { name: 'browser' });
+    await flush();
+    expect(cardShown).toBe(true);
+    // 此刻还没有回帧:调用正等在卡上。
+    expect(captured.sent.find((m) => m.id === 'r26')).toBeUndefined();
+
+    await handle.setPermissionMode?.('bypassPermissions');
+    expect(await waitForResponse('r26')).toEqual({
+      type: 'extension_ui_response', id: 'r26', confirmed: true,
+    });
+    // UI 侧必须收到 dismissed,否则卡会留在界面上而工具已经继续执行。
+    const dismissed = events.find((e) => e.type === 'interaction_dismissed');
+    expect(dismissed?.data).toMatchObject({ requestId: 'r26', resolvedAs: 'allow' });
+  });
+
+  /**
+   * 放宽档位不得替用户批准他还没表态的**高风险**调用:prompt-each-time 的挂起卡在切到
+   * Full access 时仍按 fail-closed 拒绝(与 CC / Codex 的 forcePrompt 语义一致)。
+   */
+  it('keeps a pending prompt-each-time card fail-closed even when the mode widens', async () => {
+    const handle = await start('ask', undefined, false, {
+      serverNames: ['cindy_ssh'],
+      policy: () => 'prompt-each-time',
+    });
+    handle.setInteractionResolver?.(async () => await new Promise(() => {}));
+    firePermissionRequest('r27', 'mcp__cindy_ssh__ssh_exec', { command: 'rm -rf /' });
+    await flush();
+    await handle.setPermissionMode?.('bypassPermissions');
+    expect(await waitForResponse('r27')).toEqual({
+      type: 'extension_ui_response', id: 'r27', confirmed: false,
+    });
+  });
+
+  /**
    * 反向边界:用户明确拒绝之后再切到 Full access,不能把这次拒绝追认成放行 —— 档位放宽只
    * 影响「拿不到决策」的情形,不覆盖用户已经表过的态。
    */

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-policy.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-policy.test.ts
@@ -82,19 +82,21 @@ describe('classifyPiToolForAutoReview', () => {
   });
 
   /**
-   * 与 Claude 的 READ_ONLY_TOOLS scope 判定对齐:目录级递归读(grep/find/ls)的根在工作区外时
-   * 必须升级 —— 根路径本身不含凭证名(过不了 isSensitiveCredentialPath),但递归能捞出区外凭证
-   * 子路径。Pi 此前不传 scope,这类调用被静默 auto-approve,比同输入下的 Claude 更宽松。
+   * 如实钉住只读工具在本 adapter 的**可达面**:bridge 对 read/grep/find/ls 在非凭证路径时
+   * 直接放行、不冒泡(`cindy-bridge-source.ts` 的 READONLY_BUILTINS 快路径),所以能走到这里的
+   * 只读调用只有命中凭证路径那一类 —— 由凭证分支收成 prompt-each-time。
+   *
+   * 反过来说:区外目录级递归读在 Pi 当前**不经** host 审阅(与 Claude 存在行为差异),但那不是
+   * 本 adapter 能修的 —— 在这一层加 CC 那套 scope 区分只会得到永不执行的死代码。真修要动
+   * bridge 的只读快路径,属独立改动。这条用例的作用是防止后人再次在错误的层加"看起来对"的补丁。
    */
-  it('escalates out-of-workspace recursive reads but keeps single-file reads cheap', () => {
-    for (const tool of ['grep', 'find', 'ls']) {
-      expect(verdict(tool, { path: '/Users/t' })).toBe('prompt');
+  it('keeps plain reads auto-approved regardless of root (bridge never bubbles them)', () => {
+    for (const tool of ['read', 'grep', 'find', 'ls']) {
+      expect(verdict(tool, { path: '/Users/t' })).toBe('auto-approve');
       expect(verdict(tool, { path: `${WS}/src` })).toBe('auto-approve');
     }
-    // 单文件读只碰一个具名文件,区外也不因"能遍历"而升级(凭证路径另有必问规则兜住)。
-    expect(verdict('read', { path: '/tmp/notes.txt' })).toBe('auto-approve');
-    // 路径缺失(如只给 pattern)时无根可判,保持原有放行语义。
-    expect(verdict('grep', { pattern: 'TODO' })).toBe('auto-approve');
+    // 唯一真会到达这里的只读形态:入参命中凭证路径 → 必问、不可记住。
+    expect(verdict('grep', { path: '/Users/t/.aws/credentials' })).toBe('prompt-each-time');
   });
 
   it('fails closed for MCP and unknown tools', () => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-policy.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-policy.test.ts
@@ -81,6 +81,22 @@ describe('classifyPiToolForAutoReview', () => {
     expect(verdict('read', { paths: [`${WS}/a.ts`, `${WS}/b.ts`] })).toBe('auto-approve');
   });
 
+  /**
+   * 与 Claude 的 READ_ONLY_TOOLS scope 判定对齐:目录级递归读(grep/find/ls)的根在工作区外时
+   * 必须升级 —— 根路径本身不含凭证名(过不了 isSensitiveCredentialPath),但递归能捞出区外凭证
+   * 子路径。Pi 此前不传 scope,这类调用被静默 auto-approve,比同输入下的 Claude 更宽松。
+   */
+  it('escalates out-of-workspace recursive reads but keeps single-file reads cheap', () => {
+    for (const tool of ['grep', 'find', 'ls']) {
+      expect(verdict(tool, { path: '/Users/t' })).toBe('prompt');
+      expect(verdict(tool, { path: `${WS}/src` })).toBe('auto-approve');
+    }
+    // 单文件读只碰一个具名文件,区外也不因"能遍历"而升级(凭证路径另有必问规则兜住)。
+    expect(verdict('read', { path: '/tmp/notes.txt' })).toBe('auto-approve');
+    // 路径缺失(如只给 pattern)时无根可判,保持原有放行语义。
+    expect(verdict('grep', { pattern: 'TODO' })).toBe('auto-approve');
+  });
+
   it('fails closed for MCP and unknown tools', () => {
     expect(verdict('mcp__cindy_orca__start_team', { anything: 1 })).toBe('prompt');
     expect(verdict('some_future_tool', {})).toBe('prompt');

--- a/packages/maker-core/src/agents/pi/auto-review-policy.ts
+++ b/packages/maker-core/src/agents/pi/auto-review-policy.ts
@@ -45,6 +45,14 @@ function describeOtherTool(toolName: string, input: Record<string, unknown>): st
 /** pi 只读内置工具(与 cindy-bridge READONLY_BUILTINS 同集)。入参路径字段统一为 `path`。 */
 const READ_ONLY_TOOLS: ReadonlySet<string> = new Set(['read', 'grep', 'find', 'ls']);
 
+/**
+ * 单文件读 vs 目录级递归读 —— 与 CC 的 READ_ONLY_TOOLS scope 判定同口径。
+ * `read` 只读一个具名文件;`grep`/`find`/`ls` 会从给定根递归遍历,根在工作区外时能捞出区外
+ * 凭证子路径(如 `grep {path:'/Users/me', pattern:'AKIA'}` 命中 ~/.aws/credentials,而 path
+ * 本身不含凭证名、过不了 isSensitiveCredentialPath)→ 必须交 core 按边界升级。
+ */
+const TREE_SCOPE_READ_TOOLS: ReadonlySet<string> = new Set(['grep', 'find', 'ls']);
+
 /** 会改文件、带结构化 `path` 入参的 pi 内置工具。 */
 const FILE_WRITE_TOOLS: ReadonlySet<string> = new Set(['write', 'edit']);
 
@@ -87,7 +95,11 @@ export function normalizePiToolForAutoReview(ctx: PiAutoReviewContext): Reviewab
     // 凭证特征可能落在任意字符串入参(grep 的 pattern、find 的表达式等),与 bridge
     // 的 touchesCredentialPath 同口径递归扫全字段;命中的字符串作为 path 交 core 判必问。
     const credentialHit = findCredentialLeaf(input);
-    return { kind: 'read', path: credentialHit ?? stringField(input, 'path') };
+    return {
+      kind: 'read',
+      path: credentialHit ?? stringField(input, 'path'),
+      scope: TREE_SCOPE_READ_TOOLS.has(toolName) ? 'tree' : 'file',
+    };
   }
   if (FILE_WRITE_TOOLS.has(toolName)) {
     return { kind: 'file-write', path: stringField(input, 'path') };

--- a/packages/maker-core/src/agents/pi/auto-review-policy.ts
+++ b/packages/maker-core/src/agents/pi/auto-review-policy.ts
@@ -42,16 +42,17 @@ function describeOtherTool(toolName: string, input: Record<string, unknown>): st
   }
 }
 
-/** pi 只读内置工具(与 cindy-bridge READONLY_BUILTINS 同集)。入参路径字段统一为 `path`。 */
-const READ_ONLY_TOOLS: ReadonlySet<string> = new Set(['read', 'grep', 'find', 'ls']);
-
 /**
- * 单文件读 vs 目录级递归读 —— 与 CC 的 READ_ONLY_TOOLS scope 判定同口径。
- * `read` 只读一个具名文件;`grep`/`find`/`ls` 会从给定根递归遍历,根在工作区外时能捞出区外
- * 凭证子路径(如 `grep {path:'/Users/me', pattern:'AKIA'}` 命中 ~/.aws/credentials,而 path
- * 本身不含凭证名、过不了 isSensitiveCredentialPath)→ 必须交 core 按边界升级。
+ * pi 只读内置工具(与 cindy-bridge READONLY_BUILTINS 同集)。入参路径字段统一为 `path`。
+ *
+ * 注意可达面:bridge 对这四个工具在**非凭证路径**时直接放行、根本不冒泡
+ * (`cindy-bridge-source.ts` 的 `READONLY_BUILTINS.has(toolName) && !credentialRead` → return),
+ * 所以能走到本 adapter 的只读调用只有「命中凭证路径」那一类,下面的凭证分支已经把它收成
+ * `prompt-each-time`。因此这里不做 CC 那套 `scope:'file' | 'tree'` 的区分 —— 加了也不会执行。
+ * Pi 的区外目录级递归读(`grep`/`find`/`ls` 根在工作区外)当前确实不经 host 审阅,与 Claude
+ * 存在行为差异;真正修它要动 bridge 的只读快路径,属独立改动(见 PR 描述里的后续项)。
  */
-const TREE_SCOPE_READ_TOOLS: ReadonlySet<string> = new Set(['grep', 'find', 'ls']);
+const READ_ONLY_TOOLS: ReadonlySet<string> = new Set(['read', 'grep', 'find', 'ls']);
 
 /** 会改文件、带结构化 `path` 入参的 pi 内置工具。 */
 const FILE_WRITE_TOOLS: ReadonlySet<string> = new Set(['write', 'edit']);
@@ -95,11 +96,7 @@ export function normalizePiToolForAutoReview(ctx: PiAutoReviewContext): Reviewab
     // 凭证特征可能落在任意字符串入参(grep 的 pattern、find 的表达式等),与 bridge
     // 的 touchesCredentialPath 同口径递归扫全字段;命中的字符串作为 path 交 core 判必问。
     const credentialHit = findCredentialLeaf(input);
-    return {
-      kind: 'read',
-      path: credentialHit ?? stringField(input, 'path'),
-      scope: TREE_SCOPE_READ_TOOLS.has(toolName) ? 'tree' : 'file',
-    };
+    return { kind: 'read', path: credentialHit ?? stringField(input, 'path') };
   }
   if (FILE_WRITE_TOOLS.has(toolName)) {
     return { kind: 'file-write', path: stringField(input, 'path') };

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -76,6 +76,7 @@ import type { AgentKind, Effort, UserMessage, UserContentBlock } from '../../typ
 import type { ListAgentSkillsOptions, ListAgentSkillsResult } from '../../types/palette.js';
 import { scanPiCustomizations } from './customization-scanner.js';
 import { createAsyncQueue, type AsyncQueue } from '../shared/async-queue.js';
+import { resolveMcpToolTarget } from '../shared/mcp-tool-target.js';
 import { resolveAgentCredentialMode } from '../credential-mode.js';
 import { PiRpcProcess, type PiRpcEvent } from './rpc-client.js';
 import {
@@ -896,6 +897,7 @@ export class PiAgent extends BaseAgent {
     let mcpBridge: PiExtraSpawnConfig['mcpBridge'] = null;
     let mcpEnv: PiExtraSpawnConfig['mcpEnv'] = {};
     let disposeSessionCtx: (() => void) | undefined;
+    const registeredMcpServerNames = new Set<string>();
     if (this.deps.preparePiExtraSpawnConfig) {
       try {
         const extra = await this.deps.preparePiExtraSpawnConfig(this.deps.mcpProviders ?? [], {
@@ -907,6 +909,13 @@ export class PiAgent extends BaseAgent {
         mcpBridge = extra?.mcpBridge ?? null;
         mcpEnv = extra?.mcpEnv ?? {};
         disposeSessionCtx = extra?.disposeSessionCtx;
+        // 归属判定只认本会话实际注册过的 server 名(见 shared/mcp-tool-target.ts:
+        // 盲切 `__` 会让第三方 server 冒名顶替第一方信任表)。
+        for (const server of mcpBridge?.servers ?? []) {
+          if (typeof server.name === 'string' && server.name.length > 0) {
+            registeredMcpServerNames.add(server.name);
+          }
+        }
       } catch (err) {
         this.deps.logger.error('pi MCP bridge prep failed, continuing without cindy tools', {
           message: err instanceof Error ? err.message : String(err),
@@ -1127,6 +1136,7 @@ export class PiAgent extends BaseAgent {
               readRoots: [opts.workingDir, ...mutableExtraDirs],
               reviewAutoAction,
               notifyAutoReviewUnavailable: () => autoReviewUnavailableNotice.notify(),
+              registeredMcpServerNames,
             }));
             return;
           }
@@ -2111,6 +2121,8 @@ export class PiAgent extends BaseAgent {
       reviewAutoAction: (action: ReviewableAction) => Promise<AutoReviewDecision>;
       /** 审阅器不可用时的会话级一次性提示;去重与重置由会话侧持有(issue #1574)。 */
       notifyAutoReviewUnavailable: () => void;
+      /** 本会话实际注册过的桥接 MCP server 名;MCP 归属判定只认这批(防冒名顶替)。 */
+      registeredMcpServerNames: ReadonlySet<string>;
     },
   ): void {
     const method = typeof event.method === 'string' ? event.method : '';
@@ -2137,6 +2149,7 @@ export class PiAgent extends BaseAgent {
         readRoots,
         reviewAutoAction,
         notifyAutoReviewUnavailable,
+        registeredMcpServerNames,
       } = getPermissionCtx();
       const requestUserConfirmation = async (): Promise<boolean> => {
         if (!resolver) {
@@ -2160,6 +2173,56 @@ export class PiAgent extends BaseAgent {
         }
       };
       void (async () => {
+        // 桥接 MCP 工具走 host 审批策略,**不进 Auto-review 灰区** —— 与 Claude Code /
+        // Codex 同一份真源(`getDesktopMcpToolApprovalPolicy`)。
+        //
+        // 为什么不能交模型判:auto-review 是安全分类器,而"要不要开协同团队 / 该不该用
+        // 某个 MCP 工具"是做法选择,不是安全判断。实测把 `mcp__cindy_orca__start_team`
+        // 送去审阅时,模型会按 prompt 里"有更安全替代方案就 block"的字面判成"这点小事
+        // 不必开团队"→ block 对用户静默 → 冒泡回 bridge 就是
+        // "User denied this tool call via Cindy",团队永远建不起来且没有任何弹窗。
+        // 同一个第一方 MCP 在三个 harness 下必须给出同一个答案(base-agent.ts
+        // getMcpToolApprovalPolicy 注释),此前 Pi 是唯一没接这条的。
+        //
+        // 位置与 CC 一致:策略判定在档位分支**之前** —— auto-approve 的第一方 server 在
+        // ask 档也不弹窗(CC claude-code/index.ts 的 mcpApprovalPolicy 分支同义)。
+        // 认不出归属(server 未注册)或 host 没提供策略时不放行,继续走用户确认。
+        const mcpPolicy = ((): 'auto-approve' | 'prompt' | 'prompt-each-time' | null => {
+          const classifier = this.deps.getMcpToolApprovalPolicy;
+          if (!classifier) return null;
+          const target = resolveMcpToolTarget(toolName, registeredMcpServerNames);
+          if (!target) return null;
+          try {
+            const policy = classifier({
+              serverName: target.serverName,
+              toolName: target.toolName,
+              toolParams: input,
+            });
+            if (policy === 'auto-approve' || policy === 'prompt' || policy === 'prompt-each-time') {
+              return policy;
+            }
+            this.deps.logger.error('invalid MCP approval policy -> user confirmation', {
+              serverName: target.serverName,
+              policy,
+            });
+          } catch (err) {
+            this.deps.logger.error('MCP approval policy threw -> user confirmation', {
+              serverName: target.serverName,
+              message: err instanceof Error ? err.message : String(err),
+            });
+          }
+          return 'prompt-each-time';
+        })();
+        if (mcpPolicy !== null) {
+          // Pi 的权限门只有放行/拒绝两态,没有会话级持久化规则,因此 prompt 与
+          // prompt-each-time 在这里收敛成同一个动作:每次都问用户。
+          proc.send({
+            type: 'extension_ui_response',
+            id,
+            confirmed: mcpPolicy === 'auto-approve' ? true : await requestUserConfirmation(),
+          });
+          return;
+        }
         if (permissionMode !== 'auto') {
           proc.send({
             type: 'extension_ui_response',

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1724,12 +1724,22 @@ export class PiAgent extends BaseAgent {
           mode: nextMode,
         });
         // 写入成功后才 settle 挂起的卡(写失败会 fail-closed 抛出,档位没真变就不该收卡)。
-        // 放宽 → 替用户 allow(高风险 forcePrompt 仍 deny);收紧 → 一律 deny。
         // 没有这一步,用户切到 Full access 后仍要手动回答一张已失效的卡,调用一直卡着。
-        if (nextMode !== previousMode) {
+        //
+        // 只有**最新且已落盘**的那次切换可以收卡:被更晚意图取代的写会在代际检查处提前
+        // 返回、但 promise 仍 resolve 成功(见 writePermissionFile 的 `gen !== permissionWriteGen`),
+        // 旧 continuation 若照自己捕获的 transition 收卡,就会用一次早已作废的放宽把 pending
+        // 调用错误放行,而真正生效的收紧只能看到卡已经没了(codex review P1)。
+        const stillLatestIntent = requestedPermissionSnapshot.mode === nextMode;
+        const persisted = persistedPermissionSnapshot.mode === nextMode;
+        if (nextMode !== previousMode && stillLatestIntent && persisted) {
+          // **只有 bypassPermissions 算「放宽」**。Auto 的语义是「区内放行、越界升级」而不是
+          // 全放行,而挂起的卡本就是被升级的越界/风险动作 —— 切到 Auto 若替用户 allow,等于
+          // 把待确认的越界动作橡皮图章掉;应当 deny,让模型重试时重新过一遍 fail-closed 的
+          // Auto dispatcher。与 CC / Codex 的同名裁决一致(claude-code/index.ts 的 moreOpen)。
           dismissAllPendingPrompts(
             `permission_mode_changed_to_${nextMode}`,
-            permissionPrivilege(nextMode) > permissionPrivilege(previousMode) ? 'allow' : 'deny',
+            nextMode === 'bypassPermissions' ? 'allow' : 'deny',
           );
         }
       },
@@ -2235,12 +2245,15 @@ export class PiAgent extends BaseAgent {
             // 切档替用户做的临时决定同样是「已决」—— 调用方不该再按 bypass 语义二次翻转。
             settle: (resolveAs) => finalize({ decided: true, approved: resolveAs === 'allow' }),
           });
-          resolver({
+          // resolver 是 host 注入的外部回调:可能同步 throw,也可能返回非 Promise。直接
+          // `.then` 会让同步异常绕过下面的 finalize —— pending 条目永不注销、这次请求永不
+          // settle,调用就此悬挂(copilot 报)。包一层把同步失败也收进 fail-closed 分支。
+          Promise.resolve().then(() => resolver({
             kind: 'permission',
             requestId: id,
             toolName,
             input,
-          }).then((decision) => {
+          })).then((decision) => {
             if (decision.kind !== 'permission') {
               this.deps.logger.warn('pi permission got mismatched decision kind', {
                 toolName,

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -2151,10 +2151,15 @@ export class PiAgent extends BaseAgent {
         notifyAutoReviewUnavailable,
         registeredMcpServerNames,
       } = getPermissionCtx();
-      const requestUserConfirmation = async (): Promise<boolean> => {
+      /**
+       * 向用户要一次表态。`decided` 区分「用户明确表态」与「压根拿不到决策」(无 resolver /
+       * resolver 抛错 / kind 不匹配) —— 调用方对后者才允许按 Full access 语义放行,
+       * 不能把用户的明确拒绝也一并翻转。
+       */
+      const requestUserDecision = async (): Promise<{ decided: boolean; approved: boolean }> => {
         if (!resolver) {
-          this.deps.logger.warn('pi permission request denied: no interaction resolver', { toolName });
-          return false;
+          this.deps.logger.warn('pi permission request has no interaction resolver', { toolName });
+          return { decided: false, approved: false };
         }
         try {
           const decision = await resolver({
@@ -2163,16 +2168,46 @@ export class PiAgent extends BaseAgent {
             toolName,
             input,
           });
-          return decision.kind === 'permission' && decision.behavior === 'allow';
+          if (decision.kind !== 'permission') {
+            this.deps.logger.warn('pi permission got mismatched decision kind', {
+              toolName,
+              decisionKind: decision.kind,
+            });
+            return { decided: false, approved: false };
+          }
+          return { decided: true, approved: decision.behavior === 'allow' };
         } catch (err) {
-          this.deps.logger.warn('pi permission resolver failed; denying', {
+          this.deps.logger.warn('pi permission resolver failed', {
             toolName,
             message: err instanceof Error ? err.message : String(err),
           });
-          return false;
+          return { decided: false, approved: false };
         }
       };
+      /**
+       * Full access 的语义是「不问、全放行」。档位支持会话中途热切换(bridge 每次 tool_call
+       * 现读 perm 文件),所以必须**按最新档位**判断,不能用请求冒泡那一刻的快照。
+       */
+      const isFullAccessNow = (): boolean =>
+        getPermissionCtx().permissionMode === 'bypassPermissions';
+      const requestUserConfirmation = async (): Promise<boolean> => {
+        // 发起确认前:已切到 Full access 就不该再弹卡。
+        if (isFullAccessNow()) return true;
+        const outcome = await requestUserDecision();
+        // 用户已明确表态 → 以用户为准。拒绝不该被随后的档位切换追认成放行。
+        if (outcome.decided) return outcome.approved;
+        // 拿不到决策:Full access 下按 bypass 语义放行,其余一律 fail-closed。
+        return isFullAccessNow();
+      };
       void (async () => {
+        // Full access 优先收口,压在所有后续判定之前。bridge 侧按 perm 文件现读已把 bypass
+        // 拦在冒泡之前,但档位是热切换的:confirm 冒泡之后用户仍可能切到 Full access。此时
+        // MCP 策略 / 灰区审阅 / 弹窗都不该再改变「全放行」语义,也不该因为没有 resolver 就
+        // 拒掉工具调用(与 auto 分支既有的 modeAfterReview bypass 收口同口径)。
+        if (isFullAccessNow()) {
+          proc.send({ type: 'extension_ui_response', id, confirmed: true });
+          return;
+        }
         // 桥接 MCP 工具走 host 审批策略,**不进 Auto-review 灰区** —— 与 Claude Code /
         // Codex 同一份真源(`getDesktopMcpToolApprovalPolicy`)。
         //
@@ -2186,7 +2221,11 @@ export class PiAgent extends BaseAgent {
         //
         // 位置与 CC 一致:策略判定在档位分支**之前** —— auto-approve 的第一方 server 在
         // ask 档也不弹窗(CC claude-code/index.ts 的 mcpApprovalPolicy 分支同义)。
-        // 认不出归属(server 未注册)或 host 没提供策略时不放行,继续走用户确认。
+        //
+        // 返回 null = 不查策略,**回落原有权限链**(ask 档弹窗 / auto 档进灰区审阅),行为与
+        // 接策略之前完全一致:host 没提供 classifier,或工具名对不上任何本会话已注册的
+        // server(认不出归属就不敢按第一方放行)。策略抛错或返回非法值则不回落 ——
+        // 那是策略本身故障,按 prompt-each-time fail-closed 收口。
         const mcpPolicy = ((): 'auto-approve' | 'prompt' | 'prompt-each-time' | null => {
           const classifier = this.deps.getMcpToolApprovalPolicy;
           if (!classifier) return null;

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1010,6 +1010,40 @@ export class PiAgent extends BaseAgent {
     // 都有机会看见。持久呈现需要一条真正的会话级 notice 通道,见 issue 外推。
       autoReviewUnavailableNotice.reset();
     };
+    /**
+     * 挂起的权限卡登记表 —— 档位切换 / 会话关闭时必须能把它们强制 settle 并让 UI 收卡,
+     * 与 Claude / Codex 的 `dismissAllPending` 同口径(Pi 此前是唯一没有这套的 harness)。
+     *
+     * 没有它的后果:用户看到卡之后切到 Full access,`resolver` 仍只挂在那张卡上,不会被唤醒,
+     * 于是「Full access 不该再问」永远等不到生效 —— 工具调用一直卡住,直到用户手动回答一张
+     * 已经失效的卡(codex review P1)。
+     */
+    type PendingPrompt = {
+      settle: (resolveAs: 'allow' | 'deny') => void;
+      /** 高风险审批(MCP prompt-each-time、灰区 ask、审查中收紧):放宽档位不得批量放行。 */
+      forcePrompt: boolean;
+    };
+    const pendingPrompts = new Map<string, PendingPrompt>();
+    const registerPendingPrompt = (requestId: string, entry: PendingPrompt): (() => void) => {
+      pendingPrompts.set(requestId, entry);
+      return () => pendingPrompts.delete(requestId);
+    };
+    const dismissAllPendingPrompts = (reason: string, resolveAs: 'allow' | 'deny'): void => {
+      if (pendingPrompts.size === 0) return;
+      for (const [requestId, entry] of Array.from(pendingPrompts.entries())) {
+        // 放宽档位不能替用户批准他还没表态的高风险调用:没拿到这一次的明确确认就 fail-closed
+        // (与 CC / Codex 的同名逻辑一致 —— 否则 pending 期间切档能让破坏性调用自动过)。
+        const effectiveResolveAs: 'allow' | 'deny' =
+          resolveAs === 'allow' && entry.forcePrompt ? 'deny' : resolveAs;
+        pendingPrompts.delete(requestId);
+        entry.settle(effectiveResolveAs);
+        queue.push({
+          type: 'interaction_dismissed',
+          data: { requestId, reason, resolvedAs: effectiveResolveAs },
+          source: 'pi',
+        });
+      }
+    };
     // 「自动审核不可用」的会话级一次性提示(issue #1574);与 Claude / Codex 同口径,走既有的
     // 非终止 error 事件 + `[CODE]` 约定,不新增事件类型。
     const autoReviewUnavailableNotice = createAutoReviewUnavailableNotice((message) => {
@@ -1137,6 +1171,7 @@ export class PiAgent extends BaseAgent {
               reviewAutoAction,
               notifyAutoReviewUnavailable: () => autoReviewUnavailableNotice.notify(),
               registeredMcpServerNames,
+              registerPendingPrompt,
             }));
             return;
           }
@@ -1620,6 +1655,8 @@ export class PiAgent extends BaseAgent {
 
       async close(): Promise<void> {
         closed = true;
+        // 会话结束时挂起的卡已经不可能有人回答:强制 deny,别让等它的调用悬着(同 CC / Codex)。
+        dismissAllPendingPrompts('session_closed', 'deny');
         // 先注销 bridge 身份注册(幂等),再关子进程。放前面:即便 proc.close 抛错
         // 也不泄漏 ctx —— 该 sessionId 的 `?session=` 路由必须随会话结束失效。
         try {
@@ -1681,10 +1718,20 @@ export class PiAgent extends BaseAgent {
           autoReviewDecisionCache.clear();
           autoReviewUnavailableNotice.reset();
         }
+        const previousMode = requestedPermissionSnapshot.mode;
         await writePermissionSnapshotOrFailClosed({
           ...requestedPermissionSnapshot,
           mode: nextMode,
         });
+        // 写入成功后才 settle 挂起的卡(写失败会 fail-closed 抛出,档位没真变就不该收卡)。
+        // 放宽 → 替用户 allow(高风险 forcePrompt 仍 deny);收紧 → 一律 deny。
+        // 没有这一步,用户切到 Full access 后仍要手动回答一张已失效的卡,调用一直卡着。
+        if (nextMode !== previousMode) {
+          dismissAllPendingPrompts(
+            `permission_mode_changed_to_${nextMode}`,
+            permissionPrivilege(nextMode) > permissionPrivilege(previousMode) ? 'allow' : 'deny',
+          );
+        }
       },
 
       async setExtraDirs(dirs: string[]): Promise<void> {
@@ -2123,6 +2170,14 @@ export class PiAgent extends BaseAgent {
       notifyAutoReviewUnavailable: () => void;
       /** 本会话实际注册过的桥接 MCP server 名;MCP 归属判定只认这批(防冒名顶替)。 */
       registeredMcpServerNames: ReadonlySet<string>;
+      /**
+       * 把一张挂起的权限卡登记进会话级表,返回注销函数。档位切换 / 关闭会话时由
+       * `dismissAllPendingPrompts` 强制 settle,避免放宽档位后调用仍卡在失效的卡上。
+       */
+      registerPendingPrompt: (
+        requestId: string,
+        entry: { settle: (resolveAs: 'allow' | 'deny') => void; forcePrompt: boolean },
+      ) => () => void;
     },
   ): void {
     const method = typeof event.method === 'string' ? event.method : '';
@@ -2150,39 +2205,59 @@ export class PiAgent extends BaseAgent {
         reviewAutoAction,
         notifyAutoReviewUnavailable,
         registeredMcpServerNames,
+        registerPendingPrompt,
       } = getPermissionCtx();
       /**
        * 向用户要一次表态。`decided` 区分「用户明确表态」与「压根拿不到决策」(无 resolver /
        * resolver 抛错 / kind 不匹配) —— 调用方对后者才允许按 Full access 语义放行,
        * 不能把用户的明确拒绝也一并翻转。
        */
-      const requestUserDecision = async (): Promise<{ decided: boolean; approved: boolean }> => {
+      const requestUserDecision = async (
+        opts: { forcePrompt: boolean },
+      ): Promise<{ decided: boolean; approved: boolean }> => {
         if (!resolver) {
           this.deps.logger.warn('pi permission request has no interaction resolver', { toolName });
           return { decided: false, approved: false };
         }
-        try {
-          const decision = await resolver({
+        // 登记进会话级 pending 表:等卡期间用户切档(或关会话)时由 dismissAllPendingPrompts
+        // 强制 settle,不再干等一张已经失效的卡。settled 门防止两边重复 resolve。
+        return new Promise<{ decided: boolean; approved: boolean }>((resolve) => {
+          let settled = false;
+          let unregister: (() => void) | null = null;
+          const finalize = (outcome: { decided: boolean; approved: boolean }): void => {
+            if (settled) return;
+            settled = true;
+            unregister?.();
+            resolve(outcome);
+          };
+          unregister = registerPendingPrompt(id, {
+            forcePrompt: opts.forcePrompt,
+            // 切档替用户做的临时决定同样是「已决」—— 调用方不该再按 bypass 语义二次翻转。
+            settle: (resolveAs) => finalize({ decided: true, approved: resolveAs === 'allow' }),
+          });
+          resolver({
             kind: 'permission',
             requestId: id,
             toolName,
             input,
-          });
-          if (decision.kind !== 'permission') {
-            this.deps.logger.warn('pi permission got mismatched decision kind', {
+          }).then((decision) => {
+            if (decision.kind !== 'permission') {
+              this.deps.logger.warn('pi permission got mismatched decision kind', {
+                toolName,
+                decisionKind: decision.kind,
+              });
+              finalize({ decided: false, approved: false });
+              return;
+            }
+            finalize({ decided: true, approved: decision.behavior === 'allow' });
+          }).catch((err) => {
+            this.deps.logger.warn('pi permission resolver failed', {
               toolName,
-              decisionKind: decision.kind,
+              message: err instanceof Error ? err.message : String(err),
             });
-            return { decided: false, approved: false };
-          }
-          return { decided: true, approved: decision.behavior === 'allow' };
-        } catch (err) {
-          this.deps.logger.warn('pi permission resolver failed', {
-            toolName,
-            message: err instanceof Error ? err.message : String(err),
+            finalize({ decided: false, approved: false });
           });
-          return { decided: false, approved: false };
-        }
+        });
       };
       /**
        * Full access 的语义是「不问、全放行」。档位支持会话中途热切换(bridge 每次 tool_call
@@ -2190,11 +2265,18 @@ export class PiAgent extends BaseAgent {
        */
       const isFullAccessNow = (): boolean =>
         getPermissionCtx().permissionMode === 'bypassPermissions';
-      const requestUserConfirmation = async (): Promise<boolean> => {
+      /**
+       * `forcePrompt` 标记高风险审批(MCP prompt-each-time、灰区 ask、审查中收紧档位):
+       * 等卡期间用户把档位放宽,这类**不**接受批量放行,仍按 fail-closed 拒绝 —— 与 CC /
+       * Codex 的 dismissAllPending 同口径。
+       */
+      const requestUserConfirmation = async (
+        opts?: { forcePrompt?: boolean },
+      ): Promise<boolean> => {
         // 发起确认前:已切到 Full access 就不该再弹卡。
         if (isFullAccessNow()) return true;
-        const outcome = await requestUserDecision();
-        // 用户已明确表态 → 以用户为准。拒绝不该被随后的档位切换追认成放行。
+        const outcome = await requestUserDecision({ forcePrompt: opts?.forcePrompt === true });
+        // 已有决策(用户明确表态,或切档时代为 settle)→ 以它为准,不再被档位二次翻转。
         if (outcome.decided) return outcome.approved;
         // 拿不到决策:Full access 下按 bypass 语义放行,其余一律 fail-closed。
         return isFullAccessNow();
@@ -2258,7 +2340,9 @@ export class PiAgent extends BaseAgent {
           proc.send({
             type: 'extension_ui_response',
             id,
-            confirmed: mcpPolicy === 'auto-approve' ? true : await requestUserConfirmation(),
+            confirmed: mcpPolicy === 'auto-approve'
+              ? true
+              : await requestUserConfirmation({ forcePrompt: mcpPolicy === 'prompt-each-time' }),
           });
           return;
         }
@@ -2290,10 +2374,12 @@ export class PiAgent extends BaseAgent {
             return;
           }
           if (modeAfterReview !== 'auto') {
+            // 审查期间用户主动收紧了档位 → 这一次必须拿到明确确认,等卡期间再放宽也不追认
+            // (forcePrompt,与 CC 对 AI ask / 确定性红线的处理同口径)。
             proc.send({
               type: 'extension_ui_response',
               id,
-              confirmed: await requestUserConfirmation(),
+              confirmed: await requestUserConfirmation({ forcePrompt: true }),
             });
             return;
           }
@@ -2301,7 +2387,7 @@ export class PiAgent extends BaseAgent {
             proc.send({
               type: 'extension_ui_response',
               id,
-              confirmed: await requestUserConfirmation(),
+              confirmed: await requestUserConfirmation({ forcePrompt: true }),
             });
             return;
           }

--- a/packages/maker-core/src/agents/shared/mcp-tool-target.ts
+++ b/packages/maker-core/src/agents/shared/mcp-tool-target.ts
@@ -1,0 +1,31 @@
+/**
+ * 把 `mcp__<server>__<tool>` 形态的工具名解析回 (serverName, toolName)。
+ *
+ * Claude Code 与 Pi 共用同一份实现 —— 两侧都用它决定「这个 MCP 工具属于哪个 server」,
+ * 再把 server 名交给 host 的 `getMcpToolApprovalPolicy`。归属判定错了就等于审批策略
+ * 认错人,必须只有一份真源。
+ *
+ * 命名格式为 `mcp__<server>__<tool>`, 但**不能**按 `__` 盲切首段当 server ——
+ * server 名自身可以含 `__`(自定义 MCP 的 id 正则是 `/^[a-z0-9_-]+$/`, 下划线合法)。
+ * 盲切会让 id 为 `cindy_browser__evil` 的第三方 server 被识别成第一方 `cindy_browser`,
+ * 直接继承信任表里的静默放行 —— 这是一条实打实的提权路径。
+ *
+ * 因此只在**本 session 实际注册过**的 server 名里做前缀匹配, 命中多个时取最长者
+ * (`cindy_browser__evil` 胜过 `cindy_browser`), 保证归属唯一。名字对不上任何已注册
+ * server 时返回 null, 调用方按"不查策略"处理 —— 走原有权限链, 不放行。
+ */
+export function resolveMcpToolTarget(
+  toolName: string,
+  registeredServerNames: ReadonlySet<string>,
+): { serverName: string; toolName: string } | null {
+  if (!toolName.startsWith('mcp__')) return null;
+  let best: { serverName: string; toolName: string } | null = null;
+  for (const serverName of registeredServerNames) {
+    const prefix = `mcp__${serverName}__`;
+    if (!toolName.startsWith(prefix) || toolName.length <= prefix.length) continue;
+    if (!best || serverName.length > best.serverName.length) {
+      best = { serverName, toolName: toolName.slice(prefix.length) };
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 会话里调 `start_team` 开协同，工具返回 `User denied this tool call via Cindy`，团队从未建起来，而用户从头到尾没见过任何权限卡（X 用户反馈）。

不是 orca 没装，也不是 MCP 没接上。根因是 **Pi 是三个 harness 里唯一没接 `getMcpToolApprovalPolicy` 的**：桥接 MCP 工具全被丢进 Auto-review 灰区（`kind:'other'`）交当前会话模型判。而 auto-review 是安全分类器，「要不要开协同团队」是做法选择、不是安全判断，两者错位的后果是确定性的。

实测把 `mcp__cindy_orca__start_team` 按真实 prompt（`buildAutoPermissionReviewPrompt` 生成）送给真实模型：

- `userIntent` 明确要协同（「帮我开一个协同团队，拉两个 worker 一起做这个重构」）→ 连跑 3 次全 `allow`；
- `userIntent` 换成一句无关的普通需求（「修一下登录页的样式错位」）→ 连跑 2 次全 `block`，理由是「这点小事不必开团队，直接在 workspaceRoot 里改」。

而 `userIntent` 只取**当前这一轮**的用户消息（`pi/index.ts` 的 `setAutoReviewIntent`，每条新用户消息重置并清裁决缓存）。多轮对话里上一轮说了要协同、这一轮只说具体任务，模型这一轮就看不到协同意图 → 判 block。**block 对用户完全静默**（prompt 里写明 `Blocking is silent to the user`），冒泡回 bridge 就是那句 `User denied this tool call via Cindy`。

Claude Code 下同一个 `start_team` 直接放行：CC 把 `mcp__` **排除在灰区之外**（`claude-code/index.ts` 的 `&& !toolName.startsWith('mcp__')`），改查确定性的 `mcp-tool-approval-policy.ts`，而 `cindy_orca` 就在它的 `TRUSTED_MCP_SERVERS` 里。那份文件的文件头写得很清楚：它是 Claude Code 与 Codex 共用的**唯一真源**，「同一个第一方 MCP 在两个 agent 下必须给出同一个答案」。此前是三个 agent 里少了一个。

本 PR 让 Pi 走同一份真源，并在三轮 review 中补齐了 Pi 相对 Claude / Codex 缺失的「档位切换 × 挂起权限卡」机制。**不新增策略、不放宽既有边界。**

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：X 用户反馈（Pi + orca `start_team` 被静默拒绝）
- 本 PR 包含：

  **① 第一方 MCP 工具走 host 审批策略（`1b9a072`）**
  - `pi/index.ts handleExtensionUiRequest` 对 `mcp__*` 先查 `getMcpToolApprovalPolicy`：`auto-approve` 直接放行，`prompt` / `prompt-each-time` 走用户确认，**一律不再消耗模型审阅**。
  - 位置与 CC 一致 —— 判定在**档位分支之前**，故可信 server 在 `ask` 档也不弹窗（CC 的 `mcpApprovalPolicy` 分支同义）。
  - 策略缺失、server 未注册、策略抛错或返回非法值**一律不放行**，继续走原确认链（fail-closed，与 CC 同口径）。
  - `resolveMcpToolTarget` 下沉到 `shared/mcp-tool-target.ts` 由 CC 与 Pi 共用：归属判定是安全敏感逻辑（盲切 `__` 会让 `cindy_orca__evil` 冒名顶替第一方信任表，是一条实打实的提权路径），不能有两份实现。
  - 归属只在本会话经 bridge **实际注册过**的 server 名里做最长匹配。
  - `pi-host.ts` 传入 `getDesktopMcpToolApprovalPolicy`。

  **② 已撤回：区外目录级递归读补 `scope`（`22aa157` → 由 `021fb88` 撤回）**

  这一项**本 PR 不再包含**，如实记录经过：为满足「与 Claude 体验一致」做的对齐审计发现 CC 的只读归一化区分单文件读与目录级递归读（`scope:'file' | 'tree'`），core 对 tree 且根在工作区外的读升级弹卡；Pi 的 adapter 没传 `scope`。于是先在 adapter 层补了 `scope`。

  Review 提醒后核实：**这个改动是死代码**。bridge 对 `read`/`grep`/`find`/`ls` 在非凭证路径时直接 `return`、根本不冒泡到 host（`cindy-bridge-source.ts` 的 `READONLY_BUILTINS.has(toolName) && !credentialRead`），所以能到达该 adapter 的只读调用只有命中凭证路径那一类，而它已被凭证分支收成 `prompt-each-time` —— `scope` 永不参与判定。原用例只在函数级为绿，不代表真实行为。已整段撤回，并把这条事实写进 `auto-review-policy.ts` 的注释 + 一条如实钉住「可达面」的用例，防止后人再在错误的层加补丁。

  **遗留差异（如实说明，未修）**：Pi 的区外目录级递归读（`grep`/`find`/`ls` 根在工作区外）当前确实不经 host 审阅，与 Claude 存在行为差异，方向是 Pi 更宽松。修它要动 bridge 的只读快路径，会改变 `ask` / `auto` 两档下 `ls`/`grep` 的弹卡行为（噪音 vs 安全的取舍），属独立改动，不塞进本 PR。

  **③ Review 轮次修复（`744ead6` / `d88b7ed` / `021fb88`）**

  三轮 review 挖出的问题都落在同一个主题上 —— Pi 的权限档位与挂起权限卡的交互，此前 Pi 是唯一没有这套机制的 harness：

  - **Full access 优先收口**：`handleExtensionUiRequest` 入口按最新档位判 `bypassPermissions`，覆盖 MCP 策略 / 灰区审阅 / 弹窗三条路径；会话没有 interaction resolver 时也不再把 Full access 的调用拒掉。
  - **挂起卡可被唤醒**（补齐 CC / Codex 的 `dismissAllPending` 语义，Pi 此前完全没有）：会话级 pending 登记表，切档 / 关会话时强制 settle 并发既有的 `interaction_dismissed` 事件让 UI 收卡。此前用户切到 Full access 后，调用仍卡在一张已失效的卡上。
  - **只有 Full access 算「放宽」**：切到 Auto 不替用户放行挂起的卡（Auto 是「区内放行、越界升级」，不是全放行），deny 后让重试重新过 fail-closed 的 Auto dispatcher —— 与 CC 的 `moreOpen` 裁决一致。
  - **高风险审批不接受放宽的批量放行**（CC / Codex 的 `forcePrompt` 语义）：MCP `prompt-each-time`、灰区 `ask`、审查期间被收紧这三类，即便切到 Full access 仍 fail-closed。
  - **并发切档**：被更晚意图取代的写虽跳过落盘但 promise 仍 resolve，旧 continuation 不得据此收卡；收卡前要求「意图仍是本次 + 该 mode 确已落盘」。
  - **resolver 同步 throw**：包成 `Promise.resolve().then(() => resolver(...))`，避免 pending 条目不注销、请求永不 settle 而悬挂。
  - **用户已表态不被档位翻转**：档位放宽只覆盖「拿不到决策」（无 resolver / 抛错），不推翻用户已经点过的拒绝。

- 明确不包含：
  - **审阅器不可用时仍然静默拒绝**这件事不动 —— 已有 PR 在做（#1597 已合，#1581 / #1590 / #1612 在途），避免重叠。注：CC 侧此行为与 Pi 完全一致（`claude-code/index.ts` 同款 `unavailable` 分支），所以这一项本身不构成 Pi/Claude 的体验差异。
  - **不改 auto-review 的 prompt 措辞**。曾考虑给 `block` 的定义补一条「不得因动作看起来没必要而 block」，但那属于改判定契约、影响三个 harness，且本 PR 的确定性路径已让 orca 不再经过模型；如需推进另开 PR 讨论。
  - **不给第三方 / 非可信 server 开任何口子**：`cindy_ssh`（远端任意命令）、插件宿主 `cindy` 的 `ghost_call`、外部 HTTP MCP 都不在信任表内，照旧逐次确认；`cindy_contacts` 仍走 inner-tool 细粒度策略。
  - `worker` 创建时 `inherited.permissionMode ?? 'bypassPermissions'` 这个 fail-open 兜底（`register.ts:6314`、`orcaInterAgentDispatcher.ts:497`）是独立问题，未混入。
- 用户可见变化：
  - Pi 会话调 orca / memory / helper / scheduler / browser 等**可信第一方 MCP 工具**不再被静默拒绝，也不再弹卡 —— 与 Claude 会话下的体验一致；
  - Pi 会话在**切换权限档位**时，挂着的权限卡会被正确收掉：切到 Full access 立即继续执行（高风险审批除外，仍 fail-closed），切到 Auto / 收紧档位则拒绝并让模型重试 —— 此前调用会一直卡在一张已失效的卡上；
  - 不可信 server 的行为不变（照旧逐次确认）；
  - 只读内置工具（`read`/`grep`/`find`/`ls`）的行为**完全不变**（见上方已撤回项）。
- 是否存在 breaking change：无。

### UI 变化

不涉及：本 PR 只改 maker-core 的权限判定链路与 host deps 接线，不新增/修改任何界面、组件、样式或 UI 文案。权限卡本身（`PermissionPrompt`）未改动。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
# ① 新增回归测试 + 反向验证（把修复临时去掉，确认用例真的会红）
pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
结果：31 passed
  每条修复都做了反向验证（临时回退该修复，确认只打红对应的用例）：
    - MCP 策略分支失效 → 3 failed（新增的 3 条）
    - 入口 Full access 收口失效 → 2 failed
    - 切档 settle 挂起卡失效 → 2 failed
    - auto 当成「放宽」/ 去掉代际门 / 去掉同步 throw 包裹 → 各 1 failed
  证明用例钉住的是真实缺陷而非摆设

# ② Pi 全量（含真 pi 二进制 0.83.0 集成测试）
pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/
结果：Test Files 15 passed | Tests 188 passed | 1 skipped

# ③ 仓库根全量单测门禁
pnpm test:unit
结果：全部 workspace PASS（无 FAIL / 无 TEST_ASSERTION_FAILED）

# ④ typecheck（本次改动涉及的两个 package）
pnpm --filter @cindy/maker-core run --if-present typecheck   → 通过
pnpm --filter desktop run --if-present typecheck             → 通过

# ⑤ DCO
pnpm check:dco
结果：DCO check passed（base upstream/main）
```

新增回归用例（`pi-auto-review-dispatch.test.ts`）：

1. 可信第一方 server（`cindy_orca`）→ **不问模型、不弹卡、直接放行**，且 `userIntent` 刻意设成与协同无关（正是原缺陷的触发条件）；
2. 不可信 server（`cindy_ssh::ssh_exec`）→ 仍逐次确认，且同样不消耗模型审阅；
3. look-alike server 名（`cindy_orca__evil`）→ 不继承第一方信任，落用户确认。

原有那条「送审阅器完整 MCP 证据」的用例保留，并标注清它现在覆盖的是 **host 未提供策略时的兜底路径**。

`pi-auto-review-policy.test.ts` 的用例改为如实钉住只读工具的**可达面**（bridge 不冒泡，只有凭证路径会到达 adapter），防止后人再在该层加不会执行的 scope 补丁。

### 手工验证

真实模型判定实测（这是定位根因的关键证据，见「摘要」）：用真实 `buildAutoPermissionReviewPrompt` 产出的 prompt 原样喂给真实模型，复现了 `block` 分支 —— 意图对齐时 3/3 `allow`，意图无关时 2/2 `block`。

### 未执行的验证

- **未做实机 UI 目检**：本次改动是纯判定逻辑，无 UI 变化，权限卡组件未改动。若需要，可起 dev 实例开 Pi 会话真实点一次 `start_team` 复核。
- **未在 Windows / Linux 实机验证**：改动无平台相关分支（不涉及路径分隔符、进程或原生层）。CI 的 Windows 单测已覆盖本次改动所在的 package。
- 过程中 `pnpm test:unit` 曾有一轮 maker-core 报 1 条失败，定位为 `cindy-protocol` submodule 刚初始化那一轮的偶发；补装依赖后连续两轮全绿。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Pi 会话的工具审批判定（`packages/maker-core/src/agents/pi/**` + `pi-host.ts` 一行 deps 接线）。CC / Codex 的行为**零变化** —— 对它们只是把 `resolveMcpToolTarget` 换成 import 同一份实现，函数体逐字未改。

- 安全边界评估（逐条核实，非推断）：
  - **不放宽既有信任面**：放行范围完全由 `mcp-tool-approval-policy.ts` 既有的 `READ_ONLY_MCP_TOOLS` / `TRUSTED_MCP_SERVERS` / contacts 细粒度策略决定，本 PR 未往这些表里加任何条目。
  - **冒名顶替**：归属判定只认本会话实际注册过的 server 名 + 最长匹配，并有专门用例覆盖 `cindy_orca__evil`。
  - **fail-closed**：策略缺失 / server 认不出 / 策略抛错 / 返回非法值，全部不放行，继续走用户确认。
  - **IM 群等 turn 权限策略不受影响**：Pi 对带 `turnPermissionPolicy` 的 send 是整体 fail-closed 拒绝的（`validateSendOptions` 抛 `TurnPermissionPolicyUnsupportedError`），这类会话根本走不到本分支 —— 不存在绕过 owner 确认的路径。
  - **bridge 侧硬拦不受影响**：凭证路径 / `/proc/*/environ` 的硬拦在 pi 进程内的 bridge，发生在 confirm 之前，且只作用于内置工具集，与 MCP 分支不相交。
  - **挂起卡的批量 settle 只在两个方向上生效**：切到 Full access → allow（`forcePrompt` 的高风险审批仍 deny）；切到 Auto / 更严档位、以及会话关闭 → 一律 deny。放宽不覆盖用户已经点过的拒绝，也不覆盖被更晚意图取代的切换。

- 回滚 / 降级方式：各 commit 独立可 revert（`22aa157` 已由 `021fb88` 撤回，无需再处理）。① 回滚后 Pi 的 MCP 工具回到「进灰区交模型判」的原行为；② 回滚后区外递归读回到静默放行。host 侧只需去掉 `pi-host.ts` 那一行 deps 即可整体停用 ①（`getMcpToolApprovalPolicy` 缺省时代码走 fail-closed 兜底，等价于改动前）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
