### PR TITLE
test(pi): 修复图片转发测试模型能力声明

### DIFF
--- a/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-agent.integration.test.ts
@@ -355,6 +355,7 @@ describe.skipIf(!piAvailable)('PiAgent integration (real pi binary + fake gatewa
             contextWindow: 200_000,
             efforts: [],
             defaultEffort: null,
+            supportsImageInput: true,
           },
         ],
       },


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 #1900 合并后暴露的 Pi 图片转发集成测试配置遗漏。共享假模型 `pi-test-model` 会接收图片附件，但没有明确声明图片输入能力，因而被新的 fail-closed guard 在 provider 调用前以 `PI_IMAGE_INPUT_UNSUPPORTED` 拒绝。

本 PR 只为该测试模型补充 `supportsImageInput: true`，不修改运行时代码或用户行为。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1900 合并后的测试回归
- 本 PR 包含：为图片转发集成测试使用的 `pi-test-model` 声明图片输入能力
- 明确不包含：Pi 运行时能力判断、Desktop 分享图片链路、其它测试 fixture
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/pi/__tests__/pi-agent.integration.test.ts -t 'forwards an image attachment through pi to the gateway'
结果：1 passed

bash -c '清除 CLAUDE* 环境变量后执行 pnpm test:unit'
结果：全部通过；Maker Core unit 通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：该 package 无 typecheck script，按仓库门禁自动跳过
```

### 手工验证

不涉及。

### 未执行的验证

`pnpm --filter @cindy/maker-core build` 未通过。失败均为上游现有测试类型错误，位于 Claude Code、Codex 与 Pi auto-review 测试文件；本 PR 唯一改动文件没有新增类型错误。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Maker Core Pi 集成测试 fixture
- 回滚 / 降级方式：回退本 PR 的单行测试能力声明

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档）
- [x] 已确认测试结果或说明未执行原因
