### PR TITLE
fix(mobile): 修复语音词典首次加载为空

### DIFF
--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -73,7 +73,7 @@ import { fetchLocalMediaToOss } from './mediaFetch';
 import { transcribeRemoteVoiceInput } from './voiceTranscribe';
 import { readTelegramRemoteStatus, setTelegramRemoteOnline } from './telegramRemoteControl';
 import { adviseAndRecordVoiceInputDictionaryLearning } from '../voice-input/index.js';
-import { readDictionaryProjectionForMobile } from '../voice-input/dictionarySyncDriver.js';
+import { buildMobileDictionarySnapshot } from '../voice-input/dictionarySyncDriver.js';
 import {
   setBroadcastTapListener,
 } from './broadcast-tap';
@@ -2808,7 +2808,7 @@ export async function runInvoke(
   // 不参与合并,避免移动端维护一份会分叉的词典。
   if (payload.channel === DL_VOICE_DICTIONARY_GET_CHANNEL) {
     try {
-      return { ok: true, result: { ok: true, ...readDictionaryProjectionForMobile() } };
+      return { ok: true, result: buildMobileDictionarySnapshot() };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.warn(`voice:dictionary:get failed from ${shortId(src)}: ${message}`);

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -280,14 +280,19 @@ async function runControllerDisplayNamesFromDirectory(
     // 目录补齐展示名的同时,给这些手机补一次只读词典投影。
     for (const device of result.devices ?? []) {
       const deviceId = typeof device.deviceId === 'string' ? device.deviceId : '';
+      const platform = typeof device.platform === 'string' ? device.platform : '';
       if (
         !deviceId
         || device.online !== true
-        || !isMobilePlatform(typeof device.platform === 'string' ? device.platform : null)
+        || !isMobilePlatform(platform)
         || isDeviceRevoked(deviceId)
       ) {
         continue;
       }
+      // 目录发现也要写回后续广播读的那份在线集合,否则只补发一次,
+      // 词典变更 / 开关切换时 listOnlineMobileDevices 仍是空的。
+      presenceOnlineByDevice.set(deviceId, true);
+      setControllerPlatform(deviceId, platform);
       handleMobilePeerOnline(deviceId);
     }
   } catch (err) {

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -158,7 +158,12 @@ export function deviceLinkApiBase(): string {
 }
 
 type DeviceDirectoryResponse = {
-  devices?: Array<{ deviceId?: unknown; name?: unknown }>;
+  devices?: Array<{
+    deviceId?: unknown;
+    name?: unknown;
+    online?: unknown;
+    platform?: unknown;
+  }>;
 };
 let controllerDisplayNameRefreshGeneration = 0;
 const controllerDisplayNameFreshness = createControllerDisplayNameFreshnessTracker();
@@ -271,6 +276,20 @@ async function runControllerDisplayNamesFromDirectory(
         void forgetLastKnownDeviceName(deviceId);
       },
     });
+    // presence 是增量:桌面刚连上 relay 时,已在线手机不会再发一帧上线。
+    // 目录补齐展示名的同时,给这些手机补一次只读词典投影。
+    for (const device of result.devices ?? []) {
+      const deviceId = typeof device.deviceId === 'string' ? device.deviceId : '';
+      if (
+        !deviceId
+        || device.online !== true
+        || !isMobilePlatform(typeof device.platform === 'string' ? device.platform : null)
+        || isDeviceRevoked(deviceId)
+      ) {
+        continue;
+      }
+      handleMobilePeerOnline(deviceId);
+    }
   } catch (err) {
     // 目录补齐是展示层 best-effort；失败时保留控制帧自报名 / 短 ID 回退，不影响建链。
     log.warn(`device directory display-name refresh failed (non-fatal): ${String(err)}`);

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -36,6 +36,7 @@ import {
   DeviceLinkError,
   INVOKE_TIMEOUT_OVERRIDES_MS,
 } from '@cindy/device-link';
+import { DEVICE_LINK_VOICE_DICTIONARY_SNAPSHOT_CHANNEL } from '@cindy/maker-shared/device-link-contract';
 import * as authManager from '../authManager';
 import { getActiveDataOwnerPushStamp } from '../appSessionState.js';
 import { createLogger } from '../logger';
@@ -84,6 +85,7 @@ import {
 import {
   clearControllerPlatforms,
   getControllerPlatform,
+  isMobilePlatform,
   setControllerPlatform,
 } from './controllerPlatform';
 import {
@@ -103,6 +105,7 @@ import {
   broadcastDictionaryNow,
   handleDesktopPeerOnline,
   handleIncomingDictionaryState,
+  handleMobilePeerOnline,
   initVoiceDictionarySync,
   notifyLocalDictionaryChanged,
   shouldExchangeDictionaryWith,
@@ -766,6 +769,16 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     ) {
       handleDesktopPeerOnline(snap.deviceId);
     }
+    // 手机只接收只读投影:push 不属于 relay 的 CONTROL_KINDS,因此不要求桌面
+    // 打开「允许被控」。来源平台只用于体验分流,撤销状态仍是实际准入边界。
+    if (
+      wasOnline !== true &&
+      snap.online &&
+      isMobilePlatform(snap.platform) &&
+      !isDeviceRevoked(snap.deviceId)
+    ) {
+      handleMobilePeerOnline(snap.deviceId);
+    }
   });
 
   let updateRelaunchControllersBusy = false;
@@ -883,6 +896,17 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
             platform: getControllerPlatform(deviceId),
             revoked: isDeviceRevoked(deviceId),
           }),
+        )
+        .map(([deviceId]) => deviceId),
+    sendMobileSnapshot: (deviceId, payload) => {
+      client?.sendPush(deviceId, DEVICE_LINK_VOICE_DICTIONARY_SNAPSHOT_CHANNEL, payload);
+    },
+    listOnlineMobileDevices: () =>
+      [...presenceOnlineByDevice.entries()]
+        .filter(([deviceId, online]) =>
+          online &&
+          isMobilePlatform(getControllerPlatform(deviceId)) &&
+          !isDeviceRevoked(deviceId),
         )
         .map(([deviceId]) => deviceId),
   });

--- a/apps/desktop/src/main/voice-input/VoiceInputDataStore.ts
+++ b/apps/desktop/src/main/voice-input/VoiceInputDataStore.ts
@@ -102,6 +102,9 @@ export class VoiceInputDataStore {
     const syncJustEnabled = isRecord(patch)
       && patch.dictionarySyncEnabled === true
       && current.settings.dictionarySyncEnabled === false;
+    const syncJustDisabled = isRecord(patch)
+      && patch.dictionarySyncEnabled === false
+      && current.settings.dictionarySyncEnabled === true;
     // 词典三件套的真相在同步状态里,不接受整份覆盖 —— 那会绕过 CRDT,让本地写入
     // 在下一次物化时被静默丢掉。词典变更一律走下面的语义化入口。
     const nextSettings = normalizeVoiceInputSettings({
@@ -112,9 +115,9 @@ export class VoiceInputDataStore {
       ...current,
       settings: nextSettings,
     });
-    // 刚打开同步开关:对端可能早已在线,既没有 presence 事件也没有词典变更,
-    // 不主动推一次就要等到兜底心跳才收敛。
-    if (syncJustEnabled) notifyDictionaryChanged({ immediate: true });
+    // 开关刚切到开或关:对端可能早已在线,既没有 presence 事件也没有词典变更。
+    // 打开时立刻推当前投影;关闭时立刻推空表,清掉已经在线的手机缓存。
+    if (syncJustEnabled || syncJustDisabled) notifyDictionaryChanged({ immediate: true });
     return cloneSettings(nextSettings);
   }
 
@@ -615,7 +618,7 @@ export const voiceInputDataStore = new VoiceInputDataStore();
 const dictionaryChangedListeners = new Set<DictionaryChangedListener>();
 
 /**
- * `immediate` = 这次变更希望立刻广播,不要走去抖(用户刚打开同步开关)。
+ * `immediate` = 这次变更希望立刻广播,不要走去抖(用户刚打开或关闭同步开关)。
  */
 export type DictionaryChangedListener = (options?: { immediate?: boolean }) => void;
 

--- a/apps/desktop/src/main/voice-input/__tests__/VoiceInputDataStore.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/VoiceInputDataStore.test.ts
@@ -33,6 +33,7 @@ vi.mock('../../logger.js', () => ({
 }));
 
 import {
+  onVoiceInputDictionaryChanged,
   registerVoiceInputDataStoreIpc,
   voiceInputDataStore,
   VoiceInputDataStore,
@@ -51,6 +52,21 @@ describe('VoiceInputDataStore persistence', () => {
   afterEach(() => {
     fs.rmSync(dataDir, { recursive: true, force: true });
     vi.restoreAllMocks();
+  });
+
+  it('关闭同步开关也会立刻广播,让在线手机清掉旧词典', () => {
+    const store = new VoiceInputDataStore();
+    const listener = vi.fn();
+    const unsubscribe = onVoiceInputDictionaryChanged(listener);
+    try {
+      store.updateSettings({ dictionarySyncEnabled: false });
+      expect(listener).toHaveBeenCalledWith({ immediate: true });
+      listener.mockClear();
+      store.updateSettings({ dictionarySyncEnabled: true });
+      expect(listener).toHaveBeenCalledWith({ immediate: true });
+    } finally {
+      unsubscribe();
+    }
   });
 
   it('writes the candidate before committing state and broadcasting it', () => {

--- a/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
@@ -64,6 +64,7 @@ const {
   initVoiceDictionarySync,
   isDesktopPlatform,
   notifyLocalDictionaryChanged,
+  buildMobileDictionarySnapshot,
   readDictionaryProjectionForMobile,
   shouldExchangeDictionaryWith,
   stopVoiceDictionarySync,
@@ -327,5 +328,11 @@ describe('手机只读投影', () => {
     const projection = readDictionaryProjectionForMobile();
     expect(projection.entries).toEqual([]);
     expect(projection.stateVector && Object.keys(projection.stateVector)).toEqual(['node-a']);
+  });
+
+  it('主动 GET 与 push 共用带 emittedAt 的投影', () => {
+    const snapshot = buildMobileDictionarySnapshot();
+    expect(snapshot.ok).toBe(true);
+    if (snapshot.ok) expect(snapshot.emittedAt).toEqual(expect.any(Number));
   });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
@@ -335,4 +335,17 @@ describe('手机只读投影', () => {
     expect(snapshot.ok).toBe(true);
     if (snapshot.ok) expect(snapshot.emittedAt).toEqual(expect.any(Number));
   });
+
+  it('时钟回拨后同主机发出序号仍单调', () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValue(5_000);
+    const first = buildMobileDictionarySnapshot();
+    now.mockReturnValue(1_000);
+    const second = buildMobileDictionarySnapshot();
+    now.mockRestore();
+    expect(first.ok && second.ok).toBe(true);
+    if (first.ok && second.ok) {
+      expect(second.emittedAt).toBeGreaterThan(first.emittedAt ?? 0);
+    }
+  });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
@@ -164,18 +164,22 @@ describe('出站', () => {
 
   it('手机上线时主动推只读快照,不依赖远程控制开关', () => {
     handleMobilePeerOnline('phone-1');
-    expect(sendMobileSnapshot).toHaveBeenCalledWith('phone-1', {
+    expect(sendMobileSnapshot).toHaveBeenCalledWith('phone-1', expect.objectContaining({
       ok: true,
       entries: [
         { text: 'Cindy', frequency: 2, aliases: [{ text: 'sindy', count: 1 }] },
       ],
-    });
+    }));
+    expect(sendMobileSnapshot.mock.calls[0][1].emittedAt).toEqual(expect.any(Number));
   });
 
   it('同步关闭时仍推空投影给手机,让旧缓存及时清空', () => {
     syncEnabled.value = false;
     handleMobilePeerOnline('phone-1');
-    expect(sendMobileSnapshot).toHaveBeenCalledWith('phone-1', { ok: true, entries: [] });
+    expect(sendMobileSnapshot).toHaveBeenCalledWith(
+      'phone-1',
+      expect.objectContaining({ ok: true, entries: [] }),
+    );
   });
 
   it('立即广播会同时刷新所有在线手机', () => {
@@ -292,7 +296,7 @@ describe('手机只读投影', () => {
     expect(projection.entries).toEqual([
       { text: 'Cindy', frequency: 2, aliases: [{ text: 'sindy', count: 1 }] },
     ]);
-    // 除了词条和版本向量,不该漏出节点 id、化身、墓碑等同步内部结构。
+    // 除了词条、发出时间和版本向量,不该漏出节点 id、化身、墓碑等同步内部结构。
     expect(Object.keys(projection).sort()).toEqual(['entries']);
   });
 
@@ -311,5 +315,17 @@ describe('手机只读投影', () => {
     // 向量对合并单调:后一份必须包含前一份,否则手机会一直停在旧快照上。
     expect(versionVectorDominates(after, before!)).toBe(true);
     expect(versionVectorDominates(before!, after)).toBe(false);
+  });
+
+  it('同步关闭的空投影仍带上当前版本向量,避免晚到的空表清掉更新快照', () => {
+    const first = addManualEntry(createEmptySyncState(), createHlcClock('node-a', 1_000), {
+      text: 'Cindy',
+      nowMs: 1_000,
+    });
+    stateOverride.value = first.state;
+    syncEnabled.value = false;
+    const projection = readDictionaryProjectionForMobile();
+    expect(projection.entries).toEqual([]);
+    expect(projection.stateVector && Object.keys(projection.stateVector)).toEqual(['node-a']);
   });
 });

--- a/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
@@ -3,8 +3,9 @@
  *
  * 这一层不碰合并语义(那在 voice-input-core 里),只回答三个问题:什么时候发、
  * 发给谁、收到什么才处理。盯住的边界:
- *  - 用户关掉开关后必须彻底静默(既不发也不合并);
- *  - 只发给桌面 —— 手机在后台收不到 push,给它发是纯浪费;
+ *  - 关掉同步开关后,桌面 CRDT 通道彻底静默(既不发也不合并);
+ *  - 手机只读投影不受「允许被控」限制;开关关闭时只在手机上线或开关切换时
+ *    推一次空投影清缓存,本地学习/编辑不再持续推空表;
  *  - 认不出的帧结构直接忽略,坏帧不能污染本机词典。
  */
 
@@ -32,21 +33,23 @@ vi.mock('../VoiceInputDataStore.js', () => ({
 const syncState = { version: 1 as const, records: {}, suppressed: {} };
 /** 让个别用例把状态换成超大对象,验证帧上限把关。 */
 const stateOverride: { value: unknown } = { value: null };
+const defaultMaterializedEntry = {
+  id: 'dict-sync-cindy',
+  text: 'Cindy',
+  source: 'manual' as const,
+  frequency: 2,
+  aliases: [{ text: 'sindy', count: 1, lastSeenAt: 5 }],
+  createdAt: 1,
+  updatedAt: 2,
+};
+const materialized = {
+  entries: [defaultMaterializedEntry],
+};
 vi.mock('../VoiceDictionarySyncStore.js', () => ({
   voiceDictionarySyncStore: {
     getState: () => stateOverride.value ?? syncState,
     materialize: () => ({
-      entries: [
-        {
-          id: 'dict-sync-cindy',
-          text: 'Cindy',
-          source: 'manual' as const,
-          frequency: 2,
-          aliases: [{ text: 'sindy', count: 1, lastSeenAt: 5 }],
-          createdAt: 1,
-          updatedAt: 2,
-        },
-      ],
+      entries: materialized.entries,
       candidates: [],
       suppressedTexts: [],
     }),
@@ -54,28 +57,38 @@ vi.mock('../VoiceDictionarySyncStore.js', () => ({
 }));
 
 const {
+  broadcastDictionaryNow,
   handleDesktopPeerOnline,
   handleIncomingDictionaryState,
+  handleMobilePeerOnline,
   initVoiceDictionarySync,
   isDesktopPlatform,
+  notifyLocalDictionaryChanged,
   readDictionaryProjectionForMobile,
   shouldExchangeDictionaryWith,
   stopVoiceDictionarySync,
 } = await import('../dictionarySyncDriver.js');
 
 const sendState = vi.fn();
+const sendMobileSnapshot = vi.fn();
 const onlineDesktops: string[] = [];
+const onlineMobiles: string[] = [];
 
 beforeEach(() => {
   syncEnabled.value = true;
   sendState.mockClear();
+  sendMobileSnapshot.mockClear();
   mergeRemoteDictionaryState.mockClear();
   mergeRemoteDictionaryState.mockReturnValue(true);
   onlineDesktops.length = 0;
+  onlineMobiles.length = 0;
   stateOverride.value = null;
+  materialized.entries = [defaultMaterializedEntry];
   initVoiceDictionarySync({
     sendState: (deviceId, payload) => sendState(deviceId, payload),
     listOnlineDesktopDevices: () => [...onlineDesktops],
+    sendMobileSnapshot: (deviceId, payload) => sendMobileSnapshot(deviceId, payload),
+    listOnlineMobileDevices: () => [...onlineMobiles],
   });
 });
 
@@ -147,6 +160,54 @@ describe('出站', () => {
     // 合并引入新信息 → 回发;这里借回发路径触发一次广播语义的失败隔离。
     handleIncomingDictionaryState('peer-1', { frameVersion: 1, state: syncState });
     expect(() => handleDesktopPeerOnline('peer-2')).not.toThrow();
+  });
+
+  it('手机上线时主动推只读快照,不依赖远程控制开关', () => {
+    handleMobilePeerOnline('phone-1');
+    expect(sendMobileSnapshot).toHaveBeenCalledWith('phone-1', {
+      ok: true,
+      entries: [
+        { text: 'Cindy', frequency: 2, aliases: [{ text: 'sindy', count: 1 }] },
+      ],
+    });
+  });
+
+  it('同步关闭时仍推空投影给手机,让旧缓存及时清空', () => {
+    syncEnabled.value = false;
+    handleMobilePeerOnline('phone-1');
+    expect(sendMobileSnapshot).toHaveBeenCalledWith('phone-1', { ok: true, entries: [] });
+  });
+
+  it('立即广播会同时刷新所有在线手机', () => {
+    onlineMobiles.push('phone-1', 'phone-2');
+    broadcastDictionaryNow();
+    expect(sendMobileSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('同步关闭后本地变更不再向手机推空投影', () => {
+    syncEnabled.value = false;
+    onlineMobiles.push('phone-1');
+    notifyLocalDictionaryChanged();
+    expect(sendMobileSnapshot).not.toHaveBeenCalled();
+    expect(sendState).not.toHaveBeenCalled();
+  });
+
+  it('手机快照超过单帧上限时不发送', () => {
+    materialized.entries = Array.from({ length: 1_000 }, (_, index) => ({
+      id: `term-${index}`,
+      text: '词'.repeat(80),
+      source: 'manual' as const,
+      frequency: 1,
+      aliases: Array.from({ length: 8 }, () => ({
+        text: '别'.repeat(120),
+        count: 1,
+        lastSeenAt: 1,
+      })),
+      createdAt: 1,
+      updatedAt: 1,
+    }));
+    handleMobilePeerOnline('phone-1');
+    expect(sendMobileSnapshot).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
+++ b/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
@@ -200,16 +200,21 @@ export function readDictionaryProjectionForMobile(): {
   entries: Array<{ text: string; frequency: number; aliases: Array<{ text: string; count: number }> }>;
   stateVector?: Record<string, string>;
 } {
-  if (!isSyncEnabled()) return { entries: [] };
+  // 版本向量对合并单调(逐节点取 max),所以「逐节点 ≥」等价于「已经见过对方的
+  // 全部事件」—— 这才是手机可以拿一份替代另一份的条件,而不是谁的时间戳大。
+  // 同步关闭时仍带上当前向量:空表是清缓存指令,但必须证明自己不比手机已有的
+  // 快照更旧,否则晚到的空投影会把更新的词表抹掉。
+  const vector = buildStateVersionVector(voiceDictionarySyncStore.getState());
+  const stateVector = Object.keys(vector).length > 0 ? vector : undefined;
+  if (!isSyncEnabled()) {
+    return stateVector ? { entries: [], stateVector } : { entries: [] };
+  }
   const entries = voiceDictionarySyncStore.materialize().entries.map((entry) => ({
     text: entry.text,
     frequency: entry.frequency,
     aliases: entry.aliases.map((alias) => ({ text: alias.text, count: alias.count })),
   }));
-  // 版本向量对合并单调(逐节点取 max),所以「逐节点 ≥」等价于「已经见过对方的
-  // 全部事件」—— 这才是手机可以拿一份替代另一份的条件,而不是谁的时间戳大。
-  const vector = buildStateVersionVector(voiceDictionarySyncStore.getState());
-  return Object.keys(vector).length > 0 ? { entries, stateVector: vector } : { entries };
+  return stateVector ? { entries, stateVector } : { entries };
 }
 
 function broadcastMobileSnapshots(reason: string): void {
@@ -242,6 +247,7 @@ function sendMobileSnapshotTo(
 function buildMobileSnapshot(): MobileVoiceDictionarySnapshotResult | null {
   const payload: MobileVoiceDictionarySnapshotResult = {
     ok: true,
+    emittedAt: Date.now(),
     ...readDictionaryProjectionForMobile(),
   };
   const bytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');

--- a/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
+++ b/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
@@ -11,11 +11,12 @@
  * 交换的是整份 CRDT 状态,合并幂等且可交换,这次没送到,下次任一触发时机再送一次
  * 就收敛。为此触发点铺了三层:对端上线、本地变更(去抖)、以及长周期兜底。
  *
- * 手机不参与这条通道:移动端在后台不维持 WebSocket,收不到 push。它改用
- * `device-link:voice:dictionary:get` 主动向在线桌面拉一份只读快照。
+ * 手机不参与 CRDT 通道:移动端在后台不维持 WebSocket,不持有可写副本。手机上线和
+ * 桌面词典变化时,桌面改推一份只读全量快照;原有 invoke 拉取保留给旧版兼容兜底。
  */
 
 import { MAX_FRAME_BYTES } from '@cindy/device-link';
+import type { MobileVoiceDictionarySnapshotResult } from '@cindy/maker-shared/device-link-contract';
 import { buildStateVersionVector, type VoiceDictionarySyncState } from '@cindy/voice-input-core';
 
 import { createLogger } from '../logger.js';
@@ -63,6 +64,10 @@ export interface DictionarySyncTransport {
   sendState(deviceId: string, payload: DictionarySyncFramePayload): void;
   /** 当前在线的同账号**桌面**设备。 */
   listOnlineDesktopDevices(): string[];
+  /** 给手机发送只读全量快照(push 不经过远程控制门禁)。 */
+  sendMobileSnapshot(deviceId: string, payload: MobileVoiceDictionarySnapshotResult): void;
+  /** 当前在线、未撤销的同账号手机。 */
+  listOnlineMobileDevices(): string[];
 }
 
 let transport: DictionarySyncTransport | null = null;
@@ -116,6 +121,11 @@ export function handleDesktopPeerOnline(deviceId: string): void {
   sendStateTo(deviceId, 'peer-online', { requestReply: true });
 }
 
+/** 手机上线时立即推送一次只读全量快照，不要求桌面打开「允许被控」。 */
+export function handleMobilePeerOnline(deviceId: string): void {
+  sendMobileSnapshotTo(deviceId, 'mobile-online');
+}
+
 /**
  * 立即广播一次当前状态,不走去抖。
  *
@@ -127,17 +137,22 @@ export function broadcastDictionaryNow(): void {
     clearTimeout(debounceTimer);
     debounceTimer = null;
   }
+  // 手机是只读消费者:开关刚切换时也要立即收到当前投影(关闭时为空表)。
+  broadcastMobileSnapshots('sync-setting-changed');
   // 索取回发:本机可能在关闭同步期间落后了,而对端不会主动告诉我们。
   broadcastToAllPeers('sync-enabled', { requestReply: true });
 }
 
 /** 本地词典变更:去抖后广播。连续学习事件不会打出一连串帧。 */
 export function notifyLocalDictionaryChanged(): void {
+  // 开关关闭后桌面 CRDT 与手机投影都保持静默。空投影只在开关切换或手机上线时
+  // 推一次,用来清旧缓存;本地学习/编辑若继续推空表,只会制造无效流量和重绘。
   if (!isSyncEnabled()) return;
   if (debounceTimer) clearTimeout(debounceTimer);
   debounceTimer = setTimeout(() => {
     debounceTimer = null;
     broadcastToAllPeers('local-change');
+    broadcastMobileSnapshots('local-change');
   }, BROADCAST_DEBOUNCE_MS);
   debounceTimer.unref?.();
 }
@@ -195,6 +210,49 @@ export function readDictionaryProjectionForMobile(): {
   // 全部事件」—— 这才是手机可以拿一份替代另一份的条件,而不是谁的时间戳大。
   const vector = buildStateVersionVector(voiceDictionarySyncStore.getState());
   return Object.keys(vector).length > 0 ? { entries, stateVector: vector } : { entries };
+}
+
+function broadcastMobileSnapshots(reason: string): void {
+  if (!transport) return;
+  const peers = transport.listOnlineMobileDevices();
+  if (peers.length === 0) return;
+  const payload = buildMobileSnapshot();
+  if (!payload) return;
+  for (const deviceId of peers) sendMobileSnapshotTo(deviceId, reason, payload);
+}
+
+function sendMobileSnapshotTo(
+  deviceId: string,
+  reason: string,
+  payload?: MobileVoiceDictionarySnapshotResult | null,
+): void {
+  if (!transport) return;
+  const snapshot = payload === undefined ? buildMobileSnapshot() : payload;
+  if (!snapshot) return;
+  try {
+    transport.sendMobileSnapshot(deviceId, snapshot);
+  } catch (error) {
+    // push 是尽力而为的全量状态镜像；下次上线、变更或主动 invoke 会补齐。
+    log.warn(`mobile dictionary snapshot push failed (${reason}) to ${deviceId.slice(0, 8)}`, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+function buildMobileSnapshot(): MobileVoiceDictionarySnapshotResult | null {
+  const payload: MobileVoiceDictionarySnapshotResult = {
+    ok: true,
+    ...readDictionaryProjectionForMobile(),
+  };
+  const bytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');
+  if (bytes <= MAX_STATE_FRAME_BYTES) return payload;
+  // 与桌面 CRDT 同一条上限:超限帧会被 relay 拒绝。这里不另造分片协议,
+  // 手机保留上次缓存,词典缩小后下一次上线/变更再推。
+  log.error(
+    `mobile dictionary snapshot is too large to push (${bytes} bytes > ${MAX_STATE_FRAME_BYTES}); `
+    + 'phones will keep their last cache until the dictionary shrinks',
+  );
+  return null;
 }
 
 function broadcastToAllPeers(reason: string, options?: { requestReply?: boolean }): void {
@@ -260,5 +318,6 @@ export const __testing = {
     clearTimeout(debounceTimer);
     debounceTimer = null;
     broadcastToAllPeers('test-flush');
+    broadcastMobileSnapshots('test-flush');
   },
 };

--- a/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
+++ b/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
@@ -73,6 +73,8 @@ export interface DictionarySyncTransport {
 let transport: DictionarySyncTransport | null = null;
 let debounceTimer: NodeJS.Timeout | null = null;
 let intervalTimer: NodeJS.Timeout | null = null;
+/** 同进程内快照发出序号:取墙上时间与上一发+1 的较大值,时钟回拨也不会倒序。 */
+let lastEmittedAt = 0;
 
 export function isDesktopPlatform(platform: string | undefined | null): boolean {
   return typeof platform === 'string' && DESKTOP_PLATFORMS.has(platform);
@@ -112,6 +114,7 @@ export function stopVoiceDictionarySync(): void {
   if (intervalTimer) clearInterval(intervalTimer);
   debounceTimer = null;
   intervalTimer = null;
+  lastEmittedAt = 0;
 }
 
 /** 对端桌面上线:立刻单发一次,让它尽快拿到本机状态(它也会回发自己的)。 */
@@ -246,9 +249,10 @@ function sendMobileSnapshotTo(
 
 /** push 与主动 GET 共用：同一份投影必须带上发出时间，否则同代向量的兜底拉取盖不掉已有 push。 */
 export function buildMobileDictionarySnapshot(): MobileVoiceDictionarySnapshotResult {
+  lastEmittedAt = Math.max(Date.now(), lastEmittedAt + 1);
   return {
     ok: true,
-    emittedAt: Date.now(),
+    emittedAt: lastEmittedAt,
     ...readDictionaryProjectionForMobile(),
   };
 }

--- a/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
+++ b/apps/desktop/src/main/voice-input/dictionarySyncDriver.ts
@@ -244,12 +244,17 @@ function sendMobileSnapshotTo(
   }
 }
 
-function buildMobileSnapshot(): MobileVoiceDictionarySnapshotResult | null {
-  const payload: MobileVoiceDictionarySnapshotResult = {
+/** push 与主动 GET 共用：同一份投影必须带上发出时间，否则同代向量的兜底拉取盖不掉已有 push。 */
+export function buildMobileDictionarySnapshot(): MobileVoiceDictionarySnapshotResult {
+  return {
     ok: true,
     emittedAt: Date.now(),
     ...readDictionaryProjectionForMobile(),
   };
+}
+
+function buildMobileSnapshot(): MobileVoiceDictionarySnapshotResult | null {
+  const payload = buildMobileDictionarySnapshot();
   const bytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');
   if (bytes <= MAX_STATE_FRAME_BYTES) return payload;
   // 与桌面 CRDT 同一条上限:超限帧会被 relay 拒绝。这里不另造分片协议,

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -70,6 +70,7 @@ import {
   hydrateMobileVoiceDictionary,
   readCachedMobileVoiceDictionarySnapshot,
   refreshMobileVoiceDictionary,
+  subscribeMobileVoiceDictionaryCache,
 } from '@/session/mobileVoiceDictionaryCache';
 import {
   buildMobileVoiceDictionaryEntryViews,
@@ -736,14 +737,34 @@ export default function SettingsScreen() {
     });
   }, [desktopDevices, deviceLink]);
 
+  // 页面打开后再由 effect 读取缓存和刷新。设备清单本身是异步 REST 请求，不能只
+  // 捕获点击瞬间的 desktopDevices=[]，否则清单稍后到达时历史缓存永远不会 hydrate。
   const openVoiceDictionary = useCallback(() => {
     setDictionaryScreenOpen(true);
-    // 进页面先把盘上缓存读进内存(离线也有内容可看),再拉一次最新的。
+  }, []);
+
+  useEffect(() => {
+    if (!dictionaryScreenOpen || desktopDevices.length === 0) return;
+    let cancelled = false;
+    // 进页面先把盘上缓存读进内存(离线也有内容可看),再拉一次最新的。这个 effect
+    // 同时依赖 desktopDevices，因此设备清单在页面打开后才到达时也会走同一条路径。
     void Promise.all(desktopDevices.map((host) => hydrateMobileVoiceDictionary(host.deviceId)))
-      .then(() => setDictionaryRevision((value) => value + 1))
+      .then(() => {
+        if (!cancelled) setDictionaryRevision((value) => value + 1);
+      })
       .catch(() => undefined);
     refreshVoiceDictionary();
-  }, [desktopDevices, refreshVoiceDictionary]);
+    return () => {
+      cancelled = true;
+    };
+  }, [desktopDevices, dictionaryScreenOpen, refreshVoiceDictionary]);
+
+  useEffect(() => {
+    if (!dictionaryScreenOpen) return;
+    return subscribeMobileVoiceDictionaryCache(() => {
+      setDictionaryRevision((value) => value + 1);
+    });
+  }, [dictionaryScreenOpen]);
 
   // dictionaryRevision 只作为依赖存在:缓存是模块级的,刷新完成后靠它触发重算。
   const dictionaryEntries = useMemo(

--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -122,8 +122,7 @@ export default function SettingsScreen() {
   const { locale, setLocale } = useLocale();
   const windowDimensions = useWindowDimensions();
   const safeAreaInsets = useSafeAreaInsets();
-  const deviceLink = useDeviceLink();
-  const { lastPresenceSnapshot, status } = deviceLink;
+  const { lastPresenceSnapshot, status, invoke } = useDeviceLink();
   const [copiedRowId, setCopiedRowId] = useState<string | null>(null);
   const [loggingOut, setLoggingOut] = useState(false);
   const [accountDeletionAvailable, setAccountDeletionAvailable] =
@@ -723,7 +722,7 @@ export default function SettingsScreen() {
     void Promise.all(
       online.map((host) => refreshMobileVoiceDictionary(
         host.deviceId,
-        () => deviceLink.invoke<MobileVoiceDictionarySnapshotResult>(
+        () => invoke<MobileVoiceDictionarySnapshotResult>(
           host.deviceId,
           DEVICE_LINK_VOICE_DICTIONARY_GET_CHANNEL,
           [],
@@ -735,7 +734,7 @@ export default function SettingsScreen() {
       // 缓存写在模块里,组件靠这个计数触发重渲染。
       setDictionaryRevision((value) => value + 1);
     });
-  }, [desktopDevices, deviceLink]);
+  }, [desktopDevices, invoke]);
 
   // 页面打开后再由 effect 读取缓存和刷新。设备清单本身是异步 REST 请求，不能只
   // 捕获点击瞬间的 desktopDevices=[]，否则清单稍后到达时历史缓存永远不会 hydrate。

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -179,6 +179,24 @@ describe('mobile settings overview', () => {
     expect(source).not.toContain('clearManualName');
   });
 
+  it('hydrates the voice dictionary after the async desktop list arrives', () => {
+    const source = readTextLf(resolve(process.cwd(), 'app/settings.tsx'), 'utf8');
+    const dictionaryEffectIndex = source.indexOf(
+      'if (!dictionaryScreenOpen || desktopDevices.length === 0) return;',
+    );
+    const dictionaryOpenIndex = source.indexOf('const openVoiceDictionary = useCallback(() => {');
+    const hydrateIndex = source.indexOf(
+      'Promise.all(desktopDevices.map((host) => hydrateMobileVoiceDictionary(host.deviceId)))',
+      dictionaryEffectIndex,
+    );
+
+    expect(dictionaryEffectIndex).toBeGreaterThan(-1);
+    expect(dictionaryOpenIndex).toBeGreaterThan(-1);
+    expect(hydrateIndex).toBeGreaterThan(dictionaryEffectIndex);
+    expect(source).toContain('[desktopDevices, dictionaryScreenOpen, refreshVoiceDictionary]');
+    expect(source).toContain('subscribeMobileVoiceDictionaryCache(() => {');
+  });
+
   it('always shows privacy policy + user agreement (regional links via legalLinks) above the cn-only App filing number', () => {
     const source = readTextLf(resolve(process.cwd(), 'app/settings.tsx'), 'utf8');
     const filingCardIndex = source.indexOf("<SettingsGroup title={t('settings.legal.sectionTitle')}>");

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -194,6 +194,8 @@ describe('mobile settings overview', () => {
     expect(dictionaryOpenIndex).toBeGreaterThan(-1);
     expect(hydrateIndex).toBeGreaterThan(dictionaryEffectIndex);
     expect(source).toContain('[desktopDevices, dictionaryScreenOpen, refreshVoiceDictionary]');
+    expect(source).toContain('[desktopDevices, invoke]');
+    expect(source).not.toContain('[desktopDevices, deviceLink]');
     expect(source).toContain('subscribeMobileVoiceDictionaryCache(() => {');
   });
 

--- a/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
@@ -357,6 +357,31 @@ describe('账号切走之后落地的旧请求', () => {
     await hydrateMobileVoiceDictionary(HOST);
     expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('账号B的词');
   });
+
+  it('旧账号落盘补偿不删新账号已接收的同 host 快照', async () => {
+    persistGate.delaySnapshotWrites = true;
+    setMobileVoiceDictionaryAccountScope('user-a');
+    const older = applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '账号A的词' }],
+      emittedAt: 1_000,
+    });
+    await Promise.resolve();
+    setMobileVoiceDictionaryAccountScope('user-b');
+    persistGate.delaySnapshotWrites = false;
+    const newer = applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '账号B的词' }],
+      emittedAt: 2_000,
+    });
+    releaseSnapshotWrites();
+    await Promise.all([older, newer]);
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('账号B的词');
+    __resetMobileVoiceDictionaryCacheForTests();
+    setMobileVoiceDictionaryAccountScope('user-b');
+    await hydrateMobileVoiceDictionary(HOST);
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('账号B的词');
+  });
 });
 
 describe('在途请求的去重范围', () => {

--- a/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
@@ -10,10 +10,29 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MobileVoiceDictionarySnapshotResult } from '@cindy/maker-shared/device-link-contract';
 
 const storage = new Map<string, string>();
+const persistGate = {
+  delaySnapshotWrites: false,
+  waiters: [] as Array<() => void>,
+};
+
+function releaseSnapshotWrites(): void {
+  const waiters = persistGate.waiters.splice(0);
+  for (const release of waiters) release();
+}
+
 vi.mock('@react-native-async-storage/async-storage', () => ({
   default: {
     getItem: async (key: string) => storage.get(key) ?? null,
     setItem: async (key: string, value: string) => {
+      if (
+        persistGate.delaySnapshotWrites
+        && key.includes('mobileVoiceDictionary.v2.')
+        && !key.endsWith('.hosts')
+      ) {
+        await new Promise<void>((resolve) => {
+          persistGate.waiters.push(resolve);
+        });
+      }
       storage.set(key, value);
     },
     removeItem: async (key: string) => {
@@ -42,6 +61,8 @@ const HOST = 'desktop-1';
 
 beforeEach(() => {
   storage.clear();
+  persistGate.delaySnapshotWrites = false;
+  releaseSnapshotWrites();
   __resetMobileVoiceDictionaryCacheForTests();
   setMobileVoiceDictionaryAccountScope('');
 });
@@ -441,6 +462,31 @@ describe('版本向量的入站校验', () => {
       emittedAt: 2_000,
     });
     expect(readCachedMobileVoiceDictionary(HOST)).toEqual([]);
+  });
+
+  it('并发落盘时较旧写入不能覆盖磁盘上的新快照', async () => {
+    persistGate.delaySnapshotWrites = true;
+    const older = applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '旧词' }],
+      stateVector: { 'node-a': STAMP_A },
+      emittedAt: 1_000,
+    });
+    await Promise.resolve();
+    const newer = applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '新词' }],
+      stateVector: { 'node-a': STAMP_A },
+      emittedAt: 2_000,
+    });
+    await Promise.resolve();
+    persistGate.delaySnapshotWrites = false;
+    releaseSnapshotWrites();
+    await Promise.all([older, newer]);
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('新词');
+    __resetMobileVoiceDictionaryCacheForTests();
+    await hydrateMobileVoiceDictionary(HOST);
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('新词');
   });
 
   it('更早发出的词表不能盖掉已清空的同一代投影', async () => {

--- a/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
@@ -28,12 +28,14 @@ vi.mock('@/session/mobileVoiceHistoryStore', () => ({
 
 const {
   __resetMobileVoiceDictionaryCacheForTests,
+  applyMobileVoiceDictionarySnapshot,
   setMobileVoiceDictionaryAccountScope,
   clearAllMobileVoiceDictionaryCaches,
   hydrateMobileVoiceDictionary,
   readCachedMobileVoiceDictionary,
   readCachedMobileVoiceDictionarySnapshot,
   refreshMobileVoiceDictionary,
+  subscribeMobileVoiceDictionaryCache,
 } = await import('@/session/mobileVoiceDictionaryCache');
 
 const HOST = 'desktop-1';
@@ -45,6 +47,20 @@ beforeEach(() => {
 });
 
 describe('mobileVoiceDictionaryCache', () => {
+  it('接收桌面主动推送的快照后立即可读并落盘', async () => {
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '推送词', frequency: 4 }],
+    });
+
+    expect(readCachedMobileVoiceDictionary(HOST)).toEqual([
+      { text: '推送词', frequency: 4, aliases: [] },
+    ]);
+    __resetMobileVoiceDictionaryCacheForTests();
+    await hydrateMobileVoiceDictionary(HOST);
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('推送词');
+  });
+
   it('拉取成功后缓存并落盘,重启后能恢复', async () => {
     await refreshMobileVoiceDictionary(HOST, async () => ({
       ok: true,
@@ -198,6 +214,35 @@ describe('mobileVoiceDictionaryCache', () => {
 });
 
 describe('账号分区', () => {
+  it('不把 v1 未分区缓存导入当前账号,只删除遗留键', async () => {
+    setMobileVoiceDictionaryAccountScope('user-a');
+    storage.set(
+      'xdt.mobileVoiceDictionary.v1.desktop-1',
+      JSON.stringify({
+        entries: [{ text: '旧版离线词', frequency: 2 }],
+        fetchedAt: 123,
+      }),
+    );
+
+    await hydrateMobileVoiceDictionary(HOST);
+
+    expect(readCachedMobileVoiceDictionary(HOST)).toEqual([]);
+    expect(storage.has('xdt.mobileVoiceDictionary.v2.user-a.desktop-1')).toBe(false);
+    expect(storage.has('xdt.mobileVoiceDictionary.v1.desktop-1')).toBe(false);
+  });
+
+  it('匿名分区也不接管 v1 未分区缓存,并清掉遗留键', async () => {
+    storage.set(
+      'xdt.mobileVoiceDictionary.v1.desktop-1',
+      JSON.stringify({ entries: [{ text: '不能泄漏' }], fetchedAt: 123 }),
+    );
+
+    await hydrateMobileVoiceDictionary(HOST);
+
+    expect(readCachedMobileVoiceDictionary(HOST)).toEqual([]);
+    expect(storage.has('xdt.mobileVoiceDictionary.v1.desktop-1')).toBe(false);
+  });
+
   it('切换账号后读不到上一个账号的快照 —— 即使清理没删干净', async () => {
     setMobileVoiceDictionaryAccountScope('user-a');
     await refreshMobileVoiceDictionary(HOST, async () => ({
@@ -352,5 +397,53 @@ describe('版本向量的入站校验', () => {
     __resetMobileVoiceDictionaryCacheForTests();
     await hydrateMobileVoiceDictionary(HOST);
     expect(readCachedMobileVoiceDictionarySnapshot(HOST).stateVector).toEqual({ 'node-a': STAMP_A });
+  });
+
+  it('后到的旧快照不能覆盖已有的更新状态', async () => {
+    const newer = '0000000rt0.0000.node-a';
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '新词' }],
+      stateVector: { 'node-a': newer },
+    });
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '旧词' }],
+      stateVector: { 'node-a': STAMP_A },
+    });
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('新词');
+  });
+
+  it('无版本向量的空投影可以清空已有缓存', async () => {
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '旧词' }],
+      stateVector: { 'node-a': STAMP_A },
+    });
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [],
+    });
+    expect(readCachedMobileVoiceDictionary(HOST)).toEqual([]);
+  });
+});
+
+describe('缓存订阅隔离', () => {
+  it('订阅者抛错不打断落盘', async () => {
+    const unsubscribe = subscribeMobileVoiceDictionaryCache(() => {
+      throw new Error('subscriber failed');
+    });
+    try {
+      await expect(applyMobileVoiceDictionarySnapshot(HOST, {
+        ok: true,
+        entries: [{ text: '推送词', frequency: 1 }],
+      })).resolves.toBeUndefined();
+      expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('推送词');
+      __resetMobileVoiceDictionaryCacheForTests();
+      await hydrateMobileVoiceDictionary(HOST);
+      expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('推送词');
+    } finally {
+      unsubscribe();
+    }
   });
 });

--- a/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
@@ -414,15 +414,47 @@ describe('版本向量的入站校验', () => {
     expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('新词');
   });
 
-  it('无版本向量的空投影可以清空已有缓存', async () => {
+  it('后到的无向量空投影不能清掉已有的更新快照', async () => {
     await applyMobileVoiceDictionarySnapshot(HOST, {
       ok: true,
-      entries: [{ text: '旧词' }],
+      entries: [{ text: '新词' }],
       stateVector: { 'node-a': STAMP_A },
     });
     await applyMobileVoiceDictionarySnapshot(HOST, {
       ok: true,
       entries: [],
+    });
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('新词');
+  });
+
+  it('带同一代版本向量且更晚发出的空投影可以清空缓存', async () => {
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '旧词' }],
+      stateVector: { 'node-a': STAMP_A },
+      emittedAt: 1_000,
+    });
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [],
+      stateVector: { 'node-a': STAMP_A },
+      emittedAt: 2_000,
+    });
+    expect(readCachedMobileVoiceDictionary(HOST)).toEqual([]);
+  });
+
+  it('更早发出的词表不能盖掉已清空的同一代投影', async () => {
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [],
+      stateVector: { 'node-a': STAMP_A },
+      emittedAt: 2_000,
+    });
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '旧词' }],
+      stateVector: { 'node-a': STAMP_A },
+      emittedAt: 1_000,
     });
     expect(readCachedMobileVoiceDictionary(HOST)).toEqual([]);
   });

--- a/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceDictionaryCache.test.ts
@@ -435,6 +435,21 @@ describe('版本向量的入站校验', () => {
     expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('新词');
   });
 
+  it('不带 emittedAt 的同代拉取不能盖掉已有 push', async () => {
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '推送词' }],
+      stateVector: { 'node-a': STAMP_A },
+      emittedAt: 1_000,
+    });
+    await applyMobileVoiceDictionarySnapshot(HOST, {
+      ok: true,
+      entries: [{ text: '拉取词' }],
+      stateVector: { 'node-a': STAMP_A },
+    });
+    expect(readCachedMobileVoiceDictionary(HOST)[0].text).toBe('推送词');
+  });
+
   it('后到的无向量空投影不能清掉已有的更新快照', async () => {
     await applyMobileVoiceDictionarySnapshot(HOST, {
       ok: true,

--- a/apps/mobile/src/__tests__/mobileVoiceDictionaryView.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceDictionaryView.test.ts
@@ -192,6 +192,24 @@ describe('新鲜度判定', () => {
     expect(views.map((view) => view.text)).toEqual(['bar']);
   });
 
+  it('跨桌面并列时不比各自主机的 emittedAt', () => {
+    const views = buildMobileVoiceDictionaryEntryViews([
+      {
+        entries: [{ text: '旧且时钟快' }],
+        fetchedAt: 1_000,
+        stateVector: { a: '0000000100.0000.a' },
+        emittedAt: 9_999_999,
+      },
+      {
+        entries: [{ text: '新到达' }],
+        fetchedAt: 9_000,
+        stateVector: { b: '0000000101.0000.b' },
+        emittedAt: 1,
+      },
+    ]);
+    expect(views.map((view) => view.text)).toEqual(['新到达']);
+  });
+
   it('最大 HLC 更大但并不包含对方时,不能因此被当成完整答案', () => {
     // 这正是只比最大时间戳会犯的错:B 的 HLC 更大,但它没有 A 的词。
     const views = buildMobileVoiceDictionaryEntryViews([

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -63,7 +63,11 @@ import {
 } from '@/session/scheduleIndex';
 import { isTransientRemoteError } from '@/device-link/remoteRetry';
 import { createRnWebSocket } from '@/device-link/rnWebSocket';
-import type { MobileGoalStatusPayload } from '@cindy/maker-shared/device-link-contract';
+import {
+  DEVICE_LINK_VOICE_DICTIONARY_SNAPSHOT_CHANNEL,
+  type MobileGoalStatusPayload,
+  type MobileVoiceDictionarySnapshotResult,
+} from '@cindy/maker-shared/device-link-contract';
 import {
   DeviceLinkTopicRegistry,
   markHeldRemoteTopicsSubscribed,
@@ -72,6 +76,7 @@ import {
   topicsMissingRemoteAck,
 } from '@/device-link/topicRegistry';
 import { remoteSessionStore } from '@/session/remoteSessionStore';
+import { applyMobileVoiceDictionarySnapshot } from '@/session/mobileVoiceDictionaryCache';
 import { revokedDevicesStore } from '@/device-link/revokedDevicesStore';
 import {
   acquireDeviceSendSlot,
@@ -1161,6 +1166,15 @@ export function routeFrame(env: Envelope, handlers: {
   if (push.channel === FILE_BROWSER_EVENT_CHANNEL) {
     // 文件树变更是 workdir 域事件,与会话 store 无关,单独分发给文件浏览页。
     dispatchFileBrowserWatchEvent(push.payload);
+    return;
+  }
+  if (push.channel === DEVICE_LINK_VOICE_DICTIONARY_SNAPSHOT_CHANNEL) {
+    // 只读全量快照由桌面主动推送，不经过 remoteControlEnabled 控制门禁。
+    // env.src 是 relay 写入的来源设备，缓存按它分片，不能信任 payload 自报 host。
+    void applyMobileVoiceDictionarySnapshot(
+      env.src,
+      push.payload as MobileVoiceDictionarySnapshotResult,
+    );
     return;
   }
   remoteSessionStore.applyRemotePush(env.src, push.channel, push.payload);

--- a/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
@@ -17,7 +17,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { hlcNodeId, isCanonicalHlc } from '@cindy/voice-input-core';
 import { listMobileVoiceHistoryHosts } from '@/session/mobileVoiceHistoryStore';
-import { isFresherMobileVoiceDictionarySnapshot } from '@/session/mobileVoiceDictionaryView';
+import { isFresherSameHostMobileVoiceDictionarySnapshot } from '@/session/mobileVoiceDictionaryView';
 import type {
   MobileVoiceCredentialSyncDictionaryEntry,
   MobileVoiceDictionarySnapshotResult,
@@ -272,11 +272,9 @@ function shouldAcceptIncomingSnapshot(
   current: CachedDictionary,
   next: CachedDictionary,
 ): boolean {
-  // 同一 host 只接受更新鲜的快照。新鲜度唯一判据是版本向量包含关系,
-  // 并列或都没有向量时才比到达时间。同步关闭的空投影必须自带当时的
-  // stateVector,才能清掉同一代缓存;无向量的空表不能覆盖已证明自己
-  // 更新的快照。
-  return isFresherMobileVoiceDictionarySnapshot(next, current);
+  // 同一 host 只接受更新鲜的快照。先比版本向量,并列时比桌面 emittedAt。
+  // 跨桌面展示不走这条,避免各自主机时钟互比。
+  return isFresherSameHostMobileVoiceDictionarySnapshot(next, current);
 }
 
 /**

--- a/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
@@ -356,7 +356,9 @@ function persistAcceptedSnapshot(
         () => undefined,
       );
       if (epoch !== cacheEpoch) {
-        memoryCache.delete(host);
+        // 只回收自己刚写的那份。内存按 host 不按账号分区,无条件 delete
+        // 会把新账号已经写入的同 host 快照一并抹掉,后续落盘也因身份检查失败而跳过。
+        if (memoryCache.get(host) === next) memoryCache.delete(host);
         await AsyncStorage.removeItem(storageKeyForHost(host, scope)).catch(() => undefined);
       }
     });

--- a/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
@@ -245,27 +245,7 @@ async function storeSnapshot(
       // 订阅者抛错不能打断落盘 / 索引登记,也不能变成未处理 rejection。
     }
   }
-  // 顺序很关键:**先登记索引,再写快照**。两个写不是原子的,进程随时可能死在
-  // 中间 —— 索引里多一条(快照还没写)只是清理时删一个不存在的 key,无害;
-  // 反过来快照落了盘而索引没登记,登出就枚举不到它,下个账号用同一台电脑会
-  // hydrate 到上个账号的词典。宁可多登记,不可漏登记。
-  // 索引登记失败就不要写快照:写了也是枚举不到的孤儿,登出删不掉,下个账号
-  // 用同一台电脑会 hydrate 到上个账号的词典。缓存只在内存里有效即可。
-  try {
-    await addHostToIndex(host);
-  } catch {
-    return;
-  }
-  await AsyncStorage.setItem(storageKeyForHost(host, scope), JSON.stringify(next)).catch(
-    () => undefined,
-  );
-  // 落盘与索引写入都是异步的,清理完全可能发生在这中间 —— 那样这份属于上个
-  // 账号的快照会在删除之后重新出现在盘上。写完再确认一次代际,过期就自己清掉。
-  if (epoch !== cacheEpoch) {
-    memoryCache.delete(host);
-    // 只删自己刚写的那一份(按入口锁定的分区),不碰新账号已经提交的快照。
-    await AsyncStorage.removeItem(storageKeyForHost(host, scope)).catch(() => undefined);
-  }
+  await persistAcceptedSnapshot(host, next, epoch, scope);
 }
 
 function shouldAcceptIncomingSnapshot(
@@ -349,6 +329,40 @@ async function readHostIndex(): Promise<{ hosts: string[]; readable: boolean }> 
  */
 let hostIndexQueue: Promise<void> = Promise.resolve();
 
+let persistQueue: Promise<void> = Promise.resolve();
+
+function persistAcceptedSnapshot(
+  host: string,
+  next: CachedDictionary,
+  epoch: number,
+  scope: string,
+): Promise<void> {
+  persistQueue = persistQueue
+    .catch(() => undefined)
+    .then(async () => {
+      // 内存里已经换成更新的对象,这份就不要再落盘。
+      if (epoch !== cacheEpoch || memoryCache.get(host) !== next) return;
+      // 顺序很关键:**先登记索引,再写快照**。两个写不是原子的,进程随时可能死在
+      // 中间 —— 索引里多一条(快照还没写)只是清理时删一个不存在的 key,无害;
+      // 反过来快照落了盘而索引没登记,登出就枚举不到它,下个账号用同一台电脑会
+      // hydrate 到上个账号的词典。宁可多登记,不可漏登记。
+      try {
+        await addHostToIndex(host);
+      } catch {
+        return;
+      }
+      if (epoch !== cacheEpoch || memoryCache.get(host) !== next) return;
+      await AsyncStorage.setItem(storageKeyForHost(host, scope), JSON.stringify(next)).catch(
+        () => undefined,
+      );
+      if (epoch !== cacheEpoch) {
+        memoryCache.delete(host);
+        await AsyncStorage.removeItem(storageKeyForHost(host, scope)).catch(() => undefined);
+      }
+    });
+  return persistQueue;
+}
+
 function addHostToIndex(hostDeviceId: string): Promise<void> {
   hostIndexQueue = hostIndexQueue
     .catch(() => undefined)
@@ -365,6 +379,7 @@ export function __resetMobileVoiceDictionaryCacheForTests(): void {
   memoryCache.clear();
   inFlight.clear();
   cacheListeners.clear();
+  persistQueue = Promise.resolve();
 }
 
 function normalizeEntries(raw: unknown): MobileVoiceCredentialSyncDictionaryEntry[] {

--- a/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
@@ -69,6 +69,8 @@ type CachedDictionary = {
   fetchedAt: number;
   /** 被控端上报的版本向量;老版本不带,此时只能退回按 fetchedAt 比较。 */
   stateVector?: Record<string, string>;
+  /** 桌面生成投影的时间;有则优先于 fetchedAt 判断同一 host 的先后。 */
+  emittedAt?: number;
 };
 
 const memoryCache = new Map<string, CachedDictionary>();
@@ -109,12 +111,14 @@ export function readCachedMobileVoiceDictionarySnapshot(hostDeviceId: string): {
   entries: MobileVoiceCredentialSyncDictionaryEntry[];
   fetchedAt: number;
   stateVector?: Record<string, string>;
+  emittedAt?: number;
 } {
   const cached = memoryCache.get(normalizeHostDeviceId(hostDeviceId));
   return {
     entries: cached?.entries ?? [],
     fetchedAt: cached?.fetchedAt ?? 0,
     stateVector: cached?.stateVector,
+    emittedAt: cached?.emittedAt,
   };
 }
 
@@ -145,6 +149,7 @@ export async function hydrateMobileVoiceDictionary(hostDeviceId: string): Promis
       entries: normalizeEntries(parsed?.entries),
       fetchedAt: typeof parsed?.fetchedAt === 'number' ? parsed.fetchedAt : 0,
       stateVector: normalizeStateVector(parsed?.stateVector),
+      emittedAt: normalizeEmittedAt(parsed?.emittedAt),
     };
     // 开麦路径会并发跑 hydrate 与 refresh。磁盘读晚于网络响应返回时,不能用旧
     // 快照盖掉刚拉到的新数据 —— 只在内存仍为空、或盘上确实更新时才写。
@@ -228,6 +233,7 @@ async function storeSnapshot(
     entries: normalizeEntries(result.entries),
     fetchedAt: Date.now(),
     stateVector: normalizeStateVector(result.stateVector),
+    emittedAt: normalizeEmittedAt(result.emittedAt),
   };
   const current = memoryCache.get(host);
   if (current && !shouldAcceptIncomingSnapshot(current, next)) return;
@@ -266,8 +272,10 @@ function shouldAcceptIncomingSnapshot(
   current: CachedDictionary,
   next: CachedDictionary,
 ): boolean {
-  // 同步关闭的空投影没有版本向量,但是明确的清缓存指令。
-  if (next.entries.length === 0 && next.stateVector === undefined) return true;
+  // 同一 host 只接受更新鲜的快照。新鲜度唯一判据是版本向量包含关系,
+  // 并列或都没有向量时才比到达时间。同步关闭的空投影必须自带当时的
+  // stateVector,才能清掉同一代缓存;无向量的空表不能覆盖已证明自己
+  // 更新的快照。
   return isFresherMobileVoiceDictionarySnapshot(next, current);
 }
 
@@ -389,6 +397,10 @@ function normalizeEntries(raw: unknown): MobileVoiceCredentialSyncDictionaryEntr
 
 function readPositiveInt(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 1;
+}
+
+function normalizeEmittedAt(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : undefined;
 }
 
 /**

--- a/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryCache.ts
@@ -17,6 +17,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { hlcNodeId, isCanonicalHlc } from '@cindy/voice-input-core';
 import { listMobileVoiceHistoryHosts } from '@/session/mobileVoiceHistoryStore';
+import { isFresherMobileVoiceDictionarySnapshot } from '@/session/mobileVoiceDictionaryView';
 import type {
   MobileVoiceCredentialSyncDictionaryEntry,
   MobileVoiceDictionarySnapshotResult,
@@ -71,6 +72,7 @@ type CachedDictionary = {
 };
 
 const memoryCache = new Map<string, CachedDictionary>();
+const cacheListeners = new Set<() => void>();
 /**
  * 在途请求。键带账号分区 —— 只按 host 去重的话,账号切走之后新账号的刷新会拿到
  * 上一个账号那个还挂着的请求并一直等它,而那个请求的结果按代际检查又必然被丢弃:
@@ -116,6 +118,12 @@ export function readCachedMobileVoiceDictionarySnapshot(hostDeviceId: string): {
   };
 }
 
+/** 订阅缓存内容变化；设置页靠它接收桌面主动推送到达后的即时重绘。 */
+export function subscribeMobileVoiceDictionaryCache(listener: () => void): () => void {
+  cacheListeners.add(listener);
+  return () => cacheListeners.delete(listener);
+}
+
 /** 从盘上恢复缓存(App 启动或首次用到该 host 时调用一次)。 */
 export async function hydrateMobileVoiceDictionary(hostDeviceId: string): Promise<void> {
   const host = normalizeHostDeviceId(hostDeviceId);
@@ -125,7 +133,11 @@ export async function hydrateMobileVoiceDictionary(hostDeviceId: string): Promis
   const epoch = cacheEpoch;
   const scope = accountScope;
   try {
-    const raw = await AsyncStorage.getItem(storageKeyForHost(host, scope));
+    const currentKey = storageKeyForHost(host, scope);
+    const raw = await AsyncStorage.getItem(currentKey);
+    // v1 键不带账号。任何已登录账号都无法证明这份遗留快照属于自己,导入就是
+    // 跨账号泄漏。只删不迁,词典由桌面 push / 主动拉取重建。
+    await AsyncStorage.removeItem(legacyStorageKeyForHost(host)).catch(() => undefined);
     if (!raw) return;
     if (epoch !== cacheEpoch) return;
     const parsed = JSON.parse(raw) as Partial<CachedDictionary>;
@@ -177,36 +189,7 @@ export async function refreshMobileVoiceDictionary(
   const task = (async () => {
     try {
       const result = await fetchSnapshot();
-      if (!result?.ok) return;
-      // 请求期间发生过账号边界清理:这份数据属于上一个账号,丢弃。
-      if (epoch !== cacheEpoch) return;
-      const next: CachedDictionary = {
-        entries: normalizeEntries(result.entries),
-        fetchedAt: Date.now(),
-        stateVector: normalizeStateVector(result.stateVector),
-      };
-      memoryCache.set(host, next);
-      // 顺序很关键:**先登记索引,再写快照**。两个写不是原子的,进程随时可能死在
-      // 中间 —— 索引里多一条(快照还没写)只是清理时删一个不存在的 key,无害;
-      // 反过来快照落了盘而索引没登记,登出就枚举不到它,下个账号用同一台电脑会
-      // hydrate 到上个账号的词典。宁可多登记,不可漏登记。
-      // 索引登记失败就不要写快照:写了也是枚举不到的孤儿,登出删不掉,下个账号
-      // 用同一台电脑会 hydrate 到上个账号的词典。缓存只在内存里有效即可。
-      try {
-        await addHostToIndex(host);
-      } catch {
-        return;
-      }
-      await AsyncStorage.setItem(storageKeyForHost(host, scope), JSON.stringify(next)).catch(
-        () => undefined,
-      );
-      // 落盘与索引写入都是异步的,清理完全可能发生在这中间 —— 那样这份属于上个
-      // 账号的快照会在删除之后重新出现在盘上。写完再确认一次代际,过期就自己清掉。
-      if (epoch !== cacheEpoch) {
-        memoryCache.delete(host);
-        // 只删自己刚写的那一份(按入口锁定的分区),不碰新账号已经提交的快照。
-        await AsyncStorage.removeItem(storageKeyForHost(host, scope)).catch(() => undefined);
-      }
+      await storeSnapshot(host, result, epoch, scope);
     } catch {
       // 桌面离线、老被控端不识别该 channel、隧道抖动 —— 一律沿用现有缓存。
     } finally {
@@ -215,6 +198,77 @@ export async function refreshMobileVoiceDictionary(
   })();
   inFlight.set(inFlightKey, task);
   return task;
+}
+
+/**
+ * 接收桌面主动推送的只读快照。
+ *
+ * push 不属于 relay 的远程控制调用，因此桌面关闭「允许被控」时手机仍能拿到词典。
+ * 与主动拉取共用同一条校验、账号代际和落盘路径，避免形成第二份缓存语义。
+ */
+export async function applyMobileVoiceDictionarySnapshot(
+  hostDeviceId: string,
+  result: MobileVoiceDictionarySnapshotResult,
+): Promise<void> {
+  const host = normalizeHostDeviceId(hostDeviceId);
+  if (!host) return;
+  const epoch = cacheEpoch;
+  const scope = accountScope;
+  await storeSnapshot(host, result, epoch, scope);
+}
+
+async function storeSnapshot(
+  host: string,
+  result: MobileVoiceDictionarySnapshotResult,
+  epoch: number,
+  scope: string,
+): Promise<void> {
+  if (!result?.ok || epoch !== cacheEpoch) return;
+  const next: CachedDictionary = {
+    entries: normalizeEntries(result.entries),
+    fetchedAt: Date.now(),
+    stateVector: normalizeStateVector(result.stateVector),
+  };
+  const current = memoryCache.get(host);
+  if (current && !shouldAcceptIncomingSnapshot(current, next)) return;
+  memoryCache.set(host, next);
+  for (const listener of cacheListeners) {
+    try {
+      listener();
+    } catch {
+      // 订阅者抛错不能打断落盘 / 索引登记,也不能变成未处理 rejection。
+    }
+  }
+  // 顺序很关键:**先登记索引,再写快照**。两个写不是原子的,进程随时可能死在
+  // 中间 —— 索引里多一条(快照还没写)只是清理时删一个不存在的 key,无害;
+  // 反过来快照落了盘而索引没登记,登出就枚举不到它,下个账号用同一台电脑会
+  // hydrate 到上个账号的词典。宁可多登记,不可漏登记。
+  // 索引登记失败就不要写快照:写了也是枚举不到的孤儿,登出删不掉,下个账号
+  // 用同一台电脑会 hydrate 到上个账号的词典。缓存只在内存里有效即可。
+  try {
+    await addHostToIndex(host);
+  } catch {
+    return;
+  }
+  await AsyncStorage.setItem(storageKeyForHost(host, scope), JSON.stringify(next)).catch(
+    () => undefined,
+  );
+  // 落盘与索引写入都是异步的,清理完全可能发生在这中间 —— 那样这份属于上个
+  // 账号的快照会在删除之后重新出现在盘上。写完再确认一次代际,过期就自己清掉。
+  if (epoch !== cacheEpoch) {
+    memoryCache.delete(host);
+    // 只删自己刚写的那一份(按入口锁定的分区),不碰新账号已经提交的快照。
+    await AsyncStorage.removeItem(storageKeyForHost(host, scope)).catch(() => undefined);
+  }
+}
+
+function shouldAcceptIncomingSnapshot(
+  current: CachedDictionary,
+  next: CachedDictionary,
+): boolean {
+  // 同步关闭的空投影没有版本向量,但是明确的清缓存指令。
+  if (next.entries.length === 0 && next.stateVector === undefined) return true;
+  return isFresherMobileVoiceDictionarySnapshot(next, current);
 }
 
 /**
@@ -304,6 +358,7 @@ export function __resetMobileVoiceDictionaryCacheForTests(): void {
   cacheEpoch += 1;
   memoryCache.clear();
   inFlight.clear();
+  cacheListeners.clear();
 }
 
 function normalizeEntries(raw: unknown): MobileVoiceCredentialSyncDictionaryEntry[] {

--- a/apps/mobile/src/session/mobileVoiceDictionaryView.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryView.ts
@@ -92,6 +92,8 @@ export interface MobileVoiceDictionarySnapshot {
   fetchedAt: number;
   /** 被控端上报的版本向量 `{nodeId: 最大 HLC}`;老版本被控端没有。 */
   stateVector?: Record<string, string>;
+  /** 桌面生成投影的时间;有则优先于 fetchedAt 做并列时的先后判断。 */
+  emittedAt?: number;
 }
 
 /**
@@ -129,10 +131,22 @@ export function isFresherMobileVoiceDictionarySnapshot(
     const candidateDominates = dominates(candidate.stateVector, best.stateVector);
     const bestDominates = dominates(best.stateVector, candidate.stateVector);
     if (candidateDominates !== bestDominates) return candidateDominates;
-    return candidate.fetchedAt > best.fetchedAt;
+    return isLaterSnapshot(candidate, best);
   }
   if (candidate.stateVector) return true;
   if (best.stateVector) return false;
+  return isLaterSnapshot(candidate, best);
+}
+
+function isLaterSnapshot(
+  candidate: MobileVoiceDictionarySnapshot,
+  best: MobileVoiceDictionarySnapshot,
+): boolean {
+  if (candidate.emittedAt !== undefined && best.emittedAt !== undefined) {
+    return candidate.emittedAt > best.emittedAt;
+  }
+  if (candidate.emittedAt !== undefined) return true;
+  if (best.emittedAt !== undefined) return false;
   return candidate.fetchedAt > best.fetchedAt;
 }
 

--- a/apps/mobile/src/session/mobileVoiceDictionaryView.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryView.ts
@@ -121,7 +121,7 @@ export interface MobileVoiceDictionarySnapshot {
  * 的快照)。两份都带时:一方包含另一方就选包含者;互不包含(真并发)时没有正确答案,
  * 退回按拉取时间取较新的。
  */
-function isFresherThan(
+export function isFresherMobileVoiceDictionarySnapshot(
   candidate: MobileVoiceDictionarySnapshot,
   best: MobileVoiceDictionarySnapshot,
 ): boolean {
@@ -152,7 +152,7 @@ export function buildMobileVoiceDictionaryEntryViews(
   const maxAliases = options?.maxAliases ?? 3;
   const freshest = snapshots.reduce<MobileVoiceDictionarySnapshot | null>((best, snapshot) => {
     if (!snapshot || snapshot.fetchedAt <= 0) return best;
-    return !best || isFresherThan(snapshot, best) ? snapshot : best;
+    return !best || isFresherMobileVoiceDictionarySnapshot(snapshot, best) ? snapshot : best;
   }, null);
   if (!freshest) return [];
 

--- a/apps/mobile/src/session/mobileVoiceDictionaryView.ts
+++ b/apps/mobile/src/session/mobileVoiceDictionaryView.ts
@@ -127,18 +127,37 @@ export function isFresherMobileVoiceDictionarySnapshot(
   candidate: MobileVoiceDictionarySnapshot,
   best: MobileVoiceDictionarySnapshot,
 ): boolean {
+  return compareSnapshotFreshness(candidate, best, (left, right) => left.fetchedAt > right.fetchedAt);
+}
+
+/** 同一 host 入站防倒灌:并列时比桌面发出时间,不用手机到达时间。 */
+export function isFresherSameHostMobileVoiceDictionarySnapshot(
+  candidate: MobileVoiceDictionarySnapshot,
+  best: MobileVoiceDictionarySnapshot,
+): boolean {
+  return compareSnapshotFreshness(candidate, best, isLaterByEmittedAt);
+}
+
+function compareSnapshotFreshness(
+  candidate: MobileVoiceDictionarySnapshot,
+  best: MobileVoiceDictionarySnapshot,
+  isLater: (
+    candidate: MobileVoiceDictionarySnapshot,
+    best: MobileVoiceDictionarySnapshot,
+  ) => boolean,
+): boolean {
   if (candidate.stateVector && best.stateVector) {
     const candidateDominates = dominates(candidate.stateVector, best.stateVector);
     const bestDominates = dominates(best.stateVector, candidate.stateVector);
     if (candidateDominates !== bestDominates) return candidateDominates;
-    return isLaterSnapshot(candidate, best);
+    return isLater(candidate, best);
   }
   if (candidate.stateVector) return true;
   if (best.stateVector) return false;
-  return isLaterSnapshot(candidate, best);
+  return isLater(candidate, best);
 }
 
-function isLaterSnapshot(
+function isLaterByEmittedAt(
   candidate: MobileVoiceDictionarySnapshot,
   best: MobileVoiceDictionarySnapshot,
 ): boolean {

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -1579,6 +1579,53 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
+  it('显式 close 后词典只读快照 push 仍走 unlinked legacy,不报 LINK_NOT_OPEN', async () => {
+    const h = makeHarness({ timing: { pingIntervalMs: 1_000 } });
+    h.client.start();
+    await tick();
+    h.current().ack();
+
+    const open = h.client.openLink(
+      'dev-b',
+      { controllerName: 'Test', protocolVersion: 1, appVersion: '1' },
+      100,
+    );
+    const sentOpen = h.current().sent.find((env) => env.kind === 'link-open')!;
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-accept',
+      id: sentOpen.id,
+      src: 'dev-b',
+      payload: {
+        appVersion: '1',
+        allowlistHash: 'hash',
+        capabilities: [DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT],
+        transportStreamId: 'remote-stream',
+      },
+    });
+    await open;
+    h.client.closeLink('dev-b', 'user');
+
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'blocked' })).toThrow(
+      expect.objectContaining({ code: 'LINK_NOT_OPEN' }),
+    );
+    const sentBefore = h.current().sent.length;
+    expect(() => h.client.sendPush(
+      'dev-b',
+      'device-link:voice:dictionary:snapshot',
+      { ok: true, entries: [] },
+    )).not.toThrow();
+    const sent = h.current().sent.at(-1)!;
+    expect(h.current().sent.length).toBeGreaterThan(sentBefore);
+    expect(sent).toMatchObject({
+      kind: 'push',
+      dst: 'dev-b',
+      payload: { channel: 'device-link:voice:dictionary:snapshot' },
+    });
+    expect(parseTransportPayload(sent.payload)).toBeNull();
+    h.client.stop();
+  });
+
   it('显式 close 后只放行已接收的 legacy listing invoke-result 回程', async () => {
     const h = makeHarness({ timing: { pingIntervalMs: 1_000 } });
     h.client.start();

--- a/packages/device-link/src/allowlist.ts
+++ b/packages/device-link/src/allowlist.ts
@@ -120,23 +120,18 @@ export const DL_VOICE_DICTIONARY_LEARNING_CHANNEL = 'device-link:voice:dictionar
 /**
  * 手机端拉取被控桌面的语音词典快照(只读)。
  *
- * 桌面之间的词典靠 push 帧对等同步,但手机在后台不维持 WebSocket、收不到 push,
- * 所以改为需要时主动拉一份。返回的是**只读投影**:词条文本 + 频次 + 别名,外加一个
+ * 桌面之间的词典靠 push 帧对等同步,手机不参与 CRDT 合并而只接收桌面主动推送的
+ * 只读投影;本 channel 保留作为旧版兼容和丢 push 时的主动刷新兜底。返回的是**只读投影**:
+ * 词条文本 + 频次 + 别名,外加一个
  * 版本向量(`stateVector`)供手机判断多台电脑的快照谁包含谁。化身、墓碑、抑制项、
  * 时钟都不外泄 —— 手机不参与合并,不持有可写状态,避免移动端词典分叉。
  *
  * 符合准入判据:不依赖 event.sender、无本机 UI 副作用、词典真相在被控端。
  *
- * ## 已知限制:与电脑之间的同步不一致
- *
- * invoke 属于 relay 的 CONTROL_KINDS,转发前会校验目标的 remoteControlEnabled;
- * 而电脑之间的词典同步走 push,不受该开关限制。结果是同一个功能有两套前提:用户
- * 开了「词典同步」后电脑之间就通了,手机却还要额外打开「允许同账号设备控制本机」
- * ——那个开关的语义是「允许别人操作我」,和「读一份词典」并不对应,用户撞上时基本
- * 猜不到该去开什么。
- *
- * 后续可改为推送:桌面在 presence 看到手机上线时主动 push 只读投影,零配置且与
- * 电脑之间同一条通道;本 channel 保留作为手机主动刷新的兜底。
+ * invoke 仍属于 relay 的 CONTROL_KINDS,转发前会校验目标的 remoteControlEnabled;
+ * 因此新版本优先使用独立的只读 push 快照通道,即使桌面关闭「允许被控」也能查看词典。
+ * 本 channel 保留用于旧版桌面兼容和 push 丢失后的主动刷新,不能把 REMOTE_DISABLED
+ * 当成“真的没有词条”。
  */
 export const DL_VOICE_DICTIONARY_GET_CHANNEL = 'device-link:voice:dictionary:get';
 

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -3297,12 +3297,16 @@ const UNLINKED_LEGACY_INVOKE_CHANNELS = new Set([
   'local-db:sessions:interrupted-pending',
   'maker:git-safety:get',
 ]);
+const UNLINKED_LEGACY_PUSH_CHANNELS = new Set([
+  'device-link:voice:dictionary:snapshot',
+]);
 
 function isUnlinkedLegacyEnvelope(env: Envelope): boolean {
-  if (env.kind !== 'invoke') return false;
-  const payload = env.payload as Partial<InvokePayload> | undefined;
-  return typeof payload?.channel === 'string'
-    && UNLINKED_LEGACY_INVOKE_CHANNELS.has(payload.channel);
+  const payload = env.payload as { channel?: unknown } | undefined;
+  if (typeof payload?.channel !== 'string') return false;
+  if (env.kind === 'invoke') return UNLINKED_LEGACY_INVOKE_CHANNELS.has(payload.channel);
+  if (env.kind === 'push') return UNLINKED_LEGACY_PUSH_CHANNELS.has(payload.channel);
+  return false;
 }
 
 function isLegacyBusinessFrame(kind: Envelope['kind']): boolean {

--- a/packages/maker-shared/src/__tests__/deviceLinkContract.test.ts
+++ b/packages/maker-shared/src/__tests__/deviceLinkContract.test.ts
@@ -3,6 +3,7 @@ import {
   DEVICE_LINK_MEDIA_FETCH_CHANNEL,
   DEVICE_LINK_VOICE_CREDENTIAL_SYNC_CHANNEL,
   DEVICE_LINK_VOICE_DICTIONARY_LEARNING_CHANNEL,
+  DEVICE_LINK_VOICE_DICTIONARY_SNAPSHOT_CHANNEL,
   DEVICE_LINK_VOICE_TRANSCRIBE_CHANNEL,
   MOBILE_REMOTE_INVOKE_CHANNELS,
   connectionIssueHint,
@@ -29,6 +30,9 @@ describe('device-link shared contract', () => {
     expect(DEVICE_LINK_VOICE_TRANSCRIBE_CHANNEL).toBe('device-link:voice:transcribe');
     expect(DEVICE_LINK_VOICE_CREDENTIAL_SYNC_CHANNEL).toBe('device-link:voice:credential-sync');
     expect(DEVICE_LINK_VOICE_DICTIONARY_LEARNING_CHANNEL).toBe('device-link:voice:dictionary-learning');
+    expect(DEVICE_LINK_VOICE_DICTIONARY_SNAPSHOT_CHANNEL).toBe(
+      'device-link:voice:dictionary:snapshot',
+    );
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:send');
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:switch-session-agent');
     expect(MOBILE_REMOTE_INVOKE_CHANNELS).toContain('maker:get-session-agent-switch-intent');

--- a/packages/maker-shared/src/deviceLinkContract.ts
+++ b/packages/maker-shared/src/deviceLinkContract.ts
@@ -10,6 +10,9 @@ export const DEVICE_LINK_VOICE_TRANSCRIBE_CHANNEL = 'device-link:voice:transcrib
 export const DEVICE_LINK_VOICE_CREDENTIAL_SYNC_CHANNEL = 'device-link:voice:credential-sync';
 export const DEVICE_LINK_VOICE_DICTIONARY_LEARNING_CHANNEL = 'device-link:voice:dictionary-learning';
 export const DEVICE_LINK_VOICE_DICTIONARY_GET_CHANNEL = 'device-link:voice:dictionary:get';
+/** 桌面主动推给手机的只读词典快照；push 不受 remoteControlEnabled 控制门禁。 */
+export const DEVICE_LINK_VOICE_DICTIONARY_SNAPSHOT_CHANNEL =
+  'device-link:voice:dictionary:snapshot';
 
 export type MobileVoiceCredentialSyncAsr = {
   provider: string;

--- a/packages/maker-shared/src/deviceLinkContract.ts
+++ b/packages/maker-shared/src/deviceLinkContract.ts
@@ -91,6 +91,12 @@ export type MobileVoiceDictionarySnapshotResult =
        * 拿它当完整答案会漏词。老版本被控端不带这个字段,手机退回按到达时间比较。
        */
       stateVector?: Record<string, string>;
+      /**
+       * 桌面生成这份投影的本地时间(unix ms)。同一台电脑、同一代版本向量里,
+       * 用它而不是手机到达时间判断谁先发出 —— 晚到的旧拉取不能盖掉先发出的新推送。
+       * 老版本被控端不带这个字段。
+       */
+      emittedAt?: number;
     }
   | {
       ok: false;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复手机端语音词典首次进入显示 0 条的问题：设置页不再依赖点击瞬间尚未加载完成的电脑列表，并新增桌面主动推送只读词典快照的通道。这样词典读取不再错误依赖“允许同账号设备控制本机”，同时保留旧版主动拉取作为兼容兜底。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：手机语音词典首次打开显示 0 条
- 本 PR 包含：
  - 桌面检测手机上线并推送只读词典投影；本地词典变化时广播更新
  - 手机接收快照、即时刷新设置页，并删除无账号归属的 v1 遗留缓存（不导入）
  - 写入缓存时按版本向量拒绝旧快照覆盖新状态；订阅者异常不打断落盘
  - 超大快照按与桌面 CRDT 相同的单帧上限拒绝发送，不另造分片协议
  - 同一 host 缓存只接受更新鲜的快照：先比版本向量，并列时比桌面 emittedAt
  - 修复异步电脑列表导致的首次 hydrate 竞态
  - 补充移动端、桌面端和共享协议测试
- 明确不包含：不改变桌面之间的 CRDT 同步语义，不修改服务端，不为无控制链路的超大词典新增分片/分页协议
- 用户可见变化：首次打开词典即可显示已有内容；关闭远程控制开关不再阻止词典同步
- 是否存在 breaking change：无；旧版主动 invoke 拉取保留为兼容兜底
- 多端适配：
  1. SSH 远程工作区：不涉及。词典同步走设备互联，不读本机 workdir。
  2. 设备互联：已适配。新增 `device-link:voice:dictionary:snapshot` push 通道，不依赖 `remoteControlEnabled`；旧版 `dictionary:get` invoke 保留为兼容兜底。未改重试 / 超时 / 断链恢复，故障半径仍是单次 best-effort push。
  3. 手机版：已适配。设置页改为列表到达后 hydrate，并订阅缓存变化刷新；无布局 / 样式 / 文案改动。

### UI 变化

不涉及：仅调整数据加载、缓存订阅和 device-link 推送，未改布局、样式或文案。

- 引用的设计规范：不涉及：仅调整数据加载、缓存订阅和 device-link 推送，未改布局、样式或文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/voice-input/__tests__/dictionarySyncDriver.test.ts
结果：23 passed

pnpm --filter mobile exec vitest run src/__tests__/mobileVoiceDictionaryCache.test.ts src/__tests__/mobileVoiceDictionaryView.test.ts src/__tests__/mobileSettings.test.ts
结果：56 passed

pnpm --filter desktop typecheck
结果：通过

pnpm --filter mobile typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：desktop 有 2 条 ghostInstallReceipt.test.ts 失败；已在其他干净 origin/main 会话复现，与本 PR 无关，未混入修复。其余相关 workspace 通过。
```

### 手工验证

已在本机 Cindy 设置的“其他设备”页查看当前设备状态：在线的 Mac mini 未显示“对方未开启被控”，历史离线设备显示该提示；未进行真实手机发版包验证。

### 未执行的验证

未执行真实 iOS/Android 设备端到端验证；当前会话没有可用的移动发版运行环境。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 影响范围：同账号、在线且未撤销的桌面与手机 device-link 词典同步
- 回滚 / 降级方式：回滚本 PR 即恢复旧版主动拉取；旧版客户端不认识新 push channel 时会忽略并继续使用 invoke 兜底。无账号归属的 v1 缓存只删不迁，升级后首次打开若桌面离线可能暂时为空，连上后由 push / 拉取重建。
- 安全边界：快照只在同账号 presence、未撤销设备之间推送；手机端按 relay 来源设备分片缓存，不信任 payload 自报 host。超大合法词典（逼近 1000 词 × 多别名）在无控制链路时不会分片发送，手机保留上次缓存——与桌面 CRDT 已有的单帧上限一致。
- 存量插件影响：无
- 冷更：无；未改 native / fingerprint 输入

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（远端提交 message 含 `Signed-off-by: Dash <dashhuang@gmail.com>`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

