### PR TITLE
fix(desktop): lazify bundled ripgrep probe in runtime-configs (#1956)

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -395,6 +395,7 @@ import {
   waitForInitialCustomMcpRefresh,
 } from './maker-host/index.js';
 import { createDynamicMaker } from './maker-host/dynamic-maker.js';
+import { ensureBundledRipgrepReady } from './maker-host/runtime-configs.js';
 import {
   ensureActiveCatalogLoaded,
   refreshCustomProvidersIntoCatalog,
@@ -4347,6 +4348,29 @@ const registerIpcHandlers = () => {
       };
     }
 
+    // ── Phase 2.5: bundled ripgrep(必需,codex spawn env 与 file-browser 搜索的
+    // 硬依赖)──────────────────────────────────────────────────────────────
+    // 探测已惰性化(import 不再触发,issue #1956),启动期 fail-fast 落在 splash
+    // 这里:缺失时与 claude/codex binary 缺失同一体验(splash failed + 可重试,
+    // dev 补跑 pnpm install:ripgrep 后重试即过),而不是 import 期硬崩、也不是
+    // maker:* IPC 静默不注册的降级启动。memoize 后此处探测近零成本。
+    try {
+      ensureBundledRipgrepReady();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      // splash 失败态 UI 不渲染 error 字段,这行日志是缺 rg 时唯一的诊断出口
+      // (补装指引在 message 里);与下方 pi 失败的 console.warn 同一既有惯例。
+      console.error('[bootstrap-electron] bundled ripgrep check failed:', message);
+      return {
+        claudeCode: { status: 'passed' as const, path: claudeRes.path },
+        codex: { status: 'passed' as const, path: codexRes.path },
+        pi: { status: 'skipped' as const },
+        ripgrep: { status: 'failed' as const, error: message },
+        allPassed: false,
+        platform,
+      };
+    }
+
     // ── Phase 3: pi 段（可选,失败不阻塞启动）──────────────────────────────────
     // broadcastFailure: false —— pi 下载失败不能把 splash 打进失败态;静默禁用
     // 本次 pi 注册，Claude Code / Codex 与 Cindy 本身仍照常可用。
@@ -4394,6 +4418,7 @@ const registerIpcHandlers = () => {
       claudeCode: { status: 'passed' as const, path: claudeRes.path },
       codex: { status: 'passed' as const, path: codexRes.path },
       pi: piInfo,
+      ripgrep: { status: 'passed' as const },
       allPassed: true,
       platform,
     };

--- a/apps/desktop/src/main/maker-host/__tests__/claudeAuthAdapterOAuthEnv.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/claudeAuthAdapterOAuthEnv.test.ts
@@ -28,10 +28,8 @@ const h = vi.hoisted(() => ({
 vi.mock('electron', () => ({
   app: {
     getPath: () => '/tmp/xdt-test-userdata-nonexistent',
-    getAppPath: () => '/tmp/xdt-test-userdata-nonexistent',
-    // isPackaged=false:runtime-configs 模块级的 bundledRipgrepDir 在 packaged 分支
-    // 依赖 process.resourcesPath(测试进程为 undefined,直接抛)——走 dev 分支绕开。
-    isPackaged: false,
+    // ripgrep 探测已惰性化(issue #1956):runtime-configs import 期不再读
+    // getAppPath / isPackaged,这里无需再补。
   },
   safeStorage: { isEncryptionAvailable: () => h.encryptionAvailable },
 }));

--- a/apps/desktop/src/main/maker-host/__tests__/runtimeConfigsRipgrep.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/runtimeConfigsRipgrep.test.ts
@@ -1,0 +1,121 @@
+/**
+ * runtimeConfigsRipgrep.test.ts —— issue #1956 回归守卫:
+ * runtime-configs 的 bundled ripgrep 探测必须**惰性化**。
+ *
+ * 固化三条契约:
+ *   1. import 零探测:electron mock 故意不提供 getAppPath / isPackaged,
+ *      import runtime-configs 不得炸(纯 node / vitest 收集期安全)。
+ *   2. 惰性 fail-fast:pathPrepends / getRipgrepBinaryPath /
+ *      ensureBundledRipgrepReady 在 rg 缺失时**访问才** throw,且失败不缓存
+ *      (补装 rg 后同进程重试即可成功)。
+ *   3. 成功结果 memoize:pathPrepends 每次 codex spawn 都读、
+ *      getRipgrepBinaryPath 每次 file-browser 搜索都调,命中后不得重复 fs 探测。
+ */
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  existsSync: vi.fn<(p: string) => boolean>(() => false),
+  chmodSync: vi.fn(),
+  getAppPath: vi.fn(() => '/xdt-lazy-rg/app'),
+}));
+
+function mockElectronApp(app: Record<string, unknown>): void {
+  vi.doMock('electron', () => ({ app }));
+}
+
+function mockFsProbe(): void {
+  vi.doMock('node:fs', async () => {
+    const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+    return {
+      ...actual,
+      existsSync: h.existsSync,
+      chmodSync: h.chmodSync,
+      default: { ...actual, existsSync: h.existsSync, chmodSync: h.chmodSync },
+    };
+  });
+}
+
+// 同 runtimeConfigs.test.ts:剪断 model-access 凭证链的文件 IO,本测试不断言 endpoint。
+function mockEffectiveEndpoint(): void {
+  vi.doMock('../../model-access/effectiveEndpoint.js', () => ({
+    effectiveXdGatewayBaseUrl: () => 'http://127.0.0.1:0',
+  }));
+}
+
+const platformKey = `${process.platform}-${process.arch}`;
+const rgBinaryName = process.platform === 'win32' ? 'rg.exe' : 'rg';
+// dev 分支第一个候选:与 runtime-configs 内 path.join 同式构造(宿主路径断言走 path API)。
+const expectedDevDir = path.join('/xdt-lazy-rg/app', '..', '..', 'apps', 'ripgrep-bin', platformKey);
+
+beforeEach(() => {
+  vi.resetModules();
+  h.existsSync.mockClear().mockReturnValue(false);
+  h.chmodSync.mockClear();
+  h.getAppPath.mockClear();
+});
+
+describe('runtime-configs bundled ripgrep laziness (#1956)', () => {
+  it('import 不探测 ripgrep:electron mock 无 getAppPath / isPackaged 也能加载', async () => {
+    // 只有 getPath:desktopCodexRuntimeConfig.userDataPath 仍在模块期读 userData。
+    // getAppPath / isPackaged 缺席 —— 若模块顶层恢复探测,这里收集期即 TypeError。
+    mockElectronApp({ getPath: () => '/xdt-lazy-rg/user-data' });
+    mockFsProbe();
+    mockEffectiveEndpoint();
+
+    const mod = await import('../runtime-configs.js');
+
+    expect(mod.desktopCodexRuntimeConfig.userDataPath).toBe('/xdt-lazy-rg/user-data');
+    expect(typeof mod.getRipgrepBinaryPath).toBe('function');
+    expect(typeof mod.ensureBundledRipgrepReady).toBe('function');
+    expect(h.existsSync).not.toHaveBeenCalled();
+  });
+
+  it('pathPrepends 访问期才探测:rg 缺失时 throw,且失败不缓存可重试', async () => {
+    mockElectronApp({
+      getPath: () => '/xdt-lazy-rg/user-data',
+      getAppPath: h.getAppPath,
+      isPackaged: false,
+    });
+    mockFsProbe();
+    mockEffectiveEndpoint();
+
+    const { desktopCodexRuntimeConfig, ensureBundledRipgrepReady } = await import(
+      '../runtime-configs.js'
+    );
+    // import 期零探测:getAppPath 与 fs 都不该被碰过。
+    expect(h.getAppPath).not.toHaveBeenCalled();
+    expect(h.existsSync).not.toHaveBeenCalled();
+
+    expect(() => desktopCodexRuntimeConfig.pathPrepends).toThrow(/Bundled ripgrep not found/u);
+    expect(() => ensureBundledRipgrepReady()).toThrow(/Bundled ripgrep not found/u);
+
+    // 失败不缓存:补装 rg(existsSync 转 true)后同进程重试即成功。
+    h.existsSync.mockReturnValue(true);
+    expect(desktopCodexRuntimeConfig.pathPrepends).toEqual([expectedDevDir]);
+  });
+
+  it('探测成功后 memoize:重复访问 pathPrepends / getRipgrepBinaryPath 不再打 fs', async () => {
+    mockElectronApp({
+      getPath: () => '/xdt-lazy-rg/user-data',
+      getAppPath: h.getAppPath,
+      isPackaged: false,
+    });
+    mockFsProbe();
+    mockEffectiveEndpoint();
+    h.existsSync.mockReturnValue(true);
+
+    const { desktopCodexRuntimeConfig, getRipgrepBinaryPath, ensureBundledRipgrepReady } =
+      await import('../runtime-configs.js');
+
+    expect(desktopCodexRuntimeConfig.pathPrepends).toEqual([expectedDevDir]);
+    const probeCallsAfterHit = h.existsSync.mock.calls.length;
+    expect(probeCallsAfterHit).toBeGreaterThan(0);
+
+    // 此后所有访问路径(spawn env、file-browser 搜索、启动期预热)都只吃缓存。
+    desktopCodexRuntimeConfig.pathPrepends;
+    ensureBundledRipgrepReady();
+    expect(getRipgrepBinaryPath()).toBe(path.join(expectedDevDir, rgBinaryName));
+    expect(h.existsSync.mock.calls.length).toBe(probeCallsAfterHit);
+  });
+});

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -101,6 +101,7 @@ import {
 import {
   buildDesktopClaudeRuntimeConfig,
   desktopCodexRuntimeConfig,
+  ensureBundledRipgrepReady,
 } from './runtime-configs.js';
 import { getClaudeEndpoint, setClaudeProxyGatewayKeyReader, setClaudeProxyOAuthSpawnChecker } from './anthropic-compat-proxy-host.js';
 import { resolveRemoteClaudeRoute } from './remote-claude-route.js';
@@ -594,6 +595,12 @@ export function getMaker(): Maker {
     if (!codexPath) {
       throw new Error('getMaker: Codex binary not provisioned (bootstrap must run agent-binaries.prepare("codex") before getMaker)');
     }
+    // bundled ripgrep 检查与上面 claude/codex 二进制同层:真正的启动期 fail-fast
+    // 在 splash check-environment(Phase 2.5,缺 rg 时 splash 进失败态可重试);
+    // 这里是防御性断言 —— 走到本函数说明 bootstrap 已完成环境检查,缺 rg 即顺序
+    // 错误,早抛比 spawn 时再炸清晰(throw 会被 bootstrap 的 register catch 兜住
+    // 并留 ERROR 日志,与 claude/codex 缺失的处理一致)。
+    ensureBundledRipgrepReady();
 
     // 图片送进模型前的 last-mile resize (省 vision token)。host 注入 logger
     // 让 sharp 失败 / 超时 / LRU 淘汰等告警进项目日志, 而不是默默丢黑洞。

--- a/apps/desktop/src/main/maker-host/runtime-configs.ts
+++ b/apps/desktop/src/main/maker-host/runtime-configs.ts
@@ -42,7 +42,18 @@ function ripgrepBinaryName(): string {
   return process.platform === 'win32' ? 'rg.exe' : 'rg';
 }
 
+// 探测结果 memoize:pathPrepends getter 每次 codex spawn 都会读、getRipgrepBinaryPath
+// 被 file-browser / pi-host 每次搜索调用,不能每次都重打 fs 探测 + chmod。
+// 只缓存成功结果 —— 探测失败的 throw 不缓存,下次调用重新探测(dev 期补装 rg 后
+// 不必纠结缓存住了失败态)。
+let cachedBundledRipgrepDir: string | undefined;
+
+// 不在模块顶层调用(issue #1956):本函数在 dev/测试分支依赖 app.getAppPath(),
+// 顶层求值会让任何 import 链摸到本模块的纯 node / vitest 环境在收集阶段就炸。
+// 调用点:desktopCodexRuntimeConfig.pathPrepends 的 lazy getter、
+// getRipgrepBinaryPath(),以及启动期 fail-fast 的 ensureBundledRipgrepReady()。
 function bundledRipgrepDir(): string {
+  if (cachedBundledRipgrepDir) return cachedBundledRipgrepDir;
   const key = platformKey();
   const file = ripgrepBinaryName();
   const candidates = app.isPackaged
@@ -59,11 +70,12 @@ function bundledRipgrepDir(): string {
     if (process.platform !== 'win32') {
       try { fs.chmodSync(bin, 0o755); } catch { /* ignore */ }
     }
+    cachedBundledRipgrepDir = dir;
     return dir;
   }
 
   throw new Error(
-    `Bundled ripgrep not found for ${key}. Run "pnpm update:ripgrep" before starting desktop dev or packaging.`,
+    `Bundled ripgrep not found for ${key}. Run "pnpm install:ripgrep" before starting desktop dev or packaging.`,
   );
 }
 
@@ -74,6 +86,19 @@ function bundledRipgrepDir(): string {
  */
 export function getRipgrepBinaryPath(): string {
   return path.join(bundledRipgrepDir(), ripgrepBinaryName());
+}
+
+/**
+ * 启动期 fail-fast 预热(issue #1956):import 本模块不再探测 ripgrep(见
+ * desktopCodexRuntimeConfig.pathPrepends 的 lazy getter),缺 rg 的显式失败由
+ * 两个启动期调用点承担 —— bootstrap 的 splash check-environment(Phase 2.5,
+ * 缺失时 splash 进失败态可重试,与 claude/codex binary 缺失同一体验)和
+ * getMaker() 首次构造(防御性断言,与那里的 claude/codex 检查同层)。
+ * dev 忘跑 "pnpm install:ripgrep" 会在 splash 即失败;生产打包缺资源同样
+ * 在启动期暴露,语义不变。
+ */
+export function ensureBundledRipgrepReady(): void {
+  bundledRipgrepDir();
 }
 
 // memorySettings 在 main 启动期已 ready (userData 同步可访问)。
@@ -239,7 +264,13 @@ export const desktopCodexRuntimeConfig: AgentRuntimeConfig = {
   behaviorFlags: (ctx) => (ctx.spawnMode === 'remote' ? {} : toolchainThreadCapEnv()),
   // 产品身份 + Skill 来源优先级 + Codex 专属段。
   systemPrompt: composeHostPrompt(codexSystemPrompt),
-  pathPrepends: [bundledRipgrepDir()],
+  // lazy getter(与 endpoint/memoryEnabled 同一惯用法,issue #1956):import 期
+  // 不探测 bundled ripgrep,纯 node / vitest 环境 import 本模块不再炸;真正的
+  // fail-fast 由 maker-host 启动期的 ensureBundledRipgrepReady() 承担,此处 getter
+  // 在 env-builder 每次 codex spawn 时求值(结果已 memoize)。
+  get pathPrepends() {
+    return [bundledRipgrepDir()];
+  },
   userDataPath: app.getPath('userData'),
   get memoryEnabled() {
     return readMemorySettings().codex;

--- a/apps/desktop/src/main/maker-ipc/__tests__/scheduleReadiness.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/scheduleReadiness.test.ts
@@ -33,13 +33,10 @@ vi.mock('electron', () => ({
   ipcMain: { handle: vi.fn() },
   BrowserWindow: { getAllWindows: h.getAllWindows },
   // 停用轴接线让本测试的 import 链带上 model-disable-store / auth-adapters →
-  // runtime-configs:模块加载期会读 app.getPath 并跑 bundledRipgrepDir 探测
-  // (getAppPath + isPackaged;dev 探测最终命中 cwd()/../ripgrep-bin)。补齐这
-  // 三个成员避免 collect 失败。
+  // runtime-configs:模块加载期会读 app.getPath('userData')(userDataPath 字段)。
+  // ripgrep 探测已惰性化(issue #1956),import 不再需要 getAppPath / isPackaged。
   app: {
     getPath: vi.fn(() => '/tmp/cindy-test-user-data'),
-    getAppPath: vi.fn(() => '/tmp/cindy-test-app'),
-    isPackaged: false,
   },
 }));
 

--- a/apps/desktop/src/renderer/contexts/EnvCheckContext.tsx
+++ b/apps/desktop/src/renderer/contexts/EnvCheckContext.tsx
@@ -344,7 +344,11 @@ export function EnvCheckProvider({ children }: { children: ReactNode }) {
         try {
           const res = await window.electronAPI.checkEnvironment();
           setResult(res);
-          setStatus('passed');
+          // claude/codex 缺失在 dev 维持既有放行(注释见上:dev 跑检查只为让
+          // 路径就绪);但 bundled ripgrep 缺失不能放行 —— #1956 的启动期
+          // fail-fast 在 dev 同样要成立,否则 dev 缺 rg 会被这里的无条件
+          // passed 吞掉,直到首次 codex spawn / 文件搜索才炸。
+          setStatus(res.ripgrep?.status === 'failed' ? 'failed' : 'passed');
         } catch {
           setStatus('passed');
         }

--- a/apps/desktop/src/renderer/contexts/__tests__/EnvCheckContext.test.tsx
+++ b/apps/desktop/src/renderer/contexts/__tests__/EnvCheckContext.test.tsx
@@ -81,6 +81,38 @@ async function mountAndKick() {
 
 const flush = () => act(async () => {});
 
+describe('EnvCheckContext dev 短路径的 ripgrep fail-fast (#1956)', () => {
+  // vitest 下 import.meta.env.DEV === true,mount 的 auto-check 走 dev 短路径,
+  // 只消费 envCheckCalls[0]。
+  it('dev:ripgrep failed 进 failed 态,不被 dev 的无条件放行吞掉', async () => {
+    const view = renderHook(() => useEnvCheck(), { wrapper });
+    await waitFor(() => expect(envCheckCalls.length).toBe(1));
+
+    await act(async () => {
+      envCheckCalls[0].resolve({
+        allPassed: false,
+        ripgrep: { status: 'failed', error: 'Bundled ripgrep not found' },
+      });
+    });
+
+    await waitFor(() => expect(view.result.current.status).toBe('failed'));
+  });
+
+  it('dev:claude/codex 缺失维持既有放行(只有 ripgrep 失败才拦)', async () => {
+    const view = renderHook(() => useEnvCheck(), { wrapper });
+    await waitFor(() => expect(envCheckCalls.length).toBe(1));
+
+    await act(async () => {
+      envCheckCalls[0].resolve({
+        allPassed: false,
+        claudeCode: { status: 'failed', error: 'no claude binary' },
+      });
+    });
+
+    await waitFor(() => expect(view.result.current.status).toBe('passed'));
+  });
+});
+
 describe('EnvCheckContext 启动下载进度时序', () => {
   it('热更先下(常态):Phase 2 在途期间热更进度直接驱动 splash,二进制接管时归零', async () => {
     const { result } = await mountAndKick();

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -59,6 +59,8 @@ interface EnvCheckResult {
   codex: { status: 'passed' | 'failed' | 'skipped'; path?: string; error?: string };
   /** pi 可选实验 agent:failed 不影响 allPassed；本次启动会禁用 pi。 */
   pi?: { status: 'passed' | 'failed' | 'skipped'; path?: string; error?: string };
+  /** bundled ripgrep(必需):failed 时 allPassed=false,splash 进失败态可重试 (#1956)。 */
+  ripgrep?: { status: 'passed' | 'failed' | 'skipped'; error?: string };
   allPassed: boolean;
   platform: 'darwin' | 'win32' | 'linux';
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 #1956:`apps/desktop/src/main/maker-host/runtime-configs.ts` 的模块级导出 `desktopCodexRuntimeConfig.pathPrepends` 在 **import 时**就执行 `bundledRipgrepDir()`(dev 分支调 `app.getAppPath()`),导致任何 import 链摸到该模块的纯 node / vitest 环境在**收集阶段**直接炸 `TypeError`。已有至少三处测试为此补 mock workaround,CI 也需要专门的 `install:ripgrep` 步骤。

按 issue 建议做惰性化:探测结果 memoize + `pathPrepends` 改 lazy getter(与同文件 `endpoint`/`memoryEnabled` 既有惯用法一致);启动期 fail-fast 显式落到 splash 的 `check-environment`(新增 Phase 2.5)——缺 rg 时 splash 进「环境初始化失败 + 重试」态,与 claude/codex binary 缺失同一体验,dev 补跑 `pnpm install:ripgrep` 后重试即过;`getMaker()` 首次构造分支保留一次防御性断言调用(与旁边的 claude/codex 二进制检查同层)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:Fixes #1956
- 本 PR 包含:
  - `bundledRipgrepDir()` 结果 memoize(只缓存成功;失败 throw 不缓存,补装后同进程重试即可)
  - `desktopCodexRuntimeConfig.pathPrepends` 改 lazy getter,import 期零探测
  - 新增 `ensureBundledRipgrepReady()`;splash `check-environment` 新增 Phase 2.5 作为启动期 fail-fast(返回 `allPassed:false` + `ripgrep:{status:'failed',error}`,catch 内 `console.error` 留诊断,因 splash 失败态 UI 不渲染 error 字段);`EnvCheckResult` 增加可选 `ripgrep` 字段
  - 新增 `runtimeConfigsRipgrep.test.ts` 固化三条契约:import 零探测(electron mock 故意缺 `getAppPath`/`isPackaged`)/ 访问期 fail-fast 且失败可重试 / 成功后 memoize 不再打 fs
  - 移除 `claudeAuthAdapterOAuthEnv.test.ts` / `scheduleReadiness.test.ts` 两处为绕过本问题补的 `getAppPath`+`isPackaged` mock workaround
  - 抛错指引统一为 `pnpm install:ripgrep`(幂等安装 pin 版本,与 CI 一致)
- 明确不包含:
  - 未做 issue 中「拆独立小模块」的可选更彻底方案(惰性化已能干净落地)
  - 未移除 CI 的 `install:ripgrep` 步骤(其注释所述理由已消失,但删 CI 步骤超出本 PR 范围,建议后续单独处理)
  - `userDataPath: app.getPath('userData')` 仍在模块加载期求值——不是本 issue 成因(既有测试均有 `getPath` mock),未顺手改
- 用户可见变化:dev 环境缺 bundled ripgrep 时,从「main 进程 import 期硬崩」变为「splash 显示环境初始化失败、可重试」(含 dev 短路径放行逻辑的配套修正:dev 下 claude/codex 缺失维持既有放行,ripgrep 失败仍进失败态);生产环境无变化(rg 随包分发,探测语义不变)
- 是否存在 breaking change:无

### UI 变化

不涉及:命中 renderer 的仅有 `vite-env.d.ts` 类型声明新增一个可选字段,无视觉/交互/文案变化(splash 失败态复用既有通用 UI,未新增/修改任何界面)。

- 引用的设计规范：不涉及：renderer 侧仅类型声明新增可选字段 + dev 短路径放行逻辑尊重 ripgrep 失败态，无视觉/交互/文案变化，splash 失败态复用既有通用 UI

## 怎么验证的

### 自动验证

```text
pnpm test:unit(rebase 到最新 upstream/main 17f2baa59 后重跑)
结果:全部通过(exit 0)

pnpm --filter desktop typecheck
结果:通过

pnpm check:dco
结果:DCO check passed(1 commit signed off)

定向:runtimeConfigsRipgrep / runtimeConfigs / claudeAuthAdapterOAuthEnv /
scheduleReadiness / agentEnvPathPrepends / authAdaptersImportPurity /
collabSendOutcome / deviceOp / piBinaryDistribution / EnvCheckContext /
SplashScreen / useSplashPhases
结果:全绿
```

另经两位 Orca Worker 独立 code review(Fable 5 与 DeepSeek V4 Flash):首轮发现「预热 throw 会被 bootstrap 的 register catch 吞掉、fail-fast 名不副实」(P2),已修复为 splash Phase 2.5 方案;复审双方确认解决、无新问题。

### 手工验证

不涉及(未起真实 Electron;dev 缺 rg 的 splash 失败态路径由静态核对 + 既有 splash 测试覆盖)。

### 未执行的验证

- 实机验证 dev 缺 rg 时 splash 失败态 → 补装 → 重试通过的完整链路:需要在真实 Electron 环境卸载 rg 后启动,未执行;失败/重试语义复用 claude/codex binary 缺失的既有成熟路径,风险低。
- macOS 实机:未验证(改动为 main 侧启动期探测,逻辑跨平台同构;路径断言均走 `path.join`)。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:desktop main 进程启动期环境检查与 codex spawn env 的 ripgrep 路径注入。行为变化点:① import runtime-configs 不再探测 rg(测试/工具链受益);② dev 缺 rg 的失败时机从 import 期硬崩改为 splash 失败态;③ `getRipgrepBinaryPath()` 成功后走缓存,不再每次重探(运行期 rg 被删的极端场景会从「清晰报错」变为 spawn ENOENT,bundled 资源运行期不可变,风险极低)。跨平台:packaged 分支(`process.resourcesPath/tools/ripgrep`)与 dev 候选目录逻辑原样未动,Windows/macOS 路径构造未变。
- 回滚 / 降级方式:revert 本 PR 单个 commit 即恢复旧行为,无数据/状态迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
