### PR TITLE
fix(tools): extract Pi tarballs with GNU tar

### DIFF
--- a/scripts/__tests__/pi-update-layout.test.mjs
+++ b/scripts/__tests__/pi-update-layout.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,6 +8,7 @@ import test from 'node:test';
 import {
   assertPinnedRuntimeAsset,
   assetDigestMatchesUpstream,
+  extractArchive,
   flattenExtractedDir,
   readCachedAssetDigest,
 } from '../../tools/pi/update.mjs';
@@ -35,6 +37,50 @@ test('Pi updater still flattens the nested Unix release layout', (t) => {
   assert.equal(flattenExtractedDir(dir, 'pi'), path.join(dir, 'pi'));
   assert.ok(fs.statSync(path.join(dir, 'pi')).isFile());
   assert.ok(fs.statSync(path.join(dir, 'theme')).isDirectory());
+});
+
+test('Pi updater extracts tar.gz archives streamed to the system tar', async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const inputDir = path.join(root, 'input');
+  const outputDir = path.join(root, 'output');
+  fs.mkdirSync(path.join(inputDir, 'pi'), { recursive: true });
+  fs.mkdirSync(outputDir);
+  fs.writeFileSync(path.join(inputDir, 'pi', 'pi'), 'pi-fixture');
+
+  const created = spawnSync('tar', ['-czf', 'fixture.tar.gz', '-C', 'input', 'pi'], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  assert.equal(created.status, 0, created.stderr || created.error?.message);
+
+  await extractArchive(path.join(root, 'fixture.tar.gz'), outputDir);
+
+  assert.equal(fs.readFileSync(path.join(outputDir, 'pi', 'pi'), 'utf8'), 'pi-fixture');
+});
+
+test('Pi updater rejects unreadable archives through the returned promise', async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const outputDir = path.join(root, 'output');
+  fs.mkdirSync(outputDir);
+
+  await assert.rejects(
+    extractArchive(path.join(root, 'missing.tar.gz'), outputDir),
+    { code: 'ENOENT' },
+  );
+});
+
+test('Pi updater rejects corrupt streamed archives', async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const archive = path.join(root, 'corrupt.tar.gz');
+  const outputDir = path.join(root, 'output');
+  // Keep the source multi-chunk so the pipeline also covers tar closing before all input is written.
+  fs.writeFileSync(archive, Buffer.alloc(4 * 1024 * 1024, 0x61));
+  fs.mkdirSync(outputDir);
+
+  await assert.rejects(extractArchive(archive, outputDir));
 });
 
 test('Pi release pin covers every supported desktop architecture', () => {

--- a/tools/pi/update.mjs
+++ b/tools/pi/update.mjs
@@ -27,6 +27,7 @@ import { spawn } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { fetchJsonWithTimeout, downloadToFileWithTimeout, createDownloadProgressLogger } from '../shared/fetch-with-timeout.mjs';
@@ -202,14 +203,22 @@ function targetsExist(version, targets) {
   });
 }
 
-/** 用 bsdtar 解压归档（tar.gz / zip 皆可识别）到 destDir。 */
-async function extractArchive(archivePath, destDir) {
-  return new Promise((resolve, reject) => {
-    const child = spawn('tar', ['-xf', '-'], { cwd: destDir, stdio: ['pipe', 'inherit', 'inherit'] });
-    child.on('error', reject);
-    child.on('close', (code) => (code === 0 ? resolve() : reject(new Error(`tar exited with code ${code}`))));
-    fs.createReadStream(archivePath).pipe(child.stdin);
+/** 用 tar 解压归档到 destDir；GNU tar 从 stdin 读取 gzip 时必须显式传 -z。 */
+export async function extractArchive(archivePath, destDir) {
+  const args = archivePath.endsWith('.tar.gz') ? ['-xzf', '-'] : ['-xf', '-'];
+  const child = spawn('tar', args, { cwd: destDir, stdio: ['pipe', 'inherit', 'inherit'] });
+  const exit = new Promise((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code) => (code === 0 ? resolve() : reject(new Error(`tar exited with code ${code}`))));
   });
+  const input = pipeline(fs.createReadStream(archivePath), child.stdin);
+  try {
+    await Promise.all([input, exit]);
+  } catch (error) {
+    if (child.exitCode === null && child.signalCode === null) child.kill();
+    await Promise.allSettled([input, exit]);
+    throw error;
+  }
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

Make Pi tar.gz extraction work with GNU tar on Linux and WSL.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- Related issue: #524
- Included: Pass the gzip flag for streamed tarballs, propagate stream/tar failures without async leaks, and add real system-tar success and failure regression tests.
- Not included: UI, schema, migration, dependency, or wire-protocol changes.
- User-visible change: Make Pi tar.gz extraction work with GNU tar on Linux and WSL.
- Breaking change: No.

### Remote and mobile adaptation

- SSH remote workspaces: Not affected.
- Device link: No channel or protocol change.
- Mobile: Not affected.

### UI 变化

Not applicable. No UI, interaction, or copy changes.

- Referenced design rules: Not applicable.

## 怎么验证的

### 自动验证

```text
pnpm test:unit
Result: passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

pnpm check:dco
Result: passed.
```

### 手工验证

WSL2 (Ubuntu 24.04 + WSLg): `pnpm restart:desktop:remote --region=global` reached `Desktop dev is ready (window + auth/local database)`.

### 未执行的验证

Windows and macOS Pi installation paths.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- Impact: Pi runtime archive extraction on Linux and WSL.
- Risk: GNU tar invocation and stream/process error coordination are stricter; the existing zip path is unchanged.
- Rollback: Revert this commit. No data migration or cleanup is required.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
