### PR TITLE
feat(desktop): 应用区域门控的新任务默认模型

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -48,6 +48,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@cindy/auth-client": "workspace:*",
+    "@cindy/model-access-protocol": "workspace:*",
     "@cindy/plugin-protocol": "workspace:*",
     "@cindy/slack-hook-protocol": "workspace:*",
     "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/catalogDerivedModels.test.ts
@@ -258,6 +258,39 @@ describe('deriveAvailableModels — dynamic-first catalog contract', () => {
     expect(cc.find((m) => m.id === 'claude-opus-4-8')?.supportsFastMode).toBe(true);
   });
 
+  it('同 id 首见胜出时仍合并 XD 对当前 agent 的区域默认标记', () => {
+    const catalog = injectedCatalog();
+    const anthropic = catalog.providers.find((provider) => provider.id === 'anthropic')!;
+    const xd = catalog.providers.find((provider) => provider.id === 'xd')!;
+
+    xd.models['claude-code'] = (xd.models['claude-code'] ?? []).map((entry) =>
+      entry.id === 'claude-opus-4-8'
+        ? { ...entry, newSessionDefault: ['claude-code', 'codex'] }
+        : entry,
+    );
+    xd.models.codex = (xd.models.codex ?? []).map((entry) =>
+      entry.id === 'gpt-5.5'
+        ? { ...entry, newSessionDefault: ['claude-code', 'codex'] }
+        : entry,
+    );
+    anthropic.models.pi = [model('shared-default')];
+    xd.models.pi = [
+      model('shared-default', { newSessionDefault: ['claude-code', 'codex'] }),
+    ];
+
+    expect(
+      deriveAvailableModels(catalog, 'claude-code').find(
+        (entry) => entry.id === 'claude-opus-4-8',
+      ),
+    ).toMatchObject({ supportsFastMode: true, newSessionDefault: ['claude-code'] });
+    expect(
+      deriveAvailableModels(catalog, 'codex').find((entry) => entry.id === 'gpt-5.5'),
+    ).toMatchObject({ contextWindow: 272_000, newSessionDefault: ['codex'] });
+    expect(
+      deriveAvailableModels(catalog, 'pi').find((entry) => entry.id === 'shared-default'),
+    ).toMatchObject({ newSessionDefault: ['claude-code'] });
+  });
+
   it('per-agent 分叉透传:gpt-5.5 cc=1M / codex=272k', () => {
     const cat = injectedCatalog();
     expect(deriveAvailableModels(cat, 'claude-code').find((m) => m.id === 'gpt-5.5')?.contextWindow).toBe(1_000_000);

--- a/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/modelPlane.test.ts
@@ -33,12 +33,12 @@ import { isRegistryTombstoneForConsumer } from '../model-plane/modelPlanePolicy.
 
 type RegistryEntries = NonNullable<Catalog['modelRegistry']>['models'];
 
-function baseCatalog(entries?: RegistryEntries): Catalog {
+function baseCatalog(entries?: RegistryEntries, schemaVersion: 1 | 2 = 1): Catalog {
   const catalog = JSON.parse(JSON.stringify(BUNDLED_CATALOG)) as Catalog;
   delete catalog.modelRegistry;
   if (entries) {
     catalog.modelRegistry = {
-      schemaVersion: 1,
+      schemaVersion,
       updatedAt: '2026-08-01T00:00:00.000Z',
       models: entries,
     };
@@ -121,6 +121,25 @@ describe('registry presence 实体化', () => {
     });
     expect(models('openai', 'claude-code').map((m) => m.id)).toContain('chatgpt/gpt-6');
     expect(models('openai', 'pi').map((m) => m.id)).toContain('chatgpt/gpt-6');
+  });
+
+  it('公共 Registry 的 newSessionDefault 不进入 CatalogModel；默认只信区域门控后的 /models', () => {
+    setActiveCatalog(
+      baseCatalog(
+        [gpt6Entry({ newSessionDefault: ['claude-code', 'codex'] })],
+        2,
+      ),
+    );
+
+    const codex = models('openai', 'codex').find((m) => m.id === 'gpt-6');
+    const claude = models('openai', 'claude-code').find((m) => m.id === 'chatgpt/gpt-6');
+    const pi = models('openai', 'pi').find((m) => m.id === 'chatgpt/gpt-6');
+    expect(codex).toBeDefined();
+    expect(claude).toBeDefined();
+    expect(pi).toBeDefined();
+    expect('newSessionDefault' in codex!).toBe(false);
+    expect('newSessionDefault' in claude!).toBe(false);
+    expect('newSessionDefault' in pi!).toBe(false);
   });
 
   it('bridge 在投影后应用目标端 perAgent,随后再执行 effort 硬约束', () => {
@@ -355,6 +374,28 @@ describe('registry presence 实体化', () => {
     setXdGatewayModels([]);
     const xd = getActiveCatalog().providers.find((p) => p.id === 'xd');
     for (const list of Object.values(xd?.models ?? {})) expect(list).toEqual([]);
+  });
+
+  it('区域门控后的 XD /models 标记保留，并从 claude-code 可达面投影到 Pi', () => {
+    setXdGatewayModels([
+      {
+        id: 'deepseek/deepseek-v4-pro',
+        agents: ['claude-code', 'codex'],
+        newSessionDefault: ['claude-code', 'codex'],
+      },
+    ]);
+
+    expect(
+      models('xd', 'claude-code').find((m) => m.id === 'deepseek/deepseek-v4-pro')
+        ?.newSessionDefault,
+    ).toEqual(['claude-code', 'codex']);
+    expect(
+      models('xd', 'codex').find((m) => m.id === 'deepseek/deepseek-v4-pro')
+        ?.newSessionDefault,
+    ).toEqual(['claude-code', 'codex']);
+    expect(
+      models('xd', 'pi').find((m) => m.id === 'deepseek/deepseek-v4-pro')?.newSessionDefault,
+    ).toEqual(['claude-code', 'codex']);
   });
 });
 

--- a/apps/desktop/src/main/maker-host/__tests__/newMakerDefaultsCache.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/newMakerDefaultsCache.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   getRemoteNewMakerDefaults,
+  getRemoteNewMakerDefaultsByVendor,
   getWorkerDefaultsFromNewMaker,
   setNewMakerDraftCache,
   setProviderModelMemoryCache,
@@ -75,6 +76,43 @@ describe('getRemoteNewMakerDefaults (device-link 远程草稿镜像)', () => {
     seed({ lastByVendor: {}, fastModeByModel: {}, effortByModel: {}, worktreeEnabled: true });
     expect(getRemoteNewMakerDefaults('claude-code')).toEqual({ worktreeEnabled: true });
     expect(getRemoteNewMakerDefaults('codex')).toEqual({ worktreeEnabled: true });
+  });
+
+  it('镜像每个 vendor 的显式模型选择状态，供控制端决定是否应用区域默认', () => {
+    seed({
+      lastByVendor: {
+        cc: { model: 'claude-opus-4-8' },
+        pi: { model: 'claude-sonnet-4-6' },
+      },
+      modelChosenByVendor: { cc: false, pi: true },
+      fastModeByModel: {},
+      effortByModel: {},
+    });
+
+    expect(getRemoteNewMakerDefaults('claude-code')).toMatchObject({
+      model: 'claude-opus-4-8',
+      modelChosenByUser: false,
+    });
+    expect(getRemoteNewMakerDefaults('pi')).toMatchObject({
+      model: 'claude-sonnet-4-6',
+      modelChosenByUser: true,
+    });
+  });
+
+  it('草稿变更广播快照始终包含 claude-code、codex、pi 三个槽', () => {
+    seed({
+      lastByVendor: { pi: { model: 'claude-sonnet-4-6' } },
+      modelChosenByVendor: { pi: false },
+      fastModeByModel: {},
+      effortByModel: {},
+    });
+
+    const snapshot = getRemoteNewMakerDefaultsByVendor();
+    expect(Object.keys(snapshot)).toEqual(['claudeCode', 'codex', 'pi']);
+    expect(snapshot.pi).toMatchObject({
+      model: 'claude-sonnet-4-6',
+      modelChosenByUser: false,
+    });
   });
 
   it('providerModelMemory 镜像就绪时随返回(device-link 草稿列表行的真实读源)', () => {

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -112,6 +112,11 @@ export interface XdGatewayModelInfo {
   supportsFastMode?: boolean;
   /** 默认可见性;缺省按 true。 */
   defaultEnabled?: boolean;
+  /**
+   * 新对话默认种子的 agent 标记(服务端 /models 下发的 newSessionDefault)。仅 wire agent;
+   * pi 由 xdGatewayTargetAgents 投影进 pi tab 后,按 'claude-code' 口径判定默认。
+   */
+  newSessionDefault?: ('claude-code' | 'codex')[];
   /** 展示图标 id(AI Gateway 设定;缺省 / 未知值渲染层回落来源供应商标)。 */
   icon?: string;
   modalities?: { input: string[]; output: string[] };
@@ -684,6 +689,9 @@ function computeMerged(): Catalog {
           ...(gm.description !== undefined ? { description: gm.description } : {}),
           ...(gm.sortOrder !== undefined ? { sortOrder: gm.sortOrder } : {}),
           ...(defaultEnabled !== undefined ? { defaultEnabled } : {}),
+          ...(gm.newSessionDefault !== undefined
+            ? { newSessionDefault: gm.newSessionDefault }
+            : {}),
           ...(gm.icon !== undefined ? { icon: gm.icon } : {}),
           ...(cost ? { cost } : {}),
           ...(gm.modalities !== undefined ? { modalities: gm.modalities } : {}),

--- a/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
+++ b/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
@@ -11,8 +11,9 @@
  * (issue #882 第 3 点:网关多返回的图像/视频/TTS/STT/实时/Embedding/压缩模型不进 Agent
  * availableModels,但仍在模型管理设置页可见——那边走完整 catalog,不走这个函数),按 id
  * **首见胜出**去重（provider 序即 anthropic → openai → xd）。不可选来源不占 seen，同 id
- * 仍可由后续可用来源补上。唯一例外是 Pi 的同 id 冲突涉及 user provider：扁平能力没有
- * provider provenance，effort 必须收敛为各可选来源的交集，不能宣称某条实际路由不支持的档位。
+ * 仍可由后续可用来源补上。例外有两项：Pi 的同 id 冲突涉及 user provider 时，扁平能力没有
+ * provider provenance，effort 必须收敛为各可选来源的交集；后见 XD 条目携带当前 agent 的
+ * 区域默认标记时，把该标记并入首见 descriptor，避免跨 provider 去重吞掉服务端策略。
  *
  * 顺序契约（no-break）：派生结果必须逐字逐序复现迁移前的有效列表
  * （cc = 旧 CLAUDE_MODELS 序 then XD 追加序；codex = 旧 CODEX_MODELS 序 then 折扣追加序）。
@@ -111,7 +112,29 @@ function intersectPiEffortCapabilities(
   return { ...first, efforts, defaultEffort };
 }
 
-/** 派生 availableModels：字段按 id 首见胜出；Pi + BYOM 同 id 时 effort 取安全交集。 */
+/**
+ * availableModels 按 id 拍平后仍要保留 XD 区域策略。展示/能力字段继续首见胜出；这里只把
+ * 当前 agent 对应的默认标记并到首见 descriptor。Pi 按既有协议复用 claude-code 标记。
+ */
+function mergeNewSessionDefaultMarker(
+  first: ModelDescriptor,
+  next: ModelDescriptor,
+  agent: AgentKind,
+): ModelDescriptor {
+  const marker = agent === 'pi' ? 'claude-code' : agent;
+  if (
+    next.newSessionDefault?.includes(marker) !== true ||
+    first.newSessionDefault?.includes(marker) === true
+  ) {
+    return first;
+  }
+  return {
+    ...first,
+    newSessionDefault: [...(first.newSessionDefault ?? []), marker],
+  };
+}
+
+/** 派生 availableModels：字段按 id 首见胜出；另收敛 Pi BYOM effort 与 XD 区域默认标记。 */
 export function deriveAvailableModels(catalog: Catalog, agent: AgentKind): ModelDescriptor[] {
   const seen = new Map<string, SeenModelProjection>();
   const out: ModelDescriptor[] = [];
@@ -130,10 +153,17 @@ export function deriveAvailableModels(catalog: Catalog, agent: AgentKind): Model
       });
       const previous = seen.get(m.id);
       if (previous) {
+        let merged = out[previous.index];
         if (agent === 'pi' && (previous.includesUserProvider || userProvider)) {
-          out[previous.index] = intersectPiEffortCapabilities(out[previous.index], descriptor);
+          merged = intersectPiEffortCapabilities(merged, descriptor);
           previous.includesUserProvider ||= userProvider;
         }
+        // 只有鉴权后的 XD /models 会被 active-catalog 投影成区域默认；公共 Registry 与
+        // user provider 均不能借同 id 碰撞改变默认策略。
+        if (provider.id === 'xd') {
+          merged = mergeNewSessionDefaultMarker(merged, descriptor, agent);
+        }
+        out[previous.index] = merged;
         continue;
       }
       seen.set(m.id, { index: out.length, includesUserProvider: userProvider });

--- a/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
+++ b/apps/desktop/src/main/maker-host/catalog-to-descriptors.ts
@@ -80,6 +80,9 @@ function toDescriptor(
   // 默认可见性要透传：渲染层的种子默认模型取「排序第一**且默认可见**」的那个，没有它就会
   // 把默认收起的 legacy 模型选成默认 —— 用户在选择器里根本看不到自己的默认模型。
   if (m.defaultEnabled !== undefined) d.defaultEnabled = m.defaultEnabled;
+  // 新对话默认种子标记要透传：渲染层 getDefaultModelForVendor 据它优先选中被标记的模型。
+  // pi tab 的条目多从 CC 投影而来，会带上 ['claude-code']，pi 侧按 'claude-code' 口径判定。
+  if (m.newSessionDefault !== undefined) d.newSessionDefault = m.newSessionDefault;
   if (m.cost !== undefined) d.cost = m.cost;
   if (m.maxOutput !== undefined) d.maxOutputTokens = m.maxOutput;
   const supportsImageInput = m.supportsImageInput

--- a/apps/desktop/src/main/maker-host/newMakerDefaultsCache.ts
+++ b/apps/desktop/src/main/maker-host/newMakerDefaultsCache.ts
@@ -8,8 +8,8 @@
  * 不再用 hardcode 默认值,优先读这份缓存 —— worker 实际启动参数 = "用户在 New Maker
  * 面板里该 vendor 当前的选择";旧 renderer 未推 providerId 时,创建服务才回退 Lead 来源。
  *
- * Vendor 名称差异: renderer 用 'cc' / 'codex' / 'orca'; worker spawn 路径用
- * 'claude-code' / 'codex'。getWorkerDefaultsFromNewMaker 内部做映射。
+ * Vendor 名称差异: renderer 用 'cc' / 'codex' / 'pi'; worker spawn 路径用
+ * 'claude-code' / 'codex' / 'pi'。getWorkerDefaultsFromNewMaker 内部做映射。
  */
 type VendorKey = 'cc' | 'codex' | 'pi';
 
@@ -27,6 +27,8 @@ interface VendorPrefsSnapshot {
 
 export interface NewMakerDraftSnapshot {
   lastByVendor: Partial<Record<VendorKey, VendorPrefsSnapshot>>;
+  /** 每个 vendor 是否由用户在 New Maker picker 明确选过模型；旧 renderer 缺省不提供。 */
+  modelChosenByVendor?: Partial<Record<VendorKey, boolean>>;
   fastModeByModel: Record<string, boolean>;
   effortByModel: Record<string, string>;
   /**
@@ -91,7 +93,7 @@ export function getWorkerDefaultsFromNewMaker(
  * device-link 远程草稿镜像用:取某 vendor 在 New Maker 草稿里的**当前完整选择**
  * (model/effort/fast/permission/source)+ **整张 per-model 记忆表**。与
  * getWorkerDefaultsFromNewMaker 的区别:
- *   - 多回 permissionMode + providerId(全量镜像)。
+ *   - 多回 permissionMode + providerId + modelChosenByUser(全量镜像)。
  *   - effort 取「当前激活档」—— 被控端 trigger 显示的就是 lastByVendor.effort,故优先它,
  *     缺省再退 effortByModel(切换记忆);worker 那条因语义不同优先 effortByModel,这里不一样。
  *   - 多回 effortByModel + fastModeByModel(整表):控制端在远程草稿里**切到列表里其它模型**时,
@@ -102,6 +104,8 @@ export function getWorkerDefaultsFromNewMaker(
  */
 export interface RemoteNewMakerDefaults {
   model?: string;
+  /** false = 明确未选过，可应用目录新任务默认；undefined = 旧端未知，保守保留原模型。 */
+  modelChosenByUser?: boolean;
   effort?: string;
   fastMode?: boolean;
   permissionMode?: string;
@@ -128,18 +132,21 @@ export interface RemoteNewMakerDefaults {
 export function getRemoteNewMakerDefaults(
   agentKind: 'claude-code' | 'codex' | 'pi',
 ): RemoteNewMakerDefaults {
+  const vendor: VendorKey =
+    agentKind === 'claude-code' ? 'cc' : agentKind === 'pi' ? 'pi' : 'codex';
   // providerModelMemory(草稿列表行真实读源)与「该 vendor 是否选过模型」无关:即便 cache 未就绪 /
   // 该 vendor 无选中模型(lastByVendor 空),只要被控端有模型级预设就要全量回给控制端,
   // 否则 req1「完整镜像被控端草稿模型列表」在这条边界上回落 capabilities 默认。故在所有早返回里都带上它。
   // worktreeEnabled(vendor 无关根字段)同理:该 vendor 尚无草稿 model 的早返回也必须携带,
   // 否则空草稿的工作端上,手机/控制端永远读不到勾选态。
   const providerModelMemory = providerMemoryCache ?? undefined;
+  const modelChosenByUser = cache?.modelChosenByVendor?.[vendor];
   const base: RemoteNewMakerDefaults = {
     ...(providerModelMemory ? { providerModelMemory } : {}),
     ...(cache ? { worktreeEnabled: cache.worktreeEnabled === true } : {}),
+    ...(typeof modelChosenByUser === 'boolean' ? { modelChosenByUser } : {}),
   };
   if (!cache) return base;
-  const vendor: VendorKey = agentKind === 'claude-code' ? 'cc' : agentKind === 'pi' ? 'pi' : 'codex';
   const prefs = cache.lastByVendor[vendor];
   if (!prefs?.model) return base;
   const model = prefs.model;
@@ -152,5 +159,18 @@ export function getRemoteNewMakerDefaults(
     effortByModel: cache.effortByModel,
     fastModeByModel: cache.fastModeByModel,
     ...base,
+  };
+}
+
+/** device-link push payload：一次广播携带所有可建草稿的 vendor，避免增量 push 丢槽。 */
+export function getRemoteNewMakerDefaultsByVendor(): {
+  claudeCode: RemoteNewMakerDefaults;
+  codex: RemoteNewMakerDefaults;
+  pi: RemoteNewMakerDefaults;
+} {
+  return {
+    claudeCode: getRemoteNewMakerDefaults('claude-code'),
+    codex: getRemoteNewMakerDefaults('codex'),
+    pi: getRemoteNewMakerDefaults('pi'),
   };
 }

--- a/apps/desktop/src/main/maker-ipc/channels.ts
+++ b/apps/desktop/src/main/maker-ipc/channels.ts
@@ -109,8 +109,8 @@ export const MAKER_INVOKE = {
   GET_CAPABILITIES: 'maker:get-capabilities',
   /**
    * device-link 远程草稿镜像:控制端为被控设备新建项目草稿时,经隧道读被控端**当前
-   * New Maker 草稿**在某 vendor 的完整选择(model/effort/fast/permission/source),1:1 seed
-   * 控制端草稿(绝不取控制端本地)。只读、无 sender 依赖、语义在被控端执行 → 进 device-link
+   * New Maker 草稿**在某 vendor 的完整选择(model/effort/fast/permission/source/是否显式
+   * 选过模型),1:1 seed 控制端草稿(绝不取控制端本地)。只读、无 sender 依赖、语义在被控端执行 → 进 device-link
    * allowlist。数据源 = newMakerDefaultsCache(renderer 经 SYNC_NEW_MAKER_DRAFT 推)。
    * 旧版被控端无此 channel → 控制端收 CHANNEL_NOT_ALLOWED → 回退被控端 capabilities 默认。
    */
@@ -681,8 +681,8 @@ export const MAKER_SEND = {
    */
   COMPUTER_PERMISSION_APP_DRAG_START: 'maker:computer:permission-app-drag-start',
   /**
-   * 把 renderer `newMakerDraft` 的关键子集 (lastByVendor / fastModeByModel /
-   * effortByModel) 同步给 main 缓存 (newMakerDefaultsCache)。collab mode spawn
+   * 把 renderer `newMakerDraft` 的关键子集 (lastByVendor / modelChosenByVendor /
+   * fastModeByModel / effortByModel) 同步给 main 缓存 (newMakerDefaultsCache)。collab mode spawn
    * worker (enableOrcaInternal / orca-bridge.create_worker) 读这份缓存决定 worker
    * 的 model / effort / fastMode, 让 worker 默认 = "用户在 New Maker 面板该 vendor
    * 当前的选择"。startup 时推一次 + draft 变化时增量推, fire-and-forget。
@@ -788,8 +788,8 @@ export const MAKER_PUSH = {
   /**
    * 被控端「当前 New Maker 草稿」全量变更广播。SYNC_NEW_MAKER_DRAFT 落 main 缓存后随即发,
    * 经 device-link tap 转发给控制端(account 级 → sessions topic),控制端刷新远程草稿显示镜像。
-   * payload = { claudeCode: RemoteNewMakerDefaults, codex: RemoteNewMakerDefaults }(per-vendor,
-   * 控制端直接复用 resolveDeviceLinkDraftDefaults)。本地窗口不消费(被控端是真相、不自镜像)。
+   * payload = { claudeCode, codex, pi }(每项均为 RemoteNewMakerDefaults，控制端直接复用
+   * resolveDeviceLinkDraftDefaults)。本地窗口不消费(被控端是真相、不自镜像)。
    */
   NEW_MAKER_DRAFT_CHANGED: 'maker:new-maker-draft:changed',
   /**

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -268,6 +268,7 @@ import {
 import type { GitSnapshotCoordinator } from '../git-snapshot/gitSnapshotCoordinator.js';
 import {
   getRemoteNewMakerDefaults,
+  getRemoteNewMakerDefaultsByVendor,
   getWorkerDefaultsFromNewMaker,
   type NewMakerDraftSnapshot,
   type ProviderModelMemorySnapshot,
@@ -4683,7 +4684,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   // ── newMakerDraft 缓存同步 ──────────────────────────────────────────────
   // Renderer push (fire-and-forget) → main 内存缓存; collab spawn worker 时
   // 读这份缓存决定 model/effort/fastMode。startup 立刻推一次 + 用户每次改 New
-  // Maker 偏好时增量推, payload 形态严格按 newMakerDefaultsCache.NewMakerDraftSnapshot。
+  // Maker 偏好时增量推（含每个 vendor 的显式模型选择状态），payload 形态严格按
+  // newMakerDefaultsCache.NewMakerDraftSnapshot。
   // 校验失败 (payload 不是 object / 缺字段) → no-op, 缓存维持上一次值, 避免脏数据污染。
   ipcMain.on(MAKER_SEND.SYNC_NEW_MAKER_DRAFT, (_e, payload: unknown) => {
     if (!payload || typeof payload !== 'object') return;
@@ -4699,6 +4701,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       return;
     setNewMakerDraftCache({
       lastByVendor: p.lastByVendor,
+      ...(p.modelChosenByVendor && typeof p.modelChosenByVendor === 'object'
+        ? { modelChosenByVendor: p.modelChosenByVendor }
+        : {}),
       fastModeByModel: p.fastModeByModel,
       effortByModel: p.effortByModel,
       // worktree 勾选记忆(vendor 无关根字段):旧 renderer 不推此字段 → false 兜底。
@@ -4847,7 +4852,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   });
 
   // device-link 远程草稿镜像(只读):返回某 vendor 在 New Maker 草稿里的当前完整选择
-  // (model/effort/fast/permission/source)。控制端经隧道调用 → seed 远程项目草稿。
+  // (model/effort/fast/permission/source/是否显式选过模型)。控制端经隧道调用 → seed 远程项目草稿。
   // 缓存未就绪 / 该 vendor 无草稿 model → 返回 {},控制端按 capabilities 默认兜底。
   ipcMain.handle(MAKER_INVOKE.GET_NEW_MAKER_DEFAULTS, (_e, agentKind: unknown) => {
     return getRemoteNewMakerDefaults(requireAgentKind(agentKind));
@@ -12445,9 +12450,9 @@ function broadcastNewMakerDraftChanged(): void {
   draftChangedScheduled = true;
   setTimeout(() => {
     draftChangedScheduled = false;
-    tapWindowBroadcast(MAKER_PUSH.NEW_MAKER_DRAFT_CHANGED, {
-      claudeCode: getRemoteNewMakerDefaults('claude-code'),
-      codex: getRemoteNewMakerDefaults('codex'),
-    });
+    tapWindowBroadcast(
+      MAKER_PUSH.NEW_MAKER_DRAFT_CHANGED,
+      getRemoteNewMakerDefaultsByVendor(),
+    );
   }, 0);
 }

--- a/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
+++ b/apps/desktop/src/main/model-access/__tests__/modelsSyncRefresh.test.ts
@@ -3,11 +3,89 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildModelsSyncRequest,
   ensureCredentialsReadyForModelsRefresh,
+  parseModelsSyncPayload,
   withModelsSyncOverallDeadline,
   waitForModelsSyncRefresh,
   XD_MODELS_SYNC_TIMEOUT_MS,
   type ModelsSyncFlightSnapshot,
 } from '../modelsSyncRefresh.js';
+
+describe('parseModelsSyncPayload', () => {
+  const baseModel = {
+    id: 'deepseek/deepseek-v4-pro',
+    currency: 'CNY' as const,
+    agents: ['claude-code', 'codex'] as const,
+    mode: 'chat',
+    modalities: { input: ['text'], output: ['text'] },
+  };
+
+  it('dual-reads the frozen v1 shape', () => {
+    expect(parseModelsSyncPayload({ schemaVersion: 1, models: [baseModel] })).toEqual({
+      ok: true,
+      models: [baseModel],
+    });
+  });
+
+  it('reads v2 and preserves the regional new-session default marker', () => {
+    const model = {
+      ...baseModel,
+      newSessionDefault: ['claude-code', 'codex'] as const,
+    };
+    expect(parseModelsSyncPayload({ schemaVersion: 2, models: [model] })).toEqual({
+      ok: true,
+      models: [model],
+    });
+  });
+
+  it.each([
+    {
+      label: 'unknown schema version',
+      payload: { schemaVersion: 3, models: [baseModel] },
+      errorPath: 'response.schemaVersion',
+    },
+    {
+      label: 'v2-only field in v1',
+      payload: {
+        schemaVersion: 1,
+        models: [{ ...baseModel, newSessionDefault: ['claude-code'] }],
+      },
+      errorPath: 'response.models[0].newSessionDefault',
+    },
+    {
+      label: 'unknown v2 entry field',
+      payload: {
+        schemaVersion: 2,
+        models: [{ ...baseModel, family: 'deepseek' }],
+      },
+      errorPath: 'response.models[0].family',
+    },
+    {
+      label: 'default marker outside live agents',
+      payload: {
+        schemaVersion: 2,
+        models: [{ ...baseModel, agents: ['claude-code'], newSessionDefault: ['codex'] }],
+      },
+      errorPath: 'response.models[0].newSessionDefault',
+    },
+  ])(
+    'rejects $label so the caller keeps its last-known-good snapshot',
+    ({ payload, errorPath }) => {
+      const parsed = parseModelsSyncPayload(payload);
+      expect(parsed.ok).toBe(false);
+      if (parsed.ok) throw new Error('unreachable');
+      expect(parsed.error).toContain(errorPath);
+    },
+  );
+
+  it('leaves the caller-owned last-known-good snapshot untouched on rejection', () => {
+    const lastKnownGood = [{ id: 'last-known-model' }];
+    const parsed = parseModelsSyncPayload({ schemaVersion: 99, models: [] });
+    const effectiveModels = parsed.ok ? parsed.models : lastKnownGood;
+
+    expect(effectiveModels).toBe(lastKnownGood);
+    expect(lastKnownGood).toEqual([{ id: 'last-known-model' }]);
+  });
+});
 
 describe('waitForModelsSyncRefresh', () => {
   it('gives the shared XD model-list request a finite deadline', () => {
@@ -30,9 +108,7 @@ describe('waitForModelsSyncRefresh', () => {
     if (typeof request.options.baseUrl !== 'function') {
       throw new Error('expected a live endpoint resolver');
     }
-    expect(request.options.baseUrl()).toBe(
-      'https://model-access.global.example.com',
-    );
+    expect(request.options.baseUrl()).toBe('https://model-access.global.example.com');
   });
 
   it('bounds the complete fetch lifecycle without cancelling the underlying auth refresh', async () => {
@@ -134,7 +210,9 @@ describe('waitForModelsSyncRefresh', () => {
 
   it('stops instead of following a new account when auth changes in flight', async () => {
     let resolveFlight!: () => void;
-    const flight = new Promise<void>((resolve) => { resolveFlight = resolve; });
+    const flight = new Promise<void>((resolve) => {
+      resolveFlight = resolve;
+    });
     let generation = 7;
     const outcome = waitForModelsSyncRefresh({
       expectedGeneration: 7,

--- a/apps/desktop/src/main/model-access/index.ts
+++ b/apps/desktop/src/main/model-access/index.ts
@@ -30,6 +30,7 @@ import {
 import {
   buildModelsSyncRequest,
   ensureCredentialsReadyForModelsRefresh,
+  parseModelsSyncPayload,
   withModelsSyncOverallDeadline,
   waitForModelsSyncRefresh,
 } from './modelsSyncRefresh.js';
@@ -145,10 +146,7 @@ let authGeneration = 0;
 let lastAuthUserId: string | null = null;
 let lastAuthRealm: ReturnType<typeof authManager.getActiveAuthRealm> | null = null;
 
-function applyGatewayModels(
-  models: ModelAccessGatewayModel[],
-  authenticatedUserId?: string,
-): void {
+function applyGatewayModels(models: ModelAccessGatewayModel[], authenticatedUserId?: string): void {
   // 同一次 /models 响应建立 XD 模型与价格投影。空成功响应会同时清空模型和价格；请求失败不会调用本函数，
   // 因而保留上一份完整成功快照。
   const pricing = replaceGatewayModelPricing(models, authenticatedUserId);
@@ -175,17 +173,20 @@ async function runModelsSync(
   authenticatedUserId: string,
   myAttempt: number,
 ): Promise<void> {
-  let payload: { models: ModelAccessGatewayModel[] };
+  let models: ModelAccessGatewayModel[];
   try {
-    const request = buildModelsSyncRequest(() =>
-      getClientEndpoint('modelAccessApiBaseUrl'),
+    const request = buildModelsSyncRequest(() => getClientEndpoint('modelAccessApiBaseUrl'));
+    const payload = await withModelsSyncOverallDeadline(
+      serverApiFetch<unknown>(request.path, request.options),
     );
-    payload = await withModelsSyncOverallDeadline(
-      serverApiFetch<{ models: ModelAccessGatewayModel[] }>(
-        request.path,
-        request.options,
-      ),
-    );
+    const parsed = parseModelsSyncPayload(payload);
+    if (!parsed.ok) {
+      log.warn('xd gateway models response rejected (keeping last valid list)', {
+        error: parsed.error,
+      });
+      return;
+    }
+    models = parsed.models;
   } catch (err) {
     log.warn('xd gateway models fetch failed (keeping last valid list)', {
       error: err instanceof Error ? err.message : String(err),
@@ -193,8 +194,6 @@ async function runModelsSync(
     return;
   }
   if (myGen !== authGeneration) return; // 响应归属旧账号,丢弃
-  const models = (payload.models ?? [])
-    .filter((m) => typeof m?.id === 'string' && m.id);
   if (models.length === 0) {
     log.warn('xd gateway models fetch returned empty list; clearing current list');
     applyGatewayModels([], authenticatedUserId);

--- a/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
+++ b/apps/desktop/src/main/model-access/modelsSyncRefresh.ts
@@ -1,8 +1,23 @@
-import type { ModelAccessStatus } from '../../shared/modelAccess.js';
+import { parseListModelsResponse } from '@cindy/model-access-protocol';
+import type { ModelAccessGatewayModel, ModelAccessStatus } from '../../shared/modelAccess.js';
 import type { CredentialsSync } from './credentialsSync.js';
 
 /** Bound the shared single-flight so a black-hole connection cannot block later refreshes. */
 export const XD_MODELS_SYNC_TIMEOUT_MS = 20_000;
+
+export type ModelsSyncPayloadParseResult =
+  { ok: true; models: ModelAccessGatewayModel[] } | { ok: false; error: string };
+
+/**
+ * Validate the actual `/models` wire envelope before it can replace the last-known-good snapshot.
+ * The shared protocol parser is the version boundary: it accepts the frozen v1 and current v2
+ * contracts, and rejects unknown versions or fields instead of partially interpreting them.
+ */
+export function parseModelsSyncPayload(value: unknown): ModelsSyncPayloadParseResult {
+  const parsed = parseListModelsResponse(value);
+  if (!parsed.ok) return parsed;
+  return { ok: true, models: parsed.value.models };
+}
 
 /**
  * Bound the whole serverApiFetch lifecycle, including its non-abortable token-rotation refresh.
@@ -54,11 +69,7 @@ export interface ModelsSyncFlightSnapshot {
   attempt: number;
 }
 
-export type ModelsSyncRefreshOutcome =
-  | 'succeeded'
-  | 'failed'
-  | 'not-started'
-  | 'account-changed';
+export type ModelsSyncRefreshOutcome = 'succeeded' | 'failed' | 'not-started' | 'account-changed';
 
 /**
  * A model-only refresh must not reacquire credentials when the current credentials

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1969,7 +1969,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   }): void => ipcRenderer.send('desktop:cc-prefs-changed', prefs),
 
   /**
-   * renderer 把 newMakerDraft 的 vendor/model 偏好快照推给 main 缓存 ——
+   * renderer 把 newMakerDraft 的 vendor/model 偏好与显式选择状态快照推给 main 缓存 ——
    * collab mode spawn worker (enableOrca / orca-bridge.create_worker) 读这份
    * 缓存决定 worker 的 model/effort/fastMode, 让 worker 默认 = "用户在 New Maker
    * 面板该 vendor 当前的选择"。启动时推一次 + 用户每次改 New Maker 偏好都推,
@@ -1978,10 +1978,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   syncNewMakerDraft: (snapshot: {
     lastByVendor: Partial<
       Record<
-        'cc' | 'codex',
+        'cc' | 'codex' | 'pi',
         { model?: string; effort?: string; permissionMode?: string; providerId?: string | null }
       >
     >;
+    /** 每个 vendor 是否由用户在 New Maker 中明确选过模型；device-link 默认校准据此保护显式选择。 */
+    modelChosenByVendor: Partial<Record<'cc' | 'codex' | 'pi', boolean>>;
     fastModeByModel: Record<string, boolean>;
     effortByModel: Record<string, string>;
     /** 「新建会话默认启用 worktree」勾选记忆(vendor 无关根字段,远程草稿播种用)。 */

--- a/apps/desktop/src/renderer/App.tsx
+++ b/apps/desktop/src/renderer/App.tsx
@@ -148,9 +148,9 @@ export function App() {
         fastMode: draft.fastModeByModel[cc.model] === true,
       });
       // main 缓存两用途:① collab worker spawn 读 model/effort/fastMode;② device-link 远程
-      // 草稿镜像读全量(model/effort/fast/permission/source)。故 lastByVendor 每项带上
-      // permissionMode + providerId(worker spawn 不消费这两项,远程草稿镜像才用)。仅 cc/codex,
-      // 不带 orca。fire-and-forget。
+      // 草稿镜像读全量(model/effort/fast/permission/source)+「是否显式选过模型」。故
+      // lastByVendor 覆盖 cc/codex/pi，并带上 permissionMode + providerId(worker spawn
+      // 不消费这两项,远程草稿镜像才用)。fire-and-forget。
       window.electronAPI.syncNewMakerDraft({
         lastByVendor: {
           cc: {
@@ -165,6 +165,17 @@ export function App() {
             permissionMode: draft.lastByVendor.codex.permissionMode,
             providerId: draft.lastByVendor.codex.providerId ?? null,
           },
+          pi: {
+            model: draft.lastByVendor.pi.model,
+            effort: draft.lastByVendor.pi.effort,
+            permissionMode: draft.lastByVendor.pi.permissionMode,
+            providerId: draft.lastByVendor.pi.providerId ?? null,
+          },
+        },
+        modelChosenByVendor: {
+          cc: draft.modelChosenByVendor.cc === true,
+          codex: draft.modelChosenByVendor.codex === true,
+          pi: draft.modelChosenByVendor.pi === true,
         },
         fastModeByModel: draft.fastModeByModel,
         effortByModel: draft.effortByModel,

--- a/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
+++ b/apps/desktop/src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts
@@ -272,6 +272,37 @@ describe('useAgentCapabilities deviceId-aware cache', () => {
     expect(mod.getCachedCapabilities('codex', 'dev-invalid-item')).toBeNull();
   });
 
+  it.each([
+    { label: '空数组', value: [] },
+    { label: '未知 agent', value: ['pi'] },
+    { label: '重复 agent', value: ['codex', 'codex'] },
+  ])('newSessionDefault 非法（$label）时整份 capabilities fail closed', async ({ value }) => {
+    const invoke = vi.fn(async () => ({
+      ...caps('invalid-default'),
+      availableModels: [
+        {
+          ...caps('invalid-default').availableModels[0],
+          newSessionDefault: value,
+        },
+      ],
+    }));
+    const getCapabilities = vi.fn(async (k: string) => caps(`local:${k}`));
+    vi.stubGlobal('window', {
+      electronAPI: { maker: { getCapabilities }, deviceLink: { invoke } },
+    });
+    const mod = await import('@/hooks/useAgentCapabilities');
+    const listener = vi.fn();
+    mod.subscribeDeviceCapabilities('dev-invalid-default', 'codex', listener);
+
+    await mod.prefetchDeviceCapabilities('dev-invalid-default');
+
+    expect(listener).toHaveBeenCalledWith({
+      status: 'error',
+      error: 'Invalid agent capabilities response',
+    });
+    expect(mod.getCachedCapabilities('codex', 'dev-invalid-default')).toBeNull();
+  });
+
   it('模型默认 effort 不在可用列表中时不得落缓存', async () => {
     const invoke = vi.fn(async () => ({
       ...caps('invalid-effort'),

--- a/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
@@ -269,14 +269,14 @@ describe('pickConnectedModelForAgent — newSessionDefault 标记优先（步骤
     expect(pickId(providers, 'claude-code', 'claude-opus-5')).toBe('claude-opus-5');
   });
 
-  it('多来源都提供被标记模型时，按订阅优先取来源', () => {
+  it('标记只在 XD 条目上时，同 ID 来源仍按订阅优先', () => {
     const gateway = provider('xd', true, {
       'claude-code': [model('deepseek', { newSessionDefault: ['claude-code'] })],
     });
     const sub = provider(
       'anthropic',
       true,
-      { 'claude-code': [model('deepseek', { newSessionDefault: ['claude-code'] })] },
+      { 'claude-code': [model('deepseek')] },
       'subscription',
     );
     const picked = pickConnectedModelForAgent([gateway, sub], 'claude-code', 'seed');

--- a/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
@@ -246,6 +246,90 @@ describe('pickConnectedModelForAgent', () => {
   });
 });
 
+describe('pickConnectedModelForAgent — newSessionDefault 标记优先（步骤 0）', () => {
+  it('被标记为新对话默认的模型优先，即便种子模型本身可用', () => {
+    const providers = [
+      provider('xd', true, {
+        'claude-code': [
+          model('claude-opus-5', { sortOrder: 0 }),
+          model('deepseek', { sortOrder: 44, newSessionDefault: ['claude-code'] }),
+        ],
+      }),
+    ];
+    // 种子是可用的 opus-5，但目录/服务端把 deepseek 标为新对话默认 → 落到 deepseek。
+    expect(pickId(providers, 'claude-code', 'claude-opus-5')).toBe('deepseek');
+  });
+
+  it('没有标记时行为不变：种子可用则保留', () => {
+    const providers = [
+      provider('xd', true, {
+        'claude-code': [model('claude-opus-5'), model('claude-sonnet-5')],
+      }),
+    ];
+    expect(pickId(providers, 'claude-code', 'claude-opus-5')).toBe('claude-opus-5');
+  });
+
+  it('多来源都提供被标记模型时，按订阅优先取来源', () => {
+    const gateway = provider('xd', true, {
+      'claude-code': [model('deepseek', { newSessionDefault: ['claude-code'] })],
+    });
+    const sub = provider(
+      'anthropic',
+      true,
+      { 'claude-code': [model('deepseek', { newSessionDefault: ['claude-code'] })] },
+      'subscription',
+    );
+    const picked = pickConnectedModelForAgent([gateway, sub], 'claude-code', 'seed');
+    expect(picked?.model).toBe('deepseek');
+    expect(picked?.providerId).toBe('anthropic');
+  });
+
+  it('pi 按 claude-code 口径判定标记（pi 镜像 cc-compatible 模型）', () => {
+    const providers = [
+      provider('xd', true, {
+        pi: [
+          model('claude-sonnet-5', { sortOrder: 0 }),
+          model('deepseek', { sortOrder: 44, newSessionDefault: ['claude-code'] }),
+        ],
+      }),
+    ];
+    expect(pickId(providers, 'pi', 'claude-sonnet-5')).toBe('deepseek');
+  });
+
+  it('被标记但默认收起(defaultEnabled:false)时不选', () => {
+    const providers = [
+      provider('xd', true, {
+        'claude-code': [
+          model('visible', { sortOrder: 5 }),
+          model('hidden', {
+            sortOrder: 0,
+            defaultEnabled: false,
+            newSessionDefault: ['claude-code'],
+          }),
+        ],
+      }),
+    ];
+    expect(pickId(providers, 'claude-code', 'visible')).toBe('visible');
+  });
+
+  it('用户显式选过时，标记不覆盖用户选择', () => {
+    const providers = [
+      provider('xd', true, {
+        'claude-code': [model('my-pick'), model('deepseek', { newSessionDefault: ['claude-code'] })],
+      }),
+    ];
+    expect(
+      calibratedId({
+        providers,
+        agent: 'claude-code',
+        model: 'my-pick',
+        chosenByUser: true,
+        providersLoading: false,
+      }),
+    ).toBe('my-pick');
+  });
+});
+
 describe('calibrateDraftModel', () => {
   const base = {
     providers: [gatewayWithoutOpus, disconnectedAnthropic],

--- a/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
@@ -328,6 +328,79 @@ describe('pickConnectedModelForAgent — newSessionDefault 标记优先（步骤
       }),
     ).toBe('my-pick');
   });
+
+  it('当前来源有偏好时，区域默认只在该来源内部校准，不会静默丢来源', () => {
+    const providers = [
+      provider(
+        'anthropic',
+        true,
+        {
+          'claude-code': [model('my-pick')],
+        },
+        'subscription',
+      ),
+      provider('xd', true, {
+        'claude-code': [model('deepseek', { newSessionDefault: ['claude-code'] })],
+      }),
+    ];
+    expect(
+      calibrateDraftModel({
+        providers,
+        agent: 'claude-code',
+        model: 'my-pick',
+        chosenByUser: false,
+        preferredProviderId: 'anthropic',
+        providersLoading: false,
+      }),
+    ).toEqual({ model: 'my-pick', providerId: 'anthropic' });
+  });
+
+  it('区域 marker 只在 XD 声明时，选定来源仍可承接其提供的同 ID 模型', () => {
+    const providers = [
+      provider(
+        'anthropic',
+        true,
+        {
+          'claude-code': [model('deepseek')],
+        },
+        'subscription',
+      ),
+      provider('xd', true, {
+        'claude-code': [
+          model('deepseek', { newSessionDefault: ['claude-code'] }),
+          model('old-default'),
+        ],
+      }),
+    ];
+    expect(
+      calibrateDraftModel({
+        providers,
+        agent: 'claude-code',
+        model: 'old-default',
+        chosenByUser: false,
+        preferredProviderId: 'anthropic',
+        providersLoading: false,
+      }),
+    ).toEqual({ model: 'deepseek', providerId: 'anthropic' });
+  });
+
+  it('陈旧的来源偏好不阻塞区域默认，回退完整的已连接候选', () => {
+    const providers = [
+      provider('xd', true, {
+        'claude-code': [model('deepseek', { newSessionDefault: ['claude-code'] })],
+      }),
+    ];
+    expect(
+      calibrateDraftModel({
+        providers,
+        agent: 'claude-code',
+        model: 'old-model',
+        chosenByUser: false,
+        preferredProviderId: 'disconnected-provider',
+        providersLoading: false,
+      }),
+    ).toEqual({ model: 'deepseek', providerId: 'xd' });
+  });
 });
 
 describe('calibrateDraftModel', () => {

--- a/apps/desktop/src/renderer/__tests__/modelDefinitionsDefaults.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelDefinitionsDefaults.test.ts
@@ -23,7 +23,12 @@ interface StubModel {
   defaultEffort: string;
   sortOrder?: number;
   defaultEnabled?: boolean;
+  /** 新对话默认种子标记(与 sortOrder 解耦);pi 按 'claude-code' 口径判定。 */
+  newSessionDefault?: ('claude-code' | 'codex')[];
 }
+
+/** pi 也是一个 vendor;缺省的 agent 一律回落空清单。 */
+type StubByAgent = Partial<Record<'claude-code' | 'codex' | 'pi', StubModel[]>>;
 
 function model(id: string, over: Partial<StubModel> = {}): StubModel {
   return {
@@ -36,9 +41,9 @@ function model(id: string, over: Partial<StubModel> = {}): StubModel {
   };
 }
 
-function stubCapabilities(byAgent: Record<'claude-code' | 'codex', StubModel[]>): void {
-  const getCapabilities = vi.fn(async (kind: 'claude-code' | 'codex') => ({
-    availableModels: byAgent[kind],
+function stubCapabilities(byAgent: StubByAgent): void {
+  const getCapabilities = vi.fn(async (kind: 'claude-code' | 'codex' | 'pi') => ({
+    availableModels: byAgent[kind] ?? [],
     hasFastMode: false,
     effortLevels: [],
     permissionModes: [],
@@ -46,7 +51,7 @@ function stubCapabilities(byAgent: Record<'claude-code' | 'codex', StubModel[]>)
   vi.stubGlobal('window', { electronAPI: { maker: { getCapabilities } } });
 }
 
-async function loadWith(byAgent: Record<'claude-code' | 'codex', StubModel[]>) {
+async function loadWith(byAgent: StubByAgent) {
   stubCapabilities(byAgent);
   const caps = await import('@/hooks/useAgentCapabilities');
   const md = await import('@/lib/modelDefinitions');
@@ -57,7 +62,10 @@ async function loadWith(byAgent: Record<'claude-code' | 'codex', StubModel[]>) {
 describe('getDefaultModelForVendor', () => {
   it('取 sortOrder 最小的模型，而不是清单里排前面的', async () => {
     const md = await loadWith({
-      'claude-code': [model('first-in-list', { sortOrder: 30 }), model('flagship', { sortOrder: 0 })],
+      'claude-code': [
+        model('first-in-list', { sortOrder: 30 }),
+        model('flagship', { sortOrder: 0 }),
+      ],
       codex: [model('gpt-old', { sortOrder: 20 }), model('gpt-new', { sortOrder: 17 })],
     });
 
@@ -173,6 +181,129 @@ describe('getDefaultModelForVendor', () => {
     expect(entry?.defaultEnabled).not.toBe(false);
     expect(entry?.group).not.toBe('gpt-budget');
     expect(md.getDefaultModelForVendor('codex').label).toBe(entry?.name);
+  });
+});
+
+describe('newSessionDefault（专用默认种子标记）', () => {
+  it('被标记的模型优先，即便 sortOrder 不是最小', async () => {
+    const md = await loadWith({
+      'claude-code': [
+        model('flagship-by-order', { sortOrder: 0 }),
+        model('deepseek', { sortOrder: 44, newSessionDefault: ['claude-code'] }),
+      ],
+      codex: [
+        model('gpt-first', { sortOrder: 0 }),
+        model('deepseek', { sortOrder: 44, newSessionDefault: ['claude-code', 'codex'] }),
+      ],
+    });
+
+    expect(md.getDefaultModelForVendor('cc').id).toBe('deepseek');
+    expect(md.getDefaultModelForVendor('codex').id).toBe('deepseek');
+    expect(md.newSessionDefaultModelId('cc')).toBe('deepseek');
+    expect(md.newSessionDefaultModelId('codex')).toBe('deepseek');
+  });
+
+  it('没有任何标记时逐字节回退到「排序第一可见」', async () => {
+    const md = await loadWith({
+      'claude-code': [model('a', { sortOrder: 5 }), model('b', { sortOrder: 1 })],
+    });
+
+    expect(md.getDefaultModelForVendor('cc').id).toBe('b');
+    expect(md.newSessionDefaultModelId('cc')).toBeNull();
+  });
+
+  it('标记只对声明的 agent 生效（只标 claude-code 时 codex 不选它）', async () => {
+    const md = await loadWith({
+      codex: [
+        model('gpt-first', { sortOrder: 0 }),
+        model('cc-only-default', { sortOrder: 44, newSessionDefault: ['claude-code'] }),
+      ],
+    });
+
+    expect(md.getDefaultModelForVendor('codex').id).toBe('gpt-first');
+    expect(md.newSessionDefaultModelId('codex')).toBeNull();
+  });
+
+  it('被标记但默认收起(defaultEnabled:false)时不选，回退排序第一', async () => {
+    const md = await loadWith({
+      'claude-code': [
+        model('visible', { sortOrder: 5 }),
+        model('hidden-flagged', {
+          sortOrder: 0,
+          defaultEnabled: false,
+          newSessionDefault: ['claude-code'],
+        }),
+      ],
+    });
+
+    expect(md.getDefaultModelForVendor('cc').id).toBe('visible');
+    expect(md.newSessionDefaultModelId('cc')).toBeNull();
+  });
+
+  it('多个被标记时按 sortOrder 决胜', async () => {
+    const md = await loadWith({
+      'claude-code': [
+        model('flag-hi', { sortOrder: 40, newSessionDefault: ['claude-code'] }),
+        model('flag-lo', { sortOrder: 10, newSessionDefault: ['claude-code'] }),
+      ],
+    });
+
+    expect(md.getDefaultModelForVendor('cc').id).toBe('flag-lo');
+  });
+
+  it('省略 sortOrder 永远排在任意有限数值之后', async () => {
+    const md = await loadWith({
+      'claude-code': [
+        model('flag-omitted', { newSessionDefault: ['claude-code'] }),
+        model('flag-large-finite', {
+          sortOrder: Number.MAX_SAFE_INTEGER + 1,
+          newSessionDefault: ['claude-code'],
+        }),
+      ],
+    });
+
+    expect(md.getDefaultModelForVendor('cc').id).toBe('flag-large-finite');
+  });
+
+  it.each([
+    {
+      label: '相同 sortOrder',
+      models: [
+        model('flag-first', { sortOrder: 10, newSessionDefault: ['claude-code'] }),
+        model('flag-second', { sortOrder: 10, newSessionDefault: ['claude-code'] }),
+      ],
+    },
+    {
+      label: '都省略 sortOrder',
+      models: [
+        model('flag-first', { newSessionDefault: ['claude-code'] }),
+        model('flag-second', { newSessionDefault: ['claude-code'] }),
+      ],
+    },
+  ])('$label 时保留 ListModels 响应顺序', async ({ models }) => {
+    const md = await loadWith({ 'claude-code': models });
+
+    expect(md.getDefaultModelForVendor('cc').id).toBe('flag-first');
+  });
+
+  it('pi 按 claude-code 口径判定：标了 claude-code 的模型成为 pi 的默认', async () => {
+    const md = await loadWith({
+      pi: [
+        model('sonnet', { sortOrder: 0 }),
+        model('deepseek', { sortOrder: 44, newSessionDefault: ['claude-code'] }),
+      ],
+    });
+
+    expect(md.getDefaultModelForVendor('pi').id).toBe('deepseek');
+    expect(md.newSessionDefaultModelId('pi')).toBe('deepseek');
+  });
+
+  it('pi 未标记时冷启动占位是 claude-sonnet-5（不再错落到 cc 的 opus-5）', async () => {
+    stubCapabilities({});
+    const md = await import('@/lib/modelDefinitions');
+
+    expect(md.coldStartModelIdForVendor('pi')).toBe('claude-sonnet-5');
+    expect(md.getDefaultModelForVendor('pi').id).toBe('claude-sonnet-5');
   });
 });
 

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -1338,6 +1338,26 @@ describe('Shared create project picker', () => {
     );
   });
 
+  it('reapplies refreshed regional defaults only while the remote runtime is untouched', () => {
+    const seed = newMakerDraftRouteSource.slice(
+      newMakerDraftRouteSource.indexOf('// seed dlSel:'),
+      newMakerDraftRouteSource.indexOf('// 远程草稿展示用:'),
+    );
+    expect(seed).toContain('shouldReseedDeviceLinkDraftDefaults({');
+    expect(seed).toContain('capabilitiesChanged,');
+    expect(seed).toContain('if (!capabilities || capabilitiesLoading');
+    expect(seed).toContain('controllerTouched: dlRuntimeTouchedRef.current,');
+    expect(seed).toContain('remoteModelChosenByUser: remoteDraftState.value?.modelChosenByUser,');
+    expect(seed).toContain('modelChosenByUser: true,');
+    expect(seed).toContain('current.model,');
+
+    const runtimeHandlers = newMakerDraftRouteSource.slice(
+      newMakerDraftRouteSource.indexOf('const handleModelDidChange = useCallback('),
+      newMakerDraftRouteSource.indexOf('// ─── 用户改 workingDir'),
+    );
+    expect((runtimeHandlers.match(/dlRuntimeTouchedRef\.current = true;/g) ?? []).length).toBe(5);
+  });
+
   // #807 review 第二十七轮:设备菜单行原来只有 hover / disabled 两态,且 outline-none 去掉了浏览器
   // 默认焦点圈 —— 键盘走这个菜单时完全看不出焦点落在哪一行。
   it('shows a token-backed focus ring on device menu rows', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -218,6 +218,7 @@ import {
 import { isSubscriptionDirectModel } from '../../../shared/subscriptionModels';
 import {
   resolveDeviceLinkDraftDefaults,
+  shouldReseedDeviceLinkDraftDefaults,
   type DeviceLinkDraftSelection,
   type RemoteDraftDefaults,
 } from './deviceLinkDraftDefaults';
@@ -1005,6 +1006,7 @@ export function NewMakerDraftRoute() {
       agent: capabilityAgentKind,
       model: chatPrefs.model,
       chosenByUser: draftModelChosenByUser,
+      preferredProviderId: chatPrefs.providerId,
       providersLoading: localProvidersLoading,
     });
   }, [
@@ -1012,6 +1014,7 @@ export function NewMakerDraftRoute() {
     autoCalibrationProviders,
     capabilityAgentKind,
     chatPrefs.model,
+    chatPrefs.providerId,
     draftModelChosenByUser,
     localProvidersLoading,
   ]);
@@ -1107,6 +1110,9 @@ export function NewMakerDraftRoute() {
   const [remoteDraftRetryEpoch, setRemoteDraftRetryEpoch] = useState(0);
   const [dlSel, setDlSel] = useState<DeviceLinkDraftSelection | null>(null);
   const dlSeedKeyRef = useRef<string | null>(null);
+  const dlSeedCapabilitiesRef = useRef<AgentCapabilities | null>(null);
+  /** 控制端是否编辑过当前设备 / Agent 的远程运行配置；能力刷新不得覆盖这类显式意图。 */
+  const dlRuntimeTouchedRef = useRef(false);
   const skipDefaultsRefetchRef = useRef(false);
   const remoteDraftIdentityRef = useRef<string | null>(null);
   const remoteDraftRevisionRef = useRef(0);
@@ -1167,18 +1173,57 @@ export function NewMakerDraftRoute() {
     remoteDraftRetryEpoch,
   ]);
 
-  // seed dlSel:等被控端 capabilities + 草稿值都就绪后种一次;按 (deviceId, vendor) 记 seedKey,
-  // 同一设备 / vendor 内不重种(用户编辑只改 dlSel、不动 seedKey,故不被覆盖),切设备 / vendor 才重种。
+  // seed dlSel:等被控端 capabilities + 草稿值都就绪后播种。切设备 / vendor 必须重种；同一目标
+  // 在被控端明确未选过模型且控制端未编辑时，允许 capabilities 刷新重新校准区域默认。
   useEffect(() => {
     if (!isDeviceLinkDraft || !effectiveDeviceLinkDeviceId) {
       dlSeedKeyRef.current = null;
+      dlSeedCapabilitiesRef.current = null;
+      dlRuntimeTouchedRef.current = false;
       setDlSel(null);
       return;
     }
-    if (!capabilities || remoteDraftState.status !== 'ready') return;
+    // provider revision 驱逐时 hook 会保留旧快照但标 loading；必须等新代际 ready，不能用 stale
+    // capabilities 把 inline handoff 或用户当前选择校准回旧目录。
+    if (!capabilities || capabilitiesLoading || remoteDraftState.status !== 'ready') return;
     const key = `${effectiveDeviceLinkDeviceId}:${capabilityAgentKind}`;
-    if (dlSeedKeyRef.current === key) return;
+    const newTarget = dlSeedKeyRef.current !== key;
+    const capabilitiesChanged = dlSeedCapabilitiesRef.current !== capabilities;
+    if (
+      !shouldReseedDeviceLinkDraftDefaults({
+        currentSeedKey: dlSeedKeyRef.current,
+        nextSeedKey: key,
+        capabilitiesChanged,
+        controllerTouched: dlRuntimeTouchedRef.current,
+        remoteModelChosenByUser: remoteDraftState.value?.modelChosenByUser,
+      })
+    ) {
+      if (capabilitiesChanged) {
+        dlSeedCapabilitiesRef.current = capabilities;
+        // 显式意图只禁止“换成区域默认”，不能把已从新能力清单消失的 model / effort /
+        // permission 留在草稿里。用当前控制端选择合成 active draft，只做合法性夹紧。
+        setDlSel((current) =>
+          current
+            ? resolveDeviceLinkDraftDefaults(
+                capabilities,
+                {
+                  model: current.model,
+                  modelChosenByUser: true,
+                  effort: current.effort,
+                  fastMode: current.fastMode,
+                  permissionMode: current.permissionMode,
+                  providerId: current.providerId,
+                },
+                current.model,
+              )
+            : current,
+        );
+      }
+      return;
+    }
     dlSeedKeyRef.current = key;
+    dlSeedCapabilitiesRef.current = capabilities;
+    if (newTarget) dlRuntimeTouchedRef.current = false;
     setDlSel(
       resolveDeviceLinkDraftDefaults(
         capabilities,
@@ -1192,6 +1237,7 @@ export function NewMakerDraftRoute() {
     effectiveDeviceLinkDeviceId,
     capabilityAgentKind,
     capabilities,
+    capabilitiesLoading,
     remoteDraftState,
   ]);
 
@@ -1534,6 +1580,7 @@ export function NewMakerDraftRoute() {
       if (req.remoteSnapshot) {
         const { capabilities: freshCaps, defaults: freshDefaults } = req.remoteSnapshot;
         dlSeedKeyRef.current = req.deviceId ? `${req.deviceId}:${capabilityAgentKind}` : null;
+        dlSeedCapabilitiesRef.current = freshCaps;
         if (deviceChanged) {
           setDlSel(
             resolveDeviceLinkDraftDefaults(
@@ -1543,6 +1590,7 @@ export function NewMakerDraftRoute() {
               capabilityAgentKind,
             ),
           );
+          dlRuntimeTouchedRef.current = false;
           // deviceId 变化会让 defaults effect 重跑;我们已经 inline 拉过了,跳过那一次避免覆盖。
           skipDefaultsRefetchRef.current = true;
         } else {
@@ -1577,6 +1625,8 @@ export function NewMakerDraftRoute() {
       } else if (deviceChanged) {
         setDlSel(null);
         dlSeedKeyRef.current = null;
+        dlSeedCapabilitiesRef.current = null;
+        dlRuntimeTouchedRef.current = false;
         setRemoteDraftState({ status: 'loading', value: null });
       }
 
@@ -1885,6 +1935,7 @@ export function NewMakerDraftRoute() {
   const handleModelDidChange = useCallback(
     (newModelId: string) => {
       if (isDeviceLinkDraft) {
+        dlRuntimeTouchedRef.current = true;
         // 远程草稿:只改 dlSel,绝不写本地 newMakerDraft。capabilities 未就绪时退化为仅换 model。
         if (!capabilities) {
           setDlSel((prev) => (prev ? { ...prev, model: newModelId } : prev));
@@ -1915,6 +1966,7 @@ export function NewMakerDraftRoute() {
   const handleFastModeChange = useCallback(
     (enabled: boolean) => {
       if (isDeviceLinkDraft) {
+        dlRuntimeTouchedRef.current = true;
         setDlSel((prev) => (prev ? { ...prev, fastMode: enabled } : prev));
         pushActiveDraftPref({ fast: enabled }); // 选中模型 fast 写穿被控端
         return;
@@ -1945,6 +1997,7 @@ export function NewMakerDraftRoute() {
   const handleEffortDidChange = useCallback(
     (newEffort: Effort) => {
       if (isDeviceLinkDraft) {
+        dlRuntimeTouchedRef.current = true;
         setDlSel((prev) => (prev ? { ...prev, effort: newEffort } : prev));
         pushActiveDraftPref({ effort: newEffort }); // 选中模型 effort 写穿被控端
         return;
@@ -1966,6 +2019,7 @@ export function NewMakerDraftRoute() {
   const handlePermissionModeDidChange = useCallback(
     (newMode: PermissionMode) => {
       if (isDeviceLinkDraft) {
+        dlRuntimeTouchedRef.current = true;
         setDlSel((prev) => (prev ? { ...prev, permissionMode: newMode } : prev));
         return;
       }
@@ -1988,6 +2042,7 @@ export function NewMakerDraftRoute() {
   const handleProviderDidChange = useCallback(
     (newProviderId: string | null) => {
       if (isDeviceLinkDraft) {
+        dlRuntimeTouchedRef.current = true;
         setDlSel((prev) => (prev ? { ...prev, providerId: newProviderId } : prev));
         return;
       }

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/deviceLinkDraftDefaults.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/deviceLinkDraftDefaults.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveDeviceLinkDraftDefaults } from '../deviceLinkDraftDefaults';
+import {
+  resolveDeviceLinkDraftDefaults,
+  shouldReseedDeviceLinkDraftDefaults,
+} from '../deviceLinkDraftDefaults';
 import type { AgentCapabilities } from '@/hooks/useAgentCapabilities';
 
 // 最小被控端 capabilities:两模型(Opus 支持 fast + 多 effort 档;Haiku 无 effort/fast)。
@@ -105,6 +108,21 @@ describe('resolveDeviceLinkDraftDefaults', () => {
       resolveDeviceLinkDraftDefaults(caps(), { model: 'claude-opus-4-8' }, undefined, 'claude-code')
         .model,
     ).toBe('claude-opus-4-8');
+  });
+
+  it('被控端已有来源偏好时不应用可能丢失该来源的区域默认', () => {
+    const sel = resolveDeviceLinkDraftDefaults(
+      caps(),
+      {
+        model: 'claude-opus-4-8',
+        modelChosenByUser: false,
+        providerId: 'anthropic',
+      },
+      undefined,
+      'claude-code',
+    );
+    expect(sel.model).toBe('claude-opus-4-8');
+    expect(sel.providerId).toBe('anthropic');
   });
 
   it('控制端本次显式 targetModel 优先于远端未选择标记', () => {
@@ -221,5 +239,107 @@ describe('resolveDeviceLinkDraftDefaults', () => {
     );
     expect(sel.effort).toBe('xhigh');
     expect(sel.fastMode).toBe(true);
+  });
+});
+
+describe('shouldReseedDeviceLinkDraftDefaults', () => {
+  it('recalibrates the same untouched target when the remote explicitly has no model choice', () => {
+    expect(
+      shouldReseedDeviceLinkDraftDefaults({
+        currentSeedKey: 'device-a:claude-code',
+        nextSeedKey: 'device-a:claude-code',
+        capabilitiesChanged: true,
+        controllerTouched: false,
+        remoteModelChosenByUser: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('preserves controller edits and remote explicit or legacy-unknown choices', () => {
+    const base = {
+      currentSeedKey: 'device-a:claude-code',
+      nextSeedKey: 'device-a:claude-code',
+    };
+    expect(
+      shouldReseedDeviceLinkDraftDefaults({
+        ...base,
+        capabilitiesChanged: true,
+        controllerTouched: true,
+        remoteModelChosenByUser: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReseedDeviceLinkDraftDefaults({
+        ...base,
+        capabilitiesChanged: true,
+        controllerTouched: false,
+        remoteModelChosenByUser: true,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReseedDeviceLinkDraftDefaults({
+        ...base,
+        capabilitiesChanged: true,
+        controllerTouched: false,
+        remoteModelChosenByUser: undefined,
+      }),
+    ).toBe(false);
+    expect(
+      shouldReseedDeviceLinkDraftDefaults({
+        ...base,
+        capabilitiesChanged: false,
+        controllerTouched: false,
+        remoteModelChosenByUser: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('always seeds a new device or agent target', () => {
+    expect(
+      shouldReseedDeviceLinkDraftDefaults({
+        currentSeedKey: 'device-a:claude-code',
+        nextSeedKey: 'device-b:codex',
+        capabilitiesChanged: false,
+        controllerTouched: true,
+        remoteModelChosenByUser: true,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('capabilities refresh clamp contract', () => {
+  it('保留仍合法的控制端选择，但会夹紧已失效的模型与运行参数', () => {
+    const refreshed = caps();
+    refreshed.availableModels = [
+      {
+        id: 'claude-haiku-4-5',
+        label: 'Haiku',
+        efforts: ['low'],
+        defaultEffort: 'low',
+        supportsFastMode: false,
+      },
+    ];
+    refreshed.permissionModes = [{ id: 'default', label: 'Default' }];
+
+    expect(
+      resolveDeviceLinkDraftDefaults(
+        refreshed,
+        {
+          model: 'removed-model',
+          modelChosenByUser: true,
+          effort: 'high',
+          fastMode: true,
+          permissionMode: 'bypassPermissions',
+          providerId: 'anthropic',
+        },
+        'removed-model',
+      ),
+    ).toEqual({
+      model: 'claude-haiku-4-5',
+      effort: 'low',
+      fastMode: false,
+      permissionMode: undefined,
+      providerId: 'anthropic',
+    });
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/deviceLinkDraftDefaults.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/deviceLinkDraftDefaults.test.ts
@@ -313,13 +313,14 @@ describe('capabilities refresh clamp contract', () => {
     refreshed.availableModels = [
       {
         id: 'claude-haiku-4-5',
-        label: 'Haiku',
+        displayName: 'Haiku',
+        contextWindow: 200_000,
         efforts: ['low'],
         defaultEffort: 'low',
         supportsFastMode: false,
       },
     ];
-    refreshed.permissionModes = [{ id: 'default', label: 'Default' }];
+    refreshed.permissionModes = [{ id: 'default', displayName: 'Default' }];
 
     expect(
       resolveDeviceLinkDraftDefaults(

--- a/apps/desktop/src/renderer/features/cc-agent/__tests__/deviceLinkDraftDefaults.test.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/__tests__/deviceLinkDraftDefaults.test.ts
@@ -22,6 +22,8 @@ function caps(overrides: Partial<AgentCapabilities> = {}): AgentCapabilities {
         efforts: [],
         defaultEffort: null,
         supportsFastMode: false,
+        sortOrder: 10,
+        newSessionDefault: ['claude-code'],
       },
     ],
     hasFastMode: true,
@@ -72,6 +74,57 @@ describe('resolveDeviceLinkDraftDefaults', () => {
     });
     expect(sel.model).toBe('claude-opus-4-8');
     expect(sel.effort).toBe('high'); // 'low' 不被 Opus 支持 → defaultEffort
+  });
+
+  it('被控端明确未选过模型 → 初始 seed 优先采用其区域目录默认', () => {
+    const sel = resolveDeviceLinkDraftDefaults(
+      caps(),
+      {
+        model: 'claude-opus-4-8',
+        modelChosenByUser: false,
+        effort: 'xhigh',
+        fastMode: true,
+      },
+      undefined,
+      'claude-code',
+    );
+    expect(sel.model).toBe('claude-haiku-4-5');
+    expect(sel.fastMode).toBe(false);
+  });
+
+  it('显式选择或旧端未知选择状态 → 保留被控端当前模型', () => {
+    expect(
+      resolveDeviceLinkDraftDefaults(
+        caps(),
+        { model: 'claude-opus-4-8', modelChosenByUser: true },
+        undefined,
+        'claude-code',
+      ).model,
+    ).toBe('claude-opus-4-8');
+    expect(
+      resolveDeviceLinkDraftDefaults(caps(), { model: 'claude-opus-4-8' }, undefined, 'claude-code')
+        .model,
+    ).toBe('claude-opus-4-8');
+  });
+
+  it('控制端本次显式 targetModel 优先于远端未选择标记', () => {
+    const sel = resolveDeviceLinkDraftDefaults(
+      caps(),
+      { model: 'claude-opus-4-8', modelChosenByUser: false },
+      'claude-opus-4-8',
+      'claude-code',
+    );
+    expect(sel.model).toBe('claude-opus-4-8');
+  });
+
+  it('Pi 的远程新任务默认沿用 claude-code wire 标记', () => {
+    const sel = resolveDeviceLinkDraftDefaults(
+      caps(),
+      { model: 'claude-opus-4-8', modelChosenByUser: false },
+      undefined,
+      'pi',
+    );
+    expect(sel.model).toBe('claude-haiku-4-5');
   });
 
   it('effort 不被目标模型支持 → 落该模型 defaultEffort', () => {

--- a/apps/desktop/src/renderer/features/cc-agent/deviceLinkDraftDefaults.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/deviceLinkDraftDefaults.ts
@@ -62,6 +62,24 @@ export interface DeviceLinkDraftSelection {
 }
 
 /**
+ * 判断同一远程草稿是否应在 capabilities 刷新后重新校准。
+ * 新设备或 Agent 始终需要 seed；同一目标只有在被控端明确从未选过模型、且控制端也尚未
+ * 编辑运行配置时才允许重校准。旧端的未知状态与任一侧的显式选择都必须保守保留。
+ */
+export function shouldReseedDeviceLinkDraftDefaults(input: {
+  currentSeedKey: string | null;
+  nextSeedKey: string;
+  capabilitiesChanged: boolean;
+  controllerTouched: boolean;
+  remoteModelChosenByUser: boolean | undefined;
+}): boolean {
+  if (input.currentSeedKey !== input.nextSeedKey) return true;
+  return (
+    input.capabilitiesChanged && !input.controllerTouched && input.remoteModelChosenByUser === false
+  );
+}
+
+/**
  * 把被控端草稿值(或 null=回落)按被控端 capabilities 校准成可 seed 的选择。
  *   - model:要解析的模型 = targetModel(用户在草稿里切模型)优先,否则 remoteDraft.model(初始 seed);
  *     该 id 在被控端清单内则用它,否则被控端 availableModels[0]。
@@ -104,7 +122,7 @@ export function resolveDeviceLinkDraftDefaults(
     : undefined;
   const wantedModelId =
     targetModel ??
-    (remoteDraft?.modelChosenByUser === false
+    (remoteDraft?.modelChosenByUser === false && providerId === null
       ? (markedDefault ?? remoteDraft.model)
       : remoteDraft?.model);
 

--- a/apps/desktop/src/renderer/features/cc-agent/deviceLinkDraftDefaults.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/deviceLinkDraftDefaults.ts
@@ -21,6 +21,8 @@ import type { Effort, PermissionMode } from '@/lib/userPreferences.types';
 /** 被控端当前草稿的原始值(maker:get-new-maker-defaults 隧道返回;字段全可选)。 */
 export interface RemoteDraftDefaults {
   model?: string;
+  /** false = 被控端明确未在 New Maker picker 选过模型；undefined = 旧端未知。 */
+  modelChosenByUser?: boolean;
   effort?: string;
   fastMode?: boolean;
   permissionMode?: string;
@@ -82,8 +84,29 @@ export function resolveDeviceLinkDraftDefaults(
   const providerId = remoteDraft?.providerId ?? null;
   const permissionMode = pickPermissionMode(capabilities, remoteDraft?.permissionMode);
 
-  // 要解析哪个模型:显式 targetModel(切模型)优先;否则被控端当前选中模型(初始 seed)。
-  const wantedModelId = targetModel ?? remoteDraft?.model;
+  // 要解析哪个模型:控制端本次显式 targetModel(切模型)永远优先。初始 seed 只有在**新端明确
+  // 回传未选过模型**时才采用区域目录默认；旧端缺字段时保守保留 remoteDraft.model，避免
+  // 把无法识别的历史显式选择覆盖掉。pi 与本地默认口径一致，映射到 claude-code wire 标记。
+  const wireAgent = agentKind === 'codex' ? 'codex' : 'claude-code';
+  const markedDefault = agentKind
+    ? models
+        .map((model, index) => ({ model, index }))
+        .filter(
+          ({ model }) =>
+            model.defaultEnabled !== false &&
+            (model.newSessionDefault?.includes(wireAgent) ?? false),
+        )
+        .sort(
+          (a, b) =>
+            (a.model.sortOrder ?? Number.MAX_SAFE_INTEGER) -
+              (b.model.sortOrder ?? Number.MAX_SAFE_INTEGER) || a.index - b.index,
+        )[0]?.model.id
+    : undefined;
+  const wantedModelId =
+    targetModel ??
+    (remoteDraft?.modelChosenByUser === false
+      ? (markedDefault ?? remoteDraft.model)
+      : remoteDraft?.model);
 
   if (models.length === 0) {
     return {

--- a/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
+++ b/apps/desktop/src/renderer/hooks/useAgentCapabilities.ts
@@ -50,6 +50,12 @@ export interface ModelDescriptor {
    * 消费点见 modelDefinitions.getDefaultModelForVendor:种子默认只从默认可见的模型里取。
    */
   defaultEnabled?: boolean;
+  /**
+   * 该模型是哪些 wire agent 的**新对话默认种子**(源自目录 newSessionDefault,与 sortOrder
+   * 解耦;生产环境 XD 网关由服务端按区域下发)。消费点见 modelDefinitions.newSessionDefaultModelId
+   * 与 draftModelCalibration:被标记且可用的模型优先作新对话默认。pi 按 'claude-code' 口径判定。
+   */
+  newSessionDefault?: ('claude-code' | 'codex')[];
 }
 
 export interface EffortDescriptor {
@@ -133,6 +139,20 @@ function isOptionalStringRecord(value: unknown): boolean {
   );
 }
 
+/** 与 protocol newSessionDefault 约束一致:可选;存在时非空、wire agent、无重复。 */
+function isOptionalNewSessionDefault(value: unknown): boolean {
+  if (value === undefined) return true;
+  if (!Array.isArray(value) || value.length === 0) return false;
+  if (
+    value.some(
+      (agent) => agent !== 'claude-code' && agent !== 'codex',
+    )
+  ) {
+    return false;
+  }
+  return new Set(value).size === value.length;
+}
+
 function isModelDescriptor(value: unknown): value is ModelDescriptor {
   if (!isRecord(value)) return false;
   const efforts = value.efforts;
@@ -154,7 +174,8 @@ function isModelDescriptor(value: unknown): value is ModelDescriptor {
     isOptionalStringRecord(value.effortDisplayNames) &&
     isOptionalBoolean(value.supportsFastMode) &&
     isOptionalFiniteNumber(value.sortOrder) &&
-    isOptionalBoolean(value.defaultEnabled)
+    isOptionalBoolean(value.defaultEnabled) &&
+    isOptionalNewSessionDefault(value.newSessionDefault)
   );
 }
 

--- a/apps/desktop/src/renderer/lib/draftModelCalibration.ts
+++ b/apps/desktop/src/renderer/lib/draftModelCalibration.ts
@@ -65,8 +65,7 @@ function firstModelByOrder(provider: ProviderView, agent: AgentKind): CatalogMod
   return pool
     .slice()
     .sort(
-      (a, b) =>
-        (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER),
+      (a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER),
     )[0];
 }
 
@@ -86,6 +85,11 @@ export interface PickedConnectedModel {
 
 /**
  * 在该 agent 的已连接来源里挑 (模型, 来源)：
+ *   0. 目录/服务端**显式标记**为新对话默认（`newSessionDefault`）、且可用且默认可见的模型
+ *      优先 —— 未显式选过模型的用户应跟随它，即便种子恰好是另一个可用模型（种子是
+ *      capabilities 未到位时算的冷启动值，不反映标记）。按订阅优先取第一家提供它的来源，
+ *      同一来源多个被标记时按 sortOrder 决胜。pi 按 claude-code 口径判定（pi 的模型宇宙是
+ *      cc-compatible 模型的镜像）。**没有任何模型被标记时这步为空转，行为回到 1/2**（非破坏性）。
  *   1. `preferredModelId` 本身可用**且默认可见** —— 默认值能用就绝不动它，避免首屏莫名换
  *      模型；来源仍按订阅优先顺序取「第一家提供它的」，让默认值也享受订阅优先；
  *   2. 否则按「订阅优先」的供应商序取第一家，返回它排序第一的默认可见模型
@@ -110,6 +114,25 @@ export function pickConnectedModelForAgent(
 ): PickedConnectedModel | null {
   const ranked = providersByPreference(providers, agent);
   if (ranked.length === 0) return null;
+  // 0. 目录/服务端显式标记的新对话默认(newSessionDefault)优先。pi 不是 wire agent,按
+  //    claude-code 口径判定(host 把含 claude-code 的模型投影进 pi tab,标记随之带上)。
+  const flagAgent: 'claude-code' | 'codex' = agent === 'codex' ? 'codex' : 'claude-code';
+  for (const provider of ranked) {
+    const userProvider = provider.source === 'user';
+    const flagged = (provider.models[agent] ?? [])
+      .filter(
+        (m) =>
+          m.defaultEnabled !== false &&
+          (m.newSessionDefault?.includes(flagAgent) ?? false) &&
+          isModelSelectableForNewRoute(m, { userProvider }),
+      )
+      .slice()
+      .sort(
+        (a, b) =>
+          (a.sortOrder ?? Number.POSITIVE_INFINITY) - (b.sortOrder ?? Number.POSITIVE_INFINITY),
+      )[0];
+    if (flagged) return { model: flagged.id, providerId: provider.id };
+  }
   for (const provider of ranked) {
     const preferred = (provider.models[agent] ?? []).find((m) => m.id === preferredModelId);
     if (
@@ -197,12 +220,7 @@ export function resolveDraftSessionProviderId({
     return explicitProviderId;
   }
   if (!effectiveProviderId) return null;
-  const modelDefaultProviderId = effectiveSourceIdForModel(
-    [...providers],
-    null,
-    model,
-    agent,
-  );
+  const modelDefaultProviderId = effectiveSourceIdForModel([...providers], null, model, agent);
   // main 收到 providerId=null 后按 agent 的原生来源选择启动链路，而不是只在“提供当前
   // 模型”的来源里重算。典型分叉：XD 与 Anthropic 都已连接，只有 Anthropic 目录含
   // claude-opus-5。modelDefault 是 anthropic，但 agentDefault 仍是 xd；若只比较前者

--- a/apps/desktop/src/renderer/lib/draftModelCalibration.ts
+++ b/apps/desktop/src/renderer/lib/draftModelCalibration.ts
@@ -6,9 +6,9 @@
  * 一个没有任何已连接来源的模型上，Send 被禁用、只能弹「当前模型没有已连接的来源」，用户还没
  * 开始用就先撞墙。这里负责把默认落到**真正可用**的模型上。
  *
- * 这里只校准**用户从没显式选过**的默认值（`modelChosenByVendor` 区分「真选过」与
- * 「默认回填」）。用户自己选的模型一律不动：他选了什么就该看到什么，静默改写比撞墙更糟
- * ——那会让「我明明选了 Codex」变成无法自查的错觉。
+ * 这里只校准**用户从没显式选过模型**的默认值（`modelChosenByVendor` 区分「真选过」与
+ * 「默认回填」）。已有来源偏好时，校准候选收窄到该来源，保证模型与来源成对变化；用户自己
+ * 选过模型则一律不动。静默改写比撞墙更糟——那会让「我明明选了 Anthropic」变成无法自查。
  */
 
 import {
@@ -83,6 +83,31 @@ export interface PickedConnectedModel {
   providerId: string;
 }
 
+/** 按正常来源优先级找出区域 / 目录明确标记的新对话默认模型。 */
+function markedDefaultModelIdForAgent(
+  providers: readonly ProviderView[],
+  agent: AgentKind,
+): string | null {
+  const flagAgent: 'claude-code' | 'codex' = agent === 'codex' ? 'codex' : 'claude-code';
+  for (const provider of providersByPreference(providers, agent)) {
+    const userProvider = provider.source === 'user';
+    const flagged = (provider.models[agent] ?? [])
+      .filter(
+        (model) =>
+          model.defaultEnabled !== false &&
+          (model.newSessionDefault?.includes(flagAgent) ?? false) &&
+          isModelSelectableForNewRoute(model, { userProvider }),
+      )
+      .slice()
+      .sort(
+        (a, b) =>
+          (a.sortOrder ?? Number.POSITIVE_INFINITY) - (b.sortOrder ?? Number.POSITIVE_INFINITY),
+      )[0];
+    if (flagged) return flagged.id;
+  }
+  return null;
+}
+
 /**
  * 在该 agent 的已连接来源里挑 (模型, 来源)：
  *   0. 目录/服务端**显式标记**为新对话默认（`newSessionDefault`）、且可用且默认可见的模型
@@ -116,27 +141,7 @@ export function pickConnectedModelForAgent(
   if (ranked.length === 0) return null;
   // 0. 目录/服务端显式标记的新对话默认(newSessionDefault)优先。pi 不是 wire agent,按
   //    claude-code 口径判定(host 把含 claude-code 的模型投影进 pi tab,标记随之带上)。
-  const flagAgent: 'claude-code' | 'codex' = agent === 'codex' ? 'codex' : 'claude-code';
-  let flaggedModelId: string | null = null;
-  for (const provider of ranked) {
-    const userProvider = provider.source === 'user';
-    const flagged = (provider.models[agent] ?? [])
-      .filter(
-        (m) =>
-          m.defaultEnabled !== false &&
-          (m.newSessionDefault?.includes(flagAgent) ?? false) &&
-          isModelSelectableForNewRoute(m, { userProvider }),
-      )
-      .slice()
-      .sort(
-        (a, b) =>
-          (a.sortOrder ?? Number.POSITIVE_INFINITY) - (b.sortOrder ?? Number.POSITIVE_INFINITY),
-      )[0];
-    if (flagged) {
-      flaggedModelId = flagged.id;
-      break;
-    }
-  }
+  const flaggedModelId = markedDefaultModelIdForAgent(ranked, agent);
   if (flaggedModelId !== null) {
     // 标记只存在于区域门控后的 XD 条目；来源选择仍必须独立遵守 ranked 的订阅优先。
     // 同 ID 的订阅副本不会重复携带标记，但只要它可选且默认可见，就应先消耗用户已付费额度。
@@ -181,6 +186,8 @@ export interface DraftModelCalibrationInput {
   model: string;
   /** 用户是否在选择器里显式选过该 vendor 的模型。 */
   chosenByUser: boolean;
+  /** 当前来源偏好；仍是有效连接来源时把自动模型候选限制在它内部，避免校准后静默丢来源。 */
+  preferredProviderId?: string | null;
   /** 供应商清单是否仍在加载：加载期不校准，避免首帧把默认模型闪成别的。 */
   providersLoading: boolean;
 }
@@ -202,10 +209,35 @@ export function calibrateDraftModel({
   agent,
   model,
   chosenByUser,
+  preferredProviderId,
   providersLoading,
 }: DraftModelCalibrationInput): DraftModelCalibrationResult {
   if (chosenByUser || providersLoading) return { model, providerId: null };
-  const picked = pickConnectedModelForAgent(providers, agent, model);
+  const connectedPreferred = preferredProviderId
+    ? connectedProvidersForAgent([...providers], agent).find(
+        (provider) => provider.id === preferredProviderId,
+      )
+    : undefined;
+  if (connectedPreferred) {
+    // marker 只需由策略来源声明一次（当前为 XD），用户选定的来源若也提供同一 ID，仍应由
+    // 该来源承接；不能因它自己的目录副本没重复 marker 就退回旧模型或偷偷改走 XD。
+    const markedModelId = markedDefaultModelIdForAgent(providers, agent);
+    const matchingMarkedModel = markedModelId
+      ? (connectedPreferred.models[agent] ?? []).find(
+          (candidate) =>
+            candidate.id === markedModelId &&
+            candidate.defaultEnabled !== false &&
+            isModelSelectableForNewRoute(candidate, {
+              userProvider: connectedPreferred.source === 'user',
+            }),
+        )
+      : undefined;
+    if (matchingMarkedModel) {
+      return { model: matchingMarkedModel.id, providerId: connectedPreferred.id };
+    }
+  }
+  const candidates = connectedPreferred ? [connectedPreferred] : providers;
+  const picked = pickConnectedModelForAgent(candidates, agent, model);
   return picked ?? { model, providerId: null };
 }
 

--- a/apps/desktop/src/renderer/lib/draftModelCalibration.ts
+++ b/apps/desktop/src/renderer/lib/draftModelCalibration.ts
@@ -117,6 +117,7 @@ export function pickConnectedModelForAgent(
   // 0. 目录/服务端显式标记的新对话默认(newSessionDefault)优先。pi 不是 wire agent,按
   //    claude-code 口径判定(host 把含 claude-code 的模型投影进 pi tab,标记随之带上)。
   const flagAgent: 'claude-code' | 'codex' = agent === 'codex' ? 'codex' : 'claude-code';
+  let flaggedModelId: string | null = null;
   for (const provider of ranked) {
     const userProvider = provider.source === 'user';
     const flagged = (provider.models[agent] ?? [])
@@ -131,7 +132,23 @@ export function pickConnectedModelForAgent(
         (a, b) =>
           (a.sortOrder ?? Number.POSITIVE_INFINITY) - (b.sortOrder ?? Number.POSITIVE_INFINITY),
       )[0];
-    if (flagged) return { model: flagged.id, providerId: provider.id };
+    if (flagged) {
+      flaggedModelId = flagged.id;
+      break;
+    }
+  }
+  if (flaggedModelId !== null) {
+    // 标记只存在于区域门控后的 XD 条目；来源选择仍必须独立遵守 ranked 的订阅优先。
+    // 同 ID 的订阅副本不会重复携带标记，但只要它可选且默认可见，就应先消耗用户已付费额度。
+    for (const provider of ranked) {
+      const matching = (provider.models[agent] ?? []).find(
+        (m) =>
+          m.id === flaggedModelId &&
+          m.defaultEnabled !== false &&
+          isModelSelectableForNewRoute(m, { userProvider: provider.source === 'user' }),
+      );
+      if (matching) return { model: flaggedModelId, providerId: provider.id };
+    }
   }
   for (const provider of ranked) {
     const preferred = (provider.models[agent] ?? []).find((m) => m.id === preferredModelId);

--- a/apps/desktop/src/renderer/lib/modelDefinitions.ts
+++ b/apps/desktop/src/renderer/lib/modelDefinitions.ts
@@ -24,6 +24,12 @@ export interface ModelDefinition {
   sortOrder?: number;
   /** 选择器里默认是否可见;缺省 ⇒ 可见(见 getDefaultModelForVendor)。 */
   defaultEnabled?: boolean;
+  /**
+   * 该模型是哪些 wire agent 的**新对话默认种子**(源自目录 newSessionDefault,与 sortOrder
+   * 解耦)。缺省 = 不作为默认。getDefaultModelForVendor / newSessionDefaultModelId 据它选默认;
+   * pi 按 'claude-code' 口径判定(见 wireAgentForVendor)。
+   */
+  newSessionDefault?: ('claude-code' | 'codex')[];
 }
 
 function toLegacy(m: ModelDescriptor, vendorKey: 'cc' | 'codex' | 'pi'): ModelDefinition {
@@ -38,6 +44,7 @@ function toLegacy(m: ModelDescriptor, vendorKey: 'cc' | 'codex' | 'pi'): ModelDe
     supportsFastMode: m.supportsFastMode,
     sortOrder: m.sortOrder,
     defaultEnabled: m.defaultEnabled,
+    newSessionDefault: m.newSessionDefault,
   };
 }
 
@@ -48,8 +55,8 @@ function allCachedModels(deviceId?: string): ModelDefinition[] {
   const cc = getCachedCapabilities('claude-code', deviceId);
   const codex = getCachedCapabilities('codex', deviceId);
   return [
-    ...((cc?.availableModels ?? []).map((m) => toLegacy(m, 'cc'))),
-    ...((codex?.availableModels ?? []).map((m) => toLegacy(m, 'codex'))),
+    ...(cc?.availableModels ?? []).map((m) => toLegacy(m, 'cc')),
+    ...(codex?.availableModels ?? []).map((m) => toLegacy(m, 'codex')),
   ];
 }
 
@@ -96,11 +103,19 @@ export function getModelById(modelId: string, deviceId?: string): ModelDefinitio
   return all.find((m) => m.id === modelId);
 }
 
+/** vendor → capabilities 缓存的 agent 键(pi 有自己的能力清单)。 */
+function agentKindForVendor(vendorKey: 'cc' | 'codex' | 'pi'): 'claude-code' | 'codex' | 'pi' {
+  return vendorKey === 'codex' ? 'codex' : vendorKey === 'pi' ? 'pi' : 'claude-code';
+}
+
 export function getModelsForVendor(
   vendorKey: 'cc' | 'codex' | 'pi',
   deviceId?: string,
 ): readonly ModelDefinition[] {
-  return allCachedModels(deviceId).filter((m) => m.vendorKey === vendorKey);
+  // 直接读该 vendor 对应 agent 的能力缓存 —— 不经 allCachedModels(后者只聚合 cc/codex 供
+  // getModelById / MODELS 等旧调用方用)。pi 有自己的能力清单,默认判定必须读它,否则 pi 恒空。
+  const caps = getCachedCapabilities(agentKindForVendor(vendorKey), deviceId);
+  return (caps?.availableModels ?? []).map((m) => toLegacy(m, vendorKey));
 }
 
 /**
@@ -114,53 +129,93 @@ export function getModelsForVendor(
  */
 function firstByCatalogOrder(models: readonly ModelDefinition[]): ModelDefinition | undefined {
   const byOrder = (a: ModelDefinition, b: ModelDefinition): number =>
-    (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER);
+    (a.sortOrder ?? Number.POSITIVE_INFINITY) - (b.sortOrder ?? Number.POSITIVE_INFINITY);
   const visible = models.filter((m) => m.defaultEnabled !== false);
   // slice() 后再 sort：sort 原地改数组，直接排会打乱调用方（capabilities 缓存）的清单顺序。
   const pool = visible.length > 0 ? visible : models;
   return pool.slice().sort(byOrder)[0];
 }
 
+/** vendor → 新对话默认所依据的 wire agent(pi 镜像 claude-code —— pi 不是 wire agent)。 */
+function wireAgentForVendor(vendorKey: 'cc' | 'codex' | 'pi'): 'claude-code' | 'codex' {
+  return vendorKey === 'codex' ? 'codex' : 'claude-code';
+}
+
 /**
- * 该 vendor 的**对话场景**默认模型 = 目录排序第一的默认可见模型。
+ * 该 vendor 被目录**显式标记**为新对话默认种子(newSessionDefault)、且当前可用且默认可见的
+ * 模型 id;没有标记则返回 null。多个被标记时按 sortOrder 决胜。与 sortOrder / defaultEnabled
+ * 解耦 —— 标记本身表达「这是默认」,sortOrder 只管选择器陈列顺序。pi 按 claude-code 口径判定
+ * (pi 的模型宇宙是 cc-compatible 模型的镜像,由 host 投影进 pi tab)。
  *
- * 这里刻意不再写死 id。写死的代价已经兑现过两次：cc 的默认停在 Opus 4.8 而目录里旗舰早已是
- * Opus 5；codex 侧更糟 —— 这里写死的 `gpt-5.5` 与 `newMakerDraft` 写死的 `gpt-5.4` 不是同一个
- * 值，而两者在目录里都默认收起，也就是种子默认模型压根不在用户看到的列表里。
- *
- * 注意它只是**种子**：真正落到哪个模型由 `calibrateDraftModel` 在供应商清单到位后决定
- * （「可用的里面选，供应商优先订阅」，见 draftModelCalibration）。这里拿不到连接态与来源，
- * 只能按目录排序给一个合理起点。
- *
- * 自动化任务（scheduler）的默认**故意不同**：无人值守场景成本保守，走 useScheduleForm.ts
- * getScheduleDefaultModel 三级回退（冷启动 Sonnet），不要把这里的默认接到 scheduler 上。
+ * 生产环境该标记对 XD 网关模型由服务端 GET /models 按区域下发(见 shared/modelAccess
+ * ModelAccessGatewayModel.newSessionDefault);bundled 目录默认不标记,故服务端未下发时
+ * 本函数返回 null、默认行为不变。
  */
-export function getDefaultModelForVendor(vendorKey: 'cc' | 'codex' | 'pi', deviceId?: string): ModelDefinition {
+export function newSessionDefaultModelId(
+  vendorKey: 'cc' | 'codex' | 'pi',
+  deviceId?: string,
+): string | null {
+  const agent = wireAgentForVendor(vendorKey);
+  const flagged = getModelsForVendor(vendorKey, deviceId).filter(
+    (m) => m.defaultEnabled !== false && (m.newSessionDefault?.includes(agent) ?? false),
+  );
+  return firstByCatalogOrder(flagged)?.id ?? null;
+}
+
+/**
+ * 该 vendor 的**对话场景**默认模型。
+ *
+ * 优先级:目录显式标记的新对话默认(newSessionDefault,与 sortOrder 解耦)> 排序第一的默认
+ * 可见模型 > capabilities 未到位时的冷启动占位。**没有任何模型被标记时,与「排序第一可见」
+ * 逐字节一致**(非破坏性)。这里刻意不写死 id。
+ *
+ * 注意它只是**种子**：真正落点由 `calibrateDraftModel` 在供应商清单到位后决定(「可用的里面
+ * 选,供应商优先订阅」,见 draftModelCalibration)。自动化任务(scheduler)默认故意不同,走
+ * useScheduleForm.ts getScheduleDefaultModel,不要把这里的默认接到 scheduler 上。
+ */
+export function getDefaultModelForVendor(
+  vendorKey: 'cc' | 'codex' | 'pi',
+  deviceId?: string,
+): ModelDefinition {
   const list = getModelsForVendor(vendorKey, deviceId);
   // capabilities 还没拉到时退化到一个静态 placeholder, 让调用方拿到非 undefined。
   // 调用方真正需要值时通常已经在 useEffect 后, capabilities 已就绪。
   if (list.length === 0) {
     return {
-      id: vendorKey === 'codex' ? COLD_START_CODEX_MODEL_ID : COLD_START_CC_MODEL_ID,
-      label: vendorKey === 'codex' ? 'GPT-5.6-Sol' : 'Opus 5',
+      id: coldStartModelIdForVendor(vendorKey),
+      label: coldStartLabelForVendor(vendorKey),
       description: '',
       efforts: [],
       defaultEffort: null,
       vendorKey,
     };
   }
-  return firstByCatalogOrder(list) ?? list[0];
+  // 显式标记优先(与 sortOrder 解耦);没有标记才回退排序第一 —— 即今天的行为。
+  const flaggedId = newSessionDefaultModelId(vendorKey, deviceId);
+  const flagged = flaggedId ? list.find((m) => m.id === flaggedId) : undefined;
+  return flagged ?? firstByCatalogOrder(list) ?? list[0];
 }
 
 /**
  * capabilities 还没拉到时的占位 id。**它们不是另一份产品默认值**，只是目录还没到位时的同值
- * 影子：必须与 bundled 目录里「排序第一且默认可见」的那个一致（订阅口径，即不取网关折扣组），
- * 否则冷启动首帧会闪一个随后被换掉的模型名。由 modelDefinitionsDefaults 测试锁住。
+ * 影子：cc/codex 必须与 bundled 目录里「排序第一且默认可见」的那个一致（订阅口径，即不取网关
+ * 折扣组），否则冷启动首帧会闪一个随后被换掉的模型名。pi 复用其历史中档默认(XD 网关 Sonnet)。
+ * 由 modelDefinitionsDefaults 测试锁住。
  */
 const COLD_START_CC_MODEL_ID = 'claude-opus-5';
 const COLD_START_CODEX_MODEL_ID = 'gpt-5.6-sol';
+const COLD_START_PI_MODEL_ID = 'claude-sonnet-5';
 
-/** 冷启动占位 id 的只读导出（newMakerDraft 的种子默认复用，避免第三处写死）。 */
-export function coldStartModelIdForVendor(vendorKey: 'cc' | 'codex'): string {
-  return vendorKey === 'codex' ? COLD_START_CODEX_MODEL_ID : COLD_START_CC_MODEL_ID;
+/** 冷启动占位 id 的只读导出（newMakerDraft 的种子默认复用，避免另一处写死）。 */
+export function coldStartModelIdForVendor(vendorKey: 'cc' | 'codex' | 'pi'): string {
+  return vendorKey === 'codex'
+    ? COLD_START_CODEX_MODEL_ID
+    : vendorKey === 'pi'
+      ? COLD_START_PI_MODEL_ID
+      : COLD_START_CC_MODEL_ID;
+}
+
+/** 冷启动占位的展示名(与占位 id 同源,仅首帧短暂可见)。 */
+function coldStartLabelForVendor(vendorKey: 'cc' | 'codex' | 'pi'): string {
+  return vendorKey === 'codex' ? 'GPT-5.6-Sol' : vendorKey === 'pi' ? 'Sonnet 5' : 'Opus 5';
 }

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -2094,6 +2094,8 @@ interface ElectronAPI {
         { model?: string; effort?: string; permissionMode?: string; providerId?: string | null }
       >
     >;
+    /** 每个 vendor 是否由用户在 New Maker 中明确选过模型；device-link 默认校准据此保护显式选择。 */
+    modelChosenByVendor: Partial<Record<'cc' | 'codex' | 'pi', boolean>>;
     fastModeByModel: Record<string, boolean>;
     effortByModel: Record<string, string>;
     /** 「新建会话默认启用 worktree」勾选记忆(vendor 无关根字段,远程草稿播种用)。 */

--- a/apps/desktop/src/shared/modelAccess.ts
+++ b/apps/desktop/src/shared/modelAccess.ts
@@ -194,6 +194,12 @@ export interface ModelAccessGatewayModel extends ModelGroupPricing {
   /** 是否默认出现在模型选择器;缺省按 true(默认可见)。 */
   defaultEnabled?: boolean;
   /**
+   * 该模型是哪些 agent 的**新对话默认种子**（源自协议 ListModels v2 的 newSessionDefault，
+   * 服务端权威、按区域下发)。与 sortOrder / defaultEnabled 独立;客户端据它选新对话默认。
+   * 缺省 = 不作为任何 agent 的默认。pi 由客户端从 'claude-code' 投影(见 active-catalog)。
+   */
+  newSessionDefault?: ('claude-code' | 'codex')[];
+  /**
    * 展示图标 id(AI Gateway 侧登记,见 @cindy/model-providers CatalogModel.icon /
    * resolveModelIconKind);缺省或未知值客户端回落来源供应商标。
    */

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -543,7 +543,7 @@ export default function NewRemoteSessionScreen() {
   const [firstMessageInputContentHeight, setFirstMessageInputContentHeight] = useState(MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT);
   const [firstMessageInputFocused, setFirstMessageInputFocused] = useState(false);
   const [voiceDraftCaretFrame, setVoiceDraftCaretFrame] = useState({ left: 0, top: 0 });
-  // 自动默认运行配置(跟随最近会话 / 列表最上面)的守卫:用户一旦手动选过模型,就不再自动覆盖;
+  // 自动默认运行配置(跟随最近会话 / 区域默认 / 列表最上面)的守卫:用户一旦手动选过模型,就不再自动覆盖;
   // 记录已自动应用过的设备,切设备时(未手动选过)按新设备重算。
   const userTouchedRuntimeRef = useRef(false);
   // 只保护当前页面刚从 provider 目录显式选中的模型，避免旧 capabilities 在途结果误回退；
@@ -743,8 +743,8 @@ export default function NewRemoteSessionScreen() {
     };
   }, [draft.agentKind, draft.permissionMode, newSessionPreferences, newSessionPreferencesLoaded]);
 
-  // 新建任务默认运行配置 = 跟随最近一次会话(整套 agent+model+effort,按所选设备 scope);没有最近会话则用
-  // 模型列表最上面那个(列表异步就绪后再设)。一旦用户手动选过模型即不再覆盖;切设备(未手动选过)按新设备重算。
+  // 新建任务默认运行配置 = 跟随最近一次会话(整套 agent+model+effort,按所选设备 scope);没有最近会话则
+  // 优先区域默认、再用模型列表最上面那个。一旦用户手动选过模型即不再覆盖;切设备(未手动选过)按新设备重算。
   // 决策逻辑全在纯函数 resolveNewSessionAutoDefault 里(便于单测);此 effect 只负责"调纯函数 → setDraft + 更新 ref"。
   // 最近会话路径同步可得(sessions 在内存);列表最上面依赖 providers 异步,故 modelRows 就绪后此 effect 再触发。
   useEffect(() => {
@@ -755,6 +755,11 @@ export default function NewRemoteSessionScreen() {
       selectedDeviceId,
       sessions,
       modelRows,
+      // provider-aware 模式只用经过可见性过滤的 rows；目录确实不可用时才回退 capabilities。
+      availableModels: !deviceProviders.loading && modelSections.connected.length === 0
+        ? capabilities?.availableModels
+        : undefined,
+      agentKind: draft.agentKind,
       currentEffort: draft.effort,
     });
     if (!result) return;
@@ -781,7 +786,7 @@ export default function NewRemoteSessionScreen() {
     return () => {
       cancelled = true;
     };
-  }, [draft.effort, draft.permissionMode, draft.agentKind, modelRows, newSessionPreferences, newSessionPreferencesLoaded, selectedDeviceId, sessions]);
+  }, [capabilities?.availableModels, deviceProviders.loading, draft.effort, draft.permissionMode, draft.agentKind, modelRows, modelSections.connected.length, newSessionPreferences, newSessionPreferencesLoaded, selectedDeviceId, sessions]);
   const draftContent = useMemo(
     // pending(乐观上传中)也算数:拍完照立刻点创建是常见路径,create() 里会等它们落定。
     () => ({ attachmentCount: attachments.length + pendingUploads.length }),

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -41,6 +41,7 @@ function modelRow(
   id: string,
   efforts: readonly string[] = [],
   defaultEffort: string | null = null,
+  newSessionDefault?: readonly ('claude-code' | 'codex')[],
 ): ProviderModelRow {
   return {
     provider: { id: `prov-${id}`, name: id } as ProviderModelRow['provider'],
@@ -50,6 +51,7 @@ function modelRow(
       efforts: efforts as ProviderModelRow['model']['efforts'],
       defaultEffort: defaultEffort as ProviderModelRow['model']['defaultEffort'],
       contextWindow: 0,
+      ...(newSessionDefault ? { newSessionDefault: [...newSessionDefault] } : {}),
     },
   };
 }
@@ -170,6 +172,25 @@ describe('pickAgentDefaultRuntime', () => {
     expect(runtime).toEqual({ agentKind: 'codex', model: 'gpt-5.4', effort: 'low' });
   });
 
+  it('uses the regional default before the top row, with Pi sharing the claude-code marker', () => {
+    const rows = [
+      modelRow('top', ['low'], 'low'),
+      modelRow('regional', ['medium'], 'medium', ['claude-code']),
+    ];
+    expect(pickAgentDefaultRuntime({
+      agentKind: 'claude-code',
+      sessions: [],
+      modelRows: rows,
+      currentEffort: 'high',
+    })).toEqual({ agentKind: 'claude-code', model: 'regional', effort: 'medium' });
+    expect(pickAgentDefaultRuntime({
+      agentKind: 'pi',
+      sessions: [],
+      modelRows: rows,
+      currentEffort: 'high',
+    })).toEqual({ agentKind: 'pi', model: 'regional', effort: 'medium' });
+  });
+
   it('falls back to DEFAULT_MODELS and keeps current effort when providers are not loaded yet', () => {
     expect(pickAgentDefaultRuntime({
       agentKind: 'codex',
@@ -207,6 +228,8 @@ describe('resolveNewSessionAutoDefault', () => {
     selectedDeviceId: 'devA',
     sessions: [] as RemoteSession[],
     modelRows: [] as ProviderModelRow[],
+    availableModels: [],
+    agentKind: 'claude-code' as const,
     currentEffort: 'medium',
   };
 
@@ -254,6 +277,37 @@ describe('resolveNewSessionAutoDefault', () => {
       patch: { model: 'claude-sonnet-4-6', effort: 'low', providerId: null },
     });
     expect(result?.patch).not.toHaveProperty('agentKind');
+  });
+
+  it('intent ②a: no recent session → regional default before the top row', () => {
+    const result = resolveNewSessionAutoDefault({
+      ...baseInput,
+      currentEffort: 'high',
+      modelRows: [
+        modelRow('top', ['low'], 'low'),
+        modelRow('regional', ['medium'], 'medium', ['claude-code']),
+      ],
+    });
+    expect(result?.patch).toEqual({ model: 'regional', effort: 'medium', providerId: null });
+  });
+
+  it('intent ②b: provider list unavailable → regional default from normalized capabilities', () => {
+    const result = resolveNewSessionAutoDefault({
+      ...baseInput,
+      currentEffort: 'high',
+      availableModels: [
+        {
+          id: 'regional',
+          label: 'Regional',
+          efforts: ['medium'],
+          effortDisplayNames: {},
+          defaultEffort: 'medium',
+          supportsFastMode: false,
+          newSessionDefault: ['claude-code'],
+        },
+      ],
+    });
+    expect(result?.patch).toEqual({ model: 'regional', effort: 'medium', providerId: null });
   });
 
   it('intent ③: switching device (not manually touched) recomputes for the new device', () => {

--- a/apps/mobile/src/session/newSession.ts
+++ b/apps/mobile/src/session/newSession.ts
@@ -1,6 +1,7 @@
 import { stripTrailingPathSeparators } from '@cindy/maker-shared/path-text';
 import { i18n } from '@/i18n';
 import type { CreateSessionOptions, RemoteDirectoryEntry } from '@/device-link/mobileMakerTransport';
+import type { MobileModelOption } from './agentCapabilities';
 import { reconcileEffortForModel, type ProviderModelRow } from './providerModelSections';
 import type { RemoteSession } from './types';
 
@@ -306,6 +307,25 @@ export interface NewSessionRuntime {
   effort: string;
 }
 
+type NewSessionDefaultModel = {
+  id: string;
+  efforts: readonly string[];
+  defaultEffort: string | null;
+  newSessionDefault?: readonly ('claude-code' | 'codex')[];
+};
+
+function newSessionDefaultMarker(agentKind: NewSessionAgentKind): 'claude-code' | 'codex' {
+  return agentKind === 'codex' ? 'codex' : 'claude-code';
+}
+
+function pickRegionalNewSessionDefault<T extends NewSessionDefaultModel>(
+  models: readonly T[],
+  agentKind: NewSessionAgentKind,
+): T | undefined {
+  const marker = newSessionDefaultMarker(agentKind);
+  return models.find((model) => model.newSessionDefault?.includes(marker) === true);
+}
+
 /**
  * 从现有会话列表挑"最近一次"的整套运行配置(agent + model + effort),用于新建对话默认跟随最近会话。
  * 过滤:排除 status==='deleted'、无 model;可选 `deviceId`(只看该设备——模型列表 per-device,跨设备 model 可能
@@ -343,8 +363,8 @@ export function pickMostRecentSessionRuntime(
  * 与初始自动默认共用同一套 fallback 口径。纯函数:所有输入显式传入,不读 react / 设备状态。
  * model 优先级:
  *   1) 该 agent 的最近一次会话模型(pickMostRecentSessionRuntime,按 deviceId scope);
- *   2) 否则该 agent 的模型列表最上面那个(modelRows[0] —— providers 已加载时同步可得,
- *      与下拉渲染的第一项一致);
+ *   2) 否则取区域门控后的新任务默认；无标记再取该 agent 的模型列表最上面那个
+ *      (modelRows[0] —— providers 已加载时同步可得,与下拉渲染的第一项一致);
  *   3) 否则该 agent 的内置默认 DEFAULT_MODELS[agentKind]。
  * effort:reconcile 到目标 model 的合法档(reconcileEffortForModel,base = 最近会话 effort ?? 当前 effort);
  *   拿不到目标 model 对应的 SectionModel(model 不在 modelRows 里,如走了 DEFAULT_MODELS 兜底或历史模型已下架)
@@ -366,8 +386,11 @@ export function pickAgentDefaultRuntime(args: {
     : undefined;
   if (recent?.model) {
     model = recent.model;
-  } else if (modelRows[0]) {
-    sectionModel = modelRows[0].model;
+  } else if (modelRows.length > 0) {
+    sectionModel = pickRegionalNewSessionDefault(
+      modelRows.map((row) => row.model),
+      agentKind,
+    ) ?? modelRows[0].model;
     model = sectionModel.id;
   } else {
     model = DEFAULT_MODELS[agentKind];
@@ -383,8 +406,9 @@ export function pickAgentDefaultRuntime(args: {
  * 三条意图与 effect 完全一致:
  *   1) 有最近会话(按 selectedDeviceId scope)→ 整套跟随(agentKind + model + effort,effort reconcile 同
  *      pickAgentDefaultRuntime 口径:model 命中 modelRows 才 reconcile,否则保留;providerId 置 null);
- *   2) 无最近会话但 modelRows 就绪 → 取列表最上面(model + effort reconcile + providerId:null,不动 agentKind);
- *   3) 无最近会话且 modelRows 未就绪(providers 加载中)→ null(等下次 modelRows 就绪再设,绝不误设)。
+ *   2) 无最近会话 → 优先区域默认标记；provider 分段不可用时允许从 capabilities 扁平列表取标记；
+ *      无标记再取 provider 列表最上面(model + effort reconcile + providerId:null,不动 agentKind);
+ *   3) 无最近会话且两份模型列表都未就绪 → null(等下次数据就绪再设,绝不误设)。
  * currentEffort = 当前 draft.effort,作为 reconcile 的 base(与 effect 里 setDraft updater 读 current.effort 等价)。
  */
 export function resolveNewSessionAutoDefault(input: {
@@ -393,9 +417,21 @@ export function resolveNewSessionAutoDefault(input: {
   selectedDeviceId: string;
   sessions: readonly RemoteSession[];
   modelRows: readonly ProviderModelRow[];
+  /** 仅在 provider-aware 列表不可用时传入，避免绕过被控端的模型可见性设置。 */
+  availableModels?: readonly MobileModelOption[];
+  agentKind: NewSessionAgentKind;
   currentEffort: string;
 }): { patch: Partial<NewSessionDraft>; appliedDeviceId: string } | null {
-  const { userTouched, appliedDeviceId, selectedDeviceId, sessions, modelRows, currentEffort } = input;
+  const {
+    userTouched,
+    appliedDeviceId,
+    selectedDeviceId,
+    sessions,
+    modelRows,
+    availableModels = [],
+    agentKind,
+    currentEffort,
+  } = input;
   if (userTouched) return null;
   if (!selectedDeviceId) return null;
   if (appliedDeviceId === selectedDeviceId) return null;
@@ -415,14 +451,21 @@ export function resolveNewSessionAutoDefault(input: {
       },
     };
   }
-  // 无最近会话 → 列表最上面那个(与 UI 渲染第一项一致);列表未就绪则不动,等下次触发。
-  const top = modelRows[0];
-  if (!top) return null;
+  // 无最近会话 → provider 区域标记优先；无 provider 结构时才信 capabilities 扁平标记。
+  // provider-aware 列表由调用方传空 availableModels，避免区域默认绕过用户隐藏设置。
+  const providerModel = modelRows.length > 0
+    ? pickRegionalNewSessionDefault(modelRows.map((row) => row.model), agentKind) ?? modelRows[0].model
+    : undefined;
+  const flatDefault = providerModel
+    ? undefined
+    : pickRegionalNewSessionDefault(availableModels, agentKind);
+  const defaultModel = providerModel ?? flatDefault;
+  if (!defaultModel) return null;
   return {
     appliedDeviceId: selectedDeviceId,
     patch: {
-      model: top.model.id,
-      effort: reconcileEffortForModel(top.model, currentEffort),
+      model: defaultModel.id,
+      effort: reconcileEffortForModel(defaultModel, currentEffort),
       providerId: null,
     },
   };

--- a/apps/mobile/src/session/providerModelSections.ts
+++ b/apps/mobile/src/session/providerModelSections.ts
@@ -179,7 +179,10 @@ export function isSelectedSourceDisconnected(args: {
  * 口径同 maker-shared `reconcileRuntimeDraftWithCapabilities`。仅供 flat 回退路径
  * (旧被控端无供应商结构、无记忆可用)消费;分段路径走 resolveRowSelection。
  */
-export function reconcileEffortForModel(model: SectionModel, currentEffort: string): string {
+export function reconcileEffortForModel(
+  model: { efforts: readonly string[]; defaultEffort: string | null },
+  currentEffort: string,
+): string {
   const efforts = model.efforts as readonly string[];
   if (efforts.length === 0) return '';
   if (efforts.includes(currentEffort)) return currentEffort;

--- a/packages/maker-core/src/types/capabilities.ts
+++ b/packages/maker-core/src/types/capabilities.ts
@@ -264,6 +264,13 @@ export interface ModelDescriptor {
   */
   defaultEnabled?: boolean;
   /**
+   * 该模型是哪些 agent 的**新对话默认种子**（源自目录 `CatalogModel.newSessionDefault`，
+   * host 派生时透传）。与 sortOrder / defaultEnabled 独立；渲染层选新对话默认时优先取被
+   * 标记且可用可见的模型（见 modelDefinitions getDefaultModelForVendor）。取值仅 wire agent
+   * （pi 由客户端从 'claude-code' 投影）。maker-core 运行时不读它。
+   */
+  newSessionDefault?: ('claude-code' | 'codex')[];
+  /**
    * 模型计费($/1M tokens,源自目录/网关刷新,host 派生时透传)。pi 用它生成
    * models.json 的 cost 让 pi 自行计价;缺省按 0 计(用量页不显示钱数)。
    */

--- a/packages/maker-shared/src/__tests__/agentCapabilities.test.ts
+++ b/packages/maker-shared/src/__tests__/agentCapabilities.test.ts
@@ -17,6 +17,7 @@ const desktopCapabilitiesPayload = {
       effortDisplayNames: { xhigh: 'Max' },
       defaultEffort: 'medium',
       supportsFastMode: true,
+      newSessionDefault: ['claude-code', 'invalid-agent', 'claude-code', 'codex'],
     },
     {
       id: 'claude-haiku-4-6',
@@ -62,6 +63,8 @@ describe('agent capabilities shared model', () => {
       'plan',
     ]);
     expect(capabilities?.supportsSessionAgentSwitch).toBe(false);
+    expect(capabilities?.availableModels[0].newSessionDefault).toEqual(['claude-code', 'codex']);
+    expect('newSessionDefault' in (capabilities?.availableModels[1] ?? {})).toBe(false);
     expect(normalizeMobileAgentCapabilities({
       ...desktopCapabilitiesPayload,
       supportsSessionAgentSwitch: true,

--- a/packages/maker-shared/src/agentCapabilities.ts
+++ b/packages/maker-shared/src/agentCapabilities.ts
@@ -6,6 +6,8 @@ export interface MobileModelOption {
   effortDisplayNames: Record<string, string>;
   defaultEffort: string | null;
   supportsFastMode: boolean;
+  /** 区域门控后的新任务默认标记；Pi 复用 claude-code 标记。 */
+  newSessionDefault?: ('claude-code' | 'codex')[];
 }
 
 export interface MobileChoiceOption {
@@ -252,6 +254,11 @@ function normalizeModelOption(value: unknown): MobileModelOption | null {
       typeof entry[1] === 'string',
     ))
     : {};
+  const newSessionDefault = Array.isArray(value.newSessionDefault)
+    ? [...new Set(value.newSessionDefault.filter(
+      (item): item is 'claude-code' | 'codex' => item === 'claude-code' || item === 'codex',
+    ))]
+    : [];
   return {
     id,
     label: readString(value.displayName) ?? id,
@@ -262,6 +269,7 @@ function normalizeModelOption(value: unknown): MobileModelOption | null {
     effortDisplayNames,
     defaultEffort: readString(value.defaultEffort),
     supportsFastMode: value.supportsFastMode === true,
+    ...(newSessionDefault.length > 0 ? { newSessionDefault } : {}),
   };
 }
 

--- a/packages/model-providers/src/__tests__/sections.test.ts
+++ b/packages/model-providers/src/__tests__/sections.test.ts
@@ -161,6 +161,23 @@ describe('buildProviderSections', () => {
     expect('icon' in (models.find((m) => m.id === 'gpt-5.5') ?? {})).toBe(false);
   });
 
+  it('区域门控后的新对话默认标记透传进 SectionModel;缺省不带字段', () => {
+    const withDefault = provider('xd', 'XD', [
+      { ...model('deepseek/deepseek-v4-pro', 'DeepSeek V4 Pro'), newSessionDefault: ['claude-code'] },
+      model('gpt-5.5', 'GPT-5.5'),
+    ]);
+    const sections = buildProviderSections({
+      providers: [withDefault],
+      agent: 'claude-code',
+      isVisible: () => true,
+    });
+    const models = sections[0].models;
+    expect(models.find((m) => m.id === 'deepseek/deepseek-v4-pro')?.newSessionDefault).toEqual([
+      'claude-code',
+    ]);
+    expect('newSessionDefault' in (models.find((m) => m.id === 'gpt-5.5') ?? {})).toBe(false);
+  });
+
   it('模型级 Codex bridge 协议透传进 SectionModel;缺省不带字段', () => {
     const bridged = provider('xd', 'XD', [
       {

--- a/packages/model-providers/src/sections.ts
+++ b/packages/model-providers/src/sections.ts
@@ -37,6 +37,8 @@ export interface SectionModel {
   defaultEffort: Effort | null;
   effortDisplayNames?: Record<string, string>;
   supportsFastMode?: boolean;
+  /** 区域门控后的新对话默认标记；仅由可信的模型访问响应投影。 */
+  newSessionDefault?: CatalogModel['newSessionDefault'];
   /** 模型级 Codex bridge 协议；Provider 级协议仍从 section.provider.routing 读取。 */
   codexCompatibilityWireProtocol?: CatalogModel['codexCompatibilityWireProtocol'];
   contextWindow: number;
@@ -177,6 +179,7 @@ export function buildProviderSections(args: {
       if (m.description !== undefined) sm.description = m.description;
       if (m.effortDisplayNames !== undefined) sm.effortDisplayNames = m.effortDisplayNames;
       if (m.supportsFastMode !== undefined) sm.supportsFastMode = m.supportsFastMode;
+      if (m.newSessionDefault !== undefined) sm.newSessionDefault = m.newSessionDefault;
       if (m.codexCompatibilityWireProtocol !== undefined) {
         sm.codexCompatibilityWireProtocol = m.codexCompatibilityWireProtocol;
       }

--- a/packages/model-providers/src/types.ts
+++ b/packages/model-providers/src/types.ts
@@ -350,6 +350,17 @@ export interface CatalogModel {
    */
   defaultEnabled?: boolean;
   /**
+   * 该模型是哪些 agent 的**新对话默认种子**（cold-start seed），与 `sortOrder`（只管选择器
+   * 陈列顺序）和 `defaultEnabled`（只管可见性）独立。桌面运行时只从**区域门控后的**
+   * model-access `/models` v2 响应写入本字段；公共 Registry 的同名策略字段由 server 消费，
+   * `modelPlanePolicy` 刻意不把它投影进 CatalogModel，避免 Global 绕过区域门。
+   *
+   * 渲染层优先取被标记、当前可用且默认可见的模型；无标记时回退 `sortOrder` 第一。取值仅
+   * wire agent（'claude-code' | 'codex'）；pi 按 'claude-code' 口径投影。缺省 = 不作为默认。
+   * 故意**不纳入** `modelSignature` 跨供应商一致性校验：同一 id 在不同供应商下可各自表态。
+   */
+  newSessionDefault?: ('claude-code' | 'codex')[];
+  /**
    * 该来源下的模型是否已由用户确认支持图片输入。目前只供 Pi 自定义 provider 使用；
    * 缺省按 false 处理，避免把纯文本端点误报成视觉模型。它是 per-provider 能力，不参与
    * `modelSignature` 的同 id 跨供应商一致性校验。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@cindy/mcps':
         specifier: workspace:*
         version: link:../../packages/lizi-mcps
+      '@cindy/model-access-protocol':
+        specifier: workspace:*
+        version: link:../../cindy-protocol/packages/model-access-protocol
       '@cindy/model-providers':
         specifier: workspace:*
         version: link:../../packages/model-providers


### PR DESCRIPTION
## 这次改了什么

### 摘要

客户端现在严格解析 Model Access `/models` 的 v1/v2 信封，并把服务端已完成区域门控的 `newSessionDefault` 标记贯穿 XD active catalog、能力快照和新任务模型校准。中国大陆版收到标记时，Claude Code、Codex 与 Pi 的新任务会优先选择 DeepSeek V4 Pro；没有标记、模型不可用/不可见或用户已有明确选择时，继续沿用原有回退逻辑。

公共 Model Registry 的同名策略不会直接进入客户端 Catalog，避免 Global 绕过服务端区域门。未知 schema、未知字段或不自洽的 v2 响应会被整体拒绝，并保留 last-known-good 模型/价格快照。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：makecindy/cindy-protocol#40
- 本 PR 包含：ListModels v1/v2 严格双读与 LKG；区域默认标记的类型/目录投影；Claude Code、Codex、Pi 新任务默认选择；边界与回归测试。
- 明确不包含：Server v2 发射与部署；公共 Registry 策略直投客户端；Scheduler 默认模型；任何 UI 样式或文案修改。
- 用户可见变化：中国大陆版服务端下发默认标记后，未明确选过模型的新任务默认使用 DeepSeek V4 Pro；Global 与无标记响应保持原行为。
- 是否存在 breaking change：无。客户端继续读取 v1，并严格读取 v2；无效或未知响应保留 last-known-good。

### UI 变化

不涉及：只修改新任务初始模型的目录解析与选择逻辑，未修改组件结构、布局、样式、动效或 UI 文案。

- 引用的设计规范：不涉及：无视觉、交互结构或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm install --frozen-lockfile
结果：PASS，lockfile 无漂移；Protocol postinstall build 通过。

pnpm --filter desktop run --if-present typecheck
结果：PASS，0 个 TypeScript 错误。

pnpm --filter @cindy/maker-core run --if-present typecheck
pnpm --filter @cindy/model-providers run --if-present typecheck
pnpm --filter @cindy/model-access-protocol run --if-present typecheck
结果：PASS；上述 package 没有 typecheck script 时按仓库门禁自动跳过，Protocol 已由 postinstall build 验证。

pnpm --filter desktop exec vitest run \
  src/main/model-access/__tests__/modelsSyncRefresh.test.ts \
  src/main/maker-host/__tests__/modelPlane.test.ts \
  src/renderer/__tests__/agentCapabilitiesDeviceCache.test.ts \
  src/renderer/__tests__/draftModelCalibration.test.ts \
  src/renderer/__tests__/modelDefinitionsDefaults.test.ts
结果：PASS，5 个文件，126/126 tests。

pnpm test:unit
结果：PASS；runner 373 passed / 1 skipped；28 个可测试 workspace 全部 PASS，6 个无可收集测试的 workspace SKIP。Desktop、Mobile、Maker Core、Model Providers 与 model-access-protocol 均通过。

pnpm check:dco
结果：PASS，1/1 commit signed off。

git diff --check
结果：PASS。
```

### 手工验证

不涉及：最终 head 未重新启动 Desktop 交互实例；默认选择与协议边界由 126 条定向测试及仓库全量单测覆盖。

### 未执行的验证

- 未在 Windows 本机运行；由 PR 的 Windows CI 覆盖。
- 未在最终 head 连接已部署的 Server v2 做端到端冒烟；Server 可独立先发布，legacy Desktop 会继续读取模型并忽略默认标记，待两边均可用后再验证新默认的端到端生效。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 的 XD `/models` 同步、active catalog 能力投影，以及 Claude Code / Codex / Pi 的新任务初始模型选择。已存在任务、用户明确选择、Global 默认与 Scheduler 不变。
- 回滚 / 降级方式：回滚本 PR commit 即恢复原排序默认逻辑；Server 尚未发 v2 时客户端继续读 v1。若收到未知或无效响应，客户端自动保留 last-known-good，不用清理用户数据。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本 PR 无需新增客户端文档；协议与服务端行为分别由 Protocol PR 和后续 Server PR 说明）
- [x] 已确认测试结果或说明未执行原因
