### PR TITLE
test(desktop): 稳定 Windows 导出包条目上限用例

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
@@ -37,8 +37,6 @@ const canSymlink = (() => {
 let workDir: string;
 let ghostDir: string;
 
-// locales 目录 + ghost.json/main.js/locales/en.json 三个文件。
-const BASIC_FIXTURE_ENTRY_COUNT = 4;
 const FILE_WRITE_BATCH_SIZE = 16;
 
 beforeEach(async () => {
@@ -235,8 +233,9 @@ describe('exportGhostPackage', () => {
   it('目录内容超过装入侧条目上限:如实 too_large', async () => {
     // 普通(非 Node)插件装入上限 256 条目;运行期写入的杂散文件可能
     // 把目录撑过上限,导出不能成功却装不回。
-    const extraEntryCount = MAX_BASIC_ZIP_ENTRIES - BASIC_FIXTURE_ENTRY_COUNT + 1;
-    await writeCacheFiles(extraEntryCount);
+    ghostDir = path.join(workDir, 'too-many-entries');
+    await fs.promises.mkdir(ghostDir);
+    await writeCacheFiles(MAX_BASIC_ZIP_ENTRIES + 1);
     const result = await exportGhostPackage('hello', makeDeps());
     expect(result).toEqual({ status: 'error', code: 'too_large' });
   });

--- a/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
@@ -233,8 +233,6 @@ describe('exportGhostPackage', () => {
   it('目录内容超过装入侧条目上限:如实 too_large', async () => {
     // 普通(非 Node)插件装入上限 256 条目;运行期写入的杂散文件可能
     // 把目录撑过上限,导出不能成功却装不回。
-    ghostDir = path.join(workDir, 'too-many-entries');
-    await fs.promises.mkdir(ghostDir);
     await writeCacheFiles(MAX_BASIC_ZIP_ENTRIES + 1);
     const result = await exportGhostPackage('hello', makeDeps());
     expect(result).toEqual({ status: 'error', code: 'too_large' });

--- a/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/exportGhostPackage.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { InstalledGhost } from '../../../shared/ghost';
 import { exportGhostPackage, sanitizeExportFileNamePart } from '../exportGhostPackage';
+import { MAX_BASIC_ZIP_ENTRIES } from '../GhostManager';
 import { signGhostPackage } from '../ghostSignature';
 
 /** 测试用发布者密钥对(每次进程一对,签名/验签都走真实 ed25519)。 */
@@ -36,6 +37,10 @@ const canSymlink = (() => {
 let workDir: string;
 let ghostDir: string;
 
+// locales 目录 + ghost.json/main.js/locales/en.json 三个文件。
+const BASIC_FIXTURE_ENTRY_COUNT = 4;
+const FILE_WRITE_BATCH_SIZE = 16;
+
 beforeEach(async () => {
   workDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'cindy-ghost-export-test-'));
   ghostDir = path.join(workDir, 'hello');
@@ -59,8 +64,26 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await fs.promises.rm(workDir, { recursive: true, force: true });
+  await fs.promises.rm(workDir, {
+    recursive: true,
+    force: true,
+    maxRetries: process.platform === 'win32' ? 5 : 0,
+    retryDelay: 20,
+  });
 });
+
+async function writeCacheFiles(count: number): Promise<void> {
+  for (let start = 0; start < count; start += FILE_WRITE_BATCH_SIZE) {
+    const batchSize = Math.min(FILE_WRITE_BATCH_SIZE, count - start);
+    const results = await Promise.allSettled(
+      Array.from({ length: batchSize }, (_, offset) =>
+        fs.promises.writeFile(path.join(ghostDir, `cache-${start + offset}.dat`), 'x'),
+      ),
+    );
+    const failure = results.find((result) => result.status === 'rejected');
+    if (failure?.status === 'rejected') throw failure.reason;
+  }
+}
 
 function makeGhost(): InstalledGhost {
   return {
@@ -212,9 +235,8 @@ describe('exportGhostPackage', () => {
   it('目录内容超过装入侧条目上限:如实 too_large', async () => {
     // 普通(非 Node)插件装入上限 256 条目;运行期写入的杂散文件可能
     // 把目录撑过上限,导出不能成功却装不回。
-    for (let i = 0; i < 260; i++) {
-      await fs.promises.writeFile(path.join(ghostDir, `cache-${i}.dat`), 'x');
-    }
+    const extraEntryCount = MAX_BASIC_ZIP_ENTRIES - BASIC_FIXTURE_ENTRY_COUNT + 1;
+    await writeCacheFiles(extraEntryCount);
     const result = await exportGhostPackage('hello', makeDeps());
     expect(result).toEqual({ status: 'error', code: 'too_large' });
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `exportGhostPackage.test.ts` 在 Windows runner 上偶发超过 Vitest 20 秒用例超时，并在超时后与 `afterEach` 清理竞争产生 `ENOTEMPTY` 的问题。

测试现在只创建刚好足以越过普通插件条目上限的夹具文件，并使用固定小批次完成有界并发写入。每批写入全部 settle 后才进入导出逻辑，避免遗留异步文件任务；Windows 递归清理增加有限重试作为文件系统兜底。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：client-ci 31107783352 的 Windows unit tests (2/2) 偶发失败
- 本 PR 包含：`exportGhostPackage.test.ts` 的超限夹具创建和临时目录清理稳定性修复
- 明确不包含：生产导出逻辑、Vitest timeout 调整、PR #1944 的文档改动
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅修改 Desktop main 单元测试，无视觉、交互或文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/exportGhostPackage.test.ts -t 目录内容超过装入侧条目上限:如实 too_large --reporter=verbose
结果：通过，目标用例 48ms

完整 exportGhostPackage.test.ts 连续运行 20 轮
结果：20/20 通过，共 520 个用例，无 ENOTEMPTY

pnpm --filter desktop run --if-present typecheck
结果：通过

XDT_UNIT_TEST_SHARD=2/2 pnpm test:unit
结果：通过；本机 macOS 下 Desktop 分片 47.2s

pnpm test:unit
结果：通过；Desktop 全量 78.2s

pnpm check:dco
结果：通过，1 个提交已签名
```

文件级 ESLint 在本分支和 `origin/main` 上均报告相同的 7 个既有错误（5 个 `no-explicit-any`、2 个 `no-unused-vars`）；本次改动未新增 lint 问题，未扩大范围修复。

### 手工验证

不涉及。

### 未执行的验证

- 尚未在 Windows runner 上重复运行；由本 PR 的 Windows 两分片 CI 验证真实文件系统行为。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop main 测试夹具和测试临时目录清理；不改变生产行为。
- Windows 考量：小文件写入改为每批 16 个的有界并发，清理仅在 Windows 使用最多 5 次、间隔 20ms 的重试。
- macOS 考量：保持原有清理次数，不引入额外等待；本机定向、分片和根全量测试均通过。
- 回滚 / 降级方式：回滚本 PR 的单个测试提交即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及）
- [x] 已确认测试结果或说明未执行原因