### PR TITLE
fix(desktop): RSB webview 截图支持 type=jpeg 并明确拒绝 fullPage

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/__tests__/rsb-webview-backend.test.ts
@@ -77,7 +77,10 @@ function fakeWc(opts?: { url?: string; title?: string }): WebContents & {
     getTitle: () => opts?.title ?? 'Example',
     isDestroyed: () => false,
     loadURL: vi.fn(async () => undefined),
-    capturePage: vi.fn(async () => ({ toPNG: () => Buffer.from('PNGDATA') })),
+    capturePage: vi.fn(async () => ({
+      toPNG: () => Buffer.from('PNGDATA'),
+      toJPEG: (quality: number) => Buffer.from(`JPEGDATA-${quality}`),
+    })),
     printToPDF: vi.fn(async () => Buffer.from('PDFDATA')),
     on: vi.fn(),
     consoleListeners: [] as Array<(...args: unknown[]) => void>,
@@ -430,6 +433,53 @@ describe('RsbWebviewBackend — direct WebContents actions', () => {
       mimeType: 'image/png',
       data: Buffer.from('PNGDATA').toString('base64'),
     });
+  });
+
+  it('screenshot honors type=jpeg with jpeg MIME and encoding', async () => {
+    const wc = fakeWc();
+    const registry = fakeRegistry(
+      [{ sessionId: 's1', tabId: 't1', webContentsId: 101 }],
+      new Map([['t1', wc]]),
+    );
+    const backend = new RsbWebviewBackend({
+      registry,
+      getActiveSessionId: () => 's1',
+      bridge: { getHostWebContents: () => null, logger: logger() },
+      logger: logger(),
+    });
+    const res = await backend.call({
+      action: 'screenshot',
+      targetId: 't1',
+      type: 'jpeg',
+    } as never);
+    expect(wc.capturePageMock).toHaveBeenCalledTimes(1);
+    expect(res.data).toMatchObject({
+      mimeType: 'image/jpeg',
+      data: Buffer.from('JPEGDATA-85').toString('base64'),
+      bytes: Buffer.from('JPEGDATA-85').length,
+    });
+  });
+
+  it('screenshot rejects fullPage explicitly', async () => {
+    const wc = fakeWc();
+    const registry = fakeRegistry(
+      [{ sessionId: 's1', tabId: 't1', webContentsId: 101 }],
+      new Map([['t1', wc]]),
+    );
+    const backend = new RsbWebviewBackend({
+      registry,
+      getActiveSessionId: () => 's1',
+      bridge: { getHostWebContents: () => null, logger: logger() },
+      logger: logger(),
+    });
+    const res = await backend.call({
+      action: 'screenshot',
+      targetId: 't1',
+      fullPage: true,
+    } as never);
+    expect(res.ok).toBe(false);
+    expect(res.message).toMatch(/fullPage is not supported/);
+    expect(wc.capturePageMock).not.toHaveBeenCalled();
   });
 
   it('pdf returns base64-encoded PDF', async () => {

--- a/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts
@@ -570,15 +570,28 @@ export class RsbWebviewBackend implements BrowserBackend {
   private async handleScreenshot(req: BackendRequest): Promise<BackendResult> {
     const tabId = await this.resolveDirectActionTarget(req);
     if (!tabId) return actionFailed(req.action, 'targetId required');
+    if (req.fullPage) {
+      // The RSB webview backend captures the guest WebContents viewport only;
+      // full-page capture is not implemented here. Reject explicitly instead of
+      // silently returning a viewport crop (matches the vendored runtime's
+      // "explicitly reject unsupported params" contract).
+      return actionFailed(
+        req.action,
+        'fullPage is not supported by the RSB webview backend (captures the visible viewport only)',
+      );
+    }
     const resolved = await this.resolveTabForDirectAction(req, tabId);
     if (!resolved.ok) return resolved.result;
     return this.withTabPin(tabId, async () => {
       const image = await resolved.wc.capturePage();
-      const buffer = image.toPNG();
+      // Honor `type` instead of always encoding PNG: JPEG via toJPEG(85),
+      // matching the CDP path's default quality. MIME/bytes follow the buffer.
+      const type = req.type === 'jpeg' ? 'jpeg' : 'png';
+      const buffer = type === 'jpeg' ? image.toJPEG(85) : image.toPNG();
       return actionOk(req.action, {
         tabId,
-        mimeType: 'image/png',
-        // Base64-encoded PNG — same shape the vendored runtime returns for
+        mimeType: type === 'jpeg' ? 'image/jpeg' : 'image/png',
+        // Base64-encoded image — same shape the vendored runtime returns for
         // `screenshot` so MCP callers don't need to know which backend ran.
         data: buffer.toString('base64'),
         bytes: buffer.length,


### PR DESCRIPTION
## 这次改了什么

修复 RSB webview 后端截图契约：`type: "jpeg"` 现在返回真实 JPEG 编码（`toJPEG(85)`，MIME/bytes 跟随）；`fullPage: true` 明确报「不支持」，不再静默返回视口裁剪。

## 风险

低风险。仅影响 RSB webview 后端（侧边栏内置浏览器）的截图行为，此前 jpeg 请求被静默降级为 png、fullPage 被静默忽略——本 PR 改为按契约处理；不涉及外置 backend、vendored 运行时、截图交付链路（#1824）与 session/tab 映射。

### 摘要

#1876 维护者已确认的缺陷：`rsb-webview-backend.ts` 的 `handleScreenshot` 忽略 `type` 参数，无条件执行 `image.toPNG()`，因此 `type: "jpeg"` 被静默忽略（请求 jpeg 返回 png，字节数与 png 完全相同）。

本 PR 修复格式契约：
1. `type: "jpeg"` 时改用 `image.toJPEG(85)`（质量 85，与 CDP 路径默认一致），响应 `mimeType`/`bytes` 跟随实际编码；
2. `fullPage: true` 明确报错「RSB webview backend 不支持全页截图」（当前实现只截可见视口），不再静默返回视口裁剪——与 vendored 运行时「不支持的参数必须显式报错」的契约一致。

范围严格限定在维护者建议路径 ① 的「修正格式契约」：**不涉及**截图交付（与 #1824 合并跟踪）、**不涉及** session/tab 映射（维护者建议路径 ②，需先实机观测）、**不新增** savePath、**不放宽** saveResource。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#1876（I-05 部分，维护者已确认根因）
- 本 PR 包含：`apps/desktop/src/main/mcp-integrations/browser-backend/rsb-webview-backend.ts` + 对应测试（2 文件，+67/-4）
- 明确不包含：截图交付通道（#1824）；tab/session 映射修复；`savePath`；`saveResource` 放宽
- 用户可见变化：请求 `type: "jpeg"` 现在返回真实 JPEG；`fullPage` 报明确错误而非静默裁剪
- 是否存在 breaking change：无（此前 jpeg 行为是静默降级为 png，属缺陷；fullPage 此前被静默忽略，现显式报错）

### UI 变化

- 不涉及

## 怎么验证的

### 自动验证

```text
cd apps/desktop
npx vitest run src/main/mcp-integrations/browser-backend
结果:11 个测试文件、153 个测试全部通过(含新增 2 个:jpeg 格式、fullPage 拒绝)

npx tsc --noEmit
结果:通过(exit 0)。注:首次运行因 cindy-protocol submodule 未初始化报
@cindy/slack-hook-protocol 缺失(hook-control 测试,与本次改动无关),
git submodule update --init cindy-protocol 后通过
```

### 手工验证

不涉及（需用户重新构建桌面端后在真实 Electron 环境验证，见下）。

### 未执行的验证

- 真实 Electron/RSB WebView 环境截图验证：本机运行版为旧构建（0.1.33），需重新构建桌面端后按 #1876 维护者验收建议执行（PNG/JPEG 各截一次校验 MIME/魔数/解码；连续 20 次 snapshot→screenshot 观测 tab 稳定性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

