### PR TITLE
fix(device-link): 修复远程任务自动起名

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts
@@ -21,7 +21,7 @@ const h = vi.hoisted(() => ({
       recent: [{ role: 'user' as const, text: '原始需求', createdAt: 1, rowid: 1 }],
     }),
   ),
-  generateTitle: vi.fn(async () => '任务标题'),
+  generateTitle: vi.fn(async (_request: unknown) => '任务标题'),
   drainPersistQueue: vi.fn<() => Promise<void>>(async () => undefined),
 }));
 
@@ -62,6 +62,7 @@ vi.mock('../../security/trustedAppRenderer.js', () => ({
 
 import { registerMakerTitleIpc } from '../title.js';
 import { getDbClient } from '../../localDb/client/current.js';
+import { runDeviceLinkInvokeContext } from '../../device-link/invoke-context.js';
 
 const EVENT = {} as Electron.IpcMainInvokeEvent;
 
@@ -71,10 +72,27 @@ function invoke(request: unknown): Promise<unknown> {
   return Promise.resolve(handler(EVENT, request));
 }
 
-function invokeRegenerate(sessionId: string): Promise<unknown> {
+function invokeGenerate(request: unknown): Promise<unknown> {
+  const handler = h.handlers.get('maker:generate-title');
+  if (!handler) throw new Error('generate-title handler not registered');
+  return Promise.resolve(handler(EVENT, request));
+}
+
+function invokeRegenerateRequest(request: unknown): Promise<unknown> {
   const handler = h.handlers.get('maker:regenerate-title');
   if (!handler) throw new Error('regenerate-title handler not registered');
-  return Promise.resolve(handler(EVENT, { sessionId }));
+  return Promise.resolve(handler(EVENT, request));
+}
+
+function invokeRegenerate(sessionId: string): Promise<unknown> {
+  return invokeRegenerateRequest({ sessionId });
+}
+
+function invokeFromDeviceLink(
+  channel: string,
+  invokeHandler: () => Promise<unknown>,
+): Promise<unknown> {
+  return runDeviceLinkInvokeContext({ controllerDeviceId: 'controller-1', channel }, invokeHandler);
 }
 
 beforeEach(() => {
@@ -211,6 +229,86 @@ describe('maker:regenerate-title — 当前 turn 状态', () => {
       expect.any(Number),
       expect.any(Function),
     );
+  });
+});
+
+describe('maker title IPC — 本机 / device-link 来源边界', () => {
+  it('非受信本机 Renderer 调用 generate / regenerate 均被拒且没有副作用', async () => {
+    h.trusted = false;
+
+    await expect(
+      invokeGenerate({ message: '排查远程标题', agentKind: 'codex', sessionId: 's1' }),
+    ).rejects.toThrow(/PERMISSION_DENIED/);
+    await expect(invokeRegenerate('s1')).rejects.toThrow(/PERMISSION_DENIED/);
+
+    expect(h.generateTitle).not.toHaveBeenCalled();
+    expect(h.drainPersistQueue).not.toHaveBeenCalled();
+  });
+
+  it('device-link 可信上下文允许合成 event 调用 generate / regenerate', async () => {
+    h.trusted = false;
+
+    await expect(
+      invokeFromDeviceLink('maker:generate-title', () =>
+        invokeGenerate({ message: '排查远程标题', agentKind: 'codex', sessionId: 's1' }),
+      ),
+    ).resolves.toEqual({ title: '任务标题' });
+    await expect(
+      invokeFromDeviceLink('maker:regenerate-title', () => invokeRegenerate('s1')),
+    ).resolves.toEqual({ title: '任务标题' });
+
+    expect(h.generateTitle).toHaveBeenCalledTimes(2);
+    expect(h.drainPersistQueue).toHaveBeenCalledOnce();
+  });
+
+  it('auto-title 不因 device-link 上下文放宽本机专属 sender 边界', async () => {
+    h.trusted = false;
+
+    await expect(
+      invokeFromDeviceLink('maker:auto-title', () =>
+        invoke({ sessionId: 's1', text: '排查远程标题', agentKind: 'codex' }),
+      ),
+    ).rejects.toThrow(/PERMISSION_DENIED/);
+    expect(h.run).not.toHaveBeenCalled();
+  });
+});
+
+describe('maker title IPC — payload 运行期校验', () => {
+  it.each([
+    ['非对象', null],
+    ['数组', []],
+    ['message 非字符串', { message: 1, agentKind: 'codex' }],
+    ['agentKind 非枚举值', { message: 'x', agentKind: 'gpt' }],
+    ['sessionId 空串', { message: 'x', agentKind: 'codex', sessionId: '' }],
+    ['sessionId 超长', { message: 'x', agentKind: 'codex', sessionId: 'a'.repeat(200) }],
+  ])('generate-title: %s → INVALID_PARAMS 且不调用模型', async (_label, payload) => {
+    await expect(invokeGenerate(payload)).rejects.toThrow(/INVALID_PARAMS/);
+    expect(h.generateTitle).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['非对象', null],
+    ['数组', []],
+    ['缺 sessionId', {}],
+    ['sessionId 非字符串', { sessionId: 1 }],
+    ['sessionId 空串', { sessionId: '' }],
+    ['sessionId 超长', { sessionId: 'a'.repeat(200) }],
+  ])('regenerate-title: %s → INVALID_PARAMS 且不读取素材', async (_label, payload) => {
+    await expect(invokeRegenerateRequest(payload)).rejects.toThrow(/INVALID_PARAMS/);
+    expect(h.drainPersistQueue).not.toHaveBeenCalled();
+    expect(h.regenerateMaterial).not.toHaveBeenCalled();
+  });
+
+  it('generate-title 截断超长正文，保留正常的空消息回落语义', async () => {
+    await invokeGenerate({ message: 'x'.repeat(9000), agentKind: 'claude-code' });
+    const forwarded = h.generateTitle.mock.calls[0]?.[0] as { prompt?: string } | undefined;
+    expect(forwarded?.prompt).toContain('x'.repeat(200));
+
+    h.generateTitle.mockClear();
+    await expect(invokeGenerate({ message: '', agentKind: 'codex' })).resolves.toEqual({
+      title: null,
+    });
+    expect(h.generateTitle).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/maker-ipc/title.ts
+++ b/apps/desktop/src/main/maker-ipc/title.ts
@@ -34,6 +34,7 @@ import {
 } from '../localDb/latestMessageText.js';
 import { createLogger } from '../logger.js';
 import { drainPersistQueue } from '../messagePersistBroadcaster.js';
+import { isDeviceLinkInvoke } from '../device-link/invoke-context.js';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
 import { TITLE_LANGUAGE_BY_LOCALE, buildRegenerateTitlePrompt } from './title-prompt.js';
@@ -219,6 +220,67 @@ const AUTO_TITLE_TEXT_MAX = 2000;
 /** sessionId 长度上限(UUID / cuid 都远小于此)。 */
 const SESSION_ID_MAX = 128;
 
+const TITLE_AGENT_KINDS = ['claude-code', 'codex', 'pi'] as const satisfies readonly AgentKind[];
+
+interface GenerateTitleRequest {
+  message: string;
+  agentKind: AgentKind;
+  sessionId?: string;
+}
+
+interface RegenerateTitleRequest {
+  sessionId: string;
+}
+
+function parseSessionId(raw: unknown, optional = false): string | undefined {
+  if (optional && raw === undefined) return undefined;
+  if (typeof raw !== 'string' || !raw || raw.length > SESSION_ID_MAX) {
+    throwIpcError('INVALID_PARAMS', 'invalid sessionId');
+  }
+  return raw;
+}
+
+function parseAgentKind(raw: unknown): AgentKind {
+  if (!TITLE_AGENT_KINDS.includes(raw as AgentKind)) {
+    throwIpcError('INVALID_PARAMS', 'invalid agentKind');
+  }
+  return raw as AgentKind;
+}
+
+/**
+ * `generate-title` / `regenerate-title` 可经 device-link allowlist 从受控设备调用。
+ * 远程来源只信主进程 AsyncLocalStorage 上下文,不信 payload 自报；本机调用仍要求真实
+ * Electron 顶层 Renderer sender。
+ */
+function assertTitleIpcCaller(event: Electron.IpcMainInvokeEvent): void {
+  if (!isDeviceLinkInvoke()) {
+    assertTrustedAppRendererEvent(event);
+  }
+}
+
+function parseGenerateTitleRequest(raw: unknown): GenerateTitleRequest {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throwIpcError('INVALID_PARAMS', 'generate-title request required');
+  }
+  const { message, agentKind, sessionId } = raw as Record<string, unknown>;
+  if (typeof message !== 'string') {
+    throwIpcError('INVALID_PARAMS', 'invalid message');
+  }
+  const parsedSessionId = parseSessionId(sessionId, true);
+  return {
+    message: message.slice(0, AUTO_TITLE_TEXT_MAX),
+    agentKind: parseAgentKind(agentKind),
+    ...(parsedSessionId === undefined ? {} : { sessionId: parsedSessionId }),
+  };
+}
+
+function parseRegenerateTitleRequest(raw: unknown): RegenerateTitleRequest {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    throwIpcError('INVALID_PARAMS', 'regenerate-title request required');
+  }
+  return { sessionId: parseSessionId((raw as Record<string, unknown>).sessionId)! };
+}
+
 /**
  * 运行期校验 `maker:auto-title` 的 payload。结构、长度、枚举值不合法一律按
  * INVALID_PARAMS 拒绝,不让畸形值进到会改写标题 / 调用付费模型的副作用路径。
@@ -228,23 +290,17 @@ function parseAutoTitleRequest(raw: unknown): SessionAutoTitleRequest {
     throwIpcError('INVALID_PARAMS', 'auto-title request required');
   }
   const { sessionId, text, agentKind, isUserText } = raw as Record<string, unknown>;
-  if (typeof sessionId !== 'string' || !sessionId || sessionId.length > SESSION_ID_MAX) {
-    throwIpcError('INVALID_PARAMS', 'invalid sessionId');
-  }
   if (typeof text !== 'string') {
     throwIpcError('INVALID_PARAMS', 'invalid text');
-  }
-  if (agentKind !== 'claude-code' && agentKind !== 'codex' && agentKind !== 'pi') {
-    throwIpcError('INVALID_PARAMS', 'invalid agentKind');
   }
   if (isUserText !== undefined && typeof isUserText !== 'boolean') {
     throwIpcError('INVALID_PARAMS', 'invalid isUserText');
   }
   return {
-    sessionId,
+    sessionId: parseSessionId(sessionId)!,
     // 截断而非拒绝:超长正文是正常输入,标题只需要开头一小段。
     text: (text as string).slice(0, AUTO_TITLE_TEXT_MAX),
-    agentKind,
+    agentKind: parseAgentKind(agentKind),
     ...(isUserText === undefined ? {} : { isUserText }),
   };
 }
@@ -256,20 +312,17 @@ export interface RegisterMakerTitleIpcOptions {
 
 export function registerMakerTitleIpc(options: RegisterMakerTitleIpcOptions = {}): void {
   // 这两条通道读供应商快照时会放行本机绑定自愈(写绑定文件、并为 Anthropic 起一次带凭证的
-  // 清单发现),与下面的 AUTO_TITLE 同属特权入口,守卫口径也应当一致 —— 原先只有 AUTO_TITLE
-  // 做了 sender 断言(PR #548 review)。两者都不在 device-link allowlist 里,可以直接用会抛的
-  // 守卫。
+  // 清单发现),因此本机调用必须守住真实 Renderer sender。它们同时是 device-link allowlist
+  // 的既有远程能力:远程身份由 dispatch 的开关 / 撤销 / allowlist 三道 gate + invoke async
+  // context 证明；合成 event 没有 Electron sender,不能再重复套本机 sender 判据。
   ipcMain.handle(
     MAKER_INVOKE.GENERATE_TITLE,
     async (
       event: Electron.IpcMainInvokeEvent,
-      {
-        message,
-        agentKind,
-        sessionId,
-      }: { message: string; agentKind: AgentKind; sessionId?: string },
+      rawRequest: unknown,
     ): Promise<{ title: string | null }> => {
-      assertTrustedAppRendererEvent(event);
+      assertTitleIpcCaller(event);
+      const { message, agentKind, sessionId } = parseGenerateTitleRequest(rawRequest);
       return { title: await generateMakerSessionTitle(message, agentKind, sessionId) };
     },
   );
@@ -277,9 +330,10 @@ export function registerMakerTitleIpc(options: RegisterMakerTitleIpcOptions = {}
     MAKER_INVOKE.REGENERATE_TITLE,
     async (
       event: Electron.IpcMainInvokeEvent,
-      { sessionId }: { sessionId: string },
+      rawRequest: unknown,
     ): Promise<{ title: string | null }> => {
-      assertTrustedAppRendererEvent(event);
+      assertTitleIpcCaller(event);
+      const { sessionId } = parseRegenerateTitleRequest(rawRequest);
       // Snapshot on both sides of the durable FIFO. The pre-drain value preserves
       // a pending terminal boundary that settles while we wait; the post-drain
       // value catches a new turn that starts during the same window. OR keeps
@@ -290,8 +344,7 @@ export function registerMakerTitleIpc(options: RegisterMakerTitleIpcOptions = {}
       let pendingCompletionObserved = pendingCompletionBeforeDrain;
       const latestTurnIsPendingCompletion = (): boolean => {
         if (!pendingCompletionObserved) {
-          pendingCompletionObserved =
-            options.isSessionTurnPendingCompletion?.(sessionId) === true;
+          pendingCompletionObserved = options.isSessionTurnPendingCompletion?.(sessionId) === true;
         }
         return pendingCompletionObserved;
       };

--- a/apps/desktop/src/renderer/__tests__/makerTransportRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/makerTransportRouting.test.ts
@@ -24,6 +24,7 @@ function stubElectron() {
     closeSession: vi.fn(),
     enableOrca: vi.fn(),
     disableOrca: vi.fn(),
+    regenerateSessionTitle: vi.fn().mockResolvedValue({ title: 'local title' }),
     plugins: { getState: vi.fn().mockResolvedValue({ effectiveEnabled: true }) },
     input: { clearSession: vi.fn(), compact: vi.fn() },
   };
@@ -181,6 +182,34 @@ describe('makerApiFor 路由(完整对等会话级操作)', () => {
     await getSessionFor('rs');
 
     expect(invoke).toHaveBeenCalledWith('dev-1', 'local-db:sessions:get', ['rs']);
+  });
+
+  it('regenerateSessionTitleFor:镜像清空期间仍在被控端自动起名，不回落控制端本机', async () => {
+    const { makerSpies, invoke } = stubElectron();
+    invoke.mockResolvedValue({ title: 'remote title' });
+    const { regenerateSessionTitleFor } = await import('@/lib/makerTransport');
+    const { remoteProjectsStore } = await import('@/features/device-link/remoteProjectsStore');
+
+    remoteProjectsStore.setDeviceSessions('dev-1', 'Mac', [sess('rs')]);
+    await regenerateSessionTitleFor('rs');
+    expect(invoke).toHaveBeenCalledWith('dev-1', 'maker:regenerate-title', [{ sessionId: 'rs' }]);
+
+    invoke.mockClear();
+    remoteProjectsStore.clear();
+    await regenerateSessionTitleFor('rs');
+
+    expect(invoke).toHaveBeenCalledWith('dev-1', 'maker:regenerate-title', [{ sessionId: 'rs' }]);
+    expect(makerSpies.regenerateSessionTitle).not.toHaveBeenCalled();
+  });
+
+  it('regenerateSessionTitleFor:从未有远程归属的会话仍走本机', async () => {
+    const { makerSpies, invoke } = stubElectron();
+    const { regenerateSessionTitleFor } = await import('@/lib/makerTransport');
+
+    await regenerateSessionTitleFor('local-only');
+
+    expect(makerSpies.regenerateSessionTitle).toHaveBeenCalledWith('local-only');
+    expect(invoke).not.toHaveBeenCalled();
   });
 
   it('远程会话 patchMeta(删/归档/改名/置顶)经隧道 local-db:sessions:patch-meta', async () => {

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -116,9 +116,7 @@ function buildRemoteSetModelArgs(args: SetModelArgs): unknown[] {
     wireArgs.push(providerId === undefined ? null : providerId);
   }
   if (expectedAgentSwitchRevision !== undefined || selection !== undefined) {
-    wireArgs.push(
-      expectedAgentSwitchRevision === undefined ? null : expectedAgentSwitchRevision,
-    );
+    wireArgs.push(expectedAgentSwitchRevision === undefined ? null : expectedAgentSwitchRevision);
   }
   if (selection !== undefined) wireArgs.push(selection);
   return wireArgs;
@@ -134,7 +132,11 @@ function remoteMakerApi(deviceId: string): RoutableMaker {
   return {
     send: t('maker:send') as FullMaker['send'],
     setModel: (async (...args: SetModelArgs) =>
-      invokeRemote(deviceId, 'maker:set-model', buildRemoteSetModelArgs(args))) as FullMaker['setModel'],
+      invokeRemote(
+        deviceId,
+        'maker:set-model',
+        buildRemoteSetModelArgs(args),
+      )) as FullMaker['setModel'],
     switchSessionAgent: t('maker:switch-session-agent') as FullMaker['switchSessionAgent'],
     getSessionAgentSwitchIntent: t(
       'maker:get-session-agent-switch-intent',
@@ -237,7 +239,7 @@ export function isRemoteSessionSticky(sessionId: string): boolean {
  * 老被控端无此 channel 时 invoke 以 CHANNEL_NOT_ALLOWED 拒绝,调用方按生成失败提示。
  */
 export function regenerateSessionTitleFor(sessionId: string): Promise<{ title: string | null }> {
-  const deviceId = getSessionDeviceId(sessionId);
+  const deviceId = getStickySessionDeviceId(sessionId);
   if (!deviceId) return window.electronAPI.maker.regenerateSessionTitle(sessionId);
   return invokeRemote(deviceId, 'maker:regenerate-title', [{ sessionId }]) as Promise<{
     title: string | null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复设备互联远程控制下，任务重命名输入框 Magic 自动起名失败的问题。被控端的标题 IPC 现在能正确识别已经通过 device-link 安全门禁的远程调用，同时保留本机 Renderer 来源校验。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：用户反馈的远程任务自动起名失败。
- 本 PR 包含：`maker:generate-title` / `maker:regenerate-title` 的远程来源处理、运行时参数校验，以及重连窗口的 sticky device 路由回归保护。
- 明确不包含：普通首条消息后的自动标题链路、SSH 远程工作区链路、device-link 重试或 teardown 机制。
- 用户可见变化：从另一台桌面或手机重命名任务时，Magic 自动起名可正常执行；relay 瞬时重连时不会错误打到控制端本机。
- 是否存在 breaking change：无。复用已有 channel 和 allowlist，不改变 wire protocol。

### UI 变化

- 不涉及：没有修改 UI 结构、样式或文案，只修复既有 Magic 操作的传输与 Main IPC 边界。
- 引用的设计规范：不涉及：纯逻辑与传输层修复，无视觉/交互/文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run \
  src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts \
  src/renderer/__tests__/makerTransportRouting.test.ts \
  src/main/__tests__/deviceLinkAutoTitleWiring.test.ts \
  src/main/__tests__/deviceLinkDispatch.test.ts \
  src/main/maker-ipc/__tests__/regenerateSessionTitle.test.ts
结果：5 个文件、178 条测试全部通过。

pnpm --filter mobile exec vitest run src/__tests__/mobileMakerTransport.test.ts
结果：18 条测试全部通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：全部 workspace 通过，0 失败；仓库既有无测试 workspace 按配置跳过。
```

### 手工验证

不涉及：本 PR 未启动两台真实设备做端到端手工验证，因该验证需要两个独立的开发版客户端和可用的 device-link 账号连接。

### 未执行的验证

两台设备的真实远程 UI 操作与 relay 重连手工场景未执行；自动测试覆盖了合成 device-link invoke、非可信本机 Renderer 拒绝、非法 payload，以及 sticky 路由恢复。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据

### 影响与回滚

- 影响范围：device-link 远程 `generate-title` / `regenerate-title`。调用仍受 remote control 开关、控制端撤销状态和 channel allowlist 约束；本机调用仍受 trusted Renderer sender 校验。
- SSH 远程工作区不涉及；device-link 使用既有 allowlist，无新增 channel；手机版复用既有 `maker:regenerate-title`，对应传输测试已通过。
- 本 PR 未修改 retry、timeout、teardown 或 relay 恢复动作，因此不扩大 device-link 故障半径。
- 回滚 / 降级方式：回滚本 PR commit 即恢复旧行为；旧版被控端不具备本修复，远程标题生成仍会按旧逻辑失败，但不会影响其它 channel。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 变化已注明“不涉及”
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果
