### PR TITLE
fix(desktop): 已安装插件区按未读通知优先排序，去掉冻结快照的会话内过时

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
@@ -210,10 +210,12 @@ describe('ChatInput session switch focus contract', () => {
     expect(pluginPageSource).toContain(
       'window.electronAPI.ghosts.onRecentUsageChanged(({ ids }) => {',
     );
-    expect(pluginPageSource).toMatch(
-      /sortGhostPluginItemsByRecentUse\(installedItems, recentGhostIds\)/,
-    );
-    expect(pluginPageSource).not.toContain('sortGhostPluginItemsByRecentUse(\n        ghosts');
+    // Ranking runs over the (searched) installed set, not the raw ghost list, and feeds
+    // recent-use + unread signals into the shared pure sorter.
+    expect(pluginPageSource).toMatch(/sortInstalledForDisplay\(searchedInstalledItems, \{/);
+    expect(pluginPageSource).toContain('recentIds: recentGhostIds');
+    expect(pluginPageSource).not.toContain('sortInstalledForDisplay(ghosts');
+    expect(pluginPageSource).not.toContain('sortInstalledForDisplay(installedItems');
   });
 });
 

--- a/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
@@ -14,6 +14,7 @@ import {
   marketPresentationForInstalledGhost,
   nextOpenPanelIdForOwner,
   sortGhostPluginItemsByRecentUse,
+  sortInstalledForDisplay,
   toGhostPluginDetail,
   toGhostPluginListItem,
   type GhostPluginListItem,
@@ -138,6 +139,53 @@ describe('ghostPluginViewModel', () => {
     expect(
       sortGhostPluginItemsByRecentUse(items, ['third', 'missing', 'first']).map((item) => item.id),
     ).toEqual(['third', 'first', 'second', 'fourth']);
+  });
+
+  describe('sortInstalledForDisplay', () => {
+    const items = [{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }];
+
+    it('surfaces unread notifications first, newest badge on top', () => {
+      expect(
+        sortInstalledForDisplay(items, {
+          recentIds: [],
+          unreadAtById: new Map([
+            ['c', 100],
+            ['a', 300],
+          ]),
+        }).map((item) => item.id),
+      ).toEqual(['a', 'c', 'b', 'd']);
+    });
+
+    it('ranks unread above recently-used, then recent, then base order', () => {
+      // b is unread (top); d & a are recently used (d newest); c falls to base tail.
+      expect(
+        sortInstalledForDisplay(items, {
+          recentIds: ['d', 'a'],
+          unreadAtById: new Map([['b', 5]]),
+        }).map((item) => item.id),
+      ).toEqual(['b', 'd', 'a', 'c']);
+    });
+
+    it('keeps base order stable when no signal applies and ignores marketUpdate entirely', () => {
+      // No unread / no recent → untouched. marketUpdate is not an input, so it cannot reorder.
+      expect(
+        sortInstalledForDisplay(items, { recentIds: [], unreadAtById: new Map() }).map(
+          (item) => item.id,
+        ),
+      ).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('breaks unread ties on the same badge time by stable base order', () => {
+      expect(
+        sortInstalledForDisplay(items, {
+          recentIds: [],
+          unreadAtById: new Map([
+            ['d', 7],
+            ['b', 7],
+          ]),
+        }).map((item) => item.id),
+      ).toEqual(['b', 'd', 'a', 'c']);
+    });
   });
 
   it('maps install-record facts onto the list item', () => {

--- a/apps/desktop/src/renderer/cindy-brain/ghostUnreadStore.ts
+++ b/apps/desktop/src/renderer/cindy-brain/ghostUnreadStore.ts
@@ -21,6 +21,9 @@ interface UnreadEntry {
 const unread = new Map<string, UnreadEntry>();
 const listeners = new Set<() => void>();
 let ready = false;
+// Bumped on every mutation so the sorted entries snapshot can be cached by identity
+// (useSyncExternalStore requires getSnapshot to return a stable ref when nothing changed).
+let version = 0;
 
 interface UnreadSnapshotEntry {
   ghostId: string;
@@ -42,6 +45,7 @@ function api(): GhostUnreadApi | undefined {
 }
 
 function emit(): void {
+  version += 1;
   for (const cb of [...listeners]) cb();
 }
 
@@ -146,6 +150,43 @@ export function useGhostUnreadSummary(ghostId: string): string | undefined {
       return unread.get(ghostId)?.summary;
     },
     () => undefined,
+  );
+}
+
+/** 某意识当前未读通知的点亮时刻(用于排序),没有未读时 undefined。 */
+export interface GhostUnreadOrderEntry {
+  ghostId: string;
+  at: number;
+}
+
+const EMPTY_UNREAD_ENTRIES: readonly GhostUnreadOrderEntry[] = [];
+let cachedEntries: { version: number; value: readonly GhostUnreadOrderEntry[] } | null = null;
+
+/**
+ * 全部未读条目的快照,按点亮时刻 `at` 从新到旧排序。
+ * 按 version 缓存:表没变就返回同一引用,满足 useSyncExternalStore 的稳定性要求;
+ * 插件页用它把「有未读通知」的插件排到已安装区最前(见 sortInstalledForDisplay)。
+ */
+function unreadEntriesSnapshot(): readonly GhostUnreadOrderEntry[] {
+  if (unread.size === 0) return EMPTY_UNREAD_ENTRIES;
+  if (!cachedEntries || cachedEntries.version !== version) {
+    const value = [...unread.entries()]
+      .map(([ghostId, entry]) => ({ ghostId, at: entry.at }))
+      .sort((a, b) => b.at - a.at);
+    cachedEntries = { version, value };
+  }
+  return cachedEntries.value;
+}
+
+/** 全部未读条目(id + 点亮时刻),新→旧;用于已安装区排序。 */
+export function useGhostUnreadEntries(): readonly GhostUnreadOrderEntry[] {
+  return useSyncExternalStore(
+    subscribe,
+    () => {
+      ensureReady();
+      return unreadEntriesSnapshot();
+    },
+    () => EMPTY_UNREAD_ENTRIES,
   );
 }
 
@@ -280,5 +321,6 @@ export function __ingestGhostBadgeForTest(
 export function __resetGhostUnreadForTest(): void {
   unread.clear();
   listeners.clear();
+  version += 1;
   ready = false;
 }

--- a/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
+++ b/apps/desktop/src/renderer/features/plugin/GhostPluginPage.tsx
@@ -57,7 +57,11 @@ import { confirmAndInstallGhost, pickAndUpdateGhost } from '@/cindy-brain/instal
 import { GhostPermissionList, GhostUpdateReview } from '@/cindy-brain/GhostPermissionList';
 import { cn } from '@/lib/utils';
 import { AttentionDot } from '@/components/sidebar/AttentionDot';
-import { useGhostUnread, useGhostUnreadSummary } from '@/cindy-brain/ghostUnreadStore';
+import {
+  useGhostUnread,
+  useGhostUnreadEntries,
+  useGhostUnreadSummary,
+} from '@/cindy-brain/ghostUnreadStore';
 import { getLastWorkingDir, subscribeToLastWorkingDir } from '@/state/lastWorkingDir';
 import { findSplitChildByPanelKind } from '../../../shared/layoutTree';
 import { resolveSystemLocale } from '../../../shared/locale';
@@ -85,7 +89,7 @@ import {
   ghostPrimaryAction,
   marketPresentationForInstalledGhost,
   nextOpenPanelIdForOwner,
-  sortGhostPluginItemsByRecentUse,
+  sortInstalledForDisplay,
   type GhostPluginListItem,
 } from './lib/ghostPluginViewModel';
 import { ignoredRoundStorageKey, isBatchFinished, updateRoundKey } from './lib/updateAllModel';
@@ -477,53 +481,25 @@ export function GhostPluginPage() {
     return counts;
   }, [searchedAvailableMarketItems]);
 
-  // ── 排序快照:进页(市场快照首次就绪)时排一次,页内交互不重排 ──
-  // 可更新的排最前,其余按最近使用;停留期间清未读/装更新都不许让卡片跳位。
-  const [orderSnapshot, setOrderSnapshot] = useState<string[] | null>(null);
-  // 换账号/模式要丢弃旧顺序:两个 owner 的已装集合、可更新集合与最近使用
-  // 都不同,沿用账号 A 的 id 顺序会把 B 的非更新项排到更新项前面,违背
-  // 「可更新优先」。清空后由下面的 effect 基于**新 owner 的首个市场快照**重排。
-  const orderOwnerKeyRef = useRef(panelOwnerKey);
-  useEffect(() => {
-    if (orderOwnerKeyRef.current === panelOwnerKey) return;
-    orderOwnerKeyRef.current = panelOwnerKey;
-    setOrderSnapshot(null);
-  }, [panelOwnerKey]);
-  useEffect(() => {
-    if (orderSnapshot !== null) return;
-    if (marketSnapshot === null) return;
-    const updatable = new Set(
-      installedItems.filter((item) => item.marketUpdate !== null).map((item) => item.id),
-    );
-    const byRecentUse = sortGhostPluginItemsByRecentUse(installedItems, recentGhostIds);
-    const ids = byRecentUse
-      .map((item, stableIndex) => ({ item, stableIndex }))
-      .sort((a, b) => {
-        const aUp = updatable.has(a.item.id) ? 0 : 1;
-        const bUp = updatable.has(b.item.id) ? 0 : 1;
-        if (aUp !== bUp) return aUp - bUp;
-        return a.stableIndex - b.stableIndex;
-      })
-      .map(({ item }) => item.id);
-    setOrderSnapshot(ids);
-  }, [orderSnapshot, marketSnapshot, installedItems, recentGhostIds]);
-  const displayInstalledItems = useMemo(() => {
-    if (orderSnapshot === null) return searchedInstalledItems;
-    const orderIndex = new Map(orderSnapshot.map((id, index) => [id, index]));
-    return searchedInstalledItems
-      .map((item, stableIndex) => ({ item, stableIndex }))
-      .sort((a, b) => {
-        const aIndex = orderIndex.get(a.item.id);
-        const bIndex = orderIndex.get(b.item.id);
-        if (aIndex !== undefined && bIndex !== undefined && aIndex !== bIndex) {
-          return aIndex - bIndex;
-        }
-        if (aIndex !== undefined && bIndex === undefined) return -1;
-        if (aIndex === undefined && bIndex !== undefined) return 1;
-        return a.stableIndex - b.stableIndex;
-      })
-      .map(({ item }) => item);
-  }, [orderSnapshot, searchedInstalledItems]);
+  // ── 已安装区排序:未读通知(新→旧) → 最近使用 → 基础序,实时计算 ──
+  // 反应式而非冻结快照:排序信号变化即重排。安全边界——`markUsed` 只在对话里
+  // 触发(ChatInput),插件页自身不打点,所以「最近使用」的变化只发生在离开本页
+  // 之后,回到页面即已重排,不会在用户眼皮下洗牌;后台到达的未读通知冒头则正是
+  // 目的所在。切账号/模式时 recentGhostIds 与未读表都会随 owner 快照整体作废,
+  // 无需本地再存一份顺序。marketUpdate 刻意不作排序键——更新已有统一横幅兜底。
+  const unreadEntries = useGhostUnreadEntries();
+  const unreadAtById = useMemo(
+    () => new Map(unreadEntries.map((entry) => [entry.ghostId, entry.at])),
+    [unreadEntries],
+  );
+  const displayInstalledItems = useMemo(
+    () =>
+      sortInstalledForDisplay(searchedInstalledItems, {
+        recentIds: recentGhostIds,
+        unreadAtById,
+      }),
+    [searchedInstalledItems, recentGhostIds, unreadAtById],
+  );
 
   // ── 更新横幅与批量更新(设计定稿:全部更新;扩权单独确认,绝不静默放行)──
   const updatableInstalledItems = useMemo(

--- a/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
@@ -173,6 +173,46 @@ export function sortGhostPluginItemsByRecentUse<T extends Pick<GhostPluginListIt
 }
 
 /**
+ * Ranks the installed shortcut row for display. Three lexicographic tiers:
+ *   1. Plugins with an unread notification (notify.badge) first, newest badge (larger `at`) on top.
+ *      A pushed notification has no other entry point, so surfacing it is the whole point.
+ *   2. Then recently used (host-recorded MRU), newest first.
+ *   3. Then base install order, stably.
+ * `marketUpdate` is deliberately NOT a key: the updates banner already surfaces updatable plugins,
+ * so letting them jump the row would only bury the unread signal.
+ * Pure and reactive — recompute freely from current signals; there is no frozen snapshot to go stale.
+ */
+export function sortInstalledForDisplay<T extends Pick<GhostPluginListItem, 'id'>>(
+  items: readonly T[],
+  {
+    recentIds,
+    unreadAtById,
+  }: { recentIds: readonly string[]; unreadAtById: ReadonlyMap<string, number> },
+): T[] {
+  const recentIndex = new Map(recentIds.map((id, index) => [id, index]));
+  return items
+    .map((item, stableIndex) => ({ item, stableIndex }))
+    .sort((a, b) => {
+      // Tier 1 — unread notifications, newest badge first.
+      const aAt = unreadAtById.get(a.item.id);
+      const bAt = unreadAtById.get(b.item.id);
+      if ((aAt !== undefined) !== (bAt !== undefined)) return aAt !== undefined ? -1 : 1;
+      if (aAt !== undefined && bAt !== undefined && aAt !== bAt) return bAt - aAt;
+      // Tier 2 — recently used, newest first.
+      const aRecent = recentIndex.get(a.item.id);
+      const bRecent = recentIndex.get(b.item.id);
+      if (aRecent !== undefined || bRecent !== undefined) {
+        if (aRecent === undefined) return 1;
+        if (bRecent === undefined) return -1;
+        if (aRecent !== bRecent) return aRecent - bRecent;
+      }
+      // Tier 3 — base install order, stable.
+      return a.stableIndex - b.stableIndex;
+    })
+    .map(({ item }) => item);
+}
+
+/**
  * 将安装清单转换成列表卡片需要的最小字段。
  *
  * 这里刻意不加入安装量、使用量、认证徽章等旧原型字段;这些字段在 Ghost


### PR DESCRIPTION
## 这次改了什么

### 摘要

重做「已安装插件」区的排序。**基线更新**:PR #1759(插件列表折叠)已合入 main,并重写了同一段排序代码——保留 `orderSnapshot` 冻结、还加了「隐藏的可更新插件临时置顶」逃生(`promoteNewlyUpdatable`)。本 PR 已 rebase 到 #1759 之上,按需求方决定整合:

- 排序改为**实时三层词典序**:未读通知(`notify.badge`,#1421,按点亮时刻 `at` 新→旧)→ 最近使用 → 基础安装序。`marketUpdate` 不再作排序键。
- 移除 #1759 的 `orderSnapshot` 冻结快照 + `reconcile/initialize/shouldInitialize/surfaceNewlyUpdatable` 整套机制及其单测——这是"会话内排序过时"的根因;**更新可被折叠**(横幅已兜底,需求方定调)。
- **保留 #1759 的折叠 UI**(前 8 + 折叠入口 + overflow 动效)不变。
- **未读通知永不折叠**:新增 `installedVisibleCount = max(8, 未读数)`;未读已排最前,扩窗即保证它们全部落在可见区(需求方明确要求,含用户装很多插件的情形)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:插件列表排序体验(已安装区排序过时 + 更新过度置顶 + 提醒类不应被折叠);基线依赖 #1759(已合并)
- 本 PR 包含:`sortInstalledForDisplay`(未读→最近用→基础序)+ `installedVisibleCount`(未读永不折叠窗口)+ 单测;`useGhostUnreadEntries`(按 version 缓存的未读快照);`GhostPluginPage` 用反应式重排替换 #1759 的 orderSnapshot 冻结+置顶机制
- 明确不包含:不改 #1759 的折叠 UI/动效;不改 `notify.badge` 通道与 recent-usage 记录时机(只消费快照);不改推荐区排序与交互
- 用户可见变化:已安装区卡片顺序——有未读通知的置顶(最新在上)且永不被折叠;其余按最近使用;更新不再置顶、可被折叠
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及新增视觉。仅改已安装区**排序与可见窗口**(卡片先后 + 折叠边界),复用 #1759 既有折叠 UI 与卡片样式,无新增颜色/间距/文案/动效。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop typecheck            # 绿
pnpm --dir apps/desktop exec eslint <改动文件>     # 干净
pnpm --dir apps/desktop exec vitest run \
  cindy-brain/__tests__/ghostPluginViewModel.test.ts \
  __tests__/chatInputSessionFocus.test.ts \
  features/plugin/__tests__/{GhostPluginCard,PluginManagementLayout,GhostPluginDetailSections}.test.*
结果:5 文件 94 用例全绿（含 sortInstalledForDisplay 4 例 + installedVisibleCount 3 例；#1759 的折叠/disclosure 测试随排序整合更新后仍绿）
```

完整 `pnpm test:unit` 交 CI。定向测试输出的嵌套 `<button>` 警告为既有问题(#1759 已注明),本 PR 未引入。

### 手工验证

不涉及新增视觉元素。反应式安全边界已在代码核实:`markUsed` 只在对话里触发(`ChatInput`),插件页自身不打点,「最近使用」只在离开本页后变化、回页即已重排,不会在眼皮下洗牌;未读通知冒头正是目的。

### 未执行的验证

- 未起 dev 实例目检排序/折叠(只改顺序与可见窗口、不改卡片视觉;正确性由 `sortInstalledForDisplay` + `installedVisibleCount` 单测覆盖)。可执行验证:装 >8 个插件 → 触发某个排在后面的插件 `notify.badge`(或在对话里用它)→ 回插件页确认它排到最前且未被折叠;有更新但无未读的插件可正常折叠、更新提示由横幅承担。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 其他:仅 Desktop 渲染层已安装区排序/可见窗口,构建在已合并的 #1759 之上

### 影响与回滚

- 影响范围:仅 Desktop「已安装插件」区卡片顺序与折叠边界;不涉及数据、协议、迁移、原生层、存量插件兼容。
- 回滚 / 降级方式:回滚本 PR 即恢复 #1759 的冻结快照排序(折叠 UI 不受影响)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明(无新增视觉,已说明)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(无独立文档变更)
- [x] 已确认测试结果或说明未执行原因
