### PR TITLE
feat(chat): 复制旁边外显开启新任务操作

### DIFF
--- a/apps/desktop/src/renderer/components/chat/AssistantMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/AssistantMessage.tsx
@@ -6,7 +6,7 @@
  * F-MSG-1: assistant message styling (left-aligned, no bubble)
  * F-MSG-2: Markdown rendering
  * message-actions V1.2: hover-revealed bar below the markdown body, left-aligned,
- *   order [copy][time]. Streaming messages do NOT mount the bar (per spec
+ *   order [copy][fork][more][time][cost]. Streaming messages do NOT mount the bar (per spec
  *   "流式期间不挂载"); 且仅当父层标记本消息为 turn 收尾正文(showActionBar)
  *   时才挂载 —— 任务执行过程中的中间句没有操作行。The bar
  *   owns its own fade lifecycle (see MessageActionBar) so this component

--- a/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
@@ -6,10 +6,10 @@
  * Layout:
  *   - Bar gap 2px, align-items: center
  *   - Order is `align`-driven:
- *       align="left"  → [CopyBtn][MoreMenu][TimeText][CostText]       (assistant)
- *       align="right" → [TimeText][CopyBtn][EditBtn][MoreMenu] (user)
+ *       align="left"  → [CopyBtn][ForkBtn][MoreMenu][TimeText][CostText] (assistant)
+ *       align="right" → [TimeText][CopyBtn][ForkBtn][EditBtn][MoreMenu] (user)
  *   - Action buttons are 24×24; More uses a pill trigger and a 12px menu
- *     containing fork, message deep-link copy, and single-message deletion.
+ *     containing message deep-link copy and single-message deletion.
  *   - Icon lucide 14×14, color #737373 (Light) / #a3a3a3 (Dark)
  *     hover color #262626 (Light) / #ffffff (Dark)
  *   - Time text 12px Inter normal, color INVERTED from icon (#a3a3a3 / #737373)
@@ -146,6 +146,9 @@ export function MessageActionBar({
   // Unified in-flight: fork (internal) OR rewind (external) — bar dims & blocks
   // pointer events for either. Same visual treatment for consistency.
   const inFlight = forking || deleting || rewindInFlight;
+  // Fork has its own visible button. Keep the More trigger's spinner scoped to
+  // actions that still live inside that menu.
+  const moreInFlight = deleting || rewindInFlight;
   // `visible` is the actual opacity driver. It tracks `hovered` with a
   // trailing debounce so the bar fades out smoothly (CSS handles the
   // opacity interpolation from current value, not from 1).
@@ -275,6 +278,43 @@ export function MessageActionBar({
     </button>
   );
 
+  const forkBtn = onFork && (
+    <Tooltip.Root key="fork">
+      <Tooltip.Trigger asChild>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            void handleFork();
+          }}
+          disabled={inFlight}
+          className={cn(
+            'group flex h-[24px] w-[24px] items-center justify-center',
+            'rounded-[4px] border-none bg-transparent outline-none cursor-pointer',
+            'hover:bg-[var(--cmd-palette-item-hover)] transition-colors',
+            'focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:cursor-default',
+          )}
+          aria-label={t('chat.messageActionBar.fork')}
+        >
+          {forking ? (
+            <Spinner size={14} strokeWidth={2} className="text-[var(--cmd-palette-item-meta)]" />
+          ) : (
+            <Split
+              size={14}
+              strokeWidth={2}
+              className={cn(
+                'text-[var(--cmd-palette-item-meta)]',
+                'group-hover:text-[var(--msg-assistant-text)]',
+                'transition-colors duration-150',
+              )}
+            />
+          )}
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{t('chat.messageActionBar.fork')}</Tooltip.Content>
+    </Tooltip.Root>
+  );
+
   const timeText = relText && (
     <Tooltip.Root key="time">
       <Tooltip.Trigger asChild>
@@ -286,7 +326,7 @@ export function MessageActionBar({
             // mid-line aligns with the lucide Copy icon glyph center.
             'relative top-[0.5px]',
             // 视觉分组:user 侧(right)时间在最左、后面跟 4 个操作图标
-            // ([copy][edit][undo][fork],彼此 gap-0.5=2px 是一组)。时间与图标组
+            // ([copy][fork][edit][more],彼此 gap-0.5=2px 是一组)。时间与图标组
             // 之间额外 +6px(共 8px),让"元信息 | 操作组"两段读起来是独立分组
             // —— 与 assistant 侧 costText 的 ml-1.5 同一间距语言。
             align === 'right' && 'mr-1.5',
@@ -431,10 +471,10 @@ export function MessageActionBar({
     </Tooltip.Root>
   );
 
-  // Fork / rewind 收进 More 菜单；链接复制与单条删除也放在同一入口。
+  // Rewind、链接复制与单条删除收进 More 菜单；Fork 与复制同级外显。
   // 面板/行几何遵守 12px container + 8px inner-control 两档圆角。
   const canRewind = Boolean(onRewind && align === 'right');
-  const moreMenu = (onFork || onAddToChat || copyLinkText || canRewind || onDelete) && (
+  const moreMenu = (onAddToChat || copyLinkText || canRewind || onDelete) && (
     <DropdownMenu key="more" open={menuOpen} onOpenChange={setMenuOpen}>
       <DropdownMenuTrigger asChild>
         <button
@@ -456,7 +496,7 @@ export function MessageActionBar({
           )}
           aria-label={t('chat.messageActionBar.moreActions')}
         >
-          {inFlight ? (
+          {moreInFlight ? (
             <Spinner size={14} strokeWidth={2} className="text-[var(--cmd-palette-item-meta)]" />
           ) : (
             <Ellipsis
@@ -491,19 +531,6 @@ export function MessageActionBar({
           'bg-[var(--cmd-palette-bg)] p-1 text-[var(--cmd-palette-item-text)] shadow-none',
         )}
       >
-        {onFork && (
-          <DropdownMenuItem
-            disabled={forking}
-            onSelect={(event) => {
-              event.stopPropagation();
-              void handleFork();
-            }}
-            className="h-8 cursor-pointer select-none rounded-lg px-2 text-sm focus:bg-[var(--cmd-palette-item-hover)]"
-          >
-            <Split size={14} strokeWidth={2} className="mr-2 shrink-0" />
-            {t('chat.messageActionBar.fork')}
-          </DropdownMenuItem>
-        )}
         {onAddToChat && (
           <DropdownMenuItem
             onSelect={(event) => {
@@ -543,7 +570,7 @@ export function MessageActionBar({
         )}
         {onDelete && (
           <>
-            {(onFork || onAddToChat || copyLinkText || canRewind) && (
+            {(onAddToChat || copyLinkText || canRewind) && (
               <DropdownMenuSeparator className="my-1 h-px bg-[var(--cmd-palette-border)]" />
             )}
             <DropdownMenuItem
@@ -566,12 +593,12 @@ export function MessageActionBar({
     </DropdownMenu>
   );
 
-  // align='left'  → [copy][more][time][cost]        (assistant)
-  // align='right' → [time][copy][edit][more]        (user)
+  // align='left'  → [copy][fork][more][time][cost]   (assistant)
+  // align='right' → [time][copy][fork][edit][more]   (user)
   const items =
     align === 'left'
-      ? [copyBtn, moreMenu, timeText, costText || tokensText]
-      : [timeText, copyBtn, editBtn, moreMenu];
+      ? [copyBtn, forkBtn, moreMenu, timeText, costText || tokensText]
+      : [timeText, copyBtn, forkBtn, editBtn, moreMenu];
 
   return (
     <div

--- a/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
@@ -143,11 +143,9 @@ export function MessageActionBar({
   // ring behind. Track the latest menu interaction modality so pointer flows
   // can skip restoration while keyboard flows keep their focus indicator.
   const menuInteractionFromPointerRef = useRef(false);
-  // Unified in-flight: fork (internal) OR rewind (external) — bar dims & blocks
-  // pointer events for either. Same visual treatment for consistency.
+  // Fork has its own visible button. Menu-owned actions still dim and block
+  // the whole bar; Fork keeps the More trigger available while it runs.
   const inFlight = forking || deleting || rewindInFlight;
-  // Fork has its own visible button. Keep the More trigger's spinner scoped to
-  // actions that still live inside that menu.
   const moreInFlight = deleting || rewindInFlight;
   // `visible` is the actual opacity driver. It tracks `hovered` with a
   // trailing debounce so the bar fades out smoothly (CSS handles the
@@ -290,7 +288,7 @@ export function MessageActionBar({
           disabled={inFlight}
           className={cn(
             'group flex h-[24px] w-[24px] items-center justify-center',
-            'rounded-[4px] border-none bg-transparent outline-none cursor-pointer',
+            'rounded-lg border-none bg-transparent outline-none cursor-pointer',
             'hover:bg-[var(--cmd-palette-item-hover)] transition-colors',
             'focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)] disabled:cursor-default',
           )}
@@ -486,7 +484,7 @@ export function MessageActionBar({
           onKeyDown={() => {
             menuInteractionFromPointerRef.current = false;
           }}
-          disabled={inFlight}
+          disabled={moreInFlight}
           className={cn(
             'group flex h-[24px] w-[24px] items-center justify-center',
             'rounded-full border-none bg-transparent outline-none cursor-pointer',
@@ -610,8 +608,9 @@ export function MessageActionBar({
         // (browser CSS transition behavior — no replay from 0).
         'transition-opacity duration-[250ms] ease-out',
         visible || menuOpen ? 'opacity-100' : 'opacity-0 pointer-events-none',
-        // Fork / delete / rewind in-flight: dim the entire bar and block clicks.
-        inFlight && 'opacity-60 pointer-events-none',
+        // Menu-owned actions dim the entire bar and block clicks. Fork only
+        // disables its own button so More remains available.
+        moreInFlight && 'opacity-60 pointer-events-none',
       )}
     >
       {items}

--- a/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageActionBar.tsx
@@ -436,8 +436,8 @@ export function MessageActionBar({
     );
 
   // Edit (Pencil) button — last user message only. Enters the inline edit
-  // state owned by UserMessage; no in-flight state here (entering edit is
-  // instant and side-effect free — commit happens on the edit box's Send).
+  // state owned by UserMessage; keep it disabled while any message action is
+  // in flight so editing cannot race with Fork's history read or a menu action.
   const editBtn = onEdit && align === 'right' && (
     <Tooltip.Root key="edit">
       <Tooltip.Trigger asChild>
@@ -447,10 +447,11 @@ export function MessageActionBar({
             e.stopPropagation();
             onEdit();
           }}
+          disabled={inFlight}
           className={cn(
             'group flex h-[24px] w-[24px] items-center justify-center',
             'rounded-[4px] border-none bg-transparent outline-none cursor-pointer',
-            'hover:bg-[var(--cmd-palette-item-hover)] transition-colors',
+            'hover:bg-[var(--cmd-palette-item-hover)] transition-colors disabled:cursor-default',
           )}
           aria-label={t('chat.messageActionBar.edit')}
         >

--- a/apps/desktop/src/renderer/components/chat/UserMessage.tsx
+++ b/apps/desktop/src/renderer/components/chat/UserMessage.tsx
@@ -1575,7 +1575,7 @@ export function UserMessage({
                   </div>
                 )}
                 {/* message-actions V1.2: hover-revealed bar below the bubble,
-            right-aligned, order [time][copy][edit][undo][more]。被拦消息只保留
+                right-aligned, order [time][copy][fork][edit][undo][more]。被拦消息只保留
             编辑和链接复制,fork/rewind/delete 对未发消息无意义。 */}
                 <MessageActionBar
                   createdAt={createdAt}

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
@@ -155,14 +155,16 @@ describe('MessageActionBar', () => {
         resolveFork = resolve;
       }),
     );
+    const onEdit = vi.fn();
 
     render(
       <MessageActionBar
         copyText="message body"
-        align="left"
+        align="right"
         hovered
         onFork={onFork}
         onAddToChat={vi.fn()}
+        onEdit={onEdit}
       />,
     );
 
@@ -172,15 +174,24 @@ describe('MessageActionBar', () => {
     const moreButton = screen.getByRole('button', {
       name: 'chat.messageActionBar.moreActions',
     });
+    const editButton = screen.getByRole('button', {
+      name: 'chat.messageActionBar.edit',
+    });
 
     fireEvent.click(forkButton);
     await waitFor(() => expect(forkButton.querySelector('.animate-spin')).toBeTruthy());
     expect(moreButton.querySelector('.lucide-ellipsis')).toBeTruthy();
     expect(moreButton.querySelector('.lucide-loader-circle')).toBeNull();
     expect((moreButton as HTMLButtonElement).disabled).toBe(false);
+    expect((editButton as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(editButton);
+    expect(onEdit).not.toHaveBeenCalled();
 
     resolveFork();
-    await waitFor(() => expect(forkButton.querySelector('.animate-spin')).toBeNull());
+    await waitFor(() => {
+      expect(forkButton.querySelector('.animate-spin')).toBeNull();
+      expect((editButton as HTMLButtonElement).disabled).toBe(false);
+    });
   });
 
   it('restores focus to the ellipsis trigger for keyboard users', async () => {

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
@@ -177,6 +177,7 @@ describe('MessageActionBar', () => {
     await waitFor(() => expect(forkButton.querySelector('.animate-spin')).toBeTruthy());
     expect(moreButton.querySelector('.lucide-ellipsis')).toBeTruthy();
     expect(moreButton.querySelector('.lucide-loader-circle')).toBeNull();
+    expect((moreButton as HTMLButtonElement).disabled).toBe(false);
 
     resolveFork();
     await waitFor(() => expect(forkButton.querySelector('.animate-spin')).toBeNull());

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageActionBar.test.tsx
@@ -38,7 +38,7 @@ describe('MessageActionBar', () => {
     });
   });
 
-  it('groups continue, add-to-chat, link copy, rewind, and delete under ellipsis', async () => {
+  it('keeps fork beside copy and groups the remaining actions under ellipsis', async () => {
     const onFork = vi.fn(async () => undefined);
     const onAddToChat = vi.fn();
     const onRewind = vi.fn();
@@ -62,9 +62,9 @@ describe('MessageActionBar', () => {
       name: 'chat.messageActionBar.moreActions',
     });
     expect(trigger).toBeTruthy();
-    expect(screen.queryByRole('button', {
+    expect(screen.getByRole('button', {
       name: 'chat.messageActionBar.fork',
-    })).toBeNull();
+    })).toBeTruthy();
     expect(screen.queryByRole('button', {
       name: 'chat.messageActionBar.rewind',
     })).toBeNull();
@@ -72,13 +72,14 @@ describe('MessageActionBar', () => {
       name: 'chat.messageActionBar.fork',
     })).toBeNull();
 
-    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
-    expect(screen.getAllByRole('menuitem', {
-      name: 'chat.messageActionBar.fork',
-    })).toHaveLength(1);
-    expect(screen.getByRole('menuitem', {
+    expect(screen.getByRole('button', {
       name: 'chat.messageActionBar.fork',
     }).querySelector('.lucide-split')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'chat.messageActionBar.fork' }));
+    await waitFor(() => expect(onFork).toHaveBeenCalledTimes(1));
+
+    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
     expect(screen.getByRole('menuitem', {
       name: 'chat.quote.addToChat',
     }).querySelector('.lucide-message-square-plus')).toBeTruthy();
@@ -92,14 +93,6 @@ describe('MessageActionBar', () => {
       name: 'chat.messageActionBar.delete',
     }).querySelector('.lucide-trash2')).toBeTruthy();
 
-    fireEvent.click(
-      screen.getByRole('menuitem', {
-        name: 'chat.messageActionBar.fork',
-      }),
-    );
-    await waitFor(() => expect(onFork).toHaveBeenCalledTimes(1));
-
-    fireEvent.pointerDown(trigger, { button: 0, ctrlKey: false });
     fireEvent.click(
       screen.getByRole('menuitem', {
         name: 'chat.quote.addToChat',
@@ -153,6 +146,40 @@ describe('MessageActionBar', () => {
     );
 
     await waitFor(() => expect(document.activeElement).not.toBe(trigger));
+  });
+
+  it('keeps the ellipsis icon static while the direct fork action is running', async () => {
+    let resolveFork!: () => void;
+    const onFork = vi.fn(
+      () => new Promise<void>((resolve) => {
+        resolveFork = resolve;
+      }),
+    );
+
+    render(
+      <MessageActionBar
+        copyText="message body"
+        align="left"
+        hovered
+        onFork={onFork}
+        onAddToChat={vi.fn()}
+      />,
+    );
+
+    const forkButton = screen.getByRole('button', {
+      name: 'chat.messageActionBar.fork',
+    });
+    const moreButton = screen.getByRole('button', {
+      name: 'chat.messageActionBar.moreActions',
+    });
+
+    fireEvent.click(forkButton);
+    await waitFor(() => expect(forkButton.querySelector('.animate-spin')).toBeTruthy());
+    expect(moreButton.querySelector('.lucide-ellipsis')).toBeTruthy();
+    expect(moreButton.querySelector('.lucide-loader-circle')).toBeNull();
+
+    resolveFork();
+    await waitFor(() => expect(forkButton.querySelector('.animate-spin')).toBeNull());
   });
 
   it('restores focus to the ellipsis trigger for keyboard users', async () => {

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -86,7 +86,11 @@ import { useMobileMakerTransport } from '@/device-link/useMobileMakerTransport';
 import { createMobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { startFocusedTopicSubscription } from '@/device-link/focusedTopicSubscription';
 import { InteractionPanel, type MobilePlanViewerState } from '@/session/InteractionPanel';
-import { MessageRenderer, type MobileMessageDraft } from '@/session/MessageRenderer';
+import {
+  MessageRenderer,
+  type MobileMessageActionBusyKind,
+  type MobileMessageDraft,
+} from '@/session/MessageRenderer';
 import { ComposerRichInput, type ComposerRichInputHandle } from '@/session/ComposerRichInput';
 import { InlineQueueSection } from '@/session/InlineQueueSection';
 import { RewindPreviewPanel } from '@/session/RewindPreviewPanel';
@@ -1116,7 +1120,10 @@ export default function SessionScreen() {
   const lastPendingPlanRequestIdRef = useRef<string | null>(null);
   const [queueBusy, setQueueBusy] = useState(false);
   const [controlBusy, setControlBusy] = useState(false);
-  const [messageActionBusy, setMessageActionBusy] = useState<string | null>(null);
+  const [messageActionBusy, setMessageActionBusy] = useState<{
+    clientId: string;
+    kind: MobileMessageActionBusyKind;
+  } | null>(null);
   const [rewindState, setRewindState] = useState<RewindPreviewState>({ kind: 'idle' });
   // 切 session 时同步(render 阶段)重置回撤确认框 / busy / loading 态并递增「请求代际」。SessionScreen 切
   // session 复用实例、不 remount,这些本地 UI state 不会自动重置,残留会让确认框跨 session 出现且
@@ -7378,7 +7385,7 @@ export default function SessionScreen() {
   const previewRewindAtMessage = useCallback(async (clientId: string, draft: MobileMessageDraft) => {
     if (messageActionBusy) return;
     const seq = ++rewindRequestSeqRef.current;
-    setMessageActionBusy(clientId);
+    setMessageActionBusy({ clientId, kind: 'rewind' });
     setError(null);
     setRewindState({
       kind: 'loading',
@@ -7420,7 +7427,7 @@ export default function SessionScreen() {
 
   const performForkAtMessage = useCallback(async (clientId: string, draft?: MobileMessageDraft) => {
     if (!deviceId || messageActionBusy) return;
-    setMessageActionBusy(clientId);
+    setMessageActionBusy({ clientId, kind: 'fork' });
     setError(null);
     try {
       const forked = await maker.fork(sessionId, clientId);
@@ -7612,7 +7619,7 @@ export default function SessionScreen() {
         style: 'destructive',
         onPress: () => {
           void (async () => {
-            setMessageActionBusy(clientId);
+            setMessageActionBusy({ clientId, kind: 'delete' });
             setError(null);
             try {
               const result = await maker.deleteMessage(sessionId, clientId);
@@ -7641,7 +7648,7 @@ export default function SessionScreen() {
     if (!deviceId || messageActionBusy || !isCommitReadyRewindState(rewindState)) return;
     const state = rewindState;
     const seq = ++rewindRequestSeqRef.current;
-    setMessageActionBusy(state.clientId);
+    setMessageActionBusy({ clientId: state.clientId, kind: 'rewind' });
     setError(null);
     try {
       const updated = await maker.rewindCommit(sessionId, state.clientId);
@@ -8078,7 +8085,8 @@ export default function SessionScreen() {
                   <MessageRenderer
                     bottomOverlayHeight={bottomOverlayHeight}
                     topOverlayHeight={topOverlayHeight}
-                    busyClientId={messageActionBusy}
+                    busyAction={messageActionBusy?.kind ?? null}
+                    busyClientId={messageActionBusy?.clientId ?? null}
                     canLoadEarlier={hasOlderMessages && messages.length > 0}
                     emptyTestID="session.messageList.empty"
                     focusedItemKey={focusedMessageItemKey ?? null}

--- a/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
@@ -23,8 +23,9 @@ describe('mobile message actions desktop-first surface', () => {
     expect(source).toContain('iconSize={actionBar.iconSize}');
     expect(source).toContain("return id === 'copy' || id === 'fork';");
     expect(source).toContain('disabled={disabled && !actionBusy}');
-    expect(source).toContain("busy={id === 'fork' && actionBusy}");
+    expect(source).toContain("busy={id === 'fork' && forkBusy}");
     expect(source).toContain("if (id === 'fork' && busy)");
+    expect(source).toContain("disabledActions={actionBusy ? ['rewind', 'delete'] : undefined}");
     expect(source).toContain('testID="message.moreButton"');
     expect(source).toContain('{ height: buttonSize, width: buttonSize }');
     expect(source).toContain('height: 24');

--- a/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
@@ -22,7 +22,7 @@ describe('mobile message actions desktop-first surface', () => {
     expect(source).toContain('buttonSize={actionBar.buttonSize}');
     expect(source).toContain('iconSize={actionBar.iconSize}');
     expect(source).toContain("return id === 'copy' || id === 'fork';");
-    expect(source).toContain('disabled={disabled && !actionBusy}');
+    expect(source).toContain('disabled={disabled && !forkBusy}');
     expect(source).toContain("busy={id === 'fork' && forkBusy}");
     expect(source).toContain("if (id === 'fork' && busy)");
     expect(source).toContain("disabledActions={actionBusy ? ['rewind', 'delete'] : undefined}");

--- a/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageActionDesktopFirst.test.ts
@@ -10,6 +10,7 @@ describe('mobile message actions desktop-first surface', () => {
     expect(source).toContain('const MESSAGE_CONTROL_HIT_SLOP = { bottom: 10, left: 10, right: 10, top: 10 };');
     expect(source).toContain('buildMessageActionBarPresentation');
     expect(sharedSource).toContain("input.canCopy ? 'copy' : null");
+    expect(sharedSource).toContain("input.canFork ? 'fork' : null");
     expect(sharedSource).toContain("input.hasMoreActions ? 'more' : null");
     expect(sharedSource).toContain("input.hasTime ? 'time' : null");
     expect(sharedSource).toContain("input.hasTurnCost ? 'cost' : null");
@@ -20,7 +21,10 @@ describe('mobile message actions desktop-first surface', () => {
     expect(source).toContain('hitSlop={MESSAGE_CONTROL_HIT_SLOP}');
     expect(source).toContain('buttonSize={actionBar.buttonSize}');
     expect(source).toContain('iconSize={actionBar.iconSize}');
-    expect(source).toContain("return id === 'copy';");
+    expect(source).toContain("return id === 'copy' || id === 'fork';");
+    expect(source).toContain('disabled={disabled && !actionBusy}');
+    expect(source).toContain("busy={id === 'fork' && actionBusy}");
+    expect(source).toContain("if (id === 'fork' && busy)");
     expect(source).toContain('testID="message.moreButton"');
     expect(source).toContain('{ height: buttonSize, width: buttonSize }');
     expect(source).toContain('height: 24');

--- a/apps/mobile/src/__tests__/messageActionMenu.test.ts
+++ b/apps/mobile/src/__tests__/messageActionMenu.test.ts
@@ -15,10 +15,8 @@ describe('mobile message action menu', () => {
       canAddToChat: true,
       canCopyLink: true,
       canDelete: true,
-      canFork: true,
       canRewind: true,
     })).toEqual([
-      { id: 'fork', label: '开启一个新任务' },
       { id: 'add-to-chat', label: '添加到对话' },
       { id: 'copy-link', label: '复制当前消息链接' },
       { id: 'rewind', label: '回到此处' },

--- a/apps/mobile/src/i18n/locales/en/session.json
+++ b/apps/mobile/src/i18n/locales/en/session.json
@@ -248,7 +248,6 @@
     "backToMenu": "Back to session menu"
   },
   "messageMenu": {
-    "fork": "Start a new session",
     "addToChat": "Add to chat",
     "copyLink": "Copy current message link",
     "rewind": "Back to here",

--- a/apps/mobile/src/i18n/locales/ja/session.json
+++ b/apps/mobile/src/i18n/locales/ja/session.json
@@ -248,7 +248,6 @@
     "backToMenu": "セッションメニューに戻る"
   },
   "messageMenu": {
-    "fork": "新しいセッションで続ける",
     "addToChat": "会話に追加",
     "copyLink": "現在のメッセージリンクをコピー",
     "rewind": "ここまで戻る",

--- a/apps/mobile/src/i18n/locales/ko/session.json
+++ b/apps/mobile/src/i18n/locales/ko/session.json
@@ -248,7 +248,6 @@
     "backToMenu": "세션 메뉴로 돌아가기"
   },
   "messageMenu": {
-    "fork": "새 세션에서 계속하기",
     "addToChat": "대화에 추가",
     "copyLink": "현재 메시지 링크 복사",
     "rewind": "여기로 돌아가기",

--- a/apps/mobile/src/i18n/locales/zh-CN/session.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/session.json
@@ -248,7 +248,6 @@
     "backToMenu": "返回任务菜单"
   },
   "messageMenu": {
-    "fork": "开启一个新任务",
     "addToChat": "添加到对话",
     "copyLink": "复制当前消息链接",
     "rewind": "回到此处",

--- a/apps/mobile/src/session/MessageActionSheet.tsx
+++ b/apps/mobile/src/session/MessageActionSheet.tsx
@@ -23,11 +23,13 @@ const ACTION_ICONS: Record<MobileMessageMenuActionId, LucideIcon> = {
 
 /** Touch-first counterpart of desktop's compact More dropdown. */
 export function MessageActionSheet({
+  disabledActions,
   items,
   onAction,
   onClose,
   visible,
 }: {
+  disabledActions?: readonly MobileMessageMenuActionId[];
   items: readonly MobileMessageMenuItem[];
   onAction(action: MobileMessageMenuActionId): void;
   onClose(): void;
@@ -72,14 +74,21 @@ export function MessageActionSheet({
           {items.map((item) => {
             const Icon = ACTION_ICONS[item.id];
             const color = item.destructive ? colors.destructive : colors.sheetActionText;
+            const disabled = disabledActions?.includes(item.id) === true;
             return (
               <View key={item.id}>
                 {item.separatorBefore ? <View style={styles.separator} /> : null}
                 <Pressable
                   accessibilityLabel={item.label}
                   accessibilityRole="button"
+                  accessibilityState={{ disabled }}
+                  disabled={disabled}
                   onPress={() => select(item.id)}
-                  style={({ pressed }) => [styles.actionRow, pressed && styles.pressed]}
+                  style={({ pressed }) => [
+                    styles.actionRow,
+                    disabled && styles.disabled,
+                    pressed && styles.pressed,
+                  ]}
                   testID={`message.actions.${item.id}`}
                 >
                   <Icon color={color} size={iconSize.lg} strokeWidth={iconStroke.regular} />
@@ -123,6 +132,7 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     paddingHorizontal: spacing.lg,
   },
   separator: { backgroundColor: colors.sheetActionBorder, height: StyleSheet.hairlineWidth },
+  disabled: { opacity: 0.42 },
   actionLabel: {
     color: colors.sheetActionText,
     flexShrink: 1,

--- a/apps/mobile/src/session/MessageActionSheet.tsx
+++ b/apps/mobile/src/session/MessageActionSheet.tsx
@@ -3,7 +3,6 @@ import { Pressable, StyleSheet, View } from 'react-native';
 import {
   Link2,
   MessageSquarePlus,
-  Split,
   Trash2,
   Undo2,
   type LucideIcon,
@@ -16,7 +15,6 @@ import type { MobileMessageMenuActionId, MobileMessageMenuItem } from '@/session
 import { fontWeight, iconSize, iconStroke, lineHeight, radius, spacing, typeScale, useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 
 const ACTION_ICONS: Record<MobileMessageMenuActionId, LucideIcon> = {
-  fork: Split,
   'add-to-chat': MessageSquarePlus,
   'copy-link': Link2,
   rewind: Undo2,

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -2079,8 +2079,9 @@ function MessageBubble({
                 <MessageMoreButton
                   buttonSize={actionBar.buttonSize}
                   // Fork has its own visible busy state. Keep More available
-                  // while that direct action is running.
-                  disabled={disabled && !actionBusy}
+                  // only while that direct action is running; rewind/delete
+                  // still block the menu while their requests are in flight.
+                  disabled={disabled && !forkBusy}
                   iconSize={actionBar.iconSize}
                   key="more"
                   onPress={() => setActionSheetOpen(true)}

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -1769,18 +1769,18 @@ function MessageBubble({
     canAddToChat,
     canCopyLink,
     canDelete,
-    canFork,
     canRewind,
-  }), [canAddToChat, canCopyLink, canDelete, canFork, canRewind, i18nInstance.language]);
+  }), [canAddToChat, canCopyLink, canDelete, canRewind, i18nInstance.language]);
   const actionBar = useMemo(() => buildMessageActionBarPresentation({
     align: isUser ? 'user' : 'agent',
     canCopy,
+    canFork,
     hasMoreActions: messageMenu.length > 0,
     hasTime: !!relativeTime,
     // 金额与 token 回退占同一格,任一有值就保留该位置。
     hasTurnCost: !!turnCost || !!turnTokens,
     isStreaming: isStreamingAssistant,
-  }), [canCopy, isStreamingAssistant, isUser, messageMenu.length, relativeTime, turnCost, turnTokens]);
+  }), [canCopy, canFork, isStreamingAssistant, isUser, messageMenu.length, relativeTime, turnCost, turnTokens]);
   const hasActions = actionBar.items.length > 0;
   const actionBusy = !!clientId && actions.busyClientId === clientId;
   const disabled = !!actions.busyClientId;
@@ -1840,7 +1840,6 @@ function MessageBubble({
   ]);
   const selectMenuAction = useCallback((id: MobileMessageMenuActionId) => {
     if (!clientId) return;
-    if (id === 'fork') return selectControlAction('fork');
     if (id === 'rewind') return selectControlAction('rewind');
     if (id === 'delete') return selectControlAction('delete');
     if (id === 'add-to-chat') return actions.onAddMessageToComposer?.(clientId);
@@ -2072,7 +2071,9 @@ function MessageBubble({
               return (
                 <MessageMoreButton
                   buttonSize={actionBar.buttonSize}
-                  disabled={disabled || actionBusy}
+                  // Fork has its own visible busy state. Keep More available
+                  // while that direct action is running.
+                  disabled={disabled && !actionBusy}
                   iconSize={actionBar.iconSize}
                   key="more"
                   onPress={() => setActionSheetOpen(true)}
@@ -2083,6 +2084,7 @@ function MessageBubble({
               return (
                 <MessageControlButton
                   buttonSize={actionBar.buttonSize}
+                  busy={id === 'fork' && actionBusy}
                   copyState={copyState}
                   disabled={disabled || actionBusy || (id === 'copy' && copyState === 'copying')}
                   id={id}
@@ -5669,6 +5671,7 @@ function formatMediaPayloadBody(
 
 function MessageControlButton({
   buttonSize,
+  busy,
   copyState,
   disabled,
   id,
@@ -5676,6 +5679,7 @@ function MessageControlButton({
   onPress,
 }: {
   buttonSize: number;
+  busy?: boolean;
   copyState: CopyMessageStatus | 'idle' | 'copying';
   disabled?: boolean;
   id: MobileMessageControlActionId;
@@ -5700,7 +5704,7 @@ function MessageControlButton({
       ]}
       testID={messageControlActionTestID(id)}
     >
-      {messageControlActionIcon(id, copyState, iconSize, colors)}
+      {messageControlActionIcon(id, copyState, iconSize, colors, busy)}
     </Pressable>
   );
 }
@@ -5739,8 +5743,8 @@ function MessageMoreButton({
   );
 }
 
-function isMessageControlActionId(id: MessageActionBarItemId): id is 'copy' {
-  return id === 'copy';
+function isMessageControlActionId(id: MessageActionBarItemId): id is 'copy' | 'fork' {
+  return id === 'copy' || id === 'fork';
 }
 
 function messageControlActionLabel(
@@ -5765,7 +5769,11 @@ function messageControlActionIcon(
   copyState: CopyMessageStatus | 'idle' | 'copying',
   iconSize: number,
   colors: ThemeColors,
+  busy = false,
 ): ReactNode {
+  if (id === 'fork' && busy) {
+    return <ActivityIndicator color={colors.textSecondary} size="small" />;
+  }
   if (id === 'copy') {
     return copyState === 'copying'
       ? <ActivityIndicator color={colors.textSecondary} size="small" />

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -430,6 +430,8 @@ export interface MobileMessageDraft {
   orderedBody?: string;
 }
 
+export type MobileMessageActionBusyKind = 'fork' | 'rewind' | 'delete';
+
 interface MessageActions {
   /** 长按/操作条「复制消息链接」:复制该消息的会话深链(带 ?message= 锚点)。 */
   onCopyMessageLink?: (clientId: string) => void;
@@ -455,6 +457,7 @@ interface MessageActions {
   onReleaseRemoteMedia?: (sourceUrl: string, media: MobileResolvedRemoteMedia) => void;
   onResolveRemoteMedia?: ResolveRemoteMediaFn;
   busyClientId?: string | null;
+  busyAction?: MobileMessageActionBusyKind | null;
   canLoadEarlier?: boolean;
   loadingEarlier?: boolean;
   screenWidth?: number;
@@ -483,6 +486,7 @@ export function MessageRenderer({
   onShareImage,
   imageAnnotation,
   busyClientId,
+  busyAction,
   canLoadEarlier,
   emptyTestID,
   bottomOverlayHeight,
@@ -780,11 +784,13 @@ export function MessageRenderer({
     // undefined,渲染分支直接 null —— 气泡整个不画,乐观显示消失。
     pendingSend,
     busyClientId,
+    busyAction,
     firstUserMessageClientId,
     isSessionStreaming,
     screenWidth: viewportLayout.contentWidth,
   }), [
     busyClientId,
+    busyAction,
     firstUserMessageClientId,
     isSessionStreaming,
     onCopyMessageLink,
@@ -1783,6 +1789,7 @@ function MessageBubble({
   }), [canCopy, canFork, isStreamingAssistant, isUser, messageMenu.length, relativeTime, turnCost, turnTokens]);
   const hasActions = actionBar.items.length > 0;
   const actionBusy = !!clientId && actions.busyClientId === clientId;
+  const forkBusy = actionBusy && actions.busyAction === 'fork';
   const disabled = !!actions.busyClientId;
 
   useEffect(() => {
@@ -2084,7 +2091,7 @@ function MessageBubble({
               return (
                 <MessageControlButton
                   buttonSize={actionBar.buttonSize}
-                  busy={id === 'fork' && actionBusy}
+                  busy={id === 'fork' && forkBusy}
                   copyState={copyState}
                   disabled={disabled || actionBusy || (id === 'copy' && copyState === 'copying')}
                   id={id}
@@ -2099,6 +2106,7 @@ function MessageBubble({
         </View>
       ) : null}
       <MessageActionSheet
+        disabledActions={actionBusy ? ['rewind', 'delete'] : undefined}
         items={messageMenu}
         onAction={selectMenuAction}
         onClose={() => setActionSheetOpen(false)}

--- a/apps/mobile/src/session/messageActionMenu.ts
+++ b/apps/mobile/src/session/messageActionMenu.ts
@@ -7,7 +7,7 @@
  */
 import { i18n } from '@/i18n';
 
-export type MobileMessageMenuActionId = 'fork' | 'add-to-chat' | 'copy-link' | 'rewind' | 'delete';
+export type MobileMessageMenuActionId = 'add-to-chat' | 'copy-link' | 'rewind' | 'delete';
 
 export interface MobileMessageMenuItem {
   id: MobileMessageMenuActionId;
@@ -20,14 +20,13 @@ export function buildMobileMessageMenu(input: {
   canAddToChat: boolean;
   canCopyLink: boolean;
   canDelete: boolean;
-  canFork: boolean;
   canRewind: boolean;
 }): MobileMessageMenuItem[] {
   const items: MobileMessageMenuItem[] = [];
   // 语义与 desktop 的 chat.messageActionBar.* 一一对应:fork 产出的是一条新任务;
-  // copy-link 复制的是带 messageClientId 的消息深链;delete 删的是单条消息。
+  // fork 已与复制同级外显;copy-link 复制的是带 messageClientId 的消息深链;
+  // delete 删的是单条消息。
   // 「添加到对话」指发进当前对话流,按 naming 规则保持「对话」。
-  if (input.canFork) items.push({ id: 'fork', label: i18n.t('session.messageMenu.fork') });
   if (input.canAddToChat) {
     items.push({ id: 'add-to-chat', label: i18n.t('session.messageMenu.addToChat') });
   }

--- a/apps/mobile/src/session/messageActions.ts
+++ b/apps/mobile/src/session/messageActions.ts
@@ -49,7 +49,7 @@ export interface MobileMessageActionBarInput {
 }
 
 /**
- * 消息行是否挂完成态操作条(复制 / 时间 / 花费 / More)。三条规则都对齐桌面:
+ * 消息行是否挂完成态操作条(复制 / 新任务 / 时间 / 花费 / More)。三条规则都对齐桌面:
  * - 流式 assistant 只显示「生成中」,不挂完成态操作;
  * - assistant 只有每轮收尾正文挂(桌面 AssistantMessage 的 showActionBar,#456);
  * - 系统边界卡整行不挂:它不是任何人的发言,没有复制 / 分叉 / 消息锚点 / 发送时间

--- a/packages/maker-shared/src/__tests__/messagePresentation.test.ts
+++ b/packages/maker-shared/src/__tests__/messagePresentation.test.ts
@@ -83,6 +83,7 @@ describe('messagePresentation', () => {
     expect(buildMessageActionBarPresentation({
       align: 'agent',
       canCopy: true,
+      canFork: true,
       hasMoreActions: true,
       hasTime: true,
       hasTurnCost: true,
@@ -91,12 +92,13 @@ describe('messagePresentation', () => {
       align: 'left',
       buttonSize: 24,
       iconSize: 14,
-      items: ['copy', 'more', 'time', 'cost'],
+      items: ['copy', 'fork', 'more', 'time', 'cost'],
     });
 
     expect(buildMessageActionBarPresentation({
       align: 'user',
       canCopy: true,
+      canFork: true,
       hasMoreActions: true,
       hasTime: true,
       hasTurnCost: true,
@@ -105,12 +107,13 @@ describe('messagePresentation', () => {
       align: 'right',
       buttonSize: 24,
       iconSize: 14,
-      items: ['time', 'copy', 'more'],
+      items: ['time', 'copy', 'fork', 'more'],
     });
 
     expect(buildMessageActionBarPresentation({
       align: 'agent',
       canCopy: true,
+      canFork: false,
       hasMoreActions: true,
       hasTime: true,
       hasTurnCost: true,

--- a/packages/maker-shared/src/messagePresentation.ts
+++ b/packages/maker-shared/src/messagePresentation.ts
@@ -84,11 +84,12 @@ export interface TodoCardPresentation {
 
 export type MessageActionBarAlignment = 'left' | 'right';
 
-export type MessageActionBarItemId = 'copy' | 'cost' | 'more' | 'streaming' | 'time';
+export type MessageActionBarItemId = 'copy' | 'cost' | 'fork' | 'more' | 'streaming' | 'time';
 
 export interface MessageActionBarPresentationInput {
   align: 'agent' | 'user';
   canCopy: boolean;
+  canFork: boolean;
   hasMoreActions?: boolean;
   hasTime: boolean;
   hasTurnCost: boolean;
@@ -359,16 +360,18 @@ export function buildMessageActionBarPresentation(
   }
 
   const agentItems: Array<MessageActionBarItemId | null> = [
-      input.canCopy ? 'copy' : null,
-      input.hasMoreActions ? 'more' : null,
-      input.hasTime ? 'time' : null,
-      input.hasTurnCost ? 'cost' : null,
-    ];
+    input.canCopy ? 'copy' : null,
+    input.canFork ? 'fork' : null,
+    input.hasMoreActions ? 'more' : null,
+    input.hasTime ? 'time' : null,
+    input.hasTurnCost ? 'cost' : null,
+  ];
   const userItems: Array<MessageActionBarItemId | null> = [
-      input.hasTime ? 'time' : null,
-      input.canCopy ? 'copy' : null,
-      input.hasMoreActions ? 'more' : null,
-    ];
+    input.hasTime ? 'time' : null,
+    input.canCopy ? 'copy' : null,
+    input.canFork ? 'fork' : null,
+    input.hasMoreActions ? 'more' : null,
+  ];
   const items = (input.align === 'agent' ? agentItems : userItems).filter(isMessageActionBarItemId);
 
   return {


### PR DESCRIPTION
## 这次改了什么

### 摘要

将消息操作条里的 Fork（开启新任务）从三个点菜单提升为与复制同级的直接操作，并统一 Desktop 与 Mobile 的进行中状态表现。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（来自产品反馈）
- 本 PR 包含：Desktop 与 Mobile 消息操作条的 Fork 外显、菜单清理、异步状态与回归断言。
- 明确不包含：Fork 服务端行为、协议、数据结构和原生配置。
- 用户可见变化：复制旁新增 Fork 按钮；Fork 进行时按钮显示转圈；三个点保持静态，不因 Fork 进行而变成转圈或禁用。
- 是否存在 breaking change：无。

### UI 变化

- 平台：Desktop、Mobile。
- 截图 / 录屏：未附；本次未重新启动 Mobile 模拟器进行额外录制。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md`：操作状态使用清晰、可见的反馈；颜色复用语义 token，兼容 Light / Dark。
  - `apps/mobile/docs/mobile-design-guide.md`：使用 lucide-react-native 同源图标、主题颜色 token 与触控 hitSlop；仅调整操作条状态，不新增原生 UI。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-expose-new-task-action
结果：GATE_EXIT=0，全量 pnpm test:unit 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter mobile run --if-present typecheck
结果：通过。

pnpm --filter mobile exec vitest run src/__tests__/messageActionDesktopFirst.test.ts src/__tests__/messageActionMenu.test.ts
结果：17 项通过。

pnpm check:dco
结果：1 个提交均已 Signed-off-by，通过。
```

### 手工验证

Desktop 开发版已观察 Fork 点击后显示转圈、三个点保持 Ellipsis。Mobile 本次未重新启动模拟器或真机验证。

### 未执行的验证

Mobile 模拟器 / 真机目检未执行：当前工作在 `/Users/dash/Code/Cindy/cindy-expose-new-task-action`（`dash/expose-new-task-action`）完成，未重新启动 Mobile Metro 或模拟器；相关代码路径已通过类型检查与定向测试。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 与 Mobile 已完成消息的操作条；未修改原生配置，因此不改变 Mobile runtime fingerprint，也不触发冷更。
- 回滚 / 降级方式：回滚提交 `8595e57b` 即可恢复 Fork 收在三个点菜单中的旧行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
