### PR TITLE
fix(desktop): xd title one-shot picks model from live gateway catalog (#1891)

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -402,6 +402,28 @@ describe('buildTitleTarget(锁定 catalog titleModel 配置)', () => {
       setXdGatewayModels([]);
     }
   });
+  it('xd 清单含 responses 模型 → 跳过,只选原生 chat(Greptile P2)', () => {
+    // responses 模型需要 Codex Responses wire,标题通道固定 gateway-chat——
+    // 选中会被网关拒收,必须排除。
+    setXdGatewayModels([
+      { id: 'qwen/qwen3.8-max', mode: 'responses' },
+      { id: 'deepseek/deepseek-v4-flash', mode: 'chat' },
+    ]);
+    try {
+      const target = buildTitleTarget('xd');
+      expect(target?.model).toBe('deepseek/deepseek-v4-flash');
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
+  it('xd 清单只有 responses 模型 → null(无可用 chat 模型,不发请求)', () => {
+    setXdGatewayModels([{ id: 'qwen/qwen3.8-max', mode: 'responses' }]);
+    try {
+      expect(buildTitleTarget('xd')).toBeNull();
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
   it('未知 provider → null', () => {
     expect(buildTitleTarget('does-not-exist')).toBeNull();
   });

--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -14,12 +14,18 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
-const { mockGetAppCapabilities } = vi.hoisted(() => ({
+const { mockGetAppCapabilities, mockReadModelDisableOverrides } = vi.hoisted(() => ({
   mockGetAppCapabilities: vi.fn(() => ({ canUseCindyGateway: true })),
+  mockReadModelDisableOverrides: vi.fn(() => ({})),
 }));
 
 vi.mock('../../appCapabilities.js', () => ({
   getAppCapabilities: mockGetAppCapabilities,
+}));
+
+// 用户停用覆盖(disable override store)在测试里可控;默认空 = 无停用。
+vi.mock('../model-disable-store.js', () => ({
+  readModelDisableOverrides: mockReadModelDisableOverrides,
 }));
 
 // xd 网关上游运行期来自 model-access server 下发(effectiveXdGatewayBaseUrl),
@@ -418,6 +424,38 @@ describe('buildTitleTarget(锁定 catalog titleModel 配置)', () => {
   });
   it('xd 清单只有 responses 模型 → null(无可用 chat 模型,不发请求)', () => {
     setXdGatewayModels([{ id: 'qwen/qwen3.8-max', mode: 'responses' }]);
+    try {
+      expect(buildTitleTarget('xd')).toBeNull();
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
+  it('用户停用清单中最便宜的模型 → 选次便宜可用模型(Codex round 2)', () => {
+    setXdGatewayModels([
+      { id: 'deepseek/deepseek-v4-flash', mode: 'chat', inputCostPerToken: 0.1, outputCostPerToken: 0.2 },
+      { id: 'moonshotai/kimi-k3', mode: 'chat', inputCostPerToken: 1, outputCostPerToken: 2 },
+    ]);
+    mockReadModelDisableOverrides.mockReturnValueOnce({
+      disabledModels: { 'xd:deepseek/deepseek-v4-flash': true },
+    });
+    try {
+      // 最便宜的 deepseek 被用户停用 → 应跳过,选 kimi-k3
+      expect(buildTitleTarget('xd')?.model).toBe('moonshotai/kimi-k3');
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
+  it('清单中全部 chat 模型都被用户停用 → null', () => {
+    setXdGatewayModels([
+      { id: 'deepseek/deepseek-v4-flash', mode: 'chat' },
+      { id: 'moonshotai/kimi-k3', mode: 'chat' },
+    ]);
+    mockReadModelDisableOverrides.mockReturnValueOnce({
+      disabledModels: {
+        'xd:deepseek/deepseek-v4-flash': true,
+        'xd:moonshotai/kimi-k3': true,
+      },
+    });
     try {
       expect(buildTitleTarget('xd')).toBeNull();
     } finally {

--- a/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts
@@ -240,19 +240,24 @@ describe('generateTitleViaProvider — provider 解析', () => {
   });
 
   it('DB 无显式 + xd 已连接 → 走 xd(cc 默认)', async () => {
-    const fetchImpl = fakeFetch(() => ({
-      json: { choices: [{ message: { content: '网关标题' } }] },
-    }));
-    const title = await generateTitleViaProvider(
-      { sessionId: 's2', agentKind: 'claude-code', prompt: 'x' },
-      {
-        fetchImpl,
-        readSessionProviderId: async () => null,
-        listConnectedProviders: async () => [providerStub('xd')],
-        readGatewayKey: () => 'gk',
-      },
-    );
-    expect(title).toBe('网关标题');
+    setXdGatewayModels([{ id: 'deepseek/deepseek-v4-flash', mode: 'chat' }]);
+    try {
+      const fetchImpl = fakeFetch(() => ({
+        json: { choices: [{ message: { content: '网关标题' } }] },
+      }));
+      const title = await generateTitleViaProvider(
+        { sessionId: 's2', agentKind: 'claude-code', prompt: 'x' },
+        {
+          fetchImpl,
+          readSessionProviderId: async () => null,
+          listConnectedProviders: async () => [providerStub('xd')],
+          readGatewayKey: () => 'gk',
+        },
+      );
+      expect(title).toBe('网关标题');
+    } finally {
+      setXdGatewayModels([]);
+    }
   });
 
   it('DB 无显式 + 只有 anthropic 已连接(无 xd)→ 走 anthropic', async () => {
@@ -348,18 +353,51 @@ describe('buildTitleTarget(锁定 catalog titleModel 配置)', () => {
       setActiveCatalog(BUNDLED_CATALOG);
     }
   });
-  it('xd → gpt-5.4-mini / 网关 chat-completions(/v1 upstream)', () => {
-    // xd 模型以网关实时清单为准(默认空):注入 titleModel 同 id 条目,
-    // 元数据(efforts)回落目录静态条目 → 最低 effort = low。
-    setXdGatewayModels([{ id: 'gpt-5.4-mini' }]);
+  it('xd → 从网关实时清单选可用聊天模型 / 网关 chat-completions(/v1 upstream)', () => {
+    // xd 模型以网关实时清单为准(2026-08-06 #1891 修复:不再读静态 titleModel):
+    // 注入清单含聊天模型与图像模型,标题应选聊天模型(最经济)。
+    setXdGatewayModels([
+      { id: 'deepseek/deepseek-v4-flash', mode: 'chat' },
+      { id: 'gpt-image-2', mode: 'image' },
+    ]);
     try {
       expect(buildTitleTarget('xd')).toEqual({
         providerId: 'xd',
-        model: 'gpt-5.4-mini',
+        model: 'deepseek/deepseek-v4-flash',
         effort: 'low',
         wire: 'gateway-chat',
         upstream: `${XD_GATEWAY_BASE_URL}/v1`,
       });
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
+  it('xd 清单只有非聊天模型(图像/向量)→ null,不发送无效请求', () => {
+    setXdGatewayModels([
+      { id: 'gpt-image-2', mode: 'image' },
+      { id: 'voyage/voyage-4', mode: 'embedding' },
+    ]);
+    try {
+      expect(buildTitleTarget('xd')).toBeNull();
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
+  it('xd 清单为空 → null(网关清单即权威,不回落静态 titleModel)', () => {
+    setXdGatewayModels([]);
+    expect(buildTitleTarget('xd')).toBeNull();
+  });
+  it('xd 清单只有 chat + 图像混合 → 只选 chat,模式权威过滤', () => {
+    setXdGatewayModels([
+      { id: 'gpt-image-2', mode: 'image' },
+      { id: 'deepseek/deepseek-v4-flash', mode: 'chat' },
+      { id: 'moonshotai/kimi-k3', mode: 'chat' },
+    ]);
+    try {
+      const target = buildTitleTarget('xd');
+      // 两个 chat 模型无 cost 信息 → 都保持可用,选中任意一个 chat 模型(非图像)
+      expect(['deepseek/deepseek-v4-flash', 'moonshotai/kimi-k3']).toContain(target?.model);
+      expect(target?.model).not.toBe('gpt-image-2');
     } finally {
       setXdGatewayModels([]);
     }
@@ -540,41 +578,70 @@ describe('generateTitleViaProvider — openai(codex Responses SSE)', () => {
 // ── generateTitleViaProvider — xd(网关 chat-completions)─────────────────
 
 describe('generateTitleViaProvider — xd(网关 chat-completions)', () => {
-  it('200 → 解析 choices[].message.content;请求形状正确', async () => {
-    const fetchImpl = fakeFetch(() => ({
-      json: { choices: [{ message: { content: '网关标题' } }] },
-    }));
-    const title = await generateTitleViaProvider(
-      { sessionId: 's3', agentKind: 'claude-code', prompt: 'x' },
-      {
-        fetchImpl,
-        readSessionProviderId: async () => 'xd',
-        listConnectedProviders: async () => [providerStub('xd')],
-        readGatewayKey: () => 'gk-1',
-      },
-    );
-    expect(title).toBe('网关标题');
-    const [url, init] = vi.mocked(fetchImpl).mock.calls[0] as [
-      string,
-      { headers: Record<string, string>; body: string },
-    ];
-    expect(url).toBe(`${XD_GATEWAY_BASE_URL}/v1/chat/completions`);
-    expect(init.headers.authorization).toBe('Bearer gk-1');
-    expect(JSON.parse(init.body).model).toBe('gpt-5.4-mini');
+  it('200 → 解析 choices[].message.content;请求形状正确(模型取自网关清单)', async () => {
+    setXdGatewayModels([{ id: 'deepseek/deepseek-v4-flash', mode: 'chat' }]);
+    try {
+      const fetchImpl = fakeFetch(() => ({
+        json: { choices: [{ message: { content: '网关标题' } }] },
+      }));
+      const title = await generateTitleViaProvider(
+        { sessionId: 's3', agentKind: 'claude-code', prompt: 'x' },
+        {
+          fetchImpl,
+          readSessionProviderId: async () => 'xd',
+          listConnectedProviders: async () => [providerStub('xd')],
+          readGatewayKey: () => 'gk-1',
+        },
+      );
+      expect(title).toBe('网关标题');
+      const [url, init] = vi.mocked(fetchImpl).mock.calls[0] as [
+        string,
+        { headers: Record<string, string>; body: string },
+      ];
+      expect(url).toBe(`${XD_GATEWAY_BASE_URL}/v1/chat/completions`);
+      expect(init.headers.authorization).toBe('Bearer gk-1');
+      expect(JSON.parse(init.body).model).toBe('deepseek/deepseek-v4-flash');
+    } finally {
+      setXdGatewayModels([]);
+    }
+  });
+  it('网关清单无聊天模型 → 不发送请求、回落 null', async () => {
+    setXdGatewayModels([{ id: 'gpt-image-2', mode: 'image' }]);
+    try {
+      const fetchImpl = fakeFetch(() => ({ json: {} }));
+      const title = await generateTitleViaProvider(
+        { sessionId: 's3', agentKind: 'claude-code', prompt: 'x' },
+        {
+          fetchImpl,
+          readSessionProviderId: async () => 'xd',
+          listConnectedProviders: async () => [providerStub('xd')],
+          readGatewayKey: () => 'gk-1',
+        },
+      );
+      expect(title).toBeNull();
+      expect(fetchImpl).not.toHaveBeenCalled();
+    } finally {
+      setXdGatewayModels([]);
+    }
   });
   it('无网关 key → null', async () => {
-    const fetchImpl = fakeFetch(() => ({ json: {} }));
-    const title = await generateTitleViaProvider(
-      { sessionId: 's3', agentKind: 'claude-code', prompt: 'x' },
-      {
-        fetchImpl,
-        readSessionProviderId: async () => 'xd',
-        listConnectedProviders: async () => [providerStub('xd')],
-        readGatewayKey: () => null,
-      },
-    );
-    expect(title).toBeNull();
-    expect(fetchImpl).not.toHaveBeenCalled();
+    setXdGatewayModels([{ id: 'deepseek/deepseek-v4-flash', mode: 'chat' }]);
+    try {
+      const fetchImpl = fakeFetch(() => ({ json: {} }));
+      const title = await generateTitleViaProvider(
+        { sessionId: 's3', agentKind: 'claude-code', prompt: 'x' },
+        {
+          fetchImpl,
+          readSessionProviderId: async () => 'xd',
+          listConnectedProviders: async () => [providerStub('xd')],
+          readGatewayKey: () => null,
+        },
+      );
+      expect(title).toBeNull();
+      expect(fetchImpl).not.toHaveBeenCalled();
+    } finally {
+      setXdGatewayModels([]);
+    }
   });
 });
 

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -139,26 +139,63 @@ function titleRouteUnavailableReason(
 }
 
 /**
+ * XD 网关实时清单中选标题模型:存在 + 具备聊天能力 + 未停用/未退休,取单价最低者
+ * (标题 oneShot 语义 = 最经济模型)。清单为空或无可用聊天模型 → null(回落启发式,
+ * 不向网关发送必然 400 的无效请求)。
+ *
+ * 2026-08-06 修复(#1891):此前 xd 分支直发静态 titleModel `gpt-5.4-mini`,而网关
+ * 清单已不含该模型(网关 /v1/models 是权威,模型 id 均带供应商前缀)——修复后改为
+ * 从 active catalog 中 xd provider 的 models(由 setXdGatewayModels 整体重建)选择,
+ * 网关清单变化不再导致标题通道硬失败。
+ */
+function pickXdTitleModel(provider: Provider): CatalogModel | null {
+  const candidates: CatalogModel[] = [];
+  for (const agent of provider.agents) {
+    for (const model of provider.models[agent] ?? []) {
+      if (isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' })) {
+        candidates.push(model);
+      }
+    }
+  }
+  if (candidates.length === 0) return null;
+  // 按 per-1M token 总价升序选最经济;无价条目排后(仍可被选中,兜底保证可用性)。
+  const costRank = (m: CatalogModel): number => {
+    const c = m.cost;
+    if (!c) return Number.POSITIVE_INFINITY;
+    return (typeof c.input === 'number' ? c.input : 0) + (typeof c.output === 'number' ? c.output : 0);
+  };
+  return [...candidates].sort((a, b) => costRank(a) - costRank(b))[0];
+}
+
+/**
  * 据 providerId 组装标题目标(模型 + 最低 effort + wire + upstream)。
  * provider 无 titleModel / 无对应路由 / 未知 provider → null(不参与智能起名)。
  *
  * wire 按 provider 分派:内置三家协议各异且无法纯靠 authStrategy 区分(anthropic 与 openai
  * 同为 oauth-passthrough 但 wire 不同),故按 id 显式分派。**新增供应商的标题支持 = 加一个 case。**
+ *
+ * 注意:anthropic / openai 的 titleModel 是各自订阅通道内有效的静态值(haiku /
+ * gpt-5.4-mini 在 ChatGPT 后端有效);xd 是动态清单供应商,**标题模型从网关实时
+ * 清单选择**(pickXdTitleModel),不读静态 titleModel(网关清单即权威)。
  */
 export function buildTitleTarget(providerId: string): TitleTarget | null {
   const provider = getActiveCatalog().providers.find((p) => p.id === providerId);
-  if (!provider?.titleModel) return null;
-  const model = provider.titleModel;
-  const effort = lowestEffort(findCatalogModel(provider, model)?.efforts ?? []);
+  if (!provider) return null;
 
   switch (provider.id) {
     case 'anthropic': {
+      if (!provider.titleModel) return null;
+      const model = provider.titleModel;
+      const effort = lowestEffort(findCatalogModel(provider, model)?.efforts ?? []);
       const routing = provider.routing['claude-code'];
       return routing
         ? { providerId, model, effort, wire: 'anthropic-messages', upstream: routing.upstream }
         : null;
     }
     case 'openai': {
+      if (!provider.titleModel) return null;
+      const model = provider.titleModel;
+      const effort = lowestEffort(findCatalogModel(provider, model)?.efforts ?? []);
       const routing = provider.routing['codex'];
       return routing
         ? { providerId, model, effort, wire: 'codex-responses', upstream: routing.upstream }
@@ -166,20 +203,25 @@ export function buildTitleTarget(providerId: string): TitleTarget | null {
     }
     case 'xd': {
       if (!getAppCapabilities().canUseCindyGateway) return null;
-      // titleModel 为 gpt-5.4-mini(OpenAI 系)→ 走网关 litellm 的 chat-completions。
       // 上游不取 catalog routing.upstream:XD 网关入口一律用 model-access server
       // 随凭据下发的 endpoint(与 key 同租户,见 effectiveEndpoint.ts);凭据未
       // 就绪(空串)时返回 null,回落启发式起名。
       const base = effectiveXdGatewayBaseUrl().trim();
-      return base
-        ? {
-            providerId,
-            model,
-            effort,
-            wire: 'gateway-chat',
-            upstream: `${trimTrailingSlash(base)}/v1`,
-          }
-        : null;
+      if (!base) return null;
+      const model = pickXdTitleModel(provider);
+      if (!model) {
+        log.debug('title oneShot skipped: no usable chat model in xd gateway catalog', {
+          providerId,
+        });
+        return null;
+      }
+      return {
+        providerId,
+        model: model.id,
+        effort: lowestEffort(model.efforts ?? []),
+        wire: 'gateway-chat',
+        upstream: `${trimTrailingSlash(base)}/v1`,
+      };
     }
     default:
       return null;

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -149,6 +149,11 @@ function titleRouteUnavailableReason(
  * 网关清单变化不再导致标题通道硬失败。
  */
 function pickXdTitleModel(provider: Provider): CatalogModel | null {
+  // 用户显式停用(disable override store)优先于清单排序:active catalog 的 xd
+  // 模型不带 buildRegistry 烘焙的 disabled 字段(那在 rail 的 ProviderView 上),
+  // 只查目录会选中已停用模型,派发前 routeUnavailableNow 再中止整个 one-shot,
+  // 标题退回落启发式而非次便宜可用模型(Codex review round 2)。
+  const disableOverrides = readModelDisableOverrides();
   const candidates: CatalogModel[] = [];
   for (const agent of provider.agents) {
     for (const model of provider.models[agent] ?? []) {
@@ -160,6 +165,7 @@ function pickXdTitleModel(provider: Provider): CatalogModel | null {
       // 被网关拒收(Greptile review P2,2026-08-06)。mode 缺省(网关旧条目)按 chat
       // 处理,由 isModelSelectableForNewRoute 的 id 分类兜底。
       if (model.mode === 'responses') continue;
+      if (isModelDisabled(disableOverrides, provider.id, model.id)) continue;
       candidates.push(model);
     }
   }

--- a/apps/desktop/src/main/maker-host/title-one-shot.ts
+++ b/apps/desktop/src/main/maker-host/title-one-shot.ts
@@ -152,9 +152,15 @@ function pickXdTitleModel(provider: Provider): CatalogModel | null {
   const candidates: CatalogModel[] = [];
   for (const agent of provider.agents) {
     for (const model of provider.models[agent] ?? []) {
-      if (isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' })) {
-        candidates.push(model);
+      if (!isModelSelectableForNewRoute(model, { userProvider: provider.source === 'user' })) {
+        continue;
       }
+      // 只选原生 chat 模型:mode 明确为 'responses' 的模型需要走 Codex Responses
+      // wire,而标题通道固定走 gateway-chat(/v1/chat/completions)——选中的话仍会
+      // 被网关拒收(Greptile review P2,2026-08-06)。mode 缺省(网关旧条目)按 chat
+      // 处理,由 isModelSelectableForNewRoute 的 id 分类兜底。
+      if (model.mode === 'responses') continue;
+      candidates.push(model);
     }
   }
   if (candidates.length === 0) return null;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 XD 网关标题通道的硬编码模型失效问题(#1891):「AI 重命名」与自动起名此前把静态 `gpt-5.4-mini` 发给网关,但该模型已不在网关实时清单(清单模型 id 均带供应商前缀,如 `deepseek/deepseek-v4-flash`),每次请求都被网关 400 `Invalid model name` 拒绝,功能一直失败。本次改为从网关实时清单动态选择最经济的可用聊天模型,清单不可用时直接回落启发式标题、不再发必然失败的请求。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#1891
- 本 PR 包含：
  - `apps/desktop/src/main/maker-host/title-one-shot.ts`：xd 标题模型选择逻辑（`pickXdTitleModel` 新增：从 active catalog 的 xd 网关清单选「存在 + 聊天能力 + 未停用」的最经济模型；排除 `mode: 'responses'` 与用户停用模型；无可用模型返回 null 回落启发式）
  - `apps/desktop/src/main/maker-host/__tests__/titleOneShot.test.ts`：更新 + 新增测试（清单选模型 / 非聊天模型排除 / responses 排除 / 用户停用排除 / 空清单与全停用回落 / 请求体模型取自清单）
- 明确不包含：embedding 通道修复（`voyage/voyage-4` 同类问题，由 #1399 跟进）；XD 清单就绪后的自动起名重试机制（独立增强，见 Greptile P1 讨论）
- 用户可见变化：AI 重命名 / 自动起名在 XD 网关下恢复可用；网关清单变化时标题模型自动跟随，不再因模型下架而失败
- 是否存在 breaking change：无

### UI 变化

不涉及（main 进程逻辑改动，无 UI 代码路径）

## 怎么验证的

### 自动验证

```text
cd apps/desktop
pnpm exec vitest run src/main/maker-host/__tests__/titleOneShot.test.ts
结果：35 passed（含新增：清单选模型、非聊天/responses/用户停用排除、空清单回落、请求体模型断言）

pnpm exec vitest run src/main/maker-ipc/__tests__/autoTitleIpcBoundary.test.ts
结果：33 passed

pnpm --filter desktop run --if-present typecheck
结果：通过（无输出）

pnpm test:unit（全量）
结果：1 个失败 devCliFlags（文件系统大小写探测，Windows 平台行为；git stash -u 后重跑仍失败 = 预先存在，与本次改动无关）
```

### 手工验证

不涉及（逻辑改动已在单测覆盖；真机验证需用户重新构建桌面端后操作 AI 重命名，见「未执行的验证」）

### 未执行的验证

未在本机运行版实机操作验证（当前运行版为 0.1.31 安装版 / 本地构建版，需用户重新构建桌面端后方可实机验证 AI 重命名；代码路径已由 68 个单测覆盖，网关 `/v1/models` 清单已实测为 6 个带前缀模型、不含 `gpt-5.4-mini`）

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 xd 供应商的标题 oneShot 选择逻辑。网关清单变化时标题模型可能在多个聊天模型间切换（均为聊天模型、标题 ≤20 字，无实质影响）；清单为空或全部停用时标题回落启发式（与修复前"请求被拒后回落"的用户可见结果一致，但不再烧一次无效请求）
- 回滚 / 降级方式：4 commits（含 1 个空 commit），合并后单 commit（squash）可整体 revert

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（不涉及 UI，已注明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

Closes #1891

🤖 Generated with [Claude Code](https://claude.com/claude-code)
