### PR TITLE
test(device-link): wait for reconnect conditions

### DIFF
--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -2779,8 +2779,7 @@ describe('DeviceLinkClient', () => {
     // 断线 → 第一次退避 5ms
     h.current().emit('close', 1006);
     expect(h.client.getStatus()).toBe('connecting');
-    await tick(15);
-    expect(h.sockets.length).toBe(2);
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
 
     h.current().ack();
     expect(h.client.getStatus()).toBe('online');
@@ -2795,9 +2794,7 @@ describe('DeviceLinkClient', () => {
 
     h.current().emit('close', 1012, 'service restart');
     expect(h.client.getStatus()).toBe('connecting');
-    await tick(15);
-
-    expect(h.sockets).toHaveLength(2);
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
     h.current().ack();
     expect(h.client.getStatus()).toBe('online');
     h.client.stop();
@@ -2817,16 +2814,14 @@ describe('DeviceLinkClient', () => {
 
     // 第一次断线 → 20ms 后重连。
     h.current().emit('close', 4409, 'replaced by newer connection');
-    await tick(30);
-    expect(h.sockets.length).toBe(2);
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
     h.current().ack();
 
     // 第二条连接还没稳定到 reconnectStableResetMs 就又被顶掉,下一次应按 40ms 退避。
     h.current().emit('close', 4409, 'replaced by newer connection');
     await tick(25);
     expect(h.sockets.length).toBe(2);
-    await tick(30);
-    expect(h.sockets.length).toBe(3);
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(3));
     h.client.stop();
   });
 
@@ -2931,8 +2926,7 @@ describe('DeviceLinkClient', () => {
 
     // 断线 → 退避重连产生 socket2(epoch2)
     stale.emit('close', 1006);
-    await tick(15);
-    expect(h.sockets.length).toBe(2);
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
     const fresh = h.current();
 
     // 过期 socket1 的迟到 close + 垃圾 message:epoch 守卫应忽略(否则 handleDisconnect 会
@@ -3132,8 +3126,7 @@ describe('DeviceLinkClient', () => {
     h.current().emit('close', 1006);
     await tick(20);
     expect(h.sockets.length).toBe(1); // 退避 50ms 未到,不重连(默认曲线未被改快)
-    await tick(50);
-    expect(h.sockets.length).toBe(2); // 到点才重连
+    await vi.waitFor(() => expect(h.sockets).toHaveLength(2)); // 到点才重连
     h.current().ack();
     expect(h.client.getStatus()).toBe('online');
     h.client.stop();
@@ -3391,7 +3384,7 @@ describe('DeviceLinkClient', () => {
       expect(h.client.getConnectionIssue()).toMatchObject({ kind: 'replaced', closeCode: 4409 });
       expect(issues).toHaveLength(1);
 
-      await tick(15);
+      await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
       h.current().ack();
       expect(h.client.getConnectionIssue()).toBeNull();
       expect(issues).toHaveLength(2);
@@ -3418,7 +3411,7 @@ describe('DeviceLinkClient', () => {
       h.current().emit('close', 4429, 'too many connections');
       expect(h.client.getConnectionIssue()).toMatchObject({ kind: 'too-many-connections' });
 
-      await tick(15);
+      await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
       h.current().emit('close', 4400, 'protocol version mismatch');
       expect(h.client.getConnectionIssue()).toMatchObject({ kind: 'version-mismatch' });
       h.client.stop();
@@ -3466,12 +3459,12 @@ describe('DeviceLinkClient', () => {
       expect(h.client.getConnectionIssue()).toBeNull();
 
       // 先制造 auth-failed,再来一次普通断线:原因不被网络抖动洗掉
-      await tick(15);
+      await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
       const ws2 = h.current();
       ws2.emit('error', new Error("Expected HTTP 101 response but was '401 Unauthorized'"));
       ws2.emit('close', 1006);
       expect(h.client.getConnectionIssue()).toMatchObject({ kind: 'auth-failed' });
-      await tick(15);
+      await vi.waitFor(() => expect(h.sockets).toHaveLength(3));
       h.current().emit('close', 1006);
       expect(h.client.getConnectionIssue()).toMatchObject({ kind: 'auth-failed' });
       h.client.stop();
@@ -3486,7 +3479,7 @@ describe('DeviceLinkClient', () => {
       const ws = h.current();
       ws.emit('error', new Error('Unexpected server response: 401'));
       ws.emit('close', 1006);
-      await tick(15);
+      await vi.waitFor(() => expect(h.sockets).toHaveLength(2));
       const ws2 = h.current();
       ws2.emit('error', new Error('Unexpected server response: 401'));
       ws2.emit('close', 1006);
@@ -3642,8 +3635,9 @@ describe('DeviceLinkClient', () => {
       h.current().ack();
       await tick();
       await establishInboundReliableLink(h, `stream-${src}`, 1, src);
+      const socketCount = h.sockets.length;
       h.current().emit('close', 1006);
-      await tick(20); // 退避后重连
+      await vi.waitFor(() => expect(h.sockets).toHaveLength(socketCount + 1));
       h.current().ack();
       await tick();
       expect(h.client.getStatus()).toBe('online');
@@ -3904,8 +3898,9 @@ describe('DeviceLinkClient', () => {
         // 恢复后仍在 30s 节流窗口内(时钟只走 1s)再次丢 link:新帧必须立刻再通知,
         // 否则 host 的唯一恢复出口最坏被推迟整个窗口。
         nowMs += 1_000;
+        const socketCount = h.sockets.length;
         h.current().emit('close', 1006);
-        await tick(20);
+        await vi.waitFor(() => expect(h.sockets).toHaveLength(socketCount + 1));
         h.current().ack();
         await tick();
         const staleFrame2 = encodeReliableFrames(


### PR DESCRIPTION
## What changed

- Replaced positive-event fixed sleeps in DeviceLinkClient tests with bounded condition waits.
- Preserved negative timing and reconnect backoff assertions.

Fixes #1625

## Change type

- [x] Tests

## Scope

Tests only. No Device Link runtime, protocol, UI, mobile, schema, or dependency changes.

## Validation

- `pnpm test:unit`
- Desktop typecheck
- DCO check

All passed.

## Risk

No runtime behavior change. Revert the commit to roll back.