### PR TITLE
fix(codex): 屏蔽重复的 Sky Computer Use 能力

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/capabilityRouting.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/capabilityRouting.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { CapabilityRoutingPolicy } from '@cindy/maker-core';
+
+import { buildDesktopCapabilityRoutingPolicy } from '../capability-routing.js';
+
+function computerUseRoutes(policy: CapabilityRoutingPolicy) {
+  return policy.overrides.filter((route) => route.capabilityId === 'computer-use');
+}
+
+describe('desktop Computer Use capability routing', () => {
+  it('keeps only the node_repl compatibility restriction before Cindy Computer Use is applied', () => {
+    const routes = computerUseRoutes(
+      buildDesktopCapabilityRoutingPolicy({
+        cindyComputerAvailable: false,
+      }),
+    );
+
+    expect(routes).toEqual([
+      expect.objectContaining({
+        source: expect.objectContaining({
+          surface: 'skill',
+          id: 'computer-use:computer-use',
+          containerId: 'computer-use@openai-bundled',
+        }),
+        invocation: 'disabled',
+      }),
+    ]);
+  });
+
+  it('disables the downstream plugin only after cindy_computer is applied', () => {
+    const routes = computerUseRoutes(
+      buildDesktopCapabilityRoutingPolicy({
+        cindyComputerAvailable: true,
+      }),
+    );
+
+    expect(routes).toHaveLength(2);
+    expect(routes[1]).toMatchObject({
+      source: {
+        surface: 'plugin',
+        id: 'computer-use@openai-bundled',
+      },
+      invocation: 'disabled',
+      replacement: {
+        kind: 'cindy-host',
+        id: 'cindy_computer',
+      },
+    });
+  });
+});

--- a/apps/desktop/src/main/maker-host/capability-routing.ts
+++ b/apps/desktop/src/main/maker-host/capability-routing.ts
@@ -1,4 +1,23 @@
-import type { CapabilityRoutingPolicy } from '@cindy/maker-core';
+import type {
+  CapabilityRouteOverride,
+  CapabilityRoutingPolicy,
+} from '@cindy/maker-core';
+
+const CODEX_COMPUTER_USE_REPLACEMENT_ROUTE = {
+  capabilityId: 'computer-use',
+  source: {
+    kind: 'harness-plugin',
+    harness: 'codex',
+    surface: 'plugin',
+    id: 'computer-use@openai-bundled',
+  },
+  invocation: 'disabled',
+  replacement: {
+    kind: 'cindy-host',
+    id: 'cindy_computer',
+  },
+  reason: 'Cindy owns desktop-control enablement, permissions, and execution.',
+} as const satisfies CapabilityRouteOverride;
 
 /**
  * Product-level arbitration for capability sources that collide inside Cindy.
@@ -95,20 +114,41 @@ export const DESKTOP_CAPABILITY_ROUTING_POLICY = {
       },
       reason: 'The downstream Feishu account must not be used without an explicit source choice.',
     },
+    // The bundled Skill requires node_repl, which Cindy's Codex host does not
+    // expose. Keep this compatibility restriction independent from whether the
+    // user enabled Cindy's own Computer Use replacement.
     {
       capabilityId: 'computer-use',
       source: {
         kind: 'harness-plugin',
         harness: 'codex',
-        surface: 'plugin',
-        id: 'computer-use@openai-bundled',
+        surface: 'skill',
+        id: 'computer-use:computer-use',
+        artifactId: 'computer-use',
+        containerId: 'computer-use@openai-bundled',
       },
       invocation: 'disabled',
-      replacement: {
-        kind: 'cindy-host',
-        id: 'cindy_computer',
-      },
-      reason: 'Cindy owns desktop-control enablement, permissions, and execution.',
+      reason: 'The bundled Skill requires node_repl, which is unavailable in Cindy.',
     },
   ],
 } as const satisfies CapabilityRoutingPolicy;
+
+/**
+ * Freeze the routing policy for one Codex session.
+ *
+ * Disabling the downstream plugin is replacement arbitration, so it only
+ * applies after the current Codex environment actually exposes cindy_computer.
+ * The base policy still hides the incompatible node_repl Skill when the Cindy
+ * replacement is unavailable, without changing the plugin-wide setting.
+ */
+export function buildDesktopCapabilityRoutingPolicy(opts: {
+  cindyComputerAvailable: boolean;
+}): CapabilityRoutingPolicy {
+  if (!opts.cindyComputerAvailable) return DESKTOP_CAPABILITY_ROUTING_POLICY;
+  return {
+    overrides: [
+      ...DESKTOP_CAPABILITY_ROUTING_POLICY.overrides,
+      CODEX_COMPUTER_USE_REPLACEMENT_ROUTE,
+    ],
+  };
+}

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -144,6 +144,7 @@ import {
 import { cleanupComputerDriverSession } from '../mcp-integrations/computer.js';
 import { createPluginRegistry, resetPluginRegistry } from './plugins/index.js';
 import {
+  getActiveCodexBridgeServerNames,
   getCodexExtraSpawnConfig,
   registerCodexMcpThreadContext,
   setCodexEnvironmentShutdownHook,
@@ -185,7 +186,10 @@ import {
 } from './mcp-tool-approval-policy.js';
 import { mapCodexAppServerModelsToCatalog } from './codex-model-discovery.js';
 import { prepareSharedProjectSkillLinks } from './shared-global-skills.js';
-import { DESKTOP_CAPABILITY_ROUTING_POLICY } from './capability-routing.js';
+import {
+  buildDesktopCapabilityRoutingPolicy,
+  DESKTOP_CAPABILITY_ROUTING_POLICY,
+} from './capability-routing.js';
 export { withRehydrateCloseSuppressed };
 
 type RemoteCcQuery = Awaited<
@@ -980,7 +984,15 @@ export function getMaker(): Maker {
       // codex 子进程没法消费 in-process JS instance, prepareCodexExtraSpawnConfig
       // 起 streamable-HTTP bridge 把 instance 通过 -c 'mcp_servers...=...' 注入。
       mcpProviders: codexMcpProviders,
-      capabilityRouting: DESKTOP_CAPABILITY_ROUTING_POLICY,
+      // Evaluate after app-server startup prepared (or reused) the MCP bridge.
+      // The bridge snapshot is the applied capability surface; the preference
+      // alone can be ahead of it while a busy Codex turn defers refresh.
+      get capabilityRouting() {
+        return buildDesktopCapabilityRoutingPolicy({
+          cindyComputerAvailable:
+            getActiveCodexBridgeServerNames()?.includes('cindy_computer') === true,
+        });
+      },
       makerMemory: makerMemoryManager,
       // 通讯录 prompt 段有效状态(codex 版): 在 claude 的判定链之上再与「实际应用
       // 到 running app-server 的 spawn 快照」对齐 —— 开关切换后失效失败(busy,

--- a/packages/maker-core/src/agents/codex/capability-routing.test.ts
+++ b/packages/maker-core/src/agents/codex/capability-routing.test.ts
@@ -4,8 +4,67 @@ import type { CapabilityRoutingPolicy } from '../../types/capability-routing.js'
 import {
   buildCodexCapabilityConfigOverrides,
   buildCodexCapabilitySkillConfigOverrides,
+  buildCodexSessionCapabilityRoutingPolicy,
   requiresCodexCapabilitySkillDiscovery,
 } from './capability-routing.js';
+
+describe('buildCodexSessionCapabilityRoutingPolicy', () => {
+  const compatibilityRoute = {
+    capabilityId: 'computer-use',
+    source: {
+      kind: 'harness-plugin',
+      harness: 'codex',
+      surface: 'skill',
+      id: 'computer-use:computer-use',
+      artifactId: 'computer-use',
+      containerId: 'computer-use@openai-bundled',
+    },
+    invocation: 'disabled',
+  } as const;
+  const localReplacementRoute = {
+    capabilityId: 'computer-use',
+    source: {
+      kind: 'harness-plugin',
+      harness: 'codex',
+      surface: 'plugin',
+      id: 'computer-use@openai-bundled',
+    },
+    invocation: 'disabled',
+    replacement: { kind: 'cindy-host', id: 'cindy_computer' },
+  } as const;
+  const pluginReplacementRoute = {
+    capabilityId: 'example',
+    source: {
+      kind: 'harness-plugin',
+      harness: 'codex',
+      surface: 'plugin',
+      id: 'example@personal',
+    },
+    invocation: 'disabled',
+    replacement: { kind: 'cindy-plugin', id: 'example' },
+  } as const;
+  const policy = {
+    overrides: [
+      compatibilityRoute,
+      localReplacementRoute,
+      pluginReplacementRoute,
+    ],
+  } as const satisfies CapabilityRoutingPolicy;
+
+  it('preserves local-host replacement arbitration for local Codex', () => {
+    expect(buildCodexSessionCapabilityRoutingPolicy(policy, {
+      cindyHostReplacementsAvailable: true,
+    })).toBe(policy);
+  });
+
+  it('removes only unavailable Cindy-host replacements for remote Codex', () => {
+    expect(buildCodexSessionCapabilityRoutingPolicy(policy, {
+      cindyHostReplacementsAvailable: false,
+    })).toEqual({
+      overrides: [compatibilityRoute, pluginReplacementRoute],
+    });
+  });
+});
 
 describe('buildCodexCapabilityConfigOverrides', () => {
   it('disables the selected Codex plugin with a per-thread config override', () => {
@@ -263,6 +322,26 @@ describe('buildCodexCapabilitySkillConfigOverrides', () => {
     });
   });
 
+  it('matches bundled marketplace snapshots without disabling namesakes', () => {
+    const macSnapshotPath =
+      '/Users/dash/.codex/.tmp/bundled-marketplaces/openai-bundled/plugins/computer-use/skills/computer-use/SKILL.md';
+    const windowsSnapshotPath =
+      'C:\\Users\\dash\\.codex\\.tmp\\bundled-marketplaces\\openai-bundled.staging-123\\plugins\\computer-use\\skills\\computer-use\\SKILL.md';
+    expect(buildCodexCapabilitySkillConfigOverrides(disabledSkillPolicy, [
+      { path: macSnapshotPath, enabled: true },
+      { path: windowsSnapshotPath, enabled: true },
+      {
+        path: '/Users/dash/.codex/skills/computer-use/SKILL.md',
+        enabled: true,
+      },
+    ])).toEqual({
+      'skills.config': [
+        { path: macSnapshotPath, enabled: false },
+        { path: windowsSnapshotPath, enabled: false },
+      ],
+    });
+  });
+
   it('disables only the selected incompatible Skill without disabling its plugin', () => {
     expect(requiresCodexCapabilitySkillDiscovery(disabledSkillPolicy)).toBe(true);
     expect(buildCodexCapabilityConfigOverrides(disabledSkillPolicy)).toEqual({});
@@ -310,6 +389,24 @@ describe('buildCodexCapabilitySkillConfigOverrides', () => {
 
     expect(() => buildCodexCapabilitySkillConfigOverrides(invalidPolicy, []))
       .toThrowError(/expected plugin id in <name>@<marketplace> form/);
+  });
+
+  it('identifies a missing plugin source id in the error', () => {
+    const invalidPolicy = {
+      overrides: [{
+        capabilityId: 'example',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'codex',
+          surface: 'plugin',
+          id: '',
+        },
+        invocation: 'disabled',
+      }],
+    } as const satisfies CapabilityRoutingPolicy;
+
+    expect(() => buildCodexCapabilitySkillConfigOverrides(invalidPolicy, []))
+      .toThrowError(/source\.id is required/);
   });
 
   it('fails closed when a disabled Skill lacks precise plugin provenance', () => {

--- a/packages/maker-core/src/agents/codex/capability-routing.test.ts
+++ b/packages/maker-core/src/agents/codex/capability-routing.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
 import type { CapabilityRoutingPolicy } from '../../types/capability-routing.js';
-import { buildCodexCapabilityConfigOverrides } from './capability-routing.js';
+import {
+  buildCodexCapabilityConfigOverrides,
+  buildCodexCapabilitySkillConfigOverrides,
+  requiresCodexCapabilitySkillDiscovery,
+} from './capability-routing.js';
 
 describe('buildCodexCapabilityConfigOverrides', () => {
   it('disables the selected Codex plugin with a per-thread config override', () => {
@@ -176,5 +180,188 @@ describe('buildCodexCapabilityConfigOverrides', () => {
         isolatedPluginOverlays: false,
       }),
     ).toThrowError(/source\.containerId is required/);
+  });
+});
+
+describe('buildCodexCapabilitySkillConfigOverrides', () => {
+  const disabledPluginPolicy = {
+    overrides: [
+      {
+        capabilityId: 'computer-use',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'codex',
+          surface: 'plugin',
+          id: 'computer-use@openai-bundled',
+        },
+        invocation: 'disabled',
+      },
+    ],
+  } as const satisfies CapabilityRoutingPolicy;
+
+  const disabledSkillPolicy = {
+    overrides: [
+      {
+        capabilityId: 'computer-use',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'codex',
+          surface: 'skill',
+          id: 'computer-use:computer-use',
+          artifactId: 'computer-use',
+          containerId: 'computer-use@openai-bundled',
+        },
+        invocation: 'disabled',
+      },
+    ],
+  } as const satisfies CapabilityRoutingPolicy;
+
+  it('disables matching plugin Skills and preserves existing disabled Skills', () => {
+    expect(requiresCodexCapabilitySkillDiscovery(disabledPluginPolicy)).toBe(true);
+    expect(buildCodexCapabilitySkillConfigOverrides(disabledPluginPolicy, [
+      {
+        path: '/Users/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+        enabled: true,
+      },
+      {
+        path: '/Users/dash/.codex/skills/already-disabled/SKILL.md',
+        enabled: false,
+      },
+      {
+        path: '/Users/dash/.codex/plugins/cache/openai-bundled/browser/1.0.0/skills/browser/SKILL.md',
+        enabled: true,
+      },
+    ])).toEqual({
+      'skills.config': [
+        {
+          path: '/Users/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+          enabled: false,
+        },
+        {
+          path: '/Users/dash/.codex/skills/already-disabled/SKILL.md',
+          enabled: false,
+        },
+      ],
+    });
+  });
+
+  it('matches remote Windows plugin cache paths without disabling namesakes', () => {
+    expect(buildCodexCapabilitySkillConfigOverrides(disabledPluginPolicy, [
+      {
+        path: 'C:\\Users\\dash\\.codex\\plugins\\cache\\openai-bundled\\computer-use\\1.0.0\\skills\\computer-use\\SKILL.md',
+        enabled: true,
+      },
+      {
+        path: 'C:\\Users\\dash\\.codex\\skills\\computer-use\\SKILL.md',
+        enabled: true,
+      },
+    ])).toEqual({
+      'skills.config': [{
+        path: 'C:\\Users\\dash\\.codex\\plugins\\cache\\openai-bundled\\computer-use\\1.0.0\\skills\\computer-use\\SKILL.md',
+        enabled: false,
+      }],
+    });
+  });
+
+  it('disables only the selected incompatible Skill without disabling its plugin', () => {
+    expect(requiresCodexCapabilitySkillDiscovery(disabledSkillPolicy)).toBe(true);
+    expect(buildCodexCapabilityConfigOverrides(disabledSkillPolicy)).toEqual({});
+    expect(buildCodexCapabilitySkillConfigOverrides(disabledSkillPolicy, [
+      {
+        path: '/Users/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+        enabled: true,
+      },
+      {
+        path: '/Users/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/setup/SKILL.md',
+        enabled: true,
+      },
+      {
+        path: '/Users/dash/.codex/skills/computer-use/SKILL.md',
+        enabled: true,
+      },
+    ])).toEqual({
+      'skills.config': [{
+        path: '/Users/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+        enabled: false,
+      }],
+    });
+  });
+
+  it('does not replace the base skills config when the plugin contributes no Skills', () => {
+    expect(buildCodexCapabilitySkillConfigOverrides(disabledPluginPolicy, [{
+      path: '/Users/dash/.codex/skills/already-disabled/SKILL.md',
+      enabled: false,
+    }])).toEqual({});
+  });
+
+  it('fails closed when a disabled plugin id has no marketplace provenance', () => {
+    const invalidPolicy = {
+      overrides: [{
+        capabilityId: 'example',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'codex',
+          surface: 'plugin',
+          id: 'plugin-without-marketplace',
+        },
+        invocation: 'disabled',
+      }],
+    } as const satisfies CapabilityRoutingPolicy;
+
+    expect(() => buildCodexCapabilitySkillConfigOverrides(invalidPolicy, []))
+      .toThrowError(/expected plugin id in <name>@<marketplace> form/);
+  });
+
+  it('fails closed when a disabled Skill lacks precise plugin provenance', () => {
+    const noContainer = {
+      overrides: [{
+        capabilityId: 'example',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'codex',
+          surface: 'skill',
+          id: 'example:skill',
+          artifactId: 'skill',
+        },
+        invocation: 'disabled',
+      }],
+    } as const satisfies CapabilityRoutingPolicy;
+    const noArtifact = {
+      overrides: [{
+        capabilityId: 'example',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'codex',
+          surface: 'skill',
+          id: 'example:skill',
+          containerId: 'example@marketplace',
+        },
+        invocation: 'disabled',
+      }],
+    } as const satisfies CapabilityRoutingPolicy;
+
+    expect(() => buildCodexCapabilitySkillConfigOverrides(noContainer, []))
+      .toThrowError(/source\.containerId is required/);
+    expect(() => buildCodexCapabilitySkillConfigOverrides(noArtifact, []))
+      .toThrowError(/source\.artifactId is required/);
+  });
+
+  it('skips discovery for unrelated routing policies', () => {
+    const unrelatedPolicy = {
+      overrides: [{
+        capabilityId: 'computer-use',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'claude-code',
+          surface: 'plugin',
+          id: 'computer-use@openai-bundled',
+        },
+        invocation: 'disabled',
+      }],
+    } as const satisfies CapabilityRoutingPolicy;
+
+    expect(requiresCodexCapabilitySkillDiscovery(unrelatedPolicy)).toBe(false);
+    expect(buildCodexCapabilitySkillConfigOverrides(unrelatedPolicy, []))
+      .toEqual({});
   });
 });

--- a/packages/maker-core/src/agents/codex/capability-routing.ts
+++ b/packages/maker-core/src/agents/codex/capability-routing.ts
@@ -34,6 +34,11 @@ export interface CodexCapabilityRoutingOptions {
   isolatedPluginOverlays?: boolean;
 }
 
+export interface CodexSessionCapabilityRoutingOptions {
+  /** Whether this Codex host can invoke replacements served by Cindy itself. */
+  cindyHostReplacementsAvailable: boolean;
+}
+
 /**
  * Codex thread config accepts flattened TOML paths. Plugin config names contain
  * `@`, so they must be rendered as quoted dotted-key segments.
@@ -73,13 +78,14 @@ function parseCodexPluginCacheIdentity(
   };
 }
 
-function isSkillFromPluginCache(
+function isSkillFromPluginDistribution(
   skillPath: string,
   target: CodexSkillDisableTarget,
 ): boolean {
   const segments = skillPath.replace(/\\/g, '/').split('/');
-  for (let index = 0; index + 6 < segments.length; index += 1) {
+  for (let index = 0; index < segments.length; index += 1) {
     if (
+      index + 6 < segments.length &&
       segments[index] === 'plugins' &&
       segments[index + 1] === 'cache' &&
       segments[index + 2] === target.plugin.marketplace &&
@@ -91,8 +97,40 @@ function isSkillFromPluginCache(
     ) {
       return true;
     }
+    const bundledMarketplace = segments[index + 1];
+    if (
+      index + 5 < segments.length &&
+      segments[index] === 'bundled-marketplaces' &&
+      (bundledMarketplace === target.plugin.marketplace ||
+        bundledMarketplace?.startsWith(
+          `${target.plugin.marketplace}.staging-`,
+        )) &&
+      segments[index + 2] === 'plugins' &&
+      segments[index + 3] === target.plugin.pluginName &&
+      segments[index + 4] === 'skills' &&
+      (target.skillArtifactId === undefined ||
+        segments[index + 5] === target.skillArtifactId)
+    ) {
+      return true;
+    }
   }
   return false;
+}
+
+/**
+ * Remove replacement-arbitration routes that the selected Codex host cannot
+ * satisfy. Compatibility-only restrictions without a replacement remain in
+ * force, so remote sessions still hide Skills that depend on unavailable APIs.
+ */
+export function buildCodexSessionCapabilityRoutingPolicy(
+  policy: CapabilityRoutingPolicy | undefined,
+  opts: CodexSessionCapabilityRoutingOptions,
+): CapabilityRoutingPolicy | undefined {
+  if (opts.cindyHostReplacementsAvailable || !policy) return policy;
+  const overrides = policy.overrides.filter(
+    (directive) => directive.replacement?.kind !== 'cindy-host',
+  );
+  return overrides.length === policy.overrides.length ? policy : { overrides };
 }
 
 /** Whether a session must inspect Codex's effective Skill catalog before start. */
@@ -124,8 +162,11 @@ export function buildCodexCapabilitySkillConfigOverrides(
       ? directive.source.id
       : directive.source.containerId;
     if (!pluginId) {
+      const requiredField = directive.source.surface === 'plugin'
+        ? 'source.id'
+        : 'source.containerId';
       throw new Error(
-        `Cannot disable Codex Skill ${directive.source.id}: source.containerId is required`,
+        `Cannot disable Codex Skill ${directive.source.id}: ${requiredField} is required`,
       );
     }
     const plugin = parseCodexPluginCacheIdentity(pluginId);
@@ -152,7 +193,7 @@ export function buildCodexCapabilitySkillConfigOverrides(
   const routedSkillPaths = skills
     .filter((skill) =>
       targets.some((target) =>
-        isSkillFromPluginCache(skill.path, target),
+        isSkillFromPluginDistribution(skill.path, target),
       ),
     )
     .map((skill) => skill.path);

--- a/packages/maker-core/src/agents/codex/capability-routing.ts
+++ b/packages/maker-core/src/agents/codex/capability-routing.ts
@@ -5,6 +5,22 @@ import type {
 
 const CODEX_HARNESS_ID = 'codex';
 
+interface CodexSkillState {
+  path: string;
+  enabled: boolean;
+}
+
+interface CodexPluginCacheIdentity {
+  pluginName: string;
+  marketplace: string;
+}
+
+interface CodexSkillDisableTarget {
+  plugin: CodexPluginCacheIdentity;
+  /** Undefined means every Skill contributed by the plugin. */
+  skillArtifactId?: string;
+}
+
 export interface CodexCapabilityRoutingOptions {
   /**
    * Whether the host prepared a provenance-preserving plugin overlay for this
@@ -33,6 +49,124 @@ function isCodexHarnessPluginDirective(
     directive.source.kind === 'harness-plugin' &&
     directive.source.harness === CODEX_HARNESS_ID
   );
+}
+
+function isDisabledCodexSkillSourceDirective(
+  directive: CapabilityRouteOverride,
+): boolean {
+  return (
+    isCodexHarnessPluginDirective(directive) &&
+    (directive.source.surface === 'plugin' ||
+      directive.source.surface === 'skill') &&
+    directive.invocation === 'disabled'
+  );
+}
+
+function parseCodexPluginCacheIdentity(
+  pluginId: string,
+): CodexPluginCacheIdentity | null {
+  const separator = pluginId.lastIndexOf('@');
+  if (separator <= 0 || separator === pluginId.length - 1) return null;
+  return {
+    pluginName: pluginId.slice(0, separator),
+    marketplace: pluginId.slice(separator + 1),
+  };
+}
+
+function isSkillFromPluginCache(
+  skillPath: string,
+  target: CodexSkillDisableTarget,
+): boolean {
+  const segments = skillPath.replace(/\\/g, '/').split('/');
+  for (let index = 0; index + 6 < segments.length; index += 1) {
+    if (
+      segments[index] === 'plugins' &&
+      segments[index + 1] === 'cache' &&
+      segments[index + 2] === target.plugin.marketplace &&
+      segments[index + 3] === target.plugin.pluginName &&
+      segments[index + 4] !== '' &&
+      segments[index + 5] === 'skills' &&
+      (target.skillArtifactId === undefined ||
+        segments[index + 6] === target.skillArtifactId)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Whether a session must inspect Codex's effective Skill catalog before start. */
+export function requiresCodexCapabilitySkillDiscovery(
+  policy: CapabilityRoutingPolicy | undefined,
+): boolean {
+  return policy?.overrides.some(isDisabledCodexSkillSourceDirective) ?? false;
+}
+
+/**
+ * Hide a selected plugin Skill, or every Skill from a disabled plugin.
+ *
+ * Codex 0.145 keeps plugin Skills enabled in the model-facing catalog even
+ * when the plugin-wide `enabled` override is false. `skills.config` is the
+ * supported per-Skill control. Cindy also uses the same narrow control when a
+ * specific downstream Skill depends on a host interface that is unavailable.
+ * Derive paths from app-server's own catalog rather than guessing local or
+ * remote homes. Existing disabled Skills in this cwd are carried forward
+ * because the per-thread array may replace the base array.
+ */
+export function buildCodexCapabilitySkillConfigOverrides(
+  policy: CapabilityRoutingPolicy | undefined,
+  skills: readonly CodexSkillState[],
+): Record<string, unknown> {
+  const targets: CodexSkillDisableTarget[] = [];
+  for (const directive of policy?.overrides ?? []) {
+    if (!isDisabledCodexSkillSourceDirective(directive)) continue;
+    const pluginId = directive.source.surface === 'plugin'
+      ? directive.source.id
+      : directive.source.containerId;
+    if (!pluginId) {
+      throw new Error(
+        `Cannot disable Codex Skill ${directive.source.id}: source.containerId is required`,
+      );
+    }
+    const plugin = parseCodexPluginCacheIdentity(pluginId);
+    if (!plugin) {
+      throw new Error(
+        `Cannot enforce disabled Codex Skill routing for ${directive.source.id}: expected plugin id in <name>@<marketplace> form`,
+      );
+    }
+    const skillArtifactId = directive.source.surface === 'skill'
+      ? directive.source.artifactId
+      : undefined;
+    if (directive.source.surface === 'skill' && !skillArtifactId) {
+      throw new Error(
+        `Cannot disable Codex Skill ${directive.source.id}: source.artifactId is required`,
+      );
+    }
+    targets.push({
+      plugin,
+      ...(skillArtifactId ? { skillArtifactId } : {}),
+    });
+  }
+  if (targets.length === 0) return {};
+
+  const routedSkillPaths = skills
+    .filter((skill) =>
+      targets.some((target) =>
+        isSkillFromPluginCache(skill.path, target),
+      ),
+    )
+    .map((skill) => skill.path);
+  if (routedSkillPaths.length === 0) return {};
+
+  const disabledPaths = new Set([
+    ...skills.filter((skill) => !skill.enabled).map((skill) => skill.path),
+    ...routedSkillPaths,
+  ]);
+  return {
+    'skills.config': [...disabledPaths]
+      .sort()
+      .map((skillPath) => ({ path: skillPath, enabled: false })),
+  };
 }
 
 /**

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -786,7 +786,7 @@ describe('CodexAgent capability routing', () => {
     ).rejects.toThrow('requires Codex app-server 0.145.0 or newer');
   });
 
-  it('disables an explicit-only plugin on remote Codex where the local overlay is unavailable', async () => {
+  it('keeps remote Computer Use available without a local host replacement', async () => {
     const agent = new CodexAgent(createDeps({}, { capabilityRouting }));
     const host = installFakeHost(agent, (method, params) => {
       if (method !== Method.SkillsList) return undefined;
@@ -819,7 +819,6 @@ describe('CodexAgent capability routing', () => {
 
     expect(params.config).toMatchObject({
       'plugins."feishu-delegate@personal".enabled': false,
-      'plugins."computer-use@openai-bundled".enabled': false,
       'skills.config': [{
         path: 'C:\\Users\\dash\\.codex\\plugins\\cache\\openai-bundled\\computer-use\\1.0.0\\skills\\computer-use\\SKILL.md',
         enabled: false,
@@ -827,6 +826,9 @@ describe('CodexAgent capability routing', () => {
     });
     expect(params.config).not.toHaveProperty(
       'plugins."feishu-delegate@personal".mcp_servers."cindy-routed-feishu-delegate".default_tools_approval_mode',
+    );
+    expect(params.config).not.toHaveProperty(
+      'plugins."computer-use@openai-bundled".enabled',
     );
 
     await handle.close();

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -353,6 +353,12 @@ function installFakeHost(
         cwd: '/repo',
       };
     }
+    if (method === Method.SkillsList) {
+      const { cwds = ['/repo'] } = params as { cwds?: string[] };
+      return {
+        data: cwds.map((cwd) => ({ cwd, skills: [], errors: [] })),
+      };
+    }
     if (method === Method.ThreadFork) {
       return {
         thread: { id: 'fork-thread-id' },
@@ -559,6 +565,18 @@ describe('CodexAgent capability routing', () => {
         source: {
           kind: 'harness-plugin',
           harness: 'codex',
+          surface: 'skill',
+          id: 'computer-use:computer-use',
+          artifactId: 'computer-use',
+          containerId: 'computer-use@openai-bundled',
+        },
+        invocation: 'disabled',
+      },
+      {
+        capabilityId: 'computer-use',
+        source: {
+          kind: 'harness-plugin',
+          harness: 'codex',
           surface: 'plugin',
           id: 'computer-use@openai-bundled',
         },
@@ -572,8 +590,34 @@ describe('CodexAgent capability routing', () => {
   } as const;
 
   it('applies host-owned plugin policy to new and resumed Codex 0.145 threads', async () => {
+    const listComputerUseSkill = (method: string, params: unknown) => {
+      if (method !== Method.SkillsList) return undefined;
+      const { cwds = ['/repo'] } = params as { cwds?: string[] };
+      return {
+        data: cwds.map((cwd) => ({
+          cwd,
+          skills: [
+            {
+              name: 'computer-use:computer-use',
+              description: 'Control local Mac apps',
+              path: '/home/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+              scope: 'user',
+              enabled: true,
+            },
+            {
+              name: 'disabled-user-skill',
+              description: 'Already disabled by the user',
+              path: '/home/dash/.codex/skills/disabled-user-skill/SKILL.md',
+              scope: 'user',
+              enabled: false,
+            },
+          ],
+          errors: [],
+        })),
+      };
+    };
     const startAgent = new CodexAgent(createDeps({}, { capabilityRouting }));
-    const startHost = installFakeHost(startAgent, undefined, {
+    const startHost = installFakeHost(startAgent, listComputerUseSkill, {
       userAgent: 'mock-codex/0.145.0',
     });
     const startHandle = await startAgent.startSession({
@@ -589,10 +633,25 @@ describe('CodexAgent capability routing', () => {
       'plugins."feishu-delegate@personal".mcp_servers."feishu-delegate".enabled': false,
       'plugins."feishu-delegate@personal".mcp_servers."cindy-routed-feishu-delegate".default_tools_approval_mode':
         'prompt',
+      'skills.config': [
+        {
+          path: '/home/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+          enabled: false,
+        },
+        {
+          path: '/home/dash/.codex/skills/disabled-user-skill/SKILL.md',
+          enabled: false,
+        },
+      ],
     });
+    expect(startHost.request).toHaveBeenCalledWith(Method.SkillsList, {
+      cwds: ['/repo'],
+      forceReload: false,
+      perCwdExtraUserRoots: null,
+    }, { timeoutMs: 60_000 });
 
     const resumeAgent = new CodexAgent(createDeps({}, { capabilityRouting }));
-    const resumeHost = installFakeHost(resumeAgent, undefined, {
+    const resumeHost = installFakeHost(resumeAgent, listComputerUseSkill, {
       userAgent: 'mock-codex/0.145.0',
     });
     const resumeHandle = await resumeAgent.startSession({
@@ -609,10 +668,107 @@ describe('CodexAgent capability routing', () => {
       'plugins."feishu-delegate@personal".mcp_servers."feishu-delegate".enabled': false,
       'plugins."feishu-delegate@personal".mcp_servers."cindy-routed-feishu-delegate".default_tools_approval_mode':
         'prompt',
+      'skills.config': [
+        {
+          path: '/home/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+          enabled: false,
+        },
+        {
+          path: '/home/dash/.codex/skills/disabled-user-skill/SKILL.md',
+          enabled: false,
+        },
+      ],
     });
 
     await startHandle.close();
     await resumeHandle.close();
+  });
+
+  it('keeps the plugin enabled when Cindy Computer Use is unavailable but hides its incompatible Skill', async () => {
+    const compatibilityOnlyRouting = {
+      overrides: [capabilityRouting.overrides[1]],
+    } as const;
+    const agent = new CodexAgent(createDeps({}, {
+      capabilityRouting: compatibilityOnlyRouting,
+    }));
+    const host = installFakeHost(agent, (method, params) => {
+      if (method !== Method.SkillsList) return undefined;
+      const { cwds = ['/repo'] } = params as { cwds?: string[] };
+      return {
+        data: cwds.map((cwd) => ({
+          cwd,
+          skills: [{
+            name: 'computer-use:computer-use',
+            description: 'Control local Mac apps',
+            path: '/home/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+            scope: 'user',
+            enabled: true,
+          }],
+          errors: [],
+        })),
+      };
+    }, {
+      userAgent: 'mock-codex/0.145.0',
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-capability-routing-compatibility-only',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const params = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { config?: Record<string, unknown> };
+
+    expect(params.config).toMatchObject({
+      'skills.config': [{
+        path: '/home/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md',
+        enabled: false,
+      }],
+    });
+    expect(params.config).not.toHaveProperty(
+      'plugins."computer-use@openai-bundled".enabled',
+    );
+
+    await handle.close();
+  });
+
+  it('disables a restricted Skill path even when catalog parsing reports it as an error', async () => {
+    const compatibilityOnlyRouting = {
+      overrides: [capabilityRouting.overrides[1]],
+    } as const;
+    const agent = new CodexAgent(createDeps({}, {
+      capabilityRouting: compatibilityOnlyRouting,
+    }));
+    const brokenSkillPath =
+      '/home/dash/.codex/plugins/cache/openai-bundled/computer-use/1.0.0/skills/computer-use/SKILL.md';
+    const host = installFakeHost(agent, (method, params) => {
+      if (method !== Method.SkillsList) return undefined;
+      const { cwds = ['/repo'] } = params as { cwds?: string[] };
+      return {
+        data: cwds.map((cwd) => ({
+          cwd,
+          skills: [],
+          errors: [{ path: brokenSkillPath, message: 'invalid metadata' }],
+        })),
+      };
+    }, {
+      userAgent: 'mock-codex/0.145.0',
+    });
+
+    const handle = await agent.startSession({
+      sessionId: 'session-capability-routing-broken-skill',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    });
+    const params = host.request.mock.calls.find(
+      ([method]) => method === Method.ThreadStart,
+    )?.[1] as { config?: Record<string, unknown> };
+
+    expect(params.config).toMatchObject({
+      'skills.config': [{ path: brokenSkillPath, enabled: false }],
+    });
+    await handle.close();
   });
 
   it('fails closed for older Codex daemons that cannot apply plugin overrides', async () => {
@@ -632,7 +788,23 @@ describe('CodexAgent capability routing', () => {
 
   it('disables an explicit-only plugin on remote Codex where the local overlay is unavailable', async () => {
     const agent = new CodexAgent(createDeps({}, { capabilityRouting }));
-    const host = installFakeHost(agent, undefined, {
+    const host = installFakeHost(agent, (method, params) => {
+      if (method !== Method.SkillsList) return undefined;
+      const { cwds = ['/repo'] } = params as { cwds?: string[] };
+      return {
+        data: cwds.map((cwd) => ({
+          cwd,
+          skills: [{
+            name: 'computer-use:computer-use',
+            description: 'Control remote desktop apps',
+            path: 'C:\\Users\\dash\\.codex\\plugins\\cache\\openai-bundled\\computer-use\\1.0.0\\skills\\computer-use\\SKILL.md',
+            scope: 'user',
+            enabled: true,
+          }],
+          errors: [],
+        })),
+      };
+    }, {
       userAgent: 'mock-codex/0.145.0',
     });
     const handle = await agent.startSession({
@@ -648,12 +820,36 @@ describe('CodexAgent capability routing', () => {
     expect(params.config).toMatchObject({
       'plugins."feishu-delegate@personal".enabled': false,
       'plugins."computer-use@openai-bundled".enabled': false,
+      'skills.config': [{
+        path: 'C:\\Users\\dash\\.codex\\plugins\\cache\\openai-bundled\\computer-use\\1.0.0\\skills\\computer-use\\SKILL.md',
+        enabled: false,
+      }],
     });
     expect(params.config).not.toHaveProperty(
       'plugins."feishu-delegate@personal".mcp_servers."cindy-routed-feishu-delegate".default_tools_approval_mode',
     );
 
     await handle.close();
+  });
+
+  it('fails closed when restricted Skill discovery is unavailable', async () => {
+    const agent = new CodexAgent(createDeps({}, { capabilityRouting }));
+    installFakeHost(agent, (method) => {
+      if (method === Method.SkillsList) {
+        throw new Error('skills/list unavailable');
+      }
+      return undefined;
+    }, {
+      userAgent: 'mock-codex/0.145.0',
+    });
+
+    await expect(agent.startSession({
+      sessionId: 'session-capability-routing-skill-discovery-failure',
+      model: 'gpt-5.4',
+      workingDir: '/repo',
+    })).rejects.toThrow(
+      'Cannot start Codex safely because Cindy could not inspect restricted Codex Skills: skills/list unavailable',
+    );
   });
 
   it('declines an explicit-only downstream MCP unless the user chose that source', async () => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -101,6 +101,7 @@ import { buildCodexEnv } from './env-builder.js';
 import {
   buildCodexCapabilityConfigOverrides,
   buildCodexCapabilitySkillConfigOverrides,
+  buildCodexSessionCapabilityRoutingPolicy,
   requiresCodexCapabilitySkillDiscovery,
 } from './capability-routing.js';
 import { scanCodexCustomizations } from './customization-scanner.js';
@@ -2960,7 +2961,15 @@ export class CodexAgent extends BaseAgent {
       : credentialMode ?? this.hostEffectiveCredentialModes.get(currentHostKey);
     const approvalsReviewerProtocolSupported =
       supportsCodexApprovalsReviewerProtocol(initResp.userAgent);
-    const capabilityRoutingPolicy = this.deps.capabilityRouting;
+    const capabilityRoutingPolicy = buildCodexSessionCapabilityRoutingPolicy(
+      this.deps.capabilityRouting,
+      {
+        // Remote Codex does not receive the local Cindy MCP bridge. Keep
+        // compatibility restrictions, but do not disable a remote capability
+        // in favor of a replacement that only exists on the local host.
+        cindyHostReplacementsAvailable: !opts.remoteHostId,
+      },
+    );
     let capabilityRoutingConfig = buildCodexCapabilityConfigOverrides(
       capabilityRoutingPolicy,
       {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -98,7 +98,11 @@ import {
   parseOverloadError,
 } from '../shared/overload-error.js';
 import { buildCodexEnv } from './env-builder.js';
-import { buildCodexCapabilityConfigOverrides } from './capability-routing.js';
+import {
+  buildCodexCapabilityConfigOverrides,
+  buildCodexCapabilitySkillConfigOverrides,
+  requiresCodexCapabilitySkillDiscovery,
+} from './capability-routing.js';
 import { scanCodexCustomizations } from './customization-scanner.js';
 import { commandExecutionDisplayInput } from './command-display.js';
 import {
@@ -1364,11 +1368,23 @@ export class CodexAgent extends BaseAgent {
     forceReload: boolean,
   ): Promise<{ skills: SkillMetadata[]; errors: Array<{ path?: string; message: string }> }> {
     const { host } = await this.getUtilityHost();
-    const response = await host.request<SkillsListResponse>(Method.SkillsList, {
+    return await this.listSkillsForHost(host, workingDir, forceReload);
+  }
+
+  private async listSkillsForHost(
+    host: AppServerHost,
+    workingDir: string,
+    forceReload: boolean,
+    timeoutMs?: number,
+  ): Promise<{ skills: SkillMetadata[]; errors: Array<{ path?: string; message: string }> }> {
+    const params = {
       cwds: [workingDir],
       forceReload,
       perCwdExtraUserRoots: null,
-    });
+    };
+    const response = timeoutMs == null
+      ? await host.request<SkillsListResponse>(Method.SkillsList, params)
+      : await host.request<SkillsListResponse>(Method.SkillsList, params, { timeoutMs });
     const entry = response.data.find((item) => item.cwd === workingDir) ?? response.data[0];
     return {
       skills: entry?.skills ?? [],
@@ -2945,7 +2961,7 @@ export class CodexAgent extends BaseAgent {
     const approvalsReviewerProtocolSupported =
       supportsCodexApprovalsReviewerProtocol(initResp.userAgent);
     const capabilityRoutingPolicy = this.deps.capabilityRouting;
-    const capabilityRoutingConfig = buildCodexCapabilityConfigOverrides(
+    let capabilityRoutingConfig = buildCodexCapabilityConfigOverrides(
       capabilityRoutingPolicy,
       {
         // Remote Codex uses its own isolated CODEX_HOME. Cindy currently
@@ -2954,6 +2970,35 @@ export class CodexAgent extends BaseAgent {
         isolatedPluginOverlays: !opts.remoteHostId,
       },
     );
+    if (requiresCodexCapabilitySkillDiscovery(capabilityRoutingPolicy)) {
+      try {
+        assertCurrentHost('capability Skill discovery');
+        const { skills, errors } = await this.listSkillsForHost(
+          host,
+          opts.workingDir,
+          false,
+          CRITICAL_THREAD_RPC_TIMEOUT_MS,
+        );
+        assertCurrentHost('capability Skill discovery');
+        capabilityRoutingConfig = {
+          ...capabilityRoutingConfig,
+          ...buildCodexCapabilitySkillConfigOverrides(capabilityRoutingPolicy, [
+            ...skills,
+            // A malformed restricted Skill may be absent from `skills` while
+            // its concrete SKILL.md path is still reported here. Disable that
+            // path too instead of failing open on a catalog parse error.
+            ...errors.flatMap((error) =>
+              error.path ? [{ path: error.path, enabled: true }] : [],
+            ),
+          ]),
+        };
+      } catch (error) {
+        releaseHostBindingLeaseIfNeeded();
+        throw new Error(
+          `Cannot start Codex safely because Cindy could not inspect restricted Codex Skills: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
     const capabilityRoutingProtocolSupported =
       supportsCodexCapabilityRoutingProtocol(initResp.userAgent);
     if (
@@ -5138,7 +5183,7 @@ export class CodexAgent extends BaseAgent {
       }
 
       const capabilityRoute = findCapabilityRouteOverride(
-        this.deps.capabilityRouting,
+        capabilityRoutingPolicy,
         {
           harness: 'codex',
           surface: 'mcp',


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Cindy 已提供本机 Computer Use 时，Codex 仍向模型暴露 bundled Sky Computer Use Skill 的重复能力问题。

Codex 0.145 中，单独设置 `plugins."computer-use@openai-bundled".enabled=false` 并不会隐藏插件贡献的 Skill。本 PR 在每个 Codex session 启动时读取 app-server 的实际 Skill catalog，并用路径级 `skills.config` 精确关闭 bundled Skill；当 `cindy_computer` 已实际挂到当前 bridge 时，再同步关闭整套 bundled plugin。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：本地巡检发现 Sky Computer Use 与 Cindy Computer Use 重复暴露
- 本 PR 包含：Codex plugin / Skill 路由仲裁、session 启动期 Skill discovery、macOS / Windows / 远程路径匹配及回归测试
- 明确不包含：system prompt 修改、Computer Use driver 行为修改、UI 或设置项修改
- 用户可见变化：Cindy Computer Use 可用时，Codex 不再看到或调用 Sky Computer Use；不可用时仍隐藏依赖 `node_repl`、在 Cindy 宿主中无法运行的 bundled Skill，但不关闭整个 plugin
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-codex-computer-use-routing
结果：GATE_EXIT=0，根级 pnpm test:unit 全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：该 package 没有 typecheck script，按仓库门禁规则跳过

pnpm exec vitest run src/agents/codex/capability-routing.test.ts src/agents/codex/index.test.ts
结果：397 tests passed

pnpm exec vitest run src/main/maker-host/__tests__/capabilityRouting.test.ts
结果：2 tests passed

pnpm check:dco
结果：1 commit signed off
```

### 手工验证

使用仓库固定的 Codex 0.145.0 执行 `debug prompt-input`：

- 仅设置 plugin `enabled=false` 时，`computer-use:computer-use` 仍出现在模型可见 Skill 列表中。
- 同时设置对应路径的 `skills.config enabled=false` 后，Sky Computer Use 不再出现在 prompt 中。
- 冷进程基准中，plugin-only 中位 789ms，plugin + Skill config 中位 853ms；该逻辑只在 session 启动时多一次 `skills/list`，不增加每轮调用。

### 未执行的验证

未启动完整 Desktop 开发版做 UI 目检；本 PR 不涉及 UI，核心行为已通过 Codex prompt 实测与 maker-core / Desktop 单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：Codex session 启动期能力路由

### 影响与回滚

- 影响范围：Codex 0.145+ session 启动时的 capability config；Claude、PI、system prompt、translator、usage 计量均不受影响。存量插件影响：无，不改安装布局、批准状态、manifest 或插件缓存内容。
- 回滚 / 降级方式：回滚本提交即可恢复原先仅按 plugin config 路由的行为。Skill discovery 失败时当前实现 fail-closed，拒绝启动受限 session，避免重复能力静默泄漏。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外用户文档）
- [x] 已确认测试结果或说明未执行原因
