### PR TITLE
feat(desktop): add plan mode composer command

### DIFF
--- a/apps/desktop/src/renderer/__tests__/effortRuntimeDirtySendGuard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/effortRuntimeDirtySendGuard.test.ts
@@ -16,6 +16,7 @@ describe('effort runtime send guard', () => {
     expect(chatInputSource).toContain('const composerMutationLocked = composerEditorLocked || voiceInput.isBusy;');
     expect(chatInputSource).toContain('editable: !composerEditorLocked');
     expect(chatInputSource).toContain('if (composerMutationLockedRef.current) return true;');
+    expect(chatInputSource).toContain("trigger.kind !== 'slash' || composerMutationLockedRef.current");
     expect(chatInputSource).toContain('if (composerMutationLocked) return;');
     expect(chatInputSource).toContain("id: 'attach-files'");
     expect(chatInputSource).toContain(

--- a/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
@@ -70,5 +70,10 @@ describe('/plan composer command', () => {
     expect(isPlanModeComposerCommandText('  /PLAN  ', true)).toBe(true);
     expect(isPlanModeComposerCommandText('/plan explain this', true)).toBe(false);
     expect(isPlanModeComposerCommandText('/plan', false)).toBe(false);
+    expect(
+      isPlanModeComposerCommandText('/plan', true, [
+        { kind: 'agent-skill', name: 'PLAN', source: 'skill' },
+      ]),
+    ).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
@@ -1,0 +1,66 @@
+import { Schema } from '@tiptap/pm/model';
+import { EditorState } from '@tiptap/pm/state';
+import { describe, expect, it } from 'vitest';
+
+import {
+  addPlanModeComposerCommand,
+  consumePlanModeComposerCommand,
+} from '../components/new-chat/planModeComposerCommand';
+import type { UnifiedCommand } from '../lib/slashCommands';
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'paragraph+' },
+    paragraph: { content: 'text*' },
+    text: {},
+  },
+});
+
+const desktopCommand = (name: string): UnifiedCommand => ({
+  kind: 'desktop',
+  name,
+  description: `${name} command`,
+});
+
+function stateWithText(text: string): EditorState {
+  return EditorState.create({
+    schema,
+    doc: schema.nodes.doc.create(null, schema.nodes.paragraph.create(null, schema.text(text))),
+  });
+}
+
+describe('/plan composer command', () => {
+  it('is only advertised when available and preserves an existing command', () => {
+    const commands = [desktopCommand('help')];
+    const existing: UnifiedCommand[] = [
+      { kind: 'agent-skill', name: 'PLAN', source: 'skill' },
+    ];
+
+    expect(addPlanModeComposerCommand(commands, null)).toBe(commands);
+    expect(
+      addPlanModeComposerCommand(commands, 'Plan mode').map((command) => command.name),
+    ).toEqual(['plan', 'help']);
+    expect(addPlanModeComposerCommand(existing, 'Plan mode')).toBe(existing);
+  });
+
+  it('removes the selected command token while preserving surrounding draft text', () => {
+    const state = stateWithText('Ask first /plan then continue');
+    const tr = state.tr;
+
+    expect(consumePlanModeComposerCommand(tr, 11, 16, desktopCommand('plan'), true)).toBe(true);
+    expect(tr.doc.textContent).toBe('Ask first  then continue');
+  });
+
+  it('does not consume unsupported or non-plan commands', () => {
+    const state = stateWithText('/plan');
+    const unsupported = state.tr;
+    const other = state.tr;
+
+    expect(consumePlanModeComposerCommand(unsupported, 1, 6, desktopCommand('plan'), false)).toBe(
+      false,
+    );
+    expect(unsupported.doc.textContent).toBe('/plan');
+    expect(consumePlanModeComposerCommand(other, 1, 6, desktopCommand('help'), true)).toBe(false);
+    expect(other.doc.textContent).toBe('/plan');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
@@ -6,6 +6,7 @@ import {
   addPlanModeComposerCommand,
   consumePlanModeComposerCommand,
   isPlanModeComposerCommandText,
+  shouldPreservePlanModeComposerDraft,
 } from '../components/new-chat/planModeComposerCommand';
 import type { UnifiedCommand } from '../lib/slashCommands';
 
@@ -76,5 +77,11 @@ describe('/plan composer command', () => {
         { kind: 'agent-skill', name: 'PLAN', source: 'skill' },
       ]),
     ).toBe(false);
+  });
+
+  it('preserves supplementary draft content when consuming plan mode', () => {
+    expect(shouldPreservePlanModeComposerDraft(1, 0)).toBe(true);
+    expect(shouldPreservePlanModeComposerDraft(0, 1)).toBe(true);
+    expect(shouldPreservePlanModeComposerDraft(0, 0)).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest';
 import {
   addPlanModeComposerCommand,
   consumePlanModeComposerCommand,
+  isPlanModeComposerCommandText,
 } from '../components/new-chat/planModeComposerCommand';
 import type { UnifiedCommand } from '../lib/slashCommands';
 
@@ -62,5 +63,12 @@ describe('/plan composer command', () => {
     expect(unsupported.doc.textContent).toBe('/plan');
     expect(consumePlanModeComposerCommand(other, 1, 6, desktopCommand('help'), true)).toBe(false);
     expect(other.doc.textContent).toBe('/plan');
+  });
+
+  it('recognizes only an available standalone plan command on send', () => {
+    expect(isPlanModeComposerCommandText('/plan', true)).toBe(true);
+    expect(isPlanModeComposerCommandText('  /PLAN  ', true)).toBe(true);
+    expect(isPlanModeComposerCommandText('/plan explain this', true)).toBe(false);
+    expect(isPlanModeComposerCommandText('/plan', false)).toBe(false);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planModeComposerCommand.test.ts
@@ -66,10 +66,11 @@ describe('/plan composer command', () => {
   });
 
   it('recognizes only an available standalone plan command on send', () => {
-    expect(isPlanModeComposerCommandText('/plan', true)).toBe(true);
-    expect(isPlanModeComposerCommandText('  /PLAN  ', true)).toBe(true);
-    expect(isPlanModeComposerCommandText('/plan explain this', true)).toBe(false);
-    expect(isPlanModeComposerCommandText('/plan', false)).toBe(false);
+    expect(isPlanModeComposerCommandText('/plan', true, [])).toBe(true);
+    expect(isPlanModeComposerCommandText('  /PLAN  ', true, [])).toBe(true);
+    expect(isPlanModeComposerCommandText('/plan explain this', true, [])).toBe(false);
+    expect(isPlanModeComposerCommandText('/plan', false, [])).toBe(false);
+    expect(isPlanModeComposerCommandText('/plan', true, null)).toBe(false);
     expect(
       isPlanModeComposerCommandText('/plan', true, [
         { kind: 'agent-skill', name: 'PLAN', source: 'skill' },

--- a/apps/desktop/src/renderer/__tests__/slashCommandRosterState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/slashCommandRosterState.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  beginSlashCommandRosterLoad,
+  EMPTY_SLASH_COMMANDS,
+  failSlashCommandRosterLoad,
+  isSlashCommandRosterReady,
+  type SlashCommandRosterState,
+  type UnifiedCommand,
+} from '../lib/slashCommands';
+
+const help: UnifiedCommand = {
+  kind: 'desktop',
+  name: 'help',
+  description: 'Open help',
+};
+
+function ready(contextKey = 'local'): SlashCommandRosterState {
+  return { contextKey, status: 'ready', commands: [help] };
+}
+
+describe('slash command roster refresh state', () => {
+  it('keeps the successful same-context roster available during refresh', () => {
+    const state = beginSlashCommandRosterLoad(ready(), 'local');
+
+    expect(state).toEqual({ contextKey: 'local', status: 'refreshing', commands: [help] });
+    expect(isSlashCommandRosterReady(state, 'local')).toBe(true);
+  });
+
+  it('restores the previous roster when a same-context refresh fails', () => {
+    const state = failSlashCommandRosterLoad(
+      { contextKey: 'local', status: 'refreshing', commands: [help] },
+      'local',
+    );
+
+    expect(state).toEqual({ contextKey: 'local', status: 'ready', commands: [help] });
+    expect(isSlashCommandRosterReady(state, 'local')).toBe(true);
+  });
+
+  it('clears commands until a new context finishes loading', () => {
+    const loading = beginSlashCommandRosterLoad(ready('local'), 'remote');
+
+    expect(loading).toEqual({
+      contextKey: 'remote',
+      status: 'loading',
+      commands: EMPTY_SLASH_COMMANDS,
+    });
+    expect(isSlashCommandRosterReady(loading, 'remote')).toBe(false);
+    expect(failSlashCommandRosterLoad(loading, 'remote')).toEqual({
+      contextKey: 'remote',
+      status: 'error',
+      commands: EMPTY_SLASH_COMMANDS,
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -4230,7 +4230,11 @@ export function ChatInput({
         if (
           attachmentsForSend.length === 0 &&
           commentsForSend.length === 0 &&
-          isPlanModeComposerCommandText(editorText, planModeEntry !== undefined)
+          isPlanModeComposerCommandText(
+            editorText,
+            planModeEntry !== undefined,
+            mergedCommands,
+          )
         ) {
           planModeEntry?.onToggle(!planModeEntry.enabled);
           isRestoringRef.current = true;

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -205,7 +205,16 @@ import { Fragment, Slice, type Node as ProseMirrorNode } from '@tiptap/pm/model'
 import { Selection, TextSelection } from '@tiptap/pm/state';
 import * as sessionService from '@/lib/sessionService';
 import { getModelById } from '@/lib/modelDefinitions';
-import { loadAllCommands, filterSlashCommands, type UnifiedCommand } from '@/lib/slashCommands';
+import {
+  beginSlashCommandRosterLoad,
+  EMPTY_SLASH_COMMANDS,
+  failSlashCommandRosterLoad,
+  filterSlashCommands,
+  isSlashCommandRosterReady,
+  loadAllCommands,
+  type SlashCommandRosterState,
+  type UnifiedCommand,
+} from '@/lib/slashCommands';
 import {
   AT_MENTION_EMPTY_WORKSPACE_SCAN_CAP,
   getAtDirectoryCompletionQuery,
@@ -3411,18 +3420,19 @@ export function ChatInput({
     isRemoteSession,
     deviceLinkDeviceId ?? null,
   ]);
-  const [slashCommandLoadState, setSlashCommandLoadState] = useState<{
-    contextKey: string;
-    status: 'loading' | 'ready' | 'error';
-    commands: UnifiedCommand[];
-  }>({ contextKey: '', status: 'loading', commands: [] });
-  const slashCommandsReady =
-    slashCommandLoadState.contextKey === slashCommandContextKey &&
-    slashCommandLoadState.status === 'ready';
+  const [slashCommandLoadState, setSlashCommandLoadState] = useState<SlashCommandRosterState>({
+    contextKey: '',
+    status: 'loading',
+    commands: EMPTY_SLASH_COMMANDS,
+  });
+  const slashCommandsReady = isSlashCommandRosterReady(
+    slashCommandLoadState,
+    slashCommandContextKey,
+  );
   const mergedCommands =
     slashCommandLoadState.contextKey === slashCommandContextKey
       ? slashCommandLoadState.commands
-      : [];
+      : EMPTY_SLASH_COMMANDS;
   const planModeCommandAvailable = planModeEntry !== undefined;
   const composerSlashCommands = useMemo(
     () =>
@@ -3442,11 +3452,9 @@ export function ChatInput({
   const reloadSlashCommands = useCallback(
     (opts?: { forceReload?: boolean }) => {
       const seq = ++slashCommandLoadSeqRef.current;
-      setSlashCommandLoadState({
-        contextKey: slashCommandContextKey,
-        status: 'loading',
-        commands: [],
-      });
+      setSlashCommandLoadState((current) =>
+        beginSlashCommandRosterLoad(current, slashCommandContextKey),
+      );
       // device-link 远程会话:agent-builtin / agent-skill 从被控端读(deviceLinkDeviceId);
       // workingDir 是被控端路径；SSH remote 显式关扫描。desktop 命令始终本地。
       loadAllCommands(
@@ -3466,11 +3474,9 @@ export function ChatInput({
         })
         .catch(() => {
           if (slashCommandLoadSeqRef.current === seq) {
-            setSlashCommandLoadState({
-              contextKey: slashCommandContextKey,
-              status: 'error',
-              commands: [],
-            });
+            setSlashCommandLoadState((current) =>
+              failSlashCommandRosterLoad(current, slashCommandContextKey),
+            );
           }
         });
     },

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -140,6 +140,10 @@ import { ExtraDirsButton, type CollaborationMenuConfig } from './ExtraDirsButton
 import { focusComposerEndNextFrame, placeGhostAtComposerStart } from './ghostComposerPlacement';
 import { NewGoalDialog } from './NewGoalDialog';
 import { PlanModeIndicator } from './PlanModeIndicator';
+import {
+  addPlanModeComposerCommand,
+  consumePlanModeComposerCommand,
+} from './planModeComposerCommand';
 import { PendingQueuePanel } from './PendingQueuePanel';
 import { SendButton } from './SendButton';
 import { FolderPickerPopover, addRecentFolder } from './FolderPickerPopover';
@@ -3397,6 +3401,15 @@ export function ChatInput({
   // Slash commands — palette refactor 后改成 loadAllCommands 一次性拉三源(desktop +
   // agent-builtin + agent-skill); 内部并发, mergeCommands 按优先级合并去重。
   const [mergedCommands, setMergedCommands] = useState<UnifiedCommand[]>([]);
+  const planModeCommandAvailable = planModeEntry !== undefined;
+  const composerSlashCommands = useMemo(
+    () =>
+      addPlanModeComposerCommand(
+        mergedCommands,
+        planModeCommandAvailable ? t('planMode.menuItem') : null,
+      ),
+    [mergedCommands, planModeCommandAvailable, t],
+  );
   const paletteAgentKind = agentKind ?? 'claude-code';
   // remote session:workingDir 是远端主机路径,不能按它扫本机 skills/files。
   // slash 退化为 desktop + agent-builtin(传 null),@ 文件面板直接关闭(见 atOpen)。
@@ -3441,8 +3454,8 @@ export function ChatInput({
   // Slash 指令与 $意识一致:doc 保持可逐字编辑的普通文本,完整命中当前 roster
   // 时才由 decoration 显示确认胶囊。异步 roster 刷新不进入 keystroke 热路径。
   useEffect(() => {
-    setSlashCommandRoster(editor, mergedCommands);
-  }, [editor, mergedCommands]);
+    setSlashCommandRoster(editor, composerSlashCommands);
+  }, [editor, composerSlashCommands]);
   // 意识指令源($ 触发):复用窗口级已装意识快照,避免输入触发符时同步扫盘。
   // 目录级禁用同判:被禁用的意识不进 $ 菜单(与胶囊 / 发送期展开同源)。
   const isGhostSigil = trigger.kind === 'slash' && trigger.sigil === '$';
@@ -3460,7 +3473,7 @@ export function ChatInput({
       );
   }, [ghostsForCommand, isGhostSigil, t]);
   // 面板显示与键盘导航共用同一份命令源:$ 只列意识,/ 只列技能/命令。
-  const paletteCommands = isGhostSigil ? ghostCommandItems : mergedCommands;
+  const paletteCommands = isGhostSigil ? ghostCommandItems : composerSlashCommands;
   const filteredCommands = useMemo(
     () => (trigger.kind === 'slash' ? filterSlashCommands(paletteCommands, trigger.query) : []),
     [paletteCommands, trigger],
@@ -3815,6 +3828,7 @@ export function ChatInput({
   useEffect(() => {
     panelBridgeRef.current = {
       captureKey: (e) => {
+        if (e.isComposing) return false;
         if (!slashOpen && !atOpen) return false;
         switch (e.key) {
           case 'ArrowDown':
@@ -3907,10 +3921,19 @@ export function ChatInput({
         }
         runEnd = parentStart + childOffset + text.length;
       });
-      editor
+      let planModeCommandConsumed = false;
+      const applied = editor
         .chain()
         .focus()
         .command(({ tr }) => {
+          planModeCommandConsumed = consumePlanModeComposerCommand(
+            tr,
+            from,
+            runEnd,
+            cmd,
+            planModeCommandAvailable && trigger.sigil === '/',
+          );
+          if (planModeCommandConsumed) return true;
           if (trigger.sigil === '$') {
             // 意识指令:纯文本 `$命令 `(不建 chip)——发送期由 expandGhostCommand
             // 识别并追加机器指令,序列化零特判。
@@ -3923,8 +3946,11 @@ export function ChatInput({
           return true;
         })
         .run();
+      if (applied && planModeCommandConsumed) {
+        planModeEntry?.onToggle(!planModeEntry.enabled);
+      }
     },
-    [editor, trigger],
+    [editor, planModeCommandAvailable, planModeEntry, trigger],
   );
 
   const resolveEffectiveAtRange = useCallback((): { from: number; to: number } | null => {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -3401,20 +3401,37 @@ export function ChatInput({
 
   // Slash commands — palette refactor 后改成 loadAllCommands 一次性拉三源(desktop +
   // agent-builtin + agent-skill); 内部并发, mergeCommands 按优先级合并去重。
-  const [mergedCommands, setMergedCommands] = useState<UnifiedCommand[]>([]);
+  const paletteAgentKind = agentKind ?? 'claude-code';
+  // remote session:workingDir 是远端主机路径,不能按它扫本机 skills/files。
+  // slash 退化为 desktop + agent-builtin(传 null),@ 文件面板直接关闭(见 atOpen)。
+  const isRemoteSession = !!remoteHostId;
+  const slashCommandContextKey = JSON.stringify([
+    workingDir ?? null,
+    paletteAgentKind,
+    isRemoteSession,
+    deviceLinkDeviceId ?? null,
+  ]);
+  const [slashCommandLoadState, setSlashCommandLoadState] = useState<{
+    contextKey: string;
+    status: 'loading' | 'ready' | 'error';
+    commands: UnifiedCommand[];
+  }>({ contextKey: '', status: 'loading', commands: [] });
+  const slashCommandsReady =
+    slashCommandLoadState.contextKey === slashCommandContextKey &&
+    slashCommandLoadState.status === 'ready';
+  const mergedCommands =
+    slashCommandLoadState.contextKey === slashCommandContextKey
+      ? slashCommandLoadState.commands
+      : [];
   const planModeCommandAvailable = planModeEntry !== undefined;
   const composerSlashCommands = useMemo(
     () =>
       addPlanModeComposerCommand(
         mergedCommands,
-        planModeCommandAvailable ? t('planMode.menuItem') : null,
+        planModeCommandAvailable && slashCommandsReady ? t('planMode.menuItem') : null,
       ),
-    [mergedCommands, planModeCommandAvailable, t],
+    [mergedCommands, planModeCommandAvailable, slashCommandsReady, t],
   );
-  const paletteAgentKind = agentKind ?? 'claude-code';
-  // remote session:workingDir 是远端主机路径,不能按它扫本机 skills/files。
-  // slash 退化为 desktop + agent-builtin(传 null),@ 文件面板直接关闭(见 atOpen)。
-  const isRemoteSession = !!remoteHostId;
   const slashCommandLoadSeqRef = useRef(0);
   useEffect(
     () => () => {
@@ -3425,6 +3442,11 @@ export function ChatInput({
   const reloadSlashCommands = useCallback(
     (opts?: { forceReload?: boolean }) => {
       const seq = ++slashCommandLoadSeqRef.current;
+      setSlashCommandLoadState({
+        contextKey: slashCommandContextKey,
+        status: 'loading',
+        commands: [],
+      });
       // device-link 远程会话:agent-builtin / agent-skill 从被控端读(deviceLinkDeviceId);
       // workingDir 是被控端路径；SSH remote 显式关扫描。desktop 命令始终本地。
       loadAllCommands(
@@ -3434,21 +3456,32 @@ export function ChatInput({
         deviceLinkDeviceId,
       )
         .then((cmds) => {
-          if (slashCommandLoadSeqRef.current === seq) setMergedCommands(cmds);
+          if (slashCommandLoadSeqRef.current === seq) {
+            setSlashCommandLoadState({
+              contextKey: slashCommandContextKey,
+              status: 'ready',
+              commands: cmds,
+            });
+          }
         })
         .catch(() => {
-          if (slashCommandLoadSeqRef.current === seq) setMergedCommands([]);
+          if (slashCommandLoadSeqRef.current === seq) {
+            setSlashCommandLoadState({
+              contextKey: slashCommandContextKey,
+              status: 'error',
+              commands: [],
+            });
+          }
         });
     },
-    [workingDir, paletteAgentKind, isRemoteSession, deviceLinkDeviceId],
+    [
+      workingDir,
+      paletteAgentKind,
+      isRemoteSession,
+      deviceLinkDeviceId,
+      slashCommandContextKey,
+    ],
   );
-  // context(workingDir / agentKind / remote)变化时先同步清空命令缓存:切换会话(尤其
-  // local→remote)那一瞬,reloadSlashCommands 是异步的,清空可避免 palette 在刷新完成前
-  // 残留上一个项目的本地 skills。下面的 reload effect 紧接着用新 context 重填。
-  // biome-ignore lint/correctness/useExhaustiveDependencies: 这里用依赖数组表达上下文切换触发清空，effect 内不直接读取这些值。
-  useEffect(() => {
-    setMergedCommands([]);
-  }, [workingDir, paletteAgentKind, isRemoteSession, deviceLinkDeviceId]);
   useEffect(() => {
     reloadSlashCommands();
   }, [reloadSlashCommands]);
@@ -4233,7 +4266,7 @@ export function ChatInput({
           isPlanModeComposerCommandText(
             editorText,
             planModeEntry !== undefined,
-            mergedCommands,
+            slashCommandsReady ? mergedCommands : null,
           )
         ) {
           planModeEntry?.onToggle(!planModeEntry.enabled);

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -143,6 +143,7 @@ import { PlanModeIndicator } from './PlanModeIndicator';
 import {
   addPlanModeComposerCommand,
   consumePlanModeComposerCommand,
+  isPlanModeComposerCommandText,
 } from './planModeComposerCommand';
 import { PendingQueuePanel } from './PendingQueuePanel';
 import { SendButton } from './SendButton';
@@ -3894,7 +3895,14 @@ export function ChatInput({
   // ── Palette insertions ─────────────────────────────────────────────
   const insertSlashCommand = useCallback(
     (cmd: UnifiedCommand) => {
-      if (!editor || trigger.kind !== 'slash' || composerMutationLockedRef.current) return;
+      if (
+        !editor ||
+        editor.isDestroyed ||
+        trigger.kind !== 'slash' || composerMutationLockedRef.current ||
+        editor.view.composing
+      ) {
+        return;
+      }
       const { from } = trigger;
       // Replace the WHOLE slash-run, not just up-to-caret: the user may
       // have moved the caret back inside the run (e.g. `/compa|ct`) and
@@ -4219,6 +4227,24 @@ export function ChatInput({
         const commentsForSend = optimisticallyClearRemoteComposer
           ? commentsBeforeOptimisticClear
           : [...browserCommentsRef.current];
+        if (
+          attachmentsForSend.length === 0 &&
+          commentsForSend.length === 0 &&
+          isPlanModeComposerCommandText(editorText, planModeEntry !== undefined)
+        ) {
+          planModeEntry?.onToggle(!planModeEntry.enabled);
+          isRestoringRef.current = true;
+          try {
+            editor.commands.clearContent(true);
+          } finally {
+            isRestoringRef.current = false;
+          }
+          historyIndexRef.current = -1;
+          hydratedHistoryDocumentRef.current = null;
+          draftRef.current = null;
+          if (sourceStorageKey) clearComposerDraft(sourceStorageKey);
+          return;
+        }
         // composerQuote 在其正文位置序列化成 markdown blockquote,支持引用与回复交错。
         // browser-comment-chip:页面评论序列化为 `# Browser comments:` 段拼在正文后
         // (截图在下方并入 filesToSend,与文本块里的 "attached as a labeled image"
@@ -4719,6 +4745,7 @@ export function ChatInput({
       remoteModelListStatus,
       confirmDialog,
       navigate,
+      planModeEntry,
     ],
   );
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -144,6 +144,7 @@ import {
   addPlanModeComposerCommand,
   consumePlanModeComposerCommand,
   isPlanModeComposerCommandText,
+  shouldPreservePlanModeComposerDraft,
 } from './planModeComposerCommand';
 import { PendingQueuePanel } from './PendingQueuePanel';
 import { SendButton } from './SendButton';
@@ -4267,8 +4268,6 @@ export function ChatInput({
           ? commentsBeforeOptimisticClear
           : [...browserCommentsRef.current];
         if (
-          attachmentsForSend.length === 0 &&
-          commentsForSend.length === 0 &&
           isPlanModeComposerCommandText(
             editorText,
             planModeEntry !== undefined,
@@ -4285,7 +4284,28 @@ export function ChatInput({
           historyIndexRef.current = -1;
           hydratedHistoryDocumentRef.current = null;
           draftRef.current = null;
-          if (sourceStorageKey) clearComposerDraft(sourceStorageKey);
+          if (sourceStorageKey) {
+            if (
+              shouldPreservePlanModeComposerDraft(
+                attachmentsForSend.length,
+                commentsForSend.length,
+              )
+            ) {
+              const existingDraft = getComposerDraft(sourceStorageKey);
+              saveComposerDraft(
+                sourceStorageKey,
+                {
+                  text: editor.getJSON(),
+                  attachments: attachmentsForSend,
+                  quotes: existingDraft?.quotes ?? [],
+                  browserComments: commentsForSend,
+                },
+                { silent: true },
+              );
+            } else {
+              clearComposerDraft(sourceStorageKey);
+            }
+          }
           return;
         }
         // composerQuote 在其正文位置序列化成 markdown blockquote,支持引用与回复交错。

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -3894,7 +3894,7 @@ export function ChatInput({
   // ── Palette insertions ─────────────────────────────────────────────
   const insertSlashCommand = useCallback(
     (cmd: UnifiedCommand) => {
-      if (!editor || trigger.kind !== 'slash') return;
+      if (!editor || trigger.kind !== 'slash' || composerMutationLockedRef.current) return;
       const { from } = trigger;
       // Replace the WHOLE slash-run, not just up-to-caret: the user may
       // have moved the caret back inside the run (e.g. `/compa|ct`) and

--- a/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
+++ b/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
@@ -1,0 +1,38 @@
+import type { Transaction } from '@tiptap/pm/state';
+
+import type { UnifiedCommand } from '@/lib/slashCommands';
+
+const PLAN_MODE_COMPOSER_COMMAND = 'plan';
+
+export function addPlanModeComposerCommand(
+  commands: UnifiedCommand[],
+  description: string | null,
+): UnifiedCommand[] {
+  if (
+    !description ||
+    commands.some((command) => command.name.toLowerCase() === PLAN_MODE_COMPOSER_COMMAND)
+  ) {
+    return commands;
+  }
+  return [
+    {
+      kind: 'desktop',
+      name: PLAN_MODE_COMPOSER_COMMAND,
+      description,
+    },
+    ...commands,
+  ];
+}
+
+export function consumePlanModeComposerCommand(
+  tr: Transaction,
+  from: number,
+  to: number,
+  command: UnifiedCommand,
+  available: boolean,
+): boolean {
+  if (!available || command.kind !== 'desktop') return false;
+  if (command.name.toLowerCase() !== PLAN_MODE_COMPOSER_COMMAND) return false;
+  tr.delete(from, to);
+  return true;
+}

--- a/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
+++ b/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
@@ -49,3 +49,10 @@ export function isPlanModeComposerCommandText(
     text.trim().toLowerCase() === `/${PLAN_MODE_COMPOSER_COMMAND}`
   );
 }
+
+export function shouldPreservePlanModeComposerDraft(
+  attachmentCount: number,
+  browserCommentCount: number,
+): boolean {
+  return attachmentCount > 0 || browserCommentCount > 0;
+}

--- a/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
+++ b/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
@@ -36,3 +36,7 @@ export function consumePlanModeComposerCommand(
   tr.delete(from, to);
   return true;
 }
+
+export function isPlanModeComposerCommandText(text: string, available: boolean): boolean {
+  return available && text.trim().toLowerCase() === `/${PLAN_MODE_COMPOSER_COMMAND}`;
+}

--- a/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
+++ b/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
@@ -40,10 +40,11 @@ export function consumePlanModeComposerCommand(
 export function isPlanModeComposerCommandText(
   text: string,
   available: boolean,
-  commands: readonly UnifiedCommand[] = [],
+  commands: readonly UnifiedCommand[] | null,
 ): boolean {
   return (
     available &&
+    commands !== null &&
     !commands.some((command) => command.name.toLowerCase() === PLAN_MODE_COMPOSER_COMMAND) &&
     text.trim().toLowerCase() === `/${PLAN_MODE_COMPOSER_COMMAND}`
   );

--- a/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
+++ b/apps/desktop/src/renderer/components/new-chat/planModeComposerCommand.ts
@@ -37,6 +37,14 @@ export function consumePlanModeComposerCommand(
   return true;
 }
 
-export function isPlanModeComposerCommandText(text: string, available: boolean): boolean {
-  return available && text.trim().toLowerCase() === `/${PLAN_MODE_COMPOSER_COMMAND}`;
+export function isPlanModeComposerCommandText(
+  text: string,
+  available: boolean,
+  commands: readonly UnifiedCommand[] = [],
+): boolean {
+  return (
+    available &&
+    !commands.some((command) => command.name.toLowerCase() === PLAN_MODE_COMPOSER_COMMAND) &&
+    text.trim().toLowerCase() === `/${PLAN_MODE_COMPOSER_COMMAND}`
+  );
 }

--- a/apps/desktop/src/renderer/lib/slashCommands.ts
+++ b/apps/desktop/src/renderer/lib/slashCommands.ts
@@ -24,6 +24,50 @@ const log = createLogger('SlashCommands');
 
 export type { UnifiedCommand } from '@cindy/maker-core';
 
+export type SlashCommandRosterStatus = 'loading' | 'refreshing' | 'ready' | 'error';
+
+export interface SlashCommandRosterState {
+  contextKey: string;
+  status: SlashCommandRosterStatus;
+  commands: UnifiedCommand[];
+}
+
+/** Stable empty roster for initial and cross-context renders. */
+export const EMPTY_SLASH_COMMANDS: UnifiedCommand[] = [];
+
+export function beginSlashCommandRosterLoad(
+  current: SlashCommandRosterState,
+  contextKey: string,
+): SlashCommandRosterState {
+  if (
+    current.contextKey === contextKey &&
+    (current.status === 'ready' || current.status === 'refreshing')
+  ) {
+    return { ...current, status: 'refreshing' };
+  }
+  return { contextKey, status: 'loading', commands: EMPTY_SLASH_COMMANDS };
+}
+
+export function failSlashCommandRosterLoad(
+  current: SlashCommandRosterState,
+  contextKey: string,
+): SlashCommandRosterState {
+  if (current.contextKey === contextKey && current.status === 'refreshing') {
+    return { ...current, status: 'ready' };
+  }
+  return { contextKey, status: 'error', commands: EMPTY_SLASH_COMMANDS };
+}
+
+export function isSlashCommandRosterReady(
+  state: SlashCommandRosterState,
+  contextKey: string,
+): boolean {
+  return (
+    state.contextKey === contextKey &&
+    (state.status === 'ready' || state.status === 'refreshing')
+  );
+}
+
 // device-link 远程会话下 desktop 命令**全量可用**:业务语义在「会话归属设备」的命令
 // (/goal /learn /cmd)由控制端 main(commands/builtins.ts)按 ctx.deviceId 经隧道路由
 // 到被控端对应 channel(maker:goal:* / learn:* / desktop-cmd:run,均在 REMOTE_INVOKE_ALLOWLIST);


### PR DESCRIPTION
## 这次改了什么

### 摘要

Add `/plan` to the Desktop composer palette and consume the exact command locally. Selection is blocked during IME composition or composer locks, command refreshes preserve the last valid roster, and attachments remain in the draft. Fixes #1867.

### 变更类型

- [x] `feat`
- [x] `fix`
- [ ] `refactor` / `perf`
- [x] `docs` / `test` / `chore`
- [ ] Other

### 范围

- Included: Desktop command discovery, palette selection, exact-command dispatch, draft preservation, and regression tests.
- Excluded: mobile UI, models, prompts, database, and Device Link protocol.
- User-visible change: `/plan` appears in the existing palette when plan mode is supported.
- Breaking change: No.

### UI 变化

Desktop, English locale. The existing palette gains this row; layout and components are unchanged.

```html
<div class="slash-command-palette">
  <div class="slash-command-row">
    <code>/plan</code>
    <span>Plan mode</span>
  </div>
</div>
```

- 引用的设计规范: `docs/design-rules/DESIGN.md` §14.3. Existing keyboard, Enter, and IME behavior is preserved.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/planModeComposerCommand.test.ts src/renderer/__tests__/slashCommandRosterState.test.ts src/renderer/__tests__/effortRuntimeDirtySendGuard.test.ts
Passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Passed.

pnpm test:unit
Passed.

pnpm check:dco
Passed.
```

### 手工验证

Not run; the UI preview above documents the existing palette row.

### 未执行的验证

No packaged Desktop build was run.

## 风险

### 风险分类

- [ ] No known risk
- [ ] SQLite or migration
- [ ] System prompt
- [ ] Protocol compatibility
- [ ] Permissions, security, or user data
- [ ] Existing plugin compatibility
- [ ] Native layer, fingerprint, or OTA
- [ ] Cross-platform behavior
- [x] Other: Desktop composer command dispatch

### 影响与回滚

- Impact: limited to plan-command discovery and dispatch in the Desktop composer.
- Rollback: revert the PR commits; no data migration or cleanup is required.

### 提交前检查

- [x] Reviewed the complete diff
- [x] Every commit has DCO sign-off
- [x] UI change references the applicable design rule
- [x] No credentials or authorization files included
- [x] Tests cover the changed behavior
- [x] Validation results confirmed
