### PR TITLE
fix(desktop): 修复新建对话语音输入无法停止

### DIFF
--- a/apps/desktop/src/renderer/__tests__/voiceInputButtonAnchor.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputButtonAnchor.test.ts
@@ -63,6 +63,15 @@ describe('ChatInput voice button anchor contract', () => {
     expect(slotDecisionBlock).not.toContain('voiceInput.isListening');
     expect(slotDecisionBlock).toContain('voiceInput.isBusy');
   });
+
+  it('keeps the stop controls enabled while voice input owns the editor lock', () => {
+    // The surrounding voice lifecycle lock must not disable the button or
+    // shortcut that is needed to end the active recording.
+    expect(chatInputSource).toContain('const disabledRef = useRef(composerEditorLocked);');
+    expect(chatInputSource).toContain('disabledRef.current = composerEditorLocked;');
+    expect(chatInputSource).toContain('disabled={composerEditorLocked || !editor}');
+    expect(chatInputSource).not.toContain('disabled={composerMutationLocked || !editor}');
+  });
 });
 
 function extractBetween(sourceBlock: string, startNeedle: string, endNeedle: string): string {

--- a/apps/desktop/src/renderer/__tests__/voiceInputEditorEditability.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputEditorEditability.test.ts
@@ -20,14 +20,24 @@ describe('ChatInput voice lifecycle locks', () => {
 
   it('keeps attachments locked while leaving permission mode available', () => {
     const extraDirsStart = chatInputSource.indexOf('<ExtraDirsButton');
+    expect(extraDirsStart).toBeGreaterThanOrEqual(0);
     const extraDirsEnd = chatInputSource.indexOf('/>', extraDirsStart);
+    expect(extraDirsEnd).toBeGreaterThan(extraDirsStart);
     const extraDirsBlock = chatInputSource.slice(extraDirsStart, extraDirsEnd);
     expect(extraDirsBlock).toContain('disabled={composerMutationLocked}');
 
     const permissionStart = chatInputSource.indexOf('<PermissionSelector');
+    expect(permissionStart).toBeGreaterThanOrEqual(0);
     const permissionEnd = chatInputSource.indexOf('/>', permissionStart);
+    expect(permissionEnd).toBeGreaterThan(permissionStart);
     const permissionBlock = chatInputSource.slice(permissionStart, permissionEnd);
     expect(permissionBlock).toContain('disabled={composerEditorLocked}');
     expect(permissionBlock).not.toContain('disabled={composerMutationLocked}');
+  });
+
+  it('lets an alert dialog consume Escape before voice cancellation', () => {
+    expect(chatInputSource).toContain(
+      "event.target instanceof Element &&\n        event.target.closest('[role=\"alertdialog\"]')",
+    );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/voiceInputEditorEditability.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputEditorEditability.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const chatInputSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'new-chat', 'ChatInput.tsx'),
+  'utf8',
+).replace(/\r\n?/g, '\n');
+
+describe('ChatInput voice lifecycle locks', () => {
+  it('keeps the editor read-only for the entire voice lifecycle', () => {
+    expect(chatInputSource).toContain(
+      'const composerMutationLocked = composerEditorLocked || voiceInput.isBusy;',
+    );
+    expect(chatInputSource).toContain('editor?.setEditable(!composerMutationLocked);');
+    expect(chatInputSource).toContain('if (composerMutationLockedRef.current) return true;');
+    expect(chatInputSource).toContain('active={voiceInput.isBusy}');
+  });
+
+  it('keeps attachments locked while leaving permission mode available', () => {
+    const extraDirsStart = chatInputSource.indexOf('<ExtraDirsButton');
+    const extraDirsEnd = chatInputSource.indexOf('/>', extraDirsStart);
+    const extraDirsBlock = chatInputSource.slice(extraDirsStart, extraDirsEnd);
+    expect(extraDirsBlock).toContain('disabled={composerMutationLocked}');
+
+    const permissionStart = chatInputSource.indexOf('<PermissionSelector');
+    const permissionEnd = chatInputSource.indexOf('/>', permissionStart);
+    const permissionBlock = chatInputSource.slice(permissionStart, permissionEnd);
+    expect(permissionBlock).toContain('disabled={composerEditorLocked}');
+    expect(permissionBlock).not.toContain('disabled={composerMutationLocked}');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/voiceInputEditorEditability.test.ts
+++ b/apps/desktop/src/renderer/__tests__/voiceInputEditorEditability.test.ts
@@ -35,9 +35,24 @@ describe('ChatInput voice lifecycle locks', () => {
     expect(permissionBlock).not.toContain('disabled={composerMutationLocked}');
   });
 
-  it('lets an alert dialog consume Escape before voice cancellation', () => {
-    expect(chatInputSource).toContain(
-      "event.target instanceof Element &&\n        event.target.closest('[role=\"alertdialog\"]')",
+  it('lets top-level permission surfaces consume Escape before voice cancellation', () => {
+    const shortcutHandlerStart = chatInputSource.indexOf(
+      'const handleKeyDown = (event: KeyboardEvent) => {',
+    );
+    expect(shortcutHandlerStart).toBeGreaterThanOrEqual(0);
+    const shortcutHandlerEnd = chatInputSource.indexOf(
+      'const enterIntent = resolveComposerEnterIntent(',
+      shortcutHandlerStart,
+    );
+    expect(shortcutHandlerEnd).toBeGreaterThan(shortcutHandlerStart);
+    const shortcutHandlerBlock = chatInputSource.slice(shortcutHandlerStart, shortcutHandlerEnd);
+
+    expect(shortcutHandlerBlock).toContain('[role="alertdialog"]');
+    expect(shortcutHandlerBlock).toContain('[data-morph-side]');
+    const voiceCancelStart = shortcutHandlerBlock.indexOf('voiceInputCancelRef.current()');
+    expect(voiceCancelStart).toBeGreaterThanOrEqual(0);
+    expect(shortcutHandlerBlock.indexOf('[data-morph-side]')).toBeLessThan(
+      voiceCancelStart,
     );
   });
 });

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2471,7 +2471,10 @@ export function ChatInput({
   const voiceInputCanStopAndSendRef = useRef(false);
   const composerCanSubmitRef = useRef(false);
   const handleVoiceInputStartRef = useRef(handleVoiceInputStart);
-  const disabledRef = useRef(composerMutationLocked);
+  // The voice lifecycle locks surrounding composer mutations while listening,
+  // but that must not disable the shortcut that stops the active recording.
+  // Keep this ref on the external composer lock only (disabled / send preflight).
+  const disabledRef = useRef(composerEditorLocked);
   const disableAutofocusRef = useRef(disableAutofocus);
   const focusOnStorageKeyChangeRef = useRef(focusOnStorageKeyChange);
   const latestStorageKeyRef = useRef<string | undefined>(storageKey);
@@ -2501,11 +2504,11 @@ export function ChatInput({
     voiceInputStopRef.current = handleVoiceInputStopWithRefinement;
     voiceInputCancelRef.current = voiceInput.cancel;
     handleVoiceInputStartRef.current = handleVoiceInputStart;
-    disabledRef.current = composerMutationLocked;
+    disabledRef.current = composerEditorLocked;
     disableAutofocusRef.current = disableAutofocus;
     focusOnStorageKeyChangeRef.current = focusOnStorageKeyChange;
   }, [
-    composerMutationLocked,
+    composerEditorLocked,
     disableAutofocus,
     focusOnStorageKeyChange,
     handleVoiceInputStart,
@@ -6009,7 +6012,7 @@ export function ChatInput({
                   onPermissionModeChange={handlePermissionModeChange}
                   vendorKey={vendorKey}
                   deviceId={deviceLinkDeviceId}
-                  disabled={composerMutationLocked}
+                  disabled={composerEditorLocked}
                   dense={effectiveDenseToolbar}
                   iconOnly={useUltraCompactToolbar}
                   visualVariant={isCreateAgentVariant ? 'create-agent' : 'default'}
@@ -6116,7 +6119,9 @@ export function ChatInput({
                   )}
                   <VoiceInputButton
                     state={voiceInput.state}
-                    disabled={composerMutationLocked || !editor}
+                    // The surrounding controls stay locked during voice input, but
+                    // this control must remain enabled so the recording can stop.
+                    disabled={composerEditorLocked || !editor}
                     shortcutLabel={voiceInputShortcutLabel}
                     onStart={handleVoiceInputStart}
                     onStop={handleVoiceInputPlainStop}

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2540,10 +2540,12 @@ export function ChatInput({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const currentState = voiceInputStateRef.current;
+      // 权限菜单 / 确认框是当前顶层交互面，应先消费 Esc；它们的 capture handler
+      // 注册在 document 或组件层，晚于本 window capture handler 执行。
       if (
         event.key === 'Escape' &&
         event.target instanceof Element &&
-        event.target.closest('[role="alertdialog"]')
+        event.target.closest('[role="alertdialog"], [data-morph-side]')
       ) {
         return;
       }

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -2540,6 +2540,13 @@ export function ChatInput({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       const currentState = voiceInputStateRef.current;
+      if (
+        event.key === 'Escape' &&
+        event.target instanceof Element &&
+        event.target.closest('[role="alertdialog"]')
+      ) {
+        return;
+      }
       const platform = window.electronAPI?.platform;
       if (event.key === 'Escape' && !event.repeat && !event.isComposing) {
         if (


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复新建对话中语音输入开始后无法停止的问题，并明确录音期间各控件的锁定边界：

- 正文编辑器在录音期间保持只读。
- 加号、附件等内容变更入口继续锁定。
- 权限模式选择器在录音期间保持可用。
- 语音停止按钮和 F16 快捷键不再被语音生命周期锁禁用。

根因是提交 `0e19d0298`（2026-08-03）将 `voiceInput.isBusy` 复用于停止按钮和 F16 的禁用判断；新建对话路径没有任务停止按钮兜底，因此录音无法结束。

### 变更类型

- [x] `fix`
- [ ] `feat`
- [ ] `refactor` / `perf`
- [x] `docs` / `test` / `chore`
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈新建对话语音输入按钮无法停止。
- 本 PR 包含：Desktop 新建对话 composer 的语音生命周期锁、权限控件可用性、停止按钮/F16 回归测试。
- 明确不包含：服务端、Mobile、语音识别协议和录音引擎实现。
- 用户可见变化：录音时可以通过按钮或 F16 停止；权限模式仍可切换；正文和附件入口保持只读/锁定。
- 是否存在 breaking change：无。

## UI 变化

- 截图或录屏：未附；本次为状态与交互修复，无布局、颜色或视觉 token 变化。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §10「Light / Dark 双模式交付门槛」；复用现有状态样式，未新增颜色或布局。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-voice-input-stop
结果：GATE_EXIT=0

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/new-chat/ChatInput.tsx src/renderer/__tests__/voiceInputButtonAnchor.test.ts src/renderer/__tests__/voiceInputEditorEditability.test.ts
结果：通过

pnpm check:dco
结果：1 个 commit 已通过 DCO 签名检查

语音输入相关 Vitest
结果：25 个测试文件、153 项通过
```

### 手工验证

macOS Desktop Global 开发版已从本 worktree 启动并通过 `pnpm desktop:whoami` 确认来源匹配、状态 Ready；实例为 remote passive 模式，PID `81040`。

### 未执行的验证

未完成真实麦克风录音与停止按钮点击的最终手工回归；已完成开发版启动来源核对和自动化测试。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 新建对话 composer 的语音输入交互。
- 回滚 / 降级方式：回滚本 PR commit 即可恢复原有禁用判断。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果并说明未执行的手工验证
