### PR TITLE
fix(mcps): 明确 wait/evaluate/saveResource 仅作为 act 子操作，避免 agent 无效尝试

### DIFF
--- a/packages/lizi-mcps/src/browser/prompts/rules/browser-workflow.md
+++ b/packages/lizi-mcps/src/browser/prompts/rules/browser-workflow.md
@@ -94,4 +94,4 @@
 | `screenshot` | 仅在需要视觉确认时用 |
 | `console` / `pdf` / `upload` / `dialog` | 控制台日志 / 导出 PDF / 上传文件 / 处理原生弹窗 |
 
-> **`wait` 不是顶层 action**:`action: "wait"` 会报 `INVALID_ARGS`。等待请用 `act` + `request.kind: "wait"`(等 `loadState` / `textGone` / `timeoutMs`)。同理,`evaluate` / `saveResource` 等原子操作也只能作为 `act` 的子操作(`request.kind`),顶层 action 枚举里没有它们。
+> **直接调用 `browser` 工具时,`wait` 不是顶层 action**:`action: "wait"` 会报 `INVALID_ARGS`。等待请用 `act` + `request.kind: "wait"`(等 `loadState` / `textGone` / `timeoutMs`)。同理,`evaluate` / `saveResource` 等原子操作也只能作为 `act` 的子操作(`request.kind`),顶层 action 枚举里没有它们。**此限制仅针对直接调用 `browser` 工具的 `action` 参数;配方 `recipeDraft.steps[].action` 里的 `wait` / `evaluate` 是配方 DSL,由运行器转换为 `act`,不在此限制内。**

--- a/packages/lizi-mcps/src/browser/prompts/rules/browser-workflow.md
+++ b/packages/lizi-mcps/src/browser/prompts/rules/browser-workflow.md
@@ -94,4 +94,4 @@
 | `screenshot` | 仅在需要视觉确认时用 |
 | `console` / `pdf` / `upload` / `dialog` | 控制台日志 / 导出 PDF / 上传文件 / 处理原生弹窗 |
 
-> **直接调用 `browser` 工具时,`wait` 不是顶层 action**:`action: "wait"` 会报 `INVALID_ARGS`。等待请用 `act` + `request.kind: "wait"`(等 `loadState` / `textGone` / `timeoutMs`)。同理,`evaluate` / `saveResource` 等原子操作也只能作为 `act` 的子操作(`request.kind`),顶层 action 枚举里没有它们。**此限制仅针对直接调用 `browser` 工具的 `action` 参数;配方 `recipeDraft.steps[].action` 里的 `wait` / `evaluate` 是配方 DSL,由运行器转换为 `act`,不在此限制内。**
+> **直接调用 `browser` 工具时,`wait` 不是顶层 action**:`action: "wait"` 会报 `INVALID_ARGS`。等待请用 `act` + `request.kind: "wait"`(等 `loadState` / `textGone` / `timeoutMs`)。同理,`evaluate` / `saveResource` 等原子操作也只能作为 `act` 的子操作(`request.kind`),顶层 action 枚举里没有它们。**此限制仅针对直接调用 `browser` 工具的 `action` 参数;配方 `recipeDraft.steps[].action` 里仅 `wait` / `evaluate` 是配方 DSL(由运行器转换为 `act`,不在此限制内),`saveResource` 在配方中同样不可用(`RecipeStepSchema` 不接受它)。**

--- a/packages/lizi-mcps/src/browser/prompts/rules/browser-workflow.md
+++ b/packages/lizi-mcps/src/browser/prompts/rules/browser-workflow.md
@@ -93,3 +93,5 @@
 | `recipe` / `siteguide` | 跑某站现成配方(`recipeId`+`inputs`) / 取某站内置指南(`site`,含入口/关键页/可用配方;非 sitemap.xml) |
 | `screenshot` | 仅在需要视觉确认时用 |
 | `console` / `pdf` / `upload` / `dialog` | 控制台日志 / 导出 PDF / 上传文件 / 处理原生弹窗 |
+
+> **`wait` 不是顶层 action**:`action: "wait"` 会报 `INVALID_ARGS`。等待请用 `act` + `request.kind: "wait"`(等 `loadState` / `textGone` / `timeoutMs`)。同理,`evaluate` / `saveResource` 等原子操作也只能作为 `act` 的子操作(`request.kind`),顶层 action 枚举里没有它们。

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -228,7 +228,7 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
     description:
       '浏览器自动化统一入口。通过 action 选择 status/start/tabs/navigate/snapshot/screenshot/act 等操作; ' +
       '优先使用 snapshot 返回的 ref 执行 click/type/press,不要猜测 CSS selector。' +
-      '注意:直接调用本工具时,wait/evaluate/saveResource 不是顶层 action(会报 INVALID_ARGS),它们只能作为 act 的 request.kind 子操作(配方 steps 里的同名 action 不受此限)。',
+      '注意:直接调用本工具时,wait/evaluate/saveResource 不是顶层 action(会报 INVALID_ARGS),它们只能作为 act 的 request.kind 子操作(配方 steps 里仅 wait/evaluate 是合法 DSL action,saveResource 在配方中同样不可用)。',
     rules: ['browser-workflow', 'recipe-author'],
     inputShape: {
       action: z.enum(ACTIONS).describe('浏览器操作类型'),

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -227,7 +227,8 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
     category: 'browser',
     description:
       '浏览器自动化统一入口。通过 action 选择 status/start/tabs/navigate/snapshot/screenshot/act 等操作; ' +
-      '优先使用 snapshot 返回的 ref 执行 click/type/press,不要猜测 CSS selector。',
+      '优先使用 snapshot 返回的 ref 执行 click/type/press,不要猜测 CSS selector。' +
+      '注意:wait/evaluate/saveResource 不是顶层 action(会报 INVALID_ARGS),它们只能作为 act 的 request.kind 子操作。',
     rules: ['browser-workflow', 'recipe-author'],
     inputShape: {
       action: z.enum(ACTIONS).describe('浏览器操作类型'),

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -228,7 +228,7 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
     description:
       '浏览器自动化统一入口。通过 action 选择 status/start/tabs/navigate/snapshot/screenshot/act 等操作; ' +
       '优先使用 snapshot 返回的 ref 执行 click/type/press,不要猜测 CSS selector。' +
-      '注意:wait/evaluate/saveResource 不是顶层 action(会报 INVALID_ARGS),它们只能作为 act 的 request.kind 子操作。',
+      '注意:直接调用本工具时,wait/evaluate/saveResource 不是顶层 action(会报 INVALID_ARGS),它们只能作为 act 的 request.kind 子操作(配方 steps 里的同名 action 不受此限)。',
     rules: ['browser-workflow', 'recipe-author'],
     inputShape: {
       action: z.enum(ACTIONS).describe('浏览器操作类型'),


### PR DESCRIPTION
## 这次改了什么

在浏览器 MCP 的规则文档与工具描述中明确 `wait`/`evaluate`/`saveResource` 只能作为 `act` 的 `request.kind` 子操作（顶层 action 枚举没有它们），减少 agent 的无效尝试。

## 风险

低风险。仅 agent 侧提示文本（`browser-workflow.md` 规则 + 工具 description），不涉及运行时逻辑；行为不变量不变。

### 摘要

Agent 将 `wait` 当作顶层 action 调用时会收到 `INVALID_ARGS`（顶层 action 枚举中不存在 `wait`，正确形式是 `act` + `request.kind: "wait"`）。这会消耗额外调用次数和上下文，并干扰故障定位。

本次在两层给 agent 明确边界：
1. `browser-workflow.md`（喂给 agent 的用法规则，经 `list_tools` 下发）：action 速查表后新增说明——`wait` 不是顶层 action，`evaluate`/`saveResource` 同理只能作为 `act` 的 `request.kind` 子操作；
2. `tools.ts` 工具描述：补一句同样的提示，让 agent 在读取 schema 时即可见。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：#1876（I-08 部分）
- 本 PR 包含：`packages/lizi-mcps/src/browser/prompts/rules/browser-workflow.md` + `packages/lizi-mcps/src/browser/tools.ts`（仅描述/规则文本，共 4 行新增）
- 明确不包含：运行时（vendored）逻辑改动；`screenshot`/`saveResource` 等其余 I 系列问题（在 #1876 中跟踪）
- 用户可见变化：agent 在调用前能看到 wait 的边界说明，减少无效尝试
- 是否存在 breaking change：无

### UI 变化

- 不涉及（非 UI 路径；MCP 工具描述与 agent 规则文本）

## 怎么验证的

### 自动验证

```text
cd packages/lizi-mcps
npx vitest run src/browser
结果:5 个测试文件、91 个测试全部通过

npx tsc --noEmit
结果:通过(exit 0)
```

### 手工验证

不涉及。说明：agent 规则经 `list_tools` 静态打包进进程内 MCP server，生效需桌面端重启 + 新 agent 会话（见 browser-control-runtime/upstream/MAINTAINING.md 坑 #7）；本地开发版未重新构建，故不做运行时实测。

### 未执行的验证

- 桌面端重启后 agent 实测（依赖用户本地构建，未执行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

