### PR TITLE
fix(pi): 修复 start_team 运行时 vendorOptions 更新

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
@@ -70,6 +70,12 @@ function createTestServer(name: string): McpServer {
       text: getLiziMcpSessionContext()?.sessionInstanceId ?? 'no-instance',
     }],
   }));
+  server.tool('current_vendor_options', 'Return the active lizi MCP vendor options.', {}, async () => ({
+    content: [{
+      type: 'text' as const,
+      text: JSON.stringify(getLiziMcpSessionContext()?.vendorOptions ?? {}),
+    }],
+  }));
   return server;
 }
 
@@ -173,6 +179,53 @@ describe('piEnvironment per-session identity', () => {
     const after = await fetch(server.url, { method: 'POST', headers, body: INIT_BODY(4) });
     expect(after.status).toBe(401);
     await after.text();
+  });
+
+  it('keeps the registered Pi MCP vendorOptions live for start_team Lead activation', async () => {
+    const vendorOptions: Record<string, unknown> = { source: 'draft' };
+    const config = await getPiExtraSpawnConfig([makeProvider('custom_probe')], noopLogger(), {
+      sessionId: 'pi-runtime-lead',
+      workingDir: '/repo',
+      vendorOptions,
+    });
+    const server = config!.mcpBridge!.servers[0]!;
+    const headers = {
+      authorization: `Bearer ${config!.mcpBridge!.token}`,
+      accept: 'application/json, text/event-stream',
+      'content-type': 'application/json',
+    };
+    const initResp = await fetch(server.url, { method: 'POST', headers, body: INIT_BODY(21) });
+    expect(initResp.status).toBe(200);
+    const mcpSessionId = initResp.headers.get('mcp-session-id');
+    await initResp.text();
+
+    // 对应 start_team 成功后的 MakerSession.setVendorOptions 原地更新。
+    Object.assign(vendorOptions, {
+      orcaRole: 'lead',
+      orcaWorkflowId: 'team-1',
+      orcaLeadSessionId: 'pi-runtime-lead',
+    });
+    const callResp = await fetch(server.url, {
+      method: 'POST',
+      headers: { ...headers, 'mcp-session-id': mcpSessionId ?? '' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 22,
+        method: 'tools/call',
+        params: { name: 'current_vendor_options', arguments: {} },
+      }),
+    });
+    expect(callResp.status).toBe(200);
+    const result = await readRpcText(callResp) as {
+      result?: { content?: Array<{ text?: string }> };
+    };
+    expect(JSON.parse(result.result?.content?.[0]?.text ?? '{}')).toMatchObject({
+      source: 'draft',
+      orcaRole: 'lead',
+      orcaWorkflowId: 'team-1',
+      orcaLeadSessionId: 'pi-runtime-lead',
+    });
+    config!.disposeSessionCtx!();
   });
 
   it('rejects a stale pi instance route after the same business session is rebound', async () => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
@@ -197,6 +197,7 @@ describe('piEnvironment per-session identity', () => {
     const initResp = await fetch(server.url, { method: 'POST', headers, body: INIT_BODY(21) });
     expect(initResp.status).toBe(200);
     const mcpSessionId = initResp.headers.get('mcp-session-id');
+    expect(mcpSessionId).toBeTruthy();
     await initResp.text();
 
     // 对应 start_team 成功后的 MakerSession.setVendorOptions 原地更新。
@@ -207,7 +208,7 @@ describe('piEnvironment per-session identity', () => {
     });
     const callResp = await fetch(server.url, {
       method: 'POST',
-      headers: { ...headers, 'mcp-session-id': mcpSessionId ?? '' },
+      headers: { ...headers, 'mcp-session-id': mcpSessionId! },
       body: JSON.stringify({
         jsonrpc: '2.0',
         id: 22,

--- a/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
+++ b/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
@@ -171,6 +171,11 @@ export async function getPiExtraSpawnConfig(
   const disabledPluginIds = createPluginRegistry().getDisabledRuntimePluginIds(
     sessionCtx?.workingDir ?? '',
   );
+  // PiAgent 传入的是该 session 专属的可变副本。这里必须保留同一引用：start_team
+  // 成功后 MakerSession.setVendorOptions 会原地写入 Lead 身份，既有 HTTP MCP handler
+  // 要在下一次 create_worker 调用时立即看到。复制对象会把 bridge 永久冻结在启动态。
+  const vendorOptions = sessionCtx?.vendorOptions ?? {};
+  vendorOptions[CODEX_DISABLED_BUILTIN_PLUGIN_IDS_KEY] = disabledPluginIds;
   const liziCtx: LiziMcpSessionContext = {
     agentKind: 'pi',
     sessionId,
@@ -178,10 +183,7 @@ export async function getPiExtraSpawnConfig(
       ? { sessionInstanceId: sessionCtx.sessionInstanceId }
       : {}),
     workingDir: sessionCtx?.workingDir ?? '',
-    vendorOptions: {
-      ...sessionCtx?.vendorOptions,
-      [CODEX_DISABLED_BUILTIN_PLUGIN_IDS_KEY]: disabledPluginIds,
-    },
+    vendorOptions,
   };
   // 同 session 重建(resume/reattach)直接覆盖注册,注册表以 sessionId 为 key,
   // 天然不累积。必须在返回(即 spawn)前完成 —— cindy-bridge extension 一起进程

--- a/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
@@ -23,6 +23,7 @@ const captured = vi.hoisted(() => ({
   requests: [] as Array<Record<string, unknown>>,
   sent: [] as Array<Record<string, unknown>>,
   proxyRegistration: null as { sessionId: string; token: string } | null,
+  mcpVendorOptions: undefined as Record<string, unknown> | undefined,
   failSetModel: false,
   rejectSetModel: false,
   onAfterSetModel: null as null | (() => void),
@@ -97,6 +98,7 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     captured.requests = [];
     captured.sent = [];
     captured.proxyRegistration = null;
+    captured.mcpVendorOptions = undefined;
     captured.failSetModel = false;
     captured.rejectSetModel = false;
     captured.onAfterSetModel = null;
@@ -137,16 +139,19 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
       ...(mcp?.policy ? { getMcpToolApprovalPolicy: mcp.policy } : {}),
       ...(mcp?.serverNames
         ? {
-          preparePiExtraSpawnConfig: async () => ({
-            mcpBridge: {
-              token: 'bridge-token',
-              servers: mcp.serverNames!.map((name) => ({
-                name,
-                url: `http://127.0.0.1:1/${name}`,
-              })),
-            },
-            mcpEnv: {},
-          }),
+          preparePiExtraSpawnConfig: async (_providers, context) => {
+            captured.mcpVendorOptions = context.vendorOptions;
+            return {
+              mcpBridge: {
+                token: 'bridge-token',
+                servers: mcp.serverNames!.map((name) => ({
+                  name,
+                  url: `http://127.0.0.1:1/${name}`,
+                })),
+              },
+              mcpEnv: {},
+            };
+          },
         }
         : {}),
       auth: {
@@ -677,6 +682,21 @@ describe('pi auto-review dispatch & spawn config (mocked pi process)', () => {
     expect(review).not.toHaveBeenCalled();
     expect(resolverCalls).toBe(0);
     expect(captured.sent).toContainEqual({ type: 'extension_ui_response', id: 'r20', confirmed: true });
+
+    // start_team 获批后 host 会把当前 session 切成 Lead。Pi 必须支持运行时原地合并，
+    // 并让启动时交给 MCP bridge 的同一 vendorOptions 引用立即看到新身份；否则
+    // MakerSession.setVendorOptions 抛 not-implemented，或后续 create_worker 仍读到旧 ctx。
+    expect(handle.setVendorOptions).toBeTypeOf('function');
+    await handle.setVendorOptions?.({
+      orcaRole: 'lead',
+      orcaWorkflowId: 'team-1',
+      orcaLeadSessionId: 's1',
+    });
+    expect(captured.mcpVendorOptions).toMatchObject({
+      orcaRole: 'lead',
+      orcaWorkflowId: 'team-1',
+      orcaLeadSessionId: 's1',
+    });
   });
 
   it('still asks the user for MCP servers the host policy does not trust', async () => {

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -787,6 +787,10 @@ export class PiAgent extends BaseAgent {
       mode === 'bypassPermissions' ? 'bypassPermissions' : mode === 'auto' ? 'auto' : 'ask';
     let permissionMode = normalizePermissionMode(opts.permissionMode);
     let mutableExtraDirs = [...(opts.extraDirs ?? [])];
+    // 与 Claude / Codex 一致，运行期 Orca 身份更新必须原地落在同一个对象上。
+    // Desktop Pi MCP bridge 在 startSession 时持有这个引用；start_team 成功后 host
+    // 调 setVendorOptions，后续 create_worker 等工具才能立即读到最新 Lead 身份。
+    const mutableVendorOptions: Record<string, unknown> = { ...(opts.vendorOptions ?? {}) };
     type PermissionSnapshot = {
       mode: 'ask' | 'auto' | 'bypassPermissions';
       readOnlyRoots: string[];
@@ -933,7 +937,7 @@ export class PiAgent extends BaseAgent {
           sessionId: opts.sessionId,
           ...(opts.sessionInstanceId ? { sessionInstanceId: opts.sessionInstanceId } : {}),
           workingDir: opts.workingDir,
-          vendorOptions: opts.vendorOptions,
+          vendorOptions: mutableVendorOptions,
         });
         mcpBridge = extra?.mcpBridge ?? null;
         mcpEnv = extra?.mcpEnv ?? {};
@@ -1790,6 +1794,11 @@ export class PiAgent extends BaseAgent {
           ...requestedPermissionSnapshot,
           readOnlyRoots: [...dirs],
         });
+      },
+
+      async setVendorOptions(patch: Record<string, unknown>): Promise<void> {
+        Object.assign(mutableVendorOptions, patch);
+        deps.logger.debug('pi setVendorOptions', { patchKeys: Object.keys(patch) });
       },
 
       isTurnRunning(): boolean {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Pi 会话里 `cindy_orca/start_team` 已通过 host 审批后，Orca lifecycle 调用 `MakerSession.setVendorOptions` 却因 Pi 未实现该运行时能力而返回 `Capability 'vendorOptions' not supported (reason: not-implemented)` 的问题。

根因有两层：

1. Pi session handle 没有实现 `setVendorOptions`；
2. Desktop Pi HTTP MCP bridge 在启动时复制了 `vendorOptions`，即使只补 handle，后续 `create_worker` 仍会读到旧的非 Lead 身份。

本 PR 为每个 Pi session 建立私有可变 `vendorOptions`，由 handle 原地合并运行时 patch；Desktop bridge 保持同一对象引用，使 `start_team` 成功后的 Lead 身份立即对既有 MCP session 可见。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1764
- 本 PR 包含：Pi runtime `vendorOptions` 原地更新；Pi MCP bridge 引用保持；批准后 `start_team` → Lead identity 刷新 → 后续 MCP 调用读取最新身份的回归测试。
- 明确不包含：不重做 #1639 的第一方 MCP host 审批策略，不修改权限档、权限卡 UI、Orca 产品契约或其它 harness。
- 用户可见变化：Pi/Grok 会话调用 `start_team` 后可正常创建 team，并继续调用 `create_worker`，不再返回 `vendorOptions not-implemented` INTERNAL。
- 是否存在 breaking change：无。

权限卡调查结论：v0.1.30 已包含 #1597 与 #1639。`cindy_orca/start_team` 是可信第一方 MCP，按现有契约应静默自动批准而不是弹卡；用户早期“未见卡却 denied”对应 #1639 修复前被 Auto-review 静默 block 的历史链，后来错误转为本 issue 的 `vendorOptions` INTERNAL，说明审批已进入新链。本 PR 保持 #1639 行为不变，相关审批、挂起卡收口与 missed-push 快照恢复测试继续通过。其它 Auto reviewer 不可用提示由 #1597 处理，持久 notice 能力仍由 #1603 跟踪。

### UI 变化

不涉及：没有修改组件、布局、样式、交互或 UI 文案。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/pi
结果：14 files passed / 157 tests passed；2 个真实 Pi 集成文件因本机环境条件跳过（37 tests）

pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/pi-auto-review-dispatch.test.ts
结果：32/32 通过

pnpm --filter desktop exec vitest run \
  src/main/mcp-integrations/__tests__/piEnvironment.test.ts \
  src/main/maker-ipc/__tests__/orcaLifecycleService.test.ts \
  src/renderer/__tests__/permissionSessionApproval.test.ts \
  src/renderer/__tests__/deviceLinkInteractionScenarios.test.ts
结果：4 files / 91 tests 全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：该 package 无 typecheck script，按门禁自动跳过

pnpm test:unit
结果：全部 required workspace 通过，0 fail

pnpm check:dco
结果：1 个 commit 已签 DCO

node ~/.agents/skills/git-workflow/scripts/pr-size-gate.mjs
结果：PASS；非测试 +16 行 / 2 文件，测试 +83 行 / 2 文件
```

回归测试在修复前真实打红：Pi handle 缺少 `setVendorOptions`；bridge 只返回启动时 `{ source: 'draft' }`，读不到 `orcaRole/orcaWorkflowId/orcaLeadSessionId`。

### 手工验证

不涉及：本轮未启动真实 Grok Pi 会话；调用链由 Pi handle、HTTP MCP bridge、Orca lifecycle 三层回归测试覆盖。

### 未执行的验证

- 未运行需要本机真实 Pi binary/provider 的集成测试；测试套件按环境条件跳过。
- 未在打包客户端中实机调用 Grok `start_team/create_worker`。
- 发布前验收项：在真实 Grok Pi 会话依次执行 `start_team` → `get_workspace_info` → `create_worker`，确认自动批准契约、Lead 身份刷新与 Worker 创建完整可用。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Pi 会话运行时 Orca 身份同步

### 影响与回滚

- 影响范围：仅 Pi session handle 与 Desktop Pi MCP bridge 的 session-local `vendorOptions` 引用；不改变审批判定、数据库、协议或 UI。
- 回滚 / 降级方式：revert 本 PR 即可；回滚后 Pi `start_team` 会恢复为 `vendorOptions not-implemented`，Claude/Codex 不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码注释与回归测试固定运行时引用契约）
- [x] 已确认测试结果或说明未执行原因
