### PR TITLE
fix(desktop): turn 收尾兜底 + rehydrate 不取消输入 + queue-head recovery 解锁

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -390,6 +390,31 @@ describe('maker:event hot path ordering', () => {
     );
   });
 
+  it('skips coordinator onSessionClosed inside the rehydrate suppression window (#1930)', () => {
+    const wireSessionSource = extractWireSessionSource();
+    const closedBlock = wireSessionSource.slice(wireSessionSource.indexOf("if (status === 'closed') {"));
+
+    // rehydrate / 凭证切换 close-rebuild 期间同一逻辑会话进程内重建:必须跳过
+    // coordinator.onSessionClosed,否则 abortInputBoundary 取消驱动本次重建的
+    // input signal → cancelled-before-dispatch(#1930)。去掉守卫即回归事故。
+    expect(closedBlock).toContain(
+      'if (!rehydrateCloseSuppression.isSuppressed(session.id)) {',
+    );
+    expect(closedBlock).toContain(
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id);',
+    );
+    expectOrder(
+      closedBlock,
+      'if (!rehydrateCloseSuppression.isSuppressed(session.id)) {',
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id);',
+    );
+    expectOrder(
+      closedBlock,
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id);',
+      'gitSnapshotCoordinator?.onSessionClosed(session.id);',
+    );
+  });
+
   it('clears Agent Island after mandatory closed-session cleanup', () => {
     const wireSessionSource = extractWireSessionSource();
     const closedBlock = wireSessionSource.slice(wireSessionSource.indexOf("if (status === 'closed') {"));

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -385,32 +385,28 @@ describe('maker:event hot path ordering', () => {
     expect(closedBlock).toContain('gitSnapshotCoordinator?.onSessionClosed(session.id);');
     expectOrder(
       closedBlock,
-      'agentInputCoordinatorHolder?.onSessionClosed(session.id);',
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id, {',
       'gitSnapshotCoordinator?.onSessionClosed(session.id);',
     );
   });
 
-  it('skips coordinator onSessionClosed inside the rehydrate suppression window (#1930)', () => {
+  it('preserves coordinator input boundary inside the rehydrate suppression window (#1930)', () => {
     const wireSessionSource = extractWireSessionSource();
     const closedBlock = wireSessionSource.slice(wireSessionSource.indexOf("if (status === 'closed') {"));
 
-    // rehydrate / 凭证切换 close-rebuild 期间同一逻辑会话进程内重建:必须跳过
-    // coordinator.onSessionClosed,否则 abortInputBoundary 取消驱动本次重建的
-    // input signal → cancelled-before-dispatch(#1930)。去掉守卫即回归事故。
+    // rehydrate / 凭证切换 close-rebuild 期间同一逻辑会话进程内重建:窗口内
+    // onSessionClosed 传 preserveInputBoundary(true)保留 input boundary(不 abort
+    // 驱动本次重建的 signal → #1930),但**其余清理必须照常执行**(不能整体跳过
+    // onSessionClosed,否则 rebuild 失败/close 后不 rebuild 时 coordinator 残留)。
     expect(closedBlock).toContain(
-      'if (!rehydrateCloseSuppression.isSuppressed(session.id)) {',
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id, {',
     );
     expect(closedBlock).toContain(
-      'agentInputCoordinatorHolder?.onSessionClosed(session.id);',
+      'preserveInputBoundary: rehydrateCloseSuppression.isSuppressed(session.id),',
     );
     expectOrder(
       closedBlock,
-      'if (!rehydrateCloseSuppression.isSuppressed(session.id)) {',
-      'agentInputCoordinatorHolder?.onSessionClosed(session.id);',
-    );
-    expectOrder(
-      closedBlock,
-      'agentInputCoordinatorHolder?.onSessionClosed(session.id);',
+      'agentInputCoordinatorHolder?.onSessionClosed(session.id, {',
       'gitSnapshotCoordinator?.onSessionClosed(session.id);',
     );
   });

--- a/apps/desktop/src/main/maker-host/__tests__/withRehydrateCloseSuppressed.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/withRehydrateCloseSuppressed.test.ts
@@ -86,6 +86,27 @@ describe('withRehydrateCloseSuppressed', () => {
     expect(sideEffect).toHaveBeenCalledTimes(1);
   });
 
+  it('isSuppressed reflects the suppression window (register closed-cleanup guard contract)', async () => {
+    const suppression = createRehydrateCloseSuppression(makeLog());
+    const sideEffect = vi.fn(async () => undefined);
+
+    // 窗口外:未抑制 → register 的 onSessionClosed 会照常执行。
+    expect(suppression.isSuppressed('session-1')).toBe(false);
+    await suppression.runOnCloseSideEffects('session-1', sideEffect);
+    expect(sideEffect).toHaveBeenCalledTimes(1);
+
+    // 窗口内:抑制 → register 跳过 coordinator.onSessionClosed(#1930 修复点)。
+    await suppression.withSuppressed('session-1', async () => {
+      expect(suppression.isSuppressed('session-1')).toBe(true);
+      await suppression.runOnCloseSideEffects('session-1', sideEffect);
+    });
+
+    // 窗口结束:恢复放行。
+    expect(suppression.isSuppressed('session-1')).toBe(false);
+    await suppression.runOnCloseSideEffects('session-1', sideEffect);
+    expect(sideEffect).toHaveBeenCalledTimes(2);
+  });
+
   it('releases suppression after timeout', async () => {
     vi.useFakeTimers();
     const log = makeLog();

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -918,6 +918,62 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(projection.recovery).toBeNull();
   });
 
+  it('reconciles a stale busy boundary after repeated SESSION_RUNNING retries (done lost)', async () => {
+    vi.useFakeTimers();
+    const h = createHarness();
+    const sid = 'session-running-reconcile-after-threshold';
+    const first = makeItem('q-1', 'first');
+
+    h.sendToAgent.mockImplementation(async () => {
+      h.setRunning(true);
+      throw sessionRunningError();
+    });
+
+    h.coordinator.enqueue(sid, first);
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+    // 默认 250ms 档,SESSION_RUNNING_RECONCILE_THRESHOLD=20 次 ≈ 5 秒。
+    // 推进 15 轮(远低于阈值)不触发 reconcile;继续推进到超过阈值后必须触发
+    // (fail-closed:false 不放行)。不绑定精确轮次——count 会因 enqueue 首轮
+    // drain / 隐式重试略有偏移,只验证「阈值内不触发、超阈值触发」的行为契约。
+    let reconcileCalls = 0;
+    h.reconcileTurnIdle.mockImplementation(() => {
+      reconcileCalls += 1;
+      return false; // live session 仍 busy,不校准
+    });
+    for (let i = 0; i < 15; i += 1) {
+      await vi.advanceTimersByTimeAsync(300);
+      await flush();
+    }
+    expect(reconcileCalls).toBe(0);
+    for (let i = 0; i < 10; i += 1) {
+      await vi.advanceTimersByTimeAsync(300);
+      await flush();
+    }
+    expect(reconcileCalls).toBeGreaterThanOrEqual(1);
+
+    // reconcile 返回 false 时不放行:消息仍排队、不重复派发。
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-1']);
+
+    // 之后 live session idle(reconcile 生效)→ drain 放行、消息派发。
+    // 换 mock 后 count 已清零,需再推进一轮阈值让 reconcile 生效并放行 drain。
+    h.reconcileTurnIdle.mockImplementation(() => {
+      h.setRunning(false);
+      return true;
+    });
+    h.sendToAgent.mockResolvedValueOnce(sendSuccess());
+    for (let i = 0; i < 25; i += 1) {
+      await vi.advanceTimersByTimeAsync(300);
+      await flush();
+    }
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    // 第二次派发的是队首原消息 first(而非别的)。
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'first' });
+    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
+  });
+
   it('keeps retrying a restored queue head when a late done arrives before SESSION_RUNNING clears', async () => {
     vi.useFakeTimers();
     const h = createHarness();
@@ -2698,6 +2754,41 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.onUiRetry).not.toHaveBeenCalled();
   });
 
+  it('ui continue with a queue-head recovery resends the failed head, skips onUiRetry, and drops the synthetic continue', async () => {
+    const h = createHarness();
+    const sid = 'ui-continue-queue-head';
+    h.sendToAgent.mockResolvedValueOnce(hostSendFailure('SEND_FAILED', 'boom'));
+
+    h.coordinator.enqueue(sid, makeItem('q-head', 'never dispatched'));
+    await flush();
+    expect(latestProjection(h.projections).recovery).toEqual({
+      kind: 'queue-head',
+      clientId: 'q-head',
+    });
+
+    // UI「继续」按钮(sendUiTrigger → enqueue CONTINUE_AFTER_ERROR_PROMPT):
+    // 等价 retryLastError 重发队首 A,合成 continue 项不入队/不派发;
+    // queue-head 从未成为 turn,与 retryLastError 同口径**不**发 onUiRetry。
+    h.sendToAgent.mockResolvedValueOnce(sendSuccess());
+    // text 是 CONTINUE_AFTER_ERROR_PROMPT → enqueue 入口 captureOriginalSyntheticTrigger
+    // 自动识别为 'continue'(isUiContinuationItem 判定),无需也不能显式赋值。
+    const continueItem = makeItem('q-continue', CONTINUE_AFTER_ERROR_PROMPT);
+    h.coordinator.enqueue(sid, continueItem);
+    await flush();
+
+    const projection = latestProjection(h.projections);
+    expect(projection.recovery).toBeNull();
+    expect(projection.pendingQueue.map((q) => q.clientId)).toEqual([]);
+    // 第二次派发的是队首 A(never dispatched),不是 continue 项。
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+      type: 'user',
+      content: 'never dispatched',
+    });
+    // queue-head 从不发 onUiRetry(与 retryLastError 语义一致)。
+    expect(h.onUiRetry).not.toHaveBeenCalled();
+  });
+
   it('queue-head retry never substitutes the continue prompt and redrains the original head', async () => {
     const h = createHarness();
     const sid = 'retry-continue-queue-head';
@@ -2756,9 +2847,9 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.sendToAgent).toHaveBeenCalledTimes(2);
   });
 
-  it('enqueue keeps a queue-head recovery blocked (no silent resend of the failed head)', async () => {
+  it('explicit user input abandons a queue-head recovery and dispatches the new message', async () => {
     const h = createHarness();
-    const sid = 'enqueue-preserves-queue-head-recovery';
+    const sid = 'enqueue-unlocks-queue-head-recovery';
     h.sendToAgent.mockResolvedValueOnce(hostSendFailure('SEND_FAILED', 'boom'));
 
     h.coordinator.enqueue(sid, makeItem('q-head', 'never dispatched'));
@@ -2768,15 +2859,56 @@ describe('AgentInputCoordinator send transaction', () => {
       clientId: 'q-head',
     });
 
-    // queue-head recovery 语义不变:失败消息还躺在队首,新消息只排队,
-    // 不触发对失败队首的静默重发。
+    // 用户显式新输入 = 表态「不重试旧消息」(2026-07-13 口径,与 active-turn 对齐):
+    // 放弃从未 accepted 的队首 A(摘除 + onDiscardedQueuedMessage 可见化),B 正常派发。
+    const discarded: string[] = [];
+    h.onDiscardedQueuedMessage.mockImplementation((_sid, item) => {
+      discarded.push(item.clientId);
+    });
+    h.sendToAgent.mockResolvedValueOnce(sendSuccess());
     h.coordinator.enqueue(sid, makeItem('q-second', 'later message'));
     await flush();
 
     const projection = latestProjection(h.projections);
+    expect(projection.recovery).toBeNull();
+    expect(projection.pendingQueue.map((q) => q.clientId)).toEqual([]);
+    expect(discarded).toEqual(['q-head']);
+    // 新消息 B 派发(而非静默重发 A):sendToAgent 第二次收到的是 B 的正文。
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({
+      type: 'user',
+      content: 'later message',
+    });
+  });
+
+  it.each([
+    { kind: 'scheduler', scheduleId: 's1', scheduleName: 's1' } as const,
+    { kind: 'orca', senderLabel: 'worker-1' } as const,
+  ])('automatic input ($kind) does not unlock a queue-head recovery', async (origin) => {
+    const h = createHarness();
+    const sid = `automatic-preserves-queue-head-recovery-${origin.kind}`;
+    h.sendToAgent.mockResolvedValueOnce(hostSendFailure('SEND_FAILED', 'boom'));
+
+    h.coordinator.enqueue(sid, makeItem('q-head', 'never dispatched'));
+    await flush();
+    expect(latestProjection(h.projections).recovery).toEqual({
+      kind: 'queue-head',
+      clientId: 'q-head',
+    });
+
+    // 自动来源(scheduler / orca)不代表用户表态,维持「不清」语义。
+    const autoItem = makeItem(`q-${origin.kind}`, `${origin.kind} prompt`);
+    autoItem.origin = origin as never;
+    h.coordinator.enqueue(sid, autoItem);
+    await flush();
+
+    const projection = latestProjection(h.projections);
     expect(projection.recovery).toEqual({ kind: 'queue-head', clientId: 'q-head' });
+    expect(projection.pendingQueue.map((q) => q.clientId)).toEqual([
+      'q-head',
+      `q-${origin.kind}`,
+    ]);
     expect(h.sendToAgent).toHaveBeenCalledTimes(1);
-    expect(projection.pendingQueue.map((q) => q.clientId)).toEqual(['q-head', 'q-second']);
   });
 
   it('does not clear a queue-head recovery when compact is requested', async () => {
@@ -3118,9 +3250,9 @@ describe('AgentInputCoordinator send transaction', () => {
     );
   });
 
-  it('does not auto-retry a failed queue head from later enqueue or Cancel', async () => {
+  it('abandons a failed queue head on explicit user enqueue and dispatches the new message', async () => {
     const h = createHarness();
-    const sid = 'send-rollback-blocks-auto-drain';
+    const sid = 'send-rollback-user-input-unlocks';
     const first = makeItem('q-1', 'first');
     const second = makeItem('q-2', 'second');
 
@@ -3130,14 +3262,20 @@ describe('AgentInputCoordinator send transaction', () => {
     await flush();
 
     h.coordinator.clearError(sid);
+    h.sendToAgent.mockResolvedValueOnce(sendSuccess());
     h.coordinator.enqueue(sid, second);
     await flush();
 
     const projection = latestProjection(h.projections);
-    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+    // 用户显式新输入 = 表态「不重试旧消息」:放弃 q-1,派发 q-2。
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
     expect(projection.error).toBeNull();
-    expect(projection.recovery).toEqual({ kind: 'queue-head', clientId: 'q-1' });
-    expect(projection.pendingQueue.map((q) => q.text)).toEqual(['first', 'second']);
+    expect(projection.recovery).toBeNull();
+    expect(projection.pendingQueue.map((q) => q.text)).toEqual([]);
+    expect(h.onDiscardedQueuedMessage).toHaveBeenCalledWith(
+      sid,
+      expect.objectContaining({ clientId: 'q-1' }),
+    );
   });
 
   it('ignores late done wakeups after a pre-accept rollback', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -3011,6 +3011,60 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'next' });
   });
 
+  it('preserveInputBoundary keeps the input signal alive but still clears active state (#1930)', async () => {
+    const h = createHarness();
+    const sid = 'session-close-preserve-input-boundary';
+    const sendStarted = deferred<void>();
+    const sendGate = deferred<AgentInputSendResult>();
+    let capturedSignal: AbortSignal | undefined;
+    h.sendToAgent.mockImplementationOnce(async (_sid, _msg, _createOpts, sendOpts) => {
+      capturedSignal = sendOpts?.signal;
+      sendStarted.resolve();
+      return sendGate.promise;
+    });
+
+    // 发送进行中(activeTurn 非空,持有 input boundary signal)。
+    const sendPromise = h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+    await sendStarted.promise;
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
+
+    // rehydrate 窗口内 close:preserveInputBoundary=true → signal 不被 abort。
+    h.coordinator.onSessionClosed(sid, { preserveInputBoundary: true });
+    await flush();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    // 但其余清理照常:activeTurn 已清,新消息可排队。
+    h.sendToAgent.mockResolvedValueOnce(sendSuccess());
+    h.coordinator.enqueue(sid, makeItem('q-2', 'second'));
+    sendGate.resolve(sendSuccess());
+    await sendPromise;
+    await flush();
+    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
+  });
+
+  it('aborts the input boundary on plain session close (no preserve flag)', async () => {
+    const h = createHarness();
+    const sid = 'session-close-aborts-input-boundary';
+    const sendStarted = deferred<void>();
+    let capturedSignal: AbortSignal | undefined;
+    h.sendToAgent.mockImplementationOnce(async (_sid, _msg, _createOpts, sendOpts) => {
+      capturedSignal = sendOpts?.signal;
+      sendStarted.resolve();
+      return new Promise<AgentInputSendResult>(() => undefined); // 永不 resolve
+    });
+
+    h.coordinator.enqueue(sid, makeItem('q-1', 'first'));
+    await sendStarted.promise;
+    await flush();
+    expect(capturedSignal?.aborted).toBe(false);
+
+    // 普通 close(无 preserve)→ abort input boundary。
+    h.coordinator.onSessionClosed(sid);
+    await flush();
+    expect(capturedSignal?.aborted).toBe(true);
+  });
+
   it('releases compact active turn when close races before dispatch outcome', async () => {
     const h = createHarness();
     const sid = 'compact-close-before-dispatch-outcome';

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -918,62 +918,6 @@ describe('AgentInputCoordinator send transaction', () => {
     expect(projection.recovery).toBeNull();
   });
 
-  it('reconciles a stale busy boundary after repeated SESSION_RUNNING retries (done lost)', async () => {
-    vi.useFakeTimers();
-    const h = createHarness();
-    const sid = 'session-running-reconcile-after-threshold';
-    const first = makeItem('q-1', 'first');
-
-    h.sendToAgent.mockImplementation(async () => {
-      h.setRunning(true);
-      throw sessionRunningError();
-    });
-
-    h.coordinator.enqueue(sid, first);
-    await flush();
-    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
-
-    // 默认 250ms 档,SESSION_RUNNING_RECONCILE_THRESHOLD=20 次 ≈ 5 秒。
-    // 推进 15 轮(远低于阈值)不触发 reconcile;继续推进到超过阈值后必须触发
-    // (fail-closed:false 不放行)。不绑定精确轮次——count 会因 enqueue 首轮
-    // drain / 隐式重试略有偏移,只验证「阈值内不触发、超阈值触发」的行为契约。
-    let reconcileCalls = 0;
-    h.reconcileTurnIdle.mockImplementation(() => {
-      reconcileCalls += 1;
-      return false; // live session 仍 busy,不校准
-    });
-    for (let i = 0; i < 15; i += 1) {
-      await vi.advanceTimersByTimeAsync(300);
-      await flush();
-    }
-    expect(reconcileCalls).toBe(0);
-    for (let i = 0; i < 10; i += 1) {
-      await vi.advanceTimersByTimeAsync(300);
-      await flush();
-    }
-    expect(reconcileCalls).toBeGreaterThanOrEqual(1);
-
-    // reconcile 返回 false 时不放行:消息仍排队、不重复派发。
-    expect(h.sendToAgent).toHaveBeenCalledTimes(1);
-    expect(latestProjection(h.projections).pendingQueue.map((q) => q.clientId)).toEqual(['q-1']);
-
-    // 之后 live session idle(reconcile 生效)→ drain 放行、消息派发。
-    // 换 mock 后 count 已清零,需再推进一轮阈值让 reconcile 生效并放行 drain。
-    h.reconcileTurnIdle.mockImplementation(() => {
-      h.setRunning(false);
-      return true;
-    });
-    h.sendToAgent.mockResolvedValueOnce(sendSuccess());
-    for (let i = 0; i < 25; i += 1) {
-      await vi.advanceTimersByTimeAsync(300);
-      await flush();
-    }
-    expect(h.sendToAgent).toHaveBeenCalledTimes(2);
-    // 第二次派发的是队首原消息 first(而非别的)。
-    expect(h.sendToAgent.mock.calls[1]?.[1]).toEqual({ type: 'user', content: 'first' });
-    expect(latestProjection(h.projections).pendingQueue).toEqual([]);
-  });
-
   it('keeps retrying a restored queue head when a late done arrives before SESSION_RUNNING clears', async () => {
     vi.useFakeTimers();
     const h = createHarness();

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -3663,6 +3663,10 @@ export class AgentInputCoordinator {
               retries: AgentInputCoordinator.SESSION_RUNNING_RECONCILE_THRESHOLD,
               reason,
             });
+            // reconcile 已确认 live session idle → 立刻 drain,不再等下一轮 retry
+            // delay(自动续跑 10s 档下避免额外 10s 等待)。
+            this.scheduleDrain(sessionId, `session-running-reconciled:${reason}`);
+            return;
           }
         }
         this.scheduleSessionRunningRetry(sessionId, reason);

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -573,8 +573,6 @@ interface SessionInputState {
   abortReconcileRetryTimer: ReturnType<typeof setTimeout> | null;
   sessionRunningRetryTimer: ReturnType<typeof setTimeout> | null;
   sessionRunningRetryGeneration: number | null;
-  /** SESSION_RUNNING 重试连续命中的次数;超阈值触发 reconcileTurnIdle 校准。 */
-  sessionRunningRetryCount: number;
   /** 当前 retry timer 绑定的队首/compact owner；队首变化时必须替换 timer policy。 */
   sessionRunningRetryOwnerKey: string | null;
   sessionRunningRetryDelayMs: number | null;
@@ -638,7 +636,6 @@ function createInitialInputState(
     abortReconcileRetryTimer: null,
     sessionRunningRetryTimer: null,
     sessionRunningRetryGeneration: null,
-    sessionRunningRetryCount: 0,
     sessionRunningRetryOwnerKey: null,
     sessionRunningRetryDelayMs: null,
     sessionRunningRetryToken: null,
@@ -3570,16 +3567,6 @@ export class AgentInputCoordinator {
     this.scheduleSessionRunningRetry(sessionId, `send:${reason}`);
   }
 
-  /**
-   * SESSION_RUNNING 重试连续命中次数的阈值:超过后调一次 reconcileTurnIdle,
-   * 校准可能因 done 丢失而残留的 busy 边界(turn 实际已结束但事件流没送达,
-   * coordinator 与 live session 状态不一致)。reconcile 以 live Session
-   * isTurnRunning() 为权威——正在跑的 turn 不会被误清。
-   * 阈值是**重试次数**而非时长:普通档 250ms × 20 ≈ 5s,自动续跑 10s 档 × 20
-   * ≈ 200s。设计意图是「短重试窗口快速探测,长档不烧 token 也能兜底」。
-   */
-  private static readonly SESSION_RUNNING_RECONCILE_THRESHOLD = 20;
-
   private prependQueueHeadIfMissing(state: SessionInputState, item: AgentInputQueuedMessage): void {
     if (state.pendingQueue.some((q) => q.clientId === item.clientId)) return;
     state.pendingQueue = [item, ...state.pendingQueue];
@@ -3635,54 +3622,12 @@ export class AgentInputCoordinator {
       latest.sessionRunningRetryOwnerKey = null;
       latest.sessionRunningRetryDelayMs = null;
       latest.sessionRunningRetryToken = null;
-      // early-return 前必须重置 count:generation 变化(clearSession / stop /
-      // cancelPreSendActiveTurn)或队列已空意味着「当前边界」已结束,残留计数
-      // 会让下一次不相关的 SESSION_RUNNING 边界过早触发 reconcile。
-      if (latest.generation !== generation) {
-        latest.sessionRunningRetryCount = 0;
-        return;
-      }
-      if (latest.pendingQueue.length === 0 && latest.pendingCompacts.length === 0) {
-        latest.sessionRunningRetryCount = 0;
-        return;
-      }
+      if (latest.generation !== generation) return;
+      if (latest.pendingQueue.length === 0 && latest.pendingCompacts.length === 0) return;
       if (this.isDispatchBoundaryBusy(sessionId, latest)) {
-        latest.sessionRunningRetryCount += 1;
-        // 兜底:done 丢失时 coordinator 的 busy 边界可能残留(live session 已
-        // idle 但终态事件没送达)。连续被 isTurnRunning 挡住的场景,调一次
-        // reconcile 以 live Session 为权威校准;正在跑的 turn 天然不被误清。
-        if (
-          latest.sessionRunningRetryCount >= AgentInputCoordinator.SESSION_RUNNING_RECONCILE_THRESHOLD
-        ) {
-          latest.sessionRunningRetryCount = 0;
-          // 防御式调用:reconcile 是 best-effort,依赖抛错绝不能中断重试链
-          // (与 abort reconcile 路径同款,见 reconcileTurnIdleAfterAbort)。
-          let reconciledIdle = false;
-          try {
-            reconciledIdle = this.deps.reconcileTurnIdle?.(sessionId) === true;
-          } catch (err) {
-            log.warn('reconcileTurnIdle after session-running retries failed', {
-              sessionId,
-              reason,
-              error: errorMessage(err),
-            });
-          }
-          if (reconciledIdle) {
-            log.warn('session-running retry reconciled stale busy boundary', {
-              sessionId,
-              retries: AgentInputCoordinator.SESSION_RUNNING_RECONCILE_THRESHOLD,
-              reason,
-            });
-            // reconcile 已确认 live session idle → 立刻 drain,不再等下一轮 retry
-            // delay(自动续跑 10s 档下避免额外 10s 等待)。
-            this.scheduleDrain(sessionId, `session-running-reconciled:${reason}`);
-            return;
-          }
-        }
         this.scheduleSessionRunningRetry(sessionId, reason);
         return;
       }
-      latest.sessionRunningRetryCount = 0;
       this.scheduleDrain(sessionId, `session-running-retry:${reason}`);
     }, policy.delayMs);
   }
@@ -3749,7 +3694,6 @@ export class AgentInputCoordinator {
     }
     state.sessionRunningRetryTimer = null;
     state.sessionRunningRetryGeneration = null;
-    state.sessionRunningRetryCount = 0;
     state.sessionRunningRetryOwnerKey = null;
     state.sessionRunningRetryDelayMs = null;
     state.sessionRunningRetryToken = null;

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -2778,7 +2778,17 @@ export class AgentInputCoordinator {
     this.scheduleDrain(sessionId, 'turn-done');
   }
 
-  onSessionClosed(sessionId: string): void {
+  /**
+   * @param opts.preserveInputBoundary 为 true 时跳过 abortInputBoundary。
+   *   用于 rehydrate / 凭证切换 close-rebuild 窗口:abort 会取消驱动本次重建的
+   *   input signal(#1930),但**其余清理必须照常**(activeTurn / steer / queue
+   *   状态不能残留,否则 rebuild 失败或 close 后不 rebuild 时 coordinator
+   *   残留旧状态阻塞后续发送)。
+   */
+  onSessionClosed(
+    sessionId: string,
+    opts?: { preserveInputBoundary?: boolean },
+  ): void {
     const state = this.getState(sessionId);
     this.supersedePendingAutoResumeRecoveries(sessionId);
     const releasedAbortLock = state.queueAbortPending;
@@ -2786,7 +2796,7 @@ export class AgentInputCoordinator {
     this.clearAbortReconcileRetry(state);
     this.clearSessionRunningRetry(state);
     this.clearPendingExternalTerminalDone(state);
-    this.abortInputBoundary(sessionId);
+    if (!opts?.preserveInputBoundary) this.abortInputBoundary(sessionId);
     this.abortSteerTransactions(sessionId);
     const active = state.activeTurn;
     if (active && !isActiveTurnDispatched(active)) {

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -573,6 +573,8 @@ interface SessionInputState {
   abortReconcileRetryTimer: ReturnType<typeof setTimeout> | null;
   sessionRunningRetryTimer: ReturnType<typeof setTimeout> | null;
   sessionRunningRetryGeneration: number | null;
+  /** SESSION_RUNNING 重试连续命中的次数;超阈值触发 reconcileTurnIdle 校准。 */
+  sessionRunningRetryCount: number;
   /** 当前 retry timer 绑定的队首/compact owner；队首变化时必须替换 timer policy。 */
   sessionRunningRetryOwnerKey: string | null;
   sessionRunningRetryDelayMs: number | null;
@@ -636,6 +638,7 @@ function createInitialInputState(
     abortReconcileRetryTimer: null,
     sessionRunningRetryTimer: null,
     sessionRunningRetryGeneration: null,
+    sessionRunningRetryCount: 0,
     sessionRunningRetryOwnerKey: null,
     sessionRunningRetryDelayMs: null,
     sessionRunningRetryToken: null,
@@ -1310,7 +1313,15 @@ export class AgentInputCoordinator {
       this.cancelPreparedAutoResume(sessionId, state);
     }
     if (isUiContinuationItem(item)) {
-      this.deps.onUiRetry?.(sessionId, item.clientId, 'manual');
+      // queue-head recovery 时**跳过** onUiRetry:那条消息在派发前就失败了,
+      // 从未成为一个 turn,与之前失败的 hook turn 无关(与 retryLastError 对
+      // queue-head 刻意不发 onUiRetry 的语义一致,见 performRetryLastError 注释)。
+      // 下方 queue-head 特判分支会清 recovery 重发队首 A,合成 continue 项不入队;
+      // 若在这里发 onUiRetry(无论用哪个 clientId)会让无关的排队桌面消息认领
+      // 并改写旧 hook/channel 的待续跑记账。
+      if (state.recovery?.kind !== 'queue-head') {
+        this.deps.onUiRetry?.(sessionId, item.clientId, 'manual');
+      }
     } else if (automaticOrigin && !schedulerOrigin) {
       this.deps.onAutomaticEnqueue?.(sessionId);
     } else if (!automaticOrigin) {
@@ -1340,6 +1351,53 @@ export class AgentInputCoordinator {
     if (!schedulerOrigin) {
       this.abandonActiveTurnRecoveryForUserAction(state);
       this.clearErrorUnlessQueueHeadBlocked(state);
+    }
+    // —— queue-head recovery 解锁(2026-08 事故复盘)——
+    // queue-head recovery 表示队首消息从未跨过 accepted 边界(派发前失败 /
+    // cancelled-before-dispatch)。getDrainableHead 见 recovery 即返回 null,
+    // 队列永久静止,后续所有消息(含用户新输入)全部排队不派发。
+    // 用户显式动作按 2026-07-13 口径表态(与 active-turn 对齐:「新消息 = 不重试旧消息」):
+    //  - 普通新消息(composer 直发,非 scheduler/orca/自愈续跑):放弃从未 accepted
+    //    的队首消息 A(摘除 + 清理回调),让 B 正常派发——无静默重发、无静默丢失;
+    //  - UI 续跑(「继续」按钮,sendUiTrigger):等价 retryLastError——清 recovery
+    //    重发队首 A(原样重发是既有 retryLastError 对 queue-head 的语义),合成
+    //    continue 项不入队,避免 A 与 continue 双发。
+    // 自动来源(scheduler / orca)与 resume(继续队列)维持既有「不清」语义:
+    // 自动化项不代表用户表态,resume 是机械放行,显式点重试/删除仍是唯一出路。
+    if (state.recovery?.kind === 'queue-head' && !automaticOrigin) {
+      const abandonedClientId = state.recovery.clientId;
+      if (isUiContinuationItem(item)) {
+        state.error = null;
+        state.stickyError = null;
+        state.recovery = null;
+        log.info('ui continue resets queue-head recovery; resending failed head', {
+          sessionId,
+          clientId: abandonedClientId,
+        });
+        // 手动「继续」是真人介入,与 retryLastError 同口径刷新 userSendAt(否则
+        // 会话活跃信号 / 列表排序不会反映这次人工动作)。
+        this.touchUserSend(sessionId, opts?.sendAtMs);
+        this.emit(sessionId);
+        this.scheduleDrain(sessionId, 'ui-continue-queue-head-unlock');
+        return this.getProjection(sessionId);
+      }
+      const abandoned = state.pendingQueue.find((q) => q.clientId === abandonedClientId);
+      if (abandoned) {
+        state.pendingQueue = state.pendingQueue.filter((q) => q.clientId !== abandonedClientId);
+        this.removePendingCompactWaitClientId(state, abandonedClientId);
+        // 与 remove() 同口径:摘除消息时同步清其 edit lock,否则留下指向不存在
+        // clientId 的孤儿锁,shouldQueueNewTurn 会把后续新输入误导向排队。
+        state.queueEditLocks = state.queueEditLocks.filter((id) => id !== abandonedClientId);
+        this.deps.onDiscardedQueuedMessage?.(sessionId, abandoned);
+        // 脱敏:只记 id/布尔,不记消息文本(白名单方向,见 log-upload-and-redaction)。
+        log.info('explicit user input abandoned queue-head message (never accepted)', {
+          sessionId,
+          clientId: abandonedClientId,
+        });
+      }
+      state.error = null;
+      state.stickyError = null;
+      state.recovery = null;
     }
     // 用户点「继续任务」表达的是恢复刚才中断/失败的 turn，必须先于此前
     // 已排队的新任务执行；普通 composer / Orca / scheduler 输入仍保持 FIFO。
@@ -3502,6 +3560,16 @@ export class AgentInputCoordinator {
     this.scheduleSessionRunningRetry(sessionId, `send:${reason}`);
   }
 
+  /**
+   * SESSION_RUNNING 重试连续命中次数的阈值:超过后调一次 reconcileTurnIdle,
+   * 校准可能因 done 丢失而残留的 busy 边界(turn 实际已结束但事件流没送达,
+   * coordinator 与 live session 状态不一致)。reconcile 以 live Session
+   * isTurnRunning() 为权威——正在跑的 turn 不会被误清。
+   * 阈值是**重试次数**而非时长:普通档 250ms × 20 ≈ 5s,自动续跑 10s 档 × 20
+   * ≈ 200s。设计意图是「短重试窗口快速探测,长档不烧 token 也能兜底」。
+   */
+  private static readonly SESSION_RUNNING_RECONCILE_THRESHOLD = 20;
+
   private prependQueueHeadIfMissing(state: SessionInputState, item: AgentInputQueuedMessage): void {
     if (state.pendingQueue.some((q) => q.clientId === item.clientId)) return;
     state.pendingQueue = [item, ...state.pendingQueue];
@@ -3557,12 +3625,50 @@ export class AgentInputCoordinator {
       latest.sessionRunningRetryOwnerKey = null;
       latest.sessionRunningRetryDelayMs = null;
       latest.sessionRunningRetryToken = null;
-      if (latest.generation !== generation) return;
-      if (latest.pendingQueue.length === 0 && latest.pendingCompacts.length === 0) return;
+      // early-return 前必须重置 count:generation 变化(clearSession / stop /
+      // cancelPreSendActiveTurn)或队列已空意味着「当前边界」已结束,残留计数
+      // 会让下一次不相关的 SESSION_RUNNING 边界过早触发 reconcile。
+      if (latest.generation !== generation) {
+        latest.sessionRunningRetryCount = 0;
+        return;
+      }
+      if (latest.pendingQueue.length === 0 && latest.pendingCompacts.length === 0) {
+        latest.sessionRunningRetryCount = 0;
+        return;
+      }
       if (this.isDispatchBoundaryBusy(sessionId, latest)) {
+        latest.sessionRunningRetryCount += 1;
+        // 兜底:done 丢失时 coordinator 的 busy 边界可能残留(live session 已
+        // idle 但终态事件没送达)。连续被 isTurnRunning 挡住的场景,调一次
+        // reconcile 以 live Session 为权威校准;正在跑的 turn 天然不被误清。
+        if (
+          latest.sessionRunningRetryCount >= AgentInputCoordinator.SESSION_RUNNING_RECONCILE_THRESHOLD
+        ) {
+          latest.sessionRunningRetryCount = 0;
+          // 防御式调用:reconcile 是 best-effort,依赖抛错绝不能中断重试链
+          // (与 abort reconcile 路径同款,见 reconcileTurnIdleAfterAbort)。
+          let reconciledIdle = false;
+          try {
+            reconciledIdle = this.deps.reconcileTurnIdle?.(sessionId) === true;
+          } catch (err) {
+            log.warn('reconcileTurnIdle after session-running retries failed', {
+              sessionId,
+              reason,
+              error: errorMessage(err),
+            });
+          }
+          if (reconciledIdle) {
+            log.warn('session-running retry reconciled stale busy boundary', {
+              sessionId,
+              retries: AgentInputCoordinator.SESSION_RUNNING_RECONCILE_THRESHOLD,
+              reason,
+            });
+          }
+        }
         this.scheduleSessionRunningRetry(sessionId, reason);
         return;
       }
+      latest.sessionRunningRetryCount = 0;
       this.scheduleDrain(sessionId, `session-running-retry:${reason}`);
     }, policy.delayMs);
   }
@@ -3629,6 +3735,7 @@ export class AgentInputCoordinator {
     }
     state.sessionRunningRetryTimer = null;
     state.sessionRunningRetryGeneration = null;
+    state.sessionRunningRetryCount = 0;
     state.sessionRunningRetryOwnerKey = null;
     state.sessionRunningRetryDelayMs = null;
     state.sessionRunningRetryToken = null;

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -286,7 +286,10 @@ import {
   applyNewMakerWorktreeBranchPreference,
   getNewMakerWorktreeBranchPreference,
 } from '../maker-host/newMakerWorktreeBranchPreferenceCache.js';
-import { withRehydrateCloseSuppressed } from '../maker-host/rehydrateCloseSuppression.js';
+import {
+  rehydrateCloseSuppression,
+  withRehydrateCloseSuppressed,
+} from '../maker-host/rehydrateCloseSuppression.js';
 import { handleCloseSessionRequest } from './closeSessionRequest.js';
 import {
   createOrcaIdleReleaseWatcher,
@@ -3430,6 +3433,15 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
       let shouldMarkTurnStatusIdleAfterBroadcast = false;
       let shouldMarkTurnTerminalIdleAfterBroadcast = false;
       const isContinuationBoundary = isTurnContinuationBoundaryEvent(event);
+      // 探针:continuation 边界命中会跳过 status idle / ended 写 / tracker idle,
+      // 若 claim 悬挂会导致 UI 永久「正在生成」。区分「claim 悬挂」与「done 未到达」。
+      if (isContinuationBoundary && (event.type === 'done' || event.type === 'status')) {
+        log.debug('turn continuation boundary event skipped from turn-finalize', {
+          sessionId: session.id,
+          eventType: event.type,
+          turnContinuationId: event.turnContinuationId,
+        });
+      }
       if (event.type === 'account_usage' && event.source === 'codex' && !session.remoteHostId) {
         pendingCodexAccountUsageSnapshot = event.data;
       }
@@ -4634,7 +4646,15 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           // 补发会把用户关掉的会话重新拉起来),后者会把结果错绑到下一个会话实例(codex P1)。
           interruptedTurnAutoResumeGuard.noteSessionReset(session.id);
           autoResumeBookkeeping.teardown(session.id);
-          agentInputCoordinatorHolder?.onSessionClosed(session.id);
+          // rehydrate / 凭证切换 close-rebuild 窗口:同一逻辑会话进程内重建,
+          // 协调器状态应连续。跳过 onSessionClosed 防止 abortInputBoundary 把
+          // 驱动本次重建的 input signal 取消(#1930 cancelled-before-dispatch),
+          // 也避免 recordActiveTurnClosedBeforeSendOutcome 挂假 done 搅乱
+          // coordinator 的 turn 边界。其余清理(凭证切换 / git snapshot / Orca
+          // hydration 标记 / wiring teardown)照常执行。
+          if (!rehydrateCloseSuppression.isSuppressed(session.id)) {
+            agentInputCoordinatorHolder?.onSessionClosed(session.id);
+          }
           // 会话关闭:兑现延迟凭证切换(直接写 route),并唤醒被它挡住的等待者。
           pendingCredentialSwitchHolder?.onSessionClosed(session.id);
           deferredCodexRestartHolder?.onSessionSettled();

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -4647,14 +4647,15 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           interruptedTurnAutoResumeGuard.noteSessionReset(session.id);
           autoResumeBookkeeping.teardown(session.id);
           // rehydrate / 凭证切换 close-rebuild 窗口:同一逻辑会话进程内重建,
-          // 协调器状态应连续。跳过 onSessionClosed 防止 abortInputBoundary 把
-          // 驱动本次重建的 input signal 取消(#1930 cancelled-before-dispatch),
-          // 也避免 recordActiveTurnClosedBeforeSendOutcome 挂假 done 搅乱
-          // coordinator 的 turn 边界。其余清理(凭证切换 / git snapshot / Orca
-          // hydration 标记 / wiring teardown)照常执行。
-          if (!rehydrateCloseSuppression.isSuppressed(session.id)) {
-            agentInputCoordinatorHolder?.onSessionClosed(session.id);
-          }
+          // 协调器状态应连续。窗口内保留 input boundary(不 abort,避免取消
+          // 驱动本次重建的 signal → #1930 cancelled-before-dispatch),但
+          // **其余清理必须照常执行**(activeTurn / steer / queue 状态不能残留,
+          // 否则 rebuild 失败或 close 后不 rebuild 时 coordinator 残留旧状态
+          // 阻塞后续发送)。其余清理(凭证切换 / git snapshot / Orca hydration
+          // 标记 / wiring teardown)照常。
+          agentInputCoordinatorHolder?.onSessionClosed(session.id, {
+            preserveInputBoundary: rehydrateCloseSuppression.isSuppressed(session.id),
+          });
           // 会话关闭:兑现延迟凭证切换(直接写 route),并唤醒被它挡住的等待者。
           pendingCredentialSwitchHolder?.onSessionClosed(session.id);
           deferredCodexRestartHolder?.onSessionSettled();

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3118,6 +3118,16 @@ export class ClaudeCodeAgent extends BaseAgent {
       continuationClaims.set(claim.id, claim);
       activeContinuationId = claim.id;
       event.turnContinuationId = claim.id;
+      // 探针:claim 创建是「continuation 悬挂」vs「done 未到达」的关键区分点。
+      // 只记 id / taskId / state 枚举,不记消息文本与 task prompt(脱敏红线)。
+      log.info('turn continuation claim created', {
+        continuationId: claim.id,
+        carriedTasks: [...carriedTasks.entries()].map(([taskId, state]) => ({
+          taskId,
+          state,
+        })),
+        wasActiveContinuation,
+      });
       return false;
     };
     const reconcileActiveContinuation = (): ContinuationClaim | null => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

一次事故复盘(会话 77e70e52 永久显示「正在生成」)发现多个缺陷。本 PR 聚焦 **#2039(fix-continuation-claim-leak)未覆盖的独立缺陷**——#2039 已对「后台 Agent 完成后仍显示正在生成」的根因(continuation claim 悬挂)做根治,故本 PR 不再包含同题的 reconcile 兜底,避免重复:

1. **rehydrate / 凭证切换 close-rebuild 自取消输入(#1930)**:Orca lead 会话 rehydrate 时 `closeSession` 同步触发 `setStatus('closed')` → `coordinator.onSessionClosed` → `abortInputBoundary`,取消驱动本次重建的 input signal → `cancelled-before-dispatch`。register.ts 在 rehydrate 抑制窗口内调用 `onSessionClosed` 但传 `preserveInputBoundary=true`(只跳过 abortInputBoundary,activeTurn / steer / queue 清理照常——凭证切换等 close 后不 rebuild 的场景不残留状态)。
2. **queue-head recovery 卡死 drain**:`cancelled-before-dispatch` 设置 `{kind:'queue-head'}` recovery 后,`getDrainableHead` 见 recovery 即返回 null,队列永久静止,后续所有消息(含用户新输入)全部排队不派发。修复:用户显式新输入(composer 直发,非 scheduler/orca)放弃从未 accepted 的队首消息(摘除 + `onDiscardedQueuedMessage` 清理),新消息正常派发;UI「继续」等价 `retryLastError` 重发队首(跳过 onUiRetry,与既有语义一致);scheduler/orca 自动来源维持「不清」语义。
3. **continuation 探针日志**:claude-code translator continuation claim 创建处 + register continuation 边界命中处加日志(脱敏,只记 id/枚举),监控 #2039 根治后 claim 悬挂是否复发。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:Fixes #1930;关联 #2039(「正在生成」根因根治,已另开 PR)
- 本 PR 包含:两个独立缺陷的修复 + continuation 探针日志 + 回归测试
- 明确不包含:「正在生成」根因(continuation claim 悬挂)的修复——由 #2039 处理;本 PR 曾含 SESSION_RUNNING reconcile 兜底,因与 #2039 重叠已撤掉
- 用户可见变化:Orca lead 恢复后首条消息不再需重发;被放弃的未发送消息从队列消失
- 是否存在 breaking change:无

### UI 变化

不涉及(纯 main 进程逻辑 + 日志,无 renderer 改动)。

- 引用的设计规范:不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck                          # 通过
pnpm --filter desktop exec vitest run src/main/maker-ipc     # 通过(含 agent-input-coordinator 263 测试)
pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/withRehydrateCloseSuppressed.test.ts src/main/__tests__/makerEventHotPathOrdering.test.ts  # 通过
pnpm --filter @cindy/maker-core exec vitest run             # 通过
结果:全部通过
```

### 手工验证

不涉及(纯 main 进程逻辑,无 UI 手工路径)。

### 未执行的验证

- 「正在生成」根因(continuation claim 悬挂)的修复不在本 PR——见 #2039。
- `storage.db.test.ts`(db tier)在本机 CN 构建有 11 个既有失败(USD vs CNY 区域敏感),与本次改动无关(干净 main 同样失败),不在 `test:unit` 门禁范围。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他:

### 影响与回滚

- 影响范围:仅 Desktop main 进程的输入协调器与 turn 收尾逻辑;queue-head recovery 语义调整(用户显式新输入会放弃未发送的队首消息,无 toast 提示,与 remove/stop 行为一致)
- 回滚 / 降级方式:回滚本提交即可恢复原行为;无数据迁移或持久化状态

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明(不涉及 UI)
