### PR TITLE
fix(desktop): show Windows tray menu reliably

### DIFF
--- a/apps/desktop/src/main/__tests__/windowsTrayLifecycle.test.ts
+++ b/apps/desktop/src/main/__tests__/windowsTrayLifecycle.test.ts
@@ -7,6 +7,7 @@ import {
   requestWindowsTrayQuit,
   type WindowsClosePromptWindow,
   type WindowsTrayMenuHost,
+  type WindowsTrayPopupMenu,
   type WindowsTrayWindow,
 } from '../windowsTrayLifecycle';
 
@@ -153,23 +154,27 @@ describe('Windows tray lifecycle', () => {
 });
 
 /** Tray fake for the JS-driven menu popup (`setContextMenu` is deliberately unused). */
-function makeTrayMenuHost(): WindowsTrayMenuHost<object> & { destroyed: boolean } {
+function makeTrayMenuHost(): WindowsTrayMenuHost & { destroyed: boolean } {
   return {
     destroyed: false,
     isDestroyed() {
       return this.destroyed;
     },
-    popUpContextMenu: vi.fn(),
   };
+}
+
+function makePopupMenu(id: string): WindowsTrayPopupMenu & { id: string } {
+  return { id, popup: vi.fn() };
 }
 
 describe('Windows tray menu popup', () => {
   it('builds the menu on first popup and keeps it referenced for the next one', () => {
     const tray = makeTrayMenuHost();
-    const built = { id: 'built' };
+    const built = makePopupMenu('built');
     const buildMenu = vi.fn(() => built);
-    let retained: object | null = null;
-    const retainMenu = vi.fn((menu: object) => {
+    let retained: typeof built | null = null;
+    const activeMenus = new Set<WindowsTrayPopupMenu>();
+    const retainMenu = vi.fn((menu: typeof built) => {
       retained = menu;
     });
 
@@ -179,40 +184,60 @@ describe('Windows tray menu popup', () => {
         menu: retained,
         buildMenu,
         retainMenu,
+        retainActiveMenu: (menu) => activeMenus.add(menu),
+        releaseActiveMenu: (menu) => activeMenus.delete(menu),
         onUnavailable: vi.fn(),
         onError: vi.fn(),
       }),
     ).toBe(true);
     expect(buildMenu).toHaveBeenCalledTimes(1);
     expect(retained).toBe(built);
+    expect(activeMenus.has(built)).toBe(true);
+    const firstPopupOptions = vi.mocked(built.popup).mock.calls[0][0];
+    expect(firstPopupOptions).toEqual({ callback: expect.any(Function) });
+    expect(firstPopupOptions).not.toHaveProperty('window');
+    expect(firstPopupOptions).not.toHaveProperty('x');
+    expect(firstPopupOptions).not.toHaveProperty('y');
+    firstPopupOptions.callback();
+    expect(activeMenus.has(built)).toBe(false);
 
-    // 第二次右键复用同一个菜单对象: 弹出期间必须一直有 JS 引用,不能每次交出新对象。
+    // 第二次右键复用同一个菜单对象。
     expect(
       popUpWindowsTrayMenu({
         tray,
         menu: retained,
         buildMenu,
         retainMenu,
+        retainActiveMenu: (menu) => activeMenus.add(menu),
+        releaseActiveMenu: (menu) => activeMenus.delete(menu),
         onUnavailable: vi.fn(),
         onError: vi.fn(),
       }),
     ).toBe(true);
     expect(buildMenu).toHaveBeenCalledTimes(1);
-    expect(tray.popUpContextMenu).toHaveBeenNthCalledWith(1, built);
-    expect(tray.popUpContextMenu).toHaveBeenNthCalledWith(2, built);
+    expect(built.popup).toHaveBeenCalledTimes(2);
   });
 
-  it('rebuilds the menu after the caller drops it on a language change', () => {
+  it('keeps an open menu alive while rebuilding after a language change', () => {
     const tray = makeTrayMenuHost();
-    const menus = [{ id: 'zh-CN' }, { id: 'en' }];
-    const buildMenu = vi.fn(() => menus.shift() ?? { id: 'exhausted' });
+    const menus = [makePopupMenu('zh-CN'), makePopupMenu('en')];
+    const buildMenu = vi.fn(() => menus.shift() ?? makePopupMenu('exhausted'));
     const retainMenu = vi.fn();
+    const activeMenus = new Set<WindowsTrayPopupMenu>();
+    const retainActiveMenu = (menu: WindowsTrayPopupMenu): void => {
+      activeMenus.add(menu);
+    };
+    const releaseActiveMenu = (menu: WindowsTrayPopupMenu): void => {
+      activeMenus.delete(menu);
+    };
 
     popUpWindowsTrayMenu({
       tray,
       menu: null,
       buildMenu,
       retainMenu,
+      retainActiveMenu,
+      releaseActiveMenu,
       onUnavailable: vi.fn(),
       onError: vi.fn(),
     });
@@ -222,17 +247,22 @@ describe('Windows tray menu popup', () => {
       menu: null,
       buildMenu,
       retainMenu,
+      retainActiveMenu,
+      releaseActiveMenu,
       onUnavailable: vi.fn(),
       onError: vi.fn(),
     });
 
     expect(buildMenu).toHaveBeenCalledTimes(2);
-    expect(retainMenu.mock.calls).toEqual([[{ id: 'zh-CN' }], [{ id: 'en' }]]);
-    expect(tray.popUpContextMenu).toHaveBeenNthCalledWith(2, { id: 'en' });
+    expect(activeMenus.size).toBe(2);
+    for (const [menu] of retainMenu.mock.calls) {
+      vi.mocked(menu.popup).mock.calls[0][0].callback();
+    }
+    expect(activeMenus.size).toBe(0);
   });
 
   it('reports a missing tray icon without building a menu', () => {
-    const buildMenu = vi.fn(() => ({}));
+    const buildMenu = vi.fn(() => makePopupMenu('unused'));
     const onUnavailable = vi.fn();
 
     expect(
@@ -241,6 +271,8 @@ describe('Windows tray menu popup', () => {
         menu: null,
         buildMenu,
         retainMenu: vi.fn(),
+        retainActiveMenu: vi.fn(),
+        releaseActiveMenu: vi.fn(),
         onUnavailable,
         onError: vi.fn(),
       }),
@@ -253,7 +285,7 @@ describe('Windows tray menu popup', () => {
   it('reports a destroyed tray icon without building a menu', () => {
     const tray = makeTrayMenuHost();
     tray.destroyed = true;
-    const buildMenu = vi.fn(() => ({}));
+    const buildMenu = vi.fn(() => makePopupMenu('unused'));
     const onUnavailable = vi.fn();
 
     expect(
@@ -262,6 +294,8 @@ describe('Windows tray menu popup', () => {
         menu: null,
         buildMenu,
         retainMenu: vi.fn(),
+        retainActiveMenu: vi.fn(),
+        releaseActiveMenu: vi.fn(),
         onUnavailable,
         onError: vi.fn(),
       }),
@@ -269,29 +303,35 @@ describe('Windows tray menu popup', () => {
 
     expect(onUnavailable).toHaveBeenCalledWith('destroyed');
     expect(buildMenu).not.toHaveBeenCalled();
-    expect(tray.popUpContextMenu).not.toHaveBeenCalled();
   });
 
   it('surfaces a failing popup instead of throwing into the tray event handler', () => {
     const tray = makeTrayMenuHost();
     const failure = new Error('popup rejected by the shell');
-    tray.popUpContextMenu = vi.fn(() => {
+    const menu = makePopupMenu('failing');
+    menu.popup = vi.fn(() => {
       throw failure;
     });
     const onError = vi.fn();
+    const retainActiveMenu = vi.fn();
+    const releaseActiveMenu = vi.fn();
 
     expect(
       popUpWindowsTrayMenu({
         tray,
         menu: null,
-        buildMenu: () => ({}),
+        buildMenu: () => menu,
         retainMenu: vi.fn(),
+        retainActiveMenu,
+        releaseActiveMenu,
         onUnavailable: vi.fn(),
         onError,
       }),
     ).toBe(false);
 
     expect(onError).toHaveBeenCalledWith(failure);
+    expect(retainActiveMenu).toHaveBeenCalledWith(menu);
+    expect(releaseActiveMenu).toHaveBeenCalledWith(menu);
   });
 
   it('surfaces a failing menu build', () => {
@@ -307,12 +347,13 @@ describe('Windows tray menu popup', () => {
           throw failure;
         },
         retainMenu: vi.fn(),
+        retainActiveMenu: vi.fn(),
+        releaseActiveMenu: vi.fn(),
         onUnavailable: vi.fn(),
         onError,
       }),
     ).toBe(false);
 
     expect(onError).toHaveBeenCalledWith(failure);
-    expect(tray.popUpContextMenu).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -1797,9 +1797,10 @@ const updatePresentationRecovery = isUpdateRelaunchCandidate
 // 让窗口 close handler 放行真正的销毁。
 let isQuitting = false;
 let windowsTray: Tray | null = null;
-// 当前的托盘菜单。我们自己 popUp(见 popUpWindowsTrayMenu 的注释),菜单对象必须由
-// JS 侧持有,不能只作为实参交出去。语言切换时置 null,下一次右键按新语言重建。
+// 当前的托盘菜单。语言切换时置 null,下一次右键按新语言重建。
 let windowsTrayMenu: Menu | null = null;
+// 已弹出的菜单在 native callback 前必须保留,即使语言切换清掉了当前缓存。
+const activeWindowsTrayMenus = new Set<Menu>();
 const windowsTrayLog = createLogger('windows-tray');
 const WINDOWS_CLOSE_PROMPT_FALLBACK_DELAY_MS = 2_000;
 
@@ -1836,6 +1837,12 @@ function openWindowsTrayMenu(): void {
     buildMenu: buildWindowsTrayMenu,
     retainMenu: (menu) => {
       windowsTrayMenu = menu;
+    },
+    retainActiveMenu: (menu) => {
+      activeWindowsTrayMenus.add(menu);
+    },
+    releaseActiveMenu: (menu) => {
+      activeWindowsTrayMenus.delete(menu);
     },
     onUnavailable: (reason) => {
       windowsTrayLog.warn('tray menu requested without a live tray icon', { reason });

--- a/apps/desktop/src/main/windowsTrayLifecycle.ts
+++ b/apps/desktop/src/main/windowsTrayLifecycle.ts
@@ -28,20 +28,27 @@ export interface WindowsTrayQuitDependencies {
   quit(): void;
 }
 
-/** Tray surface needed to open the tray menu from JS instead of via `setContextMenu`. */
-export interface WindowsTrayMenuHost<TMenu> {
+/** Tray surface needed to confirm the JS-driven menu still has a live icon. */
+export interface WindowsTrayMenuHost {
   isDestroyed(): boolean;
-  popUpContextMenu(menu: TMenu): void;
+}
+
+/** Menu surface used to let Electron choose the native cursor position. */
+export interface WindowsTrayPopupMenu {
+  popup(options: { callback(): void }): void;
 }
 
 /** Dependencies for the JS-driven tray menu popup. */
-export interface WindowsTrayMenuPopupDependencies<TMenu> {
-  tray: WindowsTrayMenuHost<TMenu> | null;
+export interface WindowsTrayMenuPopupDependencies<TMenu extends WindowsTrayPopupMenu> {
+  tray: WindowsTrayMenuHost | null;
   /** Cached menu, or null when it must be (re)built — callers drop it on language change. */
   menu: TMenu | null;
   buildMenu(): TMenu;
   /** Hands the menu back to the caller, which keeps it referenced for the next popup. */
   retainMenu(menu: TMenu): void;
+  /** Keeps an open menu alive even if the cached menu is invalidated. */
+  retainActiveMenu(menu: TMenu): void;
+  releaseActiveMenu(menu: TMenu): void;
   onUnavailable(reason: 'no-tray' | 'destroyed'): void;
   onError(error: unknown): void;
 }
@@ -50,14 +57,12 @@ export interface WindowsTrayMenuPopupDependencies<TMenu> {
  * Open the Windows tray menu ourselves on right-click.
  *
  * ⚠️ 不要改回 `tray.setContextMenu()`。那条路径把弹菜单整个交给 native 侧,
- * 一旦系统那次弹出失败(上游 electron#47421: 前台有全屏应用时右键固定在任务栏的
- * 托盘图标毫无反应),JS 侧既收不到事件也记不下日志,用户就只剩任务管理器可用 ——
- * 这正是 Windows 用户报的 "左键能恢复窗口、右键什么都不弹" 的现象。
+ * 一旦系统那次弹出失败,JS 侧既收不到事件也记不下日志,用户就只剩任务管理器可用。
  * 而且 `setContextMenu` 一旦设置,`right-click` 事件按设计不再 emit
  * (electron#5058,维护者明确说是预期行为),所以两种方式不能并存做双保险:
  * 设了它,这里的兜底就永远不会被触发。
  */
-export function popUpWindowsTrayMenu<TMenu>(
+export function popUpWindowsTrayMenu<TMenu extends WindowsTrayPopupMenu>(
   deps: WindowsTrayMenuPopupDependencies<TMenu>,
 ): boolean {
   const { tray } = deps;
@@ -71,10 +76,22 @@ export function popUpWindowsTrayMenu<TMenu>(
   }
 
   try {
-    // 缓存不只是省一次构建: 菜单对象必须一直有 JS 引用,否则弹出期间被 GC 掉。
     const menu = deps.menu ?? deps.buildMenu();
     deps.retainMenu(menu);
-    tray.popUpContextMenu(menu);
+    let released = false;
+    const releaseMenu = (): void => {
+      if (released) return;
+      released = true;
+      deps.releaseActiveMenu(menu);
+    };
+    deps.retainActiveMenu(menu);
+    try {
+      // Omit window and coordinates so Windows uses the native cursor position.
+      menu.popup({ callback: releaseMenu });
+    } catch (error) {
+      releaseMenu();
+      throw error;
+    }
     return true;
   } catch (error) {
     deps.onError(error);


### PR DESCRIPTION
## 这次改了什么

### 摘要

Open the Windows tray menu through `Menu.popup()` without an owner window or coordinates, allowing Electron to use the native cursor position. Keep each open menu referenced until its close callback runs.

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1817
- 本 PR 包含：Windows tray popup behavior and lifecycle regression tests.
- 明确不包含：Exit confirmation or active-turn detection changes.
- 用户可见变化：Right-clicking the Windows tray icon opens the existing menu reliably.
- 是否存在 breaking change：None.

### UI 变化

No visual or copy changes. Native menu labels and layout are unchanged.

- 引用的设计规范：Not applicable; this changes only the native popup invocation.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/windowsTrayLifecycle.test.ts
Result: 14 tests passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Result: passed.

NODE_OPTIONS="--experimental-webstorage --localstorage-file=/tmp/cindy-localstorage" pnpm test:unit
Result: passed using the repository-supported forks pool.

pnpm check:dco
Result: passed.
```

### 手工验证

Not run; no Windows host was available.

### 未执行的验证

Windows manual verification, for the reason above.

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Windows tray right-click handling only.
- 回滚 / 降级方式：Revert this commit to restore `Tray.popUpContextMenu()`.

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
