### PR TITLE
fix(desktop): only refetch the device directory for relevant presence

### DIFF
--- a/apps/desktop/src/renderer/features/device-link/__tests__/presenceRefreshRelevance.test.ts
+++ b/apps/desktop/src/renderer/features/device-link/__tests__/presenceRefreshRelevance.test.ts
@@ -1,0 +1,141 @@
+/**
+ * presenceRefreshRelevance —— presence 触发目录重拉的相关性判据(issue #1726)。
+ *
+ * 背景:relay 把 presence-changed 广播给同账号所有连接**含本机**(刻意保留的僵尸订阅回收
+ * 信号),而本机每开始 / 跑完一轮任务都翻转 busy。修复前 `onPresenceChanged(() => refresh())`
+ * 不做任何过滤,自己的 busy 绕一圈回来就触发一次全量 listDevices。
+ *
+ * 这里只测纯判据函数;订阅接线本身由 useDeviceLinkReconnectEpoch.test.ts 那类用例覆盖。
+ */
+import { describe, it, expect } from 'vitest';
+
+import { shouldRefreshForPresence } from '../useDeviceLinkDeviceList';
+
+function view(over: Partial<DeviceLinkDeviceView> = {}): DeviceLinkDeviceView {
+  return {
+    deviceId: 'peer-1',
+    name: 'Peer Mac',
+    platform: 'darwin',
+    appVersion: '0.1.27',
+    lastSeenAt: null,
+    online: true,
+    busy: false,
+    remoteControlEnabled: true,
+    controlEnabled: true,
+    isSelf: false,
+    ...over,
+  };
+}
+
+function presence(over: Partial<DeviceLinkPresenceSnapshot> = {}): DeviceLinkPresenceSnapshot {
+  return {
+    deviceId: 'peer-1',
+    online: true,
+    deviceName: 'Peer Mac',
+    platform: 'darwin',
+    appVersion: '0.1.27',
+    lastSeenAt: 1_000,
+    remoteControlEnabled: true,
+    busy: false,
+    ...over,
+  };
+}
+
+describe('shouldRefreshForPresence · 必须重拉', () => {
+  it('尚无首份目录(devices === null)', () => {
+    expect(shouldRefreshForPresence(null, presence())).toBe(true);
+  });
+
+  it('presence 指向目录里没有的设备(新机器上线)', () => {
+    expect(shouldRefreshForPresence([view()], presence({ deviceId: 'peer-新' }))).toBe(true);
+  });
+
+  it('对端 online 翻转', () => {
+    expect(shouldRefreshForPresence([view({ online: true })], presence({ online: false }))).toBe(true);
+  });
+
+  it('对端 remoteControlEnabled 翻转(「允许被控」开关)', () => {
+    expect(
+      shouldRefreshForPresence(
+        [view({ remoteControlEnabled: true })],
+        presence({ remoteControlEnabled: false }),
+      ),
+    ).toBe(true);
+  });
+
+  it('对端 platform 由 null 变成具体值 —— 决定移动端过滤,漏了会让手机留在切换栏', () => {
+    expect(shouldRefreshForPresence([view({ platform: null })], presence({ platform: 'ios' }))).toBe(
+      true,
+    );
+  });
+
+  it('对端改名', () => {
+    expect(
+      shouldRefreshForPresence([view({ name: '旧名' })], presence({ deviceName: '新名' })),
+    ).toBe(true);
+  });
+});
+
+describe('shouldRefreshForPresence · 必须跳过', () => {
+  it('本机自 presence:busy 翻转不重拉(issue #1726 的主要浪费来源)', () => {
+    const self = [view({ deviceId: 'self-1', isSelf: true })];
+    expect(shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: true }))).toBe(false);
+    expect(shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: false }))).toBe(false);
+  });
+
+  it('本机自 presence:即便 online / remoteControlEnabled 也变了仍跳过 —— 本机不进切换栏', () => {
+    const self = [view({ deviceId: 'self-1', isSelf: true, online: true, remoteControlEnabled: true })];
+    expect(
+      shouldRefreshForPresence(
+        self,
+        presence({ deviceId: 'self-1', online: false, remoteControlEnabled: false }),
+      ),
+    ).toBe(false);
+  });
+
+  it('对端只有 busy / lastSeenAt / appVersion / deviceInfo 变化(心跳噪音)', () => {
+    expect(
+      shouldRefreshForPresence(
+        [view()],
+        presence({
+          busy: true,
+          lastSeenAt: 999_999,
+          appVersion: '0.1.28',
+          deviceInfo: { note: 'whatever' } as never,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('完全无变化的 presence', () => {
+    expect(shouldRefreshForPresence([view()], presence())).toBe(false);
+  });
+
+  it('名字仅首尾空白差异按未变(与 applyDeviceRename 的 trim 口径一致)', () => {
+    expect(
+      shouldRefreshForPresence([view({ name: 'Peer Mac' })], presence({ deviceName: '  Peer Mac  ' })),
+    ).toBe(false);
+  });
+
+  it('platform 的 null 与空串等价,不算变化', () => {
+    expect(shouldRefreshForPresence([view({ platform: null })], presence({ platform: '' }))).toBe(
+      false,
+    );
+  });
+});
+
+describe('shouldRefreshForPresence · 多设备目录只看命中的那一行', () => {
+  it('对端 A 的心跳不因对端 B 的状态差异而误判为需要重拉', () => {
+    const list = [
+      view({ deviceId: 'peer-a', name: 'A', online: true }),
+      view({ deviceId: 'peer-b', name: 'B', online: false }),
+    ];
+    expect(shouldRefreshForPresence(list, presence({ deviceId: 'peer-a', deviceName: 'A', busy: true }))).toBe(
+      false,
+    );
+    // B 自己上线 → 命中 B 那一行,online 有差异,重拉。
+    expect(
+      shouldRefreshForPresence(list, presence({ deviceId: 'peer-b', deviceName: 'B', online: true })),
+    ).toBe(true);
+  });
+});

--- a/apps/desktop/src/renderer/features/device-link/__tests__/presenceRefreshRelevance.test.ts
+++ b/apps/desktop/src/renderer/features/device-link/__tests__/presenceRefreshRelevance.test.ts
@@ -43,15 +43,15 @@ function presence(over: Partial<DeviceLinkPresenceSnapshot> = {}): DeviceLinkPre
 
 describe('shouldRefreshForPresence · 必须重拉', () => {
   it('尚无首份目录(devices === null)', () => {
-    expect(shouldRefreshForPresence(null, presence())).toBe(true);
+    expect(shouldRefreshForPresence(null, presence(), 'ready')).toBe(true);
   });
 
   it('presence 指向目录里没有的设备(新机器上线)', () => {
-    expect(shouldRefreshForPresence([view()], presence({ deviceId: 'peer-新' }))).toBe(true);
+    expect(shouldRefreshForPresence([view()], presence({ deviceId: 'peer-新' }), 'ready')).toBe(true);
   });
 
   it('对端 online 翻转', () => {
-    expect(shouldRefreshForPresence([view({ online: true })], presence({ online: false }))).toBe(true);
+    expect(shouldRefreshForPresence([view({ online: true })], presence({ online: false }), 'ready')).toBe(true);
   });
 
   it('对端 remoteControlEnabled 翻转(「允许被控」开关)', () => {
@@ -59,19 +59,20 @@ describe('shouldRefreshForPresence · 必须重拉', () => {
       shouldRefreshForPresence(
         [view({ remoteControlEnabled: true })],
         presence({ remoteControlEnabled: false }),
+        'ready',
       ),
     ).toBe(true);
   });
 
   it('对端 platform 由 null 变成具体值 —— 决定移动端过滤,漏了会让手机留在切换栏', () => {
-    expect(shouldRefreshForPresence([view({ platform: null })], presence({ platform: 'ios' }))).toBe(
+    expect(shouldRefreshForPresence([view({ platform: null })], presence({ platform: 'ios' }), 'ready')).toBe(
       true,
     );
   });
 
   it('对端改名', () => {
     expect(
-      shouldRefreshForPresence([view({ name: '旧名' })], presence({ deviceName: '新名' })),
+      shouldRefreshForPresence([view({ name: '旧名' })], presence({ deviceName: '新名' }), 'ready'),
     ).toBe(true);
   });
 });
@@ -79,8 +80,8 @@ describe('shouldRefreshForPresence · 必须重拉', () => {
 describe('shouldRefreshForPresence · 必须跳过', () => {
   it('本机自 presence:busy 翻转不重拉(issue #1726 的主要浪费来源)', () => {
     const self = [view({ deviceId: 'self-1', isSelf: true })];
-    expect(shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: true }))).toBe(false);
-    expect(shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: false }))).toBe(false);
+    expect(shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: true }), 'ready')).toBe(false);
+    expect(shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: false }), 'ready')).toBe(false);
   });
 
   it('本机自 presence:即便 online / remoteControlEnabled 也变了仍跳过 —— 本机不进切换栏', () => {
@@ -89,6 +90,7 @@ describe('shouldRefreshForPresence · 必须跳过', () => {
       shouldRefreshForPresence(
         self,
         presence({ deviceId: 'self-1', online: false, remoteControlEnabled: false }),
+        'ready',
       ),
     ).toBe(false);
   });
@@ -103,22 +105,27 @@ describe('shouldRefreshForPresence · 必须跳过', () => {
           appVersion: '0.1.28',
           deviceInfo: { note: 'whatever' } as never,
         }),
+        'ready',
       ),
     ).toBe(false);
   });
 
   it('完全无变化的 presence', () => {
-    expect(shouldRefreshForPresence([view()], presence())).toBe(false);
+    expect(shouldRefreshForPresence([view()], presence(), 'ready')).toBe(false);
   });
 
   it('名字仅首尾空白差异按未变(与 applyDeviceRename 的 trim 口径一致)', () => {
     expect(
-      shouldRefreshForPresence([view({ name: 'Peer Mac' })], presence({ deviceName: '  Peer Mac  ' })),
+      shouldRefreshForPresence(
+        [view({ name: 'Peer Mac' })],
+        presence({ deviceName: '  Peer Mac  ' }),
+        'ready',
+      ),
     ).toBe(false);
   });
 
   it('platform 的 null 与空串等价,不算变化', () => {
-    expect(shouldRefreshForPresence([view({ platform: null })], presence({ platform: '' }))).toBe(
+    expect(shouldRefreshForPresence([view({ platform: null })], presence({ platform: '' }), 'ready')).toBe(
       false,
     );
   });
@@ -130,12 +137,44 @@ describe('shouldRefreshForPresence · 多设备目录只看命中的那一行', 
       view({ deviceId: 'peer-a', name: 'A', online: true }),
       view({ deviceId: 'peer-b', name: 'B', online: false }),
     ];
-    expect(shouldRefreshForPresence(list, presence({ deviceId: 'peer-a', deviceName: 'A', busy: true }))).toBe(
+    expect(shouldRefreshForPresence(list, presence({ deviceId: 'peer-a', deviceName: 'A', busy: true }), 'ready')).toBe(
       false,
     );
     // B 自己上线 → 命中 B 那一行,online 有差异,重拉。
     expect(
-      shouldRefreshForPresence(list, presence({ deviceId: 'peer-b', deviceName: 'B', online: true })),
+      shouldRefreshForPresence(
+        list,
+        presence({ deviceId: 'peer-b', deviceName: 'B', online: true }),
+        'ready',
+      ),
     ).toBe(true);
+  });
+});
+
+/**
+ * 上一次 listDevices 失败(此前已有快照 → devices 非空、requestState 停在 'error')。
+ * push 驱动 + 无轮询兜底,若此时仍按「字段没变」滤掉 presence,侧栏会被钉在错误/陈旧目录上
+ * 直到 status / control-target 事件或手动重试(review: codex P1 on PR #1799)。
+ */
+describe('shouldRefreshForPresence · 上一次请求失败时一律放行', () => {
+  it("requestStatus='error':本机 busy 自回声也当作重试机会", () => {
+    const self = [view({ deviceId: 'self-1', isSelf: true })];
+    expect(shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: true }), 'error')).toBe(
+      true,
+    );
+  });
+
+  it("requestStatus='error':对端纯心跳(无相关字段变化)也放行", () => {
+    expect(shouldRefreshForPresence([view()], presence({ lastSeenAt: 999_999 }), 'error')).toBe(true);
+  });
+
+  it("requestStatus='loading':不叠加请求 —— 已有一笔在飞,失败后会落到 error 再由下条 presence 接管", () => {
+    const self = [view({ deviceId: 'self-1', isSelf: true })];
+    expect(
+      shouldRefreshForPresence(self, presence({ deviceId: 'self-1', busy: true }), 'loading'),
+    ).toBe(false);
+    expect(shouldRefreshForPresence([view()], presence({ lastSeenAt: 999_999 }), 'loading')).toBe(
+      false,
+    );
   });
 });

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
@@ -95,6 +95,48 @@ function relevantEqual(a: DeviceLinkDeviceView[] | null, b: DeviceLinkDeviceView
   return true;
 }
 
+/** platform 在目录里可为 null、在 presence 里是字符串;比较前归一化,空值等价。 */
+function normalizePlatform(value: string | null | undefined): string {
+  return (value ?? '').trim();
+}
+
+/**
+ * 这条 presence 是否可能改变切换栏关心的字段 —— 不可能就别重拉整份目录(纯函数,可单测)。
+ *
+ * relay 把 presence-changed 广播给同账号所有连接、**含本机**(dispatch.ts 写明这是控制端崩溃 /
+ * 拔网后回收僵尸订阅的兜底信号,刻意保留)。而本机每开始 / 跑完一轮任务都会翻转 busy 并上报,
+ * 于是自己的 busy 绕一圈回来就触发一次全量 listDevices —— 开跑一次、跑完一次,纯浪费(issue #1726)。
+ *
+ * 判据与 `relevantEqual` 同源:只有切换栏真正消费的字段变化才值得重拉。`busy` / `lastSeenAt` /
+ * `appVersion` / `deviceInfo` 虽然在 `DeviceLinkDeviceView` 里,但 `relevantEqual` 刻意不比较
+ * 它们(「忽略 busy / lastSeenAt 等高频字段,避免无谓重渲染」)—— 既然它们变了也不会让快照替换,
+ * 为它们重拉一整份目录就纯是浪费。
+ *
+ * 刻意**不**比较 `controlEnabled`:它由本地 opt-out 决定、不在 presence 里,其改动走
+ * `control-target-changed` 事件的既有刷新路径。
+ *
+ * `isSelf` 直接跳过是安全的:`switcherDevices.ts` 明确「本机(isSelf)排除」,本机行的
+ * online / remoteControlEnabled 不参与列表内容。
+ */
+export function shouldRefreshForPresence(
+  current: readonly DeviceLinkDeviceView[] | null,
+  snap: DeviceLinkPresenceSnapshot,
+): boolean {
+  // 还没有首份目录 → 照常拉(这条 presence 可能正是「终于连上了」的信号)。
+  if (current === null) return true;
+  const row = current.find((d) => d.deviceId === snap.deviceId);
+  // 目录里没有这台设备 → 它是新出现的,必须重拉才能进列表。
+  if (row === undefined) return true;
+  // 自 presence 自回声:本机不进切换栏,重拉不会改变任何可见内容。
+  if (row.isSelf) return false;
+  return (
+    row.online !== snap.online ||
+    row.remoteControlEnabled !== snap.remoteControlEnabled ||
+    normalizePlatform(row.platform) !== normalizePlatform(snap.platform) ||
+    row.name.trim() !== snap.deviceName.trim()
+  );
+}
+
 /**
  * 就地改名(纯函数,可单测):返回把 `deviceId` 的 name 改成 `name`(trim 后)的新数组;
  * 无需改动(空名 / null 列表 / 设备不在列表 / 名字未变)时**返回原引用**,调用方可用 `===` 判定 no-op。
@@ -238,7 +280,12 @@ function ensureStarted(): void {
   };
   refreshImpl = () => refresh(true);
   // app 生命周期常驻(侧边栏始终有订阅者),不解绑监听。
-  window.electronAPI.deviceLink.onPresenceChanged(() => refresh());
+  // 只有相关 presence 才重拉目录(见 shouldRefreshForPresence):本机 busy 自回声与对端的
+  // busy / lastSeenAt 心跳都不改变切换栏内容,却各触发一次全量 listDevices(issue #1726)。
+  window.electronAPI.deviceLink.onPresenceChanged((snap) => {
+    if (!shouldRefreshForPresence(devices, snap)) return;
+    refresh();
+  });
   window.electronAPI.deviceLink.onStatusChanged((p) => {
     linkStatusRevision += 1;
     linkStatus = p.status;

--- a/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
+++ b/apps/desktop/src/renderer/features/device-link/useDeviceLinkDeviceList.ts
@@ -121,7 +121,16 @@ function normalizePlatform(value: string | null | undefined): string {
 export function shouldRefreshForPresence(
   current: readonly DeviceLinkDeviceView[] | null,
   snap: DeviceLinkPresenceSnapshot,
+  requestStatus: DeviceLinkDeviceListStatus,
 ): boolean {
+  // 上一次拉取失败(且此前已有快照 → `devices` 仍非空、状态停在 'error')时**一律放行**:
+  // 这条链路 push 驱动、没有轮询兜底,若此时还按「字段没变」把 presence 滤掉,一次瞬时 REST
+  // 失败就会把侧栏钉在错误 / 陈旧目录上,直到 status / control-target 事件或用户手动重试
+  // (review: codex P1)。presence 是这段时间里唯一稳定到达的信号,必须当成重试机会。
+  //
+  // 'loading' 不放行:那说明已有一笔在飞,`loadGeneration` 会让后到的结果胜出,再叠一次
+  // refresh 只是徒增请求;它若失败会落到 'error',下一条 presence 自然接管重试。
+  if (requestStatus === 'error') return true;
   // 还没有首份目录 → 照常拉(这条 presence 可能正是「终于连上了」的信号)。
   if (current === null) return true;
   const row = current.find((d) => d.deviceId === snap.deviceId);
@@ -283,7 +292,7 @@ function ensureStarted(): void {
   // 只有相关 presence 才重拉目录(见 shouldRefreshForPresence):本机 busy 自回声与对端的
   // busy / lastSeenAt 心跳都不改变切换栏内容,却各触发一次全量 listDevices(issue #1726)。
   window.electronAPI.deviceLink.onPresenceChanged((snap) => {
-    if (!shouldRefreshForPresence(devices, snap)) return;
+    if (!shouldRefreshForPresence(devices, snap, requestState.status)) return;
     refresh();
   });
   window.electronAPI.deviceLink.onStatusChanged((p) => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

`onPresenceChanged(() => refresh())` 没有任何过滤，每条 presence 帧都触发一次全量 `listDevices()` REST 重拉。relay 把 presence-changed 广播给同账号所有连接、**含本机**（`dispatch.ts` 写明这是控制端崩溃/拔网后回收僵尸订阅的兜底信号，刻意保留），而本机每开始/跑完一轮任务都会翻转 `busy` —— 于是自己的 busy 绕一圈回来，一轮任务重拉两次整份目录。

`relevantEqual` 其实已经写下了正确判据（「忽略 busy / lastSeenAt 等高频字段，避免无谓重渲染」）。本 PR 把同一判据往前挪一步：从「要不要重渲染」延伸到「要不要重拉」。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue：Fixes #1726
- 本 PR 包含（2 文件，+189/−1）：
  - `useDeviceLinkDeviceList.ts`：新增纯函数 `shouldRefreshForPresence()`（与旁边的 `applyDeviceRename` 同款可单测形态），并接到 presence 订阅上。
  - 新增 `__tests__/presenceRefreshRelevance.test.ts`：13 个用例。
- 判据（按 issue 下的分析逐条实现）：
  - 尚无目录，或 presence 指向目录里没有的设备 → 重拉；
  - `isSelf` 行 → 跳过。安全性依据：`switcherDevices.ts` 明确「本机(isSelf)排除」并在建列表前就丢弃本机，所以本机行的可变字段不参与列表内容；
  - 其余情况只在 `online`、`remoteControlEnabled`、归一化 `platform`、trim 后展示名有差异时重拉。
- 明确不包含：
  - **不比较 `controlEnabled`** —— 它来自本地 opt-out、不在 presence payload 里，改动已有 `control-target-changed` 的独立刷新路径；
  - 不引入轮询、不改协议；`status` online/connecting、`stopped`、改名、手动重试全部保持原行为；
  - 未加「按触发原因聚合的 refetch 计数」遥测（issue 里作为可选项提出），以免把范围扩到所报缺陷之外。
- 用户可见变化：无（去掉的是后台冗余请求；#1713 已经把可见横幅撤掉了）
- 是否存在 breaking change：无

### 故障半径（`remote-and-mobile-adaptation.md`「恢复动作先回答故障半径」）

1. **触发条件是哪一层的故障？** 都不是。这里没有故障，是稳态下的冗余读请求。
2. **恢复动作作用在哪一层？** 本 PR 不含任何恢复动作 —— 它是 renderer 读路径的相关性过滤，不碰重试、超时、teardown、重连，因此不可能放大故障半径。它携带的风险恰恰是反方向的：**误抑制一次本该发生的重拉**。所以判据把切换栏消费的每个字段都逐一比较，任何未知情况（无目录、设备不在目录里）一律 fall through 去重拉。
3. **多 peer 拓扑下测过吗？** 有一个多设备目录用例：对端 A 的心跳不因对端 B 的状态差异而误判，且 B 自己上线时命中 B 那一行并重拉。但**双机实测我做不到**（只有一台机器），见「未执行的验证」。

### UI 变化

不涉及。改动只作用于「presence 事件要不要触发一次 `listDevices()` 重拉」这一个判断，不改目录内容的计算、排序与渲染，也不新增/修改任何组件、样式或文案。

- 引用的设计规范：不涉及：纯数据层相关性过滤，无视觉、交互与文案变化，只减少后台冗余 REST 请求

## 怎么验证的

### 自动验证

```text
npx vitest run src/renderer/features/device-link/
结果：Test Files 2 passed (2) / Tests 15 passed (15)
      —— 13 个新增 + 2 个既有 reconnect-epoch 用例

pnpm test:unit
结果：56 workspaces PASS，0 FAIL（exit 0）

pnpm --filter desktop run --if-present typecheck
结果：exit 0
```

**回归证明**：把判据强行改成 `return true`（等价于修复前的无过滤接线）后重跑，恰好 7 条「必须跳过」全红、6 条「必须重拉」全绿：

```text
× 本机自 presence:busy 翻转不重拉(issue #1726 的主要浪费来源)
× 本机自 presence:即便 online / remoteControlEnabled 也变了仍跳过 —— 本机不进切换栏
× 对端只有 busy / lastSeenAt / appVersion / deviceInfo 变化(心跳噪音)
× 完全无变化的 presence
× 名字仅首尾空白差异按未变
× platform 的 null 与空串等价,不算变化
× 对端 A 的心跳不因对端 B 的状态差异而误判为需要重拉
Tests  7 failed | 6 passed (13)
```

### 手工验证

不涉及（无 UI 变化）。

### 未执行的验证

- **issue 里建议的双设备手工验证未做**：连续 10 轮任务确认不再产生目录 REST；对端上下线、开启/关闭「允许被控」、本机关闭目标控制、设备改名、relay 重连仍及时更新切换栏；控制端异常退出后被控端僵尸订阅仍由 offline presence 回收。原因是我只有一台机器。上面 13 个用例把这些字段变化逐条编码成了单测，但不能替代真实硬件上的端到端接线验证。
- 未加 refetch 触发原因的遥测计数，因此本 PR 不提供「发布前后请求量下降」的实测数字。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 renderer 侧「presence 是否触发目录重拉」这一个判断。不改 main 进程、协议、device-link 恢复逻辑，也不改目录内容本身的计算与渲染。
- 最坏情况：判据若漏了某个切换栏实际消费的字段，会表现为该字段变化后切换栏延迟更新（直到下一次 status/control-target/手动重试触发刷新）。为此判据与 `relevantEqual` 的字段集保持同源。
- 回滚 / 降级方式：revert 本 PR 即回到无过滤的 `onPresenceChanged(() => refresh())`，无持久化状态或数据变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
