### PR TITLE
fix(plugin): 将 OAuth scope 上限提高到 256

### DIFF
--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1272,7 +1272,7 @@ node 详单**不接受** \`command\` / \`args\` / \`shell\` / \`env\` 或其它�
       "clientId": "xxx.apps.example.com",           // 可选:内置 OAuth 客户端 ID(用户零配置开箱即用;用户在设置页自填的覆盖内置,清除自填即回落)
       "clientIdAlternatives": ["xxx-global.apps.example.com"],  // 可选 ≤8 条:仅 tokenBroker 模式;意识按 app-context 选 App 时,connect 只接受默认值或这里声明的公开 ID
       "clientSecret": "xxx",                        // 可选(须与 clientId 成对):内置 client 的 secret;桌面应用的 client 凭证本非机密,纯 PKCE 服务商可省略
-      "scopes": ["read.a", "write.b"],              // 可选 ≤48 条:申请的权限范围(确认框逐条展示给用户)
+      "scopes": ["read.a", "write.b"],              // 可选 ≤256 条:申请的权限范围(确认框逐条展示给用户)
       "scopeDelimiter": ",",                        // 可选:authorize URL 的 scope 拼接分隔符;缺省空格(OAuth 标准),Slack 这类逗号分隔的服务商声明 ","(目前只认这一个值)
       "pkce": true,                                 // 可选:PKCE(S256)开关,缺省 true
       "extraAuthorizeParams": { "access_type": "offline", "prompt": "consent" },  // 可选 ≤8 条:服务商特有授权参数(协议保留参数禁写)

--- a/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts
@@ -5,6 +5,7 @@
  */
 import { describe, expect, it, vi } from 'vitest';
 
+import { GHOST_OAUTH_SCOPES_MAX } from '../../../../shared/ghost.js';
 import { GhostKvError } from '../../ghostKvStore.js';
 import { GHOST_SECRET_VALUE_MAX_CHARS } from '../ghostSecretsEndpoint.js';
 import { handleGhostOauthRequest, type GhostOauthEndpointManager } from '../ghostOauthEndpoint.js';
@@ -274,7 +275,10 @@ describe('POST /oauth/<key>/connect · scopes body(降面授权)', () => {
 });
 
 describe('POST /oauth/<key>/insufficient-scopes', () => {
-  const DECLARED_SCOPES = Array.from({ length: 64 }, (_, index) => `scope.${index}`);
+  const DECLARED_SCOPES = Array.from(
+    { length: GHOST_OAUTH_SCOPES_MAX },
+    (_, index) => `scope.${index}`,
+  );
   const SCOPED: GhostOauthDecl = {
     authorizeUrl: 'https://accounts.example.com/authorize',
     tokenUrl: 'https://accounts.example.com/token',
@@ -325,7 +329,7 @@ describe('POST /oauth/<key>/insufficient-scopes', () => {
     expect(onChanged).not.toHaveBeenCalled();
   });
 
-  it('64 条边界放行；65 条拒绝', async () => {
+  it('声明上限边界放行；上限加一条拒绝', async () => {
     const accepted = fakeManager();
     expect((await report(JSON.stringify({ scopes: DECLARED_SCOPES }), accepted)).status).toBe(204);
     expect(accepted.reportInsufficientScopes).toHaveBeenCalledWith(

--- a/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
+++ b/apps/desktop/src/main/cindy-brain/runtime/ghostOauthEndpoint.ts
@@ -28,7 +28,7 @@
  * 产生的全部令牌只存在主机保险库与内存缓存,本端点没有任何读回动作。
  */
 
-import { isOfficialGhostId } from '../../../shared/ghost.js';
+import { GHOST_OAUTH_SCOPES_MAX, isOfficialGhostId } from '../../../shared/ghost.js';
 import { GhostKvError } from '../ghostKvStore.js';
 import { GHOST_SECRET_VALUE_MAX_CHARS } from './ghostSecretsEndpoint.js';
 import type {
@@ -283,7 +283,11 @@ export async function handleGhostOauthRequest(args: {
     const parsed = await readJsonBody();
     if (!parsed.ok) return { status: parsed.status };
     const rawScopes = parsed.body.scopes;
-    if (!Array.isArray(rawScopes) || rawScopes.length === 0 || rawScopes.length > 64) {
+    if (
+      !Array.isArray(rawScopes)
+      || rawScopes.length === 0
+      || rawScopes.length > GHOST_OAUTH_SCOPES_MAX
+    ) {
       return { status: 400 };
     }
     // 逐字属于声明面即形状合法(清单校验已保证声明 scope ≤200 字符、无空白),

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -630,10 +630,9 @@ export interface GhostSecretExchangeDecl {
  * 本校验取值级"严出"(plugin-security-and-authoring.md §7):超上限的包在旧版
  * 客户端拒装,插件市场铺开须等携带新上限的客户端先行发布。
  *
- * 涨过 64 前必须同步两处只留了防御余量的 64 上限,否则会拒绝合法的缺权上报
- * /静默判废 assessment:insufficient-scopes 端点的整包条数上限
- * (runtime/ghostOauthEndpoint.ts)与 cindy-tools 的 SETUP_REAUTH_SCOPE_MAX
- * (ghost/mcpServer.ts,包依赖方向不允许直接引用本常量)。
+ * insufficient-scopes 端点直接复用本常量；cindy-tools 的
+ * SETUP_REAUTH_SCOPE_MAX 因包依赖方向无法引用本常量，调整时必须同步，
+ * 否则会静默判废合法的 assessment。
  */
 export { GHOST_OAUTH_SCOPES_MAX };
 /** OAuth broker 模式可声明的备用 clientId 上限(默认 clientId 不计入)。 */
@@ -687,7 +686,7 @@ export interface GhostSecretOauthDecl {
   clientIdAlternatives?: string[];
   /** 可选:内置 client 的 secret(与 clientId 成对;纯 PKCE 服务商可省略)。 */
   clientSecret?: string;
-  /** 申请的 scope 列表(0–48 条,确认框逐条展示;缺省 = 不带 scope 参数)。 */
+  /** 申请的 scope 列表(0–256 条,确认框逐条展示;缺省 = 不带 scope 参数)。 */
   scopes?: string[];
   /**
    * 可选:authorize URL 里 scope 参数的拼接分隔符。OAuth 标准是空格(缺省),

--- a/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
+++ b/packages/cindy-tools/src/__tests__/ghostMcp.test.ts
@@ -9,6 +9,7 @@ import {
   handleForgeScaffold,
   handleGhostCall,
   handleGhostList,
+  sanitizeGhostSetupAssessment,
 } from "../ghost/mcpServer.js";
 import type {
   CindyGhostSetupAssessment,
@@ -81,6 +82,23 @@ const READY_WITH_REAUTH_SUGGEST = {
   },
 };
 
+function reauthAssessmentWithScopeCount(
+  count: number,
+): CindyGhostSetupAssessment {
+  const missingScopes = Array.from(
+    { length: count },
+    (_, index) => `scope:${index}`,
+  );
+  return {
+    ...READY_WITH_REAUTH_SUGGEST,
+    reauthSuggest: {
+      ...READY_WITH_REAUTH_SUGGEST.reauthSuggest,
+      missingScopes,
+      missingScopeCount: missingScopes.length,
+    },
+  };
+}
+
 describe("cindy_ghosts · ghost_list(总机接线簿,现查现报)", () => {
   it("返回唤醒中的意识与工具,附调用提示", async () => {
     const result = await handleGhostList(fakeDeps());
@@ -110,6 +128,15 @@ describe("cindy_ghosts · ghost_list(总机接线簿,现查现报)", () => {
     );
     const ghosts = parsePayload(result).ghosts as Array<{ setup?: unknown }>;
     expect(ghosts[0].setup).toEqual(READY_WITH_REAUTH_SUGGEST);
+  });
+
+  it("reauthSuggest 接受 256 条缺权 scope，并拒绝第 257 条", () => {
+    expect(
+      sanitizeGhostSetupAssessment(reauthAssessmentWithScopeCount(256)),
+    ).not.toBeNull();
+    expect(
+      sanitizeGhostSetupAssessment(reauthAssessmentWithScopeCount(257)),
+    ).toBeNull();
   });
 
   it("setup assessment 由 Host 脱敏生成并原样透传", async () => {

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -217,9 +217,9 @@ const SETUP_REQUIREMENT_KINDS = new Set([
   "client_config",
 ]);
 const SETUP_REQUIREMENT_STATES = new Set(["missing", "expired", "satisfied"]);
-// 对主机声明上限 GHOST_OAUTH_SCOPES_MAX(desktop shared/ghost.ts,当前 48;包依赖
-// 方向不允许引用)只留防御余量;该值涨过 64 时必须同步,否则整份 assessment 判废。
-const SETUP_REAUTH_SCOPE_MAX = 64;
+// 与主机声明上限 GHOST_OAUTH_SCOPES_MAX(desktop shared/ghost.ts,当前 256)同步；
+// 包依赖方向不允许引用该常量，调整协议上限时必须同步，否则整份 assessment 判废。
+const SETUP_REAUTH_SCOPE_MAX = 256;
 
 function sanitizeSetupAction(
   raw: unknown,

--- a/packages/cindy-tools/src/ghost/mcpServer.ts
+++ b/packages/cindy-tools/src/ghost/mcpServer.ts
@@ -217,7 +217,8 @@ const SETUP_REQUIREMENT_KINDS = new Set([
   "client_config",
 ]);
 const SETUP_REQUIREMENT_STATES = new Set(["missing", "expired", "satisfied"]);
-// 与主机声明上限 GHOST_OAUTH_SCOPES_MAX(desktop shared/ghost.ts,当前 256)同步；
+// 与主机声明上限 GHOST_OAUTH_SCOPES_MAX 同步
+// (apps/desktop/src/shared/ghost.ts 从 @cindy/plugin-protocol re-export，当前 256)；
 // 包依赖方向不允许引用该常量，调整协议上限时必须同步，否则整份 assessment 判废。
 const SETUP_REAUTH_SCOPE_MAX = 256;
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

将插件 OAuth scope 声明上限从 48 提高到 256，并同步客户端缺权上报、重新授权建议清洗和插件编写说明。这样声明 49–256 条 scope 的插件可以正常安装、更新和重新授权。

协议正本已由 makecindy/cindy-protocol#32 更新；本 PR 将客户端子模块同步到最新 Protocol `main@14c2bd35`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：插件 OAuth scope 数量超过旧上限时安装/更新失败
- 本 PR 包含：Protocol 子模块更新；manifest 消费方同步；缺权上报与 `cindy-tools` 防御上限同步；边界测试与作者说明更新
- 明确不包含：插件本身的 scope 内容调整；Server 发布部署
- 用户可见变化：声明 49–256 条 OAuth scope 的插件可正常安装、更新，并在权限变化时继续走重新确认流程
- 是否存在 breaking change：无；仅放宽校验

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：PASS，全部适用 workspace unit 测试通过

pnpm --filter desktop typecheck
结果：PASS，0 errors

pnpm --filter cindy-tools build
结果：PASS，0 errors

pnpm --filter @cindy/plugin-protocol build
结果：PASS，0 errors

pnpm --filter desktop exec eslint src/main/cindy-brain/forge.ts src/main/cindy-brain/runtime/ghostOauthEndpoint.ts src/main/cindy-brain/runtime/__tests__/ghostOauthEndpoint.test.ts src/shared/ghost.ts
结果：PASS，0 errors
```

### 手工验证

不涉及：本 PR 为协议数量边界放宽，256/257 边界由自动测试覆盖。

### 未执行的验证

未执行真实市场插件点击更新；需要等待包含本 PR 的客户端构建。安装/更新共用的 manifest 校验、缺权上报与 assessment 清洗边界均已有自动测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：客户端插件 manifest 校验与 OAuth 缺权重新授权链路。客户端应先于允许发布 49–256 条 scope 插件的 Server 版本发布。
- 回滚 / 降级方式：回滚本提交，并在 Server 侧继续限制为旧上限，避免旧客户端收到超过 48 条 scope 的插件版本。
- 存量插件影响：无。已有 ≤48 条 scope 的插件行为不变；不修改批准状态、指纹、receipt、安装布局、包格式、启用状态或面板位置，不要求重装。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
