### PR TITLE
ci: build model-access protocol before consumer checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # @cindy/model-access-protocol exposes only generated dist artifacts.
+      # Build it before any consumer typecheck or test collection resolves the
+      # workspace package.
+      - name: Build model-access protocol
+        run: pnpm --filter @cindy/model-access-protocol build
+
       # XDT_SKIP_AGENT_BIN_INSTALL 跳过了 postinstall 的全部 agent 二进制,但
       # runtime-configs.ts 模块顶层的 bundledRipgrepDir() 缺 rg 时直接 throw,
       # 会让 apps/desktop 单测在收集阶段全挂——ripgrep 必须单独装回来。
@@ -185,6 +191,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Build model-access protocol
+        run: pnpm --filter @cindy/model-access-protocol build
 
       - name: Install bundled ripgrep
         env:

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -117,6 +117,40 @@ test("client CI owns the complete Desktop Git integration tier", () => {
 	);
 });
 
+test("client CI builds model-access protocol before consumer checks", () => {
+	const workflow = fs.readFileSync(
+		path.join(ROOT, ".github", "workflows", "ci.yml"),
+		"utf8",
+	).replace(/\r\n/g, "\n");
+	const jobs = [
+		{
+			name: "verify",
+			body: workflow.match(/\n  verify:\n([\s\S]*?)\n  windows-unit-shards:/)?.[1],
+			consumerCommand: "run: pnpm --filter desktop typecheck",
+		},
+		{
+			name: "windows-unit-shards",
+			body: workflow.match(/\n  windows-unit-shards:\n([\s\S]*?)\n  windows-unit:/)?.[1],
+			consumerCommand: "run: pnpm test:unit",
+		},
+	];
+
+	for (const { name, body, consumerCommand } of jobs) {
+		assert.ok(body, `client CI must define the ${name} job`);
+		const installIndex = body.indexOf("run: pnpm install --frozen-lockfile");
+		const buildIndex = body.indexOf(
+			"run: pnpm --filter @cindy/model-access-protocol build",
+		);
+		const consumerIndex = body.indexOf(consumerCommand);
+		assert.ok(installIndex >= 0, `${name} must install dependencies`);
+		assert.ok(buildIndex > installIndex, `${name} must build protocol after install`);
+		assert.ok(
+			consumerIndex > buildIndex,
+			`${name} must build protocol before consumer checks`,
+		);
+	}
+});
+
 test("help groups copyable desktop, binary, and Mobile workflows", async () => {
 	const { printHelp } = await import("../help.mjs");
 	const lines = [];


### PR DESCRIPTION
## 这次改了什么

### 摘要

`@cindy/model-access-protocol` 只导出构建后的 `dist` 文件，但 client CI 在安装依赖后直接运行 Desktop typecheck 和全量单测，导致模块解析失败，并连锁触发 TS7006 与 Windows 测试收集失败。本 PR 在消费者检查前显式构建协议包，并加入工作流顺序回归断言。

### 变更类型

- [x] `fix` 缺陷修复
- [x] 其他：CI 基线修复

### 范围

- 关联 Issue / 需求：修复 client-ci 基线失败，解除 PR #1216 的非业务阻塞
- 本 PR 包含：`verify` 与 Windows unit shards 在 `pnpm install` 后运行 `pnpm --filter @cindy/model-access-protocol build`
- 明确不包含：不修改 model-providers 业务类型、不修改 contactsTools flaky test、不修改 PR #1216 的 Markdown 修复
- 用户可见变化：无直接 UI 变化；CI 恢复正确的协议消费顺序
- 是否存在 breaking change：无

## UI 变化

- 不涉及：仅修改 GitHub Actions 工作流和 CI 回归测试。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/model-access-protocol build
结果：通过

pnpm --filter desktop typecheck
结果：通过；协议包构建后原有 TS2307/TS7006 消失

NODE_OPTIONS='--experimental-webstorage --localstorage-file=/tmp/cindy-ci-model-access-localstorage.json' pnpm test:unit
结果：通过（Desktop 使用仓库已有的 forks 执行路径，其余 workspace 全部通过）

node --test scripts/__tests__/test-workspaces.test.mjs
结果：74/74 通过

git diff --check
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

未在 GitHub-hosted Windows runner 上手工执行；工作流本身保留 Linux verify 与两个 Windows shard，CI 会覆盖该平台。

## 风险

### 风险分类

- [x] 无已知风险
- [x] 跨平台差异：同一协议构建步骤加入 Linux verify 和 Windows unit shards，确保两种消费者环境一致

### 影响与回滚

- 影响范围：CI 在消费者检查前多执行一次无副作用的 TypeScript build，预计耗时增加约数秒。
- 回滚 / 降级方式：删除新增的两个 workflow step 和对应回归断言即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果
