### PR TITLE
fix(desktop): Android 自动化禁用时打开电脑使用面板不再拉起 adb server

### DIFF
--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -442,7 +442,8 @@ export function ComputerUseSection({
             if (!cancelled && status) setAndroidStatus(status);
           })
           .catch((err) => {
-            log.warn('android.prepareAdb failed', err);
+            // 这个 catch 同时兜 prepareAdb 与后续 status 的失败,文案别写死单边。
+            log.warn('android adb probe (prepareAdb/status) failed', err);
             if (!cancelled) setAndroidStatus(androidStatusFallback(err));
           })
           .finally(() => {
@@ -890,6 +891,10 @@ export function ComputerUseSection({
           setAndroidPreparePending(true);
           await window.electronAPI.maker.android.prepareAdb();
           await handleRefreshAndroidStatus(false);
+        } else {
+          // 关闭时清掉旧探测结果:状态区回到禁用提示,设备选择入口一并禁用,
+          // 不再展示已过时的就绪/设备状态(#1829 review)。
+          setAndroidStatus(null);
         }
         toast.success(
           next

--- a/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ComputerUseSection.tsx
@@ -426,49 +426,36 @@ export function ComputerUseSection({
       });
     void window.electronAPI.maker.plugins.getState(ANDROID_PLUGIN_ID)
       .then((state) => {
-        if (!cancelled) {
-          setAndroidEnabled(state.effectiveEnabled);
-          if (state.effectiveEnabled) {
-            setAndroidPreparePending(true);
-            void window.electronAPI.maker.android.prepareAdb()
-              .then(() => {
-                if (!cancelled) {
-                  return window.electronAPI.maker.android.status()
-                    .then((status) => {
-                      if (!cancelled) setAndroidStatus(status);
-                    });
-                }
-                return undefined;
-              })
-              .catch((err) => {
-                log.warn('android.prepareAdb failed', err);
-              })
-              .finally(() => {
-                if (!cancelled) setAndroidPreparePending(false);
-              });
-          }
+        if (cancelled) return;
+        setAndroidEnabled(state.effectiveEnabled);
+        // 插件禁用时 mount 不做任何 adb 探测:status() 会跑 `adb devices -l`,
+        // 5037 上没有 server 时会顺手 fork 一个 daemon(#1806)。禁用态只展示
+        // 提示文案;探测留到用户开启开关或手动点「刷新」时进行。
+        if (!state.effectiveEnabled) {
+          setAndroidStatusPending(false);
+          return;
         }
+        setAndroidPreparePending(true);
+        void window.electronAPI.maker.android.prepareAdb()
+          .then(() => (cancelled ? undefined : window.electronAPI.maker.android.status()))
+          .then((status) => {
+            if (!cancelled && status) setAndroidStatus(status);
+          })
+          .catch((err) => {
+            log.warn('android.prepareAdb failed', err);
+            if (!cancelled) setAndroidStatus(androidStatusFallback(err));
+          })
+          .finally(() => {
+            if (!cancelled) {
+              setAndroidPreparePending(false);
+              setAndroidStatusPending(false);
+            }
+          });
       })
       .catch((err) => {
         log.warn('plugins.getState(android) failed', err);
         if (!cancelled) {
           setAndroidEnabled(false);
-        }
-      });
-    void window.electronAPI.maker.android.status()
-      .then((status) => {
-        if (!cancelled) {
-          setAndroidStatus(status);
-        }
-      })
-      .catch((err) => {
-        log.warn('android.status failed', err);
-        if (!cancelled) {
-          setAndroidStatus(androidStatusFallback(err));
-        }
-      })
-      .finally(() => {
-        if (!cancelled) {
           setAndroidStatusPending(false);
         }
       });
@@ -1194,7 +1181,12 @@ export function ComputerUseSection({
     configuredDefaultAndroidDevice
     && !androidDevices.some((device) => device.device_serial === configuredDefaultAndroidDevice),
   );
-  const androidDeviceStatusText = describeAndroidDeviceStatus(androidStatus, t);
+  // 禁用且尚无任何探测结果时显示禁用提示,避免落在 describeAndroidDeviceStatus
+  // 的「正在检查…」上(禁用态 mount 不探测,#1806)。用户手动「刷新」拿到结果后
+  // 仍按真实 status 展示。
+  const androidDeviceStatusText = androidEnabled === false && !androidStatus
+    ? t('settings.computerUse.android.status.disabled')
+    : describeAndroidDeviceStatus(androidStatus, t);
   const androidConnectionGuideKind = getAndroidConnectionGuideKind(androidStatus);
   const androidAdbSource = androidStatus?.adb_path_source ?? androidStatus?.adb_preparation?.source ?? null;
   const androidAdbSourceText = androidPreparePending

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.androidDisabledGate.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.androidDisabledGate.test.tsx
@@ -6,7 +6,7 @@
  * 一个 daemon)。禁用态只展示提示文案;启用态保持原有 prepareAdb → status 链路。
  */
 
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
@@ -53,7 +53,7 @@ function installElectronApi(options: { androidEnabled: boolean }) {
       maker: {
         plugins: {
           getState: pluginsGetState,
-          setEnabled: vi.fn(),
+          setEnabled: vi.fn(async () => ({ codexMcpRefreshed: true })),
           setProjectEnabled: vi.fn(),
         },
         browser: {
@@ -138,5 +138,29 @@ describe('ComputerUseSection android disabled gate (#1806)', () => {
     expect(
       screen.queryByText('settings.computerUse.android.status.disabled'),
     ).toBeNull();
+  });
+
+  it('clears the stale probe result when the android plugin is toggled off', async () => {
+    const api = installElectronApi({ androidEnabled: true });
+
+    render(<ComputerUseSection workingDir="/repo" />);
+
+    await waitFor(() => {
+      expect(api.androidStatus).toHaveBeenCalledOnce();
+    });
+
+    fireEvent.click(
+      screen.getByRole('switch', { name: 'settings.computerUse.android.toggleAria' }),
+    );
+
+    // 关闭后状态区回到禁用提示,不残留旧的就绪/设备状态。
+    await waitFor(() => {
+      expect(
+        screen.getByText('settings.computerUse.android.status.disabled'),
+      ).toBeTruthy();
+    });
+    // 关闭动作本身不得触发新的 adb 探测。
+    expect(api.androidStatus).toHaveBeenCalledOnce();
+    expect(api.androidPrepareAdb).toHaveBeenCalledOnce();
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.androidDisabledGate.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ComputerUseSection.androidDisabledGate.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+
+/**
+ * Issue #1806 回归:Android 自动化插件禁用时,打开「电脑使用」面板不得触发
+ * 任何 adb 探测(status() 会跑 `adb devices -l`,5037 无 server 时会顺手 fork
+ * 一个 daemon)。禁用态只展示提示文案;启用态保持原有 prepareAdb → status 链路。
+ */
+
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { ComputerUseSection } from '../ComputerUseSection';
+
+function installElectronApi(options: { androidEnabled: boolean }) {
+  const androidStatus = vi.fn(async () => ({
+    adb_available: true,
+    adb_path: '/sdk/platform-tools/adb',
+    adb_path_source: 'sdk',
+    version: 'Android Debug Bridge version 1.0.41',
+    devices: [],
+    default_device_serial: null,
+    configured_default_device_serial: null,
+    issue: 'NO_DEVICE',
+    error: null,
+  }));
+  const androidPrepareAdb = vi.fn(async () => ({ status: 'ready', source: 'sdk' }));
+  const androidGetConfig = vi.fn(async () => ({
+    value: { defaultDeviceSerial: null, adbPathOverride: null },
+  }));
+  const pluginsGetState = vi.fn(async (pluginId: string) => ({
+    pluginId,
+    effectiveEnabled: pluginId === 'android' ? options.androidEnabled : false,
+  }));
+
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: {
+      platform: 'win32',
+      openExternal: vi.fn(async () => ({ success: true })),
+      maker: {
+        plugins: {
+          getState: pluginsGetState,
+          setEnabled: vi.fn(),
+          setProjectEnabled: vi.fn(),
+        },
+        browser: {
+          status: vi.fn(async () => ({
+            detected: false,
+            browserKind: null,
+            executablePath: null,
+          })),
+        },
+        computer: {
+          status: vi.fn(async () => ({
+            installed: false,
+            executablePath: null,
+            version: null,
+            daemonRunning: false,
+            installCommand: 'noop',
+            docsUrl: 'https://example.invalid/docs',
+          })),
+          checkUpdate: vi.fn(async () => ({ updateAvailable: false, updating: false })),
+          onPermissionGuideStatusChanged: vi.fn(() => () => {}),
+          onPermissionGuideCancelled: vi.fn(() => () => {}),
+          onUpdateProgress: vi.fn(() => () => {}),
+          cancelPermissionGrant: vi.fn(async () => {}),
+        },
+        android: {
+          getConfig: androidGetConfig,
+          status: androidStatus,
+          prepareAdb: androidPrepareAdb,
+          setDefaultDevice: vi.fn(),
+          setAdbPath: vi.fn(),
+        },
+      },
+    } as unknown as Window['electronAPI'],
+  });
+
+  return { androidStatus, androidPrepareAdb, androidGetConfig, pluginsGetState };
+}
+
+afterEach(() => {
+  cleanup();
+  Reflect.deleteProperty(window, 'electronAPI');
+  vi.clearAllMocks();
+});
+
+describe('ComputerUseSection android disabled gate (#1806)', () => {
+  it('does not probe adb on mount while the android plugin is disabled', async () => {
+    const api = installElectronApi({ androidEnabled: false });
+
+    render(<ComputerUseSection workingDir="/repo" />);
+
+    // 等 mount 数据链路完全落地(插件状态 + 配置都已返回)再断言。
+    await waitFor(() => {
+      expect(api.pluginsGetState).toHaveBeenCalledWith('android');
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText('settings.computerUse.android.status.disabled'),
+      ).toBeTruthy();
+    });
+
+    // 核心断言:禁用态 mount 绝不触碰 adb(status 会拉起 adb server)。
+    expect(api.androidStatus).not.toHaveBeenCalled();
+    expect(api.androidPrepareAdb).not.toHaveBeenCalled();
+    // 纯设置读取不受影响。
+    expect(api.androidGetConfig).toHaveBeenCalled();
+  });
+
+  it('keeps prepareAdb → status probing on mount when the android plugin is enabled', async () => {
+    const api = installElectronApi({ androidEnabled: true });
+
+    render(<ComputerUseSection workingDir="/repo" />);
+
+    await waitFor(() => {
+      expect(api.androidStatus).toHaveBeenCalledOnce();
+    });
+    expect(api.androidPrepareAdb).toHaveBeenCalledOnce();
+    // prepareAdb 先于 status:status 必须消费准备完成后的 adb 解析结果。
+    const prepareOrder = api.androidPrepareAdb.mock.invocationCallOrder[0]!;
+    const statusOrder = api.androidStatus.mock.invocationCallOrder[0]!;
+    expect(prepareOrder).toBeLessThan(statusOrder);
+    // 启用态不显示禁用提示。
+    expect(
+      screen.queryByText('settings.computerUse.android.status.disabled'),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -2413,6 +2413,7 @@
         "toggleHint": "This machine-wide toggle only applies to agent sessions started afterward; it does not affect a session that is already running.",
         "status": {
           "checking": "Checking ADB status…",
+          "disabled": "Android automation is off. Turn it on to detect ADB and devices.",
           "preparing": "Preparing ADB…",
           "ready": "ADB ready. Ready devices: {{count}}. Default: {{device}}",
           "adbDetail": "{{version}} at {{path}}",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2412,6 +2412,7 @@
         "toggleHint": "このマシン全体の切り替えは、以降に開始した Agent セッションにのみ反映されます。実行中のセッションには影響しません。",
         "status": {
           "checking": "ADB の状態を確認しています…",
+          "disabled": "Android 自動化はオフです。オンにすると ADB とデバイスを検出します。",
           "preparing": "ADB を準備しています…",
           "ready": "ADB は準備できています。利用可能なデバイス: {{count}}。デフォルト: {{device}}",
           "adbDetail": "{{version}}（{{path}}）",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -2412,7 +2412,7 @@
         "toggleHint": "このマシン全体の切り替えは、以降に開始した Agent セッションにのみ反映されます。実行中のセッションには影響しません。",
         "status": {
           "checking": "ADB の状態を確認しています…",
-          "disabled": "Android 自動化はオフです。オンにすると ADB とデバイスを検出します。",
+          "disabled": "Android 自動操作はオフです。オンにすると ADB とデバイスを検出します。",
           "preparing": "ADB を準備しています…",
           "ready": "ADB は準備できています。利用可能なデバイス: {{count}}。デフォルト: {{device}}",
           "adbDetail": "{{version}}（{{path}}）",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -2412,6 +2412,7 @@
         "toggleHint": "이 시스템 전체 토글은 이후 시작하는 Agent 세션에만 적용되며, 진행 중인 세션에는 영향을 주지 않습니다.",
         "status": {
           "checking": "ADB 상태 확인 중…",
+          "disabled": "Android 자동화가 꺼져 있습니다. 켜면 ADB와 기기를 감지합니다.",
           "preparing": "ADB 준비 중…",
           "ready": "ADB 준비됨. 사용 가능한 기기: {{count}}. 기본값: {{device}}",
           "adbDetail": "{{version}} 위치: {{path}}",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -2412,6 +2412,7 @@
         "toggleHint": "这个全局开关只对之后新建的 Agent 会话生效；已在运行的 Agent 会话不受影响。",
         "status": {
           "checking": "正在检查 ADB 状态…",
+          "disabled": "Android 自动化未启用。启用后将检测 ADB 与设备。",
           "preparing": "正在准备 ADB…",
           "ready": "ADB 已就绪。可用设备：{{count}}。默认设备：{{device}}",
           "adbDetail": "{{version}}，路径 {{path}}",


### PR DESCRIPTION
## 这次改了什么

### 摘要

Android 自动化是默认禁用的内置插件，但设置 →「电脑使用」面板 mount 时会无条件调用 `maker.android.status()`。该 IPC 直连 `getAndroidStatusSummary()`，不经过插件 enable gate，链路里会执行 `adb devices -l`——5037 端口没有 server 时 adb 会顺手 fork 一个 daemon，首次探测还会因冷启动超时走 `adb start-server` 重试。结果是插件保持禁用的用户只是打开设置页，就会拉起一个 adb server；dev 模式下该 server 来自 SDK/PATH（bundled adb 缺失回退），不在退出清理的 bundled/prepared 范围内，应用退出后进程残留（Issue #1806）。

本 PR 修复禁用态副作用：mount 只读取插件状态与配置，`effectiveEnabled` 为 true 才执行原有 `prepareAdb → status` 探测链；禁用态显示新增的禁用提示文案，探测留到用户开启开关或手动点「刷新」时进行。

Issue 中的另一半（把 SDK/PATH 来源纳入退出 kill-server 清理）涉及既有所有权语义（现有单测明确要求「adb 来自用户 PATH 时退出不 kill-server」），属于产品决策，本 PR 明确不包含，留待单独裁决。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1806
- 本 PR 包含：`ComputerUseSection` mount 探测按插件 `effectiveEnabled` 门控；禁用态状态区提示文案（4 个 locale 新增 `settings.computerUse.android.status.disabled`）；renderer 回归测试。
- 明确不包含：SDK/PATH/custom/env 来源 adb 的退出清理范围调整（既有所有权语义，待产品决策）；main 侧 `android.ts` 与 IPC handler 无改动。
- 用户可见变化：插件禁用时打开「电脑使用」面板不再触发 adb 探测/拉起 server；该状态下设备状态区显示「Android 自动化未启用。启用后将检测 ADB 与设备。」（此前显示真实探测结果）。启用态、开关开启、手动「刷新」、修改 adb 路径后的探测行为不变。
- 是否存在 breaking change：无

### UI 变化

- 仅文案级变化：Android 自动化禁用时，设备状态行显示禁用提示，不再显示 adb 探测结果；无布局、颜色、组件结构改动。
- 引用的设计规范：DESIGN.md §10「Light / Dark Dual-Mode Delivery Gate（双模式交付门槛）」——新文案复用既有语义 token（`--settings-section-desc`）渲染，无任何硬编码颜色，两种模式共用同一样式路径；未做实机双模式目检（见「未执行的验证」）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run --project standard src/renderer/components/settings/__tests__/ComputerUseSection.androidDisabledGate.test.tsx
结果：2 passed（禁用态 mount 不调用 status/prepareAdb 且显示禁用提示；启用态保持 prepareAdb → status 顺序探测）

pnpm --filter desktop run typecheck
结果：通过

pnpm check:i18n-glossary
结果：通过（en / zh-CN / ja / ko 无新增违规）

pnpm test:unit（仓库根，全部单元测试）
结果：全部 PASS（含 apps/desktop unit 143.1s），0 fail
```

### 手工验证

不涉及：修复点在 renderer mount 数据流，已由组件级回归测试覆盖禁用/启用两条路径；本地为 Windows 环境但未跑 dev 实机复现链路。

### 未执行的验证

- 未做 Windows 实机 dev 复现验证（打开设置面板观察 5037 端口/adb 进程）；原因：修复逻辑为「禁用态不发起 status/prepareAdb IPC」，已被单测直接断言，且 main 侧 adb 链路零改动。
- 未做 Light/Dark 双模式实机目检；新文案走既有 `--settings-section-desc` token，两种模式共用同一渲染路径。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅设置 →「电脑使用」面板的 Android 卡片 mount 行为与禁用态文案；插件启用用户与 MCP 工具链路不受影响。
- 回滚 / 降级方式：revert 本 commit 即恢复原行为，无数据/配置迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因