### PR TITLE
chore(browser-runtime): make sync.mjs runnable on Windows

### DIFF
--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -28,6 +28,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { resolvePosixShell } from '../lib/posix-shell.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../..');
@@ -77,8 +78,18 @@ function shHide(cmd) {
   // Windows paths are converted to /c/... and tar gets --wildcards. On POSIX
   // (incl. macOS BSD/libarchive tar) the command runs UNCHANGED — no
   // GNU-only flags are injected, so other platforms keep upstream behavior.
+  // Locate a real sh up front: on win32 the PATH may only contain Git\cmd
+  // (without Git\bin), so a bare `sh` would ENOENT — the repo resolver finds
+  // the Git-bundled sh.exe in standard install locations (codex-connector
+  // P1, round 3). Non-win32 callers keep using their normal PATH ('sh').
+  const sh = resolvePosixShell('sh');
+  if (!sh) {
+    throw new Error(
+      'sync: 找不到可用的 sh（未检测到 Git for Windows）。请安装 Git for Windows 后重试。',
+    );
+  }
   if (process.platform !== 'win32') {
-    execFileSync('sh', ['-c', cmd], { stdio: ['ignore', 'ignore', 'inherit'] });
+    execFileSync(sh, ['-c', cmd], { stdio: ['ignore', 'ignore', 'inherit'] });
     return;
   }
   // Inject --wildcards ONLY when the resolved tar is actually GNU tar: on
@@ -97,7 +108,7 @@ function shHide(cmd) {
   const posix = cmd
     .replace(/"((?:[A-Za-z]:)?[^"]*)"/g, (m, p) => JSON.stringify(toMsys(p)))
     .replace(/(^|\s)tar(\s)/g, `$1tar${wildcards}$2`);
-  execFileSync('sh', ['-c', posix], { stdio: ['ignore', 'ignore', 'inherit'] });
+  execFileSync(sh, ['-c', posix], { stdio: ['ignore', 'ignore', 'inherit'] });
 }
 
 /**

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -55,9 +55,15 @@ function resolveRef(repoSlug, ref) {
   }).trim();
 }
 function shHide(cmd) {
-  // Windows (msys) compatibility: GNU tar treats `C:\` drive letters as remote
-  // hosts and does not glob by default, so quoted Windows paths are converted
-  // to /c/... and tar gets --wildcards. No-op on POSIX paths / Linux.
+  // Windows (msys) compatibility ONLY. On win32, msys GNU tar treats `C:\`
+  // drive letters as remote hosts and does not glob by default, so quoted
+  // Windows paths are converted to /c/... and tar gets --wildcards. On POSIX
+  // (incl. macOS BSD/libarchive tar) the command runs UNCHANGED — no
+  // GNU-only flags are injected, so other platforms keep upstream behavior.
+  if (process.platform !== 'win32') {
+    execFileSync('sh', ['-c', cmd], { stdio: ['ignore', 'ignore', 'inherit'] });
+    return;
+  }
   const toMsys = (p) => p.replace(/^([A-Za-z]):[\\/]/, (_, d) => `/${d.toLowerCase()}/`).replace(/\\/g, '/');
   const posix = cmd
     .replace(/"((?:[A-Za-z]:)?[^"]*)"/g, (m, p) => JSON.stringify(toMsys(p)))

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -55,7 +55,14 @@ function resolveRef(repoSlug, ref) {
   }).trim();
 }
 function shHide(cmd) {
-  execFileSync('sh', ['-c', cmd], { stdio: ['ignore', 'ignore', 'inherit'] });
+  // Windows (msys) compatibility: GNU tar treats `C:\` drive letters as remote
+  // hosts and does not glob by default, so quoted Windows paths are converted
+  // to /c/... and tar gets --wildcards. No-op on POSIX paths / Linux.
+  const toMsys = (p) => p.replace(/^([A-Za-z]):[\\/]/, (_, d) => `/${d.toLowerCase()}/`).replace(/\\/g, '/');
+  const posix = cmd
+    .replace(/"((?:[A-Za-z]:)?[^"]*)"/g, (m, p) => JSON.stringify(toMsys(p)))
+    .replace(/(^|\s)tar(\s)/g, '$1tar --wildcards$2');
+  execFileSync('sh', ['-c', posix], { stdio: ['ignore', 'ignore', 'inherit'] });
 }
 
 /**
@@ -126,7 +133,9 @@ function computeLeafClosure(repoTmp) {
     }
   }
   for (const s of SEEDS) walk(path.join(repoTmp, s));
-  return [...visited].map((f) => path.relative(repoTmp, f)).sort();
+  // Normalize separators: on win32 path.relative emits '\', and the 'src/'
+  // prefix filter below is POSIX-separator based.
+  return [...visited].map((f) => path.relative(repoTmp, f).split(path.sep).join('/')).sort();
 }
 
 /** Rewrite all bare/aliased imports for a generated file at `genRelFromGenRoot`. */
@@ -319,6 +328,10 @@ function applyLocalPatches(relDest, raw) {
 }
 
 function writeGen(relDest, raw, srcLabel, hashes, appliedPatches) {
+  // Normalize to POSIX separators: LOCAL_PATCHES keys and the lock's patch
+  // records use '/', but path.join on win32 emits '\' — without this the
+  // patches silently never match on Windows.
+  relDest = relDest.replace(/\\/g, '/');
   const { patched, applied } = applyLocalPatches(relDest, raw);
   if (appliedPatches) appliedPatches.push(...applied);
   const dest = path.join(genRoot, relDest);

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -86,7 +86,14 @@ function shHide(cmd) {
   // options as fatal errors (Greptile P1 round 1). bsdtar matches extraction
   // paths as shell-style patterns natively, so no flag is needed there.
   const wildcards = isGnuTar() ? ' --wildcards' : '';
-  const toMsys = (p) => p.replace(/^([A-Za-z]):[\\/]/, (_, d) => `/${d.toLowerCase()}/`).replace(/\\/g, '/');
+  const toMsys = (p) =>
+    p
+      // Collapse JSON-escaped double backslashes FIRST: converting each `\\`
+      // separately would emit doubled separators like /c//Users//foo
+      // (Copilot P1, round 2).
+      .replace(/\\\\/g, '\\')
+      .replace(/^([A-Za-z]):[\\/]/, (_, d) => `/${d.toLowerCase()}/`)
+      .replace(/\\/g, '/');
   const posix = cmd
     .replace(/"((?:[A-Za-z]:)?[^"]*)"/g, (m, p) => JSON.stringify(toMsys(p)))
     .replace(/(^|\s)tar(\s)/g, `$1tar${wildcards}$2`);

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -63,8 +63,18 @@ function isGnuTar() {
   if (!gnuTarChecked) {
     gnuTarChecked = true;
     try {
+      // Probe tar in the SAME environment that will execute it: on win32 the
+      // Node process PATH may resolve `tar` to System32\bsdtar while the Git
+      // sh resolves GNU tar — probing through the resolved sh keeps
+      // detection and execution consistent (Greptile P1 + codex-connector
+      // P1, round 4).
+      const sh = resolvePosixShell('sh');
+      if (!sh) throw new Error('no sh resolved');
       gnuTar = /GNU tar/i.test(
-        execFileSync('tar', ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }),
+        execFileSync(sh, ['-c', 'tar --version'], {
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }),
       );
     } catch {
       gnuTar = false;

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -95,7 +95,8 @@ function shHide(cmd) {
   const sh = resolvePosixShell('sh');
   if (!sh) {
     throw new Error(
-      'sync: 找不到可用的 sh（未检测到 Git for Windows）。请安装 Git for Windows 后重试。',
+      'sync: could not locate a usable sh (Git for Windows not detected). ' +
+        'Install Git for Windows and retry.',
     );
   }
   if (process.platform !== 'win32') {

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -54,6 +54,23 @@ function resolveRef(repoSlug, ref) {
     stdio: ['ignore', 'pipe', 'inherit'],
   }).trim();
 }
+/** Whether the `tar` on PATH is GNU tar (msys/GNU accept `--wildcards`;
+ * bsdtar/libarchive — the Windows/macOS system default — rejects it). */
+let gnuTarChecked = false;
+let gnuTar = false;
+function isGnuTar() {
+  if (!gnuTarChecked) {
+    gnuTarChecked = true;
+    try {
+      gnuTar = /GNU tar/i.test(
+        execFileSync('tar', ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }),
+      );
+    } catch {
+      gnuTar = false;
+    }
+  }
+  return gnuTar;
+}
 function shHide(cmd) {
   // Windows (msys) compatibility ONLY. On win32, msys GNU tar treats `C:\`
   // drive letters as remote hosts and does not glob by default, so quoted
@@ -64,10 +81,15 @@ function shHide(cmd) {
     execFileSync('sh', ['-c', cmd], { stdio: ['ignore', 'ignore', 'inherit'] });
     return;
   }
+  // Inject --wildcards ONLY when the resolved tar is actually GNU tar: on
+  // win32 the PATH may resolve to the system bsdtar, which treats unsupported
+  // options as fatal errors (Greptile P1 round 1). bsdtar matches extraction
+  // paths as shell-style patterns natively, so no flag is needed there.
+  const wildcards = isGnuTar() ? ' --wildcards' : '';
   const toMsys = (p) => p.replace(/^([A-Za-z]):[\\/]/, (_, d) => `/${d.toLowerCase()}/`).replace(/\\/g, '/');
   const posix = cmd
     .replace(/"((?:[A-Za-z]:)?[^"]*)"/g, (m, p) => JSON.stringify(toMsys(p)))
-    .replace(/(^|\s)tar(\s)/g, '$1tar --wildcards$2');
+    .replace(/(^|\s)tar(\s)/g, `$1tar${wildcards}$2`);
   execFileSync('sh', ['-c', posix], { stdio: ['ignore', 'ignore', 'inherit'] });
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

`scripts/browser-runtime/sync.mjs`（vendored 同步脚本）此前在 Windows 上无法运行，导致维护者在 Windows 上无法重新生成 `_generated/**`：

1. **msys GNU tar 路径与 glob 兼容**：GNU tar 把 `C:` 盘符路径当成远程主机（`host:path`），且默认关闭通配符匹配。修复为把引号内的 Windows 路径转换为 `/c/...` 形式并给 tar 传 `--wildcards`。
2. **path.sep 归一化**：`path.join` 在 win32 上输出反斜杠，导致 `LOCAL_PATCHES` 的 key（POSIX 正斜杠）永远匹配不上、leaf 的 `src/` 前缀过滤把全部 leaf 文件过滤掉。修复为统一转成 POSIX 分隔符。

**关键性质：不改变任何生成产物**——重新生成后 `contentHash` 与既有 lock 完全一致（`--check` 通过），无 `_generated` / lock 变更。

### 变更类型

- [x] `chore` 工程维护

### 范围

- 关联 Issue / 需求：无（从 PR #1803 拆分出的独立修复，维护者建议降低核心安全改动评审成本）
- 本 PR 包含：`scripts/browser-runtime/sync.mjs` 3 处 Windows 兼容修复（无产物变化）
- 明确不包含：`previewLocalHtml` 功能与 SSRF allowedOrigins 接线（在 PR #1803）
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及：无 UI 代码路径。

## 怎么验证的

### 自动验证

```text
node scripts/browser-runtime/sync.mjs --check
# [browser-runtime] lock is up to date (contentHash + counts match).
# contentHash=1bc2c6ddddf7（与既有 lock 完全一致，无产物变化）
```

Windows 10（git bash/msys）实测可完整跑通 `sync.mjs`（下载 tarball → 解压 → 应用 LOCAL_PATCHES → 生成 335 个文件）。

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [ ] 无已知风险（改动仅影响脚本在本机运行时的路径处理；产物逐字节不变，contentHash 已证明）

### 影响与回滚

- 影响范围：仅 `sync.mjs` 在 Windows 本地运行；CI（Linux）路径行为不变（修复对 POSIX 路径为 no-op）
- 回滚 / 降级方式：回退本 commit 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因