### PR TITLE
fix(pi): 按网关模型能力拦截图片输入

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
@@ -208,6 +208,32 @@ describe('XD 网关权威模型清单重建', () => {
     expect('icon' in (cc.find((m) => m.id === 'plain-model') ?? {})).toBe(false);
   });
 
+  it('把网关图片输入 modalities 投影到 Pi 的 provider-model 能力', () => {
+    setActiveCatalog(BUNDLED_CATALOG);
+    setXdGatewayModels([
+      {
+        id: 'gateway-vision',
+        modalities: { input: ['text', 'image'], output: ['text'] },
+      },
+      {
+        id: 'gateway-text',
+        modalities: { input: ['text'], output: ['text'] },
+      },
+      { id: 'gateway-unknown' },
+    ]);
+
+    const pi = deriveAvailableModels(getActiveCatalog(), 'pi');
+    expect(pi.find((model) => model.id === 'gateway-vision')).toMatchObject({
+      supportsImageInput: true,
+    });
+    expect(pi.find((model) => model.id === 'gateway-text')).toMatchObject({
+      supportsImageInput: false,
+    });
+    expect(pi.find((model) => model.id === 'gateway-unknown')).not.toHaveProperty(
+      'supportsImageInput',
+    );
+  });
+
   it('把标准 token 价投影为每百万 token 的折后展示价', () => {
     setActiveCatalog(BUNDLED_CATALOG);
     setXdGatewayModels([

--- a/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
@@ -177,6 +177,27 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
     });
   });
 
+  it('projects explicit provider-model image modalities and leaves unknown capability unset', () => {
+    const catalog = structuredClone(BUNDLED_CATALOG);
+    const xd = catalog.providers.find((provider) => provider.id === 'xd');
+    expect(xd).toBeDefined();
+    xd!.models.pi = [
+      model('gateway-vision', { modalities: { input: ['text', 'image'], output: ['text'] } }),
+      model('gateway-text', { modalities: { input: ['text'], output: ['text'] } }),
+      model('gateway-unknown'),
+    ];
+
+    expect(resolvePiRuntimeModelDescriptor(catalog, 'cindy', 'gateway-vision')).toMatchObject({
+      supportsImageInput: true,
+    });
+    expect(resolvePiRuntimeModelDescriptor(catalog, 'cindy', 'gateway-text')).toMatchObject({
+      supportsImageInput: false,
+    });
+    expect(resolvePiRuntimeModelDescriptor(catalog, 'cindy', 'gateway-unknown')).not.toHaveProperty(
+      'supportsImageInput',
+    );
+  });
+
   it('bundled(未注入)派生 = 仅 xai 静态清单,动态供应商不贡献任何条目', () => {
     const cc = deriveAvailableModels(BUNDLED_CATALOG, 'claude-code');
     const codex = deriveAvailableModels(BUNDLED_CATALOG, 'codex');

--- a/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
+++ b/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
@@ -82,6 +82,9 @@ function toDescriptor(
   if (m.defaultEnabled !== undefined) d.defaultEnabled = m.defaultEnabled;
   if (m.cost !== undefined) d.cost = m.cost;
   if (m.maxOutput !== undefined) d.maxOutputTokens = m.maxOutput;
+  const supportsImageInput = m.supportsImageInput
+    ?? (m.modalities !== undefined ? m.modalities.input.includes('image') : undefined);
+  if (supportsImageInput !== undefined) d.supportsImageInput = supportsImageInput;
   return d;
 }
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-provider-routing.test.ts
@@ -570,26 +570,64 @@ describe('Pi provider-aware model routing', () => {
     await handle.close();
   });
 
-  it('guards image prompts by the actual provider-model capability and follows model switches', async () => {
-    const agent = new PiAgent(byomDeps(async () => ({
-      providers: [
-        {
-          id: 'native-text',
-          name: 'Native Text',
-          baseUrl: 'http://text.test',
-          api: 'openai-completions',
-          models: [{ id: 'local-model', input: ['text'] }],
-        },
-        {
-          id: 'native-vision',
-          name: 'Native Vision',
-          baseUrl: 'http://vision.test',
-          api: 'openai-completions',
-          models: [{ id: 'local-model', input: ['text', 'image'] }],
-        },
-      ],
-      env: {},
-    })));
+  it('guards image prompts by the startup provider-model capability and follows model switches', async () => {
+    const gatewayModels: ModelDescriptor[] = [
+      {
+        id: 'gateway-text',
+        displayName: 'Gateway Text',
+        contextWindow: 200_000,
+        efforts: [],
+        defaultEffort: null,
+        supportsImageInput: false,
+      },
+      {
+        id: 'gateway-vision',
+        displayName: 'Gateway Vision',
+        contextWindow: 200_000,
+        efforts: [],
+        defaultEffort: null,
+        supportsImageInput: true,
+      },
+      {
+        id: 'gateway-unknown',
+        displayName: 'Gateway Unknown',
+        contextWindow: 200_000,
+        efforts: [],
+        defaultEffort: null,
+      },
+      {
+        id: 'local-model',
+        displayName: 'Local',
+        contextWindow: 200_000,
+        efforts: [],
+        defaultEffort: null,
+      },
+    ];
+    const resolveGatewayModel = vi.fn((modelId: string) =>
+      gatewayModels.find((candidate) => candidate.id === modelId) ?? null,
+    );
+    const agent = new PiAgent({
+      ...byomDeps(async () => ({
+        providers: [
+          {
+            id: 'native-text',
+            name: 'Native Text',
+            baseUrl: 'http://text.test',
+            api: 'openai-completions',
+            models: [{ id: 'local-model', input: ['text'] }],
+          },
+          {
+            id: 'native-vision',
+            name: 'Native Vision',
+            baseUrl: 'http://vision.test',
+            api: 'openai-completions',
+            models: [{ id: 'local-model', input: ['text', 'image'] }],
+          },
+        ],
+        env: {},
+      }), gatewayModels),
+      resolvePiGatewayModelDescriptor: resolveGatewayModel,
+    });
     const handle = await agent.startSession({
       sessionId: 'image-capability',
       workingDir: cwd,
@@ -608,6 +646,37 @@ describe('Pi provider-aware model routing', () => {
       type: 'user' as const,
       content: [{ type: 'image' as const, path: imagePath }],
     };
+    const mixedMessage = {
+      type: 'user' as const,
+      content: [
+        { type: 'text' as const, text: 'describe this image' },
+        { type: 'image' as const, path: imagePath },
+      ],
+    };
+    const instructedMessage = {
+      type: 'user' as const,
+      content: [
+        { type: 'text' as const, text: '$识图 请读取附件' },
+        { type: 'image' as const, path: imagePath },
+      ],
+    };
+    const multiImageMessage = {
+      type: 'user' as const,
+      content: [
+        { type: 'image' as const, path: imagePath },
+        { type: 'image' as const, path: imagePath },
+      ],
+    };
+    const modelsJson = JSON.parse(
+      readFileSync(path.join(captured.env.PI_CODING_AGENT_DIR as string, 'models.json'), 'utf8'),
+    ) as {
+      providers: Record<string, { models: Array<{ id: string; input: string[] }> }>;
+    };
+    expect(modelsJson.providers.cindy?.models).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'gateway-text', input: ['text'] }),
+      expect.objectContaining({ id: 'gateway-vision', input: ['text', 'image'] }),
+      expect.objectContaining({ id: 'gateway-unknown', input: ['text'] }),
+    ]));
 
     captured.requests.length = 0;
     await expect(handle.send(imageMessage)).rejects.toMatchObject({
@@ -627,11 +696,42 @@ describe('Pi provider-aware model routing', () => {
       images: [expect.objectContaining({ type: 'image', mimeType: 'image/png' })],
     }));
 
-    // 显式清除来源后实际路由回到 cindy 网关；同名 BYOM 不能抢走能力判断。
-    await handle.setModel!('local-model', { providerId: null });
+    // 网关纯文本模型在 Pi/provider 调用前拒绝所有带图形态；文本指令不能绕过能力门。
+    await handle.setModel!('gateway-text', { providerId: null });
     captured.requests.length = 0;
-    await handle.send(imageMessage);
-    expect(captured.requests.some((request) => request.type === 'prompt')).toBe(true);
+    for (const message of [imageMessage, mixedMessage, instructedMessage, multiImageMessage]) {
+      await expect(handle.send(message)).rejects.toMatchObject({
+        code: 'PI_IMAGE_INPUT_UNSUPPORTED',
+      });
+    }
+    await expect(handle.steer!(mixedMessage)).rejects.toMatchObject({
+      code: 'PI_IMAGE_INPUT_UNSUPPORTED',
+    });
+    expect(captured.requests.some((request) => request.type === 'prompt' || request.type === 'steer'))
+      .toBe(false);
+
+    // 能力未知同样 fail closed；活动会话只认启动时写入 models.json 的能力快照。
+    await handle.setModel!('gateway-unknown', { providerId: null });
+    await expect(handle.send(imageMessage)).rejects.toMatchObject({
+      code: 'PI_IMAGE_INPUT_UNSUPPORTED',
+    });
+    gatewayModels[0]!.supportsImageInput = true;
+    await handle.setModel!('gateway-text', { providerId: null });
+    await expect(handle.send(imageMessage)).rejects.toMatchObject({
+      code: 'PI_IMAGE_INPUT_UNSUPPORTED',
+    });
+
+    // 明确支持图片的网关模型保留全部图片块，多图不被剥离或改写。
+    await handle.setModel!('gateway-vision', { providerId: null });
+    captured.requests.length = 0;
+    await handle.send(multiImageMessage);
+    expect(captured.requests).toContainEqual(expect.objectContaining({
+      type: 'prompt',
+      images: [
+        expect.objectContaining({ type: 'image', mimeType: 'image/png' }),
+        expect.objectContaining({ type: 'image', mimeType: 'image/png' }),
+      ],
+    }));
 
     // 文件读失败不会生成 image block，仍保留既有的“图片不可读”文本语义。
     await handle.setModel!('local-model', { providerId: 'native-text' });

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -435,7 +435,7 @@ export class PiAgent extends BaseAgent {
     agentHome: string,
     nativeProviders: PiNativeProviderSpec[] = [],
     retainedRuntimeModel?: ModelDescriptor,
-  ): Promise<void> {
+  ): Promise<Map<string, boolean>> {
     const endpoint = this.deps.runtimeConfig.endpoint;
     if (!endpoint) {
       this.deps.logger.warn('pi: runtimeConfig.endpoint missing — models.json will have no usable provider');
@@ -444,17 +444,20 @@ export class PiAgent extends BaseAgent {
     const runtimeModels = retainedRuntimeModel && !publicModels.some((m) => m.id === retainedRuntimeModel.id)
       ? [...publicModels, retainedRuntimeModel]
       : publicModels;
+    const gatewayImageInputByModel = new Map<string, boolean>();
     const models = runtimeModels.map((publicModel: ModelDescriptor) => {
       // availableModels 为跨 provider 拍平的公开能力；BYOM 同 id 冲突时 effort
       // 会按设计收敛成交集。cindy gateway 块则代表内置路由，必须回查其
       // provider-aware 描述符，不能被同名 non-reasoning BYOM 清空 reasoning。
       // host 未注入 resolver 或只有 BYOM 条目时保留旧 flat fallback。
       const m = this.deps.resolvePiGatewayModelDescriptor?.(publicModel.id) ?? publicModel;
+      const supportsImageInput = m.supportsImageInput === true;
+      gatewayImageInputByModel.set(m.id, supportsImageInput);
       return {
         id: m.id,
         name: m.displayName,
         reasoning: m.efforts.length > 0,
-        input: ['text', 'image'],
+        input: supportsImageInput ? ['text', 'image'] : ['text'],
         contextWindow: m.contextWindow > 0 ? m.contextWindow : 200_000,
         maxTokens: m.maxOutputTokens && m.maxOutputTokens > 0 ? m.maxOutputTokens : 32_000,
         // 计费单位与目录一致($/1M tokens);pi 按此自行计价,usage 事件的 cost 才有真值。
@@ -504,6 +507,7 @@ export class PiAgent extends BaseAgent {
     }
     await fs.mkdir(agentHome, { recursive: true });
     await fs.writeFile(path.join(agentHome, 'models.json'), JSON.stringify({ providers }, null, 2) + '\n');
+    return gatewayImageInputByModel;
   }
 
   async startSession(opts: StartSessionOptions): Promise<AgentSessionHandle> {
@@ -716,7 +720,11 @@ export class PiAgent extends BaseAgent {
       configHomeCleaned = true;
       void fs.rm(configHome, { recursive: true, force: true }).catch(() => {});
     };
-    await this.writeModelsJson(configHome, nativeProviders, retainedRuntimeModel);
+    const gatewayImageInputByModel = await this.writeModelsJson(
+      configHome,
+      nativeProviders,
+      retainedRuntimeModel,
+    );
     const sessionDir = path.join(agentHome, 'sessions');
     await fs.mkdir(sessionDir, { recursive: true });
 
@@ -1468,11 +1476,14 @@ export class PiAgent extends BaseAgent {
     };
 
     const assertImageInputSupported = (images: readonly PiPromptImage[]): void => {
-      if (images.length === 0 || mutablePiProviderId === PI_PROVIDER_ID) return;
-      const nativeModel = nativeProviderById
-        .get(mutablePiProviderId)
-        ?.models.find((candidate) => candidate.id === mutableModel);
-      if (nativeModel?.input?.includes('image')) return;
+      if (images.length === 0) return;
+      const supportsImageInput = mutablePiProviderId === PI_PROVIDER_ID
+        ? gatewayImageInputByModel.get(mutableModel) === true
+        : nativeProviderById
+          .get(mutablePiProviderId)
+          ?.models.find((candidate) => candidate.id === mutableModel)
+          ?.input?.includes('image') === true;
+      if (supportsImageInput) return;
       throw new PiImageInputUnsupportedError();
     };
 

--- a/packages/maker-core/src/types/capabilities.ts
+++ b/packages/maker-core/src/types/capabilities.ts
@@ -270,6 +270,11 @@ export interface ModelDescriptor {
   cost?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
   /** 最大输出 tokens(源自目录 maxOutput)。缺省时各 agent 用自身默认值。 */
   maxOutputTokens?: number;
+  /**
+   * 当前实际 provider-model 路由是否明确支持图片输入。
+   * 缺省表示能力未知；调用方必须 fail closed，不能据模型名或协议猜测。
+   */
+  supportsImageInput?: boolean;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

Pi 的 Cindy 网关 `models.json` 过去把所有模型统一声明为支持图片，并在发送前对网关模型跳过现有图片能力 guard。纯文本模型因此会收到 `image_url` / 图片块，provider 返回 400 后进一步触发会话终端重建。

本 PR 将网关 `/models` 已有的 per-model `modalities` 真值投影为 Pi 的 provider-model 图片能力快照，并复用 #1402 已有的 `PiImageInputUnsupportedError` guard。只有明确声明支持图片的模型会接收图片；纯文本或能力未知的模型在 Pi/provider 调用前可恢复地拒绝。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1896
- 本 PR 包含：网关模型图片能力投影、Pi 启动时能力快照、网关/BYOM 共用的发送前 guard、回归测试
- 明确不包含：剥离图片、注入占位提示、自动调用 `vision-relay`、重做 #1402 的消息恢复/切模重试、修改 terminal rebuild 通用逻辑
- 用户可见变化：纯文本或图片能力未知的 Pi 网关模型收到带图消息时显示现有可恢复错误，不再调用 provider 或导致终端崩溃；视觉模型仍收到原始图片
- 是否存在 breaking change：无

### UI 变化

不涉及：未修改 UI、交互或文案，复用现有 Pi 图片能力错误展示。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/pi-provider-routing.test.ts
结果：PASS，24 项

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/catalogDerivedModels.test.ts src/main/maker-host/__tests__/activeCatalogXdAvailability.test.ts
结果：PASS，41 项

NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter desktop run --if-present typecheck
结果：PASS

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：PASS（该 package 无 typecheck script，按 --if-present 跳过）

pnpm test:unit
结果：PASS；根级 runner 350 通过、1 skip，Desktop、Mobile、Maker Core 与全部 unit workspace 通过

pnpm check:dco
结果：PASS，1 个 commit 已签名

node ~/.agents/skills/git-workflow/scripts/pr-size-gate.mjs
结果：PASS；非测试 +27 行 / 3 文件
```

定向 ESLint 覆盖 6 个改动文件并通过。

额外执行 `pnpm --filter @cindy/maker-core build` 时，被 upstream/main 已存在的 Claude/Codex/Pi 测试类型错误阻断；报错不位于本 PR 改动文件，仓库硬门禁使用的完整 unit 与 Desktop typecheck 均通过。

### 手工验证

通过 Pi RPC 回归夹具验证：

- 纯文本网关模型的纯图片、文字+图片、带 `$识图` 指令、steer、多图均在 RPC 前拒绝，未产生 `prompt` / `steer` provider 请求；
- 图片能力未知的网关模型 fail closed；
- 会话启动后的目录能力变化不会改写活动会话快照；
- 切到明确支持图片的网关模型后，多张图片均原样进入 prompt；
- BYOM 纯文本/视觉模型的 #1402 行为保持不变；不可读图片仍沿用原文本占位语义。

Maker Core 指标评估：未修改 system prompt、tool/MCP、translator 或 usage；文本消息走原有早返回，带图消息仅增加一次内存 Map 查询，无网络往返。准确性由回归测试确认：纯文本/未知能力不再收到图片，明确视觉模型不丢图。

### 未执行的验证

- 未使用真实 `deepseek-v4-flash` 额度向线上 provider 发请求；修复后的预期是本地 guard 先拒绝，因此请求中不再出现 `image_url`。
- 未启动 Desktop 做视觉目检；本 PR 无 UI、样式或文案变化。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Pi 网关模型能力声明与发送前路由判断

### 影响与回滚

- 影响范围：仅 Pi 会话的图片输入能力声明与发送前检查。能力未知按 fail closed；纯文本消息、Claude/Codex、插件与协议不受影响。
- 回滚 / 降级方式：回滚本 PR 即恢复网关模型统一声明图片能力的旧行为。无数据迁移、无持久化格式变化、存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及额外文档）
- [x] 已确认测试结果或说明未执行原因
