### PR TITLE
test(lizi-mcps): 系统回写用例改按批上限常量建卡,消除 Windows 上 5s 超时 flake

### DIFF
--- a/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
@@ -423,8 +423,8 @@ describe('cindy_contacts tools', () => {
     expect(vcfExport.count).toBe(1);
   });
 
-  it('系统回写: group 超 200 条时按 host 单批上限分批执行, 不整批被拒', async () => {
-    // 回归: group 路径条数不受 zod cap 约束, 曾把 >200 的 plans 整批传给
+  it('系统回写: group 超单批上限时按批上限分批执行, 不整批被拒', async () => {
+    // 回归: group 路径条数不受 zod cap 约束, 曾把超单批上限的 plans 整批传给
     // writeSystemContacts(host 上限 200 直接拒绝) — dry_run 能过, 真执行全军覆没
     const store = manager.getStore();
     const g = parseResult(await registry.call('contacts_create_group', { name: '大组' })).data as {

--- a/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
@@ -43,7 +43,7 @@ function noopLogger() {
 /** 测试用的小批上限:注入 deps.systemWriteBatchSize 让分批在几笔建卡内触发,
  * 避免为跨过 host 默认 200 上限而建 201 张卡(Windows 慢 runner 上撞 vitest 5s
  * 超时, 见 #1598)。分批/锚点回归意图不变。 */
-const SYSTEM_WRITE_BATCH = 5;
+const TEST_SYSTEM_WRITE_BATCH_SIZE = 5;
 
 function parseResult(res: { content: Array<{ type: string; text?: string }> }): {
   ok: boolean;
@@ -82,7 +82,7 @@ describe('cindy_contacts tools', () => {
         mutations += 1;
       },
       // 测试用小批上限:分批/锚点回归在几笔建卡内触发, 避免建 201 张卡撞超时
-      systemWriteBatchSize: SYSTEM_WRITE_BATCH,
+      systemWriteBatchSize: TEST_SYSTEM_WRITE_BATCH_SIZE,
       // stub 回写器: 记录计划, created 返回伪 apple id
       writeSystemContacts: async (items): Promise<SystemContactWriteResult[]> => {
         writeCalls.push(items);
@@ -431,15 +431,15 @@ describe('cindy_contacts tools', () => {
       id: string;
     };
     const ids: string[] = [];
-    for (let i = 0; i < SYSTEM_WRITE_BATCH + 1; i += 1) {
+    for (let i = 0; i < TEST_SYSTEM_WRITE_BATCH_SIZE + 1; i += 1) {
       ids.push(store.createContact({ kind: 'person', displayName: `批量成员${i}`, source: 'agent' }).id);
     }
     store.addToGroup(g.id, ids);
 
     const res = parseResult(await registry.call('contacts_export_system', { group: '大组' }));
     expect(res.ok).toBe(true);
-    expect((res.data as { created: number }).created).toBe(SYSTEM_WRITE_BATCH + 1);
-    expect(writeCalls.map((batch) => batch.length)).toEqual([SYSTEM_WRITE_BATCH, 1]);
+    expect((res.data as { created: number }).created).toBe(TEST_SYSTEM_WRITE_BATCH_SIZE + 1);
+    expect(writeCalls.map((batch) => batch.length)).toEqual([TEST_SYSTEM_WRITE_BATCH_SIZE, 1]);
   });
 
   it('系统回写: 锚点每批立即回填, 后续批失败时已建卡不失锚', async () => {
@@ -450,7 +450,7 @@ describe('cindy_contacts tools', () => {
     const failingDeps: ContactsMcpDeps = {
       getManager: () => manager,
       isEnabled: () => true,
-      systemWriteBatchSize: SYSTEM_WRITE_BATCH,
+      systemWriteBatchSize: TEST_SYSTEM_WRITE_BATCH_SIZE,
       writeSystemContacts: async (items): Promise<SystemContactWriteResult[]> => {
         call += 1;
         if (call > 1) throw new Error('[PERMISSION_DENIED] revoked mid-run');
@@ -470,7 +470,7 @@ describe('cindy_contacts tools', () => {
       id: string;
     };
     const ids: string[] = [];
-    for (let i = 0; i < SYSTEM_WRITE_BATCH + 1; i += 1) {
+    for (let i = 0; i < TEST_SYSTEM_WRITE_BATCH_SIZE + 1; i += 1) {
       ids.push(store.createContact({ kind: 'person', displayName: `中断成员${i}`, source: 'agent' }).id);
     }
     store.addToGroup(g.id, ids);
@@ -481,7 +481,7 @@ describe('cindy_contacts tools', () => {
     const anchored = ids.filter((id) =>
       store.getContact(id).identities.some((i) => i.platform === 'apple-contacts'),
     );
-    expect(anchored).toHaveLength(SYSTEM_WRITE_BATCH);
+    expect(anchored).toHaveLength(TEST_SYSTEM_WRITE_BATCH_SIZE);
   });
 
   it('write/manage 工具成功后触发 onMutated, 只读工具不触发(UI 刷新通道)', async () => {

--- a/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
@@ -442,6 +442,45 @@ describe('cindy_contacts tools', () => {
     expect(writeCalls.map((batch) => batch.length)).toEqual([TEST_SYSTEM_WRITE_BATCH_SIZE, 1]);
   });
 
+  it('系统回写: 非法 systemWriteBatchSize(0/超限 201)回退默认 200, 小批量单批不分批', async () => {
+    // 回归: 注入值只接受 1..200 正整数, 0/负数/非整数/超限一律回退默认 200
+    // (防 for 步进失序或死循环, 防单批 slice 超 host 硬限制被拒)
+    const store = manager.getStore();
+    const g = parseResult(await registry.call('contacts_create_group', { name: '回退组' })).data as {
+      id: string;
+    };
+    const ids: string[] = [];
+    for (let i = 0; i < TEST_SYSTEM_WRITE_BATCH_SIZE + 1; i += 1) {
+      ids.push(store.createContact({ kind: 'person', displayName: `回退成员${i}`, source: 'agent' }).id);
+    }
+    store.addToGroup(g.id, ids);
+
+    for (const bad of [0, 201] as const) {
+      writeCalls.length = 0; // 每次迭代独立统计
+      const badDeps: ContactsMcpDeps = {
+        getManager: () => manager,
+        isEnabled: () => true,
+        systemWriteBatchSize: bad,
+        writeSystemContacts: async (items): Promise<SystemContactWriteResult[]> => {
+          writeCalls.push(items);
+          return items.map((it) => ({
+            contactId: it.contactId,
+            name: it.name,
+            action: 'created' as const,
+            appleId: `fake-${it.contactId.slice(0, 8)}`,
+          }));
+        },
+      };
+      const badRegistry = new ContactsToolRegistry();
+      registerContactsExportSystemTool(badRegistry, badDeps);
+      const res = parseResult(await badRegistry.call('contacts_export_system', { group: '回退组' }));
+      expect(res.ok).toBe(true);
+      // 回退 200 > 6: 单批写入, 未跨批
+      expect(writeCalls).toHaveLength(1);
+      expect(writeCalls[0]).toHaveLength(TEST_SYSTEM_WRITE_BATCH_SIZE + 1);
+    }
+  });
+
   it('系统回写: 锚点每批立即回填, 后续批失败时已建卡不失锚', async () => {
     // 回归: 锚点回填曾等全部批次完成后统一做 — 第二批抛错(权限被收回/超时)时
     // 首批已建的系统卡失锚, 下次回写同一批人会重复建卡。

--- a/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
@@ -40,6 +40,11 @@ function noopLogger() {
   return l;
 }
 
+/** 测试用的小批上限:注入 deps.systemWriteBatchSize 让分批在几笔建卡内触发,
+ * 避免为跨过 host 默认 200 上限而建 201 张卡(Windows 慢 runner 上撞 vitest 5s
+ * 超时, 见 #1598)。分批/锚点回归意图不变。 */
+const SYSTEM_WRITE_BATCH = 5;
+
 function parseResult(res: { content: Array<{ type: string; text?: string }> }): {
   ok: boolean;
   data?: unknown;
@@ -76,6 +81,8 @@ describe('cindy_contacts tools', () => {
       onMutated: () => {
         mutations += 1;
       },
+      // 测试用小批上限:分批/锚点回归在几笔建卡内触发, 避免建 201 张卡撞超时
+      systemWriteBatchSize: SYSTEM_WRITE_BATCH,
       // stub 回写器: 记录计划, created 返回伪 apple id
       writeSystemContacts: async (items): Promise<SystemContactWriteResult[]> => {
         writeCalls.push(items);
@@ -424,25 +431,26 @@ describe('cindy_contacts tools', () => {
       id: string;
     };
     const ids: string[] = [];
-    for (let i = 0; i < 201; i += 1) {
+    for (let i = 0; i < SYSTEM_WRITE_BATCH + 1; i += 1) {
       ids.push(store.createContact({ kind: 'person', displayName: `批量成员${i}`, source: 'agent' }).id);
     }
     store.addToGroup(g.id, ids);
 
     const res = parseResult(await registry.call('contacts_export_system', { group: '大组' }));
     expect(res.ok).toBe(true);
-    expect((res.data as { created: number }).created).toBe(201);
-    expect(writeCalls.map((batch) => batch.length)).toEqual([200, 1]);
+    expect((res.data as { created: number }).created).toBe(SYSTEM_WRITE_BATCH + 1);
+    expect(writeCalls.map((batch) => batch.length)).toEqual([SYSTEM_WRITE_BATCH, 1]);
   });
 
   it('系统回写: 锚点每批立即回填, 后续批失败时已建卡不失锚', async () => {
     // 回归: 锚点回填曾等全部批次完成后统一做 — 第二批抛错(权限被收回/超时)时
-    // 首批已建的 200 张系统卡失锚, 下次回写同一批人会重复建卡
+    // 首批已建的系统卡失锚, 下次回写同一批人会重复建卡。
     const store = manager.getStore();
     let call = 0;
     const failingDeps: ContactsMcpDeps = {
       getManager: () => manager,
       isEnabled: () => true,
+      systemWriteBatchSize: SYSTEM_WRITE_BATCH,
       writeSystemContacts: async (items): Promise<SystemContactWriteResult[]> => {
         call += 1;
         if (call > 1) throw new Error('[PERMISSION_DENIED] revoked mid-run');
@@ -462,18 +470,18 @@ describe('cindy_contacts tools', () => {
       id: string;
     };
     const ids: string[] = [];
-    for (let i = 0; i < 201; i += 1) {
+    for (let i = 0; i < SYSTEM_WRITE_BATCH + 1; i += 1) {
       ids.push(store.createContact({ kind: 'person', displayName: `中断成员${i}`, source: 'agent' }).id);
     }
     store.addToGroup(g.id, ids);
 
     const res = parseResult(await failingRegistry.call('contacts_export_system', { group: '中断组' }));
     expect(res.ok).toBe(false); // 第二批失败照常报错
-    // 但首批 200 人的锚点已落库, 不会因后续批失败而丢
+    // 但首批的锚点已落库, 不会因后续批失败而丢
     const anchored = ids.filter((id) =>
       store.getContact(id).identities.some((i) => i.platform === 'apple-contacts'),
     );
-    expect(anchored).toHaveLength(200);
+    expect(anchored).toHaveLength(SYSTEM_WRITE_BATCH);
   });
 
   it('write/manage 工具成功后触发 onMutated, 只读工具不触发(UI 刷新通道)', async () => {

--- a/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
+++ b/packages/lizi-mcps/src/__tests__/contactsTools.test.ts
@@ -442,7 +442,7 @@ describe('cindy_contacts tools', () => {
     expect(writeCalls.map((batch) => batch.length)).toEqual([TEST_SYSTEM_WRITE_BATCH_SIZE, 1]);
   });
 
-  it('系统回写: 非法 systemWriteBatchSize(0/超限 201)回退默认 200, 小批量单批不分批', async () => {
+  it('系统回写: 非法 systemWriteBatchSize(0/负数/非整数/超限)回退默认 200, 小批量单批不分批', async () => {
     // 回归: 注入值只接受 1..200 正整数, 0/负数/非整数/超限一律回退默认 200
     // (防 for 步进失序或死循环, 防单批 slice 超 host 硬限制被拒)
     const store = manager.getStore();
@@ -455,7 +455,7 @@ describe('cindy_contacts tools', () => {
     }
     store.addToGroup(g.id, ids);
 
-    for (const bad of [0, 201] as const) {
+    for (const bad of [0, -1, 1.5, Number.NaN, 201] as const) {
       writeCalls.length = 0; // 每次迭代独立统计
       const badDeps: ContactsMcpDeps = {
         getManager: () => manager,

--- a/packages/lizi-mcps/src/contacts/manage.ts
+++ b/packages/lizi-mcps/src/contacts/manage.ts
@@ -303,10 +303,14 @@ export function registerContactsExportSystemTool(registry: ContactsToolRegistry,
         // host 侧 writeSystemContacts 单批上限 200; ids 路径有 zod cap 而 group 路径
         // 条数不受限 — 超限前分批执行, 否则 dry_run 能过、真执行整批被拒。
         // 批上限可通过 deps.systemWriteBatchSize 注入(测试用小值省建卡开销)。
-        // 只接受正整数;0/负数/非整数会让下方 for 步进失序或死循环, 非法值回退默认。
+        // 只接受 1..200 的正整数:0/负数/非整数会让下方 for 步进失序或死循环,
+        // 超过 200 会让单批 slice 超出 host 硬限制被拒 — 非法/超限一律回退默认 200。
         const injected = deps.systemWriteBatchSize;
         const SYSTEM_WRITE_BATCH =
-          typeof injected === 'number' && Number.isInteger(injected) && injected > 0
+          typeof injected === 'number' &&
+          Number.isInteger(injected) &&
+          injected > 0 &&
+          injected <= 200
             ? injected
             : 200;
         const results: SystemContactWriteResult[] = [];

--- a/packages/lizi-mcps/src/contacts/manage.ts
+++ b/packages/lizi-mcps/src/contacts/manage.ts
@@ -301,8 +301,14 @@ export function registerContactsExportSystemTool(registry: ContactsToolRegistry,
           };
         }
         // host 侧 writeSystemContacts 单批上限 200; ids 路径有 zod cap 而 group 路径
-        // 条数不受限 — 超限前分批执行, 否则 dry_run 能过、真执行整批被拒
-        const SYSTEM_WRITE_BATCH = 200;
+        // 条数不受限 — 超限前分批执行, 否则 dry_run 能过、真执行整批被拒。
+        // 批上限可通过 deps.systemWriteBatchSize 注入(测试用小值省建卡开销)。
+        // 只接受正整数;0/负数/非整数会让下方 for 步进失序或死循环, 非法值回退默认。
+        const injected = deps.systemWriteBatchSize;
+        const SYSTEM_WRITE_BATCH =
+          typeof injected === 'number' && Number.isInteger(injected) && injected > 0
+            ? injected
+            : 200;
         const results: SystemContactWriteResult[] = [];
         let anchorsAdded = 0;
         // created 的锚点每批立即回填, 不等全部批次跑完: 后续批失败(权限中途被

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -402,7 +402,8 @@ export interface ContactsMcpDeps {
   ) => Promise<import('@cindy/maker-core').SystemContactWriteResult[]>;
   /**
    * 系统通讯录回写的单批上限(host 侧 writeSystemContacts 一次能接收的最大条数)。
-   * 缺省 200(host 硬限制);测试注入小值可省去大量建卡开销, 仍能验证分批边界。
+   * 只接受 1..200 的整数, 缺省 200(host 硬限制);非法值/超限回退 200。
+   * 测试注入小值可省去大量建卡开销, 仍能验证分批边界。
    */
   systemWriteBatchSize?: number;
   /**

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -401,6 +401,11 @@ export interface ContactsMcpDeps {
     items: import('@cindy/maker-core').SystemContactWriteItem[],
   ) => Promise<import('@cindy/maker-core').SystemContactWriteResult[]>;
   /**
+   * 系统通讯录回写的单批上限(host 侧 writeSystemContacts 一次能接收的最大条数)。
+   * 缺省 200(host 硬限制);测试注入小值可省去大量建卡开销, 仍能验证分批边界。
+   */
+  systemWriteBatchSize?: number;
+  /**
    * write/manage 类工具成功后的变更通知(host 注入, 用于广播 renderer 刷新)。
    * MCP 直写同进程 store 不经 IPC 层, 没有这个回调 UI 就收不到 agent 侧变更。
    */


### PR DESCRIPTION
## 问题

`packages/lizi-mcps/src/__tests__/contactsTools.test.ts` 的用例

> 系统回写: 锚点每批立即回填, 后续批失败时已建卡不失锚

在 Windows runner 上间歇失败（issue #1598）：

```
Error: Test timed out in 5000ms.
```

不是断言失败，是 **vitest 默认 5000ms 超时**。用例建 201 个联系人（`createContact` 全是同步 store 操作），Windows runner 的文件 IO / 进程开销比 macOS、Linux 高一截，201 次建卡本地毫秒级、Windows CI 上接近甚至超过 5s。

## 根因

用例只为**跨过 host 单批上限 200 触发分批**而建 201 张卡，201 这个数字对断言没有贡献（回归意图是「第二批失败时首批不失锚」），却是耗时主因。同一文件的另一个用例（group 分批）也建 201 张，同样有超时风险。

## 修复

按 issue 建议的方向（「把批量规模从 201 降到刚好跨批的量，用常量而非硬编码」）：

- 产品侧（可配置增强，缺省行为不变）：`contacts/manage.ts` 的分批上限改为读 `deps.systemWriteBatchSize`（缺省 200，与 host 硬限制一致；只接受 1..200 正整数，非法/超限回退 200），测试可注入小值省建卡开销
- 测试侧：`ContactsMcpDeps` 新增可选 `systemWriteBatchSize`；两个相关用例注入 5，建 `5+1` 个联系人即触发分批（`[5, 1]`），断言改用常量表达
- 回归意图不变：跨批触发分批、第二批抛错时首批锚点仍回填

## 验证

- `contactsTools.test.ts` 全部 21 用例通过（含两个改动用例）
- `tsc --noEmit` 通过

Closes #1598