### PR TITLE
fix(desktop): reserve macOS chrome space for left panels

### DIFF
--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { BrowserWebviewPool } from '@/components/layout/BrowserWebviewPool';
 import { ChromeActions } from '@/components/layout/ChromeActions';
+import { shouldReserveLeftChromeActions } from '@/components/layout/chromeActionsLayout';
 import { ContentHeaderSlot } from '@/components/layout/ContentHeader';
 import { rightSidebarOwnsRailChromeActions as resolveRightSidebarRailChromeActionsOwner } from '@/components/layout/railChromeActions';
 import { FadeSwitcher } from '@/components/layout/FadeSwitcher';
@@ -1328,7 +1329,11 @@ export function MainLayout() {
                   onCloseSidebar={isMac ? undefined : handleToggleRightSidebar}
                   onMaximize={handleMaximizeRightSidebar}
                   isMaximized={isRightSidebarMaximized}
-                  reserveLeftChromeActions={isRightSidebarMaximized && isSidebarCollapsed}
+                  reserveLeftChromeActions={shouldReserveLeftChromeActions({
+                    isSidebarCollapsed,
+                    rightSidebarSide,
+                    isRightSidebarMaximized,
+                  })}
                   railChromeActionsHitHole={rightSidebarOwnsRailChromeActions}
                   sessionId={rightSidebarSessionId}
                   workdir={rightSidebarWorkdirInfo.workdir}

--- a/apps/desktop/src/renderer/components/layout/__tests__/chromeActionsLayout.test.ts
+++ b/apps/desktop/src/renderer/components/layout/__tests__/chromeActionsLayout.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldReserveLeftChromeActions } from '../chromeActionsLayout';
+
+describe('shouldReserveLeftChromeActions', () => {
+  it.each([
+    [
+      'collapsed left-docked panel',
+      {
+        isSidebarCollapsed: true,
+        rightSidebarSide: 'left' as const,
+        isRightSidebarMaximized: false,
+      },
+    ],
+    [
+      'collapsed maximized panel',
+      {
+        isSidebarCollapsed: true,
+        rightSidebarSide: 'right' as const,
+        isRightSidebarMaximized: true,
+      },
+    ],
+  ])('reserves the topbar chrome area for %s', (_name, input) => {
+    expect(shouldReserveLeftChromeActions(input)).toBe(true);
+  });
+
+  it.each([
+    [
+      'expanded left-docked panel',
+      {
+        isSidebarCollapsed: false,
+        rightSidebarSide: 'left' as const,
+        isRightSidebarMaximized: false,
+      },
+    ],
+    [
+      'expanded maximized panel',
+      {
+        isSidebarCollapsed: false,
+        rightSidebarSide: 'right' as const,
+        isRightSidebarMaximized: true,
+      },
+    ],
+    [
+      'collapsed right-docked panel',
+      {
+        isSidebarCollapsed: true,
+        rightSidebarSide: 'right' as const,
+        isRightSidebarMaximized: false,
+      },
+    ],
+  ])('does not reserve the area for %s', (_name, input) => {
+    expect(shouldReserveLeftChromeActions(input)).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/components/layout/chromeActionsLayout.ts
+++ b/apps/desktop/src/renderer/components/layout/chromeActionsLayout.ts
@@ -1,0 +1,11 @@
+export function shouldReserveLeftChromeActions({
+  isSidebarCollapsed,
+  rightSidebarSide,
+  isRightSidebarMaximized,
+}: {
+  isSidebarCollapsed: boolean;
+  rightSidebarSide: 'left' | 'right';
+  isRightSidebarMaximized: boolean;
+}): boolean {
+  return isSidebarCollapsed && (rightSidebarSide === 'left' || isRightSidebarMaximized);
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 macOS 新窗口中，左侧栏收起且工具面板停靠左侧时，面板标签栏与系统窗口按钮/左上角操作区重叠的问题。统一复用现有 ChromeActions 安全区，仅扩展触发条件。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 回归测试

### 范围

- 关联 Issue / 需求：Fixes #1909
- 本 PR 包含：左置非最大化场景的顶部安全区条件与纯函数回归测试。
- 明确不包含：窗口创建、标签栏样式、右置面板和全屏已有逻辑。
- 用户可见变化：左置工具面板的第一个标签不再被 macOS 窗口按钮遮挡。
- 是否存在 breaking change：无。

### UI 变化

复用现有 ChromeActions spacer，不新增颜色或尺寸。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2 Layer System（沿用现有顶栏安全区）、§10 Light / Dark Dual-Mode Delivery Gate（复用现有布局机制）。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run src/renderer/components/layout/__tests__/chromeActionsLayout.test.ts src/renderer/features/right-sidebar/__tests__/RightSidebarShell.test.ts
结果：2 files / 26 tests passed。

pnpm --dir apps/desktop exec eslint src/renderer/components/layout/chromeActionsLayout.ts src/renderer/components/layout/__tests__/chromeActionsLayout.test.ts src/renderer/components/layout/MainLayout.tsx
结果：通过。

pnpm --dir apps/desktop typecheck
结果：通过。
```

### 手工验证

尚未完成 macOS 新窗口实机目检；合并前需确认左置、右置、最大化、全屏及 tab 切换。

### 未执行的验证

- macOS 视觉回归：待维护者或本地 Desktop 启动后确认。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：Desktop Renderer 顶栏布局条件。
- 回滚 / 降级方式：revert 本 PR；不涉及数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个非 merge commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充测试