### PR TITLE
fix(desktop): 修复 codex 0.145.0 下 node_repl 禁用覆写导致 Codex 会话无法创建

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/capability-routing.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/capability-routing.test.ts
@@ -70,14 +70,30 @@ describe('buildDesktopCapabilityRoutingPolicy', () => {
       'chrome@openai-bundled',
     ]);
     expect(routes.every((route) => route.replacement === undefined)).toBe(true);
-    const nodeReplRoute = policy.overrides.find(
+    // The unprovisioned spawn config has no node_repl entry; a per-thread
+    // `mcp_servers.node_repl.enabled=false` on codex 0.145.0 would synthesize
+    // a transport-less entry and fail every thread/start with "invalid
+    // transport" (-32600). The route must be absent, not merely unreplaced.
+    expect(policy.overrides.some(
       (route) => route.source.surface === 'mcp' && route.source.id === 'node_repl',
-    );
-    expect(nodeReplRoute).toMatchObject({
-      invocation: 'disabled',
-      source: expect.objectContaining({ surface: 'mcp', id: 'node_repl' }),
+    )).toBe(false);
+  });
+
+  it('drops the node_repl MCP route when Cindy Browser owns the capability but the companion was not provisioned', () => {
+    const policy = buildDesktopCapabilityRoutingPolicy({
+      cindyBrowserEnabled: true,
+      codexBrowserUseAvailable: false,
     });
-    expect(nodeReplRoute?.replacement).toBeUndefined();
+
+    expect(policy.overrides.some(
+      (route) => route.source.surface === 'mcp' && route.source.id === 'node_repl',
+    )).toBe(false);
+    // The plugin-wide disable does not synthesize an mcp_servers entry and
+    // must stay in force.
+    expect(policy.overrides).toContainEqual(expect.objectContaining({
+      invocation: 'disabled',
+      source: expect.objectContaining({ surface: 'plugin', id: 'chrome@openai-bundled' }),
+    }));
   });
 
   it('keeps remote Chrome available without claiming the local Cindy Browser replacement', () => {

--- a/apps/desktop/src/main/maker-host/__tests__/capability-routing.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/capability-routing.test.ts
@@ -46,6 +46,7 @@ describe('buildDesktopCapabilityRoutingPolicy', () => {
     const routes = buildDesktopCapabilityRoutingPolicy({
       cindyBrowserEnabled: true,
       codexBrowserUseAvailable: true,
+      codexBrowserUseProvisioned: true,
     }).overrides;
 
     expect(routes).toContainEqual(expect.objectContaining({
@@ -55,10 +56,29 @@ describe('buildDesktopCapabilityRoutingPolicy', () => {
     }));
   });
 
+  it('keeps the node_repl disable when the provisioned companion fails its readiness probe', () => {
+    // Spawn supplied a full node_repl transport (provisioned), then the
+    // session-time Chrome readiness probe failed. The per-thread disable
+    // merges onto the real transport and is required — dropping it would
+    // leave the privileged node_repl surface enabled.
+    const policy = buildDesktopCapabilityRoutingPolicy({
+      cindyBrowserEnabled: false,
+      codexBrowserUseAvailable: false,
+      codexBrowserUseProvisioned: true,
+    });
+
+    const nodeReplRoute = policy.overrides.find(
+      (route) => route.source.surface === 'mcp' && route.source.id === 'node_repl',
+    );
+    expect(nodeReplRoute).toMatchObject({ invocation: 'disabled' });
+    expect(nodeReplRoute?.replacement).toBeUndefined();
+  });
+
   it('fails closed without claiming a replacement when neither browser runtime is available', () => {
     const policy = buildDesktopCapabilityRoutingPolicy({
       cindyBrowserEnabled: false,
       codexBrowserUseAvailable: false,
+      codexBrowserUseProvisioned: false,
     });
     const routes = policy.overrides.filter(
       (route) =>
@@ -83,6 +103,7 @@ describe('buildDesktopCapabilityRoutingPolicy', () => {
     const policy = buildDesktopCapabilityRoutingPolicy({
       cindyBrowserEnabled: true,
       codexBrowserUseAvailable: false,
+      codexBrowserUseProvisioned: false,
     });
 
     expect(policy.overrides.some(

--- a/apps/desktop/src/main/maker-host/__tests__/codex-browser-companion.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codex-browser-companion.test.ts
@@ -234,9 +234,79 @@ describe('prepareCodexBrowserCompanion', () => {
       status: 'unavailable',
       reason: 'platform_unsupported',
     });
+    // codex 0.145.0 rejects a config whose node_repl entry has no complete
+    // transport ("invalid transport" → child exit 1). With no runnable entry
+    // in the isolated config there is nothing to disable, so the fail-closed
+    // result must not synthesize one via `-c` overrides.
+    expect(resolveCodexBrowserCompanionSpawnConfig(companion)).toEqual({
+      codexBrowserUseAvailable: false,
+      extraArgs: [],
+    });
+  });
+
+  it('fails closed against a runnable node_repl entry in the isolated config', async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-browser-companion-'));
+    tempDirs.push(root);
+    const codexHome = path.join(root, 'cindy-codex-home');
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(codexHome, 'config.toml'),
+      [
+        '[mcp_servers.node_repl]',
+        'command = "/tmp/untrusted/node_repl"',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const companion = await prepareCodexBrowserCompanion({
+      codexHome,
+      platform: 'win32',
+      arch: 'x64',
+    });
+
+    expect(companion).toMatchObject({
+      status: 'unavailable',
+      reason: 'platform_unsupported',
+    });
     expect(resolveCodexBrowserCompanionSpawnConfig(companion)).toEqual({
       codexBrowserUseAvailable: false,
       extraArgs: ['-c', 'mcp_servers.node_repl.enabled=false'],
+    });
+  });
+
+  it('does not complete a transport-less node_repl entry into a fatal override', async () => {
+    // A `-c mcp_servers.node_repl.*` override on a transport-less entry turns
+    // codex's survivable "Invalid configuration; using defaults" degradation
+    // into a fatal config load error. Codex already refuses to run such an
+    // entry, so no override may be emitted.
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'codex-browser-companion-'));
+    tempDirs.push(root);
+    const codexHome = path.join(root, 'cindy-codex-home');
+    await fs.mkdir(codexHome, { recursive: true });
+    await fs.writeFile(
+      path.join(codexHome, 'config.toml'),
+      [
+        '[mcp_servers.node_repl.env]',
+        'NODE_OPTIONS = "--require=/tmp/untrusted.cjs"',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const companion = await prepareCodexBrowserCompanion({
+      codexHome,
+      platform: 'win32',
+      arch: 'x64',
+    });
+
+    expect(companion).toMatchObject({
+      status: 'unavailable',
+      reason: 'platform_unsupported',
+    });
+    expect(resolveCodexBrowserCompanionSpawnConfig(companion)).toEqual({
+      codexBrowserUseAvailable: false,
+      extraArgs: [],
     });
   });
 

--- a/apps/desktop/src/main/maker-host/capability-routing.ts
+++ b/apps/desktop/src/main/maker-host/capability-routing.ts
@@ -187,6 +187,28 @@ const CODEX_CHROME_USE_UNAVAILABLE_OVERRIDES = CODEX_CHROME_USE_OVERRIDES.map(
   }),
 ) satisfies CapabilityRoutingPolicy['overrides'];
 
+/**
+ * codex 0.145.0's config loader requires every `mcp_servers` entry to carry a
+ * complete transport even when disabled, and thread/start validates per-thread
+ * overrides against the same loader. The spawn config defines a node_repl
+ * entry only when the verified Browser companion was provisioned; without it,
+ * the per-thread `mcp_servers.node_repl.enabled=false` override synthesizes a
+ * transport-less entry and every thread/start fails with "invalid transport"
+ * (-32600). Emit the node_repl MCP route only when the entry exists — when it
+ * does not, the capability is already absent and fail-closed holds without
+ * the directive.
+ */
+function withoutUnprovisionedNodeReplRoute(
+  overrides: readonly CapabilityRouteOverride[],
+  codexBrowserUseAvailable: boolean | undefined,
+): CapabilityRouteOverride[] {
+  if (codexBrowserUseAvailable === true) return [...overrides];
+  return overrides.filter(
+    (override) =>
+      !(override.source.surface === 'mcp' && override.source.id === 'node_repl'),
+  );
+}
+
 /** Freeze workspace-scoped capability arbitration for one new runtime. */
 export function buildDesktopCapabilityRoutingPolicy(opts: {
   /** Whether the current Codex bridge exposes Cindy's Computer Use host. */
@@ -208,9 +230,15 @@ export function buildDesktopCapabilityRoutingPolicy(opts: {
   const chromeOverrides = cindyBrowserEnabled === undefined
     ? []
     : cindyBrowserEnabled
-    ? CODEX_CHROME_USE_OVERRIDES
+    ? withoutUnprovisionedNodeReplRoute(
+        CODEX_CHROME_USE_OVERRIDES,
+        opts.codexBrowserUseAvailable,
+      )
     : opts.codexBrowserUseAvailable === false
-      ? CODEX_CHROME_USE_UNAVAILABLE_OVERRIDES
+      ? withoutUnprovisionedNodeReplRoute(
+          CODEX_CHROME_USE_UNAVAILABLE_OVERRIDES,
+          opts.codexBrowserUseAvailable,
+        )
       : [];
   return {
     overrides: [

--- a/apps/desktop/src/main/maker-host/capability-routing.ts
+++ b/apps/desktop/src/main/maker-host/capability-routing.ts
@@ -194,15 +194,20 @@ const CODEX_CHROME_USE_UNAVAILABLE_OVERRIDES = CODEX_CHROME_USE_OVERRIDES.map(
  * entry only when the verified Browser companion was provisioned; without it,
  * the per-thread `mcp_servers.node_repl.enabled=false` override synthesizes a
  * transport-less entry and every thread/start fails with "invalid transport"
- * (-32600). Emit the node_repl MCP route only when the entry exists — when it
- * does not, the capability is already absent and fail-closed holds without
- * the directive.
+ * (-32600). Emit the node_repl MCP route only when the spawn transport exists
+ * — when it does not, the capability is already absent and fail-closed holds
+ * without the directive.
+ *
+ * The gate is spawn-time provisioning, NOT session-time availability: a
+ * provisioned companion whose Chrome readiness probe failed still has the
+ * full node_repl transport in its spawn config, so the disable both merges
+ * cleanly and is required to keep the privileged surface off.
  */
 function withoutUnprovisionedNodeReplRoute(
   overrides: readonly CapabilityRouteOverride[],
-  codexBrowserUseAvailable: boolean | undefined,
+  codexBrowserUseProvisioned: boolean | undefined,
 ): CapabilityRouteOverride[] {
-  if (codexBrowserUseAvailable === true) return [...overrides];
+  if (codexBrowserUseProvisioned === true) return [...overrides];
   return overrides.filter(
     (override) =>
       !(override.source.surface === 'mcp' && override.source.id === 'node_repl'),
@@ -215,7 +220,14 @@ export function buildDesktopCapabilityRoutingPolicy(opts: {
   cindyComputerAvailable?: boolean;
   /** Workspace-scoped Cindy Browser ownership snapshot. */
   cindyBrowserEnabled?: boolean;
+  /** Session-time snapshot: companion provisioned AND Chrome currently ready. */
   codexBrowserUseAvailable?: boolean;
+  /**
+   * Spawn-time snapshot: the verified companion supplied a full node_repl
+   * transport to this app-server. Gates the mcp node_repl route (a per-thread
+   * disable is only valid — and only needed — when the entry exists).
+   */
+  codexBrowserUseProvisioned?: boolean;
   /** Remote Codex cannot invoke the local Cindy Browser plugin bridge. */
   remoteHostId?: string | null;
 }): CapabilityRoutingPolicy {
@@ -232,12 +244,12 @@ export function buildDesktopCapabilityRoutingPolicy(opts: {
     : cindyBrowserEnabled
     ? withoutUnprovisionedNodeReplRoute(
         CODEX_CHROME_USE_OVERRIDES,
-        opts.codexBrowserUseAvailable,
+        opts.codexBrowserUseProvisioned,
       )
     : opts.codexBrowserUseAvailable === false
       ? withoutUnprovisionedNodeReplRoute(
           CODEX_CHROME_USE_UNAVAILABLE_OVERRIDES,
-          opts.codexBrowserUseAvailable,
+          opts.codexBrowserUseProvisioned,
         )
       : [];
   return {

--- a/apps/desktop/src/main/maker-host/codex-browser-companion.ts
+++ b/apps/desktop/src/main/maker-host/codex-browser-companion.ts
@@ -45,7 +45,8 @@ export type CodexBrowserCompanionResult =
     }
   | {
       status: 'unavailable';
-      extraArgs: [];
+      /** Fail-closed spawn overrides prepared for this result (may be empty). */
+      extraArgs: string[];
       reason: CodexBrowserCompanionUnavailableReason;
       detail: string;
     };
@@ -58,7 +59,8 @@ export type CodexBrowserCompanionSpawnConfig = {
 /**
  * Only a verified companion may enable Cindy's privileged node_repl bridge.
  * A null result belongs to the control-plane host and must remain neutral;
- * every concrete unavailable result fails closed for the local app-server.
+ * every concrete unavailable result fails closed for the local app-server
+ * (its extraArgs carry the disable override when one is applicable).
  */
 export function resolveCodexBrowserCompanionSpawnConfig(
   companion: CodexBrowserCompanionResult | null,
@@ -66,12 +68,9 @@ export function resolveCodexBrowserCompanionSpawnConfig(
   if (companion === null) {
     return { codexBrowserUseAvailable: false, extraArgs: [] };
   }
-  if (companion.status === 'ready') {
-    return { codexBrowserUseAvailable: true, extraArgs: companion.extraArgs };
-  }
   return {
-    codexBrowserUseAvailable: false,
-    extraArgs: ['-c', 'mcp_servers.node_repl.enabled=false'],
+    codexBrowserUseAvailable: companion.status === 'ready',
+    extraArgs: companion.extraArgs,
   };
 }
 
@@ -593,17 +592,55 @@ async function inspectCodexBrowserCompanion(
   };
 }
 
+/**
+ * Codex 0.145.0's config loader requires every `mcp_servers` entry to carry a
+ * complete transport even when disabled: a bare
+ * `-c mcp_servers.node_repl.enabled=false` on a config whose node_repl entry
+ * is missing (or transport-less) synthesizes/completes an invalid entry and
+ * kills the app-server at spawn ("invalid transport", child exit 1; verified
+ * against codex-cli 0.145.0). Only emit the fail-closed disable when the
+ * isolated config defines the entry with a real transport — the override then
+ * deep-merges onto that transport, which the loader accepts. In every other
+ * case codex itself refuses to load a runnable node_repl from that config
+ * (absent entry, or "Invalid configuration; using defaults"), so fail-closed
+ * already holds without an override.
+ */
+async function nodeReplFailClosedOverrideArgs(codexHome: string): Promise<string[]> {
+  try {
+    const parsed = parseToml(
+      await fsp.readFile(path.join(codexHome, 'config.toml'), 'utf8'),
+    ) as Record<string, unknown>;
+    const mcpServers = isRecord(parsed.mcp_servers) ? parsed.mcp_servers : {};
+    const nodeRepl = mcpServers.node_repl;
+    if (
+      isRecord(nodeRepl)
+      && (typeof nodeRepl.command === 'string' || typeof nodeRepl.url === 'string')
+    ) {
+      return ['-c', 'mcp_servers.node_repl.enabled=false'];
+    }
+  } catch {
+    // Missing or unparseable isolated config: codex cannot load a node_repl
+    // entry from it either, so there is nothing to fail closed against.
+  }
+  return [];
+}
+
 export async function prepareCodexBrowserCompanion(
   opts: PrepareCodexBrowserCompanionOptions,
 ): Promise<CodexBrowserCompanionResult> {
+  let result: CodexBrowserCompanionResult;
   try {
-    return await inspectCodexBrowserCompanion(opts);
+    result = await inspectCodexBrowserCompanion(opts);
   } catch (error) {
-    return unavailable(
+    result = unavailable(
       'descriptor_invalid',
       `browser companion preflight failed: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
+  if (result.status === 'unavailable') {
+    return { ...result, extraArgs: await nodeReplFailClosedOverrideArgs(opts.codexHome) };
+  }
+  return result;
 }
 
 /**

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -1021,6 +1021,7 @@ export function getMaker(): Maker {
             getActiveCodexBridgeServerNames()?.includes('cindy_computer') === true,
           cindyBrowserEnabled,
           codexBrowserUseAvailable: connectedCodexBrowserUse,
+          codexBrowserUseProvisioned,
           remoteHostId,
         });
       },


### PR DESCRIPTION
## 这次改了什么

### 摘要

#1706 引入的 Codex Browser 能力仲裁在两个层面向 codex 下发孤立的 `mcp_servers.node_repl.enabled=false` 覆写。codex 0.145.0 的 config loader 要求每个 `mcp_servers` 条目必须带完整 transport(`command` 或 `url`),即使被禁用也一样;当配置里本没有 node_repl 条目时(companion 不可用的所有机器:全部 Windows,以及未装/未验证签名 ChatGPT.app 的 macOS),这条覆写会凭空造出一个无 transport 的条目,导致:

1. **spawn 层**:app-server 子进程启动即 `invalid transport` 退出(exit 1),UI 报 `LAZY_CREATE_FAILED: child exited (exit code=1)`;
2. **thread/start 层**:capability routing 的 per-thread 覆写触发同一校验,报 `-32600: failed to load configuration: invalid transport`。

两层都命中时,受影响机器上**所有本地 Codex 会话完全无法创建**。

修复原则:**只在覆写能 deep-merge 到真实存在的 transport 上时才下发禁用**;条目不存在时 codex 本来就加载不出 node_repl,fail-closed 语义天然成立,无需覆写。

- `codex-browser-companion.ts`(spawn 层):companion unavailable 时改为读取 isolated `codex-home/config.toml`,仅当其中定义了带 `command`/`url` 的 `node_repl` 条目才发 `-c mcp_servers.node_repl.enabled=false`;无 transport 的条目(如仅 `.env` 段)也不发——codex 对这类条目自身降级为 "Invalid configuration; using defaults" 且不加载它,而任何指向该条目的 `-c` 覆写会把可存活降级变成致命错误。
- `capability-routing.ts`(thread 层):仅当 `codexBrowserUseAvailable === true`(spawn 确实配置了 node_repl 条目,即 companion ready)时才保留 `surface: 'mcp', id: 'node_repl'` 路由;plugin 级禁用(`chrome@openai-bundled` 等)不涉及 transport 校验,原样保留。

companion ready 路径(macOS + 已签名 ChatGPT.app)的 extraArgs 拼装与 thread 禁用行为均未改变:spawn 定义了完整条目,thread 层 `enabled=false` merge 合法且仍然生效,#1706 的能力仲裁目标保持不变。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(#1706 合入当日的回归,Windows dev 与 macOS 0.1.29 canary 实测复现)
- 本 PR 包含:codex node_repl 禁用覆写的条件化(spawn 层 + thread 层)及对应单测
- 明确不包含:companion ready 路径的行为变更;codex 二进制版本变更
- 用户可见变化:受影响机器上 Codex agent 恢复可用(修复前所有本地 Codex 会话创建失败)
- 是否存在 breaking change:无

### UI 变化

不涉及。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__
结果:99 文件 / 1401 通过、1 skipped(win32 跳过 darwin 探测用例)

pnpm --filter desktop typecheck
结果:通过

pnpm test:unit(仓库根全量)
结果:通过(提交前门禁,详见提交说明)
```

新增/更新用例:
- `codex-browser-companion.test.ts`:unavailable + 无条目 → 不发覆写;有 transport 条目 → 发禁用;env-only 无 transport 条目 → 不发(避免把 codex 的可存活降级变成致命)
- `capability-routing.test.ts`:双浏览器运行时均不可用 → mcp node_repl 路由必须缺席;Cindy Browser 启用但 companion 未 provision → 丢弃 mcp 路由、保留 plugin 级禁用

### 手工验证

- Windows 11 dev(cn + isolated 沙箱)实机:修复前 spawn 层 `LAZY_CREATE_FAILED: child exited (exit code=1)`、修复 spawn 层后 thread/start `-32600 invalid transport` 均稳定复现;两处修复后 Codex 会话正常创建并完成对话。
- 用 codex-cli 0.145.0 二进制直接复现/验证了四种配置形态:无条目 + 裸 enabled=false(致命)、无条目不发覆写(正常)、command/url 条目 + enabled=false(正常且禁用)、env-only 条目 + 任意 node_repl 覆写(致命)/不发覆写(降级存活)。

### 未执行的验证

- macOS 实机未验证:无 ChatGPT.app 场景与 Windows 完全同代码路径(darwin 分支在单测中以 platform: 'darwin' + stub 签名校验覆盖);companion ready 场景(装有已签名 ChatGPT.app)代码路径未改动,但需要 mac 实机做 codesign 实调回归,建议合入前抽验:分别在 Cindy Browser 开/关状态下发 codex 消息确认能力仲裁不回退。
- `checkCodexBrowserCompanionConnection` 的 Chrome 探测用例在 Windows 上 skip(用例本身即 skipIf win32)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 codex agent 的 spawn extraArgs 与 per-thread capability 覆写生成;不触及 system prompt、prompt 前缀稳定性、其它 agent。fail-closed 语义保持:node_repl 条目存在则仍被禁用,不存在则本来就不可用。
- 回滚 / 降级方式:revert 本 PR 即回到 #1706 行为(注意 revert 会重新引入本回归)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因