### PR TITLE
feat(im): 增加 lane 隔离的 Telegram 群历史检索核心

### DIFF
--- a/apps/desktop/drizzle/0087_puzzling_shen.sql
+++ b/apps/desktop/drizzle/0087_puzzling_shen.sql
@@ -1,0 +1,30 @@
+CREATE INDEX IF NOT EXISTS `hook_group_context_cursors_updated_at_idx` ON `hook_group_context_cursors` (`updated_at`);--> statement-breakpoint
+CREATE VIRTUAL TABLE IF NOT EXISTS `hook_group_messages_fts` USING fts5(
+	`text`,
+	`author`,
+	`file_names`,
+	content='hook_group_messages',
+	content_rowid='id',
+	tokenize='porter unicode61'
+);--> statement-breakpoint
+INSERT INTO `hook_group_messages_fts`(`hook_group_messages_fts`) VALUES('rebuild');--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `hook_group_messages_fts_insert`
+AFTER INSERT ON `hook_group_messages`
+BEGIN
+	INSERT INTO `hook_group_messages_fts`(rowid, `text`, `author`, `file_names`)
+	VALUES (new.`id`, new.`text`, new.`author`, new.`file_names`);
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `hook_group_messages_fts_delete`
+AFTER DELETE ON `hook_group_messages`
+BEGIN
+	INSERT INTO `hook_group_messages_fts`(`hook_group_messages_fts`, rowid, `text`, `author`, `file_names`)
+	VALUES ('delete', old.`id`, old.`text`, old.`author`, old.`file_names`);
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `hook_group_messages_fts_update`
+AFTER UPDATE ON `hook_group_messages`
+BEGIN
+	INSERT INTO `hook_group_messages_fts`(`hook_group_messages_fts`, rowid, `text`, `author`, `file_names`)
+	VALUES ('delete', old.`id`, old.`text`, old.`author`, old.`file_names`);
+	INSERT INTO `hook_group_messages_fts`(rowid, `text`, `author`, `file_names`)
+	VALUES (new.`id`, new.`text`, new.`author`, new.`file_names`);
+END;

--- a/apps/desktop/drizzle/0088_thankful_captain_midlands.sql
+++ b/apps/desktop/drizzle/0088_thankful_captain_midlands.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS `hook_group_message_stats` (
+	`provider` text PRIMARY KEY NOT NULL,
+	`row_count` integer NOT NULL,
+	`text_bytes` integer NOT NULL
+);--> statement-breakpoint
+INSERT INTO `hook_group_message_stats` (`provider`, `row_count`, `text_bytes`)
+SELECT `provider`, count(*), coalesce(sum(length(CAST(`text` AS BLOB))), 0)
+FROM `hook_group_messages`
+GROUP BY `provider`
+ON CONFLICT(`provider`) DO UPDATE SET
+	`row_count` = excluded.`row_count`,
+	`text_bytes` = excluded.`text_bytes`;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `hook_group_message_stats_insert`
+AFTER INSERT ON `hook_group_messages`
+BEGIN
+	INSERT INTO `hook_group_message_stats` (`provider`, `row_count`, `text_bytes`)
+	VALUES (new.`provider`, 1, length(CAST(new.`text` AS BLOB)))
+	ON CONFLICT(`provider`) DO UPDATE SET
+		`row_count` = `row_count` + 1,
+		`text_bytes` = `text_bytes` + excluded.`text_bytes`;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `hook_group_message_stats_delete`
+AFTER DELETE ON `hook_group_messages`
+BEGIN
+	UPDATE `hook_group_message_stats`
+	SET `row_count` = `row_count` - 1,
+		`text_bytes` = max(0, `text_bytes` - length(CAST(old.`text` AS BLOB)))
+	WHERE `provider` = old.`provider`;
+	DELETE FROM `hook_group_message_stats`
+	WHERE `provider` = old.`provider` AND `row_count` <= 0;
+END;--> statement-breakpoint
+CREATE TRIGGER IF NOT EXISTS `hook_group_message_stats_update`
+AFTER UPDATE ON `hook_group_messages`
+BEGIN
+	UPDATE `hook_group_message_stats`
+	SET `row_count` = `row_count` - 1,
+		`text_bytes` = max(0, `text_bytes` - length(CAST(old.`text` AS BLOB)))
+	WHERE `provider` = old.`provider`;
+	DELETE FROM `hook_group_message_stats`
+	WHERE `provider` = old.`provider` AND `row_count` <= 0;
+	INSERT INTO `hook_group_message_stats` (`provider`, `row_count`, `text_bytes`)
+	VALUES (new.`provider`, 1, length(CAST(new.`text` AS BLOB)))
+	ON CONFLICT(`provider`) DO UPDATE SET
+		`row_count` = `row_count` + 1,
+		`text_bytes` = `text_bytes` + excluded.`text_bytes`;
+END;

--- a/apps/desktop/drizzle/meta/0087_snapshot.json
+++ b/apps/desktop/drizzle/meta/0087_snapshot.json
@@ -1,0 +1,3898 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "832ba250-c879-4419-b8f9-750835a8b7d4",
+  "prevId": "cb0166d9-e42c-4135-8658-f291594a7c81",
+  "tables": {
+    "account_usage_snapshots": {
+      "name": "account_usage_snapshots",
+      "columns": {
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_input_queue_snapshots": {
+      "name": "agent_input_queue_snapshots",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_input_queue_snapshots_session_id_sessions_id_fk": {
+          "name": "agent_input_queue_snapshots_session_id_sessions_id_fk",
+          "tableFrom": "agent_input_queue_snapshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_mcp_servers": {
+      "name": "custom_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_mcp_servers_sort_order": {
+          "name": "idx_custom_mcp_servers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtimes": {
+          "name": "runtimes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_providers_sort_order": {
+          "name": "idx_custom_providers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_model_usage": {
+      "name": "daily_model_usage",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_model_usage_day_agent_kind_model_cost_currency_pk": {
+          "columns": [
+            "day",
+            "agent_kind",
+            "model",
+            "cost_currency"
+          ],
+          "name": "daily_model_usage_day_agent_kind_model_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_spend": {
+      "name": "daily_spend",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_spend_day_cost_currency_pk": {
+          "columns": [
+            "day",
+            "cost_currency"
+          ],
+          "name": "daily_spend_day_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_link_ownership": {
+      "name": "device_link_ownership",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_pid": {
+          "name": "owner_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_label": {
+          "name": "owner_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_jobs": {
+      "name": "embedding_jobs",
+      "columns": {
+        "rowid": {
+          "name": "rowid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_embedding_jobs_natural": {
+          "name": "uniq_embedding_jobs_natural",
+          "columns": [
+            "source",
+            "source_id",
+            "chunk_index",
+            "model_id"
+          ],
+          "isUnique": true
+        },
+        "idx_embedding_jobs_status_scheduled": {
+          "name": "idx_embedding_jobs_status_scheduled",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_embedding_jobs_source_id": {
+          "name": "idx_embedding_jobs_source_id",
+          "columns": [
+            "source",
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_meta": {
+      "name": "embedding_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ghost_cards": {
+      "name": "ghost_cards",
+      "columns": {
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ghost_id": {
+          "name": "ghost_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v": {
+          "name": "v",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ghost_cards_updated_at_idx": {
+          "name": "ghost_cards_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_context_cursors": {
+      "name": "hook_group_context_cursors",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_key": {
+          "name": "cursor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_context_cursors_updated_at_idx": {
+          "name": "hook_group_context_cursors_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "hook_group_context_cursors_provider_cursor_key_pk": {
+          "columns": [
+            "provider",
+            "cursor_key"
+          ],
+          "name": "hook_group_context_cursors_provider_cursor_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_messages": {
+      "name": "hook_group_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_names": {
+          "name": "file_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_messages_msg_idx": {
+          "name": "hook_group_messages_msg_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "hook_group_messages_window_idx": {
+          "name": "hook_group_messages_window_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "im_bindings": {
+      "name": "im_bindings",
+      "columns": {
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_context_id": {
+          "name": "bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_via_card_message_id": {
+          "name": "attached_via_card_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_im_bindings_target": {
+          "name": "idx_im_bindings_target",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_target_session_id_sessions_id_fk": {
+          "name": "im_bindings_target_session_id_sessions_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "im_bindings_channel_bot_context_id_user_id_scope_key_pk": {
+          "columns": [
+            "channel",
+            "bot_context_id",
+            "user_id",
+            "scope_key"
+          ],
+          "name": "im_bindings_channel_bot_context_id_user_id_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_blobs": {
+      "name": "media_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_cache": {
+          "name": "is_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_access_at": {
+          "name": "last_access_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_refs": {
+      "name": "media_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_refs_hash_idx": {
+          "name": "media_refs_hash_idx",
+          "columns": [
+            "hash"
+          ],
+          "isUnique": false
+        },
+        "media_refs_ref_idx": {
+          "name": "media_refs_ref_idx",
+          "columns": [
+            "ref_kind",
+            "ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_refs_hash_media_blobs_hash_fk": {
+          "name": "media_refs_hash_media_blobs_hash_fk",
+          "tableFrom": "media_refs",
+          "tableTo": "media_blobs",
+          "columnsFrom": [
+            "hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_meta": {
+          "name": "agent_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewind_at": {
+          "name": "rewind_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_messages_session_client": {
+          "name": "uniq_messages_session_client",
+          "columns": [
+            "session_id",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_messages_session_created": {
+          "name": "idx_messages_session_created",
+          "columns": [
+            "session_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_created_at": {
+          "name": "idx_messages_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_rewind_at": {
+          "name": "idx_messages_rewind_at",
+          "columns": [
+            "rewind_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_history": {
+      "name": "migration_history",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_meta": {
+      "name": "migration_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_teams": {
+      "name": "orca_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_session_id": {
+          "name": "lead_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_active_team_per_lead": {
+          "name": "uniq_active_team_per_lead",
+          "columns": [
+            "lead_session_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_teams\".\"status\" = 'active'"
+        },
+        "idx_orca_teams_status": {
+          "name": "idx_orca_teams_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_teams_lead_session_id_sessions_id_fk": {
+          "name": "orca_teams_lead_session_id_sessions_id_fk",
+          "tableFrom": "orca_teams",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "lead_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_worker_creation_reservations": {
+      "name": "orca_worker_creation_reservations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_worker_creation_reservations_team_label": {
+          "name": "uniq_orca_worker_creation_reservations_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "idx_orca_worker_creation_reservations_expires_at": {
+          "name": "idx_orca_worker_creation_reservations_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_worker_creation_reservations_team_id_orca_teams_id_fk": {
+          "name": "orca_worker_creation_reservations_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_worker_creation_reservations",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_workers": {
+      "name": "orca_workers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'developer'"
+        },
+        "focused": {
+          "name": "focused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "idle_since": {
+          "name": "idle_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_workers_session_id": {
+          "name": "uniq_orca_workers_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_team_label": {
+          "name": "uniq_orca_workers_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_focused_per_team": {
+          "name": "uniq_orca_workers_focused_per_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_workers\".\"focused\" = true"
+        },
+        "idx_orca_workers_team_id": {
+          "name": "idx_orca_workers_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orca_workers_status": {
+          "name": "idx_orca_workers_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_workers_team_id_orca_teams_id_fk": {
+          "name": "orca_workers_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "orca_workers_session_id_sessions_id_fk": {
+          "name": "orca_workers_session_id_sessions_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_aliases": {
+      "name": "project_aliases",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_aliases_updated_at": {
+          "name": "idx_project_aliases_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_automation_consents": {
+      "name": "project_automation_consents",
+      "columns": {
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recent_workdirs": {
+      "name": "recent_workdirs",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recent_workdirs_last_used_at": {
+          "name": "idx_recent_workdirs_last_used_at",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "right_sidebar_tabs": {
+      "name": "right_sidebar_tabs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "right_sidebar_tabs_session_idx": {
+          "name": "right_sidebar_tabs_session_idx",
+          "columns": [
+            "session_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "right_sidebar_tabs_session_id_sessions_id_fk": {
+          "name": "right_sidebar_tabs_session_id_sessions_id_fk",
+          "tableFrom": "right_sidebar_tabs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_runs": {
+      "name": "schedule_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_msg": {
+          "name": "error_msg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_usd": {
+          "name": "estimated_value_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_amount": {
+          "name": "estimated_value_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_attribution": {
+          "name": "cost_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "result_text": {
+          "name": "result_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_result": {
+          "name": "pre_run_hook_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_runs_schedule": {
+          "name": "idx_schedule_runs_schedule",
+          "columns": [
+            "schedule_id",
+            "fired_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_runs_schedule_id_schedules_id_fk": {
+          "name": "schedule_runs_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_runs_session_id_sessions_id_fk": {
+          "name": "schedule_runs_session_id_sessions_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prompt'"
+        },
+        "job_config": {
+          "name": "job_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "script_config": {
+          "name": "script_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "project_config_id": {
+          "name": "project_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_session_fallback": {
+          "name": "legacy_session_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cron'"
+        },
+        "cron_expr": {
+          "name": "cron_expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "manual": {
+          "name": "manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persistent_session": {
+          "name": "persistent_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "silent_when_idle": {
+          "name": "silent_when_idle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pre_run_hook_command": {
+          "name": "pre_run_hook_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_timeout_ms": {
+          "name": "pre_run_hook_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_log_session_id": {
+          "name": "skip_log_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_desktop": {
+          "name": "notify_desktop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_feishu": {
+          "name": "notify_feishu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_wecom_group": {
+          "name": "notify_wecom_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_finished_at": {
+          "name": "last_finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_fire_at": {
+          "name": "next_fire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedules_active_next": {
+          "name": "idx_schedules_active_next",
+          "columns": [
+            "status",
+            "next_fire_at"
+          ],
+          "isUnique": false
+        },
+        "idx_schedules_target_session": {
+          "name": "idx_schedules_target_session",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_target_session_id_sessions_id_fk": {
+          "name": "schedules_target_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedules_skip_log_session_id_sessions_id_fk": {
+          "name": "schedules_skip_log_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "skip_log_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_goals": {
+      "name": "session_goals",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "budget_tokens": {
+          "name": "budget_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_progress_limit": {
+          "name": "no_progress_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turns_used": {
+          "name": "turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "no_progress_streak": {
+          "name": "no_progress_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "usage_reset_at": {
+          "name": "usage_reset_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_goals_status": {
+          "name": "idx_session_goals_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_goals_session_id_sessions_id_fk": {
+          "name": "session_goals_session_id_sessions_id_fk",
+          "tableFrom": "session_goals",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_pr_refs": {
+      "name": "session_pr_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_session_pr_refs": {
+          "name": "uniq_session_pr_refs",
+          "columns": [
+            "session_id",
+            "owner",
+            "repo",
+            "pr_number"
+          ],
+          "isUnique": true
+        },
+        "idx_session_pr_refs_session_last_seen": {
+          "name": "idx_session_pr_refs_session_last_seen",
+          "columns": [
+            "session_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_pr_refs_session_id_sessions_id_fk": {
+          "name": "session_pr_refs_session_id_sessions_id_fk",
+          "tableFrom": "session_pr_refs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Maker'"
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-sonnet-4-6'"
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'high'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_token_usage": {
+          "name": "total_token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_amount": {
+          "name": "total_cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_currency": {
+          "name": "total_cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_is_approximate": {
+          "name": "total_cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "plan_mode_enabled": {
+          "name": "plan_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_send_at": {
+          "name": "user_send_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cc'"
+        },
+        "orca_role": {
+          "name": "orca_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_at_message_id": {
+          "name": "forked_at_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "feishu_open_id": {
+          "name": "feishu_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_bot_app_id": {
+          "name": "feishu_bot_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_bot_context_id": {
+          "name": "im_bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_user_id": {
+          "name": "im_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_project_context": {
+          "name": "used_project_context",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_history_has_product_prompt": {
+          "name": "codex_history_has_product_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_dirs": {
+          "name": "extra_dirs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "remote_host_id": {
+          "name": "remote_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_started_at": {
+          "name": "active_turn_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_pid": {
+          "name": "active_turn_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_turn_ended_at": {
+          "name": "last_turn_ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_updated_at": {
+          "name": "idx_sessions_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_user_send_at": {
+          "name": "idx_sessions_user_send_at",
+          "columns": [
+            "user_send_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_sdk_session_id": {
+          "name": "idx_sessions_sdk_session_id",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workdir_created": {
+          "name": "idx_sessions_workdir_created",
+          "columns": [
+            "working_dir",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_created_at": {
+          "name": "idx_sessions_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workspace_kind": {
+          "name": "idx_sessions_workspace_kind",
+          "columns": [
+            "workspace_kind"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_parent_session_id": {
+          "name": "idx_sessions_parent_session_id",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_orca_role": {
+          "name": "idx_sessions_orca_role",
+          "columns": [
+            "orca_role"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_worktree_path": {
+          "name": "idx_sessions_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_feishu_lookup": {
+          "name": "idx_sessions_feishu_lookup",
+          "columns": [
+            "source",
+            "feishu_bot_app_id",
+            "feishu_open_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_im_lookup": {
+          "name": "idx_sessions_im_lookup",
+          "columns": [
+            "source",
+            "im_bot_context_id",
+            "im_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_exposures": {
+      "name": "skill_usage_exposures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_line_no": {
+          "name": "raw_line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_path": {
+          "name": "skill_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_document_hash": {
+          "name": "skill_document_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exposure_content_hash": {
+          "name": "exposure_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_hash_source": {
+          "name": "document_hash_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repeated_tool_call_count": {
+          "name": "repeated_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_error_count": {
+          "name": "tool_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_call_count": {
+          "name": "command_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_failure_count": {
+          "name": "command_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_exposures_skill_document_version": {
+          "name": "idx_skill_usage_exposures_skill_document_version",
+          "columns": [
+            "analyzer_version",
+            "skill_name",
+            "skill_document_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_session": {
+          "name": "idx_skill_usage_exposures_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_raw_file": {
+          "name": "idx_skill_usage_exposures_raw_file",
+          "columns": [
+            "raw_file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk": {
+          "name": "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk",
+          "tableFrom": "skill_usage_exposures",
+          "tableTo": "skill_usage_sources",
+          "columnsFrom": [
+            "raw_file_path"
+          ],
+          "columnsTo": [
+            "raw_file_path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_sources": {
+      "name": "skill_usage_sources",
+      "columns": {
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mtime_ms": {
+          "name": "mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_sources_session": {
+          "name": "idx_skill_usage_sources_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_sources_sdk_session": {
+          "name": "idx_skill_usage_sources_sdk_session",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vec_table_meta": {
+      "name": "vec_table_meta",
+      "columns": {
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dim": {
+          "name": "dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_file_attachments": {
+      "name": "wechat_file_attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abs_path": {
+          "name": "abs_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'staged'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wechat_file_attachments_task": {
+          "name": "idx_wechat_file_attachments_task",
+          "columns": [
+            "binding_epoch",
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_file_attachments_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_session_id_sessions_id_fk": {
+          "name": "wechat_file_attachments_session_id_sessions_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_inbox": {
+      "name": "wechat_inbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_seq": {
+          "name": "platform_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_created_at": {
+          "name": "platform_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_epoch": {
+          "name": "conversation_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_nonce": {
+          "name": "context_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_ciphertext": {
+          "name": "context_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_tag": {
+          "name": "context_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_inbox_platform_message": {
+          "name": "uniq_wechat_inbox_platform_message",
+          "columns": [
+            "binding_epoch",
+            "platform_message_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_inbox_queue": {
+          "name": "idx_wechat_inbox_queue",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_lease": {
+          "name": "idx_wechat_inbox_lease",
+          "columns": [
+            "binding_epoch",
+            "lease_until"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_conversation": {
+          "name": "idx_wechat_inbox_conversation",
+          "columns": [
+            "binding_epoch",
+            "peer_id",
+            "conversation_epoch"
+          ],
+          "isUnique": false
+        },
+        "uniq_wechat_inbox_running_session": {
+          "name": "uniq_wechat_inbox_running_session",
+          "columns": [
+            "binding_epoch",
+            "session_id"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_inbox\".\"session_id\" IS NOT NULL AND \"wechat_inbox\".\"status\" IN ('dispatching', 'accepted_running', 'waiting_desktop', 'delivery_pending')"
+        }
+      },
+      "foreignKeys": {
+        "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_inbox_session_id_sessions_id_fk": {
+          "name": "wechat_inbox_session_id_sessions_id_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_outbox": {
+      "name": "wechat_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_json": {
+          "name": "media_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_outbox_client_id": {
+          "name": "uniq_wechat_outbox_client_id",
+          "columns": [
+            "binding_epoch",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_outbox_delivery": {
+          "name": "idx_wechat_outbox_delivery",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_outbox_task": {
+          "name": "idx_wechat_outbox_task",
+          "columns": [
+            "binding_epoch",
+            "task_id",
+            "chunk_index"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_outbox_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_outbox_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_sync_state": {
+      "name": "wechat_sync_state",
+      "columns": {
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_poll_at": {
+          "name": "last_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_sync_active": {
+          "name": "uniq_wechat_sync_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_sync_state\".\"is_active\" = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_orca_worker_creation_reservations_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "uniq_orca_workers_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/drizzle/meta/0088_snapshot.json
+++ b/apps/desktop/drizzle/meta/0088_snapshot.json
@@ -1,0 +1,3929 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7e28c084-8cbc-4d74-a47f-f84ddefabae0",
+  "prevId": "832ba250-c879-4419-b8f9-750835a8b7d4",
+  "tables": {
+    "account_usage_snapshots": {
+      "name": "account_usage_snapshots",
+      "columns": {
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_input_queue_snapshots": {
+      "name": "agent_input_queue_snapshots",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_input_queue_snapshots_session_id_sessions_id_fk": {
+          "name": "agent_input_queue_snapshots_session_id_sessions_id_fk",
+          "tableFrom": "agent_input_queue_snapshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_mcp_servers": {
+      "name": "custom_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_mcp_servers_sort_order": {
+          "name": "idx_custom_mcp_servers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtimes": {
+          "name": "runtimes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_providers_sort_order": {
+          "name": "idx_custom_providers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_model_usage": {
+      "name": "daily_model_usage",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_model_usage_day_agent_kind_model_cost_currency_pk": {
+          "columns": [
+            "day",
+            "agent_kind",
+            "model",
+            "cost_currency"
+          ],
+          "name": "daily_model_usage_day_agent_kind_model_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_spend": {
+      "name": "daily_spend",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_spend_day_cost_currency_pk": {
+          "columns": [
+            "day",
+            "cost_currency"
+          ],
+          "name": "daily_spend_day_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_link_ownership": {
+      "name": "device_link_ownership",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_pid": {
+          "name": "owner_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_label": {
+          "name": "owner_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_jobs": {
+      "name": "embedding_jobs",
+      "columns": {
+        "rowid": {
+          "name": "rowid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_embedding_jobs_natural": {
+          "name": "uniq_embedding_jobs_natural",
+          "columns": [
+            "source",
+            "source_id",
+            "chunk_index",
+            "model_id"
+          ],
+          "isUnique": true
+        },
+        "idx_embedding_jobs_status_scheduled": {
+          "name": "idx_embedding_jobs_status_scheduled",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_embedding_jobs_source_id": {
+          "name": "idx_embedding_jobs_source_id",
+          "columns": [
+            "source",
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_meta": {
+      "name": "embedding_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ghost_cards": {
+      "name": "ghost_cards",
+      "columns": {
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ghost_id": {
+          "name": "ghost_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v": {
+          "name": "v",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ghost_cards_updated_at_idx": {
+          "name": "ghost_cards_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_context_cursors": {
+      "name": "hook_group_context_cursors",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_key": {
+          "name": "cursor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_context_cursors_updated_at_idx": {
+          "name": "hook_group_context_cursors_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "hook_group_context_cursors_provider_cursor_key_pk": {
+          "columns": [
+            "provider",
+            "cursor_key"
+          ],
+          "name": "hook_group_context_cursors_provider_cursor_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_message_stats": {
+      "name": "hook_group_message_stats",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_bytes": {
+          "name": "text_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_messages": {
+      "name": "hook_group_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_names": {
+          "name": "file_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_messages_msg_idx": {
+          "name": "hook_group_messages_msg_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "hook_group_messages_window_idx": {
+          "name": "hook_group_messages_window_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "im_bindings": {
+      "name": "im_bindings",
+      "columns": {
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_context_id": {
+          "name": "bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_via_card_message_id": {
+          "name": "attached_via_card_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_im_bindings_target": {
+          "name": "idx_im_bindings_target",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_target_session_id_sessions_id_fk": {
+          "name": "im_bindings_target_session_id_sessions_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "im_bindings_channel_bot_context_id_user_id_scope_key_pk": {
+          "columns": [
+            "channel",
+            "bot_context_id",
+            "user_id",
+            "scope_key"
+          ],
+          "name": "im_bindings_channel_bot_context_id_user_id_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_blobs": {
+      "name": "media_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_cache": {
+          "name": "is_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_access_at": {
+          "name": "last_access_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_refs": {
+      "name": "media_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_refs_hash_idx": {
+          "name": "media_refs_hash_idx",
+          "columns": [
+            "hash"
+          ],
+          "isUnique": false
+        },
+        "media_refs_ref_idx": {
+          "name": "media_refs_ref_idx",
+          "columns": [
+            "ref_kind",
+            "ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_refs_hash_media_blobs_hash_fk": {
+          "name": "media_refs_hash_media_blobs_hash_fk",
+          "tableFrom": "media_refs",
+          "tableTo": "media_blobs",
+          "columnsFrom": [
+            "hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_meta": {
+          "name": "agent_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewind_at": {
+          "name": "rewind_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_messages_session_client": {
+          "name": "uniq_messages_session_client",
+          "columns": [
+            "session_id",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_messages_session_created": {
+          "name": "idx_messages_session_created",
+          "columns": [
+            "session_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_created_at": {
+          "name": "idx_messages_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_rewind_at": {
+          "name": "idx_messages_rewind_at",
+          "columns": [
+            "rewind_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_history": {
+      "name": "migration_history",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_meta": {
+      "name": "migration_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_teams": {
+      "name": "orca_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_session_id": {
+          "name": "lead_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_active_team_per_lead": {
+          "name": "uniq_active_team_per_lead",
+          "columns": [
+            "lead_session_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_teams\".\"status\" = 'active'"
+        },
+        "idx_orca_teams_status": {
+          "name": "idx_orca_teams_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_teams_lead_session_id_sessions_id_fk": {
+          "name": "orca_teams_lead_session_id_sessions_id_fk",
+          "tableFrom": "orca_teams",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "lead_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_worker_creation_reservations": {
+      "name": "orca_worker_creation_reservations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_worker_creation_reservations_team_label": {
+          "name": "uniq_orca_worker_creation_reservations_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "idx_orca_worker_creation_reservations_expires_at": {
+          "name": "idx_orca_worker_creation_reservations_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_worker_creation_reservations_team_id_orca_teams_id_fk": {
+          "name": "orca_worker_creation_reservations_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_worker_creation_reservations",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_workers": {
+      "name": "orca_workers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'developer'"
+        },
+        "focused": {
+          "name": "focused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "idle_since": {
+          "name": "idle_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_workers_session_id": {
+          "name": "uniq_orca_workers_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_team_label": {
+          "name": "uniq_orca_workers_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_focused_per_team": {
+          "name": "uniq_orca_workers_focused_per_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_workers\".\"focused\" = true"
+        },
+        "idx_orca_workers_team_id": {
+          "name": "idx_orca_workers_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orca_workers_status": {
+          "name": "idx_orca_workers_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_workers_team_id_orca_teams_id_fk": {
+          "name": "orca_workers_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "orca_workers_session_id_sessions_id_fk": {
+          "name": "orca_workers_session_id_sessions_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_aliases": {
+      "name": "project_aliases",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_aliases_updated_at": {
+          "name": "idx_project_aliases_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_automation_consents": {
+      "name": "project_automation_consents",
+      "columns": {
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recent_workdirs": {
+      "name": "recent_workdirs",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recent_workdirs_last_used_at": {
+          "name": "idx_recent_workdirs_last_used_at",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "right_sidebar_tabs": {
+      "name": "right_sidebar_tabs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "right_sidebar_tabs_session_idx": {
+          "name": "right_sidebar_tabs_session_idx",
+          "columns": [
+            "session_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "right_sidebar_tabs_session_id_sessions_id_fk": {
+          "name": "right_sidebar_tabs_session_id_sessions_id_fk",
+          "tableFrom": "right_sidebar_tabs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_runs": {
+      "name": "schedule_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_msg": {
+          "name": "error_msg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_usd": {
+          "name": "estimated_value_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_amount": {
+          "name": "estimated_value_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_attribution": {
+          "name": "cost_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "result_text": {
+          "name": "result_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_result": {
+          "name": "pre_run_hook_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_runs_schedule": {
+          "name": "idx_schedule_runs_schedule",
+          "columns": [
+            "schedule_id",
+            "fired_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_runs_schedule_id_schedules_id_fk": {
+          "name": "schedule_runs_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_runs_session_id_sessions_id_fk": {
+          "name": "schedule_runs_session_id_sessions_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prompt'"
+        },
+        "job_config": {
+          "name": "job_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "script_config": {
+          "name": "script_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "project_config_id": {
+          "name": "project_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_session_fallback": {
+          "name": "legacy_session_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cron'"
+        },
+        "cron_expr": {
+          "name": "cron_expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "manual": {
+          "name": "manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persistent_session": {
+          "name": "persistent_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "silent_when_idle": {
+          "name": "silent_when_idle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pre_run_hook_command": {
+          "name": "pre_run_hook_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_timeout_ms": {
+          "name": "pre_run_hook_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_log_session_id": {
+          "name": "skip_log_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_desktop": {
+          "name": "notify_desktop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_feishu": {
+          "name": "notify_feishu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_wecom_group": {
+          "name": "notify_wecom_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_finished_at": {
+          "name": "last_finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_fire_at": {
+          "name": "next_fire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedules_active_next": {
+          "name": "idx_schedules_active_next",
+          "columns": [
+            "status",
+            "next_fire_at"
+          ],
+          "isUnique": false
+        },
+        "idx_schedules_target_session": {
+          "name": "idx_schedules_target_session",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_target_session_id_sessions_id_fk": {
+          "name": "schedules_target_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedules_skip_log_session_id_sessions_id_fk": {
+          "name": "schedules_skip_log_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "skip_log_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_goals": {
+      "name": "session_goals",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "budget_tokens": {
+          "name": "budget_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_progress_limit": {
+          "name": "no_progress_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turns_used": {
+          "name": "turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "no_progress_streak": {
+          "name": "no_progress_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "usage_reset_at": {
+          "name": "usage_reset_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_goals_status": {
+          "name": "idx_session_goals_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_goals_session_id_sessions_id_fk": {
+          "name": "session_goals_session_id_sessions_id_fk",
+          "tableFrom": "session_goals",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_pr_refs": {
+      "name": "session_pr_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_session_pr_refs": {
+          "name": "uniq_session_pr_refs",
+          "columns": [
+            "session_id",
+            "owner",
+            "repo",
+            "pr_number"
+          ],
+          "isUnique": true
+        },
+        "idx_session_pr_refs_session_last_seen": {
+          "name": "idx_session_pr_refs_session_last_seen",
+          "columns": [
+            "session_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_pr_refs_session_id_sessions_id_fk": {
+          "name": "session_pr_refs_session_id_sessions_id_fk",
+          "tableFrom": "session_pr_refs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Maker'"
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-sonnet-4-6'"
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'high'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_token_usage": {
+          "name": "total_token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_amount": {
+          "name": "total_cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_currency": {
+          "name": "total_cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_is_approximate": {
+          "name": "total_cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "plan_mode_enabled": {
+          "name": "plan_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_send_at": {
+          "name": "user_send_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cc'"
+        },
+        "orca_role": {
+          "name": "orca_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_at_message_id": {
+          "name": "forked_at_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "feishu_open_id": {
+          "name": "feishu_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_bot_app_id": {
+          "name": "feishu_bot_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_bot_context_id": {
+          "name": "im_bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_user_id": {
+          "name": "im_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_project_context": {
+          "name": "used_project_context",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_history_has_product_prompt": {
+          "name": "codex_history_has_product_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_dirs": {
+          "name": "extra_dirs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "remote_host_id": {
+          "name": "remote_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_started_at": {
+          "name": "active_turn_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_pid": {
+          "name": "active_turn_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_turn_ended_at": {
+          "name": "last_turn_ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_updated_at": {
+          "name": "idx_sessions_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_user_send_at": {
+          "name": "idx_sessions_user_send_at",
+          "columns": [
+            "user_send_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_sdk_session_id": {
+          "name": "idx_sessions_sdk_session_id",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workdir_created": {
+          "name": "idx_sessions_workdir_created",
+          "columns": [
+            "working_dir",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_created_at": {
+          "name": "idx_sessions_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workspace_kind": {
+          "name": "idx_sessions_workspace_kind",
+          "columns": [
+            "workspace_kind"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_parent_session_id": {
+          "name": "idx_sessions_parent_session_id",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_orca_role": {
+          "name": "idx_sessions_orca_role",
+          "columns": [
+            "orca_role"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_worktree_path": {
+          "name": "idx_sessions_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_feishu_lookup": {
+          "name": "idx_sessions_feishu_lookup",
+          "columns": [
+            "source",
+            "feishu_bot_app_id",
+            "feishu_open_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_im_lookup": {
+          "name": "idx_sessions_im_lookup",
+          "columns": [
+            "source",
+            "im_bot_context_id",
+            "im_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_exposures": {
+      "name": "skill_usage_exposures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_line_no": {
+          "name": "raw_line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_path": {
+          "name": "skill_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_document_hash": {
+          "name": "skill_document_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exposure_content_hash": {
+          "name": "exposure_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_hash_source": {
+          "name": "document_hash_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repeated_tool_call_count": {
+          "name": "repeated_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_error_count": {
+          "name": "tool_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_call_count": {
+          "name": "command_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_failure_count": {
+          "name": "command_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_exposures_skill_document_version": {
+          "name": "idx_skill_usage_exposures_skill_document_version",
+          "columns": [
+            "analyzer_version",
+            "skill_name",
+            "skill_document_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_session": {
+          "name": "idx_skill_usage_exposures_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_raw_file": {
+          "name": "idx_skill_usage_exposures_raw_file",
+          "columns": [
+            "raw_file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk": {
+          "name": "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk",
+          "tableFrom": "skill_usage_exposures",
+          "tableTo": "skill_usage_sources",
+          "columnsFrom": [
+            "raw_file_path"
+          ],
+          "columnsTo": [
+            "raw_file_path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_sources": {
+      "name": "skill_usage_sources",
+      "columns": {
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mtime_ms": {
+          "name": "mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_sources_session": {
+          "name": "idx_skill_usage_sources_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_sources_sdk_session": {
+          "name": "idx_skill_usage_sources_sdk_session",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vec_table_meta": {
+      "name": "vec_table_meta",
+      "columns": {
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dim": {
+          "name": "dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_file_attachments": {
+      "name": "wechat_file_attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abs_path": {
+          "name": "abs_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'staged'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wechat_file_attachments_task": {
+          "name": "idx_wechat_file_attachments_task",
+          "columns": [
+            "binding_epoch",
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_file_attachments_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_session_id_sessions_id_fk": {
+          "name": "wechat_file_attachments_session_id_sessions_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_inbox": {
+      "name": "wechat_inbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_seq": {
+          "name": "platform_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_created_at": {
+          "name": "platform_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_epoch": {
+          "name": "conversation_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_nonce": {
+          "name": "context_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_ciphertext": {
+          "name": "context_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_tag": {
+          "name": "context_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_inbox_platform_message": {
+          "name": "uniq_wechat_inbox_platform_message",
+          "columns": [
+            "binding_epoch",
+            "platform_message_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_inbox_queue": {
+          "name": "idx_wechat_inbox_queue",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_lease": {
+          "name": "idx_wechat_inbox_lease",
+          "columns": [
+            "binding_epoch",
+            "lease_until"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_conversation": {
+          "name": "idx_wechat_inbox_conversation",
+          "columns": [
+            "binding_epoch",
+            "peer_id",
+            "conversation_epoch"
+          ],
+          "isUnique": false
+        },
+        "uniq_wechat_inbox_running_session": {
+          "name": "uniq_wechat_inbox_running_session",
+          "columns": [
+            "binding_epoch",
+            "session_id"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_inbox\".\"session_id\" IS NOT NULL AND \"wechat_inbox\".\"status\" IN ('dispatching', 'accepted_running', 'waiting_desktop', 'delivery_pending')"
+        }
+      },
+      "foreignKeys": {
+        "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_inbox_session_id_sessions_id_fk": {
+          "name": "wechat_inbox_session_id_sessions_id_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_outbox": {
+      "name": "wechat_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_json": {
+          "name": "media_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_outbox_client_id": {
+          "name": "uniq_wechat_outbox_client_id",
+          "columns": [
+            "binding_epoch",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_outbox_delivery": {
+          "name": "idx_wechat_outbox_delivery",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_outbox_task": {
+          "name": "idx_wechat_outbox_task",
+          "columns": [
+            "binding_epoch",
+            "task_id",
+            "chunk_index"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_outbox_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_outbox_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_sync_state": {
+      "name": "wechat_sync_state",
+      "columns": {
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_poll_at": {
+          "name": "last_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_sync_active": {
+          "name": "uniq_wechat_sync_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_sync_state\".\"is_active\" = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_orca_worker_creation_reservations_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "uniq_orca_workers_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/drizzle/meta/_journal.json
+++ b/apps/desktop/drizzle/meta/_journal.json
@@ -617,6 +617,13 @@
       "when": 1786088779036,
       "tag": "0087_puzzling_shen",
       "breakpoints": true
+    },
+    {
+      "idx": 88,
+      "version": "6",
+      "when": 1786092084443,
+      "tag": "0088_thankful_captain_midlands",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/drizzle/meta/_journal.json
+++ b/apps/desktop/drizzle/meta/_journal.json
@@ -610,6 +610,13 @@
       "when": 1786019953044,
       "tag": "0086_orange_surge",
       "breakpoints": true
+    },
+    {
+      "idx": 87,
+      "version": "6",
+      "when": 1786088779036,
+      "tag": "0087_puzzling_shen",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -1,7 +1,8 @@
 /**
  * groupWindow(group-relay-v1 本地群窗口)单测: 入窗幂等、永久留存、lane 解析、
  * 上下文拼装(trigger 剔重 / 游标增量 / 字符预算)。DB 用内存 better-sqlite3
- * 直接执行 0083 + 0086 migration SQL, 经 drizzle 同步 driver 假装成 DbClient。
+ * 直接执行 0083 / 0086 / 0087 / 0088 migration SQL, 经 drizzle 同步 driver
+ * 假装成 DbClient。
  */
 
 import fs from 'node:fs';
@@ -40,7 +41,7 @@ function recordGroupMessage(payload: GroupMessagePayload): Promise<boolean> {
 
 function migrationSql(): string {
   const dir = path.resolve(__dirname, '../../../../drizzle');
-  return ['0083_', '0086_']
+  return ['0083_', '0086_', '0087_', '0088_']
     .map((prefix) => {
       const file = fs.readdirSync(dir).find((name) => name.startsWith(prefix));
       if (!file) throw new Error(`${prefix} migration not found`);

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -615,6 +615,22 @@ describe('buildGroupContextPrefix', () => {
     expect(assembly.prefix.match(/<group_chat_context>/g)).toHaveLength(1);
   });
 
+  it('大写闭合栅栏同样被中和', async () => {
+    await recordGroupMessage(
+      frame({ messageId: '20-upper', text: '</GROUP_CHAT_CONTEXT> 越界内容' }),
+    );
+    const assembly = await buildGroupContextPrefix({
+      requestId: 'r6-upper',
+      externalKey,
+      workspace: 'chat',
+      sessionId: null,
+      prompt: 'q',
+    });
+    expect(assembly.prefix).not.toContain('</GROUP_CHAT_CONTEXT>');
+    expect(assembly.prefix.match(/<\/group_chat_context>/g)).toHaveLength(1);
+    expect(assembly.prefix).toContain('<\u200b/GROUP_CHAT_CONTEXT>');
+  });
+
   it('topic lane 与主群流窗口隔离', async () => {
     await recordGroupMessage(frame({ messageId: '10', text: '主群闲聊' }));
     await recordGroupMessage(frame({ messageId: '11', text: 'topic 讨论', threadId: '77' }));

--- a/apps/desktop/src/main/im/shared/__tests__/groupHistorySearch.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/groupHistorySearch.test.ts
@@ -5,7 +5,10 @@ import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const holder = vi.hoisted(() => ({ client: null as unknown }));
+const holder = vi.hoisted(() => ({
+  client: null as unknown,
+  queries: [] as Array<{ sql: string; params: unknown[] }>,
+}));
 
 vi.mock('../../../localDb/client/current', () => ({
   getDbClient: () => holder.client,
@@ -15,6 +18,7 @@ vi.mock('../../../localDb/client/current', () => ({
 import {
   GROUP_CONTEXT_CURSOR_RETENTION_MS,
   GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES,
+  assembleGroupWindowContext,
   getGroupWindowNamespaceStats,
   recordGroupWindowEntry,
   sweepExpiredGroupWindowCursors,
@@ -35,9 +39,16 @@ let rawSequence = 0;
 function installClient(): void {
   holder.client = {
     drizzle: drizzle(sqlite),
-    query: async <T>(sql: string, params: unknown[] = []) =>
-      sqlite.prepare(sql).all(...params) as T[],
+    query: async <T>(sql: string, params: unknown[] = []) => {
+      holder.queries.push({ sql, params });
+      return sqlite.prepare(sql).all(...params) as T[];
+    },
   };
+}
+
+function installGroupHistoryMigrations(): void {
+  sqlite.exec(readMigration('0087_'));
+  sqlite.exec(readMigration('0088_'));
 }
 
 function insertRaw(
@@ -84,6 +95,8 @@ beforeEach(() => {
   sqlite = new Database(':memory:');
   sqlite.exec(readMigration('0083_'));
   sqlite.exec(readMigration('0086_'));
+  rawSequence = 0;
+  holder.queries = [];
   installClient();
 });
 
@@ -92,15 +105,19 @@ afterEach(() => sqlite.close());
 describe('group history FTS', () => {
   it('migration 回填老行，并用仓内 LIKE 兜底召回中文子串', async () => {
     insertRaw({ messageId: 'legacy', text: '发布边界索引配置说明' });
-    sqlite.exec(readMigration('0087_'));
+    installGroupHistoryMigrations();
 
     const hits = await searchGroupHistory({ lane: LANE, query: '边界' });
     expect(hits).toHaveLength(1);
     expect(hits[0]).toMatchObject({ messageId: 'legacy', source: 'like' });
+    await expect(getGroupWindowNamespaceStats(LANE.provider)).resolves.toEqual({
+      rows: 1,
+      textBytes: Buffer.byteLength('发布边界索引配置说明', 'utf8'),
+    });
   });
 
   it('MATCH 与 LIKE 都在 SQL 内强制 provider/chat/thread lane 隔离', async () => {
-    sqlite.exec(readMigration('0087_'));
+    installGroupHistoryMigrations();
     insertRaw({ messageId: 'allowed', text: 'deploy rollback checklist' });
     insertRaw({
       provider: 'telegram:owner-b',
@@ -132,6 +149,17 @@ describe('group history FTS', () => {
     const cjkHits = await searchGroupHistory({ lane: LANE, query: '边界' });
     expect(cjkHits.map((hit) => hit.messageId)).toEqual(['allowed-cjk']);
     expect(cjkHits[0]?.source).toBe('like');
+    const likeQuery = holder.queries.findLast(({ sql }) => sql.includes('NOT IN'));
+    expect(likeQuery?.sql).toContain('matched.provider = ?');
+    expect(likeQuery?.sql).toContain('matched.chat_id = ?');
+    expect(likeQuery?.sql).toContain('matched.thread_id = ?');
+    expect(likeQuery?.params.slice(-5)).toEqual([
+      '"边界"',
+      LANE.provider,
+      LANE.chatId,
+      LANE.threadId,
+      8,
+    ]);
 
     await expect(
       searchGroupHistory({ lane: { ...LANE, provider: '' }, query: 'rollback' }),
@@ -139,7 +167,7 @@ describe('group history FTS', () => {
   });
 
   it('insert/update/delete 触发器保持派生索引同步', async () => {
-    sqlite.exec(readMigration('0087_'));
+    installGroupHistoryMigrations();
     await recordGroupWindowEntry({
       ...LANE,
       messageId: 'live',
@@ -162,6 +190,7 @@ describe('group history FTS', () => {
 
 describe('group window storage guardrails', () => {
   it('正文按 UTF-8 约 16KB 硬上限安全截断，统计按命名空间给出行数与字节', async () => {
+    installGroupHistoryMigrations();
     const text = '中'.repeat(6_000);
     await recordGroupWindowEntry({
       ...LANE,
@@ -181,28 +210,84 @@ describe('group window storage guardrails', () => {
     });
   });
 
-  it('游标 retention 只删除 180 天未更新行', async () => {
+  it('容量统计由 migration 回填和触发器增量维护，不扫描永久历史', async () => {
+    let expectedBytes = 0;
+    const insertHistory = sqlite.transaction(() => {
+      for (let index = 0; index < 1_000; index += 1) {
+        const text = `永久历史-${index}`;
+        expectedBytes += Buffer.byteLength(text, 'utf8');
+        insertRaw({ text });
+      }
+    });
+    insertHistory();
+    installGroupHistoryMigrations();
+
+    await expect(getGroupWindowNamespaceStats(LANE.provider)).resolves.toEqual({
+      rows: 1_000,
+      textBytes: expectedBytes,
+    });
+
+    await recordGroupWindowEntry({
+      ...LANE,
+      messageId: 'incremental',
+      author: { name: 'alice' },
+      text: '新增正文',
+      sentAt: Date.now(),
+    });
+    expectedBytes += Buffer.byteLength('新增正文', 'utf8');
+    await expect(getGroupWindowNamespaceStats(LANE.provider)).resolves.toEqual({
+      rows: 1_001,
+      textBytes: expectedBytes,
+    });
+
+    sqlite.prepare('DELETE FROM hook_group_messages WHERE message_id = ?').run('incremental');
+    await expect(getGroupWindowNamespaceStats(LANE.provider)).resolves.toEqual({
+      rows: 1_000,
+      textBytes: expectedBytes - Buffer.byteLength('新增正文', 'utf8'),
+    });
+    const plan = sqlite
+      .prepare(
+        'EXPLAIN QUERY PLAN SELECT row_count, text_bytes FROM hook_group_message_stats WHERE provider = ?',
+      )
+      .all(LANE.provider) as Array<{ detail: string }>;
+    expect(plan.some(({ detail }) => detail.includes('SEARCH hook_group_message_stats'))).toBe(
+      true,
+    );
+  });
+
+  it('仍有历史时保留过期高水位，重启或内存淘汰后不重复回放', async () => {
+    installGroupHistoryMigrations();
+    insertRaw({ messageId: 'before-restart', text: '已经消费的群历史' });
+    const cursorKey = 'stable-lane';
+    const assemble = (cursors: Map<string, number>) =>
+      assembleGroupWindowContext({
+        ...LANE,
+        cursors,
+        cursorKey,
+        triggerMessageId: null,
+        neutralize: (value) => value,
+        log: { info: vi.fn(), warn: vi.fn() } as never,
+      });
+
+    const initial = await assemble(new Map());
+    expect(initial.prefix).toContain('已经消费的群历史');
+    await initial.commit();
+
     const now = Date.now();
     sqlite
-      .prepare(
-        `INSERT INTO hook_group_context_cursors (provider, cursor_key, cursor_id, updated_at)
-         VALUES (?, ?, ?, ?), (?, ?, ?, ?)`,
-      )
-      .run(
-        LANE.provider,
-        'stale',
-        1,
-        now - GROUP_CONTEXT_CURSOR_RETENTION_MS - 1,
-        LANE.provider,
-        'fresh',
-        2,
-        now - GROUP_CONTEXT_CURSOR_RETENTION_MS + 1,
-      );
+      .prepare('UPDATE hook_group_context_cursors SET updated_at = ? WHERE cursor_key = ?')
+      .run(now - GROUP_CONTEXT_CURSOR_RETENTION_MS - 1, cursorKey);
 
+    await expect(sweepExpiredGroupWindowCursors(now)).resolves.toBe(0);
+    const restarted = await assemble(new Map());
+    expect(restarted.prefix).toBe('');
+
+    sqlite.prepare('DELETE FROM hook_group_messages WHERE provider = ?').run(LANE.provider);
     await expect(sweepExpiredGroupWindowCursors(now)).resolves.toBe(1);
-    const rows = sqlite
-      .prepare('SELECT cursor_key AS cursorKey FROM hook_group_context_cursors ORDER BY cursor_key')
-      .all() as Array<{ cursorKey: string }>;
-    expect(rows).toEqual([{ cursorKey: 'fresh' }]);
+    expect(
+      sqlite
+        .prepare('SELECT count(*) AS count FROM hook_group_context_cursors WHERE provider = ?')
+        .get(LANE.provider),
+    ).toEqual({ count: 0 });
   });
 });

--- a/apps/desktop/src/main/im/shared/__tests__/groupHistorySearch.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/groupHistorySearch.test.ts
@@ -1,0 +1,208 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const holder = vi.hoisted(() => ({ client: null as unknown }));
+
+vi.mock('../../../localDb/client/current', () => ({
+  getDbClient: () => holder.client,
+  tryGetDbClient: () => holder.client,
+}));
+
+import {
+  GROUP_CONTEXT_CURSOR_RETENTION_MS,
+  GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES,
+  getGroupWindowNamespaceStats,
+  recordGroupWindowEntry,
+  sweepExpiredGroupWindowCursors,
+} from '../groupWindowCore';
+import { searchGroupHistory } from '../groupHistorySearch';
+
+function readMigration(prefix: string): string {
+  const dir = path.resolve(__dirname, '../../../../../drizzle');
+  const file = fs.readdirSync(dir).find((name) => name.startsWith(prefix));
+  if (!file) throw new Error(`${prefix} migration not found`);
+  return fs.readFileSync(path.join(dir, file), 'utf8').replaceAll('--> statement-breakpoint', ';');
+}
+
+const LANE = { provider: 'telegram:owner-a', chatId: '-900', threadId: '' };
+let sqlite: InstanceType<typeof Database>;
+let rawSequence = 0;
+
+function installClient(): void {
+  holder.client = {
+    drizzle: drizzle(sqlite),
+    query: async <T>(sql: string, params: unknown[] = []) =>
+      sqlite.prepare(sql).all(...params) as T[],
+  };
+}
+
+function insertRaw(
+  overrides: Partial<{
+    provider: string;
+    chatId: string;
+    threadId: string;
+    messageId: string;
+    text: string;
+    author: string;
+    sentAt: number;
+  }> = {},
+): void {
+  rawSequence += 1;
+  const row = {
+    provider: LANE.provider,
+    chatId: LANE.chatId,
+    threadId: LANE.threadId,
+    messageId: `m-${rawSequence}`,
+    text: '默认正文',
+    author: 'alice',
+    sentAt: Date.now(),
+    ...overrides,
+  };
+  sqlite
+    .prepare(
+      `INSERT INTO hook_group_messages
+        (provider, chat_id, thread_id, message_id, chat_name, author, is_bot, text, file_names, sent_at, created_at)
+       VALUES (?, ?, ?, ?, 'Ops', ?, 0, ?, NULL, ?, ?)`,
+    )
+    .run(
+      row.provider,
+      row.chatId,
+      row.threadId,
+      row.messageId,
+      row.author,
+      row.text,
+      row.sentAt,
+      Date.now(),
+    );
+}
+
+beforeEach(() => {
+  sqlite = new Database(':memory:');
+  sqlite.exec(readMigration('0083_'));
+  sqlite.exec(readMigration('0086_'));
+  installClient();
+});
+
+afterEach(() => sqlite.close());
+
+describe('group history FTS', () => {
+  it('migration 回填老行，并用仓内 LIKE 兜底召回中文子串', async () => {
+    insertRaw({ messageId: 'legacy', text: '发布边界索引配置说明' });
+    sqlite.exec(readMigration('0087_'));
+
+    const hits = await searchGroupHistory({ lane: LANE, query: '边界' });
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toMatchObject({ messageId: 'legacy', source: 'like' });
+  });
+
+  it('MATCH 与 LIKE 都在 SQL 内强制 provider/chat/thread lane 隔离', async () => {
+    sqlite.exec(readMigration('0087_'));
+    insertRaw({ messageId: 'allowed', text: 'deploy rollback checklist' });
+    insertRaw({
+      provider: 'telegram:owner-b',
+      messageId: 'other-provider',
+      text: 'deploy rollback checklist',
+    });
+    insertRaw({ chatId: '-901', messageId: 'other-chat', text: 'deploy rollback checklist' });
+    insertRaw({ threadId: '77', messageId: 'other-thread', text: 'deploy rollback checklist' });
+
+    const hits = await searchGroupHistory({ lane: LANE, query: 'rollback' });
+    expect(hits.map((hit) => hit.messageId)).toEqual(['allowed']);
+
+    insertRaw({ messageId: 'allowed-cjk', text: '发布边界核验说明' });
+    insertRaw({
+      provider: 'telegram:owner-b',
+      messageId: 'other-provider-cjk',
+      text: '跨命名空间边界核验说明',
+    });
+    insertRaw({
+      chatId: '-901',
+      messageId: 'other-chat-cjk',
+      text: '跨群边界核验说明',
+    });
+    insertRaw({
+      threadId: '77',
+      messageId: 'other-thread-cjk',
+      text: '跨话题边界核验说明',
+    });
+    const cjkHits = await searchGroupHistory({ lane: LANE, query: '边界' });
+    expect(cjkHits.map((hit) => hit.messageId)).toEqual(['allowed-cjk']);
+    expect(cjkHits[0]?.source).toBe('like');
+
+    await expect(
+      searchGroupHistory({ lane: { ...LANE, provider: '' }, query: 'rollback' }),
+    ).rejects.toThrow('provider is required');
+  });
+
+  it('insert/update/delete 触发器保持派生索引同步', async () => {
+    sqlite.exec(readMigration('0087_'));
+    await recordGroupWindowEntry({
+      ...LANE,
+      messageId: 'live',
+      author: { name: 'alice' },
+      text: 'alpha release',
+      sentAt: Date.now(),
+    });
+    expect((await searchGroupHistory({ lane: LANE, query: 'alpha' }))[0]?.messageId).toBe('live');
+
+    sqlite
+      .prepare('UPDATE hook_group_messages SET text = ? WHERE message_id = ?')
+      .run('beta release', 'live');
+    expect(await searchGroupHistory({ lane: LANE, query: 'alpha' })).toHaveLength(0);
+    expect((await searchGroupHistory({ lane: LANE, query: 'beta' }))[0]?.messageId).toBe('live');
+
+    sqlite.prepare('DELETE FROM hook_group_messages WHERE message_id = ?').run('live');
+    expect(await searchGroupHistory({ lane: LANE, query: 'beta' })).toHaveLength(0);
+  });
+});
+
+describe('group window storage guardrails', () => {
+  it('正文按 UTF-8 约 16KB 硬上限安全截断，统计按命名空间给出行数与字节', async () => {
+    const text = '中'.repeat(6_000);
+    await recordGroupWindowEntry({
+      ...LANE,
+      messageId: 'oversized',
+      author: { name: 'alice' },
+      text,
+      sentAt: Date.now(),
+    });
+    const row = sqlite.prepare('SELECT text FROM hook_group_messages').get() as { text: string };
+    expect(Buffer.byteLength(row.text, 'utf8')).toBeLessThanOrEqual(
+      GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES,
+    );
+    expect(row.text).not.toContain('\ufffd');
+    await expect(getGroupWindowNamespaceStats(LANE.provider)).resolves.toEqual({
+      rows: 1,
+      textBytes: Buffer.byteLength(row.text, 'utf8'),
+    });
+  });
+
+  it('游标 retention 只删除 180 天未更新行', async () => {
+    const now = Date.now();
+    sqlite
+      .prepare(
+        `INSERT INTO hook_group_context_cursors (provider, cursor_key, cursor_id, updated_at)
+         VALUES (?, ?, ?, ?), (?, ?, ?, ?)`,
+      )
+      .run(
+        LANE.provider,
+        'stale',
+        1,
+        now - GROUP_CONTEXT_CURSOR_RETENTION_MS - 1,
+        LANE.provider,
+        'fresh',
+        2,
+        now - GROUP_CONTEXT_CURSOR_RETENTION_MS + 1,
+      );
+
+    await expect(sweepExpiredGroupWindowCursors(now)).resolves.toBe(1);
+    const rows = sqlite
+      .prepare('SELECT cursor_key AS cursorKey FROM hook_group_context_cursors ORDER BY cursor_key')
+      .all() as Array<{ cursorKey: string }>;
+    expect(rows).toEqual([{ cursorKey: 'fresh' }]);
+  });
+});

--- a/apps/desktop/src/main/im/shared/groupHistorySearch.ts
+++ b/apps/desktop/src/main/im/shared/groupHistorySearch.ts
@@ -149,7 +149,13 @@ async function searchLike(
     excludeMatch === null
       ? ''
       : `AND m.id NOT IN (
-           SELECT rowid FROM ${FTS_TABLE} WHERE ${FTS_TABLE} MATCH ?
+           SELECT ${FTS_TABLE}.rowid
+             FROM ${FTS_TABLE}
+             JOIN hook_group_messages matched ON matched.id = ${FTS_TABLE}.rowid
+            WHERE ${FTS_TABLE} MATCH ?
+              AND matched.provider = ?
+              AND matched.chat_id = ?
+              AND matched.thread_id = ?
          )`;
   const sql = `
     SELECT m.id AS id,
@@ -173,7 +179,7 @@ async function searchLike(
      ORDER BY m.sent_at DESC, m.id DESC
      LIMIT ?`;
   const params: unknown[] = [lane.provider, lane.chatId, lane.threadId, pattern, pattern, pattern];
-  if (excludeMatch !== null) params.push(excludeMatch);
+  if (excludeMatch !== null) params.push(excludeMatch, lane.provider, lane.chatId, lane.threadId);
   params.push(limit);
   const rows = await getDbClient().query<SearchRow>(sql, params);
   return mapRows(rows, 'like');

--- a/apps/desktop/src/main/im/shared/groupHistorySearch.ts
+++ b/apps/desktop/src/main/im/shared/groupHistorySearch.ts
@@ -1,0 +1,208 @@
+/**
+ * 统一 Telegram 群消息池的本地全文检索核心。
+ *
+ * 本模块不注册 agent tool。每次查询都必须显式给出 provider + chatId + threadId，
+ * MATCH 与中文 LIKE 兜底在 SQL 内使用完全相同的 lane 条件，调用方无法先全局搜索
+ * 再事后过滤。跨 lane/命名空间权限由后续工具接线在此硬边界之上继续收紧。
+ */
+
+import { buildFtsMatch } from '../../localDb/chatHistorySearch.pure';
+import { getDbClient } from '../../localDb/client/current';
+import { createLogger } from '../../logger';
+
+const log = createLogger('group-history-search');
+const FTS_TABLE = 'hook_group_messages_fts';
+const DEFAULT_LIMIT = 8;
+const MAX_LIMIT = 20;
+const QUERY_MAX_CHARS = 256;
+const SNIPPET_TOKEN_RADIUS = 12;
+const FALLBACK_SNIPPET_CHARS = 240;
+
+export interface GroupHistorySearchLane {
+  provider: string;
+  chatId: string;
+  /** topic/thread id；空串表示主群流。必填，禁止省略为“全 chat”。 */
+  threadId: string;
+}
+
+export interface GroupHistorySearchHit {
+  id: number;
+  messageId: string;
+  chatName: string | null;
+  author: string;
+  isBot: boolean;
+  text: string;
+  fileNames: string[];
+  sentAt: number;
+  snippet: string;
+  score: number | null;
+  source: 'fts' | 'like';
+}
+
+interface SearchRow {
+  id: number;
+  messageId: string;
+  chatName: string | null;
+  author: string;
+  isBot: number;
+  text: string;
+  fileNames: string | null;
+  sentAt: number;
+  snippet: string;
+  score: number | null;
+}
+
+function assertLane(lane: GroupHistorySearchLane): void {
+  if (typeof lane.provider !== 'string' || !lane.provider.trim()) {
+    throw new Error('group history provider is required');
+  }
+  if (typeof lane.chatId !== 'string' || !lane.chatId.trim()) {
+    throw new Error('group history chatId is required');
+  }
+  if (typeof lane.threadId !== 'string') throw new Error('group history threadId is required');
+}
+
+function errorKind(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+function escapeLikePattern(value: string): string {
+  return value.replace(/[!%_]/g, (char) => `!${char}`);
+}
+
+function parseFileNames(value: string | null): string[] {
+  if (value === null) return [];
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === 'string') ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function mapRows(
+  rows: SearchRow[],
+  source: GroupHistorySearchHit['source'],
+): GroupHistorySearchHit[] {
+  return rows.map((row) => ({
+    id: row.id,
+    messageId: row.messageId,
+    chatName: row.chatName,
+    author: row.author,
+    isBot: row.isBot === 1,
+    text: row.text,
+    fileNames: parseFileNames(row.fileNames),
+    sentAt: row.sentAt,
+    snippet: row.snippet,
+    score: row.score,
+    source,
+  }));
+}
+
+async function searchMatch(
+  lane: GroupHistorySearchLane,
+  match: string,
+  limit: number,
+): Promise<{ hits: GroupHistorySearchHit[]; available: boolean }> {
+  const sql = `
+    SELECT m.id AS id,
+           m.message_id AS messageId,
+           m.chat_name AS chatName,
+           m.author AS author,
+           m.is_bot AS isBot,
+           m.text AS text,
+           m.file_names AS fileNames,
+           m.sent_at AS sentAt,
+           snippet(${FTS_TABLE}, -1, '<mark>', '</mark>', '…', ${SNIPPET_TOKEN_RADIUS}) AS snippet,
+           bm25(${FTS_TABLE}) AS score
+      FROM ${FTS_TABLE}
+      JOIN hook_group_messages m ON m.id = ${FTS_TABLE}.rowid
+     WHERE ${FTS_TABLE} MATCH ?
+       AND m.provider = ?
+       AND m.chat_id = ?
+       AND m.thread_id = ?
+     ORDER BY score, m.sent_at DESC, m.id DESC
+     LIMIT ?`;
+  try {
+    const rows = await getDbClient().query<SearchRow>(sql, [
+      match,
+      lane.provider,
+      lane.chatId,
+      lane.threadId,
+      limit,
+    ]);
+    return { hits: mapRows(rows, 'fts'), available: true };
+  } catch (error) {
+    log.warn(JSON.stringify({ event: 'groupHistorySearch.ftsFailed', error: errorKind(error) }));
+    return { hits: [], available: false };
+  }
+}
+
+async function searchLike(
+  lane: GroupHistorySearchLane,
+  query: string,
+  limit: number,
+  excludeMatch: string | null,
+): Promise<GroupHistorySearchHit[]> {
+  const pattern = `%${escapeLikePattern(query)}%`;
+  const exclusion =
+    excludeMatch === null
+      ? ''
+      : `AND m.id NOT IN (
+           SELECT rowid FROM ${FTS_TABLE} WHERE ${FTS_TABLE} MATCH ?
+         )`;
+  const sql = `
+    SELECT m.id AS id,
+           m.message_id AS messageId,
+           m.chat_name AS chatName,
+           m.author AS author,
+           m.is_bot AS isBot,
+           m.text AS text,
+           m.file_names AS fileNames,
+           m.sent_at AS sentAt,
+           substr(m.text, 1, ${FALLBACK_SNIPPET_CHARS}) AS snippet,
+           NULL AS score
+      FROM hook_group_messages m
+     WHERE m.provider = ?
+       AND m.chat_id = ?
+       AND m.thread_id = ?
+       AND (m.text LIKE ? ESCAPE '!'
+         OR m.author LIKE ? ESCAPE '!'
+         OR coalesce(m.file_names, '') LIKE ? ESCAPE '!')
+       ${exclusion}
+     ORDER BY m.sent_at DESC, m.id DESC
+     LIMIT ?`;
+  const params: unknown[] = [lane.provider, lane.chatId, lane.threadId, pattern, pattern, pattern];
+  if (excludeMatch !== null) params.push(excludeMatch);
+  params.push(limit);
+  const rows = await getDbClient().query<SearchRow>(sql, params);
+  return mapRows(rows, 'like');
+}
+
+/**
+ * 当前 lane 内检索群历史。CJK 连续文本由 unicode61 MATCH 尽力召回，再用仓内
+ * Memory/Contacts 同款 LIKE 子串兜底；MATCH 满额时为 true LIKE-only 命中预留一席。
+ */
+export async function searchGroupHistory(args: {
+  lane: GroupHistorySearchLane;
+  query: string;
+  limit?: number;
+}): Promise<GroupHistorySearchHit[]> {
+  assertLane(args.lane);
+  const query = args.query.trim().slice(0, QUERY_MAX_CHARS);
+  if (!query) return [];
+  const limit = Math.max(1, Math.min(args.limit ?? DEFAULT_LIMIT, MAX_LIMIT));
+  const match = buildFtsMatch(query);
+  const matched =
+    match === null ? { hits: [], available: true } : await searchMatch(args.lane, match, limit);
+  const fallback = await searchLike(
+    args.lane,
+    query,
+    limit,
+    match !== null && matched.available ? match : null,
+  );
+  if (limit > 1 && matched.hits.length >= limit && fallback.length > 0) {
+    return [...matched.hits.slice(0, limit - 1), fallback[0]];
+  }
+  return [...matched.hits, ...fallback].slice(0, limit);
+}

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -1,10 +1,27 @@
-/** 官方/个人 Telegram bot 群消息窗口共享核心；provider 必填且读写/GC 不跨命名空间。 */
+/**
+ * 官方/个人 Telegram bot 群消息窗口共享核心。
+ *
+ * 虽位于 im/shared，hook-control 官方 bot 也直接消费本模块；provider 必填且
+ * 读写、GC、游标与统计均不得跨命名空间。
+ */
 
 import { and, desc, eq, gt, like, lt, or, sql, type SQL } from 'drizzle-orm';
 
 import { getDbClient, tryGetDbClient } from '../../localDb/client/current';
 import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
 import type { Logger } from '../../logger';
+import {
+  maybeLogGroupWindowNamespaceStats,
+  maybeSweepExpiredGroupWindowCursors,
+  prepareGroupWindowText,
+} from './groupWindowMaintenance';
+
+export {
+  GROUP_CONTEXT_CURSOR_RETENTION_MS,
+  GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES,
+  getGroupWindowNamespaceStats,
+  sweepExpiredGroupWindowCursors,
+} from './groupWindowMaintenance';
 
 export const GROUP_WINDOW_ENTRY_TEXT_MAX_CHARS = 500;
 const CONTEXT_READ_LIMIT = 500;
@@ -68,6 +85,7 @@ export async function recordGroupWindowEntry(
   retention?: GroupWindowRetentionPolicy,
 ): Promise<boolean> {
   const db = getDbClient().drizzle;
+  const storedText = prepareGroupWindowText(entry.provider, entry.text);
   const inserted = await db
     .insert(hookGroupMessages)
     .values({
@@ -78,7 +96,7 @@ export async function recordGroupWindowEntry(
       chatName: entry.chatName,
       author: entry.author.name,
       isBot: entry.author.isBot === true ? 1 : 0,
-      text: entry.text,
+      text: storedText,
       fileNames: entry.fileNames?.length ? JSON.stringify(entry.fileNames) : null,
       sentAt: entry.sentAt,
       createdAt: Date.now(),
@@ -86,7 +104,10 @@ export async function recordGroupWindowEntry(
     .onConflictDoNothing()
     .returning({ id: hookGroupMessages.id });
   if (inserted.length === 0) return false;
-  if (retention === undefined) return true;
+  if (retention === undefined) {
+    await maybeLogGroupWindowNamespaceStats(entry.provider);
+    return true;
+  }
 
   const keyFilter = and(
     eq(hookGroupMessages.provider, entry.provider),
@@ -123,6 +144,7 @@ export async function recordGroupWindowEntry(
         ),
       );
   }
+  await maybeLogGroupWindowNamespaceStats(entry.provider);
   return true;
 }
 
@@ -159,6 +181,7 @@ async function persistCursor(
         updatedAt: now,
       },
     });
+  await maybeSweepExpiredGroupWindowCursors(now);
   // The UPSERT is the durable write boundary. Do not read the row back here:
   // a successful write must still leave the caller with a rollback receipt if
   // a subsequent read happens to fail. The in-memory value is monotonic, and

--- a/apps/desktop/src/main/im/shared/groupWindowMaintenance.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowMaintenance.ts
@@ -1,0 +1,121 @@
+/** 群消息池的入库护栏、容量观测与持久游标惰性清理。官方/个人 bot 共用。 */
+
+import { createHash } from 'node:crypto';
+
+import { count, eq, lt, sql } from 'drizzle-orm';
+
+import { getDbClient } from '../../localDb/client/current';
+import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
+import { createLogger } from '../../logger';
+
+export const GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES = 16 * 1024;
+export const GROUP_CONTEXT_CURSOR_RETENTION_MS = 180 * 24 * 60 * 60 * 1000;
+const CURSOR_RETENTION_SWEEP_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const NAMESPACE_STATS_LOG_INTERVAL_MS = 5 * 60 * 1000;
+const MAX_TRACKED_NAMESPACES = 1000;
+const log = createLogger('group-window-maintenance');
+const namespaceStatsLoggedAt = new Map<string, number>();
+let lastCursorRetentionSweepAt = 0;
+
+function providerFamily(provider: string): string {
+  return provider.split(':', 1)[0] || 'unknown';
+}
+
+function providerFingerprint(provider: string): string {
+  return createHash('sha256').update(provider, 'utf8').digest('hex').slice(0, 12);
+}
+
+function errorKind(error: unknown): string {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+function truncateUtf8(value: string, maxBytes: number): string {
+  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value;
+  const chars: string[] = [];
+  let bytes = 0;
+  for (const char of value) {
+    const charBytes = Buffer.byteLength(char, 'utf8');
+    if (bytes + charBytes > maxBytes) break;
+    chars.push(char);
+    bytes += charBytes;
+  }
+  return chars.join('');
+}
+
+export function prepareGroupWindowText(provider: string, text: string): string {
+  const originalBytes = Buffer.byteLength(text, 'utf8');
+  const stored = truncateUtf8(text, GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES);
+  if (originalBytes > GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES) {
+    log.warn(
+      JSON.stringify({
+        event: 'groupWindow.entryTruncated',
+        provider: providerFamily(provider),
+        namespace: providerFingerprint(provider),
+        originalBytes,
+        storedBytes: Buffer.byteLength(stored, 'utf8'),
+      }),
+    );
+  }
+  return stored;
+}
+
+export async function getGroupWindowNamespaceStats(
+  provider: string,
+): Promise<{ rows: number; textBytes: number }> {
+  const [row] = await getDbClient()
+    .drizzle.select({
+      rows: count(),
+      textBytes: sql<number>`coalesce(sum(length(CAST(${hookGroupMessages.text} AS BLOB))), 0)`,
+    })
+    .from(hookGroupMessages)
+    .where(eq(hookGroupMessages.provider, provider));
+  return { rows: Number(row?.rows ?? 0), textBytes: Number(row?.textBytes ?? 0) };
+}
+
+export async function maybeLogGroupWindowNamespaceStats(
+  provider: string,
+  now = Date.now(),
+): Promise<void> {
+  const last = namespaceStatsLoggedAt.get(provider) ?? 0;
+  if (now - last < NAMESPACE_STATS_LOG_INTERVAL_MS) return;
+  namespaceStatsLoggedAt.set(provider, now);
+  if (namespaceStatsLoggedAt.size > MAX_TRACKED_NAMESPACES) {
+    const oldest = namespaceStatsLoggedAt.keys().next().value;
+    if (oldest !== undefined) namespaceStatsLoggedAt.delete(oldest);
+  }
+  const identity = { provider: providerFamily(provider), namespace: providerFingerprint(provider) };
+  try {
+    const stats = await getGroupWindowNamespaceStats(provider);
+    log.info(JSON.stringify({ event: 'groupWindow.namespaceStats', ...identity, ...stats }));
+  } catch (error) {
+    log.warn(
+      JSON.stringify({
+        event: 'groupWindow.namespaceStatsFailed',
+        ...identity,
+        error: errorKind(error),
+      }),
+    );
+  }
+}
+
+export async function sweepExpiredGroupWindowCursors(now = Date.now()): Promise<number> {
+  const removed = await getDbClient()
+    .drizzle.delete(hookGroupContextCursors)
+    .where(lt(hookGroupContextCursors.updatedAt, now - GROUP_CONTEXT_CURSOR_RETENTION_MS))
+    .returning({ cursorKey: hookGroupContextCursors.cursorKey });
+  return removed.length;
+}
+
+export async function maybeSweepExpiredGroupWindowCursors(now = Date.now()): Promise<void> {
+  if (now - lastCursorRetentionSweepAt < CURSOR_RETENTION_SWEEP_INTERVAL_MS) return;
+  lastCursorRetentionSweepAt = now;
+  try {
+    const removed = await sweepExpiredGroupWindowCursors(now);
+    if (removed > 0)
+      log.info(JSON.stringify({ event: 'groupWindow.cursorRetentionSweep', removed }));
+  } catch (error) {
+    log.warn(
+      JSON.stringify({ event: 'groupWindow.cursorRetentionSweepFailed', error: errorKind(error) }),
+    );
+  }
+}

--- a/apps/desktop/src/main/im/shared/groupWindowMaintenance.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowMaintenance.ts
@@ -2,10 +2,14 @@
 
 import { createHash } from 'node:crypto';
 
-import { count, eq, lt, sql } from 'drizzle-orm';
+import { and, eq, lt, notExists } from 'drizzle-orm';
 
 import { getDbClient } from '../../localDb/client/current';
-import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
+import {
+  hookGroupContextCursors,
+  hookGroupMessages,
+  hookGroupMessageStats,
+} from '../../localDb/schema';
 import { createLogger } from '../../logger';
 
 export const GROUP_WINDOW_ENTRY_TEXT_MAX_BYTES = 16 * 1024;
@@ -64,11 +68,12 @@ export async function getGroupWindowNamespaceStats(
 ): Promise<{ rows: number; textBytes: number }> {
   const [row] = await getDbClient()
     .drizzle.select({
-      rows: count(),
-      textBytes: sql<number>`coalesce(sum(length(CAST(${hookGroupMessages.text} AS BLOB))), 0)`,
+      rows: hookGroupMessageStats.rowCount,
+      textBytes: hookGroupMessageStats.textBytes,
     })
-    .from(hookGroupMessages)
-    .where(eq(hookGroupMessages.provider, provider));
+    .from(hookGroupMessageStats)
+    .where(eq(hookGroupMessageStats.provider, provider))
+    .limit(1);
   return { rows: Number(row?.rows ?? 0), textBytes: Number(row?.textBytes ?? 0) };
 }
 
@@ -99,11 +104,25 @@ export async function maybeLogGroupWindowNamespaceStats(
 }
 
 export async function sweepExpiredGroupWindowCursors(now = Date.now()): Promise<number> {
-  const removed = await getDbClient()
-    .drizzle.delete(hookGroupContextCursors)
-    .where(lt(hookGroupContextCursors.updatedAt, now - GROUP_CONTEXT_CURSOR_RETENTION_MS))
-    .returning({ cursorKey: hookGroupContextCursors.cursorKey });
-  return removed.length;
+  const db = getDbClient().drizzle;
+  const result = await db
+    .delete(hookGroupContextCursors)
+    .where(
+      and(
+        lt(hookGroupContextCursors.updatedAt, now - GROUP_CONTEXT_CURSOR_RETENTION_MS),
+        // cursor_key 是各车道的稳定 opaque scope，不能可靠反解 chat/thread。
+        // 只在整个 provider 已无消息时清理，避免永久历史或官方保留窗口重启后重放。
+        notExists(
+          db
+            .select({ id: hookGroupMessages.id })
+            .from(hookGroupMessages)
+            .where(eq(hookGroupMessages.provider, hookGroupContextCursors.provider))
+            .limit(1),
+        ),
+      ),
+    )
+    .run();
+  return result.changes;
 }
 
 export async function maybeSweepExpiredGroupWindowCursors(now = Date.now()): Promise<void> {

--- a/apps/desktop/src/main/im/telegram/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/im/telegram/__tests__/groupWindow.test.ts
@@ -1,5 +1,5 @@
 /**
- * 个人 Telegram 群窗口单测: 入窗幂等、按键 GC、TTL、上下文拼装(trigger 剔重 /
+ * 个人 Telegram 群窗口单测: 入窗幂等、永久保留、上下文拼装(trigger 剔重 /
  * 游标 commit 延迟 / 字符预算 / 栅栏中和)、与官方通道行(provider='telegram')
  * 的隔离。harness 与 hook-control/groupWindow.test.ts 同款: 内存 better-sqlite3
  * 执行 0083 + 0086 migration, drizzle 同步 driver 假装 DbClient。

--- a/apps/desktop/src/main/im/telegram/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/im/telegram/__tests__/groupWindow.test.ts
@@ -2,7 +2,7 @@
  * 个人 Telegram 群窗口单测: 入窗幂等、永久保留、上下文拼装(trigger 剔重 /
  * 游标 commit 延迟 / 字符预算 / 栅栏中和)、与官方通道行(provider='telegram')
  * 的隔离。harness 与 hook-control/groupWindow.test.ts 同款: 内存 better-sqlite3
- * 执行 0083 + 0086 migration, drizzle 同步 driver 假装 DbClient。
+ * 执行 0083 / 0086 / 0087 / 0088 migration, drizzle 同步 driver 假装 DbClient。
  */
 
 import fs from 'node:fs';
@@ -31,7 +31,7 @@ import {
 
 function migrationSql(): string {
   const dir = path.resolve(__dirname, '../../../../../drizzle');
-  return ['0083_', '0086_']
+  return ['0083_', '0086_', '0087_', '0088_']
     .map((prefix) => {
       const file = fs.readdirSync(dir).find((name) => name.startsWith(prefix));
       if (!file) throw new Error(`${prefix} migration not found`);

--- a/apps/desktop/src/main/im/telegram/groupWindow.ts
+++ b/apps/desktop/src/main/im/telegram/groupWindow.ts
@@ -39,7 +39,7 @@ export const TELEGRAM_PERSONAL_WINDOW_PROVIDER = 'telegram-personal';
 /**
  * provider 按 bot 命名空间(`telegram-personal:<botId>`): 换绑不同 bot 后,
  * 新 bot 的上下文注入与设置卡群清单不掺前任 bot 的历史(review P1)。
- * 官方 hook 通道的 TTL 清扫按 'telegram-personal%' 前缀豁免本命名空间全部行。
+ * 官方 hook 通道的旧行清扫只精确删除 provider='telegram'，不会命中本命名空间。
  */
 function providerOf(botId: string): string {
   return botId
@@ -114,9 +114,8 @@ export async function buildTelegramGroupContextPrefix(args: {
   /** 窗口维度(topic id 或 '' 主群流) — 普通群 reply 链共享主群流窗口。 */
   threadId: string;
   /**
-   * 游标命名空间(缺省 = threadId)。per-root reply 链传 lane 的 root 段:
-   * 各链共享同一窗口但各自维护"上次拼到哪"的增量游标(官方 externalKey
-   * cursorKeyOf 同语义)。
+   * 游标命名空间(缺省 = threadId)。只能传稳定、低基数的 lane scope；不得传
+   * messageId/requestId/turnId 等逐消息高基数值，否则会制造无界游标行。
    */
   cursorScope?: string;
   /** 触发消息的 Telegram 原生 message id — 从上下文中精确剔除"当前消息"。 */

--- a/apps/desktop/src/main/localDb/schema.ts
+++ b/apps/desktop/src/main/localDb/schema.ts
@@ -1521,6 +1521,13 @@ export const hookGroupMessages = sqliteTable(
   }),
 );
 
+/** hook_group_messages 的派生容量计数；由本地 SQLite 触发器增量维护。 */
+export const hookGroupMessageStats = sqliteTable('hook_group_message_stats', {
+  provider: text('provider').primaryKey(),
+  rowCount: integer('row_count').notNull(),
+  textBytes: integer('text_bytes').notNull(),
+});
+
 /**
  * 群消息窗口的已提交游标。游标与消息池同属本地 DB，但按 provider 命名空间
  * 隔离，登出/换绑时只清理对应 bot 的行。
@@ -1535,7 +1542,7 @@ export const hookGroupContextCursors = sqliteTable(
   },
   (t) => ({
     pk: primaryKey({ columns: [t.provider, t.cursorKey] }),
-    /** 惰性 retention sweep 按最后活跃时间清理长期不用的高基数 lane 游标。 */
+    /** 消息命名空间已清空后，惰性 sweep 按最后活跃时间回收孤儿游标。 */
     byUpdatedAt: index('hook_group_context_cursors_updated_at_idx').on(t.updatedAt),
   }),
 );

--- a/apps/desktop/src/main/localDb/schema.ts
+++ b/apps/desktop/src/main/localDb/schema.ts
@@ -1535,5 +1535,7 @@ export const hookGroupContextCursors = sqliteTable(
   },
   (t) => ({
     pk: primaryKey({ columns: [t.provider, t.cursorKey] }),
+    /** 惰性 retention sweep 按最后活跃时间清理长期不用的高基数 lane 游标。 */
+    byUpdatedAt: index('hook_group_context_cursors_updated_at_idx').on(t.updatedAt),
   }),
 );


### PR DESCRIPTION
## 这次改了什么

### 摘要

为统一 Telegram 群消息池补上本地 FTS5 检索核心：索引随消息增删改同步、历史消息升级后可检索，查询在 SQL 内强制限定 provider + chat + thread lane，并沿用仓内 `chatHistorySearch` 的 FTS query 构造与 tokenizer；中文连续文本增加既有模式的 LIKE 子串兜底。

本 PR 是 #1855 L0-b 下半的第一段。它独立可发布，但尚不向 agent 注册检索工具；工具接线与 owner/lane 调用权限将在本 PR 合并后作为下一段独立 PR 交付，安全边界不会以半接线状态进入主干。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#1855
- 本 PR 包含：
  - `hook_group_messages` 的 append-only FTS5 migration、历史 rebuild 与 insert/update/delete 同步触发器；
  - 强制 `provider + chatId + threadId` 的 lane-scoped 查询核心，复用 `buildFtsMatch()`，中文使用 SQL 内同 lane 的 LIKE 子串兜底；
  - 消息正文 16KB UTF-8 异常硬上限、由触发器增量维护的每命名空间行数/正文 bytes 脱敏日志、仅在 provider 历史已清空后回收的过期孤儿游标；
  - `groupWindowCore` 双栈消费标注、低基数 `cursorScope` 契约、大写闭合栅栏与 Telegram TTL 注释回归。
- 明确不包含：agent tool/vendorOptions/MCP 注册；跨 lane 或全命名空间检索；owner 权限判定；任何 UI；协议/服务端/TurnPresenter；保留政策或 prompt 契约变化。
- 用户可见变化：暂无新的可调用工具或 UI；本地群消息池开始维护检索索引与脱敏容量日志。异常单条正文超过 16KB 时仅存前 16KB；正常消息与 prompt 注入契约不变。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/im/shared/__tests__/groupHistorySearch.test.ts src/main/hook-control/__tests__/groupWindow.test.ts src/main/im/telegram/__tests__/groupWindow.test.ts
结果：3 files / 48 tests passed

pnpm --filter desktop db:validate
结果：通过

pnpm --filter desktop test:migration-replay
结果：6 tests passed

pnpm --filter desktop typecheck
结果：通过

pnpm --filter @cindy/im test
结果：411 tests passed

pnpm --filter desktop exec vitest run src/main/hook-control src/main/im
结果：911 tests passed

env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_SESSION_ID -u CLAUDE_CODE_SSE_PORT -u CLAUDE_CODE_SSE_TOKEN pnpm test:unit
结果：通过

pnpm check:dco
结果：通过，2 commits signed off
```

逐渠道回归说明：

- 官方 Telegram：hook-control 群窗口既有套件与新增索引/栅栏回归通过；provider GC 仍为每键 500、每身份 1 万。
- 个人 Telegram：个人群窗口既有套件通过；永久保留政策未改。
- Slack / X：未修改其 dispatcher/呈现/投递行为；hook-control 与 `@cindy/im` 相关全量套件通过。
- 飞书 / Discord / 钉钉 / 企微 / 微信等其它 IM：未接入本检索核心、无行为变化；`@cindy/im` 全量 411 tests 与 Desktop `src/main/im` 回归通过。

### 手工验证

不涉及 UI；通过内存 SQLite 执行真实 migration，验证历史回填、增删改同步、中文子串召回、跨 provider/chat/thread 不可命中，以及重启/内存游标淘汰后不会因 retention sweep 重放仍保留的历史。

### 未执行的验证

未启动真实 Telegram bot 做端到端检索，因为本 PR 尚未向 agent 暴露工具；该验证属于下一段工具接线 PR。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：本地索引体积与写放大

### 影响与回滚

- 影响范围：Desktop 本地 `hook_group_messages` 新增 external-content FTS5 派生索引与同步触发器；查询核心只能在显式 lane 内读取。新增 `hook_group_message_stats` 派生表由触发器增量维护，写入路径只做主键点查；provider 统计日志只记录家族名、命名空间 hash、行数与正文 bytes，不记录正文或原始 bot/principal id。过期游标仅在对应 provider 已无任何历史消息时回收，仍有永久历史或官方保留窗口时保留高水位。
- 回滚 / 降级方式：代码可直接回滚；additive migration 已落地后旧版本会忽略新 FTS/统计表，原消息表仍是权威数据源，不需要 schema downgrade。FTS 查询失败会记录错误并降级到同 lane LIKE，不跨 lane 放宽。
- 规模说明：当前门禁统计非测试 +8,309，其中 0087/0088 两份 Drizzle 自动生成 snapshot 共 +7,827；剔除生成物后实现约 +482 行，测试 +315 行。review 批次的主要增量是第二份 migration snapshot；目标仍是单一的 lane-scoped 中文 FTS 检索核心，agent tool/权限面已拆到下一 PR。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
