### PR TITLE
feat(desktop): steer first pending prompt on empty enter

### DIFF
--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -206,7 +206,7 @@ describe('resolveDevCliFlags', () => {
           });
           expect(viaLink.isolatedDirIsEpochDerived).toBe(true);
         } finally {
-          rmSync(linkAncestor, { force: true });
+          rmSync(linkAncestor, { recursive: true, force: true });
         }
       }
       // TOCTOU 稳定性:目录被并发进程创建前后,同一写法的判定结果一致——

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -370,8 +370,11 @@ export async function clearCodexAuthBoundaryStateBeforeLogin(
  */
 async function tightenAclWindows(file: string): Promise<void> {
   const username = process.env.USERNAME ?? os.userInfo().username;
+  // 本机名和用户名相同时，裸用户名会被 icacls 解析成空用户名（例如 `YOP\\`）。
+  // 进程提供域名时显式限定，确保授权对象仍是当前 Windows 用户。
+  const account = process.env.USERDOMAIN ? `${process.env.USERDOMAIN}\\${username}` : username;
   try {
-    await execFileP('icacls', [file, '/inheritance:r', '/grant:r', `${username}:F`]);
+    await execFileP('icacls', [file, '/inheritance:r', '/grant:r', `${account}:(F)`]);
   } catch (err) {
     log.warn('icacls failed', { file, error: (err as Error).message });
   }

--- a/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSteerShortcut.test.ts
@@ -88,6 +88,34 @@ describe('ChatInput steer shortcut contract', () => {
     );
   });
 
+  it('uses the normal empty-composer Enter shortcut to steer only the first eligible queued message', () => {
+    const queueHeadSteerBlock = extractBetween(
+      chatInputSource,
+      'const steerFirstPendingQueueMessageRef = useRef<() => boolean>(() => false);',
+      '// F-QUEUE-DEFER: when the queue panel is expanded',
+    );
+    const editorEnterBlock = extractBetween(
+      chatInputSource,
+      '// Resolve the configurable send shortcut after structured list handling.',
+      'return false;\n      },\n    },',
+    );
+
+    expect(queueHeadSteerBlock).toContain('const firstPendingMessage = pendingQueueRef.current?.[0];');
+    expect(queueHeadSteerBlock).toContain('getPendingQueueRowPresentation(firstPendingMessage).canSteer');
+    expect(queueHeadSteerBlock).toContain('void steer(firstPendingMessage.clientId);');
+    expect(editorEnterBlock).toContain("voiceInputStateRef.current === 'listening'");
+    expect(editorEnterBlock).toContain('void voiceInputStopAndSendRef.current(enterIntent);');
+    expect(editorEnterBlock).toContain('const hasSendableComposerInput =');
+    expect(editorEnterBlock).toContain('!composerDocIsEmpty(view.state.doc)');
+    expect(editorEnterBlock).toContain('latestAttachmentsRef.current.length > 0');
+    expect(editorEnterBlock).toContain('browserCommentsRef.current.length > 0');
+    expect(editorEnterBlock).toContain('steerFirstPendingQueueMessageRef.current()');
+    expect(editorEnterBlock).toContain('if (!hasSendableComposerInput) {');
+    expect(editorEnterBlock.indexOf('void voiceInputStopAndSendRef.current(enterIntent);')).toBeLessThan(
+      editorEnterBlock.indexOf('steerFirstPendingQueueMessageRef.current()'),
+    );
+  });
+
   it('keeps mode A queue and running-turn steer semantics on the Tiptap path', () => {
     expect(
       resolveComposerEnterIntent(makeEnterEvent(), 'enter', {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -141,6 +141,7 @@ import { focusComposerEndNextFrame, placeGhostAtComposerStart } from './ghostCom
 import { NewGoalDialog } from './NewGoalDialog';
 import { PlanModeIndicator } from './PlanModeIndicator';
 import { PendingQueuePanel } from './PendingQueuePanel';
+import { getPendingQueueRowPresentation } from './pendingQueueRowPresentation';
 import { SendButton } from './SendButton';
 import { FolderPickerPopover, addRecentFolder } from './FolderPickerPopover';
 import { SlashCommandPalette } from './SlashCommandPalette';
@@ -1020,6 +1021,26 @@ export function ChatInput({
   onStopRef.current = onStop;
   const showStopButtonRef = useRef(showStopButton);
   showStopButtonRef.current = showStopButton;
+  // 空 composer 的发送快捷键可以把队首用户消息直接插入当前对话。只允许与
+  // PendingQueuePanel 相同的可插话行，避免把 Orca / 自动化 / 系统触发消息误送进当前轮。
+  const pendingQueueRef = useRef(pendingQueue);
+  pendingQueueRef.current = pendingQueue;
+  const onQueueSteerRef = useRef(onQueueSteer);
+  onQueueSteerRef.current = onQueueSteer;
+  const steerFirstPendingQueueMessageRef = useRef<() => boolean>(() => false);
+  steerFirstPendingQueueMessageRef.current = () => {
+    const firstPendingMessage = pendingQueueRef.current?.[0];
+    const steer = onQueueSteerRef.current;
+    if (
+      !firstPendingMessage ||
+      !steer ||
+      !getPendingQueueRowPresentation(firstPendingMessage).canSteer
+    ) {
+      return false;
+    }
+    void steer(firstPendingMessage.clientId);
+    return true;
+  };
   // F-QUEUE-DEFER: when the queue panel is expanded, esc collapses it
   // BEFORE falling through to the existing stop / history shortcuts. That
   // way the user's mental model stays consistent: esc = "back out of the
@@ -2117,6 +2138,18 @@ export function ChatInput({
             void voiceInputStopAndSendRef.current(enterIntent);
             return true;
           }
+
+          // 只有既有 Enter 处理不需要发送当前输入时，才把它作为空 Enter，尝试
+          // 将队首可插话消息送入当前轮。附件和页面评论都是可发送输入，不能被抢走。
+          const hasSendableComposerInput =
+            !composerDocIsEmpty(view.state.doc) ||
+            latestAttachmentsRef.current.length > 0 ||
+            browserCommentsRef.current.length > 0;
+          if (!hasSendableComposerInput) {
+            steerFirstPendingQueueMessageRef.current();
+            return true;
+          }
+
           void dispatchSendRef.current(enterIntent);
           return true;
         }


### PR DESCRIPTION
## 这次改了什么

### 摘要

空 composer 按发送快捷键时，如果 pending 队首正是鼠标悬停会显示“插入”操作的可插话消息，则将它插入当前对话；队首为 system、Orca 或自动化等不可手动插入消息时不执行，也不会跳过它。

该交互与当前 Codex 已有的行为一致，且已被证明是更好的交互方式。

全量测试还揭示并修复两项既有 Windows 问题：`icacls` 对本机名与用户名相同时会错误授权空用户名；目录 symlink 测试未递归清理链接。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：空输入框 Enter 插入 pending 队首 prompt
- 本 PR 包含：Desktop 队列插话快捷键、其契约测试，以及全量测试发现的 Windows ACL / symlink 测试修复
- 明确不包含：跳过不可插入队首、改变系统 prompt 或队列排序
- 用户可见变化：空输入框按发送快捷键可快速插入队首可插话 pending prompt
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：DESIGN.md「交互与反馈」；不新增视觉元素或文案，复用 PendingQueuePanel 已有的 `canSteer` 资格判定，保留 Light / Dark 既有样式。

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/renderer/__tests__/chatInputSteerShortcut.test.ts src/renderer/__tests__/pendingQueueRowPresentation.test.ts
结果：13 passed

corepack pnpm --filter desktop exec vitest run src/main/__tests__/devCliFlags.test.ts src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
结果：65 passed

pnpm test:unit
结果：全部通过；Desktop 221.3s、Mobile 18.7s、maker-core 90.0s，其余适用 workspace 通过

corepack pnpm --filter desktop typecheck
结果：通过

corepack pnpm check:dco
结果：通过（1 commit signed off）
```

### 手工验证

不涉及：本次未启动 Desktop 进行实机目检；交互资格复用已有队列行判定，并由单测覆盖。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 影响范围：Desktop 空 composer 的发送快捷键；Windows 上 Codex 登录成功后的 `auth.json` ACL。
- 回滚 / 降级方式：回滚本 PR 即恢复原行为；不可插话队首始终保持不插入。ACL 修复只将授权对象准确限定为当前域用户。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因