### PR TITLE
fix(mobile): 整包版本改读原生真值,避免热更后回退

### DIFF
--- a/apps/mobile/app/settings.tsx
+++ b/apps/mobile/app/settings.tsx
@@ -41,6 +41,7 @@ import {
   StatusDot,
 } from '@/components/MobilePrimitives';
 import {
+  APP_BINARY_VERSION,
   AUTH_API_BASE_URL,
   AUTH_REGION,
   DESKTOP_PACKAGE_VERSION,
@@ -165,7 +166,11 @@ export default function SettingsScreen() {
     [auth.deviceId, auth.user?.email, auth.user?.id, auth.user?.name, deviceName, status, t],
   );
 
-  const appVersion = Constants.expoConfig?.version ?? '0.0.0';
+  // 整包版本必须读原生烧进的值(CFBundleShortVersionString / versionName):
+  // OTA 热更会把 manifest 里内嵌的 expoClient.version 覆盖给 Constants.expoConfig.version,
+  // 而热更不改原生包,若读 expoConfig 会在热更后回退成打热更时主仓 app.json 的旧值。
+  // APP_BINARY_VERSION 优先取原生层、热更后不漂移(与 mobileTapdb / env 上报同口径)。
+  const appVersion = APP_BINARY_VERSION || '0.0.0';
   const updatesEnabled = Updates.isEnabled;
   // 当前运行的 OTA bundle 信息(只读),折进「调试」分组,用于核验热更是否生效。
   const { currentlyRunning } = useUpdates();

--- a/apps/mobile/src/__tests__/mobileSettings.test.ts
+++ b/apps/mobile/src/__tests__/mobileSettings.test.ts
@@ -231,4 +231,14 @@ describe('mobile settings overview', () => {
     expect(i18n.t('settings.version.pairedDesktopVersion', { version: '0.1.18' }))
       .toBe('配套桌面版本 0.1.18');
   });
+
+  it('整包版本读原生真值 APP_BINARY_VERSION,不读会被 OTA 覆盖的 expoConfig.version', () => {
+    const source = readTextLf(resolve(process.cwd(), 'app/settings.tsx'), 'utf8');
+
+    // 整包版本必须取原生烧进的 CFBundleShortVersionString / versionName(APP_BINARY_VERSION),
+    // 热更后不漂移;绝不能读 Constants.expoConfig.version —— 它会被 OTA manifest 内嵌的
+    // expoClient.version(打热更时主仓 app.json 的旧值)覆盖,导致整包版本回退。
+    expect(source).toContain("const appVersion = APP_BINARY_VERSION || '0.0.0';");
+    expect(source).not.toContain("const appVersion = Constants.expoConfig?.version");
+  });
 });

--- a/apps/mobile/src/update/bundleUpdate.ts
+++ b/apps/mobile/src/update/bundleUpdate.ts
@@ -39,7 +39,7 @@ export interface BundleUpdateEvaluation {
 export interface EvaluateBundleUpdateInput {
   /** 当前运行包的 runtimeVersion(取自 expo-updates Updates.runtimeVersion)。 */
   currentRuntimeVersion: string | null | undefined;
-  /** 当前包的应用版本(Constants.expoConfig.version)。 */
+  /** 当前包的应用版本(原生真值 APP_BINARY_VERSION;不要传会被 OTA 覆盖的 expoConfig.version)。 */
   currentVersion: string | null | undefined;
   /** `/latest` 返回体(已解析)。无效/缺字段视为无更新。 */
   latest: unknown;

--- a/apps/mobile/src/update/useBundleUpdatePrompt.ts
+++ b/apps/mobile/src/update/useBundleUpdatePrompt.ts
@@ -7,10 +7,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Alert, Linking, Platform } from 'react-native';
-import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
 import { i18n } from '@/i18n';
 import {
+  APP_BINARY_VERSION,
   IS_OTA_SELFHOST,
   IS_TESTFLIGHT_BUILD,
   REVIEW_MODE,
@@ -128,7 +128,9 @@ export function useBundleUpdatePrompt({
       if (requestEpoch !== channelEpochRef.current) return 'skipped';
       const evaluation = evaluateBundleUpdate({
         currentRuntimeVersion: Updates.runtimeVersion,
-        currentVersion: Constants.expoConfig?.version ?? null,
+        // 强更门槛(minVersion)按原生真值比,避免热更后 expoConfig.version 被内嵌旧值
+        // 覆盖导致原生已达标的机器被误判为低于门槛、错误触发强更。
+        currentVersion: APP_BINARY_VERSION || null,
         latest,
       });
       if (evaluation.needsUpdate) {

--- a/apps/mobile/src/update/useForcedUpdateRecheck.ts
+++ b/apps/mobile/src/update/useForcedUpdateRecheck.ts
@@ -6,8 +6,8 @@
 
 import { useEffect } from 'react';
 import { AppState, Platform } from 'react-native';
-import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
+import { APP_BINARY_VERSION } from '@/config/env';
 import { fetchLatestRelease } from './fetchLatestRelease';
 import { createForcedUpdateRechecker } from './forcedUpdateRecheck';
 import {
@@ -32,7 +32,8 @@ export function useForcedUpdateRecheck(isCanary = isCanaryChannel()): void {
         isCanary,
       ),
       getCurrentRuntimeVersion: () => Updates.runtimeVersion,
-      getCurrentVersion: () => Constants.expoConfig?.version ?? null,
+      // 与 useBundleUpdatePrompt 同口径:强更解除也按原生真值比,热更后不漂移。
+      getCurrentVersion: () => APP_BINARY_VERSION || null,
       onCleared: clearForcedUpdate,
       // 仍强更时刷新目标(等值时 enterForcedUpdate 幂等,不会引发重渲染)。
       onStillForced: enterForcedUpdate,

--- a/apps/mobile/src/update/useResumeUpdateCheck.ts
+++ b/apps/mobile/src/update/useResumeUpdateCheck.ts
@@ -7,9 +7,9 @@
 
 import { useEffect } from 'react';
 import { AppState, Platform } from 'react-native';
-import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
 import {
+  APP_BINARY_VERSION,
   IS_OTA_SELFHOST,
   IS_TESTFLIGHT_BUILD,
   REVIEW_MODE,
@@ -44,7 +44,8 @@ export function useResumeUpdateCheck(isCanary = isCanaryChannel()): void {
         isCanary,
       ),
       getCurrentRuntimeVersion: () => Updates.runtimeVersion,
-      getCurrentVersion: () => Constants.expoConfig?.version ?? null,
+      // 与 useBundleUpdatePrompt / useForcedUpdateRecheck 同口径:强更比较按原生真值,热更后不漂移。
+      getCurrentVersion: () => APP_BINARY_VERSION || null,
       onForcedUpdate: promptBundleUpdate,
       now: () => Date.now(),
       isCurrent: () => current,


### PR DESCRIPTION
## 这次改了什么

### 摘要

移动端「设置 → 版本」里的**整包版本**原先读 `Constants.expoConfig?.version`。这个值在 OTA 热更后会被热更 manifest 内嵌的 `extra.expoClient.version` 覆盖,而该内嵌值取自**打热更时主仓 `app.json` 的旧值**(按设计 `app.json` 只在冷更构建时临时注入真版本、不 commit 回仓)。结果:原生整包实际已是 0.1.1 的机器,在收到基于它打的热更后,整包版本显示**回退成 0.1.0**。

改为复用仓内既有的 `APP_BINARY_VERSION`(`src/config/env.ts`,优先取原生 `CFBundleShortVersionString` / `versionName`,热更后不漂移,与 `mobileTapdb` / `env` 的版本上报同口径)。同时把 `evaluateBundleUpdate` 的 `currentVersion` 取值源(`useBundleUpdatePrompt`、`useForcedUpdateRecheck`)一并对齐,避免 `minVersion` 强更判定按被覆盖的旧值误判、把原生已达标的机器错误强更。

线上核对结论(cn 线):App Store 已发布 0.1.1、`release.json` version=0.1.1,而 OTA manifest 的 `expoClient.version=0.1.0` —— 与本改动诊断一致。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:移动端整包版本号热更后错误回退
- 本 PR 包含:`app/settings.tsx` 整包版本取值源、`useBundleUpdatePrompt.ts` 与 `useForcedUpdateRecheck.ts` 的 `currentVersion` 取值源、一条回归单测
- 明确不包含:任何打包脚本 / `app.json` 注入机制 / i18n 文案改动;`cindy-protocol` 子模块指针
- 用户可见变化:热更后设置页整包版本正确显示原生真值(如 0.1.1),不再回退
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及:仅调整整包版本号的**取值来源**(`expoConfig.version` → `APP_BINARY_VERSION`),渲染结构、文案、样式与交互均未变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile run --if-present typecheck        # 通过
pnpm --filter mobile exec vitest run src/__tests__/mobileSettings.test.ts src/update
  结果:10 files / 165 tests passed(含新增回归用例)
pnpm test:unit
  结果:全绿。注:本地工作区 cindy-protocol 子模块被 checkout 到分叉的 298cd35
        (缺 supportsCindyVersion),导致 desktop/plugin-market 测试本地报错;
        临时切回主仓记录的子模块 0cb87cb5 后这些用例 104 tests 全部通过,随即无损还原。
        该失败为本地子模块分叉的假象,与本改动无关,PR CI 使用记录版子模块。
```

### 手工验证

不涉及(未在真机/模拟器运行;改动为纯逻辑,行为由单测覆盖)。

### 未执行的验证

真机 / 模拟器实跑与 `__DEV__` build label 证据:未执行 —— 当前环境无法启动 mobile app。改动为纯 JS/TS 取值源切换,不改 fingerprint 输入,逻辑正确性由 `mobileSettings` 回归用例与既有 `bundleUpdate` 单测覆盖。

## 风险

### 风险分类

- [x] 原生层 / fingerprint / OTA

### 影响与回滚

- 影响范围:仅移动端版本号显示与 `minVersion` 强更比较基准;取值改为原生真值,更正确。
- **不触发冷更**:改动全在 `app/`、`src/` 下的 TS,不改任何 fingerprint 输入(依赖、`app.json` 原生字段、config plugin、原生目录均未动),runtimeVersion 不变(仍 `906505dc…`),以热更发布,现网装机用户直接收到修复。
- 回滚 / 降级方式:回退本 commit 即可;无数据迁移、无持久化影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`)
- [x] UI 改动已在「UI 变化」注明(不涉及视觉/交互/文案,已说明理由)
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
