### PR TITLE
fix(desktop): clarify hidden selected model state

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -284,12 +284,18 @@ const providersRef = vi.hoisted(() => {
       },
     },
   ] as unknown[];
-  return { DEFAULT_PROVIDERS, providers: DEFAULT_PROVIDERS, providerOrder: [] as string[] };
+  return {
+    DEFAULT_PROVIDERS,
+    providers: DEFAULT_PROVIDERS,
+    providerOrder: [] as string[],
+    loading: false,
+  };
 });
 vi.mock('@/hooks/useProviders', () => ({
   useProviders: () => ({
     providers: providersRef.providers,
     providerOrder: providersRef.providerOrder,
+    loading: providersRef.loading,
   }),
 }));
 
@@ -426,7 +432,9 @@ const requestProviderModelsAutoRefresh = vi.fn(async () => ({ ok: true as const 
 beforeEach(() => {
   requestProviderModelsAutoRefresh.mockClear();
   modelVisibilityRef.isEnabled = () => true;
+  providersRef.providers = providersRef.DEFAULT_PROVIDERS;
   providersRef.providerOrder = [];
+  providersRef.loading = false;
   agentCapabilitiesRef.loading = false;
   agentCapabilitiesRef.error = null;
   deviceProvidersRef.loading = false;
@@ -1929,6 +1937,34 @@ describe('ModelSelector trigger variants', () => {
     }
   });
 
+  it('keeps only the selected hidden model in the flat picker', () => {
+    providersRef.providers = [
+      {
+        ...(providersRef.DEFAULT_PROVIDERS[0] as Record<string, unknown>),
+        access: { kind: 'subscription', product: 'Claude Pro' },
+      },
+    ];
+    modelVisibilityRef.isEnabled = () => false;
+
+    render(
+      React.createElement(ModelSelectorContent, {
+        modelId: 'claude-opus-4-8',
+        effort: 'high',
+        onModelChange: vi.fn(),
+        onEffortChange: vi.fn(),
+        vendorKey: 'cc',
+        currentProviderId: 'anthropic',
+        fluidWidth: true,
+      }),
+    );
+
+    const selected = screen.getByRole('option', { name: /Opus 4\.8/ });
+    expect(selected.querySelector('[data-model-hidden-label]')?.textContent).toBe('已隐藏');
+    expect(within(selected).getByText('settings.providers.models.subscription')).toBeTruthy();
+    expect(screen.queryByRole('option', { name: /Sonnet 4\.6/ })).toBeNull();
+    expect(screen.queryByRole('option', { name: /Haiku 4\.5/ })).toBeNull();
+  });
+
   it('prioritizes the full selected model name in the fixed 320px picker', () => {
     providersRef.providers = [
       {
@@ -1987,7 +2023,6 @@ describe('ModelSelector trigger variants', () => {
           vendorKey: 'cc',
           deviceId: 'remote-device',
           currentProviderId: 'anthropic',
-          onProviderChange: vi.fn(),
         }),
       );
 
@@ -1996,6 +2031,107 @@ describe('ModelSelector trigger variants', () => {
     } finally {
       deviceProvidersRef.providers = [];
       deviceProvidersRef.modelVisibilityOverrides = undefined;
+    }
+  });
+
+  it('binds the pane observer when providers arrive after the empty state', async () => {
+    type ObserverInstance = {
+      callback: ResizeObserverCallback;
+      observe: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+    };
+    const instances: ObserverInstance[] = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    class MockResizeObserver {
+      readonly callback: ResizeObserverCallback;
+      readonly observe = vi.fn();
+      readonly unobserve = vi.fn();
+      readonly disconnect = vi.fn();
+
+      constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        instances.push(this);
+      }
+    }
+    Object.defineProperty(globalThis, 'ResizeObserver', {
+      configurable: true,
+      writable: true,
+      value: MockResizeObserver,
+    });
+    const rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      () =>
+        ({
+          top: 0,
+          bottom: 100,
+          left: 0,
+          right: 500,
+          width: 500,
+          height: 100,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    );
+    providersRef.providers = [];
+
+    try {
+      const props = {
+        modelId: 'claude-opus-4-8',
+        effort: 'high' as Effort,
+        onModelChange: vi.fn(),
+        onEffortChange: vi.fn(),
+        vendorKey: 'cc' as const,
+        currentProviderId: 'anthropic',
+        onProviderChange: vi.fn(),
+        fluidWidth: true,
+      };
+      const view = render(React.createElement(ModelSelectorContent, props));
+
+      expect(screen.getByText('newChat.modelSelector.source.emptyTitle')).toBeTruthy();
+      expect(instances).toHaveLength(0);
+
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+      view.rerender(React.createElement(ModelSelectorContent, props));
+
+      await waitFor(() => expect(instances).toHaveLength(1));
+      const firstPane = document.querySelector<HTMLElement>('[data-model-tag-density]');
+      expect(firstPane).not.toBeNull();
+      expect(instances[0].observe).toHaveBeenCalledWith(firstPane);
+      expect(firstPane?.getAttribute('data-model-tag-density')).toBe('full');
+
+      act(() => {
+        instances[0].callback(
+          [
+            {
+              target: firstPane,
+              contentRect: { width: 320 },
+            } as unknown as ResizeObserverEntry,
+          ],
+          instances[0] as unknown as ResizeObserver,
+        );
+      });
+      expect(firstPane?.getAttribute('data-model-tag-density')).toBe('hidden');
+
+      providersRef.providers = [];
+      view.rerender(React.createElement(ModelSelectorContent, props));
+      await waitFor(() => expect(instances[0].disconnect).toHaveBeenCalledTimes(1));
+
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+      view.rerender(React.createElement(ModelSelectorContent, props));
+      await waitFor(() => expect(instances).toHaveLength(2));
+      const secondPane = document.querySelector<HTMLElement>('[data-model-tag-density]');
+      expect(secondPane).not.toBeNull();
+      expect(instances[1].observe).toHaveBeenCalledWith(secondPane);
+
+      view.unmount();
+      expect(instances[1].disconnect).toHaveBeenCalledTimes(1);
+    } finally {
+      rectSpy.mockRestore();
+      Object.defineProperty(globalThis, 'ResizeObserver', {
+        configurable: true,
+        writable: true,
+        value: originalResizeObserver,
+      });
     }
   });
 

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -32,6 +32,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'newChat.modelSelector.trigger.placeholder': '选择模型',
         'newChat.modelSelector.trigger.agent.claudeCode': 'Claude Code',
         'newChat.modelSelector.trigger.agent.codex': 'Codex',
+        'newChat.modelSelector.hidden': '已隐藏',
         'newChat.modelSelector.pricing.free': '限时免费',
         'newChat.modelSelector.source.disconnected': '已断开',
         'newChat.modelSelector.remoteLoading': '正在从远程设备读取模型…',
@@ -297,6 +298,7 @@ const deviceProvidersRef = vi.hoisted(() => ({
   loading: false,
   error: null as string | null,
   unsupported: false,
+  modelVisibilityOverrides: undefined as Record<string, boolean> | undefined,
   prefetch: vi.fn(async () => {}),
 }));
 vi.mock('@/hooks/useDeviceProviders', () => ({
@@ -308,6 +310,7 @@ vi.mock('@/hooks/useDeviceProviders', () => ({
     loading: deviceProvidersRef.loading,
     error: deviceProvidersRef.error,
     unsupported: deviceProvidersRef.unsupported,
+    modelVisibilityOverrides: deviceProvidersRef.modelVisibilityOverrides,
   }),
 }));
 
@@ -331,6 +334,15 @@ vi.mock('@/lib/providerModels', () => ({
   // #245 新增:ModelSelector 渲染路径直接调用;fixture providers 无 routing,按不过滤透传。
   isChatBridgedCodexProvider: () => false,
   filterChatBridgedCodexProviders: (providers: unknown[]) => providers,
+  isDeviceModelVisible: (
+    overrides: Record<string, boolean> | undefined,
+    agent: string,
+    providerId: string,
+    model: { id: string; defaultEnabled?: boolean },
+  ) =>
+    overrides === undefined
+      ? true
+      : (overrides[`${agent}:${providerId}:${model.id}`] ?? model.defaultEnabled !== false),
   resolveVisibleModelAgentKind: ({ agentKind }: { agentKind: 'claude-code' | 'codex' | null }) =>
     agentKind ?? 'claude-code',
   selectVisibleModels: ({ agentKind }: { agentKind: 'claude-code' | 'codex' | null }) => {
@@ -403,6 +415,7 @@ import {
   ModelSelectorContent,
   modelEffortLabel,
   modelListMaxHeightForRows,
+  modelTagDensityForWidth,
   resolveRemoteModelListStatus,
   resolveModelSelectorAgentIdentity,
 } from '@/components/new-chat/ModelSelector';
@@ -412,12 +425,14 @@ const requestProviderModelsAutoRefresh = vi.fn(async () => ({ ok: true as const 
 
 beforeEach(() => {
   requestProviderModelsAutoRefresh.mockClear();
+  modelVisibilityRef.isEnabled = () => true;
   providersRef.providerOrder = [];
   agentCapabilitiesRef.loading = false;
   agentCapabilitiesRef.error = null;
   deviceProvidersRef.loading = false;
   deviceProvidersRef.error = null;
   deviceProvidersRef.unsupported = false;
+  deviceProvidersRef.modelVisibilityOverrides = undefined;
   deviceProvidersRef.prefetch.mockReset();
   deviceProvidersRef.prefetch.mockResolvedValue(undefined);
   (window as unknown as { electronAPI: unknown }).electronAPI = {
@@ -501,6 +516,16 @@ describe('resolveRemoteModelListStatus', () => {
 });
 
 describe('ModelSelector trigger variants', () => {
+  it('keeps required model status tags as the fluid picker narrows', () => {
+    expect(modelTagDensityForWidth(null)).toBe('full');
+    // 320px pane 还要扣掉图标、effort、勾选和左右 padding；英文 Subscription
+    // 会把模型名压成 GPT-...，所以此时只保留当前模型的已隐藏标识。
+    expect(modelTagDensityForWidth(320)).toBe('hidden');
+    expect(modelTagDensityForWidth(370)).toBe('subscription');
+    expect(modelTagDensityForWidth(449)).toBe('subscription');
+    expect(modelTagDensityForWidth(450)).toBe('full');
+  });
+
   // 打开选择器既发起刷新、又把「发现在途」状态推给内容区(见 useModelDiscoveryPending),
   // 所以点击要走 act:那次刷新 resolve 后还有一次 setPending(false) 落在微任务里。
   const clickTrigger = async (): Promise<void> => {
@@ -1372,6 +1397,7 @@ describe('ModelSelector trigger variants', () => {
       expect(row.textContent).not.toContain('¥12 / ¥36');
       expect(row.textContent).not.toContain('¥6 / ¥18');
       expect(row.querySelector('[data-model-promotion-badge]')).toBeNull();
+      expect(row.querySelector('[data-model-hidden-label]')).toBeNull();
 
       fireEvent.pointerEnter(row);
       expect(
@@ -1854,10 +1880,122 @@ describe('ModelSelector trigger variants', () => {
       expect(
         within(tags as HTMLElement).getByText('settings.providers.models.subscription'),
       ).toBeTruthy();
+      expect(row.querySelector('[data-model-hidden-label]')).toBeNull();
       expect(row.textContent).not.toContain('$3 / $15');
       expect(row.querySelector('[data-model-promotion-badge]')).toBeNull();
     } finally {
       providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
+  it('renders selected hidden status before its subscription label', () => {
+    providersRef.providers = [
+      {
+        ...(providersRef.DEFAULT_PROVIDERS[0] as Record<string, unknown>),
+        access: { kind: 'subscription', product: 'Claude Pro' },
+      },
+    ];
+    modelVisibilityRef.isEnabled = () => false;
+
+    try {
+      render(
+        React.createElement(ModelSelectorContent, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          currentProviderId: 'anthropic',
+          onProviderChange: vi.fn(),
+          fluidWidth: true,
+        }),
+      );
+
+      const row = screen.getByRole('option', { name: /Opus 4\.8/ });
+      const tags = row.querySelector('[data-model-tags]');
+      expect(tags).not.toBeNull();
+      const hidden = within(tags as HTMLElement).getByText('已隐藏');
+      const subscription = within(tags as HTMLElement).getByText(
+        'settings.providers.models.subscription',
+      );
+      expect(
+        hidden.compareDocumentPosition(subscription) & Node.DOCUMENT_POSITION_FOLLOWING,
+      ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+      expect(row.querySelector('[data-model-hidden-label]')).toBe(hidden);
+      expect(screen.queryByRole('option', { name: /Sonnet 4\.6/ })).toBeNull();
+    } finally {
+      modelVisibilityRef.isEnabled = () => true;
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
+  it('prioritizes the full selected model name in the fixed 320px picker', () => {
+    providersRef.providers = [
+      {
+        ...(providersRef.DEFAULT_PROVIDERS[0] as Record<string, unknown>),
+        access: { kind: 'subscription', product: 'Claude Pro' },
+      },
+    ];
+    modelVisibilityRef.isEnabled = (_agent: string, _providerId: string, model: { id: string }) =>
+      model.id !== 'claude-opus-4-8';
+
+    try {
+      render(
+        React.createElement(ModelSelectorContent, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          currentProviderId: 'anthropic',
+          onProviderChange: vi.fn(),
+        }),
+      );
+
+      const selected = screen.getByRole('option', { name: /Opus 4\.8/ });
+      expect(selected.querySelector('[data-model-hidden-label]')?.textContent).toBe('已隐藏');
+      expect(selected.textContent).not.toContain('settings.providers.models.subscription');
+      expect(
+        within(screen.getByRole('option', { name: /Sonnet 4\.6/ })).getByText(
+          'settings.providers.models.subscription',
+        ),
+      ).toBeTruthy();
+    } finally {
+      modelVisibilityRef.isEnabled = () => true;
+      providersRef.providers = providersRef.DEFAULT_PROVIDERS;
+    }
+  });
+
+  it('uses the remote visibility snapshot for the selected hidden status', () => {
+    deviceProvidersRef.providers = [
+      {
+        ...(providersRef.DEFAULT_PROVIDERS[0] as Record<string, unknown>),
+        access: { kind: 'subscription', product: 'Claude Pro' },
+      },
+    ];
+    deviceProvidersRef.modelVisibilityOverrides = {
+      'claude-code:anthropic:claude-opus-4-8': false,
+    };
+
+    try {
+      render(
+        React.createElement(ModelSelectorContent, {
+          modelId: 'claude-opus-4-8',
+          effort: 'high',
+          onModelChange: vi.fn(),
+          onEffortChange: vi.fn(),
+          vendorKey: 'cc',
+          deviceId: 'remote-device',
+          currentProviderId: 'anthropic',
+          onProviderChange: vi.fn(),
+        }),
+      );
+
+      const row = screen.getByRole('option', { name: /Opus 4\.8/ });
+      expect(row.querySelector('[data-model-hidden-label]')?.textContent).toBe('已隐藏');
+    } finally {
+      deviceProvidersRef.providers = [];
+      deviceProvidersRef.modelVisibilityOverrides = undefined;
     }
   });
 

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -703,20 +703,24 @@ function ModelSelectorContentView({
   const resolveCurrentSourceId = actualRoute ? actualSourceIdForModel : effectiveSourceIdForModel;
   const { t } = useTranslation();
   const constrainedListMaxHeight = modelListMaxHeightForRows(maxVisibleModelRows);
-  const paneRef = useRef<HTMLDivElement | null>(null);
+  const [paneElement, setPaneElement] = useState<HTMLDivElement | null>(null);
   const [paneWidth, setPaneWidth] = useState<number | null>(null);
+  const bindPaneElement = useCallback((node: HTMLDivElement | null) => {
+    setPaneElement(node);
+  }, []);
   useEffect(() => {
-    if (!paneRef.current || typeof ResizeObserver === 'undefined') {
+    if (!paneElement || typeof ResizeObserver === 'undefined') {
       setPaneWidth(null);
       return;
     }
-    const paneElement = paneRef.current;
-    const updateWidth = () => setPaneWidth(paneElement.getBoundingClientRect().width);
-    updateWidth();
-    const observer = new ResizeObserver(updateWidth);
+    setPaneWidth(paneElement.getBoundingClientRect().width);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries.find((candidate) => candidate.target === paneElement) ?? entries[0];
+      if (entry) setPaneWidth(entry.contentRect.width);
+    });
     observer.observe(paneElement);
     return () => observer.disconnect();
-  }, [fluidWidth]);
+  }, [paneElement]);
   // 非 fluid 选择器的契约宽度就是 320px。此前这里直接传 null，导致固定宽度的聊天
   // 选择器永远处于 full 密度，英文 Subscription 会把当前模型名挤成 GPT-...。
   // ResizeObserver 可用时仍以实际宽度为准；测试/首帧则用契约宽度避免标签闪现。
@@ -986,6 +990,30 @@ function ModelSelectorContentView({
         : null,
     [providers, currentProviderId, modelId, currentAgentKind, resolveCurrentSourceId],
   );
+  const currentModelProvider = useMemo(
+    () =>
+      activeSourceId ? providers.find((provider) => provider.id === activeSourceId) : undefined,
+    [activeSourceId, providers],
+  );
+  const currentCatalogModel =
+    currentModelProvider && currentAgentKind
+      ? getModel(currentModelProvider, modelId, currentAgentKind)
+      : undefined;
+  const isCurrentModelHidden =
+    !browsing &&
+    !!currentAgentKind &&
+    !!currentModelProvider &&
+    (deviceId
+      ? !isDeviceModelVisible(
+          remoteProviders.modelVisibilityOverrides,
+          currentAgentKind,
+          currentModelProvider.id,
+          { id: modelId, defaultEnabled: currentCatalogModel?.defaultEnabled },
+        )
+      : !isModelEnabled(currentAgentKind, currentModelProvider.id, {
+          id: modelId,
+          defaultEnabled: currentCatalogModel?.defaultEnabled,
+        }));
 
   // 行级 Fast 可编辑性 = agent 能力 × 该(供应商, 模型)条目的 supportsFastMode。
   // Fast 能力是 per-(provider, agent) 的(见 CatalogModel)：按该行供应商现查它自己的模型条目,
@@ -1194,7 +1222,13 @@ function ModelSelectorContentView({
             ).map((model) => model.id),
           ),
         );
-    const selectable = selectableIds ? base.filter((model) => selectableIds.has(model.id)) : base;
+    // flat 清单没有 buildProviderSections 的 keepSelected。这里只豁免当前且确实已隐藏的
+    // 模型，避免它从已有会话的选择器消失；其它隐藏模型仍按正常可见性过滤。
+    const selectable = selectableIds
+      ? base.filter(
+          (model) => selectableIds.has(model.id) || (isCurrentModelHidden && model.id === modelId),
+        )
+      : base;
     if (!q) return selectable;
     return selectable.filter(
       (m) => m.displayName.toLowerCase().includes(q) || m.id.toLowerCase().includes(q),
@@ -1207,6 +1241,8 @@ function ModelSelectorContentView({
     agentKind,
     providers,
     deviceId,
+    isCurrentModelHidden,
+    modelId,
     visibilityVersion,
     remoteProviders.modelVisibilityOverrides,
   ]);
@@ -1637,21 +1673,26 @@ function ModelSelectorContentView({
   const renderModelItem = (provider: ProviderView | null, model: RowModel) => {
     const providerId = provider?.id ?? null;
     const isSelected = isSelectedRow(providerId, model.id);
-    const isSubscriptionModel = provider?.access?.kind === 'subscription';
+    // flat 行仍保持 providerId=null 的选择语义，但当前行的状态展示要读取会话实际来源：
+    // 否则拍平后既看不到 Subscription，也无法判断该 (agent,provider,model) 是否已隐藏。
+    const statusProvider = provider ?? (isSelected ? currentModelProvider : undefined);
+    const isSubscriptionModel = statusProvider?.access?.kind === 'subscription';
     const selectedCatalogModel =
-      provider && currentAgentKind ? getModel(provider, model.id, currentAgentKind) : undefined;
+      statusProvider && currentAgentKind
+        ? getModel(statusProvider, model.id, currentAgentKind)
+        : undefined;
     const isHiddenSelectedModel =
       isSelected &&
-      !!provider &&
+      !!statusProvider &&
       !!currentAgentKind &&
       (deviceId
         ? !isDeviceModelVisible(
             remoteProviders.modelVisibilityOverrides,
             currentAgentKind,
-            provider.id,
+            statusProvider.id,
             { id: model.id, defaultEnabled: selectedCatalogModel?.defaultEnabled },
           )
-        : !isModelEnabled(currentAgentKind, provider.id, {
+        : !isModelEnabled(currentAgentKind, statusProvider.id, {
             id: model.id,
             defaultEnabled: selectedCatalogModel?.defaultEnabled,
           }));
@@ -1901,7 +1942,7 @@ function ModelSelectorContentView({
   //    portal 到 body,hover 时主菜单完全不重排 ─────
   const pane = (
     <div
-      ref={paneRef}
+      ref={bindPaneElement}
       data-model-tag-density={modelTagDensity}
       className={cn(
         'flex shrink-0 flex-col gap-1.5 p-2',

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -93,6 +93,20 @@ import { buildProviderSections } from './sourceSwitch';
 // 300ms 门槛也与仓库其它本地/远程混合 loading 提示一致；真正的秒级发现仍会明确反馈。
 const MODEL_DISCOVERY_INDICATOR_DELAY_MS = 300;
 
+/**
+ * 标签降级按选择器 pane 宽度生效。这里的 width 是整个 pane 宽度，不是模型名
+ * 实际可用宽度；行还要扣掉左右 padding、来源图标、effort 和选中勾选。因此不能把
+ * 300px 当成“能放下全部标签”的阈值，否则英文 Subscription 会先把模型名压成省略号。
+ * 模型名优先：促销标签先收起，订阅标签随后收起，只保留「已隐藏」和选中勾选。
+ */
+export type ModelTagDensity = 'full' | 'subscription' | 'hidden';
+
+export function modelTagDensityForWidth(width: number | null): ModelTagDensity {
+  if (width === null || width >= 450) return 'full';
+  if (width >= 370) return 'subscription';
+  return 'hidden';
+}
+
 // 厂商分类 / 分组标题 key 表的纯逻辑在 ./sourceSwitch。这里 re-export 给 ChatInput
 // (它从 './ModelSelector' import categorize / CATEGORY_LABEL_KEY / ModelCategory 做跨厂商确认弹窗)。
 export { categorize, CATEGORY_LABEL_KEY, type ModelCategory } from './sourceSwitch';
@@ -689,6 +703,24 @@ function ModelSelectorContentView({
   const resolveCurrentSourceId = actualRoute ? actualSourceIdForModel : effectiveSourceIdForModel;
   const { t } = useTranslation();
   const constrainedListMaxHeight = modelListMaxHeightForRows(maxVisibleModelRows);
+  const paneRef = useRef<HTMLDivElement | null>(null);
+  const [paneWidth, setPaneWidth] = useState<number | null>(null);
+  useEffect(() => {
+    if (!paneRef.current || typeof ResizeObserver === 'undefined') {
+      setPaneWidth(null);
+      return;
+    }
+    const paneElement = paneRef.current;
+    const updateWidth = () => setPaneWidth(paneElement.getBoundingClientRect().width);
+    updateWidth();
+    const observer = new ResizeObserver(updateWidth);
+    observer.observe(paneElement);
+    return () => observer.disconnect();
+  }, [fluidWidth]);
+  // 非 fluid 选择器的契约宽度就是 320px。此前这里直接传 null，导致固定宽度的聊天
+  // 选择器永远处于 full 密度，英文 Subscription 会把当前模型名挤成 GPT-...。
+  // ResizeObserver 可用时仍以实际宽度为准；测试/首帧则用契约宽度避免标签闪现。
+  const modelTagDensity = modelTagDensityForWidth(paneWidth ?? (fluidWidth ? null : 320));
   // session-agent-switch:两步式引擎切换的浏览态。browseVendor 初始 = 会话当前引擎;
   // 切到另一家 tab 只是「浏览目标引擎的模型」,选中模型行才真正触发切换事务。
   const [browseVendor, setBrowseVendor] = useState<'cc' | 'codex' | 'pi'>(
@@ -1606,6 +1638,23 @@ function ModelSelectorContentView({
     const providerId = provider?.id ?? null;
     const isSelected = isSelectedRow(providerId, model.id);
     const isSubscriptionModel = provider?.access?.kind === 'subscription';
+    const selectedCatalogModel =
+      provider && currentAgentKind ? getModel(provider, model.id, currentAgentKind) : undefined;
+    const isHiddenSelectedModel =
+      isSelected &&
+      !!provider &&
+      !!currentAgentKind &&
+      (deviceId
+        ? !isDeviceModelVisible(
+            remoteProviders.modelVisibilityOverrides,
+            currentAgentKind,
+            provider.id,
+            { id: model.id, defaultEnabled: selectedCatalogModel?.defaultEnabled },
+          )
+        : !isModelEnabled(currentAgentKind, provider.id, {
+            id: model.id,
+            defaultEnabled: selectedCatalogModel?.defaultEnabled,
+          }));
     const disabled = interactionDisabled || modelDisabledOf(provider, model.id);
     const disabledReason = subscriptionDirectDisabledReason(model.id);
     const rowEffort = rowEffortOf(providerId, model);
@@ -1620,6 +1669,12 @@ function ModelSelectorContentView({
               modelPriceDiscountLabelValues(rowPrice.discount),
             )
           : null;
+    // 普通模型沿用订阅标识；只有“当前模型已隐藏”这一额外状态与订阅标签争抢空间时，
+    // 才按宽度收起订阅标签，确保模型名、已隐藏状态和选中勾选都完整可见。
+    const showSubscriptionTag =
+      isSubscriptionModel && (!isHiddenSelectedModel || modelTagDensity !== 'hidden');
+    const showPromotionTag =
+      !!rowPromotionLabel && (!isHiddenSelectedModel || modelTagDensity === 'full');
     // 信息面板对所有可用模型开放;能否编辑 effort / Fast 在面板内部另行判定。
     // session-agent-switch 浏览目标引擎态同样开放:选模型前正需要看描述/上下文/价格/来源;
     // 面板内配置写的是**目标引擎**的 per-(来源,模型) 全局预设(currentAgentKind 已随浏览态
@@ -1734,14 +1789,22 @@ function ModelSelectorContentView({
                     />
                   )}
                 </span>
-                {(isSubscriptionModel || rowPromotionLabel) && (
+                {(isHiddenSelectedModel || showSubscriptionTag || showPromotionTag) && (
                   <span data-model-tags className="ml-auto flex shrink-0 items-center gap-1.5">
-                    {isSubscriptionModel && (
+                    {isHiddenSelectedModel && (
+                      <span
+                        data-model-hidden-label
+                        className="shrink-0 select-none text-11 font-normal text-[var(--text-tertiary)]"
+                      >
+                        {t('newChat.modelSelector.hidden')}
+                      </span>
+                    )}
+                    {showSubscriptionTag && (
                       <span className="inline-flex shrink-0 items-center rounded-full bg-[var(--surface-chip)] px-2 py-[1px] text-[11px] font-medium text-[var(--text-secondary)]">
                         {t('settings.providers.models.subscription')}
                       </span>
                     )}
-                    {rowPromotionLabel && (
+                    {showPromotionTag && rowPromotionLabel && (
                       <ModelPromotionBadge>{rowPromotionLabel}</ModelPromotionBadge>
                     )}
                   </span>
@@ -1838,6 +1901,8 @@ function ModelSelectorContentView({
   //    portal 到 body,hover 时主菜单完全不重排 ─────
   const pane = (
     <div
+      ref={paneRef}
+      data-model-tag-density={modelTagDensity}
       className={cn(
         'flex shrink-0 flex-col gap-1.5 p-2',
         fluidWidth ? 'w-full min-w-0' : 'w-[320px]',

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5034,6 +5034,7 @@
     },
     "modelSelector": {
       "budgetNeedsApiKey": "This model needs an API key — configure it in Settings",
+      "hidden": "Hidden",
       "subscriptionDirectDisabled": {
         "chatgpt": "Subscription-direct GPT models are not supported in SSH remote sessions yet",
         "xai": "Subscription-direct Grok models are not supported in SSH remote sessions yet",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5032,6 +5032,7 @@
     },
     "modelSelector": {
       "budgetNeedsApiKey": "このモデルは設定で API key を構成してから使用できます",
+      "hidden": "非表示",
       "subscriptionDirectDisabled": {
         "chatgpt": "サブスクリプション直結の GPT モデルは SSH リモートセッションに未対応です",
         "xai": "サブスクリプション直結の Grok モデルは SSH リモートセッションに未対応です",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5032,6 +5032,7 @@
     },
     "modelSelector": {
       "budgetNeedsApiKey": "이 모델은 설정에서 API key를 구성해야 사용할 수 있습니다",
+      "hidden": "숨김",
       "subscriptionDirectDisabled": {
         "chatgpt": "구독 직결 GPT 모델은 SSH 원격 세션을 아직 지원하지 않습니다",
         "xai": "구독 직결 Grok 모델은 SSH 원격 세션을 아직 지원하지 않습니다",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5032,6 +5032,7 @@
     },
     "modelSelector": {
       "budgetNeedsApiKey": "此模型需先在设置里配置 API key 才能使用",
+      "hidden": "已隐藏",
       "subscriptionDirectDisabled": {
         "chatgpt": "订阅直连的 GPT 模型协议暂不支持 SSH 远程会话",
         "xai": "订阅直连的 Grok 模型协议暂不支持 SSH 远程会话",


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复隐藏订阅模型后的当前会话状态提示：已有会话保留原模型并可继续使用；打开模型选择器时，当前模型明确显示 `Hidden`。模型名称优先保留，窄选择器会收起非必要标签。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Fixes #1153
- 本 PR 包含：当前选中隐藏模型的 `Hidden` 状态展示、固定/流式选择器窄宽度下的标签降级、远程 device-link 可见性快照支持、回归测试和四语文案。
- 明确不包含：不改变隐藏模型的发送能力，不改 Settings 页面，不立即切换当前会话模型。
- 用户可见变化：隐藏模型在选择器中仍保留为当前项，并显示 `Hidden`；模型名和勾选不会被标签遮挡。
- 是否存在 breaking change：无

### UI 变化

- 截图：Issue #1153 评论中附上拟真界面图。
- 引用的设计规范：不涉及新的视觉规范；沿用现有模型选择器标签、间距和灰度层级，仅新增低层级 `Hidden` 文案并按宽度收起非必要标签。

## 怎么验证的

### 自动验证

```text
pnpm vitest run src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：1 个文件，57 个测试全部通过

pnpm typecheck
结果：通过

pnpm exec eslint src/renderer/components/new-chat/ModelSelector.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
结果：通过

pnpm check:i18n && pnpm check:i18n-glossary
结果：通过；check:i18n 仅报告仓库已有警告

git diff --check
结果：通过
```

### 手工验证

已用拟真界面图确认：当前隐藏模型保留完整模型名，选择器内显示 `Hidden` 与选中勾选；普通订阅模型继续显示 `Subscription`。

### 未执行的验证

未执行 Electron 真机启动；本 PR 仅涉及 renderer 逻辑、文案和测试。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 模型选择器的状态展示和标签布局，不改变模型路由准入或会话发送语义。
- 回滚 / 降级方式：回滚本 PR commit 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因