### PR TITLE
fix(desktop): 提问导航条预览卡竖向划过不再闪断，动效时长改走 token

### DIFF
--- a/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageNavRail.tsx
@@ -36,7 +36,7 @@ import { useCallback, useEffect, useRef, useState, type WheelEvent as ReactWheel
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
-import { Tip } from '@/components/ui/tooltip';
+import { Tooltip } from '@/components/ui/tooltip';
 
 import { useNavigationKeyListener } from './useNavigationKeyListener';
 import {
@@ -382,7 +382,9 @@ export function MessageNavRail({
       // 刻度组在(避开输入 overlay 的)带内垂直居中。
       className={cn(
         'pointer-events-none absolute inset-y-0 left-2 z-30 flex w-6 flex-col items-stretch justify-center',
-        'transition-opacity duration-200 ease-out',
+        // §14.4 禁硬编码 duration / cubic-bezier。不透明度变化属 fast 档
+        // (150ms);原先是 Tailwind 的 duration-200 + ease-out。
+        'transition-opacity duration-[var(--motion-fast)] ease-[var(--motion-ease-out)]',
         awake ? 'opacity-100' : NAV_RAIL_IDLE_OPACITY_CLASS,
       )}
       style={{ paddingTop: RAIL_TOP_PX, paddingBottom: bottomOffset + RAIL_BOTTOM_EXTRA_PX }}
@@ -390,111 +392,136 @@ export function MessageNavRail({
       // "更早还有 N 条"占位刻度一并覆盖。
       onWheel={handleRailWheel}
     >
-      {plan.hiddenCount > 0 ? (
-        <Tip
-          text={t('chat.messageNavRail.hiddenEarlier', { count: plan.hiddenCount })}
-          side="right"
-          delay={150}
-        >
-          <div
-            className={cn('flex items-center justify-center', tickEvents)}
-            style={{ height: plan.pitchPx }}
-            onMouseEnter={handleTickMouseEnter}
-            onMouseLeave={handleTickMouseLeave}
-          >
-            <span
-              aria-hidden="true"
-              className="text-[9px] leading-none text-[var(--text-tertiary)]"
-            >
-              ⋯
-            </span>
-          </div>
-        </Tip>
-      ) : null}
-      {shown.map((entry, i) => {
-        // 纯附件且无文件名的提问用 i18n 计数文案兜底(模型层不碰 i18n)。
-        const preview =
-          entry.preview ||
-          (entry.attachmentsOnly
-            ? t('chat.messageNavRail.attachmentOnly', { count: entry.attachmentsOnly })
-            : '');
-        const isActive = entry.id === displayActiveId;
-        const fullIdx = plan.startIndex + i;
-        // 该轮次的内容当前正显示在视口里 → 提亮(Codex 同款"屏上内容高亮");
-        // 当前项在提亮之上再加长,两个信号分工:范围 = 在看什么,长刻度 = 读到哪。
-        const inView = rangeStartIdx >= 0 && fullIdx >= rangeStartIdx && fullIdx <= rangeEndIdx;
-        return (
-          <Tip
-            key={entry.id}
-            // 预览卡 = 提问(加粗一行)+ 回答摘要(灰字,至多 3 行)。
-            // 摘要是识别的主载体:大量提问是"继续 / 重来"式短指令,只靠
-            // 提问认不出是哪一轮。回答未产生时只显示提问行。
-            text={
-              preview ? (
-                <span className="flex max-w-[344px] flex-col gap-1">
-                  <span className="truncate text-13 font-medium">{preview}</span>
-                  {entry.answerExcerpt ? (
-                    // 摘要 = 主文字色 × 50% 透明度,不引新 token。数值由多轮
-                    // 实机验收夹逼、最终用户直接指定(2026-07-28)。注意半透明
-                    // 文字经抗锯齿合成会比同亮度实心灰**显得更亮**,别拿色值
-                    // 计算器推这个数,调整必须实机看效果。
-                    <span className="line-clamp-3 whitespace-normal break-normal text-13 leading-relaxed opacity-50">
-                      {entry.answerExcerpt}
-                    </span>
-                  ) : null}
+      {/*
+       * 整条导轨共用一个 Provider。原先每根刻度包一层 <Tip>,而 Tip 内部是
+       * 无条件自带 <TooltipProvider> 的 —— 而 skipDelayDuration 是 **Provider
+       * 级**状态,跨刻度就是跨 Provider,新 Provider 没有"刚刚开过"的记忆,于是
+       * 每根都重新等满 delay。刻度纵距只有 9px,鼠标竖着划过去是连续闪断。
+       * 换成 primitives 挂在一个 Provider 下:首次 hover 等 150ms,之后 700ms 内
+       * 切到相邻刻度立即显示,竖向移动时预览卡只换内容、不中断。
+       * (在 <Tip> 外面套一层 Provider 没用 —— 内层会把外层遮住。)
+       */}
+      <Tooltip.Provider delayDuration={150} skipDelayDuration={700}>
+        {plan.hiddenCount > 0 ? (
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <div
+                className={cn('flex items-center justify-center', tickEvents)}
+                style={{ height: plan.pitchPx }}
+                onMouseEnter={handleTickMouseEnter}
+                onMouseLeave={handleTickMouseLeave}
+              >
+                <span
+                  aria-hidden="true"
+                  className="text-[9px] leading-none text-[var(--text-tertiary)]"
+                >
+                  ⋯
                 </span>
-              ) : null
-            }
-            side="right"
-            delay={150}
-            // 面色刻意不用全局 tooltip token(亮暗两模式都是近黑,那是给
-            // "一句话标签"定的惯例):本卡是**内容预览**,语义对应 popover
-            // 内容面 —— 白底深字 / 暗色深面,多行正文可读性优先。旁边的
-            // "更早还有 N 条"是标签,继续用默认 tooltip 面色,两类不混。
-            // 覆盖类刻意与 TooltipContent 的原类同形式(任意值 bg-[...] /
-            // text-[...]),确保 tailwind-merge 归入同一冲突组、后写的必胜,
-            // 不赌歧义值的分组启发式。
-            // 阴影不覆盖:继承 TooltipContent 基座的浮层阴影决策,本卡不引入
-            // 新的深度样式(PR #830 review)。
-            contentClassName={cn(
-              'max-w-[380px] break-normal px-3 py-2',
-              'border-[var(--border-default)] bg-[hsl(var(--popover))] text-[hsl(var(--popover-foreground))]',
-              'dark:border-[var(--border-default)]',
-            )}
-          >
-            <button
-              type="button"
-              aria-label={t('chat.messageNavRail.jumpAria', {
-                index: plan.startIndex + i + 1,
-                preview,
-              })}
-              aria-current={isActive ? 'true' : undefined}
-              onClick={() => handleTickClick(entry.id)}
-              onMouseEnter={handleTickMouseEnter}
-              onMouseLeave={handleTickMouseLeave}
-              // 命中区吃满整格纵距,刻度线本体只有 2px 高。焦点环用全局
-              // --focus-ring token(AgentTaskCard 同款),键盘 Tab 可见
-              // (PR #830 review:纯 outline-none 会让键盘用户丢焦点)。
-              className={cn(
-                'group flex w-full items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-                tickEvents,
-              )}
-              style={{ height: plan.pitchPx }}
-            >
-              <span
-                className={cn(
-                  'h-[2px] rounded-full transition-all duration-200 ease-out',
-                  isActive
-                    ? 'w-4 bg-[var(--text-primary)]'
-                    : inView
-                      ? 'w-3 bg-[var(--text-primary)] group-hover:w-3.5'
-                      : 'w-3 bg-[var(--border-default)] group-hover:w-3.5 group-hover:bg-[var(--text-secondary)]',
-                )}
-              />
-            </button>
-          </Tip>
-        );
-      })}
+              </div>
+            </Tooltip.Trigger>
+            {/* 占位刻度是**标签**,继续用默认 tooltip 面色(近黑),与下面的
+                内容预览卡两类不混 —— 面色决策同 #830 原状。 */}
+            <Tooltip.Content side="right">
+              {t('chat.messageNavRail.hiddenEarlier', { count: plan.hiddenCount })}
+            </Tooltip.Content>
+          </Tooltip.Root>
+        ) : null}
+        {shown.map((entry, i) => {
+          // 纯附件且无文件名的提问用 i18n 计数文案兜底(模型层不碰 i18n)。
+          const preview =
+            entry.preview ||
+            (entry.attachmentsOnly
+              ? t('chat.messageNavRail.attachmentOnly', { count: entry.attachmentsOnly })
+              : '');
+          const isActive = entry.id === displayActiveId;
+          const fullIdx = plan.startIndex + i;
+          // 该轮次的内容当前正显示在视口里 → 提亮(Codex 同款"屏上内容高亮");
+          // 当前项在提亮之上再加长,两个信号分工:范围 = 在看什么,长刻度 = 读到哪。
+          const inView = rangeStartIdx >= 0 && fullIdx >= rangeStartIdx && fullIdx <= rangeEndIdx;
+          return (
+            <Tooltip.Root key={entry.id}>
+              <Tooltip.Trigger asChild>
+                <button
+                  type="button"
+                  aria-label={t('chat.messageNavRail.jumpAria', {
+                    index: plan.startIndex + i + 1,
+                    preview,
+                  })}
+                  aria-current={isActive ? 'true' : undefined}
+                  onClick={() => handleTickClick(entry.id)}
+                  onMouseEnter={handleTickMouseEnter}
+                  onMouseLeave={handleTickMouseLeave}
+                  // 命中区吃满整格纵距,刻度线本体只有 2px 高。焦点环用全局
+                  // --focus-ring token(AgentTaskCard 同款),键盘 Tab 可见
+                  // (PR #830 review:纯 outline-none 会让键盘用户丢焦点)。
+                  className={cn(
+                    'group flex w-full items-center rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                    tickEvents,
+                  )}
+                  style={{ height: plan.pitchPx }}
+                >
+                  <span
+                    className={cn(
+                      // §14.4 禁硬编码 duration / cubic-bezier:base 档
+                      // (200ms)与原先的 duration-200 同值,曲线取尺寸插值的
+                      // ease-move。过渡属性从 all 收窄到实际会变的两项。
+                      'h-[2px] rounded-full',
+                      'transition-[width,background-color] duration-[var(--motion-base)]',
+                      'ease-[var(--motion-ease-move)]',
+                      isActive
+                        ? 'w-4 bg-[var(--text-primary)]'
+                        : inView
+                          ? 'w-3 bg-[var(--text-primary)] group-hover:w-3.5'
+                          : 'w-3 bg-[var(--border-default)] group-hover:w-3.5 group-hover:bg-[var(--text-secondary)]',
+                    )}
+                  />
+                </button>
+              </Tooltip.Trigger>
+              {/*
+               * 预览卡 = 提问(加粗一行)+ 回答摘要(灰字,至多 3 行)。
+               * 摘要是识别的主载体:大量提问是"继续 / 重来"式短指令,只靠
+               * 提问认不出是哪一轮。回答未产生时只显示提问行。
+               *
+               * 面色刻意不用全局 tooltip token(亮暗两模式都是近黑,那是给
+               * "一句话标签"定的惯例):本卡是**内容预览**,语义对应 popover
+               * 内容面 —— 白底深字 / 暗色深面,多行正文可读性优先。旁边的
+               * "更早还有 N 条"是标签,继续用默认 tooltip 面色,两类不混。
+               * 覆盖类刻意与 TooltipContent 的原类同形式(任意值 bg-[...] /
+               * text-[...]),确保 tailwind-merge 归入同一冲突组、后写的必胜,
+               * 不赌歧义值的分组启发式。
+               * 阴影不覆盖:继承 TooltipContent 基座的浮层阴影决策,本卡不引入
+               * 新的深度样式(PR #830 review)。
+               *
+               * 无预览文本时不渲染 Content —— 与原先 <Tip text={null}> 的
+               * 透明传递等价(空内容不该冒出一个空卡)。
+               */}
+              {preview ? (
+                <Tooltip.Content
+                  side="right"
+                  className={cn(
+                    'max-w-[380px] break-normal px-3 py-2',
+                    'border-[var(--border-default)] bg-[hsl(var(--popover))] text-[hsl(var(--popover-foreground))]',
+                    'dark:border-[var(--border-default)]',
+                  )}
+                >
+                  <span className="flex max-w-[344px] flex-col gap-1">
+                    <span className="truncate text-13 font-medium">{preview}</span>
+                    {entry.answerExcerpt ? (
+                      // 摘要 = 主文字色 × 50% 透明度,不引新 token。数值由多轮
+                      // 实机验收夹逼、最终用户直接指定(2026-07-28)。注意半透明
+                      // 文字经抗锯齿合成会比同亮度实心灰**显得更亮**,别拿色值
+                      // 计算器推这个数,调整必须实机看效果。
+                      <span className="line-clamp-3 whitespace-normal break-normal text-13 leading-relaxed opacity-50">
+                        {entry.answerExcerpt}
+                      </span>
+                    ) : null}
+                  </span>
+                </Tooltip.Content>
+              ) : null}
+            </Tooltip.Root>
+          );
+        })}
+      </Tooltip.Provider>
     </nav>
   );
 }

--- a/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
@@ -14,9 +14,30 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@/components/ui/tooltip', () => ({
-  Tip: ({ children }: { children: ReactNode }) => <>{children}</>,
-}));
+// 预览卡内容不在本文件的覆盖范围(Content 直接丢掉,与原先 Tip stub 只透传
+// children 等价)。Provider 记**挂载中的实例数**而不是渲染次数:组件会因
+// 测量 setState 反复重渲,计渲染次数是脆的;挂载数对重渲染免疫。
+const tooltipMocks = vi.hoisted(() => ({ mountedProviders: { value: 0 } }));
+
+vi.mock('@/components/ui/tooltip', async () => {
+  const { useEffect } = await import('react');
+  return {
+    Tooltip: {
+      Provider: ({ children }: { children: ReactNode }) => {
+        useEffect(() => {
+          tooltipMocks.mountedProviders.value += 1;
+          return () => {
+            tooltipMocks.mountedProviders.value -= 1;
+          };
+        }, []);
+        return <>{children}</>;
+      },
+      Root: ({ children }: { children: ReactNode }) => <>{children}</>,
+      Trigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+      Content: () => null,
+    },
+  };
+});
 
 import { MessageNavRail } from '../MessageNavRail';
 import { NAV_RAIL_ACTIVE_FUDGE_PX, type NavRailEntry } from '../messageNavRailModel';
@@ -71,6 +92,7 @@ const ENTRIES: NavRailEntry[] = [
 describe('MessageNavRail', () => {
   beforeEach(() => {
     document.body.innerHTML = '';
+    tooltipMocks.mountedProviders.value = 0;
     vi.stubGlobal('ResizeObserver', ResizeObserverStub);
     // jsdom 没有 CSS.escape(真实渲染器 Chromium 提供);测试 id 都是安全字符。
     vi.stubGlobal('CSS', { escape: (s: string) => s });
@@ -103,6 +125,34 @@ describe('MessageNavRail', () => {
     expect(buttons[1].getAttribute('aria-current')).toBe('true');
     expect(buttons[0].getAttribute('aria-current')).toBeNull();
     expect(buttons[2].getAttribute('aria-current')).toBeNull();
+  });
+
+  it('整条导轨只挂一个 TooltipProvider(而不是每根刻度一个)', async () => {
+    // skipDelayDuration 是 Provider 级状态:每根刻度各自一个 Provider 时,
+    // 相邻刻度之间跨 Provider,新 Provider 没有"刚刚开过"的记忆,鼠标竖着
+    // 划过去会看到预览卡反复消失再冒出(刻度纵距只有 9px)。这条守的就是
+    // 「别退回每刻度一个 Provider」——闪断本身依赖 Radix 真实计时,在 jsdom
+    // 里测不稳,所以断言结构不断言时序。
+    const root = buildScrollContainer(1000, [
+      { id: 'u1', top: -400 },
+      { id: 'u2', top: 50 },
+      { id: 'u3', top: 400 },
+      { id: 'u4', top: 600 },
+      { id: 'u5', top: 900 },
+    ]);
+    render(
+      <MessageNavRail
+        entries={ENTRIES}
+        scrollRef={{ current: root }}
+        contentMaxWidth={880}
+        bottomOffset={200}
+        onJump={vi.fn()}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getAllByRole('button')).toHaveLength(5);
+    });
+    expect(tooltipMocks.mountedProviders.value).toBe(1);
   });
 
   it('点击刻度回调 onJump(clientId),且点击项乐观标记为当前项', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

#830 的提问导航条上，鼠标竖着划过刻度带时预览卡会连续闪断：卡片消失、重新等一遍延迟、再冒出来，一根刻度一次。原因是每根刻度各包了一层 `<Tip>`，而 `Tip` 内部是无条件自带 `<TooltipProvider>` 的，`skipDelayDuration` 又是 Provider 级状态 —— 跨刻度就是跨 Provider，新 Provider 没有「刚刚开过」的记忆，于是每根都从头等满 delay。刻度纵距只有 9px（轮次多时会压到 5px），划过去就是一串闪。

在 `<Tip>` 外面套一层 Provider 不解决问题，内层会把外层遮住。所以换成 tooltip primitives、整列共用一个 Provider（`delayDuration` 150 / `skipDelayDuration` 700）：首次 hover 等 150ms，之后 700ms 内切到相邻刻度立即显示，竖向移动时预览卡只换内容、不中断。

顺带把同一文件里两处硬编码的过渡时长改走 §14.4 的 motion token。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Refs #830（本 PR 是它的小幅修补，不关闭）
- 本 PR 包含：`MessageNavRail` 预览卡改为整列共用一个 `TooltipProvider`；同文件两处过渡时长/曲线改走 motion token；一条守「只挂一个 Provider」的回归用例。
- 明确不包含：刻度密度与热区问题（120 轮以上纵距压到 5px、点击热区随之只有 5px 高，130 根之后截断），那是 `planNavRailTicks` 的设计取舍，需要先定方向，不在本 PR。
- 用户可见变化：竖向划过刻度带时预览卡不再闪断；整条导轨的空闲淡出从 200ms 变 150ms。其余无变化。
- 是否存在 breaking change：无

### UI 变化

不涉及新增界面；改的是既有预览卡的显示时机与两处过渡时长。没有实机截图 —— 这两项都要跑起来划一遍才看得出，静态截图体现不了，实机目检情况见「未执行的验证」。

- 引用的设计规范：

`DESIGN.md` §14.4「Motion tokens (the only tier source)」——**New transitions/animations must reference tokens — no hardcoded durations or cubic-beziers**。两处按 token 表落法：

1. 刻度：`transition-all duration-200 ease-out` → `transition-[width,background-color] duration-[var(--motion-base)] ease-[var(--motion-ease-move)]`。`--motion-base` 即 200ms，**时长不变**（#830 实机验收过的值不动），只换 token；过渡属性从 `all` 收窄到实际会变的两项；曲线取表里「Position/size interpolation」对应的 `--motion-ease-move`（刻度 hover / active 的变化是宽度，属尺寸插值）。
2. 整条淡出：`transition-opacity duration-200 ease-out` → `duration-[var(--motion-fast)] ease-[var(--motion-ease-out)]`。这一处 200 → 150ms 是本 PR 唯一的数值变化，依据是表里 `--motion-fast` = 「Color/opacity state changes」。

预览卡的面色、阴影、字号、间距一律沿用 #830 原状，本 PR 不引入新的颜色或深度样式；双模式走的还是原来的语义 token（`--border-default` / `hsl(var(--popover))` / `hsl(var(--popover-foreground))`），没有新增任何硬编码色值（`hardcoded-color-audit` 通过）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：exit=0，error TS 计数 0

pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/MessageNavRail.test.tsx
结果：exit=0，6 passed

node scripts/hardcoded-color-audit.mjs
结果：exit=0，PASS unexpected=0

GIT_CONFIG_GLOBAL=/dev/null pnpm test:unit
结果：exit=0
```

新增用例 `整条导轨只挂一个 TooltipProvider(而不是每根刻度一个)` 的有效性已验证：把实现临时改回每刻度一个 Provider 后该用例失败（`expected 6 to be 1`）。

闪断本身依赖 Radix 的真实计时，在 jsdom 里测不稳，所以这条用例断言结构、不断言时序。Provider stub 记的是**挂载中的实例数**而不是渲染次数 —— 组件会因测量 `setState` 反复重渲，计次数是脆的。

### 手工验证

不涉及。

### 未执行的验证

实机双模式目检（Light / Dark）均未做。本 PR 改的是 tooltip 计时与过渡时长/曲线，都要在客户端里跑起来、在一个提问较多的会话里竖向划过刻度带才看得出效果，静态目检无法确认；两种模式共用同一套语义 token，但我不把「复用了 themed 样式」当成「双模式已验证」。需要实机确认的话请指出，我补。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `apps/desktop` 渲染层的 `MessageNavRail`（提问导航条），且该功能默认关闭、需在设置 → 个性化 → 小技巧手动开启。不碰主进程、数据库、协议、原生层，不改 mobile runtime fingerprint。
- 回滚 / 降级方式：单 commit，直接 revert 即可；无数据或配置迁移。

行为等价的地方逐项核过，均与原 `<Tip>` 一致：`variant` 默认 `sans`（`Tip` 传的也是 `sans`）、`sideOffset` 默认 6（`Tip` 未覆盖）、`side="right"` 显式保留、`Tooltip.Root` 不传 props 即非受控（对应 `Tip` 的 `open={undefined}`）。无预览文本时不渲染 `Content`，对应原先 `<Tip text={null}>` 的透明传递。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
