### PR TITLE
fix(mobile): prevent voice pill flicker during startup

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1959,6 +1959,10 @@ export default function SessionScreen() {
     expanded: voiceIsListening || voiceStartPending,
     counting: voiceIsListening,
   });
+  // Keep Composer geometry stable while startup waits for the first PCM chunk.
+  // Pending reserves the listening slot without enabling the stop gesture or
+  // showing live listening content before capture is real.
+  const voiceIsActiveLayout = voiceIsListening || voiceStartPending;
   const composerEffectiveContentHeight = composerInputContentHeight;
   const voiceDraftShowsListeningPrompt = voiceIsListening && draft.length === 0;
   // 状态行只承载错误信息;「正在听 / 转写中」不再占一行,对齐桌面版——
@@ -2333,7 +2337,7 @@ export default function SessionScreen() {
       {renderComposerSendSlot()}
     </>
   );
-  const renderComposerInputOverlay = () => voiceIsListening ? (
+  const renderComposerInputOverlay = () => voiceIsActiveLayout ? (
     // 「点输入区 = 想打字 → 停止听写」由这层 RN 覆盖层承接。听写期间真正盖在输入区上的
     // 就是它;底下的富文本 WebView 此刻是 hidden(opacity 0),iOS hitTest 会跳过 alpha≈0
     // 的 view,它根本收不到触摸——把停听写挂在 WebView 的 focus / touch 上都不成立
@@ -2346,6 +2350,7 @@ export default function SessionScreen() {
       // handler 幂等:finishVoiceRecording 有 voiceStopInFlight 门,重复调用是 no-op。
       onPress={handleComposerInputPressIn}
       onPressIn={handleComposerInputPressIn}
+      pointerEvents={voiceIsListening ? 'auto' : 'none'}
       style={styles.voiceDraftOverlay}
       testID="session.voiceDraftOverlay"
     >
@@ -2367,7 +2372,7 @@ export default function SessionScreen() {
         showsVerticalScrollIndicator={false}
         style={styles.voiceDraftScroll}
       >
-        {voiceDraftShowsListeningPrompt ? (
+        {voiceIsListening ? (voiceDraftShowsListeningPrompt ? (
           <View style={styles.voiceDraftListeningPrompt}>
             <VoiceMicWaveCaret color={colors.textPrimary} testID="session.voiceMicCaret" />
             <Text style={styles.voiceDraftListeningText}>{composerLayout.input.placeholder}</Text>
@@ -2393,7 +2398,7 @@ export default function SessionScreen() {
               <VoiceMicWaveCaret color={colors.textPrimary} testID="session.voiceMicCaret" />
             </View>
           </View>
-        )}
+        )) : null}
       </ScrollView>
     </Pressable>
   ) : null;
@@ -8498,7 +8503,7 @@ export default function SessionScreen() {
                     accessoryAbove={attachments.length > 0 || pendingUploads.length > 0 || pastePlaceholderCount > 0 ? renderComposerAttachmentTray() : null}
                     autoFocus={visualFocusComposer}
                     cardActive={composerCardActive}
-                    caretHidden={voiceIsListening}
+                    caretHidden={voiceIsActiveLayout}
                     compact={compactComposer && !composerCardActive}
                     editable={!composerLayout.input.disabled}
                     floatingVoiceButton={voiceUiAvailable ? renderComposerVoiceButton : undefined}
@@ -8506,7 +8511,7 @@ export default function SessionScreen() {
                     inputFrameHeight={composerResize.frameHeight}
                     // 听写期间把输入区撑到 44pt 触控目标:命中层盖在 inputFrame 上,
                     // hitSlop 越不过父边界(见常量注释)。
-                    inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}
+                    inputFrameMinHeight={voiceIsActiveLayout ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}
                     inputElement={(
                       <ComposerRichInput
                         ref={composerInputRef}
@@ -8515,7 +8520,7 @@ export default function SessionScreen() {
                         document={composerDocument}
                         editable={!composerLayout.input.disabled}
                         height={composerInputVisibleHeight}
-                        hidden={voiceIsListening}
+                        hidden={voiceIsActiveLayout}
                         maxHeight={composerResize.inputMaxHeight}
                         onBlur={() => {
                           setComposerFocused(false);
@@ -8527,7 +8532,7 @@ export default function SessionScreen() {
                         onPasteImages={(uris) => void addPastedImageAttachments(uris)}
                         onPasteImagesLoading={beginPastePlaceholders}
                         onPasteImagesLoadFailed={failPastePlaceholders}
-                        placeholder={voiceIsListening ? '' : composerLayout.input.placeholder}
+                        placeholder={voiceIsActiveLayout ? '' : composerLayout.input.placeholder}
                         resolveSessionLinkLabel={resolvePastedSessionLinkLabel}
                         testID="session.composerRichInput"
                         theme={{
@@ -8542,7 +8547,7 @@ export default function SessionScreen() {
                       />
                     )}
                     inputOverlay={renderComposerInputOverlay()}
-                    inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
+                    inputStyle={voiceIsActiveLayout ? styles.inputVoiceHidden : undefined}
                     inputTestID="session.composerInput"
                     leading={renderComposerCollapsedAttachmentBadge()}
                     maxHeight={composerResize.inputMaxHeight}
@@ -8562,7 +8567,7 @@ export default function SessionScreen() {
                     onPasteImagesLoading={beginPastePlaceholders}
                     onPasteImagesLoadFailed={failPastePlaceholders}
                     onPressIn={handleComposerInputPressIn}
-                    placeholder={voiceIsListening ? '' : composerLayout.input.placeholder}
+                    placeholder={voiceIsActiveLayout ? '' : composerLayout.input.placeholder}
                     placeholderTextColor={colors.textTertiary}
                     resizeHandle={composerCardActive ? renderComposerResizeHandle() : null}
                     scrollEnabled={composerInputScrollEnabled}

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -371,10 +371,7 @@ import {
   recordMobileVoiceInputHistoryForHost,
   updateMobileVoiceInputHistoryEntryForHost,
 } from '@/session/mobileVoiceHistoryStore';
-import {
-  hydrateMobileVoiceDictionary,
-  refreshMobileVoiceDictionary,
-} from '@/session/mobileVoiceDictionaryCache';
+import { refreshMobileVoiceDictionary } from '@/session/mobileVoiceDictionaryCache';
 import {
   playMobileVoiceInputEndCue,
 } from '@/session/mobileVoiceCue';
@@ -4440,11 +4437,16 @@ export default function SessionScreen() {
       // 词典快照拉取不进 await:它只影响润色提示的丰富度,拉不到(桌面离线、老版本
       // 被控端)就用上次缓存,绝不为它推迟开麦。本次拉到的内容供下一次润色使用。
       void refreshMobileVoiceDictionary(deviceId, () => maker.getVoiceDictionary());
-      const [prewarmedVoice, localVoiceInputHistory] = await Promise.all([
-        takePrewarmedMobileVoiceAsr(deviceId) ?? Promise.resolve(null),
-        getMobileVoiceInputHistoryForHost(deviceId),
-        hydrateMobileVoiceDictionary(deviceId),
-      ]);
+      // Claiming a prewarm must not await its in-flight WebSocket handshake:
+      // BufferedAsrProvider already lets capture start concurrently and replays
+      // the early PCM once the connection settles.
+      const prewarmedVoice = takePrewarmedMobileVoiceAsr(deviceId);
+      // History and dictionary enrich refinement only. Load both behind the mic
+      // start; the retained array is read when refinement actually runs.
+      const localVoiceInputHistory: string[] = [];
+      void getMobileVoiceInputHistoryForHost(deviceId)
+        .then((history) => localVoiceInputHistory.push(...history))
+        .catch(() => undefined);
       claimedPrewarm = prewarmedVoice;
       const credential = prewarmedVoice?.credential
         ?? createMobileCindyVoiceCredential(deviceId);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1916,7 +1916,7 @@ export default function SessionScreen() {
     if (!voiceStartPending) return;
     if (shouldClearMobileVoiceStartPending({
       voiceState,
-      startupSettled: false,
+      startupSettled: !voiceStartupInFlightRef.current,
       recordingActive: voiceRecordingActiveRef.current,
       hasController: Boolean(voiceControllerSessionRef.current),
     })) {

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1912,6 +1912,10 @@ export default function SessionScreen() {
   const voiceStartPendingSeqRef = useRef(0);
   // pressIn 已起录的标记:同一次手势的松手(onPress)不能再被当作「再点一下停止」。
   const voiceStartedOnPressInRef = useRef(false);
+  const clearVoiceStartPending = useCallback(() => {
+    voiceStartPendingSeqRef.current += 1;
+    setVoiceStartPending(false);
+  }, []);
   useEffect(() => {
     if (!voiceStartPending) return;
     if (shouldClearMobileVoiceStartPending({
@@ -4603,6 +4607,7 @@ export default function SessionScreen() {
     voiceStartupInFlightRef.current = false;
     voiceStopInFlightRef.current = false;
     voiceRecordingActiveRef.current = false;
+    clearVoiceStartPending();
     voiceLongPressActiveRef.current = false;
     voiceSuppressNextPressRef.current = false;
     voiceStopAfterStartRef.current = false;
@@ -4613,7 +4618,7 @@ export default function SessionScreen() {
     discardPendingPrewarm();
     if (controller) void controller.cancel().catch(() => undefined);
     void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
-  }, [setVoiceState]);
+  }, [clearVoiceStartPending, setVoiceState]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
@@ -4636,10 +4641,12 @@ export default function SessionScreen() {
     voicePermissionRequestAbortRef.current?.abort();
     voicePermissionRequestAbortRef.current = null;
     voicePermissionRequestInFlightRef.current = false;
+    clearVoiceStartPending();
     cancelVoiceForAppBackground();
-  }, [cancelVoiceForAppBackground]);
+  }, [cancelVoiceForAppBackground, clearVoiceStartPending]);
 
   useEffect(() => {
+    setVoiceStartPending(false);
     return () => {
       const controller = voiceControllerSessionRef.current;
       voiceControllerSessionRef.current = null;
@@ -4649,6 +4656,7 @@ export default function SessionScreen() {
       voicePermissionRequestAbortRef.current?.abort();
       voicePermissionRequestAbortRef.current = null;
       voicePermissionRequestInFlightRef.current = false;
+      voiceStartPendingSeqRef.current += 1;
       voiceStartupSeqRef.current += 1;
       voiceStartupInFlightRef.current = false;
       voiceStopInFlightRef.current = false;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -4504,23 +4504,19 @@ export default function SessionScreen() {
           onStateChanged: setVoiceState,
           onError: (message) => {
             const failedController = getCreatedController();
-            if (
-              failedController
-              && voiceControllerSessionRef.current === failedController
-            ) {
-              voiceStartupSeqRef.current += 1;
-              voiceControllerSessionRef.current = null;
-              voiceStartupInFlightRef.current = false;
-              voiceStopInFlightRef.current = false;
-              voiceRecordingActiveRef.current = false;
-              clearVoiceStartPending();
-              voiceLongPressActiveRef.current = false;
-              voiceSuppressNextPressRef.current = false;
-              voiceStopAfterStartRef.current = false;
-              setVoiceReleaseToSendActive(false);
-              setComposerVoiceHoldArmed(false);
-              void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
-            }
+            if (!failedController || voiceControllerSessionRef.current !== failedController) return;
+            voiceStartupSeqRef.current += 1;
+            voiceControllerSessionRef.current = null;
+            voiceStartupInFlightRef.current = false;
+            voiceStopInFlightRef.current = false;
+            voiceRecordingActiveRef.current = false;
+            clearVoiceStartPending();
+            voiceLongPressActiveRef.current = false;
+            voiceSuppressNextPressRef.current = false;
+            voiceStopAfterStartRef.current = false;
+            setVoiceReleaseToSendActive(false);
+            setComposerVoiceHoldArmed(false);
+            void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
             setVoiceState('error');
             setVoiceError(message);
           },

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -1907,6 +1907,9 @@ export default function SessionScreen() {
   // pending 的世代号:本组件会随 sessionId 复用,上一个会话的启动收尾不能把
   // 当前会话刚展开的乐观胶囊收掉——finally 只在世代未前进时清 pending。
   const voiceStartPendingSeqRef = useRef(0);
+  // The permission request starts before voiceStartupInFlightRef is set. Keep
+  // optimistic pending alive across that synchronous-to-async handoff.
+  const voiceStartRequestedRef = useRef(false);
   // pressIn 已起录的标记:同一次手势的松手(onPress)不能再被当作「再点一下停止」。
   const voiceStartedOnPressInRef = useRef(false);
   const clearVoiceStartPending = useCallback(() => {
@@ -1917,7 +1920,7 @@ export default function SessionScreen() {
     if (!voiceStartPending) return;
     if (shouldClearMobileVoiceStartPending({
       voiceState,
-      startupSettled: !voiceStartupInFlightRef.current,
+      startupSettled: !voiceStartupInFlightRef.current && !voiceStartRequestedRef.current,
       recordingActive: voiceRecordingActiveRef.current,
       hasController: Boolean(voiceControllerSessionRef.current),
     })) {
@@ -4794,6 +4797,7 @@ export default function SessionScreen() {
     // 否则松手的 onPress 会被吞掉,用户失去 toggle 能力。
     if (voiceStartupInFlightRef.current || voiceStopInFlightRef.current) return;
     voiceStartedOnPressInRef.current = true;
+    voiceStartRequestedRef.current = true;
     const pendingSeq = ++voiceStartPendingSeqRef.current;
     setVoiceStartPending(true);
     void startVoiceRecording()
@@ -4808,6 +4812,7 @@ export default function SessionScreen() {
           recordingActive: voiceRecordingActiveRef.current,
           hasController: Boolean(voiceControllerSessionRef.current),
         })) setVoiceStartPending(false);
+        voiceStartRequestedRef.current = false;
       });
   }, [deviceId, startVoiceRecording, voiceIsProcessing, voiceState]);
 

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -353,6 +353,7 @@ import {
 } from '@/session/mobileVoicePrewarm';
 import {
   resolveMobileVoiceRecordingPermission,
+  shouldClearMobileVoiceStartPending,
   shouldCancelMobileVoiceForBackground,
   waitForMobileVoiceAppActive,
 } from '@/session/mobileVoiceStartup';
@@ -1911,6 +1912,17 @@ export default function SessionScreen() {
   const voiceStartPendingSeqRef = useRef(0);
   // pressIn 已起录的标记:同一次手势的松手(onPress)不能再被当作「再点一下停止」。
   const voiceStartedOnPressInRef = useRef(false);
+  useEffect(() => {
+    if (!voiceStartPending) return;
+    if (shouldClearMobileVoiceStartPending({
+      voiceState,
+      startupSettled: false,
+      recordingActive: voiceRecordingActiveRef.current,
+      hasController: Boolean(voiceControllerSessionRef.current),
+    })) {
+      setVoiceStartPending(false);
+    }
+  }, [voiceStartPending, voiceState]);
   // 发送槽双语义(对齐桌面 ChatInput 的主槽判定,voice busy = listening|submitting|refining):
   // 任务执行中且发送不可用、又没有语音在进行时,停止任务顶替发送位;语音一旦开始,
   // 发送键回到发送位(录音期=「结束并发送」,润色期=禁用态占位),停止任务退到
@@ -4754,8 +4766,15 @@ export default function SessionScreen() {
     void startVoiceRecording()
       .catch(() => undefined)
       .finally(() => {
-        // 只收自己世代的 pending:切会话后旧启动的收尾不能塌掉新录音的胶囊。
-        if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);
+        // 启动 Promise 可能早于首个 PCM 完成;这时仍保持 pending,由
+        // listening 状态 effect 在真实采集开始后收口。
+        if (voiceStartPendingSeqRef.current !== pendingSeq) return;
+        if (shouldClearMobileVoiceStartPending({
+          voiceState: voiceStateTransitionRef.current,
+          startupSettled: true,
+          recordingActive: voiceRecordingActiveRef.current,
+          hasController: Boolean(voiceControllerSessionRef.current),
+        })) setVoiceStartPending(false);
       });
   }, [deviceId, startVoiceRecording, voiceIsProcessing, voiceState]);
 

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -4493,6 +4493,24 @@ export default function SessionScreen() {
           onDraftChanged: setComposerDraft,
           onStateChanged: setVoiceState,
           onError: (message) => {
+            const failedController = getCreatedController();
+            if (
+              failedController
+              && voiceControllerSessionRef.current === failedController
+            ) {
+              voiceStartupSeqRef.current += 1;
+              voiceControllerSessionRef.current = null;
+              voiceStartupInFlightRef.current = false;
+              voiceStopInFlightRef.current = false;
+              voiceRecordingActiveRef.current = false;
+              clearVoiceStartPending();
+              voiceLongPressActiveRef.current = false;
+              voiceSuppressNextPressRef.current = false;
+              voiceStopAfterStartRef.current = false;
+              setVoiceReleaseToSendActive(false);
+              setComposerVoiceHoldArmed(false);
+              void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
+            }
             setVoiceState('error');
             setVoiceError(message);
           },
@@ -4586,7 +4604,7 @@ export default function SessionScreen() {
       setVoiceError(formatRemoteError(err));
       await setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
     }
-  }, [deviceId, draft, openLink, renderItems, t, voiceIsProcessing, voiceState]);
+  }, [clearVoiceStartPending, deviceId, draft, openLink, renderItems, t, voiceIsProcessing, voiceState]);
 
   const cancelVoiceForAppBackground = useCallback(() => {
     const controller = voiceControllerSessionRef.current;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1236,7 +1236,7 @@ export default function NewRemoteSessionScreen() {
     if (!voiceStartPending) return;
     if (shouldClearMobileVoiceStartPending({
       voiceState,
-      startupSettled: false,
+      startupSettled: !voiceStartupInFlightRef.current,
       recordingActive: voiceRecordingActiveRef.current,
       hasController: Boolean(voiceControllerSessionRef.current),
     })) {

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -2863,6 +2863,20 @@ export default function NewRemoteSessionScreen() {
         onDraftChanged: setFirstMessageDraft,
         onStateChanged: setVoiceState,
         onError: (message) => {
+          const failedController = createdController;
+          if (
+            failedController
+            && voiceControllerSessionRef.current === failedController
+          ) {
+            voiceStartupSeqRef.current += 1;
+            voiceControllerSessionRef.current = null;
+            voiceStartupInFlightRef.current = false;
+            voiceStopInFlightRef.current = false;
+            voiceRecordingActiveRef.current = false;
+            clearVoiceStartPending();
+            setComposerVoiceHoldArmed(false);
+            void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
+          }
           setVoiceState('error');
           setVoiceError(message);
         },
@@ -2938,7 +2952,7 @@ export default function NewRemoteSessionScreen() {
       setVoiceError(formatRemoteError(err));
       await setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
     }
-  }, [openLink, selectedDeviceId, setFirstMessageDraft, voiceIsProcessing, voiceState]);
+  }, [clearVoiceStartPending, openLink, selectedDeviceId, setFirstMessageDraft, voiceIsProcessing, voiceState]);
 
   const finishVoiceRecording = useCallback(async (): Promise<string | null> => {
     if (voiceStopInFlightRef.current) return null;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1228,6 +1228,9 @@ export default function NewRemoteSessionScreen() {
   // 声明在 composerShowCreateButton 之前:pending 期就要占住创建槽。
   const [voiceStartPending, setVoiceStartPending] = useState(false);
   const voiceStartPendingSeqRef = useRef(0);
+  // The permission request starts before voiceStartupInFlightRef is set. Keep
+  // optimistic pending alive across that synchronous-to-async handoff.
+  const voiceStartRequestedRef = useRef(false);
   const voiceStartedOnPressInRef = useRef(false);
   const clearVoiceStartPending = useCallback(() => {
     voiceStartPendingSeqRef.current += 1;
@@ -1237,7 +1240,7 @@ export default function NewRemoteSessionScreen() {
     if (!voiceStartPending) return;
     if (shouldClearMobileVoiceStartPending({
       voiceState,
-      startupSettled: !voiceStartupInFlightRef.current,
+      startupSettled: !voiceStartupInFlightRef.current && !voiceStartRequestedRef.current,
       recordingActive: voiceRecordingActiveRef.current,
       hasController: Boolean(voiceControllerSessionRef.current),
     })) {
@@ -3029,6 +3032,7 @@ export default function NewRemoteSessionScreen() {
     // 启动已在途/停止在途时不重复发起,也不把这次按下标成「已起录」。
     if (voiceStartupInFlightRef.current || voiceStopInFlightRef.current) return;
     voiceStartedOnPressInRef.current = true;
+    voiceStartRequestedRef.current = true;
     const pendingSeq = ++voiceStartPendingSeqRef.current;
     setVoiceStartPending(true);
     void startVoiceRecording()
@@ -3043,6 +3047,7 @@ export default function NewRemoteSessionScreen() {
           recordingActive: voiceRecordingActiveRef.current,
           hasController: Boolean(voiceControllerSessionRef.current),
         })) setVoiceStartPending(false);
+        voiceStartRequestedRef.current = false;
       });
   }, [creating, selectedDeviceId, startVoiceRecording, voiceIsProcessing, voiceState]);
 

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -241,6 +241,7 @@ import {
 } from '@/session/mobileVoicePrewarm';
 import {
   resolveMobileVoiceRecordingPermission,
+  shouldClearMobileVoiceStartPending,
   shouldCancelMobileVoiceForBackground,
   waitForMobileVoiceAppActive,
 } from '@/session/mobileVoiceStartup';
@@ -1231,6 +1232,17 @@ export default function NewRemoteSessionScreen() {
   const [voiceStartPending, setVoiceStartPending] = useState(false);
   const voiceStartPendingSeqRef = useRef(0);
   const voiceStartedOnPressInRef = useRef(false);
+  useEffect(() => {
+    if (!voiceStartPending) return;
+    if (shouldClearMobileVoiceStartPending({
+      voiceState,
+      startupSettled: false,
+      recordingActive: voiceRecordingActiveRef.current,
+      hasController: Boolean(voiceControllerSessionRef.current),
+    })) {
+      setVoiceStartPending(false);
+    }
+  }, [voiceStartPending, voiceState]);
   // 语音生命周期内创建按钮常驻(与会话页发送槽同理,对齐桌面):录音中点创建
   // = 结束录音并用转写创建(create() 已有 listening 分支);否则首段转写落地的
   // 瞬间按钮冒出来,右对齐工具排会把语音胶囊整格推左。乐观 pending 期同理占位,
@@ -2998,8 +3010,15 @@ export default function NewRemoteSessionScreen() {
     void startVoiceRecording()
       .catch(() => undefined)
       .finally(() => {
-        // 只收自己世代的 pending(与会话页同款守卫)。
-        if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);
+        // 启动 Promise 可能早于首个 PCM 完成;这时仍保持 pending,由
+        // listening 状态 effect 在真实采集开始后收口。
+        if (voiceStartPendingSeqRef.current !== pendingSeq) return;
+        if (shouldClearMobileVoiceStartPending({
+          voiceState: voiceStateTransitionRef.current,
+          startupSettled: true,
+          recordingActive: voiceRecordingActiveRef.current,
+          hasController: Boolean(voiceControllerSessionRef.current),
+        })) setVoiceStartPending(false);
       });
   }, [creating, selectedDeviceId, startVoiceRecording, voiceIsProcessing, voiceState]);
 

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -2872,19 +2872,15 @@ export default function NewRemoteSessionScreen() {
         onStateChanged: setVoiceState,
         onError: (message) => {
           const failedController = createdController;
-          if (
-            failedController
-            && voiceControllerSessionRef.current === failedController
-          ) {
-            voiceStartupSeqRef.current += 1;
-            voiceControllerSessionRef.current = null;
-            voiceStartupInFlightRef.current = false;
-            voiceStopInFlightRef.current = false;
-            voiceRecordingActiveRef.current = false;
-            clearVoiceStartPending();
-            setComposerVoiceHoldArmed(false);
-            void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
-          }
+          if (!failedController || voiceControllerSessionRef.current !== failedController) return;
+          voiceStartupSeqRef.current += 1;
+          voiceControllerSessionRef.current = null;
+          voiceStartupInFlightRef.current = false;
+          voiceStopInFlightRef.current = false;
+          voiceRecordingActiveRef.current = false;
+          clearVoiceStartPending();
+          setComposerVoiceHoldArmed(false);
+          void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
           setVoiceState('error');
           setVoiceError(message);
         },

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1258,6 +1258,9 @@ export default function NewRemoteSessionScreen() {
     || voiceState === 'refining';
   const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);
   const voiceIsListening = voiceState === 'listening';
+  // Keep Composer geometry stable while startup waits for the first PCM chunk.
+  // Pending reserves the listening slot without showing live listening content.
+  const voiceIsActiveLayout = voiceIsListening || voiceStartPending;
   const voiceIsProcessing = voiceState === 'submitting' || voiceState === 'refining';
   // 只有一台可选设备时无可切换项:禁用下拉、隐藏 ⇕(用户反馈:单选项不要出选框)。
   const deviceHasChoices = deviceOptions.length > 1;
@@ -3224,7 +3227,7 @@ export default function NewRemoteSessionScreen() {
       {composerShowCreateButton ? renderCreateButton() : null}
     </>
   );
-  const renderComposerInputOverlay = () => voiceIsListening ? (
+  const renderComposerInputOverlay = () => voiceIsActiveLayout ? (
     <ScrollView
       ref={voiceDraftScrollRef}
       contentContainerStyle={styles.voiceDraftOverlayContent}
@@ -3243,7 +3246,7 @@ export default function NewRemoteSessionScreen() {
       showsVerticalScrollIndicator={false}
       style={styles.voiceDraftOverlay}
     >
-      {voiceDraftShowsListeningPrompt ? (
+      {voiceIsListening ? (voiceDraftShowsListeningPrompt ? (
         <View style={styles.voiceDraftListeningPrompt}>
           <VoiceMicWaveCaret color={colors.textPrimary} testID="newSession.voiceMicCaret" />
           <Text style={styles.voiceDraftListeningText}>{composerListeningPlaceholder}</Text>
@@ -3269,7 +3272,7 @@ export default function NewRemoteSessionScreen() {
             <VoiceMicWaveCaret color={colors.textPrimary} testID="newSession.voiceMicCaret" />
           </View>
         </View>
-      )}
+      )) : null}
     </ScrollView>
   ) : null;
 
@@ -4911,16 +4914,16 @@ export default function NewRemoteSessionScreen() {
                   accessoryAbove={attachments.length > 0 || pendingUploads.length > 0 || pastePlaceholderCount > 0 ? renderComposerAttachmentTray() : null}
                   autoFocus={visualFocusComposer}
                   cardActive={composerCardActive}
-                  caretHidden={voiceIsListening}
+                  caretHidden={voiceIsActiveLayout}
                   cursorColor={colors.inputCaret}
                   inputRef={firstMessageInputRef}
                   leading={renderComposerCollapsedAttachmentBadge()}
                   inputFrameHeight={composerResize.frameHeight}
                   // 听写期间把输入区撑到 44pt 触控目标:此时「点输入区停止听写」的命中层
                   // 是这层输入区自身(TextInput 的 onPressIn),单行时只有 28pt。
-                  inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}
+                  inputFrameMinHeight={voiceIsActiveLayout ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}
                   inputOverlay={renderComposerInputOverlay()}
-                  inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}
+                  inputStyle={voiceIsActiveLayout ? styles.inputVoiceHidden : undefined}
                   inputTestID="newSession.firstMessageInput"
                   maxHeight={composerResize.inputMaxHeight}
                   multilineShape={!composerCardActive && composerInputIsMultiline}
@@ -4938,7 +4941,7 @@ export default function NewRemoteSessionScreen() {
                   onPressIn={() => {
                     if (voiceIsListening) void finishVoiceRecording();
                   }}
-                  placeholder={voiceIsListening ? '' : composerPlaceholder}
+                  placeholder={voiceIsActiveLayout ? '' : composerPlaceholder}
                   placeholderTextColor={colors.textTertiary}
                   resizeHandle={composerCardActive ? renderComposerResizeHandle() : null}
                   scrollEnabled={composerInputScrollEnabled}

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1232,6 +1232,10 @@ export default function NewRemoteSessionScreen() {
   const [voiceStartPending, setVoiceStartPending] = useState(false);
   const voiceStartPendingSeqRef = useRef(0);
   const voiceStartedOnPressInRef = useRef(false);
+  const clearVoiceStartPending = useCallback(() => {
+    voiceStartPendingSeqRef.current += 1;
+    setVoiceStartPending(false);
+  }, []);
   useEffect(() => {
     if (!voiceStartPending) return;
     if (shouldClearMobileVoiceStartPending({
@@ -1439,13 +1443,14 @@ export default function NewRemoteSessionScreen() {
     voiceStartupInFlightRef.current = false;
     voiceStopInFlightRef.current = false;
     voiceRecordingActiveRef.current = false;
+    clearVoiceStartPending();
     setComposerVoiceHoldArmed(false);
     setVoiceState('idle');
     setVoiceError(null);
     discardPendingPrewarm();
     if (controller) void controller.cancel().catch(() => undefined);
     void setAudioModeAsync({ allowsRecording: false }).catch(() => undefined);
-  }, [setVoiceState]);
+  }, [clearVoiceStartPending, setVoiceState]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
@@ -3030,6 +3035,7 @@ export default function NewRemoteSessionScreen() {
       voicePermissionRequestAbortRef.current?.abort();
       voicePermissionRequestAbortRef.current = null;
       voicePermissionRequestInFlightRef.current = false;
+      voiceStartPendingSeqRef.current += 1;
       voiceStartupSeqRef.current += 1;
       voiceStartupInFlightRef.current = false;
       voiceStopInFlightRef.current = false;

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -259,10 +259,7 @@ import {
   recordMobileVoiceInputHistoryForHost,
   updateMobileVoiceInputHistoryEntryForHost,
 } from '@/session/mobileVoiceHistoryStore';
-import {
-  hydrateMobileVoiceDictionary,
-  refreshMobileVoiceDictionary,
-} from '@/session/mobileVoiceDictionaryCache';
+import { refreshMobileVoiceDictionary } from '@/session/mobileVoiceDictionaryCache';
 import {
   playMobileVoiceInputEndCue,
 } from '@/session/mobileVoiceCue';
@@ -2813,11 +2810,16 @@ export default function NewRemoteSessionScreen() {
       // 词典快照拉取不进 await:它只影响润色提示的丰富度,拉不到(桌面离线、老版本
       // 被控端)就用上次缓存,绝不为它推迟开麦。
       void refreshMobileVoiceDictionary(selectedDeviceId, () => maker.getVoiceDictionary());
-      const [prewarmedVoice, localVoiceInputHistory] = await Promise.all([
-        takePrewarmedMobileVoiceAsr(selectedDeviceId) ?? Promise.resolve(null),
-        getMobileVoiceInputHistoryForHost(selectedDeviceId),
-        hydrateMobileVoiceDictionary(selectedDeviceId),
-      ]);
+      // Claiming a prewarm must not await its in-flight WebSocket handshake:
+      // BufferedAsrProvider already lets capture start concurrently and replays
+      // the early PCM once the connection settles.
+      const prewarmedVoice = takePrewarmedMobileVoiceAsr(selectedDeviceId);
+      // History and dictionary enrich refinement only. Load both behind the mic
+      // start; the retained array is read when refinement actually runs.
+      const localVoiceInputHistory: string[] = [];
+      void getMobileVoiceInputHistoryForHost(selectedDeviceId)
+        .then((history) => localVoiceInputHistory.push(...history))
+        .catch(() => undefined);
       claimedPrewarm = prewarmedVoice;
       const credential = prewarmedVoice?.credential
         ?? createMobileCindyVoiceCredential(selectedDeviceId);

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -119,7 +119,7 @@ describe('mobile composer rich input HTML', () => {
     // 单行听写时 inputFrame 只有 28pt,命中层必须靠父容器撑到 44pt 触控目标——
     // hitSlop 无效(RN 的命中区不会越过父视图边界),所以不许再用它顶替。
     expect(overlaySource).not.toContain('hitSlop');
-    expect(screenSource).toContain('inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
+    expect(screenSource).toContain('inputFrameMinHeight={voiceIsActiveLayout ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
 
     // hidden 的富文本编辑器必须同时从两端的无障碍树里摘掉:opacity: 0 不隐藏读屏焦点,
     // 而它的 focus 已不再停听写,焦点留在那里会让读屏用户卡在「按了没反应」的输入框上。

--- a/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
@@ -99,8 +99,8 @@ describe('composer voice draft text metrics', () => {
     expect(row).toContain('Math.max(inputFrameHeight, inputFrameMinHeight)');
     expect(row).toContain('resolvedInputFrameHeight != null && { height: resolvedInputFrameHeight }');
     for (const rel of COMPOSER_PAGES) {
-      expect(read(rel), `${rel} 听写期间必须把输入区撑到触控目标`)
-        .toContain('inputFrameMinHeight={voiceIsListening ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
+      expect(read(rel), `${rel} 启动 pending 和听写期间都必须把输入区撑到触控目标`)
+        .toContain('inputFrameMinHeight={voiceIsActiveLayout ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
     }
   });
 

--- a/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
+++ b/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
@@ -174,6 +174,51 @@ describe('mobileRealtimeAudio', () => {
     expect(streamRelease).toHaveBeenCalledTimes(1);
   });
 
+  it('stops custom native capture when the first PCM chunk stalls', async () => {
+    vi.useFakeTimers();
+    try {
+      type NativeEvent = 'onAudioChunk' | 'onAudioError';
+      const listeners = new Map<NativeEvent, (event: never) => void>();
+      const nativeStop = vi.fn(async () => undefined);
+      const nativeModule = {
+        start: vi.fn(async () => undefined),
+        stop: nativeStop,
+        prewarm: vi.fn(async () => undefined),
+        addListener(eventName: NativeEvent, listener: (event: never) => void) {
+          listeners.set(eventName, listener);
+          return { remove: () => listeners.delete(eventName) };
+        },
+      };
+
+      vi.mocked(requireNativeModule).mockImplementation((moduleName: string) => {
+        if (moduleName === 'XdtMobileRealtimeAudio') return nativeModule;
+        throw new Error(`${moduleName} not linked`);
+      });
+
+      const {
+        __testing,
+        startMobileRealtimeAudio,
+      } = await import('@/session/mobileRealtimeAudio');
+      __testing.resetNativeBindingForTests();
+
+      const onChunk = vi.fn();
+      const onError = vi.fn();
+      const stopCapture = await startMobileRealtimeAudio({ onChunk, onError });
+
+      await vi.advanceTimersByTimeAsync(6_001);
+
+      expect(onChunk).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(nativeStop).toHaveBeenCalledTimes(1);
+      expect(listeners.size).toBe(0);
+
+      await stopCapture();
+      expect(nativeStop).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('preserves non-integer resampling phase across native buffer boundaries', async () => {
     const { __testing } = await import('@/session/mobileRealtimeAudio');
     const convert = __testing.createExpoAudioPcm16Converter(16_000);

--- a/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
+++ b/apps/mobile/src/__tests__/mobileRealtimeAudio.test.ts
@@ -174,6 +174,58 @@ describe('mobileRealtimeAudio', () => {
     expect(streamRelease).toHaveBeenCalledTimes(1);
   });
 
+  it('prefers the fresh Expo AudioStream when the Apple custom binding is also linked', async () => {
+    const nativeModule = {
+      start: vi.fn(async () => undefined),
+      stop: vi.fn(async () => undefined),
+      prewarm: vi.fn(async () => undefined),
+      addListener: vi.fn(() => ({ remove: vi.fn() })),
+    };
+    const streamStart = vi.fn(async () => undefined);
+    const streamStop = vi.fn();
+    const streamRelease = vi.fn();
+
+    class MockExpoAudioStream {
+      readonly id = 'apple-pcm-stream';
+      readonly sampleRate = 16_000;
+      readonly channels = 1;
+      readonly isStreaming = true;
+
+      addListener() {
+        return { remove: vi.fn() };
+      }
+
+      start = streamStart;
+      stop = streamStop;
+      release = streamRelease;
+    }
+
+    vi.mocked(requireNativeModule).mockImplementation((moduleName: string) => {
+      if (moduleName === 'XdtMobileRealtimeAudio') return nativeModule;
+      if (moduleName === 'ExpoAudio') return { AudioStream: MockExpoAudioStream };
+      throw new Error(`${moduleName} not linked`);
+    });
+    const {
+      __testing,
+      prewarmMobileRealtimeAudio,
+      startMobileRealtimeAudio,
+    } = await import('@/session/mobileRealtimeAudio');
+    __testing.resetNativeBindingForTests();
+
+    const stopCapture = await startMobileRealtimeAudio({ onChunk: vi.fn() });
+    expect(streamStart).toHaveBeenCalledTimes(1);
+    expect(nativeModule.start).not.toHaveBeenCalled();
+
+    // The legacy play-and-record warmup would force an extra session category
+    // transition immediately before AudioStream opens its input-only engine.
+    prewarmMobileRealtimeAudio();
+    expect(nativeModule.prewarm).not.toHaveBeenCalled();
+
+    await stopCapture();
+    expect(streamStop).toHaveBeenCalledTimes(1);
+    expect(streamRelease).toHaveBeenCalledTimes(1);
+  });
+
   it('stops custom native capture when the first PCM chunk stalls', async () => {
     vi.useFakeTimers();
     try {

--- a/apps/mobile/src/__tests__/mobileVoiceController.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceController.test.ts
@@ -648,6 +648,7 @@ describe('mobileVoiceController', () => {
     // 'listening' is only surfaced once the mic delivers real PCM (capture goes
     // live), so a chunk must arrive before it appears. The native layer then
     // reports an interruption mid-capture.
+    expect(states).not.toContain('listening');
     audioChunkCb?.({
       pcm16: new Uint8Array([1, 2]).buffer,
       trace: { capturedAt: 1, convertedAt: 2, chunkIndex: 0, sampleRate: 16_000, durationMs: 20 },

--- a/apps/mobile/src/__tests__/mobileVoicePrewarm.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoicePrewarm.test.ts
@@ -96,10 +96,11 @@ describe('mobileVoicePrewarm', () => {
 
     prewarmMobileVoiceStart('device-1', AUTH);
     expect(prewarmMobileRealtimeAudio).toHaveBeenCalledTimes(1);
-    await settle();
     expect(provider.startCalls).toBe(1);
 
-    const claimed = await takePrewarmedMobileVoiceAsr('device-1');
+    // Claiming returns the provider immediately while its speculative connect
+    // is still pending, so the caller can open the mic in parallel.
+    const claimed = takePrewarmedMobileVoiceAsr('device-1');
     expect(claimed?.credential).toBe(CREDENTIAL);
     expect(__testing.hasPending()).toBe(false);
 

--- a/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   resolveMobileVoiceRecordingPermission,
+  shouldClearMobileVoiceStartPending,
   shouldCancelMobileVoiceForBackground,
   waitForMobileVoiceAppActive,
 } from '@/session/mobileVoiceStartup';
@@ -27,6 +28,49 @@ function stableAppStateLifecycle(): {
 }
 
 describe('mobileVoiceStartup', () => {
+  it('keeps the optimistic pill while startup settles before the first PCM chunk', () => {
+    expect(shouldClearMobileVoiceStartPending({
+      voiceState: 'idle',
+      startupSettled: true,
+      recordingActive: true,
+      hasController: true,
+    })).toBe(false);
+  });
+
+  it.each(['listening', 'submitting', 'refining'] as const)(
+    'clears the optimistic pill once voice state is %s',
+    (voiceState) => {
+      expect(shouldClearMobileVoiceStartPending({
+        voiceState,
+        startupSettled: false,
+        recordingActive: true,
+        hasController: true,
+      })).toBe(true);
+    },
+  );
+
+  it.each(['error', 'done'] as const)('keeps a stale terminal voice state %s while the new controller is active', (voiceState) => {
+    expect(shouldClearMobileVoiceStartPending({
+      voiceState,
+      startupSettled: true,
+      recordingActive: true,
+      hasController: true,
+    })).toBe(false);
+  });
+
+  it.each([
+    { voiceState: 'idle', reason: 'no active recording' },
+    { voiceState: 'error', reason: 'startup failure' },
+    { voiceState: 'done', reason: 'cancelled previous run' },
+  ] as const)('clears the optimistic pill after %s', ({ voiceState }) => {
+    expect(shouldClearMobileVoiceStartPending({
+      voiceState,
+      startupSettled: true,
+      recordingActive: false,
+      hasController: false,
+    })).toBe(true);
+  });
+
   it('uses an existing microphone grant without opening the system prompt', async () => {
     const requestPermission = vi.fn(async () => ({ granted: true }));
 

--- a/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
+++ b/apps/mobile/src/__tests__/mobileVoiceStartup.test.ts
@@ -37,6 +37,15 @@ describe('mobileVoiceStartup', () => {
     })).toBe(false);
   });
 
+  it('clears a settled startup after cancellation releases the controller', () => {
+    expect(shouldClearMobileVoiceStartPending({
+      voiceState: 'idle',
+      startupSettled: true,
+      recordingActive: false,
+      hasController: false,
+    })).toBe(true);
+  });
+
   it.each(['listening', 'submitting', 'refining'] as const)(
     'clears the optimistic pill once voice state is %s',
     (voiceState) => {

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1113,8 +1113,9 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('getAccessToken: () => auth.getAccessToken(),');
     expect(newSource).toContain('refreshAccessToken: () => auth.refreshAccessToken(),');
     expect(newSource).toContain('apiFetch: auth.apiFetch,');
-    expect(newSource).toContain('const [prewarmedVoice, localVoiceInputHistory] = await Promise.all([');
-    expect(newSource).toContain('takePrewarmedMobileVoiceAsr(selectedDeviceId) ?? Promise.resolve(null),');
+    expect(newSource).toContain('const prewarmedVoice = takePrewarmedMobileVoiceAsr(selectedDeviceId);');
+    expect(newSource).toContain('void getMobileVoiceInputHistoryForHost(selectedDeviceId)');
+    expect(newSource).not.toContain('await Promise.all([\n        takePrewarmedMobileVoiceAsr(selectedDeviceId)');
     expect(newSource).not.toContain('MobileVoiceServiceMode');
     expect(newSource).not.toContain('LiteLlm');
     expect(newSource).toContain('?? createMobileCindyVoiceCredential(selectedDeviceId);');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -995,6 +995,10 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('startupSettled: !voiceStartupInFlightRef.current');
     expect(newSource).toContain('startupSettled: true');
     expect(newSource).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
+    // controller/ref teardown 不一定改变 voiceState;显式清 pending,避免同值 idle
+    // 被 React 跳过后胶囊常驻。
+    expect(newSource).toContain('const clearVoiceStartPending = useCallback(() => {');
+    expect(newSource).toContain('voiceRecordingActiveRef.current = false;\n    clearVoiceStartPending();\n    setComposerVoiceHoldArmed(false);');
     // listening 时只豁免「缺正文/附件」校验(路径/模型等其它校验不放行,
     // 否则按钮可点但必失败):点创建 = 停录并用最终转写创建(review 二轮收窄)。
     // 判定必须是结构化的 isNewSessionDraftMissingPayloadOnly,禁止比对本地化

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -999,6 +999,11 @@ describe('new session composer surface', () => {
     // 被 React 跳过后胶囊常驻。
     expect(newSource).toContain('const clearVoiceStartPending = useCallback(() => {');
     expect(newSource).toContain('voiceRecordingActiveRef.current = false;\n    clearVoiceStartPending();\n    setComposerVoiceHoldArmed(false);');
+    // Controller 异步报错可能发生在 start() 已 resolve 之后；页面必须立即释放
+    // 本轮 owner refs/pending，不能等一个不会再触发的 voiceState effect。
+    expect(newSource).toContain('const failedController = createdController;');
+    expect(newSource).toContain('voiceControllerSessionRef.current === failedController');
+    expect(newSource).toContain('voiceStartupInFlightRef.current = false;\n            voiceStopInFlightRef.current = false;\n            voiceRecordingActiveRef.current = false;\n            clearVoiceStartPending();');
     // listening 时只豁免「缺正文/附件」校验(路径/模型等其它校验不放行,
     // 否则按钮可点但必失败):点创建 = 停录并用最终转写创建(review 二轮收窄)。
     // 判定必须是结构化的 isNewSessionDraftMissingPayloadOnly,禁止比对本地化

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -992,7 +992,7 @@ describe('new session composer surface', () => {
     // 用转写创建;否则首段转写落地瞬间按钮冒出来会把语音胶囊整格推左。
     expect(newSource).toContain("|| voiceStartPending\n    || voiceState === 'listening'\n    || voiceState === 'submitting'\n    || voiceState === 'refining';");
     expect(newSource).toContain('shouldClearMobileVoiceStartPending');
-    expect(newSource).toContain('startupSettled: false');
+    expect(newSource).toContain('startupSettled: !voiceStartupInFlightRef.current');
     expect(newSource).toContain('startupSettled: true');
     expect(newSource).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
     // listening 时只豁免「缺正文/附件」校验(路径/模型等其它校验不放行,

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -992,7 +992,8 @@ describe('new session composer surface', () => {
     // 用转写创建;否则首段转写落地瞬间按钮冒出来会把语音胶囊整格推左。
     expect(newSource).toContain("|| voiceStartPending\n    || voiceState === 'listening'\n    || voiceState === 'submitting'\n    || voiceState === 'refining';");
     expect(newSource).toContain('shouldClearMobileVoiceStartPending');
-    expect(newSource).toContain('startupSettled: !voiceStartupInFlightRef.current');
+    expect(newSource).toContain('startupSettled: !voiceStartupInFlightRef.current && !voiceStartRequestedRef.current');
+    expect(newSource).toContain('voiceStartRequestedRef.current = true;');
     expect(newSource).toContain('startupSettled: true');
     expect(newSource).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
     // controller/ref teardown 不一定改变 voiceState;显式清 pending,避免同值 idle

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1001,10 +1001,13 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('const clearVoiceStartPending = useCallback(() => {');
     expect(newSource).toContain('voiceRecordingActiveRef.current = false;\n    clearVoiceStartPending();\n    setComposerVoiceHoldArmed(false);');
     // Controller 异步报错可能发生在 start() 已 resolve 之后；页面必须立即释放
-    // 本轮 owner refs/pending，不能等一个不会再触发的 voiceState effect。
+    // 本轮 owner refs/pending，且旧 controller 的迟到错误不得覆盖当前录音状态。
     expect(newSource).toContain('const failedController = createdController;');
-    expect(newSource).toContain('voiceControllerSessionRef.current === failedController');
-    expect(newSource).toContain('voiceStartupInFlightRef.current = false;\n            voiceStopInFlightRef.current = false;\n            voiceRecordingActiveRef.current = false;\n            clearVoiceStartPending();');
+    expect(newSource).toContain(
+      'if (!failedController || voiceControllerSessionRef.current !== failedController) return;\n'
+      + '          voiceStartupSeqRef.current += 1;',
+    );
+    expect(newSource).toContain('voiceStartupInFlightRef.current = false;\n          voiceStopInFlightRef.current = false;\n          voiceRecordingActiveRef.current = false;\n          clearVoiceStartPending();');
     // listening 时只豁免「缺正文/附件」校验(路径/模型等其它校验不放行,
     // 否则按钮可点但必失败):点创建 = 停录并用最终转写创建(review 二轮收窄)。
     // 判定必须是结构化的 isNewSessionDraftMissingPayloadOnly,禁止比对本地化

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -934,10 +934,10 @@ describe('new session composer surface', () => {
     expect(newComposerSource).toContain('selectionColor={colors.inputCaret}');
     expect(newComposerSource).toContain('inputRef={firstMessageInputRef}');
     expect(newComposerSource).toContain('inputOverlay={renderComposerInputOverlay()}');
-    expect(newComposerSource).toContain('inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}');
+    expect(newComposerSource).toContain('inputStyle={voiceIsActiveLayout ? styles.inputVoiceHidden : undefined}');
     expect(newComposerSource).toContain('onChangeText={setFirstMessageDraft}');
     expect(newComposerSource).toContain('onContentSizeChange={handleFirstMessageInputContentSizeChange}');
-    expect(newComposerSource).toContain("placeholder={voiceIsListening ? '' : composerPlaceholder}");
+    expect(newComposerSource).toContain("placeholder={voiceIsActiveLayout ? '' : composerPlaceholder}");
     expect(newComposerSource).toContain('scrollEnabled={composerInputScrollEnabled}');
     expect(newComposerSource).toContain('trailing={composerCardActive || !composerShowCreateButton ? null : renderCreateButton()}');
     expect(newSource).toContain('const renderComposerToolbar = () => (');
@@ -1071,7 +1071,11 @@ describe('new session composer surface', () => {
     expect(newSource).toContain('testID="newSession.voiceStatus"');
     expect(newSource).toContain('testID="newSession.voiceSettingsButton"');
     expect(newSource).toContain('testID="newSession.voiceMicCaret"');
-    expect(newSource).toContain('const renderComposerInputOverlay = () => voiceIsListening ? (');
+    expect(newSource).toContain('const voiceIsActiveLayout = voiceIsListening || voiceStartPending;');
+    expect(newSource).toContain('const renderComposerInputOverlay = () => voiceIsActiveLayout ? (');
+    expect(newSource).toContain('{voiceIsListening ? (voiceDraftShowsListeningPrompt ? (');
+    expect(newSource).toContain('caretHidden={voiceIsActiveLayout}');
+    expect(newSource).toContain('inputFrameMinHeight={voiceIsActiveLayout ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
     expect(newSource).toContain("import { buildSessionComposerLayout } from '@/session/sessionComposerLayout';");
     expect(newSource).toContain('const composerListeningPlaceholder = buildSessionComposerLayout({');
     expect(newSource).toContain('<Text style={styles.voiceDraftListeningText}>{composerListeningPlaceholder}</Text>');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -991,6 +991,10 @@ describe('new session composer surface', () => {
     // 语音生命周期内创建按钮常驻(2026-07-25 对齐桌面):录音中点创建=结束录音并
     // 用转写创建;否则首段转写落地瞬间按钮冒出来会把语音胶囊整格推左。
     expect(newSource).toContain("|| voiceStartPending\n    || voiceState === 'listening'\n    || voiceState === 'submitting'\n    || voiceState === 'refining';");
+    expect(newSource).toContain('shouldClearMobileVoiceStartPending');
+    expect(newSource).toContain('startupSettled: false');
+    expect(newSource).toContain('startupSettled: true');
+    expect(newSource).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
     // listening 时只豁免「缺正文/附件」校验(路径/模型等其它校验不放行,
     // 否则按钮可点但必失败):点创建 = 停录并用最终转写创建(review 二轮收窄)。
     // 判定必须是结构化的 isNewSessionDraftMissingPayloadOnly,禁止比对本地化

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -660,6 +660,11 @@ describe('mobile session composer desktop-first surface', () => {
     // cleanup 只改 ref 时不会触发 effect;后台、手势取消和会话切换必须显式清 pending。
     expect(source).toContain('const clearVoiceStartPending = useCallback(() => {');
     expect(source).toContain('voiceRecordingActiveRef.current = false;\n    clearVoiceStartPending();\n    voiceLongPressActiveRef.current = false;');
+    // Controller 异步报错必须释放仍由本轮持有的 refs/pending，同时保留 owner
+    // 比对，避免旧 controller 的迟到错误清掉下一轮录音。
+    expect(voiceSource).toContain('const failedController = getCreatedController();');
+    expect(voiceSource).toContain('voiceControllerSessionRef.current === failedController');
+    expect(voiceSource).toContain('voiceStartupInFlightRef.current = false;\n              voiceStopInFlightRef.current = false;\n              voiceRecordingActiveRef.current = false;\n              clearVoiceStartPending();');
     expect(source).toContain('voicePermissionRequestInFlightRef.current = false;\n    clearVoiceStartPending();\n    cancelVoiceForAppBackground();');
     expect(source).toContain('useEffect(() => {\n    setVoiceStartPending(false);\n    return () => {');
     // 手势被系统/滚动打断时撤销按下即录(review P1)。

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -654,7 +654,7 @@ describe('mobile session composer desktop-first surface', () => {
     // pending 世代守卫:启动 Promise 早于首个 PCM 时不得收掉乐观胶囊,
     // 进入真实 listening 或终态后才收口。
     expect(source).toContain('shouldClearMobileVoiceStartPending');
-    expect(source).toContain('startupSettled: false');
+    expect(source).toContain('startupSettled: !voiceStartupInFlightRef.current');
     expect(source).toContain('startupSettled: true');
     expect(source).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
     // 手势被系统/滚动打断时撤销按下即录(review P1)。

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -352,12 +352,16 @@ describe('mobile session composer desktop-first surface', () => {
     // (停止听写并有意打字)时由 WebKit 按触点放置。
     expect(source).not.toContain('setSelectionToEnd');
     expect(source).toContain('voiceDraftScrollRef.current?.scrollToEnd({ animated: false });');
-    expect(source).toContain('caretHidden={voiceIsListening}');
+    expect(source).toContain('const voiceIsActiveLayout = voiceIsListening || voiceStartPending;');
+    expect(source).toContain('caretHidden={voiceIsActiveLayout}');
     expect(source).toContain('const handleComposerInputPressIn = useCallback(() => {');
     expect(source).toContain('onPressIn={handleComposerInputPressIn}');
-    expect(source).toContain("placeholder={voiceIsListening ? '' : composerLayout.input.placeholder}");
+    expect(source).toContain("placeholder={voiceIsActiveLayout ? '' : composerLayout.input.placeholder}");
     expect(source).toContain('placeholderTextColor={colors.textTertiary}');
-    expect(source).toContain('inputStyle={voiceIsListening ? styles.inputVoiceHidden : undefined}');
+    expect(source).toContain('inputStyle={voiceIsActiveLayout ? styles.inputVoiceHidden : undefined}');
+    expect(source).toContain('inputFrameMinHeight={voiceIsActiveLayout ? MOBILE_COMPOSER_MIN_TOUCH_TARGET : undefined}');
+    expect(source).toContain('hidden={voiceIsActiveLayout}');
+    expect(source).toContain("pointerEvents={voiceIsListening ? 'auto' : 'none'}");
     expect(source).toContain('styles.voiceDraftOverlay');
     expect(voiceDraftOverlayStyle).toContain('...StyleSheet.absoluteFill');
     expect(voiceDraftOverlayStyle).toContain("overflow: 'hidden'");

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -651,8 +651,12 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('expanded: voiceIsListening || voiceStartPending,');
     expect(source).toContain('counting: voiceIsListening,');
     expect(source).toContain('const voiceStartedOnPressInRef = useRef(false);');
-    // pending 世代守卫:切会话后旧启动收尾不得塌掉新录音的乐观胶囊(review P1)。
-    expect(source).toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
+    // pending 世代守卫:启动 Promise 早于首个 PCM 时不得收掉乐观胶囊,
+    // 进入真实 listening 或终态后才收口。
+    expect(source).toContain('shouldClearMobileVoiceStartPending');
+    expect(source).toContain('startupSettled: false');
+    expect(source).toContain('startupSettled: true');
+    expect(source).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
     // 手势被系统/滚动打断时撤销按下即录(review P1)。
     expect(source).toContain('cancelVoiceForAppBackground();');
     expect(source).toContain('testID="session.voiceRecordingPill"');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -659,7 +659,8 @@ describe('mobile session composer desktop-first surface', () => {
     // pending 世代守卫:启动 Promise 早于首个 PCM 时不得收掉乐观胶囊,
     // 进入真实 listening 或终态后才收口。
     expect(source).toContain('shouldClearMobileVoiceStartPending');
-    expect(source).toContain('startupSettled: !voiceStartupInFlightRef.current');
+    expect(source).toContain('startupSettled: !voiceStartupInFlightRef.current && !voiceStartRequestedRef.current');
+    expect(source).toContain('voiceStartRequestedRef.current = true;');
     expect(source).toContain('startupSettled: true');
     expect(source).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
     // cleanup 只改 ref 时不会触发 effect;后台、手势取消和会话切换必须显式清 pending。

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -524,8 +524,9 @@ describe('mobile session composer desktop-first surface', () => {
     // fresh (credential already resolved, WebSocket already connecting) and
     // falls back to building the managed credential itself otherwise. 手机语音
     // 只保留 Cindy 官方托管路径:BYOK/穿透已删除。
-    expect(source).toContain('const [prewarmedVoice, localVoiceInputHistory] = await Promise.all([');
-    expect(source).toContain('takePrewarmedMobileVoiceAsr(deviceId) ?? Promise.resolve(null),');
+    expect(source).toContain('const prewarmedVoice = takePrewarmedMobileVoiceAsr(deviceId);');
+    expect(source).toContain('void getMobileVoiceInputHistoryForHost(deviceId)');
+    expect(source).not.toContain('await Promise.all([\n        takePrewarmedMobileVoiceAsr(deviceId)');
     expect(source).not.toContain('MobileVoiceServiceMode');
     expect(source).not.toContain('LiteLlm');
     expect(source).toContain('?? createMobileCindyVoiceCredential(deviceId);');
@@ -538,7 +539,7 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('connectionProvider: (providerId: string) => voiceContext.createAsrConnection(providerId),');
     expect(source).toContain('voiceContext.createRefinerTarget(providerId, options),');
     expect(source).toContain('voiceContext.warmRefiner(input),');
-    expect(source).toContain('getMobileVoiceInputHistoryForHost(deviceId),');
+    expect(source).toContain('void getMobileVoiceInputHistoryForHost(deviceId)');
     // Device link is opened non-blocking (not awaited): dictation goes through the
     // cloud ASR proxy and does not need the link, so it must not gate mic start.
     expect(source).toContain('void openLink(deviceId).catch(() => undefined);');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -666,11 +666,14 @@ describe('mobile session composer desktop-first surface', () => {
     // cleanup 只改 ref 时不会触发 effect;后台、手势取消和会话切换必须显式清 pending。
     expect(source).toContain('const clearVoiceStartPending = useCallback(() => {');
     expect(source).toContain('voiceRecordingActiveRef.current = false;\n    clearVoiceStartPending();\n    voiceLongPressActiveRef.current = false;');
-    // Controller 异步报错必须释放仍由本轮持有的 refs/pending，同时保留 owner
-    // 比对，避免旧 controller 的迟到错误清掉下一轮录音。
+    // Controller 异步报错必须释放仍由本轮持有的 refs/pending，同时让 owner
+    // 不匹配的迟到错误整体退出，避免覆盖下一轮录音的状态。
     expect(voiceSource).toContain('const failedController = getCreatedController();');
-    expect(voiceSource).toContain('voiceControllerSessionRef.current === failedController');
-    expect(voiceSource).toContain('voiceStartupInFlightRef.current = false;\n              voiceStopInFlightRef.current = false;\n              voiceRecordingActiveRef.current = false;\n              clearVoiceStartPending();');
+    expect(voiceSource).toContain(
+      'if (!failedController || voiceControllerSessionRef.current !== failedController) return;\n'
+      + '            voiceStartupSeqRef.current += 1;',
+    );
+    expect(voiceSource).toContain('voiceStartupInFlightRef.current = false;\n            voiceStopInFlightRef.current = false;\n            voiceRecordingActiveRef.current = false;\n            clearVoiceStartPending();');
     expect(source).toContain('voicePermissionRequestInFlightRef.current = false;\n    clearVoiceStartPending();\n    cancelVoiceForAppBackground();');
     expect(source).toContain('useEffect(() => {\n    setVoiceStartPending(false);\n    return () => {');
     // 手势被系统/滚动打断时撤销按下即录(review P1)。

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -657,6 +657,11 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('startupSettled: !voiceStartupInFlightRef.current');
     expect(source).toContain('startupSettled: true');
     expect(source).not.toContain('if (voiceStartPendingSeqRef.current === pendingSeq) setVoiceStartPending(false);');
+    // cleanup 只改 ref 时不会触发 effect;后台、手势取消和会话切换必须显式清 pending。
+    expect(source).toContain('const clearVoiceStartPending = useCallback(() => {');
+    expect(source).toContain('voiceRecordingActiveRef.current = false;\n    clearVoiceStartPending();\n    voiceLongPressActiveRef.current = false;');
+    expect(source).toContain('voicePermissionRequestInFlightRef.current = false;\n    clearVoiceStartPending();\n    cancelVoiceForAppBackground();');
+    expect(source).toContain('useEffect(() => {\n    setVoiceStartPending(false);\n    return () => {');
     // 手势被系统/滚动打断时撤销按下即录(review P1)。
     expect(source).toContain('cancelVoiceForAppBackground();');
     expect(source).toContain('testID="session.voiceRecordingPill"');

--- a/apps/mobile/src/session/mobileRealtimeAudio.ts
+++ b/apps/mobile/src/session/mobileRealtimeAudio.ts
@@ -127,10 +127,18 @@ export async function startMobileRealtimeAudio(
     return startE2eMockRealtimeAudio(options);
   }
   const binding = getNativeBinding();
+  const expoAudioModule = getExpoAudioNativeModule();
+  // Current Apple builds contain both bindings. Prefer Expo AudioStream there:
+  // it creates a fresh AVAudioEngine for each run and uses the input-only
+  // `.record` session category, which keeps PCM flowing while iOS system screen
+  // recording is active. The retained custom play-and-record engine can start
+  // successfully in that state without ever delivering a tap buffer.
+  if (binding && expoAudioModule) {
+    return startExpoAudioRealtimeAudio(expoAudioModule, options);
+  }
   if (binding) {
     return startCustomNativeRealtimeAudio(binding, options);
   }
-  const expoAudioModule = getExpoAudioNativeModule();
   if (expoAudioModule) {
     return startExpoAudioRealtimeAudio(expoAudioModule, options);
   }
@@ -216,7 +224,9 @@ async function startCustomNativeRealtimeAudio(
  * Mobile already ships expo-audio for permission and audio-mode management.
  * SDK 56 also exposes the native SharedObject behind its public useAudioStream
  * hook. The voice controller is intentionally imperative, so construct that
- * same stream class directly rather than carrying a second AudioRecord stack.
+ * same stream class directly. Android uses it as its only PCM implementation;
+ * Apple builds prefer it over the legacy custom engine so system screen
+ * recording and voice input can remain active together.
  */
 async function startExpoAudioRealtimeAudio(
   module: ExpoAudioNativeModule,
@@ -334,6 +344,10 @@ async function startExpoAudioRealtimeAudio(
  */
 export function prewarmMobileRealtimeAudio(): void {
   if (isE2eMockRealtimeAudioEnabled()) return;
+  // AudioStream owns a fresh input-only engine and has no separate prepare
+  // phase. Prewarming the legacy play-and-record session before AudioStream
+  // starts would only force a second category/route reconfiguration.
+  if (getExpoAudioNativeModule()) return;
   const binding = getNativeBinding();
   if (!binding) return;
   void binding.module.prewarm().catch(() => undefined);

--- a/apps/mobile/src/session/mobileRealtimeAudio.ts
+++ b/apps/mobile/src/session/mobileRealtimeAudio.ts
@@ -92,8 +92,8 @@ type ExpoAudioPcm16ResampleState = {
 };
 
 const DEFAULT_NATIVE_AUDIO_BUFFER_SIZE = 4096;
-const EXPO_AUDIO_STREAM_STALL_TIMEOUT_MS = 5_000;
-const EXPO_AUDIO_STREAM_WATCHDOG_INTERVAL_MS = 1_000;
+const REALTIME_AUDIO_STALL_TIMEOUT_MS = 5_000;
+const REALTIME_AUDIO_WATCHDOG_INTERVAL_MS = 1_000;
 
 let nativeBinding: RealtimeAudioNativeBinding | null | undefined;
 let expoAudioNativeModule: ExpoAudioNativeModule | null | undefined;
@@ -146,8 +146,16 @@ async function startCustomNativeRealtimeAudio(
     bufferSize?: number;
   },
 ): Promise<() => Promise<void>> {
+  let stopped = false;
+  let failureReported = false;
+  let hasReceivedChunk = false;
+  let lastChunkAt = Date.now();
+  let watchdog: ReturnType<typeof setInterval> | null = null;
   const subscriptions: EventSubscription[] = [
     binding.module.addListener('onAudioChunk', (event) => {
+      if (stopped) return;
+      hasReceivedChunk = true;
+      lastChunkAt = Date.now();
       options.onChunk({
         pcm16: decodeBase64ToArrayBuffer(event.base64Pcm16),
         trace: {
@@ -160,9 +168,27 @@ async function startCustomNativeRealtimeAudio(
       });
     }),
     binding.module.addListener('onAudioError', (event) => {
-      options.onError?.(new Error(event.message));
+      reportFailure(new Error(event.message));
     }),
   ];
+
+  const stopCapture = async (): Promise<void> => {
+    if (stopped) return;
+    stopped = true;
+    if (watchdog) {
+      clearInterval(watchdog);
+      watchdog = null;
+    }
+    subscriptions.forEach((subscription) => subscription.remove());
+    await binding.module.stop();
+  };
+
+  function reportFailure(error: Error): void {
+    if (stopped || failureReported) return;
+    failureReported = true;
+    void stopCapture().catch(() => undefined);
+    options.onError?.(error);
+  }
 
   try {
     await binding.module.start({
@@ -174,13 +200,16 @@ async function startCustomNativeRealtimeAudio(
     throw error;
   }
 
-  let stopped = false;
-  return async () => {
-    if (stopped) return;
-    stopped = true;
-    subscriptions.forEach((subscription) => subscription.remove());
-    await binding.module.stop();
-  };
+  if (!stopped) {
+    if (!hasReceivedChunk) lastChunkAt = Date.now();
+    watchdog = setInterval(() => {
+      if (Date.now() - lastChunkAt > REALTIME_AUDIO_STALL_TIMEOUT_MS) {
+        reportFailure(new Error(i18n.t('composer.voice.incomplete')));
+      }
+    }, REALTIME_AUDIO_WATCHDOG_INTERVAL_MS);
+  }
+
+  return stopCapture;
 }
 
 /**
@@ -282,10 +311,10 @@ async function startExpoAudioRealtimeAudio(
     streamStarted = true;
     lastChunkAt = Date.now();
     watchdog = setInterval(() => {
-      if (Date.now() - lastChunkAt > EXPO_AUDIO_STREAM_STALL_TIMEOUT_MS) {
+      if (Date.now() - lastChunkAt > REALTIME_AUDIO_STALL_TIMEOUT_MS) {
         reportFailure();
       }
-    }, EXPO_AUDIO_STREAM_WATCHDOG_INTERVAL_MS);
+    }, REALTIME_AUDIO_WATCHDOG_INTERVAL_MS);
   } catch (error) {
     stopStream();
     throw error;

--- a/apps/mobile/src/session/mobileVoicePrewarm.ts
+++ b/apps/mobile/src/session/mobileVoicePrewarm.ts
@@ -18,7 +18,7 @@ export type PrewarmedMobileVoiceAsr = {
 type PendingPrewarm = {
   deviceId: string;
   createdAt: number;
-  promise: Promise<PrewarmedMobileVoiceAsr | null>;
+  value: PrewarmedMobileVoiceAsr | null;
   expireTimer: ReturnType<typeof setTimeout>;
 };
 
@@ -63,11 +63,11 @@ export function prewarmMobileVoiceStart(
     return;
   }
   discardPendingPrewarm();
-  const promise = buildPrewarm(deviceId, options);
+  const value = buildPrewarm(deviceId, options);
   const entry: PendingPrewarm = {
     deviceId,
     createdAt: Date.now(),
-    promise,
+    value,
     expireTimer: setTimeout(() => {
       if (pendingPrewarm === entry) discardPendingPrewarm();
     }, PREWARM_MAX_AGE_MS),
@@ -83,14 +83,14 @@ export function prewarmMobileVoiceStart(
  */
 export function takePrewarmedMobileVoiceAsr(
   deviceId: string,
-): Promise<PrewarmedMobileVoiceAsr | null> | null {
+): PrewarmedMobileVoiceAsr | null {
   const entry = pendingPrewarm;
   if (!entry || entry.deviceId !== deviceId || Date.now() - entry.createdAt >= PREWARM_MAX_AGE_MS) {
     return null;
   }
   pendingPrewarm = null;
   clearTimeout(entry.expireTimer);
-  return entry.promise;
+  return entry.value;
 }
 
 /** Discards (and closes) any unclaimed prewarmed connection, e.g. on unmount. */
@@ -99,19 +99,17 @@ export function discardPendingPrewarm(): void {
   if (!entry) return;
   pendingPrewarm = null;
   clearTimeout(entry.expireTimer);
-  void entry.promise
-    .then((prewarmed) => prewarmed?.asr.stop())
-    .catch(() => undefined);
+  void entry.value?.asr.stop().catch(() => undefined);
 }
 
-async function buildPrewarm(
+function buildPrewarm(
   deviceId: string,
   auth?: {
     getAccessToken: () => Promise<string | null>;
     refreshAccessToken: () => Promise<string | null>;
     apiFetch: <T>(path: string, options: Omit<ApiFetchOptions, 'token'>) => Promise<T>;
   },
-): Promise<PrewarmedMobileVoiceAsr | null> {
+): PrewarmedMobileVoiceAsr | null {
   // 手机语音只保留 Cindy 官方托管路径:没有登录态(auth)就没有可预热的连接。
   if (!auth) return null;
   try {

--- a/apps/mobile/src/session/mobileVoiceStartup.ts
+++ b/apps/mobile/src/session/mobileVoiceStartup.ts
@@ -1,3 +1,5 @@
+import type { MobileVoiceState } from '@/session/mobileVoiceInput';
+
 export type MobileVoiceRecordingPermission = {
   granted: boolean;
 };
@@ -135,4 +137,27 @@ export function shouldCancelMobileVoiceForBackground(
   state: MobileVoiceBackgroundState,
 ): boolean {
   return state.startupInFlight || state.recordingActive || state.hasController;
+}
+
+/**
+ * Resolves the optimistic voice-pill startup state without racing the first
+ * native PCM chunk. Native `start()` / `AudioStream.start()` may settle while
+ * the controller is still waiting to surface `listening` from its first chunk.
+ */
+export function shouldClearMobileVoiceStartPending(input: {
+  voiceState: MobileVoiceState;
+  startupSettled: boolean;
+  recordingActive: boolean;
+  hasController: boolean;
+}): boolean {
+  if (
+    input.voiceState === 'listening'
+    || input.voiceState === 'submitting'
+    || input.voiceState === 'refining'
+  ) return true;
+  if (!input.startupSettled) return false;
+  // A completed state may belong to the previous run. Keep the optimistic pill
+  // while this run still owns a controller; cleanup paths clear it once the
+  // startup is cancelled or fails and the controller is released.
+  return !input.recordingActive || !input.hasController;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Mobile 端点击录音后，启动 Promise 早于首个 PCM 音频块完成时，录音胶囊短暂消失后重新出现的问题。

共享启动状态判定会在活动录音 controller 仍等待首个 PCM 时保留乐观 pending；进入真实 `listening` / `submitting` / `refining`，或启动失败、取消、controller 已释放时再清除。该逻辑同时覆盖 iOS 与支持实时 PCM 的 Android 构建。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：N/A — explicitly approved quick fix
- 本 PR 包含：录音启动 pending 的平台无关判定、新建任务页与已有任务页接入、启动与首个 PCM 时序及页面契约测试。
- 明确不包含：原生音频模块、录音计时、权限流程、协议、依赖、原生配置和 runtime fingerprint 变更。
- 用户可见变化：点击录音后胶囊持续可见，不再在首个 PCM 到达前闪烁消失。
- 是否存在 breaking change：无。

### UI 变化

- iOS 新建任务录音胶囊连续性录屏将作为 PR comment 的 GitHub 原生附件补充。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.4 Motion & Transitions。此次不新增样式或动画，仅修正功能状态切换，使录音胶囊在启动 pending 到真实采集状态之间连续可见，避免非预期视觉跳变。

## 怎么验证的

### 自动验证

```text
Node: v22.22.3（仓库 .nvmrc）

pnpm --filter mobile exec vitest run src/__tests__/mobileVoiceStartup.test.ts src/__tests__/mobileVoiceController.test.ts src/__tests__/newSession.test.ts src/__tests__/sessionComposerDesktopFirst.test.ts
结果：4 files passed，105 tests passed。

pnpm --filter mobile typecheck
结果：通过。

pnpm test:unit
结果：通过；Desktop、Mobile 及所有 required workspace 均通过。

pnpm check:dco
结果：通过；1 commit signed off。

git diff --check origin/main...HEAD
结果：通过。
```

补充：依赖同步后的首次完整门禁在 Desktop Vitest 8-worker 运行中遇到一次进程 `SIGSEGV`，无测试断言失败；Desktop 单 worker 完整复跑为 1695/1695 files、21822 tests 通过，随后原始 `pnpm test:unit` 8-worker 配置再次完整通过。

### 手工验证

- 分支：`fix/quick-mobile-voice-pill-flicker`
- worktree：`/private/tmp/cindy-quick-fix.wONbpM`
- iOS：本地 Global unsigned arm64 IPA 已在 LiveContainer 验证通过；新建任务点击录音后胶囊连续可见。
- 构建产物仅用于本地验收，未上传、未签名、未提交。

### 未执行的验证

- Android 真机未执行；Android 与 iOS 共用本 PR 的 JS 状态判定，支持实时 PCM 的 Android 构建由相同单元测试覆盖。
- 本次使用独立 IPA 在 LiveContainer 验证，不使用 Metro，因此无 Metro 归属或 `__DEV__` build label。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：iOS 与支持实时 PCM 的 Android Mobile 录音启动状态；未链接实时 PCM 原生模块的构建仍隐藏语音入口。无原生层、fingerprint、OTA、协议、权限、用户数据或存量插件影响。
- 回滚 / 降级方式：revert 本 PR 的单个 commit，恢复启动 Promise 完成时立即清除 pending 的旧行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增仓库文档）
- [x] 已确认测试结果或说明未执行原因
