### PR TITLE
test(desktop): 稳定 OAuth 固定端口交接测试

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
@@ -70,27 +70,16 @@ async function probeFreePort(): Promise<number> {
  * LISTEN_FAILED 就是回归,必须原样交给断言。若也一并重试,换个端口跑一次碰巧成功
  * 就把回归掩盖掉了。所以 body 的第一个元素必须是"初始 bind 那一单"的结果。
  */
-type PinnedPortPicker = (attempt: number) => number | Promise<number>;
-
 async function pinnedPortCase<T extends readonly unknown[]>(
   body: (port: number) => Promise<T>,
   attempts = 5,
-  pickPort: PinnedPortPicker = () => probeFreePort(),
 ): Promise<T> {
   let last!: T;
-  for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    last = await body(await pickPort(attempt - 1));
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    last = await body(await probeFreePort());
     if (!isListenFailed(last[0])) return last;
   }
   return last;
-}
-
-/**
- * 为需要固定端口交接的用例选 worker 级候选端口。低于常见系统动态端口范围,
- * 避免其它 listen(0) 在前一单释放到下一单重绑的窗口随机拿走被测端口。
- */
-function pickNonEphemeralPinnedPort(attempt: number): number {
-  return 20_000 + ((process.pid + attempt) % 10_000);
 }
 
 /** 只认引擎明确报出的 LISTEN_FAILED;形状不符的值一律不算"端口被抢"。 */
@@ -415,34 +404,35 @@ describe('startGhostOauthFlow', () => {
 
   it('钉死端口:第二单还在排队时第三单进场——前两单 CANCELLED,最后一单赢', async () => {
     const neverOpen = vi.fn();
-    const [firstResult, secondResult, thirdResult] = await pinnedPortCase(
-      async (fixedPort) => {
-        let secondDone: Promise<unknown> = Promise.resolve();
-        let thirdDone: Promise<unknown> = Promise.resolve();
-        const first = await startGhostOauthFlow({
+    let secondDone: Promise<unknown> = Promise.resolve();
+    let thirdDone: Promise<unknown> = Promise.resolve();
+    const firstResult = await startGhostOauthFlow({
+      config: { ...BASE_CONFIG, pkce: false },
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: (url) => {
+        const redirectUri = new URL(url).searchParams.get('redirect_uri');
+        if (!redirectUri) throw new Error('authorize URL 缺 redirect_uri');
+        const fixedPort = Number(new URL(redirectUri).port);
+        if (!fixedPort) throw new Error('redirect_uri 缺端口');
+
+        // 第一单已由系统分配并占住端口;第二单进场(排队等第一单收尾),
+        // 紧接着第三单进场顶掉排队中的第二单,两单都显式复用第一单的实际端口。
+        secondDone = startGhostOauthFlow({
           config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
           fetchImpl: vi.fn() as unknown as typeof fetch,
-          openExternal: () => {
-            // 第二单进场(排队等第一单收尾),紧接着第三单进场顶掉排队中的第二单。
-            secondDone = startGhostOauthFlow({
-              config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-              fetchImpl: vi.fn() as unknown as typeof fetch,
-              openExternal: neverOpen,
-            });
-            thirdDone = startGhostOauthFlow({
-              config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-              fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-third' })) as unknown as typeof fetch,
-              openExternal: (url3) => {
-                browserRedirect(url3, (au) => ({ code: 'c-third', state: au.searchParams.get('state') ?? '' }));
-              },
-            });
+          openExternal: neverOpen,
+        });
+        thirdDone = startGhostOauthFlow({
+          config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-third' })) as unknown as typeof fetch,
+          openExternal: (url3) => {
+            browserRedirect(url3, (au) => ({ code: 'c-third', state: au.searchParams.get('state') ?? '' }));
           },
         });
-        return [first, await secondDone, await thirdDone];
       },
-      5,
-      pickNonEphemeralPinnedPort,
-    );
+    });
+    const secondResult = await secondDone;
+    const thirdResult = await thirdDone;
     expect(firstResult).toMatchObject({ ok: false, error: 'CANCELLED' });
     expect(secondResult).toMatchObject({ ok: false, error: 'CANCELLED' });
     expect(thirdResult).toMatchObject({ ok: true });

--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
@@ -70,16 +70,27 @@ async function probeFreePort(): Promise<number> {
  * LISTEN_FAILED 就是回归,必须原样交给断言。若也一并重试,换个端口跑一次碰巧成功
  * 就把回归掩盖掉了。所以 body 的第一个元素必须是"初始 bind 那一单"的结果。
  */
+type PinnedPortPicker = (attempt: number) => number | Promise<number>;
+
 async function pinnedPortCase<T extends readonly unknown[]>(
   body: (port: number) => Promise<T>,
   attempts = 5,
+  pickPort: PinnedPortPicker = () => probeFreePort(),
 ): Promise<T> {
   let last!: T;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
-    last = await body(await probeFreePort());
+    last = await body(await pickPort(attempt - 1));
     if (!isListenFailed(last[0])) return last;
   }
   return last;
+}
+
+/**
+ * 为需要固定端口交接的用例选 worker 级候选端口。低于常见系统动态端口范围,
+ * 避免其它 listen(0) 在前一单释放到下一单重绑的窗口随机拿走被测端口。
+ */
+function pickNonEphemeralPinnedPort(attempt: number): number {
+  return 20_000 + ((process.pid + attempt) % 10_000);
 }
 
 /** 只认引擎明确报出的 LISTEN_FAILED;形状不符的值一律不算"端口被抢"。 */
@@ -429,6 +440,8 @@ describe('startGhostOauthFlow', () => {
         });
         return [first, await secondDone, await thirdDone];
       },
+      5,
+      pickNonEphemeralPinnedPort,
     );
     expect(firstResult).toMatchObject({ ok: false, error: 'CANCELLED' });
     expect(secondResult).toMatchObject({ ok: false, error: 'CANCELLED' });


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `ghostOauthFlow.test.ts` 三单固定端口交接用例的偶发失败。

PR #2039 的 verify 曾出现唯一失败：

- `apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts`
- “钉死端口:第二单还在排队时第三单进场——前两单 CANCELLED,最后一单赢”
- 第三单返回 `ok: false`，断言期望 `ok: true`
- 失败耗时约 26ms，符合立即 `LISTEN_FAILED`，不是 timeout 或 OAuth 回调/token 交换失败。

根因是测试先用 `listen(0)` 探测并释放临时端口；第一单结束后，其他并行测试可能在第三单重绑前拿走同一个动态端口。生产侧 `activeSettled` 和监听关闭语义没有证据表明有 bug。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：PR #2039 verify 中的既有 CI flaky test
- 本 PR 包含：为固定端口测试 helper 增加可注入端口选择器；目标三单用例改用 worker 级、低于常见系统动态端口范围的候选端口。
- 明确不包含：不改 `ghostOauthFlow.ts` 生产逻辑；不改 PR #2039 的 Claude continuation 或其它权限改动；不恢复对后续 `LISTEN_FAILED` 的重试。
- 用户可见变化：无。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop test --run src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
结果：41/41 通过

目标用例重复 50 次
结果：50/50 通过

8 路并发运行目标用例，共 40 次
结果：40/40 通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过；Desktop、Mobile 及所有 required package workspace 通过，既有 notApplicable workspace 按仓库规则跳过

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

Windows 本地未实测，依赖 CI 的 Windows unit tests 两个 shard 验证。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop OAuth 单测端口夹具；生产行为、OAuth 协议和 UI 均不变。低端口候选按进程 PID 与尝试次数区分；若初始候选被占用，沿用现有“仅首单 LISTEN_FAILED 才换端口”的测试重跑语义。
- 回滚 / 降级方式：回退本 PR 的单个测试提交即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果