### PR TITLE
fix(desktop): preserve legacy plugin permission approvals

### DIFF
--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -13,8 +13,8 @@ import {
   GHOST_CARD_HEIGHT_MIN,
   GHOST_NETWORK_MAX_CONNECTIONS_PER_DECL,
   GHOST_NOTIFY_MIN_INTERVAL_MS,
-  diffGhostPermissionItems,
   ghostPermissionBaselineKey,
+  unreviewedGhostPermissionItems,
   ghostWebviewEntryPaths,
   isCindyAccountGhostId,
   isOfficialGhostId,
@@ -3174,6 +3174,11 @@ export async function installOrUpdateMarketGhostPackage(
      * 本地 `.cindy` 装入不经此出口,确认框读的就是包本身,没有这层漂移。
      */
     reviewedManifest?: GhostManifest;
+    /**
+     * 经市场账本摘要认证的旧版已安装清单。历史详情投影漏掉、但用户此前
+     * 已批准的权限可继续作为基线；未被该基线覆盖的真实包权限仍走复核。
+     */
+    previouslyInstalledManifest?: GhostManifest;
     /** 用户确认过的真实下载包 SHA 与确认时的已装权限基线。 */
     approvedPackageSha256?: string;
     reviewedBaseline?: string;
@@ -3193,6 +3198,7 @@ async function installOrUpdateMarketGhostPackageLocked(
     ghostId: string;
     version: string;
     reviewedManifest?: GhostManifest;
+    previouslyInstalledManifest?: GhostManifest;
     approvedPackageSha256?: string;
     reviewedBaseline?: string;
   },
@@ -3245,10 +3251,11 @@ async function installOrUpdateMarketGhostPackageLocked(
           'Downloaded Plugin package changed after permission review',
         );
       }
-      const added = diffGhostPermissionItems(
+      const added = unreviewedGhostPermissionItems(
         expected.reviewedManifest,
+        expected.previouslyInstalledManifest,
         inspected.canonicalManifest,
-      ).added;
+      );
       if (added.length > 0) {
         const review: PluginMarketPackageReview = {
           manifest: inspected.manifest,

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -61,7 +61,7 @@ import type { VisiblePluginDetail, VisiblePluginSummary } from '@cindy/plugin-pr
 
 import { withGhostInstallLock } from '../../cindy-brain/ghostInstallLock';
 import { GhostPackagePermissionReviewRequiredError } from '../../cindy-brain/packagePermissionReview';
-import { PluginMarketLedger } from '../ledger';
+import { PluginMarketLedger, ghostManifestDigest } from '../ledger';
 import { PluginMarketService } from '../service';
 import type { PluginMarketApi } from '../api';
 
@@ -508,6 +508,95 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(h.ledger.installationForGhost(item.ghostId)).toBeNull();
   });
 
+  it('uses a digest-matched installed manifest as the legacy approval baseline', async () => {
+    const item = summary({
+      currentRelease: { ...summary().currentRelease, id: 'release-2', version: '2.0.0' },
+    });
+    const installed = manifest(item.ghostId, '1.0.0', ['notify', 'fs']);
+    const installedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-installed-ghost-'));
+    roots.push(installedDir);
+    fs.writeFileSync(path.join(installedDir, 'ghost.json'), JSON.stringify(installed));
+    runtime.ghosts = [
+      {
+        manifest: { ...installed, name: 'Localized Test Plugin' },
+        dir: installedDir,
+        enabled: true,
+      },
+    ];
+    runtime.install.mockResolvedValue({
+      manifest: manifest(item.ghostId, '2.0.0', ['notify', 'fs']),
+      dir: '/userData/cindy-brain/cindy-test',
+      enabled: true,
+    });
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      ...recordForTest(item),
+      releaseId: 'release-1',
+      version: '1.0.0',
+      manifestDigest: ghostManifestDigest(installed),
+    });
+
+    await h.service.install(item.id, { expectedReleaseId: item.currentRelease.id });
+
+    expect(runtime.install.mock.calls[0]?.[1]).toMatchObject({
+      previouslyInstalledManifest: installed,
+    });
+  });
+
+  it('does not use a changed installed manifest as an approval baseline', async () => {
+    const item = summary({
+      currentRelease: { ...summary().currentRelease, id: 'release-2', version: '2.0.0' },
+    });
+    const installed = manifest(item.ghostId, '1.0.0', ['notify', 'fs']);
+    const installedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-installed-ghost-'));
+    roots.push(installedDir);
+    fs.writeFileSync(path.join(installedDir, 'ghost.json'), JSON.stringify(installed));
+    runtime.ghosts = [{ manifest: installed, dir: installedDir, enabled: true }];
+    runtime.install.mockResolvedValue({
+      manifest: manifest(item.ghostId, '2.0.0', ['notify']),
+      dir: '/userData/cindy-brain/cindy-test',
+      enabled: true,
+    });
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      ...recordForTest(item),
+      releaseId: 'release-1',
+      version: '1.0.0',
+      manifestDigest: ghostManifestDigest({ ...installed, slots: ['notify'] }),
+    });
+
+    await h.service.install(item.id, { expectedReleaseId: item.currentRelease.id });
+
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('previouslyInstalledManifest');
+  });
+
+  it('does not use a legacy ledger record without an authenticated manifest digest', async () => {
+    const item = summary({
+      currentRelease: { ...summary().currentRelease, id: 'release-2', version: '2.0.0' },
+    });
+    const installed = manifest(item.ghostId, '1.0.0', ['notify', 'fs']);
+    const installedDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-installed-ghost-'));
+    roots.push(installedDir);
+    fs.writeFileSync(path.join(installedDir, 'ghost.json'), JSON.stringify(installed));
+    runtime.ghosts = [{ manifest: installed, dir: installedDir, enabled: true }];
+    runtime.install.mockResolvedValue({
+      manifest: manifest(item.ghostId, '2.0.0', ['notify']),
+      dir: '/userData/cindy-brain/cindy-test',
+      enabled: true,
+    });
+    const h = harness([item]);
+    h.ledger.upsertInstallation({
+      ...recordForTest(item),
+      source: 'legacy-adopted',
+      releaseId: 'legacy-unresolved:1.0.0',
+      version: '1.0.0',
+    });
+
+    await h.service.install(item.id, { expectedReleaseId: item.currentRelease.id });
+
+    expect(runtime.install.mock.calls[0]?.[1]).not.toHaveProperty('previouslyInstalledManifest');
+  });
+
   it('installs and enables a public defaultInstall package in local mode', async () => {
     runtime.session = {
       mode: 'local',
@@ -569,7 +658,7 @@ describe('PluginMarketService migration and defaultInstall', () => {
   it('服务端安装持 ghostId 锁,覆盖落位到溯源写入整段', async () => {
     // 少了这把锁,本地 .cindy 装入能在包检查窗口里落入同 id 的包,随后被本次安装
     // 当作更新目标覆盖;账本写入若在锁外,本地装入还能插在"落位"与"写溯源"之间,
-    // 让账本认领一个已被替换的包(服务端记录不带 manifestDigest,投影判不出来)。
+    // 让账本认领一个已被替换的包(账本摘要若未对上当前安装内容,投影不会认领)。
     // 这里用真实的 withGhostInstallLock(service 直接 import,未被 mock)观察:
     // 安装在飞行中时,外部同 id 请求必须进不来;账本已写入后才放行。
     const item = summary();

--- a/apps/desktop/src/main/plugin-market/ledger.ts
+++ b/apps/desktop/src/main/plugin-market/ledger.ts
@@ -37,7 +37,7 @@ export interface PluginMarketInstallationRecord {
    * "我装过"的声明,运行时的包在降级窗口可以被旧版换成任何东西(旧版不认识
    * custom 账本,卸载/本地重装都不会更新它)——认领运行时安装必须同时对上这个
    * 摘要,只凭 ghostId 存在就恢复所有权会把别人的包错误归属给本来源并放行其
-   * 更新覆盖。仅自定义安装记录携带。
+   * 更新覆盖。新写入的市场、自定义市场和 legacy adoption 记录均应携带。
    */
   manifestDigest?: string;
 }

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -158,7 +158,9 @@ function defaultInstallSubject(owner: ActiveAppSession): string {
 function recordFrom(
   plugin: VisiblePluginSummary | VisiblePluginDetail,
   source: PluginMarketInstallationRecord['source'],
+  installed?: InstalledGhost,
 ): PluginMarketInstallationRecord {
+  const rawManifest = installed ? installedGhostRawManifest(installed.dir) : null;
   return {
     pluginId: plugin.id,
     ghostId: plugin.ghostId,
@@ -170,6 +172,7 @@ function recordFrom(
     source,
     installed: true,
     updatedAt: new Date().toISOString(),
+    ...(rawManifest ? { manifestDigest: ghostManifestDigest(rawManifest) } : {}),
   };
 }
 
@@ -183,6 +186,7 @@ function legacyRecordFrom(
   plugin: VisiblePluginSummary,
   ghost: InstalledGhost,
 ): PluginMarketInstallationRecord {
+  const rawManifest = installedGhostRawManifest(ghost.dir);
   return {
     pluginId: plugin.id,
     ghostId: plugin.ghostId,
@@ -194,6 +198,7 @@ function legacyRecordFrom(
     source: 'legacy-adopted',
     installed: true,
     updatedAt: new Date().toISOString(),
+    ...(rawManifest ? { manifestDigest: ghostManifestDigest(rawManifest) } : {}),
   };
 }
 
@@ -244,7 +249,7 @@ function stripDirectionalControls(text: string): string {
   return text.replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\u200e\u200f\u202a-\u202e\u2066-\u2069]/g, '');
 }
 
-function installedGhostRawManifestDigest(dir: string): string | null {
+function installedGhostRawManifest(dir: string): GhostManifest | null {
   try {
     // 安装目录也可能被外部进程/同步盘改动,且本函数每次市场快照都会执行:
     // 与市场目录同一把单句柄限量闸,拒链接、超限即拒,不让无界字节进快照路径。
@@ -255,10 +260,15 @@ function installedGhostRawManifestDigest(dir: string): string | null {
     if (bytes === null) return null;
     const raw = JSON.parse(bytes.toString('utf8')) as unknown;
     const validated = validateGhostManifest(raw);
-    return validated.ok ? ghostManifestDigest(validated.manifest) : null;
+    return validated.ok ? validated.manifest : null;
   } catch {
     return null;
   }
+}
+
+function installedGhostRawManifestDigest(dir: string): string | null {
+  const manifest = installedGhostRawManifest(dir);
+  return manifest ? ghostManifestDigest(manifest) : null;
 }
 
 /** Stable local facts reused while projecting one market catalog response. */
@@ -1177,11 +1187,21 @@ export class PluginMarketService {
           // 权限扩权的**权威**判定点:锁内按当前已装 manifest 重算。锁外那次
           // 只是快速失败;下载窗口期本地装入/更新若换掉了已装包,旧批准在这里
           // 被基线比对拦下,并发替换绕不过去(落位就在下面几行)。
-          assertExpansionApproved(
-            getGhostManager()
-              .list()
-              .find((ghost) => ghost.manifest.id === plugin.ghostId)?.manifest ?? null,
-          );
+          const installedNow = getGhostManager()
+            .list()
+            .find((ghost) => ghost.manifest.id === plugin.ghostId);
+          assertExpansionApproved(installedNow?.manifest ?? null);
+          const currentRecordNow = ledger.installationForGhost(plugin.ghostId);
+          const installedRawManifest = installedNow
+            ? installedGhostRawManifest(installedNow.dir)
+            : null;
+          const previouslyInstalledManifest =
+            installedRawManifest &&
+            currentRecordNow?.installed &&
+            (currentRecordNow.source === 'market' || currentRecordNow.source === 'legacy-adopted') &&
+            currentRecordNow.manifestDigest === ghostManifestDigest(installedRawManifest)
+              ? installedRawManifest
+              : undefined;
           // 市场首装一律装完即开(2026-07-26 定案,见 installOrUpdateMarketGhostPackage);
           // 已装过则走原位更新,唤醒/沉睡状态延续当前值。
           const installed = await installOrUpdateMarketGhostPackage(tempPath, {
@@ -1191,6 +1211,7 @@ export class PluginMarketService {
             // 暂停落位并返回真实包权限——服务端投影层与客户端清单契约漂移时,
             // 必须让用户按实际要安装的能力面重新确认。
             reviewedManifest: compatible.manifest,
+            ...(previouslyInstalledManifest ? { previouslyInstalledManifest } : {}),
             ...(options.approvedPackageSha256 !== undefined
               ? {
                   approvedPackageSha256: options.approvedPackageSha256,
@@ -1203,7 +1224,7 @@ export class PluginMarketService {
           // changes. The bound ledger prevents this write from leaking into the
           // new owner.
           await this.withCapturedLedgerMutation(ledger, () => {
-            ledger.upsertInstallation(recordFrom(plugin, 'market'));
+            ledger.upsertInstallation(recordFrom(plugin, 'market', installed));
           });
           return installed;
         }),

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -158,9 +158,9 @@ function defaultInstallSubject(owner: ActiveAppSession): string {
 function recordFrom(
   plugin: VisiblePluginSummary | VisiblePluginDetail,
   source: PluginMarketInstallationRecord['source'],
-  installed?: InstalledGhost,
+  installed: InstalledGhost,
 ): PluginMarketInstallationRecord {
-  const rawManifest = installed ? installedGhostRawManifest(installed.dir) : null;
+  const rawManifest = installedGhostRawManifest(installed.dir);
   return {
     pluginId: plugin.id,
     ghostId: plugin.ghostId,
@@ -1177,7 +1177,7 @@ export class PluginMarketService {
       //   互斥。少了它,本地装入能在包检查窗口里落入同 id 的包,随后被本次安装当作
       //   更新目标覆盖,而权限差异确认因审阅时目标不存在而没跑过。账本写入也必须在
       //   锁内:否则本地装入可以插在"落位"与"写溯源"之间,让账本认领一个其实已被
-      //   替换掉的包(服务端记录不带 manifestDigest,投影时判不出来)。
+      //   替换掉的包(账本摘要若未对上当前安装内容,投影时不会认领)。
       // 锁序:pluginId → SOURCE_MUTATION_KEY → ghostId → ledgerMutation,不可反向。
       const ghost = await this.withMutation(SOURCE_MUTATION_KEY, () =>
         withGhostInstallLock(plugin.ghostId, async () => {

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -16,6 +16,7 @@ import {
   parseGhostNodeChildToHostMessage,
   ghostPartition,
   ghostPermissionItems,
+  unreviewedGhostPermissionItems,
   ghostWebviewEntryPaths,
   isGhostCallToolName,
   isValidGhostId,
@@ -122,6 +123,38 @@ describe('ghost · id 规则', () => {
 });
 
 describe('ghost · 清单校验', () => {
+  it('updates preserve permissions already approved by the installed manifest when release metadata omits them', () => {
+    const makeToolManifest = (tools: Array<{ name: string; description: string }>) => {
+      const raw = { ...goodManifest(), slots: ['tool'], tools } as Record<string, unknown>;
+      delete raw.panel;
+      const result = validateGhostManifest(raw);
+      if (!result.ok) throw new Error(result.reason);
+      return result.manifest;
+    };
+    const installed = makeToolManifest([{ name: 'gen_image', description: 'Generate images' }]);
+    const reviewed = makeToolManifest([{ name: 'gen_image', description: 'Projected description' }]);
+    const samePackage = makeToolManifest([{ name: 'gen_image', description: 'Generate images' }]);
+    const expandedPackage = makeToolManifest([
+      { name: 'gen_image', description: 'Generate images' },
+      { name: 'edit_image', description: 'Edit images' },
+    ]);
+    const changedPackage = makeToolManifest([
+      { name: 'gen_image', description: 'A third, unreviewed description' },
+    ]);
+
+    expect(unreviewedGhostPermissionItems(reviewed, installed, samePackage)).toEqual([]);
+    expect(
+      unreviewedGhostPermissionItems(reviewed, installed, expandedPackage).map((item) => item.key),
+    ).toEqual([
+      'tool:edit_image',
+    ]);
+    expect(
+      unreviewedGhostPermissionItems(reviewed, installed, changedPackage).map((item) => item.key),
+    ).toEqual([
+      'tool:gen_image',
+    ]);
+  });
+
   it('全字段合法清单通过,并按已知字段收窄输出', () => {
     const v = validateGhostManifest({ ...goodManifest(), unknownField: 'ignored' });
     expect(v.ok).toBe(true);

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -123,7 +123,7 @@ describe('ghost · id 规则', () => {
 });
 
 describe('ghost · 清单校验', () => {
-  it('updates preserve permissions already approved by the installed manifest when release metadata omits them', () => {
+  it('更新保留已安装清单中已批准的权限，即使发布元数据遗漏这些权限', () => {
     const makeToolManifest = (tools: Array<{ name: string; description: string }>) => {
       const raw = { ...goodManifest(), slots: ['tool'], tools } as Record<string, unknown>;
       delete raw.panel;

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -1894,6 +1894,27 @@ export function diffGhostPermissionItems(
 }
 
 /**
+ * Returns package permissions not covered by the reviewed release manifest or
+ * by permissions already approved on the installed version.
+ *
+ * The second source is important for updates from older marketplace metadata
+ * that omitted permissions which were already present in the installed pack.
+ */
+export function unreviewedGhostPermissionItems(
+  reviewed: GhostManifest,
+  previouslyInstalled: GhostManifest | undefined,
+  actual: GhostManifest,
+): GhostPermissionItem[] {
+  const approvalKey = (item: GhostPermissionItem): string =>
+    JSON.stringify([item.key, item.detail ?? '']);
+  const approved = new Set(ghostPermissionItems(reviewed).map(approvalKey));
+  for (const item of ghostPermissionItems(previouslyInstalled ?? reviewed)) {
+    approved.add(approvalKey(item));
+  }
+  return ghostPermissionItems(actual).filter((item) => !approved.has(approvalKey(item)));
+}
+
+/**
  * icon 允许的图片扩展名 → mime(校验与 main 读盘供图共用同一口径)。
  * 不收 svg:svg 可携带脚本,虽经 <img> 渲染不执行,仍不给这个面。
  */

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -1894,11 +1894,10 @@ export function diffGhostPermissionItems(
 }
 
 /**
- * Returns package permissions not covered by the reviewed release manifest or
- * by permissions already approved on the installed version.
+ * 返回未被发布清单或已批准旧版本覆盖的包权限。
  *
- * The second source is important for updates from older marketplace metadata
- * that omitted permissions which were already present in the installed pack.
+ * 第二个来源用于兼容旧市场元数据：旧详情投影可能漏掉已存在的权限，
+ * 但这些权限此前已经被用户批准，更新时应继续保留。
  */
 export function unreviewedGhostPermissionItems(
   reviewed: GhostManifest,


### PR DESCRIPTION
## 这次改了什么

### 摘要

本 PR 已重构为已合并 PR #1648 之上的存量插件兼容补丁。

PR #1648 负责使用真实包内的 `canonicalManifest` 校验权限，并在真实包权限超出市场展示时，通过现有 `reviewRequired` 流程让用户重新确认。本 PR 不再重复实现该链路，只补充经过认证的历史批准基线：当市场账本中的 `manifestDigest` 与当前安装目录的原始 `ghost.json` 一致时，历史版本已批准、但服务端详情投影遗漏的权限继续视为已审核；真正新增或无法认证的权限仍交由 #1648 的真实包复核流程处理。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 包含：Desktop 市场安装/更新的历史权限基线合并、服务端市场与 legacy adoption 账本摘要写入、摘要对账及回归测试。
- 基于：PR #1648 提供的 `canonicalManifest`、`reviewRequired`、包 SHA 和已装权限基线绑定，以及 Renderer 单项/批量更新恢复流程。
- 明确不包含：服务端仓库、`cindy-protocol`、插件仓库、移动端代码、移动端原生配置，以及新的 Renderer 交互状态。
- 用户可见变化：摘要匹配的历史安装不会因市场详情漏投影旧权限而重复确认；摘要缺失或不匹配时，继续显示 #1648 的真实包权限确认。
- Breaking change：无。

### UI 变化

不新增 UI、交互或文案；权限需要复核时复用 PR #1648 已有的确认界面。

- 引用的设计规范：不涉及新的 UI 代码或视觉变更。

## 怎么验证的

### 自动验证

`pnpm --filter desktop exec vitest run src/shared/__tests__/ghost.test.ts src/main/plugin-market/__tests__/service.test.ts`

结果：通过，2 个测试文件、200 个测试通过。

`pnpm --filter desktop run --if-present typecheck`

结果：通过。

`pnpm test:unit`

结果：通过，全仓 unit tier 工作区通过。

`git diff --check origin/main...HEAD`

结果：通过。

`pnpm check:dco`

结果：通过，2 个提交均包含匹配 author/committer 的 `Signed-off-by`。

### 手工验证

重构前在 Dev 沙盒中使用脱敏 fixture 模拟 release 环境的历史插件状态，验证以下批量更新可正常完成：Art 1.9.2 → 1.11.0、GitHub 1.1.1 → 1.2.2、GitLab 1.1.1 → 1.2.2、Mermaid 1.0.0 → 1.1.2、Web Search 1.1.4 → 1.2.2。验收通过，未出现错误的未审核权限提示。

### 未执行的验证

- rebase 到 PR #1648 后未重新启动 Dev 沙盒做运行时验收；重构后的权限合并、摘要匹配和 #1648 复核衔接由上述 200 个定向测试及全仓单测覆盖。
- 未修改移动端 runtime fingerprint 输入，因此不触发移动端冷更。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：Desktop 服务端市场插件的安装/更新权限判定和本地市场账本；不改变插件包格式、安装目录格式、服务端数据或协议。
- 安全边界：仅当账本来源为 `market` / `legacy-adopted`，且账本摘要与当前原始安装清单一致时，才复用历史权限；安装内容变化、摘要读取失败或摘要缺失均 fail closed，转入 #1648 的重新确认流程。
- 存量插件影响：不会导致插件失效、重新安装、凭证或偏好丢失。没有 `manifestDigest` 的既有旧账本记录无法安全自动回填，首次遇到详情投影差异时仍会按 #1648 重新确认一次；成功安装后会写入摘要，后续可使用兼容基线。
- 回滚方式：回滚本 PR 的两个提交即可恢复 #1648 原有行为，即所有真实包与市场详情的权限差异均要求重新确认。
- 合并门禁：本 PR 触及插件批准状态与 manifest 校验，需按插件基座白名单确认门由指定放行人明确 Approve。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 均带 DCO 签名并通过 `pnpm check:dco`
- [x] 不涉及新的 UI 设计规范
- [x] 未提交凭证、令牌或授权文件
- [x] 未提交 Markdown 文档到仓库（本内容仅为 GitHub PR 描述）
- [x] 已确认测试结果并如实说明未执行的运行时复验

## 关联 Issue

- #1656
