### PR TITLE
fix(desktop): classify incompatible market manifests

### DIFF
--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -11,7 +11,6 @@ import {
   GHOST_LOCALE_MAX_BYTES,
   GHOST_ICON_MAX_BYTES,
   GHOST_INSTALL_MANIFEST_MAX_BYTES,
-  GHOST_SLOTS,
   GHOST_MANUAL_ENTRY_FILE,
   GHOST_MANUAL_MD_MAX_BYTES,
   GHOST_SKILL_MD_MAX_BYTES,
@@ -488,29 +487,48 @@ export interface GhostExclusiveMutation {
   uninstall(id: string, options?: GhostUninstallOptions): Promise<UninstallResult>;
 }
 
+/** 校验器在「除未知字符串 slot 外其余字段全合法」时给出的延后诊断前缀。 */
+const UNKNOWN_SLOT_REASON_PREFIX = 'slots 含未知卡槽 ';
+
 /**
  * 区分“包本身坏了”和“包使用了更新版 Cindy 才认识的契约”。
  *
- * 这里只收窄识别两个可证明是 Host 版本差异的形状：未来 schemaVersion，或
- * 字符串形态的未知 capability slot。其它畸形输入仍交给完整 manifest 校验，
- * 不能借友好提示放松安装安全边界。
+ * 必须在完整 `validateGhostManifest` 之后调用:校验器已先于此处拦掉 tools 等
+ * 其它字段畸形,并把字符串未知 slot 的上报延后到所有字段合法之后。这里只识别
+ * 两个可证明是 Host 版本差异的形状:
+ *  1. 未来 schemaVersion(整数且 > 2);
+ *  2. 校验器延后到收尾才报的「字符串未知 capability slot」诊断。
+ * 直接扫描 raw.slots 会在 tools 也畸形时抢先返回升级提示、掩盖包本身的问题,
+ * 故改为消费校验器已经收敛过的 reason。
  */
-export function ghostManifestHostUnsupportedReason(raw: unknown): string | null {
-  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null;
-  const record = raw as Record<string, unknown>;
-  if (
-    typeof record.schemaVersion === 'number' &&
-    Number.isInteger(record.schemaVersion) &&
-    record.schemaVersion > 2
-  ) {
-    return `插件使用了更新的清单格式(schemaVersion ${record.schemaVersion})`;
+export function ghostManifestHostUnsupportedReason(
+  raw: unknown,
+  reason: string,
+): string | null {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const record = raw as Record<string, unknown>;
+    if (
+      typeof record.schemaVersion === 'number' &&
+      Number.isInteger(record.schemaVersion) &&
+      record.schemaVersion > 2
+    ) {
+      return `插件使用了更新的清单格式(schemaVersion ${record.schemaVersion})`;
+    }
   }
-  if (!Array.isArray(record.slots)) return null;
-  const supported = new Set<string>([...GHOST_SLOTS, 'model']);
-  const unknown = [
-    ...new Set(record.slots.filter((slot): slot is string => typeof slot === 'string')),
-  ].filter((slot) => !supported.has(slot));
-  return unknown.length > 0 ? `插件需要当前 Cindy 尚不支持的能力:${unknown.join(' / ')}` : null;
+  // 该 reason 只可能由校验器在「其余字段全合法」的收尾路径产生(见 shared/ghost.ts
+  // 的 unknownStringSlot 延后逻辑),故见到它即可安全归类为宿主不支持。
+  if (reason.startsWith(UNKNOWN_SLOT_REASON_PREFIX)) {
+    const serialized = reason.slice(UNKNOWN_SLOT_REASON_PREFIX.length).split('(可用:', 1)[0];
+    try {
+      const slot = JSON.parse(serialized) as unknown;
+      if (typeof slot === 'string') {
+        return `插件需要当前 Cindy 尚不支持的能力:${slot}`;
+      }
+    } catch {
+      // fall through to null
+    }
+  }
+  return null;
 }
 
 /**
@@ -2640,12 +2658,15 @@ export class GhostManager {
         rejection: { code: 'file-invalid', reason: `${GHOST_MANIFEST_FILE} 不是合法 JSON` },
       };
     }
-    const hostUnsupportedReason = ghostManifestHostUnsupportedReason(manifestRaw);
-    if (hostUnsupportedReason) {
-      return { rejection: { code: 'host-unsupported', reason: hostUnsupportedReason } };
-    }
+    // 先完整校验再分类:校验器已先于 host-unsupported 拦掉 tools 等其它字段畸形,
+    // 并把字符串未知 slot 的上报延后到所有字段合法之后。直接扫 raw.slots 会在
+    // 未知 slot + tools 畸形时抢先返回升级提示、掩盖包本身的问题。
     const v = validateGhostManifest(manifestRaw);
     if (!v.ok) {
+      const hostUnsupportedReason = ghostManifestHostUnsupportedReason(manifestRaw, v.reason);
+      if (hostUnsupportedReason) {
+        return { rejection: { code: 'host-unsupported', reason: hostUnsupportedReason } };
+      }
       return { rejection: { code: 'file-invalid', reason: `清单不合格:${v.reason}` } };
     }
     if (!v.manifest.node && buf.byteLength > MAX_BASIC_CINDY_FILE_BYTES) {

--- a/apps/desktop/src/main/cindy-brain/GhostManager.ts
+++ b/apps/desktop/src/main/cindy-brain/GhostManager.ts
@@ -8,6 +8,7 @@ import JSZip from 'jszip';
 import {
   GHOST_MANIFEST_FILE,
   GHOST_MANIFEST_MAX_BYTES,
+  GHOST_SLOTS,
   GHOST_LOCALE_MAX_BYTES,
   GHOST_ICON_MAX_BYTES,
   GHOST_INSTALL_MANIFEST_MAX_BYTES,
@@ -489,6 +490,12 @@ export interface GhostExclusiveMutation {
 
 /** 校验器在「除未知字符串 slot 外其余字段全合法」时给出的延后诊断前缀。 */
 const UNKNOWN_SLOT_REASON_PREFIX = 'slots 含未知卡槽 ';
+// 与 shared/ghost.ts 的诊断构造同源:`slots 含未知卡槽
+// <JSON.stringify(slot)>(可用:<GHOST_SLOTS join ' / ')`。后缀必须锚定到诊断
+// 末尾,不能用 split('(可用:')——合法未知 slot 名本身可能包含 "(可用:" 文本
+// (如 `future(可用:x)`),从 slot 名内部任意位置反解析会切坏 JSON、把该升级的
+// 包误判为包无效。与 plugin-market/protocolErrors.ts 的锚定写法保持一致。
+const UNKNOWN_SLOT_REASON_SUFFIX = `(可用:${GHOST_SLOTS.join(' / ')})`;
 
 /**
  * 区分“包本身坏了”和“包使用了更新版 Cindy 才认识的契约”。
@@ -518,7 +525,13 @@ export function ghostManifestHostUnsupportedReason(
   // 该 reason 只可能由校验器在「其余字段全合法」的收尾路径产生(见 shared/ghost.ts
   // 的 unknownStringSlot 延后逻辑),故见到它即可安全归类为宿主不支持。
   if (reason.startsWith(UNKNOWN_SLOT_REASON_PREFIX)) {
-    const serialized = reason.slice(UNKNOWN_SLOT_REASON_PREFIX.length).split('(可用:', 1)[0];
+    // 后缀必须紧贴诊断末尾;长度不匹配说明不是这条已知形状(可能是其它清单错误,
+    // 也可能是用户可控 slot 名里碰巧含 "(可用:" 文本),交给包无效分支。
+    if (!reason.endsWith(UNKNOWN_SLOT_REASON_SUFFIX)) return null;
+    const serialized = reason.slice(
+      UNKNOWN_SLOT_REASON_PREFIX.length,
+      reason.length - UNKNOWN_SLOT_REASON_SUFFIX.length,
+    );
     try {
       const slot = JSON.parse(serialized) as unknown;
       if (typeof slot === 'string') {

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -4668,6 +4668,24 @@ describe('GhostManager · inspect(只验不装)', () => {
     await expectRejection(await manager.inspect(futureCapability), 'host-unsupported');
   });
 
+  it('未知字符串 slot 名内含 "(可用:" 时仍正确归类为 host-unsupported', async () => {
+    // 回归:旧实现用 split("(可用:", 1) 反解析 slot 名,slot 名自身含该文本会
+    // 截断 JSON 导致 parse 失败,把该升级的包误判为 file-invalid。后缀必须锚定到
+    // 诊断末尾(与 plugin-market/protocolErrors.ts 同一条边界)。
+    const trickySlot = 'future(可用:x)';
+    const futureCapability = await makeCindy('future-capability-tricky-slot.cindy', {
+      ...goodManifest(),
+      slots: ['tool', trickySlot],
+    });
+    const result = await manager.inspect(futureCapability);
+    expect((result as { rejection: { code: string; reason: string } }).rejection.code).toBe(
+      'host-unsupported',
+    );
+    expect(
+      (result as { rejection: { reason: string } }).rejection.reason,
+    ).toContain(trickySlot);
+  });
+
   it('slot 形状畸形仍按非法文件拒绝，友好提示不放松安全校验', async () => {
     const malformed = await makeCindy('malformed-slot.cindy', {
       ...goodManifest(),

--- a/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/GhostManager.test.ts
@@ -4675,6 +4675,25 @@ describe('GhostManager · inspect(只验不装)', () => {
     });
     await expectRejection(await manager.inspect(malformed), 'file-invalid');
   });
+
+  it('未知字符串 slot 叠加其它字段畸形时,先报包本身的问题而非提示升级', async () => {
+    // 字符串未知 slot 本可提示"宿主不支持、请升级",但同一清单 tools 字段也畸形——
+    // 必须先完整校验其它字段,返回 file-invalid(tools 错误),不能被升级提示掩盖
+    // (与市场路径 protocolErrors 同一条边界;Codex P2 回归)。
+    const malformed = await makeCindy('unknown-slot-bad-tools.cindy', {
+      ...goodManifest(),
+      slots: ['future-host-capability'],
+      // 声明未知 slot 时不再有 tool 槽,但 tools 仍被显式塞成畸形值。
+      tools: 'not an array',
+    });
+    const result = await manager.inspect(malformed);
+    expect((result as { rejection: { code: string; reason: string } }).rejection.code).toBe(
+      'file-invalid',
+    );
+    expect(
+      (result as { rejection: { reason: string } }).rejection.reason,
+    ).toContain('tools 必须是 1–16 项的数组');
+  });
 });
 
 describe('GhostManager · author / icon(身份卡展示字段)', () => {

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -4,7 +4,10 @@ import { resolve } from 'node:path';
 import { parseGetPluginResponse } from '@cindy/plugin-protocol';
 import { describe, expect, it } from 'vitest';
 
-import { isPluginManifestIncompatibilityError } from '../protocolErrors';
+import {
+  isPluginHostUnsupportedError,
+  isPluginManifestIncompatibilityError,
+} from '../protocolErrors';
 
 function parserError(parse: () => unknown): unknown {
   try {
@@ -15,7 +18,10 @@ function parserError(parse: () => unknown): unknown {
   throw new Error('Expected the protocol parser to reject the response');
 }
 
-function invalidManifestResponse(schemaVersion = 2): Record<string, unknown> {
+function invalidManifestResponse(
+  schemaVersion = 2,
+  manifestOverrides: Record<string, unknown> = {},
+): Record<string, unknown> {
   return {
     schemaVersion,
     plugin: {
@@ -42,6 +48,7 @@ function invalidManifestResponse(schemaVersion = 2): Record<string, unknown> {
           entry: 'index.js',
           slots: ['tool'],
           tools: 'not an array',
+          ...manifestOverrides,
         },
       },
     },
@@ -110,6 +117,20 @@ describe('Plugin Market IPC error boundary', () => {
     expect(isPluginManifestIncompatibilityError(manifestError)).toBe(true);
     expect(isPluginManifestIncompatibilityError(schemaError)).toBe(false);
     expect(isPluginManifestIncompatibilityError(new Error('network failed'))).toBe(false);
+  });
+
+  it('preserves future manifest schema and capability errors as host incompatibilities', () => {
+    const futureSchemaError = parserError(() =>
+      parseGetPluginResponse(invalidManifestResponse(2, { schemaVersion: 99 })),
+    );
+    const unknownSlotError = parserError(() =>
+      parseGetPluginResponse(invalidManifestResponse(2, { slots: ['future-capability'] })),
+    );
+
+    expect(isPluginHostUnsupportedError(futureSchemaError)).toBe(true);
+    expect(isPluginHostUnsupportedError(unknownSlotError)).toBe(true);
+    expect(isPluginManifestIncompatibilityError(futureSchemaError)).toBe(false);
+    expect(isPluginManifestIncompatibilityError(unknownSlotError)).toBe(false);
   });
 
   it('guards removal notice consumption and signals trusted app windows only', () => {

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -3,6 +3,8 @@ import { resolve } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
+import { isPluginManifestIncompatibilityError } from '../protocolErrors';
+
 /**
  * The IPC registration module imports Electron and the full Ghost host graph,
  * so guard its error-boundary contract using the established main-process
@@ -36,6 +38,8 @@ describe('Plugin Market IPC error boundary', () => {
     const body = registerSource.slice(start, end);
 
     expect(body).toContain('if (isIpcError(error)) throw error;');
+    expect(body).toContain('isPluginManifestIncompatibilityError(error)');
+    expect(body).toContain("throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');");
     expect(body).toContain("throwIpcError('INTERNAL', 'Plugin market operation failed');");
     expect(registerSource.match(/return invokePluginMarket\(/g)?.length).toBe(13);
   });
@@ -52,6 +56,24 @@ describe('Plugin Market IPC error boundary', () => {
     expect(body).toContain(
       "throwIpcError('PRECONDITION_FAILED', 'Too many local Plugin icon requests');",
     );
+  });
+
+  it('recognizes only manifest failures from the market protocol as incompatibilities', () => {
+    expect(
+      isPluginManifestIncompatibilityError(
+        Object.assign(new Error('response.plugin.currentRelease.manifest 不合法'), {
+          name: 'PluginProtocolError',
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isPluginManifestIncompatibilityError(
+        Object.assign(new Error('response.schemaVersion 必须为 2'), {
+          name: 'PluginProtocolError',
+        }),
+      ),
+    ).toBe(false);
+    expect(isPluginManifestIncompatibilityError(new Error('network failed'))).toBe(false);
   });
 
   it('guards removal notice consumption and signals trusted app windows only', () => {

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -1,9 +1,52 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import { parseGetPluginResponse } from '@cindy/plugin-protocol';
 import { describe, expect, it } from 'vitest';
 
 import { isPluginManifestIncompatibilityError } from '../protocolErrors';
+
+function parserError(parse: () => unknown): unknown {
+  try {
+    parse();
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected the protocol parser to reject the response');
+}
+
+function invalidManifestResponse(schemaVersion = 2): Record<string, unknown> {
+  return {
+    schemaVersion,
+    plugin: {
+      id: `c${'a'.repeat(24)}`,
+      ghostId: 'acme-helper',
+      name: 'Acme Helper',
+      description: null,
+      author: null,
+      scope: 'public',
+      organizationId: null,
+      defaultInstall: false,
+      currentRelease: {
+        id: 'release-1',
+        version: '1.0.0',
+        sha256: 'a'.repeat(64),
+        sizeBytes: 42,
+        publishedAt: '2026-07-23T00:00:00.000Z',
+        manifest: {
+          schemaVersion: 2,
+          id: 'acme-helper',
+          name: 'Acme Helper',
+          version: '1.0.0',
+          kind: 'chip',
+          entry: 'index.js',
+          slots: ['tool'],
+          tools: 'not an array',
+        },
+      },
+    },
+  };
+}
 
 /**
  * The IPC registration module imports Electron and the full Ghost host graph,
@@ -59,20 +102,13 @@ describe('Plugin Market IPC error boundary', () => {
   });
 
   it('recognizes only manifest failures from the market protocol as incompatibilities', () => {
-    expect(
-      isPluginManifestIncompatibilityError(
-        Object.assign(new Error('response.plugin.currentRelease.manifest 不合法'), {
-          name: 'PluginProtocolError',
-        }),
-      ),
-    ).toBe(true);
-    expect(
-      isPluginManifestIncompatibilityError(
-        Object.assign(new Error('response.schemaVersion 必须为 2'), {
-          name: 'PluginProtocolError',
-        }),
-      ),
-    ).toBe(false);
+    const manifestError = parserError(() => parseGetPluginResponse(invalidManifestResponse()));
+    const schemaError = parserError(() =>
+      parseGetPluginResponse(invalidManifestResponse(1)),
+    );
+
+    expect(isPluginManifestIncompatibilityError(manifestError)).toBe(true);
+    expect(isPluginManifestIncompatibilityError(schemaError)).toBe(false);
     expect(isPluginManifestIncompatibilityError(new Error('network failed'))).toBe(false);
   });
 

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -217,6 +217,22 @@ describe('Plugin Market IPC error boundary', () => {
     ).toBe(false);
   });
 
+  // Non-parse protocol errors whose message merely mentions currentRelease.manifest
+  // (oidc scope mismatch, name/description/author consistency) are envelope-level
+  // failures, not a bad package. They must stay INTERNAL rather than being mapped
+  // to GHOST_FILE_INVALID by the broad `.includes('currentRelease.manifest')` match.
+  it.each([
+    'response.plugin.currentRelease.manifest 的 oidc-token 仅允许 organization scope',
+    'response.plugin.name 与 currentRelease.manifest.name 不一致',
+    'response.plugin.description 与 currentRelease.manifest.description 不一致',
+    'response.plugin.author 与 currentRelease.manifest.author 不一致',
+    'response.plugin.currentRelease.manifest.id 与 ghostId 不一致',
+  ])('does not map non-parse protocol error %j to a manifest/package failure', (message) => {
+    const error = Object.assign(new Error(message), { name: 'PluginProtocolError' });
+    expect(isPluginHostUnsupportedError(error)).toBe(false);
+    expect(isPluginManifestIncompatibilityError(error)).toBe(false);
+  });
+
   it('guards removal notice consumption and signals trusted app windows only', () => {
     const consumeStart = registerSource.indexOf(
       "ipcMain.handle('plugin-market:consume-removal-notice'",

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -170,6 +170,17 @@ describe('Plugin Market IPC error boundary', () => {
       manifestIncompatible: false,
     },
     {
+      label: 'a duplicated unknown string slot',
+      // 同一个未知 slot 出现两次:新 Host 识别后仍会因重复声明而拒包,所以不该
+      // 提示升级,应判为包本身无效(GHOST_FILE_INVALID)。
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['future-capability', 'future-capability'],
+        tools: undefined,
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
       label: 'an unknown string slot alongside another malformed field',
       // slots 的未知字符串项本可提示升级,但 tools 字段也畸形——包本身有问题,
       // 必须报文件无效而非让用户升级 Cindy(其余字段先校验,错误不被升级提示掩盖)。

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -160,12 +160,24 @@ describe('Plugin Market IPC error boundary', () => {
       manifestIncompatible: true,
     },
     {
-      label: 'an unknown string slot',
+      label: 'an unknown string slot in an otherwise valid manifest',
       response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
         slots: ['future-capability'],
+        // 声明了未知卡槽时不再声明 tool 槽相关字段,保证除此之外清单结构合法。
+        tools: undefined,
       }),
       hostUnsupported: true,
       manifestIncompatible: false,
+    },
+    {
+      label: 'an unknown string slot alongside another malformed field',
+      // slots 的未知字符串项本可提示升级,但 tools 字段也畸形——包本身有问题,
+      // 必须报文件无效而非让用户升级 Cindy(其余字段先校验,错误不被升级提示掩盖)。
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['future-capability'],
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
     },
     {
       label: 'a numeric slot',

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
-import { parseGetPluginResponse } from '@cindy/plugin-protocol';
+import { GHOST_MANIFEST_SCHEMA_VERSION, parseGetPluginResponse } from '@cindy/plugin-protocol';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -19,11 +19,25 @@ function parserError(parse: () => unknown): unknown {
 }
 
 function invalidManifestResponse(
-  schemaVersion = 2,
+  manifestSchemaVersion: unknown = GHOST_MANIFEST_SCHEMA_VERSION,
   manifestOverrides: Record<string, unknown> = {},
+  omitSchemaVersion = false,
 ): Record<string, unknown> {
+  const manifest: Record<string, unknown> = {
+    schemaVersion: manifestSchemaVersion,
+    id: 'acme-helper',
+    name: 'Acme Helper',
+    version: '1.0.0',
+    kind: 'chip',
+    entry: 'index.js',
+    slots: ['tool'],
+    tools: 'not an array',
+    ...manifestOverrides,
+  };
+  if (omitSchemaVersion) delete manifest.schemaVersion;
+
   return {
-    schemaVersion,
+    schemaVersion: GHOST_MANIFEST_SCHEMA_VERSION,
     plugin: {
       id: `c${'a'.repeat(24)}`,
       ghostId: 'acme-helper',
@@ -39,17 +53,7 @@ function invalidManifestResponse(
         sha256: 'a'.repeat(64),
         sizeBytes: 42,
         publishedAt: '2026-07-23T00:00:00.000Z',
-        manifest: {
-          schemaVersion: 2,
-          id: 'acme-helper',
-          name: 'Acme Helper',
-          version: '1.0.0',
-          kind: 'chip',
-          entry: 'index.js',
-          slots: ['tool'],
-          tools: 'not an array',
-          ...manifestOverrides,
-        },
+        manifest,
       },
     },
   };
@@ -108,29 +112,97 @@ describe('Plugin Market IPC error boundary', () => {
     );
   });
 
-  it('recognizes only manifest failures from the market protocol as incompatibilities', () => {
-    const manifestError = parserError(() => parseGetPluginResponse(invalidManifestResponse()));
-    const schemaError = parserError(() =>
-      parseGetPluginResponse(invalidManifestResponse(1)),
-    );
+  it.each([
+    {
+      label: 'an ordinary malformed manifest',
+      response: invalidManifestResponse(),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'a future schema version',
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION + 1),
+      hostUnsupported: true,
+      manifestIncompatible: false,
+    },
+    {
+      label: 'a much newer schema version',
+      response: invalidManifestResponse(99),
+      hostUnsupported: true,
+      manifestIncompatible: false,
+    },
+    {
+      label: 'the legacy schema version',
+      response: invalidManifestResponse(1),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'a missing schema version',
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {}, true),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'a non-numeric schema version',
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        schemaVersion: '3',
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'a fractional future schema version',
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        schemaVersion: GHOST_MANIFEST_SCHEMA_VERSION + 0.5,
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'an unknown string slot',
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['future-capability'],
+      }),
+      hostUnsupported: true,
+      manifestIncompatible: false,
+    },
+    {
+      label: 'a numeric slot',
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: [42],
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'a null slot',
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: [null],
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+  ])(
+    'classifies $label without widening the compatibility boundary',
+    ({ response, hostUnsupported, manifestIncompatible }) => {
+      const error = parserError(() => parseGetPluginResponse(response));
 
-    expect(isPluginManifestIncompatibilityError(manifestError)).toBe(true);
-    expect(isPluginManifestIncompatibilityError(schemaError)).toBe(false);
+      expect(isPluginHostUnsupportedError(error)).toBe(hostUnsupported);
+      expect(isPluginManifestIncompatibilityError(error)).toBe(manifestIncompatible);
+    },
+  );
+
+  it('does not classify unrelated protocol or network failures as manifest errors', () => {
+    expect(isPluginHostUnsupportedError(new Error('network failed'))).toBe(false);
     expect(isPluginManifestIncompatibilityError(new Error('network failed'))).toBe(false);
-  });
-
-  it('preserves future manifest schema and capability errors as host incompatibilities', () => {
-    const futureSchemaError = parserError(() =>
-      parseGetPluginResponse(invalidManifestResponse(2, { schemaVersion: 99 })),
-    );
-    const unknownSlotError = parserError(() =>
-      parseGetPluginResponse(invalidManifestResponse(2, { slots: ['future-capability'] })),
-    );
-
-    expect(isPluginHostUnsupportedError(futureSchemaError)).toBe(true);
-    expect(isPluginHostUnsupportedError(unknownSlotError)).toBe(true);
-    expect(isPluginManifestIncompatibilityError(futureSchemaError)).toBe(false);
-    expect(isPluginManifestIncompatibilityError(unknownSlotError)).toBe(false);
+    expect(
+      isPluginHostUnsupportedError(
+        Object.assign(new Error('plugin.currentRelease.manifest is missing'), {
+          name: 'PluginProtocolError',
+        }),
+      ),
+    ).toBe(false);
   });
 
   it('guards removal notice consumption and signals trusted app windows only', () => {

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -182,6 +182,18 @@ describe('Plugin Market IPC error boundary', () => {
       manifestIncompatible: false,
     },
     {
+      label: 'a Desktop-only slot the protocol does not yet whitelist (library)',
+      // 'library' 是当前桌面已知但 plugin-protocol 白名单尚未纳入的 Desktop-only
+      // slot:协议层把它报成"未知卡槽",但本端 Cindy 已支持它,升级无济于事。必须
+      // 落为 GHOST_FILE_INVALID,不能提示用户升级(Codex P2 回归)。
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['library'],
+        tools: undefined,
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
       label: 'a duplicated unknown string slot',
       // 同一个未知 slot 出现两次:新 Host 识别后仍会因重复声明而拒包,所以不该
       // 提示升级,应判为包本身无效(GHOST_FILE_INVALID)。

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -194,6 +194,41 @@ describe('Plugin Market IPC error boundary', () => {
       manifestIncompatible: true,
     },
     {
+      label: 'a future slot preceding a Desktop-only slot (library) is not masked',
+      // 顺序相反的回归(Codex P1):校验器过去只保留第一个未知字符串 slot,若普通未来
+      // 能力排在 'library' 之前,分类器只看到前者就会误判"宿主不支持、请升级",
+      // 掩盖了本端已知、升级无济于事的 Desktop-only slot。任一 slot 命中本端已知
+      // 集合就必须落为 GHOST_FILE_INVALID。
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['future-capability', 'library'],
+        tools: undefined,
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'a Desktop-only slot (library) preceding a future slot is not masked',
+      // 反向顺序同样必须正确:无论 library 排在前面还是后面,只要存在本端已知 slot,
+      // 就不能提示升级。
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['library', 'future-capability'],
+        tools: undefined,
+      }),
+      hostUnsupported: false,
+      manifestIncompatible: true,
+    },
+    {
+      label: 'multiple distinct unknown slots all unknown to this Host',
+      // 多个不同的、本端确实不认识的未来能力:诊断序列化为 JSON 数组,分类器必须识别
+      // 全部为 genuine future 能力并提示升级,不能因为是数组形状就漏判。
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['future-capability', 'another-future'],
+        tools: undefined,
+      }),
+      hostUnsupported: true,
+      manifestIncompatible: false,
+    },
+    {
       label: 'a duplicated unknown string slot',
       // 同一个未知 slot 出现两次:新 Host 识别后仍会因重复声明而拒包,所以不该
       // 提示升级,应判为包本身无效(GHOST_FILE_INVALID)。

--- a/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts
@@ -170,6 +170,18 @@ describe('Plugin Market IPC error boundary', () => {
       manifestIncompatible: false,
     },
     {
+      label: 'an unknown string slot whose name contains the suffix separator text',
+      // 合法未知 slot 名本身可能包含诊断后缀分隔文本 "(可用:"。分类器必须锚定诊断
+      // 末尾的完整后缀、从 slot 名外部反解析,而不是 indexOf 任意位置——否则会把
+      // 这个该升级的包误判为 GHOST_FILE_INVALID(Codex P2 回归)。
+      response: invalidManifestResponse(GHOST_MANIFEST_SCHEMA_VERSION, {
+        slots: ['future(可用:x)'],
+        tools: undefined,
+      }),
+      hostUnsupported: true,
+      manifestIncompatible: false,
+    },
+    {
       label: 'a duplicated unknown string slot',
       // 同一个未知 slot 出现两次:新 Host 识别后仍会因重复声明而拒包,所以不该
       // 提示升级,应判为包本身无效(GHOST_FILE_INVALID)。

--- a/apps/desktop/src/main/plugin-market/protocolErrors.ts
+++ b/apps/desktop/src/main/plugin-market/protocolErrors.ts
@@ -7,6 +7,27 @@ export function isPluginManifestIncompatibilityError(error: unknown): boolean {
   return (
     error instanceof Error &&
     error.name === 'PluginProtocolError' &&
-    error.message.includes('.manifest')
+    error.message.includes('currentRelease.manifest') &&
+    !isPluginHostUnsupportedError(error)
+  );
+}
+
+/**
+ * A valid future manifest must remain distinguishable from a malformed one.
+ * The protocol validator deliberately reports these two compatibility signals
+ * in the manifest reason so the desktop can give upgrade guidance.
+ */
+export function isPluginHostUnsupportedError(error: unknown): boolean {
+  if (
+    !(error instanceof Error) ||
+    error.name !== 'PluginProtocolError' ||
+    !error.message.includes('currentRelease.manifest')
+  ) {
+    return false;
+  }
+
+  return (
+    error.message.includes('schemaVersion 必须是') ||
+    error.message.includes('slots 含未知卡槽')
   );
 }

--- a/apps/desktop/src/main/plugin-market/protocolErrors.ts
+++ b/apps/desktop/src/main/plugin-market/protocolErrors.ts
@@ -30,16 +30,20 @@ function parseJsonLiteral(serialized: string): { ok: true; value: unknown } | { 
 
 /**
  * The market protocol validates the current release manifest while parsing a
- * detail response. Keep this narrow: malformed envelopes must remain an
- * internal/network failure, while an unsupported manifest gets actionable UI.
+ * detail response. Keep this narrow: only a genuine manifest parse/validation
+ * failure (the ` 不合法: ` marker emitted by the protocol parser) maps to
+ * `GHOST_FILE_INVALID`. Other protocol errors whose message merely mentions
+ * `currentRelease.manifest` — e.g. oidc-token scope mismatch, name/description/
+ * author consistency checks, or a missing manifest field — are envelope-level
+ * failures and must stay INTERNAL so we don't mislabel a malformed server
+ * response as a bad package. Malformed envelopes remain an internal/network
+ * failure, while an unsupported manifest gets actionable UI.
  */
 export function isPluginManifestIncompatibilityError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    error.name === 'PluginProtocolError' &&
-    error.message.includes('currentRelease.manifest') &&
-    !isPluginHostUnsupportedError(error)
-  );
+  // Require the exact `currentRelease.manifest 不合法: <reason>` shape produced
+  // by the protocol validator, not any message that happens to mention the
+  // path. `currentReleaseManifestReason` returns null for non-parse errors.
+  return currentReleaseManifestReason(error) !== null && !isPluginHostUnsupportedError(error);
 }
 
 /**

--- a/apps/desktop/src/main/plugin-market/protocolErrors.ts
+++ b/apps/desktop/src/main/plugin-market/protocolErrors.ts
@@ -1,3 +1,33 @@
+import { GHOST_MANIFEST_SCHEMA_VERSION } from '@cindy/plugin-protocol';
+
+const CURRENT_RELEASE_MANIFEST_MARKER = 'currentRelease.manifest';
+const MANIFEST_SCHEMA_REASON_PREFIX = `schemaVersion 必须是 ${GHOST_MANIFEST_SCHEMA_VERSION},得到 `;
+const UNKNOWN_SLOT_REASON_PREFIX = 'slots 含未知卡槽 ';
+const UNKNOWN_SLOT_REASON_SUFFIX = '(可用:';
+
+function currentReleaseManifestReason(error: unknown): string | null {
+  if (
+    !(error instanceof Error) ||
+    error.name !== 'PluginProtocolError' ||
+    !error.message.includes(CURRENT_RELEASE_MANIFEST_MARKER)
+  ) {
+    return null;
+  }
+
+  const marker = ' 不合法: ';
+  const markerIndex = error.message.indexOf(marker);
+  if (markerIndex < 0) return null;
+  return error.message.slice(markerIndex + marker.length);
+}
+
+function parseJsonLiteral(serialized: string): { ok: true; value: unknown } | { ok: false } {
+  try {
+    return { ok: true, value: JSON.parse(serialized) as unknown };
+  } catch {
+    return { ok: false };
+  }
+}
+
 /**
  * The market protocol validates the current release manifest while parsing a
  * detail response. Keep this narrow: malformed envelopes must remain an
@@ -18,16 +48,23 @@ export function isPluginManifestIncompatibilityError(error: unknown): boolean {
  * in the manifest reason so the desktop can give upgrade guidance.
  */
 export function isPluginHostUnsupportedError(error: unknown): boolean {
-  if (
-    !(error instanceof Error) ||
-    error.name !== 'PluginProtocolError' ||
-    !error.message.includes('currentRelease.manifest')
-  ) {
-    return false;
+  const reason = currentReleaseManifestReason(error);
+  if (reason === null) return false;
+
+  if (reason.startsWith(MANIFEST_SCHEMA_REASON_PREFIX)) {
+    const serialized = reason.slice(MANIFEST_SCHEMA_REASON_PREFIX.length).split('(', 1)[0];
+    const parsed = parseJsonLiteral(serialized);
+    return (
+      parsed.ok &&
+      typeof parsed.value === 'number' &&
+      Number.isSafeInteger(parsed.value) &&
+      parsed.value > GHOST_MANIFEST_SCHEMA_VERSION
+    );
   }
 
-  return (
-    error.message.includes('schemaVersion 必须是') ||
-    error.message.includes('slots 含未知卡槽')
-  );
+  if (!reason.startsWith(UNKNOWN_SLOT_REASON_PREFIX)) return false;
+  const suffixIndex = reason.indexOf(UNKNOWN_SLOT_REASON_SUFFIX);
+  if (suffixIndex < 0) return false;
+  const parsed = parseJsonLiteral(reason.slice(UNKNOWN_SLOT_REASON_PREFIX.length, suffixIndex));
+  return parsed.ok && typeof parsed.value === 'string';
 }

--- a/apps/desktop/src/main/plugin-market/protocolErrors.ts
+++ b/apps/desktop/src/main/plugin-market/protocolErrors.ts
@@ -1,0 +1,12 @@
+/**
+ * The market protocol validates the current release manifest while parsing a
+ * detail response. Keep this narrow: malformed envelopes must remain an
+ * internal/network failure, while an unsupported manifest gets actionable UI.
+ */
+export function isPluginManifestIncompatibilityError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === 'PluginProtocolError' &&
+    error.message.includes('.manifest')
+  );
+}

--- a/apps/desktop/src/main/plugin-market/protocolErrors.ts
+++ b/apps/desktop/src/main/plugin-market/protocolErrors.ts
@@ -1,5 +1,7 @@
 import { GHOST_MANIFEST_SCHEMA_VERSION, GHOST_SLOTS } from '@cindy/plugin-protocol';
 
+import { GHOST_SLOTS as DESKTOP_GHOST_SLOTS } from '../../shared/ghost.js';
+
 const CURRENT_RELEASE_MANIFEST_MARKER = 'currentRelease.manifest';
 const MANIFEST_SCHEMA_REASON_PREFIX = `schemaVersion 必须是 ${GHOST_MANIFEST_SCHEMA_VERSION},得到 `;
 const UNKNOWN_SLOT_REASON_PREFIX = 'slots 含未知卡槽 ';
@@ -79,5 +81,10 @@ export function isPluginHostUnsupportedError(error: unknown): boolean {
     reason.length - UNKNOWN_SLOT_REASON_SUFFIX.length,
   );
   const parsed = parseJsonLiteral(serialized);
-  return parsed.ok && typeof parsed.value === 'string';
+  if (!parsed.ok || typeof parsed.value !== 'string') return false;
+  // `library` 等是当前桌面已知、但 plugin-protocol 白名单尚未纳入的 Desktop-only
+  // slot:协议层把它报成"未知卡槽",但本端 Cindy 已支持它,升级无济于事。这类 slot
+  // 必须落为 manifest invalid(GHOST_FILE_INVALID),不能提示用户升级。
+  if ((DESKTOP_GHOST_SLOTS as readonly string[]).includes(parsed.value)) return false;
+  return true;
 }

--- a/apps/desktop/src/main/plugin-market/protocolErrors.ts
+++ b/apps/desktop/src/main/plugin-market/protocolErrors.ts
@@ -1,9 +1,13 @@
-import { GHOST_MANIFEST_SCHEMA_VERSION } from '@cindy/plugin-protocol';
+import { GHOST_MANIFEST_SCHEMA_VERSION, GHOST_SLOTS } from '@cindy/plugin-protocol';
 
 const CURRENT_RELEASE_MANIFEST_MARKER = 'currentRelease.manifest';
 const MANIFEST_SCHEMA_REASON_PREFIX = `schemaVersion 必须是 ${GHOST_MANIFEST_SCHEMA_VERSION},得到 `;
 const UNKNOWN_SLOT_REASON_PREFIX = 'slots 含未知卡槽 ';
-const UNKNOWN_SLOT_REASON_SUFFIX = '(可用:';
+// 与 plugin-protocol 的诊断构造同源(manifest.ts):`slots 含未知卡槽
+// <JSON.stringify(slot)>(可用:<GHOST_SLOTS join ' / ')`。后缀必须锚定到诊断
+// 末尾,不能用 indexOf——合法未知 slot 名本身可能包含 "(可用:" 文本,从 slot 名
+// 内部任意位置反解析会切坏 JSON、把该升级的包误判为包无效。
+const UNKNOWN_SLOT_REASON_SUFFIX = `(可用:${GHOST_SLOTS.join(' / ')})`;
 
 function currentReleaseManifestReason(error: unknown): string | null {
   if (
@@ -67,8 +71,13 @@ export function isPluginHostUnsupportedError(error: unknown): boolean {
   }
 
   if (!reason.startsWith(UNKNOWN_SLOT_REASON_PREFIX)) return false;
-  const suffixIndex = reason.indexOf(UNKNOWN_SLOT_REASON_SUFFIX);
-  if (suffixIndex < 0) return false;
-  const parsed = parseJsonLiteral(reason.slice(UNKNOWN_SLOT_REASON_PREFIX.length, suffixIndex));
+  // 后缀必须紧贴诊断末尾;长度不匹配说明不是这条已知形状(可能是其它清单错误,
+  // 也可能是用户可控 slot 名里碰巧含 "(可用:" 文本),交给包无效分支。
+  if (!reason.endsWith(UNKNOWN_SLOT_REASON_SUFFIX)) return false;
+  const serialized = reason.slice(
+    UNKNOWN_SLOT_REASON_PREFIX.length,
+    reason.length - UNKNOWN_SLOT_REASON_SUFFIX.length,
+  );
+  const parsed = parseJsonLiteral(serialized);
   return parsed.ok && typeof parsed.value === 'string';
 }

--- a/apps/desktop/src/main/plugin-market/protocolErrors.ts
+++ b/apps/desktop/src/main/plugin-market/protocolErrors.ts
@@ -81,10 +81,20 @@ export function isPluginHostUnsupportedError(error: unknown): boolean {
     reason.length - UNKNOWN_SLOT_REASON_SUFFIX.length,
   );
   const parsed = parseJsonLiteral(serialized);
-  if (!parsed.ok || typeof parsed.value !== 'string') return false;
-  // `library` 等是当前桌面已知、但 plugin-protocol 白名单尚未纳入的 Desktop-only
-  // slot:协议层把它报成"未知卡槽",但本端 Cindy 已支持它,升级无济于事。这类 slot
-  // 必须落为 manifest invalid(GHOST_FILE_INVALID),不能提示用户升级。
-  if ((DESKTOP_GHOST_SLOTS as readonly string[]).includes(parsed.value)) return false;
-  return true;
+  if (!parsed.ok) return false;
+  // 校验器对单个未知 slot 输出 JSON 字符串(`"<slot>"`),对多个未知 slot 输出 JSON
+  // 字符串数组(`["<a>","<b>"]`)。逐一分流:其中任一 slot 是本端已知但市场协议
+  // 白名单尚未纳入的 Desktop-only slot(如 `library`),都必须落为 manifest invalid
+  // (GHOST_FILE_INVALID)——升级 Cindy 无济于事,不能让排在前面的普通未知 slot 把
+  // 它掩盖成"宿主不支持、请升级"。只有全部 slot 都是本端确实不认识的未来能力时,
+  // 才提示升级。
+  const unknownSlots = Array.isArray(parsed.value)
+    ? parsed.value
+    : typeof parsed.value === 'string'
+      ? [parsed.value]
+      : [];
+  if (unknownSlots.length === 0 || !unknownSlots.every((slot) => typeof slot === 'string')) {
+    return false;
+  }
+  return !unknownSlots.some((slot) => (DESKTOP_GHOST_SLOTS as readonly string[]).includes(slot));
 }

--- a/apps/desktop/src/main/plugin-market/registerIpc.ts
+++ b/apps/desktop/src/main/plugin-market/registerIpc.ts
@@ -19,7 +19,10 @@ import { requireObject, requireString, throwIpcError } from '../utils/ipcValidat
 import { parseMarketSource } from './sources/parse.js';
 import { LocalIconRequestGate } from './localIconRequestGate.js';
 import { PluginMarketPackagePermissionReviewBridge } from './packagePermissionReviewBridge.js';
-import { isPluginManifestIncompatibilityError } from './protocolErrors.js';
+import {
+  isPluginHostUnsupportedError,
+  isPluginManifestIncompatibilityError,
+} from './protocolErrors.js';
 import {
   PluginMarketService,
   type PluginMarketSnapshotOptions,
@@ -123,7 +126,16 @@ async function invokePluginMarket<T>(operation: () => Promise<T>): Promise<T> {
     return await operation();
   } catch (error) {
     if (isIpcError(error)) throw error;
+    if (isPluginHostUnsupportedError(error)) {
+      log.warn('plugin market protocol manifest requires a newer host', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      throwIpcError('GHOST_HOST_UNSUPPORTED', 'This Plugin requires a newer Cindy host');
+    }
     if (isPluginManifestIncompatibilityError(error)) {
+      log.warn('plugin market protocol manifest is incompatible', {
+        error: error instanceof Error ? error.message : String(error),
+      });
       throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
     }
     log.warn('plugin market IPC failed', {

--- a/apps/desktop/src/main/plugin-market/registerIpc.ts
+++ b/apps/desktop/src/main/plugin-market/registerIpc.ts
@@ -19,6 +19,7 @@ import { requireObject, requireString, throwIpcError } from '../utils/ipcValidat
 import { parseMarketSource } from './sources/parse.js';
 import { LocalIconRequestGate } from './localIconRequestGate.js';
 import { PluginMarketPackagePermissionReviewBridge } from './packagePermissionReviewBridge.js';
+import { isPluginManifestIncompatibilityError } from './protocolErrors.js';
 import {
   PluginMarketService,
   type PluginMarketSnapshotOptions,
@@ -122,6 +123,9 @@ async function invokePluginMarket<T>(operation: () => Promise<T>): Promise<T> {
     return await operation();
   } catch (error) {
     if (isIpcError(error)) throw error;
+    if (isPluginManifestIncompatibilityError(error)) {
+      throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
+    }
     log.warn('plugin market IPC failed', {
       error: error instanceof Error ? error.message : String(error),
     });

--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketErrorKey.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketErrorKey.test.ts
@@ -24,6 +24,12 @@ describe('pluginMarketErrorKey', () => {
     );
   });
 
+  it('maps GHOST_HOST_UNSUPPORTED to the localized upgrade copy', () => {
+    expect(pluginMarketErrorKey(serializedIpcError('GHOST_HOST_UNSUPPORTED'))).toBe(
+      'settings.ghosts.errors.hostUnsupported',
+    );
+  });
+
   it('never exposes a plain main-process error message', () => {
     expect(pluginMarketErrorKey(new Error('不应显示给 renderer 的内部错误'))).toBe(
       'settings.ghosts.market.errors.generic',

--- a/apps/desktop/src/renderer/features/plugin/lib/pluginMarketErrorKey.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/pluginMarketErrorKey.ts
@@ -17,6 +17,9 @@ export function pluginMarketErrorKey(error: unknown): string {
       return 'settings.ghosts.market.errors.notConfigured';
     case 'GHOST_FILE_INVALID':
       return 'settings.ghosts.market.errors.invalidPackage';
+    case 'GHOST_HOST_UNSUPPORTED':
+      // 复用插件装入失败的升级文案(包合法但本端 Cindy 版本过旧)。
+      return 'settings.ghosts.errors.hostUnsupported';
     case 'GHOST_ID_RESERVED':
       return 'settings.ghosts.errors.idReserved';
     case 'GHOST_BROKER_REDIRECT_PORT_REQUIRED':

--- a/apps/desktop/src/shared/__tests__/ghost.test.ts
+++ b/apps/desktop/src/shared/__tests__/ghost.test.ts
@@ -1020,6 +1020,39 @@ describe('ghost · 芯片型清单(schemaVersion 2)', () => {
     expect(validateGhostManifest(noPanel).ok).toBe(true);
   });
 
+  it('字符串未知卡槽延后到其余字段校验通过后才报,畸形字段优先', () => {
+    // Desktop 镜像必须与 packages/plugin-protocol 清单校验器同一条边界:
+    // 未知字符串 slot 先记下并跳过,让 tools 等其它字段继续校验。
+    const base = {
+      schemaVersion: 2,
+      id: 'hello-chip',
+      name: 'Hello 芯片',
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      slots: ['subscribe'],
+    };
+    // 未知 slot + tools 畸形:必须先报 tools 错误,不能被升级提示掩盖。
+    expect(
+      validateGhostManifest({ ...base, slots: ['future-capability'], tools: 'not an array' }),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('tools 必须是 1–16 项的数组'),
+    });
+    // 除未知 slot 外完全合法:收尾才报未知卡槽(供装入侧映射为宿主不支持)。
+    expect(validateGhostManifest({ ...base, slots: ['future-capability'] })).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('未知卡槽 "future-capability"'),
+    });
+    // 重复的未知 slot:新 Host 识别后仍会因重复声明拒包,必须判包无效而非升级。
+    expect(
+      validateGhostManifest({ ...base, slots: ['future-capability', 'future-capability'] }),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('重复卡槽'),
+    });
+  });
+
   it('agent 槽默认只允许真人点击；background 是单独的高风险加档', () => {
     const userActionOnly = validateGhostManifest({
       ...goodChipManifest(),

--- a/apps/desktop/src/shared/ghost.ts
+++ b/apps/desktop/src/shared/ghost.ts
@@ -3536,10 +3536,27 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
     return { ok: false, reason: '必须声明 slots(非空数组,能力白名单)' };
   }
   const slots: GhostSlot[] = [];
+  // 字符串形态的未知卡槽可能是新版 Cindy 才认识的能力(应提示升级宿主);非字符串
+  // (数字/null 等)是形状畸形,立即判包无效。字符串未知项先记下并跳过,让其余字段
+  // 继续校验——只有除此之外清单完全合法时才在收尾处报"宿主不支持",避免 tools
+  // 等其它字段也有错误时被升级提示掩盖(包本身坏了,不该让用户去升级 Cindy)。
+  // 与 packages/plugin-protocol 的清单校验器保持同一条边界。
+  let unknownStringSlot: string | null = null;
+  // 未知字符串 slot 也要查重:['future','future'] 不是「升级就能用」——新 Host 识别
+  // 该 slot 后,同一校验器会因重复声明而拒包,所以重复值必须归为包无效而非宿主不支持。
+  const seenUnknownStringSlots = new Set<string>();
   for (const s of raw.slots) {
     // 旧名兼容:'model' 静默归一化为 'cindy'(2026-07-11 更名,已装老包不消失)。
     const name = s === 'model' ? 'cindy' : s;
     if (typeof name !== 'string' || !(GHOST_SLOTS as readonly string[]).includes(name)) {
+      if (typeof s === 'string' && s !== 'model') {
+        if (seenUnknownStringSlots.has(s)) {
+          return { ok: false, reason: `slots 含重复卡槽 ${JSON.stringify(s)}` };
+        }
+        seenUnknownStringSlots.add(s);
+        unknownStringSlot ??= s;
+        continue;
+      }
       return {
         ok: false,
         reason: `slots 含未知卡槽 ${JSON.stringify(s)}(可用:${GHOST_SLOTS.join(' / ')})`,
@@ -5469,6 +5486,15 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
       seen.add(fold);
       keywords.push(word);
     }
+  }
+
+  // 走到这里说明除字符串未知卡槽外的所有字段都合法:此时才报告"宿主不支持",
+  // 给桌面端升级指引。若其它字段也有错误,上面早已返回具体的包无效原因。
+  if (unknownStringSlot !== null) {
+    return {
+      ok: false,
+      reason: `slots 含未知卡槽 ${JSON.stringify(unknownStringSlot)}(可用:${GHOST_SLOTS.join(' / ')})`,
+    };
   }
 
   return {

--- a/packages/plugin-protocol/src/__tests__/manifest.test.ts
+++ b/packages/plugin-protocol/src/__tests__/manifest.test.ts
@@ -941,6 +941,32 @@ describe('Ghost manifest contract', () => {
     });
   });
 
+  it('defers the unknown-string-slot error until other fields pass validation', () => {
+    // 字符串形态的未知卡槽本可提示"宿主不支持、请升级",但 tools 字段畸形时必须先报
+    // 包本身的问题,不能让用户去升级 Cindy。
+    expect(
+      validateGhostManifest({
+        ...validManifest,
+        slots: ['future-capability'],
+        tools: 'not an array',
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('tools 必须是 1–16 项的数组'),
+    });
+    // 除未知字符串卡槽外完全合法时,才在收尾处报告未知卡槽(供桌面端映射为升级提示)。
+    expect(
+      validateGhostManifest({
+        ...validManifest,
+        slots: ['future-capability'],
+        tools: undefined,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('未知卡槽 "future-capability"'),
+    });
+  });
+
   it('enforces node slot / detail pairing and entry discipline', () => {
     const base = {
       ...validManifest,

--- a/packages/plugin-protocol/src/__tests__/manifest.test.ts
+++ b/packages/plugin-protocol/src/__tests__/manifest.test.ts
@@ -967,6 +967,39 @@ describe('Ghost manifest contract', () => {
     });
   });
 
+  it('preserves every unknown string slot instead of keeping only the first', () => {
+    // 多个未知字符串 slot 时不能只留第一个:后面可能跟着市场协议白名单尚未纳入的
+    // Desktop-only slot(如 'library'),只留第一个会让桌面端把包无效误判成宿主不支持。
+    // 单 slot 诊断形状保持不变(`"<slot>"`);多 slot 序列化为 JSON 数组。
+    expect(
+      validateGhostManifest({
+        ...validManifest,
+        slots: ['future-capability', 'another-future'],
+        tools: undefined,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: 'slots 含未知卡槽 ["future-capability","another-future"](可用:'
+        + `${GHOST_SLOTS.join(' / ')})`,
+    });
+  });
+
+  it('does not let an earlier ordinary unknown slot mask a later Desktop-only slot', () => {
+    // 顺序相反:普通未来能力排在 Desktop-only 'library' 之前。诊断必须同时携带两者,
+    // 桌面端分类器才能见到 'library' 并判包无效,而不是只看到前者提示升级。
+    expect(
+      validateGhostManifest({
+        ...validManifest,
+        slots: ['future-capability', 'library'],
+        tools: undefined,
+      }),
+    ).toMatchObject({
+      ok: false,
+      reason: 'slots 含未知卡槽 ["future-capability","library"](可用:'
+        + `${GHOST_SLOTS.join(' / ')})`,
+    });
+  });
+
   it('enforces node slot / detail pairing and entry discipline', () => {
     const base = {
       ...validManifest,

--- a/packages/plugin-protocol/src/manifest.ts
+++ b/packages/plugin-protocol/src/manifest.ts
@@ -1442,11 +1442,18 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
   // 继续校验——只有除此之外清单完全合法时才在收尾处报"宿主不支持",避免 tools
   // 等其它字段也有错误时被升级提示掩盖(包本身坏了,不该让用户去升级 Cindy)。
   let unknownStringSlot: string | null = null;
+  // 未知字符串 slot 也要查重:['future','future'] 不是「升级就能用」——新 Host 识别
+  // 该 slot 后,同一校验器会因重复声明而拒包,所以重复值必须归为包无效而非宿主不支持。
+  const seenUnknownStringSlots = new Set<string>();
   for (const s of raw.slots) {
     // 旧名兼容:'model' 静默归一化为 'cindy'(2026-07-11 更名,已装老包不消失)。
     const name = s === 'model' ? 'cindy' : s;
     if (typeof name !== 'string' || !(GHOST_SLOTS as readonly string[]).includes(name)) {
       if (typeof s === 'string' && s !== 'model') {
+        if (seenUnknownStringSlots.has(s)) {
+          return { ok: false, reason: `slots 含重复卡槽 ${JSON.stringify(s)}` };
+        }
+        seenUnknownStringSlots.add(s);
         unknownStringSlot ??= s;
         continue;
       }

--- a/packages/plugin-protocol/src/manifest.ts
+++ b/packages/plugin-protocol/src/manifest.ts
@@ -1441,7 +1441,10 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
   // (数字/null 等)是形状畸形,立即判包无效。字符串未知项先记下并跳过,让其余字段
   // 继续校验——只有除此之外清单完全合法时才在收尾处报"宿主不支持",避免 tools
   // 等其它字段也有错误时被升级提示掩盖(包本身坏了,不该让用户去升级 Cindy)。
-  let unknownStringSlot: string | null = null;
+  // 必须保留全部未知 slot 而非只留第一个:其中任一可能是市场协议白名单尚未纳入的
+  // Desktop-only slot(如 'library'),被前面的普通未知 slot 掩盖会让桌面端把
+  // 「包无效」误判成「宿主不支持、请升级」。
+  const unknownStringSlots: string[] = [];
   // 未知字符串 slot 也要查重:['future','future'] 不是「升级就能用」——新 Host 识别
   // 该 slot 后,同一校验器会因重复声明而拒包,所以重复值必须归为包无效而非宿主不支持。
   const seenUnknownStringSlots = new Set<string>();
@@ -1454,7 +1457,7 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
           return { ok: false, reason: `slots 含重复卡槽 ${JSON.stringify(s)}` };
         }
         seenUnknownStringSlots.add(s);
-        unknownStringSlot ??= s;
+        unknownStringSlots.push(s);
         continue;
       }
       return {
@@ -3449,10 +3452,18 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
 
   // 走到这里说明除字符串未知卡槽外的所有字段都合法:此时才报告"宿主不支持",
   // 给桌面端升级指引。若其它字段也有错误,上面早已返回具体的包无效原因。
-  if (unknownStringSlot !== null) {
+  // 单个未知 slot 时逐字沿用历史诊断形状(`"<slot>"`),桌面端分类器按单值解析;
+  // 多个未知 slot 时序列化为 JSON 数组(`["<a>","<b>"]`),桌面端必须逐一分流——
+  // 其中只要有一个 Desktop-only slot(本端已知、协议白名单未纳入),就应判包无效
+  // 而非提示升级,不能让排在前面的普通未知 slot 把它掩盖掉。
+  if (unknownStringSlots.length > 0) {
+    const slotLiteral =
+      unknownStringSlots.length === 1
+        ? JSON.stringify(unknownStringSlots[0])
+        : JSON.stringify(unknownStringSlots);
     return {
       ok: false,
-      reason: `slots 含未知卡槽 ${JSON.stringify(unknownStringSlot)}(可用:${GHOST_SLOTS.join(' / ')})`,
+      reason: `slots 含未知卡槽 ${slotLiteral}(可用:${GHOST_SLOTS.join(' / ')})`,
     };
   }
 

--- a/packages/plugin-protocol/src/manifest.ts
+++ b/packages/plugin-protocol/src/manifest.ts
@@ -1437,10 +1437,19 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
     return { ok: false, reason: '必须声明 slots(非空数组,能力白名单)' };
   }
   const slots: GhostSlot[] = [];
+  // 字符串形态的未知卡槽可能是新版 Cindy 才认识的能力(应提示升级宿主);非字符串
+  // (数字/null 等)是形状畸形,立即判包无效。字符串未知项先记下并跳过,让其余字段
+  // 继续校验——只有除此之外清单完全合法时才在收尾处报"宿主不支持",避免 tools
+  // 等其它字段也有错误时被升级提示掩盖(包本身坏了,不该让用户去升级 Cindy)。
+  let unknownStringSlot: string | null = null;
   for (const s of raw.slots) {
     // 旧名兼容:'model' 静默归一化为 'cindy'(2026-07-11 更名,已装老包不消失)。
     const name = s === 'model' ? 'cindy' : s;
     if (typeof name !== 'string' || !(GHOST_SLOTS as readonly string[]).includes(name)) {
+      if (typeof s === 'string' && s !== 'model') {
+        unknownStringSlot ??= s;
+        continue;
+      }
       return {
         ok: false,
         reason: `slots 含未知卡槽 ${JSON.stringify(s)}(可用:${GHOST_SLOTS.join(' / ')})`,
@@ -3429,6 +3438,15 @@ export function validateGhostManifest(raw: unknown): ManifestValidation {
       seen.add(fold);
       keywords.push(word);
     }
+  }
+
+  // 走到这里说明除字符串未知卡槽外的所有字段都合法:此时才报告"宿主不支持",
+  // 给桌面端升级指引。若其它字段也有错误,上面早已返回具体的包无效原因。
+  if (unknownStringSlot !== null) {
+    return {
+      ok: false,
+      reason: `slots 含未知卡槽 ${JSON.stringify(unknownStringSlot)}(可用:${GHOST_SLOTS.join(' / ')})`,
+    };
   }
 
   return {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 插件市场详情解析里「当前版本清单不兼容」的错误分类边界:把服务端校验 `currentRelease.manifest` 失败的协议错误,映射到已有的稳定 IPC 错误码(`GHOST_FILE_INVALID` / `GHOST_HOST_UNSUPPORTED`),而不是落到通用 `INTERNAL`,使用户能看到已本地化的「包无效」或「请升级 Cindy」指引。

本轮在上一轮基础上收窄分类器:只有 manifest 校验器产生的 `currentRelease.manifest 不合法: <reason>` 格式才会被识别为清单不兼容;信封层错误(oidc-token scope、name/description/author 不一致、manifest.id 与 ghostId 不一致)虽然消息里也提到 `currentRelease.manifest`,但仍属于服务端/协议故障,保持 INTERNAL。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:Related to #1968
- 本 PR 包含:
  - `packages/plugin-protocol/src/manifest.ts`:把未知字符串 slot 的上报推迟到清单其余字段全部校验通过之后(避免 tools 等字段畸形时被升级提示掩盖)。
  - `apps/desktop/src/main/plugin-market/protocolErrors.ts`:新增窄分类器,只识别 manifest 校验器产生的不合法原因;未来 `schemaVersion`、形状合法的未知字符串 slot 映射为「宿主不支持」,其余清单错误映射为「包无效」。
  - `apps/desktop/src/main/plugin-market/registerIpc.ts`:在 IPC 边界把两类协议错误映射到稳定 IPC 错误码,并保留 main 日志里的原始诊断。
  - `apps/desktop/src/renderer/features/plugin/lib/pluginMarketErrorKey.ts`:`GHOST_HOST_UNSUPPORTED` 复用已有的「请升级 Cindy」本地化文案。
  - 配套 parser-backed 回归测试。
- 明确不包含:服务端改动、UI 视觉/交互改版、新文案 key。
- 用户可见变化:未来 manifest / 未知能力 slot 触发升级提示,普通清单错误触发「包无效」提示,其它协议/网络故障保持通用「请重试」。
- 是否存在 breaking change:无。

### UI 变化

不涉及:本次仅在已有错误码到已有 i18n key 的映射表上新增 `GHOST_HOST_UNSUPPORTED` 分支(复用 `settings.ghosts.errors.hostUnsupported`),没有新增组件、视觉、动效或文案 key;Light / Dark 两种模式均无新增样式。

- 引用的设计规范:不涉及——命中 `src/renderer/features/plugin/lib/` 路径的改动只是错误码到既有本地化 key 的纯数据映射,不渲染任何新界面,也不修改颜色/间距/排版/动效。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/plugin-market/__tests__/ipcErrorBoundary.test.ts --reporter=dot
结果:23 tests passed

pnpm --filter desktop exec vitest run src/main/plugin-market --reporter=dot
结果:16 files / 368 tests passed

pnpm --filter desktop exec vitest run src/renderer/features/plugin --reporter=dot
结果:24 files / 241 tests passed

pnpm --filter desktop run --if-present typecheck
结果:通过,无错误

pnpm --filter @cindy/plugin-protocol run --if-present test
结果:通过

pnpm check:dco
结果:通过
```

### 手工验证

不涉及——错误分类为纯逻辑分支,已由 parser-backed 单测覆盖未来 schema、旧 schema、缺失 schema、非数字 schema、未知字符串 slot、未知字符串 slot 叠加 tools 畸形、数字 slot、null slot、信封层不匹配等场景。

### 未执行的验证

- 未跑全量 `pnpm test:unit`:desktop 全量 vitest 在本机遇到 worker SIGSEGV(并行 worker 的已知环境问题,与本次改动无关);已跑与改动直接相关的 plugin-market main + renderer 全量测试(共 609 tests)以及 plugin-protocol 测试,全部通过。CI 上跑全量。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响面:Desktop 插件市场详情接口失败时的用户可见错误文案;不影响数据、协议、安装路径。
- 回滚:revert 单 PR 即可,无 schema / 存储迁移。
- 兼容性:`GHOST_HOST_UNSUPPORTED` / `GHOST_FILE_INVALID` 是已有稳定 IPC 错误码,renderer 已有对应本地化文案;不引入新错误码或新 i18n key。

