### PR TITLE
feat(discord): 增加上下线通知设置

### DIFF
--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1666,6 +1666,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         | { kind: 'conflict'; appId: string }
         | { kind: 'error'; reason: string };
       ownerUserId: string | null;
+      lifecycleAnnouncement: boolean;
     }> => ipcRenderer.invoke('discordBot:get-status'),
     setConfig: (payload: {
       token: string;
@@ -1693,6 +1694,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         | { kind: 'conflict'; appId: string }
         | { kind: 'error'; reason: string };
     }> => ipcRenderer.invoke('discordBot:disconnect'),
+    setLifecycleAnnouncement: (enabled: boolean): Promise<{
+      ok: boolean;
+      lifecycleAnnouncement: boolean;
+    }> => ipcRenderer.invoke('discordBot:set-lifecycle-announcement', { enabled }),
     checkSessionAuth: (): Promise<DiscordBotSessionAuthCheckWire> =>
       ipcRenderer.invoke('discordBot:check-session-auth'),
     onStatusChange: fanOutDiscordBotStatusChange,

--- a/apps/desktop/src/renderer/components/settings/DiscordBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/DiscordBotSection.tsx
@@ -7,6 +7,7 @@ import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { useDiscordBot } from '@/hooks/useDiscordBot';
 import { ImChannelSettingsCard, useImChannelSettingsSummary } from './ImChannelSettingsCard';
 import { ImDefaultSettingsSection } from './ImDefaultSettingsSection';
+import { ImLifecycleAnnouncementSection } from './ImLifecycleAnnouncementSection';
 
 const DISCORD_DEVELOPER_PORTAL_URL = 'https://discord.com/developers/applications';
 
@@ -49,6 +50,8 @@ export function DiscordBotSection({
     ownerUserId,
     setOwnerUserId,
     status,
+    lifecycleAnnouncement,
+    setLifecycleAnnouncement,
     validationError,
     isSaving,
     isDisconnecting,
@@ -263,6 +266,19 @@ export function DiscordBotSection({
               : t('settings.discordBot.connect')}
           </button>
         </div>
+      )}
+
+      {hasSavedCreds && (
+        <>
+          <div className="h-px w-full bg-[var(--border-default)]" />
+          <ImLifecycleAnnouncementSection
+            label={t('settings.discordBot.lifecycleAnnouncement.label')}
+            cellLabel={t('settings.discordBot.lifecycleAnnouncement.cellLabel')}
+            hint={t('settings.discordBot.lifecycleAnnouncement.hint')}
+            checked={lifecycleAnnouncement}
+            onCheckedChange={setLifecycleAnnouncement}
+          />
+        </>
       )}
 
       <div className="border-t border-[var(--settings-theme-card-border)] pt-3">

--- a/apps/desktop/src/renderer/components/settings/FeishuBotNotificationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/FeishuBotNotificationSection.tsx
@@ -1,8 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
-import { cn } from '@/lib/utils';
-import { Switch } from '@/components/ui/switch';
 import { useFeishuBot } from '@/hooks/useFeishuBot';
+import { ImLifecycleAnnouncementSection } from './ImLifecycleAnnouncementSection';
 
 export function FeishuBotNotificationSection() {
   const {
@@ -15,36 +14,12 @@ export function FeishuBotNotificationSection() {
   if (!hasSavedCreds) return null;
 
   return (
-    <div className="flex flex-col gap-[14px]">
-      <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
-        {t('settings.feishuBot.lifecycleAnnouncement.label')}
-      </h2>
-
-      <div
-        className={cn(
-          'flex items-center justify-between gap-3 rounded-xl p-5',
-          'bg-[var(--settings-theme-card-bg)]',
-          'border border-[var(--settings-theme-card-border)]',
-        )}
-      >
-        <div className="flex min-w-0 flex-col gap-1">
-          <p
-            className="text-13 font-medium text-[var(--settings-section-sublabel)]"
-            style={{ letterSpacing: '0.12px' }}
-          >
-            {t('settings.feishuBot.lifecycleAnnouncement.cellLabel')}
-          </p>
-          <p className="text-12 leading-[1.4] text-[var(--settings-section-sublabel)] opacity-70">
-            {t('settings.feishuBot.lifecycleAnnouncement.hint')}
-          </p>
-        </div>
-
-        <Switch
-          checked={lifecycleAnnouncement}
-          onCheckedChange={setLifecycleAnnouncement}
-          aria-label={t('settings.feishuBot.lifecycleAnnouncement.label')}
-        />
-      </div>
-    </div>
+    <ImLifecycleAnnouncementSection
+      label={t('settings.feishuBot.lifecycleAnnouncement.label')}
+      cellLabel={t('settings.feishuBot.lifecycleAnnouncement.cellLabel')}
+      hint={t('settings.feishuBot.lifecycleAnnouncement.hint')}
+      checked={lifecycleAnnouncement}
+      onCheckedChange={setLifecycleAnnouncement}
+    />
   );
 }

--- a/apps/desktop/src/renderer/components/settings/ImLifecycleAnnouncementSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImLifecycleAnnouncementSection.tsx
@@ -1,0 +1,44 @@
+import { Switch } from '@/components/ui/switch';
+import { cn } from '@/lib/utils';
+
+export function ImLifecycleAnnouncementSection(props: {
+  label: string;
+  cellLabel: string;
+  hint: string;
+  checked: boolean;
+  onCheckedChange: (enabled: boolean) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-[14px]">
+      <h2 className="select-none text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
+        {props.label}
+      </h2>
+
+      <div
+        className={cn(
+          'flex items-center justify-between gap-3 rounded-xl p-5',
+          'bg-[var(--settings-theme-card-bg)]',
+          'border border-[var(--settings-theme-card-border)]',
+        )}
+      >
+        <div className="flex min-w-0 select-none flex-col gap-1">
+          <p
+            className="text-13 font-medium text-[var(--settings-section-sublabel)]"
+            style={{ letterSpacing: '0.12px' }}
+          >
+            {props.cellLabel}
+          </p>
+          <p className="text-12 leading-[1.4] text-[var(--settings-section-sublabel)] opacity-70">
+            {props.hint}
+          </p>
+        </div>
+
+        <Switch
+          checked={props.checked}
+          onCheckedChange={props.onCheckedChange}
+          aria-label={props.label}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
@@ -27,10 +27,17 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
-function installDiscordApi(status: DiscordBotTransportStatus = { kind: 'idle' }) {
+function installDiscordApi(
+  status: DiscordBotTransportStatus = { kind: 'idle' },
+  lifecycleAnnouncement = true,
+) {
   const listeners = new Set<(update: { status: DiscordBotTransportStatus }) => void>();
   const api = {
-    getStatus: vi.fn(async () => ({ status, ownerUserId: '12345678901234567' })),
+    getStatus: vi.fn(async () => ({
+      status,
+      ownerUserId: '12345678901234567',
+      lifecycleAnnouncement,
+    })),
     setConfig: vi.fn(async (payload: { token: string; ownerUserId: string }) => ({
       status: { kind: 'connecting' } as DiscordBotTransportStatus,
       saveErrorStatus: undefined as DiscordBotTransportStatus | undefined,
@@ -38,6 +45,10 @@ function installDiscordApi(status: DiscordBotTransportStatus = { kind: 'idle' })
       payload,
     })),
     disconnect: vi.fn(async () => ({ status: { kind: 'idle' } as DiscordBotTransportStatus })),
+    setLifecycleAnnouncement: vi.fn(async (enabled: boolean) => ({
+      ok: true,
+      lifecycleAnnouncement: enabled,
+    })),
     onStatusChange: vi.fn((cb: (update: { status: DiscordBotTransportStatus }) => void) => {
       listeners.add(cb);
       return () => listeners.delete(cb);
@@ -145,5 +156,19 @@ describe('useDiscordBot', () => {
     expect(result.current.token).toBe('');
     expect(result.current.ownerUserId).toBe('');
     expect(result.current.status.kind).toBe('idle');
+  });
+
+  it('loads and updates the lifecycle announcement preference', async () => {
+    const api = installDiscordApi({ kind: 'connected', appId: 'MakerBot#1234' }, false);
+    const { result } = renderHook(() => useDiscordBot());
+
+    await waitFor(() => expect(result.current.lifecycleAnnouncement).toBe(false));
+
+    act(() => {
+      result.current.setLifecycleAnnouncement(true);
+    });
+
+    expect(result.current.lifecycleAnnouncement).toBe(true);
+    expect(api.setLifecycleAnnouncement).toHaveBeenCalledWith(true);
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
@@ -30,14 +30,21 @@ vi.mock('@/lib/logger', () => ({
 function installDiscordApi(
   status: DiscordBotTransportStatus = { kind: 'idle' },
   lifecycleAnnouncement = true,
+  getStatusOverride?: () => Promise<{
+    status: DiscordBotTransportStatus;
+    ownerUserId: string | null;
+    lifecycleAnnouncement: boolean;
+  }>,
 ) {
   const listeners = new Set<(update: { status: DiscordBotTransportStatus }) => void>();
   const api = {
-    getStatus: vi.fn(async () => ({
-      status,
-      ownerUserId: '12345678901234567',
-      lifecycleAnnouncement,
-    })),
+    getStatus: vi.fn(
+      getStatusOverride ?? (async () => ({
+        status,
+        ownerUserId: '12345678901234567',
+        lifecycleAnnouncement,
+      })),
+    ),
     setConfig: vi.fn(async (payload: { token: string; ownerUserId: string }) => ({
       status: { kind: 'connecting' } as DiscordBotTransportStatus,
       saveErrorStatus: undefined as DiscordBotTransportStatus | undefined,
@@ -166,6 +173,45 @@ describe('useDiscordBot', () => {
 
     act(() => {
       result.current.setLifecycleAnnouncement(true);
+    });
+
+    expect(result.current.lifecycleAnnouncement).toBe(true);
+    expect(api.setLifecycleAnnouncement).toHaveBeenCalledWith(true);
+  });
+
+  it('does not let an in-flight status read overwrite a newer lifecycle toggle', async () => {
+    let resolveStatus!: (value: {
+      status: DiscordBotTransportStatus;
+      ownerUserId: string | null;
+      lifecycleAnnouncement: boolean;
+    }) => void;
+    const statusPromise = new Promise<{
+      status: DiscordBotTransportStatus;
+      ownerUserId: string | null;
+      lifecycleAnnouncement: boolean;
+    }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    const api = installDiscordApi(
+      { kind: 'connected', appId: 'MakerBot#1234' },
+      false,
+      () => statusPromise,
+    );
+    const { result } = renderHook(() => useDiscordBot());
+
+    await waitFor(() => expect(api.getStatus).toHaveBeenCalled());
+    act(() => {
+      result.current.setLifecycleAnnouncement(true);
+    });
+
+    await act(async () => {
+      resolveStatus({
+        status: { kind: 'connected', appId: 'MakerBot#1234' },
+        ownerUserId: '12345678901234567',
+        lifecycleAnnouncement: false,
+      });
+      await statusPromise;
+      await Promise.resolve();
     });
 
     expect(result.current.lifecycleAnnouncement).toBe(true);

--- a/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
@@ -179,7 +179,7 @@ describe('useDiscordBot', () => {
     expect(api.setLifecycleAnnouncement).toHaveBeenCalledWith(true);
   });
 
-  it('does not let an in-flight status read overwrite a newer lifecycle toggle', async () => {
+  it('preserves a newer lifecycle toggle in cache after an in-flight status read resolves', async () => {
     let resolveStatus!: (value: {
       status: DiscordBotTransportStatus;
       ownerUserId: string | null;
@@ -192,29 +192,36 @@ describe('useDiscordBot', () => {
     }>((resolve) => {
       resolveStatus = resolve;
     });
-    const api = installDiscordApi(
-      { kind: 'connected', appId: 'MakerBot#1234' },
-      false,
-      () => statusPromise,
-    );
-    const { result } = renderHook(() => useDiscordBot());
+    const api = installDiscordApi();
+    const hydrated = renderHook(() => useDiscordBot());
 
-    await waitFor(() => expect(api.getStatus).toHaveBeenCalled());
+    await waitFor(() => expect(hydrated.result.current.ownerUserId).toBe('12345678901234567'));
+    hydrated.unmount();
+
+    api.getStatus.mockReturnValueOnce(statusPromise);
+    const current = renderHook(() => useDiscordBot());
+
+    await waitFor(() => expect(api.getStatus).toHaveBeenCalledTimes(2));
     act(() => {
-      result.current.setLifecycleAnnouncement(true);
+      current.result.current.setLifecycleAnnouncement(false);
     });
 
     await act(async () => {
       resolveStatus({
         status: { kind: 'connected', appId: 'MakerBot#1234' },
         ownerUserId: '12345678901234567',
-        lifecycleAnnouncement: false,
+        lifecycleAnnouncement: true,
       });
       await statusPromise;
       await Promise.resolve();
     });
 
-    expect(result.current.lifecycleAnnouncement).toBe(true);
-    expect(api.setLifecycleAnnouncement).toHaveBeenCalledWith(true);
+    expect(current.result.current.lifecycleAnnouncement).toBe(false);
+    expect(api.setLifecycleAnnouncement).toHaveBeenCalledWith(false);
+    current.unmount();
+
+    api.getStatus.mockImplementationOnce(() => new Promise(() => {}));
+    const remounted = renderHook(() => useDiscordBot());
+    expect(remounted.result.current.lifecycleAnnouncement).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useDiscordBot.test.ts
@@ -27,6 +27,16 @@ vi.mock('@/lib/logger', () => ({
   }),
 }));
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function installDiscordApi(
   status: DiscordBotTransportStatus = { kind: 'idle' },
   lifecycleAnnouncement = true,
@@ -220,6 +230,77 @@ describe('useDiscordBot', () => {
     expect(api.setLifecycleAnnouncement).toHaveBeenCalledWith(false);
     current.unmount();
 
+    api.getStatus.mockImplementationOnce(() => new Promise(() => {}));
+    const remounted = renderHook(() => useDiscordBot());
+    expect(remounted.result.current.lifecycleAnnouncement).toBe(false);
+  });
+
+  it('preserves a newer lifecycle toggle in cache after an in-flight connect resolves', async () => {
+    const api = installDiscordApi();
+    const connectResult = deferred<{
+      status: DiscordBotTransportStatus;
+      saveErrorStatus: DiscordBotTransportStatus | undefined;
+      ownerUserId: string;
+      payload: { token: string; ownerUserId: string };
+    }>();
+    api.setConfig.mockReturnValueOnce(connectResult.promise);
+    const current = renderHook(() => useDiscordBot());
+
+    await waitFor(() => expect(current.result.current.ownerUserId).toBe('12345678901234567'));
+    act(() => {
+      current.result.current.setToken('bot-token');
+    });
+
+    let pendingConnect!: Promise<boolean>;
+    act(() => {
+      pendingConnect = current.result.current.connect();
+    });
+    await waitFor(() => expect(api.setConfig).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      current.result.current.setLifecycleAnnouncement(false);
+    });
+
+    await act(async () => {
+      connectResult.resolve({
+        status: { kind: 'connected', appId: 'MakerBot#1234' },
+        saveErrorStatus: undefined,
+        ownerUserId: '12345678901234567',
+        payload: { token: 'bot-token', ownerUserId: '12345678901234567' },
+      });
+      await pendingConnect;
+    });
+
+    current.unmount();
+    api.getStatus.mockImplementationOnce(() => new Promise(() => {}));
+    const remounted = renderHook(() => useDiscordBot());
+    expect(remounted.result.current.lifecycleAnnouncement).toBe(false);
+  });
+
+  it('preserves a newer lifecycle toggle in cache after an in-flight disconnect resolves', async () => {
+    const api = installDiscordApi({ kind: 'connected', appId: 'MakerBot#1234' });
+    const disconnectResult = deferred<{ status: DiscordBotTransportStatus }>();
+    api.disconnect.mockReturnValueOnce(disconnectResult.promise);
+    const current = renderHook(() => useDiscordBot());
+
+    await waitFor(() => expect(current.result.current.status.kind).toBe('connected'));
+
+    let pendingDisconnect!: Promise<void>;
+    act(() => {
+      pendingDisconnect = current.result.current.disconnect();
+    });
+    await waitFor(() => expect(api.disconnect).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      current.result.current.setLifecycleAnnouncement(false);
+    });
+
+    await act(async () => {
+      disconnectResult.resolve({ status: { kind: 'idle' } });
+      await pendingDisconnect;
+    });
+
+    current.unmount();
     api.getStatus.mockImplementationOnce(() => new Promise(() => {}));
     const remounted = renderHook(() => useDiscordBot());
     expect(remounted.result.current.lifecycleAnnouncement).toBe(false);

--- a/apps/desktop/src/renderer/hooks/useDiscordBot.ts
+++ b/apps/desktop/src/renderer/hooks/useDiscordBot.ts
@@ -152,7 +152,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
       cachedState = {
         ownerUserId: canonicalOwnerUserId,
         status: result.status,
-        lifecycleAnnouncement,
+        lifecycleAnnouncement: cachedState?.lifecycleAnnouncement ?? lifecycleAnnouncement,
       };
       if (result.saveErrorStatus?.kind === 'error' || result.status.kind === 'error') {
         toast.error(t('logic.toasts.discordBotConnectFailed'));
@@ -182,7 +182,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
       cachedState = {
         ownerUserId: '',
         status: result.status,
-        lifecycleAnnouncement,
+        lifecycleAnnouncement: cachedState?.lifecycleAnnouncement ?? lifecycleAnnouncement,
       };
       toast.success(t('logic.toasts.discordBotDisconnected'));
     } catch (err) {

--- a/apps/desktop/src/renderer/hooks/useDiscordBot.ts
+++ b/apps/desktop/src/renderer/hooks/useDiscordBot.ts
@@ -66,7 +66,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
           status: state.status,
           lifecycleAnnouncement: lifecycleReadIsCurrent
             ? nextLifecycleAnnouncement
-            : (cachedState?.lifecycleAnnouncement ?? lifecycleAnnouncement),
+            : (cachedState?.lifecycleAnnouncement ?? true),
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/apps/desktop/src/renderer/hooks/useDiscordBot.ts
+++ b/apps/desktop/src/renderer/hooks/useDiscordBot.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { toast } from '@/lib/toast';
@@ -10,6 +10,7 @@ const OWNER_USER_ID_PATTERN = /^\d{17,20}$/;
 interface DiscordBotCache {
   ownerUserId: string;
   status: DiscordBotTransportStatus;
+  lifecycleAnnouncement: boolean;
 }
 
 let cachedState: DiscordBotCache | null = null;
@@ -20,6 +21,8 @@ export interface UseDiscordBotReturn {
   ownerUserId: string;
   setOwnerUserId: (v: string) => void;
   status: DiscordBotTransportStatus;
+  lifecycleAnnouncement: boolean;
+  setLifecycleAnnouncement: (enabled: boolean) => void;
   validationError: string | null;
   isSaving: boolean;
   isDisconnecting: boolean;
@@ -35,9 +38,13 @@ export function useDiscordBot(): UseDiscordBotReturn {
   const [status, setStatus] = useState<DiscordBotTransportStatus>(
     () => cachedState?.status ?? { kind: 'idle' },
   );
+  const [lifecycleAnnouncement, setLifecycleAnnouncementState] = useState(
+    () => cachedState?.lifecycleAnnouncement ?? true,
+  );
   const [validationError, setValidationError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const lifecycleRequestVersionRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -46,11 +53,14 @@ export function useDiscordBot(): UseDiscordBotReturn {
         const state = await window.electronAPI.discordBot.getStatus();
         if (cancelled) return;
         const nextOwnerUserId = state.ownerUserId ?? '';
+        const nextLifecycleAnnouncement = state.lifecycleAnnouncement !== false;
         setStatus(state.status);
         setOwnerUserIdState(nextOwnerUserId);
+        setLifecycleAnnouncementState(nextLifecycleAnnouncement);
         cachedState = {
           ownerUserId: nextOwnerUserId,
           status: state.status,
+          lifecycleAnnouncement: nextLifecycleAnnouncement,
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -68,6 +78,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
       cachedState = {
         ownerUserId: cachedState?.ownerUserId ?? '',
         status: update.status,
+        lifecycleAnnouncement: cachedState?.lifecycleAnnouncement ?? true,
       };
     });
     return unsub;
@@ -82,6 +93,31 @@ export function useDiscordBot(): UseDiscordBotReturn {
     setOwnerUserIdState(v);
     setValidationError(null);
   }, []);
+
+  const setLifecycleAnnouncement = useCallback((enabled: boolean) => {
+    const previous = lifecycleAnnouncement;
+    const requestVersion = ++lifecycleRequestVersionRef.current;
+    setLifecycleAnnouncementState(enabled);
+    cachedState = {
+      ownerUserId: cachedState?.ownerUserId ?? '',
+      status: cachedState?.status ?? { kind: 'idle' },
+      lifecycleAnnouncement: enabled,
+    };
+    void window.electronAPI.discordBot.setLifecycleAnnouncement(enabled).then((result) => {
+      if (requestVersion !== lifecycleRequestVersionRef.current) return;
+      if (result.ok && result.lifecycleAnnouncement === enabled) return;
+      setLifecycleAnnouncementState(result.lifecycleAnnouncement);
+      if (cachedState) {
+        cachedState = { ...cachedState, lifecycleAnnouncement: result.lifecycleAnnouncement };
+      }
+    }).catch((err) => {
+      if (requestVersion !== lifecycleRequestVersionRef.current) return;
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error('setLifecycleAnnouncement failed:', msg);
+      setLifecycleAnnouncementState(previous);
+      if (cachedState) cachedState = { ...cachedState, lifecycleAnnouncement: previous };
+    });
+  }, [lifecycleAnnouncement]);
 
   const connect = useCallback(async () => {
     if (isSaving) return false;
@@ -110,6 +146,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
       cachedState = {
         ownerUserId: canonicalOwnerUserId,
         status: result.status,
+        lifecycleAnnouncement,
       };
       if (result.saveErrorStatus?.kind === 'error' || result.status.kind === 'error') {
         toast.error(t('logic.toasts.discordBotConnectFailed'));
@@ -125,7 +162,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
     } finally {
       setIsSaving(false);
     }
-  }, [isSaving, ownerUserId, t, token]);
+  }, [isSaving, lifecycleAnnouncement, ownerUserId, t, token]);
 
   const disconnect = useCallback(async () => {
     if (isDisconnecting) return;
@@ -139,6 +176,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
       cachedState = {
         ownerUserId: '',
         status: result.status,
+        lifecycleAnnouncement,
       };
       toast.success(t('logic.toasts.discordBotDisconnected'));
     } catch (err) {
@@ -148,7 +186,7 @@ export function useDiscordBot(): UseDiscordBotReturn {
     } finally {
       setIsDisconnecting(false);
     }
-  }, [isDisconnecting, t]);
+  }, [isDisconnecting, lifecycleAnnouncement, t]);
 
   const canConnect =
     token.trim().length > 0 &&
@@ -162,6 +200,8 @@ export function useDiscordBot(): UseDiscordBotReturn {
     ownerUserId,
     setOwnerUserId,
     status,
+    lifecycleAnnouncement,
+    setLifecycleAnnouncement,
     validationError,
     isSaving,
     isDisconnecting,

--- a/apps/desktop/src/renderer/hooks/useDiscordBot.ts
+++ b/apps/desktop/src/renderer/hooks/useDiscordBot.ts
@@ -48,19 +48,25 @@ export function useDiscordBot(): UseDiscordBotReturn {
 
   useEffect(() => {
     let cancelled = false;
+    const lifecycleReadVersion = lifecycleRequestVersionRef.current;
     void (async () => {
       try {
         const state = await window.electronAPI.discordBot.getStatus();
         if (cancelled) return;
         const nextOwnerUserId = state.ownerUserId ?? '';
         const nextLifecycleAnnouncement = state.lifecycleAnnouncement !== false;
+        const lifecycleReadIsCurrent = lifecycleReadVersion === lifecycleRequestVersionRef.current;
         setStatus(state.status);
         setOwnerUserIdState(nextOwnerUserId);
-        setLifecycleAnnouncementState(nextLifecycleAnnouncement);
+        if (lifecycleReadIsCurrent) {
+          setLifecycleAnnouncementState(nextLifecycleAnnouncement);
+        }
         cachedState = {
           ownerUserId: nextOwnerUserId,
           status: state.status,
-          lifecycleAnnouncement: nextLifecycleAnnouncement,
+          lifecycleAnnouncement: lifecycleReadIsCurrent
+            ? nextLifecycleAnnouncement
+            : (cachedState?.lifecycleAnnouncement ?? lifecycleAnnouncement),
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1833,6 +1833,11 @@
         "confirm": "Unbind",
         "cancel": "Cancel"
       },
+      "lifecycleAnnouncement": {
+        "label": "Online/Offline Notifications",
+        "cellLabel": "Message Notifications",
+        "hint": "Have the Discord Bot send a message when this device goes online or offline"
+      },
       "ownerNotice": {
         "linked": "✅ All linked. Just send a message when you're ready.",
         "disconnected": "🔌 Unlinked. Link again whenever you need me.",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1832,6 +1832,11 @@
         "confirm": "連携解除",
         "cancel": "キャンセル"
       },
+      "lifecycleAnnouncement": {
+        "label": "オンライン・オフライン通知",
+        "cellLabel": "メッセージ通知",
+        "hint": "このデバイスのオンライン・オフライン時に Discord Bot から通知メッセージを送信します"
+      },
       "ownerNotice": {
         "linked": "✅ 連携できました。準備できたらそのまま話しかけてください。",
         "disconnected": "🔌 連携を解除しました。必要になったらまたつないでください。",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1832,6 +1832,11 @@
         "confirm": "연동 해제",
         "cancel": "취소"
       },
+      "lifecycleAnnouncement": {
+        "label": "온라인/오프라인 알림",
+        "cellLabel": "메시지 알림",
+        "hint": "이 기기가 온라인 또는 오프라인 상태가 되면 Discord Bot이 알림 메시지를 보냅니다"
+      },
       "ownerNotice": {
         "linked": "✅ 연동됐어요. 준비되면 바로 말을 걸어 주세요.",
         "disconnected": "🔌 연동을 해제했어요. 필요할 때 다시 연결하면 됩니다.",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1832,6 +1832,11 @@
         "confirm": "解绑",
         "cancel": "取消"
       },
+      "lifecycleAnnouncement": {
+        "label": "上下线通知",
+        "cellLabel": "消息通知",
+        "hint": "上下线时由 Discord Bot 发送通知消息"
+      },
       "ownerNotice": {
         "linked": "✅ 关联好啦，直接开聊就行~",
         "disconnected": "🔌 已断开关联啦，需要时再连上就行~",

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1894,6 +1894,7 @@ interface ElectronAPI {
     getStatus: () => Promise<{
       status: DiscordBotTransportStatus;
       ownerUserId: string | null;
+      lifecycleAnnouncement: boolean;
     }>;
     setConfig: (payload: { token: string; ownerUserId: string }) => Promise<{
       status: DiscordBotTransportStatus;
@@ -1902,6 +1903,10 @@ interface ElectronAPI {
     }>;
     disconnect: () => Promise<{
       status: DiscordBotTransportStatus;
+    }>;
+    setLifecycleAnnouncement: (enabled: boolean) => Promise<{
+      ok: boolean;
+      lifecycleAnnouncement: boolean;
     }>;
     checkSessionAuth: () => Promise<DiscordBotSessionAuthCheckResult>;
     onStatusChange: (

--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -297,6 +297,72 @@ describe('DiscordIM inbound pipeline', () => {
     });
   });
 
+  it('reads the persisted lifecycle preference from IPC before init', async () => {
+    const host = makeHost({
+      initialSecrets: [['discord-bot-lifecycle-announcement', 'false']],
+    });
+    const readSecret = vi.spyOn(host.secrets, 'read');
+    const im = new DiscordIM(host);
+
+    expect(readSecret).not.toHaveBeenCalled();
+
+    im.registerIpc();
+
+    await expect(host.invoke('discordBot:get-status')).resolves.toMatchObject({
+      lifecycleAnnouncement: false,
+    });
+    expect(readSecret).toHaveBeenCalledWith('discord-bot-lifecycle-announcement');
+  });
+
+  it('rolls back a pre-init lifecycle write failure to the persisted preference', async () => {
+    const host = makeHost({
+      initialSecrets: [['discord-bot-lifecycle-announcement', 'false']],
+      write: (name, value, secrets) => {
+        if (name === 'discord-bot-lifecycle-announcement') return false;
+        secrets.set(name, value);
+        return true;
+      },
+    });
+    const im = new DiscordIM(host);
+    im.registerIpc();
+
+    await expect(
+      host.invoke('discordBot:set-lifecycle-announcement', { enabled: true }),
+    ).resolves.toEqual({
+      ok: false,
+      lifecycleAnnouncement: false,
+    });
+    expect(host.readSecret('discord-bot-lifecycle-announcement')).toBe('false');
+  });
+
+  it('rolls back a post-init lifecycle write failure to the persisted preference', async () => {
+    let rejectLifecycleWrites = false;
+    const host = makeHost({
+      initialSecrets: [['discord-bot-lifecycle-announcement', 'false']],
+      write: (name, value, secrets) => {
+        if (name === 'discord-bot-lifecycle-announcement' && rejectLifecycleWrites) return false;
+        secrets.set(name, value);
+        return true;
+      },
+    });
+    const im = new DiscordIM(host);
+    im.registerIpc();
+    await im.init();
+
+    // Simulate the active account's persisted preference changing after init,
+    // leaving the runtime cache stale until the next explicit lifecycle load.
+    expect(host.secrets.write('discord-bot-lifecycle-announcement', 'true')).toBe(true);
+    rejectLifecycleWrites = true;
+
+    await expect(
+      host.invoke('discordBot:set-lifecycle-announcement', { enabled: false }),
+    ).resolves.toEqual({
+      ok: false,
+      lifecycleAnnouncement: true,
+    });
+    expect(host.readSecret('discord-bot-lifecycle-announcement')).toBe('true');
+  });
+
   it('silently drops non-owner DM messages', async () => {
     const gateway = makeGateway();
     const im = new DiscordIM(makeHost(), {

--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -279,6 +279,24 @@ describe('DiscordIM inbound pipeline', () => {
     );
   });
 
+  it('defers lifecycle preference reads until explicit init', async () => {
+    const host = makeHost({
+      initialSecrets: [['discord-bot-lifecycle-announcement', 'false']],
+    });
+    const readSecret = vi.spyOn(host.secrets, 'read');
+    const im = new DiscordIM(host);
+
+    expect(readSecret).not.toHaveBeenCalled();
+
+    im.registerIpc();
+    await im.init();
+
+    expect(readSecret).toHaveBeenCalledWith('discord-bot-lifecycle-announcement');
+    await expect(host.invoke('discordBot:get-status')).resolves.toMatchObject({
+      lifecycleAnnouncement: false,
+    });
+  });
+
   it('silently drops non-owner DM messages', async () => {
     const gateway = makeGateway();
     const im = new DiscordIM(makeHost(), {
@@ -891,6 +909,7 @@ describe('DiscordIM inbound pipeline', () => {
     });
     const im = new DiscordIM(host);
     im.registerIpc();
+    await im.init();
 
     await expect(host.invoke('discordBot:set-lifecycle-announcement', {}))
       .rejects.toThrow('[INVALID_PARAMS] enabled must be a boolean');

--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -762,6 +762,7 @@ describe('DiscordIM inbound pipeline', () => {
       },
     });
 
+    im.registerIpc();
     await im.init();
     await flushMicrotasks();
 
@@ -882,6 +883,61 @@ describe('DiscordIM inbound pipeline', () => {
       'localized:disconnected',
     ]);
     expect(host.readSecret('discord-bot-lifecycle-announcement')).toBe('false');
+  });
+
+  it('rejects an invalid lifecycle announcement payload without changing the preference', async () => {
+    const host = makeHost({
+      initialSecrets: [['discord-bot-lifecycle-announcement', 'false']],
+    });
+    const im = new DiscordIM(host);
+    im.registerIpc();
+
+    await expect(host.invoke('discordBot:set-lifecycle-announcement', {}))
+      .rejects.toThrow('[INVALID_PARAMS] enabled must be a boolean');
+    await expect(host.invoke('discordBot:get-status')).resolves.toMatchObject({
+      lifecycleAnnouncement: false,
+    });
+    expect(host.readSecret('discord-bot-lifecycle-announcement')).toBe('false');
+  });
+
+  it('does not leave a dirty runtime marker when an in-flight offline notice is invalidated', async () => {
+    const offlineStarted = deferred();
+    const releaseOffline = deferred();
+    const channel = makeChannel('dm-1');
+    channel.send
+      .mockResolvedValueOnce({ id: 'm-online' })
+      .mockImplementationOnce(async (payload: unknown) => {
+        expect(payload).toBe('localized:offline');
+        offlineStarted.resolve();
+        await releaseOffline.promise;
+        return { id: 'm-offline' };
+      });
+    const gateway = makeGateway({ client: makeClient(channel) });
+    gateway.connect.mockImplementationOnce(async () => {
+      gateway.emitStatus({ kind: 'connected', appId: 'bot#0000' });
+    });
+    const host = makeHost();
+    const im = new DiscordIM(host, {
+      ownerNoticeText: (phase) => `localized:${phase}`,
+      gatewayFactory: (handlers) => {
+        gateway.setHandlers(handlers);
+        return gateway;
+      },
+    });
+
+    im.registerIpc();
+    await im.init();
+    await flushMicrotasks();
+    expect(host.readSecret('discord-bot-runtime-active')).toBeTruthy();
+
+    const disposing = im.dispose();
+    await offlineStarted.promise;
+    await host.invoke('discordBot:set-lifecycle-announcement', { enabled: false });
+    await host.invoke('discordBot:set-lifecycle-announcement', { enabled: true });
+    releaseOffline.resolve();
+    await disposing;
+
+    expect(host.readSecret('discord-bot-runtime-active')).toBeNull();
   });
 
   it('does not repeat runtime online notice on transient gateway reconnect', async () => {

--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -769,6 +769,121 @@ describe('DiscordIM inbound pipeline', () => {
     expect(host.readSecret('discord-bot-runtime-active')).toBeTruthy();
   });
 
+  it('suppresses all lifecycle notices and clears a dirty marker when disabled', async () => {
+    const channel = makeChannel('dm-1');
+    const gateway = makeGateway({ client: makeClient(channel) });
+    gateway.connect.mockImplementationOnce(async () => {
+      gateway.emitStatus({ kind: 'connected', appId: 'bot#0000' });
+    });
+    const host = makeHost({
+      initialSecrets: [
+        ['discord-bot-token', 'token'],
+        ['discord-owner-user-id', 'user-1'],
+        ['discord-bot-runtime-active', 'previous-run'],
+        ['discord-bot-lifecycle-announcement', 'false'],
+      ],
+    });
+    const im = new DiscordIM(host, {
+      ownerNoticeText: (phase) => `localized:${phase}`,
+      gatewayFactory: (handlers) => {
+        gateway.setHandlers(handlers);
+        return gateway;
+      },
+    });
+
+    im.registerIpc();
+    await im.init();
+    await flushMicrotasks();
+    await im.dispose();
+
+    expect(channel.send).not.toHaveBeenCalled();
+    expect(host.readSecret('discord-bot-runtime-active')).toBeNull();
+    await expect(host.invoke('discordBot:get-status')).resolves.toMatchObject({
+      lifecycleAnnouncement: false,
+    });
+  });
+
+  it('invalidates a queued dirty-runtime notice when lifecycle announcements are disabled', async () => {
+    const fetchStarted = deferred();
+    const releaseFetch = deferred();
+    const channel = makeChannel('dm-1');
+    const client = {
+      users: {
+        fetch: vi.fn(async () => {
+          fetchStarted.resolve();
+          await releaseFetch.promise;
+          return { createDM: vi.fn(async () => channel) };
+        }),
+      },
+    };
+    const gateway = makeGateway({ client });
+    gateway.connect.mockImplementationOnce(async () => {
+      gateway.emitStatus({ kind: 'connected', appId: 'bot#0000' });
+    });
+    const host = makeHost({
+      initialSecrets: [
+        ['discord-bot-token', 'token'],
+        ['discord-owner-user-id', 'user-1'],
+        ['discord-bot-runtime-active', 'previous-run'],
+      ],
+    });
+    const im = new DiscordIM(host, {
+      ownerNoticeText: (phase) => `localized:${phase}`,
+      gatewayFactory: (handlers) => {
+        gateway.setHandlers(handlers);
+        return gateway;
+      },
+    });
+
+    im.registerIpc();
+    await im.init();
+    await fetchStarted.promise;
+
+    await host.invoke('discordBot:set-lifecycle-announcement', { enabled: false });
+    expect(host.readSecret('discord-bot-lifecycle-announcement')).toBe('false');
+    releaseFetch.resolve();
+    await flushMicrotasks();
+    await im.dispose();
+
+    expect(channel.send).not.toHaveBeenCalled();
+    expect(host.readSecret('discord-bot-runtime-active')).toBeNull();
+  });
+
+  it('keeps linked and disconnected confirmations enabled when lifecycle notices are disabled', async () => {
+    const channel = makeChannel('dm-1');
+    const gateway = makeGateway({ client: makeClient(channel) });
+    gateway.connect.mockImplementationOnce(async () => {
+      gateway.emitStatus({ kind: 'connected', appId: 'bot#0000' });
+    });
+    const host = makeHost({
+      initialSecrets: [
+        ['discord-bot-token', 'token'],
+        ['discord-owner-user-id', 'user-1'],
+        ['discord-bot-lifecycle-announcement', 'false'],
+      ],
+    });
+    const im = new DiscordIM(host, {
+      ownerNoticeText: (phase) => `localized:${phase}`,
+      gatewayFactory: (handlers) => {
+        gateway.setHandlers(handlers);
+        return gateway;
+      },
+    });
+
+    im.registerIpc();
+    await host.invoke('discordBot:set-config', {
+      token: 'new-token',
+      ownerUserId: 'user-1',
+    });
+    await host.invoke('discordBot:disconnect');
+
+    expect(channel.send.mock.calls.map(([payload]) => payload)).toEqual([
+      'localized:linked',
+      'localized:disconnected',
+    ]);
+    expect(host.readSecret('discord-bot-lifecycle-announcement')).toBe('false');
+  });
+
   it('does not repeat runtime online notice on transient gateway reconnect', async () => {
     const channel = makeChannel('dm-1');
     const gateway = makeGateway({ client: makeClient(channel) });
@@ -1666,6 +1781,7 @@ describe('DiscordIM inbound pipeline', () => {
         appId: 'bot#0000',
       },
       ownerUserId: 'user-1',
+      lifecycleAnnouncement: true,
     });
   });
 });

--- a/packages/lizi-im/src/discord/__tests__/inbound.test.ts
+++ b/packages/lizi-im/src/discord/__tests__/inbound.test.ts
@@ -944,6 +944,7 @@ describe('DiscordIM inbound pipeline', () => {
       initialSecrets: [
         ['discord-bot-token', 'token'],
         ['discord-owner-user-id', 'user-1'],
+        ['discord-bot-runtime-active', 'previous-run'],
         ['discord-bot-lifecycle-announcement', 'false'],
       ],
     });
@@ -960,6 +961,8 @@ describe('DiscordIM inbound pipeline', () => {
       token: 'new-token',
       ownerUserId: 'user-1',
     });
+
+    expect(host.readSecret('discord-bot-runtime-active')).toBeNull();
     await host.invoke('discordBot:disconnect');
 
     expect(channel.send.mock.calls.map(([payload]) => payload)).toEqual([

--- a/packages/lizi-im/src/discord/index.ts
+++ b/packages/lizi-im/src/discord/index.ts
@@ -233,8 +233,10 @@ export class DiscordIM extends BaseIM implements ChannelIM {
     }));
 
     this.host.ipc.handle('discordBot:set-lifecycle-announcement', (payload) => {
-      const config = isRecord(payload) ? payload : {};
-      const enabled = typeof config.enabled === 'boolean' ? config.enabled : true;
+      if (!isRecord(payload) || typeof payload.enabled !== 'boolean') {
+        return this.host.ipc.throwIpcError('INVALID_PARAMS', 'enabled must be a boolean');
+      }
+      const enabled = payload.enabled;
       if (!this.writeLifecycleAnnouncement(enabled)) {
         return {
           ok: false,
@@ -466,7 +468,12 @@ export class DiscordIM extends BaseIM implements ChannelIM {
       if (!enabled) {
         this.pendingOfflineNotice = false;
         this.clearRuntimeActiveMarker();
-      } else if (this.status.kind === 'connected' && this.ownerUserId && this.gateway.client) {
+      } else if (
+        !this.disposing &&
+        this.status.kind === 'connected' &&
+        this.ownerUserId &&
+        this.gateway.client
+      ) {
         this.markRuntimeActive();
       }
       return;
@@ -483,7 +490,12 @@ export class DiscordIM extends BaseIM implements ChannelIM {
       this.clearRuntimeActiveMarker();
       return;
     }
-    if (this.status.kind === 'connected' && this.ownerUserId && this.gateway.client) {
+    if (
+      !this.disposing &&
+      this.status.kind === 'connected' &&
+      this.ownerUserId &&
+      this.gateway.client
+    ) {
       this.markRuntimeActive();
     }
   }

--- a/packages/lizi-im/src/discord/index.ts
+++ b/packages/lizi-im/src/discord/index.ts
@@ -161,6 +161,9 @@ export class DiscordIM extends BaseIM implements ChannelIM {
     });
 
     this.host.ipc.handle('discordBot:set-config', async (payload) => {
+      // IPC handlers are registered before init(). Sync the persisted preference
+      // before any gateway status can queue a lifecycle notice or write its marker.
+      this.applyLifecycleAnnouncement(this.readLifecycleAnnouncement());
       const config = isRecord(payload) ? payload : {};
       const token = typeof config.token === 'string' ? config.token.trim() : '';
       const ownerUserId =

--- a/packages/lizi-im/src/discord/index.ts
+++ b/packages/lizi-im/src/discord/index.ts
@@ -112,7 +112,6 @@ export class DiscordIM extends BaseIM implements ChannelIM {
         void this.handleButtonInteraction(i as unknown as ButtonInteractionLike);
       },
     });
-    this.lifecycleAnnouncementEnabled = this.readLifecycleAnnouncement();
   }
 
   async init(): Promise<void> {

--- a/packages/lizi-im/src/discord/index.ts
+++ b/packages/lizi-im/src/discord/index.ts
@@ -36,6 +36,7 @@ import { startStreaming } from './streamingText.js';
 const TOKEN_SECRET_KEY = 'discord-bot-token';
 const OWNER_USER_ID_SECRET_KEY = 'discord-owner-user-id';
 const RUNTIME_ACTIVE_SECRET_KEY = 'discord-bot-runtime-active';
+const LIFECYCLE_ANNOUNCEMENT_SECRET_KEY = 'discord-bot-lifecycle-announcement';
 const MAX_OUTBOUND_FILE_BYTES = 8 * 1024 * 1024;
 const DISCORD_CREATE_MESSAGE_MAX_BYTES = 25 * 1024 * 1024;
 // Leave room for multipart framing/content; Discord also caps bot message uploads by file count.
@@ -92,6 +93,8 @@ export class DiscordIM extends BaseIM implements ChannelIM {
   private pendingOfflineNotice = false;
   private runtimeOnlineAnnounced = false;
   private runtimeOnlineNotice: Promise<void> | null = null;
+  private lifecycleAnnouncementEnabled = true;
+  private lifecycleNoticeVersion = 0;
   private disposing = false;
 
   constructor(host: IMHost, private readonly opts: DiscordIMOptions = {}) {
@@ -109,6 +112,7 @@ export class DiscordIM extends BaseIM implements ChannelIM {
         void this.handleButtonInteraction(i as unknown as ButtonInteractionLike);
       },
     });
+    this.lifecycleAnnouncementEnabled = this.readLifecycleAnnouncement();
   }
 
   async init(): Promise<void> {
@@ -116,14 +120,19 @@ export class DiscordIM extends BaseIM implements ChannelIM {
     this.suppressNextOnlineNotice = false;
     this.runtimeOnlineNotice = null;
     this.runtimeOnlineAnnounced = false;
+    this.lifecycleNoticeVersion += 1;
+    this.lifecycleAnnouncementEnabled = this.readLifecycleAnnouncement();
     const token = this.host.secrets.read(TOKEN_SECRET_KEY)?.trim() ?? '';
     this.ownerUserId = this.host.secrets.read(OWNER_USER_ID_SECRET_KEY)?.trim() ?? '';
+    if (!this.lifecycleAnnouncementEnabled) {
+      this.clearRuntimeActiveMarker();
+    }
     if (!token) {
       this.setStatus({ kind: 'idle' });
       return;
     }
 
-    this.pendingOfflineNotice = Boolean(
+    this.pendingOfflineNotice = this.lifecycleAnnouncementEnabled && Boolean(
       this.ownerUserId && this.host.secrets.read(RUNTIME_ACTIVE_SECRET_KEY),
     );
 
@@ -220,7 +229,21 @@ export class DiscordIM extends BaseIM implements ChannelIM {
     this.host.ipc.handle('discordBot:get-status', () => ({
       status: this.status,
       ownerUserId: this.ownerUserId || null,
+      lifecycleAnnouncement: this.lifecycleAnnouncementEnabled,
     }));
+
+    this.host.ipc.handle('discordBot:set-lifecycle-announcement', (payload) => {
+      const config = isRecord(payload) ? payload : {};
+      const enabled = typeof config.enabled === 'boolean' ? config.enabled : true;
+      if (!this.writeLifecycleAnnouncement(enabled)) {
+        return {
+          ok: false,
+          lifecycleAnnouncement: this.lifecycleAnnouncementEnabled,
+        };
+      }
+      this.applyLifecycleAnnouncement(enabled);
+      return { ok: true, lifecycleAnnouncement: enabled };
+    });
 
     this.host.ipc.handle('discordBot:disconnect', async () => {
       this.configVersion += 1;
@@ -423,6 +446,48 @@ export class DiscordIM extends BaseIM implements ChannelIM {
     this.host.secrets.write(key, previousValue);
   }
 
+  private readLifecycleAnnouncement(): boolean {
+    return this.host.secrets.read(LIFECYCLE_ANNOUNCEMENT_SECRET_KEY) !== 'false';
+  }
+
+  private writeLifecycleAnnouncement(enabled: boolean): boolean {
+    try {
+      if (!this.host.secrets.isAvailable()) return false;
+      return this.host.secrets.write(LIFECYCLE_ANNOUNCEMENT_SECRET_KEY, String(enabled));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log.warn(`discord lifecycle announcement preference write threw: ${msg}`);
+      return false;
+    }
+  }
+
+  private applyLifecycleAnnouncement(enabled: boolean): void {
+    if (this.lifecycleAnnouncementEnabled === enabled) {
+      if (!enabled) {
+        this.pendingOfflineNotice = false;
+        this.clearRuntimeActiveMarker();
+      } else if (this.status.kind === 'connected' && this.ownerUserId && this.gateway.client) {
+        this.markRuntimeActive();
+      }
+      return;
+    }
+
+    this.lifecycleAnnouncementEnabled = enabled;
+    this.lifecycleNoticeVersion += 1;
+    this.runtimeOnlineNotice = null;
+    this.runtimeOnlineAnnounced = false;
+    this.pendingOfflineNotice = false;
+    this.suppressNextOnlineNotice = false;
+
+    if (!enabled) {
+      this.clearRuntimeActiveMarker();
+      return;
+    }
+    if (this.status.kind === 'connected' && this.ownerUserId && this.gateway.client) {
+      this.markRuntimeActive();
+    }
+  }
+
   private async reconnectPreviousGateway(previousToken: string | null): Promise<void> {
     const token = previousToken?.trim() ?? '';
     if (!token) return;
@@ -457,6 +522,7 @@ export class DiscordIM extends BaseIM implements ChannelIM {
   }
 
   private shouldQueueRuntimeOnlineNotice(): boolean {
+    if (!this.lifecycleAnnouncementEnabled) return false;
     if (this.runtimeOnlineNotice) return false;
     return this.suppressNextOnlineNotice || this.pendingOfflineNotice || !this.runtimeOnlineAnnounced;
   }
@@ -464,9 +530,11 @@ export class DiscordIM extends BaseIM implements ChannelIM {
   private queueRuntimeOnlineNotice(): void {
     const expectedConfigVersion = this.configVersion;
     const expectedOwnerUserId = this.ownerUserId;
+    const expectedLifecycleNoticeVersion = this.lifecycleNoticeVersion;
     const notice = this.announceRuntimeOnline(
       expectedConfigVersion,
       expectedOwnerUserId,
+      expectedLifecycleNoticeVersion,
     ).catch((err) => {
       const msg = err instanceof Error ? err.message : String(err);
       this.log.warn(`discord runtime online notice failed: ${msg}`);
@@ -514,8 +582,13 @@ export class DiscordIM extends BaseIM implements ChannelIM {
   private async announceRuntimeOnline(
     expectedConfigVersion: number,
     expectedOwnerUserId: string,
+    expectedLifecycleNoticeVersion: number,
   ): Promise<void> {
-    if (!this.isOwnerNoticeCurrent(expectedConfigVersion, expectedOwnerUserId)) {
+    if (!this.isLifecycleNoticeCurrent(
+      expectedConfigVersion,
+      expectedOwnerUserId,
+      expectedLifecycleNoticeVersion,
+    )) {
       return;
     }
 
@@ -528,9 +601,17 @@ export class DiscordIM extends BaseIM implements ChannelIM {
       const sent = await this.sendOwnerNotice(
         expectedOwnerUserId,
         'offlineNotice',
-        () => this.isOwnerNoticeCurrent(expectedConfigVersion, expectedOwnerUserId),
+        () => this.isLifecycleNoticeCurrent(
+          expectedConfigVersion,
+          expectedOwnerUserId,
+          expectedLifecycleNoticeVersion,
+        ),
       );
-      if (!this.isOwnerNoticeCurrent(expectedConfigVersion, expectedOwnerUserId)) {
+      if (!this.isLifecycleNoticeCurrent(
+        expectedConfigVersion,
+        expectedOwnerUserId,
+        expectedLifecycleNoticeVersion,
+      )) {
         return;
       }
       if (sent) {
@@ -538,7 +619,11 @@ export class DiscordIM extends BaseIM implements ChannelIM {
       }
     }
 
-    if (!this.isOwnerNoticeCurrent(expectedConfigVersion, expectedOwnerUserId)) {
+    if (!this.isLifecycleNoticeCurrent(
+      expectedConfigVersion,
+      expectedOwnerUserId,
+      expectedLifecycleNoticeVersion,
+    )) {
       return;
     }
     if (this.disposing) return;
@@ -551,9 +636,17 @@ export class DiscordIM extends BaseIM implements ChannelIM {
       const sent = await this.sendOwnerNotice(
         expectedOwnerUserId,
         'online',
-        () => this.isOwnerNoticeCurrent(expectedConfigVersion, expectedOwnerUserId),
+        () => this.isLifecycleNoticeCurrent(
+          expectedConfigVersion,
+          expectedOwnerUserId,
+          expectedLifecycleNoticeVersion,
+        ),
       );
-      if (!this.isOwnerNoticeCurrent(expectedConfigVersion, expectedOwnerUserId)) {
+      if (!this.isLifecycleNoticeCurrent(
+        expectedConfigVersion,
+        expectedOwnerUserId,
+        expectedLifecycleNoticeVersion,
+      )) {
         return;
       }
       if (sent) {
@@ -573,19 +666,51 @@ export class DiscordIM extends BaseIM implements ChannelIM {
     );
   }
 
+  private isLifecycleNoticeCurrent(
+    expectedConfigVersion: number,
+    expectedOwnerUserId: string,
+    expectedLifecycleNoticeVersion: number,
+  ): boolean {
+    return Boolean(
+      this.lifecycleAnnouncementEnabled &&
+      this.lifecycleNoticeVersion === expectedLifecycleNoticeVersion &&
+      this.isOwnerNoticeCurrent(expectedConfigVersion, expectedOwnerUserId),
+    );
+  }
+
   private async announceRuntimeOffline(deadlineMs?: number): Promise<void> {
+    if (!this.lifecycleAnnouncementEnabled) {
+      this.pendingOfflineNotice = false;
+      this.clearRuntimeActiveMarker();
+      return;
+    }
     if (!this.ownerUserId) return;
     if (!this.gateway.client) return;
     if (!this.host.secrets.read(RUNTIME_ACTIVE_SECRET_KEY) && this.status.kind !== 'connected') return;
 
+    const expectedConfigVersion = this.configVersion;
+    const expectedOwnerUserId = this.ownerUserId;
+    const expectedLifecycleNoticeVersion = this.lifecycleNoticeVersion;
     const timeoutMs = deadlineMs !== undefined
       ? Math.min(RUNTIME_OFFLINE_NOTICE_TIMEOUT_MS, Math.max(0, deadlineMs - Date.now()))
       : RUNTIME_OFFLINE_NOTICE_TIMEOUT_MS;
     const sent = await this.sendOwnerNoticeWithTimeout(
-      this.ownerUserId,
+      expectedOwnerUserId,
       'offline',
       timeoutMs,
+      () => this.isLifecycleNoticeCurrent(
+        expectedConfigVersion,
+        expectedOwnerUserId,
+        expectedLifecycleNoticeVersion,
+      ),
     );
+    if (!this.isLifecycleNoticeCurrent(
+      expectedConfigVersion,
+      expectedOwnerUserId,
+      expectedLifecycleNoticeVersion,
+    )) {
+      return;
+    }
     if (sent && !this.pendingOfflineNotice) {
       this.clearRuntimeActiveMarker();
     } else {
@@ -595,6 +720,7 @@ export class DiscordIM extends BaseIM implements ChannelIM {
 
   private markRuntimeActive(): void {
     try {
+      if (!this.lifecycleAnnouncementEnabled) return;
       if (!this.host.secrets.isAvailable()) return;
       const ok = this.host.secrets.write(RUNTIME_ACTIVE_SECRET_KEY, String(Date.now()));
       if (!ok) this.log.warn('discord runtime active marker write failed');

--- a/packages/lizi-im/src/discord/index.ts
+++ b/packages/lizi-im/src/discord/index.ts
@@ -225,10 +225,12 @@ export class DiscordIM extends BaseIM implements ChannelIM {
       return configResult();
     });
 
+    // Renderer IPC can run after handler registration but before init(). Read the
+    // persisted preference here instead of exposing the constructor default.
     this.host.ipc.handle('discordBot:get-status', () => ({
       status: this.status,
       ownerUserId: this.ownerUserId || null,
-      lifecycleAnnouncement: this.lifecycleAnnouncementEnabled,
+      lifecycleAnnouncement: this.readLifecycleAnnouncement(),
     }));
 
     this.host.ipc.handle('discordBot:set-lifecycle-announcement', (payload) => {
@@ -239,7 +241,9 @@ export class DiscordIM extends BaseIM implements ChannelIM {
       if (!this.writeLifecycleAnnouncement(enabled)) {
         return {
           ok: false,
-          lifecycleAnnouncement: this.lifecycleAnnouncementEnabled,
+          // Roll back to the persisted source of truth, which may differ from
+          // the runtime cache before init or after an external account change.
+          lifecycleAnnouncement: this.readLifecycleAnnouncement(),
         };
       }
       this.applyLifecycleAnnouncement(enabled);


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Discord 个人机器人补充“上下线通知”设置，交互与飞书现有设置保持一致。设置仅在已有 Discord 凭据时展示，沿用现有 secrets 持久化，默认开启以保持旧行为；关闭时立即失效当前 runtime marker，并阻止陈旧异步上线/下线通知反写。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Discord 个人机器人增加可配置的上下线通知，复用飞书设置与交互。
- 本 PR 包含：Discord runtime、现有 secrets 偏好、IPC/preload、Renderer hook、Settings UI、四语言文案及聚焦测试。
- 明确不包含：IM 通用架构重构、数据库 migration、token / owner ID 存储格式调整、官方共享机器人分发逻辑。
- 用户可见变化：已保存 Discord 凭据时，个人 Discord 设置卡新增“上下线通知”开关；默认开启，关闭后不再发送后续上线/下线通知。
- 是否存在 breaking change：无。既有用户默认保持开启，存储缺少该字段时按开启处理。

### UI 变化

- Desktop Settings → IM 机器人 → 个人 → Discord：在已有凭据时展示生命周期通知开关。
- 未附 Electron 截图/录屏：分支实机启动受数据库 schema 保护和内存压力阻塞，状态在“未执行的验证”中如实记录；本 PR 复用飞书现有区块，不引入新的视觉样式。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md §2 Color Palette & Roles`：全部颜色继续使用现有 Settings / 语义 token，Light / Dark 不写硬编码色值。
  - `docs/design-rules/DESIGN.md §4 Component Stylings（Cards & Containers）`：复用现有设置卡层级、边框和无阴影规则，没有新增平行卡片样式。
  - `docs/design-rules/DESIGN.md §5 Layout Principles / Border Radius Scale`：通过共享 `ImLifecycleAnnouncementSection` 复用飞书布局与既有圆角档位，不新增任意 radius 或装饰层。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm --filter @cindy/im run --if-present typecheck
结果：package 当前无 typecheck script，命令正常跳过。

pnpm check:dco
结果：通过。

git diff --check origin/main...HEAD
结果：通过。

pnpm exec vitest run src/renderer/hooks/__tests__/useDiscordBot.test.ts
结果：6 tests passed。

pnpm exec vitest run src/discord/__tests__/inbound.test.ts
结果：51 tests passed。

GitHub Actions client-ci / DCO
结果：当前 HEAD 通过。
```

### 手工验证

- 已静态核对 Settings 展示条件：仅已有 Discord 凭据时渲染开关，并复用飞书生命周期通知区块。
- 已核对关闭、重新开启、写入失败回滚，以及初始 `getStatus` 晚于用户切换返回时的 request-version / cache 路径。

### 未执行的验证

- Electron 真机验收未完成：共享数据启动被 schema 版本保护拦截（本地数据库 81、当前 checkout 85）；改用隔离沙箱后两次均在 120 秒内未达到 renderer ready。为避免再次造成内存压力，已停止分支 Electron。
- PR 已进入 Ready for review，但不会把开关展示、切换和重启持久化描述为已实机验证；内存条件允许时继续补验。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：生命周期通知异步竞态与 Renderer cache 一致性。

### 影响与回滚

- 影响范围：仅已配置凭据的 Discord 个人机器人生命周期通知偏好；凭据仍由原有 owner-scoped secrets 保存，不新增明文或数据库字段。
- 并发保护：关闭时递增版本并清理 active marker，陈旧异步结果不能补发通知；Renderer 初始读取失效后保留最新 optimistic / persisted cache。
- 回滚 / 降级方式：回退本 PR 即恢复 Discord 生命周期通知固定开启的旧行为；既有 token、owner ID 与 secrets 数据无需迁移或清理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（设置行为、风险和未完成验收已记录在 PR）
- [x] 已确认测试结果或说明未执行原因
