### PR TITLE
fix(desktop): 修复模型与引擎菜单交接闪退

### DIFF
--- a/apps/desktop/src/renderer/__tests__/morphPopover.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/morphPopover.test.tsx
@@ -221,6 +221,74 @@ describe('MorphPopover interaction contract', () => {
     expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Dialog field' }));
   });
 
+  it('outside pointerdown 交接给相邻 MorphPopover 时旧层不延迟抢回焦点', async () => {
+    setReducedMotion(false);
+
+    function SiblingHandoffHarness() {
+      const [modelOpen, setModelOpen] = useState(false);
+      const [agentOpen, setAgentOpen] = useState(false);
+      return (
+        <>
+          <MorphPopover
+            open={modelOpen}
+            onOpenChange={setModelOpen}
+            panelAriaLabel="Model panel"
+            trigger={
+              <button type="button" aria-expanded={modelOpen} onClick={() => setModelOpen(true)}>
+                Model
+              </button>
+            }
+          >
+            <input aria-label="Search models" />
+          </MorphPopover>
+          <MorphPopover
+            open={agentOpen}
+            onOpenChange={setAgentOpen}
+            panelAriaLabel="Agent panel"
+            trigger={
+              <button
+                type="button"
+                aria-expanded={agentOpen}
+                // AgentSelect 为保持 composer focus-within 视觉会阻止鼠标默认聚焦。
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => setAgentOpen(true)}
+              >
+                Agent
+              </button>
+            }
+          >
+            <button type="button" data-morph-autofocus>
+              Current agent
+            </button>
+          </MorphPopover>
+        </>
+      );
+    }
+
+    render(<SiblingHandoffHarness />);
+    fireEvent.click(screen.getByRole('button', { name: 'Model' }));
+    const search = await screen.findByRole('textbox', { name: 'Search models' });
+    await waitFor(() => expect(document.activeElement).toBe(search));
+
+    const agentTrigger = screen.getByRole('button', { name: 'Agent' });
+    // 真实点击从 pointerdown 到 click 有按压时长。旧层从 pointerdown 起计 240ms 收合，
+    // 新层到 click 才开始 220ms autofocus；按压超过 20ms 时旧层会先走到回焦终点。
+    fireEvent.pointerDown(agentTrigger);
+    fireEvent.mouseDown(agentTrigger);
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 40));
+    });
+    fireEvent.mouseUp(agentTrigger);
+    fireEvent.click(agentTrigger);
+    expect(agentTrigger.getAttribute('aria-expanded')).toBe('true');
+
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 260));
+    });
+    expect(agentTrigger.getAttribute('aria-expanded')).toBe('true');
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Current agent' }));
+  });
+
   it('嵌套 Radix portal 内 pointerdown 不算 outside;真正 outside pointerdown 关闭', async () => {
     render(<Harness />);
     fireEvent.click(screen.getByRole('button', { name: 'Toggle' }));

--- a/apps/desktop/src/renderer/components/ui/morph-popover.tsx
+++ b/apps/desktop/src/renderer/components/ui/morph-popover.tsx
@@ -153,8 +153,8 @@ export function MorphPopover({
   const chipRectRef = useRef<DOMRect | null>(null);
   // 初始形变是否已完成(ResizeObserver 只在其后接管,避免和开场动画打架)
   const settledRef = useRef(false);
-  // 指针选择菜单动作时不把焦点归还 trigger:否则 trigger 的 focus tooltip 会压在
-  // 动作打开的下一层弹窗上。键盘关闭仍按 §14.2 回焦。
+  // 指针驱动的关闭(菜单动作、trigger toggle、outside 交接)不把焦点归还 trigger:
+  // 否则旧层会在收合结束时抢走下一层交互面的焦点。键盘关闭仍按 §14.2 回焦。
   const pointerInteractionRef = useRef(false);
 
   const requestClose = useCallback(() => onOpenChange(false), [onOpenChange]);
@@ -428,6 +428,10 @@ export function MorphPopover({
       // 面板内容可能再弹 Radix 浮层(portal 到 body,如模型行的 effort/Fast 配置
       // 子面板)——点它不算 outside,否则子面板永远点不了(整个面板会先被关掉)
       if ((t as Element).closest?.('[data-radix-popper-content-wrapper]')) return;
+      // outside pointerdown 也是鼠标关闭。目标控件可能 preventDefault 阻止默认聚焦
+      // (如 AgentSelect 为维持 composer focus-within),不能因此把旧层误判成键盘关闭、
+      // 在收合结束后延迟抢回旧 trigger 焦点并关掉刚打开的相邻弹层。
+      pointerInteractionRef.current = true;
       requestClose();
     };
     const onKeyDown = (e: KeyboardEvent) => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复新建对话中先打开模型菜单、再点击 Harness/引擎选择器时，引擎菜单闪现后自动消失的问题。

根因是旧模型 `MorphPopover` 在 outside pointerdown 后仍可能延迟把焦点归还旧 trigger，抢走刚打开的相邻弹层焦点；现在将 outside pointerdown 明确记为鼠标交互，不再触发旧层的键盘式焦点回收。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [x] `docs` / `test` / `chore` 文档、测试或工程维护（回归测试）
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：`MorphPopover` outside pointerdown 焦点语义修正；相邻弹层交接回归测试
- 明确不包含：模型目录、Harness 列表、持久化状态和服务端逻辑
- 用户可见变化：模型菜单切换到 Harness/引擎菜单后，后者保持打开
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.2 Focus Management；§14.4 Motion & Transitions 的 MorphPopover 焦点、outside-click 与容器形变约束。没有改颜色、布局或文案，仅修正弹层交接时的焦点行为。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/morphPopover.test.tsx src/renderer/__tests__/agentSelect.test.tsx
结果：31 个测试通过（新增相邻 MorphPopover 交接回归覆盖）

pnpm --filter desktop run --if-present typecheck
结果：通过

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-morph-popover-handoff
结果：GATE_EXIT=0

pnpm check:dco
结果：通过，1 个 commit 均已 Signed-off-by
```

### 手工验证

macOS Desktop remote dev，修复 worktree `/Users/dash/Code/Cindy/cindy-fix-morph-popover-handoff`，共享现有登录态。打开模型选择器后不选择模型，点击 Harness/引擎选择器；引擎菜单保持打开。用户已确认修复生效。

### 未执行的验证

无。Windows 实机未执行。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 通用 `MorphPopover` 的鼠标关闭焦点语义；键盘 Esc 关闭仍按原规则归还 trigger 焦点。
- 回滚 / 降级方式：回滚本 PR commit `7bceb73f` 即可恢复原实现。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
