### PR TITLE
fix(desktop): 恢复冷启动自动应用已就绪更新

### DIFF
--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -322,7 +322,8 @@ describe('startup update relaunch safety', () => {
   // historic behavior restored deliberately (owner-approved). A fresh launch has
   // no in-flight agent turn / schedule to protect, so the startup gate skips the
   // idle/busy/user-active checks that guard the *background* auto-relaunch and
-  // keeps only the essentials (disabled / dev / not-ready / relaunching).
+  // keeps only the essentials (dev / not-ready / relaunching). The idle-install
+  // preference controls running sessions, not applying a patch on cold launch.
   it('auto-applies a staged startup update as soon as it is ready', async () => {
     await expect(runStartupUpdate()).resolves.toMatchObject({
       hasUpdate: true,
@@ -348,13 +349,12 @@ describe('startup update relaunch safety', () => {
     });
   });
 
-  it('keeps the patch staged (no relaunch) when auto-update is disabled', async () => {
-    await expect(runStartupUpdate({ enabled: false })).resolves.toMatchObject({ action: 'none' });
-    expect(logInfo).toHaveBeenCalledWith(
-      'startup update relaunch deferred (%s); patch v%s remains ready',
-      'disabled',
-      '0.0.65',
-    );
+  it('auto-applies at startup even when idle auto-install is disabled', async () => {
+    await expect(runStartupUpdate({ enabled: false })).resolves.toMatchObject({
+      hasUpdate: true,
+      action: 'relaunch',
+      version: '0.0.65',
+    });
   });
 
   it('never runs the startup update flow (nor the native updater) on a dev build', async () => {
@@ -385,17 +385,17 @@ describe('startup update relaunch safety', () => {
 
       await expect(startupHandler?.()).resolves.toMatchObject({ action: 'relaunch' });
 
-      // User flips the auto-update switch off during the renderer's presentation
-      // delay → the apply boundary must still honor it and defer (no relaunch).
-      readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
+      // The runtime changes to dev during the renderer's presentation delay →
+      // the essential startup guard must still defer at the apply boundary.
+      isDev.mockReturnValue(true);
       await expect(autoApplyHandler?.({}, 'dark')).resolves.toEqual({
         accepted: false,
-        blockReason: 'disabled',
+        blockReason: 'dev',
       });
       expect(service.getUpdateStatus()).toBe('ready');
       expect(logInfo).toHaveBeenCalledWith(
         'startup automatic relaunch deferred at apply boundary (%s)',
-        'disabled',
+        'dev',
       );
     } finally {
       service.stopUpdateService();
@@ -433,16 +433,11 @@ describe('isUpdateRelaunchImminent', () => {
     }
   });
 
-  // Regression: a staged patch used to read as "about to relaunch" purely from
-  // status==='ready'. With auto-relaunch off the patch sits there indefinitely,
-  // so every cold boot re-observed 'ready' and callers (startImConnection) kept
-  // deferring to a "next cold boot" that behaved identically — the FeishuBot
-  // never came online and feishuBot:save failed with [IM_NOT_READY] forever.
-  it('is false for a patch staged while auto-relaunch is off', async () => {
+  it('is true for a startup patch even when idle auto-install is off', async () => {
     const service = await bootWithStagedPatch({ enabled: false });
     try {
       expect(service.getUpdateStatus()).toBe('ready');
-      expect(service.isUpdateRelaunchImminent()).toBe(false);
+      expect(service.isUpdateRelaunchImminent()).toBe(true);
     } finally {
       service.stopUpdateService();
     }
@@ -458,14 +453,22 @@ describe('isUpdateRelaunchImminent', () => {
     }
   });
 
-  it('re-reads the auto-relaunch switch on every call', async () => {
-    const service = await bootWithStagedPatch({ enabled: true });
+  it('re-reads the idle auto-install switch outside the startup flow', async () => {
+    readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
+    fetchManifest.mockResolvedValue(updateManifest());
+    download.mockImplementation(async ({ targetPath }: { targetPath: string }) => {
+      fs.mkdirSync(path.join(TEST_USER_DATA, 'updates'), { recursive: true });
+      fs.writeFileSync(targetPath, 'update');
+      return { path: targetPath, size: 123 };
+    });
+    const service = await freshUpdateService('darwin');
     try {
-      expect(service.isUpdateRelaunchImminent()).toBe(true);
-      readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
+      await expect(service.checkForUpdate(updateManifest())).resolves.toBe('ready');
       expect(service.isUpdateRelaunchImminent()).toBe(false);
       readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: true });
       expect(service.isUpdateRelaunchImminent()).toBe(true);
+      readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
     } finally {
       service.stopUpdateService();
     }

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -449,11 +449,11 @@ describe('isUpdateRelaunchImminent', () => {
     }
   });
 
-  it('is true for a startup patch even when idle auto-install is off', async () => {
+  it('is false after the startup reply when idle auto-install is off', async () => {
     const service = await bootWithStagedPatch({ enabled: false });
     try {
       expect(service.getUpdateStatus()).toBe('ready');
-      expect(service.isUpdateRelaunchImminent()).toBe(true);
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
     } finally {
       service.stopUpdateService();
     }
@@ -506,6 +506,38 @@ describe('isUpdateRelaunchImminent', () => {
     const service = await bootWithStagedPatch({ enabled: true });
     try {
       expect(service.getUpdateStatus()).toBe('ready');
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('is true while a cold-start download is still in progress', async () => {
+    readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
+    fetchManifest.mockResolvedValue(updateManifest());
+    let finishDownload: (() => void) | undefined;
+    download.mockImplementation(({ targetPath }: { targetPath: string }) =>
+      new Promise((resolve) => {
+        finishDownload = () => {
+          fs.mkdirSync(path.join(TEST_USER_DATA, 'updates'), { recursive: true });
+          fs.writeFileSync(targetPath, 'update');
+          resolve({ path: targetPath, size: 123 });
+        };
+      }),
+    );
+
+    const service = await freshUpdateService('darwin');
+    service.initUpdateService();
+    try {
+      const startupHandler = ipcHandlers.get('update-check-startup');
+      if (!startupHandler) throw new Error('update-check-startup handler not registered');
+      const pendingReply = startupHandler();
+
+      await vi.waitFor(() => expect(service.getUpdateStatus()).toBe('downloading'));
+      expect(service.isUpdateRelaunchImminent()).toBe(true);
+
+      finishDownload?.();
+      await expect(pendingReply).resolves.toMatchObject({ action: 'relaunch' });
       expect(service.isUpdateRelaunchImminent()).toBe(false);
     } finally {
       service.stopUpdateService();

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -380,6 +380,41 @@ describe('startup update relaunch safety', () => {
     );
   });
 
+  it('keeps a legacy staged patch on Linux without entering the unsupported updater', async () => {
+    vi.useFakeTimers();
+    readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
+    fetchManifest.mockResolvedValue(updateManifest());
+    const updatesDir = path.join(TEST_USER_DATA, 'updates');
+    fs.mkdirSync(updatesDir, { recursive: true });
+    fs.writeFileSync(path.join(updatesDir, 'staged.zip'), 'update');
+    fs.writeFileSync(
+      path.join(updatesDir, 'patch-info.json'),
+      JSON.stringify({ version: '0.0.65', fileName: 'staged.zip' }),
+    );
+
+    const service = await freshUpdateService('linux');
+    service.initUpdateService();
+    try {
+      const startupHandler = ipcHandlers.get('update-check-startup');
+      if (!startupHandler) throw new Error('update-check-startup handler not registered');
+      await expect(startupHandler()).resolves.toMatchObject({
+        hasUpdate: true,
+        action: 'none',
+        version: '0.0.65',
+      });
+      expect(service.getUpdateStatus()).toBe('ready');
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
+      expect(download).not.toHaveBeenCalled();
+      expect(logInfo).toHaveBeenCalledWith(
+        'startup update relaunch deferred (%s); patch v%s remains ready',
+        'unsupported-platform',
+        '0.0.65',
+      );
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
   it('re-checks the startup policy at the apply boundary, keeping manual apply separate', async () => {
     vi.useFakeTimers();
     fetchManifest.mockResolvedValue(updateManifest());
@@ -449,10 +484,15 @@ describe('isUpdateRelaunchImminent', () => {
     }
   });
 
-  it('is false after the startup reply when idle auto-install is off', async () => {
+  it('stays true after the startup reply until the renderer abandons it', async () => {
     const service = await bootWithStagedPatch({ enabled: false });
     try {
       expect(service.getUpdateStatus()).toBe('ready');
+      expect(service.isUpdateRelaunchImminent()).toBe(true);
+
+      const abandonListener = ipcListeners.get('update-startup-relaunch-abandon');
+      if (!abandonListener) throw new Error('startup relaunch abandon listener not registered');
+      abandonListener();
       expect(service.isUpdateRelaunchImminent()).toBe(false);
     } finally {
       service.stopUpdateService();
@@ -512,7 +552,7 @@ describe('isUpdateRelaunchImminent', () => {
     }
   });
 
-  it('is true while a cold-start download is still in progress', async () => {
+  it('does not restore a relaunch plan after an in-flight startup check is abandoned', async () => {
     readAutoUpdateSettings.mockReturnValue({ autoRelaunchOnIdle: false });
     fetchManifest.mockResolvedValue(updateManifest());
     let finishDownload: (() => void) | undefined;
@@ -536,8 +576,13 @@ describe('isUpdateRelaunchImminent', () => {
       await vi.waitFor(() => expect(service.getUpdateStatus()).toBe('downloading'));
       expect(service.isUpdateRelaunchImminent()).toBe(true);
 
+      const abandonListener = ipcListeners.get('update-startup-relaunch-abandon');
+      if (!abandonListener) throw new Error('startup relaunch abandon listener not registered');
+      abandonListener();
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
+
       finishDownload?.();
-      await expect(pendingReply).resolves.toMatchObject({ action: 'relaunch' });
+      await expect(pendingReply).resolves.toMatchObject({ action: 'none' });
       expect(service.isUpdateRelaunchImminent()).toBe(false);
     } finally {
       service.stopUpdateService();

--- a/apps/desktop/src/main/__tests__/updateService.test.ts
+++ b/apps/desktop/src/main/__tests__/updateService.test.ts
@@ -322,8 +322,9 @@ describe('startup update relaunch safety', () => {
   // historic behavior restored deliberately (owner-approved). A fresh launch has
   // no in-flight agent turn / schedule to protect, so the startup gate skips the
   // idle/busy/user-active checks that guard the *background* auto-relaunch and
-  // keeps only the essentials (dev / not-ready / relaunching). The idle-install
-  // preference controls running sessions, not applying a patch on cold launch.
+  // keeps only the essentials (dev / translocated / not-ready / relaunching).
+  // The idle-install preference controls running sessions, not applying a patch
+  // on cold launch.
   it('auto-applies a staged startup update as soon as it is ready', async () => {
     await expect(runStartupUpdate()).resolves.toMatchObject({
       hasUpdate: true,
@@ -362,6 +363,21 @@ describe('startup update relaunch safety', () => {
     // forge/dev instance); the startup gate's `dev` branch is defense-in-depth.
     isDev.mockReturnValue(true);
     await expect(runStartupUpdate()).resolves.toMatchObject({ hasUpdate: false, action: 'none' });
+  });
+
+  it('keeps the patch staged when a packaged macOS app is outside Applications', async () => {
+    appIsInApplicationsFolder.mockReturnValue(false);
+
+    await expect(runStartupUpdate({ enabled: false })).resolves.toMatchObject({
+      hasUpdate: true,
+      action: 'none',
+      version: '0.0.65',
+    });
+    expect(logInfo).toHaveBeenCalledWith(
+      'startup update relaunch deferred (%s); patch v%s remains ready',
+      'translocated',
+      '0.0.65',
+    );
   });
 
   it('re-checks the startup policy at the apply boundary, keeping manual apply separate', async () => {
@@ -479,6 +495,17 @@ describe('isUpdateRelaunchImminent', () => {
     try {
       expect(service.getUpdateStatus()).toBe('ready');
       isDev.mockReturnValue(true);
+      expect(service.isUpdateRelaunchImminent()).toBe(false);
+    } finally {
+      service.stopUpdateService();
+    }
+  });
+
+  it('is false outside Applications even when a startup patch is staged', async () => {
+    appIsInApplicationsFolder.mockReturnValue(false);
+    const service = await bootWithStagedPatch({ enabled: true });
+    try {
+      expect(service.getUpdateStatus()).toBe('ready');
       expect(service.isUpdateRelaunchImminent()).toBe(false);
     } finally {
       service.stopUpdateService();

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -605,8 +605,8 @@ configureImAccountScope({
  *
  * The gate MUST be `isUpdateRelaunchImminent()`, not the raw update status: a
  * `ready` (staged) patch may wait for a manual action throughout a running
- * session when idle auto-install is off. The update service separately marks a
- * cold-start patch that is already scheduled for relaunch as imminent.
+ * session when idle auto-install is off. The update service separately treats
+ * an in-flight cold-start update check as imminent.
  */
 export function startImConnection(): void {
   if (connectionLifecycle.isStarted()) {

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -604,11 +604,9 @@ configureImAccountScope({
  * connect normally.
  *
  * The gate MUST be `isUpdateRelaunchImminent()`, not the raw update status: a
- * `ready` (staged) patch never relaunches on its own when the user turned
- * auto-relaunch off, so gating on the status left this permanently skipped on
- * every cold boot of an out-of-date install — the bot never came online and
- * `feishuBot:save` kept failing with `[IM_NOT_READY]` (the account boundary is
- * activated inside `im.init()`), with no way out but manually updating.
+ * `ready` (staged) patch may wait for a manual action throughout a running
+ * session when idle auto-install is off. The update service separately marks a
+ * cold-start patch that is already scheduled for relaunch as imminent.
  */
 export function startImConnection(): void {
   if (connectionLifecycle.isStarted()) {

--- a/apps/desktop/src/main/updateAutoRelaunchPolicy.ts
+++ b/apps/desktop/src/main/updateAutoRelaunchPolicy.ts
@@ -7,6 +7,7 @@ export const AUTO_UPDATE_BUSY_QUIET_PERIOD_MS = 60 * 1000;
 export type AutoRelaunchBlockReason =
   | 'disabled'
   | 'dev'
+  | 'translocated'
   | 'not-ready'
   | 'relaunching'
   | 'busy'

--- a/apps/desktop/src/main/updateAutoRelaunchPolicy.ts
+++ b/apps/desktop/src/main/updateAutoRelaunchPolicy.ts
@@ -8,6 +8,7 @@ export type AutoRelaunchBlockReason =
   | 'disabled'
   | 'dev'
   | 'translocated'
+  | 'unsupported-platform'
   | 'not-ready'
   | 'relaunching'
   | 'busy'

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -142,6 +142,7 @@ let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
 let startupUpdateCheckInProgress = false;
+let startupAutoRelaunchPlanned = false;
 let resolvedRelaunchTheme: 'light' | 'dark' = 'dark';
 let busyProbe: () => boolean | Promise<boolean> = () => false;
 
@@ -243,7 +244,6 @@ async function getAutoRelaunchBlockReasonForCurrentState(): Promise<AutoRelaunch
  * launched, so there is no in-flight agent turn / schedule / active session to
  * interrupt. We therefore relaunch into the updater as soon as a patch is ready,
  * gating only on the essentials:
- *   - `disabled`     — user turned the auto-update relaunch switch off; respect it.
  *   - `dev`          — the native updater replaces the *installed* app; it can't
  *                      sanely update a dev / electron-forge instance, so never
  *                      auto-launch it there.
@@ -253,9 +253,11 @@ async function getAutoRelaunchBlockReasonForCurrentState(): Promise<AutoRelaunch
  * applied here — those protect a long-running session from a surprise restart,
  * which is not a concern at a fresh launch. (Background auto-relaunch keeps the
  * full policy via getAutoRelaunchBlockReasonForCurrentState.)
+ * `autoRelaunchOnIdle` belongs to that background policy as well: turning it off
+ * prevents an in-session idle restart, but a staged patch is still applied on the
+ * next cold launch.
  */
 async function getStartupRelaunchBlockReason(): Promise<AutoRelaunchBlockReason | null> {
-  if (!readAutoUpdateSettings().autoRelaunchOnIdle) return 'disabled';
   if (isDev()) return 'dev';
   if (currentStatus !== 'ready') return 'not-ready';
   if (isRelaunching || autoRelaunchInProgress) return 'relaunching';
@@ -265,7 +267,7 @@ async function getStartupRelaunchBlockReason(): Promise<AutoRelaunchBlockReason 
 /**
  * Startup update checks apply a staged patch as soon as it is ready (the historic
  * behavior), gated only by the lightweight startup policy above. Whenever that
- * policy blocks (auto-update off / dev / not ready / already relaunching) the
+ * policy blocks (dev / not ready / already relaunching) the
  * patch stays staged and the app enters normally, surfacing the UpdateBanner.
  */
 async function buildStartupReadyReply(version: string | undefined): Promise<{
@@ -275,6 +277,7 @@ async function buildStartupReadyReply(version: string | undefined): Promise<{
 }> {
   const blockReason = await getStartupRelaunchBlockReason();
   if (blockReason) {
+    startupAutoRelaunchPlanned = false;
     lastAutoRelaunchBlockReason = blockReason;
     log.info(
       'startup update relaunch deferred (%s); patch v%s remains ready',
@@ -283,6 +286,7 @@ async function buildStartupReadyReply(version: string | undefined): Promise<{
     );
     return { hasUpdate: true, action: 'none', version };
   }
+  startupAutoRelaunchPlanned = true;
   return { hasUpdate: true, action: 'relaunch', version };
 }
 
@@ -302,6 +306,7 @@ async function requestAutoRelaunch(
     ? await getStartupRelaunchBlockReason()
     : await getAutoRelaunchBlockReasonForCurrentState();
   if (blockReason) {
+    if (useStartupPolicy) startupAutoRelaunchPlanned = false;
     if (blockReason !== lastAutoRelaunchBlockReason) {
       lastAutoRelaunchBlockReason = blockReason;
       if (readAutoUpdateSettings().autoRelaunchOnIdle && currentStatus === 'ready') {
@@ -312,6 +317,7 @@ async function requestAutoRelaunch(
   }
 
   lastAutoRelaunchBlockReason = null;
+  if (useStartupPolicy) startupAutoRelaunchPlanned = false;
   autoRelaunchInProgress = true;
   log.info('auto relaunch conditions met (%s), applying update v%s', reason, readyVersion ?? '<unknown>');
   executeRelaunch(theme);
@@ -396,17 +402,13 @@ export function getUpdateStatus(): UpdateStatus {
  * pair).
  *
  * This is deliberately NOT `status === 'downloading' | 'ready'`: `ready` only
- * means "a patch is staged", and a staged patch stays staged forever when the
- * user turned auto-relaunch off (`getStartupRelaunchBlockReason() → 'disabled'`)
- * or on a dev build. Gating on the raw status made every cold boot of an
- * out-of-date install re-observe `ready` and skip the side-effect again, so the
- * "we'll do it on the next cold boot" fallback could never fire — the IM
- * transport stayed down permanently and `feishuBot:save` failed with
- * `[IM_NOT_READY]` until the user manually applied the update.
+ * means "a patch is staged". During a long-running session the patch may stay
+ * staged until the user applies it or restarts Cindy, so gating on raw status
+ * could suppress side-effects indefinitely.
  *
- * When auto-relaunch IS on, a `ready` patch that is currently blocked by the
- * idle/busy policy still counts as imminent: the poller applies it once the app
- * goes idle, and the following cold boot is up to date and ungated.
+ * A startup patch explicitly scheduled for relaunch is imminent regardless of
+ * the background idle-install preference. Outside startup, a ready patch counts
+ * as imminent only when that background policy is enabled.
  */
 export function isUpdateRelaunchImminent(): boolean {
   // Already committed — the updater is spawning / windows are tearing down.
@@ -415,8 +417,9 @@ export function isUpdateRelaunchImminent(): boolean {
   if (currentStatus !== 'downloading' && currentStatus !== 'ready') return false;
   // The native updater replaces the *installed* app; it never runs in dev.
   if (isDev()) return false;
-  // Respecting the user's switch: with auto-relaunch off the patch just sits
-  // there until they click the banner, which is not "imminent".
+  if (startupAutoRelaunchPlanned) return true;
+  // During a running session, the idle-install preference determines whether a
+  // staged patch will be applied automatically.
   return readAutoUpdateSettings().autoRelaunchOnIdle;
 }
 
@@ -1215,6 +1218,7 @@ export function initUpdateService(): void {
 
   ipcMain.handle('update-check-startup', async () => {
     log.info('update-check-startup called');
+    startupAutoRelaunchPlanned = false;
     startupUpdateCheckInProgress = true;
     try {
       if (isDev()) {

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -247,6 +247,8 @@ async function getAutoRelaunchBlockReasonForCurrentState(): Promise<AutoRelaunch
  *   - `dev`          — the native updater replaces the *installed* app; it can't
  *                      sanely update a dev / electron-forge instance, so never
  *                      auto-launch it there.
+ *   - `translocated` — a packaged macOS app outside Applications must first be
+ *                      moved to a persistent, writable install location.
  *   - `not-ready`    — no staged patch to apply.
  *   - `relaunching`  — a relaunch is already in flight; don't double-fire.
  * The idle / busy / user-active / recent-resume / screen-state checks are NOT
@@ -259,6 +261,7 @@ async function getAutoRelaunchBlockReasonForCurrentState(): Promise<AutoRelaunch
  */
 async function getStartupRelaunchBlockReason(): Promise<AutoRelaunchBlockReason | null> {
   if (isDev()) return 'dev';
+  if (isMacAppTranslocated()) return 'translocated';
   if (currentStatus !== 'ready') return 'not-ready';
   if (isRelaunching || autoRelaunchInProgress) return 'relaunching';
   return null;
@@ -267,7 +270,7 @@ async function getStartupRelaunchBlockReason(): Promise<AutoRelaunchBlockReason 
 /**
  * Startup update checks apply a staged patch as soon as it is ready (the historic
  * behavior), gated only by the lightweight startup policy above. Whenever that
- * policy blocks (dev / not ready / already relaunching) the
+ * policy blocks (dev / translocated / not ready / already relaunching) the
  * patch stays staged and the app enters normally, surfacing the UpdateBanner.
  */
 async function buildStartupReadyReply(version: string | undefined): Promise<{
@@ -415,8 +418,9 @@ export function isUpdateRelaunchImminent(): boolean {
   if (isRelaunching || autoRelaunchInProgress) return true;
   // Nothing staged or being staged can relaunch us.
   if (currentStatus !== 'downloading' && currentStatus !== 'ready') return false;
-  // The native updater replaces the *installed* app; it never runs in dev.
-  if (isDev()) return false;
+  // The native updater replaces the *installed* app; it cannot run in dev or
+  // from a transient macOS App Translocation path.
+  if (isDev() || isMacAppTranslocated()) return false;
   if (startupAutoRelaunchPlanned) return true;
   // During a running session, the idle-install preference determines whether a
   // staged patch will be applied automatically.
@@ -1141,9 +1145,9 @@ export function initUpdateService(): void {
     async (_event, theme: 'light' | 'dark'): Promise<AutoRelaunchRequestResult> => {
       // Startup checks and the renderer's 1.5 s presentation delay create a
       // real TOCTOU window. Re-run the startup policy at the apply boundary so a
-      // settings change / already-in-flight relaunch cannot be cut off by a
-      // stale decision. (Startup deliberately does not gate on idle/busy — there
-      // is no in-flight work to protect at a fresh launch.)
+      // install-location change / already-in-flight relaunch cannot be cut off
+      // by a stale decision. (Startup deliberately does not gate on idle/busy —
+      // there is no in-flight work to protect at a fresh launch.)
       const resolved = theme === 'light' || theme === 'dark' ? theme : 'dark';
       resolvedRelaunchTheme = resolved;
       const result = await requestAutoRelaunch('startup-apply-boundary', resolved, true);

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -142,7 +142,6 @@ let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
 let startupUpdateCheckInProgress = false;
-let startupAutoRelaunchPlanned = false;
 let resolvedRelaunchTheme: 'light' | 'dark' = 'dark';
 let busyProbe: () => boolean | Promise<boolean> = () => false;
 
@@ -280,7 +279,6 @@ async function buildStartupReadyReply(version: string | undefined): Promise<{
 }> {
   const blockReason = await getStartupRelaunchBlockReason();
   if (blockReason) {
-    startupAutoRelaunchPlanned = false;
     lastAutoRelaunchBlockReason = blockReason;
     log.info(
       'startup update relaunch deferred (%s); patch v%s remains ready',
@@ -289,7 +287,6 @@ async function buildStartupReadyReply(version: string | undefined): Promise<{
     );
     return { hasUpdate: true, action: 'none', version };
   }
-  startupAutoRelaunchPlanned = true;
   return { hasUpdate: true, action: 'relaunch', version };
 }
 
@@ -309,7 +306,6 @@ async function requestAutoRelaunch(
     ? await getStartupRelaunchBlockReason()
     : await getAutoRelaunchBlockReasonForCurrentState();
   if (blockReason) {
-    if (useStartupPolicy) startupAutoRelaunchPlanned = false;
     if (blockReason !== lastAutoRelaunchBlockReason) {
       lastAutoRelaunchBlockReason = blockReason;
       if (readAutoUpdateSettings().autoRelaunchOnIdle && currentStatus === 'ready') {
@@ -320,7 +316,6 @@ async function requestAutoRelaunch(
   }
 
   lastAutoRelaunchBlockReason = null;
-  if (useStartupPolicy) startupAutoRelaunchPlanned = false;
   autoRelaunchInProgress = true;
   log.info('auto relaunch conditions met (%s), applying update v%s', reason, readyVersion ?? '<unknown>');
   executeRelaunch(theme);
@@ -421,7 +416,7 @@ export function isUpdateRelaunchImminent(): boolean {
   // The native updater replaces the *installed* app; it cannot run in dev or
   // from a transient macOS App Translocation path.
   if (isDev() || isMacAppTranslocated()) return false;
-  if (startupAutoRelaunchPlanned) return true;
+  if (startupUpdateCheckInProgress) return true;
   // During a running session, the idle-install preference determines whether a
   // staged patch will be applied automatically.
   return readAutoUpdateSettings().autoRelaunchOnIdle;
@@ -1222,7 +1217,6 @@ export function initUpdateService(): void {
 
   ipcMain.handle('update-check-startup', async () => {
     log.info('update-check-startup called');
-    startupAutoRelaunchPlanned = false;
     startupUpdateCheckInProgress = true;
     try {
       if (isDev()) {

--- a/apps/desktop/src/main/updateService.ts
+++ b/apps/desktop/src/main/updateService.ts
@@ -142,6 +142,8 @@ let lastAutoRelaunchBlockReason: AutoRelaunchBlockReason | null = null;
 let lastBusyAtMs: number | null = null;
 let lastResumeAtMs: number | null = null;
 let startupUpdateCheckInProgress = false;
+let startupUpdateCheckAbandoned = false;
+let startupAutoRelaunchPlanned = false;
 let resolvedRelaunchTheme: 'light' | 'dark' = 'dark';
 let busyProbe: () => boolean | Promise<boolean> = () => false;
 
@@ -246,6 +248,8 @@ async function getAutoRelaunchBlockReasonForCurrentState(): Promise<AutoRelaunch
  *   - `dev`          — the native updater replaces the *installed* app; it can't
  *                      sanely update a dev / electron-forge instance, so never
  *                      auto-launch it there.
+ *   - `unsupported-platform` — the first Linux release does not support in-app
+ *                      replacement; keep any legacy staged patch untouched.
  *   - `translocated` — a packaged macOS app outside Applications must first be
  *                      moved to a persistent, writable install location.
  *   - `not-ready`    — no staged patch to apply.
@@ -260,6 +264,9 @@ async function getAutoRelaunchBlockReasonForCurrentState(): Promise<AutoRelaunch
  */
 async function getStartupRelaunchBlockReason(): Promise<AutoRelaunchBlockReason | null> {
   if (isDev()) return 'dev';
+  if (process.platform !== 'darwin' && process.platform !== 'win32') {
+    return 'unsupported-platform';
+  }
   if (isMacAppTranslocated()) return 'translocated';
   if (currentStatus !== 'ready') return 'not-ready';
   if (isRelaunching || autoRelaunchInProgress) return 'relaunching';
@@ -269,7 +276,7 @@ async function getStartupRelaunchBlockReason(): Promise<AutoRelaunchBlockReason 
 /**
  * Startup update checks apply a staged patch as soon as it is ready (the historic
  * behavior), gated only by the lightweight startup policy above. Whenever that
- * policy blocks (dev / translocated / not ready / already relaunching) the
+ * policy blocks (dev / unsupported platform / translocated / not ready / already relaunching) the
  * patch stays staged and the app enters normally, surfacing the UpdateBanner.
  */
 async function buildStartupReadyReply(version: string | undefined): Promise<{
@@ -287,6 +294,12 @@ async function buildStartupReadyReply(version: string | undefined): Promise<{
     );
     return { hasUpdate: true, action: 'none', version };
   }
+  if (startupUpdateCheckAbandoned) {
+    startupAutoRelaunchPlanned = false;
+    log.info('startup update reply abandoned; patch v%s remains ready', version ?? '<unknown>');
+    return { hasUpdate: true, action: 'none', version };
+  }
+  startupAutoRelaunchPlanned = true;
   return { hasUpdate: true, action: 'relaunch', version };
 }
 
@@ -306,6 +319,7 @@ async function requestAutoRelaunch(
     ? await getStartupRelaunchBlockReason()
     : await getAutoRelaunchBlockReasonForCurrentState();
   if (blockReason) {
+    if (useStartupPolicy) startupAutoRelaunchPlanned = false;
     if (blockReason !== lastAutoRelaunchBlockReason) {
       lastAutoRelaunchBlockReason = blockReason;
       if (readAutoUpdateSettings().autoRelaunchOnIdle && currentStatus === 'ready') {
@@ -316,6 +330,7 @@ async function requestAutoRelaunch(
   }
 
   lastAutoRelaunchBlockReason = null;
+  if (useStartupPolicy) startupAutoRelaunchPlanned = false;
   autoRelaunchInProgress = true;
   log.info('auto relaunch conditions met (%s), applying update v%s', reason, readyVersion ?? '<unknown>');
   executeRelaunch(theme);
@@ -415,8 +430,13 @@ export function isUpdateRelaunchImminent(): boolean {
   if (currentStatus !== 'downloading' && currentStatus !== 'ready') return false;
   // The native updater replaces the *installed* app; it cannot run in dev or
   // from a transient macOS App Translocation path.
-  if (isDev() || isMacAppTranslocated()) return false;
-  if (startupUpdateCheckInProgress) return true;
+  if (
+    isDev()
+    || (process.platform !== 'darwin' && process.platform !== 'win32')
+    || isMacAppTranslocated()
+  ) return false;
+  if (startupUpdateCheckAbandoned) return false;
+  if (startupUpdateCheckInProgress || startupAutoRelaunchPlanned) return true;
   // During a running session, the idle-install preference determines whether a
   // staged patch will be applied automatically.
   return readAutoUpdateSettings().autoRelaunchOnIdle;
@@ -1135,6 +1155,11 @@ export function initUpdateService(): void {
     executeRelaunch(resolved);
   });
 
+  ipcMain.on('update-startup-relaunch-abandon', () => {
+    if (startupUpdateCheckInProgress) startupUpdateCheckAbandoned = true;
+    startupAutoRelaunchPlanned = false;
+  });
+
   ipcMain.handle(
     'update-relaunch-auto',
     async (_event, theme: 'light' | 'dark'): Promise<AutoRelaunchRequestResult> => {
@@ -1217,6 +1242,8 @@ export function initUpdateService(): void {
 
   ipcMain.handle('update-check-startup', async () => {
     log.info('update-check-startup called');
+    startupUpdateCheckAbandoned = false;
+    startupAutoRelaunchPlanned = false;
     startupUpdateCheckInProgress = true;
     try {
       if (isDev()) {
@@ -1312,6 +1339,7 @@ export function initUpdateService(): void {
       return reply;
     } finally {
       startupUpdateCheckInProgress = false;
+      startupUpdateCheckAbandoned = false;
     }
   });
 

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -2047,6 +2047,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     version?: string;
     error?: 'manifest_failed' | 'download_failed';
   }> => ipcRenderer.invoke('update-check-startup'),
+  abandonStartupUpdateRelaunch: (): void =>
+    ipcRenderer.send('update-startup-relaunch-abandon'),
   getUpdateStatus: (): Promise<{ status: string; version?: string; errorCode?: string }> =>
     ipcRenderer.invoke('update-get-status'),
   getAutoUpdateSettings: (): Promise<{

--- a/apps/desktop/src/renderer/contexts/EnvCheckContext.tsx
+++ b/apps/desktop/src/renderer/contexts/EnvCheckContext.tsx
@@ -255,6 +255,9 @@ export function EnvCheckProvider({ children }: { children: ReactNode }) {
       // 新调用已把 flag 置 true;旧调用返回时无脑清 false 会让新调用的二进制
       // 进度事件被当成乱序尾包丢弃(splash 卡在 checking)。
       if (thisCallId === callIdRef.current) phase2InFlightRef.current = false;
+      if (thisCallId === callIdRef.current) {
+        window.electronAPI.abandonStartupUpdateRelaunch();
+      }
       setStatus('failed');
       return;
     }
@@ -262,6 +265,7 @@ export function EnvCheckProvider({ children }: { children: ReactNode }) {
     if (thisCallId === callIdRef.current) phase2InFlightRef.current = false;
 
     if (!phase2Passed) {
+      window.electronAPI.abandonStartupUpdateRelaunch();
       setStatus('failed');
       return;
     }
@@ -301,6 +305,7 @@ export function EnvCheckProvider({ children }: { children: ReactNode }) {
           setTimeout(tick, 500);
           return;
         }
+        window.electronAPI.abandonStartupUpdateRelaunch();
         safeResolve(null);
       };
       setTimeout(tick, UPDATE_GRACE_MS);

--- a/apps/desktop/src/renderer/contexts/__tests__/EnvCheckContext.test.tsx
+++ b/apps/desktop/src/renderer/contexts/__tests__/EnvCheckContext.test.tsx
@@ -31,12 +31,14 @@ let binaryCb: (p: BinaryPayload) => void = () => {};
 let updateCb: (p: UpdatePayload) => void = () => {};
 let envCheckCalls: Array<Deferred<unknown>> = [];
 let appUpdateCalls: Array<Deferred<unknown>> = [];
+const abandonStartupUpdateRelaunch = vi.fn();
 
 beforeEach(() => {
   binaryCb = () => {};
   updateCb = () => {};
   envCheckCalls = [];
   appUpdateCalls = [];
+  abandonStartupUpdateRelaunch.mockReset();
   (window as unknown as { electronAPI: unknown }).electronAPI = {
     onBinaryDownloadProgress: (cb: (p: BinaryPayload) => void) => {
       binaryCb = cb;
@@ -54,6 +56,7 @@ beforeEach(() => {
       new Promise((resolve, reject) => {
         appUpdateCalls.push({ resolve, reject });
       }),
+    abandonStartupUpdateRelaunch,
   };
 });
 
@@ -178,6 +181,30 @@ describe('EnvCheckContext 启动下载进度时序', () => {
       envCheckCalls[1].resolve({ allPassed: false });
     });
     expect(result.current.status).toBe('failed');
+    expect(abandonStartupUpdateRelaunch).toHaveBeenCalledTimes(1);
+  });
+
+  it('grace 超时放行时显式放弃迟到的启动重启回复', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      const { result } = await mountAndKick();
+
+      await act(async () => {
+        envCheckCalls[1].resolve({ allPassed: true });
+      });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3_000);
+      });
+
+      expect(result.current.status).toBe('passed');
+      expect(abandonStartupUpdateRelaunch).toHaveBeenCalledTimes(1);
+
+      appUpdateCalls[0].resolve({ hasUpdate: true, action: 'relaunch', version: '9.9.9' });
+      await flush();
+      expect(result.current.status).toBe('passed');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('热更下载失败:reply error 落地为 download_failed,不被 passed 冲掉', async () => {

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2150,6 +2150,7 @@ interface ElectronAPI {
     version?: string;
     error?: 'manifest_failed' | 'download_failed';
   }>;
+  abandonStartupUpdateRelaunch: () => void;
   onAppUpdateProgress: (callback: (payload: AppUpdateProgressPayload) => void) => () => void;
   fileBrowser: {
     listDir: (params: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

恢复 Desktop 的历史更新语义：运行中检测到更新时仍遵守「空闲时自动安装更新」设置；但用户完整关闭并重新启动 Cindy 后，已下载就绪的补丁会在启动阶段自动应用，不再因为该设置关闭而永久停留在旧版本。

根因是启动更新门禁复用了运行中空闲重启开关，导致日志持续出现 `startup update relaunch deferred (disabled)`。旧客户端即使反复关闭重开，仍不会安装已经下载的新版，进而继续触发新版插件与旧客户端不兼容的问题。

Owner 确认：Lizi 已于 2026-08-06 明确确认恢复「应用完整重启时自动更新并加载最新版本」，运行中检测到更新仍由用户手动触发或遵守空闲安装策略。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈完整重启后已下载更新仍未应用
- 本 PR 包含：冷启动更新门禁不再检查运行中空闲安装开关；同步启动期重启状态和 IM 门禁；更新回归测试
- 明确不包含：下载、校验、原生替换、手动更新、运行中空闲重启策略，以及插件安装逻辑
- 用户可见变化：存在已就绪补丁时，完整关闭并重新启动 Cindy 会自动应用补丁；macOS 应用不在 Applications 时保持补丁暂存，并进入现有更新提示流程
- 是否存在 breaking change：无

### UI 变化

不涉及：没有修改 UI、交互或文案，仅修正主进程启动更新策略及 renderer 启动门禁的状态通知。

- 引用的设计规范：不涉及；`EnvCheckContext` 仅在启动环境检查失败或超时时通知主进程放弃本轮自动重启计划，不改变任何视觉、交互或文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop typecheck
结果：通过

pnpm test:unit
结果：通过；Desktop unit 及仓库 unit tier 全部通过
```

### 手工验证

不涉及：本 PR 未启动或复用任何现有 Cindy 实例，避免污染用户当前环境。

### 未执行的验证

未构建签名安装包、未触发真实 OTA 替换。原生下载、校验和替换链路没有改动；真实安装包冷启动验证可在 CI 产物或后续发布候选版本上完成。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：Desktop 更新应用时机

### 影响与回滚

- 影响范围：正常安装位置下 macOS / Windows Desktop 的冷启动更新决策；Linux、dev/versionless 构建及不在 Applications 的 macOS 应用仍由门禁阻止原生更新
- 存量插件影响：无。插件文件、批准状态、指纹、manifest 校验和安装布局均未修改；修复后旧客户端能在完整重启时升级到与新版插件兼容的客户端版本
- 回滚 / 降级方式：回滚本提交即可恢复「关闭空闲自动安装时，冷启动也不自动应用补丁」的旧行为；已下载补丁格式与原生替换流程没有变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
