### PR TITLE
test(desktop): 等待模型选择器最终聚焦状态

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -11,7 +11,7 @@
  *   5. 长供应商名称不撑破弹层(truncate)
  */
 
-import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -413,6 +413,11 @@ describe('ModelSelector provider groups', () => {
     renderSelector({ visualVariant: 'create-agent', useMorphPopover: true });
     await openDropdown();
 
+    const searchInput = screen.getByRole('textbox');
+    await waitFor(() => {
+      expect(document.activeElement).toBe(searchInput);
+    });
+
     const modelList = screen.getByRole('listbox', { name: 'Model list' });
     const originalRow = within(modelList).getByRole('option', { name: /Opus 4\.8/ });
     await openModelOptionsPanel(originalRow);
@@ -423,7 +428,6 @@ describe('ModelSelector provider groups', () => {
     };
     expect(originalFloatingOptions.elements.reference).toBe(originalRow);
 
-    const searchInput = screen.getByRole('textbox');
     await act(async () => {
       fireEvent.change(searchInput, { target: { value: 'qwen' } });
     });


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows client-ci run 31142543171 的首次 `Windows unit tests (2/2)` job 92755302947 偶发失败：`modelSelectorProviderGroups.test.tsx` 在搜索恢复模型行后找不到 `model-options-floating-panel`。同一 SHA 的第二次执行和近期 main CI 均通过，PR #1993 也没有修改这段产品逻辑，确认是既有测试时序问题。

父级 `MorphPopover` 打开后会在 220ms 动画结束时自动聚焦搜索框。测试此前可能在这个最终聚焦发生前打开次级面板；延迟聚焦随后落到次级面板外，Radix `DismissableLayer` 会按正常交互语义关闭面板。慢速 Windows 调度更容易撞上这个窗口。

本 PR 只在失败用例开始交互前，用 Testing Library `waitFor` 等待搜索框成为 `document.activeElement`，再验证模型行卸载、重挂载和浮层锚点更新。没有修改产品逻辑，也没有增加 sleep、测试 retry 或 timeout。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Windows client-ci run 31142543171，job 92755302947
- 本 PR 包含：等待 ModelSelector 父级 MorphPopover 完成最终自动聚焦后，再执行锚点重挂载测试
- 明确不包含：PR #1993 的 Worker 权限默认值改动、ModelSelector 产品逻辑、timeout/retry/sleep
- 用户可见变化：无
- 是否存在 breaking change：无

### UI 变化

不涉及：仅修改 Renderer 单测等待最终 DOM/焦点状态，不改变视觉、交互或文案。

- 引用的设计规范：不涉及：仅修改 Renderer 单测等待最终 DOM/焦点状态，不改变视觉、交互或文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorProviderGroups.test.tsx -t "refreshes the create-agent floating anchor after search remounts the active model row"
结果：通过；修复后目标用例连续 50/50 通过。

pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
结果：完整测试文件连续 20/20 通过，共 220 个用例。

pnpm --filter desktop run --if-present typecheck
结果：通过。

XDT_UNIT_TEST_SHARD=2/2 pnpm test:unit
结果：通过；Desktop shard 2/2 用时 40.7s。

pnpm test:unit
结果：通过；Desktop 全量单元测试用时 75.9s。

pnpm check:dco
结果：通过，1 个提交已签名。
```

### 手工验证

不涉及：纯测试时序修复，无产品行为改动。

### 未执行的验证

- 未在本地 Windows runner 上重复执行；当前本地验证环境为 macOS。
- Windows 的最终稳定性由本 PR client-ci 的 Windows shard 2/2 验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅一个 Renderer 单测的交互起点；断言和产品代码不变。
- 风险：Testing Library 默认等待窗口内需要观察到搜索框完成自动聚焦；该状态是 MorphPopover 已有且用户可观察的焦点契约。
- 回滚 / 降级方式：回退本 PR 的单个测试提交即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及，无需新增文档）
- [x] 已确认测试结果或说明未执行原因
