### PR TITLE
refactor(mobile): Android bundle 不再引用 expo-notifications 原生模块

### DIFF
--- a/apps/mobile/src/__tests__/nativeNotificationsDecoupling.test.ts
+++ b/apps/mobile/src/__tests__/nativeNotificationsDecoupling.test.ts
@@ -34,10 +34,16 @@ const SDK_ALLOWLIST = new Set([
   path.join(NOTIFICATIONS_DIR, 'nativeNotifications.types.ts'),
 ]);
 
-/** 只认真正的模块引用形态,散文里提到 SDK 名(注释)不算违规。 */
+/**
+ * 只认真正的模块引用形态,散文里提到 SDK 名(注释)不算违规。
+ *
+ * 关键字必须带 `\b`:否则 `perform('expo-notifications')` 之类会把 `form` 当成 `from`
+ * 误判。引号两种都收:漏掉一种会让守门在双引号写法下静默失效(漏判比误判更糟)。
+ */
 const SDK_MODULE_REFERENCE =
-  /(?:from|import|require)\s*\(?\s*['"]expo-notifications(?:\/[^'"]*)?['"]/;
-const NATIVE_NOTIFICATIONS_IMPORT = /from '(?:\.\/|@\/notifications\/)nativeNotifications'/;
+  /\b(?:from|import|require)\s*\(?\s*['"]expo-notifications(?:\/[^'"]*)?['"]/;
+const NATIVE_NOTIFICATIONS_IMPORT =
+  /\b(?:from|import|require)\s*\(?\s*['"](?:\.\/|@\/notifications\/)nativeNotifications['"]/;
 const NOTIFICATIONS_MEMBER = /\bNotifications\.([A-Za-z0-9_]+)/g;
 
 function* walkSourceFiles(dir: string): Generator<string> {
@@ -56,6 +62,37 @@ function allSourceFiles(): string[] {
 }
 
 describe('Android 不引用 expo-notifications 原生模块', () => {
+  // 守门自身的判据要有用例:正则悄悄失配会让上面两条断言变成永绿的假保险。
+  it('模块引用正则认得各种写法,且不被散文/相似词误命中', () => {
+    for (const violation of [
+      "import * as Notifications from 'expo-notifications';",
+      'import * as Notifications from "expo-notifications";',
+      "const n = await import('expo-notifications');",
+      "require('expo-notifications')",
+      "import { setBadgeCountAsync } from 'expo-notifications/build/BadgeModule';",
+    ]) {
+      expect(SDK_MODULE_REFERENCE.test(violation), violation).toBe(true);
+    }
+    for (const allowed of [
+      '// expo-notifications 的 JS 入口在 import 期就 requireNativeModule(...)',
+      "await perform('expo-notifications')", // form ≠ from:词边界必须挡住
+      "import * as Notifications from './nativeNotifications';",
+    ]) {
+      expect(SDK_MODULE_REFERENCE.test(allowed), allowed).toBe(false);
+    }
+
+    for (const consumer of [
+      "import Notifications from './nativeNotifications';",
+      'import Notifications from "./nativeNotifications";',
+      "import Notifications from '@/notifications/nativeNotifications';",
+    ]) {
+      expect(NATIVE_NOTIFICATIONS_IMPORT.test(consumer), consumer).toBe(true);
+    }
+    expect(
+      NATIVE_NOTIFICATIONS_IMPORT.test("import x from './nativeNotificationsHelper';"),
+    ).toBe(false);
+  });
+
   it('除接入点外没有文件直接 import expo-notifications', () => {
     const violations = allSourceFiles().filter(
       (file) =>

--- a/apps/mobile/src/__tests__/nativeNotificationsDecoupling.test.ts
+++ b/apps/mobile/src/__tests__/nativeNotificationsDecoupling.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Android 与 expo-notifications 原生模块解耦的守门(静态断言 + 面接口对齐)。
+ *
+ * expo-notifications 的 JS 入口在 **import 期**就 `requireNativeModule(...)`,原生模块
+ * 缺失即抛;而 Android 推送从未实现(`isPushSupported()` 只放行 iOS),那颗原生模块只是
+ * 把 Firebase Messaging / Installations / DataTransport 与消息权限带进 Android 包。
+ * 因此约定:业务代码只经 `@/notifications/nativeNotifications` 访问该 SDK,Android 由
+ * `nativeNotifications.android.ts` 顶成空实现,Android bundle 完全不引用真模块。
+ *
+ * 这两条断言拦的是**运行期才会暴露**的两类回归:
+ *  1. 有人在别处直接 import 'expo-notifications' → Android 冷启动崩(typecheck 拦不住);
+ *  2. 有人新增 `Notifications.foo()` 调用但没在 Android 替身里补 foo → Android 上
+ *     `undefined is not a function`。typecheck 已能拦第 2 类(替身按
+ *     NativeNotificationsApi 收敛),这里再加一道源码级兜底,顺带覆盖 app/ 路由文件。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it, vi } from 'vitest';
+
+// 真模块拖 react-native 依赖链,node 环境下不可 import;替身只用到 PermissionStatus 枚举。
+vi.mock('expo-modules-core', () => ({
+  PermissionStatus: { GRANTED: 'granted', UNDETERMINED: 'undetermined', DENIED: 'denied' },
+}));
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const APP_ROOT = path.resolve(SRC_ROOT, '..', 'app');
+const NOTIFICATIONS_DIR = path.join(SRC_ROOT, 'notifications');
+
+/** 唯一允许出现 'expo-notifications' 的两个文件:真接入点与它的纯类型契约。 */
+const SDK_ALLOWLIST = new Set([
+  path.join(NOTIFICATIONS_DIR, 'nativeNotifications.ts'),
+  path.join(NOTIFICATIONS_DIR, 'nativeNotifications.types.ts'),
+]);
+
+/** 只认真正的模块引用形态,散文里提到 SDK 名(注释)不算违规。 */
+const SDK_MODULE_REFERENCE =
+  /(?:from|import|require)\s*\(?\s*['"]expo-notifications(?:\/[^'"]*)?['"]/;
+const NATIVE_NOTIFICATIONS_IMPORT = /from '(?:\.\/|@\/notifications\/)nativeNotifications'/;
+const NOTIFICATIONS_MEMBER = /\bNotifications\.([A-Za-z0-9_]+)/g;
+
+function* walkSourceFiles(dir: string): Generator<string> {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.') || entry.name === '__tests__') {
+      continue;
+    }
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) yield* walkSourceFiles(full);
+    else if (/\.(ts|tsx)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) yield full;
+  }
+}
+
+function allSourceFiles(): string[] {
+  return [...walkSourceFiles(SRC_ROOT), ...walkSourceFiles(APP_ROOT)];
+}
+
+describe('Android 不引用 expo-notifications 原生模块', () => {
+  it('除接入点外没有文件直接 import expo-notifications', () => {
+    const violations = allSourceFiles().filter(
+      (file) =>
+        !SDK_ALLOWLIST.has(file) &&
+        SDK_MODULE_REFERENCE.test(fs.readFileSync(file, 'utf8')),
+    );
+    expect(
+      violations.map((file) => path.relative(SRC_ROOT, file)),
+      '请改用 @/notifications/nativeNotifications(原因见该文件头注)',
+    ).toEqual([]);
+  });
+
+  it('Android 替身覆盖了业务代码用到的每个成员', async () => {
+    const androidStub = (
+      await import('@/notifications/nativeNotifications.android')
+    ).default as Record<string, unknown>;
+
+    const used = new Set<string>();
+    for (const file of allSourceFiles()) {
+      const content = fs.readFileSync(file, 'utf8');
+      if (!NATIVE_NOTIFICATIONS_IMPORT.test(content)) continue;
+      for (const [, member] of content.matchAll(NOTIFICATIONS_MEMBER)) {
+        used.add(member);
+      }
+    }
+
+    // 面接口不为空,避免正则失配导致这条断言空转成永真。
+    expect(used.size).toBeGreaterThan(0);
+    expect(
+      [...used].filter((member) => typeof androidStub[member] !== 'function').sort(),
+      '请在 nativeNotifications.android.ts 补上这些成员的 Android 实现',
+    ).toEqual([]);
+  });
+});

--- a/apps/mobile/src/notifications/PushNotificationsBridge.tsx
+++ b/apps/mobile/src/notifications/PushNotificationsBridge.tsx
@@ -1,7 +1,7 @@
-import * as Notifications from 'expo-notifications';
 import { useRouter } from 'expo-router';
 import { useEffect, useRef } from 'react';
 import { useAuth } from '@/auth/AuthContext';
+import Notifications from './nativeNotifications';
 import { parseNotificationDeepLink } from './pushRegistrationModel';
 import {
   configureForegroundNotificationBehavior,

--- a/apps/mobile/src/notifications/nativeNotifications.android.ts
+++ b/apps/mobile/src/notifications/nativeNotifications.android.ts
@@ -1,0 +1,47 @@
+import { PermissionStatus } from 'expo-modules-core';
+
+import type { NativeNotificationsApi } from './nativeNotifications.types';
+
+/**
+ * Android 的 expo-notifications 替身(Metro 平台扩展在 `platform === 'android'` 时
+ * 顶掉 `nativeNotifications.ts`)。
+ *
+ * 为什么是替身而不是直接用真模块:见 `nativeNotifications.ts` 的说明——真模块在
+ * import 期就要求原生模块存在,而 Android 推送从未实现(`isPushSupported()` 只放行
+ * iOS),那颗原生模块只是把 Firebase Messaging / Installations / DataTransport 与消息
+ * 权限带进包里。本文件让 Android bundle 完全不引用 expo-notifications。
+ *
+ * 因此这里的实现只需保证「被 import 不炸」:所有真实调用点都在 `isPushSupported()`
+ * 之后,正常路径下一个都不会执行到。行为上取最保守语义(权限拒绝、订阅空实现、
+ * 无历史通知),而 `getDevicePushTokenAsync` 直接抛——它没有任何合理的假值可返回,
+ * 静默返回空串只会把坏数据发到 server 的注册表。
+ *
+ * 要给 Android 接推送时:实现应该落在本文件(接国内厂商通道或 FCM),而不是把
+ * `isPushSupported()` 放开去用真模块——那会把整条 Google 链重新带回来。
+ */
+
+const EMPTY_SUBSCRIPTION = { remove: () => {} };
+
+const DENIED: Awaited<
+  ReturnType<NativeNotificationsApi['getPermissionsAsync']>
+> = {
+  status: PermissionStatus.DENIED,
+  expires: 'never',
+  granted: false,
+  canAskAgain: false,
+};
+
+const nativeNotifications: NativeNotificationsApi = {
+  setNotificationHandler: () => {},
+  getPermissionsAsync: async () => DENIED,
+  requestPermissionsAsync: async () => DENIED,
+  getDevicePushTokenAsync: async () => {
+    throw new Error('Push notifications are not supported on Android');
+  },
+  addPushTokenListener: () => EMPTY_SUBSCRIPTION,
+  addNotificationResponseReceivedListener: () => EMPTY_SUBSCRIPTION,
+  getLastNotificationResponseAsync: async () => null,
+  clearLastNotificationResponseAsync: async () => {},
+};
+
+export default nativeNotifications;

--- a/apps/mobile/src/notifications/nativeNotifications.ts
+++ b/apps/mobile/src/notifications/nativeNotifications.ts
@@ -1,0 +1,25 @@
+import * as Notifications from 'expo-notifications';
+
+import type { NativeNotificationsApi } from './nativeNotifications.types';
+
+/**
+ * expo-notifications 的接入点(iOS / Web / 单测走本文件;Android 由
+ * `nativeNotifications.android.ts` 按 Metro 平台扩展顶掉)。
+ *
+ * 为什么要这层间接:expo-notifications 的 JS 入口在 **import 期**就
+ * `requireNativeModule('ExpoNotificationsEmitter')`(见其
+ * `build/NotificationsEmitterModule.native.js`),原生模块缺失即抛。而移动推送只实现了
+ * iOS(APNs,见 `pushNotifications.ts` 的 `isPushSupported`),Android 从未走通:
+ * 仓内没有 `google-services.json`,拿不到 FCM token,原生模块纯属搭载——却把
+ * Firebase Messaging / Installations / DataTransport 与相关消息权限一整条链带进了包。
+ *
+ * 把 import 收进本模块后,Android bundle 里不会再出现 expo-notifications,
+ * 该原生模块可以被安全剥离(是否剥离由出包侧决定,与本层解耦无关)。
+ *
+ * 与 `platform/appDistribution.ts` 的平台扩展方向相反(那里基础文件是兜底、
+ * `.ios.ts` 才是原生):这里基础文件必须是真模块,才能让 iOS、Web 与 node 单测
+ * (mock 'expo-notifications')都走真实接线,只有 Android 需要被顶掉。
+ */
+const nativeNotifications: NativeNotificationsApi = Notifications;
+
+export default nativeNotifications;

--- a/apps/mobile/src/notifications/nativeNotifications.types.ts
+++ b/apps/mobile/src/notifications/nativeNotifications.types.ts
@@ -1,0 +1,19 @@
+/**
+ * 移动推送真正用到的 expo-notifications 接口面(纯类型,不产生任何运行期 import)。
+ *
+ * 这里刻意只列**已在用**的成员:Android 侧的实现(`nativeNotifications.android.ts`)
+ * 必须逐个补齐,新增调用点时漏补会直接 typecheck 失败,不会静默漏到运行期。
+ * 用 `typeof import(...)` 而不是 `import type * as`,保证本文件编译后为空模块,
+ * Android bundle 不会因为它而牵进 expo-notifications。
+ */
+export type NativeNotificationsApi = Pick<
+  typeof import('expo-notifications'),
+  | 'setNotificationHandler'
+  | 'getPermissionsAsync'
+  | 'requestPermissionsAsync'
+  | 'getDevicePushTokenAsync'
+  | 'addPushTokenListener'
+  | 'addNotificationResponseReceivedListener'
+  | 'getLastNotificationResponseAsync'
+  | 'clearLastNotificationResponseAsync'
+>;

--- a/apps/mobile/src/notifications/pushNotifications.ts
+++ b/apps/mobile/src/notifications/pushNotifications.ts
@@ -1,4 +1,3 @@
-import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import type { ClientEndpointRegion } from '@cindy/maker-shared/client-endpoints';
@@ -10,6 +9,7 @@ import {
   getMobileEndpointForRealm,
   loadMobileEndpointsForRealm,
 } from '@/config/env';
+import Notifications from './nativeNotifications';
 import { buildPushTokenRegistrationBody } from './pushRegistrationModel';
 
 /**
@@ -19,7 +19,8 @@ import { buildPushTokenRegistrationBody } from './pushRegistrationModel';
  * - 注册目标是 device-link server 的 PUT /push-token(Bearer 鉴权与 WS 同源);
  *   关闭开关 / 登出 / 换账号或区域时注销(DELETE,幂等)。
  * - 仅 iOS(APNs):Android 需 FCM / 国内厂商通道,二期接入(server 侧已预留
- *   provider='fcm' 字段)。
+ *   provider='fcm' 字段)。原生模块只在 iOS 存在,所有调用一律经
+ *   `./nativeNotifications`(Android 由平台扩展顶成空实现,原因见该文件)。
  * - App 在前台时压掉系统横幅(WS 活着,会话本来就在实时刷新)。
  */
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

移动推送只实现了 iOS(APNs):`isPushSupported()` 只放行 iOS,仓内也没有 `google-services.json`,Android 拿不到 FCM token。但 `expo-notifications` 的 JS 入口在 **import 期**就 `requireNativeModule('ExpoNotificationsEmitter')`(见其 `build/NotificationsEmitterModule.native.js`),所以 Android 只能一直链着那颗用不上的原生模块——而它把 Firebase Messaging / Installations / DataTransport 与消息权限(`com.google.android.c2dm.permission.RECEIVE`、`POST_NOTIFICATIONS`、`RECEIVE_BOOT_COMPLETED`)整条链带进了 Android 包。

本 PR 把 SDK 访问收进一层 `nativeNotifications`:iOS / Web / node 单测走真模块,Android 由 `nativeNotifications.android.ts` 按 Metro 平台扩展顶成保守空实现。Android bundle 从此完全不引用 `expo-notifications`,为后续在出包侧按 region 剥离对应原生模块解开前置依赖。

行为零变化:所有真实调用点本来就在 `isPushSupported()` 之后,Android 正常路径一个都执行不到。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求:CN Android 包移除 Firebase / Google Play Services 依赖(第一步)
- 本 PR 包含:`nativeNotifications`(真模块)/ `nativeNotifications.android.ts`(Android 替身)/ `nativeNotifications.types.ts`(纯类型契约)、两个消费点改走该层、`nativeNotificationsDecoupling` 守门测试
- 明确不包含:**任何原生剥离**。是否把 `expo-notifications` / `@react-native-google-signin` 从 Android autolinking 排除,由出包侧(cindy-build-scripts)按 region 决定,与本 PR 无关
- 用户可见变化:无
- 是否存在 breaking change:无

### UI 变化

不涉及:本 PR 只改推送接线层的模块引用方式(SDK 访问收进一层平台扩展),不新增或修改任何界面、组件、样式与文案。

- 引用的设计规范:不涉及:纯逻辑重构,无视觉 / 交互 / 文案变化;改动命中 `apps/mobile/src/notifications/` 是因为推送接线层在该目录下,但改的只是模块引用与一个 Android 空实现。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全绿(exit 0)

pnpm --filter mobile test
结果：286 files / 3209 tests passed

pnpm --filter mobile typecheck
结果：通过

node apps/mobile/scripts/ci-fingerprint.mjs compute   # base(upstream/main) 与本分支各一次
结果：两次逐字节一致 —— ios fe2b463479472d5f6ff238263d716068452fe36d
      android e32303018a056a53a00839069914afef2ddc6135
      → 纯 JS 改动，不动 runtime fingerprint，走 OTA，不触发冷更

npx expo export --platform android   # 生产 bundle 实证
结果：ExpoNotificationsEmitter 0 / ExpoPushTokenManager 0 / expo-notifications 0
      对照组 ExpoSecureStore 1、RNGoogleSignin 2（证明该检索方式确实能命中原生模块名）
      Android 替身的错误串命中 1（确认平台扩展生效、被打进 bundle 的是替身）
```

### 手工验证

未做真机 / 模拟器运行验证。

### 未执行的验证

- 未在 iOS 真机或模拟器上跑推送全流程(开关 → 权限 → APNs token → 点击深链)。iOS 侧代码路径逐字未变(基础文件仍是真模块,只是多一层同对象的 re-export),风险由 `pushNotificationsRealm` 等既有单测 + typecheck 覆盖。
- 未在 Android 真机验证冷启动。等价证据是上面的 android 生产 bundle 检索:替身进包、真模块 0 命中,即 import 期不会再触碰原生模块。
- 未跑 Maestro E2E:本 PR 不涉及导航、Device Link 或 UI。
- 附注:`pnpm lint` 在 `packages/project-context/src/toc.ts` 有 2 处 `no-useless-escape` 报错,存在于 base(main),与本 PR 无关,未一并修。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围:仅 `apps/mobile` 推送接线层。iOS / Web / 单测走真模块,行为不变;Android 走替身,而 Android 推送本来就未实现。
- 不改 runtime fingerprint(见上方两次 `ci-fingerprint.mjs` 结果),因此**不触发冷更**,存量装机通过 OTA 获得本次改动。
- 回滚 / 降级方式:revert 本 commit 即可(纯 JS,可随 OTA 回滚)。注意:若出包侧已经据此剥离了 Android 原生模块,则必须先回滚出包侧的排除配置,再回滚本 PR ——反序回滚会让 Android 冷启动崩。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(约定写在 `nativeNotifications.ts` 头注与守门测试头注,未新增独立文档)
- [x] 已确认测试结果或说明未执行原因
