### PR TITLE
feat(local-proxy): 对外开放本地模型代理(Anthropic + Codex/OpenAI)

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -358,6 +358,7 @@ import { registerSidebarSettingsIpc } from './sidebarSettingsStore';
 import { registerRemotePrecreatedWorktreeLedgerIpc } from './remotePrecreatedWorktreeLedger';
 import { registerTerminalHandlers } from './maker-ipc/terminal-handlers';
 import { registerLocalThemesIpc } from './local-themes/register';
+import { registerLocalProxyServiceIpc } from './local-proxy-service/register';
 import {
   registerRemoteSshIpc,
   disposeRemoteSshPool,
@@ -6453,6 +6454,7 @@ app.on('ready', async () => {
       mainWindowRef && !mainWindowRef.isDestroyed() ? mainWindowRef.webContents : null,
   });
   registerLocalThemesIpc();
+  registerLocalProxyServiceIpc();
   registerVoiceInputIpc();
   registerGlobalVoiceInputIpc({
     getMainWindow: () => mainWindowRef,

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -412,12 +412,14 @@ import { clearXaiRateLimitSnapshot } from './usageBroadcaster.js';
 import {
   ensureAnthropicCompatProxyReady,
   disposeAnthropicCompatProxy,
+  disposeAnthropicExternalProxy,
 } from './maker-host/anthropic-compat-proxy-host.js';
 import {
   onClaudeSessionRouteChange,
   readClaudeSessionRoute,
 } from './maker-host/claude-session-route-registry.js';
 import {
+  disposeCodexExternalProxy,
   disposeCodexProxy,
   getCodexProxyAuthInjectionState,
 } from './maker-host/codex-proxy-host.js';
@@ -6694,11 +6696,15 @@ onQuit('embedding-host', () => stopEmbeddingHost(), 'async');
 // Claude CLI 子进程收到 ECONNRESET, 但 session 本来就在 close 路径上, 这种 error 直接
 // 被吞, 影响可接受。
 onQuit('anthropic-compat-proxy', () => disposeAnthropicCompatProxy(), 'async');
+// 对外 loopback(端口拆分,#1666)是独立 handle,单独关。同为 async 阶段,权衡同上。
+onQuit('anthropic-external-proxy', () => disposeAnthropicExternalProxy(), 'async');
 // browser-runtime: stop the managed Chrome so it doesn't outlive the app (headed
 // browser + locked user-data-dir would otherwise survive quit and force a stale
 // SingletonLock recovery next launch). `stop` is idempotent / no-op if never started.
 onQuit('browser-runtime', () => disposeBrowserRuntime(), 'async');
 onQuit('codex-proxy', () => disposeCodexProxy(), 'async');
+// 对外 codex loopback(端口拆分,#1666 Finding 2)是独立 handle,单独关。同为 async 阶段。
+onQuit('codex-external-proxy', () => disposeCodexExternalProxy(), 'async');
 // Remote file-service clients: 先于 pool 关闭, 挂断远端 daemon 的 exec channel。
 onQuit('remote-file-browser', () => disposeRemoteFileBrowser(), 'async');
 // Remote SSH pool: 主动断开所有活动连接, 防止 ssh2 子句柄阻塞 Node 进程退出。

--- a/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
@@ -98,6 +98,19 @@ describe('codex-external-config-writer — preview', () => {
     expect(previewCodexConfig(URL, TOKEN).conflicts).toEqual([]);
   });
 
+  it('已有 supports_websockets=true(boolean)→ 报告为将被覆盖成 false 的冲突', () => {
+    writeFileSync(
+      configPath(),
+      ['[model_providers.cindy_external]', 'supports_websockets = true'].join('\n'),
+      'utf8',
+    );
+    expect(previewCodexConfig(URL, TOKEN).conflicts).toContainEqual({
+      key: 'model_providers.cindy_external.supports_websockets',
+      current: 'true',
+      next: 'false',
+    });
+  });
+
   // Finding G:proposedToml 只回 Cindy 会改动的两处片段,绝不把用户既有的其它 provider / MCP
   // 凭证 merge 进去回给 renderer。受注入的渲染进程只要调预览就能读走整份配置里的密文。
   it('proposedToml 不含用户既有的其它 provider 块及其密文(只含 cindy_external)', () => {
@@ -152,7 +165,29 @@ describe('codex-external-config-writer — write（非破坏性 merge）', () =>
       base_url: URL,
       wire_api: 'responses',
       env_key: 'CINDY_LOCAL_TOKEN',
+      // 安全(#1666 review):必须写死 false,否则外部 Codex CLI 一开 Responses WebSocket,
+      // proxy 的 upgrade 处理会连同 CINDY_LOCAL_TOKEN 头直送固定上游,绕过对外鉴权/strip。
+      supports_websockets: false,
     });
+  });
+
+  it('写入的 cindy_external 必带 supports_websockets=false(禁 WS,与内部 cindy_gateway 对称)', () => {
+    writeCodexConfig(URL);
+    const parsed = parseToml(readFileSync(configPath(), 'utf8')) as Record<string, unknown>;
+    const providers = parsed.model_providers as Record<string, Record<string, unknown>>;
+    expect(providers.cindy_external.supports_websockets).toBe(false);
+  });
+
+  it('用户已有 supports_websockets=true → 被强制覆盖为 false', () => {
+    writeFileSync(
+      configPath(),
+      ['[model_providers.cindy_external]', 'supports_websockets = true'].join('\n'),
+      'utf8',
+    );
+    writeCodexConfig(URL);
+    const parsed = parseToml(readFileSync(configPath(), 'utf8')) as Record<string, unknown>;
+    const providers = parsed.model_providers as Record<string, Record<string, unknown>>;
+    expect(providers.cindy_external.supports_websockets).toBe(false);
   });
 
   it('保留其它顶层字段与其它 provider 块,只动 model_provider 与 cindy_external', () => {

--- a/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
@@ -21,6 +21,7 @@ import {
 } from '../codex-external-config-writer';
 
 const URL = 'http://127.0.0.1:51888';
+// test fixture — not a real token. 虚构的 Cindy 本地代理 token 占位值,仅供单测。
 const TOKEN = 'cindy-local-abcdef';
 
 let dir: string;
@@ -114,7 +115,9 @@ describe('codex-external-config-writer — preview', () => {
   // Finding G:proposedToml 只回 Cindy 会改动的两处片段,绝不把用户既有的其它 provider / MCP
   // 凭证 merge 进去回给 renderer。受注入的渲染进程只要调预览就能读走整份配置里的密文。
   it('proposedToml 不含用户既有的其它 provider 块及其密文(只含 cindy_external)', () => {
-    const OTHER_PROVIDER_SECRET = 'sk-other-provider-secret-key';
+    // test fixture — not a real key. 虚构占位值,仅用于断言预览会把「用户既有的其它 provider
+    // 密文」剔除(见下方 not.toContain 断言);sk- 前缀纯为触发/模拟真实密钥形状,并非真实凭证。
+    const OTHER_PROVIDER_SECRET = 'sk-not-a-real-key-test-fixture';
     writeFileSync(
       configPath(),
       [
@@ -126,14 +129,15 @@ describe('codex-external-config-writer — preview', () => {
         `api_key = "${OTHER_PROVIDER_SECRET}"`,
         '',
         '[mcp_servers.secret_tool]',
-        'auth_token = "mcp-secret-token-xyz"',
+        // test fixture — not a real token. 同上,虚构值,用于断言 MCP 段密文不进预览。
+        'auth_token = "not-a-real-token-test-fixture"',
       ].join('\n'),
       'utf8',
     );
     const preview = previewCodexConfig(URL, TOKEN);
     // 既有密文绝不出现在预览里。
     expect(preview.proposedToml).not.toContain(OTHER_PROVIDER_SECRET);
-    expect(preview.proposedToml).not.toContain('mcp-secret-token-xyz');
+    expect(preview.proposedToml).not.toContain('not-a-real-token-test-fixture');
     expect(preview.proposedToml).not.toContain('model_providers.other');
     expect(preview.proposedToml).not.toContain('mcp_servers');
     // 只含 Cindy 会写的那两处。

--- a/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
@@ -97,6 +97,45 @@ describe('codex-external-config-writer — preview', () => {
     writeFileSync(configPath(), `model_provider = "cindy_external"\n`, 'utf8');
     expect(previewCodexConfig(URL, TOKEN).conflicts).toEqual([]);
   });
+
+  // Finding G:proposedToml 只回 Cindy 会改动的两处片段,绝不把用户既有的其它 provider / MCP
+  // 凭证 merge 进去回给 renderer。受注入的渲染进程只要调预览就能读走整份配置里的密文。
+  it('proposedToml 不含用户既有的其它 provider 块及其密文(只含 cindy_external)', () => {
+    const OTHER_PROVIDER_SECRET = 'sk-other-provider-secret-key';
+    writeFileSync(
+      configPath(),
+      [
+        'model_provider = "other"',
+        '',
+        '[model_providers.other]',
+        'name = "Other"',
+        'base_url = "https://other.example/v1"',
+        `api_key = "${OTHER_PROVIDER_SECRET}"`,
+        '',
+        '[mcp_servers.secret_tool]',
+        'auth_token = "mcp-secret-token-xyz"',
+      ].join('\n'),
+      'utf8',
+    );
+    const preview = previewCodexConfig(URL, TOKEN);
+    // 既有密文绝不出现在预览里。
+    expect(preview.proposedToml).not.toContain(OTHER_PROVIDER_SECRET);
+    expect(preview.proposedToml).not.toContain('mcp-secret-token-xyz');
+    expect(preview.proposedToml).not.toContain('model_providers.other');
+    expect(preview.proposedToml).not.toContain('mcp_servers');
+    // 只含 Cindy 会写的那两处。
+    const parsed = parseToml(preview.proposedToml) as Record<string, unknown>;
+    expect(parsed.model_provider).toBe('cindy_external');
+    const providers = parsed.model_providers as Record<string, unknown>;
+    expect(Object.keys(providers)).toEqual(['cindy_external']);
+    expect(parsed.mcp_servers).toBeUndefined();
+    // 冲突项仍照常暴露(供用户判断会覆盖什么),但那是 Cindy 自己块的键,非其它 provider 密文。
+    expect(preview.conflicts).toContainEqual({
+      key: 'model_provider',
+      current: 'other',
+      next: 'cindy_external',
+    });
+  });
 });
 
 describe('codex-external-config-writer — write（非破坏性 merge）', () => {
@@ -204,5 +243,21 @@ describe('codex-external-config-writer — write（非破坏性 merge）', () =>
   posixIt('新建文件默认收紧到 0600', () => {
     expect(writeCodexConfig(URL).success).toBe(true);
     expect(statSync(configPath()).mode & 0o777).toBe(0o600);
+  });
+
+  // Finding I:temp 必须**在写入任何密文前**就以 0600 创建 —— 若先按默认 mode(umask 022 → 0644)
+  // 建 temp 再 chmod,那一瞬间 merge 后含用户既有 provider/MCP 凭证的密文就是世界可读的。
+  it('writeFileSync 建 temp 时即带 mode:0600(不是先建 0644 再 chmod)', async () => {
+    const fsModule = await import('node:fs');
+    const spy = vi.spyOn(fsModule.default, 'writeFileSync');
+    try {
+      expect(writeCodexConfig(URL).success).toBe(true);
+      const tempWrite = spy.mock.calls.find(([p]) => String(p).endsWith('.tmp'));
+      expect(tempWrite).toBeDefined();
+      const options = tempWrite?.[2];
+      expect(options).toMatchObject({ mode: 0o600 });
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
@@ -1,0 +1,186 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parse as parseToml } from 'smol-toml';
+
+// logger 顶层 import electron 的 app —— 无 electron 的 vitest 环境用轻量替身隔离掉。
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  }),
+}));
+
+import {
+  previewCodexConfig,
+  writeCodexConfig,
+} from '../codex-external-config-writer';
+
+const URL = 'http://127.0.0.1:51888';
+const TOKEN = 'cindy-local-abcdef';
+
+let dir: string;
+let prevCodexHome: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), 'cindy-codex-config-'));
+  prevCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = dir;
+});
+
+afterEach(() => {
+  if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+  else process.env.CODEX_HOME = prevCodexHome;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function configPath(): string {
+  return path.join(dir, 'config.toml');
+}
+
+describe('codex-external-config-writer — preview', () => {
+  it('文件不存在:exists=false,无冲突,proposedToml 含 cindy_external,token 只在 export 行', () => {
+    const preview = previewCodexConfig(URL, TOKEN);
+    expect(preview.exists).toBe(false);
+    expect(preview.conflicts).toEqual([]);
+    expect(preview.path).toBe(configPath());
+    const parsed = parseToml(preview.proposedToml) as Record<string, unknown>;
+    expect(parsed.model_provider).toBe('cindy_external');
+    const providers = parsed.model_providers as Record<string, Record<string, unknown>>;
+    expect(providers.cindy_external).toMatchObject({
+      name: 'Cindy',
+      base_url: URL,
+      wire_api: 'responses',
+      env_key: 'CINDY_LOCAL_TOKEN',
+    });
+    // token 绝不进 TOML;只在给用户复制的 export 行里。
+    expect(preview.proposedToml).not.toContain(TOKEN);
+    expect(preview.tokenExportLine).toBe(`export CINDY_LOCAL_TOKEN=${TOKEN}`);
+  });
+
+  it('已有不同的 model_provider / base_url → 报告冲突项', () => {
+    writeFileSync(
+      configPath(),
+      [
+        'model_provider = "openai"',
+        '',
+        '[model_providers.cindy_external]',
+        'base_url = "http://old"',
+        'env_key = "OTHER_KEY"',
+      ].join('\n'),
+      'utf8',
+    );
+    const preview = previewCodexConfig(URL, TOKEN);
+    expect(preview.exists).toBe(true);
+    expect(preview.conflicts).toContainEqual({
+      key: 'model_provider',
+      current: 'openai',
+      next: 'cindy_external',
+    });
+    expect(preview.conflicts).toContainEqual({
+      key: 'model_providers.cindy_external.base_url',
+      current: 'http://old',
+      next: URL,
+    });
+    expect(preview.conflicts).toContainEqual({
+      key: 'model_providers.cindy_external.env_key',
+      current: 'OTHER_KEY',
+      next: 'CINDY_LOCAL_TOKEN',
+    });
+  });
+
+  it('已有同值不算冲突', () => {
+    writeFileSync(configPath(), `model_provider = "cindy_external"\n`, 'utf8');
+    expect(previewCodexConfig(URL, TOKEN).conflicts).toEqual([]);
+  });
+});
+
+describe('codex-external-config-writer — write（非破坏性 merge）', () => {
+  it('新建文件:写入 cindy_external 块 + model_provider,token 不入文件', () => {
+    const res = writeCodexConfig(URL);
+    expect(res.success).toBe(true);
+    const raw = readFileSync(configPath(), 'utf8');
+    expect(raw).not.toContain(TOKEN);
+    const parsed = parseToml(raw) as Record<string, unknown>;
+    expect(parsed.model_provider).toBe('cindy_external');
+    const providers = parsed.model_providers as Record<string, Record<string, unknown>>;
+    expect(providers.cindy_external).toEqual({
+      name: 'Cindy',
+      base_url: URL,
+      wire_api: 'responses',
+      env_key: 'CINDY_LOCAL_TOKEN',
+    });
+  });
+
+  it('保留其它顶层字段与其它 provider 块,只动 model_provider 与 cindy_external', () => {
+    writeFileSync(
+      configPath(),
+      [
+        'model = "gpt-5"',
+        'model_provider = "other"',
+        '',
+        '[model_providers.other]',
+        'name = "Other"',
+        'base_url = "https://other.example/v1"',
+        '',
+        '[tui]',
+        'theme = "dark"',
+      ].join('\n'),
+      'utf8',
+    );
+    const res = writeCodexConfig(URL);
+    expect(res.success).toBe(true);
+    const parsed = parseToml(readFileSync(configPath(), 'utf8')) as Record<string, unknown>;
+    // 顶层无关字段保留。
+    expect(parsed.model).toBe('gpt-5');
+    expect(parsed.tui).toEqual({ theme: 'dark' });
+    // model_provider 被切到 cindy_external。
+    expect(parsed.model_provider).toBe('cindy_external');
+    const providers = parsed.model_providers as Record<string, Record<string, unknown>>;
+    // 其它 provider 块原样保留。
+    expect(providers.other).toEqual({
+      name: 'Other',
+      base_url: 'https://other.example/v1',
+    });
+    // cindy_external 块被写入。
+    expect(providers.cindy_external).toMatchObject({ base_url: URL, env_key: 'CINDY_LOCAL_TOKEN' });
+  });
+
+  it('已有 cindy_external 块的额外字段被保留,只覆盖我们管的四键', () => {
+    writeFileSync(
+      configPath(),
+      [
+        '[model_providers.cindy_external]',
+        'base_url = "http://stale"',
+        'query_params = { foo = "bar" }',
+      ].join('\n'),
+      'utf8',
+    );
+    writeCodexConfig(URL);
+    const parsed = parseToml(readFileSync(configPath(), 'utf8')) as Record<string, unknown>;
+    const block = (parsed.model_providers as Record<string, Record<string, unknown>>)
+      .cindy_external;
+    expect(block.base_url).toBe(URL); // 覆盖
+    expect(block.query_params).toEqual({ foo: 'bar' }); // 保留额外字段
+  });
+
+  it('损坏 TOML → 不覆盖,返回失败', () => {
+    writeFileSync(configPath(), 'this is [ not valid toml', 'utf8');
+    const res = writeCodexConfig(URL);
+    expect(res.success).toBe(false);
+    // 原坏文件保持不动。
+    expect(readFileSync(configPath(), 'utf8')).toBe('this is [ not valid toml');
+  });
+
+  it('空文件视为无配置,可安全新建结构', () => {
+    writeFileSync(configPath(), '   \n', 'utf8');
+    const res = writeCodexConfig(URL);
+    expect(res.success).toBe(true);
+    const parsed = parseToml(readFileSync(configPath(), 'utf8')) as Record<string, unknown>;
+    expect(parsed.model_provider).toBe('cindy_external');
+  });
+});

--- a/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/codex-external-config-writer.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -182,5 +182,27 @@ describe('codex-external-config-writer — write（非破坏性 merge）', () =>
     expect(res.success).toBe(true);
     const parsed = parseToml(readFileSync(configPath(), 'utf8')) as Record<string, unknown>;
     expect(parsed.model_provider).toBe('cindy_external');
+  });
+
+  // POSIX 权限保护(#1666):temp+rename 不得把密文配置放宽成世界可读。Windows 无 POSIX mode 位,跳过。
+  const posixIt = process.platform === 'win32' ? it.skip : it;
+
+  posixIt('已有 0600 的配置被改写后仍是 0600(不被 rename 放宽成 0644)', () => {
+    writeFileSync(configPath(), 'model = "gpt-5"\n', 'utf8');
+    chmodSync(configPath(), 0o600);
+    expect(writeCodexConfig(URL).success).toBe(true);
+    expect(statSync(configPath()).mode & 0o777).toBe(0o600);
+  });
+
+  posixIt('已有 0644 的配置沿用其原有 mode(保权限,不擅自收紧也不放宽)', () => {
+    writeFileSync(configPath(), 'model = "gpt-5"\n', 'utf8');
+    chmodSync(configPath(), 0o644);
+    expect(writeCodexConfig(URL).success).toBe(true);
+    expect(statSync(configPath()).mode & 0o777).toBe(0o644);
+  });
+
+  posixIt('新建文件默认收紧到 0600', () => {
+    expect(writeCodexConfig(URL).success).toBe(true);
+    expect(statSync(configPath()).mode & 0o777).toBe(0o600);
   });
 });

--- a/apps/desktop/src/main/local-proxy-service/__tests__/external-config-writer.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/external-config-writer.test.ts
@@ -1,0 +1,130 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// logger 顶层 import electron 的 app —— 无 electron 的 vitest 环境用轻量替身隔离掉。
+vi.mock('../../logger.js', () => ({
+  createLogger: () => ({
+    info: () => {},
+    warn: () => {},
+    debug: () => {},
+    error: () => {},
+  }),
+}));
+
+import {
+  previewExternalConfig,
+  writeExternalConfig,
+} from '../external-config-writer';
+
+const URL = 'http://127.0.0.1:54321';
+const TOKEN = 'cindy-local-abcdef';
+
+let dir: string;
+let prevConfigDir: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(os.tmpdir(), 'cindy-cc-config-'));
+  prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = dir;
+});
+
+afterEach(() => {
+  if (prevConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function settingsPath(): string {
+  return path.join(dir, 'settings.json');
+}
+
+describe('external-config-writer — preview', () => {
+  it('文件不存在:exists=false,无冲突,proposedEnv 含两键', () => {
+    const preview = previewExternalConfig(URL, TOKEN);
+    expect(preview.exists).toBe(false);
+    expect(preview.conflicts).toEqual([]);
+    expect(preview.proposedEnv).toEqual({
+      ANTHROPIC_BASE_URL: URL,
+      ANTHROPIC_API_KEY: TOKEN,
+    });
+    expect(preview.path).toBe(settingsPath());
+  });
+
+  it('已有不同的同名 env 值 → 报告冲突项', () => {
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({ env: { ANTHROPIC_BASE_URL: 'http://old', OTHER: 'keep' } }),
+      'utf8',
+    );
+    const preview = previewExternalConfig(URL, TOKEN);
+    expect(preview.exists).toBe(true);
+    expect(preview.conflicts).toEqual([
+      { key: 'ANTHROPIC_BASE_URL', current: 'http://old', next: URL },
+    ]);
+  });
+
+  it('同名同值不算冲突', () => {
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({ env: { ANTHROPIC_BASE_URL: URL } }),
+      'utf8',
+    );
+    expect(previewExternalConfig(URL, TOKEN).conflicts).toEqual([]);
+  });
+});
+
+describe('external-config-writer — write（非破坏性 merge）', () => {
+  it('新建文件:写入 env 两键', () => {
+    const res = writeExternalConfig(URL, TOKEN);
+    expect(res.success).toBe(true);
+    const written = JSON.parse(readFileSync(settingsPath(), 'utf8'));
+    expect(written.env).toEqual({ ANTHROPIC_BASE_URL: URL, ANTHROPIC_API_KEY: TOKEN });
+  });
+
+  it('保留其它顶层字段与其它 env 键,只覆盖两键', () => {
+    writeFileSync(
+      settingsPath(),
+      JSON.stringify({
+        model: 'sonnet',
+        permissions: { allow: ['Bash'] },
+        env: { ANTHROPIC_BASE_URL: 'http://old', MY_FLAG: '1' },
+      }),
+      'utf8',
+    );
+    const res = writeExternalConfig(URL, TOKEN);
+    expect(res.success).toBe(true);
+    const written = JSON.parse(readFileSync(settingsPath(), 'utf8'));
+    expect(written.model).toBe('sonnet');
+    expect(written.permissions).toEqual({ allow: ['Bash'] });
+    expect(written.env).toEqual({
+      MY_FLAG: '1',
+      ANTHROPIC_BASE_URL: URL,
+      ANTHROPIC_API_KEY: TOKEN,
+    });
+  });
+
+  it('损坏 JSON → 不覆盖,返回失败', () => {
+    writeFileSync(settingsPath(), '{ not valid json', 'utf8');
+    const res = writeExternalConfig(URL, TOKEN);
+    expect(res.success).toBe(false);
+    // 原坏文件保持不动。
+    expect(readFileSync(settingsPath(), 'utf8')).toBe('{ not valid json');
+  });
+
+  it('env 段不是对象 → 不覆盖,返回失败', () => {
+    writeFileSync(settingsPath(), JSON.stringify({ env: 'nope' }), 'utf8');
+    const res = writeExternalConfig(URL, TOKEN);
+    expect(res.success).toBe(false);
+  });
+
+  it('空文件视为无配置,可安全新建结构', () => {
+    writeFileSync(settingsPath(), '   \n', 'utf8');
+    const res = writeExternalConfig(URL, TOKEN);
+    expect(res.success).toBe(true);
+    const written = JSON.parse(readFileSync(settingsPath(), 'utf8'));
+    expect(written.env).toEqual({ ANTHROPIC_BASE_URL: URL, ANTHROPIC_API_KEY: TOKEN });
+  });
+});

--- a/apps/desktop/src/main/local-proxy-service/__tests__/preview-masking.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/preview-masking.test.ts
@@ -11,7 +11,7 @@ import type {
   LocalProxyCodexConfigPreview,
   LocalProxyConfigPreview,
 } from '../../../shared/localProxyService';
-import { maskAnthropicPreview, maskCodexPreview } from '../preview-masking';
+import { MASK_FALLBACK, maskAnthropicPreview, maskCodexPreview } from '../preview-masking';
 
 const TOKEN = 'cindy-local-supersecret-abcdef0123456789';
 const MASKED = 'cindy-local-••••';
@@ -34,7 +34,8 @@ describe('maskAnthropicPreview — 写 ~/.claude 预览掩码 token', () => {
     expect(JSON.stringify(masked)).not.toContain(TOKEN);
   });
 
-  it('冲突项里等于 token 的 next 被掩码;其它冲突值原样保留', () => {
+  it('冲突项:next(=token)掩成 token 掩码,current(用户既有真 key)兜底掩掉,非密文段保留', () => {
+    const EXISTING_USER_KEY = 'sk-old-user-key';
     const preview: LocalProxyConfigPreview = {
       path: '/home/u/.claude/settings.json',
       exists: true,
@@ -43,18 +44,21 @@ describe('maskAnthropicPreview — 写 ~/.claude 预览掩码 token', () => {
         ANTHROPIC_API_KEY: TOKEN,
       },
       conflicts: [
-        { key: 'ANTHROPIC_API_KEY', current: 'sk-old-user-key', next: TOKEN },
+        { key: 'ANTHROPIC_API_KEY', current: EXISTING_USER_KEY, next: TOKEN },
         { key: 'ANTHROPIC_BASE_URL', current: 'https://old', next: 'http://127.0.0.1:51888' },
       ],
     };
     const masked = maskAnthropicPreview(preview, TOKEN, MASKED);
     const apiKeyConflict = masked.conflicts.find((c) => c.key === 'ANTHROPIC_API_KEY');
-    // next(= 我们的 token)被掩;current(用户旧值,非我们 token)保留。
+    // next(= 我们的 token)→ token 掩码;current(用户既有真 key,Finding F)→ 通用占位,绝不原样过 IPC。
     expect(apiKeyConflict?.next).toBe(MASKED);
-    expect(apiKeyConflict?.current).toBe('sk-old-user-key');
+    expect(apiKeyConflict?.current).toBe(MASK_FALLBACK);
     const baseUrlConflict = masked.conflicts.find((c) => c.key === 'ANTHROPIC_BASE_URL');
+    expect(baseUrlConflict?.current).toBe('https://old');
     expect(baseUrlConflict?.next).toBe('http://127.0.0.1:51888');
+    // 我们的 token 与用户既有真 key 都不得出现在序列化后的预览里。
     expect(JSON.stringify(masked)).not.toContain(TOKEN);
+    expect(JSON.stringify(masked)).not.toContain(EXISTING_USER_KEY);
   });
 });
 

--- a/apps/desktop/src/main/local-proxy-service/__tests__/preview-masking.test.ts
+++ b/apps/desktop/src/main/local-proxy-service/__tests__/preview-masking.test.ts
@@ -1,0 +1,75 @@
+/**
+ * preview-masking.test.ts
+ * ---------------------------------------------------------------------------
+ * #1666 Finding E 回归:写配置预览交给 renderer 前,对外 token 明文必须被掩掉。
+ * 真实明文只在 main 侧落文件 / 落剪贴板;预览纯展示,绝不把明文带过 IPC 边界。
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type {
+  LocalProxyCodexConfigPreview,
+  LocalProxyConfigPreview,
+} from '../../../shared/localProxyService';
+import { maskAnthropicPreview, maskCodexPreview } from '../preview-masking';
+
+const TOKEN = 'cindy-local-supersecret-abcdef0123456789';
+const MASKED = 'cindy-local-••••';
+
+describe('maskAnthropicPreview — 写 ~/.claude 预览掩码 token', () => {
+  it('proposedEnv.ANTHROPIC_API_KEY 被掩码,base_url 等非 token 段原样保留', () => {
+    const preview: LocalProxyConfigPreview = {
+      path: '/home/u/.claude/settings.json',
+      exists: false,
+      proposedEnv: {
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:51888',
+        ANTHROPIC_API_KEY: TOKEN,
+      },
+      conflicts: [],
+    };
+    const masked = maskAnthropicPreview(preview, TOKEN, MASKED);
+    expect(masked.proposedEnv.ANTHROPIC_API_KEY).toBe(MASKED);
+    expect(masked.proposedEnv.ANTHROPIC_BASE_URL).toBe('http://127.0.0.1:51888');
+    // 明文绝不出现在任何序列化后的预览里。
+    expect(JSON.stringify(masked)).not.toContain(TOKEN);
+  });
+
+  it('冲突项里等于 token 的 next 被掩码;其它冲突值原样保留', () => {
+    const preview: LocalProxyConfigPreview = {
+      path: '/home/u/.claude/settings.json',
+      exists: true,
+      proposedEnv: {
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:51888',
+        ANTHROPIC_API_KEY: TOKEN,
+      },
+      conflicts: [
+        { key: 'ANTHROPIC_API_KEY', current: 'sk-old-user-key', next: TOKEN },
+        { key: 'ANTHROPIC_BASE_URL', current: 'https://old', next: 'http://127.0.0.1:51888' },
+      ],
+    };
+    const masked = maskAnthropicPreview(preview, TOKEN, MASKED);
+    const apiKeyConflict = masked.conflicts.find((c) => c.key === 'ANTHROPIC_API_KEY');
+    // next(= 我们的 token)被掩;current(用户旧值,非我们 token)保留。
+    expect(apiKeyConflict?.next).toBe(MASKED);
+    expect(apiKeyConflict?.current).toBe('sk-old-user-key');
+    const baseUrlConflict = masked.conflicts.find((c) => c.key === 'ANTHROPIC_BASE_URL');
+    expect(baseUrlConflict?.next).toBe('http://127.0.0.1:51888');
+    expect(JSON.stringify(masked)).not.toContain(TOKEN);
+  });
+});
+
+describe('maskCodexPreview — 写 ~/.codex/config.toml 预览掩码 token', () => {
+  it('tokenExportLine 里的明文被掩码;proposedToml(本就不含 token)原样保留', () => {
+    const preview: LocalProxyCodexConfigPreview = {
+      path: '/home/u/.codex/config.toml',
+      exists: false,
+      proposedToml: 'model_provider = "cindy_external"\n',
+      conflicts: [],
+      tokenExportLine: `export CINDY_LOCAL_TOKEN=${TOKEN}`,
+    };
+    const masked = maskCodexPreview(preview, TOKEN, MASKED);
+    expect(masked.tokenExportLine).toBe(`export CINDY_LOCAL_TOKEN=${MASKED}`);
+    expect(masked.proposedToml).toBe('model_provider = "cindy_external"\n');
+    expect(JSON.stringify(masked)).not.toContain(TOKEN);
+  });
+});

--- a/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
+++ b/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
@@ -40,12 +40,17 @@ export function resolveCodexConfigPath(): string {
 }
 
 /** 待写入 `[model_providers.cindy_external]` 的键值(**不含 token** —— 走 env_key)。 */
-function buildProviderBlock(codexUrl: string): Record<string, string> {
+function buildProviderBlock(codexUrl: string): Record<string, string | boolean> {
   return {
     name: 'Cindy',
     base_url: codexUrl,
     wire_api: 'responses',
     env_key: CINDY_TOKEN_ENV_KEY,
+    // 安全(#1666 review):必须冻成 false,与内部 cindy_gateway(codex-gateway-config.ts)对称。
+    // 外部 loopback 代理要整段 JSON.parse 请求体才能跑对外 token 判定与头 strip;若放任 Codex CLI
+    // 开 Responses WebSocket,proxy 的 upgrade 处理会把连接连同入站头(含 CINDY_LOCAL_TOKEN)直送
+    // 固定上游,绕过 createExternalCodexRoutingTransform 的鉴权/strip = 凭证透传上游 + 路由绕过。
+    supports_websockets: false,
   };
 }
 
@@ -114,7 +119,7 @@ function mergeConfig(root: Record<string, unknown>, codexUrl: string): Record<st
   };
 }
 
-/** 收集会被覆盖的同名冲突项(root.model_provider 与 provider 块内四个键)。 */
+/** 收集会被覆盖的同名冲突项(root.model_provider 与 provider 块内 Cindy 管理的各键)。 */
 function collectConflicts(
   root: Record<string, unknown>,
   codexUrl: string,
@@ -127,8 +132,17 @@ function collectConflicts(
   const existing = existingProviderBlock(root);
   for (const [key, next] of Object.entries(buildProviderBlock(codexUrl))) {
     const current = existing[key];
-    if (typeof current === 'string' && current !== next) {
-      conflicts.push({ key: `model_providers.${CINDY_PROVIDER_ID}.${key}`, current, next });
+    // 现值为 string / boolean(如已有 supports_websockets=true)且与将写入值不同 → 暴露冲突,
+    // 让用户在确认前看到会被覆盖的键(尤其 supports_websockets:true→false 属安全性强制覆盖)。
+    if (
+      (typeof current === 'string' || typeof current === 'boolean') &&
+      current !== next
+    ) {
+      conflicts.push({
+        key: `model_providers.${CINDY_PROVIDER_ID}.${key}`,
+        current: String(current),
+        next: String(next),
+      });
     }
   }
   return conflicts;

--- a/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
+++ b/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
@@ -161,9 +161,20 @@ export function writeCodexConfig(
     const nextRoot = mergeConfig(root, codexUrl);
     const dir = path.dirname(filePath);
     fs.mkdirSync(dir, { recursive: true });
+    // 保权限:codex config.toml 常含 provider 凭证,可能本就是 0600。temp+rename 若用
+    // Node 默认 `0666 & umask`(常见 022 → 0644)落位,会把一个 0600 的密文配置 rename 成
+    // 世界可读,泄漏同机其它用户可读的凭证。故:文件已存在 → 沿用其原有 mode(绝不放宽);
+    // 新建 → 收紧到 0600。Windows(NTFS)不吃 POSIX mode 位,跳过 chmod。(#1666 review)
+    let targetMode = 0o600;
+    try {
+      targetMode = fs.statSync(filePath).mode & 0o777;
+    } catch { /* 文件不存在 → 用默认 0600 */ }
     const tmpPath = `${filePath}.${process.pid}-${Date.now()}.tmp`;
     try {
       fs.writeFileSync(tmpPath, `${stringifyToml(nextRoot)}\n`, 'utf8');
+      if (process.platform !== 'win32') {
+        fs.chmodSync(tmpPath, targetMode);
+      }
       fs.renameSync(tmpPath, filePath);
     } catch (writeErr) {
       try { fs.unlinkSync(tmpPath); } catch { /* best-effort 清理 */ }

--- a/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
+++ b/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
@@ -1,0 +1,179 @@
+/**
+ * 把对外模型代理的 **Codex(OpenAI Responses)出口**连接信息写进用户 **自己的 Codex CLI 全局
+ * 配置**(`$CODEX_HOME/config.toml` 或 `~/.codex/config.toml`),让外部 `codex` 直接指向 Cindy
+ * 本地 loopback。
+ *
+ * 这是**外向文件写**(写用户家目录),红线:
+ *   - 只在用户主动点击「写入 Codex 配置」时调用(IPC 过 `assertTrustedAppRendererEvent`)。
+ *   - 非破坏性 merge:只设 root `model_provider="cindy_external"` 与
+ *     `[model_providers.cindy_external]`(name/base_url/wire_api/env_key)这两处,其余所有
+ *     字段(其它 provider、profiles、mcp servers…)原样保留。
+ *   - **token 绝不写进文件** —— codex 经 `env_key="CINDY_LOCAL_TOKEN"` 从环境变量读;预览里
+ *     给出用户需在外部 shell 自设的 `export CINDY_LOCAL_TOKEN=<token>` 行(含明文,仅用户主动
+ *     触发时返回)。
+ *   - 写前经 `previewCodexConfig` 展示完整 merge 后 TOML + 同名冲突项,由 UI 二次确认。
+ *   - 原子写(temp + rename),失败不留半截文件;`smol-toml` 解析失败/根非 table 一律不覆盖,报错。
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { parse as parseToml, stringify as stringifyToml } from 'smol-toml';
+
+import { createLogger } from '../logger.js';
+import type { LocalProxyCodexConfigPreview } from '../../shared/localProxyService.js';
+
+const log = createLogger('local-proxy:codex-config');
+
+/** Cindy 在用户 codex 配置里注册的 provider id / 环境变量名(固定值,勿改 —— 迁移/复用靠它)。 */
+const CINDY_PROVIDER_ID = 'cindy_external';
+const CINDY_TOKEN_ENV_KEY = 'CINDY_LOCAL_TOKEN';
+
+/**
+ * 用户 Codex CLI 全局配置文件路径。遵循 codex 自己的 `CODEX_HOME` 覆盖约定;
+ * 未设置时用 `~/.codex`(与 codex 默认一致)。
+ */
+export function resolveCodexConfigPath(): string {
+  const dir = process.env.CODEX_HOME?.trim() || path.join(os.homedir(), '.codex');
+  return path.join(dir, 'config.toml');
+}
+
+/** 待写入 `[model_providers.cindy_external]` 的键值(**不含 token** —— 走 env_key)。 */
+function buildProviderBlock(codexUrl: string): Record<string, string> {
+  return {
+    name: 'Cindy',
+    base_url: codexUrl,
+    wire_api: 'responses',
+    env_key: CINDY_TOKEN_ENV_KEY,
+  };
+}
+
+/** 用户需在外部 shell 自设的 token 环境变量行(含明文 token)。 */
+function buildTokenExportLine(token: string): string {
+  return `export ${CINDY_TOKEN_ENV_KEY}=${token}`;
+}
+
+/**
+ * 读并解析现有 config.toml。文件不存在 → 空壳(exists=false)。存在但 `smol-toml` 解析失败、
+ * 或根不是 table → 抛错(调用方据此拒绝写,绝不覆盖用户的坏文件/异形结构)。
+ */
+function readExistingConfig(filePath: string): { exists: boolean; root: Record<string, unknown> } {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { exists: false, root: {} };
+    }
+    throw err;
+  }
+  if (raw.trim().length === 0) {
+    return { exists: true, root: {} };
+  }
+  let parsed: unknown;
+  try {
+    parsed = parseToml(raw);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(`${filePath} 不是合法 TOML(${detail}),已放弃写入(不覆盖用户文件)。`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${filePath} 顶层不是 table,已放弃写入。`);
+  }
+  return { exists: true, root: parsed as Record<string, unknown> };
+}
+
+/** 从已解析根里取现有的 `model_providers.cindy_external` 块(不存在/异形 → 空对象)。 */
+function existingProviderBlock(root: Record<string, unknown>): Record<string, unknown> {
+  const providers = root.model_providers;
+  if (!providers || typeof providers !== 'object' || Array.isArray(providers)) return {};
+  const block = (providers as Record<string, unknown>)[CINDY_PROVIDER_ID];
+  if (!block || typeof block !== 'object' || Array.isArray(block)) return {};
+  return block as Record<string, unknown>;
+}
+
+/**
+ * 非破坏性 merge:返回一个新的根 table,仅设 `model_provider` 与 `model_providers.cindy_external`,
+ * 其余字段(含其它 provider 块)原样保留。
+ */
+function mergeConfig(root: Record<string, unknown>, codexUrl: string): Record<string, unknown> {
+  const providersRaw = root.model_providers;
+  const providers =
+    providersRaw && typeof providersRaw === 'object' && !Array.isArray(providersRaw)
+      ? { ...(providersRaw as Record<string, unknown>) }
+      : {};
+  providers[CINDY_PROVIDER_ID] = {
+    ...existingProviderBlock(root),
+    ...buildProviderBlock(codexUrl),
+  };
+  return {
+    ...root,
+    model_provider: CINDY_PROVIDER_ID,
+    model_providers: providers,
+  };
+}
+
+/** 收集会被覆盖的同名冲突项(root.model_provider 与 provider 块内四个键)。 */
+function collectConflicts(
+  root: Record<string, unknown>,
+  codexUrl: string,
+): { key: string; current: string; next: string }[] {
+  const conflicts: { key: string; current: string; next: string }[] = [];
+  const currentProvider = root.model_provider;
+  if (typeof currentProvider === 'string' && currentProvider !== CINDY_PROVIDER_ID) {
+    conflicts.push({ key: 'model_provider', current: currentProvider, next: CINDY_PROVIDER_ID });
+  }
+  const existing = existingProviderBlock(root);
+  for (const [key, next] of Object.entries(buildProviderBlock(codexUrl))) {
+    const current = existing[key];
+    if (typeof current === 'string' && current !== next) {
+      conflicts.push({ key: `model_providers.${CINDY_PROVIDER_ID}.${key}`, current, next });
+    }
+  }
+  return conflicts;
+}
+
+/** 生成写入预览:目标路径、是否存在、完整 merge 后 TOML、冲突项、需自设的 token env 行。 */
+export function previewCodexConfig(codexUrl: string, token: string): LocalProxyCodexConfigPreview {
+  const filePath = resolveCodexConfigPath();
+  const { exists, root } = readExistingConfig(filePath);
+  const proposedToml = stringifyToml(mergeConfig(root, codexUrl));
+  return {
+    path: filePath,
+    exists,
+    proposedToml,
+    conflicts: collectConflicts(root, codexUrl),
+    tokenExportLine: buildTokenExportLine(token),
+  };
+}
+
+/**
+ * 非破坏性写入:merge `model_provider` 与 `[model_providers.cindy_external]`,保留其它所有字段,
+ * 原子落盘。解析失败/异形结构直接抛,不写(见 readExistingConfig)。token 不入文件。
+ */
+export function writeCodexConfig(
+  codexUrl: string,
+): { success: true; path: string } | { success: false; error: string } {
+  const filePath = resolveCodexConfigPath();
+  try {
+    const { root } = readExistingConfig(filePath);
+    const nextRoot = mergeConfig(root, codexUrl);
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpPath = `${filePath}.${process.pid}-${Date.now()}.tmp`;
+    try {
+      fs.writeFileSync(tmpPath, `${stringifyToml(nextRoot)}\n`, 'utf8');
+      fs.renameSync(tmpPath, filePath);
+    } catch (writeErr) {
+      try { fs.unlinkSync(tmpPath); } catch { /* best-effort 清理 */ }
+      throw writeErr;
+    }
+    log.info(`已写入 Codex 对外代理配置到 ${filePath}`);
+    return { success: true, path: filePath };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`写入 Codex 对外代理配置失败: ${message}`);
+    return { success: false, error: message };
+  }
+}

--- a/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
+++ b/apps/desktop/src/main/local-proxy-service/codex-external-config-writer.ts
@@ -134,15 +134,32 @@ function collectConflicts(
   return conflicts;
 }
 
-/** 生成写入预览:目标路径、是否存在、完整 merge 后 TOML、冲突项、需自设的 token env 行。 */
+/**
+ * 只含 Cindy 会**写入/改动**的两处(root `model_provider` + `[model_providers.cindy_external]` 块)的
+ * TOML 片段 —— 绝不含用户既有的其它 provider / mcp / profile 凭证。预览专用。
+ */
+function buildProposedFragment(codexUrl: string): string {
+  return stringifyToml({
+    model_provider: CINDY_PROVIDER_ID,
+    model_providers: { [CINDY_PROVIDER_ID]: buildProviderBlock(codexUrl) },
+  });
+}
+
+/**
+ * 生成写入预览:目标路径、是否存在、**仅 Cindy 改动处**的 TOML 片段、冲突项、需自设的 token env 行。
+ *
+ * ⚠ 安全(#1666 二轮 Finding G):`proposedToml` 只回 Cindy 会写的那两处片段,**绝不**把整份 merge 后
+ * 配置回给 renderer —— 整份 config.toml 常含用户既有的 provider key / MCP token 等密文,受注入的渲染
+ * 进程只要调预览通道就能在用户确认前把它们读走。真实的整份 merge 只在 `writeCodexConfig`(main 侧)落文件。
+ * 非破坏性 merge 的保证仍在 `mergeConfig`:除这两处外其余字段原样保留。
+ */
 export function previewCodexConfig(codexUrl: string, token: string): LocalProxyCodexConfigPreview {
   const filePath = resolveCodexConfigPath();
   const { exists, root } = readExistingConfig(filePath);
-  const proposedToml = stringifyToml(mergeConfig(root, codexUrl));
   return {
     path: filePath,
     exists,
-    proposedToml,
+    proposedToml: buildProposedFragment(codexUrl),
     conflicts: collectConflicts(root, codexUrl),
     tokenExportLine: buildTokenExportLine(token),
   };
@@ -171,7 +188,11 @@ export function writeCodexConfig(
     } catch { /* 文件不存在 → 用默认 0600 */ }
     const tmpPath = `${filePath}.${process.pid}-${Date.now()}.tmp`;
     try {
-      fs.writeFileSync(tmpPath, `${stringifyToml(nextRoot)}\n`, 'utf8');
+      // ⚠ temp 必须**在写入任何密文前**就以 0600 创建。merge 后的 TOML 会含用户既有的 provider /
+      // MCP 凭证;若先按 Node 默认 mode(022 umask → 0644)建 temp 再 chmod,那一瞬间同机其它
+      // 用户/监视者就能读到密文(#1666 二轮 Finding I)。故 writeFileSync 直接带 mode:0600 建文件,
+      // 再 chmod 到 targetMode(已存在文件沿用其原 mode,不放宽也不额外收紧)。
+      fs.writeFileSync(tmpPath, `${stringifyToml(nextRoot)}\n`, { encoding: 'utf8', mode: 0o600 });
       if (process.platform !== 'win32') {
         fs.chmodSync(tmpPath, targetMode);
       }

--- a/apps/desktop/src/main/local-proxy-service/external-config-writer.ts
+++ b/apps/desktop/src/main/local-proxy-service/external-config-writer.ts
@@ -128,7 +128,11 @@ export function writeExternalConfig(url: string, token: string): LocalProxyConfi
     fs.mkdirSync(dir, { recursive: true });
     const tmpPath = `${filePath}.${process.pid}-${Date.now()}.tmp`;
     try {
-      fs.writeFileSync(tmpPath, `${JSON.stringify(nextRoot, null, 2)}\n`, 'utf8');
+      // settings.json 写入后含 `env.ANTHROPIC_API_KEY`(对外访问 token),是敏感文件:temp 以
+      // 0600 创建,再显式 chmod(不受 umask 影响)后 rename。rename 用 temp 的 inode 替换目标,
+      // 故结果一定是 0600 —— 既不让新文件默认 world-readable,也顺带收紧已存在的 0644 旧文件。
+      fs.writeFileSync(tmpPath, `${JSON.stringify(nextRoot, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+      fs.chmodSync(tmpPath, 0o600);
       fs.renameSync(tmpPath, filePath);
     } catch (writeErr) {
       try { fs.unlinkSync(tmpPath); } catch { /* best-effort 清理 */ }

--- a/apps/desktop/src/main/local-proxy-service/external-config-writer.ts
+++ b/apps/desktop/src/main/local-proxy-service/external-config-writer.ts
@@ -1,0 +1,144 @@
+/**
+ * 把对外模型代理的连接信息写进用户 **自己的 Claude Code 全局配置**
+ * (`~/.claude/settings.json` 的 `env` 段),让外部 `claude` CLI 直接指向 Cindy 本地服务。
+ *
+ * 这是**外向文件写**(写用户家目录),红线:
+ *   - 只在用户主动点击「写入配置」时调用(IPC 过 `assertTrustedAppRendererEvent`)。
+ *   - 非破坏性 merge:只增改 `env.ANTHROPIC_BASE_URL` / `env.ANTHROPIC_API_KEY` 两个键,
+ *     其余 env 键与所有其它顶层配置原样保留。
+ *   - 写前经 `previewExternalConfig` 展示将改动的内容 + 同名冲突项,由 UI 二次确认。
+ *   - 原子写(temp + rename),失败不留半截文件;解析失败/非法 JSON 一律不覆盖,报错回滚。
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createLogger } from '../logger.js';
+import type {
+  LocalProxyConfigPreview,
+  LocalProxyConfigWriteResult,
+} from '../../shared/localProxyService.js';
+
+const log = createLogger('local-proxy:external-config');
+
+const ENV_BASE_URL_KEY = 'ANTHROPIC_BASE_URL';
+const ENV_API_KEY_KEY = 'ANTHROPIC_API_KEY';
+
+/**
+ * 用户 Claude Code 全局配置目录。遵循 CLI 自己的 `CLAUDE_CONFIG_DIR` 覆盖约定;
+ * 未设置时用 `~/.claude`(与 CLI 默认一致)。
+ */
+export function resolveClaudeSettingsPath(): string {
+  const dir = process.env.CLAUDE_CONFIG_DIR?.trim() || path.join(os.homedir(), '.claude');
+  return path.join(dir, 'settings.json');
+}
+
+/** 待写入的 env 键值。 */
+export function buildProposedEnv(url: string, token: string): Record<string, string> {
+  return {
+    [ENV_BASE_URL_KEY]: url,
+    [ENV_API_KEY_KEY]: token,
+  };
+}
+
+interface ParsedSettings {
+  /** 解析出的顶层对象(非对象 JSON 视为损坏)。 */
+  root: Record<string, unknown>;
+  /** 现有 env 段(若存在且为对象)。 */
+  env: Record<string, string>;
+}
+
+/**
+ * 读并解析现有配置。文件不存在 → 返回空壳(exists=false)。存在但不是合法 JSON 对象、
+ * 或 `env` 段不是对象 → 抛错(调用方据此拒绝写,绝不覆盖用户的坏文件/异形结构)。
+ */
+function readExistingSettings(filePath: string): { exists: boolean; parsed: ParsedSettings } {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { exists: false, parsed: { root: {}, env: {} } };
+    }
+    throw err;
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    // 空文件视为「无配置」,可安全新建结构。
+    return { exists: true, parsed: { root: {}, env: {} } };
+  }
+  let json: unknown;
+  try {
+    json = JSON.parse(trimmed);
+  } catch {
+    throw new Error(`${filePath} 不是合法 JSON,已放弃写入(不覆盖用户文件)。`);
+  }
+  if (json === null || typeof json !== 'object' || Array.isArray(json)) {
+    throw new Error(`${filePath} 顶层不是对象,已放弃写入。`);
+  }
+  const root = json as Record<string, unknown>;
+  const envRaw = root.env;
+  const env: Record<string, string> = {};
+  if (envRaw !== undefined) {
+    if (envRaw === null || typeof envRaw !== 'object' || Array.isArray(envRaw)) {
+      throw new Error(`${filePath} 的 env 段不是对象,已放弃写入。`);
+    }
+    for (const [k, v] of Object.entries(envRaw as Record<string, unknown>)) {
+      // Claude Code 的 env 值都是字符串;非字符串项原样透传(下面写回时保留)。
+      if (typeof v === 'string') env[k] = v;
+    }
+  }
+  return { exists: true, parsed: { root, env } };
+}
+
+/** 生成写入预览:目标路径、是否存在、将写入的 env、以及会被覆盖的同名冲突项。 */
+export function previewExternalConfig(url: string, token: string): LocalProxyConfigPreview {
+  const filePath = resolveClaudeSettingsPath();
+  const { exists, parsed } = readExistingSettings(filePath);
+  const proposedEnv = buildProposedEnv(url, token);
+  const conflicts: { key: string; current: string; next: string }[] = [];
+  for (const [key, next] of Object.entries(proposedEnv)) {
+    const current = parsed.env[key];
+    if (current !== undefined && current !== next) {
+      conflicts.push({ key, current, next });
+    }
+  }
+  return { path: filePath, exists, proposedEnv, conflicts };
+}
+
+/**
+ * 非破坏性写入:merge 两个键进 `env`,保留其它 env 键与所有顶层字段,原子落盘。
+ * 解析失败/异形结构直接抛,不写(见 readExistingSettings)。
+ */
+export function writeExternalConfig(url: string, token: string): LocalProxyConfigWriteResult {
+  const filePath = resolveClaudeSettingsPath();
+  try {
+    const { parsed } = readExistingSettings(filePath);
+    // 保留 root 里原样的 env 段(含非字符串项),只覆盖我们这两个键。
+    const existingEnvRaw =
+      parsed.root.env && typeof parsed.root.env === 'object' && !Array.isArray(parsed.root.env)
+        ? (parsed.root.env as Record<string, unknown>)
+        : {};
+    const nextRoot: Record<string, unknown> = {
+      ...parsed.root,
+      env: { ...existingEnvRaw, ...buildProposedEnv(url, token) },
+    };
+    const dir = path.dirname(filePath);
+    fs.mkdirSync(dir, { recursive: true });
+    const tmpPath = `${filePath}.${process.pid}-${Date.now()}.tmp`;
+    try {
+      fs.writeFileSync(tmpPath, `${JSON.stringify(nextRoot, null, 2)}\n`, 'utf8');
+      fs.renameSync(tmpPath, filePath);
+    } catch (writeErr) {
+      try { fs.unlinkSync(tmpPath); } catch { /* best-effort 清理 */ }
+      throw writeErr;
+    }
+    log.info(`已写入对外代理配置到 ${filePath}`);
+    return { success: true, path: filePath };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn(`写入对外代理配置失败: ${message}`);
+    return { success: false, error: message };
+  }
+}

--- a/apps/desktop/src/main/local-proxy-service/preview-masking.ts
+++ b/apps/desktop/src/main/local-proxy-service/preview-masking.ts
@@ -1,0 +1,59 @@
+/**
+ * 对外模型代理「写配置预览」交给 renderer 前的 token 掩码(#1666 Finding E)。
+ *
+ * 安全约束(勿改):写配置预览纯展示,不需要也**绝不**把对外 token 明文带过 IPC 边界。
+ * 真实明文只在 main 侧落文件(`writeExternalConfig`)/ 落剪贴板(`copy-*` 通道);预览里凡是
+ * 等于 token 的段一律换成掩码。`assertTrustedAppRendererEvent` 只验来源帧、不验用户手势,
+ * 所以哪怕来源可信也不把明文交给可能被注入的渲染进程。
+ *
+ * 纯函数、无 electron / 无 IO 依赖 —— 单测可直接 import(见 __tests__/preview-masking.test.ts)。
+ */
+
+import type {
+  LocalProxyCodexConfigPreview,
+  LocalProxyConfigPreview,
+} from '../../shared/localProxyService.js';
+
+/** token 拿不到掩码时的兜底占位(不泄漏长度/内容)。 */
+export const MASK_FALLBACK = '••••••••';
+
+/**
+ * 把 Anthropic 写配置预览里的 token 段替换成掩码。`proposedEnv.ANTHROPIC_API_KEY` 与任何
+ * 取值等于 token 的冲突项(current/next)都会被掩掉,其余原样保留。
+ */
+export function maskAnthropicPreview(
+  preview: LocalProxyConfigPreview,
+  token: string,
+  masked: string,
+): LocalProxyConfigPreview {
+  const scrub = (v: string): string => (token.length > 0 && v === token ? masked : v);
+  const proposedEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(preview.proposedEnv)) proposedEnv[k] = scrub(v);
+  return {
+    ...preview,
+    proposedEnv,
+    conflicts: preview.conflicts.map((c) => ({
+      key: c.key,
+      current: scrub(c.current),
+      next: scrub(c.next),
+    })),
+  };
+}
+
+/**
+ * codex 预览的 `proposedToml` 本就不含 token(codex 从 `env_key` 读),只 `tokenExportLine`
+ * 带明文 —— 掩码它;真实明文走 `copy-codex-token-export` 剪贴板通道。
+ */
+export function maskCodexPreview(
+  preview: LocalProxyCodexConfigPreview,
+  token: string,
+  masked: string,
+): LocalProxyCodexConfigPreview {
+  return {
+    ...preview,
+    tokenExportLine:
+      token.length > 0
+        ? preview.tokenExportLine.split(token).join(masked)
+        : preview.tokenExportLine,
+  };
+}

--- a/apps/desktop/src/main/local-proxy-service/preview-masking.ts
+++ b/apps/desktop/src/main/local-proxy-service/preview-masking.ts
@@ -1,10 +1,15 @@
 /**
- * 对外模型代理「写配置预览」交给 renderer 前的 token 掩码(#1666 Finding E)。
+ * 对外模型代理「写配置预览」交给 renderer 前的密文掩码(#1666 Finding E + 二轮 Finding F)。
  *
- * 安全约束(勿改):写配置预览纯展示,不需要也**绝不**把对外 token 明文带过 IPC 边界。
+ * 安全约束(勿改):写配置预览纯展示,不需要也**绝不**把任何密文明文带过 IPC 边界。
  * 真实明文只在 main 侧落文件(`writeExternalConfig`)/ 落剪贴板(`copy-*` 通道);预览里凡是
- * 等于 token 的段一律换成掩码。`assertTrustedAppRendererEvent` 只验来源帧、不验用户手势,
- * 所以哪怕来源可信也不把明文交给可能被注入的渲染进程。
+ * 等于对外 token 的段一律换成 token 掩码。`assertTrustedAppRendererEvent` 只验来源帧、不验
+ * 用户手势,所以哪怕来源可信也不把明文交给可能被注入的渲染进程。
+ *
+ * 二轮 Finding F:冲突项的 `current` 是**用户自己既有的值**——当 key 是密文型环境变量
+ * (如 `ANTHROPIC_API_KEY` 里用户原本填的真 key)时,它同样是密文,若原样过 IPC 就等于把用户
+ * 现有的 Claude key 泄漏给渲染进程。故除对外 token 外,任何密文型 key 的 current/next 非空值
+ * 一律再兜底掩掉(用不含 token 前缀的通用占位,以示这不是我们的 token)。
  *
  * 纯函数、无 electron / 无 IO 依赖 —— 单测可直接 import(见 __tests__/preview-masking.test.ts)。
  */
@@ -18,24 +23,39 @@ import type {
 export const MASK_FALLBACK = '••••••••';
 
 /**
- * 把 Anthropic 写配置预览里的 token 段替换成掩码。`proposedEnv.ANTHROPIC_API_KEY` 与任何
- * 取值等于 token 的冲突项(current/next)都会被掩掉,其余原样保留。
+ * 判定一个环境变量名是否承载密文。宁可多掩不可漏掩:名字里含 KEY/TOKEN/SECRET 一律视为密文。
+ * `ANTHROPIC_BASE_URL` 这类非密文 key 不命中,原样展示。
+ */
+function isSecretEnvKey(key: string): boolean {
+  return /(?:KEY|TOKEN|SECRET|PASSWORD)/i.test(key);
+}
+
+/**
+ * 把 Anthropic 写配置预览里的密文段替换成掩码。规则:
+ *   - 等于对外 token 的段 → token 掩码 `masked`(带 `cindy-local-` 前缀,示意是我们生成的)。
+ *   - 密文型 key(见 `isSecretEnvKey`)上其余非空值(尤其是用户既有的真 key)→ 通用占位
+ *     `MASK_FALLBACK`,绝不原样过 IPC(Finding F)。
+ *   - 其余(base_url 等非密文段)→ 原样保留。
  */
 export function maskAnthropicPreview(
   preview: LocalProxyConfigPreview,
   token: string,
   masked: string,
 ): LocalProxyConfigPreview {
-  const scrub = (v: string): string => (token.length > 0 && v === token ? masked : v);
+  const scrub = (key: string, v: string): string => {
+    if (token.length > 0 && v === token) return masked;
+    if (v.length > 0 && isSecretEnvKey(key)) return MASK_FALLBACK;
+    return v;
+  };
   const proposedEnv: Record<string, string> = {};
-  for (const [k, v] of Object.entries(preview.proposedEnv)) proposedEnv[k] = scrub(v);
+  for (const [k, v] of Object.entries(preview.proposedEnv)) proposedEnv[k] = scrub(k, v);
   return {
     ...preview,
     proposedEnv,
     conflicts: preview.conflicts.map((c) => ({
       key: c.key,
-      current: scrub(c.current),
-      next: scrub(c.next),
+      current: scrub(c.key, c.current),
+      next: scrub(c.key, c.next),
     })),
   };
 }

--- a/apps/desktop/src/main/local-proxy-service/register.ts
+++ b/apps/desktop/src/main/local-proxy-service/register.ts
@@ -1,0 +1,359 @@
+/**
+ * 对外模型代理的 IPC 层。渲染层设置页(模型供应商 → 模型代理子区块)经这些通道读写状态。
+ *
+ * 安全约束(勿改):
+ *   - 所有**写**通道(set-enabled / set-default-provider / regenerate-token / set-port /
+ *     write-external-config)都过 `assertTrustedAppRendererEvent` —— 只允许 Cindy 自有顶层
+ *     页面发起,插件面板 / webview 无法触达。
+ *   - token 明文只在 `get-env-example` / `write-external-config` 这两个「用户主动触发」的
+ *     出口返回;`get-state` 只给掩码。
+ */
+
+import { ipcMain } from 'electron';
+
+import type {
+  LocalProxyCodexConfigPreviewResult,
+  LocalProxyConfigPreviewResult,
+  LocalProxyConfigWriteResult,
+  LocalProxyEnvExampleResult,
+  LocalProxyMutationResult,
+  LocalProxyServiceState,
+} from '../../shared/localProxyService.js';
+import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer.js';
+import {
+  getLocalProxyUrl,
+  portFromProxyUrl,
+  restartAnthropicCompatProxy,
+} from '../maker-host/anthropic-compat-proxy-host.js';
+import {
+  codexPortFromProxyUrl,
+  ensureCodexProxyReady,
+  getCodexProxyUrl,
+  restartCodexProxy,
+} from '../maker-host/codex-proxy-host.js';
+import { listExternalRoutableProviders } from '../maker-host/provider-route.js';
+import {
+  getExternalTokenMasked,
+  getOrCreateExternalToken,
+  hasExternalToken,
+  regenerateExternalToken,
+  getCodexExternalTokenMasked,
+  getOrCreateCodexExternalToken,
+  hasCodexExternalToken,
+  regenerateCodexExternalToken,
+} from '../maker-host/local-proxy-external-auth.js';
+import {
+  isCodexExternalAccessEnabled,
+  isValidLocalProxyPort,
+  loadLocalProxySettings,
+  setLocalProxyCodexDefaultProviderId,
+  setLocalProxyCodexEnabled,
+  setLocalProxyCodexPort,
+  setLocalProxyDefaultProviderId,
+  setLocalProxyEnabled,
+  setLocalProxyPort,
+} from '../maker-host/local-proxy-settings-store.js';
+import {
+  previewExternalConfig,
+  writeExternalConfig,
+} from './external-config-writer.js';
+import {
+  previewCodexConfig,
+  writeCodexConfig,
+} from './codex-external-config-writer.js';
+
+/** 组装设置页所需的全部非明文状态(单一事实源,各写通道改完都回读它)。 */
+function buildState(): LocalProxyServiceState {
+  const settings = loadLocalProxySettings();
+  return {
+    enabled: settings.enabled,
+    url: getLocalProxyUrl(),
+    port: settings.port,
+    hasToken: hasExternalToken(),
+    maskedToken: getExternalTokenMasked(),
+    providers: listExternalRoutableProviders(),
+    defaultProviderId: settings.defaultProviderId,
+    // ── Codex / 通用 OpenAI 出口(第三期:独立开关 + 独立 token,另一个 loopback 端口)──
+    codexEnabled: settings.codexEnabled,
+    codexHasToken: hasCodexExternalToken(),
+    codexMaskedToken: getCodexExternalTokenMasked(),
+    codexUrl: getCodexProxyUrl(),
+    codexPort: settings.codexPort,
+    codexProviders: listExternalRoutableProviders('codex'),
+    codexDefaultProviderId: settings.codexDefaultProviderId,
+  };
+}
+
+export function registerLocalProxyServiceIpc(): void {
+  ipcMain.handle('local-proxy:get-state', async (): Promise<LocalProxyServiceState> =>
+    buildState());
+
+  // 开启 A 族(Anthropic / Claude Code)对外服务:①确保已有 A 族 token;②捕获当前正在跑的
+  // (默认随机)端口并持久化,让外部 CLI 的 ANTHROPIC_BASE_URL 从此稳定。关闭则仅置
+  // enabled=false(端口保留,下次开启复用同一端口)。B 族(Codex)有独立开关,互不影响。
+  ipcMain.handle(
+    'local-proxy:set-enabled',
+    async (event, enabled: unknown): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (typeof enabled !== 'boolean') {
+        return { success: false, error: 'invalid enabled flag', state: buildState() };
+      }
+      if (enabled) {
+        getOrCreateExternalToken();
+        // 未固定端口时,捕获当前实际端口固定下来(proxy 已在随机端口上跑)。
+        if (loadLocalProxySettings().port <= 0) {
+          const url = getLocalProxyUrl();
+          const running = url ? portFromProxyUrl(url) : null;
+          if (running) setLocalProxyPort(running);
+        }
+      }
+      setLocalProxyEnabled(enabled);
+      return { success: true, state: buildState() };
+    },
+  );
+
+  // 开启 B 族(Codex / 通用 OpenAI)对外服务:①确保已有 B 族独立 token;②codex loopback 可能
+  // 尚未起(纯外部用法、无内部 codex 会话),显式 ensureCodexProxyReady() 拉起;③捕获其当前
+  // 端口固定下来,让外部 codex/OpenAI 客户端 base_url 稳定。关闭则仅置 codexEnabled=false。
+  ipcMain.handle(
+    'local-proxy:set-codex-enabled',
+    async (event, enabled: unknown): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (typeof enabled !== 'boolean') {
+        return { success: false, error: 'invalid enabled flag', state: buildState() };
+      }
+      if (enabled) {
+        getOrCreateCodexExternalToken();
+        try {
+          await ensureCodexProxyReady();
+          if (loadLocalProxySettings().codexPort <= 0) {
+            const codexUrl = getCodexProxyUrl();
+            const codexRunning = codexUrl ? codexPortFromProxyUrl(codexUrl) : null;
+            if (codexRunning) setLocalProxyCodexPort(codexRunning);
+          }
+        } catch {
+          // codex loopback 起不来不阻断开关置位;codexUrl 会保持 null,UI 侧据此提示未就绪。
+        }
+      }
+      setLocalProxyCodexEnabled(enabled);
+      return { success: true, state: buildState() };
+    },
+  );
+
+  ipcMain.handle(
+    'local-proxy:set-default-provider',
+    async (event, providerId: unknown): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (typeof providerId !== 'string') {
+        return { success: false, error: 'invalid provider id', state: buildState() };
+      }
+      // 允许空串(= 清空默认供应商);非空时必须是当前可路由候选之一,防写入陈旧/不可用 id。
+      const trimmed = providerId.trim();
+      if (trimmed.length > 0 && !listExternalRoutableProviders().some((p) => p.id === trimmed)) {
+        return { success: false, error: 'provider not routable', state: buildState() };
+      }
+      setLocalProxyDefaultProviderId(trimmed);
+      return { success: true, state: buildState() };
+    },
+  );
+
+  // 重新生成对外 token(旧 token 立即失效)。只回掩码后的最新 state;明文要复制的话走
+  // get-env-example。
+  ipcMain.handle(
+    'local-proxy:regenerate-token',
+    async (event): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      regenerateExternalToken();
+      return { success: true, state: buildState() };
+    },
+  );
+
+  // 重新生成 B 族(Codex / 通用 OpenAI)独立对外 token(旧 token 立即失效,不影响 A 族)。
+  ipcMain.handle(
+    'local-proxy:regenerate-codex-token',
+    async (event): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      regenerateCodexExternalToken();
+      return { success: true, state: buildState() };
+    },
+  );
+
+  // 手改固定端口:校验区间 → 持久化 → 重建 proxy 让新端口生效(会中断经代理的 in-flight 请求)。
+  // 端口被占用时 host 内部会 fallback 随机并回写,故重建后回读的 state.url 反映实际绑定值。
+  ipcMain.handle(
+    'local-proxy:set-port',
+    async (event, port: unknown): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (!isValidLocalProxyPort(port)) {
+        return { success: false, error: 'invalid port', state: buildState() };
+      }
+      setLocalProxyPort(port);
+      try {
+        await restartAnthropicCompatProxy();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: message, state: buildState() };
+      }
+      return { success: true, state: buildState() };
+    },
+  );
+
+  // 明文 env 出口(复制到剪贴板 / 展示用)。用户主动触发,过来源闸。
+  ipcMain.handle(
+    'local-proxy:get-env-example',
+    async (event): Promise<LocalProxyEnvExampleResult> => {
+      assertTrustedAppRendererEvent(event);
+      const url = getLocalProxyUrl();
+      if (!url) {
+        return { success: false, error: 'proxy not ready' };
+      }
+      const token = getOrCreateExternalToken();
+      return {
+        success: true,
+        env: {
+          baseUrl: url,
+          apiKey: token,
+          // 带 export 前缀:粘进 shell 后是两条独立、可直接运行的语句(子进程 claude 才能继承
+          // 这两个变量;裸 `KEY=value` 只是当前 shell 的局部变量,不会传给子进程)。渲染层用
+          // 换行连接。
+          lines: [`export ANTHROPIC_BASE_URL=${url}`, `export ANTHROPIC_API_KEY=${token}`],
+        },
+      };
+    },
+  );
+
+  // 写用户 ~/.claude 配置前的预览(展示改动 + 冲突项,由 UI 二次确认)。
+  ipcMain.handle(
+    'local-proxy:preview-external-config',
+    async (event): Promise<LocalProxyConfigPreviewResult> => {
+      assertTrustedAppRendererEvent(event);
+      const url = getLocalProxyUrl();
+      if (!url) {
+        return { success: false, error: 'proxy not ready' };
+      }
+      const token = getOrCreateExternalToken();
+      try {
+        return { success: true, preview: previewExternalConfig(url, token) };
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  );
+
+  // 非破坏性写入用户 ~/.claude 配置。仅用户在预览后主动确认时调用。
+  ipcMain.handle(
+    'local-proxy:write-external-config',
+    async (event): Promise<LocalProxyConfigWriteResult> => {
+      assertTrustedAppRendererEvent(event);
+      const url = getLocalProxyUrl();
+      if (!url) {
+        return { success: false, error: 'proxy not ready' };
+      }
+      const token = getOrCreateExternalToken();
+      return writeExternalConfig(url, token);
+    },
+  );
+
+  // ───────── 第二期:Codex / 通用 OpenAI 出口专属通道 ─────────
+
+  // codex「对外默认供应商」。空串 = 清空;非空须是 codex agent 当前可路由候选之一。
+  ipcMain.handle(
+    'local-proxy:set-codex-default-provider',
+    async (event, providerId: unknown): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (typeof providerId !== 'string') {
+        return { success: false, error: 'invalid provider id', state: buildState() };
+      }
+      const trimmed = providerId.trim();
+      if (
+        trimmed.length > 0 &&
+        !listExternalRoutableProviders('codex').some((p) => p.id === trimmed)
+      ) {
+        return { success: false, error: 'provider not routable', state: buildState() };
+      }
+      setLocalProxyCodexDefaultProviderId(trimmed);
+      return { success: true, state: buildState() };
+    },
+  );
+
+  // 手改 codex loopback 固定端口:校验 → 持久化 → 重建 codex proxy 让新端口生效
+  // (会中断经该 loopback 的内部 codex in-flight 请求;被占用时 host 内部 fallback 随机并回写)。
+  ipcMain.handle(
+    'local-proxy:set-codex-port',
+    async (event, port: unknown): Promise<LocalProxyMutationResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (!isValidLocalProxyPort(port)) {
+        return { success: false, error: 'invalid port', state: buildState() };
+      }
+      setLocalProxyCodexPort(port);
+      try {
+        await restartCodexProxy();
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { success: false, error: message, state: buildState() };
+      }
+      return { success: true, state: buildState() };
+    },
+  );
+
+  // codex 明文 env 出口(OPENAI_BASE_URL/OPENAI_API_KEY)。用户主动触发,过来源闸。
+  ipcMain.handle(
+    'local-proxy:get-codex-env-example',
+    async (event): Promise<LocalProxyEnvExampleResult> => {
+      assertTrustedAppRendererEvent(event);
+      const url = getCodexProxyUrl();
+      if (!url) {
+        return { success: false, error: 'codex proxy not ready' };
+      }
+      const token = getOrCreateCodexExternalToken();
+      return {
+        success: true,
+        env: {
+          baseUrl: url,
+          apiKey: token,
+          lines: [`export OPENAI_BASE_URL=${url}`, `export OPENAI_API_KEY=${token}`],
+        },
+      };
+    },
+  );
+
+  // 写用户 ~/.codex/config.toml 前的预览(展示 merge 后 TOML + 冲突 + 需自设的 token env 行)。
+  ipcMain.handle(
+    'local-proxy:preview-codex-config',
+    async (event): Promise<LocalProxyCodexConfigPreviewResult> => {
+      assertTrustedAppRendererEvent(event);
+      const url = getCodexProxyUrl();
+      if (!url) {
+        return { success: false, error: 'codex proxy not ready' };
+      }
+      const token = getOrCreateCodexExternalToken();
+      try {
+        return { success: true, preview: previewCodexConfig(url, token) };
+      } catch (err) {
+        return { success: false, error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  );
+
+  // 非破坏性写入用户 ~/.codex/config.toml。仅用户在预览后主动确认时调用。token 不入文件。
+  ipcMain.handle(
+    'local-proxy:write-codex-config',
+    async (event): Promise<LocalProxyConfigWriteResult> => {
+      assertTrustedAppRendererEvent(event);
+      const url = getCodexProxyUrl();
+      if (!url) {
+        return { success: false, error: 'codex proxy not ready' };
+      }
+      return writeCodexConfig(url);
+    },
+  );
+
+  // boot 期:B 族(Codex)独立开启时,codex loopback 应在启动时就绪(而非等下次点开关)——
+  // 与「每族可独立开」一致。仅 codexEnabled 为真才拉起;fire-and-forget,起不来不阻断 IPC 注册
+  // (UI 侧据 codexUrl=null 提示未就绪)。A 族的 loopback 由 anthropic host 在 boot 常驻,无需此处。
+  if (isCodexExternalAccessEnabled()) {
+    void ensureCodexProxyReady().catch(() => {
+      // codex loopback 起不来不阻断启动;codexUrl 保持 null,UI 侧提示未就绪。
+    });
+  }
+}

--- a/apps/desktop/src/main/local-proxy-service/register.ts
+++ b/apps/desktop/src/main/local-proxy-service/register.ts
@@ -44,7 +44,7 @@ import {
 } from '../maker-host/local-proxy-external-auth.js';
 import {
   isCodexExternalAccessEnabled,
-  isValidLocalProxyPort,
+  isValidLocalProxyPortOrAuto,
   loadLocalProxySettings,
   setLocalProxyCodexDefaultProviderId,
   setLocalProxyCodexEnabled,
@@ -184,7 +184,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:set-port',
     async (event, port: unknown): Promise<LocalProxyMutationResult> => {
       assertTrustedAppRendererEvent(event);
-      if (!isValidLocalProxyPort(port)) {
+      if (!isValidLocalProxyPortOrAuto(port)) {
         return { success: false, error: 'invalid port', state: buildState() };
       }
       setLocalProxyPort(port);
@@ -282,7 +282,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:set-codex-port',
     async (event, port: unknown): Promise<LocalProxyMutationResult> => {
       assertTrustedAppRendererEvent(event);
-      if (!isValidLocalProxyPort(port)) {
+      if (!isValidLocalProxyPortOrAuto(port)) {
         return { success: false, error: 'invalid port', state: buildState() };
       }
       setLocalProxyCodexPort(port);

--- a/apps/desktop/src/main/local-proxy-service/register.ts
+++ b/apps/desktop/src/main/local-proxy-service/register.ts
@@ -28,15 +28,18 @@ import {
 } from './preview-masking.js';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer.js';
 import {
-  getLocalProxyUrl,
+  disposeAnthropicExternalProxy,
+  ensureAnthropicExternalProxyReady,
+  getExternalProxyUrl,
   portFromProxyUrl,
-  restartAnthropicCompatProxy,
+  restartAnthropicExternalProxy,
 } from '../maker-host/anthropic-compat-proxy-host.js';
 import {
   codexPortFromProxyUrl,
-  ensureCodexProxyReady,
-  getCodexProxyUrl,
-  restartCodexProxy,
+  disposeCodexExternalProxy,
+  ensureCodexExternalProxyReady,
+  getCodexExternalProxyUrl,
+  restartCodexExternalProxy,
 } from '../maker-host/codex-proxy-host.js';
 import { listExternalRoutableProviders } from '../maker-host/provider-route.js';
 import {
@@ -53,6 +56,7 @@ import {
 import { addProviderSecretsClearedListener } from '../secrets/providerSecretStore.js';
 import {
   isCodexExternalAccessEnabled,
+  isExternalAccessEnabled,
   isValidLocalProxyPortOrAuto,
   loadLocalProxySettings,
   setLocalProxyCodexDefaultProviderId,
@@ -76,7 +80,7 @@ function buildState(): LocalProxyServiceState {
   const settings = loadLocalProxySettings();
   return {
     enabled: settings.enabled,
-    url: getLocalProxyUrl(),
+    url: getExternalProxyUrl(),
     port: settings.port,
     hasToken: hasExternalToken(),
     maskedToken: getExternalTokenMasked(),
@@ -86,7 +90,7 @@ function buildState(): LocalProxyServiceState {
     codexEnabled: settings.codexEnabled,
     codexHasToken: hasCodexExternalToken(),
     codexMaskedToken: getCodexExternalTokenMasked(),
-    codexUrl: getCodexProxyUrl(),
+    codexUrl: getCodexExternalProxyUrl(),
     codexPort: settings.codexPort,
     codexProviders: listExternalRoutableProviders('codex'),
     codexDefaultProviderId: settings.codexDefaultProviderId,
@@ -112,9 +116,11 @@ export function registerLocalProxyServiceIpc(): void {
   ipcMain.handle('local-proxy:get-state', async (): Promise<LocalProxyServiceState> =>
     buildState());
 
-  // 开启 A 族(Anthropic / Claude Code)对外服务:①确保已有 A 族 token;②捕获当前正在跑的
-  // (默认随机)端口并持久化,让外部 CLI 的 ANTHROPIC_BASE_URL 从此稳定。关闭则仅置
-  // enabled=false(端口保留,下次开启复用同一端口)。B 族(Codex)有独立开关,互不影响。
+  // 开启 A 族(Anthropic / Claude Code)对外服务:①确保已有 A 族 token;②拉起**独立的对外
+  // loopback 端口**(端口拆分,#1666:内部 cc 子进程代理与对外端口不再共用一个 handle);③未固定
+  // 端口时捕获其实际端口并持久化,让外部 CLI 的 ANTHROPIC_BASE_URL 从此稳定。关闭则置
+  // enabled=false 并**关掉对外端口**(不再监听公开端口,外部直接连不上;端口设置保留,下次开启复用)。
+  // B 族(Codex)有独立开关,互不影响。
   ipcMain.handle(
     'local-proxy:set-enabled',
     async (event, enabled: unknown): Promise<LocalProxyMutationResult> => {
@@ -124,21 +130,29 @@ export function registerLocalProxyServiceIpc(): void {
       }
       if (enabled) {
         getOrCreateExternalToken();
-        // 未固定端口时,捕获当前实际端口固定下来(proxy 已在随机端口上跑)。
-        if (loadLocalProxySettings().port <= 0) {
-          const url = getLocalProxyUrl();
-          const running = url ? portFromProxyUrl(url) : null;
-          if (running) setLocalProxyPort(running);
+        try {
+          await ensureAnthropicExternalProxyReady();
+          // 未固定端口时,捕获对外 handle 的实际(随机)端口固定下来。
+          if (loadLocalProxySettings().port <= 0) {
+            const url = getExternalProxyUrl();
+            const running = url ? portFromProxyUrl(url) : null;
+            if (running) setLocalProxyPort(running);
+          }
+        } catch {
+          // 对外端口起不来不阻断开关置位;url 会保持 null,UI 侧据此提示未就绪。
         }
+      } else {
+        await disposeAnthropicExternalProxy();
       }
       setLocalProxyEnabled(enabled);
       return { success: true, state: buildState() };
     },
   );
 
-  // 开启 B 族(Codex / 通用 OpenAI)对外服务:①确保已有 B 族独立 token;②codex loopback 可能
-  // 尚未起(纯外部用法、无内部 codex 会话),显式 ensureCodexProxyReady() 拉起;③捕获其当前
-  // 端口固定下来,让外部 codex/OpenAI 客户端 base_url 稳定。关闭则仅置 codexEnabled=false。
+  // 开启 B 族(Codex / 通用 OpenAI)对外服务:①确保已有 B 族独立 token;②拉起**独立的对外 codex
+  // loopback 端口**(端口拆分,#1666 Finding 2:内部 codex 子进程代理与对外端口不再共用一个 handle);
+  // ③未固定端口时捕获其实际端口并持久化,让外部 codex/OpenAI 客户端 base_url 稳定。关闭则置
+  // codexEnabled=false 并**关掉对外端口**(端口设置保留,下次开启复用)。A 族(Anthropic)有独立开关。
   ipcMain.handle(
     'local-proxy:set-codex-enabled',
     async (event, enabled: unknown): Promise<LocalProxyMutationResult> => {
@@ -149,15 +163,17 @@ export function registerLocalProxyServiceIpc(): void {
       if (enabled) {
         getOrCreateCodexExternalToken();
         try {
-          await ensureCodexProxyReady();
+          await ensureCodexExternalProxyReady();
           if (loadLocalProxySettings().codexPort <= 0) {
-            const codexUrl = getCodexProxyUrl();
+            const codexUrl = getCodexExternalProxyUrl();
             const codexRunning = codexUrl ? codexPortFromProxyUrl(codexUrl) : null;
             if (codexRunning) setLocalProxyCodexPort(codexRunning);
           }
         } catch {
-          // codex loopback 起不来不阻断开关置位;codexUrl 会保持 null,UI 侧据此提示未就绪。
+          // codex 对外端口起不来不阻断开关置位;codexUrl 会保持 null,UI 侧据此提示未就绪。
         }
+      } else {
+        await disposeCodexExternalProxy();
       }
       setLocalProxyCodexEnabled(enabled);
       return { success: true, state: buildState() };
@@ -187,7 +203,12 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:regenerate-token',
     async (event): Promise<LocalProxyMutationResult> => {
       assertTrustedAppRendererEvent(event);
-      regenerateExternalToken();
+      try {
+        regenerateExternalToken();
+      } catch (err) {
+        // 轮换失败(旧物理 token 无法失效)→ 如实回失败,别谎报成功让旧 token 继续鉴权。
+        return { success: false, error: (err as Error).message, state: buildState() };
+      }
       return { success: true, state: buildState() };
     },
   );
@@ -197,7 +218,11 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:regenerate-codex-token',
     async (event): Promise<LocalProxyMutationResult> => {
       assertTrustedAppRendererEvent(event);
-      regenerateCodexExternalToken();
+      try {
+        regenerateCodexExternalToken();
+      } catch (err) {
+        return { success: false, error: (err as Error).message, state: buildState() };
+      }
       return { success: true, state: buildState() };
     },
   );
@@ -213,7 +238,7 @@ export function registerLocalProxyServiceIpc(): void {
       }
       setLocalProxyPort(port);
       try {
-        await restartAnthropicCompatProxy();
+        await restartAnthropicExternalProxy();
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { success: false, error: message, state: buildState() };
@@ -227,7 +252,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:copy-token',
     async (event): Promise<LocalProxyCopyResult> => {
       assertTrustedAppRendererEvent(event);
-      if (!getLocalProxyUrl()) return { success: false, error: 'proxy not ready' };
+      if (!getExternalProxyUrl()) return { success: false, error: 'proxy not ready' };
       return copyToClipboardInMain(getOrCreateExternalToken());
     },
   );
@@ -239,7 +264,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:copy-env',
     async (event): Promise<LocalProxyCopyResult> => {
       assertTrustedAppRendererEvent(event);
-      const url = getLocalProxyUrl();
+      const url = getExternalProxyUrl();
       if (!url) return { success: false, error: 'proxy not ready' };
       const token = getOrCreateExternalToken();
       return copyToClipboardInMain(
@@ -254,7 +279,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:preview-external-config',
     async (event): Promise<LocalProxyConfigPreviewResult> => {
       assertTrustedAppRendererEvent(event);
-      const url = getLocalProxyUrl();
+      const url = getExternalProxyUrl();
       if (!url) {
         return { success: false, error: 'proxy not ready' };
       }
@@ -273,7 +298,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:write-external-config',
     async (event): Promise<LocalProxyConfigWriteResult> => {
       assertTrustedAppRendererEvent(event);
-      const url = getLocalProxyUrl();
+      const url = getExternalProxyUrl();
       if (!url) {
         return { success: false, error: 'proxy not ready' };
       }
@@ -304,8 +329,8 @@ export function registerLocalProxyServiceIpc(): void {
     },
   );
 
-  // 手改 codex loopback 固定端口:校验 → 持久化 → 重建 codex proxy 让新端口生效
-  // (会中断经该 loopback 的内部 codex in-flight 请求;被占用时 host 内部 fallback 随机并回写)。
+  // 手改 codex 对外 loopback 固定端口:校验 → 持久化 → 重建**对外** codex proxy 让新端口生效
+  // (会中断经该对外 loopback 的 in-flight 请求;被占用时 host 内部 fallback 随机并回写)。
   ipcMain.handle(
     'local-proxy:set-codex-port',
     async (event, port: unknown): Promise<LocalProxyMutationResult> => {
@@ -315,7 +340,7 @@ export function registerLocalProxyServiceIpc(): void {
       }
       setLocalProxyCodexPort(port);
       try {
-        await restartCodexProxy();
+        await restartCodexExternalProxy();
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return { success: false, error: message, state: buildState() };
@@ -329,7 +354,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:copy-codex-token',
     async (event): Promise<LocalProxyCopyResult> => {
       assertTrustedAppRendererEvent(event);
-      if (!getCodexProxyUrl()) return { success: false, error: 'codex proxy not ready' };
+      if (!getCodexExternalProxyUrl()) return { success: false, error: 'codex proxy not ready' };
       return copyToClipboardInMain(getOrCreateCodexExternalToken());
     },
   );
@@ -339,7 +364,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:copy-codex-env',
     async (event): Promise<LocalProxyCopyResult> => {
       assertTrustedAppRendererEvent(event);
-      const url = getCodexProxyUrl();
+      const url = getCodexExternalProxyUrl();
       if (!url) return { success: false, error: 'codex proxy not ready' };
       const token = getOrCreateCodexExternalToken();
       return copyToClipboardInMain(
@@ -354,7 +379,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:copy-codex-token-export',
     async (event): Promise<LocalProxyCopyResult> => {
       assertTrustedAppRendererEvent(event);
-      if (!getCodexProxyUrl()) return { success: false, error: 'codex proxy not ready' };
+      if (!getCodexExternalProxyUrl()) return { success: false, error: 'codex proxy not ready' };
       return copyToClipboardInMain(`export CINDY_LOCAL_TOKEN=${getOrCreateCodexExternalToken()}`);
     },
   );
@@ -365,7 +390,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:preview-codex-config',
     async (event): Promise<LocalProxyCodexConfigPreviewResult> => {
       assertTrustedAppRendererEvent(event);
-      const url = getCodexProxyUrl();
+      const url = getCodexExternalProxyUrl();
       if (!url) {
         return { success: false, error: 'codex proxy not ready' };
       }
@@ -384,7 +409,7 @@ export function registerLocalProxyServiceIpc(): void {
     'local-proxy:write-codex-config',
     async (event): Promise<LocalProxyConfigWriteResult> => {
       assertTrustedAppRendererEvent(event);
-      const url = getCodexProxyUrl();
+      const url = getCodexExternalProxyUrl();
       if (!url) {
         return { success: false, error: 'codex proxy not ready' };
       }
@@ -392,12 +417,18 @@ export function registerLocalProxyServiceIpc(): void {
     },
   );
 
-  // boot 期:B 族(Codex)独立开启时,codex loopback 应在启动时就绪(而非等下次点开关)——
-  // 与「每族可独立开」一致。仅 codexEnabled 为真才拉起;fire-and-forget,起不来不阻断 IPC 注册
-  // (UI 侧据 codexUrl=null 提示未就绪)。A 族的 loopback 由 anthropic host 在 boot 常驻,无需此处。
+  // boot 期:两族各自独立开启时,对应的对外 loopback 应在启动时就绪(而非等下次点开关)——
+  // 与「每族可独立开」一致。端口拆分后 A 族对外端口是独立 handle(不再随内部 cc 代理常驻),
+  // 故 A 族也要在此按 enabled 拉起。fire-and-forget,起不来不阻断 IPC 注册(UI 侧据 url/codexUrl=null
+  // 提示未就绪)。内部 cc 子进程代理仍由 anthropic host 在 boot 常驻,与此处的对外端口无关。
+  if (isExternalAccessEnabled()) {
+    void ensureAnthropicExternalProxyReady().catch(() => {
+      // 对外端口起不来不阻断启动;url 保持 null,UI 侧提示未就绪。
+    });
+  }
   if (isCodexExternalAccessEnabled()) {
-    void ensureCodexProxyReady().catch(() => {
-      // codex loopback 起不来不阻断启动;codexUrl 保持 null,UI 侧提示未就绪。
+    void ensureCodexExternalProxyReady().catch(() => {
+      // codex 对外端口起不来不阻断启动;codexUrl 保持 null,UI 侧提示未就绪。
     });
   }
 }

--- a/apps/desktop/src/main/local-proxy-service/register.ts
+++ b/apps/desktop/src/main/local-proxy-service/register.ts
@@ -3,22 +3,29 @@
  *
  * 安全约束(勿改):
  *   - 所有**写**通道(set-enabled / set-default-provider / regenerate-token / set-port /
- *     write-external-config)都过 `assertTrustedAppRendererEvent` —— 只允许 Cindy 自有顶层
- *     页面发起,插件面板 / webview 无法触达。
- *   - token 明文只在 `get-env-example` / `write-external-config` 这两个「用户主动触发」的
- *     出口返回;`get-state` 只给掩码。
+ *     write-external-config / copy-*)都过 `assertTrustedAppRendererEvent` —— 只允许 Cindy 自有
+ *     顶层页面发起,插件面板 / webview 无法触达。
+ *   - **token 明文绝不回传 renderer**:复制到剪贴板由 `copy-*` 通道在**主进程**里
+ *     `clipboard.writeText` 完成,只回 `{success}`;写用户配置的明文也只在 main 落文件。
+ *     `get-state` 与两个 preview 通道给 renderer 的一律是掩码。`assertTrustedAppRendererEvent`
+ *     只验来源帧、不验用户手势,所以哪怕来源可信也不把明文交给可能被注入的渲染进程。
  */
 
-import { ipcMain } from 'electron';
+import { clipboard, ipcMain } from 'electron';
 
 import type {
   LocalProxyCodexConfigPreviewResult,
   LocalProxyConfigPreviewResult,
   LocalProxyConfigWriteResult,
-  LocalProxyEnvExampleResult,
+  LocalProxyCopyResult,
   LocalProxyMutationResult,
   LocalProxyServiceState,
 } from '../../shared/localProxyService.js';
+import {
+  MASK_FALLBACK,
+  maskAnthropicPreview,
+  maskCodexPreview,
+} from './preview-masking.js';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer.js';
 import {
   getLocalProxyUrl,
@@ -84,6 +91,16 @@ function buildState(): LocalProxyServiceState {
     codexProviders: listExternalRoutableProviders('codex'),
     codexDefaultProviderId: settings.codexDefaultProviderId,
   };
+}
+
+/** 主进程侧把明文写进系统剪贴板;明文不出 main。 */
+function copyToClipboardInMain(text: string): LocalProxyCopyResult {
+  try {
+    clipboard.writeText(text);
+    return { success: true };
+  } catch (err) {
+    return { success: false, error: err instanceof Error ? err.message : String(err) };
+  }
 }
 
 export function registerLocalProxyServiceIpc(): void {
@@ -164,8 +181,8 @@ export function registerLocalProxyServiceIpc(): void {
     },
   );
 
-  // 重新生成对外 token(旧 token 立即失效)。只回掩码后的最新 state;明文要复制的话走
-  // get-env-example。
+  // 重新生成对外 token(旧 token 立即失效)。只回掩码后的最新 state;要复制明文走
+  // copy-token / copy-env(main 侧落剪贴板)。
   ipcMain.handle(
     'local-proxy:regenerate-token',
     async (event): Promise<LocalProxyMutationResult> => {
@@ -205,31 +222,34 @@ export function registerLocalProxyServiceIpc(): void {
     },
   );
 
-  // 明文 env 出口(复制到剪贴板 / 展示用)。用户主动触发,过来源闸。
+  // 复制 A 族对外 token 明文到系统剪贴板 —— 明文只在 main 落剪贴板,不回传 renderer。
   ipcMain.handle(
-    'local-proxy:get-env-example',
-    async (event): Promise<LocalProxyEnvExampleResult> => {
+    'local-proxy:copy-token',
+    async (event): Promise<LocalProxyCopyResult> => {
       assertTrustedAppRendererEvent(event);
-      const url = getLocalProxyUrl();
-      if (!url) {
-        return { success: false, error: 'proxy not ready' };
-      }
-      const token = getOrCreateExternalToken();
-      return {
-        success: true,
-        env: {
-          baseUrl: url,
-          apiKey: token,
-          // 带 export 前缀:粘进 shell 后是两条独立、可直接运行的语句(子进程 claude 才能继承
-          // 这两个变量;裸 `KEY=value` 只是当前 shell 的局部变量,不会传给子进程)。渲染层用
-          // 换行连接。
-          lines: [`export ANTHROPIC_BASE_URL=${url}`, `export ANTHROPIC_API_KEY=${token}`],
-        },
-      };
+      if (!getLocalProxyUrl()) return { success: false, error: 'proxy not ready' };
+      return copyToClipboardInMain(getOrCreateExternalToken());
     },
   );
 
-  // 写用户 ~/.claude 配置前的预览(展示改动 + 冲突项,由 UI 二次确认)。
+  // 复制 A 族完整 env(两条 `export` 行)到系统剪贴板。带 export 前缀:粘进 shell 后是两条独立、
+  // 可直接运行的语句(子进程 claude 才能继承这两个变量;裸 `KEY=value` 只是当前 shell 局部变量,
+  // 不会传给子进程)。明文只在 main 落剪贴板,不回传 renderer。
+  ipcMain.handle(
+    'local-proxy:copy-env',
+    async (event): Promise<LocalProxyCopyResult> => {
+      assertTrustedAppRendererEvent(event);
+      const url = getLocalProxyUrl();
+      if (!url) return { success: false, error: 'proxy not ready' };
+      const token = getOrCreateExternalToken();
+      return copyToClipboardInMain(
+        `export ANTHROPIC_BASE_URL=${url}\nexport ANTHROPIC_API_KEY=${token}`,
+      );
+    },
+  );
+
+  // 写用户 ~/.claude 配置前的预览(展示改动 + 冲突项,由 UI 二次确认)。token 段掩码后再回
+  // renderer;真实明文只在 write-external-config 落文件。
   ipcMain.handle(
     'local-proxy:preview-external-config',
     async (event): Promise<LocalProxyConfigPreviewResult> => {
@@ -240,7 +260,8 @@ export function registerLocalProxyServiceIpc(): void {
       }
       const token = getOrCreateExternalToken();
       try {
-        return { success: true, preview: previewExternalConfig(url, token) };
+        const masked = getExternalTokenMasked() ?? MASK_FALLBACK;
+        return { success: true, preview: maskAnthropicPreview(previewExternalConfig(url, token), token, masked) };
       } catch (err) {
         return { success: false, error: err instanceof Error ? err.message : String(err) };
       }
@@ -303,28 +324,43 @@ export function registerLocalProxyServiceIpc(): void {
     },
   );
 
-  // codex 明文 env 出口(OPENAI_BASE_URL/OPENAI_API_KEY)。用户主动触发,过来源闸。
+  // 复制 B 族(Codex)对外 token 明文到系统剪贴板。明文只在 main 落剪贴板,不回传 renderer。
   ipcMain.handle(
-    'local-proxy:get-codex-env-example',
-    async (event): Promise<LocalProxyEnvExampleResult> => {
+    'local-proxy:copy-codex-token',
+    async (event): Promise<LocalProxyCopyResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (!getCodexProxyUrl()) return { success: false, error: 'codex proxy not ready' };
+      return copyToClipboardInMain(getOrCreateCodexExternalToken());
+    },
+  );
+
+  // 复制 B 族完整 env(OPENAI_BASE_URL/OPENAI_API_KEY 两条 export 行)到系统剪贴板。
+  ipcMain.handle(
+    'local-proxy:copy-codex-env',
+    async (event): Promise<LocalProxyCopyResult> => {
       assertTrustedAppRendererEvent(event);
       const url = getCodexProxyUrl();
-      if (!url) {
-        return { success: false, error: 'codex proxy not ready' };
-      }
+      if (!url) return { success: false, error: 'codex proxy not ready' };
       const token = getOrCreateCodexExternalToken();
-      return {
-        success: true,
-        env: {
-          baseUrl: url,
-          apiKey: token,
-          lines: [`export OPENAI_BASE_URL=${url}`, `export OPENAI_API_KEY=${token}`],
-        },
-      };
+      return copyToClipboardInMain(
+        `export OPENAI_BASE_URL=${url}\nexport OPENAI_API_KEY=${token}`,
+      );
+    },
+  );
+
+  // 复制 codex 需自设的 `export CINDY_LOCAL_TOKEN=<token>` 行到系统剪贴板(写 config.toml 弹窗里
+  // 那行掩码展示,真实明文经此通道复制)。明文只在 main 落剪贴板,不回传 renderer。
+  ipcMain.handle(
+    'local-proxy:copy-codex-token-export',
+    async (event): Promise<LocalProxyCopyResult> => {
+      assertTrustedAppRendererEvent(event);
+      if (!getCodexProxyUrl()) return { success: false, error: 'codex proxy not ready' };
+      return copyToClipboardInMain(`export CINDY_LOCAL_TOKEN=${getOrCreateCodexExternalToken()}`);
     },
   );
 
   // 写用户 ~/.codex/config.toml 前的预览(展示 merge 后 TOML + 冲突 + 需自设的 token env 行)。
+  // token export 行掩码后再回 renderer;真实明文走 copy-codex-token-export。
   ipcMain.handle(
     'local-proxy:preview-codex-config',
     async (event): Promise<LocalProxyCodexConfigPreviewResult> => {
@@ -335,7 +371,8 @@ export function registerLocalProxyServiceIpc(): void {
       }
       const token = getOrCreateCodexExternalToken();
       try {
-        return { success: true, preview: previewCodexConfig(url, token) };
+        const masked = getCodexExternalTokenMasked() ?? MASK_FALLBACK;
+        return { success: true, preview: maskCodexPreview(previewCodexConfig(url, token), token, masked) };
       } catch (err) {
         return { success: false, error: err instanceof Error ? err.message : String(err) };
       }

--- a/apps/desktop/src/main/local-proxy-service/register.ts
+++ b/apps/desktop/src/main/local-proxy-service/register.ts
@@ -33,6 +33,7 @@ import {
 } from '../maker-host/codex-proxy-host.js';
 import { listExternalRoutableProviders } from '../maker-host/provider-route.js';
 import {
+  clearExternalTokenMemoryFallback,
   getExternalTokenMasked,
   getOrCreateExternalToken,
   hasExternalToken,
@@ -42,6 +43,7 @@ import {
   hasCodexExternalToken,
   regenerateCodexExternalToken,
 } from '../maker-host/local-proxy-external-auth.js';
+import { addProviderSecretsClearedListener } from '../secrets/providerSecretStore.js';
 import {
   isCodexExternalAccessEnabled,
   isValidLocalProxyPortOrAuto,
@@ -85,6 +87,11 @@ function buildState(): LocalProxyServiceState {
 }
 
 export function registerLocalProxyServiceIpc(): void {
+  // 账号边界清理(切换账号 / 清空 secrets)时,providerSecretStore 会删掉两族物理 token。
+  // 但 safeStorage 写失败时留下的进程内兜底 token 不经 secretStore,必须在同一路径上一并清掉,
+  // 否则旧账号的对外 token 会跨账号存活、在新账号下仍被判定命中(串到新账号付费凭证)。
+  addProviderSecretsClearedListener(clearExternalTokenMemoryFallback);
+
   ipcMain.handle('local-proxy:get-state', async (): Promise<LocalProxyServiceState> =>
     buildState());
 

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -47,7 +47,7 @@ vi.mock('../claude-fast-mode-log', () => ({
 // 有界拒绝(P1)用例按需把 externalEnabled 翻开。
 const externalAuthMock = vi.hoisted(() => ({
   externalEnabled: false,
-  matchToken: (_token: string) => false,
+  matchToken: (_token: string): boolean => false,
 }));
 vi.mock('../local-proxy-external-auth', () => ({
   isCindyLocalToken: (token: unknown) =>
@@ -57,6 +57,7 @@ vi.mock('../local-proxy-external-auth', () => ({
 }));
 
 import {
+  createExternalRoutingTransform,
   createModelRoutingTransform,
   setClaudeProxyGatewayKeyReader,
   setClaudeProxySessionIdResolver,
@@ -240,7 +241,9 @@ describe('pi routingTransform — xdt session header selects the Pi provider rou
   });
 });
 
-describe('cc routingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网关 key)', () => {
+describe('cc 对外端口有界拒绝 (P1: 匿名/伪造客户端不得白嫖网关 key,#1666 端口拆分)', () => {
+  // 端口拆分后,对外判定全部落在**独立对外端口**的 createExternalRoutingTransform 上:放行的
+  // 唯一条件是命中不可伪造的对外 token;伪造 session-header / authorization 在此端口上毫无作用。
   async function drainLocalHandler(
     decision: unknown,
   ): Promise<{ status: number; body: { error?: { code?: string } } | null }> {
@@ -265,9 +268,9 @@ describe('cc routingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网�
     externalAuthMock.externalEnabled = false;
   });
 
-  it('对外开启 + 无会话 + 无 x-api-key + 无 authorization + 无会话头 → 401 external_token_required', async () => {
+  it('对外端口:无 x-api-key + 无 authorization + 无会话头 → 401 external_token_required', async () => {
     externalAuthMock.externalEnabled = true;
-    const decision = await Promise.resolve(createModelRoutingTransform()(
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
       { model: 'claude-opus-4-8' },
       ctxWith({}),
     ));
@@ -276,34 +279,43 @@ describe('cc routingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网�
     expect(body?.error?.code).toBe('external_token_required');
   });
 
-  it('伪造 authorization bearer + 无 x-api-key + 无会话头 → 仍 401(假 bearer 不得绕过 #1666)', async () => {
+  it('对外端口:伪造 authorization bearer + 无 x-api-key + 无会话头 → 仍 401(假 bearer 不得绕过 #1666)', async () => {
     externalAuthMock.externalEnabled = true;
-    // 本机进程随手编一个 Bearer:既没有可用 x-api-key,也没有 x-claude-code-session-id 会话头。
-    // 修复前「带 authorization 即豁免」会放它落到 gatewayDefaultRouteDecision 白嫖网关 key;
-    // 修复后 authorization 不再作豁免,仍按匿名客户端拒绝。
-    const decision = await Promise.resolve(createModelRoutingTransform()(
+    // 本机进程随手编一个 Bearer:既没有可用 x-api-key,也没有命中的对外 token。对外端口无 session
+    // 启发式,放行只认对外 token,故仍按匿名客户端拒绝 —— 假 bearer / 伪造会话头都绕不过去。
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
       { model: 'claude-opus-4-8' },
-      ctxWith({ authorization: 'Bearer anything' }),
+      ctxWith({ authorization: 'Bearer anything', 'x-claude-code-session-id': 'forged' }),
     ));
     const { status, body } = await drainLocalHandler(decision);
     expect(status).toBe(401);
     expect(body?.error?.code).toBe('external_token_required');
   });
+});
 
-  it('内部 oauth-spawn 子进程(带 authorization bearer + 会话头)不被有界拒绝命中', async () => {
+describe('cc 内部端口 (端口拆分后内部路由不再承担对外判定,字节级不变)', () => {
+  beforeEach(() => {
+    setClaudeProxyGatewayKeyReader(() => 'sk-gw');
+    setClaudeProxySessionIdResolver(() => null);
+  });
+
+  afterEach(() => {
+    externalAuthMock.externalEnabled = false;
+  });
+
+  it('内部 oauth-spawn 子进程(带 authorization bearer + 会话头)→ ② 段默认路由换网关 key', async () => {
+    // 对外访问开启也不影响内部端口:内部 transform 不再有对外闸,走 ② 段默认路由。
     externalAuthMock.externalEnabled = true;
-    // 带 x-claude-code-session-id(任何 cc 子进程都带)+ OAuth bearer,但会话解析不出(注册时序窗口)。
     const decision = await Promise.resolve(createModelRoutingTransform()(
       { model: 'claude-opus-4-8' },
       ctxWith({ 'x-claude-code-session-id': 'sdk-unresolved', authorization: 'Bearer sk-ant-oat01' }),
     ));
-    // 不是 401 有界拒绝:落到 ② 段默认路由,oauth-spawn 换网关 key。
     expect(decision).toEqual({
       headerOverride: { 'x-api-key': 'sk-gw', authorization: 'Bearer sk-gw' },
     });
   });
 
-  it('对外关闭时不启用闸:匿名请求按内部默认路由(oauth-spawn 无 key)→ 直连订阅,字节级不变', async () => {
+  it('内部匿名请求(oauth-spawn 无 key)→ 直连订阅,字节级不变', async () => {
     externalAuthMock.externalEnabled = false;
     setClaudeProxyGatewayKeyReader(() => null);
     const decision = await Promise.resolve(createModelRoutingTransform()(
@@ -311,5 +323,100 @@ describe('cc routingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网�
       ctxWith({ authorization: 'Bearer sk-ant-oat01' }),
     ));
     expect(decision).toEqual({ upstreamOverride: 'https://api.anthropic.com' });
+  });
+});
+
+describe('cc routingTransform 外部路径白名单 (P2: 对外只服务 /v1/messages + GET /v1/models, #1666)', () => {
+  const GOOD_TOKEN = 'cindy-local-good-external-token';
+
+  async function drainLocalHandler(
+    decision: unknown,
+  ): Promise<{ status: number; body: { error?: { code?: string } } | null }> {
+    const res = {
+      status: 0,
+      raw: '',
+      writeHead(status: number) { this.status = status; },
+      end(chunk: string) { this.raw = chunk; },
+    };
+    await (decision as { localHandler?: (arg: { res: unknown }) => Promise<void> })
+      .localHandler?.({ res } as never);
+    return { status: res.status, body: res.raw ? JSON.parse(res.raw) : null };
+  }
+
+  function ctx(method: string, url: string, headers: Record<string, string>) {
+    return { reqId: 1, method, url, headers } as never;
+  }
+
+  beforeEach(() => {
+    // 命中对外 token → 判定外部客户端;开启对外访问,让请求进入 routeExternalClient。
+    externalAuthMock.externalEnabled = true;
+    externalAuthMock.matchToken = (token: string) => token === GOOD_TOKEN;
+    setClaudeProxyGatewayKeyReader(() => 'sk-gw');
+    setClaudeProxySessionIdResolver(() => null);
+  });
+
+  afterEach(() => {
+    externalAuthMock.externalEnabled = false;
+    externalAuthMock.matchToken = () => false;
+  });
+
+  it('外部客户端 POST /v1/files → 404 unsupported_path(绝不带 Cindy 凭证转发到任意路径)', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctx('POST', '/v1/files', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
+
+  it('外部客户端 POST /v1/complete(不带 model 的控制面调用)→ 404 unsupported_path', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      {},
+      ctx('POST', '/v1/complete', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
+
+  it('外部客户端 POST /v1/messages → 通过白名单(不是 unsupported_path)', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctx('POST', '/v1/messages', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    // 可能路由成功(headerOverride/upstreamOverride)或 400 no_provider_for_model,
+    // 但绝不是路径白名单的 404 —— 证明 /v1/messages 过闸。
+    const asErr = decision as { localHandler?: unknown };
+    if (asErr.localHandler) {
+      const { body } = await drainLocalHandler(decision);
+      expect(body?.error?.code).not.toBe('unsupported_path');
+    } else {
+      // 直接返回转发决策(headerOverride 等),显然不是 404。
+      expect(decision).not.toBeNull();
+    }
+  });
+
+  it('外部客户端 POST /v1/messages/count_tokens(子路径)→ 通过白名单', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctx('POST', '/v1/messages/count_tokens', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const asErr = decision as { localHandler?: unknown };
+    if (asErr.localHandler) {
+      const { body } = await drainLocalHandler(decision);
+      expect(body?.error?.code).not.toBe('unsupported_path');
+    } else {
+      expect(decision).not.toBeNull();
+    }
+  });
+
+  it('外部客户端 GET /v1/models → 本地吐清单(200,不受路径白名单影响)', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      {},
+      ctx('GET', '/v1/models', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status } = await drainLocalHandler(decision);
+    expect(status).toBe(200);
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -43,6 +43,19 @@ vi.mock('../claude-fast-mode-log', () => ({
   createClaudeFastModeResponseObserver: () => () => undefined,
 }));
 
+// 对外 token 鉴权:默认关闭 + 不命中(与真实 store 默认态一致,上面既有 scope-gate / Pi 用例不受影响)。
+// 有界拒绝(P1)用例按需把 externalEnabled 翻开。
+const externalAuthMock = vi.hoisted(() => ({
+  externalEnabled: false,
+  matchToken: (_token: string) => false,
+}));
+vi.mock('../local-proxy-external-auth', () => ({
+  isCindyLocalToken: (token: unknown) =>
+    typeof token === 'string' && token.startsWith('cindy-local-'),
+  isExternalAccessEnabled: () => externalAuthMock.externalEnabled,
+  matchesExternalToken: (token: string) => externalAuthMock.matchToken(token),
+}));
+
 import {
   createModelRoutingTransform,
   setClaudeProxyGatewayKeyReader,
@@ -224,5 +237,65 @@ describe('pi routingTransform — xdt session header selects the Pi provider rou
       headerDelete: ['x-cindy-pi-session-id', 'x-cindy-pi-session-token'],
     });
     expect(decision?.headerOverride).not.toHaveProperty('x-cindy-pi-session-token');
+  });
+});
+
+describe('cc routingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网关 key)', () => {
+  async function drainLocalHandler(
+    decision: unknown,
+  ): Promise<{ status: number; body: { error?: { code?: string } } | null }> {
+    const res = {
+      status: 0,
+      raw: '',
+      writeHead(status: number) { this.status = status; },
+      end(chunk: string) { this.raw = chunk; },
+    };
+    await (decision as { localHandler?: (arg: { res: unknown }) => Promise<void> })
+      .localHandler?.({ res } as never);
+    return { status: res.status, body: res.raw ? JSON.parse(res.raw) : null };
+  }
+
+  beforeEach(() => {
+    // 即使网关 key 就绪,匿名请求也必须被拒 —— 证明它不会借道 gatewayDefaultRouteDecision。
+    setClaudeProxyGatewayKeyReader(() => 'sk-gw');
+    setClaudeProxySessionIdResolver(() => null);
+  });
+
+  afterEach(() => {
+    externalAuthMock.externalEnabled = false;
+  });
+
+  it('对外开启 + 无会话 + 无 x-api-key + 无 authorization + 无会话头 → 401 external_token_required', async () => {
+    externalAuthMock.externalEnabled = true;
+    const decision = await Promise.resolve(createModelRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctxWith({}),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+  });
+
+  it('内部 oauth-spawn 子进程(带 authorization bearer + 会话头)不被有界拒绝命中', async () => {
+    externalAuthMock.externalEnabled = true;
+    // 带 x-claude-code-session-id(任何 cc 子进程都带)+ OAuth bearer,但会话解析不出(注册时序窗口)。
+    const decision = await Promise.resolve(createModelRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctxWith({ 'x-claude-code-session-id': 'sdk-unresolved', authorization: 'Bearer sk-ant-oat01' }),
+    ));
+    // 不是 401 有界拒绝:落到 ② 段默认路由,oauth-spawn 换网关 key。
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': 'sk-gw', authorization: 'Bearer sk-gw' },
+    });
+  });
+
+  it('对外关闭时不启用闸:匿名请求按内部默认路由(oauth-spawn 无 key)→ 直连订阅,字节级不变', async () => {
+    externalAuthMock.externalEnabled = false;
+    setClaudeProxyGatewayKeyReader(() => null);
+    const decision = await Promise.resolve(createModelRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctxWith({ authorization: 'Bearer sk-ant-oat01' }),
+    ));
+    expect(decision).toEqual({ upstreamOverride: 'https://api.anthropic.com' });
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -419,4 +419,36 @@ describe('cc routingTransform 外部路径白名单 (P2: 对外只服务 /v1/mes
     const { status } = await drainLocalHandler(decision);
     expect(status).toBe(200);
   });
+
+  // 路径穿越(#1666 二轮 P1):前缀白名单会放行含 /v1/messages/ 的路径,若原样转发,规范化上游会把
+  // dot-segment 解析成越权路径并带上 Cindy 注入的凭证。必须在过闸前按段拒绝 `.` / `..`。
+  it('外部客户端 POST /v1/messages/../../v1/files → 404 unsupported_path(挡路径穿越)', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctx('POST', '/v1/messages/../../v1/files', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
+
+  it('外部客户端 POST /v1/messages/%2e%2e/v1/files(百分号编码 ..)→ 404 unsupported_path', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctx('POST', '/v1/messages/%2e%2e/v1/files', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
+
+  it('外部客户端 GET /v1/models/../messages(向 models 端点做穿越)→ 404 unsupported_path', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      {},
+      ctx('GET', '/v1/models/../messages', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -451,4 +451,43 @@ describe('cc routingTransform 外部路径白名单 (P2: 对外只服务 /v1/mes
     expect(status).toBe(404);
     expect(body?.error?.code).toBe('unsupported_path');
   });
+
+  // 开头锚定(#1666 三轮 P2):白名单不锚开头时是「包含」判定,带任意前缀的路径同样命中,而无
+  // pathOverride 时转发的是原样 ctx.url → 供应商侧收到未支持路径却带着 Cindy 注入的真实凭证。
+  // 这些路径都不含 dot-segment,所以只有开头锚定能挡住(与上面的穿越用例是两条独立防线)。
+  it.each([
+    ['POST', '/anything/v1/messages'],
+    ['POST', '/v2/v1/messages'],
+    ['POST', '/proxy/deep/v1/messages/count_tokens'],
+  ])('外部客户端 %s %s(带前缀绕过白名单)→ 404 unsupported_path', async (method, url) => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctx(method, url, { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
+
+  it('外部客户端 GET /anything/v1/models(带前缀)→ 不走本地清单,落 404 unsupported_path', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      {},
+      ctx('GET', '/anything/v1/models', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
+
+  // absolute-form 请求(HTTP/1.1 允许对代理发 `POST http://host/path`):此时 req.url 不以 `/` 开头,
+  // 开头锚定顺带把它挡在外面,不会因为「含 /v1/messages」而带凭证转发到别的 origin。
+  it('外部客户端 POST http://evil.example/v1/messages(absolute-form)→ 404 unsupported_path', async () => {
+    const decision = await Promise.resolve(createExternalRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctx('POST', 'http://evil.example/v1/messages', { 'x-api-key': GOOD_TOKEN }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(404);
+    expect(body?.error?.code).toBe('unsupported_path');
+  });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeProxyScopeGate.test.ts
@@ -276,6 +276,20 @@ describe('cc routingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网�
     expect(body?.error?.code).toBe('external_token_required');
   });
 
+  it('伪造 authorization bearer + 无 x-api-key + 无会话头 → 仍 401(假 bearer 不得绕过 #1666)', async () => {
+    externalAuthMock.externalEnabled = true;
+    // 本机进程随手编一个 Bearer:既没有可用 x-api-key,也没有 x-claude-code-session-id 会话头。
+    // 修复前「带 authorization 即豁免」会放它落到 gatewayDefaultRouteDecision 白嫖网关 key;
+    // 修复后 authorization 不再作豁免,仍按匿名客户端拒绝。
+    const decision = await Promise.resolve(createModelRoutingTransform()(
+      { model: 'claude-opus-4-8' },
+      ctxWith({ authorization: 'Bearer anything' }),
+    ));
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+  });
+
   it('内部 oauth-spawn 子进程(带 authorization bearer + 会话头)不被有界拒绝命中', async () => {
     externalAuthMock.externalEnabled = true;
     // 带 x-claude-code-session-id(任何 cc 子进程都带)+ OAuth bearer,但会话解析不出(注册时序窗口)。

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -4201,6 +4201,38 @@ describe('createModelRoutingTransform 有界拒绝 (P1: 匿名客户端不得白
     expect(body?.error?.code).toBe('external_token_required');
   });
 
+  it('对外开启 + provider-oauth + GET /models + 伪造 Bearer(无 model/无 thread-id)→ 401,不注入 Cindy 供应商 OAuth token(#1666 二轮 Finding H)', async () => {
+    const host = await freshCodexProxyHost();
+    const { setProviderOAuthTokenReader } = await import('../provider-route.js');
+    externalAuthMock.codexEnabled = true;
+    // provider-oauth 控制面桶③ 会经 resolveProviderOAuthControlRouteDecision 注入真实供应商 OAuth token。
+    // 若放行伪造 Bearer 的匿名 GET /models,未鉴权者就借 Cindy 的 xAI 凭证打 /models,对外 token 形同虚设。
+    setProviderOAuthTokenReader((providerId, agent) =>
+      providerId === 'xai' && agent === 'codex' ? 'xai-live-token-must-not-leak' : null,
+    );
+    host.setCodexProxyAuthInjection('provider-oauth');
+
+    const decision = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        undefined,
+        {
+          reqId: 1,
+          method: 'GET',
+          url: '/models',
+          headers: { authorization: 'Bearer anything-forged' },
+        } as never,
+      ),
+    );
+
+    // 绝不返回注入 xai token 的 headerOverride 决策;必须是 401 有界拒绝的 localHandler。
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+    expect(JSON.stringify(decision)).not.toContain('xai-live-token-must-not-leak');
+
+    setProviderOAuthTokenReader(() => null);
+  });
+
   it('对外关闭时不启用闸:匿名无会话请求按内部默认路由,字节级不变', async () => {
     const host = await freshCodexProxyHost();
     externalAuthMock.codexEnabled = false;

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1878,6 +1878,35 @@ describe('codex proxy host', () => {
     );
   });
 
+  it('对外端口绝不解析 WS 上游:内部 spawn 处于 oauth-bearer 态也返回 null(#1666 review 禁 WS 兜底)', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy.mockResolvedValueOnce({
+      url: 'http://127.0.0.1:51999',
+      dispose: vi.fn(async () => undefined),
+    });
+    // 内部 spawn 处于 oauth-bearer:对**内部**端口这会解析出 ChatGPT 上游(见上一用例);对外端口
+    // 必须仍然拒绝 —— 否则手工客户端 / 陈旧配置向公开端口发 Upgrade 就会把 cindy-local- token 透传上游。
+    host.setCodexProxyAuthInjection('oauth-bearer');
+    await host.ensureCodexExternalProxyReady();
+
+    const externalOpts = mockState.createAnthropicCompatProxy.mock.calls.at(-1)![0] as {
+      resolveWebSocketUpstream: (ctx: {
+        url: string;
+        headers: Readonly<Record<string, string>>;
+      }) => string | null;
+    };
+    // 无 thread-id、带 thread-id 都必须为 null(对外端口结构性禁 WS,不看身份 / recovery 状态)。
+    expect(
+      externalOpts.resolveWebSocketUpstream({ url: '/v1/responses', headers: {} }),
+    ).toBeNull();
+    expect(
+      externalOpts.resolveWebSocketUpstream({
+        url: '/v1/responses',
+        headers: { 'thread-id': 'thread-x' },
+      }),
+    ).toBeNull();
+  });
+
   it('declines the next websocket upgrade after a body recovery error is armed', async () => {
     const host = await freshCodexProxyHost();
     const disconnectWebSocketsForThread = vi.fn(() => 2);

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -1907,6 +1907,75 @@ describe('codex proxy host', () => {
     ).toBeNull();
   });
 
+  it('对外 transformRequest 链不含 instructions 注入 / Guardian / gateway web_search(#1666 review external-safe chain)', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy
+      .mockResolvedValueOnce({ url: 'http://127.0.0.1:43210', dispose: vi.fn(async () => undefined) })
+      .mockResolvedValueOnce({ url: 'http://127.0.0.1:51999', dispose: vi.fn(async () => undefined) });
+
+    await host.ensureCodexProxyReady();
+    const internalInjectionTransformCalls = mockState.createInstructionsInjectionTransform.mock.calls.length;
+    await host.ensureCodexExternalProxyReady();
+
+    const internalOpts = mockState.createAnthropicCompatProxy.mock.calls[0]![0] as {
+      transformRequest: unknown[];
+    };
+    const externalOpts = mockState.createAnthropicCompatProxy.mock.calls.at(-1)![0] as {
+      transformRequest: unknown[];
+    };
+
+    // 内部链保持原样(instructions 注入 + Guardian + gateway web_search 三条内部态耦合 transform
+    // 在内);对外链去掉这三条,长度恰好少 3,且末尾仍是纯 body 归一化的 stripNonAnthropicFields。
+    expect(externalOpts.transformRequest.length).toBe(internalOpts.transformRequest.length - 3);
+    expect(externalOpts.transformRequest.at(-1)).toBe(mockState.stripNonAnthropicFields);
+    // 对外 handle 根本没构造 instructions 注入 transform —— 内部 thread registry 不出现在对外链里,
+    // 伪造 thread-id 也拼不到 Cindy 的内部产品提示词。
+    expect(mockState.createInstructionsInjectionTransform.mock.calls.length).toBe(
+      internalInjectionTransformCalls,
+    );
+  });
+
+  it('对外链在内部 env-key 态下也绝不给 gpt-5.6 注入 gateway web_search(#1666 review)', async () => {
+    const host = await freshCodexProxyHost();
+    mockState.createAnthropicCompatProxy
+      .mockResolvedValueOnce({ url: 'http://127.0.0.1:43210', dispose: vi.fn(async () => undefined) })
+      .mockResolvedValueOnce({ url: 'http://127.0.0.1:51999', dispose: vi.fn(async () => undefined) });
+
+    await host.ensureCodexProxyReady();
+    await host.ensureCodexExternalProxyReady();
+
+    // 内部 spawn 处于 env-key:对内部链这会给 gpt-5.6 的 /responses 补 web_search 工具(gateway 原生
+    // 搜索能力);对外链必须不受该内部态影响——外部路由可能选不支持它的自定义供应商 → 不支持工具报错。
+    host.setCodexProxyAuthInjection('env-key');
+
+    const internalChain = (mockState.createAnthropicCompatProxy.mock.calls[0]![0] as {
+      transformRequest: Array<(body: unknown, ctx: unknown) => unknown>;
+    }).transformRequest;
+    const externalChain = (mockState.createAnthropicCompatProxy.mock.calls.at(-1)![0] as {
+      transformRequest: Array<(body: unknown, ctx: unknown) => unknown>;
+    }).transformRequest;
+
+    const ctx = { reqId: 1, method: 'POST', url: '/v1/responses', headers: {} };
+    const runChain = async (
+      chain: Array<(body: unknown, ctx: unknown) => unknown>,
+    ): Promise<Record<string, unknown>> => {
+      let current: Record<string, unknown> = { model: 'gpt-5.6', input: [], tools: [] };
+      for (const transform of chain) {
+        const next = await Promise.resolve(transform(current, ctx));
+        if (next != null) current = next as Record<string, unknown>;
+      }
+      return current;
+    };
+    const hasWebSearch = (body: Record<string, unknown>) =>
+      Array.isArray(body.tools) &&
+      body.tools.some((tool) => tool && typeof tool === 'object' && (tool as { type?: unknown }).type === 'web_search');
+
+    // 对照:内部链确实注入了 web_search(证明该 transform 生效、对外剔除是有意义的)。
+    expect(hasWebSearch(await runChain(internalChain))).toBe(true);
+    // 对外链绝不注入。
+    expect(hasWebSearch(await runChain(externalChain))).toBe(false);
+  });
+
   it('declines the next websocket upgrade after a body recovery error is armed', async () => {
     const host = await freshCodexProxyHost();
     const disconnectWebSocketsForThread = vi.fn(() => 2);

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -4349,6 +4349,114 @@ describe('createExternalCodexRoutingTransform 对外端口有界拒绝 (P1: 只�
     const { status } = await drainCodexLocalHandler(decision);
     expect(status).toBe(200);
   });
+
+  // 端点正则开头锚定(#1666 三轮 P2):只锚尾部时是「后缀」判定,`/foo/responses` 之类带前缀的路径
+  // 也能进外部路由分支;responses 是透明转发(无 pathOverride → 原样转发 ctx.url),供应商侧就会
+  // 收到这个未支持路径却带着 buildRouteDecision 注入的真实凭证。必须落 400 unsupported_request。
+  it.each([
+    ['POST', '/foo/responses'],
+    ['POST', '/v2/v1/responses'],
+    ['POST', '/foo/v1/chat/completions'],
+    ['POST', '/anything/chat/completions'],
+  ])('命中本族 token 但路径带前缀(%s %s)→ 400 unsupported_request,不进转发分支', async (method, url) => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    externalAuthMock.matchToken = (t) => t === 'cindy-local-valid';
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method,
+          url,
+          headers: { authorization: 'Bearer cindy-local-valid' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(400);
+    expect(body?.error?.code).toBe('unsupported_request');
+  });
+
+  it('命中本族 token 但 GET /foo/models(带前缀)→ 不吐清单,落 400 unsupported_request', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    externalAuthMock.matchToken = (t) => t === 'cindy-local-valid';
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        undefined,
+        {
+          reqId: 1,
+          method: 'GET',
+          url: '/foo/models',
+          headers: { authorization: 'Bearer cindy-local-valid' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(400);
+    expect(body?.error?.code).toBe('unsupported_request');
+  });
+
+  // absolute-form 请求(HTTP/1.1 允许对代理发 `POST http://host/path`):req.url 不以 `/` 开头,
+  // 开头锚定顺带挡住,不会因为「以 /responses 结尾」而带凭证转发到别的 origin。
+  it('命中本族 token 但 absolute-form(http://evil.example/responses)→ 400 unsupported_request', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    externalAuthMock.matchToken = (t) => t === 'cindy-local-valid';
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: 'http://evil.example/responses',
+          headers: { authorization: 'Bearer cindy-local-valid' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(400);
+    expect(body?.error?.code).toBe('unsupported_request');
+  });
+
+  // 对照:公布的三个端点(及 /models 发现)必须照旧放行 —— 锚定只砍前缀绕过,不改正常用法。
+  // 自环 chat 端点打的就是对外端口自己的 `/responses`(见 externalChatCompletionsDecision)。
+  it.each([
+    ['POST', '/responses'],
+    ['POST', '/v1/responses'],
+    ['POST', '/v1/responses/'],
+  ])('公布端点 %s %s 照旧放行(不是 unsupported_request)', async (method, url) => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    externalAuthMock.matchToken = (t) => t === 'cindy-local-valid';
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method,
+          url,
+          headers: { authorization: 'Bearer cindy-local-valid' },
+        } as never,
+      ),
+    );
+
+    // 可能是转发决策,也可能是 400 no_provider_for_model 之类;但绝不是路径闸的 unsupported_request。
+    if ((decision as { localHandler?: unknown } | null)?.localHandler) {
+      const { body } = await drainCodexLocalHandler(decision);
+      expect(body?.error?.code).not.toBe('unsupported_request');
+    } else {
+      expect(decision).not.toBeNull();
+    }
+  });
 });
 
 describe('createModelRoutingTransform 内部端口(端口拆分后内部路由不再承担对外判定 #1666 Finding 2)', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -4133,10 +4133,11 @@ describe('createModelRoutingTransform 有界拒绝 (P1: 匿名客户端不得白
     expect(body?.error?.code).toBe('external_token_required');
   });
 
-  it('内部 codex 子进程(带 Authorization bearer)即使无会话也不被有界拒绝命中', async () => {
+  it('内部 codex 子进程(带 thread-id 身份头)即使会话未解析也不被有界拒绝命中', async () => {
     const host = await freshCodexProxyHost();
     externalAuthMock.codexEnabled = true;
-    // 非 cindy-local、不命中本族 token 的 bearer —— 模拟内部子进程 spawn 凭证。
+    // 内部子进程的真凭 = 带 spawn bearer + thread-id 身份头(注册时序窗口内 session 尚未绑上)。
+    // 关键:内部身份靠 thread-id 头证明,而非「带了个 bearer」。
     host.setCodexProxyAuthInjection('env-key');
 
     const decision = await Promise.resolve(
@@ -4146,13 +4147,58 @@ describe('createModelRoutingTransform 有界拒绝 (P1: 匿名客户端不得白
           reqId: 1,
           method: 'POST',
           url: '/responses',
-          headers: { authorization: 'Bearer sk-internal-spawn' },
+          headers: { authorization: 'Bearer sk-internal-spawn', 'thread-id': 'thread-internal' },
         } as never,
       ),
     );
 
     // 未落到 401 有界拒绝:env-key + 非 codex/ 模型 → decideCodexRoute 返回 null(默认上游 passthrough)。
     expect(decision).toBeNull();
+  });
+
+  it('伪造 Bearer + codex/* 模型 + oauth-bearer + 无会话 + 无 thread-id → 401(假 bearer 不得白嫖网关 key #1666)', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    // oauth-bearer 态 + codex/* 模型 = 会经 decideCodexRoute 注入 Cindy 网关 key 的泄漏路径。
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    const decision = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { authorization: 'Bearer anything-forged' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+  });
+
+  it('伪造非 Bearer 方案(Basic xxx)+ 无会话 → 仍 401(bearerToken 不回落原值 #1666)', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    const decision = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { authorization: 'Basic dXNlcjpwYXNz' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
   });
 
   it('对外关闭时不启用闸:匿名无会话请求按内部默认路由,字节级不变', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -125,7 +125,7 @@ vi.mock('@cindy/responses-anthropic-bridge', () => ({
 // 单测按需翻开 codexEnabled / matchToken 覆盖有界拒绝(P1)分支。
 const externalAuthMock = vi.hoisted(() => ({
   codexEnabled: false,
-  matchToken: (_token: string) => false,
+  matchToken: (_token: string): boolean => false,
 }));
 
 vi.mock('../local-proxy-external-auth.js', () => ({
@@ -4093,51 +4093,171 @@ describe('codex proxy host', () => {
   });
 });
 
-describe('createModelRoutingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网关 key)', () => {
-  // 调用 externalOpenAIError 决策的 localHandler,抓取写出的状态码与错误信封。
-  async function drainLocalHandler(
-    decision: unknown,
-  ): Promise<{ status: number; body: { error?: { code?: string } } | null }> {
-    let status = 0;
-    let raw = '';
-    const res = {
-      writeHead: (s: number) => {
-        status = s;
-        return res;
-      },
-      end: (chunk?: string) => {
-        if (chunk) raw = chunk;
-      },
-    };
-    const handler = (decision as { localHandler?: (arg: { res: unknown }) => Promise<void> })
-      .localHandler;
-    if (!handler) throw new Error('decision 不含 localHandler');
-    await handler({ res });
-    return { status, body: raw ? JSON.parse(raw) : null };
-  }
+// 调用 externalOpenAIError 决策的 localHandler,抓取写出的状态码与错误信封。
+async function drainCodexLocalHandler(
+  decision: unknown,
+): Promise<{ status: number; body: { error?: { code?: string } } | null }> {
+  let status = 0;
+  let raw = '';
+  const res = {
+    writeHead: (s: number) => {
+      status = s;
+      return res;
+    },
+    end: (chunk?: string) => {
+      if (chunk) raw = chunk;
+    },
+  };
+  const handler = (decision as { localHandler?: (arg: { res: unknown }) => Promise<void> })
+    .localHandler;
+  if (!handler) throw new Error('decision 不含 localHandler');
+  await handler({ res });
+  return { status, body: raw ? JSON.parse(raw) : null };
+}
 
-  it('对外开启 + 无会话 + 无 Authorization → 401 external_token_required', async () => {
+describe('createExternalCodexRoutingTransform 对外端口有界拒绝 (P1: 只认不可伪造的 B 族 token #1666 Finding 2)', () => {
+  // 端口拆分后对外判定全落在这个**独立对外端口**的 transform 上:放行的唯一条件是 Bearer 命中 B 族
+  // 对外 token,伪造任何 header(session / thread-id / 非本族 bearer)都拦。内部端口不再承担对外判定。
+  it('无 Authorization → 401 external_token_required', async () => {
     const host = await freshCodexProxyHost();
     externalAuthMock.codexEnabled = true;
-    host.setCodexProxyAuthInjection('env-key');
 
     const decision = await Promise.resolve(
-      host.createModelRoutingTransform()(
+      host.createExternalCodexRoutingTransform()(
         { model: 'codex/gpt-5' },
         { reqId: 1, method: 'POST', url: '/responses', headers: {} } as never,
       ),
     );
 
-    const { status, body } = await drainLocalHandler(decision);
+    const { status, body } = await drainCodexLocalHandler(decision);
     expect(status).toBe(401);
     expect(body?.error?.code).toBe('external_token_required');
   });
 
-  it('内部 codex 子进程(带 thread-id 身份头)即使会话未解析也不被有界拒绝命中', async () => {
+  it('伪造 Bearer + codex/* 模型 + oauth-bearer → 401(假 bearer 不得白嫖网关 key)', async () => {
     const host = await freshCodexProxyHost();
     externalAuthMock.codexEnabled = true;
-    // 内部子进程的真凭 = 带 spawn bearer + thread-id 身份头(注册时序窗口内 session 尚未绑上)。
-    // 关键:内部身份靠 thread-id 头证明,而非「带了个 bearer」。
+    // 对外端口的 transform 不看 injection 形态;哪怕内部是 oauth-bearer,伪造 bearer 也只得到 401。
+    host.setCodexProxyAuthInjection('oauth-bearer');
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { authorization: 'Bearer anything-forged' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+  });
+
+  it('伪造非 Bearer 方案(Basic xxx)→ 仍 401(bearerToken 不回落原值)', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { authorization: 'Basic dXNlcjpwYXNz' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+  });
+
+  it('带 cindy-local- 前缀但不命中本族 token → 401 invalid_external_token(跨族 / 已失效)', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    // matchToken 仍返回 false(非本族);但前缀判别器认得它是 Cindy 本地 token → 明确 401,不透传上游。
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { authorization: 'Bearer cindy-local-stale-or-crossfamily' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('invalid_external_token');
+  });
+
+  it('provider-oauth + GET /models + 伪造 Bearer → 401,绝不注入 Cindy 供应商 OAuth token', async () => {
+    const host = await freshCodexProxyHost();
+    const { setProviderOAuthTokenReader } = await import('../provider-route.js');
+    externalAuthMock.codexEnabled = true;
+    // 即使配了真 xAI OAuth token,对外端口的 transform 也在命中 token 前就 401,永不触及 provider-oauth
+    // 控制面路由 → 该 token 无从泄漏。
+    setProviderOAuthTokenReader((providerId, agent) =>
+      providerId === 'xai' && agent === 'codex' ? 'xai-live-token-must-not-leak' : null,
+    );
+    host.setCodexProxyAuthInjection('provider-oauth');
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        undefined,
+        {
+          reqId: 1,
+          method: 'GET',
+          url: '/models',
+          headers: { authorization: 'Bearer anything-forged' },
+        } as never,
+      ),
+    );
+
+    const { status, body } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+    expect(JSON.stringify(decision)).not.toContain('xai-live-token-must-not-leak');
+
+    setProviderOAuthTokenReader(() => null);
+  });
+
+  it('命中本族 token + GET /models → 放行到 routeExternalCodexClient(200,非 401)', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    externalAuthMock.matchToken = (t) => t === 'cindy-local-valid';
+
+    const decision = await Promise.resolve(
+      host.createExternalCodexRoutingTransform()(
+        undefined,
+        {
+          reqId: 1,
+          method: 'GET',
+          url: '/models',
+          headers: { authorization: 'Bearer cindy-local-valid' },
+        } as never,
+      ),
+    );
+
+    // 命中 token → routeExternalCodexClient 的 GET /models 分支从 Cindy catalog 吐 OpenAI 形状清单。
+    const { status } = await drainCodexLocalHandler(decision);
+    expect(status).toBe(200);
+  });
+});
+
+describe('createModelRoutingTransform 内部端口(端口拆分后内部路由不再承担对外判定 #1666 Finding 2)', () => {
+  it('内部 codex 子进程(带 thread-id 身份头)按内部默认路由,不被对外判定干扰', async () => {
+    const host = await freshCodexProxyHost();
+    // 内部端口绑随机口、不公布;codexEnabled 与它无关。env-key + 非 codex/ 模型 → decideCodexRoute null。
+    externalAuthMock.codexEnabled = true;
     host.setCodexProxyAuthInjection('env-key');
 
     const decision = await Promise.resolve(
@@ -4152,88 +4272,10 @@ describe('createModelRoutingTransform 有界拒绝 (P1: 匿名客户端不得白
       ),
     );
 
-    // 未落到 401 有界拒绝:env-key + 非 codex/ 模型 → decideCodexRoute 返回 null(默认上游 passthrough)。
     expect(decision).toBeNull();
   });
 
-  it('伪造 Bearer + codex/* 模型 + oauth-bearer + 无会话 + 无 thread-id → 401(假 bearer 不得白嫖网关 key #1666)', async () => {
-    const host = await freshCodexProxyHost();
-    externalAuthMock.codexEnabled = true;
-    // oauth-bearer 态 + codex/* 模型 = 会经 decideCodexRoute 注入 Cindy 网关 key 的泄漏路径。
-    host.setCodexProxyAuthInjection('oauth-bearer');
-
-    const decision = await Promise.resolve(
-      host.createModelRoutingTransform()(
-        { model: 'codex/gpt-5' },
-        {
-          reqId: 1,
-          method: 'POST',
-          url: '/responses',
-          headers: { authorization: 'Bearer anything-forged' },
-        } as never,
-      ),
-    );
-
-    const { status, body } = await drainLocalHandler(decision);
-    expect(status).toBe(401);
-    expect(body?.error?.code).toBe('external_token_required');
-  });
-
-  it('伪造非 Bearer 方案(Basic xxx)+ 无会话 → 仍 401(bearerToken 不回落原值 #1666)', async () => {
-    const host = await freshCodexProxyHost();
-    externalAuthMock.codexEnabled = true;
-    host.setCodexProxyAuthInjection('oauth-bearer');
-
-    const decision = await Promise.resolve(
-      host.createModelRoutingTransform()(
-        { model: 'codex/gpt-5' },
-        {
-          reqId: 1,
-          method: 'POST',
-          url: '/responses',
-          headers: { authorization: 'Basic dXNlcjpwYXNz' },
-        } as never,
-      ),
-    );
-
-    const { status, body } = await drainLocalHandler(decision);
-    expect(status).toBe(401);
-    expect(body?.error?.code).toBe('external_token_required');
-  });
-
-  it('对外开启 + provider-oauth + GET /models + 伪造 Bearer(无 model/无 thread-id)→ 401,不注入 Cindy 供应商 OAuth token(#1666 二轮 Finding H)', async () => {
-    const host = await freshCodexProxyHost();
-    const { setProviderOAuthTokenReader } = await import('../provider-route.js');
-    externalAuthMock.codexEnabled = true;
-    // provider-oauth 控制面桶③ 会经 resolveProviderOAuthControlRouteDecision 注入真实供应商 OAuth token。
-    // 若放行伪造 Bearer 的匿名 GET /models,未鉴权者就借 Cindy 的 xAI 凭证打 /models,对外 token 形同虚设。
-    setProviderOAuthTokenReader((providerId, agent) =>
-      providerId === 'xai' && agent === 'codex' ? 'xai-live-token-must-not-leak' : null,
-    );
-    host.setCodexProxyAuthInjection('provider-oauth');
-
-    const decision = await Promise.resolve(
-      host.createModelRoutingTransform()(
-        undefined,
-        {
-          reqId: 1,
-          method: 'GET',
-          url: '/models',
-          headers: { authorization: 'Bearer anything-forged' },
-        } as never,
-      ),
-    );
-
-    // 绝不返回注入 xai token 的 headerOverride 决策;必须是 401 有界拒绝的 localHandler。
-    const { status, body } = await drainLocalHandler(decision);
-    expect(status).toBe(401);
-    expect(body?.error?.code).toBe('external_token_required');
-    expect(JSON.stringify(decision)).not.toContain('xai-live-token-must-not-leak');
-
-    setProviderOAuthTokenReader(() => null);
-  });
-
-  it('对外关闭时不启用闸:匿名无会话请求按内部默认路由,字节级不变', async () => {
+  it('匿名无会话请求按内部默认路由,字节级不变(内部端口无对外闸)', async () => {
     const host = await freshCodexProxyHost();
     externalAuthMock.codexEnabled = false;
     host.setCodexProxyAuthInjection('env-key');

--- a/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexProxyHost.test.ts
@@ -121,6 +121,20 @@ vi.mock('@cindy/responses-anthropic-bridge', () => ({
   createResponsesAnthropicHandler: mockState.createResponsesAnthropicHandler,
 }));
 
+// 对外 token 鉴权:默认关闭 + 不命中(与真实 store 的默认态一致,现有内部路由用例不受影响)。
+// 单测按需翻开 codexEnabled / matchToken 覆盖有界拒绝(P1)分支。
+const externalAuthMock = vi.hoisted(() => ({
+  codexEnabled: false,
+  matchToken: (_token: string) => false,
+}));
+
+vi.mock('../local-proxy-external-auth.js', () => ({
+  isCindyLocalToken: (token: unknown) =>
+    typeof token === 'string' && token.startsWith('cindy-local-'),
+  isCodexExternalAccessEnabled: () => externalAuthMock.codexEnabled,
+  matchesCodexExternalToken: (token: string) => externalAuthMock.matchToken(token),
+}));
+
 async function freshCodexProxyHost() {
   vi.resetModules();
   mockState.createAnthropicCompatProxy.mockReset();
@@ -132,6 +146,8 @@ async function freshCodexProxyHost() {
   mockState.stripNonAnthropicFields.mockReset();
   mockState.stripNonAnthropicFields.mockReturnValue(null);
   mockState.resetCapturedRegistry();
+  externalAuthMock.codexEnabled = false;
+  externalAuthMock.matchToken = () => false;
   return import('../codex-proxy-host.js');
 }
 
@@ -4074,5 +4090,83 @@ describe('codex proxy host', () => {
     await Promise.all([first, second]);
 
     expect(host.getCodexProxyEndpoint()).toBe('http://127.0.0.1:43210');
+  });
+});
+
+describe('createModelRoutingTransform 有界拒绝 (P1: 匿名客户端不得白嫖网关 key)', () => {
+  // 调用 externalOpenAIError 决策的 localHandler,抓取写出的状态码与错误信封。
+  async function drainLocalHandler(
+    decision: unknown,
+  ): Promise<{ status: number; body: { error?: { code?: string } } | null }> {
+    let status = 0;
+    let raw = '';
+    const res = {
+      writeHead: (s: number) => {
+        status = s;
+        return res;
+      },
+      end: (chunk?: string) => {
+        if (chunk) raw = chunk;
+      },
+    };
+    const handler = (decision as { localHandler?: (arg: { res: unknown }) => Promise<void> })
+      .localHandler;
+    if (!handler) throw new Error('decision 不含 localHandler');
+    await handler({ res });
+    return { status, body: raw ? JSON.parse(raw) : null };
+  }
+
+  it('对外开启 + 无会话 + 无 Authorization → 401 external_token_required', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    host.setCodexProxyAuthInjection('env-key');
+
+    const decision = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        { model: 'codex/gpt-5' },
+        { reqId: 1, method: 'POST', url: '/responses', headers: {} } as never,
+      ),
+    );
+
+    const { status, body } = await drainLocalHandler(decision);
+    expect(status).toBe(401);
+    expect(body?.error?.code).toBe('external_token_required');
+  });
+
+  it('内部 codex 子进程(带 Authorization bearer)即使无会话也不被有界拒绝命中', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = true;
+    // 非 cindy-local、不命中本族 token 的 bearer —— 模拟内部子进程 spawn 凭证。
+    host.setCodexProxyAuthInjection('env-key');
+
+    const decision = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        { model: 'gpt-5' },
+        {
+          reqId: 1,
+          method: 'POST',
+          url: '/responses',
+          headers: { authorization: 'Bearer sk-internal-spawn' },
+        } as never,
+      ),
+    );
+
+    // 未落到 401 有界拒绝:env-key + 非 codex/ 模型 → decideCodexRoute 返回 null(默认上游 passthrough)。
+    expect(decision).toBeNull();
+  });
+
+  it('对外关闭时不启用闸:匿名无会话请求按内部默认路由,字节级不变', async () => {
+    const host = await freshCodexProxyHost();
+    externalAuthMock.codexEnabled = false;
+    host.setCodexProxyAuthInjection('env-key');
+
+    const decision = await Promise.resolve(
+      host.createModelRoutingTransform()(
+        { model: 'gpt-5' },
+        { reqId: 1, method: 'POST', url: '/responses', headers: {} } as never,
+      ),
+    );
+
+    expect(decision).toBeNull();
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
@@ -9,6 +9,8 @@ const codexEnabledBox = vi.hoisted(() => ({ value: false }));
 // safeStorage 是否可落盘;置 false 模拟 safeStorage 不可用(write 返回 false),
 // 用来验证进程内兜底缓存路径。
 const writableBox = vi.hoisted(() => ({ value: true }));
+// remove 是否生效;置 false 模拟 safeStorage 不可用时旧物理值删不掉(轮换失败路径)。
+const removableBox = vi.hoisted(() => ({ value: true }));
 
 vi.mock('../../secrets/providerSecretStore', () => ({
   readLocalProxyExternalToken: () => tokenBox.value,
@@ -17,11 +19,21 @@ vi.mock('../../secrets/providerSecretStore', () => ({
     tokenBox.value = v;
     return true;
   },
+  removeLocalProxyExternalToken: () => {
+    if (!removableBox.value) return { success: false, error: 'unavailable' };
+    tokenBox.value = null;
+    return { success: true };
+  },
   readLocalProxyCodexExternalToken: () => codexTokenBox.value,
   writeLocalProxyCodexExternalToken: (v: string) => {
     if (!writableBox.value) return false;
     codexTokenBox.value = v;
     return true;
+  },
+  removeLocalProxyCodexExternalToken: () => {
+    if (!removableBox.value) return { success: false, error: 'unavailable' };
+    codexTokenBox.value = null;
+    return { success: true };
   },
 }));
 
@@ -53,6 +65,8 @@ beforeEach(() => {
   codexTokenBox.value = null;
   codexEnabledBox.value = false;
   writableBox.value = true;
+  removableBox.value = true;
+  clearExternalTokenMemoryFallback();
 });
 
 describe('local proxy external token auth (A 族 = Anthropic)', () => {
@@ -293,5 +307,41 @@ describe('in-process fallback when safeStorage write fails', () => {
     expect(matchesCodexExternalToken(b)).toBe(true);
     expect(matchesCodexExternalToken(a)).toBe(false);
     expect(matchesExternalToken(b)).toBe(false);
+  });
+});
+
+describe('regenerate rotation integrity (旧物理 token 删不掉时必须报失败,不谎报成功)', () => {
+  it('throws when the previous physical token can neither be removed nor overwritten', () => {
+    // 先在可落盘时存一个旧物理 token。
+    const stale = getOrCreateExternalToken();
+    expect(tokenBox.value).toBe(stale);
+    // 模拟 safeStorage 变得不可用:remove 删不掉旧值、write 也写不进新值。
+    removableBox.value = false;
+    writableBox.value = false;
+    // 轮换无法让新值生效(effectiveRead 仍读到旧物理值)→ 抛错,绝不谎报成功。
+    expect(() => regenerateExternalToken()).toThrow(/rotation failed/i);
+    // 旧物理 token 仍在,但轮换抛错让 IPC 层如实回失败(旧 token 仍有效必须让调用方知道)。
+    expect(tokenBox.value).toBe(stale);
+    // 内存兜底已回滚,不残留一个既写不进物理、又被旧物理值遮挡的新值。
+    expect(matchesExternalToken(stale)).toBe(true);
+  });
+
+  it('codex family throws on the same rotation failure independently', () => {
+    const stale = getOrCreateCodexExternalToken();
+    removableBox.value = false;
+    writableBox.value = false;
+    expect(() => regenerateCodexExternalToken()).toThrow(/rotation failed/i);
+    expect(codexTokenBox.value).toBe(stale);
+  });
+
+  it('rotation succeeds via remove even when write fails (safeStorage clears but cannot persist)', () => {
+    const stale = getOrCreateExternalToken();
+    // remove 能删掉旧物理值,但 write 写不进 —— effectiveRead 落到内存新值,旧值已失效。
+    writableBox.value = false;
+    const next = regenerateExternalToken();
+    expect(next).not.toBe(stale);
+    expect(tokenBox.value).toBeNull(); // 旧物理值被 remove 清掉
+    expect(matchesExternalToken(stale)).toBe(false); // 旧 token 失效
+    expect(matchesExternalToken(next)).toBe(true); // 新 token 经内存兜底命中
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
@@ -31,12 +31,14 @@ vi.mock('../local-proxy-settings-store', () => ({
 }));
 
 import {
+  clearExternalTokenMemoryFallback,
   getCodexExternalTokenMasked,
   getExternalTokenMasked,
   getOrCreateCodexExternalToken,
   getOrCreateExternalToken,
   hasCodexExternalToken,
   hasExternalToken,
+  isCindyLocalToken,
   isCodexExternalAccessEnabled,
   isExternalAccessEnabled,
   matchesCodexExternalToken,
@@ -206,6 +208,52 @@ describe('cross-family isolation (跨族 token 不互通)', () => {
     codexEnabledBox.value = true;
     expect(isExternalAccessEnabled()).toBe(false);
     expect(isCodexExternalAccessEnabled()).toBe(true);
+  });
+});
+
+describe('isCindyLocalToken(前缀判别器,用于拒绝陈旧/跨族 token)', () => {
+  it('只按前缀判定,不比对具体值', () => {
+    expect(isCindyLocalToken('cindy-local-anything')).toBe(true);
+    // 生成的真 token 也带前缀。
+    expect(isCindyLocalToken(getOrCreateExternalToken())).toBe(true);
+  });
+
+  it('非前缀值(真凭证 / 网关 key / 占位 key / 空)一律否', () => {
+    expect(isCindyLocalToken('sk-ant-realkey')).toBe(false);
+    expect(isCindyLocalToken('xdt-provider-auth-placeholder-key')).toBe(false);
+    expect(isCindyLocalToken('')).toBe(false);
+    expect(isCindyLocalToken(null)).toBe(false);
+    expect(isCindyLocalToken(undefined)).toBe(false);
+  });
+
+  it('陈旧/跨族的 cindy-local- token 命不中但仍被识别为本地代理 token', () => {
+    const a = getOrCreateExternalToken();
+    const b = getOrCreateCodexExternalToken();
+    // 跨族:A 族 token 打 B 族命不中,但前缀判别器认得它是 Cindy 本地 token(host 据此 401,不透传)。
+    expect(matchesCodexExternalToken(a)).toBe(false);
+    expect(isCindyLocalToken(a)).toBe(true);
+    // 重置后旧值命不中,但仍带前缀。
+    regenerateExternalToken();
+    expect(matchesExternalToken(a)).toBe(false);
+    expect(isCindyLocalToken(a)).toBe(true);
+    expect(isCindyLocalToken(b)).toBe(true);
+  });
+});
+
+describe('clearExternalTokenMemoryFallback(账号切换清理)', () => {
+  it('清掉进程内兜底 token,清理后旧 token 不再命中', () => {
+    writableBox.value = false;
+    const a = regenerateExternalToken();
+    const b = regenerateCodexExternalToken();
+    // 落盘失败,兜底缓存让两族 token 本次运行仍命中。
+    expect(matchesExternalToken(a)).toBe(true);
+    expect(matchesCodexExternalToken(b)).toBe(true);
+    // 切换账号:物理 token 由 providerSecretStore 清除(此处物理本就为空),兜底须一并清。
+    clearExternalTokenMemoryFallback();
+    expect(hasExternalToken()).toBe(false);
+    expect(hasCodexExternalToken()).toBe(false);
+    expect(matchesExternalToken(a)).toBe(false);
+    expect(matchesCodexExternalToken(b)).toBe(false);
   });
 });
 

--- a/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
@@ -6,15 +6,20 @@ const tokenBox = vi.hoisted(() => ({ value: null as string | null }));
 const enabledBox = vi.hoisted(() => ({ value: false }));
 const codexTokenBox = vi.hoisted(() => ({ value: null as string | null }));
 const codexEnabledBox = vi.hoisted(() => ({ value: false }));
+// safeStorage 是否可落盘;置 false 模拟 safeStorage 不可用(write 返回 false),
+// 用来验证进程内兜底缓存路径。
+const writableBox = vi.hoisted(() => ({ value: true }));
 
 vi.mock('../../secrets/providerSecretStore', () => ({
   readLocalProxyExternalToken: () => tokenBox.value,
   writeLocalProxyExternalToken: (v: string) => {
+    if (!writableBox.value) return false;
     tokenBox.value = v;
     return true;
   },
   readLocalProxyCodexExternalToken: () => codexTokenBox.value,
   writeLocalProxyCodexExternalToken: (v: string) => {
+    if (!writableBox.value) return false;
     codexTokenBox.value = v;
     return true;
   },
@@ -45,6 +50,7 @@ beforeEach(() => {
   enabledBox.value = false;
   codexTokenBox.value = null;
   codexEnabledBox.value = false;
+  writableBox.value = true;
 });
 
 describe('local proxy external token auth (A 族 = Anthropic)', () => {
@@ -200,5 +206,44 @@ describe('cross-family isolation (跨族 token 不互通)', () => {
     codexEnabledBox.value = true;
     expect(isExternalAccessEnabled()).toBe(false);
     expect(isCodexExternalAccessEnabled()).toBe(true);
+  });
+});
+
+describe('in-process fallback when safeStorage write fails', () => {
+  // 用 regenerate(总是覆盖兜底)取确定值,避免依赖模块级兜底 Map 的跨用例残留。
+  it('keeps the token stable in memory so it still matches this run', () => {
+    writableBox.value = false;
+    const token = regenerateExternalToken();
+    // 落盘失败:物理存储仍为空。
+    expect(tokenBox.value).toBeNull();
+    // 但兜底缓存让本次运行期读取/掩码/命中都拿到同一个稳定值。
+    expect(hasExternalToken()).toBe(true);
+    expect(getExternalTokenMasked()).not.toBeNull();
+    expect(matchesExternalToken(token)).toBe(true);
+    // getOrCreate 不再重新生成,复用兜底值(否则鉴权永远命不中)。
+    expect(getOrCreateExternalToken()).toBe(token);
+  });
+
+  it('a later successful write supersedes the memory fallback', () => {
+    writableBox.value = false;
+    const stale = regenerateExternalToken();
+    writableBox.value = true;
+    const fresh = regenerateExternalToken();
+    // 落盘成功后以持久值为准,旧兜底值失效。
+    expect(tokenBox.value).toBe(fresh);
+    expect(matchesExternalToken(fresh)).toBe(true);
+    expect(matchesExternalToken(stale)).toBe(false);
+  });
+
+  it('memory fallback is keyed per family (A vs B do not collide)', () => {
+    writableBox.value = false;
+    const a = regenerateExternalToken();
+    const b = regenerateCodexExternalToken();
+    expect(a).not.toBe(b);
+    // 各族兜底各认各的,跨族仍不互通。
+    expect(matchesExternalToken(a)).toBe(true);
+    expect(matchesCodexExternalToken(b)).toBe(true);
+    expect(matchesCodexExternalToken(a)).toBe(false);
+    expect(matchesExternalToken(b)).toBe(false);
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/local-proxy-external-auth.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// 用内存变量替身掉 safeStorage 落盘与非密钥设置存储,隔离出鉴权/生成/掩码逻辑,
+// 不触碰 electron。两族各一份 token box + enabled box,验证互不串扰。
+const tokenBox = vi.hoisted(() => ({ value: null as string | null }));
+const enabledBox = vi.hoisted(() => ({ value: false }));
+const codexTokenBox = vi.hoisted(() => ({ value: null as string | null }));
+const codexEnabledBox = vi.hoisted(() => ({ value: false }));
+
+vi.mock('../../secrets/providerSecretStore', () => ({
+  readLocalProxyExternalToken: () => tokenBox.value,
+  writeLocalProxyExternalToken: (v: string) => {
+    tokenBox.value = v;
+    return true;
+  },
+  readLocalProxyCodexExternalToken: () => codexTokenBox.value,
+  writeLocalProxyCodexExternalToken: (v: string) => {
+    codexTokenBox.value = v;
+    return true;
+  },
+}));
+
+vi.mock('../local-proxy-settings-store', () => ({
+  isExternalAccessEnabled: () => enabledBox.value,
+  isCodexExternalAccessEnabled: () => codexEnabledBox.value,
+}));
+
+import {
+  getCodexExternalTokenMasked,
+  getExternalTokenMasked,
+  getOrCreateCodexExternalToken,
+  getOrCreateExternalToken,
+  hasCodexExternalToken,
+  hasExternalToken,
+  isCodexExternalAccessEnabled,
+  isExternalAccessEnabled,
+  matchesCodexExternalToken,
+  matchesExternalToken,
+  regenerateCodexExternalToken,
+  regenerateExternalToken,
+} from '../local-proxy-external-auth';
+
+beforeEach(() => {
+  tokenBox.value = null;
+  enabledBox.value = false;
+  codexTokenBox.value = null;
+  codexEnabledBox.value = false;
+});
+
+describe('local proxy external token auth (A 族 = Anthropic)', () => {
+  it('creates a prefixed token once and reuses it', () => {
+    expect(hasExternalToken()).toBe(false);
+    const first = getOrCreateExternalToken();
+    expect(first).toMatch(/^cindy-local-/);
+    expect(hasExternalToken()).toBe(true);
+    // 已存在则复用,不重新生成。
+    expect(getOrCreateExternalToken()).toBe(first);
+  });
+
+  it('regenerate replaces the token so the old one no longer matches', () => {
+    const first = getOrCreateExternalToken();
+    const next = regenerateExternalToken();
+    expect(next).not.toBe(first);
+    expect(matchesExternalToken(next)).toBe(true);
+    expect(matchesExternalToken(first)).toBe(false);
+  });
+
+  it('matchesExternalToken is independent of enabled flag', () => {
+    const token = getOrCreateExternalToken();
+    enabledBox.value = false;
+    // 命中判定与 enabled 无关:携带正确 token 的请求任何时候都算外部客户端。
+    expect(matchesExternalToken(token)).toBe(true);
+    enabledBox.value = true;
+    expect(matchesExternalToken(token)).toBe(true);
+  });
+
+  it('rejects empty / wrong / length-mismatched candidates', () => {
+    getOrCreateExternalToken();
+    expect(matchesExternalToken(null)).toBe(false);
+    expect(matchesExternalToken(undefined)).toBe(false);
+    expect(matchesExternalToken('')).toBe(false);
+    expect(matchesExternalToken('cindy-local-wrong')).toBe(false);
+  });
+
+  it('returns false when no token has been stored yet', () => {
+    expect(matchesExternalToken('cindy-local-anything')).toBe(false);
+  });
+
+  it('masks the token without leaking the middle or true length', () => {
+    expect(getExternalTokenMasked()).toBeNull();
+    const token = getOrCreateExternalToken();
+    const masked = getExternalTokenMasked();
+    expect(masked).not.toBeNull();
+    expect(masked).toMatch(/^cindy-local-•+/);
+    expect(masked!.endsWith(token.slice(-4))).toBe(true);
+    // 掩码不应包含 token 中段。
+    expect(masked).not.toContain(token.slice(12, 20));
+  });
+
+  it('reflects the settings-store enabled flag', () => {
+    enabledBox.value = false;
+    expect(isExternalAccessEnabled()).toBe(false);
+    enabledBox.value = true;
+    expect(isExternalAccessEnabled()).toBe(true);
+  });
+});
+
+describe('local proxy external token auth (B 族 = Codex / OpenAI)', () => {
+  it('creates a prefixed token once and reuses it', () => {
+    expect(hasCodexExternalToken()).toBe(false);
+    const first = getOrCreateCodexExternalToken();
+    expect(first).toMatch(/^cindy-local-/);
+    expect(hasCodexExternalToken()).toBe(true);
+    expect(getOrCreateCodexExternalToken()).toBe(first);
+  });
+
+  it('regenerate replaces the token so the old one no longer matches', () => {
+    const first = getOrCreateCodexExternalToken();
+    const next = regenerateCodexExternalToken();
+    expect(next).not.toBe(first);
+    expect(matchesCodexExternalToken(next)).toBe(true);
+    expect(matchesCodexExternalToken(first)).toBe(false);
+  });
+
+  it('matchesCodexExternalToken is independent of codexEnabled flag', () => {
+    const token = getOrCreateCodexExternalToken();
+    codexEnabledBox.value = false;
+    expect(matchesCodexExternalToken(token)).toBe(true);
+    codexEnabledBox.value = true;
+    expect(matchesCodexExternalToken(token)).toBe(true);
+  });
+
+  it('masks the token without leaking the middle or true length', () => {
+    expect(getCodexExternalTokenMasked()).toBeNull();
+    const token = getOrCreateCodexExternalToken();
+    const masked = getCodexExternalTokenMasked();
+    expect(masked).not.toBeNull();
+    expect(masked).toMatch(/^cindy-local-•+/);
+    expect(masked!.endsWith(token.slice(-4))).toBe(true);
+    expect(masked).not.toContain(token.slice(12, 20));
+  });
+
+  it('reflects the settings-store codexEnabled flag', () => {
+    codexEnabledBox.value = false;
+    expect(isCodexExternalAccessEnabled()).toBe(false);
+    codexEnabledBox.value = true;
+    expect(isCodexExternalAccessEnabled()).toBe(true);
+  });
+});
+
+describe('cross-family isolation (跨族 token 不互通)', () => {
+  it('each family owns an independent token', () => {
+    const a = getOrCreateExternalToken();
+    const b = getOrCreateCodexExternalToken();
+    expect(a).not.toBe(b);
+    expect(hasExternalToken()).toBe(true);
+    expect(hasCodexExternalToken()).toBe(true);
+  });
+
+  it("A-family token does not match the codex host, and vice versa", () => {
+    const a = getOrCreateExternalToken();
+    const b = getOrCreateCodexExternalToken();
+    // 拿 A 族 token 打 codex loopback → 不命中(收紧隔离,不放行为外部客户端)。
+    expect(matchesCodexExternalToken(a)).toBe(false);
+    // 拿 B 族 token 打 anthropic loopback → 同样不命中。
+    expect(matchesExternalToken(b)).toBe(false);
+    // 各自 token 只命中本族。
+    expect(matchesExternalToken(a)).toBe(true);
+    expect(matchesCodexExternalToken(b)).toBe(true);
+  });
+
+  it('regenerating one family leaves the other untouched', () => {
+    const a = getOrCreateExternalToken();
+    const b = getOrCreateCodexExternalToken();
+    regenerateExternalToken();
+    // A 族换新后旧值失效,但 B 族原封不动。
+    expect(matchesExternalToken(a)).toBe(false);
+    expect(matchesCodexExternalToken(b)).toBe(true);
+    const b2 = regenerateCodexExternalToken();
+    expect(matchesCodexExternalToken(b)).toBe(false);
+    expect(matchesCodexExternalToken(b2)).toBe(true);
+    // B 族换新不影响 A 族当前 token。
+    expect(matchesExternalToken(getOrCreateExternalToken())).toBe(true);
+  });
+
+  it('one family having a token does not imply the other does', () => {
+    getOrCreateExternalToken();
+    expect(hasExternalToken()).toBe(true);
+    expect(hasCodexExternalToken()).toBe(false);
+    // B 族无 token 时,任何候选都不命中。
+    expect(matchesCodexExternalToken('cindy-local-anything')).toBe(false);
+  });
+
+  it('the two enabled flags are independent', () => {
+    enabledBox.value = true;
+    codexEnabledBox.value = false;
+    expect(isExternalAccessEnabled()).toBe(true);
+    expect(isCodexExternalAccessEnabled()).toBe(false);
+    enabledBox.value = false;
+    codexEnabledBox.value = true;
+    expect(isExternalAccessEnabled()).toBe(false);
+    expect(isCodexExternalAccessEnabled()).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/maker-host/__tests__/piAuthEnv.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piAuthEnv.test.ts
@@ -36,6 +36,12 @@ vi.mock('../custom-provider-header-secrets.js', () => ({
 }));
 vi.mock('../../secrets/providerSecretStore.js', () => ({
   readCustomProviderKey: (id: string) => (id === 'my-vllm' ? 'BYOM-KEY' : null),
+  // pi-host 的 import 图经 anthropic-compat-proxy-host → local-proxy-external-auth 触及这些
+  // 对外代理 token 存取器;此处只需惰性桩(Pi 鉴权用例不涉及对外代理)。
+  readLocalProxyExternalToken: () => null,
+  writeLocalProxyExternalToken: () => true,
+  readLocalProxyCodexExternalToken: () => null,
+  writeLocalProxyCodexExternalToken: () => true,
 }));
 
 import { desktopPiAuthAdapter } from '../pi-host.js';

--- a/apps/desktop/src/main/maker-host/__tests__/piByomNoCindyAuth.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/piByomNoCindyAuth.test.ts
@@ -21,7 +21,15 @@ vi.mock('../custom-provider-header-secrets.js', () => ({
     },
   ],
 }));
-vi.mock('../../secrets/providerSecretStore.js', () => ({ readCustomProviderKey: () => null }));
+vi.mock('../../secrets/providerSecretStore.js', () => ({
+  readCustomProviderKey: () => null,
+  // pi-host 的 import 图经 anthropic-compat-proxy-host → local-proxy-external-auth 触及这些
+  // 对外代理 token 存取器;此处只需惰性桩(该用例不涉及对外代理)。
+  readLocalProxyExternalToken: () => null,
+  writeLocalProxyExternalToken: () => true,
+  readLocalProxyCodexExternalToken: () => null,
+  writeLocalProxyCodexExternalToken: () => true,
+}));
 
 import { desktopPiAuthAdapter } from '../pi-host.js';
 

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -972,6 +972,28 @@ describe('对外模型代理 — resolveExternalModelRouteDecision（无会话�
       pathOverride: '/tenant/acme/infer?stream=1',
     });
   });
+
+  it('模型名唯一命中 oauth-passthrough(订阅直连)供应商 → null(与下拉候选同源排除)', async () => {
+    // stock claude 模型此处只由内置 anthropic(oauth-passthrough)提供 → 唯一命中它。
+    // 但订阅直连依赖子进程 OAuth bearer,外部 CLI 没有;外部解析必须拦掉,不能 strip 掉
+    // Cindy bearer 后转发(否则必然上游 401,或把不可路由供应商当可路由对外)。
+    setAnthropicDiscoveredModels([
+      {
+        id: 'claude-passthrough-only',
+        name: 'Claude Passthrough Only',
+        contextWindow: 200_000,
+        efforts: [],
+        defaultEffort: null,
+      },
+    ]);
+    expect(inferProviderIdForModel('claude-passthrough-only', 'claude-code')).toBe('anthropic');
+    await expect(
+      resolveExternalModelRouteDecision('claude-passthrough-only', KEY, ''),
+    ).resolves.toBeNull();
+    // 显式把 passthrough 供应商当默认供应商也一样拦掉(纵深防御,不依赖下拉过滤)。
+    await expect(resolveExternalModelRouteDecision('whatever', KEY, 'anthropic')).resolves.toBeNull();
+    setAnthropicDiscoveredModels([]);
+  });
 });
 
 describe('对外模型代理 — listExternalRoutableProviders（下拉候选）', () => {
@@ -1071,6 +1093,26 @@ describe('对外模型代理 — resolveExternalCodexRoute（Codex 无会话,返
   it('xd 网关(codex)显式选中时解析出网关 route,不越过外部分支', async () => {
     const route = await resolveExternalCodexRoute('anything-codex', 'xd');
     expect(route).toMatchObject({ providerId: 'xd', providerSource: 'builtin' });
+  });
+
+  it('模型名唯一命中 oauth-passthrough(内置 OpenAI Codex 订阅直连)供应商 → null', async () => {
+    // 该 gpt 模型此处只由内置 openai(codex=oauth-passthrough)提供 → 唯一命中它。
+    // 订阅直连依赖子进程 OAuth bearer,外部 CLI 没有;外部解析必须拦掉,绝不 strip 掉
+    // Cindy bearer 后转发(否则必然上游 401)。
+    setDiscoveredCodexModels([
+      {
+        id: 'gpt-passthrough-only',
+        name: 'GPT Passthrough Only',
+        contextWindow: 272_000,
+        efforts: [],
+        defaultEffort: null,
+      },
+    ]);
+    expect(inferProviderIdForModel('gpt-passthrough-only', 'codex')).toBe('openai');
+    await expect(resolveExternalCodexRoute('gpt-passthrough-only', '')).resolves.toBeNull();
+    // 显式把 passthrough 供应商当默认供应商也一样拦掉(纵深防御)。
+    await expect(resolveExternalCodexRoute('whatever-codex', 'openai')).resolves.toBeNull();
+    setDiscoveredCodexModels([]);
   });
 });
 

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -26,6 +26,9 @@ import {
   resolveImplicitLocalBridgeRoute,
   inferProviderIdForModel,
   isUserProviderSession,
+  listExternalRoutableProviders,
+  resolveExternalCodexRoute,
+  resolveExternalModelRouteDecision,
   setCustomProviderKeyReader,
   setProviderOAuthTokenReader,
   setProviderViewsReader,
@@ -868,5 +871,212 @@ describe('resolveSessionRouteDecision — 自定义供应商(resolve 时注入 k
   it('内置供应商 isUserProviderSession=false', () => {
     setSessionProvider('s-user', 'xd');
     expect(isUserProviderSession('s-user')).toBe(false);
+  });
+});
+
+describe('对外模型代理 — resolveExternalModelRouteDecision（无会话）', () => {
+  afterEach(() => {
+    setCustomProviders([]);
+    setCustomProviderKeyReader(() => null);
+  });
+
+  function seedClaudeUserProvider() {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'my-claude',
+        name: 'My Claude',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://claude.example/v1',
+            models: [{ id: 'house-claude', name: 'House Claude' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader((id, agent) =>
+      id === 'my-claude' && agent === 'claude-code' ? 'sk-house' : null,
+    );
+  }
+
+  it('按模型名解析到供应商并注入其真实凭证', async () => {
+    seedClaudeUserProvider();
+    // 前置：模型名确实唯一命中该供应商。
+    expect(inferProviderIdForModel('house-claude', 'claude-code')).toBe('my-claude');
+
+    const decision = await resolveExternalModelRouteDecision('house-claude', KEY, '');
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': 'sk-house', authorization: 'Bearer sk-house' },
+      upstreamOverride: 'https://claude.example/v1',
+    });
+  });
+
+  it('模型名推不出供应商时回落到「对外默认供应商」', async () => {
+    seedClaudeUserProvider();
+    // stock/未知模型名推不出唯一供应商 → 用 defaultProviderId 兜底。
+    expect(inferProviderIdForModel('unknown-stock-claude', 'claude-code')).toBeNull();
+
+    const decision = await resolveExternalModelRouteDecision(
+      'unknown-stock-claude',
+      KEY,
+      'my-claude',
+    );
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': 'sk-house', authorization: 'Bearer sk-house' },
+      upstreamOverride: 'https://claude.example/v1',
+    });
+  });
+
+  it('既推不出模型也没有默认供应商 → null（绝不回落 Cindy 默认网关/订阅）', async () => {
+    seedClaudeUserProvider();
+    await expect(
+      resolveExternalModelRouteDecision('unknown-stock-claude', KEY, ''),
+    ).resolves.toBeNull();
+    await expect(
+      resolveExternalModelRouteDecision('unknown-stock-claude', KEY, '   '),
+    ).resolves.toBeNull();
+  });
+
+  it('模型名与默认供应商都指向 xd 网关也不例外：仍按该供应商路由，不越过外部分支', async () => {
+    // xd 是 gateway-key 策略：外部分支解析出网关决策（换网关 key），
+    // 与「回落默认路由」不同——这是显式选中的供应商，凭证由 buildRouteDecision 注入。
+    const decision = await resolveExternalModelRouteDecision('anything', KEY, 'xd');
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': KEY, authorization: `Bearer ${KEY}` },
+    });
+  });
+});
+
+describe('对外模型代理 — listExternalRoutableProviders（下拉候选）', () => {
+  afterEach(() => {
+    setCustomProviders([]);
+  });
+
+  it('列出 gateway-key（xd），排除 oauth-passthrough（anthropic/openai 订阅直连）', () => {
+    const ids = listExternalRoutableProviders().map((p) => p.id);
+    expect(ids).toContain('xd');
+    expect(ids).not.toContain('anthropic');
+    expect(ids).not.toContain('openai');
+  });
+
+  it('包含 api-key-header 的自定义 claude-code 供应商（含 id+name，无凭证）', () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'my-claude',
+        name: 'My Claude',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://claude.example/v1',
+            models: [{ id: 'house-claude', name: 'House Claude' }],
+          },
+        },
+      }),
+    ]);
+    const listed = listExternalRoutableProviders();
+    expect(listed).toContainEqual({ id: 'my-claude', name: 'My Claude' });
+    // 只投影 id/name,不含任何路由/凭证字段。
+    for (const p of listed) {
+      expect(Object.keys(p).sort()).toEqual(['id', 'name']);
+    }
+  });
+
+  it('canUseCindyGateway=false 时排除 xd', () => {
+    mockGetAppCapabilities.mockReturnValue({ canUseCindyGateway: false });
+    const ids = listExternalRoutableProviders().map((p) => p.id);
+    expect(ids).not.toContain('xd');
+  });
+});
+
+describe('对外模型代理 — resolveExternalCodexRoute（Codex 无会话,返回完整 route）', () => {
+  afterEach(() => {
+    setCustomProviders([]);
+    setCustomProviderKeyReader(() => null);
+  });
+
+  function seedCodexUserProvider() {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'my-codex',
+        name: 'My Codex',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://codex.example/v1',
+            models: [{ id: 'house-codex', name: 'House Codex' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader((id, agent) =>
+      id === 'my-codex' && agent === 'codex' ? 'sk-codex-house' : null,
+    );
+  }
+
+  it('按模型名解析到 codex 供应商并带出完整 route(含注入的真实凭证)', async () => {
+    seedCodexUserProvider();
+    expect(inferProviderIdForModel('house-codex', 'codex')).toBe('my-codex');
+
+    const route = await resolveExternalCodexRoute('house-codex', '');
+    expect(route).toMatchObject({
+      providerId: 'my-codex',
+      providerSource: 'user',
+      apiKey: 'sk-codex-house',
+    });
+    // host 侧据 routing.wireProtocol 决定直连 Responses(undefined/openai-responses)还是走本地
+    // bridge(openai-chat/anthropic-messages)—— 必须带出 routing 供分派。
+    expect(route?.routing).toBeTruthy();
+  });
+
+  it('模型名推不出供应商时回落到 codex「对外默认供应商」', async () => {
+    seedCodexUserProvider();
+    expect(inferProviderIdForModel('unknown-codex-model', 'codex')).toBeNull();
+
+    const route = await resolveExternalCodexRoute('unknown-codex-model', 'my-codex');
+    expect(route).toMatchObject({ providerId: 'my-codex', apiKey: 'sk-codex-house' });
+  });
+
+  it('既推不出模型也没有默认供应商 → null（调用方 400,绝不回落 Cindy 默认网关/订阅）', async () => {
+    seedCodexUserProvider();
+    await expect(resolveExternalCodexRoute('unknown-codex-model', '')).resolves.toBeNull();
+    await expect(resolveExternalCodexRoute('unknown-codex-model', '   ')).resolves.toBeNull();
+    await expect(resolveExternalCodexRoute('', '')).resolves.toBeNull();
+  });
+
+  it('xd 网关(codex)显式选中时解析出网关 route,不越过外部分支', async () => {
+    const route = await resolveExternalCodexRoute('anything-codex', 'xd');
+    expect(route).toMatchObject({ providerId: 'xd', providerSource: 'builtin' });
+  });
+});
+
+describe('对外模型代理 — listExternalRoutableProviders(\'codex\')（codex 下拉候选）', () => {
+  afterEach(() => {
+    setCustomProviders([]);
+  });
+
+  it('列出 gateway-key(xd),排除 oauth-passthrough(openai codex 订阅直连)', () => {
+    // 注意与 claude-code 侧不同:codex agent 下 anthropic 走**可注入**订阅 token 的策略
+    //(非 oauth-passthrough),故 anthropic/xai 对 codex 可路由并出现在候选里;只有 openai
+    // 的 codex routing 是 oauth-passthrough(依赖子进程订阅 bearer),外部没有 → 排除。
+    const ids = listExternalRoutableProviders('codex').map((p) => p.id);
+    expect(ids).toContain('xd');
+    expect(ids).not.toContain('openai');
+  });
+
+  it('包含自定义 codex 供应商(只投影 id+name,无凭证)', () => {
+    setCustomProviders([
+      buildUserProvider({
+        id: 'my-codex',
+        name: 'My Codex',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://codex.example/v1',
+            models: [{ id: 'house-codex', name: 'House Codex' }],
+          },
+        },
+      }),
+    ]);
+    const listed = listExternalRoutableProviders('codex');
+    expect(listed).toContainEqual({ id: 'my-codex', name: 'My Codex' });
+    for (const p of listed) {
+      expect(Object.keys(p).sort()).toEqual(['id', 'name']);
+    }
   });
 });

--- a/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerRoute.test.ts
@@ -944,6 +944,34 @@ describe('对外模型代理 — resolveExternalModelRouteDecision（无会话�
       headerOverride: { 'x-api-key': KEY, authorization: `Bearer ${KEY}` },
     });
   });
+
+  it('自定义 requestPath 供应商:pathOverride 随决策带上(与会话路由一致)', async () => {
+    // 精确端点供应商(如 /tenant/acme/infer):外部路由必须把 pathOverride 带出去,
+    // 否则请求会被转发到客户端传入的 /v1/messages 而打不中该端点。
+    setCustomProviders([
+      buildUserProvider({
+        id: 'exact-claude',
+        name: 'Exact Claude',
+        runtimes: {
+          'claude-code': {
+            baseUrl: 'https://gateway.example/api',
+            requestPath: '/tenant/acme/infer?stream=1',
+            models: [{ id: 'exact-house-claude', name: 'Exact House Claude' }],
+          },
+        },
+      }),
+    ]);
+    setCustomProviderKeyReader((id, agent) =>
+      id === 'exact-claude' && agent === 'claude-code' ? 'sk-exact' : null,
+    );
+
+    const decision = await resolveExternalModelRouteDecision('exact-house-claude', KEY, '');
+    expect(decision).toEqual({
+      headerOverride: { 'x-api-key': 'sk-exact', authorization: 'Bearer sk-exact' },
+      upstreamOverride: 'https://gateway.example/api',
+      pathOverride: '/tenant/acme/infer?stream=1',
+    });
+  });
 });
 
 describe('对外模型代理 — listExternalRoutableProviders（下拉候选）', () => {

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -281,7 +281,7 @@ function routeExternalClient(
   if (pathnameHasDotSegments(pathname)) {
     return externalErrorDecision(404, 'unsupported_path', '对外 Anthropic 代理不支持该路径。');
   }
-  if (ctx.method.toUpperCase() === 'GET' && /\/v1\/models\/?$/.test(pathname)) {
+  if (ctx.method.toUpperCase() === 'GET' && /^\/v1\/models\/?$/.test(pathname)) {
     return {
       localHandler: async ({ res }) => {
         res.writeHead(200, {
@@ -298,7 +298,14 @@ function routeExternalClient(
   // 自定义供应商凭证注入并转发到调用方任意路径 —— 否则配了对外默认供应商时,一个不带 model 的
   // POST /v1/files 也足以借 Cindy 凭证打供应商任意 API。与 codex 侧只放行 /responses +
   // /v1/chat/completions 对称(#1666 review)。
-  if (!/\/v1\/messages(?:\/|$)/.test(pathname)) {
+  //
+  // ⚠ 必须 `^` 锚在**开头**(#1666 三轮 P2):不锚的话这是「包含」判定,`POST /anything/v1/messages`
+  //   同样命中白名单,而无 pathOverride 时转发的是原样 ctx.url → 供应商侧收到的是 /anything/v1/messages
+  //   这个未支持路径,却带着 buildRouteDecision 注入的真实凭证。锚定后也顺带挡掉 absolute-form 请求
+  //   (`POST http://evil.example/v1/messages`,此时 req.url 不以 `/` 开头)。
+  //   子路径放行(`(?:\/|$)`)是有意保留的:Claude Code 会打 /v1/messages/count_tokens,且同族推理
+  //   子路径向前兼容;越权风险来自**换顶级路径**(/v1/files 等),那已被开头锚定挡住。
+  if (!/^\/v1\/messages(?:\/|$)/.test(pathname)) {
     return externalErrorDecision(404, 'unsupported_path', '对外 Anthropic 代理不支持该路径。');
   }
   if (!isPlainObject(body)) {

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -471,19 +471,20 @@ export function createModelRoutingTransform(): RoutingTransform {
       return null;
     }
     // 有界拒绝(P1):对外访问开启时,这个端口被公布给外部 CLI。走到这里的请求既没有可用
-    // x-api-key(上面已判)、又没有可解析 session、又不带 authorization bearer、又不带
-    // x-claude-code-session-id 头 —— 它不是 Cindy 自家 cc 子进程(oauth-spawn 必带 OAuth
-    // bearer;任何 cc 子进程都带 x-claude-code-session-id;gateway-spawn 带可用 x-api-key 已在
-    // 上面 return),而是本机某个直接打这个对外端口、连对外 token 都省了的匿名客户端。放行会让它
-    // 经 gatewayDefaultRouteDecision 白嫖 Cindy 的网关 key。故 401,不落默认路由。
-    // ⚠ 有界修复:存心伪造一个假 authorization bearer / 会话头的本机进程仍能溜过(loopback 非鉴权
-    //   边界);彻底隔离需把对外监听与内部子进程代理拆到不同端口。未开启对外访问时不启用此闸,内部
-    //   流量字节级不变。
+    // x-api-key(上面已判)、又没有可解析 session、又不带 x-claude-code-session-id 头 —— 它不是
+    // Cindy 自家 cc 子进程(任何 cc 子进程,含注册时序窗口内会话反解不出的 oauth-spawn,都带
+    // x-claude-code-session-id;gateway-spawn 带可用 x-api-key 已在上面 return),而是本机某个直接
+    // 打这个对外端口、连对外 token 都省了的匿名客户端。放行会让它经 gatewayDefaultRouteDecision
+    // 白嫖 Cindy 的网关 key。故 401,不落默认路由。
+    // ⚠ 不以 authorization 头作豁免:内部子进程靠 x-claude-code-session-id 头(而非是否带 bearer)
+    //   与外部区分;若把「带 authorization」当豁免,本机进程随手伪造一个 `Bearer anything`(既无
+    //   x-api-key 也无会话头)即可跳过此闸,落到 gatewayDefaultRouteDecision 白嫖网关 key —— 假
+    //   bearer 绝不能绕过对外 token 要求(#1666 review)。loopback 本身仍不是鉴权边界,彻底隔离需
+    //   把对外监听与内部子进程代理拆到不同端口;未开启对外访问时不启用此闸,内部流量字节级不变。
     if (
       isExternalAccessEnabled()
       && sessionId === null
       && !sdkSessionId
-      && headerValue(ctx.headers, 'authorization') === null
     ) {
       return externalErrorDecision(
         401,

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -108,6 +108,12 @@ const log = createMakerLogger('cc-proxy');
 let _handle: ProxyHandle | null = null;
 let _initialized = false;
 
+// 对外 loopback 代理(端口拆分,#1666 Finding 1):与内部 _handle 完全独立的第二个 handle,
+// 绑用户在设置里固定的端口,只挂 createExternalRoutingTransform(无条件要求命中不可伪造的对外
+// token)。_externalStartPromise 做并发去重,避免 boot 与 set-enabled 同时拉起两个。
+let _externalHandle: ProxyHandle | null = null;
+let _externalStartPromise: Promise<void> | null = null;
+
 // gateway api key reader —— 由 host 注入(readClaudeApiKey),避免 proxy-host 直接 import
 // auth-adapters(重模块)。oauth-spawn 下走网关的请求(默认 / 选 XD)要把鉴权头换成它。
 // 复刻 codex-proxy-host.ts 的 setCodexProxyGatewayKeyReader 套路。
@@ -262,6 +268,15 @@ function routeExternalClient(
       },
     };
   }
+  // 路径白名单(P2):对外 Anthropic 代理只服务推理端点 /v1/messages(及其子路径,如
+  // /v1/messages/count_tokens)——外加上方 GET /v1/models 发现。其余路径(/v1/files、
+  // /v1/complete、任意非模型控制面 API)一律 404,绝不在解析出(默认)供应商后把 Cindy 的网关/
+  // 自定义供应商凭证注入并转发到调用方任意路径 —— 否则配了对外默认供应商时,一个不带 model 的
+  // POST /v1/files 也足以借 Cindy 凭证打供应商任意 API。与 codex 侧只放行 /responses +
+  // /v1/chat/completions 对称(#1666 review)。
+  if (!/\/v1\/messages(?:\/|$)/.test(pathname)) {
+    return externalErrorDecision(404, 'unsupported_path', '对外 Anthropic 代理不支持该路径。');
+  }
   if (!isPlainObject(body)) {
     // 非 JSON 的外部请求(非 /models 的控制面调用等):不识别就拒绝,绝不带着 token 透传上游。
     return externalErrorDecision(400, 'unsupported_request', '不支持的外部请求。');
@@ -306,6 +321,36 @@ function createExternalModelRewriteTransform(): RequestTransform {
 }
 
 /**
+ * 对外端口专用路由 transform(端口拆分,#1666 Finding 1)。绑在**独立的对外 loopback 端口**上
+ * (见 ensureAnthropicExternalProxyReady),只服务用户自己的 Claude Code CLI:
+ *   - `x-api-key` 命中 A 族对外 token → routeExternalClient(GET /v1/models 发现、/v1/messages
+ *     白名单、按模型 / 对外默认供应商解析)。命中判定与 enabled 无关;enabled 与否由
+ *     routeExternalClient 内决定放行 / 401。
+ *   - 带 `cindy-local-` 前缀但不命中(已重置 / 跨族拿 B 族 token / 已失效)→ 401 invalid_external_token,
+ *     绝不把它当作 x-api-key 透传上游。
+ *   - 其余(无 token / 伪造任意 header)→ 401 external_token_required。
+ * **无 session-header 启发式、无内部默认路由回落**——放行的唯一条件是命中不可伪造的对外 token,
+ * 因此在此端口上伪造 x-claude-code-session-id / authorization 毫无作用(彻底消除 Finding 1 的
+ * 可伪造绕过面)。export 供单测。
+ */
+export function createExternalRoutingTransform(): RoutingTransform {
+  return (body, ctx) => {
+    const externalApiKey = headerValue(ctx.headers, 'x-api-key');
+    if (matchesExternalToken(externalApiKey)) {
+      return routeExternalClient(body, ctx);
+    }
+    if (isCindyLocalToken(externalApiKey)) {
+      return externalErrorDecision(401, 'invalid_external_token', 'Cindy 对外访问 token 无效或已失效。');
+    }
+    return externalErrorDecision(
+      401,
+      'external_token_required',
+      'Cindy 对外模型代理需要有效的访问 token。',
+    );
+  };
+}
+
+/**
  * per-request 路由 transform。两段:
  *   ① 会话显式选了供应商 → 据 catalog 统一路由(per-session,取代全局开关推断)。
  *   ② 未显式选 → 据**请求实际携带的凭证**判定 spawn 形态:
@@ -323,19 +368,11 @@ function createExternalModelRewriteTransform(): RequestTransform {
  */
 export function createModelRoutingTransform(): RoutingTransform {
   const route: RoutingTransform = (body, ctx) => {
-    // ⓪ 对外模型代理:x-api-key 命中已存对外 token → 外部客户端,走独立无会话分支。
-    //    放在最前:优先级高于 Pi / per-session / spawn 默认路由。命中判定与 enabled 无关
-    //    (matchesExternalToken 只比 token),enabled 与否在 routeExternalClient 内决定放行/401。
-    //    未命中(Cindy 自家子进程 / 无 token)→ 落到下方现有逻辑,字节级不变。
-    const externalApiKey = headerValue(ctx.headers, 'x-api-key');
-    if (matchesExternalToken(externalApiKey)) {
-      return routeExternalClient(body, ctx);
-    }
-    // 带 `cindy-local-` 前缀但不命中 A 族 token(已重置 / 跨族拿 B 族 token 打 A 族 loopback /
-    // 已失效)→ 明确 401,绝不落到下方内部路由把这个对外 token 当 x-api-key 透传上游。
-    if (isCindyLocalToken(externalApiKey)) {
-      return externalErrorDecision(401, 'invalid_external_token', 'Cindy 对外访问 token 无效或已失效。');
-    }
+    // 本 transform 只服务 Cindy 自家内部流量(cc 子进程 / Pi)。对外客户端(用户自己的
+    // Claude Code CLI)走**独立的对外 loopback 端口**,由 createExternalRoutingTransform 处理
+    // ——那条路径无条件要求命中不可伪造的对外 token,绝不落到这里。端口拆分见
+    // ensureAnthropicExternalProxyReady(#1666 Finding 1:同端口上的 session-header 启发式可被
+    // 本机进程伪造绕过 → 白嫖网关 key;拆端口后此 transform 不再承担任何对外判定)。
     const claimedPiSessionId = headerValue(ctx.headers, 'x-cindy-pi-session-id');
     if (
       claimedPiSessionId
@@ -470,28 +507,8 @@ export function createModelRoutingTransform(): RoutingTransform {
       }
       return null;
     }
-    // 有界拒绝(P1):对外访问开启时,这个端口被公布给外部 CLI。走到这里的请求既没有可用
-    // x-api-key(上面已判)、又没有可解析 session、又不带 x-claude-code-session-id 头 —— 它不是
-    // Cindy 自家 cc 子进程(任何 cc 子进程,含注册时序窗口内会话反解不出的 oauth-spawn,都带
-    // x-claude-code-session-id;gateway-spawn 带可用 x-api-key 已在上面 return),而是本机某个直接
-    // 打这个对外端口、连对外 token 都省了的匿名客户端。放行会让它经 gatewayDefaultRouteDecision
-    // 白嫖 Cindy 的网关 key。故 401,不落默认路由。
-    // ⚠ 不以 authorization 头作豁免:内部子进程靠 x-claude-code-session-id 头(而非是否带 bearer)
-    //   与外部区分;若把「带 authorization」当豁免,本机进程随手伪造一个 `Bearer anything`(既无
-    //   x-api-key 也无会话头)即可跳过此闸,落到 gatewayDefaultRouteDecision 白嫖网关 key —— 假
-    //   bearer 绝不能绕过对外 token 要求(#1666 review)。loopback 本身仍不是鉴权边界,彻底隔离需
-    //   把对外监听与内部子进程代理拆到不同端口;未开启对外访问时不启用此闸,内部流量字节级不变。
-    if (
-      isExternalAccessEnabled()
-      && sessionId === null
-      && !sdkSessionId
-    ) {
-      return externalErrorDecision(
-        401,
-        'external_token_required',
-        'Cindy 对外模型代理需要有效的访问 token。',
-      );
-    }
+    // 端口拆分后此处不再承担任何对外判定(#1666 Finding 1):对外监听已挪到独立端口,
+    // 走到这里的一定是 Cindy 自家内部流量,按内部默认路由处理,字节级与加对外功能前一致。
     const decision = gatewayDefaultRouteDecision(requestAgent, gatewayKey);
     if (decision) {
       // oauth-spawn 默认:全量换网关 key(防订阅 token 泄漏到网关)。
@@ -544,27 +561,21 @@ export function createModelRoutingTransform(): RoutingTransform {
 }
 
 /**
- * 启动本地代理。幂等 —— 重复调用直接返回已缓存 handle。
- *
- * 即使代理启动失败,也会把 _initialized 置 true,后续 getClaudeEndpoint()
- * 直接 fallback 到真上游 URL,不会反复重试拖慢启动。
+ * 构造 anthropic-compat-proxy 的启动 options。**每次调用产出全新的 transform 实例** ——
+ * routingTransform / transformRequest 里含按 reqId 预留状态的有状态 transform(子代理 usage、
+ * fast mode 等),内部端口与对外端口必须各自持有独立实例,绝不共享同一个。
+ *   - external=false:内部端口(cc 子进程 / Pi),行为与加对外功能前字节级一致(随机端口)。
+ *   - external=true :对外端口,挂 createExternalRoutingTransform + 命名空间 model 改写(固定端口)。
  */
-export async function ensureAnthropicCompatProxyReady(): Promise<void> {
-  if (_initialized) return;
-  _initialized = true;
-
-  // 对外模型代理的端口策略:默认随机;用户在设置里开启对外服务时会捕获当前端口并持久化
-  // (见 local-proxy IPC)。持久化了(>0)就固定绑该端口,让外部 CLI 的 ANTHROPIC_BASE_URL 稳定;
-  // 固定端口被占用则 fallback 随机并回写新端口(UI 始终显示当前实际 url)。
-  const pinnedPort = loadLocalProxySettings().port;
-  try {
+function buildAnthropicProxyOptions(external: boolean) {
     const proxyOptions = {
       // 函数形态:model-access 凭据同步可能在 proxy 启动(splash)后才把 endpoint
       // 换成下发值;每请求现取才能保证与当前 key 同租户(proxy 内部按值 memoize)。
       upstream: () => claudeUpstreamEndpoint(),
-      // 'oauth' 模式按 model 分流(claude-* → api.anthropic.com 走订阅;其余 → gateway 换 key)。
-      // 'gateway' 模式恒返 null,字节级行为与扩展前一致。
-      routingTransform: createModelRoutingTransform(),
+      // 内部端口:'oauth' 模式按 model 分流(claude-* → api.anthropic.com 走订阅;其余 → gateway
+      // 换 key),'gateway' 模式恒返 null,字节级行为与扩展前一致。对外端口:只认对外 token 的
+      // 独立路由,绝不回落内部默认路由(见 createExternalRoutingTransform)。
+      routingTransform: external ? createExternalRoutingTransform() : createModelRoutingTransform(),
       // 只读响应观察器(组合三个,互不感知):
       //   - fast mode 链路核验:tee SSE 抽上游 usage.speed(debug-gated);
       //   - 订阅余量旁路:读 anthropic-ratelimit-unified-* headers(仅订阅直连响应,
@@ -601,9 +612,10 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
         }),
       ),
       transformRequest: [
-        // 对外模型代理:外部客户端带命名空间前缀的 model 在发往上游前剥成裸 id(仅外部请求生效)。
+        // 对外端口:外部客户端带命名空间前缀的 model 在发往上游前剥成裸 id(仅对外 handle 挂载)。
         // 放最前:后续 strip/修复 transform 看到的就是最终 model,与路由 transform 用原始 model 推断供应商互补。
-        createExternalModelRewriteTransform(),
+        // 内部端口不挂它(external=false)—— 内部流量的 model 由内部路由链处理,保持字节级不变。
+        ...(external ? [createExternalModelRewriteTransform()] : []),
         // 子代理 usage 在请求阶段预留 taskId，后续用同一 reqId 关联响应，避免响应乱序交换归因。
         createClaudeSubagentUsageRequestTransform(),
         // 开头:fast mode 请求侧核验(passthrough 不改写,放最前先记 cc 实际发出的 speed/beta)。
@@ -691,25 +703,22 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       // 行为与之前字节级一致。见 outbound-proxy-resolver.ts。
       resolveOutboundProxy: resolveDesktopOutboundProxy,
     };
-    try {
-      _handle = await createAnthropicCompatProxy(
-        pinnedPort > 0 ? { ...proxyOptions, port: pinnedPort } : proxyOptions,
-      );
-    } catch (err) {
-      // 固定端口不可用时 fallback 随机端口重试,并把持久化端口回写成实际绑定值,避免下次启动
-      // 又撞同一个坏端口。三类可 fallback:被占用(EADDRINUSE)/ 无权限(EACCES)/ 落在 Fetch
-      // 屏蔽端口(包内直接抛,SDK 连不上)。其它错误照抛给外层兜底。
-      const code = (err as NodeJS.ErrnoException | undefined)?.code;
-      const fetchBlocked = isFetchBlockedPort(pinnedPort);
-      if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES' || fetchBlocked)) {
-        log.error('固定的对外代理端口不可用,fallback 随机端口', { pinnedPort, code, fetchBlocked });
-        _handle = await createAnthropicCompatProxy(proxyOptions);
-        const actual = portFromProxyUrl(_handle.url);
-        if (actual) setLocalProxyPort(actual);
-      } else {
-        throw err;
-      }
-    }
+  return proxyOptions;
+}
+
+/**
+ * 启动**内部** loopback 代理(cc 子进程 / Pi 用)。幂等 —— 重复调用直接返回已缓存 handle。
+ * 绑随机端口(不对用户公布;端口在 spawn 时经 env 注入给子进程)。对外访问是**独立** handle,
+ * 绑固定端口,见 ensureAnthropicExternalProxyReady —— 端口拆分后内部端口不再承担任何对外判定。
+ *
+ * 即使代理启动失败,也会把 _initialized 置 true,后续 getClaudeEndpoint() 直接 fallback 到真
+ * 上游 URL,不会反复重试拖慢启动。
+ */
+export async function ensureAnthropicCompatProxyReady(): Promise<void> {
+  if (_initialized) return;
+  _initialized = true;
+  try {
+    _handle = await createAnthropicCompatProxy(buildAnthropicProxyOptions(false));
     log.debug('proxy ready', { url: _handle.url, upstream: claudeUpstreamEndpoint() });
   } catch (err) {
     _handle = null;
@@ -718,6 +727,52 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       fallbackEndpoint: claudeUpstreamEndpoint(),
     });
   }
+}
+
+/**
+ * 启动**对外** loopback 代理(给用户自己电脑上的 Claude Code CLI 用)。只在用户开启 A 族对外
+ * 访问时由 IPC / boot 拉起。端口策略:绑持久化的固定端口(loadLocalProxySettings().port),让外部
+ * CLI 的 ANTHROPIC_BASE_URL 稳定;端口被占用(EADDRINUSE / EACCES / 落在 Fetch 屏蔽端口)则
+ * fallback 随机并回写新端口(UI 始终显示当前实际 url)。并发去重(_externalStartPromise),启动
+ * 失败不抛 —— getExternalProxyUrl() 保持 null,UI 据此提示未就绪。
+ */
+export async function ensureAnthropicExternalProxyReady(): Promise<void> {
+  if (_externalHandle) return;
+  if (_externalStartPromise) return _externalStartPromise;
+  _externalStartPromise = (async () => {
+    const pinnedPort = loadLocalProxySettings().port;
+    try {
+      const options = buildAnthropicProxyOptions(true);
+      try {
+        _externalHandle = await createAnthropicCompatProxy(
+          pinnedPort > 0 ? { ...options, port: pinnedPort } : options,
+        );
+      } catch (err) {
+        // 固定端口不可用时 fallback 随机端口重试,并把持久化端口回写成实际绑定值,避免下次启动
+        // 又撞同一个坏端口。三类可 fallback:被占用(EADDRINUSE)/ 无权限(EACCES)/ 落在 Fetch
+        // 屏蔽端口(包内直接抛,SDK 连不上)。其它错误照抛给外层兜底。
+        const code = (err as NodeJS.ErrnoException | undefined)?.code;
+        const fetchBlocked = isFetchBlockedPort(pinnedPort);
+        if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES' || fetchBlocked)) {
+          log.error('固定的对外代理端口不可用,fallback 随机端口', { pinnedPort, code, fetchBlocked });
+          _externalHandle = await createAnthropicCompatProxy(options);
+          const actual = portFromProxyUrl(_externalHandle.url);
+          if (actual) setLocalProxyPort(actual);
+        } else {
+          throw err;
+        }
+      }
+      log.info('anthropic external proxy ready', { url: _externalHandle.url });
+    } catch (err) {
+      _externalHandle = null;
+      log.error('anthropic external proxy failed to start', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      _externalStartPromise = null;
+    }
+  })();
+  return _externalStartPromise;
 }
 
 /** 从 loopback proxy url(`http://127.0.0.1:<port>`)取端口;解析失败返回 null。 */
@@ -730,9 +785,18 @@ export function portFromProxyUrl(url: string): number | null {
   }
 }
 
-/** 当前代理是否就绪且其 url;供 IPC get-state 展示 127.0.0.1 地址与端口。未就绪返回 null。 */
+/** 内部代理(cc 子进程 / Pi)当前 url;供内部重启 / 诊断用。未就绪返回 null。 */
 export function getLocalProxyUrl(): string | null {
   return _handle?.url ?? null;
+}
+
+/**
+ * **对外**代理当前 url;供 IPC get-state / copy / preview / write 展示给外部 CLI 的
+ * 127.0.0.1 地址与端口。只有开启了 A 族对外访问并 ensureAnthropicExternalProxyReady 成功后才非
+ * null;未就绪返回 null,UI 据此提示未就绪。
+ */
+export function getExternalProxyUrl(): string | null {
+  return _externalHandle?.url ?? null;
 }
 
 /**
@@ -744,6 +808,16 @@ export async function restartAnthropicCompatProxy(): Promise<string | null> {
   await disposeAnthropicCompatProxy();
   await ensureAnthropicCompatProxyReady();
   return getLocalProxyUrl();
+}
+
+/**
+ * 重建**对外**代理以让新的固定端口生效(用户在设置里改端口后调用)。返回重建后的实际 url。
+ * 会中断当前经对外代理的 in-flight 请求 —— 仅在用户显式改端口时用。
+ */
+export async function restartAnthropicExternalProxy(): Promise<string | null> {
+  await disposeAnthropicExternalProxy();
+  await ensureAnthropicExternalProxyReady();
+  return getExternalProxyUrl();
 }
 
 /**
@@ -790,7 +864,7 @@ export function getClaudeEndpoint(): string {
 }
 
 /**
- * 优雅关闭。注册到 bootstrap-electron 的 onQuit('async') 阶段。
+ * 优雅关闭内部代理。注册到 bootstrap-electron 的 onQuit('async') 阶段(该阶段也会关对外代理)。
  */
 export async function disposeAnthropicCompatProxy(): Promise<void> {
   if (!_handle) return;
@@ -801,5 +875,27 @@ export async function disposeAnthropicCompatProxy(): Promise<void> {
     await h.dispose();
   } catch (err) {
     log.warn('proxy dispose failed', { err: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+/**
+ * 优雅关闭**对外**代理(关闭 A 族对外访问 / 改端口 / 退出时)。先等待 in-flight 的启动去重
+ * Promise 结算,避免与并发的 ensure 抢 _externalHandle。
+ */
+export async function disposeAnthropicExternalProxy(): Promise<void> {
+  if (_externalStartPromise) {
+    try {
+      await _externalStartPromise;
+    } catch {
+      // 启动失败已在 ensure 内部记日志;这里只是确保不在启动中途 dispose。
+    }
+  }
+  if (!_externalHandle) return;
+  const h = _externalHandle;
+  _externalHandle = null;
+  try {
+    await h.dispose();
+  } catch (err) {
+    log.warn('external proxy dispose failed', { err: err instanceof Error ? err.message : String(err) });
   }
 }

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -65,6 +65,7 @@ import {
   rewriteImplicitModelIdForRoute,
 } from './provider-route.js';
 import {
+  isCindyLocalToken,
   isExternalAccessEnabled,
   matchesExternalToken,
 } from './local-proxy-external-auth.js';
@@ -319,8 +320,14 @@ export function createModelRoutingTransform(): RoutingTransform {
     //    放在最前:优先级高于 Pi / per-session / spawn 默认路由。命中判定与 enabled 无关
     //    (matchesExternalToken 只比 token),enabled 与否在 routeExternalClient 内决定放行/401。
     //    未命中(Cindy 自家子进程 / 无 token)→ 落到下方现有逻辑,字节级不变。
-    if (matchesExternalToken(headerValue(ctx.headers, 'x-api-key'))) {
+    const externalApiKey = headerValue(ctx.headers, 'x-api-key');
+    if (matchesExternalToken(externalApiKey)) {
       return routeExternalClient(body, ctx);
+    }
+    // 带 `cindy-local-` 前缀但不命中 A 族 token(已重置 / 跨族拿 B 族 token 打 A 族 loopback /
+    // 已失效)→ 明确 401,绝不落到下方内部路由把这个对外 token 当 x-api-key 透传上游。
+    if (isCindyLocalToken(externalApiKey)) {
+      return externalErrorDecision(401, 'invalid_external_token', 'Cindy 对外访问 token 无效或已失效。');
     }
     const claimedPiSessionId = headerValue(ctx.headers, 'x-cindy-pi-session-id');
     if (

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -27,6 +27,7 @@ import {
   createToolExchangeAdjacencyRecoveryRule,
   createToolUseProviderSpecificFieldsRecoveryRule,
   dedupeDuplicateToolUseIds,
+  isFetchBlockedPort,
   repairToolExchangeAdjacency,
   stripEmptyAssistantMessagesFromBody,
   stripEmptyTextFromBody,
@@ -60,6 +61,7 @@ import { getSessionProvider } from './session-provider-store.js';
 import {
   gatewayDefaultRouteDecision,
   getUserProviderIdForSession,
+  listExternalRoutableProviders,
   resolveExternalModelRouteDecision,
   resolveSessionRouteDecision,
   rewriteImplicitModelIdForRoute,
@@ -209,14 +211,19 @@ function stripExternalTokenHeaders(decision: RoutingDecision | null): RoutingDec
  * 构造 `GET /v1/models` 的 Anthropic 形状清单:外部 CLI 用它发现可用模型。
  * 取「对外可路由的 claude-code 供应商」并集里的模型,按 id 去重(同一 stock claude-* 可能
  * 同时由多家提供)。不含任何凭证 / 上游地址。
+ *
+ * 只宣告 `listExternalRoutableProviders('claude-code')` 认可的供应商:与实际路由判据
+ * (`isExternalRoutableProvider`,排除 oauth-passthrough 订阅直连、网关不可用的 xd 等)同源。
+ * 否则会把外部客户端根本路由不通的模型也列进 discovery,诱导其选中后必然上游 401。
  */
 function buildExternalModelsPayload(): string {
+  const routableIds = new Set(
+    listExternalRoutableProviders('claude-code').map((provider) => provider.id),
+  );
   const seen = new Set<string>();
   const data: { type: 'model'; id: string; display_name: string }[] = [];
   for (const provider of getActiveCatalog().providers) {
-    if (!provider.agents.includes('claude-code')) continue;
-    const routing = provider.routing['claude-code'];
-    if (!routing || routing.disabled) continue;
+    if (!routableIds.has(provider.id)) continue;
     for (const model of provider.models['claude-code'] ?? []) {
       if (!model.id || seen.has(model.id)) continue;
       seen.add(model.id);
@@ -463,6 +470,27 @@ export function createModelRoutingTransform(): RoutingTransform {
       }
       return null;
     }
+    // 有界拒绝(P1):对外访问开启时,这个端口被公布给外部 CLI。走到这里的请求既没有可用
+    // x-api-key(上面已判)、又没有可解析 session、又不带 authorization bearer、又不带
+    // x-claude-code-session-id 头 —— 它不是 Cindy 自家 cc 子进程(oauth-spawn 必带 OAuth
+    // bearer;任何 cc 子进程都带 x-claude-code-session-id;gateway-spawn 带可用 x-api-key 已在
+    // 上面 return),而是本机某个直接打这个对外端口、连对外 token 都省了的匿名客户端。放行会让它
+    // 经 gatewayDefaultRouteDecision 白嫖 Cindy 的网关 key。故 401,不落默认路由。
+    // ⚠ 有界修复:存心伪造一个假 authorization bearer / 会话头的本机进程仍能溜过(loopback 非鉴权
+    //   边界);彻底隔离需把对外监听与内部子进程代理拆到不同端口。未开启对外访问时不启用此闸,内部
+    //   流量字节级不变。
+    if (
+      isExternalAccessEnabled()
+      && sessionId === null
+      && !sdkSessionId
+      && headerValue(ctx.headers, 'authorization') === null
+    ) {
+      return externalErrorDecision(
+        401,
+        'external_token_required',
+        'Cindy 对外模型代理需要有效的访问 token。',
+      );
+    }
     const decision = gatewayDefaultRouteDecision(requestAgent, gatewayKey);
     if (decision) {
       // oauth-spawn 默认:全量换网关 key(防订阅 token 泄漏到网关)。
@@ -667,11 +695,13 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
         pinnedPort > 0 ? { ...proxyOptions, port: pinnedPort } : proxyOptions,
       );
     } catch (err) {
-      // 固定端口被占用(EADDRINUSE)/ 无权限(EACCES):fallback 随机端口重试,并把
-      // 持久化端口回写成实际绑定值,避免下次启动又撞同一个占用端口。其它错误照抛给外层兜底。
+      // 固定端口不可用时 fallback 随机端口重试,并把持久化端口回写成实际绑定值,避免下次启动
+      // 又撞同一个坏端口。三类可 fallback:被占用(EADDRINUSE)/ 无权限(EACCES)/ 落在 Fetch
+      // 屏蔽端口(包内直接抛,SDK 连不上)。其它错误照抛给外层兜底。
       const code = (err as NodeJS.ErrnoException | undefined)?.code;
-      if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES')) {
-        log.error('固定的对外代理端口不可用,fallback 随机端口', { pinnedPort, code });
+      const fetchBlocked = isFetchBlockedPort(pinnedPort);
+      if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES' || fetchBlocked)) {
+        log.error('固定的对外代理端口不可用,fallback 随机端口', { pinnedPort, code, fetchBlocked });
         _handle = await createAnthropicCompatProxy(proxyOptions);
         const actual = portFromProxyUrl(_handle.url);
         if (actual) setLocalProxyPort(actual);

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -35,6 +35,7 @@ import {
   stripNonAnthropicFields,
   stripToolUseProviderSpecificFields,
   type ProxyHandle,
+  type RequestTransform,
   type RoutingDecision,
   type RoutingTransform,
 } from '@cindy/anthropic-compat-proxy';
@@ -59,8 +60,18 @@ import { getSessionProvider } from './session-provider-store.js';
 import {
   gatewayDefaultRouteDecision,
   getUserProviderIdForSession,
+  resolveExternalModelRouteDecision,
   resolveSessionRouteDecision,
+  rewriteImplicitModelIdForRoute,
 } from './provider-route.js';
+import {
+  isExternalAccessEnabled,
+  matchesExternalToken,
+} from './local-proxy-external-auth.js';
+import {
+  loadLocalProxySettings,
+  setLocalProxyPort,
+} from './local-proxy-settings-store.js';
 import { createProviderUpstreamErrorObserver } from './provider-upstream-error-observer.js';
 import { createClaudeAutoClassifierFailureObserver } from './claude-auto-permission-fallback.js';
 import {
@@ -139,6 +150,153 @@ function headerValue(headers: Readonly<Record<string, string>>, name: string): s
   return null;
 }
 
+// ───────────────────────── 对外模型代理(external client)─────────────────────────
+// 用户自己电脑上的 Claude Code CLI 把 ANTHROPIC_BASE_URL 指向本代理、ANTHROPIC_API_KEY
+// 设为 Cindy 生成的对外 token 时,这些请求没有 Cindy session。它们靠 x-api-key 命中已存
+// 对外 token 被识别为「外部客户端」,走一条独立、无会话、按模型名/默认供应商的路由分支,
+// **绝不回落 Cindy 默认网关/订阅路由**(否则外部 token 会被当成 gateway 的 x-api-key 透传
+// 上游 → 凭证泄漏/误计费)。
+
+/** 从 ctx.url(可能带 query)取纯 path,小写化便于匹配。 */
+function requestPathname(url: string): string {
+  const q = url.indexOf('?');
+  return (q === -1 ? url : url.slice(0, q)).toLowerCase();
+}
+
+/** 外部分支的统一 JSON 错误响应(localHandler 完全接管,不转发上游)。 */
+function externalErrorDecision(
+  status: number,
+  code: string,
+  message: string,
+): RoutingDecision {
+  return {
+    localHandler: async ({ res }) => {
+      const payload = JSON.stringify({
+        type: 'error',
+        error: { type: status === 401 || status === 403 ? 'authentication_error' : 'invalid_request_error', code, message },
+      });
+      res.writeHead(status, {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      });
+      res.end(payload);
+    },
+  };
+}
+
+/**
+ * 转发前从外部请求剥掉它自带的对外 token 头,防止透传上游。
+ * headerDelete 在 headerOverride **之后**应用 —— 若路由决策已用 headerOverride 覆盖了某个
+ * 鉴权头(gateway-key / api-key-header 注入真实凭证),就**不能**再 delete 它(否则会净删除真凭证);
+ * 仅对决策没有覆盖的鉴权头追加 delete。这样:注入了真凭证的头保留真值,没注入的(如 oauth-passthrough
+ * 只 upstreamOverride 不换头)则把外部 token 删掉 → fail-closed(上游 401),不泄漏。
+ */
+function stripExternalTokenHeaders(decision: RoutingDecision | null): RoutingDecision | null {
+  if (!decision || decision.localHandler) return decision;
+  const overridden = new Set(
+    Object.keys(decision.headerOverride ?? {}).map((k) => k.toLowerCase()),
+  );
+  const toDelete = ['x-api-key', 'authorization'].filter((h) => !overridden.has(h));
+  if (toDelete.length === 0) return decision;
+  return {
+    ...decision,
+    headerDelete: [...new Set([...(decision.headerDelete ?? []), ...toDelete])],
+  };
+}
+
+/**
+ * 构造 `GET /v1/models` 的 Anthropic 形状清单:外部 CLI 用它发现可用模型。
+ * 取「对外可路由的 claude-code 供应商」并集里的模型,按 id 去重(同一 stock claude-* 可能
+ * 同时由多家提供)。不含任何凭证 / 上游地址。
+ */
+function buildExternalModelsPayload(): string {
+  const seen = new Set<string>();
+  const data: { type: 'model'; id: string; display_name: string }[] = [];
+  for (const provider of getActiveCatalog().providers) {
+    if (!provider.agents.includes('claude-code')) continue;
+    const routing = provider.routing['claude-code'];
+    if (!routing || routing.disabled) continue;
+    for (const model of provider.models['claude-code'] ?? []) {
+      if (!model.id || seen.has(model.id)) continue;
+      seen.add(model.id);
+      data.push({ type: 'model', id: model.id, display_name: model.name });
+    }
+  }
+  return JSON.stringify({
+    data,
+    has_more: false,
+    first_id: data[0]?.id ?? null,
+    last_id: data[data.length - 1]?.id ?? null,
+  });
+}
+
+/**
+ * 外部客户端请求的路由决策。**先判 enabled**:未开启 → 401(即使 token 还在,也拒绝,
+ * 防止关了开关后旧 token 还能用)。GET /v1/models → 本地吐清单。其余按 model 解析供应商,
+ * 解析不出 → 400(不回落默认路由)。最后 strip 外部 token 头。
+ */
+function routeExternalClient(
+  body: unknown,
+  ctx: Parameters<RoutingTransform>[1],
+): RoutingDecision | Promise<RoutingDecision | null> {
+  if (!isExternalAccessEnabled()) {
+    return externalErrorDecision(401, 'external_access_disabled', 'Cindy 对外模型代理未开启。');
+  }
+  const pathname = requestPathname(ctx.url);
+  if (ctx.method.toUpperCase() === 'GET' && /\/v1\/models\/?$/.test(pathname)) {
+    return {
+      localHandler: async ({ res }) => {
+        res.writeHead(200, {
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'no-store',
+        });
+        res.end(buildExternalModelsPayload());
+      },
+    };
+  }
+  if (!isPlainObject(body)) {
+    // 非 JSON 的外部请求(非 /models 的控制面调用等):不识别就拒绝,绝不带着 token 透传上游。
+    return externalErrorDecision(400, 'unsupported_request', '不支持的外部请求。');
+  }
+  const wireModel = typeof body.model === 'string' ? body.model : '';
+  // 订阅前缀模型(chatgpt/ / xai/):交本地 responses bridge,用 Cindy 持有的订阅 OAuth 直连
+  // (与内部同一 handler)。外部客户端由此可复用 Cindy 的订阅额度。
+  if (isSubscriptionDirectModel(wireModel)) {
+    const bridgeHandler = getResponsesBridgeHandler();
+    if (!bridgeHandler) {
+      return externalErrorDecision(503, 'bridge_unavailable', '订阅直连桥暂不可用。');
+    }
+    return { localHandler: (args) => bridgeHandler.handle({ ...args, prefs: {} }) };
+  }
+  const gatewayKey = _readGatewayKey();
+  const defaultProviderId = loadLocalProxySettings().defaultProviderId;
+  return resolveExternalModelRouteDecision(wireModel, gatewayKey, defaultProviderId).then(
+    (decision) => {
+      if (!decision) {
+        return externalErrorDecision(
+          400,
+          'no_provider_for_model',
+          `没有可路由「${wireModel || '(未指定)'}」的供应商;请在 Cindy 设置里选择对外默认供应商,或换用某供应商的模型 id。`,
+        );
+      }
+      return stripExternalTokenHeaders(decision);
+    },
+  );
+}
+
+/**
+ * 外部模型代理的 model id 改写请求 transform:仅对外部客户端(x-api-key 命中对外 token)
+ * 生效,把带命名空间前缀的 model(如某自定义供应商的 `foo/bar`)在发往上游前剥成上游可识别
+ * 的裸 id。与路由 transform 同源(都用 inferProviderIdForModel);路由 transform 看**原始** body
+ * (带前缀)推断供应商,本 transform 改写**转发** body,两者互补。
+ */
+function createExternalModelRewriteTransform(): RequestTransform {
+  return (body, ctx) => {
+    if (!matchesExternalToken(headerValue(ctx.headers, 'x-api-key'))) return null;
+    return rewriteImplicitModelIdForRoute('claude-code', body);
+  };
+}
+
 /**
  * per-request 路由 transform。两段:
  *   ① 会话显式选了供应商 → 据 catalog 统一路由(per-session,取代全局开关推断)。
@@ -157,6 +315,13 @@ function headerValue(headers: Readonly<Record<string, string>>, name: string): s
  */
 export function createModelRoutingTransform(): RoutingTransform {
   const route: RoutingTransform = (body, ctx) => {
+    // ⓪ 对外模型代理:x-api-key 命中已存对外 token → 外部客户端,走独立无会话分支。
+    //    放在最前:优先级高于 Pi / per-session / spawn 默认路由。命中判定与 enabled 无关
+    //    (matchesExternalToken 只比 token),enabled 与否在 routeExternalClient 内决定放行/401。
+    //    未命中(Cindy 自家子进程 / 无 token)→ 落到下方现有逻辑,字节级不变。
+    if (matchesExternalToken(headerValue(ctx.headers, 'x-api-key'))) {
+      return routeExternalClient(body, ctx);
+    }
     const claimedPiSessionId = headerValue(ctx.headers, 'x-cindy-pi-session-id');
     if (
       claimedPiSessionId
@@ -352,8 +517,12 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
   if (_initialized) return;
   _initialized = true;
 
+  // 对外模型代理的端口策略:默认随机;用户在设置里开启对外服务时会捕获当前端口并持久化
+  // (见 local-proxy IPC)。持久化了(>0)就固定绑该端口,让外部 CLI 的 ANTHROPIC_BASE_URL 稳定;
+  // 固定端口被占用则 fallback 随机并回写新端口(UI 始终显示当前实际 url)。
+  const pinnedPort = loadLocalProxySettings().port;
   try {
-    _handle = await createAnthropicCompatProxy({
+    const proxyOptions = {
       // 函数形态:model-access 凭据同步可能在 proxy 启动(splash)后才把 endpoint
       // 换成下发值;每请求现取才能保证与当前 key 同租户(proxy 内部按值 memoize)。
       upstream: () => claudeUpstreamEndpoint(),
@@ -396,6 +565,9 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
         }),
       ),
       transformRequest: [
+        // 对外模型代理:外部客户端带命名空间前缀的 model 在发往上游前剥成裸 id(仅外部请求生效)。
+        // 放最前:后续 strip/修复 transform 看到的就是最终 model,与路由 transform 用原始 model 推断供应商互补。
+        createExternalModelRewriteTransform(),
         // 子代理 usage 在请求阶段预留 taskId，后续用同一 reqId 关联响应，避免响应乱序交换归因。
         createClaudeSubagentUsageRequestTransform(),
         // 开头:fast mode 请求侧核验(passthrough 不改写,放最前先记 cc 实际发出的 speed/beta)。
@@ -482,7 +654,24 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       // 上游连接跟随代理环境变量 / 系统代理(非 TUN 的代理软件场景);无代理配置时直连,
       // 行为与之前字节级一致。见 outbound-proxy-resolver.ts。
       resolveOutboundProxy: resolveDesktopOutboundProxy,
-    });
+    };
+    try {
+      _handle = await createAnthropicCompatProxy(
+        pinnedPort > 0 ? { ...proxyOptions, port: pinnedPort } : proxyOptions,
+      );
+    } catch (err) {
+      // 固定端口被占用(EADDRINUSE)/ 无权限(EACCES):fallback 随机端口重试,并把
+      // 持久化端口回写成实际绑定值,避免下次启动又撞同一个占用端口。其它错误照抛给外层兜底。
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES')) {
+        log.error('固定的对外代理端口不可用,fallback 随机端口', { pinnedPort, code });
+        _handle = await createAnthropicCompatProxy(proxyOptions);
+        const actual = portFromProxyUrl(_handle.url);
+        if (actual) setLocalProxyPort(actual);
+      } else {
+        throw err;
+      }
+    }
     log.debug('proxy ready', { url: _handle.url, upstream: claudeUpstreamEndpoint() });
   } catch (err) {
     _handle = null;
@@ -491,6 +680,32 @@ export async function ensureAnthropicCompatProxyReady(): Promise<void> {
       fallbackEndpoint: claudeUpstreamEndpoint(),
     });
   }
+}
+
+/** 从 loopback proxy url(`http://127.0.0.1:<port>`)取端口;解析失败返回 null。 */
+export function portFromProxyUrl(url: string): number | null {
+  try {
+    const port = Number.parseInt(new URL(url).port, 10);
+    return Number.isInteger(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+/** 当前代理是否就绪且其 url;供 IPC get-state 展示 127.0.0.1 地址与端口。未就绪返回 null。 */
+export function getLocalProxyUrl(): string | null {
+  return _handle?.url ?? null;
+}
+
+/**
+ * 重建代理以让新的固定端口生效(用户在设置里改端口后调用)。dispose 会把
+ * `_initialized` 复位,随后 ensure 按最新持久化端口重新绑定。返回重建后的实际 url。
+ * 注意:会中断当前经代理的 in-flight 请求 —— 仅在用户显式改端口时用,不做常态调用。
+ */
+export async function restartAnthropicCompatProxy(): Promise<string | null> {
+  await disposeAnthropicCompatProxy();
+  await ensureAnthropicCompatProxyReady();
+  return getLocalProxyUrl();
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/anthropic-compat-proxy-host.ts
@@ -172,6 +172,25 @@ function requestPathname(url: string): string {
   return (q === -1 ? url : url.slice(0, q)).toLowerCase();
 }
 
+/**
+ * 路径穿越防护(#1666 二轮 P1)。`/v1/messages` 白名单是**前缀**判定(为放行 count_tokens 等
+ * 合法子路径),而 anthropic-compat-proxy 在无 pathOverride 时**原样转发 ctx.url**。若放行
+ * `/v1/messages/../../v1/files` 这类带点段路径,会规范化 dot-segment 的上游 / 中间代理会把它解析
+ * 成 `/v1/files`,借 buildRouteDecision 注入的真实供应商凭证去打该供应商的任意 API。故在过白名单
+ * **之前**先解一层百分号编码(挡 `%2e` 等编码变体),再按段检查:任一段为 `.` / `..` 即视为不支持
+ * 路径拒绝,绝不转发;非法百分号编码本身可疑,一并拒绝。这样即便上游会规范化,Cindy 也从不把带点段
+ * 的路径连同凭证送出去(不依赖上游是否规范化)。
+ */
+function pathnameHasDotSegments(pathname: string): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    return true;
+  }
+  return decoded.split('/').some((segment) => segment === '.' || segment === '..');
+}
+
 /** 外部分支的统一 JSON 错误响应(localHandler 完全接管,不转发上游)。 */
 function externalErrorDecision(
   status: number,
@@ -257,6 +276,11 @@ function routeExternalClient(
     return externalErrorDecision(401, 'external_access_disabled', 'Cindy 对外模型代理未开启。');
   }
   const pathname = requestPathname(ctx.url);
+  // 先挡路径穿越:带 `.` / `..` 段的路径(如 /v1/messages/../../v1/files)一律不支持 —— 否则前缀
+  // 白名单会放行它,而原样转发的 ctx.url 会被规范化上游解析成越权路径,借 Cindy 凭证打任意 API。
+  if (pathnameHasDotSegments(pathname)) {
+    return externalErrorDecision(404, 'unsupported_path', '对外 Anthropic 代理不支持该路径。');
+  }
   if (ctx.method.toUpperCase() === 'GET' && /\/v1\/models\/?$/.test(pathname)) {
     return {
       localHandler: async ({ res }) => {

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -2163,7 +2163,12 @@ function requestPathname(url: string): string {
   return (q === -1 ? url : url.slice(0, q)).toLowerCase();
 }
 
-/** 从 `Authorization` 头取 Bearer token(大小写不敏感,去 "Bearer " 前缀);缺失 → ''。 */
+/**
+ * 从 `Authorization` 头取 Bearer token(大小写不敏感,去 "Bearer " 前缀);缺失 → ''。
+ * ⚠ 非 Bearer 方案(如 `Basic xxx`)一律视为「未提供 token」返回 '' —— 绝不回落原值:否则
+ *   `!externalToken` 有界拒绝判定会被一个随手伪造的 `Authorization: Basic xxx` 骗过(原值非空
+ *   → 判为「带了 token」→ 跳过 external_token_required 闸)(#1666 review)。
+ */
 function bearerToken(headers: Readonly<Record<string, string>>): string {
   const raw = headerValue(headers, 'authorization');
   if (!raw) return '';
@@ -2518,16 +2523,27 @@ export function createModelRoutingTransform(
       requestModel;
     const threadId = selectedThreadIdFromHeaders(ctx.headers);
     const sessionId = sessionIdFromHeaders(ctx.headers);
-    // 有界拒绝(P1):对外访问开启时,这个 codex loopback 端口被公布给外部 CLI。走到这里的请求
-    // 上面既没命中本族对外 token、又不带 `cindy-local-` 前缀(否则已 401)、又解析不出会话、又完全
-    // 不带 Authorization bearer —— 它不是 Cindy 自家 codex 子进程(任何 spawn 模式下子进程都揣着
-    // env_key / OAuth bearer,GET /models 轮询也带),而是本机某个直接打对外端口、连 token 都省了的
-    // 匿名客户端。放行会让带 model 的请求经下方 decideCodexRoute 白嫖 Cindy 的网关 key。故 401。
-    // ⚠ 有界修复:存心伪造一个假 Authorization bearer 的本机进程仍能溜过(loopback 非鉴权边界,且伪造
-    //   bearer 与内部子进程的真实凭证 bearer 无法区分);彻底隔离需把对外监听与内部子进程代理拆到不同
-    //   端口。未开启对外访问时不启用此闸,内部流量字节级不变。
-    // 置于 collab-spawn 分支之前:合法 collab spawn 必带 thread-id,不会走到这个匿名闸。
-    if (isCodexExternalAccessEnabled() && !sessionId && !externalToken) {
+    // 内部身份信号:任何 Cindy 自家 codex 子进程的请求都带 thread-id / x-client-request-id 头
+    //(缺失才是 'unknown'),即便 threadToSession 还没在注册时序窗口内把它绑上 session 也带着它。
+    // 这与 anthropic 侧靠 x-claude-code-session-id 区分内外同构 —— 光「带了个 bearer」不算内部身份。
+    const hasInternalCodexIdentity = threadId !== 'unknown';
+    // 有界拒绝(P1):对外访问开启时,这个 codex loopback 端口被公布给外部 CLI。走到这里的请求上面
+    // 既没命中本族对外 token、又不带 `cindy-local-` 前缀(否则已 401)、又解析不出会话、又不带内部
+    // thread-id 身份头 —— 它不是 Cindy 自家 codex 子进程,而是本机某个直接打对外端口的客户端。
+    //   · 带 model:放行会经下方 decideCodexRoute(oauth-bearer + codex/* + gatewayKey)白嫖 Cindy 的
+    //     网关 key —— 这是 #1666 review 指出的真实泄漏点,故一律 401。⚠ 关键修复:不再把「带了个
+    //     bearer」当内部豁免;伪造一个非本族 `Bearer anything` 既不能冒充内部,也不能让对外 token 变可选。
+    //   · 无 model:控制面请求(如 codex models-manager 的 `GET /models` 轮询)。带 bearer 的它经 ③ 段
+    //     只 override 上游、透传其自带 bearer(不注入 Cindy 网关 key/凭证),不泄漏,故仅在「连 bearer
+    //     都没有」的纯匿名态才拦,避免误伤无 thread-id 头的内部轮询。
+    // ⚠ 残留:存心伪造一个假 thread-id 身份头的本机进程仍能溜过(loopback 非鉴权边界,与 anthropic 侧
+    //   伪造会话头同权衡);彻底隔离需把对外监听与内部子进程代理拆到不同端口。未开启对外时不启用此闸。
+    if (
+      isCodexExternalAccessEnabled()
+      && !sessionId
+      && !hasInternalCodexIdentity
+      && (Boolean(model) || !externalToken)
+    ) {
       return externalOpenAIError(401, 'external_token_required', 'Cindy 对外模型代理需要有效的访问 token。');
     }
     if (!sessionId && isCollabSpawnRequest(ctx.headers)) {

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -113,6 +113,13 @@ const _controlPlaneStartPromises = new Map<CodexProxyAuthInjection, Promise<void
 let _disposeGeneration = 0;
 let dumpSeq = 0;
 
+// 对外(B 族 = Codex/OpenAI)loopback 代理:与内部 _handle 分处**不同端口**(#1666 Finding 2 端口
+// 拆分)。绑用户在设置里固定的 codexPort,只挂 createExternalCodexRoutingTransform(无条件要求命中
+// 不可伪造的 B 族对外 token)。_externalStartPromise 做并发去重,避免 boot 与 set-codex-enabled 同时
+// 拉起两个。内部 _handle 回到加对外功能前的行为(随机端口、不承担任何对外判定)。
+let _externalHandle: ProxyHandle | null = null;
+let _externalStartPromise: Promise<void> | null = null;
+
 const CODEX_RESPONSE_OBSERVER_MAX_BYTES = 2 * 1024 * 1024;
 
 const encryptedContentRecoveryRule = createEncryptedContentRecoveryRule({
@@ -2317,7 +2324,10 @@ function externalChatCompletionsDecision(externalToken: string): RoutingDecision
         writeExternalOpenAIError(res, 400, 'invalid_request', 'chat completions 请求缺少 messages。');
         return;
       }
-      const proxyUrl = getCodexProxyUrl();
+      // 自环 re-POST 必须打**对外**端口自己的 `/responses`:那条路由挂 createExternalCodexRoutingTransform,
+      // 会用 B 族 token 命中 → routeExternalCodexClient 的 responses 分派(单一事实源)。内部端口(_handle)
+      // 端口拆分后已不再认对外 token,打它会落到内部路由 → 误路由/凭证误用。
+      const proxyUrl = getCodexExternalProxyUrl();
       if (!proxyUrl) {
         writeExternalOpenAIError(res, 503, 'proxy_unavailable', 'Cindy Codex proxy 尚未就绪。');
         return;
@@ -2496,23 +2506,41 @@ function routeExternalCodexClient(
   return externalOpenAIError(400, 'unsupported_request', '不支持的外部请求。');
 }
 
-export function createModelRoutingTransform(
-  frozenAuthInjection?: CodexProxyAuthInjection,
-): RoutingTransform {
+/**
+ * 对外端口专用路由 transform(端口拆分,#1666 Finding 2)。绑在**独立的对外 loopback 端口**上
+ * (见 ensureCodexExternalProxyReady),只服务用户自己的 Codex / OpenAI CLI:
+ *   - `Authorization: Bearer` 命中 B 族对外 token → routeExternalCodexClient(GET /models 发现、
+ *     POST /responses 按模型解析、POST /v1/chat/completions 自环)。命中判定与 codexEnabled 无关;
+ *     enabled 与否由 routeExternalCodexClient 内决定放行 / 401。
+ *   - 带 `cindy-local-` 前缀但不命中(已重置 / 跨族拿 A 族 token 打 B 族 loopback / 已失效)→ 401
+ *     invalid_external_token,绝不把它当 Authorization 透传上游。
+ *   - 其余(无 token / 伪造任意 header)→ 401 external_token_required。
+ * **无 thread-id / session 启发式、无内部默认路由回落**——放行的唯一条件是命中不可伪造的对外 token,
+ * 因此在此端口上伪造 thread-id / x-client-request-id 毫无作用(彻底消除 Finding 2 的可伪造绕过面)。
+ * export 供单测。
+ */
+export function createExternalCodexRoutingTransform(): RoutingTransform {
   return (body, ctx) => {
-    // ⓪ 对外模型代理:`Authorization: Bearer` 命中已存对外 token → 外部客户端,走独立无会话分支。
-    //    放在最前:优先级高于 per-session / spawn 默认路由。命中判定与 enabled 无关(matchesCodexExternalToken
-    //    只比 B 族 token),enabled 与否在 routeExternalCodexClient 内决定放行/401。未命中(Cindy 自家 codex
-    //    子进程 / 无 token)→ 落到下方现有逻辑,字节级不变。
     const externalToken = bearerToken(ctx.headers);
     if (externalToken && matchesCodexExternalToken(externalToken)) {
       return routeExternalCodexClient(body, ctx, externalToken);
     }
-    // 带 `cindy-local-` 前缀但不命中本族 token(已重置 / 跨族拿 A 族 token 打 B 族 loopback /
-    // 已失效)→ 明确 401,绝不落到下方内部路由把这个对外 token 当 Authorization 透传上游。
     if (externalToken && isCindyLocalToken(externalToken)) {
       return externalOpenAIError(401, 'invalid_external_token', 'Cindy 对外访问 token 无效或已失效。');
     }
+    return externalOpenAIError(401, 'external_token_required', 'Cindy 对外模型代理需要有效的访问 token。');
+  };
+}
+
+export function createModelRoutingTransform(
+  frozenAuthInjection?: CodexProxyAuthInjection,
+): RoutingTransform {
+  return (body, ctx) => {
+    // 本 transform 只服务 Cindy 自家内部流量(codex 子进程 / collab spawn / 控制面)。对外客户端
+    //(用户自己的 Codex / OpenAI CLI)走**独立的对外 loopback 端口**,由 createExternalCodexRoutingTransform
+    // 处理——那条路径无条件要求命中不可伪造的 B 族对外 token,绝不落到这里。端口拆分见
+    // ensureCodexExternalProxyReady(#1666 Finding 2:同端口上的 thread-id / session 启发式可被本机进程
+    // 伪造绕过 → 白嫖网关 key;拆端口后此 transform 不再承担任何对外判定)。
     // body 可能为 undefined —— 无 body 的 GET(典型: codex models-manager 的 `GET /models` 轮询,
     // 引擎现在也会对它跑路由)。不再因 body 非对象就短路;会话解析只依赖 headers,model 字段可选。
     const gatewayKey = _readGatewayKey();
@@ -2523,38 +2551,6 @@ export function createModelRoutingTransform(
       requestModel;
     const threadId = selectedThreadIdFromHeaders(ctx.headers);
     const sessionId = sessionIdFromHeaders(ctx.headers);
-    // 内部身份信号:任何 Cindy 自家 codex 子进程的请求都带 thread-id / x-client-request-id 头
-    //(缺失才是 'unknown'),即便 threadToSession 还没在注册时序窗口内把它绑上 session 也带着它。
-    // 这与 anthropic 侧靠 x-claude-code-session-id 区分内外同构 —— 光「带了个 bearer」不算内部身份。
-    // 注:collab spawn(x-openai-subagent=collab-spawn)也带 thread-id,故 hasInternalCodexIdentity 为真,
-    // 会跳过下方 401 闸,落到再下方的 collab-spawn 分支 —— 内部协同 spawn 不受对外闸影响。
-    const hasInternalCodexIdentity = threadId !== 'unknown';
-    // 有界拒绝(P1):对外访问开启时,这个 codex loopback 端口被公布给外部 CLI。走到这里的请求上面
-    // 既没命中本族对外 token(否则已在 ⓪ 段被 routeExternalCodexClient 接走)、又不带 `cindy-local-`
-    // 前缀(否则已 401)、又解析不出会话、又不带内部 thread-id / x-client-request-id 身份头 —— 它不是
-    // Cindy 自家 codex 子进程,而是本机某个直接打对外端口的客户端。一律 401(带不带 model、带不带
-    // 伪造 bearer 都拦):
-    //   · 带 model:放行会经下方 decideCodexRoute(oauth-bearer + codex/* + gatewayKey)白嫖 Cindy 网关 key。
-    //   · 无 model(控制面,如 codex models-manager 的 `GET /models` 轮询):放行会经下方桶③,在
-    //     provider-oauth 态经 resolveProviderOAuthControlRouteDecision 把 Cindy 的供应商 OAuth token 注入
-    //     上游 —— 未鉴权者借 Cindy 凭证打供应商 /models,使对外 token 形同虚设(#1666 review 二轮 Finding H)。
-    // ⚠ 关键:内部身份只认 thread-id / x-client-request-id 头,绝不把「带了个 bearer」当豁免 —— 伪造一个
-    //   非本族 `Bearer anything` 既冒充不了内部,也不能让对外 token 变可选。合法外部客户端的 /models 由
-    //   ⓪ 段 routeExternalCodexClient 用本族 token 命中后从 Cindy catalog 返回,根本不依赖桶③,故这里
-    //   收紧不影响它。代价:对外开启期间,内部无 thread-id 的控制面轮询也一并被拦(与本就被拦的匿名
-    //   轮询同权衡;Cindy 自有 catalog,退化有界)。
-    // ⚠ 残留:存心伪造一个假 thread-id 身份头的本机进程仍能溜过(loopback 非鉴权边界,与 anthropic 侧
-    //   伪造会话头同权衡);彻底隔离需把对外监听与内部子进程代理拆到不同端口。未开启对外时不启用此闸,
-    //   内部无 thread-id 的控制面轮询照旧走桶③。
-    // 置于 collab-spawn 分支之前:合法 collab spawn 必带 thread-id(hasInternalCodexIdentity 为真)会跳过
-    // 本闸;而伪造 collab-spawn 头却不带 thread-id 的对外客户端会被这里 401,不至于蹭到下方 collab 分支。
-    if (
-      isCodexExternalAccessEnabled()
-      && !sessionId
-      && !hasInternalCodexIdentity
-    ) {
-      return externalOpenAIError(401, 'external_token_required', 'Cindy 对外模型代理需要有效的访问 token。');
-    }
     if (!sessionId && isCollabSpawnRequest(ctx.headers)) {
       return unresolvedCollabSpawnRouteDecision();
     }
@@ -2793,6 +2789,7 @@ export function withCodexUpstreamRecording(
 function createCodexProxyHandle(
   frozenAuthInjection?: CodexProxyAuthInjection,
   port?: number,
+  external = false,
 ): Promise<ProxyHandle> {
   return createAnthropicCompatProxy({
     // 对外模型代理:给定固定端口(仅 loopback)时绑它,让外部 CLI 的 OPENAI_BASE_URL 稳定;
@@ -2801,10 +2798,11 @@ function createCodexProxyHandle(
     // 默认上游 = gateway(含 /v1)；普通模型 + oauth 由 routingTransform 覆盖到 ChatGPT。
     upstream: () => buildCodexGatewayBaseUrl(),
     transformRequest: createTransformRequestChain(frozenAuthInjection),
-    // 常规 session proxy 继续读取当前全局 spawn 形态；control-plane proxy 在创建时
-    // 冻结自己的形态，两个 app-server 并行时不会互相改写路由。
+    // external=true:对外端口,只认 B 族对外 token 的独立路由(createExternalCodexRoutingTransform),
+    // 绝不回落内部默认路由/网关 key。external=false:常规 session proxy 读当前全局 spawn 形态;
+    // control-plane proxy 在创建时冻结自己的形态,两个 app-server 并行时不会互相改写路由。
     routingTransform: withCodexUpstreamRecording(
-      createModelRoutingTransform(frozenAuthInjection),
+      external ? createExternalCodexRoutingTransform() : createModelRoutingTransform(frozenAuthInjection),
       () => buildCodexGatewayBaseUrl(),
     ),
     responseObserver: composeResponseObservers(
@@ -2860,7 +2858,10 @@ function createCodexProxyHandle(
 }
 
 /**
- * 启动本地 Codex prompt proxy。幂等 —— 重复调用直接返回已缓存状态。
+ * 启动**内部** Codex prompt proxy(codex 子进程 / collab spawn / 控制面用)。幂等 —— 重复调用直接
+ * 返回已缓存状态。绑**随机端口**(不对用户公布;端口在 spawn 时经 env 注入给子进程)。对外访问是
+ * **独立** handle,绑固定 codexPort,见 ensureCodexExternalProxyReady —— 端口拆分(#1666 Finding 2)后
+ * 内部端口不再承担任何对外判定。
  *
  * `_startPromise` 去重并发启动;`_handle` 为空时 getCodexProxyEndpoint()
  * 直接 fallback 到真上游 URL。
@@ -2872,30 +2873,7 @@ export async function ensureCodexProxyReady(): Promise<void> {
   const generation = _disposeGeneration;
   _startPromise = (async () => {
     try {
-      // 对外模型代理端口策略(与 anthropic host 同):用户开启对外服务时捕获并持久化 codexPort;
-      // 持久化了(>0)就固定绑,固定端口不可用则 fallback 随机并回写实际值,避免下次又撞同一个坏
-      // 端口。三类可 fallback:被占用(EADDRINUSE)/ 无权限(EACCES)/ 落在 Fetch 屏蔽端口(包内
-      // 直接抛,SDK 连不上)。其它错误照抛给外层兜底。
-      const pinnedPort = loadLocalProxySettings().codexPort;
-      let handle: ProxyHandle;
-      try {
-        handle = await createCodexProxyHandle(undefined, pinnedPort > 0 ? pinnedPort : undefined);
-      } catch (bindErr) {
-        const code = (bindErr as NodeJS.ErrnoException | undefined)?.code;
-        const fetchBlocked = isFetchBlockedPort(pinnedPort);
-        if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES' || fetchBlocked)) {
-          log.error('固定的 codex 对外代理端口不可用,fallback 随机端口', {
-            pinnedPort,
-            code,
-            fetchBlocked,
-          });
-          handle = await createCodexProxyHandle();
-          const actual = codexPortFromProxyUrl(handle.url);
-          if (actual) setLocalProxyCodexPort(actual);
-        } else {
-          throw bindErr;
-        }
-      }
+      const handle = await createCodexProxyHandle();
       if (generation !== _disposeGeneration) {
         await handle.dispose().catch((err) => {
           log.warn('codex proxy start raced with dispose; disposing fresh handle failed', {
@@ -3011,21 +2989,111 @@ export function codexPortFromProxyUrl(url: string): number | null {
 }
 
 /**
- * codex loopback proxy 当前的实际 url —— **不回落远程网关**(与 getCodexProxyEndpoint 相反)。
- * 供 IPC get-state 展示 127.0.0.1 地址,以及 chat-completions 自环 re-POST 用。未就绪返回 null。
+ * **内部** codex loopback proxy 当前的实际 url —— **不回落远程网关**(与 getCodexProxyEndpoint
+ * 相反)。供内部重启 / 诊断用。未就绪返回 null。对外展示 / 自环请用 getCodexExternalProxyUrl。
  */
 export function getCodexProxyUrl(): string | null {
   return _handle?.url ?? null;
 }
 
 /**
- * 重建 codex proxy 以让新的固定端口生效(用户在设置里改端口后调用)。会中断当前经代理的内部
- * codex in-flight 请求 —— 仅在用户显式改端口时用,不做常态调用。返回重建后的实际 url。
+ * 重建**内部** codex proxy 以让新配置生效。会中断当前经代理的内部 codex in-flight 请求 —— 仅在
+ * 显式需要时用,不做常态调用。返回重建后的实际 url。
  */
 export async function restartCodexProxy(): Promise<string | null> {
   await disposeCodexProxy();
   await ensureCodexProxyReady();
   return getCodexProxyUrl();
+}
+
+/**
+ * 启动**对外**(B 族 = Codex/OpenAI)loopback 代理(给用户自己电脑上的 Codex / OpenAI CLI 用)。
+ * 只在用户开启 B 族对外访问时由 IPC / boot 拉起。端口策略:绑持久化的固定 codexPort
+ * (loadLocalProxySettings().codexPort),让外部 CLI 的 OPENAI_BASE_URL 稳定;端口被占用
+ * (EADDRINUSE / EACCES / 落在 Fetch 屏蔽端口)则 fallback 随机并回写新端口(UI 始终显示实际 url)。
+ * 并发去重(_externalStartPromise),启动失败不抛 —— getCodexExternalProxyUrl() 保持 null。
+ */
+export async function ensureCodexExternalProxyReady(): Promise<void> {
+  if (_externalHandle) return;
+  if (_externalStartPromise) return _externalStartPromise;
+  _externalStartPromise = (async () => {
+    const pinnedPort = loadLocalProxySettings().codexPort;
+    try {
+      try {
+        _externalHandle = await createCodexProxyHandle(
+          undefined,
+          pinnedPort > 0 ? pinnedPort : undefined,
+          true,
+        );
+      } catch (bindErr) {
+        // 固定端口不可用时 fallback 随机端口重试,并把持久化端口回写成实际绑定值,避免下次启动
+        // 又撞同一个坏端口。三类可 fallback:被占用(EADDRINUSE)/ 无权限(EACCES)/ 落在 Fetch
+        // 屏蔽端口(包内直接抛,SDK 连不上)。其它错误照抛给外层兜底。
+        const code = (bindErr as NodeJS.ErrnoException | undefined)?.code;
+        const fetchBlocked = isFetchBlockedPort(pinnedPort);
+        if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES' || fetchBlocked)) {
+          log.error('固定的 codex 对外代理端口不可用,fallback 随机端口', { pinnedPort, code, fetchBlocked });
+          _externalHandle = await createCodexProxyHandle(undefined, undefined, true);
+          const actual = codexPortFromProxyUrl(_externalHandle.url);
+          if (actual) setLocalProxyCodexPort(actual);
+        } else {
+          throw bindErr;
+        }
+      }
+      log.info('codex external proxy ready', { url: _externalHandle.url });
+    } catch (err) {
+      _externalHandle = null;
+      log.error('codex external proxy failed to start', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      _externalStartPromise = null;
+    }
+  })();
+  return _externalStartPromise;
+}
+
+/**
+ * **对外** codex 代理当前 url;供 IPC get-state / copy / preview / write 展示给外部 CLI 的
+ * 127.0.0.1 地址与端口,以及 chat-completions 自环 re-POST 用。只有开启了 B 族对外访问并
+ * ensureCodexExternalProxyReady 成功后才非 null;未就绪返回 null。
+ */
+export function getCodexExternalProxyUrl(): string | null {
+  return _externalHandle?.url ?? null;
+}
+
+/**
+ * 重建**对外** codex 代理以让新的固定端口生效(用户在设置里改端口后调用)。返回重建后的实际 url。
+ * 会中断当前经对外代理的 in-flight 请求 —— 仅在用户显式改端口时用。
+ */
+export async function restartCodexExternalProxy(): Promise<string | null> {
+  await disposeCodexExternalProxy();
+  await ensureCodexExternalProxyReady();
+  return getCodexExternalProxyUrl();
+}
+
+/**
+ * 优雅关闭**对外** codex 代理(关闭 B 族对外访问 / 改端口 / 退出时)。先等待 in-flight 的启动去重
+ * Promise 结算,避免与并发的 ensure 抢 _externalHandle。
+ */
+export async function disposeCodexExternalProxy(): Promise<void> {
+  if (_externalStartPromise) {
+    try {
+      await _externalStartPromise;
+    } catch {
+      // 启动失败已在 ensure 内部记日志;这里只是确保不在启动中途 dispose。
+    }
+  }
+  if (!_externalHandle) return;
+  const h = _externalHandle;
+  _externalHandle = null;
+  try {
+    await h.dispose();
+  } catch (err) {
+    log.warn('codex external proxy dispose failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -33,7 +33,10 @@ import {
 } from '@cindy/anthropic-compat-proxy';
 import {
   createResponsesChatHandler,
+  translateChatToResponsesRequest,
+  ResponsesSseToChatTranslator,
   type ChatBridgeCapabilities,
+  type ChatCompletionsRequest,
 } from '@cindy/responses-chat-bridge';
 import { createResponsesAnthropicHandler } from '@cindy/responses-anthropic-bridge';
 import { createHash, randomUUID } from 'node:crypto';
@@ -60,7 +63,17 @@ import {
   resolveProviderOAuthControlRouteDecision,
   rewriteImplicitModelIdForRoute,
   rewriteSessionModelIdForRoute,
+  resolveExternalCodexRoute,
+  buildRouteDecision,
 } from './provider-route.js';
+import {
+  isCodexExternalAccessEnabled,
+  matchesCodexExternalToken,
+} from './local-proxy-external-auth.js';
+import {
+  loadLocalProxySettings,
+  setLocalProxyCodexPort,
+} from './local-proxy-settings-store.js';
 import { getSessionProvider } from './session-provider-store.js';
 import { composeResponseObservers } from './claude-rate-limit-headers-observer.js';
 import { createProviderUpstreamErrorObserver, reportProviderUpstreamError } from './provider-upstream-error-observer.js';
@@ -2131,10 +2144,336 @@ export function decideCodexRoute(opts: {
   return { upstreamOverride: CODEX_OAUTH_UPSTREAM };
 }
 
+// ───────── 对外模型代理:Codex / 通用 OpenAI 客户端(external client)─────────
+// 用户自己的 Codex CLI(说 OpenAI Responses,打 `POST /responses`)或通用 OpenAI 工具(说 Chat
+// Completions,打 `POST /v1/chat/completions`)把 base_url 指向本 codex loopback、`Authorization:
+// Bearer` 设为 Cindy 生成的对外 token 时,这些请求没有 Cindy session。它们靠 Bearer 命中已存对外
+// token(matchesCodexExternalToken 只比值,B 族独立 token)被识别为「外部客户端」,走一条独立、无会话、按模型名/对外默认
+// 供应商的路由分支。
+//
+// 红线:codex 外部分支**只返回显式决策或错误 localHandler,绝不返回 null** —— 返回 null 会掉进
+// codex 默认网关转发、带着外部 token 透传上游 = 凭证泄漏/误计费。
+
+/** 从 ctx.url(可能带 query)取纯 path,小写化便于匹配。 */
+function requestPathname(url: string): string {
+  const q = url.indexOf('?');
+  return (q === -1 ? url : url.slice(0, q)).toLowerCase();
+}
+
+/** 从 `Authorization` 头取 Bearer token(大小写不敏感,去 "Bearer " 前缀);缺失 → ''。 */
+function bearerToken(headers: Readonly<Record<string, string>>): string {
+  const raw = headerValue(headers, 'authorization');
+  if (!raw) return '';
+  const m = /^bearer\s+(.+)$/i.exec(raw);
+  return m ? m[1].trim() : raw;
+}
+
+/** 外部分支统一的 OpenAI 错误信封(localHandler 完全接管,不转发上游)。 */
+function externalOpenAIError(status: number, code: string, message: string): RoutingDecision {
+  return {
+    localHandler: async ({ res }) => {
+      const payload = JSON.stringify({
+        error: {
+          message,
+          type: status === 401 || status === 403 ? 'authentication_error' : 'invalid_request_error',
+          code,
+        },
+      });
+      res.writeHead(status, {
+        'content-type': 'application/json; charset=utf-8',
+        'cache-control': 'no-store',
+      });
+      res.end(payload);
+    },
+  };
+}
+
+/** localHandler 内直接写 OpenAI 错误(响应头未发出时用)。 */
+function writeExternalOpenAIError(
+  res: import('node:http').ServerResponse,
+  status: number,
+  code: string,
+  message: string,
+): void {
+  const payload = JSON.stringify({
+    error: {
+      message,
+      type: status === 401 || status === 403 ? 'authentication_error' : 'invalid_request_error',
+      code,
+    },
+  });
+  res.writeHead(status, {
+    'content-type': 'application/json; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  res.end(payload);
+}
+
+/**
+ * 转发上游前从外部请求剥掉它自带的 `Authorization` 外部 token 头,防止透传上游。
+ * headerDelete 在 headerOverride **之后**应用 —— 决策已 override authorization(注入真实凭证)
+ * 时不能再 delete(否则净删真凭证);仅对决策没覆盖 authorization 的情况追加 delete →
+ * fail-closed(上游 401),不泄漏。
+ */
+function stripExternalTokenHeadersCodex(decision: RoutingDecision | null): RoutingDecision | null {
+  if (!decision || decision.localHandler) return decision;
+  const overridden = new Set(
+    Object.keys(decision.headerOverride ?? {}).map((k) => k.toLowerCase()),
+  );
+  if (overridden.has('authorization')) return decision;
+  return {
+    ...decision,
+    headerDelete: [...new Set([...(decision.headerDelete ?? []), 'authorization'])],
+  };
+}
+
+/**
+ * 构造 `GET /models` / `/v1/models` 的 OpenAI 形状清单:外部 CLI 用它发现可用模型。
+ * 取「codex agent 可路由」供应商并集里的模型,按 id 去重。不含任何凭证 / 上游地址。
+ */
+function buildExternalOpenAIModelsPayload(): string {
+  const seen = new Set<string>();
+  const data: { id: string; object: 'model'; created: number; owned_by: string }[] = [];
+  for (const provider of getActiveCatalog().providers) {
+    if (!provider.agents.includes('codex')) continue;
+    const routing = provider.routing.codex;
+    if (!routing || routing.disabled) continue;
+    for (const model of provider.models.codex ?? []) {
+      if (!model.id || seen.has(model.id)) continue;
+      seen.add(model.id);
+      data.push({ id: model.id, object: 'model', created: 0, owned_by: provider.id });
+    }
+  }
+  return JSON.stringify({ object: 'list', data });
+}
+
+/**
+ * 外部 Codex 客户端 `POST /responses` 的路由决策。按模型名解析供应商('codex' agent) → 依
+ * `routing.wireProtocol` 分派:
+ *   - openai-chat / anthropic-messages → 复用 `createLocalBridgeDecision`(无会话:instructions
+ *     省略、synthetic threadId 'external');
+ *   - openai-responses / 其它 → `buildRouteDecision` 注入真实凭证 + strip 外部 token 头。
+ * 解析不出供应商 → 400(不回落默认网关)。**任何分支都不返回 null。**
+ */
+async function resolveExternalCodexResponsesDecision(body: unknown): Promise<RoutingDecision> {
+  if (!isPlainObject(body)) {
+    return externalOpenAIError(400, 'unsupported_request', '不支持的外部请求。');
+  }
+  const wireModel = typeof body.model === 'string' ? body.model : '';
+  const defaultProviderId = loadLocalProxySettings().codexDefaultProviderId;
+  const route = await resolveExternalCodexRoute(wireModel, defaultProviderId);
+  if (!route) {
+    return externalOpenAIError(
+      400,
+      'no_provider_for_model',
+      `没有可路由「${wireModel || '(未指定)'}」的供应商;请在 Cindy 设置里选择对外默认供应商(Codex),或换用某供应商的模型 id。`,
+    );
+  }
+  const wire = route.routing.wireProtocol;
+  if (wire === 'openai-chat' || wire === 'anthropic-messages') {
+    const decision = createLocalBridgeDecision(route, undefined, wireModel, undefined, 'external');
+    if (decision) return decision;
+    return externalOpenAIError(502, 'bridge_unavailable', `「${wireModel}」的本地桥接不可用。`);
+  }
+  // openai-responses / 其它:透明转发到供应商真上游,注入真实凭证,再 strip 外部 token 头。
+  const gatewayKey = _readGatewayKey();
+  const decision = buildRouteDecision(route.routing, gatewayKey, 'codex', route.apiKey, route.oauthToken);
+  const stripped = stripExternalTokenHeadersCodex(decision);
+  if (stripped) return stripped;
+  return externalOpenAIError(502, 'provider_unavailable', `「${wireModel}」的供应商暂不可用。`);
+}
+
+/**
+ * 通用 OpenAI Chat Completions 端点(自环设计):把外部 chat 请求译成 Responses,POST 到本 codex
+ * loopback 自己的 `/responses`(复用端点 1 的全部路由/分派/头 strip 单一事实源),再把回来的
+ * Responses SSE 经 `ResponsesSseToChatTranslator` 译回 Chat 写给客户端。多一跳 localhost 可忽略。
+ */
+function externalChatCompletionsDecision(externalToken: string): RoutingDecision {
+  return {
+    localHandler: async ({ parsedBody, res }) => {
+      const chatRequest = isPlainObject(parsedBody)
+        ? (parsedBody as unknown as ChatCompletionsRequest)
+        : null;
+      if (!chatRequest || !Array.isArray(chatRequest.messages)) {
+        writeExternalOpenAIError(res, 400, 'invalid_request', 'chat completions 请求缺少 messages。');
+        return;
+      }
+      const proxyUrl = getCodexProxyUrl();
+      if (!proxyUrl) {
+        writeExternalOpenAIError(res, 503, 'proxy_unavailable', 'Cindy Codex proxy 尚未就绪。');
+        return;
+      }
+      const wantStream = chatRequest.stream !== false;
+      const includeUsage =
+        isPlainObject(chatRequest.stream_options)
+        && (chatRequest.stream_options as Record<string, unknown>).include_usage === true;
+      const responsesRequest = translateChatToResponsesRequest(chatRequest, {
+        onDowngrade: (feature) => log.debug('external chat→responses downgrade', { feature }),
+      });
+      // 自环上游总是请求流式(Responses SSE),再按客户端 stream 决定聚合还是逐帧转发。
+      responsesRequest.stream = true;
+      const abort = new AbortController();
+      const abortUpstream = (): void => abort.abort();
+      res.once('close', abortUpstream);
+
+      let upstream: Response;
+      try {
+        upstream = await outboundFetch(`${proxyUrl.replace(/\/$/, '')}/responses`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'text/event-stream',
+            authorization: `Bearer ${externalToken}`,
+          },
+          body: JSON.stringify(responsesRequest),
+          signal: abort.signal,
+        });
+      } catch (err) {
+        res.off('close', abortUpstream);
+        if (abort.signal.aborted) return;
+        writeExternalOpenAIError(res, 502, 'upstream_unreachable', 'Cindy Responses 端点不可达。');
+        return;
+      }
+
+      const translator = new ResponsesSseToChatTranslator({ model: chatRequest.model, includeUsage });
+      if (!upstream.ok || !upstream.body) {
+        res.off('close', abortUpstream);
+        let detail = `上游返回 HTTP ${upstream.status}`;
+        try {
+          const text = await upstream.text();
+          if (text) detail = text.slice(0, 2000);
+        } catch {
+          /* ignore */
+        }
+        writeExternalOpenAIError(res, upstream.status || 502, 'upstream_error', detail);
+        return;
+      }
+
+      const MAX_SSE_BUFFER_CHARS = 8 * 1024 * 1024;
+      const writeChunk = (chunk: Record<string, unknown>): void => {
+        if (wantStream) res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+      };
+      const parsePayload = (payload: string): void => {
+        if (!payload || payload === '[DONE]') return;
+        let event: unknown;
+        try {
+          event = JSON.parse(payload);
+        } catch {
+          return;
+        }
+        if (isPlainObject(event)) {
+          for (const chunk of translator.push(event)) writeChunk(chunk);
+        }
+      };
+
+      if (wantStream) {
+        res.writeHead(200, {
+          'content-type': 'text/event-stream; charset=utf-8',
+          'cache-control': 'no-cache',
+          connection: 'keep-alive',
+        });
+      }
+
+      const reader = upstream.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let streamFailed = false;
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          if (buffer.length > MAX_SSE_BUFFER_CHARS) {
+            throw new Error('responses SSE buffer overflow');
+          }
+          let nl: number;
+          while ((nl = buffer.indexOf('\n')) >= 0) {
+            const line = buffer.slice(0, nl).replace(/\r$/, '');
+            buffer = buffer.slice(nl + 1);
+            if (line.startsWith('data:')) parsePayload(line.slice(5).trim());
+          }
+        }
+        buffer += decoder.decode();
+        for (const line of buffer.split(/\r?\n/)) {
+          if (line.startsWith('data:')) parsePayload(line.slice(5).trim());
+        }
+      } catch (err) {
+        if (!abort.signal.aborted) {
+          streamFailed = true;
+          const message = err instanceof Error ? err.message : String(err);
+          for (const chunk of translator.fail(message)) writeChunk(chunk);
+        }
+      } finally {
+        res.off('close', abortUpstream);
+        if (abort.signal.aborted) {
+          if (!res.writableEnded) res.end();
+        } else if (wantStream) {
+          if (!streamFailed) {
+            for (const chunk of translator.finish()) writeChunk(chunk);
+          }
+          res.write('data: [DONE]\n\n');
+          res.end();
+        } else if (streamFailed) {
+          writeExternalOpenAIError(res, 502, 'upstream_error', 'Cindy Responses 流式中断。');
+        } else {
+          res.writeHead(200, {
+            'content-type': 'application/json; charset=utf-8',
+            'cache-control': 'no-store',
+          });
+          res.end(JSON.stringify(translator.aggregate()));
+        }
+      }
+    },
+  };
+}
+
+/**
+ * 外部客户端(Bearer 命中对外 token)的路由分发。**先判 enabled**:未开启 → 401(即使 token 还在
+ * 也拒绝,防关了开关旧 token 还能用)。`GET /models`|`/v1/models` → 本地吐清单;`POST /responses`
+ * → 按模型解析供应商;`POST /v1/chat/completions` → 自环 chat 端点;其余 → 400。**永不返回 null。**
+ */
+function routeExternalCodexClient(
+  body: unknown,
+  ctx: RequestTransformCtx,
+  externalToken: string,
+): RoutingDecision | Promise<RoutingDecision> {
+  if (!isCodexExternalAccessEnabled()) {
+    return externalOpenAIError(401, 'external_access_disabled', 'Cindy 对外模型代理未开启。');
+  }
+  const pathname = requestPathname(ctx.url);
+  const method = ctx.method.toUpperCase();
+  if (method === 'GET' && /\/(v1\/)?models\/?$/.test(pathname)) {
+    return {
+      localHandler: async ({ res }) => {
+        res.writeHead(200, {
+          'content-type': 'application/json; charset=utf-8',
+          'cache-control': 'no-store',
+        });
+        res.end(buildExternalOpenAIModelsPayload());
+      },
+    };
+  }
+  if (method === 'POST' && /\/(v1\/)?chat\/completions\/?$/.test(pathname)) {
+    return externalChatCompletionsDecision(externalToken);
+  }
+  if (method === 'POST' && /\/(v1\/)?responses\/?$/.test(pathname)) {
+    return resolveExternalCodexResponsesDecision(body);
+  }
+  return externalOpenAIError(400, 'unsupported_request', '不支持的外部请求。');
+}
+
 export function createModelRoutingTransform(
   frozenAuthInjection?: CodexProxyAuthInjection,
 ): RoutingTransform {
   return (body, ctx) => {
+    // ⓪ 对外模型代理:`Authorization: Bearer` 命中已存对外 token → 外部客户端,走独立无会话分支。
+    //    放在最前:优先级高于 per-session / spawn 默认路由。命中判定与 enabled 无关(matchesCodexExternalToken
+    //    只比 B 族 token),enabled 与否在 routeExternalCodexClient 内决定放行/401。未命中(Cindy 自家 codex
+    //    子进程 / 无 token)→ 落到下方现有逻辑,字节级不变。
+    const externalToken = bearerToken(ctx.headers);
+    if (externalToken && matchesCodexExternalToken(externalToken)) {
+      return routeExternalCodexClient(body, ctx, externalToken);
+    }
     // body 可能为 undefined —— 无 body 的 GET(典型: codex models-manager 的 `GET /models` 轮询,
     // 引擎现在也会对它跑路由)。不再因 body 非对象就短路;会话解析只依赖 headers,model 字段可选。
     const gatewayKey = _readGatewayKey();
@@ -2382,8 +2721,12 @@ export function withCodexUpstreamRecording(
 
 function createCodexProxyHandle(
   frozenAuthInjection?: CodexProxyAuthInjection,
+  port?: number,
 ): Promise<ProxyHandle> {
   return createAnthropicCompatProxy({
+    // 对外模型代理:给定固定端口(仅 loopback)时绑它,让外部 CLI 的 OPENAI_BASE_URL 稳定;
+    // 省略 = 随机端口(内部 codex 用法,行为不变)。control-plane proxy 永不传 port。
+    ...(port && port > 0 ? { port } : {}),
     // 默认上游 = gateway(含 /v1)；普通模型 + oauth 由 routingTransform 覆盖到 ChatGPT。
     upstream: () => buildCodexGatewayBaseUrl(),
     transformRequest: createTransformRequestChain(frozenAuthInjection),
@@ -2458,7 +2801,24 @@ export async function ensureCodexProxyReady(): Promise<void> {
   const generation = _disposeGeneration;
   _startPromise = (async () => {
     try {
-      const handle = await createCodexProxyHandle();
+      // 对外模型代理端口策略(与 anthropic host 同):用户开启对外服务时捕获并持久化 codexPort;
+      // 持久化了(>0)就固定绑,固定端口被占用(EADDRINUSE)/无权限(EACCES)则 fallback 随机
+      // 并回写实际值,避免下次又撞同一个占用端口。其它错误照抛给外层兜底。
+      const pinnedPort = loadLocalProxySettings().codexPort;
+      let handle: ProxyHandle;
+      try {
+        handle = await createCodexProxyHandle(undefined, pinnedPort > 0 ? pinnedPort : undefined);
+      } catch (bindErr) {
+        const code = (bindErr as NodeJS.ErrnoException | undefined)?.code;
+        if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES')) {
+          log.error('固定的 codex 对外代理端口不可用,fallback 随机端口', { pinnedPort, code });
+          handle = await createCodexProxyHandle();
+          const actual = codexPortFromProxyUrl(handle.url);
+          if (actual) setLocalProxyCodexPort(actual);
+        } else {
+          throw bindErr;
+        }
+      }
       if (generation !== _disposeGeneration) {
         await handle.dispose().catch((err) => {
           log.warn('codex proxy start raced with dispose; disposing fresh handle failed', {
@@ -2561,6 +2921,34 @@ export function getCodexProxyEndpoint(): string {
   const fallbackEndpoint = buildCodexGatewayBaseUrl();
   log.warn('codex proxy not ready, falling back to direct gateway', { fallbackEndpoint });
   return fallbackEndpoint;
+}
+
+/** 从 loopback proxy url(`http://127.0.0.1:<port>`)取端口;解析失败返回 null。 */
+export function codexPortFromProxyUrl(url: string): number | null {
+  try {
+    const port = Number.parseInt(new URL(url).port, 10);
+    return Number.isInteger(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * codex loopback proxy 当前的实际 url —— **不回落远程网关**(与 getCodexProxyEndpoint 相反)。
+ * 供 IPC get-state 展示 127.0.0.1 地址,以及 chat-completions 自环 re-POST 用。未就绪返回 null。
+ */
+export function getCodexProxyUrl(): string | null {
+  return _handle?.url ?? null;
+}
+
+/**
+ * 重建 codex proxy 以让新的固定端口生效(用户在设置里改端口后调用)。会中断当前经代理的内部
+ * codex in-flight 请求 —— 仅在用户显式改端口时用,不做常态调用。返回重建后的实际 url。
+ */
+export async function restartCodexProxy(): Promise<string | null> {
+  await disposeCodexProxy();
+  await ensureCodexProxyReady();
+  return getCodexProxyUrl();
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -2842,6 +2842,15 @@ function createCodexProxyHandle(
      * thread 不预扫描、不降级，继续保留原生 WS 容量体验。
      */
     resolveWebSocketUpstream: ({ headers }) => {
+      // 对外端口(端口拆分,#1666 review):**绝不**提供 WS 上游。WS upgrade 走的是 proxy 的
+      // upgrade 处理,既不过 createExternalCodexRoutingTransform(对外 token 判定),也不 strip
+      // 入站 Authorization。一旦内部 codex spawn 处于 oauth-bearer 态,手工客户端 / 陈旧配置只要
+      // 向这个已公布的对外端口发 Upgrade,下面就会把连接连同 `Authorization: Bearer cindy-local-*`
+      // 直送 ChatGPT 订阅后端 = 凭证透传上游 + 绕过对外鉴权。生成配置的 supports_websockets=false
+      // 只挡「自家 codex 发起 upgrade」,这里是对「任意客户端向对外端口发 upgrade」的结构性兜底:
+      // 返回 null → proxy 回 426 → 客户端(含 codex 原生 transport)降级到 HTTP,HTTP 路径才有
+      // 对外 token 判定与 strip。
+      if (external) return null;
       if ((frozenAuthInjection ?? getCodexProxyAuthInjection()) !== 'oauth-bearer') return null;
       const threadId = selectedThreadIdFromHeaders(headers);
       const recoveryReason = httpRecoveryReasonByThread.get(threadId);

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -67,6 +67,7 @@ import {
   buildRouteDecision,
 } from './provider-route.js';
 import {
+  isCindyLocalToken,
   isCodexExternalAccessEnabled,
   matchesCodexExternalToken,
 } from './local-proxy-external-auth.js';
@@ -2277,7 +2278,13 @@ async function resolveExternalCodexResponsesDecision(body: unknown): Promise<Rou
   }
   // openai-responses / 其它:透明转发到供应商真上游,注入真实凭证,再 strip 外部 token 头。
   const gatewayKey = _readGatewayKey();
-  const decision = buildRouteDecision(route.routing, gatewayKey, 'codex', route.apiKey, route.oauthToken);
+  const base = buildRouteDecision(route.routing, gatewayKey, 'codex', route.apiKey, route.oauthToken);
+  // 供应商 runtime 若定义了 requestPath(如 /tenant/acme/infer),外部转发也要带上 pathOverride,
+  // 与 session 路由(resolveSessionRouteDecision)一致;否则会被转到客户端原始入向路径(/responses),
+  // 固定 endpoint 的供应商会失败,尽管它可作为对外默认供应商被选中。
+  const decision = route.routing.requestPath
+    ? { ...base, pathOverride: route.routing.requestPath }
+    : base;
   const stripped = stripExternalTokenHeadersCodex(decision);
   if (stripped) return stripped;
   return externalOpenAIError(502, 'provider_unavailable', `「${wireModel}」的供应商暂不可用。`);
@@ -2303,7 +2310,9 @@ function externalChatCompletionsDecision(externalToken: string): RoutingDecision
         writeExternalOpenAIError(res, 503, 'proxy_unavailable', 'Cindy Codex proxy 尚未就绪。');
         return;
       }
-      const wantStream = chatRequest.stream !== false;
+      // OpenAI Chat Completions 语义:省略 stream 视为**非流式**(仅 stream===true 才流式)。
+      // 之前把「未指定」当流式,会让不设 stream 的客户端拿到 SSE 而非期望的单个 JSON。
+      const wantStream = chatRequest.stream === true;
       const includeUsage =
         isPlainObject(chatRequest.stream_options)
         && (chatRequest.stream_options as Record<string, unknown>).include_usage === true;
@@ -2350,7 +2359,15 @@ function externalChatCompletionsDecision(externalToken: string): RoutingDecision
       }
 
       const MAX_SSE_BUFFER_CHARS = 8 * 1024 * 1024;
+      // 上游失败(response.failed)时,translator 会产出一个带 `error` 字段的 chunk。流式路径会把它
+      // 写给客户端;非流式路径下 writeChunk 直接丢弃 → 若不另行捕获,finally 会照常 aggregate 出一个
+      // 200 的空 completion,把失败伪装成成功。这里捕获首个 error chunk,让非流式路径改吐 OpenAI 错误。
+      let failureMessage: string | null = null;
       const writeChunk = (chunk: Record<string, unknown>): void => {
+        if (isPlainObject(chunk.error) && failureMessage === null) {
+          const msg = (chunk.error as Record<string, unknown>).message;
+          failureMessage = typeof msg === 'string' && msg ? msg : '上游返回错误。';
+        }
         if (wantStream) res.write(`data: ${JSON.stringify(chunk)}\n\n`);
       };
       const parsePayload = (payload: string): void => {
@@ -2413,8 +2430,13 @@ function externalChatCompletionsDecision(externalToken: string): RoutingDecision
           }
           res.write('data: [DONE]\n\n');
           res.end();
-        } else if (streamFailed) {
-          writeExternalOpenAIError(res, 502, 'upstream_error', 'Cindy Responses 流式中断。');
+        } else if (streamFailed || failureMessage) {
+          writeExternalOpenAIError(
+            res,
+            502,
+            'upstream_error',
+            failureMessage ?? 'Cindy Responses 流式中断。',
+          );
         } else {
           res.writeHead(200, {
             'content-type': 'application/json; charset=utf-8',
@@ -2473,6 +2495,11 @@ export function createModelRoutingTransform(
     const externalToken = bearerToken(ctx.headers);
     if (externalToken && matchesCodexExternalToken(externalToken)) {
       return routeExternalCodexClient(body, ctx, externalToken);
+    }
+    // 带 `cindy-local-` 前缀但不命中本族 token(已重置 / 跨族拿 A 族 token 打 B 族 loopback /
+    // 已失效)→ 明确 401,绝不落到下方内部路由把这个对外 token 当 Authorization 透传上游。
+    if (externalToken && isCindyLocalToken(externalToken)) {
+      return externalOpenAIError(401, 'invalid_external_token', 'Cindy 对外访问 token 无效或已失效。');
     }
     // body 可能为 undefined —— 无 body 的 GET(典型: codex models-manager 的 `GET /models` 轮询,
     // 引擎现在也会对它跑路由)。不再因 body 非对象就短路;会话解析只依赖 headers,model 字段可选。

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -20,6 +20,7 @@ import {
   createImageGenerationIdRecoveryRule,
   createInstructionsInjectionTransform,
   createInstructionsRegistry,
+  isFetchBlockedPort,
   stripEncryptedContentFromBody,
   stripImageGenerationItemsWithoutIdFromBody,
   stripNonAnthropicFields,
@@ -63,6 +64,7 @@ import {
   resolveProviderOAuthControlRouteDecision,
   rewriteImplicitModelIdForRoute,
   rewriteSessionModelIdForRoute,
+  listExternalRoutableProviders,
   resolveExternalCodexRoute,
   buildRouteDecision,
 } from './provider-route.js';
@@ -2231,14 +2233,19 @@ function stripExternalTokenHeadersCodex(decision: RoutingDecision | null): Routi
 /**
  * 构造 `GET /models` / `/v1/models` 的 OpenAI 形状清单:外部 CLI 用它发现可用模型。
  * 取「codex agent 可路由」供应商并集里的模型,按 id 去重。不含任何凭证 / 上游地址。
+ *
+ * 只宣告 `listExternalRoutableProviders('codex')` 认可的供应商:与实际路由判据
+ * (`isExternalRoutableProvider`,排除 oauth-passthrough 订阅直连等)同源。否则会把外部
+ * 客户端根本路由不通的模型也列进 discovery,诱导其选中后必然上游 401。
  */
 function buildExternalOpenAIModelsPayload(): string {
+  const routableIds = new Set(
+    listExternalRoutableProviders('codex').map((provider) => provider.id),
+  );
   const seen = new Set<string>();
   const data: { id: string; object: 'model'; created: number; owned_by: string }[] = [];
   for (const provider of getActiveCatalog().providers) {
-    if (!provider.agents.includes('codex')) continue;
-    const routing = provider.routing.codex;
-    if (!routing || routing.disabled) continue;
+    if (!routableIds.has(provider.id)) continue;
     for (const model of provider.models.codex ?? []) {
       if (!model.id || seen.has(model.id)) continue;
       seen.add(model.id);
@@ -2511,6 +2518,18 @@ export function createModelRoutingTransform(
       requestModel;
     const threadId = selectedThreadIdFromHeaders(ctx.headers);
     const sessionId = sessionIdFromHeaders(ctx.headers);
+    // 有界拒绝(P1):对外访问开启时,这个 codex loopback 端口被公布给外部 CLI。走到这里的请求
+    // 上面既没命中本族对外 token、又不带 `cindy-local-` 前缀(否则已 401)、又解析不出会话、又完全
+    // 不带 Authorization bearer —— 它不是 Cindy 自家 codex 子进程(任何 spawn 模式下子进程都揣着
+    // env_key / OAuth bearer,GET /models 轮询也带),而是本机某个直接打对外端口、连 token 都省了的
+    // 匿名客户端。放行会让带 model 的请求经下方 decideCodexRoute 白嫖 Cindy 的网关 key。故 401。
+    // ⚠ 有界修复:存心伪造一个假 Authorization bearer 的本机进程仍能溜过(loopback 非鉴权边界,且伪造
+    //   bearer 与内部子进程的真实凭证 bearer 无法区分);彻底隔离需把对外监听与内部子进程代理拆到不同
+    //   端口。未开启对外访问时不启用此闸,内部流量字节级不变。
+    // 置于 collab-spawn 分支之前:合法 collab spawn 必带 thread-id,不会走到这个匿名闸。
+    if (isCodexExternalAccessEnabled() && !sessionId && !externalToken) {
+      return externalOpenAIError(401, 'external_token_required', 'Cindy 对外模型代理需要有效的访问 token。');
+    }
     if (!sessionId && isCollabSpawnRequest(ctx.headers)) {
       return unresolvedCollabSpawnRouteDecision();
     }
@@ -2829,16 +2848,22 @@ export async function ensureCodexProxyReady(): Promise<void> {
   _startPromise = (async () => {
     try {
       // 对外模型代理端口策略(与 anthropic host 同):用户开启对外服务时捕获并持久化 codexPort;
-      // 持久化了(>0)就固定绑,固定端口被占用(EADDRINUSE)/无权限(EACCES)则 fallback 随机
-      // 并回写实际值,避免下次又撞同一个占用端口。其它错误照抛给外层兜底。
+      // 持久化了(>0)就固定绑,固定端口不可用则 fallback 随机并回写实际值,避免下次又撞同一个坏
+      // 端口。三类可 fallback:被占用(EADDRINUSE)/ 无权限(EACCES)/ 落在 Fetch 屏蔽端口(包内
+      // 直接抛,SDK 连不上)。其它错误照抛给外层兜底。
       const pinnedPort = loadLocalProxySettings().codexPort;
       let handle: ProxyHandle;
       try {
         handle = await createCodexProxyHandle(undefined, pinnedPort > 0 ? pinnedPort : undefined);
       } catch (bindErr) {
         const code = (bindErr as NodeJS.ErrnoException | undefined)?.code;
-        if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES')) {
-          log.error('固定的 codex 对外代理端口不可用,fallback 随机端口', { pinnedPort, code });
+        const fetchBlocked = isFetchBlockedPort(pinnedPort);
+        if (pinnedPort > 0 && (code === 'EADDRINUSE' || code === 'EACCES' || fetchBlocked)) {
+          log.error('固定的 codex 对外代理端口不可用,fallback 随机端口', {
+            pinnedPort,
+            code,
+            fetchBlocked,
+          });
           handle = await createCodexProxyHandle();
           const actual = codexPortFromProxyUrl(handle.url);
           if (actual) setLocalProxyCodexPort(actual);

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -2505,7 +2505,13 @@ function routeExternalCodexClient(
   }
   const pathname = requestPathname(ctx.url);
   const method = ctx.method.toUpperCase();
-  if (method === 'GET' && /\/(v1\/)?models\/?$/.test(pathname)) {
+  // ⚠ 三条端点正则都必须 `^` 锚在**开头**(#1666 三轮 P2):只锚尾部时这是「后缀」判定,
+  //   `POST /foo/responses`、`/foo/v1/chat/completions` 同样能进外部路由分支;而 responses 这条是
+  //   透明转发(无 pathOverride → 原样转发 ctx.url),供应商侧就会收到这个未支持路径,却带着
+  //   buildRouteDecision 注入的真实凭证。锚定后对外端口只接受对外公布的那三个端点
+  //   (/responses、/v1/responses、/v1/chat/completions,及 /models 发现),并顺带挡掉
+  //   absolute-form 请求(`POST http://evil.example/responses`,此时 req.url 不以 `/` 开头)。
+  if (method === 'GET' && /^\/(v1\/)?models\/?$/.test(pathname)) {
     return {
       localHandler: async ({ res }) => {
         res.writeHead(200, {
@@ -2516,10 +2522,10 @@ function routeExternalCodexClient(
       },
     };
   }
-  if (method === 'POST' && /\/(v1\/)?chat\/completions\/?$/.test(pathname)) {
+  if (method === 'POST' && /^\/(v1\/)?chat\/completions\/?$/.test(pathname)) {
     return externalChatCompletionsDecision(externalToken);
   }
-  if (method === 'POST' && /\/(v1\/)?responses\/?$/.test(pathname)) {
+  if (method === 'POST' && /^\/(v1\/)?responses\/?$/.test(pathname)) {
     return resolveExternalCodexResponsesDecision(body);
   }
   return externalOpenAIError(400, 'unsupported_request', '不支持的外部请求。');

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -2168,7 +2168,7 @@ function bearerToken(headers: Readonly<Record<string, string>>): string {
   const raw = headerValue(headers, 'authorization');
   if (!raw) return '';
   const m = /^bearer\s+(.+)$/i.exec(raw);
-  return m ? m[1].trim() : raw;
+  return m ? m[1].trim() : '';
 }
 
 /** 外部分支统一的 OpenAI 错误信封(localHandler 完全接管,不转发上游)。 */

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -1758,10 +1758,14 @@ function createByteDanceSeedResponsesCompatTransform(): RequestTransform {
   };
 }
 
-function createXaiResponsesCompatTransform(): RequestTransform {
+function createXaiResponsesCompatTransform(external = false): RequestTransform {
   return (body, ctx) => {
     if (!isPlainObject(body)) return null;
-    const sessionId = sessionIdFromTransformCtx(ctx);
+    // 对外端口无 session 语义:external 时绝不读(外部客户端可伪造的)session header 去
+    // getSessionProvider,只按请求自身的 body.model 推断供应商——与 resolveExternalCodexRoute
+    // 的模型推断同源。否则伪造 session 可让 xAI schema 改写错误地施加到非 xAI 外部路由,或反过来
+    // 被跳过(#1666 review:external-safe chain)。
+    const sessionId = external ? undefined : sessionIdFromTransformCtx(ctx);
     const explicitProviderId = sessionId ? getSessionProvider(sessionId) : null;
     const inferredProviderId =
       explicitProviderId ?? (typeof body.model === 'string' ? inferProviderIdForModel(body.model, 'codex') : null);
@@ -1786,7 +1790,9 @@ function createXaiResponsesCompatTransform(): RequestTransform {
     // 保证注入项不会被同一轮的裁剪逻辑改形或丢掉。
     // Guardian must retain xAI's schema/input compatibility, but it must not
     // gain provider-hosted search tools while reviewing another action.
-    if (!guardianParentThreadIdFromHeaders(ctx.headers)) {
+    // 对外端口同样不注入服务端 search 工具:与不注入 gateway web_search 对称,外部客户端没主动
+    // 要就不改其请求语义/计费(#1666 review)——仍保留 xAI 的 schema/input 归一化,请求照样可用。
+    if (!external && !guardianParentThreadIdFromHeaders(ctx.headers)) {
       const withServerSideTools = ensureXaiServerSideTools(current);
       if (withServerSideTools) {
         current = withServerSideTools;
@@ -1922,6 +1928,19 @@ function createProviderModelRewriteTransform(): RequestTransform {
     if (sessionId && explicitProviderId) return rewriteSessionModelIdForRoute(sessionId, 'codex', body);
     return rewriteImplicitModelIdForRoute('codex', body);
   };
+}
+
+/**
+ * 对外端口专用 model 改写:只做**隐式**(按请求自身 model 命名空间前缀)改写,绝不读 session。
+ *
+ * 内部端口的 createProviderModelRewriteTransform 在有 session + 显式供应商时会走
+ * rewriteSessionModelIdForRoute,按内部会话选定的供应商改写 model。对外端口若沿用它,外部客户端
+ * 只要伪造 x-codex-session-id 之类的 header 就能触发「按 Cindy 内部会话」的 model 改写,把内部
+ * 会话状态带进外部请求(#1666 review)。对外只按请求自身的 model 前缀改写,与
+ * resolveExternalCodexRoute 的模型推断同源,不受任何 client 提供的 session/thread header 影响。
+ */
+function createExternalCodexModelRewriteTransform(): RequestTransform {
+  return (body) => rewriteImplicitModelIdForRoute('codex', body);
 }
 
 function createDumpTransform(): RequestTransform {
@@ -2660,6 +2679,7 @@ export function createModelRoutingTransform(
 
 function createTransformRequestChain(
   frozenAuthInjection?: CodexProxyAuthInjection,
+  external = false,
 ): RequestTransform[] {
   const transforms: RequestTransform[] = [
     createActiveStripTransform({
@@ -2672,20 +2692,32 @@ function createTransformRequestChain(
       enabled: () => true,
       strip: stripImageGenerationItemsWithoutIdFromBody,
     }),
-    createCodexTransform(),
-    // Guardian uses an isolated child thread. Resolve its parent business
-    // session and select that session's real provider model before provider
-    // compatibility transforms inspect the request.
-    createProviderAwareGuardianReviewerTransform(frozenAuthInjection),
-    createGatewayNativeWebSearchTransform(),
+    // instructions 注入 / Guardian / gateway-native web_search 三条都耦合 Cindy 内部 session、
+    // 内部 thread registry 或 spawn 形态,对外端口一律不挂(#1666 review:external-safe chain):
+    //   - createCodexTransform 按**客户端提供的** thread-id header 查内部 instructions registry。
+    //     该 registry 只由内部 codex 会话的 registerComposed 写入,外部客户端不可能合法命中;挂着
+    //     只意味着伪造/猜中 thread-id 就能把 Cindy 的内部产品提示词拼进外部请求发往上游。
+    //   - Guardian(createProviderAwareGuardianReviewerTransform)是内部子线程概念,靠 thread→
+    //     session 反解 + authInjection 选内部会话的真实供应商模型;外部客户端没有 guardian 父会话,
+    //     只会让伪造的 thread header 触发按内部会话的 prompt/model 改写。
+    //   - createGatewayNativeWebSearchTransform 会在内部 authInjection==='env-key' 时给 gpt-5.6*
+    //     注入 web_search,哪怕外部路由选的是不支持它的自定义/非网关供应商 → 不支持工具报错。
+    ...(external
+      ? []
+      : [
+          createCodexTransform(),
+          createProviderAwareGuardianReviewerTransform(frozenAuthInjection),
+          createGatewayNativeWebSearchTransform(),
+        ]),
     // 必须先于 xAI/MiniMax 兼容改写:加密压缩块换成明文占位 message 后,后续
     // 针对具体供应商的 input 归一化才能按标准 message 处理它。
     createCrossProviderCompactionCompatTransform(),
     createStrictGatewayHistoryCompatTransform(),
-    createXaiResponsesCompatTransform(),
+    createXaiResponsesCompatTransform(external),
     createByteDanceSeedResponsesCompatTransform(),
     createMiniMaxResponsesCompatTransform(),
-    createProviderModelRewriteTransform(),
+    // 对外端口用隐式(按 body.model 前缀)model 改写,绝不读 session;内部端口保持会话感知改写。
+    external ? createExternalCodexModelRewriteTransform() : createProviderModelRewriteTransform(),
     stripNonAnthropicFields,
   ];
   if (process.env.XDT_CODEX_PROXY_DUMP_TRANSFORMED_BODY === '1') {
@@ -2797,7 +2829,7 @@ function createCodexProxyHandle(
     ...(port && port > 0 ? { port } : {}),
     // 默认上游 = gateway(含 /v1)；普通模型 + oauth 由 routingTransform 覆盖到 ChatGPT。
     upstream: () => buildCodexGatewayBaseUrl(),
-    transformRequest: createTransformRequestChain(frozenAuthInjection),
+    transformRequest: createTransformRequestChain(frozenAuthInjection, external),
     // external=true:对外端口,只认 B 族对外 token 的独立路由(createExternalCodexRoutingTransform),
     // 绝不回落内部默认路由/网关 key。external=false:常规 session proxy 读当前全局 spawn 形态;
     // control-plane proxy 在创建时冻结自己的形态,两个 app-server 并行时不会互相改写路由。

--- a/apps/desktop/src/main/maker-host/codex-proxy-host.ts
+++ b/apps/desktop/src/main/maker-host/codex-proxy-host.ts
@@ -2526,23 +2526,32 @@ export function createModelRoutingTransform(
     // 内部身份信号:任何 Cindy 自家 codex 子进程的请求都带 thread-id / x-client-request-id 头
     //(缺失才是 'unknown'),即便 threadToSession 还没在注册时序窗口内把它绑上 session 也带着它。
     // 这与 anthropic 侧靠 x-claude-code-session-id 区分内外同构 —— 光「带了个 bearer」不算内部身份。
+    // 注:collab spawn(x-openai-subagent=collab-spawn)也带 thread-id,故 hasInternalCodexIdentity 为真,
+    // 会跳过下方 401 闸,落到再下方的 collab-spawn 分支 —— 内部协同 spawn 不受对外闸影响。
     const hasInternalCodexIdentity = threadId !== 'unknown';
     // 有界拒绝(P1):对外访问开启时,这个 codex loopback 端口被公布给外部 CLI。走到这里的请求上面
-    // 既没命中本族对外 token、又不带 `cindy-local-` 前缀(否则已 401)、又解析不出会话、又不带内部
-    // thread-id 身份头 —— 它不是 Cindy 自家 codex 子进程,而是本机某个直接打对外端口的客户端。
-    //   · 带 model:放行会经下方 decideCodexRoute(oauth-bearer + codex/* + gatewayKey)白嫖 Cindy 的
-    //     网关 key —— 这是 #1666 review 指出的真实泄漏点,故一律 401。⚠ 关键修复:不再把「带了个
-    //     bearer」当内部豁免;伪造一个非本族 `Bearer anything` 既不能冒充内部,也不能让对外 token 变可选。
-    //   · 无 model:控制面请求(如 codex models-manager 的 `GET /models` 轮询)。带 bearer 的它经 ③ 段
-    //     只 override 上游、透传其自带 bearer(不注入 Cindy 网关 key/凭证),不泄漏,故仅在「连 bearer
-    //     都没有」的纯匿名态才拦,避免误伤无 thread-id 头的内部轮询。
+    // 既没命中本族对外 token(否则已在 ⓪ 段被 routeExternalCodexClient 接走)、又不带 `cindy-local-`
+    // 前缀(否则已 401)、又解析不出会话、又不带内部 thread-id / x-client-request-id 身份头 —— 它不是
+    // Cindy 自家 codex 子进程,而是本机某个直接打对外端口的客户端。一律 401(带不带 model、带不带
+    // 伪造 bearer 都拦):
+    //   · 带 model:放行会经下方 decideCodexRoute(oauth-bearer + codex/* + gatewayKey)白嫖 Cindy 网关 key。
+    //   · 无 model(控制面,如 codex models-manager 的 `GET /models` 轮询):放行会经下方桶③,在
+    //     provider-oauth 态经 resolveProviderOAuthControlRouteDecision 把 Cindy 的供应商 OAuth token 注入
+    //     上游 —— 未鉴权者借 Cindy 凭证打供应商 /models,使对外 token 形同虚设(#1666 review 二轮 Finding H)。
+    // ⚠ 关键:内部身份只认 thread-id / x-client-request-id 头,绝不把「带了个 bearer」当豁免 —— 伪造一个
+    //   非本族 `Bearer anything` 既冒充不了内部,也不能让对外 token 变可选。合法外部客户端的 /models 由
+    //   ⓪ 段 routeExternalCodexClient 用本族 token 命中后从 Cindy catalog 返回,根本不依赖桶③,故这里
+    //   收紧不影响它。代价:对外开启期间,内部无 thread-id 的控制面轮询也一并被拦(与本就被拦的匿名
+    //   轮询同权衡;Cindy 自有 catalog,退化有界)。
     // ⚠ 残留:存心伪造一个假 thread-id 身份头的本机进程仍能溜过(loopback 非鉴权边界,与 anthropic 侧
-    //   伪造会话头同权衡);彻底隔离需把对外监听与内部子进程代理拆到不同端口。未开启对外时不启用此闸。
+    //   伪造会话头同权衡);彻底隔离需把对外监听与内部子进程代理拆到不同端口。未开启对外时不启用此闸,
+    //   内部无 thread-id 的控制面轮询照旧走桶③。
+    // 置于 collab-spawn 分支之前:合法 collab spawn 必带 thread-id(hasInternalCodexIdentity 为真)会跳过
+    // 本闸;而伪造 collab-spawn 头却不带 thread-id 的对外客户端会被这里 401,不至于蹭到下方 collab 分支。
     if (
       isCodexExternalAccessEnabled()
       && !sessionId
       && !hasInternalCodexIdentity
-      && (Boolean(model) || !externalToken)
     ) {
       return externalOpenAIError(401, 'external_token_required', 'Cindy 对外模型代理需要有效的访问 token。');
     }

--- a/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
+++ b/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
@@ -43,6 +43,18 @@ function generateTokenValue(): string {
   return `${TOKEN_PREFIX}${randomBytes(32).toString('base64url')}`;
 }
 
+/**
+ * 候选值是否长得像一个 Cindy 本地代理对外 token(带 `cindy-local-` 前缀)。仅凭前缀判定,
+ * **不比对具体值**。用途:host 侧在「命中本族已存 token」判定**失败后**,借此区分
+ *   ① 带前缀但不命中(已重置 / 跨族 / 已失效的 Cindy 对外 token)→ 应明确 401,
+ *      绝不能落到内部默认路由把它当作 x-api-key / Authorization 透传上游(否则泄漏 + 误路由);
+ *   ② 完全不带前缀(Cindy 自家子进程的真凭证 / 网关 key / 占位 key)→ 正常走内部逻辑。
+ * 真凭证不会以 `cindy-local-` 开头,故前缀是一个安全的判别器。
+ */
+export function isCindyLocalToken(candidate: string | null | undefined): boolean {
+  return typeof candidate === 'string' && candidate.startsWith(TOKEN_PREFIX);
+}
+
 /** 一族 token 的存取 + 开关读取器。A / B 族各注入自己的一套,核心逻辑完全共享。 */
 interface TokenFamily {
   /** 族标识,用作 safeStorage 写失败时的进程内兜底缓存 key。 */
@@ -194,4 +206,14 @@ export function matchesCodexExternalToken(candidate: string | null | undefined):
 /** B 族对外服务是否已开启(来自非密钥设置存储)。 */
 export function isCodexExternalAccessEnabled(): boolean {
   return codexFamily.isEnabled();
+}
+
+/**
+ * 清空进程内兜底缓存(两族)。切换账号 / 清空所有 secrets 时必须调用 —— 否则
+ * safeStorage 写失败留下的兜底 token 会跨账号存活,让旧账号的对外 token 在新账号下
+ * 仍被判定命中。物理 token 由 providerSecretStore 的 clearAllSecrets 删除,本函数补上
+ * 内存兜底这一路,与其在同一清理路径里调用。
+ */
+export function clearExternalTokenMemoryFallback(): void {
+  memoryFallbackTokens.clear();
 }

--- a/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
+++ b/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
@@ -1,0 +1,169 @@
+/**
+ * 对外模型代理(给用户自己的 CLI 用)的**对外访问 token** 鉴权。
+ *
+ * loopback 不是鉴权边界 —— 本机任何进程都能连上代理端口,而它背后是用户配好的付费
+ * 供应商凭证。因此外部客户端必须携带一个 Cindy 生成的 token 才能被放行。token 存
+ * safeStorage(跨重启稳定),校验用 `timingSafeEqual`(先比长度),范式与
+ * `pi-proxy-session-auth.ts` 一致。
+ *
+ * 两族独立(第三期):
+ *   - **A 族 = Anthropic(Claude Code)**:token 经 `ANTHROPIC_API_KEY` 传入(请求头
+ *     `x-api-key`),开关是 `enabled`。
+ *   - **B 族 = Codex / 通用 OpenAI**:token 经 `OPENAI_API_KEY` 传入(请求头
+ *     `Authorization: Bearer`),开关是 `codexEnabled`,独立一份 token。
+ * 每族各自开关、各自 token,**跨族 token 不互通** —— 各 host 只认自己族的 token,命中失败
+ * 即非本族外部客户端。这比共享 token 更收紧隔离。
+ *
+ * 关键安全语义(勿改):
+ *   - 「一个请求是不是(本族)外部客户端」= 它带的凭据是否**命中本族已存 token**,与 enabled
+ *     无关。命中即判定外部客户端,强制走外部路由分支或(服务关闭时)直接 401 —— 绝不让
+ *     一个携带对外 token 的请求回落到 Cindy 默认网关/订阅路由(否则 token 会被当成
+ *     gateway 的 key 透传上游,造成凭证泄漏/误计费)。
+ *   - token 只以掩码形式给 renderer;明文只在 main 侧鉴权与「复制/写入 env」时使用。
+ */
+
+import { randomBytes, timingSafeEqual } from 'node:crypto';
+
+import {
+  readLocalProxyExternalToken,
+  writeLocalProxyExternalToken,
+  readLocalProxyCodexExternalToken,
+  writeLocalProxyCodexExternalToken,
+} from '../secrets/providerSecretStore.js';
+import {
+  isExternalAccessEnabled as isAnthropicEnabledFromStore,
+  isCodexExternalAccessEnabled as isCodexEnabledFromStore,
+} from './local-proxy-settings-store.js';
+
+/** token 前缀:便于用户/日志一眼认出这是 Cindy 本地代理的对外 token,而非真供应商 key。 */
+const TOKEN_PREFIX = 'cindy-local-';
+
+function generateTokenValue(): string {
+  // 32 字节 → base64url,足够抗猜测;不含 `+/=`,可安全放进 env / header。
+  return `${TOKEN_PREFIX}${randomBytes(32).toString('base64url')}`;
+}
+
+/** 一族 token 的存取 + 开关读取器。A / B 族各注入自己的一套,核心逻辑完全共享。 */
+interface TokenFamily {
+  read: () => string | null;
+  write: (value: string) => boolean;
+  isEnabled: () => boolean;
+}
+
+function hasToken(family: TokenFamily): boolean {
+  return family.read() !== null;
+}
+
+/**
+ * 读取现有 token;不存在则生成并落盘后返回。开启对外服务 / 展示 env 时用来确保有 token。
+ * safeStorage 不可用导致写失败时,返回内存里刚生成的值(本次进程内可用),不静默吞掉。
+ */
+function getOrCreateToken(family: TokenFamily): string {
+  const existing = family.read();
+  if (existing) return existing;
+  const next = generateTokenValue();
+  family.write(next);
+  return next;
+}
+
+/** 重新生成并覆盖 token(旧 token 立即失效);返回新 token 明文。 */
+function regenerateToken(family: TokenFamily): string {
+  const next = generateTokenValue();
+  family.write(next);
+  return next;
+}
+
+/**
+ * 掩码后的 token,供 UI 展示(永不把明文交给 renderer)。保留前缀 + 末 4 位,
+ * 中间用固定长度的 `•`,不泄漏真实长度。无 token 时返回 null。
+ */
+function getTokenMasked(family: TokenFamily): string | null {
+  const token = family.read();
+  if (!token) return null;
+  const tail = token.slice(-4);
+  return `${TOKEN_PREFIX}••••••••${tail}`;
+}
+
+/**
+ * 候选 token 是否命中本族已存 token。timingSafeEqual 前先比长度(长度不等直接判否,
+ * 且长度信息本身不算敏感)。无已存 token / 候选为空 → 一律否。**与 enabled 无关**:
+ * 调用方据此判定「是不是外部客户端」,再结合 enabled 决定放行还是 401。
+ */
+function matchesToken(family: TokenFamily, candidate: string | null | undefined): boolean {
+  const expected = family.read();
+  if (!expected || !candidate) return false;
+  const expectedBytes = Buffer.from(expected);
+  const candidateBytes = Buffer.from(candidate);
+  return (
+    expectedBytes.length === candidateBytes.length &&
+    timingSafeEqual(expectedBytes, candidateBytes)
+  );
+}
+
+// ─────────────── A 族:Anthropic(Claude Code)—— 签名保持不变 ───────────────
+
+const anthropicFamily: TokenFamily = {
+  read: readLocalProxyExternalToken,
+  write: writeLocalProxyExternalToken,
+  isEnabled: isAnthropicEnabledFromStore,
+};
+
+/** 本机是否已生成过 A 族对外 token。 */
+export function hasExternalToken(): boolean {
+  return hasToken(anthropicFamily);
+}
+
+export function getOrCreateExternalToken(): string {
+  return getOrCreateToken(anthropicFamily);
+}
+
+export function regenerateExternalToken(): string {
+  return regenerateToken(anthropicFamily);
+}
+
+export function getExternalTokenMasked(): string | null {
+  return getTokenMasked(anthropicFamily);
+}
+
+export function matchesExternalToken(candidate: string | null | undefined): boolean {
+  return matchesToken(anthropicFamily, candidate);
+}
+
+/** A 族对外服务是否已开启(来自非密钥设置存储)。 */
+export function isExternalAccessEnabled(): boolean {
+  return anthropicFamily.isEnabled();
+}
+
+// ─────────────── B 族:Codex / 通用 OpenAI —— 独立一份 token ───────────────
+
+const codexFamily: TokenFamily = {
+  read: readLocalProxyCodexExternalToken,
+  write: writeLocalProxyCodexExternalToken,
+  isEnabled: isCodexEnabledFromStore,
+};
+
+/** 本机是否已生成过 B 族对外 token。 */
+export function hasCodexExternalToken(): boolean {
+  return hasToken(codexFamily);
+}
+
+export function getOrCreateCodexExternalToken(): string {
+  return getOrCreateToken(codexFamily);
+}
+
+export function regenerateCodexExternalToken(): string {
+  return regenerateToken(codexFamily);
+}
+
+export function getCodexExternalTokenMasked(): string | null {
+  return getTokenMasked(codexFamily);
+}
+
+export function matchesCodexExternalToken(candidate: string | null | undefined): boolean {
+  return matchesToken(codexFamily, candidate);
+}
+
+/** B 族对外服务是否已开启(来自非密钥设置存储)。 */
+export function isCodexExternalAccessEnabled(): boolean {
+  return codexFamily.isEnabled();
+}

--- a/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
+++ b/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
@@ -45,13 +45,39 @@ function generateTokenValue(): string {
 
 /** 一族 token 的存取 + 开关读取器。A / B 族各注入自己的一套,核心逻辑完全共享。 */
 interface TokenFamily {
+  /** 族标识,用作 safeStorage 写失败时的进程内兜底缓存 key。 */
+  id: string;
   read: () => string | null;
   write: (value: string) => boolean;
   isEnabled: () => boolean;
 }
 
+/**
+ * safeStorage 不可用(write 返回 false)时的进程内兜底:落盘失败也把刚生成的 token 记在
+ * 内存里,保证本次运行期 read/matches/masked/env 复制拿到的是同一个稳定值,而不是每次都
+ * 生成新 token 导致「对外 token 鉴权」永远命不中。落盘成功则清掉兜底(以持久值为准)。
+ */
+const memoryFallbackTokens = new Map<string, string>();
+
+/** 读物理存储;失败(safeStorage 不可用)时回退到进程内兜底缓存。 */
+function effectiveRead(family: TokenFamily): string | null {
+  const physical = family.read();
+  if (physical) return physical;
+  return memoryFallbackTokens.get(family.id) ?? null;
+}
+
+/** 落盘;失败则记进程内兜底缓存,成功则清掉旧兜底。 */
+function persistToken(family: TokenFamily, value: string): void {
+  const ok = family.write(value);
+  if (ok) {
+    memoryFallbackTokens.delete(family.id);
+  } else {
+    memoryFallbackTokens.set(family.id, value);
+  }
+}
+
 function hasToken(family: TokenFamily): boolean {
-  return family.read() !== null;
+  return effectiveRead(family) !== null;
 }
 
 /**
@@ -59,17 +85,17 @@ function hasToken(family: TokenFamily): boolean {
  * safeStorage 不可用导致写失败时,返回内存里刚生成的值(本次进程内可用),不静默吞掉。
  */
 function getOrCreateToken(family: TokenFamily): string {
-  const existing = family.read();
+  const existing = effectiveRead(family);
   if (existing) return existing;
   const next = generateTokenValue();
-  family.write(next);
+  persistToken(family, next);
   return next;
 }
 
 /** 重新生成并覆盖 token(旧 token 立即失效);返回新 token 明文。 */
 function regenerateToken(family: TokenFamily): string {
   const next = generateTokenValue();
-  family.write(next);
+  persistToken(family, next);
   return next;
 }
 
@@ -78,7 +104,7 @@ function regenerateToken(family: TokenFamily): string {
  * 中间用固定长度的 `•`,不泄漏真实长度。无 token 时返回 null。
  */
 function getTokenMasked(family: TokenFamily): string | null {
-  const token = family.read();
+  const token = effectiveRead(family);
   if (!token) return null;
   const tail = token.slice(-4);
   return `${TOKEN_PREFIX}••••••••${tail}`;
@@ -90,7 +116,7 @@ function getTokenMasked(family: TokenFamily): string | null {
  * 调用方据此判定「是不是外部客户端」,再结合 enabled 决定放行还是 401。
  */
 function matchesToken(family: TokenFamily, candidate: string | null | undefined): boolean {
-  const expected = family.read();
+  const expected = effectiveRead(family);
   if (!expected || !candidate) return false;
   const expectedBytes = Buffer.from(expected);
   const candidateBytes = Buffer.from(candidate);
@@ -103,6 +129,7 @@ function matchesToken(family: TokenFamily, candidate: string | null | undefined)
 // ─────────────── A 族:Anthropic(Claude Code)—— 签名保持不变 ───────────────
 
 const anthropicFamily: TokenFamily = {
+  id: 'anthropic',
   read: readLocalProxyExternalToken,
   write: writeLocalProxyExternalToken,
   isEnabled: isAnthropicEnabledFromStore,
@@ -137,6 +164,7 @@ export function isExternalAccessEnabled(): boolean {
 // ─────────────── B 族:Codex / 通用 OpenAI —— 独立一份 token ───────────────
 
 const codexFamily: TokenFamily = {
+  id: 'codex',
   read: readLocalProxyCodexExternalToken,
   write: writeLocalProxyCodexExternalToken,
   isEnabled: isCodexEnabledFromStore,

--- a/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
+++ b/apps/desktop/src/main/maker-host/local-proxy-external-auth.ts
@@ -27,8 +27,10 @@ import { randomBytes, timingSafeEqual } from 'node:crypto';
 import {
   readLocalProxyExternalToken,
   writeLocalProxyExternalToken,
+  removeLocalProxyExternalToken,
   readLocalProxyCodexExternalToken,
   writeLocalProxyCodexExternalToken,
+  removeLocalProxyCodexExternalToken,
 } from '../secrets/providerSecretStore.js';
 import {
   isExternalAccessEnabled as isAnthropicEnabledFromStore,
@@ -61,6 +63,8 @@ interface TokenFamily {
   id: string;
   read: () => string | null;
   write: (value: string) => boolean;
+  /** 删除物理持久 token(轮换失败兜底时用来消除旧值遮挡)。 */
+  remove: () => void;
   isEnabled: () => boolean;
 }
 
@@ -104,10 +108,33 @@ function getOrCreateToken(family: TokenFamily): string {
   return next;
 }
 
-/** 重新生成并覆盖 token(旧 token 立即失效);返回新 token 明文。 */
+/**
+ * 重新生成并覆盖 token(旧 token 立即失效);返回新 token 明文。
+ *
+ * 轮换不变量(勿弱化):**轮换后 `effectiveRead` 必须返回新值**,旧 token 不得再命中。
+ * 轮换常因旧 token 疑似泄漏而触发,若旧值仍能鉴权而 IPC 谎报成功,泄漏的 token 会继续放行。
+ * 因此顺序是:先把新值写进内存兜底 → 清掉旧物理值(消除「物理旧值遮挡内存新值」)→ 写新物理值。
+ *   - write 成功:清掉内存兜底,以物理新值为准。
+ *   - remove 成功但 write 失败(safeStorage 不可用):物理已空,effectiveRead 回内存新值,旧值已失效。
+ *   - remove 与 write 均失败:物理旧值仍在并遮挡新值 → 抛错,绝不谎报成功(旧 token 仍有效这一
+ *     事实必须让调用方/用户知道,而非静默保留)。
+ */
 function regenerateToken(family: TokenFamily): string {
   const next = generateTokenValue();
-  persistToken(family, next);
+  memoryFallbackTokens.set(family.id, next);
+  family.remove();
+  const ok = family.write(next);
+  if (ok) {
+    memoryFallbackTokens.delete(family.id);
+  }
+  if (effectiveRead(family) !== next) {
+    // 旧物理值既没被 remove 掉、新值又没写进去 —— 无法让新值生效。回滚不可能生效的内存兜底并抛错,
+    // 让 regenerate IPC 报失败,而不是让旧(可能已泄漏的)token 继续鉴权、新 token 反而不可用。
+    memoryFallbackTokens.delete(family.id);
+    throw new Error(
+      'local proxy external token rotation failed: the previous token could not be invalidated',
+    );
+  }
   return next;
 }
 
@@ -144,6 +171,9 @@ const anthropicFamily: TokenFamily = {
   id: 'anthropic',
   read: readLocalProxyExternalToken,
   write: writeLocalProxyExternalToken,
+  remove: () => {
+    removeLocalProxyExternalToken();
+  },
   isEnabled: isAnthropicEnabledFromStore,
 };
 
@@ -179,6 +209,9 @@ const codexFamily: TokenFamily = {
   id: 'codex',
   read: readLocalProxyCodexExternalToken,
   write: writeLocalProxyCodexExternalToken,
+  remove: () => {
+    removeLocalProxyCodexExternalToken();
+  },
   isEnabled: isCodexEnabledFromStore,
 };
 

--- a/apps/desktop/src/main/maker-host/local-proxy-settings-store.ts
+++ b/apps/desktop/src/main/maker-host/local-proxy-settings-store.ts
@@ -17,6 +17,8 @@
 
 import Store from 'electron-store';
 
+import { isFetchBlockedPort } from '@cindy/anthropic-compat-proxy';
+
 interface LocalProxySettingsShape {
   enabled: boolean;
   defaultProviderId: string;
@@ -135,9 +137,19 @@ export function setLocalProxyPort(port: number): number {
   return normalized;
 }
 
-/** 端口是否在合法可绑区间(不含 0 哨兵)。UI 校验与 IPC 入参校验共用。 */
+/**
+ * 端口是否在合法可绑区间(不含 0 哨兵)。UI 校验与 IPC 入参校验共用。
+ * 额外拒绝 Fetch/undici 屏蔽端口(如 6000/6667/10080):SDK 会对这些端口直接
+ * ERR_INVALID_ARGUMENT 拒连,固定绑上去外部 CLI 根本连不通,故不允许用户持久化。
+ */
 export function isValidLocalProxyPort(port: unknown): port is number {
-  return typeof port === 'number' && Number.isInteger(port) && port >= MIN_PORT && port <= MAX_PORT;
+  return (
+    typeof port === 'number' &&
+    Number.isInteger(port) &&
+    port >= MIN_PORT &&
+    port <= MAX_PORT &&
+    !isFetchBlockedPort(port)
+  );
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/local-proxy-settings-store.ts
+++ b/apps/desktop/src/main/maker-host/local-proxy-settings-store.ts
@@ -1,0 +1,146 @@
+/**
+ * 对外模型代理(给用户自己的 Claude Code CLI 用)的**非密钥**偏好存储。
+ *
+ * 只存三样东西,均非敏感:
+ *   - enabled:是否对外开放代理(默认关闭 —— loopback 背后是付费凭证,必须用户显式开启)。
+ *   - defaultProviderId:多来源 / stock `claude-*` 模型按模型名解析不出唯一供应商时,
+ *     回落到的「对外默认供应商」id;为空表示未选。
+ *   - port:开启对外服务时固定的监听端口(默认随机 → 开启即捕获当前端口并持久化)。
+ *     0 / 未设置表示「未固定,启动时随机」。
+ *
+ * 对外访问 **token** 是敏感凭据,不在这里 —— 它走 safeStorage
+ * (`providerSecretStore` 的 `read/writeLocalProxyExternalToken`)。
+ *
+ * userData/local-proxy-settings.json,跨 dev(http://localhost)/ installed(file://)共享,
+ * 绕开 localStorage 按 origin 隔离的问题(与 sidebar-settings 同范式)。
+ */
+
+import Store from 'electron-store';
+
+interface LocalProxySettingsShape {
+  enabled: boolean;
+  defaultProviderId: string;
+  /** 固定监听端口;0 表示未固定(启动时随机)。 */
+  port: number;
+  /**
+   * Codex / 通用 OpenAI 出口(codex loopback proxy)。**独立开关 + 独立 token**(第三期):
+   * 与 Anthropic 出口(A 族)的 `enabled` 互不影响,可单独开启。
+   *   - codexEnabled:B 族是否对外开放(默认关闭)。
+   *   - codexPort:codex loopback 固定端口;0 表示未固定(启动时随机)。
+   *   - codexDefaultProviderId:codex agent 按模型名解析不出唯一供应商时回落的默认供应商 id。
+   */
+  codexEnabled: boolean;
+  codexPort: number;
+  codexDefaultProviderId: string;
+}
+
+/** TCP 端口合法区间(0 = 未固定的哨兵值,单独允许)。 */
+const MIN_PORT = 1;
+const MAX_PORT = 65_535;
+
+let storeInstance: Store<LocalProxySettingsShape> | null = null;
+
+function getStore(): Store<LocalProxySettingsShape> {
+  if (!storeInstance) {
+    storeInstance = new Store<LocalProxySettingsShape>({
+      name: 'local-proxy-settings',
+      defaults: {
+        enabled: false,
+        defaultProviderId: '',
+        port: 0,
+        codexEnabled: false,
+        codexPort: 0,
+        codexDefaultProviderId: '',
+      },
+      schema: {
+        enabled: { type: 'boolean' },
+        defaultProviderId: { type: 'string' },
+        port: { type: 'integer', minimum: 0, maximum: MAX_PORT },
+        codexEnabled: { type: 'boolean' },
+        codexPort: { type: 'integer', minimum: 0, maximum: MAX_PORT },
+        codexDefaultProviderId: { type: 'string' },
+      },
+      clearInvalidConfig: true,
+    });
+  }
+  return storeInstance;
+}
+
+export interface LocalProxySettings {
+  enabled: boolean;
+  defaultProviderId: string;
+  port: number;
+  codexEnabled: boolean;
+  codexPort: number;
+  codexDefaultProviderId: string;
+}
+
+export function loadLocalProxySettings(): LocalProxySettings {
+  const store = getStore();
+  return {
+    enabled: store.get('enabled', false),
+    defaultProviderId: store.get('defaultProviderId', ''),
+    port: store.get('port', 0),
+    codexEnabled: store.get('codexEnabled', false),
+    codexPort: store.get('codexPort', 0),
+    codexDefaultProviderId: store.get('codexDefaultProviderId', ''),
+  };
+}
+
+/** A 族(Anthropic)对外服务是否已开启(默认关闭)。热路径(每次外部请求鉴权)会调用,保持同步读。 */
+export function isExternalAccessEnabled(): boolean {
+  return getStore().get('enabled', false);
+}
+
+/** B 族(Codex / 通用 OpenAI)对外服务是否已开启(默认关闭)。与 A 族独立。热路径同步读。 */
+export function isCodexExternalAccessEnabled(): boolean {
+  return getStore().get('codexEnabled', false);
+}
+
+export function setLocalProxyEnabled(enabled: boolean): void {
+  getStore().set('enabled', enabled);
+}
+
+export function setLocalProxyCodexEnabled(enabled: boolean): void {
+  getStore().set('codexEnabled', enabled);
+}
+
+export function setLocalProxyDefaultProviderId(providerId: string): void {
+  getStore().set('defaultProviderId', providerId);
+}
+
+export function setLocalProxyCodexDefaultProviderId(providerId: string): void {
+  getStore().set('codexDefaultProviderId', providerId);
+}
+
+/**
+ * 持久化 codex loopback 固定端口。归一化范式与 {@link setLocalProxyPort} 完全一致
+ * (越界 / 非整数 → 0 未固定)。返回实际写入值。
+ */
+export function setLocalProxyCodexPort(port: number): number {
+  const normalized =
+    Number.isInteger(port) && port >= MIN_PORT && port <= MAX_PORT ? port : 0;
+  getStore().set('codexPort', normalized);
+  return normalized;
+}
+
+/**
+ * 持久化固定端口。传 0 / 越界值一律归一为 0(未固定)——非法端口不落盘,避免下次
+ * 启动拿一个绑不上的端口。返回归一化后实际写入的值。
+ */
+export function setLocalProxyPort(port: number): number {
+  const normalized =
+    Number.isInteger(port) && port >= MIN_PORT && port <= MAX_PORT ? port : 0;
+  getStore().set('port', normalized);
+  return normalized;
+}
+
+/** 端口是否在合法可绑区间(不含 0 哨兵)。UI 校验与 IPC 入参校验共用。 */
+export function isValidLocalProxyPort(port: unknown): port is number {
+  return typeof port === 'number' && Number.isInteger(port) && port >= MIN_PORT && port <= MAX_PORT;
+}
+
+/** 测试隔离:丢弃单例,下次 getStore 重新构造。 */
+export function resetLocalProxySettingsStoreForTest(): void {
+  storeInstance = null;
+}

--- a/apps/desktop/src/main/maker-host/local-proxy-settings-store.ts
+++ b/apps/desktop/src/main/maker-host/local-proxy-settings-store.ts
@@ -140,6 +140,14 @@ export function isValidLocalProxyPort(port: unknown): port is number {
   return typeof port === 'number' && Number.isInteger(port) && port >= MIN_PORT && port <= MAX_PORT;
 }
 
+/**
+ * IPC set-port 入参校验:除了合法可绑端口,额外接受 0 = 「自动(启动时随机绑)」。
+ * 用户清空端口输入框即用 0 把端口从固定改回自动,与状态模型里 0 的语义一致。
+ */
+export function isValidLocalProxyPortOrAuto(port: unknown): port is number {
+  return port === 0 || isValidLocalProxyPort(port);
+}
+
 /** 测试隔离:丢弃单例,下次 getStore 重新构造。 */
 export function resetLocalProxySettingsStoreForTest(): void {
   storeInstance = null;

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -647,7 +647,15 @@ export async function resolveExternalModelRouteDecision(
   const providerId = inferred ?? (defaultProviderId?.trim() || null);
   if (!providerId) return null;
   const resolved = await resolveProviderRouteDecision(providerId, 'claude-code', gatewayKey);
-  return resolved?.decision ?? null;
+  if (!resolved?.decision) return null;
+  // 与会话路由(resolveSessionRouteDecision 的 withRequestPath)一致:自定义 requestPath 的
+  // 供应商必须把 pathOverride 带上。否则外部请求会被 compat-proxy 转发到客户端传入的
+  // Anthropic 路径(/v1/messages),命中 /tenant/acme/infer 这类精确端点的供应商就会失败。
+  // (resolveProviderRouteDecision 本身不套 requestPath,是因为其另一消费者 remote-claude-route
+  //  对自定义 requestPath 直接判不支持;compat-proxy 支持 pathOverride,故这里补上。)
+  return resolved.routing.requestPath
+    ? { ...resolved.decision, pathOverride: resolved.routing.requestPath }
+    : resolved.decision;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -646,6 +646,9 @@ export async function resolveExternalModelRouteDecision(
   const inferred = model ? inferProviderIdForModel(model, 'claude-code') : null;
   const providerId = inferred ?? (defaultProviderId?.trim() || null);
   if (!providerId) return null;
+  // 与下拉候选同源:按模型名命中的供应商也必须是可对外路由的(排除 oauth-passthrough 订阅直连)。
+  // 否则 host 会当它可路由、strip 掉 Cindy bearer 后转发,而外部 CLI 没有订阅 OAuth bearer → 上游 401。
+  if (!isExternalRoutableProvider(providerId, 'claude-code')) return null;
   const resolved = await resolveProviderRouteDecision(providerId, 'claude-code', gatewayKey);
   if (!resolved?.decision) return null;
   // 与会话路由(resolveSessionRouteDecision 的 withRequestPath)一致:自定义 requestPath 的
@@ -676,6 +679,9 @@ export async function resolveExternalCodexRoute(
   const inferred = model ? inferProviderIdForModel(model, 'codex') : null;
   const providerId = inferred ?? (defaultProviderId?.trim() || null);
   if (!providerId) return null;
+  // 与下拉候选同源:按模型名命中的供应商也必须是可对外路由的(排除 oauth-passthrough 订阅直连,
+  // 如内置 OpenAI Codex 路由)。否则 host strip 掉 Cindy bearer 后转发,外部 CLI 无订阅 bearer → 上游 401。
+  if (!isExternalRoutableProvider(providerId, 'codex')) return null;
   return resolveProviderRouteById(providerId, 'codex', model);
 }
 
@@ -697,18 +703,33 @@ const EXTERNAL_ROUTABLE_AUTH_STRATEGIES = new Set([
   'provider-oauth-header',
   'none',
 ]);
+
+/**
+ * 某供应商在给定 agent 下是否可被**外部**客户端路由。判据与 `listExternalRoutableProviders`
+ * 下拉候选**同源**:未在 mutation 窗口内、`xd` 仅在网关可用时、该 agent 有未 disabled 的 routing、
+ * 且 `authStrategy ∈ EXTERNAL_ROUTABLE_AUTH_STRATEGIES`(排除 `oauth-passthrough` 订阅直连)。
+ *
+ * 单独抽出来是因为 `inferProviderIdForModel` 会**按模型名**命中一个下拉里被排除的 passthrough
+ * 供应商(如内置 OpenAI Codex / Anthropic 订阅直连 —— 尤其网关不可用、`xd` 被排除、stock 模型转而
+ * 唯一命中订阅供应商时)。外部解析必须用同一判据拦掉:否则 host 会当它可路由、strip 掉 Cindy
+ * bearer 后转发,而外部 CLI 没有子进程订阅 OAuth bearer,结果必然上游 401(或把不可路由供应商
+ * 当成可路由对外宣告)。
+ */
+function isExternalRoutableProvider(providerId: string, agent: AgentKind): boolean {
+  if (isProviderRouteMutationInProgress(providerId)) return false;
+  if (providerId === 'xd' && !getAppCapabilities().canUseCindyGateway) return false;
+  const provider = getActiveCatalog().providers.find((p) => p.id === providerId);
+  if (!provider || !provider.agents.includes(agent)) return false;
+  const routing = provider.routing[agent];
+  if (!routing || routing.disabled) return false;
+  return EXTERNAL_ROUTABLE_AUTH_STRATEGIES.has(routing.authStrategy);
+}
+
 export function listExternalRoutableProviders(
   agent: AgentKind = 'claude-code',
 ): { id: string; name: string }[] {
   return getActiveCatalog()
-    .providers.filter((provider) => {
-      if (isProviderRouteMutationInProgress(provider.id)) return false;
-      if (provider.id === 'xd' && !getAppCapabilities().canUseCindyGateway) return false;
-      if (!provider.agents.includes(agent)) return false;
-      const routing = provider.routing[agent];
-      if (!routing || routing.disabled) return false;
-      return EXTERNAL_ROUTABLE_AUTH_STRATEGIES.has(routing.authStrategy);
-    })
+    .providers.filter((provider) => isExternalRoutableProvider(provider.id, agent))
     .map((provider) => ({ id: provider.id, name: provider.name }));
 }
 

--- a/apps/desktop/src/main/maker-host/provider-route.ts
+++ b/apps/desktop/src/main/maker-host/provider-route.ts
@@ -487,7 +487,7 @@ export interface ResolvedSessionRoute {
   oauthToken: string | null;
 }
 
-async function resolveProviderRouteById(
+export async function resolveProviderRouteById(
   providerId: string,
   agent: AgentKind,
   wireModel?: string,
@@ -623,6 +623,85 @@ export async function resolveProviderRouteDecision(
     routing,
     decision: buildRouteDecision(routing, gatewayKey, agent, apiKey, oauthToken),
   };
+}
+
+/**
+ * 对外模型代理(给用户自己的 Claude Code CLI 用)的**无会话**路由解析。
+ *
+ * 外部客户端没有 Cindy session,所以不查 getSessionProvider,而是纯按**模型名**推断供应商:
+ *   - `inferProviderIdForModel` 唯一命中 → 用该供应商(注入其真实凭证)。
+ *   - 推断不出(多来源 / stock `claude-*` 同时由 Anthropic 与 XD 提供)→ 回落到用户在设置里选的
+ *     「对外默认供应商」`defaultProviderId`。
+ * 两者都拿不到供应商 → 返回 null(调用方据此 401 / 拒绝,**绝不回落 Cindy 默认网关/订阅**,
+ * 否则外部 token 会被当成 gateway 的 x-api-key 透传上游 —— 见 host 外部分支注释)。
+ *
+ * 只解析 `claude-code` agent(compat-proxy 保持 Anthropic wire 格式)。凭证经
+ * `resolveProviderRouteDecision` → `buildRouteDecision` 注入,外部 token 头由 host 侧再 strip。
+ */
+export async function resolveExternalModelRouteDecision(
+  model: string,
+  gatewayKey: string | null,
+  defaultProviderId: string | null | undefined,
+): Promise<RoutingDecision | null> {
+  const inferred = model ? inferProviderIdForModel(model, 'claude-code') : null;
+  const providerId = inferred ?? (defaultProviderId?.trim() || null);
+  if (!providerId) return null;
+  const resolved = await resolveProviderRouteDecision(providerId, 'claude-code', gatewayKey);
+  return resolved?.decision ?? null;
+}
+
+/**
+ * 对外模型代理的 **Codex(OpenAI Responses)** 无会话路由解析。
+ *
+ * 与 `resolveExternalModelRouteDecision`(claude-code、只需 forward decision)不同,codex
+ * 侧要按 `routing.wireProtocol` 决定是直连 Responses 还是走本地 bridge(openai-chat /
+ * anthropic-messages),因此返回**完整** `ResolvedSessionRoute`(含 routing/apiKey/oauthToken),
+ * 由 host 侧据此分派。
+ *
+ * 纯按模型名推断供应商('codex' agent);推断不出则回落用户在设置里选的「对外默认供应商」。
+ * 两者都拿不到 → 返回 null(调用方 400,**绝不回落 Cindy 默认网关/订阅** —— 见 host 外部分支注释)。
+ */
+export async function resolveExternalCodexRoute(
+  model: string,
+  defaultProviderId: string | null | undefined,
+): Promise<ResolvedSessionRoute | null> {
+  const inferred = model ? inferProviderIdForModel(model, 'codex') : null;
+  const providerId = inferred ?? (defaultProviderId?.trim() || null);
+  if (!providerId) return null;
+  return resolveProviderRouteById(providerId, 'codex', model);
+}
+
+/**
+ * 「对外默认供应商」候选:能被对外模型代理用来给**外部**客户端路由的 claude-code 供应商。
+ *
+ * 判据 = 该供应商 claude-code routing 的 authStrategy 属于「Cindy 能自行注入凭证」的一类
+ * (`gateway-key` 换网关 key、`api-key-header` 注入用户 key、`oauth-token` / `provider-oauth-header`
+ * 注入 host 持有的 token、`none` 无鉴权)。**排除 `oauth-passthrough`**(Anthropic/ChatGPT 订阅直连):
+ * 它依赖子进程自带的订阅 OAuth bearer,外部 CLI 没有,选它只会 401 且无凭证可注入。
+ *
+ * 同时排除:mutation 窗口内的供应商、xd(网关不可用时)、被 disabled 的 routing。
+ * 供 IPC 层投影给设置页下拉;只回 `{id,name}`,不含任何凭证。
+ */
+const EXTERNAL_ROUTABLE_AUTH_STRATEGIES = new Set([
+  'gateway-key',
+  'api-key-header',
+  'oauth-token',
+  'provider-oauth-header',
+  'none',
+]);
+export function listExternalRoutableProviders(
+  agent: AgentKind = 'claude-code',
+): { id: string; name: string }[] {
+  return getActiveCatalog()
+    .providers.filter((provider) => {
+      if (isProviderRouteMutationInProgress(provider.id)) return false;
+      if (provider.id === 'xd' && !getAppCapabilities().canUseCindyGateway) return false;
+      if (!provider.agents.includes(agent)) return false;
+      const routing = provider.routing[agent];
+      if (!routing || routing.disabled) return false;
+      return EXTERNAL_ROUTABLE_AUTH_STRATEGIES.has(routing.authStrategy);
+    })
+    .map((provider) => ({ id: provider.id, name: provider.name }));
 }
 
 export function resolveSessionRouteDecision(

--- a/apps/desktop/src/main/secrets/__tests__/providerSecretStore.test.ts
+++ b/apps/desktop/src/main/secrets/__tests__/providerSecretStore.test.ts
@@ -51,6 +51,8 @@ import {
   GHOST_SECRET_TAIL_MIN_VALUE_CHARS,
   isRendererAccessibleSafeStorageKey,
   PROVIDER_SECRET_IDS,
+  LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY,
+  LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY,
 } from '../../../shared/providerSecrets';
 
 /** 内存版 SecretStorageIo:按"存储键名"读写一个 Map,模拟 safeStorage 文件层。 */
@@ -340,6 +342,15 @@ describe('providerSecretStore account boundary (clearAll + reconcileOwner)', () 
     expect(io.store.has(ghostSecretStorageKey('web-search', 'tavily_api_key'))).toBe(false);
     expect(io.store.has(ghostSecretHintStorageKey('my-ghost', 'api_key'))).toBe(false);
     expect(io.store.get('unrelated_key')).toBe('keep-me');
+  });
+
+  it('clearAll 清掉两族对外代理 token(A=Anthropic / B=Codex),换账号后旧 token 不能串新账号凭证', () => {
+    const store = createProviderSecretStore(io);
+    io.store.set(LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY, 'cindy-local-anthropic');
+    io.store.set(LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY, 'cindy-local-codex');
+    store.clearAll();
+    expect(io.store.has(LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY)).toBe(false);
+    expect(io.store.has(LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY)).toBe(false);
   });
 
   it('reconcileOwner for a different user clears custom MCP tokens (no cross-account bleed)', () => {

--- a/apps/desktop/src/main/secrets/providerSecretStore.ts
+++ b/apps/desktop/src/main/secrets/providerSecretStore.ts
@@ -18,6 +18,8 @@ import {
   GHOST_SECRET_HINT_PREFIX,
   PROVIDER_SECRET_IDS,
   REMOTE_MCP_BRIDGE_TOKEN_STORAGE_KEY,
+  LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY,
+  LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY,
   type ProviderSecretId,
 } from '../../shared/providerSecrets.js';
 import {
@@ -275,6 +277,9 @@ export function createProviderSecretStore(
     // SSH 远端 daemon 直连 MCP bridge 的 persistent token 同清:同机换账号后,
     // 旧账号远端 host 上仍在跑的 daemon env 里的 token 必须失效,防串号。
     io.remove(REMOTE_MCP_BRIDGE_TOKEN_STORAGE_KEY);
+    // 对外模型代理的对外访问 token:同机换账号后,旧账号生成的 token 必须失效,
+    // 防止新账号沿用旧 token 访问代理(背后是新账号的付费凭证)。
+    io.remove(LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY);
     // 动态键名密钥同清(按前缀扫 io.list()):自定义 MCP bearer token(mcp_token_<id>)、
     // 自定义供应商 per-runtime key(provider_key_*)、通用 OAuth 凭证 blob(provider_oauth_*)、
     // 意识 network 槽凭证(ghost_secret_*)。这些不在 PROVIDER_SECRET_IDS 静态集合里,
@@ -563,6 +568,90 @@ export function writeRemoteMcpBridgeToken(value: string): boolean {
       'write remote mcp bridge token failed',
     );
     return false;
+  }
+}
+
+/**
+ * 读取对外模型代理的**对外访问 token**(**main 侧鉴权专用**)。不存在 / safeStorage
+ * 不可用 / 读失败均返回 null。main-only 键,renderer 不经通用 safe-storage IPC 访问。
+ */
+export function readLocalProxyExternalToken(): string | null {
+  try {
+    return electronSecretIo.read(LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'read local proxy external token failed',
+    );
+    return null;
+  }
+}
+
+/** 写入(覆盖)对外模型代理的对外访问 token;返回是否成功落盘。 */
+export function writeLocalProxyExternalToken(value: string): boolean {
+  try {
+    return electronSecretIo.write(LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY, value);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'write local proxy external token failed',
+    );
+    return false;
+  }
+}
+
+/** 删除对外模型代理的对外访问 token;不存在视为成功(幂等)。 */
+export function removeLocalProxyExternalToken(): { success: boolean; error?: string } {
+  try {
+    return electronSecretIo.remove(LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'remove local proxy external token failed',
+    );
+    return { success: false, error: 'remove_failed' };
+  }
+}
+
+/**
+ * 读取 Codex / 通用 OpenAI 出口(B 族)的**对外访问 token**(main 侧鉴权专用)。与 A 族
+ * token 独立存储。不存在 / safeStorage 不可用 / 读失败均返回 null。
+ */
+export function readLocalProxyCodexExternalToken(): string | null {
+  try {
+    return electronSecretIo.read(LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'read local proxy codex external token failed',
+    );
+    return null;
+  }
+}
+
+/** 写入(覆盖)B 族对外访问 token;返回是否成功落盘。 */
+export function writeLocalProxyCodexExternalToken(value: string): boolean {
+  try {
+    return electronSecretIo.write(LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY, value);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'write local proxy codex external token failed',
+    );
+    return false;
+  }
+}
+
+/** 删除 B 族对外访问 token;不存在视为成功(幂等)。 */
+export function removeLocalProxyCodexExternalToken(): { success: boolean; error?: string } {
+  try {
+    return electronSecretIo.remove(LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY);
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      'remove local proxy codex external token failed',
+    );
+    return { success: false, error: 'remove_failed' };
   }
 }
 

--- a/apps/desktop/src/main/secrets/providerSecretStore.ts
+++ b/apps/desktop/src/main/secrets/providerSecretStore.ts
@@ -278,8 +278,10 @@ export function createProviderSecretStore(
     // 旧账号远端 host 上仍在跑的 daemon env 里的 token 必须失效,防串号。
     io.remove(REMOTE_MCP_BRIDGE_TOKEN_STORAGE_KEY);
     // 对外模型代理的对外访问 token:同机换账号后,旧账号生成的 token 必须失效,
-    // 防止新账号沿用旧 token 访问代理(背后是新账号的付费凭证)。
+    // 防止新账号沿用旧 token 访问代理(背后是新账号的付费凭证)。A 族(Anthropic)与
+    // B 族(Codex/OpenAI)两个独立 token 都要清,漏清任一族都会让旧客户端串到新账号凭证。
     io.remove(LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY);
+    io.remove(LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY);
     // 动态键名密钥同清(按前缀扫 io.list()):自定义 MCP bearer token(mcp_token_<id>)、
     // 自定义供应商 per-runtime key(provider_key_*)、通用 OAuth 凭证 blob(provider_oauth_*)、
     // 意识 network 槽凭证(ghost_secret_*)。这些不在 PROVIDER_SECRET_IDS 静态集合里,

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -54,6 +54,14 @@ import type {
   LocalThemeWriteResult,
 } from '../shared/local-themes';
 import type { LocalThemeImportResult } from '../shared/theme-import/types';
+import type {
+  LocalProxyCodexConfigPreviewResult,
+  LocalProxyConfigPreviewResult,
+  LocalProxyConfigWriteResult,
+  LocalProxyEnvExampleResult,
+  LocalProxyMutationResult,
+  LocalProxyServiceState,
+} from '../shared/localProxyService';
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type SupportedLocale } from '../shared/locale';
 import {
   MODEL_ACCESS_STATUS_CHANNEL,
@@ -872,6 +880,42 @@ contextBridge.exposeInMainWorld('electronAPI', {
     // 任何路径参数。失败走 IPC 错误协议(reject,renderer 用 extractIpcError 解码)。
     importExternal: (): Promise<LocalThemeImportResult> =>
       ipcRenderer.invoke('local-themes:import') as Promise<LocalThemeImportResult>,
+  },
+
+  // 对外模型代理(给用户自己的 Claude Code CLI 用):设置页 → 模型供应商 → 模型代理子区块。
+  // 明文 token 只经 getEnvExample / writeExternalConfig 返回(用户主动触发);getState 只给掩码。
+  localProxyService: {
+    getState: (): Promise<LocalProxyServiceState> =>
+      ipcRenderer.invoke('local-proxy:get-state'),
+    setEnabled: (enabled: boolean): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:set-enabled', enabled),
+    setDefaultProvider: (providerId: string): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:set-default-provider', providerId),
+    regenerateToken: (): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:regenerate-token'),
+    setPort: (port: number): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:set-port', port),
+    getEnvExample: (): Promise<LocalProxyEnvExampleResult> =>
+      ipcRenderer.invoke('local-proxy:get-env-example'),
+    previewExternalConfig: (): Promise<LocalProxyConfigPreviewResult> =>
+      ipcRenderer.invoke('local-proxy:preview-external-config'),
+    writeExternalConfig: (): Promise<LocalProxyConfigWriteResult> =>
+      ipcRenderer.invoke('local-proxy:write-external-config'),
+    // Codex / 通用 OpenAI 出口(第三期:独立开关 + 独立 token,另一个 loopback 端口)。
+    setCodexEnabled: (enabled: boolean): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:set-codex-enabled', enabled),
+    regenerateCodexToken: (): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:regenerate-codex-token'),
+    setCodexDefaultProvider: (providerId: string): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:set-codex-default-provider', providerId),
+    setCodexPort: (port: number): Promise<LocalProxyMutationResult> =>
+      ipcRenderer.invoke('local-proxy:set-codex-port', port),
+    getCodexEnvExample: (): Promise<LocalProxyEnvExampleResult> =>
+      ipcRenderer.invoke('local-proxy:get-codex-env-example'),
+    previewCodexConfig: (): Promise<LocalProxyCodexConfigPreviewResult> =>
+      ipcRenderer.invoke('local-proxy:preview-codex-config'),
+    writeCodexConfig: (): Promise<LocalProxyConfigWriteResult> =>
+      ipcRenderer.invoke('local-proxy:write-codex-config'),
   },
 
   // RSB terminal tab(PTY 后端 + xterm.js)

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -58,7 +58,7 @@ import type {
   LocalProxyCodexConfigPreviewResult,
   LocalProxyConfigPreviewResult,
   LocalProxyConfigWriteResult,
-  LocalProxyEnvExampleResult,
+  LocalProxyCopyResult,
   LocalProxyMutationResult,
   LocalProxyServiceState,
 } from '../shared/localProxyService';
@@ -883,7 +883,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // 对外模型代理(给用户自己的 Claude Code CLI 用):设置页 → 模型供应商 → 模型代理子区块。
-  // 明文 token 只经 getEnvExample / writeExternalConfig 返回(用户主动触发);getState 只给掩码。
+  // 明文 token 绝不回传 renderer:复制走 copy* 通道(main 侧 clipboard.writeText,只回 {success});
+  // getState 与两个 preview 通道只给掩码。
   localProxyService: {
     getState: (): Promise<LocalProxyServiceState> =>
       ipcRenderer.invoke('local-proxy:get-state'),
@@ -895,8 +896,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('local-proxy:regenerate-token'),
     setPort: (port: number): Promise<LocalProxyMutationResult> =>
       ipcRenderer.invoke('local-proxy:set-port', port),
-    getEnvExample: (): Promise<LocalProxyEnvExampleResult> =>
-      ipcRenderer.invoke('local-proxy:get-env-example'),
+    copyToken: (): Promise<LocalProxyCopyResult> =>
+      ipcRenderer.invoke('local-proxy:copy-token'),
+    copyEnv: (): Promise<LocalProxyCopyResult> =>
+      ipcRenderer.invoke('local-proxy:copy-env'),
     previewExternalConfig: (): Promise<LocalProxyConfigPreviewResult> =>
       ipcRenderer.invoke('local-proxy:preview-external-config'),
     writeExternalConfig: (): Promise<LocalProxyConfigWriteResult> =>
@@ -910,8 +913,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.invoke('local-proxy:set-codex-default-provider', providerId),
     setCodexPort: (port: number): Promise<LocalProxyMutationResult> =>
       ipcRenderer.invoke('local-proxy:set-codex-port', port),
-    getCodexEnvExample: (): Promise<LocalProxyEnvExampleResult> =>
-      ipcRenderer.invoke('local-proxy:get-codex-env-example'),
+    copyCodexToken: (): Promise<LocalProxyCopyResult> =>
+      ipcRenderer.invoke('local-proxy:copy-codex-token'),
+    copyCodexEnv: (): Promise<LocalProxyCopyResult> =>
+      ipcRenderer.invoke('local-proxy:copy-codex-env'),
+    copyCodexTokenExport: (): Promise<LocalProxyCopyResult> =>
+      ipcRenderer.invoke('local-proxy:copy-codex-token-export'),
     previewCodexConfig: (): Promise<LocalProxyCodexConfigPreviewResult> =>
       ipcRenderer.invoke('local-proxy:preview-codex-config'),
     writeCodexConfig: (): Promise<LocalProxyConfigWriteResult> =>

--- a/apps/desktop/src/renderer/components/settings/ModelProxySubsection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ModelProxySubsection.tsx
@@ -1,0 +1,740 @@
+/**
+ * 模型代理(Model Proxy)子区块 —— 设置 → 模型供应商 页底部。
+ *
+ * 把 Cindy 已有的本地 loopback 代理对外开放,让用户**自己电脑上的 CLI** 复用这里配好的
+ * 供应商 + 凭证(cc-switch 的「服务端」版)。两族出口各自独立开关 + 各自独立 token:
+ *   - Claude Code / Anthropic(`ANTHROPIC_BASE_URL`,Anthropic wire)。
+ *   - Codex / 通用 OpenAI(`OPENAI_BASE_URL`,OpenAI Responses + Chat Completions),另一个 loopback 端口。
+ * 跨族 token 不互通(各 host 只认自己族的 token)。
+ *
+ * 安全:
+ *   - 常态只显示掩码 token;明文只在用户点「复制环境变量 / 写入配置」时经 IPC 取回。
+ *   - 「写入配置」改用户 `~/.claude/settings.json` 或 `~/.codex/config.toml`,先预览(展示改动
+ *     + 冲突)再二次确认;codex 侧 **token 绝不写进文件**,预览里给出需自设的 export 行。
+ *   - 开关、端口、默认供应商、重置 token 都过 main 侧 trusted-renderer 闸(见 IPC register)。
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Check, ChevronDown, Copy, FileCog, RefreshCw } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+import { toast } from '@/lib/toast';
+import { Switch } from '@/components/ui/switch';
+import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
+import { SettingsTextInput } from './SettingsTextInput';
+import type {
+  LocalProxyProviderOption,
+  LocalProxyServiceState,
+} from '../../../shared/localProxyService';
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const CARD_STYLE = {
+  backgroundColor: 'var(--surface-elevated)',
+  borderColor: 'var(--settings-theme-card-border)',
+} as const;
+
+const SUBLABEL_STYLE = { color: 'var(--settings-section-sublabel)' } as const;
+const HINT_STYLE = { color: 'var(--text-tertiary)' } as const;
+const PILL_STYLE = {
+  borderColor: 'var(--settings-input-border)',
+  color: 'var(--settings-input-text)',
+} as const;
+
+export function ModelProxySubsection() {
+  const { t } = useTranslation();
+  const { confirm } = useConfirmDialog();
+  const [state, setState] = useState<LocalProxyServiceState | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [portDraft, setPortDraft] = useState('');
+  const [codexPortDraft, setCodexPortDraft] = useState('');
+
+  const applyState = useCallback((next: LocalProxyServiceState) => {
+    setState(next);
+    setPortDraft(next.port > 0 ? String(next.port) : '');
+    setCodexPortDraft(next.codexPort > 0 ? String(next.codexPort) : '');
+  }, []);
+
+  const refresh = useCallback(async () => {
+    // preload 尚未就绪 / 测试环境未注入该命名空间时,静默保持未加载,不抛未处理拒绝。
+    const api = window.electronAPI?.localProxyService;
+    if (!api) return;
+    try {
+      applyState(await api.getState());
+    } catch {
+      // 取状态失败:维持 state=null(整块不渲染),不影响所在设置页。
+    }
+  }, [applyState]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleToggle = useCallback(
+    async (enabled: boolean) => {
+      setBusy(true);
+      try {
+        const res = await window.electronAPI.localProxyService.setEnabled(enabled);
+        applyState(res.state);
+        if (!res.success) toast.error(t('settings.localProxy.toast.updateFailed'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [applyState, t],
+  );
+
+  const handleRegenerate = useCallback(async () => {
+    const ok = await confirm({
+      title: t('settings.localProxy.regenerate.title'),
+      description: t('settings.localProxy.regenerate.description'),
+      confirmText: t('settings.localProxy.regenerate.confirm'),
+    });
+    if (!ok) return;
+    setBusy(true);
+    try {
+      const res = await window.electronAPI.localProxyService.regenerateToken();
+      applyState(res.state);
+      if (res.success) toast.success(t('settings.localProxy.toast.tokenReset'));
+      else toast.error(t('settings.localProxy.toast.updateFailed'));
+    } finally {
+      setBusy(false);
+    }
+  }, [applyState, confirm, t]);
+
+  const handleCopyToken = useCallback(async () => {
+    const res = await window.electronAPI.localProxyService.getEnvExample();
+    if (!res.success) {
+      toast.error(t('settings.localProxy.toast.notReady'));
+      return;
+    }
+    const ok = await copyToClipboard(res.env.apiKey);
+    if (ok) toast.success(t('settings.localProxy.toast.tokenCopied'));
+    else toast.error(t('settings.localProxy.toast.copyFailed'));
+  }, [t]);
+
+  // ───────── Claude Code / Anthropic 出口 ─────────
+
+  const handleApplyPort = useCallback(async () => {
+    const parsed = Number.parseInt(portDraft, 10);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+      toast.error(t('settings.localProxy.toast.invalidPort'));
+      return;
+    }
+    if (state && parsed === state.port) return;
+    setBusy(true);
+    try {
+      const res = await window.electronAPI.localProxyService.setPort(parsed);
+      applyState(res.state);
+      if (res.success) toast.success(t('settings.localProxy.toast.portApplied'));
+      else toast.error(t('settings.localProxy.toast.updateFailed'));
+    } finally {
+      setBusy(false);
+    }
+  }, [applyState, portDraft, state, t]);
+
+  const handleDefaultProvider = useCallback(
+    async (providerId: string) => {
+      setBusy(true);
+      try {
+        const res = await window.electronAPI.localProxyService.setDefaultProvider(providerId);
+        applyState(res.state);
+        if (!res.success) toast.error(t('settings.localProxy.toast.updateFailed'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [applyState, t],
+  );
+
+  const handleCopyAddress = useCallback(async () => {
+    if (!state?.url) return;
+    const ok = await copyToClipboard(state.url);
+    if (ok) toast.success(t('settings.localProxy.toast.copied'));
+    else toast.error(t('settings.localProxy.toast.copyFailed'));
+  }, [state, t]);
+
+  const handleCopyEnv = useCallback(async () => {
+    const res = await window.electronAPI.localProxyService.getEnvExample();
+    if (!res.success) {
+      toast.error(t('settings.localProxy.toast.notReady'));
+      return;
+    }
+    const ok = await copyToClipboard(res.env.lines.join('\n'));
+    if (ok) toast.success(t('settings.localProxy.toast.envCopied'));
+    else toast.error(t('settings.localProxy.toast.copyFailed'));
+  }, [t]);
+
+  const handleWriteConfig = useCallback(async () => {
+    const preview = await window.electronAPI.localProxyService.previewExternalConfig();
+    if (!preview.success) {
+      toast.error(t('settings.localProxy.toast.notReady'));
+      return;
+    }
+    const { path, exists, proposedEnv, conflicts } = preview.preview;
+    const ok = await confirm({
+      title: t('settings.localProxy.writeConfig.title'),
+      description: exists
+        ? t('settings.localProxy.writeConfig.descExisting', { path })
+        : t('settings.localProxy.writeConfig.descNew', { path }),
+      confirmText: t('settings.localProxy.writeConfig.confirm'),
+      maxWidth: 480,
+      content: (
+        <div className="mt-2 flex flex-col gap-2 text-12">
+          <pre
+            className="overflow-x-auto rounded-lg border p-2.5 font-mono text-11 leading-[1.5]"
+            style={{
+              backgroundColor: 'var(--surface-elevated)',
+              borderColor: 'var(--settings-theme-card-border)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            {Object.entries(proposedEnv)
+              .map(([k, v]) => `${k}=${v}`)
+              .join('\n')}
+          </pre>
+          {conflicts.length > 0 && (
+            <p className="text-11 leading-[1.5]" style={{ color: 'var(--text-warning, var(--text-tertiary))' }}>
+              {t('settings.localProxy.writeConfig.overwriteWarning', {
+                keys: conflicts.map((c) => c.key).join(', '),
+              })}
+            </p>
+          )}
+        </div>
+      ),
+    });
+    if (!ok) return;
+    setBusy(true);
+    try {
+      const res = await window.electronAPI.localProxyService.writeExternalConfig();
+      if (res.success) toast.success(t('settings.localProxy.toast.configWritten'));
+      else toast.error(t('settings.localProxy.toast.configWriteFailed'));
+    } finally {
+      setBusy(false);
+    }
+  }, [confirm, t]);
+
+  // ───────── Codex / 通用 OpenAI 出口 ─────────
+
+  const handleToggleCodex = useCallback(
+    async (enabled: boolean) => {
+      setBusy(true);
+      try {
+        const res = await window.electronAPI.localProxyService.setCodexEnabled(enabled);
+        applyState(res.state);
+        if (!res.success) toast.error(t('settings.localProxy.toast.updateFailed'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [applyState, t],
+  );
+
+  const handleRegenerateCodex = useCallback(async () => {
+    const ok = await confirm({
+      title: t('settings.localProxy.regenerate.title'),
+      description: t('settings.localProxy.regenerate.description'),
+      confirmText: t('settings.localProxy.regenerate.confirm'),
+    });
+    if (!ok) return;
+    setBusy(true);
+    try {
+      const res = await window.electronAPI.localProxyService.regenerateCodexToken();
+      applyState(res.state);
+      if (res.success) toast.success(t('settings.localProxy.toast.tokenReset'));
+      else toast.error(t('settings.localProxy.toast.updateFailed'));
+    } finally {
+      setBusy(false);
+    }
+  }, [applyState, confirm, t]);
+
+  const handleCopyCodexToken = useCallback(async () => {
+    const res = await window.electronAPI.localProxyService.getCodexEnvExample();
+    if (!res.success) {
+      toast.error(t('settings.localProxy.toast.codexNotReady'));
+      return;
+    }
+    const ok = await copyToClipboard(res.env.apiKey);
+    if (ok) toast.success(t('settings.localProxy.toast.tokenCopied'));
+    else toast.error(t('settings.localProxy.toast.copyFailed'));
+  }, [t]);
+
+  const handleApplyCodexPort = useCallback(async () => {
+    const parsed = Number.parseInt(codexPortDraft, 10);
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+      toast.error(t('settings.localProxy.toast.invalidPort'));
+      return;
+    }
+    if (state && parsed === state.codexPort) return;
+    setBusy(true);
+    try {
+      const res = await window.electronAPI.localProxyService.setCodexPort(parsed);
+      applyState(res.state);
+      if (res.success) toast.success(t('settings.localProxy.toast.codexPortApplied'));
+      else toast.error(t('settings.localProxy.toast.updateFailed'));
+    } finally {
+      setBusy(false);
+    }
+  }, [applyState, codexPortDraft, state, t]);
+
+  const handleCodexDefaultProvider = useCallback(
+    async (providerId: string) => {
+      setBusy(true);
+      try {
+        const res =
+          await window.electronAPI.localProxyService.setCodexDefaultProvider(providerId);
+        applyState(res.state);
+        if (!res.success) toast.error(t('settings.localProxy.toast.updateFailed'));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [applyState, t],
+  );
+
+  const handleCopyCodexAddress = useCallback(async () => {
+    if (!state?.codexUrl) return;
+    const ok = await copyToClipboard(state.codexUrl);
+    if (ok) toast.success(t('settings.localProxy.toast.copied'));
+    else toast.error(t('settings.localProxy.toast.copyFailed'));
+  }, [state, t]);
+
+  const handleCopyCodexEnv = useCallback(async () => {
+    const res = await window.electronAPI.localProxyService.getCodexEnvExample();
+    if (!res.success) {
+      toast.error(t('settings.localProxy.toast.codexNotReady'));
+      return;
+    }
+    const ok = await copyToClipboard(res.env.lines.join('\n'));
+    if (ok) toast.success(t('settings.localProxy.toast.codexEnvCopied'));
+    else toast.error(t('settings.localProxy.toast.copyFailed'));
+  }, [t]);
+
+  const handleWriteCodexConfig = useCallback(async () => {
+    const preview = await window.electronAPI.localProxyService.previewCodexConfig();
+    if (!preview.success) {
+      toast.error(t('settings.localProxy.toast.codexNotReady'));
+      return;
+    }
+    const { path, exists, proposedToml, conflicts, tokenExportLine } = preview.preview;
+    const ok = await confirm({
+      title: t('settings.localProxy.openai.writeConfig.title'),
+      description: exists
+        ? t('settings.localProxy.openai.writeConfig.descExisting', { path })
+        : t('settings.localProxy.openai.writeConfig.descNew', { path }),
+      confirmText: t('settings.localProxy.openai.writeConfig.confirm'),
+      maxWidth: 520,
+      content: (
+        <div className="mt-2 flex flex-col gap-2 text-12">
+          <pre
+            className="max-h-[240px] overflow-auto rounded-lg border p-2.5 font-mono text-11 leading-[1.5]"
+            style={{
+              backgroundColor: 'var(--surface-elevated)',
+              borderColor: 'var(--settings-theme-card-border)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            {proposedToml}
+          </pre>
+          {conflicts.length > 0 && (
+            <p className="text-11 leading-[1.5]" style={{ color: 'var(--text-warning, var(--text-tertiary))' }}>
+              {t('settings.localProxy.writeConfig.overwriteWarning', {
+                keys: conflicts.map((c) => c.key).join(', '),
+              })}
+            </p>
+          )}
+          {/* token 不入文件:提示用户需自行在外部 shell 设 CINDY_LOCAL_TOKEN(codex 从 env_key 读)。 */}
+          <p className="text-11 leading-[1.5]" style={HINT_STYLE}>
+            {t('settings.localProxy.openai.writeConfig.tokenExportHint')}
+          </p>
+          <pre
+            className="overflow-x-auto rounded-lg border p-2.5 font-mono text-11 leading-[1.5]"
+            style={{
+              backgroundColor: 'var(--surface-elevated)',
+              borderColor: 'var(--settings-theme-card-border)',
+              color: 'var(--text-secondary)',
+            }}
+          >
+            {tokenExportLine}
+          </pre>
+        </div>
+      ),
+    });
+    if (!ok) return;
+    setBusy(true);
+    try {
+      const res = await window.electronAPI.localProxyService.writeCodexConfig();
+      if (res.success) toast.success(t('settings.localProxy.toast.codexConfigWritten'));
+      else toast.error(t('settings.localProxy.toast.codexConfigWriteFailed'));
+    } finally {
+      setBusy(false);
+    }
+  }, [confirm, t]);
+
+  if (!state) return null;
+
+  /** 一族出口卡片里的「对外默认供应商」下拉(两族共用外形,只是数据源不同)。 */
+  const renderProviderSelect = (
+    providers: LocalProxyProviderOption[],
+    value: string,
+    onChange: (id: string) => void,
+    ariaLabel: string,
+  ) =>
+    providers.length === 0 ? (
+      <p className="text-11 leading-[1.4]" style={HINT_STYLE}>
+        {t('settings.localProxy.noProviders')}
+      </p>
+    ) : (
+      <div className="relative w-full max-w-[280px]">
+        <select
+          value={value}
+          disabled={busy}
+          onChange={(e) => void onChange(e.target.value)}
+          className={cn(
+            'h-9 w-full min-w-0 appearance-none rounded-full border py-0 pl-3 pr-9 text-12 outline-none disabled:opacity-50',
+            'bg-[var(--settings-input-bg)] text-[var(--settings-input-text)]',
+            'border-[var(--settings-input-border)] focus:ring-2 focus:ring-[var(--focus-ring-soft)]',
+          )}
+          aria-label={ariaLabel}
+        >
+          <option value="">{t('settings.localProxy.defaultProviderNone')}</option>
+          {providers.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name}
+            </option>
+          ))}
+        </select>
+        <ChevronDown
+          size={15}
+          className="pointer-events-none absolute right-3.5 top-1/2 -translate-y-1/2 opacity-75"
+          style={{ color: 'var(--settings-input-text)' }}
+        />
+      </div>
+    );
+
+  /** 一族出口卡片里的独立对外 token 块(掩码展示 + 复制 + 重置)。两族外形一致,数据/回调不同。 */
+  const renderTokenBlock = (
+    masked: string | null,
+    onCopy: () => void,
+    onRegenerate: () => void,
+  ) => (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-12 font-medium" style={SUBLABEL_STYLE}>
+        {t('settings.localProxy.token')}
+      </span>
+      <div className="flex items-center gap-2">
+        <SettingsTextInput
+          value={masked ?? ''}
+          onChange={() => {}}
+          size="sm"
+          mono
+          className="flex-1 min-w-0"
+        />
+        <button
+          type="button"
+          onClick={onRegenerate}
+          disabled={busy}
+          className="inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-12 disabled:opacity-50"
+          style={PILL_STYLE}
+        >
+          <RefreshCw size={13} />
+          {t('settings.localProxy.regenerate.button')}
+        </button>
+        <button
+          type="button"
+          onClick={onCopy}
+          className="inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-12"
+          style={PILL_STYLE}
+        >
+          <Copy size={13} />
+          {t('settings.localProxy.copy')}
+        </button>
+      </div>
+    </div>
+  );
+
+  /**
+   * 服务地址 + 端口合并成「一个框」:scheme+host 前缀固定不可改(从实际 url 解析,回落 loopback
+   * 默认),只有端口段可编辑;「应用」提交改端口(会重启本地代理),「复制」拷贝**完整** url。
+   * url 为 null(代理未就绪)时退化为只读的「未就绪」框,端口不可编辑。
+   */
+  const renderAddressField = (
+    url: string | null,
+    portDraft: string,
+    setPortDraft: (v: string) => void,
+    onApply: () => void,
+    onCopy: () => void,
+    portHint: string,
+    addressLabel: string,
+  ) => {
+    let prefix = 'http://127.0.0.1:';
+    if (url) {
+      try {
+        const u = new URL(url);
+        prefix = `${u.protocol}//${u.hostname}:`;
+      } catch {
+        // 解析失败保留 loopback 默认前缀。
+      }
+    }
+    return (
+      <div className="flex flex-col gap-1.5">
+        <span className="text-12 font-medium" style={SUBLABEL_STYLE}>
+          {addressLabel}
+        </span>
+        <div className="flex items-center gap-2">
+          {url ? (
+            <div
+              className="flex h-8 min-w-0 flex-1 items-center rounded-full border px-3 text-12 focus-within:ring-2 focus-within:ring-[var(--focus-ring)]"
+              style={{
+                backgroundColor: 'var(--surface-elevated)',
+                borderColor: 'var(--settings-input-border)',
+              }}
+            >
+              {/* 固定前缀:scheme + 127.0.0.1(不可改),弱化色以示只读。 */}
+              <span
+                className="shrink-0 font-mono"
+                style={{ color: 'var(--settings-input-placeholder)' }}
+              >
+                {prefix}
+              </span>
+              {/* 仅端口可编辑。 */}
+              <input
+                value={portDraft}
+                onChange={(e) => setPortDraft(e.target.value)}
+                placeholder={t('settings.localProxy.portPlaceholder')}
+                inputMode="numeric"
+                aria-label={t('settings.localProxy.port')}
+                className="min-w-0 flex-1 bg-transparent font-mono outline-none placeholder:text-[var(--settings-input-placeholder)]"
+                style={{ color: 'var(--settings-input-text)' }}
+              />
+            </div>
+          ) : (
+            <SettingsTextInput
+              value={t('settings.localProxy.notReady')}
+              onChange={() => {}}
+              size="sm"
+              mono
+              className="flex-1 min-w-0"
+            />
+          )}
+          <button
+            type="button"
+            onClick={onApply}
+            disabled={busy || !url}
+            className="inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-12 disabled:opacity-50"
+            style={PILL_STYLE}
+          >
+            <Check size={13} />
+            {t('settings.localProxy.applyPort')}
+          </button>
+          <button
+            type="button"
+            onClick={onCopy}
+            disabled={!url}
+            className="inline-flex h-8 items-center gap-1.5 rounded-full border px-3 text-12 disabled:opacity-50"
+            style={PILL_STYLE}
+          >
+            <Copy size={13} />
+            {t('settings.localProxy.copy')}
+          </button>
+        </div>
+        <p className="text-11 leading-[1.4]" style={HINT_STYLE}>
+          {portHint}
+        </p>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-3 rounded-xl border p-4"
+      style={{
+        backgroundColor: 'var(--settings-theme-card-bg)',
+        borderColor: 'var(--settings-theme-card-border)',
+      }}
+    >
+      {/* 子区块标题(无总开关:两族各自独立开启) */}
+      <div className="flex flex-col gap-1">
+        <span
+          className="text-14 font-medium leading-[1.2]"
+          style={{ color: 'var(--settings-section-title)' }}
+        >
+          {t('settings.localProxy.title')}
+        </span>
+        <p
+          className="text-12 leading-[1.5]"
+          style={{ color: 'var(--settings-section-desc)' }}
+        >
+          {t('settings.localProxy.subtitle')}
+        </p>
+      </div>
+
+      {/* 卡片 A:Claude Code / Anthropic —— 独立开关 + 独立 token */}
+      <div className="flex flex-col gap-3 rounded-lg border p-3" style={CARD_STYLE}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-12 font-semibold" style={{ color: 'var(--settings-section-title)' }}>
+              {t('settings.localProxy.anthropic.title')}
+            </span>
+            <p className="text-11 leading-[1.5]" style={HINT_STYLE}>
+              {t('settings.localProxy.anthropic.subtitle')}
+            </p>
+          </div>
+          <Switch
+            checked={state.enabled}
+            disabled={busy}
+            onCheckedChange={(v) => void handleToggle(v)}
+            aria-label={t('settings.localProxy.anthropic.title')}
+          />
+        </div>
+
+        {state.enabled && (
+          <div
+            className="flex flex-col gap-3 border-t pt-3"
+            style={{ borderColor: 'var(--settings-theme-card-border)' }}
+          >
+            {renderTokenBlock(
+              state.maskedToken,
+              () => void handleCopyToken(),
+              () => void handleRegenerate(),
+            )}
+
+            {renderAddressField(
+              state.url,
+              portDraft,
+              setPortDraft,
+              () => void handleApplyPort(),
+              () => void handleCopyAddress(),
+              t('settings.localProxy.portHint'),
+              t('settings.localProxy.address'),
+            )}
+
+            <div className="flex flex-col gap-1.5">
+              <span className="text-12 font-medium" style={SUBLABEL_STYLE}>
+                {t('settings.localProxy.defaultProvider')}
+              </span>
+              {renderProviderSelect(
+                state.providers,
+                state.defaultProviderId,
+                handleDefaultProvider,
+                t('settings.localProxy.defaultProvider'),
+              )}
+              <p className="text-11 leading-[1.4]" style={HINT_STYLE}>
+                {t('settings.localProxy.defaultProviderHint')}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => void handleCopyEnv()}
+                className="inline-flex h-9 items-center gap-1.5 rounded-full border px-4 text-12 font-medium"
+                style={PILL_STYLE}
+              >
+                <Copy size={14} />
+                {t('settings.localProxy.copyEnv')}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleWriteConfig()}
+                disabled={busy}
+                className="inline-flex h-9 items-center gap-1.5 rounded-full border px-4 text-12 font-medium disabled:opacity-50"
+                style={PILL_STYLE}
+              >
+                <FileCog size={14} />
+                {t('settings.localProxy.writeConfig.button')}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 卡片 B:Codex / 通用 OpenAI —— 独立开关 + 独立 token */}
+      <div className="flex flex-col gap-3 rounded-lg border p-3" style={CARD_STYLE}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-12 font-semibold" style={{ color: 'var(--settings-section-title)' }}>
+              {t('settings.localProxy.openai.title')}
+            </span>
+            <p className="text-11 leading-[1.5]" style={HINT_STYLE}>
+              {t('settings.localProxy.openai.subtitle')}
+            </p>
+          </div>
+          <Switch
+            checked={state.codexEnabled}
+            disabled={busy}
+            onCheckedChange={(v) => void handleToggleCodex(v)}
+            aria-label={t('settings.localProxy.openai.title')}
+          />
+        </div>
+
+        {state.codexEnabled && (
+          <div
+            className="flex flex-col gap-3 border-t pt-3"
+            style={{ borderColor: 'var(--settings-theme-card-border)' }}
+          >
+            {renderTokenBlock(
+              state.codexMaskedToken,
+              () => void handleCopyCodexToken(),
+              () => void handleRegenerateCodex(),
+            )}
+
+            {renderAddressField(
+              state.codexUrl,
+              codexPortDraft,
+              setCodexPortDraft,
+              () => void handleApplyCodexPort(),
+              () => void handleCopyCodexAddress(),
+              t('settings.localProxy.openai.portHint'),
+              t('settings.localProxy.openai.address'),
+            )}
+
+            <div className="flex flex-col gap-1.5">
+              <span className="text-12 font-medium" style={SUBLABEL_STYLE}>
+                {t('settings.localProxy.openai.defaultProvider')}
+              </span>
+              {renderProviderSelect(
+                state.codexProviders,
+                state.codexDefaultProviderId,
+                handleCodexDefaultProvider,
+                t('settings.localProxy.openai.defaultProvider'),
+              )}
+              <p className="text-11 leading-[1.4]" style={HINT_STYLE}>
+                {t('settings.localProxy.openai.defaultProviderHint')}
+              </p>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => void handleCopyCodexEnv()}
+                className="inline-flex h-9 items-center gap-1.5 rounded-full border px-4 text-12 font-medium"
+                style={PILL_STYLE}
+              >
+                <Copy size={14} />
+                {t('settings.localProxy.openai.copyEnv')}
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleWriteCodexConfig()}
+                disabled={busy || !state.codexUrl}
+                className="inline-flex h-9 items-center gap-1.5 rounded-full border px-4 text-12 font-medium disabled:opacity-50"
+                style={PILL_STYLE}
+              >
+                <FileCog size={14} />
+                {t('settings.localProxy.openai.writeConfig.button')}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/settings/ModelProxySubsection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ModelProxySubsection.tsx
@@ -109,14 +109,10 @@ export function ModelProxySubsection() {
     }
   }, [applyState, confirm, t]);
 
+  // 复制在 main 侧完成(clipboard.writeText),明文不进 renderer;这里只据 {success} 提示。
   const handleCopyToken = useCallback(async () => {
-    const res = await window.electronAPI.localProxyService.getEnvExample();
-    if (!res.success) {
-      toast.error(t('settings.localProxy.toast.notReady'));
-      return;
-    }
-    const ok = await copyToClipboard(res.env.apiKey);
-    if (ok) toast.success(t('settings.localProxy.toast.tokenCopied'));
+    const res = await window.electronAPI.localProxyService.copyToken();
+    if (res.success) toast.success(t('settings.localProxy.toast.tokenCopied'));
     else toast.error(t('settings.localProxy.toast.copyFailed'));
   }, [t]);
 
@@ -163,13 +159,8 @@ export function ModelProxySubsection() {
   }, [state, t]);
 
   const handleCopyEnv = useCallback(async () => {
-    const res = await window.electronAPI.localProxyService.getEnvExample();
-    if (!res.success) {
-      toast.error(t('settings.localProxy.toast.notReady'));
-      return;
-    }
-    const ok = await copyToClipboard(res.env.lines.join('\n'));
-    if (ok) toast.success(t('settings.localProxy.toast.envCopied'));
+    const res = await window.electronAPI.localProxyService.copyEnv();
+    if (res.success) toast.success(t('settings.localProxy.toast.envCopied'));
     else toast.error(t('settings.localProxy.toast.copyFailed'));
   }, [t]);
 
@@ -257,13 +248,15 @@ export function ModelProxySubsection() {
   }, [applyState, confirm, t]);
 
   const handleCopyCodexToken = useCallback(async () => {
-    const res = await window.electronAPI.localProxyService.getCodexEnvExample();
-    if (!res.success) {
-      toast.error(t('settings.localProxy.toast.codexNotReady'));
-      return;
-    }
-    const ok = await copyToClipboard(res.env.apiKey);
-    if (ok) toast.success(t('settings.localProxy.toast.tokenCopied'));
+    const res = await window.electronAPI.localProxyService.copyCodexToken();
+    if (res.success) toast.success(t('settings.localProxy.toast.tokenCopied'));
+    else toast.error(t('settings.localProxy.toast.copyFailed'));
+  }, [t]);
+
+  // 写 config.toml 弹窗里 `export CINDY_LOCAL_TOKEN=…` 行掩码展示,复制其明文走 main 剪贴板。
+  const handleCopyCodexTokenExport = useCallback(async () => {
+    const res = await window.electronAPI.localProxyService.copyCodexTokenExport();
+    if (res.success) toast.success(t('settings.localProxy.toast.tokenCopied'));
     else toast.error(t('settings.localProxy.toast.copyFailed'));
   }, [t]);
 
@@ -309,13 +302,8 @@ export function ModelProxySubsection() {
   }, [state, t]);
 
   const handleCopyCodexEnv = useCallback(async () => {
-    const res = await window.electronAPI.localProxyService.getCodexEnvExample();
-    if (!res.success) {
-      toast.error(t('settings.localProxy.toast.codexNotReady'));
-      return;
-    }
-    const ok = await copyToClipboard(res.env.lines.join('\n'));
-    if (ok) toast.success(t('settings.localProxy.toast.codexEnvCopied'));
+    const res = await window.electronAPI.localProxyService.copyCodexEnv();
+    if (res.success) toast.success(t('settings.localProxy.toast.codexEnvCopied'));
     else toast.error(t('settings.localProxy.toast.copyFailed'));
   }, [t]);
 
@@ -352,20 +340,32 @@ export function ModelProxySubsection() {
               })}
             </p>
           )}
-          {/* token 不入文件:提示用户需自行在外部 shell 设 CINDY_LOCAL_TOKEN(codex 从 env_key 读)。 */}
+          {/* token 不入文件:提示用户需自行在外部 shell 设 CINDY_LOCAL_TOKEN(codex 从 env_key 读)。
+              这里展示的是掩码行,复制按钮走 main 剪贴板通道拿真实明文。 */}
           <p className="text-11 leading-[1.5]" style={HINT_STYLE}>
             {t('settings.localProxy.openai.writeConfig.tokenExportHint')}
           </p>
-          <pre
-            className="overflow-x-auto rounded-lg border p-2.5 font-mono text-11 leading-[1.5]"
-            style={{
-              backgroundColor: 'var(--surface-elevated)',
-              borderColor: 'var(--settings-theme-card-border)',
-              color: 'var(--text-secondary)',
-            }}
-          >
-            {tokenExportLine}
-          </pre>
+          <div className="flex items-center gap-2">
+            <pre
+              className="min-w-0 flex-1 overflow-x-auto rounded-lg border p-2.5 font-mono text-11 leading-[1.5]"
+              style={{
+                backgroundColor: 'var(--surface-elevated)',
+                borderColor: 'var(--settings-theme-card-border)',
+                color: 'var(--text-secondary)',
+              }}
+            >
+              {tokenExportLine}
+            </pre>
+            <button
+              type="button"
+              onClick={() => void handleCopyCodexTokenExport()}
+              className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-full border px-3 text-12"
+              style={PILL_STYLE}
+            >
+              <Copy size={13} />
+              {t('settings.localProxy.copy')}
+            </button>
+          </div>
         </div>
       ),
     });
@@ -378,7 +378,7 @@ export function ModelProxySubsection() {
     } finally {
       setBusy(false);
     }
-  }, [confirm, t]);
+  }, [confirm, handleCopyCodexTokenExport, t]);
 
   if (!state) return null;
 

--- a/apps/desktop/src/renderer/components/settings/ModelProxySubsection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ModelProxySubsection.tsx
@@ -123,8 +123,9 @@ export function ModelProxySubsection() {
   // ───────── Claude Code / Anthropic 出口 ─────────
 
   const handleApplyPort = useCallback(async () => {
-    const parsed = Number.parseInt(portDraft, 10);
-    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    // 空/纯空白 = 恢复「自动」(端口 0 → host 启动时随机绑),与 placeholder 文案一致。
+    const parsed = portDraft.trim() === '' ? 0 : Number.parseInt(portDraft, 10);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
       toast.error(t('settings.localProxy.toast.invalidPort'));
       return;
     }
@@ -267,8 +268,9 @@ export function ModelProxySubsection() {
   }, [t]);
 
   const handleApplyCodexPort = useCallback(async () => {
-    const parsed = Number.parseInt(codexPortDraft, 10);
-    if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    // 空/纯空白 = 恢复「自动」(端口 0 → host 启动时随机绑),与 placeholder 文案一致。
+    const parsed = codexPortDraft.trim() === '' ? 0 : Number.parseInt(codexPortDraft, 10);
+    if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
       toast.error(t('settings.localProxy.toast.invalidPort'));
       return;
     }

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -71,6 +71,7 @@ import { BILLING_CURRENCY, formatBillingAmount } from '@/features/billing/money'
 import { canAccessBillingSettings } from './billingVisibility';
 import { resolveXdAssetModuleState } from './providerAssetModule';
 import { CustomProviderDialog } from './CustomProviderDialog';
+import { ModelProxySubsection } from './ModelProxySubsection';
 import { AddProviderWizard, type WizardEntry } from './AddProviderWizard';
 import { OAuthDeviceCodeCard } from './OAuthDeviceCodeCard';
 import { SettingsTextInput } from './SettingsTextInput';
@@ -2446,6 +2447,9 @@ export function ProvidersSection() {
           </div>
         </div>
       )}
+
+      {/* 模型代理:把本地代理对外开放给用户自己的 Claude Code CLI(cc-switch 的服务端版)。 */}
+      {!loading && <ModelProxySubsection />}
 
       {wizard && (
         <AddProviderWizard

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2674,6 +2674,77 @@
         "toggleFailed": "Failed to switch silent encrypted-content retry"
       }
     },
+    "localProxy": {
+      "title": "Model Proxy",
+      "subtitle": "Open the local service to command-line tools on your own machine: set a few environment variables to reuse the providers and credentials configured here. Compatible with both Anthropic API clients (such as Claude Code) and OpenAI API clients (such as Codex and other OpenAI-compatible tools).",
+      "address": "Address",
+      "notReady": "Service not ready",
+      "copy": "Copy",
+      "port": "Port",
+      "portPlaceholder": "Auto",
+      "applyPort": "Apply",
+      "portHint": "Enabling the service pins the current port. Changing it restarts the local service and may interrupt in-flight requests.",
+      "token": "Access token",
+      "regenerate": {
+        "button": "Reset",
+        "title": "Reset access token?",
+        "description": "The old token stops working immediately. Any external client you configured must switch to the new token.",
+        "confirm": "Reset"
+      },
+      "defaultProvider": "Default provider",
+      "defaultProviderNone": "None (route by model name)",
+      "noProviders": "No routable providers yet. Add and configure one above first.",
+      "defaultProviderHint": "Used as a fallback when a model name doesn't map to a single provider.",
+      "copyEnv": "Copy environment variables",
+      "writeConfig": {
+        "button": "Write Claude Code config",
+        "title": "Write Claude Code config?",
+        "descExisting": "Connection details will be merged into your existing config file ({{path}}), keeping other fields.",
+        "descNew": "A config file will be created with the connection details ({{path}}).",
+        "confirm": "Write",
+        "overwriteWarning": "These existing entries will be overwritten: {{keys}}"
+      },
+      "toast": {
+        "updateFailed": "Update failed",
+        "invalidPort": "Port must be between 1 and 65535",
+        "portApplied": "Port updated",
+        "tokenReset": "Access token reset",
+        "copied": "Copied",
+        "copyFailed": "Copy failed",
+        "envCopied": "Environment variables copied",
+        "tokenCopied": "Access token copied",
+        "notReady": "Service not ready",
+        "configWritten": "Config written",
+        "configWriteFailed": "Failed to write config",
+        "codexPortApplied": "Port updated",
+        "codexEnvCopied": "Environment variables copied",
+        "codexNotReady": "Codex service not ready",
+        "codexConfigWritten": "Codex config written",
+        "codexConfigWriteFailed": "Failed to write Codex config"
+      },
+      "anthropic": {
+        "title": "Claude Code / Anthropic",
+        "subtitle": "For tools that speak the Anthropic format, such as Claude Code: point ANTHROPIC_BASE_URL at the local port."
+      },
+      "openai": {
+        "title": "Codex / OpenAI",
+        "subtitle": "For tools that speak the OpenAI format: Codex uses Responses, other tools use Chat Completions, on a separate local port.",
+        "address": "Service address",
+        "port": "Port",
+        "portHint": "Enabling the service pins the current port; changing it restarts the local Codex service and may interrupt in-flight requests.",
+        "defaultProvider": "Default provider",
+        "defaultProviderHint": "Falls back to this provider when the model name doesn't map to a single provider.",
+        "copyEnv": "Copy environment variables",
+        "writeConfig": {
+          "button": "Write Codex config",
+          "title": "Write Codex config?",
+          "descExisting": "Merges the connection details into the existing config file ({{path}}), keeping other fields.",
+          "descNew": "Creates the config file and writes the connection details ({{path}}).",
+          "confirm": "Write",
+          "tokenExportHint": "The access token is never written to the file. Set the following environment variable yourself in the terminal where you run Codex:"
+        }
+      }
+    },
     "remoteControl": {
       "title": "Remote Connection",
       "description": "Control your other signed-in devices remotely, or connect to a remote host over SSH.",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2673,6 +2673,77 @@
         "toggleFailed": "暗号化コンテンツの静かな再試行の切り替えに失敗しました"
       }
     },
+    "localProxy": {
+      "title": "モデルプロキシ",
+      "subtitle": "ローカルサービスをあなた自身のコマンドラインツールに公開します。環境変数を設定するだけで、ここで構成したプロバイダーと認証情報を再利用できます。Anthropic API 形式(Claude Code など)と OpenAI API 形式(Codex やその他の OpenAI 互換ツール)の両方に対応します。",
+      "address": "アドレス",
+      "notReady": "サービスは準備できていません",
+      "copy": "コピー",
+      "port": "ポート",
+      "portPlaceholder": "自動",
+      "applyPort": "適用",
+      "portHint": "サービスを有効にすると現在のポートが固定されます。変更するとローカルサービスが再起動し、処理中のリクエストが中断される場合があります。",
+      "token": "アクセストークン",
+      "regenerate": {
+        "button": "再生成",
+        "title": "アクセストークンを再生成しますか？",
+        "description": "古いトークンは直ちに無効になります。設定済みの外部クライアントは新しいトークンに切り替える必要があります。",
+        "confirm": "再生成"
+      },
+      "defaultProvider": "既定のプロバイダー",
+      "defaultProviderNone": "指定しない（モデル名でルーティング）",
+      "noProviders": "ルーティングできるプロバイダーがまだありません。まず上で追加して構成してください。",
+      "defaultProviderHint": "モデル名が単一のプロバイダーに対応しない場合のフォールバックとして使用します。",
+      "copyEnv": "環境変数をコピー",
+      "writeConfig": {
+        "button": "Claude Code の設定に書き込む",
+        "title": "Claude Code の設定に書き込みますか？",
+        "descExisting": "接続情報を既存の設定ファイル（{{path}}）にマージし、他のフィールドは保持します。",
+        "descNew": "接続情報を含む設定ファイル（{{path}}）を作成します。",
+        "confirm": "書き込む",
+        "overwriteWarning": "次の既存項目が上書きされます：{{keys}}"
+      },
+      "toast": {
+        "updateFailed": "更新に失敗しました",
+        "invalidPort": "ポートは 1〜65535 の範囲で指定してください",
+        "portApplied": "ポートを更新しました",
+        "tokenReset": "アクセストークンを再生成しました",
+        "copied": "コピーしました",
+        "copyFailed": "コピーに失敗しました",
+        "envCopied": "環境変数をコピーしました",
+        "tokenCopied": "アクセストークンをコピーしました",
+        "notReady": "サービスは準備できていません",
+        "configWritten": "設定を書き込みました",
+        "configWriteFailed": "設定の書き込みに失敗しました",
+        "codexPortApplied": "ポートを更新しました",
+        "codexEnvCopied": "環境変数をコピーしました",
+        "codexNotReady": "Codex サービスが準備できていません",
+        "codexConfigWritten": "Codex 設定を書き込みました",
+        "codexConfigWriteFailed": "Codex 設定の書き込みに失敗しました"
+      },
+      "anthropic": {
+        "title": "Claude Code / Anthropic",
+        "subtitle": "Anthropic 形式を話すツール向け(Claude Code など):ANTHROPIC_BASE_URL をローカルポートに向けるだけです。"
+      },
+      "openai": {
+        "title": "Codex / OpenAI",
+        "subtitle": "OpenAI 形式を話すツール向け:Codex は Responses、その他のツールは Chat Completions を使用し、別のローカルポートで動作します。",
+        "address": "サービスアドレス",
+        "port": "ポート",
+        "portHint": "サービスを有効にすると現在のポートが固定されます。ポートを変更するとローカルの Codex サービスが再起動し、実行中のリクエストが中断されることがあります。",
+        "defaultProvider": "デフォルトプロバイダー",
+        "defaultProviderHint": "モデル名から単一のプロバイダーを特定できない場合、このプロバイダーにフォールバックします。",
+        "copyEnv": "環境変数をコピー",
+        "writeConfig": {
+          "button": "Codex 設定に書き込む",
+          "title": "Codex 設定に書き込みますか?",
+          "descExisting": "接続情報を既存の設定ファイル({{path}})にマージし、他のフィールドは保持します。",
+          "descNew": "設定ファイルを作成し、接続情報を書き込みます({{path}})。",
+          "confirm": "書き込む",
+          "tokenExportHint": "アクセストークンはファイルに書き込まれません。Codex を実行するターミナルで、次の環境変数を自分で設定してください:"
+        }
+      }
+    },
     "remoteControl": {
       "title": "リモート接続",
       "description": "同じアカウントのデバイスを相互に遠隔操作したり、SSH でリモートホストに接続したりできます。",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2673,6 +2673,77 @@
         "toggleFailed": "암호화 콘텐츠 자동 재시도 전환에 실패했습니다"
       }
     },
+    "localProxy": {
+      "title": "모델 프록시",
+      "subtitle": "로컬 서비스를 사용자 컴퓨터의 명령줄 도구에 개방합니다. 환경 변수를 설정하면 여기서 구성한 제공자와 자격 증명을 재사용할 수 있습니다. Anthropic API 형식(Claude Code 등)과 OpenAI API 형식(Codex 및 기타 OpenAI 호환 도구)을 모두 지원합니다.",
+      "address": "주소",
+      "notReady": "서비스가 준비되지 않았습니다",
+      "copy": "복사",
+      "port": "포트",
+      "portPlaceholder": "자동",
+      "applyPort": "적용",
+      "portHint": "서비스를 켜면 현재 포트가 고정됩니다. 포트를 변경하면 로컬 서비스가 다시 시작되어 진행 중인 요청이 중단될 수 있습니다.",
+      "token": "액세스 토큰",
+      "regenerate": {
+        "button": "재설정",
+        "title": "액세스 토큰을 재설정할까요?",
+        "description": "이전 토큰은 즉시 무효화됩니다. 구성한 외부 클라이언트는 새 토큰으로 교체해야 합니다.",
+        "confirm": "재설정"
+      },
+      "defaultProvider": "기본 제공자",
+      "defaultProviderNone": "지정 안 함(모델 이름으로 라우팅)",
+      "noProviders": "아직 라우팅할 수 있는 제공자가 없습니다. 먼저 위에서 추가하고 구성하세요.",
+      "defaultProviderHint": "모델 이름이 단일 제공자에 매핑되지 않을 때 대체로 사용됩니다.",
+      "copyEnv": "환경 변수 복사",
+      "writeConfig": {
+        "button": "Claude Code 설정에 쓰기",
+        "title": "Claude Code 설정에 쓸까요?",
+        "descExisting": "연결 정보를 기존 설정 파일({{path}})에 병합하고 다른 필드는 유지합니다.",
+        "descNew": "연결 정보가 포함된 설정 파일({{path}})을 만듭니다.",
+        "confirm": "쓰기",
+        "overwriteWarning": "다음 기존 항목이 덮어써집니다: {{keys}}"
+      },
+      "toast": {
+        "updateFailed": "업데이트 실패",
+        "invalidPort": "포트는 1~65535 사이여야 합니다",
+        "portApplied": "포트가 업데이트되었습니다",
+        "tokenReset": "액세스 토큰이 재설정되었습니다",
+        "copied": "복사됨",
+        "copyFailed": "복사 실패",
+        "envCopied": "환경 변수가 복사되었습니다",
+        "tokenCopied": "액세스 토큰이 복사되었습니다",
+        "notReady": "서비스가 준비되지 않았습니다",
+        "configWritten": "설정이 기록되었습니다",
+        "configWriteFailed": "설정 쓰기 실패",
+        "codexPortApplied": "포트가 업데이트되었습니다",
+        "codexEnvCopied": "환경 변수를 복사했습니다",
+        "codexNotReady": "Codex 서비스가 준비되지 않았습니다",
+        "codexConfigWritten": "Codex 구성을 저장했습니다",
+        "codexConfigWriteFailed": "Codex 구성 쓰기에 실패했습니다"
+      },
+      "anthropic": {
+        "title": "Claude Code / Anthropic",
+        "subtitle": "Anthropic 형식을 사용하는 도구용(Claude Code 등): ANTHROPIC_BASE_URL을 로컬 포트로 지정하면 됩니다."
+      },
+      "openai": {
+        "title": "Codex / OpenAI",
+        "subtitle": "OpenAI 형식을 사용하는 도구용: Codex는 Responses를, 다른 도구는 Chat Completions를 사용하며 별도의 로컬 포트에서 동작합니다.",
+        "address": "서비스 주소",
+        "port": "포트",
+        "portHint": "서비스를 켜면 현재 포트가 고정됩니다. 포트를 변경하면 로컬 Codex 서비스가 다시 시작되어 진행 중인 요청이 중단될 수 있습니다.",
+        "defaultProvider": "기본 제공자",
+        "defaultProviderHint": "모델 이름으로 단일 제공자를 확정할 수 없을 때 이 제공자로 대체합니다.",
+        "copyEnv": "환경 변수 복사",
+        "writeConfig": {
+          "button": "Codex 구성 쓰기",
+          "title": "Codex 구성을 쓸까요?",
+          "descExisting": "연결 정보를 기존 구성 파일({{path}})에 병합하고 다른 필드는 유지합니다.",
+          "descNew": "구성 파일을 만들고 연결 정보를 씁니다({{path}}).",
+          "confirm": "쓰기",
+          "tokenExportHint": "액세스 토큰은 파일에 기록되지 않습니다. Codex를 실행하는 터미널에서 다음 환경 변수를 직접 설정하세요:"
+        }
+      }
+    },
     "remoteControl": {
       "title": "원격 연결",
       "description": "같은 계정의 기기를 서로 원격으로 제어하거나 SSH로 원격 호스트에 연결합니다.",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2673,6 +2673,77 @@
         "toggleFailed": "切换静默加密内容重试失败"
       }
     },
+    "localProxy": {
+      "title": "模型 Proxy",
+      "subtitle": "把本地服务开放给你自己电脑上的命令行工具：设好环境变量，即可复用这里配置的供应商与凭证。同时兼容 Anthropic API 格式（如 Claude Code）与 OpenAI API 格式（如 Codex 及其它 OpenAI 兼容工具）。",
+      "address": "服务地址",
+      "notReady": "服务未就绪",
+      "copy": "复制",
+      "port": "端口",
+      "portPlaceholder": "自动",
+      "applyPort": "应用",
+      "portHint": "开启服务时会固定当前端口；改端口会重启本地服务，可能中断进行中的请求。",
+      "token": "访问令牌",
+      "regenerate": {
+        "button": "重置",
+        "title": "重置访问令牌？",
+        "description": "重置后旧令牌立即失效，已配置的外部客户端需要换用新令牌。",
+        "confirm": "重置"
+      },
+      "defaultProvider": "默认供应商",
+      "defaultProviderNone": "不指定(按模型名路由)",
+      "noProviders": "暂无可路由的供应商，请先在上方添加并配置。",
+      "defaultProviderHint": "当模型名无法唯一对应某个供应商时，回落到这个供应商。",
+      "copyEnv": "复制环境变量",
+      "writeConfig": {
+        "button": "写入 Claude Code 配置",
+        "title": "写入 Claude Code 配置？",
+        "descExisting": "将把连接信息合并进现有配置文件（{{path}}），保留其它字段。",
+        "descNew": "将创建配置文件并写入连接信息（{{path}}）。",
+        "confirm": "写入",
+        "overwriteWarning": "以下已有配置项将被覆盖：{{keys}}"
+      },
+      "toast": {
+        "updateFailed": "更新失败",
+        "invalidPort": "端口需在 1–65535 之间",
+        "portApplied": "端口已更新",
+        "tokenReset": "访问令牌已重置",
+        "copied": "已复制",
+        "copyFailed": "复制失败",
+        "envCopied": "环境变量已复制",
+        "tokenCopied": "访问令牌已复制",
+        "notReady": "服务未就绪",
+        "configWritten": "已写入配置",
+        "configWriteFailed": "写入配置失败",
+        "codexPortApplied": "端口已更新",
+        "codexEnvCopied": "环境变量已复制",
+        "codexNotReady": "Codex 服务未就绪",
+        "codexConfigWritten": "已写入 Codex 配置",
+        "codexConfigWriteFailed": "写入 Codex 配置失败"
+      },
+      "anthropic": {
+        "title": "Claude Code / Anthropic",
+        "subtitle": "供说 Anthropic 格式的工具使用：如 Claude Code，把 ANTHROPIC_BASE_URL 指向本地端口即可。"
+      },
+      "openai": {
+        "title": "Codex / OpenAI",
+        "subtitle": "供说 OpenAI 格式的工具使用：Codex 走 Responses，其它工具走 Chat Completions，使用独立的本地端口。",
+        "address": "服务地址",
+        "port": "端口",
+        "portHint": "开启服务时会固定当前端口；改端口会重启本地 Codex 服务，可能中断进行中的请求。",
+        "defaultProvider": "默认供应商",
+        "defaultProviderHint": "当模型名无法唯一对应某个供应商时，回落到这个供应商。",
+        "copyEnv": "复制环境变量",
+        "writeConfig": {
+          "button": "写入 Codex 配置",
+          "title": "写入 Codex 配置？",
+          "descExisting": "将把连接信息合并进现有配置文件（{{path}}），保留其它字段。",
+          "descNew": "将创建配置文件并写入连接信息（{{path}}）。",
+          "confirm": "写入",
+          "tokenExportHint": "访问令牌不会写入文件。请在运行 Codex 的终端里自行设置下面这行环境变量："
+        }
+      }
+    },
     "remoteControl": {
       "title": "远程连接",
       "description": "在同账号的设备之间互相远程操控，或通过 SSH 连接远端主机。",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1102,6 +1102,57 @@ interface ElectronAPI {
     importExternal: () => Promise<import('../shared/theme-import/types').LocalThemeImportResult>;
   };
 
+  /**
+   * 对外模型代理(给用户自己的 Claude Code CLI 用):设置页 → 模型供应商 → 模型代理子区块。
+   * 明文 token 只经 getEnvExample / writeExternalConfig 返回(用户主动触发);getState 只给掩码。
+   */
+  localProxyService: {
+    getState: () => Promise<import('../shared/localProxyService').LocalProxyServiceState>;
+    setEnabled: (
+      enabled: boolean,
+    ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
+    setDefaultProvider: (
+      providerId: string,
+    ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
+    regenerateToken: () => Promise<
+      import('../shared/localProxyService').LocalProxyMutationResult
+    >;
+    setPort: (
+      port: number,
+    ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
+    getEnvExample: () => Promise<
+      import('../shared/localProxyService').LocalProxyEnvExampleResult
+    >;
+    previewExternalConfig: () => Promise<
+      import('../shared/localProxyService').LocalProxyConfigPreviewResult
+    >;
+    writeExternalConfig: () => Promise<
+      import('../shared/localProxyService').LocalProxyConfigWriteResult
+    >;
+    // Codex / 通用 OpenAI 出口(第三期:独立开关 + 独立 token,另一个 loopback 端口)。
+    setCodexEnabled: (
+      enabled: boolean,
+    ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
+    regenerateCodexToken: () => Promise<
+      import('../shared/localProxyService').LocalProxyMutationResult
+    >;
+    setCodexDefaultProvider: (
+      providerId: string,
+    ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
+    setCodexPort: (
+      port: number,
+    ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
+    getCodexEnvExample: () => Promise<
+      import('../shared/localProxyService').LocalProxyEnvExampleResult
+    >;
+    previewCodexConfig: () => Promise<
+      import('../shared/localProxyService').LocalProxyCodexConfigPreviewResult
+    >;
+    writeCodexConfig: () => Promise<
+      import('../shared/localProxyService').LocalProxyConfigWriteResult
+    >;
+  };
+
   /** RSB terminal tab —— PTY 后端 + xterm.js,详见 shared/terminal-bridge.ts 注释。 */
   terminal: import('../shared/terminal-bridge').TerminalBridge;
 

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1104,7 +1104,8 @@ interface ElectronAPI {
 
   /**
    * 对外模型代理(给用户自己的 Claude Code CLI 用):设置页 → 模型供应商 → 模型代理子区块。
-   * 明文 token 只经 getEnvExample / writeExternalConfig 返回(用户主动触发);getState 只给掩码。
+   * 明文 token 绝不回传 renderer:复制走 copy* 通道(main 侧 clipboard.writeText,只回 {success});
+   * getState 与两个 preview 通道只给掩码。
    */
   localProxyService: {
     getState: () => Promise<import('../shared/localProxyService').LocalProxyServiceState>;
@@ -1120,9 +1121,8 @@ interface ElectronAPI {
     setPort: (
       port: number,
     ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
-    getEnvExample: () => Promise<
-      import('../shared/localProxyService').LocalProxyEnvExampleResult
-    >;
+    copyToken: () => Promise<import('../shared/localProxyService').LocalProxyCopyResult>;
+    copyEnv: () => Promise<import('../shared/localProxyService').LocalProxyCopyResult>;
     previewExternalConfig: () => Promise<
       import('../shared/localProxyService').LocalProxyConfigPreviewResult
     >;
@@ -1142,8 +1142,10 @@ interface ElectronAPI {
     setCodexPort: (
       port: number,
     ) => Promise<import('../shared/localProxyService').LocalProxyMutationResult>;
-    getCodexEnvExample: () => Promise<
-      import('../shared/localProxyService').LocalProxyEnvExampleResult
+    copyCodexToken: () => Promise<import('../shared/localProxyService').LocalProxyCopyResult>;
+    copyCodexEnv: () => Promise<import('../shared/localProxyService').LocalProxyCopyResult>;
+    copyCodexTokenExport: () => Promise<
+      import('../shared/localProxyService').LocalProxyCopyResult
     >;
     previewCodexConfig: () => Promise<
       import('../shared/localProxyService').LocalProxyCodexConfigPreviewResult

--- a/apps/desktop/src/shared/localProxyService.ts
+++ b/apps/desktop/src/shared/localProxyService.ts
@@ -1,0 +1,110 @@
+/**
+ * 对外模型代理(给用户自己的 Claude Code CLI 用)的 preload/main/renderer 共享类型。
+ *
+ * 安全约束(勿改):
+ *   - token 明文只在 `getEnvExample` / `writeExternalConfig` 这两个「用户主动触发」的
+ *     出口经 IPC 返回给 renderer(复制到剪贴板 / 写入用户配置需要明文);常态 `getState`
+ *     只给 `maskedToken`。
+ *   - 写用户 `~/.claude` 配置是外向文件写,必须先 `previewExternalConfig` 展示改动 +
+ *     二次确认,再 `writeExternalConfig` 非破坏性 merge。
+ */
+
+/** 「对外默认供应商」候选(只投影 id/name,不含任何凭证)。 */
+export interface LocalProxyProviderOption {
+  id: string;
+  name: string;
+}
+
+/** 设置页渲染所需的全部非明文状态。 */
+export interface LocalProxyServiceState {
+  /** 是否已对外开放(默认关闭)。 */
+  enabled: boolean;
+  /** 当前实际 127.0.0.1 url;proxy 未就绪为 null。 */
+  url: string | null;
+  /** 固定端口;0 表示未固定(启动时随机)。 */
+  port: number;
+  /** 是否已生成对外 token。 */
+  hasToken: boolean;
+  /** 掩码 token(永不把明文交给 renderer 的常态出口)。 */
+  maskedToken: string | null;
+  /** claude-code 可路由的供应商候选。 */
+  providers: LocalProxyProviderOption[];
+  /** 已选「对外默认供应商」id;为空表示未选。 */
+  defaultProviderId: string;
+
+  // ───────── Codex / 通用 OpenAI 出口(codex loopback,第三期:独立开关 + 独立 token)─────────
+  /** B 族是否已对外开放(默认关闭,与 A 族 enabled 独立)。 */
+  codexEnabled: boolean;
+  /** 是否已生成 B 族独立对外 token。 */
+  codexHasToken: boolean;
+  /** B 族掩码 token(永不把明文交给 renderer 的常态出口)。 */
+  codexMaskedToken: string | null;
+  /** codex loopback 当前实际 127.0.0.1 url;未就绪为 null。 */
+  codexUrl: string | null;
+  /** codex loopback 固定端口;0 表示未固定(启动时随机)。 */
+  codexPort: number;
+  /** codex agent 可路由的供应商候选(排除 oauth-passthrough 订阅直连)。 */
+  codexProviders: LocalProxyProviderOption[];
+  /** 已选 codex「对外默认供应商」id;为空表示未选。 */
+  codexDefaultProviderId: string;
+}
+
+/** 复制 / 写入用的示例环境变量(含明文 token —— 仅用户主动触发时返回)。 */
+export interface LocalProxyEnvExample {
+  baseUrl: string;
+  /** 对外 token 明文(作为 ANTHROPIC_API_KEY,非真供应商 key)。 */
+  apiKey: string;
+  /** 可直接粘进 shell 运行的 `export KEY=VALUE` 行(供复制;渲染层用换行连接)。 */
+  lines: string[];
+}
+
+export type LocalProxyEnvExampleResult =
+  | { success: true; env: LocalProxyEnvExample }
+  | { success: false; error: string };
+
+/** 写入 `~/.claude/settings.json` 前的预览:展示将改动的 env 段与冲突项。 */
+export interface LocalProxyConfigPreview {
+  /** 目标文件绝对路径。 */
+  path: string;
+  /** 文件当前是否存在。 */
+  exists: boolean;
+  /** 将写入的 env 键值。 */
+  proposedEnv: Record<string, string>;
+  /** 目标里同名但取值不同、将被覆盖的项(用于二次确认提示)。 */
+  conflicts: { key: string; current: string; next: string }[];
+}
+
+export type LocalProxyConfigPreviewResult =
+  | { success: true; preview: LocalProxyConfigPreview }
+  | { success: false; error: string };
+
+export type LocalProxyConfigWriteResult =
+  | { success: true; path: string }
+  | { success: false; error: string };
+
+/**
+ * 写入 `~/.codex/config.toml` 前的预览。TOML 结构与 `~/.claude` 的 env 段不同,单独建型。
+ * **token 绝不写进文件** —— codex 经 `env_key=CINDY_LOCAL_TOKEN` 从环境变量读;`tokenExportLine`
+ * 给出用户需自设的 `export CINDY_LOCAL_TOKEN=<token>`(含明文 token,仅用户主动触发时返回)。
+ */
+export interface LocalProxyCodexConfigPreview {
+  /** 目标文件绝对路径。 */
+  path: string;
+  /** 文件当前是否存在。 */
+  exists: boolean;
+  /** merge 后将写入的完整 TOML 文本(供二次确认展示)。 */
+  proposedToml: string;
+  /** 已有但取值不同、将被覆盖的项(用于二次确认提示)。 */
+  conflicts: { key: string; current: string; next: string }[];
+  /** 用户需在外部 shell 自设的 token 环境变量行(含明文 token)。 */
+  tokenExportLine: string;
+}
+
+export type LocalProxyCodexConfigPreviewResult =
+  | { success: true; preview: LocalProxyCodexConfigPreview }
+  | { success: false; error: string };
+
+/** set-port 入参校验失败等的通用返回(带最新 state 便于 UI 同步)。 */
+export type LocalProxyMutationResult =
+  | { success: true; state: LocalProxyServiceState }
+  | { success: false; error: string; state: LocalProxyServiceState };

--- a/apps/desktop/src/shared/localProxyService.ts
+++ b/apps/desktop/src/shared/localProxyService.ts
@@ -2,9 +2,11 @@
  * 对外模型代理(给用户自己的 Claude Code CLI 用)的 preload/main/renderer 共享类型。
  *
  * 安全约束(勿改):
- *   - token 明文只在 `getEnvExample` / `writeExternalConfig` 这两个「用户主动触发」的
- *     出口经 IPC 返回给 renderer(复制到剪贴板 / 写入用户配置需要明文);常态 `getState`
- *     只给 `maskedToken`。
+ *   - **token 明文绝不回传 renderer**。复制到剪贴板由 main 侧完成(`copy*` 通道在主进程
+ *     `clipboard.writeText` 写明文,只回 `{success}`);写用户配置的明文 token 也只在 main
+ *     侧落文件。renderer 常态只拿 `maskedToken`,预览里的 token 段一律掩码。
+ *     (`assertTrustedAppRendererEvent` 只验来源帧、不验用户手势,所以哪怕来源可信也不把
+ *     明文交给 renderer —— 被注入的渲染进程无法把它读出来外泄。)
  *   - 写用户 `~/.claude` 配置是外向文件写,必须先 `previewExternalConfig` 展示改动 +
  *     二次确认,再 `writeExternalConfig` 非破坏性 merge。
  */
@@ -49,17 +51,12 @@ export interface LocalProxyServiceState {
   codexDefaultProviderId: string;
 }
 
-/** 复制 / 写入用的示例环境变量(含明文 token —— 仅用户主动触发时返回)。 */
-export interface LocalProxyEnvExample {
-  baseUrl: string;
-  /** 对外 token 明文(作为 ANTHROPIC_API_KEY,非真供应商 key)。 */
-  apiKey: string;
-  /** 可直接粘进 shell 运行的 `export KEY=VALUE` 行(供复制;渲染层用换行连接)。 */
-  lines: string[];
-}
-
-export type LocalProxyEnvExampleResult =
-  | { success: true; env: LocalProxyEnvExample }
+/**
+ * 主进程侧「复制到系统剪贴板」的结果。明文(token / 完整 env 行 / token export 行)只在 main
+ * 里经 `clipboard.writeText` 落剪贴板,**绝不随此结果回传 renderer** —— 只回成功与否。
+ */
+export type LocalProxyCopyResult =
+  | { success: true }
   | { success: false; error: string };
 
 /** 写入 `~/.claude/settings.json` 前的预览:展示将改动的 env 段与冲突项。 */
@@ -68,7 +65,7 @@ export interface LocalProxyConfigPreview {
   path: string;
   /** 文件当前是否存在。 */
   exists: boolean;
-  /** 将写入的 env 键值。 */
+  /** 将写入的 env 键值(**展示用**:其中 `ANTHROPIC_API_KEY` 为掩码;真实明文只在 main 落文件)。 */
   proposedEnv: Record<string, string>;
   /** 目标里同名但取值不同、将被覆盖的项(用于二次确认提示)。 */
   conflicts: { key: string; current: string; next: string }[];
@@ -85,7 +82,8 @@ export type LocalProxyConfigWriteResult =
 /**
  * 写入 `~/.codex/config.toml` 前的预览。TOML 结构与 `~/.claude` 的 env 段不同,单独建型。
  * **token 绝不写进文件** —— codex 经 `env_key=CINDY_LOCAL_TOKEN` 从环境变量读;`tokenExportLine`
- * 给出用户需自设的 `export CINDY_LOCAL_TOKEN=<token>`(含明文 token,仅用户主动触发时返回)。
+ * 给出用户需自设的 `export CINDY_LOCAL_TOKEN=<token>`,但**展示用为掩码**(真实明文复制走
+ * main 侧 `copyCodexTokenExport` 剪贴板通道)。
  */
 export interface LocalProxyCodexConfigPreview {
   /** 目标文件绝对路径。 */
@@ -96,7 +94,7 @@ export interface LocalProxyCodexConfigPreview {
   proposedToml: string;
   /** 已有但取值不同、将被覆盖的项(用于二次确认提示)。 */
   conflicts: { key: string; current: string; next: string }[];
-  /** 用户需在外部 shell 自设的 token 环境变量行(含明文 token)。 */
+  /** 用户需在外部 shell 自设的 token 环境变量行(**掩码展示**;真实明文走 main 剪贴板通道)。 */
   tokenExportLine: string;
 }
 

--- a/apps/desktop/src/shared/providerSecrets.ts
+++ b/apps/desktop/src/shared/providerSecrets.ts
@@ -74,11 +74,28 @@ export function providerSecretStorageKey(id: ProviderSecretId): string {
  */
 export const REMOTE_MCP_BRIDGE_TOKEN_STORAGE_KEY = 'remote_mcp_bridge_token';
 
+/**
+ * 对外开放的本地模型代理(给用户自己的 Claude Code CLI 用)所生成的 **对外访问 token**
+ * 的存储键名。它是外部客户端访问 loopback 代理的鉴权凭据(不是真供应商 key),需要跨 app
+ * 重启稳定,故落 safeStorage。main-only:renderer 只拿到掩码版,永不经通用 safe-storage IPC
+ * 读到明文。
+ */
+export const LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY = 'local_proxy_external_token';
+
+/**
+ * Codex / 通用 OpenAI 出口(B 族)独立的**对外访问 token** 存储键名。与上面的 Anthropic
+ * 出口(A 族)token 完全独立:两族各自开关、各自 token,跨族不互通。同样 main-only、跨重启
+ * 稳定,只把掩码版交给 renderer。
+ */
+export const LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY = 'local_proxy_codex_external_token';
+
 const MAIN_ONLY_PROVIDER_SECRET_STORAGE_KEYS = new Set<string>([
   STORAGE_KEYS['voice-asr'].toLowerCase(),
   STORAGE_KEYS['gemini'].toLowerCase(),
   STORAGE_KEYS['openai-images'].toLowerCase(),
   REMOTE_MCP_BRIDGE_TOKEN_STORAGE_KEY.toLowerCase(),
+  LOCAL_PROXY_EXTERNAL_TOKEN_STORAGE_KEY.toLowerCase(),
+  LOCAL_PROXY_CODEX_EXTERNAL_TOKEN_STORAGE_KEY.toLowerCase(),
 ]);
 
 /** Custom-provider runtime header blobs are main-only credential material. */

--- a/packages/anthropic-compat-proxy/src/index.ts
+++ b/packages/anthropic-compat-proxy/src/index.ts
@@ -13,7 +13,7 @@
  *   - transform 链可注入自定义改写;什么都不传走默认 [stripNonAnthropicFields]
  */
 
-export { createAnthropicCompatProxy } from './server.js';
+export { createAnthropicCompatProxy, isFetchBlockedPort } from './server.js';
 export {
   createEnvOutboundProxyResolver,
   hasProxyEnvConfig,

--- a/packages/anthropic-compat-proxy/src/server-fixed-port.test.ts
+++ b/packages/anthropic-compat-proxy/src/server-fixed-port.test.ts
@@ -1,0 +1,57 @@
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { createAnthropicCompatProxy } from './server.js';
+import { listenOnAvailableLoopbackPort } from './test-loopback-server.js';
+import type { ProxyHandle } from './types.js';
+
+// opts.port 固定端口:给定则只绑这一个端口,被占用直接抛错(不随机重试),
+// 由 host 侧负责 fallback。省略时维持随机 Fetch-safe 端口(默认行为)。
+
+let proxy: ProxyHandle | null = null;
+let blocker: Server | null = null;
+
+afterEach(async () => {
+  if (proxy) { await proxy.dispose(); proxy = null; }
+  if (blocker) { await new Promise<void>((r) => blocker!.close(() => r())); blocker = null; }
+});
+
+describe('anthropic-compat-proxy fixed port (opts.port)', () => {
+  it('binds the exact requested loopback port when free', async () => {
+    // 先抢一个空闲端口拿到它的号,立刻释放,再要求 proxy 绑同一个号。
+    const probe = createServer();
+    const wantPort = await listenOnAvailableLoopbackPort(probe);
+    await new Promise<void>((r) => probe.close(() => r()));
+
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://127.0.0.1:1',
+      transformRequest: [],
+      port: wantPort,
+    });
+
+    expect(proxy.url).toBe(`http://127.0.0.1:${wantPort}`);
+  });
+
+  it('throws (no random retry) when the requested port is already in use', async () => {
+    blocker = createServer();
+    const takenPort = await listenOnAvailableLoopbackPort(blocker);
+
+    await expect(
+      createAnthropicCompatProxy({
+        upstream: 'http://127.0.0.1:1',
+        transformRequest: [],
+        port: takenPort,
+      }),
+    ).rejects.toMatchObject({ code: 'EADDRINUSE' });
+  });
+
+  it('still picks a random port when opts.port is omitted', async () => {
+    proxy = await createAnthropicCompatProxy({
+      upstream: 'http://127.0.0.1:1',
+      transformRequest: [],
+    });
+    expect(proxy.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+  });
+});

--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -127,6 +127,16 @@ describe('anthropic-compat-proxy loopback port guard', () => {
     expect(result).toEqual({ status: 200, text: JSON.stringify({ ok: true }) });
   });
 
+  it('refuses to bind a pinned Fetch-blocked loopback port (host falls back to random)', async () => {
+    await expect(
+      createAnthropicCompatProxy({
+        upstream: 'https://gateway.example/v1',
+        transformRequest: [],
+        port: 6000,
+      }),
+    ).rejects.toThrow(/refusing to bind Fetch-blocked loopback port 6000/);
+  });
+
   it('jumps out of a Windows excluded-port range after EACCES and cleans listeners', async () => {
     const attemptedPorts: number[] = [];
     let boundPort = 0;

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -2102,7 +2102,10 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     socket.on('close', () => inflightSockets.delete(socket));
   });
 
-  const port = await listenOnFetchSafeLoopbackPort(server, host, logger);
+  // 固定端口(opts.port)时只绑这一个,失败即抛(host 负责 fallback);否则随机选 Fetch-safe 端口。
+  const port = opts.port !== undefined
+    ? await listenOnLoopbackPort(server, host, opts.port)
+    : await listenOnFetchSafeLoopbackPort(server, host, logger);
   const hostInUrl = host.includes(':') ? `[${host}]` : host;
   const url = `http://${hostInUrl}:${port}`;
 

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -1587,9 +1587,21 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
     // upstream(订阅直连 api.anthropic.com / 走网关 endpoint),而非静态默认上游。
     let decision: RoutingDecision | null = null;
     let rawParsed: unknown = undefined;
-    if (opts.routingTransform && contentType.toLowerCase().startsWith('application/json')) {
+    if (opts.routingTransform) {
+      // 仅 JSON body 解析出 rawParsed 供基于字段(如 body.model)的路由;非 JSON / 解析失败时
+      // rawParsed 保持 undefined。但**无论 content-type 如何都调用 routingTransform** —— 它可据
+      // method/url/headers(如对外访问 token)判路由或拒绝。若像旧逻辑那样只在 application/json
+      // 时才调,携带对外 token 但 content-type 缺失/错误的请求会绕过外部检查、带着 token 头透传
+      // 上游(凭证泄漏 / 误路由)。transform 对 undefined body 应自行短路返回 null(= 默认上游 +
+      // 透传 headers,与 GET 无 body 路径同契约),故对内部请求向后兼容。
+      if (contentType.toLowerCase().startsWith('application/json')) {
+        try {
+          rawParsed = JSON.parse(rawBody.toString('utf8'));
+        } catch {
+          rawParsed = undefined;
+        }
+      }
       try {
-        rawParsed = JSON.parse(rawBody.toString('utf8'));
         const maybeDecision = opts.routingTransform(rawParsed, requestCtx);
         decision = isPromiseLike<RoutingDecision | null>(maybeDecision)
           ? await maybeDecision

--- a/packages/anthropic-compat-proxy/src/server.ts
+++ b/packages/anthropic-compat-proxy/src/server.ts
@@ -2115,6 +2115,13 @@ export async function createAnthropicCompatProxy(opts: ProxyOptions): Promise<Pr
   });
 
   // 固定端口(opts.port)时只绑这一个,失败即抛(host 负责 fallback);否则随机选 Fetch-safe 端口。
+  // 固定端口若落在 Fetch 屏蔽端口(fetch/undici 会直接 ERR_INVALID_ARGUMENT 拒连,SDK 根本连不上)
+  // 里,先自证拒绝再抛 —— 与随机选口路径的 isFetchBlockedPort 过滤同源,host 据此 fallback 随机口。
+  if (opts.port !== undefined && isFetchBlockedPort(opts.port)) {
+    throw new Error(
+      `anthropic-compat-proxy: refusing to bind Fetch-blocked loopback port ${opts.port}`,
+    );
+  }
   const port = opts.port !== undefined
     ? await listenOnLoopbackPort(server, host, opts.port)
     : await listenOnFetchSafeLoopbackPort(server, host, logger);

--- a/packages/anthropic-compat-proxy/src/types.ts
+++ b/packages/anthropic-compat-proxy/src/types.ts
@@ -230,6 +230,13 @@ export interface ProxyOptions {
   /** 监听 host,默认 127.0.0.1 (loopback only;不要改成 0.0.0.0) */
   host?: string;
   /**
+   * 可选: 固定监听端口。给定时**只尝试绑这一个端口**,被占用(EADDRINUSE)或无权限
+   * (EACCES)直接抛错,不做随机重试 —— 调用方(host)据此 fallback 到随机端口并回写
+   * 新值。省略 = 在 Fetch-safe 高位区间随机选空闲端口(默认行为,字节级不变)。
+   * 仅 loopback 用途;端口值不校验范围,交给 OS(非法值 listen 会抛错)。
+   */
+  port?: number;
+  /**
    * 可选: 单条请求 body 上限(字节),超限回 413。默认 32MB(Claude Code 场景足够)。
    * Codex 走 Responses API 每轮全量重发 thread 历史,长会话(贴图 base64 / 加密
    * reasoning blob)会越过默认值,desktop 侧对 codex proxy 显式调大。

--- a/packages/responses-chat-bridge/src/__tests__/responses-sse-to-chat-translator.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/responses-sse-to-chat-translator.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+
+import { ResponsesSseToChatTranslator } from '../responses-sse-to-chat-translator.js';
+
+function drain(
+  translator: ResponsesSseToChatTranslator,
+  events: Array<Record<string, unknown>>,
+): Array<Record<string, unknown>> {
+  const chunks: Array<Record<string, unknown>> = [];
+  for (const event of events) chunks.push(...translator.push(event));
+  chunks.push(...translator.finish());
+  return chunks;
+}
+
+const TEXT_STREAM: Array<Record<string, unknown>> = [
+  { type: 'response.created', response: { id: 'resp_1', model: 'gpt-4o', created_at: 111 } },
+  { type: 'response.output_item.added', output_index: 0, item: { type: 'message', role: 'assistant' } },
+  { type: 'response.output_text.delta', output_index: 0, delta: 'Hel' },
+  { type: 'response.output_text.delta', output_index: 0, delta: 'lo' },
+  {
+    type: 'response.completed',
+    response: {
+      id: 'resp_1',
+      model: 'gpt-4o',
+      created_at: 111,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        total_tokens: 15,
+        input_tokens_details: { cached_tokens: 2 },
+        output_tokens_details: { reasoning_tokens: 1 },
+      },
+    },
+  },
+];
+
+describe('ResponsesSseToChatTranslator (streaming)', () => {
+  it('emits role chunk, content deltas, and a final finish chunk', () => {
+    const chunks = drain(new ResponsesSseToChatTranslator(), TEXT_STREAM);
+    expect(chunks[0]).toMatchObject({
+      object: 'chat.completion.chunk',
+      id: 'chatcmpl-resp_1',
+      model: 'gpt-4o',
+      created: 111,
+      choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }],
+    });
+    expect(chunks[1].choices).toEqual([{ index: 0, delta: { content: 'Hel' }, finish_reason: null }]);
+    expect(chunks[2].choices).toEqual([{ index: 0, delta: { content: 'lo' }, finish_reason: null }]);
+    const last = chunks[chunks.length - 1];
+    expect(last.choices).toEqual([{ index: 0, delta: {}, finish_reason: 'stop' }]);
+  });
+
+  it('appends a usage-only chunk when includeUsage is set', () => {
+    const chunks = drain(new ResponsesSseToChatTranslator({ includeUsage: true }), TEXT_STREAM);
+    const usageChunk = chunks[chunks.length - 1];
+    expect(usageChunk.choices).toEqual([]);
+    expect(usageChunk.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+      prompt_tokens_details: { cached_tokens: 2 },
+      completion_tokens_details: { reasoning_tokens: 1 },
+    });
+  });
+
+  it('translates the function-call lifecycle into indexed tool_calls deltas', () => {
+    const chunks = drain(new ResponsesSseToChatTranslator(), [
+      { type: 'response.created', response: { id: 'resp_2', model: 'gpt-4o' } },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: { type: 'function_call', id: 'fc_1', call_id: 'call_a', name: 'Bash', arguments: '' },
+      },
+      { type: 'response.function_call_arguments.delta', item_id: 'fc_1', output_index: 0, delta: '{"cmd":' },
+      { type: 'response.function_call_arguments.delta', item_id: 'fc_1', output_index: 0, delta: '"ls"}' },
+      { type: 'response.function_call_arguments.done', item_id: 'fc_1', output_index: 0, arguments: '{"cmd":"ls"}' },
+      { type: 'response.output_item.done', output_index: 0, item: { type: 'function_call', call_id: 'call_a', name: 'Bash', arguments: '{"cmd":"ls"}' } },
+      { type: 'response.completed', response: { id: 'resp_2', model: 'gpt-4o' } },
+    ]);
+    const toolChunks = chunks.filter((c) => {
+      const choice = (c.choices as Array<Record<string, unknown>> | undefined)?.[0];
+      return choice && (choice.delta as Record<string, unknown>)?.tool_calls;
+    });
+    expect((toolChunks[0].choices as any)[0].delta.tool_calls).toEqual([{
+      index: 0,
+      id: 'call_a',
+      type: 'function',
+      function: { name: 'Bash', arguments: '' },
+    }]);
+    expect((toolChunks[1].choices as any)[0].delta.tool_calls).toEqual([{
+      index: 0,
+      function: { arguments: '{"cmd":' },
+    }]);
+    expect((toolChunks[2].choices as any)[0].delta.tool_calls).toEqual([{
+      index: 0,
+      function: { arguments: '"ls"}' },
+    }]);
+    // .done must NOT re-emit args when deltas already streamed them.
+    expect(toolChunks).toHaveLength(3);
+    const last = chunks[chunks.length - 1];
+    expect(last.choices).toEqual([{ index: 0, delta: {}, finish_reason: 'tool_calls' }]);
+  });
+
+  it('emits full args on function_call_arguments.done when no deltas were streamed', () => {
+    const chunks = drain(new ResponsesSseToChatTranslator(), [
+      { type: 'response.created', response: { id: 'resp_3' } },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: { type: 'function_call', id: 'fc_9', call_id: 'call_z', name: 'Grep', arguments: '' },
+      },
+      { type: 'response.function_call_arguments.done', item_id: 'fc_9', output_index: 0, arguments: '{"q":"x"}' },
+      { type: 'response.completed', response: { id: 'resp_3' } },
+    ]);
+    const argsChunk = chunks.find((c) => {
+      const tc = ((c.choices as any)?.[0]?.delta?.tool_calls) as Array<Record<string, unknown>> | undefined;
+      return tc && (tc[0].function as Record<string, unknown>)?.arguments === '{"q":"x"}';
+    });
+    expect(argsChunk).toBeTruthy();
+  });
+
+  it('maps response.incomplete (max_output_tokens) to finish_reason length', () => {
+    const chunks = drain(new ResponsesSseToChatTranslator(), [
+      { type: 'response.created', response: { id: 'resp_4' } },
+      { type: 'response.output_text.delta', output_index: 0, delta: 'partial' },
+      {
+        type: 'response.incomplete',
+        response: { id: 'resp_4', incomplete_details: { reason: 'max_output_tokens' } },
+      },
+    ]);
+    const last = chunks[chunks.length - 1];
+    expect(last.choices).toEqual([{ index: 0, delta: {}, finish_reason: 'length' }]);
+  });
+
+  it('produces a Chat error frame on response.failed', () => {
+    const t = new ResponsesSseToChatTranslator();
+    t.push({ type: 'response.created', response: { id: 'resp_5' } });
+    const out = t.push({ type: 'response.failed', response: { error: { message: 'boom' } } });
+    expect(out).toEqual([{ error: { message: 'boom', type: 'upstream_error', code: null } }]);
+    expect(t.isTerminal).toBe(true);
+    // further events are ignored after terminal
+    expect(t.push({ type: 'response.output_text.delta', delta: 'x' })).toEqual([]);
+  });
+});
+
+describe('ResponsesSseToChatTranslator (aggregate / stream:false)', () => {
+  it('aggregates text output into a single chat.completion', () => {
+    const t = new ResponsesSseToChatTranslator();
+    for (const event of TEXT_STREAM) t.push(event);
+    const completion = t.aggregate();
+    expect(completion).toMatchObject({
+      id: 'chatcmpl-resp_1',
+      object: 'chat.completion',
+      model: 'gpt-4o',
+      created: 111,
+      choices: [{
+        index: 0,
+        message: { role: 'assistant', content: 'Hello' },
+        finish_reason: 'stop',
+      }],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      },
+    });
+  });
+
+  it('aggregates tool calls into message.tool_calls with null content', () => {
+    const t = new ResponsesSseToChatTranslator();
+    const events = [
+      { type: 'response.created', response: { id: 'resp_6', model: 'gpt-4o' } },
+      {
+        type: 'response.output_item.added',
+        output_index: 0,
+        item: { type: 'function_call', id: 'fc_a', call_id: 'call_1', name: 'Bash', arguments: '' },
+      },
+      { type: 'response.function_call_arguments.delta', item_id: 'fc_a', output_index: 0, delta: '{"cmd":"ls"}' },
+      { type: 'response.output_item.done', output_index: 0, item: { type: 'function_call', call_id: 'call_1', name: 'Bash', arguments: '{"cmd":"ls"}' } },
+      { type: 'response.completed', response: { id: 'resp_6' } },
+    ];
+    for (const event of events) t.push(event);
+    const completion = t.aggregate();
+    const message = (completion.choices as any)[0].message;
+    expect(message.content).toBeNull();
+    expect(message.tool_calls).toEqual([{
+      id: 'call_1',
+      type: 'function',
+      function: { name: 'Bash', arguments: '{"cmd":"ls"}' },
+    }]);
+    expect((completion.choices as any)[0].finish_reason).toBe('tool_calls');
+  });
+});

--- a/packages/responses-chat-bridge/src/__tests__/translate-chat-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-chat-request.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+
+import { translateChatToResponsesRequest } from '../translate-chat-request.js';
+import type { ChatCompletionsRequest } from '../types.js';
+
+function base(overrides: Partial<ChatCompletionsRequest> = {}): ChatCompletionsRequest {
+  return {
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: 'hello' }],
+    stream: true,
+    ...overrides,
+  };
+}
+
+describe('translateChatToResponsesRequest', () => {
+  it('folds leading system/developer into instructions and maps a user message', () => {
+    const out = translateChatToResponsesRequest(base({
+      messages: [
+        { role: 'system', content: 'be concise' },
+        { role: 'developer', content: 'no markdown' },
+        { role: 'user', content: 'hello' },
+      ],
+    }));
+    expect(out.model).toBe('gpt-4o');
+    expect(out.instructions).toBe('be concise\nno markdown');
+    expect(out.input).toEqual([{ role: 'user', content: 'hello' }]);
+    expect(out.stream).toBe(true);
+  });
+
+  it('keeps mid-conversation system/developer as message items', () => {
+    const out = translateChatToResponsesRequest(base({
+      messages: [
+        { role: 'user', content: 'hi' },
+        { role: 'system', content: 'switch tone' },
+        { role: 'user', content: 'again' },
+      ],
+    }));
+    expect(out.instructions).toBeUndefined();
+    expect(out.input).toEqual([
+      { role: 'user', content: 'hi' },
+      { type: 'message', role: 'system', content: 'switch tone' },
+      { role: 'user', content: 'again' },
+    ]);
+  });
+
+  it('maps user content parts (text/image) to input_* parts', () => {
+    const out = translateChatToResponsesRequest(base({
+      messages: [{
+        role: 'user',
+        content: [
+          { type: 'text', text: 'look' },
+          { type: 'image_url', image_url: { url: 'https://x/y.png', detail: 'high' } },
+        ],
+      }],
+    }));
+    expect(out.input).toEqual([{
+      role: 'user',
+      content: [
+        { type: 'input_text', text: 'look' },
+        { type: 'input_image', image_url: { url: 'https://x/y.png', detail: 'high' } },
+      ],
+    }]);
+  });
+
+  it('maps assistant tool_calls to function_call items and tool result to function_call_output', () => {
+    const out = translateChatToResponsesRequest(base({
+      messages: [
+        { role: 'user', content: 'run it' },
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [{
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'Bash', arguments: '{"cmd":"ls"}' },
+          }],
+        },
+        { role: 'tool', tool_call_id: 'call_1', content: 'file.txt' },
+      ],
+    }));
+    expect(out.input).toEqual([
+      { role: 'user', content: 'run it' },
+      { type: 'function_call', call_id: 'call_1', name: 'Bash', arguments: '{"cmd":"ls"}' },
+      { type: 'function_call_output', call_id: 'call_1', output: 'file.txt' },
+    ]);
+  });
+
+  it('records reasoning_content history as a downgrade instead of emitting it', () => {
+    const downgrades: string[] = [];
+    const out = translateChatToResponsesRequest(base({
+      messages: [{
+        role: 'assistant',
+        content: 'answer',
+        reasoning_content: 'my private chain of thought',
+      }],
+    }), { onDowngrade: (f) => downgrades.push(f) });
+    expect(out.input).toEqual([{ role: 'assistant', content: 'answer' }]);
+    expect(downgrades).toContain('assistant.reasoning_content');
+  });
+
+  it('maps tools, tool_choice, token limit, effort and passthrough sampling', () => {
+    const out = translateChatToResponsesRequest(base({
+      tools: [{
+        type: 'function',
+        function: { name: 'Bash', description: 'run', parameters: { type: 'object' }, strict: true },
+      }],
+      tool_choice: { type: 'function', function: { name: 'Bash' } },
+      parallel_tool_calls: true,
+      max_completion_tokens: 256,
+      reasoning_effort: 'high',
+      temperature: 0.4,
+      top_p: 0.9,
+    }));
+    expect(out.tools).toEqual([{
+      type: 'function',
+      name: 'Bash',
+      description: 'run',
+      parameters: { type: 'object' },
+      strict: true,
+    }]);
+    expect(out.tool_choice).toEqual({ type: 'function', name: 'Bash' });
+    expect(out.parallel_tool_calls).toBe(true);
+    expect(out.max_output_tokens).toBe(256);
+    expect(out.reasoning).toEqual({ effort: 'high' });
+    expect(out.temperature).toBe(0.4);
+    expect(out.top_p).toBe(0.9);
+  });
+
+  it('prefers max_completion_tokens over max_tokens and reasoning.effort over reasoning_effort', () => {
+    const out = translateChatToResponsesRequest(base({
+      max_tokens: 100,
+      max_completion_tokens: 200,
+      reasoning_effort: 'low',
+      reasoning: { effort: 'medium' },
+    }));
+    expect(out.max_output_tokens).toBe(200);
+    expect(out.reasoning).toEqual({ effort: 'medium' });
+  });
+
+  it('treats stream:false as non-streaming and records n>1 downgrade', () => {
+    const downgrades: string[] = [];
+    const out = translateChatToResponsesRequest(
+      { ...base(), stream: false, n: 3 } as ChatCompletionsRequest,
+      { onDowngrade: (f) => downgrades.push(f) },
+    );
+    expect(out.stream).toBe(false);
+    expect(downgrades).toContain('n>1');
+  });
+});

--- a/packages/responses-chat-bridge/src/__tests__/translate-chat-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-chat-request.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { translateChatToResponsesRequest } from '../translate-chat-request.js';
+import { translateResponsesRequest } from '../translate-request.js';
 import type { ChatCompletionsRequest } from '../types.js';
 
 function base(overrides: Partial<ChatCompletionsRequest> = {}): ChatCompletionsRequest {
@@ -135,6 +136,71 @@ describe('translateChatToResponsesRequest', () => {
     }));
     expect(out.max_output_tokens).toBe(200);
     expect(out.reasoning).toEqual({ effort: 'medium' });
+  });
+
+  // Responses API 没有顶层 response_format;照抄 Chat 字段会让透明转发到 Responses 供应商的路由
+  // 以「未知参数」拒掉本来合法的结构化输出请求(#1666 review P1)。
+  it('maps Chat response_format json_object to Responses text.format', () => {
+    const out = translateChatToResponsesRequest(base({
+      response_format: { type: 'json_object' },
+    }));
+    expect(out.text).toEqual({ format: { type: 'json_object' } });
+    expect(out).not.toHaveProperty('response_format');
+  });
+
+  it('flattens Chat json_schema nesting into Responses text.format', () => {
+    const out = translateChatToResponsesRequest(base({
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'answer',
+          description: 'structured answer',
+          schema: { type: 'object', properties: { value: { type: 'string' } } },
+          strict: true,
+        },
+      },
+    }));
+    expect(out.text).toEqual({
+      format: {
+        type: 'json_schema',
+        name: 'answer',
+        description: 'structured answer',
+        schema: { type: 'object', properties: { value: { type: 'string' } } },
+        strict: true,
+      },
+    });
+    expect(out).not.toHaveProperty('response_format');
+  });
+
+  it('passes response_format shapes it does not recognise through to text.format unchanged', () => {
+    const out = translateChatToResponsesRequest(base({
+      response_format: { type: 'text' },
+    }));
+    expect(out.text).toEqual({ format: { type: 'text' } });
+  });
+
+  it('omits text entirely when the Chat request has no response_format', () => {
+    const out = translateChatToResponsesRequest(base());
+    expect(out).not.toHaveProperty('text');
+  });
+
+  // 走 openai-chat 供应商时 body 会再被反向译回 Chat(自环 /responses → createLocalBridgeDecision),
+  // 所以这对映射必须互逆,否则结构化输出会在第二跳丢形状。
+  it('round-trips json_schema back to the original Chat response_format shape', () => {
+    const responseFormat = {
+      type: 'json_schema',
+      json_schema: {
+        name: 'answer',
+        description: 'structured answer',
+        schema: { type: 'object', properties: { value: { type: 'string' } } },
+        strict: true,
+      },
+    };
+    const responses = translateChatToResponsesRequest(base({ response_format: responseFormat }));
+    const chat = translateResponsesRequest(responses, {
+      capabilities: { passthroughFields: ['response_format'] },
+    });
+    expect(chat.response_format).toEqual(responseFormat);
   });
 
   it('treats stream:false as non-streaming and records n>1 downgrade', () => {

--- a/packages/responses-chat-bridge/src/index.ts
+++ b/packages/responses-chat-bridge/src/index.ts
@@ -1,6 +1,14 @@
 export { ChatSseTranslator, type ChatSseTranslatorOptions } from './chat-sse-translator.js';
 export { createResponsesChatHandler, type ResponsesChatHandlerOptions } from './handler.js';
 export {
+  translateChatToResponsesRequest,
+  type TranslateChatToResponsesOptions,
+} from './translate-chat-request.js';
+export {
+  ResponsesSseToChatTranslator,
+  type ResponsesSseToChatTranslatorOptions,
+} from './responses-sse-to-chat-translator.js';
+export {
   translateResponsesRequest,
   translateResponsesRequestWithContext,
   type TranslatedResponsesChatRequest,

--- a/packages/responses-chat-bridge/src/responses-sse-to-chat-translator.ts
+++ b/packages/responses-chat-bridge/src/responses-sse-to-chat-translator.ts
@@ -1,0 +1,366 @@
+/**
+ * OpenAI Responses SSE → Chat Completions(chat-sse-translator.ts 的**反向**)。
+ *
+ * 用途:对外「通用 OpenAI Chat Completions 端点」把 Cindy `/responses` 回来的 Responses SSE
+ * 事件流译回标准 Chat `chat.completion.chunk`(流式)或聚合成单个 `chat.completion`
+ * (`stream:false`)。消费的事件词表以 `ChatSseTranslator` 的**产出**为基准:
+ *   response.created / response.in_progress
+ *   response.output_item.added (item.type: message / reasoning / function_call / ...)
+ *   response.output_text.delta / response.reasoning_summary_text.delta
+ *   response.function_call_arguments.delta / .done
+ *   response.output_item.done
+ *   response.completed / response.incomplete / response.failed
+ *
+ * 每次 `push(event)` 返回本次应写出的 Chat chunk 数组;`finish()` 补终止 chunk;
+ * `fail(message)` 产出 Chat error 帧。非流式路径无视返回的 chunk,末尾调 `aggregate()`。
+ */
+
+export interface ResponsesSseToChatTranslatorOptions {
+  /** 缺省 model(上游事件里没带 model 时用)。 */
+  model?: string;
+  /** 是否在流末尾追加 usage-only chunk(对应 chat 的 stream_options.include_usage)。 */
+  includeUsage?: boolean;
+}
+
+interface ToolCallState {
+  chatIndex: number;
+  outputIndex: number;
+  id: string;
+  name: string;
+  args: string;
+}
+
+type ChatFinishReason = 'stop' | 'length' | 'tool_calls' | 'content_filter';
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringField(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function numberField(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+export class ResponsesSseToChatTranslator {
+  private readonly fallbackModel: string;
+  private readonly includeUsage: boolean;
+
+  private responseId = '';
+  private model: string;
+  private created = 0;
+  private roleEmitted = false;
+  private terminal = false;
+  private nextToolIndex = 0;
+
+  private text = '';
+  private reasoning = '';
+  private pendingFinish: ChatFinishReason | null = null;
+  private usage: Record<string, unknown> | null = null;
+
+  private readonly toolsByOutputIndex = new Map<number, ToolCallState>();
+  private readonly outputIndexByItemId = new Map<string, number>();
+
+  constructor(options: ResponsesSseToChatTranslatorOptions = {}) {
+    this.fallbackModel = options.model ?? '';
+    this.model = this.fallbackModel;
+    this.includeUsage = options.includeUsage ?? false;
+  }
+
+  /** 消费一个 Responses SSE 事件,返回本次要写出的 Chat chunk 列表(非流式可忽略)。 */
+  push(event: unknown): Array<Record<string, unknown>> {
+    if (this.terminal || !isPlainObject(event)) return [];
+    const type = event.type;
+    const out: Array<Record<string, unknown>> = [];
+
+    switch (type) {
+      case 'response.created':
+      case 'response.in_progress': {
+        this.absorbResponseMeta(event.response);
+        this.ensureRoleChunk(out);
+        break;
+      }
+      case 'response.output_item.added': {
+        const item = event.item;
+        if (isPlainObject(item) && item.type === 'function_call') {
+          this.startToolCall(numberField(event.output_index), item, out);
+        }
+        break;
+      }
+      case 'response.output_text.delta': {
+        const delta = stringField(event.delta);
+        if (delta) {
+          this.text += delta;
+          this.ensureRoleChunk(out);
+          out.push(this.chunk({ content: delta }));
+        }
+        break;
+      }
+      case 'response.reasoning_summary_text.delta': {
+        const delta = stringField(event.delta);
+        if (delta) {
+          this.reasoning += delta;
+          this.ensureRoleChunk(out);
+          out.push(this.chunk({ reasoning_content: delta }));
+        }
+        break;
+      }
+      case 'response.function_call_arguments.delta': {
+        const state = this.resolveToolState(event.item_id, event.output_index);
+        const delta = stringField(event.delta);
+        if (state && delta) {
+          state.args += delta;
+          out.push(this.chunk({
+            tool_calls: [{ index: state.chatIndex, function: { arguments: delta } }],
+          }));
+        }
+        break;
+      }
+      case 'response.function_call_arguments.done': {
+        const state = this.resolveToolState(event.item_id, event.output_index);
+        const full = stringField(event.arguments);
+        // 只在此前完全没收到过增量参数时补发一次完整参数(某些上游只发 .done)。
+        if (state && full && state.args.length === 0) {
+          state.args = full;
+          out.push(this.chunk({
+            tool_calls: [{ index: state.chatIndex, function: { arguments: full } }],
+          }));
+        }
+        break;
+      }
+      case 'response.output_item.done': {
+        const item = event.item;
+        if (isPlainObject(item) && item.type === 'function_call') {
+          this.finalizeToolFromItem(numberField(event.output_index), item, out);
+        }
+        break;
+      }
+      case 'response.completed':
+      case 'response.incomplete': {
+        this.absorbResponseMeta(event.response);
+        const reason: ChatFinishReason = type === 'response.incomplete'
+          ? this.incompleteReason(event.response)
+          : this.toolsByOutputIndex.size > 0 ? 'tool_calls' : 'stop';
+        this.pendingFinish = reason;
+        this.markComplete(out);
+        break;
+      }
+      case 'response.failed': {
+        return this.fail(this.failureMessage(event.response));
+      }
+      default:
+        break;
+    }
+
+    return out;
+  }
+
+  /** 流结束时补终止 chunk(正常路径已在 response.completed 里终止,此处兜底)。 */
+  finish(): Array<Record<string, unknown>> {
+    if (this.terminal) return [];
+    const out: Array<Record<string, unknown>> = [];
+    if (!this.pendingFinish) {
+      this.pendingFinish = this.toolsByOutputIndex.size > 0 ? 'tool_calls' : 'stop';
+    }
+    this.markComplete(out);
+    return out;
+  }
+
+  /** 中途失败:产出一个 Chat error 帧(尽力而为,上游可能已经开始流)。 */
+  fail(message: string): Array<Record<string, unknown>> {
+    if (this.terminal) return [];
+    this.terminal = true;
+    return [{
+      error: {
+        message: message || 'upstream responses stream failed',
+        type: 'upstream_error',
+        code: null,
+      },
+    }];
+  }
+
+  /** 是否已产出终止 chunk。 */
+  get isTerminal(): boolean {
+    return this.terminal;
+  }
+
+  /** 非流式:把累积状态聚合成单个 chat.completion 对象。 */
+  aggregate(): Record<string, unknown> {
+    const message: Record<string, unknown> = { role: 'assistant' };
+    const toolCalls = [...this.toolsByOutputIndex.values()]
+      .sort((a, b) => a.chatIndex - b.chatIndex)
+      .map((state) => ({
+        id: state.id,
+        type: 'function' as const,
+        function: { name: state.name, arguments: state.args },
+      }));
+    message.content = this.text.length > 0 ? this.text : null;
+    if (this.reasoning.length > 0) message.reasoning_content = this.reasoning;
+    if (toolCalls.length > 0) message.tool_calls = toolCalls;
+
+    const completion: Record<string, unknown> = {
+      id: this.chatId(),
+      object: 'chat.completion',
+      created: this.created,
+      model: this.model,
+      choices: [{
+        index: 0,
+        message,
+        finish_reason: this.pendingFinish ?? (toolCalls.length > 0 ? 'tool_calls' : 'stop'),
+      }],
+    };
+    const usage = this.chatUsage();
+    if (usage) completion.usage = usage;
+    return completion;
+  }
+
+  private absorbResponseMeta(response: unknown): void {
+    if (!isPlainObject(response)) return;
+    if (!this.responseId && typeof response.id === 'string' && response.id) {
+      this.responseId = response.id;
+    }
+    if (typeof response.model === 'string' && response.model) this.model = response.model;
+    if (typeof response.created_at === 'number' && response.created_at) {
+      this.created = response.created_at;
+    }
+    if (isPlainObject(response.usage)) this.usage = response.usage;
+  }
+
+  private ensureRoleChunk(out: Array<Record<string, unknown>>): void {
+    if (this.roleEmitted) return;
+    this.roleEmitted = true;
+    out.push(this.chunk({ role: 'assistant' }));
+  }
+
+  private startToolCall(
+    outputIndex: number,
+    item: Record<string, unknown>,
+    out: Array<Record<string, unknown>>,
+  ): ToolCallState {
+    const existing = this.toolsByOutputIndex.get(outputIndex);
+    if (existing) return existing;
+    const chatIndex = this.nextToolIndex++;
+    const id = stringField(item.call_id) || `call_${this.responseId || 'bridge'}_${outputIndex}`;
+    const state: ToolCallState = {
+      chatIndex,
+      outputIndex,
+      id,
+      name: stringField(item.name),
+      args: '',
+    };
+    this.toolsByOutputIndex.set(outputIndex, state);
+    if (typeof item.id === 'string' && item.id) this.outputIndexByItemId.set(item.id, outputIndex);
+    this.ensureRoleChunk(out);
+    out.push(this.chunk({
+      tool_calls: [{
+        index: chatIndex,
+        id: state.id,
+        type: 'function',
+        function: { name: state.name, arguments: '' },
+      }],
+    }));
+    return state;
+  }
+
+  private finalizeToolFromItem(
+    outputIndex: number,
+    item: Record<string, unknown>,
+    out: Array<Record<string, unknown>>,
+  ): void {
+    let state = this.toolsByOutputIndex.get(outputIndex);
+    if (!state) state = this.startToolCall(outputIndex, item, out);
+    if (!state.name && stringField(item.name)) state.name = stringField(item.name);
+    const full = stringField(item.arguments);
+    if (full && state.args.length === 0) {
+      state.args = full;
+      out.push(this.chunk({
+        tool_calls: [{ index: state.chatIndex, function: { arguments: full } }],
+      }));
+    }
+  }
+
+  private resolveToolState(itemId: unknown, outputIndex: unknown): ToolCallState | undefined {
+    if (typeof itemId === 'string' && this.outputIndexByItemId.has(itemId)) {
+      return this.toolsByOutputIndex.get(this.outputIndexByItemId.get(itemId)!);
+    }
+    if (typeof outputIndex === 'number') return this.toolsByOutputIndex.get(outputIndex);
+    return undefined;
+  }
+
+  private markComplete(out: Array<Record<string, unknown>>): void {
+    if (this.terminal) return;
+    this.terminal = true;
+    this.ensureRoleChunk(out);
+    out.push(this.chunk({}, this.pendingFinish ?? 'stop'));
+    if (this.includeUsage) {
+      const usage = this.chatUsage();
+      if (usage) {
+        out.push({
+          id: this.chatId(),
+          object: 'chat.completion.chunk',
+          created: this.created,
+          model: this.model,
+          choices: [],
+          usage,
+        });
+      }
+    }
+  }
+
+  private incompleteReason(response: unknown): ChatFinishReason {
+    if (isPlainObject(response) && isPlainObject(response.incomplete_details)) {
+      const reason = response.incomplete_details.reason;
+      if (reason === 'max_output_tokens') return 'length';
+      if (reason === 'content_filter') return 'content_filter';
+    }
+    return 'length';
+  }
+
+  private failureMessage(response: unknown): string {
+    if (isPlainObject(response) && isPlainObject(response.error)) {
+      const message = response.error.message;
+      if (typeof message === 'string' && message) return message;
+    }
+    return 'upstream responses stream failed';
+  }
+
+  private chatId(): string {
+    return this.responseId ? `chatcmpl-${this.responseId}` : 'chatcmpl-bridge';
+  }
+
+  private chunk(
+    delta: Record<string, unknown>,
+    finishReason: ChatFinishReason | null = null,
+  ): Record<string, unknown> {
+    return {
+      id: this.chatId(),
+      object: 'chat.completion.chunk',
+      created: this.created,
+      model: this.model,
+      choices: [{ index: 0, delta, finish_reason: finishReason }],
+    };
+  }
+
+  private chatUsage(): Record<string, unknown> | null {
+    const u = this.usage;
+    if (!u) return null;
+    const inputDetails = isPlainObject(u.input_tokens_details)
+      ? u.input_tokens_details
+      : isPlainObject(u.prompt_tokens_details) ? u.prompt_tokens_details : undefined;
+    const outputDetails = isPlainObject(u.output_tokens_details)
+      ? u.output_tokens_details
+      : isPlainObject(u.completion_tokens_details) ? u.completion_tokens_details : undefined;
+    const prompt = numberField(u.input_tokens ?? u.prompt_tokens);
+    const completion = numberField(u.output_tokens ?? u.completion_tokens);
+    const total = numberField(u.total_tokens) || prompt + completion;
+    return {
+      prompt_tokens: prompt,
+      completion_tokens: completion,
+      total_tokens: total,
+      prompt_tokens_details: { cached_tokens: numberField(inputDetails?.cached_tokens) },
+      completion_tokens_details: { reasoning_tokens: numberField(outputDetails?.reasoning_tokens) },
+    };
+  }
+}

--- a/packages/responses-chat-bridge/src/translate-chat-request.ts
+++ b/packages/responses-chat-bridge/src/translate-chat-request.ts
@@ -97,6 +97,25 @@ const SAMPLING_PASSTHROUGH_FIELDS = [
 ] as const;
 
 /**
+ * Chat 的 `response_format` → Responses 的 `text.format`。
+ *
+ * Responses API 没有顶层 `response_format`,结构化输出挂在 `text.format` 下,且 `json_schema` 是
+ * **扁平**的(name/description/schema/strict 直接铺在 format 上),不是 Chat 的
+ * `{ json_schema: {...} }` 嵌套。见 OpenAI structured outputs 文档。原样照抄 Chat 字段会让
+ * 透明转发到 Responses 供应商(如 XD 网关)的路由以「未知参数」拒掉本来合法的请求(#1666 review P1)。
+ *
+ * 这与反向的 `chatResponseFormat()`(translate-request.ts)构成一对互逆映射:反向把 format 里除
+ * `type` 以外的字段收进 `json_schema`,这里就把 `json_schema` 的内容摊回顶层。
+ */
+function responsesTextFormat(value: unknown): unknown {
+  if (!isPlainObject(value) || value.type !== 'json_schema' || !isPlainObject(value.json_schema)) {
+    return value;
+  }
+  const { json_schema: jsonSchema, ...rest } = value;
+  return { ...rest, ...jsonSchema, type: 'json_schema' };
+}
+
+/**
  * 把一个标准 Chat Completions 请求译成 Responses 请求。
  *
  * - 前导 system/developer 合并进 `instructions`;之后出现的 system/developer 保留为 message item。
@@ -104,6 +123,7 @@ const SAMPLING_PASSTHROUGH_FIELDS = [
  *   assistant.tool_calls → function_call item;role:tool → function_call_output item。
  * - tools(function)→ Responses function tools;max_tokens/max_completion_tokens → max_output_tokens;
  *   reasoning_effort / reasoning.effort → reasoning.effort;常规采样参数透传。
+ * - response_format → text.format(见 responsesTextFormat)。
  */
 export function translateChatToResponsesRequest(
   input: ChatCompletionsRequest,
@@ -214,7 +234,9 @@ export function translateChatToResponsesRequest(
   for (const field of SAMPLING_PASSTHROUGH_FIELDS) {
     if (record[field] !== undefined) target[field] = record[field];
   }
-  if (input.response_format !== undefined) request.response_format = input.response_format;
+  if (input.response_format !== undefined) {
+    request.text = { format: responsesTextFormat(input.response_format) };
+  }
 
   if (typeof record.n === 'number' && record.n > 1) opts.onDowngrade?.('n>1');
 

--- a/packages/responses-chat-bridge/src/translate-chat-request.ts
+++ b/packages/responses-chat-bridge/src/translate-chat-request.ts
@@ -1,0 +1,223 @@
+/**
+ * Chat Completions 请求 → OpenAI Responses 请求(translate-request.ts 的**反向**)。
+ *
+ * 用途:对外「通用 OpenAI Chat Completions 端点」把外部客户端的标准 Chat 请求译成 Responses
+ * 请求,再打到 Cindy 自己的 `/responses`(那里按供应商 wire 分派:直连 Responses / 经
+ * responses-chat 或 responses-anthropic bridge)。这样一条 chat 客户端就能复用全部供应商。
+ *
+ * 与 Codex 特有的 namespace / tool_search / custom_tool 无关 —— 通用 chat 客户端只发标准
+ * `function` 工具与标准 content part,这里只做「标准 Chat ⇒ 标准 Responses」的忠实映射。
+ * 无法在 Responses 语义里表达的字段(如 assistant.reasoning_content 历史、n>1)记降级后丢弃。
+ */
+
+import type {
+  ChatCompletionsRequest,
+  ResponsesContentPart,
+  ResponsesInputItem,
+  ResponsesRequest,
+} from './types.js';
+
+export interface TranslateChatToResponsesOptions {
+  /** 覆盖上游真实 model(缺省用请求里的 model)。 */
+  model?: string;
+  /** 记录无法在 Responses 里表达、被丢弃的特性(用于观测降级,不抛错)。 */
+  onDowngrade?: (feature: string) => void;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Chat user content parts → Responses input content parts(text/image/file/audio 忠实映射)。 */
+function convertUserContent(
+  content: unknown,
+): string | ResponsesContentPart[] {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: ResponsesContentPart[] = [];
+  for (const raw of content) {
+    if (!isPlainObject(raw) || typeof raw.type !== 'string') continue;
+    if (raw.type === 'text' && typeof raw.text === 'string') {
+      parts.push({ type: 'input_text', text: raw.text });
+    } else if (raw.type === 'image_url' && isPlainObject(raw.image_url) && typeof raw.image_url.url === 'string') {
+      const detail = typeof raw.image_url.detail === 'string' ? raw.image_url.detail : undefined;
+      parts.push({
+        type: 'input_image',
+        image_url: { url: raw.image_url.url, ...(detail ? { detail } : {}) },
+      });
+    } else if (raw.type === 'file' && isPlainObject(raw.file)) {
+      const file = raw.file;
+      parts.push({
+        type: 'input_file',
+        ...(typeof file.file_id === 'string' ? { file_id: file.file_id } : {}),
+        ...(typeof file.file_data === 'string' ? { file_data: file.file_data } : {}),
+        ...(typeof file.file_url === 'string' ? { file_url: file.file_url } : {}),
+        ...(typeof file.filename === 'string' ? { filename: file.filename } : {}),
+      });
+    } else if (raw.type === 'input_audio' && isPlainObject(raw.input_audio)
+      && typeof raw.input_audio.data === 'string' && typeof raw.input_audio.format === 'string') {
+      parts.push({
+        type: 'input_audio',
+        input_audio: { data: raw.input_audio.data, format: raw.input_audio.format },
+      });
+    }
+  }
+  return parts;
+}
+
+/** Chat tool_choice → Responses tool_choice(具名工具从 `{type,function:{name}}` 压平成 `{type,name}`)。 */
+function convertToolChoice(choice: unknown): unknown {
+  if (choice === undefined || choice === 'auto' || choice === 'none' || choice === 'required') {
+    return choice;
+  }
+  if (
+    isPlainObject(choice)
+    && choice.type === 'function'
+    && isPlainObject(choice.function)
+    && typeof choice.function.name === 'string'
+  ) {
+    return { type: 'function', name: choice.function.name };
+  }
+  return choice;
+}
+
+const SAMPLING_PASSTHROUGH_FIELDS = [
+  'temperature',
+  'top_p',
+  'frequency_penalty',
+  'presence_penalty',
+  'stop',
+  'seed',
+  'user',
+  'metadata',
+  'service_tier',
+  'logit_bias',
+  'logprobs',
+  'top_logprobs',
+] as const;
+
+/**
+ * 把一个标准 Chat Completions 请求译成 Responses 请求。
+ *
+ * - 前导 system/developer 合并进 `instructions`;之后出现的 system/developer 保留为 message item。
+ * - user → message item(content 转 input_* part);assistant.content → assistant message item;
+ *   assistant.tool_calls → function_call item;role:tool → function_call_output item。
+ * - tools(function)→ Responses function tools;max_tokens/max_completion_tokens → max_output_tokens;
+ *   reasoning_effort / reasoning.effort → reasoning.effort;常规采样参数透传。
+ */
+export function translateChatToResponsesRequest(
+  input: ChatCompletionsRequest,
+  opts: TranslateChatToResponsesOptions = {},
+): ResponsesRequest {
+  const inputItems: ResponsesInputItem[] = [];
+  let instructions = '';
+  let seenNonSystem = false;
+
+  for (const message of Array.isArray(input.messages) ? input.messages : []) {
+    if (!isPlainObject(message) || typeof message.role !== 'string') continue;
+    const role = message.role;
+
+    if (role === 'system' || role === 'developer') {
+      const text = typeof message.content === 'string' ? message.content : '';
+      if (!seenNonSystem) {
+        instructions = instructions ? `${instructions}\n${text}` : text;
+      } else {
+        inputItems.push({ type: 'message', role, content: text });
+      }
+      continue;
+    }
+
+    seenNonSystem = true;
+
+    if (role === 'user') {
+      inputItems.push({ role: 'user', content: convertUserContent(message.content) });
+      continue;
+    }
+
+    if (role === 'assistant') {
+      const content = message.content;
+      if (typeof content === 'string' && content.length > 0) {
+        inputItems.push({ role: 'assistant', content });
+      }
+      // reasoning_content 历史无法在 Responses input 里忠实承载,记降级后丢弃。
+      if (typeof message.reasoning_content === 'string' && message.reasoning_content.trim()) {
+        opts.onDowngrade?.('assistant.reasoning_content');
+      }
+      const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
+      for (const call of toolCalls) {
+        if (!isPlainObject(call) || !isPlainObject(call.function)) continue;
+        inputItems.push({
+          type: 'function_call',
+          call_id: typeof call.id === 'string' ? call.id : '',
+          name: typeof call.function.name === 'string' ? call.function.name : '',
+          arguments: typeof call.function.arguments === 'string' ? call.function.arguments : '',
+          ...(isPlainObject(call.extra_content) ? { extra_content: call.extra_content } : {}),
+        });
+      }
+      continue;
+    }
+
+    if (role === 'tool') {
+      inputItems.push({
+        type: 'function_call_output',
+        call_id: typeof message.tool_call_id === 'string' ? message.tool_call_id : '',
+        output: typeof message.content === 'string' ? message.content : (message.content ?? ''),
+      });
+      continue;
+    }
+  }
+
+  const request: ResponsesRequest = {
+    model: opts.model ?? input.model,
+    input: inputItems,
+  };
+  if (instructions) request.instructions = instructions;
+
+  const tools: NonNullable<ResponsesRequest['tools']> = [];
+  for (const tool of Array.isArray(input.tools) ? input.tools : []) {
+    if (!isPlainObject(tool) || tool.type !== 'function' || !isPlainObject(tool.function)) continue;
+    const fn = tool.function;
+    if (typeof fn.name !== 'string') continue;
+    tools.push({
+      type: 'function',
+      name: fn.name,
+      ...(typeof fn.description === 'string' ? { description: fn.description } : {}),
+      ...(isPlainObject(fn.parameters) ? { parameters: fn.parameters } : {}),
+      ...(typeof fn.strict === 'boolean' ? { strict: fn.strict } : {}),
+    });
+  }
+  if (tools.length > 0) {
+    request.tools = tools;
+    const toolChoice = convertToolChoice(input.tool_choice);
+    if (toolChoice !== undefined) request.tool_choice = toolChoice;
+    if (typeof input.parallel_tool_calls === 'boolean') {
+      request.parallel_tool_calls = input.parallel_tool_calls;
+    }
+  }
+
+  const maxTokens = typeof input.max_completion_tokens === 'number'
+    ? input.max_completion_tokens
+    : typeof input.max_tokens === 'number'
+      ? input.max_tokens
+      : undefined;
+  if (typeof maxTokens === 'number') request.max_output_tokens = maxTokens;
+
+  const effort = typeof input.reasoning?.effort === 'string'
+    ? input.reasoning.effort
+    : typeof input.reasoning_effort === 'string'
+      ? input.reasoning_effort
+      : undefined;
+  if (effort) request.reasoning = { effort };
+
+  const record = input as unknown as Record<string, unknown>;
+  const target = request as Record<string, unknown>;
+  for (const field of SAMPLING_PASSTHROUGH_FIELDS) {
+    if (record[field] !== undefined) target[field] = record[field];
+  }
+  if (input.response_format !== undefined) request.response_format = input.response_format;
+
+  if (typeof record.n === 'number' && record.n > 1) opts.onDowngrade?.('n>1');
+
+  request.stream = input.stream !== false;
+  return request;
+}


### PR DESCRIPTION
把 Cindy 内部 loopback 代理对外开放,让用户自己的外部 CLI 复用 Cindy 里 配好的供应商与凭证,本质是 cc-switch 的服务端版。

- Anthropic wire(Claude Code):x-api-key 鉴权,ANTHROPIC_BASE_URL 指向本地端口。
- Codex/OpenAI wire:新增 responses-chat-bridge 反向翻译(chat→responses), Codex 说 Responses、通用 OpenAI 工具说 Chat Completions 都可用, Authorization: Bearer 鉴权。
- 两族各自独立开关 + 各自独立访问令牌,跨族 token 不互通(收紧隔离)。
- 设置 → 模型供应商 内新增「模型 Proxy」子区块:两张卡片各带开关/令牌/ 地址端口(合并成一个框,host 固定、仅端口可编辑、复制取完整 url)/默认供应商/ 复制环境变量/写入配置(仅用户主动点击、二次确认、非破坏性 merge、token 不入文件)。

安全底线:只绑 127.0.0.1;外部分支绝不回落默认网关(防 token 透传上游);
转发前 strip 外部 token 头;供应商下拉只列 agent 可路由项;写通道全过
assertTrustedAppRendererEvent;token 只进 safeStorage、renderer 只拿掩码。

验证:desktop / anthropic-compat-proxy / responses-chat-bridge 单测全通过; 三包 typecheck 通过;check:i18n 与 check:i18n-glossary 通过。

<!--
PR Title 不是下面的正文标题，而是 GitHub PR 页面最上方的标题。
格式：<type>(<scope>): <简短描述>（scope 可省略）

type：feat / fix / refactor / perf / chore / docs / test / revert / build / ci
示例：docs(readme): 补充本地模式与远程开发说明；fix: 修复登录跳转
-->

## 这次改了什么

### 摘要

<!-- 用大白话说明改了什么，以及为什么改。保持单一目标。 -->

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：
- 本 PR 包含：
- 明确不包含：
- 用户可见变化：
- 是否存在 breaking change：无 / 有，说明：

### UI 变化

<!-- 涉及 UI 时附截图或录屏，并注明平台；不涉及则写“不涉及”。 -->

- 引用的设计规范：

<!-- 涉及 UI 时必填：列出本次改动遵循的设计规范章节与约束，并说明如何满足。
规范正本为 docs/design-rules/DESIGN.md（相关文档索引见
docs/design-rules/cindy-design-system.md）。写到具体章节/条款，
如“DESIGN.md §间距与栅格：卡片内边距 16px”。
改动命中 UI 代码路径但确无视觉/交互/文案变化时，写“不涉及：<理由>”；
完全不涉及 UI 则写“不涉及”。CI（pr-design-basis）会在变更命中 UI 路径时
校验本字段，判定逻辑见 scripts/check-pr-design-basis.mjs。 -->

## 怎么验证的

### 自动验证

<!-- 列出实际执行的命令及结果，不要只写“已测试”。 -->

```text
pnpm ...
结果：
```

### 手工验证

<!-- 写明操作路径、平台、账号或环境；不涉及则写“不涉及”。 -->

### 未执行的验证

<!-- 没有执行某项验证时，说明原因；没有则写“无”。mobile 本地验证需注明
branch/worktree、Metro 归属与 __DEV__ build label 证据。 -->

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：
- 回滚 / 降级方式：

<!-- 命中 SQLite migration、system prompt、协议、原生层、fingerprint/OTA 或跨平台差异时，
必须写清影响和回滚/降级方式；不涉及风险时明确写“无”。

命中「存量插件兼容」时，必须写明「存量插件影响：无」或「有 + 迁移与提示方案」，并说明
基于旧布局的升级用例跑在哪。会让用户已装插件失效或需要重装／重新确认的改动与冷更同级，
需把关人对该影响明确确认；规则见 docs/dev-rules/plugin-security-and-authoring.md 第 5 节。

改动会改变 mobile runtime fingerprint（即触发冷更）时，还要写明为什么冷更不可避免、
存量装机的影响范围与发版节奏建议；这类 PR 与技术框架变动同级，需仓库指定的把关人针对
冷更明确确认后才能合并（提交者身份不构成例外），规则见
docs/dev-rules/mobile-development.md 的「冷更边界」。 -->

### 提交前检查

- [ ] 已 review 完整 diff
- [ ] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [ ] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [ ] 已确认测试结果或说明未执行原因
