### PR TITLE
fix(desktop): X 回复收到服务端确认前持续重试

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -9,6 +9,7 @@ import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  HOOK_FEATURE_TURN_DELIVERY,
   HOOK_FEATURE_TURN_REOPEN,
   type HookMessage,
   type TaskDispatchPayload,
@@ -282,7 +283,6 @@ describe('normalizeTaskSource', () => {
     }
     expect(fr.calls.map((call) => call.laneKind)).toEqual(['group', 'group', 'dm', 'dm']);
   });
-
 });
 
 describe('dispatcher 核心语义', () => {
@@ -433,7 +433,8 @@ describe('dispatcher 核心语义', () => {
     d.handleDispatch(
       'conn-1',
       dispatch({
-        prompt: '<thread_context>\n[@alice] 为啥大厂都自研 agent\n</thread_context>\n\n以上仅供参考\n\n你来解释下这个问题',
+        prompt:
+          '<thread_context>\n[@alice] 为啥大厂都自研 agent\n</thread_context>\n\n以上仅供参考\n\n你来解释下这个问题',
         source: { im: 'x', userText: '你来解释下这个问题' },
       }),
       c.send,
@@ -1237,6 +1238,101 @@ describe('dispatcher 核心语义', () => {
     const c2 = collector();
     d.onConnected('conn-1', c2.send);
     expect(c2.last('turn.end')?.payload).toMatchObject({ finalText: '离线结果' });
+  });
+
+  it('协商 delivery ACK 后，accepted 前按退避重放同一 turn.end，accepted 后停止并释放正文', async () => {
+    vi.useFakeTimers();
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({ runner: fr.runner });
+    const c = collector();
+    try {
+      d.onConnected('conn-1', c.send, [HOOK_FEATURE_TURN_DELIVERY]);
+      d.handleDispatch('conn-1', dispatch(), c.send);
+      await tick();
+      fr.finish({ finalText: '等待接管' });
+      await tick();
+      expect(c.ofType('turn.end')).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(c.ofType('turn.end')).toHaveLength(2);
+      expect(c.ofType('turn.end')[1]).toEqual(c.ofType('turn.end')[0]);
+
+      d.handleTurnDelivery('conn-1', {
+        requestId: 'req-1',
+        state: 'accepted',
+        attempt: 0,
+        retryAt: null,
+        error: null,
+      });
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(c.ofType('turn.end')).toHaveLength(2);
+    } finally {
+      d.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it('ACK server 断线期间完成的 turn.end 在重连后进入 ACK 缓冲，retrying 也视为已接管', async () => {
+    vi.useFakeTimers();
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({ runner: fr.runner });
+    const first = collector();
+    const second = collector();
+    try {
+      d.onConnected('conn-1', first.send, [HOOK_FEATURE_TURN_DELIVERY]);
+      d.handleDispatch('conn-1', dispatch(), first.send);
+      await tick();
+      d.onDisconnected('conn-1');
+      fr.finish({ finalText: '离线完成' });
+      await tick();
+      expect(first.ofType('turn.end')).toHaveLength(0);
+
+      d.onConnected('conn-1', second.send, [HOOK_FEATURE_TURN_DELIVERY]);
+      expect(second.ofType('turn.end')).toHaveLength(1);
+      d.handleTurnDelivery('conn-1', {
+        requestId: 'req-1',
+        state: 'retrying',
+        attempt: 1,
+        retryAt: Date.now() + 60_000,
+        error: { code: 'X_UNAVAILABLE', message: 'retrying', retryable: true },
+      });
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(second.ofType('turn.end')).toHaveLength(1);
+    } finally {
+      d.dispose();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(['delivered', 'failed'] as const)('终态 %s 也会释放待重放正文', async (state) => {
+    vi.useFakeTimers();
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({ runner: fr.runner });
+    const c = collector();
+    try {
+      d.onConnected('conn-1', c.send, [HOOK_FEATURE_TURN_DELIVERY]);
+      d.handleDispatch('conn-1', dispatch(), c.send);
+      await tick();
+      fr.finish({ finalText: '终态确认' });
+      await tick();
+      expect(c.ofType('turn.end')).toHaveLength(1);
+
+      d.handleTurnDelivery('conn-1', {
+        requestId: 'req-1',
+        state,
+        attempt: 1,
+        retryAt: null,
+        error:
+          state === 'failed'
+            ? { code: 'X_REQUEST_REJECTED', message: 'rejected', retryable: false }
+            : null,
+      });
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(c.ofType('turn.end')).toHaveLength(1);
+    } finally {
+      d.dispose();
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/transport-manager.test.ts
@@ -21,8 +21,10 @@ import {
   HOOK_FEATURE_PROVIDER_BEHAVIOR,
   HOOK_FEATURE_PROVIDER_PREFS,
   HOOK_FEATURE_PROVIDER_TELEGRAM,
+  HOOK_FEATURE_PROVIDER_X,
   HOOK_FEATURE_SESSION_PICKER,
   HOOK_FEATURE_SLACK_TOOLS,
+  HOOK_FEATURE_TURN_DELIVERY,
   makeBindState,
   makeBindUpdate,
   makePing,
@@ -33,6 +35,7 @@ import {
   makeProviderPrefsState,
   makeQueryRequest,
   makeTaskDispatch,
+  makeTurnDelivery,
   makeToolResponse,
   makeWelcome,
   parseHookMessage,
@@ -175,6 +178,63 @@ afterEach(() => {
 });
 
 describe('hook-control runtime capability gate', () => {
+  it('X hello 声明 delivery ACK，且只在 welcome 双向协商后把回执路由给 dispatcher', () => {
+    const transportOpts: HookTransportOpts[] = [];
+    const handleTurnDelivery = vi.fn();
+    const dispatcher = {
+      handleDispatch: vi.fn(),
+      onConnected: vi.fn(),
+      onDisconnected: vi.fn(),
+      cancel: vi.fn(),
+      handleSessionArchive: vi.fn(),
+      handleInteractionDecision: vi.fn(),
+      handleTurnDelivery,
+      activateAccount: vi.fn(),
+      deactivateAccount: vi.fn(async () => undefined),
+      dispose: vi.fn(),
+    } as NonNullable<HookControlManagerDeps['dispatcher']>;
+    const manager = makeManager(
+      memoryStore({ url: 'wss://unused.example', enabled: false, xEnabled: true }),
+      {
+        dispatcher,
+        getXUrl: () => 'wss://x-hook.example',
+        createTransport: (opts) => {
+          transportOpts.push(opts);
+          return { send: () => true, dispose: () => {} };
+        },
+      },
+    );
+    manager.sync();
+    const opts = transportOpts[0];
+    if (opts === undefined) throw new Error('X transport was not created');
+    expect(opts.buildHello().features).toContain(HOOK_FEATURE_TURN_DELIVERY);
+
+    const delivery = makeTurnDelivery({
+      requestId: 'x:999:post-1',
+      state: 'accepted',
+      attempt: 0,
+      retryAt: null,
+      error: null,
+    });
+    opts.onMessage(delivery, () => true);
+    expect(handleTurnDelivery).not.toHaveBeenCalled();
+
+    opts.onWelcome?.({
+      serverName: 'x-hook',
+      features: [
+        HOOK_FEATURE_PROVIDER_BIND,
+        HOOK_FEATURE_PROVIDER_PREFS,
+        HOOK_FEATURE_SESSION_PICKER,
+        HOOK_FEATURE_PROVIDER_X,
+        HOOK_FEATURE_TURN_DELIVERY,
+      ],
+    });
+    opts.onStatus('connected', null);
+    opts.onMessage(delivery, () => true);
+    expect(handleTurnDelivery).toHaveBeenCalledWith(expect.stringMatching(/:x$/), delivery.payload);
+    manager.dispose();
+  });
+
   it('keeps an enabled cloud preference disconnected when the capability is unavailable', () => {
     const createTransport = vi.fn(() => {
       throw new Error('transport must not start');
@@ -1524,6 +1584,7 @@ describe('Telegram provider capability, binding and prefs', () => {
       cancel: vi.fn(),
       handleSessionArchive: vi.fn(),
       handleInteractionDecision: vi.fn(),
+      handleTurnDelivery: vi.fn(),
       activateAccount: vi.fn(),
       deactivateAccount: vi.fn(async () => undefined),
       dispose: vi.fn(),
@@ -2619,9 +2680,7 @@ describe('Telegram provider capability, binding and prefs', () => {
     const server = collectFrames(sock);
     const hello = await server.waitFor('hello');
     if (hello.type !== 'hello') throw new Error('unreachable');
-    expect(hello.payload.features).toEqual(
-      expect.arrayContaining(TELEGRAM_FEATURES),
-    );
+    expect(hello.payload.features).toEqual(expect.arrayContaining(TELEGRAM_FEATURES));
     sock.send(
       serializeHookMessage(
         makeWelcome({ serverName: 'telegram-server', features: TELEGRAM_FEATURES }),

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -42,8 +42,10 @@ import {
   makeTurnEnd,
   makeTurnProgress,
   makeTurnReopen,
+  HOOK_FEATURE_TURN_DELIVERY,
   HOOK_FEATURE_TURN_REOPEN,
   type HookMessage,
+  type HookTurnEndMessage,
   type InteractionButton,
   type InteractionDecisionPayload,
   type TaskAckPayload,
@@ -51,6 +53,7 @@ import {
   type TaskDispatchPayload,
   type TaskRejectReason,
   type TaskSource,
+  type TurnDeliveryPayload,
 } from '@cindy/slack-hook-protocol';
 
 import { HOOK_CHAT_WORKSPACE_ALIAS } from '../../shared/hookControlIpc.js';
@@ -333,6 +336,8 @@ export interface HookDispatcher {
    * 正在执行的任务)后按 interactionId 配对 resolve; 未知 / 迟到的静默忽略。
    */
   handleInteractionDecision(connectionId: string, payload: InteractionDecisionPayload): void;
+  /** X server 对普通 turn.end 的持久接管 / 渠道发布状态回执。 */
+  handleTurnDelivery(connectionId: string, payload: TurnDeliveryPayload): void;
   /** Re-open ingress after the next account DB is ready. */
   activateAccount(): void;
   /** Close ingress, abort old-account turns and await their final async boundary. */
@@ -349,6 +354,10 @@ export interface HookDispatcher {
 const MAX_QUEUE_PER_SESSION = 20;
 /** 单连接离线 turn.end 缓存上限(FIFO 丢最老)。 */
 const MAX_PENDING_TURN_ENDS = 100;
+/** ACK 能力启用后，普通 turn.end 在未获 server 接管确认前的首轮等待。 */
+const TURN_DELIVERY_ACK_TIMEOUT_MS = 10_000;
+/** 重发退避封顶；完整正文仍保留到 ACK、账号切换或容量淘汰。 */
+const TURN_DELIVERY_ACK_MAX_DELAY_MS = 60_000;
 
 /**
  * 失败任务的续跑记账保留时长。
@@ -597,7 +606,17 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   /** 每连接当前发送函数(transport 重建后由 onConnected / handleDispatch 刷新)。 */
   const sendFns = new Map<string, (m: HookMessage) => boolean>();
   /** 离线积压的 turn.end, 按连接缓存。 */
-  const pendingTurnEnds = new Map<string, HookMessage[]>();
+  const pendingTurnEnds = new Map<string, HookTurnEndMessage[]>();
+  /** 双向 ACK 已协商时，等待 server durable accepted 的完整 turn.end 副本。 */
+  const pendingDeliveryTurnEnds = new Map<
+    string,
+    {
+      connectionId: string;
+      message: HookTurnEndMessage;
+      attempts: number;
+      timer: ReturnType<typeof setTimeout> | null;
+    }
+  >();
   /** 正在执行 turn 的 session(本模块发起的)。 */
   const running = new Set<string>();
   /**
@@ -774,7 +793,77 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     return `${connectionId} ${requestId}`;
   }
 
-  function sendOrBuffer(connectionId: string, msg: HookMessage): void {
+  function supportsDeliveryAck(connectionId: string): boolean {
+    return serverFeatures.get(connectionId)?.includes(HOOK_FEATURE_TURN_DELIVERY) === true;
+  }
+
+  function clearPendingDelivery(key: string): void {
+    const pending = pendingDeliveryTurnEnds.get(key);
+    if (pending?.timer) clearTimeout(pending.timer);
+    pendingDeliveryTurnEnds.delete(key);
+  }
+
+  function enforcePendingDeliveryLimit(connectionId: string): void {
+    const keys = [...pendingDeliveryTurnEnds]
+      .filter(([, pending]) => pending.connectionId === connectionId)
+      .map(([key]) => key);
+    while (keys.length > MAX_PENDING_TURN_ENDS) {
+      const oldest = keys.shift();
+      if (oldest !== undefined) {
+        const evictedRequestId = pendingDeliveryTurnEnds.get(oldest)?.message.payload.requestId;
+        clearPendingDelivery(oldest);
+        log.warn(
+          `turn.end ACK buffer full; oldest result evicted: connectionId=${connectionId} requestId=${evictedRequestId ?? 'unknown'}`,
+        );
+      }
+    }
+  }
+
+  function sendPendingDelivery(
+    key: string,
+    pending: NonNullable<ReturnType<typeof pendingDeliveryTurnEnds.get>>,
+    sendOverride?: (m: HookMessage) => boolean,
+  ): void {
+    if (pendingDeliveryTurnEnds.get(key) !== pending) return;
+    if (pending.timer) clearTimeout(pending.timer);
+    pending.timer = null;
+    const send = sendOverride ?? sendFns.get(pending.connectionId);
+    if (!send || !send(pending.message)) return;
+    pending.attempts += 1;
+    const delay = Math.min(
+      TURN_DELIVERY_ACK_TIMEOUT_MS * 2 ** Math.min(3, Math.max(0, pending.attempts - 1)),
+      TURN_DELIVERY_ACK_MAX_DELAY_MS,
+    );
+    const timer = setTimeout(() => {
+      if (pendingDeliveryTurnEnds.get(key) !== pending) return;
+      pending.timer = null;
+      log.warn(
+        `turn.end ACK timed out; replaying unchanged result: ${pending.message.payload.requestId}`,
+      );
+      sendPendingDelivery(key, pending);
+    }, delay);
+    timer.unref?.();
+    pending.timer = timer;
+  }
+
+  function trackPendingDelivery(connectionId: string, msg: HookTurnEndMessage): void {
+    const key = ackKey(connectionId, msg.payload.requestId);
+    const existing = pendingDeliveryTurnEnds.get(key);
+    if (existing !== undefined) {
+      sendPendingDelivery(key, existing);
+      return;
+    }
+    const pending = { connectionId, message: msg, attempts: 0, timer: null };
+    pendingDeliveryTurnEnds.set(key, pending);
+    enforcePendingDeliveryLimit(connectionId);
+    if (pendingDeliveryTurnEnds.get(key) === pending) sendPendingDelivery(key, pending);
+  }
+
+  function sendOrBuffer(connectionId: string, msg: HookTurnEndMessage): void {
+    if (supportsDeliveryAck(connectionId)) {
+      trackPendingDelivery(connectionId, msg);
+      return;
+    }
     const send = sendFns.get(connectionId);
     if (send && send(msg)) return;
     const buf = pendingTurnEnds.get(connectionId) ?? [];
@@ -1731,6 +1820,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       queues.clear();
       sendFns.clear();
       pendingTurnEnds.clear();
+      for (const key of [...pendingDeliveryTurnEnds.keys()]) clearPendingDelivery(key);
       // 能力快照按连接存, 而连接身份含账号指纹 —— 换账号后旧条目永远不会再被
       // 命中, 但留着会让 supportsReopen 对"同名连接"给出上一个账号的答案。
       serverFeatures.clear();
@@ -1866,6 +1956,26 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         `interaction.decision ${payload.interactionId} button=${payload.buttonId} resolved=${resolved}`,
       );
     },
+    handleTurnDelivery(connectionId, payload) {
+      if (!accountActive) return;
+      const key = ackKey(connectionId, payload.requestId);
+      clearPendingDelivery(key);
+      if (payload.state === 'retrying') {
+        log.warn(
+          `turn.end accepted; X publish retrying: requestId=${payload.requestId} attempt=${payload.attempt} retryAt=${payload.retryAt ?? 'unknown'} code=${payload.error?.code ?? 'unknown'}`,
+        );
+        return;
+      }
+      if (payload.state === 'failed') {
+        log.warn(
+          `turn.end delivery failed: requestId=${payload.requestId} attempt=${payload.attempt} code=${payload.error?.code ?? 'unknown'}`,
+        );
+        return;
+      }
+      log.info(
+        `turn.end delivery ${payload.state}: requestId=${payload.requestId} attempt=${payload.attempt}`,
+      );
+    },
     cancel(connectionId, requestId) {
       if (!accountActive) return;
       // 1) 排队中的: 从队列摘除, 立即回 cancelled(任务从未开始)
@@ -1914,6 +2024,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     },
     onDisconnected(connectionId) {
       sendFns.delete(connectionId);
+      for (const pending of pendingDeliveryTurnEnds.values()) {
+        if (pending.connectionId !== connectionId || pending.timer === null) continue;
+        clearTimeout(pending.timer);
+        pending.timer = null;
+      }
       // 断连是续跑回流的终局(协议阶段 18): server 此刻会收口那条消息并解绑这一轮
       // 的 requestId。观察器若活到重连后, 它的 progress / turn.end 会带着那个已被
       // 解绑的 id 发到新 socket(dispatchId 在重连间稳定, 所以真的发得出去), 被当
@@ -1942,6 +2057,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       pendingReopens.clear();
       serverFeatures.clear();
       sendFns.clear();
+      pendingTurnEnds.clear();
+      for (const key of [...pendingDeliveryTurnEnds.keys()]) clearPendingDelivery(key);
     },
     onConnected(connectionId, send, features) {
       if (!accountActive) return;
@@ -1949,11 +2066,26 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       // 老实例不宣告 turn.reopen 时必须立刻停用回流, 不能拿上一次的快照发帧。
       serverFeatures.set(connectionId, features ? [...features] : []);
       sendFns.set(connectionId, send);
+      const deliveryAck = supportsDeliveryAck(connectionId);
+      for (const [key, pending] of [...pendingDeliveryTurnEnds]) {
+        if (pending.connectionId !== connectionId) continue;
+        if (deliveryAck) {
+          sendPendingDelivery(key, pending, send);
+        } else if (send(pending.message)) {
+          // 滚动发布回落到老 server：按历史 fire-and-forget 语义收口。
+          clearPendingDelivery(key);
+        }
+      }
       const buf = pendingTurnEnds.get(connectionId);
       if (!buf?.length) return;
-      // 按序补发; 发送失败(又断了)停下, 剩余留在缓存
+      // 按序补发；新 server 先转入 ACK 缓冲，老 server 沿用 fire-and-forget。
       while (buf.length > 0) {
-        if (!send(buf[0])) break;
+        const message = buf[0];
+        if (deliveryAck) {
+          trackPendingDelivery(connectionId, message);
+        } else if (!send(message)) {
+          break;
+        }
         buf.shift();
       }
       if (buf.length === 0) pendingTurnEnds.delete(connectionId);

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -28,6 +28,7 @@ import {
   HOOK_FEATURE_PROVIDER_X,
   HOOK_FEATURE_SESSION_PICKER,
   HOOK_FEATURE_SLACK_TOOLS,
+  HOOK_FEATURE_TURN_DELIVERY,
   makeBindRevoke,
   makeBindStart,
   makeHello,
@@ -751,6 +752,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       HOOK_FEATURE_PROVIDER_BIND,
       HOOK_FEATURE_PROVIDER_PREFS,
       HOOK_FEATURE_SESSION_PICKER,
+      HOOK_FEATURE_TURN_DELIVERY,
     ],
     isEnabled: () => store.get().xEnabled,
     setEnabled: (enabled) => {
@@ -2303,6 +2305,21 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
           send(makeQueryResponse(response));
         }),
       );
+      return;
+    }
+    if (msg.type === 'turn.delivery') {
+      if (
+        expectedProvider !== 'x' ||
+        lane?.serverFeatures.includes(HOOK_FEATURE_TURN_DELIVERY) !== true
+      ) {
+        log.warn('turn.delivery ignored without negotiated X delivery ACK capability');
+        return;
+      }
+      if (dispatcher) {
+        dispatcher.handleTurnDelivery(dispatchId('x'), msg.payload);
+      } else {
+        log.warn('turn.delivery ignored (no dispatcher)');
+      }
       return;
     }
     if (msg.type === 'task.cancel') {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 X 回复在 Desktop 已生成、但尚未被服务端可靠接收时可能静默丢失的问题。客户端现在会保留完整 `turn.end`，在收到服务端 `turn.delivery` 回执前跨断线重发；收到任一回执后停止重发，并在连接到旧服务端时自动降级到原来的 fire-and-forget 行为。

关联变更：

- Protocol: https://github.com/makecindy/cindy-protocol/pull/33
- Server: https://github.com/xindong/cindy-server/pull/328

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：X 回复偶发未同步的线上反馈
- 本 PR 包含：更新 `cindy-protocol` submodule；X hook feature 协商与 `turn.delivery` 路由；完整 `turn.end` 的内存保留、指数退避重发、断线重连恢复；兼容旧服务端的降级逻辑；回归测试与文档。
- 明确不包含：服务端 receipt/outbox 实现（见关联 Server PR）；跨应用重启的本地磁盘持久化；UI 变化。
- 用户可见变化：X 回复在临时断线或服务端暂时不可用后更不容易丢失；界面与文案无变化。
- 是否存在 breaking change：无。只有双方协商 `turn-delivery-v1` 后才启用回执语义。

### UI 变化

不涉及：仅修改后台 X hook 传输与重试逻辑，没有视觉、交互或文案变化。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
结果：通过，0 errors

pnpm test:unit
结果：非 Desktop workspaces 全部通过；Desktop 在默认 threads 池发生进程级 SIGSEGV，连续两次重试均无断言失败。

同一门禁在干净 origin/main worktree 复现相同 Desktop threads SIGSEGV，连续两次均无断言失败。

Desktop 同一测试范围改用 Vitest forks 池复核
结果：1,639 test files passed；20,624 tests passed，2 skipped；exit 0。

pnpm check:dco
结果：origin/main..HEAD 通过。
```

默认线程池崩溃也能在干净基线稳定复现，因此判定为当前 Node 24 / Vitest threads 运行时问题，不是本 PR 的测试回归；未跳过任何断言，改用仓库支持的 forks 池完成了完整 Desktop 单测。

### 手工验证

不涉及：本次行为由传输管理器、dispatcher 和协议协商测试覆盖，未使用真实 X 账号发送公开回复。

### 未执行的验证

未执行真实 X 端到端发帖：需要 live X 账号并产生外部公开写入；风险由协议、服务端和客户端三侧回归测试覆盖，仍建议在 sh-dev 部署后做一次受控验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：待回执队列只保存在当前进程内，并设置每连接 100 条上限。

### 影响与回滚

- 影响范围：Desktop 的 X hook 普通任务完成帧；continuation 路径不重试。完整结果在当前连接内存中保留，10 秒起指数退避、最长 60 秒，收到任一回执后清理。应用进程在服务端 `accepted` 前崩溃，或离线积压超过 100 条，仍是明确的剩余边界。
- 回滚 / 降级方式：旧服务端不声明 `turn-delivery-v1`，客户端自动使用旧 fire-and-forget 行为；如需回滚，撤销客户端变更即可，无本地数据迁移。服务端/Protocol 独立回滚顺序见关联 PR。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
