### PR TITLE
fix(plugin): replay requested embedding dimensions in forge guide

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/forge.test.ts
@@ -696,6 +696,17 @@ describe('scaffoldGhostDir', () => {
 });
 
 describe('FORGE_GUIDE', () => {
+  it('向量检索示例按请求维度回放,不把回执 dim 当作请求判据', () => {
+    expect(FORGE_GUIDE).toContain('const requestedDim = undefined');
+    expect(FORGE_GUIDE).toContain('requestedDim 来自这次请求而不是回执');
+    expect(FORGE_GUIDE).toContain(
+      '...(storedRequestedDim !== undefined ? { dimensions: storedRequestedDim } : {}),',
+    );
+    expect(FORGE_GUIDE).not.toContain(
+      '...(storedDim !== undefined ? { dimensions: storedDim } : {}),',
+    );
+  });
+
   it('分章体量守卫:每个 ## 章节须留在单次工具结果安全体量内(#890 分章投递的不变量)', () => {
     // 手册"随主机版本演进"持续增长;任一章越过单次 MCP 结果上限会静默复现 #890 于该章。
     // 上限取 32KB:当前最大章 ~22KB,余量 ~45%,越线即该拆小节。

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1640,18 +1640,21 @@ Agent 做检索增强)时,用这个能力把文字算成向量:
 // 需声明:"slots": [..., "cindy"], "cindy": { "embed": ["text"] }
 
 // 1) 入库:把你的内容算成向量,自己存起来
+const requestedDim = undefined; // 传 dimensions 时改成具体数字;不传就是 undefined
 const doc = await cindy.send({
   type: 'cindy-request',
   kind: 'embed_text',
   texts: ['第一段内容…', '第二段内容…'],
   inputType: 'document',   // 可选:这批是"被检索的内容"
-  // dimensions: 1024,     // 可选:降维省存储与传输(默认随型号)
+  ...(requestedDim !== undefined ? { dimensions: requestedDim } : {}),
   // tier: 'best',         // 可选:档位意图(draft/standard/best)
   callId: msg.callId,
 });
 // 成功:{ ok:true, embeddings:[[…],[…]], model:'…', dim:1024, modelLabel:'…' }
-// 把 embeddings 连同 model + dim 一起存进你自己的 kv / 文件
-// (下面检索时要用这两个值,记作 storedModel / storedDim)
+// 把 embeddings 连同 model + dim + requestedDim 一起存进你自己的 kv / 文件
+// requestedDim 来自这次请求而不是回执;没传 dimensions 时保持 undefined。
+// dim 只用于兼容性校验(例如比对存量向量长度),不是检索请求的回放依据。
+// (下面检索时要用 storedModel / storedRequestedDim; storedDim 可继续用于校验)
 // 回执里的 model 一定是可以原样回传的那个 id;偶尔还会多一个 upstreamModel
 // (上游带版本号的实际型号),那个只用来看"后端是不是换了实现",别回传。
 
@@ -1665,7 +1668,7 @@ const q = await cindy.send({
   // 入库时传过 dimensions 就必须**原样再传一次**:不传等于要该型号的默认维度,
   // 默认值往往不是你入库时那个,拿到的查询向量和存量长度都不一样,没法比。
   // 入库时没传过,这里也别传(两边都用默认)。
-  ...(storedDim !== undefined ? { dimensions: storedDim } : {}),
+  ...(storedRequestedDim !== undefined ? { dimensions: storedRequestedDim } : {}),
   callId: msg.callId,
 });
 \`\`\`


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 FORGE_GUIDE §4.0.3 的 `embed_text` 检索示例：示例现在从入库请求侧记录 `requestedDim`，只有入库时显式传过 `dimensions` 才在检索时回放；回执里的 `dim` 仅用于向量长度兼容性校验。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：PR #1707 follow-up，BUG 2（`cindy-embed-endpoint-readiness-bug.md`）。
- 本 PR 包含：`FORGE_GUIDE` 向量检索示例修正；新增回归断言锁住请求维度与回执维度的区别。
- 明确不包含：BUG 1（网关 endpoint 就绪判据）；不改任何运行时 slot、manifest、打包或列表投影逻辑。
- 用户可见变化：Agent 照抄手册示例时，默认维度流程不会再被错误地显式回放 `dimensions`；显式降维流程仍会原样回放。
- 是否存在 breaking change：无。

### UI 变化

- 不涉及。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/forge.test.ts
结果：34 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/main/cindy-brain/forge.ts src/main/cindy-brain/__tests__/forge.test.ts
结果：通过

pnpm test:unit
结果：通过；所有 required workspace PASS，仓库 runner 343 项中 342 passed、1 skipped、0 failed

pnpm check:dco
结果：通过
```

### 手工验证

- 不涉及；本 PR 只改插件作者手册示例和对应回归测试。

### 未执行的验证

- Windows 实机验证未执行；改动不含平台分支或运行时路径。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：作者手册示例一致性

### 影响与回滚

- 影响范围：仅影响通过 `ghost_forge_guide` 获取手册的插件作者；不改变已安装插件运行时或 wire 行为。
- 手册已同步：FORGE_GUIDE §4.0.3（`embed_text` 检索示例）。
- 回滚 / 降级方式：回滚本 PR commit 即可恢复旧手册文本；无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因