### PR TITLE
fix(plugin): 支持真实包权限变化后重新确认

### DIFF
--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -316,6 +316,8 @@ export class GhostManager {
   ): Promise<
     | {
         manifest: GhostManifest;
+        /** 包内原始清单，仅供 Main 安全比较。 */
+        canonicalManifest: GhostManifest;
         trust: GhostTrustInfo;
         packageSha256: string;
         iconDataUrl?: string;
@@ -326,6 +328,7 @@ export class GhostManager {
     if ('rejection' in parsed) return parsed;
     return {
       manifest: parsed.manifest,
+      canonicalManifest: parsed.canonicalManifest,
       trust: parsed.trust,
       packageSha256: parsed.packageSha256,
       ...(parsed.iconDataUrl !== undefined ? { iconDataUrl: parsed.iconDataUrl } : {}),
@@ -338,6 +341,7 @@ export class GhostManager {
   ): Promise<
     | {
         manifest: GhostManifest;
+        canonicalManifest: GhostManifest;
         trust: GhostTrustInfo;
         packageSha256: string;
         iconDataUrl?: string;
@@ -614,6 +618,7 @@ export class GhostManager {
 
     return {
       manifest: localizedManifest,
+      canonicalManifest: v.manifest,
       trust: signature.trust,
       packageSha256: crypto.createHash('sha256').update(buf).digest('hex'),
       ...(iconDataUrl !== undefined ? { iconDataUrl } : {}),

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -535,6 +535,37 @@ describe('GhostManager · inspect(只验不装)', () => {
     expect(onChanged).not.toHaveBeenCalled();
   });
 
+  it('本地化展示清单与包内 canonical 清单分离', async () => {
+    hostLocale = 'zh-CN';
+    const base = {
+      ...goodManifest(),
+      name: 'Base name',
+      locales: {
+        en: 'locales/en.json',
+        'zh-CN': 'locales/zh-CN.json',
+      },
+    };
+    const cindy = await makeCindy('canonical.cindy', base, {
+      'locales/en.json': JSON.stringify({ name: 'English name' }),
+      'locales/zh-CN.json': JSON.stringify({
+        name: '中文名称',
+        tools: { do_thing: { description: '中文工具说明' } },
+      }),
+    });
+
+    const inspected = await manager.inspect(cindy);
+    expect(inspected).toMatchObject({
+      manifest: {
+        name: '中文名称',
+        tools: [{ name: 'do_thing', description: '中文工具说明' }],
+      },
+      canonicalManifest: {
+        name: 'Base name',
+        tools: [{ name: 'do_thing', description: '做点事' }],
+      },
+    });
+  });
+
   it('确认后源文件被替换时，整包指纹不一致会拒绝安装', async () => {
     const cindy = await makeCindy('swap.cindy', goodManifest(), { 'payload.txt': 'before' });
     const inspected = await manager.inspect(cindy);

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -14,6 +14,7 @@ import {
   GHOST_NETWORK_MAX_CONNECTIONS_PER_DECL,
   GHOST_NOTIFY_MIN_INTERVAL_MS,
   diffGhostPermissionItems,
+  ghostPermissionBaselineKey,
   ghostWebviewEntryPaths,
   isCindyAccountGhostId,
   isOfficialGhostId,
@@ -28,6 +29,7 @@ import {
   type GhostVideoResultParams,
   type InstalledGhost,
 } from '../../shared/ghost.js';
+import type { PluginMarketPackageReview } from '../../shared/pluginMarket.js';
 import { getAppCapabilities } from '../appCapabilities.js';
 import {
   activeOwnerScopeKey,
@@ -41,6 +43,7 @@ import { GhostManager, type InstallRejection, type UninstallRejection } from './
 import { exportGhostPackage } from './exportGhostPackage.js';
 import { GhostMutationCoordinator } from './ghostMutationCoordinator.js';
 import { withGhostInstallLock } from './ghostInstallLock.js';
+import { GhostPackagePermissionReviewRequiredError } from './packagePermissionReview.js';
 import {
   clearBuiltinTombstone,
   listEligibleBuiltinCommands,
@@ -3167,10 +3170,13 @@ export async function installOrUpdateMarketGhostPackage(
     version: string;
     /**
      * 装入确认框实际展示给用户的那份 manifest(来源方给的)。给了就逐项比对:
-     * 包里多出来的权限一律拒装(见 Locked 版里的说明)。两条市场路径都必须给;
+     * 包里多出来的权限会暂停落位并交由上层复核。两条市场路径都必须给;
      * 本地 `.cindy` 装入不经此出口,确认框读的就是包本身,没有这层漂移。
      */
     reviewedManifest?: GhostManifest;
+    /** 用户确认过的真实下载包 SHA 与确认时的已装权限基线。 */
+    approvedPackageSha256?: string;
+    reviewedBaseline?: string;
   },
 ): Promise<InstalledGhost> {
   // 卡点:按 ghostId 上锁,覆盖 inspect → 落位整段。服务端与自定义两条市场路径
@@ -3187,6 +3193,8 @@ async function installOrUpdateMarketGhostPackageLocked(
     ghostId: string;
     version: string;
     reviewedManifest?: GhostManifest;
+    approvedPackageSha256?: string;
+    reviewedBaseline?: string;
   },
 ): Promise<InstalledGhost> {
   const mutationOwner = captureGhostMutationOwner();
@@ -3196,8 +3204,8 @@ async function installOrUpdateMarketGhostPackageLocked(
     const inspected = await manager.inspect(cindyFilePath);
     if ('rejection' in inspected) throwInstallError(inspected.rejection);
     if (
-      inspected.manifest.id !== expected.ghostId ||
-      inspected.manifest.version !== expected.version
+      inspected.canonicalManifest.id !== expected.ghostId ||
+      inspected.canonicalManifest.version !== expected.version
     ) {
       throwIpcError(
         'GHOST_FILE_INVALID',
@@ -3215,29 +3223,49 @@ async function installOrUpdateMarketGhostPackageLocked(
      * 未知槽名,投影时会被丢掉或整份拒绝。结果:确认框漏列该项权限,包却原样带着
      * 它装进来,用户**从没审过就多出一个常驻能力面**。
      *
-     * 这里按权限项逐项比对,包里多出来的一律拒装——不是只挡 badge,是把这一整类
-     * 「来源投影漏字段」的洞一次封死。落在 inspect 之后、任何落地动作之前,所以
-     * 拒绝时磁盘上什么都没动,不需要回滚。
+     * 这里按权限项逐项比对。包里多出来的权限先暂停落位,由 Renderer 按真实包
+     * 重新展示；用户批准后携带包 SHA 和已装权限基线重试。
+     * 卡点落在 inspect 之后、任何落地动作之前,所以等待复核时磁盘上什么都没动。
      */
+    const installed = manager.list().find((ghost) => ghost.manifest.id === expected.ghostId);
     if (expected.reviewedManifest) {
-      const unreviewed = diffGhostPermissionItems(
-        expected.reviewedManifest,
-        inspected.manifest,
-      ).added;
-      if (unreviewed.length > 0) {
-        log.warn('market package declares unreviewed permissions', {
-          ghostId: expected.ghostId,
-          keys: unreviewed.map((item) => item.key),
-        });
+      const installedBaseline = installed
+        ? ghostPermissionBaselineKey(installed.manifest)
+        : null;
+      // 真实包复核的批准必须始终绑定当时那份包与已装权限面，不能只在
+      // 当前仍存在来源清单差异时才校验。否则两次请求间包字节发生变化、
+      // 新包恰好不再多权限时，会绕过旧批准的 SHA/基线绑定直接落位。
+      if (
+        expected.approvedPackageSha256 !== undefined &&
+        (expected.approvedPackageSha256 !== inspected.packageSha256 ||
+          (expected.reviewedBaseline ?? null) !== installedBaseline)
+      ) {
         throwIpcError(
           'PRECONDITION_FAILED',
-          '下载包申请的权限多于安装确认框展示的内容,已阻止安装(请向插件来源反馈)',
+          'Downloaded Plugin package changed after permission review',
         );
       }
+      const added = diffGhostPermissionItems(
+        expected.reviewedManifest,
+        inspected.canonicalManifest,
+      ).added;
+      if (added.length > 0) {
+        const review: PluginMarketPackageReview = {
+          manifest: inspected.manifest,
+          packageSha256: inspected.packageSha256,
+          installedBaseline,
+        };
+        if (expected.approvedPackageSha256 === undefined) {
+          log.warn('market package declares unreviewed permissions', {
+            ghostId: expected.ghostId,
+            keys: added.map((item) => item.key),
+          });
+          throw new GhostPackagePermissionReviewRequiredError(review);
+        }
+      }
     }
-    rejectUnauthorizedTokenBroker(inspected.manifest);
+    rejectUnauthorizedTokenBroker(inspected.canonicalManifest);
 
-    const installed = manager.list().find((ghost) => ghost.manifest.id === expected.ghostId);
     // Node 高风险条目由 renderer 装入确认卡权限清单如实展示;
     // 2026-07-24 Lizi 定案:不再有 Main 侧原生二次确认弹窗(PR #333,本处为其
     // 漏删的市场安装路径调用点,一并对齐)。
@@ -4522,7 +4550,12 @@ export function registerGhostIpc(): void {
     // 官方前缀在 inspect 就拒(确认弹窗都不该弹出来),install/update 双保险再拦。
     rejectReservedGhostId(result.manifest.id);
     rejectUnauthorizedTokenBroker(result.manifest);
-    return result;
+    return {
+      manifest: result.manifest,
+      trust: result.trust,
+      packageSha256: result.packageSha256,
+      ...(result.iconDataUrl !== undefined ? { iconDataUrl: result.iconDataUrl } : {}),
+    };
   });
 
   ipcMain.handle('ghosts:uninstall', async (_event, id: unknown) => {

--- a/apps/desktop/src/main/cindy-brain/packagePermissionReview.ts
+++ b/apps/desktop/src/main/cindy-brain/packagePermissionReview.ts
@@ -1,0 +1,8 @@
+import type { PluginMarketPackageReview } from '../../shared/pluginMarket.js';
+
+/** 安装包权限与市场展示不一致时，交给 PluginMarketService 转成可恢复结果。 */
+export class GhostPackagePermissionReviewRequiredError extends Error {
+  constructor(readonly review: PluginMarketPackageReview) {
+    super('The downloaded Plugin package requires permission review');
+  }
+}

--- a/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
@@ -412,7 +412,7 @@ describe('PluginMarketService 自定义市场 detail/install', () => {
       expectedReleaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
       expectedManifest: reviewed.manifest,
     });
-    expect(result.ghost.manifest.id).toBe('alpha');
+    expect(result.ghost?.manifest.id).toBe('alpha');
     expect(runtime.install).toHaveBeenCalledTimes(1);
     // 打包产物是临时文件，装完即删
     expect(runtime.install.mock.calls[0]?.[0]).toMatch(/cindy-custom-market-alpha-.*\.cindy$/);

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -60,6 +60,7 @@ vi.mock('../download.js', () => ({
 import type { VisiblePluginDetail, VisiblePluginSummary } from '@cindy/plugin-protocol';
 
 import { withGhostInstallLock } from '../../cindy-brain/ghostInstallLock';
+import { GhostPackagePermissionReviewRequiredError } from '../../cindy-brain/packagePermissionReview';
 import { PluginMarketLedger } from '../ledger';
 import { PluginMarketService } from '../service';
 import type { PluginMarketApi } from '../api';
@@ -423,14 +424,14 @@ describe('PluginMarketService migration and defaultInstall', () => {
       },
     );
     // 锁定装完即开的最终结果:装入入口返回的 ghost 必须是启用态。
-    expect(ghost.enabled).toBe(true);
+    expect(ghost?.enabled).toBe(true);
   });
 
   // 装入确认框渲染的是**服务端给的** manifest,真正落地的是 .cindy 包里的
   // ghost.json。服务端投影层与客户端清单契约漂移时(cindy-protocol 那份平行
   // 校验器已经缺了 confirm 槽,新字段按「忽略未知字段」被静默丢掉),包会带着
   // 用户没审过的权限装进来。出口处需要这份 reviewedManifest 才能逐项比对拦下。
-  it('passes the reviewed server manifest to the install entry so unreviewed package permissions can be blocked', async () => {
+  it('passes the reviewed server manifest to the install entry so package permissions can be re-reviewed', async () => {
     const item = summary();
     runtime.install.mockResolvedValue({
       manifest: manifest(),
@@ -448,6 +449,63 @@ describe('PluginMarketService migration and defaultInstall', () => {
       id: item.ghostId,
       version: item.currentRelease.version,
     });
+  });
+
+  it('returns a recoverable package review result and forwards the bound approval on retry', async () => {
+    const item = summary();
+    const review = {
+      manifest: manifest('cindy-test', '1.0.0', ['notify', 'fs']),
+      packageSha256: 'a'.repeat(64),
+      installedBaseline: null,
+    };
+    runtime.install.mockRejectedValueOnce(
+      new GhostPackagePermissionReviewRequiredError(review),
+    );
+    const h = harness([item]);
+
+    await expect(
+      h.service.install(item.id, { expectedReleaseId: item.currentRelease.id }),
+    ).resolves.toEqual({ reviewRequired: review });
+    expect(h.ledger.installationForGhost(item.ghostId)).toBeNull();
+
+    runtime.install.mockResolvedValueOnce({
+      manifest: manifest(),
+      dir: '/userData/cindy-brain/cindy-test',
+      enabled: true,
+    });
+    await expect(
+      h.service.install(item.id, {
+        expectedReleaseId: item.currentRelease.id,
+        approvedPackageSha256: review.packageSha256,
+      }),
+    ).resolves.toMatchObject({ ghost: { manifest: { id: item.ghostId } } });
+    expect(runtime.install).toHaveBeenLastCalledWith(
+      expect.stringMatching(/\.cindy$/),
+      expect.objectContaining({ approvedPackageSha256: review.packageSha256 }),
+    );
+  });
+
+  it('does not return package review details after the active owner changes', async () => {
+    const item = summary();
+    const review = {
+      manifest: manifest('cindy-test', '1.0.0', ['notify', 'fs']),
+      packageSha256: 'a'.repeat(64),
+      installedBaseline: null,
+    };
+    runtime.install.mockImplementationOnce(async () => {
+      runtime.session = {
+        mode: 'cloud',
+        dataOwnerId: 'user-2',
+        generation: 2,
+      };
+      throw new GhostPackagePermissionReviewRequiredError(review);
+    });
+    const h = harness([item]);
+
+    await expect(
+      h.service.install(item.id, { expectedReleaseId: item.currentRelease.id }),
+    ).rejects.toThrow('[PRECONDITION_FAILED]');
+    expect(h.ledger.installationForGhost(item.ghostId)).toBeNull();
   });
 
   it('installs and enables a public defaultInstall package in local mode', async () => {

--- a/apps/desktop/src/main/plugin-market/registerIpc.ts
+++ b/apps/desktop/src/main/plugin-market/registerIpc.ts
@@ -80,6 +80,7 @@ export function registerPluginMarketIpc(): void {
               expectedManifest?: unknown;
               allowPermissionExpansion?: unknown;
               reviewedBaseline?: unknown;
+              approvedPackageSha256?: unknown;
             })
           : null;
       const expectedReleaseId = requireString(obj?.expectedReleaseId, 'expectedReleaseId');
@@ -91,12 +92,23 @@ export function registerPluginMarketIpc(): void {
       // 扩权批准的审阅基线:只收字符串,野值按缺席处理(缺席 = 保持旧行为)。
       const reviewedBaseline =
         typeof obj?.reviewedBaseline === 'string' ? obj.reviewedBaseline : undefined;
+      const approvedPackageSha256 =
+        typeof obj?.approvedPackageSha256 === 'string'
+          ? obj.approvedPackageSha256
+          : undefined;
+      if (
+        approvedPackageSha256 !== undefined &&
+        !/^[a-f0-9]{64}$/.test(approvedPackageSha256)
+      ) {
+        throwIpcError('INVALID_PARAMS', 'approvedPackageSha256 is invalid');
+      }
       return invokePluginMarket(() =>
         service().install(requireString(pluginId, 'pluginId'), {
           expectedReleaseId,
           ...(expectedManifest ? { expectedManifest: expectedManifest as unknown as GhostManifest } : {}),
           allowPermissionExpansion,
           ...(reviewedBaseline !== undefined ? { reviewedBaseline } : {}),
+          ...(approvedPackageSha256 !== undefined ? { approvedPackageSha256 } : {}),
         }),
       );
     },

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -21,6 +21,8 @@ import type {
   MarketSourceConfig,
   MarketSourceSummary,
   PluginMarketDetail,
+  PluginMarketInstallOptions,
+  PluginMarketInstallResult,
   PluginMarketItem,
   PluginMarketSnapshot,
 } from '../../shared/pluginMarket.js';
@@ -52,6 +54,7 @@ import {
   readBoundedFileNoFollowSync,
 } from '../utils/readBoundedFile.js';
 import { withGhostInstallLock } from '../cindy-brain/ghostInstallLock.js';
+import { GhostPackagePermissionReviewRequiredError } from '../cindy-brain/packagePermissionReview.js';
 import { PluginMarketApi } from './api.js';
 import { downloadVerifiedPlugin } from './download.js';
 import { installCustomMarketPlugin } from './install.js';
@@ -405,23 +408,8 @@ export class PluginMarketService {
 
   async install(
     pluginId: string,
-    options: {
-      /** Renderer 确认框实际展示过的 release。Main 重拉详情后必须仍一致,
-       *  否则用户审阅 A、实际安装/启用 B(review P1)。 */
-      expectedReleaseId: string;
-      /** 自定义市场插件：Renderer 确认框实际审阅过的完整 manifest。 */
-      expectedManifest?: GhostManifest;
-      allowPermissionExpansion?: boolean;
-      /**
-       * 扩权批准所依据的**已装 manifest 权限指纹**
-       * (`ghostPermissionBaselineKey`)。带 allowPermissionExpansion 时应一并
-       * 传入:Main 在安装锁内用当前已装 manifest 重算比对,不一致说明审阅与
-       * 现实已经脱节(典型是审阅期间「从文件更新」换了包),此时拒绝这次批准
-       * 而不是拿旧批准放行相对新 manifest 的全部新增权限。
-       */
-      reviewedBaseline?: string;
-    },
-  ): Promise<{ ghost: InstalledGhost }> {
+    options: PluginMarketInstallOptions,
+  ): Promise<PluginMarketInstallResult> {
     const customRef = parseCustomMarketPluginId(pluginId);
     if (customRef) {
       if (!options.expectedManifest) {
@@ -484,6 +472,9 @@ export class PluginMarketService {
             ...(options.reviewedBaseline !== undefined
               ? { reviewedBaseline: options.reviewedBaseline }
               : {}),
+            ...(options.approvedPackageSha256 !== undefined
+              ? { approvedPackageSha256: options.approvedPackageSha256 }
+              : {}),
             // 下载可能持续数分钟,提交副作用前按当前事实再算一次。
             recheckOwnership: assertOwnership,
           },
@@ -491,6 +482,12 @@ export class PluginMarketService {
           ledger,
         ),
       };
+    }).catch((error: unknown) => {
+      if (error instanceof GhostPackagePermissionReviewRequiredError) {
+        requireSameMarketOwner(owner);
+        return { reviewRequired: error.review };
+      }
+      throw error;
     });
   }
 
@@ -1084,6 +1081,8 @@ export class PluginMarketService {
       allowPermissionExpansion?: boolean;
       /** 扩权批准所依据的已装权限指纹;安装锁内复核,详见 install() 的说明。 */
       reviewedBaseline?: string;
+      /** 用户确认过的真实下载包 SHA。 */
+      approvedPackageSha256?: string;
       /** 确认操作时的安装意图;下载窗口期目标被另一窗口卸载时拒绝滑入首装。 */
       expectedInstalled: boolean;
       /**
@@ -1188,10 +1187,16 @@ export class PluginMarketService {
           const installed = await installOrUpdateMarketGhostPackage(tempPath, {
             ghostId: plugin.ghostId,
             version: plugin.currentRelease.version,
-            // 确认框渲染的就是这份服务端 manifest;包里若多出权限项,出口处拒装
-            // ——服务端投影层与客户端清单契约漂移时,用户会在没审过的情况下多拿
-            // 一个能力面(codex review P1)。
+            // 确认框渲染的就是这份服务端 manifest;包里若多出权限项,出口处先
+            // 暂停落位并返回真实包权限——服务端投影层与客户端清单契约漂移时,
+            // 必须让用户按实际要安装的能力面重新确认。
             reviewedManifest: compatible.manifest,
+            ...(options.approvedPackageSha256 !== undefined
+              ? {
+                  approvedPackageSha256: options.approvedPackageSha256,
+                  reviewedBaseline: options.reviewedBaseline,
+                }
+              : {}),
           });
           // Once the package directory is committed, finish provenance against
           // the owner captured at operation start even if the active session

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1083,14 +1083,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('plugin-market:detail', pluginId),
     install: (
       pluginId: string,
-      options: {
-        expectedReleaseId: string;
-        expectedManifest?: import('../shared/ghost').GhostManifest;
-        allowPermissionExpansion?: boolean;
-        /** 扩权批准所依据的已装权限指纹;Main 在安装锁内复核后才放行扩权。 */
-        reviewedBaseline?: string;
-      },
-    ): Promise<{ ghost: import('../shared/ghost').InstalledGhost }> =>
+      options: import('../shared/pluginMarket').PluginMarketInstallOptions,
+    ): Promise<import('../shared/pluginMarket').PluginMarketInstallResult> =>
       ipcRenderer.invoke('plugin-market:install', pluginId, options),
     uninstall: (pluginId: string): Promise<{ ok: true }> =>
       ipcRenderer.invoke('plugin-market:uninstall', pluginId),

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -68,9 +68,11 @@ import {
   ghostPermissionItems,
   isOfficialGhostId,
   type GhostSetupStatus,
+  type InstalledGhost,
 } from '../../../shared/ghost';
 import type {
   PluginMarketDetail,
+  PluginMarketInstallOptions,
   PluginMarketItem,
   PluginMarketSnapshot,
 } from '../../../shared/pluginMarket';
@@ -652,6 +654,57 @@ export function GhostPluginPage() {
     [t],
   );
 
+  /**
+   * 市场详情与真实下载包权限不一致时，展示 Main 验证后的真实权限并绑定重试。
+   * Renderer 只负责确认；包 SHA 和已装权限基线均由 Main 重新核对。
+   */
+  const installReviewedMarketPackage = useCallback(
+    async (input: {
+      detail: PluginMarketDetail;
+      lease: { pluginId: string };
+      options: PluginMarketInstallOptions;
+    }): Promise<InstalledGhost | null> => {
+      const initial = await window.electronAPI.pluginMarket.install(
+        input.detail.pluginId,
+        input.options,
+      );
+      if (initial.ghost !== undefined) return initial.ghost;
+      if (!isMarketBusyLeaseActive(input.lease)) return null;
+
+      const review = initial.reviewRequired;
+      if (!review) return null;
+      const approved = await confirm({
+        title: t('settings.ghosts.market.installConfirmTitle', {
+          name: input.detail.name,
+        }),
+        description: t('settings.ghosts.market.installConfirmDescription'),
+        content: <GhostPermissionList items={ghostPermissionItems(review.manifest)} />,
+        maxWidth: 520,
+        confirmText: t('settings.ghosts.market.install'),
+        cancelText: t('settings.ghosts.installConfirm.cancel'),
+        autoFocusConfirm: true,
+      });
+      if (!approved || !isMarketBusyLeaseActive(input.lease)) return null;
+
+      const retried = await window.electronAPI.pluginMarket.install(
+        input.detail.pluginId,
+        {
+          ...input.options,
+          allowPermissionExpansion: review.installedBaseline !== null,
+          reviewedBaseline: review.installedBaseline ?? undefined,
+          approvedPackageSha256: review.packageSha256,
+        },
+      );
+      if (retried.ghost !== undefined) return retried.ghost;
+
+      // 同一 release 的真实包不应漂移；再次要求复核说明已装基线在往返窗口内变化。
+      toast.error(t('settings.ghosts.market.errors.stateChanged'));
+      await refreshMarket();
+      return null;
+    },
+    [confirm, isMarketBusyLeaseActive, refreshMarket, t],
+  );
+
   // 市场更新流程由列表卡片和详情页共用:先取目标 release 的完整 manifest 做
   // 权限 diff,经用户确认后才安装,不做静默升级。
   const handleMarketUpdate = useCallback(
@@ -681,21 +734,26 @@ export function GhostPluginPage() {
           cancelText: t('settings.ghosts.updateConfirm.cancel'),
         });
         if (!approved || !isMarketBusyLeaseActive(marketBusyLease)) return;
-        const result = await window.electronAPI.pluginMarket.install(marketItem.pluginId, {
-          expectedReleaseId: next.releaseId,
-          ...(next.sourceType !== 'server' ? { expectedManifest: next.manifest } : {}),
-          allowPermissionExpansion: diff.added.length > 0,
-          // 用户看确认框这段时间里已装 manifest 可能被换掉(如从文件更新);
-          // 把审阅基线交给 Main,在安装锁内复核后才放行扩权。
-          ...(installedGhost
-            ? { reviewedBaseline: ghostPermissionBaselineKey(installedGhost.manifest) }
-            : {}),
+        const ghost = await installReviewedMarketPackage({
+          detail: next,
+          lease: marketBusyLease,
+          options: {
+            expectedReleaseId: next.releaseId,
+            ...(next.sourceType !== 'server' ? { expectedManifest: next.manifest } : {}),
+            allowPermissionExpansion: diff.added.length > 0,
+            // 用户看确认框这段时间里已装 manifest 可能被换掉(如从文件更新);
+            // 把审阅基线交给 Main,在安装锁内复核后才放行扩权。
+            ...(installedGhost
+              ? { reviewedBaseline: ghostPermissionBaselineKey(installedGhost.manifest) }
+              : {}),
+          },
         });
+        if (!ghost) return;
         if (!isMarketBusyLeaseActive(marketBusyLease)) return;
         toast.success(
           t('settings.ghosts.toast.updated', {
-            name: result.ghost.manifest.name,
-            version: result.ghost.manifest.version,
+            name: ghost.manifest.name,
+            version: ghost.manifest.version,
           }),
         );
         await refreshMarket();
@@ -712,6 +770,7 @@ export function GhostPluginPage() {
       confirm,
       ghosts,
       isMarketBusyLeaseActive,
+      installReviewedMarketPackage,
       marketByGhostId,
       refreshMarket,
       releaseMarketBusy,
@@ -1056,39 +1115,44 @@ export function GhostPluginPage() {
         autoFocusConfirm: true,
       });
       if (!confirmed || !isMarketBusyLeaseActive(marketBusyLease)) return;
-      const result = await window.electronAPI.pluginMarket.install(marketDetail.pluginId, {
-        expectedReleaseId: marketDetail.releaseId,
-        ...(marketDetail.sourceType !== 'server'
-          ? { expectedManifest: marketDetail.manifest }
-          : {}),
-        ...(isUpdate && diff!.added.length > 0
-          ? {
-              allowPermissionExpansion: true,
-              // 确认框展示期间已装 manifest 可能被换掉;基线交由 Main 在
-              // 安装锁内复核,不一致就拒绝这次批准而不是沿用旧同意。
-              ...(installedGhost
-                ? { reviewedBaseline: ghostPermissionBaselineKey(installedGhost.manifest) }
-                : {}),
-            }
-          : {}),
+      const ghost = await installReviewedMarketPackage({
+        detail: marketDetail,
+        lease: marketBusyLease,
+        options: {
+          expectedReleaseId: marketDetail.releaseId,
+          ...(marketDetail.sourceType !== 'server'
+            ? { expectedManifest: marketDetail.manifest }
+            : {}),
+          ...(isUpdate && diff!.added.length > 0
+            ? {
+                allowPermissionExpansion: true,
+                // 确认框展示期间已装 manifest 可能被换掉;基线交由 Main 在
+                // 安装锁内复核,不一致就拒绝这次批准而不是沿用旧同意。
+                ...(installedGhost
+                  ? { reviewedBaseline: ghostPermissionBaselineKey(installedGhost.manifest) }
+                  : {}),
+              }
+            : {}),
+        },
       });
+      if (!ghost) return;
       if (!isMarketBusyLeaseActive(marketBusyLease)) return;
       // 市场首装装完即开(2026-07-26 定案),toast 用"已安装";更新路径如实
       // 用"已更新"(生效状态未被改变)。
       toast.success(
         isUpdate
           ? t('settings.ghosts.toast.updated', {
-              name: result.ghost.manifest.name,
-              version: result.ghost.manifest.version,
+              name: ghost.manifest.name,
+              version: ghost.manifest.version,
             })
           : t('settings.ghosts.toast.installed', {
-              name: result.ghost.manifest.name,
+              name: ghost.manifest.name,
             }),
       );
       setMarketDetail((current) =>
         current?.pluginId === marketDetail.pluginId ? null : current,
       );
-      setSelectedId(result.ghost.manifest.id);
+      setSelectedId(ghost.manifest.id);
       await refreshMarket();
     } catch (error) {
       if (isMarketBusyLeaseActive(marketBusyLease)) {
@@ -1102,6 +1166,7 @@ export function GhostPluginPage() {
     confirm,
     ghosts,
     isMarketBusyLeaseActive,
+    installReviewedMarketPackage,
     refreshMarket,
     releaseMarketBusy,
     t,

--- a/apps/desktop/src/renderer/features/plugin/__tests__/updateAllController.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/updateAllController.test.ts
@@ -21,7 +21,7 @@ import {
   setDataOwnerGeneration,
 } from '@/contexts/dataOwnerGeneration';
 import { toast } from '@/lib/toast';
-import type { GhostManifest } from '../../../../shared/ghost';
+import { ghostPermissionBaselineKey, type GhostManifest } from '../../../../shared/ghost';
 import type { PluginMarketDetail, PluginMarketItem } from '../../../../shared/pluginMarket';
 import {
   __resetUpdateAllBatchForTest,
@@ -112,6 +112,32 @@ describe('updateAllController', () => {
 
     expect(getUpdateAllBatchState().rows?.[0]?.status).toBe('skipped');
     expect(installMock).not.toHaveBeenCalled();
+  });
+
+  it('holds actual package permissions for approval', async () => {
+    stubDetail({ manifest: manifest({}), sourceType: 'server' });
+    const review = {
+      manifest: manifest({ network: { hosts: ['api.example.com'] } }),
+      packageSha256: 'a'.repeat(64),
+      installedBaseline: ghostPermissionBaselineKey(installedGhosts[0].manifest),
+    };
+    installMock.mockResolvedValueOnce({ reviewRequired: review } as never);
+
+    startUpdateAllBatch([marketItem({})]);
+    await waitForSettledBatch();
+    expect(getUpdateAllBatchState().rows?.[0]).toMatchObject({
+      status: 'needs-confirm',
+      releaseId: 'release-2',
+      packageReview: review,
+    });
+
+    await approveUpdateExpansion('plugin-a');
+    expect(installMock).toHaveBeenLastCalledWith(
+      'plugin-a',
+      expect.objectContaining({
+        approvedPackageSha256: review.packageSha256,
+      }),
+    );
   });
 
   it('passes the reviewed manifest back when approving a non-server expansion', async () => {

--- a/apps/desktop/src/renderer/features/plugin/__tests__/updateAllController.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/updateAllController.test.ts
@@ -1,7 +1,7 @@
 /**
  * Regression coverage for the module-level update-all batch controller:
- * uninstall guards, reviewed-manifest passthrough on approval, and batch
- * state surviving page unmount (review 定稿 2026-08-02).
+ * uninstall guards, reviewed-manifest passthrough, package-review baseline
+ * drift recovery, and batch state surviving page unmount (review 定稿 2026-08-04).
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  * @vitest-environment jsdom
  */
@@ -138,6 +138,36 @@ describe('updateAllController', () => {
         approvedPackageSha256: review.packageSha256,
       }),
     );
+  });
+
+  it('keeps package review recoverable when the installed baseline drifts in flight', async () => {
+    stubDetail({ manifest: manifest({}), sourceType: 'server' });
+    const review = {
+      manifest: manifest({ network: { hosts: ['api.example.com'] } }),
+      packageSha256: 'a'.repeat(64),
+      installedBaseline: ghostPermissionBaselineKey(installedGhosts[0].manifest),
+    };
+    installMock.mockImplementationOnce(async () => {
+      installedGhosts = [{ manifest: manifest({ version: '1.0.5', slots: ['fs'] }) }];
+      return { reviewRequired: review } as never;
+    });
+
+    startUpdateAllBatch([marketItem({})]);
+    await waitForSettledBatch();
+
+    expect(getUpdateAllBatchState().rows?.[0]).toMatchObject({
+      status: 'needs-confirm',
+      staleReview: true,
+      releaseId: 'release-2',
+      fromVersion: '1.0.5',
+      toVersion: '1.1.0',
+    });
+
+    await approveUpdateExpansion('plugin-a');
+    expect(installMock).toHaveBeenLastCalledWith('plugin-a', {
+      expectedReleaseId: 'release-2',
+    });
+    expect(getUpdateAllBatchState().rows?.[0]?.status).toBe('done');
   });
 
   it('passes the reviewed manifest back when approving a non-server expansion', async () => {

--- a/apps/desktop/src/renderer/features/plugin/lib/updateAllController.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/updateAllController.ts
@@ -8,7 +8,8 @@
  * 为什么在组件外:批次可以在用户关掉弹窗、离开 /plugins 后继续跑
  * (「后台继续」语义),待确认的扩权项也必须在回到插件页后仍然保留
  * 批准/跳过入口——状态生命周期必须长于页面组件,所以照
- * useInstalledGhosts 的先例做成模块级单例 store。
+ * useInstalledGhosts 的先例做成模块级单例 store。真实包复核返回期间若
+ * 已装权限基线漂移,保留目标 release 并退回可恢复的重新审阅状态。
  * [PROTOCOL]: 变更时更新此头部，然后检查 CLAUDE.md
  */
 
@@ -210,7 +211,12 @@ function holdPackageReview(
   }
   const reviewedBaseline = ghostPermissionBaselineKey(installed);
   if (reviewedBaseline !== review.installedBaseline) {
-    holdRowForReReview(generation, row.pluginId);
+    holdRowForReReview(generation, row.pluginId, {
+      releaseId: row.releaseId,
+      fromVersion: installed.version,
+      toVersion: row.toVersion,
+      expectedManifest: undefined,
+    });
     return;
   }
   patchRow(generation, row.pluginId, {

--- a/apps/desktop/src/renderer/features/plugin/lib/updateAllController.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/updateAllController.ts
@@ -26,7 +26,10 @@ import {
   ghostPermissionBaselineKey,
   type GhostManifest,
 } from '../../../../shared/ghost';
-import type { PluginMarketItem } from '../../../../shared/pluginMarket';
+import type {
+  PluginMarketItem,
+  PluginMarketPackageReview,
+} from '../../../../shared/pluginMarket';
 import { pluginMarketErrorKey } from './pluginMarketErrorKey';
 import {
   batchSummary,
@@ -152,6 +155,7 @@ function holdRowForReReview(
     status: 'needs-confirm',
     staleReview: true,
     permissionDiff: undefined,
+    packageReview: undefined,
     ...patch,
     releaseId,
   });
@@ -188,6 +192,38 @@ function installedManifestOf(ghostId: string): GhostManifest | null {
   return (
     readInstalledGhostsSnapshot().find((ghost) => ghost.manifest.id === ghostId)?.manifest ?? null
   );
+}
+
+function holdPackageReview(
+  generation: number,
+  row: Pick<UpdateAllRow, 'pluginId' | 'ghostId'> & {
+    releaseId: string;
+    toVersion: string;
+    expectedManifest?: GhostManifest;
+  },
+  review: PluginMarketPackageReview,
+): void {
+  const installed = installedManifestOf(row.ghostId);
+  if (!installed) {
+    patchRow(generation, row.pluginId, { status: 'skipped' });
+    return;
+  }
+  const reviewedBaseline = ghostPermissionBaselineKey(installed);
+  if (reviewedBaseline !== review.installedBaseline) {
+    holdRowForReReview(generation, row.pluginId);
+    return;
+  }
+  patchRow(generation, row.pluginId, {
+    status: 'needs-confirm',
+    fromVersion: installed.version,
+    toVersion: row.toVersion,
+    releaseId: row.releaseId,
+    permissionDiff: diffGhostPermissionItems(installed, review.manifest),
+    staleReview: false,
+    reviewedBaseline,
+    packageReview: review,
+    expectedManifest: row.expectedManifest,
+  });
 }
 
 async function refreshMarketIfMounted(): Promise<void> {
@@ -285,10 +321,24 @@ async function runQueue(generation: number): Promise<void> {
           });
           continue;
         }
-        await window.electronAPI.pluginMarket.install(next.pluginId, {
+        const result = await window.electronAPI.pluginMarket.install(next.pluginId, {
           expectedReleaseId: detail.releaseId,
           ...(detail.sourceType !== 'server' ? { expectedManifest: detail.manifest } : {}),
         });
+        if (result.reviewRequired) {
+          holdPackageReview(
+            generation,
+            {
+              pluginId: next.pluginId,
+              ghostId: next.ghostId,
+              releaseId: detail.releaseId,
+              toVersion: detail.version,
+              ...(detail.sourceType !== 'server' ? { expectedManifest: detail.manifest } : {}),
+            },
+            result.reviewRequired,
+          );
+          continue;
+        }
         patchRow(generation, next.pluginId, { status: 'done' });
       } catch (error) {
         if (batchGeneration !== generation) return;
@@ -440,6 +490,7 @@ async function runApprovalBody(pluginId: string, generation: number): Promise<vo
         permissionDiff: diffGhostPermissionItems(installed, detail.manifest),
         staleReview: false,
         reviewedBaseline: ghostPermissionBaselineKey(installed),
+        packageReview: undefined,
         expectedManifest: detail.sourceType !== 'server' ? detail.manifest : undefined,
       });
     };
@@ -478,7 +529,21 @@ async function runApprovalBody(pluginId: string, generation: number): Promise<vo
       options: Parameters<typeof window.electronAPI.pluginMarket.install>[1],
     ): Promise<boolean> => {
       try {
-        await window.electronAPI.pluginMarket.install(pluginId, options);
+        const result = await window.electronAPI.pluginMarket.install(pluginId, options);
+        if (result.reviewRequired) {
+          holdPackageReview(
+            generation,
+            {
+              pluginId,
+              ghostId: row.ghostId,
+              releaseId: detail.releaseId,
+              toVersion: detail.version,
+              ...(detail.sourceType !== 'server' ? { expectedManifest: detail.manifest } : {}),
+            },
+            result.reviewRequired,
+          );
+          return false;
+        }
         return true;
       } catch (error) {
         if (batchGeneration !== generation) return false;
@@ -508,6 +573,9 @@ async function runApprovalBody(pluginId: string, generation: number): Promise<vo
         // renderer 这边的检查挡不住 IPC 往返窗口内的替换。
         ...(row.reviewedBaseline !== undefined
           ? { reviewedBaseline: row.reviewedBaseline }
+          : {}),
+        ...(row.packageReview
+          ? { approvedPackageSha256: row.packageReview.packageSha256 }
           : {}),
       });
       if (!didInstall) return;
@@ -586,6 +654,7 @@ export function reconcileUpdateAllBatch(marketItems: readonly PluginMarketItem[]
         fromVersion: installed.version,
         permissionDiff: undefined,
         staleReview: true,
+        packageReview: undefined,
       });
       changed = true;
     } else if (installed.version !== row.fromVersion) {

--- a/apps/desktop/src/renderer/features/plugin/lib/updateAllModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/updateAllModel.ts
@@ -8,7 +8,10 @@
  */
 
 import type { GhostManifest, GhostPermissionDiff } from '../../../../shared/ghost';
-import type { PluginMarketItem } from '../../../../shared/pluginMarket';
+import type {
+  PluginMarketItem,
+  PluginMarketPackageReview,
+} from '../../../../shared/pluginMarket';
 
 /**
  * 批量更新策略(设计定稿):权限无变化的自动串行完成;权限有扩张的
@@ -51,6 +54,8 @@ export interface UpdateAllRow {
    * 传回同一份 reviewed manifest,approve 必须原样带上,否则 INVALID_PARAMS。
    */
   expectedManifest?: GhostManifest;
+  /** 实际下载包等待用户确认的权限事实。 */
+  packageReview?: PluginMarketPackageReview;
   /** status 为 failed 时的用户可读错误(已经过 i18n 映射)。 */
   errorText?: string;
 }

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1411,12 +1411,8 @@ interface ElectronAPI {
     ) => Promise<import('../shared/pluginMarket').PluginMarketDetail>;
     install: (
       pluginId: string,
-      options: {
-        expectedReleaseId: string;
-        expectedManifest?: import('../shared/ghost').GhostManifest;
-        allowPermissionExpansion?: boolean;
-      },
-    ) => Promise<{ ghost: import('../shared/ghost').InstalledGhost }>;
+      options: import('../shared/pluginMarket').PluginMarketInstallOptions,
+    ) => Promise<import('../shared/pluginMarket').PluginMarketInstallResult>;
     uninstall: (pluginId: string) => Promise<{ ok: true }>;
     listSources: () => Promise<import('../shared/pluginMarket').MarketSourceSummary[]>;
     pickLocalSource: (

--- a/apps/desktop/src/shared/pluginMarket.ts
+++ b/apps/desktop/src/shared/pluginMarket.ts
@@ -1,4 +1,4 @@
-import type { GhostManifest } from './ghost';
+import type { GhostManifest, InstalledGhost } from './ghost';
 import type { PluginIconMetadata } from '@cindy/plugin-protocol';
 
 export type PluginMarketScope = 'public' | 'organization' | 'personal';
@@ -44,6 +44,32 @@ export interface PluginMarketSnapshot {
 export interface PluginMarketDetail extends PluginMarketItem {
   manifest: GhostManifest;
 }
+
+/** Main 验证真实下载包后，交给 Renderer 展示的权限复核事实。 */
+export interface PluginMarketPackageReview {
+  /** 已按当前界面语言本地化，仅用于展示；安全指纹由 Main 基于原始清单计算。 */
+  manifest: GhostManifest;
+  packageSha256: string;
+  /** 产生复核结果时的已装权限基线；null 表示当时尚未安装。 */
+  installedBaseline: string | null;
+}
+
+export interface PluginMarketInstallOptions {
+  /** 用户审阅时看到的目标 release；Main 会在下载前重新核对。 */
+  expectedReleaseId: string;
+  /** 自定义市场审阅过的完整清单；服务端市场由 Main 读取 release 清单。 */
+  expectedManifest?: GhostManifest;
+  allowPermissionExpansion?: boolean;
+  /** 用户审阅扩权时的已装权限基线。 */
+  reviewedBaseline?: string;
+  /** 用户确认过的真实下载包；Main 会重新下载并核对 SHA。 */
+  approvedPackageSha256?: string;
+}
+
+/** 安装成功，或真实包权限与市场展示不一致而需要用户复核。 */
+export type PluginMarketInstallResult =
+  | { ghost: InstalledGhost; reviewRequired?: never }
+  | { ghost?: never; reviewRequired: PluginMarketPackageReview };
 
 /* ------------------------------------------------------------------------ */
 /* 自定义市场源（Git / 本地文件夹）                                           */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 客户端更新市场插件时，权限比较误用本地化 manifest 导致正常更新被拒绝的问题。安全比较现在始终使用包内已校验的 canonical manifest；如果真实下载包确实比市场确认页多出权限，不再直接报错终止，而是把 Main 验证后的真实权限交给现有确认弹窗，用户确认后继续安装。

重试会重新下载并绑定 Release、包 SHA、已安装权限基线和数据 owner；任一事实变化都在落盘、启用和账本写入前停止。列表/详情单项更新和“全部更新”均覆盖该恢复路径。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：客户端市场插件更新在 manifest 权限或本地化文案变化时无法继续安装
- 本 PR 包含：Desktop Main 权限裁决、现有安装 IPC 返回联合类型、单项/批量更新恢复流程及回归测试
- 明确不包含：服务端改动、`ghost.json`/插件包格式变更、持久化 schema/批准 receipt、作者契约变更
- 用户可见变化：真实包出现未展示权限时，会再次显示完整权限确认；确认后继续更新，不再只能看到通用报错
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4「Dialog & Modal」复用现有 `ConfirmDialog` 和权限列表；§14.2「Focus Management」继续使用 `autoFocusConfirm`；§10「Light / Dark Dual-Mode Delivery Gate」复用现有 token 化组件，不新增颜色、样式或主题分支。
- 不新增页面、布局、视觉样式或文案；只在 Main 返回真实包复核事实时复用首次安装的确认交互。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；脚本自测、Desktop、Mobile 与所有必跑 workspace 均 PASS

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/GhostManager.test.ts src/main/plugin-market/__tests__/service.test.ts src/renderer/features/plugin/__tests__/updateAllController.test.ts
结果：3 个文件、124 条测试通过

pnpm check:i18n
结果：通过，四语言 key 对齐；只有仓库既有非阻塞警告

pnpm check:i18n-glossary
结果：通过，无新增术语违规

pnpm --filter desktop exec eslint src/main/cindy-brain/__tests__/GhostManager.test.ts src/main/cindy-brain/packagePermissionReview.ts src/main/plugin-market/__tests__/service-custom-sources.test.ts src/main/plugin-market/__tests__/service.test.ts src/main/plugin-market/registerIpc.ts src/main/plugin-market/service.ts src/preload/preload.ts src/renderer/features/plugin/GhostPluginPage.tsx src/renderer/features/plugin/__tests__/updateAllController.test.ts src/renderer/features/plugin/lib/updateAllController.ts src/renderer/features/plugin/lib/updateAllModel.ts src/renderer/vite-env.d.ts src/shared/pluginMarket.ts
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签署
```

### 手工验证

- macOS，命名隔离沙箱 `--isolated=plugin-permission-rereview`，核对窗口来自本 worktree，未使用正式版或其它 dev 实例。
- 官方 GitHub 插件模拟 `1.2.1 → 1.2.2` 普通更新：更新完成，未再出现“插件或版本已发生变化”的原错误。
- 在隔离数据中移除旧版 `notify` 权限后更新：现有更新确认页显示新增“可弹出系统提示”，确认后更新完成；随后核对磁盘恢复官方 `1.2.2` manifest、Release ID 与 SHA。

### 未执行的验证

- 未在 Windows 手工走查；本次为纯 TypeScript/IPC 状态流，无新增平台分支或原生 API。
- 未单独手工构造“服务端清单缺字段、真实包多权限”分支（当前官方 Release 无法在不改服务端的情况下稳定构造）；Service 结果转换和批量恢复状态由自动测试覆盖。
- Desktop 全量 lint 未作为通过项：主分支已有 164 条无关错误。本次逐文件 lint 时，两个被触及的大文件仍只报告主分支既有 8 条错误（`GhostManager.ts:154`、`index.ts:3077-3097`，均不在 diff）；其余 13 个变更文件定向 lint 通过。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop 插件市场安装/更新流程。Main 仍是唯一安全裁决者；Renderer 只展示并回传确认绑定信息。账号切换时不会把旧 owner 的真实包清单返回当前界面。
- 存量插件影响：无。未改变安装目录、批准状态、manifest 校验契约、包格式、运行时授权记录或布局；不会在客户端升级时要求已安装插件重装/重新确认。不命中旧布局升级路径，因此无需迁移或旧布局 fixture。
- 作者契约影响：无。未改变 `ghost.json` 字段、slot、validator 或打包格式，无需同步 `FORGE_GUIDE`。
- 插件基座改动：按仓库规则需要白名单把关人明确 Approve。
- 回滚 / 降级方式：回滚本提交即可恢复旧客户端行为；无数据 migration，也无需回滚用户数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无作者契约文档需要同步）
- [x] 已确认测试结果或说明未执行原因
