### PR TITLE
fix(desktop): 避免重复重试不可用的 Computer Use 光标样式

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/computer.test.ts
@@ -999,7 +999,7 @@ describe('computer mcp integration', () => {
     expectDriverSessionGenerations([payload.session], 'session-1', [0]);
   });
 
-  it('styles the TapTap cursor once per long-lived MCP session before actions', async () => {
+  it('styles the Cindy cursor once per long-lived MCP session before actions', async () => {
     mcpCallToolMock
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
@@ -1023,6 +1023,79 @@ describe('computer mcp integration', () => {
 
     const toolCalls = mcpCallToolMock.mock.calls.map((call) => call[0]?.name);
     expect(toolCalls).toEqual([
+      'set_agent_cursor_motion',
+      'set_agent_cursor_style',
+      'click',
+      'click',
+    ]);
+    expect(mcpCallToolMock.mock.calls[0]?.[0]?.arguments).toMatchObject({
+      cursor_color: '#DF0C27',
+      cursor_label: BRAND_NAME,
+    });
+    expect(mcpCallToolMock.mock.calls[1]?.[0]?.arguments).toMatchObject({
+      gradient_colors: ['#DF0C27', '#A61629'],
+      bloom_color: '#DF0C27',
+    });
+    expect(mcpConnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries Cindy cursor styling after a transient styling failure', async () => {
+    mcpCallToolMock
+      .mockRejectedValueOnce(new Error('motion unavailable'))
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true,"clicked":true}' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true,"clicked":true}' }] });
+
+    await expect(callComputerDriverTool('click', {
+      pid: 123,
+      window_id: 7,
+      x: 10,
+      y: 20,
+      session: 'session-1',
+    }, { sessionId: 'session-1' })).resolves.toEqual({ ok: true, clicked: true });
+    await expect(callComputerDriverTool('click', {
+      pid: 123,
+      window_id: 7,
+      x: 11,
+      y: 21,
+      session: 'session-1',
+    }, { sessionId: 'session-1' })).resolves.toEqual({ ok: true, clicked: true });
+
+    const toolCalls = mcpCallToolMock.mock.calls.map((call) => call[0]?.name);
+    expect(toolCalls).toEqual([
+      'set_agent_cursor_motion',
+      'set_agent_cursor_style',
+      'click',
+      'set_agent_cursor_motion',
+      'click',
+    ]);
+  });
+
+  it('stops retrying unsupported cursor setup tools for the current MCP session', async () => {
+    mcpCallToolMock
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
+      .mockResolvedValueOnce({
+        isError: true,
+        content: [{ type: 'text', text: "Permission denied: tool 'set_agent_cursor_style' has no reviewed risk classification" }],
+      })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true,"clicked":true}' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true,"clicked":true}' }] });
+
+    await expect(callComputerDriverTool('click', {
+      pid: 123,
+      window_id: 7,
+      x: 10,
+      y: 20,
+    }, { sessionId: 'session-unsupported-style' })).resolves.toEqual({ ok: true, clicked: true });
+    await expect(callComputerDriverTool('click', {
+      pid: 123,
+      window_id: 7,
+      x: 11,
+      y: 21,
+    }, { sessionId: 'session-unsupported-style' })).resolves.toEqual({ ok: true, clicked: true });
+
+    expect(mcpCallToolMock.mock.calls.map((call) => call[0]?.name)).toEqual([
       'set_agent_cursor_motion',
       'set_agent_cursor_style',
       'click',
@@ -1031,39 +1104,43 @@ describe('computer mcp integration', () => {
     expect(mcpConnectMock).toHaveBeenCalledTimes(1);
   });
 
-  it('retries TapTap cursor styling after a transient styling failure', async () => {
+  it('retries unsupported cursor setup after the MCP session is recreated', async () => {
     mcpCallToolMock
-      .mockRejectedValueOnce(new Error('motion unavailable'))
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
+      .mockResolvedValueOnce({
+        isError: true,
+        content: [{ type: 'text', text: "Permission denied: tool 'set_agent_cursor_style' has no reviewed risk classification" }],
+      })
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true,"clicked":true}' }] })
+      .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true}' }] })
       .mockResolvedValueOnce({ content: [{ type: 'text', text: '{"ok":true,"clicked":true}' }] });
 
-    await expect(callComputerDriverTool('click', {
+    await callComputerDriverTool('click', {
       pid: 123,
       window_id: 7,
       x: 10,
       y: 20,
-      session: 'session-1',
-    }, { sessionId: 'session-1' })).resolves.toEqual({ ok: true, clicked: true });
-    await expect(callComputerDriverTool('click', {
+    }, { sessionId: 'session-style-recreated' });
+    await cleanupComputerDriverSession('session-style-recreated');
+    await callComputerDriverTool('click', {
       pid: 123,
       window_id: 7,
       x: 11,
       y: 21,
-      session: 'session-1',
-    }, { sessionId: 'session-1' })).resolves.toEqual({ ok: true, clicked: true });
+    }, { sessionId: 'session-style-recreated' });
 
-    const toolCalls = mcpCallToolMock.mock.calls.map((call) => call[0]?.name);
-    expect(toolCalls).toEqual([
+    expect(mcpCallToolMock.mock.calls.map((call) => call[0]?.name)).toEqual([
       'set_agent_cursor_motion',
       'set_agent_cursor_style',
       'click',
+      'end_session',
       'set_agent_cursor_motion',
       'set_agent_cursor_style',
       'click',
     ]);
+    expect(mcpConnectMock).toHaveBeenCalledTimes(2);
   });
 
   it('throws the driver stderr when a tool call exits non-zero', async () => {
@@ -3288,7 +3365,6 @@ describe('computer mcp integration', () => {
     });
   });
 });
-
 
 function currentPlatformReleaseAsset(version: string, size = 21147689) {
   const name = getCuaDriverReleaseAssetName(version);

--- a/apps/desktop/src/main/mcp-integrations/computer.ts
+++ b/apps/desktop/src/main/mcp-integrations/computer.ts
@@ -118,13 +118,15 @@ const CLI_FALLBACK_TOOL_NAMES = new Set<ComputerMcpToolName>([
   'get_screen_size',
   'get_cursor_position',
 ]);
-const TAPTAP_CURSOR_STYLE = {
-  gradient_colors: ['#00D9C5', '#000050'],
-  bloom_color: '#00D9C5',
+// The out-of-process driver cannot consume renderer theme tokens, so keep the
+// concrete Cindy brand palette here in sync with DESIGN.md §15.1 / §15.7.
+const CINDY_CURSOR_STYLE = {
+  gradient_colors: ['#DF0C27', '#A61629'],
+  bloom_color: '#DF0C27',
 } as const;
-const TAPTAP_CURSOR_MOTION = {
+const CINDY_CURSOR_MOTION = {
   cursor_icon: 'arrow',
-  cursor_color: '#00D9C5',
+  cursor_color: '#DF0C27',
   cursor_label: BRAND_NAME,
   cursor_size: 30,
   cursor_opacity: 0.96,
@@ -278,8 +280,12 @@ interface CuaMcpSessionEntry {
   transport: StdioClientTransport;
   ready: Promise<void>;
   driverSessionId: string;
-  styled: boolean;
+  cursorSetup: {
+    motion: CursorSetupState;
+    style: CursorSetupState;
+  };
 }
+type CursorSetupState = 'pending' | 'applied' | 'unavailable';
 
 interface ProcessSnapshotEntry {
   pid: number;
@@ -2069,7 +2075,10 @@ function createCuaMcpSession(sessionId: string): CuaMcpSessionEntry {
     client,
     transport,
     driverSessionId: getDriverSessionId(sessionId),
-    styled: false,
+    cursorSetup: {
+      motion: 'pending',
+      style: 'pending',
+    },
     ready: withTimeout(
       client.connect(transport),
       MCP_STARTUP_TIMEOUT_MS,
@@ -2217,28 +2226,33 @@ async function initializeDefaultCursorStyle(
   session: string,
 ): Promise<void> {
   if (!CURSOR_STYLED_TOOL_NAMES.has(name)) return;
-  if (entry.styled) return;
 
-  const calls: Array<{ tool: string; args: Record<string, unknown> }> = [
+  const calls: Array<{
+    stateKey: keyof CuaMcpSessionEntry['cursorSetup'];
+    tool: string;
+    args: Record<string, unknown>;
+  }> = [
     {
+      stateKey: 'motion',
       tool: 'set_agent_cursor_motion',
       args: {
         cursor_id: session,
-        ...TAPTAP_CURSOR_MOTION,
+        ...CINDY_CURSOR_MOTION,
       },
     },
     {
+      stateKey: 'style',
       tool: 'set_agent_cursor_style',
       args: {
         cursor_id: session,
-        gradient_colors: TAPTAP_CURSOR_STYLE.gradient_colors,
-        bloom_color: TAPTAP_CURSOR_STYLE.bloom_color,
+        gradient_colors: CINDY_CURSOR_STYLE.gradient_colors,
+        bloom_color: CINDY_CURSOR_STYLE.bloom_color,
       },
     },
   ];
 
-  let styled = true;
   for (const call of calls) {
+    if (entry.cursorSetup[call.stateKey] !== 'pending') continue;
     try {
       await callCuaMcpTool(
         entry,
@@ -2246,17 +2260,36 @@ async function initializeDefaultCursorStyle(
         call.args,
         STATUS_TIMEOUT_MS,
       );
+      entry.cursorSetup[call.stateKey] = 'applied';
     } catch (err) {
-      styled = false;
+      const message = err instanceof Error ? err.message : String(err);
+      if (isCursorSetupUnavailableError(message)) {
+        entry.cursorSetup[call.stateKey] = 'unavailable';
+        logger.info('cua-driver cursor setup unavailable; continuing without it', {
+          tool: name,
+          cursorTool: call.tool,
+          session,
+          error: message,
+        });
+        continue;
+      }
       logger.warn('failed to apply default cua-driver cursor style', {
         tool: name,
         cursorTool: call.tool,
         session,
-        error: err instanceof Error ? err.message : String(err),
+        error: message,
       });
     }
   }
-  entry.styled = styled;
+}
+
+/**
+ * Driver capability/policy failures cannot recover while the same MCP process
+ * remains alive. Remember them on the session entry so an optional cursor
+ * decoration never adds a rejected tool call to every real computer action.
+ */
+function isCursorSetupUnavailableError(message: string): boolean {
+  return /has no reviewed risk classification|method not found|unknown tool|tool .+ not found/i.test(message);
 }
 
 function readBooleanGrant(value: unknown): ComputerDriverPermissionGrant {

--- a/docs/design-rules/DESIGN.md
+++ b/docs/design-rules/DESIGN.md
@@ -1007,6 +1007,12 @@ The splash wordmark is a separate asset pair (`assets/splash/wordmark.png`, whit
 - **Constraints**: the white QR background is a scanner-contrast requirement, not a general brand panel. Do not add a border, edge, shadow, motion or other decoration to the code.
 - **Scope boundary**: this approval covers the current Alipay QR payment paths only. `BillingPaymentAction` currently does not carry a provider; any future non-Alipay `QR_CODE` channel must first add provider-aware rendering rather than inheriting this mark by default.
 
+**Sanctioned brand surface — Computer Use cursor (approved 2026-08-04).**
+
+- **Where**: the optional agent cursor configured by `apps/desktop/src/main/mcp-integrations/computer.ts` while Cindy Computer Use actions are running. Its arrow color and bloom use Brand red `#DF0C27`; the driver-required gradient transitions from Brand red to Deep brand red `#A61629`.
+- **Why the values are concrete**: the cursor is rendered by the out-of-process `cua-driver`, which cannot consume renderer CSS variables or the active theme registry. The fixed two-color brand palette is therefore identical in Light, Dark, and imported themes.
+- **Scope boundary**: this approval identifies Cindy's automated pointer only. It does not authorize brand red for ordinary controls, focus/caret states, buttons, or other working UI. Cursor styling remains optional; a driver capability/policy rejection degrades without blocking Computer Use and is remembered for the current MCP session.
+
 ### 15.8 status-badge-fg
 
 - The orange badge (bg `status-bar-accent` `#EA6B17`) has its own foreground token `status-badge-fg`: **default mirrors `accent-pure-cta-fg`** (light white / dark black — zero change for the 9 existing themes); **CINDY overrides both modes to `#1F1F1F`** (near-black), contrast × `#EA6B17` = **5.19:1 ≥ 4.5** (user-approved; darken toward `#000000` if a future orange fails 4.5).


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Cindy 每次 Computer Use 动作前都会重复调用已被 cua-driver 永久拒绝的默认光标样式工具、持续产生告警的问题；同时把自动控制光标调整为 Cindy 品牌红。

光标 motion / style 在每个 MCP session 内分别维护 `pending`、`applied`、`unavailable` 三态：永久 capability / policy 错误会在当前 session 熔断，临时错误仍会重试，MCP session 重建后会重新探测。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Cindy 自身 Computer Use 使用体验巡检发现的重复 `set_agent_cursor_style` 告警。
- 本 PR 包含：session 级光标初始化状态、永久错误熔断、临时错误重试、session 重建重新探测、Cindy 品牌红光标参数、回归测试与设计规范登记。
- 明确不包含：不修改 cua-driver；不修改 system prompt、translator、usage、event loop 或 Computer Use 权限边界。
- 用户可见变化：Cindy 自动控制时的可选光标由青色改为品牌红；不支持光标样式能力的 driver 不再在每次动作前重复失败和污染日志。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §15.7 “Sanctioned brand surface — Computer Use cursor”。箭头与 bloom 使用 Brand red `#DF0C27`，driver 所需渐变使用 `#DF0C27` → Deep brand red `#A61629`；例外仅限进程外渲染的自动控制光标，不扩散到普通按钮、focus、caret 等 UI。
- 截图 / 录屏：未附；尚未进行真实 cua-driver 光标视觉验证，见“未执行的验证”。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-computer-cursor-style-fallback
结果：GATE_EXIT=0，全仓 unit gate 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco
结果：1 个提交 DCO 签名检查通过。

git diff --check
结果：通过。
```

### 手工验证

不涉及：未启动真实 cua-driver 做光标视觉检查。

### 未执行的验证

- 未进行真实 Computer Use 光标视觉 QA；颜色参数与 session 行为由单元测试锁定，最终视觉仍需在支持样式工具的 cua-driver 环境确认。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Computer Use 可选光标装饰的兼容与视觉变化。

### 影响与回滚

- 影响范围：仅 Desktop main 侧对 cua-driver 默认光标 motion / style 的初始化；真实 click、type_text、screenshot 等动作参数与权限语义不变。
- 回滚 / 降级方式：回退本提交即可恢复旧行为；driver 不支持或策略拒绝样式工具时自动降级为不设置对应光标装饰，Computer Use 主动作继续执行。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
