### PR TITLE
fix(mobile): 补齐开发环境 APNs 推送 Token 注册

### DIFF
--- a/apps/mobile/src/__tests__/pushNotificationsRealm.test.ts
+++ b/apps/mobile/src/__tests__/pushNotificationsRealm.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const store = vi.hoisted(() => new Map<string, string>());
 const envState = vi.hoisted(() => ({
   activeRealm: 'cn' as 'cn' | 'global',
+  buildRegion: 'cn' as 'cn' | 'global' | 'dev',
   endpointByRealm: {
     cn: 'https://relay.cn.example',
     global: 'https://relay.global.example',
@@ -40,7 +41,9 @@ vi.mock('react-native', () => ({
 }));
 
 vi.mock('@/config/env', () => ({
-  AUTH_REGION: 'cn',
+  get AUTH_REGION() {
+    return envState.buildRegion;
+  },
   BUILD_AUTH_REGION: 'cn',
   getActiveMobileSessionRealm: () => envState.activeRealm,
   loadMobileEndpointsForRealm: mocks.loadMobileEndpointsForRealm,
@@ -73,6 +76,7 @@ describe('push notification realm routing', () => {
     vi.clearAllMocks();
     store.clear();
     envState.activeRealm = 'cn';
+    envState.buildRegion = 'cn';
     mocks.getPermissionsAsync.mockResolvedValue({
       status: 'granted',
       canAskAgain: false,
@@ -109,6 +113,28 @@ describe('push notification realm routing', () => {
       'revocationToken',
     );
     expect(readStoredRealms(REGISTERED_KEY)).toEqual(['global']);
+  });
+
+  it('dev 构建复用 cn 推送构建线向开发环境注册', async () => {
+    envState.buildRegion = 'dev';
+    expect((await import('@/config/env')).AUTH_REGION).toBe('dev');
+    const apiFetch = vi.fn().mockResolvedValue({ registered: true });
+
+    await expect(
+      syncPushRegistration({ enabled: true, apiFetch }),
+    ).resolves.toBe('registered');
+
+    expect(apiFetch).toHaveBeenCalledWith(
+      '/api/device-link/push-token',
+      expect.objectContaining({
+        baseUrl: 'https://relay.cn.example',
+        method: 'PUT',
+        body: expect.objectContaining({
+          token: 'apns-device-token',
+          appVariant: 'cn',
+        }),
+      }),
+    );
   });
 
   it('切换区域前用旧 token 向显式冻结的旧区域撤销', async () => {

--- a/apps/mobile/src/__tests__/pushRegistrationModel.test.ts
+++ b/apps/mobile/src/__tests__/pushRegistrationModel.test.ts
@@ -6,10 +6,10 @@ import {
 } from '@/notifications/pushRegistrationModel';
 
 describe('resolvePushAppVariant', () => {
-  it('cn / global 直通,dev 身份不注册', () => {
+  it('cn / global 直通,dev 身份归 cn 推送构建线', () => {
     expect(resolvePushAppVariant('cn')).toBe('cn');
     expect(resolvePushAppVariant('global')).toBe('global');
-    expect(resolvePushAppVariant('dev')).toBeNull();
+    expect(resolvePushAppVariant('dev')).toBe('cn');
   });
 });
 
@@ -27,10 +27,12 @@ describe('buildPushTokenRegistrationBody', () => {
     expect(
       buildPushTokenRegistrationBody({ token: 'abc123', region: 'global', isDevBuild: false }),
     ).toMatchObject({ appVariant: 'global', apnsEnv: 'prod' });
+    expect(
+      buildPushTokenRegistrationBody({ token: 'dev-token', region: 'dev', isDevBuild: true }),
+    ).toMatchObject({ appVariant: 'cn', apnsEnv: 'sandbox' });
   });
 
-  it('dev 身份 / 空 token 返回 null', () => {
-    expect(buildPushTokenRegistrationBody({ token: 'abc', region: 'dev', isDevBuild: true })).toBeNull();
+  it('空 token 返回 null', () => {
     expect(buildPushTokenRegistrationBody({ token: '   ', region: 'cn', isDevBuild: true })).toBeNull();
   });
 });

--- a/apps/mobile/src/notifications/pushRegistrationModel.ts
+++ b/apps/mobile/src/notifications/pushRegistrationModel.ts
@@ -10,10 +10,11 @@ export type PushAppVariant = 'cn' | 'global';
 
 /**
  * 构建线 → server 侧 appVariant(决定 APNs topic/bundleId)。
- * dev 第三身份(com.xd.cindydev)没有对应 APNs topic,不注册(返回 null)。
+ * dev 是内部开发身份且行为语义归 cn 系：开发环境用 APNS_TOPIC_CN
+ * 配置 com.xd.cindydev，因此注册时复用 appVariant='cn'。
  */
-export function resolvePushAppVariant(region: 'cn' | 'global' | 'dev'): PushAppVariant | null {
-  return region === 'cn' || region === 'global' ? region : null;
+export function resolvePushAppVariant(region: 'cn' | 'global' | 'dev'): PushAppVariant {
+  return region === 'global' ? 'global' : 'cn';
 }
 
 export interface PushTokenRegistrationBody {
@@ -25,7 +26,7 @@ export interface PushTokenRegistrationBody {
 }
 
 /**
- * 组装 PUT /push-token 的 body;不可注册的场景(dev 身份 / 空 token)返回 null。
+ * 组装 PUT /push-token 的 body；空 token 返回 null。
  * apnsEnv:dev client(Xcode debug 签名)走 sandbox APNs,TestFlight / App Store /
  * 自建 release 走 prod —— 与 __DEV__ 语义一致。
  */
@@ -35,7 +36,6 @@ export function buildPushTokenRegistrationBody(opts: {
   isDevBuild: boolean;
 }): PushTokenRegistrationBody | null {
   const appVariant = resolvePushAppVariant(opts.region);
-  if (!appVariant) return null;
   const token = opts.token.trim();
   if (!token) return null;
   return {


### PR DESCRIPTION
## 这次改了什么

### 摘要

iOS 通知功能已经正式启用。

补齐内部开发构建 com.xd.cindydev 的 iOS APNs Token 注册。开发身份复用服务端 appVariant: cn，由开发环境的 APNS_TOPIC_CN=com.xd.cindydev 映射到开发 Bundle ID。

### 变更类型

- [x] fix：缺陷修复
- [ ] feat：新功能
- [ ] refactor / perf：重构或性能优化
- [ ] docs / test / chore：文档、测试或工程维护
- [ ] 其他

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：dev 构建身份的推送注册映射、注册链路测试和模型测试。
- 明确不包含：服务端部署配置、APNs 凭证、运维部署文档、正式包推送逻辑。
- 用户可见变化：开发包开启系统通知后，会向开发环境服务端注册 APNs Token。
- 是否存在 breaking change：无

### UI 变化

- 不涉及：仅修改通知注册逻辑和测试，没有界面、交互或文案变化。
- 引用的设计规范：不涉及：纯逻辑改动，无视觉/交互/文案变化。

## 怎么验证的

### 自动验证

```text
XDT_UNIT_TEST_SHARD=1/2 pnpm test:unit -- --workspace-concurrency=1
结果：通过

XDT_UNIT_TEST_SHARD=2/2 pnpm test:unit -- --workspace-concurrency=1
结果：通过

pnpm --filter mobile test
结果：285 个测试文件、3208 项测试通过

pnpm --filter mobile typecheck
结果：通过
```

### 手工验证

不涉及：本次未在已签名的 iOS 开发真机上执行 APNs 真实下发验证。

### 未执行的验证

未执行真实 iOS 开发真机 APNs E2E：需要开发签名包、开发环境服务端配置和可用测试账号；服务端配置由运维单独部署。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：仅影响内部 dev 构建的移动推送 Token 注册；正式 cn / Global 构建行为不变。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复开发身份不注册的旧行为。

本改动为 TypeScript 逻辑和测试变更，不修改原生配置、runtime fingerprint、协议、数据库或服务端代码；服务端开发环境需单独配置 APNS_TOPIC_CN=com.xd.cindydev。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档：不适用，运维文档保留在独立服务端仓库，不放入本 PR
- [x] 已确认测试结果或说明未执行原因
