### PR TITLE
refactor(ghost): OAuth scope 上限改读 cindy-protocol 正本

### DIFF
--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -1,3 +1,4 @@
+import { GHOST_OAUTH_SCOPES_MAX } from '@cindy/plugin-protocol';
 import { findSplitChildByPanelKind, insertRootSplitPane, type Layout } from './layoutTree';
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type SupportedLocale } from './locale';
 
@@ -605,17 +606,17 @@ export interface GhostSecretExchangeDecl {
 
 /**
  * OAuth 凭证:scopes 条数上限(超出拒装;确认框逐条展示要可读)。
- * 32→48(2026-08):原值按当时最大存量顶格(xd-feishu 老登录链全集 32 条),
- * xd-feishu 补审批/表情/导入等能力到 41 条后,上限随最大存量演进。注意本校验
- * 取值级"严出"(plugin-security-and-authoring.md §7):超 32 条的包在旧版客户端
- * 拒装,插件市场铺开须等携带本值的客户端先行发布。
+ * 数值正本在 cindy-protocol 的 plugin-protocol(manifest.ts,发布服务端同读),
+ * 客户端只 re-export 不再手抄副本;调整上限一律改协议仓再 bump submodule。
+ * 本校验取值级"严出"(plugin-security-and-authoring.md §7):超上限的包在旧版
+ * 客户端拒装,插件市场铺开须等携带新上限的客户端先行发布。
  *
  * 涨过 64 前必须同步两处只留了防御余量的 64 上限,否则会拒绝合法的缺权上报
  * /静默判废 assessment:insufficient-scopes 端点的整包条数上限
  * (runtime/ghostOauthEndpoint.ts)与 cindy-tools 的 SETUP_REAUTH_SCOPE_MAX
  * (ghost/mcpServer.ts,包依赖方向不允许直接引用本常量)。
  */
-export const GHOST_OAUTH_SCOPES_MAX = 48;
+export { GHOST_OAUTH_SCOPES_MAX };
 /** OAuth broker 模式可声明的备用 clientId 上限(默认 clientId 不计入)。 */
 export const GHOST_OAUTH_CLIENT_ID_ALTERNATIVES_MAX = 8;
 /** OAuth 凭证:extraAuthorizeParams 条数上限。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 OAuth scope 条数上限（`GHOST_OAUTH_SCOPES_MAX`）的数值来源从客户端手抄副本改为 cindy-protocol 正本：`shared/ghost.ts` 删除本地 `= 48` 定义，改为从 `@cindy/plugin-protocol` import 后 re-export，并把 cindy-protocol submodule 指针从 ff055be bump 到 f694bbf。

背景：这个上限在协议仓（`plugin-protocol/src/manifest.ts`，发布服务端同读）与客户端各有一份。#1695 把客户端副本提到 48 时协议正本仍是 32，导致 43-scope 的 xd-feishu 2.3.0 发布被 plugin server 按旧正本打回（`PLUGIN_FILE_INVALID`）。协议仓已通过 PR #31 将正本提到 48；本 PR 消灭客户端副本，让两端永远同源。

本次 bump 的 submodule 区间恰好只含协议仓 PR #31（常量 32→48 + JSDoc/文档 + 协议侧测试），零无关夹带。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求：#1695 的后续；xd-feishu 43-scope 包发布被 plugin server 拒绝暴露的正本/副本漂移
- 本 PR 包含：`shared/ghost.ts` 常量改 re-export（含注释更新）、cindy-protocol submodule bump 到 f694bbf
- 明确不包含：上限数值变化（48==48）、校验逻辑与报错文案变化、服务端改动、`forge.ts` 作者手册与接口 JSDoc 里的散文「48」（保持文字，正本注释在协议仓）
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck
结果：通过（无输出错误）

pnpm --filter desktop exec vitest run src/shared/__tests__/ghost.oauth.test.ts
结果：20/20 通过（含以 GHOST_OAUTH_SCOPES_MAX + 1 构造的超限拒装边界用例，换源后即验证协议正本取值）

pnpm test:unit（仓库根，全量）
结果：exit 0 全通过；workspace 内协议包自测（含协议仓新增的 manifest 上限测试）一并通过
```

### 手工验证

不涉及（本 PR 行为零变化）。构建面与端到端验收（desktop 构建 + dev 启动 renderer 冒烟 + 真实 43-scope 包装入）由 tester 独立执行，结果在 PR 评论补充。

### 未执行的验证

- renderer 对 `@cindy/plugin-protocol` 的首次值引用（此前仅 type-only import）在 vite 打包下的实机确认，交由 tester 验收后回填。renderer 值引用 workspace 源码直发包已有大量先例（`@cindy/maker-shared`、`@cindy/model-providers`），风险判断为低。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）

### 影响与回滚

- 影响范围：manifest 校验常量的取值来源；数值不变（48==48），校验行为与报错文案逐字不变。协议兼容：submodule bump 区间仅含协议仓 PR #31，服务端由服务端仓库同步 bump（同一常量、同一正本），两端不漂移正是本 PR 的目的。存量插件影响：无——上限只增不减，已装/已批准插件不受影响，无需重装或重新确认。
- 回滚 / 降级方式：revert 本 commit 即回到本地常量 48 + 旧 submodule 指针，行为不变。
