### PR TITLE
test(device-link): 代际闸/clearDevice 在途写入用例改用清理前显式令牌,消除 withAutoToken 补读竞态

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheStore.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheStore.test.ts
@@ -1146,10 +1146,16 @@ describe('clearDevice / clearAll', () => {
   );
 
   it('clearAll 之后到达的在途写入不会把内容写回(代际闸)', async () => {
-    const c = cache();
+    // 必须用 rawCache + 显式令牌,不能用 withAutoToken(cache()):withAutoToken 会在
+    // writeMessages 调用时才异步补读作废计数,若清理恰在此之前完成,它拿到的是清理后
+    // 的新计数 —— 携带清理前旧数据的写入反而被当成新写入放行落盘(实测在 CI 慢环境下
+    // 偶发把 #1538 判红)。生产里令牌在远端请求**发起时**捕获(invalidationAtRequestStart),
+    // 早于任何清理;这里等价地在清理前捕获旧计数当令牌。
+    const c = rawCache();
     const rows = [row('m1', '2026-01-01T00:00:00.000Z')];
-    // 模拟并发:写入发起后、落盘前发生了登出清理。
-    const inFlight = c.writeMessages('dev-1', 'sess-1', rows);
+    // 模拟并发:写入发起后、落盘前发生了登出清理。令牌取清理前计数(请求发起时捕获)。
+    const token = (await c.readMessagesWithInvalidation('dev-1', 'sess-1')).invalidation;
+    const inFlight = c.writeMessages('dev-1', 'sess-1', rows, token);
     await c.clearAll();
     await inFlight;
 
@@ -1178,8 +1184,12 @@ describe('clearDevice / clearAll', () => {
   // review(codex P1):clearDevice 与 clearAll 同构 —— 在途写入的原子 rename 会在删除之后
   // 完成,把刚被撤销的设备正文重建出来。
   it('clearDevice 之后到达的在途写入不会重建该设备的消息', async () => {
-    const c = cache();
-    const inFlight = c.writeMessages('dev-1', 'sess-1', [row('m1', '2026-01-01T00:00:00.000Z')]);
+    // 同代际闸用例:用 rawCache + 清理前捕获的显式令牌(模拟真实客户端在远端请求
+    // 发起时捕获 invalidationAtRequestStart),避免 withAutoToken 在清理后补读拿到
+    // 新计数、把清理前旧数据的写入误放行。
+    const c = rawCache();
+    const token = (await c.readMessagesWithInvalidation('dev-1', 'sess-1')).invalidation;
+    const inFlight = c.writeMessages('dev-1', 'sess-1', [row('m1', '2026-01-01T00:00:00.000Z')], token);
     await c.clearDevice('dev-1');
     await inFlight;
     expect(await c.readMessages('dev-1', 'sess-1')).toEqual([]);

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheStore.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheStore.test.ts
@@ -1154,8 +1154,18 @@ describe('clearDevice / clearAll', () => {
     const c = rawCache();
     const rows = [row('m1', '2026-01-01T00:00:00.000Z')];
     // 模拟并发:写入发起后、落盘前发生了登出清理。令牌取清理前计数(请求发起时捕获)。
-    const token = (await c.readMessagesWithInvalidation('dev-1', 'sess-1')).invalidation;
-    const inFlight = c.writeMessages('dev-1', 'sess-1', rows, token);
+    // 非空写入需同时提供 invalidation / ownerRoot / accountCounter,否则 canCommitNonEmpty
+    // 会 fail-closed 拒写,测试就不再真正验证「清理前发起的在途写入被代际闸作废」(
+    // review: Copilot)。
+    const cap = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    const inFlight = c.writeMessages(
+      'dev-1',
+      'sess-1',
+      rows,
+      cap.invalidation,
+      cap.ownerRoot,
+      cap.accountCounter,
+    );
     await c.clearAll();
     await inFlight;
 
@@ -1188,8 +1198,15 @@ describe('clearDevice / clearAll', () => {
     // 发起时捕获 invalidationAtRequestStart),避免 withAutoToken 在清理后补读拿到
     // 新计数、把清理前旧数据的写入误放行。
     const c = rawCache();
-    const token = (await c.readMessagesWithInvalidation('dev-1', 'sess-1')).invalidation;
-    const inFlight = c.writeMessages('dev-1', 'sess-1', [row('m1', '2026-01-01T00:00:00.000Z')], token);
+    const cap = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    const inFlight = c.writeMessages(
+      'dev-1',
+      'sess-1',
+      [row('m1', '2026-01-01T00:00:00.000Z')],
+      cap.invalidation,
+      cap.ownerRoot,
+      cap.accountCounter,
+    );
     await c.clearDevice('dev-1');
     await inFlight;
     expect(await c.readMessages('dev-1', 'sess-1')).toEqual([]);


### PR DESCRIPTION
## 问题

`apps/desktop/src/main/device-link/__tests__/mirrorCacheStore.test.ts` 的两个用例在 CI 上间歇失败（issue #1538）：

- `clearAll 之后到达的在途写入不会把内容写回(代际闸)`（Linux verify + Windows 分片都出现过）
- `clearDevice 之后到达的在途写入不会重建该设备的消息`

失败断言：`expected [] to deeply equal []` 实际残留一条，或 20s 超时。本地无法复现（issue 作者 macOS 12 轮 + 本机 15 轮均通过）。

## 根因（withAutoToken 测试辅助的语义偏差，非产品缺陷）

`cache()` 包装的 `withAutoToken` 会在 **`writeMessages` 调用时**才异步补读作废计数当令牌：

```ts
async writeMessages(deviceId, sessionId, messages, expected) {
  const token = expected ?? (messages.length > 0
    ? (await store.readMessagesWithInvalidation(deviceId, sessionId)).invalidation  // ← 补读
    : undefined);
  return store.writeMessages(deviceId, sessionId, messages, token);
}
```

若 `clearAll`/`clearDevice` 恰在补读**之前**完成，令牌 = 清理后的**新计数** → `writeMessages` 内部 `now === expectedInvalidation` 匹配 → 各道防线（`isStale`、`clearedSince`）全部放行 → **携带清理前旧数据的写入落盘** → 文件残留 → 断言失败。CI 慢环境下这个窗口被放大。

**生产代码没有这个问题**：真实客户端在远端请求**发起时**捕获令牌（`mirrorCacheClient.ts` 的 `invalidationAtRequestStart`），早于任何清理——该文件注释明确"时序是这条屏障的全部意义"。同文件「并发写入串行化」用例已有先例：`rawCache + 显式令牌`。

## 修复

两个在途写入用例改用 `rawCache` + **清理前捕获的显式令牌**（`readMessagesWithInvalidation`），精确模拟真实客户端的令牌时序：

```ts
const c = rawCache();
const token = (await c.readMessagesWithInvalidation('dev-1', 'sess-1')).invalidation;
const inFlight = c.writeMessages('dev-1', 'sess-1', rows, token);
await c.clearAll();
await inFlight;
```

断言语义不变（清理后在途写入必须被作废），未放宽任何断言、未触碰产品代码。

## 验证

- 完整 `mirrorCacheStore.test.ts`：85 passed
- 代际闸/clearDevice 用例连跑 15 次：稳定通过
- desktop typecheck：通过
- 用「清理后发起写入」场景复现旧行为：withAutoToken 下文件残留（失败）；修复后显式令牌稳定拒绝

Closes #1538