### PR TITLE
fix(desktop): 解除分支选择与 Worktree 勾选联动

### DIFF
--- a/apps/desktop/src/renderer/__tests__/branchPick.test.ts
+++ b/apps/desktop/src/renderer/__tests__/branchPick.test.ts
@@ -1,12 +1,10 @@
 /**
  * branchPick.test.ts — 分支区点选语义(纯函数)回归。
  *
- * 语义契约(2026-07-29 用户裁决第二版,实测后定稿):
- *  - 分支菜单永远可点;勾选框**跟随用户的分支选择**双向联动(本次草稿内生效,
- *    持久化档位由调用方 source 分档控制,不在本函数职责内)
- *  - OFF + 选非当前分支 → enable-worktree(从别的分支启动必须隔离)
- *  - ON + 选回当前 HEAD → disable-worktree(回到当前 checkout 直接启动,对称)
- *  - ON + 选其它分支 = 改源分支;选当前源分支(非 HEAD)= no-op
+ * 语义契约(2026-08-05 用户裁决):
+ *  - 分支选择永不隐式改动 worktree 勾选状态
+ *  - worktree ON:选分支 = 改源分支;选当前源分支 no-op
+ *  - worktree OFF:分支区只读;防御性触达一律 no-op
  *  - 永远不产生"checkout 用户 checkout"的效果
  */
 import { describe, expect, it } from 'vitest';
@@ -15,72 +13,25 @@ import { resolveBranchPick } from '../components/new-chat/branchPick';
 
 describe('resolveBranchPick', () => {
   it('worktree ON: picking a different branch changes the source branch', () => {
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: true, currentBranch: 'main', sourceBranch: 'feat/x' },
-        'feat/y',
-      ),
-    ).toEqual({ kind: 'set-source', branch: 'feat/y' });
+    expect(resolveBranchPick({ worktreeEnabled: true, sourceBranch: 'main' }, 'feat/x')).toEqual({
+      kind: 'set-source',
+      branch: 'feat/x',
+    });
   });
 
   it('worktree ON: picking the current source branch is a no-op', () => {
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: true, currentBranch: 'main', sourceBranch: 'feat/x' },
-        'feat/x',
-      ),
-    ).toEqual({ kind: 'noop' });
+    expect(resolveBranchPick({ worktreeEnabled: true, sourceBranch: 'feat/x' }, 'feat/x')).toEqual({
+      kind: 'noop',
+    });
   });
 
-  it('worktree ON: picking the repo HEAD branch leaves worktree (symmetric follow)', () => {
-    // 用户最初的吐槽点:从 worktree 切回 main 时勾选仍亮着。定稿语义:选回当前
-    // HEAD = 不再需要隔离,勾选跟随熄灭(仅本次草稿,不写记忆)。
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: true, currentBranch: 'main', sourceBranch: 'feat/x' },
-        'main',
-      ),
-    ).toEqual({ kind: 'disable-worktree' });
-    // source 恰好等于 HEAD 时同理:选它 = 回当前 checkout。
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: true, currentBranch: 'main', sourceBranch: 'main' },
-        'main',
-      ),
-    ).toEqual({ kind: 'disable-worktree' });
-  });
-
-  it('worktree OFF: picking the repo HEAD branch is a no-op', () => {
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: false, currentBranch: 'main', sourceBranch: '' },
-        'main',
-      ),
-    ).toEqual({ kind: 'noop' });
-  });
-
-  it('worktree OFF: picking another branch enables worktree from it', () => {
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: false, currentBranch: 'main', sourceBranch: '' },
-        'feat/x',
-      ),
-    ).toEqual({ kind: 'enable-worktree', branch: 'feat/x' });
-  });
-
-  it('detached HEAD (currentBranch=null): no "current branch" special cases fire', () => {
-    // OFF:任何选择都按隔离启动;ON:任何选择都只是改源,绝不因 null 误触发退出。
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: false, currentBranch: null, sourceBranch: '' },
-        'main',
-      ),
-    ).toEqual({ kind: 'enable-worktree', branch: 'main' });
-    expect(
-      resolveBranchPick(
-        { worktreeEnabled: true, currentBranch: null, sourceBranch: 'feat/x' },
-        'main',
-      ),
-    ).toEqual({ kind: 'set-source', branch: 'main' });
+  it('worktree OFF: any pick is a no-op — selection must never flip the checkbox', () => {
+    // 用户裁决:勾选状态只有用户本人能改。选分支不能自动开启 worktree。
+    expect(resolveBranchPick({ worktreeEnabled: false, sourceBranch: '' }, 'main')).toEqual({
+      kind: 'noop',
+    });
+    expect(resolveBranchPick({ worktreeEnabled: false, sourceBranch: '' }, 'feat/x')).toEqual({
+      kind: 'noop',
+    });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -213,6 +213,7 @@ describe('Shared create project picker', () => {
       'const branchInteractive = !disabled && effectiveWorktreeEnabled && baseRepo !== null',
     );
     expect(worktreeChipsSource).toContain('aria-disabled={!branchInteractive}');
+    expect(worktreeChipsSource).toContain('tabIndex={branchInteractive ? 0 : -1}');
     expect(worktreeChipsSource).not.toMatch(/\n\s+disabled=\{!branchInteractive\}/);
     expect(worktreeChipsSource).toContain(
       "sourceBranch || branches.current || currentBranch || 'HEAD'",

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -204,6 +204,8 @@ describe('Shared create project picker', () => {
     expect(worktreeChipsSource).toContain(
       'const branchInteractive = !disabled && effectiveWorktreeEnabled',
     );
+    expect(worktreeChipsSource).toContain('aria-disabled={!branchInteractive}');
+    expect(worktreeChipsSource).not.toMatch(/\n\s+disabled=\{!branchInteractive\}/);
     expect(worktreeChipsSource).toContain('group-hover:opacity-0');
     expect(worktreeChipsSource).not.toContain('function BranchChip');
     expect(worktreeChipsSource).not.toContain('function WorktreeChip(');

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -196,6 +196,14 @@ describe('Shared create project picker', () => {
     expect(newMakerDraftRouteSource).not.toContain('worktreeMissingRepo');
   });
 
+  it('only forwards a worktree-eligible repo root to the send path', () => {
+    // linked worktree、非 Git 目录和探测失败都必须让发送侧自然降级，不能只因 repoRoot
+    // 存在就触发 main 侧必然拒绝的 createWorktree。
+    expect(worktreeChipsSource).toMatch(
+      /const baseRepo =\s*detect\.data\?\.gitInstalled === true[\s\S]*detect\.data\.isGitRepo[\s\S]*!detect\.data\.isInsideWorktree[\s\S]*detect\.data\.repoRoot \?\? null/,
+    );
+  });
+
   it('merges branch and worktree into a single joined pill (Claude Code style)', () => {
     // 2026-07-29 用户裁决:[⎇ 分支 │ ☑ worktree] 是一个 pill、两个点击区;
     // 未勾时分支区只读;已勾时分支菜单 = worktree 源分支选择器。

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -214,6 +214,10 @@ describe('Shared create project picker', () => {
     );
     expect(worktreeChipsSource).toContain('aria-disabled={!branchInteractive}');
     expect(worktreeChipsSource).not.toMatch(/\n\s+disabled=\{!branchInteractive\}/);
+    expect(worktreeChipsSource).toContain(
+      "sourceBranch || branches.current || currentBranch || 'HEAD'",
+    );
+    expect(worktreeChipsSource).toContain('branchInteractive\n          ? t(\'newChat.branchChip.sourceTooltip\')');
     expect(worktreeChipsSource).toContain('group-hover:opacity-0');
     expect(worktreeChipsSource).not.toContain('function BranchChip');
     expect(worktreeChipsSource).not.toContain('function WorktreeChip(');
@@ -227,7 +231,9 @@ describe('Shared create project picker', () => {
     expect(newMakerDraftRouteSource).toContain(
       'deviceLinkReconnectEpoch={remoteDraftRefreshEpoch}',
     );
-    expect(worktreeChipsSource).toContain("sourceBranch || branches.current || 'HEAD'");
+    expect(worktreeChipsSource).toContain(
+      "sourceBranch || branches.current || currentBranch || 'HEAD'",
+    );
     expect(worktreeChipsSource).not.toContain("sourceBranch || branches.current || 'main'");
   });
 

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -175,23 +175,20 @@ describe('Shared create project picker', () => {
     );
   });
 
-  it('keeps the worktree checkbox owned by the user alone (2026-07-29 invariant, v2)', () => {
-    // 用户裁决(实测后第二版):勾选状态只属于用户——
+  it('keeps the worktree checkbox owned by the user alone (2026-08-05 invariant)', () => {
+    // 用户裁决:勾选状态只属于用户——
     //  1) 组件内不存在任何 useEffect 自动改写 enabled 的路径(资格变化只禁用、
     //     不改状态;旧 handleAutoDisable 机制不得复活);
-    //  2) 用户点击 checkbox(source='chip')→ 写穿工作端记忆(本地专用单字段 setter /
+    //  2) 用户点击 checkbox → 写穿工作端记忆(本地专用单字段 setter /
     //     device-link 远程 apply-new-maker-worktree-pref);
-    //  3) 用户选分支(source='branch-pick')→ 勾选双向联动但仅本次草稿、不落记忆
-    //     (route 侧 source !== 'chip' 直接 return);
+    //  3) 用户选分支→ 不会隐式修改勾选状态;
     //  4) checkbox 原样直出记忆(播种无 baseRepo 点亮门槛),发送侧按
     //     「勾选 && baseRepo 就绪」静默降级,不报错拦截。
     expect(worktreeChipsSource).not.toContain('handleAutoDisable');
     expect(worktreeChipsSource).not.toMatch(/useEffect\([^)]*onEnabledChange/s);
-    expect(worktreeChipsSource).toContain("onToggle={(v) => onEnabledChange(v, 'chip')}");
-    expect(worktreeChipsSource).toContain("onEnabledChange(true, 'branch-pick')");
-    expect(worktreeChipsSource).toContain("onEnabledChange(false, 'branch-pick')");
-    expect(branchPickSource).toContain("kind: 'disable-worktree'");
-    expect(newMakerDraftRouteSource).toContain("if (source !== 'chip') return;");
+    expect(worktreeChipsSource).toContain('onToggle={onEnabledChange}');
+    expect(worktreeChipsSource).not.toContain("'branch-pick'");
+    expect(branchPickSource).not.toContain("kind: 'disable-worktree'");
     expect(newMakerDraftRouteSource).toContain("'maker:apply-new-maker-worktree-pref'");
     expect(newMakerDraftRouteSource).toContain('setWorktreePreference(enabled)');
     expect(newMakerDraftRouteSource).toContain('setWtEnabled(worktreePref)');
@@ -201,11 +198,11 @@ describe('Shared create project picker', () => {
 
   it('merges branch and worktree into a single joined pill (Claude Code style)', () => {
     // 2026-07-29 用户裁决:[⎇ 分支 │ ☑ worktree] 是一个 pill、两个点击区;
-    // 分支菜单永远可点(worktree 开不了的仓库除外);悬停任一半区时分隔线隐去。
+    // 未勾时分支区只读;已勾时分支菜单 = worktree 源分支选择器。
     expect(worktreeChipsSource).toContain('function BranchWorktreeChip');
     expect(worktreeChipsSource).toContain('data-testid="create-agent-branch-worktree"');
     expect(worktreeChipsSource).toContain(
-      'const branchInteractive = !disabled && (effectiveWorktreeEnabled || !switchDisabled)',
+      'const branchInteractive = !disabled && effectiveWorktreeEnabled',
     );
     expect(worktreeChipsSource).toContain('group-hover:opacity-0');
     expect(worktreeChipsSource).not.toContain('function BranchChip');

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -217,7 +217,7 @@ describe('Shared create project picker', () => {
     expect(worktreeChipsSource).toContain(
       "sourceBranch || branches.current || currentBranch || 'HEAD'",
     );
-    expect(worktreeChipsSource).toContain('branchInteractive\n          ? t(\'newChat.branchChip.sourceTooltip\')');
+    expect(worktreeChipsSource).toContain('checked\n          ? t(\'newChat.branchChip.sourceTooltip\')');
     expect(worktreeChipsSource).toContain('group-hover:opacity-0');
     expect(worktreeChipsSource).not.toContain('function BranchChip');
     expect(worktreeChipsSource).not.toContain('function WorktreeChip(');

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -210,7 +210,7 @@ describe('Shared create project picker', () => {
     expect(worktreeChipsSource).toContain('function BranchWorktreeChip');
     expect(worktreeChipsSource).toContain('data-testid="create-agent-branch-worktree"');
     expect(worktreeChipsSource).toContain(
-      'const branchInteractive = !disabled && effectiveWorktreeEnabled',
+      'const branchInteractive = !disabled && effectiveWorktreeEnabled && baseRepo !== null',
     );
     expect(worktreeChipsSource).toContain('aria-disabled={!branchInteractive}');
     expect(worktreeChipsSource).not.toMatch(/\n\s+disabled=\{!branchInteractive\}/);

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -6,17 +6,15 @@
  * 2026-07-29 用户裁决(对齐 Claude Code):分支与 worktree 合并为**一个** pill——
  * 左半分支区、竖分隔线、右半 checkbox + "worktree",两个点击区各管各的。
  *
- * 状态不变量(2026-07-29 用户裁决,实测后第二版):**勾选状态只属于用户**——
+ * 状态不变量(2026-08-05 用户裁决):**勾选状态只属于用户**——
  *   - 系统/环境因素(切项目、探测结果、播种)永远不改 checkbox;资格不满足只是
  *     禁用 + tooltip,发送时由上层按「勾选 && 合格」静默降级,记忆永不被抹;
- *   - 用户点击 checkbox 本体(source='chip')→ 改状态并写工作端勾选记忆;
- *   - 用户选分支(source='branch-pick')→ 勾选**跟随本次选择**双向联动
- *     (选非当前分支必须隔离 → 亮;选回当前 HEAD → 灭;见 branchPick.ts),
- *     但只对本次草稿生效、不写记忆——分支选择表达的是"这一次从哪启动",
- *     不是"以后都默认 worktree"。
+ *   - 唯一改动路径 = 用户点击 checkbox 本体(onEnabledChange,上层必持久化);
+ *   - 选分支不会隐式开启或关闭 worktree。未勾时分支区只读;想从别的分支启动
+ *     必须先显式勾选 worktree。
  *
- * 分支区语义:菜单永远可点(资格允许时);未勾时菜单脚注说明"选其他分支将以
- * worktree 隔离启动",已勾时脚注说明"选当前分支将退回直接启动"。
+ * 分支区语义:未勾 = 只读展示仓库当前 HEAD(会话就跑在它上面);已勾 = worktree
+ * 源分支选择器(默认当前分支,点开可换;见 branchPick.ts)。
  *
  * worktree 名称 **自动生成**（不暴露 UI），由 useSuggestName 拉取后透传给上层。
  */
@@ -60,13 +58,10 @@ export interface WorktreeChipsRowProps {
   emptyProjectLabel?: string;
   enabled: boolean;
   /**
-   * 用户切换 worktree。source 决定是否写工作端勾选记忆:
-   *  - 'chip':点 checkbox 本体 → 持久化;
-   *  - 'branch-pick':分支选择的双向联动(用户动作,但表达的是"这一次从哪启动")
-   *    → 仅本次草稿,不落记忆。
-   * 系统/环境路径不得调用它替用户翻状态。
+   * 用户点击 checkbox 本体切换 worktree——**唯一**的状态改动路径,上层必持久化
+   * (写工作端勾选记忆)。系统任何路径都不得调用它替用户翻状态。
    */
-  onEnabledChange: (v: boolean, source: 'chip' | 'branch-pick') => void;
+  onEnabledChange: (v: boolean) => void;
   sourceBranch: string;
   onSourceBranchChange: (v: string) => void;
   onBaseRepoChange?: (baseRepo: string | null) => void;
@@ -139,12 +134,7 @@ export function WorktreeChipsRow({
     onRecoveryKeyDiscardSupportChange?.(
       detect.data ? detect.data.supportsRecoveryKeyDiscard === true : null,
     );
-  }, [
-    baseRepo,
-    detect.data,
-    onBaseRepoChange,
-    onRecoveryKeyDiscardSupportChange,
-  ]);
+  }, [baseRepo, detect.data, onBaseRepoChange, onRecoveryKeyDiscardSupportChange]);
 
   const cantUseReason = useMemo<string | null>(() => {
     if (detect.loading) return t('newChat.worktree.detecting');
@@ -162,13 +152,8 @@ export function WorktreeChipsRow({
   // 资格不满足只体现为 checkbox 禁用(switchDisabled)+发送侧「勾选 && 合格」降级。
 
   const effectiveWorktreeEnabled = enabled && !advancedHidden && !worktreeDisabled;
-  // 分支列表懒加载 latch:worktree 未开时不预拉,首次点开分支 chip 菜单才拉,
-  // 之后保持订阅(baseRepo 变化由 hook 自身依赖触发重拉)。
-  const [branchListWanted, setBranchListWanted] = useState(false);
-  const branches = useBranches(
-    effectiveWorktreeEnabled || branchListWanted ? baseRepo : null,
-    deviceLinkDeviceId,
-  );
+  // 分支列表只在 worktree 开启后拉取;关闭态左半区仅展示当前 checkout 分支。
+  const branches = useBranches(effectiveWorktreeEnabled ? baseRepo : null, deviceLinkDeviceId);
   const suggested = useSuggestName(effectiveWorktreeEnabled ? baseRepo : null, deviceLinkDeviceId);
 
   useEffect(() => {
@@ -213,30 +198,19 @@ export function WorktreeChipsRow({
     ? sourceBranch || branches.current || 'HEAD'
     : (currentBranch ?? 'HEAD');
   const showBranchChip = !advancedHidden && !!detect.data?.isGitRepo;
-  // 分支菜单永远可点(worktree 开不了的仓库除外——已在 worktree 内等场景选分支
-  // 无法产生任何效果,菜单保持只读展示)。
-  const branchInteractive = !disabled && (effectiveWorktreeEnabled || !switchDisabled);
+  // 分支菜单只在 worktree 已勾时可交互(= 源分支选择器);未勾时分支区只读展示当前
+  // HEAD——选分支不再承担任何隐式开关语义(状态不变量,见文件头)。
+  const branchInteractive = !disabled && effectiveWorktreeEnabled;
 
   const handleBranchPick = useCallback(
     (picked: string) => {
       const effect = resolveBranchPick(
-        { worktreeEnabled: effectiveWorktreeEnabled, currentBranch, sourceBranch: branchLabel },
+        { worktreeEnabled: effectiveWorktreeEnabled, sourceBranch: branchLabel },
         picked,
       );
-      if (effect.kind === 'set-source') {
-        onSourceBranchChange(effect.branch);
-      } else if (effect.kind === 'enable-worktree') {
-        // 同帧一起写:sourceBranch 非空会让"worktree 开启后回填 current"的
-        // effect 自然跳过,不会覆盖用户的选择。branch-pick 档 → 不落记忆。
-        onEnabledChange(true, 'branch-pick');
-        onSourceBranchChange(effect.branch);
-      } else if (effect.kind === 'disable-worktree') {
-        // 选回当前 HEAD → 勾选跟随熄灭(仅本次草稿);清源分支,下次开启重新回填。
-        onEnabledChange(false, 'branch-pick');
-        onSourceBranchChange('');
-      }
+      if (effect.kind === 'set-source') onSourceBranchChange(effect.branch);
     },
-    [effectiveWorktreeEnabled, currentBranch, branchLabel, onSourceBranchChange, onEnabledChange],
+    [effectiveWorktreeEnabled, branchLabel, onSourceBranchChange],
   );
 
   const branchWorktree = showBranchChip ? (
@@ -252,11 +226,10 @@ export function WorktreeChipsRow({
       cantUseReason={cantUseReason ?? undefined}
       onPick={handleBranchPick}
       onOpenRequested={() => {
-        setBranchListWanted(true);
         // 上次拉取失败的话,重新打开菜单就自动重试一次,不逼用户去点重试项。
         if (branches.failed && !branches.loading) branches.refetch();
       }}
-      onToggle={(v) => onEnabledChange(v, 'chip')}
+      onToggle={onEnabledChange}
       compact={compact}
     />
   ) : null;
@@ -460,9 +433,7 @@ function BranchWorktreeChip({
   const branchTipped = (
     <Tip
       text={
-        checked
-          ? t('newChat.branchChip.sourceTooltip')
-          : t('newChat.branchChip.currentTooltip')
+        checked ? t('newChat.branchChip.sourceTooltip') : t('newChat.branchChip.currentTooltip')
       }
     >
       {branchSegment}
@@ -512,13 +483,6 @@ function BranchWorktreeChip({
             </DropdownMenuItem>
           ))
         )}
-        {/* 脚注说明双向联动语义:未勾 → 选其他分支将开 worktree;已勾 → 选回
-            当前分支将退回直接启动。用户第一次遇到"勾选跟着分支走"时不至于意外。 */}
-        <div className="mt-1 border-t border-border px-3 pb-1 pt-1.5 text-[11px] leading-snug text-muted-foreground">
-          {checked
-            ? t('newChat.branchChip.exitWorktreeHint')
-            : t('newChat.branchChip.worktreeHint')}
-        </div>
       </DropdownMenuContent>
     </DropdownMenu>
   ) : (

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -125,9 +125,15 @@ export function WorktreeChipsRow({
     deviceLinkDeviceId,
     deviceLinkReconnectEpoch,
   );
-  const baseRepo = detect.data?.repoRoot ?? null;
+  const baseRepo =
+    detect.data?.gitInstalled === true &&
+    detect.data.isGitRepo &&
+    !detect.data.isInsideWorktree
+      ? (detect.data.repoRoot ?? null)
+      : null;
 
-  // repoRoot 参与发送侧 worktree 创建，必须在 paint / 下一次用户输入前同步收敛；
+  // 只有明确具备 worktree 资格的仓库才向发送侧提供 repoRoot；linked worktree、非 Git
+  // 目录或探测失败都传 null，让发送侧按「勾选 && baseRepo」自然降级为普通启动。
   // useDetectCwd 同时按 {cwd, deviceId} 做 render 阶段 fence，切目标时这里先写 null。
   useLayoutEffect(() => {
     onBaseRepoChange?.(baseRepo);

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -206,7 +206,7 @@ export function WorktreeChipsRow({
   const showBranchChip = !advancedHidden && !!detect.data?.isGitRepo;
   // 分支菜单只在 worktree 已勾时可交互(= 源分支选择器);未勾时分支区只读展示当前
   // HEAD——选分支不再承担任何隐式开关语义(状态不变量,见文件头)。
-  const branchInteractive = !disabled && effectiveWorktreeEnabled;
+  const branchInteractive = !disabled && effectiveWorktreeEnabled && baseRepo !== null;
 
   const handleBranchPick = useCallback(
     (picked: string) => {

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -439,7 +439,7 @@ function BranchWorktreeChip({
   const branchTipped = (
     <Tip
       text={
-        branchInteractive
+        checked
           ? t('newChat.branchChip.sourceTooltip')
           : t('newChat.branchChip.currentTooltip')
       }

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -201,7 +201,7 @@ export function WorktreeChipsRow({
   // 分支入口,绝不能因加载失败而消失。OFF 显仓库当前 HEAD 分支；detached HEAD
   // 没有分支名时仍显示 HEAD，让默认未勾选用户保有开启 worktree 的入口。
   const branchLabel = effectiveWorktreeEnabled
-    ? sourceBranch || branches.current || 'HEAD'
+    ? sourceBranch || branches.current || currentBranch || 'HEAD'
     : (currentBranch ?? 'HEAD');
   const showBranchChip = !advancedHidden && !!detect.data?.isGitRepo;
   // 分支菜单只在 worktree 已勾时可交互(= 源分支选择器);未勾时分支区只读展示当前
@@ -439,7 +439,9 @@ function BranchWorktreeChip({
   const branchTipped = (
     <Tip
       text={
-        checked ? t('newChat.branchChip.sourceTooltip') : t('newChat.branchChip.currentTooltip')
+        branchInteractive
+          ? t('newChat.branchChip.sourceTooltip')
+          : t('newChat.branchChip.currentTooltip')
       }
     >
       {branchSegment}

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -407,6 +407,7 @@ function BranchWorktreeChip({
     <button
       type="button"
       aria-disabled={!branchInteractive}
+      tabIndex={branchInteractive ? 0 : -1}
       data-testid="create-agent-branch-chip"
       className={cn(
         'inline-flex h-full min-w-0 items-center transition-colors',

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -400,7 +400,7 @@ function BranchWorktreeChip({
   const branchSegment = (
     <button
       type="button"
-      disabled={!branchInteractive}
+      aria-disabled={!branchInteractive}
       data-testid="create-agent-branch-chip"
       className={cn(
         'inline-flex h-full min-w-0 items-center transition-colors',

--- a/apps/desktop/src/renderer/components/new-chat/branchPick.ts
+++ b/apps/desktop/src/renderer/components/new-chat/branchPick.ts
@@ -1,42 +1,25 @@
 /**
  * branchPick — 分支区点选语义的纯函数(与 UI 解耦,便于单测)。
  *
- * 2026-07-29 用户裁决(第二版,实测后定稿):分支菜单永远可点,勾选框**跟随用户的
- * 分支选择**双向联动——这是用户亲手的动作,不算系统擅改;但联动只对本次草稿生效,
- * **不写工作端勾选记忆**(记忆只在用户点 checkbox 本体时保存,见调用方 source 分档):
- *  - 选非当前分支 → 开 worktree 并以其为源(从别的分支启动必须隔离,
- *    绝不 checkout 用户的 checkout);
- *  - 选回当前 HEAD 分支 → 关 worktree(回到当前 checkout 直接启动,对称);
- *  - worktree 已勾时选其它分支 = 改源分支;选当前源分支(非 HEAD)= no-op。
- *  - 系统/环境因素(切项目、探测结果、播种)永远无权触达本函数之外的开关路径。
+ * 2026-08-05 用户裁决(worktree 勾选状态只属于用户,分支选择不得隐式改动):
+ *  - worktree 已勾:分支菜单 = worktree 源分支选择器,选当前源分支为 no-op;
+ *  - worktree 未勾:分支区只读展示当前 HEAD,菜单不打开——选分支不能替用户
+ *    自动开启 worktree。想从别的分支启动 = 先勾 worktree、再选源分支(全部显式)。
  *  - 永远不产生"checkout 用户 checkout"的效果(effect 种类里根本没有这个选项)。
  */
 
 export interface BranchPickState {
-  /** worktree 勾选框当前显示状态(用户记忆或本次草稿内联动后的值)。 */
+  /** worktree 勾选状态(用户记忆原样直出;未勾时分支区只读,不应触达本函数)。 */
   worktreeEnabled: boolean;
-  /** 仓库当前 HEAD 分支;detached / 未知时为 null。 */
-  currentBranch: string | null;
   /** worktree 源分支(仅 worktreeEnabled 时有意义)。 */
   sourceBranch: string;
 }
 
-export type BranchPickEffect =
-  | { kind: 'noop' }
-  | { kind: 'set-source'; branch: string }
-  | { kind: 'enable-worktree'; branch: string }
-  | { kind: 'disable-worktree' };
+export type BranchPickEffect = { kind: 'noop' } | { kind: 'set-source'; branch: string };
 
 export function resolveBranchPick(state: BranchPickState, picked: string): BranchPickEffect {
-  if (state.worktreeEnabled) {
-    // 选回当前 HEAD = 不再需要隔离,勾选跟随熄灭(解决「从 worktree 切回 main
-    // 仍勾着」的不对称);detached(currentBranch=null)时无"当前分支"可言,不触发。
-    if (state.currentBranch !== null && picked === state.currentBranch) {
-      return { kind: 'disable-worktree' };
-    }
-    if (picked === state.sourceBranch) return { kind: 'noop' };
-    return { kind: 'set-source', branch: picked };
-  }
-  if (state.currentBranch !== null && picked === state.currentBranch) return { kind: 'noop' };
-  return { kind: 'enable-worktree', branch: picked };
+  // 未勾时分支区只读(UI 不开菜单);防御性兜底:即使被触达也绝不改勾选状态。
+  if (!state.worktreeEnabled) return { kind: 'noop' };
+  if (picked === state.sourceBranch) return { kind: 'noop' };
+  return { kind: 'set-source', branch: picked };
 }

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2118,17 +2118,12 @@ export function NewMakerDraftRoute() {
     [handleWorkingDirChange],
   );
 
-  // 用户切换 worktree(2026-07-29 实测后第二版):
-  //  - source='chip'(点 checkbox 本体)→ 写穿「工作端勾选记忆」——本地草稿写本地
-  //    newMakerDraft 根字段;device-link 远程草稿写到被控端(状态归工作端所有,
-  //    控制端只是远程操作器,与手机端同语义);
-  //  - source='branch-pick'(分支选择的双向联动)→ 仅本次草稿的 UI 态,不落记忆
-  //    ——分支选择表达"这一次从哪启动",不改全局默认。
-  // 系统/环境路径没有任何入口能触达这里(不变量)。
+  // 用户点击 checkbox 切换 worktree:写穿「工作端勾选记忆」——本地草稿写本地
+  // newMakerDraft 根字段;device-link 远程草稿写到被控端(状态归工作端所有,
+  // 控制端只是远程操作器,与手机端同语义)。分支选择不会隐式改动这个状态。
   const handleWtEnabledChange = useCallback(
-    (enabled: boolean, source: 'chip' | 'branch-pick') => {
+    (enabled: boolean) => {
       setWtEnabled(enabled);
-      if (source !== 'chip') return;
       if (isDeviceLinkDraft && effectiveDeviceLinkDeviceId) {
         remoteDraftRevisionRef.current += 1;
         window.electronAPI.deviceLink

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5153,9 +5153,7 @@
       "loading": "Loading branches…",
       "loadFailed": "Failed to load branches — tap to retry",
       "currentTooltip": "Current branch",
-      "sourceTooltip": "Worktree source branch",
-      "worktreeHint": "Picking another branch starts this chat in an isolated worktree",
-      "exitWorktreeHint": "Picking the current branch leaves worktree and starts directly on it"
+      "sourceTooltip": "Worktree source branch"
     },
     "folderPicker": {
       "selectFolder": "Select folder",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5151,9 +5151,7 @@
       "loading": "ブランチを読み込み中…",
       "loadFailed": "ブランチの読み込みに失敗しました。タップして再試行",
       "currentTooltip": "現在のブランチ",
-      "sourceTooltip": "worktree のソースブランチ",
-      "worktreeHint": "別のブランチを選ぶと worktree 分離で開始します",
-      "exitWorktreeHint": "現在のブランチを選ぶと worktree を解除し、そのまま開始します"
+      "sourceTooltip": "worktree のソースブランチ"
     },
     "folderPicker": {
       "selectFolder": "フォルダを選択",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5151,9 +5151,7 @@
       "loading": "브랜치 불러오는 중…",
       "loadFailed": "브랜치를 불러오지 못했습니다. 눌러서 다시 시도",
       "currentTooltip": "현재 브랜치",
-      "sourceTooltip": "worktree 소스 브랜치",
-      "worktreeHint": "다른 브랜치를 선택하면 worktree 격리로 시작합니다",
-      "exitWorktreeHint": "현재 브랜치를 선택하면 worktree를 해제하고 바로 시작합니다"
+      "sourceTooltip": "worktree 소스 브랜치"
     },
     "folderPicker": {
       "selectFolder": "폴더 선택",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5151,9 +5151,7 @@
       "loading": "加载分支中…",
       "loadFailed": "分支列表加载失败，点此重试",
       "currentTooltip": "当前分支",
-      "sourceTooltip": "worktree 源分支",
-      "worktreeHint": "选择其他分支将以 worktree 隔离启动",
-      "exitWorktreeHint": "选择当前分支将退出 worktree，直接在当前分支上启动"
+      "sourceTooltip": "worktree 源分支"
     },
     "folderPicker": {
       "selectFolder": "选择文件夹",


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复新建任务页中分支选择与 Worktree 勾选框互相篡改状态的问题。

Worktree 勾选状态现在只会由用户点击勾选框本体改变：未勾选时，分支区域只读展示项目当前 checkout 分支；勾选后，分支区域才成为 Worktree 源分支选择器。选择分支不会再自动勾选或取消 Worktree。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈新建任务时 Worktree 勾选框无法独立取消，分支选择会自动改变勾选状态
- 本 PR 包含：分支选择状态机、Worktree 控件交互、四语言提示文案及对应 Renderer 单元测试
- 明确不包含：Worktree 创建、分支 checkout、自动命名及 Git 后端逻辑
- 用户可见变化：未勾选时分支区域只显示当前分支；必须先显式勾选 Worktree，才能选择源分支；切换分支不再改变勾选状态
- 是否存在 breaking change：无

### UI 变化

无视觉布局、颜色或组件样式变化；仅收紧已有联合控件的交互职责。未附截图，因为静态画面与改动前一致。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4「Component Stylings / Select & Dropdown」：继续复用既有 chip、dropdown 与 disabled 状态样式；§10「Light / Dark Dual-Mode Delivery Gate」：未新增颜色或模式分支，保留现有语义 token 与双模式表现；§14「Interaction Conventions」：将状态改变收敛到明确的勾选框操作，分支区按当前状态只承担展示或源分支选择职责。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy/.cindy-worktrees/auto-fmlbju
结果：通过，GATE_EXIT=0

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:i18n-glossary
结果：通过，en / zh-CN / ja / ko 无新增违规

pnpm check:dco
结果：通过，1 个提交已签署 DCO
```

### 手工验证

不涉及：当前运行中的 Desktop 来自主 checkout，功能 worktree 的 Renderer 改动不会被宿主实例热加载。

### 未执行的验证

- 未在 Light / Dark 模式下做实机目检；本 PR 未修改视觉样式或颜色。
- 未做运行时点击验证；交互状态由 Renderer 单元测试及全量单元测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 新建任务页的分支 / Worktree 联合控件
- 回滚 / 降级方式：回退本 PR 即恢复原有分支选择与勾选框双向联动行为；不涉及数据迁移或持久数据转换

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
