### PR TITLE
fix(desktop): show provider-specific model name in selector

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -509,6 +509,183 @@ describe('ModelSelector trigger variants', () => {
     });
   };
 
+  it('uses the selected provider model name when duplicate model ids have source-specific names', () => {
+    const modelId = 'deepseek/deepseek-v4-pro';
+    const originalModels = visibleModelsRef.models;
+    const originalProviders = providersRef.providers;
+
+    // 拍平后的模型名称来自第一个来源，复现 issue #1644 的关键前提。
+    visibleModelsRef.models = [
+      {
+        id: modelId,
+        displayName: '火山 DeepSeek-V4-Pro',
+        contextWindow: 1048576,
+        efforts: [],
+        defaultEffort: null,
+      },
+    ];
+    providersRef.providers = [
+      {
+        id: 'volcengine-ark',
+        name: 'Volcengine Ark',
+        connected: true,
+        agents: ['claude-code'],
+        routing: { 'claude-code': {} },
+        models: {
+          'claude-code': [
+            {
+              id: modelId,
+              name: '火山 DeepSeek-V4-Pro',
+              contextWindow: 1048576,
+              efforts: [],
+              defaultEffort: null,
+            },
+          ],
+        },
+      },
+      {
+        id: 'cindy-gateway',
+        name: 'Cindy Gateway',
+        connected: true,
+        agents: ['claude-code'],
+        routing: { 'claude-code': {} },
+        models: {
+          'claude-code': [
+            {
+              id: modelId,
+              name: 'Cindy DeepSeek-V4-Pro',
+              contextWindow: 1048576,
+              efforts: [],
+              defaultEffort: null,
+            },
+          ],
+        },
+      },
+    ];
+
+    const props = {
+      modelId,
+      effort: 'medium' as Effort,
+      onModelChange: vi.fn(),
+      onEffortChange: vi.fn(),
+      vendorKey: 'cc' as const,
+      currentProviderId: 'volcengine-ark',
+    };
+    const view = render(React.createElement(ModelSelector, props));
+
+    try {
+      let trigger = screen.getByRole('button', {
+        name: 'Select model. Current: 火山 DeepSeek-V4-Pro',
+      });
+      expect(trigger.textContent).toContain('火山 DeepSeek-V4-Pro');
+      expect(trigger.getAttribute('aria-label')).toBe(
+        'Select model. Current: 火山 DeepSeek-V4-Pro',
+      );
+
+      view.rerender(
+        React.createElement(ModelSelector, {
+          ...props,
+          currentProviderId: 'cindy-gateway',
+        }),
+      );
+
+      trigger = screen.getByRole('button', {
+        name: 'Select model. Current: Cindy DeepSeek-V4-Pro',
+      });
+      expect(trigger.textContent).toContain('Cindy DeepSeek-V4-Pro');
+      expect(trigger.textContent).not.toContain('火山 DeepSeek-V4-Pro');
+      expect(trigger.getAttribute('aria-label')).toBe(
+        'Select model. Current: Cindy DeepSeek-V4-Pro',
+      );
+    } finally {
+      view.unmount();
+      visibleModelsRef.models = originalModels;
+      providersRef.providers = originalProviders;
+    }
+  });
+
+  it('keeps remote status labels when the provider catalog arrives before visible models', () => {
+    const modelId = 'deepseek/deepseek-v4-pro';
+    const providerModelName = 'Remote catalog DeepSeek-V4-Pro';
+    const originalCapabilities = agentCapabilitiesRef.capabilities;
+    const originalCapabilitiesLoading = agentCapabilitiesRef.loading;
+    const originalCapabilitiesError = agentCapabilitiesRef.error;
+    const originalModels = visibleModelsRef.models;
+    const originalDeviceProviders = deviceProvidersRef.providers;
+    const originalProvidersLoading = deviceProvidersRef.loading;
+    const originalProvidersError = deviceProvidersRef.error;
+
+    // provider 目录可能先于远程 capability/visibleModels 到达。
+    deviceProvidersRef.providers = [
+      {
+        id: 'remote-ark',
+        name: 'Remote Ark',
+        connected: true,
+        agents: ['claude-code'],
+        routing: { 'claude-code': {} },
+        models: {
+          'claude-code': [
+            {
+              id: modelId,
+              name: providerModelName,
+              contextWindow: 1048576,
+              efforts: [],
+              defaultEffort: null,
+            },
+          ],
+        },
+      },
+    ];
+    deviceProvidersRef.loading = false;
+    deviceProvidersRef.error = null;
+    visibleModelsRef.models = [];
+    agentCapabilitiesRef.capabilities = null;
+    agentCapabilitiesRef.loading = true;
+    agentCapabilitiesRef.error = null;
+
+    const props = {
+      modelId,
+      effort: 'medium' as Effort,
+      onModelChange: vi.fn(),
+      onEffortChange: vi.fn(),
+      vendorKey: 'cc' as const,
+      deviceId: 'dev-a',
+      currentProviderId: 'remote-ark',
+    };
+    const view = render(React.createElement(ModelSelector, props));
+
+    try {
+      let trigger = screen.getByRole('button', {
+        name: 'Select model. Current: 正在从远程设备读取模型…',
+      });
+      expect(trigger.textContent).toContain('正在从远程设备读取模型…');
+      expect(trigger.textContent).not.toContain(providerModelName);
+      expect(trigger.getAttribute('aria-label')).toBe(
+        'Select model. Current: 正在从远程设备读取模型…',
+      );
+
+      agentCapabilitiesRef.loading = false;
+      agentCapabilitiesRef.error = 'offline';
+      view.rerender(React.createElement(ModelSelector, props));
+
+      trigger = screen.getByRole('button', {
+        name: 'Select model. Current: 模型读取失败',
+      });
+      expect(trigger.textContent).toContain('模型读取失败');
+      expect(trigger.textContent).not.toContain(providerModelName);
+      expect(trigger.getAttribute('aria-label')).toBe('Select model. Current: 模型读取失败');
+    } finally {
+      view.unmount();
+      agentCapabilitiesRef.capabilities = originalCapabilities;
+      agentCapabilitiesRef.loading = originalCapabilitiesLoading;
+      agentCapabilitiesRef.error = originalCapabilitiesError;
+      visibleModelsRef.models = originalModels;
+      deviceProvidersRef.providers = originalDeviceProviders;
+      deviceProvidersRef.loading = originalProvidersLoading;
+      deviceProvidersRef.error = originalProvidersError;
+    }
+  });
+
   it('remote loading replaces the placeholder and no-results empty state', async () => {
     const originalCapabilities = agentCapabilitiesRef.capabilities;
     const originalModels = visibleModelsRef.models;

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -2121,38 +2121,6 @@ export function ModelSelector({
   // 给出诊断性文案(通常是裸 id),行为与本组件接管前一致。
   // unknown label 空串/全空白按缺省处理(否则 ?? 不回落,trigger 渲染成空白)。
   const unknownLabel = modelId && unknownModelLabel ? unknownModelLabel(modelId).trim() : '';
-  const displayLabel = fallbackOption?.active
-    ? fallbackOption.label
-    : (currentModel?.displayName ??
-      (remoteModelLoading ? t('newChat.modelSelector.remoteLoading') : null) ??
-      (remoteModelLoadFailed ? t('newChat.modelSelector.remoteLoadFailedShort') : null) ??
-      (unknownLabel !== '' ? unknownLabel : null) ??
-      t('newChat.modelSelector.trigger.placeholder'));
-  const agentName =
-    agentIdentity && !fallbackOption?.active
-      ? agentIdentity.vendorKey === 'cc'
-        ? t('newChat.modelSelector.trigger.agent.claudeCode')
-        : agentIdentity.vendorKey === 'pi'
-          ? t('newChat.modelSelector.trigger.agent.pi')
-          : t('newChat.modelSelector.trigger.agent.codex')
-      : null;
-  const agentIdentityLabel =
-    agentName && agentIdentity?.state === 'pending'
-      ? t('newChat.modelSelector.trigger.agent.pending', { agent: agentName })
-      : agentName;
-  const baseDisplayIdentityLabel = agentIdentityLabel
-    ? `${agentIdentityLabel} · ${displayLabel}`
-    : displayLabel;
-  const remoteStatusLabel = currentModel
-    ? remoteModelLoading
-      ? t('newChat.modelSelector.remoteLoading')
-      : remoteModelLoadFailed
-        ? t('newChat.modelSelector.remoteLoadFailedShort')
-        : null
-    : null;
-  const displayIdentityLabel = remoteStatusLabel
-    ? `${baseDisplayIdentityLabel} · ${remoteStatusLabel}`
-    : baseDisplayIdentityLabel;
   const efforts = currentModel?.efforts ?? [];
 
   const currentAgentKind: AgentKind | null = useMemo(() => {
@@ -2216,12 +2184,13 @@ export function ModelSelector({
   const triggerActiveProvider = activeSourceId
     ? providers.find((p) => p.id === activeSourceId)
     : undefined;
+  const triggerActiveModel =
+    triggerActiveProvider && currentAgentKind
+      ? getModel(triggerActiveProvider, modelId, currentAgentKind)
+      : undefined;
   // trigger 图标的统一规则:当前 (来源, 模型) 条目的 icon(AI Gateway / 目录设定)优先,
   // 缺省回落来源供应商标 —— 与列表行、手机版同一套口径(ModelIconMark)。
-  const triggerModelIcon =
-    triggerActiveProvider && currentAgentKind
-      ? getModel(triggerActiveProvider, modelId, currentAgentKind)?.icon
-      : undefined;
+  const triggerModelIcon = triggerActiveModel?.icon;
   const disconnectedProvider = currentProviderId
     ? providers.find((p) => p.id === currentProviderId)
     : undefined;
@@ -2237,6 +2206,44 @@ export function ModelSelector({
   // 断开态仅在「非 noSource」时生效:全部来源都断开时 noSource CTA 优先(下拉已无可选行,
   // 跳设置才是正确恢复路径);还有别的已连接来源时,下拉换源就是恢复路径,trigger 保持可点。
   const showSourceDisconnected = !noSource && sourceDisconnected && !!currentProviderId;
+
+  // 仅在普通可用态用当前生效来源的名称。currentModel gate 保证远程列表尚未就绪时
+  // 不会拿 provider 缓存提前覆盖 loading/error;断开态继续沿用既有拍平名称 / modelId 语义。
+  const sourceSpecificModelName =
+    currentModel && !showSourceDisconnected ? triggerActiveModel?.name : undefined;
+  const displayLabel = fallbackOption?.active
+    ? fallbackOption.label
+    : (sourceSpecificModelName ??
+      currentModel?.displayName ??
+      (remoteModelLoading ? t('newChat.modelSelector.remoteLoading') : null) ??
+      (remoteModelLoadFailed ? t('newChat.modelSelector.remoteLoadFailedShort') : null) ??
+      (unknownLabel !== '' ? unknownLabel : null) ??
+      t('newChat.modelSelector.trigger.placeholder'));
+  const agentName =
+    agentIdentity && !fallbackOption?.active
+      ? agentIdentity.vendorKey === 'cc'
+        ? t('newChat.modelSelector.trigger.agent.claudeCode')
+        : agentIdentity.vendorKey === 'pi'
+          ? t('newChat.modelSelector.trigger.agent.pi')
+          : t('newChat.modelSelector.trigger.agent.codex')
+      : null;
+  const agentIdentityLabel =
+    agentName && agentIdentity?.state === 'pending'
+      ? t('newChat.modelSelector.trigger.agent.pending', { agent: agentName })
+      : agentName;
+  const baseDisplayIdentityLabel = agentIdentityLabel
+    ? `${agentIdentityLabel} · ${displayLabel}`
+    : displayLabel;
+  const remoteStatusLabel = currentModel
+    ? remoteModelLoading
+      ? t('newChat.modelSelector.remoteLoading')
+      : remoteModelLoadFailed
+        ? t('newChat.modelSelector.remoteLoadFailedShort')
+        : null
+    : null;
+  const displayIdentityLabel = remoteStatusLabel
+    ? `${baseDisplayIdentityLabel} · ${remoteStatusLabel}`
+    : baseDisplayIdentityLabel;
   const baseAriaLabel = noSource
     ? t('newChat.modelSelector.source.connect')
     : showSourceDisconnected


### PR DESCRIPTION
## 这次改了什么

### 摘要

Fix the collapsed desktop model selector showing the wrong provider-specific label when multiple providers expose the same `modelId`.

The flattened `visibleModels` list keeps the first display name for a duplicate ID. The trigger now resolves its label from the active provider catalog entry when safe, while preserving existing fallback, disconnected, remote-loading/error, unknown-model, and placeholder behavior.

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Fixes #1644
- 本 PR 包含：provider-aware trigger label/icon resolution and regressions for duplicate IDs and remote catalog loading order.
- 明确不包含：model routing changes, provider configuration changes, or catalog schema changes.
- 用户可见变化：after switching providers, the collapsed selector identifies the provider/model that is actually selected.
- 是否存在 breaking change：无。

### UI 变化

- The existing trigger layout and interaction are unchanged; only the resolved model label/icon source is corrected.
- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Select & Dropdown — the trigger continues to show the selected value, now resolved from the active provider entry；§10 Light / Dark — no geometry, color, token, asset, or styling changes.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test -- src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：50/50 passed

pnpm --filter desktop typecheck
结果：passed

pnpm test:unit
结果：all runnable workspaces passed

pnpm exec prettier --check apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：passed

pnpm --filter desktop exec eslint src/renderer/components/new-chat/ModelSelector.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：passed

pnpm check:dco
结果：1 signed-off commit passed
```

### 手工验证

未执行：the real end-to-end reproduction requires both an official DeepSeek source and a Volcengine Ark Agent Plan source. The reported provider-switch behavior is covered by the focused component regression.

### 未执行的验证

- No credential-backed end-to-end provider test, for the reason above.
- No visual screenshot/recording; the change does not alter layout or styling.

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：desktop collapsed `ModelSelector` label, icon lookup, and accessible name only.
- 回滚 / 降级方式：revert commit `0182a5c61edcfd4456618ce6cc42ca748ec12131`.
- The guards retain remote loading/error, disconnected-source, fallback, unknown-model, and placeholder semantics.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认本次不需要额外文档变更
- [x] 已确认测试结果并说明未执行的验证

<!-- ci: retrigger pr-design-basis after concurrency cancellation 2026-08-10 -->