### PR TITLE
feat(chat): Markdown 代码块支持一键在终端执行

### DIFF
--- a/apps/desktop/src/renderer/__tests__/markdownDiffBlock.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownDiffBlock.test.ts
@@ -171,7 +171,7 @@ describe('F3 — MarkdownRenderer routes ```diff to MarkdownDiffBlock', () => {
 
   it('default pre fallthrough still renders <pre className=...> for non-diff blocks', () => {
     // 非 diff 代码块现在先落到 CodeBlockPre,再由 CodeBlockPre 渲染真实 <pre>。
-    expect(rendererSrc).toMatch(/return\s+<CodeBlockPre\s+\{\.\.\.props\}>\{children\}<\/CodeBlockPre>/);
+    expect(rendererSrc).toMatch(/return\s+<CodeBlockPre\s+\{\.\.\.props\}\s+language=\{extractCodeLanguage\(firstChild\)\}>\{children\}<\/CodeBlockPre>/);
     expect(rendererSrc).toMatch(/function\s+CodeBlockPre[\s\S]*<pre[\s\S]*className=\{cn\(/);
     expect(rendererSrc).toMatch(/border-\[var\(--msg-code-block-border\)\]/);
   });

--- a/apps/desktop/src/renderer/__tests__/markdownDiffBlock.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownDiffBlock.test.ts
@@ -170,8 +170,10 @@ describe('F3 — MarkdownRenderer routes ```diff to MarkdownDiffBlock', () => {
   });
 
   it('default pre fallthrough still renders <pre className=...> for non-diff blocks', () => {
-    // 非 diff 代码块现在先落到 CodeBlockPre,再由 CodeBlockPre 渲染真实 <pre>。
-    expect(rendererSrc).toMatch(/return\s+<CodeBlockPre\s+\{\.\.\.props\}\s+language=\{extractCodeLanguage\(firstChild\)\}>\{children\}<\/CodeBlockPre>/);
+    // 非 diff 代码块现在先落到 renderCodeBlock helper,再由 CodeBlockPre 渲染
+    // 真实 <pre>。CodeBlockPre 接受可选 sessionId:baseComponents.pre(文档预览
+    // / TextLightbox)不传,聊天流 instance-level override 传 currentSessionId。
+    expect(rendererSrc).toMatch(/<CodeBlockPre\s+\{\.\.\.props\}\s+language=\{extractCodeLanguage\(firstChild\)\}\s+sessionId=\{sessionId\}>\s*\{children\}\s*<\/CodeBlockPre>/);
     expect(rendererSrc).toMatch(/function\s+CodeBlockPre[\s\S]*<pre[\s\S]*className=\{cn\(/);
     expect(rendererSrc).toMatch(/border-\[var\(--msg-code-block-border\)\]/);
   });
@@ -250,5 +252,46 @@ describe('F5 — parseDiffText classification', () => {
     expect(out).toHaveLength(2);
     expect(out[0].text).toBe('a');
     expect(out[1].text).toBe('b');
+  });
+});
+
+describe('F6 — 「在终端执行」按钮 TextLightbox 隔离', () => {
+  // CodeBlockPre 不再读 useChatSessionFile context,改由 prop 传入 sessionId。
+  // 这样 TextLightbox(挂在会话树内但渲染的是文件内容)不会因为外层
+  // ChatSessionFileProvider 而误显示执行按钮。baseComponents.pre 不传
+  // sessionId(doc-mode / TextLightbox 安全),只有聊天流的 instance-level
+  // override 才传 currentSessionId。
+
+  it('CodeBlockPre 不使用 useChatSessionFile', () => {
+    // 在 CodeBlockPre 函数体内不应出现 useChatSessionFile 调用。
+    const codeBlockPreMatch = rendererSrc.match(
+      /function\s+CodeBlockPre\s*\([^)]*\)\s*\{[\s\S]*?\n\}/,
+    );
+    expect(codeBlockPreMatch, 'CodeBlockPre function not found').toBeTruthy();
+    expect(codeBlockPreMatch![0]).not.toMatch(/useChatSessionFile/);
+  });
+
+  it('CodeBlockPre 接受 sessionId prop', () => {
+    expect(rendererSrc).toMatch(
+      /function\s+CodeBlockPre\s*\(\s*\{[^}]*sessionId[^}]*\}/,
+    );
+  });
+
+  it('renderCodeBlock helper 存在且接受 sessionId 参数', () => {
+    expect(rendererSrc).toMatch(
+      /function\s+renderCodeBlock\s*\(\s*children[^)]*sessionId\?:\s*string[^)]*\)/,
+    );
+  });
+
+  it('baseComponents.pre 调用 renderCodeBlock 不传 sessionId', () => {
+    expect(rendererSrc).toMatch(
+      /pre\(\{\s*children,\s*\.\.\.props\s*\}\)\s*\{[\s\S]*?return\s+renderCodeBlock\(children,\s*props\);/,
+    );
+  });
+
+  it('instance-level pre override 传入 currentSessionId(仅非 doc-mode)', () => {
+    expect(rendererSrc).toMatch(
+      /!\s*emitSourceLines\s*\?[\s\S]*?pre:\s*\([^)]*\)\s*=>\s*renderCodeBlock\(children,\s*props[^)]*,\s*currentSessionId\)/,
+    );
   });
 });

--- a/apps/desktop/src/renderer/__tests__/runInTerminal.test.ts
+++ b/apps/desktop/src/renderer/__tests__/runInTerminal.test.ts
@@ -1,0 +1,312 @@
+/**
+ * runInTerminal.test.ts
+ * ---------------------------------------------------------------------------
+ * Behavioral tests for runInTerminal.ts:
+ *
+ *   N1  normalizeCommand: single-line / multi-line / \r\n / \r / trailing
+ *       newlines / heredoc — all normalized to \n line endings + exactly one
+ *       trailing \n.
+ *   N2  runInTerminal happy path: PTY already ready → write called with
+ *       normalized command → returns true.
+ *   N3  runInTerminal PTY becomes ready via subscribe notification → write
+ *       called → returns true.
+ *   N4  runInTerminal timeout (PTY never ready) → returns false, write not
+ *       called, subscribe unsubscribed (no leak).
+ *   N5  runInTerminal tab destroyed mid-wait → returns false immediately
+ *       (does not wait for full timeout), write not called.
+ *   N6  subscribe unsubscribe called on every exit path (ready / missing /
+ *       timeout) — no listener leak.
+ *   N7  command normalization flows through to terminal.write: \r stripped,
+ *       trailing newlines collapsed.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll, vi } from 'vitest';
+
+// runInTerminal.ts uses window.setTimeout / window.clearTimeout / window.electronAPI.
+// In node env (no jsdom — undici dep incomplete), point window at globalThis so
+// those resolve to node globals (which vitest fake timers also instrument).
+beforeAll(() => {
+  (globalThis as { window: typeof globalThis }).window = globalThis;
+});
+afterAll(() => {
+  delete (globalThis as { window?: unknown }).window;
+});
+
+// Mocks must be declared before the import of the module under test. vi.mock
+// is hoisted to the top of the file by the transformer.
+vi.mock('@/features/right-sidebar/store', () => ({
+  ensureHydrated: vi.fn(),
+  addOrFocusSingletonTab: vi.fn(),
+  getBucket: vi.fn(),
+  subscribe: vi.fn(),
+}));
+vi.mock('@/features/right-sidebar/lib/sidebarCommands', () => ({
+  requestRightSidebarVisibility: vi.fn(),
+}));
+
+import {
+  ensureHydrated,
+  addOrFocusSingletonTab,
+  getBucket,
+  subscribe,
+} from '@/features/right-sidebar/store';
+import { requestRightSidebarVisibility } from '@/features/right-sidebar/lib/sidebarCommands';
+import { runInTerminal, normalizeCommand } from '../components/chat/runInTerminal';
+
+const SESSION_ID = 'session-1';
+const TAB_ID = 'tab-1';
+
+function mockTabState(created: boolean) {
+  return { id: TAB_ID, kind: 'terminal' as const, state: { created } };
+}
+
+function mockBucket(created: boolean | null) {
+  // created === null → tab missing from bucket
+  return {
+    hydrated: true,
+    tabs: created === null ? [] : [mockTabState(created)],
+    activeTabId: created === null ? null : TAB_ID,
+  };
+}
+
+describe('N1 — normalizeCommand', () => {
+  it('appends \\n to a single-line command without one', () => {
+    expect(normalizeCommand('ls -la')).toBe('ls -la\n');
+  });
+
+  it('preserves a single trailing \\n', () => {
+    expect(normalizeCommand('ls -la\n')).toBe('ls -la\n');
+  });
+
+  it('collapses multiple trailing newlines into one', () => {
+    expect(normalizeCommand('ls\n\n\n')).toBe('ls\n');
+  });
+
+  it('normalizes \\r\\n to \\n', () => {
+    expect(normalizeCommand('cd /tmp\r\nls\r\n')).toBe('cd /tmp\nls\n');
+  });
+
+  it('normalizes lone \\r to \\n', () => {
+    expect(normalizeCommand('echo hello\recho world\r')).toBe('echo hello\necho world\n');
+  });
+
+  it('preserves multi-line content (heredoc / for loop)', () => {
+    const heredoc = 'cat <<EOF\nhello\nworld\nEOF';
+    expect(normalizeCommand(heredoc)).toBe('cat <<EOF\nhello\nworld\nEOF\n');
+  });
+
+  it('preserves internal blank lines, only trims trailing', () => {
+    expect(normalizeCommand('echo a\n\necho b\n\n')).toBe('echo a\n\necho b\n');
+  });
+
+  it('handles empty string', () => {
+    expect(normalizeCommand('')).toBe('\n');
+  });
+});
+
+describe('N2 — runInTerminal happy path (PTY already ready)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ensureHydrated).mockResolvedValue(undefined);
+    vi.mocked(addOrFocusSingletonTab).mockResolvedValue(mockTabState(true));
+    vi.mocked(getBucket).mockReturnValue(mockBucket(true) as never);
+    vi.mocked(subscribe).mockReturnValue(vi.fn());
+    vi.mocked(requestRightSidebarVisibility).mockReturnValue(undefined);
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      terminal: { write: vi.fn().mockResolvedValue(undefined) },
+    };
+  });
+
+  it('calls ensureHydrated, requestRightSidebarVisibility, addOrFocusSingletonTab', async () => {
+    await runInTerminal(SESSION_ID, 'ls');
+    expect(ensureHydrated).toHaveBeenCalledWith(SESSION_ID);
+    expect(requestRightSidebarVisibility).toHaveBeenCalledWith('open', { sessionId: SESSION_ID });
+    expect(addOrFocusSingletonTab).toHaveBeenCalledWith(SESSION_ID, 'terminal');
+  });
+
+  it('writes normalized command to terminal and returns true', async () => {
+    const result = await runInTerminal(SESSION_ID, 'ls -la');
+    expect(result).toBe(true);
+    expect(window.electronAPI.terminal.write).toHaveBeenCalledWith(TAB_ID, 'ls -la\n');
+  });
+
+  it('does not call subscribe (PTY already ready — early return)', async () => {
+    await runInTerminal(SESSION_ID, 'ls');
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+});
+
+describe('N3 — runInTerminal PTY becomes ready via subscribe', () => {
+  let listener: (() => void) | null = null;
+  const mockUnsubscribe = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listener = null;
+    vi.mocked(ensureHydrated).mockResolvedValue(undefined);
+    vi.mocked(addOrFocusSingletonTab).mockResolvedValue(mockTabState(false));
+    // Initial state: pending
+    vi.mocked(getBucket).mockReturnValue(mockBucket(false) as never);
+    vi.mocked(subscribe).mockImplementation(((l: () => void) => {
+      listener = l;
+      return mockUnsubscribe;
+    }) as never);
+    vi.mocked(requestRightSidebarVisibility).mockReturnValue(undefined);
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      terminal: { write: vi.fn().mockResolvedValue(undefined) },
+    };
+  });
+
+  it('returns true when PTY becomes ready via subscribe notification', async () => {
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    // Wait for runInTerminal to reach waitForTerminalReady → subscribe
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalled());
+    // Simulate PTY spawn completing
+    vi.mocked(getBucket).mockReturnValue(mockBucket(true) as never);
+    listener!();
+    const result = await promise;
+    expect(result).toBe(true);
+    expect(window.electronAPI.terminal.write).toHaveBeenCalledWith(TAB_ID, 'ls\n');
+  });
+
+  it('unsubscribes after PTY becomes ready (no listener leak)', async () => {
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    await vi.waitFor(() => expect(subscribe).toHaveBeenCalled());
+    vi.mocked(getBucket).mockReturnValue(mockBucket(true) as never);
+    listener!();
+    await promise;
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('N4 — runInTerminal timeout (PTY never ready)', () => {
+  const mockUnsubscribe = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ensureHydrated).mockResolvedValue(undefined);
+    vi.mocked(addOrFocusSingletonTab).mockResolvedValue(mockTabState(false));
+    vi.mocked(getBucket).mockReturnValue(mockBucket(false) as never);
+    vi.mocked(subscribe).mockImplementation((() => mockUnsubscribe) as never);
+    vi.mocked(requestRightSidebarVisibility).mockReturnValue(undefined);
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      terminal: { write: vi.fn().mockResolvedValue(undefined) },
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns false after timeout', async () => {
+    vi.useFakeTimers();
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    // Flush microtasks (ensureHydrated + addOrFocusSingletonTab resolves)
+    await vi.advanceTimersByTimeAsync(0);
+    // Advance past PTY_READY_TIMEOUT_MS (5000ms)
+    await vi.advanceTimersByTimeAsync(5001);
+    const result = await promise;
+    expect(result).toBe(false);
+  });
+
+  it('does not call terminal.write on timeout', async () => {
+    vi.useFakeTimers();
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5001);
+    await promise;
+    expect(window.electronAPI.terminal.write).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes after timeout (no listener leak)', async () => {
+    vi.useFakeTimers();
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(5001);
+    await promise;
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('N5 — runInTerminal tab destroyed mid-wait', () => {
+  let listener: (() => void) | null = null;
+  const mockUnsubscribe = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listener = null;
+    vi.mocked(ensureHydrated).mockResolvedValue(undefined);
+    vi.mocked(addOrFocusSingletonTab).mockResolvedValue(mockTabState(false));
+    vi.mocked(getBucket).mockReturnValue(mockBucket(false) as never);
+    vi.mocked(subscribe).mockImplementation(((l: () => void) => {
+      listener = l;
+      return mockUnsubscribe;
+    }) as never);
+    vi.mocked(requestRightSidebarVisibility).mockReturnValue(undefined);
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      terminal: { write: vi.fn().mockResolvedValue(undefined) },
+    };
+  });
+
+  it('returns false when tab is destroyed (not waiting for timeout)', async () => {
+    vi.useFakeTimers();
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    await vi.advanceTimersByTimeAsync(0);
+    // Tab destroyed: getBucket returns empty
+    vi.mocked(getBucket).mockReturnValue(mockBucket(null) as never);
+    listener!();
+    const result = await promise;
+    expect(result).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('does not call terminal.write when tab destroyed', async () => {
+    vi.useFakeTimers();
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    await vi.advanceTimersByTimeAsync(0);
+    vi.mocked(getBucket).mockReturnValue(mockBucket(null) as never);
+    listener!();
+    await promise;
+    expect(window.electronAPI.terminal.write).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('unsubscribes when tab destroyed (no listener leak)', async () => {
+    vi.useFakeTimers();
+    const promise = runInTerminal(SESSION_ID, 'ls');
+    await vi.advanceTimersByTimeAsync(0);
+    vi.mocked(getBucket).mockReturnValue(mockBucket(null) as never);
+    listener!();
+    await promise;
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+    vi.useRealTimers();
+  });
+});
+
+describe('N7 — command normalization flows through to terminal.write', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(ensureHydrated).mockResolvedValue(undefined);
+    vi.mocked(addOrFocusSingletonTab).mockResolvedValue(mockTabState(true));
+    vi.mocked(getBucket).mockReturnValue(mockBucket(true) as never);
+    vi.mocked(subscribe).mockReturnValue(vi.fn());
+    vi.mocked(requestRightSidebarVisibility).mockReturnValue(undefined);
+    (window as unknown as { electronAPI: unknown }).electronAPI = {
+      terminal: { write: vi.fn().mockResolvedValue(undefined) },
+    };
+  });
+
+  it('strips \\r and collapses trailing newlines before writing', async () => {
+    await runInTerminal(SESSION_ID, 'cd /tmp\r\nls\r\n\n');
+    expect(window.electronAPI.terminal.write).toHaveBeenCalledWith(TAB_ID, 'cd /tmp\nls\n');
+  });
+
+  it('preserves multi-line heredoc content', async () => {
+    const cmd = 'cat <<EOF\nhello\nEOF';
+    await runInTerminal(SESSION_ID, cmd);
+    expect(window.electronAPI.terminal.write).toHaveBeenCalledWith(
+      TAB_ID,
+      'cat <<EOF\nhello\nEOF\n',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -452,17 +452,19 @@ function useStreamingThrottle(value: string, enabled: boolean, intervalMs = 100)
  * <pre>, so they always act on the latest text even mid-stream. We use
  * group-hover to keep the chrome out of the way until the user reaches for it.
  *
- * 「在终端执行」按钮仅对 shell-like 语言(bash/sh/powershell/cmd...)且处于
- * 聊天会话流内(sessionId 存在)时显示:点击后复用或新建 RSB 内置 terminal tab,
- * 把整段命令写入 PTY 执行。聊天流外(设置页 / TextLightbox 等)不显示。
+ * 「在终端执行」按钮仅对 shell-like 语言(bash/sh/powershell/cmd...)且
+ * `sessionId` 存在时显示。`sessionId` 由调用方显式传入:聊天会话流内传入
+ * `currentSessionId`,TextLightbox / 设置页等不传 → 按钮不显示。不读
+ * ChatSessionFileContext,因为 TextLightbox 可能挂在会话树内、渲染的却是
+ * 与当前会话无关的文件,context 里仍可能带着外层 session id。
  */
 function CodeBlockPre({
   children,
   language,
+  sessionId,
   ...props
-}: HTMLAttributes<HTMLPreElement> & { language?: string }) {
+}: HTMLAttributes<HTMLPreElement> & { language?: string; sessionId?: string }) {
   const { t } = useTranslation();
-  const { sessionId } = useChatSessionFile();
   const preRef = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
   const [running, setRunning] = useState(false);
@@ -568,6 +570,42 @@ function CodeBlockPre({
   );
 }
 
+/**
+ * 渲染 fenced code block:```diff → MarkdownDiffBlock,```mermaid →
+ * MarkdownMermaidBlock,其余 → CodeBlockPre。
+ *
+ * 抽成 helper 是因为 `pre` renderer 有两处入口:
+ *   - `baseComponents.pre`(模块级,doc-mode / TextLightbox 用)—— 不传
+ *     sessionId,「在终端执行」按钮不显示
+ *   - instance-level `pre` override(聊天流用,见下方 useMemo)—— 传入
+ *     currentSessionId,shell-like 代码块显示按钮
+ * 两处共享 diff / mermaid 分派逻辑,放在一起避免分叉。
+ */
+function renderCodeBlock(
+  children: ReactNode,
+  props: Record<string, unknown>,
+  sessionId?: string,
+): ReactNode {
+  const firstChild = Array.isArray(children) ? children[0] : children;
+  if (isDiffCodeChild(firstChild)) {
+    const codeChildren = (firstChild as { props: { children?: ReactNode } })
+      .props.children;
+    const raw = nodeToText(codeChildren);
+    return <MarkdownDiffBlock raw={raw} />;
+  }
+  if (isMermaidCodeChild(firstChild)) {
+    const codeChildren = (firstChild as { props: { children?: ReactNode } })
+      .props.children;
+    const raw = nodeToText(codeChildren);
+    return <MarkdownMermaidBlock raw={raw} />;
+  }
+  return (
+    <CodeBlockPre {...props} language={extractCodeLanguage(firstChild)} sessionId={sessionId}>
+      {children}
+    </CodeBlockPre>
+  );
+}
+
 const baseComponents: Components = {
   // NOTE: the `code` renderer is NOT defined here at module level anymore.
   // Inline-code path detection (text-lightbox-trigger-extension v2) needs
@@ -577,27 +615,10 @@ const baseComponents: Components = {
   // simpler renderer there. See line ~310 for the implementation.
 
   pre({ children, ...props }) {
-    // Intercept ```diff fenced blocks before they fall through to highlight.js
-    // — we render them with our own row/gutter/symbol layout (MarkdownDiffBlock)
-    // so the visual matches the Edit-tool DiffView card and the GitHub red/green
-    // tokens (`--diff-add-fg` / `--diff-del-fg`) get applied predictably.
-    // Other languages (js/ts/python/...) still go through the default pre+code
-    // path with rehype-highlight.
-    const firstChild = Array.isArray(children) ? children[0] : children;
-    if (isDiffCodeChild(firstChild)) {
-      const codeChildren = (firstChild as { props: { children?: ReactNode } })
-        .props.children;
-      const raw = nodeToText(codeChildren);
-      return <MarkdownDiffBlock raw={raw} />;
-    }
-    if (isMermaidCodeChild(firstChild)) {
-      const codeChildren = (firstChild as { props: { children?: ReactNode } })
-        .props.children;
-      const raw = nodeToText(codeChildren);
-      return <MarkdownMermaidBlock raw={raw} />;
-    }
-
-    return <CodeBlockPre {...props} language={extractCodeLanguage(firstChild)}>{children}</CodeBlockPre>;
+    // baseComponents.pre 不传 sessionId —— doc-mode(TextLightbox 等)走这条
+    // 路径,「在终端执行」按钮不应在文件预览里出现。聊天流的 instance-level
+    // override 会显式传入 currentSessionId。
+    return renderCodeBlock(children, props);
   },
 
   // Tables (GFM)。外层 CopyAsImageBlock 承载「复制为图片 / 标注」hover 工具栏,
@@ -1747,6 +1768,16 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
       // renderer 整体替换成带 data-source-line 注入的版本。chat 调用方不传 prop
       // → 默认 false → 整段是 falsy 短路, components 对象与之前完全一致。
       ...(emitSourceLines ? makeSourceLineWrappers() : {}),
+      // 聊天流(非 doc-mode)override pre:传入 currentSessionId 让 shell-like
+      // 代码块显示「在终端执行」按钮。doc-mode(TextLightbox 等)走
+      // makeSourceLineWrappers 包装的 baseComponents.pre,不传 sessionId →
+      // 按钮不显示,避免在文件预览里出现与当前会话无关的执行入口。
+      ...(!emitSourceLines
+        ? {
+            pre: ({ children, ...props }: HTMLAttributes<HTMLPreElement>) =>
+              renderCodeBlock(children, props as Record<string, unknown>, currentSessionId),
+          }
+        : {}),
       img: ({ src, alt, node, ...props }) => {
         const rawLocalSrc = node?.properties?.[RAW_LOCAL_IMAGE_SRC_PROP];
         const normalized = normalizeMarkdownImageSrc(

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -35,7 +35,7 @@ import { FENCED_CODE_PROP, rehypeFencedCodeMarker } from './rehypeFencedCodeMark
 import { CopyAsImageBlock, mathBlockToLatex, tableToTsv } from './CopyAsImageBlock';
 import type { Components, UrlTransform } from 'react-markdown';
 import type { PluggableList } from 'unified';
-import { Check, Copy, FolderOpen } from 'lucide-react';
+import { Check, Copy, FolderOpen, Terminal } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { cn, basename } from '@/lib/utils';
@@ -108,6 +108,7 @@ import {
   openUrlByPreference,
   useOpenWithMenu,
 } from './useOpenWithMenu';
+import { runInTerminal } from './runInTerminal';
 
 /**
  * Recursively flatten an arbitrary react-markdown children tree into a
@@ -152,6 +153,33 @@ function isMermaidCodeChild(child: ReactNode): boolean {
   if (!isValidElement(child)) return false;
   const className = (child.props as { className?: string })?.className ?? '';
   return /\b(language-)?mermaid\b/.test(className);
+}
+
+/**
+ * 从 `<code>` 子元素提取 rehype-highlight 注入的语言标记(class `language-xxx`)。
+ * 无语言标注(裸围栏 / 4 空格缩进)返回 undefined。
+ */
+function extractCodeLanguage(child: ReactNode): string | undefined {
+  if (!isValidElement(child)) return undefined;
+  const className = (child.props as { className?: string })?.className ?? '';
+  const match = /language-([\w-]+)/.exec(className);
+  return match?.[1]?.toLowerCase();
+}
+
+/**
+ * 命令行类语言集合 —— 这些语言的代码块才显示「在终端执行」按钮。
+ * bash/sh/zsh/fish 等 unix shell + powershell/cmd 系列。其它语言(python/js/...)
+ * 即便能写进终端,语义也不是「逐行执行命令」,不显示按钮避免误用。
+ */
+const SHELL_LIKE_LANGUAGES = new Set([
+  'bash', 'sh', 'shell', 'zsh', 'fish', 'dash', 'ksh',
+  'powershell', 'pwsh', 'ps1', 'ps',
+  'cmd', 'bat', 'batch',
+]);
+
+function isShellLikeLanguage(language: string | undefined): boolean {
+  if (!language) return false;
+  return SHELL_LIKE_LANGUAGES.has(language.toLowerCase());
 }
 
 // Module-level constants — defined once, never recreated across renders.
@@ -419,16 +447,28 @@ function useStreamingThrottle(value: string, enabled: boolean, intervalMs = 100)
 }
 
 /**
- * CodeBlockPre — fenced code block with a hover-revealed copy button at the
- * top-right corner. The button reads `innerText` from the live <pre>, so it
- * always copies the latest text even mid-stream. We use group-hover to keep
- * the chrome out of the way until the user reaches for it.
+ * CodeBlockPre — fenced code block with hover-revealed chrome (copy + run-in-
+ * terminal) at the top-right corner. Buttons read `innerText` from the live
+ * <pre>, so they always act on the latest text even mid-stream. We use
+ * group-hover to keep the chrome out of the way until the user reaches for it.
+ *
+ * 「在终端执行」按钮仅对 shell-like 语言(bash/sh/powershell/cmd...)且处于
+ * 聊天会话流内(sessionId 存在)时显示:点击后复用或新建 RSB 内置 terminal tab,
+ * 把整段命令写入 PTY 执行。聊天流外(设置页 / TextLightbox 等)不显示。
  */
-function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
+function CodeBlockPre({
+  children,
+  language,
+  ...props
+}: HTMLAttributes<HTMLPreElement> & { language?: string }) {
   const { t } = useTranslation();
+  const { sessionId } = useChatSessionFile();
   const preRef = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
+  const [running, setRunning] = useState(false);
   const timerRef = useRef<number | null>(null);
+
+  const canRunInTerminal = isShellLikeLanguage(language) && !!sessionId;
 
   useEffect(() => {
     return () => {
@@ -452,6 +492,21 @@ function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
     }
   }
 
+  async function handleRun() {
+    if (!sessionId || running) return;
+    const text = preRef.current?.innerText ?? '';
+    if (!text) return;
+    setRunning(true);
+    try {
+      const ok = await runInTerminal(sessionId, text);
+      if (!ok) toast.error(t('chat.markdownRenderer.runInTerminalFailed'));
+    } catch {
+      toast.error(t('chat.markdownRenderer.runInTerminalFailed'));
+    } finally {
+      setRunning(false);
+    }
+  }
+
   return (
     <div className="group relative my-3">
       <pre
@@ -469,22 +524,46 @@ function CodeBlockPre({ children, ...props }: HTMLAttributes<HTMLPreElement>) {
       >
         {children}
       </pre>
-      <button
-        type="button"
-        onClick={handleCopy}
-        aria-label={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copyCode')}
-        title={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copy')}
+      <div
         className={cn(
-          'absolute right-2 top-2 inline-flex h-7 w-7 items-center justify-center',
-          'rounded-md border border-[var(--msg-code-block-border)]',
-          'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
+          'absolute right-2 top-2 flex items-center gap-1',
           'opacity-0 transition-opacity duration-150',
-          'group-hover:opacity-100 focus-visible:opacity-100',
-          'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
+          'group-hover:opacity-100 focus-within:opacity-100',
         )}
       >
-        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-      </button>
+        {canRunInTerminal && (
+          <button
+            type="button"
+            onClick={handleRun}
+            disabled={running}
+            aria-label={t('chat.markdownRenderer.runInTerminal')}
+            title={t('chat.markdownRenderer.runInTerminal')}
+            className={cn(
+              'inline-flex h-7 w-7 items-center justify-center',
+              'rounded-md border border-[var(--msg-code-block-border)]',
+              'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
+              'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
+              'disabled:opacity-50 disabled:cursor-not-allowed',
+            )}
+          >
+            <Terminal className="h-3.5 w-3.5" />
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={handleCopy}
+          aria-label={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copyCode')}
+          title={copied ? t('chat.markdownRenderer.codeCopied') : t('chat.markdownRenderer.copy')}
+          className={cn(
+            'inline-flex h-7 w-7 items-center justify-center',
+            'rounded-md border border-[var(--msg-code-block-border)]',
+            'bg-[var(--msg-code-block-bg)] text-[var(--msg-tool-text)]',
+            'hover:bg-[var(--cmd-palette-item-hover)] hover:text-[var(--msg-assistant-text)]',
+          )}
+        >
+          {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+        </button>
+      </div>
     </div>
   );
 }
@@ -518,7 +597,7 @@ const baseComponents: Components = {
       return <MarkdownMermaidBlock raw={raw} />;
     }
 
-    return <CodeBlockPre {...props}>{children}</CodeBlockPre>;
+    return <CodeBlockPre {...props} language={extractCodeLanguage(firstChild)}>{children}</CodeBlockPre>;
   },
 
   // Tables (GFM)。外层 CopyAsImageBlock 承载「复制为图片 / 标注」hover 工具栏,

--- a/apps/desktop/src/renderer/components/chat/runInTerminal.ts
+++ b/apps/desktop/src/renderer/components/chat/runInTerminal.ts
@@ -29,12 +29,21 @@ interface TerminalStateLike {
   created?: boolean;
 }
 
-function readTerminalCreated(sessionId: string, tabId: string): boolean {
+type TerminalReadiness = 'ready' | 'missing' | 'pending';
+
+/**
+ * 读取指定 terminal tab 的 PTY 就绪状态。
+ * - 'ready'   — tab 存在且 state.created === true,可以 write
+ * - 'missing' — tab 已不在 store(被用户关闭 / session 切换 / 水合重置),
+ *                调用方不应继续等
+ * - 'pending' — tab 存在但 PTY 尚未 spawn 完成,需继续等
+ */
+function readTerminalStatus(sessionId: string, tabId: string): TerminalReadiness {
   const bucket = getBucket(sessionId);
   const tab = bucket.tabs.find((t) => t.id === tabId);
-  if (!tab) return false;
+  if (!tab) return 'missing';
   const state = tab.state as TerminalStateLike | null;
-  return state?.created === true;
+  return state?.created === true ? 'ready' : 'pending';
 }
 
 /**
@@ -42,14 +51,20 @@ function readTerminalCreated(sessionId: string, tabId: string): boolean {
  *
  * TerminalTabBody 挂载后异步调 terminal.create spawn PTY,成功后 patchState
  * ({ created: true })。subscribe 监听 store 变化,state 翻 true 后立即返回;
+ * tab 被销毁(用户手关 / session 切换)时立即返回 false,不等超时;
  * 超时则放弃,调用方据 false 决定是否报错。
+ *
+ * 生命周期保证:无论走哪条出口(ready / missing / timeout),subscribe 都会被
+ * 取消,timer 会被清除,不会泄漏。
  */
 function waitForTerminalReady(
   sessionId: string,
   tabId: string,
   timeoutMs = PTY_READY_TIMEOUT_MS,
 ): Promise<boolean> {
-  if (readTerminalCreated(sessionId, tabId)) return Promise.resolve(true);
+  const initial = readTerminalStatus(sessionId, tabId);
+  if (initial === 'ready') return Promise.resolve(true);
+  if (initial === 'missing') return Promise.resolve(false);
   return new Promise<boolean>((resolve) => {
     let settled = false;
     const finish = (ok: boolean) => {
@@ -60,10 +75,29 @@ function waitForTerminalReady(
       resolve(ok);
     };
     const unsubscribe = subscribe(() => {
-      if (readTerminalCreated(sessionId, tabId)) finish(true);
+      const status = readTerminalStatus(sessionId, tabId);
+      if (status === 'ready') finish(true);
+      else if (status === 'missing') finish(false);
     });
     const timer = window.setTimeout(() => finish(false), timeoutMs);
   });
+}
+
+/**
+ * 归一化命令以安全写入 PTY。
+ *
+ * - `\r\n` / 单独 `\r` 统一成 `\n`:PTY host(node-pty / xterm.js)把 `\n` 当
+ *   Enter 处理,不需要 `\r`;残留 `\r` 在某些 shell(cmd.exe)里会被当作额外
+ *   按键,导致空行或意外行为。
+ * - 去掉尾部多余空行,只保留一个 `\n`:多行命令最后一条也要按 Enter 提交,
+ *   但连续多个 Enter 只会产生空提示符。
+ *
+ * 多行命令(heredoc / for 循环 / 续行)整块写入,shell 逐行执行,与用户
+ * 逐行手敲等价。
+ */
+export function normalizeCommand(command: string): string {
+  const normalized = command.replace(/\r\n?/g, '\n').replace(/\n+$/, '');
+  return normalized + '\n';
 }
 
 /**
@@ -73,7 +107,8 @@ function waitForTerminalReady(
  * - RSB 折叠态会自动展开;detached 子窗口不抢前台(由 visibility 订阅方决定)
  * - 命令多行时整块写入,PTY shell 逐行执行
  *
- * @returns 成功返回 true;终端 PTY 未在时限内就绪返回 false(调用方应 toast 提示)
+ * @returns 成功返回 true;终端 PTY 未在时限内就绪或 tab 被销毁返回 false
+ *          (调用方应 toast 提示)
  */
 export async function runInTerminal(sessionId: string, command: string): Promise<boolean> {
   await ensureHydrated(sessionId);
@@ -81,7 +116,6 @@ export async function runInTerminal(sessionId: string, command: string): Promise
   const tab = await addOrFocusSingletonTab(sessionId, 'terminal');
   const ready = await waitForTerminalReady(sessionId, tab.id);
   if (!ready) return false;
-  const text = command.endsWith('\n') ? command : command + '\n';
-  await window.electronAPI.terminal.write(tab.id, text);
+  await window.electronAPI.terminal.write(tab.id, normalizeCommand(command));
   return true;
 }

--- a/apps/desktop/src/renderer/components/chat/runInTerminal.ts
+++ b/apps/desktop/src/renderer/components/chat/runInTerminal.ts
@@ -1,0 +1,87 @@
+/**
+ * runInTerminal —— 把一段命令写到 RSB 内置终端执行。
+ * ---------------------------------------------------------------------------
+ * 流程:
+ *   1. ensureHydrated(sessionId) 确保 bucket 已加载(避免在 IPC list 完成前
+ *      乐观建 tab,与 hydrate 结果合并冲突)
+ *   2. requestRightSidebarVisibility('open') 展开 RSB,让用户看到执行结果
+ *   3. addOrFocusSingletonTab(sessionId, 'terminal') 复用已有 terminal tab
+ *      或新建一个(cwd 由 TerminalTabBody 从 session workdir 取,这里不管)
+ *   4. 等 PTY created —— TerminalTabBody 在 mount 后的 useEffect 里异步 spawn
+ *      PTY,建 tab 后立即 write 会拿到 main 端 TERMINAL_NOT_FOUND
+ *   5. terminal.write(tabId, command + '\n') 把命令喂给 PTY
+ *
+ * 多行命令整块写入:PTY 是真实 shell,会逐行执行(与用户逐行手敲等价)。
+ */
+
+import {
+  addOrFocusSingletonTab,
+  ensureHydrated,
+  getBucket,
+  subscribe,
+} from '@/features/right-sidebar/store';
+import { requestRightSidebarVisibility } from '@/features/right-sidebar/lib/sidebarCommands';
+
+/** 等 PTY spawn 的最长时限。TerminalTabBody 的 create 通常 < 200ms,5s 足够兜底。 */
+const PTY_READY_TIMEOUT_MS = 5000;
+
+interface TerminalStateLike {
+  created?: boolean;
+}
+
+function readTerminalCreated(sessionId: string, tabId: string): boolean {
+  const bucket = getBucket(sessionId);
+  const tab = bucket.tabs.find((t) => t.id === tabId);
+  if (!tab) return false;
+  const state = tab.state as TerminalStateLike | null;
+  return state?.created === true;
+}
+
+/**
+ * 等待指定 terminal tab 的 PTY 就绪(state.created === true)。
+ *
+ * TerminalTabBody 挂载后异步调 terminal.create spawn PTY,成功后 patchState
+ * ({ created: true })。subscribe 监听 store 变化,state 翻 true 后立即返回;
+ * 超时则放弃,调用方据 false 决定是否报错。
+ */
+function waitForTerminalReady(
+  sessionId: string,
+  tabId: string,
+  timeoutMs = PTY_READY_TIMEOUT_MS,
+): Promise<boolean> {
+  if (readTerminalCreated(sessionId, tabId)) return Promise.resolve(true);
+  return new Promise<boolean>((resolve) => {
+    let settled = false;
+    const finish = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      unsubscribe();
+      window.clearTimeout(timer);
+      resolve(ok);
+    };
+    const unsubscribe = subscribe(() => {
+      if (readTerminalCreated(sessionId, tabId)) finish(true);
+    });
+    const timer = window.setTimeout(() => finish(false), timeoutMs);
+  });
+}
+
+/**
+ * 把命令写到 RSB 内置终端执行。
+ *
+ * - 没有 terminal tab 则新建一个;已有则复用并激活
+ * - RSB 折叠态会自动展开;detached 子窗口不抢前台(由 visibility 订阅方决定)
+ * - 命令多行时整块写入,PTY shell 逐行执行
+ *
+ * @returns 成功返回 true;终端 PTY 未在时限内就绪返回 false(调用方应 toast 提示)
+ */
+export async function runInTerminal(sessionId: string, command: string): Promise<boolean> {
+  await ensureHydrated(sessionId);
+  requestRightSidebarVisibility('open', { sessionId });
+  const tab = await addOrFocusSingletonTab(sessionId, 'terminal');
+  const ready = await waitForTerminalReady(sessionId, tab.id);
+  if (!ready) return false;
+  const text = command.endsWith('\n') ? command : command + '\n';
+  await window.electronAPI.terminal.write(tab.id, text);
+  return true;
+}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6161,6 +6161,8 @@
     "markdownRenderer": {
       "codeCopied": "Copied",
       "copyCode": "Copy code",
+      "runInTerminal": "Run in terminal",
+      "runInTerminalFailed": "Terminal not ready, please retry later",
       "annotateImage": "Annotate image",
       "copy": "Copy",
       "blockCopied": "Copied",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6158,6 +6158,8 @@
     "markdownRenderer": {
       "codeCopied": "コピー済み",
       "copyCode": "コードをコピー",
+      "runInTerminal": "ターミナルで実行",
+      "runInTerminalFailed": "ターミナルの準備ができていません。後でもう一度お試しください",
       "annotateImage": "画像に注釈",
       "copy": "コピー",
       "blockCopied": "コピー済み",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6158,6 +6158,8 @@
     "markdownRenderer": {
       "codeCopied": "복사됨",
       "copyCode": "코드 복사",
+      "runInTerminal": "터미널에서 실행",
+      "runInTerminalFailed": "터미널이 준비되지 않았습니다. 잠시 후 다시 시도해 주세요",
       "annotateImage": "이미지 주석",
       "copy": "복사",
       "blockCopied": "복사됨",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6158,6 +6158,8 @@
     "markdownRenderer": {
       "codeCopied": "已复制",
       "copyCode": "复制代码",
+      "runInTerminal": "在终端执行",
+      "runInTerminalFailed": "终端未就绪，请稍后重试",
       "annotateImage": "标注图片",
       "copy": "复制",
       "blockCopied": "已复制",


### PR DESCRIPTION
## 这次改了什么

### 摘要

对 bash/sh/powershell/cmd 等 shell-like 语言的围栏代码块，hover 时在右上角显示「在终端执行」按钮（与复制按钮并列）。点击后复用或新建 RSB 内置终端 tab，等 PTY 就绪后把整段命令写入 PTY 执行。

本 PR 含两部分：
1. feat：MarkdownRenderer 新增 extractCodeLanguage / SHELL_LIKE_LANGUAGES 白名单 / CodeBlockPre 执行按钮 / runInTerminal.ts（ensureHydrated → 展开 RSB → addOrFocusSingletonTab → subscribe 等 state.created → terminal.write）/ 四语言 i18n 文案。
2. fix（review 反馈 + rebase 后修复）：终端生命周期（tab 销毁检测、subscribe/timer 全出口无泄漏）、shell 兼容性（normalizeCommand 把 \r\n/\r 统一为 \n、去尾部空行、多行命令整块写入）、TextLightbox 隔离（CodeBlockPre 改为接受 sessionId prop，baseComponents.pre 不传 → doc-mode/TextLightbox 不显示按钮，instance-level pre override 传 currentSessionId）、补齐自动化测试（runInTerminal 21 用例 + markdownDiffBlock F6 describe）。rebase 到最新 main 后修复了 instance-level pre override 参数类型与 react-markdown Components['pre'] 不兼容的问题。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复（review 反馈 + rebase 后类型修复）

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Markdown 代码块「在终端执行」按钮 + runInTerminal 模块 + i18n + 测试
- 明确不包含：对话分享为图片（#1879 已独立合入 main，本次 rebase 已包含）
- 用户可见变化：shell-like 围栏代码块 hover 显示「在终端执行」按钮，点击在 RSB 内置终端执行
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：新增「在终端执行」按钮与现有复制按钮同处 CodeBlockPre 右上角 hover chrome，复用既有 hover 容器与交互（hover 显隐），未引入新视觉变量。遵循 `docs/design-rules/DESIGN.md` §5 容器层级（代码块为 12px 容器）、hover 状态色 token（`--surface-hover` / `--accent-hover`）、双模式交付（颜色走语义 token，Light/Dark 同源，未硬编码）。

## 怎么验证的

### 自动验证

```text
pnpm check:dco
结果：DCO check passed: 2 commits signed off — range b386338e..47ec81b6 (base origin/main)

pnpm --filter desktop run typecheck
结果：本次改动 0 错误。rebase 后发现并修复了 1 条本次引入的类型错误
     （instance-level pre override 参数类型 { children?: ReactNode } & Record<string, unknown>
      与 react-markdown Components['pre'] 不兼容，改为 HTMLAttributes<HTMLPreElement>）。
     剩余 6 条 typecheck 错误为环境性预先存在（@cindy/model-access-protocol 找不到模块、
     electron 缺 ConfigureWebAuthnOptions、子模块 dist 未 build / pnpm install 未完成），
     与本 PR 无关，CI 不会出现。

pnpm --filter desktop exec vitest run src/renderer/__tests__/runInTerminal.test.ts src/renderer/__tests__/markdownDiffBlock.test.ts
结果：2 files passed, 48 tests passed (runInTerminal 21 + markdownDiffBlock 27)
```

### 手工验证

不涉及（当前环境无法启动 Desktop dev，未做实机目检；按钮交互复用既有 CodeBlockPre hover chrome）。

### 未执行的验证

- 全仓 `pnpm test:unit`：本地环境受限——`pnpm install` 在 download 阶段卡住（reused 1984 / +2124，换 npmjs 与 npmmirror 均卡），node_modules 不完整；`corepack prepare --activate` 后 pnpm shim 仍不在当前 shell PATH，导致 `pnpm test:unit` 子脚本调不到 pnpm。依赖 CI 跑完整门禁。
- 实机 UI 目检：当前环境无法启动 Desktop dev，未做 Light/Dark 实机目检。按钮样式复用语义 token，理论双模式同源，但未实机验证。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 desktop renderer 的 Markdown 代码块渲染，不涉及 SQLite/协议/权限/插件/原生层/跨平台差异
- 回滚 / 降级方式：revert 本 PR 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
