### PR TITLE
test(desktop): cover restoring deleted Codex imports

### DIFF
--- a/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
+++ b/apps/desktop/src/main/__tests__/codexLocalSessions.test.ts
@@ -392,6 +392,39 @@ describe('Codex local session import', () => {
     expect(rows).toEqual([{ id: `codex-${threadId}`, title: 'Import Me' }]);
   });
 
+  it('restores a soft-deleted imported Codex session without creating a duplicate', async () => {
+    const dbPath = createStateDb(externalHome);
+    const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);
+    fs.mkdirSync(path.dirname(rolloutPath), { recursive: true });
+    fs.writeFileSync(rolloutPath, '');
+    insertThread(dbPath, threadId, rolloutPath, { updatedAt: 2_000, title: 'Restored from Codex' });
+
+    const localId = `codex-${threadId}`;
+    insertImportedCodexSession(currentTestDb(), localId, threadId);
+    currentTestDb().prepare('UPDATE sessions SET status = ? WHERE id = ?').run('deleted', localId);
+
+    const result = await importExternalCodexSessions([threadId]);
+
+    expect(result).toMatchObject({ scanned: 1, inserted: 0, updated: 1 });
+    const sessions = currentTestDb()
+      .prepare(
+        `
+        SELECT id, title, status, sdk_session_id AS sdkSessionId
+        FROM sessions
+        WHERE sdk_session_id = ?
+      `,
+      )
+      .all(threadId);
+    expect(sessions).toEqual([
+      {
+        id: localId,
+        title: 'Restored from Codex',
+        status: 'active',
+        sdkSessionId: threadId,
+      },
+    ]);
+  });
+
   it('normalizes Windows backslash cwd to storage form on import (#537)', async () => {
     const dbPath = createStateDb(externalHome);
     const rolloutPath = path.join(externalHome, 'sessions', `rollout-2026-05-13-${threadId}.jsonl`);


### PR DESCRIPTION
## 这次改了什么

### 摘要

为 Codex 本地任务导入补上一条端到端回归测试：用户在 Cindy 软删除已导入的任务后，再从同一 Codex thread 导入时，应恢复原任务而不是消失或创建重复项。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1929
- 本 PR 包含：断言同一 `sdk_session_id` 重导后保留原 ID、恢复 `active` 状态、返回 `updated: 1`，且不产生重复记录
- 明确不包含：改变导入、删除或项目隐藏的运行时行为
- 用户可见变化：无；防止已存在的恢复行为在未来回归
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅新增主进程本地导入回归测试，无 UI 代码或视觉交互变更。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/codexLocalSessions.test.ts --reporter=dot
结果：118 个测试通过

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit
结果：通过（373 passed, 1 skipped）
```

### 手工验证

不涉及：测试使用内存 SQLite 和外部 Codex state/rollout fixture，覆盖导入、软删、再次导入的完整本地数据链。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅测试覆盖。
- 回滚 / 降级方式：回退本提交即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
