### PR TITLE
fix(mobile): 修复 iOS 推送点击任务跳转

### DIFF
--- a/apps/mobile/src/__tests__/pushRegistrationModel.test.ts
+++ b/apps/mobile/src/__tests__/pushRegistrationModel.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildPushTokenRegistrationBody,
   parseNotificationDeepLink,
+  parseNotificationResponseDeepLink,
   resolvePushAppVariant,
 } from '@/notifications/pushRegistrationModel';
 
@@ -54,5 +55,69 @@ describe('parseNotificationDeepLink', () => {
     ['协议相对', { deepLink: '//evil.example/sessions/x' }],
   ])('拒绝:%s', (_label, input) => {
     expect(parseNotificationDeepLink(input)).toBeNull();
+  });
+});
+
+describe('parseNotificationResponseDeepLink', () => {
+  it('读取 Expo content.data 中的深链', () => {
+    expect(
+      parseNotificationResponseDeepLink({
+        notification: {
+          request: {
+            content: { data: { deepLink: '/sessions/s-1?deviceId=d-1' } },
+            trigger: { type: 'push', payload: {} },
+          },
+        },
+      }),
+    ).toBe('/sessions/s-1?deviceId=d-1');
+  });
+
+  it('兼容 iOS APNs trigger.payload 顶层深链', () => {
+    expect(
+      parseNotificationResponseDeepLink({
+        notification: {
+          request: {
+            content: { data: {} },
+            trigger: {
+              type: 'push',
+              payload: { deepLink: '/sessions/s-2?deviceId=d-2' },
+            },
+          },
+        },
+      }),
+    ).toBe('/sessions/s-2?deviceId=d-2');
+  });
+
+  it('兼容 relay 将自定义字段包在 payload.body / payload.data 中', () => {
+    expect(
+      parseNotificationResponseDeepLink({
+        notification: {
+          request: {
+            content: { data: {} },
+            trigger: {
+              type: 'push',
+              payload: { body: { deepLink: '/sessions/s-3?deviceId=d-3' } },
+            },
+          },
+        },
+      }),
+    ).toBe('/sessions/s-3?deviceId=d-3');
+    expect(
+      parseNotificationResponseDeepLink({
+        notification: {
+          request: {
+            content: { data: {} },
+            trigger: {
+              type: 'push',
+              payload: { data: { deepLink: '/sessions/s-4?deviceId=d-4' } },
+            },
+          },
+        },
+      }),
+    ).toBe('/sessions/s-4?deviceId=d-4');
+  });
+
+  it('非对象响应返回 null', () => {
+    expect(parseNotificationResponseDeepLink(null)).toBeNull();
   });
 });

--- a/apps/mobile/src/notifications/PushNotificationsBridge.tsx
+++ b/apps/mobile/src/notifications/PushNotificationsBridge.tsx
@@ -102,7 +102,7 @@ export function PushNotificationsBridge() {
       const dedupeKey = identifier ? `id:${identifier}` : `deepLink:${deepLink}`;
       if (consumedNotificationResponseKeys.has(dedupeKey)) return;
       consumedNotificationResponseKeys.add(dedupeKey);
-      void Notifications.clearLastNotificationResponseAsync?.().catch(() => undefined);
+      void Notifications.clearLastNotificationResponseAsync?.()?.catch(() => undefined);
       pendingDeepLinkRef.current = deepLink;
       flushPendingDeepLink();
     };

--- a/apps/mobile/src/notifications/PushNotificationsBridge.tsx
+++ b/apps/mobile/src/notifications/PushNotificationsBridge.tsx
@@ -1,8 +1,9 @@
 import { useRouter } from 'expo-router';
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
 import { useAuth } from '@/auth/AuthContext';
 import Notifications from './nativeNotifications';
-import { parseNotificationDeepLink } from './pushRegistrationModel';
+import { parseNotificationResponseDeepLink } from './pushRegistrationModel';
 import {
   configureForegroundNotificationBehavior,
   isPushSupported,
@@ -11,22 +12,35 @@ import {
   syncPushRegistration,
 } from './pushNotifications';
 
-/** 冷启动 last-response 的已消费标记(模块级:组件重挂/Provider 重建也不重复路由)。 */
-const consumedLastResponseIds = new Set<string>();
+/** 已消费点击的去重键(模块级:组件重挂/Provider 重建也不重复路由)。 */
+const consumedNotificationResponseKeys = new Set<string>();
+type NotificationResponse = Parameters<
+  Parameters<typeof Notifications.addNotificationResponseReceivedListener>[0]
+>[0];
 
 /**
  * 移动推送的运行时桥(挂在 AuthProvider 内、导航树旁,不渲染任何 UI):
  *
  * 1. 登录后按本机开关同步 token 注册(启动补偿:上次注册失败/换账号后自愈);
  * 2. APNs token 轮换时重新上报;
- * 3. 通知点击(前台/后台/冷启动)→ 校验 data.deepLink → 路由到对应会话;
+ * 3. 通知点击(前台/后台/冷启动)→ 解析 APNs / Expo 深链 → 路由到对应会话;
  * 4. 前台压掉系统横幅。
  */
 export function PushNotificationsBridge() {
   const auth = useAuth();
   const router = useRouter();
+  const routerRef = useRef(router);
+  routerRef.current = router;
   /** 冷启动点通知时 auth 可能未就绪,先存下待路由的深链。 */
   const pendingDeepLinkRef = useRef<string | null>(null);
+  const authStateRef = useRef({
+    initialized: auth.initialized,
+    isAuthenticated: auth.isAuthenticated,
+  });
+  authStateRef.current = {
+    initialized: auth.initialized,
+    isAuthenticated: auth.isAuthenticated,
+  };
   const apiFetchRef = useRef(auth.apiFetch);
   apiFetchRef.current = auth.apiFetch;
 
@@ -69,41 +83,56 @@ export function PushNotificationsBridge() {
     return () => sub.remove();
   }, [auth.initialized, auth.isAuthenticated]);
 
-  // 通知点击路由:后台点击经 response listener,冷启动经 last response 补偿
+  const flushPendingDeepLink = useCallback((): void => {
+    const target = pendingDeepLinkRef.current;
+    if (!target) return;
+    const { initialized, isAuthenticated } = authStateRef.current;
+    if (!initialized || !isAuthenticated) return; // 待 auth 就绪后由下方 effect 重放
+    pendingDeepLinkRef.current = null;
+    routerRef.current.push(target as never);
+  }, []);
+
+  // 通知点击路由:后台点击经 response listener,冷启动 / 回前台经 last response 补偿
   useEffect(() => {
     if (!isPushSupported()) return;
-    const routeTo = (deepLink: string | null): void => {
+    const consumeResponse = (response: NotificationResponse): void => {
+      const deepLink = parseNotificationResponseDeepLink(response);
       if (!deepLink) return;
+      const identifier = response.notification.request.identifier;
+      const dedupeKey = identifier ? `id:${identifier}` : `deepLink:${deepLink}`;
+      if (consumedNotificationResponseKeys.has(dedupeKey)) return;
+      consumedNotificationResponseKeys.add(dedupeKey);
+      void Notifications.clearLastNotificationResponseAsync?.().catch(() => undefined);
       pendingDeepLinkRef.current = deepLink;
       flushPendingDeepLink();
     };
-    const flushPendingDeepLink = (): void => {
-      const target = pendingDeepLinkRef.current;
-      if (!target) return;
-      if (!auth.initialized || !auth.isAuthenticated) return; // 待 auth 就绪后由下方 effect 重放
-      pendingDeepLinkRef.current = null;
-      router.push(target as never);
+
+    const readLastResponse = (): void => {
+      void Notifications.getLastNotificationResponseAsync()
+        .then((response) => {
+          if (response) consumeResponse(response);
+        })
+        .catch(() => undefined);
     };
-    // effect 因 auth 就绪重跑时,冷启动阶段暂存的深链在此重放——last response
-    // 已被上一轮消费/清除,不能依赖再次读取它来触发
-    flushPendingDeepLink();
+
     const sub = Notifications.addNotificationResponseReceivedListener((response) => {
-      routeTo(parseNotificationDeepLink(response.notification.request.content.data));
+      consumeResponse(response);
     });
-    void Notifications.getLastNotificationResponseAsync().then((response) => {
-      if (!response) return;
-      // last response 会一直返回同一次点击(effect 因 auth 变化重跑、组件重挂时会
-      // 再次读到):按 request.identifier 去重,消费后清掉系统侧记录,避免用户处理
-      // 完通知后又被重复推回旧会话。
-      const identifier = response.notification.request.identifier;
-      if (identifier && consumedLastResponseIds.has(identifier)) return;
-      if (identifier) consumedLastResponseIds.add(identifier);
-      void Notifications.clearLastNotificationResponseAsync?.().catch(() => undefined);
-      routeTo(parseNotificationDeepLink(response.notification.request.content.data));
+    readLastResponse();
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      if (state === 'active') readLastResponse();
     });
-    return () => sub.remove();
-    // auth 状态变化时重跑以重放 pending 深链(冷启动点通知 → 登录恢复完成 → 进会话)
-  }, [auth.initialized, auth.isAuthenticated, router]);
+    return () => {
+      sub.remove();
+      appStateSub.remove();
+    };
+  }, [flushPendingDeepLink]);
+
+  // auth 就绪后重放冷启动 / 点击期间暂存的深链。监听本身保持挂载，避免 auth
+  // 状态变化重建 effect 时与 last-response 读取发生竞态。
+  useEffect(() => {
+    flushPendingDeepLink();
+  }, [auth.initialized, auth.isAuthenticated, flushPendingDeepLink]);
 
   return null;
 }

--- a/apps/mobile/src/notifications/pushRegistrationModel.ts
+++ b/apps/mobile/src/notifications/pushRegistrationModel.ts
@@ -59,3 +59,39 @@ export function parseNotificationDeepLink(data: unknown): string | null {
   if (deepLink.includes('://') || deepLink.startsWith('//')) return null;
   return deepLink;
 }
+
+function parseNotificationPayloadDeepLink(data: unknown): string | null {
+  const direct = parseNotificationDeepLink(data);
+  if (direct) return direct;
+  if (!data || typeof data !== 'object') return null;
+  const record = data as Record<string, unknown>;
+  // APNs relay implementations may wrap custom fields under `body` or `data`.
+  // Keep the fallback explicit rather than recursively walking untrusted payloads.
+  return parseNotificationDeepLink(record.body) ?? parseNotificationDeepLink(record.data);
+}
+
+/**
+ * 从 expo-notifications 的点击响应中解析任务深链。
+ *
+ * iOS 远程通知在 Expo 56 有两条数据出口：`content.data` 通常来自 APNs
+ * userInfo 的 `body` 字段，而完整的 APNs userInfo 保存在
+ * `request.trigger.payload`。两者都支持，避免 relay 的 payload 包装方式
+ * 让点击事件静默失效。
+ */
+export function parseNotificationResponseDeepLink(response: unknown): string | null {
+  if (!response || typeof response !== 'object') return null;
+  const notification = (response as Record<string, unknown>).notification;
+  if (!notification || typeof notification !== 'object') return null;
+  const request = (notification as Record<string, unknown>).request;
+  if (!request || typeof request !== 'object') return null;
+  const requestRecord = request as Record<string, unknown>;
+  const content = requestRecord.content;
+  if (content && typeof content === 'object') {
+    const contentData = (content as Record<string, unknown>).data;
+    const fromContent = parseNotificationPayloadDeepLink(contentData);
+    if (fromContent) return fromContent;
+  }
+  const trigger = requestRecord.trigger;
+  if (!trigger || typeof trigger !== 'object') return null;
+  return parseNotificationPayloadDeepLink((trigger as Record<string, unknown>).payload);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 iOS Expo Notifications 点击推送后无法跳转到对应任务的问题。iOS 远程通知的完整 APNs 数据可能位于 `request.trigger.payload`，旧逻辑只读取 `content.data.deepLink`，导致 App 被唤起但深链为空。

本 PR 同时让通知点击监听保持稳定挂载，并在 App 回到 active 时补读 last response，避免 auth 状态变化造成监听重建或冷启动竞态。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：兼容 `content.data.deepLink`、`trigger.payload.deepLink` 以及 `payload.body/data.deepLink`；统一通知响应去重、清理和待认证完成后的跳转。
- 明确不包含：服务端推送 payload、原生配置、UI 改动。
- 用户可见变化：点击 iOS 推送后进入通知对应的 `/sessions/...` 任务。
- 是否存在 breaking change：无。

### UI 变化

不涉及 UI：纯逻辑修复，无视觉、交互或文案变化。

- 引用的设计规范：不涉及：纯逻辑修复，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm exec vitest run src/__tests__/pushRegistrationModel.test.ts
结果：1 个测试文件通过，15 个测试通过。

pnpm exec esbuild apps/mobile/src/notifications/PushNotificationsBridge.tsx --loader:.tsx=tsx --format=esm --platform=neutral --bundle --external:* --outfile=/private/tmp/cindy-push-bridge-check.js
结果：通过。

git diff --check
结果：通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：未通过。仓库脚本测试在当前沙箱中尝试监听 127.0.0.1 时收到 EPERM，另有 workspace 包缺少本地 node_modules；失败未命中本次改动文件。

pnpm --filter mobile run --if-present typecheck
结果：当前 worktree 缺少 tsc/node_modules，无法启动；使用已有依赖布局检查时仅出现既有 workspace 依赖/基线类型错误，未命中本次三个改动文件。
```

### 手工验证

未由 agent 执行 iOS 真机验证；用户已在 App 未被杀、处于打开状态时复现旧版本点击推送不跳转任务。

### 未执行的验证

iOS 真机点击推送回归尚未执行，需要在包含本分支 JS 的开发构建中验证。

## 风险

### 风险分类

- [x] 跨平台差异
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 其他：

### 影响与回滚

- 影响范围：仅移动端推送点击导航；新增解析路径均保留 `/sessions/...` 深链安全校验。
- 回滚 / 降级方式：回滚 commit `d57b432ca` 及后续修复 commit 即可。
- 不涉及原生层或 runtime fingerprint，不需要冷更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已说明理由）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
