### PR TITLE
feat(desktop): add Cindy AI web search

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
@@ -21,7 +21,13 @@ function fakeGhost(
   overrides: {
     enabled?: boolean;
     slots?: string[];
-    model?: { image?: string[]; video?: string[]; media?: string[]; text?: string[] } | null;
+    model?: {
+      image?: string[];
+      video?: string[];
+      media?: string[];
+      text?: string[];
+      search?: string[];
+    } | null;
   } = {},
 ): InstalledGhost {
   return {
@@ -67,6 +73,7 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
   depositMedia: ReturnType<typeof vi.fn>;
   depositUsageBytes: ReturnType<typeof vi.fn>;
   releaseDeposit: ReturnType<typeof vi.fn>;
+  searchWeb: ReturnType<typeof vi.fn>;
 } {
   const generateImage = vi.fn(async () => ({
     buffer: new Uint8Array([1, 2, 3]),
@@ -136,6 +143,17 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
   );
   const depositUsageBytes = vi.fn(async () => 0);
   const releaseDeposit = vi.fn(async () => true);
+  const searchWeb = vi.fn(async () => ({
+    ok: true as const,
+    results: [
+      {
+        title: 'Cindy',
+        url: 'https://example.test/cindy',
+        snippet: 'Search result',
+      },
+    ],
+    requestId: 'search-call-1',
+  }));
   const slot = new GhostCindySlot({
     getGhost: () => fakeGhost(),
     getOwnerScopeKey: () => 'cloud:test-owner:1',
@@ -155,6 +173,7 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
     depositMedia,
     depositUsageBytes,
     releaseDeposit,
+    searchWeb,
     ...overrides,
   } as CindySlotDeps);
   return {
@@ -173,6 +192,7 @@ function makeSlot(overrides: Partial<CindySlotDeps> = {}): {
     depositMedia,
     depositUsageBytes,
     releaseDeposit,
+    searchWeb,
   };
 }
 
@@ -278,6 +298,104 @@ describe('载荷校验', () => {
     expect(videoBad).toMatchObject({ ok: false });
     expect((videoBad as { message: string }).message).toContain('ratio');
     expect(generateVideo).not.toHaveBeenCalled();
+  });
+});
+
+describe('Cindy Web Search', () => {
+  const SEARCH_REQ = {
+    type: 'cindy-request',
+    kind: 'search_web',
+    query: '  Cindy Web Search  ',
+    provider: 'cindy',
+    callId: 'call-search-1',
+  };
+
+  const searchGhost = () => fakeGhost({ model: { search: ['web'] } });
+
+  it('按能力声明放行，trim query、补默认结果数并保持逻辑 Provider 为 cindy', async () => {
+    const searchWeb = vi.fn(async () => ({
+      ok: true as const,
+      results: [
+        {
+          title: 'Result',
+          url: 'https://example.test/result',
+          snippet: 'Summary',
+        },
+      ],
+      requestId: 'litellm-call-1',
+    }));
+    const { slot } = makeSlot({
+      getGhost: searchGhost,
+      searchWeb,
+    });
+
+    const result = await slot.handleModelRequest('art', SEARCH_REQ);
+
+    expect(searchWeb).toHaveBeenCalledWith({ query: 'Cindy Web Search', limit: 5 });
+    expect(result).toEqual({
+      ok: true,
+      provider: 'cindy',
+      results: [
+        {
+          title: 'Result',
+          url: 'https://example.test/result',
+          snippet: 'Summary',
+        },
+      ],
+    });
+  });
+
+  it('拒绝未声明能力、非 cindy Provider、非法 query/limit/callId，且不出网', async () => {
+    const searchWeb = vi.fn();
+    const undeclared = makeSlot({ searchWeb });
+    expect(await undeclared.slot.handleModelRequest('art', SEARCH_REQ)).toMatchObject({
+      ok: false,
+      errorCode: 'NOT_CONFIGURED',
+    });
+
+    const { slot } = makeSlot({ getGhost: searchGhost, searchWeb });
+    for (const request of [
+      { ...SEARCH_REQ, provider: 'tavily' },
+      { ...SEARCH_REQ, query: '   ' },
+      { ...SEARCH_REQ, query: 'x'.repeat(2001) },
+      { ...SEARCH_REQ, limit: 0 },
+      { ...SEARCH_REQ, limit: 1.5 },
+      { ...SEARCH_REQ, limit: 11 },
+      { ...SEARCH_REQ, callId: '' },
+    ]) {
+      expect(await slot.handleModelRequest('art', request)).toMatchObject({
+        ok: false,
+        errorCode: 'INVALID_PARAMS',
+      });
+    }
+    expect(searchWeb).not.toHaveBeenCalled();
+  });
+
+  it('保留主机搜索错误码；账号切换期间 fail closed', async () => {
+    const searchWeb = vi.fn(async () => ({
+      ok: false as const,
+      errorCode: 'QUOTA_EXHAUSTED' as const,
+      message: 'Cindy AI 搜索额度不足',
+      status: 402,
+      requestId: 'litellm-call-2',
+    }));
+    const quota = makeSlot({ getGhost: searchGhost, searchWeb });
+    expect(await quota.slot.handleModelRequest('art', SEARCH_REQ)).toEqual({
+      ok: false,
+      errorCode: 'QUOTA_EXHAUSTED',
+      message: 'Cindy AI 搜索额度不足',
+    });
+
+    const switching = makeSlot({
+      getGhost: searchGhost,
+      searchWeb,
+      isOwnerBoundaryPending: () => true,
+    });
+    expect(await switching.slot.handleModelRequest('art', SEARCH_REQ)).toMatchObject({
+      ok: false,
+      errorCode: 'UPSTREAM_UNAVAILABLE',
+    });
+    expect(searchWeb).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -47,6 +47,9 @@ import {
   GHOST_CINDY_DEPOSIT_REFILL_MS,
   GHOST_CINDY_JOB_TTL_MS,
   GHOST_CINDY_MAX_ASYNC_JOBS,
+  GHOST_CINDY_SEARCH_DEFAULT_RESULTS,
+  GHOST_CINDY_SEARCH_MAX_QUERY_CHARS,
+  GHOST_CINDY_SEARCH_MAX_RESULTS,
   GHOST_IMAGE_ASPECT_RATIOS,
   GHOST_MODEL_TIERS,
   GHOST_ONESHOT_TEXT_DEFAULT_MAX_TOKENS,
@@ -69,6 +72,7 @@ import {
   type GhostVideoResultParams,
   type InstalledGhost,
 } from '../../shared/ghost.js';
+import type { CindyProxySearchService } from '../mcp-integrations/cindyProxySearch.js';
 import { probeImageSize } from './imageProbe.js';
 
 /**
@@ -235,6 +239,13 @@ export interface CindySlotDeps {
   depositUsageBytes?(ghostId: string): Promise<number>;
   /** 撤回该意识对某指纹的寄存引用;返回是否真的删掉了行(false = 本就没有)。 */
   releaseDeposit?(params: { ghostId: string; hash: string }): Promise<boolean>;
+  /**
+   * Cindy 托管 Web Search。实现固定读取主机 XD endpoint + XD user key，
+   * 并通过固定模型别名调用 Anthropic Messages 原生网页搜索；插件不能注入
+   * 上游地址、凭证、模型名或工具定义。
+   * 可选依赖:未接线的宿主/测试环境 fail closed。
+   */
+  searchWeb?: CindyProxySearchService['search'];
   /**
    * 快问快答(text.oneshot,2026-07-31):把 prompt 交给主机的轻量任务
    * 模型链直答一次。注入实现包装 utility-model/oneShotCandidates 的
@@ -461,6 +472,9 @@ export class GhostCindySlot {
       data?: unknown;
       label?: unknown;
       hash?: unknown;
+      query?: unknown;
+      limit?: unknown;
+      provider?: unknown;
     };
     if (p?.kind === 'query_job') {
       return this.handleQueryJob(ghostId, p);
@@ -506,13 +520,28 @@ export class GhostCindySlot {
         return { ok: false, message: `快问快答失败:${message}`, errorCode: 'INTERNAL' };
       }
     }
+    if (p?.kind === 'search_web') {
+      try {
+        return await this.handleSearchWeb(ghostId, payload);
+      } catch (err) {
+        this.deps.log?.warn('ghost cindy-request search_web unexpected failure', {
+          ghostId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return {
+          ok: false,
+          message: 'Cindy AI 搜索失败，请稍后再试',
+          errorCode: 'INTERNAL',
+        };
+      }
+    }
     const info = typeof p?.kind === 'string' ? KIND_INFO[p.kind] : undefined;
     if (!info) {
       return {
         ok: false,
         message:
           `未知的代办类型(当前支持 ${Object.keys(KIND_INFO).join(' / ')} / ` +
-          'deposit_media / release_media / oneshot_text / query_job)',
+          'deposit_media / release_media / oneshot_text / search_web / query_job)',
       };
     }
     const kind = p.kind as string;
@@ -1018,6 +1047,172 @@ export class GhostCindySlot {
       };
     }
     return null;
+  }
+
+  /**
+   * search_web:Cindy 托管公网搜索。它与插件 network 槽里的 BYO Provider
+   * 完全分账，主机只接受 provider:'cindy'，失败不做任何跨 Provider fallback。
+   * 查询文本不进日志；日志只留归因号、状态、耗时、结果数和上游 request id。
+   */
+  private async handleSearchWeb(
+    ghostId: string,
+    payload: unknown,
+  ): Promise<GhostPipeModelResult> {
+    const ghost = this.deps.getGhost(ghostId);
+    if (!ghost || !ghost.enabled) {
+      return {
+        ok: false,
+        message: '意识不在可用状态',
+        errorCode: 'NOT_CONFIGURED',
+      };
+    }
+    if (!ghost.manifest.slots?.includes('cindy')) {
+      return {
+        ok: false,
+        message: '本意识未声明 cindy 卡槽，无权请 Cindy 搜索',
+        errorCode: 'NOT_CONFIGURED',
+      };
+    }
+    const declared: readonly string[] = ghost.manifest.cindy?.search ?? [];
+    if (!declared.includes('web')) {
+      return {
+        ok: false,
+        message:
+          '本意识未声明搜索「网页搜索」能力(身份卡 cindy.search 缺 "web")，请意识作者更新声明',
+        errorCode: 'NOT_CONFIGURED',
+      };
+    }
+
+    const p = payload as {
+      query?: unknown;
+      limit?: unknown;
+      provider?: unknown;
+      callId?: unknown;
+    };
+    if (p.provider !== 'cindy') {
+      return {
+        ok: false,
+        message: 'search_web 的 provider 必须固定为 cindy',
+        errorCode: 'INVALID_PARAMS',
+      };
+    }
+    if (typeof p.query !== 'string' || p.query.trim().length === 0) {
+      return { ok: false, message: 'query 不能为空', errorCode: 'INVALID_PARAMS' };
+    }
+    const query = p.query.trim();
+    if (query.length > GHOST_CINDY_SEARCH_MAX_QUERY_CHARS) {
+      return {
+        ok: false,
+        message: `query 过长(上限 ${GHOST_CINDY_SEARCH_MAX_QUERY_CHARS} 字符)`,
+        errorCode: 'INVALID_PARAMS',
+      };
+    }
+    if (
+      p.limit !== undefined &&
+      (typeof p.limit !== 'number' ||
+        !Number.isInteger(p.limit) ||
+        p.limit < 1 ||
+        p.limit > GHOST_CINDY_SEARCH_MAX_RESULTS)
+    ) {
+      return {
+        ok: false,
+        message: `limit 不合法(1–${GHOST_CINDY_SEARCH_MAX_RESULTS} 的整数，或不传)`,
+        errorCode: 'INVALID_PARAMS',
+      };
+    }
+    if (
+      typeof p.callId !== 'string' ||
+      p.callId.length === 0 ||
+      p.callId.length > MAX_CALL_ID_LEN
+    ) {
+      return {
+        ok: false,
+        message: 'callId 不合法(搜索必须透传 1–128 字符的 tool-call 归因号)',
+        errorCode: 'INVALID_PARAMS',
+      };
+    }
+    const callId = p.callId;
+    const searchWeb = this.deps.searchWeb;
+    if (!searchWeb) {
+      return {
+        ok: false,
+        message: '主机当前不支持 Cindy AI 搜索(能力未接线)',
+        errorCode: 'NOT_CONFIGURED',
+      };
+    }
+
+    const inflight = this.inflight.get(ghostId) ?? 0;
+    const inflightLimit = this.deps.getInflightLimit?.(ghostId) ?? null;
+    if (inflightLimit !== null && inflight >= inflightLimit) {
+      return {
+        ok: false,
+        message: `同时进行的代办已达上限(${inflightLimit} 单)，请稍后再试`,
+        errorCode: 'RATE_LIMITED',
+      };
+    }
+
+    this.inflight.set(ghostId, inflight + 1);
+    try {
+      if (this.deps.isOwnerBoundaryPending()) {
+        return {
+          ok: false,
+          message: '账号正在切换，请稍后再试',
+          errorCode: 'UPSTREAM_UNAVAILABLE',
+        };
+      }
+      const ownerScopeKey = this.deps.getOwnerScopeKey();
+      this.deps.log?.info('ghost cindy-request search_web start', {
+        ghostId,
+        callId,
+        logicalProvider: 'cindy',
+      });
+      const outcome = await searchWeb({
+        query,
+        limit: (p.limit as number | undefined) ?? GHOST_CINDY_SEARCH_DEFAULT_RESULTS,
+      });
+      if (
+        this.deps.isOwnerBoundaryPending() ||
+        this.deps.getOwnerScopeKey() !== ownerScopeKey
+      ) {
+        return {
+          ok: false,
+          message: '搜索期间账号已切换，本次结果已丢弃',
+          errorCode: 'UPSTREAM_UNAVAILABLE',
+        };
+      }
+      if (!outcome.ok) {
+        this.deps.log?.warn('ghost cindy-request search_web failed', {
+          ghostId,
+          callId,
+          logicalProvider: 'cindy',
+          errorCode: outcome.errorCode,
+          ...(outcome.status !== undefined ? { status: outcome.status } : {}),
+          ...(outcome.requestId ? { requestId: outcome.requestId } : {}),
+        });
+        return {
+          ok: false,
+          message: outcome.message,
+          errorCode: outcome.errorCode,
+        };
+      }
+      this.deps.log?.info('ghost cindy-request search_web done', {
+        ghostId,
+        callId,
+        logicalProvider: 'cindy',
+        resultCount: outcome.results.length,
+        ...(outcome.webSearchRequests !== undefined
+          ? { webSearchRequests: outcome.webSearchRequests }
+          : {}),
+        ...(outcome.requestId ? { requestId: outcome.requestId } : {}),
+      });
+      return {
+        ok: true,
+        provider: 'cindy',
+        results: outcome.results,
+      };
+    } finally {
+      this.releaseInflight(ghostId);
+    }
   }
 
   /**

--- a/apps/desktop/src/main/cindy-brain/forge.ts
+++ b/apps/desktop/src/main/cindy-brain/forge.ts
@@ -1074,9 +1074,10 @@ my-ghost/
   // 否则请始终声明一个 command。
   "tools": [ /* 见 §3 */ ],
   "cindy": { "image": ["generate", "edit"] },   // 声明了 cindy 槽时必写:能力详单,见下
-  // 三个类目:image / video 的动作是 "generate" | "edit";media 的动作只有
-  // "deposit"(把你手里的媒体字节寄存进总仓换指纹,见 §4.0.1)。按需申请,
-  // 每条都会在装入确认框里单独列给用户看。
+  // 类目按需申请:image / video 的动作是 "generate" | "edit";media 只有
+  // "deposit"(把你手里的媒体字节寄存进总仓换指纹,见 §4.0.1);
+  // text 只有 "oneshot";search 只有 "web"(Cindy 托管公网搜索)。每条都会
+  // 在装入确认框里单独列给用户看。
   "panel": { "title": "面板标题", "html": "panel.html", "position": "left",
              "minWidth": 240, "defaultFraction": 0.24,
              "systemButtons": { "maximize": false } },
@@ -1469,6 +1470,19 @@ const r = await cindy.send({ type: 'cindy-request', kind: 'gen_image', prompt: '
 //     聊天卡片时用它按比例精确声明卡高(见 §4.5),别拿去写进交卷文案。
 // 图像可选画幅 aspectRatio:'1:1' 方图 / '3:2' 横图 / '2:3' 竖图,不传 = 后端自定:
 //   { kind: 'gen_image', prompt: '一只猫', aspectRatio: '3:2' }
+
+// Cindy 托管 Web Search(需声明 cindy.search:["web"]):
+// provider 固定为 cindy,主机固定 Anthropic Messages 搜索模型与上游凭证;
+// 不接受 api_base/header/key/model/tool。
+const search = await cindy.send({
+  type: 'cindy-request',
+  kind: 'search_web',
+  query: 'Cindy 最新版本',
+  limit: 5,                       // 可选,1–10,缺省 5
+  provider: 'cindy',
+  callId: msg.callId,             // 搜索只由 tool-call 触发,必须透传
+});
+// search = { ok:true, provider:'cindy', results:[{ title, url, snippet }] }
 //   比例是意图声明(同 tier 哲学),主机翻译成该模型支持的具体尺寸,真实像素
 //   以返回的 width/height 为准。**图像类专用**(gen_image 与 edit_image 都收;
 //   改图不传 = 跟随源图画幅);视频画幅是另一个参数 ratio,值域不同,带错会被拒。

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -257,6 +257,7 @@ import {
 } from './ghostRecentUsageStore.js';
 import { createXaiImageChannel } from './xaiImageClient.js';
 import { getCindyProxyMediaService } from '../mcp-integrations/cindyProxyMedia.js';
+import { getCindyProxySearchService } from '../mcp-integrations/cindyProxySearch.js';
 import { ImageChannelRegistry, decodeImageResponse } from './imageChannelRegistry.js';
 import { createGeminiImageChannel } from './geminiImageClient.js';
 import { createCodexImageChannel } from './codexImageClient.js';
@@ -2726,6 +2727,10 @@ export function getGhostCindySlot(): GhostCindySlot {
       // 在途并发上限:用户级隐藏配置(ghost-cindy-prefs.json 的 inflightLimits),
       // 缺省 null = 不限并发;每单现读,改配置即生效。
       getInflightLimit: (ghostId) => readGhostCindyInflightLimit(ghostId),
+      // Web Search:固定走主机托管的 LiteLLM /v1/messages。endpoint/key 与
+      // model-access 下发值同源，模型别名和 Claude 原生 Web Search 工具定义
+      // 留在主机侧，意识只拿规范化结果。
+      searchWeb: (params) => getCindyProxySearchService().search(params),
       // 快问快答(text.oneshot):走轻量任务模型链(与会话起标题/任务摘要
       // 同一条,用户在设置里配置)。动态 import:utility-model 的传递依赖在
       // 模块顶层读 electron app 路径,静态引入会把这条链拽进所有 import 本

--- a/apps/desktop/src/main/mcp-integrations/__tests__/cindyProxySearch.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/cindyProxySearch.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildCindySearchUrl,
+  CINDY_SEARCH_MODEL_NAME,
+  createCindyProxySearchService,
+} from '../cindyProxySearch';
+
+function response(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+}
+
+describe('cindyProxySearch', () => {
+  it('supports LiteLLM hosts stored with or without the /v1 suffix', () => {
+    expect(buildCindySearchUrl('https://gateway.example.test')).toBe(
+      'https://gateway.example.test/v1/messages',
+    );
+    expect(buildCindySearchUrl('https://gateway.example.test/v1/')).toBe(
+      'https://gateway.example.test/v1/messages',
+    );
+    expect(buildCindySearchUrl('https://gateway.example.test/v1/messages')).toBe(
+      'https://gateway.example.test/v1/messages',
+    );
+  });
+
+  it('固定调用 cindy/web-search 的 Messages Web Search，并解析工具结果与 citations', async () => {
+    const fetchImpl = vi.fn(async () =>
+      response(
+        {
+          id: 'msg-search-123',
+          usage: { server_tool_use: { web_search_requests: 2 } },
+          content: [
+            {
+              type: 'web_search_tool_result',
+              content: [
+                {
+                  type: 'web_search_result',
+                  title: 'Cindy',
+                  url: 'https://example.test/cindy',
+                },
+                {
+                  type: 'web_search_result',
+                  title: '',
+                  url: 'https://example.test/second',
+                },
+              ],
+            },
+            {
+              type: 'text',
+              text: '搜索结果已整理。',
+              citations: [
+                {
+                  type: 'web_search_result_location',
+                  title: 'Cindy',
+                  url: 'https://example.test/cindy',
+                  cited_text: 'Cindy search result',
+                },
+                {
+                  type: 'web_search_result_location',
+                  title: 'Second',
+                  url: 'https://example.test/second',
+                  cited_text: 'Second search result',
+                },
+                {
+                  type: 'web_search_result_location',
+                  title: 'Citation only',
+                  url: 'https://example.test/citation-only',
+                  cited_text: 'Citation-only result',
+                },
+              ],
+            },
+          ],
+        },
+        { headers: { 'x-litellm-call-id': 'call-123' } },
+      ),
+    ) as unknown as typeof fetch;
+    const service = createCindyProxySearchService({
+      getBaseUrl: () => 'https://gateway.example.test/',
+      getApiKey: () => 'test-key',
+      fetchImpl,
+    });
+
+    const result = await service.search({ query: 'Cindy', limit: 3 });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe('https://gateway.example.test/v1/messages');
+    expect(init).toMatchObject({
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer test-key',
+        'Content-Type': 'application/json',
+        'anthropic-version': '2023-06-01',
+      },
+    });
+    expect(JSON.parse(String(init.body))).toEqual({
+      model: CINDY_SEARCH_MODEL_NAME,
+      max_tokens: 2048,
+      messages: [{ role: 'user', content: 'Cindy' }],
+      tools: [
+        {
+          type: 'web_search_20250305',
+          name: 'web_search',
+          max_uses: 1,
+        },
+      ],
+    });
+    expect(result).toEqual({
+      ok: true,
+      requestId: 'call-123',
+      webSearchRequests: 2,
+      results: [
+        {
+          title: 'Cindy',
+          url: 'https://example.test/cindy',
+          snippet: 'Cindy search result',
+        },
+        {
+          title: 'Second',
+          url: 'https://example.test/second',
+          snippet: 'Second search result',
+        },
+        {
+          title: 'Citation only',
+          url: 'https://example.test/citation-only',
+          snippet: 'Citation-only result',
+        },
+      ],
+    });
+  });
+
+  it('未配置 endpoint/key 时 fail closed，且不发请求', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    for (const [baseUrl, apiKey] of [
+      ['', 'test-key'],
+      ['https://gateway.example.test', null],
+    ] as const) {
+      const service = createCindyProxySearchService({
+        getBaseUrl: () => baseUrl,
+        getApiKey: () => apiKey,
+        fetchImpl,
+      });
+      await expect(service.search({ query: 'Cindy', limit: 5 })).resolves.toMatchObject({
+        ok: false,
+        errorCode: 'NOT_CONFIGURED',
+      });
+    }
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('归一化额度、限流、服务不可用和非法响应错误', async () => {
+    const cases = [
+      { status: 402, body: { error: 'insufficient balance' }, code: 'QUOTA_EXHAUSTED' },
+      { status: 429, body: { error: 'rate limit' }, code: 'RATE_LIMITED' },
+      { status: 503, body: { error: 'unavailable' }, code: 'UPSTREAM_UNAVAILABLE' },
+    ] as const;
+
+    for (const testCase of cases) {
+      const service = createCindyProxySearchService({
+        getBaseUrl: () => 'https://gateway.example.test',
+        getApiKey: () => 'test-key',
+        fetchImpl: vi.fn(async () =>
+          response(testCase.body, { status: testCase.status }),
+        ) as unknown as typeof fetch,
+      });
+      await expect(service.search({ query: 'Cindy', limit: 5 })).resolves.toMatchObject({
+        ok: false,
+        errorCode: testCase.code,
+        status: testCase.status,
+      });
+    }
+
+    const malformed = createCindyProxySearchService({
+      getBaseUrl: () => 'https://gateway.example.test',
+      getApiKey: () => 'test-key',
+      fetchImpl: vi.fn(async () =>
+        response({
+          content: [
+            {
+              type: 'web_search_tool_result',
+              content: [{ type: 'web_search_result', title: 'missing url' }],
+            },
+          ],
+        }),
+      ) as unknown as typeof fetch,
+    });
+    await expect(malformed.search({ query: 'Cindy', limit: 5 })).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'RESPONSE_INVALID',
+    });
+  });
+
+  it('日志只包含状态元数据，不包含 query 或 Authorization', async () => {
+    const info = vi.fn();
+    const warn = vi.fn();
+    const service = createCindyProxySearchService({
+      getBaseUrl: () => 'https://gateway.example.test',
+      getApiKey: () => 'super-secret-test-key',
+      fetchImpl: vi.fn(async () =>
+        response({
+          content: [
+            {
+              type: 'web_search_tool_result',
+              content: [
+                {
+                  type: 'web_search_result',
+                  title: 'Result',
+                  url: 'https://example.test/result',
+                },
+              ],
+            },
+          ],
+        }),
+      ) as unknown as typeof fetch,
+      log: { info, warn },
+    });
+
+    await service.search({ query: 'sensitive user query', limit: 5 });
+
+    const logged = JSON.stringify([info.mock.calls, warn.mock.calls]);
+    expect(logged).not.toContain('sensitive user query');
+    expect(logged).not.toContain('super-secret-test-key');
+  });
+});

--- a/apps/desktop/src/main/mcp-integrations/cindyProxySearch.ts
+++ b/apps/desktop/src/main/mcp-integrations/cindyProxySearch.ts
@@ -1,0 +1,376 @@
+import { getAppCapabilities } from '../appCapabilities.js';
+import { createLogger } from '../logger.js';
+import { effectiveXdGatewayBaseUrl } from '../model-access/effectiveEndpoint.js';
+import { getProviderSecretStore } from '../secrets/providerSecretStore.js';
+import { outboundFetch } from '../maker-host/outbound-fetch.js';
+
+export const CINDY_SEARCH_MODEL_NAME = 'cindy/web-search';
+const CINDY_SEARCH_WEB_TOOL_TYPE = 'web_search_20250305';
+const CINDY_SEARCH_MAX_TOKENS = 2_048;
+const CINDY_SEARCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Join the Anthropic-compatible Messages endpoint for either a gateway root or
+ * a `/v1` base returned by the logged-in Cindy gateway configuration.
+ */
+export function buildCindySearchUrl(baseUrl: string): string {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, '');
+  let pathname = '';
+  try {
+    pathname = new URL(normalizedBaseUrl).pathname.replace(/\/+$/, '');
+  } catch {
+    // The caller validates configured URLs; retaining the old path makes this
+    // helper harmless for injected unit-test values as well.
+  }
+  if (pathname === '/v1/messages' || pathname.endsWith('/v1/messages')) {
+    return normalizedBaseUrl;
+  }
+  const suffix = pathname === '/v1' || pathname.endsWith('/v1') ? '/messages' : '/v1/messages';
+  return `${normalizedBaseUrl}${suffix}`;
+}
+
+export type CindyProxySearchErrorCode =
+  | 'NOT_CONFIGURED'
+  | 'QUOTA_EXHAUSTED'
+  | 'AUTH_REJECTED'
+  | 'RATE_LIMITED'
+  | 'UPSTREAM_UNAVAILABLE'
+  | 'INVALID_PARAMS'
+  | 'RESPONSE_INVALID'
+  | 'INTERNAL';
+
+export interface CindyProxySearchItem {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+export type CindyProxySearchOutcome =
+  | {
+      ok: true;
+      results: CindyProxySearchItem[];
+      requestId?: string;
+      webSearchRequests?: number;
+    }
+  | {
+      ok: false;
+      errorCode: CindyProxySearchErrorCode;
+      message: string;
+      status?: number;
+      requestId?: string;
+    };
+
+export interface CindyProxySearchService {
+  search(params: { query: string; limit: number }): Promise<CindyProxySearchOutcome>;
+}
+
+export interface CindyProxySearchDeps {
+  getBaseUrl(): string;
+  getApiKey(): string | null;
+  fetchImpl: typeof fetch;
+  timeoutMs?: number;
+  log?: {
+    info(message: string, meta?: Record<string, unknown>): void;
+    warn(message: string, meta?: Record<string, unknown>): void;
+  };
+}
+
+function requestIdOf(response: Response): string | undefined {
+  return (
+    response.headers.get('x-litellm-call-id') ?? response.headers.get('x-request-id') ?? undefined
+  );
+}
+
+function classifyHttpFailure(
+  status: number,
+  body: string,
+): { errorCode: CindyProxySearchErrorCode; message: string } {
+  const normalized = body.slice(0, 1024).toLowerCase();
+  const looksLikeQuota =
+    status === 402 ||
+    /(?:quota|credit|balance|insufficient|exhausted|spend limit)/.test(normalized);
+  if (looksLikeQuota) {
+    return {
+      errorCode: 'QUOTA_EXHAUSTED',
+      message: 'Cindy AI 搜索额度不足，请稍后再试或在插件设置中改用自己的搜索渠道',
+    };
+  }
+  if (status === 401 || status === 403) {
+    return {
+      errorCode: 'AUTH_REJECTED',
+      message: 'Cindy AI 搜索鉴权失败，请重新登录或稍后再试',
+    };
+  }
+  if (status === 404) {
+    return {
+      errorCode: 'NOT_CONFIGURED',
+      message: 'Cindy AI 搜索服务尚未配置，请稍后再试',
+    };
+  }
+  if (
+    (status === 400 || status === 422) &&
+    /(?:invalid|unknown|not found|does not exist).{0,80}model|model.{0,80}(?:invalid|unknown|not found|does not exist)/.test(
+      normalized,
+    )
+  ) {
+    return {
+      errorCode: 'NOT_CONFIGURED',
+      message: 'Cindy AI 搜索模型尚未配置，请稍后再试',
+    };
+  }
+  if (status === 429) {
+    return {
+      errorCode: 'RATE_LIMITED',
+      message: 'Cindy AI 搜索请求过于频繁，请稍后再试',
+    };
+  }
+  if (status >= 500) {
+    return {
+      errorCode: 'UPSTREAM_UNAVAILABLE',
+      message: 'Cindy AI 搜索服务暂时不可用，请稍后再试',
+    };
+  }
+  if (status === 400 || status === 422) {
+    return {
+      errorCode: 'INVALID_PARAMS',
+      message: 'Cindy AI 搜索请求参数未被服务接受',
+    };
+  }
+  return {
+    errorCode: 'INTERNAL',
+    message: 'Cindy AI 搜索失败，请稍后再试',
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizedHttpUrl(value: unknown): string | null {
+  if (typeof value !== 'string' || value.trim().length === 0) return null;
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function fallbackTitle(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+interface SearchSource {
+  url: string;
+  title: string;
+  snippet: string;
+}
+
+function sourceFromRecord(value: Record<string, unknown>): SearchSource | null {
+  const url = normalizedHttpUrl(value.url);
+  if (!url) return null;
+  const title =
+    typeof value.title === 'string' && value.title.trim().length > 0
+      ? value.title.trim()
+      : fallbackTitle(url);
+  const snippet =
+    typeof value.cited_text === 'string'
+      ? value.cited_text.trim()
+      : typeof value.snippet === 'string'
+        ? value.snippet.trim()
+        : '';
+  return { url, title, snippet };
+}
+
+function parseSearchResults(raw: unknown, limit: number): CindyProxySearchItem[] | null {
+  if (!isRecord(raw) || !Array.isArray(raw.content)) {
+    return null;
+  }
+
+  const sources = new Map<string, SearchSource>();
+  const mergeSource = (source: SearchSource) => {
+    const existing = sources.get(source.url);
+    if (!existing) {
+      sources.set(source.url, source);
+      return;
+    }
+    if (existing.title === fallbackTitle(existing.url) && source.title !== existing.title) {
+      existing.title = source.title;
+    }
+    if (!existing.snippet && source.snippet) existing.snippet = source.snippet;
+  };
+
+  for (const block of raw.content) {
+    if (!isRecord(block)) continue;
+
+    if (block.type === 'web_search_tool_result' && Array.isArray(block.content)) {
+      for (const item of block.content) {
+        if (!isRecord(item) || item.type !== 'web_search_result') continue;
+        const source = sourceFromRecord(item);
+        if (source) mergeSource(source);
+      }
+    }
+
+    if (block.type === 'text' && Array.isArray(block.citations)) {
+      for (const citation of block.citations) {
+        if (!isRecord(citation)) continue;
+        const source = sourceFromRecord(citation);
+        if (source) mergeSource(source);
+      }
+    }
+  }
+
+  if (sources.size === 0) return null;
+  return Array.from(sources.values()).slice(0, limit);
+}
+
+function webSearchRequestsOf(raw: unknown): number | undefined {
+  if (!isRecord(raw) || !isRecord(raw.usage) || !isRecord(raw.usage.server_tool_use)) {
+    return undefined;
+  }
+  const value = raw.usage.server_tool_use.web_search_requests;
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined;
+}
+
+export function createCindyProxySearchService(deps: CindyProxySearchDeps): CindyProxySearchService {
+  return {
+    async search({ query, limit }): Promise<CindyProxySearchOutcome> {
+      const baseUrl = deps.getBaseUrl().trim().replace(/\/+$/, '');
+      const apiKey = deps.getApiKey();
+      if (!baseUrl || !apiKey) {
+        return {
+          ok: false,
+          errorCode: 'NOT_CONFIGURED',
+          message: 'Cindy AI 搜索尚未就绪，请重新登录或在插件设置中改用自己的搜索渠道',
+        };
+      }
+
+      const startedAt = Date.now();
+      let response: Response;
+      try {
+        response = await deps.fetchImpl(buildCindySearchUrl(baseUrl), {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'anthropic-version': '2023-06-01',
+          },
+          body: JSON.stringify({
+            model: CINDY_SEARCH_MODEL_NAME,
+            max_tokens: CINDY_SEARCH_MAX_TOKENS,
+            messages: [{ role: 'user', content: query }],
+            tools: [
+              {
+                type: CINDY_SEARCH_WEB_TOOL_TYPE,
+                name: 'web_search',
+                max_uses: 1,
+              },
+            ],
+          }),
+          signal: AbortSignal.timeout(deps.timeoutMs ?? CINDY_SEARCH_TIMEOUT_MS),
+        });
+      } catch (error) {
+        const latencyMs = Date.now() - startedAt;
+        deps.log?.warn('cindy search request failed before response', {
+          logicalProvider: 'cindy',
+          upstreamProtocol: 'anthropic-messages',
+          modelAlias: CINDY_SEARCH_MODEL_NAME,
+          latencyMs,
+          error:
+            error instanceof DOMException && error.name === 'TimeoutError'
+              ? 'timeout'
+              : 'network failure',
+        });
+        return {
+          ok: false,
+          errorCode: 'UPSTREAM_UNAVAILABLE',
+          message: 'Cindy AI 搜索服务连接失败，请稍后再试',
+        };
+      }
+
+      const latencyMs = Date.now() - startedAt;
+      const requestId = requestIdOf(response);
+      const body = await response.text();
+      if (!response.ok) {
+        const failure = classifyHttpFailure(response.status, body);
+        deps.log?.warn('cindy search request rejected', {
+          logicalProvider: 'cindy',
+          upstreamProtocol: 'anthropic-messages',
+          modelAlias: CINDY_SEARCH_MODEL_NAME,
+          status: response.status,
+          latencyMs,
+          ...(requestId ? { requestId } : {}),
+          errorCode: failure.errorCode,
+        });
+        return {
+          ok: false,
+          ...failure,
+          status: response.status,
+          ...(requestId ? { requestId } : {}),
+        };
+      }
+
+      let decoded: unknown;
+      try {
+        decoded = JSON.parse(body);
+      } catch {
+        decoded = null;
+      }
+      const results = parseSearchResults(decoded, limit);
+      const webSearchRequests = webSearchRequestsOf(decoded);
+      if (!results) {
+        deps.log?.warn('cindy search returned invalid response', {
+          logicalProvider: 'cindy',
+          upstreamProtocol: 'anthropic-messages',
+          modelAlias: CINDY_SEARCH_MODEL_NAME,
+          status: response.status,
+          latencyMs,
+          ...(requestId ? { requestId } : {}),
+        });
+        return {
+          ok: false,
+          errorCode: 'RESPONSE_INVALID',
+          message: 'Cindy AI 搜索返回了无法识别的结果，请稍后再试',
+          status: response.status,
+          ...(requestId ? { requestId } : {}),
+        };
+      }
+
+      deps.log?.info('cindy search request completed', {
+        logicalProvider: 'cindy',
+        upstreamProtocol: 'anthropic-messages',
+        modelAlias: CINDY_SEARCH_MODEL_NAME,
+        status: response.status,
+        latencyMs,
+        resultCount: results.length,
+        ...(webSearchRequests !== undefined ? { webSearchRequests } : {}),
+        ...(requestId ? { requestId } : {}),
+      });
+      return {
+        ok: true,
+        results,
+        ...(webSearchRequests !== undefined ? { webSearchRequests } : {}),
+        ...(requestId ? { requestId } : {}),
+      };
+    },
+  };
+}
+
+const log = createLogger('search');
+let service: CindyProxySearchService | null = null;
+
+export function getCindyProxySearchService(): CindyProxySearchService {
+  service ??= createCindyProxySearchService({
+    getBaseUrl: () => effectiveXdGatewayBaseUrl(),
+    getApiKey: () =>
+      getAppCapabilities().canUseCindyGateway ? getProviderSecretStore().get('xd') : null,
+    fetchImpl: outboundFetch,
+    log,
+  });
+  return service;
+}

--- a/apps/desktop/src/renderer/cindy-brain/__tests__/GhostPermissionList.test.tsx
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/GhostPermissionList.test.tsx
@@ -121,6 +121,16 @@ describe('GhostPermissionList(装入全量清单)', () => {
     expect(screen.queryByText('settings.ghosts.perm.codeDetail')).toBeNull();
   });
 
+  it('Cindy Web Search 能力在安装权限清单中单独披露', () => {
+    const search: GhostManifest = {
+      ...chip(),
+      cindy: { search: ['web'] },
+    };
+    render(<GhostPermissionList items={ghostPermissionItems(search)} />);
+    expect(screen.getByText('settings.ghosts.perm.cindySearchWeb')).toBeTruthy();
+    expect(screen.getByText('settings.ghosts.perm.cindySearchWebDetail')).toBeTruthy();
+  });
+
   it('Node 持久凭证单独披露明文注入范围', () => {
     const node: GhostManifest = {
       ...chip(),

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3383,6 +3383,8 @@
         "cindyMediaDepositDetail": "This lets AI work on material you paste or drop into the plugin. Saved items are recorded under this plugin, use at most {{quota}}, and are cleaned up when you uninstall it.",
         "cindyTextOneshot": "Can ask Cindy's fast lane a question and receive a text answer",
         "cindyTextOneshotDetail": "Uses the system's lightweight utility model chain (the same lane as auto titles). No Agent involved and no file access. Model charges may apply.",
+        "cindySearchWeb": "Can search the public web with Cindy AI",
+        "cindySearchWebDetail": "Uses Cindy AI by default; you can turn it off in the plugin settings.",
         "agentUserAction": "Can start a new Agent turn after you click a plugin card",
         "agentUserActionDetail": "Each click permits one turn only, and only in the session that owns the card.",
         "agentBackground": "Can automatically start new Agent turns in the background",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3382,6 +3382,8 @@
         "cindyMediaDepositDetail": "プラグイン内で貼り付け・ドロップした素材も AI で加工できるようにするための権限です。保存内容はこのプラグイン名義で記録され、最大 {{quota}} まで使用し、アンインストール時に併せて削除されます。",
         "cindyTextOneshot": "Cindy のクイックチャンネルに質問してテキスト回答を受け取れます",
         "cindyTextOneshotDetail": "システムの軽量タスクモデルチェーン(自動タイトルと同じ経路)を使用します。Agent は使わず、ファイルにもアクセスしません。モデル料金が発生する場合があります。",
+        "cindySearchWeb": "Cindy AI で公開ウェブを検索できます",
+        "cindySearchWebDetail": "既定では Cindy AI を使います。プラグイン設定でオフにできます。",
         "agentUserAction": "プラグインカードをクリックした後、Agent の新しいターンを開始できます",
         "agentUserActionDetail": "1 回のクリックにつき 1 回だけ開始でき、そのカードが属するセッションでのみ使用できます。",
         "agentBackground": "バックグラウンドで Agent の新しいターンを自動的に開始できます",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3382,6 +3382,8 @@
         "cindyMediaDepositDetail": "플러그인에 붙여넣거나 끌어다 놓은 소재도 AI가 편집할 수 있게 하는 권한입니다. 저장된 항목은 이 플러그인 이름으로 기록되며 최대 {{quota}}까지 사용하고, 플러그인을 삭제하면 함께 정리됩니다.",
         "cindyTextOneshot": "Cindy의 빠른 채널에 질문하고 텍스트 답변을 받을 수 있음",
         "cindyTextOneshotDetail": "시스템의 경량 작업 모델 체인(자동 제목과 같은 경로)을 사용합니다. Agent를 사용하지 않고 파일에도 접근하지 않습니다. 모델 비용이 발생할 수 있습니다.",
+        "cindySearchWeb": "Cindy AI로 공개 웹을 검색할 수 있음",
+        "cindySearchWebDetail": "기본적으로 Cindy AI를 사용하며 플러그인 설정에서 끌 수 있습니다.",
         "agentUserAction": "플러그인 카드를 클릭한 뒤 Agent의 새 작업을 시작할 수 있음",
         "agentUserActionDetail": "클릭 한 번마다 한 번만 시작할 수 있으며, 해당 카드가 속한 세션에서만 사용할 수 있습니다.",
         "agentBackground": "백그라운드에서 Agent의 새 작업을 자동으로 시작할 수 있음",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3382,6 +3382,8 @@
         "cindyMediaDepositDetail": "用于让你在插件里粘贴或拖入的素材也能被 AI 加工。存入的内容记在这个插件名下，最多占用 {{quota}}，卸载插件时一并清理。",
         "cindyTextOneshot": "可向 Cindy 的快速通道提问并获得文字回答",
         "cindyTextOneshotDetail": "走系统的轻量任务模型链(与自动起标题同一条通道)，不动用 Agent、碰不到你的文件，可能产生模型费用。",
+        "cindySearchWeb": "可使用 Cindy AI 搜索公网",
+        "cindySearchWebDetail": "默认使用 Cindy AI 搜索，可在插件设置中关闭。",
         "agentUserAction": "用户点击插件卡片后，可让 Agent 开始新一轮工作",
         "agentUserActionDetail": "每次点击只允许启动一次，并且只能使用这张卡所属的任务。",
         "agentBackground": "可在后台自动让 Agent 开始新一轮工作",

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -1425,6 +1425,8 @@ describe('ghost · cindy 能力详单校验(字段旧名 model 别名兼容)', (
       'image',
       { media: ['upload'] }, // media 类目只有 deposit
       { media: [] },
+      { search: ['deep'] },
+      { search: [] },
     ]) {
       const v = validateGhostManifest(chipWithModel(bad));
       expect(v.ok, JSON.stringify(bad)).toBe(false);
@@ -1486,6 +1488,23 @@ describe('ghost · cindy 能力详单校验(字段旧名 model 别名兼容)', (
       media: ['deposit'],
       text: ['oneshot'],
     });
+  });
+
+  it('search 类目落进 cindy.search，并生成独立的 Web Search 权限行', () => {
+    const v = validateGhostManifest(chipWithModel({ search: ['web'] }));
+    expect(v.ok, JSON.stringify(v)).toBe(true);
+    if (!v.ok) return;
+    expect(v.manifest.cindy).toEqual({ search: ['web'] });
+    expect(ghostPermissionItems(v.manifest)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'cindy:search.web',
+          kind: 'cindy',
+          labelKey: 'cindySearchWeb',
+          detailKey: 'cindySearchWebDetail',
+        }),
+      ]),
+    );
   });
 });
 

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -450,6 +450,17 @@ export const GHOST_CINDY_TEXT_ACTIONS = ['oneshot'] as const;
 export type GhostCindyTextAction = (typeof GHOST_CINDY_TEXT_ACTIONS)[number];
 
 /**
+ * cindy 槽·搜索类可申请的动作。
+ *
+ * `web` = Cindy 托管的公网搜索:意识只递查询词与结果数，主机固定走当前
+ * model-access 下发的 XD endpoint + XD user key，通过固定模型别名调用
+ * Anthropic Messages 原生网页搜索，不把网关 key、模型名或工具定义暴露给
+ * 意识。它与 network 槽里的 BYO Brave/Tavily 是两条独立凭证与计费路径。
+ */
+export const GHOST_CINDY_SEARCH_ACTIONS = ['web'] as const;
+export type GhostCindySearchAction = (typeof GHOST_CINDY_SEARCH_ACTIONS)[number];
+
+/**
  * cindy 槽能力详单(卡槽⑤配套,原名模型槽,2026-07-11 设计定案):声明"这个意识被允许
  * 向主机点哪几类代办"——只有类目与动作,**不含任何具体模型/供应商信息**
  * (选型权在主机的解析表:调用时显式点名 > 意识专属覆盖 > 用户能力偏好 >
@@ -464,6 +475,8 @@ export interface GhostCindyNeeds {
   media?: GhostCindyMediaAction[];
   /** 文本类:oneshot=快问快答(轻量任务模型链直答一次,无 agent 无工具)。 */
   text?: GhostCindyTextAction[];
+  /** 搜索类:web=Cindy 托管的公网搜索(主机固定路由，意识不经手网关凭证)。 */
+  search?: GhostCindySearchAction[];
 }
 
 /**
@@ -1532,6 +1545,7 @@ const GHOST_CINDY_PERM_LABEL: Record<string, string> = {
   'video.edit': 'cindyVideoEdit',
   'media.deposit': 'cindyMediaDeposit',
   'text.oneshot': 'cindyTextOneshot',
+  'search.web': 'cindySearchWeb',
 };
 
 /**
@@ -1542,6 +1556,7 @@ const GHOST_CINDY_PERM_LABEL: Record<string, string> = {
 const GHOST_CINDY_PERM_DETAIL: Record<string, string> = {
   'media.deposit': 'cindyMediaDepositDetail',
   'text.oneshot': 'cindyTextOneshotDetail',
+  'search.web': 'cindySearchWebDetail',
 };
 
 /**
@@ -2986,6 +3001,7 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
       video: GHOST_MODEL_VIDEO_ACTIONS,
       media: GHOST_CINDY_MEDIA_ACTIONS,
       text: GHOST_CINDY_TEXT_ACTIONS,
+      search: GHOST_CINDY_SEARCH_ACTIONS,
     };
     for (const [category, actionsRaw] of Object.entries(cindyRaw)) {
       const allowed = actionTable[category];
@@ -3017,13 +3033,15 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
       else if (category === 'video') cindy.video = actions as GhostModelVideoAction[];
       else if (category === 'media') cindy.media = actions as GhostCindyMediaAction[];
       else if (category === 'text') cindy.text = actions as GhostCindyTextAction[];
+      else if (category === 'search') cindy.search = actions as GhostCindySearchAction[];
       else return { ok: false, reason: `cindy 能力类目 ${JSON.stringify(category)} 尚未接线(主机缺陷)` };
     }
     if (
       cindy.image === undefined &&
       cindy.video === undefined &&
       cindy.media === undefined &&
-      cindy.text === undefined
+      cindy.text === undefined &&
+      cindy.search === undefined
     ) {
       return { ok: false, reason: 'cindy 能力详单不能是空对象' };
     }
@@ -5407,6 +5425,11 @@ export const GHOST_ONESHOT_TEXT_DEFAULT_MAX_TOKENS = 1024;
 /** 单次快问快答的等待上限(毫秒;超时按结构化失败收单,不吊管子)。 */
 export const GHOST_ONESHOT_TEXT_TIMEOUT_MS = 60_000;
 
+/** Cindy 托管 Web Search 的请求边界。 */
+export const GHOST_CINDY_SEARCH_MAX_QUERY_CHARS = 2000;
+export const GHOST_CINDY_SEARCH_DEFAULT_RESULTS = 5;
+export const GHOST_CINDY_SEARCH_MAX_RESULTS = 10;
+
 /**
  * 上行:cindy 槽代办请求(请 Cindy 本体出图 / 改图)。协议 type 为
  * 'cindy-request'(2026-07-11 由 'model-request' 更名,主机对旧名保持
@@ -5533,6 +5556,27 @@ export type GhostPipeCindyRequest =
       callId?: string;
       /** 异步模式(同 gen_video 分支)。 */
       mode?: 'submit';
+    }
+  | {
+      /**
+       * Cindy 托管 Web Search:主机固定使用当前 XD endpoint、XD user key
+       * 与内置 Anthropic Messages 搜索模型，不接受意识传入
+       * api_base/header/key/model/tool。
+       * `provider` 固定为 cindy，用于与插件 network 槽的 BYO Brave/Tavily
+       * 明确分账。
+       *
+       * 须声明 'cindy' 卡槽 + `cindy.search: ["web"]`。
+       */
+      type: 'cindy-request';
+      kind: 'search_web';
+      /** 用户原话查询，trim 后 1–2000 字符。 */
+      query: string;
+      /** 结果条数，1–10，缺省 5。 */
+      limit?: number;
+      /** 固定为 cindy；其它值明拒。 */
+      provider: 'cindy';
+      /** 搜索只由 tool-call 触发，必须透传本次 callId 用于账单与日志归因。 */
+      callId: string;
     }
   | {
       type: 'cindy-request';
@@ -5719,13 +5763,25 @@ export type GhostPipeModelResult =
       model?: string;
     }
   | {
+      /** search_web 成功；逻辑 Provider 恒为 cindy，不暴露内部模型路由。 */
+      ok: true;
+      provider: 'cindy';
+      results: Array<{
+        title: string;
+        url: string;
+        snippet: string;
+      }>;
+    }
+  | {
       ok: false;
       message: string;
       /**
        * 结构化错误码(2026-07-31 起 oneshot_text 填写;媒体代办暂只有
        * message)。稳定值:'NO_CANDIDATE'(快速通道无可用模型/凭证)、
        * 'BAD_MODEL_OUTPUT'(expectJson 下输出不可解析)、'RATE_LIMITED'、
-       * 'TIMEOUT'、'PERMISSION_DENIED'、'INVALID_PARAMS'、'INTERNAL'。
+       * 'TIMEOUT'、'PERMISSION_DENIED'、'INVALID_PARAMS'、'INTERNAL'；
+       * search_web 另使用 'NOT_CONFIGURED'、'QUOTA_EXHAUSTED'、
+       * 'AUTH_REJECTED'、'UPSTREAM_UNAVAILABLE'、'RESPONSE_INVALID'。
        */
       errorCode?: string;
     };


### PR DESCRIPTION
## 这次改了什么

### 摘要

为官方 Web Search 插件增加 Cindy Desktop 托管搜索能力。插件声明 `cindy.search: ["web"]` 后，可由宿主固定调用 XD 网关的 `/v1/messages`，使用模型别名 `cindy/web-search` 和 Anthropic 原生 Web Search 工具，并只把规范化搜索结果返回插件。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Cindy Web Search 默认使用 Cindy AI 搜索
- 本 PR 包含：`cindy.search.web` manifest 能力、安装权限披露、`search_web` cindy-request 协议、XD Messages 请求与响应解析、结构化错误和回归测试
- 明确不包含：官方插件包改动（单独 PR）、Codex Responses 兼容或 `responses-chat-bridge` 实验、LiteLLM / AIGateway 代码改动
- 用户可见变化：安装声明该能力的插件时会显示“可使用 Cindy AI 搜索公网”；插件可使用 Cindy AI 额度完成网页搜索
- 是否存在 breaking change：无；已有插件和已有 cindy 能力保持兼容

### UI 变化

仅在现有插件权限清单中增加一条 Cindy Web Search 权限说明，不新增布局或交互模式。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11 Voice & Content；复用现有 `GhostPermissionList` 的权限行结构与四语言 i18n，不引入新的视觉组件

## 怎么验证的

### 自动验证

```text
PATH="$HOME/.proto/tools/node/22.22.3/bin:$PATH" VITE_CINDY_AUTH_REGION=global pnpm test:unit
结果：全部 required workspace 通过，Desktop unit 通过

PATH="$HOME/.proto/tools/node/22.22.3/bin:$PATH" pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:i18n
结果：6689 个 key 一致，无阻断错误

pnpm check:i18n-glossary
结果：无新增违规

pnpm --dir apps/desktop exec vitest run src/main/maker-host/__tests__/providerRoute.test.ts src/main/maker-host/__tests__/codexProxyHost.test.ts src/main/mcp-integrations/__tests__/cindyProxySearch.test.ts
结果：192 tests passed
```

### 手工验证

- macOS CN shared-session remote dev 已启动到 `state=ready`
- 编译产物确认包含 `cindy/web-search`，且已撤回无关的 DeepSeek Chat bridge 实验
- 已确认插件调用可以进入 Cindy 宿主搜索链路并产生结构化日志

### 未执行的验证

- 未在 Windows 实机验证
- `cindy/web-search` 新别名的最终线上 E2E 需随网关模型授权同步后复测；本地 Nova dev 测试 key 当前尚未获得该别名

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅声明 `cindy.search: ["web"]` 的插件；宿主固定掌握 XD endpoint、凭证、模型名和工具定义，插件无法读取网关凭证
- 存量插件影响：无；新增字段为可选能力，旧 manifest 不需要迁移或重新授权
- 发布协调：配套官方插件 PR 应在包含本能力的 Desktop 版本可用后再发布，避免旧客户端无法使用新插件版本
- 回滚 / 降级方式：移除 `cindy.search` 声明和 `search_web` 宿主接线即可；Brave / Tavily BYO 路径不受影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因