### PR TITLE
fix(desktop): 变更捕获上线首日三修——空审查卡、同目录任务串行、零信息卡收敛

### DIFF
--- a/apps/desktop/src/main/turn-change-set/__tests__/store.git-integration.test.ts
+++ b/apps/desktop/src/main/turn-change-set/__tests__/store.git-integration.test.ts
@@ -945,6 +945,110 @@ describe('turn change-set sidecar store', () => {
     });
   });
 
+  it('drops the change set when a turn fails without any capture activity', async () => {
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'claude-code',
+      cwd: workdir,
+    });
+    await finalizeTurnChangeSet('session-1', null, 'partial');
+
+    expect(await listTurnChangeSets('session-1')).toHaveLength(0);
+  });
+
+  it('drops the change set when a failed turn only touched files without changing them', async () => {
+    const target = path.join(workdir, 'a.ts');
+    await fs.writeFile(target, 'same\n', 'utf8');
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'claude-code',
+      cwd: workdir,
+    });
+    await captureKnownFileBefore({
+      sessionId: 'session-1',
+      provider: 'claude-code',
+      cwd: workdir,
+      targetPath: 'a.ts',
+    });
+    await finalizeTurnChangeSet('session-1', null, 'partial');
+
+    expect(await listTurnChangeSets('session-1')).toHaveLength(0);
+  });
+
+  it('persists a partial entry with turn-failed when a failed turn changed files', async () => {
+    const target = path.join(workdir, 'a.ts');
+    await fs.writeFile(target, 'old\n', 'utf8');
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'claude-code',
+      cwd: workdir,
+    });
+    await captureKnownFileBefore({
+      sessionId: 'session-1',
+      provider: 'claude-code',
+      cwd: workdir,
+      targetPath: 'a.ts',
+    });
+    await fs.writeFile(target, 'new\n', 'utf8');
+    await finalizeTurnChangeSet('session-1', null, 'partial');
+
+    const [summary] = await listTurnChangeSets('session-1');
+    expect(summary).toMatchObject({
+      state: 'partial',
+      incompleteReasons: ['turn-failed'],
+      fileCount: 1,
+      additions: 1,
+      deletions: 1,
+    });
+  });
+
+  it('hides legacy zero-file turn-failed-only entries persisted by earlier builds', async () => {
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'pi',
+      cwd: workdir,
+    });
+    noteOpaqueTurnChange({ sessionId: 'session-1', provider: 'pi', cwd: workdir });
+    await finalizeTurnChangeSet('session-1', null, 'complete');
+    expect(await listTurnChangeSets('session-1')).toHaveLength(1);
+
+    // Rewrite the sidecar as an earlier build would have persisted a failed turn
+    // with no capture activity: zero files, incompleteReasons = ['turn-failed'].
+    const sidecarDir = path.join(mocks.userDataRoot, 'turn-change-sets', 'session-1');
+    const indexPath = path.join(sidecarDir, 'index.json');
+    const index = JSON.parse(await fs.readFile(indexPath, 'utf8')) as {
+      version: number;
+      entries: Array<{ id: string; incompleteReasons: string[] }>;
+    };
+    index.entries[0]!.incompleteReasons = ['turn-failed'];
+    await fs.writeFile(indexPath, `${JSON.stringify(index)}\n`, 'utf8');
+
+    expect(await listTurnChangeSets('session-1')).toHaveLength(0);
+  });
+
+  it('keeps the zero-file partial entry when a failed turn also ran an opaque tool', async () => {
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'pi',
+      cwd: workdir,
+    });
+    noteOpaqueTurnChange({ sessionId: 'session-1', provider: 'pi', cwd: workdir });
+    await finalizeTurnChangeSet('session-1', null, 'partial');
+
+    const [summary] = await listTurnChangeSets('session-1');
+    expect(summary).toMatchObject({
+      state: 'partial',
+      incompleteReasons: expect.arrayContaining(['opaque-tool', 'turn-failed']),
+      fileCount: 0,
+      files: [],
+    });
+  });
+
   it.each([
     ['absolute path', 'diff --git /outside.txt /outside.txt'],
     ['parent traversal', 'diff --git a/../escape.txt b/../escape.txt'],

--- a/apps/desktop/src/main/turn-change-set/__tests__/store.git-integration.test.ts
+++ b/apps/desktop/src/main/turn-change-set/__tests__/store.git-integration.test.ts
@@ -194,7 +194,7 @@ describe('turn change-set sidecar store', () => {
     });
   });
 
-  it('serializes exact captures for sessions sharing one workspace', async () => {
+  it('keeps overlapping same-workspace captures parallel and degrades both to review-only', async () => {
     const target = path.join(workdir, 'shared.txt');
     const workspaceAlias = path.join(root, 'workspace-alias');
     await fs.writeFile(target, 'old\n', 'utf8');
@@ -215,37 +215,191 @@ describe('turn change-set sidecar store', () => {
       targetPath: 'shared.txt',
     });
 
-    let secondResolved = false;
-    const second = beginTurnChangeSet({
+    // The second dispatch through the workspace alias must not wait for the first
+    // session's turn — overlap is marked instead of serialized.
+    await beginTurnChangeSet({
       sessionId: 'session-2',
       anchorClientId: 'user-2',
       provider: 'pi',
       cwd: workspaceAlias,
-    }).then(() => {
-      secondResolved = true;
     });
-    await Promise.resolve();
-    expect(secondResolved).toBe(false);
-
-    await fs.writeFile(target, 'first\n', 'utf8');
-    await finalizeTurnChangeSet('session-1', null, 'complete');
-    await second;
-
     await captureKnownFileBefore({
       sessionId: 'session-2',
       provider: 'pi',
       cwd: workspaceAlias,
       targetPath: 'shared.txt',
     });
+
+    await fs.writeFile(target, 'first\n', 'utf8');
+    await finalizeTurnChangeSet('session-1', null, 'complete');
     await fs.writeFile(target, 'second\n', 'utf8');
     await finalizeTurnChangeSet('session-2', null, 'complete');
 
-    const [first] = await getTurnChangeSets('session-1', (await listTurnChangeSets('session-1')).map(({ id }) => id));
-    const [secondDetail] = await getTurnChangeSets('session-2', (await listTurnChangeSets('session-2')).map(({ id }) => id));
-    expect(first?.diffs[0]?.rawPatch).toContain('-old');
-    expect(first?.diffs[0]?.rawPatch).toContain('+first');
-    expect(secondDetail?.diffs[0]?.rawPatch).toContain('-first');
-    expect(secondDetail?.diffs[0]?.rawPatch).toContain('+second');
+    const [first] = await listTurnChangeSets('session-1');
+    const [second] = await listTurnChangeSets('session-2');
+    expect(first).toMatchObject({
+      state: 'partial',
+      incompleteReasons: expect.arrayContaining(['concurrent-workspace']),
+      isReversible: false,
+    });
+    expect(second).toMatchObject({
+      state: 'partial',
+      incompleteReasons: expect.arrayContaining(['concurrent-workspace']),
+      isReversible: false,
+    });
+    // Captures are still recorded for review even though they overlapped.
+    const [firstDetail] = await getTurnChangeSets('session-1', [first!.id]);
+    expect(firstDetail?.diffs[0]?.rawPatch).toContain('-old');
+    await expect(applyTurnChangeSetAction('session-1', first!.id, 'undo'))
+      .rejects.toMatchObject({ kind: 'unsupported' } satisfies Partial<TurnChangeSetActionError>);
+  });
+
+  it('does not degrade sequential turns or different workspaces', async () => {
+    const target = path.join(workdir, 'seq.txt');
+    await fs.writeFile(target, 'a\n', 'utf8');
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'claude-code',
+      cwd: workdir,
+    });
+    await captureKnownFileBefore({
+      sessionId: 'session-1',
+      provider: 'claude-code',
+      cwd: workdir,
+      targetPath: 'seq.txt',
+    });
+    await fs.writeFile(target, 'b\n', 'utf8');
+
+    // A concurrent turn in a *different* directory shares nothing.
+    const otherDir = path.join(root, 'other-workspace');
+    await fs.mkdir(otherDir);
+    const otherTarget = path.join(otherDir, 'other.txt');
+    await fs.writeFile(otherTarget, 'x\n', 'utf8');
+    await beginTurnChangeSet({
+      sessionId: 'session-2',
+      anchorClientId: 'user-2',
+      provider: 'pi',
+      cwd: otherDir,
+    });
+    await captureKnownFileBefore({
+      sessionId: 'session-2',
+      provider: 'pi',
+      cwd: otherDir,
+      targetPath: 'other.txt',
+    });
+    await fs.writeFile(otherTarget, 'y\n', 'utf8');
+
+    await finalizeTurnChangeSet('session-1', null, 'complete');
+    await finalizeTurnChangeSet('session-2', null, 'complete');
+
+    expect((await listTurnChangeSets('session-1'))[0]).toMatchObject({
+      state: 'complete',
+      incompleteReasons: [],
+      isReversible: true,
+    });
+    expect((await listTurnChangeSets('session-2'))[0]).toMatchObject({
+      state: 'complete',
+      incompleteReasons: [],
+      isReversible: true,
+    });
+
+    // A sequential turn in the same directory (begun after the prior finalize) is
+    // untouched by overlap marking.
+    await beginTurnChangeSet({
+      sessionId: 'session-2',
+      anchorClientId: 'user-2',
+      provider: 'pi',
+      cwd: workdir,
+    });
+    await captureKnownFileBefore({
+      sessionId: 'session-2',
+      provider: 'pi',
+      cwd: workdir,
+      targetPath: 'seq.txt',
+    });
+    await fs.writeFile(target, 'c\n', 'utf8');
+    await finalizeTurnChangeSet('session-2', null, 'complete');
+    const sequential = (await listTurnChangeSets('session-2')).find(
+      (entry) => entry.cwd === workdir,
+    );
+    expect(sequential).toMatchObject({
+      state: 'complete',
+      incompleteReasons: [],
+      isReversible: true,
+    });
+  });
+
+  it('waits for the prior after-image seal instead of marking a non-overlapping dispatch', async () => {
+    const target = path.join(workdir, 'seal.txt');
+    await fs.writeFile(target, 'before\n', 'utf8');
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'claude-code',
+      cwd: workdir,
+    });
+    await captureKnownFileBefore({
+      sessionId: 'session-1',
+      provider: 'claude-code',
+      cwd: workdir,
+      targetPath: 'seal.txt',
+    });
+    await fs.writeFile(target, 'after\n', 'utf8');
+
+    // Finalize is not awaited: the next dispatch must wait for the seal, then see
+    // no active capture — no degradation on either side.
+    const sealing = finalizeTurnChangeSet('session-1', null, 'complete');
+    await beginTurnChangeSet({
+      sessionId: 'session-2',
+      anchorClientId: 'user-2',
+      provider: 'pi',
+      cwd: workdir,
+    });
+    await sealing;
+    await finalizeTurnChangeSet('session-2', null, 'complete');
+
+    expect((await listTurnChangeSets('session-1'))[0]).toMatchObject({
+      state: 'complete',
+      incompleteReasons: [],
+      isReversible: true,
+    });
+    expect(await listTurnChangeSets('session-2')).toHaveLength(0);
+  });
+
+  it('drops an overlapping turn that never touched files instead of persisting an empty card', async () => {
+    await beginTurnChangeSet({
+      sessionId: 'session-1',
+      anchorClientId: 'user-1',
+      provider: 'claude-code',
+      cwd: workdir,
+    });
+    const target = path.join(workdir, 'busy-work.txt');
+    await fs.writeFile(target, 'v1\n', 'utf8');
+    await captureKnownFileBefore({
+      sessionId: 'session-1',
+      provider: 'claude-code',
+      cwd: workdir,
+      targetPath: 'busy-work.txt',
+    });
+    // Chat-only turn overlapping in the same directory: no captures, no card.
+    await beginTurnChangeSet({
+      sessionId: 'session-2',
+      anchorClientId: 'user-2',
+      provider: 'pi',
+      cwd: workdir,
+    });
+    await finalizeTurnChangeSet('session-2', null, 'complete');
+    await fs.writeFile(target, 'v2\n', 'utf8');
+    await finalizeTurnChangeSet('session-1', null, 'complete');
+
+    expect(await listTurnChangeSets('session-2')).toHaveLength(0);
+    expect((await listTurnChangeSets('session-1'))[0]).toMatchObject({
+      state: 'partial',
+      incompleteReasons: expect.arrayContaining(['concurrent-workspace']),
+      isReversible: false,
+      fileCount: 1,
+    });
   });
 
   it('undoes and reapplies an exact text patch without changing chat history', async () => {

--- a/apps/desktop/src/main/turn-change-set/store.ts
+++ b/apps/desktop/src/main/turn-change-set/store.ts
@@ -1096,7 +1096,13 @@ async function persistPending(
   const files = diffs.length > 0 ? summarizeDiffs(diffs) : pending.nativeFiles;
   // An opaque tool with no known paths is still important turn metadata. Persist a
   // zero-file partial entry so the UI never silently represents it as fully tracked.
-  if (files.length === 0 && pending.incompleteReasons.size === 0) return;
+  // 'turn-failed' alone is not such evidence: a turn that failed without any capture
+  // activity (no tools, no files) cannot have changed the workspace, so persisting
+  // an empty partial card would claim untracked changes that never existed.
+  if (
+    files.length === 0
+    && [...pending.incompleteReasons].every((reason) => reason === 'turn-failed')
+  ) return;
   const anchorClientId = pending.anchorClientId;
   if (!anchorClientId) {
     log.warn('turn change-set has no visible user anchor', { sessionId, id: pending.id });
@@ -1442,10 +1448,21 @@ async function validAnchorIds(sessionId: string, summaries: readonly TurnChangeS
   return new Set(rows.map((row) => row.clientId));
 }
 
+/**
+ * A zero-file entry whose only incomplete reason is 'turn-failed' carries no change
+ * information (see persistPending). Earlier builds persisted such entries for every
+ * failed turn; hide them on read so legacy sidecars self-heal without a migration.
+ */
+function isEmptyFailedTurnEntry(summary: TurnChangeSetSummary): boolean {
+  return summary.fileCount === 0
+    && summary.incompleteReasons.every((reason) => reason === 'turn-failed');
+}
+
 export async function listTurnChangeSets(sessionId: string): Promise<TurnChangeSetSummary[]> {
   const summaries = await readIndex(sessionId);
   const anchors = await validAnchorIds(sessionId, summaries);
-  return summaries.filter((summary) => anchors.has(summary.anchorClientId));
+  return summaries.filter((summary) =>
+    anchors.has(summary.anchorClientId) && !isEmptyFailedTurnEntry(summary));
 }
 
 export async function getTurnChangeSets(

--- a/apps/desktop/src/main/turn-change-set/store.ts
+++ b/apps/desktop/src/main/turn-change-set/store.ts
@@ -95,6 +95,7 @@ const INCOMPLETE_REASONS = new Set<TurnChangeIncompleteReason>([
   'diff-too-large',
   'provider-diff-conflict',
   'turn-failed',
+  'concurrent-workspace',
 ]);
 const FILE_STATUSES = new Set<FileDiff['status']>([
   'added',
@@ -133,24 +134,14 @@ export interface BeginTurnChangeSetInput {
 const pendingBySession = new Map<string, PendingTurnChangeSet>();
 const sessionWriteChains = new Map<string, Promise<unknown>>();
 const workspaceActionChains = new Map<string, Promise<unknown>>();
-const workspaceCaptureChains = new Map<string, Promise<void>>();
-const workspaceCaptureLeasesBySession = new Map<string, WorkspaceCaptureLease>();
+const workspaceSealChains = new Map<string, Promise<void>>();
+const beginEpochBySession = new Map<string, number>();
 const pendingWorkspaceBySession = new Map<string, string>();
 const pendingWorkspaceCounts = new Map<string, number>();
 const retainedSessionDirs = new Map<string, number>();
 const activeActionPromises = new Set<Promise<unknown>>();
 const legacyReversibleCapabilityByDetailPath = new Map<string, boolean>();
 let storageWriteChain = Promise.resolve();
-
-interface WorkspaceCaptureLease {
-  key: string;
-  anchorClientId: string;
-  ready: Promise<void>;
-  resolveReady: () => void;
-  rejectReady: (error: unknown) => void;
-  cancelled: boolean;
-  release: () => void;
-}
 
 function byteLength(value: string): number {
   return Buffer.byteLength(value, 'utf8');
@@ -249,6 +240,10 @@ function isReversiblePatch(value: PersistedTurnChangeSetV1): boolean {
   ) {
     return false;
   }
+  // An after-image read while another turn overlapped in the same workspace may
+  // contain the other turn's writes; applying it in either direction could undo
+  // work this turn never did. Keep overlapped captures review-only.
+  if (value.incompleteReasons.includes('concurrent-workspace')) return false;
   if (/^(?:GIT binary patch|Binary files .* differ)$/m.test(value.unifiedDiff)) return false;
   if (/^(?:old mode|new mode)\s+/m.test(value.unifiedDiff)) return false;
   if (/\b160000\b/.test(value.unifiedDiff)) return false;
@@ -555,59 +550,55 @@ function unregisterPendingWorkspace(sessionId: string): void {
   else pendingWorkspaceCounts.set(key, next);
 }
 
-function releaseWorkspaceCaptureLease(sessionId: string): void {
-  const lease = workspaceCaptureLeasesBySession.get(sessionId);
-  if (!lease) return;
-  workspaceCaptureLeasesBySession.delete(sessionId);
-  lease.rejectReady(new Error('Turn change-set capture was cancelled.'));
-  lease.release();
+function cancelPendingBegin(sessionId: string): void {
+  beginEpochBySession.set(sessionId, (beginEpochBySession.get(sessionId) ?? 0) + 1);
 }
 
 /**
- * Reserve the workspace synchronously before the first await in beginTurnChangeSet.
- * This makes concurrent dispatches for one local workdir queue behind the prior
- * turn's after-image capture instead of interleaving before/after snapshots.
+ * Tracks in-flight after-image persistence per workspace. The next dispatch in the
+ * same directory waits for prior snapshots to seal before its turn may mutate files.
+ * This wait is bounded capture I/O — never the duration of a running turn.
  */
-function reserveWorkspaceCaptureLease(sessionId: string, cwd: string, anchorClientId: string): {
-  previous: Promise<void>;
-  lease: WorkspaceCaptureLease;
-} {
+function registerWorkspaceSeal(cwd: string, operation: Promise<unknown>): void {
   const key = normalizeTurnChangeSetWorkspaceKey(cwd);
-  const previous = workspaceCaptureChains.get(key) ?? Promise.resolve();
-  let resolveCurrent!: () => void;
-  const current = new Promise<void>((resolve) => {
-    resolveCurrent = resolve;
+  const settled = operation.then(() => undefined, () => undefined);
+  const previous = workspaceSealChains.get(key) ?? Promise.resolve();
+  const current = previous.then(() => settled).finally(() => {
+    if (workspaceSealChains.get(key) === current) workspaceSealChains.delete(key);
   });
-  workspaceCaptureChains.set(key, current);
+  workspaceSealChains.set(key, current);
+}
 
-  let resolveReady!: () => void;
-  let rejectReady!: (error: unknown) => void;
-  const ready = new Promise<void>((resolve, reject) => {
-    resolveReady = resolve;
-    rejectReady = reject;
-  });
-  // A rejected readiness promise is only an internal coordination signal. Keep
-  // it from becoming an unhandled rejection when no re-entrant caller awaits it.
-  void ready.catch(() => undefined);
+async function waitForWorkspaceSeals(cwd: string): Promise<void> {
+  const key = normalizeTurnChangeSetWorkspaceKey(cwd);
+  for (;;) {
+    const current = workspaceSealChains.get(key);
+    if (!current) return;
+    await current.catch(() => undefined);
+    if (workspaceSealChains.get(key) === current) return;
+  }
+}
 
-  let released = false;
-  const lease: WorkspaceCaptureLease = {
-    key,
-    anchorClientId,
-    ready,
-    resolveReady,
-    rejectReady,
-    cancelled: false,
-    release: () => {
-      if (released) return;
-      released = true;
-      lease.cancelled = true;
-      resolveCurrent();
-      if (workspaceCaptureChains.get(key) === current) workspaceCaptureChains.delete(key);
-    },
-  };
-  workspaceCaptureLeasesBySession.set(sessionId, lease);
-  return { previous, lease };
+/**
+ * Optimistic concurrency for one shared workdir: overlapping turns are never
+ * serialized (a turn has no bounded duration). Instead every capture that overlaps
+ * another session's active capture is marked — the record stays reviewable, but an
+ * after-image read during overlap may contain the other turn's writes, so both
+ * sides become review-only (see isReversiblePatch).
+ */
+function markConcurrentWorkspaceCapture(sessionId: string): void {
+  const key = pendingWorkspaceBySession.get(sessionId);
+  const own = pendingBySession.get(sessionId);
+  if (!key || !own) return;
+  let overlapped = false;
+  for (const [otherSessionId, otherKey] of pendingWorkspaceBySession) {
+    if (otherSessionId === sessionId || otherKey !== key) continue;
+    const other = pendingBySession.get(otherSessionId);
+    if (!other) continue;
+    addIncompleteReason(other, 'concurrent-workspace');
+    overlapped = true;
+  }
+  if (overlapped) addIncompleteReason(own, 'concurrent-workspace');
 }
 
 async function waitForWorkspaceActions(cwd: string): Promise<void> {
@@ -814,7 +805,7 @@ export async function beginTurnChangeSet(input: BeginTurnChangeSetInput): Promis
     clearPendingTurnChangeSets(input.sessionId);
     return;
   }
-  let existing = pendingBySession.get(input.sessionId);
+  const existing = pendingBySession.get(input.sessionId);
   if (existing) {
     if (existing.anchorClientId === input.anchorClientId) return;
     log.warn('replacing unfinished turn change-set at dispatch boundary', {
@@ -825,41 +816,21 @@ export async function beginTurnChangeSet(input: BeginTurnChangeSetInput): Promis
     pendingBySession.delete(input.sessionId);
     unregisterPendingWorkspace(input.sessionId);
   }
-  const existingLease = workspaceCaptureLeasesBySession.get(input.sessionId);
-  if (existingLease) {
-    if (existingLease.anchorClientId === input.anchorClientId) {
-      await existingLease.ready;
-      return;
-    }
-    releaseWorkspaceCaptureLease(input.sessionId);
+  const epoch = beginEpochBySession.get(input.sessionId) ?? 0;
+  // Bounded waits only: prior after-image seals and user-triggered undo/reapply in
+  // this workspace. Dispatch never waits for another session's running turn — an
+  // overlapping turn degrades both captures instead (markConcurrentWorkspaceCapture).
+  await waitForWorkspaceSeals(input.cwd);
+  await waitForWorkspaceActions(input.cwd);
+  if ((beginEpochBySession.get(input.sessionId) ?? 0) !== epoch) return;
+  const raced = pendingBySession.get(input.sessionId);
+  if (raced && raced.anchorClientId !== null && raced.anchorClientId !== input.anchorClientId) {
+    pendingBySession.delete(input.sessionId);
+    unregisterPendingWorkspace(input.sessionId);
   }
-  const { previous, lease } = reserveWorkspaceCaptureLease(
-    input.sessionId,
-    input.cwd,
-    input.anchorClientId,
-  );
-  try {
-    await previous.catch(() => undefined);
-    if (lease.cancelled || workspaceCaptureLeasesBySession.get(input.sessionId) !== lease) return;
-    await waitForWorkspaceActions(input.cwd);
-    if (lease.cancelled || workspaceCaptureLeasesBySession.get(input.sessionId) !== lease) return;
-    existing = pendingBySession.get(input.sessionId);
-    if (existing?.anchorClientId === input.anchorClientId) {
-      lease.resolveReady();
-      return;
-    }
-    if (existing) {
-      pendingBySession.delete(input.sessionId);
-      unregisterPendingWorkspace(input.sessionId);
-    }
-    const pending = ensurePending(input.sessionId, input.provider, input.cwd);
-    pending.anchorClientId = input.anchorClientId;
-    lease.resolveReady();
-  } catch (error) {
-    lease.rejectReady(error);
-    releaseWorkspaceCaptureLease(input.sessionId);
-    throw error;
-  }
+  const pending = ensurePending(input.sessionId, input.provider, input.cwd);
+  pending.anchorClientId = input.anchorClientId;
+  markConcurrentWorkspaceCapture(input.sessionId);
 }
 
 function addIncompleteReason(
@@ -1096,12 +1067,15 @@ async function persistPending(
   const files = diffs.length > 0 ? summarizeDiffs(diffs) : pending.nativeFiles;
   // An opaque tool with no known paths is still important turn metadata. Persist a
   // zero-file partial entry so the UI never silently represents it as fully tracked.
-  // 'turn-failed' alone is not such evidence: a turn that failed without any capture
-  // activity (no tools, no files) cannot have changed the workspace, so persisting
-  // an empty partial card would claim untracked changes that never existed.
+  // 'turn-failed' and 'concurrent-workspace' alone are not such evidence: a turn
+  // that failed or merely overlapped another session without any capture activity
+  // (no tools, no files) has nothing to record, so persisting an empty partial card
+  // would claim untracked changes that never existed.
   if (
     files.length === 0
-    && [...pending.incompleteReasons].every((reason) => reason === 'turn-failed')
+    && [...pending.incompleteReasons].every(
+      (reason) => reason === 'turn-failed' || reason === 'concurrent-workspace',
+    )
   ) return;
   const anchorClientId = pending.anchorClientId;
   if (!anchorClientId) {
@@ -1148,12 +1122,15 @@ export function finalizeTurnChangeSet(
   const pending = pendingBySession.get(sessionId);
   if (!pending) return Promise.resolve();
   pendingBySession.delete(sessionId);
-  return enqueueSessionWrite(sessionId, () => persistPending(sessionId, pending, terminalState))
+  const write = enqueueSessionWrite(sessionId, () => persistPending(sessionId, pending, terminalState))
     .catch((error) => log.warn('turn change-set persist failed', { sessionId, error }))
     .finally(() => {
       unregisterPendingWorkspace(sessionId);
-      releaseWorkspaceCaptureLease(sessionId);
     });
+  // The next dispatch in this workspace must not let its turn mutate files while
+  // this after-image is still being read (registered synchronously on purpose).
+  registerWorkspaceSeal(pending.cwd, write);
+  return write;
 }
 
 /** Prevents the next product turn from mutating files before the prior after-image is sealed. */
@@ -1427,7 +1404,7 @@ export function applyTurnChangeSetAction(
 export function clearPendingTurnChangeSets(sessionId: string): void {
   pendingBySession.delete(sessionId);
   unregisterPendingWorkspace(sessionId);
-  releaseWorkspaceCaptureLease(sessionId);
+  cancelPendingBegin(sessionId);
 }
 
 async function validAnchorIds(sessionId: string, summaries: readonly TurnChangeSetSummary[]): Promise<Set<string>> {
@@ -1495,7 +1472,7 @@ export async function getTurnChangeSets(
 export async function removeTurnChangeSetsForSession(sessionId: string): Promise<void> {
   pendingBySession.delete(sessionId);
   unregisterPendingWorkspace(sessionId);
-  releaseWorkspaceCaptureLease(sessionId);
+  cancelPendingBegin(sessionId);
   await enqueueSessionWrite(sessionId, async () => {
     await fs.rm(sessionDir(sessionId), { recursive: true, force: true });
   });

--- a/apps/desktop/src/main/turn-change-set/store.ts
+++ b/apps/desktop/src/main/turn-change-set/store.ts
@@ -1426,9 +1426,12 @@ async function validAnchorIds(sessionId: string, summaries: readonly TurnChangeS
 }
 
 /**
- * A zero-file entry whose only incomplete reason is 'turn-failed' carries no change
- * information (see persistPending). Earlier builds persisted such entries for every
- * failed turn; hide them on read so legacy sidecars self-heal without a migration.
+ * A zero-file entry whose incomplete reasons are at most 'turn-failed' carries no
+ * change information (see persistPending). Earlier builds persisted such entries for
+ * every failed turn; hide them on read so legacy sidecars self-heal without a
+ * migration. The reasons-empty shape is deliberately included: no build has ever
+ * persisted it (the write guard drops it), and if a corrupted sidecar produced one
+ * it would render an equally information-free "+0 -0" card, so it is hidden too.
  */
 function isEmptyFailedTurnEntry(summary: TurnChangeSetSummary): boolean {
   return summary.fileCount === 0

--- a/apps/desktop/src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
+++ b/apps/desktop/src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
@@ -327,6 +327,52 @@ describe('buildRenderItems — key stability', () => {
     expect(items.indexOf(cards[0])).toBeGreaterThan(items.findIndex((item) => item.key === 'msg-a1'));
   });
 
+  it('hides zero-file cards without change evidence but keeps evidence-bearing ones', () => {
+    const base: TurnChangeSetSummary = {
+      id: 'cs-base',
+      sessionId: 's1',
+      anchorClientId: 'u1',
+      provider: 'claude-code',
+      providerTurnId: null,
+      cwd: 'C:/work',
+      state: 'partial',
+      workspaceState: 'applied',
+      isReversible: false,
+      incompleteReasons: [],
+      createdAt: 1,
+      completedAt: 2,
+      files: [],
+      fileCount: 0,
+      additions: 0,
+      deletions: 0,
+    };
+    // Only "we might not have seen everything" reasons: review pane would be empty.
+    const noEvidence: TurnChangeSetSummary = {
+      ...base,
+      id: 'cs-noise',
+      incompleteReasons: ['opaque-tool', 'turn-failed', 'concurrent-workspace'],
+    };
+    // Proof that real changes existed but were not recorded: card must stay.
+    const truncated: TurnChangeSetSummary = {
+      ...base,
+      id: 'cs-too-large',
+      incompleteReasons: ['opaque-tool', 'diff-too-large'],
+      createdAt: 3,
+      completedAt: 4,
+    };
+
+    const { items } = buildRenderItems(
+      [mkUser('u1'), mkAssistant('a1'), mkUser('u2')],
+      undefined,
+      undefined,
+      { turnChangeSets: [noEvidence, truncated] },
+    );
+    const cards = items.filter(
+      (item): item is Extract<RenderItem, { type: 'turn_changes' }> => item.type === 'turn_changes',
+    );
+    expect(cards.map((card) => card.changeSet.id)).toEqual(['cs-too-large']);
+  });
+
   it('keeps opaque command artifacts as fallback chips without duplicating exact files', () => {
     const messages = [
       mkUser('u1'),

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -218,8 +218,7 @@ import { useNavigationKeyListener } from './useNavigationKeyListener';
 import { suppressScrollbarActivation } from '@/lib/scrollbarAutoHide';
 import { collectAssistantTurnUsageDetails } from '@/lib/userTurnUsage';
 import type { TurnUsageDetails } from '../../../shared/turnUsageDetails';
-import { hasReviewableTurnChanges } from '../../../shared/turnChangeSet';
-import type { TurnChangeSetSummary } from '../../../shared/turnChangeSet';
+import { hasReviewableTurnChanges, type TurnChangeSetSummary } from '../../../shared/turnChangeSet';
 
 interface MessageStreamProps {
   /** Active session id — used to reset scroll state on session switch. */

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -218,6 +218,7 @@ import { useNavigationKeyListener } from './useNavigationKeyListener';
 import { suppressScrollbarActivation } from '@/lib/scrollbarAutoHide';
 import { collectAssistantTurnUsageDetails } from '@/lib/userTurnUsage';
 import type { TurnUsageDetails } from '../../../shared/turnUsageDetails';
+import { hasReviewableTurnChanges } from '../../../shared/turnChangeSet';
 import type { TurnChangeSetSummary } from '../../../shared/turnChangeSet';
 
 interface MessageStreamProps {
@@ -1083,6 +1084,9 @@ export function buildRenderItems(
       }
     }
     for (const changeSet of changeSets) {
+      // Zero-file entries without change evidence (e.g. only opaque tools ran)
+      // would render a card whose review pane is empty — skip the dead end.
+      if (!hasReviewableTurnChanges(changeSet)) continue;
       items.push({
         type: 'turn_changes',
         key: `turnchanges-${changeSet.id}`,

--- a/apps/desktop/src/shared/turnChangeSet.ts
+++ b/apps/desktop/src/shared/turnChangeSet.ts
@@ -75,6 +75,29 @@ export interface PersistedTurnChangeSetV1 {
   files: TurnChangeFileSummary[];
 }
 
+/**
+ * Reasons that only say "the capture may not have seen everything", without any
+ * evidence that a change actually happened (opaque tools ran, the turn failed, or
+ * another session overlapped). Reasons outside this set (diff-too-large,
+ * outside-workspace, sensitive-file, …) prove real changes existed but were not
+ * recorded.
+ */
+const NO_CHANGE_EVIDENCE_REASONS: ReadonlySet<TurnChangeIncompleteReason> = new Set([
+  'opaque-tool',
+  'turn-failed',
+  'concurrent-workspace',
+]);
+
+/**
+ * Whether a summary carries anything a standalone review card can show. Zero-file
+ * entries whose reasons carry no change evidence open an empty review pane — hide
+ * the chat-stream card instead of sending users into a dead end.
+ */
+export function hasReviewableTurnChanges(summary: TurnChangeSetSummary): boolean {
+  if (summary.fileCount > 0 || summary.files.length > 0) return true;
+  return summary.incompleteReasons.some((reason) => !NO_CHANGE_EVIDENCE_REASONS.has(reason));
+}
+
 export interface TurnChangeSetUpdatedPayload {
   sessionId: string;
   summary: TurnChangeSetSummary;

--- a/apps/desktop/src/shared/turnChangeSet.ts
+++ b/apps/desktop/src/shared/turnChangeSet.ts
@@ -16,7 +16,9 @@ export type TurnChangeIncompleteReason =
   | 'read-failed'
   | 'diff-too-large'
   | 'provider-diff-conflict'
-  | 'turn-failed';
+  | 'turn-failed'
+  /** Another session's turn overlapped in the same workspace; capture attribution is best-effort and never undoable. */
+  | 'concurrent-workspace';
 
 export interface TurnChangeFileSummary {
   id: string;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复昨天合入的本轮变更捕获(#1901)上线首日暴露的三个问题,三个 commit 各对应一个:

1. **`1263b6e3c` 失败轮次的空审查卡**:轮次以 `partial` 收尾时无条件追加 `turn-failed` 原因,击穿了零文件空集守卫——任何失败轮次(如请求 400 立即报错、一个工具都没跑)都会落盘一张 `+0 -0` 的「文件变更未完整记录」卡。写侧:零文件且原因仅 `turn-failed` 不落盘;读侧:`listTurnChangeSets` 过滤存量同类空条目,旧数据自愈、无需迁移。
2. **`1eb499f52` 同目录多任务被整轮串行**:workspace capture lease 持锁区间是整个 agent 轮次,且 await 在 vendor 派发之前、无超时无提示——同一工作目录的多个任务被完全串行化,后发任务的消息落库后无限期滞留(实测 17 分钟,卡在上一任务轮次结束的毫秒级时刻才放行)。:无轮次级锁 + 冲突检测降级)改为乐观并发:派发永不等待运行中轮次;同目录轮次重叠时双方变更集标记新增的 `concurrent-workspace` 原因,diff 照常可审查但判为不可撤销(重叠期间读到的 after-image 可能混入对方写入,双向 apply 都不安全)。仅保留两类有界等待:上一轮 after-image 落盘(seal,纯捕获 I/O)与进行中的 undo/reapply。
3. **`f101b90c3` 无变更证据的零文件卡是死胡同**:agent 几乎每轮都跑 Bash(不透明工具),每轮都落盘零文件 `opaque-tool` 条目并渲染空卡,点「审查」打开的是空面板。按「有无变更证据」划分:仅 `opaque-tool` / `turn-failed` / `concurrent-workspace`(只说明「可能没看全」)的零文件条目不再在聊天流渲染卡片;`diff-too-large` / `outside-workspace` / `sensitive-file` 等(证明真实变更存在但未记录)保留。落盘行为不变,仅渲染层过滤。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:无(dogfooding 实报,根因分析见各 commit message)
- 本 PR 包含:`turn-change-set/store.ts` 的串行锁改乐观并发与空集守卫、`shared/turnChangeSet.ts` 新增 `concurrent-workspace` 原因与 `hasReviewableTurnChanges` 判定、`MessageStream.tsx` 渲染过滤、对应回归测试
- 明确不包含:worktree-per-task 的产品引导、`concurrent-workspace` 专属的 UI 文案(暂用通用 partial 警示)
- 用户可见变化:同目录多任务真正并行(消息不再排队等另一任务整轮结束);失败/纯 Bash 轮次不再出现 `+0 -0` 空审查卡;同目录并行期间双方都改了文件时,审查卡带「未完整记录」警示且无撤销按钮
- 是否存在 breaking change:无(持久化格式向后兼容;新增枚举值旧版本 parse 到会整条丢弃该条目,仅影响本地 sidecar 展示,不丢用户数据)

### UI 变化

聊天流中零文件、无变更证据的审查卡不再渲染(纯移除,无新增视觉/交互/文案)。修复前后对比:修复前每个跑过 Bash 的轮次都有一张 `+0 -0` 卡,点「审查」是空面板;修复后不出现。有文件变更的卡片渲染完全不变。

- 引用的设计规范:DESIGN.md §7 Do「Keep content density low — each section should present one clear idea」。本次为纯移除零信息量元素,无新增样式、组件或文案,不涉及双模式适配(未触碰任何颜色/布局代码)。

## 怎么验证的

### 自动验证

```text
pnpm test:unit                       # 全仓单测,三个 commit 各跑一轮,全部 PASS(desktop ~155s)
pnpm test:git-integration            # 含 store.git-integration.test.ts 40/40(串行改并行的语义测试重写 + 8 个新增回归)
pnpm --filter desktop typecheck      # PASS(每个 commit 提交前各跑一轮)
pnpm check:dco                       # 3 commits signed off
```

新增/重写的关键回归:
- 失败轮次:无活动不落盘、有文件变更落盘标 `turn-failed`、跑过 opaque 工具零文件也保留、读侧隐藏旧版本存量空条目
- 并发:同目录重叠 → 双方并行放行 + 标 `concurrent-workspace` + 不可撤销 + undo 拒绝 `unsupported`;顺序轮次/异目录不降级;seal 等待不误标;纯对话重叠不落盘
- 渲染:零文件无证据条目不出卡,`diff-too-large` 零文件卡保留(`buildRenderItemsKeyStability.test.ts` 59/59)

### 手工验证

Windows,worktree dev 实例(`restart:desktop:remote --region=cn`)实机确认:失败轮次与纯 Bash 轮次不再出现空卡;存量 `turn-failed` 空卡打开旧会话即消失(读侧自愈);有文件变更的卡片照常显示、审查面板内容正常。

### 未执行的验证

- 同目录双任务并行的实机端到端(消息即时派发 + 双方降级标记)未做完整实测——机制有 git-integration 测试覆盖,实机仅验证了单任务路径。原因:需要两个长轮次精确重叠,人工构造中;如实标注。
- Light/Dark 双模式目检:不适用,本次未新增/修改任何视觉样式(纯移除渲染分支)。

## 风险

### 风险分类

- [x] 其他:变更捕获/撤销功能的产品语义调整(详见下)

### 影响与回滚

- 影响范围:仅 Desktop 本地会话的变更捕获、审查卡与撤销;远程会话、mobile、协议、数据库 schema、插件均不涉及。**产品语义变化需 review 确认**:同目录并行期间重叠的轮次,撤销功能降级为只读审查(显式标记,不静默混淆)。这是把 #1901 的「阻塞换精确」改为「并行 + 诚实降级」,取舍同型且多一层显式标记。
- 回滚 / 降级方式:整体 revert 本 PR 即回到 #1901 行为(同目录重新串行);三个 commit 相互独立,可单独 revert。新增的 `concurrent-workspace` 枚举值随 revert 一并消失,已落盘的带该标记条目会被旧代码的 parse 白名单整条忽略,不产生错误状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释即文档;无需独立规则文档变更)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
