### PR TITLE
test(device-link): 入站重放用例模拟真实对端立即 ACK,消除 Windows 慢 runner 上的时序 flake

### DIFF
--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -792,6 +792,25 @@ describe('DeviceLinkClient', () => {
     // 对端重开链路 → 陈旧 push 前缀被清扫,live invoke-result 按原 seq 重放
     const sentBefore = firstSocket.sent.length;
     await establishInboundReliableLink(h, 'inbound-timeout-stream');
+    // 模拟真实接收端:重放帧已写入 socket FIFO 后立即回 ACK(见 client.ts
+    // sendTransportAck 的交付即确认语义)。不 ACK 的话,重放后 retryTimer
+    // 会在 Windows 低精度计时器(≈12ms>配置 5ms)下把同一帧再发一遍,慢 CI
+    // runner 上断言窗口跨过该周期时会把「重试重发」误判成「重放两次」。
+    const justReplayed = firstSocket.sent.slice(sentBefore).filter((env) => (
+      env.kind === 'invoke-result' && parseTransportPayload(env.payload)
+    ));
+    if (justReplayed.length > 0) {
+      const meta = parseTransportPayload(justReplayed[0].payload)!.meta;
+      h.current().push({
+        v: PROTOCOL_VERSION,
+        kind: 'push',
+        src: 'dev-b',
+        payload: {
+          channel: DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
+          payload: { streamId: meta.streamId, ackSeq: meta.seq },
+        },
+      });
+    }
     const replayed = firstSocket.sent.slice(sentBefore);
     const replays = replayed.filter((env) => (
       env.kind === 'invoke-result' && parseTransportPayload(env.payload)


### PR DESCRIPTION
## 问题

`packages/device-link/src/__tests__/client.test.ts` 的用例

> 入站 link 的可靠重试耗尽只重置该 peer link:relay 连接不拆,发 transport-timeout link-close,重开后 live 帧按原 seq 重放

在 Windows CI 分片上间歇失败（issue #1599）：

```
AssertionError: expected [ { v: 1, …(4) }, { v: 1, …(4) } ] to have a length of 1 but got 2
```

即重放后同一个 live 帧被计数为 2 次，而用例期望只重放一次。

## 根因

测试用例的时序假设过紧 + Windows 计时器精度差异：

1. 重试耗尽后本机发 `transport-timeout` link-close 并重置 peer link（`linkReady=false`），**保留 pending**（live invoke-result 等待重放）。
2. 对端重开链路 → `sendLinkAccept` → `replayPending`：重放 invoke-result（第 1 帧），随后 `ensureRetryTimer` **重启 retryTimer**。
3. 测试里对端重开后**从不 ACK** 重放帧。retryTimer 在下一次触发时（Windows 上 `setInterval(5ms)` 实际 ≈12ms，总是大于配置的 5ms 重试间隔）把同一帧**再次重发**（第 2 帧）。
4. 慢 CI runner 上断言窗口跨过该周期 → 把「重试重发」误判成「重放两次」。

**产品代码行为是正确的**：重放后对端若不 ACK，按可靠传输语义应当重试；真实接收端收到重放帧会立即回 ACK（`client.ts` 的 `sendTransportAck` 交付即确认），pending 随即清空、retryTimer 停止，不会出现第 2 帧。问题只在于**测试用例没有模拟真实对端的 ACK 行为**。

## 修复

在用例重开后，模拟真实接收端：对刚重放的 invoke-result **立即回 ACK**（与真实对端行为一致，与同文件 669 行用例的收尾方式相同，但在断言前完成）。断言语义不变——仍验证「重放恰好一次、按原 seq」。

## 验证

在 Windows 本机（`setInterval(5ms)` 实际 ≈12ms 的环境）执行：

- 目标用例连续运行多次：✅ 通过
- 修复前用同等时序（重放后等 100ms 让 retryTimer 触发）复现：`replays = 2` → **失败**
- 修复后同等时序：`replays = 1` → **通过**（ACK 后 pending 清空，retryTimer 停止）
- 完整 `packages/device-link` 测试：**166 passed**（6 files）
- `pnpm --dir packages/device-link run build`（tsc --noEmit）：通过

Closes #1599