### PR TITLE
fix(plugin): 网关 endpoint 未就绪时隐藏向量与视频模型

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/cindyGatewayReadiness.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindyGatewayReadiness.test.ts
@@ -46,6 +46,12 @@ const XD_CASES: Array<{
     expected: false,
   },
   {
+    name: '已登录但 endpoint 仅含空白 → 未就绪',
+    canUseCindyGateway: true,
+    gatewayBaseUrl: '  \n\t  ',
+    expected: false,
+  },
+  {
     name: '未登录但 endpoint 残留 → 未就绪',
     canUseCindyGateway: false,
     gatewayBaseUrl: 'https://gateway.example',

--- a/apps/desktop/src/main/cindy-brain/__tests__/cindyGatewayReadiness.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindyGatewayReadiness.test.ts
@@ -1,0 +1,79 @@
+/**
+ * cindyGatewayReadiness.test.ts — 锁住 XD 网关 endpoint 的运行期就绪判据。
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const runtime = vi.hoisted(() => ({
+  canUseCindyGateway: true,
+  gatewayBaseUrl: 'https://gateway.example',
+  appCapabilityReads: 0,
+  endpointReads: 0,
+}));
+
+vi.mock('../../appCapabilities.js', () => ({
+  getAppCapabilities: () => {
+    runtime.appCapabilityReads += 1;
+    return { canUseCindyGateway: runtime.canUseCindyGateway };
+  },
+}));
+
+vi.mock('../../model-access/effectiveEndpoint.js', () => ({
+  effectiveXdGatewayBaseUrl: () => {
+    runtime.endpointReads += 1;
+    return runtime.gatewayBaseUrl;
+  },
+}));
+
+import { isXdGatewayProviderReady } from '../cindyGatewayReadiness';
+
+const XD_CASES: Array<{
+  name: string;
+  canUseCindyGateway: boolean;
+  gatewayBaseUrl: string;
+  expected: boolean;
+}> = [
+  {
+    name: '已登录且 endpoint 已下发 → 就绪',
+    canUseCindyGateway: true,
+    gatewayBaseUrl: 'https://gateway.example',
+    expected: true,
+  },
+  {
+    name: '已登录但 endpoint 尚未下发 → 未就绪',
+    canUseCindyGateway: true,
+    gatewayBaseUrl: '',
+    expected: false,
+  },
+  {
+    name: '未登录但 endpoint 残留 → 未就绪',
+    canUseCindyGateway: false,
+    gatewayBaseUrl: 'https://gateway.example',
+    expected: false,
+  },
+];
+
+describe('isXdGatewayProviderReady', () => {
+  beforeEach(() => {
+    runtime.canUseCindyGateway = true;
+    runtime.gatewayBaseUrl = 'https://gateway.example';
+    runtime.appCapabilityReads = 0;
+    runtime.endpointReads = 0;
+  });
+
+  it.each(XD_CASES)('$name', ({ canUseCindyGateway, gatewayBaseUrl, expected }) => {
+    runtime.canUseCindyGateway = canUseCindyGateway;
+    runtime.gatewayBaseUrl = gatewayBaseUrl;
+
+    expect(isXdGatewayProviderReady('xd')).toBe(expected);
+  });
+
+  it('非 XD 供应商不依赖 XD 网关状态', () => {
+    runtime.canUseCindyGateway = false;
+    runtime.gatewayBaseUrl = '';
+
+    expect(isXdGatewayProviderReady('other')).toBe(true);
+    expect(runtime.appCapabilityReads).toBe(0);
+    expect(runtime.endpointReads).toBe(0);
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/cindyGatewayReadiness.ts
+++ b/apps/desktop/src/main/cindy-brain/cindyGatewayReadiness.ts
@@ -9,5 +9,5 @@ import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js'
 
 export function isXdGatewayProviderReady(providerId: string): boolean {
   if (providerId !== 'xd') return true;
-  return getAppCapabilities().canUseCindyGateway && effectiveXdGatewayBaseUrl() !== '';
+  return getAppCapabilities().canUseCindyGateway && effectiveXdGatewayBaseUrl().trim() !== '';
 }

--- a/apps/desktop/src/main/cindy-brain/cindyGatewayReadiness.ts
+++ b/apps/desktop/src/main/cindy-brain/cindyGatewayReadiness.ts
@@ -1,0 +1,13 @@
+/**
+ * cindyGatewayReadiness.ts — cindy 槽向量 / 视频供应商的运行期就绪判据。
+ *
+ * XD 是这两个类目当前唯一的网关执行来源；账号能力与随凭据成对下发的
+ * endpoint 必须同时存在，才能把 XD 型号投影进插件清单。
+ */
+import { getAppCapabilities } from '../appCapabilities.js';
+import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
+
+export function isXdGatewayProviderReady(providerId: string): boolean {
+  if (providerId !== 'xd') return true;
+  return getAppCapabilities().canUseCindyGateway && effectiveXdGatewayBaseUrl() !== '';
+}

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -159,6 +159,7 @@ import {
   type CindyCapabilityKind,
   type CindyMediaCatalogConfig,
 } from './cindyMediaCatalog.js';
+import { isXdGatewayProviderReady } from './cindyGatewayReadiness.js';
 import {
   GhostCindySlot,
   type CindyImageCapabilities,
@@ -2397,12 +2398,12 @@ function getCatalogMediaConfig(kind: CindyCapabilityKind): CindyMediaCatalogConf
       // 网关能力在场 —— 未登录本地模式(canUseCindyGateway=false)下 xd 的视频型号
       // 不能进清单,否则用户在本地模式钉选/点名视频型号就是"可选但必失败"
       // (2026-07 review:与图像的就绪语义对齐)。
-      // 向量与视频同口径:通道只有 xd 一家、不经 registry,但要求网关能力在场
-      // (本地模式没有网关 key,embedSync 必然 AUTH_FAILED —— 那种型号不该出现在
-      // 清单里让用户钉选)。
+      // 向量与视频同口径:通道只有 xd 一家、不经 registry,但要求账号网关能力与
+      // model-access 随凭据成对下发的 endpoint 同时在场。登录同步完成前 / 存量
+      // 手填 key 没有配套 endpoint 时,那种型号不该出现在清单里让用户钉选。
       kind === 'image'
         ? (providerId) => getImageChannelRegistry().isProviderReady(providerId)
-        : (providerId) => providerId !== 'xd' || getAppCapabilities().canUseCindyGateway,
+        : isXdGatewayProviderReady,
       // 编辑就绪过滤:仅支持生成的来源(supportsEdit: false)的模型不进编辑清单,
       // 防用户把该型号钉到 image.edit 偏好后在 editImage 路径拿到确定性 400。
       kind === 'image' ? (providerId) => getImageChannelRegistry().isProviderEditReady(providerId) : undefined,


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `cindy` 槽向量（`embed.text`）与视频共用的 XD provider 就绪判据。

此前清单只检查 `canUseCindyGateway`，没有检查 model-access 是否已经随凭据成对下发网关 endpoint；endpoint 为空时，型号仍会进入插件白名单与设置列表，实际下单则用空 base URL 重试后报 `INTERNAL`。

现在把组合条件抽成运行期具名判据：只有云端网关能力可用，且 `effectiveXdGatewayBaseUrl()` 去除首尾空白后非空时，XD 向量/视频型号才进入清单。空清单沿用既有语义立即返回 `NO_CANDIDATE`，不再发起网络重试。视频与向量共用同一接线，因此一并修复视频上的同类既有缺陷。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PR #1707 review 后续，`cindy-embed-endpoint-readiness-bug.md` BUG1
- 本 PR 包含：XD 网关 endpoint readiness 接线；登录/endpoint 状态与非 XD 回归测试
- 明确不包含：BUG2（FORGE_GUIDE 检索示例）
- 用户可见变化：endpoint 尚未下发、不存在或仅含空白时，向量/视频型号不再显示为可用；插件调用立即得到 `NO_CANDIDATE`
- 是否存在 breaking change：无

### UI 变化

不涉及。只调整 Desktop main 侧能力清单的运行期过滤，不修改组件、布局、样式或 UI 文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/cindyGatewayReadiness.test.ts src/main/cindy-brain/__tests__/cindyMediaCatalog.test.ts src/main/cindy-brain/__tests__/cindySlot.test.ts
结果：通过，3 files / 154 tests

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过（全部 required workspace）

pnpm check:dco
结果：通过，2 个 commit 均已签名

pnpm --filter desktop exec eslint src/main/cindy-brain/cindyGatewayReadiness.ts src/main/cindy-brain/__tests__/cindyGatewayReadiness.test.ts
结果：通过
```

补充：`pnpm --filter desktop lint` 仍命中仓库现有 lint 基线（180 errors / 4 warnings）；报错未命中两个新增文件，本次新增文件已用上面的定向 ESLint 验证通过。

### 手工验证

不涉及。该修复是纯 main 侧同步判据，未启动宿主 Desktop 做实机验证。

### 未执行的验证

- Windows 实机验证未执行；本次未新增平台 API、文件路径或系统分支
- Light / Dark 目检不涉及（无 UI 改动）

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：插件基座的能力清单 readiness 过滤，需白名单放行人明确 Approve

### 影响与回滚

- 影响范围：仅 `cindy` 槽的 XD 向量与视频目录投影；endpoint 正常下发时行为不变，非 XD provider 与图像通道不变
- 改动边界：未修改 manifest、slot kind/参数、批准状态、偏好 schema、凭证、安装布局或包格式；验证仅覆盖本 PR 的代码路径与自动化测试，不外推未验证的部署或使用情况
- 手册同步：无需。本 PR 不修改插件作者可见的能力契约、参数或模型白名单，只修正 Host 对当前可用性的判断
- 回滚 / 降级方式：revert 本提交即可；回滚会恢复 endpoint 为空时的错误可用状态与延迟失败
- 白名单确认：本 PR 命中 `main/cindy-brain/` 插件基座，合并前需放行人明确 Approve

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需作者手册变更，原因见风险说明）
- [x] 已确认测试结果或说明未执行原因
