### PR TITLE
fix(desktop): 修复自定义网关 codex 模型置灰

### DIFF
--- a/apps/desktop/src/main/im/shared/__tests__/authCheck.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/authCheck.test.ts
@@ -223,7 +223,9 @@ describe('checkImRouteAuth', () => {
   });
 
   it('allows an explicitly connected no-auth proxy without API key material', async () => {
-    const providerSnapshot = [provider({ id: 'local-proxy', strategy: 'none', connected: true })];
+    const providerSnapshot = [
+      provider({ id: 'local-proxy', strategy: 'none', connected: true }),
+    ];
 
     await expect(
       checkImRouteAuth(row({ providerId: 'local-proxy' }), providerSnapshot, deps()),
@@ -286,29 +288,19 @@ describe('resolveEffectiveProvider', () => {
     const nonChat = provider({
       id: 'xd',
       strategy: 'gateway-key',
-      models: {
-        'claude-code': [
-          {
-            ...model('shared-id'),
-            efforts: [] as const,
-            defaultEffort: null,
-            mode: 'image_generation',
-          },
-        ],
-      },
+      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'image_generation' }] },
     });
     const chat = provider({
       id: 'openai',
       strategy: 'oauth-passthrough',
-      models: {
-        'claude-code': [
-          { ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' },
-        ],
-      },
+      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' }] },
     });
 
     expect(
-      resolveEffectiveProvider(row({ model: 'shared-id', providerId: 'xd' }), [nonChat, chat]),
+      resolveEffectiveProvider(
+        row({ model: 'shared-id', providerId: 'xd' }),
+        [nonChat, chat],
+      ),
     ).toEqual({ kind: 'explicit-invalid' });
   });
 
@@ -316,31 +308,18 @@ describe('resolveEffectiveProvider', () => {
     const nonChat = provider({
       id: 'xd',
       strategy: 'gateway-key',
-      models: {
-        'claude-code': [
-          {
-            ...model('shared-id'),
-            efforts: [] as const,
-            defaultEffort: null,
-            mode: 'image_generation',
-          },
-        ],
-      },
+      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'image_generation' }] },
     });
     const chat = provider({
       id: 'openai',
       strategy: 'oauth-passthrough',
-      models: {
-        'claude-code': [
-          { ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' },
-        ],
-      },
+      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' }] },
     });
 
-    const resolution = resolveEffectiveProvider(row({ model: 'shared-id', providerId: null }), [
-      nonChat,
-      chat,
-    ]);
+    const resolution = resolveEffectiveProvider(
+      row({ model: 'shared-id', providerId: null }),
+      [nonChat, chat],
+    );
     expect(resolution.kind).toBe('provider');
     expect(resolution.kind === 'provider' ? resolution.provider.id : null).toBe('openai');
   });

--- a/apps/desktop/src/main/im/shared/__tests__/authCheck.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/authCheck.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import type { AgentKind } from '@cindy/maker-core';
-import type { ProviderView } from '@cindy/model-providers';
+import type { CatalogModel, ProviderView } from '@cindy/model-providers';
 
 import { ui as discordUi } from '../../discord/uiText';
 import { ui as feishuUi } from '../../feishu/uiText';
@@ -35,7 +35,7 @@ function row(overrides: Partial<AuthRow> = {}): AuthRow {
   };
 }
 
-function model(id: string) {
+function model(id: string): CatalogModel {
   return {
     id,
     name: id,
@@ -92,6 +92,45 @@ describe('checkImRouteAuth', () => {
 
     expect(message).toContain('Settings');
     expect(message).not.toContain('/new');
+  });
+
+  it('uses the selected user-provider route for codex/ models without an XD gateway key', async () => {
+    const providerSnapshot = [
+      provider({
+        id: 'custom-litellm',
+        source: 'user',
+        strategy: 'api-key-header',
+        agentKind: 'codex',
+        modelId: 'codex/foo',
+        routing: {
+          codex: {
+            upstream: 'https://litellm.example.test',
+            authStrategy: 'api-key-header',
+            headerOverride: { authorization: 'Bearer configured-by-provider' },
+          },
+        },
+        models: { codex: [model('codex/foo')] },
+      }),
+    ];
+
+    // 自定义供应商的 host 注入鉴权不应回落到 codex/ 的 XD 网关 key gate。
+    await expect(
+      checkImRouteAuth(
+        row({ agentKind: 'codex', model: 'codex/foo', providerId: 'custom-litellm' }),
+        providerSnapshot,
+        deps(),
+      ),
+    ).resolves.toEqual({ ok: true, missing: null });
+  });
+
+  it('reports gateway-key for an implicit codex/ route without an XD gateway key', async () => {
+    const providerSnapshot = [
+      provider({ id: 'xd', strategy: 'gateway-key', agentKind: 'codex', modelId: 'codex/foo' }),
+    ];
+
+    await expect(
+      checkImRouteAuth(row({ agentKind: 'codex', model: 'codex/foo' }), providerSnapshot, deps()),
+    ).resolves.toEqual({ ok: false, missing: 'gateway-key' });
   });
 
   it('reports gateway-key when a gateway route has no XD key', async () => {
@@ -184,9 +223,7 @@ describe('checkImRouteAuth', () => {
   });
 
   it('allows an explicitly connected no-auth proxy without API key material', async () => {
-    const providerSnapshot = [
-      provider({ id: 'local-proxy', strategy: 'none', connected: true }),
-    ];
+    const providerSnapshot = [provider({ id: 'local-proxy', strategy: 'none', connected: true })];
 
     await expect(
       checkImRouteAuth(row({ providerId: 'local-proxy' }), providerSnapshot, deps()),
@@ -249,19 +286,29 @@ describe('resolveEffectiveProvider', () => {
     const nonChat = provider({
       id: 'xd',
       strategy: 'gateway-key',
-      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'image_generation' }] },
+      models: {
+        'claude-code': [
+          {
+            ...model('shared-id'),
+            efforts: [] as const,
+            defaultEffort: null,
+            mode: 'image_generation',
+          },
+        ],
+      },
     });
     const chat = provider({
       id: 'openai',
       strategy: 'oauth-passthrough',
-      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' }] },
+      models: {
+        'claude-code': [
+          { ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' },
+        ],
+      },
     });
 
     expect(
-      resolveEffectiveProvider(
-        row({ model: 'shared-id', providerId: 'xd' }),
-        [nonChat, chat],
-      ),
+      resolveEffectiveProvider(row({ model: 'shared-id', providerId: 'xd' }), [nonChat, chat]),
     ).toEqual({ kind: 'explicit-invalid' });
   });
 
@@ -269,18 +316,31 @@ describe('resolveEffectiveProvider', () => {
     const nonChat = provider({
       id: 'xd',
       strategy: 'gateway-key',
-      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'image_generation' }] },
+      models: {
+        'claude-code': [
+          {
+            ...model('shared-id'),
+            efforts: [] as const,
+            defaultEffort: null,
+            mode: 'image_generation',
+          },
+        ],
+      },
     });
     const chat = provider({
       id: 'openai',
       strategy: 'oauth-passthrough',
-      models: { 'claude-code': [{ ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' }] },
+      models: {
+        'claude-code': [
+          { ...model('shared-id'), efforts: [] as const, defaultEffort: null, mode: 'chat' },
+        ],
+      },
     });
 
-    const resolution = resolveEffectiveProvider(
-      row({ model: 'shared-id', providerId: null }),
-      [nonChat, chat],
-    );
+    const resolution = resolveEffectiveProvider(row({ model: 'shared-id', providerId: null }), [
+      nonChat,
+      chat,
+    ]);
     expect(resolution.kind).toBe('provider');
     expect(resolution.kind === 'provider' ? resolution.provider.id : null).toBe('openai');
   });

--- a/apps/desktop/src/renderer/__tests__/modelSelectorCustomProviderCodexGate.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorCustomProviderCodexGate.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+
+/**
+ * modelSelectorCustomProviderCodexGate.test.tsx
+ * ---------------------------------------------------------------------------
+ * #1568 回归:未登录(hasSavedKey=false)时,codex/ 前缀的本机 key gate 只应作用于
+ * XD 网关折扣路由;自定义(user)供应商目录里的同前缀模型按其供应商自身状态判定,
+ * 不得因缺少 Cindy AI 网关 key 被置灰。
+ */
+
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-i18next')>()),
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, string>) => {
+      const translations: Record<string, string> = {
+        'settings.providers.xd.title': 'Cindy AI',
+        'newChat.modelSelector.trigger.placeholder': '选择模型',
+        'newChat.modelSelector.trigger.aria': `Select model. Current: ${options?.model ?? ''}`,
+        'newChat.modelSelector.trigger.ariaWithEffort': `Select model. Current: ${options?.model ?? ''}, effort: ${options?.effort ?? ''}`,
+        'newChat.modelSelector.search.noResults': '无匹配模型',
+        'newChat.modelSelector.pricing.free': '限时免费',
+        'newChat.modelSelector.source.disconnected': '已断开',
+      };
+      return translations[key] ?? options?.defaultValue ?? key;
+    },
+  }),
+}));
+
+vi.mock('@/components/ui/popover', async () => {
+  const React = await import('react');
+  const OpenContext = React.createContext<{
+    open: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }>({ open: true });
+  return {
+    Popover: ({
+      children,
+      open,
+      onOpenChange,
+    }: {
+      children: React.ReactNode;
+      open?: boolean;
+      onOpenChange?: (open: boolean) => void;
+    }) =>
+      React.createElement(
+        OpenContext.Provider,
+        { value: { open: open ?? true, onOpenChange } },
+        children,
+      ),
+    PopoverTrigger: ({ children }: { children: React.ReactNode }) => {
+      const state = React.useContext(OpenContext);
+      const child = children as React.ReactElement<{ onClick?: React.MouseEventHandler }>;
+      return React.cloneElement(child, {
+        onClick: (event: React.MouseEvent) => {
+          child.props.onClick?.(event);
+          state.onOpenChange?.(!state.open);
+        },
+      });
+    },
+    PopoverAnchor: ({ children }: { children: React.ReactNode }) => children,
+    PopoverContent: ({ children }: { children: React.ReactNode }) => {
+      const state = React.useContext(OpenContext);
+      return state.open
+        ? React.createElement('div', { 'data-testid': 'model-options-popover' }, children)
+        : null;
+    },
+  };
+});
+
+vi.mock('@/lib/scrollbarAutoHide', () => ({ flashScrollbar: vi.fn() }));
+
+vi.mock('@/hooks/useAgentCapabilities', () => ({
+  evictDeviceCapabilities: vi.fn(),
+  prefetchDeviceCapabilities: vi.fn(async () => {}),
+  useAgentCapabilities: () => ({ capabilities: null, loading: false, error: null }),
+}));
+
+// 未登录:本机没有 Cindy AI/XD 网关 key。
+vi.mock('@/hooks/useApiKey', () => ({
+  useApiKey: () => ({ hasSavedKey: false }),
+}));
+
+vi.mock('@/hooks/useConnectedSource', () => ({
+  useConnectedSource: () => ({ hasConnectedSource: true, loading: false }),
+}));
+
+vi.mock('@/hooks/useModelPricing', () => ({
+  useGatewayModelPricing: () => ({}),
+  useReferenceModelPricing: () => ({}),
+}));
+
+const providersRef = vi.hoisted(() => {
+  const codexModel = (id: string, name: string) => ({
+    id,
+    name,
+    contextWindow: 200000,
+    efforts: ['low', 'medium', 'high'],
+    defaultEffort: 'high',
+  });
+  const DEFAULT_PROVIDERS = [
+    {
+      id: 'xd',
+      name: 'Cindy AI',
+      source: 'builtin',
+      agents: ['codex'],
+      auth: { method: 'api-key' },
+      routing: { codex: {} },
+      connected: true,
+      models: { codex: [codexModel('codex/gpt-5.5', 'GPT-5.5')] },
+    },
+    {
+      id: 'custom-litellm',
+      name: '自建 LiteLLM',
+      source: 'user',
+      agents: ['codex'],
+      auth: { method: 'api-key' },
+      routing: { codex: {} },
+      connected: true,
+      models: { codex: [codexModel('codex/gpt-5.6-sol', 'codex/gpt-5.6-sol')] },
+    },
+  ] as unknown[];
+  return { DEFAULT_PROVIDERS, providers: DEFAULT_PROVIDERS };
+});
+vi.mock('@/hooks/useProviders', () => ({
+  useProviders: () => ({ providers: providersRef.providers, providerOrder: [] }),
+}));
+
+vi.mock('@/hooks/useDeviceProviders', () => ({
+  evictDeviceProviders: vi.fn(),
+  prefetchDeviceProviders: vi.fn(async () => {}),
+  useDeviceProviders: () => ({
+    providers: [],
+    loading: false,
+    error: null,
+    unsupported: false,
+  }),
+}));
+
+vi.mock('@/lib/providerModels', () => ({
+  providerMonogram: (name: string) => name.slice(0, 1).toUpperCase(),
+  isChatBridgedCodexProvider: () => false,
+  filterChatBridgedCodexProviders: (providers: unknown[]) => providers,
+  resolveVisibleModelAgentKind: ({ agentKind }: { agentKind: string | null }) =>
+    agentKind ?? 'codex',
+  selectVisibleModels: () => [],
+}));
+
+vi.mock('@/state/modelVisibilityPrefs', () => ({
+  isModelEnabled: () => true,
+  useModelVisibilityVersion: () => 0,
+}));
+
+vi.mock('@/state/providerModelMemory', () => ({
+  useProviderModelMemoryVersion: () => 0,
+}));
+
+vi.mock('@/state/deviceLinkModelMirror', () => ({
+  useDeviceLinkModelMirrorVersion: () => 0,
+}));
+
+import { ModelSelector } from '@/components/new-chat/ModelSelector';
+
+const requestProviderModelsAutoRefresh = vi.fn(async () => ({ ok: true as const }));
+
+beforeEach(() => {
+  requestProviderModelsAutoRefresh.mockClear();
+  providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    maker: { requestProviderModelsAutoRefresh },
+  };
+});
+
+function renderSelector(props: Partial<React.ComponentProps<typeof ModelSelector>> = {}) {
+  return render(
+    React.createElement(ModelSelector, {
+      modelId: 'codex/gpt-5.5',
+      effort: 'high',
+      onModelChange: vi.fn(),
+      onEffortChange: vi.fn(),
+      vendorKey: 'codex',
+      currentProviderId: 'xd',
+      onProviderChange: vi.fn(),
+      ...props,
+    }),
+  );
+}
+
+async function openDropdown(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByRole('button', { name: /Select model/ }));
+  });
+}
+
+describe('ModelSelector codex/ key gate scope (#1568)', () => {
+  it('keeps custom-provider codex/ models selectable without a saved gateway key', async () => {
+    renderSelector();
+    await openDropdown();
+    const popover = screen.getByTestId('model-options-popover');
+    const options = within(popover).getAllByRole('option');
+    const customRow = options.find((row) =>
+      within(row).queryByText('codex/gpt-5.6-sol'),
+    );
+    expect(customRow).toBeTruthy();
+    expect(customRow?.getAttribute('aria-disabled')).toBe('false');
+  });
+
+  it('still disables XD gateway codex/ models without a saved gateway key', async () => {
+    renderSelector();
+    await openDropdown();
+    const popover = screen.getByTestId('model-options-popover');
+    const options = within(popover).getAllByRole('option');
+    const gatewayRow = options.find((row) => within(row).queryByText('GPT-5.5'));
+    expect(gatewayRow).toBeTruthy();
+    expect(gatewayRow?.getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/remoteWorkerCreationContext.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remoteWorkerCreationContext.test.ts
@@ -50,12 +50,14 @@ describe('remote Orca Worker creation context', () => {
   it('never uses the controller API key to gate a remote model row', () => {
     const selector = read('components/new-chat/ModelSelector.tsx');
 
-    // 本地会话仍只按 codex/ + hasSavedKey 准入;SSH 远程额外按订阅直连前缀禁用
-    // (不可路由)。device-link 远程在目录未就绪或真实读取失败时禁用旧行，
+    // 本地会话按 codex/ + hasSavedKey 准入,但该 key gate 只属于 XD 网关折扣路由,
+    // 自定义(user)供应商的同前缀模型不受 Cindy 登录门禁(#1568);SSH 远程额外按订阅
+    // 直连前缀禁用(不可路由)。device-link 远程在目录未就绪或真实读取失败时禁用旧行，
     // 只有明确判定老被控端不支持 provider:list 时才回退 capabilities flat list；
     // 任一远程路径都不得回退到 controller key 判定。
     expect(selector).toContain('if (!deviceId) {');
     expect(selector).toContain('if (subscriptionDirectDisabledReason(id)) return true;');
+    expect(selector).toContain("if (provider?.source === 'user') return false;");
     expect(selector).toContain("return id.startsWith('codex/') && !hasSavedKey;");
     expect(selector).toContain("if (remoteModelListStatus !== 'ready') return true;");
     expect(selector).toContain(

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -1010,9 +1010,14 @@ function ModelSelectorContentView({
         ? t('newChat.modelSelector.subscriptionDirectDisabled.xai')
         : t('newChat.modelSelector.subscriptionDirectDisabled.generic');
   };
-  const modelDisabledOf = (id: string): boolean => {
+  const modelDisabledOf = (provider: ProviderView | null, id: string): boolean => {
     if (!deviceId) {
       if (subscriptionDirectDisabledReason(id)) return true;
+      // codex/ 的本机 key gate 只属于 XD 网关折扣路由。自定义(user)供应商目录里的
+      // 同前缀模型由该供应商自身配置路由(codex-proxy-host 按会话显式供应商解析,
+      // 不按前缀落网关),不依赖 Cindy 登录/网关 key(#1568)。flat 列表(provider
+      // 为 null,无供应商概念)与内置来源保持原前缀判定。
+      if (provider?.source === 'user') return false;
       return id.startsWith('codex/') && !hasSavedKey;
     }
     if (remoteModelListStatus !== 'ready') return true;
@@ -1601,7 +1606,7 @@ function ModelSelectorContentView({
     const providerId = provider?.id ?? null;
     const isSelected = isSelectedRow(providerId, model.id);
     const isSubscriptionModel = provider?.access?.kind === 'subscription';
-    const disabled = interactionDisabled || modelDisabledOf(model.id);
+    const disabled = interactionDisabled || modelDisabledOf(provider, model.id);
     const disabledReason = subscriptionDirectDisabledReason(model.id);
     const rowEffort = rowEffortOf(providerId, model);
     const rowFastOn = fastOnOf(providerId, model);


### PR DESCRIPTION
## 这次改了什么

### 摘要
修复未登录时自定义供应商提供的 `codex/` 模型被 Cindy AI 网关 key gate 错误置灰的问题。模型选择器现在按供应商来源区分自定义供应商与 XD 网关，并保留 XD 网关模型的登录门禁。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#1568
- 本 PR 包含：按 `ProviderView.source` 传递供应商上下文；新增未登录场景下自定义与 XD 网关模型的回归测试。
- 明确不包含：定时任务、Orca Worker、IM 路径中其它同类前缀门禁。
- 用户可见变化：未登录时自定义网关的 `codex/` 模型可正常选择；XD 网关模型仍按 key 置灰。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §Light / Dark Dual-Mode Delivery Gate；本次仅改变可用性判定，不改变布局、颜色、文案或主题 token，Light/Dark 均沿用现有模型选择器实现。

#### 改动后界面效果证据

本次 UI 改动只改变模型行的可用性状态，下面是对应选择器行的 HTML 结构示意：自定义供应商的 `codex/` 行可选，XD 网关的同前缀行仍置灰。两行继续使用现有模型选择器的语义 token、布局和主题样式；没有连接宿主 Desktop 实例，因此未附实机截图。

```html
<div role="option" data-provider-source="user" aria-disabled="false">
  <span>自建 LiteLLM</span>
  <span>codex/gpt-5.6-sol</span>
</div>
<div role="option" data-provider-source="builtin" data-provider-id="xd" aria-disabled="true">
  <span>Cindy AI</span>
  <span>codex/gpt-5.5</span>
</div>
```

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/im/shared/__tests__/authCheck.test.ts src/renderer/__tests__/modelSelectorCustomProviderCodexGate.test.tsx src/renderer/__tests__/remoteWorkerCreationContext.test.ts
结果：3 个测试文件、23 个测试通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：全量单元测试通过。
```

### 手工验证
未执行：当前 worktree 无法连接宿主 Desktop 实例进行实机目检；已在回归测试中验证自定义供应商行与 XD 网关行的 `aria-disabled` 状态。

### 未执行的验证
无

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：Desktop 本机模型选择器的供应商分段行，以及 IM 鉴权回归测试覆盖。
- 回滚 / 降级方式：回退本 PR 提交即可恢复原门禁。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名 (`git commit -s`)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

## 关联 Issue

- #1568
