### PR TITLE
fix(desktop): defer bundled ripgrep probing

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/runtimeConfigs.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/runtimeConfigs.test.ts
@@ -7,6 +7,11 @@ let memorySettings = {
   pi: false,
 };
 
+const fsMocks = vi.hoisted(() => ({
+  existsSync: vi.fn(() => true),
+  chmodSync: vi.fn(),
+}));
+
 vi.mock('electron', () => ({
   app: {
     isPackaged: false,
@@ -22,12 +27,12 @@ vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
-    existsSync: vi.fn(() => true),
-    chmodSync: vi.fn(),
+    existsSync: fsMocks.existsSync,
+    chmodSync: fsMocks.chmodSync,
     default: {
       ...actual,
-      existsSync: vi.fn(() => true),
-      chmodSync: vi.fn(),
+      existsSync: fsMocks.existsSync,
+      chmodSync: fsMocks.chmodSync,
     },
   };
 });
@@ -40,8 +45,10 @@ vi.mock('../../model-access/effectiveEndpoint.js', async () => {
 });
 
 describe('runtime-configs', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.resetModules();
+    vi.clearAllMocks();
+    fsMocks.existsSync.mockReturnValue(true);
     memorySettings = {
       maker: true,
       claudeCode: false,
@@ -77,6 +84,33 @@ describe('runtime-configs', () => {
     expect(claudeConfig.makerMemoryEnabled).toBe(false);
     expect(desktopCodexRuntimeConfig.memoryEnabled).toBe(true);
     expect(desktopCodexRuntimeConfig.makerMemoryEnabled).toBe(false);
+  });
+
+  it('warms bundled ripgrep lazily and reuses a successful probe', async () => {
+    vi.doMock('../memory-settings-store.js', () => ({
+      readMemorySettings: () => memorySettings,
+    }));
+
+    const existsSync = fsMocks.existsSync;
+    const { warmUpBundledRipgrep, getRipgrepBinaryPath, desktopCodexRuntimeConfig } =
+      await import('../runtime-configs.js');
+
+    expect(existsSync).not.toHaveBeenCalled();
+    const path = warmUpBundledRipgrep();
+    const probes = existsSync.mock.calls.length;
+    expect(path).toContain('/apps/ripgrep-bin/');
+    expect(desktopCodexRuntimeConfig.pathPrepends).toEqual([path.replace(/\/rg$/, '')]);
+    expect(getRipgrepBinaryPath()).toBe(path);
+    expect(existsSync).toHaveBeenCalledTimes(probes);
+  });
+
+  it('fails during warmup when the bundled ripgrep binary is missing', async () => {
+    vi.doMock('../memory-settings-store.js', () => ({
+      readMemorySettings: () => memorySettings,
+    }));
+    fsMocks.existsSync.mockReturnValue(false);
+    const { warmUpBundledRipgrep } = await import('../runtime-configs.js');
+    expect(() => warmUpBundledRipgrep()).toThrow(/Bundled ripgrep not found/);
   });
 
   it('places generic Cindy-side Skill precedence in Claude and Codex only', async () => {

--- a/apps/desktop/src/main/maker-host/__tests__/runtimeConfigs.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/runtimeConfigs.test.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 let memorySettings = {
@@ -96,11 +98,11 @@ describe('runtime-configs', () => {
       await import('../runtime-configs.js');
 
     expect(existsSync).not.toHaveBeenCalled();
-    const path = warmUpBundledRipgrep();
+    const ripgrepPath = warmUpBundledRipgrep();
     const probes = existsSync.mock.calls.length;
-    expect(path).toContain('/apps/ripgrep-bin/');
-    expect(desktopCodexRuntimeConfig.pathPrepends).toEqual([path.replace(/\/rg$/, '')]);
-    expect(getRipgrepBinaryPath()).toBe(path);
+    expect(ripgrepPath.replaceAll('\\', '/')).toContain('/apps/ripgrep-bin/');
+    expect(desktopCodexRuntimeConfig.pathPrepends).toEqual([path.dirname(ripgrepPath)]);
+    expect(getRipgrepBinaryPath()).toBe(ripgrepPath);
     expect(existsSync).toHaveBeenCalledTimes(probes);
   });
 

--- a/apps/desktop/src/main/maker-host/__tests__/runtimeConfigsImportPurity.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/runtimeConfigsImportPurity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const fsState = vi.hoisted(() => ({
+  existsSync: vi.fn(() => true),
+  chmodSync: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  // Deliberately omit getAppPath: importing runtime-configs must not probe rg.
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp/cindy-test-user-data',
+  },
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    existsSync: fsState.existsSync,
+    chmodSync: fsState.chmodSync,
+    default: { ...actual, existsSync: fsState.existsSync, chmodSync: fsState.chmodSync },
+  };
+});
+
+vi.mock('../../model-access/effectiveEndpoint.js', () => ({
+  effectiveXdGatewayBaseUrl: () => 'https://gateway.example.test',
+}));
+
+describe('runtime-configs import purity', () => {
+  it('does not access the Electron app path or probe the filesystem during import', async () => {
+    const mod = await import('../runtime-configs.js');
+
+    expect(mod.desktopCodexRuntimeConfig).toBeDefined();
+    expect(fsState.existsSync).not.toHaveBeenCalled();
+    expect(fsState.chmodSync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -101,6 +101,7 @@ import {
 import {
   buildDesktopClaudeRuntimeConfig,
   desktopCodexRuntimeConfig,
+  warmUpBundledRipgrep,
 } from './runtime-configs.js';
 import { getClaudeEndpoint, setClaudeProxyGatewayKeyReader, setClaudeProxyOAuthSpawnChecker } from './anthropic-compat-proxy-host.js';
 import { resolveRemoteClaudeRoute } from './remote-claude-route.js';
@@ -594,6 +595,7 @@ export function getMaker(): Maker {
     if (!codexPath) {
       throw new Error('getMaker: Codex binary not provisioned (bootstrap must run agent-binaries.prepare("codex") before getMaker)');
     }
+    warmUpBundledRipgrep();
 
     // 图片送进模型前的 last-mile resize (省 vision token)。host 注入 logger
     // 让 sharp 失败 / 超时 / LRU 淘汰等告警进项目日志, 而不是默默丢黑洞。

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -42,7 +42,11 @@ function ripgrepBinaryName(): string {
   return process.platform === 'win32' ? 'rg.exe' : 'rg';
 }
 
+let bundledRipgrepDirCache: string | undefined;
+
 function bundledRipgrepDir(): string {
+  if (bundledRipgrepDirCache) return bundledRipgrepDirCache;
+
   const key = platformKey();
   const file = ripgrepBinaryName();
   const candidates = app.isPackaged
@@ -59,6 +63,7 @@ function bundledRipgrepDir(): string {
     if (process.platform !== 'win32') {
       try { fs.chmodSync(bin, 0o755); } catch { /* ignore */ }
     }
+    bundledRipgrepDirCache = dir;
     return dir;
   }
 
@@ -74,6 +79,11 @@ function bundledRipgrepDir(): string {
  */
 export function getRipgrepBinaryPath(): string {
   return path.join(bundledRipgrepDir(), ripgrepBinaryName());
+}
+
+/** Validate and warm the bundled ripgrep path before constructing an agent. */
+export function warmUpBundledRipgrep(): string {
+  return getRipgrepBinaryPath();
 }
 
 // memorySettings 在 main 启动期已 ready (userData 同步可访问)。
@@ -239,7 +249,11 @@ export const desktopCodexRuntimeConfig: AgentRuntimeConfig = {
   behaviorFlags: (ctx) => (ctx.spawnMode === 'remote' ? {} : toolchainThreadCapEnv()),
   // 产品身份 + Skill 来源优先级 + Codex 专属段。
   systemPrompt: composeHostPrompt(codexSystemPrompt),
-  pathPrepends: [bundledRipgrepDir()],
+  // Keep the runtime config import-safe. The packaged/dev resource probe belongs
+  // to the first Codex agent construction, after desktop bootstrap is complete.
+  get pathPrepends() {
+    return [bundledRipgrepDir()];
+  },
   userDataPath: app.getPath('userData'),
   get memoryEnabled() {
     return readMemorySettings().codex;


### PR DESCRIPTION
## 这次改了什么
- 将 bundled ripgrep 的目录探测延后到首次构造 Codex agent 时执行。
- 缓存成功的探测结果；探测失败不会被缓存，仍会在实际启动边界明确报错。
- 补充导入纯净性、预热、缓存与缺失二进制的回归测试。

## 怎么验证的
- `pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/runtimeConfigs.test.ts src/main/maker-host/__tests__/runtimeConfigsImportPurity.test.ts --reporter=dot`
- `pnpm --filter desktop run --if-present typecheck`
- `pnpm test:unit`

## 风险
- 仅改变 ripgrep 的探测时机，不改变实际 PATH 注入或缺失二进制时的 fail-fast 行为。
- 首次创建 Codex agent 时会执行一次探测；之后复用已验证路径。

Fixes #1956