### PR TITLE
fix(desktop): 个人微信渠道区分 Agent 不支持与权限模式不支持的报错指引

### DIFF
--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -5,13 +5,16 @@
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { TurnPermissionPolicyUnsupportedError } from '@cindy/maker-core';
 import type {
   AgentEvent,
+  Capabilities,
   InteractionDecision,
   InteractionRequest,
   MakerEvent,
   Session,
   SessionSendResult,
+  TurnPermissionPolicy,
 } from '@cindy/maker-core';
 import type { ChannelIM } from '@cindy/im';
 
@@ -192,6 +195,9 @@ function createSessionHarness(
     message: Parameters<Session['send']>[0],
   ) => Promise<SessionSendResult>,
   sessionId = 'feishu-session',
+  options: {
+    capabilities?: Capabilities;
+  } = {},
 ): SessionHarness {
   const listeners: Array<(event: AgentEvent) => void> = [];
   // onAccepted 仅在消息真被接受时触发 — 对齐 maker-core Session.send 语义;
@@ -212,6 +218,7 @@ function createSessionHarness(
   const session = {
     id: sessionId,
     agentKind: 'claude-code',
+    capabilities: options.capabilities ?? ({} as Capabilities),
     send,
     isTurnRunning,
     abort,
@@ -923,6 +930,11 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
 
   it('applies a deferred switch and sends the first queued IM message through the refreshed session', async () => {
     const order: string[] = [];
+    const turnPermissionPolicy: TurnPermissionPolicy = {
+      origin: { kind: 'im', channel: 'wechat' },
+      confirmationSurface: 'channel',
+      forceConfirmToolCall: () => false,
+    };
     const oldSession = createSessionHarness(async () => ({
       accepted: false,
       reason: 'cancelled-before-dispatch',
@@ -978,17 +990,74 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
         userMessageId: 'msg-agent-switch',
         text: 'send after switch',
         attachments: [],
+        turnPermissionPolicy,
       });
 
       expect(acquirePendingAgentSwitch).toHaveBeenCalledWith('feishu-session');
       expect(oldSession.send).not.toHaveBeenCalled();
-      expect(switchedSession.send).toHaveBeenCalledTimes(1);
+      expect(switchedSession.send).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ turnPermissionPolicy }),
+      );
       expect(mocks.wireSessionToIpcExternal).toHaveBeenLastCalledWith(switchedSession.session);
       expect(order).toEqual(['apply', 'send', 'release']);
       expect(localRunner.getMakerSessionById('feishu-session')).toBeNull();
     } finally {
       localRunner.disposeAllSessions();
     }
+  });
+
+  it.each([
+    {
+      label: 'Agent capability is unavailable',
+      capabilities: {} as Capabilities,
+      mode: 'ask' as const,
+      failureKind: 'agent',
+    },
+    {
+      label: 'only the final permission mode is unsupported',
+      capabilities: {
+        turnPermissionPolicy: {
+          supported: { supported: true },
+          unsupportedPermissionModes: ['bypassPermissions'],
+        },
+      } as unknown as Capabilities,
+      mode: 'bypassPermissions' as const,
+      failureKind: 'mode',
+    },
+  ])('classifies final turn-policy rejection when $label', async ({
+    capabilities,
+    mode,
+    failureKind,
+  }) => {
+    const h = createSessionHarness(
+      async () => {
+        throw new TurnPermissionPolicyUnsupportedError('claude-code', mode);
+      },
+      'feishu-session',
+      { capabilities },
+    );
+    mocks.getMaker.mockReturnValue(createMakerHarness(h.session));
+
+    const dispatch = await getRunner().dispatchAgentTurn({
+      botContextId: 'cli_test_bot',
+      userId: 'ou_user',
+      userMessageId: `msg-policy-${failureKind}`,
+      text: 'policy failure',
+      attachments: [],
+      queueMode: 'external',
+      beforeProviderStart: vi.fn(async () => undefined),
+      turnPermissionPolicy: {
+        origin: { kind: 'im', channel: 'wechat' },
+        confirmationSurface: 'channel',
+        forceConfirmToolCall: () => false,
+      },
+    });
+
+    expect(dispatch).toEqual({
+      kind: 'rejected',
+      reason: `TURN_PERMISSION_POLICY_UNSUPPORTED:${failureKind}:${mode}`,
+    });
   });
 
   it('does not suppress a requested close during no-op switch acquisition', async () => {

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -1043,7 +1043,7 @@ export function createTurnRunner(
       return null;
     }
     const failureKind =
-      state.makerSession.capabilities.turnPermissionPolicy?.supported.supported === true
+      state.makerSession.capabilities.turnPermissionPolicy?.supported?.supported === true
         ? 'mode'
         : 'agent';
     return `${error.code}:${failureKind}:${error.permissionMode}`;

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -67,11 +67,13 @@ import { resolveSafe as resolveXdtImageUrl } from '../../imageCacheStore';
 import { resolveSafe as resolveCindyMediaUrl } from '../../cindy-media/blobStore';
 import { beginHeadlessGhostSetupTurn } from '../../mcp-integrations/ghostSetupInteractionSurface.js';
 
-import { isTerminalAgentErrorEvent } from '@cindy/maker-core';
+import {
+  isTerminalAgentErrorEvent,
+  TurnPermissionPolicyUnsupportedError,
+} from '@cindy/maker-core';
 import type {
   AgentEvent,
   AgentKind,
-  Capabilities,
   InteractionDecision,
   InteractionRequest,
   PermissionMode,
@@ -342,11 +344,6 @@ export interface ImRunAgentTurnArgs {
   trackBackgroundTask?: (operation: () => Promise<void>) => void;
   /** Optional per-turn host policy (personal WeChat routes confirmations to Desktop). */
   turnPermissionPolicy?: TurnPermissionPolicy;
-  /** Resolve a channel safety policy after the concrete session route is known. */
-  turnPermissionPolicyForRoute?(
-    row: ImSessionRow,
-    capabilities: Capabilities,
-  ): TurnPermissionPolicy | undefined;
 }
 
 export interface ImTurnTerminal {
@@ -737,11 +734,6 @@ export function createTurnRunner(
       startBackgroundTask(() => maybeGenerateImSessionTitle(row.id, text, threadHeaderCardId));
     }
 
-    const turnPermissionPolicy =
-      args.turnPermissionPolicyForRoute?.(
-        row,
-        getMaker().getCapabilities(row.agentKind),
-      ) ?? args.turnPermissionPolicy;
     const item: QueuedSend = {
       turn,
       userMessage: buildImUserMessage(args.agentText ?? text, attachments, target.attached),
@@ -752,7 +744,7 @@ export function createTurnRunner(
       queueMode: args.queueMode,
       ...(args.beforeProviderStart ? { beforeProviderStart: args.beforeProviderStart } : {}),
       ...(args.onRouteResolved ? { onRouteResolved: args.onRouteResolved } : {}),
-      ...(turnPermissionPolicy ? { turnPermissionPolicy } : {}),
+      ...(args.turnPermissionPolicy ? { turnPermissionPolicy: args.turnPermissionPolicy } : {}),
     };
 
     // turn 进行中(本 session 的本渠道 turn 未收口 / sendQueue 已有人排队 /
@@ -845,6 +837,7 @@ export function createTurnRunner(
       } else {
         await refreshSessionAfterPendingAgentSwitch(state, rowId, userId);
       }
+
       // session-agent-switch:本路径直发 session.send(不经 makerSendTransaction),
       // 交接注入自己接——切换后首条消息若来自 IM 渠道,新引擎同样需要交接上下文
       // (2026-07-20 审计)。落库(persistUserMessage)仍是渠道原文。
@@ -855,6 +848,7 @@ export function createTurnRunner(
             pendingHandoff,
           )
         : item.userMessage;
+
       const sendResult = await state.makerSession.send(outgoingMessage as typeof item.userMessage, {
         planMode: false,
         ...(item.turnPermissionPolicy ? { turnPermissionPolicy: item.turnPermissionPolicy } : {}),
@@ -978,6 +972,16 @@ export function createTurnRunner(
       return { kind: 'accepted', acceptedAt: acceptedAt || Date.now() };
     } catch (err) {
       if (turnChangeSetStarted) clearPendingTurnChangeSets(rowId);
+      const turnPolicyFailureReason = classifyTurnPermissionPolicySendFailure(err, item, state);
+      if (turnPolicyFailureReason) {
+        await handleSendPreDispatchFailure(state, userId, {
+          turn: item.turn,
+          source: `${channel}-runner`,
+          reason: turnPolicyFailureReason,
+          context: buildSendContext(rowId),
+        });
+        return { kind: 'rejected', reason: turnPolicyFailureReason };
+      }
       const normalized = normalizeSendError(err);
       if (normalized.reason === 'SESSION_RUNNING') {
         releaseTurnInteractionRoute(item.turn, 'session_running_race');
@@ -1028,6 +1032,21 @@ export function createTurnRunner(
     } finally {
       releaseAgentSwitchLock();
     }
+  }
+
+  function classifyTurnPermissionPolicySendFailure(
+    error: unknown,
+    item: QueuedSend,
+    state: SessionState,
+  ): string | null {
+    if (!(error instanceof TurnPermissionPolicyUnsupportedError) || !item.turnPermissionPolicy) {
+      return null;
+    }
+    const failureKind =
+      state.makerSession.capabilities.turnPermissionPolicy?.supported.supported === true
+        ? 'mode'
+        : 'agent';
+    return `${error.code}:${failureKind}:${error.permissionMode}`;
   }
 
   async function beginChunkedReply(turn: TurnState): Promise<void> {

--- a/apps/desktop/src/main/im/shared/types.ts
+++ b/apps/desktop/src/main/im/shared/types.ts
@@ -239,6 +239,8 @@ export interface ImUiTextPack {
   error?: {
     agentUnsupported: string;
     permissionModeUnsupported: string;
+    /** 换 Agent 后仍可能不兼容的权限模式(bypassPermissions / acceptEdits)时附加。 */
+    agentSwitchAlsoCheckPermissionMode?: string;
   };
   cards: {
     permission: {

--- a/apps/desktop/src/main/im/shared/types.ts
+++ b/apps/desktop/src/main/im/shared/types.ts
@@ -230,6 +230,16 @@ export interface ImUiTextPack {
     unsupportedOnly: (entries: IMUnsupportedEntry[]) => string;
     unsupportedNotice: (entries: IMUnsupportedEntry[]) => string;
   };
+  /**
+   * 派发前失败文案。agentUnsupported 用于「所选 Agent 无法提供渠道所需的
+   * 逐条权限确认」(如 Pi 在个人微信),permissionModeUnsupported 用于
+   * 「当前权限模式在该 Agent 的 turnPermissionPolicy 排除清单里」。
+   * 可选:仅需要细分文案的渠道实现,其余渠道可不提供。
+   */
+  error?: {
+    agentUnsupported: string;
+    permissionModeUnsupported: string;
+  };
   cards: {
     permission: {
       title: (toolName: string) => string;

--- a/apps/desktop/src/main/im/wechat/WechatIM.ts
+++ b/apps/desktop/src/main/im/wechat/WechatIM.ts
@@ -1904,6 +1904,12 @@ function safeMachineCode(value: string): string {
  */
 export function wechatPreDispatchFailureText(reason: string): string {
   if (reason.includes(`${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent`)) {
+    // 当前权限模式若是换 Agent 后仍不兼容的档位(bypassPermissions / acceptEdits),
+    // 仅换 Agent 会在新 Agent 上再次命中权限模式错误,补一条 /permission 提示。
+    const mode = reason.split(':').pop() ?? '';
+    if (mode === 'bypassPermissions' || mode === 'acceptEdits') {
+      return `${ui.error.agentUnsupported}\n${ui.error.agentSwitchAlsoCheckPermissionMode}`;
+    }
     return ui.error.agentUnsupported;
   }
   if (

--- a/apps/desktop/src/main/im/wechat/WechatIM.ts
+++ b/apps/desktop/src/main/im/wechat/WechatIM.ts
@@ -1062,16 +1062,39 @@ export class WechatIM extends BaseIM implements RichChannelIM {
             active.routeSessionId = sessionId;
           }
         },
-        turnPermissionPolicyForRoute: (row, capabilities) =>
-          createWechatTurnPermissionPolicyForMode(task.id, capabilities, row.permissionMode, {
-            onInteractionStateChange: (state) => {
-              void this.#requireStore().setWaitingDesktop(
-                task.bindingEpoch,
-                task.id,
-                state === 'waiting',
+        turnPermissionPolicyForRoute: (row, capabilities) => {
+          try {
+            return createWechatTurnPermissionPolicyForMode(
+              task.id,
+              capabilities,
+              row.permissionMode,
+              {
+                onInteractionStateChange: (state) => {
+                  void this.#requireStore().setWaitingDesktop(
+                    task.bindingEpoch,
+                    task.id,
+                    state === 'waiting',
+                  );
+                },
+              },
+            );
+          } catch (error) {
+            if (
+              error instanceof Error &&
+              error.message.startsWith(WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED)
+            ) {
+              // 区分「Agent 不支持」与「权限模式不支持」:未声明 turnPermissionPolicy
+              // 的 Agent(如 Pi)在任何模式下都无法提供微信所需的逐条确认,换权限模式
+              // 无用,只能换 Agent;已声明的 Agent(Claude Code / Codex)仅个别模式
+              // 不可用,换权限模式即可。给用户可执行的指引而非含混提示。
+              const unsupportedKind = capabilities.turnPermissionPolicy ? 'mode' : 'agent';
+              throw new Error(
+                `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:${unsupportedKind}:${row.permissionMode}`,
               );
-            },
-          }),
+            }
+            throw error;
+          }
+        },
       });
     } catch (error) {
       await stopTyping();
@@ -1376,13 +1399,7 @@ export class WechatIM extends BaseIM implements RichChannelIM {
   }
 
   async #commitPreDispatchFailure(task: WechatTask, reason: string): Promise<void> {
-    const text =
-      reason.includes(WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED) ||
-      reason.includes('unsupported_turn_permission')
-        ? '当前 Agent 无法在个人微信中安全使用此权限模式。请在 Cindy 中切换权限模式；若仍失败，请改用支持个人微信权限确认的 Agent。'
-        : reason === 'missing_auth'
-          ? '当前 Agent 尚未完成授权，请先在 Cindy 中连接模型服务。'
-          : '这条消息暂时无法启动，请稍后重试。';
+    const text = wechatPreDispatchFailureText(reason);
     const chunks = chunkWechatText(text);
     await this.#requireStore().commitPreDispatchFailure({
       bindingEpoch: task.bindingEpoch,
@@ -1906,6 +1923,33 @@ function safeMachineCode(value: string): string {
   return normalized || 'PRE_DISPATCH_REJECTED';
 }
 
+/**
+ * 派发前失败的用户可见文案(纯函数,便于单测)。reason 来源:
+ *  - `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent:<mode>` — Agent 未声明
+ *    turnPermissionPolicy(如 Pi),任何模式都不可用 → 引导换 Agent;
+ *  - `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:mode:<mode>` — 当前权限模式
+ *    在该 Agent 的 unsupportedPermissionModes 里 → 引导换权限模式;
+ *  - 旧格式 `TURN_PERMISSION_POLICY_UNSUPPORTED:<mode>` / `unsupported_turn_permission`
+ *    兜底按「换权限模式或换 Agent」处理;
+ *  - 'missing_auth' — 未连接模型服务;
+ *  - 其余 — 通用重试提示。
+ */
+export function wechatPreDispatchFailureText(reason: string): string {
+  if (reason.includes(`${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent`)) {
+    return ui.error.agentUnsupported;
+  }
+  if (
+    reason.includes(WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED) ||
+    reason.includes('unsupported_turn_permission')
+  ) {
+    return ui.error.permissionModeUnsupported;
+  }
+  if (reason === 'missing_auth') {
+    return '当前 Agent 尚未完成授权，请先在 Cindy 中连接模型服务。';
+  }
+  return '这条消息暂时无法启动，请稍后重试。';
+}
+
 function normalizeFinalOutputText(text: string): string {
   return filterWechatMarkdown(text) || '✅ (本轮无文本输出)';
 }
@@ -2006,6 +2050,7 @@ export const __testing = {
   formatWechatInteractionPrompt,
   parseWechatInteractionReply,
   stopActiveWechatTurns,
+  wechatPreDispatchFailureText,
 };
 
 function delay(ms: number, signal?: AbortSignal): Promise<void> {

--- a/apps/desktop/src/main/im/wechat/WechatIM.ts
+++ b/apps/desktop/src/main/im/wechat/WechatIM.ts
@@ -23,7 +23,11 @@ import {
   type WechatInboundMessage,
   type WechatTransport,
 } from '@cindy/wechat-ilink';
-import type { InteractionDecision, InteractionRequest } from '@cindy/maker-core';
+import type {
+  Capabilities,
+  InteractionDecision,
+  InteractionRequest,
+} from '@cindy/maker-core';
 
 import type { ImSessionRepo } from '../shared/sessionRepo';
 import type { ImOrchestratorConfig } from '../shared/types';
@@ -1084,10 +1088,11 @@ export class WechatIM extends BaseIM implements RichChannelIM {
               error.message.startsWith(WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED)
             ) {
               // 区分「Agent 不支持」与「权限模式不支持」:未声明 turnPermissionPolicy
-              // 的 Agent(如 Pi)在任何模式下都无法提供微信所需的逐条确认,换权限模式
-              // 无用,只能换 Agent;已声明的 Agent(Claude Code / Codex)仅个别模式
-              // 不可用,换权限模式即可。给用户可执行的指引而非含混提示。
-              const unsupportedKind = capabilities.turnPermissionPolicy ? 'mode' : 'agent';
+              // (或声明了但 supported.supported !== true)的 Agent(如 Pi)在任何模式下
+              // 都无法提供微信所需的逐条确认,换权限模式无用,只能换 Agent;声明且受
+              // 支持的 Agent(Claude Code / Codex)仅个别模式不可用,换权限模式即可。
+              // 判定逻辑见 wechatPermissionPolicyFailureKind(纯函数,便于单测)。
+              const unsupportedKind = wechatPermissionPolicyFailureKind(capabilities);
               throw new Error(
                 `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:${unsupportedKind}:${row.permissionMode}`,
               );
@@ -1924,6 +1929,18 @@ function safeMachineCode(value: string): string {
 }
 
 /**
+ * turnPermissionPolicy 不支持时的分类:agent 无法提供该机制(换 Agent 才能解决)
+ * 还是仅当前权限模式被排除(切权限模式即可)。判定与
+ * supportsWechatTurnPermissionMode 同口径——字段存在但 supported.supported !== true
+ * 时所有模式都不可用,同样归为 agent(不能只看字段是否存在)。纯函数,便于单测。
+ */
+export function wechatPermissionPolicyFailureKind(
+  capabilities: Capabilities,
+): 'agent' | 'mode' {
+  return capabilities.turnPermissionPolicy?.supported.supported === true ? 'mode' : 'agent';
+}
+
+/**
  * 派发前失败的用户可见文案(纯函数,便于单测)。reason 来源:
  *  - `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent:<mode>` — Agent 未声明
  *    turnPermissionPolicy(如 Pi),任何模式都不可用 → 引导换 Agent;
@@ -1935,7 +1952,14 @@ function safeMachineCode(value: string): string {
  *  - 其余 — 通用重试提示。
  */
 export function wechatPreDispatchFailureText(reason: string): string {
-  if (reason.includes(`${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent`)) {
+  // Pi 等 agent 在 send 侧 fail-closed 抛的 TurnPermissionPolicyUnsupportedError 的
+  // message 是 "Turn permission policy is not supported by <agent> in permission
+  // mode <mode>"(与 WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED 前缀大小写/格式不同),
+  // 同样按「Agent 不支持」给可执行指引,而不是落入通用重试提示。
+  if (
+    reason.includes(`${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent`) ||
+    /turn permission policy is not supported/i.test(reason)
+  ) {
     return ui.error.agentUnsupported;
   }
   if (
@@ -2050,6 +2074,7 @@ export const __testing = {
   formatWechatInteractionPrompt,
   parseWechatInteractionReply,
   stopActiveWechatTurns,
+  wechatPermissionPolicyFailureKind,
   wechatPreDispatchFailureText,
 };
 

--- a/apps/desktop/src/main/im/wechat/WechatIM.ts
+++ b/apps/desktop/src/main/im/wechat/WechatIM.ts
@@ -1898,7 +1898,7 @@ function safeMachineCode(value: string): string {
  *  - `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:mode:<mode>` — 当前权限模式
  *    在该 Agent 的 unsupportedPermissionModes 里 → 引导换权限模式;
  *  - 旧格式 `TURN_PERMISSION_POLICY_UNSUPPORTED:<mode>` / `unsupported_turn_permission`
- *    兜底按「换权限模式或换 Agent」处理;
+ *    保持既有兼容行为,兜底按「换权限模式」处理;
  *  - 'missing_auth' — 未连接模型服务;
  *  - 其余 — 通用重试提示。
  */

--- a/apps/desktop/src/main/im/wechat/WechatIM.ts
+++ b/apps/desktop/src/main/im/wechat/WechatIM.ts
@@ -23,18 +23,14 @@ import {
   type WechatInboundMessage,
   type WechatTransport,
 } from '@cindy/wechat-ilink';
-import type {
-  Capabilities,
-  InteractionDecision,
-  InteractionRequest,
-} from '@cindy/maker-core';
+import type { InteractionDecision, InteractionRequest } from '@cindy/maker-core';
 
 import type { ImSessionRepo } from '../shared/sessionRepo';
 import type { ImOrchestratorConfig } from '../shared/types';
 import type { ImFinalOutput } from '@cindy/im';
 import type { ImTurnRunner } from '../shared/turnRunner';
 import {
-  createWechatTurnPermissionPolicyForMode,
+  createWechatTurnPermissionPolicy,
   WECHAT_INTERACTION_CONFIRM_TIMEOUT_MS,
   WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED,
 } from './permissionPolicy';
@@ -1066,51 +1062,18 @@ export class WechatIM extends BaseIM implements RichChannelIM {
             active.routeSessionId = sessionId;
           }
         },
-        turnPermissionPolicyForRoute: (row, capabilities) => {
-          try {
-            return createWechatTurnPermissionPolicyForMode(
+        turnPermissionPolicy: createWechatTurnPermissionPolicy(task.id, {
+          onInteractionStateChange: (state) => {
+            void this.#requireStore().setWaitingDesktop(
+              task.bindingEpoch,
               task.id,
-              capabilities,
-              row.permissionMode,
-              {
-                onInteractionStateChange: (state) => {
-                  void this.#requireStore().setWaitingDesktop(
-                    task.bindingEpoch,
-                    task.id,
-                    state === 'waiting',
-                  );
-                },
-              },
+              state === 'waiting',
             );
-          } catch (error) {
-            if (
-              error instanceof Error &&
-              error.message.startsWith(WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED)
-            ) {
-              // 区分「Agent 不支持」与「权限模式不支持」:未声明 turnPermissionPolicy
-              // (或声明了但 supported.supported !== true)的 Agent(如 Pi)在任何模式下
-              // 都无法提供微信所需的逐条确认,换权限模式无用,只能换 Agent;声明且受
-              // 支持的 Agent(Claude Code / Codex)仅个别模式不可用,换权限模式即可。
-              // 判定逻辑见 wechatPermissionPolicyFailureKind(纯函数,便于单测)。
-              const unsupportedKind = wechatPermissionPolicyFailureKind(capabilities);
-              throw new Error(
-                `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:${unsupportedKind}:${row.permissionMode}`,
-              );
-            }
-            throw error;
-          }
-        },
+          },
+        }),
       });
     } catch (error) {
       await stopTyping();
-      if (
-        error instanceof Error &&
-        error.message.startsWith(WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED)
-      ) {
-        this.#activeTasks.delete(task.peerId);
-        await this.#commitPreDispatchFailure(task, error.message);
-        return;
-      }
       throw error;
     }
 
@@ -1929,18 +1892,6 @@ function safeMachineCode(value: string): string {
 }
 
 /**
- * turnPermissionPolicy 不支持时的分类:agent 无法提供该机制(换 Agent 才能解决)
- * 还是仅当前权限模式被排除(切权限模式即可)。判定与
- * supportsWechatTurnPermissionMode 同口径——字段存在但 supported.supported !== true
- * 时所有模式都不可用,同样归为 agent(不能只看字段是否存在)。纯函数,便于单测。
- */
-export function wechatPermissionPolicyFailureKind(
-  capabilities: Capabilities,
-): 'agent' | 'mode' {
-  return capabilities.turnPermissionPolicy?.supported.supported === true ? 'mode' : 'agent';
-}
-
-/**
  * 派发前失败的用户可见文案(纯函数,便于单测)。reason 来源:
  *  - `${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent:<mode>` — Agent 未声明
  *    turnPermissionPolicy(如 Pi),任何模式都不可用 → 引导换 Agent;
@@ -1952,14 +1903,7 @@ export function wechatPermissionPolicyFailureKind(
  *  - 其余 — 通用重试提示。
  */
 export function wechatPreDispatchFailureText(reason: string): string {
-  // Pi 等 agent 在 send 侧 fail-closed 抛的 TurnPermissionPolicyUnsupportedError 的
-  // message 是 "Turn permission policy is not supported by <agent> in permission
-  // mode <mode>"(与 WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED 前缀大小写/格式不同),
-  // 同样按「Agent 不支持」给可执行指引,而不是落入通用重试提示。
-  if (
-    reason.includes(`${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent`) ||
-    /turn permission policy is not supported/i.test(reason)
-  ) {
+  if (reason.includes(`${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:agent`)) {
     return ui.error.agentUnsupported;
   }
   if (
@@ -2074,7 +2018,6 @@ export const __testing = {
   formatWechatInteractionPrompt,
   parseWechatInteractionReply,
   stopActiveWechatTurns,
-  wechatPermissionPolicyFailureKind,
   wechatPreDispatchFailureText,
 };
 

--- a/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
@@ -62,6 +62,27 @@ describe('WechatIM host boundary', () => {
     expect(__testing.normalizeFinalOutputText('hello')).toBe('hello');
   });
 
+  it('distinguishes agent-unsupported from permission-mode-unsupported pre-dispatch failures', () => {
+    // Agent 未声明 turnPermissionPolicy(如 Pi):换权限模式无效,文案引导换 Agent。
+    expect(__testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:agent:ask')).toContain(
+      'Pi',
+    );
+    expect(__testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:agent:auto')).not.toContain(
+      '权限模式',
+    );
+    // 权限模式在 unsupportedPermissionModes 里(如 bypassPermissions):文案引导调权限模式。
+    expect(
+      __testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:mode:bypassPermissions'),
+    ).toContain('权限模式');
+    // 旧格式 / 渠道侧 unsupported_turn_permission 兼容分支:同样按权限模式处理。
+    expect(__testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:ask')).toContain(
+      '权限模式',
+    );
+    expect(__testing.wechatPreDispatchFailureText('unsupported_turn_permission')).toContain('权限模式');
+    expect(__testing.wechatPreDispatchFailureText('missing_auth')).toContain('模型服务');
+    expect(__testing.wechatPreDispatchFailureText('boom')).toContain('稍后重试');
+  });
+
   it('dispatches attachment-only WeChat messages to the agent', () => {
     expect(__testing.hasWechatTaskContent('', [])).toBe(false);
     expect(

--- a/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Capabilities } from '@cindy/maker-core';
 import type { IMHost } from '@cindy/im';
 import {
   WechatIlinkError,
@@ -66,7 +65,7 @@ describe('WechatIM host boundary', () => {
   it('distinguishes agent-unsupported from permission-mode-unsupported pre-dispatch failures', () => {
     // Agent 未声明 turnPermissionPolicy(如 Pi):换权限模式无效,文案引导换 Agent。
     expect(__testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:agent:ask')).toContain(
-      'Pi',
+      '换成 Claude Code 或 Codex',
     );
     expect(__testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:agent:auto')).not.toContain(
       '权限模式',
@@ -82,42 +81,6 @@ describe('WechatIM host boundary', () => {
     expect(__testing.wechatPreDispatchFailureText('unsupported_turn_permission')).toContain('权限模式');
     expect(__testing.wechatPreDispatchFailureText('missing_auth')).toContain('模型服务');
     expect(__testing.wechatPreDispatchFailureText('boom')).toContain('稍后重试');
-  });
-
-  it('classifies failure kind by the capability gate, not mere field presence', () => {
-    // 未声明 → agent;声明且 supported → mode;声明但 supported:false → agent。
-    expect(__testing.wechatPermissionPolicyFailureKind({} as Capabilities)).toBe('agent');
-    expect(
-      __testing.wechatPermissionPolicyFailureKind({
-        turnPermissionPolicy: {
-          supported: { supported: true },
-          unsupportedPermissionModes: [],
-        },
-      } as unknown as Capabilities),
-    ).toBe('mode');
-    expect(
-      __testing.wechatPermissionPolicyFailureKind({
-        turnPermissionPolicy: {
-          supported: { supported: false },
-          unsupportedPermissionModes: [],
-        },
-      } as unknown as Capabilities),
-    ).toBe('agent');
-  });
-
-  it('maps the agent-side TurnPermissionPolicyUnsupportedError message to the switch-agent copy', () => {
-    // Pi 在 send 侧 fail-closed 抛的内部错误(message 形态与渠道侧前缀不同),
-    // 同样应给「换 Agent」指引而不是通用「稍后重试」。
-    expect(
-      __testing.wechatPreDispatchFailureText(
-        'Turn permission policy is not supported by pi in permission mode ask',
-      ),
-    ).toContain('Pi');
-    expect(
-      __testing.wechatPreDispatchFailureText(
-        'Turn permission policy is not supported by pi in permission mode ask',
-      ),
-    ).not.toContain('稍后重试');
   });
 
   it('dispatches attachment-only WeChat messages to the agent', () => {

--- a/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
@@ -70,6 +70,19 @@ describe('WechatIM host boundary', () => {
     expect(__testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:agent:auto')).not.toContain(
       '权限模式',
     );
+    // 当前权限模式若是换 Agent 后仍不兼容的档位(bypassPermissions / acceptEdits),
+    // 换 Agent 指引应附带 /permission 提示,避免新 Agent 再次命中权限模式错误。
+    expect(
+      __testing.wechatPreDispatchFailureText(
+        'TURN_PERMISSION_POLICY_UNSUPPORTED:agent:bypassPermissions',
+      ),
+    ).toContain('/permission');
+    expect(
+      __testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:agent:acceptEdits'),
+    ).toContain('/permission');
+    expect(__testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:agent:ask')).not.toContain(
+      '/permission',
+    );
     // 权限模式在 unsupportedPermissionModes 里(如 bypassPermissions):文案引导调权限模式。
     expect(
       __testing.wechatPreDispatchFailureText('TURN_PERMISSION_POLICY_UNSUPPORTED:mode:bypassPermissions'),

--- a/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { Capabilities } from '@cindy/maker-core';
 import type { IMHost } from '@cindy/im';
 import {
   WechatIlinkError,
@@ -81,6 +82,42 @@ describe('WechatIM host boundary', () => {
     expect(__testing.wechatPreDispatchFailureText('unsupported_turn_permission')).toContain('权限模式');
     expect(__testing.wechatPreDispatchFailureText('missing_auth')).toContain('模型服务');
     expect(__testing.wechatPreDispatchFailureText('boom')).toContain('稍后重试');
+  });
+
+  it('classifies failure kind by the capability gate, not mere field presence', () => {
+    // 未声明 → agent;声明且 supported → mode;声明但 supported:false → agent。
+    expect(__testing.wechatPermissionPolicyFailureKind({} as Capabilities)).toBe('agent');
+    expect(
+      __testing.wechatPermissionPolicyFailureKind({
+        turnPermissionPolicy: {
+          supported: { supported: true },
+          unsupportedPermissionModes: [],
+        },
+      } as unknown as Capabilities),
+    ).toBe('mode');
+    expect(
+      __testing.wechatPermissionPolicyFailureKind({
+        turnPermissionPolicy: {
+          supported: { supported: false },
+          unsupportedPermissionModes: [],
+        },
+      } as unknown as Capabilities),
+    ).toBe('agent');
+  });
+
+  it('maps the agent-side TurnPermissionPolicyUnsupportedError message to the switch-agent copy', () => {
+    // Pi 在 send 侧 fail-closed 抛的内部错误(message 形态与渠道侧前缀不同),
+    // 同样应给「换 Agent」指引而不是通用「稍后重试」。
+    expect(
+      __testing.wechatPreDispatchFailureText(
+        'Turn permission policy is not supported by pi in permission mode ask',
+      ),
+    ).toContain('Pi');
+    expect(
+      __testing.wechatPreDispatchFailureText(
+        'Turn permission policy is not supported by pi in permission mode ask',
+      ),
+    ).not.toContain('稍后重试');
   });
 
   it('dispatches attachment-only WeChat messages to the agent', () => {

--- a/apps/desktop/src/main/im/wechat/__tests__/permissionPolicy.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/permissionPolicy.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Capabilities } from '@cindy/maker-core';
 
-import {
-  createWechatTurnPermissionPolicy,
-  createWechatTurnPermissionPolicyForMode,
-  supportsWechatTurnPermissionMode,
-} from '../permissionPolicy';
+import { createWechatTurnPermissionPolicy } from '../permissionPolicy';
 
 describe('personal WeChat turn permission policy', () => {
   it('forces destructive shell and wrapped MCP actions through Desktop', () => {
@@ -76,34 +71,5 @@ describe('personal WeChat turn permission policy', () => {
     expect(
       policy.forceConfirmToolCall('permissions', { permissions: { network: true } }),
     ).toBe(true);
-  });
-
-  it('honors the provider capability gate without silently downgrading Full Access', () => {
-    const capabilities = {
-      turnPermissionPolicy: {
-        supported: { supported: true },
-        unsupportedPermissionModes: ['bypassPermissions'],
-      },
-    } as Capabilities;
-
-    expect(supportsWechatTurnPermissionMode(capabilities, 'auto')).toBe(true);
-    expect(
-      supportsWechatTurnPermissionMode(capabilities, 'bypassPermissions'),
-    ).toBe(false);
-    expect(
-      supportsWechatTurnPermissionMode({} as Capabilities, 'ask'),
-    ).toBe(false);
-
-    expect(() =>
-      createWechatTurnPermissionPolicyForMode('task-3', capabilities, 'bypassPermissions'),
-    ).toThrow('TURN_PERMISSION_POLICY_UNSUPPORTED:bypassPermissions');
-    expect(() =>
-      createWechatTurnPermissionPolicyForMode('task-4', {} as Capabilities, 'ask'),
-    ).toThrow('TURN_PERMISSION_POLICY_UNSUPPORTED:ask');
-    expect(createWechatTurnPermissionPolicyForMode('task-5', capabilities, 'auto').origin).toEqual({
-      kind: 'im',
-      channel: 'wechat',
-      taskId: 'task-5',
-    });
   });
 });

--- a/apps/desktop/src/main/im/wechat/permissionPolicy.ts
+++ b/apps/desktop/src/main/im/wechat/permissionPolicy.ts
@@ -1,8 +1,4 @@
-import type {
-  Capabilities,
-  PermissionMode,
-  TurnPermissionPolicy,
-} from '@cindy/maker-core';
+import type { TurnPermissionPolicy } from '@cindy/maker-core';
 
 import { channelForceConfirmToolCall } from '../shared/channelToolPolicy';
 
@@ -41,27 +37,4 @@ export function createWechatTurnPermissionPolicy(
       : {}),
     forceConfirmToolCall: channelForceConfirmToolCall,
   };
-}
-
-export function supportsWechatTurnPermissionMode(
-  capabilities: Capabilities,
-  mode: PermissionMode,
-): boolean {
-  const policy = capabilities.turnPermissionPolicy;
-  return (
-    policy?.supported.supported === true &&
-    !policy.unsupportedPermissionModes.includes(mode)
-  );
-}
-
-export function createWechatTurnPermissionPolicyForMode(
-  taskId: string,
-  capabilities: Capabilities,
-  mode: PermissionMode,
-  options?: Parameters<typeof createWechatTurnPermissionPolicy>[1],
-): TurnPermissionPolicy {
-  if (!supportsWechatTurnPermissionMode(capabilities, mode)) {
-    throw new Error(`${WECHAT_TURN_PERMISSION_POLICY_UNSUPPORTED}:${mode}`);
-  }
-  return createWechatTurnPermissionPolicy(taskId, options);
 }

--- a/apps/desktop/src/main/im/wechat/uiText.ts
+++ b/apps/desktop/src/main/im/wechat/uiText.ts
@@ -69,6 +69,17 @@ export const ui = {
       `ℹ️ 以下内容我消化不了，先丢一边了：\n${entries.map((entry) => `• ${entry.label}`).join('\n')}\n\n` +
       '其它部分收到啦，正在处理~',
   },
+  error: {
+    // turnPermissionPolicy 分类:agent(如 Pi)未声明该 capability,任何权限模式
+    // 都无法提供微信所需的逐条确认 → 换 Agent;已声明的 agent 仅个别模式不可用
+    // (如 bypassPermissions / acceptEdits) → 换权限模式。
+    agentUnsupported:
+      '⚠️ 当前 Agent（Pi）不支持个人微信的逐条权限确认，消息无法启动。\n' +
+      '请在 desktop 设置里把微信渠道的 Agent 换成 Claude Code 或 Codex，再重试。',
+    permissionModeUnsupported:
+      '⚠️ 当前 Agent 无法在个人微信中安全使用此权限模式。\n' +
+      '请在 desktop 设置里调整权限模式（或发 /permission），再重试。',
+  },
   cards: {
     permission: {
       title: (toolName: string) => `🔧 工具调用：${toolName}`,

--- a/apps/desktop/src/main/im/wechat/uiText.ts
+++ b/apps/desktop/src/main/im/wechat/uiText.ts
@@ -78,6 +78,11 @@ export const ui = {
     agentUnsupported:
       '⚠️ 当前 Agent 不支持个人微信的逐条权限确认，消息无法启动。\n' +
       '请在 desktop 设置里把微信渠道的 Agent 换成 Claude Code 或 Codex，再在微信发送 /new，然后重试。',
+    // 换 Agent 后仍可能不兼容的权限模式(Claude Code / Codex 的
+    // unsupportedPermissionModes 并集:bypassPermissions / acceptEdits):
+    // 仅换 Agent 会在新 Agent 上再次命中权限模式错误,补一条 /permission 提示。
+    agentSwitchAlsoCheckPermissionMode:
+      '若新的 Agent 仍提示权限模式问题，请在微信发送 /permission 调整权限模式后重试。',
     permissionModeUnsupported:
       '⚠️ 当前 Agent 无法在个人微信中安全使用此权限模式。\n' +
       '请在 desktop 设置里调整权限模式（或发 /permission），再重试。',

--- a/apps/desktop/src/main/im/wechat/uiText.ts
+++ b/apps/desktop/src/main/im/wechat/uiText.ts
@@ -85,7 +85,7 @@ export const ui = {
       '若新的 Agent 仍提示权限模式问题，请在微信发送 /permission 调整权限模式后重试。',
     permissionModeUnsupported:
       '⚠️ 当前 Agent 无法在个人微信中安全使用此权限模式。\n' +
-      '请在 desktop 设置里调整权限模式（或发 /permission），再重试。',
+      '请在微信发送 /permission 切换权限模式后重试。',
   },
   cards: {
     permission: {

--- a/apps/desktop/src/main/im/wechat/uiText.ts
+++ b/apps/desktop/src/main/im/wechat/uiText.ts
@@ -73,9 +73,11 @@ export const ui = {
     // turnPermissionPolicy 分类:agent(如 Pi)未声明该 capability,任何权限模式
     // 都无法提供微信所需的逐条确认 → 换 Agent;已声明的 agent 仅个别模式不可用
     // (如 bypassPermissions / acceptEdits) → 换权限模式。
+    // 注意:微信渠道的 Agent 配置只在 /new 时应用到现有会话(设置仅影响新对话),
+    // 所以「换 Agent」指引必须带 /new,否则用户改完设置重发仍路由到旧 Agent。
     agentUnsupported:
       '⚠️ 当前 Agent（Pi）不支持个人微信的逐条权限确认，消息无法启动。\n' +
-      '请在 desktop 设置里把微信渠道的 Agent 换成 Claude Code 或 Codex，再重试。',
+      '请在 desktop 设置里把微信渠道的 Agent 换成 Claude Code 或 Codex，再在微信发送 /new，然后重试。',
     permissionModeUnsupported:
       '⚠️ 当前 Agent 无法在个人微信中安全使用此权限模式。\n' +
       '请在 desktop 设置里调整权限模式（或发 /permission），再重试。',

--- a/apps/desktop/src/main/im/wechat/uiText.ts
+++ b/apps/desktop/src/main/im/wechat/uiText.ts
@@ -76,7 +76,7 @@ export const ui = {
     // 注意:微信渠道的 Agent 配置只在 /new 时应用到现有会话(设置仅影响新对话),
     // 所以「换 Agent」指引必须带 /new,否则用户改完设置重发仍路由到旧 Agent。
     agentUnsupported:
-      '⚠️ 当前 Agent（Pi）不支持个人微信的逐条权限确认，消息无法启动。\n' +
+      '⚠️ 当前 Agent 不支持个人微信的逐条权限确认，消息无法启动。\n' +
       '请在 desktop 设置里把微信渠道的 Agent 换成 Claude Code 或 Codex，再在微信发送 /new，然后重试。',
     permissionModeUnsupported:
       '⚠️ 当前 Agent 无法在个人微信中安全使用此权限模式。\n' +

--- a/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
@@ -227,20 +227,30 @@ export function ImDefaultSettingsSection({
       : settings.agentKind === 'codex'
         ? codex
         : pi;
-  const selectedAgentUnsupported =
+  const selectedAgentCapabilitiesReady =
     !selectedAgentCaps.loading &&
     selectedAgentCaps.error === null &&
-    selectedAgentCaps.capabilities !== null &&
-    selectedAgentCaps.capabilities.turnPermissionPolicy?.supported.supported !== true;
+    selectedAgentCaps.capabilities !== null;
+  const selectedTurnPolicy = selectedAgentCaps.capabilities?.turnPermissionPolicy;
+  const selectedAgentUnsupported =
+    selectedAgentCapabilitiesReady && selectedTurnPolicy?.supported.supported !== true;
+  const selectedPermissionModeUnsupported =
+    selectedAgentCapabilitiesReady &&
+    selectedTurnPolicy?.supported.supported === true &&
+    selectedTurnPolicy.unsupportedPermissionModes.includes(settings.permissionMode);
   // 渠道默认权限模式若是换 Agent 后仍不兼容的档位(Claude Code / Codex 的
   // unsupportedPermissionModes 并集:bypassPermissions / acceptEdits),仅换 Agent
   // 会在新会话(/new)上再次命中权限模式错误,警告需附加 /permission 提示。
   const modeUnsupportedAfterSwitch =
     settings.permissionMode === 'bypassPermissions' || settings.permissionMode === 'acceptEdits';
-  const agentUnsupportedOnChannel =
-    channel !== undefined &&
-    isUnconditionalTurnPolicyChannel(channel) &&
-    selectedAgentUnsupported;
+  const turnPolicyWarning =
+    channel !== undefined && isUnconditionalTurnPolicyChannel(channel)
+      ? selectedAgentUnsupported
+        ? 'agent'
+        : selectedPermissionModeUnsupported
+          ? 'mode'
+          : null
+      : null;
 
   const changeAgent = (agentKind: ImDefaultAgentKind) => {
     if (agentKind === settings.agentKind) return;
@@ -361,7 +371,7 @@ export function ImDefaultSettingsSection({
         </div>
       </div>
 
-      {agentUnsupportedOnChannel && (
+      {turnPolicyWarning && (
         <div
           role="status"
           aria-live="polite"
@@ -374,14 +384,22 @@ export function ImDefaultSettingsSection({
             aria-hidden
           />
           <div className="min-w-0">
-            <p className="text-11 leading-[1.45] text-[var(--text-secondary)]">
-              {t('settings.imBot.defaults.agentUnsupportedOnChannelHint', {
-                agent: t(`settings.imBot.defaults.agents.${settings.agentKind}`),
-              })}
-            </p>
-            {modeUnsupportedAfterSwitch && (
-              <p className="mt-1 text-11 leading-[1.45] text-[var(--text-secondary)]">
-                {t('settings.imBot.defaults.agentUnsupportedOnChannelModeHint')}
+            {turnPolicyWarning === 'agent' ? (
+              <>
+                <p className="text-11 leading-[1.45] text-[var(--text-secondary)]">
+                  {t('settings.imBot.defaults.agentUnsupportedOnChannelHint', {
+                    agent: t(`settings.imBot.defaults.agents.${settings.agentKind}`),
+                  })}
+                </p>
+                {modeUnsupportedAfterSwitch && (
+                  <p className="mt-1 text-11 leading-[1.45] text-[var(--text-secondary)]">
+                    {t('settings.imBot.defaults.agentUnsupportedOnChannelModeHint')}
+                  </p>
+                )}
+              </>
+            ) : (
+              <p className="text-11 leading-[1.45] text-[var(--text-secondary)]">
+                {t('settings.imBot.defaults.permissionModeUnsupportedOnChannelHint')}
               </p>
             )}
           </div>

--- a/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
@@ -216,13 +216,23 @@ export function ImDefaultSettingsSection({
   }
 
   const activeSettings = settings.agents[settings.agentKind];
-  // 个人微信对每次 dispatch 无条件挂 turnPermissionPolicy;Pi 未声明该 capability,
-  // 选它发消息必然失败,此处给可执行提示。(Telegram / 钉钉仅在群聊挂 policy,
+  // 按选中 Agent 的 capabilities 判断:未声明 / 声明了但 supported.supported !== true
+  // 的 Agent(如 Pi)无法在「无条件挂逐条权限确认」的渠道(个人微信)使用。不写死 Pi——
+  // 未来 Pi 补上该 capability、或新增其它不支持的 Agent 时,此处自动跟随 main 侧
+  // 的 capability 真相,不会误警告 / 漏警告。(Telegram / 钉钉仅在群聊挂 policy,
   // 主人私聊 Pi 可用,设置 UI 不区分群聊/私聊,故不整体警告。)
-  const piUnsupportedOnChannel =
+  const selectedAgentCaps =
+    settings.agentKind === 'claude-code'
+      ? cc
+      : settings.agentKind === 'codex'
+        ? codex
+        : pi;
+  const selectedAgentUnsupported =
+    selectedAgentCaps.capabilities?.turnPermissionPolicy?.supported.supported !== true;
+  const agentUnsupportedOnChannel =
     channel !== undefined &&
     isUnconditionalTurnPolicyChannel(channel) &&
-    settings.agentKind === 'pi';
+    selectedAgentUnsupported;
 
   const changeAgent = (agentKind: ImDefaultAgentKind) => {
     if (agentKind === settings.agentKind) return;
@@ -343,7 +353,7 @@ export function ImDefaultSettingsSection({
         </div>
       </div>
 
-      {piUnsupportedOnChannel && (
+      {agentUnsupportedOnChannel && (
         <div
           role="note"
           className="flex items-start gap-2 rounded-lg bg-[var(--warning-bg-soft)] px-3 py-2"
@@ -354,7 +364,9 @@ export function ImDefaultSettingsSection({
             aria-hidden
           />
           <p className="text-11 leading-[1.45] text-[var(--text-secondary)]">
-            {t('settings.imBot.defaults.piUnsupportedHint')}
+            {t('settings.imBot.defaults.agentUnsupportedOnChannelHint', {
+              agent: t(`settings.imBot.defaults.agents.${settings.agentKind}`),
+            })}
           </p>
         </div>
       )}

--- a/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
@@ -10,7 +10,7 @@ import {
   getModel,
   isModelSelectableForNewRoute,
 } from '@cindy/model-providers';
-import { MessageSquare } from 'lucide-react';
+import { MessageSquare, AlertTriangle } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -25,6 +25,7 @@ import { cn } from '@/lib/utils';
 import {
   IM_DEFAULT_EFFORT_OVERRIDES,
   IM_DEFAULT_SETTINGS,
+  isUnconditionalTurnPolicyChannel,
   type ImDefaultAgentKind,
   type ImDefaultEffort,
   type ImDefaultSettingsChannel,
@@ -215,6 +216,13 @@ export function ImDefaultSettingsSection({
   }
 
   const activeSettings = settings.agents[settings.agentKind];
+  // 个人微信对每次 dispatch 无条件挂 turnPermissionPolicy;Pi 未声明该 capability,
+  // 选它发消息必然失败,此处给可执行提示。(Telegram / 钉钉仅在群聊挂 policy,
+  // 主人私聊 Pi 可用,设置 UI 不区分群聊/私聊,故不整体警告。)
+  const piUnsupportedOnChannel =
+    channel !== undefined &&
+    isUnconditionalTurnPolicyChannel(channel) &&
+    settings.agentKind === 'pi';
 
   const changeAgent = (agentKind: ImDefaultAgentKind) => {
     if (agentKind === settings.agentKind) return;
@@ -334,6 +342,22 @@ export function ImDefaultSettingsSection({
           />
         </div>
       </div>
+
+      {piUnsupportedOnChannel && (
+        <div
+          role="note"
+          className="flex items-start gap-2 rounded-lg bg-[var(--warning-bg-soft)] px-3 py-2"
+        >
+          <AlertTriangle
+            size={14}
+            className="mt-0.5 shrink-0 text-[var(--warning-fg)]"
+            aria-hidden
+          />
+          <p className="text-11 leading-[1.45] text-[var(--text-secondary)]">
+            {t('settings.imBot.defaults.piUnsupportedHint')}
+          </p>
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
@@ -232,6 +232,11 @@ export function ImDefaultSettingsSection({
     selectedAgentCaps.error === null &&
     selectedAgentCaps.capabilities !== null &&
     selectedAgentCaps.capabilities.turnPermissionPolicy?.supported.supported !== true;
+  // 渠道默认权限模式若是换 Agent 后仍不兼容的档位(Claude Code / Codex 的
+  // unsupportedPermissionModes 并集:bypassPermissions / acceptEdits),仅换 Agent
+  // 会在新会话(/new)上再次命中权限模式错误,警告需附加 /permission 提示。
+  const modeUnsupportedAfterSwitch =
+    settings.permissionMode === 'bypassPermissions' || settings.permissionMode === 'acceptEdits';
   const agentUnsupportedOnChannel =
     channel !== undefined &&
     isUnconditionalTurnPolicyChannel(channel) &&
@@ -368,11 +373,18 @@ export function ImDefaultSettingsSection({
             className="mt-0.5 shrink-0 text-[var(--warning-fg)]"
             aria-hidden
           />
-          <p className="text-11 leading-[1.45] text-[var(--text-secondary)]">
-            {t('settings.imBot.defaults.agentUnsupportedOnChannelHint', {
-              agent: t(`settings.imBot.defaults.agents.${settings.agentKind}`),
-            })}
-          </p>
+          <div className="min-w-0">
+            <p className="text-11 leading-[1.45] text-[var(--text-secondary)]">
+              {t('settings.imBot.defaults.agentUnsupportedOnChannelHint', {
+                agent: t(`settings.imBot.defaults.agents.${settings.agentKind}`),
+              })}
+            </p>
+            {modeUnsupportedAfterSwitch && (
+              <p className="mt-1 text-11 leading-[1.45] text-[var(--text-secondary)]">
+                {t('settings.imBot.defaults.agentUnsupportedOnChannelModeHint')}
+              </p>
+            )}
+          </div>
         </div>
       )}
     </section>

--- a/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
@@ -358,7 +358,9 @@ export function ImDefaultSettingsSection({
 
       {agentUnsupportedOnChannel && (
         <div
-          role="note"
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
           className="flex items-start gap-2 rounded-lg bg-[var(--warning-bg-soft)] px-3 py-2"
         >
           <AlertTriangle

--- a/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImDefaultSettingsSection.tsx
@@ -228,7 +228,10 @@ export function ImDefaultSettingsSection({
         ? codex
         : pi;
   const selectedAgentUnsupported =
-    selectedAgentCaps.capabilities?.turnPermissionPolicy?.supported.supported !== true;
+    !selectedAgentCaps.loading &&
+    selectedAgentCaps.error === null &&
+    selectedAgentCaps.capabilities !== null &&
+    selectedAgentCaps.capabilities.turnPermissionPolicy?.supported.supported !== true;
   const agentUnsupportedOnChannel =
     channel !== undefined &&
     isUnconditionalTurnPolicyChannel(channel) &&

--- a/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
@@ -8,6 +8,10 @@ import { ImDefaultSettingsSection } from '../ImDefaultSettingsSection';
 const capabilityMockState = vi.hoisted(() => ({
   loadingAgent: null as string | null,
   errorAgent: null as string | null,
+  piTurnPermissionPolicy: null as {
+    supported: { supported: true };
+    unsupportedPermissionModes: string[];
+  } | null,
 }));
 
 vi.mock('react-i18next', () => ({
@@ -27,11 +31,6 @@ vi.mock('@/hooks/useAgentCapabilities', () => {
     loading: false,
     error: null,
   };
-  const unsupported = {
-    capabilities: { availableModels: [] },
-    loading: false,
-    error: null,
-  };
   return {
     useAgentCapabilities: (agentKind: string) => {
       if (capabilityMockState.loadingAgent === agentKind) {
@@ -40,7 +39,18 @@ vi.mock('@/hooks/useAgentCapabilities', () => {
       if (capabilityMockState.errorAgent === agentKind) {
         return { capabilities: null, loading: false, error: 'capabilities unavailable' };
       }
-      return agentKind === 'pi' ? unsupported : supported;
+      return agentKind === 'pi'
+        ? {
+            capabilities: {
+              availableModels: [],
+              ...(capabilityMockState.piTurnPermissionPolicy
+                ? { turnPermissionPolicy: capabilityMockState.piTurnPermissionPolicy }
+                : {}),
+            },
+            loading: false,
+            error: null,
+          }
+        : supported;
     },
   };
 });
@@ -84,6 +94,7 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
   beforeEach(() => {
     capabilityMockState.loadingAgent = null;
     capabilityMockState.errorAgent = null;
+    capabilityMockState.piTurnPermissionPolicy = null;
     window.electronAPI = {
       maker: {
         imDefaultSettingsGet: vi.fn(async () => defaults('pi')),
@@ -130,6 +141,41 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
     const status = await screen.findByRole('status');
     expect(status.textContent).not.toContain(
       'settings.imBot.defaults.agentUnsupportedOnChannelModeHint',
+    );
+  });
+
+  it('does not warn for Pi ask/auto once its turn policy capability supports those modes', async () => {
+    capabilityMockState.piTurnPermissionPolicy = {
+      supported: { supported: true },
+      unsupportedPermissionModes: ['bypassPermissions'],
+    };
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    await screen.findByText('settings.imBot.defaults.agentLabel');
+    expect(screen.queryByRole('status')).toBeNull();
+  });
+
+  it('warns to change permission mode when Pi supports turn policy but not Full Access', async () => {
+    capabilityMockState.piTurnPermissionPolicy = {
+      supported: { supported: true },
+      unsupportedPermissionModes: ['bypassPermissions'],
+    };
+    window.electronAPI = {
+      maker: {
+        imDefaultSettingsGet: vi.fn(async () => ({
+          ...defaults('pi'),
+          permissionMode: 'bypassPermissions',
+        })),
+      },
+    } as unknown as typeof window.electronAPI;
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    const status = await screen.findByRole('status');
+    expect(status.textContent).toContain(
+      'settings.imBot.defaults.permissionModeUnsupportedOnChannelHint',
+    );
+    expect(status.textContent).not.toContain(
+      'settings.imBot.defaults.agentUnsupportedOnChannelHint',
     );
   });
 

--- a/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IM_DEFAULT_SETTINGS, type ImDefaultSettingsState } from '../../../../shared/imDefaultSettings';
+import { ImDefaultSettingsSection } from '../ImDefaultSettingsSection';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/useAgentCapabilities', () => ({
+  useAgentCapabilities: () => ({ capabilities: { availableModels: [] } }),
+}));
+
+vi.mock('@/hooks/useProviders', () => ({
+  useProviders: () => ({ providers: [] }),
+}));
+
+vi.mock('@/components/new-chat/AgentSelect', () => ({
+  AgentSelect: () => null,
+}));
+
+vi.mock('@/components/new-chat/ModelSelector', () => ({
+  ModelSelector: () => null,
+}));
+
+vi.mock('../DefaultOverrideControls', () => ({
+  DefaultOverrideControls: () => null,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+function defaults(agentKind: ImDefaultSettingsState['agentKind']): ImDefaultSettingsState {
+  return {
+    agentKind,
+    permissionMode: 'auto',
+    agents: {
+      'claude-code': { providerId: null, model: 'claude-opus-4-8', effort: 'xhigh' },
+      codex: { providerId: null, model: 'codex/gpt-5.5', effort: 'high' },
+      pi: { providerId: null, model: 'claude-sonnet-5', effort: 'high' },
+    },
+    isCustomized: false,
+    customizedKeys: [],
+    defaults: IM_DEFAULT_SETTINGS,
+  };
+}
+
+describe('ImDefaultSettingsSection Pi channel warning', () => {
+  beforeEach(() => {
+    window.electronAPI = {
+      maker: {
+        imDefaultSettingsGet: vi.fn(async () => defaults('pi')),
+      },
+    } as unknown as typeof window.electronAPI;
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('warns when Pi is selected on a turn-policy channel (wechat)', async () => {
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    expect(
+      await screen.findByText('settings.imBot.defaults.piUnsupportedHint'),
+    ).toBeTruthy();
+  });
+
+  it('does not warn for a supported agent on wechat', async () => {
+    window.electronAPI = {
+      maker: {
+        imDefaultSettingsGet: vi.fn(async () => defaults('claude-code')),
+      },
+    } as unknown as typeof window.electronAPI;
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    await screen.findByText('settings.imBot.defaults.agentLabel');
+    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+  });
+
+  it('does not warn for Pi on channels without turn policy (feishu)', async () => {
+    render(<ImDefaultSettingsSection channel="feishu" />);
+
+    await screen.findByText('settings.imBot.defaults.agentLabel');
+    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+  });
+
+  it('does not warn for Pi on conditional-policy channels (telegram / dingtalk)', async () => {
+    // Telegram / 钉钉仅在群聊(event.speaker 存在)挂 turnPermissionPolicy,
+    // 主人私聊 Pi 可用;设置 UI 不区分群聊/私聊,不能整体警告。
+    const first = render(<ImDefaultSettingsSection channel="telegram" />);
+    await first.findByText('settings.imBot.defaults.agentLabel');
+    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+    cleanup();
+
+    const second = render(<ImDefaultSettingsSection channel="dingtalk" />);
+    await second.findByText('settings.imBot.defaults.agentLabel');
+    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
@@ -107,6 +107,32 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
     expect(status.getAttribute('aria-atomic')).toBe('true');
   });
 
+  it('appends the permission-mode hint when the channel default mode is incompatible with the replacement agents', async () => {
+    window.electronAPI = {
+      maker: {
+        imDefaultSettingsGet: vi.fn(async () => ({ ...defaults('pi'), permissionMode: 'bypassPermissions' })),
+      },
+    } as unknown as typeof window.electronAPI;
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    const status = await screen.findByRole('status');
+    expect(status.textContent).toContain(
+      'settings.imBot.defaults.agentUnsupportedOnChannelHint',
+    );
+    expect(status.textContent).toContain(
+      'settings.imBot.defaults.agentUnsupportedOnChannelModeHint',
+    );
+  });
+
+  it('omits the permission-mode hint for a compatible default mode', async () => {
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    const status = await screen.findByRole('status');
+    expect(status.textContent).not.toContain(
+      'settings.imBot.defaults.agentUnsupportedOnChannelModeHint',
+    );
+  });
+
   it('does not warn for a supported agent on wechat', async () => {
     window.electronAPI = {
       maker: {

--- a/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
@@ -99,9 +99,12 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
   it('warns when Pi is selected on a turn-policy channel (wechat)', async () => {
     render(<ImDefaultSettingsSection channel="wechat" />);
 
-    expect(
-      await screen.findByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
-    ).toBeTruthy();
+    const status = await screen.findByRole('status');
+    expect(status.textContent).toContain(
+      'settings.imBot.defaults.agentUnsupportedOnChannelHint',
+    );
+    expect(status.getAttribute('aria-live')).toBe('polite');
+    expect(status.getAttribute('aria-atomic')).toBe('true');
   });
 
   it('does not warn for a supported agent on wechat', async () => {

--- a/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
@@ -9,9 +9,23 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@/hooks/useAgentCapabilities', () => ({
-  useAgentCapabilities: () => ({ capabilities: { availableModels: [] } }),
-}));
+vi.mock('@/hooks/useAgentCapabilities', () => {
+  // Pi 未声明 turnPermissionPolicy(警告);Claude Code / Codex 声明且受支持(不警告)。
+  const supported = {
+    capabilities: {
+      availableModels: [],
+      turnPermissionPolicy: {
+        supported: { supported: true },
+        unsupportedPermissionModes: [],
+      },
+    },
+  };
+  const unsupported = { capabilities: { availableModels: [] } };
+  return {
+    useAgentCapabilities: (agentKind: string) =>
+      agentKind === 'pi' ? unsupported : supported,
+  };
+});
 
 vi.mock('@/hooks/useProviders', () => ({
   useProviders: () => ({ providers: [] }),
@@ -66,7 +80,7 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
     render(<ImDefaultSettingsSection channel="wechat" />);
 
     expect(
-      await screen.findByText('settings.imBot.defaults.piUnsupportedHint'),
+      await screen.findByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
     ).toBeTruthy();
   });
 
@@ -79,14 +93,18 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
     render(<ImDefaultSettingsSection channel="wechat" />);
 
     await screen.findByText('settings.imBot.defaults.agentLabel');
-    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+    expect(
+      screen.queryByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
+    ).toBeNull();
   });
 
   it('does not warn for Pi on channels without turn policy (feishu)', async () => {
     render(<ImDefaultSettingsSection channel="feishu" />);
 
     await screen.findByText('settings.imBot.defaults.agentLabel');
-    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+    expect(
+      screen.queryByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
+    ).toBeNull();
   });
 
   it('does not warn for Pi on conditional-policy channels (telegram / dingtalk)', async () => {
@@ -94,11 +112,15 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
     // 主人私聊 Pi 可用;设置 UI 不区分群聊/私聊,不能整体警告。
     const first = render(<ImDefaultSettingsSection channel="telegram" />);
     await first.findByText('settings.imBot.defaults.agentLabel');
-    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+    expect(
+      screen.queryByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
+    ).toBeNull();
     cleanup();
 
     const second = render(<ImDefaultSettingsSection channel="dingtalk" />);
     await second.findByText('settings.imBot.defaults.agentLabel');
-    expect(screen.queryByText('settings.imBot.defaults.piUnsupportedHint')).toBeNull();
+    expect(
+      screen.queryByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
+    ).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx
@@ -5,6 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { IM_DEFAULT_SETTINGS, type ImDefaultSettingsState } from '../../../../shared/imDefaultSettings';
 import { ImDefaultSettingsSection } from '../ImDefaultSettingsSection';
 
+const capabilityMockState = vi.hoisted(() => ({
+  loadingAgent: null as string | null,
+  errorAgent: null as string | null,
+}));
+
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
@@ -19,11 +24,24 @@ vi.mock('@/hooks/useAgentCapabilities', () => {
         unsupportedPermissionModes: [],
       },
     },
+    loading: false,
+    error: null,
   };
-  const unsupported = { capabilities: { availableModels: [] } };
+  const unsupported = {
+    capabilities: { availableModels: [] },
+    loading: false,
+    error: null,
+  };
   return {
-    useAgentCapabilities: (agentKind: string) =>
-      agentKind === 'pi' ? unsupported : supported,
+    useAgentCapabilities: (agentKind: string) => {
+      if (capabilityMockState.loadingAgent === agentKind) {
+        return { capabilities: null, loading: true, error: null };
+      }
+      if (capabilityMockState.errorAgent === agentKind) {
+        return { capabilities: null, loading: false, error: 'capabilities unavailable' };
+      }
+      return agentKind === 'pi' ? unsupported : supported;
+    },
   };
 });
 
@@ -64,6 +82,8 @@ function defaults(agentKind: ImDefaultSettingsState['agentKind']): ImDefaultSett
 
 describe('ImDefaultSettingsSection Pi channel warning', () => {
   beforeEach(() => {
+    capabilityMockState.loadingAgent = null;
+    capabilityMockState.errorAgent = null;
     window.electronAPI = {
       maker: {
         imDefaultSettingsGet: vi.fn(async () => defaults('pi')),
@@ -90,6 +110,26 @@ describe('ImDefaultSettingsSection Pi channel warning', () => {
         imDefaultSettingsGet: vi.fn(async () => defaults('claude-code')),
       },
     } as unknown as typeof window.electronAPI;
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    await screen.findByText('settings.imBot.defaults.agentLabel');
+    expect(
+      screen.queryByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
+    ).toBeNull();
+  });
+
+  it('does not warn while the selected Agent capabilities are loading', async () => {
+    capabilityMockState.loadingAgent = 'pi';
+    render(<ImDefaultSettingsSection channel="wechat" />);
+
+    await screen.findByText('settings.imBot.defaults.agentLabel');
+    expect(
+      screen.queryByText('settings.imBot.defaults.agentUnsupportedOnChannelHint'),
+    ).toBeNull();
+  });
+
+  it('does not warn when the selected Agent capabilities failed to load', async () => {
+    capabilityMockState.errorAgent = 'pi';
     render(<ImDefaultSettingsSection channel="wechat" />);
 
     await screen.findByText('settings.imBot.defaults.agentLabel');

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -115,6 +115,16 @@ export interface AgentCapabilities {
    * device-link 老被控端无此字段 → undefined，控制端必须阻止开启协同并提示升级。
    */
   supportsOrcaWorkerPermissionMode?: boolean;
+  /**
+   * 每轮 host 权限策略能力门:未声明或 supported.supported !== true 的 Agent 无法
+   * 用于「无条件挂逐条权限确认」的渠道(如个人微信)。与 maker-core 的
+   * Capabilities.turnPermissionPolicy 同构;device-link 老被控端无此字段 →
+   * undefined = 不支持。
+   */
+  turnPermissionPolicy?: {
+    supported: CapabilityStatus;
+    unsupportedPermissionModes: string[];
+  };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3034,7 +3034,7 @@
           "wecom": "New WeCom conversations use this Agent, model, and permission mode. Send /new in an existing chat to apply them."
         },
         "agentLabel": "Agent",
-        "piUnsupportedHint": "Pi Agent does not support per-message permission confirmations on this channel; messages cannot be processed. Switch to Claude Code or Codex.",
+        "agentUnsupportedOnChannelHint": "{{agent}} Agent does not support per-message permission confirmations on this channel; messages cannot be processed. Switch to Claude Code or Codex.",
         "modelLabel": "Model Configuration",
         "loading": "Loading new conversation configuration…",
         "loadFailed": "Failed to load new conversation configuration",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3034,6 +3034,7 @@
           "wecom": "New WeCom conversations use this Agent, model, and permission mode. Send /new in an existing chat to apply them."
         },
         "agentLabel": "Agent",
+        "piUnsupportedHint": "Pi Agent does not support per-message permission confirmations on this channel; messages cannot be processed. Switch to Claude Code or Codex.",
         "modelLabel": "Model Configuration",
         "loading": "Loading new conversation configuration…",
         "loadFailed": "Failed to load new conversation configuration",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3035,6 +3035,7 @@
         },
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent does not support per-message permission confirmations on this channel; messages cannot be processed. Switch to Claude Code or Codex.",
+        "agentUnsupportedOnChannelModeHint": "After switching the Agent and sending /new, if the new Agent still reports a permission-mode issue, send /permission to adjust the permission mode.",
         "modelLabel": "Model Configuration",
         "loading": "Loading new conversation configuration…",
         "loadFailed": "Failed to load new conversation configuration",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3036,6 +3036,7 @@
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent does not support per-message permission confirmations on this channel; messages cannot be processed. Switch to Claude Code or Codex.",
         "agentUnsupportedOnChannelModeHint": "After switching the Agent and sending /new, if the new Agent still reports a permission-mode issue, send /permission to adjust the permission mode.",
+        "permissionModeUnsupportedOnChannelHint": "The current Agent cannot run on this channel in this permission mode, so messages cannot be processed. Send /permission to choose a supported mode.",
         "modelLabel": "Model Configuration",
         "loading": "Loading new conversation configuration…",
         "loadFailed": "Failed to load new conversation configuration",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3033,7 +3033,7 @@
           "wecom": "WeCom の新規会話では、この Agent・モデル・権限モードを使用します。既存のチャットには /new で適用します。"
         },
         "agentLabel": "Agent",
-        "piUnsupportedHint": "Pi Agent はこのチャンネルでメッセージごとの権限確認に対応していないため、メッセージを処理できません。Claude Code または Codex に切り替えてください。",
+        "agentUnsupportedOnChannelHint": "{{agent}} Agent はこのチャンネルでメッセージごとの権限確認に対応していないため、メッセージを処理できません。Claude Code または Codex に切り替えてください。",
         "modelLabel": "モデル設定",
         "loading": "新規会話設定を読み込み中…",
         "loadFailed": "新規会話設定を読み込めませんでした",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3035,6 +3035,7 @@
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent はこのチャンネルでメッセージごとの権限確認に対応していないため、メッセージを処理できません。Claude Code または Codex に切り替えてください。",
         "agentUnsupportedOnChannelModeHint": "Agent を切り替えて /new を送信した後、新しい Agent でも権限モードの問題が表示される場合は、/permission を送信して権限モードを調整してください。",
+        "permissionModeUnsupportedOnChannelHint": "現在の Agent はこの権限モードではこのチャンネルを利用できないため、メッセージを処理できません。/permission を送信して対応する権限モードに変更してください。",
         "modelLabel": "モデル設定",
         "loading": "新規会話設定を読み込み中…",
         "loadFailed": "新規会話設定を読み込めませんでした",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3034,6 +3034,7 @@
         },
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent はこのチャンネルでメッセージごとの権限確認に対応していないため、メッセージを処理できません。Claude Code または Codex に切り替えてください。",
+        "agentUnsupportedOnChannelModeHint": "Agent を切り替えて /new を送信した後、新しい Agent でも権限モードの問題が表示される場合は、/permission を送信して権限モードを調整してください。",
         "modelLabel": "モデル設定",
         "loading": "新規会話設定を読み込み中…",
         "loadFailed": "新規会話設定を読み込めませんでした",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3033,6 +3033,7 @@
           "wecom": "WeCom の新規会話では、この Agent・モデル・権限モードを使用します。既存のチャットには /new で適用します。"
         },
         "agentLabel": "Agent",
+        "piUnsupportedHint": "Pi Agent はこのチャンネルでメッセージごとの権限確認に対応していないため、メッセージを処理できません。Claude Code または Codex に切り替えてください。",
         "modelLabel": "モデル設定",
         "loading": "新規会話設定を読み込み中…",
         "loadFailed": "新規会話設定を読み込めませんでした",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3034,6 +3034,7 @@
         },
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent는 이 채널에서 메시지별 권한 확인을 지원하지 않아 메시지를 처리할 수 없습니다. Claude Code 또는 Codex로 전환하세요.",
+        "agentUnsupportedOnChannelModeHint": "Agent를 전환하고 /new를 보낸 후에도 새 Agent에서 권한 모드 문제가 표시되면 /permission을 보내 권한 모드를 조정하세요.",
         "modelLabel": "모델 설정",
         "loading": "새 대화 설정을 불러오는 중…",
         "loadFailed": "새 대화 설정을 불러오지 못했습니다",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3033,6 +3033,7 @@
           "wecom": "새 WeCom 대화는 이 Agent, 모델, 권한 모드를 사용합니다. 기존 채팅에는 /new를 보내 적용하세요."
         },
         "agentLabel": "Agent",
+        "piUnsupportedHint": "Pi Agent는 이 채널에서 메시지별 권한 확인을 지원하지 않아 메시지를 처리할 수 없습니다. Claude Code 또는 Codex로 전환하세요.",
         "modelLabel": "모델 설정",
         "loading": "새 대화 설정을 불러오는 중…",
         "loadFailed": "새 대화 설정을 불러오지 못했습니다",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3033,7 +3033,7 @@
           "wecom": "새 WeCom 대화는 이 Agent, 모델, 권한 모드를 사용합니다. 기존 채팅에는 /new를 보내 적용하세요."
         },
         "agentLabel": "Agent",
-        "piUnsupportedHint": "Pi Agent는 이 채널에서 메시지별 권한 확인을 지원하지 않아 메시지를 처리할 수 없습니다. Claude Code 또는 Codex로 전환하세요.",
+        "agentUnsupportedOnChannelHint": "{{agent}} Agent는 이 채널에서 메시지별 권한 확인을 지원하지 않아 메시지를 처리할 수 없습니다. Claude Code 또는 Codex로 전환하세요.",
         "modelLabel": "모델 설정",
         "loading": "새 대화 설정을 불러오는 중…",
         "loadFailed": "새 대화 설정을 불러오지 못했습니다",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3035,6 +3035,7 @@
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent는 이 채널에서 메시지별 권한 확인을 지원하지 않아 메시지를 처리할 수 없습니다. Claude Code 또는 Codex로 전환하세요.",
         "agentUnsupportedOnChannelModeHint": "Agent를 전환하고 /new를 보낸 후에도 새 Agent에서 권한 모드 문제가 표시되면 /permission을 보내 권한 모드를 조정하세요.",
+        "permissionModeUnsupportedOnChannelHint": "현재 Agent는 이 권한 모드로 이 채널에서 실행할 수 없어 메시지를 처리할 수 없습니다. /permission을 보내 지원되는 권한 모드로 변경하세요.",
         "modelLabel": "모델 설정",
         "loading": "새 대화 설정을 불러오는 중…",
         "loadFailed": "새 대화 설정을 불러오지 못했습니다",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3033,6 +3033,7 @@
           "wecom": "企业微信新对话会使用这组 Agent、模型和权限模式；已有对话发送 /new 后应用。"
         },
         "agentLabel": "Agent",
+        "piUnsupportedHint": "Pi Agent 不支持此渠道的逐条权限确认，消息将无法处理。请改用 Claude Code 或 Codex。",
         "modelLabel": "模型配置",
         "loading": "正在读取新对话配置…",
         "loadFailed": "读取新对话配置失败",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3034,6 +3034,7 @@
         },
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent 不支持此渠道的逐条权限确认，消息将无法处理。请改用 Claude Code 或 Codex。",
+        "agentUnsupportedOnChannelModeHint": "切换 Agent 后发送 /new，若新的 Agent 仍提示权限模式问题，请再发送 /permission 调整权限模式。",
         "modelLabel": "模型配置",
         "loading": "正在读取新对话配置…",
         "loadFailed": "读取新对话配置失败",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3035,6 +3035,7 @@
         "agentLabel": "Agent",
         "agentUnsupportedOnChannelHint": "{{agent}} Agent 不支持此渠道的逐条权限确认，消息将无法处理。请改用 Claude Code 或 Codex。",
         "agentUnsupportedOnChannelModeHint": "切换 Agent 后发送 /new，若新的 Agent 仍提示权限模式问题，请再发送 /permission 调整权限模式。",
+        "permissionModeUnsupportedOnChannelHint": "当前 Agent 不支持以此权限模式在该渠道运行，消息将无法处理。请发送 /permission 调整权限模式。",
         "modelLabel": "模型配置",
         "loading": "正在读取新对话配置…",
         "loadFailed": "读取新对话配置失败",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3033,7 +3033,7 @@
           "wecom": "企业微信新对话会使用这组 Agent、模型和权限模式；已有对话发送 /new 后应用。"
         },
         "agentLabel": "Agent",
-        "piUnsupportedHint": "Pi Agent 不支持此渠道的逐条权限确认，消息将无法处理。请改用 Claude Code 或 Codex。",
+        "agentUnsupportedOnChannelHint": "{{agent}} Agent 不支持此渠道的逐条权限确认，消息将无法处理。请改用 Claude Code 或 Codex。",
         "modelLabel": "模型配置",
         "loading": "正在读取新对话配置…",
         "loadFailed": "读取新对话配置失败",

--- a/apps/desktop/src/shared/imDefaultSettings.ts
+++ b/apps/desktop/src/shared/imDefaultSettings.ts
@@ -97,6 +97,28 @@ export const WECHAT_UNSUPPORTED_PERMISSION_MODES: readonly ImDefaultPermissionMo
   'bypassPermissions',
 ];
 
+/**
+ * 渠道对**任何消息**都挂 turnPermissionPolicy 的清单(与 main 侧 adapter 的
+ * turnPermissionPolicyFor / turnPermissionPolicyForRoute 事实对齐):这些渠道把
+ * 工具确认渲染成渠道文本提示,要求所选 Agent 声明 turnPermissionPolicy
+ * capability。Pi 未声明该 capability,在这些渠道的任何权限模式下都不可用
+ * (fail-closed);Claude Code / Codex 声明了,仅在个别权限模式不可用。
+ *
+ * 目前只有个人微信(WechatIM.turnPermissionPolicyForRoute)对每次 dispatch
+ * 无条件挂 policy;Telegram / 钉钉的 turnPermissionPolicyFor 仅在群聊
+ * (event.speaker 存在)时挂载,主人私聊不挂 → Pi 在私聊可用,设置 UI 不区分
+ * 群聊/私聊,不能整体警告。新增渠道时先确认其 policy 挂载是否无条件。
+ */
+export const UNCONDITIONAL_TURN_POLICY_CHANNELS: readonly ImDefaultSettingsChannel[] = [
+  'wechat',
+];
+
+export function isUnconditionalTurnPolicyChannel(
+  channel: ImDefaultSettingsChannel,
+): boolean {
+  return UNCONDITIONAL_TURN_POLICY_CHANNELS.includes(channel);
+}
+
 export function isImDefaultAgentKind(value: unknown): value is ImDefaultAgentKind {
   return typeof value === 'string' && AGENT_KINDS.has(value as ImDefaultAgentKind);
 }

--- a/apps/desktop/src/shared/imDefaultSettings.ts
+++ b/apps/desktop/src/shared/imDefaultSettings.ts
@@ -99,12 +99,12 @@ export const WECHAT_UNSUPPORTED_PERMISSION_MODES: readonly ImDefaultPermissionMo
 
 /**
  * 渠道对**任何消息**都挂 turnPermissionPolicy 的清单(与 main 侧 adapter 的
- * turnPermissionPolicyFor / turnPermissionPolicyForRoute 事实对齐):这些渠道把
+ * turnPermissionPolicy / turnPermissionPolicyFor 事实对齐):这些渠道把
  * 工具确认渲染成渠道文本提示,要求所选 Agent 声明 turnPermissionPolicy
  * capability。Pi 未声明该 capability,在这些渠道的任何权限模式下都不可用
  * (fail-closed);Claude Code / Codex 声明了,仅在个别权限模式不可用。
  *
- * 目前只有个人微信(WechatIM.turnPermissionPolicyForRoute)对每次 dispatch
+ * 目前只有个人微信(WechatIM.turnPermissionPolicy)对每次 dispatch
  * 无条件挂 policy;Telegram / 钉钉的 turnPermissionPolicyFor 仅在群聊
  * (event.speaker 存在)时挂载,主人私聊不挂 → Pi 在私聊可用,设置 UI 不区分
  * 群聊/私聊,不能整体警告。新增渠道时先确认其 policy 挂载是否无条件。

--- a/packages/maker-core/src/maker.test.ts
+++ b/packages/maker-core/src/maker.test.ts
@@ -4,7 +4,11 @@ import path from 'node:path';
 import { Maker, type CreateSessionOptions } from './maker.js';
 import { Session } from './session.js';
 import { createAsyncQueue } from './agents/shared/async-queue.js';
-import type { AgentSessionHandle, BaseAgent } from './agents/base-agent.js';
+import {
+  TurnPermissionPolicyUnsupportedError,
+  type AgentSessionHandle,
+  type BaseAgent,
+} from './agents/base-agent.js';
 import type { SessionMeta, SessionStorage } from './interfaces/session-storage.js';
 import type { AgentKind, PermissionMode } from './types/common.js';
 import type { AgentEvent } from './types/events.js';
@@ -1118,13 +1122,15 @@ describe('Session turn send guard', () => {
     await expect(session.send('second')).resolves.toEqual({ accepted: true });
   });
 
-  it('runs provider option preflight before durable or accepted side effects', async () => {
-    const preflightError = new Error('unsupported policy/mode combination');
+  it('keeps the session reusable when provider option preflight rejects before dispatch', async () => {
+    vi.useFakeTimers();
+    const preflightError = new TurnPermissionPolicyUnsupportedError('pi', 'ask');
     const handle = createHandle({ id: 'thread-send-preflight' });
     handle.validateSendOptions = vi.fn(() => {
       throw preflightError;
     });
     handle.send = vi.fn(async () => undefined);
+    handle.close = vi.fn(async () => undefined);
     const session = new Session({
       id: 'send-preflight',
       agentKind: 'codex',
@@ -1135,18 +1141,28 @@ describe('Session turn send guard', () => {
     });
     const beforeProviderStart = vi.fn();
     const onAccepted = vi.fn();
+    const send = () => session.send('message', { beforeProviderStart, onAccepted });
 
-    await expect(
-      session.send('first', {
-        beforeProviderStart,
-        onAccepted,
-      }),
-    ).rejects.toBe(preflightError);
+    try {
+      await expect(send()).rejects.toBe(preflightError);
+      await expect(send()).rejects.toBe(preflightError);
+      expect(session.isTurnRunning()).toBe(false);
+      expect(session.getStatus()).toBe('active');
 
-    expect(handle.validateSendOptions).toHaveBeenCalledOnce();
-    expect(beforeProviderStart).not.toHaveBeenCalled();
-    expect(onAccepted).not.toHaveBeenCalled();
-    expect(handle.send).not.toHaveBeenCalled();
+      // A pure validateSendOptions failure happens before origin installation,
+      // so it must not arm the 250 ms terminal-drain fence or close the Session.
+      await vi.advanceTimersByTimeAsync(300);
+      await expect(send()).rejects.toBe(preflightError);
+
+      expect(handle.validateSendOptions).toHaveBeenCalledTimes(3);
+      expect(beforeProviderStart).not.toHaveBeenCalled();
+      expect(onAccepted).not.toHaveBeenCalled();
+      expect(handle.send).not.toHaveBeenCalled();
+      expect(handle.close).not.toHaveBeenCalled();
+      expect(session.getStatus()).toBe('active');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('runs reservation state preparation before provider option preflight', async () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

个人微信渠道对**每次 dispatch 无条件**挂逐条权限确认 policy（`WechatIM.turnPermissionPolicyForRoute`），而 Pi Agent 未声明 `turnPermissionPolicy` capability（fail-closed，codex review P1 的既有安全设计），因此 Pi 在微信渠道**任何权限模式**下都必然失败。原报错文案「请在 Cindy 中切换权限模式」对 Pi 完全无效，误导用户反复尝试。

本 PR 把运行时错误按「Agent 不支持（只能换 Agent）」与「权限模式不支持（切权限模式即可）」区分，并给设置界面加提前警告：

- `WechatIM.turnPermissionPolicyForRoute` 失败时按 `capabilities.turnPermissionPolicy` 有无分类重抛，`wechatPreDispatchFailureText` 纯函数选择文案（含旧格式兼容分支）；
- 设置界面「新对话配置」在**微信渠道**选择 Pi 时显示警告 callout；
- Telegram / 钉钉仅在群聊（`event.speaker` 存在）挂 policy，主人私聊 Pi 可用，设置 UI 不区分群聊/私聊，因此不整体警告。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（社区反馈 bug）
- 本 PR 包含：WechatIM 错误分类与文案、设置 UI 警告、i18n 4 语、单测
- 明确不包含：不改 `packages/maker-core`（Pi 的 fail-closed 安全设计不动）；不做「让 Pi 支持微信」的架构改动；不动 Telegram / 钉钉
- 用户可见变化：微信渠道选 Pi 发消息 → 报错明确引导换 Agent（不再误导切权限模式）；设置界面选 Pi 显示警告
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - DESIGN.md §2 Semantic & Accent（警告橙）：警告 callout 使用 `--warning-bg-soft` / `--warning-fg`（警告族 token）
  - DESIGN.md §10 Light/Dark 双模式交付门槛：颜色全部走语义 token（`--warning-*`、`--text-secondary`），无硬编码 hex，Light/Dark 同时满足
  - DESIGN.md §10 Token Selection Rules：未引入新 token，复用既有警告族

## 怎么验证的

### 自动验证

```text
pnpm check:i18n
结果：✅ zh-CN / en / ja / ko 共 6726 个 key 全部一致（550 处警告为存量，与本次无关）

pnpm check:i18n-glossary
结果：✅ 无新增违规

pnpm --filter desktop run typecheck
结果：✅ 通过

npx vitest run src/main/im/wechat/__tests__/WechatIM.test.ts \
  src/renderer/components/settings/__tests__/ImDefaultSettingsSection.test.tsx \
  src/main/im/wechat/__tests__/permissionPolicy.test.ts
结果：✅ 3 个文件 23 个测试全过

pnpm test:unit
结果：34 个 workspace 中除 desktop 的 2 个既有性能超时测试外全部 PASS（详见「未执行的验证」）

pnpm check:dco
结果：✅ 1 commit signed off
```

### 手工验证

不涉及（改动为报错文案与设置界面警告，均已在单测覆盖；未做双模式实机目检）。

### 未执行的验证

desktop 全量单测中 `codexLocalSessions.test.ts` 的两个测试（`applies the import cap after filtering subagent threads`、`caps to newest MAX_THREADS_PER_HOME top-level threads when more than 1000 exist`）在本机稳定超时：测试硬编码 15000ms 超时且需写入 1001 个 thread 文件 + SQLite。已用 `git stash` 验证**干净 main 代码同样超时**，属存量本机性能问题，与本 PR 无关（CI 机器应可正常通过）。Light/Dark 实机目检未执行：仅新增 token 化警告色，未做真机目检。

## 风险

### 风险分类

- [x] 无已知风险

（说明：改动为文案分类与 UI 提示，不触碰任何权限判定逻辑；Pi 的 fail-closed 行为不变。）

### 影响与回滚

- 影响范围：微信渠道报错文案、设置界面警告；纯文案 / UI，无协议、DB、system prompt 变更
- 回滚 / 降级方式：`git revert` 即可，无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档）
- [x] 已确认测试结果或说明未执行原因

---

Fixes #1906

### Review 收敛补充

原始方案与主体实现由 @RandallLiuXin 提交；维护者在 bb48d590 中按首轮完整 review 合批补充：

- 按 turnPermissionPolicy.supported.supported === true 判断 Agent 是否整体支持，避免 capability 字段存在但实际不支持时误导切换权限模式；
- 微信设置页动态警告改为 role="status" + aria-live="polite" + aria-atomic="true"，并覆盖切换 Agent 时挂载与消失；
- 旧格式兼容分支注释与既有“切换权限模式”行为对齐，不扩展旧格式产品行为。

### 最新验证（2026-08-06）

- pnpm test:unit：全部适用 workspace 通过。
- pnpm --filter desktop run --if-present typecheck：通过。
- pnpm check:i18n：四语 6726 个 key 一致；550 条存量警告，不阻塞。
- pnpm check:i18n-glossary：通过。
- 微信权限策略 / 微信派发 / 设置组件：3 文件 23 项通过。
- pnpm --filter @cindy/im test：32 文件、399 项通过，覆盖 Telegram、飞书、Discord、钉钉、企微等个人 IM 基础层。
- Desktop src/main/im + src/main/hook-control：62 文件、851 项通过，覆盖个人微信、Telegram/钉钉私聊与群聊 policy 边界，以及官方 Slack / Telegram / X 共享链路。
- pnpm check:dco：2 个 commit 均通过。

### 尚未验证

- 未执行真实 Windows Desktop + 个人微信端到端验证。
- 未做 Light / Dark 两种模式实机目检；样式继续复用既有语义 token，自动测试覆盖了 warning 的动态显示、消失与 live-region 语义。

### 与 #1964 的兼容边界（2026-08-07）

- 本 PR 仍只负责准确提示，不实现 Pi 的 turn permission policy bridge；能力实现由 #1964 负责，不重复造能力。
- 当前 main 上 Pi 未声明能力时，个人微信继续提示更换 Agent。
- #1964 合入后，设置页按 live capabilities 与 unsupportedPermissionModes 联合判断：Pi ask / auto 不再显示不兼容警告；Pi Full Access 只提示发送 /permission 切换权限模式，不再误报为 Agent 整体不支持。
- 运行时派发错误同样按 live session capabilities 分类，个人微信每次 dispatch 的 turnPermissionPolicy 与 fail-closed 边界不变。

兼容调整 commit：1a8bed2a。新增/更新验证：设置组件 10 项、微信/turnRunner 定向 79 项、根级 pnpm test:unit、Desktop typecheck、四语 i18n/术语门禁、@cindy/im 399 项、Desktop IM + hook-control 852 项均通过。