### PR TITLE
fix(mobile): 支持国际版 Android 使用 Apple 登录

### DIFF
--- a/apps/mobile/app/(auth)/login.tsx
+++ b/apps/mobile/app/(auth)/login.tsx
@@ -20,6 +20,10 @@ import { canResumePendingConsent, makeConsentStamp, type ConsentStamp } from '@/
 import { acceptPrivacyConsent } from '@/analytics/analyticsConsentStore';
 import { initMobileTapdb } from '@/analytics/mobileTapdb';
 import { isNativeSocialProviderSupported } from '@/auth/nativeSocial';
+import {
+  resolveMobileSocialLoginMode,
+  type MobileSocialLoginMode,
+} from '@/auth/mobileSocialLoginMode';
 import { Text, TextInput } from '@/components/AppText';
 import { useTheme, useThemedStyles, type ThemeColors } from '@/theme';
 import {
@@ -72,7 +76,7 @@ import {
   MobileLoginHandoffStage,
   useLoginSurface,
 } from '@/components/MobileLoginHandoffStage';
-import { AUTH_REGION, getMobileConfigIssues } from '@/config/env';
+import { AUTH_REGION, BUILD_AUTH_REGION, getMobileConfigIssues } from '@/config/env';
 import { resolveIdentifierMethod } from '@/auth/loginIdentifierMethod';
 import { fontWeight, lineHeight, loginPalettes, loginSizes, radius, spacing, typeScale } from '@/theme/tokens';
 
@@ -355,11 +359,21 @@ export default function LoginScreen() {
     const state = auth.loginState;
     if (state?.step !== 'identifier') return null;
     const providers = state.providers;
-    const socialProviders = providers.social.filter(
-      isNativeSocialProviderSupported,
+    const socialProviderModes = new Map<SocialProvider, MobileSocialLoginMode>();
+    for (const provider of providers.social) {
+      const mode = resolveMobileSocialLoginMode({
+        provider,
+        region: BUILD_AUTH_REGION,
+        platform: Platform.OS,
+        nativeSupported: isNativeSocialProviderSupported(provider),
+      });
+      if (mode) socialProviderModes.set(provider, mode);
+    }
+    const socialProviders = providers.social.filter((provider) =>
+      socialProviderModes.has(provider),
     );
-    // App Store 合规:Apple 必须用官方 Sign in with Apple 按钮(不可皮肤化),
-    // 从统一社交圆钮行中拆出、单独全宽渲染;其余(Google/微信/SSO)保留皮肤圆钮。
+    // Apple 保持官方 Logo-only 样式:iOS 走原生凭据,Global Android
+    // 走系统浏览器 PKCE;其余(Google/微信/SSO)保留原有圆钮。
     const nonAppleProviders = socialProviders.filter(
       // type guard 收窄为 Google/微信(SSO 由行内末位单独渲染),与 LoginSocialGlyph
       // 收窄后的 provider 类型对齐;Apple 走圆钮行第一颗(AppleLogoGlyph,variant='apple')。
@@ -518,9 +532,8 @@ export default function LoginScreen() {
           />
           {identifierErrorNode}
         </LoginPanel>
-        {/* App Store 合规(Guideline 4):Apple 入口为圆钮行第一颗(iOS only,沿用
-            socialProviders.includes('apple') 即 isNativeSocialProviderSupported 判定,
-            Android 自动无此钮)。圆钮底色用 ADR 官方 Black/White 配色(appleCircleBg)、
+        {/* Apple 入口为圆钮行第一颗:iOS 走原生 Sign in with Apple,
+            Global Android 复用系统浏览器 PKCE。圆钮底色用 ADR 官方 Black/White 配色(appleCircleBg)、
             logo 用官方 Logo-only artwork(AppleLogoGlyph,path 逐字节原样未改)、无描边。
             HIG 允许 logo-only 自定义按钮(圆形),artwork 来自 Apple Design Resources。 */}
         <LoginSocialRow
@@ -539,13 +552,22 @@ export default function LoginScreen() {
               onPress={() => {
                 // SC-SOC-7: in-flight 期间 no-op(行为层 guard,无 disabled 视觉回填)。
                 if (disabled) return;
-                // Apple 属个人登录链路,过协议门(未勾选先弹协议弹窗,同意后续接原路径)
-                requireConsent(() =>
+                // Apple 属个人登录链路,过协议门(未勾选先弹协议弹窗,同意后续接当前平台路径)
+                requireConsent(() => {
+                  const mode = socialProviderModes.get('apple');
+                  if (mode === 'browser') {
+                    void auth.dispatchLoginAction({
+                      type: 'start-social-browser',
+                      provider: 'apple',
+                      label: loginText('apple'),
+                    });
+                    return;
+                  }
                   void auth.dispatchLoginAction({
                     type: 'native-social',
                     provider: 'apple',
-                  }),
-                );
+                  });
+                });
               }}
               testID="login.appleButton"
             >

--- a/apps/mobile/src/__tests__/mobileAuthServerLogin.test.ts
+++ b/apps/mobile/src/__tests__/mobileAuthServerLogin.test.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('mobile auth-server login', () => {
-  it('uses native social SDK credentials and exchanges them only with auth-server', () => {
+  it('uses native social credentials where available and browser PKCE for Global Android Apple', () => {
     const loginSource = readFileSync(
       resolve(process.cwd(), 'app/(auth)/login.tsx'),
       'utf8',
@@ -14,6 +14,10 @@ describe('mobile auth-server login', () => {
     );
     const nativeSource = readFileSync(
       resolve(process.cwd(), 'src/auth/nativeSocial.ts'),
+      'utf8',
+    );
+    const modeSource = readFileSync(
+      resolve(process.cwd(), 'src/auth/mobileSocialLoginMode.ts'),
       'utf8',
     );
 
@@ -29,7 +33,9 @@ describe('mobile auth-server login', () => {
     expect(loginSource).toMatch(
       /type:\s*'native-social',\s*provider:\s*'apple',?\s*\n/,
     );
-    // 行 count 计入 apple(iOS 1 + nonAppleProviders + SSO 1)
+    expect(loginSource).toContain("type: 'start-social-browser'");
+    expect(loginSource).toContain("mode === 'browser'");
+    // 行 count 计入当前平台可用的 Apple + nonAppleProviders + SSO。
     expect(loginSource).toContain("socialProviders.includes('apple') ? 1 : 0");
     expect(loginSource).toContain('nonAppleProviders.length');
     expect(loginSource).not.toContain('react-native-webview');
@@ -61,6 +67,9 @@ describe('mobile auth-server login', () => {
     );
     expect(nativeSource).toContain('!GOOGLE_IOS_URL_SCHEME');
     expect(nativeSource).toMatch(/\|\|\s*!WECHAT_UNIVERSAL_LINK/);
+    expect(modeSource).toContain("input.region === 'global'");
+    expect(modeSource).toContain("input.platform === 'android'");
+    expect(modeSource).toContain("return 'browser'");
   });
 
   it('AppleLogoGlyph path d 与桌面 ADR 官方资产逐字节一致(防手抄/跨端漂移)', () => {
@@ -113,7 +122,7 @@ describe('mobile auth-server login', () => {
     expect(androidSource).toContain('fun cancel()');
   });
 
-  it('keeps SSO in the system browser and completes PKCE through the regional deep link', () => {
+  it('keeps social and SSO browser auth on one PKCE path through the regional deep link', () => {
     const authSource = readFileSync(
       resolve(process.cwd(), 'src/auth/AuthContext.tsx'),
       'utf8',
@@ -124,6 +133,9 @@ describe('mobile auth-server login', () => {
     ).replace(/\r\n/g, '\n');
 
     expect(authSource).toContain("kind: 'sso'");
+    expect(authSource).toContain("kind: 'social'");
+    expect(authSource).toContain("action.type === 'start-social-browser'");
+    expect(authSource).toContain('const startBrowserAuthorization = async');
     expect(authSource).toMatch(
       /WebBrowser\.openAuthSessionAsync\(\s*authUrl,\s*MOBILE_REDIRECT_URL,?\s*\)/,
     );
@@ -153,6 +165,7 @@ describe('mobile auth-server login', () => {
     expect(authSource).toContain("action.type === 'discover' ||");
     expect(authSource).toContain("action.type === 'request-code' ||");
     expect(authSource).toContain("action.type === 'verify-code' ||");
+    expect(authSource).toContain("action.type === 'start-social-browser' ||");
     expect(authSource).toContain("action.type === 'native-social'");
     expect(authSource).toContain(
       'if (startsBuildRealmFlow) {\n            pendingAuthRealmRef.current = null;',

--- a/apps/mobile/src/auth/AuthContext.tsx
+++ b/apps/mobile/src/auth/AuthContext.tsx
@@ -142,6 +142,11 @@ export type MobileLoginAction =
       code: string;
     }
   | { type: 'start-sso'; connectionId: string; label: string }
+  | {
+      type: 'start-social-browser';
+      provider: SocialProvider;
+      label: string;
+    }
   | { type: 'native-social'; provider: SocialProvider }
   | { type: 'select-account'; accountId: string }
   | { type: 'request-sso-verification-code' }
@@ -917,6 +922,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             action.type === 'discover' ||
             action.type === 'request-code' ||
             action.type === 'verify-code' ||
+            action.type === 'start-social-browser' ||
             action.type === 'native-social';
           if (startsBuildRealmFlow) {
             pendingAuthRealmRef.current = null;
@@ -924,6 +930,51 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           }
           const loginRealm = pendingAuthRealmRef.current ?? BUILD_AUTH_REGION;
           const client = authClientFor(did, loginRealm);
+          const startBrowserAuthorization = async (input: {
+            previousState: AuthFlowState;
+            kind: 'social' | 'sso';
+            providerOrConnectionId: string;
+            label: string;
+          }): Promise<boolean> => {
+            const { codeVerifier, codeChallenge } = await createPkcePair();
+            const state = createState();
+            await setSecureItem(
+              PENDING_OAUTH_KEY,
+              JSON.stringify({
+                codeVerifier,
+                deviceId: did,
+                state,
+                createdAt: Date.now(),
+                label: input.label,
+                realm: loginRealm,
+              } satisfies PendingOAuth),
+            );
+            updateLoginState(
+              reduceAuthFlow(input.previousState, {
+                type: 'browser-started',
+                label: input.label,
+              }),
+            );
+            const authUrl = client.buildAuthorizeUrl({
+              kind: input.kind,
+              providerOrConnectionId: input.providerOrConnectionId,
+              redirectUri: MOBILE_REDIRECT_URL,
+              codeChallenge,
+              state,
+            });
+            const result = await WebBrowser.openAuthSessionAsync(
+              authUrl,
+              MOBILE_REDIRECT_URL,
+            );
+            if (result.type === 'success') {
+              await completeOAuthCallback(result.url);
+              return true;
+            }
+            await deleteSecureItem(PENDING_OAUTH_KEY).catch(() => undefined);
+            pendingAuthRealmRef.current = null;
+            updateLoginState(null);
+            throw authCodeError('USER_CANCELLED');
+          };
 
           if (action.type === 'reset') {
             pendingAccountTokenRef.current = null;
@@ -1096,6 +1147,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             );
             return true;
           }
+          if (action.type === 'start-social-browser') {
+            const previousState = loginStateRef.current;
+            if (
+              previousState?.step !== 'identifier' ||
+              !previousState.providers.social.includes(action.provider)
+            ) {
+              throw authCodeError('SOCIAL_PROVIDER_UNAVAILABLE');
+            }
+            return startBrowserAuthorization({
+              previousState,
+              kind: 'social',
+              providerOrConnectionId: action.provider,
+              label: action.label,
+            });
+          }
           if (action.type === 'start-sso') {
             const previousState = loginStateRef.current;
             if (
@@ -1108,44 +1174,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             ) {
               throw authCodeError('INVALID_AUTH_ACTION');
             }
-            const { codeVerifier, codeChallenge } = await createPkcePair();
-            const state = createState();
-            await setSecureItem(
-              PENDING_OAUTH_KEY,
-              JSON.stringify({
-                codeVerifier,
-                deviceId: did,
-                state,
-                createdAt: Date.now(),
-                label: action.label,
-                realm: loginRealm,
-              } satisfies PendingOAuth),
-            );
-            updateLoginState(
-              reduceAuthFlow(previousState, {
-                type: 'browser-started',
-                label: action.label,
-              }),
-            );
-            const authUrl = client.buildAuthorizeUrl({
+            return startBrowserAuthorization({
+              previousState,
               kind: 'sso',
               providerOrConnectionId: action.connectionId,
-              redirectUri: MOBILE_REDIRECT_URL,
-              codeChallenge,
-              state,
+              label: action.label,
             });
-            const result = await WebBrowser.openAuthSessionAsync(
-              authUrl,
-              MOBILE_REDIRECT_URL,
-            );
-            if (result.type === 'success') {
-              await completeOAuthCallback(result.url);
-              return true;
-            }
-            await deleteSecureItem(PENDING_OAUTH_KEY).catch(() => undefined);
-            pendingAuthRealmRef.current = null;
-            updateLoginState(null);
-            throw authCodeError('USER_CANCELLED');
           }
           if (action.type === 'select-account') {
             const accountToken = pendingAccountTokenRef.current;

--- a/apps/mobile/src/auth/__tests__/loginConsent.test.ts
+++ b/apps/mobile/src/auth/__tests__/loginConsent.test.ts
@@ -139,7 +139,13 @@ describe('login.tsx 接线(源码断言)', () => {
     // 发码点(phone + 邮箱个人行)与社交圆钮为实际发起点,必须过门
     expect(loginSource).toMatch(/requireConsent\(\(\) =>[\s\S]{0,200}?kind: 'phone'/);
     expect(loginSource).toMatch(/requireConsent\(\(\) =>[\s\S]{0,240}?kind: 'email'/);
-    expect(loginSource).toMatch(/requireConsent\(\(\) =>[\s\S]{0,200}?provider: 'apple'/);
+    const appleStart = loginSource.indexOf("label={loginText('apple')}");
+    const appleEnd = loginSource.indexOf('testID="login.appleButton"', appleStart);
+    expect(appleStart).toBeGreaterThan(0);
+    expect(appleEnd).toBeGreaterThan(appleStart);
+    const appleBlock = loginSource.slice(appleStart, appleEnd);
+    expect(appleBlock).toContain('requireConsent(() =>');
+    expect(appleBlock).toContain("provider: 'apple'");
   });
 
   it('企业 SSO 入口豁免:ssoEntryButton onPress 不过 requireConsent', () => {

--- a/apps/mobile/src/auth/__tests__/loginSkinStates.test.ts
+++ b/apps/mobile/src/auth/__tests__/loginSkinStates.test.ts
@@ -60,7 +60,7 @@ describe('loginSkin 全登录态(harness 真链 + 渲染层接线)', () => {
     expect(loginSource).toContain('testID="login.identifierInput"');
     expect(loginSource).toContain('testID="login.continueButton"');
     expect(loginSource).toContain('testID="login.ssoEntryButton"');
-    // Apple 圆钮(iOS)计入行 count:apple 1 + nonAppleProviders + SSO 1
+    // Apple 圆钮(当前平台有可用路径时)计入行 count:apple 1 + nonAppleProviders + SSO 1
     expect(loginSource).toContain("socialProviders.includes('apple') ? 1 : 0");
     expect(loginSource).toContain('nonAppleProviders.length');
     expect(loginSource).toContain(
@@ -382,13 +382,14 @@ describe('loginSkin 全登录态(harness 真链 + 渲染层接线)', () => {
     // accessibilityState.busy 无障碍语义(非视觉,对齐桌面 aria-disabled;见 LoginSkinButton),
     // 不传原生 disabled——视觉/交互态不变。
     // 渲染层读源码断言(login.tsx 依赖 expo/RN,node vitest 不加载,沿用仓内既有模式)。
-    // 1. in-flight guard 存在:两个圆钮 onPress 各一(native-social + ssoEntry),≥2 处
+    // 1. in-flight guard 存在:两个圆钮 onPress 各一(social + ssoEntry),≥2 处
     // FRAGILE:源码字面匹配——重排版空格仍匹配(\s* 容差),但变量改名(disabled→别的)或
     // 改写为 if-block 会假失败;改 onPress guard 时同步更新此正则,或抽成纯函数测行为。
     const guardMatches = loginSource.match(/if\s*\(\s*disabled\s*\)\s*return\s*;/g) ?? [];
     expect(guardMatches.length).toBeGreaterThanOrEqual(2);
-    // 2. 非 in-flight 派发路径保留(native-social dispatch 仍在,措辞 verbatim)
+    // 2. 非 in-flight 派发路径保留:iOS native + Global Android browser。
     expect(loginSource).toMatch(/type:\s*'native-social',\s*provider/);
+    expect(loginSource).toContain("type: 'start-social-browser'");
     // 3. SSO 非 in-flight 路径保留(clearAuthError + setSsoOrgMode)
     expect(loginSource).toContain('auth.clearAuthError();');
     expect(loginSource).toContain('setSsoOrgMode(true);');

--- a/apps/mobile/src/auth/__tests__/mobileSocialLoginMode.test.ts
+++ b/apps/mobile/src/auth/__tests__/mobileSocialLoginMode.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveMobileSocialLoginMode } from '@/auth/mobileSocialLoginMode';
+
+describe('resolveMobileSocialLoginMode', () => {
+  it('uses browser PKCE for Apple on Global Android', () => {
+    expect(
+      resolveMobileSocialLoginMode({
+        provider: 'apple',
+        region: 'global',
+        platform: 'android',
+        nativeSupported: false,
+      }),
+    ).toBe('browser');
+  });
+
+  it('keeps Apple native on iOS', () => {
+    expect(
+      resolveMobileSocialLoginMode({
+        provider: 'apple',
+        region: 'global',
+        platform: 'ios',
+        nativeSupported: true,
+      }),
+    ).toBe('native');
+  });
+
+  it('does not change Mainland China Android provider behavior', () => {
+    expect(
+      resolveMobileSocialLoginMode({
+        provider: 'apple',
+        region: 'cn',
+        platform: 'android',
+        nativeSupported: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('keeps other configured providers on their native path', () => {
+    expect(
+      resolveMobileSocialLoginMode({
+        provider: 'google',
+        region: 'global',
+        platform: 'android',
+        nativeSupported: true,
+      }),
+    ).toBe('native');
+  });
+});

--- a/apps/mobile/src/auth/mobileSocialLoginMode.ts
+++ b/apps/mobile/src/auth/mobileSocialLoginMode.ts
@@ -1,0 +1,25 @@
+import type { AuthRegion, SocialProvider } from '@cindy/auth-client';
+
+export type MobileSocialLoginMode = 'native' | 'browser';
+
+/**
+ * Chooses the credential path for a provider advertised by auth-server.
+ * Native support remains the default; Global Android falls back to the
+ * existing browser PKCE flow for Apple instead of hiding the provider.
+ */
+export function resolveMobileSocialLoginMode(input: {
+  provider: SocialProvider;
+  region: AuthRegion;
+  platform: string;
+  nativeSupported: boolean;
+}): MobileSocialLoginMode | null {
+  if (input.nativeSupported) return 'native';
+  if (
+    input.provider === 'apple' &&
+    input.region === 'global' &&
+    input.platform === 'android'
+  ) {
+    return 'browser';
+  }
+  return null;
+}


### PR DESCRIPTION
## 这次改了什么

### 摘要

国际版 Android 之前会把 Apple 登录当成「仅 iOS 原生能力」过滤掉，导致用 Apple 账号登录 Desktop 的用户无法在 Android 端登录同一账号。

本 PR 保留 iOS 的原生 Sign in with Apple，并让国际版 Android 通过现有系统浏览器 PKCE 授权链路登录 Apple。Desktop 原有的浏览器 Apple 登录不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：X 用户反馈国际版 Android 无法使用 Apple 账号登录
- 本 PR 包含：Global Android Apple 入口可见性、浏览器 PKCE 路由、回调复用与回归测试
- 明确不包含：服务端改动、新原生 SDK、中国大陆版 Android 行为变更
- 用户可见变化：国际版 Android 登录页显示 Apple 入口；点击后在系统浏览器授权并返回 App
- 是否存在 breaking change：无

### UI 变化

- 国际版 Android 复用现有 Apple Logo-only 圆钮，不新增样式、文案或色值。
- 引用的设计规范：`docs/design-rules/DESIGN.md` §16.2 Apple 「Sign in with Apple」平台差异；§16.4 社交登录协议门。
- 未附截图：本地未启动 Android 国际版真机/模拟器。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile typecheck
结果：通过

pnpm --filter mobile test
结果：288 个测试文件、3274 项测试通过

pnpm --filter mobile test:scope
结果：通过

/Users/cindy/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/cindy/Code/Cindy/cindy-apple-login-global-channels
结果：通过
```

### 手工验证

不涉及：本地未配置可用的 Android 国际版 Apple 测试账号与运行环境。

### 未执行的验证

- 未在 Android 真机/模拟器完成 Apple OAuth 实际授权。
- 未做双模式视觉目检；本 PR 仅恢复现有双模式 Apple 圆钮的平台可见性，未改样式。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅国际版 Android 的 Apple 登录入口与授权路由；iOS、Desktop 及中国大陆版 Android 行为不变。
- 回滚 / 降级方式：回退本 PR 即恢复 Android 隐藏 Apple 入口的旧行为。
- Mobile runtime fingerprint：不变；未修改原生配置、原生依赖、config plugin 或指纹输入。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
