### PR TITLE
fix(mobile): 修复 Android 长会话消息显示不全且无法滚动

### DIFF
--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -1347,6 +1347,90 @@ describe('groupMobileMarkdownSelectableBlocks', () => {
       expect(hasImage || isComplex).toBe(true);
     }
   });
+
+  it('can bound text runs by block count for tall native selectable text views', () => {
+    const blocks = parseMobileMarkdown([
+      '# 标题',
+      '',
+      '第一段',
+      '',
+      '- 列表项 A',
+      '- 列表项 B',
+      '',
+      '第二段',
+    ].join('\n'));
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunBlocks: 2 });
+    expect(groups.map((group) => group.type)).toEqual(['text_run', 'text_run', 'text_run']);
+    expect(groups.map((group) => (group.type === 'text_run' ? group.blocks.length : 0))).toEqual([2, 2, 1]);
+  });
+
+  it('can bound text runs by rendered inline text length', () => {
+    const blocks = parseMobileMarkdown([
+      '短段',
+      '',
+      '这是一段超过阈值的正文',
+      '',
+      '尾段',
+    ].join('\n'));
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+    expect(groups.map((group) => group.type)).toEqual(['text_run', 'text_run', 'text_run']);
+    expect(groups.map((group) => (group.type === 'text_run' ? group.blocks.length : 0))).toEqual([1, 1, 2]);
+  });
+
+  it('splits a single oversized text block by rendered inline text length', () => {
+    const blocks = parseMobileMarkdown('a'.repeat(21));
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+    expect(groups.map((group) => group.type)).toEqual(['text_run', 'text_run', 'text_run']);
+
+    const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
+    expect(chunks.map((block) => (
+      block.inlines.map((inline) => (inline.type === 'image' ? inline.alt : inline.text)).join('')
+    ))).toEqual([
+      'a'.repeat(8),
+      'a'.repeat(8),
+      'a'.repeat(5),
+    ]);
+    expect(chunks.map((block) => block.textRunContinuation === true)).toEqual([false, true, true]);
+    expect(groups.map((group) => (
+      group.type === 'text_run' && group.textRunContinuation === true
+    ))).toEqual([false, true, true]);
+  });
+
+  it('does not split surrogate pairs when a limit falls before an emoji', () => {
+    const text = `${'a'.repeat(7)}😀b`;
+    const blocks = parseMobileMarkdown(text);
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+    const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
+
+    const chunkText = chunks.map((block) => (
+      block.inlines.map((inline) => (inline.type === 'image' ? inline.alt : inline.text)).join('')
+    ));
+    expect(chunkText).toEqual(['a'.repeat(7), '😀b']);
+    expect(chunkText.join('')).toBe(text);
+  });
+
+  it('counts rendered list marker spaces when splitting long list items', () => {
+    const blocks = parseMobileMarkdown('- abcdefghij');
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+    const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
+
+    expect(chunks.map((block) => (
+      block.inlines.map((inline) => (inline.type === 'image' ? inline.alt : inline.text)).join('')
+    ))).toEqual(['abcdef', 'ghij']);
+    expect(chunks.map((block) => block.textRunContinuation === true)).toEqual([false, true]);
+  });
+
+  it('treats fractional text run limits below one as disabled', () => {
+    const blocks = parseMobileMarkdown(['first', '', 'second'].join('\n'));
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, {
+      maxTextRunBlocks: 0.5,
+      maxTextRunUtf16Length: 0.5,
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].type).toBe('text_run');
+    if (groups[0].type !== 'text_run') throw new Error('expected text_run');
+    expect(groups[0].blocks).toHaveLength(2);
+  });
 });
 
 describe('LaTeX math(块级 $$ 围栏与 inline $ 定界符)', () => {

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -1377,6 +1377,14 @@ describe('groupMobileMarkdownSelectableBlocks', () => {
     expect(groups.map((group) => (group.type === 'text_run' ? group.blocks.length : 0))).toEqual([1, 1, 2]);
   });
 
+  it('counts rendered block separators when bounding text runs by text length', () => {
+    const blocks = parseMobileMarkdown(['aaaa', '', 'bbbb'].join('\n'));
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+
+    expect(groups.map((group) => group.type)).toEqual(['text_run', 'text_run']);
+    expect(groups.map((group) => (group.type === 'text_run' ? group.blocks.length : 0))).toEqual([1, 1]);
+  });
+
   it('splits a single oversized text block by rendered inline text length', () => {
     const blocks = parseMobileMarkdown('a'.repeat(21));
     const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
@@ -1407,6 +1415,35 @@ describe('groupMobileMarkdownSelectableBlocks', () => {
     ));
     expect(chunkText).toEqual(['a'.repeat(7), '😀b']);
     expect(chunkText.join('')).toBe(text);
+  });
+
+  it('splits oversized non-direct image alt text by rendered inline text length', () => {
+    const blocks = parseMobileMarkdown(`![${'a'.repeat(21)}](docs/local-image.png)`);
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+    const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
+    const imageInlines = chunks.flatMap((block) => block.inlines.filter((inline) => inline.type === 'image'));
+
+    expect(groups.map((group) => group.type)).toEqual(['text_run', 'text_run', 'text_run']);
+    expect(imageInlines.map((inline) => inline.alt)).toEqual([
+      'a'.repeat(8),
+      'a'.repeat(8),
+      'a'.repeat(5),
+    ]);
+    expect(imageInlines.every((inline) => inline.url === 'docs/local-image.png')).toBe(true);
+    expect(chunks.map((block) => block.textRunContinuation === true)).toEqual([false, true, true]);
+  });
+
+  it('does not split surrogate pairs in oversized image alt text', () => {
+    const alt = `${'a'.repeat(7)}😀b`;
+    const blocks = parseMobileMarkdown(`![${alt}](docs/local-image.png)`);
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+    const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
+    const imageAltChunks = chunks.flatMap((block) => (
+      block.inlines.filter((inline) => inline.type === 'image').map((inline) => inline.alt)
+    ));
+
+    expect(imageAltChunks).toEqual(['a'.repeat(7), '😀b']);
+    expect(imageAltChunks.join('')).toBe(alt);
   });
 
   it('counts rendered list marker spaces when splitting long list items', () => {

--- a/apps/mobile/src/__tests__/messageMarkdown.test.ts
+++ b/apps/mobile/src/__tests__/messageMarkdown.test.ts
@@ -6,6 +6,8 @@ import {
   isMobileMarkdownImageDirectUrl,
   mobileMarkdownImageTitle,
   mobileMarkdownImageUrlForWorkdir,
+  mobileMarkdownImageAltChipText,
+  MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH,
   mobileMarkdownInlineImageSize,
   parseMobileMarkdown,
   parseMobileMarkdownInlines,
@@ -1417,33 +1419,30 @@ describe('groupMobileMarkdownSelectableBlocks', () => {
     expect(chunkText.join('')).toBe(text);
   });
 
-  it('splits oversized non-direct image alt text by rendered inline text length', () => {
-    const blocks = parseMobileMarkdown(`![${'a'.repeat(21)}](docs/local-image.png)`);
-    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
+  it('keeps oversized non-direct image alt text in one image inline while bounding rendered chip text', () => {
+    const alt = 'a'.repeat(MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH + 21);
+    const blocks = parseMobileMarkdown(`![${alt}](docs/local-image.png)`);
+    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 1800 });
     const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
     const imageInlines = chunks.flatMap((block) => block.inlines.filter((inline) => inline.type === 'image'));
 
-    expect(groups.map((group) => group.type)).toEqual(['text_run', 'text_run', 'text_run']);
-    expect(imageInlines.map((inline) => inline.alt)).toEqual([
-      'a'.repeat(8),
-      'a'.repeat(8),
-      'a'.repeat(5),
-    ]);
-    expect(imageInlines.every((inline) => inline.url === 'docs/local-image.png')).toBe(true);
-    expect(chunks.map((block) => block.textRunContinuation === true)).toEqual([false, true, true]);
+    expect(groups.map((group) => group.type)).toEqual(['text_run']);
+    expect(imageInlines).toHaveLength(1);
+    expect(imageInlines[0]).toMatchObject({ alt, url: 'docs/local-image.png' });
+    expect(mobileMarkdownImageAltChipText(imageInlines[0].alt)).toHaveLength(
+      MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH,
+    );
+    expect(mobileMarkdownImageAltChipText(imageInlines[0].alt).endsWith('…')).toBe(true);
   });
 
-  it('does not split surrogate pairs in oversized image alt text', () => {
-    const alt = `${'a'.repeat(7)}😀b`;
-    const blocks = parseMobileMarkdown(`![${alt}](docs/local-image.png)`);
-    const groups = groupMobileMarkdownSelectableBlocks(blocks, { maxTextRunUtf16Length: 8 });
-    const chunks = groups.flatMap((group) => (group.type === 'text_run' ? group.blocks : []));
-    const imageAltChunks = chunks.flatMap((block) => (
-      block.inlines.filter((inline) => inline.type === 'image').map((inline) => inline.alt)
-    ));
+  it('does not split surrogate pairs when truncating oversized image alt chip text', () => {
+    const alt = `${'a'.repeat(MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH - 1)}😀b`;
+    const chipText = mobileMarkdownImageAltChipText(alt);
 
-    expect(imageAltChunks).toEqual(['a'.repeat(7), '😀b']);
-    expect(imageAltChunks.join('')).toBe(alt);
+    expect(chipText).toHaveLength(MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH);
+    expect(chipText).toBe(`${'a'.repeat(MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH - 1)}…`);
+    expect(chipText).not.toContain('\uD83D');
+    expect(chipText).not.toContain('\uDE00');
   });
 
   it('counts rendered list marker spaces when splitting long list items', () => {

--- a/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
@@ -52,9 +52,15 @@ describe('mobile message text selection', () => {
     expect(markdownBodySource).toContain('selectable={inlinesSelectable(block.inlines)}');
 
     // 跨段选择:连续纯文本块合并进同一个原生文本视图(text_run),原生选择手柄可横跨段落。
-    expect(markdownBodySource).toContain('groupMobileMarkdownSelectableBlocks(blocks)');
+    // Android 上长 selectable Text 分块,避免单个超高原生文本视图干扰列表测高/滚动。
+    expect(markdownBodySource).toContain('ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS');
+    expect(markdownBodySource).toContain('groupMobileMarkdownSelectableBlocks(blocks, textRunGroupingOptions)');
     expect(markdownBodySource).toContain('testID="message.markdownTextRun"');
     expect(markdownBodySource).toContain("lineHeight: layout.markdownBodyGap");
+    expect(markdownBodySource).toContain('!block.textRunContinuation');
+    expect(markdownBodySource).toContain('isTextRunContinuationGroup(group)');
+    expect(markdownBodySource).toContain('height: layout.markdownBodyGap');
+    expect(markdownBodySource).not.toContain('{ gap: layout.markdownBodyGap }');
     expect(markdownBodySource).toContain('selectable={inlinesSelectable(cell)}');
     expect(markdownBodySource).toContain('selectable={selectable === true}');
 

--- a/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/messageSelectionDesktopFirst.test.ts
@@ -61,6 +61,7 @@ describe('mobile message text selection', () => {
     expect(markdownBodySource).toContain('isTextRunContinuationGroup(group)');
     expect(markdownBodySource).toContain('height: layout.markdownBodyGap');
     expect(markdownBodySource).not.toContain('{ gap: layout.markdownBodyGap }');
+    expect(source).toContain('mobileMarkdownImageAltChipText(inline.alt)');
     expect(markdownBodySource).toContain('selectable={inlinesSelectable(cell)}');
     expect(markdownBodySource).toContain('selectable={selectable === true}');
 

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -161,6 +161,7 @@ import {
   parseMobileMarkdownInlines,
   type MobileMarkdownBlockGroup,
   type MobileMarkdownInline,
+  type MobileMarkdownTextRunGroupingOptions,
 } from '@/session/messageMarkdown';
 import {
   extractSessionLinkIds,
@@ -324,6 +325,12 @@ const MOBILE_PROGRAMMATIC_ANIMATED_SCROLL_SETTLE_MS = 1400;
 /** Cold-open history fill is useful, but bounded so a short/duplicate host page cannot drain history forever. */
 const MAX_INITIAL_HISTORY_AUTOFILL_PAGES = 3;
 const MOBILE_MESSAGE_ESTIMATED_ITEM_SIZE = 140;
+const ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS = 12;
+const ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH = 1800;
+const ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS: MobileMarkdownTextRunGroupingOptions = {
+  maxTextRunBlocks: ANDROID_SELECTABLE_TEXT_RUN_MAX_BLOCKS,
+  maxTextRunUtf16Length: ANDROID_SELECTABLE_TEXT_RUN_MAX_UTF16_LENGTH,
+};
 /** Running work groups expose only the same latest-five activity window as desktop. */
 const MAX_LIVE_WORK_ACTIVITIES = 5;
 // LegendList 预渲距离(px,视口外每侧):约 1 屏,挂载集小 → 滚动 mount 帧压进一帧内(见 listperf 实测)。
@@ -420,6 +427,10 @@ function MarkdownSelectableText({
  */
 function MarkdownSelectableSpan(props: ComponentProps<typeof Text>) {
   return <UITextView maxFontSizeMultiplier={MAX_FONT_SIZE_MULTIPLIER} {...props} />;
+}
+
+function isTextRunContinuationGroup(group: MobileMarkdownBlockGroup): boolean {
+  return group.type === 'text_run' && group.textRunContinuation === true;
 }
 
 /** Composer-ready user message body with product quotes kept out of raw text. */
@@ -3386,8 +3397,16 @@ function MarkdownBody({
     ),
     [onOpenSessionLink, openMarkdownImage, sessionLinkTitles, sessionReferenceDetails, streaming, styles],
   );
+  const textRunGroupingOptions = selectable === true && Platform.OS === 'android'
+    ? ANDROID_SELECTABLE_TEXT_RUN_GROUPING_OPTIONS
+    : undefined;
   // 连续纯文本块合并为 text_run(跨段选择),代码块/表格/mermaid/含直连图块保持独立。
-  const groups = useMemo(() => groupMobileMarkdownSelectableBlocks(blocks), [blocks]);
+  // Android selectable Text 在超长原生文本视图里会偶发高度/滚动协商异常,长 run 分块
+  // 后仍保留块内跨段选择,同时避免单个 LegendList item 内出现巨型 selectable Text。
+  const groups = useMemo(
+    () => groupMobileMarkdownSelectableBlocks(blocks, textRunGroupingOptions),
+    [blocks, textRunGroupingOptions],
+  );
   // 块可选中且 iOS → 嵌套 span 必须是 UITextView 家族;其余场景缺省 RN Text。
   const spanFor = useCallback((blockSelectable: boolean) => (
     blockSelectable && allowIosUITextView && Platform.OS === 'ios'
@@ -3397,7 +3416,8 @@ function MarkdownBody({
   // 文本运行组:连续纯文本块(段落/标题/列表项)合进同一个原生文本视图,
   // 原生选择手柄即可横跨段落(单个 text view 是 iOS/Android 原生选择的天然边界)。
   // 段间距用「lineHeight = markdownBodyGap 的空行 span」还原:原生文本树内没有块级 gap 可用,
-  // 一个高度恰为 gap 的空行在视觉上与原块间距一致。列表项在树内表达为「marker 前缀 span + 正文」
+  // 一个高度恰为 gap 的空行在视觉上与原块间距一致。由单块切出的 continuation 不插间距。
+  // 列表项在树内表达为「marker 前缀 span + 正文」
   // (无悬挂缩进;任务项以 ☑/☐ 字符替代原边框小方块)。
   const renderTextRun = (group: Extract<MobileMarkdownBlockGroup, { type: 'text_run' }>): ReactNode => {
     const runSelectable = selectable === true;
@@ -3412,7 +3432,7 @@ function MarkdownBody({
       >
         {group.blocks.flatMap((block, index) => {
           const spans: ReactNode[] = [];
-          if (index > 0) {
+          if (index > 0 && !block.textRunContinuation) {
             spans.push(
               <RunSpan key={`${block.key}:gap`} style={{ lineHeight: layout.markdownBodyGap }}>
                 {'\n\n'}
@@ -3422,7 +3442,7 @@ function MarkdownBody({
           const baseStyle: StyleProp<TextStyle> = block.type === 'heading'
             ? [styles.markdownHeading, headingSizeStyle(styles, block.level)]
             : styles.messageText;
-          if (block.type === 'list_item') {
+          if (block.type === 'list_item' && !block.textRunContinuation) {
             const task = typeof block.checked === 'boolean';
             spans.push(
               <RunSpan
@@ -3441,15 +3461,16 @@ function MarkdownBody({
   };
   return (
     <View
-      style={[styles.markdownBody, { gap: layout.markdownBodyGap }]}
+      style={styles.markdownBody}
       testID="message.markdownBody"
     >
-      {groups.map((group) => {
-        if (group.type === 'text_run') {
-          return renderTextRun(group);
-        }
-        const block = group.block;
-        if (block.type === 'mermaid') {
+      {groups.flatMap((group, groupIndex) => {
+        const renderedGroup = (() => {
+          if (group.type === 'text_run') {
+            return renderTextRun(group);
+          }
+          const block = group.block;
+          if (block.type === 'mermaid') {
           // 内联图表按「图片」形态呈现:无卡片 chrome、无标签文字、无按钮,
           // 就是一块圆角图表;点击任意位置打开沉浸式全屏详情(透明 Pressable
           // 盖住整块——WebView 会吞掉触摸事件,不盖层拿不到点击)。
@@ -3625,6 +3646,14 @@ function MarkdownBody({
             {renderInlines(block.inlines, spanFor(inlinesSelectable(block.inlines)))}
           </MarkdownSelectableText>
         );
+        })();
+        if (groupIndex === 0 || isTextRunContinuationGroup(group)) {
+          return [renderedGroup];
+        }
+        return [
+          <View key={`${group.key}:body-gap`} style={{ height: layout.markdownBodyGap }} />,
+          renderedGroup,
+        ];
       })}
     </View>
   );
@@ -6098,7 +6127,7 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     fontSize: typeScale.caption,
     lineHeight: lineHeight.caption,
   },
-  markdownBody: { gap: 10 },
+  markdownBody: {},
   // 外链 / 会话深链等一切可点行内元素:**只有下划线**,不加粗、不换色、不换字体
   // (DESIGN.md §14.5;GitHub 的 `.markdown-body a` 同样只有 text-decoration)。
   //

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -154,6 +154,7 @@ import {
 import {
   groupMobileMarkdownSelectableBlocks,
   isMobileMarkdownImageDirectUrl,
+  mobileMarkdownImageAltChipText,
   mobileMarkdownImageTitle,
   mobileMarkdownImageUrlForWorkdir,
   mobileMarkdownInlineImageSize,
@@ -4015,6 +4016,9 @@ function renderInline(
       // xdt 系非直连图:RN Image 无法直接加载内部 scheme,渲染可点 chip,
       // 点开后由 ImageLightbox 经 remote-media resolver 取图。
       if (!isMobileMarkdownImageDirectUrl(inline.url)) {
+        const imageChipText = inline.alt
+          ? mobileMarkdownImageAltChipText(inline.alt)
+          : i18n.t('message.renderer.imageFallbackTitle');
         return (
           <SpanText
             key={spanKey(`image:${index}:${inline.url}`)}
@@ -4022,7 +4026,7 @@ function renderInline(
             style={clickableInlineStyle(styles, openImageChip, ctx.baseStyle)}
             testID="message.markdownInlineImageChip"
           >
-            {inline.alt || i18n.t('message.renderer.imageFallbackTitle')}
+            {imageChipText}
           </SpanText>
         );
       }

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -430,6 +430,7 @@ export interface MobileMarkdownTextRunGroupingOptions {
 }
 
 const MOBILE_MARKDOWN_TEXT_RUN_BLOCK_SEPARATOR_UTF16_LENGTH = 2;
+export const MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH = 256;
 
 export function groupMobileMarkdownSelectableBlocks(
   blocks: readonly MobileMarkdownBlock[],
@@ -510,9 +511,15 @@ function mobileMarkdownTextRunBlockLength(block: MobileMarkdownTextRunBlock): nu
 
 function mobileMarkdownInlineTextLength(inline: MobileMarkdownInline): number {
   if (inline.type === 'image') {
-    return inline.alt.length;
+    return mobileMarkdownImageAltChipText(inline.alt).length;
   }
   return inline.text.length;
+}
+
+export function mobileMarkdownImageAltChipText(alt: string): string {
+  if (alt.length <= MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH) return alt;
+  const end = safeUtf16SliceEnd(alt, 0, MOBILE_MARKDOWN_IMAGE_ALT_CHIP_MAX_UTF16_LENGTH - 1);
+  return `${alt.slice(0, end)}…`;
 }
 
 function splitOversizedTextRunBlock(
@@ -564,7 +571,13 @@ function splitOversizedTextRunBlock(
 
   for (const inline of block.inlines) {
     if (inline.type === 'image') {
-      appendInlineTextChunks(inline.alt, (alt) => ({ ...inline, alt }));
+      const inlineLength = mobileMarkdownInlineTextLength(inline);
+      if (current.length > 0 && currentTextLength + inlineLength > currentLimit()) {
+        flushCurrent();
+      }
+      current.push(inline);
+      currentTextLength += inlineLength;
+      if (currentTextLength >= currentLimit()) flushCurrent();
       continue;
     }
 

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -412,25 +412,59 @@ export function mobileMarkdownImageUrlForWorkdir(
  * 它们承载非文本结构(横向滚动 / 边框 / 内嵌 View),不能进原生文本树,选择也天然止步于此。
  */
 export type MobileMarkdownTextRunBlock =
-  Extract<MobileMarkdownBlock, { type: 'paragraph' | 'heading' | 'list_item' }>;
+  Extract<MobileMarkdownBlock, { type: 'paragraph' | 'heading' | 'list_item' }>
+  & { textRunContinuation?: boolean };
 
 export type MobileMarkdownBlockGroup =
-  | { type: 'text_run'; key: string; blocks: MobileMarkdownTextRunBlock[] }
+  | { type: 'text_run'; key: string; blocks: MobileMarkdownTextRunBlock[]; textRunContinuation?: boolean }
   | { type: 'single'; key: string; block: MobileMarkdownBlock };
+
+export interface MobileMarkdownTextRunGroupingOptions {
+  /**
+   * Upper bound for one selectable native text view. Undefined keeps the
+   * historical "merge until a non-text block" behavior.
+   */
+  maxTextRunBlocks?: number;
+  /** Same guard by rendered inline text length, measured in JS UTF-16 units. */
+  maxTextRunUtf16Length?: number;
+}
 
 export function groupMobileMarkdownSelectableBlocks(
   blocks: readonly MobileMarkdownBlock[],
+  options?: MobileMarkdownTextRunGroupingOptions,
 ): MobileMarkdownBlockGroup[] {
   const groups: MobileMarkdownBlockGroup[] = [];
   let run: MobileMarkdownTextRunBlock[] = [];
+  let runTextLength = 0;
+  const maxTextRunBlocks = normalizePositiveLimit(options?.maxTextRunBlocks);
+  const maxTextRunUtf16Length = normalizePositiveLimit(options?.maxTextRunUtf16Length);
   const flushRun = () => {
     if (run.length === 0) return;
-    groups.push({ type: 'text_run', key: `run:${run[0].key}`, blocks: run });
+    groups.push({
+      type: 'text_run',
+      key: `run:${run[0].key}`,
+      blocks: run,
+      ...(run[0].textRunContinuation ? { textRunContinuation: true } : {}),
+    });
     run = [];
+    runTextLength = 0;
   };
   for (const block of blocks) {
     if (isTextRunBlock(block)) {
-      run.push(block);
+      for (const chunk of splitOversizedTextRunBlock(block, maxTextRunUtf16Length)) {
+        const blockTextLength = mobileMarkdownTextRunBlockLength(chunk);
+        if (
+          run.length > 0
+          && (
+            run.length >= maxTextRunBlocks
+            || runTextLength + blockTextLength > maxTextRunUtf16Length
+          )
+        ) {
+          flushRun();
+        }
+        run.push(chunk);
+        runTextLength += blockTextLength;
+      }
     } else {
       flushRun();
       groups.push({ type: 'single', key: block.key, block });
@@ -448,6 +482,150 @@ function isTextRunBlock(block: MobileMarkdownBlock): block is MobileMarkdownText
   return !block.inlines.some(
     (inline) => inline.type === 'image' && isMobileMarkdownImageDirectUrl(inline.url),
   );
+}
+
+function normalizePositiveLimit(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const normalized = Math.floor(value);
+  return normalized > 0 ? normalized : Number.POSITIVE_INFINITY;
+}
+
+function mobileMarkdownTextRunBlockLength(block: MobileMarkdownTextRunBlock): number {
+  const inlineLength = block.inlines.reduce((total, inline) => total + mobileMarkdownInlineTextLength(inline), 0);
+  if (block.type === 'list_item' && !block.textRunContinuation) {
+    return inlineLength + mobileMarkdownListMarkerText(block).length;
+  }
+  return inlineLength;
+}
+
+function mobileMarkdownInlineTextLength(inline: MobileMarkdownInline): number {
+  if (inline.type === 'image') {
+    return inline.alt.length;
+  }
+  return inline.text.length;
+}
+
+function splitOversizedTextRunBlock(
+  block: MobileMarkdownTextRunBlock,
+  maxTextRunUtf16Length: number,
+): MobileMarkdownTextRunBlock[] {
+  if (
+    !Number.isFinite(maxTextRunUtf16Length)
+    || mobileMarkdownTextRunBlockLength(block) <= maxTextRunUtf16Length
+  ) {
+    return [block];
+  }
+
+  const chunks: MobileMarkdownInline[][] = [];
+  let current: MobileMarkdownInline[] = [];
+  let currentTextLength = 0;
+  const currentLimit = () => Math.max(
+    1,
+    maxTextRunUtf16Length - (chunks.length === 0 ? mobileMarkdownTextRunBlockPrefixLength(block) : 0),
+  );
+  const flushCurrent = () => {
+    if (current.length === 0) return;
+    chunks.push(current);
+    current = [];
+    currentTextLength = 0;
+  };
+
+  for (const inline of block.inlines) {
+    if (inline.type === 'image') {
+      const inlineLength = mobileMarkdownInlineTextLength(inline);
+      if (current.length > 0 && currentTextLength + inlineLength > currentLimit()) {
+        flushCurrent();
+      }
+      current.push(inline);
+      currentTextLength += inlineLength;
+      if (currentTextLength >= currentLimit()) flushCurrent();
+      continue;
+    }
+
+    let start = 0;
+    while (start < inline.text.length) {
+      if (currentTextLength >= currentLimit()) flushCurrent();
+      const capacity = currentLimit() - currentTextLength;
+      if (
+        currentTextLength > 0
+        && capacity === 1
+        && startsWithSurrogatePair(inline.text, start)
+      ) {
+        flushCurrent();
+        continue;
+      }
+      const end = safeUtf16SliceEnd(inline.text, start, capacity);
+      current.push({ ...inline, text: inline.text.slice(start, end) });
+      currentTextLength += end - start;
+      start = end;
+    }
+  }
+  flushCurrent();
+
+  if (chunks.length <= 1) return [block];
+  return chunks.map((inlines, index) => cloneTextRunBlockChunk(block, inlines, index));
+}
+
+function mobileMarkdownTextRunBlockPrefixLength(block: MobileMarkdownTextRunBlock): number {
+  if (block.type !== 'list_item' || block.textRunContinuation) return 0;
+  return mobileMarkdownListMarkerText(block).length;
+}
+
+function mobileMarkdownListMarkerText(block: Extract<MobileMarkdownTextRunBlock, { type: 'list_item' }>): string {
+  if (typeof block.checked === 'boolean') return block.checked ? '☑ ' : '☐ ';
+  return block.ordered ? `${block.marker} ` : '• ';
+}
+
+function cloneTextRunBlockChunk(
+  block: MobileMarkdownTextRunBlock,
+  inlines: MobileMarkdownInline[],
+  index: number,
+): MobileMarkdownTextRunBlock {
+  const key = index === 0 ? block.key : `${block.key}:split:${index}`;
+  const continuation = index > 0 ? { textRunContinuation: true } : {};
+  if (block.type === 'paragraph') return { ...block, key, inlines, ...continuation };
+  if (block.type === 'heading') return { ...block, key, inlines, ...continuation };
+  return {
+    ...block,
+    key,
+    inlines,
+    ...continuation,
+  };
+}
+
+function safeUtf16SliceEnd(text: string, start: number, maxLength: number): number {
+  const length = Math.max(1, maxLength);
+  if (length === 1 && startsWithSurrogatePair(text, start)) {
+    return start + 2;
+  }
+  let end = Math.min(text.length, start + length);
+  if (
+    end < text.length
+    && end > start
+    && isHighSurrogate(text.charCodeAt(end - 1))
+    && isLowSurrogate(text.charCodeAt(end))
+  ) {
+    end -= 1;
+  }
+  return end > start ? end : Math.min(text.length, start + 1);
+}
+
+function startsWithSurrogatePair(text: string, start: number): boolean {
+  return (
+    start + 1 < text.length
+    && isHighSurrogate(text.charCodeAt(start))
+    && isLowSurrogate(text.charCodeAt(start + 1))
+  );
+}
+
+function isHighSurrogate(value: number): boolean {
+  return value >= 0xD800 && value <= 0xDBFF;
+}
+
+function isLowSurrogate(value: number): boolean {
+  return value >= 0xDC00 && value <= 0xDFFF;
 }
 
 const MARKDOWN_INLINE_IMAGE_DEFAULT_WIDTH = 150;

--- a/apps/mobile/src/session/messageMarkdown.ts
+++ b/apps/mobile/src/session/messageMarkdown.ts
@@ -429,6 +429,8 @@ export interface MobileMarkdownTextRunGroupingOptions {
   maxTextRunUtf16Length?: number;
 }
 
+const MOBILE_MARKDOWN_TEXT_RUN_BLOCK_SEPARATOR_UTF16_LENGTH = 2;
+
 export function groupMobileMarkdownSelectableBlocks(
   blocks: readonly MobileMarkdownBlock[],
   options?: MobileMarkdownTextRunGroupingOptions,
@@ -453,17 +455,23 @@ export function groupMobileMarkdownSelectableBlocks(
     if (isTextRunBlock(block)) {
       for (const chunk of splitOversizedTextRunBlock(block, maxTextRunUtf16Length)) {
         const blockTextLength = mobileMarkdownTextRunBlockLength(chunk);
+        const separatorLength = run.length > 0 && !chunk.textRunContinuation
+          ? MOBILE_MARKDOWN_TEXT_RUN_BLOCK_SEPARATOR_UTF16_LENGTH
+          : 0;
         if (
           run.length > 0
           && (
             run.length >= maxTextRunBlocks
-            || runTextLength + blockTextLength > maxTextRunUtf16Length
+            || runTextLength + separatorLength + blockTextLength > maxTextRunUtf16Length
           )
         ) {
           flushRun();
         }
+        const pushedSeparatorLength = run.length > 0 && !chunk.textRunContinuation
+          ? MOBILE_MARKDOWN_TEXT_RUN_BLOCK_SEPARATOR_UTF16_LENGTH
+          : 0;
         run.push(chunk);
-        runTextLength += blockTextLength;
+        runTextLength += pushedSeparatorLength + blockTextLength;
       }
     } else {
       flushRun();
@@ -531,36 +539,36 @@ function splitOversizedTextRunBlock(
     current = [];
     currentTextLength = 0;
   };
-
-  for (const inline of block.inlines) {
-    if (inline.type === 'image') {
-      const inlineLength = mobileMarkdownInlineTextLength(inline);
-      if (current.length > 0 && currentTextLength + inlineLength > currentLimit()) {
-        flushCurrent();
-      }
-      current.push(inline);
-      currentTextLength += inlineLength;
-      if (currentTextLength >= currentLimit()) flushCurrent();
-      continue;
-    }
-
+  const appendInlineTextChunks = (
+    text: string,
+    buildInline: (text: string) => MobileMarkdownInline,
+  ) => {
     let start = 0;
-    while (start < inline.text.length) {
+    while (start < text.length) {
       if (currentTextLength >= currentLimit()) flushCurrent();
       const capacity = currentLimit() - currentTextLength;
       if (
         currentTextLength > 0
         && capacity === 1
-        && startsWithSurrogatePair(inline.text, start)
+        && startsWithSurrogatePair(text, start)
       ) {
         flushCurrent();
         continue;
       }
-      const end = safeUtf16SliceEnd(inline.text, start, capacity);
-      current.push({ ...inline, text: inline.text.slice(start, end) });
+      const end = safeUtf16SliceEnd(text, start, capacity);
+      current.push(buildInline(text.slice(start, end)));
       currentTextLength += end - start;
       start = end;
     }
+  };
+
+  for (const inline of block.inlines) {
+    if (inline.type === 'image') {
+      appendInlineTextChunks(inline.alt, (alt) => ({ ...inline, alt }));
+      continue;
+    }
+
+    appendInlineTextChunks(inline.text, (text) => ({ ...inline, text }));
   }
   flushCurrent();
 


### PR DESCRIPTION
Fixes #1866.

## 这次改了什么

### 摘要

修复 Android 端特定长会话中，超长 selectable Markdown Text 可能导致会话页显示不全、页面无法继续滚动的问题。

本次改动将 Android 上连续可选中的 Markdown 文本按块数和 UTF-16 长度做上限拆分，避免单个原生 selectable Text 过高影响列表测高和滚动协商。同时补充超长单段拆分逻辑，确保长段落、标题、列表项也会被拆分；拆出的 continuation 片段不会额外插入段落间距，视觉上仍保持为原始连续文本。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1866
- 本 PR 包含：Android selectable Markdown text run 分块上限、超长单段拆分、continuation 间距修正、UTF-16 surrogate pair 切分保护、列表 marker 长度估算修正、相关测试。
- 明确不包含：不改 iOS 选择实现、不改消息数据结构、不改 Markdown 视觉样式。
- 用户可见变化：Android 导入特定长会话后，会话页可以正常显示并继续滚动。
- 是否存在 breaking change：无。

### UI 变化

命中 mobile UI 渲染路径，但不涉及视觉规范调整；本 PR 仅拆分 Android 原生 selectable Text 的内部渲染结构，保持原 Markdown 文本视觉连续性和原有间距。

- 引用的设计规范：不涉及视觉 / 交互 / 文案变更。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter mobile typecheck
结果：通过

corepack pnpm --dir apps/mobile exec vitest run src/__tests__/messageMarkdown.test.ts src/__tests__/messageSelectionDesktopFirst.test.ts
结果：通过，2 个测试文件，101 个测试通过
```

### 手工验证

```text
本地 worktree / branch：
fix/1866-android-long-message-scroll

Android debug build：
C:\cf1866\apps\mobile\android\app\build\outputs\apk\debug\app-debug.apk

构建命令：
apps/mobile/android/gradlew.bat app:assembleDebug -x lint -x test --configure-on-demand --build-cache -PreactNativeArchitectures=arm64-v8a --console=plain

结果：
BUILD SUCCESSFUL
assembleDebug exit code: 0
```

真机验证：

- 设备：Xiaomi M2007J1SC
- App：Android dev/debug build
- Metro：本地 `C:\cf1866`，端口 `8081`
- 验证会话：`Cindy灰度发布回归方案`
- 验证结果：导入复现会话后，Android 会话页可以正常显示并继续滚动，未复现“显示不全 / 页面卡住无法滚动”。

录屏证据：见 PR 评论区附件。

### 未执行的验证

未执行 release 包验证和完整移动端 e2e。原因：本次修改限定在 JS/TS Markdown 渲染路径，已覆盖 typecheck、相关单测、Android debug build 和真实 Android 设备复现会话验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：Android selectable Text 渲染结构调整

### 影响与回滚

- 影响范围：仅影响 mobile Markdown 消息正文渲染。Android 完成态可选中文本会在超长情况下拆成多个较小 native Text run；iOS 默认行为不变。
- 潜在风险：Android 上跨超长分块边界的文本选择范围可能仍受 native Text 边界限制。Markdown 文本拆分逻辑如果回归，可能影响长段落或列表项的视觉连续性；本 PR 已补 continuation 间距和 surrogate pair 单测覆盖。
- 回滚 / 降级方式：回滚本 PR 即恢复原先不设 Android text run 上限的行为。若线上仍发现特定机型问题，可以调整 Android text run 的 `maxTextRunBlocks` / `maxTextRunUtf16Length` 阈值。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因