### PR TITLE
fix(plugin-market): 服务端 release 清单校验失败按「版本不支持」呈现，不再误报「插件包无效」

### DIFF
--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -551,6 +551,71 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(runtime.install).not.toHaveBeenCalled();
   });
 
+  // 复现 2026-08-07 cindy-github 1.2.6 事故:服务端 release 用了本构建校验器
+  // 尚不认识的清单特性(network.secrets[].source: "gh-cli")。协议层放行、本地
+  // validateGhostManifest 拒绝——必须按「版本不支持」呈现,不能报「包无效」。
+  function mockDetailWithManifestOnce(
+    h: ReturnType<typeof harness>,
+    item: VisiblePluginSummary,
+    manifestOverride: Record<string, unknown>,
+  ) {
+    h.api.detail.mockResolvedValueOnce({
+      ...item,
+      currentRelease: {
+        ...item.currentRelease,
+        manifest: manifestOverride,
+      },
+    } as unknown as Awaited<ReturnType<ReturnType<typeof harness>['api']['detail']>>);
+  }
+
+  function schemaForwardManifest(): Record<string, unknown> {
+    return {
+      ...manifest(),
+      slots: ['notify', 'network'],
+      network: {
+        hosts: ['api.github.com'],
+        secrets: [{ key: 'github_pat', label: 'GitHub 登录', source: 'gh-cli' }],
+      },
+    };
+  }
+
+  it('treats a schema-forward official release as version-gated, not an invalid package', async () => {
+    const item = summary();
+    const h = harness([item]);
+    mockDetailWithManifestOnce(h, item, schemaForwardManifest());
+
+    const failure = await h.service.detail(item.id).then(
+      () => null,
+      (error: unknown) => error,
+    );
+    expect(String(failure)).toContain('[NOT_FOUND]');
+    expect(String(failure)).not.toContain('GHOST_FILE_INVALID');
+  });
+
+  it('skips defaultInstall of a schema-forward release without failing the snapshot', async () => {
+    const item = summary({ defaultInstall: true });
+    const h = harness([item]);
+    mockDetailWithManifestOnce(h, item, schemaForwardManifest());
+
+    const snapshot = await h.service.snapshot();
+
+    expect(runtime.install).not.toHaveBeenCalled();
+    expect(snapshot.items[0]?.installState).toBe('not-installed');
+    expect(h.ledger.installationForGhost(item.ghostId)).toBeNull();
+  });
+
+  it('does not defaultInstall a release above minCindyVersion', async () => {
+    const item = summary({ defaultInstall: true });
+    const h = harness([item]);
+    mockDetailWithManifestOnce(h, item, { ...manifest(), minCindyVersion: '2.0.0' });
+
+    const snapshot = await h.service.snapshot();
+
+    expect(runtime.install).not.toHaveBeenCalled();
+    expect(snapshot.items[0]?.installState).toBe('not-installed');
+    expect(h.ledger.installationForGhost(item.ghostId)).toBeNull();
+  });
+
   // 2026-07-26 定案:市场首装一律装完即开,手动安装与 defaultInstall 归一,
   // 不再向装入入口透传 initiallyEnabled(启用语义收敛在市场装入入口本身)。
   it('manual market install goes through the auto-enable install entry', async () => {

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -459,7 +459,15 @@ export class PluginMarketService {
       }
       const compatible = validateGhostManifest(plugin.currentRelease.manifest);
       if (!compatible.ok) {
-        throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
+        // 服务端 release 已过市场协议层的清单校验、包体由 SHA-256 钉死,走到这里
+        // 的失败只剩一种真实成因:该 release 使用了比本 Cindy 构建更新的清单特性
+        // (schema 前向偏移)。按「版本不支持」呈现,而不是「包无效」——后者会误导
+        // 用户去卸载仍在正常工作的已装旧版本(装回时又被同一道校验拒绝)。
+        log.warn('market release manifest not supported by this Cindy build', {
+          pluginId,
+          reason: compatible.reason,
+        });
+        throwIpcError('NOT_FOUND', 'This Plugin is unavailable for this Cindy version');
       }
       if (!manifestSupportsCurrentCindy(compatible.manifest)) {
         throwIpcError('NOT_FOUND', 'This Plugin is unavailable for this Cindy version');
@@ -1470,7 +1478,14 @@ export class PluginMarketService {
           assertDetailMatchesSummary(summary, detail);
           const reviewedManifest = validateGhostManifest(detail.currentRelease.manifest);
           if (!reviewedManifest.ok) {
-            throwIpcError('GHOST_FILE_INVALID', 'This Plugin manifest is not supported');
+            // 与 detail() 同一判定:协议层已放行的 release 在本地校验失败,说明它
+            // 需要更新的 Cindy,按「版本不支持」跳过本轮默认安装(外层 catch 记日志)。
+            throwIpcError('NOT_FOUND', 'This Plugin is unavailable for this Cindy version');
+          }
+          if (!manifestSupportsCurrentCindy(reviewedManifest.manifest)) {
+            // 手动 detail()/install() 都会拒绝低于 minCindyVersion 的宿主,
+            // 默认安装不能绕过同一道门。
+            throwIpcError('NOT_FOUND', 'This Plugin is unavailable for this Cindy version');
           }
           // 装完即开语义已收敛进市场安装入口本身,这里无需再显式声明。
           await this.installDetail(


### PR DESCRIPTION
关联 issue:#2047(完整事故链路与日志证据在该 issue)

## 问题

市场详情页对服务端 release 的本地 `validateGhostManifest` 校验失败一律抛
`GHOST_FILE_INVALID`,前端文案是「该插件包无效,或当前 Cindy 版本不支持它」。

但服务端 release 在市场协议层(`@cindy/plugin-protocol`)已过清单校验、包体由
SHA-256 钉死,走到这一步的失败实际只有一种真实成因:release 使用了比本构建更新
的清单特性(schema 前向偏移)。按「包无效」呈现会误导用户卸载仍在正常工作的已装
旧版本——而装回时又被同一道校验拒绝,插件从此装不回来。

2026-08-07 实际发生:`cindy-github` 1.2.6 清单声明
`network.secrets[].source: "gh-cli"`(该值 2026-08-05 增补进 cindy-protocol 的
schema,桌面端 `shared/ghost.ts` 的 `GHOST_SECRET_SOURCES` 尚未同步),市场里该
插件详情页硬错、文案误导、用户卸载后无法重装。

## 修改

- `detail()`:服务端 release 本地校验失败改抛 `NOT_FOUND`「This Plugin is
  unavailable for this Cindy version」,与既有 `minCindyVersion` 门槛同一语义;
  同时 `log.warn` 记录具体拒绝理由,便于定位真实的 schema 偏移点。
- `applyDefaultInstalls()`:同一判定;并补上该路径缺失的 `minCindyVersion`
  门槛(手动 `detail()`/`install()` 均有此门槛,默认安装此前可绕过)。
- 不改动本地包安装 / 自定义市场路径:`GHOST_FILE_INVALID` 仍保留给真正的坏包。

## 测试

- 新增 3 个用例(`service.test.ts`,66/66 通过):
  - schema 前向偏移的服务端 release:`detail()` 抛 `[NOT_FOUND]` 而非
    `GHOST_FILE_INVALID`(用 `source: "gh-cli"` 复现事故场景);
  - 同场景默认安装:静默跳过,不装、不写账本、不拖垮 snapshot;
  - `minCindyVersion` 高于宿主的 release:默认安装不再安装。
- `pnpm check:dco` 通过;eslint 无告警;`tsc --noEmit` 全量通过。

## 不在本 PR 范围(建议后续)

- 服务端发布门槛:避免向仅有旧 schema 的稳定版宿主下发前向清单(如强制 release
  声明 `minCindyVersion`,或服务端按宿主版本过滤下发)。
- 桌面端 `shared/ghost.ts` 与 cindy-protocol 各持一份 ghost schema 的收敛/同步
  机制(本次事故的结构性根源)。
- 前端为「版本不支持」提供专属文案(当前复用 notFound 文案「该插件已不可用」)。
