### PR TITLE
fix(im): 控制命令收归主人专属，群成员的 !stop / slash 不再生效

### DIFF
--- a/apps/desktop/src/main/im/shared/__tests__/stopCommandRouting.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/stopCommandRouting.test.ts
@@ -261,6 +261,88 @@ describe('messageHandler !stop routing', () => {
     });
   });
 
+  // ── 控制命令的主人门 ──────────────────────────────────────────────────────
+  // 群消息的 senderId 是群 lane, 所以任何群成员的 !stop 都会解析到同一个群会话,
+  // 等于掐掉主人正在跑的那一轮; slash 则会去动主人的目录/会话。speaker 存在即
+  // 代表这是群里的一次发言, 必须 isOwner 才放行(fail-closed)。
+  const groupSpeaker = (isOwner: boolean): IMMessageEvent['speaker'] => ({
+    id: 'member-9001',
+    name: '群友',
+    isOwner,
+  });
+
+  it('群成员的 !stop 静默丢弃: 不掐主人的 turn、不回提示、不落 agent', async () => {
+    deliver(makeEvent({ text: '!stop', speaker: groupSpeaker(false) }));
+    await flushMicrotasks();
+    await waitForImAccountGenerationIdle();
+
+    expect(stopActiveTurn).not.toHaveBeenCalled();
+    expect(sendMarkdownText).not.toHaveBeenCalled();
+    expect(sendText).not.toHaveBeenCalled();
+    expect(runAgentTurn).not.toHaveBeenCalled();
+  });
+
+  it('群成员的 slash 命令同样静默丢弃(不动主人的目录/会话)', async () => {
+    deliver(makeEvent({ text: '/project', speaker: groupSpeaker(false) }));
+    await flushMicrotasks();
+    await waitForImAccountGenerationIdle();
+
+    expect(handleSlashCommand).not.toHaveBeenCalled();
+    expect(runAgentTurn).not.toHaveBeenCalled();
+    expect(sendMarkdownText).not.toHaveBeenCalled();
+  });
+
+  it('群主人的 !stop 照常执行', async () => {
+    deliver(makeEvent({ text: '!stop', speaker: groupSpeaker(true) }));
+    await flushMicrotasks();
+    await waitForImAccountGenerationIdle();
+
+    expect(stopActiveTurn).toHaveBeenCalledTimes(1);
+    expect(sendMarkdownText).toHaveBeenCalledWith('U123456789', slackUi.agent.stopDone(0), {
+      threadTs: '1234.5678',
+    });
+  });
+
+  it('群主人的 slash 命令照常执行', async () => {
+    deliver(makeEvent({ text: '/project', speaker: groupSpeaker(true) }));
+    await flushMicrotasks();
+    await waitForImAccountGenerationIdle();
+
+    expect(handleSlashCommand).toHaveBeenCalledTimes(1);
+  });
+
+  it('无 speaker(私聊/单人对话)放行: 各渠道入站已做过 owner 门', async () => {
+    deliver(makeEvent({ text: '!stop' }));
+    await flushMicrotasks();
+    await waitForImAccountGenerationIdle();
+
+    expect(stopActiveTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('群成员的普通消息不受影响: 仍照常进 agent', async () => {
+    deliver(makeEvent({ text: '帮我看看这个', speaker: groupSpeaker(false) }));
+    await flushMicrotasks();
+    await waitForImAccountGenerationIdle();
+
+    expect(runAgentTurn).toHaveBeenCalledTimes(1);
+    expect(stopActiveTurn).not.toHaveBeenCalled();
+  });
+
+  it('群成员带附件发 !stop: 不是命令, 照常进 agent(不被门误伤)', async () => {
+    deliver(
+      makeEvent({
+        text: '!stop',
+        speaker: groupSpeaker(false),
+        attachments: [{ kind: 'image', absPath: '/tmp/a.png' } as unknown as IMAttachment],
+      }),
+    );
+    await flushMicrotasks();
+    await waitForImAccountGenerationIdle();
+
+    expect(stopActiveTurn).not.toHaveBeenCalled();
+    expect(runAgentTurn).toHaveBeenCalledTimes(1);
+  });
+
   it('treats !stop with attachments as a normal agent message', async () => {
     deliver(
       makeEvent({

--- a/apps/desktop/src/main/im/shared/__tests__/stopCommandRouting.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/stopCommandRouting.test.ts
@@ -274,7 +274,6 @@ describe('messageHandler !stop routing', () => {
   it('群成员的 !stop 静默丢弃: 不掐主人的 turn、不回提示、不落 agent', async () => {
     deliver(makeEvent({ text: '!stop', speaker: groupSpeaker(false) }));
     await flushMicrotasks();
-    await waitForImAccountGenerationIdle();
 
     expect(stopActiveTurn).not.toHaveBeenCalled();
     expect(sendMarkdownText).not.toHaveBeenCalled();
@@ -285,7 +284,6 @@ describe('messageHandler !stop routing', () => {
   it('群成员的 slash 命令同样静默丢弃(不动主人的目录/会话)', async () => {
     deliver(makeEvent({ text: '/project', speaker: groupSpeaker(false) }));
     await flushMicrotasks();
-    await waitForImAccountGenerationIdle();
 
     expect(handleSlashCommand).not.toHaveBeenCalled();
     expect(runAgentTurn).not.toHaveBeenCalled();
@@ -295,7 +293,6 @@ describe('messageHandler !stop routing', () => {
   it('群主人的 !stop 照常执行', async () => {
     deliver(makeEvent({ text: '!stop', speaker: groupSpeaker(true) }));
     await flushMicrotasks();
-    await waitForImAccountGenerationIdle();
 
     expect(stopActiveTurn).toHaveBeenCalledTimes(1);
     expect(sendMarkdownText).toHaveBeenCalledWith('U123456789', slackUi.agent.stopDone(0), {
@@ -306,7 +303,6 @@ describe('messageHandler !stop routing', () => {
   it('群主人的 slash 命令照常执行', async () => {
     deliver(makeEvent({ text: '/project', speaker: groupSpeaker(true) }));
     await flushMicrotasks();
-    await waitForImAccountGenerationIdle();
 
     expect(handleSlashCommand).toHaveBeenCalledTimes(1);
   });
@@ -314,7 +310,6 @@ describe('messageHandler !stop routing', () => {
   it('无 speaker(私聊/单人对话)放行: 各渠道入站已做过 owner 门', async () => {
     deliver(makeEvent({ text: '!stop' }));
     await flushMicrotasks();
-    await waitForImAccountGenerationIdle();
 
     expect(stopActiveTurn).toHaveBeenCalledTimes(1);
   });
@@ -322,10 +317,46 @@ describe('messageHandler !stop routing', () => {
   it('群成员的普通消息不受影响: 仍照常进 agent', async () => {
     deliver(makeEvent({ text: '帮我看看这个', speaker: groupSpeaker(false) }));
     await flushMicrotasks();
-    await waitForImAccountGenerationIdle();
 
     expect(runAgentTurn).toHaveBeenCalledTimes(1);
     expect(stopActiveTurn).not.toHaveBeenCalled();
+  });
+
+  // 文本 + unsupported(音视频/超限/未知类型)不是"裸命令": 必须留在原有的
+  // unsupportedNotice + agent 路径上, 否则连"你那个音频我处理不了"的反馈一起被吞。
+  const unsupportedEntry = [{ type: 'audio', label: '语音（暂不支持）' }] as IMMessageEvent['unsupported'];
+
+  it('群成员发 !stop 但带 unsupported 内容: 不当命令, 照常走 unsupported + agent', async () => {
+    deliver(
+      makeEvent({ text: '!stop', speaker: groupSpeaker(false), unsupported: unsupportedEntry }),
+    );
+    await flushMicrotasks();
+
+    expect(stopActiveTurn).not.toHaveBeenCalled();
+    // 关键: 没有被主人门静默丢掉 —— 反馈与 agent 路径都还在。
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(runAgentTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('群成员发 slash 但带 unsupported 内容: 不当命令, 照常走 unsupported + agent', async () => {
+    deliver(
+      makeEvent({ text: '/project', speaker: groupSpeaker(false), unsupported: unsupportedEntry }),
+    );
+    await flushMicrotasks();
+
+    expect(handleSlashCommand).not.toHaveBeenCalled();
+    expect(sendText).toHaveBeenCalledTimes(1);
+    expect(runAgentTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it('主人发 !stop 但带 unsupported 内容: 同样不当命令(判据与门逐字一致)', async () => {
+    deliver(
+      makeEvent({ text: '!stop', speaker: groupSpeaker(true), unsupported: unsupportedEntry }),
+    );
+    await flushMicrotasks();
+
+    expect(stopActiveTurn).not.toHaveBeenCalled();
+    expect(runAgentTurn).toHaveBeenCalledTimes(1);
   });
 
   it('群成员带附件发 !stop: 不是命令, 照常进 agent(不被门误伤)', async () => {
@@ -337,7 +368,6 @@ describe('messageHandler !stop routing', () => {
       }),
     );
     await flushMicrotasks();
-    await waitForImAccountGenerationIdle();
 
     expect(stopActiveTurn).not.toHaveBeenCalled();
     expect(runAgentTurn).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/im/shared/controlCommands.ts
+++ b/apps/desktop/src/main/im/shared/controlCommands.ts
@@ -7,3 +7,23 @@ export function isStopCommand(text: string): boolean {
   const normalized = text.trim().toLowerCase();
   return normalized === '!stop' || normalized === '！stop';
 }
+
+/**
+ * 控制命令(`!stop` / slash)是否被授权执行 —— **主人专属**。
+ *
+ * 判据只看 `speaker`:
+ *   - 有 speaker = 群/多人对话的一次发言, 必须 `isOwner === true`(fail-closed:
+ *     字段缺失或为假一律不放行);
+ *   - 无 speaker = 私聊/单人对话, 各渠道在入站处已做过 owner 门(telegram 非
+ *     owner 私聊回礼貌提示即 return, wecom 一切消息都过 acceptOwner), 这里放行。
+ *
+ * 为什么必须在这一层拦: 群消息的 `senderId` 被折叠成**群 lane**(telegram 的
+ * `g/<chatId>`、钉钉的 `encodeLaneUserId(conversationId)`), 于是任何群成员发的
+ * `!stop` 都会解析到**同一个群会话**, 效果等同于掐掉主人正在跑的那一轮; slash
+ * 命令同理会操作主人的目录/会话。telegram 在入站层已经拦了(命令 owner 专属),
+ * 钉钉没有 —— 门放在共用路由上, 六个渠道一次盖住。
+ */
+export function isCommandAuthorized(event: { speaker?: { isOwner: boolean } }): boolean {
+  if (event.speaker === undefined) return true;
+  return event.speaker.isOwner === true;
+}

--- a/apps/desktop/src/main/im/shared/messageHandler.ts
+++ b/apps/desktop/src/main/im/shared/messageHandler.ts
@@ -27,7 +27,7 @@ import {
 } from '../accountBoundary';
 
 import { getControlScope, isInControl } from './controlState';
-import { isStopCommand } from './controlCommands';
+import { isCommandAuthorized, isStopCommand } from './controlCommands';
 import type { ImSlashHandlers } from './slashCommands';
 import { looksLikeSlashCommand } from './slashCommands';
 import type { ImTurnRunner } from './turnRunner';
@@ -60,6 +60,27 @@ export function createMessageHandler(
       `processOne sender=...${event.senderId.slice(-8)} chat=...${event.chatId.slice(-8)} ` +
         `textLen=${event.text.length} att=${event.attachments.length} unsupported=${event.unsupported.length}`,
     );
+
+    // ── 控制命令的主人门: 群成员的 !stop / slash 静默丢弃 ────────────────────
+    // 群消息的 senderId 是**群 lane**(telegram g/<chatId>、钉钉
+    // encodeLaneUserId(conversationId)), 所以群成员发的 !stop 会解析到同一个群
+    // 会话 —— 等于掐掉主人正在跑的那一轮; slash 则会去动主人的目录/会话。
+    // 静默(不回提示)与 telegram 入站层同口径: 群里不可被探测。也不落到 agent,
+    // 否则命令会变成一句普通 prompt。
+    //
+    // 放在 /ctr 拦截**之前**: 否则主人正走 /ctr 时, 群成员发命令会收到一句
+    // "控制流程中" —— 等于把主人的状态回给了没有权限的人。
+    const commandLike =
+      event.text.length > 0 &&
+      event.attachments.length === 0 &&
+      (isStopCommand(event.text) || looksLikeSlashCommand(event.text));
+    if (commandLike && !isCommandAuthorized(event)) {
+      log.info(
+        `dropped non-owner command sender=...${event.senderId.slice(-8)} ` +
+          `speaker=...${(event.speaker?.id ?? '').slice(-8)}`,
+      );
+      return;
+    }
 
     // ── /ctr 原子化拦截 ────────────────────────────────────────────────
     // 该 (bot, owner) 处于 /ctr 流程中 → 任何消息都不路由到 slash/agent,

--- a/apps/desktop/src/main/im/shared/messageHandler.ts
+++ b/apps/desktop/src/main/im/shared/messageHandler.ts
@@ -70,9 +70,16 @@ export function createMessageHandler(
     //
     // 放在 /ctr 拦截**之前**: 否则主人正走 /ctr 时, 群成员发命令会收到一句
     // "控制流程中" —— 等于把主人的状态回给了没有权限的人。
+    //
+    // 只有**纯文本**才算控制命令: 附件与 unsupported(音视频/超限/未知类型等)都要
+    // 让消息走 unsupportedNotice / unsupportedOnly / agent 的原有路径, 不能被当成
+    // 一句裸命令吞掉 —— 那会连"你那个音频我处理不了"的反馈一起吃掉。
+    // 这个判据必须与下面两条命令分支**逐字一致**: 门比分支窄一点, 非主人的
+    // `!stop` + unsupported 就会穿过门再被分支执行, 洞等于没堵。
+    const pureTextCommandInput =
+      event.text.length > 0 && event.attachments.length === 0 && event.unsupported.length === 0;
     const commandLike =
-      event.text.length > 0 &&
-      event.attachments.length === 0 &&
+      pureTextCommandInput &&
       (isStopCommand(event.text) || looksLikeSlashCommand(event.text));
     if (commandLike && !isCommandAuthorized(event)) {
       log.info(
@@ -110,10 +117,10 @@ export function createMessageHandler(
     }
 
     // ── !stop 控制指令: 中止当前 turn, 绝不作为普通消息入队 ─────────────────
-    // 放在 slash 之前; 与 slash 同口径只认无附件的纯文本。turn 运行期间
-    // userLocks 并不持锁(runAgentTurn 在 dispatch 后即返回), 所以这里能在
+    // 放在 slash 之前; 与 slash 同口径只认纯文本(见 pureTextCommandInput)。turn
+    // 运行期间 userLocks 并不持锁(runAgentTurn 在 dispatch 后即返回), 所以这里能在
     // 上一轮仍在跑时立刻执行, 而不是排到它后面。
-    if (event.text && event.attachments.length === 0 && isStopCommand(event.text)) {
+    if (pureTextCommandInput && isStopCommand(event.text)) {
       let reply: string;
       try {
         const result = await turnRunner.stopActiveTurn({
@@ -139,8 +146,8 @@ export function createMessageHandler(
       return;
     }
 
-    // ── slash command (only on plain text, no attachments) ──────────────────
-    if (event.text && event.attachments.length === 0 && looksLikeSlashCommand(event.text)) {
+    // ── slash command (only on plain text: no attachments, no unsupported) ──
+    if (pureTextCommandInput && looksLikeSlashCommand(event.text)) {
       try {
         await slash.handleSlashCommand(event.text, {
           botContextId: event.contextId,


### PR DESCRIPTION
## 这次改了什么

### 摘要

**群成员可以用主人的控制命令。**

IM 群消息的 `senderId` 被折叠成**群 lane**，不是发言的那个人：

- Telegram：`g/<chatId>`（`encodeLaneUserId`）
- 钉钉：`encodeLaneUserId(conversationId)`

于是任何群成员发一句 `!stop`，都会解析到**主人的那个群会话**，`stopActiveTurn` 直接掐掉正在跑的那一轮，顺带把排队的消息一起撤了。slash 命令同理——`/project`、`/session` 会去动主人的工作目录与会话绑定。

`messageHandler` 的 `!stop` 与 slash 两条分支**都没有任何身份校验**，只看文本形状。各渠道的实际情况：

| 渠道 | 群里非主人的 `!stop` / slash | 说明 |
|---|---|---|
| Telegram 个人 bot | 已拦 | 入站层 `isCommand && (!isOwner \|\| ambient) → return`（#1078 起），`/` 与 `!` 都盖 |
| 企业微信 | 已拦 | 所有消息一律过 `acceptOwner`，非主人根本进不来 |
| **钉钉** | **未拦** | 群消息只要求 `envelope.mentioned`；owner 门只管私聊（`if (!isGroup && senderId !== ownerUserId) return`） |
| 飞书 / 微信 / Discord | 无命令层身份门 | 依赖各自入站路径，缺一道统一兜底 |

六个渠道共用 `apps/desktop/src/main/im/shared/messageHandler.ts`，所以门放在这一层，一处盖住全部，Telegram 那道入站门顺势变成第二层。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

**意图契约**

- **目标**：控制命令（`!stop` / slash）主人专属，群成员发的一律不生效。
- **非目标**：不改命令本身的语义、不改各渠道入站层已有的门、不动 `stopActiveTurn` / slash 的实现。
- **行为契约**：群轮次里 `speaker.isOwner !== true` 的命令**整条静默丢弃** —— 不执行、不回提示、也不落给 agent（否则命令会变成一句普通 prompt）。
- **失效契约**：`speaker` 字段缺失即视为未授权（fail-closed）；无 `speaker`（私聊/单人对话）放行，那条路径各渠道在入站处已做过 owner 门。
- **验收**：群成员的 `!stop` 不再调用 `stopActiveTurn`、slash 不再执行；主人的两者照常；群成员的普通消息与带附件的 `!stop` 不受影响。

- 关联 Issue / 需求：无（复查 Telegram 群 bot 行为时发现）
- 本 PR 包含：`isCommandAuthorized()` 判据 + `messageHandler` 里一道 fail-closed 门 + 7 条回归。
- 明确不包含：给非主人回一句「无权限」（会让 bot 在群里可被探测，与 Telegram 现有语义相反）；把钉钉入站层也补上命令门（共用路由这一道已经足够，重复设门只会多一处要同步维护的判据）。
- 用户可见变化：群成员发 `!stop` / `/xxx` 从「生效」变成「什么都不发生」。主人无变化。Telegram 与企业微信无行为变化（本来就拦着）。
- 是否存在 breaking change：无

### UI 变化

不涉及：改动只在 IM 消息路由层，无界面代码、无新增或修改 UI 文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/im
结果：Test Files 44 passed (44) / Tests 367 passed (367)

pnpm --filter desktop run --if-present typecheck
结果：通过（exit 0）

pnpm test:unit（仓库根全量门禁）
结果：通过（exit 0），56 个 workspace 全 PASS，零 FAIL
```

**回归用例确认会咬**（把门用 `false &&` 短路后实跑）：

```text
× 群成员的 !stop 静默丢弃: 不掐主人的 turn、不回提示、不落 agent
  → expected "spy" to not be called at all, but actually been called 1 times
× 群成员的 slash 命令同样静默丢弃(不动主人的目录/会话)
  → expected "spy" to not be called at all, but actually been called 1 times
```

新增 7 条：群成员 `!stop` 丢弃 / 群成员 slash 丢弃 / 群主人 `!stop` 照常 / 群主人 slash 照常 / 无 `speaker` 放行 / 群成员普通消息照常进 agent / 群成员带附件发 `!stop` 不被门误伤。

### 手工验证

不涉及。

### 未执行的验证

- **真机未验证**：需要一个真实的钉钉群 + 第二个非主人账号才能实机复现，本地没有该环境；worktree 改动对运行中的 app 也无效。逻辑面用 `messageHandler` 的路由级用例覆盖（直接注入 `speaker.isOwner=false` 的事件断言 spy 未被调用）。
- 建议的真机验证路径：钉钉群里用另一个账号 @bot 发 `!stop`，观察主人正在跑的那一轮是否还在继续。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- **影响范围**：`apps/desktop/src/main/im/shared/`（六个 IM 渠道共用的消息路由）。不动协议、不动 DB、不动 UI。
- **回滚 / 降级方式**：整体 revert 即可，无残留状态、无数据迁移。
- **收紧方向的权限改动**：本 PR 只会让**更少**的人能执行命令，不会放开任何原本被拦的路径。Telegram / 企业微信本来就拦着，行为不变；钉钉从「群成员能执行」收紧到「不能」。
- **误伤面**：判据只看 `speaker`。目前只有 Telegram 群、钉钉群、企业微信群会带 `speaker`；企业微信恒为 `isOwner: true`（非主人进不来），所以不会误伤。若将来某渠道给**私聊**也带上 `speaker` 但忘了填 `isOwner`，主人的命令会被误拦 —— fail-closed 方向，宁可失效不可越权，且会在该渠道首次自测时立刻暴露。
- **门的位置**：放在 `/ctr` 原子化拦截**之前**。否则主人正走 `/ctr` 时，群成员发命令会收到一句「控制流程中」——等于把主人的状态回给了没有权限的人。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（判据的 why 写在 `controlCommands.ts` 的注释里）
- [x] 已确认测试结果或说明未执行原因
