### PR TITLE
test(lizi-mcps): extend contacts export timeout

### DIFF
--- a/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
@@ -474,7 +474,7 @@ describe('cindy_contacts tools', () => {
       store.getContact(id).identities.some((i) => i.platform === 'apple-contacts'),
     );
     expect(anchored).toHaveLength(200);
-  });
+  }, 15_000);
 
   it('write/manage 工具成功后触发 onMutated, 只读工具不触发(UI 刷新通道)', async () => {
     // 回归: onMutated 注入后从未被调用 — agent 经 MCP 直写 store 不经 IPC 层,


### PR DESCRIPTION
## 这次改了什么

### 摘要

Give the heavy two-batch contacts export regression enough time on Windows CI.

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: Fixes #1598
- Included: Raise only this test timeout to 15 seconds without changing its workload or assertions.
- Not included: UI, schema, migration, dependency, or wire-protocol changes.
- User-visible change: None; test-only timeout adjustment.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not applicable. No UI, interaction, or copy changes.

- Referenced design rules: Not applicable.

## 怎么验证的

### 自动验证

```text
pnpm test:unit
Result: passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

No additional manual flow was run.

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: One Windows-sensitive regression test receives a 15-second timeout.
- Risk: No known risks.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

