### PR TITLE
fix(claude): 修复后台 Agent 完成后仍显示正在生成

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1572,6 +1572,58 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('只退休 stopTask 成功的 wake 任务，失败任务保留并正常记账', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn parallel background work' });
+    stream.emit(taskStarted('task-success', 'local_agent'));
+    stream.emit(taskStarted('task-failed', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 2, 'parallel wake tasks observed');
+
+    const successfulStop = createDeferred<void>();
+    const failedStop = createDeferred<void>();
+    fakeQuery.stopTask!.mockImplementation((taskId: string) =>
+      taskId === 'task-success' ? successfulStop.promise : failedStop.promise,
+    );
+    const abortPromise = handle.abort();
+    await waitFor(() => fakeQuery.stopTask!.mock.calls.length === 2, 'both stopTask RPCs dispatched');
+    expect(handle.listBackgroundTasks?.().map((task) => task.taskId).sort()).toEqual([
+      'task-failed',
+      'task-success',
+    ]);
+
+    successfulStop.resolve(undefined);
+    failedStop.reject(new Error('task still running remotely'));
+    await abortPromise;
+
+    // Only the fulfilled stopTask is retired. The rejected task remains visible
+    // until its provider completion arrives, so it cannot continue untracked.
+    expect(handle.listBackgroundTasks?.().map((task) => task.taskId)).toEqual(['task-failed']);
+
+    stream.emit(interruptedTurnResult());
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'stopped foreground terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'stopped foreground turn settled');
+
+    stream.emit(taskNotification('task-failed', 'completed'));
+    await waitFor(
+      () => taskEvents(events).some((event) =>
+        (event.data as { taskId?: unknown; status?: unknown } | null | undefined)?.taskId === 'task-failed' &&
+        (event.data as { status?: unknown } | null | undefined)?.status === 'completed',
+      ),
+      'failed stop task completion observed',
+    );
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    await handle.send({ type: 'user', content: 'ordinary next turn' });
+    stream.emit(turnResult('ordinary turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'ordinary terminal observed');
+    expect(events.filter((event) => event.type === 'done').at(-1)?.turnContinuationId).toBeUndefined();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('stopTask 成功但 interrupt 失败时不伪造 continuation 收口', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1507,6 +1507,70 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('Stop closes a foreground Query when a wake stop is unconfirmed', async () => {
+    const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'foreground turn with wake task' });
+    stream.emit(taskStarted('task-unconfirmed', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
+    await handle.abort();
+
+    // The ACK succeeds, so the old provider process is retired even though its
+    // stopTask RPC was rejected. A synthetic foreground terminal replaces the
+    // interrupted result that close() intentionally prevents from arriving.
+    expect(fakeQuery.close).toHaveBeenCalledTimes(1);
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic foreground terminal observed');
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    const eventCountAfterStop = events.length;
+    stream.emit(assistantText('late old-query assistant'));
+    stream.emit(turnResult('late old-query result'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toHaveLength(eventCountAfterStop);
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+
+    await handle.send({ type: 'user', content: 'fresh turn after query close' });
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('fresh turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'fresh terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'fresh turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('natural foreground result before Stop ACK is not duplicated when the Query closes', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'natural result races Stop' });
+    stream.emit(taskStarted('task-unconfirmed', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
+    const interrupt = createDeferred<void>();
+    fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
+    const abortPromise = handle.abort();
+    await waitFor(() => fakeQuery.interrupt.mock.calls.length === 1, 'interrupt dispatched');
+
+    // The provider's natural success result wins before interrupt ACK. The
+    // later close must not synthesize a second product terminal.
+    stream.emit(turnResult('natural completion'));
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'natural terminal observed');
+    interrupt.resolve(undefined);
+    await abortPromise;
+
+    expect(fakeQuery.close).toHaveBeenCalledTimes(1);
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('stopTask rejection does not leak an awaiting claim after interrupt succeeds', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 
@@ -1572,7 +1636,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('只退休 stopTask 成功的 wake 任务，失败任务保留并正常记账', async () => {
+  it('Stop 成功后关闭 Query，stopTask 失败任务不再留在本地表', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn parallel background work' });
@@ -1596,9 +1660,11 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     failedStop.reject(new Error('task still running remotely'));
     await abortPromise;
 
-    // Only the fulfilled stopTask is retired. The rejected task remains visible
-    // until its provider completion arrives, so it cannot continue untracked.
-    expect(handle.listBackgroundTasks?.().map((task) => task.taskId)).toEqual(['task-failed']);
+    // Stop now closes the Query as well as installing the cancellation fence.
+    // A rejected stopTask cannot continue in a closed provider process, so its
+    // local row is cleared instead of waiting for a notification that close()
+    // guarantees will never arrive.
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
 
     stream.emit(interruptedTurnResult());
     await waitFor(() => events.filter(isProductTerminal).length === 1, 'stopped foreground terminal observed');
@@ -1624,7 +1690,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('stopTask reject 后允许本代 success result 收口并封住迟到续跑', async () => {
+  it('stopTask reject 后关闭 Query，合成终态并封住迟到续跑', async () => {
     const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn background work' });
@@ -1633,14 +1699,15 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
 
     fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
     await handle.abort();
-    // The foreground turn can naturally finish before the interrupt takes
-    // effect; its success result must still settle this fenced generation.
+    // Stop ACK retires this Query immediately; the synthetic terminal settles
+    // the foreground turn while the old provider tail is discarded.
     stream.emit(turnResult('natural completion raced with stop'));
     await waitFor(() => events.filter(isProductTerminal).length === 1, 'foreground stop terminal observed');
     await waitFor(() => handle.isTurnRunning?.() === false, 'foreground stop settled');
 
-    // The terminal task notification remains visible and clears local task
-    // accounting; only the same-generation automatic continuation tail is fenced.
+    // Terminal task notifications still pass through the retired-query path
+    // and clear local task accounting; only the automatic continuation tail is
+    // discarded.
     stream.emit(taskNotification('task-unconfirmed', 'completed'));
     await waitFor(
       () => taskEvents(events).some((event) =>
@@ -1668,7 +1735,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('老 daemon 无 stopTask 时也为未确认 wake 安装栅栏并在下一 send 换代', async () => {
+  it('老 daemon 无 stopTask 时关闭 Query 并在下一 send 换代', async () => {
     const { handle, stream, events, fakeQueries } = await startSessionWithStream({ omitStopTask: true });
 
     await handle.send({ type: 'user', content: 'spawn background work' });
@@ -1676,6 +1743,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await waitFor(() => taskEvents(events).length >= 1, 'legacy wake task observed');
 
     await handle.abort();
+    expect(fakeQueries[0]?.close).toHaveBeenCalledTimes(1);
     stream.emit(interruptedTurnResult());
     await waitFor(() => events.filter(isProductTerminal).length === 1, 'legacy stop terminal observed');
     await waitFor(() => handle.isTurnRunning?.() === false, 'legacy stop settled');
@@ -1948,7 +2016,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     },
   );
 
-  it('synthetic cancellation 后先 rewind 只重建一个 Query', async () => {
+  it('synthetic cancellation 后先 rewind 保持 checkpoint 重建链路', async () => {
     const { handle, stream, events, fakeQueries } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn background work' });
@@ -1963,12 +2031,123 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
 
     await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');
     await handle.send({ type: 'user', content: 'send after rewind' });
-    expect(fakeQueries).toHaveLength(2);
-    expect(fakeQueries[1]?.close).not.toHaveBeenCalled();
+    // Cancellation Stop closed query 0. Direct commit first installs query 1
+    // solely to access rewindFiles, then closes it and the normal rewind send
+    // installs query 2 at the checkpoint; three Query objects are intentional.
+    expect(fakeQueries).toHaveLength(3);
+    expect(fakeQueries[1]?.close).toHaveBeenCalledTimes(1);
+    expect(fakeQueries[2]?.close).not.toHaveBeenCalled();
 
     stream.emit(turnResult('rewound turn complete'));
     await waitFor(() => events.filter(isProductTerminal).length === 2, 'rewound turn terminal observed');
     await waitFor(() => handle.isTurnRunning?.() === false, 'rewound turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('Stop 后直接 previewRewindFiles 会先换 fresh Query 再访问 rewindFiles', async () => {
+    const { handle, stream, events, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting for task'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+
+    const preview = await handle.previewRewindFiles?.('user-uuid-1');
+    expect(preview?.canRewind).toBe(false);
+    expect(fakeQueries).toHaveLength(2);
+    expect(fakeQueries[0]?.rewindFiles).not.toHaveBeenCalled();
+    expect(fakeQueries[1]?.rewindFiles).toHaveBeenCalledWith('user-uuid-1', { dryRun: true });
+    expect(fakeQueries[0]?.close).toHaveBeenCalledTimes(1);
+    expect(fakeQueries[1]?.close).not.toHaveBeenCalled();
+
+    await handle.send({ type: 'user', content: 'send after rewind preview' });
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('preview follow-up complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'preview follow-up terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'preview follow-up settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('Stop 后直接 commitRewindFiles 会在可用 Query 上回滚并保留后续重建状态', async () => {
+    const { handle, stream, events, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting for task'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+
+    await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');
+    expect(fakeQueries).toHaveLength(2);
+    expect(fakeQueries[0]?.rewindFiles).not.toHaveBeenCalled();
+    expect(fakeQueries[1]?.rewindFiles).toHaveBeenCalledWith('user-uuid-1', { dryRun: false });
+    expect(fakeQueries[0]?.close).toHaveBeenCalledTimes(1);
+    expect(fakeQueries[1]?.close).toHaveBeenCalledTimes(1);
+
+    await handle.send({ type: 'user', content: 'send after direct rewind commit' });
+    expect(fakeQueries).toHaveLength(3);
+    stream.emit(turnResult('rewind follow-up complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'rewind follow-up terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'rewind follow-up settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('preview 重建跳过 compact 后，下一 send 仍先补 compact 再入队消息', async () => {
+    const { handle, stream, streams, events, fakeQueries } = await startSessionWithStream(
+      undefined,
+      { autoCompactThresholdPct: 50, capturePrompts: true },
+    );
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit({
+      type: 'stream_event',
+      event: { type: 'message_delta', usage: { input_tokens: 400_000, output_tokens: 0 } },
+    });
+    await vi.waitFor(() => {
+      expect(handle.getUsageSnapshot().contextTokens).toBe(400_000);
+    });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit({ ...turnResult('waiting'), usage: { input_tokens: 400_000, output_tokens: 1 } });
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    await handle.setModel?.('claude-sonnet-5');
+    expect(handle.getUsageSnapshot().contextWindow).toBe(500_000);
+
+    const preview = await handle.previewRewindFiles?.('user-uuid-1');
+    expect(preview?.canRewind).toBe(false);
+    expect(fakeQueries).toHaveLength(2);
+    expect(fakeQueries[1]?.rewindFiles).toHaveBeenCalledWith('user-uuid-1', { dryRun: true });
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    await handle.send({ type: 'user', content: 'send after preview compact rearm' });
+    expect(fakeQueries).toHaveLength(3);
+    const sendPrompt = (sdkMock.query.mock.calls[2]?.[0] as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
+    expect(sendPrompt).toBeDefined();
+    const sendPromptIter = sendPrompt![Symbol.asyncIterator]();
+    expect((await sendPromptIter.next()).value?.message?.content).toBe('/compact');
+    expect((await sendPromptIter.next()).value?.message?.content).toBe('send after preview compact rearm');
+
+    streams[2]?.emit(turnResult('compact complete'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+    expect(handle.isTurnRunning?.()).toBe(true);
+    streams[2]?.emit(turnResult('user complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'user terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'user turn settled');
 
     stream.end();
     await handle.close().catch(() => undefined);

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -2401,6 +2401,59 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('bridge Stop waits for the retired Query close before retry rebuild', async () => {
+    const { handle, stream, streams, events, fakeQueries } = await startSessionWithStream(
+      undefined,
+      { autoCompactThresholdPct: 50, capturePrompts: true },
+    );
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit({ ...turnResult('waiting'), usage: { input_tokens: 400_000, output_tokens: 1 } });
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'synthetic terminal acknowledged');
+
+    await handle.setModel?.('claude-sonnet-5');
+    await handle.send({ type: 'user', content: 'must be cancelled with compact' });
+    expect(fakeQueries).toHaveLength(2);
+    const bridgePrompt = (sdkMock.query.mock.calls[1]?.[0] as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
+    expect(bridgePrompt).toBeDefined();
+    const bridgePromptIter = bridgePrompt![Symbol.asyncIterator]();
+    expect((await bridgePromptIter.next()).value?.message?.content).toBe('/compact');
+    expect((await bridgePromptIter.next()).value?.message?.content).toBe('must be cancelled with compact');
+    streams[1]?.emit(turnResult('compact complete'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    const closeDeferred = createDeferred<void>();
+    fakeQueries[1]?.close.mockImplementationOnce(() => closeDeferred.promise);
+    await handle.abort();
+    expect(fakeQueries[1]?.close).toHaveBeenCalledTimes(1);
+
+    const retryPromise = handle.send({ type: 'user', content: 'retry after deferred bridge close' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fakeQueries).toHaveLength(2);
+
+    closeDeferred.resolve(undefined);
+    await retryPromise;
+    expect(fakeQueries).toHaveLength(3);
+
+    streams[2]?.emit(turnResult('retry compact complete'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    // 初始 Stop synthetic + bridge Stop synthetic 已各自产生一个产品终态；
+    // retry 的 compact result 仍被 bridge 语义 suppress。
+    expect(events.filter(isProductTerminal)).toHaveLength(2);
+    streams[2]?.emit(turnResult('retry user complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 3, 'retry terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'retry settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('cancellation rebuild 不重复初始 resumeSessionAt / forkSession', async () => {
     const { handle, stream, events, fakeQueries } = await startSessionWithStream(undefined, {
       vendorOptions: {

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -658,6 +658,71 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it.each(['resolve', 'reject'] as const)(
+    'interrupt pending 时 provider stopped 先收口，interrupt %s 后仍保持单终态并可继续发送',
+    async (interruptOutcome) => {
+      const { handle, stream, streams, events, fakeQuery, fakeQueries } =
+        await startSessionWithStream();
+
+      await handle.send({ type: 'user', content: 'spawn background work' });
+      stream.emit(taskStarted('task-agent', 'local_agent'));
+      await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+      stream.emit(turnResult('waiting'));
+      await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+      const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+      expect(continuationId).toBeTypeOf('number');
+
+      const interrupt = createDeferred<void>();
+      fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
+      const abortPromise = handle.abort();
+      await waitFor(() => fakeQuery.interrupt.mock.calls.length === 1, 'interrupt dispatched');
+
+      // Provider confirmation is authoritative even while the idle interrupt
+      // control request is unresolved: all tracked wake tasks are stopped, so
+      // no automatic continuation or second provider done can still arrive.
+      stream.emit(taskNotification('task-agent', 'stopped'));
+      await waitFor(() => taskEvents(events).length >= 2, 'stopped notification observed');
+      await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+      await waitFor(() => handle.isTurnRunning?.() === false, 'all-stopped claim settled');
+      expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+      expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+      // The synthetic terminal installs the cancelled-query fence immediately,
+      // before interrupt settles. Buffered provider tail must not add content
+      // or a second product terminal.
+      const eventCountBeforeOldTail = events.length;
+      streams[0]?.emit(assistantText('late old-query assistant'));
+      streams[0]?.emit(turnResult('late old-query result'));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(events).toHaveLength(eventCountBeforeOldTail);
+      expect(events.filter(isProductTerminal)).toHaveLength(1);
+
+      if (interruptOutcome === 'resolve') {
+        interrupt.resolve(undefined);
+      } else {
+        interrupt.reject(new Error('idle interrupt rejected'));
+      }
+      await abortPromise;
+      expect(handle.isTurnRunning?.()).toBe(false);
+      expect(events.filter(isProductTerminal)).toHaveLength(1);
+      expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+      await handle.send({ type: 'user', content: 'next turn after stopped echo' });
+      expect(fakeQueries).toHaveLength(2);
+      stream.emit(assistantText('new-query output'));
+      await waitFor(
+        () => events.some((event) => event.type === 'text'),
+        'replacement query output observed',
+      );
+      stream.emit(turnResult('replacement query complete'));
+      await waitFor(() => events.filter(isProductTerminal).length === 2, 'replacement terminal observed');
+      await waitFor(() => handle.isTurnRunning?.() === false, 'replacement turn settled');
+
+      stream.end();
+      await handle.close().catch(() => undefined);
+    },
+  );
+
   it.each([
     ['success', () => turnResult('late old-generation success')],
     ['is_error', interruptedTurnResult],

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -34,10 +34,17 @@ const sdkMock = vi.hoisted(() => ({
 const asyncQueueMock = vi.hoisted(() => ({
   rejectNextDone: false,
 }));
+const imageResizerMock = vi.hoisted(() => ({
+  process: vi.fn(async (p: string) => p),
+}));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   forkSession: sdkMock.forkSession,
   query: sdkMock.query,
+}));
+
+vi.mock('../../shared/image-resizer.js', () => ({
+  getDefaultImageResizer: () => imageResizerMock,
 }));
 
 vi.mock('../../shared/async-queue.js', async (importOriginal) => {
@@ -75,6 +82,7 @@ import { Session } from '../../../session.js';
 
 const tempDirs: string[] = [];
 const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+const originalIdleTimeout = process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS;
 
 const TEST_MODELS: ModelDescriptor[] = [
   {
@@ -456,6 +464,11 @@ afterEach(async () => {
     delete process.env.CLAUDE_CONFIG_DIR;
   } else {
     process.env.CLAUDE_CONFIG_DIR = originalClaudeConfigDir;
+  }
+  if (originalIdleTimeout === undefined) {
+    delete process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS;
+  } else {
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = originalIdleTimeout;
   }
   await Promise.all(tempDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
@@ -2449,6 +2462,123 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     streams[2]?.emit(turnResult('retry user complete'));
     await waitFor(() => events.filter(isProductTerminal).length === 3, 'retry terminal observed');
     await waitFor(() => handle.isTurnRunning?.() === false, 'retry settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('watchdog bridge waits for the retired Query close before retry rebuild', async () => {
+    process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS = '50';
+    const { handle, stream, streams, events, fakeQueries } = await startSessionWithStream(
+      undefined,
+      { autoCompactThresholdPct: 50, capturePrompts: true },
+    );
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit({
+      type: 'stream_event',
+      event: { type: 'message_delta', usage: { input_tokens: 400_000, output_tokens: 0 } },
+    });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit({ ...turnResult('waiting'), usage: { input_tokens: 400_000, output_tokens: 1 } });
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'synthetic terminal acknowledged');
+
+    await handle.setModel?.('claude-sonnet-5');
+    await handle.send({ type: 'user', content: 'must be cancelled by watchdog' });
+    expect(fakeQueries).toHaveLength(2);
+    const bridgePrompt = (sdkMock.query.mock.calls[1]?.[0] as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
+    expect(bridgePrompt).toBeDefined();
+    const bridgePromptIter = bridgePrompt![Symbol.asyncIterator]();
+    expect((await bridgePromptIter.next()).value?.message?.content).toBe('/compact');
+    expect((await bridgePromptIter.next()).value?.message?.content).toBe('must be cancelled by watchdog');
+
+    const closeDeferred = createDeferred<void>();
+    fakeQueries[1]?.close.mockImplementationOnce(() => closeDeferred.promise);
+    await waitFor(
+      () => events.some(
+        (event) => event.type === 'error' &&
+          (event.data as { reason?: unknown } | null | undefined)?.reason ===
+            'upstream_response_idle_timeout',
+      ),
+      'watchdog timeout observed',
+    );
+    expect(fakeQueries[1]?.close).toHaveBeenCalledTimes(1);
+
+    const retryPromise = handle.send({ type: 'user', content: 'retry after watchdog close' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fakeQueries).toHaveLength(2);
+
+    closeDeferred.resolve(undefined);
+    await retryPromise;
+    expect(fakeQueries).toHaveLength(3);
+
+    streams[2]?.emit(turnResult('retry compact complete'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    streams[2]?.emit(turnResult('retry user complete'));
+    await waitFor(() => handle.isTurnRunning?.() === false, 'watchdog retry settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('abandoned bridge send waits for the retired Query close before retry rebuild', async () => {
+    const { handle, stream, streams, events, fakeQueries } = await startSessionWithStream(
+      undefined,
+      { autoCompactThresholdPct: 50, capturePrompts: true },
+    );
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit({
+      type: 'stream_event',
+      event: { type: 'message_delta', usage: { input_tokens: 400_000, output_tokens: 0 } },
+    });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit({ ...turnResult('waiting'), usage: { input_tokens: 400_000, output_tokens: 1 } });
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'synthetic terminal acknowledged');
+
+    await handle.setModel?.('claude-sonnet-5');
+    let resolveResize!: (value: string) => void;
+    imageResizerMock.process.mockImplementationOnce(
+      () => new Promise<string>((resolve) => { resolveResize = resolve; }),
+    );
+    const controller = new AbortController();
+    const sendPromise = handle.send(
+      { type: 'user', content: [{ type: 'image', path: path.join(os.tmpdir(), 'abandoned-send.png') }] },
+      { signal: controller.signal },
+    );
+    await waitFor(() => fakeQueries.length === 2, 'cancellation bridge query created');
+    const bridgePrompt = (sdkMock.query.mock.calls[1]?.[0] as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
+    expect(bridgePrompt).toBeDefined();
+    const bridgePromptIter = bridgePrompt![Symbol.asyncIterator]();
+    expect((await bridgePromptIter.next()).value?.message?.content).toBe('/compact');
+
+    const closeDeferred = createDeferred<void>();
+    fakeQueries[1]?.close.mockImplementationOnce(() => closeDeferred.promise);
+    controller.abort();
+    resolveResize(path.join(os.tmpdir(), 'abandoned-send.png'));
+    await expect(sendPromise).rejects.toThrow('Claude send cancelled before acceptance');
+    expect(fakeQueries[1]?.close).toHaveBeenCalledTimes(1);
+
+    const retryPromise = handle.send({ type: 'user', content: 'retry after abandoned send close' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fakeQueries).toHaveLength(2);
+
+    closeDeferred.resolve(undefined);
+    await retryPromise;
+    expect(fakeQueries).toHaveLength(3);
+
+    streams[2]?.emit(turnResult('retry compact complete'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    streams[2]?.emit(turnResult('retry user complete'));
+    await waitFor(() => handle.isTurnRunning?.() === false, 'abandoned send retry settled');
 
     stream.end();
     await handle.close().catch(() => undefined);

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -335,9 +335,10 @@ function interruptedTurnResult(): Record<string, unknown> {
   };
 }
 
-function assistantText(text: string): Record<string, unknown> {
+function assistantText(text: string, parentToolUseId?: string): Record<string, unknown> {
   return {
     type: 'assistant',
+    parent_tool_use_id: parentToolUseId ?? null,
     message: {
       role: 'assistant',
       content: [{ type: 'text', text }],
@@ -990,6 +991,66 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
 
     stream.end();
     await handle.close().catch(() => undefined);
+  });
+
+  it('子 Agent 的 sidechain assistant 不会提前激活父 continuation 并制造第二个 claim', async () => {
+    const { handle, stream } = await startSessionWithStream(
+      undefined,
+      { autoCollect: false },
+    );
+    const session = wrapInSession(handle);
+    const seen: AgentEvent[] = [];
+    session.onEvent((event) => seen.push(event));
+
+    await session.send('spawn one background agent', { turnAttemptToken: 201 });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(seen).length >= 1, 'background agent observed');
+    stream.emit(turnResult('background agent still running'));
+    await waitFor(
+      () => seen.some((event) => event.type === 'done' && event.turnContinuationId !== undefined),
+      'parent continuation boundary observed',
+    );
+    const firstClaimId = seen.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(firstClaimId).toBeTypeOf('number');
+    expect(handle.beginTurnContinuationWait?.(firstClaimId)).toBe('awaiting');
+
+    // 真实 SDK 顺序:父 result 后，后台 Agent 自己的 Bash/tool activity 会以
+    // parent_tool_use_id 非空的 sidechain assistant 先进入同一 Query。它不是
+    // task_notification 触发的顶层 continuation，不能把 claim 提前转 active。
+    stream.emit({
+      type: 'stream_event',
+      parent_tool_use_id: 'toolu-background-agent',
+      event: {
+        type: 'message_start',
+        message: { model: 'claude-haiku-4-5', usage: { input_tokens: 0 } },
+      },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(handle.beginTurnContinuationWait?.(firstClaimId)).toBe('awaiting');
+
+    stream.emit(assistantText('subagent is invoking Bash', 'toolu-background-agent'));
+    await waitFor(
+      () => seen.some((event) => event.type === 'text'),
+      'sidechain assistant output observed',
+    );
+    expect(handle.beginTurnContinuationWait?.(firstClaimId)).toBe('awaiting');
+
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(seen).length >= 2, 'completion notification observed');
+    expect(handle.beginTurnContinuationWait?.(firstClaimId)).toBe('awaiting');
+
+    stream.emit(assistantText('E2E_TOP_DONE'));
+    stream.emit(turnResult('E2E_TOP_DONE'));
+    await waitFor(() => seen.filter(isProductTerminal).length === 1, 'product turn settled');
+
+    const doneEvents = seen.filter((event) => event.type === 'done');
+    expect(doneEvents).toHaveLength(2);
+    expect(doneEvents[1]?.turnContinuationId).toBeUndefined();
+    expect(handle.beginTurnContinuationWait?.(firstClaimId)).toBeNull();
+    expect(session.isTurnRunning()).toBe(false);
+
+    stream.end();
+    await session.close().catch(() => undefined);
   });
 
   it('合并 continuation 只把仍 running 的任务带入下一 claim', async () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1543,6 +1543,60 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('Stop rebuild waits for an in-flight remote Query close before creating the replacement', async () => {
+    const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
+    const closeDeferred = createDeferred<void>();
+
+    await handle.send({ type: 'user', content: 'foreground turn with remote wake task' });
+    stream.emit(taskStarted('task-unconfirmed', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
+    fakeQuery.close.mockImplementationOnce(() => closeDeferred.promise);
+
+    await handle.abort();
+    expect(fakeQuery.close).toHaveBeenCalledTimes(1);
+
+    const sendPromise = handle.send({ type: 'user', content: 'send after remote close' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fakeQueries).toHaveLength(1);
+
+    closeDeferred.resolve(undefined);
+    await sendPromise;
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('replacement turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'replacement terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'replacement turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('Stop rebuild proceeds when the retired remote Query close rejects', async () => {
+    const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
+    const closeDeferred = createDeferred<void>();
+
+    await handle.send({ type: 'user', content: 'foreground turn with rejected close' });
+    stream.emit(taskStarted('task-unconfirmed', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
+    fakeQuery.close.mockImplementationOnce(() => closeDeferred.promise);
+
+    await handle.abort();
+    const sendPromise = handle.send({ type: 'user', content: 'send after rejected close' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(fakeQueries).toHaveLength(1);
+
+    closeDeferred.reject(new Error('remote close rejected'));
+    await sendPromise;
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('replacement after rejected close'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'replacement terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'replacement turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('natural foreground result before Stop ACK is not duplicated when the Query closes', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1597,6 +1597,46 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('Stop closes when a rejected stop is followed by completed notification before interrupt ACK', async () => {
+    const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
+    const interrupt = createDeferred<void>();
+
+    await handle.send({ type: 'user', content: 'foreground turn with racing completion' });
+    stream.emit(taskStarted('task-completed-during-stop', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('task already completed remotely'));
+    fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
+
+    const abortPromise = handle.abort();
+    await waitFor(() => fakeQuery.interrupt.mock.calls.length === 1, 'interrupt dispatched');
+    stream.emit(taskNotification('task-completed-during-stop', 'completed'));
+    await waitFor(
+      () => taskEvents(events).some((event) =>
+        (event.data as { taskId?: unknown; status?: unknown } | null | undefined)?.taskId === 'task-completed-during-stop' &&
+        (event.data as { status?: unknown } | null | undefined)?.status === 'completed',
+      ),
+      'completed notification observed before interrupt ACK',
+    );
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    interrupt.resolve(undefined);
+    await abortPromise;
+    expect(fakeQuery.close).toHaveBeenCalledTimes(1);
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    await handle.send({ type: 'user', content: 'fresh turn after rejected stop' });
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('fresh turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'fresh terminal observed');
+    expect(events.filter(isProductTerminal)).toHaveLength(2);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('natural foreground result before Stop ACK is not duplicated when the Query closes', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -2169,6 +2169,52 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('并发 cancellation rebuild 只创建一个 Query 和一条事件流', async () => {
+    const { handle, stream, events, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting for task'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+
+    const buildDeferred = createDeferred<void>();
+    const buildReplacement = sdkMock.query.getMockImplementation();
+    if (!buildReplacement) throw new Error('query mock implementation is unavailable');
+    sdkMock.query.mockImplementationOnce((options: unknown) =>
+      buildDeferred.promise.then(() => buildReplacement(options)),
+    );
+
+    const firstPreview = handle.previewRewindFiles?.('user-uuid-1');
+    await waitFor(() => sdkMock.query.mock.calls.length === 2, 'replacement query build started');
+    const secondPreview = handle.previewRewindFiles?.('user-uuid-2');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(sdkMock.query).toHaveBeenCalledTimes(2);
+    expect(fakeQueries).toHaveLength(1);
+    expect(fakeQueries[0]?.close).toHaveBeenCalledTimes(1);
+
+    buildDeferred.resolve(undefined);
+    await Promise.all([firstPreview, secondPreview]);
+
+    expect(sdkMock.query).toHaveBeenCalledTimes(2);
+    expect(fakeQueries).toHaveLength(2);
+    expect(fakeQueries[0]?.close).toHaveBeenCalledTimes(1);
+    expect(fakeQueries[1]?.rewindFiles).toHaveBeenCalledTimes(2);
+
+    await handle.send({ type: 'user', content: 'send after concurrent previews' });
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('concurrent preview follow-up complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'follow-up terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'follow-up turn settled');
+    expect(events.filter(isProductTerminal)).toHaveLength(2);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('Stop 后直接 commitRewindFiles 会在可用 Query 上回滚并保留后续重建状态', async () => {
     const { handle, stream, events, fakeQueries } = await startSessionWithStream();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1624,7 +1624,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('stopTask reject 后为未确认 wake 安装栅栏，迟到自动续跑被丢弃', async () => {
+  it('stopTask reject 后允许本代 success result 收口并封住迟到续跑', async () => {
     const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn background work' });
@@ -1633,7 +1633,9 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
 
     fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
     await handle.abort();
-    stream.emit(interruptedTurnResult());
+    // The foreground turn can naturally finish before the interrupt takes
+    // effect; its success result must still settle this fenced generation.
+    stream.emit(turnResult('natural completion raced with stop'));
     await waitFor(() => events.filter(isProductTerminal).length === 1, 'foreground stop terminal observed');
     await waitFor(() => handle.isTurnRunning?.() === false, 'foreground stop settled');
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -30,11 +30,44 @@ const sdkMock = vi.hoisted(() => ({
   forkSession: vi.fn(),
   query: vi.fn(),
 }));
+const asyncQueueMock = vi.hoisted(() => ({
+  rejectNextDone: false,
+}));
 
 vi.mock('@anthropic-ai/claude-agent-sdk', () => ({
   forkSession: sdkMock.forkSession,
   query: sdkMock.query,
 }));
+
+vi.mock('../../shared/async-queue.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../shared/async-queue.js')>();
+  return {
+    ...actual,
+    createAsyncQueue<T>() {
+      const queue = actual.createAsyncQueue<T>();
+      return {
+        push(item: T) {
+          if (
+            asyncQueueMock.rejectNextDone &&
+            typeof item === 'object' &&
+            item !== null &&
+            (item as { type?: unknown }).type === 'done'
+          ) {
+            asyncQueueMock.rejectNextDone = false;
+            return false;
+          }
+          return queue.push(item);
+        },
+        end: () => queue.end(),
+        clear: () => queue.clear(),
+        get pending() {
+          return queue.pending;
+        },
+        [Symbol.asyncIterator]: () => queue[Symbol.asyncIterator](),
+      };
+    },
+  };
+});
 
 import { ClaudeCodeAgent } from '../index.js';
 
@@ -56,7 +89,7 @@ function createNoopLogger(): Logger {
   return logger;
 }
 
-function createDeps(): AgentDeps {
+function createDeps(overrides: Partial<AgentDeps> = {}): AgentDeps {
   const auth: AuthAdapter = {
     async getState() {
       return { authenticated: true };
@@ -74,6 +107,7 @@ function createDeps(): AgentDeps {
     runtimeConfig: {},
     binaryPath: process.execPath,
     logger: createNoopLogger(),
+    ...overrides,
   };
 }
 
@@ -82,7 +116,7 @@ function createControlledStream() {
   const items: unknown[] = [];
   let waiter: { resolve: (r: IteratorResult<unknown>) => void; reject: (e: unknown) => void } | null = null;
   let ended = false;
-  let failure: unknown = null;
+  const failure: unknown = null;
 
   function pump(): void {
     if (!waiter) return;
@@ -134,7 +168,13 @@ function createFakeQuery(
     interrupt: vi.fn(async () => {}),
     close: vi.fn(async () => {}),
     rewindFiles: vi.fn(async () => ({ canRewind: false })),
-    ...(opts?.omitStopTask ? {} : { stopTask: vi.fn(async (_taskId: string) => {}) }),
+    ...(opts?.omitStopTask
+      ? {}
+      : {
+          stopTask: vi.fn(async (taskId: string) => {
+            void taskId;
+          }),
+        }),
   };
 }
 
@@ -159,7 +199,9 @@ async function startSessionWithStream(
     if (prompt) {
       void (async () => {
         try {
-          for await (const _ of prompt) { /* discard — 只对齐 pending 语义 */ }
+          for await (const ignored of prompt) {
+            void ignored; // discard — 只对齐 pending 语义
+          }
         } catch { /* end / abort 都算正常收尾 */ }
       })();
     }
@@ -186,6 +228,33 @@ async function startSessionWithStream(
   return { agent, handle, stream, fakeQuery, events, collected };
 }
 
+async function startRemoteSessionWithStream() {
+  const configDir = await makeTempDir();
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  const workingDir = await makeTempDir();
+  const stream = createControlledStream();
+  const fakeQuery = {
+    ...createFakeQuery(stream),
+    send: vi.fn(async () => {}),
+    detach: vi.fn(async () => {}),
+  };
+  const remoteCcQueryFactory: NonNullable<AgentDeps['remoteCcQueryFactory']> = async () =>
+    fakeQuery as never;
+  const agent = new ClaudeCodeAgent(createDeps({ remoteCcQueryFactory }));
+  const handle = await agent.startSession({
+    sessionId: 'session-stop-task-remote',
+    remoteHostId: 'remote-host',
+    model: 'claude-opus-4-6',
+    workingDir,
+    permissionMode: 'acceptEdits',
+  });
+  const events: AgentEvent[] = [];
+  const collected = (async () => {
+    for await (const event of handle.events()) events.push(event);
+  })();
+  return { handle, stream, fakeQuery, events, collected };
+}
+
 function taskStarted(taskId: string, taskType: string): Record<string, unknown> {
   return {
     type: 'system',
@@ -203,6 +272,25 @@ function taskNotification(taskId: string, status: 'completed' | 'failed' | 'stop
     subtype: 'task_notification',
     task_id: taskId,
     status,
+  };
+}
+
+function taskProgress(taskId: string, taskType = 'local_agent'): Record<string, unknown> {
+  return {
+    type: 'system',
+    subtype: 'task_progress',
+    task_id: taskId,
+    task_type: taskType,
+    description: `late progress ${taskId}`,
+  };
+}
+
+function taskUpdatedRunning(taskId: string): Record<string, unknown> {
+  return {
+    type: 'system',
+    subtype: 'task_updated',
+    task_id: taskId,
+    patch: { status: 'pending' },
   };
 }
 
@@ -235,11 +323,26 @@ async function waitFor(cond: () => boolean, label: string): Promise<void> {
   }
 }
 
+function createDeferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function taskEvents(events: AgentEvent[]): AgentEvent[] {
   return events.filter((e) => e.type === 'agent_task_update');
 }
 
 afterEach(async () => {
+  asyncQueueMock.rejectNextDone = false;
   sdkMock.forkSession.mockReset();
   sdkMock.query.mockReset();
   if (originalClaudeConfigDir === undefined) {
@@ -393,6 +496,296 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('completed wake task 在用户 Stop 成功后显式取消 awaiting claim', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'task completion observed');
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+
+    await handle.abort();
+    expect(fakeQuery.stopTask).not.toHaveBeenCalled();
+    expect(fakeQuery.interrupt).toHaveBeenCalledTimes(1);
+    await waitFor(
+      () =>
+        events.some(
+          (event) =>
+            event.type === 'done' &&
+            (event.data as { reason?: unknown } | null | undefined)?.reason ===
+              'turn_continuation_cancelled',
+        ),
+      'user Stop cancellation boundary observed',
+    );
+    const completionIndex = events.findIndex(
+      (event) =>
+        event.type === 'agent_task_update' &&
+        (event.data as { status?: unknown } | null | undefined)?.status === 'completed',
+    );
+    const cancellationDoneIndex = events.findIndex(
+      (event) =>
+        event.type === 'done' &&
+        (event.data as { reason?: unknown } | null | undefined)?.reason ===
+          'turn_continuation_cancelled',
+    );
+    expect(cancellationDoneIndex).toBeGreaterThan(completionIndex);
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('stopTask 先取消 claim 后 interrupt 成功仍屏蔽迟到 continuation 尾巴', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+
+    const interrupt = createDeferred<void>();
+    fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
+    const abortPromise = handle.abort();
+    await waitFor(() => fakeQuery.stopTask!.mock.calls.length === 1, 'stopTask dispatched');
+    await waitFor(
+      () =>
+        events.some(
+          (event) =>
+            event.type === 'done' &&
+            (event.data as { reason?: unknown } | null | undefined)?.reason ===
+              'turn_continuation_cancelled',
+        ),
+      'stopTask cancelled claim before interrupt resolved',
+    );
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+
+    interrupt.resolve(undefined);
+    await abortPromise;
+    const eventCountAfterCancellation = events.length;
+    stream.emit(taskStarted('task-late', 'local_agent'));
+    stream.emit({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'late assistant output' }] },
+    });
+    stream.emit(turnResult('late interrupted result'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(events).toHaveLength(eventCountAfterCancellation);
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('interrupt 在途时 awaiting claim 先变 active，result 正常收尾且不再建 claim', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+
+    const interrupt = createDeferred<void>();
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('stop raced with continuation'));
+    fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
+    const abortPromise = handle.abort();
+    await waitFor(() => fakeQuery.interrupt.mock.calls.length === 1, 'interrupt dispatched');
+
+    stream.emit({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'continuation started before interrupt' }] },
+    });
+    await waitFor(
+      () => handle.beginTurnContinuationWait?.(continuationId) === 'active',
+      'awaiting claim activated while interrupt was pending',
+    );
+
+    interrupt.resolve(undefined);
+    await abortPromise;
+    stream.emit(turnResult('interrupted continuation'));
+    await waitFor(
+      () => events.filter((event) => event.type === 'done').length >= 2,
+      'active continuation result observed',
+    );
+
+    const finalDone = events.filter((event) => event.type === 'done').at(-1);
+    expect(finalDone?.turnContinuationId).toBeUndefined();
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('stopBackgroundTask RPC 在途时先收到 completion，成功回包仍能取消 claim', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+
+    const stopTask = createDeferred<void>();
+    fakeQuery.stopTask!.mockImplementationOnce(() => stopTask.promise);
+    const stopPromise = handle.stopBackgroundTask!('task-agent');
+    await waitFor(() => fakeQuery.stopTask!.mock.calls.length === 1, 'stopTask dispatched');
+
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'completion raced ahead of RPC response');
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+
+    stopTask.resolve(undefined);
+    await stopPromise;
+    await waitFor(
+      () =>
+        events.some(
+          (event) =>
+            event.type === 'done' &&
+            (event.data as { reason?: unknown } | null | undefined)?.reason ===
+              'turn_continuation_cancelled',
+        ),
+      'stopTask cancellation boundary observed',
+    );
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('本代 Stop 后到达的 interrupted done 不会从残留 wake task 新建 claim', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+
+    const stopTask = createDeferred<void>();
+    const interrupt = createDeferred<void>();
+    fakeQuery.stopTask!.mockImplementationOnce(() => stopTask.promise);
+    fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
+    const abortPromise = handle.abort();
+    await waitFor(() => fakeQuery.interrupt.mock.calls.length === 1, 'interrupt dispatched');
+
+    stream.emit(turnResult('interrupted turn'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'interrupted done observed');
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+
+    interrupt.resolve(undefined);
+    stopTask.resolve(undefined);
+    await abortPromise;
+    await waitFor(() => handle.isTurnRunning?.() === false, 'interrupted turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it.each(
+    (['completed', 'failed', 'stopped'] as const).flatMap((status) => [
+      [status, 'task_started', (taskId: string) => taskStarted(taskId, 'local_agent')] as const,
+      [status, 'task_progress', taskProgress] as const,
+      [status, 'task_updated(pending)', taskUpdatedRunning] as const,
+    ]),
+  )('终态 %s 后迟到 %s 不会复活 wake task 或制造 claim', async (status, _lateType, lateEvent) => {
+    const { handle, stream, events } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    stream.emit(taskNotification('task-agent', status));
+    await waitFor(() => taskEvents(events).length >= 2, 'task terminal observed');
+
+    stream.emit(lateEvent('task-agent'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(taskEvents(events)).toHaveLength(2);
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    stream.emit(turnResult('foreground finished'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeUndefined();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('四个并行 Agent 相邻 completed 后逐段自动续跑，最后一个 done 归零 busy', async () => {
+    const { handle, stream, events } = await startSessionWithStream();
+    const taskIds = ['task-1', 'task-2', 'task-3', 'task-4'];
+
+    await handle.send({ type: 'user', content: 'spawn four background agents' });
+    for (const taskId of taskIds) stream.emit(taskStarted(taskId, 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= taskIds.length, 'parallel tasks observed');
+    stream.emit(turnResult('waiting for parallel tasks'));
+    await waitFor(() => events.filter((event) => event.type === 'done').length >= 1, 'foreground done observed');
+
+    for (const taskId of taskIds) stream.emit(taskNotification(taskId, 'completed'));
+    await waitFor(
+      () => taskEvents(events).length >= taskIds.length * 2,
+      'adjacent task completions observed',
+    );
+
+    for (let index = 0; index < taskIds.length; index += 1) {
+      stream.emit(turnResult(''));
+      await waitFor(
+        () => events.filter((event) => event.type === 'done').length >= index + 2,
+        `continuation ${index + 1} done observed`,
+      );
+      const continuationDone = events.filter((event) => event.type === 'done')[index + 1];
+      if (index < taskIds.length - 1) {
+        expect(continuationDone?.turnContinuationId).toBeTypeOf('number');
+      } else {
+        expect(continuationDone?.turnContinuationId).toBeUndefined();
+      }
+      expect(handle.isTurnRunning?.()).toBe(index < taskIds.length - 1);
+    }
+
+    const doneEvents = events.filter((event) => event.type === 'done');
+    expect(doneEvents.at(-1)?.turnContinuationId).toBeUndefined();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('remote detach 显式丢弃 awaiting claim', async () => {
+    const { handle, stream, fakeQuery, events, collected } = await startRemoteSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn remote background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'remote wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'remote foreground done observed');
+    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+
+    await handle.detach?.();
+    expect(fakeQuery.detach).toHaveBeenCalledTimes(1);
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await collected;
+  });
+
   it('result-only 自动续 turn 会把旧 claim 标成 active，并由第二个 done 正常收口', async () => {
     const { handle, stream, events } = await startSessionWithStream();
 
@@ -425,6 +818,27 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     expect(handle.isTurnRunning?.()).toBe(false);
     expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
     off?.();
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('active continuation 的最终 done 入队失败时回滚 terminal busy 计数', async () => {
+    const { handle, stream, events } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.filter((event) => event.type === 'done').length >= 1, 'foreground done observed');
+
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'task completion observed');
+    asyncQueueMock.rejectNextDone = true;
+    stream.emit(turnResult(''));
+
+    await waitFor(() => handle.isTurnRunning?.() === false, 'rejected final done counter rolled back');
+    expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
 
     stream.end();
     await handle.close().catch(() => undefined);
@@ -572,7 +986,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('a rejecting stopTask does not block interrupt and abort still resolves', async () => {
+  it('stopTask rejection does not leak an awaiting claim after interrupt succeeds', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn background work' });
@@ -588,10 +1002,81 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     expect(fakeQuery.interrupt).toHaveBeenCalledTimes(1);
     // fire-and-forget 的 rejection 被 catch 消化 —— 给微任务一拍确认无 unhandled。
     await new Promise((r) => setTimeout(r, 20));
-    // RPC 失败时不能先猜任务已经停下；claim 继续保持 busy，等待真实的
-    // task_notification / 自动续 turn 终态。
+    await waitFor(
+      () =>
+        events.some(
+          (event) =>
+            event.type === 'done' &&
+            (event.data as { reason?: unknown } | null | undefined)?.reason ===
+              'turn_continuation_cancelled',
+        ),
+      'interrupt-authoritative cancellation observed',
+    );
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    // q.interrupt can resolve before the provider's cancelled tail drains.
+    // Neither an unknown late task nor model output may restart the turn.
+    const eventCountAfterCancellation = events.length;
+    stream.emit(taskStarted('task-late', 'local_agent'));
+    stream.emit({
+      type: 'assistant',
+      message: { content: [{ type: 'text', text: 'late assistant output' }] },
+    });
+    stream.emit({
+      type: 'stream_event',
+      event: {
+        type: 'message_start',
+        message: { model: 'claude-opus-4-6', usage: { input_tokens: 0 } },
+      },
+    });
+    stream.emit(turnResult('late interrupted result'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toHaveLength(eventCountAfterCancellation);
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    // The tombstone is scoped to the cancelled provider tail. A newly
+    // accepted user input clears it and runs normally.
+    await handle.send({ type: 'user', content: 'start a new turn' });
+    expect(handle.isTurnRunning?.()).toBe(true);
+    stream.emit(turnResult('new turn finished'));
+    await waitFor(
+      () => events.filter((event) => event.type === 'done').length >= 3,
+      'new explicit turn completed',
+    );
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('stopTask 与 interrupt 都失败时不伪造 continuation 收口', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-1', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'task_started observed');
+    stream.emit(turnResult('waiting for task'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('stop failed'));
+    fakeQuery.interrupt.mockRejectedValueOnce(new Error('interrupt failed'));
+    await expect(handle.abort()).resolves.toBeUndefined();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
     expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
     expect(handle.isTurnRunning?.()).toBe(true);
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'done' &&
+          (event.data as { reason?: unknown } | null | undefined)?.reason ===
+            'turn_continuation_cancelled',
+      ),
+    ).toBe(false);
 
     stream.end();
     await handle.close().catch(() => undefined);

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1440,6 +1440,34 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('Stop ACK retires wake tasks without a stopped echo, so the next ordinary done stays unclaimed', async () => {
+    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+
+    await handle.abort();
+    expect(fakeQuery.stopTask).toHaveBeenCalledWith('task-agent');
+    expect(fakeQuery.interrupt).toHaveBeenCalledTimes(1);
+    // The provider does not echo task_notification(stopped); the successful
+    // interrupt ACK still retires the locally tracked wake task.
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    stream.emit(interruptedTurnResult());
+    await waitFor(() => handle.isTurnRunning?.() === false, 'stopped foreground turn settled');
+
+    await handle.send({ type: 'user', content: 'ordinary next turn' });
+    stream.emit(turnResult('ordinary turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'ordinary terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'ordinary turn settled');
+    expect(events.filter((event) => event.type === 'done').at(-1)?.turnContinuationId).toBeUndefined();
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('does not stop tasks that already reached a terminal status', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -21,7 +21,7 @@ import path from 'node:path';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { AgentDeps } from '../../base-agent.js';
+import type { AgentDeps, AgentSessionHandle } from '../../base-agent.js';
 import type { AuthAdapter } from '../../../interfaces/auth-adapter.js';
 import type { AgentEvent } from '../../../types/events.js';
 import type { Logger } from '../../../interfaces/logger.js';
@@ -70,6 +70,7 @@ vi.mock('../../shared/async-queue.js', async (importOriginal) => {
 });
 
 import { ClaudeCodeAgent } from '../index.js';
+import { Session } from '../../../session.js';
 
 const tempDirs: string[] = [];
 const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
@@ -186,15 +187,29 @@ async function makeTempDir(): Promise<string> {
 
 async function startSessionWithStream(
   queryOpts?: { omitStopTask?: boolean },
-  opts?: { autoCollect?: boolean },
+  opts?: { autoCollect?: boolean; vendorOptions?: Record<string, unknown> },
 ) {
   const configDir = await makeTempDir();
   process.env.CLAUDE_CONFIG_DIR = configDir;
   const workingDir = await makeTempDir();
 
-  const stream = createControlledStream();
-  const fakeQuery = createFakeQuery(stream, queryOpts);
+  const streams: Array<ReturnType<typeof createControlledStream>> = [];
+  const fakeQueries: Array<ReturnType<typeof createFakeQuery>> = [];
+  const stream = {
+    emit(message: unknown): void {
+      const current = streams.at(-1);
+      if (!current) throw new Error('query stream is not ready');
+      current.emit(message);
+    },
+    end(): void {
+      for (const queryStream of streams) queryStream.end();
+    },
+  };
   sdkMock.query.mockImplementation((options: unknown) => {
+    const queryStream = createControlledStream();
+    const fakeQuery = createFakeQuery(queryStream, queryOpts);
+    streams.push(queryStream);
+    fakeQueries.push(fakeQuery);
     const prompt = (options as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
     if (prompt) {
       void (async () => {
@@ -214,6 +229,7 @@ async function startSessionWithStream(
     model: 'claude-opus-4-6',
     workingDir,
     permissionMode: 'acceptEdits',
+    vendorOptions: opts?.vendorOptions,
   });
 
   const events: AgentEvent[] = [];
@@ -225,10 +241,12 @@ async function startSessionWithStream(
         }
       })();
 
-  return { agent, handle, stream, fakeQuery, events, collected };
+  const fakeQuery = fakeQueries[0];
+  if (!fakeQuery) throw new Error('initial fake query was not created');
+  return { agent, handle, stream, streams, fakeQuery, fakeQueries, events, collected };
 }
 
-async function startRemoteSessionWithStream() {
+async function startRemoteSessionWithStream(opts?: { autoCollect?: boolean }) {
   const configDir = await makeTempDir();
   process.env.CLAUDE_CONFIG_DIR = configDir;
   const workingDir = await makeTempDir();
@@ -249,9 +267,11 @@ async function startRemoteSessionWithStream() {
     permissionMode: 'acceptEdits',
   });
   const events: AgentEvent[] = [];
-  const collected = (async () => {
-    for await (const event of handle.events()) events.push(event);
-  })();
+  const collected = opts?.autoCollect === false
+    ? Promise.resolve()
+    : (async () => {
+        for await (const event of handle.events()) events.push(event);
+      })();
   return { handle, stream, fakeQuery, events, collected };
 }
 
@@ -304,6 +324,17 @@ function turnResult(result = 'ok'): Record<string, unknown> {
   };
 }
 
+function interruptedTurnResult(): Record<string, unknown> {
+  return {
+    type: 'result',
+    subtype: 'error_during_execution',
+    is_error: true,
+    stop_reason: null,
+    total_cost_usd: 0,
+    usage: { input_tokens: 1, output_tokens: 1 },
+  };
+}
+
 function assistantText(text: string): Record<string, unknown> {
   return {
     type: 'assistant',
@@ -339,6 +370,40 @@ function createDeferred<T = void>(): {
 
 function taskEvents(events: AgentEvent[]): AgentEvent[] {
   return events.filter((e) => e.type === 'agent_task_update');
+}
+
+function isProductTerminal(event: AgentEvent): boolean {
+  return (
+    (event.type === 'done' && event.turnContinuationId === undefined) ||
+    (event.type === 'error' &&
+      (event.data as { isTerminal?: unknown } | null | undefined)?.isTerminal === true)
+  );
+}
+
+function createEventReader(handle: AgentSessionHandle) {
+  const iterator = handle.events()[Symbol.asyncIterator]();
+  const seen: AgentEvent[] = [];
+  const nextMatching = async (predicate: (event: AgentEvent) => boolean): Promise<AgentEvent> => {
+    for (;;) {
+      const result = await iterator.next();
+      if (result.done) throw new Error('event stream ended before the expected event');
+      seen.push(result.value);
+      if (predicate(result.value)) return result.value;
+    }
+  };
+  return { iterator, nextMatching, seen };
+}
+
+function wrapInSession(handle: AgentSessionHandle): Session {
+  return new Session({
+    id: 'session-continuation-cross-layer',
+    agentKind: 'claude-code',
+    workDir: path.join('workspace', 'repo'),
+    handle,
+    capabilities: {} as never,
+    logger: createNoopLogger(),
+    turnStallMs: 0,
+  });
 }
 
 afterEach(async () => {
@@ -543,90 +608,162 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('stopTask 先取消 claim 后 interrupt 成功仍屏蔽迟到 continuation 尾巴', async () => {
+  it('interrupt ACK 前真实 continuation done 先到时不再追加 synthetic 终态', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn background work' });
     stream.emit(taskStarted('task-agent', 'local_agent'));
     await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
     stream.emit(turnResult('waiting'));
-    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
     const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
     expect(continuationId).toBeTypeOf('number');
 
+    const stopTask = createDeferred<void>();
     const interrupt = createDeferred<void>();
+    fakeQuery.stopTask!.mockImplementationOnce(() => stopTask.promise);
     fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
     const abortPromise = handle.abort();
-    await waitFor(() => fakeQuery.stopTask!.mock.calls.length === 1, 'stopTask dispatched');
-    await waitFor(
-      () =>
-        events.some(
-          (event) =>
-            event.type === 'done' &&
-            (event.data as { reason?: unknown } | null | undefined)?.reason ===
-              'turn_continuation_cancelled',
-        ),
-      'stopTask cancelled claim before interrupt resolved',
-    );
-    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
+    await waitFor(() => fakeQuery.interrupt.mock.calls.length === 1, 'interrupt dispatched');
 
+    stream.emit(assistantText('real continuation wins'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+    stream.emit(turnResult('real interrupted result'));
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'real product terminal observed');
+
+    stopTask.resolve(undefined);
     interrupt.resolve(undefined);
     await abortPromise;
-    const eventCountAfterCancellation = events.length;
-    stream.emit(taskStarted('task-late', 'local_agent'));
-    stream.emit({
-      type: 'assistant',
-      message: { content: [{ type: 'text', text: 'late assistant output' }] },
-    });
-    stream.emit(turnResult('late interrupted result'));
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await waitFor(() => handle.isTurnRunning?.() === false, 'real terminal acknowledged');
 
-    expect(events).toHaveLength(eventCountAfterCancellation);
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+    expect(
+      events.filter(
+        (event) =>
+          event.type === 'done' &&
+          (event.data as { reason?: unknown } | null | undefined)?.reason ===
+            'turn_continuation_cancelled',
+      ),
+    ).toHaveLength(0);
     expect(handle.listBackgroundTasks?.()).toEqual([]);
-    expect(handle.isTurnRunning?.()).toBe(false);
+
+    await handle.send({ type: 'user', content: 'next turn after real terminal' });
+    stream.emit(turnResult('next turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'next product terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'next turn settled');
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
 
     stream.end();
     await handle.close().catch(() => undefined);
   });
 
-  it('interrupt 在途时 awaiting claim 先变 active，result 正常收尾且不再建 claim', async () => {
-    const { handle, stream, events, fakeQuery } = await startSessionWithStream();
+  it.each([
+    ['success', () => turnResult('late old-generation success')],
+    ['is_error', interruptedTurnResult],
+  ] as const)(
+    '跨层 Session 丢弃 gen N 迟到的 %s result，不终结 gen N+1',
+    async (_lateKind, lateResult) => {
+      const { handle, stream, streams } = await startSessionWithStream(
+        undefined,
+        { autoCollect: false },
+      );
+      const session = wrapInSession(handle);
+      const seen: AgentEvent[] = [];
+      session.onEvent((event) => seen.push(event));
+
+      const firstSend = await session.send('spawn background work', { turnAttemptToken: 101 });
+      expect(firstSend).toEqual({ accepted: true });
+      stream.emit(taskStarted('task-agent', 'local_agent'));
+      await waitFor(() => taskEvents(seen).length >= 1, 'Session observed wake task');
+      stream.emit(turnResult('waiting'));
+      await waitFor(
+        () => seen.some((event) => event.type === 'done' && event.turnContinuationId !== undefined),
+        'Session observed claimed parent done',
+      );
+      expect(seen.filter(isProductTerminal)).toHaveLength(0);
+      await expect(session.send('must remain blocked')).rejects.toThrow(/SESSION_RUNNING/);
+
+      stream.emit(taskNotification('task-agent', 'completed'));
+      await waitFor(() => taskEvents(seen).length >= 2, 'Session observed task completion');
+      await session.abort();
+      await waitFor(() => seen.filter(isProductTerminal).length === 1, 'Stop terminal observed');
+      await waitFor(() => session.isTurnRunning() === false, 'generation N settled');
+      expect(seen.filter(isProductTerminal)[0]?.turnAttemptToken).toBe(101);
+
+      const secondSend = await session.send('start generation N+1', { turnAttemptToken: 202 });
+      expect(secondSend).toEqual({ accepted: true });
+      await waitFor(
+        () =>
+          seen.some(
+            (event) =>
+              event.type === 'status' &&
+              event.turnAttemptToken === 202 &&
+              (event.data as { isRunning?: unknown } | null | undefined)?.isRunning === true,
+          ),
+        'generation N+1 start status observed',
+      );
+      const eventCountBeforeLateResult = seen.length;
+      streams[0]?.emit(lateResult());
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(seen).toHaveLength(eventCountBeforeLateResult);
+      expect(session.isTurnRunning()).toBe(true);
+
+      stream.emit(assistantText('generation N+1 output'));
+      await waitFor(
+        () => seen.some((event) => event.type === 'text' && event.turnAttemptToken === 202),
+        'generation N+1 assistant observed',
+      );
+      stream.emit(turnResult('generation N+1 complete'));
+      await waitFor(() => seen.filter(isProductTerminal).length === 2, 'generation N+1 terminal observed');
+      await waitFor(() => session.isTurnRunning() === false, 'generation N+1 settled');
+      expect(seen.filter(isProductTerminal).map((event) => event.turnAttemptToken)).toEqual([
+        101,
+        202,
+      ]);
+
+      stream.end();
+      await session.close().catch(() => undefined);
+    },
+  );
+
+  it('旧 query 迟到 result 被隔离后，新 query 的 is_error result 仍正常收口', async () => {
+    const { handle, stream, streams, events } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn background work' });
     stream.emit(taskStarted('task-agent', 'local_agent'));
     await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
     stream.emit(turnResult('waiting'));
-    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
-    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
-    expect(continuationId).toBeTypeOf('number');
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'task completion observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'Stop terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'cancelled generation settled');
 
-    const interrupt = createDeferred<void>();
-    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('stop raced with continuation'));
-    fakeQuery.interrupt.mockImplementationOnce(() => interrupt.promise);
-    const abortPromise = handle.abort();
-    await waitFor(() => fakeQuery.interrupt.mock.calls.length === 1, 'interrupt dispatched');
-
-    stream.emit({
-      type: 'assistant',
-      message: { content: [{ type: 'text', text: 'continuation started before interrupt' }] },
-    });
+    const eventCountBeforeNewSend = events.length;
+    await handle.send({ type: 'user', content: 'new failing turn' });
     await waitFor(
-      () => handle.beginTurnContinuationWait?.(continuationId) === 'active',
-      'awaiting claim activated while interrupt was pending',
+      () => events.length > eventCountBeforeNewSend,
+      'new generation start status observed',
     );
+    const eventCountBeforeOldTail = events.length;
+    streams[0]?.emit(turnResult('late old result'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toHaveLength(eventCountBeforeOldTail);
 
-    interrupt.resolve(undefined);
-    await abortPromise;
-    stream.emit(turnResult('interrupted continuation'));
+    stream.emit(interruptedTurnResult());
     await waitFor(
-      () => events.filter((event) => event.type === 'done').length >= 2,
-      'active continuation result observed',
+      () =>
+        events.some(
+          (event) =>
+            event.type === 'error' &&
+            (event.data as { isTerminal?: unknown } | null | undefined)?.isTerminal === true,
+        ),
+      'new generation terminal error observed',
     );
-
-    const finalDone = events.filter((event) => event.type === 'done').at(-1);
-    expect(finalDone?.turnContinuationId).toBeUndefined();
-    expect(handle.beginTurnContinuationWait?.(continuationId)).toBeNull();
-    expect(handle.isTurnRunning?.()).toBe(false);
+    await waitFor(() => handle.isTurnRunning?.() === false, 'new failing generation settled');
+    expect(events.filter((event) => event.type === 'done').at(-1)?.turnContinuationId).toBeUndefined();
 
     stream.end();
     await handle.close().catch(() => undefined);
@@ -726,7 +863,36 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('四个并行 Agent 相邻 completed 后逐段自动续跑，最后一个 done 归零 busy', async () => {
+  it('terminal latch 只压同 task，其他 running wake task 仍正常进入 claim', async () => {
+    const { handle, stream, events } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn two background tasks' });
+    stream.emit(taskStarted('task-a', 'local_agent'));
+    stream.emit(taskStarted('task-b', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 2, 'parallel tasks observed');
+
+    stream.emit(taskNotification('task-a', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 3, 'task a completed');
+    stream.emit(taskProgress('task-a'));
+    stream.emit(taskUpdatedRunning('task-a'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(taskEvents(events)).toHaveLength(3);
+    expect(handle.listBackgroundTasks?.().map((task) => task.taskId)).toEqual(['task-b']);
+
+    stream.emit(turnResult('task b is still running'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
+    const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+
+    stream.emit(taskNotification('task-b', 'stopped'));
+    await waitFor(() => handle.isTurnRunning?.() === false, 'task b cancellation settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('四个并行 Agent 的相邻终态通知合并为一段 continuation', async () => {
     const { handle, stream, events } = await startSessionWithStream();
     const taskIds = ['task-1', 'task-2', 'task-3', 'task-4'];
 
@@ -736,29 +902,68 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     stream.emit(turnResult('waiting for parallel tasks'));
     await waitFor(() => events.filter((event) => event.type === 'done').length >= 1, 'foreground done observed');
 
-    for (const taskId of taskIds) stream.emit(taskNotification(taskId, 'completed'));
+    stream.emit(taskNotification('task-1', 'completed'));
+    stream.emit(taskNotification('task-2', 'failed'));
+    stream.emit(taskNotification('task-3', 'completed'));
+    stream.emit(taskNotification('task-4', 'failed'));
     await waitFor(
       () => taskEvents(events).length >= taskIds.length * 2,
       'adjacent task completions observed',
     );
 
-    for (let index = 0; index < taskIds.length; index += 1) {
-      stream.emit(turnResult(''));
-      await waitFor(
-        () => events.filter((event) => event.type === 'done').length >= index + 2,
-        `continuation ${index + 1} done observed`,
-      );
-      const continuationDone = events.filter((event) => event.type === 'done')[index + 1];
-      if (index < taskIds.length - 1) {
-        expect(continuationDone?.turnContinuationId).toBeTypeOf('number');
-      } else {
-        expect(continuationDone?.turnContinuationId).toBeUndefined();
-      }
-      expect(handle.isTurnRunning?.()).toBe(index < taskIds.length - 1);
-    }
+    stream.emit(assistantText('all merged results'));
+    stream.emit(turnResult(''));
+    await waitFor(
+      () => events.filter((event) => event.type === 'done').length >= 2,
+      'single merged continuation done observed',
+    );
 
     const doneEvents = events.filter((event) => event.type === 'done');
+    expect(doneEvents).toHaveLength(2);
     expect(doneEvents.at(-1)?.turnContinuationId).toBeUndefined();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('合并 continuation 只把仍 running 的任务带入下一 claim', async () => {
+    const { handle, stream, events } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn three background agents' });
+    for (const taskId of ['task-a', 'task-b', 'task-c']) {
+      stream.emit(taskStarted(taskId, 'local_agent'));
+    }
+    await waitFor(() => taskEvents(events).length >= 3, 'parallel tasks observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.filter((event) => event.type === 'done').length >= 1, 'parent done observed');
+
+    stream.emit(taskNotification('task-a', 'completed'));
+    stream.emit(taskNotification('task-b', 'failed'));
+    await waitFor(() => taskEvents(events).length >= 5, 'merged terminal notifications observed');
+    stream.emit(assistantText('merged a and b'));
+    stream.emit(turnResult(''));
+    await waitFor(
+      () => events.filter((event) => event.type === 'done').length >= 2,
+      'merged continuation done observed',
+    );
+
+    const nextClaimId = events.filter((event) => event.type === 'done').at(-1)?.turnContinuationId;
+    expect(nextClaimId).toBeTypeOf('number');
+    expect(handle.beginTurnContinuationWait?.(nextClaimId)).toBe('awaiting');
+
+    stream.emit(taskNotification('task-c', 'stopped'));
+    await waitFor(
+      () =>
+        events.some(
+          (event) =>
+            event.type === 'done' &&
+            (event.data as { reason?: unknown } | null | undefined)?.reason ===
+              'turn_continuation_cancelled',
+        ),
+      'remaining running task cancellation observed',
+    );
+    expect(handle.beginTurnContinuationWait?.(nextClaimId)).toBeNull();
     expect(handle.isTurnRunning?.()).toBe(false);
 
     stream.end();
@@ -784,6 +989,30 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
 
     stream.end();
     await collected;
+  });
+
+  it('remote detach 在 claim boundary 未 ACK 时也立即释放旧 continuation id', async () => {
+    const { handle, stream, fakeQuery } = await startRemoteSessionWithStream({
+      autoCollect: false,
+    });
+    const { iterator, nextMatching, seen } = createEventReader(handle);
+
+    await handle.send({ type: 'user', content: 'spawn remote background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await nextMatching((event) => event.type === 'agent_task_update');
+    stream.emit(turnResult('waiting'));
+    const parentDone = await nextMatching((event) => event.type === 'done');
+    expect(parentDone.turnContinuationId).toBeTypeOf('number');
+    expect(handle.beginTurnContinuationWait?.(parentDone.turnContinuationId)).toBe('awaiting');
+
+    await handle.detach?.();
+    expect(fakeQuery.detach).toHaveBeenCalledTimes(1);
+    expect(handle.beginTurnContinuationWait?.(parentDone.turnContinuationId)).toBeNull();
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(seen.filter(isProductTerminal)).toHaveLength(0);
+
+    stream.end();
+    await iterator.return?.();
   });
 
   it('result-only 自动续 turn 会把旧 claim 标成 active，并由第二个 done 正常收口', async () => {
@@ -841,6 +1070,41 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     expect(events.filter((event) => event.type === 'done')).toHaveLength(1);
 
     stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('claim-bearing parent done 入队失败时回滚 claim 的两条 boundary 账', async () => {
+    const { handle, stream } = await startSessionWithStream(undefined, { autoCollect: false });
+    const { iterator, nextMatching } = createEventReader(handle);
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await nextMatching((event) => event.type === 'agent_task_update');
+
+    asyncQueueMock.rejectNextDone = true;
+    stream.emit(turnResult('waiting'));
+    const pairedStatus = await nextMatching(
+      (event) =>
+        event.type === 'status' &&
+        event.turnContinuationId !== undefined &&
+        (event.data as { isRunning?: unknown } | null | undefined)?.isRunning === false,
+    );
+    const continuationId = pairedStatus.turnContinuationId;
+    expect(continuationId).toBeTypeOf('number');
+    // The rejected done ledger was rolled back, while the yielded paired
+    // status still owns exactly one claim boundary until the next iterator ACK.
+    expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    const drain = iterator.next();
+    await waitFor(
+      () => handle.beginTurnContinuationWait?.(continuationId) === null,
+      'accepted paired status claim ledger acknowledged',
+    );
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await drain;
     await handle.close().catch(() => undefined);
   });
 
@@ -1051,7 +1315,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
-  it('stopTask 与 interrupt 都失败时不伪造 continuation 收口', async () => {
+  it('stopTask 成功但 interrupt 失败时不伪造 continuation 收口', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 
     await handle.send({ type: 'user', content: 'spawn background work' });
@@ -1061,22 +1325,30 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await waitFor(() => events.some((event) => event.type === 'done'), 'foreground done observed');
     const continuationId = events.find((event) => event.type === 'done')?.turnContinuationId;
     expect(continuationId).toBeTypeOf('number');
+    const productTerminalCountBeforeAbort = events.filter(isProductTerminal).length;
+    const unclaimedIdleStatusCountBeforeAbort = events.filter(
+      (event) =>
+        event.type === 'status' &&
+        event.turnContinuationId === undefined &&
+        (event.data as { isRunning?: unknown } | null | undefined)?.isRunning === false,
+    ).length;
 
-    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('stop failed'));
     fakeQuery.interrupt.mockRejectedValueOnce(new Error('interrupt failed'));
     await expect(handle.abort()).resolves.toBeUndefined();
     await new Promise((resolve) => setTimeout(resolve, 20));
 
+    expect(fakeQuery.stopTask).toHaveBeenCalledTimes(1);
     expect(handle.beginTurnContinuationWait?.(continuationId)).toBe('awaiting');
     expect(handle.isTurnRunning?.()).toBe(true);
+    expect(events.filter(isProductTerminal)).toHaveLength(productTerminalCountBeforeAbort);
     expect(
-      events.some(
+      events.filter(
         (event) =>
-          event.type === 'done' &&
-          (event.data as { reason?: unknown } | null | undefined)?.reason ===
-            'turn_continuation_cancelled',
+          event.type === 'status' &&
+          event.turnContinuationId === undefined &&
+          (event.data as { isRunning?: unknown } | null | undefined)?.isRunning === false,
       ),
-    ).toBe(false);
+    ).toHaveLength(unclaimedIdleStatusCountBeforeAbort);
 
     stream.end();
     await handle.close().catch(() => undefined);
@@ -1186,6 +1458,161 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await waitFor(() => handle.isTurnRunning?.() === false, 'cancellation done consumed');
     stream.end();
     await drain;
+    await handle.close().catch(() => undefined);
+  });
+
+  it('completed claim stays busy until Stop synthetic terminal is acknowledged', async () => {
+    const { handle, stream, fakeQuery } = await startSessionWithStream(
+      undefined,
+      { autoCollect: false },
+    );
+    const { iterator, nextMatching, seen } = createEventReader(handle);
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await nextMatching(
+      (event) =>
+        event.type === 'agent_task_update' &&
+        (event.data as { status?: unknown } | null | undefined)?.status === 'running',
+    );
+    stream.emit(turnResult('waiting for task'));
+    const foregroundDone = await nextMatching((event) => event.type === 'done');
+    expect(foregroundDone.turnContinuationId).toBeTypeOf('number');
+
+    const completedEvent = nextMatching(
+      (event) =>
+        event.type === 'agent_task_update' &&
+        (event.data as { status?: unknown } | null | undefined)?.status === 'completed',
+    );
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await completedEvent;
+    expect(handle.beginTurnContinuationWait?.(foregroundDone.turnContinuationId)).toBe('awaiting');
+
+    await handle.abort();
+    expect(fakeQuery.stopTask).not.toHaveBeenCalled();
+    expect(fakeQuery.interrupt).toHaveBeenCalledTimes(1);
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    // interrupt ACK 已返回、synthetic terminal 已排队但尚未被消费；provider
+    // 的迟到尾巴不能越过 tombstone 再追加一个真实终态。
+    stream.emit(assistantText('late provider assistant after interrupt ACK'));
+    stream.emit(turnResult('late provider result after interrupt ACK'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    const cancellationDone = await nextMatching(
+      (event) =>
+        event.type === 'done' &&
+        (event.data as { reason?: unknown } | null | undefined)?.reason ===
+          'turn_continuation_cancelled',
+    );
+    expect(cancellationDone.turnContinuationId).toBeUndefined();
+    expect(handle.isTurnRunning?.()).toBe(true);
+    expect(seen.filter(isProductTerminal)).toHaveLength(1);
+
+    // Asking for the next item acknowledges the yielded terminal boundary.
+    const drain = iterator.next();
+    await waitFor(() => handle.isTurnRunning?.() === false, 'cancellation done consumed');
+    expect(handle.beginTurnContinuationWait?.(foregroundDone.turnContinuationId)).toBeNull();
+    const nextState = await Promise.race([
+      drain.then(() => 'event' as const),
+      new Promise<'pending'>((resolve) => setTimeout(() => resolve('pending'), 30)),
+    ]);
+    expect(nextState).toBe('pending');
+    stream.end();
+    await handle.close().catch(() => undefined);
+    await drain;
+  });
+
+  it.each(['user Stop', 'stopped notification', 'single-task Stop'] as const)(
+    '%s synthetic 收口后无旧 result，新一代 result-only 仍正常结束',
+    async (source) => {
+      const { handle, stream, events, fakeQueries } = await startSessionWithStream();
+
+      await handle.send({ type: 'user', content: 'spawn background work' });
+      stream.emit(taskStarted('task-agent', 'local_agent'));
+      await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+      stream.emit(turnResult('waiting'));
+      await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+      expect(events.find((event) => event.type === 'done')?.turnContinuationId).toBeTypeOf('number');
+
+      if (source === 'user Stop') {
+        await handle.abort();
+      } else if (source === 'stopped notification') {
+        stream.emit(taskNotification('task-agent', 'stopped'));
+      } else {
+        await handle.stopBackgroundTask?.('task-agent');
+      }
+      await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+      await waitFor(() => handle.isTurnRunning?.() === false, 'synthetic terminal acknowledged');
+
+      await handle.send({ type: 'user', content: 'result-only next turn' });
+      expect(fakeQueries).toHaveLength(2);
+      stream.emit(turnResult('next turn complete'));
+      await waitFor(() => events.filter(isProductTerminal).length === 2, 'new result-only terminal observed');
+      await waitFor(() => handle.isTurnRunning?.() === false, 'new result-only turn settled');
+
+      stream.end();
+      await handle.close().catch(() => undefined);
+    },
+  );
+
+  it('synthetic cancellation 后先 rewind 只重建一个 Query', async () => {
+    const { handle, stream, events, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'completion observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+
+    await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');
+    await handle.send({ type: 'user', content: 'send after rewind' });
+    expect(fakeQueries).toHaveLength(2);
+    expect(fakeQueries[1]?.close).not.toHaveBeenCalled();
+
+    stream.emit(turnResult('rewound turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'rewound turn terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'rewound turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('cancellation rebuild 不重复初始 resumeSessionAt / forkSession', async () => {
+    const { handle, stream, events, fakeQueries } = await startSessionWithStream(undefined, {
+      vendorOptions: {
+        resumeSessionAt: 'initial-assistant-uuid',
+        forkSession: true,
+      },
+    });
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'completion observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+
+    await handle.send({ type: 'user', content: 'send after cancellation' });
+    expect(fakeQueries).toHaveLength(2);
+    const rebuiltOptions = (sdkMock.query.mock.calls[1]?.[0] as {
+      options?: Record<string, unknown>;
+    } | undefined)?.options;
+    expect(rebuiltOptions).not.toHaveProperty('resumeSessionAt');
+    expect(rebuiltOptions).not.toHaveProperty('forkSession');
+
+    stream.emit(turnResult('replacement query complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'replacement terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'replacement turn settled');
+
+    stream.end();
     await handle.close().catch(() => undefined);
   });
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -218,8 +218,6 @@ async function startSessionWithStream(
 
   const streams: Array<ReturnType<typeof createControlledStream>> = [];
   const fakeQueries: Array<ReturnType<typeof createFakeQuery>> = [];
-  const queryInputs: unknown[][] = [];
-  const prompts: Array<AsyncIterable<unknown> | undefined> = [];
   const stream = {
     emit(message: unknown): void {
       const current = streams.at(-1);
@@ -233,17 +231,14 @@ async function startSessionWithStream(
   sdkMock.query.mockImplementation((options: unknown) => {
     const queryStream = createControlledStream();
     const fakeQuery = createFakeQuery(queryStream, queryOpts);
-    const inputs: unknown[] = [];
     streams.push(queryStream);
     fakeQueries.push(fakeQuery);
-    queryInputs.push(inputs);
     const prompt = (options as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
-    prompts.push(prompt);
     if (prompt && !opts?.capturePrompts) {
       void (async () => {
         try {
           for await (const ignored of prompt) {
-            inputs.push(ignored);
+            void ignored;
           }
         } catch { /* end / abort 都算正常收尾 */ }
       })();
@@ -287,8 +282,6 @@ async function startSessionWithStream(
     streams,
     fakeQuery,
     fakeQueries,
-    queryInputs,
-    prompts,
     events,
     collected,
   };
@@ -1757,7 +1750,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
   });
 
   it('synthetic cancellation rebuilds with compact before the next user message after a small-window switch', async () => {
-    const { handle, stream, streams, events, fakeQueries, prompts } = await startSessionWithStream(
+    const { handle, stream, streams, events, fakeQueries } = await startSessionWithStream(
       undefined,
       { autoCompactThresholdPct: 50, capturePrompts: true },
     );
@@ -1787,7 +1780,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.send({ type: 'user', content: 'user after cancellation' });
     expect(fakeQueries).toHaveLength(2);
     expect(streams).toHaveLength(2);
-    const prompt = prompts[1];
+    const prompt = (sdkMock.query.mock.calls[1]?.[0] as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
     expect(prompt).toBeDefined();
     const promptIter = prompt![Symbol.asyncIterator]();
     expect((await promptIter.next()).value?.message?.content).toBe('/compact');
@@ -1807,7 +1800,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
   });
 
   it('Stop during a cancellation compact bridge retries with a fresh query and no rewind target', async () => {
-    const { handle, stream, streams, events, fakeQueries, prompts } = await startSessionWithStream(
+    const { handle, stream, streams, events, fakeQueries } = await startSessionWithStream(
       undefined,
       { autoCompactThresholdPct: 50, capturePrompts: true },
     );
@@ -1824,7 +1817,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.setModel?.('claude-sonnet-5');
     await handle.send({ type: 'user', content: 'must be cancelled with compact' });
     expect(fakeQueries).toHaveLength(2);
-    const bridgePrompt = prompts[1];
+    const bridgePrompt = (sdkMock.query.mock.calls[1]?.[0] as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
     expect(bridgePrompt).toBeDefined();
     const bridgePromptIter = bridgePrompt![Symbol.asyncIterator]();
     expect((await bridgePromptIter.next()).value?.message?.content).toBe('/compact');
@@ -1844,7 +1837,7 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     };
     expect(retryArgs.options).not.toHaveProperty('resumeSessionAt');
     expect(retryArgs.options).not.toHaveProperty('forkSession');
-    const retryPrompt = prompts[2];
+    const retryPrompt = (sdkMock.query.mock.calls[2]?.[0] as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
     expect(retryPrompt).toBeDefined();
     const retryPromptIter = retryPrompt![Symbol.asyncIterator]();
     expect((await retryPromptIter.next()).value?.message?.content).toBe('/compact');

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -25,6 +25,7 @@ import type { AgentDeps, AgentSessionHandle } from '../../base-agent.js';
 import type { AuthAdapter } from '../../../interfaces/auth-adapter.js';
 import type { AgentEvent } from '../../../types/events.js';
 import type { Logger } from '../../../interfaces/logger.js';
+import type { ModelDescriptor } from '../../../types/capabilities.js';
 
 const sdkMock = vi.hoisted(() => ({
   forkSession: vi.fn(),
@@ -74,6 +75,23 @@ import { Session } from '../../../session.js';
 
 const tempDirs: string[] = [];
 const originalClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+const TEST_MODELS: ModelDescriptor[] = [
+  {
+    id: 'claude-opus-4-6',
+    displayName: 'Claude Opus 4.6',
+    contextWindow: 1_000_000,
+    efforts: ['low', 'medium', 'high', 'max'],
+    defaultEffort: 'high',
+  },
+  {
+    id: 'claude-sonnet-5',
+    displayName: 'Claude Sonnet 5',
+    contextWindow: 500_000,
+    efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+    defaultEffort: 'high',
+  },
+];
 
 function createNoopLogger(): Logger {
   const logger: Logger = {
@@ -187,7 +205,12 @@ async function makeTempDir(): Promise<string> {
 
 async function startSessionWithStream(
   queryOpts?: { omitStopTask?: boolean },
-  opts?: { autoCollect?: boolean; vendorOptions?: Record<string, unknown> },
+  opts?: {
+    autoCollect?: boolean;
+    vendorOptions?: Record<string, unknown>;
+    autoCompactThresholdPct?: number;
+    capturePrompts?: boolean;
+  },
 ) {
   const configDir = await makeTempDir();
   process.env.CLAUDE_CONFIG_DIR = configDir;
@@ -195,6 +218,8 @@ async function startSessionWithStream(
 
   const streams: Array<ReturnType<typeof createControlledStream>> = [];
   const fakeQueries: Array<ReturnType<typeof createFakeQuery>> = [];
+  const queryInputs: unknown[][] = [];
+  const prompts: Array<AsyncIterable<unknown> | undefined> = [];
   const stream = {
     emit(message: unknown): void {
       const current = streams.at(-1);
@@ -208,14 +233,17 @@ async function startSessionWithStream(
   sdkMock.query.mockImplementation((options: unknown) => {
     const queryStream = createControlledStream();
     const fakeQuery = createFakeQuery(queryStream, queryOpts);
+    const inputs: unknown[] = [];
     streams.push(queryStream);
     fakeQueries.push(fakeQuery);
+    queryInputs.push(inputs);
     const prompt = (options as { prompt?: AsyncIterable<unknown> } | undefined)?.prompt;
-    if (prompt) {
+    prompts.push(prompt);
+    if (prompt && !opts?.capturePrompts) {
       void (async () => {
         try {
           for await (const ignored of prompt) {
-            void ignored; // discard — 只对齐 pending 语义
+            inputs.push(ignored);
           }
         } catch { /* end / abort 都算正常收尾 */ }
       })();
@@ -223,7 +251,16 @@ async function startSessionWithStream(
     return fakeQuery;
   });
 
-  const agent = new ClaudeCodeAgent(createDeps());
+  const agent = new ClaudeCodeAgent({
+    ...createDeps({
+      runtimeConfig: {
+        ...(opts?.autoCompactThresholdPct === undefined
+          ? {}
+          : { autoCompactThresholdPct: opts.autoCompactThresholdPct }),
+      },
+    }),
+    capabilityAdditions: { availableModels: TEST_MODELS },
+  });
   const handle = await agent.startSession({
     sessionId: 'session-stop-task',
     model: 'claude-opus-4-6',
@@ -243,7 +280,18 @@ async function startSessionWithStream(
 
   const fakeQuery = fakeQueries[0];
   if (!fakeQuery) throw new Error('initial fake query was not created');
-  return { agent, handle, stream, streams, fakeQuery, fakeQueries, events, collected };
+  return {
+    agent,
+    handle,
+    stream,
+    streams,
+    fakeQuery,
+    fakeQueries,
+    queryInputs,
+    prompts,
+    events,
+    collected,
+  };
 }
 
 async function startRemoteSessionWithStream(opts?: { autoCollect?: boolean }) {
@@ -1703,6 +1751,114 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     stream.emit(turnResult('rewound turn complete'));
     await waitFor(() => events.filter(isProductTerminal).length === 2, 'rewound turn terminal observed');
     await waitFor(() => handle.isTurnRunning?.() === false, 'rewound turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('synthetic cancellation rebuilds with compact before the next user message after a small-window switch', async () => {
+    const { handle, stream, streams, events, fakeQueries, prompts } = await startSessionWithStream(
+      undefined,
+      { autoCompactThresholdPct: 50, capturePrompts: true },
+    );
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit({
+      type: 'stream_event',
+      event: { type: 'message_delta', usage: { input_tokens: 400_000, output_tokens: 0 } },
+    });
+    await vi.waitFor(() => {
+      expect(handle.getUsageSnapshot().contextTokens).toBe(400_000);
+    });
+    expect(handle.getUsageSnapshot().contextWindow).toBe(1_000_000);
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit({ ...turnResult('waiting'), usage: { input_tokens: 400_000, output_tokens: 1 } });
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'synthetic terminal acknowledged');
+
+    await expect(handle.setModel?.('claude-sonnet-5')).resolves.toBeUndefined();
+    expect(handle.getUsageSnapshot().contextWindow).toBe(500_000);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    await handle.send({ type: 'user', content: 'user after cancellation' });
+    expect(fakeQueries).toHaveLength(2);
+    expect(streams).toHaveLength(2);
+    const prompt = prompts[1];
+    expect(prompt).toBeDefined();
+    const promptIter = prompt![Symbol.asyncIterator]();
+    expect((await promptIter.next()).value?.message?.content).toBe('/compact');
+    expect((await promptIter.next()).value?.message?.content).toBe('user after cancellation');
+
+    streams[1]?.emit(turnResult('compact complete'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    streams[1]?.emit(turnResult('user complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'user terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'user turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('Stop during a cancellation compact bridge retries with a fresh query and no rewind target', async () => {
+    const { handle, stream, streams, events, fakeQueries, prompts } = await startSessionWithStream(
+      undefined,
+      { autoCompactThresholdPct: 50, capturePrompts: true },
+    );
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit({ ...turnResult('waiting'), usage: { input_tokens: 400_000, output_tokens: 1 } });
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'synthetic terminal acknowledged');
+
+    await handle.setModel?.('claude-sonnet-5');
+    await handle.send({ type: 'user', content: 'must be cancelled with compact' });
+    expect(fakeQueries).toHaveLength(2);
+    const bridgePrompt = prompts[1];
+    expect(bridgePrompt).toBeDefined();
+    const bridgePromptIter = bridgePrompt![Symbol.asyncIterator]();
+    expect((await bridgePromptIter.next()).value?.message?.content).toBe('/compact');
+    expect((await bridgePromptIter.next()).value?.message?.content).toBe(
+      'must be cancelled with compact',
+    );
+
+    await handle.abort();
+    expect(fakeQueries[1]?.close).toHaveBeenCalledTimes(1);
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'bridge Stop terminal observed');
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    await handle.send({ type: 'user', content: 'retry after cancellation bridge Stop' });
+    expect(fakeQueries).toHaveLength(3);
+    const retryArgs = sdkMock.query.mock.calls[2]?.[0] as {
+      options?: Record<string, unknown>;
+    };
+    expect(retryArgs.options).not.toHaveProperty('resumeSessionAt');
+    expect(retryArgs.options).not.toHaveProperty('forkSession');
+    const retryPrompt = prompts[2];
+    expect(retryPrompt).toBeDefined();
+    const retryPromptIter = retryPrompt![Symbol.asyncIterator]();
+    expect((await retryPromptIter.next()).value?.message?.content).toBe('/compact');
+    expect((await retryPromptIter.next()).value?.message?.content).toBe(
+      'retry after cancellation bridge Stop',
+    );
+
+    streams[2]?.emit(turnResult('retry compact complete'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events.filter(isProductTerminal)).toHaveLength(2);
+    expect(handle.isTurnRunning?.()).toBe(true);
+    streams[2]?.emit(turnResult('retry user complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 3, 'retry terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'retry settled');
 
     stream.end();
     await handle.close().catch(() => undefined);

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -650,6 +650,68 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('user Stop 取消 awaiting claim 后立即关闭旧 Query，并在下一次 send 使用 fresh Query', async () => {
+    const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting for background task'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'task completion observed');
+    expect(handle.isTurnRunning?.()).toBe(true);
+
+    await handle.abort();
+    expect(fakeQuery.close).toHaveBeenCalledTimes(1);
+    // 下一条 send 的 rebuildCancelledContinuationQuery 会对已关闭 stale Query
+    // 再做一次幂等 close；这里锁定的是 send 之前立即发生的第一次 close。
+    const closeCallsBeforeSend = fakeQuery.close.mock.calls.length;
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'synthetic terminal acknowledged');
+
+    await handle.send({ type: 'user', content: 'fresh turn after cancellation' });
+    expect(fakeQueries).toHaveLength(2);
+    expect(closeCallsBeforeSend).toBe(1);
+    expect(fakeQueries[1]?.close).not.toHaveBeenCalled();
+    stream.emit(turnResult('fresh turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'fresh turn terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'fresh turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('立即关闭后旧 Query 的迟到 assistant/result 不会产生新事件或终态', async () => {
+    const { handle, stream, streams, events, fakeQuery } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-agent', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+    stream.emit(turnResult('waiting for background task'));
+    await waitFor(() => events.some((event) => event.type === 'done'), 'parent done observed');
+    stream.emit(taskNotification('task-agent', 'completed'));
+    await waitFor(() => taskEvents(events).length >= 2, 'task completion observed');
+
+    await handle.abort();
+    expect(fakeQuery.close).toHaveBeenCalledTimes(1);
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic terminal observed');
+    const eventCountAfterCancellation = events.length;
+
+    streams[0]?.emit(assistantText('late old-query assistant'));
+    streams[0]?.emit(turnResult('late old-query result'));
+    streams[0]?.emit(taskProgress('task-agent'));
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    expect(events).toHaveLength(eventCountAfterCancellation);
+    expect(events.filter(isProductTerminal)).toHaveLength(1);
+    expect(handle.beginTurnContinuationWait?.(1)).toBeNull();
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('interrupt ACK 前真实 continuation done 先到时不再追加 synthetic 终态', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1624,6 +1624,87 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('stopTask reject 后为未确认 wake 安装栅栏，迟到自动续跑被丢弃', async () => {
+    const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-unconfirmed', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
+    await handle.abort();
+    stream.emit(interruptedTurnResult());
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'foreground stop terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'foreground stop settled');
+
+    // The terminal task notification remains visible and clears local task
+    // accounting; only the same-generation automatic continuation tail is fenced.
+    stream.emit(taskNotification('task-unconfirmed', 'completed'));
+    await waitFor(
+      () => taskEvents(events).some((event) =>
+        (event.data as { taskId?: unknown; status?: unknown } | null | undefined)?.taskId === 'task-unconfirmed' &&
+        (event.data as { status?: unknown } | null | undefined)?.status === 'completed',
+      ),
+      'unconfirmed task completion observed',
+    );
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    const eventCountBeforeLateTail = events.length;
+    stream.emit(assistantText('late untracked continuation'));
+    stream.emit(turnResult('late untracked result'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toHaveLength(eventCountBeforeLateTail);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    await handle.send({ type: 'user', content: 'fresh turn after fenced continuation' });
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('fresh turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'fresh turn terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'fresh turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('老 daemon 无 stopTask 时也为未确认 wake 安装栅栏并在下一 send 换代', async () => {
+    const { handle, stream, events, fakeQueries } = await startSessionWithStream({ omitStopTask: true });
+
+    await handle.send({ type: 'user', content: 'spawn background work' });
+    stream.emit(taskStarted('task-legacy', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'legacy wake task observed');
+
+    await handle.abort();
+    stream.emit(interruptedTurnResult());
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'legacy stop terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'legacy stop settled');
+
+    stream.emit(taskNotification('task-legacy', 'completed'));
+    await waitFor(
+      () => taskEvents(events).some((event) =>
+        (event.data as { taskId?: unknown; status?: unknown } | null | undefined)?.taskId === 'task-legacy' &&
+        (event.data as { status?: unknown } | null | undefined)?.status === 'completed',
+      ),
+      'legacy task completion observed',
+    );
+    expect(handle.listBackgroundTasks?.()).toEqual([]);
+
+    const eventCountBeforeLateTail = events.length;
+    stream.emit(assistantText('late legacy continuation'));
+    stream.emit(turnResult('late legacy result'));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(events).toHaveLength(eventCountBeforeLateTail);
+    expect(handle.isTurnRunning?.()).toBe(false);
+
+    await handle.send({ type: 'user', content: 'fresh turn after legacy fence' });
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult('fresh legacy turn complete'));
+    await waitFor(() => events.filter(isProductTerminal).length === 2, 'fresh legacy terminal observed');
+    await waitFor(() => handle.isTurnRunning?.() === false, 'fresh legacy turn settled');
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('stopTask 成功但 interrupt 失败时不伪造 continuation 收口', async () => {
     const { handle, stream, events, fakeQuery } = await startSessionWithStream();
 

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3175,6 +3175,13 @@ export class ClaudeCodeAgent extends BaseAgent {
       const states = [...claim.tasks.values()];
       // A completed/failed wake task still has the SDK continuation contract;
       // only an all-stopped group proves that a second `done` cannot arrive.
+      // Authority model: q.interrupt ACK is required when user Stop has no
+      // provider confirmation and must revoke a completed/failed continuation
+      // contract itself. An all-stopped snapshot is already provider-confirmed
+      // fact: every tracked task can no longer continue, while an awaiting
+      // claim has no foreground turn. It therefore settles independently of a
+      // concurrent interrupt resolving or rejecting; waiting for that control
+      // result would leak the claim when no further provider event can exist.
       if (
         states.length > 0 &&
         states.every((state) => state === 'stopped')

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2127,11 +2127,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           log.warn('upstream-idle watchdog during bridge: inputQueue.end threw', { error: String(e) });
         }
         canceledBridgeQueries.add(q);
-        try {
-          q.close();
-        } catch (e) {
-          log.warn('upstream-idle watchdog during bridge: q.close threw', { error: String(e) });
-        }
+        recordCanceledQueryClose(q, 'upstream idle watchdog during bridge');
         turnInFlight = false;
         turnState.interruptRequested = false;
         pendingToolIds.clear();
@@ -4589,11 +4585,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               log.warn('send failed after bridge /compact injection: inputQueue.end threw', { error: String(endError) });
             }
             canceledBridgeQueries.add(q);
-            try {
-              q.close();
-            } catch (closeError) {
-              log.warn('send failed after bridge /compact injection: q.close threw', { error: String(closeError) });
-            }
+            recordCanceledQueryClose(q, 'bridge send abandoned');
             turnInFlight = false;
             turnState.interruptRequested = false;
             pendingToolIds.clear();

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4877,13 +4877,13 @@ export class ClaudeCodeAgent extends BaseAgent {
             // best-effort stopTask RPCs above remain responsible for stopping
             // the provider tasks themselves.
             retireContinuationTasks(cancelledContinuation);
-            emitCancelledContinuationBoundary(cancelledContinuation, 'user_stop');
             // The provider may already have queued the automatic continuation
             // on this Query. Close it now so that cancellation fences process
             // termination and canUseTool callbacks as well as event output;
             // the next send will perform the existing fresh-query rebuild.
             const cancelledQuery = q;
             canceledBridgeQueries.add(cancelledQuery);
+            emitCancelledContinuationBoundary(cancelledContinuation, 'user_stop');
             inputQueue.clear();
             try {
               inputQueue.end();

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2208,6 +2208,18 @@ export class ClaudeCodeAgent extends BaseAgent {
       return true;
     }
 
+    // Rewind preview/commit intentionally skip injecting /compact because they
+    // are control operations, not product turns. If a blocked model/window
+    // switch crossed the threshold while the old Query was retired, leave the
+    // cancellation rebuild tombstone armed so the next send can inject the
+    // compact bridge on a fresh Query before accepting user input.
+    function shouldRearmAutoCompactAfterRewindControl(): boolean {
+      const snapshot = autoCompactController?.getLatestSnapshot();
+      const threshold = autoCompactController?.getCurrentThresholdPct();
+      return snapshot !== null && snapshot !== undefined &&
+        threshold !== undefined && snapshot.ratio >= threshold / 100;
+    }
+
     function queueAutoCompactBridge(kind: ActiveBridgeKind, resumeAt?: string): boolean {
       const queued = triggerAutoCompactIfNeeded();
       if (!queued) return false;
@@ -3070,7 +3082,6 @@ export class ClaudeCodeAgent extends BaseAgent {
     // Query is replaced before the next explicit user turn.
     let continuationCancellationGeneration: number | null = null;
     let continuationCancellationRequiresQueryRebuild = false;
-    let cancelledTailInterruptResultPending = false;
     const continuationClaims = new Map<number, ContinuationClaim>();
     const continuationListeners = new Set<(
       continuationId: number,
@@ -3647,7 +3658,6 @@ export class ClaudeCodeAgent extends BaseAgent {
       // 残留的 interruptRequested 会错误抑制新 q 首个真实 is_error 终态 —— 兜底清。
       turnState.interruptRequested = false;
       continuationCancellationGeneration = null;
-      cancelledTailInterruptResultPending = false;
       // Any successfully installed replacement Query isolates the cancelled
       // provider tail. This also covers rewind / invalid-resume rebuilds, so a
       // later send must not create a redundant intermediate Query.
@@ -3661,7 +3671,17 @@ export class ClaudeCodeAgent extends BaseAgent {
         try {
           for await (const rawMsg of currentQ) {
             if (closed) break;
-            if (canceledBridgeQueries.has(currentQ) || rewindTransitionQueries.has(currentQ)) {
+            const rawType = (rawMsg as { type?: string } | null)?.type;
+            const rawSubtype = (rawMsg as { subtype?: string } | null)?.subtype;
+            const rawStatus = (rawMsg as { status?: string } | null)?.status;
+            const isTerminalTaskNotification =
+              rawType === 'system' &&
+              rawSubtype === 'task_notification' &&
+              (rawStatus === 'completed' || rawStatus === 'failed' || rawStatus === 'stopped');
+            if (
+              (canceledBridgeQueries.has(currentQ) || rewindTransitionQueries.has(currentQ)) &&
+              !(canceledBridgeQueries.has(currentQ) && isTerminalTaskNotification)
+            ) {
               continue;
             }
             if (activeBridgeKind !== null && queuedBridgeTurns === 0) {
@@ -3671,16 +3691,9 @@ export class ClaudeCodeAgent extends BaseAgent {
               });
               clearBridgeState();
             }
-            const rawType = (rawMsg as { type?: string } | null)?.type;
-            // Keep the foreground result that acknowledges user Stop; only
-            // subsequent result/activity messages belong to the fenced tail.
-            const isExpectedInterruptResult =
-              cancelledTailInterruptResultPending &&
-              rawType === 'result';
             if (
               continuationCancellationGeneration !== null &&
-              (rawType === 'assistant' || rawType === 'stream_event' || rawType === 'result') &&
-              !isExpectedInterruptResult
+              (rawType === 'assistant' || rawType === 'stream_event' || rawType === 'result')
             ) {
               log.debug('ignoring provider activity from cancelled continuation query', {
                 rawType,
@@ -3873,7 +3886,6 @@ export class ClaudeCodeAgent extends BaseAgent {
                   }
                 : {}),
             });
-            if (isExpectedInterruptResult) cancelledTailInterruptResultPending = false;
             if (shouldCorrelateResumeFailure) {
               deferResumeFailureBoundary = false;
               deferredResumeFailureTimer = setTimeout(
@@ -4338,7 +4350,10 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
       log.warn(`${label}: runtime drift kept changing while replaying; leaving remaining drift to the next setter/rebuild`);
     }
-    async function rebuildCancelledContinuationQuery(signal?: AbortSignal): Promise<boolean> {
+    async function rebuildCancelledContinuationQuery(
+      signal?: AbortSignal,
+      options?: { queueCompactBridge?: boolean },
+    ): Promise<boolean> {
       if (!continuationCancellationRequiresQueryRebuild) return false;
       const staleQuery = q;
       const runtimeSnapshot: QueryRuntimeSnapshot = {
@@ -4353,10 +4368,12 @@ export class ClaudeCodeAgent extends BaseAgent {
       abortController = new AbortController();
       runtimeState.lastResultUsageAggregate = null;
       rewindTransitionQueries.add(staleQuery);
-      try {
-        await Promise.resolve(staleQuery.close());
-      } catch (e) {
-        log.warn('cancelled continuation query close threw before rebuild', { error: String(e) });
+      if (!canceledBridgeQueries.has(staleQuery)) {
+        try {
+          await Promise.resolve(staleQuery.close());
+        } catch (e) {
+          log.warn('cancelled continuation query close threw before rebuild', { error: String(e) });
+        }
       }
       try {
         q = await buildQuery({
@@ -4378,12 +4395,20 @@ export class ClaudeCodeAgent extends BaseAgent {
         startForwardLoop(q);
         notifySupportedModels(q);
         await replayRuntimeDrift(runtimeSnapshot, 'cancelled continuation rebuild');
-        // Cancellation rebuilds are fresh queries without a rewind checkpoint, but the
-        // model/window drift that was deferred while the cancelled query was fenced still
-        // needs the same compact→user bridge as rewind.  Register the bridge before the
-        // caller pushes the next user message; do not invent activeBridgeRewindResumeAt.
-        const bridgeCompactQueued = queueAutoCompactBridge('cancellation');
-        continuationCancellationRequiresQueryRebuild = false;
+        // Cancellation rebuilds used by send need the compact→user bridge for deferred
+        // model/window drift. Rewind preview/commit use the same fresh-query isolation but
+        // must not start a product turn or inject /compact before rewindFiles runs.
+        const skipCompactBridge = options?.queueCompactBridge === false;
+        const bridgeCompactQueued = skipCompactBridge
+          ? false
+          : queueAutoCompactBridge('cancellation');
+        // Preview/commit must not generate, but a deferred compact caused by a
+        // blocked model/window switch must survive until the next send. Keep
+        // the tombstone only for that case; otherwise the fresh Query is ready
+        // and the cancellation rebuild state can be cleared normally.
+        continuationCancellationRequiresQueryRebuild = skipCompactBridge
+          ? shouldRearmAutoCompactAfterRewindControl()
+          : false;
         return bridgeCompactQueued;
       } finally {
         acceptingRebuiltSend = false;
@@ -4902,51 +4927,50 @@ export class ClaudeCodeAgent extends BaseAgent {
           // produce another provider result. Close it explicitly after the
           // control action succeeds and append the ordered product terminal.
           const cancelledContinuation = stoppedClaim ?? cancelActiveContinuation('user_stop');
-          if (cancelledContinuation) {
-            // The successful Stop revokes these tasks' continuation contract.
-            // Retire their tracking entries as well, so a late provider
-            // result or running patch cannot rebuild the claim we just
-            // cancelled. This is product-side cancellation bookkeeping; the
-            // best-effort stopTask RPCs above remain responsible for stopping
-            // the provider tasks themselves.
-            retireContinuationTasks(cancelledContinuation);
-            // The provider may already have queued the automatic continuation
-            // on this Query. Close it now so that cancellation fences process
-            // termination and canUseTool callbacks as well as event output;
-            // the next send will perform the existing fresh-query rebuild.
+          const hasUnconfirmedWakeTasks = [...runningBackgroundTasks.values()].some((info) => info.wake);
+          if (cancelledContinuation || hasUnconfirmedWakeTasks) {
+            // Both cancellation sources share one terminal state: a cancelled
+            // continuation claim or an unconfirmed wake task means this Query
+            // must be retired. The provider tail is fenced by the per-query
+            // marker, then the next send/rewind installs a fresh Query.
             const cancelledQuery = q;
+            const foregroundNeedsTerminal = turnInFlight;
             canceledBridgeQueries.add(cancelledQuery);
-            emitCancelledContinuationBoundary(cancelledContinuation, 'user_stop');
+            // Query retirement always leaves a rebuild tombstone, even if the
+            // synthetic boundary is rejected because the event queue is
+            // already closing. The next explicit send/rewind must never push
+            // into this retired query.
+            continuationCancellationGeneration = turnState.generation;
+            continuationCancellationRequiresQueryRebuild = true;
+            if (cancelledContinuation) {
+              // The successful Stop revokes the continuation contract. Retire
+              // its task ledger before closing the provider process.
+              retireContinuationTasks(cancelledContinuation);
+              emitCancelledContinuationBoundary(cancelledContinuation, 'user_stop');
+            } else {
+              log.info('closing Query after user Stop with unconfirmed wake tasks', {
+                generation: turnState.generation,
+              });
+              // close() prevents the interrupted result from arriving. If the
+              // foreground turn has not already produced a terminal, replace
+              // it with one synthetic boundary; a raced natural result leaves
+              // turnInFlight=false and therefore does not get a duplicate.
+              if (foregroundNeedsTerminal) emitTurnBoundary('user_stop_unconfirmed_wake_tasks');
+            }
             inputQueue.clear();
             try {
               inputQueue.end();
             } catch (e) {
-              log.warn('user_stop continuation cancellation: inputQueue.end threw', { error: String(e) });
+              log.warn('user_stop cancellation: inputQueue.end threw', { error: String(e) });
             }
             try {
               cancelledQuery.close();
             } catch (e) {
-              log.warn('user_stop continuation cancellation: q.close threw', { error: String(e) });
+              log.warn('user_stop cancellation: q.close threw', { error: String(e) });
             }
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
             turnInFlight = false;
-          }
-          const hasUnconfirmedWakeTasks = [...runningBackgroundTasks.values()].some((info) => info.wake);
-          if (
-            hasUnconfirmedWakeTasks &&
-            continuationCancellationGeneration !== turnState.generation
-          ) {
-            // A successful interrupt without a cancelled claim still leaves
-            // wake tasks whose stop was rejected or unsupported. Keep the
-            // product turn idle, but fence their queued auto-continuation
-            // until the next send installs a fresh Query.
-            continuationCancellationGeneration = turnState.generation;
-            continuationCancellationRequiresQueryRebuild = true;
-            cancelledTailInterruptResultPending = turnInFlight;
-            log.info('installed cancelled-tail fence for unconfirmed wake tasks after user stop', {
-              generation: turnState.generation,
-            });
           }
         } catch (e) {
           // interrupt 失败 → 无 result 消费标记, 回收防误抑制(同 watchdog)。
@@ -5429,6 +5453,14 @@ export class ClaudeCodeAgent extends BaseAgent {
         while (idleResumeRebuildGate) {
           await idleResumeRebuildGate;
         }
+        if (continuationCancellationRequiresQueryRebuild) {
+          // Stop may have already closed the old Query while leaving the
+          // cancellation rebuild tombstone for the next explicit turn. A
+          // rewind preview is also a valid next control action: install an
+          // isolated fresh Query first, but do not inject the send-only
+          // /compact bridge or start a product turn.
+          await rebuildCancelledContinuationQuery(undefined, { queueCompactBridge: false });
+        }
         log.info('previewRewindFiles', { userUuid, sdkSessionId });
         try {
           const result = await q.rewindFiles(userUuid, { dryRun: true });
@@ -5460,6 +5492,11 @@ export class ClaudeCodeAgent extends BaseAgent {
         // 否则 pendingRewindTo 会指向一个已不存在的会话时点。等替换 query 就绪再走。
         while (idleResumeRebuildGate) {
           await idleResumeRebuildGate;
+        }
+        if (continuationCancellationRequiresQueryRebuild) {
+          // See previewRewindFiles: rebuild the fenced Query without the
+          // compact bridge so rewindFiles retains its checkpoint semantics.
+          await rebuildCancelledContinuationQuery(undefined, { queueCompactBridge: false });
         }
         log.info('commitRewindFiles ▶', { userUuid, priorAssistantUuid, sdkSessionId });
         // ① 立即把文件回滚到 target 时点 (失败 warn + 继续, forkSession=true 兜底)

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3016,6 +3016,10 @@ export class ClaudeCodeAgent extends BaseAgent {
     }
 
     const canceledBridgeQueries = new WeakSet<Query>();
+    // Despite the historical name, this per-query fence also marks an old
+    // Query closed after user Stop cancels an awaiting continuation. Its
+    // forward loop must silently discard any buffered tail until the next
+    // fresh Query is installed.
     // Rewind commit 会 close 当前 Query,但它的 forward loop 可能晚于下一次 send 的
     // rebuild 完成才退出。pendingRewindTo 是共享状态,会在新 q 接管后清掉;旧 q 自身仍
     // 需要一个 per-query 标记,否则迟到的 stream_end/abort 会被误判为当前新 q 的崩溃。
@@ -4874,6 +4878,26 @@ export class ClaudeCodeAgent extends BaseAgent {
             // the provider tasks themselves.
             retireContinuationTasks(cancelledContinuation);
             emitCancelledContinuationBoundary(cancelledContinuation, 'user_stop');
+            // The provider may already have queued the automatic continuation
+            // on this Query. Close it now so that cancellation fences process
+            // termination and canUseTool callbacks as well as event output;
+            // the next send will perform the existing fresh-query rebuild.
+            const cancelledQuery = q;
+            canceledBridgeQueries.add(cancelledQuery);
+            inputQueue.clear();
+            try {
+              inputQueue.end();
+            } catch (e) {
+              log.warn('user_stop continuation cancellation: inputQueue.end threw', { error: String(e) });
+            }
+            try {
+              cancelledQuery.close();
+            } catch (e) {
+              log.warn('user_stop continuation cancellation: q.close threw', { error: String(e) });
+            }
+            runningBackgroundTasks.clear();
+            terminalBackgroundTaskIds.clear();
+            turnInFlight = false;
           }
         } catch (e) {
           // interrupt 失败 → 无 result 消费标记, 回收防误抑制(同 watchdog)。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4875,6 +4875,9 @@ export class ClaudeCodeAgent extends BaseAgent {
         const stopRequests = stopRunningWakeBackgroundTasks('user_stop');
         try {
           await q.interrupt();
+          // stopTask and interrupt share an ordered control channel: an
+          // interrupt ACK guarantees these earlier stop requests have settled,
+          // so allSettled intentionally has no timeout or extra watchdog.
           const settledStops = await Promise.allSettled(stopRequests.map(({ promise }) => promise));
           const fulfilledWakeIds = stopRequests
             .filter((_, index) => settledStops[index]?.status === 'fulfilled')

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2908,6 +2908,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       activeBridgeRewindResumeAt = undefined;
       pendingToolIds.clear();
       runningBackgroundTasks.clear();
+      terminalBackgroundTaskIds.clear();
       closed = true;
       try { dismissAllPending('session_closed', 'deny'); } catch (e) {
         log.warn(`${logLabel}: dismissAllPending threw`, { error: String(e) });
@@ -2960,12 +2961,15 @@ export class ClaudeCodeAgent extends BaseAgent {
         continuationTerminalBoundaryEvents.add(doneEvent);
         pendingContinuationTerminalBoundaries += 1;
       }
-      if (!eventQueue.push(doneEvent) && trackContinuationTerminal) {
-        continuationTerminalBoundaryEvents.delete(doneEvent);
-        pendingContinuationTerminalBoundaries = Math.max(
-          0,
-          pendingContinuationTerminalBoundaries - 1,
-        );
+      const accepted = eventQueue.push(doneEvent);
+      if (trackContinuationTerminal) {
+        if (!accepted) {
+          continuationTerminalBoundaryEvents.delete(doneEvent);
+          pendingContinuationTerminalBoundaries = Math.max(
+            0,
+            pendingContinuationTerminalBoundaries - 1,
+          );
+        }
       }
     }
 
@@ -2993,6 +2997,12 @@ export class ClaudeCodeAgent extends BaseAgent {
       string,
       { wake: boolean; taskType?: string; toolUseId?: string; title?: string }
     >();
+    // SDK task progress can race behind its terminal notification. Once a task
+    // is terminal within the current Query generation, a late running/progress
+    // patch must not resurrect it into runningBackgroundTasks and manufacture
+    // a fresh continuation claim at the next done.
+    const terminalBackgroundTaskIds = new Set<string>();
+    const ignoredLateTerminalTaskEvents = new WeakSet<AgentEvent>();
 
     type ContinuationTaskState = 'running' | 'completed' | 'failed' | 'stopped';
     type ContinuationClaim = {
@@ -3009,6 +3019,10 @@ export class ClaudeCodeAgent extends BaseAgent {
     // result-only continuation cannot change what the host later observes.
     let nextContinuationId = 1;
     let activeContinuationId: number | null = null;
+    // User Stop can close an awaiting product continuation while the provider
+    // still has buffered activity. Suppress that cancelled tail until the next
+    // explicit user input is accepted (or the Query is replaced).
+    let continuationCancellationGeneration: number | null = null;
     const continuationClaims = new Map<number, ContinuationClaim>();
     const continuationListeners = new Set<(
       continuationId: number,
@@ -3103,6 +3117,16 @@ export class ClaudeCodeAgent extends BaseAgent {
         // attaching a fresh claim to this done when another automatic turn is
         // now expected.
       }
+      // A result produced by the generation being interrupted is already a
+      // terminal boundary. Even if a wake task remains in the provider table,
+      // user Stop has revoked the right to create another automatic segment.
+      if (
+        (turnState.interruptRequested &&
+          turnState.interruptGeneration === turnState.generation) ||
+        continuationCancellationGeneration === turnState.generation
+      ) {
+        return wasActiveContinuation;
+      }
       const wakeTasks = [...runningBackgroundTasks.entries()].filter(([, info]) => info.wake);
       for (const [taskId] of wakeTasks) {
         if (!carriedTasks.has(taskId)) carriedTasks.set(taskId, 'running');
@@ -3141,8 +3165,12 @@ export class ClaudeCodeAgent extends BaseAgent {
       const claim = activeContinuationClaim();
       for (const taskId of taskIds) {
         const info = runningBackgroundTasks.get(taskId);
-        if (!info?.wake) continue;
+        const claimTracksWakeTask =
+          (claim?.state === 'awaiting' || claim?.state === 'active') &&
+          claim.tasks.has(taskId);
+        if (!info?.wake && !claimTracksWakeTask) continue;
         runningBackgroundTasks.delete(taskId);
+        terminalBackgroundTaskIds.add(taskId);
         if (claim?.state === 'awaiting' || claim?.state === 'active') {
           claim.tasks.set(taskId, 'stopped');
         }
@@ -3169,6 +3197,19 @@ export class ClaudeCodeAgent extends BaseAgent {
       if (!taskId) return null;
       const status = data?.status;
       if (status === 'running') {
+        if (continuationCancellationGeneration !== null) {
+          log.debug('ignoring task activity after user-cancelled continuation', {
+            taskId,
+            cancellationGeneration: continuationCancellationGeneration,
+          });
+          ignoredLateTerminalTaskEvents.add(e);
+          return null;
+        }
+        if (terminalBackgroundTaskIds.has(taskId)) {
+          log.debug('ignoring late running update for terminal background task', { taskId });
+          ignoredLateTerminalTaskEvents.add(e);
+          return null;
+        }
         const prev = runningBackgroundTasks.get(taskId);
         const wake =
           prev?.wake === true ||
@@ -3190,6 +3231,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       } else if (status === 'completed' || status === 'failed' || status === 'stopped') {
         const prev = runningBackgroundTasks.get(taskId);
         runningBackgroundTasks.delete(taskId);
+        terminalBackgroundTaskIds.add(taskId);
         const claim = activeContinuationClaim();
         if (
           (claim?.state === 'awaiting' || claim?.state === 'active') &&
@@ -3343,7 +3385,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       deferResumeFailureBoundary = false;
     }
     let pendingTerminalStatusEvent: AgentEvent | undefined;
-    const forwardEventSink: AsyncQueue<AgentEvent> = {
+    const forwardEventSink: Pick<AsyncQueue<AgentEvent>, 'push'> = {
       // Claude's translator emits `status(isRunning=false)` immediately before
       // the matching `done`. Hold that status long enough to copy the
       // provider continuation claim from `done`; otherwise every generic
@@ -3356,6 +3398,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         }
         // 后台任务表旁路观察(O(1) type check,task 事件低频,不碰热路径逻辑)。
         const cancelledContinuation = noteBackgroundTaskEvent(e);
+        if (ignoredLateTerminalTaskEvents.delete(e)) return true;
         if (queuedBridgeTurns > 0) {
           if (e.type === 'done') {
             rememberBridgeSuppressedDoneData(e.data);
@@ -3415,6 +3458,15 @@ export class ClaudeCodeAgent extends BaseAgent {
           pendingContinuationTerminalBoundaries += 1;
         }
         const accepted = eventQueue.push(e);
+        if (isContinuationTerminalDone) {
+          if (!accepted) {
+            continuationTerminalBoundaryEvents.delete(e);
+            pendingContinuationTerminalBoundaries = Math.max(
+              0,
+              pendingContinuationTerminalBoundaries - 1,
+            );
+          }
+        }
         // A stopped notification is part of the visible turn history. Preserve
         // its order, then append a real product-turn boundary so Session can
         // close the current generation even though the SDK will not emit a
@@ -3424,19 +3476,6 @@ export class ClaudeCodeAgent extends BaseAgent {
         }
         return accepted;
       },
-      end: () => {
-        if (pendingTerminalStatusEvent) {
-          eventQueue.push(pendingTerminalStatusEvent);
-          pendingTerminalStatusEvent = undefined;
-        }
-        eventQueue.end();
-      },
-      clear: () => {
-        pendingTerminalStatusEvent = undefined;
-        eventQueue.clear();
-      },
-      get pending() { return eventQueue.pending; },
-      [Symbol.asyncIterator]: () => eventQueue[Symbol.asyncIterator](),
     };
 
     // ── 事件 forward loop（SDK 原始事件 → maker-core AgentEvent） ─────────────
@@ -3479,10 +3518,12 @@ export class ClaudeCodeAgent extends BaseAgent {
       // q 换代: 上一代 q 的 pending interrupted result 不可能从新 q drain 出来,
       // 残留的 interruptRequested 会错误抑制新 q 首个真实 is_error 终态 —— 兜底清。
       turnState.interruptRequested = false;
+      continuationCancellationGeneration = null;
       discardActiveContinuation('query_replaced');
       // q 换代 = 旧 CLI 子进程已死,其后台任务全部随之终止 —— 清表防 stale 条目
       // 让下次 abort 对不存在的任务空发 stopTask。
       runningBackgroundTasks.clear();
+      terminalBackgroundTaskIds.clear();
       void (async () => {
         try {
           for await (const rawMsg of currentQ) {
@@ -3499,6 +3540,16 @@ export class ClaudeCodeAgent extends BaseAgent {
               bridgeSuppressedDoneData = undefined;
             }
             const rawType = (rawMsg as { type?: string } | null)?.type;
+            if (
+              continuationCancellationGeneration !== null &&
+              (rawType === 'assistant' || rawType === 'stream_event' || rawType === 'result')
+            ) {
+              log.debug('ignoring provider activity after user-cancelled continuation', {
+                rawType,
+                cancellationGeneration: continuationCancellationGeneration,
+              });
+              continue;
+            }
             if (noteSdkInitMcpServerNames(rawMsg)) {
               await refreshSdkMcpProvenance(currentQ);
             }
@@ -4459,6 +4510,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             throw new Error('Claude input queue is closed');
           }
           userInputAccepted = true;
+          continuationCancellationGeneration = null;
           activeCapabilitySelectionText = userMessageTextForCapabilityRouting(message.content);
           setAutoReviewIntent(message.content);
           replayableUserInput = sdkInput;
@@ -4580,6 +4632,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           const cancelledContinuation = cancelActiveContinuation('bridge_aborted');
           if (!cancelledContinuation) settleActiveContinuation('bridge_aborted');
           runningBackgroundTasks.clear();
+          terminalBackgroundTaskIds.clear();
           turnInFlight = false;
           turnState.interruptRequested = false;
           emitTurnBoundary(
@@ -4599,12 +4652,56 @@ export class ClaudeCodeAgent extends BaseAgent {
           turnState.interruptRequested = true;
           turnState.interruptGeneration = turnState.generation;
         }
+        const awaitingContinuationAtUserStop = activeContinuationClaim();
+        const awaitingContinuationIdAtUserStop =
+          awaitingContinuationAtUserStop?.state === 'awaiting'
+            ? awaitingContinuationAtUserStop.id
+            : null;
+        const continuationGenerationAtUserStop = turnState.generation;
         // 用户 Stop 的产品语义 = 本会话所有模型调用停止:先发 stopTask 再 interrupt
         // (同一控制通道按序处理),封掉「interrupt 后任务恰好完成 → task_notification
         // 自动续跑新 turn」的竞态窗口。fire-and-forget,不阻塞 interrupt。
         stopRunningWakeBackgroundTasks('user_stop');
         try {
           await q.interrupt();
+          // Stop is the authoritative cancellation boundary. An awaiting
+          // continuation may already have lost every task from the running
+          // table, so neither stopTask nor an idle interrupt is guaranteed to
+          // produce another provider result. Close it explicitly after the
+          // control action succeeds and append the ordered product terminal.
+          const cancelledContinuation = cancelActiveContinuation('user_stop');
+          if (awaitingContinuationIdAtUserStop !== null) {
+            const continuationAfterInterrupt = activeContinuationClaim();
+            if (
+              continuationAfterInterrupt?.id === awaitingContinuationIdAtUserStop &&
+              continuationAfterInterrupt.state === 'active'
+            ) {
+              // Provider activity may have activated the snapshotted claim
+              // while interrupt was in flight. Let its interrupted result run
+              // the normal turn teardown, but forbid that result from minting
+              // another continuation claim.
+              turnState.interruptRequested = true;
+              turnState.interruptGeneration = turnState.generation;
+            } else if (continuationAfterInterrupt?.id !== awaitingContinuationIdAtUserStop) {
+              // stopTask may have won the race and cancelled the same claim
+              // before interrupt resolved. The successful interrupt still
+              // authorizes the same cancelled-tail tombstone.
+              continuationCancellationGeneration = continuationGenerationAtUserStop;
+            }
+          }
+          if (cancelledContinuation) {
+            // The successful Stop revokes these tasks' continuation contract.
+            // Retire their tracking entries as well, so a late provider
+            // result or running patch cannot rebuild the claim we just
+            // cancelled. This is product-side cancellation bookkeeping; the
+            // best-effort stopTask RPCs above remain responsible for stopping
+            // the provider tasks themselves.
+            for (const taskId of cancelledContinuation.tasks.keys()) {
+              runningBackgroundTasks.delete(taskId);
+              terminalBackgroundTaskIds.add(taskId);
+            }
+            emitCancelledContinuationBoundary(cancelledContinuation, 'user_stop');
+          }
         } catch (e) {
           // interrupt 失败 → 无 result 消费标记, 回收防误抑制(同 watchdog)。
           turnState.interruptRequested = false;
@@ -4677,6 +4774,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           abortController.abort();
           // close 会终结 CLI 子进程(本地)/ 远端 session,后台任务随之死亡。
           runningBackgroundTasks.clear();
+          terminalBackgroundTaskIds.clear();
         } catch (e) {
           log.warn('close threw', { error: String(e) });
         }
@@ -4698,11 +4796,14 @@ export class ClaudeCodeAgent extends BaseAgent {
         ? {
             async detach() {
               if (closed) return;
+              discardActiveContinuation('session_detached');
               closed = true;
               try {
                 dismissAllPending('session_closed', 'deny');
                 inputQueue.end();
                 abortController.abort();
+                runningBackgroundTasks.clear();
+                terminalBackgroundTaskIds.clear();
               } catch (e) {
                 log.warn('detach threw', { error: String(e) });
               }

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3070,6 +3070,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     // Query is replaced before the next explicit user turn.
     let continuationCancellationGeneration: number | null = null;
     let continuationCancellationRequiresQueryRebuild = false;
+    let cancelledTailInterruptResultPending = false;
     const continuationClaims = new Map<number, ContinuationClaim>();
     const continuationListeners = new Set<(
       continuationId: number,
@@ -3646,6 +3647,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // 残留的 interruptRequested 会错误抑制新 q 首个真实 is_error 终态 —— 兜底清。
       turnState.interruptRequested = false;
       continuationCancellationGeneration = null;
+      cancelledTailInterruptResultPending = false;
       // Any successfully installed replacement Query isolates the cancelled
       // provider tail. This also covers rewind / invalid-resume rebuilds, so a
       // later send must not create a redundant intermediate Query.
@@ -3670,9 +3672,15 @@ export class ClaudeCodeAgent extends BaseAgent {
               clearBridgeState();
             }
             const rawType = (rawMsg as { type?: string } | null)?.type;
+            // Keep the foreground result that acknowledges user Stop; only
+            // subsequent result/activity messages belong to the fenced tail.
+            const isExpectedInterruptResult =
+              cancelledTailInterruptResultPending &&
+              rawType === 'result';
             if (
               continuationCancellationGeneration !== null &&
-              (rawType === 'assistant' || rawType === 'stream_event' || rawType === 'result')
+              (rawType === 'assistant' || rawType === 'stream_event' || rawType === 'result') &&
+              !isExpectedInterruptResult
             ) {
               log.debug('ignoring provider activity from cancelled continuation query', {
                 rawType,
@@ -3865,6 +3873,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                   }
                 : {}),
             });
+            if (isExpectedInterruptResult) cancelledTailInterruptResultPending = false;
             if (shouldCorrelateResumeFailure) {
               deferResumeFailureBoundary = false;
               deferredResumeFailureTimer = setTimeout(
@@ -4922,6 +4931,22 @@ export class ClaudeCodeAgent extends BaseAgent {
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
             turnInFlight = false;
+          }
+          const hasUnconfirmedWakeTasks = [...runningBackgroundTasks.values()].some((info) => info.wake);
+          if (
+            hasUnconfirmedWakeTasks &&
+            continuationCancellationGeneration !== turnState.generation
+          ) {
+            // A successful interrupt without a cancelled claim still leaves
+            // wake tasks whose stop was rejected or unsupported. Keep the
+            // product turn idle, but fence their queued auto-continuation
+            // until the next send installs a fresh Query.
+            continuationCancellationGeneration = turnState.generation;
+            continuationCancellationRequiresQueryRebuild = true;
+            cancelledTailInterruptResultPending = turnInFlight;
+            log.info('installed cancelled-tail fence for unconfirmed wake tasks after user stop', {
+              generation: turnState.generation,
+            });
           }
         } catch (e) {
           // interrupt 失败 → 无 result 消费标记, 回收防误抑制(同 watchdog)。

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3380,13 +3380,13 @@ export class ClaudeCodeAgent extends BaseAgent {
     // fire-and-forget 逐个 stopTask:单个失败(任务恰好已自然结束 / 远端 daemon
     // 版本差)只 warn,绝不阻塞随后的 q.interrupt()。SDK 对每个被停任务会回吐
     // status:'stopped' 的 task_notification → 现有事件链把任务出表并让 UI 确定性收口。
-    function stopRunningWakeBackgroundTasks(reason: string): void {
-      if (runningBackgroundTasks.size === 0) return;
+    function stopRunningWakeBackgroundTasks(reason: string): string[] {
+      if (runningBackgroundTasks.size === 0) return [];
       const wakeIds: string[] = [];
       for (const [taskId, info] of runningBackgroundTasks) {
         if (info.wake) wakeIds.push(taskId);
       }
-      if (wakeIds.length === 0) return;
+      if (wakeIds.length === 0) return [];
       // 远端老 daemon / 老 SDK 没有 stopTask:退化为原行为(interrupt-only),
       // proxy 活动检测 + 「全部停止」兜底仍在。
       if (typeof q.stopTask !== 'function') {
@@ -3394,7 +3394,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           reason,
           wakeIds,
         });
-        return;
+        return [];
       }
       log.info('stopping running background wake tasks', { reason, wakeIds });
       for (const taskId of wakeIds) {
@@ -3419,6 +3419,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           },
         );
       }
+      return wakeIds;
     }
 
     // ── Middle-turn 事件过滤 (Codex review 3534925347 / 3535259132 / 3535293200) ──
@@ -4860,15 +4861,19 @@ export class ClaudeCodeAgent extends BaseAgent {
         // 用户 Stop 的产品语义 = 本会话所有模型调用停止:先发 stopTask 再 interrupt
         // (同一控制通道按序处理),封掉「interrupt 后任务恰好完成 → task_notification
         // 自动续跑新 turn」的竞态窗口。fire-and-forget,不阻塞 interrupt。
-        stopRunningWakeBackgroundTasks('user_stop');
+        const stopRequestedWakeIds = stopRunningWakeBackgroundTasks('user_stop');
         try {
           await q.interrupt();
+          // interrupt ACK authorizes retiring every wake task whose stop RPC
+          // was issued. A provider stopped echo is optional; without this
+          // local accounting, the next ordinary done can mint a ghost claim.
+          const stoppedClaim = markWakeTasksStopped(stopRequestedWakeIds, 'user_stop');
           // Stop is the authoritative cancellation boundary. An awaiting
           // continuation may already have lost every task from the running
           // table, so neither stopTask nor an idle interrupt is guaranteed to
           // produce another provider result. Close it explicitly after the
           // control action succeeds and append the ordered product terminal.
-          const cancelledContinuation = cancelActiveContinuation('user_stop');
+          const cancelledContinuation = stoppedClaim ?? cancelActiveContinuation('user_stop');
           if (cancelledContinuation) {
             // The successful Stop revokes these tasks' continuation contract.
             // Retire their tracking entries as well, so a late provider

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4284,6 +4284,8 @@ export class ClaudeCodeAgent extends BaseAgent {
     // onAccepted 已持久化/ack 消息,抛普通 Error 会把瞬时重建变成孤儿用户消息(desktop
     // 只对 SESSION_RUNNING 前缀 requeue)。恢复结束(成功或失败)后 resolve 放行。
     let idleResumeRebuildGate: Promise<void> | null = null;
+    // Idle-resume recovery and cancelled-continuation rebuilds have independent gates.
+    let cancellationRebuildGate: Promise<void> | null = null;
     // runtime control request 可写性判定: commitRewindFiles 后旧 Query 已 close、新 Query
     // 等下一次 send 重建;或 bridge Stop/watchdog 已 close 当前 Query、等待下一次
     // send 从同一 rewind point 重建。这些窗口里对 q 发 control request 会抛
@@ -4373,71 +4375,84 @@ export class ClaudeCodeAgent extends BaseAgent {
       signal?: AbortSignal,
       options?: { queueCompactBridge?: boolean },
     ): Promise<boolean> {
-      if (!continuationCancellationRequiresQueryRebuild) return false;
-      const staleQuery = q;
-      const runtimeSnapshot: QueryRuntimeSnapshot = {
-        model: mutableModel,
-        effort: mutableEffort,
-        fastMode: mutableFastMode,
-        sdkPermissionMode: currentTurnSdkPermissionMode(),
-      };
-      acceptingRebuiltSend = true;
-      inputQueue.end();
-      inputQueue = createAsyncQueue<SdkUserInput>();
-      abortController = new AbortController();
-      runtimeState.lastResultUsageAggregate = null;
-      rewindTransitionQueries.add(staleQuery);
-      const recordedClose = canceledQueryClosePromises.get(staleQuery);
-      if (recordedClose) {
-        try {
-          await recordedClose;
-        } catch (error) {
-          log.warn('cancelled continuation query close rejected before rebuild', { error: String(error) });
-        }
-      } else {
-        try {
-          await Promise.resolve(staleQuery.close());
-        } catch (e) {
-          log.warn('cancelled continuation query close threw before rebuild', { error: String(e) });
-        }
+      while (cancellationRebuildGate) {
+        await cancellationRebuildGate;
       }
+      if (!continuationCancellationRequiresQueryRebuild) return false;
+
+      let releaseCancellationRebuildGate: (() => void) | undefined;
+      cancellationRebuildGate = new Promise<void>((resolve) => {
+        releaseCancellationRebuildGate = resolve;
+      });
       try {
-        q = await buildQuery({
-          permissionMode: runtimeSnapshot.sdkPermissionMode,
-          fresh: true,
-        });
-        if (signal?.aborted) {
-          inputQueue.end();
-          rewindTransitionQueries.add(q);
+        const staleQuery = q;
+        const runtimeSnapshot: QueryRuntimeSnapshot = {
+          model: mutableModel,
+          effort: mutableEffort,
+          fastMode: mutableFastMode,
+          sdkPermissionMode: currentTurnSdkPermissionMode(),
+        };
+        acceptingRebuiltSend = true;
+        inputQueue.end();
+        inputQueue = createAsyncQueue<SdkUserInput>();
+        abortController = new AbortController();
+        runtimeState.lastResultUsageAggregate = null;
+        rewindTransitionQueries.add(staleQuery);
+        const recordedClose = canceledQueryClosePromises.get(staleQuery);
+        if (recordedClose) {
           try {
-            await Promise.resolve(q.close());
-          } catch (e) {
-            log.warn('cancelled continuation rebuild close threw after send cancellation', {
-              error: String(e),
-            });
+            await recordedClose;
+          } catch (error) {
+            log.warn('cancelled continuation query close rejected before rebuild', { error: String(error) });
           }
-          throw new Error('Claude send cancelled before acceptance');
+        } else {
+          try {
+            await Promise.resolve(staleQuery.close());
+          } catch (e) {
+            log.warn('cancelled continuation query close threw before rebuild', { error: String(e) });
+          }
         }
-        startForwardLoop(q);
-        notifySupportedModels(q);
-        await replayRuntimeDrift(runtimeSnapshot, 'cancelled continuation rebuild');
-        // Cancellation rebuilds used by send need the compact→user bridge for deferred
-        // model/window drift. Rewind preview/commit use the same fresh-query isolation but
-        // must not start a product turn or inject /compact before rewindFiles runs.
-        const skipCompactBridge = options?.queueCompactBridge === false;
-        const bridgeCompactQueued = skipCompactBridge
-          ? false
-          : queueAutoCompactBridge('cancellation');
-        // Preview/commit must not generate, but a deferred compact caused by a
-        // blocked model/window switch must survive until the next send. Keep
-        // the tombstone only for that case; otherwise the fresh Query is ready
-        // and the cancellation rebuild state can be cleared normally.
-        continuationCancellationRequiresQueryRebuild = skipCompactBridge
-          ? shouldRearmAutoCompactAfterRewindControl()
-          : false;
-        return bridgeCompactQueued;
+        try {
+          q = await buildQuery({
+            permissionMode: runtimeSnapshot.sdkPermissionMode,
+            fresh: true,
+          });
+          if (signal?.aborted) {
+            inputQueue.end();
+            rewindTransitionQueries.add(q);
+            try {
+              await Promise.resolve(q.close());
+            } catch (e) {
+              log.warn('cancelled continuation rebuild close threw after send cancellation', {
+                error: String(e),
+              });
+            }
+            throw new Error('Claude send cancelled before acceptance');
+          }
+          startForwardLoop(q);
+          notifySupportedModels(q);
+          await replayRuntimeDrift(runtimeSnapshot, 'cancelled continuation rebuild');
+          // Cancellation rebuilds used by send need the compact→user bridge for deferred
+          // model/window drift. Rewind preview/commit use the same fresh-query isolation but
+          // must not start a product turn or inject /compact before rewindFiles runs.
+          const skipCompactBridge = options?.queueCompactBridge === false;
+          const bridgeCompactQueued = skipCompactBridge
+            ? false
+            : queueAutoCompactBridge('cancellation');
+          // Preview/commit must not generate, but a deferred compact caused by a
+          // blocked model/window switch must survive until the next send. Keep
+          // the tombstone only for that case; otherwise the fresh Query is ready
+          // and the cancellation rebuild state can be cleared normally.
+          continuationCancellationRequiresQueryRebuild = skipCompactBridge
+            ? shouldRearmAutoCompactAfterRewindControl()
+            : false;
+          return bridgeCompactQueued;
+        } finally {
+          acceptingRebuiltSend = false;
+        }
       } finally {
-        acceptingRebuiltSend = false;
+        cancellationRebuildGate = null;
+        releaseCancellationRebuildGate?.();
       }
     }
     const handle: AgentSessionHandle = {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4912,11 +4912,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             log.warn('abort during bridge turn: inputQueue.end threw', { error: String(e) });
           }
           canceledBridgeQueries.add(q);
-          try {
-            q.close();
-          } catch (e) {
-            log.warn('abort during bridge turn: q.close threw', { error: String(e) });
-          }
+          recordCanceledQueryClose(q, 'bridge aborted');
           // close 本地会连 CLI 子进程一起杀(远端为 daemon 侧 interrupt + 输入流收口,
           // SDK 退出前有极窄残留窗口,由下次 q 换代清表兜底),后台任务随之终止,清表即可。
           const cancelledContinuation = cancelActiveContinuation('bridge_aborted');

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3377,10 +3377,12 @@ export class ClaudeCodeAgent extends BaseAgent {
         pendingContinuationTerminalBoundaries = 0;
       }
     };
-    // fire-and-forget 逐个 stopTask:单个失败(任务恰好已自然结束 / 远端 daemon
-    // 版本差)只 warn,绝不阻塞随后的 q.interrupt()。SDK 对每个被停任务会回吐
-    // status:'stopped' 的 task_notification → 现有事件链把任务出表并让 UI 确定性收口。
-    function stopRunningWakeBackgroundTasks(reason: string): string[] {
+    // 逐个发起 stopTask,但不在这里等待 RPC:interrupt 必须先按控制通道顺序发出。
+    // 返回每个 RPC 的 promise,供 interrupt ACK 后只退休真正成功的任务;失败任务
+    // 仍留在本地账中,等待 provider 的真实 completed/stopped 事件继续记账。
+    function stopRunningWakeBackgroundTasks(
+      reason: string,
+    ): Array<{ taskId: string; promise: Promise<void> }> {
       if (runningBackgroundTasks.size === 0) return [];
       const wakeIds: string[] = [];
       for (const [taskId, info] of runningBackgroundTasks) {
@@ -3397,13 +3399,17 @@ export class ClaudeCodeAgent extends BaseAgent {
         return [];
       }
       log.info('stopping running background wake tasks', { reason, wakeIds });
+      const requests: Array<{ taskId: string; promise: Promise<void> }> = [];
       for (const taskId of wakeIds) {
-        void q.stopTask(taskId).then(
+        let stopTaskPromise: Promise<void>;
+        try {
+          stopTaskPromise = Promise.resolve(q.stopTask(taskId));
+        } catch (error) {
+          stopTaskPromise = Promise.reject(error);
+        }
+        const promise = stopTaskPromise.then(
           () => {
-            // abort 的产品收口权威来自 q.interrupt ACK。stopTask 先成功不能提前
-            // cancel claim：若随后 interrupt reject，必须保持 awaiting/busy，等待
-            // provider 的真实 stopped/result；否则会伪造一次用户 Stop 成功。
-            log.debug('background wake task stop acknowledged; awaiting interrupt authority', {
+            log.debug('background wake task stop acknowledged', {
               reason,
               taskId,
             });
@@ -3411,15 +3417,20 @@ export class ClaudeCodeAgent extends BaseAgent {
           (e: unknown) => {
             // 两类预期失败:任务恰好已自然结束;远端老 daemon 不认识 query/stopTask
             // (RemoteQuery 恒有本地方法,老 daemon 差异只会在这里以 RPC 错误暴露)。
-            // 失败时保留任务和 continuation：它仍可能自然完成并自动续 turn。
             log.warn('stopTask failed (task already finished, or remote daemon predates query/stopTask)', {
               taskId,
               error: String(e),
             });
+            throw e;
           },
         );
+        // The rejection handler above preserves the rejected status needed by
+        // Promise.allSettled, while this immediate noop handler prevents an
+        // unhandled-rejection report before interrupt ACK attaches allSettled.
+        void promise.catch(() => undefined);
+        requests.push({ taskId, promise });
       }
-      return wakeIds;
+      return requests;
     }
 
     // ── Middle-turn 事件过滤 (Codex review 3534925347 / 3535259132 / 3535293200) ──
@@ -4861,13 +4872,18 @@ export class ClaudeCodeAgent extends BaseAgent {
         // 用户 Stop 的产品语义 = 本会话所有模型调用停止:先发 stopTask 再 interrupt
         // (同一控制通道按序处理),封掉「interrupt 后任务恰好完成 → task_notification
         // 自动续跑新 turn」的竞态窗口。fire-and-forget,不阻塞 interrupt。
-        const stopRequestedWakeIds = stopRunningWakeBackgroundTasks('user_stop');
+        const stopRequests = stopRunningWakeBackgroundTasks('user_stop');
         try {
           await q.interrupt();
-          // interrupt ACK authorizes retiring every wake task whose stop RPC
-          // was issued. A provider stopped echo is optional; without this
-          // local accounting, the next ordinary done can mint a ghost claim.
-          const stoppedClaim = markWakeTasksStopped(stopRequestedWakeIds, 'user_stop');
+          const settledStops = await Promise.allSettled(stopRequests.map(({ promise }) => promise));
+          const fulfilledWakeIds = stopRequests
+            .filter((_, index) => settledStops[index]?.status === 'fulfilled')
+            .map(({ taskId }) => taskId);
+          // interrupt ACK authorizes retiring only wake tasks whose stop RPC
+          // also succeeded. Rejected stops remain tracked for provider events,
+          // preserving their continuation contract instead of creating an
+          // unaccounted auto-continue.
+          const stoppedClaim = markWakeTasksStopped(fulfilledWakeIds, 'user_stop');
           // Stop is the authoritative cancellation boundary. An awaiting
           // continuation may already have lost every task from the running
           // table, so neither stopTask nor an idle interrupt is guaranteed to

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3660,13 +3660,23 @@ export class ClaudeCodeAgent extends BaseAgent {
             //    而吞掉终态,turn 永远收不了尾。
             //  - queuedBridgeTurns > 0:桥接 /compact 序列里 turnInFlight 本就被
             //    onTurnEnd 保持,不会走进本分支;计数守卫只是防御性一致。
+            // 子 Agent 的 sidechain assistant/stream_event 也会穿过同一 Query，且
+            // 常在它自己的 task_notification 之前到达。它只证明后台任务仍在跑，
+            // 不能证明顶层自动 continuation 已开始；否则会过早把 awaiting claim
+            // 转 active，随后同一任务的 completed 会被误当成“active 段期间完成的
+            // 下一任务”，让第二个顶层 result 再铸造一个永远等不到后续活动的 claim。
+            const rawParentToolUseId = (
+              rawMsg as { parent_tool_use_id?: unknown } | null
+            )?.parent_tool_use_id;
+            const isTopLevelProviderActivity =
+              typeof rawParentToolUseId !== 'string' || rawParentToolUseId.length === 0;
             if (
               !turnInFlight &&
               !turnState.interruptRequested &&
               queuedBridgeTurns === 0 &&
               (
-                rawType === 'assistant' ||
-                rawType === 'stream_event' ||
+                ((rawType === 'assistant' || rawType === 'stream_event') &&
+                  isTopLevelProviderActivity) ||
                 (activeContinuationClaim()?.state === 'awaiting' && rawType === 'result')
               )
             ) {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1972,12 +1972,16 @@ export class ClaudeCodeAgent extends BaseAgent {
      * 的边界事件正常放行、清 turnInFlight。计数 = "已注入但 SDK 还没跑完的桥接 turn 数"。
      */
     let queuedBridgeTurns = 0;
-    // Bridge /compact 只在 rewind rebuild 尾部注入。若用户 Stop 打在该 bridge turn
+    type ActiveBridgeKind = 'rewind' | 'cancellation';
+    let activeBridgeKind: ActiveBridgeKind | null = null;
+    // Bridge /compact 由 rewind 或 cancellation rebuild 尾部注入。若用户 Stop 打在该 bridge turn
     // 上, 已被 SDK eager-drain 的后续真实用户输入无法再从 inputQueue.clear() 追回;
     // 必须 close 当前 Query, 并在下一次 send 用同一个 resume point 重建, 才能从 SDK
     // 侧取消整条 compact → user 序列。
     let activeBridgeRewindResumeAt: string | undefined;
     let bridgeCompactUsageSnapshot: ReturnType<AutoCompactController['getLatestSnapshot']> = null;
+    const bridgeStateActive = (): boolean =>
+      queuedBridgeTurns > 0 || activeBridgeKind !== null || activeBridgeRewindResumeAt !== undefined;
     let q: Query;
     function restoreBridgeAutoCompactSnapshot(reason: string): void {
       const snapshot = bridgeCompactUsageSnapshot;
@@ -2088,7 +2092,9 @@ export class ClaudeCodeAgent extends BaseAgent {
       // 也可能只中断当前 /compact turn,让已 drain 的真实消息继续跑。这里走与
       // abort() 相同的 close-and-rebuild 路径,并保留 rewind resume point 给下一次
       // send 重建。
-      if (queuedBridgeTurns > 0 || activeBridgeRewindResumeAt !== undefined) {
+      if (bridgeStateActive()) {
+        const timedOutBridgeKind = activeBridgeKind;
+        const timedOutRewindResumeAt = activeBridgeRewindResumeAt;
         log.warn('upstream-idle watchdog fired during bridge — closing query and preserving rewind resume point', {
           queuedBridgeTurns,
           queuedInput: inputQueue.pending,
@@ -2128,6 +2134,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         turnInFlight = false;
         turnState.interruptRequested = false;
         pendingToolIds.clear();
+        preserveBridgeRetryTarget(timedOutBridgeKind, timedOutRewindResumeAt);
         emitTurnBoundary('upstream_response_idle_timeout', takeBridgeSuppressedDoneData());
         return;
       }
@@ -2198,6 +2205,34 @@ export class ClaudeCodeAgent extends BaseAgent {
       });
       armUpstreamResponseIdle();
       return true;
+    }
+
+    function queueAutoCompactBridge(kind: ActiveBridgeKind, resumeAt?: string): boolean {
+      const queued = triggerAutoCompactIfNeeded();
+      if (!queued) return false;
+      bridgeCompactUsageSnapshot = autoCompactController?.getLatestSnapshot() ?? null;
+      activeBridgeKind = kind;
+      if (kind === 'rewind') activeBridgeRewindResumeAt = resumeAt;
+      queuedBridgeTurns += 1;
+      log.debug('rebuild: bridge /compact injected', {
+        bridgeKind: kind,
+        queuedBridgeTurns,
+        activeBridgeRewindResumeAt,
+      });
+      return true;
+    }
+
+    function preserveBridgeRetryTarget(
+      kind: ActiveBridgeKind | null,
+      rewindResumeAt: string | undefined,
+    ): void {
+      if (kind === 'rewind' && rewindResumeAt !== undefined) {
+        pendingRewindTo = rewindResumeAt;
+      } else if (kind === 'cancellation') {
+        continuationCancellationRequiresQueryRebuild = true;
+      }
+      activeBridgeKind = null;
+      activeBridgeRewindResumeAt = undefined;
     }
 
     // 当前 session 的 one-shot tip 状态 (turn-start status 用):
@@ -2905,6 +2940,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // handle 死透 → 后续没有排队 turn 可跑, counter 归零避免残留污染下一 handle 重建
       // (虽然 closed=true + inputQueue.end 已经让新消息进不来, 归零是防御性一致)
       queuedBridgeTurns = 0;
+      activeBridgeKind = null;
       activeBridgeRewindResumeAt = undefined;
       pendingToolIds.clear();
       runningBackgroundTasks.clear();
@@ -3605,11 +3641,13 @@ export class ClaudeCodeAgent extends BaseAgent {
             if (canceledBridgeQueries.has(currentQ) || rewindTransitionQueries.has(currentQ)) {
               continue;
             }
-            if (activeBridgeRewindResumeAt !== undefined && queuedBridgeTurns === 0) {
+            if (activeBridgeKind !== null && queuedBridgeTurns === 0) {
               log.debug('bridge follow-up turn started — clearing bridge rewind resume point', {
+                bridgeKind: activeBridgeKind,
                 activeBridgeRewindResumeAt,
               });
               activeBridgeRewindResumeAt = undefined;
+              activeBridgeKind = null;
               bridgeCompactUsageSnapshot = null;
               bridgeSuppressedDoneData = undefined;
             }
@@ -3824,16 +3862,18 @@ export class ClaudeCodeAgent extends BaseAgent {
                 canceledBridge: canceledBridgeQueries.has(currentQ),
               });
               queuedBridgeTurns = 0;
+              activeBridgeKind = null;
             }
             if (isCurrentQuery(currentQ)) {
               pendingToolIds.clear();
             }
-          } else if (activeBridgeRewindResumeAt) {
+          } else if (activeBridgeKind !== null) {
             // Bridge /compact query 自发结束(非 Stop/watchdog 主动 close)说明底层 SDK
             // stream 已死;不能当 rewind transition 静默,否则 queuedBridgeTurns/turnInFlight
             // 会污染下一条真实用户 turn。
             log.warn('event loop ended unexpectedly during bridge turn');
             queuedBridgeTurns = 0;
+            activeBridgeKind = null;
             eventQueue.push({
               type: 'error',
               data: {
@@ -3926,13 +3966,14 @@ export class ClaudeCodeAgent extends BaseAgent {
                 canceledBridge: canceledBridgeQueries.has(currentQ),
               });
               queuedBridgeTurns = 0;
+              activeBridgeKind = null;
             }
             // rewind/bridge cancel 过渡: 老 q 留下的 pending tool_use_id 不能跨到新 q, 否则新 turn
             // 起来 armUpstreamResponseIdle 被旧 id 短路, watchdog 永久失效。
             if (isCurrentQuery(currentQ)) {
               pendingToolIds.clear();
             }
-          } else if (activeBridgeRewindResumeAt) {
+          } else if (activeBridgeKind !== null) {
             flushDeferredResumeFailure();
             log.error('event loop crashed during bridge turn', {
               error: String(e),
@@ -3940,6 +3981,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               queuedBridgeTurns,
             });
             queuedBridgeTurns = 0;
+            activeBridgeKind = null;
             eventQueue.push({
               type: 'error',
               data: { message: String(e), isTerminal: true, reason: 'bridge_sdk_stream_crashed' },
@@ -4258,8 +4300,8 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
       log.warn(`${label}: runtime drift kept changing while replaying; leaving remaining drift to the next setter/rebuild`);
     }
-    async function rebuildCancelledContinuationQuery(signal?: AbortSignal): Promise<void> {
-      if (!continuationCancellationRequiresQueryRebuild) return;
+    async function rebuildCancelledContinuationQuery(signal?: AbortSignal): Promise<boolean> {
+      if (!continuationCancellationRequiresQueryRebuild) return false;
       const staleQuery = q;
       const runtimeSnapshot: QueryRuntimeSnapshot = {
         model: mutableModel,
@@ -4298,7 +4340,13 @@ export class ClaudeCodeAgent extends BaseAgent {
         startForwardLoop(q);
         notifySupportedModels(q);
         await replayRuntimeDrift(runtimeSnapshot, 'cancelled continuation rebuild');
+        // Cancellation rebuilds are fresh queries without a rewind checkpoint, but the
+        // model/window drift that was deferred while the cancelled query was fenced still
+        // needs the same compact→user bridge as rewind.  Register the bridge before the
+        // caller pushes the next user message; do not invent activeBridgeRewindResumeAt.
+        const bridgeCompactQueued = queueAutoCompactBridge('cancellation');
         continuationCancellationRequiresQueryRebuild = false;
+        return bridgeCompactQueued;
       } finally {
         acceptingRebuiltSend = false;
       }
@@ -4332,6 +4380,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           throw new Error('Claude send cancelled before acceptance');
         }
         if (sendOpts) handle.validateSendOptions?.(sendOpts);
+        let bridgeCompactQueued = false;
         // 保持普通 send / rewind send 原有的同步前置语义：即使 async helper 立即
         // return，裸 await 也会让出一个 microtask，导致调用方在 Query rebuild 真正
         // 开始前观察到半初始化窗口。只有确实存在 cancellation tombstone 时才进入
@@ -4341,7 +4390,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           pendingRewindTo === undefined &&
           activeBridgeRewindResumeAt === undefined
         ) {
-          await rebuildCancelledContinuationQuery(sendOpts?.signal);
+          bridgeCompactQueued = await rebuildCancelledContinuationQuery(sendOpts?.signal);
         }
         activeTurnPermissionPolicy = sendOpts?.turnPermissionPolicy ?? null;
         // 仅用于诊断日志: 调用方每次 send 都可以带 logTitle (取自 storage 的最新值);
@@ -4411,19 +4460,20 @@ export class ClaudeCodeAgent extends BaseAgent {
         // ── Rewind 三件套重启 ──────────────────────────────────────────────
         // commitRewindFiles 只设标记, 真正的 SDK Query 重起延迟到这里 —— 老 agentManager
         // 同款设计 (CLI 拿到 input 才会发 init, 避免"无 input → 30s timeout"死锁)。
-        let bridgeCompactQueued = false;
         let runtimeReplaySnapshot: QueryRuntimeSnapshot | undefined;
         const finishSendBeforeUserInput = (reason: string, error?: unknown): void => {
           if (
             bridgeCompactQueued &&
             !canceledBridgeQueries.has(q) &&
-            (queuedBridgeTurns > 0 || activeBridgeRewindResumeAt !== undefined)
+            bridgeStateActive()
           ) {
             log.warn('send failed after bridge /compact injection — canceling bridge query and preserving rewind resume point', {
               error: error === undefined ? undefined : String(error),
               queuedBridgeTurns,
               activeBridgeRewindResumeAt,
             });
+            const abandonedBridgeKind = activeBridgeKind;
+            const abandonedRewindResumeAt = activeBridgeRewindResumeAt;
             queuedBridgeTurns = 0;
             restoreBridgeAutoCompactSnapshot('bridge_send_abandoned');
             autoCompactController?.onCompactCanceled('bridge_send_abandoned');
@@ -4443,8 +4493,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             turnState.interruptRequested = false;
             pendingToolIds.clear();
             acceptingRebuiltSend = false;
-            pendingRewindTo = activeBridgeRewindResumeAt;
-            activeBridgeRewindResumeAt = undefined;
+            preserveBridgeRetryTarget(abandonedBridgeKind, abandonedRewindResumeAt);
             emitTurnBoundary('bridge_send_abandoned', takeBridgeSuppressedDoneData());
             return;
           }
@@ -4533,6 +4582,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             pendingRewindTo = resumeAt;
             activeBridgeRewindResumeAt = undefined;
             queuedBridgeTurns = 0;
+            activeBridgeKind = null;
             acceptingRebuiltSend = false;
             inputQueue.end();
             canceledBridgeQueries.add(q);
@@ -4552,15 +4602,9 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 轮直接撞上下文上限。
           // 桥接 turn 计数: 实际 push /compact 时 +1, 让后续 middle-turn suppress /
           // onTurnEnd 保持 turnInFlight 靠精确计数, 不受 SDK prompt 消费模式影响。
-          bridgeCompactQueued = triggerAutoCompactIfNeeded();
+          bridgeCompactQueued = queueAutoCompactBridge('rewind', resumeAt);
           if (bridgeCompactQueued) {
-            bridgeCompactUsageSnapshot = autoCompactController?.getLatestSnapshot() ?? null;
-            activeBridgeRewindResumeAt = resumeAt;
-            queuedBridgeTurns += 1;
-            log.debug('rebuild: bridge /compact injected', {
-              queuedBridgeTurns,
-              activeBridgeRewindResumeAt,
-            });
+            // queueAutoCompactBridge owns the bridge counter and rewind resume point.
           }
           // 本次 send 的 bridge state 已注册;guard 继续保持到下面 turnInFlight=true,
           // 防止 runtime setter 在 user turn 尚未登记时把 /compact 注入成未标记 turn。
@@ -4666,7 +4710,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           if (
             bridgeCompactQueued &&
             !canceledBridgeQueries.has(q) &&
-            (queuedBridgeTurns > 0 || activeBridgeRewindResumeAt !== undefined)
+            bridgeStateActive()
           ) {
             finishSendBeforeUserInput('bridge_send_abandoned', e);
           } else if (sendOpts?.signal?.aborted) {
@@ -4749,7 +4793,9 @@ export class ClaudeCodeAgent extends BaseAgent {
         // inputQueue.clear() 只能丢 maker-core 本地尚未被拉取的 item;SDK 可能已经 eager-drain
         // 了真实用户消息。此时必须 close 当前 Query 并保留 activeBridgeRewindResumeAt,让下一次
         // send 从同一个 rewind resume point 重建,从 SDK 侧取消已 drain 的后续输入。
-        if (turnInFlight && (queuedBridgeTurns > 0 || activeBridgeRewindResumeAt !== undefined)) {
+        if (turnInFlight && bridgeStateActive()) {
+          const abortedBridgeKind = activeBridgeKind;
+          const abortedRewindResumeAt = activeBridgeRewindResumeAt;
           log.info('abort during bridge turn — closing query and preserving rewind resume point', {
             queuedBridgeTurns,
             queuedInput: inputQueue.pending,
@@ -4778,6 +4824,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           terminalBackgroundTaskIds.clear();
           turnInFlight = false;
           turnState.interruptRequested = false;
+          preserveBridgeRetryTarget(abortedBridgeKind, abortedRewindResumeAt);
           emitTurnBoundary(
             'bridge_aborted',
             takeBridgeSuppressedDoneData(),
@@ -5353,6 +5400,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         // bridge counter 兜底: rewind idle 时应该已经归零, 但如果上一轮 bridge 中途异常
         // (SDK 崩 / abort 未 drain result) counter 可能残留, 会污染 rebuild 后的第一 turn。
         queuedBridgeTurns = 0;
+        activeBridgeKind = null;
         log.info('commitRewindFiles ◀ pendingRewindTo set, awaiting next send to rebuild');
         return undefined;
       },

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2116,9 +2116,10 @@ export class ClaudeCodeAgent extends BaseAgent {
           },
           source: 'claude-code',
         });
-        queuedBridgeTurns = 0;
         restoreBridgeAutoCompactSnapshot('upstream_response_idle_timeout');
         autoCompactController?.onCompactCanceled('upstream_response_idle_timeout');
+        const suppressedDoneData = takeBridgeSuppressedDoneData();
+        clearBridgeState();
         inputQueue.clear();
         try {
           inputQueue.end();
@@ -2135,7 +2136,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         turnState.interruptRequested = false;
         pendingToolIds.clear();
         preserveBridgeRetryTarget(timedOutBridgeKind, timedOutRewindResumeAt);
-        emitTurnBoundary('upstream_response_idle_timeout', takeBridgeSuppressedDoneData());
+        emitTurnBoundary('upstream_response_idle_timeout', suppressedDoneData);
         return;
       }
       eventQueue.push({
@@ -2231,8 +2232,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       } else if (kind === 'cancellation') {
         continuationCancellationRequiresQueryRebuild = true;
       }
-      activeBridgeKind = null;
-      activeBridgeRewindResumeAt = undefined;
+      // Caller may preserve a retry target before clearing this state.
     }
 
     // 当前 session 的 one-shot tip 状态 (turn-start status 用):
@@ -2939,9 +2939,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       turnInFlight = false;
       // handle 死透 → 后续没有排队 turn 可跑, counter 归零避免残留污染下一 handle 重建
       // (虽然 closed=true + inputQueue.end 已经让新消息进不来, 归零是防御性一致)
-      queuedBridgeTurns = 0;
-      activeBridgeKind = null;
-      activeBridgeRewindResumeAt = undefined;
+      clearBridgeState();
       pendingToolIds.clear();
       runningBackgroundTasks.clear();
       terminalBackgroundTaskIds.clear();
@@ -2968,6 +2966,13 @@ export class ClaudeCodeAgent extends BaseAgent {
     }
 
     let bridgeSuppressedDoneData: Record<string, unknown> | undefined;
+    function clearBridgeState(): void {
+      queuedBridgeTurns = 0;
+      activeBridgeKind = null;
+      activeBridgeRewindResumeAt = undefined;
+      bridgeCompactUsageSnapshot = null;
+      bridgeSuppressedDoneData = undefined;
+    }
     function takeBridgeSuppressedDoneData(): Record<string, unknown> | undefined {
       const data = bridgeSuppressedDoneData;
       bridgeSuppressedDoneData = undefined;
@@ -3646,10 +3651,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                 bridgeKind: activeBridgeKind,
                 activeBridgeRewindResumeAt,
               });
-              activeBridgeRewindResumeAt = undefined;
-              activeBridgeKind = null;
-              bridgeCompactUsageSnapshot = null;
-              bridgeSuppressedDoneData = undefined;
+              clearBridgeState();
             }
             const rawType = (rawMsg as { type?: string } | null)?.type;
             if (
@@ -3788,9 +3790,18 @@ export class ClaudeCodeAgent extends BaseAgent {
                     // 与 upstream-idle watchdog 同款兜底: tool-loop 中断 = "整个 turn 序列已死",
                     // bridge counter 归零避免 filter 吞掉本条 error / counter 永久停在 >0。
                     // 实践上 bridge /compact turn 不用 tool, 该分支难以触发, 归零是防御性一致。
-                    if (queuedBridgeTurns > 0) {
-                      log.warn('tool-loop hard interrupt fired during bridge — clearing bridge counter', { queuedBridgeTurns });
-                      queuedBridgeTurns = 0;
+                    if (bridgeStateActive()) {
+                      const interruptedBridgeKind = activeBridgeKind;
+                      const interruptedRewindResumeAt = activeBridgeRewindResumeAt;
+                      log.warn('tool-loop hard interrupt fired during bridge — clearing bridge state', {
+                        queuedBridgeTurns,
+                        activeBridgeKind,
+                        activeBridgeRewindResumeAt,
+                      });
+                      restoreBridgeAutoCompactSnapshot('tool_loop_hard_interrupt');
+                      autoCompactController?.onCompactCanceled('tool_loop_hard_interrupt');
+                      clearBridgeState();
+                      preserveBridgeRetryTarget(interruptedBridgeKind, interruptedRewindResumeAt);
                     }
                     eventQueue.push({
                       type: 'error',
@@ -3861,8 +3872,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                 rewindTransition: rewindTransitionQueries.has(currentQ),
                 canceledBridge: canceledBridgeQueries.has(currentQ),
               });
-              queuedBridgeTurns = 0;
-              activeBridgeKind = null;
+              clearBridgeState();
             }
             if (isCurrentQuery(currentQ)) {
               pendingToolIds.clear();
@@ -3872,8 +3882,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             // stream 已死;不能当 rewind transition 静默,否则 queuedBridgeTurns/turnInFlight
             // 会污染下一条真实用户 turn。
             log.warn('event loop ended unexpectedly during bridge turn');
-            queuedBridgeTurns = 0;
-            activeBridgeKind = null;
+            clearBridgeState();
             eventQueue.push({
               type: 'error',
               data: {
@@ -3965,8 +3974,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                 rewindTransition: rewindTransitionQueries.has(currentQ),
                 canceledBridge: canceledBridgeQueries.has(currentQ),
               });
-              queuedBridgeTurns = 0;
-              activeBridgeKind = null;
+              clearBridgeState();
             }
             // rewind/bridge cancel 过渡: 老 q 留下的 pending tool_use_id 不能跨到新 q, 否则新 turn
             // 起来 armUpstreamResponseIdle 被旧 id 短路, watchdog 永久失效。
@@ -3980,8 +3988,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               activeBridgeRewindResumeAt,
               queuedBridgeTurns,
             });
-            queuedBridgeTurns = 0;
-            activeBridgeKind = null;
+            clearBridgeState();
             eventQueue.push({
               type: 'error',
               data: { message: String(e), isTerminal: true, reason: 'bridge_sdk_stream_crashed' },
@@ -4102,6 +4109,12 @@ export class ClaudeCodeAgent extends BaseAgent {
       );
       clearUpstreamResponseIdle();
       pendingToolIds.clear();
+      // A fresh invalid-resume recovery must not inherit a half-consumed
+      // compact bridge from the dead query. There is no rewind target to
+      // preserve here: the replacement query intentionally starts fresh.
+      restoreBridgeAutoCompactSnapshot('invalid_resume_recovery');
+      autoCompactController?.onCompactCanceled('invalid_resume_recovery');
+      clearBridgeState();
       try { inputQueue.end(); } catch (error) {
         log.debug('invalid resume recovery: old input queue end failed', { error: String(error) });
       }
@@ -4474,9 +4487,10 @@ export class ClaudeCodeAgent extends BaseAgent {
             });
             const abandonedBridgeKind = activeBridgeKind;
             const abandonedRewindResumeAt = activeBridgeRewindResumeAt;
-            queuedBridgeTurns = 0;
             restoreBridgeAutoCompactSnapshot('bridge_send_abandoned');
             autoCompactController?.onCompactCanceled('bridge_send_abandoned');
+            const suppressedDoneData = takeBridgeSuppressedDoneData();
+            clearBridgeState();
             inputQueue.clear();
             try {
               inputQueue.end();
@@ -4494,7 +4508,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             pendingToolIds.clear();
             acceptingRebuiltSend = false;
             preserveBridgeRetryTarget(abandonedBridgeKind, abandonedRewindResumeAt);
-            emitTurnBoundary('bridge_send_abandoned', takeBridgeSuppressedDoneData());
+            emitTurnBoundary('bridge_send_abandoned', suppressedDoneData);
             return;
           }
           if (!turnInFlight) return;
@@ -4570,7 +4584,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           //    后续消息推进已死旧 q 的黑洞。
           // 新 forward loop 是 async 任务, 在本同步段之后才起跑, 不会误读到 true。
           pendingRewindTo = undefined;
-          activeBridgeRewindResumeAt = undefined;
+          clearBridgeState();
           runtimeReplaySnapshot = {
             model: snapModel,
             effort: snapEffort,
@@ -4580,9 +4594,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           await replayRuntimeDrift(runtimeReplaySnapshot, 'rewind rebuild');
           if (sendOpts?.signal?.aborted) {
             pendingRewindTo = resumeAt;
-            activeBridgeRewindResumeAt = undefined;
-            queuedBridgeTurns = 0;
-            activeBridgeKind = null;
+            clearBridgeState();
             acceptingRebuiltSend = false;
             inputQueue.end();
             canceledBridgeQueries.add(q);
@@ -4603,9 +4615,6 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 桥接 turn 计数: 实际 push /compact 时 +1, 让后续 middle-turn suppress /
           // onTurnEnd 保持 turnInFlight 靠精确计数, 不受 SDK prompt 消费模式影响。
           bridgeCompactQueued = queueAutoCompactBridge('rewind', resumeAt);
-          if (bridgeCompactQueued) {
-            // queueAutoCompactBridge owns the bridge counter and rewind resume point.
-          }
           // 本次 send 的 bridge state 已注册;guard 继续保持到下面 turnInFlight=true,
           // 防止 runtime setter 在 user turn 尚未登记时把 /compact 注入成未标记 turn。
         }
@@ -4801,9 +4810,10 @@ export class ClaudeCodeAgent extends BaseAgent {
             queuedInput: inputQueue.pending,
             activeBridgeRewindResumeAt,
           });
-          queuedBridgeTurns = 0;
           restoreBridgeAutoCompactSnapshot('bridge_aborted');
           autoCompactController?.onCompactCanceled('bridge_aborted');
+          const suppressedDoneData = takeBridgeSuppressedDoneData();
+          clearBridgeState();
           inputQueue.clear();
           try {
             inputQueue.end();
@@ -4827,7 +4837,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           preserveBridgeRetryTarget(abortedBridgeKind, abortedRewindResumeAt);
           emitTurnBoundary(
             'bridge_aborted',
-            takeBridgeSuppressedDoneData(),
+            suppressedDoneData,
             cancelledContinuation !== null,
           );
           return;
@@ -4929,6 +4939,10 @@ export class ClaudeCodeAgent extends BaseAgent {
         // Closing/dead sessions settle through Session status (or their queued
         // terminal event), never through the successful task-stop path.
         discardActiveContinuation('session_closed');
+        clearUpstreamResponseIdle();
+        pendingToolIds.clear();
+        turnInFlight = false;
+        clearBridgeState();
         closed = true;
         try {
           // 任何挂着的 interaction 强制 deny + emit dismissed, 防止 host 卡住等永远不会来的回应
@@ -4960,6 +4974,10 @@ export class ClaudeCodeAgent extends BaseAgent {
             async detach() {
               if (closed) return;
               discardActiveContinuation('session_detached', true);
+              clearUpstreamResponseIdle();
+              pendingToolIds.clear();
+              turnInFlight = false;
+              clearBridgeState();
               closed = true;
               try {
                 dismissAllPending('session_closed', 'deny');
@@ -5399,8 +5417,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         turnInFlight = false;
         // bridge counter 兜底: rewind idle 时应该已经归零, 但如果上一轮 bridge 中途异常
         // (SDK 崩 / abort 未 drain result) counter 可能残留, 会污染 rebuild 后的第一 turn。
-        queuedBridgeTurns = 0;
-        activeBridgeKind = null;
+        clearBridgeState();
         log.info('commitRewindFiles ◀ pendingRewindTo set, awaiting next send to rebuild');
         return undefined;
       },

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -4939,6 +4939,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // interrupt ACK guarantees these earlier stop requests have settled,
           // so allSettled intentionally has no timeout or extra watchdog.
           const settledStops = await Promise.allSettled(stopRequests.map(({ promise }) => promise));
+          const hasRejectedStops = settledStops.some((stop) => stop.status === 'rejected');
           const fulfilledWakeIds = stopRequests
             .filter((_, index) => settledStops[index]?.status === 'fulfilled')
             .map(({ taskId }) => taskId);
@@ -4950,15 +4951,18 @@ export class ClaudeCodeAgent extends BaseAgent {
           // Stop is the authoritative cancellation boundary. An awaiting
           // continuation may already have lost every task from the running
           // table, so neither stopTask nor an idle interrupt is guaranteed to
-          // produce another provider result. Close it explicitly after the
-          // control action succeeds and append the ordered product terminal.
+          // produce another provider result. A rejected stop is likewise
+          // unconfirmed even when a completed notification already removed
+          // that task from the local table; the old Query must still be closed
+          // to prevent a queued automatic continuation from escaping Stop.
           const cancelledContinuation = stoppedClaim ?? cancelActiveContinuation('user_stop');
           const hasUnconfirmedWakeTasks = [...runningBackgroundTasks.values()].some((info) => info.wake);
-          if (cancelledContinuation || hasUnconfirmedWakeTasks) {
-            // Both cancellation sources share one terminal state: a cancelled
-            // continuation claim or an unconfirmed wake task means this Query
-            // must be retired. The provider tail is fenced by the per-query
-            // marker, then the next send/rewind installs a fresh Query.
+          if (cancelledContinuation || hasUnconfirmedWakeTasks || hasRejectedStops) {
+            // All cancellation sources share one terminal state: a cancelled
+            // continuation claim, an unconfirmed wake task, or a rejected stop
+            // means this Query must be retired. The provider tail is fenced by
+            // the per-query marker, then the next send/rewind installs a fresh
+            // Query.
             const cancelledQuery = q;
             const foregroundNeedsTerminal = turnInFlight;
             canceledBridgeQueries.add(cancelledQuery);

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3028,6 +3028,25 @@ export class ClaudeCodeAgent extends BaseAgent {
     }
 
     const canceledBridgeQueries = new WeakSet<Query>();
+    // RemoteQuery.close() is asynchronous. User Stop records the in-flight
+    // close promise here so an immediate send/rewind can wait for the remote
+    // session to become dead before creating its replacement Query.
+    const canceledQueryClosePromises = new WeakMap<Query, Promise<void>>();
+    function recordCanceledQueryClose(query: Query, reason: string): void {
+      let closePromise: Promise<void>;
+      try {
+        closePromise = Promise.resolve(query.close());
+      } catch (error) {
+        log.warn(`${reason}: q.close threw`, { error: String(error) });
+        closePromise = Promise.reject(error);
+      }
+      canceledQueryClosePromises.set(query, closePromise);
+      // Attach a handler immediately so a remote close rejection cannot
+      // become unhandled before rebuild awaits the recorded promise.
+      void closePromise.catch((error) => {
+        log.warn(`${reason}: q.close rejected`, { error: String(error) });
+      });
+    }
     // Despite the historical name, this per-query fence also marks an old
     // Query closed after user Stop cancels an awaiting continuation. Its
     // forward loop must silently discard any buffered tail until the next
@@ -4368,7 +4387,14 @@ export class ClaudeCodeAgent extends BaseAgent {
       abortController = new AbortController();
       runtimeState.lastResultUsageAggregate = null;
       rewindTransitionQueries.add(staleQuery);
-      if (!canceledBridgeQueries.has(staleQuery)) {
+      const recordedClose = canceledQueryClosePromises.get(staleQuery);
+      if (recordedClose) {
+        try {
+          await recordedClose;
+        } catch (error) {
+          log.warn('cancelled continuation query close rejected before rebuild', { error: String(error) });
+        }
+      } else {
         try {
           await Promise.resolve(staleQuery.close());
         } catch (e) {
@@ -4963,11 +4989,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             } catch (e) {
               log.warn('user_stop cancellation: inputQueue.end threw', { error: String(e) });
             }
-            try {
-              cancelledQuery.close();
-            } catch (e) {
-              log.warn('user_stop cancellation: q.close threw', { error: String(e) });
-            }
+            recordCanceledQueryClose(cancelledQuery, 'user_stop cancellation');
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
             turnInFlight = false;

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -2946,7 +2946,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       reason: string,
       doneData?: Record<string, unknown>,
       trackContinuationTerminal = false,
-    ): void {
+    ): boolean {
       eventQueue.push({
         type: 'status',
         data: { status: 'Done', ...usageTracker.snapshot(), isRunning: false },
@@ -2971,6 +2971,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           );
         }
       }
+      return accepted;
     }
 
     const canceledBridgeQueries = new WeakSet<Query>();
@@ -3020,9 +3021,10 @@ export class ClaudeCodeAgent extends BaseAgent {
     let nextContinuationId = 1;
     let activeContinuationId: number | null = null;
     // User Stop can close an awaiting product continuation while the provider
-    // still has buffered activity. Suppress that cancelled tail until the next
-    // explicit user input is accepted (or the Query is replaced).
+    // still has buffered activity. Suppress that cancelled tail until its
+    // Query is replaced before the next explicit user turn.
     let continuationCancellationGeneration: number | null = null;
+    let continuationCancellationRequiresQueryRebuild = false;
     const continuationClaims = new Map<number, ContinuationClaim>();
     const continuationListeners = new Set<(
       continuationId: number,
@@ -3048,6 +3050,12 @@ export class ClaudeCodeAgent extends BaseAgent {
       if (!claim.settled || claim.pendingBoundaryEvents > 0) return;
       continuationClaims.delete(claim.id);
     };
+    const retireContinuationTasks = (claim: ContinuationClaim): void => {
+      for (const taskId of claim.tasks.keys()) {
+        runningBackgroundTasks.delete(taskId);
+        terminalBackgroundTaskIds.add(taskId);
+      }
+    };
     const cancelActiveContinuation = (reason: string): ContinuationClaim | null => {
       const claim = activeContinuationClaim();
       if (!claim || claim.state !== 'awaiting') return null;
@@ -3070,7 +3078,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       });
       releaseSettledContinuationClaim(claim);
     };
-    const discardActiveContinuation = (reason: string): void => {
+    const discardActiveContinuation = (reason: string, forceRelease = false): void => {
       if (continuationClaims.size > 0) {
         log.debug('discarding turn continuation claims', {
           reason,
@@ -3082,16 +3090,33 @@ export class ClaudeCodeAgent extends BaseAgent {
         claim.settled = true;
         releaseSettledContinuationClaim(claim);
       }
+      if (forceRelease) continuationClaims.clear();
     };
-    const consumeTaskNotificationForActiveSegment = (claim: ContinuationClaim): void => {
-      const consumed = [...claim.tasks].find(
-        ([, state]) => state === 'completed' || state === 'failed',
-      );
-      if (consumed) claim.tasks.delete(consumed[0]);
+    const consumeTaskNotificationsForActiveSegment = (claim: ContinuationClaim): void => {
+      // The SDK may merge several task notifications that arrived before the
+      // first continuation activity into one automatic segment. Consume that
+      // whole terminal snapshot at activation; notifications arriving after
+      // the claim becomes active remain for the following segment.
+      for (const [taskId, state] of claim.tasks) {
+        if (state === 'completed' || state === 'failed') claim.tasks.delete(taskId);
+      }
     };
     const captureContinuationBoundary = (event: AgentEvent): boolean => {
       if (event.type !== 'done') return false;
       const existing = activeContinuationClaim();
+      const interruptedGeneration =
+        turnState.interruptRequested &&
+        turnState.interruptGeneration === turnState.generation;
+      if (interruptedGeneration && existing?.state === 'awaiting') {
+        // A real provider terminal can beat the interrupt ACK. It is the
+        // product terminal for this Stop, so retire the snapshotted awaiting
+        // claim instead of attaching it (or minting a successor) to this done.
+        retireContinuationTasks(existing);
+        existing.settled = true;
+        activeContinuationId = null;
+        releaseSettledContinuationClaim(existing);
+        return true;
+      }
       if (existing?.state === 'awaiting') {
         // Defensive duplicate done for the same boundary: preserve the same
         // claim instead of letting the duplicate terminate host observers.
@@ -3121,10 +3146,10 @@ export class ClaudeCodeAgent extends BaseAgent {
       // terminal boundary. Even if a wake task remains in the provider table,
       // user Stop has revoked the right to create another automatic segment.
       if (
-        (turnState.interruptRequested &&
-          turnState.interruptGeneration === turnState.generation) ||
+        interruptedGeneration ||
         continuationCancellationGeneration === turnState.generation
       ) {
+        if (interruptedGeneration && existing) retireContinuationTasks(existing);
         return wasActiveContinuation;
       }
       const wakeTasks = [...runningBackgroundTasks.entries()].filter(([, info]) => info.wake);
@@ -3251,10 +3276,17 @@ export class ClaudeCodeAgent extends BaseAgent {
         reason,
         continuationId: claim.id,
       });
-      emitTurnBoundary('turn_continuation_cancelled', undefined, true);
+      if (emitTurnBoundary('turn_continuation_cancelled', undefined, true)) {
+        // Install the cancelled-tail fence at the same enqueue boundary as
+        // the synthetic product terminal. stopTask can win before interrupt
+        // resolves, so waiting for the interrupt ACK leaves a double-terminal
+        // window for a late provider result.
+        continuationCancellationGeneration = turnState.generation;
+        continuationCancellationRequiresQueryRebuild = true;
+      }
     };
 
-    const acknowledgeConsumedEvent = (event: AgentEvent): void => {
+    const releaseEventAccounting = (event: AgentEvent): void => {
       if (event.turnContinuationId !== undefined) {
         const claim = continuationClaims.get(event.turnContinuationId);
         if (claim) {
@@ -3269,6 +3301,11 @@ export class ClaudeCodeAgent extends BaseAgent {
         );
       }
     };
+    const pushForwardedEvent = (event: AgentEvent): boolean => {
+      const accepted = eventQueue.push(event);
+      if (!accepted) releaseEventAccounting(event);
+      return accepted;
+    };
 
     const consumedEventStream = async function* (): AsyncGenerator<AgentEvent> {
       try {
@@ -3278,7 +3315,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           } finally {
             // Code after yield runs when Session asks for the next event, i.e.
             // after its synchronous fan-out (including Hook/Scheduler queries).
-            acknowledgeConsumedEvent(event);
+            releaseEventAccounting(event);
           }
         }
       } finally {
@@ -3311,11 +3348,13 @@ export class ClaudeCodeAgent extends BaseAgent {
       for (const taskId of wakeIds) {
         void q.stopTask(taskId).then(
           () => {
-            // RPC 成功才有资格把 provider claim 判成 stopped。若 foreground
-            // `done` 已先入队，host 会暂时等在该 claim 上，并在这里收到确定的
-            // cancellation；不能在 RPC 尚可能失败时先猜任务已经停下。
-            const cancelledClaim = markWakeTasksStopped([taskId], reason);
-            if (cancelledClaim) emitCancelledContinuationBoundary(cancelledClaim, reason);
+            // abort 的产品收口权威来自 q.interrupt ACK。stopTask 先成功不能提前
+            // cancel claim：若随后 interrupt reject，必须保持 awaiting/busy，等待
+            // provider 的真实 stopped/result；否则会伪造一次用户 Stop 成功。
+            log.debug('background wake task stop acknowledged; awaiting interrupt authority', {
+              reason,
+              taskId,
+            });
           },
           (e: unknown) => {
             // 两类预期失败:任务恰好已自然结束;远端老 daemon 不认识 query/stopTask
@@ -3385,7 +3424,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       deferResumeFailureBoundary = false;
     }
     let pendingTerminalStatusEvent: AgentEvent | undefined;
-    const forwardEventSink: Pick<AsyncQueue<AgentEvent>, 'push'> = {
+    const forwardEventSink: AsyncQueue<AgentEvent> = {
       // Claude's translator emits `status(isRunning=false)` immediately before
       // the matching `done`. Hold that status long enough to copy the
       // provider continuation claim from `done`; otherwise every generic
@@ -3432,17 +3471,26 @@ export class ClaudeCodeAgent extends BaseAgent {
           const data = e.data as { isRunning?: unknown } | null | undefined;
           if (data?.isRunning === false) {
             if (pendingTerminalStatusEvent) {
-              eventQueue.push(pendingTerminalStatusEvent);
+              pushForwardedEvent(pendingTerminalStatusEvent);
             }
             pendingTerminalStatusEvent = e;
             return true;
           }
         }
         if (e.type !== 'done' && pendingTerminalStatusEvent) {
-          eventQueue.push(pendingTerminalStatusEvent);
+          pushForwardedEvent(pendingTerminalStatusEvent);
           pendingTerminalStatusEvent = undefined;
         }
+        const continuationBeforeCapture = activeContinuationClaim();
         const isContinuationTerminalDone = captureContinuationBoundary(e);
+        const continuationAfterCapture = activeContinuationClaim();
+        const createdContinuationClaim =
+          e.type === 'done' &&
+          e.turnContinuationId !== undefined &&
+          continuationAfterCapture?.id === e.turnContinuationId &&
+          continuationBeforeCapture?.id !== continuationAfterCapture.id
+            ? continuationAfterCapture
+            : null;
         if (e.type === 'done' && pendingTerminalStatusEvent) {
           const statusEvent = pendingTerminalStatusEvent;
           pendingTerminalStatusEvent = undefined;
@@ -3451,21 +3499,23 @@ export class ClaudeCodeAgent extends BaseAgent {
             const claim = continuationClaims.get(e.turnContinuationId);
             if (claim) claim.pendingBoundaryEvents += 1;
           }
-          eventQueue.push(statusEvent);
+          pushForwardedEvent(statusEvent);
         }
         if (isContinuationTerminalDone) {
           continuationTerminalBoundaryEvents.add(e);
           pendingContinuationTerminalBoundaries += 1;
         }
-        const accepted = eventQueue.push(e);
-        if (isContinuationTerminalDone) {
-          if (!accepted) {
-            continuationTerminalBoundaryEvents.delete(e);
-            pendingContinuationTerminalBoundaries = Math.max(
-              0,
-              pendingContinuationTerminalBoundaries - 1,
-            );
+        const accepted = pushForwardedEvent(e);
+        if (!accepted && createdContinuationClaim) {
+          // A claim minted for a boundary that the host can never observe has
+          // no continuation contract. Retire it after rolling back the done's
+          // own ledger entry; an accepted paired status keeps the claim object
+          // alive only until that status is acknowledged.
+          createdContinuationClaim.settled = true;
+          if (activeContinuationId === createdContinuationClaim.id) {
+            activeContinuationId = null;
           }
+          releaseSettledContinuationClaim(createdContinuationClaim);
         }
         // A stopped notification is part of the visible turn history. Preserve
         // its order, then append a real product-turn boundary so Session can
@@ -3476,6 +3526,19 @@ export class ClaudeCodeAgent extends BaseAgent {
         }
         return accepted;
       },
+      end: () => {
+        if (pendingTerminalStatusEvent) {
+          eventQueue.push(pendingTerminalStatusEvent);
+          pendingTerminalStatusEvent = undefined;
+        }
+        eventQueue.end();
+      },
+      clear: () => {
+        pendingTerminalStatusEvent = undefined;
+        eventQueue.clear();
+      },
+      get pending() { return eventQueue.pending; },
+      [Symbol.asyncIterator]: () => eventQueue[Symbol.asyncIterator](),
     };
 
     // ── 事件 forward loop（SDK 原始事件 → maker-core AgentEvent） ─────────────
@@ -3519,6 +3582,10 @@ export class ClaudeCodeAgent extends BaseAgent {
       // 残留的 interruptRequested 会错误抑制新 q 首个真实 is_error 终态 —— 兜底清。
       turnState.interruptRequested = false;
       continuationCancellationGeneration = null;
+      // Any successfully installed replacement Query isolates the cancelled
+      // provider tail. This also covers rewind / invalid-resume rebuilds, so a
+      // later send must not create a redundant intermediate Query.
+      continuationCancellationRequiresQueryRebuild = false;
       discardActiveContinuation('query_replaced');
       // q 换代 = 旧 CLI 子进程已死,其后台任务全部随之终止 —— 清表防 stale 条目
       // 让下次 abort 对不存在的任务空发 stopTask。
@@ -3544,7 +3611,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               continuationCancellationGeneration !== null &&
               (rawType === 'assistant' || rawType === 'stream_event' || rawType === 'result')
             ) {
-              log.debug('ignoring provider activity after user-cancelled continuation', {
+              log.debug('ignoring provider activity from cancelled continuation query', {
                 rawType,
                 cancellationGeneration: continuationCancellationGeneration,
               });
@@ -3601,7 +3668,7 @@ export class ClaudeCodeAgent extends BaseAgent {
                 // Each task notification queues one SDK continuation segment.
                 // Consume only the notification that activated this segment;
                 // other terminal tasks must keep the next boundary claimed.
-                consumeTaskNotificationForActiveSegment(claim);
+                consumeTaskNotificationsForActiveSegment(claim);
                 claim.state = 'active';
                 emitContinuationState(claim.id, 'active');
               }
@@ -4099,7 +4166,11 @@ export class ClaudeCodeAgent extends BaseAgent {
     // 窗口里用户切模型/权限档只会改闭包,不会影响当前和后续 turn。只有当前 q 已被
     // 主动 close 并登记到 canceledBridgeQueries 时才阻塞 control request。
     const controlRequestsBlocked = (): boolean =>
-      pendingRewindTo !== undefined || acceptingRebuiltSend || idleResumeRebuildGate !== null || canceledBridgeQueries.has(q);
+      pendingRewindTo !== undefined ||
+      acceptingRebuiltSend ||
+      idleResumeRebuildGate !== null ||
+      continuationCancellationRequiresQueryRebuild ||
+      canceledBridgeQueries.has(q);
     type QueryRuntimeSnapshot = {
       model: string;
       effort: Effort;
@@ -4170,6 +4241,51 @@ export class ClaudeCodeAgent extends BaseAgent {
       }
       log.warn(`${label}: runtime drift kept changing while replaying; leaving remaining drift to the next setter/rebuild`);
     }
+    async function rebuildCancelledContinuationQuery(signal?: AbortSignal): Promise<void> {
+      if (!continuationCancellationRequiresQueryRebuild) return;
+      const staleQuery = q;
+      const runtimeSnapshot: QueryRuntimeSnapshot = {
+        model: mutableModel,
+        effort: mutableEffort,
+        fastMode: mutableFastMode,
+        sdkPermissionMode: currentTurnSdkPermissionMode(),
+      };
+      acceptingRebuiltSend = true;
+      inputQueue.end();
+      inputQueue = createAsyncQueue<SdkUserInput>();
+      abortController = new AbortController();
+      runtimeState.lastResultUsageAggregate = null;
+      rewindTransitionQueries.add(staleQuery);
+      try {
+        await Promise.resolve(staleQuery.close());
+      } catch (e) {
+        log.warn('cancelled continuation query close threw before rebuild', { error: String(e) });
+      }
+      try {
+        q = await buildQuery({
+          permissionMode: runtimeSnapshot.sdkPermissionMode,
+          fresh: true,
+        });
+        if (signal?.aborted) {
+          inputQueue.end();
+          rewindTransitionQueries.add(q);
+          try {
+            await Promise.resolve(q.close());
+          } catch (e) {
+            log.warn('cancelled continuation rebuild close threw after send cancellation', {
+              error: String(e),
+            });
+          }
+          throw new Error('Claude send cancelled before acceptance');
+        }
+        startForwardLoop(q);
+        notifySupportedModels(q);
+        await replayRuntimeDrift(runtimeSnapshot, 'cancelled continuation rebuild');
+        continuationCancellationRequiresQueryRebuild = false;
+      } finally {
+        acceptingRebuiltSend = false;
+      }
+    }
     const handle: AgentSessionHandle = {
       get id() { return sdkSessionId ?? '<pending>'; },
       agentKind: 'claude-code',
@@ -4199,6 +4315,17 @@ export class ClaudeCodeAgent extends BaseAgent {
           throw new Error('Claude send cancelled before acceptance');
         }
         if (sendOpts) handle.validateSendOptions?.(sendOpts);
+        // 保持普通 send / rewind send 原有的同步前置语义：即使 async helper 立即
+        // return，裸 await 也会让出一个 microtask，导致调用方在 Query rebuild 真正
+        // 开始前观察到半初始化窗口。只有确实存在 cancellation tombstone 时才进入
+        // 异步重建。
+        if (
+          continuationCancellationRequiresQueryRebuild &&
+          pendingRewindTo === undefined &&
+          activeBridgeRewindResumeAt === undefined
+        ) {
+          await rebuildCancelledContinuationQuery(sendOpts?.signal);
+        }
         activeTurnPermissionPolicy = sendOpts?.turnPermissionPolicy ?? null;
         // 仅用于诊断日志: 调用方每次 send 都可以带 logTitle (取自 storage 的最新值);
         // 缺省时保留上一次的值 (没传不等于"清空")。
@@ -4510,7 +4637,6 @@ export class ClaudeCodeAgent extends BaseAgent {
             throw new Error('Claude input queue is closed');
           }
           userInputAccepted = true;
-          continuationCancellationGeneration = null;
           activeCapabilitySelectionText = userMessageTextForCapabilityRouting(message.content);
           setAutoReviewIntent(message.content);
           replayableUserInput = sdkInput;
@@ -4645,19 +4771,14 @@ export class ClaudeCodeAgent extends BaseAgent {
         // 用户主动停止: SDK 被 interrupt 后会 drain 出 error_during_execution 的
         // is_error result, 打标记让 translator turn-end 跳过"失败兜底 error",
         // 否则用户点停止会被误报成"执行失败"通知。
-        // turnInFlight 守卫(与 watchdog / tool-loop 对齐): turn 已自然结束时的
-        // 迟到 Stop 不置位 —— idle query 上的 interrupt 不保证产出 result 来消费
-        // 标记, 残留会泄漏到下一真实 turn 吞掉其失败兜底(review P2)。
-        if (turnInFlight) {
+        // 前台仍在跑或 provider continuation 正在 awaiting 时都要锁定本代 Stop。
+        // 后者的 turnInFlight 已经是 false，但 interrupt ACK 前的迟到 result 同样
+        // 不得重新铸造 continuation claim。
+        const awaitingContinuationAtUserStop = activeContinuationClaim();
+        if (turnInFlight || awaitingContinuationAtUserStop?.state === 'awaiting') {
           turnState.interruptRequested = true;
           turnState.interruptGeneration = turnState.generation;
         }
-        const awaitingContinuationAtUserStop = activeContinuationClaim();
-        const awaitingContinuationIdAtUserStop =
-          awaitingContinuationAtUserStop?.state === 'awaiting'
-            ? awaitingContinuationAtUserStop.id
-            : null;
-        const continuationGenerationAtUserStop = turnState.generation;
         // 用户 Stop 的产品语义 = 本会话所有模型调用停止:先发 stopTask 再 interrupt
         // (同一控制通道按序处理),封掉「interrupt 后任务恰好完成 → task_notification
         // 自动续跑新 turn」的竞态窗口。fire-and-forget,不阻塞 interrupt。
@@ -4670,25 +4791,6 @@ export class ClaudeCodeAgent extends BaseAgent {
           // produce another provider result. Close it explicitly after the
           // control action succeeds and append the ordered product terminal.
           const cancelledContinuation = cancelActiveContinuation('user_stop');
-          if (awaitingContinuationIdAtUserStop !== null) {
-            const continuationAfterInterrupt = activeContinuationClaim();
-            if (
-              continuationAfterInterrupt?.id === awaitingContinuationIdAtUserStop &&
-              continuationAfterInterrupt.state === 'active'
-            ) {
-              // Provider activity may have activated the snapshotted claim
-              // while interrupt was in flight. Let its interrupted result run
-              // the normal turn teardown, but forbid that result from minting
-              // another continuation claim.
-              turnState.interruptRequested = true;
-              turnState.interruptGeneration = turnState.generation;
-            } else if (continuationAfterInterrupt?.id !== awaitingContinuationIdAtUserStop) {
-              // stopTask may have won the race and cancelled the same claim
-              // before interrupt resolved. The successful interrupt still
-              // authorizes the same cancelled-tail tombstone.
-              continuationCancellationGeneration = continuationGenerationAtUserStop;
-            }
-          }
           if (cancelledContinuation) {
             // The successful Stop revokes these tasks' continuation contract.
             // Retire their tracking entries as well, so a late provider
@@ -4696,10 +4798,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             // cancelled. This is product-side cancellation bookkeeping; the
             // best-effort stopTask RPCs above remain responsible for stopping
             // the provider tasks themselves.
-            for (const taskId of cancelledContinuation.tasks.keys()) {
-              runningBackgroundTasks.delete(taskId);
-              terminalBackgroundTaskIds.add(taskId);
-            }
+            retireContinuationTasks(cancelledContinuation);
             emitCancelledContinuationBoundary(cancelledContinuation, 'user_stop');
           }
         } catch (e) {
@@ -4796,7 +4895,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         ? {
             async detach() {
               if (closed) return;
-              discardActiveContinuation('session_detached');
+              discardActiveContinuation('session_detached', true);
               closed = true;
               try {
                 dismissAllPending('session_closed', 'deny');

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -21,6 +21,7 @@ import {
   extractNonSecretErrorSignals,
   redactSensitiveText,
 } from '@cindy/maker-shared/error-redaction';
+import type { createAsyncQueue } from '../shared/async-queue.js';
 import { stripTerminalControlSequences } from '../shared/terminal-output.js';
 import { formatOverloadRetryMessage, parseOverloadError } from '../shared/overload-error.js';
 import {
@@ -406,7 +407,7 @@ function formatCacheBucket(b: {
 const TURN_END_LOGGER_KEY = 'SDK ◀ turn end (result)';
 void TURN_END_LOGGER_KEY; // 只是给调用方对照参考
 
-type EventQueue = { push(event: AgentEvent): boolean };
+type EventQueue = ReturnType<typeof createAsyncQueue<AgentEvent>>;
 interface TranslatorLog {
   debug(msg: string, ctx?: Record<string, unknown>): void;
   info(msg: string, ctx?: Record<string, unknown>): void;

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -21,7 +21,6 @@ import {
   extractNonSecretErrorSignals,
   redactSensitiveText,
 } from '@cindy/maker-shared/error-redaction';
-import type { createAsyncQueue } from '../shared/async-queue.js';
 import { stripTerminalControlSequences } from '../shared/terminal-output.js';
 import { formatOverloadRetryMessage, parseOverloadError } from '../shared/overload-error.js';
 import {
@@ -407,7 +406,7 @@ function formatCacheBucket(b: {
 const TURN_END_LOGGER_KEY = 'SDK ◀ turn end (result)';
 void TURN_END_LOGGER_KEY; // 只是给调用方对照参考
 
-type EventQueue = ReturnType<typeof createAsyncQueue<AgentEvent>>;
+type EventQueue = { push(event: AgentEvent): boolean };
 interface TranslatorLog {
   debug(msg: string, ctx?: Record<string, unknown>): void;
   info(msg: string, ctx?: Record<string, unknown>): void;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Claude Code 启动后台 Agent 后可能卡死的问题：后台 Agent 完成后，会话仍永久停在“正在生成”，后续消息只能排队。普通会话和 Orca 协同会话都可能触发，但协同模式更容易暴露：Lead 更常通过后台 Agent / workflow 并行工作，后台完成通知和自动续跑出现得更频繁；Lead 一旦因 continuation claim 泄漏而永久 busy，Worker 的 `send_to_lead` 或 auto-bridge 回信以及用户后续消息都会继续排队，把单个会话的收尾故障放大为“协同整体卡住”。Worker 通信本身不是 claim 的直接来源，因此本 PR 修复的是 Claude Code continuation 状态机，而不是 Orca 消息桥。

#1703 引入 continuation claim 后，把“后台任务 `completed` / `failed` 后一定还会出现下一段 SDK continuation”当成了恒真条件。真实 SDK 事件里还会混入带 `parent_tool_use_id` 的子 Agent sidechain assistant/stream event；旧逻辑把这些事件误当成顶层 continuation 已启动，最终可能在顶层回复已经完成后再创建一个永远无法收口的 awaiting claim。

本 PR 补齐 Stop、任务终态、迟到 provider 事件和 Query 换代的收口逻辑，并只允许顶层 provider activity 激活父 continuation。与具体模型无关：#1915 的 Claude Code 会话使用 deepseek-v4-flash，也触发了相同的 handle 状态泄漏。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1941, Closes #1932, Closes #1915；关联 #1703、#1743
- 本 PR 包含：
  - 成功 Stop 后确定性消解 awaiting continuation，并处理 `stopTask` / `interrupt` / 任务终态的竞态；
  - 用 Query 重建隔离 Stop 后旧代迟到事件，防止终结新一代；
  - 防止终态任务被迟到 running/progress 事件复活；
  - 合并顶层 continuation 开始前相邻到达的任务终态；
  - 只允许顶层 assistant/stream event 激活父 continuation，忽略子 Agent sidechain activity；
  - 覆盖 event queue 拒绝、remote detach、rewind、result-only continuation 等边界的双账本收口；
  - review 修复一：user Stop 取消 awaiting continuation 后立即关闭旧 Query（mark → boundary → close），切断僵尸续跑；
  - review 修复二：interrupt ACK 成功后退休 stopTask 确认成功的 wake 任务，不依赖 provider 的 stopped 回显，防止残留任务卡把下一个普通 done 铸成幽灵 claim；stopTask 被拒的任务保留在账，继续走 provider 事件记账，不脱账续跑；
  - review 修复三/四（最终形态）：user Stop 收敛为两态——无 wake 任务或全部 stopTask 确认成功走轻路径（仅 interrupt，Query 保活）；有 cancelled claim 或仍有未确认停止的 wake 任务（stopTask 被拒 / 老 daemon 不支持）统一走 close-and-rebuild：恰好一次 synthetic terminal + 关闭 Query（终结后台工具与模型调用）+ 下一条 send/rewind 换 fresh Query；
  - review 修复五：Stop 关闭 Query 后直接点 Rewind 预览/执行不再触碰已关闭 Query——preview/commit 先重建隔离的 fresh Query（不注入 /compact、不触发生成）再调 rewindFiles；若模型/窗口漂移已越 compact 阈值，保留重建标记让下一次 send 仍先补 /compact；
  - review 修复六：Stop 关闭 Query 时记录异步 close promise，随后的 send/rewind 重建先 await 它——SSH 远端场景不再撞 SESSION_ALREADY_EXISTS；
  - review 修复七：stopTask 被拒时强制走 close-and-rebuild——即使 completed 通知抢在 interrupt ACK 前把任务从本地表移除，被拒的 stop 仍表示停止未确认，SDK 侧已排队的自动续跑只有关闭 Query 才能终结；
  - review 修复八：cancellation Query 重建加重入门控（复用 idleResumeRebuildGate 同款 promise gate 习惯）——Stop 后 send / Rewind 预览 / Rewind 执行并发触发重建时合流为一次，杜绝并发 buildQuery 泄漏第二个 Query 与双 forward loop；
  - review 修复九：bridge Stop 分支同样记录 close promise（补齐修复六的另一入口）——cancellation compact bridge 期间 Stop 后立即重发，重建会先等待远端老 session 真正关闭，SSH 远端不再撞 SESSION_ALREADY_EXISTS；
  - review 修复十：同系列闭集收尾——watchdog 超时关桥与 bridge send 失败弃桥两个入口同样记录 close promise；至此所有会装 cancellation 重建标志的路径（user_stop / bridge Stop / watchdog / abandoned send）的 close 全部被下一次重建 await，闭集经独立 review 交叉枚举确认；
  - 新增 ClaudeCodeAgent → Session 的受控流回归和真实 SDK sidechain 顺序测试。
- 明确不包含：恢复后暂停队列只能靠用户输入解锁的老问题；busyReasons/超时自愈；Desktop manual Stop 的 Orca bridge 放大链路；#1743 的重复消息渲染问题。
- 用户可见变化：后台 Agent 自然完成或被停止后，会话会正常结束“正在生成”；随后消息可正常开始执行。
- 是否存在 breaking change：无。

### UI 变化

不涉及：未修改 UI 组件、视觉、文案或交互定义；仅修复底层 turn/continuation 状态收口。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run \
  src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts \
  src/agents/claude-code/__tests__/auto-continued-turn-in-flight.test.ts \
  src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts \
  src/agents/claude-code/__tests__/invalid-resume-recovery.test.ts
结果：5 files，129 tests 全部通过（71 + 2 + 36 + 3 + 17）。

pnpm test:unit
结果：runner 375 项中 374 pass / 1 skip；全部 unit workspace 通过，含 Desktop、Mobile、maker-core 和 cindy-protocol。

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：退出码 0；该 package 当前没有独立 typecheck script，按仓库规则跳过。

pnpm check:dco
结果：19 个提交全部 Signed-off-by，通过。

git diff --check origin/main..HEAD
结果：通过。
```

补充：`pnpm --filter @cindy/maker-core exec tsc --noEmit` 仍会报主线已有的 4 个测试文件类型错误（`codex/index.test.ts`、`pi-auto-review-dispatch.test.ts`、`plan-mode.test.ts`、`jsonl-tool-id-normalize.test.ts`）；本 PR 修改的两个文件没有新增错误。

### 手工验证

macOS，国内区，共享 userData，Playground project，使用 agent-browser 做了同类场景的修复前后对照：

**复现手法**：在新 Claude Code 会话中，要求顶层使用 `run_in_background` 启动一个后台 `local_agent`；后台 Agent 内部实际调用 Bash 执行无副作用的 `printf`；顶层先结束父段，等待 task notification `completed` 后自动续跑并输出 `E2E_TOP_DONE`；随后观察 UI 是否回到 idle，并发送 `E2E_SENTINEL_OK` 验证下一条消息能否真实执行。

**修复前（RED，HEAD `e8ba1b710`）**：

1. `pnpm restart:desktop:remote --region=cn` 启动，`desktop:whoami --all` 和 bundle 特征确认运行的是该 worktree/commit，不是已安装 App。
2. 后台 Agent 自然完成，顶层第二个 SDK result 已 `completed`，`E2E_TOP_DONE` 已显示；超过 60 秒仍显示“正在生成”和停止按钮。
3. 随后手动 Stop 的日志明确取消 `continuationId: 2`，证明第二个 result 后又遗留了 awaiting claim；Stop 后 sentinel 才能正常执行。

**修复后（GREEN，最新 HEAD `2481d0bc6`）：**

1. 使用相同启动方式、区域、共享 userData、Playground、后台 Agent + Bash sidechain + 自然 completed 流程复测；bundle、进程 cwd 和 commit 均确认匹配。
2. task `completed` 后顶层自动 continuation 输出 `E2E_TOP_DONE_2481`，约 60 秒内 UI 恢复 idle，停止按钮消失；正常路径未点击 Stop。
3. 直接发送 sentinel；日志确认 `queued → started → completed`，收到 `E2E_SENTINEL_2481_OK` 后再次 idle。
4. 最新 session 时间窗内未出现 `continuationId:2`、`stalledGeneration`、`turn continuation cancelled`、`activeBeforeNormalize` 或 `No active Claude turn to steer`。
5. 证据：
   - session 日志：`apps/desktop/logs/sessions/bcd3303a-ae01-471e-8e86-ef75cd6b7c13/2026-08-07.ndjson`
   - SDK JSONL：`/Users/fmfsaisai/.claude/projects/-Users-fmfsaisai-Documents-Playground/d1f3c555-bbea-410a-9130-ddeacaa49e6e.jsonl`
   - 截图：`/private/tmp/pr2039-e2e-2481d0bc/screenshots/1941-top-done-idle.png`、`/private/tmp/pr2039-e2e-2481d0bc/screenshots/1941-sentinel-complete-idle.png`
6. 临时 compaction 设置已恢复默认，dev app 已关闭；复查确认无活动 dev instance、9222 无监听、agent-browser 已关闭。

**Cancellation + auto-compact 复测：**

- 两条 controlled lifecycle 测试均通过：`synthetic cancellation rebuilds with compact...`、`Stop during a cancellation compact bridge...`。
- 未能在真实 Desktop 完成 1M→500K + Stop + `/compact` 全链路：复用的旧 Orca Playground 会话均已 source disconnected/offline，消息没有进入真实生成流程。因此这部分不能标为真实 Desktop PASS；这是测试环境阻断，不是代码失败。

### 未执行的验证

- 未跑 `pnpm test:all`。
- 未完成真实 Desktop 的 cancellation + 1M→500K + Stop + `/compact` 全链路，原因见上；controlled lifecycle 已通过。
- 数轮 review 修复（立即 close 旧 Query、Stop ACK 退休 wake 任务、未确认任务 close-and-rebuild、Rewind 重建守卫）以 unit 回归为主：相关竞态窗口为毫秒级或需要「daemon 拒绝 stop」等无法在真实环境确定性构造的条件。真实 Desktop e2e 已在 `525c61014` 上跑过一轮：#1941 主场景 PASS；前台 turn + 后台 Agent 运行中 Stop 的 UI 收口 / 任务卡移除 / 下一条正常执行均 PASS；awaiting continuation 窗口 Stop 因窗口仅数秒未能构造，语义由 unit 回归锁定。**全部 review 收口后将在最终 HEAD 上重跑完整 e2e 回归**（#1941 主场景、运行中 Stop、awaiting Stop、Stop 后直接 Rewind 预览/执行），结果补充在 PR 评论。
- 独立缺口（非本 PR 引入、不在本 PR 修）：`commitRewindFiles` 中 rewindFiles(dryRun:false) 失败后的注释声称「forkSession on next send will retry」，经核实下一次 send 只做会话上下文分叉、不会重试文件回滚——文件回滚失败时缺乏兜底，将另行跟进。
- 未覆盖“恢复后暂停队列”的独立老问题，按范围另案处理。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Claude Code turn/continuation 状态机与 Stop 竞态

### 影响与回滚

- 影响范围：Claude Code 会话中的后台 wake 任务、自动 continuation、用户 Stop、Query rebuild、rewind/detach 收口。Codex、PI、Desktop schema、协议和插件系统不受影响。
- 回滚 / 降级方式：可整体回滚本 PR 的 19 个提交；但会恢复 #1941/#1932/#1915 的永久 busy 回归。实现没有 migration、持久数据格式或协议变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不涉及长期文档变更；回归测试内说明状态机不变量）
- [x] 已确认测试结果或说明未执行原因






