### PR TITLE
fix(desktop): 本条消息生成的文件卡对转义残留路径去重

### DIFF
--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -122,6 +122,40 @@ describe('collectGeneratedFiles', () => {
     expect(files[0].source).toBe('tool');
   });
 
+  it('collapses doubled backslashes so escaped wrapper commands do not duplicate chips', () => {
+    // 实测场景(pr-watch session):powershell 包一层 node -e,落库命令文本里的
+    // 路径带转义残留(`C:\\Users\\...`);同轮另一条命令用正斜杠形态。fs 层它们
+    // 是同一文件(Windows 归并重复分隔符),不折叠会出两个同名 chip。
+    const files = collectGeneratedFiles(
+      [
+        toolUse('Bash', {
+          command: "powershell -Command '$p = 'C:\\\\Users\\\\U\\\\pr-watch\\\\registry.json'; Get-Content $p'",
+        }),
+        toolUse('Bash', {
+          command: "node -e \"const p='C:/Users/U/pr-watch/registry.json'; console.log(p);\"",
+        }),
+      ],
+      'C:\\Users\\U\\pr-watch',
+    );
+    const registry = files.filter((f) => f.name === 'registry.json');
+    expect(registry).toHaveLength(1);
+    // 画布路径本身也折叠成单反斜杠本机形态,不带转义残留。
+    expect(registry[0].path).toBe('C:\\Users\\U\\pr-watch\\registry.json');
+  });
+
+  it('keeps the UNC leading double backslash while collapsing inner separator runs', () => {
+    const files = collectGeneratedFiles(
+      [
+        toolUse('Bash', { command: "copy out '\\\\server\\share\\\\dir\\report.csv'" }),
+        toolUse('Bash', { command: "open '\\\\server\\share\\dir\\report.csv'" }),
+      ],
+      'C:\\work',
+    );
+    const reports = files.filter((f) => f.name === 'report.csv');
+    expect(reports).toHaveLength(1);
+    expect(reports[0].path.startsWith('\\\\server\\')).toBe(true);
+  });
+
   it('excludes command mentions of files edited by file tools this turn', () => {
     // 编码会话形态:Edit 改了源码文件,随后命令引用它(跑测试)。它是编辑不是
     // 新建,不能因 mtime 落在本轮窗口就被当成产物。

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -51,9 +51,16 @@ interface ToolUseLike {
  */
 function dedupeKeyForPath(abs: string): string {
   const isWindowsShape = /^[a-zA-Z]:[\\/]/.test(abs) || abs.includes('\\');
+  if (!isWindowsShape) return abs;
   // 斜杠也归一:`C:/x/a.md`(命令文本常见形态)与 `C:\x\a.md`(Write 记录)是
-  // 同一文件,不折叠会重复出 chip。
-  return isWindowsShape ? abs.replace(/\//g, '\\').toLowerCase() : abs;
+  // 同一文件,不折叠会重复出 chip。连续分隔符同理折叠:命令文本常是二次转义的
+  // 包装串(如 powershell 包一层 node -e),提取出的 `C:\\x\\a.md` 与 `C:\x\a.md`
+  // 在 fs 层等价(Windows 归并重复分隔符),不折叠会对同一文件出两个 chip。
+  // UNC 头部的 `\\` 是路径语义的一部分,保留。
+  return abs
+    .replace(/\//g, '\\')
+    .replace(/(?<!^)\\{2,}/g, '\\')
+    .toLowerCase();
 }
 
 /**
@@ -63,7 +70,11 @@ function dedupeKeyForPath(abs: string): string {
  * 路径原样保留。
  */
 function canonicalizeWindowsShape(abs: string): string {
-  return /^[a-zA-Z]:[\\/]/.test(abs) ? abs.replace(/\//g, '\\') : abs;
+  // 连续分隔符折叠进画布路径本身(不只 dedupe key):stat 虽能容忍 `C:\\x`,但
+  // Explorer `/select` 与 chip 展示不该带转义残留。盘符形态不存在 UNC 头,可整段折叠。
+  return /^[a-zA-Z]:[\\/]/.test(abs)
+    ? abs.replace(/\//g, '\\').replace(/\\{2,}/g, '\\')
+    : abs;
 }
 
 /** 单条 tool_use 消息 → 它新建的文件原始路径列表(可能为空)。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

「本条消息生成的文件」卡会对同一个文件出两个同名 chip。实测根因(取自真实 session 落库数据):powershell 包一层 node -e 的命令文本里,路径带转义残留(`C:\Users\...`,双反斜杠);同一轮另一条命令用正斜杠形态(`C:/Users/...`)。二者在 fs 层是同一文件(Windows 归并重复分隔符,stat 均成功),但派生管线的去重 key 只折叠 `/`→`\` 与大小写、不折叠连续反斜杠 → 两个 key → 两个 chip。

修复:`dedupeKeyForPath` 对 Windows 形态折叠连续分隔符(UNC 头部 `\` 保留);`canonicalizeWindowsShape` 对盘符路径把画布路径本身一并折叠——chip tooltip、Explorer 定位、打开拿到干净的单反斜杠形态,MessageStream 与变更卡 exactPaths 的抑制比对也能对上。POSIX 路径一律不动(维持 PR #1835 的「宁可 macOS 偶尔重复,不在 Linux 丢文件」取舍)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:实机反馈(pr-watch session 中 registry.json 重复出 chip)
- 本 PR 包含:`generatedFiles.ts` 两个归一化函数 + 回归测试
- 明确不包含:命令文本路径候选提取规则本身(未动);POSIX 路径归一化(有意不动)
- 用户可见变化:同一文件不再出重复 chip;chip 的路径 tooltip 不再带 `\` 转义残留
- 是否存在 breaking change:无

### UI 变化

不涉及:纯数据派生层修复,无视觉/交互/文案变化。

## 怎么验证的

### 自动验证

```text
pnpm test:unit                    全仓 PASS(desktop 147.5s)
pnpm --filter desktop typecheck   PASS
pnpm check:dco                    PASS
```

新增回归测试 2 例:转义包装串双反斜杠与正斜杠形态收敛为单 chip 且路径干净;UNC 头部 `\` 保留、内部连续分隔符折叠。

### 手工验证

用触发该 bug 的真实 session(8e2e9a6b…)落库消息离线重放派生管线:修复前 registry.json 出 2 条,修复后 1 条、路径为干净单反斜杠形态。

### 未执行的验证

- 未在实机 UI 重放原始 session(离线重放使用与渲染层相同的 collectGeneratedFiles 入口,置信度等价)

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围:仅「本条消息生成的文件」卡的路径归一化;折叠只发生在 Windows 形态路径,fs 层等价变换
- 回滚 / 降级方式:revert 单 commit

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(代码内注释)
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
