### PR TITLE
fix(desktop): 自定义市场插件安装后图标丢失

### DIFF
--- a/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import type { InstalledGhost } from '../../../../../shared/ghost';
 import type { PluginMarketItem } from '../../../../../shared/pluginMarket';
+import { marketPresentationForInstalledGhost } from '../ghostPluginViewModel';
 import {
   orderPluginCatalogItems,
   pluginPresentationOrigin,
@@ -30,6 +32,70 @@ function marketItem(
     sourceMarketName: null,
   };
 }
+
+function installedGhost(): Pick<InstalledGhost, 'manifest' | 'iconDataUrl'> {
+  return {
+    manifest: {
+      schemaVersion: 2,
+      id: 'example',
+      name: 'Example',
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      slots: [],
+    },
+    iconDataUrl: 'data:image/png;base64,LOCAL',
+  };
+}
+
+describe('marketPresentationForInstalledGhost', () => {
+  it('uses the server market icon URL for an exact installed version', () => {
+    const item = marketItem('plugin-server-icon', 'example', 'installed');
+    item.icon = {
+      mimeType: 'image/png',
+      sha256: 'a'.repeat(64),
+      sizeBytes: 128,
+      url: 'https://plugin.example.invalid/example.png?signature=new',
+      expiresAt: '2026-07-27T01:00:00.000Z',
+    };
+
+    expect(marketPresentationForInstalledGhost(installedGhost(), item)?.iconDataUrl).toBe(
+      item.icon.url,
+    );
+  });
+
+  it('keeps a null server icon authoritative over the local package icon', () => {
+    const presentation = marketPresentationForInstalledGhost(
+      installedGhost(),
+      marketItem('plugin-server-no-icon', 'example', 'installed'),
+    );
+
+    expect(presentation).not.toBeNull();
+    expect(presentation?.iconDataUrl).toBeUndefined();
+  });
+
+  it.each(['git-market', 'local-market'] as const)(
+    'uses the installed package icon for an exact %s item',
+    (sourceType) => {
+      const ghost = installedGhost();
+      const item = marketItem(`plugin-${sourceType}`, 'example', 'installed');
+      item.sourceType = sourceType;
+      item.sourceMarketName = 'Custom Market';
+
+      expect(marketPresentationForInstalledGhost(ghost, item)?.iconDataUrl).toBe(ghost.iconDataUrl);
+    },
+  );
+
+  it('returns null when the market item does not exactly own the installed version', () => {
+    const versionMismatch = marketItem('plugin-version-mismatch', 'example', 'installed');
+    versionMismatch.version = '2.0.0';
+    const conflict = marketItem('plugin-conflict', 'example', 'conflict');
+
+    expect(marketPresentationForInstalledGhost(installedGhost(), versionMismatch)).toBeNull();
+    expect(marketPresentationForInstalledGhost(installedGhost(), conflict)).toBeNull();
+    expect(marketPresentationForInstalledGhost(installedGhost(), null)).toBeNull();
+  });
+});
 
 describe('pluginPresentationOrigin', () => {
   it('maps public plugins independently of their default-install policy', () => {

--- a/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
@@ -73,8 +73,10 @@ export interface GhostPluginDetail extends GhostPluginListItem {
 /**
  * 展示投影只覆盖用户能看到的四个字段；运行时仍完全来自本地安装包。
  *
- * `iconDataUrl` 是有意要求存在的字段：市场项的 `icon: null` 也必须覆盖本地
- * 包图标，而不是因为缺少 URL 又显示旧图标。
+ * `iconDataUrl` 是有意要求存在的字段：服务端市场项的 `icon: null` 必须覆盖
+ * 本地包图标，而不是因为缺少 URL 又显示旧图标。自定义市场没有服务端图标
+ * 管道，回退本地包图标；其 `installed` 归属要求安装清单摘要与市场目录一致，
+ * 版本一致时本地图标即对应市场包，不存在旧图标问题。
  */
 export interface GhostPluginMarketPresentation {
   name: string;
@@ -89,11 +91,18 @@ export interface GhostPluginMarketPresentation {
  * market item, or a pending version update must keep using its local manifest.
  */
 export function marketPresentationForInstalledGhost(
-  ghost: Pick<InstalledGhost, 'manifest'>,
+  ghost: Pick<InstalledGhost, 'manifest' | 'iconDataUrl'>,
   marketItem:
     | Pick<
         PluginMarketItem,
-        'ghostId' | 'installState' | 'version' | 'name' | 'description' | 'author' | 'icon'
+        | 'ghostId'
+        | 'installState'
+        | 'version'
+        | 'name'
+        | 'description'
+        | 'author'
+        | 'icon'
+        | 'sourceType'
       >
     | null
     | undefined,
@@ -110,7 +119,7 @@ export function marketPresentationForInstalledGhost(
     name: marketItem.name,
     description: marketItem.description ?? '',
     author: marketItem.author,
-    iconDataUrl: marketItem.icon?.url,
+    iconDataUrl: marketItem.sourceType === 'server' ? marketItem.icon?.url : ghost.iconDataUrl,
   };
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

通过自定义插件市场（Git 仓库 / 本地文件夹）安装的插件，安装完成后在插件列表和详情页看不到插件包自带的图标，只显示灰色兜底符号。

根因在 renderer 的已装插件展示投影：`marketPresentationForInstalledGhost` 会在插件归市场所有且版本一致时，用市场项字段覆盖本地清单，其中 `iconDataUrl` 取 `marketItem.icon?.url`。服务端市场的图标由服务端在发布时从包里抽出、以短期签名 URL 下发；自定义市场没有这条管道，main 侧 `plugin-market/service.ts` 的 `customToItem` 对自定义市场项固定给 `icon: null`。于是投影把 `iconDataUrl` 覆写成 `undefined`，把本地安装包里真实存在的图标（`GhostManager.readInstalledIconDataUrl` 抽出的 data URL）抹掉了。

「市场项的 `icon: null` 必须覆盖本地包图标」这条原语义对服务端市场是对的——服务端是图标的权威来源。本 PR 只把它限定在 `sourceType === 'server'`，自定义来源回退本地包图标。安全依据：自定义市场项判为 `installed` 要求安装时 manifest 摘要与市场目录一致（main 侧 `customToItem` 的 `ownsInstall`），版本一致时本地图标即对应市场包，不存在显示旧图标的问题。

一个佐证：同一个包不经自定义市场安装（手动装入，市场项判 conflict 或版本不一致）时 presentation 为 null，图标反而正常显示——是「从自定义市场安装」这个动作本身让图标消失的。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：renderer 展示投影按市场来源分流 `iconDataUrl`，以及 `marketPresentationForInstalledGhost` 的单元测试（此前无专属覆盖）
- 明确不包含：**未安装的市场卡片图标**。自定义市场项在市场列表里仍然没有图标——那需要 main 侧从插件目录读图标并新增一条下发通道（协议的 `PluginIconMetadata` 语义是短期 HTTPS 地址，不宜塞 data URL），属于另一个改动
- 用户可见变化：从自定义市场安装的插件，安装后在插件列表与详情页显示插件包自带的图标（此前为灰色兜底符号）
- 是否存在 breaking change：无

### UI 变化

不涉及。本 PR 是数据投影层的缺陷修复，diff 内没有任何样式、布局、token 或文案改动。

- 引用的设计规范：不涉及：本 PR 只改数据投影层，未新增或修改任何样式、布局、语义 token、动效与文案；图标渲染仍由既有 `GhostPluginIcon` 组件承担。

## 怎么验证的

### 自动验证

```text
node scripts/test-workspaces.mjs --tier unit --workspace desktop
结果：PASS apps/desktop unit (67.6s)，exit 0

pnpm test:unit
结果：全部 required workspace 通过，exit 0

pnpm --filter desktop run --if-present typecheck
结果：通过（tsc --noEmit 无输出）

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range fcc3c92a..f0f85492

git diff --check
结果：通过
```

定向用例在 `apps/desktop/src/renderer/features/plugin/lib/__tests__/pluginMarketPresentation.test.ts`，覆盖：server 来源使用签名 URL；server 来源 `icon: null` 仍覆盖本地图标（保留原语义）；`git-market` / `local-market` 回退本地包图标；版本不一致 / conflict / 无市场项时不返回投影。

### 手工验证

由仓库开发者在 dev 命名沙箱实机验证（`pnpm restart:desktop:remote --region=global --isolated=<名字>`，macOS，userData 与正式版隔离）：添加自定义市场并安装插件后，插件图标正常显示。验证完成后沙箱 userData 已清理。

### 未执行的验证

- Light / Dark 双模式目检未单独执行：本 PR 未涉及样式、颜色或 token 改动，图标渲染沿用既有组件；实机验证在单一外观模式下完成。按 `docs/design-rules/DESIGN.md` 的双模式交付门槛，不把「复用既有 themed 样式」当作双模式已验证。
- `pnpm test:all` 未执行：改动限于 renderer 一个纯函数及其测试，unit tier 已覆盖。
- Windows 未验证：改动是平台无关的纯 TypeScript 逻辑。

## 风险

### 风险分类

- [x] 无已知风险

不命中 SQLite / migration、system prompt、协议兼容、原生层 / fingerprint / OTA、跨平台差异。

**不命中「存量插件兼容」**：未改批准状态 schema、指纹格式、manifest 校验、安装布局或包格式。**存量插件影响：无**——升级后已装插件的可用性、启用状态与授权均不变，唯一变化是自定义市场来源的插件图标由「错误地不显示」恢复为正常显示。

### 需要放行人确认（插件基座白名单门）

本 PR 改动 `apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts`，该路径由 `docs/dev-rules/plugin-security-and-authoring.md` 第 5 节列为**插件基座**（已装列表投影）。按该节规定，命中基座的 PR 一律走白名单确认门，需放行人在 PR 上明确 Approve 才能合并——不看 diff 大小，也不因为是 bugfix / 纯技术改动而豁免。

### 影响与回滚

- 影响范围：仅 renderer 已装插件列表与详情页的图标取值；不改运行时、安装、授权与账本链路，服务端市场项的行为逐字节不变。
- 回滚 / 降级方式：revert 本 commit 即可，无数据迁移、无持久化状态变更、无协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（本 PR 无 UI 变化，按「不涉及 + 理由」填写）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增文档；受影响的代码注释已随改动更新）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
