### PR TITLE
fix(im): 将 Discord 私聊归入对话分组

### DIFF
--- a/apps/desktop/src/main/im/discord/__tests__/discordAdapter.test.ts
+++ b/apps/desktop/src/main/im/discord/__tests__/discordAdapter.test.ts
@@ -45,6 +45,7 @@ describe('discord ImChannelAdapter characterization', () => {
   it('channel / source are discord and the adapter is not thread scoped', () => {
     expect(adapter.channel).toBe('discord');
     expect(adapter.sessions.source).toBe('discord');
+    expect(adapter.sessions.workspaceKind).toBe('dialogue');
     expect(adapter.threadScoped).toBeUndefined();
   });
 

--- a/apps/desktop/src/main/im/discord/adapter.ts
+++ b/apps/desktop/src/main/im/discord/adapter.ts
@@ -35,6 +35,10 @@ export function buildDiscordAdapter(
       sessionIdFor: (appId, userId) => `discord_${appId}_${userId}`,
       defaultTitle: (userId) => `Discord · ${userId.slice(-6)}`,
       generatedTitlePrefix: 'Discord · ',
+      // Discord personal DMs use Cindy-managed working directories just like
+      // Feishu/Telegram DMs. Keep them in the global "dialogue" bucket instead
+      // of making `discord-{appId}` look like a user project.
+      workspaceKind: 'dialogue',
       ensureWorkingDir,
       extraInsertColumns: (appId, userId) => ({
         imBotContextId: appId,

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -287,6 +287,20 @@ async function initializeImConnection(): Promise<void> {
     const msg = err instanceof Error ? err.message : String(err);
     log.warn(`feishu sessions workspaceKind backfill failed (non-fatal): ${msg}`);
   }
+  // Discord personal DM sessions use the same managed dialogue bucket as
+  // Feishu/Telegram. Older Discord rows were created before the adapter
+  // declared workspaceKind='dialogue' and otherwise remain grouped under the
+  // synthetic `discord-{appId}` working directory. Idempotent and deliberately
+  // does not bump updatedAt, so the migration does not reorder the sidebar.
+  try {
+    await getDbClient()
+      .drizzle.update(sessions)
+      .set({ workspaceKind: 'dialogue' })
+      .where(and(eq(sessions.source, 'discord'), ne(sessions.workspaceKind, 'dialogue')));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(`discord sessions workspaceKind backfill failed (non-fatal): ${msg}`);
+  }
   // 存量 feishu 会话的旧默认标题 `飞书 · {后6位}` 迁到新风格 `[飞书·DM] {后6位}`。
   try {
     await getDbClient()


### PR DESCRIPTION
## 这次改了什么

### 摘要

Discord 个人私聊 session 现在沿用飞书/Telegram 的 `workspaceKind: 'dialogue'` 语义，避免把 Cindy 托管的 `discord-{appId}` 工作目录显示成项目文件夹。启动时会幂等修复已有 Discord session。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Discord 个人 IM 私聊不应按托管工作目录形成假项目分组。
- 本 PR 包含：Discord adapter 新会话归入 dialogue；启动期回填存量 Discord session；adapter 回归断言。
- 明确不包含：侧栏 source 白名单调整；IM bot ownership binding WIP；真正隐藏 session 的产品策略。
- 用户可见变化：Discord 私聊不再出现在 `discord-...` 项目文件夹下，而与飞书/Telegram 一样进入「对话」分组。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及 UI 代码或视觉组件；仅复用现有 `workspaceKind='dialogue'` 分组契约。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec eslint src/main/im/discord/adapter.ts src/main/im/index.ts src/main/im/discord/__tests__/discordAdapter.test.ts
结果：通过

pnpm --dir apps/desktop typecheck
结果：通过

pnpm --dir apps/desktop exec vitest run src/main/im/discord/__tests__/discordAdapter.test.ts src/main/im/shared/__tests__/sessionRepoRevive.test.ts
结果：2 个文件、16 个用例全部通过

git diff --check
结果：通过
```

### 手工验证

不涉及真实 Discord 账号操作；通过 adapter 契约和 session repo 回归测试验证。

### 未执行的验证

未执行完整桌面打包和真实 Discord 登录验证，因为本 PR 只改变 session 分组元数据和启动期回填逻辑。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅修改 `sessions.source='discord'` 且 `workspaceKind!='dialogue'` 的存量行；不更新 `updatedAt`，不改变其他渠道或会话内容。
- 回滚 / 降级方式：回滚该 commit；新 Discord session 会恢复默认 project 归组，已回填行可由后续数据修复重新调整。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
