### PR TITLE
fix(desktop): keep pasted-text selection inside preview

### DIFF
--- a/apps/desktop/src/renderer/__tests__/toolPayloadLightbox.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/toolPayloadLightbox.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ToolPayloadLightbox } from '@/components/chat/ToolPayloadLightbox';
 import { Tooltip } from '@/components/ui/tooltip';
@@ -24,6 +24,13 @@ vi.mock('@/components/chat/MarkdownDiffBlock', () => ({
   MarkdownDiffBlock: ({ raw }: { raw: string }) => <div data-testid="raw-diff-view">{raw}</div>,
 }));
 
+beforeEach(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    configurable: true,
+    value: { platform: 'darwin' },
+  });
+});
+
 afterEach(() => {
   act(() => vi.runOnlyPendingTimers());
   cleanup();
@@ -31,10 +38,12 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-function renderEditable(options: {
-  onSave?: (text: string) => void;
-  onClose?: () => void;
-} = {}) {
+function renderEditable(
+  options: {
+    onSave?: (text: string) => void;
+    onClose?: () => void;
+  } = {},
+) {
   const onSave = options.onSave ?? vi.fn();
   const onClose = options.onClose ?? vi.fn();
   render(
@@ -118,9 +127,11 @@ describe('ToolPayloadLightbox editable text mode', () => {
         />
       </Tooltip.Provider>,
     );
-    expect(screen.queryByRole('textbox')).toBeNull();
+    const textPreview = screen.getByRole('textbox', { name: 'Pasted Text' });
+    expect(textPreview).toHaveProperty('readOnly', true);
+    expect(textPreview).toHaveProperty('value', 'read only');
+    expect(document.activeElement).toBe(textPreview);
     expect(screen.queryByRole('button', { name: 'Save Text' })).toBeNull();
-    expect(screen.getByText('read only').tagName).toBe('PRE');
 
     unmount();
     render(
@@ -133,6 +144,24 @@ describe('ToolPayloadLightbox editable text mode', () => {
     );
     expect(screen.queryByRole('textbox')).toBeNull();
     expect(screen.queryByRole('button', { name: 'Save Text' })).toBeNull();
+  });
+
+  it('keeps select-all scoped to the focused read-only text preview', () => {
+    vi.useFakeTimers();
+    render(
+      <Tooltip.Provider>
+        <ToolPayloadLightbox
+          payload={{ kind: 'text', title: 'Pasted Text', text: 'first\nsecond' }}
+          onClose={() => undefined}
+        />
+      </Tooltip.Provider>,
+    );
+
+    const textPreview = screen.getByRole('textbox', { name: 'Pasted Text' }) as HTMLTextAreaElement;
+    fireEvent.keyDown(document, { key: 'a', metaKey: true });
+
+    expect(textPreview.selectionStart).toBe(0);
+    expect(textPreview.selectionEnd).toBe(textPreview.value.length);
   });
 });
 

--- a/apps/desktop/src/renderer/components/chat/ToolPayloadLightbox.tsx
+++ b/apps/desktop/src/renderer/components/chat/ToolPayloadLightbox.tsx
@@ -103,9 +103,7 @@ export function ToolPayloadLightbox({
   // 会话文件来源:remote 时 diff 的"定位文件"改为下载缓存副本后定位。
   const fileCtx = useChatSessionFile();
   const [isVisible, setIsVisible] = useState(false);
-  const [draftText, setDraftText] = useState(() =>
-    payload.kind === 'text' ? payload.text : '',
-  );
+  const [draftText, setDraftText] = useState(() => (payload.kind === 'text' ? payload.text : ''));
   const isClosingRef = useRef(false);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const isEditingText = payload.kind === 'text' && textEdit !== undefined;
@@ -134,14 +132,36 @@ export function ToolPayloadLightbox({
     return () => cancelAnimationFrame(raf);
   }, []);
 
-  // Editable text opens with the primary input focused, per the dialog focus contract.
+  // Text payloads own focus while open so the native Edit > Select All command
+  // stays scoped to the pasted text instead of selecting the conversation behind it.
   useEffect(() => {
-    if (!isEditingText) return;
+    if (payload.kind !== 'text') return;
     const textarea = textareaRef.current;
     if (!textarea) return;
-    textarea.focus();
-    textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-  }, [isEditingText]);
+    textarea.focus({ preventScroll: true });
+    const caretPosition = isEditingText ? textarea.value.length : 0;
+    textarea.setSelectionRange(caretPosition, caretPosition);
+  }, [isEditingText, payload.kind]);
+
+  useEffect(() => {
+    if (payload.kind !== 'text') return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() !== 'a' || event.altKey || event.shiftKey) return;
+      const isMac = window.electronAPI?.platform === 'darwin';
+      const primaryModifier = isMac ? event.metaKey : event.ctrlKey;
+      const secondaryModifier = isMac ? event.ctrlKey : event.metaKey;
+      if (!primaryModifier || secondaryModifier || event.isComposing) return;
+
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      event.preventDefault();
+      event.stopPropagation();
+      textarea.focus({ preventScroll: true });
+      textarea.select();
+    };
+    document.addEventListener('keydown', handler, true);
+    return () => document.removeEventListener('keydown', handler, true);
+  }, [payload.kind]);
 
   const handleSaveText = useCallback(() => {
     if (!textEdit || payload.kind !== 'text') return;
@@ -180,7 +200,9 @@ export function ToolPayloadLightbox({
   async function copyTitle() {
     try {
       await navigator.clipboard.writeText(fullTitle);
-      toast.success(payload.kind === 'diff' ? t('chat.lightbox.pathCopied') : t('chat.lightbox.copied'));
+      toast.success(
+        payload.kind === 'diff' ? t('chat.lightbox.pathCopied') : t('chat.lightbox.copied'),
+      );
     } catch {
       toast.error(t('chat.media.copyFailed'));
     }
@@ -315,7 +337,9 @@ export function ToolPayloadLightbox({
               </button>
             </Tooltip.Trigger>
             <Tooltip.Content>
-              {payload.kind === 'diff' ? t('chat.lightbox.clickToCopyPath') : t('chat.lightbox.clickToCopy')}
+              {payload.kind === 'diff'
+                ? t('chat.lightbox.clickToCopyPath')
+                : t('chat.lightbox.clickToCopy')}
             </Tooltip.Content>
           </Tooltip.Root>
 
@@ -377,7 +401,7 @@ export function ToolPayloadLightbox({
         <div
           className={cn(
             'flex-1 px-5 py-4 select-text',
-            isEditingText ? 'flex overflow-hidden' : 'overflow-auto',
+            payload.kind === 'text' ? 'flex overflow-hidden' : 'overflow-auto',
             'text-[var(--msg-tool-card-text)]',
           )}
         >
@@ -426,31 +450,23 @@ export function ToolPayloadLightbox({
             </div>
           )}
 
-          {payload.kind === 'text' &&
-            (isEditingText ? (
-              <textarea
-                ref={textareaRef}
-                value={draftText}
-                onChange={(event) => setDraftText(event.target.value)}
-                spellCheck={false}
-                className={cn(
-                  'h-full min-h-0 w-full resize-none rounded-lg border',
-                  'border-[var(--msg-code-block-border)] bg-[var(--msg-code-block-bg)]',
-                  'p-3 font-mono text-[length:calc(var(--app-code-font-size)_-_1px)] leading-[1.5]',
-                  'text-[var(--msg-tool-card-text)] outline-none',
-                )}
-              />
-            ) : (
-              <pre
-                className={cn(
-                  'overflow-x-auto rounded-[12px] border border-[var(--msg-code-block-border)]',
-                  'bg-[var(--msg-code-block-bg)] p-3 font-mono text-[length:calc(var(--app-code-font-size)_-_1px)] leading-[1.5]',
-                  'text-[var(--msg-tool-card-text)] select-text whitespace-pre-wrap break-words',
-                )}
-              >
-                {payload.text}
-              </pre>
-            ))}
+          {payload.kind === 'text' && (
+            <textarea
+              ref={textareaRef}
+              aria-label={payload.title}
+              value={isEditingText ? draftText : payload.text}
+              onChange={isEditingText ? (event) => setDraftText(event.target.value) : undefined}
+              readOnly={!isEditingText}
+              spellCheck={false}
+              wrap="soft"
+              className={cn(
+                'h-full min-h-0 w-full resize-none rounded-lg border',
+                'border-[var(--msg-code-block-border)] bg-[var(--msg-code-block-bg)]',
+                'p-3 font-mono text-[length:calc(var(--app-code-font-size)_-_1px)] leading-[1.5]',
+                'text-[var(--msg-tool-card-text)] outline-none',
+              )}
+            />
+          )}
 
           {payload.kind === 'json' && (
             <div className="flex flex-col gap-4">


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 上打开已发送消息的「粘贴的文本」预览后，按 Command+A 会选中背后整个对话，而不是预览文本的问题。

只读文本预览原先使用不可聚焦的 `pre`，因此原生 Select All 仍可能作用在旧焦点所在的对话区域。现在文本预览统一使用 textarea：只读场景设置 `readOnly`，打开时主动聚焦，并将平台主选择快捷键限定在当前预览文本内。可编辑粘贴文本仍保持打开后光标位于文本末尾的行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈的 macOS 粘贴文本预览 Select All 焦点问题
- 本 PR 包含：只读文本预览的焦点管理、macOS Command+A / Windows Ctrl+A 处理，以及回归测试
- 明确不包含：文件、JSON、diff 预览行为；对话列表或消息渲染逻辑调整
- 用户可见变化：打开「粘贴的文本」预览后，Command+A 只选择预览中的文本，不再选择背后的对话内容
- 是否存在 breaking change：无

### UI 变化

无视觉变化；仅修复键盘交互与焦点范围。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.1 Text Selectability（用户可复制的内容保持可选择）与 §14.2 Focus Management（弹层打开后焦点落在主要输入/内容控件）。预览打开后主动聚焦只读 textarea，并保持现有 Light/Dark 语义 token 与样式不变。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；全部 required unit workspaces PASS，Desktop unit PASS

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/chat/ToolPayloadLightbox.tsx src/renderer/__tests__/toolPayloadLightbox.test.tsx
结果：通过

pnpm --filter desktop exec prettier --check src/renderer/components/chat/ToolPayloadLightbox.tsx src/renderer/__tests__/toolPayloadLightbox.test.tsx
结果：通过

git diff --check
结果：通过
```

### 手工验证

- 平台：macOS，真实 Electron dev Renderer
- 挂载实际 `ToolPayloadLightbox` 只读文本组件后，确认焦点位于 textarea，`readOnly=true`
- 通过 Electron CDP 派发 Meta+A，选择范围从 `0` 到文本总长度，仅选中预览文本
- 派发 Ctrl+A 时未触发全选，符合 macOS 平台快捷键语义

### 未执行的验证

- macOS 物理键盘/系统级按键注入：AppleScript 被本机 Accessibility 权限拒绝；已在真实 Electron Renderer 内验证 Meta+A 事件链路
- Windows 实机：未执行；实现按平台将主快捷键映射为 Ctrl+A，并保留相同回归逻辑

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop `ToolPayloadLightbox` 的文本 payload；JSON、文件和 diff payload 不变
- 回滚 / 降级方式：回退本 PR commit 即恢复原有 `pre` 只读预览行为；不涉及数据迁移、持久化格式或协议变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
