### PR TITLE
fix(desktop): 保住 Windows 反斜杠本地路径的 markdown 链接不再退化纯文本

### DIFF
--- a/apps/desktop/src/renderer/__tests__/markdownImagePathEncoding.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownImagePathEncoding.test.ts
@@ -11,9 +11,9 @@ import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
 import { describe, expect, it } from 'vitest';
 
 import { normalizeMarkdownImageSrc } from '@/lib/localPathResolver';
-import remarkPreserveLocalImagePaths, {
+import remarkPreserveRawLocalDestinations, {
   RAW_LOCAL_IMAGE_SRC_PROP,
-} from '../components/chat/remarkPreserveLocalImagePaths';
+} from '../components/chat/remarkPreserveRawLocalDestinations';
 
 function normalizedImageSrc(markdown: string, workingDir = '/repo'): string | undefined {
   let normalized: string | undefined;
@@ -30,7 +30,7 @@ function normalizedImageSrc(markdown: string, workingDir = '/repo'): string | un
           return null;
         },
       },
-      remarkPlugins: [remarkPreserveLocalImagePaths],
+      remarkPlugins: [remarkPreserveRawLocalDestinations],
       urlTransform: defaultUrlTransform,
       children: markdown,
     }),

--- a/apps/desktop/src/renderer/__tests__/markdownLinkPathEncoding.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownLinkPathEncoding.test.ts
@@ -18,9 +18,9 @@ import { describe, expect, it } from 'vitest';
 
 import { classifyMarkdownLinkTarget } from '@/lib/markdownTarget';
 import remarkLocalPathLinks from '../components/chat/remarkLocalPathLinks';
-import remarkPreserveLocalImagePaths, {
+import remarkPreserveRawLocalDestinations, {
   RAW_LOCAL_LINK_HREF_PROP,
-} from '../components/chat/remarkPreserveLocalImagePaths';
+} from '../components/chat/remarkPreserveRawLocalDestinations';
 
 interface CapturedLink {
   raw?: string;
@@ -41,7 +41,7 @@ function renderLink(markdown: string): CapturedLink {
       },
       // 与 MarkdownRenderer 的约束一致:preserve 插件必须排在
       // remarkLocalPathLinks 之后,正文裸路径切出的 link 才拿得到原始值。
-      remarkPlugins: [remarkLocalPathLinks, remarkPreserveLocalImagePaths],
+      remarkPlugins: [remarkLocalPathLinks, remarkPreserveRawLocalDestinations],
       urlTransform: defaultUrlTransform,
       children: markdown,
     }),

--- a/apps/desktop/src/renderer/__tests__/markdownLinkPathEncoding.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownLinkPathEncoding.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Regression coverage for local Markdown *links* whose destinations survive
+ * mdast-to-hast URL serialization only through the raw-preservation channel
+ * (issue #1629).
+ *
+ * `normalizeUri` percent-encodes Windows backslashes (`\` → `%5C`), so a
+ * model-written `[label](C:\Users\...\a.png)` reaches urlTransform as
+ * `C:%5CUsers%5C...` — it no longer matches the Windows-absolute whitelist,
+ * falls into react-markdown's protocol whitelist (`c:` = unknown scheme), and
+ * the href is stripped to "". Without the raw property the link degrades to
+ * dead plain text while the identical path renders fine as an image.
+ */
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown';
+import { describe, expect, it } from 'vitest';
+
+import { classifyMarkdownLinkTarget } from '@/lib/markdownTarget';
+import remarkLocalPathLinks from '../components/chat/remarkLocalPathLinks';
+import remarkPreserveLocalImagePaths, {
+  RAW_LOCAL_LINK_HREF_PROP,
+} from '../components/chat/remarkPreserveLocalImagePaths';
+
+interface CapturedLink {
+  raw?: string;
+  href?: string;
+}
+
+function renderLink(markdown: string): CapturedLink {
+  const captured: CapturedLink = {};
+  renderToStaticMarkup(
+    createElement(ReactMarkdown, {
+      components: {
+        a: ({ href, node }) => {
+          const raw = node?.properties?.[RAW_LOCAL_LINK_HREF_PROP];
+          captured.raw = typeof raw === 'string' ? raw : undefined;
+          captured.href = href;
+          return null;
+        },
+      },
+      // 与 MarkdownRenderer 的约束一致:preserve 插件必须排在
+      // remarkLocalPathLinks 之后,正文裸路径切出的 link 才拿得到原始值。
+      remarkPlugins: [remarkLocalPathLinks, remarkPreserveLocalImagePaths],
+      urlTransform: defaultUrlTransform,
+      children: markdown,
+    }),
+  );
+  return captured;
+}
+
+describe('Markdown local link path encoding', () => {
+  it('preserves a Windows backslash absolute link that urlTransform strips to ""', () => {
+    const path = 'C:\\Users\\test\\AppData\\Roaming\\Cindy\\dialogues\\random_coordinates.png';
+    const { raw, href } = renderLink(`[查看图片 random_coordinates.png](${path})`);
+
+    // 前提锁死:没有 raw 通道时这条链接必死(href 被清空)。这一断言失败说明
+    // 上游序列化/transform 行为变了,需要重新评估本修复是否仍必要。
+    expect(href).toBe('');
+    expect(raw).toBe(path);
+
+    // 原始值走既有分类链路 → 本地图片 candidate(后续 resolve → 可点)。
+    const target = classifyMarkdownLinkTarget(raw);
+    expect(target.kind).toBe('local-candidate');
+    expect(target.kind === 'local-candidate' && target.localKind).toBe('image');
+  });
+
+  it('preserves a Windows absolute link with spaces via <> wrapping', () => {
+    const path = 'C:\\Users\\test\\My Pictures\\random coordinates.png';
+    const { raw } = renderLink(`[查看图片](<${path}>)`);
+    expect(raw).toBe(path);
+  });
+
+  it('preserves a POSIX absolute link with a real space next to a literal %20', () => {
+    const path = '/tmp/report %20final.csv';
+    const { raw } = renderLink(`[下载数据](<${path}>)`);
+    expect(raw).toBe(path);
+  });
+
+  it('preserves a workingDir-relative link destination', () => {
+    const { raw } = renderLink('[脚本](./scripts/generate_random_coordinates.py)');
+    expect(raw).toBe('./scripts/generate_random_coordinates.py');
+  });
+
+  it('stashes bare prose Windows paths cut out by remarkLocalPathLinks', () => {
+    // remarkLocalPathLinks 从正文纯文本切出的 link 节点同样经过 hast 序列化,
+    // 同样需要 raw 通道 —— preserve 插件排它之后才能覆盖到。
+    const { raw } = renderLink('改的是 C:\\proj\\src\\app.ts 这个文件');
+    expect(raw).toBe('C:\\proj\\src\\app.ts');
+  });
+
+  it('does not stash scheme-bearing destinations', () => {
+    for (const md of [
+      '[外链](https://example.com/a.png)',
+      '[邮件](mailto:a@b.com)',
+      '[深链](cindy://session/00000000-0000-0000-0000-000000000000)',
+    ]) {
+      expect(renderLink(md).raw).toBeUndefined();
+    }
+  });
+
+  it('still stashes file:// destinations, matching the image channel', () => {
+    const url = 'file:///C:/Users/test/My%20Pictures/image.png';
+    expect(renderLink(`[图](${url})`).raw).toBe(url);
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
@@ -104,6 +104,21 @@ describe('Markdown target rendering contract', () => {
     expect(markdownRenderer).toContain('WINDOWS_ABSOLUTE_HREF_RE.test(url)');
   });
 
+  it('restores raw local link hrefs mangled by hast URL serialization (#1629)', () => {
+    // mdast→hast 会把反斜杠 percent-encode 成 %5C,`C:\...` 链接因此漏出
+    // trustedUrlTransform 白名单、href 被清空退化纯文本。a 渲染器必须优先消费
+    // remarkPreserveLocalImagePaths 存的原始值(与 img 同构),且仅限受信任内容。
+    expect(markdownRenderer).toContain('RAW_LOCAL_LINK_HREF_PROP');
+    expect(markdownRenderer).toContain(
+      "allowPrivilegedLinks && typeof rawLocalHref === 'string' ? rawLocalHref : href",
+    );
+    // preserve 插件必须排在两份插件链的**链尾**(remarkLocalPathLinks 之后),
+    // 正文裸路径切出的 link 节点才拿得到原始值。
+    expect(
+      markdownRenderer.match(/remarkLocalPathLinks,\n  remarkPreserveLocalImagePaths,\n\]/g),
+    ).toHaveLength(2);
+  });
+
   it('passes already-rewritten remote media image URLs through normalization', () => {
     expect(markdownRenderer).toContain('remarkPreserveLocalImagePaths');
     expect(markdownRenderer).toContain('normalizeMarkdownImageSrc(');

--- a/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/markdownTargetRendererContract.test.ts
@@ -107,7 +107,7 @@ describe('Markdown target rendering contract', () => {
   it('restores raw local link hrefs mangled by hast URL serialization (#1629)', () => {
     // mdast→hast 会把反斜杠 percent-encode 成 %5C,`C:\...` 链接因此漏出
     // trustedUrlTransform 白名单、href 被清空退化纯文本。a 渲染器必须优先消费
-    // remarkPreserveLocalImagePaths 存的原始值(与 img 同构),且仅限受信任内容。
+    // remarkPreserveRawLocalDestinations 存的原始值(与 img 同构),且仅限受信任内容。
     expect(markdownRenderer).toContain('RAW_LOCAL_LINK_HREF_PROP');
     expect(markdownRenderer).toContain(
       "allowPrivilegedLinks && typeof rawLocalHref === 'string' ? rawLocalHref : href",
@@ -115,12 +115,12 @@ describe('Markdown target rendering contract', () => {
     // preserve 插件必须排在两份插件链的**链尾**(remarkLocalPathLinks 之后),
     // 正文裸路径切出的 link 节点才拿得到原始值。
     expect(
-      markdownRenderer.match(/remarkLocalPathLinks,\n  remarkPreserveLocalImagePaths,\n\]/g),
+      markdownRenderer.match(/remarkLocalPathLinks,\n  remarkPreserveRawLocalDestinations,\n\]/g),
     ).toHaveLength(2);
   });
 
   it('passes already-rewritten remote media image URLs through normalization', () => {
-    expect(markdownRenderer).toContain('remarkPreserveLocalImagePaths');
+    expect(markdownRenderer).toContain('remarkPreserveRawLocalDestinations');
     expect(markdownRenderer).toContain('normalizeMarkdownImageSrc(');
     const normalizeBlock = localPathResolver.match(
       /export function normalizeMarkdownImageSrc[\s\S]*?return toLocalFileUrl/,

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -27,6 +27,7 @@ import remarkLocalPathLinks, { BARE_PATH_ATTR } from './remarkLocalPathLinks';
 import remarkHtmlImages from './remarkHtmlImages';
 import remarkPreserveLocalImagePaths, {
   RAW_LOCAL_IMAGE_SRC_PROP,
+  RAW_LOCAL_LINK_HREF_PROP,
 } from './remarkPreserveLocalImagePaths';
 import remarkSessionLinks from './remarkSessionLinks';
 import { rehypeMathBlockMarker } from './rehypeMathBlockMarker';
@@ -186,6 +187,11 @@ function isMermaidCodeChild(child: ReactNode): boolean {
 // 全中招);mobile 自研 parser 用正则配对本就能渲染这些写法,此处对齐。只放宽
 // emphasis/strong 的定界判定,不碰 `~~` 删除线(gfm strikethrough 有独立定界
 // 逻辑,行为不变),也不影响带空格的 `2 ** 3 ** 4` 这类本应保持字面量的写法。
+// remarkPreserveLocalImagePaths 必须排在**链尾**:它给 image / link 节点存原始
+// 本地目的地(见该文件头部说明),必须在所有会新建这两类节点的插件之后运行——
+// remarkHtmlImages(<img> HTML → mdast image)与 remarkLocalPathLinks(正文裸路径
+// → link)。remarkSessionLinks 产出的 cindy:// 深链带 scheme,被它的判据跳过,
+// 顺序无关。
 const REMARK_PLUGINS: PluggableList = [
   [remarkGfm, { singleTilde: false }],
   remarkCjkFriendly,
@@ -193,8 +199,8 @@ const REMARK_PLUGINS: PluggableList = [
   remarkStrictInlineMath,
   remarkTruncateCjkUrls,
   remarkHtmlImages,
-  remarkPreserveLocalImagePaths,
   remarkLocalPathLinks,
+  remarkPreserveLocalImagePaths,
 ];
 const REMARK_PLUGINS_PRIVILEGED: PluggableList = [
   [remarkGfm, { singleTilde: false }],
@@ -203,9 +209,9 @@ const REMARK_PLUGINS_PRIVILEGED: PluggableList = [
   remarkStrictInlineMath,
   remarkTruncateCjkUrls,
   remarkHtmlImages,
-  remarkPreserveLocalImagePaths,
   remarkSessionLinks,
   remarkLocalPathLinks,
+  remarkPreserveLocalImagePaths,
 ];
 // rehypeSlug: assigns a slug-style `id` to every heading. Without it
 // in-document anchor links (`[Section](#section-name)`) hit dead targets.
@@ -1738,8 +1744,17 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
         // remarkLocalPathLinks 打的标记:这条 link 来自正文裸写的路径,不是作者手写的
         // `[label](path)`。读完即从 DOM props 里剥掉(它只是内部信道,不该落到 <a> 上)。
         const fromBarePath = BARE_PATH_ATTR in rawProps;
+        // remarkPreserveLocalImagePaths 存的原始本地 href。mdast→hast 序列化会把
+        // 反斜杠 percent-encode 成 %5C,`C:\Users\...` 变成 `C:%5CUsers...` 后既过不了
+        // trustedUrlTransform 的 Windows 绝对路径白名单(href 被清成 "" → 链接退化
+        // 纯文本,#1629),字面 `%20` 与真实空格也不可区分。与 img 渲染器同构:
+        // 分类/解析优先用原始值;仅受信任内容启用(untrusted 保持既有降级)。
+        const rawLocalHref = rawProps[RAW_LOCAL_LINK_HREF_PROP];
         const safeProps = omitMarkdownInternalProps(rawProps);
         delete safeProps[BARE_PATH_ATTR];
+        delete safeProps[RAW_LOCAL_LINK_HREF_PROP];
+        const targetHref =
+          allowPrivilegedLinks && typeof rawLocalHref === 'string' ? rawLocalHref : href;
         if (allowPrivilegedLinks && href != null && hasDeepLinkPathPrefix(href, 'session-card/')) {
           const parsed = parseSessionCardHref(href);
           if (parsed) {
@@ -1776,7 +1791,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
         }
         return (
           <MarkdownTargetLink
-            href={href}
+            href={targetHref}
             workingDir={workingDir}
             isStreaming={isStreaming}
             localFileRefs={localFileRefs}

--- a/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
+++ b/apps/desktop/src/renderer/components/chat/MarkdownRenderer.tsx
@@ -25,10 +25,10 @@ import remarkStrictInlineMath from './remarkStrictInlineMath';
 import { normalizeMathDelimiters } from '@cindy/maker-shared/math-markdown';
 import remarkLocalPathLinks, { BARE_PATH_ATTR } from './remarkLocalPathLinks';
 import remarkHtmlImages from './remarkHtmlImages';
-import remarkPreserveLocalImagePaths, {
+import remarkPreserveRawLocalDestinations, {
   RAW_LOCAL_IMAGE_SRC_PROP,
   RAW_LOCAL_LINK_HREF_PROP,
-} from './remarkPreserveLocalImagePaths';
+} from './remarkPreserveRawLocalDestinations';
 import remarkSessionLinks from './remarkSessionLinks';
 import { rehypeMathBlockMarker } from './rehypeMathBlockMarker';
 import { FENCED_CODE_PROP, rehypeFencedCodeMarker } from './rehypeFencedCodeMarker';
@@ -187,7 +187,7 @@ function isMermaidCodeChild(child: ReactNode): boolean {
 // 全中招);mobile 自研 parser 用正则配对本就能渲染这些写法,此处对齐。只放宽
 // emphasis/strong 的定界判定,不碰 `~~` 删除线(gfm strikethrough 有独立定界
 // 逻辑,行为不变),也不影响带空格的 `2 ** 3 ** 4` 这类本应保持字面量的写法。
-// remarkPreserveLocalImagePaths 必须排在**链尾**:它给 image / link 节点存原始
+// remarkPreserveRawLocalDestinations 必须排在**链尾**:它给 image / link 节点存原始
 // 本地目的地(见该文件头部说明),必须在所有会新建这两类节点的插件之后运行——
 // remarkHtmlImages(<img> HTML → mdast image)与 remarkLocalPathLinks(正文裸路径
 // → link)。remarkSessionLinks 产出的 cindy:// 深链带 scheme,被它的判据跳过,
@@ -200,7 +200,7 @@ const REMARK_PLUGINS: PluggableList = [
   remarkTruncateCjkUrls,
   remarkHtmlImages,
   remarkLocalPathLinks,
-  remarkPreserveLocalImagePaths,
+  remarkPreserveRawLocalDestinations,
 ];
 const REMARK_PLUGINS_PRIVILEGED: PluggableList = [
   [remarkGfm, { singleTilde: false }],
@@ -211,7 +211,7 @@ const REMARK_PLUGINS_PRIVILEGED: PluggableList = [
   remarkHtmlImages,
   remarkSessionLinks,
   remarkLocalPathLinks,
-  remarkPreserveLocalImagePaths,
+  remarkPreserveRawLocalDestinations,
 ];
 // rehypeSlug: assigns a slug-style `id` to every heading. Without it
 // in-document anchor links (`[Section](#section-name)`) hit dead targets.
@@ -1744,7 +1744,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
         // remarkLocalPathLinks 打的标记:这条 link 来自正文裸写的路径,不是作者手写的
         // `[label](path)`。读完即从 DOM props 里剥掉(它只是内部信道,不该落到 <a> 上)。
         const fromBarePath = BARE_PATH_ATTR in rawProps;
-        // remarkPreserveLocalImagePaths 存的原始本地 href。mdast→hast 序列化会把
+        // remarkPreserveRawLocalDestinations 存的原始本地 href。mdast→hast 序列化会把
         // 反斜杠 percent-encode 成 %5C,`C:\Users\...` 变成 `C:%5CUsers...` 后既过不了
         // trustedUrlTransform 的 Windows 绝对路径白名单(href 被清成 "" → 链接退化
         // 纯文本,#1629),字面 `%20` 与真实空格也不可区分。与 img 渲染器同构:

--- a/apps/desktop/src/renderer/components/chat/remarkPreserveLocalImagePaths.ts
+++ b/apps/desktop/src/renderer/components/chat/remarkPreserveLocalImagePaths.ts
@@ -1,22 +1,41 @@
 /**
- * Preserve the exact local image destination before mdast-to-hast URL
- * serialization makes literal percent escapes ambiguous.
+ * Preserve the exact local image / link destination before mdast-to-hast URL
+ * serialization mangles it.
  *
- * Both a real space and the literal filename segment `%20` reach a custom
- * react-markdown image renderer as `%20`. Store the mdast value in a neutral
- * data property so the renderer can route the original filesystem path.
+ * Two distinct failure modes, one mechanism:
+ *   - Percent ambiguity: both a real space and the literal filename segment
+ *     `%20` reach a custom react-markdown renderer as `%20`.
+ *   - Windows backslashes: `normalizeUri` percent-encodes `\` into `%5C`, so a
+ *     model-written `[label](C:\Users\...\a.png)` arrives as `C:%5CUsers%5C...`.
+ *     That no longer matches the renderer's Windows-absolute whitelist in
+ *     `trustedUrlTransform`, falls into react-markdown's default protocol
+ *     whitelist (`c:` = unknown scheme), and the href is stripped to `""` —
+ *     the link degrades to dead plain text while the same path renders fine
+ *     as an image (issue #1629; images were already covered, links were not).
+ *
+ * Store the mdast value in a neutral data property so the img / a renderers
+ * can route the original filesystem path. Links and images use separate
+ * property names so neither renderer can accidentally consume the other's
+ * channel.
+ *
+ * Ordering: must run AFTER every plugin that creates image / link nodes with
+ * local destinations — remarkHtmlImages (single <img> HTML → mdast image) and
+ * remarkLocalPathLinks (bare prose paths → link). Keep it last in the remark
+ * plugin lists. remarkSessionLinks emits cindy:// deep links, which the
+ * scheme check below skips regardless of order.
  */
 
-import type { Image, Root } from 'mdast';
+import type { Image, Link, Root } from 'mdast';
 import type { Plugin } from 'unified';
 import { visit } from 'unist-util-visit';
 
 export const RAW_LOCAL_IMAGE_SRC_PROP = 'data-cindy-raw-local-image-src';
+export const RAW_LOCAL_LINK_HREF_PROP = 'data-cindy-raw-local-link-href';
 
 const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 const WINDOWS_ABSOLUTE_PATH_RE = /^[A-Za-z]:[\\/]/;
 
-function isLocalImageDestination(url: string): boolean {
+function isLocalDestination(url: string): boolean {
   return (
     WINDOWS_ABSOLUTE_PATH_RE.test(url) ||
     url.startsWith('file://') ||
@@ -26,14 +45,16 @@ function isLocalImageDestination(url: string): boolean {
 
 const remarkPreserveLocalImagePaths: Plugin<[], Root> = () => {
   return (tree) => {
-    visit(tree, 'image', (node: Image) => {
-      if (!isLocalImageDestination(node.url)) return;
+    visit(tree, ['image', 'link'], (node) => {
+      const typed = node as Image | Link;
+      if (!isLocalDestination(typed.url)) return;
 
-      node.data = {
-        ...node.data,
+      const prop = node.type === 'image' ? RAW_LOCAL_IMAGE_SRC_PROP : RAW_LOCAL_LINK_HREF_PROP;
+      typed.data = {
+        ...typed.data,
         hProperties: {
-          ...(node.data?.hProperties ?? {}),
-          [RAW_LOCAL_IMAGE_SRC_PROP]: node.url,
+          ...(typed.data?.hProperties ?? {}),
+          [prop]: typed.url,
         },
       };
     });

--- a/apps/desktop/src/renderer/components/chat/remarkPreserveRawLocalDestinations.ts
+++ b/apps/desktop/src/renderer/components/chat/remarkPreserveRawLocalDestinations.ts
@@ -43,7 +43,7 @@ function isLocalDestination(url: string): boolean {
   );
 }
 
-const remarkPreserveLocalImagePaths: Plugin<[], Root> = () => {
+const remarkPreserveRawLocalDestinations: Plugin<[], Root> = () => {
   return (tree) => {
     visit(tree, ['image', 'link'], (node) => {
       const typed = node as Image | Link;
@@ -61,4 +61,4 @@ const remarkPreserveLocalImagePaths: Plugin<[], Root> = () => {
   };
 };
 
-export default remarkPreserveLocalImagePaths;
+export default remarkPreserveRawLocalDestinations;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Issue #1629 沙箱实测确认的根因:在 Windows 上,模型最终回复里用反斜杠绝对路径写的 markdown 链接 `[查看图片 xx.png](C:\Users\...\xx.png)` 必然退化成不可点的纯文本,用户拿不到任何文件入口;而同一路径写成 `![](...)` 却能正常渲染成内联图片。

退化链路(已用管线级脚本逐步复现):

1. mdast 中 link 的 `url` 还是原始 `C:\Users\...`;
2. mdast→hast 序列化(`normalizeUri`)把 `\` percent-encode 成 `%5C` → `C:%5CUsers%5C...`;
3. `trustedUrlTransform` 的 Windows 绝对路径白名单 `/^[A-Za-z]:[\\/]/` 匹配不到 `C:%5C`,落入 `defaultUrlTransform`,`c:` 被当未知协议 → **href 清空 → 链接退化 `<span>`**;
4. 图片之所以幸存,是因为 `remarkPreserveLocalImagePaths` 把原始 src 存进 data 属性、img 渲染器优先读它——**link 节点没有对应机制**。

修复方式:把该插件的原始值保真机制推广到 link 节点(独立属性 `data-cindy-raw-local-link-href`,与 image 的通道分开),插件移到两份 remark 插件链的**链尾**(覆盖 `remarkLocalPathLinks` 从正文裸路径切出的 link);`a` 渲染器与 `img` 同构地优先消费原始值,仅受信任内容(`allowPrivilegedLinks`)启用,读完即从 DOM props 剥掉。顺带修复了同一通道的字面 `%20` 与真实空格不可区分问题(与 image 侧既有行为对齐)。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#1629
- 本 PR 包含:desktop renderer 的 link 原始目的地保真(remark 插件扩展 + `a` 渲染器消费)、插件链顺序调整、回归测试(新增 `markdownLinkPathEncoding.test.ts` 7 例 + 契约测试 1 例)
- 明确不包含:Issue 中"正文裸文件名不点亮"的设计取舍(那是 `remarkLocalPathLinks` 有意为之的防误报边界,不属于本缺陷);提示词侧引导模型输出可解析路径(另行讨论);移动端(自研 tokenizer 不经过 mdast→hast 序列化,无此问题)
- 用户可见变化:Windows 上模型用反斜杠绝对路径写的文件链接从"死文本"恢复为可点击(等宽 chip / 下划线链接,均为既有形态,无新视觉)
- 是否存在 breaking change:无

### UI 变化

无新视觉形态:链接点亮后走的是既有 `FileTargetChip` / `ResolvedLocalLink` 分支(等宽 chip 或下划线链接),只是原本该点亮却退化成纯文本的链接恢复了设计意图。Light/Dark 均由既有语义 token 组件承载,本 PR 未新增任何样式。

- 引用的设计规范:DESIGN.md §14.5(本地路径点亮形态:作者手写 `[label](path)` → 按 label 形态决定 chip;正文裸路径 → 仅下划线)——本 PR 不改变该形态决策逻辑,只恢复"作者手写链接能进入该链路"的前提。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/markdownLinkPathEncoding.test.ts src/renderer/__tests__/markdownTargetRendererContract.test.ts src/renderer/__tests__/markdownImagePathEncoding.test.ts
结果:3 files 27 tests 全部通过

pnpm --filter desktop typecheck
结果:通过(无输出)

pnpm test:unit(仓库根全量)
结果:全部 PASS(exit 0)
```

### 手工验证

Windows 11,`--isolated=issue1629` 命名沙箱 dev 实测(复现 → 修复 → 复验):

1. 修复前:让 agent 用 matplotlib 生成 PNG,最终回复中 `[查看图片 random_coordinates.png](C:\...绝对路径)` 等三条文件链接渲染为不可点 `<span>`(CDP 抓取 DOM 确认),内联 `![](...)` 图片正常;
2. 修复后(renderer 热更新):三条链接全部渲染为可点链接,href 为原始 Windows 路径,主进程解析成功(渲染成 `ResolvedLocalLink` 即已通过 stat);
3. 点击 PNG 链接打开 ImageLightbox(img 数量 1→2,新增 img src 为 `xdt-file://...random_coordinates.png`);内联图片渲染不受影响。

### 未执行的验证

- Light/Dark 双模式实机目检未单独执行:本 PR 无任何样式改动,点亮形态复用既有 themed 组件;沙箱实测在 Dark 模式下进行,Light 模式未目检。
- macOS 实机未验证:改动为平台无关的 AST/props 传递逻辑,POSIX 路径行为由单测覆盖(含空格与字面 `%20` 用例)。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 desktop renderer 的 markdown 链接分类入参(原始值优先);安全边界不变——raw 通道只对无 scheme / `file://` / Windows 盘符形态的目的地生效,`javascript:` 等未知协议仍被 defaultUrlTransform 清空,untrusted 内容(`allowPrivilegedLinks=false`)不消费 raw 值,分类后仍需主进程 stat 存在性校验才点亮。
- 回滚 / 降级方式:revert 本 commit 即回到"Windows 反斜杠链接退化纯文本"的旧行为,无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(插件头部注释与插件链顺序注释已更新)
- [x] 已确认测试结果或说明未执行原因