### PR TITLE
fix(desktop): 同 socket 降级回落时缴械遗留的 turn.delivery 退避 timer

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -1824,6 +1824,46 @@ describe('dispatcher 核心语义', () => {
     }
   });
 
+  it('同 socket 能力降级且回落发送失败 -> 旧退避 timer 被缴械, 不再向老 server 重放', async () => {
+    vi.useFakeTimers();
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({ runner: fr.runner });
+    const c = collector();
+    try {
+      d.onConnected('conn-1', c.send, [HOOK_FEATURE_TURN_DELIVERY]);
+      d.handleDispatch('conn-1', dispatch(), c.send);
+      await tick();
+      fr.finish({ finalText: '降级前完成' });
+      await tick();
+      expect(c.ofType('turn.end')).toHaveLength(1); // ACK 世代已发送并武装退避 timer
+
+      // 同一 socket 上 welcome 重新协商为无 ACK(refreshHello), 不经过
+      // onDisconnected; 回落补发这一次恰好发送失败。
+      let sendable = false;
+      const downgraded: HookMessage[] = [];
+      d.onConnected('conn-1', (message) => {
+        if (!sendable) return false;
+        downgraded.push(message);
+        return true;
+      });
+
+      // 旧 timer 若未被缴械, 到点会经 sendFns 向老 server 重放 turn.end。
+      sendable = true;
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(downgraded).toHaveLength(0);
+
+      // 条目仍保留, 下次重连按当次协商结果正常收口。
+      const recovered = collector();
+      d.onConnected('conn-1', recovered.send);
+      expect(recovered.ofType('turn.end')).toHaveLength(1);
+      await vi.advanceTimersByTimeAsync(600_000);
+      expect(recovered.ofType('turn.end')).toHaveLength(1);
+    } finally {
+      d.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it('ACK 模式重投终态 -> 回放经 ACK 缓冲退避重发, 账本保持 pending 直到回执', async () => {
     vi.useFakeTimers();
     const terminalLedger = memoryTerminalLedger();

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -2207,7 +2207,17 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         if (pending.connectionId !== connectionId) continue;
         if (deliveryAck) {
           sendPendingDelivery(key, pending, send);
-        } else if (send(pending.message)) {
+          continue;
+        }
+        // 同 socket 能力降级(refreshHello/welcome 重新协商为无 ACK)不经过
+        // onDisconnected, ACK 世代武装的退避 timer 可能仍在计时; 若下面这次
+        // 回落发送恰好失败, 到点的 timer 会向永远不回 turn.delivery 的老
+        // server 无限重放。进入无 ACK 世界先无条件缴械。
+        if (pending.timer) {
+          clearTimeout(pending.timer);
+          pending.timer = null;
+        }
+        if (send(pending.message)) {
           // 滚动发布回落到老 server：按历史 fire-and-forget 语义收口。
           clearPendingDelivery(key);
         }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #1794 引入的 X hook 送达确认(turn.delivery)机制在「同 socket 能力降级」场景下的退避 timer 泄漏:滚动发布时同一连接经 refreshHello/welcome 重新协商为不含 `turn-delivery-v1` 的老服务端,不经过 `onDisconnected`(该路径会清 timer);若回落补发的那次 `send` 恰好失败,ACK 世代武装的退避 timer 仍在计时,到点后会向永远不回 `turn.delivery` 的老服务端按 ≤60 秒周期无限重放同一条 turn.end,老服务端可能表现为重复的 X 公开回复。

修复:`onConnected` 的无 ACK 回落分支进入时,无条件先缴械该条目的遗留 timer;条目本身保留,由后续重连按当次协商结果正常收口(与既有语义一致)。

该问题由 #1794 合并前的深度审查发现并记录于 https://github.com/makecindy/cindy/pull/1794#issuecomment-5190462156,按当时的统筹计划作为合并后独立 follow-up 处理,即本 PR。计划中的可选项「pendingDeliveryTurnEnds 与持久账本融合为单一送达状态机」经评估不在本 PR 做:两套机制在 #1784 的组合语义下各司其职且回归充分,融合属纯结构重构,无正确性收益,不再另开 PR。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#1794 审查遗留 P2(见上述评论)
- 本 PR 包含:`dispatcher.ts` onConnected 回落分支的 timer 缴械(1 处)+ 回归测试(1 个)。
- 明确不包含:重试策略、协商机制、账本语义的任何变化;融合重构(理由见摘要)。
- 用户可见变化:无(仅消除一个窄窗口下的重复发送风险)。
- 是否存在 breaking change:无。

### UI 变化

不涉及:仅 main 侧 hook 传输逻辑。

- 引用的设计规范:不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/hook-control/__tests__/dispatcher.test.ts
结果:120 passed(含新增回归「同 socket 能力降级且回落发送失败 -> 旧退避 timer 被缴械, 不再向老 server 重放」)

负向验证:仅暂存 dispatcher.ts 修复后重跑,恰好该新用例失败(119/120),证明用例钉住缺陷。

pnpm --filter desktop run --if-present typecheck
结果:通过(exit 0)

bash run-unit-gate.sh(根 pnpm test:unit)
结果:GATE_EXIT=0

pnpm check:dco
结果:通过
```

### 手工验证

不涉及:窄窗口传输竞态由 fake-timers 回归测试覆盖,不使用真实 X 账号。

### 未执行的验证

未做真实滚动发布降级演练;窗口条件(同 socket 降级 + 回落 send 失败)已由测试精确模拟。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 X hook 的 ACK→无 ACK 回落路径;正常 ACK 路径与 Slack/Telegram 不受影响。
- 回滚 / 降级方式:revert 本提交即可,无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(行为以代码注释与测试为文档)
- [x] 已确认测试结果或说明未执行原因
