### PR TITLE
fix(usage): 修复 DeepSeek BYOK 缓存费用高估

### DIFF
--- a/apps/desktop/src/main/usage/__tests__/turnCostCalculator.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/turnCostCalculator.test.ts
@@ -496,6 +496,40 @@ describe('resolveTurnCost', () => {
     });
   });
 
+  it('recomputes DeepSeek BYOK cost from cache-aware official pricing instead of SDK estimates', () => {
+    const result = resolveTurnCost({
+      rawModel: 'deepseek-v4-pro[1m]',
+      tokens: {
+        inputTokens: 2_000,
+        outputTokens: 500,
+        cacheReadTokens: 118_000,
+        cacheCreateTokens: 0,
+      },
+      // 模拟 SDK 把 12 万输入 token 全按 cache miss 估出的高值。
+      sdkCostDelta: 0.052635,
+      pricing: catalog(
+        quote('deepseek-v4-pro', 0.435, 0.87, {
+          providerId: 'deepseek',
+          cacheReadPerMtok: 0.003625,
+          source: 'provider-reference',
+          approximate: true,
+        }),
+      ),
+      context: { providerId: 'deepseek', billingRoute: 'provider-api', region: 'global' },
+    });
+
+    expect(result).toMatchObject({
+      model: 'deepseek-v4-pro',
+      source: 'reference',
+      money: {
+        currency: 'USD',
+        approximate: true,
+        kind: 'value-estimate',
+      },
+    });
+    expect(result.money?.amount).toBeCloseTo(0.00173275, 10);
+  });
+
   it('uses a provider reference or user override estimate when the SDK reports no cost', () => {
     const result = resolveTurnCost({
       rawModel: 'custom-model',

--- a/apps/desktop/src/main/usage/__tests__/turnCostCalculator.test.ts
+++ b/apps/desktop/src/main/usage/__tests__/turnCostCalculator.test.ts
@@ -530,6 +530,39 @@ describe('resolveTurnCost', () => {
     expect(result.money?.amount).toBeCloseTo(0.00173275, 10);
   });
 
+  it('keeps the DeepSeek SDK cost when token deltas are unavailable', () => {
+    const result = resolveTurnCost({
+      rawModel: 'deepseek-v4-pro',
+      tokens: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreateTokens: 0,
+      },
+      sdkCostDelta: 0.052635,
+      pricing: catalog(
+        quote('deepseek-v4-pro', 0.435, 0.87, {
+          providerId: 'deepseek',
+          cacheReadPerMtok: 0.003625,
+          source: 'provider-reference',
+          approximate: true,
+        }),
+      ),
+      context: { providerId: 'deepseek', billingRoute: 'provider-api', region: 'global' },
+    });
+
+    expect(result).toEqual({
+      model: 'deepseek-v4-pro',
+      source: 'sdk',
+      money: {
+        amount: 0.052635,
+        currency: 'USD',
+        approximate: false,
+        kind: 'actual-cost',
+      },
+    });
+  });
+
   it('uses a provider reference or user override estimate when the SDK reports no cost', () => {
     const result = resolveTurnCost({
       rawModel: 'custom-model',

--- a/apps/desktop/src/main/usage/turnCostCalculator.ts
+++ b/apps/desktop/src/main/usage/turnCostCalculator.ts
@@ -230,7 +230,23 @@ export function resolveTurnCost(args: {
     };
   }
 
-  // 第三方供应商 / 未知路由:SDK 值是 USD 口径,投影到账本币种而不是构建区域,
+  const providerQuote =
+    context.billingRoute === 'provider-api'
+      ? getModelPriceQuote(pricing, context.providerId, model, 'claude-code')
+      : undefined;
+  // DeepSeek 的缓存命中价与未命中价相差数十倍。Claude SDK 的 costUSD 是客户端
+  // 对第三方模型的估值，不是 DeepSeek 账单事实；一旦把缓存 token 按普通输入价算，
+  // 前台金额就会被成倍放大。官方参考价存在时按实际 token/cache 分桶重算，并保留
+  // value-estimate 标记；目录缺价时再退回 SDK，避免新模型完全没有金额。
+  if (context.providerId === 'deepseek' && providerQuote) {
+    return {
+      model,
+      money: computePriceQuoteTurnMoney(tokens, providerQuote, ledgerCurrency),
+      source: 'reference',
+    };
+  }
+
+  // 其它第三方供应商 / 未知路由:SDK 值是 USD 口径,投影到账本币种而不是构建区域,
   // 否则 USD 结算账号上这些花费会变成 CNY 并被账本守卫丢弃。
   const sdkAmount = Math.max(0, sdkCostDelta ?? 0);
   if (sdkAmount > 0) {
@@ -240,10 +256,6 @@ export function resolveTurnCost(args: {
       source: context.billingRoute === 'provider-api' ? 'sdk' : 'sdk-fallback',
     };
   }
-  const providerQuote =
-    context.billingRoute === 'provider-api'
-      ? getModelPriceQuote(pricing, context.providerId, model, 'claude-code')
-      : undefined;
   return {
     model,
     money: providerQuote ? computePriceQuoteTurnMoney(tokens, providerQuote, ledgerCurrency) : null,

--- a/apps/desktop/src/main/usage/turnCostCalculator.ts
+++ b/apps/desktop/src/main/usage/turnCostCalculator.ts
@@ -234,16 +234,25 @@ export function resolveTurnCost(args: {
     context.billingRoute === 'provider-api'
       ? getModelPriceQuote(pricing, context.providerId, model, 'claude-code')
       : undefined;
+  const hasTokenDeltas =
+    tokens.inputTokens > 0 ||
+    tokens.outputTokens > 0 ||
+    tokens.cacheReadTokens > 0 ||
+    tokens.cacheCreateTokens > 0;
   // DeepSeek 的缓存命中价与未命中价相差数十倍。Claude SDK 的 costUSD 是客户端
   // 对第三方模型的估值，不是 DeepSeek 账单事实；一旦把缓存 token 按普通输入价算，
-  // 前台金额就会被成倍放大。官方参考价存在时按实际 token/cache 分桶重算，并保留
-  // value-estimate 标记；目录缺价时再退回 SDK，避免新模型完全没有金额。
-  if (context.providerId === 'deepseek' && providerQuote) {
-    return {
-      model,
-      money: computePriceQuoteTurnMoney(tokens, providerQuote, ledgerCurrency),
-      source: 'reference',
-    };
+  // 前台金额就会被成倍放大。有 token 增量且官方参考价存在时，按实际 token/cache
+  // 分桶重算并保留 value-estimate 标记；只有 cost 增量或目录价格不覆盖本轮时仍退回
+  // SDK，避免把有费用但无 token 明细的轮次误算成 $0。
+  if (context.providerId === 'deepseek' && providerQuote && hasTokenDeltas) {
+    const referenceMoney = computePriceQuoteTurnMoney(tokens, providerQuote, ledgerCurrency);
+    if (referenceMoney) {
+      return {
+        model,
+        money: referenceMoney,
+        source: 'reference',
+      };
+    }
   }
 
   // 其它第三方供应商 / 未知路由:SDK 值是 USD 口径,投影到账本币种而不是构建区域,

--- a/packages/model-providers/catalog/model-registry.json
+++ b/packages/model-providers/catalog/model-registry.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-01T00:00:00.000Z",
+  "updatedAt": "2026-08-05T00:00:00.000Z",
   "models": [
     {
       "id": "openai/gpt-5.6-sol",
@@ -1537,6 +1537,26 @@
           "providerId": "xd",
           "modelId": "deepseek/deepseek-v4-pro",
           "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "deepseek",
+          "modelId": "deepseek-v4-pro",
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.435,
+              "outputPerMtok": 0.87,
+              "cacheReadPerMtok": 0.003625,
+              "effectiveFrom": "2026-07-31",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-08-05"
+              }
+            }
+          ]
         }
       ]
     },
@@ -1555,6 +1575,26 @@
           "providerId": "xd",
           "modelId": "deepseek/deepseek-v4-flash",
           "agents": ["claude-code", "codex"]
+        },
+        {
+          "providerId": "deepseek",
+          "modelId": "deepseek-v4-flash",
+          "agents": ["claude-code", "codex"],
+          "referencePrices": [
+            {
+              "currency": "USD",
+              "variant": "standard",
+              "inputPerMtok": 0.14,
+              "outputPerMtok": 0.28,
+              "cacheReadPerMtok": 0.0028,
+              "effectiveFrom": "2026-07-31",
+              "source": {
+                "kind": "provider-official",
+                "url": "https://api-docs.deepseek.com/quick_start/pricing",
+                "verifiedAt": "2026-08-05"
+              }
+            }
+          ]
         }
       ]
     },

--- a/packages/model-providers/src/__tests__/modelRegistry.test.ts
+++ b/packages/model-providers/src/__tests__/modelRegistry.test.ts
@@ -137,6 +137,32 @@ describe("model registry", () => {
     ).toMatchObject({ inputPerMtok: 3, outputPerMtok: 15 });
   });
 
+  it("resolves DeepSeek BYOK cache-hit pricing for both runtimes", () => {
+    for (const [modelId, expected] of [
+      [
+        "deepseek-v4-pro",
+        { inputPerMtok: 0.435, outputPerMtok: 0.87, cacheReadPerMtok: 0.003625 },
+      ],
+      [
+        "deepseek-v4-flash",
+        { inputPerMtok: 0.14, outputPerMtok: 0.28, cacheReadPerMtok: 0.0028 },
+      ],
+    ] as const) {
+      expect(
+        resolveModelReferencePrice(registry, "deepseek", modelId, {
+          agent: "claude-code",
+          at: "2026-08-05",
+        })?.price,
+      ).toMatchObject(expected);
+      expect(
+        resolveModelReferencePrice(registry, "deepseek", modelId, {
+          agent: "codex",
+          at: "2026-08-05",
+        })?.price,
+      ).toMatchObject(expected);
+    }
+  });
+
   it("normalizes historical Claude aliases before resolving date-effective prices", () => {
     expect(
       resolveModelReferencePrice(registry, "anthropic", "sonnet", {

--- a/packages/model-providers/src/__tests__/source-registry.test.ts
+++ b/packages/model-providers/src/__tests__/source-registry.test.ts
@@ -417,6 +417,7 @@ describe('loadCatalog', () => {
 
   it('keeps a newer cached modelRegistry when a valid remote Catalog is stale', async () => {
     const url = 'https://catalog.example.test/providers.json';
+    const newerUpdatedAt = '2099-08-02T00:00:00.000Z';
     const registry = JSON.parse(JSON.stringify(BUNDLED_CATALOG.modelRegistry));
     const xai = BUNDLED_CATALOG.providers.find((provider) => provider.id === 'xai');
     if (!xai) throw new Error('missing bundled xAI provider');
@@ -436,7 +437,7 @@ describe('loadCatalog', () => {
       providers: [...MINIMAL.providers, { ...xai, name: 'NEWER-LKG-XAI' }],
       modelRegistry: {
         ...registry,
-        updatedAt: '2026-08-02T00:00:00.000Z',
+        updatedAt: newerUpdatedAt,
         models: registry.models.map((entry: { id: string }) => (
           entry.id === 'openai/gpt-5.6-sol' ? { ...entry, name: 'NEWER-LKG' } : entry
         )),
@@ -455,14 +456,14 @@ describe('loadCatalog', () => {
 
     expect(loaded.source).toBe('remote');
     expect(loaded.catalog.providers[0]?.name).toBe(MINIMAL.providers[0]?.name);
-    expect(loaded.catalog.modelRegistry?.updatedAt).toBe('2026-08-02T00:00:00.000Z');
+    expect(loaded.catalog.modelRegistry?.updatedAt).toBe(newerUpdatedAt);
     expect(
       loaded.catalog.modelRegistry?.models.find((entry) => entry.id === 'openai/gpt-5.6-sol')?.name,
     ).toBe('NEWER-LKG');
     expect(loaded.catalog.providers.find((provider) => provider.id === 'xai')?.name)
       .toBe('NEWER-LKG-XAI');
     const persisted = JSON.parse(writeCache.mock.calls[0]![1]);
-    expect(persisted.modelRegistry.updatedAt).toBe('2026-08-02T00:00:00.000Z');
+    expect(persisted.modelRegistry.updatedAt).toBe(newerUpdatedAt);
     expect(persisted.providers.find((provider: Provider) => provider.id === 'xai')?.name)
       .toBe('NEWER-LKG-XAI');
   });
@@ -505,12 +506,13 @@ describe('loadCatalog', () => {
 
   it('adopts the newer snapshot returned by a serialized LKG commit', async () => {
     const url = 'https://catalog.example.test/providers.json';
+    const newerUpdatedAt = '2099-08-01T00:00:00.000Z';
     const registry = JSON.parse(JSON.stringify(BUNDLED_CATALOG.modelRegistry));
     const newer: Catalog = {
       ...MINIMAL,
       modelRegistry: {
         ...registry,
-        updatedAt: '2026-08-01T00:00:00.000Z',
+        updatedAt: newerUpdatedAt,
       },
     };
     const older: Catalog = {
@@ -530,7 +532,7 @@ describe('loadCatalog', () => {
     );
 
     expect(loaded.source).toBe('remote');
-    expect(loaded.catalog.modelRegistry?.updatedAt).toBe('2026-08-01T00:00:00.000Z');
+    expect(loaded.catalog.modelRegistry?.updatedAt).toBe(newerUpdatedAt);
   });
 
   it('reads LKG even when the startup network budget is zero and rejects bad cache', async () => {

--- a/packages/responses-chat-bridge/src/__tests__/chat-sse-translator.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/chat-sse-translator.test.ts
@@ -605,6 +605,57 @@ describe('ChatSseTranslator', () => {
     ]);
   });
 
+  it('maps DeepSeek cache-hit counters into Responses cached tokens', () => {
+    const translator = new ChatSseTranslator('deepseek-v4-pro');
+    const out = [
+      ...translator.push({
+        id: 'deepseek-cache',
+        choices: [{ delta: { content: 'answer' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_tokens: 120_000,
+          prompt_cache_hit_tokens: 118_000,
+          prompt_cache_miss_tokens: 2_000,
+          completion_tokens: 500,
+          total_tokens: 120_500,
+        },
+      }),
+      ...translator.finish(),
+    ] as Array<Record<string, unknown>>;
+
+    const response = (out.at(-1) as { response: { usage: Record<string, unknown> } }).response;
+    expect(response.usage).toEqual({
+      input_tokens: 120_000,
+      output_tokens: 500,
+      total_tokens: 120_500,
+      input_tokens_details: { cached_tokens: 118_000 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    });
+  });
+
+  it('reconstructs DeepSeek total input when only cache hit/miss counters are present', () => {
+    const translator = new ChatSseTranslator('deepseek-v4-flash');
+    const out = [
+      ...translator.push({
+        id: 'deepseek-cache-only',
+        choices: [{ delta: { content: 'answer' }, finish_reason: 'stop' }],
+        usage: {
+          prompt_cache_hit_tokens: 80_000,
+          prompt_cache_miss_tokens: 1_000,
+          completion_tokens: 250,
+        },
+      }),
+      ...translator.finish(),
+    ] as Array<Record<string, unknown>>;
+
+    const response = (out.at(-1) as { response: { usage: Record<string, unknown> } }).response;
+    expect(response.usage).toMatchObject({
+      input_tokens: 81_000,
+      output_tokens: 250,
+      total_tokens: 81_250,
+      input_tokens_details: { cached_tokens: 80_000 },
+    });
+  });
+
   it('preserves the provider service tier in the terminal Responses object', () => {
     const translator = new ChatSseTranslator('m');
     const out = [

--- a/packages/responses-chat-bridge/src/chat-sse-translator.ts
+++ b/packages/responses-chat-bridge/src/chat-sse-translator.ts
@@ -27,6 +27,9 @@ interface UsageShape {
   total_tokens?: number;
   input_tokens?: number;
   output_tokens?: number;
+  /** DeepSeek-compatible cache counters exposed alongside prompt_tokens. */
+  prompt_cache_hit_tokens?: number;
+  prompt_cache_miss_tokens?: number;
   prompt_tokens_details?: { cached_tokens?: number };
   input_tokens_details?: { cached_tokens?: number };
   completion_tokens_details?: { reasoning_tokens?: number };
@@ -737,7 +740,15 @@ export class ChatSseTranslator {
       if (state.done) items.push({ outputIndex: state.outputIndex, item: this.toolItem(state, 'completed') });
     }
     const output = items.sort((a, b) => a.outputIndex - b.outputIndex).map((entry) => entry.item);
-    const inputTokens = numberField(this.usage?.prompt_tokens ?? this.usage?.input_tokens);
+    const cachedTokens = numberField(
+      this.usage?.prompt_tokens_details?.cached_tokens
+        ?? this.usage?.input_tokens_details?.cached_tokens
+        ?? this.usage?.prompt_cache_hit_tokens,
+    );
+    const reportedInputTokens = this.usage?.prompt_tokens ?? this.usage?.input_tokens;
+    const inputTokens = reportedInputTokens === undefined
+      ? numberField(this.usage?.prompt_cache_miss_tokens) + cachedTokens
+      : numberField(reportedInputTokens);
     const outputTokens = numberField(this.usage?.completion_tokens ?? this.usage?.output_tokens);
     const usage = this.usage || this.zeroUsageOnMissing
       ? {
@@ -745,10 +756,7 @@ export class ChatSseTranslator {
           output_tokens: outputTokens,
           total_tokens: numberField(this.usage?.total_tokens) || inputTokens + outputTokens,
           input_tokens_details: {
-            cached_tokens: numberField(
-              this.usage?.prompt_tokens_details?.cached_tokens
-                ?? this.usage?.input_tokens_details?.cached_tokens,
-            ),
+            cached_tokens: cachedTokens,
           },
           output_tokens_details: {
             reasoning_tokens: numberField(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 DeepSeek BYOK 用量金额显著高于 DeepSeek 后台账单的问题。此前 OpenAI Chat bridge 没有把 DeepSeek 返回的缓存命中 token 映射进统一 usage，Desktop 又优先采用 SDK 对第三方模型的费用估值，导致大量缓存命中 token 被按普通输入价格高估。

本次补齐缓存命中/未命中 token 映射，登记 DeepSeek V4 Pro / Flash 的官方参考价格，并在 DeepSeek BYOK 路由下优先按实际 token 与缓存分桶重算费用。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：X 用户反馈 DeepSeek BYOK 前台金额与供应商后台相差数倍
- 本 PR 包含：DeepSeek cache token usage 映射、官方参考价格、缓存感知费用计算及回归测试
- 明确不包含：历史费用回溯重算、其他第三方供应商的费用口径调整
- 用户可见变化：后续 DeepSeek BYOK 回合的金额估算会正确区分缓存命中与普通输入
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及；未修改 UI、交互或文案，仅修正费用数据源与计算口径

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/model-providers run --if-present typecheck
pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果：通过；@cindy/model-providers 未定义 typecheck script，按 --if-present 跳过

NODE_OPTIONS='--experimental-webstorage --localstorage-file=/tmp/cindy-node24-localstorage-humble-darwin-pr' /Users/cindy/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh <worktree>
结果：GATE_EXIT=0，全仓 unit tier 通过；Node 24 下 Desktop 使用仓库已有 forks 兼容路径，规避 threads 池已知 SIGSEGV

pnpm check:dco
结果：通过，1 个 commit 已签署 DCO
```

### 手工验证

不涉及；费用链路通过 usage 映射、价格解析和最终金额计算的回归测试覆盖。

### 未执行的验证

未使用真实 DeepSeek 账号产生账单；自动测试使用与供应商字段一致的 usage fixture 验证计算结果。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：第三方供应商费用估算口径

### 影响与回滚

- 影响范围：仅 `providerId=deepseek` 且能解析到官方参考价格的 BYOK 费用估算；缺少价格的新模型仍回退 SDK 估值
- 回滚 / 降级方式：回滚本 PR 即恢复原有 SDK 估值；参考价格仍标记为 approximate / value-estimate，不会伪装成供应商账单事实

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（价格来源记录在模型目录；无需额外用户文档）
- [x] 已确认测试结果或说明未执行原因
