### PR TITLE
perf(desktop): 加速任务切换渲染

### DIFF
--- a/apps/desktop/src/main/localDb/ipc/__tests__/messagesListImportSideEffects.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/messagesListImportSideEffects.test.ts
@@ -111,7 +111,8 @@ describe('runMessagesListImportSideEffects (injectable)', () => {
       { deviceLinkFirstPage: true },
     );
 
-    expect(importCodex).toHaveBeenCalledExactlyOnceWith('codex-s1');
+    expect(importCodex).toHaveBeenCalledTimes(1);
+    expect(importCodex).toHaveBeenCalledWith('codex-s1');
     expect(importClaude).not.toHaveBeenCalled();
   });
 
@@ -126,7 +127,8 @@ describe('runMessagesListImportSideEffects (injectable)', () => {
     });
 
     expect(importCodex).not.toHaveBeenCalled();
-    expect(importClaude).toHaveBeenCalledExactlyOnceWith('claude-s1');
+    expect(importClaude).toHaveBeenCalledTimes(1);
+    expect(importClaude).toHaveBeenCalledWith('claude-s1');
   });
 
   it('普通任务 → 两个 importer 都跳过', async () => {
@@ -191,7 +193,8 @@ describe('local-db:messages:list × import side-effects (integration)', () => {
       () => listHandler?.({}, 'codex-s1', { limit: 10 }),
     );
 
-    expect(codexMock).toHaveBeenCalledExactlyOnceWith('codex-s1');
+    expect(codexMock).toHaveBeenCalledTimes(1);
+    expect(codexMock).toHaveBeenCalledWith('codex-s1');
     expect(claudeMock).not.toHaveBeenCalled();
     expect(Array.isArray(rows)).toBe(true);
   });

--- a/apps/desktop/src/main/localDb/ipc/__tests__/messagesListImportSideEffects.test.ts
+++ b/apps/desktop/src/main/localDb/ipc/__tests__/messagesListImportSideEffects.test.ts
@@ -1,10 +1,11 @@
 /**
  * messagesListImportSideEffects.test.ts — #318 A3。
  * ------------------------------------------------------------------------------------
- * 验证 `local-db:messages:list` 在 device-link 远程读路径上跳过「外部 CLI 历史导入」副作用,
- * 而本机(非 device-link)路径仍按原有语义串行触发两个 importer:
- *   - device-link 路径(isDeviceLinkInvoke()=true)→ 两个 importer 都不调用;
- *   - 本机路径 → codex / claude importer 均按顺序调用一次;
+ * 验证 `local-db:messages:list` 只为带来源前缀的任务运行对应「外部 CLI 历史导入」副作用:
+ *   - 普通任务(无 codex-/claude- 前缀) → 两个 importer 都不调用;
+ *   - Codex 任务 → 只调用 Codex importer;
+ *   - Claude 任务 → 只调用 Claude importer;
+ *   - device-link 分页仍跳过 importer;
  *   - importer reject → 被吞并(warn),不冒泡。
  * 既覆盖可注入纯函数 `runMessagesListImportSideEffects`,也通过真实 handler + 真实
  * `runDeviceLinkInvokeContext`(AsyncLocalStorage)做一次集成断言。
@@ -55,7 +56,7 @@ import { importExternalClaudeCodeMessagesForSession } from '../../../maker-host/
 const codexMock = vi.mocked(importExternalCodexMessagesForSession);
 const claudeMock = vi.mocked(importExternalClaudeCodeMessagesForSession);
 
-function createDb(): Database.Database {
+function createDb(sessionId = 's1'): Database.Database {
   const sqlite = new Database(':memory:');
   sqlite.exec(`
     CREATE TABLE sessions (
@@ -75,7 +76,7 @@ function createDb(): Database.Database {
       rewind_at INTEGER
     );
   `);
-  sqlite.prepare('INSERT INTO sessions (id, cleared_at) VALUES (?, NULL)').run('s1');
+  sqlite.prepare('INSERT INTO sessions (id, cleared_at) VALUES (?, NULL)').run(sessionId);
   h.db = drizzle(sqlite, { schema: { messages, sessions } });
   return sqlite;
 }
@@ -99,30 +100,38 @@ describe('runMessagesListImportSideEffects (injectable)', () => {
     expect(importClaude).not.toHaveBeenCalled();
   });
 
-  it('device-link 首页请求(deviceLinkFirstPage)→ 照跑 importer', async () => {
-    // 被控端可能从未本机打开该会话,rollout 从未导入 —— 首页请求必须补导入,
-    // 否则崩溃前 CLI 已写的产出不进 DB,中断行滞留尾部(review P2)。
+  it('Codex 首页请求(deviceLinkFirstPage)→ 只跑 Codex importer', async () => {
+    // 被控端可能从未本机打开该会话,rollout 从未导入 —— 首页请求必须补导入。
     const importCodex = vi.fn(async () => undefined);
     const importClaude = vi.fn(async () => undefined);
 
     await runMessagesListImportSideEffects(
-      's1',
+      'codex-s1',
       { isDeviceLink: () => true, importCodex, importClaude },
       { deviceLinkFirstPage: true },
     );
 
-    expect(importCodex).toHaveBeenCalledExactlyOnceWith('s1');
-    expect(importClaude).toHaveBeenCalledExactlyOnceWith('s1');
+    expect(importCodex).toHaveBeenCalledExactlyOnceWith('codex-s1');
+    expect(importClaude).not.toHaveBeenCalled();
   });
 
-  it('本机路径 → 按顺序调用 codex 再 claude importer', async () => {
-    const order: string[] = [];
-    const importCodex = vi.fn(async () => {
-      order.push('codex');
+  it('Claude 首页请求 → 只跑 Claude importer', async () => {
+    const importCodex = vi.fn(async () => undefined);
+    const importClaude = vi.fn(async () => undefined);
+
+    await runMessagesListImportSideEffects('claude-s1', {
+      isDeviceLink: () => false,
+      importCodex,
+      importClaude,
     });
-    const importClaude = vi.fn(async () => {
-      order.push('claude');
-    });
+
+    expect(importCodex).not.toHaveBeenCalled();
+    expect(importClaude).toHaveBeenCalledExactlyOnceWith('claude-s1');
+  });
+
+  it('普通任务 → 两个 importer 都跳过', async () => {
+    const importCodex = vi.fn(async () => undefined);
+    const importClaude = vi.fn(async () => undefined);
 
     await runMessagesListImportSideEffects('s1', {
       isDeviceLink: () => false,
@@ -130,30 +139,26 @@ describe('runMessagesListImportSideEffects (injectable)', () => {
       importClaude,
     });
 
-    expect(importCodex).toHaveBeenCalledExactlyOnceWith('s1');
-    expect(importClaude).toHaveBeenCalledExactlyOnceWith('s1');
-    expect(order).toEqual(['codex', 'claude']);
+    expect(importCodex).not.toHaveBeenCalled();
+    expect(importClaude).not.toHaveBeenCalled();
   });
 
-  it('本机路径 → importer reject 被吞并,不冒泡', async () => {
+  it('对应 importer reject 被吞并,不冒泡', async () => {
     const importCodex = vi.fn(async () => {
       throw new Error('boom-codex');
     });
-    const importClaude = vi.fn(async () => {
-      throw new Error('boom-claude');
-    });
+    const importClaude = vi.fn(async () => undefined);
 
     await expect(
-      runMessagesListImportSideEffects('s1', {
+      runMessagesListImportSideEffects('codex-s1', {
         isDeviceLink: () => false,
         importCodex,
         importClaude,
       }),
     ).resolves.toBeUndefined();
 
-    // codex reject 不应阻断 claude importer 触发(沿用原串行 + 各自 .catch 语义)。
     expect(importCodex).toHaveBeenCalledTimes(1);
-    expect(importClaude).toHaveBeenCalledTimes(1);
+    expect(importClaude).not.toHaveBeenCalled();
   });
 });
 
@@ -163,36 +168,36 @@ describe('local-db:messages:list × import side-effects (integration)', () => {
     h.handlers.clear();
   });
 
-  it('本机 invoke → 触发真实 importer(默认依赖)', async () => {
-    createDb();
+  it('普通任务 invoke → 跳过真实 importer', async () => {
+    createDb('s1');
     registerMessageIpc();
     const listHandler = h.handlers.get('local-db:messages:list');
     expect(listHandler).toBeTypeOf('function');
 
     await listHandler?.({}, 's1', { limit: 10 });
 
-    expect(codexMock).toHaveBeenCalledExactlyOnceWith('s1');
-    expect(claudeMock).toHaveBeenCalledExactlyOnceWith('s1');
+    expect(codexMock).not.toHaveBeenCalled();
+    expect(claudeMock).not.toHaveBeenCalled();
   });
 
-  it('device-link 首页 invoke → 照跑真实 importer(补被控端从未本机打开的导入)', async () => {
-    createDb();
+  it('device-link Codex 首页 invoke → 只跑真实 Codex importer', async () => {
+    createDb('codex-s1');
     registerMessageIpc();
     const listHandler = h.handlers.get('local-db:messages:list');
     expect(listHandler).toBeTypeOf('function');
 
     const rows = await runDeviceLinkInvokeContext(
       { controllerDeviceId: 'ctrl-1', channel: 'local-db:messages:list' },
-      () => listHandler?.({}, 's1', { limit: 10 }),
+      () => listHandler?.({}, 'codex-s1', { limit: 10 }),
     );
 
-    expect(codexMock).toHaveBeenCalledExactlyOnceWith('s1');
-    expect(claudeMock).toHaveBeenCalledExactlyOnceWith('s1');
+    expect(codexMock).toHaveBeenCalledExactlyOnceWith('codex-s1');
+    expect(claudeMock).not.toHaveBeenCalled();
     expect(Array.isArray(rows)).toBe(true);
   });
 
   it('device-link 分页 invoke(带 beforeTs)→ 跳过真实 importer(#318 性能语义)', async () => {
-    createDb();
+    createDb('s1');
     registerMessageIpc();
     const listHandler = h.handlers.get('local-db:messages:list');
     expect(listHandler).toBeTypeOf('function');

--- a/apps/desktop/src/main/localDb/ipc/messages.ts
+++ b/apps/desktop/src/main/localDb/ipc/messages.ts
@@ -542,11 +542,9 @@ export function registerMessageIpc(): void {
 /**
  * messages:list 的「按需导入外部 CLI 会话历史」副作用。
  *
- * codex / cc importer 各自在会话非对应 agent / 非 import 会话时 early-return，但仍各跑一次
- * `SELECT FROM sessions`，且二者串行 await 在真正的消息查询之前。device-link 远程读是被控端
- * 已导入状态的镜像:在每次(含分页)远程 open 上重跑这些「读外部 rollout/JSONL → 写本机 DB」的
- * 本地副作用,只会把导入延迟串接到消息查询前(见 GitHub issue #318 A3)。故 device-link 路径
- * 整体跳过这些副作用;非 device-link 路径保持原有的串行顺序、错误吞并与告警语义不变。
+ * 普通 Cindy 任务不需要外部 CLI 历史导入；只有带有明确来源前缀的任务才运行对应 importer。
+ * 这样可以避免每次切换普通任务都先为两个 importer 各做一次 sessions 查询。device-link 远程读
+ * 仍遵循首页/分页语义，但首页也只对 Codex/Claude 来源任务运行对应 importer。
  *
  * 抽成可注入函数仅为单测(规则 14):默认依赖即生产实现,Electron `ipcMain.handle` 只做 adapter。
  */
@@ -568,18 +566,23 @@ export async function runMessagesListImportSideEffects(
   if (isDeviceLink() && !opts.deviceLinkFirstPage) return;
   const importCodex = deps.importCodex ?? importExternalCodexMessagesForSession;
   const importClaude = deps.importClaude ?? importExternalClaudeCodeMessagesForSession;
-  await importCodex(sessionId).catch((err) => {
-    log.warn('external Codex message import failed', {
-      sessionId,
-      err: err instanceof Error ? err.message : String(err),
+  if (sessionId.startsWith('codex-')) {
+    await importCodex(sessionId).catch((err) => {
+      log.warn('external Codex message import failed', {
+        sessionId,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
-  });
-  await importClaude(sessionId).catch((err) => {
-    log.warn('external Claude Code message import failed', {
-      sessionId,
-      err: err instanceof Error ? err.message : String(err),
+    return;
+  }
+  if (sessionId.startsWith('claude-')) {
+    await importClaude(sessionId).catch((err) => {
+      log.warn('external Claude Code message import failed', {
+        sessionId,
+        err: err instanceof Error ? err.message : String(err),
+      });
     });
-  });
+  }
 }
 
 /**

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
@@ -316,6 +316,9 @@ describe('makerChatStore active view tracking', () => {
 
   it('initial history load treats swallowed plan tool rows as non-anchor rows', async () => {
     const sessionId = sid('initial-plan-non-anchor');
+    // Preserve a local-only row so loadOlderMessages would have a beforeTs
+    // cursor if the initial non-anchor backfill failed to acquire its lock.
+    addMessage(sessionId);
     vi.mocked(messageService.list).mockClear();
     const latestPage = Array.from({ length: 50 }, (_, i) =>
       dbToolUseMessage(
@@ -326,21 +329,37 @@ describe('makerChatStore active view tracking', () => {
         new Date(BASE_TIME.getTime() + (60 + i) * 1000).toISOString(),
       ),
     );
+    let resolveOlderPage!: (rows: Message[]) => void;
     vi.mocked(messageService.list)
       .mockResolvedValueOnce(latestPage)
-      .mockResolvedValueOnce([
-        dbMessage(sessionId, 'older-visible', 'older visible message', BASE_TIME.toISOString()),
-      ]);
+      .mockReturnValueOnce(
+        new Promise<Message[]>((resolve) => {
+          resolveOlderPage = resolve;
+        }),
+      );
 
     makerChatStore.ensureInitialMessages(sessionId);
-    await flushPromises();
+    await flushPromises(4);
 
     expect(messageService.list).toHaveBeenCalledTimes(2);
     expect(messageService.list).toHaveBeenNthCalledWith(2, sessionId, {
       limit: 50,
       before: 'plan-00',
     });
-    expect(makerChatStore.getSnapshot(sessionId).oldestMessageId).toBe('older-visible');
+    expect(makerChatStore.getSnapshot(sessionId).isLoadingMore).toBe(true);
+
+    makerChatStore.loadOlderMessages(sessionId);
+    expect(messageService.list).toHaveBeenCalledTimes(2);
+
+    resolveOlderPage([
+      dbMessage(sessionId, 'older-visible', 'older visible message', BASE_TIME.toISOString()),
+    ]);
+    await flushPromises();
+
+    const snapshot = makerChatStore.getSnapshot(sessionId);
+    expect(snapshot.oldestMessageId).toBe('older-visible');
+    expect(snapshot.historyLoaded).toBe(true);
+    expect(snapshot.isLoadingMore).toBe(false);
   });
 
   it('continues initial history backfill until the latest plan boundary is found', async () => {

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
@@ -269,6 +269,51 @@ describe('makerChatStore active view tracking', () => {
     expect(snapshot.oldestMessageId).toBe('older-plan');
   });
 
+  it('shows the latest page before background plan discovery completes', async () => {
+    const sessionId = sid('initial-page-first');
+    const latestPage = Array.from({ length: 50 }, (_, i) =>
+      dbMessage(
+        sessionId,
+        `latest-${String(i).padStart(2, '0')}`,
+        `latest message ${i}`,
+        new Date(BASE_TIME.getTime() + (60 + i) * 1000).toISOString(),
+      ),
+    );
+    let resolveOlderPage!: (rows: Message[]) => void;
+    vi.mocked(messageService.list)
+      .mockResolvedValueOnce(latestPage)
+      .mockReturnValueOnce(
+        new Promise<Message[]>((resolve) => {
+          resolveOlderPage = resolve;
+        }),
+      );
+
+    makerChatStore.ensureInitialMessages(sessionId);
+    await flushPromises(4);
+
+    const firstPageSnapshot = makerChatStore.getSnapshot(sessionId);
+    expect(firstPageSnapshot.messages).toHaveLength(50);
+    expect(firstPageSnapshot.historyLoaded).toBe(false);
+    expect(firstPageSnapshot.isLoadingMore).toBe(true);
+    expect(messageService.list).toHaveBeenCalledTimes(2);
+
+    // The background phase owns the same pagination lock; a user scroll cannot
+    // start a competing request or move the cursor backwards.
+    makerChatStore.loadOlderMessages(sessionId);
+    expect(messageService.list).toHaveBeenCalledTimes(2);
+
+    const olderPage = [
+      dbMessage(sessionId, 'older-visible', 'older visible message', BASE_TIME.toISOString()),
+    ];
+    resolveOlderPage(olderPage);
+    await flushPromises();
+
+    const finalSnapshot = makerChatStore.getSnapshot(sessionId);
+    expect(finalSnapshot.messages.some((message) => message.clientId === 'client-older-visible')).toBe(true);
+    expect(finalSnapshot.historyLoaded).toBe(true);
+    expect(finalSnapshot.isLoadingMore).toBe(false);
+  });
+
   it('initial history load treats swallowed plan tool rows as non-anchor rows', async () => {
     const sessionId = sid('initial-plan-non-anchor');
     vi.mocked(messageService.list).mockClear();
@@ -1040,8 +1085,11 @@ describe('makerChatStore active view tracking', () => {
     expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(1);
 
     dispose(); // 写 lastViewedAt = BASE_TIME
-    // 推进 90s（>60s DEMOTE_IDLE_MS）让 demote timer 至少跑一次（间隔 30s）。
-    vi.advanceTimersByTime(90_000);
+    // 4:59 仍保留，5:00 的 demote timer 才清空（检查间隔 30s）。
+    vi.advanceTimersByTime(4 * 60_000 + 59_000);
+    expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(1);
+
+    vi.advanceTimersByTime(1_000);
 
     expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(0);
     expect(makerChatStore.getSnapshot(sessionId).historyLoaded).toBe(false);

--- a/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerChatStoreActiveView.test.ts
@@ -1094,4 +1094,29 @@ describe('makerChatStore active view tracking', () => {
     expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(0);
     expect(makerChatStore.getSnapshot(sessionId).historyLoaded).toBe(false);
   });
+
+  it('demotes a prefetched session that never enters a mounted view', async () => {
+    const sessionId = sid('prefetch-demote');
+    addMessage(sessionId);
+
+    makerChatStore.ensureInitialMessages(sessionId);
+    await flushPromises();
+
+    expect(makerChatStore.__activeViewTest.getLastViewedAt(sessionId)).toBe(BASE_TIME.getTime());
+    expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(1);
+
+    vi.advanceTimersByTime(4 * 60_000);
+    makerChatStore.ensureInitialMessages(sessionId);
+    expect(makerChatStore.__activeViewTest.getLastViewedAt(sessionId)).toBe(
+      BASE_TIME.getTime() + 4 * 60_000,
+    );
+
+    vi.advanceTimersByTime(4 * 60_000 + 59_000);
+    expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(1);
+
+    vi.advanceTimersByTime(1_000);
+
+    expect(makerChatStore.getSnapshot(sessionId).messages).toHaveLength(0);
+    expect(makerChatStore.getSnapshot(sessionId).historyLoaded).toBe(false);
+  });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionCard.tsx
@@ -78,6 +78,7 @@ import { useSessionBoundSchedules, scheduleFocusPath } from '@/features/schedule
 import { loadScheduleSidebarIndexRuns } from '@/features/scheduler/lib/scheduleSidebarIndexRuns';
 import { resolveSidebarRightStatus } from './sidebarRightStatus';
 import { SidebarRightStatusIndicator } from './SidebarRightStatusIndicator';
+import { shouldPrefetchSessionOnPointerDown } from './sessionSwitchPrefetch';
 
 const log = createLogger('SessionCard');
 
@@ -523,6 +524,11 @@ export function SessionCard({
       data-sidebar-session-row="true"
       role="button"
       tabIndex={0}
+      onPointerDown={(e) => {
+        if (shouldPrefetchSessionOnPointerDown(e, { isActive, isEditing })) {
+          makerChatStore.ensureInitialMessages(session.id);
+        }
+      }}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onKeyDown={(e) => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/SessionItem.tsx
@@ -37,6 +37,7 @@ import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
 import type { Session } from '@/lib/ccAgent.types';
+import { makerChatStore } from '@/lib/makerChatStore';
 import { WorktreeBadge } from '@/components/sidebar/WorktreeBadge';
 import { SessionStatusIcon } from './SessionStatusIcon';
 import { SessionRenameInput } from '../SessionRenameInput';
@@ -90,6 +91,7 @@ import { useRemoteSessionActivity } from '@/features/device-link/remoteSessionAc
 import { resolveSidebarRightStatus } from './sidebarRightStatus';
 import { AutomationTimerIcon } from './AutomationTimerIcon';
 import { SidebarRightStatusIndicator } from './SidebarRightStatusIndicator';
+import { shouldPrefetchSessionOnPointerDown } from './sessionSwitchPrefetch';
 
 // Module-level dedup cache for loadScheduleSidebarIndexRuns.
 // When many ungrouped automation rows mount simultaneously they all need the
@@ -610,6 +612,11 @@ export const SessionItem = memo(function SessionItem({
       data-sidebar-session-row="true"
       role="button"
       tabIndex={0}
+      onPointerDown={(e) => {
+        if (shouldPrefetchSessionOnPointerDown(e, { isActive, isEditing })) {
+          makerChatStore.ensureInitialMessages(session.id);
+        }
+      }}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onKeyDown={(e) => {

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -222,7 +222,8 @@ describe('SessionCard visual cases', () => {
 
     fireEvent.pointerDown(card!, { button: 0 });
 
-    expect(mocks.ensureInitialMessages).toHaveBeenCalledExactlyOnceWith('short-idle-cc');
+    expect(mocks.ensureInitialMessages).toHaveBeenCalledTimes(1);
+    expect(mocks.ensureInitialMessages).toHaveBeenCalledWith('short-idle-cc');
   });
 
   it.each(sessionCardVisualCases.map((item) => [item.label, item.id] as const))(

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -220,7 +220,7 @@ describe('SessionCard visual cases', () => {
     const card = screen.getByTestId('visual-case').querySelector('[data-sidebar-session-row="true"]');
     expect(card).not.toBeNull();
 
-    fireEvent.pointerDown(card!, { button: 0 });
+    fireEvent.pointerDown(card!, { button: 0, pointerType: 'mouse' });
 
     expect(mocks.ensureInitialMessages).toHaveBeenCalledTimes(1);
     expect(mocks.ensureInitialMessages).toHaveBeenCalledWith('short-idle-cc');

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/SessionCard.visual.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   runningDetailBySession: new Map<string, string>(),
   pendingPluginSetupSessionIds: new Set<string>(),
   attentionKindBySession: new Map<string, 'done' | 'awaiting' | 'error'>(),
+  ensureInitialMessages: vi.fn(),
 }));
 
 vi.mock('react-router-dom', () => ({
@@ -95,6 +96,7 @@ vi.mock('@/state/agentIslandActivity', () => ({
 
 vi.mock('@/lib/makerChatStore', () => ({
   makerChatStore: {
+    ensureInitialMessages: mocks.ensureInitialMessages,
     subscribeAll: () => () => {},
     getRunningSnapshot: () =>
       new Map(
@@ -187,6 +189,7 @@ describe('SessionCard visual cases', () => {
     mocks.runningDetailBySession.clear();
     mocks.pendingPluginSetupSessionIds.clear();
     mocks.attentionKindBySession.clear();
+    mocks.ensureInitialMessages.mockReset();
   });
 
   afterEach(() => {
@@ -210,6 +213,16 @@ describe('SessionCard visual cases', () => {
       'archived',
       'selected-active',
     ]);
+  });
+
+  it('prefetches a new task on primary pointerdown before navigation', () => {
+    renderCase('short-idle-cc');
+    const card = screen.getByTestId('visual-case').querySelector('[data-sidebar-session-row="true"]');
+    expect(card).not.toBeNull();
+
+    fireEvent.pointerDown(card!, { button: 0 });
+
+    expect(mocks.ensureInitialMessages).toHaveBeenCalledExactlyOnceWith('short-idle-cc');
   });
 
   it.each(sessionCardVisualCases.map((item) => [item.label, item.id] as const))(

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionSwitchPrefetch.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionSwitchPrefetch.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { shouldPrefetchSessionOnPointerDown } from '../sessionSwitchPrefetch';
 
 const primaryPointer = {
+  pointerType: 'mouse',
   button: 0,
   shiftKey: false,
   metaKey: false,
@@ -27,10 +28,11 @@ describe('shouldPrefetchSessionOnPointerDown', () => {
   });
 
   it.each([
-    ['secondary pointer', { button: 2, shiftKey: false, metaKey: false, ctrlKey: false }],
-    ['shift selection', { button: 0, shiftKey: true, metaKey: false, ctrlKey: false }],
-    ['command selection', { button: 0, shiftKey: false, metaKey: true, ctrlKey: false }],
-    ['control selection', { button: 0, shiftKey: false, metaKey: false, ctrlKey: true }],
+    ['secondary pointer', { pointerType: 'mouse', button: 2, shiftKey: false, metaKey: false, ctrlKey: false }],
+    ['touch pointer', { pointerType: 'touch', button: 0, shiftKey: false, metaKey: false, ctrlKey: false }],
+    ['shift selection', { pointerType: 'mouse', button: 0, shiftKey: true, metaKey: false, ctrlKey: false }],
+    ['command selection', { pointerType: 'mouse', button: 0, shiftKey: false, metaKey: true, ctrlKey: false }],
+    ['control selection', { pointerType: 'mouse', button: 0, shiftKey: false, metaKey: false, ctrlKey: true }],
   ])('skips %s', (_label, event) => {
     expect(
       shouldPrefetchSessionOnPointerDown(event, { isActive: false, isEditing: false }),

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionSwitchPrefetch.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/__tests__/sessionSwitchPrefetch.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldPrefetchSessionOnPointerDown } from '../sessionSwitchPrefetch';
+
+const primaryPointer = {
+  button: 0,
+  shiftKey: false,
+  metaKey: false,
+  ctrlKey: false,
+} as const;
+
+describe('shouldPrefetchSessionOnPointerDown', () => {
+  it('accepts an unmodified primary pointer on an inactive row', () => {
+    expect(
+      shouldPrefetchSessionOnPointerDown(primaryPointer, {
+        isActive: false,
+        isEditing: false,
+      }),
+    ).toBe(true);
+  });
+
+  it.each([
+    ['active row', { isActive: true, isEditing: false }],
+    ['editing row', { isActive: false, isEditing: true }],
+  ])('skips %s', (_label, opts) => {
+    expect(shouldPrefetchSessionOnPointerDown(primaryPointer, opts)).toBe(false);
+  });
+
+  it.each([
+    ['secondary pointer', { button: 2, shiftKey: false, metaKey: false, ctrlKey: false }],
+    ['shift selection', { button: 0, shiftKey: true, metaKey: false, ctrlKey: false }],
+    ['command selection', { button: 0, shiftKey: false, metaKey: true, ctrlKey: false }],
+    ['control selection', { button: 0, shiftKey: false, metaKey: false, ctrlKey: true }],
+  ])('skips %s', (_label, event) => {
+    expect(
+      shouldPrefetchSessionOnPointerDown(event, { isActive: false, isEditing: false }),
+    ).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionSwitchPrefetch.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionSwitchPrefetch.ts
@@ -1,0 +1,21 @@
+/**
+ * Keep task-switch prefetch limited to an intentional primary click on an
+ * inactive, non-editing row. Modifier clicks belong to range/multi-select and
+ * secondary buttons inside a row stop propagation before reaching the row.
+ */
+export function shouldPrefetchSessionOnPointerDown(
+  event: Pick<
+    PointerEvent,
+    'button' | 'shiftKey' | 'metaKey' | 'ctrlKey'
+  >,
+  opts: { isActive: boolean; isEditing: boolean },
+): boolean {
+  return (
+    !opts.isActive &&
+    !opts.isEditing &&
+    event.button === 0 &&
+    !event.shiftKey &&
+    !event.metaKey &&
+    !event.ctrlKey
+  );
+}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionSwitchPrefetch.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sessionSwitchPrefetch.ts
@@ -1,18 +1,20 @@
 /**
- * Keep task-switch prefetch limited to an intentional primary click on an
- * inactive, non-editing row. Modifier clicks belong to range/multi-select and
- * secondary buttons inside a row stop propagation before reaching the row.
+ * Keep task-switch prefetch limited to an intentional mouse primary click on
+ * an inactive, non-editing row. Touch scrolling and modifier clicks belong to
+ * navigation/selection gestures, while secondary buttons inside a row stop
+ * propagation before reaching the row.
  */
 export function shouldPrefetchSessionOnPointerDown(
   event: Pick<
     PointerEvent,
-    'button' | 'shiftKey' | 'metaKey' | 'ctrlKey'
+    'button' | 'pointerType' | 'shiftKey' | 'metaKey' | 'ctrlKey'
   >,
   opts: { isActive: boolean; isEditing: boolean },
 ): boolean {
   return (
     !opts.isActive &&
     !opts.isEditing &&
+    event.pointerType === 'mouse' &&
     event.button === 0 &&
     !event.shiftKey &&
     !event.metaKey &&

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/background-tasks/BackgroundTasksBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/background-tasks/BackgroundTasksBody.tsx
@@ -507,8 +507,10 @@ export function BackgroundTasksBody({
   // 整段缺失。该函数幂等(historyLoaded / in-flight 双守卫),主窗口场景是 no-op。
   useEffect(() => {
     if (!sessionId) return;
+    const dispose = visible ? makerChatStore.enterView(sessionId) : undefined;
     makerChatStore.ensureInitialMessages(sessionId);
-  }, [sessionId]);
+    return dispose;
+  }, [sessionId, visible]);
 
   // 快照水合:挂载 / 切会话时拉一次存量后台任务(订阅前已启动 / 重载清空
   // taskUpdates 后事件流看不到的任务)。listSessionBackgroundTasksFor 按会话来源

--- a/apps/desktop/src/renderer/lib/__tests__/sessionService.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/sessionService.test.ts
@@ -41,7 +41,8 @@ describe('sessionService.get in-flight deduplication', () => {
 
     const first = service.get('session-1');
     const second = service.get('session-1');
-    expect(get).toHaveBeenCalledExactlyOnceWith('session-1');
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(get).toHaveBeenCalledWith('session-1');
     expect(first).toBe(second);
 
     const session = { id: 'session-1' };

--- a/apps/desktop/src/renderer/lib/__tests__/sessionService.test.ts
+++ b/apps/desktop/src/renderer/lib/__tests__/sessionService.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/makerTransport', () => ({
+  makerApiFor: vi.fn(),
+}));
+vi.mock('@/features/device-link/remoteProjectsStore', () => ({
+  getSessionDeviceId: vi.fn(),
+}));
+
+type SessionLike = { id: string };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function loadSessionService() {
+  vi.resetModules();
+  return import('@/lib/sessionService');
+}
+
+describe('sessionService.get in-flight deduplication', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('shares one IPC request for concurrent reads of the same session', async () => {
+    const pending = deferred<SessionLike>();
+    const get = vi.fn(() => pending.promise);
+    vi.stubGlobal('window', { electronAPI: { localDb: { sessions: { get } } } });
+    const service = await loadSessionService();
+
+    const first = service.get('session-1');
+    const second = service.get('session-1');
+    expect(get).toHaveBeenCalledExactlyOnceWith('session-1');
+    expect(first).toBe(second);
+
+    const session = { id: 'session-1' };
+    pending.resolve(session);
+    await expect(first).resolves.toBe(session);
+    await expect(second).resolves.toBe(session);
+  });
+
+  it('keeps different session ids independent', async () => {
+    const requests = new Map<string, ReturnType<typeof deferred<SessionLike>>>();
+    const get = vi.fn((id: string) => {
+      const request = deferred<SessionLike>();
+      requests.set(id, request);
+      return request.promise;
+    });
+    vi.stubGlobal('window', { electronAPI: { localDb: { sessions: { get } } } });
+    const service = await loadSessionService();
+
+    const first = service.get('session-a');
+    const second = service.get('session-b');
+    expect(get).toHaveBeenCalledTimes(2);
+
+    requests.get('session-a')?.resolve({ id: 'session-a' });
+    requests.get('session-b')?.resolve({ id: 'session-b' });
+    await expect(first).resolves.toMatchObject({ id: 'session-a' });
+    await expect(second).resolves.toMatchObject({ id: 'session-b' });
+  });
+
+  it('removes settled requests instead of retaining stale metadata', async () => {
+    const get = vi.fn(async (id: string) => ({ id }));
+    vi.stubGlobal('window', { electronAPI: { localDb: { sessions: { get } } } });
+    const service = await loadSessionService();
+
+    await service.get('session-1');
+    await service.get('session-1');
+
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears rejected requests so the next read can retry', async () => {
+    const get = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('[NOT_FOUND] missing'))
+      .mockResolvedValueOnce({ id: 'session-1' });
+    vi.stubGlobal('window', { electronAPI: { localDb: { sessions: { get } } } });
+    const service = await loadSessionService();
+
+    const first = service.get('session-1');
+    const second = service.get('session-1');
+    expect(first).toBe(second);
+    await expect(first).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    await expect(second).rejects.toMatchObject({ code: 'NOT_FOUND' });
+
+    await expect(service.get('session-1')).resolves.toMatchObject({ id: 'session-1' });
+    expect(get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -5907,6 +5907,13 @@ function releaseCacheHydrationAfterFailure(sessionId: string): void {
 function ensureInitialMessages(sessionId: string): void {
   const state = getOrCreateState(sessionId);
   requestInputProjection(sessionId);
+  // Prefetch and other non-mounted callers still create a cache entry. Give
+  // that entry the same bounded lifetime as a viewed session so a cancelled
+  // navigation cannot leave messages permanently exempt from soft eviction.
+  if (!_activeViewSessions.has(sessionId)) {
+    _lastViewedAt.set(sessionId, Date.now());
+    _ensureDemoteTimer();
+  }
   if (state.historyLoaded) return;
   if (_historyFetchInFlight.has(sessionId)) return;
   // 行水合并行异步读的陈旧性守卫: fetch 启动时定格 rev, 应用时比对(见 planModeRev)。

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -1544,7 +1544,7 @@ function _trimMessagesIfNeeded(sessionId: string): void {
 // ensureInitialMessages to reload from DB.
 // ---------------------------------------------------------------------------
 
-const DEMOTE_IDLE_MS = 60_000;
+const DEMOTE_IDLE_MS = 5 * 60_000;
 const DEMOTE_CHECK_INTERVAL_MS = 30_000;
 
 const _lastViewedAt = new Map<string, number>();
@@ -6082,6 +6082,50 @@ function ensureInitialMessages(sessionId: string): void {
       const MAX_NO_ANCHOR_BACKFILL_PAGES = 10;
       const MAX_PLAN_DISCOVERY_BACKFILL_PAGES = 10;
       const MAX_PLAN_RESOLUTION_BACKFILL_PAGES = 10;
+
+      // Make the newest page visible as soon as it arrives. `historyLoaded`
+      // deliberately remains false until the optional anchor/plan backfill is
+      // complete: several consumers use that flag to gate remote reconciliation
+      // and resume/restore side effects. `isLoadingMore` is the shared lock that
+      // keeps user-triggered pagination from racing this background backfill.
+      const initialHasVisibleAnchor = existing.some((row) => !isNonAnchorHistoryRow(row));
+      const initialPlanState = historyRowsPlanBackfillState(existing, hasMore);
+      const initialNeedsBackfill =
+        hasMore &&
+        (existing.every(isNonAnchorHistoryRow) ||
+          !initialPlanState.hasPlanEvent ||
+          !initialPlanState.isResolved);
+      if (initialHasVisibleAnchor) {
+        const initialMapped = mapServerMessages(existing);
+        const initialOldestId = oldestRow.id;
+        settleCacheHydration(sessionId);
+        setState(sessionId, (s) => ({
+          ...s,
+          // Keep historyLoaded=false until the full initial window is ready;
+          // MessageStream renders this fresh page directly from `messages`.
+          historyLoaded: false,
+          messages: mergeMessages(
+            initialMapped,
+            s.messages.some((m) => m.cacheHydrated === true)
+              ? s.messages.filter((m) => m.cacheHydrated !== true)
+              : s.messages,
+            {},
+            'newest-first',
+          ),
+          isFirstMessage: false,
+          oldestMessageId:
+            s.historyWindowHasIsland === true
+              ? initialOldestId
+              : (oldestServerMessageIdForWindow(
+                  existing,
+                  s.messages,
+                  s.oldestMessageId,
+                  'newest-first',
+                ) ?? initialOldestId),
+          hasMoreMessages: hasMore,
+          isLoadingMore: initialNeedsBackfill,
+        }));
+      }
       let pagesFetched = 0;
       let planResolutionPagesFetched = 0;
       while (hasMore) {
@@ -6179,6 +6223,7 @@ function ensureInitialMessages(sessionId: string): void {
                 'newest-first',
               ) ?? oldestId),
         hasMoreMessages: hasMore,
+        isLoadingMore: false,
       }));
       if (import.meta.env.DEV) {
         const ingestDurMs = performance.now() - ingestStartMs;

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -6132,6 +6132,12 @@ function ensureInitialMessages(sessionId: string): void {
           hasMoreMessages: hasMore,
           isLoadingMore: initialNeedsBackfill,
         }));
+      } else if (initialNeedsBackfill) {
+        // The newest page has no renderable anchor, so there is nothing useful
+        // to publish yet. Still acquire the shared pagination lock before the
+        // first background await: a stale/local-only row may already give
+        // loadOlderMessages a cursor, and it must not race this backfill.
+        setState(sessionId, (s) => ({ ...s, isLoadingMore: true }));
       }
       let pagesFetched = 0;
       let planResolutionPagesFetched = 0;

--- a/apps/desktop/src/renderer/lib/sessionService.ts
+++ b/apps/desktop/src/renderer/lib/sessionService.ts
@@ -39,6 +39,11 @@ function wrap<T>(p: Promise<T>): Promise<T> {
   });
 }
 
+// Session metadata is read by both the session view and the message bootstrap
+// path during a task switch. Share only requests that are currently in flight:
+// settled rows must not become a stale renderer cache.
+const getInFlight = new Map<string, Promise<Session>>();
+
 export async function list(
   limit: number = 20,
   status?: ListStatusFilter,
@@ -73,8 +78,23 @@ export async function create(body?: {
   return wrap(window.electronAPI.localDb.sessions.create(body));
 }
 
-export async function get(id: string): Promise<Session> {
-  return wrap(window.electronAPI.localDb.sessions.get(id));
+export function get(id: string): Promise<Session> {
+  const existing = getInFlight.get(id);
+  if (existing) return existing;
+
+  const request = wrap(window.electronAPI.localDb.sessions.get(id));
+  getInFlight.set(id, request);
+  // Use both fulfillment and rejection handlers so the cleanup promise cannot
+  // become an unhandled rejection when the IPC request fails.
+  void request.then(
+    () => {
+      if (getInFlight.get(id) === request) getInFlight.delete(id);
+    },
+    () => {
+      if (getInFlight.get(id) === request) getInFlight.delete(id);
+    },
+  );
+  return request;
 }
 
 /** Resolve scheduler-held ids against live, archived, deleted, and missing rows. */


### PR DESCRIPTION
## 这次改了什么

### 摘要

优化 Desktop 在切换任务时的首屏渲染链路，减少点击侧栏任务后等待内容出现的时间：最新一页消息先显示，计划与无可见锚点的历史补齐继续在后台进行；同时去掉重复的会话元数据请求和普通任务不需要的外部历史导入检查，并用点击前预取与更长的内存缓存进一步降低切换延迟。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：任务切换后消息内容渲染较慢
- 本 PR 包含：首屏消息分阶段提交、`sessions:get` 在途 singleflight、外部历史 importer 前缀门控、任务消息缓存延长至 5 分钟、侧栏行 `pointerdown` 预取，以及对应回归测试
- 明确不包含：数据库 schema / migration、跨端协议、服务端接口、视觉样式和 UI 文案调整
- 用户可见变化：点击新的任务后，已有消息更早出现在内容区；常用任务来回切换更容易命中内存缓存
- 是否存在 breaking change：无

### UI 变化

不涉及视觉、布局或文案变化；仅在既有任务行交互上增加点击前消息预取，并避开当前任务、编辑态、右键及多选操作。

- 引用的设计规范：`docs/design-rules/DESIGN.md`；本次未改变视觉 token、布局、动效或内容规范

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-session-switch-performance
结果：通过。统一门禁 `GATE_EXIT=0`；仓库 runner 341 项通过、1 项条件跳过；Desktop unit 通过（94.5s）。

pnpm --filter desktop run typecheck
结果：通过。

pnpm check:dco
结果：通过，当前 PR 仅 1 个提交且包含与 author 一致的 Signed-off-by
```

### 手工验证

- macOS 功能 worktree 开发版，Remote passive 模式，共享当前登录态和本地数据
- `pnpm desktop:whoami` 确认运行来源与 worktree / commit / ready 状态一致
- 用户实际体验任务切换后确认没有问题

### 未执行的验证

- 未做 Windows 实机目检；改动使用平台无关的 Renderer / IPC 逻辑，Windows 由 CI 单元测试和类型检查继续覆盖

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：异步首屏提交与后台历史补齐的竞态风险

### 影响与回滚

- 影响范围：Desktop Renderer 任务消息加载、侧栏任务点击，以及 main 进程 `messages:list` 的外部 CLI 历史导入门控
- 回滚 / 降级方式：回退本 PR 即恢复原先一次性提交首屏、60 秒缓存和逐次元数据 / importer 查询行为；不涉及数据迁移或持久格式变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增用户文档）
- [x] 已确认测试结果或说明未执行原因
