### PR TITLE
feat(pi): expose runtime capability manifest from get_commands

### DIFF
--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -69,6 +69,7 @@ import type {
   ListCustomizationsOptions,
   ListCustomizationsResult,
 } from '../types/customizations.js';
+import type { PiRuntimeCapabilityManifest } from '../types/pi-runtime-capabilities.js';
 import { scanWorkspaceFileResources } from './shared/palette-scanner.js';
 import type { AutoReviewDelegate } from './shared/auto-review-decision.js';
 
@@ -1160,6 +1161,12 @@ export interface AgentSessionHandle {
   readonly id: string;
   readonly agentKind: AgentKind;
   readonly model: string;
+  /** Pi-only, per-session runtime command catalog. Undefined for other agents. */
+  getRuntimeCapabilities?(): PiRuntimeCapabilityManifest | undefined;
+  /** Subscribe to Pi runtime catalog replacement; returns an idempotent disposer. */
+  onRuntimeCapabilitiesChange?(
+    listener: (manifest: PiRuntimeCapabilityManifest | undefined) => void,
+  ): () => void;
   /** Codex-only: 当前会话绑定的 app-server host 是否经 loopback proxy 出口。 */
   readonly codexProxyActive?: boolean;
   /**

--- a/packages/maker-core/src/agents/pi/__tests__/pi-rpc-resource-discovery.integration.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-rpc-resource-discovery.integration.test.ts
@@ -25,6 +25,8 @@ import { StringDecoder } from 'node:string_decoder';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { capturePiRuntimeCapabilityManifest } from '../runtime-capabilities.js';
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../../../../../..');
 const PLATFORM_KEY = `${process.platform}-${process.arch}`;
@@ -634,6 +636,26 @@ describe.skipIf(!existsSync(PI_BINARY))('Pi v0.83.0 RPC resource discovery facts
       approve: false,
     });
     const skills = normalizeSkills(result.commands, fixture);
+
+    const manifest = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: true, data: { commands: result.commands } }) },
+      {},
+      1,
+      'ready',
+    );
+    expect(manifest.status).toBe('loaded');
+    expect(manifest.commands).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'skill:global-skill',
+        description: 'fixture global-skill',
+        source: 'skill',
+        sourceInfo: expect.objectContaining({
+          source: 'auto',
+          scope: 'user',
+          baseDir: fixture.configHome,
+        }),
+      }),
+    ]));
 
     expect(skills).toEqual([{
       name: 'skill:global-skill',

--- a/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
@@ -34,20 +34,20 @@ vi.mock('../rpc-client.js', () => ({
       captured.instances.push(this.state);
       void opts.onEvent;
     }
-    async request(command: Record<string, unknown>): Promise<{ success: boolean; data?: unknown; error?: string }> {
+    async request(command: Record<string, unknown>): Promise<{ type?: string; command?: string; success: boolean; data?: unknown; error?: string }> {
       this.state.requests.push(command);
       if (command.type === 'get_state') {
         return { success: true, data: { sessionFile: `/mock/${this.state.sessionId || 'fork'}.jsonl`, model: { contextWindow: 200_000 } } };
       }
       if (command.type === 'get_commands') {
         if (captured.runtimeFailures.has(this.state.sessionId)) {
-          return { success: false, error: 'provider=/secret/path rejected' };
+          return { type: 'response', command: 'get_commands', success: false, error: 'provider=/secret/path rejected' };
         }
         if (captured.runtimeDeferred) {
           await new Promise<void>((resolve) => { captured.runtimeRelease = resolve; });
         }
         const data = captured.catalogs[this.state.sessionId] ?? { commands: [] };
-        return { success: true, data };
+        return { type: 'response', command: 'get_commands', success: true, data };
       }
       if (command.type === 'switch_session') return { success: true, data: {} };
       if (command.type === 'clone') return { success: true, data: {} };

--- a/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
@@ -12,6 +12,8 @@ const captured = vi.hoisted(() => ({
   }>,
   catalogs: {} as Record<string, unknown>,
   runtimeFailures: new Set<string>(),
+  runtimeDeferred: false,
+  runtimeRelease: undefined as (() => void) | undefined,
 }));
 
 vi.mock('../rpc-client.js', () => ({
@@ -40,6 +42,9 @@ vi.mock('../rpc-client.js', () => ({
       if (command.type === 'get_commands') {
         if (captured.runtimeFailures.has(this.state.sessionId)) {
           return { success: false, error: 'provider=/secret/path rejected' };
+        }
+        if (captured.runtimeDeferred) {
+          await new Promise<void>((resolve) => { captured.runtimeRelease = resolve; });
         }
         const data = captured.catalogs[this.state.sessionId] ?? { commands: [] };
         return { success: true, data };
@@ -72,6 +77,8 @@ describe('Pi runtime capability lifecycle', () => {
     captured.instances = [];
     captured.catalogs = {};
     captured.runtimeFailures = new Set();
+    captured.runtimeDeferred = false;
+    captured.runtimeRelease = undefined;
     home = mkdtempSync(path.join(tmpdir(), 'pi-runtime-home-'));
     cwd = mkdtempSync(path.join(tmpdir(), 'pi-runtime-cwd-'));
   });
@@ -99,12 +106,15 @@ describe('Pi runtime capability lifecycle', () => {
     const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
     const changes: unknown[] = [];
     const dispose = handle.onRuntimeCapabilitiesChange?.((manifest) => changes.push(manifest));
-    expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', sessionId: 's1', commands: [{ name: 'skill:s1' }] });
+    await vi.waitFor(() => {
+      expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', sessionId: 's1', commands: [{ name: 'skill:s1' }] });
+    });
     expect(captured.instances[0]?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(1);
     await handle.close();
     expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
-    expect(changes).toHaveLength(1);
-    expect(changes[0]).toBeUndefined();
+    expect(changes).toHaveLength(2);
+    expect(changes[0]).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:s1' }] });
+    expect(changes[1]).toBeUndefined();
     dispose?.();
   });
 
@@ -124,11 +134,26 @@ describe('Pi runtime capability lifecycle', () => {
   it('does not block normal prompt dispatch when get_commands fails', async () => {
     captured.runtimeFailures.add('s1');
     const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
-    expect(handle.getRuntimeCapabilities?.()).toMatchObject({
-      status: 'failed',
-      error: { code: 'rpc_failed', message: 'Pi runtime command discovery was rejected' },
+    await vi.waitFor(() => {
+      expect(handle.getRuntimeCapabilities?.()).toMatchObject({
+        status: 'failed',
+        error: { code: 'rpc_failed', message: 'Pi runtime command discovery was rejected' },
+      });
     });
-    await expect(handle.send({ content: 'hello' })).resolves.toBeUndefined();
+    await expect(handle.send({ type: 'user', content: 'hello' })).resolves.toBeUndefined();
+    await handle.close();
+  });
+
+  it('does not block ready while capability discovery is pending', async () => {
+    captured.catalogs.s1 = catalog('skill:s1');
+    captured.runtimeDeferred = true;
+    const start = new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
+    const handle = await start;
+    expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
+    captured.runtimeRelease?.();
+    await vi.waitFor(() => {
+      expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:s1' }] });
+    });
     await handle.close();
   });
 
@@ -140,8 +165,10 @@ describe('Pi runtime capability lifecycle', () => {
       agent.startSession({ sessionId: 's1', workingDir: cwd, model: 'm' }),
       agent.startSession({ sessionId: 's2', workingDir: cwd, model: 'm' }),
     ]);
-    expect(first.getRuntimeCapabilities?.()?.commands[0]?.name).toBe('skill:s1');
-    expect(second.getRuntimeCapabilities?.()?.commands[0]?.name).toBe('skill:s2');
+    await vi.waitFor(() => {
+      expect(first.getRuntimeCapabilities?.()?.commands[0]?.name).toBe('skill:s1');
+      expect(second.getRuntimeCapabilities?.()?.commands[0]?.name).toBe('skill:s2');
+    });
     const before = captured.instances.map((instance) => instance.requests.length);
     await agent.listAgentSkills({ workingDir: cwd });
     expect(captured.instances.map((instance) => instance.requests.length)).toEqual(before);
@@ -156,14 +183,25 @@ describe('Pi runtime capability lifecycle', () => {
     const instance = captured.instances[0]!;
     expect(instance.requests.filter((request) => request.type === 'switch_session')).toHaveLength(1);
     expect(instance.requests.filter((request) => request.type === 'get_commands')).toHaveLength(1);
-    expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:resumed' }] });
+    await vi.waitFor(() => {
+      expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:resumed' }] });
+    });
     await handle.close();
 
     captured.catalogs[''] = catalog('skill:fork');
+    captured.catalogs.forked = catalog('skill:fork');
     const fork = await new PiAgent(deps()).forkSdkSession({
       sourceSdkSessionId: '/mock/source.jsonl', upToMessageId: undefined, workingDir: cwd,
     });
-    expect(fork.runtimeCapabilities).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:fork' }] });
-    expect(captured.instances.at(-1)?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(1);
+    expect(fork.runtimeCapabilities).toBeUndefined();
+    expect(captured.instances.at(-1)?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(0);
+
+    const forkedHandle = await new PiAgent(deps()).startSession({
+      sessionId: 'forked', workingDir: cwd, model: 'm', resumeSessionId: fork.newSdkSessionId,
+    });
+    await vi.waitFor(() => {
+      expect(forkedHandle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:fork' }] });
+    });
+    await forkedHandle.close();
   });
 });

--- a/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
@@ -113,11 +113,13 @@ describe('Pi runtime capability lifecycle', () => {
   it('captures once after ready, exposes a stable per-session query/event contract, and clears on close', async () => {
     captured.catalogs.s1 = catalog('skill:s1');
     const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
-    const changes: unknown[] = [];
-    const dispose = handle.onRuntimeCapabilitiesChange?.((manifest) => changes.push(manifest));
     await vi.waitFor(() => {
       expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', sessionId: 's1', commands: [{ name: 'skill:s1' }] });
     });
+    const changes: unknown[] = [];
+    const dispose = handle.onRuntimeCapabilitiesChange?.((manifest) => changes.push(manifest));
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:s1' }] });
     expect(captured.instances[0]?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(1);
     await handle.close();
     expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
@@ -135,7 +137,8 @@ describe('Pi runtime capability lifecycle', () => {
     handle.onRuntimeCapabilitiesChange?.((manifest) => changes.push(manifest));
     instance.onExit?.({ code: 1, signal: null });
     expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
-    expect(changes).toEqual([undefined]);
+    expect(changes.at(-1)).toBeUndefined();
+    expect(changes.length).toBeGreaterThanOrEqual(1);
     await handle.close();
     expect(instance.closed).toBe(true);
   });
@@ -203,7 +206,9 @@ describe('Pi runtime capability lifecycle', () => {
     const result = await handle.commitRewindFiles?.('', '', { tailTurnsToDrop: 1 });
     expect(result?.sdkSessionId).toBe('/mock/s1-rewind.jsonl');
     expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
-    expect(changes).toEqual([undefined]);
+    expect(changes).toHaveLength(2);
+    expect(changes[0]).toMatchObject({ sdkSessionId: '/mock/s1.jsonl', status: 'loaded' });
+    expect(changes[1]).toBeUndefined();
 
     captured.runtimeRelease?.();
     await vi.waitFor(() => {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
@@ -1,0 +1,169 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const captured = vi.hoisted(() => ({
+  instances: [] as Array<{
+    sessionId: string;
+    requests: Array<Record<string, unknown>>;
+    closed: boolean;
+    onExit?: (info: { code: number | null; signal: string | null }) => void;
+  }>,
+  catalogs: {} as Record<string, unknown>,
+  runtimeFailures: new Set<string>(),
+}));
+
+vi.mock('../rpc-client.js', () => ({
+  PiRpcProcess: class {
+    private readonly state: (typeof captured.instances)[number];
+    isClosed = false;
+    constructor(opts: {
+      env: Record<string, string | undefined>;
+      onEvent: (event: unknown) => void;
+      onExit?: (info: { code: number | null; signal: string | null }) => void;
+    }) {
+      this.state = {
+        sessionId: opts.env.CINDY_PI_SESSION_ID ?? '',
+        requests: [],
+        closed: false,
+        onExit: opts.onExit,
+      };
+      captured.instances.push(this.state);
+      void opts.onEvent;
+    }
+    async request(command: Record<string, unknown>): Promise<{ success: boolean; data?: unknown; error?: string }> {
+      this.state.requests.push(command);
+      if (command.type === 'get_state') {
+        return { success: true, data: { sessionFile: `/mock/${this.state.sessionId || 'fork'}.jsonl`, model: { contextWindow: 200_000 } } };
+      }
+      if (command.type === 'get_commands') {
+        if (captured.runtimeFailures.has(this.state.sessionId)) {
+          return { success: false, error: 'provider=/secret/path rejected' };
+        }
+        const data = captured.catalogs[this.state.sessionId] ?? { commands: [] };
+        return { success: true, data };
+      }
+      if (command.type === 'switch_session') return { success: true, data: {} };
+      if (command.type === 'clone') return { success: true, data: {} };
+      return { success: true, data: { entries: [] } };
+    }
+    send(): void {}
+    async close(): Promise<void> {
+      this.isClosed = true;
+      this.state.closed = true;
+    }
+  },
+}));
+
+import { PiAgent } from '../index.js';
+import type { AgentDeps } from '../../base-agent.js';
+import type { Logger } from '../../../interfaces/logger.js';
+
+const noopLogger: Logger = {
+  trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, fatal: () => {}, child: () => noopLogger,
+};
+
+describe('Pi runtime capability lifecycle', () => {
+  let home = '';
+  let cwd = '';
+
+  beforeEach(() => {
+    captured.instances = [];
+    captured.catalogs = {};
+    captured.runtimeFailures = new Set();
+    home = mkdtempSync(path.join(tmpdir(), 'pi-runtime-home-'));
+    cwd = mkdtempSync(path.join(tmpdir(), 'pi-runtime-cwd-'));
+  });
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  function deps(): AgentDeps {
+    return {
+      auth: {
+        getState: async () => ({ authenticated: true, identity: 'test', authSource: 'api-key' as const }),
+        triggerLogin: async () => ({ authenticated: true }), logout: async () => {}, getAuthEnv: async () => ({}),
+      },
+      runtimeConfig: { endpoint: 'http://127.0.0.1:9' }, binaryPath: '/mock/pi', logger: noopLogger,
+      capabilityAdditions: { availableModels: [{ id: 'm', displayName: 'M', contextWindow: 200_000, efforts: [], defaultEffort: null }] },
+      resolvePiAgentHome: () => home,
+    };
+  }
+
+  const catalog = (name: string) => ({ commands: [{ name, source: 'skill', sourceInfo: { source: 'auto', scope: 'user', baseDir: '/tmp' } }] });
+
+  it('captures once after ready, exposes a stable per-session query/event contract, and clears on close', async () => {
+    captured.catalogs.s1 = catalog('skill:s1');
+    const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
+    const changes: unknown[] = [];
+    const dispose = handle.onRuntimeCapabilitiesChange?.((manifest) => changes.push(manifest));
+    expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', sessionId: 's1', commands: [{ name: 'skill:s1' }] });
+    expect(captured.instances[0]?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(1);
+    await handle.close();
+    expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toBeUndefined();
+    dispose?.();
+  });
+
+  it('clears the catalog when the Pi process exits unexpectedly', async () => {
+    captured.catalogs.s1 = catalog('skill:s1');
+    const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
+    const instance = captured.instances[0]!;
+    const changes: unknown[] = [];
+    handle.onRuntimeCapabilitiesChange?.((manifest) => changes.push(manifest));
+    instance.onExit?.({ code: 1, signal: null });
+    expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
+    expect(changes).toEqual([undefined]);
+    await handle.close();
+    expect(instance.closed).toBe(true);
+  });
+
+  it('does not block normal prompt dispatch when get_commands fails', async () => {
+    captured.runtimeFailures.add('s1');
+    const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
+    expect(handle.getRuntimeCapabilities?.()).toMatchObject({
+      status: 'failed',
+      error: { code: 'rpc_failed', message: 'Pi runtime command discovery was rejected' },
+    });
+    await expect(handle.send({ content: 'hello' })).resolves.toBeUndefined();
+    await handle.close();
+  });
+
+  it('keeps concurrent session catalogs isolated and does not let list calls trigger RPC', async () => {
+    captured.catalogs.s1 = catalog('skill:s1');
+    captured.catalogs.s2 = catalog('skill:s2');
+    const agent = new PiAgent(deps());
+    const [first, second] = await Promise.all([
+      agent.startSession({ sessionId: 's1', workingDir: cwd, model: 'm' }),
+      agent.startSession({ sessionId: 's2', workingDir: cwd, model: 'm' }),
+    ]);
+    expect(first.getRuntimeCapabilities?.()?.commands[0]?.name).toBe('skill:s1');
+    expect(second.getRuntimeCapabilities?.()?.commands[0]?.name).toBe('skill:s2');
+    const before = captured.instances.map((instance) => instance.requests.length);
+    await agent.listAgentSkills({ workingDir: cwd });
+    expect(captured.instances.map((instance) => instance.requests.length)).toEqual(before);
+    await Promise.all([first.close(), second.close()]);
+  });
+
+  it('refreshes the catalog after switch_session resume and returns a separate fork catalog', async () => {
+    captured.catalogs.s1 = catalog('skill:resumed');
+    const resumeFile = path.join(cwd, 'resume.jsonl');
+    writeFileSync(resumeFile, '{}');
+    const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm', resumeSessionId: resumeFile });
+    const instance = captured.instances[0]!;
+    expect(instance.requests.filter((request) => request.type === 'switch_session')).toHaveLength(1);
+    expect(instance.requests.filter((request) => request.type === 'get_commands')).toHaveLength(1);
+    expect(handle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:resumed' }] });
+    await handle.close();
+
+    captured.catalogs[''] = catalog('skill:fork');
+    const fork = await new PiAgent(deps()).forkSdkSession({
+      sourceSdkSessionId: '/mock/source.jsonl', upToMessageId: undefined, workingDir: cwd,
+    });
+    expect(fork.runtimeCapabilities).toMatchObject({ status: 'loaded', commands: [{ name: 'skill:fork' }] });
+    expect(captured.instances.at(-1)?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(1);
+  });
+});

--- a/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
@@ -15,6 +15,7 @@ const captured = vi.hoisted(() => ({
   runtimeFailures: new Set<string>(),
   runtimeDeferred: false,
   runtimeRelease: undefined as (() => void) | undefined,
+  rewindStateFailure: false,
 }));
 
 vi.mock('../rpc-client.js', () => ({
@@ -39,6 +40,9 @@ vi.mock('../rpc-client.js', () => ({
     async request(command: Record<string, unknown>): Promise<{ type?: string; command?: string; success: boolean; data?: unknown; error?: string }> {
       this.state.requests.push(command);
       if (command.type === 'get_state') {
+        if (captured.rewindStateFailure && this.state.requests.some((request) => request.type === 'fork')) {
+          return { success: false, error: 'rewind state unavailable' };
+        }
         return { success: true, data: { sessionFile: this.state.sdkSessionId, model: { contextWindow: 200_000 } } };
       }
       if (command.type === 'get_commands') {
@@ -88,6 +92,7 @@ describe('Pi runtime capability lifecycle', () => {
     captured.runtimeFailures = new Set();
     captured.runtimeDeferred = false;
     captured.runtimeRelease = undefined;
+    captured.rewindStateFailure = false;
     home = mkdtempSync(path.join(tmpdir(), 'pi-runtime-home-'));
     cwd = mkdtempSync(path.join(tmpdir(), 'pi-runtime-cwd-'));
   });
@@ -188,6 +193,21 @@ describe('Pi runtime capability lifecycle', () => {
   });
 
   it('clears the old catalog immediately when rewind changes runtime identity', async () => {
+    captured.catalogs.s1 = catalog('skill:before-failed-rewind');
+    const failedHandle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
+    await vi.waitFor(() => {
+      expect(failedHandle.getRuntimeCapabilities?.()).toMatchObject({ status: 'loaded' });
+    });
+    const failedChanges: unknown[] = [];
+    failedHandle.onRuntimeCapabilitiesChange?.((manifest) => failedChanges.push(manifest));
+    captured.rewindStateFailure = true;
+    await expect(failedHandle.commitRewindFiles?.('', '', { tailTurnsToDrop: 1 }))
+      .rejects.toThrow('pi rewind get_state failed');
+    expect(failedHandle.getRuntimeCapabilities?.()).toBeUndefined();
+    expect(failedChanges.at(-1)).toBeUndefined();
+    await failedHandle.close();
+
+    captured.rewindStateFailure = false;
     captured.catalogs.s1 = catalog('skill:before-rewind');
     const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
     await vi.waitFor(() => {
@@ -218,7 +238,7 @@ describe('Pi runtime capability lifecycle', () => {
         commands: [{ name: 'skill:after-rewind' }],
       });
     });
-    expect(captured.instances[0]?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(2);
+    expect(captured.instances.at(-1)?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(2);
     await handle.close();
   });
 

--- a/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-runtime-capabilities.lifecycle.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const captured = vi.hoisted(() => ({
   instances: [] as Array<{
     sessionId: string;
+    sdkSessionId: string;
     requests: Array<Record<string, unknown>>;
     closed: boolean;
     onExit?: (info: { code: number | null; signal: string | null }) => void;
@@ -27,6 +28,7 @@ vi.mock('../rpc-client.js', () => ({
     }) {
       this.state = {
         sessionId: opts.env.CINDY_PI_SESSION_ID ?? '',
+        sdkSessionId: `/mock/${opts.env.CINDY_PI_SESSION_ID || 'fork'}.jsonl`,
         requests: [],
         closed: false,
         onExit: opts.onExit,
@@ -37,7 +39,7 @@ vi.mock('../rpc-client.js', () => ({
     async request(command: Record<string, unknown>): Promise<{ type?: string; command?: string; success: boolean; data?: unknown; error?: string }> {
       this.state.requests.push(command);
       if (command.type === 'get_state') {
-        return { success: true, data: { sessionFile: `/mock/${this.state.sessionId || 'fork'}.jsonl`, model: { contextWindow: 200_000 } } };
+        return { success: true, data: { sessionFile: this.state.sdkSessionId, model: { contextWindow: 200_000 } } };
       }
       if (command.type === 'get_commands') {
         if (captured.runtimeFailures.has(this.state.sessionId)) {
@@ -48,6 +50,13 @@ vi.mock('../rpc-client.js', () => ({
         }
         const data = captured.catalogs[this.state.sessionId] ?? { commands: [] };
         return { type: 'response', command: 'get_commands', success: true, data };
+      }
+      if (command.type === 'get_fork_messages') {
+        return { success: true, data: { messages: [{ entryId: 'rewind-entry' }] } };
+      }
+      if (command.type === 'fork') {
+        this.state.sdkSessionId = `/mock/${this.state.sessionId || 'fork'}-rewind.jsonl`;
+        return { success: true, data: {} };
       }
       if (command.type === 'switch_session') return { success: true, data: {} };
       if (command.type === 'clone') return { success: true, data: {} };
@@ -173,6 +182,39 @@ describe('Pi runtime capability lifecycle', () => {
     await agent.listAgentSkills({ workingDir: cwd });
     expect(captured.instances.map((instance) => instance.requests.length)).toEqual(before);
     await Promise.all([first.close(), second.close()]);
+  });
+
+  it('clears the old catalog immediately when rewind changes runtime identity', async () => {
+    captured.catalogs.s1 = catalog('skill:before-rewind');
+    const handle = await new PiAgent(deps()).startSession({ sessionId: 's1', workingDir: cwd, model: 'm' });
+    await vi.waitFor(() => {
+      expect(handle.getRuntimeCapabilities?.()).toMatchObject({
+        status: 'loaded',
+        sdkSessionId: '/mock/s1.jsonl',
+        commands: [{ name: 'skill:before-rewind' }],
+      });
+    });
+
+    const changes: unknown[] = [];
+    handle.onRuntimeCapabilitiesChange?.((manifest) => changes.push(manifest));
+    captured.runtimeDeferred = true;
+    captured.catalogs.s1 = catalog('skill:after-rewind');
+
+    const result = await handle.commitRewindFiles?.('', '', { tailTurnsToDrop: 1 });
+    expect(result?.sdkSessionId).toBe('/mock/s1-rewind.jsonl');
+    expect(handle.getRuntimeCapabilities?.()).toBeUndefined();
+    expect(changes).toEqual([undefined]);
+
+    captured.runtimeRelease?.();
+    await vi.waitFor(() => {
+      expect(handle.getRuntimeCapabilities?.()).toMatchObject({
+        status: 'loaded',
+        sdkSessionId: '/mock/s1-rewind.jsonl',
+        commands: [{ name: 'skill:after-rewind' }],
+      });
+    });
+    expect(captured.instances[0]?.requests.filter((request) => request.type === 'get_commands')).toHaveLength(2);
+    await handle.close();
   });
 
   it('refreshes the catalog after switch_session resume and returns a separate fork catalog', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
@@ -33,12 +33,22 @@ describe('Pi runtime capability parsing', () => {
     ['missing commands', {}],
     ['duplicate names', { commands: [command, command] }],
     ['missing sourceInfo', { commands: [{ ...command, sourceInfo: undefined }] }],
+    ['invalid known sourceInfo field', { commands: [{ ...command, sourceInfo: { source: 'auto', scope: 1 } }] }],
     ['unknown command field', { commands: [{ ...command, extra: 'secret' }] }],
     ['unknown sourceInfo field', { commands: [{ ...command, sourceInfo: { ...command.sourceInfo, extra: 'secret' } }] }],
     ['unknown response field', { commands: [command], extra: 'secret' }],
     ['oversized payload', { commands: [{ ...command, description: 'x'.repeat(4_097) }] }],
   ])('rejects conservative malformed case: %s', (_name, data) => {
     expect(parsePiRuntimeCommands(data)).toEqual({ ok: false });
+  });
+
+  it('rejects a catalog whose total serialized payload is oversized', () => {
+    const commands = Array.from({ length: 100 }, (_, index) => ({
+      ...command,
+      name: `skill:fixture-${index}`,
+      description: 'x'.repeat(3_000),
+    }));
+    expect(parsePiRuntimeCommands({ commands })).toEqual({ ok: false });
   });
 
   it('redacts rpc failures and classifies unsupported/timeout as unknown', async () => {
@@ -100,5 +110,29 @@ describe('Pi runtime capability parsing', () => {
       'ready',
     );
     expect(rejectedExit).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
+
+    const spawnFailure = await capturePiRuntimeCapabilityManifest(
+      { request: async () => { throw new Error('pi process error: spawn ENOENT'); } },
+      { sessionId: 's1' },
+      5,
+      'ready',
+    );
+    expect(spawnFailure).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
+  });
+
+  it.each([
+    ['non-object', null],
+    ['missing type', { command: 'get_commands', success: true, data: { commands: [command] } }],
+    ['missing success', { type: 'response', command: 'get_commands', data: { commands: [command] } }],
+    ['wrong command', { type: 'response', command: 'get_state', success: true, data: { commands: [command] } }],
+    ['unknown envelope field', { type: 'response', command: 'get_commands', success: true, data: { commands: [command] }, extra: 'secret' }],
+  ])('rejects malformed RPC response envelope: %s', async (_name, response) => {
+    const manifest = await capturePiRuntimeCapabilityManifest(
+      { request: async () => response as never },
+      { sessionId: 's1' },
+      1,
+      'ready',
+    );
+    expect(manifest).toMatchObject({ status: 'failed', error: { code: 'malformed_response' } });
   });
 });

--- a/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  capturePiRuntimeCapabilityManifest,
+  parsePiRuntimeCommands,
+} from '../runtime-capabilities.js';
+
+describe('Pi runtime capability parsing', () => {
+  const command = {
+    name: 'skill:fixture',
+    description: 'fixture skill',
+    source: 'skill',
+    sourceInfo: {
+      source: 'auto',
+      scope: 'user',
+      baseDir: '/private/user/pi-home',
+      path: '/private/user/pi-home/skills/fixture',
+    },
+  };
+
+  it('keeps stable command and provenance fields from a real-shaped response', () => {
+    expect(parsePiRuntimeCommands({ commands: [command] })).toEqual({
+      ok: true,
+      commands: [command],
+    });
+  });
+
+  it('accepts an authoritative empty catalog without treating it as scanner discovery', () => {
+    expect(parsePiRuntimeCommands({ commands: [] })).toEqual({ ok: true, commands: [] });
+  });
+
+  it.each([
+    ['missing commands', {}],
+    ['duplicate names', { commands: [command, command] }],
+    ['missing sourceInfo', { commands: [{ ...command, sourceInfo: undefined }] }],
+    ['unknown command field', { commands: [{ ...command, extra: 'secret' }] }],
+    ['unknown sourceInfo field', { commands: [{ ...command, sourceInfo: { ...command.sourceInfo, extra: 'secret' } }] }],
+    ['unknown response field', { commands: [command], extra: 'secret' }],
+    ['oversized payload', { commands: [{ ...command, description: 'x'.repeat(4_097) }] }],
+  ])('rejects conservative malformed case: %s', (_name, data) => {
+    expect(parsePiRuntimeCommands(data)).toEqual({ ok: false });
+  });
+
+  it('redacts rpc failures and classifies unsupported/timeout as unknown', async () => {
+    const loggerSpy = vi.fn();
+    const unsupported = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: '/secret/provider/path unsupported' }) },
+      { sessionId: 's1', sdkSessionId: '/private/session.jsonl' },
+      1,
+      'ready',
+    );
+    expect(unsupported).toMatchObject({
+      sessionId: 's1',
+      sdkSessionId: '/private/session.jsonl',
+      status: 'unknown',
+      error: { stage: 'ready', code: 'unsupported', message: 'Pi does not support runtime command discovery' },
+    });
+    expect(JSON.stringify(unsupported)).not.toContain('secret/provider/path');
+
+    const timedOut = await capturePiRuntimeCapabilityManifest(
+      { request: async () => { throw new Error('pi rpc timeout after 30000ms: get_commands /token=secret'); } },
+      { sessionId: 's2' },
+      2,
+      'ready',
+    );
+    expect(timedOut).toMatchObject({ status: 'unknown', error: { code: 'timeout' } });
+    expect(JSON.stringify(timedOut)).not.toContain('token=secret');
+    expect(loggerSpy).not.toHaveBeenCalled();
+  });
+
+  it('marks malformed and explicit rpc failures without throwing', async () => {
+    const malformed = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: true, data: { commands: [{ ...command, sourceInfo: {} }] } }) },
+      { sessionId: 's1' },
+      1,
+      'ready',
+    );
+    expect(malformed).toMatchObject({ status: 'failed', error: { code: 'malformed_response' } });
+
+    const failed = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: 'gateway failed' }) },
+      { sessionId: 's1' },
+      2,
+      'switch_session',
+    );
+    expect(failed).toMatchObject({ status: 'failed', error: { stage: 'switch_session', code: 'rpc_failed' } });
+  });
+});

--- a/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   capturePiRuntimeCapabilityManifest,
@@ -52,7 +52,6 @@ describe('Pi runtime capability parsing', () => {
   });
 
   it('redacts rpc failures and classifies unsupported/timeout as unknown', async () => {
-    const loggerSpy = vi.fn();
     const unsupported = await capturePiRuntimeCapabilityManifest(
       { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: '/secret/provider/path unsupported' }) },
       { sessionId: 's1', sdkSessionId: '/private/session.jsonl' },
@@ -75,7 +74,6 @@ describe('Pi runtime capability parsing', () => {
     );
     expect(timedOut).toMatchObject({ status: 'unknown', error: { code: 'timeout' } });
     expect(JSON.stringify(timedOut)).not.toContain('token=secret');
-    expect(loggerSpy).not.toHaveBeenCalled();
   });
 
   it('marks malformed and explicit rpc failures without throwing', async () => {

--- a/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
@@ -84,5 +84,21 @@ describe('Pi runtime capability parsing', () => {
       'switch_session',
     );
     expect(failed).toMatchObject({ status: 'failed', error: { stage: 'switch_session', code: 'rpc_failed' } });
+
+    const rejectedTimeout = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: 'timeout waiting for get_commands' }) },
+      { sessionId: 's1' },
+      3,
+      'ready',
+    );
+    expect(rejectedTimeout).toMatchObject({ status: 'unknown', error: { code: 'timeout' } });
+
+    const rejectedExit = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: 'process already exited' }) },
+      { sessionId: 's1' },
+      4,
+      'ready',
+    );
+    expect(rejectedExit).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
   });
 });

--- a/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/runtime-capabilities.test.ts
@@ -99,23 +99,63 @@ describe('Pi runtime capability parsing', () => {
       3,
       'ready',
     );
-    expect(rejectedTimeout).toMatchObject({ status: 'unknown', error: { code: 'timeout' } });
+    expect(rejectedTimeout).toMatchObject({ status: 'failed', error: { code: 'rpc_failed' } });
 
-    const rejectedExit = await capturePiRuntimeCapabilityManifest(
+    const rejectedProcessText = await capturePiRuntimeCapabilityManifest(
       { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: 'process already exited' }) },
       { sessionId: 's1' },
       4,
       'ready',
     );
-    expect(rejectedExit).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
+    expect(rejectedProcessText).toMatchObject({ status: 'failed', error: { code: 'rpc_failed' } });
 
-    const spawnFailure = await capturePiRuntimeCapabilityManifest(
-      { request: async () => { throw new Error('pi process error: spawn ENOENT'); } },
+    const rejectedClosed = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: 'account closed' }) },
       { sessionId: 's1' },
       5,
       'ready',
     );
-    expect(spawnFailure).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
+    expect(rejectedClosed).toMatchObject({ status: 'failed', error: { code: 'rpc_failed' } });
+
+    const rejectedSpawn = await capturePiRuntimeCapabilityManifest(
+      { request: async () => ({ type: 'response', command: 'get_commands', success: false, error: 'extension spawn policy rejected' }) },
+      { sessionId: 's1' },
+      6,
+      'ready',
+    );
+    expect(rejectedSpawn).toMatchObject({ status: 'failed', error: { code: 'rpc_failed' } });
+
+    const writeFailure = await capturePiRuntimeCapabilityManifest(
+      { request: async () => { throw new Error('pi rpc write failed: EPIPE'); } },
+      { sessionId: 's1' },
+      7,
+      'ready',
+    );
+    expect(writeFailure).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
+
+    const processError = await capturePiRuntimeCapabilityManifest(
+      { request: async () => { throw new Error('pi process error: spawn ENOENT'); } },
+      { sessionId: 's1' },
+      8,
+      'ready',
+    );
+    expect(processError).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
+
+    const processExit = await capturePiRuntimeCapabilityManifest(
+      { request: async () => { throw new Error('pi process exited (code=1, signal=null)'); } },
+      { sessionId: 's1' },
+      9,
+      'ready',
+    );
+    expect(processExit).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
+
+    const alreadyExited = await capturePiRuntimeCapabilityManifest(
+      { request: async () => { throw new Error('pi process already exited'); } },
+      { sessionId: 's1' },
+      10,
+      'ready',
+    );
+    expect(alreadyExited).toMatchObject({ status: 'unknown', error: { code: 'process_unavailable' } });
   });
 
   it.each([

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1438,8 +1438,13 @@ export class PiAgent extends BaseAgent {
     let sdkSessionId = '';
     const refreshRuntimeCapabilities = async (
       stage: 'ready' | 'switch_session' | 'fork',
+      clearCurrent = false,
     ): Promise<void> => {
       const generation = ++runtimeCapabilityGeneration;
+      // A runtime identity switch invalidates the old catalog immediately.
+      // This runs before the first await, so callers may keep discovery
+      // fire-and-forget without exposing commands from the previous runtime.
+      if (clearCurrent) publishRuntimeCapabilities(undefined);
       const manifest = await capturePiRuntimeCapabilityManifest(
         proc,
         {
@@ -2056,8 +2061,9 @@ export class PiAgent extends BaseAgent {
         queue.push({ type: 'session_id', data: replacement, source: 'pi' });
         // The Pi session has already switched to the replacement file. Do not
         // make rewind wait for optional discovery; the generation fence keeps
-        // this asynchronous refresh from publishing stale data.
-        void refreshRuntimeCapabilities('fork');
+        // this asynchronous refresh from publishing stale data. Clear the old
+        // catalog synchronously so it cannot be observed under the new id.
+        void refreshRuntimeCapabilities('fork', true);
         return { sdkSessionId: replacement };
       },
 

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -80,6 +80,7 @@ import { createAsyncQueue, type AsyncQueue } from '../shared/async-queue.js';
 import { resolveMcpToolTarget } from '../shared/mcp-tool-target.js';
 import { resolveAgentCredentialMode } from '../credential-mode.js';
 import { PiRpcProcess, type PiRpcEvent } from './rpc-client.js';
+import { capturePiRuntimeCapabilityManifest } from './runtime-capabilities.js';
 import {
   createPiTranslateContext,
   translatePiEvent,
@@ -93,6 +94,7 @@ import {
   piContextTokensFromTree,
   userDraftTextFromPiEntry,
 } from './session-tree.js';
+import type { PiRuntimeCapabilityManifest } from '../../types/pi-runtime-capabilities.js';
 
 const PI_PROVIDER_ID = 'cindy';
 // 既非 Cindy 网关(cindy/xd)也非订阅直连(openai/anthropic/xai)的 providerId = 显式 BYOM
@@ -1146,6 +1148,23 @@ export class PiAgent extends BaseAgent {
     // preparePiExtraSpawnConfig 注册、但 handle 尚未交出,close() 不会跑 → 单独
     // 兜底注销 ctx 再抛(构造失败没有 proc 可关)。catch 必抛,故其后 proc 恒已赋值。
     let proc: PiRpcProcess;
+    let runtimeCapabilityManifest: PiRuntimeCapabilityManifest | undefined;
+    let runtimeCapabilityGeneration = 0;
+    const runtimeCapabilityListeners = new Set<(
+      manifest: PiRuntimeCapabilityManifest | undefined,
+    ) => void>();
+    const publishRuntimeCapabilities = (manifest: PiRuntimeCapabilityManifest | undefined): void => {
+      runtimeCapabilityManifest = manifest;
+      for (const listener of runtimeCapabilityListeners) {
+        try {
+          listener(manifest);
+        } catch (error) {
+          this.deps.logger.warn('pi runtime capability listener failed (non-fatal)', {
+            message: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    };
     const proxySessionToken = randomBytes(32).toString('base64url');
     let disposeProxySession: (() => void) | undefined;
     // 幂等:onExit(进程异常退出)与 close()(用户结束)可能都调用它;首次注销后置位,
@@ -1281,6 +1300,9 @@ export class PiAgent extends BaseAgent {
         },
         onExit: ({ code, signal }) => {
           clearActiveTurnPermissionPolicy('process_exit', { dismissPending: true });
+          runtimeCapabilityGeneration++;
+          publishRuntimeCapabilities(undefined);
+          runtimeCapabilityListeners.clear();
           if (!closed) {
             // 非用户 close 的进程死亡:terminal error + 收尾,避免 UI 永久 running。
             queue.push({
@@ -1411,6 +1433,22 @@ export class PiAgent extends BaseAgent {
     // 身份注册(否则 ?session= ctx 泄漏)+ 关掉可能已 spawn 的子进程(否则僵尸 pi
     // 仍持有本会话的 MCP 路由),再把原始错误抛给调用方。
     let sdkSessionId = '';
+    const refreshRuntimeCapabilities = async (
+      stage: 'ready' | 'switch_session' | 'fork',
+    ): Promise<void> => {
+      const generation = ++runtimeCapabilityGeneration;
+      const manifest = await capturePiRuntimeCapabilityManifest(
+        proc,
+        {
+          ...(opts.sessionId ? { sessionId: opts.sessionId } : {}),
+          ...(sdkSessionId ? { sdkSessionId } : {}),
+        },
+        generation,
+        stage,
+      );
+      if (!closed && generation === runtimeCapabilityGeneration) publishRuntimeCapabilities(manifest);
+    };
+    let runtimeCaptureStage: 'ready' | 'switch_session' = 'ready';
     try {
       // Resume:pi 的会话钥匙是 session JSONL 绝对路径(get_state.sessionFile),
       // 落库 sdk_session_id 存的就是它;切换失败走 invalid-resume CAS 协定。
@@ -1443,6 +1481,8 @@ export class PiAgent extends BaseAgent {
               resumeSessionId: opts.resumeSessionId,
               error: switched.error,
             });
+          } else {
+            runtimeCaptureStage = 'switch_session';
           }
         }
       }
@@ -1477,6 +1517,11 @@ export class PiAgent extends BaseAgent {
       }
       sdkSessionId = stateData.sessionFile || stateData.sessionId || `pi-${Date.now()}`;
       queue.push({ type: 'session_id', data: sdkSessionId, source: 'pi' });
+
+      // get_state is the ready boundary. Capture exactly once after the final
+      // fresh/resumed runtime has been selected; list/customization calls never
+      // trigger this RPC.
+      await refreshRuntimeCapabilities(runtimeCaptureStage);
 
       // plan 镜像与 pi 持久态对齐(resume 关键):pi 的 plan-mode 扩展在 session_start 会从
       // session entry 自恢复 planModeEnabled,但不发 notify。若镜像固定为 false 而 pi 实为 true,
@@ -1689,6 +1734,11 @@ export class PiAgent extends BaseAgent {
       get id() { return sdkSessionId; },
       agentKind,
       get model() { return mutableModel; },
+      getRuntimeCapabilities() { return runtimeCapabilityManifest; },
+      onRuntimeCapabilitiesChange(listener) {
+        runtimeCapabilityListeners.add(listener);
+        return () => runtimeCapabilityListeners.delete(listener);
+      },
 
       // 每轮权限策略(IM 群 / 个人微信等)是 host 侧的 forceConfirmToolCall 回调,必须在
       // 工具执行前的审批边界强制执行。ask/auto 下 cindy-bridge 会把非只读内置工具与桥接
@@ -1780,6 +1830,9 @@ export class PiAgent extends BaseAgent {
 
       async close(): Promise<void> {
         closed = true;
+        runtimeCapabilityGeneration++;
+        publishRuntimeCapabilities(undefined);
+        runtimeCapabilityListeners.clear();
         // 会话结束时挂起的卡已经不可能有人回答:清 policy 并强制 deny,别让等它的调用
         // 悬着(同 CC / Codex)。
         clearActiveTurnPermissionPolicy('session_closed', { dismissPending: true });
@@ -1995,6 +2048,7 @@ export class PiAgent extends BaseAgent {
         if (!replacement) throw new Error('pi rewind replacement session path unavailable');
         sdkSessionId = replacement;
         queue.push({ type: 'session_id', data: replacement, source: 'pi' });
+        await refreshRuntimeCapabilities('fork');
         return { sdkSessionId: replacement };
       },
 
@@ -2248,13 +2302,20 @@ export class PiAgent extends BaseAgent {
           );
       }
 
+      const runtimeCapabilities = await capturePiRuntimeCapabilityManifest(
+        proc,
+        { sdkSessionId: newPath },
+        1,
+        'fork',
+      );
+
       log.info('pi forkSdkSession ◀', {
         source: opts.sourceSdkSessionId,
         newSdkSessionId: newPath,
         tailTurnsToDrop: tailDrop,
       });
       // uuidMap 空:与 Codex 一致,pi agentMeta 不存 SDK message uuid。
-      return { newSdkSessionId: newPath, uuidMap: new Map() };
+      return { newSdkSessionId: newPath, uuidMap: new Map(), runtimeCapabilities };
     } finally {
       await proc.close();
       // 清理隔离的 fork 家目录(只含 models.json;新分支 session 文件在共享 sessions,不受影响)。

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -426,6 +426,9 @@ export class PiAgent extends BaseAgent {
       // pi 原生 compact RPC:手动压缩(可带聚焦指令,调 LLM 生成摘要)。
       // 斜杠转义后用户无法手输 /compact,此能力是 pi 会话手动压缩的唯一入口。
       manualCompact: { supported: true },
+      // Pi 的 get_commands runtime catalog 通过 per-session handle 查询；
+      // manifest 本身在 ready/fork 后异步采集，暂不可用不代表能力不支持。
+      runtimeCapabilities: { supported: true },
     };
   }
 
@@ -1521,7 +1524,10 @@ export class PiAgent extends BaseAgent {
       // get_state is the ready boundary. Capture exactly once after the final
       // fresh/resumed runtime has been selected; list/customization calls never
       // trigger this RPC.
-      await refreshRuntimeCapabilities(runtimeCaptureStage);
+      // Capability discovery is optional and must not delay session creation.
+      // The ready boundary has selected the final Pi session identity; publish
+      // the result later through the per-session query/listener contract.
+      void refreshRuntimeCapabilities(runtimeCaptureStage);
 
       // plan 镜像与 pi 持久态对齐(resume 关键):pi 的 plan-mode 扩展在 session_start 会从
       // session entry 自恢复 planModeEnabled,但不发 notify。若镜像固定为 false 而 pi 实为 true,
@@ -2048,7 +2054,10 @@ export class PiAgent extends BaseAgent {
         if (!replacement) throw new Error('pi rewind replacement session path unavailable');
         sdkSessionId = replacement;
         queue.push({ type: 'session_id', data: replacement, source: 'pi' });
-        await refreshRuntimeCapabilities('fork');
+        // The Pi session has already switched to the replacement file. Do not
+        // make rewind wait for optional discovery; the generation fence keeps
+        // this asynchronous refresh from publishing stale data.
+        void refreshRuntimeCapabilities('fork');
         return { sdkSessionId: replacement };
       },
 
@@ -2302,20 +2311,16 @@ export class PiAgent extends BaseAgent {
           );
       }
 
-      const runtimeCapabilities = await capturePiRuntimeCapabilityManifest(
-        proc,
-        { sdkSessionId: newPath },
-        1,
-        'fork',
-      );
-
       log.info('pi forkSdkSession ◀', {
         source: opts.sourceSdkSessionId,
         newSdkSessionId: newPath,
         tailTurnsToDrop: tailDrop,
       });
       // uuidMap 空:与 Codex 一致,pi agentMeta 不存 SDK message uuid。
-      return { newSdkSessionId: newPath, uuidMap: new Map(), runtimeCapabilities };
+      // This short-lived control-plane process is closed immediately. The
+      // newly created live session will capture its own authoritative catalog
+      // at ready; do not hold this fork path for an optional 5s RPC timeout.
+      return { newSdkSessionId: newPath, uuidMap: new Map() };
     } finally {
       await proc.close();
       // 清理隔离的 fork 家目录(只含 models.json;新分支 session 文件在共享 sessions,不受影响)。

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1444,13 +1444,8 @@ export class PiAgent extends BaseAgent {
     let sdkSessionId = '';
     const refreshRuntimeCapabilities = async (
       stage: 'ready' | 'switch_session' | 'fork',
-      clearCurrent = false,
     ): Promise<void> => {
       const generation = ++runtimeCapabilityGeneration;
-      // A runtime identity switch invalidates the old catalog immediately.
-      // This runs before the first await, so callers may keep discovery
-      // fire-and-forget without exposing commands from the previous runtime.
-      if (clearCurrent) publishRuntimeCapabilities(undefined);
       const manifest = await capturePiRuntimeCapabilityManifest(
         proc,
         {
@@ -2066,6 +2061,10 @@ export class PiAgent extends BaseAgent {
         }
         const forked = await proc.request({ type: 'fork', entryId });
         if (!forked.success) throw new Error(`pi rewind fork failed: ${forked.error ?? 'unknown'}`);
+        // Pi has switched runtime identity at the successful fork response. Clear
+        // the old catalog before any follow-up get_state can fail or time out.
+        runtimeCapabilityGeneration++;
+        publishRuntimeCapabilities(undefined);
         const state = await proc.request({ type: 'get_state' });
         if (!state.success) throw new Error(`pi rewind get_state failed: ${state.error ?? 'unknown'}`);
         const replacement = (state.data as { sessionFile?: string } | undefined)?.sessionFile;
@@ -2074,9 +2073,8 @@ export class PiAgent extends BaseAgent {
         queue.push({ type: 'session_id', data: replacement, source: 'pi' });
         // The Pi session has already switched to the replacement file. Do not
         // make rewind wait for optional discovery; the generation fence keeps
-        // this asynchronous refresh from publishing stale data. Clear the old
-        // catalog synchronously so it cannot be observed under the new id.
-        void refreshRuntimeCapabilities('fork', true);
+        // this asynchronous refresh from publishing stale data.
+        void refreshRuntimeCapabilities('fork');
         return { sdkSessionId: replacement };
       },
 

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -1156,16 +1156,22 @@ export class PiAgent extends BaseAgent {
     const runtimeCapabilityListeners = new Set<(
       manifest: PiRuntimeCapabilityManifest | undefined,
     ) => void>();
+    const notifyRuntimeCapabilityListener = (
+      listener: (manifest: PiRuntimeCapabilityManifest | undefined) => void,
+      manifest: PiRuntimeCapabilityManifest | undefined,
+    ): void => {
+      try {
+        listener(manifest);
+      } catch (error) {
+        this.deps.logger.warn('pi runtime capability listener failed (non-fatal)', {
+          message: error instanceof Error ? error.message : String(error),
+        });
+      }
+    };
     const publishRuntimeCapabilities = (manifest: PiRuntimeCapabilityManifest | undefined): void => {
       runtimeCapabilityManifest = manifest;
       for (const listener of runtimeCapabilityListeners) {
-        try {
-          listener(manifest);
-        } catch (error) {
-          this.deps.logger.warn('pi runtime capability listener failed (non-fatal)', {
-            message: error instanceof Error ? error.message : String(error),
-          });
-        }
+        notifyRuntimeCapabilityListener(listener, manifest);
       }
     };
     const proxySessionToken = randomBytes(32).toString('base64url');
@@ -1747,7 +1753,14 @@ export class PiAgent extends BaseAgent {
       get model() { return mutableModel; },
       getRuntimeCapabilities() { return runtimeCapabilityManifest; },
       onRuntimeCapabilitiesChange(listener) {
+        if (closed) {
+          notifyRuntimeCapabilityListener(listener, undefined);
+          return () => undefined;
+        }
         runtimeCapabilityListeners.add(listener);
+        // Replay the current snapshot synchronously so late subscribers cannot
+        // miss an async ready/rewind capture that completed before registration.
+        notifyRuntimeCapabilityListener(listener, runtimeCapabilityManifest);
         return () => runtimeCapabilityListeners.delete(listener);
       },
 

--- a/packages/maker-core/src/agents/pi/runtime-capabilities.ts
+++ b/packages/maker-core/src/agents/pi/runtime-capabilities.ts
@@ -105,6 +105,12 @@ function classifyFailure(raw: string): Pick<PiRuntimeCapabilityError, 'code' | '
   return { code: 'rpc_failed', message: 'Pi runtime command discovery was rejected' };
 }
 
+function statusForFailureCode(code: PiRuntimeCapabilityError['code']): 'unknown' | 'failed' {
+  return code === 'unsupported' || code === 'timeout' || code === 'process_unavailable'
+    ? 'unknown'
+    : 'failed';
+}
+
 function errorManifest(
   identity: { sessionId?: string; sdkSessionId?: string },
   generation: number,
@@ -142,7 +148,7 @@ export async function capturePiRuntimeCapabilityManifest(
     );
     if (!response || response.success !== true) {
       const failure = classifyFailure(typeof response?.error === 'string' ? response.error : 'rpc rejected');
-      return errorManifest(identity, generation, stage, failure, failure.code === 'unsupported' ? 'unknown' : 'failed');
+      return errorManifest(identity, generation, stage, failure, statusForFailureCode(failure.code));
     }
     const parsed = parsePiRuntimeCommands(response.data);
     if (!parsed.ok) {
@@ -162,9 +168,6 @@ export async function capturePiRuntimeCapabilityManifest(
     };
   } catch (error) {
     const failure = classifyFailure(error instanceof Error ? error.message : 'rpc failed');
-    const status = failure.code === 'unsupported' || failure.code === 'timeout' || failure.code === 'process_unavailable'
-      ? 'unknown'
-      : 'failed';
-    return errorManifest(identity, generation, stage, failure, status);
+    return errorManifest(identity, generation, stage, failure, statusForFailureCode(failure.code));
   }
 }

--- a/packages/maker-core/src/agents/pi/runtime-capabilities.ts
+++ b/packages/maker-core/src/agents/pi/runtime-capabilities.ts
@@ -1,0 +1,170 @@
+import type { PiRpcResponse } from './rpc-client.js';
+import type {
+  PiRuntimeCapabilityError,
+  PiRuntimeCapabilityErrorStage,
+  PiRuntimeCapabilityManifest,
+  PiRuntimeCommand,
+  PiRuntimeCommandSourceInfo,
+} from '../../types/pi-runtime-capabilities.js';
+
+const MAX_RESPONSE_BYTES = 256_000;
+const MAX_COMMANDS = 4_096;
+const MAX_NAME_LENGTH = 256;
+const MAX_DESCRIPTION_LENGTH = 4_096;
+const MAX_SOURCE_LENGTH = 128;
+const MAX_SOURCE_INFO_VALUE_LENGTH = 4_096;
+const MAX_ERROR_MESSAGE_LENGTH = 160;
+export const PI_RUNTIME_CAPABILITY_TIMEOUT_MS = 5_000;
+
+type RuntimeCommandParseResult =
+  | { ok: true; commands: PiRuntimeCommand[] }
+  | { ok: false };
+
+function boundedString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string' || value.trim().length === 0 || value.length > maxLength) return undefined;
+  return value;
+}
+
+function parseSourceInfo(value: unknown): PiRuntimeCommandSourceInfo | undefined {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  if (Object.keys(raw).some((key) => !['path', 'scope', 'baseDir', 'source', 'origin'].includes(key))) return undefined;
+  const path = boundedString(raw.path, MAX_SOURCE_INFO_VALUE_LENGTH);
+  const scope = boundedString(raw.scope, MAX_SOURCE_INFO_VALUE_LENGTH);
+  const baseDir = boundedString(raw.baseDir, MAX_SOURCE_INFO_VALUE_LENGTH);
+  const source = boundedString(raw.source, MAX_SOURCE_INFO_VALUE_LENGTH);
+  const origin = boundedString(raw.origin, MAX_SOURCE_INFO_VALUE_LENGTH);
+  // A sourceInfo object with no recognized provenance is not trustworthy enough
+  // to mark the command catalog loaded.
+  if (!path && !scope && !baseDir && !source) return undefined;
+  return {
+    ...(path ? { path } : {}),
+    ...(scope ? { scope } : {}),
+    ...(baseDir ? { baseDir } : {}),
+    ...(source ? { source } : {}),
+    ...(origin ? { origin } : {}),
+  };
+}
+
+/** Conservative parser for Pi's get_commands `data.commands` payload. */
+export function parsePiRuntimeCommands(data: unknown): RuntimeCommandParseResult {
+  if (data === null || typeof data !== 'object' || Array.isArray(data)) return { ok: false };
+  let serializedLength = 0;
+  try {
+    const serialized = JSON.stringify(data);
+    if (typeof serialized !== 'string') return { ok: false };
+    serializedLength = Buffer.byteLength(serialized, 'utf8');
+  } catch {
+    return { ok: false };
+  }
+  if (serializedLength > MAX_RESPONSE_BYTES) return { ok: false };
+
+  const rawData = data as Record<string, unknown>;
+  if (Object.keys(rawData).some((key) => key !== 'commands')) return { ok: false };
+  const commands = rawData.commands;
+  if (!Array.isArray(commands) || commands.length > MAX_COMMANDS) return { ok: false };
+
+  const seen = new Set<string>();
+  const parsed: PiRuntimeCommand[] = [];
+  for (const value of commands) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) return { ok: false };
+    const raw = value as Record<string, unknown>;
+    if (Object.keys(raw).some((key) => !['name', 'description', 'source', 'sourceInfo'].includes(key))) {
+      return { ok: false };
+    }
+    const name = boundedString(raw.name, MAX_NAME_LENGTH);
+    const source = boundedString(raw.source, MAX_SOURCE_LENGTH);
+    const sourceInfo = parseSourceInfo(raw.sourceInfo);
+    if (!name || !source || !sourceInfo || seen.has(name)) return { ok: false };
+    const description = raw.description === undefined
+      ? undefined
+      : boundedString(raw.description, MAX_DESCRIPTION_LENGTH);
+    if (raw.description !== undefined && !description) return { ok: false };
+    seen.add(name);
+    parsed.push({
+      name,
+      ...(description ? { description } : {}),
+      source,
+      sourceInfo,
+    });
+  }
+  return { ok: true, commands: parsed };
+}
+
+function classifyFailure(raw: string): Pick<PiRuntimeCapabilityError, 'code' | 'message'> {
+  const text = raw.toLowerCase();
+  if (text.includes('unknown command') || text.includes('unsupported') || text.includes('not supported')) {
+    return { code: 'unsupported', message: 'Pi does not support runtime command discovery' };
+  }
+  if (text.includes('timeout')) {
+    return { code: 'timeout', message: 'Pi runtime command discovery timed out' };
+  }
+  if (text.includes('already exited') || text.includes('process exited') || text.includes('not ready')) {
+    return { code: 'process_unavailable', message: 'Pi process was unavailable for runtime command discovery' };
+  }
+  return { code: 'rpc_failed', message: 'Pi runtime command discovery was rejected' };
+}
+
+function errorManifest(
+  identity: { sessionId?: string; sdkSessionId?: string },
+  generation: number,
+  stage: PiRuntimeCapabilityErrorStage,
+  failure: Pick<PiRuntimeCapabilityError, 'code' | 'message'>,
+  status: 'unknown' | 'failed',
+): PiRuntimeCapabilityManifest {
+  return {
+    ...(identity.sessionId ? { sessionId: identity.sessionId } : {}),
+    ...(identity.sdkSessionId ? { sdkSessionId: identity.sdkSessionId } : {}),
+    capturedAt: new Date().toISOString(),
+    generation,
+    status,
+    source: 'pi:get_commands',
+    commands: [],
+    error: { stage, ...failure, message: failure.message.slice(0, MAX_ERROR_MESSAGE_LENGTH) },
+  };
+}
+
+export async function capturePiRuntimeCapabilityManifest(
+  requester: {
+    request(
+      command: Record<string, unknown>,
+      options?: { timeoutMs?: number },
+    ): Promise<PiRpcResponse>;
+  },
+  identity: { sessionId?: string; sdkSessionId?: string },
+  generation: number,
+  stage: PiRuntimeCapabilityErrorStage,
+): Promise<PiRuntimeCapabilityManifest> {
+  try {
+    const response = await requester.request(
+      { type: 'get_commands' },
+      { timeoutMs: PI_RUNTIME_CAPABILITY_TIMEOUT_MS },
+    );
+    if (!response || response.success !== true) {
+      const failure = classifyFailure(typeof response?.error === 'string' ? response.error : 'rpc rejected');
+      return errorManifest(identity, generation, stage, failure, failure.code === 'unsupported' ? 'unknown' : 'failed');
+    }
+    const parsed = parsePiRuntimeCommands(response.data);
+    if (!parsed.ok) {
+      return errorManifest(identity, generation, stage, {
+        code: 'malformed_response',
+        message: 'Pi returned an invalid runtime command catalog',
+      }, 'failed');
+    }
+    return {
+      ...(identity.sessionId ? { sessionId: identity.sessionId } : {}),
+      ...(identity.sdkSessionId ? { sdkSessionId: identity.sdkSessionId } : {}),
+      capturedAt: new Date().toISOString(),
+      generation,
+      status: 'loaded',
+      source: 'pi:get_commands',
+      commands: parsed.commands,
+    };
+  } catch (error) {
+    const failure = classifyFailure(error instanceof Error ? error.message : 'rpc failed');
+    const status = failure.code === 'unsupported' || failure.code === 'timeout' || failure.code === 'process_unavailable'
+      ? 'unknown'
+      : 'failed';
+    return errorManifest(identity, generation, stage, failure, status);
+  }
+}

--- a/packages/maker-core/src/agents/pi/runtime-capabilities.ts
+++ b/packages/maker-core/src/agents/pi/runtime-capabilities.ts
@@ -97,21 +97,24 @@ export function parsePiRuntimeCommands(data: unknown): RuntimeCommandParseResult
   return { ok: true, commands: parsed };
 }
 
-function classifyFailure(raw: string): Pick<PiRuntimeCapabilityError, 'code' | 'message'> {
+function classifyExplicitRpcFailure(raw: string): Pick<PiRuntimeCapabilityError, 'code' | 'message'> {
   const text = raw.toLowerCase();
   if (text.includes('unknown command') || text.includes('unsupported') || text.includes('not supported')) {
     return { code: 'unsupported', message: 'Pi does not support runtime command discovery' };
   }
-  if (text.includes('timeout')) {
+  return { code: 'rpc_failed', message: 'Pi runtime command discovery was rejected' };
+}
+
+function classifyTransportFailure(raw: string): Pick<PiRuntimeCapabilityError, 'code' | 'message'> {
+  const text = raw.toLowerCase();
+  if (text.startsWith('pi rpc timeout after ')) {
     return { code: 'timeout', message: 'Pi runtime command discovery timed out' };
   }
   if (
-    text.includes('already exited')
-    || text.includes('process exited')
-    || text.includes('process error')
-    || text.includes('not ready')
-    || text.includes('spawn')
-    || text.includes('closed')
+    text.startsWith('pi process already exited')
+    || text.startsWith('pi process exited (')
+    || text.startsWith('pi process error:')
+    || text.startsWith('pi rpc write failed:')
   ) {
     return { code: 'process_unavailable', message: 'Pi process was unavailable for runtime command discovery' };
   }
@@ -186,7 +189,7 @@ export async function capturePiRuntimeCapabilityManifest(
     }
     const typedResponse = responseRecord as unknown as PiRpcResponse;
     if (!typedResponse.success) {
-      const failure = classifyFailure(typeof typedResponse.error === 'string' ? typedResponse.error : 'rpc rejected');
+      const failure = classifyExplicitRpcFailure(typeof typedResponse.error === 'string' ? typedResponse.error : 'rpc rejected');
       return errorManifest(identity, generation, stage, failure, statusForFailureCode(failure.code));
     }
     const parsed = parsePiRuntimeCommands(typedResponse.data);
@@ -206,7 +209,7 @@ export async function capturePiRuntimeCapabilityManifest(
       commands: parsed.commands,
     };
   } catch (error) {
-    const failure = classifyFailure(error instanceof Error ? error.message : 'rpc failed');
+    const failure = classifyTransportFailure(error instanceof Error ? error.message : 'rpc failed');
     return errorManifest(identity, generation, stage, failure, statusForFailureCode(failure.code));
   }
 }

--- a/packages/maker-core/src/agents/pi/runtime-capabilities.ts
+++ b/packages/maker-core/src/agents/pi/runtime-capabilities.ts
@@ -15,6 +15,7 @@ const MAX_SOURCE_LENGTH = 128;
 const MAX_SOURCE_INFO_VALUE_LENGTH = 4_096;
 const MAX_ERROR_MESSAGE_LENGTH = 160;
 export const PI_RUNTIME_CAPABILITY_TIMEOUT_MS = 5_000;
+const PI_RPC_RESPONSE_KEYS = new Set(['type', 'id', 'command', 'success', 'data', 'error']);
 
 type RuntimeCommandParseResult =
   | { ok: true; commands: PiRuntimeCommand[] }
@@ -29,6 +30,11 @@ function parseSourceInfo(value: unknown): PiRuntimeCommandSourceInfo | undefined
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined;
   const raw = value as Record<string, unknown>;
   if (Object.keys(raw).some((key) => !['path', 'scope', 'baseDir', 'source', 'origin'].includes(key))) return undefined;
+  for (const key of ['path', 'scope', 'baseDir', 'source', 'origin'] as const) {
+    if (Object.hasOwn(raw, key) && !boundedString(raw[key], MAX_SOURCE_INFO_VALUE_LENGTH)) {
+      return undefined;
+    }
+  }
   const path = boundedString(raw.path, MAX_SOURCE_INFO_VALUE_LENGTH);
   const scope = boundedString(raw.scope, MAX_SOURCE_INFO_VALUE_LENGTH);
   const baseDir = boundedString(raw.baseDir, MAX_SOURCE_INFO_VALUE_LENGTH);
@@ -99,7 +105,14 @@ function classifyFailure(raw: string): Pick<PiRuntimeCapabilityError, 'code' | '
   if (text.includes('timeout')) {
     return { code: 'timeout', message: 'Pi runtime command discovery timed out' };
   }
-  if (text.includes('already exited') || text.includes('process exited') || text.includes('not ready')) {
+  if (
+    text.includes('already exited')
+    || text.includes('process exited')
+    || text.includes('process error')
+    || text.includes('not ready')
+    || text.includes('spawn')
+    || text.includes('closed')
+  ) {
     return { code: 'process_unavailable', message: 'Pi process was unavailable for runtime command discovery' };
   }
   return { code: 'rpc_failed', message: 'Pi runtime command discovery was rejected' };
@@ -146,11 +159,37 @@ export async function capturePiRuntimeCapabilityManifest(
       { type: 'get_commands' },
       { timeoutMs: PI_RUNTIME_CAPABILITY_TIMEOUT_MS },
     );
-    if (!response || response.success !== true) {
-      const failure = classifyFailure(typeof response?.error === 'string' ? response.error : 'rpc rejected');
+    const rawResponse = response as unknown;
+    if (
+      typeof rawResponse !== 'object'
+      || rawResponse === null
+      || Array.isArray(rawResponse)
+    ) {
+      return errorManifest(identity, generation, stage, {
+        code: 'malformed_response',
+        message: 'Pi returned an invalid runtime command response',
+      }, 'failed');
+    }
+    const responseRecord = rawResponse as Record<string, unknown>;
+    if (
+      Object.keys(responseRecord).some((key) => !PI_RPC_RESPONSE_KEYS.has(key))
+      || responseRecord.type !== 'response'
+      || responseRecord.command !== 'get_commands'
+      || typeof responseRecord.success !== 'boolean'
+      || (responseRecord.id !== undefined && typeof responseRecord.id !== 'string')
+      || (responseRecord.error !== undefined && typeof responseRecord.error !== 'string')
+    ) {
+      return errorManifest(identity, generation, stage, {
+        code: 'malformed_response',
+        message: 'Pi returned an invalid runtime command response',
+      }, 'failed');
+    }
+    const typedResponse = responseRecord as unknown as PiRpcResponse;
+    if (!typedResponse.success) {
+      const failure = classifyFailure(typeof typedResponse.error === 'string' ? typedResponse.error : 'rpc rejected');
       return errorManifest(identity, generation, stage, failure, statusForFailureCode(failure.code));
     }
-    const parsed = parsePiRuntimeCommands(response.data);
+    const parsed = parsePiRuntimeCommands(typedResponse.data);
     if (!parsed.ok) {
       return errorManifest(identity, generation, stage, {
         code: 'malformed_response',

--- a/packages/maker-core/src/agents/pi/runtime-capabilities.ts
+++ b/packages/maker-core/src/agents/pi/runtime-capabilities.ts
@@ -55,6 +55,11 @@ function parseSourceInfo(value: unknown): PiRuntimeCommandSourceInfo | undefined
 /** Conservative parser for Pi's get_commands `data.commands` payload. */
 export function parsePiRuntimeCommands(data: unknown): RuntimeCommandParseResult {
   if (data === null || typeof data !== 'object' || Array.isArray(data)) return { ok: false };
+  const rawData = data as Record<string, unknown>;
+  if (Object.keys(rawData).some((key) => key !== 'commands')) return { ok: false };
+  const commands = rawData.commands;
+  if (!Array.isArray(commands) || commands.length > MAX_COMMANDS) return { ok: false };
+
   let serializedLength = 0;
   try {
     const serialized = JSON.stringify(data);
@@ -64,11 +69,6 @@ export function parsePiRuntimeCommands(data: unknown): RuntimeCommandParseResult
     return { ok: false };
   }
   if (serializedLength > MAX_RESPONSE_BYTES) return { ok: false };
-
-  const rawData = data as Record<string, unknown>;
-  if (Object.keys(rawData).some((key) => key !== 'commands')) return { ok: false };
-  const commands = rawData.commands;
-  if (!Array.isArray(commands) || commands.length > MAX_COMMANDS) return { ok: false };
 
   const seen = new Set<string>();
   const parsed: PiRuntimeCommand[] = [];

--- a/packages/maker-core/src/maker.ts
+++ b/packages/maker-core/src/maker.ts
@@ -31,6 +31,7 @@ import type {
   ListCustomizationsOptions,
   ListCustomizationsResult,
 } from './types/customizations.js';
+import type { PiRuntimeCapabilityManifest } from './types/pi-runtime-capabilities.js';
 import { Session, generateSessionId } from './session.js';
 import type {
   AgentSessionHandle,
@@ -640,6 +641,19 @@ export class Maker {
   /** 拿到一个已激活的 session（不发起恢复） */
   getSession(id: string): Session | undefined {
     return this.activeSessions.get(id);
+  }
+
+  /** Read a live session's per-runtime Pi capability snapshot without creating or resuming it. */
+  getSessionRuntimeCapabilities(id: string): PiRuntimeCapabilityManifest | undefined {
+    return this.activeSessions.get(id)?.getRuntimeCapabilities();
+  }
+
+  /** Subscribe to a live session's per-runtime Pi catalog without sharing state across sessions. */
+  onSessionRuntimeCapabilitiesChange(
+    id: string,
+    listener: (manifest: PiRuntimeCapabilityManifest | undefined) => void,
+  ): () => void {
+    return this.activeSessions.get(id)?.onRuntimeCapabilitiesChange(listener) ?? (() => undefined);
   }
 
   /**

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -42,6 +42,7 @@ import type {
 } from './types/events.js';
 import { isTerminalAgentErrorEvent } from './types/events.js';
 import type { ContextUsageData } from './types/context-usage.js';
+import type { PiRuntimeCapabilityManifest } from './types/pi-runtime-capabilities.js';
 import type {
   AgentSessionHandle,
   BackgroundTaskSnapshot,
@@ -717,6 +718,18 @@ export class Session {
 
   getUsageSnapshot(): UsageSnapshot {
     return this.handle.getUsageSnapshot();
+  }
+
+  /** Return the current per-session Pi runtime capability snapshot, if exposed. */
+  getRuntimeCapabilities(): PiRuntimeCapabilityManifest | undefined {
+    return this.handle.getRuntimeCapabilities?.();
+  }
+
+  /** Subscribe to replacement of the current per-session Pi runtime catalog. */
+  onRuntimeCapabilitiesChange(
+    listener: (manifest: PiRuntimeCapabilityManifest | undefined) => void,
+  ): () => void {
+    return this.handle.onRuntimeCapabilitiesChange?.(listener) ?? (() => undefined);
   }
 
   async getContextUsage(): Promise<ContextUsageData> {

--- a/packages/maker-core/src/types/capabilities.ts
+++ b/packages/maker-core/src/types/capabilities.ts
@@ -74,6 +74,12 @@ export interface Capabilities {
   multimodal: MultimodalCapability;
 
   /** Session 操作 */
+  /**
+   * Pi runtime command catalog queried from the live session. This is a
+   * capability of the session contract; the manifest itself may still be
+   * undefined while discovery is pending or unavailable.
+   */
+  runtimeCapabilities?: CapabilityStatus;
   fork: CapabilityStatus;
   rewind: CapabilityStatus;
   /** 同一 SDK session 内的原生分支树；与创建独立 Cindy 会话的 fork 正交。 */

--- a/packages/maker-core/src/types/events.ts
+++ b/packages/maker-core/src/types/events.ts
@@ -10,6 +10,7 @@
  */
 
 import type { WorkflowProgressEntry } from '@cindy/maker-shared/agent-task';
+import type { PiRuntimeCapabilityManifest } from './pi-runtime-capabilities.js';
 
 export type AgentEventType =
   | 'text'                  // 流式文本输出（增量或完整）
@@ -394,4 +395,6 @@ export interface ForkSdkSessionResult {
    * upToMessageId 锚点能在新 jsonl 里查到。
    */
   uuidMap: Map<string, string>;
+  /** Pi-only runtime command catalog captured from the forked runtime, if available. */
+  runtimeCapabilities?: PiRuntimeCapabilityManifest;
 }

--- a/packages/maker-core/src/types/index.ts
+++ b/packages/maker-core/src/types/index.ts
@@ -5,5 +5,6 @@ export * from './events.js';
 export * from './permissions.js';
 export * from './palette.js';
 export * from './customizations.js';
+export * from './pi-runtime-capabilities.js';
 export * from './memory.js';
 export * from './account-rate-limits.js';

--- a/packages/maker-core/src/types/pi-runtime-capabilities.ts
+++ b/packages/maker-core/src/types/pi-runtime-capabilities.ts
@@ -1,0 +1,63 @@
+/**
+ * Pi runtime capability facts.
+ *
+ * This is deliberately separate from customization discovery: a filesystem
+ * scanner can report `discovered`, while only Pi's `get_commands` response can
+ * report `loaded`.
+ */
+
+export type PiRuntimeCapabilityStatus =
+  | 'discovered'
+  | 'approved'
+  | 'loaded'
+  | 'failed'
+  | 'unknown';
+
+export type PiRuntimeCapabilitySource = 'pi:get_commands';
+
+export type PiRuntimeCapabilityErrorStage = 'ready' | 'switch_session' | 'fork';
+
+export interface PiRuntimeCapabilityError {
+  stage: PiRuntimeCapabilityErrorStage;
+  code:
+    | 'unsupported'
+    | 'timeout'
+    | 'process_unavailable'
+    | 'rpc_failed'
+    | 'malformed_response';
+  /** Bounded, provider/auth/path-redacted diagnostic text. */
+  message: string;
+}
+
+/** Stable provenance fields exposed by Pi's command catalog. */
+export interface PiRuntimeCommandSourceInfo {
+  path?: string;
+  scope?: string;
+  baseDir?: string;
+  source?: string;
+  origin?: string;
+}
+
+export interface PiRuntimeCommand {
+  name: string;
+  description?: string;
+  source: string;
+  sourceInfo: PiRuntimeCommandSourceInfo;
+}
+
+/**
+ * Per-session runtime catalog snapshot. All fields are optional at call sites
+ * through the AgentSessionHandle contract, so old consumers remain compatible.
+ */
+export interface PiRuntimeCapabilityManifest {
+  /** Existing Cindy business session key, when the caller supplied one. */
+  sessionId?: string;
+  /** Existing Pi SDK/session file key; no new cross-layer identity is created. */
+  sdkSessionId?: string;
+  capturedAt: string;
+  generation: number;
+  status: PiRuntimeCapabilityStatus;
+  source: PiRuntimeCapabilitySource;
+  commands: readonly PiRuntimeCommand[];
+  error?: PiRuntimeCapabilityError;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

这是 tracking issue [#1991] 的 **PR1**，对应子 Issue [#2011]。#1991 要解决的是：Cindy 为每个 Pi 会话隔离 `PI_CODING_AGENT_DIR`，但现有文件系统 scanner 的“发现结果”没有运行时权威来源，导致上层无法知道某个资源是否真的被当前 Pi 会话加载。

本 PR 接入 Pi `get_commands` RPC，把 Pi 当前运行时实际返回的 command/skill catalog 建模为 **per-session runtime capability manifest**。它只建立事实层和 maker-core 查询契约，不直接改变 scanner、项目 trust 或 UI。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 上下文与方案选择

问题的根因不是 Pi 没有资源发现能力，而是 Cindy 把 Pi 配置根隔离到每会话临时目录后，没有把“当前运行时实际加载了什么”回桥给 maker-core；同时 scanner 只能表达“文件存在”，不能证明“Pi 已加载”。

选择 `get_commands` 作为权威来源，是因为它直接来自当前 Pi 进程，能够携带 `name`、`source`、`sourceInfo` 等 provenance；单靠 fs scanner 会继续把 `discovered` 误当成 `loaded`。采集采用 ready 后异步执行，避免把可选诊断请求放进会话启动关键路径；每个 session 独立保存 manifest，并用 generation fence 防止旧的异步结果覆盖新 session。

### 范围

- 关联 Issue / 需求：Refs #1991；Closes #2011；前置事实层为 #2009 / PR #2030。
- 本 PR 包含：
  - ready 后异步、单次采集 Pi `get_commands`；
  - `switch_session`、live fork/rewind、close、异常退出时的刷新或清理；
  - provider-neutral、per-session 的查询/订阅接口，供 #2012 消费；
  - 保留稳定 command/provenance 字段；
  - 对 malformed、duplicate、oversized、unknown provenance 和 timeout 做保守解析与有限脱敏诊断。
- 明确不包含：
  - customization scanner 路径和祖先目录规则（#2012）；
  - Cindy project approval/trust、`trust.json`、`--approve` 或项目资源装配（#2013/#2014）；
  - packages/extensions、shared-global-skills、hooks、settings 默认值和 UI。
- 用户可见变化：本 PR本身没有直接 UI 变化；它为后续 scanner/UI 接线提供“`loaded` / `unknown` / `failed`”事实来源，避免列表把“发现”误呈现为“当前可用”。
- 是否存在 breaking change：无。新增能力面为可选、provider-neutral 接口，旧调用方不需要提供或读取新字段。

### 降级语义

- `get_commands` 不支持、Pi 未 ready、超时或进程不可用：标记 `unknown`，正常会话继续；
- 明确 RPC 失败或 malformed response：标记 `failed`，保留脱敏、有限长度的诊断；
- 只有合法的实际 RPC 返回才能确认 `loaded`；不会从 scanner 或资源缺席推导 approval/trust。

## UI 变化

- 不涉及：本 PR 只增加 maker-core 运行时事实层和测试，没有修改 UI、交互或文案。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

基于当前 `origin/main`，包含已合入的 PR #2030 / merge commit `7cd9b643`：

```text
Pi runtime 定向测试：34 passed
@cindy/maker-core 全量测试：1,996 passed，1 skipped
根 pnpm test:unit：在 NODE_OPTIONS=--no-experimental-webstorage 下通过
pnpm --filter @cindy/maker-core run --if-present typecheck：无独立脚本，正常跳过
git diff --check：通过
DCO：通过
```

### 手工验证

不涉及线上账号或真实 provider；使用仓库 pinned Pi 夹具、临时隔离 config home、dummy provider 和脱敏错误路径验证。

### 未执行的验证

未启动 Desktop 做 UI 验收，因为本 PR 没有 UI 或用户可见交互变更；#2012 负责后续消费方接线。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [x] 其他：异步运行时能力快照

### 影响与回滚

- 影响范围：仅 Pi 会话在 ready/lifecycle 边界增加一次非阻断的 `get_commands` 能力采集，以及 maker-core 内部可选查询/订阅契约。不会改变 Pi 的 trust、资源装配、prompt、scanner 或 UI 行为。
- 主要风险：manifest 是异步最终一致的；旧 Pi、超时或 malformed response 只能得到 `unknown`/`failed`。因此后续消费方必须只把明确 `loaded` 当作可用，不能把未知状态 fail-open。
- 并发/生命周期风险：通过 per-session 隔离、generation fence、switch/rewind 清旧 catalog、close/异常退出清理来避免 stale catalog 和跨 session 污染。
- 回滚 / 降级方式：回滚本 PR 即移除 runtime manifest 采集与查询接口；正常 Pi prompt/session 在采集失败时已经保持原有行为，无数据迁移和持久化格式变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（契约通过类型、测试和 PR 范围说明提供）
- [x] 已确认测试结果或说明未执行原因
