### PR TITLE
feat(desktop): 标题栏左上角菜单新增「设置」入口 #1881

### DIFF
--- a/apps/desktop/src/renderer/__tests__/menuButtonSettingsEntry.test.ts
+++ b/apps/desktop/src/renderer/__tests__/menuButtonSettingsEntry.test.ts
@@ -26,10 +26,11 @@ describe('MenuButton — settings menu item (#1881)', () => {
     expect(source).toContain("t('titleBar.menuItems.settings')");
   });
 
-  it('navigates to /settings with a same-path guard', () => {
-    // 与 MainLayout 'open-settings' / UserInfoSection 相同的防重复导航语义
+  it('navigates to /settings with the open-settings same-path guard (pathname + search)', () => {
+    // 与 MainLayout 'open-settings' 相同判定(currentPathRef = pathname + search):
+    // 已在设置默认页不重复导航;在 /settings?tab=xxx 子页回到设置默认页。
     expect(source).toMatch(
-      /if \(location\.pathname !== '\/settings'\) \{\s*\n\s*navigate\('\/settings'\);/,
+      /if \(`\$\{location\.pathname\}\$\{location\.search\}` !== '\/settings'\) \{\s*\n\s*navigate\('\/settings'\);/,
     );
     expect(source).toContain("import { useLocation, useNavigate } from 'react-router-dom';");
   });

--- a/apps/desktop/src/renderer/__tests__/menuButtonSettingsEntry.test.ts
+++ b/apps/desktop/src/renderer/__tests__/menuButtonSettingsEntry.test.ts
@@ -1,0 +1,58 @@
+/**
+ * menuButtonSettingsEntry.test.ts
+ * ---------------------------------------------------------------------------
+ * Regression test for Issue #1881: Windows / Linux 缺少清晰可发现的「设置」入口。
+ *
+ * 契约:标题栏左上角应用内菜单(MenuButton)必须常驻「设置」菜单项——
+ * 非 darwin 平台没有原生应用菜单(installApplicationMenu 置 null),macOS
+ * 的「设置…」菜单项在这些平台不可见,此处是唯一的菜单型设置入口。
+ *
+ * 这份测试做静态源码扫描,确保以下契约不被未来的提交悄悄回退:
+ * 1. 菜单包含 settings 菜单项,文案走 i18n key `titleBar.menuItems.settings`。
+ * 2. 点击导航 `/settings`,且已在设置页时不重复导航(与 MainLayout
+ *    'open-settings' 命令、侧栏用户卡片同一行为)。
+ * 3. 四语言 locale 都提供 `titleBar.menuItems.settings` 文案。
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const sourcePath = resolve(__dirname, '..', 'components', 'title-bar', 'MenuButton.tsx');
+const source = readFileSync(sourcePath, 'utf8');
+
+describe('MenuButton — settings menu item (#1881)', () => {
+  it('renders a settings item backed by the i18n key', () => {
+    expect(source).toContain("t('titleBar.menuItems.settings')");
+  });
+
+  it('navigates to /settings with a same-path guard', () => {
+    // 与 MainLayout 'open-settings' / UserInfoSection 相同的防重复导航语义
+    expect(source).toMatch(
+      /if \(location\.pathname !== '\/settings'\) \{\s*\n\s*navigate\('\/settings'\);/,
+    );
+    expect(source).toContain("import { useLocation, useNavigate } from 'react-router-dom';");
+  });
+
+  it('keeps the existing help / issues / check-for-updates items', () => {
+    expect(source).toContain("t('titleBar.menuItems.help')");
+    expect(source).toContain("t('titleBar.menuItems.issues')");
+    expect(source).toContain("t('titleBar.menuItems.checkForUpdates')");
+  });
+});
+
+describe('MenuButton — locale coverage for the settings item', () => {
+  const locales = ['zh-CN', 'en', 'ja', 'ko'] as const;
+
+  for (const lng of locales) {
+    it(`${lng} provides titleBar.menuItems.settings`, () => {
+      const localePath = resolve(__dirname, '..', 'i18n', 'locales', lng, 'common.json');
+      const locale = JSON.parse(readFileSync(localePath, 'utf8')) as {
+        titleBar: { menuItems: { settings?: string } };
+      };
+      const label = locale.titleBar.menuItems.settings;
+      expect(label, `${lng} 缺少 titleBar.menuItems.settings`).toBeTruthy();
+      expect(label).not.toContain('?');
+    });
+  }
+});

--- a/apps/desktop/src/renderer/components/title-bar/MenuButton.tsx
+++ b/apps/desktop/src/renderer/components/title-bar/MenuButton.tsx
@@ -1,6 +1,6 @@
 import { Menu } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 import { cn } from '@/lib/utils';
 import { checkForUpdateWithToast } from '@/lib/checkForUpdateWithToast';
@@ -17,6 +17,7 @@ import {
 export function MenuButton() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const location = useLocation();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -40,6 +41,22 @@ export function MenuButton() {
         align="start"
         className="bg-titlebar border-titlebar-border"
       >
+        {/* 设置入口:Windows / Linux 没有原生应用菜单(installApplicationMenu 非
+            darwin 直接置 null),macOS「设置…」菜单项在这些平台不可见;侧栏底部
+            用户卡片虽可进设置但无可见「设置」标识,可发现性不足(#1881)。此处
+            常驻应用内左上角菜单,与 MainLayout 'open-settings' 命令同一行为:
+            已在设置页时不重复导航,避免堆叠重复 history 记录。 */}
+        <DropdownMenuItem
+          className="focus:bg-titlebar-button-hover"
+          onSelect={() => {
+            log.info('Settings clicked');
+            if (location.pathname !== '/settings') {
+              navigate('/settings');
+            }
+          }}
+        >
+          {t('titleBar.menuItems.settings')}
+        </DropdownMenuItem>
         <DropdownMenuItem
           className="focus:bg-titlebar-button-hover"
           onSelect={() => {

--- a/apps/desktop/src/renderer/components/title-bar/MenuButton.tsx
+++ b/apps/desktop/src/renderer/components/title-bar/MenuButton.tsx
@@ -44,13 +44,15 @@ export function MenuButton() {
         {/* 设置入口:Windows / Linux 没有原生应用菜单(installApplicationMenu 非
             darwin 直接置 null),macOS「设置…」菜单项在这些平台不可见;侧栏底部
             用户卡片虽可进设置但无可见「设置」标识,可发现性不足(#1881)。此处
-            常驻应用内左上角菜单,与 MainLayout 'open-settings' 命令同一行为:
-            已在设置页时不重复导航,避免堆叠重复 history 记录。 */}
+            常驻应用内左上角菜单,与 MainLayout 'open-settings' 命令同一判定
+            (pathname + search,见 MainLayout currentPathRef):已在设置默认页时
+            不重复导航;在 /settings?tab=xxx 子页时回到设置默认页,与 macOS 原生
+            菜单「设置…」行为一致。 */}
         <DropdownMenuItem
           className="focus:bg-titlebar-button-hover"
           onSelect={() => {
             log.info('Settings clicked');
-            if (location.pathname !== '/settings') {
+            if (`${location.pathname}${location.search}` !== '/settings') {
               navigate('/settings');
             }
           }}

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -4291,6 +4291,7 @@
     "maximize": "Maximize",
     "close": "Close",
     "menuItems": {
+      "settings": "Settings",
       "help": "Help",
       "issues": "Issues",
       "checkForUpdates": "Check for Updates"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4289,6 +4289,7 @@
     "maximize": "最大化",
     "close": "閉じる",
     "menuItems": {
+      "settings": "設定",
       "help": "ヘルプ",
       "issues": "フィードバック",
       "checkForUpdates": "更新を確認"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4289,6 +4289,7 @@
     "maximize": "최대화",
     "close": "닫기",
     "menuItems": {
+      "settings": "설정",
       "help": "도움말",
       "issues": "이슈",
       "checkForUpdates": "업데이트 확인"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4289,6 +4289,7 @@
     "maximize": "最大化",
     "close": "关闭",
     "menuItems": {
+      "settings": "设置",
       "help": "帮助",
       "issues": "问题反馈",
       "checkForUpdates": "检查更新"


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows / Linux 没有原生应用菜单(`installApplicationMenu` 非 darwin 直接置 null),macOS 的「设置…」菜单项在这些平台不可见;侧栏底部用户卡片虽可点击进入设置,但无可见「设置」文字或齿轮标识,设置入口可发现性不足(Issue #1881)。本 PR 在标题栏左上角应用内下拉菜单(MenuButton)顶部新增常驻「设置」菜单项,点击进入 `/settings`,与 MainLayout `open-settings` 命令、侧栏用户卡片同一行为(已在设置页时不重复导航)。不改动用户卡片现有行为,不新增快捷键(经与需求方确认,本次仅做菜单入口)。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:#1881
- 本 PR 包含:MenuButton 新增「设置」菜单项;四语言(zh-CN / en / ja / ko)新增 `titleBar.menuItems.settings` 文案;静态契约回归测试 `menuButtonSettingsEntry.test.ts`。
- 明确不包含:Windows `Ctrl+,` 快捷键(`open-settings` 仍限定 darwin);用户卡片齿轮图标 / tooltip / 首次引导;设置页本身的任何改动。
- 用户可见变化:Windows / Linux(及 macOS 应用内菜单)左上角菜单新增「设置」项,位于「帮助」上方。
- 是否存在 breaking change:无

### UI 变化

标题栏左上角下拉菜单新增一个菜单项,复用现有 `DropdownMenuItem` 组件与样式(`focus:bg-titlebar-button-hover`),与相邻「帮助 / 问题反馈 / 检查更新」视觉完全一致;无新增样式代码。平台:Windows / Linux 常驻可见,macOS 应用内菜单同样显示(与原生菜单「设置…」行为一致,不冲突)。

- 引用的设计规范:
  - DESIGN.md §4 Component Stylings → Select & Dropdown:复用现有 dropdown-menu 组件与 titlebar 语义 token,未引入新样式。
  - DESIGN.md §10 Light / Dark Dual-Mode Delivery Gate:菜单项颜色全部走既有语义 token(`bg-titlebar` / `focus:bg-titlebar-button-hover`),无硬编码色,Light / Dark 双模式由 token 层保证。
  - 菜单项文案沿用该菜单既有「动作短语」风格(见 MenuButton.tsx 注释),文案「设置」与 macOS 原生菜单 `applicationMenuLabels.ts` 四语一致(应用内菜单项不带省略号,与相邻项一致)。

## 怎么验证的

### 自动验证

```text
pnpm vitest run src/renderer/__tests__/menuButtonSettingsEntry.test.ts
结果:7 passed

pnpm test:unit(仓库根)
结果:通过(exit 0)

pnpm --filter desktop run typecheck
结果:通过

pnpm check:i18n-glossary / pnpm check:i18n
结果:通过,zh-CN / en / ja / ko 共 6726 key 一致,无新增术语违规
```

### 手工验证

未执行(见下)。

### 未执行的验证

- Windows / Linux / macOS 实机目检未执行:本次开发环境无法起 Desktop 实机验证。改动复用既有 DropdownMenuItem 组件与语义 token,Light / Dark 两种模式均未实机目检,如实说明;建议合并前由有实机环境的同学在 Windows 上目检菜单项可见性与点击导航。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 Desktop renderer 标题栏菜单与四语言 locale 文案;不触及 main 进程、数据库、协议、插件与移动端。移动端冷更分析:未改动 `apps/mobile` 及任何 runtime fingerprint 输入(app.json / eas.json / plugins / modules 等),不会触发冷更。
- 回滚 / 降级方式:revert 本 PR 单个 commit 即可,无数据或状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因