### PR TITLE
fix(desktop): preserve Pi agent switch intent echo

### DIFF
--- a/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
@@ -132,6 +132,32 @@ describe('performSessionAgentSwitch', () => {
     );
   });
 
+  it('codex → pi + OpenAI 关闭旧会话并保持目标 provider route', async () => {
+    const { deps, calls } = makeDeps({
+      getSessionRow: vi.fn(async () =>
+        makeRow({ agentKind: 'codex', model: 'gpt-5.5-codex', sdkSessionId: 'codex-thread' }),
+      ),
+    });
+
+    const result = await performSessionAgentSwitch(deps, {
+      sessionId: 's1',
+      targetAgentKind: 'pi',
+      model: 'chatgpt/gpt-5.5',
+      providerId: 'openai',
+      applyNow: true,
+    });
+
+    expect(result).toMatchObject({ switched: true, agentKind: 'pi', engineReady: true });
+    expect(calls).toEqual(['close', 'db', 'provider', 'boundary', 'pending', 'bootstrap']);
+    expect(deps.applyAgentSwitchToDb).toHaveBeenCalledWith('s1', {
+      agentKind: 'pi',
+      model: 'chatgpt/gpt-5.5',
+      providerId: 'openai',
+      sdkSessionId: null,
+    });
+    expect(deps.setSessionProvider).toHaveBeenCalledWith('s1', 'openai');
+  });
+
   it('跨引擎 DB 提交后立即覆盖旧 provider route', async () => {
     const { deps } = makeDeps();
 

--- a/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
+++ b/apps/desktop/src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts
@@ -116,6 +116,31 @@ describe('makerChatStore.mirrorAgentSwitchIntent', () => {
     expect(makerChatStore.getSnapshot(s)).toBe(snap); // 引用不变 = 未触发更新
   });
 
+  it('回归:Pi 权威回声不得被当成非法值清掉切换意图', async () => {
+    const { makerChatStore } = await import('@/lib/makerChatStore');
+    const s = sid();
+    makerChatStore.noteAgentSwitchIntent(s, 'pi', {
+      model: 'chatgpt/gpt-5.5',
+      providerId: 'openai',
+    });
+    const snap = makerChatStore.getSnapshot(s);
+
+    makerChatStore.mirrorAgentSwitchIntent(s, {
+      targetAgentKind: 'pi',
+      model: 'chatgpt/gpt-5.5',
+      providerId: 'openai',
+    });
+
+    expect(makerChatStore.getSnapshot(s)).toBe(snap);
+    expect(makerChatStore.getSnapshot(s).agentSwitchIntent).toEqual({
+      target: 'pi',
+      model: 'chatgpt/gpt-5.5',
+      providerId: 'openai',
+      effort: undefined,
+      fastMode: undefined,
+    });
+  });
+
   it('null / 非法值 = 无意图 → 清除', async () => {
     const { makerChatStore } = await import('@/lib/makerChatStore');
     const s = sid();

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -13310,7 +13310,12 @@ function getAgentSwitchIntentRev(sessionId: string): number {
 function normalizeAgentSwitchIntent(value: unknown): AgentSwitchIntentRecord | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const item = value as Record<string, unknown>;
-  if (item.targetAgentKind !== 'claude-code' && item.targetAgentKind !== 'codex') return null;
+  if (
+    item.targetAgentKind !== 'claude-code' &&
+    item.targetAgentKind !== 'codex' &&
+    item.targetAgentKind !== 'pi'
+  )
+    return null;
   if (typeof item.model !== 'string' || item.model.length === 0) return null;
   // providerId 缺失按 null(与 main projectPendingAgentSwitchIntent 的 `?? null` 对齐);
   // 只有出现非 string / 非空值的脏值才判非法,避免协议演进时静默丢掉合法意图。


### PR DESCRIPTION
## 这次改了什么

### 摘要

跨引擎切换已经正式支持 Pi，但 renderer 在镜像 main 侧权威切换意图时仍只接受 `claude-code` 与 `codex`。因此 Codex + OpenAI 切换到 Pi + OpenAI 后，合法的 `targetAgentKind: pi` 回显会被当成非法值，清空本地 pending intent，造成多窗口/远程回显与实际切换状态失配。

本 PR 将 `pi` 补入该归一化边界，并增加旧实现可稳定打红的回归测试；同时固定 Codex → Pi + OpenAI 控制流会关闭旧会话、保持目标 provider route，并完成新 Pi bootstrap。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1851
- 本 PR 包含：允许 renderer 接受 Pi 的权威切换意图回显；补充 Pi 回显幂等回归测试；补充 Codex → Pi + OpenAI provider route 控制流测试。
- 明确不包含：不禁用 Codex → Pi，不强制新建 session，不修改 Pi 出站 TLS/SNI、系统代理或通用 terminal drain/超时逻辑。
- 用户可见变化：切换到 Pi 后，权威回显不再错误清空 pending intent；切换状态可保持一致并继续由现有 Pi lazy-create/恢复链处理。
- 是否存在 breaking change：无。

### UI 变化

不涉及：仅修改 renderer 状态归一化逻辑与单元测试，没有视觉、交互或文案变化。

- 引用的设计规范：不涉及：纯状态逻辑修复，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/sessionAgentSwitchRemoteRouting.test.ts src/main/maker-ipc/__tests__/sessionAgentSwitchHandler.test.ts
结果：2 files passed，92 tests passed。

pnpm test:unit
结果：通过；全部 required unit workspaces PASS。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm check:dco
结果：通过；1 个提交已签署。

git diff --check
结果：通过。

node ~/.agents/skills/git-workflow/scripts/pr-size-gate.mjs
结果：PASS；非测试 +6 行 / 1 文件，测试 +51 行 / 2 文件。
```

定位阶段还完成：

- Pi agent integration：30 passed，1 skipped。
- Desktop outbound proxy resolver/fetch 模拟覆盖：63 tests passed。
- anthropic-compat proxy outbound/SOCKS 模拟覆盖：45 tests passed。

### 手工验证

- macOS Apple Silicon，本地无系统代理环境。
- 使用仓库固定的 Pi 0.83.0 runtime 与真实 OpenAI Responses bridge，Pi + OpenAI 连续两轮成功，最终状态回到 idle。
- 用假上游持续返回 `502 proxy_error` / `TLSV1_ALERT_UNRECOGNIZED_NAME`，确认 Pi 完成 terminal error 与 `agent_settled`；同一 Pi 进程的下一条消息可恢复成功。
- 对照 main 与 0.1.31：相关 Pi pin 与核心切换路径一致；本次定位到的差异来自 renderer 对 Pi 权威回显的遗漏。

### 未执行的验证

- 未在报告人的真实 HTTP/SOCKS/PAC 环境复现；本机系统代理均关闭，代理覆盖仅为模拟测试。
- 尚无证据确认报告中的 502/TLS/SNI 是 Cindy 出站路由问题，因此本 PR 不宣称修复该网络根因，也未修改网络路由。
- 未运行 0.1.31 正式包的完整 GUI 对照矩阵；已完成源码对照、真实 Pi/OpenAI 两轮与故障恢复诊断。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop renderer 的 agent switch intent 镜像归一化；仅新增已被 main 正式支持的 `pi` 值。
- 回滚 / 降级方式：回退本提交即可；不会迁移或改写用户数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

