### PR TITLE
feat(im): Telegram 群消息全文入库与游标持久化

### DIFF
--- a/apps/desktop/drizzle/0086_orange_surge.sql
+++ b/apps/desktop/drizzle/0086_orange_surge.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `hook_group_context_cursors` (
+	`provider` text NOT NULL,
+	`cursor_key` text NOT NULL,
+	`cursor_id` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`provider`, `cursor_key`)
+);

--- a/apps/desktop/drizzle/meta/0086_snapshot.json
+++ b/apps/desktop/drizzle/meta/0086_snapshot.json
@@ -1,0 +1,3890 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cb0166d9-e42c-4135-8658-f291594a7c81",
+  "prevId": "daddbf8c-2d5f-48e4-8f12-f760511b47fa",
+  "tables": {
+    "account_usage_snapshots": {
+      "name": "account_usage_snapshots",
+      "columns": {
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_input_queue_snapshots": {
+      "name": "agent_input_queue_snapshots",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_input_queue_snapshots_session_id_sessions_id_fk": {
+          "name": "agent_input_queue_snapshots_session_id_sessions_id_fk",
+          "tableFrom": "agent_input_queue_snapshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_mcp_servers": {
+      "name": "custom_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_mcp_servers_sort_order": {
+          "name": "idx_custom_mcp_servers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtimes": {
+          "name": "runtimes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_providers_sort_order": {
+          "name": "idx_custom_providers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_model_usage": {
+      "name": "daily_model_usage",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_model_usage_day_agent_kind_model_cost_currency_pk": {
+          "columns": [
+            "day",
+            "agent_kind",
+            "model",
+            "cost_currency"
+          ],
+          "name": "daily_model_usage_day_agent_kind_model_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_spend": {
+      "name": "daily_spend",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_spend_day_cost_currency_pk": {
+          "columns": [
+            "day",
+            "cost_currency"
+          ],
+          "name": "daily_spend_day_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_link_ownership": {
+      "name": "device_link_ownership",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_pid": {
+          "name": "owner_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_label": {
+          "name": "owner_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_jobs": {
+      "name": "embedding_jobs",
+      "columns": {
+        "rowid": {
+          "name": "rowid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_embedding_jobs_natural": {
+          "name": "uniq_embedding_jobs_natural",
+          "columns": [
+            "source",
+            "source_id",
+            "chunk_index",
+            "model_id"
+          ],
+          "isUnique": true
+        },
+        "idx_embedding_jobs_status_scheduled": {
+          "name": "idx_embedding_jobs_status_scheduled",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_embedding_jobs_source_id": {
+          "name": "idx_embedding_jobs_source_id",
+          "columns": [
+            "source",
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_meta": {
+      "name": "embedding_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ghost_cards": {
+      "name": "ghost_cards",
+      "columns": {
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ghost_id": {
+          "name": "ghost_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v": {
+          "name": "v",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ghost_cards_updated_at_idx": {
+          "name": "ghost_cards_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_context_cursors": {
+      "name": "hook_group_context_cursors",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_key": {
+          "name": "cursor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "hook_group_context_cursors_provider_cursor_key_pk": {
+          "columns": [
+            "provider",
+            "cursor_key"
+          ],
+          "name": "hook_group_context_cursors_provider_cursor_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_messages": {
+      "name": "hook_group_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_names": {
+          "name": "file_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_messages_msg_idx": {
+          "name": "hook_group_messages_msg_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "hook_group_messages_window_idx": {
+          "name": "hook_group_messages_window_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "im_bindings": {
+      "name": "im_bindings",
+      "columns": {
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_context_id": {
+          "name": "bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_via_card_message_id": {
+          "name": "attached_via_card_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_im_bindings_target": {
+          "name": "idx_im_bindings_target",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_target_session_id_sessions_id_fk": {
+          "name": "im_bindings_target_session_id_sessions_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "im_bindings_channel_bot_context_id_user_id_scope_key_pk": {
+          "columns": [
+            "channel",
+            "bot_context_id",
+            "user_id",
+            "scope_key"
+          ],
+          "name": "im_bindings_channel_bot_context_id_user_id_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_blobs": {
+      "name": "media_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_cache": {
+          "name": "is_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_access_at": {
+          "name": "last_access_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_refs": {
+      "name": "media_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_refs_hash_idx": {
+          "name": "media_refs_hash_idx",
+          "columns": [
+            "hash"
+          ],
+          "isUnique": false
+        },
+        "media_refs_ref_idx": {
+          "name": "media_refs_ref_idx",
+          "columns": [
+            "ref_kind",
+            "ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_refs_hash_media_blobs_hash_fk": {
+          "name": "media_refs_hash_media_blobs_hash_fk",
+          "tableFrom": "media_refs",
+          "tableTo": "media_blobs",
+          "columnsFrom": [
+            "hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_meta": {
+          "name": "agent_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewind_at": {
+          "name": "rewind_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_messages_session_client": {
+          "name": "uniq_messages_session_client",
+          "columns": [
+            "session_id",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_messages_session_created": {
+          "name": "idx_messages_session_created",
+          "columns": [
+            "session_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_created_at": {
+          "name": "idx_messages_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_rewind_at": {
+          "name": "idx_messages_rewind_at",
+          "columns": [
+            "rewind_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_history": {
+      "name": "migration_history",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_meta": {
+      "name": "migration_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_teams": {
+      "name": "orca_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_session_id": {
+          "name": "lead_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_active_team_per_lead": {
+          "name": "uniq_active_team_per_lead",
+          "columns": [
+            "lead_session_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_teams\".\"status\" = 'active'"
+        },
+        "idx_orca_teams_status": {
+          "name": "idx_orca_teams_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_teams_lead_session_id_sessions_id_fk": {
+          "name": "orca_teams_lead_session_id_sessions_id_fk",
+          "tableFrom": "orca_teams",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "lead_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_worker_creation_reservations": {
+      "name": "orca_worker_creation_reservations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_worker_creation_reservations_team_label": {
+          "name": "uniq_orca_worker_creation_reservations_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "idx_orca_worker_creation_reservations_expires_at": {
+          "name": "idx_orca_worker_creation_reservations_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_worker_creation_reservations_team_id_orca_teams_id_fk": {
+          "name": "orca_worker_creation_reservations_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_worker_creation_reservations",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_workers": {
+      "name": "orca_workers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'developer'"
+        },
+        "focused": {
+          "name": "focused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "idle_since": {
+          "name": "idle_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_workers_session_id": {
+          "name": "uniq_orca_workers_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_team_label": {
+          "name": "uniq_orca_workers_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_focused_per_team": {
+          "name": "uniq_orca_workers_focused_per_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_workers\".\"focused\" = true"
+        },
+        "idx_orca_workers_team_id": {
+          "name": "idx_orca_workers_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orca_workers_status": {
+          "name": "idx_orca_workers_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_workers_team_id_orca_teams_id_fk": {
+          "name": "orca_workers_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "orca_workers_session_id_sessions_id_fk": {
+          "name": "orca_workers_session_id_sessions_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_aliases": {
+      "name": "project_aliases",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_aliases_updated_at": {
+          "name": "idx_project_aliases_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_automation_consents": {
+      "name": "project_automation_consents",
+      "columns": {
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recent_workdirs": {
+      "name": "recent_workdirs",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recent_workdirs_last_used_at": {
+          "name": "idx_recent_workdirs_last_used_at",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "right_sidebar_tabs": {
+      "name": "right_sidebar_tabs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "right_sidebar_tabs_session_idx": {
+          "name": "right_sidebar_tabs_session_idx",
+          "columns": [
+            "session_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "right_sidebar_tabs_session_id_sessions_id_fk": {
+          "name": "right_sidebar_tabs_session_id_sessions_id_fk",
+          "tableFrom": "right_sidebar_tabs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_runs": {
+      "name": "schedule_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_msg": {
+          "name": "error_msg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_usd": {
+          "name": "estimated_value_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_amount": {
+          "name": "estimated_value_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_attribution": {
+          "name": "cost_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "result_text": {
+          "name": "result_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_result": {
+          "name": "pre_run_hook_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_runs_schedule": {
+          "name": "idx_schedule_runs_schedule",
+          "columns": [
+            "schedule_id",
+            "fired_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_runs_schedule_id_schedules_id_fk": {
+          "name": "schedule_runs_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_runs_session_id_sessions_id_fk": {
+          "name": "schedule_runs_session_id_sessions_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prompt'"
+        },
+        "job_config": {
+          "name": "job_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "script_config": {
+          "name": "script_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "project_config_id": {
+          "name": "project_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_session_fallback": {
+          "name": "legacy_session_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cron'"
+        },
+        "cron_expr": {
+          "name": "cron_expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "manual": {
+          "name": "manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persistent_session": {
+          "name": "persistent_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "silent_when_idle": {
+          "name": "silent_when_idle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pre_run_hook_command": {
+          "name": "pre_run_hook_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_timeout_ms": {
+          "name": "pre_run_hook_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_log_session_id": {
+          "name": "skip_log_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_desktop": {
+          "name": "notify_desktop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_feishu": {
+          "name": "notify_feishu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_wecom_group": {
+          "name": "notify_wecom_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_finished_at": {
+          "name": "last_finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_fire_at": {
+          "name": "next_fire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedules_active_next": {
+          "name": "idx_schedules_active_next",
+          "columns": [
+            "status",
+            "next_fire_at"
+          ],
+          "isUnique": false
+        },
+        "idx_schedules_target_session": {
+          "name": "idx_schedules_target_session",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_target_session_id_sessions_id_fk": {
+          "name": "schedules_target_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedules_skip_log_session_id_sessions_id_fk": {
+          "name": "schedules_skip_log_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "skip_log_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_goals": {
+      "name": "session_goals",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "budget_tokens": {
+          "name": "budget_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_progress_limit": {
+          "name": "no_progress_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turns_used": {
+          "name": "turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "no_progress_streak": {
+          "name": "no_progress_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "usage_reset_at": {
+          "name": "usage_reset_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_goals_status": {
+          "name": "idx_session_goals_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_goals_session_id_sessions_id_fk": {
+          "name": "session_goals_session_id_sessions_id_fk",
+          "tableFrom": "session_goals",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_pr_refs": {
+      "name": "session_pr_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_session_pr_refs": {
+          "name": "uniq_session_pr_refs",
+          "columns": [
+            "session_id",
+            "owner",
+            "repo",
+            "pr_number"
+          ],
+          "isUnique": true
+        },
+        "idx_session_pr_refs_session_last_seen": {
+          "name": "idx_session_pr_refs_session_last_seen",
+          "columns": [
+            "session_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_pr_refs_session_id_sessions_id_fk": {
+          "name": "session_pr_refs_session_id_sessions_id_fk",
+          "tableFrom": "session_pr_refs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Maker'"
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-sonnet-4-6'"
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'high'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_token_usage": {
+          "name": "total_token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_amount": {
+          "name": "total_cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_currency": {
+          "name": "total_cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_is_approximate": {
+          "name": "total_cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "plan_mode_enabled": {
+          "name": "plan_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_send_at": {
+          "name": "user_send_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cc'"
+        },
+        "orca_role": {
+          "name": "orca_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_at_message_id": {
+          "name": "forked_at_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "feishu_open_id": {
+          "name": "feishu_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_bot_app_id": {
+          "name": "feishu_bot_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_bot_context_id": {
+          "name": "im_bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_user_id": {
+          "name": "im_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_project_context": {
+          "name": "used_project_context",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_history_has_product_prompt": {
+          "name": "codex_history_has_product_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_dirs": {
+          "name": "extra_dirs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "remote_host_id": {
+          "name": "remote_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_started_at": {
+          "name": "active_turn_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_pid": {
+          "name": "active_turn_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_turn_ended_at": {
+          "name": "last_turn_ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_updated_at": {
+          "name": "idx_sessions_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_user_send_at": {
+          "name": "idx_sessions_user_send_at",
+          "columns": [
+            "user_send_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_sdk_session_id": {
+          "name": "idx_sessions_sdk_session_id",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workdir_created": {
+          "name": "idx_sessions_workdir_created",
+          "columns": [
+            "working_dir",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_created_at": {
+          "name": "idx_sessions_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workspace_kind": {
+          "name": "idx_sessions_workspace_kind",
+          "columns": [
+            "workspace_kind"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_parent_session_id": {
+          "name": "idx_sessions_parent_session_id",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_orca_role": {
+          "name": "idx_sessions_orca_role",
+          "columns": [
+            "orca_role"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_worktree_path": {
+          "name": "idx_sessions_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_feishu_lookup": {
+          "name": "idx_sessions_feishu_lookup",
+          "columns": [
+            "source",
+            "feishu_bot_app_id",
+            "feishu_open_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_im_lookup": {
+          "name": "idx_sessions_im_lookup",
+          "columns": [
+            "source",
+            "im_bot_context_id",
+            "im_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_exposures": {
+      "name": "skill_usage_exposures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_line_no": {
+          "name": "raw_line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_path": {
+          "name": "skill_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_document_hash": {
+          "name": "skill_document_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exposure_content_hash": {
+          "name": "exposure_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_hash_source": {
+          "name": "document_hash_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repeated_tool_call_count": {
+          "name": "repeated_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_error_count": {
+          "name": "tool_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_call_count": {
+          "name": "command_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_failure_count": {
+          "name": "command_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_exposures_skill_document_version": {
+          "name": "idx_skill_usage_exposures_skill_document_version",
+          "columns": [
+            "analyzer_version",
+            "skill_name",
+            "skill_document_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_session": {
+          "name": "idx_skill_usage_exposures_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_raw_file": {
+          "name": "idx_skill_usage_exposures_raw_file",
+          "columns": [
+            "raw_file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk": {
+          "name": "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk",
+          "tableFrom": "skill_usage_exposures",
+          "tableTo": "skill_usage_sources",
+          "columnsFrom": [
+            "raw_file_path"
+          ],
+          "columnsTo": [
+            "raw_file_path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_sources": {
+      "name": "skill_usage_sources",
+      "columns": {
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mtime_ms": {
+          "name": "mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_sources_session": {
+          "name": "idx_skill_usage_sources_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_sources_sdk_session": {
+          "name": "idx_skill_usage_sources_sdk_session",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vec_table_meta": {
+      "name": "vec_table_meta",
+      "columns": {
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dim": {
+          "name": "dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_file_attachments": {
+      "name": "wechat_file_attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abs_path": {
+          "name": "abs_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'staged'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wechat_file_attachments_task": {
+          "name": "idx_wechat_file_attachments_task",
+          "columns": [
+            "binding_epoch",
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_file_attachments_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_session_id_sessions_id_fk": {
+          "name": "wechat_file_attachments_session_id_sessions_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_inbox": {
+      "name": "wechat_inbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_seq": {
+          "name": "platform_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_created_at": {
+          "name": "platform_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_epoch": {
+          "name": "conversation_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_nonce": {
+          "name": "context_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_ciphertext": {
+          "name": "context_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_tag": {
+          "name": "context_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_inbox_platform_message": {
+          "name": "uniq_wechat_inbox_platform_message",
+          "columns": [
+            "binding_epoch",
+            "platform_message_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_inbox_queue": {
+          "name": "idx_wechat_inbox_queue",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_lease": {
+          "name": "idx_wechat_inbox_lease",
+          "columns": [
+            "binding_epoch",
+            "lease_until"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_conversation": {
+          "name": "idx_wechat_inbox_conversation",
+          "columns": [
+            "binding_epoch",
+            "peer_id",
+            "conversation_epoch"
+          ],
+          "isUnique": false
+        },
+        "uniq_wechat_inbox_running_session": {
+          "name": "uniq_wechat_inbox_running_session",
+          "columns": [
+            "binding_epoch",
+            "session_id"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_inbox\".\"session_id\" IS NOT NULL AND \"wechat_inbox\".\"status\" IN ('dispatching', 'accepted_running', 'waiting_desktop', 'delivery_pending')"
+        }
+      },
+      "foreignKeys": {
+        "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_inbox_session_id_sessions_id_fk": {
+          "name": "wechat_inbox_session_id_sessions_id_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_outbox": {
+      "name": "wechat_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_json": {
+          "name": "media_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_outbox_client_id": {
+          "name": "uniq_wechat_outbox_client_id",
+          "columns": [
+            "binding_epoch",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_outbox_delivery": {
+          "name": "idx_wechat_outbox_delivery",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_outbox_task": {
+          "name": "idx_wechat_outbox_task",
+          "columns": [
+            "binding_epoch",
+            "task_id",
+            "chunk_index"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_outbox_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_outbox_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_sync_state": {
+      "name": "wechat_sync_state",
+      "columns": {
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_poll_at": {
+          "name": "last_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_sync_active": {
+          "name": "uniq_wechat_sync_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_sync_state\".\"is_active\" = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_orca_worker_creation_reservations_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "uniq_orca_workers_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/drizzle/meta/_journal.json
+++ b/apps/desktop/drizzle/meta/_journal.json
@@ -603,6 +603,13 @@
       "when": 1785574922980,
       "tag": "0085_skinny_iron_man",
       "breakpoints": true
+    },
+    {
+      "idx": 86,
+      "version": "6",
+      "when": 1786019953044,
+      "tag": "0086_orange_surge",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -1052,7 +1052,9 @@ async function teardownAuthAccountBoundary(reason: string): Promise<void> {
   } catch (err) {
     authBoundaryLog.error(`stopHookControlAccount on ${reason} failed (non-fatal):`, err);
   } finally {
-    resetHookControlOwnerBoundary();
+    // Auth/runtime boundaries keep durable group cursors for a later relogin;
+    // only explicit account deletion is a data-removal boundary.
+    resetHookControlOwnerBoundary({ clearPersisted: reason === 'account-deletion' });
   }
   // Every Ghost sandbox can retain live OAuth, subscription, or in-memory
   // state. Stop them before changing owners; resident Ghosts are recreated by

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -423,7 +423,7 @@ describe('dispatcher 核心语义', () => {
     });
   });
 
-  it('切账号清排队时按提交逆序回滚未开始任务的群游标', async () => {
+  it('切账号清排队时不提交未开始任务的群游标', async () => {
     const fr = fakeRunner();
     const rollbacks: string[] = [];
     let commitCount = 0;
@@ -461,7 +461,8 @@ describe('dispatcher 核心语义', () => {
     fr.finish({ finalText: '旧账号任务' });
     await draining;
 
-    expect(rollbacks).toEqual(['commit-3', 'commit-2']);
+    expect(commitCount).toBe(1);
+    expect(rollbacks).toEqual([]);
   });
 
   it('收口期间的重新激活会被后到的关闭请求作废', async () => {
@@ -1695,6 +1696,47 @@ describe('dispatcher 核心语义', () => {
       ['a', 'A'],
       ['b', 'B'],
       ['c', 'C'],
+    ]);
+  });
+
+  it('排队任务只在真正开始时 commit, 取消队列前项不丢后项上下文', async () => {
+    const fr = fakeRunner();
+    const committed: string[] = [];
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      buildContextPrefix: async (payload) => ({
+        prefix: '<group_chat_context>背景</group_chat_context>',
+        commit: () => {
+          committed.push(payload.requestId);
+        },
+      }),
+    });
+    const c = collector();
+    const externalKey = 'telegram:group:bot:-900:9:g0';
+
+    d.handleDispatch('conn-1', dispatch({ requestId: 'running', externalKey }), c.send);
+    await tick();
+    d.handleDispatch('conn-1', dispatch({ requestId: 'queued-a', externalKey }), c.send);
+    await tick();
+    d.handleDispatch('conn-1', dispatch({ requestId: 'queued-b', externalKey }), c.send);
+    await tick();
+
+    expect(committed).toEqual(['running']);
+    d.cancel('conn-1', 'queued-a');
+    await tick();
+    expect(committed).toEqual(['running']);
+
+    fr.finish({ finalText: 'running done' });
+    await tick();
+    expect(fr.calls).toHaveLength(2);
+    expect(committed).toEqual(['running', 'queued-b']);
+
+    fr.finish({ finalText: 'queued b done' });
+    await tick();
+    expect(c.ofType('turn.end').map((m) => m.payload.requestId)).toEqual([
+      'queued-a',
+      'running',
+      'queued-b',
     ]);
   });
 

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -423,7 +423,7 @@ describe('dispatcher 核心语义', () => {
     });
   });
 
-  it('切账号清排队时不提交未开始任务的群游标', async () => {
+  it('切账号清排队时不提交未受理群游标，并为已 queued 任务补 cancelled 终态', async () => {
     const fr = fakeRunner();
     const rollbacks: string[] = [];
     let commitCount = 0;
@@ -443,10 +443,11 @@ describe('dispatcher 核心语义', () => {
       }),
     });
     const c = collector();
-    const externalKey = 'team-slack:C1:1.1';
+    const externalKey = 'telegram:group:bot:-900:9:g0';
 
     d.handleDispatch('conn-1', dispatch({ requestId: 'running', externalKey }), c.send);
     await tick();
+    await fr.calls[0]?.onProviderAccepted?.();
     d.handleDispatch('conn-1', dispatch({ requestId: 'queued-1', externalKey }), c.send);
     await tick();
     d.handleDispatch('conn-1', dispatch({ requestId: 'queued-2', externalKey }), c.send);
@@ -463,6 +464,12 @@ describe('dispatcher 核心语义', () => {
 
     expect(commitCount).toBe(1);
     expect(rollbacks).toEqual([]);
+    expect(
+      c.ofType('turn.end').map((message) => [message.payload.requestId, message.payload.status]),
+    ).toEqual([
+      ['queued-1', 'cancelled'],
+      ['queued-2', 'cancelled'],
+    ]);
   });
 
   it('收口期间的重新激活会被后到的关闭请求作废', async () => {
@@ -1716,6 +1723,7 @@ describe('dispatcher 核心语义', () => {
 
     d.handleDispatch('conn-1', dispatch({ requestId: 'running', externalKey }), c.send);
     await tick();
+    await fr.calls[0]?.onProviderAccepted?.();
     d.handleDispatch('conn-1', dispatch({ requestId: 'queued-a', externalKey }), c.send);
     await tick();
     d.handleDispatch('conn-1', dispatch({ requestId: 'queued-b', externalKey }), c.send);
@@ -1729,6 +1737,7 @@ describe('dispatcher 核心语义', () => {
     fr.finish({ finalText: 'running done' });
     await tick();
     expect(fr.calls).toHaveLength(2);
+    await fr.calls[1]?.onProviderAccepted?.();
     expect(committed).toEqual(['running', 'queued-b']);
 
     fr.finish({ finalText: 'queued b done' });
@@ -1740,280 +1749,152 @@ describe('dispatcher 核心语义', () => {
     ]);
   });
 
-  it('群游标 commit 返回后账号代次失效时回滚且不确认受理', async () => {
-    let beginDeactivation: () => Promise<void> = async () => undefined;
-    let deactivation: Promise<void> | null = null;
+  it('已出队但 provider 未受理的群任务在切账号时 cancelled 且不提交游标', async () => {
+    const committed: string[] = [];
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      abortSession: async () => undefined,
+      buildContextPrefix: async (payload) => ({
+        prefix: '<group_chat_context>背景</group_chat_context>',
+        commit: async () => {
+          committed.push(payload.requestId);
+        },
+      }),
+    });
+    const c = collector();
+    const externalKey = 'telegram:group:bot:-900:9:g0';
+
+    d.handleDispatch('conn-1', dispatch({ requestId: 'running', externalKey }), c.send);
+    await tick();
+    await fr.calls[0]?.onProviderAccepted?.();
+    d.handleDispatch('conn-1', dispatch({ requestId: 'queued-inflight', externalKey }), c.send);
+    await tick();
+
+    fr.finish({ finalText: 'running done' });
+    await tick();
+    expect(fr.calls).toHaveLength(2);
+    expect(committed).toEqual(['running']);
+
+    const draining = d.deactivateAccount();
+    await tick();
+    expect(
+      c.ofType('turn.end').find((message) => message.payload.requestId === 'queued-inflight')
+        ?.payload,
+    ).toMatchObject({ status: 'cancelled' });
+
+    fr.finish({ finalText: 'must not cross account boundary' });
+    await draining;
+    expect(committed).toEqual(['running']);
+  });
+
+  it('直达任务 provider 未受理前账号失效不提交游标，并补 cancelled 终态', async () => {
     const rollback = vi.fn(async () => undefined);
+    const commit = vi.fn(async () => ({ rollback }));
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      abortSession: async () => undefined,
+      buildContextPrefix: async () => ({
+        prefix: '<group_chat_context>背景</group_chat_context>',
+        commit,
+      }),
+    });
+    const c = collector();
+
+    d.handleDispatch(
+      'conn-1',
+      dispatch({ requestId: 'not-accepted', externalKey: 'telegram:group:bot:-900:9:g0' }),
+      c.send,
+    );
+    await tick();
+    expect(c.last('task.ack')?.payload.result).toBe('accepted');
+    expect(fr.calls).toHaveLength(1);
+    expect(commit).not.toHaveBeenCalled();
+
+    const draining = d.deactivateAccount();
+    fr.finish({ finalText: '旧账号任务' });
+    await draining;
+
+    expect(commit).not.toHaveBeenCalled();
+    expect(rollback).not.toHaveBeenCalled();
+    expect(
+      c.ofType('turn.end').filter((message) => message.payload.requestId === 'not-accepted'),
+    ).toHaveLength(1);
+    expect(
+      c.ofType('turn.end').find((message) => message.payload.requestId === 'not-accepted')?.payload,
+    ).toMatchObject({ status: 'cancelled' });
+  });
+
+  it('直达任务只在 provider 受理后提交一次群游标', async () => {
+    const commit = vi.fn(async () => undefined);
     const fr = fakeRunner();
     const { d } = makeDispatcher({
       runner: fr.runner,
       buildContextPrefix: async () => ({
         prefix: '<group_chat_context>背景</group_chat_context>',
-        commit: async () => {
-          // commit 已完成；让账号边界微任务先于 dispatcher 的 await continuation
-          // 失效，钉住“返回后、ACK 前”的窄竞态。
-          queueMicrotask(() => {
-            deactivation = beginDeactivation();
-          });
-          return { rollback };
-        },
+        commit,
       }),
     });
-    beginDeactivation = () => d.deactivateAccount();
     const c = collector();
 
     d.handleDispatch(
       'conn-1',
-      dispatch({ requestId: 'stale-commit', externalKey: 'telegram:group:bot:-900:9:g0' }),
+      dispatch({ requestId: 'accepted-once', externalKey: 'telegram:group:bot:-900:9:g0' }),
       c.send,
     );
-    for (let i = 0; i < 30 && deactivation === null; i += 1) await Promise.resolve();
-    expect(deactivation).not.toBeNull();
-    await deactivation!;
     await tick();
+    expect(commit).not.toHaveBeenCalled();
 
-    expect(rollback).toHaveBeenCalledTimes(1);
-    expect(c.ofType('task.ack')).toHaveLength(0);
-    expect(fr.calls).toHaveLength(0);
+    await fr.calls[0]?.onProviderAccepted?.();
+    expect(commit).toHaveBeenCalledTimes(1);
+
+    fr.finish({ finalText: 'done' });
+    await tick();
+    expect(c.last('turn.end')?.payload).toMatchObject({
+      requestId: 'accepted-once',
+      status: 'ok',
+    });
   });
 
-  it('直达受理的游标补偿失败时保留 admission，恢复后才结束账号边界', async () => {
-    vi.useFakeTimers();
-    try {
-      let beginDeactivation: () => Promise<void> = async () => undefined;
-      let deactivation: Promise<void> | null = null;
-      let rollbackAttempts = 0;
-      const log = { info: vi.fn(), warn: vi.fn() };
-      const rollback = vi.fn(async () => {
-        rollbackAttempts += 1;
-        if (rollbackAttempts === 1) throw new Error('sqlite busy');
-      });
-      const fr = fakeRunner();
-      const { d } = makeDispatcher({
-        runner: fr.runner,
-        log,
-        buildContextPrefix: async () => ({
-          prefix: '<group_chat_context>背景</group_chat_context>',
-          commit: async () => {
-            queueMicrotask(() => {
-              deactivation = beginDeactivation();
-            });
-            return { rollback };
-          },
-        }),
-      });
-      beginDeactivation = () => d.deactivateAccount();
-      const c = collector();
+  it('provider 受理后的群游标持久化失败不反转任务，旧游标留待下次重带', async () => {
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const commit = vi.fn(async () => {
+      throw new Error('database is readonly');
+    });
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      log,
+      buildContextPrefix: async () => ({
+        prefix: '<group_chat_context>背景</group_chat_context>',
+        commit,
+      }),
+    });
+    const c = collector();
 
-      d.handleDispatch(
-        'conn-1',
-        dispatch({ requestId: 'accepted-recovery', externalKey: 'telegram:group:bot:-900:9:g0' }),
-        c.send,
-      );
-      for (let i = 0; i < 30 && rollbackAttempts === 0; i += 1) await Promise.resolve();
-      expect(deactivation).not.toBeNull();
-      expect(rollback).toHaveBeenCalledTimes(1);
+    d.handleDispatch(
+      'conn-1',
+      dispatch({ requestId: 'persist-failed', externalKey: 'telegram:group:bot:-900:9:g0' }),
+      c.send,
+    );
+    await tick();
+    await fr.calls[0]?.onProviderAccepted?.();
 
-      let deactivated = false;
-      void deactivation!.then(() => {
-        deactivated = true;
-      });
-      await tick();
-      expect(deactivated).toBe(false);
-      expect(c.ofType('task.ack')).toHaveLength(0);
-      expect(fr.calls).toHaveLength(0);
+    expect(commit).toHaveBeenCalledTimes(1);
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'group context cursor commit failed after provider acceptance: requestId=persist-failed',
+      ),
+    );
 
-      await vi.advanceTimersByTimeAsync(25);
-      await deactivation!;
-      expect(rollback).toHaveBeenCalledTimes(2);
-      expect(deactivated).toBe(true);
-      expect(log.warn).toHaveBeenCalledWith(
-        expect.stringContaining('group context cursor rollback retained for retry'),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('直达受理的游标补偿持续失败时有界结束账号边界并记录失败终态', async () => {
-    vi.useFakeTimers();
-    try {
-      let beginDeactivation: () => Promise<void> = async () => undefined;
-      let deactivation: Promise<void> | null = null;
-      const log = { info: vi.fn(), warn: vi.fn() };
-      const rollback = vi.fn(async () => {
-        throw new Error('disk full');
-      });
-      const fr = fakeRunner();
-      const { d } = makeDispatcher({
-        runner: fr.runner,
-        log,
-        buildContextPrefix: async () => ({
-          prefix: '<group_chat_context>背景</group_chat_context>',
-          commit: async () => {
-            queueMicrotask(() => {
-              deactivation = beginDeactivation();
-            });
-            return { rollback };
-          },
-        }),
-      });
-      beginDeactivation = () => d.deactivateAccount();
-      const c = collector();
-
-      d.handleDispatch(
-        'conn-1',
-        dispatch({ requestId: 'accepted-exhausted', externalKey: 'telegram:group:bot:-900:9:g0' }),
-        c.send,
-      );
-      for (let i = 0; i < 30 && rollback.mock.calls.length === 0; i += 1) {
-        await Promise.resolve();
-      }
-      expect(deactivation).not.toBeNull();
-
-      await vi.runAllTimersAsync();
-      await deactivation!;
-
-      expect(rollback).toHaveBeenCalledTimes(6);
-      expect(c.ofType('task.ack')).toHaveLength(0);
-      expect(fr.calls).toHaveLength(0);
-      expect(log.warn).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'group context cursor rollback recovery exhausted: phase=accepted requestId=accepted-exhausted attempts=6 state=exhausted',
-        ),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('排队任务的游标补偿失败时保留 execution，恢复前不丢任务引用', async () => {
-    vi.useFakeTimers();
-    try {
-      let beginDeactivation: () => Promise<void> = async () => undefined;
-      let deactivation: Promise<void> | null = null;
-      let rollbackAttempts = 0;
-      const log = { info: vi.fn(), warn: vi.fn() };
-      const rollback = vi.fn(async () => {
-        rollbackAttempts += 1;
-        if (rollbackAttempts === 1) throw new Error('sqlite busy');
-      });
-      const fr = fakeRunner();
-      const { d } = makeDispatcher({
-        runner: fr.runner,
-        log,
-        buildContextPrefix: async (payload) => ({
-          prefix: '<group_chat_context>背景</group_chat_context>',
-          commit:
-            payload.requestId === 'queued-recovery'
-              ? async () => {
-                  queueMicrotask(() => {
-                    deactivation = beginDeactivation();
-                  });
-                  return { rollback };
-                }
-              : () => undefined,
-        }),
-      });
-      beginDeactivation = () => d.deactivateAccount();
-      const c = collector();
-      const externalKey = 'telegram:group:bot:-900:9:g0';
-
-      d.handleDispatch('conn-1', dispatch({ requestId: 'running', externalKey }), c.send);
-      await tick();
-      d.handleDispatch('conn-1', dispatch({ requestId: 'queued-recovery', externalKey }), c.send);
-      await tick();
-      expect(c.last('task.ack')?.payload).toMatchObject({
-        requestId: 'queued-recovery',
-        result: 'queued',
-      });
-
-      fr.finish({ finalText: 'running done' });
-      for (let i = 0; i < 30 && rollbackAttempts === 0; i += 1) await Promise.resolve();
-      expect(deactivation).not.toBeNull();
-      expect(rollback).toHaveBeenCalledTimes(1);
-      expect(fr.calls).toHaveLength(1);
-
-      let deactivated = false;
-      void deactivation!.then(() => {
-        deactivated = true;
-      });
-      await tick();
-      expect(deactivated).toBe(false);
-
-      await vi.advanceTimersByTimeAsync(25);
-      await deactivation!;
-      expect(rollback).toHaveBeenCalledTimes(2);
-      expect(deactivated).toBe(true);
-      expect(fr.calls).toHaveLength(1);
-      expect(c.ofType('turn.end').some((m) => m.payload.requestId === 'queued-recovery')).toBe(
-        false,
-      );
-      expect(log.warn).toHaveBeenCalledWith(
-        expect.stringContaining('group context cursor rollback retained for retry'),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('排队任务的游标补偿持续失败时有界结束账号边界且不启动旧任务', async () => {
-    vi.useFakeTimers();
-    try {
-      let beginDeactivation: () => Promise<void> = async () => undefined;
-      let deactivation: Promise<void> | null = null;
-      const log = { info: vi.fn(), warn: vi.fn() };
-      const rollback = vi.fn(async () => {
-        throw new Error('database is readonly');
-      });
-      const fr = fakeRunner();
-      const { d } = makeDispatcher({
-        runner: fr.runner,
-        log,
-        buildContextPrefix: async (payload) => ({
-          prefix: '<group_chat_context>背景</group_chat_context>',
-          commit:
-            payload.requestId === 'queued-exhausted'
-              ? async () => {
-                  queueMicrotask(() => {
-                    deactivation = beginDeactivation();
-                  });
-                  return { rollback };
-                }
-              : () => undefined,
-        }),
-      });
-      beginDeactivation = () => d.deactivateAccount();
-      const c = collector();
-      const externalKey = 'telegram:group:bot:-900:9:g0';
-
-      d.handleDispatch('conn-1', dispatch({ requestId: 'running-exhausted', externalKey }), c.send);
-      await tick();
-      d.handleDispatch('conn-1', dispatch({ requestId: 'queued-exhausted', externalKey }), c.send);
-      await tick();
-
-      fr.finish({ finalText: 'running done' });
-      for (let i = 0; i < 30 && rollback.mock.calls.length === 0; i += 1) {
-        await Promise.resolve();
-      }
-      expect(deactivation).not.toBeNull();
-
-      await vi.runAllTimersAsync();
-      await deactivation!;
-
-      expect(rollback).toHaveBeenCalledTimes(6);
-      expect(fr.calls).toHaveLength(1);
-      expect(c.ofType('turn.end').some((m) => m.payload.requestId === 'queued-exhausted')).toBe(
-        false,
-      );
-      expect(log.warn).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'group context cursor rollback recovery exhausted: phase=queued requestId=queued-exhausted attempts=6 state=exhausted',
-        ),
-      );
-    } finally {
-      vi.useRealTimers();
-    }
+    fr.finish({ finalText: '磁盘失败也要继续' });
+    await tick();
+    expect(c.last('turn.end')?.payload).toMatchObject({
+      requestId: 'persist-failed',
+      status: 'ok',
+      finalText: '磁盘失败也要继续',
+    });
   });
 
   it('runner 失败 -> turn.end status=error 且 errorMessage 非空', async () => {
@@ -2038,7 +1919,7 @@ describe('dispatcher 核心语义', () => {
     // 同一同步 tick 内连发(ws 同步 emit 场景) —— 修复前会各开一个新 session
     d.handleDispatch('conn-1', dispatch({ requestId: 'r1' }), c.send);
     d.handleDispatch('conn-1', dispatch({ requestId: 'r2' }), c.send);
-    // 受理前会等待 durable-context commit；多给几轮微任务，不改变 FIFO 语义。
+    // 会话定位与受理链含多个微任务；多给几轮，不改变 FIFO 语义。
     await tick(30);
 
     const acks = c.ofType('task.ack').map((m) => m.payload);
@@ -2343,7 +2224,7 @@ describe('dispatcher 核心语义', () => {
     await tick();
     for (let i = 0; i < 21; i++) {
       d.handleDispatch('conn-1', dispatch({ requestId: `q${i}` }), c.send);
-      // 受理前会等待 durable-context commit；多给几轮微任务，不改变 FIFO 语义。
+      // 会话定位与受理链含多个微任务；多给几轮，不改变 FIFO 语义。
       await tick(30);
     }
     const acks = c.ofType('task.ack').map((m) => m.payload);

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -423,6 +423,47 @@ describe('dispatcher 核心语义', () => {
     });
   });
 
+  it('切账号清排队时按提交逆序回滚未开始任务的群游标', async () => {
+    const fr = fakeRunner();
+    const rollbacks: string[] = [];
+    let commitCount = 0;
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      buildContextPrefix: async () => ({
+        prefix: '<group_chat_context>背景</group_chat_context>',
+        commit: async () => {
+          commitCount += 1;
+          const label = `commit-${commitCount}`;
+          return {
+            rollback: async () => {
+              rollbacks.push(label);
+            },
+          };
+        },
+      }),
+    });
+    const c = collector();
+    const externalKey = 'team-slack:C1:1.1';
+
+    d.handleDispatch('conn-1', dispatch({ requestId: 'running', externalKey }), c.send);
+    await tick();
+    d.handleDispatch('conn-1', dispatch({ requestId: 'queued-1', externalKey }), c.send);
+    await tick();
+    d.handleDispatch('conn-1', dispatch({ requestId: 'queued-2', externalKey }), c.send);
+    await tick();
+
+    expect(c.ofType('task.ack').map((message) => message.payload.result)).toEqual([
+      'accepted',
+      'queued',
+      'queued',
+    ]);
+    const draining = d.deactivateAccount();
+    fr.finish({ finalText: '旧账号任务' });
+    await draining;
+
+    expect(rollbacks).toEqual(['commit-3', 'commit-2']);
+  });
+
   it('收口期间的重新激活会被后到的关闭请求作废', async () => {
     const fr = fakeRunner();
     const { d } = makeDispatcher({ runner: fr.runner });

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -1657,26 +1657,27 @@ describe('dispatcher 核心语义', () => {
     ]);
   });
 
-  it('账号边界与异步群游标 commit 重叠时不确认受理也不启动 runner', async () => {
-    let releaseCommit!: () => void;
-    const commitPending = new Promise<void>((resolve) => {
-      releaseCommit = resolve;
-    });
-    let commitGuard: (() => boolean | Promise<boolean>) | undefined;
-    let persisted = false;
+  it('群游标 commit 返回后账号代次失效时回滚且不确认受理', async () => {
+    let beginDeactivation: () => Promise<void> = async () => undefined;
+    let deactivation: Promise<void> | null = null;
+    const rollback = vi.fn(async () => undefined);
     const fr = fakeRunner();
     const { d } = makeDispatcher({
       runner: fr.runner,
       buildContextPrefix: async () => ({
         prefix: '<group_chat_context>背景</group_chat_context>',
         commit: async (guard) => {
-          commitGuard = guard;
-          await commitPending;
-          if (guard !== undefined && !(await guard())) return;
-          persisted = true;
+          expect(await guard?.()).toBe(true);
+          // commit 已完成；让账号边界微任务先于 dispatcher 的 await continuation
+          // 失效，钉住“返回后、ACK 前”的窄竞态。
+          queueMicrotask(() => {
+            deactivation = beginDeactivation();
+          });
+          return { rollback };
         },
       }),
     });
+    beginDeactivation = () => d.deactivateAccount();
     const c = collector();
 
     d.handleDispatch(
@@ -1684,15 +1685,12 @@ describe('dispatcher 核心语义', () => {
       dispatch({ requestId: 'stale-commit', externalKey: 'telegram:group:bot:-900:9:g0' }),
       c.send,
     );
-    for (let i = 0; i < 20 && commitGuard === undefined; i += 1) await Promise.resolve();
-    expect(commitGuard).toBeDefined();
-
-    const deactivation = d.deactivateAccount();
-    releaseCommit();
-    await deactivation;
+    for (let i = 0; i < 30 && deactivation === null; i += 1) await Promise.resolve();
+    expect(deactivation).not.toBeNull();
+    await deactivation!;
     await tick();
 
-    expect(persisted).toBe(false);
+    expect(rollback).toHaveBeenCalledTimes(1);
     expect(c.ofType('task.ack')).toHaveLength(0);
     expect(fr.calls).toHaveLength(0);
   });

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -1835,6 +1835,58 @@ describe('dispatcher 核心语义', () => {
     }
   });
 
+  it('直达受理的游标补偿持续失败时有界结束账号边界并记录失败终态', async () => {
+    vi.useFakeTimers();
+    try {
+      let beginDeactivation: () => Promise<void> = async () => undefined;
+      let deactivation: Promise<void> | null = null;
+      const log = { info: vi.fn(), warn: vi.fn() };
+      const rollback = vi.fn(async () => {
+        throw new Error('disk full');
+      });
+      const fr = fakeRunner();
+      const { d } = makeDispatcher({
+        runner: fr.runner,
+        log,
+        buildContextPrefix: async () => ({
+          prefix: '<group_chat_context>背景</group_chat_context>',
+          commit: async () => {
+            queueMicrotask(() => {
+              deactivation = beginDeactivation();
+            });
+            return { rollback };
+          },
+        }),
+      });
+      beginDeactivation = () => d.deactivateAccount();
+      const c = collector();
+
+      d.handleDispatch(
+        'conn-1',
+        dispatch({ requestId: 'accepted-exhausted', externalKey: 'telegram:group:bot:-900:9:g0' }),
+        c.send,
+      );
+      for (let i = 0; i < 30 && rollback.mock.calls.length === 0; i += 1) {
+        await Promise.resolve();
+      }
+      expect(deactivation).not.toBeNull();
+
+      await vi.runAllTimersAsync();
+      await deactivation!;
+
+      expect(rollback).toHaveBeenCalledTimes(6);
+      expect(c.ofType('task.ack')).toHaveLength(0);
+      expect(fr.calls).toHaveLength(0);
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'group context cursor rollback recovery exhausted: phase=accepted requestId=accepted-exhausted attempts=6 state=exhausted',
+        ),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('排队任务的游标补偿失败时保留 execution，恢复前不丢任务引用', async () => {
     vi.useFakeTimers();
     try {
@@ -1899,6 +1951,65 @@ describe('dispatcher 核心语义', () => {
       );
       expect(log.warn).toHaveBeenCalledWith(
         expect.stringContaining('group context cursor rollback retained for retry'),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('排队任务的游标补偿持续失败时有界结束账号边界且不启动旧任务', async () => {
+    vi.useFakeTimers();
+    try {
+      let beginDeactivation: () => Promise<void> = async () => undefined;
+      let deactivation: Promise<void> | null = null;
+      const log = { info: vi.fn(), warn: vi.fn() };
+      const rollback = vi.fn(async () => {
+        throw new Error('database is readonly');
+      });
+      const fr = fakeRunner();
+      const { d } = makeDispatcher({
+        runner: fr.runner,
+        log,
+        buildContextPrefix: async (payload) => ({
+          prefix: '<group_chat_context>背景</group_chat_context>',
+          commit:
+            payload.requestId === 'queued-exhausted'
+              ? async () => {
+                  queueMicrotask(() => {
+                    deactivation = beginDeactivation();
+                  });
+                  return { rollback };
+                }
+              : () => undefined,
+        }),
+      });
+      beginDeactivation = () => d.deactivateAccount();
+      const c = collector();
+      const externalKey = 'telegram:group:bot:-900:9:g0';
+
+      d.handleDispatch('conn-1', dispatch({ requestId: 'running-exhausted', externalKey }), c.send);
+      await tick();
+      d.handleDispatch('conn-1', dispatch({ requestId: 'queued-exhausted', externalKey }), c.send);
+      await tick();
+
+      fr.finish({ finalText: 'running done' });
+      for (let i = 0; i < 30 && rollback.mock.calls.length === 0; i += 1) {
+        await Promise.resolve();
+      }
+      expect(deactivation).not.toBeNull();
+
+      await vi.runAllTimersAsync();
+      await deactivation!;
+
+      expect(rollback).toHaveBeenCalledTimes(6);
+      expect(fr.calls).toHaveLength(1);
+      expect(c.ofType('turn.end').some((m) => m.payload.requestId === 'queued-exhausted')).toBe(
+        false,
+      );
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'group context cursor rollback recovery exhausted: phase=queued requestId=queued-exhausted attempts=6 state=exhausted',
+        ),
       );
     } finally {
       vi.useRealTimers();

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -1749,8 +1749,7 @@ describe('dispatcher 核心语义', () => {
       runner: fr.runner,
       buildContextPrefix: async () => ({
         prefix: '<group_chat_context>背景</group_chat_context>',
-        commit: async (guard) => {
-          expect(await guard?.()).toBe(true);
+        commit: async () => {
           // commit 已完成；让账号边界微任务先于 dispatcher 的 await continuation
           // 失效，钉住“返回后、ACK 前”的窄竞态。
           queueMicrotask(() => {
@@ -1776,6 +1775,134 @@ describe('dispatcher 核心语义', () => {
     expect(rollback).toHaveBeenCalledTimes(1);
     expect(c.ofType('task.ack')).toHaveLength(0);
     expect(fr.calls).toHaveLength(0);
+  });
+
+  it('直达受理的游标补偿失败时保留 admission，恢复后才结束账号边界', async () => {
+    vi.useFakeTimers();
+    try {
+      let beginDeactivation: () => Promise<void> = async () => undefined;
+      let deactivation: Promise<void> | null = null;
+      let rollbackAttempts = 0;
+      const log = { info: vi.fn(), warn: vi.fn() };
+      const rollback = vi.fn(async () => {
+        rollbackAttempts += 1;
+        if (rollbackAttempts === 1) throw new Error('sqlite busy');
+      });
+      const fr = fakeRunner();
+      const { d } = makeDispatcher({
+        runner: fr.runner,
+        log,
+        buildContextPrefix: async () => ({
+          prefix: '<group_chat_context>背景</group_chat_context>',
+          commit: async () => {
+            queueMicrotask(() => {
+              deactivation = beginDeactivation();
+            });
+            return { rollback };
+          },
+        }),
+      });
+      beginDeactivation = () => d.deactivateAccount();
+      const c = collector();
+
+      d.handleDispatch(
+        'conn-1',
+        dispatch({ requestId: 'accepted-recovery', externalKey: 'telegram:group:bot:-900:9:g0' }),
+        c.send,
+      );
+      for (let i = 0; i < 30 && rollbackAttempts === 0; i += 1) await Promise.resolve();
+      expect(deactivation).not.toBeNull();
+      expect(rollback).toHaveBeenCalledTimes(1);
+
+      let deactivated = false;
+      void deactivation!.then(() => {
+        deactivated = true;
+      });
+      await tick();
+      expect(deactivated).toBe(false);
+      expect(c.ofType('task.ack')).toHaveLength(0);
+      expect(fr.calls).toHaveLength(0);
+
+      await vi.advanceTimersByTimeAsync(25);
+      await deactivation!;
+      expect(rollback).toHaveBeenCalledTimes(2);
+      expect(deactivated).toBe(true);
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('group context cursor rollback retained for retry'),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('排队任务的游标补偿失败时保留 execution，恢复前不丢任务引用', async () => {
+    vi.useFakeTimers();
+    try {
+      let beginDeactivation: () => Promise<void> = async () => undefined;
+      let deactivation: Promise<void> | null = null;
+      let rollbackAttempts = 0;
+      const log = { info: vi.fn(), warn: vi.fn() };
+      const rollback = vi.fn(async () => {
+        rollbackAttempts += 1;
+        if (rollbackAttempts === 1) throw new Error('sqlite busy');
+      });
+      const fr = fakeRunner();
+      const { d } = makeDispatcher({
+        runner: fr.runner,
+        log,
+        buildContextPrefix: async (payload) => ({
+          prefix: '<group_chat_context>背景</group_chat_context>',
+          commit:
+            payload.requestId === 'queued-recovery'
+              ? async () => {
+                  queueMicrotask(() => {
+                    deactivation = beginDeactivation();
+                  });
+                  return { rollback };
+                }
+              : () => undefined,
+        }),
+      });
+      beginDeactivation = () => d.deactivateAccount();
+      const c = collector();
+      const externalKey = 'telegram:group:bot:-900:9:g0';
+
+      d.handleDispatch('conn-1', dispatch({ requestId: 'running', externalKey }), c.send);
+      await tick();
+      d.handleDispatch('conn-1', dispatch({ requestId: 'queued-recovery', externalKey }), c.send);
+      await tick();
+      expect(c.last('task.ack')?.payload).toMatchObject({
+        requestId: 'queued-recovery',
+        result: 'queued',
+      });
+
+      fr.finish({ finalText: 'running done' });
+      for (let i = 0; i < 30 && rollbackAttempts === 0; i += 1) await Promise.resolve();
+      expect(deactivation).not.toBeNull();
+      expect(rollback).toHaveBeenCalledTimes(1);
+      expect(fr.calls).toHaveLength(1);
+
+      let deactivated = false;
+      void deactivation!.then(() => {
+        deactivated = true;
+      });
+      await tick();
+      expect(deactivated).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(25);
+      await deactivation!;
+      expect(rollback).toHaveBeenCalledTimes(2);
+      expect(deactivated).toBe(true);
+      expect(fr.calls).toHaveLength(1);
+      expect(c.ofType('turn.end').some((m) => m.payload.requestId === 'queued-recovery')).toBe(
+        false,
+      );
+      expect(log.warn).toHaveBeenCalledWith(
+        expect.stringContaining('group context cursor rollback retained for retry'),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('runner 失败 -> turn.end status=error 且 errorMessage 非空', async () => {

--- a/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/dispatcher.test.ts
@@ -184,6 +184,7 @@ function makeDispatcher(overrides?: {
   terminalLedger?: HookRequestLedger;
   config?: HookConnectionConfig | null;
   prepareWorktree?: HookDispatcherDeps['prepareWorktree'];
+  buildContextPrefix?: HookDispatcherDeps['buildContextPrefix'];
   dialogue?: HookDispatcherDeps['dialogue'];
   abortSession?: HookDispatcherDeps['abortSession'];
   subscribeUiContinuation?: HookDispatcherDeps['subscribeUiContinuation'];
@@ -204,6 +205,7 @@ function makeDispatcher(overrides?: {
     terminalLedger: overrides?.terminalLedger,
     runner,
     prepareWorktree: overrides?.prepareWorktree,
+    buildContextPrefix: overrides?.buildContextPrefix,
     dialogue: overrides?.dialogue,
     abortSession: overrides?.abortSession,
     subscribeUiContinuation: overrides?.subscribeUiContinuation,
@@ -1655,6 +1657,46 @@ describe('dispatcher 核心语义', () => {
     ]);
   });
 
+  it('账号边界与异步群游标 commit 重叠时不确认受理也不启动 runner', async () => {
+    let releaseCommit!: () => void;
+    const commitPending = new Promise<void>((resolve) => {
+      releaseCommit = resolve;
+    });
+    let commitGuard: (() => boolean | Promise<boolean>) | undefined;
+    let persisted = false;
+    const fr = fakeRunner();
+    const { d } = makeDispatcher({
+      runner: fr.runner,
+      buildContextPrefix: async () => ({
+        prefix: '<group_chat_context>背景</group_chat_context>',
+        commit: async (guard) => {
+          commitGuard = guard;
+          await commitPending;
+          if (guard !== undefined && !(await guard())) return;
+          persisted = true;
+        },
+      }),
+    });
+    const c = collector();
+
+    d.handleDispatch(
+      'conn-1',
+      dispatch({ requestId: 'stale-commit', externalKey: 'telegram:group:bot:-900:9:g0' }),
+      c.send,
+    );
+    for (let i = 0; i < 20 && commitGuard === undefined; i += 1) await Promise.resolve();
+    expect(commitGuard).toBeDefined();
+
+    const deactivation = d.deactivateAccount();
+    releaseCommit();
+    await deactivation;
+    await tick();
+
+    expect(persisted).toBe(false);
+    expect(c.ofType('task.ack')).toHaveLength(0);
+    expect(fr.calls).toHaveLength(0);
+  });
+
   it('runner 失败 -> turn.end status=error 且 errorMessage 非空', async () => {
     const fr = fakeRunner();
     const { d } = makeDispatcher({ runner: fr.runner });
@@ -1677,7 +1719,8 @@ describe('dispatcher 核心语义', () => {
     // 同一同步 tick 内连发(ws 同步 emit 场景) —— 修复前会各开一个新 session
     d.handleDispatch('conn-1', dispatch({ requestId: 'r1' }), c.send);
     d.handleDispatch('conn-1', dispatch({ requestId: 'r2' }), c.send);
-    await tick(6);
+    // 受理前会等待 durable-context commit；多给几轮微任务，不改变 FIFO 语义。
+    await tick(30);
 
     const acks = c.ofType('task.ack').map((m) => m.payload);
     expect(acks).toHaveLength(2);
@@ -1981,7 +2024,8 @@ describe('dispatcher 核心语义', () => {
     await tick();
     for (let i = 0; i < 21; i++) {
       d.handleDispatch('conn-1', dispatch({ requestId: `q${i}` }), c.send);
-      await tick();
+      // 受理前会等待 durable-context commit；多给几轮微任务，不改变 FIFO 语义。
+      await tick(30);
     }
     const acks = c.ofType('task.ack').map((m) => m.payload);
     const overflow = acks[acks.length - 1];

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -303,6 +303,48 @@ describe('recordGroupMessage', () => {
     expect(replay.prefix).toContain('待补偿消息');
   });
 
+  it('游标 UPSERT 成功后不依赖写后回读，仍返回回滚凭据', async () => {
+    await recordGroupMessage(frame({ messageId: 'post-write-read-failure' }));
+    const assembly = await buildGroupContextPrefix({
+      requestId: 'post-write-read-failure-context',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+
+    const baseDrizzle = holder.drizzle as object;
+    let selectCalls = 0;
+    holder.drizzle = new Proxy(baseDrizzle, {
+      get(target, property, receiver) {
+        if (property === 'select') {
+          const select = Reflect.get(target, property, target) as (...args: unknown[]) => unknown;
+          return (...args: unknown[]) => {
+            selectCalls += 1;
+            if (selectCalls > 1) throw new Error('post-write read failed');
+            return Reflect.apply(select, target, args);
+          };
+        }
+        return Reflect.get(target, property, target);
+      },
+    });
+
+    try {
+      const receipt = await assembly.commit();
+      expect(receipt).toBeDefined();
+      expect(selectCalls).toBe(1);
+      expect(
+        sqlite
+          .prepare(
+            'SELECT cursor_id FROM hook_group_context_cursors WHERE provider = ? AND cursor_key = ?',
+          )
+          .get('telegram:9', 'telegram:group:1:-900:9'),
+      ).toEqual({ cursor_id: 1 });
+    } finally {
+      holder.drizzle = drizzle(sqlite);
+    }
+  });
+
   it('群历史不按时间过期，但每个 principal + 群/topic 只保留最近 500 条', async () => {
     for (let i = 0; i < 502; i += 1) {
       await recordGroupMessage(frame({ messageId: `m${i}`, text: `msg ${i}` }));

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -275,6 +275,34 @@ describe('recordGroupMessage', () => {
     ).toEqual({ cursor_id: 99 });
   });
 
+  it('commit 返回后由受理方回滚时恢复本次游标', async () => {
+    await recordGroupMessage(frame({ messageId: 'receipt-rollback', text: '待补偿消息' }));
+    const assembly = await buildGroupContextPrefix({
+      requestId: 'receipt-rollback-context',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+
+    const receipt = await assembly.commit();
+    expect(receipt).toBeDefined();
+    await receipt?.rollback();
+    expect(
+      sqlite
+        .prepare('SELECT 1 FROM hook_group_context_cursors WHERE provider = ?')
+        .get('telegram:9'),
+    ).toBeUndefined();
+    const replay = await buildGroupContextPrefix({
+      requestId: 'receipt-rollback-replay',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+    expect(replay.prefix).toContain('待补偿消息');
+  });
+
   it('群历史不按时间过期，但每个 principal + 群/topic 只保留最近 500 条', async () => {
     for (let i = 0; i < 502; i += 1) {
       await recordGroupMessage(frame({ messageId: `m${i}`, text: `msg ${i}` }));

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -190,6 +190,91 @@ describe('recordGroupMessage', () => {
     ).toEqual({ cursor_id: 99 });
   });
 
+  it('受理代次在写库前失效时不推进内存或持久游标', async () => {
+    await recordGroupMessage(frame({ messageId: 'guard-before', text: '待受理消息' }));
+    const first = await buildGroupContextPrefix({
+      requestId: 'guard-before-context',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+
+    await first.commit(() => false);
+    expect(
+      sqlite
+        .prepare('SELECT 1 FROM hook_group_context_cursors WHERE provider = ?')
+        .get('telegram:9'),
+    ).toBeUndefined();
+    const replay = await buildGroupContextPrefix({
+      requestId: 'guard-before-replay',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+    expect(replay.prefix).toContain('待受理消息');
+  });
+
+  it('写库后代次失效会回滚本次推进', async () => {
+    await recordGroupMessage(frame({ messageId: 'guard-rollback', text: '仍待受理' }));
+    const assembly = await buildGroupContextPrefix({
+      requestId: 'guard-rollback-context',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+    let guardCalls = 0;
+    await assembly.commit(() => ++guardCalls === 1);
+    expect(guardCalls).toBe(2);
+    expect(
+      sqlite
+        .prepare('SELECT 1 FROM hook_group_context_cursors WHERE provider = ?')
+        .get('telegram:9'),
+    ).toBeUndefined();
+    const replay = await buildGroupContextPrefix({
+      requestId: 'guard-rollback-replay',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+    expect(replay.prefix).toContain('仍待受理');
+  });
+
+  it('写库后代次失效只回滚本次写入, 不覆盖更高游标', async () => {
+    await recordGroupMessage(frame({ messageId: 'guard-after', text: '待回滚消息' }));
+    const assembly = await buildGroupContextPrefix({
+      requestId: 'guard-after-context',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+    let guardCalls = 0;
+    await assembly.commit(() => {
+      guardCalls += 1;
+      if (guardCalls === 1) return true;
+      sqlite
+        .prepare(
+          `INSERT INTO hook_group_context_cursors
+            (provider, cursor_key, cursor_id, updated_at) VALUES (?, ?, ?, ?)
+           ON CONFLICT(provider, cursor_key) DO UPDATE SET cursor_id = excluded.cursor_id`,
+        )
+        .run('telegram:9', 'telegram:group:1:-900:9', 99, Date.now());
+      return false;
+    });
+    expect(guardCalls).toBe(2);
+    expect(
+      sqlite
+        .prepare(
+          'SELECT cursor_id FROM hook_group_context_cursors WHERE provider = ? AND cursor_key = ?',
+        )
+        .get('telegram:9', 'telegram:group:1:-900:9'),
+    ).toEqual({ cursor_id: 99 });
+  });
+
   it('群历史不按时间过期，但每个 principal + 群/topic 只保留最近 500 条', async () => {
     for (let i = 0; i < 502; i += 1) {
       await recordGroupMessage(frame({ messageId: `m${i}`, text: `msg ${i}` }));

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -1,7 +1,7 @@
 /**
  * groupWindow(group-relay-v1 本地群窗口)单测: 入窗幂等、永久留存、lane 解析、
  * 上下文拼装(trigger 剔重 / 游标增量 / 字符预算)。DB 用内存 better-sqlite3
- * 直接执行 0083 migration SQL, 经 drizzle 同步 driver 假装成 DbClient。
+ * 直接执行 0083 + 0086 migration SQL, 经 drizzle 同步 driver 假装成 DbClient。
  */
 
 import fs from 'node:fs';
@@ -17,6 +17,7 @@ const holder = vi.hoisted(() => ({ drizzle: null as unknown }));
 
 vi.mock('../../localDb/client/current.js', () => ({
   getDbClient: () => ({ drizzle: holder.drizzle }),
+  tryGetDbClient: () => ({ drizzle: holder.drizzle }),
 }));
 
 import {
@@ -39,9 +40,14 @@ function recordGroupMessage(payload: GroupMessagePayload): Promise<boolean> {
 
 function migrationSql(): string {
   const dir = path.resolve(__dirname, '../../../../drizzle');
-  const file = fs.readdirSync(dir).find((name) => name.startsWith('0083_'));
-  if (!file) throw new Error('0083 migration not found');
-  return fs.readFileSync(path.join(dir, file), 'utf8').replaceAll('--> statement-breakpoint', ';');
+  return ['0083_', '0086_']
+    .map((prefix) => {
+      const file = fs.readdirSync(dir).find((name) => name.startsWith(prefix));
+      if (!file) throw new Error(`${prefix} migration not found`);
+      return fs.readFileSync(path.join(dir, file), 'utf8');
+    })
+    .join('\n')
+    .replaceAll('--> statement-breakpoint', ';');
 }
 
 function frame(overrides: Partial<GroupMessagePayload> = {}): GroupMessagePayload {
@@ -60,11 +66,11 @@ function frame(overrides: Partial<GroupMessagePayload> = {}): GroupMessagePayloa
 
 let sqlite: InstanceType<typeof Database>;
 
-beforeEach(() => {
+beforeEach(async () => {
   sqlite = new Database(':memory:');
   sqlite.exec(migrationSql());
   holder.drizzle = drizzle(sqlite);
-  resetGroupContextCursors();
+  await resetGroupContextCursors();
 });
 
 afterEach(() => {
@@ -131,6 +137,57 @@ describe('recordGroupMessage', () => {
       n: number;
     };
     expect(rows.n).toBe(1);
+  });
+
+  it('正文全文入库, 但拼 prompt 仍按 500 字符截断', async () => {
+    const text = 'x'.repeat(700);
+    await recordGroupMessage(frame({ messageId: 'long', text }));
+    const row = sqlite
+      .prepare('SELECT text FROM hook_group_messages WHERE message_id = ?')
+      .get('long') as { text: string };
+    expect(row.text).toBe(text);
+
+    const prefix = (
+      await buildGroupContextPrefix({
+        requestId: 'long-context',
+        externalKey: 'telegram:group:1:-900:9:g1',
+        workspace: 'chat',
+        sessionId: null,
+        prompt: 'q',
+      })
+    ).prefix;
+    expect(prefix).toContain('x'.repeat(500));
+    expect(prefix).not.toContain('x'.repeat(501));
+  });
+
+  it('重置只删除官方 provider 的持久游标', async () => {
+    await recordGroupMessage(frame({ messageId: 'cursor-reset' }));
+    const assembly = await buildGroupContextPrefix({
+      requestId: 'cursor-reset-context',
+      externalKey: 'telegram:group:1:-900:9:g1',
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+    await assembly.commit();
+    sqlite
+      .prepare(
+        `INSERT INTO hook_group_context_cursors
+          (provider, cursor_key, cursor_id, updated_at) VALUES (?, ?, ?, ?)`,
+      )
+      .run('telegram-personal:bot-1', 'bot-1:-900:', 99, Date.now());
+
+    await resetGroupContextCursors();
+    expect(
+      sqlite
+        .prepare('SELECT 1 FROM hook_group_context_cursors WHERE provider = ?')
+        .get('telegram:9'),
+    ).toBeUndefined();
+    expect(
+      sqlite
+        .prepare('SELECT cursor_id FROM hook_group_context_cursors WHERE provider = ?')
+        .get('telegram-personal:bot-1') as { cursor_id: number },
+    ).toEqual({ cursor_id: 99 });
   });
 
   it('群历史不按时间过期，但每个 principal + 群/topic 只保留最近 500 条', async () => {
@@ -345,7 +402,26 @@ describe('buildGroupContextPrefix', () => {
       source: { im: 'telegram', triggerMessageId: '3' },
     });
     expect(replay.prefix).toContain('部署失败了');
-    firstAssembly.commit();
+    await firstAssembly.commit();
+    expect(
+      sqlite
+        .prepare(
+          'SELECT cursor_id FROM hook_group_context_cursors WHERE provider = ? AND cursor_key = ?',
+        )
+        .get('telegram:9', 'telegram:group:1:-900:42:9') as { cursor_id: number },
+    ).toEqual({ cursor_id: 3 });
+
+    // 模拟进程重启: 清掉内存态但保留 DB, 恢复后不重复已提交消息。
+    await resetGroupContextCursors({ clearPersisted: false });
+    const restored = await buildGroupContextPrefix({
+      requestId: 'r3-restart',
+      externalKey,
+      workspace: 'chat',
+      sessionId: null,
+      prompt: '怎么回事?',
+      source: { im: 'telegram', triggerMessageId: '3' },
+    });
+    expect(restored.prefix).toBe('');
 
     await recordGroupMessage(
       frame({ messageId: '4', text: '重启后恢复了', author: { name: '@user303' } }),

--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -496,6 +496,23 @@ describe('hook session-runner 的 userSendAt 时序(未分类误判回归)', () 
     expect(h.touchUserSendInDb).toHaveBeenCalledWith('sess-old');
   });
 
+  it('provider 接受后才执行回调，回调失败不反转已受理 turn', async () => {
+    const onProviderAccepted = vi.fn(async () => {
+      h.calls.push('providerAccepted');
+      throw new Error('cursor db unavailable');
+    });
+    const runner = createMakerHookSessionRunner({ log });
+
+    const outcome = await runner.run(baseReq({ onProviderAccepted }));
+
+    expect(outcome.status).toBe('ok');
+    expect(onProviderAccepted).toHaveBeenCalledTimes(1);
+    expect(h.calls.indexOf('createMessage')).toBeLessThan(h.calls.indexOf('providerAccepted'));
+    expect(log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('provider-accepted callback failed for session=sess-new'),
+    );
+  });
+
   it('入站图片附件:ingest 进媒体总仓挂 session-attachment 引用,喂 agent 用 blob 绝对路径,落库用 cindy-media url', async () => {
     const runner = createMakerHookSessionRunner({ log });
     const outcome = await runner.run(

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -242,7 +242,7 @@ export interface HookDispatcherDeps {
    */
   buildContextPrefix?: (
     payload: TaskDispatchPayload,
-  ) => Promise<{ prefix: string; commit: () => void }>;
+  ) => Promise<{ prefix: string; commit: () => void | Promise<void> }>;
   /**
    * 可选: 内置「对话」伪目录(chat 保留别名)的解析面。rootDir 在每次
    * dispatch 时解析当前 data owner 的 app 托管目录根，allocateDir 为新会话
@@ -1929,7 +1929,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     serializeByKey(`${connectionId} ${payload.externalKey}`, async () => {
       try {
         let contextPrefix = '';
-        let commitContextCursor: () => void = () => undefined;
+        let commitContextCursor: () => void | Promise<void> = () => undefined;
         if (buildContextPrefix) {
           try {
             const assembly = await buildContextPrefix(dispatchPayload);
@@ -1988,7 +1988,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           const task: PendingTask = { ...taskBase, ack };
           queue.push(task);
           queues.set(sessionId, queue);
-          commitContextCursor();
+          const commitResult = commitContextCursor();
+          if (commitResult instanceof Promise) await commitResult;
           reply(connectionId, send, ack);
           // 排队时目标 session 可能是 desktop 侧用户手动在跑(runner.isBusy),
           // 没有本模块的收口点 —— 轮询兜底: 空闲即 drain
@@ -1997,7 +1998,8 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         }
 
         running.add(sessionId);
-        commitContextCursor();
+        const commitResult = commitContextCursor();
+        if (commitResult instanceof Promise) await commitResult;
         const ack: TaskAckPayload = {
           requestId: payload.requestId,
           result: 'accepted',

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -240,9 +240,10 @@ export interface HookDispatcherDeps {
    * 失败或空装配 = 无前缀, 绝不因上下文拒单。commit 在任务被受理
    * (accepted/queued)后由本模块调用, 拒单不推进窗口游标。
    */
-  buildContextPrefix?: (
-    payload: TaskDispatchPayload,
-  ) => Promise<{ prefix: string; commit: () => void | Promise<void> }>;
+  buildContextPrefix?: (payload: TaskDispatchPayload) => Promise<{
+    prefix: string;
+    commit: (guard?: () => boolean | Promise<boolean>) => void | Promise<void>;
+  }>;
   /**
    * 可选: 内置「对话」伪目录(chat 保留别名)的解析面。rootDir 在每次
    * dispatch 时解析当前 data owner 的 app 托管目录根，allocateDir 为新会话
@@ -616,6 +617,34 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     void stored.finally(() => {
       if (keyChains.get(key) === stored) keyChains.delete(key);
     });
+  }
+  /** 同一 session 的受理段串行化，避免不同 externalKey 在 commit await 期间同时占槽。 */
+  const sessionAdmissionChains = new Map<string, Promise<void>>();
+  async function serializeSessionAdmission(
+    sessionId: string,
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    const previous = sessionAdmissionChains.get(sessionId);
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const stored = previous
+      ? previous.then(
+          () => current,
+          () => current,
+        )
+      : current;
+    sessionAdmissionChains.set(sessionId, stored);
+    try {
+      if (previous !== undefined) await previous;
+      await fn();
+    } finally {
+      release();
+      if (sessionAdmissionChains.get(sessionId) === stored) {
+        sessionAdmissionChains.delete(sessionId);
+      }
+    }
   }
   /** 每连接当前发送函数(transport 重建后由 onConnected / handleDispatch 刷新)。 */
   const sendFns = new Map<string, (m: HookMessage) => boolean>();
@@ -1929,7 +1958,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     serializeByKey(`${connectionId} ${payload.externalKey}`, async () => {
       try {
         let contextPrefix = '';
-        let commitContextCursor: () => void | Promise<void> = () => undefined;
+        let commitContextCursor: (
+          guard?: () => boolean | Promise<boolean>,
+        ) => void | Promise<void> = () => undefined;
         if (buildContextPrefix) {
           try {
             const assembly = await buildContextPrefix(dispatchPayload);
@@ -1970,50 +2001,53 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           ...(resolved.cleanupWorktree ? { cleanupWorktree: resolved.cleanupWorktree } : {}),
         };
         const sessionId = resolved.run.sessionId;
-        const queue = queues.get(sessionId) ?? [];
-
-        if (running.has(sessionId) || runner.isBusy(sessionId) || queue.length > 0) {
-          if (queue.length >= MAX_QUEUE_PER_SESSION) {
+        await serializeSessionAdmission(sessionId, async () => {
+          if (!isCurrentGeneration(admittedGeneration)) return;
+          const initialQueue = queues.get(sessionId) ?? [];
+          const initiallyBusy =
+            running.has(sessionId) || runner.isBusy(sessionId) || initialQueue.length > 0;
+          if (initiallyBusy && initialQueue.length >= MAX_QUEUE_PER_SESSION) {
             reply(connectionId, send, rejected(payload.requestId, 'invalid'));
             log.warn(`dispatch queue overflow: session=${sessionId}`);
             return;
           }
+
+          // 代次守卫覆盖写库前后；账号边界若在 await 期间失效，commit 会回滚
+          // 自己的 durable cursor，下面也不会留下 queue/running/ACK 副作用。
+          await commitContextCursor(() => isCurrentGeneration(admittedGeneration));
+          if (!isCurrentGeneration(admittedGeneration)) return;
+
+          const queue = queues.get(sessionId) ?? [];
+          if (running.has(sessionId) || runner.isBusy(sessionId) || queue.length > 0) {
+            const ack: TaskAckPayload = {
+              requestId: payload.requestId,
+              result: 'queued',
+              reason: null,
+              sessionId,
+              queuePosition: queue.length,
+            };
+            const task: PendingTask = { ...taskBase, ack };
+            queue.push(task);
+            queues.set(sessionId, queue);
+            reply(connectionId, send, ack);
+            // 排队时目标 session 可能是 desktop 侧用户手动在跑(runner.isBusy),
+            // 没有本模块的收口点 —— 轮询兜底: 空闲即 drain
+            if (!running.has(sessionId)) scheduleDrainPoll(sessionId);
+            return;
+          }
+
+          running.add(sessionId);
           const ack: TaskAckPayload = {
             requestId: payload.requestId,
-            result: 'queued',
+            result: 'accepted',
             reason: null,
             sessionId,
-            queuePosition: queue.length,
+            queuePosition: null,
           };
           const task: PendingTask = { ...taskBase, ack };
-          queue.push(task);
-          queues.set(sessionId, queue);
-          const queuedCommit = commitContextCursor();
-          if (queuedCommit !== undefined && typeof queuedCommit.then === 'function') {
-            await queuedCommit;
-          }
           reply(connectionId, send, ack);
-          // 排队时目标 session 可能是 desktop 侧用户手动在跑(runner.isBusy),
-          // 没有本模块的收口点 —— 轮询兜底: 空闲即 drain
-          if (!running.has(sessionId)) scheduleDrainPoll(sessionId);
-          return;
-        }
-
-        running.add(sessionId);
-        const acceptedCommit = commitContextCursor();
-        if (acceptedCommit !== undefined && typeof acceptedCommit.then === 'function') {
-          await acceptedCommit;
-        }
-        const ack: TaskAckPayload = {
-          requestId: payload.requestId,
-          result: 'accepted',
-          reason: null,
-          sessionId,
-          queuePosition: null,
-        };
-        const task: PendingTask = { ...taskBase, ack };
-        reply(connectionId, send, ack);
-        startExecution(task);
+          startExecution(task);
+        });
       } catch (err) {
         if (!isCurrentGeneration(admittedGeneration)) return;
         log.warn(`handleDispatch failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -2101,7 +2135,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           }
         }
         await Promise.allSettled(aborts);
-        await Promise.allSettled([...keyChains.values()]);
+        await Promise.allSettled([...keyChains.values(), ...sessionAdmissionChains.values()]);
         await Promise.allSettled([...executing]);
 
         ackHistory.clear();
@@ -2115,6 +2149,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         awaitingPersist.clear();
         staleTakeoverReplacements.clear();
         keyChains.clear();
+        sessionAdmissionChains.clear();
       })();
       accountDeactivation = drain.finally(() => {
         accountDeactivation = null;

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -177,6 +177,11 @@ export interface HookRunRequest {
   /** IM 来源元数据(平台 + thread 上下文); 省略 = 旧 server 不发。 */
   source?: TaskSource;
   /**
+   * provider 已实际接受本次发送后的副作用。runner 只在 send outcome
+   * 确认为 dispatched 后 await；失败必须由调用方自行降级，不能反转已受理 turn。
+   */
+  onProviderAccepted?: () => void | Promise<void>;
+  /**
    * 执行中渲染快照回调(turn.progress 链路)。runner 合成「过程区时间线 +
    * 部分正文」的完整 markdown 快照并节流回调; dispatcher 注入的实现把它
    * 打成 turn.progress 帧发给 server。进度是尽力而为的装饰性信息 ——
@@ -237,8 +242,8 @@ export interface HookDispatcherDeps {
    * 可选: 为派发组装本地群上下文前缀(group-relay-v1 窗口, 生产为
    * groupWindow.buildGroupContextPrefix)。只影响发给 agent 的 prompt,
    * 不影响会话标题与 UI 渲染(二者用 source.userText / 原始 prompt);
-   * 失败或空装配 = 无前缀, 绝不因上下文拒单。accepted 任务在 ACK 前提交；
-   * queued 任务把 commit 延迟到真正开始执行, 拒单/取消/清队列都不推进窗口游标。
+   * 失败或空装配 = 无前缀, 绝不因上下文拒单。两条路径都只在 provider
+   * 实际受理后提交；拒单、取消或清队列都不推进窗口游标。
    */
   buildContextPrefix?: (payload: TaskDispatchPayload) => Promise<{
     prefix: string;
@@ -383,11 +388,6 @@ const TURN_DELIVERY_ACK_MAX_DELAY_MS = 60_000;
 const REOPEN_TTL_MS = 24 * 60 * 60_000;
 /** 续跑记账条数上限(FIFO 淘汰最老), 同 ackHistory 语义: 防长驻进程无界增长。 */
 const MAX_PENDING_REOPENS = 200;
-/** 游标补偿已在共享核心内有界重试；dispatcher 再保留任务做有限轮退避恢复。 */
-const CURSOR_ROLLBACK_RECOVERY_BASE_DELAY_MS = 25;
-const CURSOR_ROLLBACK_RECOVERY_MAX_DELAY_MS = 1_000;
-const CURSOR_ROLLBACK_RECOVERY_MAX_ATTEMPTS = 6;
-
 /**
  * 原对话不再落在工作目录映射内时(被移到映射外的项目, 或映射本身被改/删),
  * 回给渠道的一次性说明(Slack / Telegram 侧文案不进 locale, 与 interactions.ts
@@ -516,7 +516,7 @@ interface PendingTask {
   externalKey: string;
   run: HookRunRequest;
   accountGeneration: number;
-  /** 群上下文游标提交回调;排队任务仅在真正开始执行前调用。 */
+  /** 群上下文游标提交回调；仅在 provider 实际受理后调用。 */
   commitContextCursor?: ContextCursorCommit;
   /** 会话定位阶段产生的一次性说明, 前置到本次 turn.end 的 finalText。 */
   notice?: string;
@@ -634,7 +634,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       if (keyChains.get(key) === stored) keyChains.delete(key);
     });
   }
-  /** 同一 session 的受理段串行化，避免不同 externalKey 在 commit await 期间同时占槽。 */
+  /** 同一 session 的受理段串行化，避免不同 externalKey 并发判断空闲并同时占槽。 */
   const sessionAdmissionChains = new Map<string, Promise<void>>();
   async function serializeSessionAdmission(
     sessionId: string,
@@ -708,6 +708,15 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   const queues = new Map<string, PendingTask[]>();
   /** connectionId + requestId -> 正在执行它的 session(cancel 定位与归属校验用, 收口即清)。 */
   const runningByRequest = new Map<string, { sessionId: string; connectionId: string }>();
+  /**
+   * 已开始执行但 provider 尚未受理的 Telegram 群任务。账号边界必须把其
+   * accepted / queued ACK 收成 cancelled；accepted=true 后消息已交给 agent，
+   * 不再按未受理任务处理。
+   */
+  const pendingGroupAdmissions = new Map<
+    string,
+    { task: PendingTask; accepted: boolean; cancelled: boolean }
+  >();
   /** 已请求取消的 connectionId + requestId(execute 收口时据此把结果改写为 cancelled)。 */
   const cancelRequested = new Set<string>();
   /** 每连接最近一次 welcome 宣告的能力集(turn.reopen 的 feature gate)。 */
@@ -1324,10 +1333,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       running.delete(sessionId);
       return;
     }
-    if (!(await commitTaskContextCursor(task))) {
-      running.delete(sessionId);
-      return;
-    }
+    const pendingGroupAdmission = task.commitContextCursor
+      ? { task, accepted: false, cancelled: false }
+      : null;
+    if (pendingGroupAdmission) pendingGroupAdmissions.set(requestKey, pendingGroupAdmission);
     // 这条消息线交给新任务了: 撤掉上一轮失败留下的续跑观察与记账。连接还在, 所以要
     // 发收口帧把那条旧消息定稿; 但不再记待续跑(它已经不是"最新一轮"了)。
     dropContinuation(sessionId, { silent: false, remember: false });
@@ -1392,6 +1401,15 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           onProgress,
           onInteraction,
           onInteractionCancel,
+          ...(task.commitContextCursor
+            ? {
+                onProviderAccepted: async () => {
+                  if (pendingGroupAdmission?.cancelled) return;
+                  if (pendingGroupAdmission) pendingGroupAdmission.accepted = true;
+                  await commitTaskContextCursor(task);
+                },
+              }
+            : {}),
           // runner 建/取到 session 后, 拿它真正要跑的那个目录回来问一次 ——
           // 那个目录可能与这里校验过的不是同一个(见 isDirAuthorized 的说明)。
           isDirAuthorized: (dir) => dirStillAllowed(task.connectionId, dir),
@@ -1406,6 +1424,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       }
     }
     runningByRequest.delete(requestKey);
+    pendingGroupAdmissions.delete(requestKey);
     if (!isCurrentGeneration(task.accountGeneration)) {
       cancelRequested.delete(requestKey);
       running.delete(sessionId);
@@ -1501,72 +1520,42 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   }
 
   /**
-   * 账号代次失效后，任务必须留在当前 admission/execution Promise 中，直到
-   * durable cursor 确认恢复或恢复预算耗尽。共享核心单次 rollback 已做有界
-   * 重试；这里再以有限轮退避承接短暂 SQLite 故障。持续故障必须进入可观测的
-   * exhausted 终态并释放账号生命周期，不能让停用、切换或退出永久等待。
+   * provider 已受理后才推进 durable cursor。此时即使账号代次随后失效，消息也
+   * 已交给 agent，游标前移是正确的；持久化失败则保留旧游标，下次最多重复携带，
+   * 不能为了游标写入失败反转一个已经受理的 turn。
    */
-  async function recoverTaskContextCursor(
-    receipt: ContextCursorReceipt | void,
-    task: { requestId: string; run: { sessionId: string } },
-    phase: 'accepted' | 'queued',
+  async function commitTaskContextCursor(
+    task: Pick<PendingTask, 'requestId' | 'commitContextCursor'>,
   ): Promise<void> {
-    if (!receipt) return;
-    for (let attempt = 1; attempt <= CURSOR_ROLLBACK_RECOVERY_MAX_ATTEMPTS; attempt += 1) {
-      try {
-        await receipt.rollback();
-        if (attempt > 1) {
-          log.info(
-            `group context cursor rollback recovered: phase=${phase} requestId=${task.requestId} attempts=${attempt}`,
-          );
-        }
-        return;
-      } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        if (attempt === CURSOR_ROLLBACK_RECOVERY_MAX_ATTEMPTS) {
-          log.warn(
-            `group context cursor rollback recovery exhausted: phase=${phase} requestId=${task.requestId} attempts=${attempt} state=exhausted error=${errorMessage}`,
-          );
-          return;
-        }
-        const retryDelayMs = Math.min(
-          CURSOR_ROLLBACK_RECOVERY_BASE_DELAY_MS * 2 ** Math.min(attempt - 1, 6),
-          CURSOR_ROLLBACK_RECOVERY_MAX_DELAY_MS,
-        );
-        log.warn(
-          `group context cursor rollback retained for retry: phase=${phase} requestId=${task.requestId} retryInMs=${retryDelayMs} error=${errorMessage}`,
-        );
-        await new Promise<void>((resolve) => setTimeout(resolve, retryDelayMs));
-      }
-    }
-  }
-
-  /**
-   * 排队任务只有在真正开始执行时才推进群上下文游标。账号代次若在提交
-   * await 期间失效，保留任务直到补偿成功，再按账号边界丢弃尚未开始的任务。
-   */
-  async function commitTaskContextCursor(task: PendingTask): Promise<boolean> {
-    if (!task.commitContextCursor) return true;
-    if (!isCurrentGeneration(task.accountGeneration)) return false;
-    let receipt: ContextCursorReceipt | void;
+    if (!task.commitContextCursor) return;
     try {
-      // dispatcher owns the post-write generation check so a successful write
-      // always returns its receipt to the recovery loop instead of losing it in
-      // the shared core's optional guard compensation path.
-      receipt = await task.commitContextCursor();
+      await task.commitContextCursor();
     } catch (error) {
-      // The production group-window commit keeps persistence failures non-fatal;
-      // retain the same queue liveness for injected/legacy callbacks.
       log.warn(
-        `queued group context cursor commit failed: ${
+        `group context cursor commit failed after provider acceptance: requestId=${task.requestId} error=${
           error instanceof Error ? error.message : String(error)
         }`,
       );
-      return isCurrentGeneration(task.accountGeneration);
     }
-    if (isCurrentGeneration(task.accountGeneration)) return true;
-    await recoverTaskContextCursor(receipt, task, 'queued');
-    return false;
+  }
+
+  /** 已回 ACK 的任务在取消或账号边界被清掉时必须有 durable 终态。 */
+  function finishTaskAsCancelled(task: PendingTask): void {
+    const turnEnd: TurnEndPayload = {
+      requestId: task.requestId,
+      externalKey: task.externalKey,
+      sessionId: task.run.sessionId,
+      status: 'cancelled',
+      finalText: '',
+      errorMessage: null,
+      usage: { durationMs: null },
+    };
+    sendOrBuffer(task.connectionId, makeTurnEnd(turnEnd), {
+      connectionId: task.connectionId,
+      requestId: task.requestId,
+      ack: task.ack,
+      turnEnd: durableTurnEnd(turnEnd),
+    });
   }
 
   /**
@@ -2084,6 +2073,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           },
           accountGeneration: admittedGeneration,
           reopenCapable: supportsReopen(connectionId),
+          ...((payload.externalKey.startsWith('telegram:group:') ||
+            payload.externalKey.startsWith('telegram:topic:')) &&
+          commitContextCursor
+            ? { commitContextCursor }
+            : {}),
           ...(resolved.notice ? { notice: resolved.notice } : {}),
           ...(resolved.cleanupWorktree ? { cleanupWorktree: resolved.cleanupWorktree } : {}),
         };
@@ -2099,7 +2093,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             return;
           }
 
-          // 排队任务只保存 commit 回调；它尚未受理，不得提前推进 durable cursor。
+          // 排队任务只保存 commit 回调；provider 尚未受理，不得提前推进 durable cursor。
           const queue = queues.get(sessionId) ?? [];
           if (running.has(sessionId) || runner.isBusy(sessionId) || queue.length > 0) {
             const ack: TaskAckPayload = {
@@ -2112,7 +2106,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             const task: PendingTask = {
               ...taskBase,
               ack,
-              ...(commitContextCursor ? { commitContextCursor } : {}),
             };
             queue.push(task);
             queues.set(sessionId, queue);
@@ -2120,17 +2113,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             // 排队时目标 session 可能是 desktop 侧用户手动在跑(runner.isBusy),
             // 没有本模块的收口点 —— 轮询兜底: 空闲即 drain
             if (!running.has(sessionId)) scheduleDrainPoll(sessionId);
-            return;
-          }
-
-          // Preserve the direct accepted path's pre-ACK generation fence: a
-          // boundary racing the durable write must roll back and emit no ACK.
-          // Do not pass the optional shared-core guard here: dispatcher must
-          // retain the returned receipt so a failed compensation can keep this
-          // admission alive and retry instead of losing the unaccepted task.
-          const cursorCommit = await commitContextCursor?.();
-          if (!isCurrentGeneration(admittedGeneration)) {
-            await recoverTaskContextCursor(cursorCommit, taskBase, 'accepted');
             return;
           }
 
@@ -2205,6 +2187,18 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
 
       for (const timer of drainPolls.values()) clearTimeout(timer);
       drainPolls.clear();
+      for (const admission of pendingGroupAdmissions.values()) {
+        if (admission.accepted || admission.cancelled) continue;
+        admission.cancelled = true;
+        finishTaskAsCancelled(admission.task);
+      }
+      // 只收口本 PR 新增的“携带群上下文 commit”任务；Slack/X 普通队列保持
+      // 既有账号 teardown 语义。终态必须在 sendFns / delivery buffer 清理前落下。
+      for (const queue of queues.values()) {
+        for (const task of queue) {
+          if (task.commitContextCursor) finishTaskAsCancelled(task);
+        }
+      }
       queues.clear();
       sendFns.clear();
       pendingTurnEnds.clear();
@@ -2240,6 +2234,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         inflightRequests.clear();
         running.clear();
         runningByRequest.clear();
+        pendingGroupAdmissions.clear();
         cancelRequested.clear();
         // 切账号时 execute() 会在代际检查处提前 return, 走不到收口那行删除 ——
         // 不在这里清的话, 每次切账号都永久留下一条 sessionId + 完整工作目录路径
@@ -2380,21 +2375,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         if (idx >= 0) {
           const [task] = queue.splice(idx, 1);
           if (queue.length === 0) queues.delete(sessionId);
-          const turnEnd: TurnEndPayload = {
-            requestId: task.requestId,
-            externalKey: task.externalKey,
-            sessionId: task.run.sessionId,
-            status: 'cancelled',
-            finalText: '',
-            errorMessage: null,
-            usage: { durationMs: null },
-          };
-          sendOrBuffer(connectionId, makeTurnEnd(turnEnd), {
-            connectionId,
-            requestId: task.requestId,
-            ack: task.ack,
-            turnEnd: durableTurnEnd(turnEnd),
-          });
+          finishTaskAsCancelled(task);
           log.info(`hook task ${requestId} cancelled while queued`);
           return;
         }

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -1988,8 +1988,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           const task: PendingTask = { ...taskBase, ack };
           queue.push(task);
           queues.set(sessionId, queue);
-          const commitResult = commitContextCursor();
-          if (commitResult instanceof Promise) await commitResult;
+          const queuedCommit = commitContextCursor();
+          if (queuedCommit !== undefined && typeof queuedCommit.then === 'function') {
+            await queuedCommit;
+          }
           reply(connectionId, send, ack);
           // 排队时目标 session 可能是 desktop 侧用户手动在跑(runner.isBusy),
           // 没有本模块的收口点 —— 轮询兜底: 空闲即 drain
@@ -1998,8 +2000,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         }
 
         running.add(sessionId);
-        const commitResult = commitContextCursor();
-        if (commitResult instanceof Promise) await commitResult;
+        const acceptedCommit = commitContextCursor();
+        if (acceptedCommit !== undefined && typeof acceptedCommit.then === 'function') {
+          await acceptedCommit;
+        }
         const ack: TaskAckPayload = {
           requestId: payload.requestId,
           result: 'accepted',

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -237,8 +237,8 @@ export interface HookDispatcherDeps {
    * 可选: 为派发组装本地群上下文前缀(group-relay-v1 窗口, 生产为
    * groupWindow.buildGroupContextPrefix)。只影响发给 agent 的 prompt,
    * 不影响会话标题与 UI 渲染(二者用 source.userText / 原始 prompt);
-   * 失败或空装配 = 无前缀, 绝不因上下文拒单。commit 在任务被受理
-   * (accepted/queued)后由本模块调用, 拒单不推进窗口游标。
+   * 失败或空装配 = 无前缀, 绝不因上下文拒单。accepted 任务在 ACK 前提交；
+   * queued 任务把 commit 延迟到真正开始执行, 拒单/取消/清队列都不推进窗口游标。
    */
   buildContextPrefix?: (payload: TaskDispatchPayload) => Promise<{
     prefix: string;
@@ -498,6 +498,13 @@ export function buildHookSessionTitle(
   return `[${contextTag}${displayProvider}${dmTag}] ${snippet}`;
 }
 
+type ContextCursorCommit = (
+  guard?: () => boolean | Promise<boolean>,
+) =>
+  | void
+  | { rollback(): void | Promise<void> }
+  | Promise<void | { rollback(): void | Promise<void> }>;
+
 /** 待执行任务(定位已完成, 排队即执行参数就绪)。 */
 interface PendingTask {
   connectionId: string;
@@ -507,10 +514,8 @@ interface PendingTask {
   externalKey: string;
   run: HookRunRequest;
   accountGeneration: number;
-  /** 群上下文已提交但尚未真正开始执行时的补偿句柄。 */
-  cursorCommit?: { rollback(): void | Promise<void> };
-  /** 仅用于账号边界按提交逆序回滚排队中的游标。 */
-  cursorCommitOrder?: number;
+  /** 群上下文游标提交回调;排队任务仅在真正开始执行前调用。 */
+  commitContextCursor?: ContextCursorCommit;
   /** 会话定位阶段产生的一次性说明, 前置到本次 turn.end 的 finalText。 */
   notice?: string;
   /**
@@ -699,11 +704,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   >();
   /** 每 session 的 FIFO 等待队列。 */
   const queues = new Map<string, PendingTask[]>();
-  /** 排队任务的游标提交序号，用于边界回滚时保持 LIFO。 */
-  let queuedCursorCommitOrder = 0;
-  /** 已提交游标但尚未开始的任务，覆盖 queue 与 queued-cancel 的窗口。 */
-  const pendingCursorTasks = new Map<number, PendingTask>();
-  const cursorRollbackPromises = new Map<PendingTask, Promise<void>>();
   /** connectionId + requestId -> 正在执行它的 session(cancel 定位与归属校验用, 收口即清)。 */
   const runningByRequest = new Map<string, { sessionId: string; connectionId: string }>();
   /** 已请求取消的 connectionId + requestId(execute 收口时据此把结果改写为 cancelled)。 */
@@ -1322,6 +1322,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       running.delete(sessionId);
       return;
     }
+    if (!(await commitTaskContextCursor(task))) {
+      running.delete(sessionId);
+      return;
+    }
     // 这条消息线交给新任务了: 撤掉上一轮失败留下的续跑观察与记账。连接还在, 所以要
     // 发收口帧把那条旧消息定稿; 但不再记待续跑(它已经不是"最新一轮"了)。
     dropContinuation(sessionId, { silent: false, remember: false });
@@ -1471,32 +1475,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     }
   }
 
-  async function rollbackQueuedCursor(task: PendingTask): Promise<void> {
-    if (!task.cursorCommit) return;
-    try {
-      await task.cursorCommit.rollback();
-    } catch (error) {
-      log.warn(
-        `queued group context cursor rollback failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
-  }
-
-  function scheduleQueuedCursorRollback(task: PendingTask): void {
-    if (task.cursorCommit === undefined || task.cursorCommitOrder === undefined) return;
-    if (cursorRollbackPromises.has(task)) return;
-    const rollback = rollbackQueuedCursor(task);
-    cursorRollbackPromises.set(task, rollback);
-    void rollback.finally(() => {
-      cursorRollbackPromises.delete(task);
-      if (pendingCursorTasks.get(task.cursorCommitOrder!) === task) {
-        pendingCursorTasks.delete(task.cursorCommitOrder!);
-      }
-    });
-  }
-
   /**
    * 这个目录**此刻**还落在该连接的工作目录映射(或内置对话根)内吗。
    *
@@ -1515,10 +1493,41 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   }
 
   function startExecution(task: PendingTask): void {
-    if (task.cursorCommitOrder !== undefined) pendingCursorTasks.delete(task.cursorCommitOrder);
     const promise = execute(task);
     executing.add(promise);
     void promise.finally(() => executing.delete(promise));
+  }
+
+  /**
+   * 排队任务只有在真正开始执行时才推进群上下文游标。账号代次若在提交
+   * await 期间失效，补偿本次提交并静默丢弃这条尚未开始的任务。
+   */
+  async function commitTaskContextCursor(task: PendingTask): Promise<boolean> {
+    if (!task.commitContextCursor) return true;
+    let receipt: { rollback(): void | Promise<void> } | void;
+    try {
+      receipt = await task.commitContextCursor(() => isCurrentGeneration(task.accountGeneration));
+    } catch (error) {
+      // The production group-window commit keeps persistence failures non-fatal;
+      // retain the same queue liveness for injected/legacy callbacks.
+      log.warn(
+        `queued group context cursor commit failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return true;
+    }
+    if (isCurrentGeneration(task.accountGeneration)) return true;
+    try {
+      await receipt?.rollback();
+    } catch (error) {
+      log.warn(
+        `queued group context cursor rollback failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    return false;
   }
 
   /**
@@ -1999,12 +2008,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     serializeByKey(`${connectionId} ${payload.externalKey}`, async () => {
       try {
         let contextPrefix = '';
-        let commitContextCursor: (
-          guard?: () => boolean | Promise<boolean>,
-        ) =>
-          | void
-          | { rollback(): void | Promise<void> }
-          | Promise<void | { rollback(): void | Promise<void> }> = () => undefined;
+        let commitContextCursor: ContextCursorCommit | undefined;
         if (buildContextPrefix) {
           try {
             const assembly = await buildContextPrefix(dispatchPayload);
@@ -2056,16 +2060,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             return;
           }
 
-          // 代次守卫覆盖写库前后；账号边界若在 await 期间失效，commit 会回滚
-          // 自己的 durable cursor，下面也不会留下 queue/running/ACK 副作用。
-          const cursorCommit = await commitContextCursor(() =>
-            isCurrentGeneration(admittedGeneration),
-          );
-          if (!isCurrentGeneration(admittedGeneration)) {
-            await cursorCommit?.rollback();
-            return;
-          }
-
+          // 排队任务只保存 commit 回调；它尚未受理，不得提前推进 durable cursor。
           const queue = queues.get(sessionId) ?? [];
           if (running.has(sessionId) || runner.isBusy(sessionId) || queue.length > 0) {
             const ack: TaskAckPayload = {
@@ -2078,22 +2073,24 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             const task: PendingTask = {
               ...taskBase,
               ack,
-              ...(cursorCommit
-                ? {
-                    cursorCommit,
-                    cursorCommitOrder: ++queuedCursorCommitOrder,
-                  }
-                : {}),
+              ...(commitContextCursor ? { commitContextCursor } : {}),
             };
-            if (task.cursorCommitOrder !== undefined) {
-              pendingCursorTasks.set(task.cursorCommitOrder, task);
-            }
             queue.push(task);
             queues.set(sessionId, queue);
             reply(connectionId, send, ack);
             // 排队时目标 session 可能是 desktop 侧用户手动在跑(runner.isBusy),
             // 没有本模块的收口点 —— 轮询兜底: 空闲即 drain
             if (!running.has(sessionId)) scheduleDrainPoll(sessionId);
+            return;
+          }
+
+          // Preserve the direct accepted path's pre-ACK guard: a generation
+          // boundary racing the durable write must roll back and emit no ACK.
+          const cursorCommit = await commitContextCursor?.(() =>
+            isCurrentGeneration(admittedGeneration),
+          );
+          if (!isCurrentGeneration(admittedGeneration)) {
+            await cursorCommit?.rollback();
             return;
           }
 
@@ -2168,12 +2165,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
 
       for (const timer of drainPolls.values()) clearTimeout(timer);
       drainPolls.clear();
-      const queuedTasks = [...pendingCursorTasks.values()]
-        .sort(
-          (a, b) =>
-            (b.cursorCommitOrder ?? Number.NEGATIVE_INFINITY) -
-            (a.cursorCommitOrder ?? Number.NEGATIVE_INFINITY),
-        );
       queues.clear();
       sendFns.clear();
       pendingTurnEnds.clear();
@@ -2189,14 +2180,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       pendingReopens.clear();
 
       const drain = (async (): Promise<void> => {
-        // Queued tasks have not started yet, so their context was not
-        // consumed. Roll back in reverse commit order: if several queued
-        // entries share a cursor key, each receipt can restore the preceding
-        // value without a later receipt being overwritten by an older one.
-        for (const task of queuedTasks) {
-          scheduleQueuedCursorRollback(task);
-          await cursorRollbackPromises.get(task);
-        }
         const aborts: Promise<void>[] = [];
         if (abortSession) {
           for (const { sessionId } of runningByRequest.values()) {
@@ -2366,9 +2349,6 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             errorMessage: null,
             usage: { durationMs: null },
           };
-          // A queued task has not started, so cancelling it must release the
-          // context cursor just like an account-boundary queue drop.
-          scheduleQueuedCursorRollback(task);
           sendOrBuffer(connectionId, makeTurnEnd(turnEnd), {
             connectionId,
             requestId: task.requestId,

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -242,7 +242,12 @@ export interface HookDispatcherDeps {
    */
   buildContextPrefix?: (payload: TaskDispatchPayload) => Promise<{
     prefix: string;
-    commit: (guard?: () => boolean | Promise<boolean>) => void | Promise<void>;
+    commit: (
+      guard?: () => boolean | Promise<boolean>,
+    ) =>
+      | void
+      | { rollback(): void | Promise<void> }
+      | Promise<void | { rollback(): void | Promise<void> }>;
   }>;
   /**
    * 可选: 内置「对话」伪目录(chat 保留别名)的解析面。rootDir 在每次
@@ -1960,7 +1965,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
         let contextPrefix = '';
         let commitContextCursor: (
           guard?: () => boolean | Promise<boolean>,
-        ) => void | Promise<void> = () => undefined;
+        ) =>
+          | void
+          | { rollback(): void | Promise<void> }
+          | Promise<void | { rollback(): void | Promise<void> }> = () => undefined;
         if (buildContextPrefix) {
           try {
             const assembly = await buildContextPrefix(dispatchPayload);
@@ -2014,8 +2022,13 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
 
           // 代次守卫覆盖写库前后；账号边界若在 await 期间失效，commit 会回滚
           // 自己的 durable cursor，下面也不会留下 queue/running/ACK 副作用。
-          await commitContextCursor(() => isCurrentGeneration(admittedGeneration));
-          if (!isCurrentGeneration(admittedGeneration)) return;
+          const cursorCommit = await commitContextCursor(() =>
+            isCurrentGeneration(admittedGeneration),
+          );
+          if (!isCurrentGeneration(admittedGeneration)) {
+            await cursorCommit?.rollback();
+            return;
+          }
 
           const queue = queues.get(sessionId) ?? [];
           if (running.has(sessionId) || runner.isBusy(sessionId) || queue.length > 0) {

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -507,6 +507,10 @@ interface PendingTask {
   externalKey: string;
   run: HookRunRequest;
   accountGeneration: number;
+  /** 群上下文已提交但尚未真正开始执行时的补偿句柄。 */
+  cursorCommit?: { rollback(): void | Promise<void> };
+  /** 仅用于账号边界按提交逆序回滚排队中的游标。 */
+  cursorCommitOrder?: number;
   /** 会话定位阶段产生的一次性说明, 前置到本次 turn.end 的 finalText。 */
   notice?: string;
   /**
@@ -695,6 +699,11 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   >();
   /** 每 session 的 FIFO 等待队列。 */
   const queues = new Map<string, PendingTask[]>();
+  /** 排队任务的游标提交序号，用于边界回滚时保持 LIFO。 */
+  let queuedCursorCommitOrder = 0;
+  /** 已提交游标但尚未开始的任务，覆盖 queue 与 queued-cancel 的窗口。 */
+  const pendingCursorTasks = new Map<number, PendingTask>();
+  const cursorRollbackPromises = new Map<PendingTask, Promise<void>>();
   /** connectionId + requestId -> 正在执行它的 session(cancel 定位与归属校验用, 收口即清)。 */
   const runningByRequest = new Map<string, { sessionId: string; connectionId: string }>();
   /** 已请求取消的 connectionId + requestId(execute 收口时据此把结果改写为 cancelled)。 */
@@ -1462,6 +1471,32 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     }
   }
 
+  async function rollbackQueuedCursor(task: PendingTask): Promise<void> {
+    if (!task.cursorCommit) return;
+    try {
+      await task.cursorCommit.rollback();
+    } catch (error) {
+      log.warn(
+        `queued group context cursor rollback failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  function scheduleQueuedCursorRollback(task: PendingTask): void {
+    if (task.cursorCommit === undefined || task.cursorCommitOrder === undefined) return;
+    if (cursorRollbackPromises.has(task)) return;
+    const rollback = rollbackQueuedCursor(task);
+    cursorRollbackPromises.set(task, rollback);
+    void rollback.finally(() => {
+      cursorRollbackPromises.delete(task);
+      if (pendingCursorTasks.get(task.cursorCommitOrder!) === task) {
+        pendingCursorTasks.delete(task.cursorCommitOrder!);
+      }
+    });
+  }
+
   /**
    * 这个目录**此刻**还落在该连接的工作目录映射(或内置对话根)内吗。
    *
@@ -1480,6 +1515,7 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   }
 
   function startExecution(task: PendingTask): void {
+    if (task.cursorCommitOrder !== undefined) pendingCursorTasks.delete(task.cursorCommitOrder);
     const promise = execute(task);
     executing.add(promise);
     void promise.finally(() => executing.delete(promise));
@@ -2039,7 +2075,19 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
               sessionId,
               queuePosition: queue.length,
             };
-            const task: PendingTask = { ...taskBase, ack };
+            const task: PendingTask = {
+              ...taskBase,
+              ack,
+              ...(cursorCommit
+                ? {
+                    cursorCommit,
+                    cursorCommitOrder: ++queuedCursorCommitOrder,
+                  }
+                : {}),
+            };
+            if (task.cursorCommitOrder !== undefined) {
+              pendingCursorTasks.set(task.cursorCommitOrder, task);
+            }
             queue.push(task);
             queues.set(sessionId, queue);
             reply(connectionId, send, ack);
@@ -2120,6 +2168,12 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
 
       for (const timer of drainPolls.values()) clearTimeout(timer);
       drainPolls.clear();
+      const queuedTasks = [...pendingCursorTasks.values()]
+        .sort(
+          (a, b) =>
+            (b.cursorCommitOrder ?? Number.NEGATIVE_INFINITY) -
+            (a.cursorCommitOrder ?? Number.NEGATIVE_INFINITY),
+        );
       queues.clear();
       sendFns.clear();
       pendingTurnEnds.clear();
@@ -2135,6 +2189,14 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
       pendingReopens.clear();
 
       const drain = (async (): Promise<void> => {
+        // Queued tasks have not started yet, so their context was not
+        // consumed. Roll back in reverse commit order: if several queued
+        // entries share a cursor key, each receipt can restore the preceding
+        // value without a later receipt being overwritten by an older one.
+        for (const task of queuedTasks) {
+          scheduleQueuedCursorRollback(task);
+          await cursorRollbackPromises.get(task);
+        }
         const aborts: Promise<void>[] = [];
         if (abortSession) {
           for (const { sessionId } of runningByRequest.values()) {
@@ -2304,6 +2366,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             errorMessage: null,
             usage: { durationMs: null },
           };
+          // A queued task has not started, so cancelling it must release the
+          // context cursor just like an account-boundary queue drop.
+          scheduleQueuedCursorRollback(task);
           sendOrBuffer(connectionId, makeTurnEnd(turnEnd), {
             connectionId,
             requestId: task.requestId,

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -383,9 +383,10 @@ const TURN_DELIVERY_ACK_MAX_DELAY_MS = 60_000;
 const REOPEN_TTL_MS = 24 * 60 * 60_000;
 /** 续跑记账条数上限(FIFO 淘汰最老), 同 ackHistory 语义: 防长驻进程无界增长。 */
 const MAX_PENDING_REOPENS = 200;
-/** 游标补偿已在共享核心内有界重试；dispatcher 继续保留任务并退避恢复。 */
+/** 游标补偿已在共享核心内有界重试；dispatcher 再保留任务做有限轮退避恢复。 */
 const CURSOR_ROLLBACK_RECOVERY_BASE_DELAY_MS = 25;
 const CURSOR_ROLLBACK_RECOVERY_MAX_DELAY_MS = 1_000;
+const CURSOR_ROLLBACK_RECOVERY_MAX_ATTEMPTS = 6;
 
 /**
  * 原对话不再落在工作目录映射内时(被移到映射外的项目, 或映射本身被改/删),
@@ -1501,9 +1502,9 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
 
   /**
    * 账号代次失效后，任务必须留在当前 admission/execution Promise 中，直到
-   * durable cursor 确认恢复。共享核心单次 rollback 已做有界重试；这里再以
-   * 退避循环承接持续 SQLite 故障，使 deactivateAccount() 继续等待该任务，
-   * 不会在补偿失败时清掉引用并让未执行消息永久越过游标。
+   * durable cursor 确认恢复或恢复预算耗尽。共享核心单次 rollback 已做有界
+   * 重试；这里再以有限轮退避承接短暂 SQLite 故障。持续故障必须进入可观测的
+   * exhausted 终态并释放账号生命周期，不能让停用、切换或退出永久等待。
    */
   async function recoverTaskContextCursor(
     receipt: ContextCursorReceipt | void,
@@ -1511,26 +1512,29 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
     phase: 'accepted' | 'queued',
   ): Promise<void> {
     if (!receipt) return;
-    let failures = 0;
-    for (;;) {
+    for (let attempt = 1; attempt <= CURSOR_ROLLBACK_RECOVERY_MAX_ATTEMPTS; attempt += 1) {
       try {
         await receipt.rollback();
-        if (failures > 0) {
+        if (attempt > 1) {
           log.info(
-            `group context cursor rollback recovered: phase=${phase} requestId=${task.requestId} attempts=${failures + 1}`,
+            `group context cursor rollback recovered: phase=${phase} requestId=${task.requestId} attempts=${attempt}`,
           );
         }
         return;
       } catch (error) {
-        failures += 1;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        if (attempt === CURSOR_ROLLBACK_RECOVERY_MAX_ATTEMPTS) {
+          log.warn(
+            `group context cursor rollback recovery exhausted: phase=${phase} requestId=${task.requestId} attempts=${attempt} state=exhausted error=${errorMessage}`,
+          );
+          return;
+        }
         const retryDelayMs = Math.min(
-          CURSOR_ROLLBACK_RECOVERY_BASE_DELAY_MS * 2 ** Math.min(failures - 1, 6),
+          CURSOR_ROLLBACK_RECOVERY_BASE_DELAY_MS * 2 ** Math.min(attempt - 1, 6),
           CURSOR_ROLLBACK_RECOVERY_MAX_DELAY_MS,
         );
         log.warn(
-          `group context cursor rollback retained for retry: phase=${phase} requestId=${task.requestId} retryInMs=${retryDelayMs} error=${
-            error instanceof Error ? error.message : String(error)
-          }`,
+          `group context cursor rollback retained for retry: phase=${phase} requestId=${task.requestId} retryInMs=${retryDelayMs} error=${errorMessage}`,
         );
         await new Promise<void>((resolve) => setTimeout(resolve, retryDelayMs));
       }

--- a/apps/desktop/src/main/hook-control/dispatcher.ts
+++ b/apps/desktop/src/main/hook-control/dispatcher.ts
@@ -383,6 +383,9 @@ const TURN_DELIVERY_ACK_MAX_DELAY_MS = 60_000;
 const REOPEN_TTL_MS = 24 * 60 * 60_000;
 /** 续跑记账条数上限(FIFO 淘汰最老), 同 ackHistory 语义: 防长驻进程无界增长。 */
 const MAX_PENDING_REOPENS = 200;
+/** 游标补偿已在共享核心内有界重试；dispatcher 继续保留任务并退避恢复。 */
+const CURSOR_ROLLBACK_RECOVERY_BASE_DELAY_MS = 25;
+const CURSOR_ROLLBACK_RECOVERY_MAX_DELAY_MS = 1_000;
 
 /**
  * 原对话不再落在工作目录映射内时(被移到映射外的项目, 或映射本身被改/删),
@@ -498,12 +501,10 @@ export function buildHookSessionTitle(
   return `[${contextTag}${displayProvider}${dmTag}] ${snippet}`;
 }
 
+type ContextCursorReceipt = { rollback(): void | Promise<void> };
 type ContextCursorCommit = (
   guard?: () => boolean | Promise<boolean>,
-) =>
-  | void
-  | { rollback(): void | Promise<void> }
-  | Promise<void | { rollback(): void | Promise<void> }>;
+) => void | ContextCursorReceipt | Promise<void | ContextCursorReceipt>;
 
 /** 待执行任务(定位已完成, 排队即执行参数就绪)。 */
 interface PendingTask {
@@ -1499,14 +1500,56 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
   }
 
   /**
+   * 账号代次失效后，任务必须留在当前 admission/execution Promise 中，直到
+   * durable cursor 确认恢复。共享核心单次 rollback 已做有界重试；这里再以
+   * 退避循环承接持续 SQLite 故障，使 deactivateAccount() 继续等待该任务，
+   * 不会在补偿失败时清掉引用并让未执行消息永久越过游标。
+   */
+  async function recoverTaskContextCursor(
+    receipt: ContextCursorReceipt | void,
+    task: { requestId: string; run: { sessionId: string } },
+    phase: 'accepted' | 'queued',
+  ): Promise<void> {
+    if (!receipt) return;
+    let failures = 0;
+    for (;;) {
+      try {
+        await receipt.rollback();
+        if (failures > 0) {
+          log.info(
+            `group context cursor rollback recovered: phase=${phase} requestId=${task.requestId} attempts=${failures + 1}`,
+          );
+        }
+        return;
+      } catch (error) {
+        failures += 1;
+        const retryDelayMs = Math.min(
+          CURSOR_ROLLBACK_RECOVERY_BASE_DELAY_MS * 2 ** Math.min(failures - 1, 6),
+          CURSOR_ROLLBACK_RECOVERY_MAX_DELAY_MS,
+        );
+        log.warn(
+          `group context cursor rollback retained for retry: phase=${phase} requestId=${task.requestId} retryInMs=${retryDelayMs} error=${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        await new Promise<void>((resolve) => setTimeout(resolve, retryDelayMs));
+      }
+    }
+  }
+
+  /**
    * 排队任务只有在真正开始执行时才推进群上下文游标。账号代次若在提交
-   * await 期间失效，补偿本次提交并静默丢弃这条尚未开始的任务。
+   * await 期间失效，保留任务直到补偿成功，再按账号边界丢弃尚未开始的任务。
    */
   async function commitTaskContextCursor(task: PendingTask): Promise<boolean> {
     if (!task.commitContextCursor) return true;
-    let receipt: { rollback(): void | Promise<void> } | void;
+    if (!isCurrentGeneration(task.accountGeneration)) return false;
+    let receipt: ContextCursorReceipt | void;
     try {
-      receipt = await task.commitContextCursor(() => isCurrentGeneration(task.accountGeneration));
+      // dispatcher owns the post-write generation check so a successful write
+      // always returns its receipt to the recovery loop instead of losing it in
+      // the shared core's optional guard compensation path.
+      receipt = await task.commitContextCursor();
     } catch (error) {
       // The production group-window commit keeps persistence failures non-fatal;
       // retain the same queue liveness for injected/legacy callbacks.
@@ -1515,18 +1558,10 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
           error instanceof Error ? error.message : String(error)
         }`,
       );
-      return true;
+      return isCurrentGeneration(task.accountGeneration);
     }
     if (isCurrentGeneration(task.accountGeneration)) return true;
-    try {
-      await receipt?.rollback();
-    } catch (error) {
-      log.warn(
-        `queued group context cursor rollback failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    }
+    await recoverTaskContextCursor(receipt, task, 'queued');
     return false;
   }
 
@@ -2084,13 +2119,14 @@ export function createHookDispatcher(deps: HookDispatcherDeps): HookDispatcher {
             return;
           }
 
-          // Preserve the direct accepted path's pre-ACK guard: a generation
+          // Preserve the direct accepted path's pre-ACK generation fence: a
           // boundary racing the durable write must roll back and emit no ACK.
-          const cursorCommit = await commitContextCursor?.(() =>
-            isCurrentGeneration(admittedGeneration),
-          );
+          // Do not pass the optional shared-core guard here: dispatcher must
+          // retain the returned receipt so a failed compensation can keep this
+          // admission alive and retry instead of losing the unaccepted task.
+          const cursorCommit = await commitContextCursor?.();
           if (!isCurrentGeneration(admittedGeneration)) {
-            await cursorCommit?.rollback();
+            await recoverTaskContextCursor(cursorCommit, taskBase, 'accepted');
             return;
           }
 

--- a/apps/desktop/src/main/hook-control/groupWindow.ts
+++ b/apps/desktop/src/main/hook-control/groupWindow.ts
@@ -185,6 +185,15 @@ export function resetGroupContextCursors(options?: {
   });
 }
 
+/** 同步生命周期入口使用的安全收口: 异步清理失败只记日志, 不产生 unhandled rejection。 */
+export function resetGroupContextCursorsSafely(options?: {
+  clearPersisted?: boolean;
+}): void {
+  void resetGroupContextCursors(options).catch((error: unknown) => {
+    log.warn(`group context cursor reset failed: ${String(error)}`);
+  });
+}
+
 /** 设置卡数据源：官方群窗口里出现过的群，按最近活跃排序。 */
 export async function listTelegramKnownGroups(
   principalId: string,

--- a/apps/desktop/src/main/hook-control/groupWindow.ts
+++ b/apps/desktop/src/main/hook-control/groupWindow.ts
@@ -142,7 +142,7 @@ const NO_CONTEXT: GroupContextAssembly = { prefix: '', commit: () => undefined }
 
 /**
  * 为一次 hook 派发组装本地群上下文前缀。非群 lane / 窗口为空返回空装配。
- * 只读窗口; 游标推进延迟到 commit(由 dispatcher 在任务受理后调用)。
+ * 只读窗口; 游标推进延迟到 commit(由 dispatcher 在 provider 实际受理后调用)。
  */
 export async function buildGroupContextPrefix(
   payload: TaskDispatchPayload,

--- a/apps/desktop/src/main/hook-control/groupWindow.ts
+++ b/apps/desktop/src/main/hook-control/groupWindow.ts
@@ -25,6 +25,7 @@ import {
   assembleGroupWindowContext,
   createFenceNeutralizer,
   recordGroupWindowEntry,
+  resetGroupWindowCursors,
   type GroupContextAssembly,
 } from '../im/shared/groupWindowCore.js';
 import { getDbClient } from '../localDb/client/current.js';
@@ -124,8 +125,8 @@ export async function sweepGroupWindowExpired(): Promise<void> {
 }
 
 /**
- * 每 lane 的增量游标(上次拼装到的窗口行 id)。内存态: 重启后首次派发会
- * 重新包含整个窗口(一次性冗余, 可接受), 之后恢复增量语义。
+ * 每 lane 的增量游标(上次拼装到的窗口行 id)。内存态只作热缓存, 持久事实在
+ * hook_group_context_cursors; 重启后首次派发从本地 DB 恢复增量语义。
  */
 const contextCursors = new Map<string, number>();
 
@@ -172,9 +173,16 @@ export async function buildGroupContextPrefix(
   });
 }
 
-/** 测试与登出清理: 重置内存游标(窗口行随 DB 生命周期)。 */
-export function resetGroupContextCursors(): void {
-  contextCursors.clear();
+/** 测试与登出清理: 只清理官方群 provider 的内存态与持久游标。 */
+export function resetGroupContextCursors(options?: {
+  clearPersisted?: boolean;
+}): Promise<void> {
+  return resetGroupWindowCursors({
+    cursors: contextCursors,
+    providerPrefixes: ['telegram:'],
+    providerNames: ['telegram'],
+    ...(options?.clearPersisted === false ? { clearPersisted: false } : {}),
+  });
 }
 
 /** 设置卡数据源：官方群窗口里出现过的群，按最近活跃排序。 */

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -1066,7 +1066,7 @@ export async function stopHookControlAccount(): Promise<void> {
 /** Stop and discard all state tied to the current data owner; IPC stays registered. */
 export function resetHookControlOwnerBoundary(): void {
   unregisterSlackToolBridge();
-  resetGroupContextCursors();
+  void resetGroupContextCursors();
   resetTelegramSpeakerRegistrationCache();
   manager?.dispose();
   manager = null;

--- a/apps/desktop/src/main/hook-control/ipc.ts
+++ b/apps/desktop/src/main/hook-control/ipc.ts
@@ -86,7 +86,7 @@ import {
   buildGroupContextPrefix,
   listTelegramKnownGroupsForStableBinding,
   mergeTelegramGroupActivationViews,
-  resetGroupContextCursors,
+  resetGroupContextCursorsSafely,
 } from './groupWindow.js';
 import { createHookDispatcher } from './dispatcher.js';
 import { createMakerHookSessionRunner } from './session-runner.js';
@@ -1064,9 +1064,9 @@ export async function stopHookControlAccount(): Promise<void> {
 }
 
 /** Stop and discard all state tied to the current data owner; IPC stays registered. */
-export function resetHookControlOwnerBoundary(): void {
+export function resetHookControlOwnerBoundary(options?: { clearPersisted?: boolean }): void {
   unregisterSlackToolBridge();
-  void resetGroupContextCursors();
+  resetGroupContextCursorsSafely(options);
   resetTelegramSpeakerRegistrationCache();
   manager?.dispose();
   manager = null;
@@ -1081,5 +1081,7 @@ export function disposeHookControl(): void {
   disposeAuthListener?.();
   disposeAuthListener = null;
   observedAuthRealm = null;
-  resetHookControlOwnerBoundary();
+  // App quit is not an account unbind: preserve the durable cursor and only
+  // discard the in-memory cache so the next process resumes incrementally.
+  resetHookControlOwnerBoundary({ clearPersisted: false });
 }

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -94,6 +94,7 @@ import {
   groupLaneOf,
   recordGroupMessage,
   resetGroupContextCursors,
+  resetGroupContextCursorsSafely,
   sweepGroupWindowExpired,
 } from './groupWindow.js';
 import { parseTelegramConnectUrl } from './telegramDeepLink.js';
@@ -1520,7 +1521,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       drainLanePendingPrefs(lane);
       drainLanePendingBehavior(lane);
       if (lane.config.provider === 'telegram') {
-        void resetGroupContextCursors();
+        resetGroupContextCursorsSafely();
         resetTelegramSpeakerRegistrationCache();
       }
     }

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -1520,7 +1520,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
       drainLanePendingPrefs(lane);
       drainLanePendingBehavior(lane);
       if (lane.config.provider === 'telegram') {
-        resetGroupContextCursors();
+        void resetGroupContextCursors();
         resetTelegramSpeakerRegistrationCache();
       }
     }
@@ -3095,7 +3095,7 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
           lane.serverFeatures = [];
           lane.serverWelcomeReceived = false;
         }
-        resetGroupContextCursors();
+        await resetGroupContextCursors();
         resetTelegramSpeakerRegistrationCache();
         notifySlackToolProviderEnabledIfChanged();
         notifyStatus(toView());

--- a/apps/desktop/src/main/hook-control/manager.ts
+++ b/apps/desktop/src/main/hook-control/manager.ts
@@ -3096,7 +3096,8 @@ export function createHookControlManager(deps: HookControlManagerDeps): HookCont
           lane.serverFeatures = [];
           lane.serverWelcomeReceived = false;
         }
-        await resetGroupContextCursors();
+        // 普通账号边界只清内存热缓存；明确删除账号数据时才清官方群 durable cursor。
+        await resetGroupContextCursors({ clearPersisted: false });
         resetTelegramSpeakerRegistrationCache();
         notifySlackToolProviderEnabledIfChanged();
         notifyStatus(toView());

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -1027,6 +1027,18 @@ export function createMakerHookSessionRunner(deps: {
           releaseTelegramGroupTurn();
           return fail(`send not dispatched: ${outcome.reason}`);
         }
+        // 与个人 IM turnRunner 的 route-resolved 时机一致：只有 provider 已
+        // 实际接受本次 send 后才执行 durable 群游标提交。回调失败不能反转
+        // 已受理 turn；旧游标会让下次最多重复携带，而不会永久跳过消息。
+        try {
+          await req.onProviderAccepted?.();
+        } catch (err) {
+          log.warn(
+            `provider-accepted callback failed for session=${session.id.slice(-8)}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
       } catch (err) {
         observer.stop();
         finalizeInteractions();

--- a/apps/desktop/src/main/im/__tests__/connectionLifecycle.test.ts
+++ b/apps/desktop/src/main/im/__tests__/connectionLifecycle.test.ts
@@ -59,6 +59,21 @@ describe('serialized IM connection lifecycle', () => {
     expect(stopConnection).toHaveBeenCalledTimes(2);
   });
 
+  it('forwards the stop reason to the serialized connection teardown', async () => {
+    const stopConnection = vi.fn(async (_reason?: string) => undefined);
+    const lifecycle = createSerializedConnectionLifecycle({
+      startConnection: vi.fn(async () => undefined),
+      stopConnection,
+      onStartError: vi.fn(),
+    });
+
+    lifecycle.start();
+    await vi.waitFor(() => expect(lifecycle.isStarted()).toBe(true));
+    await lifecycle.stop('quit');
+
+    expect(stopConnection).toHaveBeenCalledWith('quit');
+  });
+
   it('cancels a queued start when logout wins the race', async () => {
     const startConnection = vi.fn(async () => undefined);
     const stopConnection = vi.fn(async () => undefined);

--- a/apps/desktop/src/main/im/connectionLifecycle.ts
+++ b/apps/desktop/src/main/im/connectionLifecycle.ts
@@ -5,7 +5,7 @@
  */
 export interface SerializedConnectionLifecycle {
   start(): void;
-  stop(): Promise<void>;
+  stop(reason?: string): Promise<void>;
   runWhileStarted<T>(operation: () => Promise<T>): Promise<T>;
   isStarted(): boolean;
 }
@@ -13,7 +13,7 @@ export interface SerializedConnectionLifecycle {
 /** Dependencies are injected so lifecycle ordering stays unit-testable. */
 export interface SerializedConnectionLifecycleDeps {
   startConnection(): Promise<void>;
-  stopConnection(): Promise<void>;
+  stopConnection(reason?: string): Promise<void>;
   onStartError(error: unknown): void;
 }
 
@@ -55,14 +55,14 @@ export function createSerializedConnectionLifecycle(
       });
     },
 
-    async stop(): Promise<void> {
+    async stop(reason?: string): Promise<void> {
       const shouldStopConnection = needsStop;
       started = false;
       needsStop = false;
       generation += 1;
       await enqueue(async () => {
         if (!shouldStopConnection) return;
-        await deps.stopConnection();
+        await deps.stopConnection(reason);
       });
     },
 

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -550,7 +550,7 @@ async function reconcileOwnerScopedImWorkingDirs(): Promise<void> {
 
 const connectionLifecycle = createSerializedConnectionLifecycle({
   startConnection: initializeImConnection,
-  stopConnection: async () => {
+  stopConnection: async (reason) => {
     // Transports stop first so no new message can enter while account-scoped
     // orchestrator and binding caches are being discarded.
     try {
@@ -565,9 +565,9 @@ const connectionLifecycle = createSerializedConnectionLifecycle({
         }
       }
       bindingStore.resetRuntime();
-      // 群上下文游标是账号内存态 — 登出/换号必须清零, 防止新账号复用旧游标
-      // 造成上下文窗口被静默跳过。
-      await resetTelegramGroupContextCursors();
+      // 登出/换号是明确的账号边界, 清掉旧账号的持久游标；普通退出只清内存
+      // 热缓存, 保留本地 DB 游标让下一次启动继续增量语义。
+      await resetTelegramGroupContextCursors({ clearPersisted: reason !== 'quit' });
     }
   },
   onStartError: (err) => {
@@ -651,5 +651,5 @@ export async function stopImConnection(reason: string): Promise<void> {
     // are released, so old-account work cannot resume against a new account.
     await waitForImAccountGenerationIdle(closingGeneration);
   }
-  await connectionLifecycle.stop();
+  await connectionLifecycle.stop(reason);
 }

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -567,7 +567,7 @@ const connectionLifecycle = createSerializedConnectionLifecycle({
       bindingStore.resetRuntime();
       // 群上下文游标是账号内存态 — 登出/换号必须清零, 防止新账号复用旧游标
       // 造成上下文窗口被静默跳过。
-      resetTelegramGroupContextCursors();
+      await resetTelegramGroupContextCursors();
     }
   },
   onStartError: (err) => {

--- a/apps/desktop/src/main/im/index.ts
+++ b/apps/desktop/src/main/im/index.ts
@@ -565,9 +565,10 @@ const connectionLifecycle = createSerializedConnectionLifecycle({
         }
       }
       bindingStore.resetRuntime();
-      // 登出/换号是明确的账号边界, 清掉旧账号的持久游标；普通退出只清内存
-      // 热缓存, 保留本地 DB 游标让下一次启动继续增量语义。
-      await resetTelegramGroupContextCursors({ clearPersisted: reason !== 'quit' });
+      // 普通退出、登出、换账号与模式切换都只清内存热缓存, 保留本地 DB 游标；
+      // 只有明确删除账号数据时才清持久表。Telegram bot 解绑由 hook-control 的
+      // binding identity reset 单独处理, 不把 auth logout 误当成数据删除。
+      await resetTelegramGroupContextCursors({ clearPersisted: reason === 'account-deletion' });
     }
   },
   onStartError: (err) => {

--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -372,6 +372,7 @@ function setupSessionWithId(
 interface TurnOverrides {
   userMessageId?: string;
   text?: string;
+  onRouteResolved?: (sessionId: string) => void | Promise<void>;
 }
 
 async function runDefaultTurn(
@@ -394,6 +395,7 @@ async function startDefaultTurn(
     text: overrides.text ?? 'PROMPT_SECRET full user message TOKEN_VALUE file body',
     attachments: [],
     onTurnComplete,
+    ...(overrides.onRouteResolved ? { onRouteResolved: overrides.onRouteResolved } : {}),
   });
   return { onTurnComplete, turnPromise };
 }
@@ -991,11 +993,13 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     const busy = new CredentialModeSwitchBusyError(['busy-session']);
     mocks.getMaker.mockReturnValue(createMakerCreateSessionFailureHarness(busy));
     const onTurnComplete = vi.fn();
+    const onRouteResolved = vi.fn();
 
-    await runDefaultTurn(onTurnComplete);
+    await runDefaultTurn(onTurnComplete, { onRouteResolved });
     await flushMicrotasks();
 
     expect(onTurnComplete).toHaveBeenCalledTimes(1);
+    expect(onRouteResolved).not.toHaveBeenCalled();
     expect(mocks.feishuIm.removeMessageReaction).toHaveBeenCalledWith('msg-user', 'reaction-1');
     expect(mocks.feishuIm.sendText).toHaveBeenCalledWith(
       'ou_user',
@@ -1203,7 +1207,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     });
   });
 
-  it('reports the attached Desktop route before provider startup', async () => {
+  it('reports the attached Desktop route only after provider startup is accepted', async () => {
     const h = setupAttachedSession(async () => ({ accepted: true }));
     const onRouteResolved = vi.fn();
     const beforeProviderStart = vi.fn(async () => undefined);
@@ -1221,7 +1225,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
 
     expect(dispatch.kind).toBe('accepted');
     expect(onRouteResolved).toHaveBeenCalledWith('desktop-attached-session');
-    expect(onRouteResolved.mock.invocationCallOrder[0]).toBeLessThan(
+    expect(onRouteResolved.mock.invocationCallOrder[0]).toBeGreaterThan(
       beforeProviderStart.mock.invocationCallOrder[0]!,
     );
 
@@ -1835,7 +1839,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
 
   it('does not report route resolution before auth passes on an existing route', async () => {
     // 群窗口游标的 commit 挂在 onRouteResolved 上(prepareAgentTurnText 契约):
-    // 鉴权失败被拒的消息若先触发它, 这批群上下文会被游标永久跳过。
+    // 受理前鉴权失败若先触发它, 这批群上下文会被游标永久跳过。
     mocks.readXdGatewayApiKey.mockReturnValue(null);
     mocks.findActiveSession.mockResolvedValue({
       id: 'feishu-session',

--- a/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
@@ -1017,18 +1017,23 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     mocks.feishuIm.reactToMessage.mockImplementation(async (messageId: string) => `reaction-${messageId}`);
     const h = setupSession(async () => ({ accepted: true }));
     const firstComplete = vi.fn();
+    const firstRouteResolved = vi.fn();
     await runDefaultTurn(firstComplete, {
       userMessageId: 'msg-first',
       text: 'first user message',
+      onRouteResolved: firstRouteResolved,
     });
 
     expect(firstComplete).not.toHaveBeenCalled();
     expect(h.send).toHaveBeenCalledTimes(1);
+    expect(firstRouteResolved).toHaveBeenCalledTimes(1);
 
     const secondComplete = vi.fn();
+    const secondRouteResolved = vi.fn();
     await runDefaultTurn(secondComplete, {
       userMessageId: 'msg-second',
       text: 'second user message',
+      onRouteResolved: secondRouteResolved,
     });
     await flushMicrotasks();
 
@@ -1038,6 +1043,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     expect(mocks.feishuIm.sendText).not.toHaveBeenCalled();
     expect(mocks.feishuIm.sendMarkdownText).toHaveBeenCalledTimes(1);
     expect(secondComplete).not.toHaveBeenCalled();
+    expect(secondRouteResolved).not.toHaveBeenCalled();
     expect(mocks.persistUserMessage).toHaveBeenCalledTimes(1);
 
     h.emit({
@@ -1057,6 +1063,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
     });
 
     expect(firstComplete).toHaveBeenCalledTimes(1);
+    expect(secondRouteResolved).toHaveBeenCalledTimes(1);
     expect(mocks.feishuIm.removeMessageReaction).toHaveBeenCalledWith('msg-first', 'reaction-msg-first');
     expect(mocks.persistUserMessage).toHaveBeenCalledTimes(2);
     // assistant 落库收口在 messagePersistBroadcaster(经 wireSessionToIpcExternal),
@@ -1943,10 +1950,22 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
       async (messageId: string) => `reaction-${messageId}`,
     );
     const h = setupSession(async () => ({ accepted: true }));
-    await runDefaultTurn(vi.fn(), { userMessageId: 'msg-first', text: 'first user message' });
-    await runDefaultTurn(vi.fn(), { userMessageId: 'msg-second', text: 'second user message' });
+    const firstRouteResolved = vi.fn();
+    await runDefaultTurn(vi.fn(), {
+      userMessageId: 'msg-first',
+      text: 'first user message',
+      onRouteResolved: firstRouteResolved,
+    });
+    const secondRouteResolved = vi.fn();
+    await runDefaultTurn(vi.fn(), {
+      userMessageId: 'msg-second',
+      text: 'second user message',
+      onRouteResolved: secondRouteResolved,
+    });
     await flushMicrotasks();
     expect(h.send).toHaveBeenCalledTimes(1);
+    expect(firstRouteResolved).toHaveBeenCalledTimes(1);
+    expect(secondRouteResolved).not.toHaveBeenCalled();
 
     const result = await getRunner().stopActiveTurn({
       botContextId: 'cli_test_bot',
@@ -1962,6 +1981,7 @@ describe('turnRunner send outcome policy (feishu adapter characterization)', () 
         'reaction-msg-second',
       );
     });
+    expect(secondRouteResolved).not.toHaveBeenCalled();
 
     // abort 触发的 done 不得把已丢弃的排队消息派发出去
     h.emit({ type: 'done', data: {} });

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -1,9 +1,9 @@
 /** 官方/个人 Telegram bot 群消息窗口共享核心；provider 必填且读写/GC 不跨命名空间。 */
 
-import { and, desc, eq, gt, lt, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gt, like, lt, or, sql, type SQL } from 'drizzle-orm';
 
-import { getDbClient } from '../../localDb/client/current';
-import { hookGroupMessages } from '../../localDb/schema';
+import { getDbClient, tryGetDbClient } from '../../localDb/client/current';
+import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
 import type { Logger } from '../../logger';
 
 export const GROUP_WINDOW_ENTRY_TEXT_MAX_CHARS = 500;
@@ -28,7 +28,7 @@ export interface GroupWindowEntryInput {
 export interface GroupContextAssembly {
   prefix: string;
   /** 任务/消息被实际受理后调用；拒绝时不调用，未读批次留给下次触发。 */
-  commit: () => void;
+  commit: () => void | Promise<void>;
 }
 
 interface GroupWindowRow {
@@ -60,7 +60,7 @@ export async function recordGroupWindowEntry(
       chatName: entry.chatName,
       author: entry.author.name,
       isBot: entry.author.isBot === true ? 1 : 0,
-      text: entry.text.slice(0, GROUP_WINDOW_ENTRY_TEXT_MAX_CHARS),
+      text: entry.text,
       fileNames: entry.fileNames?.length ? JSON.stringify(entry.fileNames) : null,
       sentAt: entry.sentAt,
       createdAt: Date.now(),
@@ -108,6 +108,72 @@ export async function recordGroupWindowEntry(
   return true;
 }
 
+async function readPersistedCursor(provider: string, cursorKey: string): Promise<number> {
+  const rows = await getDbClient()
+    .drizzle.select({ cursorId: hookGroupContextCursors.cursorId })
+    .from(hookGroupContextCursors)
+    .where(
+      and(
+        eq(hookGroupContextCursors.provider, provider),
+        eq(hookGroupContextCursors.cursorKey, cursorKey),
+      ),
+    )
+    .limit(1);
+  return rows[0]?.cursorId ?? 0;
+}
+
+async function persistCursor(provider: string, cursorKey: string, cursorId: number): Promise<number> {
+  const now = Date.now();
+  await getDbClient()
+    .drizzle.insert(hookGroupContextCursors)
+    .values({ provider, cursorKey, cursorId, updatedAt: now })
+    .onConflictDoUpdate({
+      target: [hookGroupContextCursors.provider, hookGroupContextCursors.cursorKey],
+      // Multiple lanes may finish close together. Never let an older commit
+      // move a durable cursor backwards.
+      set: {
+        cursorId: sql`MAX(cursor_id, excluded.cursor_id)`,
+        updatedAt: now,
+      },
+    });
+  return readPersistedCursor(provider, cursorKey);
+}
+
+function rememberCursor(cursors: Map<string, number>, cursorKey: string, cursor: number): void {
+  cursors.set(cursorKey, cursor);
+  if (cursors.size <= CURSOR_MAX_KEYS) return;
+  const oldest = cursors.keys().next().value;
+  if (oldest !== undefined) cursors.delete(oldest);
+}
+
+/** 清理指定 provider 命名空间的内存态与持久游标。 */
+export async function resetGroupWindowCursors(args: {
+  cursors: Map<string, number>;
+  providerPrefixes: readonly string[];
+  providerNames?: readonly string[];
+  clearPersisted?: boolean;
+}): Promise<void> {
+  args.cursors.clear();
+  if (
+    args.clearPersisted === false ||
+    (args.providerPrefixes.length === 0 && (args.providerNames?.length ?? 0) === 0)
+  )
+    return;
+  const filters = [
+    ...args.providerPrefixes.map((prefix) =>
+      like(hookGroupContextCursors.provider, `${prefix}%`),
+    ),
+    ...(args.providerNames ?? []).map((provider) =>
+      eq(hookGroupContextCursors.provider, provider),
+    ),
+  ];
+  const dbClient = tryGetDbClient();
+  if (!dbClient) return;
+  await dbClient
+    .drizzle.delete(hookGroupContextCursors)
+    .where(filters.length === 1 ? filters[0] : or(...filters));
+}
+
 async function readRows(args: {
   provider: string;
   chatId: string;
@@ -146,7 +212,9 @@ export async function assembleGroupWindowContext(args: {
   neutralize: (value: string) => string;
   log: Logger;
 }): Promise<GroupContextAssembly> {
-  const cursor = args.cursors.get(args.cursorKey) ?? 0;
+  const inMemoryCursor = args.cursors.get(args.cursorKey);
+  const cursor = inMemoryCursor ?? (await readPersistedCursor(args.provider, args.cursorKey));
+  if (inMemoryCursor === undefined) rememberCursor(args.cursors, args.cursorKey, cursor);
   const read = (threadFilter: SQL<unknown>) =>
     readRows({ provider: args.provider, chatId: args.chatId, threadFilter, cursor });
   const primaryRows = await read(eq(hookGroupMessages.threadId, args.threadId));
@@ -169,7 +237,9 @@ export async function assembleGroupWindowContext(args: {
           /* 老行损坏时静默丢附件标注 */
         }
       }
-      const line = args.neutralize(`[${row.author}] ${row.text}${fileNote}`);
+      const line = args.neutralize(
+        `[${row.author}] ${row.text.slice(0, GROUP_WINDOW_ENTRY_TEXT_MAX_CHARS)}${fileNote}`,
+      );
       if (totalChars + line.length > CONTEXT_MAX_CHARS) {
         truncated = true;
         break;
@@ -185,13 +255,18 @@ export async function assembleGroupWindowContext(args: {
 
   const commit =
     maxId > cursor
-      ? (): void => {
+      ? async (): Promise<void> => {
           const current = args.cursors.get(args.cursorKey) ?? 0;
           if (maxId <= current) return;
-          args.cursors.set(args.cursorKey, maxId);
-          if (args.cursors.size > CURSOR_MAX_KEYS) {
-            const oldest = args.cursors.keys().next().value;
-            if (oldest !== undefined) args.cursors.delete(oldest);
+          try {
+            const durableCursor = await persistCursor(args.provider, args.cursorKey, maxId);
+            const latest = args.cursors.get(args.cursorKey) ?? 0;
+            if (durableCursor > latest) rememberCursor(args.cursors, args.cursorKey, durableCursor);
+          } catch (error) {
+            // Durable cursor failure must not turn an already-routable message
+            // into a stuck queue/running slot. Keep the old in-memory cursor so
+            // the same batch is retried on the next trigger.
+            args.log.warn(`group context cursor persist failed: ${String(error)}`);
           }
         }
       : (): void => undefined;

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -138,7 +138,12 @@ async function readPersistedCursor(provider: string, cursorKey: string): Promise
   return rows[0]?.cursorId ?? 0;
 }
 
-async function persistCursor(provider: string, cursorKey: string, cursorId: number): Promise<number> {
+async function persistCursor(
+  provider: string,
+  cursorKey: string,
+  cursorId: number,
+  previousCursor: number,
+): Promise<number> {
   const now = Date.now();
   await getDbClient()
     .drizzle.insert(hookGroupContextCursors)
@@ -152,7 +157,11 @@ async function persistCursor(provider: string, cursorKey: string, cursorId: numb
         updatedAt: now,
       },
     });
-  return readPersistedCursor(provider, cursorKey);
+  // The UPSERT is the durable write boundary. Do not read the row back here:
+  // a successful write must still leave the caller with a rollback receipt if
+  // a subsequent read happens to fail. The in-memory value is monotonic, and
+  // a concurrent higher commit is protected by the update/rollback guards.
+  return Math.max(previousCursor, cursorId);
 }
 
 /**
@@ -306,7 +315,12 @@ export async function assembleGroupWindowContext(args: {
           if (guard !== undefined && !(await guard())) return;
           try {
             const previousDurableCursor = await readPersistedCursor(args.provider, args.cursorKey);
-            const durableCursor = await persistCursor(args.provider, args.cursorKey, maxId);
+            const durableCursor = await persistCursor(
+              args.provider,
+              args.cursorKey,
+              maxId,
+              previousDurableCursor,
+            );
             let rolledBack = false;
             const receipt: GroupContextCommitReceipt = {
               rollback: async (): Promise<void> => {

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -10,6 +10,8 @@ export const GROUP_WINDOW_ENTRY_TEXT_MAX_CHARS = 500;
 const CONTEXT_READ_LIMIT = 500;
 const CONTEXT_MAX_CHARS = 4_000;
 const CURSOR_MAX_KEYS = 1000;
+const CURSOR_ROLLBACK_MAX_ATTEMPTS = 3;
+const CURSOR_ROLLBACK_RETRY_DELAY_MS = 25;
 
 export type GroupWindowRetentionPolicy = { keepPerKey: number; keepPerNamespace: number };
 
@@ -325,25 +327,40 @@ export async function assembleGroupWindowContext(args: {
             const receipt: GroupContextCommitReceipt = {
               rollback: async (): Promise<void> => {
                 if (rolledBack) return;
-                rolledBack = true;
-                try {
-                  const restoredDurableCursor = await rollbackPersistedCursor(
-                    args.provider,
-                    args.cursorKey,
-                    maxId,
-                    previousDurableCursor,
-                  );
-                  const latest = args.cursors.get(args.cursorKey) ?? 0;
-                  if (latest <= maxId) {
-                    rememberCursor(
-                      args.cursors,
+                let lastError: unknown;
+                for (let attempt = 0; attempt < CURSOR_ROLLBACK_MAX_ATTEMPTS; attempt += 1) {
+                  try {
+                    const restoredDurableCursor = await rollbackPersistedCursor(
+                      args.provider,
                       args.cursorKey,
-                      Math.max(current, restoredDurableCursor),
+                      maxId,
+                      previousDurableCursor,
                     );
+                    const latest = args.cursors.get(args.cursorKey) ?? 0;
+                    if (latest <= maxId) {
+                      rememberCursor(
+                        args.cursors,
+                        args.cursorKey,
+                        Math.max(current, restoredDurableCursor),
+                      );
+                    }
+                    // Keep the receipt live until the durable restore has
+                    // completed. A transient SQLite failure must leave the
+                    // caller able to retry the compensation instead of
+                    // silently turning a failed rollback into a permanent
+                    // cursor advance.
+                    rolledBack = true;
+                    return;
+                  } catch (error) {
+                    lastError = error;
+                    if (attempt + 1 < CURSOR_ROLLBACK_MAX_ATTEMPTS) {
+                      await new Promise<void>((resolve) =>
+                        setTimeout(resolve, CURSOR_ROLLBACK_RETRY_DELAY_MS * (attempt + 1)),
+                      );
+                    }
                   }
-                } catch (error) {
-                  args.log.warn(`group context cursor rollback failed: ${String(error)}`);
                 }
+                args.log.warn(`group context cursor rollback failed: ${String(lastError)}`);
               },
             };
             if (guard !== undefined && !(await guard())) {

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -360,7 +360,14 @@ export async function assembleGroupWindowContext(args: {
                     }
                   }
                 }
-                args.log.warn(`group context cursor rollback failed: ${String(lastError)}`);
+                const rollbackError =
+                  lastError instanceof Error ? lastError : new Error(String(lastError));
+                args.log.warn(`group context cursor rollback failed: ${rollbackError.message}`);
+                // Do not report compensation as successful after the bounded
+                // retry budget is exhausted. Callers must keep the failure
+                // visible rather than discarding an unexecuted task as if its
+                // durable cursor had been restored.
+                throw rollbackError;
               },
             };
             if (guard !== undefined && !(await guard())) {

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -28,7 +28,12 @@ export interface GroupWindowEntryInput {
 export interface GroupContextAssembly {
   prefix: string;
   /** 任务/消息被实际受理后调用；拒绝时不调用，未读批次留给下次触发。 */
-  commit: (guard?: GroupContextCommitGuard) => void | Promise<void>;
+  commit: (
+    guard?: GroupContextCommitGuard,
+  ) =>
+    | void
+    | GroupContextCommitReceipt
+    | Promise<void | GroupContextCommitReceipt>;
 }
 
 /**
@@ -36,6 +41,11 @@ export interface GroupContextAssembly {
  * commit 必须回滚自己刚写入的游标，避免“任务没跑但上下文已跳过”。
  */
 export type GroupContextCommitGuard = () => boolean | Promise<boolean>;
+
+/** commit 已落下游标后的补偿句柄；只撤销本次写入，不覆盖并发推进的更高游标。 */
+export interface GroupContextCommitReceipt {
+  rollback(): Promise<void>;
+}
 
 interface GroupWindowRow {
   id: number;
@@ -154,7 +164,7 @@ async function rollbackPersistedCursor(
   cursorKey: string,
   maxId: number,
   previousCursor: number,
-): Promise<void> {
+): Promise<number> {
   const db = getDbClient().drizzle;
   const rowFilter = and(
     eq(hookGroupContextCursors.provider, provider),
@@ -166,9 +176,10 @@ async function rollbackPersistedCursor(
       .update(hookGroupContextCursors)
       .set({ cursorId: previousCursor, updatedAt: Date.now() })
       .where(rowFilter);
-    return;
+  } else {
+    await db.delete(hookGroupContextCursors).where(rowFilter);
   }
-  await db.delete(hookGroupContextCursors).where(rowFilter);
+  return readPersistedCursor(provider, cursorKey);
 }
 
 function rememberCursor(cursors: Map<string, number>, cursorKey: string, cursor: number): void {
@@ -287,27 +298,47 @@ export async function assembleGroupWindowContext(args: {
 
   const commit =
     maxId > cursor
-      ? async (guard?: GroupContextCommitGuard): Promise<void> => {
+      ? async (
+          guard?: GroupContextCommitGuard,
+        ): Promise<void | GroupContextCommitReceipt> => {
           const current = args.cursors.get(args.cursorKey) ?? 0;
           if (maxId <= current) return;
           if (guard !== undefined && !(await guard())) return;
           try {
             const previousDurableCursor = await readPersistedCursor(args.provider, args.cursorKey);
             const durableCursor = await persistCursor(args.provider, args.cursorKey, maxId);
+            let rolledBack = false;
+            const receipt: GroupContextCommitReceipt = {
+              rollback: async (): Promise<void> => {
+                if (rolledBack) return;
+                rolledBack = true;
+                try {
+                  const restoredDurableCursor = await rollbackPersistedCursor(
+                    args.provider,
+                    args.cursorKey,
+                    maxId,
+                    previousDurableCursor,
+                  );
+                  const latest = args.cursors.get(args.cursorKey) ?? 0;
+                  if (latest <= maxId) {
+                    rememberCursor(
+                      args.cursors,
+                      args.cursorKey,
+                      Math.max(current, restoredDurableCursor),
+                    );
+                  }
+                } catch (error) {
+                  args.log.warn(`group context cursor rollback failed: ${String(error)}`);
+                }
+              },
+            };
             if (guard !== undefined && !(await guard())) {
-              await rollbackPersistedCursor(
-                args.provider,
-                args.cursorKey,
-                maxId,
-                previousDurableCursor,
-              );
-              if ((args.cursors.get(args.cursorKey) ?? 0) === maxId) {
-                rememberCursor(args.cursors, args.cursorKey, current);
-              }
+              await receipt.rollback();
               return;
             }
             const latest = args.cursors.get(args.cursorKey) ?? 0;
             if (durableCursor > latest) rememberCursor(args.cursors, args.cursorKey, durableCursor);
+            return receipt;
           } catch (error) {
             // Durable cursor failure must not turn an already-routable message
             // into a stuck queue/running slot. Keep the old in-memory cursor so

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -28,8 +28,14 @@ export interface GroupWindowEntryInput {
 export interface GroupContextAssembly {
   prefix: string;
   /** 任务/消息被实际受理后调用；拒绝时不调用，未读批次留给下次触发。 */
-  commit: () => void | Promise<void>;
+  commit: (guard?: GroupContextCommitGuard) => void | Promise<void>;
 }
+
+/**
+ * 可选的受理代次守卫。持久游标写入前后都会检查它；账号边界在中途失效时，
+ * commit 必须回滚自己刚写入的游标，避免“任务没跑但上下文已跳过”。
+ */
+export type GroupContextCommitGuard = () => boolean | Promise<boolean>;
 
 interface GroupWindowRow {
   id: number;
@@ -137,6 +143,32 @@ async function persistCursor(provider: string, cursorKey: string, cursorId: numb
       },
     });
   return readPersistedCursor(provider, cursorKey);
+}
+
+/**
+ * 仅在该行仍等于本次 commit 写入的 maxId 时回滚，避免覆盖并发任务已经推进的
+ * 更高游标。旧值为 0 时删除行，保持空游标的原始形态。
+ */
+async function rollbackPersistedCursor(
+  provider: string,
+  cursorKey: string,
+  maxId: number,
+  previousCursor: number,
+): Promise<void> {
+  const db = getDbClient().drizzle;
+  const rowFilter = and(
+    eq(hookGroupContextCursors.provider, provider),
+    eq(hookGroupContextCursors.cursorKey, cursorKey),
+    eq(hookGroupContextCursors.cursorId, maxId),
+  );
+  if (previousCursor > 0) {
+    await db
+      .update(hookGroupContextCursors)
+      .set({ cursorId: previousCursor, updatedAt: Date.now() })
+      .where(rowFilter);
+    return;
+  }
+  await db.delete(hookGroupContextCursors).where(rowFilter);
 }
 
 function rememberCursor(cursors: Map<string, number>, cursorKey: string, cursor: number): void {
@@ -255,11 +287,25 @@ export async function assembleGroupWindowContext(args: {
 
   const commit =
     maxId > cursor
-      ? async (): Promise<void> => {
+      ? async (guard?: GroupContextCommitGuard): Promise<void> => {
           const current = args.cursors.get(args.cursorKey) ?? 0;
           if (maxId <= current) return;
+          if (guard !== undefined && !(await guard())) return;
           try {
+            const previousDurableCursor = await readPersistedCursor(args.provider, args.cursorKey);
             const durableCursor = await persistCursor(args.provider, args.cursorKey, maxId);
+            if (guard !== undefined && !(await guard())) {
+              await rollbackPersistedCursor(
+                args.provider,
+                args.cursorKey,
+                maxId,
+                previousDurableCursor,
+              );
+              if ((args.cursors.get(args.cursorKey) ?? 0) === maxId) {
+                rememberCursor(args.cursors, args.cursorKey, current);
+              }
+              return;
+            }
             const latest = args.cursors.get(args.cursorKey) ?? 0;
             if (durableCursor > latest) rememberCursor(args.cursors, args.cursorKey, durableCursor);
           } catch (error) {

--- a/apps/desktop/src/main/im/shared/messageHandler.ts
+++ b/apps/desktop/src/main/im/shared/messageHandler.ts
@@ -215,8 +215,8 @@ export function createMessageHandler(
         ...(prepared ? { agentText: prepared.agentText } : {}),
         ...(prepared?.commit
           ? {
-              // 路由解析成功 = 消息确定会被派发/排队 — 群窗口游标此刻才推进,
-              // 路由失败(鉴权缺失等)不推进, 上下文批次下次仍进 prompt。
+              // turnRunner 只在消息完成鉴权、wiring 且确定派发/排队后调用；
+              // 受理前失败不推进, 上下文批次下次仍进 prompt。
               onRouteResolved: async () => {
                 await prepared?.commit?.();
               },

--- a/apps/desktop/src/main/im/shared/messageHandler.ts
+++ b/apps/desktop/src/main/im/shared/messageHandler.ts
@@ -194,7 +194,7 @@ export function createMessageHandler(
 
     // ── invoke agent ────────────────────────────────────────────────────────
     // 送模型正文改写钩子(群上下文拼装): 失败按"不改写"降级, 不阻断消息。
-    let prepared: { agentText: string; commit?: () => void } | null = null;
+    let prepared: { agentText: string; commit?: () => void | Promise<void> } | null = null;
     if (adapter.prepareAgentTurnText) {
       try {
         prepared = await adapter.prepareAgentTurnText(event);
@@ -217,7 +217,9 @@ export function createMessageHandler(
           ? {
               // 路由解析成功 = 消息确定会被派发/排队 — 群窗口游标此刻才推进,
               // 路由失败(鉴权缺失等)不推进, 上下文批次下次仍进 prompt。
-              onRouteResolved: () => prepared?.commit?.(),
+              onRouteResolved: async () => {
+                await prepared?.commit?.();
+              },
             }
           : {}),
         attachments: event.attachments,

--- a/apps/desktop/src/main/im/shared/messageHandler.ts
+++ b/apps/desktop/src/main/im/shared/messageHandler.ts
@@ -215,8 +215,8 @@ export function createMessageHandler(
         ...(prepared ? { agentText: prepared.agentText } : {}),
         ...(prepared?.commit
           ? {
-              // turnRunner 只在消息完成鉴权、wiring 且确定派发/排队后调用；
-              // 受理前失败不推进, 上下文批次下次仍进 prompt。
+              // turnRunner 只在 provider 真正接受消息后调用；排队、停止与
+              // teardown 都不推进游标, 受理前失败时上下文批次下次仍进 prompt。
               onRouteResolved: async () => {
                 await prepared?.commit?.();
               },

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -324,7 +324,7 @@ export interface ImRunAgentTurnArgs {
   outputCardMessageId?: string;
   outputCardPrefix?: string;
   onTurnComplete?: () => void;
-  /** Reports the concrete channel/default or attached Desktop session before provider startup. */
+  /** Reports the concrete session only after this message is accepted or queued for dispatch. */
   onRouteResolved?: (sessionId: string) => void | Promise<void>;
   /** Keep fire-and-forget work inside the ingress account's drain boundary. */
   trackBackgroundTask?: (operation: () => Promise<void>) => void;
@@ -597,10 +597,6 @@ export function createTurnRunner(
         return { kind: 'rejected', reason: 'missing_auth' };
       }
     }
-    // onRouteResolved 必须在鉴权通过之后才算"路由解析成功" —— 群窗口游标的
-    // commit 挂在它上面, 鉴权失败被拒的消息若先触发它, 这批群上下文会被游标
-    // 永久跳过(prepareAgentTurnText 的契约: 路由失败不推进游标)。
-    await args.onRouteResolved?.(row.id);
     // ── thread 名片卡(threadScoped 新 thread 会话)─────────────────────────
     // 在 bot 第一条回复之前发进 thread, 让用户第一眼理解"这个 thread = 一条
     // 独立会话";首条消息的 oneshot 标题生成完成后, 名片原地升级为正式标题
@@ -758,6 +754,9 @@ export function createTurnRunner(
         return { kind: 'busy', reason: 'session_running' };
       }
       state.sendQueue.push(item);
+      // wiring 已成功且消息已可靠入队；此刻才推进群窗口游标，避免
+      // credential-mode switch 等 pre-dispatch 失败跳过未受理上下文。
+      await args.onRouteResolved?.(row.id);
       log.info(`queued message for session=${row.id.slice(-8)} position=${state.sendQueue.length}`);
       // 本渠道没有未收口的 turn(纯 desktop turn 在跑) → 派发只能靠它的 stray
       // done/error 触发;若该事件在 enqueue 前已送达(isTurnRunning 释放略晚于
@@ -771,6 +770,13 @@ export function createTurnRunner(
     }
 
     const dispatch = await dispatchQueuedSend(state, userId, item);
+    if (
+      dispatch.kind === 'accepted' ||
+      (dispatch.kind === 'busy' && dispatch.reason === 'queued_internally')
+    ) {
+      // accepted 或 SESSION_RUNNING 竞态下已可靠回队首，均已确定会执行。
+      await args.onRouteResolved?.(row.id);
+    }
     if (dispatch.kind !== 'accepted') return dispatch;
     return {
       kind: 'accepted',

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -225,6 +225,8 @@ interface QueuedSend {
   notified: boolean;
   queueMode: 'internal' | 'external';
   beforeProviderStart?: () => Promise<void>;
+  /** Durable route side effects run only after provider acceptance, never on enqueue. */
+  onRouteResolved?: (sessionId: string) => void | Promise<void>;
   turnPermissionPolicy?: TurnPermissionPolicy;
 }
 
@@ -324,7 +326,7 @@ export interface ImRunAgentTurnArgs {
   outputCardMessageId?: string;
   outputCardPrefix?: string;
   onTurnComplete?: () => void;
-  /** Reports the concrete session only after this message is accepted or queued for dispatch. */
+  /** Reports the concrete session only after the provider accepts this message. */
   onRouteResolved?: (sessionId: string) => void | Promise<void>;
   /** Keep fire-and-forget work inside the ingress account's drain boundary. */
   trackBackgroundTask?: (operation: () => Promise<void>) => void;
@@ -738,6 +740,7 @@ export function createTurnRunner(
       notified: false,
       queueMode: args.queueMode,
       ...(args.beforeProviderStart ? { beforeProviderStart: args.beforeProviderStart } : {}),
+      ...(args.onRouteResolved ? { onRouteResolved: args.onRouteResolved } : {}),
       ...(turnPermissionPolicy ? { turnPermissionPolicy } : {}),
     };
 
@@ -754,9 +757,6 @@ export function createTurnRunner(
         return { kind: 'busy', reason: 'session_running' };
       }
       state.sendQueue.push(item);
-      // wiring 已成功且消息已可靠入队；此刻才推进群窗口游标，避免
-      // credential-mode switch 等 pre-dispatch 失败跳过未受理上下文。
-      await args.onRouteResolved?.(row.id);
       log.info(`queued message for session=${row.id.slice(-8)} position=${state.sendQueue.length}`);
       // 本渠道没有未收口的 turn(纯 desktop turn 在跑) → 派发只能靠它的 stray
       // done/error 触发;若该事件在 enqueue 前已送达(isTurnRunning 释放略晚于
@@ -770,13 +770,6 @@ export function createTurnRunner(
     }
 
     const dispatch = await dispatchQueuedSend(state, userId, item);
-    if (
-      dispatch.kind === 'accepted' ||
-      (dispatch.kind === 'busy' && dispatch.reason === 'queued_internally')
-    ) {
-      // accepted 或 SESSION_RUNNING 竞态下已可靠回队首，均已确定会执行。
-      await args.onRouteResolved?.(row.id);
-    }
     if (dispatch.kind !== 'accepted') return dispatch;
     return {
       kind: 'accepted',
@@ -927,6 +920,18 @@ export function createTurnRunner(
           context: outcome.context,
         });
         return { kind: 'rejected', reason: outcome.reason };
+      }
+      // Route side effects include the durable group cursor commit. The
+      // provider has accepted this send now; invoking the callback here keeps
+      // queued teardown and SESSION_RUNNING requeue paths from advancing it.
+      try {
+        await item.onRouteResolved?.(rowId);
+      } catch (err) {
+        log.warn(
+          `route-resolved callback failed for session=${rowId.slice(-8)}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
       }
       return { kind: 'accepted', acceptedAt: acceptedAt || Date.now() };
     } catch (err) {

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -325,7 +325,7 @@ export interface ImRunAgentTurnArgs {
   outputCardPrefix?: string;
   onTurnComplete?: () => void;
   /** Reports the concrete channel/default or attached Desktop session before provider startup. */
-  onRouteResolved?: (sessionId: string) => void;
+  onRouteResolved?: (sessionId: string) => void | Promise<void>;
   /** Keep fire-and-forget work inside the ingress account's drain boundary. */
   trackBackgroundTask?: (operation: () => Promise<void>) => void;
   /** Optional per-turn host policy (personal WeChat routes confirmations to Desktop). */
@@ -600,7 +600,8 @@ export function createTurnRunner(
     // onRouteResolved 必须在鉴权通过之后才算"路由解析成功" —— 群窗口游标的
     // commit 挂在它上面, 鉴权失败被拒的消息若先触发它, 这批群上下文会被游标
     // 永久跳过(prepareAgentTurnText 的契约: 路由失败不推进游标)。
-    args.onRouteResolved?.(row.id);
+    const routeResolvedResult = args.onRouteResolved?.(row.id);
+    if (routeResolvedResult instanceof Promise) await routeResolvedResult;
     // ── thread 名片卡(threadScoped 新 thread 会话)─────────────────────────
     // 在 bot 第一条回复之前发进 thread, 让用户第一眼理解"这个 thread = 一条
     // 独立会话";首条消息的 oneshot 标题生成完成后, 名片原地升级为正式标题

--- a/apps/desktop/src/main/im/shared/turnRunner.ts
+++ b/apps/desktop/src/main/im/shared/turnRunner.ts
@@ -600,8 +600,7 @@ export function createTurnRunner(
     // onRouteResolved 必须在鉴权通过之后才算"路由解析成功" —— 群窗口游标的
     // commit 挂在它上面, 鉴权失败被拒的消息若先触发它, 这批群上下文会被游标
     // 永久跳过(prepareAgentTurnText 的契约: 路由失败不推进游标)。
-    const routeResolvedResult = args.onRouteResolved?.(row.id);
-    if (routeResolvedResult instanceof Promise) await routeResolvedResult;
+    await args.onRouteResolved?.(row.id);
     // ── thread 名片卡(threadScoped 新 thread 会话)─────────────────────────
     // 在 bot 第一条回复之前发进 thread, 让用户第一眼理解"这个 thread = 一条
     // 独立会话";首条消息的 oneshot 标题生成完成后, 名片原地升级为正式标题

--- a/apps/desktop/src/main/im/shared/types.ts
+++ b/apps/desktop/src/main/im/shared/types.ts
@@ -156,7 +156,7 @@ export interface ImChannelAdapter {
    */
   prepareAgentTurnText?(event: IMMessageEvent): Promise<{
     agentText: string;
-    commit?: () => void;
+    commit?: () => void | Promise<void>;
   } | null>;
   /**
    * 按入站事件给该轮挂 per-turn 权限策略(telegram 群成员触发 → 破坏性调用

--- a/apps/desktop/src/main/im/shared/types.ts
+++ b/apps/desktop/src/main/im/shared/types.ts
@@ -150,8 +150,8 @@ export interface ImChannelAdapter {
   /**
    * 送模型正文的改写钩子(群上下文拼装等): 返回 agentText 替换发给 agent 的
    * 文本 —— 落库与标题生成仍用渠道原文, 桌面 transcript 不被上下文前缀污染。
-   * commit 在路由解析成功(消息确定会被派发/排队)时调用, 是群窗口游标推进的
-   * 时机锚点; 路由失败(如鉴权缺失)不调用, 这批上下文下次仍会进入 prompt。
+   * commit 在消息完成鉴权、session wiring 且确定被派发/排队后调用, 是群窗口
+   * 游标推进的时机锚点; 受理前失败不调用, 这批上下文下次仍会进入 prompt。
    * 返回 null = 不改写。钩子抛错按"不改写"降级, 不阻断消息。
    */
   prepareAgentTurnText?(event: IMMessageEvent): Promise<{

--- a/apps/desktop/src/main/im/telegram/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/im/telegram/__tests__/groupWindow.test.ts
@@ -2,7 +2,7 @@
  * 个人 Telegram 群窗口单测: 入窗幂等、按键 GC、TTL、上下文拼装(trigger 剔重 /
  * 游标 commit 延迟 / 字符预算 / 栅栏中和)、与官方通道行(provider='telegram')
  * 的隔离。harness 与 hook-control/groupWindow.test.ts 同款: 内存 better-sqlite3
- * 执行 0083 migration, drizzle 同步 driver 假装 DbClient。
+ * 执行 0083 + 0086 migration, drizzle 同步 driver 假装 DbClient。
  */
 
 import fs from 'node:fs';
@@ -18,6 +18,7 @@ const holder = vi.hoisted(() => ({ drizzle: null as unknown }));
 
 vi.mock('../../../localDb/client/current', () => ({
   getDbClient: () => ({ drizzle: holder.drizzle }),
+  tryGetDbClient: () => ({ drizzle: holder.drizzle }),
 }));
 
 import {
@@ -30,9 +31,14 @@ import {
 
 function migrationSql(): string {
   const dir = path.resolve(__dirname, '../../../../../drizzle');
-  const file = fs.readdirSync(dir).find((name) => name.startsWith('0083_'));
-  if (!file) throw new Error('0083 migration not found');
-  return fs.readFileSync(path.join(dir, file), 'utf8').replaceAll('--> statement-breakpoint', ';');
+  return ['0083_', '0086_']
+    .map((prefix) => {
+      const file = fs.readdirSync(dir).find((name) => name.startsWith(prefix));
+      if (!file) throw new Error(`${prefix} migration not found`);
+      return fs.readFileSync(path.join(dir, file), 'utf8');
+    })
+    .join('\n')
+    .replaceAll('--> statement-breakpoint', ';');
 }
 
 let entrySeq = 0;
@@ -56,11 +62,11 @@ const LANE = { botId: 'bot-1', chatId: '-900', threadId: '' };
 
 let sqlite: InstanceType<typeof Database>;
 
-beforeEach(() => {
+beforeEach(async () => {
   sqlite = new Database(':memory:');
   sqlite.exec(migrationSql());
   holder.drizzle = drizzle(sqlite);
-  resetTelegramGroupContextCursors();
+  await resetTelegramGroupContextCursors();
 });
 
 afterEach(() => {
@@ -102,6 +108,48 @@ describe('recordTelegramGroupMessage', () => {
     };
     expect(row.is_bot).toBe(1);
   });
+
+  it('正文全文入库, 但拼 prompt 仍按 500 字符截断', async () => {
+    const text = 'x'.repeat(700);
+    await recordTelegramGroupMessage(entry({ messageId: 'long', text }));
+    const row = sqlite
+      .prepare('SELECT text FROM hook_group_messages WHERE message_id = ?')
+      .get('long') as { text: string };
+    expect(row.text).toBe(text);
+
+    const prefix = (
+      await buildTelegramGroupContextPrefix({ ...LANE, triggerMessageId: 'none' })
+    ).prefix;
+    expect(prefix).toContain('x'.repeat(500));
+    expect(prefix).not.toContain('x'.repeat(501));
+  });
+
+  it('重置只删除个人 Telegram provider 的持久游标', async () => {
+    await recordTelegramGroupMessage(entry({ messageId: 'cursor-reset' }));
+    const assembly = await buildTelegramGroupContextPrefix({
+      ...LANE,
+      triggerMessageId: 'none',
+    });
+    await assembly.commit();
+    sqlite
+      .prepare(
+        `INSERT INTO hook_group_context_cursors
+          (provider, cursor_key, cursor_id, updated_at) VALUES (?, ?, ?, ?)`,
+      )
+      .run('telegram:9', 'telegram:group:1:-900:9', 99, Date.now());
+
+    await resetTelegramGroupContextCursors();
+    expect(
+      sqlite
+        .prepare('SELECT 1 FROM hook_group_context_cursors WHERE provider = ?')
+        .get('telegram-personal:bot-1'),
+    ).toBeUndefined();
+    expect(
+      sqlite
+        .prepare('SELECT cursor_id FROM hook_group_context_cursors WHERE provider = ?')
+        .get('telegram:9') as { cursor_id: number },
+    ).toEqual({ cursor_id: 99 });
+  });
 });
 
 describe('buildTelegramGroupContextPrefix', () => {
@@ -124,7 +172,17 @@ describe('buildTelegramGroupContextPrefix', () => {
     // 不 commit → 第二次拼装仍包含
     const again = await buildTelegramGroupContextPrefix({ ...LANE, triggerMessageId: 't1' });
     expect(again.prefix).toContain('旧消息');
-    again.commit();
+    await again.commit();
+    expect(
+      sqlite
+        .prepare(
+          'SELECT cursor_id FROM hook_group_context_cursors WHERE provider = ? AND cursor_key = ?',
+        )
+        .get('telegram-personal:bot-1', 'bot-1:-900:') as { cursor_id: number },
+    ).toEqual({ cursor_id: 1 });
+
+    // 模拟进程重启: 清掉内存态但保留 DB, 恢复后不重复已提交消息。
+    await resetTelegramGroupContextCursors({ clearPersisted: false });
     // commit 后 → 增量为空
     const after = await buildTelegramGroupContextPrefix({ ...LANE, triggerMessageId: 't2' });
     expect(after.prefix).toBe('');
@@ -135,7 +193,7 @@ describe('buildTelegramGroupContextPrefix', () => {
     await recordTelegramGroupMessage(entry({ messageId: 'only', text: '@bot hi' }));
     const asm = await buildTelegramGroupContextPrefix({ ...LANE, triggerMessageId: 'only' });
     expect(asm.prefix).toBe('');
-    asm.commit();
+    await asm.commit();
     await recordTelegramGroupMessage(entry({ messageId: 'next', text: '新消息' }));
     const after = await buildTelegramGroupContextPrefix({ ...LANE, triggerMessageId: 't' });
     expect(after.prefix).toContain('新消息');

--- a/apps/desktop/src/main/im/telegram/adapter.ts
+++ b/apps/desktop/src/main/im/telegram/adapter.ts
@@ -139,7 +139,9 @@ export function buildTelegramAdapter(
       // 顺序: 群窗口(较远的背景) → 引用块(直接相关) → 发言人 → 用户正文。
       return {
         agentText: `${persona}${ambientBlock}${assembly.prefix}${replyBlock}${speakerLine}${event.text}`,
-        commit: assembly.commit,
+        commit: async () => {
+          await assembly.commit();
+        },
       };
     },
   };

--- a/apps/desktop/src/main/im/telegram/groupWindow.ts
+++ b/apps/desktop/src/main/im/telegram/groupWindow.ts
@@ -24,6 +24,7 @@ import {
   createFenceNeutralizer,
   GROUP_WINDOW_ENTRY_TEXT_MAX_CHARS,
   recordGroupWindowEntry,
+  resetGroupWindowCursors,
   type GroupContextAssembly,
 } from '../shared/groupWindowCore';
 import { getDbClient } from '../../localDb/client/current';
@@ -69,8 +70,8 @@ export async function recordTelegramGroupMessage(entry: TelegramGroupWindowEntry
 }
 
 /**
- * 每 lane 的增量游标(上次拼装到的窗口行 id)。内存态: 重启后首次触发会
- * 重新包含整个窗口(一次性冗余, 可接受), 之后恢复增量语义。
+ * 每 lane 的增量游标(上次拼装到的窗口行 id)。内存态只作热缓存, 持久事实在
+ * hook_group_context_cursors; 重启后首次触发从本地 DB 恢复增量语义。
  */
 const contextCursors = new Map<string, number>();
 
@@ -134,9 +135,16 @@ export async function buildTelegramGroupContextPrefix(args: {
   });
 }
 
-/** 测试与登出清理: 重置内存游标(窗口行随账号 DB 生命周期)。 */
-export function resetTelegramGroupContextCursors(): void {
-  contextCursors.clear();
+/** 测试与登出清理: 只清理个人 Telegram provider 的内存态与持久游标。 */
+export function resetTelegramGroupContextCursors(options?: {
+  clearPersisted?: boolean;
+}): Promise<void> {
+  return resetGroupWindowCursors({
+    cursors: contextCursors,
+    providerPrefixes: ['telegram-personal:'],
+    providerNames: [TELEGRAM_PERSONAL_WINDOW_PROVIDER],
+    ...(options?.clearPersisted === false ? { clearPersisted: false } : {}),
+  });
 }
 
 /**

--- a/apps/desktop/src/main/im/wechat/WechatIM.ts
+++ b/apps/desktop/src/main/im/wechat/WechatIM.ts
@@ -96,6 +96,16 @@ interface ActiveTask {
   terminalCommitted: boolean;
 }
 
+function activePeerIdForSession<
+  T extends { routeSessionId?: string; task: { sessionId: string } },
+>(activeTasks: ReadonlyMap<string, T>, sessionId: string | undefined): string | null {
+  if (!sessionId) return null;
+  const peers = [...activeTasks.entries()]
+    .filter(([, active]) => (active.routeSessionId ?? active.task.sessionId) === sessionId)
+    .map(([peerId]) => peerId);
+  return peers.length === 1 ? peers[0]! : null;
+}
+
 interface PendingWechatInteraction {
   request: InteractionRequest;
   resolve: (decision: InteractionDecision) => void;
@@ -466,13 +476,7 @@ export class WechatIM extends BaseIM implements RichChannelIM {
   }
 
   getActivePeerIdForSession(sessionId: string | undefined): string | null {
-    if (!sessionId) return null;
-    const peers = [...this.#activeTasks.entries()]
-      .filter(
-        ([, active]) => (active.routeSessionId ?? active.task.sessionId) === sessionId,
-      )
-      .map(([peerId]) => peerId);
-    return peers.length === 1 ? peers[0]! : null;
+    return activePeerIdForSession(this.#activeTasks, sessionId);
   }
 
   async handleTextInteraction(
@@ -1973,6 +1977,7 @@ function machineErrorCode(error: unknown): string {
 }
 
 export const __testing = {
+  activePeerIdForSession,
   acceptedPollTaskIds,
   authorizationCancelPhase,
   classifyOutboxSendError,

--- a/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
+++ b/apps/desktop/src/main/im/wechat/__tests__/WechatIM.test.ts
@@ -75,6 +75,26 @@ describe('WechatIM host boundary', () => {
     ).toBe(true);
   });
 
+  it('排队等待 provider 受理时按 task session 回退微信 peer', () => {
+    const activeTasks = new Map<
+      string,
+      { routeSessionId?: string; task: { sessionId: string } }
+    >([
+      ['peer-queued', { task: { sessionId: 'wechat-task-session' } }],
+      ['peer-other', { task: { sessionId: 'other-session' } }],
+    ]);
+
+    expect(__testing.activePeerIdForSession(activeTasks, 'wechat-task-session')).toBe(
+      'peer-queued',
+    );
+
+    activeTasks.get('peer-queued')!.routeSessionId = 'accepted-route-session';
+    expect(__testing.activePeerIdForSession(activeTasks, 'wechat-task-session')).toBeNull();
+    expect(__testing.activePeerIdForSession(activeTasks, 'accepted-route-session')).toBe(
+      'peer-queued',
+    );
+  });
+
   it('keeps staged files only for accepted poll tasks', () => {
     const accepted = __testing.acceptedPollTaskIds({
       committed: true,

--- a/apps/desktop/src/main/localDb/schema.ts
+++ b/apps/desktop/src/main/localDb/schema.ts
@@ -1520,3 +1520,20 @@ export const hookGroupMessages = sqliteTable(
     byWindow: index('hook_group_messages_window_idx').on(t.provider, t.chatId, t.threadId, t.id),
   }),
 );
+
+/**
+ * 群消息窗口的已提交游标。游标与消息池同属本地 DB，但按 provider 命名空间
+ * 隔离，登出/换绑时只清理对应 bot 的行。
+ */
+export const hookGroupContextCursors = sqliteTable(
+  'hook_group_context_cursors',
+  {
+    provider: text('provider').notNull(),
+    cursorKey: text('cursor_key').notNull(),
+    cursorId: integer('cursor_id').notNull(),
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.provider, t.cursorKey] }),
+  }),
+);


### PR DESCRIPTION
## 这次改了什么

### 摘要

这是 #1855 第一刀 L0-b1：统一 Telegram 群消息池改为保存完整正文，并把两侧上下文游标持久化到本地 SQLite。这样 prompt 仍保持原有窗口预算，但重启后不会重新消费已提交的增量消息。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：#1855
- 本 PR 包含：全文入库；`hook_group_context_cursors` 增量 migration；官方 bot 与个人 bot 的 provider-scoped 游标读取、提交、reset；受影响异步调用链等待持久化完成。
- 共享层契约变更：`im/shared/turnRunner.ts` 的 `onRouteResolved` 从“鉴权通过后、入队前”改为“provider 接受这条消息后”触发。个人微信也消费该回调写入 `routeSessionId`；排队等待 provider 受理期间，`getActivePeerIdForSession()` 继续回退到 `task.sessionId`，避免权限卡或交互回执错投。
- 明确不包含：FTS5 虚表/同步、群历史检索 API、agent 检索工具；协议、服务端、TurnPresenter、Slack/X 行为改动。
- 用户可见变化：单条消息仍最多注入 500 字符、总预算仍为 4000 字符；入库正文不再被 500 字符永久截断，重启后上下文继续增量。同 lane 多条任务排队或前一条执行期间，游标会延迟到 provider 实际受理后提交，因此后到任务可能重复携带尚未提交的同一批群上下文，产生真实的 prompt/token 增量；这是为了避免未受理任务推进 durable cursor，本 PR 不消除这项重复。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/im test
结果：411/411 通过（共享 IM 层全量）

pnpm --filter desktop exec vitest run src/main/hook-control src/main/im
结果：62 个测试文件、886 个测试通过

pnpm --filter desktop exec vitest run \
  src/main/im/wechat/__tests__/WechatIM.test.ts \
  src/main/im/shared/__tests__/turnRunnerSendOutcome.test.ts
结果：2 个测试文件、67 个测试通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop db:validate
结果：通过；0000..0086 migration、journal、snapshot 无 drift

pnpm --filter desktop test:migration-replay
结果：6/6 通过

bash -c 'for v in $(env | awk -F= "/^CLAUDE/{print $1}"); do unset "$v"; done; pnpm test:unit'
结果：apps/desktop、apps/mobile 及其余 workspace 通过；packages/maker-core 有 1 个既有 Pi 多模态 fixture 失败（1920/1922 通过，错误为当前测试模型未声明 image input，与本 PR 无文件交集）
```

逐渠道覆盖：

- Telegram 官方 bot：`hook-control` 的群窗口、dispatcher/manager、排队受理与 durable cursor 回归均包含在 Desktop 全量中。
- Telegram personal bot：个人群窗口与 `im/shared/turnRunner` 的 provider 受理后 commit、排队/停止/teardown 路径包含在 Desktop 全量中。
- Slack / X：两者共用 `hook-control` dispatcher 的受理、排队、取消与账号代次路径；本轮由 dispatcher 全量回归覆盖，未修改渠道协议与输出行为。
- 微信：`turnRunnerSendOutcome` 覆盖 `onRouteResolved` 只在 provider accepted 后触发；`WechatIM.test.ts` 新增排队窗口按 `task.sessionId` 反查 peer 的回退断言，避免权限卡/交互回执错投。
- 飞书 / Discord / 钉钉 / 企微：`pnpm --filter @cindy/im test` 全量 411/411 通过。

### 手工验证

不涉及 UI；本 PR 的本地 SQLite migration、全文入库和游标重启语义由内存 SQLite 回归测试覆盖。

### 未执行的验证

根 `pnpm test:unit` 的 `packages/maker-core` Pi image integration 仍受当前基线 fixture 影响，未修改无关模块；待上游 #1896 或 vision-capable 测试 fixture 收口后复跑该 workspace。

## 风险

### 风险分类

- [x] SQLite / migration
- [x] 权限 / 安全 / 用户数据
- [ ] system prompt
- [ ] 协议兼容
- [ ] 跨平台差异

### 影响与回滚

- 影响范围：Desktop 本地 `hook_group_messages` 写入、群上下文组装、官方/个人 Telegram 账号边界 reset，以及共享 `onRouteResolved` 回调时机；群消息仍只驻留用户本地设备，provider 命名空间继续隔离。官方 Telegram binding identity 变化会清整个 `telegram:` provider 前缀，不触碰个人 bot 的 `telegram-personal:` 命名空间。
- 回滚 / 降级方式：回滚本 PR commit；新增表为纯增量，不影响旧 `hook_group_messages` 行读取。若只回滚代码而保留 migration，未使用的游标表可安全留存。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要 migration 与回归测试
- [x] 已确认测试结果并说明未执行原因


### 最终 review 收敛（9a8bbfe7）

- 删除“先提交 durable cursor、账号代次失效后再 rollback”的补偿链；官方 Telegram 群任务改为只有 provider 实际受理 send 后才提交游标。SQLite 提交失败保留旧游标，下次最多重复携带，不会永久跳过未交给 agent 的消息。
- 直达与排队入口统一经 runner 的 onProviderAccepted 回调提交；账号 teardown 会把尚未受理但已经回复 accepted/queued ACK 的 Telegram 群任务收成唯一 cancelled turn.end，迟到回调不再提交游标。Slack/X 不携带群游标 commit，保持既有 teardown 行为。
- 本轮最新增量验证：dispatcher + session-runner 231/231 通过；desktop typecheck 通过；git diff --check 与 staged 安全扫描通过。此前整批验证的 @cindy/im 411/411、Desktop hook-control + IM 886/886、DB validate、migration replay 结果保持不变。根 test:unit 唯一失败仍是无文件交集的既有 Pi image-capability fixture。
- 规模说明：pr-drift-check 因 4 个 address-review commit 与非测试 +4395 行为 STOP；本轮按强制收敛只修 durable cursor 正确性问题，没有加入 FTS、检索工具、GC 或 provider 隔离改动。