### PR TITLE
fix(codex): 强制退役时只对真实在飞的会话广播终态错误

### DIFF
--- a/packages/maker-core/src/agents/codex/app-server/host.ts
+++ b/packages/maker-core/src/agents/codex/app-server/host.ts
@@ -173,6 +173,21 @@ export interface ThreadEventHandlers {
   autoApprovalReviewCompleted?: (params: ItemGuardianApprovalReviewCompletedNotification) => void;
   guardianWarning?: (params: GuardianWarningNotification) => void;
   error?: (params: ErrorNotification['params']) => void;
+  /**
+   * Host 被永久替换（强制退役，如账号切换 / auth 失效）时发给每个订阅者的结构化
+   * 生命周期信号。订阅者按自身真实状态收口：
+   *
+   * - 空闲 / 已完成的订阅者静默失效，不产生任何错误事件——不应把一次内部 host 替换
+   *   渲染成历史会话的终止错误（#1391 场景：闲置数小时的已完成会话在切账号时被打
+   *   永久红框）。
+   * - 真实在飞（turn in-flight / turn/start pending / overload retry）的订阅者清理
+   *   在途状态并产生一次终态 error + Done，保证 isTurnRunning 复位、上层 busy 判定 /
+   *   Stop 锁 / 输入队列不卡死（2026-07-19 auth app_session_terminated 实排）。
+   *
+   * 提供该回调时，host **不再**广播 transport error（否则空 turnId 的错误无法被
+   * pending/retry 会话收口）。未提供时保持旧行为（广播 transport error）。
+   */
+  hostForcedRetire?: (signal: { reason: string }) => void;
 
   // ── ServerRequest (Phase 2 approval) ─────────────────────────────────────
   // server → client 的 request, 必须返回 response (否则 server 卡 turn)。
@@ -739,7 +754,7 @@ export class AppServerHost {
   }
 
   /**
-   * 强制收割前把终态 transport error 广播给仍在订阅的 session。
+   * 强制收割前通知订阅者（结构化生命周期信号）。
    *
    * retire()/shutdown() 会静默清空 subscribers —— 常规路径(凭证切换/app 退出)由
    * 上层先 Session.close 收尾,这是对的;但 auth 失效等强制路径会带着 in-flight turn
@@ -747,14 +762,61 @@ export class AppServerHost {
    * 的输入队列 / Stop 的 queueAbortPending 锁 / 凭证切换 busy 判定全部永久卡死
    * (2026-07-19 实排:auth app_session_terminated 触发 retire 后会话假 busy 数小时)。
    * 只广播、不清订阅 —— 紧随其后的 retire() 负责清理。
+   *
+   * 但**不能**对每个订阅者广播 transport error：空闲/已完成的订阅者（没有 in-flight
+   * turn，例如闲置数小时的已完成会话）收到终态 error 后会被写入永久红框，而它并没有
+   * 任何真实工作被中断——这只是一次内部 host 替换（#1391 场景）。而真实在飞的
+   * turn/start pending / overload retry 订阅者若只收到**空 turnId** 的 transport
+   * error，现有 error handler 的 `targetsPendingTurn`（要求非空 turnId）与
+   * `wasTurnRunning`（不含 overload retry）无法把它收口，busy 状态会永久卡死。
+   *
+   * 因此改为发送结构化 `hostForcedRetire` 信号，由每个订阅者按自身完整状态收口
+   * （空闲→静默失效；在飞→终态 error + Done）。未提供该回调的订阅者退回旧行为
+   * （广播 transport error），保证兼容。
    */
   notifySubscribersOfForcedRetire(reason: string): void {
     if (this.subscribers.size === 0) return;
-    this.logger.warn('forced retire with live subscribers — broadcasting terminal transport error', {
+    let notified = 0;
+    let fellBack = 0;
+    for (const [threadId, handlers] of this.subscribers) {
+      if (handlers.hostForcedRetire) {
+        notified += 1;
+        try {
+          handlers.hostForcedRetire({ reason });
+          continue;
+        } catch (e) {
+          // handler 抛错 → 该订阅者收不到结构化信号, 强退场景最需要兜底:
+          // 回退到旧 transport-error 广播, 至少保证有一条终态错误触发收口,
+          // 否则 busy 永久卡死 (copilot review on #1720)。
+          this.logger.warn('forced retire handler threw — falling back to transport error', {
+            threadId,
+            message: (e as Error).message,
+          });
+        }
+      }
+      // 旧订阅者（未接 hostForcedRetire）保持旧行为：广播 transport error。
+      fellBack += 1;
+      try {
+        handlers.error?.({
+          threadId,
+          turnId: '',
+          willRetry: false,
+          scope: 'transport',
+          error: { message: `app-server force-retired: ${reason}` },
+        });
+      } catch (e) {
+        this.logger.warn('forced retire broadcast handler threw', {
+          threadId,
+          message: (e as Error).message,
+        });
+      }
+    }
+    this.logger.warn('forced retire with live subscribers — notifying session lifecycles', {
       subscribers: this.subscribers.size,
+      notified,
+      fellBack,
       reason,
     });
-    this.broadcastTransportErrorToSubscribers(`app-server force-retired: ${reason}`);
   }
 
   // ── 订阅 / 路由 ───────────────────────────────────────────────────────────

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -4304,6 +4304,198 @@ describe('CodexAgent MCP thread context hooks', () => {
     await agent.dispose();
   });
 
+  it('silently invalidates idle sessions when the local host is force-retired, while still notifying busy ones', async () => {
+    // 回归:切账号/auth 失效触发 force-retire 时,旧实现把终态 transport error 广播给
+    // 所有订阅者——闲置/已完成的会话也会收到永久红框(#1391 场景,用户侧实测:闲置
+    // 4 小时的已完成会话被写 app-server force-retired 错误)。修复后 host 发结构化
+    // hostForcedRetire 信号,由每个 session 按自身状态收口:空闲订阅者静默失效,
+    // 真实在飞的订阅者收到终态错误 + Done。
+    const agent = new CodexAgent(createDeps());
+
+    const idleHandle = await agent.startSession({
+      sessionId: 'session-force-retire-idle',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    const busyHandle = await agent.startSession({
+      sessionId: 'session-force-retire-busy',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+
+    // 两个会话共用一个 app-server host(共享 codex app-server)。
+    expect(createdTransports).toHaveLength(1);
+    const transport = createdTransports[0];
+
+    const idleEvents: Array<Record<string, unknown>> = [];
+    const busyEvents: Array<Record<string, unknown>> = [];
+    const collectIdle = (async () => {
+      for await (const event of idleHandle.events()) idleEvents.push(event as Record<string, unknown>);
+    })();
+    const collectBusy = (async () => {
+      for await (const event of busyHandle.events()) busyEvents.push(event as Record<string, unknown>);
+    })();
+
+    // busy 会话先进入 in-flight turn;idle 会话保持空闲。
+    // threadSeq 从 1 递增:第一个 startSession(idle)拿到 thread-1,第二个(busy)拿到 thread-2。
+    transport.emitMockLine({
+      method: 'turn/started',
+      params: { threadId: 'thread-2', turn: { id: 'turn-forced-retire-busy' } },
+    });
+    await waitForExpectation(() => {
+      expect(busyHandle.isTurnRunning?.()).toBe(true);
+    });
+    expect(idleHandle.isTurnRunning?.()).toBe(false);
+
+    await agent.forceDisposeLocalHostForAuthChange('test forced retire with idle subscriber');
+
+    // busy 会话:照旧收到一次终态 transport error + Done,isTurnRunning 复位。
+    expect(busyHandle.isTurnRunning?.()).toBe(false);
+    await waitForExpectation(() => {
+      expect(busyEvents.some((e) => e.type === 'error')).toBe(true);
+      expect(busyEvents.some((e) => e.type === 'status' && (e.data as { status?: string }).status === 'Done')).toBe(true);
+    });
+
+    // idle 会话:不产生任何 error/终态事件(否则 UI 会留下永久红框)。
+    // 断言放在事件流结束后(await collectIdle 之后),不用固定 sleep 赌时序。
+    await idleHandle.close();
+    await busyHandle.close();
+    await collectIdle;
+    await collectBusy;
+    expect(idleEvents.some((e) => e.type === 'error')).toBe(false);
+    expect(idleEvents.some((e) => e.type === 'status' && (e.data as { status?: string }).status === 'Done')).toBe(false);
+
+    await agent.dispose();
+  });
+
+  it('idle session send after force-retire rejects with stale-host error', async () => {
+    // P2 (chatgpt-codex-connector on #1720): 静默失效的空闲会话在 force-retire 后
+    // 下次 send 会因 isCurrentHost()===false 抛 stale-host 错误, 不会透明重建。
+    // 这是本 PR 的已知边界: 透明重建(换 host + 重新 thread)属于独立改动, 这里
+    // 只把行为钉死, 防止未来无意的语义漂移。
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({
+      sessionId: 'session-force-retire-idle-then-send',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    await agent.forceDisposeLocalHostForAuthChange('test forced retire idle then send');
+
+    await expect(
+      handle.send({ type: 'user', content: 'hello after retire' }),
+    ).rejects.toThrow(/Codex session expired/);
+
+    await handle.close();
+    await agent.dispose();
+  });
+
+  it('collapses a pending turn/start session with terminal error + Done when the local host is force-retired', async () => {
+    // 回归(Greptile P1 on #1720):空 turnId 的 transport error 无法收口
+    // turn/start pending 的会话(handler 的 targetsPendingTurn 要求非空 turnId),
+    // busy 会永久卡死。修复后由 hostForcedRetire 信号在 session 侧统一收口:
+    // 清理在途状态并推终态。
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({
+      sessionId: 'session-force-retire-pending-start',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    const events: Array<Record<string, unknown>> = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event as unknown as Record<string, unknown>);
+    })();
+    const transport = createdTransports[0];
+
+    // 模拟 turn/start 已发出但响应未回:send 前 handle 先推初始 status,
+    // 断言按顺序(初始 status → error → Done),不用 nextEvent 逐个取值。
+    const sendPromise = handle.send({ type: 'user', content: 'pending turn start' });
+    await waitForExpectation(() => {
+      expect(transport.lines.some((line) => line.includes('turn/start'))).toBe(true);
+    });
+
+    await agent.forceDisposeLocalHostForAuthChange('test forced retire with pending turn/start');
+
+    // pending turn/start 的会话必须收到一次终态 error + Done,且不残留 busy。
+    expect(handle.isTurnRunning?.()).toBe(false);
+    await waitForExpectation(() => {
+      const errorIdx = events.findIndex((e) => e.type === 'error');
+      expect(errorIdx).toBeGreaterThan(0);
+      // 信号路径直接推 app-server-force-retired(reason 精确匹配);RPC 被 reject
+      // 时复用既有墓碑路径推 turn/start failed(无 reason 字段)。两者都必须是一次
+      // 终态,否则 UI 卡红框。willRetry 只有信号路径带 false,这里不强求。
+      expect(events[errorIdx]).toMatchObject({
+        type: 'error',
+        data: expect.objectContaining({ isTerminal: true }),
+      });
+      const doneIdx = events.findIndex((e) => e.type === 'status' && (e.data as { status?: string }).status === 'Done');
+      expect(doneIdx).toBeGreaterThan(errorIdx);
+      expect(events[doneIdx]).toMatchObject({
+        type: 'status',
+        data: expect.objectContaining({ status: 'Done', isRunning: false }),
+      });
+    });
+    expect(transport.closed).toBe(true);
+
+    await sendPromise.catch(() => undefined);
+    await collectEvents;
+    await handle.close();
+    await agent.dispose();
+  });
+
+  it('does not re-activate a force-retired session when a late turn/start success response arrives', async () => {
+    // 回归 (Greptile P1 on #1720): 强退发生在 turn/start 尚无 turnId 时, 迟到的
+    // 成功响应不得重新激活已终态收口的会话 (currentTurnId / isTurnInFlight 复活,
+    // 事件队列已 end → 上层 busy 永久卡死)。
+    const agent = new CodexAgent(createDeps());
+    const handle = await agent.startSession({
+      sessionId: 'session-force-retire-late-start-resp',
+      model: 'gpt-5.4',
+      workingDir: '/repo-local',
+    });
+    const events: Array<Record<string, unknown>> = [];
+    const collectEvents = (async () => {
+      for await (const event of handle.events()) events.push(event as unknown as Record<string, unknown>);
+    })();
+    const transport = createdTransports[0];
+
+    // turn/start 发出但响应不立即回 (挂起 RPC)。
+    const sendPromise = handle.send({ type: 'user', content: 'pending turn start' });
+    await waitForExpectation(() => {
+      expect(transport.lines.some((line) => line.includes('turn/start'))).toBe(true);
+    });
+
+    // 强退: notifySubscribersOfForcedRetire 同步执行 → quarantine + 终态收口。
+    await agent.forceDisposeLocalHostForAuthChange('test forced retire with late start response');
+
+    // 收口先发生: 终态 error + Done, 不再 busy。
+    await waitForExpectation(() => {
+      expect(events.some((e) => e.type === 'error')).toBe(true);
+      expect(events.some((e) => e.type === 'status' && (e.data as { status?: string }).status === 'Done')).toBe(true);
+    });
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    // 迟到成功响应随后到达 (挂起 RPC 在 close/reject 之前 resolve 的竞态窗口)。
+    const line = transport.lines.find((l) => l.includes('turn/start'));
+    const req = line ? JSON.parse(line) : null;
+    if (req?.id !== undefined) {
+      transport.emitMockLine({ id: req.id, result: { turn: { id: 'late-success-turn' } } });
+    }
+    await sendPromise.catch(() => undefined);
+    // 事件流结束(collectEvents 完成)后再统一断言, 不用固定 sleep 赌时序:
+    // 全程只能有一次 error + 一次 Done, 迟到响应不得新增第二组终态。
+    await collectEvents;
+
+    // 不得复活 busy, 也不得新增第二组终态事件。
+    expect(handle.isTurnRunning?.()).toBe(false);
+    const errorCount = events.filter((e) => e.type === 'error').length;
+    expect(errorCount).toBe(1);
+    const doneCount = events.filter((e) => e.type === 'status' && (e.data as { status?: string }).status === 'Done').length;
+    expect(doneCount).toBe(1);
+
+    await handle.close();
+    await agent.dispose();
+  });
+
   it('keeps shared Codex sessions usable when ordinary stderr contains auth keywords', async () => {
     const invalidate = vi.fn(async () => undefined);
     const agent = new CodexAgent(createDeps({}, {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -2756,6 +2756,7 @@ export class CodexAgent extends BaseAgent {
 
     let closed = false;
     let subscriptionInvalidatedByTransport = false;
+    let sessionHostForceRetired = false;
     let subscription: ThreadSubscription | null = null;
     let interactionResolver: InteractionResolver | null = null;
     // Kept across the internal plan implementation/revision turns. A later
@@ -2988,6 +2989,7 @@ export class CodexAgent extends BaseAgent {
     const capturedHostWasRegistered = this.hosts.get(currentHostKey) === host;
     const connectionId = host.getConnectionId();
     const isCurrentHost = (): boolean => {
+      if (sessionHostForceRetired) return false;
       const currentHost = this.hosts.get(currentHostKey);
       if ((this.hostGenerations.get(currentHostKey) ?? 0) !== hostGeneration) return false;
       return capturedHostWasRegistered ? currentHost === host : currentHost === undefined;
@@ -7331,6 +7333,68 @@ export class CodexAgent extends BaseAgent {
 
     // ── subscribeThread: notification 路由 + approval handlers ─────────────
     const handlers: ThreadEventHandlers = {
+      // 强制退役(账号切换/auth 失效)时由 host 发结构化信号，按本会话自身真实状态收口。
+      // 空闲/已完成 → 静默失效；真实在飞(turn in-flight / turn/start pending /
+      // overload retry) → 清理在途状态并推终态 error + Done。
+      // 不能在 host 层用空 turnId 的 transport error 广播：error handler 的
+      // targetsPendingTurn 要求非空 turnId、wasTurnRunning 不含 overload retry，
+      // pending/retry 会话会收不了口（busy 永久卡死）。所以由这里统一收口。
+      hostForcedRetire: ({ reason }) => {
+        sessionHostForceRetired = true;
+        subscriptionInvalidatedByTransport = false;
+
+        const hadPendingWork =
+          isTurnInFlight
+          || isTurnStartPending
+          || overloadRetryPending();
+        if (!hadPendingWork) {
+          log.info('idle Codex session invalidated by forced host retirement', { threadId });
+          eventQueue.end();
+          return;
+        }
+
+        // turn/start 可能尚未返回 id。先把所有在途请求标为已收口并隔离，随后 RPC
+        // reject/迟到 resolve 时复用既有 finally/墓碑路径，不再发第二组终态。
+        markInFlightStartsTerminallySettled();
+        quarantineAllInFlightStarts();
+        discardOverloadRetry('app-server force-retired');
+        // 强制退役后 host 不再投递后代 turn/completed 通知, 与 close /
+        // transport-error 同款: 先把仍在跑的子代理卡收成终态, 否则渲染端在
+        // parent 已推 Done 之后仍会看到子代理卡永久转圈。
+        for (const update of subagentLiveCards.drainRunningForShutdown()) emitSubagentCardUpdate(update);
+        subagentLiveCards.clear();
+        dismissAllPending('app_server_force_retired', 'deny');
+        dismissAllPendingUserInput('transport_error');
+        activeToolContexts.clear();
+        stopActiveRolloutPlanFallback();
+        resetUpstreamIdleForTurnEnd();
+        if (currentTurnId) terminalErroredTurnIds.add(currentTurnId);
+        currentTurnId = null;
+        isTurnInFlight = false;
+        isTurnStartPending = false;
+        currentTurnPlanModeActive = false;
+        pendingTurnStartPlanMode = null;
+
+        eventQueue.push({
+          type: 'error',
+          data: {
+            message: `app-server force-retired: ${reason}`,
+            isTerminal: true,
+            willRetry: false,
+            reason: 'app-server-force-retired',
+          },
+          source: 'codex',
+        });
+        eventQueue.push({
+          type: 'status',
+          data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
+          source: 'codex',
+        });
+        // 该 host 已被永久替换，handle 不可能原地恢复。结束内部事件流，让已启动的
+        // Session 走既有 auto-close → Maker lazy create；尚未启动 event loop 的
+        // Session 会在下一次 send 明确失败后 drain 到这里并重建。
+        eventQueue.end();
+      },
       threadStarted: (params) => {
         const sid = params.thread?.id;
         if (sid && sid !== sdkSessionId) sdkSessionId = sid;
@@ -8331,7 +8395,12 @@ export class CodexAgent extends BaseAgent {
             // 墓碑: 该 turn 的终态已抢在本响应之前到达 (典型: 收紧补中断后
             // turnCompleted(interrupted) 先回), 不得重新置活, 否则会话卡 running。
             const alreadyCompleted = turnsCompletedBeforeStartResp.has(resp.turn.id);
-            if (!alreadyCompleted && !terminalErroredTurnIds.has(resp.turn.id)) {
+            // 强退守卫 (Greptile P1 on #1720): hostForcedRetire 已把本会话终态收口
+            // (eventQueue.end), 迟到的 turn/start 成功响应不得重新激活。正常流程里
+            // client.close() 会 reject 挂起 RPC 且 quarantine 已在 adoptUnidentifiedDeadTurn
+            // 落墓碑, 这里再显式挡一道, 不依赖那些间接语义 —— 否则 currentTurnId /
+            // isTurnInFlight 复活后事件队列已 end, 上层 busy 永久卡死。
+            if (!alreadyCompleted && !terminalErroredTurnIds.has(resp.turn.id) && !sessionHostForceRetired) {
               // The app-server has now acknowledged which turn owns this
               // input. Bind explicit source selection before buffered tool
               // requests are released, and never on a pre-accept failure.


### PR DESCRIPTION
## 这次改了什么

### 摘要

账号切换 / ChatGPT auth 失效会触发共享 codex app-server 强制退役（`codex local auth restart: retiring host with active sessions`）。旧实现把终态 transport error **广播给所有订阅者**（`notifySubscribersOfForcedRetire` → `broadcastTransportErrorToSubscribers`），导致**闲置数小时的已完成会话也被写入 `app-server force-retired` 永久红框**——会话并没有任何真实工作被中断，这只是一次内部 host 替换。

本 PR 改为 host 在强制退役时向每个订阅者发送**结构化生命周期信号 `hostForcedRetire`**，由会话按自身真实状态收口：

- **空闲 / 已完成**的会话静默失效（`eventQueue.end()`），不产生任何错误事件，UI 不再出现红框；
- **真实在飞**（turn in-flight / turn/start pending / overload retry）的会话清理在途状态、收口子代理卡，并推一次终态 error（`app-server-force-retired`）+ `Done`，保证 `isTurnRunning` 复位、上层 busy 判定 / Stop 锁 / 输入队列不卡死（2026-07-19 auth app_session_terminated 实排）；
- **迟到响应防护**：`sessionHostForceRetired` 标记 + start quarantine + 终态墓碑，阻止强退后迟到的 `turn/start` 成功响应重新激活已收口会话（`currentTurnId`/`isTurnInFlight` 复活导致 busy 永久卡死）；
- 未提供该回调的旧订阅者保持旧行为（广播 transport error），不破坏兼容。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#1391（同源问题，该 PR 未合入且带未解决的 P1/P2 竞态）、#1412（#1391 架构确认门）
- 本 PR 包含：`ThreadEventHandlers.hostForcedRetire` 可选回调（替代首版 `isBusy` 甄别）；`notifySubscribersOfForcedRetire` 结构化通知 + 旧订阅者兼容回退；Session 侧完整收口（空闲静默 / 在飞终态 + 子代理卡 drain）；迟到 turn/start 响应守卫；回归测试（idle / busy / pending turn/start / 迟到成功响应）
- 明确不包含：UI、SQLite、远端 Codex 服务、普通关闭流程、其他 Agent provider
- 用户可见变化：闲置/已完成对话不再因切账号或 auth 失效突然出现 `app-server force-retired` 红色失败；真实进行中的工作仍会明确失败
- 是否存在 breaking change：无。`hostForcedRetire` 为可选回调，未提供时保持旧行为（广播 transport error）

### 为什么独立实现而非沿用 #1391

#1391（Chener）方向一致，但截至本 PR 仍未合入，且 review 指出未修竞态。首版实现采用 `isBusy()` 甄别 + 空 turnId transport error 广播，Greptile 审查发现该方案无法收口 pending/retry 会话（error handler 的 `targetsPendingTurn` 要求非空 turnId、`wasTurnRunning` 不含 overload retry）——故重构为当前的结构化信号方案，会话按自身完整状态收口，天然覆盖这两类状态，并显式守卫迟到响应重激活。

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
cd packages/maker-core
pnpm exec vitest run src/agents/codex/index.test.ts
结果：402 passed（含 idle/busy 双订阅者、pending turn/start 收口、迟到成功响应不复活、force-retire 后 idle send 拒绝 4 个回归测试）

pnpm exec vitest run src/agents/codex/app-server/host.test.ts
结果：16 passed

pnpm --filter @cindy/maker-core run build
结果：源文件零类型错误（测试文件有既有类型错误，改动前后一致）

pnpm exec eslint src/agents/codex/index.ts src/agents/codex/app-server/host.ts
结果：零错误
```

### 手工验证

不涉及。

### 未执行的验证

- 未在真实账号切换场景做端到端验证（需真实 ChatGPT 账号切换）；由单测覆盖 idle/completed/in-flight/pending 四种订阅状态。
- Desktop 470 个既有环境性失败未修复（与本次改动无关，建议另开 issue 跟踪）。

## 风险

- 无已知风险；`hostForcedRetire` 可选、未提供时行为不变。
