### PR TITLE
feat(ghost): 插件新增权限后引导用户重新授权

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
@@ -111,7 +111,7 @@ describe('isScopeStale', () => {
       { id: 'acc-old', scopeStale: false },
       { id: 'acc-bad', scopeStale: false },
     ]);
-    expect(mgr.defaultScopeStaleness(GHOST, KEY, expanded)).toBeNull();
+    expect(mgr.defaultMissingScopes(GHOST, KEY, expanded)).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
@@ -9,7 +9,7 @@ import {
   GHOST_OAUTH_INVALID_GRANT_RECHECK_DELAY_MS,
   GHOST_OAUTH_MAX_ACCOUNTS,
   GhostOauthAccountManager,
-  isScopeStale,
+  missingAuthScopes,
   type GhostOauthDecl,
   type GhostOauthVault,
 } from '../ghostOauthAccounts.js';
@@ -79,7 +79,7 @@ function seededVault(rt = 'rt-seed'): ReturnType<typeof memoryVault> {
   });
 }
 
-describe('isScopeStale', () => {
+describe('missingAuthScopes(快照推断)', () => {
   it.each([
     ['全量快照没有新增 scope', ['scope.a'], { authFace: 'full', authScopes: ['scope.a'] }, false],
     [
@@ -97,7 +97,7 @@ describe('isScopeStale', () => {
     ['老账号无快照不猜', ['scope.a', 'scope.b'], {}, false],
     ['只有 scope 面没有 full 标记不猜', ['scope.a', 'scope.b'], { authScopes: ['scope.a'] }, false],
   ] as const)('%s', (_name, declScopes, row, expected) => {
-    expect(isScopeStale(declScopes, row)).toBe(expected);
+    expect(missingAuthScopes(declScopes, row).length > 0).toBe(expected);
   });
 
   it('老清单与非法快照继续宽松读取，不误报陈旧授权', () => {
@@ -220,7 +220,7 @@ describe('isScopeStale', () => {
     ['纯空白', ['   ']],
     ['单项超长', ['x'.repeat(257)]],
     ['条数超限', Array.from({ length: 65 }, (_, index) => `scope.${index}`)],
-  ])('%s 的持久化错误证据按 undefined 读取', (_name, insufficientScopes) => {
+  ])('%s 的持久化坏证据对判定惰性(按当前声明过滤,不整包丢弃)', (_name, insufficientScopes) => {
     const vault = memoryVault({
       [`${KEY}-accounts`]: JSON.stringify({
         defaultAccountId: 'acc-1',
@@ -294,8 +294,11 @@ describe('isScopeStale', () => {
       openExternal: vi.fn(),
     });
 
-    expect(mgr.reportInsufficientScopes(GHOST, KEY, ['scope.a', 'scope.b', 'scope.b'])).toBe(true);
-    expect(mgr.reportInsufficientScopes(GHOST, KEY, ['scope.b'])).toBe(true);
+    const decl = ['scope.a', 'scope.b'];
+    expect(mgr.reportInsufficientScopes(GHOST, KEY, ['scope.a', 'scope.b', 'scope.b'], decl)).toBe(
+      'stored',
+    );
+    expect(mgr.reportInsufficientScopes(GHOST, KEY, ['scope.b'], decl)).toBe('unchanged');
     const accounts = JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts;
     expect(accounts[0]).not.toHaveProperty('insufficientScopes');
     expect(accounts[1].insufficientScopes).toEqual(['scope.a', 'scope.b']);
@@ -304,8 +307,36 @@ describe('isScopeStale', () => {
         vault: memoryVault(),
         fetchImpl: vi.fn() as unknown as typeof fetch,
         openExternal: vi.fn(),
-      }).reportInsufficientScopes(GHOST, KEY, ['scope.a']),
+      }).reportInsufficientScopes(GHOST, KEY, ['scope.a'], decl),
     ).toBe(false);
+  });
+
+  it('合并时按当前声明面裁剪,清单换代后的过期证据被淘汰,条数不越积越多', () => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-1',
+        accounts: [
+          {
+            id: 'acc-1',
+            label: 'a@example.com',
+            status: 'connected',
+            createdAt: 1,
+            insufficientScopes: ['scope.old', 'scope.b'],
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+
+    expect(mgr.reportInsufficientScopes(GHOST, KEY, ['scope.c'], ['scope.b', 'scope.c'])).toBe(
+      'stored',
+    );
+    const accounts = JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts;
+    expect(accounts[0].insufficientScopes).toEqual(['scope.b', 'scope.c']);
   });
 });
 
@@ -1624,9 +1655,7 @@ describe('identity.displayTemplate 展示名', () => {
       read: baseVault.read,
       remove: baseVault.remove,
       store: (ghostId, storageKey, value) =>
-        storageKey === `${KEY}-accounts`
-          ? false
-          : baseVault.store(ghostId, storageKey, value),
+        storageKey === `${KEY}-accounts` ? false : baseVault.store(ghostId, storageKey, value),
     };
     const mgr = new GhostOauthAccountManager({
       vault,

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
@@ -27,8 +27,12 @@ const DECL: GhostOauthDecl = {
   identity: { url: 'https://api.example.com/userinfo', labelPath: 'email' },
 };
 
-function memoryVault(seed?: Record<string, string>): GhostOauthVault & { data: Map<string, string> } {
-  const data = new Map<string, string>(Object.entries(seed ?? {}).map(([k, v]) => [`${GHOST}\u0000${k}`, v]));
+function memoryVault(
+  seed?: Record<string, string>,
+): GhostOauthVault & { data: Map<string, string> } {
+  const data = new Map<string, string>(
+    Object.entries(seed ?? {}).map(([k, v]) => [`${GHOST}\u0000${k}`, v]),
+  );
   return {
     data,
     read: (ghostId, key) => data.get(`${ghostId}\u0000${key}`) ?? null,
@@ -43,7 +47,10 @@ function memoryVault(seed?: Record<string, string>): GhostOauthVault & { data: M
 }
 
 function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } });
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
 /** 模拟浏览器:从授权 URL 提取回调地址与 state 并回打 code。 */
@@ -75,8 +82,18 @@ function seededVault(rt = 'rt-seed'): ReturnType<typeof memoryVault> {
 describe('isScopeStale', () => {
   it.each([
     ['全量快照没有新增 scope', ['scope.a'], { authFace: 'full', authScopes: ['scope.a'] }, false],
-    ['全量快照存在新增 scope', ['scope.a', 'scope.b'], { authFace: 'full', authScopes: ['scope.a'] }, true],
-    ['主动降面账号不猜', ['scope.a', 'scope.b'], { authFace: 'subset', authScopes: ['scope.a'] }, false],
+    [
+      '全量快照存在新增 scope',
+      ['scope.a', 'scope.b'],
+      { authFace: 'full', authScopes: ['scope.a'] },
+      true,
+    ],
+    [
+      '主动降面账号不猜',
+      ['scope.a', 'scope.b'],
+      { authFace: 'subset', authScopes: ['scope.a'] },
+      false,
+    ],
     ['老账号无快照不猜', ['scope.a', 'scope.b'], {}, false],
     ['只有 scope 面没有 full 标记不猜', ['scope.a', 'scope.b'], { authScopes: ['scope.a'] }, false],
   ] as const)('%s', (_name, declScopes, row, expected) => {
@@ -112,6 +129,183 @@ describe('isScopeStale', () => {
       { id: 'acc-bad', scopeStale: false },
     ]);
     expect(mgr.defaultMissingScopes(GHOST, KEY, expanded)).toEqual([]);
+  });
+
+  it('老账号无快照但有真实错误证据时触发建议与详情页角标', () => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-old',
+        accounts: [
+          {
+            id: 'acc-old',
+            label: 'old@example.com',
+            status: 'connected',
+            createdAt: 1,
+            insufficientScopes: ['scope.b'],
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+    const expanded = { ...DECL, scopes: ['scope.a', 'scope.b'] };
+
+    expect(mgr.defaultMissingScopes(GHOST, KEY, expanded)).toEqual(['scope.b']);
+    expect(mgr.listAccounts(GHOST, KEY, expanded)[0]?.scopeStale).toBe(true);
+  });
+
+  it('真实错误证据优先于快照推断；无证据时回退快照', () => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-1',
+        accounts: [
+          {
+            id: 'acc-1',
+            label: 'a@example.com',
+            status: 'connected',
+            createdAt: 1,
+            authScopes: ['scope.a'],
+            authFace: 'full',
+            insufficientScopes: ['scope.c'],
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+    const expanded = { ...DECL, scopes: ['scope.a', 'scope.b', 'scope.c'] };
+
+    expect(mgr.defaultMissingScopes(GHOST, KEY, expanded)).toEqual(['scope.c']);
+    const manifest = JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}');
+    delete manifest.accounts[0].insufficientScopes;
+    vault.store(GHOST, `${KEY}-accounts`, JSON.stringify(manifest));
+    expect(mgr.defaultMissingScopes(GHOST, KEY, expanded)).toEqual(['scope.b', 'scope.c']);
+  });
+
+  it('非法错误证据按 undefined 宽松读取，并回退快照推断', () => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-1',
+        accounts: [
+          {
+            id: 'acc-1',
+            label: 'a@example.com',
+            status: 'connected',
+            createdAt: 1,
+            authScopes: ['scope.a'],
+            authFace: 'full',
+            insufficientScopes: ['scope.b', 42],
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+
+    expect(
+      mgr.defaultMissingScopes(GHOST, KEY, { ...DECL, scopes: ['scope.a', 'scope.b'] }),
+    ).toEqual(['scope.b']);
+  });
+
+  it.each([
+    ['纯空白', ['   ']],
+    ['单项超长', ['x'.repeat(257)]],
+    ['条数超限', Array.from({ length: 65 }, (_, index) => `scope.${index}`)],
+  ])('%s 的持久化错误证据按 undefined 读取', (_name, insufficientScopes) => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-1',
+        accounts: [
+          {
+            id: 'acc-1',
+            label: 'a@example.com',
+            status: 'connected',
+            createdAt: 1,
+            insufficientScopes,
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+
+    expect(mgr.defaultMissingScopes(GHOST, KEY, DECL)).toEqual([]);
+  });
+
+  it('历史证据已不在当前声明时忽略，并回退快照推断', () => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-1',
+        accounts: [
+          {
+            id: 'acc-1',
+            label: 'a@example.com',
+            status: 'connected',
+            createdAt: 1,
+            authScopes: ['scope.a'],
+            authFace: 'full',
+            insufficientScopes: ['scope.removed'],
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+
+    expect(
+      mgr.defaultMissingScopes(GHOST, KEY, { ...DECL, scopes: ['scope.a', 'scope.b'] }),
+    ).toEqual(['scope.b']);
+  });
+
+  it('错误证据只合并到默认账号，重复上报去重', () => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-2',
+        accounts: [
+          { id: 'acc-1', label: 'one@example.com', status: 'connected', createdAt: 1 },
+          {
+            id: 'acc-2',
+            label: 'two@example.com',
+            status: 'connected',
+            createdAt: 2,
+            insufficientScopes: ['scope.a'],
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+
+    expect(mgr.reportInsufficientScopes(GHOST, KEY, ['scope.a', 'scope.b', 'scope.b'])).toBe(true);
+    expect(mgr.reportInsufficientScopes(GHOST, KEY, ['scope.b'])).toBe(true);
+    const accounts = JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts;
+    expect(accounts[0]).not.toHaveProperty('insufficientScopes');
+    expect(accounts[1].insufficientScopes).toEqual(['scope.a', 'scope.b']);
+    expect(
+      new GhostOauthAccountManager({
+        vault: memoryVault(),
+        fetchImpl: vi.fn() as unknown as typeof fetch,
+        openExternal: vi.fn(),
+      }).reportInsufficientScopes(GHOST, KEY, ['scope.a']),
+    ).toBe(false);
   });
 });
 
@@ -190,10 +384,12 @@ describe('connectAccount', () => {
     // 清单里不落任何令牌字节。
     expect(vault.read(GHOST, `${KEY}-accounts`)).not.toContain('rt-1');
     expect(vault.read(GHOST, `${KEY}-accounts`)).not.toContain('at-1');
-    expect(JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts[0]).toMatchObject({
+    const persistedAccount = JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts[0];
+    expect(persistedAccount).toMatchObject({
       authScopes: ['scope.a'],
       authFace: 'full',
     });
+    expect(persistedAccount).not.toHaveProperty('insufficientScopes');
 
     // 授权余温:access token 已进缓存,取用不再走网络。
     const fetchCalls = fetchImpl.mock.calls.length;
@@ -208,7 +404,11 @@ describe('connectAccount', () => {
     const fetchImpl = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
       if (url === DECL.tokenUrl) {
-        return jsonResponse({ access_token: 'at-stale', refresh_token: 'rt-stale', expires_in: 3600 });
+        return jsonResponse({
+          access_token: 'at-stale',
+          refresh_token: 'rt-stale',
+          expires_in: 3600,
+        });
       }
       if (url === DECL.identity?.url) {
         return jsonResponse({ email: 'stale@example.com' });
@@ -236,7 +436,11 @@ describe('connectAccount', () => {
   it('声明 avatarPath → 连接时下载头像存库(不带凭证),listAccounts 带 avatarDataUrl,断开清掉', async () => {
     const avatarDecl: GhostOauthDecl = {
       ...DECL,
-      identity: { url: 'https://api.example.com/userinfo', labelPath: 'email', avatarPath: 'picture' },
+      identity: {
+        url: 'https://api.example.com/userinfo',
+        labelPath: 'email',
+        avatarPath: 'picture',
+      },
     };
     const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
     const expectedDataUrl = `data:image/png;base64,${pngBytes.toString('base64')}`;
@@ -247,12 +451,18 @@ describe('connectAccount', () => {
         return jsonResponse({ access_token: 'at-1', refresh_token: 'rt-1', expires_in: 3600 });
       }
       if (url === 'https://api.example.com/userinfo') {
-        return jsonResponse({ email: 'user@example.com', picture: 'https://cdn.example.com/a.png' });
+        return jsonResponse({
+          email: 'user@example.com',
+          picture: 'https://cdn.example.com/a.png',
+        });
       }
       if (url === 'https://cdn.example.com/a.png') {
         // 头像下载绝不带 Authorization(CDN 域名不在凭证注入白名单)。
         expect(new Headers(init?.headers).get('Authorization')).toBeNull();
-        return new Response(new Uint8Array(pngBytes), { status: 200, headers: { 'Content-Type': 'image/png' } });
+        return new Response(new Uint8Array(pngBytes), {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        });
       }
       throw new Error(`unexpected fetch ${url}`);
     });
@@ -280,7 +490,11 @@ describe('connectAccount', () => {
     const avatarDecl: GhostOauthDecl = {
       ...DECL,
       clientId: 'cid-baked',
-      identity: { url: 'https://api.example.com/userinfo', labelPath: 'email', avatarPath: 'picture' },
+      identity: {
+        url: 'https://api.example.com/userinfo',
+        labelPath: 'email',
+        avatarPath: 'picture',
+      },
     };
     const fetchImpl = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
@@ -288,7 +502,10 @@ describe('connectAccount', () => {
         return jsonResponse({ access_token: 'at-1', refresh_token: 'rt-1', expires_in: 3600 });
       }
       if (url === 'https://api.example.com/userinfo') {
-        return jsonResponse({ email: 'user@example.com', picture: 'https://internal.example/secret.png' });
+        return jsonResponse({
+          email: 'user@example.com',
+          picture: 'https://internal.example/secret.png',
+        });
       }
       throw new Error(`unexpected fetch ${url}`);
     });
@@ -302,13 +519,19 @@ describe('connectAccount', () => {
     if (!result.ok) return;
     expect(result.account.avatarDataUrl).toBeNull();
     // 头像地址从未被主机请求过(fetch 只打过 token 与身份端点)。
-    expect(fetchImpl.mock.calls.map((c) => String(c[0]))).not.toContain('https://internal.example/secret.png');
+    expect(fetchImpl.mock.calls.map((c) => String(c[0]))).not.toContain(
+      'https://internal.example/secret.png',
+    );
   });
 
   it('头像下载失败 → 连接照常成功,avatarDataUrl 为 null(best-effort)', async () => {
     const avatarDecl: GhostOauthDecl = {
       ...DECL,
-      identity: { url: 'https://api.example.com/userinfo', labelPath: 'email', avatarPath: 'picture' },
+      identity: {
+        url: 'https://api.example.com/userinfo',
+        labelPath: 'email',
+        avatarPath: 'picture',
+      },
     };
     const fetchImpl = vi.fn(async (input: string | URL | Request) => {
       const url = String(input);
@@ -316,7 +539,10 @@ describe('connectAccount', () => {
         return jsonResponse({ access_token: 'at-1', refresh_token: 'rt-1', expires_in: 3600 });
       }
       if (url === 'https://api.example.com/userinfo') {
-        return jsonResponse({ email: 'user@example.com', picture: 'https://cdn.example.com/a.png' });
+        return jsonResponse({
+          email: 'user@example.com',
+          picture: 'https://cdn.example.com/a.png',
+        });
       }
       throw new Error('avatar cdn down');
     });
@@ -359,7 +585,11 @@ describe('connectAccount', () => {
     });
     const fetchImpl = vi.fn(async (input: string | URL | Request) => {
       if (String(input) === DECL.tokenUrl) {
-        return jsonResponse({ access_token: 'at-full', refresh_token: 'rt-full', expires_in: 3600 });
+        return jsonResponse({
+          access_token: 'at-full',
+          refresh_token: 'rt-full',
+          expires_in: 3600,
+        });
       }
       return jsonResponse({ email: 'brand-new@x.com' });
     });
@@ -437,7 +667,11 @@ describe('connectAccount', () => {
     });
     expect((await mgrNew.connectAccount(GHOST, KEY, DECL)).ok).toBe(true);
     expect(onNew).toHaveBeenCalledTimes(1);
-    expect(onNew).toHaveBeenCalledWith({ ghostId: GHOST, secretKey: KEY, label: 'user@example.com' });
+    expect(onNew).toHaveBeenCalledWith({
+      ghostId: GHOST,
+      secretKey: KEY,
+      label: 'user@example.com',
+    });
 
     // 同身份重连(合并):同样触发;钩子抛错不影响 ok 结果
     const onMerge = vi.fn(() => {
@@ -610,7 +844,9 @@ describe('getFreshAccessToken', () => {
     const onAccountStatusChanged = vi.fn();
     const mgr = new GhostOauthAccountManager({
       vault,
-      fetchImpl: vi.fn(async () => jsonResponse({ error: 'invalid_grant' }, 400)) as unknown as typeof fetch,
+      fetchImpl: vi.fn(async () =>
+        jsonResponse({ error: 'invalid_grant' }, 400),
+      ) as unknown as typeof fetch,
       openExternal: vi.fn(),
       sleep: instantSleep,
       onAccountStatusChanged,
@@ -682,7 +918,9 @@ describe('getFreshAccessToken', () => {
   it('瞬时刷新失败 → REFRESH_FAILED,账号不标过期', async () => {
     const mgr = new GhostOauthAccountManager({
       vault: seededVault(),
-      fetchImpl: vi.fn(async () => jsonResponse({ error: 'server_error' }, 500)) as unknown as typeof fetch,
+      fetchImpl: vi.fn(async () =>
+        jsonResponse({ error: 'server_error' }, 500),
+      ) as unknown as typeof fetch,
       openExternal: vi.fn(),
     });
     await expect(mgr.getFreshAccessToken(GHOST, KEY, DECL)).resolves.toMatchObject({
@@ -875,7 +1113,12 @@ describe('多实例共库的 RT 轮换竞态(invalid_grant 防误删)', () => {
       expect(params.refreshToken).toBe('rt-winner');
       return {
         ok: true as const,
-        bundle: { accessToken: 'at-bk2', refreshToken: null, expiresAt: Date.now() + 60_000, grantedScope: null },
+        bundle: {
+          accessToken: 'at-bk2',
+          refreshToken: null,
+          expiresAt: Date.now() + 60_000,
+          grantedScope: null,
+        },
       };
     });
     const mgr = new GhostOauthAccountManager({
@@ -1000,7 +1243,12 @@ describe('tokenBroker 模式', () => {
     const fetchImpl = vi.fn();
     const exchange = vi.fn(async () => ({
       ok: true as const,
-      bundle: { accessToken: 'at-bk', refreshToken: 'rt-bk', expiresAt: Date.now() + 60_000, grantedScope: null },
+      bundle: {
+        accessToken: 'at-bk',
+        refreshToken: 'rt-bk',
+        expiresAt: Date.now() + 60_000,
+        grantedScope: null,
+      },
     }));
     const mgr = new GhostOauthAccountManager({
       vault,
@@ -1128,7 +1376,9 @@ describe('brokerBounce(双地址弹跳回调)', () => {
       openExternal: openExternal1,
       broker: { exchange: vi.fn(), refresh: vi.fn() },
     });
-    await expect(mgrNoResolver.connectAccount(GHOST, KEY, bounceDecl(53699))).resolves.toMatchObject({
+    await expect(
+      mgrNoResolver.connectAccount(GHOST, KEY, bounceDecl(53699)),
+    ).resolves.toMatchObject({
       ok: false,
       error: 'INVALID_CONFIG',
     });
@@ -1143,7 +1393,9 @@ describe('brokerBounce(双地址弹跳回调)', () => {
       broker: { exchange: vi.fn(), refresh: vi.fn() },
       resolveBrokerPublicUrl: vi.fn(() => null),
     });
-    await expect(mgrNullResolver.connectAccount(GHOST, KEY, bounceDecl(53699))).resolves.toMatchObject({
+    await expect(
+      mgrNullResolver.connectAccount(GHOST, KEY, bounceDecl(53699)),
+    ).resolves.toMatchObject({
       ok: false,
       error: 'INVALID_CONFIG',
     });
@@ -1170,7 +1422,12 @@ describe('brokerBounce(双地址弹跳回调)', () => {
       expect(params.redirectUri).toBe(PUBLIC_URI);
       return {
         ok: true as const,
-        bundle: { accessToken: 'at-bb', refreshToken: 'rt-bb', expiresAt: Date.now() + 60_000, grantedScope: null },
+        bundle: {
+          accessToken: 'at-bb',
+          refreshToken: 'rt-bb',
+          expiresAt: Date.now() + 60_000,
+          grantedScope: null,
+        },
       };
     });
     const mgr = new GhostOauthAccountManager({
@@ -1278,7 +1535,11 @@ describe('identity.displayTemplate 展示名', () => {
     const onConnected = vi.fn();
     const mgr = new GhostOauthAccountManager({
       vault,
-      fetchImpl: slackFetch({ team: 'acme', user: 'devuser', user_id: 'U0EXAMPLE1' }) as unknown as typeof fetch,
+      fetchImpl: slackFetch({
+        team: 'acme',
+        user: 'devuser',
+        user_id: 'U0EXAMPLE1',
+      }) as unknown as typeof fetch,
       openExternal: autoBrowser(),
       onAccountConnected: onConnected,
     });
@@ -1291,9 +1552,16 @@ describe('identity.displayTemplate 展示名', () => {
     const manifest = JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}') as {
       accounts: Array<{ label: string; displayLabel: string }>;
     };
-    expect(manifest.accounts[0]).toMatchObject({ label: 'U0EXAMPLE1', displayLabel: 'acme · devuser' });
+    expect(manifest.accounts[0]).toMatchObject({
+      label: 'U0EXAMPLE1',
+      displayLabel: 'acme · devuser',
+    });
     // 授权成功提示用展示名。
-    expect(onConnected).toHaveBeenCalledWith({ ghostId: GHOST, secretKey: KEY, label: 'acme · devuser' });
+    expect(onConnected).toHaveBeenCalledWith({
+      ghostId: GHOST,
+      secretKey: KEY,
+      label: 'acme · devuser',
+    });
   });
 
   it('同身份重连:按稳定键合并到老账号(旧行 label 是 user_id),并补上展示名', async () => {
@@ -1301,13 +1569,25 @@ describe('identity.displayTemplate 展示名', () => {
       [`${KEY}-client-id`]: 'cid',
       [`${KEY}-accounts`]: JSON.stringify({
         defaultAccountId: 'acc-legacy',
-        accounts: [{ id: 'acc-legacy', label: 'U0EXAMPLE1', status: 'connected', createdAt: 1 }],
+        accounts: [
+          {
+            id: 'acc-legacy',
+            label: 'U0EXAMPLE1',
+            status: 'connected',
+            createdAt: 1,
+            insufficientScopes: ['scope.a'],
+          },
+        ],
       }),
       [`${KEY}-rt-acc-legacy`]: 'rt-old',
     });
     const mgr = new GhostOauthAccountManager({
       vault,
-      fetchImpl: slackFetch({ team: 'acme', user: 'devuser', user_id: 'U0EXAMPLE1' }) as unknown as typeof fetch,
+      fetchImpl: slackFetch({
+        team: 'acme',
+        user: 'devuser',
+        user_id: 'U0EXAMPLE1',
+      }) as unknown as typeof fetch,
       openExternal: autoBrowser(),
     });
     const result = await mgr.connectAccount(GHOST, KEY, SLACK_DECL);
@@ -1317,6 +1597,54 @@ describe('identity.displayTemplate 展示名', () => {
     expect(result.account.id).toBe('acc-legacy');
     expect(result.account.label).toBe('acme · devuser');
     expect(mgr.listAccounts(GHOST, KEY)).toHaveLength(1);
+    expect(JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts[0]).not.toHaveProperty(
+      'insufficientScopes',
+    );
+    expect(mgr.defaultMissingScopes(GHOST, KEY, SLACK_DECL)).toEqual([]);
+  });
+
+  it('同身份重连清除证据时账号清单写失败，返回 VAULT_WRITE_FAILED 而不假报成功', async () => {
+    const baseVault = memoryVault({
+      [`${KEY}-client-id`]: 'cid',
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-legacy',
+        accounts: [
+          {
+            id: 'acc-legacy',
+            label: 'U0EXAMPLE1',
+            status: 'connected',
+            createdAt: 1,
+            insufficientScopes: ['scope.a'],
+          },
+        ],
+      }),
+      [`${KEY}-rt-acc-legacy`]: 'rt-old',
+    });
+    const vault: GhostOauthVault = {
+      read: baseVault.read,
+      remove: baseVault.remove,
+      store: (ghostId, storageKey, value) =>
+        storageKey === `${KEY}-accounts`
+          ? false
+          : baseVault.store(ghostId, storageKey, value),
+    };
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: slackFetch({
+        team: 'acme',
+        user: 'devuser',
+        user_id: 'U0EXAMPLE1',
+      }) as unknown as typeof fetch,
+      openExternal: autoBrowser(),
+    });
+
+    await expect(mgr.connectAccount(GHOST, KEY, SLACK_DECL)).resolves.toMatchObject({
+      ok: false,
+      error: 'VAULT_WRITE_FAILED',
+    });
+    expect(JSON.parse(baseVault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts[0]).toMatchObject({
+      insufficientScopes: ['scope.a'],
+    });
   });
 
   it('模板占位符取不到值 → 展示名降级,view.label 回落稳定身份键', async () => {
@@ -1342,10 +1670,16 @@ describe('identity.displayTemplate 展示名', () => {
     });
     const mgr = new GhostOauthAccountManager({
       vault,
-      fetchImpl: slackFetch({ team: 'acme', user: 'devuser', user_id: 'U0EXAMPLE1' }) as unknown as typeof fetch,
+      fetchImpl: slackFetch({
+        team: 'acme',
+        user: 'devuser',
+        user_id: 'U0EXAMPLE1',
+      }) as unknown as typeof fetch,
       openExternal: vi.fn(),
     });
-    await expect(mgr.getFreshAccessToken(GHOST, KEY, SLACK_DECL)).resolves.toMatchObject({ ok: true });
+    await expect(mgr.getFreshAccessToken(GHOST, KEY, SLACK_DECL)).resolves.toMatchObject({
+      ok: true,
+    });
     // 回填是 fire-and-forget,轮询等它落库。
     await vi.waitFor(() => {
       expect(mgr.listAccounts(GHOST, KEY)[0]?.label).toBe('acme · devuser');
@@ -1358,7 +1692,13 @@ describe('identity.displayTemplate 展示名', () => {
       [`${KEY}-accounts`]: JSON.stringify({
         defaultAccountId: 'acc-1',
         accounts: [
-          { id: 'acc-1', label: 'U0EXAMPLE1', displayLabel: 'acme · devuser', status: 'connected', createdAt: 1 },
+          {
+            id: 'acc-1',
+            label: 'U0EXAMPLE1',
+            displayLabel: 'acme · devuser',
+            status: 'connected',
+            createdAt: 1,
+          },
         ],
       }),
       [`${KEY}-rt-acc-1`]: 'rt-old',
@@ -1369,7 +1709,9 @@ describe('identity.displayTemplate 展示名', () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
       openExternal: vi.fn(),
     });
-    await expect(mgr.getFreshAccessToken(GHOST, KEY, SLACK_DECL)).resolves.toMatchObject({ ok: true });
+    await expect(mgr.getFreshAccessToken(GHOST, KEY, SLACK_DECL)).resolves.toMatchObject({
+      ok: true,
+    });
     // 给潜在的异步回填一个宏任务窗口,再断言没有第二次网络调用。
     await new Promise((r) => setTimeout(r, 20));
     expect(fetchImpl).toHaveBeenCalledTimes(1);
@@ -1380,7 +1722,11 @@ describe('identity.displayTemplate 展示名', () => {
 describe('identity.avatarPath 头像回填', () => {
   const AVATAR_DECL: GhostOauthDecl = {
     ...DECL,
-    identity: { url: 'https://api.example.com/userinfo', labelPath: 'email', avatarPath: 'picture' },
+    identity: {
+      url: 'https://api.example.com/userinfo',
+      labelPath: 'email',
+      avatarPath: 'picture',
+    },
   };
   const PNG_BYTES = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
   const PNG_DATA_URL = `data:image/png;base64,${PNG_BYTES.toString('base64')}`;
@@ -1402,10 +1748,16 @@ describe('identity.avatarPath 头像回填', () => {
       const url = String(input);
       if (url === DECL.tokenUrl) return jsonResponse({ access_token: 'at-2', expires_in: 3600 });
       if (url === 'https://api.example.com/userinfo') {
-        return jsonResponse({ email: 'user@example.com', picture: 'https://cdn.example.com/a.png' });
+        return jsonResponse({
+          email: 'user@example.com',
+          picture: 'https://cdn.example.com/a.png',
+        });
       }
       if (url === 'https://cdn.example.com/a.png') {
-        return new Response(new Uint8Array(PNG_BYTES), { status: 200, headers: { 'Content-Type': 'image/png' } });
+        return new Response(new Uint8Array(PNG_BYTES), {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        });
       }
       throw new Error(`unexpected fetch ${url}`);
     });
@@ -1418,7 +1770,9 @@ describe('identity.avatarPath 头像回填', () => {
       fetchImpl: avatarFetch() as unknown as typeof fetch,
       openExternal: vi.fn(),
     });
-    await expect(mgr.getFreshAccessToken(GHOST, KEY, AVATAR_DECL)).resolves.toMatchObject({ ok: true });
+    await expect(mgr.getFreshAccessToken(GHOST, KEY, AVATAR_DECL)).resolves.toMatchObject({
+      ok: true,
+    });
     // 回填是 fire-and-forget,轮询等它落库。
     await vi.waitFor(() => {
       expect(vault.read(GHOST, `${KEY}-avatar-acc-1`)).toBe(PNG_DATA_URL);
@@ -1453,12 +1807,16 @@ describe('identity.avatarPath 头像回填', () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
       openExternal: vi.fn(),
     });
-    await expect(mgr.getFreshAccessToken('evil-tools', KEY, decl)).resolves.toMatchObject({ ok: true });
+    await expect(mgr.getFreshAccessToken('evil-tools', KEY, decl)).resolves.toMatchObject({
+      ok: true,
+    });
     // 等展示名回填落库,证明身份端点确实拉过了(而不是回填整体没跑)。
     await vi.waitFor(() => {
       expect(mgr.listAccounts('evil-tools', KEY)[0]?.label).toBe('user@example.com·bf');
     });
-    expect(fetchImpl.mock.calls.map((c) => String(c[0]))).not.toContain('https://cdn.example.com/a.png');
+    expect(fetchImpl.mock.calls.map((c) => String(c[0]))).not.toContain(
+      'https://cdn.example.com/a.png',
+    );
     expect(vault.read('evil-tools', `${KEY}-avatar-acc-1`)).toBeNull();
   });
 
@@ -1476,12 +1834,18 @@ describe('identity.avatarPath 头像回填', () => {
       const url = String(input);
       if (url === DECL.tokenUrl) return jsonResponse({ access_token: 'at-2', expires_in: 3600 });
       if (url === 'https://api.example.com/userinfo') {
-        return jsonResponse({ email: 'user@example.com', picture: 'https://cdn.example.com/a.png' });
+        return jsonResponse({
+          email: 'user@example.com',
+          picture: 'https://cdn.example.com/a.png',
+        });
       }
       if (url === 'https://cdn.example.com/a.png') {
         avatarRequestedResolve();
         await gate;
-        return new Response(new Uint8Array(PNG_BYTES), { status: 200, headers: { 'Content-Type': 'image/png' } });
+        return new Response(new Uint8Array(PNG_BYTES), {
+          status: 200,
+          headers: { 'Content-Type': 'image/png' },
+        });
       }
       throw new Error(`unexpected fetch ${url}`);
     });
@@ -1490,7 +1854,9 @@ describe('identity.avatarPath 头像回填', () => {
       fetchImpl: fetchImpl as unknown as typeof fetch,
       openExternal: vi.fn(),
     });
-    await expect(mgr.getFreshAccessToken(GHOST, KEY, AVATAR_DECL)).resolves.toMatchObject({ ok: true });
+    await expect(mgr.getFreshAccessToken(GHOST, KEY, AVATAR_DECL)).resolves.toMatchObject({
+      ok: true,
+    });
     // 等回填走到头像下载(此时被 gate 卡住),断开账号后再放行下载。
     await avatarRequested;
     mgr.disconnectAccount(GHOST, KEY, 'acc-1');

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthAccounts.test.ts
@@ -9,6 +9,7 @@ import {
   GHOST_OAUTH_INVALID_GRANT_RECHECK_DELAY_MS,
   GHOST_OAUTH_MAX_ACCOUNTS,
   GhostOauthAccountManager,
+  isScopeStale,
   type GhostOauthDecl,
   type GhostOauthVault,
 } from '../ghostOauthAccounts.js';
@@ -70,6 +71,49 @@ function seededVault(rt = 'rt-seed'): ReturnType<typeof memoryVault> {
     [`${KEY}-rt-acc-1`]: rt,
   });
 }
+
+describe('isScopeStale', () => {
+  it.each([
+    ['全量快照没有新增 scope', ['scope.a'], { authFace: 'full', authScopes: ['scope.a'] }, false],
+    ['全量快照存在新增 scope', ['scope.a', 'scope.b'], { authFace: 'full', authScopes: ['scope.a'] }, true],
+    ['主动降面账号不猜', ['scope.a', 'scope.b'], { authFace: 'subset', authScopes: ['scope.a'] }, false],
+    ['老账号无快照不猜', ['scope.a', 'scope.b'], {}, false],
+    ['只有 scope 面没有 full 标记不猜', ['scope.a', 'scope.b'], { authScopes: ['scope.a'] }, false],
+  ] as const)('%s', (_name, declScopes, row, expected) => {
+    expect(isScopeStale(declScopes, row)).toBe(expected);
+  });
+
+  it('老清单与非法快照继续宽松读取，不误报陈旧授权', () => {
+    const vault = memoryVault({
+      [`${KEY}-accounts`]: JSON.stringify({
+        defaultAccountId: 'acc-old',
+        accounts: [
+          { id: 'acc-old', label: 'old@example.com', status: 'connected', createdAt: 1 },
+          {
+            id: 'acc-bad',
+            label: 'bad@example.com',
+            status: 'connected',
+            createdAt: 2,
+            authScopes: ['scope.a', 42],
+            authFace: 'unknown',
+          },
+        ],
+      }),
+    });
+    const mgr = new GhostOauthAccountManager({
+      vault,
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: vi.fn(),
+    });
+    const expanded = { ...DECL, scopes: ['scope.a', 'scope.b'] };
+
+    expect(mgr.listAccounts(GHOST, KEY, expanded)).toMatchObject([
+      { id: 'acc-old', scopeStale: false },
+      { id: 'acc-bad', scopeStale: false },
+    ]);
+    expect(mgr.defaultScopeStaleness(GHOST, KEY, expanded)).toBeNull();
+  });
+});
 
 describe('connectAccount', () => {
   it('端口回收器只对第一方官方意识放行(第三方 redirectPort 不许借刀杀进程)', async () => {
@@ -138,13 +182,18 @@ describe('connectAccount', () => {
     expect(result.account.label).toBe('user@example.com');
     expect(result.account.isDefault).toBe(true);
     expect(result.account.status).toBe('connected');
+    expect(result.account.scopeStale).toBe(false);
 
-    const listed = mgr.listAccounts(GHOST, KEY);
+    const listed = mgr.listAccounts(GHOST, KEY, DECL);
     expect(listed).toHaveLength(1);
     expect(vault.read(GHOST, `${KEY}-rt-${result.account.id}`)).toBe('rt-1');
     // 清单里不落任何令牌字节。
     expect(vault.read(GHOST, `${KEY}-accounts`)).not.toContain('rt-1');
     expect(vault.read(GHOST, `${KEY}-accounts`)).not.toContain('at-1');
+    expect(JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts[0]).toMatchObject({
+      authScopes: ['scope.a'],
+      authFace: 'full',
+    });
 
     // 授权余温:access token 已进缓存,取用不再走网络。
     const fetchCalls = fetchImpl.mock.calls.length;
@@ -360,6 +409,10 @@ describe('connectAccount', () => {
     const listed = mgr.listAccounts(GHOST, KEY);
     expect(listed).toHaveLength(2);
     expect(vault.read(GHOST, `${KEY}-rt-acc-1`)).toBe('rt-fresh');
+    expect(JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts[0]).toMatchObject({
+      authScopes: ['scope.a'],
+      authFace: 'full',
+    });
     // 授权余温:合并账号的 access token 已进缓存。
     await expect(mgr.getFreshAccessToken(GHOST, KEY, DECL, 'acc-1')).resolves.toMatchObject({
       ok: true,
@@ -1153,8 +1206,9 @@ describe('connectAccount · opts.scopes 收窄', () => {
 
   it('声明子集 → 授权 URL 的 scope 面收窄为子集', async () => {
     let capturedScope: string | null = null;
+    const vault = memoryVault();
     const mgr = new GhostOauthAccountManager({
-      vault: memoryVault(),
+      vault,
       fetchImpl: vi.fn(async () =>
         jsonResponse({ access_token: 'at-narrow', refresh_token: 'rt-narrow', expires_in: 3600 }),
       ) as unknown as typeof fetch,
@@ -1167,6 +1221,16 @@ describe('connectAccount · opts.scopes 收窄', () => {
       mgr.connectAccount(GHOST, KEY, NARROW_DECL, { scopes: ['read:x'] }),
     ).resolves.toMatchObject({ ok: true });
     expect(capturedScope).toBe('read:x');
+    expect(JSON.parse(vault.read(GHOST, `${KEY}-accounts`) ?? '{}').accounts[0]).toMatchObject({
+      authScopes: ['read:x'],
+      authFace: 'subset',
+    });
+    expect(
+      mgr.listAccounts(GHOST, KEY, {
+        ...NARROW_DECL,
+        scopes: ['read:x', 'write:y', 'admin:z'],
+      })[0]?.scopeStale,
+    ).toBe(false);
   });
 
   it('含未声明条目 / 空数组 → INVALID_CONFIG,不拉浏览器', async () => {

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthScopeStaleness.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthScopeStaleness.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GhostManifest, GhostSetupAssessment } from '../../../shared/ghost.js';
+import {
+  appendReadyGhostOauthReauthSuggest,
+  findGhostOauthReauthSuggest,
+} from '../ghostOauthScopeStaleness.js';
+
+const MANIFEST: GhostManifest = {
+  schemaVersion: 2,
+  id: 'xd-feishu',
+  name: 'XD Feishu',
+  version: '2.3.0',
+  kind: 'chip',
+  entry: 'main.js',
+  slots: ['network'],
+  network: {
+    hosts: ['open.feishu.cn'],
+    secrets: [
+      {
+        key: 'feishu_account',
+        label: 'Feishu account',
+        source: 'oauth',
+        inject: { header: 'Authorization', format: 'Bearer {value}' },
+        oauth: {
+          authorizeUrl: 'https://accounts.feishu.cn/authorize',
+          tokenUrl: 'https://open.feishu.cn/token',
+          scopes: ['scope.old', 'scope.new'],
+        },
+      },
+    ],
+  },
+};
+
+const READY: GhostSetupAssessment = { state: 'ready', revision: 7, groups: [] };
+
+describe('OAuth scope stale runtime assessment', () => {
+  it('ready + 默认账号陈旧时附加非阻塞 reauthSuggest', () => {
+    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => ({
+      missingScopes: ['scope.new'],
+    }));
+
+    expect(appendReadyGhostOauthReauthSuggest(READY, suggest)).toEqual({
+      ...READY,
+      reauthSuggest: {
+        ghostId: 'xd-feishu',
+        secretKey: 'feishu_account',
+        missingScopes: ['scope.new'],
+        missingScopeCount: 1,
+        requirement: {
+          ref: 'secret:feishu_account',
+          kind: 'oauth',
+          label: 'Feishu account',
+          action: {
+            id: 'oauth_connect:secret:feishu_account',
+            kind: 'oauth_connect',
+          },
+        },
+      },
+    });
+  });
+
+  it.each([
+    ['非 stale', { missingScopes: [] }],
+    ['老账号无快照', null],
+  ] as const)('%s 时不附建议', (_name, staleness) => {
+    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => staleness);
+    expect(appendReadyGhostOauthReauthSuggest(READY, suggest)).toBe(READY);
+  });
+
+  it('setup required 时不附建议，不改变既有 gate 语义', () => {
+    const required: GhostSetupAssessment = {
+      state: 'required',
+      revision: 8,
+      groups: [],
+    };
+    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => ({
+      missingScopes: ['scope.new'],
+    }));
+
+    expect(appendReadyGhostOauthReauthSuggest(required, suggest)).toBe(required);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthScopeStaleness.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthScopeStaleness.test.ts
@@ -36,9 +36,7 @@ const READY: GhostSetupAssessment = { state: 'ready', revision: 7, groups: [] };
 
 describe('OAuth scope stale runtime assessment', () => {
   it('ready + 默认账号陈旧时附加非阻塞 reauthSuggest', () => {
-    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => ({
-      missingScopes: ['scope.new'],
-    }));
+    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => ['scope.new']);
 
     expect(appendReadyGhostOauthReauthSuggest(READY, suggest)).toEqual({
       ...READY,
@@ -60,11 +58,8 @@ describe('OAuth scope stale runtime assessment', () => {
     });
   });
 
-  it.each([
-    ['非 stale', { missingScopes: [] }],
-    ['老账号无快照', null],
-  ] as const)('%s 时不附建议', (_name, staleness) => {
-    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => staleness);
+  it('缺失面为空(非 stale / 老账号判不准)时不附建议', () => {
+    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => []);
     expect(appendReadyGhostOauthReauthSuggest(READY, suggest)).toBe(READY);
   });
 
@@ -74,9 +69,7 @@ describe('OAuth scope stale runtime assessment', () => {
       revision: 8,
       groups: [],
     };
-    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => ({
-      missingScopes: ['scope.new'],
-    }));
+    const suggest = findGhostOauthReauthSuggest(MANIFEST, () => ['scope.new']);
 
     expect(appendReadyGhostOauthReauthSuggest(required, suggest)).toBe(required);
   });

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupCoordinator.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupCoordinator.test.ts
@@ -306,6 +306,27 @@ describe('GhostSetupCoordinator', () => {
     expect(h.executeAction).not.toHaveBeenCalled();
   });
 
+  it('ready + reauthSuggest 但未带 plan 时不弹卡直接放行(建议非阻塞)', async () => {
+    const h = harness(readyWithReauth());
+    await expect(
+      h.coordinator.ensureReady({ sessionId: 'session-1', ghostId: 'gmail', tool: 'search' }),
+    ).resolves.toMatchObject({ ok: true, assessment: { state: 'ready' } });
+    expect(h.bridge.pendingSnapshots()).toEqual([]);
+  });
+
+  it('ready + reauthSuggest + plan 但无交互面(IM/定时任务)时丢弃 plan 放行，不拦成 SETUP_REQUIRED', async () => {
+    const h = harness(readyWithReauth());
+    await expect(
+      h.coordinator.ensureReady({
+        sessionId: null,
+        ghostId: 'gmail',
+        tool: 'search',
+        plan: reauthPlan(),
+      }),
+    ).resolves.toMatchObject({ ok: true, assessment: { state: 'ready' } });
+    expect(h.bridge.pendingSnapshots()).toEqual([]);
+  });
+
   it('ready 无 reauthSuggest 时忽略随调用携带的 plan，直接放行', async () => {
     const h = harness(ready(7));
     await expect(

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupCoordinator.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostSetupCoordinator.test.ts
@@ -54,6 +54,42 @@ function ready(revision = 1): GhostSetupAssessment {
   };
 }
 
+function readyWithReauth(revision = 7): GhostSetupAssessment {
+  return {
+    ...ready(revision),
+    reauthSuggest: {
+      ghostId: 'gmail',
+      secretKey: 'google',
+      missingScopes: ['scope.new'],
+      missingScopeCount: 1,
+      requirement: {
+        ref: 'secret:google',
+        kind: 'oauth',
+        label: 'Google 账号',
+        action: {
+          id: 'oauth_connect:secret:google',
+          kind: 'oauth_connect',
+        },
+      },
+    },
+  };
+}
+
+function reauthPlan(revision = 7): GhostSetupPlan {
+  return {
+    assessmentRevision: revision,
+    steps: [
+      {
+        id: 'reauth-google',
+        title: '重新连接账号',
+        description: '补齐新增权限',
+        requirementRefs: ['secret:google'],
+        actionId: 'oauth_connect:secret:google',
+      },
+    ],
+  };
+}
+
 function requiredInline(revision = 0): GhostSetupAssessment {
   return {
     state: 'required',
@@ -212,6 +248,110 @@ describe('GhostSetupCoordinator', () => {
     expect(h.bridge.pendingSnapshots()).toEqual([]);
   });
 
+  it('ready + reauthSuggest + 匹配 plan 复用交互卡，重连清除建议后放行调用', async () => {
+    const h = harness(readyWithReauth());
+    const waiting = h.coordinator.ensureReady({
+      sessionId: 'session-1',
+      ghostId: 'gmail',
+      tool: 'search',
+      plan: reauthPlan(),
+    });
+    await vi.waitFor(() => expect(h.bridge.pendingSnapshots()).toHaveLength(1));
+    const snapshot = h.bridge.pendingSnapshots()[0].request;
+    expect(snapshot.steps).toHaveLength(1);
+    expect(snapshot.steps[0]).toMatchObject({
+      title: '重新连接账号',
+      action: { id: 'oauth_connect:secret:google', kind: 'oauth_connect' },
+    });
+    h.executeAction.mockImplementationOnce(async () => {
+      h.setAssessment(ready(8));
+      h.changeBus.emit('gmail', { source: 'oauth', ref: 'google' });
+      return { ok: true };
+    });
+    h.bridge.resolve(snapshot.requestId, {
+      kind: 'plugin_setup',
+      action: 'run_action',
+      actionId: 'oauth_connect:secret:google',
+      expectedRevision: snapshot.revision,
+    });
+
+    await expect(waiting).resolves.toMatchObject({
+      ok: true,
+      assessment: { state: 'ready', revision: 8 },
+    });
+    expect(h.executeAction).toHaveBeenCalledOnce();
+  });
+
+  it('ready 重连卡取消沿用 SETUP_CANCELLED，本次调用不执行', async () => {
+    const h = harness(readyWithReauth());
+    const waiting = h.coordinator.ensureReady({
+      sessionId: 'session-1',
+      ghostId: 'gmail',
+      tool: 'search',
+      plan: reauthPlan(),
+    });
+    await vi.waitFor(() => expect(h.bridge.pendingSnapshots()).toHaveLength(1));
+    const snapshot = h.bridge.pendingSnapshots()[0].request;
+    h.bridge.resolve(snapshot.requestId, {
+      kind: 'plugin_setup',
+      action: 'cancel',
+      expectedRevision: snapshot.revision,
+    });
+
+    await expect(waiting).resolves.toEqual({
+      ok: false,
+      errorCode: 'SETUP_CANCELLED',
+      message: '用户取消了插件设置，本次调用未执行。',
+    });
+    expect(h.executeAction).not.toHaveBeenCalled();
+  });
+
+  it('ready 无 reauthSuggest 时忽略随调用携带的 plan，直接放行', async () => {
+    const h = harness(ready(7));
+    await expect(
+      h.coordinator.ensureReady({
+        sessionId: 'session-1',
+        ghostId: 'gmail',
+        tool: 'search',
+        plan: reauthPlan(),
+      }),
+    ).resolves.toMatchObject({ ok: true, assessment: { state: 'ready' } });
+    expect(h.bridge.pendingSnapshots()).toEqual([]);
+  });
+
+  it('ready 重连 plan 引用不匹配时拒绝 Agent 编排，回落 Host 默认单步卡', async () => {
+    const h = harness(readyWithReauth());
+    const invalidPlan: GhostSetupPlan = {
+      ...reauthPlan(),
+      steps: [
+        {
+          ...reauthPlan().steps[0],
+          requirementRefs: ['secret:other'],
+          actionId: 'oauth_connect:secret:other',
+        },
+      ],
+    };
+    const waiting = h.coordinator.ensureReady({
+      sessionId: 'session-1',
+      ghostId: 'gmail',
+      tool: 'search',
+      plan: invalidPlan,
+    });
+    await vi.waitFor(() => expect(h.bridge.pendingSnapshots()).toHaveLength(1));
+    const snapshot = h.bridge.pendingSnapshots()[0].request;
+    expect(snapshot.steps).toHaveLength(1);
+    expect(snapshot.steps[0]).toMatchObject({
+      title: 'Google 账号',
+      action: { id: 'oauth_connect:secret:google', kind: 'oauth_connect' },
+    });
+    h.bridge.resolve(snapshot.requestId, {
+      kind: 'plugin_setup',
+      action: 'cancel',
+      expectedRevision: snapshot.revision,
+    });
+    await waiting;
+  });
+
   it('submits inline Secret per request, re-assesses on change, and never snapshots the value', async () => {
     const h = harness(requiredInline());
     const waiting = h.coordinator.ensureReady({
@@ -305,10 +445,7 @@ describe('GhostSetupCoordinator', () => {
 
     const terminalSnapshots = h.broadcast.mock.calls
       .filter(([channel]) => channel === MAKER_PUSH.INTERACTION_REQUEST)
-      .map(
-        ([, payload]) =>
-          (payload as { request: GhostSetupInteractionSnapshot }).request,
-      )
+      .map(([, payload]) => (payload as { request: GhostSetupInteractionSnapshot }).request)
       .filter((request) => request.terminal === true);
     expect(terminalSnapshots).toHaveLength(1);
     expect(terminalSnapshots[0].steps).toEqual([
@@ -566,9 +703,7 @@ describe('GhostSetupCoordinator', () => {
 
     for (const release of releases) release();
     await vi.waitFor(() =>
-      expect(h.bridge.pendingSnapshots()[0].request.steps[0]?.phase).toBe(
-        'waiting_external',
-      ),
+      expect(h.bridge.pendingSnapshots()[0].request.steps[0]?.phase).toBe('waiting_external'),
     );
     const current = h.bridge.pendingSnapshots()[0].request;
     h.bridge.resolve(current.requestId, {
@@ -1031,13 +1166,13 @@ describe('GhostSetupCoordinator', () => {
     let disabledWorkdir: string | null = null;
     const validateTarget = vi.fn(
       (_ghostId: string, _tool: string | undefined, workingDir?: string | null) =>
-      workingDir === disabledWorkdir
-        ? ({
-            ok: false,
-            errorCode: 'GHOST_DISABLED_IN_WORKDIR',
-            message: '用户已在当前工作目录停用该插件;不要重试。',
-          } as const)
-        : ({ ok: true } as const),
+        workingDir === disabledWorkdir
+          ? ({
+              ok: false,
+              errorCode: 'GHOST_DISABLED_IN_WORKDIR',
+              message: '用户已在当前工作目录停用该插件;不要重试。',
+            } as const)
+          : ({ ok: true } as const),
     );
     const coordinator = new GhostSetupCoordinator({
       changeBus,

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -2149,7 +2149,9 @@ const r = await (await fetch('/oauth/acct/connect', connectInit)).json();
 await fetch('/oauth/acct/accounts/<accountId>', { method:'DELETE' });          // 204(幂等)
 await fetch('/oauth/acct/default', { method:'POST', body: JSON.stringify({ accountId }) });  // 204
 // 真实 API 返回缺失 scope 时可 fire-and-forget 上报；只接受清单 oauth.scopes 内的值,
-// 任一越界整包 400 拒绝。主机会据此在对话流与详情页非阻塞引导用户重新连接:
+// 任一越界整包 400 拒绝。主机会据此在对话流与详情页非阻塞引导用户重新连接。
+// 证据只记默认账号:带 authAccount 指定非默认账号的调用报错时不要上报,
+// 否则会引导用户重连错账号:
 await fetch('/oauth/acct/insufficient-scopes', { method:'POST', body: JSON.stringify({ scopes:['write.b'] }) });  // 204
 \`\`\`
 

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -26,10 +26,7 @@ import {
   validateGhostManifest,
   type GhostManifest,
 } from '../../shared/ghost.js';
-import {
-  GHOST_MANIFEST_MAX_BYTES,
-  readBoundedFileNoFollow,
-} from '../utils/readBoundedFile.js';
+import { GHOST_MANIFEST_MAX_BYTES, readBoundedFileNoFollow } from '../utils/readBoundedFile.js';
 import { validateGhostLocaleResourcesInDirectory } from './ghostLocaleFiles.js';
 import { GHOST_SIGNATURE_FILE } from './ghostSignature.js';
 import { checkSkillMdConsistency } from './skillSlot.js';
@@ -426,7 +423,11 @@ export async function scaffoldGhostDir(
   const resolved = path.resolve(input.dir);
   const workdir = options?.sessionWorkdir;
   if (!workdir) {
-    return { ok: false, errorCode: 'INVALID_INPUT', message: '没有会话工作目录,无法确定骨架输出位置' };
+    return {
+      ok: false,
+      errorCode: 'INVALID_INPUT',
+      message: '没有会话工作目录,无法确定骨架输出位置',
+    };
   }
   // 字面 startsWith 不设防软链:工作目录里若有 out -> /tmp/out 之类的
   // 软链祖先,字面在内、实际在外。两边都按 realpath 对账——目标还不存在,
@@ -435,7 +436,11 @@ export async function scaffoldGhostDir(
   try {
     realWorkdir = await fs.promises.realpath(path.resolve(workdir));
   } catch {
-    return { ok: false, errorCode: 'INVALID_INPUT', message: '会话工作目录不存在,无法确定骨架输出位置' };
+    return {
+      ok: false,
+      errorCode: 'INVALID_INPUT',
+      message: '会话工作目录不存在,无法确定骨架输出位置',
+    };
   }
   let realAncestor = resolved;
   const pendingSegments: string[] = [];
@@ -725,7 +730,10 @@ async function buildGhostPackage(
     const maxFiles = manifest.node ? MAX_NODE_FILES : MAX_BASIC_FILES;
     const maxTotalBytes = manifest.node ? MAX_NODE_TOTAL_BYTES : MAX_BASIC_TOTAL_BYTES;
     const seenPackPaths = new Set<string>();
-    const walk = async (cur: string, relBase: string): Promise<Exclude<ForgePackResult, { ok: true }> | null> => {
+    const walk = async (
+      cur: string,
+      relBase: string,
+    ): Promise<Exclude<ForgePackResult, { ok: true }> | null> => {
       const entries = await fs.promises.readdir(cur, { withFileTypes: true });
       for (const e of entries) {
         if (shouldSkip(e.name)) continue;
@@ -780,7 +788,8 @@ async function buildGhostPackage(
       return {
         ok: false,
         errorCode: 'MANIFEST_INVALID',
-        message: '已签名插件不能使用 AI 图标覆盖；请保留原图标，或先修改源码图标再由正式发布流水线重新签名',
+        message:
+          '已签名插件不能使用 AI 图标覆盖；请保留原图标，或先修改源码图标再由正式发布流水线重新签名',
       };
     }
     const foldedAiIconPath = FORGE_AI_ICON_PATH.toLowerCase();
@@ -2121,7 +2130,7 @@ settingsHtml 里自填**(用户用自己注册的 OAuth 应用,配额风控归�
 const list = await (await fetch('/oauth')).json();
 // → [{ key:'acct', clientConfigured:true, clientCustom:false, accounts:[{ id, label, status:'connected'|'expired', isDefault, createdAt, avatarDataUrl, scopeStale }] }]
 // avatarDataUrl = 头像 data URL(声明了 identity.avatarPath 且主机下载成功才有,否则 null;<img src> 直接用)
-// scopeStale = true 表示该全量授权账号未包含插件后来新增的 scope;账号仍可用,设置页应显示非阻塞提示并复用现有重新连接动作
+// scopeStale = true 表示该账号有真实权限错误证据,或其全量授权快照未包含插件后来新增的 scope;账号仍可用,设置页应显示非阻塞提示并复用现有重新连接动作
 // clientConfigured = 自填或内置任一在场;clientCustom = 用户自填过(UI 显示"内置应用身份/已自定义")
 // client 凭证只写入库(和 /secrets 同纪律,存入后拿不回;clientSecret 可省略 = 纯 PKCE):
 await fetch('/oauth/acct/client', { method:'PUT', body: JSON.stringify({ clientId, clientSecret }) });  // 204 即入库
@@ -2139,6 +2148,9 @@ const r = await (await fetch('/oauth/acct/connect', connectInit)).json();
 // 断开账号 / 设默认账号:
 await fetch('/oauth/acct/accounts/<accountId>', { method:'DELETE' });          // 204(幂等)
 await fetch('/oauth/acct/default', { method:'POST', body: JSON.stringify({ accountId }) });  // 204
+// 真实 API 返回缺失 scope 时可 fire-and-forget 上报；只接受清单 oauth.scopes 内的值,
+// 任一越界整包 400 拒绝。主机会据此在对话流与详情页非阻塞引导用户重新连接:
+await fetch('/oauth/acct/insufficient-scopes', { method:'POST', body: JSON.stringify({ scopes:['write.b'] }) });  // 204
 \`\`\`
 
 多账号:每个 oauth 凭证槽最多 8 个账号;cindy.fetch 可带 \`authAccount: '<账号id>'\`

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -2119,8 +2119,9 @@ settingsHtml 里自填**(用户用自己注册的 OAuth 应用,配额风控归�
 \`\`\`js
 // 状态回查(哪些 oauth 凭证槽、client 配没配、连了哪些账号;零令牌字节):
 const list = await (await fetch('/oauth')).json();
-// → [{ key:'acct', clientConfigured:true, clientCustom:false, accounts:[{ id, label, status:'connected'|'expired', isDefault, createdAt, avatarDataUrl }] }]
+// → [{ key:'acct', clientConfigured:true, clientCustom:false, accounts:[{ id, label, status:'connected'|'expired', isDefault, createdAt, avatarDataUrl, scopeStale }] }]
 // avatarDataUrl = 头像 data URL(声明了 identity.avatarPath 且主机下载成功才有,否则 null;<img src> 直接用)
+// scopeStale = true 表示该全量授权账号未包含插件后来新增的 scope;账号仍可用,设置页应显示非阻塞提示并复用现有重新连接动作
 // clientConfigured = 自填或内置任一在场;clientCustom = 用户自填过(UI 显示"内置应用身份/已自定义")
 // client 凭证只写入库(和 /secrets 同纪律,存入后拿不回;clientSecret 可省略 = 纯 PKCE):
 await fetch('/oauth/acct/client', { method:'PUT', body: JSON.stringify({ clientId, clientSecret }) });  // 204 即入库

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1267,7 +1267,7 @@ node 详单**不接受** \`command\` / \`args\` / \`shell\` / \`env\` 或其它�
       "clientId": "xxx.apps.example.com",           // 可选:内置 OAuth 客户端 ID(用户零配置开箱即用;用户在设置页自填的覆盖内置,清除自填即回落)
       "clientIdAlternatives": ["xxx-global.apps.example.com"],  // 可选 ≤8 条:仅 tokenBroker 模式;意识按 app-context 选 App 时,connect 只接受默认值或这里声明的公开 ID
       "clientSecret": "xxx",                        // 可选(须与 clientId 成对):内置 client 的 secret;桌面应用的 client 凭证本非机密,纯 PKCE 服务商可省略
-      "scopes": ["read.a", "write.b"],              // 可选 ≤32 条:申请的权限范围(确认框逐条展示给用户)
+      "scopes": ["read.a", "write.b"],              // 可选 ≤48 条:申请的权限范围(确认框逐条展示给用户)
       "scopeDelimiter": ",",                        // 可选:authorize URL 的 scope 拼接分隔符;缺省空格(OAuth 标准),Slack 这类逗号分隔的服务商声明 ","(目前只认这一个值)
       "pkce": true,                                 // 可选:PKCE(S256)开关,缺省 true
       "extraAuthorizeParams": { "access_type": "offline", "prompt": "consent" },  // 可选 ≤8 条:服务商特有授权参数(协议保留参数禁写)

--- a/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
@@ -233,15 +233,11 @@ function parseManifest(raw: string | null): AccountsManifest {
           ? { authScopes: [...r.authScopes] }
           : {}),
         ...(r.authFace === 'full' || r.authFace === 'subset' ? { authFace: r.authFace } : {}),
+        // 与 authScopes 同风格宽松读取:上限由写侧(端点校验 + 合并裁剪)钳制,
+        // 库里的坏值对消费方惰性(判定前先按当前声明过滤),不整包丢弃证据。
         ...(Array.isArray(r.insufficientScopes) &&
-          r.insufficientScopes.length > 0 &&
-          r.insufficientScopes.length <= 64 &&
-          r.insufficientScopes.every(
-            (scope) =>
-              typeof scope === 'string' &&
-              scope.trim().length > 0 &&
-              scope.length <= 256,
-          )
+        r.insufficientScopes.length > 0 &&
+        r.insufficientScopes.every((scope) => typeof scope === 'string')
           ? { insufficientScopes: [...new Set(r.insufficientScopes)] }
           : {}),
       });
@@ -277,8 +273,9 @@ function toView(
 }
 
 /**
- * 仅在可证明“当时拿的是全量面”时列出新增 scope；老数据与降面授权不猜
- * (返回空数组)。这是陈旧判定的唯一实现,isScopeStale 只是它的布尔投影。
+ * 快照推断分量:仅在可证明“当时拿的是全量面”时列出新增 scope；老数据与
+ * 降面授权不猜(返回空数组)。合并后的判定入口是 accountMissingScopes
+ * (真实错误证据优先,本函数只做无证据时的兜底)。
  */
 export function missingAuthScopes(
   declScopes: readonly string[],
@@ -287,13 +284,6 @@ export function missingAuthScopes(
   if (row.authFace !== 'full' || row.authScopes === undefined) return [];
   const granted = new Set(row.authScopes);
   return declScopes.filter((scope) => !granted.has(scope));
-}
-
-export function isScopeStale(
-  declScopes: readonly string[],
-  row: { authScopes?: readonly string[]; authFace?: 'full' | 'subset' },
-): boolean {
-  return missingAuthScopes(declScopes, row).length > 0;
 }
 
 /** 真实错误证据优先；没有证据时才退回授权面快照推断。 */
@@ -458,15 +448,32 @@ export class GhostOauthAccountManager {
     return row ? accountMissingScopes(decl.scopes ?? [], row) : [];
   }
 
-  /** 把真实权限错误证据合并到当前默认账号；无默认账号或写失败返回 false。 */
-  reportInsufficientScopes(ghostId: string, secretKey: string, scopes: readonly string[]): boolean {
+  /**
+   * 把真实权限错误证据合并到当前默认账号,并按当前声明面裁剪——顺手淘汰清单
+   * 换代后的过期证据,恒有条数 ≤ 声明上限(GHOST_OAUTH_SCOPES_MAX)。返回
+   * 'unchanged' = 证据已在库未重写(调用方据此跳过广播);false = 无默认账号
+   * 或写失败。
+   */
+  reportInsufficientScopes(
+    ghostId: string,
+    secretKey: string,
+    scopes: readonly string[],
+    declScopes: readonly string[],
+  ): 'stored' | 'unchanged' | false {
     const manifest = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
     const row = manifest.accounts.find((account) => account.id === manifest.defaultAccountId);
     if (!row) return false;
-    const merged = [...new Set([...(row.insufficientScopes ?? []), ...scopes])];
-    if (row.insufficientScopes && sameScopeFace(row.insufficientScopes, merged)) return true;
+    const declared = new Set(declScopes);
+    const merged = [...new Set([...(row.insufficientScopes ?? []), ...scopes])].filter((scope) =>
+      declared.has(scope),
+    );
+    if (row.insufficientScopes && sameScopeFace(row.insufficientScopes, merged)) {
+      return 'unchanged';
+    }
     row.insufficientScopes = merged;
-    return this.deps.vault.store(ghostId, accountsKey(secretKey), JSON.stringify(manifest));
+    return this.deps.vault.store(ghostId, accountsKey(secretKey), JSON.stringify(manifest))
+      ? 'stored'
+      : false;
   }
 
   /** 头像 data URL 读取(形状校验兜底:库里的坏值当无头像,不喂给 <img>)。 */

--- a/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
@@ -265,24 +265,23 @@ function toView(
 }
 
 /**
- * 仅在可证明“当时拿的是全量面”时判断新增 scope；老数据与降面授权不猜。
+ * 仅在可证明“当时拿的是全量面”时列出新增 scope；老数据与降面授权不猜
+ * (返回空数组)。这是陈旧判定的唯一实现,isScopeStale 只是它的布尔投影。
  */
+export function missingAuthScopes(
+  declScopes: readonly string[],
+  row: { authScopes?: readonly string[]; authFace?: 'full' | 'subset' },
+): string[] {
+  if (row.authFace !== 'full' || row.authScopes === undefined) return [];
+  const granted = new Set(row.authScopes);
+  return declScopes.filter((scope) => !granted.has(scope));
+}
+
 export function isScopeStale(
   declScopes: readonly string[],
   row: { authScopes?: readonly string[]; authFace?: 'full' | 'subset' },
 ): boolean {
-  if (row.authFace !== 'full' || row.authScopes === undefined) return false;
-  const granted = new Set(row.authScopes);
-  return declScopes.some((scope) => !granted.has(scope));
-}
-
-function missingScopes(
-  declScopes: readonly string[],
-  row: { authScopes?: readonly string[]; authFace?: 'full' | 'subset' },
-): string[] {
-  if (!isScopeStale(declScopes, row) || row.authScopes === undefined) return [];
-  const granted = new Set(row.authScopes);
-  return declScopes.filter((scope) => !granted.has(scope));
+  return missingAuthScopes(declScopes, row).length > 0;
 }
 
 function sameScopeFace(left: readonly string[], right: readonly string[]): boolean {
@@ -423,17 +422,11 @@ export class GhostOauthAccountManager {
     );
   }
 
-  /** 默认账号的陈旧授权面；判不准或无需重连时返回 null。 */
-  defaultScopeStaleness(
-    ghostId: string,
-    secretKey: string,
-    decl: GhostOauthDecl,
-  ): { missingScopes: string[] } | null {
+  /** 默认账号相对当前声明缺失的 scope；空数组 = 无需重连或判不准。 */
+  defaultMissingScopes(ghostId: string, secretKey: string, decl: GhostOauthDecl): string[] {
     const manifest = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
     const row = manifest.accounts.find((account) => account.id === manifest.defaultAccountId);
-    if (!row) return null;
-    const missing = missingScopes(decl.scopes ?? [], row);
-    return missing.length > 0 ? { missingScopes: missing } : null;
+    return row ? missingAuthScopes(decl.scopes ?? [], row) : [];
   }
 
   /** 头像 data URL 读取(形状校验兜底:库里的坏值当无头像,不喂给 <img>)。 */

--- a/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
@@ -87,8 +87,8 @@ export interface GhostOauthAccountView {
    */
   avatarDataUrl: string | null;
   /**
-   * 当前清单声明新增了本账号全量授权时未申请的 scope。仅 full 快照可判定；
-   * 老账号与主动降面账号恒为 false，避免把未知状态误报成异常。
+   * 当前账号有经宿主校验的真实缺权证据，或当前清单新增了该账号全量授权
+   * 时未申请的 scope。没有证据时，老账号与主动降面账号仍不猜。
    */
   scopeStale: boolean;
 }
@@ -123,7 +123,7 @@ export interface GhostOauthAccountManagerDeps {
    * 授权成功钩子(2026-07-14):新连与同身份重连两个成功出口都触发,调用方
    * 拿它广播"授权成功"的主机代言 tips(label = 账号展示标签,声明 identity
    * 且拉取成功才有)。抛错不许影响连接结果,实现侧自兜。
-  */
+   */
   onAccountConnected?: (info: { ghostId: string; secretKey: string; label: string | null }) => void;
   /**
    * Refresh-path status transition hook. It deliberately carries no token,
@@ -140,11 +140,7 @@ export interface GhostOauthAccountManagerDeps {
    * verifies that the plugin and the exact OAuth declaration still exist
    * before any callback result is persisted.
    */
-  isConnectTargetCurrent?: (
-    ghostId: string,
-    secretKey: string,
-    decl: GhostOauthDecl,
-  ) => boolean;
+  isConnectTargetCurrent?: (ghostId: string, secretKey: string, decl: GhostOauthDecl) => boolean;
   /** 延时器(仅 invalid_grant 轮换探测用;测试注入即时假体,生产缺省 setTimeout)。 */
   sleep?: (ms: number) => Promise<void>;
 }
@@ -186,6 +182,8 @@ interface AccountRow {
   authScopes?: string[];
   /** full = 当时清单全量；subset = 用户主动选择了降面授权。 */
   authFace?: 'full' | 'subset';
+  /** 插件从真实 API 权限错误中上报、且已由宿主按当前声明校验的缺失 scope。 */
+  insufficientScopes?: string[];
 }
 
 interface AccountsManifest {
@@ -226,17 +224,31 @@ function parseManifest(raw: string | null): AccountsManifest {
       accounts.push({
         id: r.id,
         label: typeof r.label === 'string' && r.label.length > 0 ? r.label : null,
-        displayLabel: typeof r.displayLabel === 'string' && r.displayLabel.length > 0 ? r.displayLabel : null,
+        displayLabel:
+          typeof r.displayLabel === 'string' && r.displayLabel.length > 0 ? r.displayLabel : null,
         status: r.status === 'expired' ? 'expired' : 'connected',
-        createdAt: typeof r.createdAt === 'number' && Number.isFinite(r.createdAt) ? r.createdAt : 0,
+        createdAt:
+          typeof r.createdAt === 'number' && Number.isFinite(r.createdAt) ? r.createdAt : 0,
         ...(Array.isArray(r.authScopes) && r.authScopes.every((scope) => typeof scope === 'string')
           ? { authScopes: [...r.authScopes] }
           : {}),
         ...(r.authFace === 'full' || r.authFace === 'subset' ? { authFace: r.authFace } : {}),
+        ...(Array.isArray(r.insufficientScopes) &&
+          r.insufficientScopes.length > 0 &&
+          r.insufficientScopes.length <= 64 &&
+          r.insufficientScopes.every(
+            (scope) =>
+              typeof scope === 'string' &&
+              scope.trim().length > 0 &&
+              scope.length <= 256,
+          )
+          ? { insufficientScopes: [...new Set(r.insufficientScopes)] }
+          : {}),
       });
     }
     const defaultAccountId =
-      typeof parsed.defaultAccountId === 'string' && accounts.some((a) => a.id === parsed.defaultAccountId)
+      typeof parsed.defaultAccountId === 'string' &&
+      accounts.some((a) => a.id === parsed.defaultAccountId)
         ? parsed.defaultAccountId
         : accounts.length > 0
           ? accounts[0].id
@@ -260,7 +272,7 @@ function toView(
     isDefault: row.id === defaultAccountId,
     createdAt: row.createdAt,
     avatarDataUrl,
-    scopeStale: isScopeStale(declScopes, row),
+    scopeStale: accountMissingScopes(declScopes, row).length > 0,
   };
 }
 
@@ -282,6 +294,16 @@ export function isScopeStale(
   row: { authScopes?: readonly string[]; authFace?: 'full' | 'subset' },
 ): boolean {
   return missingAuthScopes(declScopes, row).length > 0;
+}
+
+/** 真实错误证据优先；没有证据时才退回授权面快照推断。 */
+function accountMissingScopes(declScopes: readonly string[], row: AccountRow): string[] {
+  if (row.insufficientScopes?.length) {
+    const declared = new Set(declScopes);
+    const currentEvidence = row.insufficientScopes.filter((scope) => declared.has(scope));
+    if (currentEvidence.length > 0) return currentEvidence;
+  }
+  return missingAuthScopes(declScopes, row);
 }
 
 function sameScopeFace(left: readonly string[], right: readonly string[]): boolean {
@@ -336,7 +358,12 @@ export class GhostOauthAccountManager {
    * 可省略——纯 PKCE 公共客户端)。改 client 后既有 access token 缓存作废
    * (旧 client 换的令牌不该再续命)。
    */
-  setClientConfig(ghostId: string, secretKey: string, clientId: string, clientSecret?: string): boolean {
+  setClientConfig(
+    ghostId: string,
+    secretKey: string,
+    clientId: string,
+    clientSecret?: string,
+  ): boolean {
     if (!this.deps.vault.store(ghostId, clientIdKey(secretKey), clientId)) return false;
     if (clientSecret !== undefined && clientSecret.length > 0) {
       if (!this.deps.vault.store(ghostId, clientSecretKey(secretKey), clientSecret)) return false;
@@ -375,7 +402,9 @@ export class GhostOauthAccountManager {
     // client 无意义且必错(自填 id 配服务端 secret = invalid_client),
     // 一律忽略自填。缺省用内置 clientId;connect 可传已经过清单白名单
     // 复验的备用 clientId,供同一意识按 region 选择不同 OAuth App。
-    const customId = decl.tokenBroker ? null : this.deps.vault.read(ghostId, clientIdKey(secretKey));
+    const customId = decl.tokenBroker
+      ? null
+      : this.deps.vault.read(ghostId, clientIdKey(secretKey));
     let clientId: string | null;
     let clientSecret: string | null | undefined;
     if (clientIdOverride !== undefined) {
@@ -426,7 +455,18 @@ export class GhostOauthAccountManager {
   defaultMissingScopes(ghostId: string, secretKey: string, decl: GhostOauthDecl): string[] {
     const manifest = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
     const row = manifest.accounts.find((account) => account.id === manifest.defaultAccountId);
-    return row ? missingAuthScopes(decl.scopes ?? [], row) : [];
+    return row ? accountMissingScopes(decl.scopes ?? [], row) : [];
+  }
+
+  /** 把真实权限错误证据合并到当前默认账号；无默认账号或写失败返回 false。 */
+  reportInsufficientScopes(ghostId: string, secretKey: string, scopes: readonly string[]): boolean {
+    const manifest = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
+    const row = manifest.accounts.find((account) => account.id === manifest.defaultAccountId);
+    if (!row) return false;
+    const merged = [...new Set([...(row.insufficientScopes ?? []), ...scopes])];
+    if (row.insufficientScopes && sameScopeFace(row.insufficientScopes, merged)) return true;
+    row.insufficientScopes = merged;
+    return this.deps.vault.store(ghostId, accountsKey(secretKey), JSON.stringify(manifest));
   }
 
   /** 头像 data URL 读取(形状校验兜底:库里的坏值当无头像,不喂给 <img>)。 */
@@ -521,7 +561,11 @@ export class GhostOauthAccountManager {
     if (opts?.scopes !== undefined) {
       const declared = new Set(decl.scopes ?? []);
       if (opts.scopes.length === 0 || opts.scopes.some((sc) => !declared.has(sc))) {
-        return { ok: false, error: 'INVALID_CONFIG', detail: '申请的 scope 必须是清单声明的非空子集' };
+        return {
+          ok: false,
+          error: 'INVALID_CONFIG',
+          detail: '申请的 scope 必须是清单声明的非空子集',
+        };
       }
       config.scopes = [...opts.scopes];
     }
@@ -576,7 +620,10 @@ export class GhostOauthAccountManager {
       // 等于给第三方意识一个"主机代发 GET + 小图字节回沙箱"的 SSRF 读原语。
       // 下载本身不带任何凭证(CDN 域名不在注入白名单);失败降级无头像。
       if (identity.avatarUrl !== null && isOfficialGhostId(ghostId)) {
-        avatar = await fetchGhostOauthAvatar({ url: identity.avatarUrl, fetchImpl: this.deps.fetchImpl });
+        avatar = await fetchGhostOauthAvatar({
+          url: identity.avatarUrl,
+          fetchImpl: this.deps.fetchImpl,
+        });
       }
     }
 
@@ -601,7 +648,13 @@ export class GhostOauthAccountManager {
     const existing = label !== null ? manifest.accounts.find((a) => a.label === label) : undefined;
     if (existing) {
       if (flow.bundle.refreshToken !== null) {
-        if (!this.deps.vault.store(ghostId, refreshTokenKey(secretKey, existing.id), flow.bundle.refreshToken)) {
+        if (
+          !this.deps.vault.store(
+            ghostId,
+            refreshTokenKey(secretKey, existing.id),
+            flow.bundle.refreshToken,
+          )
+        ) {
           return { ok: false, error: 'VAULT_WRITE_FAILED' };
         }
       }
@@ -624,8 +677,15 @@ export class GhostOauthAccountManager {
         existing.authFace = authFace;
         manifestDirty = true;
       }
-      if (manifestDirty) {
-        this.deps.vault.store(ghostId, accountsKey(secretKey), JSON.stringify(manifest));
+      if (existing.insufficientScopes !== undefined) {
+        delete existing.insufficientScopes;
+        manifestDirty = true;
+      }
+      if (
+        manifestDirty &&
+        !this.deps.vault.store(ghostId, accountsKey(secretKey), JSON.stringify(manifest))
+      ) {
+        return { ok: false, error: 'VAULT_WRITE_FAILED' };
       }
       // 重连顺带刷新头像(用户可能换过头像;写失败不影响连接结果)。
       if (avatar !== null) {
@@ -635,7 +695,11 @@ export class GhostOauthAccountManager {
         accessToken: flow.bundle.accessToken,
         expiresAt: flow.bundle.expiresAt,
       });
-      this.deps.logger?.info('ghost oauth 账号已重连(同身份合并)', { ghostId, secretKey, accountId: existing.id });
+      this.deps.logger?.info('ghost oauth 账号已重连(同身份合并)', {
+        ghostId,
+        secretKey,
+        accountId: existing.id,
+      });
       this.notifyConnected(ghostId, secretKey, existing.displayLabel ?? existing.label);
       return {
         ok: true,
@@ -668,7 +732,13 @@ export class GhostOauthAccountManager {
     // 可能出现"清单有账号但无 rt"的半身位。没有 rt 的服务商(罕见)照样
     // 挂账号,access token 走内存缓存,过期后 AUTH_EXPIRED 引导重连。
     if (flow.bundle.refreshToken !== null) {
-      if (!this.deps.vault.store(ghostId, refreshTokenKey(secretKey, account.id), flow.bundle.refreshToken)) {
+      if (
+        !this.deps.vault.store(
+          ghostId,
+          refreshTokenKey(secretKey, account.id),
+          flow.bundle.refreshToken,
+        )
+      ) {
         return { ok: false, error: 'VAULT_WRITE_FAILED' };
       }
     }
@@ -691,7 +761,10 @@ export class GhostOauthAccountManager {
     });
     this.deps.logger?.info('ghost oauth 账号已连接', { ghostId, secretKey, accountId: account.id });
     this.notifyConnected(ghostId, secretKey, account.displayLabel ?? account.label);
-    return { ok: true, account: toView(account, nextManifest.defaultAccountId, avatar, decl.scopes) };
+    return {
+      ok: true,
+      account: toView(account, nextManifest.defaultAccountId, avatar, decl.scopes),
+    };
   }
 
   /** 授权成功通知(自兜异常:提示挂了不影响连接结果)。 */
@@ -783,7 +856,11 @@ export class GhostOauthAccountManager {
         // 已被服务商作废,下一次刷新注定 invalid_grant → 重新授权。
         if (result.bundle.refreshToken !== null && result.bundle.refreshToken !== refreshToken) {
           if (
-            !this.deps.vault.store(ghostId, refreshTokenKey(secretKey, accountId), result.bundle.refreshToken)
+            !this.deps.vault.store(
+              ghostId,
+              refreshTokenKey(secretKey, accountId),
+              result.bundle.refreshToken,
+            )
           ) {
             this.deps.logger?.warn(
               'ghost oauth 轮换后的新 refresh token 落库失败——新令牌仅存内存,重启后需要重新授权',
@@ -799,7 +876,13 @@ export class GhostOauthAccountManager {
         this.markConnected(ghostId, secretKey, accountId);
         // 展示名/头像回填(fire-and-forget,不拖累令牌热路径):displayTemplate /
         // avatarPath 上线前连的老账号缺这些,借下一次令牌刷新顺路补上,无需重连。
-        void this.backfillIdentityExtras(ghostId, secretKey, decl, accountId, result.bundle.accessToken);
+        void this.backfillIdentityExtras(
+          ghostId,
+          secretKey,
+          decl,
+          accountId,
+          result.bundle.accessToken,
+        );
         return { ok: true, accessToken: result.bundle.accessToken, accountId };
       }
 
@@ -811,7 +894,12 @@ export class GhostOauthAccountManager {
       }
 
       if (attempt === 0) {
-        const rotated = await this.readRotatedRefreshToken(ghostId, secretKey, accountId, refreshToken);
+        const rotated = await this.readRotatedRefreshToken(
+          ghostId,
+          secretKey,
+          accountId,
+          refreshToken,
+        );
         if (rotated !== null) {
           this.deps.logger?.info(
             'ghost oauth invalid_grant 后检测到 refresh token 已被其它实例轮换,用新令牌重试',
@@ -902,7 +990,10 @@ export class GhostOauthAccountManager {
         this.deps.logger?.info('ghost oauth 账号展示名已回填', { ghostId, secretKey, accountId });
       }
       if (needAvatar && identity.avatarUrl !== null) {
-        const avatar = await fetchGhostOauthAvatar({ url: identity.avatarUrl, fetchImpl: this.deps.fetchImpl });
+        const avatar = await fetchGhostOauthAvatar({
+          url: identity.avatarUrl,
+          fetchImpl: this.deps.fetchImpl,
+        });
         // 存前重验账号仍在清单(拉取期间可能被断开;断开后不再写孤儿头像键)。
         if (avatar !== null) {
           const fresh = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
@@ -936,11 +1027,7 @@ export class GhostOauthAccountManager {
     const manifest = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
     const row = manifest.accounts.find((a) => a.id === accountId);
     if (!row || !mutator(row)) return false;
-    return this.deps.vault.store(
-      ghostId,
-      accountsKey(secretKey),
-      JSON.stringify(manifest),
-    );
+    return this.deps.vault.store(ghostId, accountsKey(secretKey), JSON.stringify(manifest));
   }
 
   private markExpired(ghostId: string, secretKey: string, accountId: string): void {
@@ -969,15 +1056,12 @@ export class GhostOauthAccountManager {
     try {
       this.deps.onAccountStatusChanged?.({ ghostId, secretKey, status });
     } catch (err) {
-      this.deps.logger?.warn?.(
-        'ghost oauth onAccountStatusChanged 通知失败(不影响状态写入)',
-        {
-          ghostId,
-          secretKey,
-          status,
-          err: String(err),
-        },
-      );
+      this.deps.logger?.warn?.('ghost oauth onAccountStatusChanged 通知失败(不影响状态写入)', {
+        ghostId,
+        secretKey,
+        status,
+        err: String(err),
+      });
     }
   }
 

--- a/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthAccounts.ts
@@ -86,6 +86,11 @@ export interface GhostOauthAccountView {
    * 上下文(networkSlot 只走 getFreshAccessToken)。
    */
   avatarDataUrl: string | null;
+  /**
+   * 当前清单声明新增了本账号全量授权时未申请的 scope。仅 full 快照可判定；
+   * 老账号与主动降面账号恒为 false，避免把未知状态误报成异常。
+   */
+  scopeStale: boolean;
 }
 
 /** 保险库最小面(providerSecretStore 在接线处适配;测试喂内存假体)。 */
@@ -177,6 +182,10 @@ interface AccountRow {
   displayLabel: string | null;
   status: GhostOauthAccountStatus;
   createdAt: number;
+  /** 本次浏览器授权 URL 实际携带的 scope 面；旧账号没有该快照。 */
+  authScopes?: string[];
+  /** full = 当时清单全量；subset = 用户主动选择了降面授权。 */
+  authFace?: 'full' | 'subset';
 }
 
 interface AccountsManifest {
@@ -220,6 +229,10 @@ function parseManifest(raw: string | null): AccountsManifest {
         displayLabel: typeof r.displayLabel === 'string' && r.displayLabel.length > 0 ? r.displayLabel : null,
         status: r.status === 'expired' ? 'expired' : 'connected',
         createdAt: typeof r.createdAt === 'number' && Number.isFinite(r.createdAt) ? r.createdAt : 0,
+        ...(Array.isArray(r.authScopes) && r.authScopes.every((scope) => typeof scope === 'string')
+          ? { authScopes: [...r.authScopes] }
+          : {}),
+        ...(r.authFace === 'full' || r.authFace === 'subset' ? { authFace: r.authFace } : {}),
       });
     }
     const defaultAccountId =
@@ -238,6 +251,7 @@ function toView(
   row: AccountRow,
   defaultAccountId: string | null,
   avatarDataUrl: string | null,
+  declScopes: readonly string[] = [],
 ): GhostOauthAccountView {
   return {
     id: row.id,
@@ -246,7 +260,35 @@ function toView(
     isDefault: row.id === defaultAccountId,
     createdAt: row.createdAt,
     avatarDataUrl,
+    scopeStale: isScopeStale(declScopes, row),
   };
+}
+
+/**
+ * 仅在可证明“当时拿的是全量面”时判断新增 scope；老数据与降面授权不猜。
+ */
+export function isScopeStale(
+  declScopes: readonly string[],
+  row: { authScopes?: readonly string[]; authFace?: 'full' | 'subset' },
+): boolean {
+  if (row.authFace !== 'full' || row.authScopes === undefined) return false;
+  const granted = new Set(row.authScopes);
+  return declScopes.some((scope) => !granted.has(scope));
+}
+
+function missingScopes(
+  declScopes: readonly string[],
+  row: { authScopes?: readonly string[]; authFace?: 'full' | 'subset' },
+): string[] {
+  if (!isScopeStale(declScopes, row) || row.authScopes === undefined) return [];
+  const granted = new Set(row.authScopes);
+  return declScopes.filter((scope) => !granted.has(scope));
+}
+
+function sameScopeFace(left: readonly string[], right: readonly string[]): boolean {
+  if (left.length !== right.length) return false;
+  const expected = new Set(left);
+  return expected.size === new Set(right).size && right.every((scope) => expected.has(scope));
 }
 
 interface CachedAccessToken {
@@ -374,11 +416,24 @@ export class GhostOauthAccountManager {
 
   /* ------------------------------ 账号清单 ------------------------------ */
 
-  listAccounts(ghostId: string, secretKey: string): GhostOauthAccountView[] {
+  listAccounts(ghostId: string, secretKey: string, decl?: GhostOauthDecl): GhostOauthAccountView[] {
     const manifest = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
     return manifest.accounts.map((a) =>
-      toView(a, manifest.defaultAccountId, this.readAvatar(ghostId, secretKey, a.id)),
+      toView(a, manifest.defaultAccountId, this.readAvatar(ghostId, secretKey, a.id), decl?.scopes),
     );
+  }
+
+  /** 默认账号的陈旧授权面；判不准或无需重连时返回 null。 */
+  defaultScopeStaleness(
+    ghostId: string,
+    secretKey: string,
+    decl: GhostOauthDecl,
+  ): { missingScopes: string[] } | null {
+    const manifest = parseManifest(this.deps.vault.read(ghostId, accountsKey(secretKey)));
+    const row = manifest.accounts.find((account) => account.id === manifest.defaultAccountId);
+    if (!row) return null;
+    const missing = missingScopes(decl.scopes ?? [], row);
+    return missing.length > 0 ? { missingScopes: missing } : null;
   }
 
   /** 头像 data URL 读取(形状校验兜底:库里的坏值当无头像,不喂给 <img>)。 */
@@ -477,6 +532,10 @@ export class GhostOauthAccountManager {
       }
       config.scopes = [...opts.scopes];
     }
+    const authScopes = [...config.scopes];
+    const authFace: AccountRow['authFace'] = sameScopeFace(decl.scopes ?? [], authScopes)
+      ? 'full'
+      : 'subset';
 
     const flow = await startGhostOauthFlow({
       config,
@@ -564,6 +623,14 @@ export class GhostOauthAccountManager {
         existing.displayLabel = display;
         manifestDirty = true;
       }
+      if (existing.authScopes === undefined || !sameScopeFace(existing.authScopes, authScopes)) {
+        existing.authScopes = authScopes;
+        manifestDirty = true;
+      }
+      if (existing.authFace !== authFace) {
+        existing.authFace = authFace;
+        manifestDirty = true;
+      }
       if (manifestDirty) {
         this.deps.vault.store(ghostId, accountsKey(secretKey), JSON.stringify(manifest));
       }
@@ -583,6 +650,7 @@ export class GhostOauthAccountManager {
           existing,
           manifest.defaultAccountId,
           avatar ?? this.readAvatar(ghostId, secretKey, existing.id),
+          decl.scopes,
         ),
       };
     }
@@ -599,6 +667,8 @@ export class GhostOauthAccountManager {
       displayLabel: display,
       status: 'connected',
       createdAt: Date.now(),
+      authScopes,
+      authFace,
     };
 
     // refresh token 先落库再挂清单:清单是"账号存在"的事实源,顺序反了
@@ -628,7 +698,7 @@ export class GhostOauthAccountManager {
     });
     this.deps.logger?.info('ghost oauth 账号已连接', { ghostId, secretKey, accountId: account.id });
     this.notifyConnected(ghostId, secretKey, account.displayLabel ?? account.label);
-    return { ok: true, account: toView(account, nextManifest.defaultAccountId, avatar) };
+    return { ok: true, account: toView(account, nextManifest.defaultAccountId, avatar, decl.scopes) };
   }
 
   /** 授权成功通知(自兜异常:提示挂了不影响连接结果)。 */

--- a/apps/desktop/src/main/cindy-brain/ghostOauthScopeStaleness.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthScopeStaleness.ts
@@ -1,34 +1,32 @@
 import type {
   GhostManifest,
+  GhostSecretOauthDecl,
   GhostSetupAssessment,
   GhostSetupReauthSuggest,
 } from '../../shared/ghost.js';
-
-export interface GhostOauthScopeStaleness {
-  missingScopes: readonly string[];
-}
+import { oauthConnectActionId, requirementRef } from './ghostSetupStatus.js';
 
 /** 从清单顺序中挑首个陈旧 OAuth 凭证槽，生成有界且不含凭证明文的建议。 */
 export function findGhostOauthReauthSuggest(
   manifest: GhostManifest,
-  resolve: (secretKey: string) => GhostOauthScopeStaleness | null,
+  resolveMissingScopes: (secretKey: string, decl: GhostSecretOauthDecl) => readonly string[],
 ): GhostSetupReauthSuggest | undefined {
   for (const secret of manifest.network?.secrets ?? []) {
     if (secret.source !== 'oauth' || !secret.oauth) continue;
-    const stale = resolve(secret.key);
-    if (!stale || stale.missingScopes.length === 0) continue;
-    const ref = `secret:${secret.key}`;
+    const missing = resolveMissingScopes(secret.key, secret.oauth);
+    if (missing.length === 0) continue;
+    const ref = requirementRef({ kind: 'secret', key: secret.key });
     return {
       ghostId: manifest.id,
       secretKey: secret.key,
-      missingScopes: [...stale.missingScopes],
-      missingScopeCount: stale.missingScopes.length,
+      missingScopes: [...missing],
+      missingScopeCount: missing.length,
       requirement: {
         ref,
         kind: 'oauth',
         label: secret.label,
         action: {
-          id: `oauth_connect:${ref}`,
+          id: oauthConnectActionId(ref),
           kind: 'oauth_connect',
         },
       },

--- a/apps/desktop/src/main/cindy-brain/ghostOauthScopeStaleness.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostOauthScopeStaleness.ts
@@ -1,0 +1,48 @@
+import type {
+  GhostManifest,
+  GhostSetupAssessment,
+  GhostSetupReauthSuggest,
+} from '../../shared/ghost.js';
+
+export interface GhostOauthScopeStaleness {
+  missingScopes: readonly string[];
+}
+
+/** 从清单顺序中挑首个陈旧 OAuth 凭证槽，生成有界且不含凭证明文的建议。 */
+export function findGhostOauthReauthSuggest(
+  manifest: GhostManifest,
+  resolve: (secretKey: string) => GhostOauthScopeStaleness | null,
+): GhostSetupReauthSuggest | undefined {
+  for (const secret of manifest.network?.secrets ?? []) {
+    if (secret.source !== 'oauth' || !secret.oauth) continue;
+    const stale = resolve(secret.key);
+    if (!stale || stale.missingScopes.length === 0) continue;
+    const ref = `secret:${secret.key}`;
+    return {
+      ghostId: manifest.id,
+      secretKey: secret.key,
+      missingScopes: [...stale.missingScopes],
+      missingScopeCount: stale.missingScopes.length,
+      requirement: {
+        ref,
+        kind: 'oauth',
+        label: secret.label,
+        action: {
+          id: `oauth_connect:${ref}`,
+          kind: 'oauth_connect',
+        },
+      },
+    };
+  }
+  return undefined;
+}
+
+/** required 保持原样；只有整体 ready 时才附加非阻塞建议。 */
+export function appendReadyGhostOauthReauthSuggest(
+  assessment: GhostSetupAssessment,
+  suggest: GhostSetupReauthSuggest | undefined,
+): GhostSetupAssessment {
+  return assessment.state === 'ready' && suggest
+    ? { ...assessment, reauthSuggest: suggest }
+    : assessment;
+}

--- a/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
@@ -160,7 +160,11 @@ export class GhostSetupCoordinator {
       unsubscribe();
       return this.internalFailure('插件配置状态读取失败', error);
     }
-    const reauthAssessment = request.plan ? toReauthInteractionAssessment(assessment) : null;
+    // ready 态的重连建议是非阻塞的:仅 Agent 主动带 plan 且本回合有交互面时才进
+    // 卡流程;无 sessionId 的回合(IM/定时任务)丢弃 plan 直接放行,绝不把 ready
+    // 插件拦成 SETUP_REQUIRED。
+    const reauthAssessment =
+      request.plan && request.sessionId ? toReauthInteractionAssessment(assessment) : null;
     const reauthMode = reauthAssessment !== null;
     if (assessment.state === 'ready' && !reauthMode) {
       unsubscribe();

--- a/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupCoordinator.ts
@@ -160,10 +160,13 @@ export class GhostSetupCoordinator {
       unsubscribe();
       return this.internalFailure('插件配置状态读取失败', error);
     }
-    if (assessment.state === 'ready') {
+    const reauthAssessment = request.plan ? toReauthInteractionAssessment(assessment) : null;
+    const reauthMode = reauthAssessment !== null;
+    if (assessment.state === 'ready' && !reauthMode) {
       unsubscribe();
       return { ok: true, assessment };
     }
+    if (reauthAssessment) assessment = reauthAssessment;
     if (!request.sessionId) {
       unsubscribe();
       return {
@@ -186,7 +189,10 @@ export class GhostSetupCoordinator {
 
     const sessionId = request.sessionId;
     const requestId = this.deps.createRequestId?.() ?? randomUUID();
-    let plan = validatePlan(request.plan, assessment) ?? defaultPlan(assessment);
+    let plan =
+      (reauthMode
+        ? validateReauthPlan(request.plan, assessment)
+        : validatePlan(request.plan, assessment)) ?? defaultPlan(assessment);
     let snapshot = toSnapshot(requestId, identity, assessment, plan);
     let settled = false;
     let verifying: Promise<void> | null = null;
@@ -297,12 +303,13 @@ export class GhostSetupCoordinator {
             return;
           }
           const next = current.assessment;
-          if (next.state === 'ready') {
+          const nextReauthAssessment = reauthMode ? toReauthInteractionAssessment(next) : null;
+          if (next.state === 'ready' && !nextReauthAssessment) {
             publishSatisfied(next);
             settle({ ok: true, assessment: next }, 'ready');
             return;
           }
-          publish(next, requiredPhase);
+          publish(nextReauthAssessment ?? next, requiredPhase);
         })().finally(() => {
           verifying = null;
           if (assessmentDirty && !settled) wakeVerify?.();
@@ -567,6 +574,47 @@ function validatePlan(
   return plan;
 }
 
+/**
+ * ready 态的非阻塞重连建议只允许一张卡、一步、一个引用、一个动作。
+ * 其余校验仍复用 required 态 validatePlan，非法 Agent plan 同样回落 Host 默认卡。
+ */
+function validateReauthPlan(
+  plan: GhostSetupPlan | undefined,
+  assessment: GhostSetupAssessment,
+): GhostSetupPlan | null {
+  if (!plan || plan.steps.length !== 1 || plan.steps[0]?.requirementRefs.length !== 1) {
+    return null;
+  }
+  return validatePlan(plan, assessment);
+}
+
+/** 把 ready assessment 的建议映射成现有卡流程可消费的单项 expired assessment。 */
+function toReauthInteractionAssessment(
+  assessment: GhostSetupAssessment,
+): GhostSetupAssessment | null {
+  if (assessment.state !== 'ready' || !assessment.reauthSuggest) return null;
+  const requirement = assessment.reauthSuggest.requirement;
+  return {
+    state: 'required',
+    revision: assessment.revision,
+    groups: [
+      {
+        id: `reauth:${assessment.reauthSuggest.secretKey}`,
+        mode: 'any_of',
+        items: [
+          {
+            ref: requirement.ref,
+            kind: requirement.kind,
+            label: requirement.label,
+            state: 'expired',
+            actions: [requirement.action],
+          },
+        ],
+      },
+    ],
+  };
+}
+
 function defaultPlan(assessment: GhostSetupAssessment): GhostSetupPlan {
   const steps = assessment.groups.flatMap((group, index) => {
     if (group.items.some((item) => item.state === 'satisfied')) return [];
@@ -635,9 +683,7 @@ function toSnapshot(
           ? (override?.phase ?? 'pending')
           : ('pending' as const),
       ...(action && !satisfied ? { action } : {}),
-      ...(!satisfied && active && override?.errorCode
-        ? { errorCode: override.errorCode }
-        : {}),
+      ...(!satisfied && active && override?.errorCode ? { errorCode: override.errorCode } : {}),
     };
   });
   return {

--- a/apps/desktop/src/main/cindy-brain/ghostSetupStatus.ts
+++ b/apps/desktop/src/main/cindy-brain/ghostSetupStatus.ts
@@ -115,8 +115,23 @@ function deriveRequirementGroups(manifest: GhostManifest): GhostSetupRequirement
 }
 
 /** 需求条目 → 展示项(label 取声明原文;kind 决定弹窗文案口径)。 */
-function requirementRef(req: GhostSetupRequirement): string {
+export function requirementRef(req: GhostSetupRequirement): string {
   return `${req.kind}:${req.key}`;
+}
+
+/**
+ * oauth_connect 动作 id 的唯一编解码对:actionFor 与 reauthSuggest 生产、
+ * executeGhostSetupAction 反解共用。改动作 id 格式只能改这两个函数,
+ * 任何一侧散落的字面量都会造成"点重连拿 ACTION_STALE"的静默失配。
+ */
+export function oauthConnectActionId(ref: string): string {
+  return `oauth_connect:${ref}`;
+}
+
+export function parseOauthConnectSecretKey(actionId: string): string | null {
+  const prefix = oauthConnectActionId('secret:');
+  const key = actionId.startsWith(prefix) ? actionId.slice(prefix.length) : '';
+  return key.length > 0 ? key : null;
 }
 
 function actionFor(
@@ -134,7 +149,12 @@ function actionFor(
         : kind === 'client_config'
           ? 'open_client_settings'
           : 'open_plugin_settings';
-  return [{ id: `${actionKind}:${ref}`, kind: actionKind }];
+  return [
+    {
+      id: actionKind === 'oauth_connect' ? oauthConnectActionId(ref) : `${actionKind}:${ref}`,
+      kind: actionKind,
+    },
+  ];
 }
 
 function inlineSecretAction(

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -28,6 +28,7 @@ import {
   type GhostManifest,
   type GhostSetupAllowedAction,
   type GhostSetupAssessment,
+  type GhostSetupReauthSuggest,
   type GhostVideoRefMode,
   type GhostVideoResultParams,
   type InstalledGhost,
@@ -98,6 +99,10 @@ import { handleGhostSecretsRequest } from './runtime/ghostSecretsEndpoint.js';
 import { handleGhostOauthRequest } from './runtime/ghostOauthEndpoint.js';
 import { handleGhostConnectionsRequest } from './runtime/ghostConnectionsEndpoint.js';
 import { GhostOauthAccountManager, type GhostOauthDecl } from './ghostOauthAccounts.js';
+import {
+  appendReadyGhostOauthReauthSuggest,
+  findGhostOauthReauthSuggest,
+} from './ghostOauthScopeStaleness.js';
 import { mapGhostOauthConnectError } from './ghostOauthSetupError.js';
 import { reclaimLoopbackPort } from './portReclaim.js';
 import { GhostConnectionManager } from './ghostConnections.js';
@@ -593,6 +598,30 @@ function availableGhosts(): InstalledGhost[] {
   return getGhostManager().list().filter((ghost) =>
     isGhostAvailableForActiveSession(ghost.manifest.id),
   );
+}
+
+function projectGhostForRenderer(ghost: InstalledGhost): InstalledGhost {
+  try {
+    const suggest = getGhostOauthReauthSuggest(withRuntimeFiloGoogleClient(ghost.manifest));
+    return {
+      ...ghost,
+      ...(suggest
+        ? {
+            oauthScopeStale: {
+              secretKey: suggest.secretKey,
+              missingScopeCount: suggest.missingScopeCount,
+            },
+          }
+        : {}),
+    };
+  } catch (error) {
+    // 详情页角标是提示面，保险库异常不能让插件清单整体消失。
+    log.warn('ghost oauth scope stale projection omitted', {
+      ghostId: ghost.manifest.id,
+      errorType: error instanceof Error ? error.name : typeof error,
+    });
+    return ghost;
+  }
 }
 
 function findAvailableGhost(id: string): InstalledGhost | null {
@@ -2772,6 +2801,7 @@ function getGhostOauthAccountManager(): GhostOauthAccountManager {
       // 展示标签时报"已连接 xxx",没有时报通用授权成功)。
       onAccountConnected: ({ ghostId, label }) => {
         getGhostSetupChangeBus().emit(ghostId, { source: 'oauth' });
+        broadcastGhostsChanged(getGhostManager().list());
         broadcastGhostHostNotice(
           ghostId,
           label
@@ -2784,6 +2814,7 @@ function getGhostOauthAccountManager(): GhostOauthAccountManager {
           source: 'oauth',
           ref: secretKey,
         });
+        broadcastGhostsChanged(getGhostManager().list());
       },
       isConnectTargetCurrent: (ghostId, secretKey, decl) => {
         const ghost = findAvailableGhost(ghostId);
@@ -2822,6 +2853,22 @@ function getGhostConnectionManager(): GhostConnectionManager {
 
 let ghostSetupKvStore: GhostKvStore | null = null;
 
+/** 默认 OAuth 账号的授权面陈旧建议；只返回首个凭证槽，保持 envelope 有界。 */
+function getGhostOauthReauthSuggest(runtimeManifest: GhostManifest): GhostSetupReauthSuggest | undefined {
+  const oauthManager = getGhostOauthAccountManager();
+  const oauthDecls = new Map(
+    (runtimeManifest.network?.secrets ?? [])
+      .filter((secret) => secret.source === 'oauth' && secret.oauth)
+      .map((secret) => [secret.key, secret.oauth!] as const),
+  );
+  return findGhostOauthReauthSuggest(runtimeManifest, (secretKey) => {
+    const decl = oauthDecls.get(secretKey);
+    return decl
+      ? oauthManager.defaultScopeStaleness(runtimeManifest.id, secretKey, decl)
+      : null;
+  });
+}
+
 /**
  * Runtime-authoritative setup assessment used by ghost_list and ghost_call.
  * Unlike the legacy plugin-page projection this path is strict: storage or
@@ -2836,13 +2883,13 @@ export function getGhostSetupAssessment(ghostId: string): GhostSetupAssessment {
   const oauthManager = getGhostOauthAccountManager();
   const connectionManager = getGhostConnectionManager();
   let kvSnapshot: Record<string, unknown> | null = null;
-  return evaluateGhostSetupAssessment(
+  const assessment = evaluateGhostSetupAssessment(
     runtimeManifest,
     {
       secretSaved: (key) => ghostSecretSaved(ghostId, key),
       oauthStatus: (key) => {
         const decl = runtimeManifest.network?.secrets?.find((secret) => secret.key === key)?.oauth;
-        const accounts = oauthManager.listAccounts(ghostId, key);
+        const accounts = oauthManager.listAccounts(ghostId, key, decl);
         return {
           clientConfigured: oauthManager.clientConfigured(ghostId, key, decl),
           connected: accounts.filter((account) => account.status === 'connected').length,
@@ -2863,6 +2910,10 @@ export function getGhostSetupAssessment(ghostId: string): GhostSetupAssessment {
           configId === 'model-provider' && isModelAccessReady(),
       }),
     },
+  );
+  return appendReadyGhostOauthReauthSuggest(
+    assessment,
+    getGhostOauthReauthSuggest(runtimeManifest),
   );
 }
 
@@ -3735,6 +3786,7 @@ export function registerGhostIpc(): void {
       ghostId,
       onChanged: (secretKey) => {
         getGhostSetupChangeBus().emit(ghostId, { source: 'oauth', ref: secretKey });
+        broadcastGhostsChanged(getGhostManager().list());
       },
       log,
     });
@@ -4248,7 +4300,7 @@ export function registerGhostIpc(): void {
   });
 
   ipcMain.on('ghosts:list', (event) => {
-    event.returnValue = { ghosts: availableGhosts() };
+    event.returnValue = { ghosts: availableGhosts().map(projectGhostForRenderer) };
   });
 
   // Plugin 页的已安装快捷行按最近成功使用排序。历史是主机 UI 状态，不写入
@@ -4349,7 +4401,7 @@ export function registerGhostIpc(): void {
           secretSaved: (key) => ghostSecretSaved(ghostId, key),
           oauthStatus: (key) => {
             const decl = runtimeManifest.network?.secrets?.find((s) => s.key === key)?.oauth;
-            const accounts = oauthManager.listAccounts(ghostId, key);
+            const accounts = oauthManager.listAccounts(ghostId, key, decl);
             return {
               clientConfigured: oauthManager.clientConfigured(ghostId, key, decl),
               connected: accounts.filter((a) => a.status === 'connected').length,
@@ -4998,7 +5050,9 @@ function broadcastGhostsChanged(
 ): void {
   getGhostSetupManifestTracker().note(ghosts);
   sweepRevokedGhostUnread(ghosts, rosterAuthoritative);
-  const visible = ghosts.filter((ghost) => isGhostAvailableForActiveSession(ghost.manifest.id));
+  const visible = ghosts
+    .filter((ghost) => isGhostAvailableForActiveSession(ghost.manifest.id))
+    .map(projectGhostForRenderer);
   BrowserWindow.getAllWindows().forEach((window) => {
     if (window.isDestroyed()) return;
     window.webContents.send('ghosts:changed', { ghosts: visible });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -89,6 +89,7 @@ import {
 import {
   evaluateGhostSetupAssessment,
   handleGhostSetupStatusRequest,
+  parseOauthConnectSecretKey,
 } from './ghostSetupStatus.js';
 import { getGhostSetupChangeBus } from './ghostSetupChangeBus.js';
 import { GhostSetupManifestTracker } from './ghostSetupManifestTracker.js';
@@ -2801,7 +2802,7 @@ function getGhostOauthAccountManager(): GhostOauthAccountManager {
       // 展示标签时报"已连接 xxx",没有时报通用授权成功)。
       onAccountConnected: ({ ghostId, label }) => {
         getGhostSetupChangeBus().emit(ghostId, { source: 'oauth' });
-        broadcastGhostsChanged(getGhostManager().list());
+        broadcastGhostsChanged(getGhostManager().list(), false, { projectionOnly: true });
         broadcastGhostHostNotice(
           ghostId,
           label
@@ -2814,7 +2815,7 @@ function getGhostOauthAccountManager(): GhostOauthAccountManager {
           source: 'oauth',
           ref: secretKey,
         });
-        broadcastGhostsChanged(getGhostManager().list());
+        broadcastGhostsChanged(getGhostManager().list(), false, { projectionOnly: true });
       },
       isConnectTargetCurrent: (ghostId, secretKey, decl) => {
         const ghost = findAvailableGhost(ghostId);
@@ -2856,17 +2857,9 @@ let ghostSetupKvStore: GhostKvStore | null = null;
 /** 默认 OAuth 账号的授权面陈旧建议；只返回首个凭证槽，保持 envelope 有界。 */
 function getGhostOauthReauthSuggest(runtimeManifest: GhostManifest): GhostSetupReauthSuggest | undefined {
   const oauthManager = getGhostOauthAccountManager();
-  const oauthDecls = new Map(
-    (runtimeManifest.network?.secrets ?? [])
-      .filter((secret) => secret.source === 'oauth' && secret.oauth)
-      .map((secret) => [secret.key, secret.oauth!] as const),
+  return findGhostOauthReauthSuggest(runtimeManifest, (secretKey, decl) =>
+    oauthManager.defaultMissingScopes(runtimeManifest.id, secretKey, decl),
   );
-  return findGhostOauthReauthSuggest(runtimeManifest, (secretKey) => {
-    const decl = oauthDecls.get(secretKey);
-    return decl
-      ? oauthManager.defaultScopeStaleness(runtimeManifest.id, secretKey, decl)
-      : null;
-  });
 }
 
 /**
@@ -2889,7 +2882,7 @@ export function getGhostSetupAssessment(ghostId: string): GhostSetupAssessment {
       secretSaved: (key) => ghostSecretSaved(ghostId, key),
       oauthStatus: (key) => {
         const decl = runtimeManifest.network?.secrets?.find((secret) => secret.key === key)?.oauth;
-        const accounts = oauthManager.listAccounts(ghostId, key, decl);
+        const accounts = oauthManager.listAccounts(ghostId, key);
         return {
           clientConfigured: oauthManager.clientConfigured(ghostId, key, decl),
           connected: accounts.filter((account) => account.status === 'connected').length,
@@ -2911,6 +2904,9 @@ export function getGhostSetupAssessment(ghostId: string): GhostSetupAssessment {
       }),
     },
   );
+  // 性能短路:required 时建议注定被丢弃,不再为它读保险库。
+  // "required 绝不带建议"的契约不变量仍由 appendReadyGhostOauthReauthSuggest 守着。
+  if (assessment.state !== 'ready') return assessment;
   return appendReadyGhostOauthReauthSuggest(
     assessment,
     getGhostOauthReauthSuggest(runtimeManifest),
@@ -2936,11 +2932,10 @@ export async function executeGhostSetupAction(args: {
     };
   }
   if (args.action.kind === 'oauth_connect') {
-    const prefix = 'oauth_connect:secret:';
-    if (!args.action.id.startsWith(prefix)) {
+    const secretKey = parseOauthConnectSecretKey(args.action.id);
+    if (!secretKey) {
       return { ok: false, errorCode: 'ACTION_STALE', message: '授权动作已失效' };
     }
-    const secretKey = args.action.id.slice(prefix.length);
     const runtimeManifest = withRuntimeFiloGoogleClient(ghost.manifest);
     const decl = runtimeManifest.network?.secrets?.find(
       (secret) => secret.key === secretKey && secret.source === 'oauth',
@@ -3786,7 +3781,7 @@ export function registerGhostIpc(): void {
       ghostId,
       onChanged: (secretKey) => {
         getGhostSetupChangeBus().emit(ghostId, { source: 'oauth', ref: secretKey });
-        broadcastGhostsChanged(getGhostManager().list());
+        broadcastGhostsChanged(getGhostManager().list(), false, { projectionOnly: true });
       },
       log,
     });
@@ -4401,7 +4396,7 @@ export function registerGhostIpc(): void {
           secretSaved: (key) => ghostSecretSaved(ghostId, key),
           oauthStatus: (key) => {
             const decl = runtimeManifest.network?.secrets?.find((s) => s.key === key)?.oauth;
-            const accounts = oauthManager.listAccounts(ghostId, key, decl);
+            const accounts = oauthManager.listAccounts(ghostId, key);
             return {
               clientConfigured: oauthManager.clientConfigured(ghostId, key, decl),
               connected: accounts.filter((a) => a.status === 'connected').length,
@@ -5047,9 +5042,19 @@ function broadcastGhostProvisioning(active: boolean): void {
 function broadcastGhostsChanged(
   ghosts: InstalledGhost[],
   rosterAuthoritative = false,
+  opts?: {
+    /**
+     * true = 花名册没变,只是 renderer 投影字段(OAuth 陈旧角标)需要刷新。
+     * 跳过清单指纹、未读扫尾与 skill 链接对账这些只对装/卸/启停/换版有
+     * 意义的花名册侧效应,OAuth 账号操作不再连带两趟全量磁盘扫描。
+     */
+    projectionOnly?: boolean;
+  },
 ): void {
-  getGhostSetupManifestTracker().note(ghosts);
-  sweepRevokedGhostUnread(ghosts, rosterAuthoritative);
+  if (!opts?.projectionOnly) {
+    getGhostSetupManifestTracker().note(ghosts);
+    sweepRevokedGhostUnread(ghosts, rosterAuthoritative);
+  }
   const visible = ghosts
     .filter((ghost) => isGhostAvailableForActiveSession(ghost.manifest.id))
     .map(projectGhostForRenderer);
@@ -5071,7 +5076,7 @@ function broadcastGhostsChanged(
   // skill 槽共享链接对账:装/卸/启停/换版全走本广播,一处挂接全覆盖。
   // 异步合并执行,不阻塞广播;用全量 list() 而非 per-session 过滤后的 visible
   // (链接对账关心"装了什么",与当前会话可见性无关)。
-  scheduleGhostSkillReconcile();
+  if (!opts?.projectionOnly) scheduleGhostSkillReconcile();
 }
 
 // —— skill 槽链接对账调度:合并突发广播(in-flight + pending 双标志),

--- a/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
@@ -51,7 +51,7 @@ function fakeManager(
     })),
     disconnectAccount: vi.fn(),
     setDefaultAccount: vi.fn(() => true),
-    reportInsufficientScopes: vi.fn(() => true),
+    reportInsufficientScopes: vi.fn(() => 'stored' as const),
     ...overrides,
   };
 }
@@ -299,7 +299,7 @@ describe('POST /oauth/<key>/insufficient-scopes', () => {
     });
   }
 
-  it('合法证据去重后落默认账号并广播变更，成功 204', async () => {
+  it('合法证据落默认账号并广播变更(重复条目由存取层去重)，成功 204', async () => {
     const manager = fakeManager();
     const onChanged = vi.fn();
     const outcome = await report(
@@ -308,17 +308,32 @@ describe('POST /oauth/<key>/insufficient-scopes', () => {
       onChanged,
     );
     expect(outcome.status).toBe(204);
-    expect(manager.reportInsufficientScopes).toHaveBeenCalledWith(GHOST, 'acct', [
-      'scope.1',
-      'scope.2',
-    ]);
+    expect(manager.reportInsufficientScopes).toHaveBeenCalledWith(
+      GHOST,
+      'acct',
+      ['scope.1', 'scope.1', 'scope.2'],
+      DECLARED_SCOPES,
+    );
     expect(onChanged).toHaveBeenCalledWith('acct');
+  });
+
+  it('证据未变时成功 204 但不广播,重复上报不空转投影与配置卡重评估', async () => {
+    const manager = fakeManager({ reportInsufficientScopes: vi.fn(() => 'unchanged' as const) });
+    const onChanged = vi.fn();
+    const outcome = await report(JSON.stringify({ scopes: ['scope.1'] }), manager, onChanged);
+    expect(outcome.status).toBe(204);
+    expect(onChanged).not.toHaveBeenCalled();
   });
 
   it('64 条边界放行；65 条拒绝', async () => {
     const accepted = fakeManager();
     expect((await report(JSON.stringify({ scopes: DECLARED_SCOPES }), accepted)).status).toBe(204);
-    expect(accepted.reportInsufficientScopes).toHaveBeenCalledWith(GHOST, 'acct', DECLARED_SCOPES);
+    expect(accepted.reportInsufficientScopes).toHaveBeenCalledWith(
+      GHOST,
+      'acct',
+      DECLARED_SCOPES,
+      DECLARED_SCOPES,
+    );
 
     const rejected = fakeManager();
     expect(
@@ -378,7 +393,7 @@ describe('POST /oauth/<key>/insufficient-scopes', () => {
       (
         await report(
           JSON.stringify({ scopes: ['scope.1'] }),
-          fakeManager({ reportInsufficientScopes: vi.fn(() => false) }),
+          fakeManager({ reportInsufficientScopes: vi.fn(() => false as const) }),
         )
       ).status,
     ).toBe(500);

--- a/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
@@ -35,6 +35,7 @@ function fakeManager(overrides: Partial<GhostOauthEndpointManager> = {}): GhostO
         isDefault: true,
         createdAt: 1,
         avatarDataUrl: null,
+        scopeStale: true,
       },
     ]),
     connectAccount: vi.fn(async () => ({
@@ -46,6 +47,7 @@ function fakeManager(overrides: Partial<GhostOauthEndpointManager> = {}): GhostO
         isDefault: false,
         createdAt: 2,
         avatarDataUrl: null,
+        scopeStale: false,
       },
     })),
     disconnectAccount: vi.fn(),
@@ -76,12 +78,18 @@ function call(params: {
 
 describe('GET /oauth', () => {
   it('回全部 oauth 凭证槽状态,零令牌字节', async () => {
-    const outcome = await call({ method: 'GET', pathname: '/oauth' });
+    const manager = fakeManager();
+    const outcome = await call({ method: 'GET', pathname: '/oauth', manager });
     expect(outcome.status).toBe(200);
     const parsed = JSON.parse(outcome.body ?? '[]') as Array<Record<string, unknown>>;
     expect(parsed).toHaveLength(1);
     expect(parsed[0]).toMatchObject({ key: 'acct', clientConfigured: true, clientCustom: false });
-    expect((parsed[0].accounts as unknown[])[0]).toMatchObject({ id: 'acc-1', isDefault: true });
+    expect((parsed[0].accounts as unknown[])[0]).toMatchObject({
+      id: 'acc-1',
+      isDefault: true,
+      scopeStale: true,
+    });
+    expect(manager.listAccounts).toHaveBeenCalledWith(GHOST, 'acct', DECL);
     // 端点契约:响应体里不可能出现 token 类字段。
     expect(outcome.body).not.toMatch(/token|secret/i);
   });

--- a/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
@@ -7,10 +7,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { GhostKvError } from '../../ghostKvStore.js';
 import { GHOST_SECRET_VALUE_MAX_CHARS } from '../ghostSecretsEndpoint.js';
-import {
-  handleGhostOauthRequest,
-  type GhostOauthEndpointManager,
-} from '../ghostOauthEndpoint.js';
+import { handleGhostOauthRequest, type GhostOauthEndpointManager } from '../ghostOauthEndpoint.js';
 import type { GhostOauthDecl } from '../../ghostOauthAccounts.js';
 
 const GHOST = 'g-oauth';
@@ -21,7 +18,9 @@ const DECL: GhostOauthDecl = {
 };
 const SECRETS = new Map<string, GhostOauthDecl>([['acct', DECL]]);
 
-function fakeManager(overrides: Partial<GhostOauthEndpointManager> = {}): GhostOauthEndpointManager {
+function fakeManager(
+  overrides: Partial<GhostOauthEndpointManager> = {},
+): GhostOauthEndpointManager {
   return {
     clientConfigured: vi.fn(() => true),
     clientCustomized: vi.fn(() => false),
@@ -52,6 +51,7 @@ function fakeManager(overrides: Partial<GhostOauthEndpointManager> = {}): GhostO
     })),
     disconnectAccount: vi.fn(),
     setDefaultAccount: vi.fn(() => true),
+    reportInsufficientScopes: vi.fn(() => true),
     ...overrides,
   };
 }
@@ -114,7 +114,12 @@ describe('PUT /oauth/<key>/client', () => {
 
   it('clientSecret 省略/空串 = 纯 PKCE(undefined 传入)', async () => {
     const manager = fakeManager();
-    await call({ method: 'PUT', pathname: '/oauth/acct/client', body: JSON.stringify({ clientId: 'cid' }), manager });
+    await call({
+      method: 'PUT',
+      pathname: '/oauth/acct/client',
+      body: JSON.stringify({ clientId: 'cid' }),
+      manager,
+    });
     expect(manager.setClientConfig).toHaveBeenCalledWith(GHOST, 'acct', 'cid', undefined);
     await call({
       method: 'PUT',
@@ -126,9 +131,17 @@ describe('PUT /oauth/<key>/client', () => {
   });
 
   it('坏 body / 空 clientId → 400;超长 → 413;写失败 → 500;DELETE 清除 → 204', async () => {
-    expect((await call({ method: 'PUT', pathname: '/oauth/acct/client', body: '{broken' })).status).toBe(400);
     expect(
-      (await call({ method: 'PUT', pathname: '/oauth/acct/client', body: JSON.stringify({ clientId: '' }) })).status,
+      (await call({ method: 'PUT', pathname: '/oauth/acct/client', body: '{broken' })).status,
+    ).toBe(400);
+    expect(
+      (
+        await call({
+          method: 'PUT',
+          pathname: '/oauth/acct/client',
+          body: JSON.stringify({ clientId: '' }),
+        })
+      ).status,
     ).toBe(400);
     expect(
       (
@@ -160,7 +173,9 @@ describe('PUT /oauth/<key>/client', () => {
       ).status,
     ).toBe(500);
     const manager = fakeManager();
-    expect((await call({ method: 'DELETE', pathname: '/oauth/acct/client', manager })).status).toBe(204);
+    expect((await call({ method: 'DELETE', pathname: '/oauth/acct/client', manager })).status).toBe(
+      204,
+    );
     expect(manager.clearClientConfig).toHaveBeenCalledWith(GHOST, 'acct');
   });
 });
@@ -176,7 +191,9 @@ describe('POST /oauth/<key>/connect', () => {
     const outcome = await call({
       method: 'POST',
       pathname: '/oauth/acct/connect',
-      manager: fakeManager({ connectAccount: vi.fn(async () => ({ ok: false as const, error: 'TIMEOUT' as const })) }),
+      manager: fakeManager({
+        connectAccount: vi.fn(async () => ({ ok: false as const, error: 'TIMEOUT' as const })),
+      }),
     });
     expect(outcome.status).toBe(200);
     expect(JSON.parse(outcome.body ?? '{}')).toMatchObject({ ok: false, error: 'TIMEOUT' });
@@ -223,7 +240,9 @@ describe('POST /oauth/<key>/connect · scopes body(降面授权)', () => {
     const manager = fakeManager();
     const outcome = await connectWith(JSON.stringify({ scopes: ['read.a', 'read.a'] }), manager);
     expect(outcome.status).toBe(200);
-    expect(manager.connectAccount).toHaveBeenCalledWith(GHOST, 'acct', SCOPED, { scopes: ['read.a'] });
+    expect(manager.connectAccount).toHaveBeenCalledWith(GHOST, 'acct', SCOPED, {
+      scopes: ['read.a'],
+    });
   });
 
   it('无 body / 空 body / 无 scopes 字段的对象 = 不传 opts(申请全量声明面)', async () => {
@@ -254,10 +273,126 @@ describe('POST /oauth/<key>/connect · scopes body(降面授权)', () => {
   });
 });
 
+describe('POST /oauth/<key>/insufficient-scopes', () => {
+  const DECLARED_SCOPES = Array.from({ length: 64 }, (_, index) => `scope.${index}`);
+  const SCOPED: GhostOauthDecl = {
+    authorizeUrl: 'https://accounts.example.com/authorize',
+    tokenUrl: 'https://accounts.example.com/token',
+    scopes: DECLARED_SCOPES,
+  };
+  const SCOPED_SECRETS = new Map<string, GhostOauthDecl>([['acct', SCOPED]]);
+
+  function report(
+    body: string,
+    manager = fakeManager(),
+    onChanged = vi.fn(),
+    pathname = '/oauth/acct/insufficient-scopes',
+  ) {
+    return handleGhostOauthRequest({
+      method: 'POST',
+      pathname,
+      readBodyText: async () => body,
+      oauthSecrets: SCOPED_SECRETS,
+      manager,
+      ghostId: GHOST,
+      onChanged,
+    });
+  }
+
+  it('合法证据去重后落默认账号并广播变更，成功 204', async () => {
+    const manager = fakeManager();
+    const onChanged = vi.fn();
+    const outcome = await report(
+      JSON.stringify({ scopes: ['scope.1', 'scope.1', 'scope.2'] }),
+      manager,
+      onChanged,
+    );
+    expect(outcome.status).toBe(204);
+    expect(manager.reportInsufficientScopes).toHaveBeenCalledWith(GHOST, 'acct', [
+      'scope.1',
+      'scope.2',
+    ]);
+    expect(onChanged).toHaveBeenCalledWith('acct');
+  });
+
+  it('64 条边界放行；65 条拒绝', async () => {
+    const accepted = fakeManager();
+    expect((await report(JSON.stringify({ scopes: DECLARED_SCOPES }), accepted)).status).toBe(204);
+    expect(accepted.reportInsufficientScopes).toHaveBeenCalledWith(GHOST, 'acct', DECLARED_SCOPES);
+
+    const rejected = fakeManager();
+    expect(
+      (await report(JSON.stringify({ scopes: [...DECLARED_SCOPES, DECLARED_SCOPES[0]] }), rejected))
+        .status,
+    ).toBe(400);
+    expect(rejected.reportInsufficientScopes).not.toHaveBeenCalled();
+  });
+
+  it('任一未声明 scope 越界时整包 400，不落任何数据', async () => {
+    const manager = fakeManager();
+    const outcome = await report(
+      JSON.stringify({ scopes: ['scope.1', 'scope.not-declared'] }),
+      manager,
+    );
+    expect(outcome.status).toBe(400);
+    expect(manager.reportInsufficientScopes).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['非数组', { scopes: 'scope.1' }],
+    ['空数组', { scopes: [] }],
+    ['空字符串', { scopes: [''] }],
+    ['空白字符串', { scopes: ['   '] }],
+    ['超长字符串', { scopes: ['x'.repeat(257)] }],
+    ['非字符串', { scopes: [42] }],
+  ])('%s → 400 且不入库', async (_name, body) => {
+    const manager = fakeManager();
+    expect((await report(JSON.stringify(body), manager)).status).toBe(400);
+    expect(manager.reportInsufficientScopes).not.toHaveBeenCalled();
+  });
+
+  it('未知 key 404；非 POST 405；持久化失败 500', async () => {
+    expect(
+      (
+        await report(
+          JSON.stringify({ scopes: ['scope.1'] }),
+          fakeManager(),
+          vi.fn(),
+          '/oauth/unknown/insufficient-scopes',
+        )
+      ).status,
+    ).toBe(404);
+    expect(
+      (
+        await handleGhostOauthRequest({
+          method: 'GET',
+          pathname: '/oauth/acct/insufficient-scopes',
+          readBodyText: async () => '',
+          oauthSecrets: SCOPED_SECRETS,
+          manager: fakeManager(),
+          ghostId: GHOST,
+        })
+      ).status,
+    ).toBe(405);
+    expect(
+      (
+        await report(
+          JSON.stringify({ scopes: ['scope.1'] }),
+          fakeManager({ reportInsufficientScopes: vi.fn(() => false) }),
+        )
+      ).status,
+    ).toBe(500);
+  });
+});
+
 describe('账号操作', () => {
   it('DELETE /oauth/<key>/accounts/<id> 断开 → 204', async () => {
     const manager = fakeManager();
-    const outcome = await call({ method: 'DELETE', pathname: '/oauth/acct/accounts/acc-1', manager });
+    const outcome = await call({
+      method: 'DELETE',
+      pathname: '/oauth/acct/accounts/acc-1',
+      manager,
+    });
     expect(outcome.status).toBe(204);
     expect(manager.disconnectAccount).toHaveBeenCalledWith(GHOST, 'acct', 'acc-1');
   });
@@ -285,7 +420,9 @@ describe('账号操作', () => {
         })
       ).status,
     ).toBe(404);
-    expect((await call({ method: 'POST', pathname: '/oauth/acct/default', body: '{}' })).status).toBe(400);
+    expect(
+      (await call({ method: 'POST', pathname: '/oauth/acct/default', body: '{}' })).status,
+    ).toBe(400);
   });
 });
 
@@ -304,7 +441,10 @@ describe('路径与 key 准入', () => {
       const outcome2 = await call({ method: 'PUT', pathname, body: '{}' });
       expect([404, 405]).toContain(outcome2.status);
     }
-    expect((await call({ method: 'PUT', pathname: '/oauth/unknown/client', body: '{"clientId":"x"}' })).status).toBe(404);
+    expect(
+      (await call({ method: 'PUT', pathname: '/oauth/unknown/client', body: '{"clientId":"x"}' }))
+        .status,
+    ).toBe(404);
   });
 });
 
@@ -338,8 +478,12 @@ describe('tokenBroker 门控', () => {
 
   it('brokered 凭证的 client 自填/清除通道一律 405', async () => {
     const manager = fakeManager();
-    await expect(callAs('xd-atlassian', 'PUT', '/oauth/acct/client', manager)).resolves.toMatchObject({ status: 405 });
-    await expect(callAs('xd-atlassian', 'DELETE', '/oauth/acct/client', manager)).resolves.toMatchObject({ status: 405 });
+    await expect(
+      callAs('xd-atlassian', 'PUT', '/oauth/acct/client', manager),
+    ).resolves.toMatchObject({ status: 405 });
+    await expect(
+      callAs('xd-atlassian', 'DELETE', '/oauth/acct/client', manager),
+    ).resolves.toMatchObject({ status: 405 });
     expect(manager.setClientConfig).not.toHaveBeenCalled();
     expect(manager.clearClientConfig).not.toHaveBeenCalled();
   });
@@ -353,32 +497,27 @@ describe('tokenBroker 门控', () => {
     const blockedManager = fakeManager();
     const blocked = await callAs('third-party', 'POST', '/oauth/acct/connect', blockedManager);
     expect(blocked.status).toBe(200);
-    expect(JSON.parse(blocked.body ?? '{}')).toMatchObject({ ok: false, error: 'BROKER_FORBIDDEN' });
+    expect(JSON.parse(blocked.body ?? '{}')).toMatchObject({
+      ok: false,
+      error: 'BROKER_FORBIDDEN',
+    });
     expect(blockedManager.connectAccount).not.toHaveBeenCalled();
   });
 
   it('connect:可选择清单声明的备用 clientId;未声明值在端点拒绝', async () => {
     const manager = fakeManager();
-    const selected = await callAs(
-      'xd-atlassian',
-      'POST',
-      '/oauth/acct/connect',
-      manager,
-      { clientId: 'global-cid' },
-    );
+    const selected = await callAs('xd-atlassian', 'POST', '/oauth/acct/connect', manager, {
+      clientId: 'global-cid',
+    });
     expect(selected.status).toBe(200);
     expect(manager.connectAccount).toHaveBeenCalledWith('xd-atlassian', 'acct', BROKERED, {
       clientId: 'global-cid',
     });
 
     const rejectedManager = fakeManager();
-    const rejected = await callAs(
-      'xd-atlassian',
-      'POST',
-      '/oauth/acct/connect',
-      rejectedManager,
-      { clientId: 'foreign-cid' },
-    );
+    const rejected = await callAs('xd-atlassian', 'POST', '/oauth/acct/connect', rejectedManager, {
+      clientId: 'foreign-cid',
+    });
     expect(rejected.status).toBe(400);
     expect(rejectedManager.connectAccount).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
@@ -6,7 +6,8 @@
  * 协议(意识 settingsHtml 页面用,`fetch('/oauth')`):
  * - GET  /oauth                          → 200 + [{ key, clientConfigured, accounts }]
  *   (仅 source:'oauth' 的凭证;accounts 只含 {id,label,status,isDefault,
- *   avatarDataUrl},零令牌字节——avatarDataUrl 是主机下载转码的头像小图);
+ *   avatarDataUrl,scopeStale},零令牌字节——avatarDataUrl 是主机下载转码
+ *   的头像小图,scopeStale 是宿主据授权面快照计算的非阻塞提示);
  * - PUT  /oauth/<key>/client             → body {"clientId":"...","clientSecret":"..."}
  *   写入用户自填的 OAuth 客户端凭证(clientSecret 可省略 = 纯 PKCE),204;
  * - DELETE /oauth/<key>/client           → 清除 client 凭证,204(幂等);
@@ -48,7 +49,7 @@ export interface GhostOauthEndpointManager {
   clientCustomized(ghostId: string, secretKey: string): boolean;
   setClientConfig(ghostId: string, secretKey: string, clientId: string, clientSecret?: string): boolean;
   clearClientConfig(ghostId: string, secretKey: string): void;
-  listAccounts(ghostId: string, secretKey: string): GhostOauthAccountView[];
+  listAccounts(ghostId: string, secretKey: string, decl?: GhostOauthDecl): GhostOauthAccountView[];
   connectAccount(
     ghostId: string,
     secretKey: string,
@@ -100,7 +101,7 @@ export async function handleGhostOauthRequest(args: {
         clientConfigured: manager.clientConfigured(ghostId, key, keyDecl),
         // 自填与内置分开报:settingsHtml 据此显示"内置应用身份 / 已自定义"。
         clientCustom: manager.clientCustomized(ghostId, key),
-        accounts: manager.listAccounts(ghostId, key),
+        accounts: manager.listAccounts(ghostId, key, keyDecl),
       }));
       return { status: 200, body: JSON.stringify(list) };
     } catch (err) {

--- a/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
@@ -7,7 +7,7 @@
  * - GET  /oauth                          → 200 + [{ key, clientConfigured, accounts }]
  *   (仅 source:'oauth' 的凭证;accounts 只含 {id,label,status,isDefault,
  *   avatarDataUrl,scopeStale},零令牌字节——avatarDataUrl 是主机下载转码
- *   的头像小图,scopeStale 是宿主据授权面快照计算的非阻塞提示);
+ *   的头像小图,scopeStale 是宿主据真实缺权证据或授权面快照计算的非阻塞提示);
  * - PUT  /oauth/<key>/client             → body {"clientId":"...","clientSecret":"..."}
  *   写入用户自填的 OAuth 客户端凭证(clientSecret 可省略 = 纯 PKCE),204;
  * - DELETE /oauth/<key>/client           → 清除 client 凭证,204(幂等);
@@ -19,6 +19,8 @@
  * - DELETE /oauth/<key>/accounts/<id>    → 断开账号,204(幂等);
  * - POST /oauth/<key>/default            → body {"accountId":"..."} 设默认账号,
  *   204;账号不存在 404;
+ * - POST /oauth/<key>/insufficient-scopes → body {"scopes":[...]} 上报真实 API
+ *   返回的缺失权限证据；只接受当前清单声明内的 scope，成功 204;
  * - 未声明 / 非 oauth 的 key → 404;坏 body / 空值 → 400;值超长 → 413;
  *   其它 method → 405;保险库写失败 → 500(不外泄细节)。
  *
@@ -47,7 +49,12 @@ export interface GhostOauthEndpointManager {
   clientConfigured(ghostId: string, secretKey: string, decl?: GhostOauthDecl): boolean;
   /** 用户是否自填过(UI 区分"内置应用身份 / 已自定义")。 */
   clientCustomized(ghostId: string, secretKey: string): boolean;
-  setClientConfig(ghostId: string, secretKey: string, clientId: string, clientSecret?: string): boolean;
+  setClientConfig(
+    ghostId: string,
+    secretKey: string,
+    clientId: string,
+    clientSecret?: string,
+  ): boolean;
   clearClientConfig(ghostId: string, secretKey: string): void;
   listAccounts(ghostId: string, secretKey: string, decl?: GhostOauthDecl): GhostOauthAccountView[];
   connectAccount(
@@ -62,6 +69,7 @@ export interface GhostOauthEndpointManager {
   ): Promise<GhostOauthConnectResult>;
   disconnectAccount(ghostId: string, secretKey: string, accountId: string): void;
   setDefaultAccount(ghostId: string, secretKey: string, accountId: string): boolean;
+  reportInsufficientScopes(ghostId: string, secretKey: string, scopes: readonly string[]): boolean;
 }
 
 export async function handleGhostOauthRequest(args: {
@@ -80,7 +88,8 @@ export async function handleGhostOauthRequest(args: {
   onChanged?: (secretKey: string) => void;
   log?: { warn(message: string, meta?: Record<string, unknown>): void };
 }): Promise<GhostOauthRequestOutcome> {
-  const { method, pathname, readBodyText, oauthSecrets, networkHosts, manager, ghostId, log } = args;
+  const { method, pathname, readBodyText, oauthSecrets, networkHosts, manager, ghostId, log } =
+    args;
   const notifyChanged = (secretKey: string): void => {
     try {
       args.onChanged?.(secretKey);
@@ -126,7 +135,8 @@ export async function handleGhostOauthRequest(args: {
     try {
       text = await readBodyText();
     } catch (err) {
-      if (err instanceof GhostKvError && err.code === 'TOO_LARGE') return { ok: false, status: 413 };
+      if (err instanceof GhostKvError && err.code === 'TOO_LARGE')
+        return { ok: false, status: 413 };
       return { ok: false, status: 400 };
     }
     try {
@@ -189,7 +199,11 @@ export async function handleGhostOauthRequest(args: {
     if (decl.tokenBroker !== undefined && !isOfficialGhostId(ghostId)) {
       return {
         status: 200,
-        body: JSON.stringify({ ok: false, error: 'BROKER_FORBIDDEN', detail: 'tokenBroker 仅第一方官方意识可用' }),
+        body: JSON.stringify({
+          ok: false,
+          error: 'BROKER_FORBIDDEN',
+          detail: 'tokenBroker 仅第一方官方意识可用',
+        }),
       };
     }
     // 可选 body {"scopes":[...],"clientId":"..."}:scopes 是本次授权申请
@@ -202,7 +216,8 @@ export async function handleGhostOauthRequest(args: {
       const text = await readBodyText();
       if (text.trim().length > 0) {
         const parsed = JSON.parse(text) as unknown;
-        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return { status: 400 };
+        if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed))
+          return { status: 400 };
         const rawScopes = (parsed as Record<string, unknown>).scopes;
         if (rawScopes !== undefined) {
           if (!Array.isArray(rawScopes) || rawScopes.length === 0) return { status: 400 };
@@ -253,6 +268,37 @@ export async function handleGhostOauthRequest(args: {
       return { status: 200, body: JSON.stringify(result) };
     } catch (err) {
       log?.warn('ghost oauth 授权流程意外失败', { ghostId, secretKey, err: String(err) });
+      return { status: 500 };
+    }
+  }
+
+  if (action === 'insufficient-scopes' && segments.length === 2) {
+    if (method !== 'POST') return { status: 405 };
+    const parsed = await readJsonBody();
+    if (!parsed.ok) return { status: parsed.status };
+    const rawScopes = parsed.body.scopes;
+    if (!Array.isArray(rawScopes) || rawScopes.length === 0 || rawScopes.length > 64) {
+      return { status: 400 };
+    }
+    const declared = new Set(decl.scopes ?? []);
+    const scopes: string[] = [];
+    for (const scope of rawScopes) {
+      if (
+        typeof scope !== 'string' ||
+        scope.trim().length === 0 ||
+        scope.length > 256 ||
+        !declared.has(scope)
+      ) {
+        return { status: 400 };
+      }
+      if (!scopes.includes(scope)) scopes.push(scope);
+    }
+    try {
+      if (!manager.reportInsufficientScopes(ghostId, secretKey, scopes)) return { status: 500 };
+      notifyChanged(secretKey);
+      return { status: 204 };
+    } catch (err) {
+      log?.warn('ghost oauth 缺失 scope 证据入库失败', { ghostId, secretKey, err: String(err) });
       return { status: 500 };
     }
   }

--- a/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
@@ -69,7 +69,13 @@ export interface GhostOauthEndpointManager {
   ): Promise<GhostOauthConnectResult>;
   disconnectAccount(ghostId: string, secretKey: string, accountId: string): void;
   setDefaultAccount(ghostId: string, secretKey: string, accountId: string): boolean;
-  reportInsufficientScopes(ghostId: string, secretKey: string, scopes: readonly string[]): boolean;
+  /** 'unchanged' = 证据已在库未重写(调用方跳过广播);false = 无默认账号或写失败。 */
+  reportInsufficientScopes(
+    ghostId: string,
+    secretKey: string,
+    scopes: readonly string[],
+    declScopes: readonly string[],
+  ): 'stored' | 'unchanged' | false;
 }
 
 export async function handleGhostOauthRequest(args: {
@@ -280,22 +286,25 @@ export async function handleGhostOauthRequest(args: {
     if (!Array.isArray(rawScopes) || rawScopes.length === 0 || rawScopes.length > 64) {
       return { status: 400 };
     }
+    // 逐字属于声明面即形状合法(清单校验已保证声明 scope ≤200 字符、无空白),
+    // 任一越界整包 400;重复条目由存取层合并去重。
     const declared = new Set(decl.scopes ?? []);
     const scopes: string[] = [];
     for (const scope of rawScopes) {
-      if (
-        typeof scope !== 'string' ||
-        scope.trim().length === 0 ||
-        scope.length > 256 ||
-        !declared.has(scope)
-      ) {
-        return { status: 400 };
-      }
-      if (!scopes.includes(scope)) scopes.push(scope);
+      if (typeof scope !== 'string' || !declared.has(scope)) return { status: 400 };
+      scopes.push(scope);
     }
     try {
-      if (!manager.reportInsufficientScopes(ghostId, secretKey, scopes)) return { status: 500 };
-      notifyChanged(secretKey);
+      const stored = manager.reportInsufficientScopes(
+        ghostId,
+        secretKey,
+        scopes,
+        decl.scopes ?? [],
+      );
+      if (stored === false) return { status: 500 };
+      // 证据未变时不广播:插件在用户重连前会反复撞同一权限错误并 fire-and-forget
+      // 重报,无变更广播只会空转投影与在途配置卡的重评估循环。
+      if (stored === 'stored') notifyChanged(secretKey);
       return { status: 204 };
     } catch (err) {
       log?.warn('ghost oauth 缺失 scope 证据入库失败', { ghostId, secretKey, err: String(err) });

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ghostWorkdirGate.test.ts
@@ -382,6 +382,40 @@ describe('ghost_call 兜底拒绝', () => {
     const deps = makeDeps();
     const r = await deps.callGhostTool({ ghostId: 'art', tool: 'run', args: {} });
     expect(r).toMatchObject({ ok: true, result: 'done' });
+    expect(r).not.toHaveProperty('setup');
+    expect(dispatchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('ready + scope stale 时成功 envelope 附非阻塞 reauthSuggest', async () => {
+    const assessment = {
+      state: 'ready' as const,
+      revision: 3,
+      groups: [],
+      reauthSuggest: {
+        ghostId: 'art',
+        secretKey: 'account',
+        missingScopes: ['scope.new'],
+        missingScopeCount: 1,
+        requirement: {
+          ref: 'secret:account',
+          kind: 'oauth' as const,
+          label: 'Account',
+          action: {
+            id: 'oauth_connect:secret:account',
+            kind: 'oauth_connect' as const,
+          },
+        },
+      },
+    };
+    setupAssessmentMock.mockReturnValue(assessment);
+
+    const result = await makeDeps().callGhostTool({ ghostId: 'art', tool: 'run', args: {} });
+
+    expect(result).toMatchObject({
+      ok: true,
+      result: 'done',
+      setup: { state: 'ready', reauthSuggest: { secretKey: 'account' } },
+    });
     expect(dispatchMock).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -1026,6 +1026,7 @@ export function getCindyGhostsMcpDeps(
           setup: finalAssessment,
         };
       }
+      let readyAssessment = finalAssessment;
       // 批量预授权(grant_only):只过户不派发。它与普通调用共用上面的
       // Host-authoritative setup gate，确保任何授权副作用之前插件已经 ready。
       if (grantOnly) {
@@ -1120,6 +1121,7 @@ export function getCindyGhostsMcpDeps(
               setup: postGrantAssessment,
             };
           }
+          readyAssessment = postGrantAssessment;
         } catch {
           return {
             ok: false,
@@ -1130,6 +1132,7 @@ export function getCindyGhostsMcpDeps(
         log.info('ghost grant-only: batch pre-granted', { ghostId, count: grant.hashes.length });
         return {
           ok: true,
+          ...(readyAssessment.reauthSuggest ? { setup: readyAssessment } : {}),
           result: {
             ok: true,
             granted_count: grant.hashes.length,
@@ -1263,6 +1266,7 @@ export function getCindyGhostsMcpDeps(
             setup: preDispatchAssessment,
           };
         }
+        readyAssessment = preDispatchAssessment;
       } catch {
         return {
           ok: false,
@@ -1324,6 +1328,7 @@ export function getCindyGhostsMcpDeps(
             setup: postCtxAssessment,
           };
         }
+        readyAssessment = postCtxAssessment;
       } catch {
         return {
           ok: false,
@@ -1358,7 +1363,11 @@ export function getCindyGhostsMcpDeps(
       // 在意识未声明媒体字段时以 xdt_media_produced 注入,兜底 IM/hook 送达。
       const producedMedia = drainGhostCallMedia(ghostId, callId);
       const finalized = withCardToken(result, cardService.finalizeCall(callId), callId);
-      return finalized.ok && producedMedia.length > 0 ? { ...finalized, producedMedia } : finalized;
+      if (!finalized.ok) return finalized;
+      const advisory = readyAssessment.reauthSuggest ? { setup: readyAssessment } : {};
+      return producedMedia.length > 0
+        ? { ...finalized, ...advisory, producedMedia }
+        : { ...finalized, ...advisory };
     },
     async forgeGuide(): Promise<string> {
       return FORGE_GUIDE;

--- a/apps/desktop/src/main/mcp-integrations/ghost.ts
+++ b/apps/desktop/src/main/mcp-integrations/ghost.ts
@@ -50,7 +50,11 @@ import {
 import { classifyLocalAttachmentPath } from '../cindy-brain/ghostLocalPathGrant.js';
 import { toolNotFoundMessage } from '../cindy-brain/pipeDispatcher.js';
 import { getSessionFsSnapshot } from '../localDb/ipc/sessions.js';
-import { deriveGhostSessionContext, type GhostSessionContextInjected } from '../../shared/ghost.js';
+import {
+  deriveGhostSessionContext,
+  type GhostSessionContextInjected,
+  type GhostSetupAssessment,
+} from '../../shared/ghost.js';
 import { withCardToken } from '../cindy-brain/cardService.js';
 import { drainGhostCallMedia } from '../cindy-brain/ghostMediaLedger.js';
 import {
@@ -1026,7 +1030,6 @@ export function getCindyGhostsMcpDeps(
           setup: finalAssessment,
         };
       }
-      let readyAssessment = finalAssessment;
       // 批量预授权(grant_only):只过户不派发。它与普通调用共用上面的
       // Host-authoritative setup gate，确保任何授权副作用之前插件已经 ready。
       if (grantOnly) {
@@ -1111,8 +1114,9 @@ export function getCindyGhostsMcpDeps(
             message: t('newChat.pluginSetup.targetDisabledInWorkdir'),
           };
         }
+        let postGrantAssessment: GhostSetupAssessment;
         try {
-          const postGrantAssessment = getGhostSetupAssessment(ghostId);
+          postGrantAssessment = getGhostSetupAssessment(ghostId);
           if (postGrantAssessment.state !== 'ready') {
             return {
               ok: false,
@@ -1121,7 +1125,6 @@ export function getCindyGhostsMcpDeps(
               setup: postGrantAssessment,
             };
           }
-          readyAssessment = postGrantAssessment;
         } catch {
           return {
             ok: false,
@@ -1132,7 +1135,7 @@ export function getCindyGhostsMcpDeps(
         log.info('ghost grant-only: batch pre-granted', { ghostId, count: grant.hashes.length });
         return {
           ok: true,
-          ...(readyAssessment.reauthSuggest ? { setup: readyAssessment } : {}),
+          ...(postGrantAssessment.reauthSuggest ? { setup: postGrantAssessment } : {}),
           result: {
             ok: true,
             granted_count: grant.hashes.length,
@@ -1266,7 +1269,6 @@ export function getCindyGhostsMcpDeps(
             setup: preDispatchAssessment,
           };
         }
-        readyAssessment = preDispatchAssessment;
       } catch {
         return {
           ok: false,
@@ -1318,8 +1320,9 @@ export function getCindyGhostsMcpDeps(
           message: toolNotFoundMessage(ghostId, tool, postCtx.manifest.tools),
         };
       }
+      let postCtxAssessment: GhostSetupAssessment;
       try {
-        const postCtxAssessment = getGhostSetupAssessment(ghostId);
+        postCtxAssessment = getGhostSetupAssessment(ghostId);
         if (postCtxAssessment.state !== 'ready') {
           return {
             ok: false,
@@ -1328,7 +1331,6 @@ export function getCindyGhostsMcpDeps(
             setup: postCtxAssessment,
           };
         }
-        readyAssessment = postCtxAssessment;
       } catch {
         return {
           ok: false,
@@ -1364,7 +1366,8 @@ export function getCindyGhostsMcpDeps(
       const producedMedia = drainGhostCallMedia(ghostId, callId);
       const finalized = withCardToken(result, cardService.finalizeCall(callId), callId);
       if (!finalized.ok) return finalized;
-      const advisory = readyAssessment.reauthSuggest ? { setup: readyAssessment } : {};
+      // 附最后一道 gate(postCtx)的快照:它是派发前最新的 ready 判定。
+      const advisory = postCtxAssessment.reauthSuggest ? { setup: postCtxAssessment } : {};
       return producedMedia.length > 0
         ? { ...finalized, ...advisory, producedMedia }
         : { ...finalized, ...advisory };

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx
@@ -11,6 +11,7 @@ import { useLayoutEffect, useRef, useState, type ReactNode } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import {
   AppWindow,
+  AlertTriangle,
   ArrowUp,
   Bot,
   ChevronDown,
@@ -416,11 +417,14 @@ export function GhostPluginDetailView({
             <div className={cn(DETAIL_SECTION_CONTENT_CLASS, 'space-y-3')}>
               {detail.hasSettingsUi ? (
                 ghost ? (
-                  <GhostSettingsWebview
-                    ghost={ghost}
-                    title={t('settings.ghosts.detail.settingsTitle', { name: detail.name })}
-                    appearance="plugin"
-                  />
+                  <>
+                    {ghost.oauthScopeStale ? <OauthScopeStaleBadge /> : null}
+                    <GhostSettingsWebview
+                      ghost={ghost}
+                      title={t('settings.ghosts.detail.settingsTitle', { name: detail.name })}
+                      appearance="plugin"
+                    />
+                  </>
                 ) : (
                   <div
                     className={cn(
@@ -465,6 +469,24 @@ export function GhostPluginDetailView({
         <DetailsSection detail={detail} panelStatus={panelStatus} />
       </article>
     </main>
+  );
+}
+
+/** 宿主侧非阻塞角标；重新连接动作继续复用插件设置区已有入口。 */
+export function OauthScopeStaleBadge() {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="status"
+      className="inline-flex w-fit max-w-full items-center gap-1.5 rounded-full bg-[var(--warning-bg-soft)] px-3 py-1.5 text-12 leading-5 text-[var(--text-secondary)]"
+    >
+      <AlertTriangle
+        size={13}
+        className="shrink-0 text-[var(--warning-fg)]"
+        aria-hidden="true"
+      />
+      <span>{t('settings.ghosts.detail.oauthScopeStale')}</span>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
+++ b/apps/desktop/src/renderer/features/plugin/__tests__/GhostPluginDetailSections.test.tsx
@@ -10,6 +10,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 const toastMocks = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
 
 vi.mock('@/lib/toast', () => ({ toast: toastMocks }));
+vi.mock('@/cindy-brain/GhostSettingsWebview', () => ({
+  GhostSettingsWebview: () => <div data-testid="ghost-settings-webview" />,
+}));
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -46,6 +49,8 @@ vi.mock('react-i18next', () => ({
         'settings.ghosts.detail.collapseInfoValue': `Collapse ${String(options?.label ?? '')}`,
         'settings.ghosts.detail.panelNotDocked': 'Not docked',
         'settings.ghosts.detail.cindyPrefs.noModels': 'No models available',
+        'settings.ghosts.detail.oauthScopeStale':
+          'This authorization does not include newly added permissions. Reconnect to enable them.',
       };
       return labels[key] ?? key;
     },
@@ -127,6 +132,50 @@ afterEach(() => {
 });
 
 describe('Ghost plugin detail sections', () => {
+  it('shows a non-blocking stale OAuth scope badge inside the configuration section', () => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    render(
+      <GhostPluginDetailView
+        ghost={{
+          manifest: {
+            schemaVersion: 2,
+            id: detail.id,
+            name: detail.name,
+            version: detail.version,
+            kind: 'chip',
+            entry: 'main.js',
+            slots: [],
+            settingsHtml: 'settings.html',
+          },
+          dir: detail.installDir ?? '/tmp/plugin',
+          enabled: true,
+          oauthScopeStale: { secretKey: 'account', missingScopeCount: 2 },
+        }}
+        detail={{ ...detail, hasSettingsUi: true }}
+        panelStatus="Docked"
+        onBack={vi.fn()}
+        onToggle={vi.fn()}
+        onUse={vi.fn()}
+        onUpdate={vi.fn()}
+        onUpdateFromFile={vi.fn()}
+        onUninstall={vi.fn()}
+        toggleDisabled={false}
+      />,
+    );
+
+    const badge = screen.getByRole('status');
+    expect(badge.textContent).toContain('newly added permissions');
+    expect(badge.className).toContain('bg-[var(--warning-bg-soft)]');
+    expect(screen.getByTestId('ghost-settings-webview')).toBeTruthy();
+  });
+
   it('keeps the detail surface on one centered content grid', () => {
     vi.stubGlobal(
       'ResizeObserver',

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3536,6 +3536,7 @@
         "exportFileType": "Cindy Plugin",
         "settingsTitle": "{{name}} Settings",
         "settingsUnavailableUntilRestore": "Restore the plugin to use this configuration again.",
+        "oauthScopeStale": "This authorization does not include newly added permissions. Reconnect to enable them.",
         "configurationTitle": "Configuration",
         "openTool": "View details for Tool {{name}}",
         "noToolDescription": "No description is available for this Tool.",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3536,7 +3536,7 @@
         "exportFileType": "Cindy Plugin",
         "settingsTitle": "{{name}} Settings",
         "settingsUnavailableUntilRestore": "Restore the plugin to use this configuration again.",
-        "oauthScopeStale": "This authorization does not include newly added permissions. Reconnect to enable them.",
+        "oauthScopeStale": "This authorization does not include newly added permissions. Reconnect to grant them.",
         "configurationTitle": "Configuration",
         "openTool": "View details for Tool {{name}}",
         "noToolDescription": "No description is available for this Tool.",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3535,6 +3535,7 @@
         "exportFileType": "Cindy プラグイン",
         "settingsTitle": "{{name}} の設定",
         "settingsUnavailableUntilRestore": "この設定を再び使用するには、プラグインを復元してください。",
+        "oauthScopeStale": "現在の認証には新しく追加された権限が含まれていません。再接続すると有効になります。",
         "configurationTitle": "設定",
         "openTool": "Tool {{name}} の詳細を表示",
         "noToolDescription": "この Tool には説明がありません。",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3535,7 +3535,7 @@
         "exportFileType": "Cindy プラグイン",
         "settingsTitle": "{{name}} の設定",
         "settingsUnavailableUntilRestore": "この設定を再び使用するには、プラグインを復元してください。",
-        "oauthScopeStale": "現在の認証には新しく追加された権限が含まれていません。再接続すると有効になります。",
+        "oauthScopeStale": "現在の認証には新しく追加された権限が含まれていません。再接続して権限を取得してください。",
         "configurationTitle": "設定",
         "openTool": "Tool {{name}} の詳細を表示",
         "noToolDescription": "この Tool には説明がありません。",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3535,7 +3535,7 @@
         "exportFileType": "Cindy 플러그인",
         "settingsTitle": "{{name}} 설정",
         "settingsUnavailableUntilRestore": "이 설정을 다시 사용하려면 플러그인을 복원하세요.",
-        "oauthScopeStale": "현재 인증에 새로 추가된 권한이 포함되어 있지 않습니다. 다시 연결하면 적용됩니다.",
+        "oauthScopeStale": "현재 인증에 새로 추가된 권한이 포함되어 있지 않습니다. 다시 연결해 권한을 받으세요.",
         "configurationTitle": "설정",
         "openTool": "Tool {{name}} 세부 정보 보기",
         "noToolDescription": "이 Tool에는 설명이 없습니다.",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3535,6 +3535,7 @@
         "exportFileType": "Cindy 플러그인",
         "settingsTitle": "{{name}} 설정",
         "settingsUnavailableUntilRestore": "이 설정을 다시 사용하려면 플러그인을 복원하세요.",
+        "oauthScopeStale": "현재 인증에 새로 추가된 권한이 포함되어 있지 않습니다. 다시 연결하면 적용됩니다.",
         "configurationTitle": "설정",
         "openTool": "Tool {{name}} 세부 정보 보기",
         "noToolDescription": "이 Tool에는 설명이 없습니다.",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3535,6 +3535,7 @@
         "exportFileType": "Cindy 插件",
         "settingsTitle": "{{name}} 设置",
         "settingsUnavailableUntilRestore": "恢复插件后可继续使用这项配置。",
+        "oauthScopeStale": "当前授权未包含插件新增权限，重新连接后生效。",
         "configurationTitle": "配置",
         "openTool": "查看 Tool {{name}} 的详情",
         "noToolDescription": "该 Tool 暂无描述。",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3535,7 +3535,7 @@
         "exportFileType": "Cindy 插件",
         "settingsTitle": "{{name}} 设置",
         "settingsUnavailableUntilRestore": "恢复插件后可继续使用这项配置。",
-        "oauthScopeStale": "当前授权未包含插件新增权限，重新连接后生效。",
+        "oauthScopeStale": "当前授权未包含插件新增权限，请重新连接补齐授权。",
         "configurationTitle": "配置",
         "openTool": "查看 Tool {{name}} 的详情",
         "noToolDescription": "该 Tool 暂无描述。",

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -582,8 +582,14 @@ export interface GhostSecretExchangeDecl {
   ttlSeconds?: number;
 }
 
-/** OAuth 凭证:scopes 条数上限(超出拒装;确认框逐条展示要可读)。 */
-export const GHOST_OAUTH_SCOPES_MAX = 32;
+/**
+ * OAuth 凭证:scopes 条数上限(超出拒装;确认框逐条展示要可读)。
+ * 32→48(2026-08):原值按当时最大存量顶格(xd-feishu 老登录链全集 32 条),
+ * xd-feishu 补审批/表情/导入等能力到 41 条后,上限随最大存量演进。注意本校验
+ * 取值级"严出"(plugin-security-and-authoring.md §7):超 32 条的包在旧版客户端
+ * 拒装,插件市场铺开须等携带本值的客户端先行发布。
+ */
+export const GHOST_OAUTH_SCOPES_MAX = 48;
 /** OAuth broker 模式可声明的备用 clientId 上限(默认 clientId 不计入)。 */
 export const GHOST_OAUTH_CLIENT_ID_ALTERNATIVES_MAX = 8;
 /** OAuth 凭证:extraAuthorizeParams 条数上限。 */

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -646,7 +646,7 @@ export interface GhostSecretOauthDecl {
   clientIdAlternatives?: string[];
   /** 可选:内置 client 的 secret(与 clientId 成对;纯 PKCE 服务商可省略)。 */
   clientSecret?: string;
-  /** 申请的 scope 列表(0–32 条,确认框逐条展示;缺省 = 不带 scope 参数)。 */
+  /** 申请的 scope 列表(0–48 条,确认框逐条展示;缺省 = 不带 scope 参数)。 */
   scopes?: string[];
   /**
    * 可选:authorize URL 里 scope 参数的拼接分隔符。OAuth 标准是空格(缺省),

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -588,6 +588,11 @@ export interface GhostSecretExchangeDecl {
  * xd-feishu 补审批/表情/导入等能力到 41 条后,上限随最大存量演进。注意本校验
  * 取值级"严出"(plugin-security-and-authoring.md §7):超 32 条的包在旧版客户端
  * 拒装,插件市场铺开须等携带本值的客户端先行发布。
+ *
+ * 涨过 64 前必须同步两处只留了防御余量的 64 上限,否则会拒绝合法的缺权上报
+ * /静默判废 assessment:insufficient-scopes 端点的整包条数上限
+ * (runtime/ghostOauthEndpoint.ts)与 cindy-tools 的 SETUP_REAUTH_SCOPE_MAX
+ * (ghost/mcpServer.ts,包依赖方向不允许直接引用本常量)。
  */
 export const GHOST_OAUTH_SCOPES_MAX = 48;
 /** OAuth broker 模式可声明的备用 clientId 上限(默认 clientId 不计入)。 */

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -1082,6 +1082,26 @@ export interface GhostSetupAssessmentGroup {
 }
 
 /**
+ * 插件仍可调用、但默认 OAuth 账号的全量授权面落后于当前清单时的非阻塞建议。
+ * 只含 scope 名称与 Host 生成的动作引用，不含令牌或 client 凭证。
+ */
+export interface GhostSetupReauthSuggest {
+  ghostId: string;
+  secretKey: string;
+  missingScopes: string[];
+  missingScopeCount: number;
+  requirement: {
+    ref: string;
+    kind: 'oauth';
+    label: string;
+    action: {
+      id: string;
+      kind: 'oauth_connect';
+    };
+  };
+}
+
+/**
  * Setup Runtime 的完整判定结果。groups 之间 all-of，组内 any-of；
  * revision 由 Host 变更总线维护，用于丢弃过期卡片更新。
  */
@@ -1089,6 +1109,8 @@ export interface GhostSetupAssessment {
   state: 'ready' | 'required';
   revision: number;
   groups: GhostSetupAssessmentGroup[];
+  /** ready 语义不变；Agent 可据此建议用户重新连接，但不得拦截当前调用。 */
+  reauthSuggest?: GhostSetupReauthSuggest;
 }
 
 /** Agent 可选提供的展示编排；身份、Action 和完成状态仍由 Host 决定。 */
@@ -1320,6 +1342,11 @@ export interface InstalledGhost {
    * 文件缺失或超限时缺省)。renderer 直接作 <img src> 用,无需 loading 态。
    */
   iconDataUrl?: string;
+  /** 插件详情页宿主角标所需的最小陈旧授权投影；不含账号或 scope 明细。 */
+  oauthScopeStale?: {
+    secretKey: string;
+    missingScopeCount: number;
+  };
 }
 
 /** 插件包的来源与审核等级；决定 UI 徽标，不改变运行时 slot 权限。 */

--- a/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
+++ b/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
@@ -60,6 +60,27 @@ function parsePayload(result: {
   return JSON.parse(result.content[0].text) as Record<string, unknown>;
 }
 
+const READY_WITH_REAUTH_SUGGEST = {
+  state: "ready" as const,
+  revision: 9,
+  groups: [],
+  reauthSuggest: {
+    ghostId: "xd-feishu",
+    secretKey: "feishu_account",
+    missingScopes: ["approval:task:read"],
+    missingScopeCount: 1,
+    requirement: {
+      ref: "secret:feishu_account",
+      kind: "oauth" as const,
+      label: "飞书账号",
+      action: {
+        id: "oauth_connect:secret:feishu_account",
+        kind: "oauth_connect" as const,
+      },
+    },
+  },
+};
+
 describe("cindy_ghosts · ghost_list(总机接线簿,现查现报)", () => {
   it("返回唤醒中的意识与工具,附调用提示", async () => {
     const result = await handleGhostList(fakeDeps());
@@ -72,6 +93,23 @@ describe("cindy_ghosts · ghost_list(总机接线簿,现查现报)", () => {
     expect(ghosts[0].id).toBe("art");
     expect(ghosts[0].tools[0].name).toBe("gen_image");
     expect(String(payload.hint)).toContain("ghost_call");
+  });
+
+  it("ready assessment 的非阻塞重连建议随 ghost_list 透传", async () => {
+    const result = await handleGhostList(
+      fakeDeps({
+        listAwakeGhosts: async () => [
+          {
+            id: "xd-feishu",
+            name: "XD Feishu",
+            tools: [],
+            setup: READY_WITH_REAUTH_SUGGEST,
+          },
+        ],
+      }),
+    );
+    const ghosts = parsePayload(result).ghosts as Array<{ setup?: unknown }>;
+    expect(ghosts[0].setup).toEqual(READY_WITH_REAUTH_SUGGEST);
   });
 
   it("setup assessment 由 Host 脱敏生成并原样透传", async () => {
@@ -250,11 +288,31 @@ describe("cindy_ghosts · ghost_call(派活透传)", () => {
       ghost_id: "art",
       tool: "gen_image",
     });
-    expect(parsePayload(result).ok).toBe(true);
+    const payload = parsePayload(result);
+    expect(payload.ok).toBe(true);
+    expect(payload).not.toHaveProperty("setup");
     expect(callGhostTool).toHaveBeenCalledWith({
       ghostId: "art",
       tool: "gen_image",
       args: {},
+    });
+  });
+
+  it("成功调用可附 setup.reauthSuggest，仍保持 ok:true", async () => {
+    const result = await handleGhostCall(
+      fakeDeps({
+        callGhostTool: async () => ({
+          ok: true,
+          result: { done: true },
+          setup: READY_WITH_REAUTH_SUGGEST,
+        }),
+      }),
+      { ghost_id: "xd-feishu", tool: "call_tool" },
+    );
+    expect(parsePayload(result)).toMatchObject({
+      ok: true,
+      result: { done: true },
+      setup: { state: "ready", reauthSuggest: { secretKey: "feishu_account" } },
     });
   });
 

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -33,7 +33,7 @@ const D_GHOST_LIST = [
   "返回条目含 id、name、command(用户显式点名用的 $指令)与 tools(名称/说明/参数)。",
   "调用具体工具用 ghost_call({ghost_id, tool, args})。清单为空 = 用户没有可用的插件工具。",
   "若某插件 tools 仅含 list_tools / call_tool,它是二级分派型:具体操作名须作 call_tool 的",
-  'name 参数下发(args:{name:"<操作名>", args:{...}}),不能直接当 tool 调。',
+  "name 参数下发(args:{name:\"<操作名>\", args:{...}}),不能直接当 tool 调。",
 ].join("\n");
 
 const D_GHOST_CALL = [
@@ -217,6 +217,8 @@ const SETUP_REQUIREMENT_KINDS = new Set([
   "client_config",
 ]);
 const SETUP_REQUIREMENT_STATES = new Set(["missing", "expired", "satisfied"]);
+// 对主机声明上限 GHOST_OAUTH_SCOPES_MAX(desktop shared/ghost.ts,当前 48;包依赖
+// 方向不允许引用)只留防御余量;该值涨过 64 时必须同步,否则整份 assessment 判废。
 const SETUP_REAUTH_SCOPE_MAX = 64;
 
 function sanitizeSetupAction(
@@ -357,8 +359,7 @@ export function sanitizeGhostSetupAssessment(
   let reauthSuggest: CindyGhostSetupAssessment["reauthSuggest"];
   if (value.reauthSuggest !== undefined) {
     // 在场即严:非法 reauthSuggest 判废整份 assessment,与缺省合法互补。
-    reauthSuggest =
-      sanitizeSetupReauthSuggest(value.reauthSuggest) ?? undefined;
+    reauthSuggest = sanitizeSetupReauthSuggest(value.reauthSuggest) ?? undefined;
     if (!reauthSuggest) return null;
   }
   return {
@@ -380,12 +381,7 @@ function sanitizeSetupReauthSuggest(
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
   const suggest = raw as Record<string, unknown>;
   const requirement = suggest.requirement;
-  if (
-    !requirement ||
-    typeof requirement !== "object" ||
-    Array.isArray(requirement)
-  )
-    return null;
+  if (!requirement || typeof requirement !== "object" || Array.isArray(requirement)) return null;
   const req = requirement as Record<string, unknown>;
   const action = sanitizeSetupAction(req.action);
   if (!action || action.kind !== "oauth_connect") return null;
@@ -400,8 +396,7 @@ function sanitizeSetupReauthSuggest(
     suggest.missingScopes.length === 0 ||
     suggest.missingScopes.length > SETUP_REAUTH_SCOPE_MAX ||
     !suggest.missingScopes.every(
-      (scope) =>
-        typeof scope === "string" && scope.length > 0 && scope.length <= 256,
+      (scope) => typeof scope === "string" && scope.length > 0 && scope.length <= 256,
     ) ||
     suggest.missingScopeCount !== suggest.missingScopes.length ||
     typeof req.ref !== "string" ||
@@ -639,8 +634,7 @@ export async function handleGhostCall(
     // (声明是意图表达,能覆盖 render:false 抑制等语义)。
     const { producedMedia, setup: unsafeSetup, ...resultForModel } = result;
     const setup = sanitizeGhostSetupAssessment(unsafeSetup);
-    const advisory =
-      setup?.state === "ready" && setup.reauthSuggest ? { setup } : {};
+    const advisory = setup?.state === "ready" && setup.reauthSuggest ? { setup } : {};
     const declaredMedia = [
       "xdt_image_urls",
       "xdt_video_urls",
@@ -777,9 +771,7 @@ export async function handleForgePack(
   try {
     const result = await deps.forgePack({
       dir: input.dir,
-      ...(input.icon_source !== undefined
-        ? { iconSource: input.icon_source }
-        : {}),
+      ...(input.icon_source !== undefined ? { iconSource: input.icon_source } : {}),
     });
     if (!result.ok) {
       deps.logger?.warn("ghost_forge_pack rejected", {

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -354,60 +354,67 @@ export function sanitizeGhostSetupAssessment(
     groups.push({ id: group.id, mode: "any_of", items });
   }
   let reauthSuggest: CindyGhostSetupAssessment["reauthSuggest"];
-  const rawSuggest = value.reauthSuggest;
-  if (rawSuggest !== undefined) {
-    if (!rawSuggest || typeof rawSuggest !== "object" || Array.isArray(rawSuggest)) return null;
-    const suggest = rawSuggest as Record<string, unknown>;
-    const requirement = suggest.requirement;
-    if (!requirement || typeof requirement !== "object" || Array.isArray(requirement)) return null;
-    const req = requirement as Record<string, unknown>;
-    const action = req.action;
-    if (!action || typeof action !== "object" || Array.isArray(action)) return null;
-    const act = action as Record<string, unknown>;
-    if (
-      typeof suggest.ghostId !== "string" ||
-      suggest.ghostId.length === 0 ||
-      suggest.ghostId.length > 128 ||
-      typeof suggest.secretKey !== "string" ||
-      suggest.secretKey.length === 0 ||
-      suggest.secretKey.length > 128 ||
-      !Array.isArray(suggest.missingScopes) ||
-      suggest.missingScopes.length === 0 ||
-      suggest.missingScopes.length > SETUP_REAUTH_SCOPE_MAX ||
-      !suggest.missingScopes.every(
-        (scope) => typeof scope === "string" && scope.length > 0 && scope.length <= 256,
-      ) ||
-      !Number.isInteger(suggest.missingScopeCount) ||
-      suggest.missingScopeCount !== suggest.missingScopes.length ||
-      typeof req.ref !== "string" ||
-      req.ref.length === 0 ||
-      req.kind !== "oauth" ||
-      typeof req.label !== "string" ||
-      req.label.length === 0 ||
-      typeof act.id !== "string" ||
-      act.id.length === 0 ||
-      act.kind !== "oauth_connect"
-    ) {
-      return null;
-    }
-    reauthSuggest = {
-      ghostId: suggest.ghostId,
-      secretKey: suggest.secretKey,
-      missingScopes: [...suggest.missingScopes] as string[],
-      missingScopeCount: suggest.missingScopeCount as number,
-      requirement: {
-        ref: req.ref,
-        kind: "oauth",
-        label: req.label,
-        action: { id: act.id, kind: "oauth_connect" },
-      },
-    };
+  if (value.reauthSuggest !== undefined) {
+    // 在场即严:非法 reauthSuggest 判废整份 assessment,与缺省合法互补。
+    reauthSuggest = sanitizeSetupReauthSuggest(value.reauthSuggest) ?? undefined;
+    if (!reauthSuggest) return null;
   }
   return {
     state: value.state as CindyGhostSetupAssessment["state"],
     revision: value.revision as number,
     groups,
     ...(reauthSuggest ? { reauthSuggest } : {}),
+  };
+}
+
+/**
+ * reauthSuggest 的独立 sanitize(与 sanitizeSetupAction 等"一形状一函数"
+ * 同款)。action 部分复用 sanitizeSetupAction —— 由它统一收 id 非空 + 256
+ * 上界与 kind 白名单,再钉死本形状只认 oauth_connect。
+ */
+function sanitizeSetupReauthSuggest(
+  raw: unknown,
+): NonNullable<CindyGhostSetupAssessment["reauthSuggest"]> | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const suggest = raw as Record<string, unknown>;
+  const requirement = suggest.requirement;
+  if (!requirement || typeof requirement !== "object" || Array.isArray(requirement)) return null;
+  const req = requirement as Record<string, unknown>;
+  const action = sanitizeSetupAction(req.action);
+  if (!action || action.kind !== "oauth_connect") return null;
+  if (
+    typeof suggest.ghostId !== "string" ||
+    suggest.ghostId.length === 0 ||
+    suggest.ghostId.length > 128 ||
+    typeof suggest.secretKey !== "string" ||
+    suggest.secretKey.length === 0 ||
+    suggest.secretKey.length > 128 ||
+    !Array.isArray(suggest.missingScopes) ||
+    suggest.missingScopes.length === 0 ||
+    suggest.missingScopes.length > SETUP_REAUTH_SCOPE_MAX ||
+    !suggest.missingScopes.every(
+      (scope) => typeof scope === "string" && scope.length > 0 && scope.length <= 256,
+    ) ||
+    suggest.missingScopeCount !== suggest.missingScopes.length ||
+    typeof req.ref !== "string" ||
+    req.ref.length === 0 ||
+    req.kind !== "oauth" ||
+    typeof req.label !== "string" ||
+    req.label.length === 0
+  ) {
+    return null;
+  }
+  return {
+    ghostId: suggest.ghostId,
+    secretKey: suggest.secretKey,
+    missingScopes: [...suggest.missingScopes] as string[],
+    missingScopeCount: suggest.missingScopes.length,
+    requirement: {
+      ref: req.ref,
+      kind: "oauth",
+      label: req.label,
+      action: { id: action.id, kind: "oauth_connect" },
+    },
   };
 }
 
@@ -624,7 +631,7 @@ export async function handleGhostCall(
     // (声明是意图表达,能覆盖 render:false 抑制等语义)。
     const { producedMedia, setup: unsafeSetup, ...resultForModel } = result;
     const setup = sanitizeGhostSetupAssessment(unsafeSetup);
-    const reauthSetup = setup?.state === "ready" && setup.reauthSuggest ? setup : null;
+    const advisory = setup?.state === "ready" && setup.reauthSuggest ? { setup } : {};
     const declaredMedia = [
       "xdt_image_urls",
       "xdt_video_urls",
@@ -665,7 +672,7 @@ export async function handleGhostCall(
           : {};
     return textResult({
       ...resultForModel,
-      ...(reauthSetup ? { setup: reauthSetup } : {}),
+      ...advisory,
       ...hoisted,
       ...producedFallback,
       ...mediaHint,

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -33,7 +33,7 @@ const D_GHOST_LIST = [
   "返回条目含 id、name、command(用户显式点名用的 $指令)与 tools(名称/说明/参数)。",
   "调用具体工具用 ghost_call({ghost_id, tool, args})。清单为空 = 用户没有可用的插件工具。",
   "若某插件 tools 仅含 list_tools / call_tool,它是二级分派型:具体操作名须作 call_tool 的",
-  "name 参数下发(args:{name:\"<操作名>\", args:{...}}),不能直接当 tool 调。",
+  'name 参数下发(args:{name:"<操作名>", args:{...}}),不能直接当 tool 调。',
 ].join("\n");
 
 const D_GHOST_CALL = [
@@ -113,8 +113,9 @@ const SETUP_PLAN_MAX_TITLE_LENGTH = 120;
 const SETUP_PLAN_MAX_DESCRIPTION_LENGTH = 500;
 
 /**
- * ghost_call 顶层 setup_plan schema。snake_case 仅存在于 Agent/MCP 边界；
- * handleGhostCall 会转成 camelCase 后单独交给 Host，绝不混入插件 args。
+ * ghost_call 顶层 setup_plan schema。required 配置卡与 ready 态 reauthSuggest
+ * 重连卡共用该形状；snake_case 仅存在于 Agent/MCP 边界，handleGhostCall
+ * 会转成 camelCase 后单独交给 Host，绝不混入插件 args。
  * 导出仅供边界单测，未从 package root 暴露。
  */
 export const ghostSetupPlanInputSchema = z
@@ -356,7 +357,8 @@ export function sanitizeGhostSetupAssessment(
   let reauthSuggest: CindyGhostSetupAssessment["reauthSuggest"];
   if (value.reauthSuggest !== undefined) {
     // 在场即严:非法 reauthSuggest 判废整份 assessment,与缺省合法互补。
-    reauthSuggest = sanitizeSetupReauthSuggest(value.reauthSuggest) ?? undefined;
+    reauthSuggest =
+      sanitizeSetupReauthSuggest(value.reauthSuggest) ?? undefined;
     if (!reauthSuggest) return null;
   }
   return {
@@ -378,7 +380,12 @@ function sanitizeSetupReauthSuggest(
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
   const suggest = raw as Record<string, unknown>;
   const requirement = suggest.requirement;
-  if (!requirement || typeof requirement !== "object" || Array.isArray(requirement)) return null;
+  if (
+    !requirement ||
+    typeof requirement !== "object" ||
+    Array.isArray(requirement)
+  )
+    return null;
   const req = requirement as Record<string, unknown>;
   const action = sanitizeSetupAction(req.action);
   if (!action || action.kind !== "oauth_connect") return null;
@@ -393,7 +400,8 @@ function sanitizeSetupReauthSuggest(
     suggest.missingScopes.length === 0 ||
     suggest.missingScopes.length > SETUP_REAUTH_SCOPE_MAX ||
     !suggest.missingScopes.every(
-      (scope) => typeof scope === "string" && scope.length > 0 && scope.length <= 256,
+      (scope) =>
+        typeof scope === "string" && scope.length > 0 && scope.length <= 256,
     ) ||
     suggest.missingScopeCount !== suggest.missingScopes.length ||
     typeof req.ref !== "string" ||
@@ -631,7 +639,8 @@ export async function handleGhostCall(
     // (声明是意图表达,能覆盖 render:false 抑制等语义)。
     const { producedMedia, setup: unsafeSetup, ...resultForModel } = result;
     const setup = sanitizeGhostSetupAssessment(unsafeSetup);
-    const advisory = setup?.state === "ready" && setup.reauthSuggest ? { setup } : {};
+    const advisory =
+      setup?.state === "ready" && setup.reauthSuggest ? { setup } : {};
     const declaredMedia = [
       "xdt_image_urls",
       "xdt_video_urls",
@@ -768,7 +777,9 @@ export async function handleForgePack(
   try {
     const result = await deps.forgePack({
       dir: input.dir,
-      ...(input.icon_source !== undefined ? { iconSource: input.icon_source } : {}),
+      ...(input.icon_source !== undefined
+        ? { iconSource: input.icon_source }
+        : {}),
     });
     if (!result.ok) {
       deps.logger?.warn("ghost_forge_pack rejected", {
@@ -851,7 +862,7 @@ export function createCindyGhostsMcpServer(
       setup_plan: ghostSetupPlanInputSchema
         .optional()
         .describe(
-          "可选:当 ghost_list 对目标插件返回 setup.state=required 时,基于该 assessment 编排 Ask 风格配置卡。assessment_revision 必须原样带回;requirement_refs 与 action_id 只能选 Host 给出的引用和动作。每个未满足 any_of 组里的所有可执行选项都必须保留为独立 step,让用户看到完整选择;Host 会拒绝隐藏任一合法配置路径的 plan。文案保持克制:单字段配置只写一句必要说明,不要在 intro、step title、description 中重复插件名、字段 label 或 Host hint。Host 会校验并执行动作,配置完成后继续本次 ghost_call;本字段不会进入插件 args。不要提供插件名、icon、URL、凭证值或完成状态。用户取消会返回 SETUP_CANCELLED;无交互面返回 SETUP_REQUIRED + 脱敏 setup,都不要自动重试。",
+          "可选:当 ghost_list 对目标插件返回 setup.state=required 时,基于该 assessment 编排 Ask 风格配置卡。assessment_revision 必须原样带回;requirement_refs 与 action_id 只能选 Host 给出的引用和动作。每个未满足 any_of 组里的所有可执行选项都必须保留为独立 step,让用户看到完整选择;Host 会拒绝隐藏任一合法配置路径的 plan。成功结果若带 setup.reauthSuggest,插件仍可用,但当前授权未含插件新增权限;通常只在插件返回权限或 scope 错误后,下一次 ghost_call 可携带只引用该 requirement 的单步 setup_plan 弹出重新连接卡,未报错时不要主动打断用户。文案保持克制:单字段配置只写一句必要说明,不要在 intro、step title、description 中重复插件名、字段 label 或 Host hint。Host 会校验并执行动作,配置完成后继续本次 ghost_call;本字段不会进入插件 args。不要提供插件名、icon、URL、凭证值或完成状态。用户取消会返回 SETUP_CANCELLED;无交互面返回 SETUP_REQUIRED + 脱敏 setup,都不要自动重试。",
         ),
     },
     async (input, extra) =>

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -216,6 +216,7 @@ const SETUP_REQUIREMENT_KINDS = new Set([
   "client_config",
 ]);
 const SETUP_REQUIREMENT_STATES = new Set(["missing", "expired", "satisfied"]);
+const SETUP_REAUTH_SCOPE_MAX = 64;
 
 function sanitizeSetupAction(
   raw: unknown,
@@ -352,10 +353,61 @@ export function sanitizeGhostSetupAssessment(
     }
     groups.push({ id: group.id, mode: "any_of", items });
   }
+  let reauthSuggest: CindyGhostSetupAssessment["reauthSuggest"];
+  const rawSuggest = value.reauthSuggest;
+  if (rawSuggest !== undefined) {
+    if (!rawSuggest || typeof rawSuggest !== "object" || Array.isArray(rawSuggest)) return null;
+    const suggest = rawSuggest as Record<string, unknown>;
+    const requirement = suggest.requirement;
+    if (!requirement || typeof requirement !== "object" || Array.isArray(requirement)) return null;
+    const req = requirement as Record<string, unknown>;
+    const action = req.action;
+    if (!action || typeof action !== "object" || Array.isArray(action)) return null;
+    const act = action as Record<string, unknown>;
+    if (
+      typeof suggest.ghostId !== "string" ||
+      suggest.ghostId.length === 0 ||
+      suggest.ghostId.length > 128 ||
+      typeof suggest.secretKey !== "string" ||
+      suggest.secretKey.length === 0 ||
+      suggest.secretKey.length > 128 ||
+      !Array.isArray(suggest.missingScopes) ||
+      suggest.missingScopes.length === 0 ||
+      suggest.missingScopes.length > SETUP_REAUTH_SCOPE_MAX ||
+      !suggest.missingScopes.every(
+        (scope) => typeof scope === "string" && scope.length > 0 && scope.length <= 256,
+      ) ||
+      !Number.isInteger(suggest.missingScopeCount) ||
+      suggest.missingScopeCount !== suggest.missingScopes.length ||
+      typeof req.ref !== "string" ||
+      req.ref.length === 0 ||
+      req.kind !== "oauth" ||
+      typeof req.label !== "string" ||
+      req.label.length === 0 ||
+      typeof act.id !== "string" ||
+      act.id.length === 0 ||
+      act.kind !== "oauth_connect"
+    ) {
+      return null;
+    }
+    reauthSuggest = {
+      ghostId: suggest.ghostId,
+      secretKey: suggest.secretKey,
+      missingScopes: [...suggest.missingScopes] as string[],
+      missingScopeCount: suggest.missingScopeCount as number,
+      requirement: {
+        ref: req.ref,
+        kind: "oauth",
+        label: req.label,
+        action: { id: act.id, kind: "oauth_connect" },
+      },
+    };
+  }
   return {
     state: value.state as CindyGhostSetupAssessment["state"],
     revision: value.revision as number,
     groups,
+    ...(reauthSuggest ? { reauthSuggest } : {}),
   };
 }
 
@@ -570,7 +622,9 @@ export async function handleGhostCall(
     // IM/hook 出站消费它,保证"意识画卡后删字段"也不影响媒体送达 IM 用户。
     // 声明了媒体字段(含 xdt_audio_tracks)时以声明为准,账本不注入
     // (声明是意图表达,能覆盖 render:false 抑制等语义)。
-    const { producedMedia, ...resultForModel } = result;
+    const { producedMedia, setup: unsafeSetup, ...resultForModel } = result;
+    const setup = sanitizeGhostSetupAssessment(unsafeSetup);
+    const reauthSetup = setup?.state === "ready" && setup.reauthSuggest ? setup : null;
     const declaredMedia = [
       "xdt_image_urls",
       "xdt_video_urls",
@@ -611,6 +665,7 @@ export async function handleGhostCall(
           : {};
     return textResult({
       ...resultForModel,
+      ...(reauthSetup ? { setup: reauthSetup } : {}),
       ...hoisted,
       ...producedFallback,
       ...mediaHint,

--- a/packages/cindy-tools/src/types.ts
+++ b/packages/cindy-tools/src/types.ts
@@ -83,6 +83,22 @@ export interface CindyGhostSetupAssessment {
       actions: CindyGhostSetupAllowedAction[];
     }>;
   }>;
+  /** 插件仍 ready 时的非阻塞重连建议；不得解释为 SETUP_REQUIRED。 */
+  reauthSuggest?: {
+    ghostId: string;
+    secretKey: string;
+    missingScopes: string[];
+    missingScopeCount: number;
+    requirement: {
+      ref: string;
+      kind: 'oauth';
+      label: string;
+      action: {
+        id: string;
+        kind: 'oauth_connect';
+      };
+    };
+  };
 }
 
 /** Agent 为 Ask 风格配置卡编排的展示步骤；Host 校验后才可采用。 */
@@ -133,6 +149,8 @@ export type CindyGhostCallResult =
   | {
       ok: true;
       result: unknown;
+      /** ready 语义不变；只在有非阻塞重连建议时由 Host 附加。 */
+      setup?: CindyGhostSetupAssessment;
       /**
        * 本次调用期间由主机实际入库(cindy-media)的媒体地址账本(可选,
        * host 按 ghostId+callId 记账后随结果带回)。这是**主机侧事实**,


### PR DESCRIPTION
## 这次改了什么

### 摘要

插件升级声明了新的 OAuth scope 之后，存量已连接账号的令牌停留在旧授权面：调用新能力吃 `99991679` 权限错误，但界面没有任何引导，用户只能反复撞墙（xd-feishu 补审批能力后实测踩到）。本 PR 打通完整的重新授权引导闭环：

1. **缺权证据通道**：插件把真实 API 权限错误中提取的缺失 scope 通过新管子路由 `POST /oauth/<key>/insufficient-scopes` 上报；主机逐项校验必须属于当前清单声明（任一越界整包 400 拒收），合法证据合并落到默认账号（按声明面裁剪，重连成功即清除）。
2. **非阻塞建议**：`ghost_list` / `ghost_call` 成功结果对 agent 附 `setup.reauthSuggest`（证据优先，授权面快照推断兜底）；插件详情页同步显示 warning 角标（四语文案）。
3. **对话内重连卡**：agent 在插件报错后的下一次调用携带单步 `setup_plan`，`ensureReady` 把建议映射成合成 assessment 复用既有交互卡；授权完成后原调用原地续跑。ready 无 plan / 无建议 / 无交互面（IM、定时任务回合）一律直接放行，required 态行为零变化。
4. **声明上限 32→48**（`GHOST_OAUTH_SCOPES_MAX`）：xd-feishu 42 条清单需要。

提交序列：`5bbaf2f0`（上限 48）→ `e5dca4f3`（授权面快照与角标）→ `d85d1e2c`（收敛重构）→ `35eac53a`（证据通道 + 重连卡跳线）→ `a0c1d55d`（评审修正：无交互面放行 / 重复上报不广播 / 合并裁剪 / 死代码清理）→ `72c51744`（角标文案润色，四语）。

### 变更类型

- [x] `feat` 新功能

### 范围

- 关联 Issue / 需求：xd-feishu 审批能力上线的配套主机能力（插件侧上报实现在 cindy-xd-plugin 仓另行提 PR）
- 本 PR 包含：desktop main（cindy-brain OAuth 账号/证据存取、setup coordinator、runtime oauth 端点、forge 手册）、`packages/cindy-tools` ghost MCP 边界、renderer 插件详情页角标、i18n 四语文案
- 明确不包含：xd-feishu 插件侧的错误提取与上报（独立仓）；装入确认框逐行 scope diff、证据到达后主机直弹卡（程序化输出）——均已记为后续项
- 用户可见变化：插件详情页新增 warning 角标；对话流中在权限错误后可弹出「重新连接」卡；`ghost_call` 的 `setup_plan` 工具描述新增使用时机说明
- 是否存在 breaking change：无

### UI 变化

详情页角标 `OauthScopeStaleBadge`（`apps/desktop/src/renderer/features/plugin/GhostPluginDetailView.tsx`），文案「当前授权未包含插件新增权限，请重新连接补齐授权。」（en/ja/ko 同步）。对话内重连卡完全复用既有 plugin_setup 交互卡组件，无新样式。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Color Palette & Roles（Semantic & Accent，warning 语义族）与 §10 Theme System & Token Reference——角标仅使用既有语义 token `--warning-bg-soft`（底色）、`--warning-fg`（图标）、`--text-secondary`（正文），三者均为双模式定义完备的 token，未新增 token、未硬编码色值；§10「Light / Dark 双模式交付门槛」：两种模式均已实现（同一组语义 token），Light 已实机目检，Dark 未实机目检（见「未执行的验证」）。

## 怎么验证的

### 自动验证

```text
（rebase 到 789f417c 之后在本 worktree 全量执行）
pnpm install                                    结果：exit 0
pnpm test:unit                                  结果：exit 0，FAIL 计数 0（含 desktop / cindy-tools 全部 workspace）
pnpm --filter desktop run typecheck             结果：exit 0
pnpm --filter cindy-tools run typecheck         结果：exit 0
pnpm --filter cindy-tools run build             结果：exit 0
pnpm check:dco                                  结果：6 commits signed off（789f417c..72c51744）
pnpm check:i18n-glossary                        结果：en / zh-CN / ja / ko 无新增违规
定向：ghostOauthAccounts / ghostOauthEndpoint / ghostSetupCoordinator /
ghostOauthScopeStaleness 四个测试文件            结果：131 tests 全绿
```

### 手工验证

dev 桌面（本 worktree 构建，macOS，真实飞书账号，与正式版 0.1.28 共用 userData 混跑）：

- 真实 `99991679` 全链路：老账号（无授权面快照）调审批待办 → 插件上报证据 → 对话弹「连接账号」卡 → 授权 → 原地续跑列出审批待办（证据路径的关键用例「老账号无快照但有证据」实机命中）
- 最终提交构建上用一次性仿真错误复跑同一链路（错误 → 上报 → 弹卡 → 授权 → 原地续跑 → 证据随重连清除），全程日志无越权上报
- 角标快照路径：临时声明第 43 条 scope 装入 → 角标出现；还原 42 条重装 → 角标消失（已移除 scope 过滤回归）
- required 态回归：断开账号 → 必选配置卡；点取消 → agent 明确告知本次未执行（SETUP_CANCELLED）；再触发点授权 → 原请求原地续跑；随后连续调用无卡片打扰、无角标
- 上限对照：42 条清单在本构建（48 上限）正常打包装入；正式版 0.1.28（32 上限）拒装为 skip-only，已装目录无损（发布顺序约束的实测确认）

（手工验证截图含真实账号与审批数据，不附入公开 PR。）

### 未执行的验证

- Dark 模式角标/卡片实机目检未做（同一组双模式语义 token，Light 已目检）——如实标注，非「已验证」
- `72c51744` 的新角标文案未实机显示（验证轮次跑在其前一构建；文案变更由 i18n 单测与术语门禁覆盖）
- IM / 无交互面回合携 plan 直接放行：由 coordinator 单测覆盖，未实机（需飞书 bot 场景）

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 其他：插件基座改动，按仓规需白名单放行人明确 Approve

### 影响与回滚

- 影响范围：ghost OAuth 插件链路。无 scope 演进的插件行为完全不变；当前只有 xd-feishu（42 条声明）会触发新路径。
- 存量插件影响：**无**，用户升级后零操作。账号清单新增字段（`authScopes`/`authFace`/`insufficientScopes`）全部可选、宽松读取，老数据原样可用（老账号判不准时不猜、不误报）；批准状态、指纹、manifest 校验语义（除上限放宽外）、安装布局、包格式零变化。上限 32→48 为取值级「严出」：超 32 条的包在旧客户端拒装（skip-only、不破坏已装目录，正式版 0.1.28 实测无害），因此**携带本 PR 的客户端必须先于 42-scope 插件包铺开**（发布顺序约束，同 xd-feishu 仓 PR 说明联动）。升级用例跑在本机：dev 构建与正式版共用 userData 混跑验证。
- 权限 / 安全：新路由暴露给插件分区（含电子脑），写入面被钳死——仅接受当前清单声明内的 scope（任一越界整包 400、不落任何数据）、只写默认账号一个可选字段、无任何令牌字节读回；重复上报内容未变时不广播。恶意插件谎报的上限是点亮自家角标与建议（声明即责任，用户可停用插件兜底）。ready 态「不得拦截当前调用」契约保持：无 plan / 无建议 / 无交互面一律放行。
- 回滚 / 降级方式：revert 整个 PR 即可。已落库的证据字段对旧代码是未知可选字段，宽松解析直接忽略，无迁移、无残留影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（forge 编写手册记档新路由用法与 `authAccount` 上报边界）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
