### PR TITLE
fix(responses-chat-bridge): support agent message history

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -349,6 +349,37 @@ describe('translateResponsesRequest', () => {
     }))).toThrowError(UnsupportedResponsesFeatureError);
   });
 
+  it('converts replayed agent messages to assistant text', () => {
+    const out = translateResponsesRequest(base({
+      input: [
+        { type: 'message', role: 'user', content: 'start' },
+        {
+          type: 'agent_message',
+          author: 'researcher',
+          content: [
+            { type: 'output_text', text: 'Findings' },
+            { type: 'encrypted_content', encrypted_content: 'opaque' },
+          ],
+        },
+        { type: 'message', role: 'user', content: 'continue' },
+        {
+          type: 'agent_message',
+          author: 'reviewer',
+          content: [{ type: 'encrypted_content', encrypted_content: 'opaque' }],
+        },
+        { type: 'message', role: 'user', content: 'finish' },
+      ],
+    }));
+
+    expect(out.messages).toEqual([
+      { role: 'user', content: 'start' },
+      { role: 'assistant', content: '[collab researcher]\nFindings' },
+      { role: 'user', content: 'continue' },
+      { role: 'assistant', content: '[collab message from reviewer; encrypted payload omitted]' },
+      { role: 'user', content: 'finish' },
+    ]);
+  });
+
   it('round-trips replayed Codex tool_search items without breaking tool-call merging', () => {
     const out = translateResponsesRequest(base({
       input: [

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -355,7 +355,7 @@ describe('translateResponsesRequest', () => {
         { type: 'message', role: 'user', content: 'start' },
         {
           type: 'agent_message',
-          author: 'researcher',
+          author: 'researcher\r\nreviewer',
           content: [
             { type: 'output_text', text: '  Findings' },
             { type: 'encrypted_content', encrypted_content: 'opaque' },
@@ -380,7 +380,7 @@ describe('translateResponsesRequest', () => {
       {
         role: 'assistant',
         content: [
-          '[collab researcher]\n  Findings',
+          '[collab researcher reviewer]\n  Findings',
           '[collab message from reviewer; encrypted payload omitted]',
           '[collab message from observer; empty content]',
         ].join('\n'),

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -361,7 +361,6 @@ describe('translateResponsesRequest', () => {
             { type: 'encrypted_content', encrypted_content: 'opaque' },
           ],
         },
-        { type: 'message', role: 'user', content: 'continue' },
         {
           type: 'agent_message',
           author: 'reviewer',
@@ -373,9 +372,10 @@ describe('translateResponsesRequest', () => {
 
     expect(out.messages).toEqual([
       { role: 'user', content: 'start' },
-      { role: 'assistant', content: '[collab researcher]\nFindings' },
-      { role: 'user', content: 'continue' },
-      { role: 'assistant', content: '[collab message from reviewer; encrypted payload omitted]' },
+      {
+        role: 'assistant',
+        content: '[collab researcher]\nFindings\n[collab message from reviewer; encrypted payload omitted]',
+      },
       { role: 'user', content: 'finish' },
     ]);
   });

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -398,6 +398,12 @@ describe('translateResponsesRequest', () => {
     },
   );
 
+  it('reports an unknown agent message part by path', () => {
+    expect(() => translateResponsesRequest(base({
+      input: [{ type: 'agent_message', content: [{ type: 'image_url' }] }],
+    }))).toThrow('input[0].content.image_url');
+  });
+
   it('round-trips replayed Codex tool_search items without breaking tool-call merging', () => {
     const out = translateResponsesRequest(base({
       input: [

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -357,7 +357,7 @@ describe('translateResponsesRequest', () => {
           type: 'agent_message',
           author: 'researcher',
           content: [
-            { type: 'output_text', text: 'Findings' },
+            { type: 'output_text', text: '  Findings' },
             { type: 'encrypted_content', encrypted_content: 'opaque' },
           ],
         },
@@ -374,7 +374,7 @@ describe('translateResponsesRequest', () => {
       { role: 'user', content: 'start' },
       {
         role: 'assistant',
-        content: '[collab researcher]\nFindings\n[collab message from reviewer; encrypted payload omitted]',
+        content: '[collab researcher]\n  Findings\n[collab message from reviewer; encrypted payload omitted]',
       },
       { role: 'user', content: 'finish' },
     ]);

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -389,6 +389,15 @@ describe('translateResponsesRequest', () => {
     ]);
   });
 
+  it.each(['input_text', 'output_text', 'text'])(
+    'reports a malformed agent message %s part by path',
+    (type) => {
+      expect(() => translateResponsesRequest(base({
+        input: [{ type: 'agent_message', content: [{ type }] }],
+      }))).toThrow(`input[0].content.${type}`);
+    },
+  );
+
   it('round-trips replayed Codex tool_search items without breaking tool-call merging', () => {
     const out = translateResponsesRequest(base({
       input: [

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -371,6 +371,7 @@ describe('translateResponsesRequest', () => {
           author: 'observer',
           content: [{ type: 'output_text', text: '   ' }],
         },
+        { type: 'message', role: 'assistant', content: 'Final answer' },
         { type: 'message', role: 'user', content: 'finish' },
       ],
     }));
@@ -385,6 +386,7 @@ describe('translateResponsesRequest', () => {
           '[collab message from observer; empty content]',
         ].join('\n'),
       },
+      { role: 'assistant', content: 'Final answer' },
       { role: 'user', content: 'finish' },
     ]);
   });

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -366,6 +366,11 @@ describe('translateResponsesRequest', () => {
           author: 'reviewer',
           content: [{ type: 'encrypted_content', encrypted_content: 'opaque' }],
         },
+        {
+          type: 'agent_message',
+          author: 'observer',
+          content: [{ type: 'output_text', text: '   ' }],
+        },
         { type: 'message', role: 'user', content: 'finish' },
       ],
     }));
@@ -374,7 +379,11 @@ describe('translateResponsesRequest', () => {
       { role: 'user', content: 'start' },
       {
         role: 'assistant',
-        content: '[collab researcher]\n  Findings\n[collab message from reviewer; encrypted payload omitted]',
+        content: [
+          '[collab researcher]\n  Findings',
+          '[collab message from reviewer; encrypted payload omitted]',
+          '[collab message from observer; empty content]',
+        ].join('\n'),
       },
       { role: 'user', content: 'finish' },
     ]);

--- a/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/translate-request.test.ts
@@ -404,6 +404,32 @@ describe('translateResponsesRequest', () => {
     }))).toThrow('input[0].content.image_url');
   });
 
+  it('keeps agent messages after the preceding tool result', () => {
+    const out = translateResponsesRequest(base({
+      input: [
+        { type: 'function_call', call_id: 'call_1', name: 'shell', arguments: '{}' },
+        {
+          type: 'agent_message',
+          author: 'researcher',
+          content: [{ type: 'output_text', text: 'Findings' }],
+        },
+        { type: 'function_call_output', call_id: 'call_1', output: 'done' },
+      ],
+    }));
+
+    expect(out.messages).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          { id: 'call_1', type: 'function', function: { name: 'shell', arguments: '{}' } },
+        ],
+      },
+      { role: 'tool', tool_call_id: 'call_1', content: 'done' },
+      { role: 'assistant', content: '[collab researcher]\nFindings' },
+    ]);
+  });
+
   it('round-trips replayed Codex tool_search items without breaking tool-call merging', () => {
     const out = translateResponsesRequest(base({
       input: [

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -299,6 +299,39 @@ function reasoningText(value: unknown): string {
   return '';
 }
 
+function agentMessageText(item: Record<string, unknown>, itemIndex: number): string {
+  const author = typeof item.author === 'string' && item.author.trim()
+    ? item.author.trim()
+    : 'agent';
+  let body = '';
+  if (typeof item.content === 'string') {
+    body = item.content;
+  } else if (Array.isArray(item.content)) {
+    const parts: string[] = [];
+    for (const part of item.content) {
+      if (!isPlainObject(part) || typeof part.type !== 'string') {
+        throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
+      }
+      if (part.type === 'encrypted_content') continue;
+      if (
+        (part.type === 'input_text' || part.type === 'output_text' || part.type === 'text')
+        && typeof part.text === 'string'
+      ) {
+        parts.push(part.text);
+        continue;
+      }
+      throw new UnsupportedResponsesFeatureError(`input content part '${part.type}'`);
+    }
+    body = parts.join('\n');
+  } else {
+    throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
+  }
+  const text = body.trim();
+  return text
+    ? `[collab ${author}]\n${text}`
+    : `[collab message from ${author}; encrypted payload omitted]`;
+}
+
 interface TranslateInputOptions {
   developerRole: ChatDeveloperRole;
   mediaCapabilities: ChatMediaCapabilities;
@@ -552,6 +585,13 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
           pushBarrier({ role, content });
         }
       }
+      continue;
+    }
+
+    if (item.type === 'agent_message') {
+      if (!assistant && pendingToolCalls.length > 0) closeUnresolvedToolRound();
+      assistant ??= { role: 'assistant', content: null };
+      assistant.content = `${assistant.content ?? ''}${agentMessageText(record, index)}`;
       continue;
     }
 

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -326,9 +326,8 @@ function agentMessageText(item: Record<string, unknown>, itemIndex: number): str
   } else {
     throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
   }
-  const text = body.trim();
-  return text
-    ? `[collab ${author}]\n${text}`
+  return body.trim()
+    ? `[collab ${author}]\n${body}`
     : `[collab message from ${author}; encrypted payload omitted]`;
 }
 

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -304,6 +304,7 @@ function agentMessageText(item: Record<string, unknown>, itemIndex: number): str
     ? item.author.trim()
     : 'agent';
   let body = '';
+  let omittedEncryptedContent = false;
   if (typeof item.content === 'string') {
     body = item.content;
   } else if (Array.isArray(item.content)) {
@@ -312,7 +313,10 @@ function agentMessageText(item: Record<string, unknown>, itemIndex: number): str
       if (!isPlainObject(part) || typeof part.type !== 'string') {
         throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
       }
-      if (part.type === 'encrypted_content') continue;
+      if (part.type === 'encrypted_content') {
+        omittedEncryptedContent = true;
+        continue;
+      }
       if (
         (part.type === 'input_text' || part.type === 'output_text' || part.type === 'text')
         && typeof part.text === 'string'
@@ -328,7 +332,9 @@ function agentMessageText(item: Record<string, unknown>, itemIndex: number): str
   }
   return body.trim()
     ? `[collab ${author}]\n${body}`
-    : `[collab message from ${author}; encrypted payload omitted]`;
+    : omittedEncryptedContent
+      ? `[collab message from ${author}; encrypted payload omitted]`
+      : `[collab message from ${author}; empty content]`;
 }
 
 interface TranslateInputOptions {

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -595,10 +595,13 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
     }
 
     if (item.type === 'agent_message') {
-      if (!assistant && pendingToolCalls.length > 0) closeUnresolvedToolRound();
-      assistant ??= { role: 'assistant', content: null };
       const content = agentMessageText(record, index);
-      assistant.content = assistant.content ? `${assistant.content}\n${content}` : content;
+      if ((assistant?.tool_calls?.length ?? 0) > 0 || pendingToolCalls.length > 0) {
+        pushBarrier({ role: 'assistant', content });
+      } else {
+        assistant ??= { role: 'assistant', content: null };
+        assistant.content = assistant.content ? `${assistant.content}\n${content}` : content;
+      }
       continue;
     }
 

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -325,7 +325,7 @@ function agentMessageText(item: Record<string, unknown>, itemIndex: number): str
         parts.push(part.text);
         continue;
       }
-      throw new UnsupportedResponsesFeatureError(`input content part '${part.type}'`);
+      throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content.${part.type}`);
     }
     body = parts.join('\n');
   } else {

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -601,6 +601,8 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
       } else {
         assistant ??= { role: 'assistant', content: null };
         assistant.content = assistant.content ? `${assistant.content}\n${content}` : content;
+        const nextItem = input[index + 1];
+        if (!isPlainObject(nextItem) || nextItem.type !== 'agent_message') flushAssistant();
       }
       continue;
     }

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -300,9 +300,10 @@ function reasoningText(value: unknown): string {
 }
 
 function agentMessageText(item: Record<string, unknown>, itemIndex: number): string {
-  const author = typeof item.author === 'string' && item.author.trim()
-    ? item.author.trim()
-    : 'agent';
+  const normalizedAuthor = typeof item.author === 'string'
+    ? item.author.replace(/\s*[\r\n]+\s*/g, ' ').trim()
+    : '';
+  const author = normalizedAuthor || 'agent';
   let body = '';
   let omittedEncryptedContent = false;
   if (typeof item.content === 'string') {

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -317,10 +317,10 @@ function agentMessageText(item: Record<string, unknown>, itemIndex: number): str
         omittedEncryptedContent = true;
         continue;
       }
-      if (
-        (part.type === 'input_text' || part.type === 'output_text' || part.type === 'text')
-        && typeof part.text === 'string'
-      ) {
+      if (part.type === 'input_text' || part.type === 'output_text' || part.type === 'text') {
+        if (typeof part.text !== 'string') {
+          throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content.${part.type}`);
+        }
         parts.push(part.text);
         continue;
       }

--- a/packages/responses-chat-bridge/src/translate-request.ts
+++ b/packages/responses-chat-bridge/src/translate-request.ts
@@ -591,7 +591,8 @@ function translateInput(input: ResponsesRequest['input'], opts: TranslateInputOp
     if (item.type === 'agent_message') {
       if (!assistant && pendingToolCalls.length > 0) closeUnresolvedToolRound();
       assistant ??= { role: 'assistant', content: null };
-      assistant.content = `${assistant.content ?? ''}${agentMessageText(record, index)}`;
+      const content = agentMessageText(record, index);
+      assistant.content = assistant.content ? `${assistant.content}\n${content}` : content;
       continue;
     }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Allow Codex conversations with agent history to continue through Chat Completions providers.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #1630
- Included: Translate readable agent_message content to assistant history, preserve formatting, normalize author newlines, distinguish empty content, omit encrypted payloads, and report malformed parts by input path.
- Not included: UI, schema, migration, dependency, or wire-protocol changes.
- User-visible change: Allow Codex conversations with agent history to continue through Chat Completions providers.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not applicable. No UI, interaction, or copy changes.

- Referenced design rules: Not applicable.

## 怎么验证的

### 自动验证

```text
pnpm test:unit
Result: passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

No additional manual flow was run.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Codex agent messages can be replayed through Chat Completions providers.
- Risk: Readable collab messages become assistant history; encrypted payloads remain omitted and empty readable content is represented separately.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

