### PR TITLE
fix(pi): expose custom MCP servers to new Pi sessions

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts
@@ -81,6 +81,23 @@ describe('account provider readiness wiring', () => {
     expect(piShutdown).toBeGreaterThan(providerRefresh);
   });
 
+  it('registers every agent MCP provider array before the initial custom MCP refresh', () => {
+    const piProviders = makerHostSource.indexOf('const piMcpProviders = [');
+    const registerArrays = makerHostSource.indexOf('registerCustomMcpArrays(');
+    const initialRefresh = makerHostSource.indexOf(
+      '_initialCustomMcpRefresh = refreshCustomMcpProviders()',
+      registerArrays,
+    );
+    const registration = makerHostSource.slice(registerArrays, initialRefresh);
+
+    expect(piProviders).toBeGreaterThanOrEqual(0);
+    expect(registerArrays).toBeGreaterThan(piProviders);
+    expect(registration).toContain('claudeMcpProviders');
+    expect(registration).toContain('codexMcpProviders');
+    expect(registration).toContain('piMcpProviders');
+    expect(initialRefresh).toBeGreaterThan(registerArrays);
+  });
+
   it('gates route resolution and the final Maker start hook', () => {
     const bootstrapSession = makerIpcSource.indexOf('async function bootstrapSession');
     const routeGate = makerIpcSource.indexOf(

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -1293,13 +1293,6 @@ export function getMaker(): Maker {
     // API 模式切换 / api_key 变更时 dispose 重建 app-server (单例进程, 配置 spawn 冻入)。
     _codexAgent = codexAgent;
 
-    // 用户自定义 MCP:把两个 agent 的 mcpProviders 数组注册进 registry，并立即尝试一次 refresh。
-    // localDb onReady 可能在 Maker 构造前就已触发（此时 registry 无数组，refresh 空跑）；
-    // 在此补一次 refresh，若 DB 尚未就绪则 refreshCustomMcpProviders 内部 catch 后静默跳过。
-    // 此后每次 CRUD（mcpHandlers.afterChange）也会 refresh。
-    registerCustomMcpArrays(claudeMcpProviders, codexMcpProviders);
-    _initialCustomMcpRefresh = refreshCustomMcpProviders();
-
     // 装配第二步: 把 agents 引用挂回 manager (manager.enable() 时遍历 setMemory(false))。
     attachAgentsToMakerMemory(makerMemoryManager, {
       'claude-code': claudeAgent,
@@ -1414,6 +1407,13 @@ export function getMaker(): Maker {
       ...createDesktopMcpProviders(makerMemoryProviderDeps),
       orcaWorkerBridgeProvider,
     ];
+    // 用户自定义 MCP:三个 agent 都必须注册其实际持有的数组引用，再统一做初始 refresh。
+    // localDb onReady 可能在 Maker 构造前就已触发（此时 registry 无数组，refresh 空跑）；
+    // 在此补一次 refresh，若 DB 尚未就绪则 refreshCustomMcpProviders 内部 catch 后静默跳过。
+    // 此后每次 CRUD（mcpHandlers.afterChange）也会原地刷新三份数组；运行中会话保持启动快照。
+    registerCustomMcpArrays(claudeMcpProviders, codexMcpProviders, piMcpProviders);
+    _initialCustomMcpRefresh = refreshCustomMcpProviders();
+
     const piAgent = buildPiAgent({
       logger: desktopMakerLogger,
       reviewAutoPermissionAction,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -5144,7 +5144,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     removeOAuthCredentials: (providerId) => removeGenericOAuthCredentialsReversibly(providerId),
   });
 
-  // 自定义 MCP 服务器 CRUD —— CRUD 成功后刷新两个 agent 的 mcpProviders 数组
+  // 自定义 MCP 服务器 CRUD —— CRUD 成功后刷新三个 agent 的 mcpProviders 数组
   // （下次新建会话生效）并广播 MCP_CHANGED 让设置页列表 live 刷新。
   registerMcpHandlers(createElectronIpcHandlerRegistry(), {
     refreshProviders: () => refreshCustomMcpProviders(),

--- a/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts
@@ -61,6 +61,21 @@ describe('refreshCustomMcpProviders', () => {
     expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'mytools']);
   });
 
+  it('refreshes every registered agent array with one duplicate-free custom provider batch', async () => {
+    const claude: McpProvider[] = [builtin('cindy_browser')];
+    const codex: McpProvider[] = [builtin('cindy_browser')];
+    const pi: McpProvider[] = [builtin('cindy_browser')];
+    registerCustomMcpArrays(claude, codex, pi);
+    storeMock.listCustomMcpServers.mockResolvedValue([config('one'), config('two')]);
+
+    await refreshCustomMcpProviders();
+    await refreshCustomMcpProviders();
+
+    for (const arr of [claude, codex, pi]) {
+      expect(arr.map((p) => p.name)).toEqual(['cindy_browser', 'one', 'two']);
+    }
+  });
+
   it('skips a custom MCP whose id collides with a builtin server name', async () => {
     const arr: McpProvider[] = [builtin('cindy_browser'), builtin('cindy_helper')];
     registerCustomMcpArrays(arr);

--- a/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
+++ b/apps/desktop/src/main/mcp-integrations/custom-mcp-registry.ts
@@ -3,12 +3,12 @@
  * `mcpProviders` 数组。
  *
  * 背景:ClaudeCodeAgent / CodexAgent 的 `mcpProviders` 数组在 maker-host 启动时
- * **构建一次**并存进 agent 实例;两处消费点(claude buildMcpServers / codex
- * codexEnvironment)每次 startSession 时**重新遍历该数组**。因此只要**原地**改这两个
- * 数组的内容(不换引用),下一次新建会话就会看到最新的自定义 MCP;进行中的会话不受影响
+ * **构建一次**并存进 agent 实例;Claude/Codex/Pi 的消费点每次 startSession 时
+ * **重新遍历该数组**。因此只要**原地**改已注册数组的内容(不换引用),下一次新建会话
+ * 就会看到最新的自定义 MCP;进行中的会话不受影响
  * (与内置 plugin 的 mtime-cached 语义一致)。
  *
- * 用法:maker-host 构造两个 agent 后,把它们各自的 mcpProviders 数组注册进来
+ * 用法:maker-host 构造各 agent 的 provider 数组后,把实际 mcpProviders 引用注册进来
  * (`registerCustomMcpArrays`),再在启动时与每次 CRUD 后调 `refreshCustomMcpProviders`。
  * refresh 会把数组里旧的 CustomMcpProvider 全部移除、按当前 DB 重新追加。
  */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 初始化 custom MCP registry 时漏注册 Pi provider 数组的问题。现在 Claude、Codex、Pi 的实际数组会在同一次 initial refresh 前完成注册，已保存或后续修改的自定义 HTTP MCP 会按现有契约进入下一次新建或重启的 Pi 会话。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1886
- 本 PR 包含：调整 Desktop maker-host 的 custom MCP 数组注册顺序；补三数组同批刷新、重复刷新去重和 Pi 注册时序回归测试。
- 明确不包含：运行中 Pi 会话热更新；HTTP transport、Bearer/custom headers、redirect、URL credentials、secret env、timeout 或 Bash 环境隔离契约改动。
- 用户可见变化：用户配置的自定义 HTTP MCP 会在下一次新建或重启 Pi 会话中出现在工具列表。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/accountProviderReadinessWiring.test.ts src/main/mcp-integrations/__tests__/custom-mcp-registry.test.ts src/main/mcp-integrations/__tests__/piEnvironment.test.ts
结果：23 tests passed

pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/pi-mcp-bridge.integration.test.ts
结果：6 tests passed（真实 Pi 0.83.0 bridge，覆盖 mcp__ 工具注册、Bearer/custom headers、SSE、分页、超时/错误与日志脱敏）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：全部通过（350 passed，1 skipped；随后 Desktop、Mobile 与各 workspace unit 均通过）

pnpm check:dco
结果：通过

node ~/.agents/skills/git-workflow/scripts/pr-size-gate.mjs
结果：PASS（非测试 +12 行 / 3 文件）
```

### 手工验证

不涉及额外手工 UI 操作；通过真实 Pi bridge integration 验证新会话工具发现链。

### 未执行的验证

未在 Windows x64 实机启动 Desktop；改动只调整 TypeScript 数组引用注册顺序，不涉及路径、环境变量格式或平台分支。未改动运行中会话热更新行为。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop custom MCP registry 初始化与 CRUD 后刷新所维护的 agent provider 数组。
- 回滚 / 降级方式：回滚本提交即可恢复原注册顺序；不涉及数据迁移、schema 或持久化格式变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外文档）
- [x] 已确认测试结果或说明未执行原因