### PR TITLE
refactor(desktop): 将飞书通知和企业微信群通知迁移至 IM 机器人设置页

### DIFF
--- a/apps/desktop/src/renderer/components/settings/FeishuBotNotificationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/FeishuBotNotificationSection.tsx
@@ -1,25 +1,56 @@
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useFeishuBot } from '@/hooks/useFeishuBot';
+import { useFeishuNotificationSettings } from '@/hooks/useFeishuNotificationSettings';
 import { ImLifecycleAnnouncementSection } from './ImLifecycleAnnouncementSection';
 
 export function FeishuBotNotificationSection() {
   const {
     hasSavedCreds,
+    ownerOpenId,
     lifecycleAnnouncement,
     setLifecycleAnnouncement,
   } = useFeishuBot();
+  const { enabled: sessionNotifyEnabled, setEnabled: setSessionNotifyEnabled } =
+    useFeishuNotificationSettings();
   const { t } = useTranslation();
+
+  const feishuReady = Boolean(ownerOpenId);
+
+  // 兜底复位:覆盖"localStorage 残留 true 但 owner 未绑"的边缘态(旧版升级 /
+  // 异常退出 / 其他 window 改的)。
+  useEffect(() => {
+    if (!feishuReady && sessionNotifyEnabled) {
+      setSessionNotifyEnabled(false);
+    }
+  }, [feishuReady, sessionNotifyEnabled, setSessionNotifyEnabled]);
 
   if (!hasSavedCreds) return null;
 
   return (
-    <ImLifecycleAnnouncementSection
-      label={t('settings.feishuBot.lifecycleAnnouncement.label')}
-      cellLabel={t('settings.feishuBot.lifecycleAnnouncement.cellLabel')}
-      hint={t('settings.feishuBot.lifecycleAnnouncement.hint')}
-      checked={lifecycleAnnouncement}
-      onCheckedChange={setLifecycleAnnouncement}
-    />
+    <>
+      <ImLifecycleAnnouncementSection
+        label={t('settings.feishuBot.lifecycleAnnouncement.label')}
+        cellLabel={t('settings.feishuBot.lifecycleAnnouncement.cellLabel')}
+        hint={t('settings.feishuBot.lifecycleAnnouncement.hint')}
+        checked={lifecycleAnnouncement}
+        onCheckedChange={setLifecycleAnnouncement}
+      />
+      <div className="h-px w-full bg-[var(--border-default)]" />
+      <ImLifecycleAnnouncementSection
+        label={t('settings.feishuBot.sessionNotification.label')}
+        cellLabel={t('settings.feishuBot.sessionNotification.cellLabel')}
+        hint={
+          feishuReady
+            ? t('settings.feishuBot.sessionNotification.hint')
+            : t('settings.feishuBot.sessionNotification.disabledHint')
+        }
+        checked={sessionNotifyEnabled && feishuReady}
+        onCheckedChange={(next) => {
+          if (feishuReady) setSessionNotifyEnabled(next);
+        }}
+      />
+    </>
   );
 }

--- a/apps/desktop/src/renderer/components/settings/FeishuBotNotificationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/FeishuBotNotificationSection.tsx
@@ -47,6 +47,7 @@ export function FeishuBotNotificationSection() {
             : t('settings.feishuBot.sessionNotification.disabledHint')
         }
         checked={sessionNotifyEnabled && feishuReady}
+        disabled={!feishuReady}
         onCheckedChange={(next) => {
           if (feishuReady) setSessionNotifyEnabled(next);
         }}

--- a/apps/desktop/src/renderer/components/settings/ImLifecycleAnnouncementSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ImLifecycleAnnouncementSection.tsx
@@ -7,6 +7,7 @@ export function ImLifecycleAnnouncementSection(props: {
   hint: string;
   checked: boolean;
   onCheckedChange: (enabled: boolean) => void;
+  disabled?: boolean;
 }) {
   return (
     <div className="flex flex-col gap-[14px]">
@@ -36,6 +37,7 @@ export function ImLifecycleAnnouncementSection(props: {
         <Switch
           checked={props.checked}
           onCheckedChange={props.onCheckedChange}
+          disabled={props.disabled}
           aria-label={props.label}
         />
       </div>

--- a/apps/desktop/src/renderer/components/settings/NotificationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/NotificationSection.tsx
@@ -1,48 +1,21 @@
 /**
  * NotificationSection — Settings 页"系统通知"区块。
  *
- * 两个个人通知开关:
- *   1. 桌面通知 — CC Agent session 完成 / 待回复时弹系统 toast(默认开)。
- *   2. 飞书通知 — 同源触发,失焦时给 bot owner 私聊一条文本(默认关)。
- * 企业微信群是共享通道,总开关控制通道可用性;每个自动操作仍需显式选择。
- *
- * 飞书开关的可用前提是 bot 已绑定 ownerOpenId(用户至少私聊过 bot 一次);
- * 未绑定时开关禁用,并在 hint 里提示去"飞书机器人" tab 完成配置/绑定。
+ * 桌面通知 — CC Agent session 完成 / 待回复时弹系统 toast(默认开)。
+ * 飞书通知与企业微信群通知已迁移至「IM 机器人」页各自对应的渠道卡片内。
  *
  * 沿用 AppearanceSection 的卡片样式(rounded 12 / Card bg / 1px Board / padding 20)。
  */
 
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Loader2, Send, Trash2 } from 'lucide-react';
-import { toast } from '@/lib/toast';
 
 import { Switch } from '@/components/ui/switch';
 import { cn } from '@/lib/utils';
 import { useNotificationSettings } from '@/hooks/useNotificationSettings';
-import { useFeishuNotificationSettings } from '@/hooks/useFeishuNotificationSettings';
-import { useFeishuBot } from '@/hooks/useFeishuBot';
-import { useWecomGroupNotificationSettings } from '@/hooks/useWecomGroupNotificationSettings';
 
 export function NotificationSection() {
   const { enabled, setEnabled } = useNotificationSettings();
-  const { enabled: feishuEnabled, setEnabled: setFeishuEnabled } = useFeishuNotificationSettings();
-  // ownerOpenId 才是 sendMarkdownText 的硬前置(status='connected' 也可能 owner 未绑),
-  // 用它作为飞书开关的可用门槛,与主进程实际兜底逻辑对齐。
-  const { ownerOpenId } = useFeishuBot();
-  const wecomGroup = useWecomGroupNotificationSettings();
-  const [webhookUrl, setWebhookUrl] = useState('');
-  const feishuReady = Boolean(ownerOpenId);
   const { t } = useTranslation();
-
-  // 兜底复位:覆盖"localStorage 残留 true 但 owner 未绑"的边缘态(旧版升级 /
-  // 异常退出 / 其他 window 改的)。解绑动作本身已在 useFeishuBot.clear() 命中,
-  // 这里只是双层保险——任何时候 Settings 挂载到飞书未绑都同步落 false。
-  useEffect(() => {
-    if (!feishuReady && feishuEnabled) {
-      setFeishuEnabled(false);
-    }
-  }, [feishuReady, feishuEnabled, setFeishuEnabled]);
 
   return (
     <div className="flex flex-col gap-[14px]">
@@ -76,161 +49,6 @@ export function NotificationSection() {
           onCheckedChange={setEnabled}
           aria-label={t('settings.notifications.sessionDoneAria')}
         />
-      </div>
-
-      {/* 飞书通知 — 同卡片样式,未绑定时仅 Switch disabled,卡片底色/边框与上方对齐 */}
-      <div
-        className={cn(
-          'flex items-center justify-between gap-3 rounded-xl p-5',
-          'bg-[var(--settings-theme-card-bg)]',
-          'border border-[var(--settings-theme-card-border)]',
-        )}
-      >
-        <div className="flex min-w-0 flex-col gap-1">
-          <p
-            className="text-13 font-medium text-[var(--settings-section-sublabel)]"
-            style={{ letterSpacing: '0.12px' }}
-          >
-            {t('settings.notifications.feishuLabel')}
-          </p>
-          <p className="text-12 leading-[1.4] text-[var(--settings-section-sublabel)] opacity-70">
-            {feishuReady
-              ? t('settings.notifications.feishuHint')
-              : t('settings.notifications.feishuDisabledHint')}
-          </p>
-        </div>
-
-        <Switch
-          checked={feishuEnabled && feishuReady}
-          onCheckedChange={setFeishuEnabled}
-          disabled={!feishuReady}
-          aria-label={t('settings.notifications.feishuAria')}
-        />
-      </div>
-
-      <div
-        className={cn(
-          'flex flex-col gap-4 rounded-xl p-5',
-          'bg-[var(--settings-theme-card-bg)]',
-          'border border-[var(--settings-theme-card-border)]',
-        )}
-      >
-        <div className="flex items-center justify-between gap-3">
-          <div className="flex min-w-0 flex-col gap-1">
-            <p
-              className="text-13 font-medium text-[var(--settings-section-sublabel)]"
-              style={{ letterSpacing: '0.12px' }}
-            >
-              {t('settings.notifications.wecomGroupLabel')}
-            </p>
-            <p className="text-12 leading-[1.4] text-[var(--settings-section-sublabel)] opacity-70">
-              {wecomGroup.configured
-                ? t('settings.notifications.wecomGroupConfiguredHint', {
-                    maskedKey: wecomGroup.maskedKey,
-                  })
-                : t('settings.notifications.wecomGroupHint')}
-            </p>
-          </div>
-          <Switch
-            checked={wecomGroup.enabled && wecomGroup.configured}
-            onCheckedChange={(next) => {
-              void wecomGroup
-                .setEnabled(next)
-                .catch(() => toast.error(t('settings.notifications.wecomGroupToggleFailed')));
-            }}
-            disabled={!wecomGroup.configured || wecomGroup.busy}
-            aria-label={t('settings.notifications.wecomGroupAria')}
-          />
-        </div>
-
-        {wecomGroup.configured ? (
-          <div className="flex gap-2">
-            <button
-              type="button"
-              disabled={wecomGroup.busy}
-              onClick={() => {
-                void wecomGroup
-                  .test(t('settings.notifications.wecomGroupTestMessage'))
-                  .then(() => toast.success(t('settings.notifications.wecomGroupTestSuccess')))
-                  .catch(() => toast.error(t('settings.notifications.wecomGroupTestFailed')));
-              }}
-              className={cn(
-                'flex h-9 flex-1 items-center justify-center gap-1.5 rounded-full',
-                'border border-[var(--settings-btn-secondary-border)]',
-                'bg-[var(--settings-btn-secondary-bg)] text-12 font-medium',
-                'text-[var(--settings-btn-secondary-text)]',
-                wecomGroup.busy && 'cursor-not-allowed opacity-40',
-              )}
-            >
-              {wecomGroup.busy ? <Loader2 size={13} className="animate-spin" /> : <Send size={13} />}
-              {t('settings.notifications.wecomGroupTest')}
-            </button>
-            <button
-              type="button"
-              disabled={wecomGroup.busy}
-              onClick={() => {
-                void wecomGroup
-                  .clear()
-                  .then(() => toast.success(t('settings.notifications.wecomGroupCleared')))
-                  .catch(() => toast.error(t('settings.notifications.wecomGroupClearFailed')));
-              }}
-              className={cn(
-                'flex h-9 flex-1 items-center justify-center gap-1.5 rounded-full',
-                'border border-[var(--settings-btn-secondary-border)]',
-                'bg-[var(--settings-btn-secondary-bg)] text-12 font-medium',
-                'text-[var(--settings-btn-secondary-text)]',
-                wecomGroup.busy && 'cursor-not-allowed opacity-40',
-              )}
-            >
-              <Trash2 size={13} />
-              {t('settings.notifications.wecomGroupClear')}
-            </button>
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            <input
-              type="password"
-              value={webhookUrl}
-              onChange={(event) => setWebhookUrl(event.target.value)}
-              placeholder={t('settings.notifications.wecomGroupPlaceholder')}
-              autoComplete="new-password"
-              spellCheck={false}
-              className={cn(
-                'h-[42px] w-full rounded-full px-[14px]',
-                'border border-[var(--settings-input-border)]',
-                'bg-[var(--settings-input-bg)] text-13 text-[var(--settings-input-text)]',
-                'placeholder:text-[var(--settings-input-placeholder)] outline-none',
-                'focus:border-[var(--settings-input-border-focus)]',
-              )}
-            />
-            <button
-              type="button"
-              disabled={wecomGroup.busy || !webhookUrl.trim()}
-              onClick={() => {
-                void wecomGroup
-                  .saveAndTest(
-                    webhookUrl,
-                    t('settings.notifications.wecomGroupTestMessage'),
-                  )
-                  .then(() => {
-                    setWebhookUrl('');
-                    toast.success(t('settings.notifications.wecomGroupSaveSuccess'));
-                  })
-                  .catch(() => toast.error(t('settings.notifications.wecomGroupSaveFailed')));
-              }}
-              className={cn(
-                'flex h-[42px] items-center justify-center gap-1.5 rounded-full',
-                'border border-[var(--settings-btn-primary-border)]',
-                'bg-[var(--settings-btn-primary-bg)] text-13 font-medium',
-                'text-[var(--settings-btn-primary-text)]',
-                (wecomGroup.busy || !webhookUrl.trim()) && 'cursor-not-allowed opacity-40',
-              )}
-            >
-              {wecomGroup.busy ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
-              {t('settings.notifications.wecomGroupSaveAndTest')}
-            </button>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
@@ -373,7 +373,7 @@ export function WecomBotSection({
               onClick={() => {
                 void wecomGroup
                   .saveAndTest(
-                    webhookUrl,
+                    webhookUrl.trim(),
                     t('settings.notifications.wecomGroupTestMessage'),
                   )
                   .then(() => {

--- a/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
@@ -359,6 +359,7 @@ export function WecomBotSection({
               placeholder={t('settings.notifications.wecomGroupPlaceholder')}
               autoComplete="new-password"
               spellCheck={false}
+              aria-label={t('settings.notifications.wecomGroupLabel')}
               className={cn(
                 'h-[42px] w-full rounded-full px-[14px]',
                 'border border-[var(--settings-input-border)]',

--- a/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WecomBotSection.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Eye, EyeOff, Loader2, Trash2 } from 'lucide-react';
+import { Check, Eye, EyeOff, Loader2, Send, Trash2 } from 'lucide-react';
 
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
+import { Switch } from '@/components/ui/switch';
 import { useWecomBot } from '@/hooks/useWecomBot';
+import { useWecomGroupNotificationSettings } from '@/hooks/useWecomGroupNotificationSettings';
 import { cn } from '@/lib/utils';
+import { toast } from '@/lib/toast';
 import { ImChannelSettingsCard, useImChannelSettingsSummary } from './ImChannelSettingsCard';
 import { ImDefaultSettingsSection } from './ImDefaultSettingsSection';
 
@@ -64,6 +67,8 @@ export function WecomBotSection({
   const [routeSummary, setRouteSummary] = useImChannelSettingsSummary('wecom');
   const { confirm } = useConfirmDialog();
   const { t } = useTranslation();
+  const wecomGroup = useWecomGroupNotificationSettings();
+  const [webhookUrl, setWebhookUrl] = useState('');
 
   const handleDisconnect = useCallback(async () => {
     const approved = await confirm({
@@ -272,6 +277,125 @@ export function WecomBotSection({
           </div>
         </div>
       )}
+      <div className="h-px w-full bg-[var(--border-default)]" />
+      <div className="flex flex-col gap-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-col gap-1">
+            <p
+              className="text-13 font-medium text-[var(--settings-section-sublabel)]"
+              style={{ letterSpacing: '0.12px' }}
+            >
+              {t('settings.notifications.wecomGroupLabel')}
+            </p>
+            <p className="text-12 leading-[1.4] text-[var(--settings-section-sublabel)] opacity-70">
+              {wecomGroup.configured
+                ? t('settings.notifications.wecomGroupConfiguredHint', {
+                    maskedKey: wecomGroup.maskedKey,
+                  })
+                : t('settings.notifications.wecomGroupHint')}
+            </p>
+          </div>
+          <Switch
+            checked={wecomGroup.enabled && wecomGroup.configured}
+            onCheckedChange={(next) => {
+              void wecomGroup
+                .setEnabled(next)
+                .catch(() => toast.error(t('settings.notifications.wecomGroupToggleFailed')));
+            }}
+            disabled={!wecomGroup.configured || wecomGroup.busy}
+            aria-label={t('settings.notifications.wecomGroupAria')}
+          />
+        </div>
+
+        {wecomGroup.configured ? (
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={wecomGroup.busy}
+              onClick={() => {
+                void wecomGroup
+                  .test(t('settings.notifications.wecomGroupTestMessage'))
+                  .then(() => toast.success(t('settings.notifications.wecomGroupTestSuccess')))
+                  .catch(() => toast.error(t('settings.notifications.wecomGroupTestFailed')));
+              }}
+              className={cn(
+                'flex h-9 flex-1 items-center justify-center gap-1.5 rounded-full',
+                'border border-[var(--settings-btn-secondary-border)]',
+                'bg-[var(--settings-btn-secondary-bg)] text-12 font-medium',
+                'text-[var(--settings-btn-secondary-text)]',
+                wecomGroup.busy && 'cursor-not-allowed opacity-40',
+              )}
+            >
+              {wecomGroup.busy ? <Loader2 size={13} className="animate-spin" /> : <Send size={13} />}
+              {t('settings.notifications.wecomGroupTest')}
+            </button>
+            <button
+              type="button"
+              disabled={wecomGroup.busy}
+              onClick={() => {
+                void wecomGroup
+                  .clear()
+                  .then(() => toast.success(t('settings.notifications.wecomGroupCleared')))
+                  .catch(() => toast.error(t('settings.notifications.wecomGroupClearFailed')));
+              }}
+              className={cn(
+                'flex h-9 flex-1 items-center justify-center gap-1.5 rounded-full',
+                'border border-[var(--settings-btn-secondary-border)]',
+                'bg-[var(--settings-btn-secondary-bg)] text-12 font-medium',
+                'text-[var(--settings-btn-secondary-text)]',
+                wecomGroup.busy && 'cursor-not-allowed opacity-40',
+              )}
+            >
+              <Trash2 size={13} />
+              {t('settings.notifications.wecomGroupClear')}
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2">
+            <input
+              type="password"
+              value={webhookUrl}
+              onChange={(event) => setWebhookUrl(event.target.value)}
+              placeholder={t('settings.notifications.wecomGroupPlaceholder')}
+              autoComplete="new-password"
+              spellCheck={false}
+              className={cn(
+                'h-[42px] w-full rounded-full px-[14px]',
+                'border border-[var(--settings-input-border)]',
+                'bg-[var(--settings-input-bg)] text-13 text-[var(--settings-input-text)]',
+                'placeholder:text-[var(--settings-input-placeholder)] outline-none',
+                'focus:border-[var(--settings-input-border-focus)]',
+              )}
+            />
+            <button
+              type="button"
+              disabled={wecomGroup.busy || !webhookUrl.trim()}
+              onClick={() => {
+                void wecomGroup
+                  .saveAndTest(
+                    webhookUrl,
+                    t('settings.notifications.wecomGroupTestMessage'),
+                  )
+                  .then(() => {
+                    setWebhookUrl('');
+                    toast.success(t('settings.notifications.wecomGroupSaveSuccess'));
+                  })
+                  .catch(() => toast.error(t('settings.notifications.wecomGroupSaveFailed')));
+              }}
+              className={cn(
+                'flex h-[42px] items-center justify-center gap-1.5 rounded-full',
+                'border border-[var(--settings-btn-primary-border)]',
+                'bg-[var(--settings-btn-primary-bg)] text-13 font-medium',
+                'text-[var(--settings-btn-primary-text)]',
+                (wecomGroup.busy || !webhookUrl.trim()) && 'cursor-not-allowed opacity-40',
+              )}
+            >
+              {wecomGroup.busy ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+              {t('settings.notifications.wecomGroupSaveAndTest')}
+            </button>
+          </div>
+        )}
+      </div>
     </ImChannelSettingsCard>
   );
 }

--- a/apps/desktop/src/renderer/features/scheduler/components/ScheduleFormDialog.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/ScheduleFormDialog.tsx
@@ -421,7 +421,7 @@ export function ScheduleFormDialog({
   };
   const goConfigWecomGroup = () => {
     onOpenChange(false);
-    navigate('/settings?tab=general&section=notifications');
+    navigate('/settings?tab=im-bot&imGroup=personal');
   };
 
   const projectOptions = useProjectPickerOptions();

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -1727,6 +1727,12 @@
         "cellLabel": "Message notification",
         "hint": "Send a notification message to the Bot on connect/disconnect"
       },
+      "sessionNotification": {
+        "label": "Session notifications",
+        "cellLabel": "Send a Feishu / Lark DM when a session finishes or needs a reply",
+        "hint": "Sends a private message via the linked Feishu or Lark bot; only when the window is unfocused.",
+        "disabledHint": "First set up the bot and DM it once to complete binding."
+      },
       "bind": "Bind"
     },
     "wechatBot": {

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -1726,6 +1726,12 @@
         "cellLabel": "メッセージ通知",
         "hint": "接続・切断時に Bot へ通知メッセージを送信"
       },
+      "sessionNotification": {
+        "label": "セッション完了通知",
+        "cellLabel": "セッション完了または応答が必要なときに Feishu / Lark メッセージを送信",
+        "hint": "連携済みの Feishu または Lark ボットを通じて DM を送信します。ウィンドウが非アクティブなときのみ送信されます。",
+        "disabledHint": "先に Bot を設定し、バインドを完了するために DM を送信してください。"
+      },
       "bind": "連携"
     },
     "wechatBot": {

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -1726,6 +1726,12 @@
         "cellLabel": "메시지 알림",
         "hint": "연결/해제 시 Bot에 알림 메시지를 전송합니다"
       },
+      "sessionNotification": {
+        "label": "세션 완료 알림",
+        "cellLabel": "세션 완료 또는 응답 필요 시 Feishu / Lark 메시지 전송",
+        "hint": "연동된 Feishu 또는 Lark 봇을 통해 DM을 보냅니다. 창이 비활성 상태일 때만 전송됩니다.",
+        "disabledHint": "먼저 Bot을 설정하고 바인딩을 완료하려면 DM을 보내주세요."
+      },
       "bind": "연동"
     },
     "wechatBot": {

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -1726,6 +1726,12 @@
         "cellLabel": "消息通知",
         "hint": "上下线时向 Bot 发送通知消息"
       },
+      "sessionNotification": {
+        "label": "任务完成通知",
+        "cellLabel": "任务完成或需要回复时发送飞书 / Lark 消息",
+        "hint": "通过已绑定的飞书或 Lark 机器人，向你私聊发送一条消息；仅在窗口失焦时发送。",
+        "disabledHint": "需要先配置 Bot 并向它发送一条消息以完成绑定。"
+      },
       "bind": "绑定"
     },
     "wechatBot": {


### PR DESCRIPTION
## 这次改了什么

### 摘要
将"设置 > 通用 > 通知"中的两个 IM 通知功能迁移到"设置 > IM 机器人"各自对应的渠道卡片中。

- **飞书通知**：从通用通知页移到 IM机器人页飞书/Lark Bot 卡片展开项内，与原有的"上下线通告"并列显示为两个开关
- **企业微信群通知**：从通用通知页移到 IM机器人页企业微信 Bot 卡片底部，webhook 配置逻辑不变

### 变更类型
- [x] `refactor` 重构

### 范围
- 关联 Issue / 需求：无
- 本 PR 包含：NotificationSection 精简、FeishuBotNotificationSection 扩展（新增"任务完成通知"开关）、WecomBotSection 增加群通知配置区域、ScheduleFormDialog 跳转修正、四语 i18n
- 明确不包含：底层通知逻辑改动（notificationService / notifier / wecomGroupNotification 均不动）
- 用户可见变化：
  - 设置 > 通用 > 通知：只保留桌面通知开关
  - IM机器人页飞书卡片：展开后显示"上下线通告"和"任务完成通知"两个开关
  - IM机器人页企业微信卡片：底部新增群通知 webhook 配置（开关/测试/清除）
- 是否存在 breaking change：无

### UI 变化
- 引用的设计规范：`docs/design-rules/DESIGN.md` — 复用已有 `ImLifecycleAnnouncementSection` 和 `ImChannelSettingsCard` 组件样式与间距，不新增独立视觉规范

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：所有 package 通过（仅 maker-core 有 1 个预存 PiAgent 图像输入测试失败，与本次改动无关）

pnpm --filter desktop run --if-present typecheck
结果：无错误
```

### 手工验证
- 打开设置 > 通用 > 通知 — 确认只保留桌面通知开关
- 打开设置 > IM机器人 > 个人栏，展开飞书卡片 — 确认上下线通告和任务完成通知两个开关
- 展开企业微信卡片 — 确认底部群通知 webhook 配置区域
- 打开定时任务编辑弹窗 — 确认"配置企微群通知"链接跳转到 IM机器人页

### 未执行的验证
- 实机目检：因 worktree 环境限制，未做 Light/Dark 双模式实机目检

## 风险

### 风险分类
- [x] 无已知风险

### 影响与回滚
- 影响范围：仅 settings 页 UI 布局和 i18n 文件，不涉及底层通知逻辑
- 回滚 / 降级方式：revert 该 PR

### 提交前检查
- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果（单元测试 + typecheck）

---

### 附：飞书通知与定时任务勾选的关系说明

两者是**独立路径**，互不干扰：

| | 飞书 | 企业微信 |
|---|---|---|
| IM机器人页开关控制 | 手动任务的通知 | 定时任务通知的**总开关** |
| 定时任务勾选控制 | 定时任务的通知 | 定时任务通知的**按任务开关** |
| 两层关系 | **独立**（各管各的） | **AND**（两层都开才发） |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1902" height="1690" alt="image" src="https://github.com/user-attachments/assets/2a1fee84-2100-438e-9b3f-004e24f64144" />
<img width="1894" height="1516" alt="image" src="https://github.com/user-attachments/assets/81ddd753-c837-46aa-816a-d7cc4aa904f3" />
