### PR TITLE
fix(device-link): 镜像缓存写入带 owner token,挡住跨账号泄漏

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpc.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpc.test.ts
@@ -23,9 +23,14 @@ vi.mock('../../logger', () => ({
 
 vi.mock('../mirrorCachePurgeQueue', () => ({
   enqueuePurge: vi.fn(async () => undefined),
-  hasPendingPurgeRecords: async (): Promise<boolean> => pendingPurges > 0,
+  hasPendingPurgeRecords: async (): Promise<boolean> => {
+    purgeChecks += 1;
+    onPurgeCheck?.(purgeChecks);
+    return pendingPurges > 0;
+  },
 }));
 vi.mock('../../appSessionState', () => ({
+  activeOwnerScopeKey: (): string => `cloud:${ownerKey}:${ownerGeneration}`,
   ownerScopedUserDataPath: (...parts: string[]): string =>
     ['/data/owners', ownerKey, ...parts].join('/'),
 }));
@@ -45,9 +50,16 @@ function fakeCache() {
     readMessagesWithInvalidation: vi.fn(async () => ({
       messages: [{ id: 'm1' }],
       invalidation: 3,
+      ownerRoot: '/data/owners/owner-a/device-link-mirror-cache',
+      accountCounter: 0,
     })),
     writeMessages: vi.fn(async () => ({ invalidation: 3 })),
     readSessionList: vi.fn(async () => [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }]),
+    readSessionListWithInvalidation: vi.fn(async () => ({
+      devices: [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }],
+      ownerRoot: '/data/owners/owner-a/device-link-mirror-cache',
+      accountCounter: 0,
+    })),
     writeSessionList: vi.fn(async () => undefined),
     clearDevice: vi.fn(async () => undefined),
     clearAll: vi.fn(async () => undefined),
@@ -56,6 +68,7 @@ function fakeCache() {
     readMessagesWithInvalidation: ReturnType<typeof vi.fn>;
     writeMessages: ReturnType<typeof vi.fn>;
     readSessionList: ReturnType<typeof vi.fn>;
+    readSessionListWithInvalidation: ReturnType<typeof vi.fn>;
     writeSessionList: ReturnType<typeof vi.fn>;
     clearDevice: ReturnType<typeof vi.fn>;
     clearAll: ReturnType<typeof vi.fn>;
@@ -65,21 +78,32 @@ function fakeCache() {
 let cache: ReturnType<typeof fakeCache>;
 /** 由 mock 的 pendingPurgeCount 读取:>0 表示队列里还有删不掉的东西。 */
 let pendingPurges = 0;
-/** 由 mock 的 ownerScopedUserDataPath 读取:模拟账号边界推进(owner 换人)。 */
+let purgeChecks = 0;
+let onPurgeCheck: ((call: number) => void) | null = null;
+/** 由 mock 的 appSessionState 读取:模拟账号边界推进(owner / generation 变化)。 */
 let ownerKey = 'owner-a';
+let ownerGeneration = 1;
 
 beforeEach(() => {
   cache = fakeCache();
   pendingPurges = 0;
+  purgeChecks = 0;
+  onPurgeCheck = null;
   ownerKey = 'owner-a';
+  ownerGeneration = 1;
 });
 
 describe('messages get / put', () => {
-  it('读:转发给 store 并包成 { messages, invalidation }', async () => {
-    await expect(handleMirrorCacheGetMessages(cache, 'dev-1', 'sess-1')).resolves.toEqual({
+  it('读:只向 renderer 返回 opaque owner token,不暴露 store 绝对路径', async () => {
+    const result = await handleMirrorCacheGetMessages(cache, 'dev-1', 'sess-1');
+    expect(result).toEqual({
       messages: [{ id: 'm1' }],
       invalidation: 3,
+      ownerToken: expect.any(String),
+      accountCounter: 0,
     });
+    expect(result.ownerToken).not.toContain('/');
+    expect(result.ownerToken).not.toBe('/data/owners/owner-a/device-link-mirror-cache');
     expect(cache.readMessagesWithInvalidation).toHaveBeenCalledWith('dev-1', 'sess-1');
   });
 
@@ -112,7 +136,78 @@ describe('messages get / put', () => {
 
   it('空数组照常透传(空 = 清掉该条缓存,是有意义的写)', async () => {
     await handleMirrorCachePutMessages(cache, 'dev-1', 'sess-1', []);
-    expect(cache.writeMessages).toHaveBeenCalledWith('dev-1', 'sess-1', [], undefined);
+    expect(cache.writeMessages).toHaveBeenCalledWith(
+      'dev-1',
+      'sess-1',
+      [],
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('作废计数 / 账号代际只接受非负整数,opaque token 验证后才还原内部 root', async () => {
+    const { ownerToken } = await handleMirrorCacheGetMessages(cache, 'dev-1', 'sess-1');
+    const owner = '/data/owners/owner-a/device-link-mirror-cache';
+    for (const [invalidation, account] of [
+      [-1, -1],
+      [1.5, 2.5],
+      [Number.NaN, Number.POSITIVE_INFINITY],
+    ]) {
+      cache.writeMessages.mockClear();
+      await handleMirrorCachePutMessages(
+        cache,
+        'dev-1',
+        'sess-1',
+        [{ id: 'm1' }],
+        undefined,
+        invalidation,
+        ownerToken,
+        account,
+      );
+      expect(cache.writeMessages).toHaveBeenCalledWith(
+        'dev-1',
+        'sess-1',
+        [{ id: 'm1' }],
+        undefined,
+        owner,
+        undefined,
+      );
+    }
+
+    cache.writeMessages.mockClear();
+    await handleMirrorCachePutMessages(
+      cache,
+      'dev-1',
+      'sess-1',
+      [{ id: 'm1' }],
+      undefined,
+      7,
+      ownerToken,
+      3,
+    );
+    expect(cache.writeMessages).toHaveBeenCalledWith(
+      'dev-1',
+      'sess-1',
+      [{ id: 'm1' }],
+      7,
+      owner,
+      3,
+    );
+
+    // 绝对路径不是合法 token:即使 renderer 猜到路径也只能落到 fail-closed。
+    cache.writeMessages.mockClear();
+    await handleMirrorCachePutMessages(
+      cache,
+      'dev-1',
+      'sess-1',
+      [{ id: 'm1' }],
+      undefined,
+      7,
+      owner,
+      3,
+    );
+    expect(cache.writeMessages.mock.calls[0]?.[4]).toBeUndefined();
   });
 });
 
@@ -218,6 +313,8 @@ describe('待清未清时读路径不命中', () => {
     await expect(handleMirrorCacheGetMessages(cache, 'dev-1', 'sess-1')).resolves.toEqual({
       messages: [{ id: 'm1' }],
       invalidation: 3,
+      ownerToken: expect.any(String),
+      accountCounter: 0,
     });
   });
 });
@@ -269,9 +366,13 @@ describe('读完成之后又有待清记录', () => {
   });
 
   it('读列表期间被登记待清 → 丢弃结果', async () => {
-    cache.readSessionList.mockImplementationOnce(async () => {
+    cache.readSessionListWithInvalidation.mockImplementationOnce(async () => {
       pendingPurges = 1;
-      return [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }];
+      return {
+        devices: [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }],
+        ownerRoot: '/data/owners/owner-a/device-link-mirror-cache',
+        accountCounter: 0,
+      };
     });
     await expect(handleMirrorCacheGetSessionList(cache)).resolves.toEqual({ devices: [] });
   });
@@ -291,16 +392,88 @@ describe('读期间账号边界推进', () => {
   });
 
   it('读列表期间 owner 变了 → 丢弃结果,返回空', async () => {
-    cache.readSessionList.mockImplementationOnce(async () => {
+    cache.readSessionListWithInvalidation.mockImplementationOnce(async () => {
       ownerKey = 'owner-b';
-      return [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }];
+      return {
+        devices: [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }],
+        ownerRoot: '/data/owners/owner-b/device-link-mirror-cache',
+        accountCounter: 0,
+      };
     });
     await expect(handleMirrorCacheGetSessionList(cache)).resolves.toEqual({ devices: [] });
   });
 
-  it('owner 没变 → 照常返回', async () => {
+  it('最终 purge 检查的 await 期间 A→B → 返回前最后安全门丢弃消息与列表', async () => {
+    onPurgeCheck = (call) => {
+      if (call === 2) {
+        ownerKey = 'owner-b';
+        ownerGeneration = 2;
+      }
+    };
+    await expect(handleMirrorCacheGetMessages(cache, 'dev-1', 'sess-1')).resolves.toEqual({
+      messages: [],
+    });
+
+    ownerKey = 'owner-a';
+    ownerGeneration = 1;
+    purgeChecks = 0;
+    onPurgeCheck = (call) => {
+      if (call === 2) {
+        ownerKey = 'owner-b';
+        ownerGeneration = 2;
+      }
+    };
+    await expect(handleMirrorCacheGetSessionList(cache)).resolves.toEqual({ devices: [] });
+  });
+
+  it('最终 purge 检查期间 A→B→A:root 相同但 generation 已变 → 仍丢弃', async () => {
+    onPurgeCheck = (call) => {
+      if (call === 2) {
+        ownerKey = 'owner-b';
+        ownerGeneration = 2;
+        ownerKey = 'owner-a';
+        ownerGeneration = 3;
+      }
+    };
+    await expect(handleMirrorCacheGetMessages(cache, 'dev-1', 'sess-1')).resolves.toEqual({
+      messages: [],
+    });
+  });
+
+  it('A→B→A ABA:首尾 root 相同但 store 读自 B root → 消息与列表都丢弃', async () => {
+    cache.readMessagesWithInvalidation.mockImplementationOnce(async () => {
+      ownerKey = 'owner-b';
+      const result = {
+        messages: [{ id: 'secret-b' }],
+        invalidation: 3,
+        ownerRoot: '/data/owners/owner-b/device-link-mirror-cache',
+        accountCounter: 0,
+      };
+      ownerKey = 'owner-a';
+      return result;
+    });
+    await expect(handleMirrorCacheGetMessages(cache, 'dev-1', 'sess-1')).resolves.toEqual({
+      messages: [],
+    });
+
+    cache.readSessionListWithInvalidation.mockImplementationOnce(async () => {
+      ownerKey = 'owner-b';
+      const result = {
+        devices: [{ deviceId: 'dev-b', deviceName: 'Bob Mac', sessions: [] }],
+        ownerRoot: '/data/owners/owner-b/device-link-mirror-cache',
+        accountCounter: 0,
+      };
+      ownerKey = 'owner-a';
+      return result;
+    });
+    await expect(handleMirrorCacheGetSessionList(cache)).resolves.toEqual({ devices: [] });
+  });
+
+  it('owner 没变 → 照常返回(并带回 opaque token / 账号代际供回写比对)', async () => {
     await expect(handleMirrorCacheGetSessionList(cache)).resolves.toEqual({
       devices: [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }],
+      ownerToken: expect.any(String),
+      accountCounter: 0,
     });
   });
 });
@@ -369,10 +542,14 @@ describe('清理失败登记重试', () => {
 });
 
 describe('session list get / put', () => {
-  it('读:包成 { devices }', async () => {
-    await expect(handleMirrorCacheGetSessionList(cache)).resolves.toEqual({
+  it('读:包成 { devices } 并只带 opaque owner token / 账号代际', async () => {
+    const result = await handleMirrorCacheGetSessionList(cache);
+    expect(result).toEqual({
       devices: [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }],
+      ownerToken: expect.any(String),
+      accountCounter: 0,
     });
+    expect(result.ownerToken).not.toContain('/');
   });
 
   it('devices 非数组 → INVALID_PARAMS', async () => {
@@ -388,6 +565,21 @@ describe('session list get / put', () => {
     }));
     await handleMirrorCachePutSessionList(cache, devices);
     expect((cache.writeSessionList.mock.calls[0]?.[0] as unknown[]).length).toBe(64);
+  });
+
+  it('列表账号代际只接受非负整数,opaque token 验证后才还原内部 root', async () => {
+    const devices = [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [] }];
+    const { ownerToken } = await handleMirrorCacheGetSessionList(cache);
+    const owner = '/data/owners/owner-a/device-link-mirror-cache';
+    for (const account of [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      cache.writeSessionList.mockClear();
+      await handleMirrorCachePutSessionList(cache, devices, undefined, ownerToken, account);
+      expect(cache.writeSessionList).toHaveBeenCalledWith(devices, owner, undefined);
+    }
+
+    cache.writeSessionList.mockClear();
+    await handleMirrorCachePutSessionList(cache, devices, undefined, ownerToken, 3);
+    expect(cache.writeSessionList).toHaveBeenCalledWith(devices, owner, 3);
   });
 });
 

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheIpcBoundary.test.ts
@@ -23,6 +23,11 @@ const h = vi.hoisted(() => ({
     })),
     writeMessages: vi.fn(async () => ({ invalidation: 0 })),
     readSessionList: vi.fn(async () => [] as unknown[]),
+    readSessionListWithInvalidation: vi.fn(async () => ({
+      devices: [] as unknown[],
+      ownerRoot: '/data/owners/x/device-link-mirror-cache',
+      accountCounter: 0,
+    })),
     writeSessionList: vi.fn(async () => undefined),
     clearDevice: vi.fn(async () => undefined),
     clearAll: vi.fn(async () => undefined),
@@ -41,6 +46,7 @@ vi.mock('../../logger', () => ({
 }));
 // 读路径要比对 owner 作用域路径(账号边界复核),这里给个稳定值即可。
 vi.mock('../../appSessionState', () => ({
+  activeOwnerScopeKey: (): string => 'cloud:owner-x:1',
   ownerScopedUserDataPath: (...parts: string[]): string => ['/data/owners/x', ...parts].join('/'),
 }));
 // 读路径还会查 purge 队列是否有待清记录;边界测试只关心授权,给"干净"。

--- a/apps/desktop/src/main/device-link/__tests__/mirrorCacheStore.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/mirrorCacheStore.test.ts
@@ -39,16 +39,40 @@ let root: string;
  * `mirrorCacheClient.invalidationAtRequestStart`;这里等价地补上,好让其余用例继续专注
  * 各自要守的行为。刻意**不给**令牌的用例直接用 `rawCache()`。
  */
-function withAutoToken(store: MirrorCache): MirrorCache {
+function withAutoToken(store: MirrorCache, rootFn: () => string = () => root): MirrorCache {
   return {
     ...store,
-    async writeMessages(deviceId, sessionId, messages, expected) {
-      const token =
-        expected ??
-        (messages.length > 0
-          ? (await store.readMessagesWithInvalidation(deviceId, sessionId)).invalidation
-          : undefined);
-      return store.writeMessages(deviceId, sessionId, messages, token);
+    async writeMessages(deviceId, sessionId, messages, expected, expectedOwnerRoot) {
+      // 与真实 renderer 流程(makerTransport 在请求发起时同时捕获会话计数 / owner root /
+      // 账号代际)对齐:非空写**任何一个**令牌缺失都补读一次,把三者一起取回 —— 现实中三者
+      // 必然同源(同一份 getMessages)。store 对「没带会话计数」「没带 owner root」「没带
+      // 账号代际」的非空写都是 fail-closed,这里保持三者同步,别让只想测会话计数机制的用例
+      // 被 owner root / 账号代际缺失误伤。
+      let token = expected;
+      let ownerRoot = expectedOwnerRoot;
+      let accountCounter: number | undefined;
+      if (messages.length > 0) {
+        const capture = await store.readMessagesWithInvalidation(deviceId, sessionId);
+        if (token === undefined) token = capture.invalidation;
+        if (ownerRoot === undefined) ownerRoot = capture.ownerRoot;
+        accountCounter = capture.accountCounter;
+      }
+      return store.writeMessages(deviceId, sessionId, messages, token, ownerRoot, accountCounter);
+    },
+    async writeSessionList(devices, expectedOwnerRoot) {
+      // 非空快照缺 owner root / 账号代际时补当前值(现实中由 scheduleSessionListPersist 在
+      // 排程时从 readCachedSessionListWithInvalidation 带回;这里直接取 store 当前 root)。
+      const ownerRoot =
+        expectedOwnerRoot !== undefined
+          ? expectedOwnerRoot
+          : normalizeDeviceSessions(devices).length > 0
+            ? rootFn()
+            : undefined;
+      const accountCounter =
+        normalizeDeviceSessions(devices).length > 0
+          ? (await store.readSessionListWithInvalidation()).accountCounter
+          : undefined;
+      return store.writeSessionList(devices, ownerRoot, accountCounter);
     },
   };
 }
@@ -58,7 +82,7 @@ function rawCache(rootFn: () => string = () => root) {
 }
 
 function cache(rootFn: () => string = () => root) {
-  return withAutoToken(createMirrorCache(rootFn));
+  return withAutoToken(createMirrorCache(rootFn), rootFn);
 }
 
 function messagesDir(): string {
@@ -375,6 +399,108 @@ describe('readMessages / writeMessages', () => {
 
     expect(fs.existsSync(file)).toBe(false);
     expect(await c.readMessages('dev-1', 'sess-1')).toEqual([]);
+  });
+
+  it('旧账号超限响应被 owner 闸拒绝前,不得删除新账号同 sessionId 的有效缓存', async () => {
+    // review(codex P2):超限分支也是副作用(删旧文件),必须先过与普通非空写完全相同的提交闸。
+    const rootA = root;
+    const rootB = await fsp.mkdtemp(path.join(os.tmpdir(), 'cindy-mirror-cache-owner-b-'));
+    let activeRoot = rootA;
+    const c = rawCache(() => activeRoot);
+    try {
+      const aliceRead = await c.readMessagesWithInvalidation('dev-1', 'shared-session');
+
+      activeRoot = rootB;
+      const bobRead = await c.readMessagesWithInvalidation('dev-1', 'shared-session');
+      await c.writeMessages(
+        'dev-1',
+        'shared-session',
+        [row('bob', '2026-02-01T00:00:00.000Z')],
+        bobRead.invalidation,
+        bobRead.ownerRoot,
+        bobRead.accountCounter,
+      );
+
+      const staleHuge = [
+        row('alice-huge', '2026-02-02T00:00:00.000Z', {
+          content: 'x'.repeat(MAX_MESSAGE_FILE_BYTES + 1),
+        }),
+      ];
+      await c.writeMessages(
+        'dev-1',
+        'shared-session',
+        staleHuge,
+        aliceRead.invalidation,
+        aliceRead.ownerRoot,
+        aliceRead.accountCounter,
+      );
+
+      expect((await c.readMessages('dev-1', 'shared-session')).map((m) => m.id)).toEqual(['bob']);
+    } finally {
+      await fsp.rm(rootB, { recursive: true, force: true });
+      await fsp.rm(`${rootB}.control`, { recursive: true, force: true });
+    }
+  });
+
+  it('超限提交闸等待 IO 期间 generation 变化 → 删除前二次复核保留有效旧缓存', async () => {
+    const c = rawCache();
+    const before = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    await c.writeMessages(
+      'dev-1',
+      'sess-1',
+      [row('keep', '2026-01-01T00:00:00.000Z')],
+      before.invalidation,
+      before.ownerRoot,
+      before.accountCounter,
+    );
+    const token = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    const sessionKey = messageFileName('dev-1', 'sess-1').replace(/\.json$/, '');
+    const counterFile = path.join(`${root}.control`, 'cleared', sessionKey);
+    const original = fsp.readFile;
+    let releaseRead!: () => void;
+    const blocked = new Promise<void>((resolve) => {
+      releaseRead = resolve;
+    });
+    let reachedRead!: () => void;
+    const reached = new Promise<void>((resolve) => {
+      reachedRead = resolve;
+    });
+    let paused = false;
+    const spy = vi.spyOn(fsp, 'readFile').mockImplementation((async (
+      target: unknown,
+      ...rest: unknown[]
+    ) => {
+      if (!paused && typeof target === 'string' && target === counterFile) {
+        paused = true;
+        reachedRead();
+        await blocked;
+      }
+      return (original as (...args: unknown[]) => Promise<unknown>)(target, ...rest);
+    }) as unknown as typeof fsp.readFile);
+    try {
+      const hugeWrite = c.writeMessages(
+        'dev-1',
+        'sess-1',
+        [
+          row('huge', '2026-02-01T00:00:00.000Z', {
+            content: 'x'.repeat(MAX_MESSAGE_FILE_BYTES + 1),
+          }),
+        ],
+        token.invalidation,
+        token.ownerRoot,
+        token.accountCounter,
+      );
+      await reached;
+      // clearDevice 同步 bump generation,随后因 root mutex 排在当前超限写后面。
+      const clearOther = c.clearDevice('dev-2');
+      releaseRead();
+      await hugeWrite;
+      await clearOther;
+
+      expect((await c.readMessages('dev-1', 'sess-1')).map((m) => m.id)).toEqual(['keep']);
+    } finally {
+      spy.mockRestore();
+    }
   });
 
   // review(copilot):`.tmp` 里是完整明文,而 /clear、rewind 正是"这些消息必须消失"的场合。
@@ -1226,6 +1352,7 @@ describe('会话级作废计数(跨窗口 / 跨进程)', () => {
     // review(codex P1):缓存读与远端请求刻意并行,远端页先到时 renderer 还没有令牌。放行
     // 那笔写等于绕过唯一的会话级比对(设备 / 账号基线是写入开始时才采样的,已在清理之后)。
     const c = rawCache();
+    // 既没会话令牌也没 owner root → fail-closed 拒绝(见 store 注释)。
     const first = await c.writeMessages('dev-1', 'sess-1', [row('m1', '2026-01-01T00:00:00.000Z')]);
     expect(await c.readMessages('dev-1', 'sess-1')).toEqual([]);
     // 拒了不等于永久关掉这条缓存:返回值里带着当前计数,下一次对账带上它就能写进去。
@@ -1235,14 +1362,18 @@ describe('会话级作废计数(跨窗口 / 跨进程)', () => {
       'sess-1',
       [row('m1', '2026-01-01T00:00:00.000Z')],
       first.invalidation,
+      root,
+      0, // 账号代际(fresh root 下 _account 计数为 0)
     );
     expect((await c.readMessages('dev-1', 'sess-1')).map((m) => m.id)).toEqual(['m1']);
   });
 
   it('空写(清缓存)不需要令牌 —— 删除是安全方向', async () => {
     const c = rawCache();
-    await c.writeMessages('dev-1', 'sess-1', [row('m1', '2026-01-01T00:00:00.000Z')], 0);
+    // 非空写带 owner root + 账号代际(隔离本用例要守的"会话计数"机制;缺失另有用例覆盖)。
+    await c.writeMessages('dev-1', 'sess-1', [row('m1', '2026-01-01T00:00:00.000Z')], 0, root, 0);
     expect((await c.readMessages('dev-1', 'sess-1')).map((m) => m.id)).toEqual(['m1']);
+    // 空写不需要会话令牌、也不需要 owner root / 账号代际 —— 删除是安全方向。
     await c.writeMessages('dev-1', 'sess-1', []);
     expect(await c.readMessages('dev-1', 'sess-1')).toEqual([]);
   });
@@ -1676,8 +1807,8 @@ describe('并发写入', () => {
     const second = [row('m1', '2026-01-01T00:00:00.000Z'), row('m2', '2026-01-02T00:00:00.000Z')];
 
     await Promise.all([
-      c.writeMessages('dev-1', 'sess-1', first, 0),
-      c.writeMessages('dev-1', 'sess-1', second, 0),
+      c.writeMessages('dev-1', 'sess-1', first, 0, root, 0),
+      c.writeMessages('dev-1', 'sess-1', second, 0, root, 0),
     ]);
 
     expect((await c.readMessages('dev-1', 'sess-1')).map((m) => m.id)).toEqual(['m1', 'm2']);
@@ -1686,26 +1817,235 @@ describe('并发写入', () => {
     const file = path.join(messagesDir(), messageFileName('dev-1', 'sess-1'));
     const past = new Date(2020, 0, 1);
     await fsp.utimes(file, past, past);
-    await c.writeMessages('dev-1', 'sess-1', second, 0);
+    await c.writeMessages('dev-1', 'sess-1', second, 0, root, 0);
     expect((await fsp.stat(file)).mtimeMs).toBe(past.getTime());
 
-    await c.writeMessages('dev-1', 'sess-1', first, 0);
+    await c.writeMessages('dev-1', 'sess-1', first, 0, root, 0);
     expect((await c.readMessages('dev-1', 'sess-1')).map((m) => m.id)).toEqual(['m1']);
   });
 
   it('列表快照的并发写入同样串行化', async () => {
-    const c = cache();
+    // 同消息版并发写:用 rawCache + 显式令牌,避免 withAutoToken 的补读把准入顺序变成
+    // "谁的补读先回来"(生产里令牌在排程时同步捕获)。
+    const c = rawCache();
     await Promise.all([
-      c.writeSessionList([
-        { deviceId: 'dev-1', deviceName: 'Mac', sessions: [{ id: 's1', status: 'active' }] },
-      ]),
-      c.writeSessionList([
-        { deviceId: 'dev-1', deviceName: 'Mac', sessions: [{ id: 's1', status: 'active' }] },
-        { deviceId: 'dev-2', deviceName: 'PC', sessions: [{ id: 's2', status: 'active' }] },
-      ]),
+      c.writeSessionList(
+        [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [{ id: 's1', status: 'active' }] }],
+        root,
+        0,
+      ),
+      c.writeSessionList(
+        [
+          { deviceId: 'dev-1', deviceName: 'Mac', sessions: [{ id: 's1', status: 'active' }] },
+          { deviceId: 'dev-2', deviceName: 'PC', sessions: [{ id: 's2', status: 'active' }] },
+        ],
+        root,
+        0,
+      ),
     ]);
 
     const devices = (await c.readSessionList()).map((d) => d.deviceId).sort();
     expect(devices).toEqual(['dev-1', 'dev-2']);
+  });
+});
+
+describe('跨账号 owner 切换(#1783)', () => {
+  // 登出 / 切账号是 clearAll 路径:删整棵缓存根、自增账号级计数。但账号级计数是**每 owner
+  // 一份**(住 `<root>.control`),新账号从 0 起 —— 旧账号在途响应若落在新账号写入之后,会话级
+  // 与账号级计数都可能与"取到内容时"撞值。唯一可靠的「内容属于哪个账号」标记是 owner root,
+  // 它由 read 时下发、写入时回传比对(review: #1783)。
+
+  it('写入携带的 owner root 与当前 root 不符(账号已切换)→ 丢弃,不落进新账号目录', async () => {
+    const rootB = fs.mkdtempSync(path.join(os.tmpdir(), 'mirror-cache-test-b-'));
+    try {
+      let current = root;
+      const c = rawCache(() => current);
+      const fileName = messageFileName('dev-1', 'sess-1');
+      // T0:alice 取内容时捕获会话计数 + owner root
+      const { invalidation, ownerRoot } = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+      expect(ownerRoot).toBe(root);
+      // T1:登出 alice
+      await c.clearAll();
+      // T2:切换 owner 到 bob
+      current = rootB;
+      // T3:alice 在途响应到达
+      await c.writeMessages(
+        'dev-1',
+        'sess-1',
+        [row('m1', '2026-01-01T00:00:00.000Z')],
+        invalidation,
+        ownerRoot,
+      );
+      // bob 目录不得出现 alice 的数据
+      expect(fs.existsSync(path.join(rootB, 'messages', fileName))).toBe(false);
+      // alice 目录已整体删除,也不应有
+      expect(fs.existsSync(path.join(root, 'messages', fileName))).toBe(false);
+    } finally {
+      fs.rmSync(rootB, { recursive: true, force: true });
+      fs.rmSync(`${rootB}.control`, { recursive: true, force: true });
+    }
+  });
+
+  it('B 复用同一 sessionId:alice 迟到写入被丢,bob 以 bob root 重建成功', async () => {
+    // review(#1801):账号切换后若 B 复用同一 sessionId,A 的迟到响应必须被丢;同时 B 自己的
+    // 响应(带着 B 的 owner root)必须能正常建立 B 的缓存 —— 否则新账号缓存被静默拒写,
+    // 是功能性回归。
+    const rootB = fs.mkdtempSync(path.join(os.tmpdir(), 'mirror-cache-test-b-'));
+    try {
+      let current = root;
+      const c = rawCache(() => current);
+      const fileName = messageFileName('dev-1', 'sess-1');
+      // T0:alice 取内容
+      const aliceRead = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+      await c.clearAll(); // 登出 alice
+      current = rootB; // 切到 bob
+      // T3:alice 迟到响应(带 alice root / alice 代际)→ 丢(owner root 与代际都不匹配)
+      await c.writeMessages(
+        'dev-1',
+        'sess-1',
+        [row('m1', '2026-01-01T00:00:00.000Z')],
+        aliceRead.invalidation,
+        aliceRead.ownerRoot,
+        aliceRead.accountCounter,
+      );
+      expect(fs.existsSync(path.join(rootB, 'messages', fileName))).toBe(false);
+      // T4:bob 自己的响应(带 bob root / bob 代际)→ 成功建立 bob 缓存
+      const bobRead = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+      expect(bobRead.ownerRoot).toBe(rootB);
+      await c.writeMessages(
+        'dev-1',
+        'sess-1',
+        [row('m2', '2026-02-01T00:00:00.000Z')],
+        bobRead.invalidation,
+        bobRead.ownerRoot,
+        bobRead.accountCounter,
+      );
+      expect(fs.existsSync(path.join(rootB, 'messages', fileName))).toBe(true);
+      expect((await c.readMessages('dev-1', 'sess-1')).map((m) => m.id)).toEqual(['m2']);
+    } finally {
+      fs.rmSync(rootB, { recursive: true, force: true });
+      fs.rmSync(`${rootB}.control`, { recursive: true, force: true });
+    }
+  });
+
+  it('会话列表快照携带的 owner root 与当前 root 不符(账号已切换)→ 丢弃', async () => {
+    const rootB = fs.mkdtempSync(path.join(os.tmpdir(), 'mirror-cache-test-b-'));
+    try {
+      let current = root;
+      const c = rawCache(() => current);
+      // T0:alice 读到快照时捕获 owner root
+      await c.readSessionList();
+      const ownerRoot = root;
+      await c.clearAll();
+      current = rootB;
+      // T2→T3:alice 在途回写携带旧 owner root
+      await c.writeSessionList(
+        [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [{ id: 's1', status: 'active' }] }],
+        ownerRoot,
+      );
+      const bobList = path.join(rootB, 'session-list.json');
+      expect(fs.existsSync(bobList)).toBe(false);
+    } finally {
+      fs.rmSync(rootB, { recursive: true, force: true });
+      fs.rmSync(`${rootB}.control`, { recursive: true, force: true });
+    }
+  });
+
+  it('owner 未切换时,携带 owner root 的正常写入与会话列表回写仍成功', async () => {
+    const c = rawCache(() => root);
+    const fileName = messageFileName('dev-1', 'sess-1');
+    const { invalidation, ownerRoot, accountCounter } =
+      await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    await c.writeMessages(
+      'dev-1',
+      'sess-1',
+      [row('m1', '2026-01-01T00:00:00.000Z')],
+      invalidation,
+      ownerRoot,
+      accountCounter,
+    );
+    expect(fs.existsSync(path.join(root, 'messages', fileName))).toBe(true);
+    await c.writeSessionList(
+      [{ deviceId: 'dev-1', deviceName: 'Mac', sessions: [{ id: 's1', status: 'active' }] }],
+      ownerRoot,
+      accountCounter,
+    );
+    const devices = (await c.readSessionList()).map((d) => d.deviceId);
+    expect(devices).toEqual(['dev-1']);
+  });
+
+  it('非空写入未携带 owner root(取不到)→ fail-closed 拒绝,不落盘', async () => {
+    // review(#1783 / Greptile):owner root 缺失时若放行,renderer 补读失败 / owner 边界
+    // 推进 / IPC 波动等现实竞态会让"清理前的旧页"按**写入时**的新账号 root 落盘 —— 与
+    // 不带会话令牌一样属于不可比对的 fail-open,必须拒写。缓存是纯优化,少写一次无妨。
+    const c = rawCache(() => root);
+    const fileName = messageFileName('dev-1', 'sess-1');
+    // 只带会话计数、不带 owner root
+    const { invalidation } = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    await c.writeMessages(
+      'dev-1',
+      'sess-1',
+      [row('m1', '2026-01-01T00:00:00.000Z')],
+      invalidation,
+      undefined,
+    );
+    expect(fs.existsSync(path.join(root, 'messages', fileName))).toBe(false);
+    expect(await c.readMessages('dev-1', 'sess-1')).toEqual([]);
+  });
+
+  it('空写(清缓存)无需 owner root,照常删除', async () => {
+    const c = rawCache(() => root);
+    const fileName = messageFileName('dev-1', 'sess-1');
+    // 先落一条(带会话计数 + owner root + 账号代际)
+    const { invalidation, ownerRoot, accountCounter } =
+      await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    await c.writeMessages(
+      'dev-1',
+      'sess-1',
+      [row('m1', '2026-01-01T00:00:00.000Z')],
+      invalidation,
+      ownerRoot,
+      accountCounter,
+    );
+    expect(fs.existsSync(path.join(root, 'messages', fileName))).toBe(true);
+    // 空写(删除)不带 owner root / 账号代际也能清掉 —— 删除是安全方向,fail-closed 只针对非空写。
+    await c.writeMessages('dev-1', 'sess-1', [], undefined, undefined, undefined);
+    expect(fs.existsSync(path.join(root, 'messages', fileName))).toBe(false);
+  });
+
+  it('同一账号登出再登录:root 相同但账号代际已变 → 登出前的在途写入被丢', async () => {
+    // review(codex P1):owner root 是 `ownerScopedUserDataPath`(由 dataOwnerId 派生),
+    // **同一账号**登出再登录后路径完全一样 —— 只比 owner root 拦不住 clearAll 已发生过的
+    // 隐私边界。clearAll 会自增 `_account` 计数,携带「取到内容时的计数」才能看出期间发生过
+    // 登出清理。这是 owner root 之外的独立维度。
+    const c = rawCache(() => root);
+    const fileName = messageFileName('dev-1', 'sess-1');
+    // T0:登出前取内容,捕获 owner root(同一账号)与账号代际
+    const beforeLogout = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    await c.clearAll(); // 登出:clearAll 删整棵 root、自增 _account
+    // T3:登出前在途响应到达 —— root 相同、代际不同 → 丢
+    await c.writeMessages(
+      'dev-1',
+      'sess-1',
+      [row('m1', '2026-01-01T00:00:00.000Z')],
+      beforeLogout.invalidation,
+      beforeLogout.ownerRoot,
+      beforeLogout.accountCounter,
+    );
+    expect(fs.existsSync(path.join(root, 'messages', fileName))).toBe(false);
+    expect(await c.readMessages('dev-1', 'sess-1')).toEqual([]);
+    // 重新登录后取到新代际,新写入成功(缓存可重建)
+    const afterLogin = await c.readMessagesWithInvalidation('dev-1', 'sess-1');
+    expect(afterLogin.accountCounter).toBeGreaterThan(beforeLogout.accountCounter);
+    await c.writeMessages(
+      'dev-1',
+      'sess-1',
+      [row('m2', '2026-02-01T00:00:00.000Z')],
+      afterLogin.invalidation,
+      afterLogin.ownerRoot,
+      afterLogin.accountCounter,
+    );
+    expect(fs.existsSync(path.join(root, 'messages', fileName))).toBe(true);
+    expect((await c.readMessages('dev-1', 'sess-1')).map((m) => m.id)).toEqual(['m2']);
   });
 });

--- a/apps/desktop/src/main/device-link/ipc.ts
+++ b/apps/desktop/src/main/device-link/ipc.ts
@@ -5,6 +5,7 @@
  * ipcMain.handle 只做 adapter),__tests__ 用内存 harness 直接调 handler body。
  */
 
+import { createHash, randomBytes } from 'node:crypto';
 import { ipcMain } from 'electron';
 import {
   DL_SESSION_REFERENCE_CAPABILITY_CHANNEL,
@@ -55,7 +56,7 @@ import {
   rememberLastKnownDeviceName,
   setDeviceControlEnabled,
 } from './settings-store';
-import { ownerScopedUserDataPath } from '../appSessionState';
+import { activeOwnerScopeKey, ownerScopedUserDataPath } from '../appSessionState';
 import {
   getMirrorCache,
   MirrorCachePurgeError,
@@ -785,14 +786,39 @@ async function mirrorCacheReadsBlocked(): Promise<boolean> {
   return hasPendingPurgeRecords();
 }
 
+/** 每个 main 进程随机生成:renderer 只需要等值令牌,不应获知 owner 的绝对存储路径。 */
+const MIRROR_CACHE_OWNER_TOKEN_SECRET = randomBytes(32);
+
+function ownerTokenForScope(scopeKey: string): string {
+  return createHash('sha256')
+    .update(MIRROR_CACHE_OWNER_TOKEN_SECRET)
+    .update('\0')
+    .update(scopeKey)
+    .digest('base64url');
+}
+
 /**
- * 缓存 owner 的身份标记 = owner 作用域路径本身(见 appSessionState.ownerScopedUserDataPath)。
- * 读路径要在**返回之前**再取一次比对:闸门等待 / 文件读期间账号边界可能已经走完,
- * 那时返回的既可能是上一个账号的明文,也可能是新账号的快照被交给旧账号发起的那次请求
- * (review: codex P1)。变了就当未命中。
+ * 缓存 owner 的 opaque 身份标记。读路径要在**返回之前**再取一次比对:闸门等待 / 文件读
+ * 期间账号边界可能已经走完,那时返回的既可能是上一个账号的明文,也可能是新账号的快照
+ * 被交给旧账号发起的那次请求(review: codex P1)。变了就当未命中。
  */
 function cacheOwnerToken(): string {
-  return ownerScopedUserDataPath('device-link-mirror-cache');
+  return ownerTokenForScope(activeOwnerScopeKey());
+}
+
+/**
+ * 所有异步读 / purge 检查完成后的**最后同步安全门**。调用后到返回 renderer 之间不允许再 await:
+ * scope token 挡 A→B→A(generation 每次 commit 都变化),readOwnerRoot 再绑定 store 实际读取的
+ * 命名空间,避免把中间账号的数据错配到首尾账号(review: Greptile P1 Security)。
+ */
+function finalMirrorCacheReadOwnerToken(
+  ownerTokenAtStart: string,
+  readOwnerRoot: string,
+): string | undefined {
+  const currentToken = cacheOwnerToken();
+  const currentRoot = ownerScopedUserDataPath('device-link-mirror-cache');
+  if (currentToken !== ownerTokenAtStart || readOwnerRoot !== currentRoot) return undefined;
+  return currentToken;
 }
 
 /**
@@ -802,6 +828,9 @@ function cacheOwnerToken(): string {
  * 真实 id 是 cuid / uuid 量级(≤ 64),给到 256 已经宽松得离谱。
  */
 const MIRROR_CACHE_MAX_ID_LENGTH = 256;
+
+/** opaque owner token 是 32-byte digest 的 base64url(43 字符);宽松上限防异常 renderer。 */
+const MIRROR_CACHE_MAX_OWNER_TOKEN_LENGTH = 128;
 
 function requireCacheId(value: unknown, name: string): string {
   const id = requireString(value, name);
@@ -815,7 +844,12 @@ export async function handleMirrorCacheGetMessages(
   cache: MirrorCache,
   deviceId: unknown,
   sessionId: unknown,
-): Promise<{ messages: Record<string, unknown>[]; invalidation?: number }> {
+): Promise<{
+  messages: Record<string, unknown>[];
+  invalidation?: number;
+  ownerToken?: string;
+  accountCounter?: number;
+}> {
   const device = requireCacheId(deviceId, 'deviceId');
   const session = requireCacheId(sessionId, 'sessionId');
   const owner = cacheOwnerToken();
@@ -826,10 +860,6 @@ export async function handleMirrorCacheGetMessages(
   }
   const read = await cache.readMessagesWithInvalidation(device, session);
   const messages = read.messages;
-  if (cacheOwnerToken() !== owner) {
-    log.warn('mirror cache read discarded: account boundary moved while reading');
-    return { messages: [] };
-  }
   // 读**之后**再复核一次待清状态:另一个共享 userData 的实例(或本进程里一次失败的清理)
   // 可能刚好在预检之后、读完成之前登记了待清 —— 那份正文已经被标记为"必须删掉",不能再交出去
   // (review: codex P1)。这是与 owner 复核并列的"返回前再验一次"。
@@ -837,9 +867,24 @@ export async function handleMirrorCacheGetMessages(
     log.warn('mirror cache read discarded: purge enqueued while reading');
     return { messages: [] };
   }
+  // 最后一个 await 已结束:从这里到 return 只做同步 owner/root 绑定,不再打开竞态窗口。
+  const ownerToken = finalMirrorCacheReadOwnerToken(owner, read.ownerRoot);
+  if (!ownerToken) {
+    log.warn('mirror cache read discarded: account boundary moved while reading');
+    return { messages: [] };
+  }
   // 带回**主进程侧**的会话级作废计数:renderer 缓存它,下一次写入用它当"我取到内容时的
   // 计数",于是另一个窗口 / 另一个进程的作废也能挡住这次写(review: codex P1)。
-  return { messages, invalidation: read.invalidation };
+  //
+  // 同时带回 opaque owner token 与账号代际计数:renderer 原样回传,写入侧在落盘前比对
+  // 「取到内容时的 owner」与「当前 owner」。绝不把 store 内部的绝对路径 `read.ownerRoot`
+  // 暴露给不可信 renderer(review: codex P2)。账号代际再区分同账号登出重登。
+  return {
+    messages,
+    invalidation: read.invalidation,
+    ownerToken,
+    accountCounter: read.accountCounter,
+  };
 }
 
 export async function handleMirrorCachePutMessages(
@@ -854,17 +899,45 @@ export async function handleMirrorCachePutMessages(
     tombstones?: readonly string[],
   ) => Promise<void> = enqueuePurge,
   expectedInvalidation?: unknown,
+  expectedOwnerToken?: unknown,
+  expectedAccountCounter?: unknown,
 ): Promise<{ ok: true; invalidation?: number }> {
   const device = requireCacheId(deviceId, 'deviceId');
   const session = requireCacheId(sessionId, 'sessionId');
   if (!Array.isArray(messages)) throwIpcError('INVALID_PARAMS', 'messages must be an array');
   const bounded = boundedItems(messages, MIRROR_CACHE_MAX_INBOUND_MESSAGES, 'messages');
   const expected =
-    typeof expectedInvalidation === 'number' && Number.isFinite(expectedInvalidation)
+    typeof expectedInvalidation === 'number'
+    && Number.isInteger(expectedInvalidation)
+    && expectedInvalidation >= 0
       ? expectedInvalidation
       : undefined;
+  // renderer 只回传 opaque token。main 用**当前 root 的 token**验证后才把内部 root 交给
+  // store;token 不匹配 / 超长一律按缺失,落到 store fail-closed。若验证后账号又切换,
+  // store 仍会用自己提交时捕获的 root 再比对一次,不会穿透边界(review: codex P2)。
+  const ownerRootAtHandler = ownerScopedUserDataPath('device-link-mirror-cache');
+  const expectedOwner =
+    typeof expectedOwnerToken === 'string'
+    && expectedOwnerToken.length > 0
+    && expectedOwnerToken.length <= MIRROR_CACHE_MAX_OWNER_TOKEN_LENGTH
+    && expectedOwnerToken === cacheOwnerToken()
+      ? ownerRootAtHandler
+      : undefined;
+  const expectedAccount =
+    typeof expectedAccountCounter === 'number'
+    && Number.isInteger(expectedAccountCounter)
+    && expectedAccountCounter >= 0
+      ? expectedAccountCounter
+      : undefined;
   try {
-    const result = await cache.writeMessages(device, session, bounded, expected);
+    const result = await cache.writeMessages(
+      device,
+      session,
+      bounded,
+      expected,
+      expectedOwner,
+      expectedAccount,
+    );
     return { ok: true, invalidation: result.invalidation };
   } catch (err) {
     // 空写(被控端 /clear、rewind、会话删除)删不掉旧文件时同样要能重试:
@@ -876,24 +949,30 @@ export async function handleMirrorCachePutMessages(
 
 export async function handleMirrorCacheGetSessionList(
   cache: MirrorCache,
-): Promise<{ devices: CachedDeviceSessions[] }> {
+): Promise<{ devices: CachedDeviceSessions[]; ownerToken?: string; accountCounter?: number }> {
   const owner = cacheOwnerToken();
   await awaitMirrorCacheReadGate();
   if (await mirrorCacheReadsBlocked()) {
     log.warn('mirror cache read suppressed: purge queue still has pending entries');
     return { devices: [] };
   }
-  const devices = await cache.readSessionList();
-  if (cacheOwnerToken() !== owner) {
-    log.warn('mirror cache read discarded: account boundary moved while reading');
-    return { devices: [] };
-  }
+  const read = await cache.readSessionListWithInvalidation();
   // 同 messages:读完再复核待清状态(见那边的说明)。
   if (await mirrorCacheReadsBlocked()) {
     log.warn('mirror cache read discarded: purge enqueued while reading');
     return { devices: [] };
   }
-  return { devices };
+  const ownerToken = finalMirrorCacheReadOwnerToken(owner, read.ownerRoot);
+  if (!ownerToken) {
+    log.warn('mirror cache read discarded: account boundary moved while reading');
+    return { devices: [] };
+  }
+  // 同 messages:只带 opaque owner token 与账号代际;store 的绝对路径不跨 renderer 边界。
+  return {
+    devices: read.devices,
+    ownerToken,
+    accountCounter: read.accountCounter,
+  };
 }
 
 export async function handleMirrorCachePutSessionList(
@@ -905,6 +984,8 @@ export async function handleMirrorCachePutSessionList(
     barriers?: readonly string[],
     tombstones?: readonly string[],
   ) => Promise<void> = enqueuePurge,
+  expectedOwnerToken?: unknown,
+  expectedAccountCounter?: unknown,
 ): Promise<{ ok: true }> {
   if (!Array.isArray(devices)) throwIpcError('INVALID_PARAMS', 'devices must be an array');
   // 先把外层数组截断,再逐台把 sessions 截断,最后对整批做结构 / 字节预算。
@@ -925,9 +1006,25 @@ export async function handleMirrorCachePutSessionList(
         : [],
     };
   });
+  const ownerRootAtHandler = ownerScopedUserDataPath('device-link-mirror-cache');
+  const expectedOwner =
+    typeof expectedOwnerToken === 'string'
+    && expectedOwnerToken.length > 0
+    && expectedOwnerToken.length <= MIRROR_CACHE_MAX_OWNER_TOKEN_LENGTH
+    && expectedOwnerToken === cacheOwnerToken()
+      ? ownerRootAtHandler
+      : undefined;
+  const expectedAccount =
+    typeof expectedAccountCounter === 'number'
+    && Number.isInteger(expectedAccountCounter)
+    && expectedAccountCounter >= 0
+      ? expectedAccountCounter
+      : undefined;
   try {
     await cache.writeSessionList(
       boundedItems(trimmed, MIRROR_CACHE_MAX_INBOUND_DEVICES, 'session-list'),
+      expectedOwner,
+      expectedAccount,
     );
   } catch (err) {
     // 快照写空(最后一台设备离场)或清理期间的补偿删除失败时,盘上会留着本该消失的设备
@@ -1139,6 +1236,8 @@ export function registerDeviceLinkIpc(deps: DeviceLinkIpcDeps = defaultDeps()): 
       sessionId?: unknown;
       messages?: unknown;
       expectedInvalidation?: unknown;
+      expectedOwnerToken?: unknown;
+      expectedAccountCounter?: unknown;
     };
     return handleMirrorCachePutMessages(
       getMirrorCache(),
@@ -1147,6 +1246,8 @@ export function registerDeviceLinkIpc(deps: DeviceLinkIpcDeps = defaultDeps()): 
       p.messages,
       undefined,
       p.expectedInvalidation,
+      p.expectedOwnerToken,
+      p.expectedAccountCounter,
     );
   });
   ipcMain.handle(DEVICE_LINK_INVOKE.MIRROR_CACHE_GET_SESSION_LIST, (e) => {
@@ -1157,8 +1258,18 @@ export function registerDeviceLinkIpc(deps: DeviceLinkIpcDeps = defaultDeps()): 
   ipcMain.handle(DEVICE_LINK_INVOKE.MIRROR_CACHE_PUT_SESSION_LIST, (e, payload: unknown) => {
     assertTrustedAppRendererEvent(e);
     requireDeviceLinkCapability();
-    const p = (payload ?? {}) as { devices?: unknown };
-    return handleMirrorCachePutSessionList(getMirrorCache(), p.devices);
+    const p = (payload ?? {}) as {
+      devices?: unknown;
+      expectedOwnerToken?: unknown;
+      expectedAccountCounter?: unknown;
+    };
+    return handleMirrorCachePutSessionList(
+      getMirrorCache(),
+      p.devices,
+      undefined,
+      p.expectedOwnerToken,
+      p.expectedAccountCounter,
+    );
   });
   ipcMain.handle(DEVICE_LINK_INVOKE.MIRROR_CACHE_CLEAR, (e, payload: unknown) => {
     assertTrustedAppRendererEvent(e);

--- a/apps/desktop/src/main/device-link/mirrorCacheStore.ts
+++ b/apps/desktop/src/main/device-link/mirrorCacheStore.ts
@@ -415,20 +415,56 @@ export interface MirrorCache {
    * `readMessages` 一并返回、renderer 缓存)。空写会**先**自增该计数再删除,于是任何"内容取自
    * 作废之前"的写入(哪怕来自另一个窗口 / 另一个进程)都会在提交前被比对挡掉 —— renderer
    * 侧的令牌只在本渲染进程内可见,挡不住多窗口(review: codex P1)。
+   *
+   * 参数在类型上可选是为了兼容空写(删除)和旧桥,但**非空写入必须同时提供**匹配的
+   * 非负整数 `expectedInvalidation`、内部 `expectedOwnerRoot` 与非负整数
+   * `expectedAccountCounter`;缺失或不匹配时实现会 fail-closed 拒写。
    */
   writeMessages(
     deviceId: string,
     sessionId: string,
     messages: readonly unknown[],
     expectedInvalidation?: number,
+    expectedOwnerRoot?: string,
+    expectedAccountCounter?: number,
   ): Promise<{ invalidation: number }>;
-  /** 读某 (设备, 会话) 的最近一页,并带回当前作废计数(供写入侧比对)。 */
+  /**
+   * 读某 (设备, 会话) 的最近一页,并带回当前作废计数与账号代际(供写入侧比对)。
+   *
+   * `ownerRoot` 是账号身份(root 路径),`accountCounter` 是账号级作废计数(clearAll 会自增)。
+   * 两者一起才能构成完整的账号边界锚点:root 能区分**不同账号**,而 accountCounter 能区分
+   * **同一账号的登出再登录**(root 相同但 clearAll 已自增过计数)(review: codex P1)。
+   */
   readMessagesWithInvalidation(
     deviceId: string,
     sessionId: string,
-  ): Promise<{ messages: Record<string, unknown>[]; invalidation: number }>;
+  ): Promise<{
+    messages: Record<string, unknown>[];
+    invalidation: number;
+    ownerRoot: string;
+    accountCounter: number;
+  }>;
   readSessionList(): Promise<CachedDeviceSessions[]>;
-  writeSessionList(devices: readonly unknown[]): Promise<void>;
+  /**
+   * 读侧边栏远程会话列表快照,并带回账号身份与代际(供回写比对)。
+   *
+   * 与 readMessagesWithInvalidation 同款:owner root 区分不同账号,accountCounter 区分
+   * 同一账号的登出再登录(clearAll 自增)。渲染进程在排程去抖回写时捕获、写回时原样回传。
+   */
+  readSessionListWithInvalidation(): Promise<{
+    devices: CachedDeviceSessions[];
+    ownerRoot: string;
+    accountCounter: number;
+  }>;
+  /**
+   * 非空快照必须提供 owner root 与非负整数账号代际;可选签名仅用于空写 / 旧桥兼容。
+   * 缺失任一令牌时实现会 fail-closed 拒写。
+   */
+  writeSessionList(
+    devices: readonly unknown[],
+    expectedOwnerRoot?: string,
+    expectedAccountCounter?: number,
+  ): Promise<void>;
   /** 某设备离场(移除 / 撤销控制):清掉它的消息文件与列表快照条目。 */
   clearDevice(deviceId: string): Promise<void>;
   /** 显式登出等隐私路径:整棵缓存目录删掉。 */
@@ -927,6 +963,7 @@ export function createMirrorCache(resolveRoot: () => string): MirrorCache {
   return {
     async readMessagesWithInvalidation(deviceId, sessionId) {
       const root = resolveRoot();
+      const ownerRoot = root;
       const key = sessionClearKey(deviceId, sessionId);
       // 计数必须**夹住**文件读(前后各读一次),不能与它并行:并行时另一个窗口正在清理这条会话,
       // 文件读可能返回清理**之前**的行、计数读却已经是新值(或反之),这一对被原样返回后,发起
@@ -941,16 +978,30 @@ export function createMirrorCache(resolveRoot: () => string): MirrorCache {
       // 墓碑要**夹住**这次读(前后各查一次):共享同一个 userData 的另一个实例可能在我们查过
       // 之后才落墓碑,然后在自增之前退出 —— 那时计数前后一致,只查一次就会把清理失败后的
       // 残留返回出去(review: codex P1)。
-      if (await hasPendingClears(root)) return { messages: [], invalidation: -1 };
+      if (await hasPendingClears(root)) {
+        return { messages: [], invalidation: -1, ownerRoot, accountCounter: -1 };
+      }
       const keys = [key, deviceClearKey(deviceId), CLEARED_ACCOUNT];
       const before = await readCounters(root, keys);
       const messages = await this.readMessages(deviceId, sessionId);
       const after = await readCounters(root, keys);
-      if (await hasPendingClears(root)) return { messages: [], invalidation: -1 };
-      if (!countersHeld(before, after)) {
-        return { messages: [], invalidation: numericCounter(after[0]) };
+      if (await hasPendingClears(root)) {
+        return { messages: [], invalidation: -1, ownerRoot, accountCounter: -1 };
       }
-      return { messages, invalidation: numericCounter(after[0]) };
+      if (!countersHeld(before, after)) {
+        return {
+          messages: [],
+          invalidation: numericCounter(after[0]),
+          ownerRoot,
+          accountCounter: numericCounter(after[2]),
+        };
+      }
+      return {
+        messages,
+        invalidation: numericCounter(after[0]),
+        ownerRoot,
+        accountCounter: numericCounter(after[2]),
+      };
     },
 
     async readMessages(deviceId, sessionId) {
@@ -960,7 +1011,14 @@ export function createMirrorCache(resolveRoot: () => string): MirrorCache {
       return normalizeMessages(messages);
     },
 
-    async writeMessages(deviceId, sessionId, messages, expectedInvalidation) {
+    async writeMessages(
+      deviceId,
+      sessionId,
+      messages,
+      expectedInvalidation,
+      expectedOwnerRoot,
+      expectedAccountCounter,
+    ) {
       if (!deviceId.trim() || !sessionId.trim()) return { invalidation: -1 };
       // root 在**发起时**快照,不能在出错时再 resolve:owner 会在进程生命周期内变(登出 /
       // 切账号),那时 resolveRoot() 指向新账号,而 `file` 还在旧账号目录里 —— 用新 root 去
@@ -1048,6 +1106,30 @@ export function createMirrorCache(resolveRoot: () => string): MirrorCache {
             });
             return { invalidation };
           }
+          const writeGuard: WriteGuard = { kind: 'write', epoch, deviceId };
+          /**
+           * 所有非空写的提交闸。必须在**任何副作用**之前、且在同一文件串行链内执行:
+           * 超限页虽然不落新内容,但会删除旧文件,同样不能让跨账号 / 已作废的迟到响应动缓存。
+           */
+          const canCommitNonEmpty = async (): Promise<boolean> => {
+            if (!held || isStale(writeGuard)) return false;
+            const now = await readClearCounter(rootAtStart, sessionKey);
+            if (typeof now !== 'number' || now !== expectedInvalidation) return false;
+            if (await clearedSince(rootAtStart, deviceClearKey(deviceId), clearCounterAtStart)) {
+              return false;
+            }
+            if (await clearedSince(rootAtStart, CLEARED_ACCOUNT, accountCounterAtStart)) return false;
+            if (typeof expectedOwnerRoot !== 'string' || expectedOwnerRoot !== rootAtStart) {
+              return false;
+            }
+            if (
+              typeof expectedAccountCounter !== 'number'
+              || await clearedSince(rootAtStart, CLEARED_ACCOUNT, expectedAccountCounter)
+            ) {
+              return false;
+            }
+            return true;
+          };
           const body = JSON.stringify(normalized);
           const payload: StoredMessages = {
             version: 1,
@@ -1060,6 +1142,10 @@ export function createMirrorCache(resolveRoot: () => string): MirrorCache {
             // 而同一个超限页每次对账都会走到这里,永远不会有第二次机会更新它。所以**作废**
             // 旧缓存,而不是留一份会骗人的旧页(review: codex P1)。
             await serializeWrite(file, async () => {
+              if (!(await canCommitNonEmpty())) return;
+              // canCommitNonEmpty 内部有多次 await;期间 clearDevice / clearAll 可同步 bump generation
+              // 后排在 root mutex 上。删除旧文件前必须再复核一次(review: independent P2)。
+              if (isStale(writeGuard)) return;
               if (unchanged(file, body)) return; // 内容没变(旧页就是它)→ 无需作废
               lastWritten.delete(file);
               try {
@@ -1075,28 +1161,8 @@ export function createMirrorCache(resolveRoot: () => string): MirrorCache {
             };
           }
           // 落盘与指纹登记必须成对且有序 → 同一文件的写入串成链(见 serializeWrite)。
-          const writeGuard: WriteGuard = { kind: 'write', epoch, deviceId };
           await serializeWrite(file, async () => {
-            // 拿不到跨进程锁(别的**进程**正在临界区)→ 跳过这次写。
-            if (!held) return;
-            if (isStale(writeGuard)) return;
-            // 调用方取到这批内容时看到的会话级计数与此刻不一致 → 期间权威侧作废过(可能是
-            // **另一个窗口 / 另一个进程**干的),手里这批属于作废之前,丢弃(review: codex P1)。
-            //
-            // **没带令牌的非空写入一律拒掉**:缓存读与远端请求是刻意并行的,于是远端页可能在
-            // 缓存读回来之前就到达,此时 renderer 拿不到令牌(undefined)。放行的话,期间另一个
-            // 窗口 rewind / 清会话,这笔取自清理之前的页就在没有任何会话级比对的情况下写回去了
-            // (设备 / 账号基线是这笔写入**开始时**才采样的,已经在清理之后)(review: codex P1)。
-            // 拒掉不会永久关掉这条缓存:下面照样把当前计数返回给调用方,它下一次对账就带上令牌。
-            // 空写(= 清掉这条缓存)不受此限 —— 它本身是安全方向,且由上面的分支处理。
-            const now = await readClearCounter(rootAtStart, sessionKey);
-            // 读不出来 / 对不上都拒写(不可比对即 fail-closed,见 clearedSince)。
-            if (typeof now !== 'number' || now !== expectedInvalidation) return;
-            // 清理在我取到内容之后完成过 → 我手里的是被清掉的旧正文,丢弃。
-            if (await clearedSince(rootAtStart, deviceClearKey(deviceId), clearCounterAtStart))
-              return;
-            // 账号级清理(登出 / 切账号)同理:它删的是整棵缓存根,而计数器在根之外。
-            if (await clearedSince(rootAtStart, CLEARED_ACCOUNT, accountCounterAtStart)) return;
+            if (!(await canCommitNonEmpty())) return;
             // 指纹只算消息体,不含 payload 的 updatedAt —— 否则每次都"变了",去重永不命中。
             // 在链内判等:排队期间前一笔可能刚写下同样内容。
             if (unchanged(file, body)) return;
@@ -1147,38 +1213,72 @@ export function createMirrorCache(resolveRoot: () => string): MirrorCache {
     },
 
     async readSessionList() {
+      const { devices } = await this.readSessionListWithInvalidation();
+      return devices;
+    },
+
+    async readSessionListWithInvalidation() {
       // 同 readMessagesWithInvalidation:用 `_any`(任一设备被清)与 `_account`(登出 / 切账号)
       // 夹住这次读 —— 否则"读到旧快照字节 → 期间设备被撤销 / 账号被清 → 照样返回"会把已经离场的
       // 设备连同会话标题画回侧边栏(review: codex P1)。
       const root = resolveRoot();
+      const ownerRoot = root;
       // 同 readMessagesWithInvalidation:有"没确认清完"的墓碑就不命中。
-      if (await hasPendingClears(root)) return [];
+      if (await hasPendingClears(root)) {
+        return { devices: [], ownerRoot, accountCounter: -1 };
+      }
       const keys = [CLEARED_ANY, CLEARED_ACCOUNT];
       const before = await readCounters(root, keys);
       const parsed = await readJson(sessionListPath());
       const after = await readCounters(root, keys);
       // 同 readMessagesWithInvalidation:墓碑夹住这次读(只查前面挡不住"读到一半才落墓碑")。
-      if (await hasPendingClears(root)) return [];
-      if (!countersHeld(before, after)) return [];
+      if (await hasPendingClears(root)) {
+        return { devices: [], ownerRoot, accountCounter: numericCounter(after[1]) };
+      }
+      if (!countersHeld(before, after)) {
+        return { devices: [], ownerRoot, accountCounter: numericCounter(after[1]) };
+      }
       const devices = isRecord(parsed) && Array.isArray(parsed.devices) ? parsed.devices : [];
-      return normalizeDeviceSessions(devices);
+      return {
+        devices: normalizeDeviceSessions(devices),
+        ownerRoot,
+        accountCounter: numericCounter(after[1]),
+      };
     },
 
-    async writeSessionList(devices) {
+    async writeSessionList(devices, expectedOwnerRoot, expectedAccountCounter) {
       // 代际在请求发起时(进互斥之前)同步捕获 —— 同 writeMessages。
       const epoch = generation;
       const rootAtStart = resolveRoot();
+      const hasContent = normalizeDeviceSessions(devices).length > 0;
       // 同 writeMessages 的三段式:互斥准入 → 等跨进程锁之前读基线 → 拿到锁才提交。
       return withRootMutex(rootAtStart, async () => {
         const clearCounterAtStart = await readClearCounter(rootAtStart, CLEARED_ANY);
         const accountCounterAtStart = await readClearCounter(rootAtStart, CLEARED_ACCOUNT);
+        // **没带 owner root 的非空快照一律拒掉**(同 writeMessages 的 fail-closed):renderer
+        // 可能因补读失败 / owner 边界推进 / IPC 波动拿不到 owner root(undefined),放行的话
+        // 会把上一个账号的快照按**写入时**的新账号 root 落盘 —— 与 #1783 同型的跨账号泄漏。
+        // 空快照(删除)是安全方向照做。
+        if (hasContent && (typeof expectedOwnerRoot !== 'string' || expectedOwnerRoot !== rootAtStart)) {
+          return;
+        }
+        // 账号代际校验(同 writeMessages):同一账号登出再登录时 root 不变,owner root 拦不住;
+        // clearAll 会自增 `_account` 计数,携带「取到内容时的计数」能看出期间发生过登出清理。
+        // 空快照(删除)是安全方向照做。
+        if (
+          hasContent
+          && (typeof expectedAccountCounter !== 'number'
+            || await clearedSince(rootAtStart, CLEARED_ACCOUNT, expectedAccountCounter))
+        ) {
+          return;
+        }
         return withCacheFileLock(rootAtStart, async (held) => {
           // 与 writeMessages 同款:同一文件的写入串成链,保证「落盘 → 登记指纹」成对有序。
           const listFile = path.join(rootAtStart, SESSION_LIST_FILE);
           const outcome = await serializeWrite(listFile, async () =>
             // 拿不到跨进程锁 → 跳过(整份快照写在别人清理途中落地会把被清设备写回来)。
             // 空快照 = **删除**,删除是安全方向:即使拿不到锁 / 期间发生过清理也照做。
-            normalizeDeviceSessions(devices).length === 0 ||
+            !hasContent ||
             (held &&
               !(await clearedSince(rootAtStart, CLEARED_ANY, clearCounterAtStart)) &&
               !(await clearedSince(rootAtStart, CLEARED_ACCOUNT, accountCounterAtStart)))

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -3622,24 +3622,38 @@ contextBridge.exposeInMainWorld('electronAPI', {
       getMessages: (
         deviceId: string,
         sessionId: string,
-      ): Promise<{ messages: Record<string, unknown>[]; invalidation?: number }> =>
-        ipcRenderer.invoke('device-link:mirror-cache:messages:get', { deviceId, sessionId }),
+      ): Promise<{
+        messages: Record<string, unknown>[];
+        invalidation?: number;
+        ownerToken?: string;
+        accountCounter?: number;
+      }> => ipcRenderer.invoke('device-link:mirror-cache:messages:get', { deviceId, sessionId }),
       /**
        * 写某 (设备, 会话) 的最近一页消息;空数组 = 清掉该条缓存。
        * `expectedInvalidation` = 取到这批内容时 main 侧的会话级作废计数(由 get / put 带回,
        * renderer 缓存):不一致说明期间**任意窗口 / 进程**作废过这个会话,main 会丢弃这次写。
+       * `expectedOwnerToken` = 取到这批内容时 main 侧的 opaque owner token(由 get 带回、renderer
+       * 原样回传):账号切换后写入侧靠它丢弃「上一个账号名下取到」的内容(见 #1783)。
+       * `expectedAccountCounter` = 取到这批内容时 main 侧的账号代际计数:同一账号登出再登录
+       * 时 token 可保持不变、但 clearAll 已自增该计数,靠它丢弃登出前取到的内容(见 codex P1)。
+       * 注意:非空写入**缺失**这两个锚点(或与当前不符)会被 main fail-closed 拒绝落盘;
+       * 只有空写(清缓存)不要求它们。
        */
       putMessages: (
         deviceId: string,
         sessionId: string,
         messages: readonly Record<string, unknown>[],
         expectedInvalidation?: number,
+        expectedOwnerToken?: string,
+        expectedAccountCounter?: number,
       ): Promise<{ ok: true; invalidation?: number }> =>
         ipcRenderer.invoke('device-link:mirror-cache:messages:put', {
           deviceId,
           sessionId,
           messages,
           expectedInvalidation,
+          expectedOwnerToken,
+          expectedAccountCounter,
         }),
       /** 读侧边栏远程会话列表快照 */
       getSessionList: (): Promise<{
@@ -3648,6 +3662,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
           deviceName: string;
           sessions: Record<string, unknown>[];
         }>;
+        ownerToken?: string;
+        accountCounter?: number;
       }> => ipcRenderer.invoke('device-link:mirror-cache:session-list:get'),
       /** 写侧边栏远程会话列表快照 */
       putSessionList: (
@@ -3656,8 +3672,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
           deviceName: string;
           sessions: readonly Record<string, unknown>[];
         }>,
+        expectedOwnerToken?: string,
+        expectedAccountCounter?: number,
       ): Promise<{ ok: true }> =>
-        ipcRenderer.invoke('device-link:mirror-cache:session-list:put', { devices }),
+        ipcRenderer.invoke('device-link:mirror-cache:session-list:put', {
+          devices,
+          expectedOwnerToken,
+          expectedAccountCounter,
+        }),
       /**
        * 清掉一台设备的缓存(撤销 / 关被控 / 禁用控制)。deviceId 必填 ——
        * 登出的整体清理由 main 在账号边界自己做,renderer 不持有那个能力。

--- a/apps/desktop/src/renderer/__tests__/deviceLinkRemoteProjects.test.ts
+++ b/apps/desktop/src/renderer/__tests__/deviceLinkRemoteProjects.test.ts
@@ -2,12 +2,69 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   createReconcileBackoff,
+  nextSessionListTokenRetryDelay,
   resolveIneligibleRemoteProjectAction,
   startRemoteSessionsReconciler,
+  startSessionListTokenRefresh,
 } from '@/features/device-link/useDeviceLinkRemoteProjects';
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe('session-list owner token retry backoff', () => {
+  it('从 2s 指数退避到 30s 后仍持续恢复,cleanup 停旧循环,新账号从 2s 重启', async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn(async () => undefined);
+    const stop = startSessionListTokenRefresh(refresh, () => false);
+    await vi.advanceTimersByTimeAsync(0); // 首次立即补读
+    expect(refresh).toHaveBeenCalledTimes(1);
+
+    // 实际循环的间隔序列:2s → 4s → 8s → 16s → 30s → 30s,封顶后不停止。
+    for (const [index, delay] of [2_000, 4_000, 8_000, 16_000, 30_000, 30_000].entries()) {
+      await vi.advanceTimersByTimeAsync(delay - 1);
+      expect(refresh).toHaveBeenCalledTimes(index + 1);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(refresh).toHaveBeenCalledTimes(index + 2);
+    }
+
+    stop();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(refresh).toHaveBeenCalledTimes(7); // 旧账号 timer 已取消
+
+    // effect 在新账号边界重建启动器:立即补读一次,首次重试重新回到 2s(不是继承 30s)。
+    const stopNextOwner = startSessionListTokenRefresh(refresh, () => false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(refresh).toHaveBeenCalledTimes(8);
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(refresh).toHaveBeenCalledTimes(8);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(refresh).toHaveBeenCalledTimes(9);
+    stopNextOwner();
+  });
+
+  it('readiness 就位后不再排后续补读', async () => {
+    vi.useFakeTimers();
+    let ready = false;
+    const refresh = vi.fn(async () => {
+      ready = true;
+    });
+    const stop = startSessionListTokenRefresh(refresh, () => ready);
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    stop();
+  });
+
+  it('纯延迟函数保持 2s 到 30s 封顶', () => {
+    const delays: number[] = [];
+    let previous = 0;
+    for (let i = 0; i < 7; i += 1) {
+      previous = nextSessionListTokenRetryDelay(previous);
+      delays.push(previous);
+    }
+    expect(delays).toEqual([2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000]);
+  });
 });
 
 describe('startRemoteSessionsReconciler', () => {

--- a/apps/desktop/src/renderer/__tests__/remoteMirrorCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/remoteMirrorCache.test.ts
@@ -40,8 +40,15 @@ import {
   cancelSessionListPersist,
   clearCachedDevice,
   clearCachedMessages,
+  clearMirrorCacheAccountState,
+  readCachedMessages,
+  readCachedSessionList,
   scheduleSessionListPersist,
 } from '@/features/device-link/mirrorCacheClient';
+import {
+  __testing as dataOwnerGenTesting,
+  setDataOwnerGeneration,
+} from '@/contexts/dataOwnerGeneration';
 import * as messageService from '@/lib/messageService';
 
 const DEVICE_ID = 'dev-A';
@@ -123,12 +130,31 @@ function emptyProjection(sessionId: string) {
 
 /** 盘上缓存的替身:key 为 `${deviceId}::${sessionId}`。 */
 let cachedMessages = new Map<string, Record<string, unknown>[]>();
-/** get 的返回形状:main 会把当前会话级作废计数一起带回来。 */
-type CachedRead = { messages: Record<string, unknown>[]; invalidation: number };
+/** get 的返回形状:main 会把当前会话级作废计数与 owner root / 账号代际一起带回来。 */
+type CachedRead = {
+  messages: Record<string, unknown>[];
+  invalidation: number;
+  ownerToken?: string;
+  accountCounter?: number;
+};
 let cachedInvalidation = 7;
-const getMessages = vi.fn(async (deviceId: string, sessionId: string) => ({
+let cachedOwnerToken = 'opaque-owner-token-a';
+let cachedAccountCounter = 0;
+const getMessages = vi.fn<
+  (
+    deviceId: string,
+    sessionId: string,
+  ) => Promise<{
+    messages: Record<string, unknown>[];
+    invalidation: number;
+    ownerToken?: string;
+    accountCounter?: number;
+  }>
+>(async (deviceId: string, sessionId: string) => ({
   messages: cachedMessages.get(`${deviceId}::${sessionId}`) ?? [],
   invalidation: cachedInvalidation,
+  ownerToken: cachedOwnerToken,
+  accountCounter: cachedAccountCounter,
 }));
 // 显式签名(而非从实现推断):断言里要读 mock.calls[0][0/1],推断成空元组就取不到。
 const putMessages = vi.fn<
@@ -137,12 +163,14 @@ const putMessages = vi.fn<
     sessionId: string,
     rows: readonly Record<string, unknown>[],
     expectedInvalidation?: number,
+    expectedOwnerToken?: string,
+    expectedAccountCounter?: number,
   ) => Promise<{ ok: true }>
 >(async () => ({ ok: true as const }));
 
 /**
- * 断言"某次写入发生过"。不用 toHaveBeenCalledWith:写入现在还带第 4 个参数
- * (main 侧作废计数,值随路径不同),逐参数写死会让断言变脆。
+ * 断言"某次写入发生过"。不用 toHaveBeenCalledWith:写入现在还带第 4~6 个参数
+ * (main 侧作废计数 / owner root / 账号代际,值随路径不同),逐参数写死会让断言变脆。
  */
 function expectPut(deviceId: string, sessionId: string, rows: unknown[]): void {
   const hit = putMessages.mock.calls.some(
@@ -151,9 +179,17 @@ function expectPut(deviceId: string, sessionId: string, rows: unknown[]): void {
   );
   expect(hit).toBe(true);
 }
-const getSessionList = vi.fn(async () => ({ devices: [] as never[] }));
+const getSessionList = vi.fn(async () => ({
+  devices: [] as never[],
+  ownerToken: cachedOwnerToken,
+  accountCounter: cachedAccountCounter,
+}));
 const putSessionList = vi.fn<
-  (devices: readonly Record<string, unknown>[]) => Promise<{ ok: true }>
+  (
+    devices: readonly Record<string, unknown>[],
+    expectedOwnerToken?: string,
+    expectedAccountCounter?: number,
+  ) => Promise<{ ok: true }>
 >(async () => ({ ok: true as const }));
 const clearCache = vi.fn(async () => ({ ok: true as const }));
 
@@ -205,6 +241,8 @@ beforeEach(() => {
   cachedMessages = new Map();
   invoke.mockClear();
   cachedInvalidation = 7;
+  cachedOwnerToken = 'opaque-owner-token-a';
+  cachedAccountCounter = 0;
   getMessages.mockClear();
   putMessages.mockClear();
   putSessionList.mockClear();
@@ -214,6 +252,9 @@ beforeEach(() => {
 afterEach(() => {
   makerChatStore.__teardownGlobalListeners();
   remoteProjectsStore.clear();
+  // 清掉 per-session owner root / 作废计数残留,保持测试隔离。
+  clearMirrorCacheAccountState();
+  dataOwnerGenTesting.reset();
   vi.unstubAllGlobals();
 });
 
@@ -545,6 +586,125 @@ describe('缓存写点纪律', () => {
     expect(putMessages.mock.calls[0]?.[3]).toBe(11);
   });
 
+  it('本地还没有 owner root 时,写入不携带 owner root(由 store fail-closed 决定去留)', async () => {
+    // review(#1783 / codex P1):owner root 只信任受保护读(如 readCachedMessages)带回的已知值;
+    // 不知道时**不做异步补读** —— 补读 IPC 若在账号切换后才被 main 处理,会把新账号的 root
+    // 当成本次请求的 owner 锚点,反而让旧账号在途响应通过比对。未知即传 undefined,由 store
+    // 侧 fail-closed 丢弃(缓存是纯优化)。
+    const s = sid();
+    registerRemote(s);
+    // 不预置 knownOwnerToken:直接发起远端请求,owner root 未知。
+    cachedOwnerToken = 'opaque-owner-token-b';
+    remoteList = [dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z')];
+
+    await listMessagesFor(s);
+    await flush(20);
+
+    // 写入仍会发出(会话计数在),但第 5 个参数(owner root)应为 undefined。
+    expect(putMessages).toHaveBeenCalledTimes(1);
+    expect(putMessages.mock.calls[0]?.[4]).toBeUndefined();
+  });
+
+  it('账号切换后复用同一 sessionId:旧账号残留 owner root 被清,新账号可重建缓存', async () => {
+    // review(#1801):knownOwnerToken 是 per-session、在某账号下读缓存时记下的。账号切换后若
+    // B 复用同一 sessionId,不清理的话会一直带着 A 的 root 提交,被 store fail-closed 持续
+    // 拒写 → B 的缓存静默失效。账号边界必须清空 per-session 残留,让 owner 重新从受保护读
+    // 获取。
+    const s = sid();
+    registerRemote(s);
+
+    // 账号 A:先有一次成功的缓存读,让 knownOwnerToken 记住 A 的 root。
+    cachedOwnerToken = 'opaque-owner-token-a';
+    await readCachedMessages(DEVICE_ID, s);
+    expect(putMessages).not.toHaveBeenCalled();
+
+    // 账号边界:登出 A / 切到 B。
+    cachedOwnerToken = 'opaque-owner-token-b';
+    clearMirrorCacheAccountState();
+
+    // 账号 B:复用同一 sessionId。真实时序里 B 的 hydrate 会先做一次受保护的缓存读(把
+    // knownOwnerToken 重设为 B 的 root),随后远端请求的写入才能带上正确的 B root —— 而不是
+    // A 的残留。这里复现「边界清空 → B 重新读到 B root → 写入带 B root」的完整序列。
+    await readCachedMessages(DEVICE_ID, s);
+    remoteList = [dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z')];
+    await listMessagesFor(s);
+    await flush(20);
+
+    expect(putMessages).toHaveBeenCalledTimes(1);
+    expect(putMessages.mock.calls[0]?.[4]).toBe('opaque-owner-token-b');
+  });
+
+  it('在途缓存读在账号切换后才完成 → 不把旧账号 owner root 写回 knownOwnerToken', async () => {
+    // review(Greptile P1):readCachedMessages 的 IPC 在途期间账号切换,clearMirrorCacheAccountState
+    // 已清掉旧 token;读完成时若直接写回,会把 A 的 owner root / 代际重新种回,导致 B 复用同一
+    // sessionId 时被 main fail-closed 持续拒写。读完成前先校验 owner 仍是发起时身份,不是则丢弃。
+    const s = sid();
+    registerRemote(s);
+
+    // 账号 A 发起一次受保护缓存读,让它挂起(读完成前切换账号)
+    setDataOwnerGeneration('owner-a', 1);
+    let resolveRead!: (v: CachedRead) => void;
+    getMessages.mockImplementationOnce(
+      () =>
+        new Promise<CachedRead>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    const readPromise = readCachedMessages(DEVICE_ID, s);
+    await flush(2);
+
+    // 账号切换:dataOwnerGeneration 推进到 B(模拟 runtime 替换刷新直接发布新 owner)
+    setDataOwnerGeneration('owner-b', 2);
+    clearMirrorCacheAccountState();
+    // 旧读完成,返回 A 的 root + A 的消息 —— 但 owner 已变:
+    //  1. 不应写回 knownOwnerToken;
+    //  2. **不应把 A 的消息返回**给 hydrate(否则 B 会看到 A 的消息,远端首拉失败时持续保留,
+    //     跨账号泄漏)(review: Greptile P1 security)。
+    resolveRead({
+      messages: [{ id: 'a-msg', role: 'user', content: 'secret A message' }] as never,
+      invalidation: 0,
+      ownerToken: 'opaque-owner-token-a',
+      accountCounter: 0,
+    });
+    const rows = await readPromise;
+    expect(rows).toEqual([]);
+
+    // B 发起远端请求:owner root 应未知(B 的受保护读还没跑),写入不携带 A 的残留
+    cachedOwnerToken = 'opaque-owner-token-b';
+    remoteList = [dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z')];
+    await listMessagesFor(s);
+    await flush(20);
+
+    expect(putMessages).toHaveBeenCalledTimes(1);
+    // 若旧 A root 被写回,这里会带上 A 的 root;正确行为是 undefined(B 尚未重读)
+    expect(putMessages.mock.calls[0]?.[4]).toBeUndefined();
+  });
+
+  it('accountCounter 不可读(-1)时整份读作废:消息不种入、owner root 不缓存', async () => {
+    // review(Codex P2):owner root 与账号代际必须**成对**缓存。main 在「计数不可读」时返回
+    // -1,此时若仍单独缓存 owner root,ownerTokenAtRequestStart 会短路返回 root、
+    // accountCounterAtRequestStart 却 undefined → 非空写入被 store fail-closed 拒到下次
+    // hydrate。counter 无效 = root 也不记,整份读作废返回 []。
+    const s = sid();
+    registerRemote(s);
+    cachedMessages.set(`${DEVICE_ID}::${s}`, [
+      dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z') as unknown as Record<string, unknown>,
+    ]);
+    cachedAccountCounter = -1; // main 返回「计数不可读」哨兵
+
+    const rows = await readCachedMessages(DEVICE_ID, s);
+    expect(rows).toEqual([]); // 不把盘上缓存内容种入
+
+    // 远端请求:写入不应携带任何残留令牌(counter 无效 → root 也没缓存)
+    remoteList = [dbMessage(s, 'm2', 'x', '2026-01-01T00:00:01.000Z')];
+    await listMessagesFor(s);
+    await flush(20);
+
+    expect(putMessages).toHaveBeenCalledTimes(1);
+    expect(putMessages.mock.calls[0]?.[4]).toBeUndefined(); // owner root
+    expect(putMessages.mock.calls[0]?.[5]).toBeUndefined(); // account counter
+  });
+
   it('翻页(before / beforeTs)不写缓存:老窗口不是"最近一页"', async () => {
     const s = sid();
     registerRemote(s);
@@ -842,6 +1002,283 @@ describe('清某设备缓存不牵连别的设备', () => {
       expect(putSessionList).toHaveBeenCalledTimes(1);
       const written = putSessionList.mock.calls[0]?.[0] as Array<{ deviceId: string }>;
       expect(written.map((d) => d.deviceId)).toEqual(['dev-A']);
+    } finally {
+      cancelSessionListPersist();
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('session-list 去抖回写的账号令牌时序', () => {
+  it('排程时令牌未知、触发前补读成功 → 使用同账号的最新令牌写入', async () => {
+    // review(codex P2):若排程时把 undefined 冻结进闭包,即使 debounce 期间令牌补齐,
+    // 非空快照仍会被 main fail-closed 丢弃;相同 reconcile 数据不再通知时缓存持续陈旧。
+    vi.useFakeTimers();
+    try {
+      setDataOwnerGeneration('owner-a', 1);
+      clearMirrorCacheAccountState();
+      scheduleSessionListPersist(() => [
+        { deviceId: 'dev-A', deviceName: 'Mac A', sessions: [{ id: 's-a' }] as never },
+      ]);
+
+      // debounce 触发前,受保护列表读把当前账号令牌补齐。
+      await readCachedSessionList();
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(putSessionList).toHaveBeenCalledTimes(1);
+      expect(putSessionList.mock.calls[0]?.[1]).toBe(cachedOwnerToken);
+      expect(putSessionList.mock.calls[0]?.[2]).toBe(cachedAccountCounter);
+    } finally {
+      cancelSessionListPersist();
+      vi.useRealTimers();
+    }
+  });
+
+  it('排程后账号切换 → 不用新账号令牌提交旧账号排下的快照', async () => {
+    vi.useFakeTimers();
+    try {
+      setDataOwnerGeneration('owner-a', 1);
+      await readCachedSessionList();
+      scheduleSessionListPersist(() => [
+        { deviceId: 'dev-A', deviceName: 'Mac A', sessions: [{ id: 'secret-a' }] as never },
+      ]);
+
+      setDataOwnerGeneration('owner-b', 2);
+      clearMirrorCacheAccountState();
+      cachedOwnerToken = 'opaque-owner-token-b';
+      await readCachedSessionList();
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(putSessionList).not.toHaveBeenCalled();
+    } finally {
+      cancelSessionListPersist();
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('cancelSessionListPersist 不丢 owner token(relay-stopped 非账号边界)', () => {
+  // review(codex P2):cancelSessionListPersist 既在账号边界也在 relay-stopped(服务停掉而非登出)
+  // 时被调用。若它在普通 cancel 时清掉 owner root / 账号代际,同一挂载实例重新 online 后
+  // scheduleSessionListPersist 会持续带 undefined 写非空快照,被 main fail-closed 丢弃 ——
+  // 侧边栏冷缓存直到重挂载都不刷新。清空只归真正的账号边界 clearMirrorCacheAccountState()。
+  it('relay stopped(普通 cancel)后,列表回写仍携带 owner root / 账号代际', async () => {
+    vi.useFakeTimers();
+    try {
+      // 先有一次受保护读,让 knownSessionListOwnerToken / knownSessionListAccountCounter 就位
+      await readCachedSessionList();
+      // relay-stopped:普通 cancel,不应清 token
+      cancelSessionListPersist();
+      // 重新 online 后排一次列表回写 → 必须仍带 owner root / 账号代际
+      scheduleSessionListPersist(() => [
+        { deviceId: 'dev-A', deviceName: 'Mac A', sessions: [{ id: 's-a' }] as never },
+      ]);
+      await vi.advanceTimersByTimeAsync(2_000);
+
+      expect(putSessionList).toHaveBeenCalledTimes(1);
+      expect(putSessionList.mock.calls[0]?.[1]).toBe(cachedOwnerToken);
+      expect(putSessionList.mock.calls[0]?.[2]).toBe(cachedAccountCounter);
+    } finally {
+      cancelSessionListPersist();
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('会话作废计数补读的等待纪律', () => {
+  it('独立 getMessages IPC 永久挂起时,超时后以 undefined 计数安全降级', async () => {
+    // review(copilot suppressed):没有受保护 hydrate 读时,invalidationAtRequestStart 会独立
+    // getMessages;若 IPC 永不 settle,persistCachedMessages 会永久卡在 Promise.all。
+    vi.useFakeTimers();
+    try {
+      const s = sid();
+      registerRemote(s);
+      let resolveRead!: (value: CachedRead) => void;
+      getMessages.mockImplementationOnce(
+        () =>
+          new Promise<CachedRead>((resolve) => {
+            resolveRead = resolve;
+          }),
+      );
+      remoteList = [dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z')];
+
+      await listMessagesFor(s);
+      await vi.advanceTimersByTimeAsync(2_999);
+      expect(putMessages).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(putMessages).toHaveBeenCalledTimes(1);
+      expect(putMessages.mock.calls[0]?.[3]).toBeUndefined(); // main invalidation
+      expect(putMessages.mock.calls[0]?.[4]).toBeUndefined(); // owner root
+      expect(putMessages.mock.calls[0]?.[5]).toBeUndefined(); // account counter
+
+      // 底层 IPC 在超时后迟到,不能再把旧结果写进 knownMainInvalidation。
+      resolveRead({
+        messages: [],
+        invalidation: 99,
+        ownerToken: 'opaque-owner-token-a',
+        accountCounter: 0,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      putMessages.mockClear();
+      remoteList = [dbMessage(s, 'm2', 'y', '2026-01-01T00:00:01.000Z')];
+      await listMessagesFor(s);
+      await vi.advanceTimersByTimeAsync(0);
+
+      // 若迟到结果污染了已知计数,第二次不会重新 get;正确行为是重新补读并拿默认值 7。
+      expect(getMessages).toHaveBeenCalledTimes(2);
+      expect(putMessages).toHaveBeenCalledTimes(1);
+      expect(putMessages.mock.calls[0]?.[3]).toBe(cachedInvalidation);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('补读完成前切换账号:旧账号计数作废且不写回 knownMainInvalidation', async () => {
+    const s = sid();
+    registerRemote(s);
+    setDataOwnerGeneration('owner-a', 1);
+    let resolveRead!: (value: CachedRead) => void;
+    getMessages.mockImplementationOnce(
+      () =>
+        new Promise<CachedRead>((resolve) => {
+          resolveRead = resolve;
+        }),
+    );
+    remoteList = [dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z')];
+    await listMessagesFor(s);
+
+    setDataOwnerGeneration('owner-b', 2);
+    clearMirrorCacheAccountState();
+    resolveRead({
+      messages: [],
+      invalidation: 99,
+      ownerToken: 'opaque-owner-token-a',
+      accountCounter: 0,
+    });
+    await flush(20);
+
+    expect(putMessages).toHaveBeenCalledTimes(1);
+    expect(putMessages.mock.calls[0]?.[3]).toBeUndefined();
+
+    // 第二次仍须补读:99 属于旧 owner,不能成为 B 的已知计数。
+    putMessages.mockClear();
+    remoteList = [dbMessage(s, 'm2', 'y', '2026-01-01T00:00:01.000Z')];
+    await listMessagesFor(s);
+    await flush(20);
+    expect(getMessages).toHaveBeenCalledTimes(2);
+    expect(putMessages.mock.calls[0]?.[3]).toBe(cachedInvalidation);
+  });
+});
+
+describe('在途受保护读的等待纪律', () => {
+  it('IPC 永久挂起时写入不被无限阻塞:超时后降级为 undefined 令牌', async () => {
+    // review(copilot P1):ownerTokenAtRequestStart 在有 pendingProtectedRead 时把 Promise 交给
+    // persistCachedMessages(它 Promise.all 等待)。若那笔 get 既不 resolve 也不 reject
+    // (main 卡死 / 通道断开但 Promise 没 settle),该会话后续缓存写入会被**永久**堵住。
+    // 缓存是 best-effort:超时降级为 undefined,由 store fail-closed 丢这一次写。
+    vi.useFakeTimers();
+    try {
+      const s = sid();
+      registerRemote(s);
+      // 永不 settle 的读:模拟挂死的 IPC
+      getMessages.mockImplementationOnce(() => new Promise(() => {}));
+      void readCachedMessages(DEVICE_ID, s);
+      await vi.advanceTimersByTimeAsync(0);
+
+      remoteList = [dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z')];
+      await listMessagesFor(s);
+      // 超时窗口内写入还在等(不该抢跑派发)
+      await vi.advanceTimersByTimeAsync(500);
+      expect(putMessages).not.toHaveBeenCalled();
+
+      // 超时后必须降级派发,而不是永久挂着
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(putMessages).toHaveBeenCalledTimes(1);
+      expect(putMessages.mock.calls[0]?.[4]).toBeUndefined(); // owner root
+      expect(putMessages.mock.calls[0]?.[5]).toBeUndefined(); // account counter
+
+      // 永久挂起的 entry 必须在超时后从 map 摘掉:第二次写不应再重复白等 3 秒。
+      putMessages.mockClear();
+      remoteList = [dbMessage(s, 'm2', 'y', '2026-01-01T00:00:01.000Z')];
+      await listMessagesFor(s);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(putMessages).toHaveBeenCalledTimes(1);
+      expect(putMessages.mock.calls[0]?.[4]).toBeUndefined();
+      expect(putMessages.mock.calls[0]?.[5]).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('账号切换后 B 不等 A 的在途读:立即降级,不白等一场', async () => {
+    // review(Greptile P1):clearMirrorCacheAccountState 清空已知令牌却保留 A 的
+    // pendingProtectedRead。B 复用同一 sessionId 时会去等那笔注定拿不到令牌的旧读
+    // (它完成时因代际不符不写令牌)—— 白等一个超时窗口后仍是 undefined。
+    const s = sid();
+    registerRemote(s);
+    getMessages.mockImplementationOnce(() => new Promise(() => {})); // A 的读挂在途
+    void readCachedMessages(DEVICE_ID, s);
+    await flush(2);
+
+    // 账号切换到 B
+    setDataOwnerGeneration('owner-b', 2);
+    clearMirrorCacheAccountState();
+
+    // B 复用同一 sessionId 发起远端请求:不该等 A 的在途读,直接 undefined 令牌
+    remoteList = [dbMessage(s, 'm1', 'x', '2026-01-01T00:00:00.000Z')];
+    await listMessagesFor(s);
+    await flush(20);
+
+    expect(putMessages).toHaveBeenCalledTimes(1);
+    expect(putMessages.mock.calls[0]?.[4]).toBeUndefined();
+    expect(putMessages.mock.calls[0]?.[5]).toBeUndefined();
+  });
+});
+
+describe('列表读在账号切换后整份作废', () => {
+  it('在途 getSessionList 在切账号后完成:不返回旧账号设备、不缓存旧令牌', async () => {
+    // review(copilot P1):readCachedSessionList 原先只挡令牌写回,仍把旧账号的 devices
+    // 返回给调用方;冷启动 hydrate 会把这份快照直接种进侧边栏 → B 看到 A 的设备与会话标题。
+    let resolveRead!: (v: {
+      devices: unknown[];
+      ownerToken?: string;
+      accountCounter?: number;
+    }) => void;
+    getSessionList.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRead = resolve as never;
+        }) as never,
+    );
+    const readPromise = readCachedSessionList();
+    await flush(2);
+
+    setDataOwnerGeneration('owner-b', 2);
+    clearMirrorCacheAccountState();
+
+    // 旧读带着 A 的设备快照完成
+    resolveRead({
+      devices: [
+        { deviceId: 'dev-A', deviceName: "Alice's Mac", sessions: [{ id: 'secret-a-session' }] },
+      ],
+      ownerToken: 'opaque-owner-token-a',
+      accountCounter: 0,
+    });
+
+    // 整份作废:一条都不能返回给侧边栏
+    expect(await readPromise).toEqual([]);
+
+    // 令牌也不该被旧读写回 —— 否则 B 的列表回写会带上 A 的 root 被 fail-closed 拒写
+    vi.useFakeTimers();
+    try {
+      scheduleSessionListPersist(() => [
+        { deviceId: 'dev-B', deviceName: 'Mac B', sessions: [{ id: 's-b' }] as never },
+      ]);
+      await vi.advanceTimersByTimeAsync(2_000);
+      expect(putSessionList).toHaveBeenCalledTimes(1);
+      expect(putSessionList.mock.calls[0]?.[1]).toBeUndefined();
+      expect(putSessionList.mock.calls[0]?.[2]).toBeUndefined();
     } finally {
       cancelSessionListPersist();
       vi.useRealTimers();

--- a/apps/desktop/src/renderer/features/device-link/mirrorCacheClient.ts
+++ b/apps/desktop/src/renderer/features/device-link/mirrorCacheClient.ts
@@ -12,6 +12,11 @@
 
 import type { Message, Session } from '@/lib/ccAgent.types';
 import { createLogger } from '@/lib/logger';
+import {
+  isDataOwnerGenerationCurrent,
+  getDataOwnerGeneration,
+  type DataOwnerGeneration,
+} from '@/contexts/dataOwnerGeneration';
 
 const log = createLogger('device-link:mirror-cache');
 
@@ -31,18 +36,110 @@ function bridge(): MirrorCacheBridge | null {
   return (window.electronAPI?.deviceLink?.mirrorCache as MirrorCacheBridge | undefined) ?? null;
 }
 
+/**
+ * 等在途受保护读的上限。缓存是纯 best-effort:若那笔 get IPC 异常挂起(既不 resolve 也不
+ * reject,如 main 侧卡死 / 通道断开但 Promise 没被 settle),无限等下去会**永久堵住**该会话
+ * 后续所有缓存写入。超时后降级为 undefined 令牌,交给 store 的 fail-closed 丢这一次写 ——
+ * 下次 hydrate 会重新补上锚点(review: copilot P1)。
+ */
+const TOKEN_READ_WAIT_TIMEOUT_MS = 3000;
+
+/**
+ * 给独立的缓存令牌补读加同一等待上限。底层 IPC 超时后仍可能在后台完成,但 `Promise.race`
+ * 已经以 undefined 收敛,不会再执行调用方的记令牌逻辑。
+ */
+function tokenReadWithin<T>(read: Promise<T>): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => resolve(undefined), TOKEN_READ_WAIT_TIMEOUT_MS);
+  });
+  return Promise.race([read, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}
+
+/** 每会话在途的受保护缓存读(供并发写点等待 opaque owner token / 代际就位,见 ownerTokenAtRequestStart)。 */
+interface PendingProtectedRead {
+  /** 发起这笔读时的 owner 身份:账号切换后旧读的令牌对新账号无效,不能等它。 */
+  readonly owner: DataOwnerGeneration;
+  readonly done: Promise<void>;
+}
+
+const pendingProtectedRead = new Map<string, PendingProtectedRead>();
+
+/**
+ * 等在途受保护读完成后取令牌,带超时与账号代际复核。
+ *
+ * 两个降级到 undefined(→ store fail-closed 丢这次写)的出口:
+ *  1. 等待超过 TOKEN_READ_WAIT_TIMEOUT_MS —— 那笔 IPC 挂住了,不能永久堵写;
+ *  2. 等待期间账号又切了 —— 取到的令牌属于旧账号,拿去比对只会误判。
+ */
+function afterProtectedRead<T>(
+  sessionId: string,
+  entry: PendingProtectedRead,
+  pick: () => T | undefined,
+): Promise<T | undefined> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<'timeout'>((resolve) => {
+    timer = setTimeout(() => resolve('timeout'), TOKEN_READ_WAIT_TIMEOUT_MS);
+  });
+  return Promise.race([entry.done.then(() => 'done' as const), timeout]).then((outcome) => {
+    if (timer !== undefined) clearTimeout(timer);
+    if (outcome === 'timeout') {
+      // done 永久不 settle 时,它自己的 finally 也永远不会清 map。超时必须把同一 entry 摘掉,
+      // 否则后续每次写仍会重复白等 3 秒,且挂起会话让 map 无界增长(review: independent P1)。
+      if (pendingProtectedRead.get(sessionId) === entry) pendingProtectedRead.delete(sessionId);
+      return undefined;
+    }
+    if (!isDataOwnerGenerationCurrent(entry.owner)) return undefined;
+    return pick();
+  });
+}
+
 /** 读某 (设备, 会话) 缓存的最近一页 server rows;未命中 / 出错一律空数组。 */
 export async function readCachedMessages(deviceId: string, sessionId: string): Promise<Message[]> {
   const api = bridge();
   if (!api || !deviceId || !sessionId) return [];
-  try {
-    const result = await api.getMessages(deviceId, sessionId);
-    rememberMainInvalidation(sessionId, result?.invalidation);
-    return Array.isArray(result?.messages) ? (result.messages as unknown as Message[]) : [];
-  } catch (err) {
-    log.debug('read cached messages failed', err);
-    return [];
-  }
+  const ownerAtStart = getDataOwnerGeneration();
+  const read = (async (): Promise<Message[]> => {
+    try {
+      const result = await api.getMessages(deviceId, sessionId);
+      // owner 不再是发起时身份(读 IPC 在途期间账号已切换)→ 整份结果作废:
+      //  1. 不记 token:把旧账号的 opaque owner token / 代际写回会污染新账号的写入锚点,让 B 复用
+      //     同一 sessionId 时被 main fail-closed 持续拒写;
+      //  2. **不返回消息**:hydrate 路径没有账号代际复核,会把 A 的消息写进 chat store,
+      //     远端首拉失败时 B 会一直看到 A 的消息 —— 跨账号数据泄漏(review: Greptile P1
+      //     security)。
+      if (!isDataOwnerGenerationCurrent(ownerAtStart)) return [];
+      // opaque owner token 与账号代际必须**成对**缓存:counter 不可读(-1 / 未提供)时 token 单独缓存
+      // 会让 ownerTokenAtRequestStart 短路返回 token、accountCounterAtRequestStart 却 undefined,
+      // 非空写入被 fail-closed 拒到下次 hydrate(review: codex P2)。
+      const accountCounter =
+        typeof result?.accountCounter === 'number'
+        && Number.isInteger(result.accountCounter)
+        && result.accountCounter >= 0
+          ? result.accountCounter
+          : undefined;
+      if (accountCounter === undefined) return [];
+      rememberMainInvalidation(sessionId, result?.invalidation);
+      rememberOwnerToken(sessionId, result?.ownerToken);
+      rememberAccountCounter(sessionId, accountCounter);
+      return Array.isArray(result?.messages) ? (result.messages as unknown as Message[]) : [];
+    } catch (err) {
+      log.debug('read cached messages failed', err);
+      return [];
+    }
+  })();
+  // 登记在途受保护读:账号切换后首次打开远程会话时,hydrate 的 readCachedMessages 与
+  // listMessagesFor 并行,写点要等这份读完成拿到 opaque owner token / 代际,而不是同步拿到 undefined
+  // 被 store fail-closed 丢弃(review: Greptile P1)。等它完成后清掉登记,避免泄漏。
+  const done = read.then(() => undefined, () => undefined);
+  const entry: PendingProtectedRead = { owner: ownerAtStart, done };
+  pendingProtectedRead.set(sessionId, entry);
+  void done.finally(() => {
+    if (pendingProtectedRead.get(sessionId) === entry) pendingProtectedRead.delete(sessionId);
+  });
+  return read;
 }
 
 /** 写某 (设备, 会话) 的最近一页 server rows(空数组 = 清掉该条缓存)。失败静默。 */
@@ -53,10 +150,77 @@ export async function readCachedMessages(deviceId: string, sessionId: string): P
  */
 const knownMainInvalidation = new Map<string, number>();
 
+/** 每会话最近一次 get 时 main 侧的 opaque owner token(见 persistCachedMessages 的 expectedOwnerToken)。 */
+const knownOwnerToken = new Map<string, string>();
+
+/** 每会话最近一次 get 时 main 侧的账号代际计数(clearAll 会自增;区分同账号登出再登录)。 */
+const knownAccountCounter = new Map<string, number>();
+
 function rememberMainInvalidation(sessionId: string, value: number | undefined): void {
-  if (typeof value === 'number' && Number.isFinite(value)) {
+  // 只缓存**非负**计数:main 在「有墓碑 / 计数不可读」时返回 -1(不可比对),缓存 -1 会让
+  // 后续请求同步拿到 -1、被 store 持续拒写,即使之后清理完成也恢复不了(review: copilot)。
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
     knownMainInvalidation.set(sessionId, value);
   }
+}
+
+function rememberOwnerToken(sessionId: string, value: string | undefined): void {
+  if (typeof value === 'string' && value.length > 0) {
+    knownOwnerToken.set(sessionId, value);
+  }
+}
+
+function rememberAccountCounter(sessionId: string, value: number | undefined): void {
+  // 同 rememberMainInvalidation:不缓存 -1(不可比对的哨兵值),否则账号代际校验会一直拒写。
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 0) {
+    knownAccountCounter.set(sessionId, value);
+  }
+}
+
+/** 该会话最近一次 get 时的 opaque owner token;未知返回 undefined。 */
+export function knownOwnerTokenFor(sessionId: string): string | undefined {
+  return knownOwnerToken.get(sessionId);
+}
+
+/**
+ * 取"发起这次远端请求时 main 侧的 opaque owner token"。
+ *
+ * **只信任受保护的缓存读**(`readCachedMessages` / `readCachedSessionList`,经 main 侧
+ * `handleMirrorCacheGetMessages` 的 owner 原子复核)带回的值,绝不单独 `getMessages` 补读:
+ * 若补读 IPC 在账号切换后才被 main 处理,读到的是**新账号**的 token,旧账号在途响应带着
+ * 这个新 token 提交时 `expectedOwnerToken === tokenAtStart` 恰好相等 → 穿透 store 的
+ * fail-closed(review: codex P1)。
+ *
+ * 但也不在未知时直接返回 undefined 丢掉首次写入:账号切换后首次打开会话时,hydrate 的
+ * readCachedMessages 与 listMessagesFor **并行**,写点此刻可能还没拿到 opaque owner token。这里
+ * **等待在途的受保护读完成**(如果存在),拿到它原子复核过的 token;没有在途读(异常时序)
+ * 才返回 undefined → 由 store fail-closed 丢弃(review: Greptile P1)。
+ */
+export function ownerTokenAtRequestStart(
+  sessionId: string,
+): string | undefined | Promise<string | undefined> {
+  const known = knownOwnerToken.get(sessionId);
+  if (typeof known === 'string') return known;
+  const pending = pendingProtectedRead.get(sessionId);
+  // 只等**当前账号**发起的在途读:B 复用同一 sessionId 时,A 的在途读已被账号边界作废
+  // (它完成时会因代际不符不写令牌),等它只会白等一场再拿到 undefined(review: Greptile P1)。
+  if (pending && isDataOwnerGenerationCurrent(pending.owner)) {
+    return afterProtectedRead(sessionId, pending, () => knownOwnerToken.get(sessionId));
+  }
+  return undefined;
+}
+
+/** 该会话最近一次 get 时的账号代际计数;未知道等受保护读,无在途读则 undefined(fail-closed)。 */
+export function accountCounterAtRequestStart(
+  sessionId: string,
+): number | undefined | Promise<number | undefined> {
+  const known = knownAccountCounter.get(sessionId);
+  if (typeof known === 'number') return known;
+  const pending = pendingProtectedRead.get(sessionId);
+  if (pending && isDataOwnerGenerationCurrent(pending.owner)) {
+    return afterProtectedRead(sessionId, pending, () => knownAccountCounter.get(sessionId));
+  }
+  return undefined;
 }
 
 export function persistCachedMessages(
@@ -64,23 +228,50 @@ export function persistCachedMessages(
   sessionId: string,
   rows: readonly Message[],
   expectedInvalidation?: number | Promise<number | undefined>,
+  expectedOwnerToken?: string | Promise<string | undefined>,
+  expectedAccountCounter?: number | Promise<number | undefined>,
 ): void {
   const api = bridge();
   if (!api || !deviceId || !sessionId) return;
-  const dispatch = (expected: number | undefined): void => {
+  const dispatch = (
+    expected: number | undefined,
+    ownerToken: string | undefined,
+    accountCounter: number | undefined,
+  ): void => {
     void api
-      .putMessages(deviceId, sessionId, rows as unknown as Record<string, unknown>[], expected)
+      .putMessages(
+        deviceId,
+        sessionId,
+        rows as unknown as Record<string, unknown>[],
+        expected,
+        ownerToken,
+        accountCounter,
+      )
       .then((result) => rememberMainInvalidation(sessionId, result?.invalidation))
       .catch((err: unknown) => log.debug('persist cached messages failed', err));
   };
   // 令牌已经在手 / 根本没有(空写)时**同步**派发 —— 清缓存这类"必须尽快到 main"的调用不该
   // 因为多一个 await 被推到下一个微任务(顺序会被后面的写入抢到前面去)。
-  if (typeof expectedInvalidation === 'number' || expectedInvalidation === undefined) {
-    dispatch(expectedInvalidation);
+  if (
+    (typeof expectedInvalidation === 'number' || expectedInvalidation === undefined)
+    && (typeof expectedOwnerToken === 'string' || expectedOwnerToken === undefined)
+    && (typeof expectedAccountCounter === 'number' || expectedAccountCounter === undefined)
+  ) {
+    dispatch(expectedInvalidation, expectedOwnerToken, expectedAccountCounter);
     return;
   }
-  void expectedInvalidation
-    .then(dispatch)
+  void Promise.all([
+    expectedInvalidation instanceof Promise
+      ? expectedInvalidation
+      : Promise.resolve(expectedInvalidation),
+    expectedOwnerToken instanceof Promise ? expectedOwnerToken : Promise.resolve(expectedOwnerToken),
+    expectedAccountCounter instanceof Promise
+      ? expectedAccountCounter
+      : Promise.resolve(expectedAccountCounter),
+  ] as const)
+    .then(([expected, ownerToken, accountCounter]) =>
+      dispatch(expected, ownerToken, accountCounter),
+    )
     .catch((err: unknown) => log.debug('persist cached messages failed', err));
 }
 
@@ -100,11 +291,17 @@ export function invalidationAtRequestStart(
   if (typeof known === 'number') return known;
   const api = bridge();
   if (!api || !deviceId || !sessionId) return Promise.resolve(undefined);
-  return api
-    .getMessages(deviceId, sessionId)
+  const ownerAtStart = getDataOwnerGeneration();
+  return tokenReadWithin(api.getMessages(deviceId, sessionId))
     .then((result) => {
-      rememberMainInvalidation(sessionId, result?.invalidation);
-      return typeof result?.invalidation === 'number' ? result.invalidation : undefined;
+      // 补读永久挂起时不能让 persistCachedMessages 的 Promise.all 永久堵住:3 秒后以 undefined
+      // 收敛,交给 store fail-closed 丢这次 best-effort 写(review: copilot suppressed)。
+      if (!result || !isDataOwnerGenerationCurrent(ownerAtStart)) return undefined;
+      rememberMainInvalidation(sessionId, result.invalidation);
+      // 刻意**不**在这里 rememberOwnerToken:这个补读 IPC 可能在账号切换后才被 main 处理,
+      // 会把新账号的 token 记进 knownOwnerToken,污染后续写入的 owner 锚点(review: codex P1)。
+      // opaque owner token 只由受保护的 readCachedMessages / readCachedSessionList 写入。
+      return typeof result.invalidation === 'number' ? result.invalidation : undefined;
     })
     .catch(() => undefined);
 }
@@ -141,12 +338,48 @@ export interface CachedDeviceSessionsSnapshot {
   sessions: Session[];
 }
 
+/** 最近一次读会话列表时 main 侧的 opaque owner token(供去抖回写时原样回传,见 scheduleSessionListPersist)。 */
+let knownSessionListOwnerToken: string | undefined;
+
+/** 最近一次读会话列表时 main 侧的账号代际计数(clearAll 自增;区分同账号登出再登录)。 */
+let knownSessionListAccountCounter: number | undefined;
+
+/**
+ * 会话列表的 owner 锚点是否已就位(opaque owner token + 账号代际都拿到了)。
+ *
+ * 账号切换后 `clearMirrorCacheAccountState` 清空它们,由 `readCachedSessionList` 重新填充;
+ * 补读可能因待清队列 / owner 边界复核 / 瞬时 IPC 错误失败。调用方(账号边界 effect)靠这个
+ * 判断是否需要重试补读,避免新账号的排程回写一直带 undefined 被 fail-closed 丢弃
+ * (review: Greptile P1)。
+ */
+export function sessionListOwnerTokensReady(): boolean {
+  return typeof knownSessionListOwnerToken === 'string'
+    && typeof knownSessionListAccountCounter === 'number';
+}
+
 /** 读侧边栏远程会话列表快照;未命中 / 出错一律空数组。 */
 export async function readCachedSessionList(): Promise<CachedDeviceSessionsSnapshot[]> {
   const api = bridge();
   if (!api) return [];
+  const ownerAtStart = getDataOwnerGeneration();
   try {
     const result = await api.getSessionList();
+    // owner 不再是发起时身份(读 IPC 在途期间账号已切换)→ 整份结果作废,与 readCachedMessages
+    // 完全一致:
+    //  1. 不记 token:旧账号的 token / 代际会污染新账号排程回写的锚点(review: Greptile P1);
+    //  2. **不返回 devices**:调用方(冷启动 hydrate)会把这份快照直接种进侧边栏,B 会看到 A
+    //     的设备与会话标题 —— 跨账号数据串读(review: copilot P1)。
+    if (!isDataOwnerGenerationCurrent(ownerAtStart)) return [];
+    if (typeof result?.ownerToken === 'string' && result.ownerToken.length > 0) {
+      knownSessionListOwnerToken = result.ownerToken;
+    }
+    if (
+      typeof result?.accountCounter === 'number'
+      && Number.isInteger(result.accountCounter)
+      && result.accountCounter >= 0
+    ) {
+      knownSessionListAccountCounter = result.accountCounter;
+    }
     if (!Array.isArray(result?.devices)) return [];
     return result.devices.map((device) => ({
       deviceId: device.deviceId,
@@ -172,6 +405,12 @@ export function scheduleSessionListPersist(
   debounceMs: number = SESSION_LIST_PERSIST_DEBOUNCE_MS,
 ): void {
   if (!bridge()) return;
+  // 排程时快照 renderer owner 代际(不是 token 字符串):触发时 owner 已变就整笔丢弃,绝不能
+  // 用新账号令牌提交旧账号排下的 collect。仍是同一代时,触发点读取**最新**已知 token / counter:
+  // 排程与 1.2s debounce 之间的 session-list 补读可能刚把令牌补齐,若把 undefined 冻结在闭包,
+  // 这次非空快照会被 main fail-closed 丢弃,而相同 reconcile 数据不再通知时缓存就持续陈旧
+  // (review: codex P2)。令牌仍只来自受保护 readCachedSessionList,这里不发起异步补读。
+  const ownerAtSchedule = getDataOwnerGeneration();
   pendingCollect = collect;
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = setTimeout(() => {
@@ -179,8 +418,10 @@ export function scheduleSessionListPersist(
     const fn = pendingCollect;
     pendingCollect = null;
     if (!fn) return;
+    // 账号边界已推进:fn 虽然是懒 collect,但排程动作属于旧账号;不能用新账号令牌落盘。
+    if (!isDataOwnerGenerationCurrent(ownerAtSchedule)) return;
     try {
-      writeSessionListNow(fn());
+      writeSessionListNow(fn(), knownSessionListOwnerToken, knownSessionListAccountCounter);
     } catch (err) {
       // collect 本身抛错也静默:最多损失一次快照更新,不能影响侧边栏。
       log.debug('collect session list snapshot failed', err);
@@ -188,7 +429,11 @@ export function scheduleSessionListPersist(
   }, debounceMs);
 }
 
-function writeSessionListNow(devices: readonly CachedDeviceSessionsSnapshot[]): void {
+function writeSessionListNow(
+  devices: readonly CachedDeviceSessionsSnapshot[],
+  expectedOwnerToken?: string,
+  expectedAccountCounter?: number,
+): void {
   const api = bridge();
   if (!api) return;
   void api
@@ -198,6 +443,8 @@ function writeSessionListNow(devices: readonly CachedDeviceSessionsSnapshot[]): 
         deviceName: device.deviceName,
         sessions: device.sessions as unknown as Record<string, unknown>[],
       })),
+      expectedOwnerToken,
+      expectedAccountCounter,
     )
     .catch((err: unknown) => log.debug('persist session list failed', err));
 }
@@ -232,8 +479,34 @@ export function cancelSessionListPersist(): void {
   if (persistTimer) clearTimeout(persistTimer);
   persistTimer = null;
   pendingCollect = null;
+  // 刻意**不**清 opaque owner token / 账号代际:本函数既在账号边界也在 relay-stopped(服务停掉而非
+  // 登出)时被调用。relay-stopped 时清掉 token 会让同一挂载实例重新 online 后 `scheduleSessionListPersist`
+  // 持续带 undefined 写非空快照,被 main fail-closed 丢弃 —— 侧边栏冷缓存直到重挂载都不刷新
+  // (review: codex P2)。owner / 代际的清空只归真正的账号边界 `clearMirrorCacheAccountState()`。
+}
+
+/**
+ * 清空账号边界上的 renderer 侧镜像缓存状态(登出 / 切账号时必须调用)。
+ *
+ * 每条会话的 `knownOwnerToken` 是在某个账号下读缓存时记下的;账号切换后若不清理,B 复用
+ * 同一 sessionId 时会一直带着 A 的 token 提交,被 store 的 fail-closed 持续拒写 —— 新账号
+ * 的缓存从此静默失效(review: #1801)。会话级 `knownMainInvalidation` / `knownAccountCounter`
+ * 同理,留在旧账号的会话上可能让后续写入的计数比对错位。owner / 代际 / 计数的唯一正确来源
+ * 是「当前账号下的受保护缓存读」,切换后让它们重新从读路径获取,而不是继承旧账号的残留。
+ */
+export function clearMirrorCacheAccountState(): void {
+  knownOwnerToken.clear();
+  knownMainInvalidation.clear();
+  knownAccountCounter.clear();
+  knownSessionListOwnerToken = undefined;
+  knownSessionListAccountCounter = undefined;
+  // 在途受保护读也要摘掉:它属于旧账号,完成时会因代际不符不写令牌。留着会让 B 复用同一
+  // sessionId 时的写点去等一笔注定拿不到令牌的读(review: Greptile P1)。`afterProtectedRead`
+  // 的代际复核已是兜底,这里直接摘掉登记,让 B 的写点走「无在途读 → undefined」的快路径。
+  pendingProtectedRead.clear();
 }
 
 export const __testing = {
   writeSessionListNow,
+  clearMirrorCacheAccountState,
 };

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkRemoteProjects.ts
@@ -50,8 +50,10 @@ import { collectSessionListSnapshot, refreshRemoteDeviceSessions } from './refre
 import {
   cancelSessionListPersist,
   clearCachedDevice,
+  clearMirrorCacheAccountState,
   readCachedSessionList,
   scheduleSessionListPersist,
+  sessionListOwnerTokensReady,
 } from './mirrorCacheClient';
 import { prefetchDeviceCapabilities, evictDeviceCapabilities } from '@/hooks/useAgentCapabilities';
 import { prefetchDeviceProviders, evictDeviceProviders } from '@/hooks/useDeviceProviders';
@@ -62,6 +64,49 @@ import {
 import { extractIpcError } from '@/utils/ipcError';
 
 const log = createLogger('device-link-remote-projects');
+
+/** session-list owner 令牌补读退避:不断恢复,但长期故障时不每 2 秒打一次 IPC。 */
+const SESSION_LIST_TOKEN_RETRY_BASE_MS = 2_000;
+const SESSION_LIST_TOKEN_RETRY_MAX_MS = 30_000;
+
+/** 返回下一次列表令牌补读的等待时间;账号边界 effect 重建时从 0 重新开始。 */
+export function nextSessionListTokenRetryDelay(previousMs: number): number {
+  if (!Number.isFinite(previousMs) || previousMs < SESSION_LIST_TOKEN_RETRY_BASE_MS) {
+    return SESSION_LIST_TOKEN_RETRY_BASE_MS;
+  }
+  return Math.min(previousMs * 2, SESSION_LIST_TOKEN_RETRY_MAX_MS);
+}
+
+/**
+ * 启动 session-list owner 令牌补读循环。返回清理函数;账号边界 effect 每次重建都会创建新的
+ * retryDelayMs,因此新账号从 2 秒重新开始,旧账号的 timer 由 cleanup 取消。
+ * 参数只用于确定性单测;生产默认走真实缓存读与 readiness。
+ */
+export function startSessionListTokenRefresh(
+  refresh: () => Promise<unknown> = readCachedSessionList,
+  isReady: () => boolean = sessionListOwnerTokensReady,
+): () => void {
+  let cancelled = false;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let retryDelayMs = 0;
+  const refreshUntilReady = async (): Promise<void> => {
+    if (cancelled) return;
+    await refresh();
+    if (cancelled) return;
+    if (!isReady()) {
+      // 不能设最大次数后永久停掉:此前正是一次补读失败后不恢复,让列表缓存持续停写。
+      // 保留无限恢复能力,只把长期故障下的频率从固定 2s 指数退避到最多 30s
+      // (review: copilot suppressed)。
+      retryDelayMs = nextSessionListTokenRetryDelay(retryDelayMs);
+      timer = setTimeout(refreshUntilReady, retryDelayMs);
+    }
+  };
+  void refreshUntilReady();
+  return () => {
+    cancelled = true;
+    if (timer) clearTimeout(timer);
+  };
+}
 
 /** sessions:created reseed 防抖(被控端短时间多次创建会话 / orca 起多 worker 时合并重拉)。 */
 const RESEED_DEBOUNCE_MS = 300;
@@ -191,13 +236,34 @@ export function resolveIneligibleRemoteProjectAction(input: {
 }
 
 export function useDeviceLinkRemoteProjects(): void {
-  const { isAuthenticated, deviceId: selfDeviceId } = useAuth();
+  const { isAuthenticated, deviceId: selfDeviceId, dataOwnerId } = useAuth();
+
+  // 账号边界真正由 dataOwnerId 界定:登出 / 切账号都必然改变它。**不能只靠 !isAuthenticated** ——
+  // 运行时替换刷新路径可以在不经过 signed-out 的情况下直接把新 owner 发布出来,那时本 effect
+  // 若只依赖 isAuthenticated / deviceId 不会重跑,旧的 owner token 残留会一直传给 store 被
+  // fail-closed 拒写,新账号冷缓存停止更新直到重挂载(review: codex P1)。因此单独挂一个
+  // dataOwnerId 依赖的 effect,owner 一换就清 mirror 状态。
+  // dataOwnerId 是 owner 边界的真源(runtime 替换刷新可跳过 signed-out 直接换 owner)。
+  const ownerBoundaryGeneration = `${dataOwnerId ?? ''}`;
+  useEffect(() => {
+    clearMirrorCacheAccountState();
+    // 清完必须**主动补读 session-list** 直到拿到新账号的 owner 锚点:
+    //  1. 主 effect 只依赖 isAuthenticated / selfDeviceId,A→B 直接切换(两者都不变)时不会
+    //     重跑,而读 session-list 的调用挂在主 effect 里 —— 不补读的话 B 的排程回写会一直
+    //     带 undefined 被 main fail-closed 丢弃(review: Greptile P1);
+    //  2. 补读可能因待清队列 / owner 边界复核 / 瞬时 IPC 错误失败,失败后**重试**直到锚点
+    //     就位 —— 否则订阅仍持续排程 undefined 写入,冷缓存停写到重挂载(本线程)。
+    // 账号在重试期间再次变化时,effect 重跑清掉定时器,旧账号的重试不再继续。
+    if (!dataOwnerId) return;
+    return startSessionListTokenRefresh();
+  }, [ownerBoundaryGeneration]);
 
   useEffect(() => {
     if (!isAuthenticated || !selfDeviceId) {
       // 同 'stopped' / unmount:cancel 在 clear 之后,免得 clear 的同步通知又排一次回写。
       remoteProjectsStore.clear();
       cancelSessionListPersist();
+      // 登出分支:上面的 dataOwnerId effect 已清 mirror 状态,这里补 cancel 去抖回写。
       return;
     }
 

--- a/apps/desktop/src/renderer/lib/makerTransport.ts
+++ b/apps/desktop/src/renderer/lib/makerTransport.ts
@@ -20,7 +20,9 @@ import {
 } from '@/features/device-link/remoteProjectsStore';
 import { isDeviceLinkRemotePushCurrent } from '@/lib/remoteDataOwnerPushFence';
 import {
+  accountCounterAtRequestStart,
   invalidationAtRequestStart,
+  ownerTokenAtRequestStart,
   persistCachedMessages,
   sessionCacheInvalidationToken,
 } from '@/features/device-link/mirrorCacheClient';
@@ -293,6 +295,13 @@ export function listMessagesFor(
     // 还没有已知值时**在这里**(与远端请求同时)补读一次 —— main 拒绝没带令牌的非空写入,
     // 而补读若拖到落盘前做,拿到的是清理之后的值,屏障就失效了(见 invalidationAtRequestStart)。
     const mainInvalidationAtStart = invalidationAtRequestStart(deviceId, sessionId);
+    // opaque owner token 只信任受保护读(readCachedMessages,经 main 原子复核)带回的值:有已知值同步
+    // 返回;有在途受保护读则等它完成(账号切换后首次打开会话时 hydrate 读在并行);都没有才
+    // undefined → 由 store fail-closed 丢弃。绝不单独 getMessages 补读,避免补读 IPC 在账号
+    // 切换后才被 main 处理、把新账号 token 当成本次请求的 owner 锚点(review: codex P1 + Greptile)。
+    const ownerTokenAtStart = ownerTokenAtRequestStart(sessionId);
+    // 账号代际计数同源:同一账号登出再登录时 token 不变,靠它区分登出前后的内容。
+    const accountCounterAtStart = accountCounterAtRequestStart(sessionId);
     void promise
       .then((rows) => {
         if (!Array.isArray(rows)) return;
@@ -306,7 +315,17 @@ export function listMessagesFor(
         if (getSessionDeviceId(sessionId) !== deviceId) return;
         // 把"我取到内容时 main 侧的会话级作废计数"一起交上去:main 会再比对一次,于是
         // **另一个窗口 / 另一个进程**的作废也能挡住这次写(renderer 令牌只在本进程内可见)。
-        persistCachedMessages(deviceId, sessionId, rows, mainInvalidationAtStart);
+        // opaque owner token 同理:它是「这份内容在哪个账号名下取的」的身份标记,账号切换后 main 靠
+        // 它丢弃上一个账号的在途响应(review: #1783)。accountCounter 再补「同账号登出再登录」。
+        // 两者取不到时(补读在途 / 失败)传 undefined,由 main 侧 fail-closed 判断。
+        persistCachedMessages(
+          deviceId,
+          sessionId,
+          rows,
+          mainInvalidationAtStart,
+          ownerTokenAtStart,
+          accountCounterAtStart,
+        );
       })
       // 拉取失败由调用方处理;这里只是不写缓存(旧缓存保留,离线时正好还能用)。
       .catch(() => undefined);

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -3359,12 +3359,19 @@ interface ElectronAPI {
       getMessages: (
         deviceId: string,
         sessionId: string,
-      ) => Promise<{ messages: Record<string, unknown>[]; invalidation?: number }>;
+      ) => Promise<{
+        messages: Record<string, unknown>[];
+        invalidation?: number;
+        ownerToken?: string;
+        accountCounter?: number;
+      }>;
       putMessages: (
         deviceId: string,
         sessionId: string,
         messages: readonly Record<string, unknown>[],
         expectedInvalidation?: number,
+        expectedOwnerToken?: string,
+        expectedAccountCounter?: number,
       ) => Promise<{ ok: true; invalidation?: number }>;
       getSessionList: () => Promise<{
         devices: Array<{
@@ -3372,6 +3379,8 @@ interface ElectronAPI {
           deviceName: string;
           sessions: Record<string, unknown>[];
         }>;
+        ownerToken?: string;
+        accountCounter?: number;
       }>;
       putSessionList: (
         devices: ReadonlyArray<{
@@ -3379,6 +3388,8 @@ interface ElectronAPI {
           deviceName: string;
           sessions: readonly Record<string, unknown>[];
         }>,
+        expectedOwnerToken?: string,
+        expectedAccountCounter?: number,
       ) => Promise<{ ok: true }>;
       /** 清掉一台设备的缓存;deviceId 必填(登出的整体清理由 main 在账号边界自己做) */
       clear: (deviceId: string) => Promise<{ ok: true }>;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复镜像冷缓存跨账号数据泄漏（#1783）：登出并切换账号后，上一个账号的在途远端响应会带着清理前捕获的令牌，把旧账号内容写进新账号的缓存目录，新账号离线冷启动会 hydrate 出旧账号消息。

**根因**：作废令牌只携带**会话级**计数；账号级（`CLEARED_ACCOUNT`）计数按 owner 命名空间隔离（新账号从 0 起），两者都察觉不了「这批内容是在上一个账号名下取的」。唯一可靠的身份标记是 **owner root 路径本身**。

**修复**：`readMessagesWithInvalidation` / `getSessionList` 在返回内容时把当时所属的 **owner root** 一并带回；renderer 原样回传；store 在 `writeMessages` / `writeSessionList` 落盘前比对「取到内容时的 owner root」与当前 root，不符即丢弃这次写。覆盖两条写入路径，并补确定性 owner 切换回归测试。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `test` 测试
- [ ] `docs` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：#1783
- 本 PR 包含：
  - `mirrorCacheStore.ts`：`readMessagesWithInvalidation` 返回 `ownerRoot`；`writeMessages` / `writeSessionList` 接受 `expectedOwnerRoot` 并在提交前校验。
  - `ipc.ts`：get 回带 owner root；put 接收并透传 `expectedOwnerRoot`。
  - `preload.ts` / `vite-env.d.ts`：桥接签名同步。
  - `mirrorCacheClient.ts` / `makerTransport.ts`：在请求发起时捕获 owner root 并随写入回传。
  - 回归测试：store 层 owner 切换、session list owner 切换、renderer 层写入携带 owner root。
- 明确不包含：
  - 不包含 `cindy-protocol` submodule 指针变更（与 #1783 无关）。
  - 不改变空写（删除缓存）分支的现有语义 —— 删除是安全方向，且空写本身不构成数据泄漏。
- 用户可见变化：无。缓存非权威，修复只是不再把旧账号内容写进新账号目录。
- 是否存在 breaking change：无。`expectedOwnerRoot` 为可选参数，旧调用方（不携带 owner root）维持原行为。

### UI 变化

- 引用的设计规范：不涉及：改动全部在 main 进程 / IPC / renderer 逻辑层（`device-link` 缓存），不触碰任何 UI 组件、视觉样式或文案。

## 怎么验证的

### 自动验证

```text
# 定向测试(改动涉及的三个测试文件)
pnpm --filter desktop exec vitest run src/main/device-link/__tests__/mirrorCacheStore.test.ts src/main/device-link/__tests__/mirrorCacheIpc.test.ts src/renderer/__tests__/remoteMirrorCache.test.ts
结果:全部通过(mirrorCacheStore 98、mirrorCacheIpc 34、remoteMirrorCache 40)

# 加相邻 device-link / renderer 测试的扩大验证
pnpm --filter desktop exec vitest run src/main/device-link/ src/renderer/__tests__/remoteMirrorCache.test.ts src/renderer/__tests__/remotePrecreatedWorktree.test.ts
结果:32 files / 612 tests passed

# desktop typecheck
pnpm --filter desktop typecheck
结果:通过

# 全量单测(根 test:unit;本地用缓存 pnpm 10.26.2 + NODE_OPTIONS=--localstorage-file 规避环境问题)
node scripts/test-workspaces.mjs --tier unit
结果:所有 workspace 通过;唯一失败是 1 个无关的 review-plugin beforeEach 10s 钩子超时
      (该文件单独跑 11/11 通过,属全量并行下的环境 flake,与本 PR 无关)

# 静态 guard
pnpm check:endpoints / check:i18n / check:i18n-glossary / brand-terminology-guard
结果:全部通过
```

### 手工验证

- 不涉及（纯逻辑 + 单测覆盖）。

### 未执行的验证

- 未在真实 Electron 多账号环境手工复测。owner 切换时序已有 store 层确定性回归测试覆盖（`mirrorCacheStore.test.ts` 的「跨账号 owner 切换」describe 块）。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据（修复对象即跨账号数据泄漏）
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容（IPC 桥接签名扩展，向后兼容）
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：`device-link` 镜像缓存（`mirrorCacheStore` / IPC / `mirrorCacheClient` / `makerTransport` 的远程消息写点）。
- 回滚 / 降级方式：撤掉本 PR 即可。`expectedOwnerRoot` 是可选参数，旧调用方不传时 store 侧跳过该校验、行为与修复前完全一致；渲染进程内 `knownOwnerRoot` / `knownSessionListOwnerRoot` 无持久状态，降级无残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无作者可见契约变更，不需文档同步）
- [x] 已确认测试结果或说明未执行原因
