### PR TITLE
fix(bridge): explain unsupported image input

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -326,6 +326,28 @@ describe('createResponsesChatHandler', () => {
     expect(res.chunks.join('')).toContain('slow down');
   });
 
+  it('normalizes known text-only image schema errors into an actionable response', async () => {
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({ authorization: 'Bearer secret' }),
+    }, {
+      fetchImpl: vi.fn(async () => new Response(
+        JSON.stringify({
+          error: "messages[0]: unknown variant 'image_url', expected 'text'",
+        }),
+        { status: 400 },
+      )) as typeof fetch,
+    });
+    const res = new FakeResponse();
+
+    await handler.handle({ parsedBody: { model: 'm', input: 'hi' }, res: res as never });
+
+    expect(res.status).toBe(400);
+    expect(res.chunks.join('')).toContain('unsupported_feature');
+    expect(res.chunks.join('')).toContain('does not support image input');
+    expect(res.chunks.join('')).not.toContain("unknown variant 'image_url'");
+  });
+
   it('translates non-streaming Chat JSON into a non-streaming Responses response', async () => {
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
       id: 'chat_json',

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -343,9 +343,31 @@ describe('createResponsesChatHandler', () => {
     await handler.handle({ parsedBody: { model: 'm', input: 'hi' }, res: res as never });
 
     expect(res.status).toBe(400);
-    expect(res.chunks.join('')).toContain('unsupported_feature');
-    expect(res.chunks.join('')).toContain('does not support image input');
-    expect(res.chunks.join('')).not.toContain("unknown variant 'image_url'");
+    const response = JSON.parse(res.chunks.join('')) as { error: { code: string; message: string } };
+    expect(response.error.code).toBe('unsupported_feature');
+    expect(response.error.message).toContain('input_image');
+    expect(response.error.message).toContain('does not support image input');
+    expect(response.error.message).not.toContain("unknown variant 'image_url'");
+  });
+
+  it('normalizes known text-only image errors sent through SSE', async () => {
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({ authorization: 'Bearer secret' }),
+    }, {
+      fetchImpl: vi.fn(async () => streamResponse([
+        { error: { message: 'unknown variant image_url, expected one of: `text`', status: 400 } },
+      ])) as typeof fetch,
+    });
+    const res = new FakeResponse();
+
+    await handler.handle({ parsedBody: { model: 'm', input: 'hi' }, res: res as never });
+
+    const wire = res.chunks.join('');
+    expect(wire).toContain('event: response.failed');
+    expect(wire).toContain('input_image');
+    expect(wire).toContain('does not support image input');
+    expect(wire).not.toContain('unknown variant image_url');
   });
 
   it('translates non-streaming Chat JSON into a non-streaming Responses response', async () => {

--- a/packages/responses-chat-bridge/src/__tests__/types.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/types.test.ts
@@ -37,6 +37,14 @@ describe('isUnsupportedResponsesImageErrorPayload', () => {
     expect(isUnsupportedResponsesImageErrorPayload(codexUnexpectedResponse(message))).toBe(true);
   });
 
+  it('accepts the bridge image message with user-facing recovery guidance', () => {
+    const message =
+      'Responses feature is not supported by the Chat Completions bridge: input_image\n\n' +
+      'This model does not support image input. Remove the image or switch to a vision-capable model.';
+
+    expect(isUnsupportedResponsesImageErrorPayload(codexUnexpectedResponse(message))).toBe(true);
+  });
+
   it('accepts a Codex error that retains the serialized bridge response body', () => {
     const payload = unsupportedFeaturePayload("input content part 'input_image'");
 

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -100,8 +100,15 @@ function responsesError(status: number, code: string, message: string): Record<s
  * provider JSON to the user when the actionable failure is known.
  */
 function isUnsupportedImageInputUpstreamError(text: string): boolean {
-  return /\bimage_url\b/i.test(text) && /\bexpected\s+['"]?text\b/i.test(text);
+  return (
+    /\bimage_url\b/i.test(text) &&
+    /\bexpected(?:\s+one\s+of:?)?\s+['"`]?text['"`]?\b/i.test(text)
+  );
 }
+
+const UNSUPPORTED_IMAGE_INPUT_MESSAGE =
+  'Responses feature is not supported by the Chat Completions bridge: input_image\n\n' +
+  'This model does not support image input. Remove the image or switch to a vision-capable model.';
 
 async function readErrorText(upstream: Response): Promise<string> {
   try {
@@ -273,7 +280,7 @@ export function createResponsesChatHandler(
             upstream.status,
             unsupportedImageInput ? 'unsupported_feature' : 'upstream_error',
             unsupportedImageInput
-              ? 'This model does not support image input. Remove the image or switch to a vision-capable model.'
+              ? UNSUPPORTED_IMAGE_INPUT_MESSAGE
               : text || `provider returned HTTP ${upstream.status}`,
           ),
         );
@@ -392,14 +399,19 @@ export function createResponsesChatHandler(
           ? event.error
           : null;
         if (streamedError) {
+          const status = typeof streamedError.status === 'number' ? streamedError.status : 502;
           const message = typeof streamedError.message === 'string'
             ? streamedError.message
             : 'provider returned an error event';
           void reportUpstreamError(
-            typeof streamedError.status === 'number' ? streamedError.status : 502,
+            status,
             JSON.stringify(streamedError).slice(0, MAX_ERROR_BODY_CHARS),
           );
-          for (const output of translator.fail(message)) emit(output);
+          const normalizedMessage =
+            status === 400 && isUnsupportedImageInputUpstreamError(message)
+              ? UNSUPPORTED_IMAGE_INPUT_MESSAGE
+              : message;
+          for (const output of translator.fail(normalizedMessage)) emit(output);
           return;
         }
         for (const output of translator.push(event)) emit(output);

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -94,6 +94,15 @@ function responsesError(status: number, code: string, message: string): Record<s
   };
 }
 
+/**
+ * Some OpenAI-compatible text-only providers reject translated image parts as
+ * `image_url` where their schema accepts only `text`. Do not expose that raw
+ * provider JSON to the user when the actionable failure is known.
+ */
+function isUnsupportedImageInputUpstreamError(text: string): boolean {
+  return /\bimage_url\b/i.test(text) && /\bexpected\s+['"]?text\b/i.test(text);
+}
+
 async function readErrorText(upstream: Response): Promise<string> {
   try {
     return (await upstream.text()).slice(0, MAX_ERROR_BODY_CHARS);
@@ -255,10 +264,18 @@ export function createResponsesChatHandler(
         const text = await readErrorText(upstream);
         await reportUpstreamError(upstream.status, text);
         res.off('close', abortUpstream);
+        const unsupportedImageInput =
+          upstream.status === 400 && isUnsupportedImageInputUpstreamError(text);
         writeJson(
           res,
           upstream.status,
-          responsesError(upstream.status, 'upstream_error', text || `provider returned HTTP ${upstream.status}`),
+          responsesError(
+            upstream.status,
+            unsupportedImageInput ? 'unsupported_feature' : 'upstream_error',
+            unsupportedImageInput
+              ? 'This model does not support image input. Remove the image or switch to a vision-capable model.'
+              : text || `provider returned HTTP ${upstream.status}`,
+          ),
         );
         return;
       }

--- a/packages/responses-chat-bridge/src/types.ts
+++ b/packages/responses-chat-bridge/src/types.ts
@@ -379,9 +379,8 @@ export function isResponsesImageContentPartType(
 }
 
 function unsupportedResponsesFeatureFromMessage(message: string): string | null {
-  return message.startsWith(UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX)
-    ? message.slice(UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX.length)
-    : null;
+  if (!message.startsWith(UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX)) return null;
+  return message.slice(UNSUPPORTED_RESPONSES_FEATURE_MESSAGE_PREFIX.length).split('\n', 1)[0] ?? null;
 }
 
 function isUnsupportedResponsesImageFeature(feature: string): boolean {


### PR DESCRIPTION
## 这次改了什么

### 摘要

部分 OpenAI 兼容的纯文本模型（如 DeepSeek V4 Flash）在收到带图片的请求时，会以原始 JSON 抛出 `image_url` schema 拒绝（如 `unknown variant image_url, expected text`）。原先这些原始上游错误直接透传给用户，既看不懂也无法被 Desktop 的图片剔除重试逻辑识别。

本 PR 在 responses-chat-bridge 中识别这类上游 400 错误，归一化为稳定的 `unsupported_feature` 响应并给出可操作指引（移除图片或改用支持视觉的模型）；同时保留不相关 400 的原始错误与 provider error observer 行为。归一化同时覆盖非 SSE 与 SSE 流式错误路径。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#1870
- 本 PR 包含：
  - `handler.ts`：新增 `isUnsupportedImageInputUpstreamError()` 识别纯文本 provider 的 `image_url` 拒绝；命中时把响应归一化为 `unsupported_feature` + 指引消息（非 SSE 与 SSE 路径均覆盖）
  - `types.ts`：`unsupportedResponsesFeatureFromMessage()` 改用 `split('\n', 1)` 只取首行 feature，使带多行指引的消息仍能被 `isUnsupportedResponsesImageErrorPayload` retry 分类器识别
  - `handler.test.ts`、`types.test.ts`：补充归一化与分类行为覆盖
- 明确不包含：不改变成功路径；不改变其他 400 错误的透传行为；错误指引文案的 i18n 不在本 PR 范围（见风险）
- 用户可见变化：纯文本模型拒绝图片时，用户看到可操作指引而非原始 provider JSON，且 Desktop 会自动剔除图片重试
- 是否存在 breaking change：无

### UI 变化

不涉及：仅改动 bridge 错误归一化逻辑，无 UI 代码路径变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-chat-bridge test
结果：133 tests 通过

pnpm --filter @cindy/responses-chat-bridge run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过
```

### 手工验证

不涉及：错误归一化路径已由单测覆盖，无 UI 交互。

### 未执行的验证

package lint 仍报告 `src/translate-request.ts` 中一处 pre-existing 未使用变量（不在本 diff 范围）。

## 风险

### 风险分类

- [x] 协议兼容

### 影响与回滚

- 影响范围：仅当上游返回 HTTP 400 且错误文本匹配 `image_url` + `expected text` 模式时，bridge 返回的 error payload 由 `{code:'upstream_error', message:<原始文本>}` 变为 `{code:'unsupported_feature', message:<指引文案>}`（非 SSE 与 SSE 路径一致）。此变化是故意的，用于让 `isUnsupportedResponsesImageErrorPayload` 识别并触发 Desktop 的图片剔除重试。其余 400 错误、成功路径、provider error observer 均不受影响。
- 回滚 / 降级方式：revert 本 PR。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因