### PR TITLE
fix(desktop): 修复远程任务侧边栏加载闪烁

### DIFF
--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -106,6 +106,20 @@ describe('Dialogue sidebar section', () => {
     );
   });
 
+  it('keeps remote background loading from changing the sidebar layout', () => {
+    // Existing local/cached rows must stay in place while remote bootstrap runs in the background.
+    // A partial loading notice in the scroll flow makes every row jump when it mounts/unmounts.
+    expect(sidebarSource).toContain(
+      '远程任务 / 设备目录的 loading 只在上面的「无内容」分支显示',
+    );
+    expect(sidebarSource).not.toMatch(
+      /remoteDeviceDirectoryStatus === 'loading'\s*&&\s*\n?\s*\(\s*<RemoteSidebarLoadNotice[\s\S]*?partial\s*\/\>\s*\)/,
+    );
+    expect(sidebarSource).not.toMatch(
+      /remoteSessionBootstrapLoadingDevices\.length > 0\s*&&\s*\n?\s*\(\s*<RemoteSidebarLoadNotice[\s\S]*?partial\s*\n?\s*\/\>\s*\)/,
+    );
+  });
+
   it('has a Dialogue-owned runtime sort setting instead of using project manual order or renderer storage', () => {
     expect(dialogueSectionSource).toContain('DIALOGUE_SORT_OPTIONS');
     expect(dialogueSectionSource).not.toMatch(/manualProjectOrder/);

--- a/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
@@ -196,11 +196,14 @@ describe('远程机器切换入口并入 SidebarTopNav(置顶段上方,固定不
     }
   });
 
-  it('在机器栏固定显示远程任务读取 loading,不把提示插入会话列表', () => {
-    // 后台 bootstrap 只占机器栏内的固定状态槽,避免列表行因提示挂载/卸载而上下跳动。
+  it('在机器栏固定显示远程任务读取 loading,不改变文字与下拉箭头间距', () => {
+    // 文字与箭头保持原有相邻布局；后台 bootstrap 只占最右侧固定状态槽，
+    // 避免列表上下跳动，也避免空槽把下拉箭头推远。
     expect(menuSource).toContain('useRemoteSessionBootstrapLoading(selectedDeviceId)');
     expect(menuSource).toContain('aria-busy={remoteSessionBootstrapLoading}');
-    expect(menuSource).toContain('className="flex h-4 w-4 shrink-0 items-center justify-center"');
+    expect(menuSource).toMatch(
+      /<span className="truncate leading-none">\{triggerText\}<\/span>\s*<ChevronDown[\s\S]*?<span\s*aria-hidden="true"\s*className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center"\s*>/,
+    );
     expect(menuSource).toContain(
       '<span className="inline-flex animate-spinner motion-reduce:animate-none">',
     );

--- a/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
+++ b/apps/desktop/src/renderer/__tests__/machineSwitcherMenu.test.ts
@@ -196,6 +196,17 @@ describe('远程机器切换入口并入 SidebarTopNav(置顶段上方,固定不
     }
   });
 
+  it('在机器栏固定显示远程任务读取 loading,不把提示插入会话列表', () => {
+    // 后台 bootstrap 只占机器栏内的固定状态槽,避免列表行因提示挂载/卸载而上下跳动。
+    expect(menuSource).toContain('useRemoteSessionBootstrapLoading(selectedDeviceId)');
+    expect(menuSource).toContain('aria-busy={remoteSessionBootstrapLoading}');
+    expect(menuSource).toContain('className="flex h-4 w-4 shrink-0 items-center justify-center"');
+    expect(menuSource).toContain(
+      '<span className="inline-flex animate-spinner motion-reduce:animate-none">',
+    );
+    expect(menuSource).toContain('<Loader2 size={14} strokeWidth={1.8} />');
+  });
+
   it('MachineSwitcherMenu 保留门控 / 设备选择 / 远程设置入口', () => {
     expect(menuSource).toContain('if (!hasRemote) return null');
     expect(menuSource).toContain('MACHINE_ALL');

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -2941,17 +2941,12 @@ function ExpandedView({
                   partial
                 />
               )}
-              {remoteDeviceDirectoryStatus === 'loading' && (
-                <RemoteSidebarLoadNotice kind="devices" status="loading" partial />
-              )}
-              {remoteSessionBootstrapLoadingDevices.length > 0 && (
-                <RemoteSidebarLoadNotice
-                  kind="tasks"
-                  status="loading"
-                  deviceLabel={loadingRemoteDeviceLabel}
-                  partial
-                />
-              )}
+              {/*
+               * 远程任务 / 设备目录的 loading 只在上面的「无内容」分支显示。
+               * 这里可能已经有本地或旧的远程快照；把后台重拉提示插进普通文档流会让
+               * 整个侧栏在 loading↔ready 间上下移动，造成可见闪烁。错误提示仍保留
+               * 在列表前，便于用户知道已有内容不是本轮权威结果。
+               */}
               <PinnedSection
                 entries={visiblePinnedEntries}
                 allKnownProjects={visibleProjectUniverse}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/MachineSwitcherMenu.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/MachineSwitcherMenu.tsx
@@ -45,6 +45,7 @@ import {
   Check,
   ChevronDown,
   EllipsisVertical,
+  Loader2,
   Monitor,
   MonitorSmartphone,
 } from 'lucide-react';
@@ -66,7 +67,10 @@ import {
   MACHINE_ALL,
   MACHINE_LOCAL,
 } from '@/features/device-link/selectedMachineStore';
-import { useMachineSwitcher } from '@/features/device-link/useMachineSwitcher';
+import {
+  useMachineSwitcher,
+  useRemoteSessionBootstrapLoading,
+} from '@/features/device-link/useMachineSwitcher';
 import { MENU_CONTENT_CLASS, MENU_ITEM_CLASS, MENU_SEPARATOR_CLASS } from './menuStyles';
 import { useHoverOpenMenu } from './useHoverOpenMenu';
 
@@ -74,6 +78,9 @@ export function MachineSwitcherMenu(): ReactNode {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { devices, selectedDeviceId, hasRemote, select, toggle } = useMachineSwitcher();
+  // 机器栏是远程任务读取状态的固定承载点。后台 bootstrap 时只更新这一行，
+  // 不再把 loading 提示插入下方会话列表，避免列表整体上下跳动。
+  const remoteSessionBootstrapLoading = useRemoteSessionBootstrapLoading(selectedDeviceId);
   // 「鼠标移上去就展开」:hover 触发行即开、移开即关(受控开合,详见 useHoverOpenMenu;
   // 2026-07-12 产品确认要 hover 展开,恢复 d5a8d77c9 之前的交互)。
   const { open, onOpenChange, triggerRef, triggerProps, contentProps } = useHoverOpenMenu();
@@ -138,6 +145,7 @@ export function MachineSwitcherMenu(): ReactNode {
           ref={triggerRef as Ref<HTMLButtonElement>}
           {...triggerProps}
           aria-label={`${triggerLabel}: ${triggerText}`}
+          aria-busy={remoteSessionBootstrapLoading}
           className={cn(
             // 与 SidebarTopNav 的 ROW_CLASS 同款 pill 行:h-8 全宽、图标 meta 灰、
             // 文字 foreground、hover 灰底;truncate 兜住过长设备名。
@@ -155,6 +163,16 @@ export function MachineSwitcherMenu(): ReactNode {
             className="shrink-0 text-[var(--sidebar-nav-text)]"
           />
           <span className="truncate leading-none">{triggerText}</span>
+          <span
+            aria-hidden="true"
+            className="flex h-4 w-4 shrink-0 items-center justify-center"
+          >
+            {remoteSessionBootstrapLoading && (
+              <span className="inline-flex animate-spinner motion-reduce:animate-none">
+                <Loader2 size={14} strokeWidth={1.8} />
+              </span>
+            )}
+          </span>
           <ChevronDown
             size={14}
             strokeWidth={1.8}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/MachineSwitcherMenu.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/MachineSwitcherMenu.tsx
@@ -163,9 +163,14 @@ export function MachineSwitcherMenu(): ReactNode {
             className="shrink-0 text-[var(--sidebar-nav-text)]"
           />
           <span className="truncate leading-none">{triggerText}</span>
+          <ChevronDown
+            size={14}
+            strokeWidth={1.8}
+            className="shrink-0 text-[var(--sidebar-nav-text)]"
+          />
           <span
             aria-hidden="true"
-            className="flex h-4 w-4 shrink-0 items-center justify-center"
+            className="ml-auto flex h-4 w-4 shrink-0 items-center justify-center"
           >
             {remoteSessionBootstrapLoading && (
               <span className="inline-flex animate-spinner motion-reduce:animate-none">
@@ -173,11 +178,6 @@ export function MachineSwitcherMenu(): ReactNode {
               </span>
             )}
           </span>
-          <ChevronDown
-            size={14}
-            strokeWidth={1.8}
-            className="shrink-0 text-[var(--sidebar-nav-text)]"
-          />
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复存在设备互联远程任务时，侧边栏因“正在读取任务”提示反复挂载和卸载而整体上下闪烁的问题。

已有本地任务或远程缓存快照时，不再把后台读取提示插入会话列表的普通文档流；改为在固定的机器切换栏中显示 loading 图标。首次没有任何可见内容时仍保留完整加载占位，读取失败提示也保持现有行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈远程任务读取状态导致侧边栏持续闪烁
- 本 PR 包含：侧边栏远程读取状态的展示位置调整，以及防止列表布局跳变的回归测试
- 明确不包含：device-link 同步、重试、超时、断链恢复或远程任务数据逻辑变更
- 用户可见变化：后台读取远程任务时，loading 图标显示在“机器”栏文字与下拉箭头之间；下面的项目和任务不再被提示条上下推挤
- 是否存在 breaking change：无

### UI 变化

- Windows：远程任务后台读取状态从会话列表顶部提示条改为机器切换栏内的固定 loading 图标
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §14.4 Motion & Transitions：loading 使用 `animate-spinner`，动画挂在 HTML wrapper 上，并以 `motion-reduce:animate-none` 响应 reduced motion
  - `docs/dev-rules/engineering-conventions.md` §7 渲染性能与视觉连续性：后台取数期间保留已有内容，避免侧边栏布局跳变；状态槽固定尺寸，loading 显隐不改变机器栏布局
  - Light / Dark 均复用现有语义文本颜色和 spinner 样式，没有新增硬编码颜色

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/machineSwitcherMenu.test.ts src/renderer/__tests__/dialogueSidebarSection.test.ts
结果：2 个测试文件通过，34 个测试通过

pnpm --filter desktop run --if-present typecheck
结果：通过

CINDY_AUTH_REGION=global VITE_CINDY_AUTH_REGION=global pnpm test:unit
结果：全量单元测试通过

pnpm check:dco
结果：1 个提交签名通过

git diff --check
结果：通过
```

### 手工验证

- Windows 11：根据用户提供的远程任务侧边栏复现场景确认根因和目标位置；代码改动后未重新启动 Desktop 做运行时目检
- macOS：未实机验证

### 未执行的验证

- Light / Dark 实机目检未执行；实现复用现有语义 token，但不把复用 token 视为已完成双模式实机验证
- 首次直接继承当前 CN Desktop dev 环境运行 `pnpm test:unit` 时，3 个既有 usage currency 测试文件共 8 个断言因测试构建区域与默认币种不一致失败；显式使用仓库默认 Global 构建区域后，相关 65 个用例及完整 `pnpm test:unit` 均通过

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop Renderer 侧边栏的远程读取状态展示，不修改设备互联协议、IPC、数据同步或恢复行为；SSH 远程工作区与手机版不受影响
- 远程 / 手机版适配：本 PR 只调整设备互联控制端 Desktop UI；没有新增 IPC 或推送事件，不需要 allowlist 变更；手机版没有对应 Desktop 侧边栏入口，因此不涉及
- 回滚 / 降级方式：回退该提交即可恢复原有列表顶部 partial loading 提示

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
