### PR TITLE
fix(browser): 将截图作为图片内容块返回

### DIFF
--- a/apps/desktop/src/main/mcp-integrations/__tests__/browserScreenshotResolver.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browserScreenshotResolver.test.ts
@@ -78,6 +78,92 @@ describe('resolveBrowserScreenshot', () => {
     );
   });
 
+  it('rejects a symlink inside the media root that points outside it', async () => {
+    const runtimeDir = await makeRuntimeDir();
+    const mediaRoot = path.join(runtimeDir, 'media', 'browser');
+    const outsideTarget = path.join(runtimeDir, 'outside-target.png');
+    const symlinkPath = path.join(mediaRoot, 'escape.png');
+    await fs.mkdir(mediaRoot, { recursive: true });
+    await fs.writeFile(outsideTarget, PNG_BYTES);
+    await fs.symlink(outsideTarget, symlinkPath);
+    const result: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { path: symlinkPath, targetId: 'tab-1' },
+    };
+
+    await expect(resolveBrowserScreenshot(result, { runtimeDir })).rejects.toThrow(
+      'Browser screenshot file is unavailable',
+    );
+  });
+
+  it('rejects external screenshot files above the 5 MiB read cap', async () => {
+    const runtimeDir = await makeRuntimeDir();
+    const mediaRoot = path.join(runtimeDir, 'media', 'browser');
+    const oversizedPath = path.join(mediaRoot, 'oversized.png');
+    await fs.mkdir(mediaRoot, { recursive: true });
+    await fs.writeFile(
+      oversizedPath,
+      Buffer.concat([PNG_BYTES, Buffer.alloc(5 * 1024 * 1024, 0x00)]),
+    );
+    const result: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { path: oversizedPath, targetId: 'tab-1' },
+    };
+
+    await expect(resolveBrowserScreenshot(result, { runtimeDir })).rejects.toThrow(
+      'Browser screenshot file is unavailable',
+    );
+  });
+
+  it('rejects path-based screenshots when no runtimeDir is configured', async () => {
+    const runtimeDir = await makeRuntimeDir();
+    const mediaRoot = path.join(runtimeDir, 'media', 'browser');
+    const screenshotPath = path.join(mediaRoot, 'screen.png');
+    await fs.mkdir(mediaRoot, { recursive: true });
+    await fs.writeFile(screenshotPath, PNG_BYTES);
+    const result: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { path: screenshotPath, targetId: 'tab-1' },
+    };
+
+    await expect(
+      resolveBrowserScreenshot(result, { runtimeDir: undefined }),
+    ).rejects.toThrow('Browser screenshot file is unavailable');
+  });
+
+  it('rejects non-object payloads, payloads without data/path, and unknown magic bytes', async () => {
+    const nonObject: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: undefined,
+    };
+    await expect(resolveBrowserScreenshot(nonObject, { runtimeDir: undefined })).rejects.toThrow(
+      'Browser screenshot payload is invalid',
+    );
+
+    const missingBoth: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { targetId: 'tab-1' },
+    };
+    await expect(resolveBrowserScreenshot(missingBoth, { runtimeDir: undefined })).rejects.toThrow(
+      'Browser screenshot payload is invalid',
+    );
+
+    // 合法 Base64,但内容既不是 PNG 也不是 JPEG 签名。
+    const unknownMagic: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { data: Buffer.alloc(64, 0x00).toString('base64'), targetId: 'tab-1' },
+    };
+    await expect(resolveBrowserScreenshot(unknownMagic, { runtimeDir: undefined })).rejects.toThrow(
+      'Browser screenshot payload is invalid',
+    );
+  });
+
   it('rejects malformed Base64 and declared MIME mismatches', async () => {
     const malformed: BrowserControlResult = {
       ok: true,

--- a/apps/desktop/src/main/mcp-integrations/__tests__/browserScreenshotResolver.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/browserScreenshotResolver.test.ts
@@ -1,0 +1,100 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { BrowserControlResult } from '@cindy/browser-control-runtime';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { resolveBrowserScreenshot } from '../browserScreenshotResolver.js';
+
+const PNG_BYTES = Buffer.concat([
+  Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+  Buffer.from('test-png'),
+]);
+
+const tempRoots: string[] = [];
+
+async function makeRuntimeDir(): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-browser-screenshot-'));
+  tempRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe('resolveBrowserScreenshot', () => {
+  it('strictly decodes an inline RSB screenshot and verifies its MIME', async () => {
+    const result: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: {
+        data: PNG_BYTES.toString('base64'),
+        mimeType: 'image/png',
+        bytes: PNG_BYTES.byteLength,
+        tabId: 'tab-1',
+      },
+    };
+
+    const resolved = await resolveBrowserScreenshot(result, { runtimeDir: undefined });
+
+    expect(resolved).toEqual({ buffer: PNG_BYTES, mimeType: 'image/png' });
+  });
+
+  it('reads external screenshots only from the browser runtime media root', async () => {
+    const runtimeDir = await makeRuntimeDir();
+    const mediaRoot = path.join(runtimeDir, 'media', 'browser');
+    const screenshotPath = path.join(mediaRoot, 'screen.png');
+    await fs.mkdir(mediaRoot, { recursive: true });
+    await fs.writeFile(screenshotPath, PNG_BYTES);
+    const result: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { path: screenshotPath, targetId: 'tab-1' },
+    };
+
+    const resolved = await resolveBrowserScreenshot(result, { runtimeDir });
+
+    expect(resolved).toEqual({ buffer: PNG_BYTES, mimeType: 'image/png' });
+  });
+
+  it('rejects external paths outside the browser runtime media root', async () => {
+    const runtimeDir = await makeRuntimeDir();
+    const mediaRoot = path.join(runtimeDir, 'media', 'browser');
+    const outsidePath = path.join(runtimeDir, 'outside.png');
+    await fs.mkdir(mediaRoot, { recursive: true });
+    await fs.writeFile(outsidePath, PNG_BYTES);
+    const result: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { path: outsidePath, targetId: 'tab-1' },
+    };
+
+    await expect(resolveBrowserScreenshot(result, { runtimeDir })).rejects.toThrow(
+      'Browser screenshot file is unavailable',
+    );
+  });
+
+  it('rejects malformed Base64 and declared MIME mismatches', async () => {
+    const malformed: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { data: 'not-base64!', mimeType: 'image/png' },
+    };
+    await expect(resolveBrowserScreenshot(malformed, { runtimeDir: undefined })).rejects.toThrow(
+      'Browser screenshot payload is invalid',
+    );
+
+    const mismatched: BrowserControlResult = {
+      ok: true,
+      action: 'screenshot',
+      data: { data: PNG_BYTES.toString('base64'), mimeType: 'image/jpeg' },
+    };
+    await expect(resolveBrowserScreenshot(mismatched, { runtimeDir: undefined })).rejects.toThrow(
+      'Browser screenshot MIME does not match its bytes',
+    );
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/browser.ts
+++ b/apps/desktop/src/main/mcp-integrations/browser.ts
@@ -11,13 +11,13 @@ import nodePath from 'node:path';
 import { app, ipcMain } from 'electron';
 import {
   createBrowserControlRuntime,
-  type BrowserControlRuntime,
 } from '@cindy/browser-control-runtime';
+import type { BrowserMcpDeps } from '@cindy/mcps';
 
 import { createLogger } from '../logger.js';
 import { extractBrowserAvailability, type BrowserAvailability } from './browser-availability.js';
-import { loadUserBrowserRecipes, type UserRecipesResult } from '../browser-recipes/loader.js';
-import { writeUserRecipe, type WriteUserRecipeResult } from '../browser-recipes/writer.js';
+import { loadUserBrowserRecipes } from '../browser-recipes/loader.js';
+import { writeUserRecipe } from '../browser-recipes/writer.js';
 import { stopRuntimeForQuitIfUsed, trackBrowserRuntimeUsage } from './browser-dispose.js';
 import {
   BrowserBackendController,
@@ -41,6 +41,8 @@ import { requireObject, optionalNullableString } from '../utils/ipcValidate.js';
 import { buildManagedConfig, MANAGED_PROFILE } from './browser-managed-config.js';
 import { assertTrustedAppRendererEvent } from '../security/trustedAppRenderer.js';
 import { createBrowserBackendIpcHandlers } from './browser-backend/settings-ipc.js';
+import { resolveBrowserScreenshot } from './browserScreenshotResolver.js';
+import { compressInlineImage } from './inlineImageCompressor.js';
 
 export { extractBrowserAvailability, type BrowserAvailability } from './browser-availability.js';
 
@@ -249,14 +251,7 @@ export async function setActiveBrowserBackendKind(kind: BackendKind): Promise<vo
  * BrowserControlRuntime contract so the desktop host does not depend on an
  * upstream product API or product-facing name.
  */
-export function getBrowserMcpDeps(): {
-  getRuntime(): BrowserControlRuntime;
-  supportsResourceDownloads(): boolean;
-  supportsSemanticQueries(): boolean;
-  logger: typeof logger;
-  getUserRecipes(): Promise<UserRecipesResult>;
-  saveUserRecipe(input: Parameters<typeof writeUserRecipe>[0]): Promise<WriteUserRecipeResult>;
-} {
+export function getBrowserMcpDeps(): BrowserMcpDeps {
   return {
     // L2 user-recipe layer (userData/browser-recipes); merged over the bundled
     // L1 catalog inside the MCP. Empty/missing dir → bundled-only (== before).
@@ -267,6 +262,11 @@ export function getBrowserMcpDeps(): {
     // the backend split. Swapping the active backend (Phase 5) is invisible from
     // @cindy/mcps' perspective.
     getRuntime: () => backendController,
+    resolveScreenshot: (result) =>
+      resolveBrowserScreenshot(result, {
+        runtimeDir: process.env.XDT_BROWSER_RUNTIME_DIR,
+      }),
+    compressInlineImage,
     supportsResourceDownloads: () => backendController.kind === 'rsb-webview',
     supportsSemanticQueries: () => backendController.kind === 'rsb-webview',
     logger,

--- a/apps/desktop/src/main/mcp-integrations/browserScreenshotResolver.ts
+++ b/apps/desktop/src/main/mcp-integrations/browserScreenshotResolver.ts
@@ -1,0 +1,103 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+import type { BrowserControlResult } from '@cindy/browser-control-runtime';
+import type { ResolvedBrowserScreenshot } from '@cindy/mcps';
+
+import { readBoundedFileNoFollow } from '../utils/readBoundedFile.js';
+
+const MAX_BROWSER_SCREENSHOT_BYTES = 5 * 1024 * 1024;
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+export interface BrowserScreenshotResolverOptions {
+  runtimeDir: string | undefined;
+}
+
+function sniffScreenshotMime(buffer: Buffer): ResolvedBrowserScreenshot['mimeType'] | null {
+  if (buffer.subarray(0, PNG_SIGNATURE.byteLength).equals(PNG_SIGNATURE)) {
+    return 'image/png';
+  }
+  if (buffer.byteLength >= 3 && buffer[0] === 0xff && buffer[1] === 0xd8 && buffer[2] === 0xff) {
+    return 'image/jpeg';
+  }
+  return null;
+}
+
+function decodeStrictBase64(value: string): Buffer | null {
+  if (
+    value.length === 0 ||
+    value.length % 4 !== 0 ||
+    value.length > Math.ceil(MAX_BROWSER_SCREENSHOT_BYTES / 3) * 4 + 4 ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(value)
+  ) {
+    return null;
+  }
+  const buffer = Buffer.from(value, 'base64');
+  if (buffer.byteLength === 0 || buffer.byteLength > MAX_BROWSER_SCREENSHOT_BYTES) return null;
+  return buffer.toString('base64') === value ? buffer : null;
+}
+
+function isLexicallyWithinRoot(candidate: string, root: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== '' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    relative !== '..' &&
+    !path.isAbsolute(relative)
+  );
+}
+
+async function readExternalScreenshot(
+  filePath: string,
+  runtimeDir: string | undefined,
+): Promise<Buffer> {
+  if (!runtimeDir || !path.isAbsolute(filePath)) {
+    throw new Error('Browser screenshot file is unavailable');
+  }
+  const mediaRoot = path.resolve(runtimeDir, 'media', 'browser');
+  const candidate = path.resolve(filePath);
+  if (!isLexicallyWithinRoot(candidate, mediaRoot)) {
+    throw new Error('Browser screenshot file is unavailable');
+  }
+  try {
+    const realRoot = await fs.realpath(mediaRoot);
+    const buffer = await readBoundedFileNoFollow(candidate, MAX_BROWSER_SCREENSHOT_BYTES, {
+      containWithin: realRoot,
+    });
+    if (!buffer || buffer.byteLength === 0) {
+      throw new Error('Browser screenshot file is unavailable');
+    }
+    return buffer;
+  } catch {
+    throw new Error('Browser screenshot file is unavailable');
+  }
+}
+
+/** Resolve both browser backends into verified bytes without exposing file reads to the MCP package. */
+export async function resolveBrowserScreenshot(
+  result: BrowserControlResult,
+  options: BrowserScreenshotResolverOptions,
+): Promise<ResolvedBrowserScreenshot> {
+  const payload = result.data;
+  if (!result.ok || result.action !== 'screenshot' || !payload || typeof payload !== 'object') {
+    throw new Error('Browser screenshot payload is invalid');
+  }
+  const record = payload as Record<string, unknown>;
+  let buffer: Buffer;
+  if (typeof record.data === 'string') {
+    const decoded = decodeStrictBase64(record.data);
+    if (!decoded) throw new Error('Browser screenshot payload is invalid');
+    buffer = decoded;
+  } else if (typeof record.path === 'string') {
+    buffer = await readExternalScreenshot(record.path, options.runtimeDir);
+  } else {
+    throw new Error('Browser screenshot payload is invalid');
+  }
+
+  const mimeType = sniffScreenshotMime(buffer);
+  if (!mimeType) throw new Error('Browser screenshot payload is invalid');
+  if (typeof record.mimeType === 'string' && record.mimeType !== mimeType) {
+    throw new Error('Browser screenshot MIME does not match its bytes');
+  }
+  return { buffer, mimeType };
+}

--- a/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
+++ b/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
@@ -736,7 +736,9 @@ describe('createBrowserMcpServer', () => {
     await h.cleanup();
   });
 
-  it('fails closed when an oversized screenshot cannot be compressed for inline delivery', async () => {
+  it('reports compressor degradation (null) as COMPRESSION_UNAVAILABLE, not TOO_LARGE', async () => {
+    // CompressInlineImageFn 契约:null = 压缩器不可用/解码失败/超时的预期降级,
+    // 不代表图片本身无法缩小 — 错误码必须与"压缩后仍超标"区分开。
     const original = Buffer.alloc(240_000, 0xab);
     const h = await makeHarness(
       {
@@ -764,9 +766,79 @@ describe('createBrowserMcpServer', () => {
     expect(JSON.parse(block.text ?? '{}')).toMatchObject({
       ok: false,
       action: 'screenshot',
-      errorCode: 'BROWSER_SCREENSHOT_TOO_LARGE',
+      errorCode: 'BROWSER_SCREENSHOT_COMPRESSION_UNAVAILABLE',
     });
     expect(block.text).not.toContain(original.toString('base64'));
+    await h.cleanup();
+  });
+
+  it('fails closed with TOO_LARGE only when the compressed copy still exceeds the inline budget', async () => {
+    const original = Buffer.alloc(400_000, 0xab);
+    const stillOversized = Buffer.alloc(INLINE_IMAGE_TARGET_BYTES + 1, 0xcd);
+    const h = await makeHarness(
+      {
+        resolveScreenshot: async () => ({ buffer: original, mimeType: 'image/png' }),
+        compressInlineImage: async () => ({ buffer: stillOversized, mime: 'image/webp' }),
+      },
+      () => ({
+        data: original.toString('base64'),
+        mimeType: 'image/png',
+        bytes: original.byteLength,
+        tabId: 'tab-1',
+      }),
+    );
+
+    const result = await h.client.callTool({
+      name: 'call_tool',
+      arguments: { name: 'browser', args: { action: 'screenshot', targetId: 'tab-1' } },
+    });
+
+    expect(result.isError).toBe(true);
+    const blocks = result.content as Array<{ type: string; text?: string }>;
+    expect(blocks).toHaveLength(1);
+    expect(JSON.parse(blocks[0].text ?? '{}')).toMatchObject({
+      ok: false,
+      action: 'screenshot',
+      errorCode: 'BROWSER_SCREENSHOT_TOO_LARGE',
+    });
+    expect(blocks[0].text).not.toContain(original.toString('base64'));
+    expect(blocks[0].text).not.toContain(stillOversized.toString('base64'));
+    await h.cleanup();
+  });
+
+  it('maps resolveScreenshot rejections to BROWSER_SCREENSHOT_INVALID without leaking details', async () => {
+    // resolver 的 8 类校验 throw(路径越界 / Base64 损坏 / MIME 不匹配等)必须
+    // 收敛为稳定的 BROWSER_SCREENSHOT_INVALID,而不是穿透外层 catch 被泛化成
+    // BROWSER_RUNTIME_ACTION_FAILED;error 里的路径不得进入模型可见结果。
+    const secretPath = '/private/browser-runtime/media/browser/secret-screenshot.png';
+    const h = await makeHarness(
+      {
+        resolveScreenshot: async () => {
+          throw new Error(`Browser screenshot file is unavailable: ${secretPath}`);
+        },
+      },
+      () => ({
+        path: secretPath,
+        targetId: 'tab-1',
+      }),
+    );
+
+    const result = await h.client.callTool({
+      name: 'call_tool',
+      arguments: { name: 'browser', args: { action: 'screenshot', targetId: 'tab-1' } },
+    });
+
+    expect(result.isError).toBe(true);
+    const blocks = result.content as Array<{ type: string; text?: string }>;
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe('text');
+    expect(JSON.parse(blocks[0].text ?? '{}')).toMatchObject({
+      ok: false,
+      action: 'screenshot',
+      errorCode: 'BROWSER_SCREENSHOT_INVALID',
+    });
+    expect(blocks[0].text).not.toContain(secretPath);
+    expect(blocks[0].text).not.toContain('BROWSER_RUNTIME_ACTION_FAILED');
     await h.cleanup();
   });
 

--- a/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
+++ b/packages/lizi-mcps/src/browser/browserMcpServer.test.ts
@@ -4,7 +4,7 @@ import type { BrowserControlRuntime } from '@cindy/browser-control-runtime';
 import { describe, expect, it } from 'vitest';
 
 import { createBrowserMcpServer } from './server.js';
-import type { BrowserMcpDeps } from '../types.js';
+import { INLINE_IMAGE_TARGET_BYTES, type BrowserMcpDeps } from '../types.js';
 
 // `respond` lets a test script the result per call (e.g. a navigate that returns
 // a swapped targetId); default echoes the request back as data.
@@ -684,6 +684,129 @@ describe('createBrowserMcpServer', () => {
     };
     expect(parsed.truncated).toBe(true);
     expect(parsed.bytes ?? 0).toBeGreaterThan(parsed.limit ?? 0);
+    await h.cleanup();
+  });
+
+  it('returns oversized screenshots as bounded image blocks without leaking binary text', async () => {
+    const original = Buffer.alloc(240_000, 0xab);
+    const compressed = Buffer.from('compressed-webp');
+    const h = await makeHarness(
+      {
+        resolveScreenshot: async () => ({ buffer: original, mimeType: 'image/png' }),
+        compressInlineImage: async () => ({ buffer: compressed, mime: 'image/webp' }),
+      },
+      () => ({
+        path: '/private/browser-runtime/media/browser/screenshot.png',
+        targetId: 'tab-1',
+        url: 'https://example.com/',
+      }),
+    );
+
+    const result = await h.client.callTool({
+      name: 'call_tool',
+      arguments: { name: 'browser', args: { action: 'screenshot', targetId: 'tab-1' } },
+    });
+
+    expect(result.isError).not.toBe(true);
+    const content = result.content as Array<
+      { type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }
+    >;
+    expect(content).toHaveLength(2);
+    const textBlock = content[0];
+    expect(textBlock.type).toBe('text');
+    const metadata = JSON.parse('text' in textBlock ? textBlock.text : '{}') as {
+      data?: Record<string, unknown>;
+      truncated?: boolean;
+    };
+    expect(metadata.truncated).not.toBe(true);
+    expect(metadata.data).toMatchObject({
+      targetId: 'tab-1',
+      url: 'https://example.com/',
+      mimeType: 'image/webp',
+      bytes: compressed.byteLength,
+    });
+    expect(metadata.data).not.toHaveProperty('path');
+    expect(metadata.data).not.toHaveProperty('data');
+    expect('text' in textBlock ? textBlock.text : '').not.toContain(original.toString('base64'));
+    expect(content[1]).toEqual({
+      type: 'image',
+      data: compressed.toString('base64'),
+      mimeType: 'image/webp',
+    });
+    await h.cleanup();
+  });
+
+  it('fails closed when an oversized screenshot cannot be compressed for inline delivery', async () => {
+    const original = Buffer.alloc(240_000, 0xab);
+    const h = await makeHarness(
+      {
+        resolveScreenshot: async () => ({ buffer: original, mimeType: 'image/png' }),
+        compressInlineImage: async () => null,
+      },
+      () => ({
+        data: original.toString('base64'),
+        mimeType: 'image/png',
+        bytes: original.byteLength,
+        tabId: 'tab-1',
+      }),
+    );
+
+    const result = await h.client.callTool({
+      name: 'call_tool',
+      arguments: { name: 'browser', args: { action: 'screenshot', targetId: 'tab-1' } },
+    });
+
+    expect(result.isError).toBe(true);
+    const blocks = result.content as Array<{ type: string; text?: string }>;
+    expect(blocks).toHaveLength(1);
+    const block = blocks[0];
+    expect(block.type).toBe('text');
+    expect(JSON.parse(block.text ?? '{}')).toMatchObject({
+      ok: false,
+      action: 'screenshot',
+      errorCode: 'BROWSER_SCREENSHOT_TOO_LARGE',
+    });
+    expect(block.text).not.toContain(original.toString('base64'));
+    await h.cleanup();
+  });
+
+  it('keeps the complete screenshot tool result below the stream-json atomic-write budget', async () => {
+    const screenshot = Buffer.alloc(INLINE_IMAGE_TARGET_BYTES, 0xab);
+    const annotationMarker = 'must-not-enter-result';
+    const h = await makeHarness(
+      {
+        resolveScreenshot: async () => ({ buffer: screenshot, mimeType: 'image/png' }),
+      },
+      () => ({
+        path: '/private/browser-runtime/media/browser/screenshot.png',
+        targetId: 'tab-1',
+        url: 'https://example.com/',
+        labels: true,
+        labelsCount: 10_000,
+        annotations: Array.from({ length: 10_000 }, () => ({ text: annotationMarker.repeat(20) })),
+      }),
+    );
+
+    const result = await h.client.callTool({
+      name: 'call_tool',
+      arguments: { name: 'browser', args: { action: 'screenshot', targetId: 'tab-1' } },
+    });
+
+    expect(result.isError).not.toBe(true);
+    const serialized = JSON.stringify(result);
+    expect(Buffer.byteLength(serialized, 'utf8')).toBeLessThan(256 * 1024);
+    expect(serialized).not.toContain(annotationMarker);
+    const text = (result.content as Array<{ type: string; text?: string }>)[0]?.text ?? '{}';
+    expect(JSON.parse(text)).toMatchObject({
+      ok: true,
+      action: 'screenshot',
+      data: {
+        targetId: 'tab-1',
+        labels: true,
+        labelsCount: 10_000,
+        annotationCount: 10_000,
+      },
+    });
     await h.cleanup();
   });
 

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -1,11 +1,15 @@
 import {
   isPublicHttpResourceUrl,
   type BrowserControlRequest,
+  type BrowserControlResult,
   type BrowserControlRuntime,
 } from '@cindy/browser-control-runtime';
 import { z } from 'zod';
 
-import type { BrowserMcpDeps } from '../types.js';
+import {
+  INLINE_IMAGE_TARGET_BYTES,
+  type BrowserMcpDeps,
+} from '../types.js';
 import type { BrowserToolRegistry } from './tool-registry.js';
 import {
   buildExtractFnSource,
@@ -205,6 +209,127 @@ function errorResult(action: string, message: string): {
       },
     ],
     isError: true,
+  };
+}
+
+function browserScreenshotError(
+  errorCode: 'BROWSER_SCREENSHOT_INVALID' | 'BROWSER_SCREENSHOT_TOO_LARGE',
+  message: string,
+): {
+  content: Array<{ type: 'text'; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: resultText({ ok: false, action: 'screenshot', errorCode, message }),
+      },
+    ],
+    isError: true,
+  };
+}
+
+function screenshotMetadata(
+  result: BrowserControlResult,
+  mimeType: string,
+  bytes: number,
+  originalBytes: number,
+): Record<string, unknown> {
+  const rawData = result.data && typeof result.data === 'object' && !Array.isArray(result.data)
+    ? result.data as Record<string, unknown>
+    : {};
+  const boundedString = (key: string, maxChars: number): string | undefined => {
+    const value = rawData[key];
+    return typeof value === 'string' ? value.slice(0, maxChars) : undefined;
+  };
+  const boundedCount = (key: string): number | undefined => {
+    const value = rawData[key];
+    return typeof value === 'number' && Number.isFinite(value) && value >= 0
+      ? Math.floor(value)
+      : undefined;
+  };
+  const annotationCount = Array.isArray(rawData.annotations)
+    ? rawData.annotations.length
+    : undefined;
+  return {
+    ok: true,
+    action: 'screenshot',
+    data: {
+      ...(boundedString('targetId', 512) ? { targetId: boundedString('targetId', 512) } : {}),
+      ...(boundedString('tabId', 512) ? { tabId: boundedString('tabId', 512) } : {}),
+      ...(boundedString('url', 4_096) ? { url: boundedString('url', 4_096) } : {}),
+      ...(typeof rawData.labels === 'boolean' ? { labels: rawData.labels } : {}),
+      ...(boundedCount('labelsCount') !== undefined
+        ? { labelsCount: boundedCount('labelsCount') }
+        : {}),
+      ...(boundedCount('labelsSkipped') !== undefined
+        ? { labelsSkipped: boundedCount('labelsSkipped') }
+        : {}),
+      ...(annotationCount !== undefined ? { annotationCount } : {}),
+      mimeType,
+      bytes,
+      ...(bytes !== originalBytes ? { originalBytes } : {}),
+    },
+  };
+}
+
+async function screenshotToolResult(
+  result: BrowserControlResult,
+  deps: BrowserMcpDeps,
+) {
+  if (!result.ok) {
+    return {
+      content: [{ type: 'text' as const, text: resultText(result) }],
+      isError: true,
+    };
+  }
+  if (!deps.resolveScreenshot) {
+    return browserScreenshotError(
+      'BROWSER_SCREENSHOT_INVALID',
+      '当前 host 无法把浏览器截图解析为模型图片输入。',
+    );
+  }
+
+  const resolved = await deps.resolveScreenshot(result);
+  const originalBytes = resolved.buffer.byteLength;
+  let buffer = resolved.buffer;
+  let mimeType: string = resolved.mimeType;
+
+  if (buffer.byteLength > INLINE_IMAGE_TARGET_BYTES) {
+    const compressed = await deps.compressInlineImage?.(buffer, mimeType, {
+      targetBytes: INLINE_IMAGE_TARGET_BYTES,
+    });
+    if (!compressed || compressed.buffer.byteLength > INLINE_IMAGE_TARGET_BYTES) {
+      return browserScreenshotError(
+        'BROWSER_SCREENSHOT_TOO_LARGE',
+        '浏览器截图超过模型内联传输上限，且无法安全压缩。请缩小窗口后重试。',
+      );
+    }
+    buffer = compressed.buffer;
+    mimeType = compressed.mime;
+  }
+
+  if (!['image/png', 'image/jpeg', 'image/webp'].includes(mimeType) || buffer.byteLength === 0) {
+    return browserScreenshotError(
+      'BROWSER_SCREENSHOT_INVALID',
+      '浏览器截图没有返回受支持的有效图片。',
+    );
+  }
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: resultText(screenshotMetadata(result, mimeType, buffer.byteLength, originalBytes)),
+      },
+      {
+        type: 'image' as const,
+        data: buffer.toString('base64'),
+        mimeType,
+      },
+    ],
+    isError: false,
   };
 }
 
@@ -613,6 +738,9 @@ export function registerBrowserTools(registry: BrowserToolRegistry, deps: Browse
           } as BrowserControlRequest);
         } else {
           result = await runtime.call(toRuntimeRequest(args));
+        }
+        if (args.action === 'screenshot') {
+          return await screenshotToolResult(result, deps);
         }
         // For extract, the runtime call may succeed (evaluate ran) while the
         // in-page extract reports ok:false (invalid selector); surface that as an

--- a/packages/lizi-mcps/src/browser/tools.ts
+++ b/packages/lizi-mcps/src/browser/tools.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 import {
   INLINE_IMAGE_TARGET_BYTES,
   type BrowserMcpDeps,
+  type ResolvedBrowserScreenshot,
 } from '../types.js';
 import type { BrowserToolRegistry } from './tool-registry.js';
 import {
@@ -213,7 +214,10 @@ function errorResult(action: string, message: string): {
 }
 
 function browserScreenshotError(
-  errorCode: 'BROWSER_SCREENSHOT_INVALID' | 'BROWSER_SCREENSHOT_TOO_LARGE',
+  errorCode:
+    | 'BROWSER_SCREENSHOT_INVALID'
+    | 'BROWSER_SCREENSHOT_TOO_LARGE'
+    | 'BROWSER_SCREENSHOT_COMPRESSION_UNAVAILABLE',
   message: string,
 ): {
   content: Array<{ type: 'text'; text: string }>;
@@ -291,19 +295,53 @@ async function screenshotToolResult(
     );
   }
 
-  const resolved = await deps.resolveScreenshot(result);
+  let resolved: ResolvedBrowserScreenshot;
+  try {
+    resolved = await deps.resolveScreenshot(result);
+  } catch (err) {
+    // resolver 抛错(路径越界 / Base64 损坏 / MIME 不匹配等)是截图内容校验
+    // 失败,不是 runtime 动作失败:映射到稳定的 BROWSER_SCREENSHOT_INVALID,
+    // 不能穿透到外层被泛化成 BROWSER_RUNTIME_ACTION_FAILED。原始 error 可能
+    // 含文件路径,只进 host 日志,不进模型可见的错误信封。
+    deps.logger?.warn('browser screenshot resolve failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return browserScreenshotError(
+      'BROWSER_SCREENSHOT_INVALID',
+      '浏览器截图内容校验失败，无法作为模型图片输入。',
+    );
+  }
   const originalBytes = resolved.buffer.byteLength;
   let buffer = resolved.buffer;
   let mimeType: string = resolved.mimeType;
 
   if (buffer.byteLength > INLINE_IMAGE_TARGET_BYTES) {
-    const compressed = await deps.compressInlineImage?.(buffer, mimeType, {
-      targetBytes: INLINE_IMAGE_TARGET_BYTES,
-    });
-    if (!compressed || compressed.buffer.byteLength > INLINE_IMAGE_TARGET_BYTES) {
+    let compressed: Awaited<ReturnType<NonNullable<BrowserMcpDeps['compressInlineImage']>>> = null;
+    try {
+      compressed = (await deps.compressInlineImage?.(buffer, mimeType, {
+        targetBytes: INLINE_IMAGE_TARGET_BYTES,
+      })) ?? null;
+    } catch (err) {
+      // CompressInlineImageFn 契约是永不 throw;真 throw 了按"压缩器不可用"
+      // 降级处理,不让异常穿透成 BROWSER_RUNTIME_ACTION_FAILED。
+      deps.logger?.warn('browser screenshot compression threw, treating as unavailable', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      compressed = null;
+    }
+    // null 是压缩器的契约降级值(sharp 缺失 / 解码失败 / 超时,见
+    // CompressInlineImageFn):不是图片本身超标,不能报 TOO_LARGE。截图仍
+    // 超过内联预算所以必须 fail-closed,但错误码和文案要说真话。
+    if (!compressed) {
+      return browserScreenshotError(
+        'BROWSER_SCREENSHOT_COMPRESSION_UNAVAILABLE',
+        '浏览器截图超过模型内联传输上限，且当前主机图片压缩不可用（压缩器缺失、无法解码或超时），无法安全内联。',
+      );
+    }
+    if (compressed.buffer.byteLength > INLINE_IMAGE_TARGET_BYTES) {
       return browserScreenshotError(
         'BROWSER_SCREENSHOT_TOO_LARGE',
-        '浏览器截图超过模型内联传输上限，且无法安全压缩。请缩小窗口后重试。',
+        '浏览器截图压缩后仍超过模型内联传输上限。请缩小窗口后重试。',
       );
     }
     buffer = compressed.buffer;

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -1,4 +1,7 @@
-import type { BrowserControlRuntime } from '@cindy/browser-control-runtime';
+import type {
+  BrowserControlResult,
+  BrowserControlRuntime,
+} from '@cindy/browser-control-runtime';
 import type { AgentKind } from '@cindy/maker-core';
 
 import type { Recipe, SiteGuide } from './browser/recipe-loader.js';
@@ -496,9 +499,24 @@ export type ControlResult<T extends object = object, E extends string = never> =
  */
 export type ControlWorkerAgent = 'claude-code' | 'codex' | 'pi';
 
+export interface ResolvedBrowserScreenshot {
+  buffer: Buffer;
+  mimeType: 'image/png' | 'image/jpeg';
+}
+
 /** Browser automation MCP host deps. Core browser execution is injected by host. */
 export interface BrowserMcpDeps {
   getRuntime(): BrowserControlRuntime;
+  /**
+   * Resolve a successful screenshot runtime result into verified image bytes.
+   * The host owns file-system access so this package never receives a generic
+   * arbitrary-path reader; inline-only hosts may validate and decode in memory.
+   */
+  resolveScreenshot?(
+    result: BrowserControlResult,
+  ): Promise<ResolvedBrowserScreenshot>;
+  /** Shrink the LLM-facing copy to the shared stream-safe byte budget. */
+  compressInlineImage?: CompressInlineImageFn;
   /** Whether the active backend accepts managed resource downloads. */
   supportsResourceDownloads?(): boolean;
   /** Whether the active backend accepts semantic element queries. */


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `browser` MCP 的 `screenshot` 结果被当成普通 JSON 文本返回、Base64 超过文本上限后遭截断的问题。截图现在由 Desktop host 安全解析并按共享图片预算压缩，再作为 MCP `image` content block 返回；文本块只保留有界元数据。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #1824
- 本 PR 包含：兼容 RSB inline Base64 与 external runtime 文件路径两种截图结果；图片 MIME/内容校验；5 MiB 读取上限；140 KB 模型内联预算；大图压缩；MCP 图片内容块；有界截图元数据与回归测试。
- 明确不包含：浏览器后端路由、截图 UI、服务端接口、截图标注生成逻辑。
- 用户可见变化：模型可收到完整可用的浏览器截图，不再收到被截断的 Base64 JSON 文本。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/mcps exec vitest run src/browser/browserMcpServer.test.ts
结果：31 tests passed

pnpm --filter desktop exec vitest run src/main/mcp-integrations/__tests__/browserScreenshotResolver.test.ts
结果：4 tests passed

pnpm --filter @cindy/mcps build
结果：通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec eslint src/main/mcp-integrations/browser.ts src/main/mcp-integrations/browserScreenshotResolver.ts src/main/mcp-integrations/__tests__/browserScreenshotResolver.test.ts
结果：通过

NODE_OPTIONS=--no-experimental-webstorage ELECTRON_OVERRIDE_DIST_PATH=<local-electron-dist> pnpm test:unit
结果：全部 required unit workspaces 通过；Desktop unit 通过（122.2s）

pnpm check:dco
结果：通过
```

### 手工验证

不涉及：没有重启当前正在使用的 Cindy；两种 backend 的返回形态均由单元测试覆盖。

### 未执行的验证

未执行 Windows/Linux 手工运行验证；实现使用跨平台 `path`/文件读取封装，并由类型检查与单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `browser` MCP 的 `screenshot` action。其他 browser action 继续使用原有 200 KB 文本结果上限。
- 安全边界：external backend 仅可读取 `<runtimeDir>/media/browser` 内、非符号链接且不超过 5 MiB 的 PNG/JPEG；路径和 Base64 不进入文本元数据。图片与包装后的完整 tool result 保持在 256 KiB 原子写预算内。
- 跨平台差异：未使用平台专属 API；路径包含关系通过 `path.relative` 与真实根目录校验。Windows/Linux 未手工运行。
- 回滚 / 降级方式：revert 本 PR 即恢复旧的截图文本返回行为；解析或压缩失败时当前实现会 fail closed，不回退到泄漏/截断 Base64 文本。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本修复不需要额外用户文档）
- [x] 已确认测试结果或说明未执行原因
