### PR TITLE
chore(ci): 更新 code review workflow pin

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -69,7 +69,7 @@ jobs:
     #
     # 已知残余风险(有意接受,不是疏漏):钉这一行锁住的是「跑哪份 workflow 文件、
     # 什么 prompt、什么权限声明、什么工具白名单」,锁不住「该文件在运行期拉取
-    # 并执行哪个版本的 action」。截至 a9cbd87,被调用文件内部是两个浮动 tag——
+    # 并执行哪个版本的 action」。截至 2dd773f,被调用文件内部是两个浮动 tag——
     # actions/checkout@v6 与 anthropics/claude-code-action@v1——它们运行在持有
     # ANTHROPIC_API_KEY 与 pull-requests:write 的 job 里。
     # 接受的理由:这两个分别是 GitHub 与 Anthropic 的第一方 action,tag 被恶意
@@ -78,7 +78,7 @@ jobs:
     # 真正的修法在上游:让 krosdai/.github 把内部 action 钉到 SHA,本仓再 re-pin
     # 到新的上游 SHA。届时删掉本段注释。
     # 背景见 PR #985 与安全门 issue #999。
-    uses: krosdai/.github/.github/workflows/code-review.yml@a9cbd870b6303a498ea341b7b6bd0e8c39e66922 # v1
+    uses: krosdai/.github/.github/workflows/code-review.yml@2dd773f8a3e85c10f09286053850e453de64bbe3 # v1
     with:
       pr_number: ${{ github.event.pull_request.number }}
       is_draft: ${{ github.event.pull_request.draft }}

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -69,7 +69,7 @@ jobs:
     #
     # 已知残余风险(有意接受,不是疏漏):钉这一行锁住的是「跑哪份 workflow 文件、
     # 什么 prompt、什么权限声明、什么工具白名单」,锁不住「该文件在运行期拉取
-    # 并执行哪个版本的 action」。截至 0838103,被调用文件内部是两个浮动 tag——
+    # 并执行哪个版本的 action」。截至 a9cbd87,被调用文件内部是两个浮动 tag——
     # actions/checkout@v6 与 anthropics/claude-code-action@v1——它们运行在持有
     # ANTHROPIC_API_KEY 与 pull-requests:write 的 job 里。
     # 接受的理由:这两个分别是 GitHub 与 Anthropic 的第一方 action,tag 被恶意
@@ -78,7 +78,7 @@ jobs:
     # 真正的修法在上游:让 krosdai/.github 把内部 action 钉到 SHA,本仓再 re-pin
     # 到新的上游 SHA。届时删掉本段注释。
     # 背景见 PR #985 与安全门 issue #999。
-    uses: krosdai/.github/.github/workflows/code-review.yml@0838103fffe7d4c38247050098defc8ae47b8355 # v1
+    uses: krosdai/.github/.github/workflows/code-review.yml@a9cbd870b6303a498ea341b7b6bd0e8c39e66922 # v1
     with:
       pr_number: ${{ github.event.pull_request.number }}
       is_draft: ${{ github.event.pull_request.draft }}


### PR DESCRIPTION
## 这次改了什么

### 摘要

将 `krosdai/.github` 的 reusable code-review workflow pin 前移到 upstream `v1` 当前指向的 commit `2dd773f8a3e85c10f09286053850e453de64bbe3`，并同步更新附近的短 SHA 注释。该上游版本会读取 downstream 默认分支的 `REVIEW.md`，并在审阅策略冲突时以 downstream policy 为准。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：更新 `.github/workflows/pr-code-review.yml` 的 upstream workflow pin
- 明确不包含：上游 reusable workflow 内容或其内部 action pin 的修改
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
env TZ=UTC TMPDIR=/var/tmp/cindy-forward-pr-code-review-tests mise x node@24 -- pnpm test:unit
结果：通过，全部 required unit workspaces PASS。

pnpm check:dco
结果：通过，2 个 commit 已 sign off。

git diff --check
结果：通过。
```

### 手工验证

- 重新查询 upstream `refs/tags/v1`，确认仍指向 `2dd773f8a3e85c10f09286053850e453de64bbe3`。
- 检查该 commit 下的 reusable workflow，确认它读取 downstream 默认分支 commit 对应的 `REVIEW.md`，并明确赋予 downstream policy 优先级。
- 确认现有残余风险注释仍准确：内部继续使用 `actions/checkout@v6` 与 `anthropics/claude-code-action@v1`。

### 未执行的验证

- package typecheck：不涉及任何 package，仅修改 GitHub Actions workflow。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：PR code-review job 将执行 upstream `v1` 当前版本；调用方权限和 secrets 接口不变。
- 回滚 / 降级方式：将 `uses:` pin 还原为 `0838103fffe7d4c38247050098defc8ae47b8355`。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [ ] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
