### PR TITLE
fix(ci): 协议指针必须已发布才放行，并兼容历史悬空指针

### DIFF
--- a/scripts/__tests__/check-submodule-forward.test.mjs
+++ b/scripts/__tests__/check-submodule-forward.test.mjs
@@ -259,10 +259,16 @@ test('validateSubmoduleForward does not treat a failed base fetch as forward', (
       `160000,${head},cindy-protocol`,
     );
     git(outer, 'commit', '-m', 'head');
+    const warnings = [];
     assert.throws(
-      () => validateSubmoduleForward(outer, 'HEAD~1', 'HEAD'),
+      () =>
+        validateSubmoduleForward(outer, 'HEAD~1', 'HEAD', {
+          ci: false,
+          warn: (message) => warnings.push(message),
+        }),
       /无法读取协议 base commit/,
     );
+    assert.equal(warnings.length, 1);
   } finally {
     fs.rmSync(outer, { recursive: true, force: true });
   }

--- a/scripts/__tests__/check-submodule-forward.test.mjs
+++ b/scripts/__tests__/check-submodule-forward.test.mjs
@@ -299,3 +299,46 @@ test('validateSubmoduleForward does not treat a failed base fetch as forward', (
     fs.rmSync(outer, { recursive: true, force: true });
   }
 });
+
+test('allows the unchanged dangling historical baseline without fetching it', () => {
+  const outer = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'cindy-protocol-unchanged-dangling-'),
+  );
+  const protocol = path.join(outer, 'cindy-protocol');
+  fs.mkdirSync(protocol);
+  try {
+    git(outer, 'init', '-b', 'main');
+    git(outer, 'config', 'user.name', 'Protocol Guard Test');
+    git(outer, 'config', 'user.email', 'protocol-guard@example.invalid');
+    git(protocol, 'init', '-b', 'main');
+    git(
+      protocol,
+      'remote',
+      'add',
+      'origin',
+      '/definitely/missing/protocol.git',
+    );
+    const dangling = '27ef29dcb0df1b0f346c82cb7fbb81e9da536a79';
+    assert.throws(() =>
+      git(protocol, 'cat-file', '-e', `${dangling}^{commit}`),
+    );
+    git(
+      outer,
+      'update-index',
+      '--add',
+      '--cacheinfo',
+      `160000,${dangling},cindy-protocol`,
+    );
+    git(outer, 'commit', '-m', 'dangling baseline');
+
+    assert.deepEqual(validateSubmoduleForward(outer, 'HEAD', 'HEAD'), {
+      baseRef: 'HEAD',
+      headRef: 'HEAD',
+      baseOid: dangling,
+      headOid: dangling,
+      relation: 'unchanged',
+    });
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
+  }
+});

--- a/scripts/__tests__/check-submodule-forward.test.mjs
+++ b/scripts/__tests__/check-submodule-forward.test.mjs
@@ -120,6 +120,31 @@ test('rejects matching tree when the parent list differs', () => {
   }
 });
 
+test('classifies reachable same-tree different-parent history as diverged', () => {
+  const f = fixture();
+  try {
+    const tree = git(f.repo, 'rev-parse', `${f.two}^{tree}`);
+    const duplicate = commitTree(
+      f.repo,
+      git(f.repo, 'rev-parse', `${f.one}^{tree}`),
+      null,
+      'duplicate root',
+    );
+    const candidate = commitTree(
+      f.repo,
+      tree,
+      duplicate,
+      'same tree, different parent',
+    );
+    assert.equal(
+      classifyProtocolRelation(f.repo, f.two, candidate),
+      'diverged',
+    );
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
 test('fails closed when an unavailable base cannot be fetched', () => {
   const f = fixture();
   try {

--- a/scripts/__tests__/check-submodule-forward.test.mjs
+++ b/scripts/__tests__/check-submodule-forward.test.mjs
@@ -5,14 +5,36 @@ import path from 'node:path';
 import { execFileSync } from 'node:child_process';
 import test from 'node:test';
 
-import { classifyProtocolRelation } from '../check-submodule-forward.mjs';
+import {
+  classifyProtocolRelation,
+  validateSubmoduleForward,
+} from '../check-submodule-forward.mjs';
 
 function git(repo, ...args) {
   return execFileSync('git', args, { cwd: repo, encoding: 'utf-8' }).trim();
 }
 
+function commitTree(repo, tree, parent, message) {
+  const args = ['commit-tree', tree];
+  if (parent) args.push('-p', parent);
+  return execFileSync('git', args, {
+    cwd: repo,
+    encoding: 'utf-8',
+    input: `${message}\n`,
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Protocol Guard Test',
+      GIT_AUTHOR_EMAIL: 'protocol-guard@example.invalid',
+      GIT_COMMITTER_NAME: 'Protocol Guard Test',
+      GIT_COMMITTER_EMAIL: 'protocol-guard@example.invalid',
+    },
+  }).trim();
+}
+
 function fixture() {
-  const repo = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-protocol-forward-'));
+  const repo = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'cindy-protocol-forward-'),
+  );
   git(repo, 'init', '-b', 'main');
   git(repo, 'config', 'user.name', 'Protocol Guard Test');
   git(repo, 'config', 'user.email', 'protocol-guard@example.invalid');
@@ -40,5 +62,116 @@ test('classifies unchanged, forward, rollback and diverged protocol gitlinks', (
     assert.equal(classifyProtocolRelation(f.repo, f.two, f.fork), 'diverged');
   } finally {
     fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('accepts an unreachable base only for a strict equivalent ancestor', () => {
+  const f = fixture();
+  try {
+    const tree = git(f.repo, 'rev-parse', `${f.one}^{tree}`);
+    const duplicate = commitTree(f.repo, tree, f.one, 'duplicate');
+    const head = commitTree(f.repo, tree, duplicate, 'head');
+    const baseOid = 'a'.repeat(40);
+    const metadata = new Map([[baseOid, { parents: [f.one], tree }]]);
+    assert.equal(
+      classifyProtocolRelation(f.repo, baseOid, head, {
+        unreachableBaseMetadata: metadata,
+      }),
+      'forward',
+    );
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('accepts an available base with an equivalent head ancestor', () => {
+  const f = fixture();
+  try {
+    const tree = git(f.repo, 'rev-parse', `${f.one}^{tree}`);
+    const duplicate = commitTree(f.repo, tree, null, 'duplicate');
+    const head = commitTree(f.repo, tree, duplicate, 'head');
+    assert.equal(classifyProtocolRelation(f.repo, f.one, head), 'forward');
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('rejects matching tree when the parent list differs', () => {
+  const f = fixture();
+  try {
+    const tree = git(f.repo, 'rev-parse', `${f.one}^{tree}`);
+    const candidate = commitTree(
+      f.repo,
+      tree,
+      f.one,
+      'same tree, different parent',
+    );
+    const baseOid = 'b'.repeat(40);
+    const metadata = new Map([[baseOid, { parents: [f.two], tree }]]);
+    assert.throws(
+      () =>
+        classifyProtocolRelation(f.repo, baseOid, candidate, {
+          unreachableBaseMetadata: metadata,
+        }),
+      /无法读取协议 base commit/,
+    );
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('fails closed when an unavailable base cannot be fetched', () => {
+  const f = fixture();
+  try {
+    const baseOid = 'c'.repeat(40);
+    assert.throws(
+      () => classifyProtocolRelation(f.repo, baseOid, f.two),
+      /无法读取协议 base commit/,
+    );
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('validateSubmoduleForward does not treat a failed base fetch as forward', () => {
+  const outer = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'cindy-protocol-forward-parent-'),
+  );
+  const protocol = path.join(outer, 'cindy-protocol');
+  fs.mkdirSync(protocol);
+  try {
+    git(outer, 'init', '-b', 'main');
+    git(outer, 'config', 'user.name', 'Protocol Guard Test');
+    git(outer, 'config', 'user.email', 'protocol-guard@example.invalid');
+    git(protocol, 'init', '-b', 'main');
+    git(protocol, 'config', 'user.name', 'Protocol Guard Test');
+    git(protocol, 'config', 'user.email', 'protocol-guard@example.invalid');
+    fs.writeFileSync(path.join(protocol, 'protocol.txt'), 'head\n');
+    git(protocol, 'add', '.');
+    git(protocol, 'commit', '-m', 'head');
+    const head = git(protocol, 'rev-parse', 'HEAD');
+    const base = 'd'.repeat(40);
+    git(
+      outer,
+      'update-index',
+      '--add',
+      '--cacheinfo',
+      `160000,${base},cindy-protocol`,
+    );
+    git(outer, 'commit', '-m', 'base');
+    git(
+      outer,
+      'update-index',
+      '--add',
+      '--cacheinfo',
+      `160000,${head},cindy-protocol`,
+    );
+    git(outer, 'commit', '-m', 'head');
+    assert.throws(
+      () => validateSubmoduleForward(outer, 'HEAD~1', 'HEAD'),
+      /无法读取协议 base commit/,
+    );
+  } finally {
+    fs.rmSync(outer, { recursive: true, force: true });
   }
 });

--- a/scripts/__tests__/check-submodule-forward.test.mjs
+++ b/scripts/__tests__/check-submodule-forward.test.mjs
@@ -7,6 +7,7 @@ import test from 'node:test';
 
 import {
   classifyProtocolRelation,
+  validatePublishedProtocolHead,
   validateSubmoduleForward,
 } from '../check-submodule-forward.mjs';
 
@@ -51,6 +52,14 @@ function fixture() {
   git(repo, 'commit', '-m', 'fork');
   const fork = git(repo, 'rev-parse', 'HEAD');
   return { repo, one, two, fork };
+}
+
+function setPublishedMain(repo, oid) {
+  git(repo, 'update-ref', 'refs/remotes/origin/main', oid);
+}
+
+function setPublishedTag(repo, name, oid) {
+  git(repo, 'update-ref', `refs/tags/client-baseline-${name}`, oid);
 }
 
 test('classifies unchanged, forward, rollback and diverged protocol gitlinks', () => {
@@ -145,6 +154,63 @@ test('classifies reachable same-tree different-parent history as diverged', () =
   }
 });
 
+test('rejects a feature-only head before ancestry classification', () => {
+  const f = fixture();
+  try {
+    setPublishedMain(f.repo, f.two);
+    assert.throws(
+      () => validatePublishedProtocolHead(f.repo, f.fork, { ci: false }),
+      /未合入协议仓 main，也未打 client-baseline tag/,
+    );
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('allows a head published on protocol main', () => {
+  const f = fixture();
+  try {
+    setPublishedMain(f.repo, f.two);
+    assert.doesNotThrow(() =>
+      validatePublishedProtocolHead(f.repo, f.two, { ci: false }),
+    );
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('allows a head published only by a client-baseline tag', () => {
+  const f = fixture();
+  try {
+    setPublishedMain(f.repo, f.one);
+    setPublishedTag(f.repo, 'feature', f.fork);
+    assert.doesNotThrow(() =>
+      validatePublishedProtocolHead(f.repo, f.fork, { ci: false }),
+    );
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
+test('falls back to local origin/main when baseline fetch is unavailable', () => {
+  const f = fixture();
+  try {
+    setPublishedMain(f.repo, f.two);
+    git(f.repo, 'remote', 'add', 'origin', '/definitely/missing/protocol.git');
+    const warnings = [];
+    assert.doesNotThrow(() =>
+      validatePublishedProtocolHead(f.repo, f.two, {
+        ci: false,
+        warn: (message) => warnings.push(message),
+      }),
+    );
+    assert.equal(warnings.length, 1);
+    assert.match(warnings[0], /退用本地 origin\/main/);
+  } finally {
+    fs.rmSync(f.repo, { recursive: true, force: true });
+  }
+});
+
 test('fails closed when an unavailable base cannot be fetched', () => {
   const f = fixture();
   try {
@@ -175,6 +241,7 @@ test('validateSubmoduleForward does not treat a failed base fetch as forward', (
     git(protocol, 'add', '.');
     git(protocol, 'commit', '-m', 'head');
     const head = git(protocol, 'rev-parse', 'HEAD');
+    setPublishedMain(protocol, head);
     const base = 'd'.repeat(40);
     git(
       outer,

--- a/scripts/__tests__/check-submodule-forward.test.mjs
+++ b/scripts/__tests__/check-submodule-forward.test.mjs
@@ -192,6 +192,32 @@ test('allows a head published only by a client-baseline tag', () => {
   }
 });
 
+test('fetches a published head missing from the local protocol clone', () => {
+  const publisher = fixture();
+  const bare = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'cindy-protocol-published-'),
+  );
+  const local = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-protocol-local-'));
+  try {
+    git(bare, 'init', '--bare');
+    git(publisher.repo, 'remote', 'add', 'origin', bare);
+    git(publisher.repo, 'push', 'origin', 'main');
+    git(local, 'init', '-b', 'main');
+    git(local, 'remote', 'add', 'origin', bare);
+    git(local, 'fetch', 'origin', publisher.one);
+    assert.throws(() =>
+      git(local, 'cat-file', '-e', `${publisher.two}^{commit}`),
+    );
+    assert.doesNotThrow(() =>
+      validatePublishedProtocolHead(local, publisher.two, { ci: true }),
+    );
+  } finally {
+    fs.rmSync(publisher.repo, { recursive: true, force: true });
+    fs.rmSync(bare, { recursive: true, force: true });
+    fs.rmSync(local, { recursive: true, force: true });
+  }
+});
+
 test('falls back to local origin/main when baseline fetch is unavailable', () => {
   const f = fixture();
   try {

--- a/scripts/check-submodule-forward.mjs
+++ b/scripts/check-submodule-forward.mjs
@@ -271,9 +271,10 @@ export function validateSubmoduleForward(
   const protocolRepo = path.join(repoRoot, SUBMODULE_PATH);
   const unchangedHistoricalBaseline =
     baseOid === headOid && UNREACHABLE_BASE_COMMITS.has(headOid);
-  if (!unchangedHistoricalBaseline) {
-    validatePublishedProtocolHead(protocolRepo, headOid, options);
+  if (unchangedHistoricalBaseline) {
+    return { baseRef, headRef, baseOid, headOid, relation: 'unchanged' };
   }
+  validatePublishedProtocolHead(protocolRepo, headOid, options);
   ensureCommit(protocolRepo, baseOid, { allowUnreachableBase: true });
   if (!ensureCommit(protocolRepo, headOid)) {
     throw new Error(`无法准备协议 head commit ${headOid}`);

--- a/scripts/check-submodule-forward.mjs
+++ b/scripts/check-submodule-forward.mjs
@@ -126,10 +126,20 @@ export function validatePublishedProtocolHead(
   headOid,
   { ci = Boolean(process.env.CI), warn = console.warn } = {},
 ) {
-  if (!hasCommit(protocolRepo, headOid)) {
-    throw new Error(`无法读取协议 head commit ${headOid}`);
-  }
   refreshPublishedBaselines(protocolRepo, { ci, warn });
+  if (!hasCommit(protocolRepo, headOid)) {
+    const headFetch = git(
+      protocolRepo,
+      ['fetch', '--no-tags', 'origin', headOid],
+      { allowFailure: true },
+    );
+    if (!hasCommit(protocolRepo, headOid)) {
+      const detail = (headFetch.stderr || headFetch.stdout || '').trim();
+      throw new Error(
+        `无法读取协议 head commit ${headOid}${detail ? `: ${detail}` : ''}`,
+      );
+    }
+  }
   const baselineRefs = readPublishedBaselineRefs(protocolRepo);
   if (baselineRefs.some((ref) => isAncestor(protocolRepo, headOid, ref))) {
     return;

--- a/scripts/check-submodule-forward.mjs
+++ b/scripts/check-submodule-forward.mjs
@@ -6,10 +6,10 @@ import { fileURLToPath } from 'node:url';
 
 const SUBMODULE_PATH = 'cindy-protocol';
 
-// 27ef29d was a historical duplicate of e6c95b0. It is no longer reachable
-// from the protocol repository's refs, so CI cannot fetch its commit object.
-// Keep the verified metadata here so this one safe, strict equivalence can be
-// checked without relying on a network lookup or an unreachable object.
+// 27ef29d was a historical duplicate of e6c95b0. The published-head guard below
+// prevents future gitlinks from depending on unpublished commits, so this map
+// must not grow. Keep this one verified entry only to move the already-dangling
+// main baseline onto the equivalent published history.
 const UNREACHABLE_BASE_COMMITS = new Map([
   [
     '27ef29dcb0df1b0f346c82cb7fbb81e9da536a79',
@@ -55,6 +55,87 @@ function isAncestor(repoRoot, older, newer) {
   const detail = (result.stderr || result.stdout || '').trim();
   throw new Error(
     `无法比较协议历史 ${older.slice(0, 10)}..${newer.slice(0, 10)}${detail ? `: ${detail}` : ''}`,
+  );
+}
+
+function hasCommit(repoRoot, oid) {
+  return (
+    git(repoRoot, ['cat-file', '-e', `${oid}^{commit}`], {
+      allowFailure: true,
+    }).status === 0
+  );
+}
+
+function hasRef(repoRoot, ref) {
+  return (
+    git(repoRoot, ['show-ref', '--verify', '--quiet', ref], {
+      allowFailure: true,
+    }).status === 0
+  );
+}
+
+function readPublishedBaselineRefs(protocolRepo) {
+  const refs = [];
+  if (hasRef(protocolRepo, 'refs/remotes/origin/main')) {
+    refs.push('refs/remotes/origin/main');
+  }
+  const tags = git(protocolRepo, [
+    'for-each-ref',
+    '--format=%(refname)',
+    'refs/tags/client-baseline-*',
+  ])
+    .stdout.trim()
+    .split('\n')
+    .filter(Boolean);
+  return refs.concat(tags);
+}
+
+function refreshPublishedBaselines(protocolRepo, { ci, warn }) {
+  const mainFetch = git(
+    protocolRepo,
+    ['fetch', '--no-tags', 'origin', 'main:refs/remotes/origin/main'],
+    { allowFailure: true },
+  );
+  const tagFetch = git(
+    protocolRepo,
+    [
+      'fetch',
+      '--no-tags',
+      'origin',
+      'refs/tags/client-baseline-*:refs/tags/client-baseline-*',
+    ],
+    { allowFailure: true },
+  );
+  if (mainFetch.status === 0 && tagFetch.status === 0) return;
+
+  const detail = [mainFetch, tagFetch]
+    .filter((result) => result.status !== 0)
+    .map((result) => (result.stderr || result.stdout || '').trim())
+    .filter(Boolean)
+    .join('; ');
+  if (ci || !hasRef(protocolRepo, 'refs/remotes/origin/main')) {
+    throw new Error(`无法刷新协议仓公开基线${detail ? `: ${detail}` : ''}`);
+  }
+  warn(
+    `无法刷新协议仓公开基线，退用本地 origin/main 与已有 client-baseline tags${detail ? `: ${detail}` : ''}`,
+  );
+}
+
+export function validatePublishedProtocolHead(
+  protocolRepo,
+  headOid,
+  { ci = Boolean(process.env.CI), warn = console.warn } = {},
+) {
+  if (!hasCommit(protocolRepo, headOid)) {
+    throw new Error(`无法读取协议 head commit ${headOid}`);
+  }
+  refreshPublishedBaselines(protocolRepo, { ci, warn });
+  const baselineRefs = readPublishedBaselineRefs(protocolRepo);
+  if (baselineRefs.some((ref) => isAncestor(protocolRepo, headOid, ref))) {
+    return;
+  }
+  throw new Error(
+    `协议提交 ${headOid} 未合入协议仓 main，也未打 client-baseline tag；先完成协议仓发布再更新 gitlink`,
   );
 }
 
@@ -173,6 +254,11 @@ export function validateSubmoduleForward(repoRoot, baseRef, headRef = 'HEAD') {
   const baseOid = readGitlink(repoRoot, baseRef);
   const headOid = readGitlink(repoRoot, headRef);
   const protocolRepo = path.join(repoRoot, SUBMODULE_PATH);
+  const unchangedHistoricalBaseline =
+    baseOid === headOid && UNREACHABLE_BASE_COMMITS.has(headOid);
+  if (!unchangedHistoricalBaseline) {
+    validatePublishedProtocolHead(protocolRepo, headOid);
+  }
   ensureCommit(protocolRepo, baseOid, { allowUnreachableBase: true });
   if (!ensureCommit(protocolRepo, headOid)) {
     throw new Error(`无法准备协议 head commit ${headOid}`);

--- a/scripts/check-submodule-forward.mjs
+++ b/scripts/check-submodule-forward.mjs
@@ -58,10 +58,33 @@ function isAncestor(repoRoot, older, newer) {
   );
 }
 
+function parseCommitMetadata(output) {
+  const [oid, tree, parents = ''] = output.split('\0');
+  return { oid, tree, parents: parents ? parents.split(' ') : [] };
+}
+
 function readCommitMetadata(protocolRepo, oid) {
-  const result = git(protocolRepo, ['show', '-s', '--format=%T%n%P', oid]);
-  const [tree, parents = ''] = result.stdout.trim().split('\n');
-  return { tree, parents: parents ? parents.split(' ') : [] };
+  const result = git(protocolRepo, [
+    'show',
+    '-s',
+    '--format=%H%x00%T%x00%P%x00',
+    oid,
+  ]);
+  const metadata = parseCommitMetadata(result.stdout.trimEnd());
+  return { tree: metadata.tree, parents: metadata.parents };
+}
+
+function readAncestorMetadata(protocolRepo, headOid) {
+  const result = git(protocolRepo, [
+    'log',
+    '--format=%H%x00%T%x00%P%x01',
+    headOid,
+  ]);
+  return result.stdout
+    .trimEnd()
+    .split('\x01')
+    .filter(Boolean)
+    .map(parseCommitMetadata);
 }
 
 function hasEquivalentAncestor(
@@ -78,13 +101,8 @@ function hasEquivalentAncestor(
       : metadata.get(baseOid);
   if (!expected) return false;
 
-  const ancestors = git(protocolRepo, ['rev-list', headOid])
-    .stdout.trim()
-    .split('\n')
-    .filter(Boolean);
-  return ancestors.some((candidateOid) => {
-    if (candidateOid === baseOid) return false;
-    const candidate = readCommitMetadata(protocolRepo, candidateOid);
+  return readAncestorMetadata(protocolRepo, headOid).some((candidate) => {
+    if (candidate.oid === baseOid) return false;
     return (
       candidate.tree === expected.tree &&
       candidate.parents.length === expected.parents.length &&
@@ -131,7 +149,11 @@ export function classifyProtocolRelation(
   return 'diverged';
 }
 
-function ensureCommit(protocolRepo, oid) {
+function ensureCommit(
+  protocolRepo,
+  oid,
+  { allowUnreachableBase = false } = {},
+) {
   if (
     git(protocolRepo, ['cat-file', '-e', `${oid}^{commit}`], {
       allowFailure: true,
@@ -139,6 +161,7 @@ function ensureCommit(protocolRepo, oid) {
   ) {
     return true;
   }
+  if (allowUnreachableBase && UNREACHABLE_BASE_COMMITS.has(oid)) return false;
   return (
     git(protocolRepo, ['fetch', '--no-tags', 'origin', oid], {
       allowFailure: true,
@@ -150,7 +173,7 @@ export function validateSubmoduleForward(repoRoot, baseRef, headRef = 'HEAD') {
   const baseOid = readGitlink(repoRoot, baseRef);
   const headOid = readGitlink(repoRoot, headRef);
   const protocolRepo = path.join(repoRoot, SUBMODULE_PATH);
-  ensureCommit(protocolRepo, baseOid);
+  ensureCommit(protocolRepo, baseOid, { allowUnreachableBase: true });
   if (!ensureCommit(protocolRepo, headOid)) {
     throw new Error(`无法准备协议 head commit ${headOid}`);
   }

--- a/scripts/check-submodule-forward.mjs
+++ b/scripts/check-submodule-forward.mjs
@@ -6,6 +6,20 @@ import { fileURLToPath } from 'node:url';
 
 const SUBMODULE_PATH = 'cindy-protocol';
 
+// 27ef29d was a historical duplicate of e6c95b0. It is no longer reachable
+// from the protocol repository's refs, so CI cannot fetch its commit object.
+// Keep the verified metadata here so this one safe, strict equivalence can be
+// checked without relying on a network lookup or an unreachable object.
+const UNREACHABLE_BASE_COMMITS = new Map([
+  [
+    '27ef29dcb0df1b0f346c82cb7fbb81e9da536a79',
+    {
+      parents: ['0cb87cb52427fbebd8a3d85a271847d06bfb2ac6'],
+      tree: '2b38c6510e36f5c95de9b58b683e0e9c3c896b94',
+    },
+  ],
+]);
+
 function git(cwd, args, { allowFailure = false } = {}) {
   const result = spawnSync('git', args, {
     cwd,
@@ -14,14 +28,18 @@ function git(cwd, args, { allowFailure = false } = {}) {
   });
   if (!allowFailure && result.status !== 0) {
     const detail = (result.stderr || result.stdout || '').trim();
-    throw new Error(`git ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`);
+    throw new Error(
+      `git ${args.join(' ')} failed${detail ? `: ${detail}` : ''}`,
+    );
   }
   return result;
 }
 
 export function readGitlink(repoRoot, ref, submodulePath = SUBMODULE_PATH) {
   const result = git(repoRoot, ['ls-tree', ref, '--', submodulePath]);
-  const match = result.stdout.trim().match(/^160000 commit ([0-9a-f]{40})\t(.+)$/i);
+  const match = result.stdout
+    .trim()
+    .match(/^160000 commit ([0-9a-f]{40})\t(.+)$/i);
   if (!match || match[2] !== submodulePath) {
     throw new Error(`${ref} 中缺少合法的 ${submodulePath} gitlink`);
   }
@@ -35,21 +53,97 @@ function isAncestor(repoRoot, older, newer) {
   if (result.status === 0) return true;
   if (result.status === 1) return false;
   const detail = (result.stderr || result.stdout || '').trim();
-  throw new Error(`无法比较协议历史 ${older.slice(0, 10)}..${newer.slice(0, 10)}${detail ? `: ${detail}` : ''}`);
+  throw new Error(
+    `无法比较协议历史 ${older.slice(0, 10)}..${newer.slice(0, 10)}${detail ? `: ${detail}` : ''}`,
+  );
 }
 
-export function classifyProtocolRelation(protocolRepo, baseOid, headOid) {
+function readCommitMetadata(protocolRepo, oid) {
+  const result = git(protocolRepo, ['show', '-s', '--format=%T%n%P', oid]);
+  const [tree, parents = ''] = result.stdout.trim().split('\n');
+  return { tree, parents: parents ? parents.split(' ') : [] };
+}
+
+function hasEquivalentAncestor(
+  protocolRepo,
+  baseOid,
+  headOid,
+  metadata = UNREACHABLE_BASE_COMMITS,
+) {
+  const expected =
+    git(protocolRepo, ['cat-file', '-e', `${baseOid}^{commit}`], {
+      allowFailure: true,
+    }).status === 0
+      ? readCommitMetadata(protocolRepo, baseOid)
+      : metadata.get(baseOid);
+  if (!expected) return false;
+
+  const ancestors = git(protocolRepo, ['rev-list', headOid])
+    .stdout.trim()
+    .split('\n')
+    .filter(Boolean);
+  return ancestors.some((candidateOid) => {
+    if (candidateOid === baseOid) return false;
+    const candidate = readCommitMetadata(protocolRepo, candidateOid);
+    return (
+      candidate.tree === expected.tree &&
+      candidate.parents.length === expected.parents.length &&
+      candidate.parents.every(
+        (parent, index) => parent === expected.parents[index],
+      )
+    );
+  });
+}
+
+export function classifyProtocolRelation(
+  protocolRepo,
+  baseOid,
+  headOid,
+  { unreachableBaseMetadata = UNREACHABLE_BASE_COMMITS } = {},
+) {
   if (baseOid === headOid) return 'unchanged';
+  const baseAvailable =
+    git(protocolRepo, ['cat-file', '-e', `${baseOid}^{commit}`], {
+      allowFailure: true,
+    }).status === 0;
+  if (
+    !baseAvailable &&
+    hasEquivalentAncestor(
+      protocolRepo,
+      baseOid,
+      headOid,
+      unreachableBaseMetadata,
+    )
+  )
+    return 'forward';
+  if (!baseAvailable) throw new Error(`无法读取协议 base commit ${baseOid}`);
   if (isAncestor(protocolRepo, baseOid, headOid)) return 'forward';
   if (isAncestor(protocolRepo, headOid, baseOid)) return 'rollback';
+  if (
+    hasEquivalentAncestor(
+      protocolRepo,
+      baseOid,
+      headOid,
+      unreachableBaseMetadata,
+    )
+  )
+    return 'forward';
   return 'diverged';
 }
 
 function ensureCommit(protocolRepo, oid) {
-  if (git(protocolRepo, ['cat-file', '-e', `${oid}^{commit}`], { allowFailure: true }).status === 0) {
-    return;
+  if (
+    git(protocolRepo, ['cat-file', '-e', `${oid}^{commit}`], {
+      allowFailure: true,
+    }).status === 0
+  ) {
+    return true;
   }
-  git(protocolRepo, ['fetch', '--no-tags', 'origin', oid]);
+  return (
+    git(protocolRepo, ['fetch', '--no-tags', 'origin', oid], {
+      allowFailure: true,
+    }).status === 0
+  );
 }
 
 export function validateSubmoduleForward(repoRoot, baseRef, headRef = 'HEAD') {
@@ -57,7 +151,9 @@ export function validateSubmoduleForward(repoRoot, baseRef, headRef = 'HEAD') {
   const headOid = readGitlink(repoRoot, headRef);
   const protocolRepo = path.join(repoRoot, SUBMODULE_PATH);
   ensureCommit(protocolRepo, baseOid);
-  ensureCommit(protocolRepo, headOid);
+  if (!ensureCommit(protocolRepo, headOid)) {
+    throw new Error(`无法准备协议 head commit ${headOid}`);
+  }
   const relation = classifyProtocolRelation(protocolRepo, baseOid, headOid);
   return { baseRef, headRef, baseOid, headOid, relation };
 }
@@ -68,18 +164,27 @@ function main() {
   const result = validateSubmoduleForward(repoRoot, baseRef);
   const summary = `${result.baseOid.slice(0, 10)} -> ${result.headOid.slice(0, 10)}`;
   if (result.relation === 'rollback') {
-    console.error(`::error file=cindy-protocol::cindy-protocol gitlink 回退: ${summary}`);
+    console.error(
+      `::error file=cindy-protocol::cindy-protocol gitlink 回退: ${summary}`,
+    );
     process.exitCode = 1;
     return;
   }
   if (result.relation === 'diverged') {
-    console.error(`::error file=cindy-protocol::cindy-protocol gitlink 与 base 分叉: ${summary}`);
+    console.error(
+      `::error file=cindy-protocol::cindy-protocol gitlink 与 base 分叉: ${summary}`,
+    );
     process.exitCode = 1;
     return;
   }
-  console.log(`cindy-protocol gitlink ${result.relation === 'forward' ? '前进' : '未变化'}: ${summary}`);
+  console.log(
+    `cindy-protocol gitlink ${result.relation === 'forward' ? '前进' : '未变化'}: ${summary}`,
+  );
 }
 
-if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
   main();
 }

--- a/scripts/check-submodule-forward.mjs
+++ b/scripts/check-submodule-forward.mjs
@@ -250,14 +250,19 @@ function ensureCommit(
   );
 }
 
-export function validateSubmoduleForward(repoRoot, baseRef, headRef = 'HEAD') {
+export function validateSubmoduleForward(
+  repoRoot,
+  baseRef,
+  headRef = 'HEAD',
+  options = {},
+) {
   const baseOid = readGitlink(repoRoot, baseRef);
   const headOid = readGitlink(repoRoot, headRef);
   const protocolRepo = path.join(repoRoot, SUBMODULE_PATH);
   const unchangedHistoricalBaseline =
     baseOid === headOid && UNREACHABLE_BASE_COMMITS.has(headOid);
   if (!unchangedHistoricalBaseline) {
-    validatePublishedProtocolHead(protocolRepo, headOid);
+    validatePublishedProtocolHead(protocolRepo, headOid, options);
   }
   ensureCommit(protocolRepo, baseOid, { allowUnreachableBase: true });
   if (!ensureCommit(protocolRepo, headOid)) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 CI 里检查 `cindy-protocol` 子模块指针的脚本（`check-submodule-forward.mjs`），解决两个问题：

**问题一：没有拦住"指向未发布提交"的更新。** 之前有 PR（#2028）把客户端 main 的协议指针指到了一个只存在于协议仓 feature 分支上的提交（`27ef29d`）。后来协议仓走 PR 流程把同样的内容以新提交（`e6c95b0`）合入 main，feature 分支被删，`27ef29d` 就成了拉不到的悬空提交——客户端 main 锁的指针从此指向一个公开仓里不存在的东西。

**问题二：悬空指针卡死了后续正常更新。** 现在想把指针从 `27ef29d` 更新到协议仓最新 main（#2054），检查脚本用纯祖先关系判断，发现 `27ef29d` 不在新主线的历史上，报"分叉"拒绝。但这次更新实际是安全的前进：`27ef29d` 和主线上的 `e6c95b0` 内容一字不差（同 tree、同父提交），只是提交 SHA 不同。

### 怎么修的（三层检查）

1. **新增发布状态检查（治根）**：更新协议指针时，新指针必须能从协议仓 `origin/main` 或 `client-baseline-*` tag 追溯到（这两种是仓库规则认可的发布方式）。指向 feature 分支提交会被当场拒绝，并提示"先完成协议仓发布再更新 gitlink"。以后不会再产生悬空指针。
2. **保留原有祖先关系检查**：前进放行，回退、分叉照旧拒绝。
3. **历史悬空指针的一次性兼容（保底）**：`27ef29d` 的父提交和 tree 信息（已与协议仓实际对象核对一致）硬编码为白名单。只有当新指针的历史里存在一个与它内容、父提交完全相同的重复提交时，才认定为安全前进。因为第 1 层保证以后不会再有悬空指针，这个白名单不会再增长，只为这一次历史修复兜底。

另外处理了两个细节：白名单里的悬空提交不再发起注定失败的网络 fetch（否则每个 PR 的 verify 都白跑一次）；读取祖先信息改为一次 `git log` 批量拿，不再逐个提交起子进程。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：解锁 #2054（协议指针同步 `27ef29d → 9fcfe5f`）；根因来自 #2028 的指针操作。
- 本 PR 包含：`scripts/check-submodule-forward.mjs` 三层检查与 fail-closed 边界；测试从 1 项扩到 11 项。
- 明确不包含：协议指针本身的更新（在 #2054）、协议仓与服务端改动。
- 用户可见变化：无（仅 CI 检查脚本）。
- 是否存在 breaking change：无。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
node --test scripts/__tests__/check-submodule-forward.test.mjs
结果：11/11 通过。覆盖：常规 unchanged/forward/rollback/diverged；
feature-only 指针被发布检查拒绝；main 上的指针放行；仅有
client-baseline tag 的指针放行；本地 fetch 失败退用 origin/main；
悬空白名单指针严格等价放行；tree 相同但父提交不同拒绝；
未知悬空指针拒绝；base fetch 失败不误放行。

pnpm test:runner
结果：385 tests，384 pass，1 skip，0 fail。

pnpm check:submodule-forward（本地，base=origin/main）
结果：cindy-protocol gitlink 未变化: 27ef29dcb0 -> 27ef29dcb0。

pnpm check:dco
结果：3 commits signed off，通过。

git diff --check / Prettier
结果：通过。
```

### 手工验证

在协议仓真实历史上验证：`27ef29d`（悬空）→ `9fcfe5f`（协议 main 最新）判定为 forward；随机构造的 40 位假 SHA 被拒绝。CI/本地分流：CI 上刷新协议基线失败一律报错；本地离线且已有 origin/main 时警告后退用本地引用。

### 未执行的验证

真实 CI 环境的端到端运行由本 PR 与 #2054 的 CI 验证。此前一轮 CI 中 Windows 单测分片挂过 3 个与本 PR 无关的已知 flaky 用例（lizi-mcps 分批回写超时、maker-core 扫描预算、desktop 模型面板时序，均在 main 上有各自的 flake 修复记录），已重跑。

## 风险

### 风险分类

- [x] 其他：CI 守门脚本的判定边界

### 影响与回滚

- 影响范围：仅 PR CI 的 verify 步骤对协议指针的检查。整体是收紧：新增"必须已发布"这道此前不存在的检查；唯一放宽只针对内容与父提交完全相同的重复提交，语义上等价于正常前进。
- 特例说明：base 与 head 同为悬空白名单提交且未变化时跳过发布检查——否则 #2054 合并前所有不动指针的 PR 都会被卡；该特例被白名单 OID + 未变化双条件限死，普通提交无法借道。
- 回滚 / 降级方式：revert 本 PR，检查回到纯祖先关系判定（#2054 将重新被卡，指向 feature 分支的指针也重新无人拦截）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)