### PR TITLE
fix(desktop,maker-shared): 计划泡泡按终态章退场,不再伪造完成

### DIFF
--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -128,6 +128,12 @@ describe('maker:event hot path ordering', () => {
       'sessionTurnActivityTracker.setSessionInTurn(sessionId, false);',
       'notifyGoalIdleAfterTurnSettled(sessionId);',
     );
+    expectOrder(
+      reconcileSource,
+      'markTurnEndedAfterPersistDrain(sessionId);',
+      'clearCodexPlanRowsForSession(sessionId);',
+      'resetTurnPersistState(sessionId);',
+    );
 
     // ABORT_SESSION reconciles from finally, so vendor abort rejection still reaches the
     // shared idle wake-up once the exact Session/generation boundary proves idle.

--- a/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
+++ b/apps/desktop/src/main/__tests__/makerEventHotPathOrdering.test.ts
@@ -132,6 +132,10 @@ describe('maker:event hot path ordering', () => {
       reconcileSource,
       'markTurnEndedAfterPersistDrain(sessionId);',
       'clearCodexPlanRowsForSession(sessionId);',
+    );
+    expectOrder(
+      reconcileSource,
+      'clearCodexPlanRowsForSession(sessionId);',
       'resetTurnPersistState(sessionId);',
     );
 

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -186,7 +186,7 @@ describe('update_plan tool_use persistence', () => {
     );
   });
 
-  it('persists a successful turn plan as completed so reload cannot resurrect progress', async () => {
+  it('seals a successful turn plan as-is so reload cannot resurrect it', async () => {
     const persistId = onToolUseEvent(
       SESSION,
       {
@@ -218,11 +218,13 @@ describe('update_plan tool_use persistence', () => {
       {
         toolUseId: 'plan:turn-1',
         toolName: 'update_plan',
+        // 步骤原样落库(Codex 报的就是 in_progress),退场靠下面这枚章,
+        // 不靠把没干完的步骤改成 completed。
         input: {
           explanation: 'keep this field',
           plan: [
             { step: 'Inspect', status: 'completed' },
-            { step: 'Start dev', status: 'completed' },
+            { step: 'Start dev', status: 'in_progress' },
           ],
         },
         terminalPlanSnapshot: true,
@@ -233,6 +235,36 @@ describe('update_plan tool_use persistence', () => {
       expect.any(Object),
       ownerScopeState.scope,
     );
+  });
+
+  /**
+   * 现场 bug 的确切形态:活儿干完了,Codex 收尾时没有再发一次 plan 更新,
+   * 于是 done 上压根没有 plan 快照,库里那份仍停在 in_progress/pending。
+   * 必须只靠章收口——胶囊据此退场,步骤事实一个不动。
+   */
+  it('seals a successful turn that ended without any final plan snapshot', async () => {
+    const openPlan = [
+      { step: 'Find the capsule', status: 'completed' },
+      { step: 'Reopen the task', status: 'in_progress' },
+      { step: 'Confirm it stays gone', status: 'pending' },
+    ];
+    const persistId = onToolUseEvent(
+      SESSION,
+      { toolUseId: 'plan:turn-no-snapshot', toolName: 'update_plan', input: { plan: openPlan } },
+      null,
+    );
+
+    expect(persistCodexPlanOnDone(SESSION, {
+      raw: { id: 'turn-no-snapshot', status: 'completed' },
+    })).toBe(true);
+
+    await flushWrites();
+    expect(updateMessageContent).toHaveBeenCalledWith(SESSION, persistId, {
+      toolUseId: 'plan:turn-no-snapshot',
+      toolName: 'update_plan',
+      input: { plan: openPlan },
+      terminalPlanSnapshot: true,
+    });
   });
 
   it('stamps an already-completed plan as terminal at the successful done boundary', async () => {

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -58,6 +58,7 @@ import {
 import {
   onToolUseEvent,
   persistCodexPlanOnDone,
+  persistCodexPlanOnTerminalError,
   onToolResultEvent,
   onToolResultFullEvent,
   prepareSyntheticToolEventForBroadcast,
@@ -337,6 +338,41 @@ describe('update_plan tool_use persistence', () => {
         turnCompleted: false,
       },
     );
+  });
+
+  it('stamps the current turn plan as failed at a terminal error without a done', async () => {
+    // Codex 在 terminal error 后显式压掉迟到的 turnCompleted,该 turn 永远等不到
+    // done → persistCodexPlanOnDone 不会跑。此时必须由 error 边界补 turnCompleted:false,
+    // 否则全勾完的失败计划没有任何存活印记,面板会当旧数据兜底退场。
+    const persistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-err',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Ship', status: 'completed' }] },
+      },
+      null,
+    );
+
+    expect(persistCodexPlanOnTerminalError(SESSION)).toBe(true);
+
+    await flushWrites();
+    expect(updateMessageContent).toHaveBeenCalledWith(SESSION, persistId, {
+      toolUseId: 'plan:turn-err',
+      toolName: 'update_plan',
+      // 只盖存活标记,步骤状态一个不动——失败不是把勾去掉的理由。
+      input: { plan: [{ step: 'Ship', status: 'completed' }] },
+      turnCompleted: false,
+    });
+    expect(broadcastMessageRow).toHaveBeenCalledWith(
+      SESSION,
+      expect.any(Object),
+      ownerScopeState.scope,
+    );
+  });
+
+  it('terminal error stamping is a no-op when the turn has no plan row', () => {
+    expect(persistCodexPlanOnTerminalError(SESSION)).toBe(false);
   });
 
   it('does not dedupe ordinary repeated tool_use ids', async () => {

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -217,7 +217,7 @@ describe('update_plan tool_use persistence', () => {
     expect(updateMessageContent).toHaveBeenCalledWith(
       SESSION,
       persistId,
-      {
+      expect.objectContaining({
         toolUseId: 'plan:turn-1',
         toolName: 'update_plan',
         // 步骤原样落库(Codex 报的就是 in_progress),退场靠下面这枚章,
@@ -231,7 +231,7 @@ describe('update_plan tool_use persistence', () => {
         },
         terminalPlanSnapshot: true,
         terminalPlanAtMs: expect.any(Number),
-      },
+      }),
     );
     expect(broadcastMessageRow).toHaveBeenCalledWith(
       SESSION,

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -339,6 +339,78 @@ describe('update_plan tool_use persistence', () => {
     );
   });
 
+  it('carries repeated update_plan snapshots into the terminal write', async () => {
+    // 同一 turn 的第二次 update_plan 走 persistId 复用分支。按-turn 缓存若只在
+    // 首次记录,终态写入会拿首版快照整行覆盖,已勾完的进度在重载/远端同步后
+    // 倒退回第一版(review P1)。
+    const persistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-multi',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Inspect', status: 'in_progress' }, { step: 'Patch', status: 'pending' }] },
+      },
+      null,
+    );
+    const secondPersistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-multi',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Inspect', status: 'completed' }, { step: 'Patch', status: 'in_progress' }] },
+      },
+      null,
+    );
+    expect(secondPersistId).toBe(persistId);
+
+    // done 不带 plan(常见):内容只能来自缓存,必须是最新那一版。
+    expect(persistCodexPlanOnDone(SESSION, {
+      raw: { id: 'turn-multi', status: 'completed' },
+    })).toBe(true);
+
+    await flushWrites();
+    expect(updateMessageContent).toHaveBeenLastCalledWith(
+      SESSION,
+      persistId,
+      expect.objectContaining({
+        input: { plan: [{ step: 'Inspect', status: 'completed' }, { step: 'Patch', status: 'in_progress' }] },
+        terminalPlanSnapshot: true,
+      }),
+    );
+  });
+
+  it('stamps a terminal-error failure onto the latest repeated plan snapshot', async () => {
+    const persistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-multi-err',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Inspect', status: 'in_progress' }] },
+      },
+      null,
+    );
+    onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-multi-err',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Inspect', status: 'completed' }] },
+      },
+      null,
+    );
+
+    expect(persistCodexPlanOnTerminalError(SESSION, 'turn-multi-err')).toBe(true);
+    await flushWrites();
+    expect(updateMessageContent).toHaveBeenLastCalledWith(
+      SESSION,
+      persistId,
+      expect.objectContaining({
+        input: { plan: [{ step: 'Inspect', status: 'completed' }] },
+        turnCompleted: false,
+      }),
+    );
+  });
+
   it('stamps an already-completed plan as terminal at the successful done boundary', async () => {
     const persistId = onToolUseEvent(
       SESSION,

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -270,6 +270,75 @@ describe('update_plan tool_use persistence', () => {
     });
   });
 
+  it('still seals after a continuation boundary cleared the per-segment maps', async () => {
+    // 分段 turn:S1 产出计划 → continuation done(reset 清空 per-segment 映射)
+    // → S2 最终 done。计划行的引用按 turnId 存活,最终 done 仍找得到它并盖章;
+    // 否则重载后胶囊无章无失败印记 → 走旧版全勾完兜底 → 永久钉住(review P1-1)。
+    const persistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-seg',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Segmented work', status: 'in_progress' }] },
+      },
+      null,
+    );
+
+    // continuation boundary 上 register 只跑 resetTurnPersistState(不 persist)。
+    resetTurnPersistState(SESSION);
+
+    expect(persistCodexPlanOnDone(SESSION, {
+      raw: { id: 'turn-seg', status: 'completed' },
+    })).toBe(true);
+
+    await flushWrites();
+    expect(updateMessageContent).toHaveBeenCalledWith(
+      SESSION,
+      persistId,
+      expect.objectContaining({
+        toolUseId: 'plan:turn-seg',
+        toolName: 'update_plan',
+        terminalPlanSnapshot: true,
+      }),
+    );
+  });
+
+  it('scopes a terminal-error failure stamp to the owning turn', async () => {
+    onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-old',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Old turn work', status: 'in_progress' }] },
+      },
+      null,
+    );
+    const currentPersistId = onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-current',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Current work', status: 'in_progress' }] },
+      },
+      null,
+    );
+
+    expect(persistCodexPlanOnTerminalError(SESSION, 'turn-current')).toBe(true);
+    await flushWrites();
+
+    expect(updateMessageContent).toHaveBeenCalledWith(
+      SESSION,
+      currentPersistId,
+      expect.objectContaining({ toolUseId: 'plan:turn-current', turnCompleted: false }),
+    );
+    // 同会话里其它 turn 的计划行不得被顺手盖失败印记。
+    expect(updateMessageContent).not.toHaveBeenCalledWith(
+      SESSION,
+      expect.anything(),
+      expect.objectContaining({ toolUseId: 'plan:turn-old' }),
+    );
+  });
+
   it('stamps an already-completed plan as terminal at the successful done boundary', async () => {
     const persistId = onToolUseEvent(
       SESSION,

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -228,6 +228,7 @@ describe('update_plan tool_use persistence', () => {
           ],
         },
         terminalPlanSnapshot: true,
+        terminalPlanAtMs: expect.any(Number),
       },
     );
     expect(broadcastMessageRow).toHaveBeenCalledWith(
@@ -264,6 +265,7 @@ describe('update_plan tool_use persistence', () => {
       toolName: 'update_plan',
       input: { plan: openPlan },
       terminalPlanSnapshot: true,
+      terminalPlanAtMs: expect.any(Number),
     });
   });
 
@@ -292,6 +294,7 @@ describe('update_plan tool_use persistence', () => {
         toolName: 'update_plan',
         input: { plan: [{ step: 'Ship', status: 'completed' }] },
         terminalPlanSnapshot: true,
+        terminalPlanAtMs: expect.any(Number),
       },
     );
     expect(broadcastMessageRow).toHaveBeenCalledWith(

--- a/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
+++ b/apps/desktop/src/main/__tests__/messagePersistBroadcaster.test.ts
@@ -70,6 +70,7 @@ import {
   isSuccessfulCodexDoneEventData,
   onTurnErrorEvent,
   resetTurnPersistState,
+  clearCodexPlanRowsForSession,
   clearSessionPersistState,
   consumeLastAssistantPersistId,
   consumeLastTopLevelAssistantPersistId,
@@ -513,6 +514,25 @@ describe('update_plan tool_use persistence', () => {
   });
 
   it('terminal error stamping is a no-op when the turn has no plan row', () => {
+    expect(persistCodexPlanOnTerminalError(SESSION)).toBe(false);
+  });
+
+  it('does not carry a reconciled turn plan into a later id-less terminal error', () => {
+    onToolUseEvent(
+      SESSION,
+      {
+        toolUseId: 'plan:turn-reconciled',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Old turn work', status: 'completed' }] },
+      },
+      null,
+    );
+
+    // reconcileSessionTurnIdle treats the lost-terminal path as a logical turn
+    // boundary and clears this cross-segment ownership before the next turn.
+    clearCodexPlanRowsForSession(SESSION);
+    resetTurnPersistState(SESSION);
+
     expect(persistCodexPlanOnTerminalError(SESSION)).toBe(false);
   });
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -9314,6 +9314,10 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       // The marker write is best-effort and ordered behind pending message
       // persistence. It may retry/settle after an owner boundary is available.
       markTurnEndedAfterPersistDrain(sessionId);
+      // This is a logical turn boundary even though the vendor terminal event
+      // was lost. Drop the cross-segment plan ownership here so a later turn's
+      // id-less terminal error cannot fail-stamp an older plan.
+      clearCodexPlanRowsForSession(sessionId);
       resetTurnPersistState(sessionId);
       noteClaudeSessionTurnState(sessionId, false);
       settlePendingCredentialSwitch(sessionId, `reconcile:${source}`);

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -336,6 +336,7 @@ import {
   onInteractionMessage,
   onInteractionResolved,
   persistCodexPlanOnDone,
+  persistCodexPlanOnTerminalError,
   onThinkingEvent,
   onToolResultEvent,
   onToolResultFullEvent,
@@ -3835,6 +3836,18 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         // A claim-bearing done seals this SDK segment, but the product turn is
         // still running and may emit another continuation segment. Reset the
         // per-SDK-turn persistence maps while deferring the logical turn marker.
+        // 没有 done 的终态 error(Codex 在 terminal error 后显式压掉迟到的
+        // turnCompleted,persistCodexPlanOnDone 永远不会跑到):本 turn 的计划行
+        // 既没有章也没有 turnCompleted:false,面板会把全勾完的失败计划当旧数据
+        // 兜底退场。在这里补失败印记——只盖 turn 存活标记,不动步骤状态。
+        if (
+          !isContinuationBoundary &&
+          event.source === 'codex' &&
+          event.type !== 'done' &&
+          isTerminalTurnErrorEvent(event)
+        ) {
+          persistCodexPlanOnTerminalError(session.id);
+        }
         if (!isContinuationBoundary && event.source === 'codex' && event.type === 'done') {
           // Renderer applies this terminal snapshot immediately. Persist the
           // same state before sealing the persist queue and clearing the

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -335,6 +335,7 @@ import {
   onAssistantTextEvent,
   onInteractionMessage,
   onInteractionResolved,
+  clearCodexPlanRowsForSession,
   persistCodexPlanOnDone,
   persistCodexPlanOnTerminalError,
   onThinkingEvent,
@@ -3846,7 +3847,11 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
           event.type !== 'done' &&
           isTerminalTurnErrorEvent(event)
         ) {
-          persistCodexPlanOnTerminalError(session.id);
+          const errorTurnId =
+            typeof (event.data as { raw?: { id?: unknown } } | null | undefined)?.raw?.id === 'string'
+              ? ((event.data as { raw?: { id?: unknown } }).raw!.id as string)
+              : null;
+          persistCodexPlanOnTerminalError(session.id, errorTurnId);
         }
         if (!isContinuationBoundary && event.source === 'codex' && event.type === 'done') {
           // Renderer applies this terminal snapshot immediately. Persist the
@@ -3866,6 +3871,10 @@ export function wireSessionToIpc(session: ReturnType<Maker['getSession']>): void
         }
         if (!isContinuationBoundary) {
           markTurnEndedAfterPersistDrain(session.id);
+          // 逻辑 turn 结束:跨段存活的计划行引用到此回收(continuation boundary
+          // 上必须保留,否则最终 done 找不到计划行 → 无章无失败印记 → 胶囊永久
+          // 钉住,review P1-1)。
+          clearCodexPlanRowsForSession(session.id);
         }
         resetTurnPersistState(session.id);
         // sidebar-card-mode: 摘要触发挪到本轮 assistant 块 flush 入队之后(原先在

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -646,6 +646,43 @@ export function persistCodexPlanOnDone(
 }
 
 /**
+ * Codex can end a turn with a terminal `error` that never gets a `done` (the
+ * agent explicitly suppresses a late `turnCompleted` after a terminal error).
+ * That path used to leave the turn's plan row with neither a seal nor a
+ * `turnCompleted:false` stamp, so plan-liveness consumers (the pinned capsule)
+ * had no durable evidence the task is still alive and could retire an all-done
+ * plan as if it were legacy history. Stamp the failure marker here — the
+ * per-turn maps only ever hold rows belonging to the current turn, so the scope
+ * is exact. Never seals, never touches step statuses.
+ */
+export function persistCodexPlanOnTerminalError(sessionId: string): boolean {
+  const infoMap = toolUseInfoBySession.get(sessionId);
+  const idMap = updatableToolUsePersistIdBySession.get(sessionId);
+  if (!infoMap || !idMap) return false;
+  let stamped = false;
+  for (const [toolUseId, info] of infoMap) {
+    if (info.toolName !== 'update_plan') continue;
+    const persistId = idMap.get(toolUseId);
+    if (!persistId) continue;
+    const input = info.input && typeof info.input === 'object' && !Array.isArray(info.input)
+      ? info.input as Record<string, unknown>
+      : null;
+    if (!input || !Array.isArray(input.plan)) continue;
+    enqueueWrite(`codex_plan_terminal_error:${sessionId}:${persistId}`, async (ownerScope) => {
+      const updated = await updateDbMessageContent(sessionId, persistId, {
+        toolUseId,
+        toolName: 'update_plan',
+        input,
+        turnCompleted: false,
+      });
+      if (updated) broadcastMessageRow(sessionId, updated, ownerScope);
+    });
+    stamped = true;
+  }
+  return stamped;
+}
+
+/**
  * Main 侧合成 tool 事件也必须遵守 renderer 的展示契约:
  * tool_result / tool_result_full 只有带 persistId + resolvedContent 才会渲染。
  *

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -482,6 +482,22 @@ const toolUseCreatedAtBySession = new Map<string, Map<string, number>>();
  * 每会话 toolUseId → { toolName, input }。媒体 echo 兜底用:flushOrphanToolResults
  * 需要按 tool_use 的 input.args 去 mediaToolResultFallback 池里认领结果。
  */
+/**
+ * Codex 计划行的持久化引用,按 `plan:<turnId>` 存活到**产品 turn** 结束。
+ *
+ * 为什么不能复用 toolUseInfoBySession / updatableToolUsePersistIdBySession:
+ * 那两张表是 per-SDK-segment 的,每个 continuation boundary 都会被
+ * resetTurnPersistState 清空。分段 turn(S1 产出计划 → continuation done →
+ * S2 最终 done)在最终 done 时已经查不到计划行,既不写终态章也不写
+ * turnCompleted:false,重载后胶囊走旧版全勾完兜底 → 永久钉住(review P1-1)。
+ * 计划行的归属键是 turnId,与 SDK 分段无关,所以单独存一张按 turnId 的表,
+ * 只在同一 turnId 被新计划覆盖或 finalize 后清理。
+ */
+const codexPlanRowByTurnToolUseId = new Map<
+  string,
+  Map<string, { persistId: string; input: unknown }>
+>();
+
 const toolUseInfoBySession = new Map<string, Map<string, { toolName: string; input: unknown }>>();
 const updatableToolUsePersistIdBySession = new Map<string, Map<string, string>>();
 
@@ -580,6 +596,14 @@ export function onToolUseEvent(
   if (isUpdatableToolUse(toolName) && toolUseId) {
     rememberUpdatableToolUsePersistId(sessionId, toolUseId, persistId);
   }
+  // 计划行额外记进按 turnId 的表:它要活过 continuation boundary 的 map 清空,
+  // 直到产品 turn 真正结束才用得上(review P1-1)。
+  if (toolName === 'update_plan' && toolUseId) {
+    getOrCreateSessionMap(codexPlanRowByTurnToolUseId, sessionId).set(toolUseId, {
+      persistId,
+      input: data.input,
+    });
+  }
   notePersistedMessage(sessionId, 'tool_use', persistId);
   return persistId;
 }
@@ -606,13 +630,19 @@ export function persistCodexPlanOnDone(
   if (!turnId) return false;
 
   const toolUseId = `plan:${turnId}`;
+  // 归属键是 turnId,与 SDK 分段无关:优先读活过 continuation boundary 的
+  // 按-turn 表,per-segment 表仅作兼容兜底(review P1-1)。
+  const planRowMap = codexPlanRowByTurnToolUseId.get(sessionId);
+  const planRow = planRowMap?.get(toolUseId);
   const infoMap = toolUseInfoBySession.get(sessionId);
   const info = infoMap?.get(toolUseId);
-  const persistId = updatableToolUsePersistIdBySession.get(sessionId)?.get(toolUseId);
-  if (!info || info.toolName !== 'update_plan' || !persistId) return false;
+  const persistId =
+    planRow?.persistId ?? updatableToolUsePersistIdBySession.get(sessionId)?.get(toolUseId);
+  const rawInput = planRow?.input ?? (info?.toolName === 'update_plan' ? info.input : undefined);
+  if (!persistId) return false;
 
-  const input = info.input && typeof info.input === 'object' && !Array.isArray(info.input)
-    ? info.input as Record<string, unknown>
+  const input = rawInput && typeof rawInput === 'object' && !Array.isArray(rawInput)
+    ? rawInput as Record<string, unknown>
     : null;
   if (!input || !Array.isArray(input.plan)) return false;
 
@@ -627,7 +657,10 @@ export function persistCodexPlanOnDone(
   // from an older ordinary DB echo that merely happens to look completed.
   const terminalPlanAtMs = Date.now();
   const nextInput = { ...input, plan: nextPlan };
-  infoMap?.set(toolUseId, { ...info, input: nextInput });
+  if (info) infoMap?.set(toolUseId, { ...info, input: nextInput });
+  // 终态已定,这份计划行不再需要跨段引用;同时保留最新 input 供同 turn 的
+  // 重复 done(罕见)幂等复用。
+  planRowMap?.set(toolUseId, { persistId, input: nextInput });
   enqueueWrite(`codex_plan_done:${sessionId}:${persistId}`, async (ownerScope) => {
     const updated = await updateDbMessageContent(sessionId, persistId, {
       toolUseId,
@@ -655,17 +688,21 @@ export function persistCodexPlanOnDone(
  * per-turn maps only ever hold rows belonging to the current turn, so the scope
  * is exact. Never seals, never touches step statuses.
  */
-export function persistCodexPlanOnTerminalError(sessionId: string): boolean {
-  const infoMap = toolUseInfoBySession.get(sessionId);
-  const idMap = updatableToolUsePersistIdBySession.get(sessionId);
-  if (!infoMap || !idMap) return false;
+export function persistCodexPlanOnTerminalError(sessionId: string, turnId?: string | null): boolean {
+  // 按-turn 表跨 continuation 存活,是这里的首选来源(同 persistCodexPlanOnDone)。
+  const planRowMap = codexPlanRowByTurnToolUseId.get(sessionId);
+  if (!planRowMap || planRowMap.size === 0) return false;
+  // turn 归属边界:调用方给出 turnId 时只盖该 turn 的计划行,不误伤同会话里
+  // 其它 turn 的行(review P2)。拿不到 turnId(Codex 的 terminal error 常不带)
+  // 时退回全表——本会话的未收口计划行本就只应有当前 turn 的那一份。
+  const expectedToolUseId = typeof turnId === 'string' && turnId ? `plan:${turnId}` : null;
   let stamped = false;
-  for (const [toolUseId, info] of infoMap) {
-    if (info.toolName !== 'update_plan') continue;
-    const persistId = idMap.get(toolUseId);
+  for (const [toolUseId, planRow] of planRowMap) {
+    if (expectedToolUseId && toolUseId !== expectedToolUseId) continue;
+    const persistId = planRow.persistId;
     if (!persistId) continue;
-    const input = info.input && typeof info.input === 'object' && !Array.isArray(info.input)
-      ? info.input as Record<string, unknown>
+    const input = planRow.input && typeof planRow.input === 'object' && !Array.isArray(planRow.input)
+      ? planRow.input as Record<string, unknown>
       : null;
     if (!input || !Array.isArray(input.plan)) continue;
     enqueueWrite(`codex_plan_terminal_error:${sessionId}:${persistId}`, async (ownerScope) => {
@@ -1115,6 +1152,9 @@ export function resetTurnPersistState(sessionId: string): void {
   toolUseCreatedAtBySession.delete(sessionId);
   toolUseInfoBySession.delete(sessionId);
   updatableToolUsePersistIdBySession.delete(sessionId);
+  // 刻意不清 codexPlanRowByTurnToolUseId:它按 turnId 归属,必须活过每个
+  // continuation boundary 的 per-segment 清空(review P1-1)。由
+  // clearCodexPlanRowsForSession(逻辑 turn 结束 / 会话清理)负责回收。
   lastAgentMetaBySession.delete(sessionId);
   _turnStartedAtBySession.delete(sessionId);
   _turnDedupIdBySession.delete(sessionId);
@@ -1401,7 +1441,16 @@ export function onTurnErrorEvent(
 }
 
 /** session 关闭时清掉该会话所有 per-session 持久化状态,避免 Map 泄漏 / 跨会话串状态。 */
+/**
+ * 回收按-turn 的计划行引用。逻辑 turn 真正结束(非 continuation boundary 的
+ * done / 终止 error 之后)与会话清理时调用——只有到那时跨段引用才不再需要。
+ */
+export function clearCodexPlanRowsForSession(sessionId: string): void {
+  codexPlanRowByTurnToolUseId.delete(sessionId);
+}
+
 export function clearSessionPersistState(sessionId: string): void {
+  clearCodexPlanRowsForSession(sessionId);
   assistantBlocks.delete(sessionId);
   lastAgentMetaBySession.delete(sessionId);
   knownToolUseIdsBySession.delete(sessionId);

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -31,7 +31,6 @@ import { createId } from '@paralleldrive/cuid2';
 
 import { BrowserWindow } from 'electron';
 import { desc, eq } from 'drizzle-orm';
-import { resolveCodexPlanSnapshotOnDone } from '@cindy/maker-shared/message-render';
 
 import {
   broadcastMessageRow,
@@ -618,13 +617,15 @@ export function persistCodexPlanOnDone(
   if (!input || !Array.isArray(input.plan)) return false;
 
   const isSuccessfulTerminal = isSuccessfulCodexDoneEventData(data);
-  const nextPlan =
-    resolveCodexPlanSnapshotOnDone(input.plan, data?.plan, isSuccessfulTerminal) ??
-    (isSuccessfulTerminal ? null : input.plan);
-  if (!nextPlan) return false;
+  // Only an explicit snapshot from Codex may change step statuses. A successful
+  // turn that left items open is recorded as-is and closed by the seal below —
+  // ticking them here would make the stored plan claim work the agent never
+  // reported doing.
+  const nextPlan = Array.isArray(data?.plan) ? data.plan : input.plan;
   // Even when Codex already emitted the exact completed/empty plan, stamp the
   // durable row at done. Renderer must distinguish this authoritative write
   // from an older ordinary DB echo that merely happens to look completed.
+  const terminalPlanAtMs = Date.now();
   const nextInput = { ...input, plan: nextPlan };
   infoMap?.set(toolUseId, { ...info, input: nextInput });
   enqueueWrite(`codex_plan_done:${sessionId}:${persistId}`, async (ownerScope) => {
@@ -633,7 +634,7 @@ export function persistCodexPlanOnDone(
       toolName: 'update_plan',
       input: nextInput,
       ...(isSuccessfulTerminal
-        ? { terminalPlanSnapshot: true }
+        ? { terminalPlanSnapshot: true, terminalPlanAtMs }
         : { turnCompleted: false }),
     });
     // Reuse the existing upsert-style row broadcast so a renderer that mounts

--- a/apps/desktop/src/main/messagePersistBroadcaster.ts
+++ b/apps/desktop/src/main/messagePersistBroadcaster.ts
@@ -541,6 +541,23 @@ function isUpdatableToolUse(toolName: string): boolean {
   return toolName === 'update_plan' || toolName === 'web_search';
 }
 
+/**
+ * 计划行进按 turnId 的表:它要活过 continuation boundary 的 map 清空,直到产品
+ * turn 真正结束才用得上(review P1-1)。**每次 update_plan 都要调**——同一 turn 的
+ * 重复更新走 onToolUseEvent 的复用分支,只在首次记录会让终态写入拿首版快照覆盖
+ * 已更新的计划(review P1)。
+ */
+function rememberCodexPlanRow(
+  sessionId: string,
+  toolName: string,
+  toolUseId: string,
+  persistId: string,
+  input: unknown,
+): void {
+  if (toolName !== 'update_plan' || !toolUseId) return;
+  getOrCreateSessionMap(codexPlanRowByTurnToolUseId, sessionId).set(toolUseId, { persistId, input });
+}
+
 function rememberUpdatableToolUsePersistId(sessionId: string, toolUseId: string, persistId: string): void {
   let idMap = updatableToolUsePersistIdBySession.get(sessionId);
   if (!idMap) {
@@ -579,6 +596,9 @@ export function onToolUseEvent(
     enqueueWrite(`tool_use_update:${sessionId}:${existingPersistId}`, () =>
       updateDbMessageContent(sessionId, existingPersistId, content),
     );
+    // 同一 turn 的第二次 update_plan 走这条复用分支,按-turn 缓存必须跟着刷新:
+    // 终态写入优先读它,停在首版快照会把已更新的计划整行盖回第一版(review P1)。
+    rememberCodexPlanRow(sessionId, toolName, toolUseId, existingPersistId, data.input);
     notePersistedMessage(sessionId, 'tool_use', existingPersistId);
     return existingPersistId;
   }
@@ -596,14 +616,7 @@ export function onToolUseEvent(
   if (isUpdatableToolUse(toolName) && toolUseId) {
     rememberUpdatableToolUsePersistId(sessionId, toolUseId, persistId);
   }
-  // 计划行额外记进按 turnId 的表:它要活过 continuation boundary 的 map 清空,
-  // 直到产品 turn 真正结束才用得上(review P1-1)。
-  if (toolName === 'update_plan' && toolUseId) {
-    getOrCreateSessionMap(codexPlanRowByTurnToolUseId, sessionId).set(toolUseId, {
-      persistId,
-      input: data.input,
-    });
-  }
+  rememberCodexPlanRow(sessionId, toolName, toolUseId, persistId, data.input);
   notePersistedMessage(sessionId, 'tool_use', persistId);
   return persistId;
 }

--- a/apps/desktop/src/renderer/__tests__/planReviewDoneRace.test.ts
+++ b/apps/desktop/src/renderer/__tests__/planReviewDoneRace.test.ts
@@ -275,7 +275,7 @@ describe('plan_review 与 done 的时序', () => {
     expect(latestPlanStatuses()).toEqual(['in_progress', 'pending']);
   });
 
-  it('codex:成功完成但缺少最终 plan 快照时收口计划卡片', () => {
+  it('codex:成功完成但缺少最终 plan 快照时盖章收口、不改步骤事实', () => {
     const startedAtMs = 1_700_000_000_000;
     const completedAtMs = startedAtMs + 5_000;
     const now = vi.spyOn(Date, 'now').mockReturnValue(startedAtMs);
@@ -285,13 +285,18 @@ describe('plan_review 与 done 的时序', () => {
     now.mockReturnValue(completedAtMs);
     emitDone('codex', undefined, 'turn-1', 'completed');
 
-    expect(latestPlanStatuses()).toEqual(['completed', 'completed']);
-    const completedPlan = makerChatStore
+    // 收口 = 终态章(生命周期),步骤保持 agent 实际报告的状态。
+    expect(latestPlanStatuses()).toEqual(['in_progress', 'pending']);
+    const sealedPlan = makerChatStore
       .getSnapshot(SESSION_ID)
       .messages.findLast(
         (message) => message.role === 'tool_use' && message.toolName === 'update_plan',
       );
-    expect(completedPlan).toMatchObject({ planUpdatedAtMs: completedAtMs });
+    expect(sealedPlan).toMatchObject({
+      terminalPlanSnapshot: true,
+      terminalPlanAtMs: completedAtMs,
+      planUpdatedAtMs: completedAtMs,
+    });
   });
 
   it('claude:done 不改 Codex update_plan 展示状态', () => {

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -60,13 +60,20 @@ export function PinnedPlanPanel({
     insertion.todos.length > 0 &&
     insertion.todos.every((todo) => todo.status === 'completed'),
   );
-  // codex 计划在 turn 流式期间是"等章"状态:host 的终态章才是权威,agent 提前把
-  // 步骤全勾完不算数——按 allDone 抢跑会在章晚到时产生"消失再闪回"。TodoWrite /
-  // Task 永远不会有章,codex 旧历史数据也不会再有,它们照旧走全勾完兜底。
-  const awaitingSeal = insertion?.source === 'codex' && insertion.sealed !== true && streaming;
+  // codex 计划有两种"任务还活着"的状态,都不得走全勾完兜底:
+  // - turn 流式中且未盖章:正在等 host 的终态章,agent 提前勾完不算数——按
+  //   allDone 抢跑会在章晚到时产生"消失再闪回";
+  // - host 给该行盖了 turnCompleted:false(中断/失败终态,见 persistCodexPlanOnDone):
+  //   按设计不盖章,计划必须留在屏幕上供用户继续指挥,哪怕步骤恰好全勾完。
+  // TodoWrite / Task 永远不会有这两种印记,codex 旧历史数据也不会再有,它们照旧
+  // 走全勾完兜底——否则旧会话的计划会永远挂着。
+  const codexPlanAlive =
+    insertion?.source === 'codex' &&
+    insertion.sealed !== true &&
+    (streaming || insertion.turnFailed === true);
   // 退场 = host 盖了终态章(权威),或计划自己勾完了(没有章的旧数据兜底)。
   const retired =
-    Boolean(insertion) && (insertion?.sealed === true || (allDone && !awaitingSeal));
+    Boolean(insertion) && (insertion?.sealed === true || (allDone && !codexPlanAlive));
   const completedAtMs =
     insertion?.sealedAtMs ?? insertion?.updatedAtMs ?? Date.parse(insertion?.createdAt ?? '');
   const persistedCompletionDeadlineMs =

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -19,7 +19,7 @@
  * 这时候按"全勾完"抢跑退场,会在章晚到(>2s)时先消失再被章复活闪回 2 秒。
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { findLatestMessageTodoInsertion } from '@cindy/maker-shared/message-render';
 
 import { TodoListCard } from '@/components/chat/TodoListCard';
@@ -90,11 +90,28 @@ export function PinnedPlanPanel({
     deadlineMs: number;
   } | null>(null);
   const completionIdentity = insertion ? `${sessionId ?? 'unknown'}:${insertion.key}` : null;
-  const completionDeadlineMs =
-    persistedCompletionDeadlineMs ??
-    (retired && fallbackCompletionVisibility?.identity === completionIdentity
+  const fallbackDeadlineMs =
+    retired && fallbackCompletionVisibility?.identity === completionIdentity
       ? fallbackCompletionVisibility.deadlineMs
-      : null);
+      : null;
+  // 执行端偏慢的另一半:实时 done 先按本地时刻(updatedAtMs/createdAt)起了
+  // 2 秒缓冲,随后到达的落库行带"过去"的执行端 sealedAtMs,重算出的期限已
+  // 过期——直接替换会把进行中的缓冲瞬间掐断。规则:同一身份的期限单调不减
+  // (render 间用 ref 记地板),后算出的更早期限只能取 max,不能倒退。重载/
+  // 新窗口是全新组件,地板为空,过期的章照旧立即隐藏(不重数 2 秒)。
+  const rawDeadlineMs =
+    persistedCompletionDeadlineMs !== null && fallbackDeadlineMs !== null
+      ? Math.max(persistedCompletionDeadlineMs, fallbackDeadlineMs)
+      : (persistedCompletionDeadlineMs ?? fallbackDeadlineMs);
+  const deadlineFloorRef = useRef<{ identity: string; deadlineMs: number } | null>(null);
+  let completionDeadlineMs = rawDeadlineMs;
+  if (completionDeadlineMs !== null && completionIdentity) {
+    const floor = deadlineFloorRef.current;
+    if (floor && floor.identity === completionIdentity) {
+      completionDeadlineMs = Math.max(completionDeadlineMs, floor.deadlineMs);
+    }
+    deadlineFloorRef.current = { identity: completionIdentity, deadlineMs: completionDeadlineMs };
+  }
   const completedPlanExpired = Boolean(
     completionDeadlineMs !== null && completionDeadlineMs <= Date.now(),
   );

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -6,7 +6,15 @@
  * 鼠标悬停时完整清单以浮层向上展开,原地实时更新,不会被后续消息冲走。
  * 数据从会话消息派生(findLatestMessageTodoInsertion):跨 source(TodoWrite /
  * update_plan / Task*)取最近更新的 plan session 快照;历史 session 不再逐张
- * 展示。无计划时返回 null,不占位;计划完成后保留 2 秒再收起。
+ * 展示。无计划时返回 null,不占位。
+ *
+ * **退场条件是 host 的终态章,不是"步骤全勾完"**(`insertion.sealed`,来源见
+ * maker-shared 的 `terminalPlanSnapshot`)。agent 收尾时漏勾最后几步是常态,
+ * 以"全勾完"为退场条件会让干完的活儿永远挂在屏幕上;而中断、失败、断线自动
+ * 续跑都不盖章,那种情况计划必须留着——任务还活着,用户正要接着指挥。
+ *
+ * 盖章后同样保留 2 秒再收起,时刻锚在章上(章落库,所以重载/新窗口看到的是
+ * 同一个时刻,不会重新数 2 秒)。旧数据没有章,按"全勾完"兜底,行为不变。
  */
 
 import { useEffect, useMemo, useState } from 'react';
@@ -47,9 +55,12 @@ export function PinnedPlanPanel({
     insertion.todos.length > 0 &&
     insertion.todos.every((todo) => todo.status === 'completed'),
   );
-  const completedAtMs = insertion?.updatedAtMs ?? Date.parse(insertion?.createdAt ?? '');
+  // 退场 = host 盖了终态章(权威),或计划自己勾完了(没有章的旧数据兜底)。
+  const retired = Boolean(insertion) && (insertion?.sealed === true || allDone);
+  const completedAtMs =
+    insertion?.sealedAtMs ?? insertion?.updatedAtMs ?? Date.parse(insertion?.createdAt ?? '');
   const persistedCompletionDeadlineMs =
-    allDone && Number.isFinite(completedAtMs) ? completedAtMs + COMPLETED_PLAN_VISIBLE_MS : null;
+    retired && Number.isFinite(completedAtMs) ? completedAtMs + COMPLETED_PLAN_VISIBLE_MS : null;
   const [fallbackCompletionVisibility, setFallbackCompletionVisibility] = useState<{
     identity: string;
     deadlineMs: number;
@@ -57,7 +68,7 @@ export function PinnedPlanPanel({
   const completionIdentity = insertion ? `${sessionId ?? 'unknown'}:${insertion.key}` : null;
   const completionDeadlineMs =
     persistedCompletionDeadlineMs ??
-    (allDone && fallbackCompletionVisibility?.identity === completionIdentity
+    (retired && fallbackCompletionVisibility?.identity === completionIdentity
       ? fallbackCompletionVisibility.deadlineMs
       : null);
   const completedPlanExpired = Boolean(
@@ -66,7 +77,7 @@ export function PinnedPlanPanel({
   const [hiddenInsertionKey, setHiddenInsertionKey] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!insertion || !allDone) {
+    if (!insertion || !retired) {
       setHiddenInsertionKey(null);
       setFallbackCompletionVisibility(null);
       return;
@@ -92,7 +103,7 @@ export function PinnedPlanPanel({
       setHiddenInsertionKey(insertion.key);
     }, remainingMs);
     return () => window.clearTimeout(timer);
-  }, [allDone, completionDeadlineMs, completionIdentity, insertion?.key]);
+  }, [retired, completionDeadlineMs, completionIdentity, insertion?.key]);
 
   if (
     !visible ||

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -20,7 +20,7 @@
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { findLatestMessageTodoInsertion } from '@cindy/maker-shared/message-render';
+import { getLatestMessageTodoState } from '@cindy/maker-shared/message-render';
 
 import { TodoListCard } from '@/components/chat/TodoListCard';
 import type { ChatMessage } from '@/lib/makerChatStore';
@@ -51,10 +51,23 @@ export function PinnedPlanPanel({
   streaming?: boolean;
   className?: string;
 }): React.ReactElement | null {
-  const insertion = useMemo(
-    () => findLatestMessageTodoInsertion(messages, { taskHistoryMayBeIncomplete }),
+  const todoState = useMemo(
+    () => getLatestMessageTodoState(messages, { taskHistoryMayBeIncomplete }),
     [messages, taskHistoryMayBeIncomplete],
   );
+  const insertion = todoState.insertion;
+  // `streaming` is session-wide, but a legacy plan can outlive its turn. Only
+  // suppress the legacy all-done fallback while the latest normal user turn
+  // still owns this plan; steer rows do not start a new turn.
+  const latestNormalUserIndex = useMemo(() => {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (message.role === 'user' && message.delivery !== 'steer') return index;
+    }
+    return -1;
+  }, [messages]);
+  const planBelongsToLatestTurn =
+    todoState.latestInsertionIndex < 0 || latestNormalUserIndex <= todoState.latestInsertionIndex;
   const allDone = Boolean(
     insertion &&
     insertion.todos.length > 0 &&
@@ -70,7 +83,7 @@ export function PinnedPlanPanel({
   const codexPlanAlive =
     insertion?.source === 'codex' &&
     insertion.sealed !== true &&
-    (streaming || insertion.turnFailed === true);
+    ((streaming && planBelongsToLatestTurn) || insertion.turnFailed === true);
   // 退场 = host 盖了终态章(权威),或计划自己勾完了(没有章的旧数据兜底)。
   const retired =
     Boolean(insertion) && (insertion?.sealed === true || (allDone && !codexPlanAlive));

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -103,15 +103,20 @@ export function PinnedPlanPanel({
     persistedCompletionDeadlineMs !== null && fallbackDeadlineMs !== null
       ? Math.max(persistedCompletionDeadlineMs, fallbackDeadlineMs)
       : (persistedCompletionDeadlineMs ?? fallbackDeadlineMs);
+  // 地板只在 effect 里写(render 阶段写 ref 在 StrictMode 双渲染 / 并发渲染下
+  // 会读到被上一次渲染污染的值,review P2);render 阶段只读。
   const deadlineFloorRef = useRef<{ identity: string; deadlineMs: number } | null>(null);
-  let completionDeadlineMs = rawDeadlineMs;
-  if (completionDeadlineMs !== null && completionIdentity) {
-    const floor = deadlineFloorRef.current;
-    if (floor && floor.identity === completionIdentity) {
-      completionDeadlineMs = Math.max(completionDeadlineMs, floor.deadlineMs);
-    }
+  const floor = deadlineFloorRef.current;
+  const completionDeadlineMs =
+    rawDeadlineMs !== null && floor && completionIdentity && floor.identity === completionIdentity
+      ? Math.max(rawDeadlineMs, floor.deadlineMs)
+      : rawDeadlineMs;
+  useEffect(() => {
+    if (completionDeadlineMs === null || !completionIdentity) return;
+    const current = deadlineFloorRef.current;
+    if (current?.identity === completionIdentity && current.deadlineMs >= completionDeadlineMs) return;
     deadlineFloorRef.current = { identity: completionIdentity, deadlineMs: completionDeadlineMs };
-  }
+  }, [completionDeadlineMs, completionIdentity]);
   const completedPlanExpired = Boolean(
     completionDeadlineMs !== null && completionDeadlineMs <= Date.now(),
   );

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -76,8 +76,15 @@ export function PinnedPlanPanel({
     Boolean(insertion) && (insertion?.sealed === true || (allDone && !codexPlanAlive));
   const completedAtMs =
     insertion?.sealedAtMs ?? insertion?.updatedAtMs ?? Date.parse(insertion?.createdAt ?? '');
+  // 章的时刻来自执行端时钟;device-link 被控场景下本机时钟可能与其偏差任意大。
+  // "未来"的时刻不可信(执行端偏快会让胶囊多挂整个偏差时长)——按缺失处理,
+  // 落进下方 fallback 通道:按身份一次性记"本地看到章的此刻 + 2 秒",不随渲染
+  // 滑动。过去的时刻照用(重载/新窗口不重数 2 秒;执行端偏慢最多提前收起,
+  // 无害)。
   const persistedCompletionDeadlineMs =
-    retired && Number.isFinite(completedAtMs) ? completedAtMs + COMPLETED_PLAN_VISIBLE_MS : null;
+    retired && Number.isFinite(completedAtMs) && completedAtMs <= Date.now()
+      ? completedAtMs + COMPLETED_PLAN_VISIBLE_MS
+      : null;
   const [fallbackCompletionVisibility, setFallbackCompletionVisibility] = useState<{
     identity: string;
     deadlineMs: number;

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -15,6 +15,8 @@
  *
  * 盖章后同样保留 2 秒再收起,时刻锚在章上(章落库,所以重载/新窗口看到的是
  * 同一个时刻,不会重新数 2 秒)。旧数据没有章,按"全勾完"兜底,行为不变。
+ * 兜底只属于旧数据:turn 还在流式时,未盖章的 codex 计划正在等 host 的终态章,
+ * 这时候按"全勾完"抢跑退场,会在章晚到(>2s)时先消失再被章复活闪回 2 秒。
  */
 
 import { useEffect, useMemo, useState } from 'react';
@@ -33,6 +35,7 @@ export function PinnedPlanPanel({
   width,
   taskHistoryMayBeIncomplete = false,
   visible = true,
+  streaming = false,
   className,
 }: {
   sessionId: string | null;
@@ -44,6 +47,8 @@ export function PinnedPlanPanel({
   taskHistoryMayBeIncomplete?: boolean;
   /** 交互卡接管底部区域时只隐藏视图,保留完成后的计时与已收起状态。 */
   visible?: boolean;
+  /** turn 还在流式:未盖章的 codex 计划正在等终态章,不走"全勾完"兜底退场。 */
+  streaming?: boolean;
   className?: string;
 }): React.ReactElement | null {
   const insertion = useMemo(
@@ -55,8 +60,13 @@ export function PinnedPlanPanel({
     insertion.todos.length > 0 &&
     insertion.todos.every((todo) => todo.status === 'completed'),
   );
+  // codex 计划在 turn 流式期间是"等章"状态:host 的终态章才是权威,agent 提前把
+  // 步骤全勾完不算数——按 allDone 抢跑会在章晚到时产生"消失再闪回"。TodoWrite /
+  // Task 永远不会有章,codex 旧历史数据也不会再有,它们照旧走全勾完兜底。
+  const awaitingSeal = insertion?.source === 'codex' && insertion.sealed !== true && streaming;
   // 退场 = host 盖了终态章(权威),或计划自己勾完了(没有章的旧数据兜底)。
-  const retired = Boolean(insertion) && (insertion?.sealed === true || allDone);
+  const retired =
+    Boolean(insertion) && (insertion?.sealed === true || (allDone && !awaitingSeal));
   const completedAtMs =
     insertion?.sealedAtMs ?? insertion?.updatedAtMs ?? Date.parse(insertion?.createdAt ?? '');
   const persistedCompletionDeadlineMs =

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -314,6 +314,45 @@ describe('PinnedPlanPanel terminal seal', () => {
     };
   }
 
+  it('does not cut short a running grace when a past-clock sealed row arrives', () => {
+    // 执行端偏慢:本地已按实时 done 起了 2 秒缓冲,随后到达的落库行带过去的
+    // 章时刻(算出的期限已过期)。取较晚者——缓冲不被远端时钟掐断。
+    const view = render(
+      <PinnedPlanPanel
+        sessionId="slow-clock"
+        messages={[{ ...planMessage('in_progress', T0), terminalPlanSnapshot: true }]}
+        animated={false}
+        width={400}
+      />,
+    );
+    // 无 sealedAtMs → fallback 通道在本地起 2 秒缓冲。
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(500));
+
+    // 持久化行到达:执行端时钟慢 10 分钟,章时刻在本地视角早已过期。
+    view.rerender(
+      <PinnedPlanPanel
+        sessionId="slow-clock"
+        messages={[
+          {
+            ...planMessage('in_progress', T0),
+            terminalPlanSnapshot: true,
+            terminalPlanAtMs: T0 - 10 * 60_000,
+          },
+        ]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    // 本地缓冲还剩 1.5 秒:不得瞬间消失。
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1_499));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
   it('clamps a future terminal seal timestamp to the local clock (device-link skew)', () => {
     // 章的时刻来自执行端时钟。被控场景下执行端偏快时,sealedAtMs 在本机看是
     // "未来"——不钳制的话胶囊会多挂整个偏差时长;钳到本地此刻后仍是标准 2 秒。

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -436,4 +436,99 @@ describe('PinnedPlanPanel terminal seal', () => {
 
     expect(screen.queryByTestId('plan-pill')).not.toBeNull();
   });
+
+  it('does not retire an unsealed all-done codex plan while the turn is still streaming', () => {
+    // 真实复现:Codex 在终态事件前就把全部步骤勾成 completed,随后最终回复流式
+    // 超过 2 秒。若 allDone 兜底在等章期间抢跑,胶囊会先消失,章一到又带着新
+    // sealedAtMs 复活 2 秒——消失再闪回。等章期间必须留在原地。
+    const allDoneStreaming = planMessage('completed', T0, T0);
+    const view = render(
+      <PinnedPlanPanel
+        sessionId="streaming-all-done"
+        messages={[allDoneStreaming]}
+        animated
+        streaming
+        width={400}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(4_000));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+
+    // 章落地:退场计时从 sealedAtMs 起数,整个过程无中断、无闪回。
+    vi.setSystemTime(T0 + 4_000);
+    view.rerender(
+      <PinnedPlanPanel
+        sessionId="streaming-all-done"
+        messages={[
+          {
+            ...allDoneStreaming,
+            terminalPlanSnapshot: true,
+            terminalPlanAtMs: T0 + 4_000,
+          },
+        ]}
+        animated={false}
+        streaming={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1_999));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('still retires an all-done codex plan from old history data without a seal', () => {
+    // 旧数据没有章(升级前落库),也永远不会再有:全勾完兜底照旧生效,
+    // 否则旧会话的计划会永远挂在屏幕上。非流式 = 没有在等章的 turn。
+    render(
+      <PinnedPlanPanel
+        sessionId="old-history-all-done"
+        messages={[planMessage('completed', T0, T0)]}
+        animated={false}
+        streaming={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('keeps the all-done fallback for TodoWrite plans even while streaming', () => {
+    // TodoWrite / Task 计划永远不会被盖章,全勾完兜底是它们唯一的退场路径,
+    // 流式与否都不该被"等章"逻辑挡住。
+    const todoAllDone: ChatMessage = {
+      clientId: 'todo-1',
+      role: 'tool_use',
+      content: '',
+      toolName: 'TodoWrite',
+      toolUseId: 'todo:turn-1',
+      toolInput: {
+        todos: [
+          { content: 'Step 1', status: 'completed' },
+          { content: 'Step 2', status: 'completed' },
+        ],
+      },
+      createdAt: new Date(T0).toISOString(),
+      planUpdatedAtMs: T0,
+    };
+
+    render(
+      <PinnedPlanPanel
+        sessionId="todo-streaming-all-done"
+        messages={[todoAllDone]}
+        animated
+        streaming
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -314,6 +314,29 @@ describe('PinnedPlanPanel terminal seal', () => {
     };
   }
 
+  it('clamps a future terminal seal timestamp to the local clock (device-link skew)', () => {
+    // 章的时刻来自执行端时钟。被控场景下执行端偏快时,sealedAtMs 在本机看是
+    // "未来"——不钳制的话胶囊会多挂整个偏差时长;钳到本地此刻后仍是标准 2 秒。
+    const sealedInFuture: ChatMessage = {
+      ...planMessage('in_progress', T0),
+      terminalPlanSnapshot: true,
+      terminalPlanAtMs: T0 + 10 * 60_000, // 执行端快 10 分钟
+    };
+
+    render(
+      <PinnedPlanPanel
+        sessionId="skewed-seal"
+        messages={[sealedInFuture]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
   it('starts the grace period at the terminal seal, not when the plan was created', () => {
     // 真实复现:计划先展示了 4 秒,agent 才回答完成。若拿 createdAt 算 2 秒,
     // 章一到就已过期,用户会看到泡泡在收尾瞬间直接消失。

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -297,3 +297,143 @@ describe('PinnedPlanPanel completed plan lifetime', () => {
     expect(screen.queryByTestId('plan-pill')).toBeNull();
   });
 });
+
+/**
+ * 终态盖章。main 只在「这一轮成功收尾」时给该计划行盖 terminalPlanSnapshot;
+ * 胶囊的退场只认这枚章,不看勾选状态——agent 收尾时没把每一步勾完是常态
+ * (Codex 官方同样如实保留未勾项),要求"全勾完才退场"等于要求它撒谎。
+ *
+ * 反过来,中断、失败、断线自动续跑都不盖章,计划照旧挂着:任务还活着,用户
+ * 正要接着指挥,这时候摘牌比不摘更糟。
+ */
+describe('PinnedPlanPanel terminal seal', () => {
+  function sealedPlanMessage(planUpdatedAtMs?: number, stepCount = 2): ChatMessage {
+    return {
+      ...planMessage('in_progress', T0, planUpdatedAtMs, stepCount),
+      terminalPlanSnapshot: true,
+    };
+  }
+
+  it('starts the grace period at the terminal seal, not when the plan was created', () => {
+    // 真实复现:计划先展示了 4 秒,agent 才回答完成。若拿 createdAt 算 2 秒,
+    // 章一到就已过期,用户会看到泡泡在收尾瞬间直接消失。
+    vi.setSystemTime(T0 + 4_000);
+    const sealedLater: ChatMessage = {
+      ...planMessage('in_progress', T0),
+      terminalPlanSnapshot: true,
+      terminalPlanAtMs: T0 + 4_000,
+    };
+
+    render(
+      <PinnedPlanPanel
+        sessionId="late-seal"
+        messages={[sealedLater]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1_999));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('retires a sealed plan that still has open steps', () => {
+    render(
+      <PinnedPlanPanel
+        sessionId="sealed-open-steps"
+        messages={[sealedPlanMessage(T0)]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1_999));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('keeps a sealed plan hidden when the task is reopened later', () => {
+    vi.setSystemTime(T0 + 60_000);
+    render(
+      <PinnedPlanPanel
+        sessionId="sealed-reopened"
+        messages={[sealedPlanMessage()]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('keeps an unsealed plan visible while the turn is still open', () => {
+    render(
+      <PinnedPlanPanel
+        sessionId="unsealed"
+        messages={[planMessage('in_progress')]}
+        animated
+        width={400}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+  });
+
+  it('keeps the plan visible when the turn was interrupted instead of finished', () => {
+    // main 对中断/失败的匹配 turn 只打 turnCompleted:false,不盖终态章。
+    const interrupted: ChatMessage = {
+      ...planMessage('in_progress'),
+      turnCompleted: false,
+    };
+
+    render(
+      <PinnedPlanPanel
+        sessionId="interrupted-turn"
+        messages={[interrupted]}
+        animated={false}
+        width={400}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+  });
+
+  it('shows the capsule again when a new plan update clears the seal', () => {
+    const view = render(
+      <PinnedPlanPanel
+        sessionId="sealed-then-updated"
+        messages={[sealedPlanMessage(T0)]}
+        animated={false}
+        width={400}
+      />,
+    );
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+
+    // 新一轮真的更新了计划:store 把章清成 false,胶囊重新亮牌。
+    view.rerender(
+      <PinnedPlanPanel
+        sessionId="sealed-then-updated"
+        messages={[
+          {
+            ...planMessage('in_progress', T0, T0 + 5_000, 3),
+            terminalPlanSnapshot: false,
+          },
+        ]}
+        animated
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -480,6 +480,29 @@ describe('PinnedPlanPanel terminal seal', () => {
     expect(screen.queryByTestId('plan-pill')).toBeNull();
   });
 
+  it('keeps an all-done codex plan visible when its turn failed instead of sealing', () => {
+    // Codex 把步骤全勾完后 turn 以中断/失败终态收场:host 按设计不盖章,只给该行
+    // 盖 turnCompleted:false。此时流式已结束,但任务还活着——不得因为"非流式 +
+    // 全勾完"就当旧数据兜底退场,否则用户正要接着指挥的计划被摘牌。
+    const failedAllDone: ChatMessage = {
+      ...planMessage('completed', T0, T0),
+      turnCompleted: false,
+    };
+
+    render(
+      <PinnedPlanPanel
+        sessionId="failed-turn-all-done"
+        messages={[failedAllDone]}
+        animated={false}
+        streaming={false}
+        width={400}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(30_000));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+  });
+
   it('still retires an all-done codex plan from old history data without a seal', () => {
     // 旧数据没有章(升级前落库),也永远不会再有:全勾完兜底照旧生效,
     // 否则旧会话的计划会永远挂在屏幕上。非流式 = 没有在等章的 turn。

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -583,6 +583,58 @@ describe('PinnedPlanPanel terminal seal', () => {
     expect(screen.queryByTestId('plan-pill')).toBeNull();
   });
 
+  it('does not revive an old unsealed all-done plan when a later turn starts streaming', () => {
+    const oldCompletedPlan = planMessage('completed', T0, T0);
+    vi.setSystemTime(T0 + 10_000);
+    const view = render(
+      <PinnedPlanPanel
+        sessionId="old-plan-new-turn"
+        messages={[oldCompletedPlan]}
+        animated={false}
+        streaming={false}
+        width={400}
+      />,
+    );
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+
+    view.rerender(
+      <PinnedPlanPanel
+        sessionId="old-plan-new-turn"
+        messages={[
+          oldCompletedPlan,
+          {
+            clientId: 'new-turn-user',
+            role: 'user',
+            content: 'Start the next turn',
+            createdAt: new Date(T0 + 10_000).toISOString(),
+            delivery: 'turn',
+          },
+        ]}
+        animated
+        streaming
+        width={400}
+      />,
+    );
+
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('keeps a current-turn unsealed all-done codex plan visible while streaming', () => {
+    const currentPlan = planMessage('completed', T0, T0);
+    render(
+      <PinnedPlanPanel
+        sessionId="current-plan-streaming"
+        messages={[currentPlan]}
+        animated
+        streaming
+        width={400}
+      />,
+    );
+
+    act(() => vi.advanceTimersByTime(4_000));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+  });
+
   it('keeps the all-done fallback for TodoWrite plans even while streaming', () => {
     // TodoWrite / Task 计划永远不会被盖章,全勾完兜底是它们唯一的退场路径,
     // 流式与否都不该被"等章"逻辑挡住。

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -3534,6 +3534,7 @@ export function CCAgentSessionView({
                   sessionId={sessionId ?? null}
                   messages={messages}
                   animated={isStreaming}
+                  streaming={isStreaming}
                   width={inputWidth}
                   taskHistoryMayBeIncomplete={
                     !historyLoaded || hasMoreMessages || historyWindowHasIsland

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -371,6 +371,8 @@ export interface ChatMessage {
   planUpdatedAtMs?: number;
   /** Main stamped this persisted Codex plan at the successful done boundary. */
   terminalPlanSnapshot?: boolean;
+  /** Host time when the successful Codex plan seal was applied. */
+  terminalPlanAtMs?: number;
   /**
    * 产生这条消息的模型 raw id(读自 agentMeta.model)。对 subagent 子消息而言
    * 即子代理实际跑的模型(如 'claude-haiku-4-5-20251001')。仅 SDK 带 model 的
@@ -14321,7 +14323,12 @@ function mapServerMessages(serverMsgs: Message[]): ChatMessage[] {
         toolName,
         toolInput,
         ...(toolName === 'update_plan' && c.terminalPlanSnapshot === true
-          ? { terminalPlanSnapshot: true }
+          ? {
+              terminalPlanSnapshot: true,
+              ...(typeof c.terminalPlanAtMs === 'number'
+                ? { terminalPlanAtMs: c.terminalPlanAtMs }
+                : {}),
+            }
           : {}),
         ...(toolName === 'update_plan' && c.turnCompleted === false
           ? { turnCompleted: false }

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -4839,7 +4839,9 @@ export function handleStreamEvent(
       });
 
       const terminalData = event.data as
-        { plan?: unknown; raw?: { id?: unknown; status?: unknown } } | null | undefined;
+        { cancelled?: unknown; plan?: unknown; raw?: { id?: unknown; status?: unknown } }
+        | null
+        | undefined;
       const terminalTurnId = typeof terminalData?.raw?.id === 'string' ? terminalData.raw.id : null;
       const terminalTurnStatus =
         typeof terminalData?.raw?.status === 'string' ? terminalData.raw.status : null;
@@ -4851,6 +4853,7 @@ export function handleStreamEvent(
               terminalTurnId,
               terminalTurnStatus,
               Date.now(),
+              terminalData?.cancelled === true,
             ).messages
           : cleanedMessages;
 

--- a/apps/desktop/src/renderer/lib/makerChatStore.ts
+++ b/apps/desktop/src/renderer/lib/makerChatStore.ts
@@ -40,6 +40,7 @@ import {
   applyCodexPlanSnapshotOnDone,
   getLatestMessageTodoState,
   isAgentPlanToolName,
+  markCodexPlanTurnFailed,
 } from '@cindy/maker-shared/message-render';
 import {
   normalizeWorkflowProgressEntries,
@@ -5007,11 +5008,19 @@ export function handleStreamEvent(
       // failure. Daemon dying outside upgrade still surfaces a normal banner.
       const isPlannedUpgradeClose =
         reason === 'remote_daemon_closed' && isSessionUpgrading(event.sessionId);
+      // 没有 done 的 codex 终态 error:该 turn 的计划行等不到章,也等不到
+      // persistCodexPlanOnDone 的 turnCompleted:false。立即在内存里补失败印记
+      // (main 的 persistCodexPlanOnTerminalError 落库版本随行广播稍后到达),
+      // 否则钉住面板会把全勾完的失败计划当旧数据兜底退场。
+      const terminalErrorMessages =
+        event.source === 'codex'
+          ? markCodexPlanTurnFailed(finalized.messages).messages
+          : finalized.messages;
       return {
         ...finalized,
         messages: suppressAutoResumeBroadcastError
-          ? finalized.messages
-          : finalized.messages.filter(
+          ? [...terminalErrorMessages]
+          : terminalErrorMessages.filter(
               (message) => message.clientId !== AUTO_RESUME_PENDING_CLIENT_ID,
             ),
         // coordinator 已经先发 autoResumePending projection 时，终态 maker:event

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -946,6 +946,52 @@ describe('remoteSessionStore', () => {
     });
   });
 
+  it('stamps the turn plan as failed on a codex terminal error, through live-plan overlays', () => {
+    // 没有 done 的 codex 终态 error:这一轮的计划行等不到章。手机端要自己补失败
+    // 印记,否则全勾完的失败计划按旧数据兜底退场;而印记只写内存行、不写 live
+    // 缓存时,overlay 会用旧缓存把 main 随后广播的落库印记盖回去(review P1)。
+    const planRow = {
+      ...message('plan-row-1', 's1'),
+      role: 'tool_use' as const,
+      toolUseId: 'plan:turn-err',
+      content: {
+        toolUseId: 'plan:turn-err',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Ship', status: 'completed' }] },
+      },
+    };
+    remoteSessionStore.setMessages('s1', [planRow]);
+    // 先按真实链路让 live 缓存记住这一行(update_plan 推送)。
+    remoteSessionStore.applyMakerEvent('s1', {
+      type: 'tool_use',
+      data: {
+        toolUseId: 'plan:turn-err',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Ship', status: 'completed' }] },
+      },
+    }, 'plan-row-1');
+
+    remoteSessionStore.applyMakerEvent('s1', {
+      type: 'error',
+      source: 'codex',
+      data: { message: 'stream disconnected' },
+    });
+
+    expect(remoteSessionStore.getMessages('s1')[0]).toMatchObject({
+      content: {
+        turnCompleted: false,
+        input: { plan: [{ step: 'Ship', status: 'completed' }] },
+      },
+    });
+
+    // main 落库前的行重新到达(无印记):overlay 用 live 缓存覆盖 content,
+    // 缓存已带印记 → 不回退成"已完成的旧计划"。
+    remoteSessionStore.mergeMessages('s1', [planRow]);
+    expect(remoteSessionStore.getMessages('s1')[0]).toMatchObject({
+      content: { turnCompleted: false },
+    });
+  });
+
   it('coalesces update_plan with streaming finalization into one notification', () => {
     vi.useFakeTimers();
     const notify = vi.fn();

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -1053,7 +1053,7 @@ describe('remoteSessionStore', () => {
     });
   });
 
-  it('keeps synthetic completion when done precedes the initial plan DB row', () => {
+  it('keeps the honest live snapshot when done precedes the initial plan DB row', () => {
     remoteSessionStore.applyRemotePush('dev-1', 'maker:event', {
       sessionId: 's1',
       persistId: 'plan-row-1',
@@ -1105,17 +1105,19 @@ describe('remoteSessionStore', () => {
       },
     });
 
+    // 成功收尾封的是生命周期,不改步骤事实:agent 报告什么就显示什么,
+    // 晚到的 DB 行也不能把 live 快照拉回更旧的内容。
     expect(remoteSessionStore.getMessages('s1')[0].content).toMatchObject({
       input: {
         plan: [
-          { step: 'Inspect', status: 'completed' },
-          { step: 'Patch', status: 'completed' },
+          { step: 'Inspect', status: 'in_progress' },
+          { step: 'Patch', status: 'pending' },
         ],
       },
     });
   });
 
-  it('does not let a delayed message window revert synthetic completion', () => {
+  it('does not let a delayed message window revert the live plan snapshot', () => {
     const stalePlanRow = {
       ...message('plan-row-1', 's1'),
       role: 'tool_use' as const,
@@ -1153,8 +1155,9 @@ describe('remoteSessionStore', () => {
 
     remoteSessionStore.setLatestMessageWindow('s1', [stalePlanRow]);
 
+    // 步骤保持 agent 实际报告的状态,不因成功收尾被改写成 completed。
     expect(remoteSessionStore.getMessages('s1')[0].content).toMatchObject({
-      input: { plan: [{ step: 'Inspect', status: 'completed' }] },
+      input: { plan: [{ step: 'Inspect', status: 'in_progress' }] },
     });
   });
 

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -7,7 +7,7 @@ import {
   type AgentTaskUpdate,
 } from '@cindy/maker-shared/agent-task';
 import type { MobileGoalStatusPayload } from '@cindy/maker-shared/device-link-contract';
-import { applyCodexPlanSnapshotOnDone } from '@cindy/maker-shared/message-render';
+import { applyCodexPlanSnapshotOnDone, markCodexPlanTurnFailed } from '@cindy/maker-shared/message-render';
 import type { RemoteSessionLiveActivity } from '@cindy/maker-shared/session-list';
 import { buildDeviceIdentity, resolveCanonicalDeviceId } from '@cindy/maker-shared/mobile-home';
 import {
@@ -2372,6 +2372,27 @@ export const remoteSessionStore = {
               completed.toolUseId,
               completedMessage.content,
             );
+          }
+        }
+      } else if (readString(event, 'source') === 'codex') {
+        // 没有 done 的 codex 终态 error:这一轮的计划行等不到章,也等不到
+        // persistCodexPlanOnDone 的 turnCompleted:false。与 desktop renderer 的
+        // markCodexPlanTurnFailed 同款补印记,否则全勾完的失败计划会按旧数据
+        // 兜底退场——任务还活着,用户正要接着指挥。
+        const currentMessages = messages.get(sessionId) ?? [];
+        const failed = markCodexPlanTurnFailed(currentMessages);
+        terminalPlanChanged = failed.changed;
+        if (failed.changed) {
+          messages.set(sessionId, [...failed.messages]);
+          const failedMessage = failed.messages.find((message) => {
+            if (message.toolUseId === failed.toolUseId) return true;
+            return readString(message.content, 'toolUseId') === failed.toolUseId;
+          });
+          // 印记也要进 live-plan 缓存:overlayLivePlanSnapshot 用缓存内容整体
+          // 替换 content,缓存不补就会把 main 随后广播的落库 turnCompleted:false
+          // 盖回去,本连接周期内再也纠不回来。
+          if (failed.toolUseId && isRecord(failedMessage?.content)) {
+            rememberLivePlanContent(sessionId, failed.toolUseId, failedMessage.content);
           }
         }
       }

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -639,6 +639,7 @@ function completeLivePlanSnapshotOnDone(
   snapshot: unknown,
   turnId: string | null,
   terminalStatus: string | null,
+  cancelled: boolean,
 ): boolean {
   if (!turnId) return false;
   const toolUseId = `plan:${turnId}`;
@@ -650,6 +651,8 @@ function completeLivePlanSnapshotOnDone(
     snapshot,
     turnId,
     terminalStatus,
+    undefined,
+    cancelled,
   );
   const content = completed.messages[0]?.content;
   if (!completed.changed || !isRecord(content)) return false;
@@ -2339,18 +2342,22 @@ export const remoteSessionStore = {
         const rawTurn = isRecord(data?.raw) ? data.raw : null;
         const turnId = readString(rawTurn, 'id');
         const turnStatus = readString(rawTurn, 'status');
+        const turnCancelled = data?.cancelled === true;
         const currentMessages = messages.get(sessionId) ?? [];
         const completed = applyCodexPlanSnapshotOnDone(
           currentMessages,
           data?.plan,
           turnId,
           turnStatus,
+          undefined,
+          turnCancelled,
         );
         completeLivePlanSnapshotOnDone(
           sessionId,
           data?.plan,
           turnId,
           turnStatus,
+          turnCancelled,
         );
         terminalPlanChanged = completed.changed;
         if (completed.changed) {

--- a/packages/maker-shared/src/__tests__/messageRender.test.ts
+++ b/packages/maker-shared/src/__tests__/messageRender.test.ts
@@ -870,6 +870,42 @@ describe('message render todo grouping', () => {
     expect(findLatestMessageTodoInsertion([tool('t1', 'Bash', {})])).toBeNull();
   });
 
+  it('a terminal seal ends the plan session even when steps were left open', () => {
+    // 成功收尾常留未勾完的步骤。章之后的下一 turn 计划必须开新 session:
+    // 否则新计划把上一轮吞成续写,历史里上一轮的卡消失、面板复用旧 key。
+    const sealedOpen = {
+      ...tool('plan1', 'update_plan', {
+        plan: [{ step: 'Ship', status: 'in_progress' }],
+      }),
+      terminalPlanSnapshot: true,
+      terminalPlanAtMs: 1_700_000_000_000,
+    };
+    const nextTurnPlan = tool('plan2', 'update_plan', {
+      plan: [{ step: 'New task', status: 'in_progress' }],
+    });
+
+    expect(findLatestMessageTodoInsertion([sealedOpen, nextTurnPlan])).toMatchObject({
+      key: 'todo-plan2',
+      todos: [{ content: 'New task', status: 'in_progress' }],
+    });
+    // 章在持久化 content 里(mobile 渲染 main 广播行的形态)同样算边界。
+    const sealedInContent = {
+      ...tool('plan3', 'update_plan', { plan: [{ step: 'Ship', status: 'in_progress' }] }),
+      content: {
+        toolUseId: 'plan3',
+        toolName: 'update_plan',
+        input: { plan: [{ step: 'Ship', status: 'in_progress' }] },
+        terminalPlanSnapshot: true,
+        terminalPlanAtMs: 1_700_000_000_000,
+      },
+    };
+    const latest = findLatestMessageTodoInsertion([sealedInContent, nextTurnPlan]);
+    expect(latest).toMatchObject({ key: 'todo-plan2' });
+    expect(
+      findLatestMessageTodoInsertion([sealedInContent]),
+    ).toMatchObject({ sealed: true, sealedAtMs: 1_700_000_000_000 });
+  });
+
   it('findLatestMessageTodoInsertion marks a plan whose turn failed as turnFailed', () => {
     // persistCodexPlanOnDone 在中断/失败终态给计划行盖 turnCompleted:false。
     // 面板据此不走"全勾完"兜底退场:任务还活着,计划必须留在屏幕上。

--- a/packages/maker-shared/src/__tests__/messageRender.test.ts
+++ b/packages/maker-shared/src/__tests__/messageRender.test.ts
@@ -870,6 +870,28 @@ describe('message render todo grouping', () => {
     expect(findLatestMessageTodoInsertion([tool('t1', 'Bash', {})])).toBeNull();
   });
 
+  it('findLatestMessageTodoInsertion marks a plan whose turn failed as turnFailed', () => {
+    // persistCodexPlanOnDone 在中断/失败终态给计划行盖 turnCompleted:false。
+    // 面板据此不走"全勾完"兜底退场:任务还活着,计划必须留在屏幕上。
+    const failedPlan = {
+      ...tool('plan1', 'update_plan', {
+        plan: [{ step: 'Ship it', status: 'completed' }],
+      }),
+      turnCompleted: false,
+    };
+
+    expect(findLatestMessageTodoInsertion([failedPlan])).toMatchObject({
+      source: 'codex',
+      turnFailed: true,
+    });
+    // 正常行没有印记,不应引入该字段。
+    expect(
+      findLatestMessageTodoInsertion([
+        tool('plan2', 'update_plan', { plan: [{ step: 'Ship it', status: 'completed' }] }),
+      ]),
+    ).not.toHaveProperty('turnFailed');
+  });
+
   it('does not infer completion from an ambiguous legacy Codex turn seal', () => {
     const plan = {
       ...tool('plan1', 'update_plan', {

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -276,6 +276,22 @@ describe('markCodexPlanTurnFailed', () => {
     const result = markCodexPlanTurnFailed([plan, steerRow]);
     expect(result.changed).toBe(true);
     expect(result.messages[0]).toMatchObject({ turnCompleted: false });
+
+    // steer 的落库位置是 agentMeta.delivery(mobile / main 侧原始行就是这个形状,
+    // 只有 desktop 渲染层把它投影成顶层字段)。只认顶层会让回扫在插话行上提前
+    // 收手,手机端全勾完的失败计划先按旧数据退场再被广播复活(review P2)。
+    const metaSteerRow = {
+      role: 'user' as const,
+      clientId: 'u-steer-meta',
+      content: 'wait',
+      agentMeta: { delivery: 'steer' },
+    };
+    const metaResult = markCodexPlanTurnFailed([
+      planMessage('plan:meta-steer', [{ step: 'Ship', status: 'completed' }]),
+      metaSteerRow,
+    ]);
+    expect(metaResult.changed).toBe(true);
+    expect(metaResult.messages[0]).toMatchObject({ turnCompleted: false });
   });
 
   it('never reaches past the latest user message into an older turn plan', () => {

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -203,4 +203,24 @@ describe('markCodexPlanTurnFailed', () => {
     const noPlan = { role: 'tool_use' as const, clientId: 'b1', toolName: 'Bash', content: '' };
     expect(markCodexPlanTurnFailed([noPlan])).toEqual({ messages: [noPlan], changed: false });
   });
+
+  it('never reaches past the latest user message into an older turn plan', () => {
+    // 所有权边界:本次失败的 turn 没发过 update_plan 时,不得把上一段历史里
+    // 未盖章的旧计划(如升级前已全勾完退场的行)标成失败复活——main 侧对应
+    // 落库也不会发生,内存里这枚错印记将没有任何广播能纠正。
+    const historicPlan = planMessage('plan:old', [{ step: 'Ship', status: 'completed' }]);
+    const newUserTurn = { role: 'user' as const, clientId: 'u2', content: 'next task' };
+    const failingTool = { role: 'tool_use' as const, clientId: 'b2', toolName: 'Bash', content: '' };
+
+    expect(markCodexPlanTurnFailed([historicPlan, newUserTurn, failingTool])).toEqual({
+      messages: [historicPlan, newUserTurn, failingTool],
+      changed: false,
+    });
+
+    // 计划在当前 user 段内(属于本次失败 turn)时照常落印。
+    const currentPlan = planMessage('plan:cur', [{ step: 'Ship', status: 'completed' }]);
+    const result = markCodexPlanTurnFailed([newUserTurn, currentPlan]);
+    expect(result.changed).toBe(true);
+    expect(result.messages[1]).toMatchObject({ turnCompleted: false });
+  });
 });

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -89,12 +89,13 @@ describe('applyCodexPlanSnapshotOnDone', () => {
     });
   });
 
-  it('marks the matching plan complete when a successful turn has no final snapshot', () => {
+  it('seals the matching plan on a successful turn without ticking its open steps', () => {
     const completedAtMs = 1_700_000_005_000;
-    const message = planMessage('plan:done', [
+    const openSteps = [
       { step: 'Inspect', status: 'in_progress' },
       { step: 'Patch', status: 'pending' },
-    ]);
+    ];
+    const message = planMessage('plan:done', openSteps);
     const result = applyCodexPlanSnapshotOnDone(
       [message],
       null,
@@ -105,54 +106,54 @@ describe('applyCodexPlanSnapshotOnDone', () => {
 
     expect(result.changed).toBe(true);
     expect(result.toolUseId).toBe('plan:done');
+    // 章封生命周期,步骤事实保持原样:agent 没报告完成的事不能替它宣布完成。
     expect(result.messages[0]).toMatchObject({
+      terminalPlanSnapshot: true,
       planUpdatedAtMs: completedAtMs,
-      toolInput: {
-        plan: [
-          { step: 'Inspect', status: 'completed' },
-          { step: 'Patch', status: 'completed' },
-        ],
-      },
-      content: {
-        input: {
-          plan: [
-            { step: 'Inspect', status: 'completed' },
-            { step: 'Patch', status: 'completed' },
-          ],
-        },
-      },
+      toolInput: { plan: openSteps },
+      content: { input: { plan: openSteps } },
     });
   });
 
-  it('treats an unfinished done snapshot as cached progress for a successful turn', () => {
+  it('seals an already-sealed row only once so the capsule grace does not restart', () => {
+    const message = {
+      ...planMessage('plan:done', [{ step: 'Inspect', status: 'in_progress' }]),
+      terminalPlanSnapshot: true,
+    };
+    const messages = [message];
+
+    expect(applyCodexPlanSnapshotOnDone(messages, null, 'done', 'completed')).toEqual({
+      messages,
+      changed: false,
+      toolUseId: 'plan:done',
+    });
+  });
+
+  it('applies an explicit unfinished snapshot verbatim and seals it', () => {
     const message = planMessage('plan:done', [
       { step: 'Inspect', status: 'in_progress' },
       { step: 'Patch', status: 'pending' },
     ]);
-    const cachedProgress = [
+    const reportedProgress = [
       { step: 'Inspect', status: 'completed', description: 'kept from latest update' },
       { step: 'Patch', status: 'in_progress' },
     ];
 
     const result = applyCodexPlanSnapshotOnDone(
       [message],
-      cachedProgress,
+      reportedProgress,
       'done',
       'completed',
     );
 
     expect(result.changed).toBe(true);
     expect(result.messages[0]).toMatchObject({
-      toolInput: {
-        plan: [
-          { step: 'Inspect', status: 'completed', description: 'kept from latest update' },
-          { step: 'Patch', status: 'completed' },
-        ],
-      },
+      terminalPlanSnapshot: true,
+      toolInput: { plan: reportedProgress },
     });
   });
 
-  it('does not infer completion without a matching turn id', () => {
+  it('does not seal without a matching turn id', () => {
     const message = planMessage('plan:unrelated', [
       { step: 'Inspect', status: 'in_progress' },
     ]);
@@ -166,7 +167,7 @@ describe('applyCodexPlanSnapshotOnDone', () => {
     )).toEqual({ messages, changed: false, toolUseId: null });
   });
 
-  it('does not infer completion for a failed or interrupted turn', () => {
+  it('does not seal a failed or interrupted turn', () => {
     const message = planMessage('plan:stopped', [{ step: 'Inspect', status: 'in_progress' }]);
     const messages = [message];
 

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -175,9 +175,20 @@ describe('applyCodexPlanSnapshotOnDone', () => {
     const message = planMessage('plan:raced', [{ step: 'Inspect', status: 'in_progress' }]);
     const messages = [message];
 
-    expect(
-      applyCodexPlanSnapshotOnDone(messages, null, 'raced', 'completed', undefined, true),
-    ).toEqual({ messages, changed: false, toolUseId: null });
+    const result = applyCodexPlanSnapshotOnDone(
+      messages,
+      null,
+      'raced',
+      'completed',
+      undefined,
+      true,
+    );
+    // 不盖成功章,但要立即落失败印记(turnCompleted:false)——只拦盖章的话,
+    // 全勾完的取消计划会被旧数据兜底即时隐藏,再被 main 落库行复活闪回。
+    expect(result.changed).toBe(true);
+    expect(result.toolUseId).toBe('plan:raced');
+    expect(result.messages[0]).toMatchObject({ turnCompleted: false });
+    expect(result.messages[0]).not.toMatchObject({ terminalPlanSnapshot: true });
   });
 
   it('does not seal a failed or interrupted turn, but stamps it as failed', () => {

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -167,6 +167,19 @@ describe('applyCodexPlanSnapshotOnDone', () => {
     )).toEqual({ messages, changed: false, toolUseId: null });
   });
 
+  it('lets the cancelled flag outrank raw.status completed', () => {
+    // done 可同时带 cancelled:true + raw.status 'completed'(用户 Stop 恰逢
+    // turn 自然收尾)。main 的 isSuccessfulCodexDoneEventData 让取消优先、按
+    // 非成功持久化;渲染端必须同序——只看 status 就会即时盖章退场,随后落库
+    // 行广播又把计划复活,即时 UI 与 DB 分叉。
+    const message = planMessage('plan:raced', [{ step: 'Inspect', status: 'in_progress' }]);
+    const messages = [message];
+
+    expect(
+      applyCodexPlanSnapshotOnDone(messages, null, 'raced', 'completed', undefined, true),
+    ).toEqual({ messages, changed: false, toolUseId: null });
+  });
+
   it('does not seal a failed or interrupted turn, but stamps it as failed', () => {
     // interrupted / failed 的 done 不盖章(任务还活着,计划必须留在屏幕上),
     // 但要立即在内存补 turnCompleted:false——main 的落库印记在 done 广播之后

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyCodexPlanSnapshotOnDone } from '../messageRender.js';
+import { applyCodexPlanSnapshotOnDone, markCodexPlanTurnFailed } from '../messageRender.js';
 
 function planMessage(id: string, plan: unknown) {
   return {
@@ -176,5 +176,31 @@ describe('applyCodexPlanSnapshotOnDone', () => {
       changed: false,
       toolUseId: null,
     });
+  });
+});
+
+describe('markCodexPlanTurnFailed', () => {
+  // 没有 done 的终态 error:该 turn 永远等不到章。renderer 在 error 边界给最近
+  // 一条未盖章的计划行补 turnCompleted:false,面板据此把它当存活任务。
+  it('stamps the latest unsealed plan row as failed without touching steps', () => {
+    const plan = planMessage('plan:err', [{ step: 'Ship', status: 'completed' }]);
+    const result = markCodexPlanTurnFailed([plan]);
+
+    expect(result.changed).toBe(true);
+    expect(result.messages[0]).toMatchObject({
+      turnCompleted: false,
+      toolInput: { plan: [{ step: 'Ship', status: 'completed' }] },
+    });
+  });
+
+  it('leaves sealed or already-stamped rows and plan-less turns alone', () => {
+    const sealed = { ...planMessage('plan:done', []), terminalPlanSnapshot: true };
+    expect(markCodexPlanTurnFailed([sealed])).toEqual({ messages: [sealed], changed: false });
+
+    const stamped = { ...planMessage('plan:old-fail', []), turnCompleted: false };
+    expect(markCodexPlanTurnFailed([stamped])).toEqual({ messages: [stamped], changed: false });
+
+    const noPlan = { role: 'tool_use' as const, clientId: 'b1', toolName: 'Bash', content: '' };
+    expect(markCodexPlanTurnFailed([noPlan])).toEqual({ messages: [noPlan], changed: false });
   });
 });

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -230,17 +230,21 @@ describe('markCodexPlanTurnFailed', () => {
       turnCompleted: false,
       toolInput: { plan: [{ step: 'Ship', status: 'completed' }] },
     });
+    // 印记同时落 content,并回传 toolUseId:mobile 靠这两样把同一份 content 写回
+    // live-plan 缓存,否则 overlay 会把落库印记盖回去(review P1)。
+    expect(result.toolUseId).toBe('plan:err');
+    expect(result.messages[0].content).toMatchObject({ turnCompleted: false });
   });
 
   it('leaves sealed or already-stamped rows and plan-less turns alone', () => {
     const sealed = { ...planMessage('plan:done', []), terminalPlanSnapshot: true };
-    expect(markCodexPlanTurnFailed([sealed])).toEqual({ messages: [sealed], changed: false });
+    expect(markCodexPlanTurnFailed([sealed])).toEqual({ messages: [sealed], changed: false, toolUseId: null });
 
     const stamped = { ...planMessage('plan:old-fail', []), turnCompleted: false };
-    expect(markCodexPlanTurnFailed([stamped])).toEqual({ messages: [stamped], changed: false });
+    expect(markCodexPlanTurnFailed([stamped])).toEqual({ messages: [stamped], changed: false, toolUseId: null });
 
     const noPlan = { role: 'tool_use' as const, clientId: 'b1', toolName: 'Bash', content: '' };
-    expect(markCodexPlanTurnFailed([noPlan])).toEqual({ messages: [noPlan], changed: false });
+    expect(markCodexPlanTurnFailed([noPlan])).toEqual({ messages: [noPlan], changed: false, toolUseId: null });
   });
 
   it('writes the lifecycle stamp into content as well for mobile live-plan overlays', () => {
@@ -285,6 +289,7 @@ describe('markCodexPlanTurnFailed', () => {
     expect(markCodexPlanTurnFailed([historicPlan, newUserTurn, failingTool])).toEqual({
       messages: [historicPlan, newUserTurn, failingTool],
       changed: false,
+      toolUseId: null,
     });
 
     // 计划在当前 user 段内(属于本次失败 turn)时照常落印。

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -219,6 +219,37 @@ describe('markCodexPlanTurnFailed', () => {
     expect(markCodexPlanTurnFailed([noPlan])).toEqual({ messages: [noPlan], changed: false });
   });
 
+  it('writes the lifecycle stamp into content as well for mobile live-plan overlays', () => {
+    // mobile 的 live-plan 缓存只保存 content,overlay 会用缓存覆盖 main 广播的
+    // 持久化 content。章/失败印记必须同时落在 content 里,否则 overlay 一盖,
+    // 成功计划在手机端永远"未盖章",下一 turn 把上一轮吞进同一 session。
+    const message = planMessage('plan:done', [{ step: 'Ship', status: 'completed' }]);
+    const sealed = applyCodexPlanSnapshotOnDone([message], null, 'done', 'completed', 1_700);
+    expect(sealed.messages[0].content).toMatchObject({
+      terminalPlanSnapshot: true,
+      terminalPlanAtMs: 1_700,
+    });
+
+    const interrupted = applyCodexPlanSnapshotOnDone(
+      [planMessage('plan:stop', [{ step: 'Ship', status: 'completed' }])],
+      null,
+      'plan:stop'.replace('plan:', ''),
+      'interrupted',
+    );
+    expect(interrupted.messages[0].content).toMatchObject({ turnCompleted: false });
+  });
+
+  it('does not stop the failure scan at a mid-turn steer interjection', () => {
+    // steer 插话不开新 turn:同一 vendor turn 里 计划 → steer user 行 → 终态
+    // error 的序列,回扫必须穿过 steer 行命中所属计划;普通 user 行仍是硬边界。
+    const plan = planMessage('plan:cur', [{ step: 'Ship', status: 'completed' }]);
+    const steerRow = { role: 'user' as const, clientId: 'u-steer', content: 'wait', delivery: 'steer' };
+
+    const result = markCodexPlanTurnFailed([plan, steerRow]);
+    expect(result.changed).toBe(true);
+    expect(result.messages[0]).toMatchObject({ turnCompleted: false });
+  });
+
   it('never reaches past the latest user message into an older turn plan', () => {
     // 所有权边界:本次失败的 turn 没发过 update_plan 时,不得把上一段历史里
     // 未盖章的旧计划(如升级前已全勾完退场的行)标成失败复活——main 侧对应

--- a/packages/maker-shared/src/__tests__/planCompletion.test.ts
+++ b/packages/maker-shared/src/__tests__/planCompletion.test.ts
@@ -167,14 +167,29 @@ describe('applyCodexPlanSnapshotOnDone', () => {
     )).toEqual({ messages, changed: false, toolUseId: null });
   });
 
-  it('does not seal a failed or interrupted turn', () => {
+  it('does not seal a failed or interrupted turn, but stamps it as failed', () => {
+    // interrupted / failed 的 done 不盖章(任务还活着,计划必须留在屏幕上),
+    // 但要立即在内存补 turnCompleted:false——main 的落库印记在 done 广播之后
+    // 才异步到达,没有这枚即时印记,全勾完的中断计划会先被旧数据兜底隐藏、
+    // 再被落库行广播复活闪回。
     const message = planMessage('plan:stopped', [{ step: 'Inspect', status: 'in_progress' }]);
-    const messages = [message];
+    const result = applyCodexPlanSnapshotOnDone([message], null, 'stopped', 'interrupted');
 
-    expect(applyCodexPlanSnapshotOnDone(messages, null, 'stopped', 'interrupted')).toEqual({
-      messages,
+    expect(result.changed).toBe(true);
+    expect(result.toolUseId).toBe('plan:stopped');
+    expect(result.messages[0]).toMatchObject({
+      turnCompleted: false,
+      // 不盖章,步骤状态不动。
+      toolInput: { explanation: 'keep', plan: [{ step: 'Inspect', status: 'in_progress' }] },
+    });
+    expect(result.messages[0]).not.toHaveProperty('terminalPlanSnapshot');
+
+    // 已有印记时是纯 no-op,不重启胶囊计时。
+    const stamped = { ...message, turnCompleted: false };
+    expect(applyCodexPlanSnapshotOnDone([stamped], null, 'stopped', 'interrupted')).toEqual({
+      messages: [stamped],
       changed: false,
-      toolUseId: null,
+      toolUseId: 'plan:stopped',
     });
   });
 });

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -634,9 +634,13 @@ export function applyCodexPlanSnapshotOnDone<
   // 只看 status 会先盖章退场,随后 main 持久化 turnCompleted:false 的 DB 行
   // 广播到达,计划复活——即时 UI 与落库分叉。
   const sealsTurn = terminalStatus === 'completed' && cancelled !== true && Boolean(turnId);
-  // done 恒为终态:status 不是 completed(interrupted / failed)即失败终态。
+  // done 恒为终态:status 非 completed(interrupted / failed),或 cancelled 覆盖
+  // 了 completed,均为失败终态——后者只拦盖章不落失败印记的话,全勾完的取消
+  // 计划会被旧数据兜底即时隐藏,再被 main 的 turnCompleted:false 落库行复活。
   const stampsFailed =
-    Boolean(turnId) && typeof terminalStatus === 'string' && terminalStatus !== 'completed';
+    Boolean(turnId) &&
+    ((typeof terminalStatus === 'string' && terminalStatus !== 'completed') ||
+      (cancelled === true && terminalStatus === 'completed'));
   if (!authoritativeSnapshot && !sealsTurn && !stampsFailed) {
     return { messages, changed: false, toolUseId: null };
   }

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -210,6 +210,11 @@ export interface MessageRenderTodoInsertion {
   sealed?: boolean;
   /** Persisted host time of the successful terminal seal. */
   sealedAtMs?: number;
+  /**
+   * host 在中断/失败 turn 给该计划行盖的 `turnCompleted: false`(见
+   * `persistCodexPlanOnDone`):任务还活着,常驻面板不得按"全勾完"兜底退场。
+   */
+  turnFailed?: boolean;
 }
 
 export interface MessageRenderLatestTodoState {
@@ -501,6 +506,7 @@ export function findMessageTodoInsertions<TMessage extends MessageRenderSourceMe
               : {}),
           }
         : {}),
+      ...(messages[session.lastIndex]?.turnCompleted === false ? { turnFailed: true } : {}),
     });
   }
   return out;

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -465,7 +465,16 @@ export function findMessageTodoInsertions<TMessage extends MessageRenderSourceMe
       source === 'task'
       && Boolean(previousAllDone)
       && taskToolTargetsExistingTask(message, resultText, taskState);
-    const startsNewSession = !previous || (Boolean(previousAllDone) && !continuesCompletedTaskSession);
+    // 终态章是计划 session 的硬边界:成功收尾的 turn 常留着未勾完的步骤,只看
+    // allDone 会让下一 turn 的计划把上一轮吞成"续写"——历史里上一轮的计划卡
+    // 消失、面板复用旧 key。同 toolUseId 的活跃行被新事件清章(terminalPlanSnapshot
+    // 置 false)后不算边界,sealed-then-updated 的复亮行为不变。
+    const previousSealed =
+      Boolean(previous) && planRowSealOf(messages[previous!.lastIndex]).sealed;
+    const startsNewSession =
+      !previous
+      || previousSealed
+      || (Boolean(previousAllDone) && !continuesCompletedTaskSession);
     if (source === 'task' && startsNewSession) {
       taskState.clear();
     }
@@ -492,21 +501,21 @@ export function findMessageTodoInsertions<TMessage extends MessageRenderSourceMe
   const out = new Map<number, MessageRenderTodoInsertion>();
   for (const session of sessions) {
     const first = messages[session.firstIndex];
+    const lastRow = messages[session.lastIndex];
+    const seal = planRowSealOf(lastRow);
     out.set(session.lastIndex, {
       key: `${keyPrefix}-${sourceClientId(first)}`,
       todos: session.todos,
-      createdAt: messages[session.lastIndex]?.createdAt,
-      updatedAtMs: messages[session.lastIndex]?.planUpdatedAtMs,
+      createdAt: lastRow?.createdAt,
+      updatedAtMs: lastRow?.planUpdatedAtMs,
       source: session.source,
-      ...(messages[session.lastIndex]?.terminalPlanSnapshot === true
+      ...(seal.sealed
         ? {
             sealed: true,
-            ...(typeof messages[session.lastIndex]?.terminalPlanAtMs === 'number'
-              ? { sealedAtMs: messages[session.lastIndex].terminalPlanAtMs }
-              : {}),
+            ...(typeof seal.sealedAtMs === 'number' ? { sealedAtMs: seal.sealedAtMs } : {}),
           }
         : {}),
-      ...(messages[session.lastIndex]?.turnCompleted === false ? { turnFailed: true } : {}),
+      ...(planRowTurnFailed(lastRow) ? { turnFailed: true } : {}),
     });
   }
   return out;
@@ -1774,6 +1783,37 @@ function toolInputOf(message: MessageRenderSourceMessageLike): unknown {
   if (message.toolInput !== undefined) return message.toolInput;
   const content = readRecord(message.content);
   return content?.input;
+}
+
+/**
+ * host 的终态章可能在顶层字段(desktop live / hydrate 路径),也可能只在持久化
+ * content 里(mobile 直接渲染 main 广播的行,updateDbMessageContent 把章写进
+ * content)。session 边界与 insertion 的 sealed 判定都必须两处都认。
+ */
+function planRowSealOf(
+  message: MessageRenderSourceMessageLike | undefined,
+): { sealed: boolean; sealedAtMs?: number } {
+  if (!message) return { sealed: false };
+  const content = readRecord(message.content);
+  const sealed =
+    message.terminalPlanSnapshot === true ||
+    (message.terminalPlanSnapshot === undefined && content?.terminalPlanSnapshot === true);
+  if (!sealed) return { sealed: false };
+  const sealedAtMs =
+    typeof message.terminalPlanAtMs === 'number'
+      ? message.terminalPlanAtMs
+      : typeof content?.terminalPlanAtMs === 'number'
+        ? content.terminalPlanAtMs
+        : undefined;
+  return { sealed: true, ...(sealedAtMs !== undefined ? { sealedAtMs } : {}) };
+}
+
+/** 同 planRowSealOf:失败印记(turnCompleted:false)也认 content 里的持久化位置。 */
+function planRowTurnFailed(message: MessageRenderSourceMessageLike | undefined): boolean {
+  if (!message) return false;
+  if (message.turnCompleted === false) return true;
+  const content = readRecord(message.content);
+  return message.turnCompleted === undefined && content?.turnCompleted === false;
 }
 
 function toolUseIdOf(message: MessageRenderSourceMessageLike): string | undefined {

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -662,6 +662,30 @@ export function applyCodexPlanSnapshotOnDone<
   return { messages, changed: false, toolUseId: null };
 }
 
+/**
+ * Live-side twin of main's `persistCodexPlanOnTerminalError`: a Codex turn that
+ * dies on a terminal `error` never gets a `done`, so nothing seals its plan row
+ * and nothing stamps `turnCompleted:false` in memory. Stamp the latest unsealed
+ * plan row here so the pinned capsule sees the task as alive immediately, in
+ * the window before the durable stamp's row broadcast arrives. Step statuses
+ * are untouched; already-sealed or already-stamped rows are left alone.
+ */
+export function markCodexPlanTurnFailed<TMessage extends MessageRenderSourceMessageLike>(
+  messages: readonly TMessage[],
+): { messages: readonly TMessage[]; changed: boolean } {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.role !== 'tool_use' || toolNameOf(message) !== 'update_plan') continue;
+    if (message.terminalPlanSnapshot === true || message.turnCompleted === false) {
+      return { messages, changed: false };
+    }
+    const next = [...messages];
+    next[index] = { ...message, turnCompleted: false };
+    return { messages: next, changed: true };
+  }
+  return { messages, changed: false };
+}
+
 function samePlanSnapshot(left: unknown[], right: unknown[]): boolean {
   return JSON.stringify(left) === JSON.stringify(right);
 }

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -729,19 +729,28 @@ export function applyCodexPlanSnapshotOnDone<
  */
 export function markCodexPlanTurnFailed<TMessage extends MessageRenderSourceMessageLike>(
   messages: readonly TMessage[],
-): { messages: readonly TMessage[]; changed: boolean } {
+): { messages: readonly TMessage[]; changed: boolean; toolUseId: string | null } {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
     if (message.role === 'user' && message.delivery !== 'steer') break;
     if (message.role !== 'tool_use' || toolNameOf(message) !== 'update_plan') continue;
     if (planRowSealOf(message).sealed || planRowTurnFailed(message)) {
-      return { messages, changed: false };
+      return { messages, changed: false, toolUseId: null };
     }
     const next = [...messages];
-    next[index] = { ...message, turnCompleted: false };
-    return { messages: next, changed: true };
+    // 印记同时落 content(与 applyCodexPlanSnapshotOnDone 同口径):mobile 的
+    // live-plan 缓存只存 content 并整体覆盖 overlay 之后的行,只写顶层的话
+    // 缓存一盖就把 main 广播的落库印记抹掉。
+    const content = readRecord(message.content);
+    next[index] = {
+      ...message,
+      turnCompleted: false,
+      ...(content ? { content: { ...content, turnCompleted: false } } : {}),
+    };
+    // toolUseId 回给调用方:mobile 按它把同一份 content 写回 live-plan 缓存。
+    return { messages: next, changed: true, toolUseId: toolUseIdOf(message) ?? null };
   }
-  return { messages, changed: false };
+  return { messages, changed: false, toolUseId: null };
 }
 
 function samePlanSnapshot(left: unknown[], right: unknown[]): boolean {

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -708,6 +708,19 @@ export function applyCodexPlanSnapshotOnDone<
 }
 
 /**
+ * 同轮 steer 插话判定。**两套字段都认**:落库位置是 `agentMeta.delivery`
+ * (mobile 与 main 侧的原始行保持这个形状),desktop 渲染层把它投影成顶层
+ * `delivery` 后丢弃原 meta。只看顶层会让 mobile / main 的所有权回扫在插话行上
+ * 提前收手,全勾完的失败计划先按旧数据退场、等 main 的异步印记广播才复活
+ * (断连时要等到重新加载,review P2)。
+ */
+function isSteerUserRow(message: MessageRenderSourceMessageLike): boolean {
+  if (message.delivery === 'steer') return true;
+  const meta = (message as { agentMeta?: { delivery?: unknown } | null }).agentMeta;
+  return meta?.delivery === 'steer';
+}
+
+/**
  * Live-side twin of main's `persistCodexPlanOnTerminalError`: a Codex turn that
  * dies on a terminal `error` never gets a `done`, so nothing seals its plan row
  * and nothing stamps `turnCompleted:false` in memory. Stamp the current turn's
@@ -732,7 +745,7 @@ export function markCodexPlanTurnFailed<TMessage extends MessageRenderSourceMess
 ): { messages: readonly TMessage[]; changed: boolean; toolUseId: string | null } {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (message.role === 'user' && message.delivery !== 'steer') break;
+    if (message.role === 'user' && !isSteerUserRow(message)) break;
     if (message.role !== 'tool_use' || toolNameOf(message) !== 'update_plan') continue;
     if (planRowSealOf(message).sealed || planRowTurnFailed(message)) {
       return { messages, changed: false, toolUseId: null };

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -28,6 +28,11 @@ export interface MessageRenderSourceMessageLike {
   terminalPlanSnapshot?: boolean;
   /** Host time when the successful turn seal was applied. */
   terminalPlanAtMs?: number;
+  /**
+   * user 消息投递方式:'steer' 是运行中插话,不开启新 turn——失败印记回扫的
+   * turn 所有权边界只认普通('turn')user 消息。
+   */
+  delivery?: string | null;
 }
 
 export type MessageRenderNormalizedMessageKind =
@@ -655,9 +660,11 @@ export function applyCodexPlanSnapshotOnDone<
       return { messages, changed: false, toolUseId };
     }
 
-    const next = [...messages];
-    next[index] = {
-      ...message,
+    // 生命周期印记(章 / 失败标记)同时写进顶层与 content:mobile 的 live-plan
+    // 缓存只保存 content(rememberLivePlanContent),overlay 会用这份缓存覆盖
+    // main 广播里已持久化的带章 content——章只在顶层的话,overlay 一盖计划就
+    // 永远"未盖章",下一 turn 的计划会把上一轮吞进同一 session。
+    const lifecycleStamp = {
       ...(sealsTurn
         ? {
             terminalPlanSnapshot: true,
@@ -667,6 +674,11 @@ export function applyCodexPlanSnapshotOnDone<
           }
         : {}),
       ...(failChanged ? { turnCompleted: false } : {}),
+    };
+    const next = [...messages];
+    next[index] = {
+      ...message,
+      ...lifecycleStamp,
       ...(typeof planUpdatedAtMs === 'number' && Number.isFinite(planUpdatedAtMs)
         ? { planUpdatedAtMs }
         : {}),
@@ -674,7 +686,7 @@ export function applyCodexPlanSnapshotOnDone<
         ? { toolInput: { ...input, plan: nextPlan } }
         : {}),
       ...(content
-        ? { content: { ...content, input: { ...input, plan: nextPlan } } }
+        ? { content: { ...content, input: { ...input, plan: nextPlan }, ...lifecycleStamp } }
         : {}),
     };
     return { messages: next, changed: true, toolUseId };
@@ -691,11 +703,14 @@ export function applyCodexPlanSnapshotOnDone<
  * are untouched; already-sealed or already-stamped rows are left alone.
  *
  * Ownership boundary: only rows inside the failing turn's segment — after the
- * latest user message — may be stamped. Codex plan rows are per-turn
- * (`plan:<turnId>` is created within its own turn), so the scan stops cold at
- * the first user row. A failed turn that never emitted `update_plan` stamps
- * nothing; reaching past the boundary would resurrect an unrelated historical
- * plan (pre-seal-era all-done rows retire via the legacy fallback, and a stray
+ * latest turn-starting user message — may be stamped. Codex plan rows are
+ * per-turn (`plan:<turnId>` is created within its own turn), so the scan stops
+ * cold at the first user row that started a turn. A mid-turn steer interjection
+ * (`delivery: 'steer'`) does NOT start a new turn — the vendor turn keeps
+ * running and its plan row stays owned by the same turn — so steer rows do not
+ * end the scan. A failed turn that never emitted `update_plan` stamps nothing;
+ * reaching past the boundary would resurrect an unrelated historical plan
+ * (pre-seal-era all-done rows retire via the legacy fallback, and a stray
  * failure stamp would flip them back to "alive" with no durable write to
  * correct it — main's stamper correctly no-ops in that case).
  */
@@ -704,9 +719,9 @@ export function markCodexPlanTurnFailed<TMessage extends MessageRenderSourceMess
 ): { messages: readonly TMessage[]; changed: boolean } {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
-    if (message.role === 'user') break;
+    if (message.role === 'user' && message.delivery !== 'steer') break;
     if (message.role !== 'tool_use' || toolNameOf(message) !== 'update_plan') continue;
-    if (message.terminalPlanSnapshot === true || message.turnCompleted === false) {
+    if (planRowSealOf(message).sealed || planRowTurnFailed(message)) {
       return { messages, changed: false };
     }
     const next = [...messages];

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -665,16 +665,26 @@ export function applyCodexPlanSnapshotOnDone<
 /**
  * Live-side twin of main's `persistCodexPlanOnTerminalError`: a Codex turn that
  * dies on a terminal `error` never gets a `done`, so nothing seals its plan row
- * and nothing stamps `turnCompleted:false` in memory. Stamp the latest unsealed
+ * and nothing stamps `turnCompleted:false` in memory. Stamp the current turn's
  * plan row here so the pinned capsule sees the task as alive immediately, in
  * the window before the durable stamp's row broadcast arrives. Step statuses
  * are untouched; already-sealed or already-stamped rows are left alone.
+ *
+ * Ownership boundary: only rows inside the failing turn's segment — after the
+ * latest user message — may be stamped. Codex plan rows are per-turn
+ * (`plan:<turnId>` is created within its own turn), so the scan stops cold at
+ * the first user row. A failed turn that never emitted `update_plan` stamps
+ * nothing; reaching past the boundary would resurrect an unrelated historical
+ * plan (pre-seal-era all-done rows retire via the legacy fallback, and a stray
+ * failure stamp would flip them back to "alive" with no durable write to
+ * correct it — main's stamper correctly no-ops in that case).
  */
 export function markCodexPlanTurnFailed<TMessage extends MessageRenderSourceMessageLike>(
   messages: readonly TMessage[],
 ): { messages: readonly TMessage[]; changed: boolean } {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index];
+    if (message.role === 'user') break;
     if (message.role !== 'tool_use' || toolNameOf(message) !== 'update_plan') continue;
     if (message.terminalPlanSnapshot === true || message.turnCompleted === false) {
       return { messages, changed: false };

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -597,7 +597,12 @@ export interface CodexPlanSnapshotApplyResult<
  *
  * Interrupted / failed turns, and any turn whose id does not match, seal
  * nothing: the task is still alive and the user is usually about to steer it,
- * so the plan must stay on screen.
+ * so the plan must stay on screen. A matching non-successful terminal `done`
+ * does stamp `turnCompleted:false` on its plan row, immediately in memory —
+ * main's durable stamp (`persistCodexPlanOnDone`) lands asynchronously after
+ * this event is broadcast, and without the in-memory twin an all-done
+ * interrupted plan would be retired by the legacy fallback the moment
+ * streaming ends, then flash back when the durable row arrives.
  */
 export function applyCodexPlanSnapshotOnDone<
   TMessage extends MessageRenderSourceMessageLike,
@@ -610,7 +615,10 @@ export function applyCodexPlanSnapshotOnDone<
 ): CodexPlanSnapshotApplyResult<TMessage> {
   const authoritativeSnapshot = Array.isArray(snapshot) ? snapshot : null;
   const sealsTurn = terminalStatus === 'completed' && Boolean(turnId);
-  if (!authoritativeSnapshot && !sealsTurn) {
+  // done 恒为终态:status 不是 completed(interrupted / failed)即失败终态。
+  const stampsFailed =
+    Boolean(turnId) && typeof terminalStatus === 'string' && terminalStatus !== 'completed';
+  if (!authoritativeSnapshot && !sealsTurn && !stampsFailed) {
     return { messages, changed: false, toolUseId: null };
   }
   const expectedToolUseId = turnId ? `plan:${turnId}` : null;
@@ -632,7 +640,9 @@ export function applyCodexPlanSnapshotOnDone<
     // Seal an already-sealed row again would be a no-op update that still
     // restarts the capsule's grace timer, so treat it as unchanged.
     const sealChanged = sealsTurn && message.terminalPlanSnapshot !== true;
-    if (!planChanged && !sealChanged) {
+    const failChanged =
+      stampsFailed && message.terminalPlanSnapshot !== true && message.turnCompleted !== false;
+    if (!planChanged && !sealChanged && !failChanged) {
       return { messages, changed: false, toolUseId };
     }
 
@@ -647,6 +657,7 @@ export function applyCodexPlanSnapshotOnDone<
               : {}),
           }
         : {}),
+      ...(failChanged ? { turnCompleted: false } : {}),
       ...(typeof planUpdatedAtMs === 'number' && Number.isFinite(planUpdatedAtMs)
         ? { planUpdatedAtMs }
         : {}),

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -633,14 +633,18 @@ export function applyCodexPlanSnapshotOnDone<
   // 'completed'(main 侧 isSuccessfulCodexDoneEventData 同序判定)。渲染端若
   // 只看 status 会先盖章退场,随后 main 持久化 turnCompleted:false 的 DB 行
   // 广播到达,计划复活——即时 UI 与落库分叉。
-  const sealsTurn = terminalStatus === 'completed' && cancelled !== true && Boolean(turnId);
-  // done 恒为终态:status 非 completed(interrupted / failed),或 cancelled 覆盖
-  // 了 completed,均为失败终态——后者只拦盖章不落失败印记的话,全勾完的取消
-  // 计划会被旧数据兜底即时隐藏,再被 main 的 turnCompleted:false 落库行复活。
-  const stampsFailed =
-    Boolean(turnId) &&
-    ((typeof terminalStatus === 'string' && terminalStatus !== 'completed') ||
-      (cancelled === true && terminalStatus === 'completed'));
+  // 成功判据与 main 的 isSuccessfulCodexDoneEventData 逐字同序:未取消 +
+  // raw.status === 'completed'。其余一切(status 为别的值、缺失、被 cancelled
+  // 覆盖)在归属明确的 turn 上都是失败终态。
+  //
+  // "缺失也算失败"很关键:main 对缺 status 的 done 同样写 turnCompleted:false,
+  // 若这里不落印记,渲染端会按旧数据兜底先退场,随后落库行带失败印记到达又把
+  // 计划判活 → 消失再闪回(review P2)。
+  const isSuccessfulTerminal = terminalStatus === 'completed' && cancelled !== true;
+  const sealsTurn = isSuccessfulTerminal && Boolean(turnId);
+  // terminalStatus === undefined = 调用方没在描述终态(仅套用权威快照的调用),
+  // 不落任何印记;null / 其它值都来自真实 done,按失败终态处理。
+  const stampsFailed = Boolean(turnId) && terminalStatus !== undefined && !isSuccessfulTerminal;
   if (!authoritativeSnapshot && !sealsTurn && !stampsFailed) {
     return { messages, changed: false, toolUseId: null };
   }

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -626,9 +626,14 @@ export function applyCodexPlanSnapshotOnDone<
   turnId?: string | null,
   terminalStatus?: unknown,
   planUpdatedAtMs?: number,
+  cancelled?: boolean,
 ): CodexPlanSnapshotApplyResult<TMessage> {
   const authoritativeSnapshot = Array.isArray(snapshot) ? snapshot : null;
-  const sealsTurn = terminalStatus === 'completed' && Boolean(turnId);
+  // 取消标记优先于 completed:done 可同时带 cancelled:true + raw.status
+  // 'completed'(main 侧 isSuccessfulCodexDoneEventData 同序判定)。渲染端若
+  // 只看 status 会先盖章退场,随后 main 持久化 turnCompleted:false 的 DB 行
+  // 广播到达,计划复活——即时 UI 与落库分叉。
+  const sealsTurn = terminalStatus === 'completed' && cancelled !== true && Boolean(turnId);
   // done 恒为终态:status 不是 completed(interrupted / failed)即失败终态。
   const stampsFailed =
     Boolean(turnId) && typeof terminalStatus === 'string' && terminalStatus !== 'completed';

--- a/packages/maker-shared/src/messageRender.ts
+++ b/packages/maker-shared/src/messageRender.ts
@@ -19,6 +19,15 @@ export interface MessageRenderSourceMessageLike {
   toolUseId?: string | null;
   /** Host-persisted SDK turn boundary on the final assistant or owning Codex plan row. */
   turnCompleted?: boolean;
+  /**
+   * Host sealed this Codex plan row because its owning turn ended successfully.
+   * The seal closes the plan's lifecycle only — step statuses stay exactly as the
+   * agent last reported them. Interrupted, failed, and auto-resumed turns never
+   * seal, so their plan stays open while the task itself is still alive.
+   */
+  terminalPlanSnapshot?: boolean;
+  /** Host time when the successful turn seal was applied. */
+  terminalPlanAtMs?: number;
 }
 
 export type MessageRenderNormalizedMessageKind =
@@ -193,6 +202,14 @@ export interface MessageRenderTodoInsertion {
   createdAt?: string;
   updatedAtMs?: number;
   source: MessageRenderTodoSource;
+  /**
+   * 这份计划所属的 turn 已被 host 判定为成功收尾(见
+   * `MessageRenderSourceMessageLike.terminalPlanSnapshot`)。常驻面板据此退场,
+   * 不看勾选状态;未盖章就一直挂着。
+   */
+  sealed?: boolean;
+  /** Persisted host time of the successful terminal seal. */
+  sealedAtMs?: number;
 }
 
 export interface MessageRenderLatestTodoState {
@@ -476,6 +493,14 @@ export function findMessageTodoInsertions<TMessage extends MessageRenderSourceMe
       createdAt: messages[session.lastIndex]?.createdAt,
       updatedAtMs: messages[session.lastIndex]?.planUpdatedAtMs,
       source: session.source,
+      ...(messages[session.lastIndex]?.terminalPlanSnapshot === true
+        ? {
+            sealed: true,
+            ...(typeof messages[session.lastIndex]?.terminalPlanAtMs === 'number'
+              ? { sealedAtMs: messages[session.lastIndex].terminalPlanAtMs }
+              : {}),
+          }
+        : {}),
     });
   }
   return out;
@@ -551,28 +576,23 @@ export interface CodexPlanSnapshotApplyResult<
 }
 
 /**
- * Resolve the plan payload that should survive a Codex turn terminal event.
- * A successful turn is authoritative even when Codex only returns its last
- * cached in-progress snapshot: every remaining item belongs to that finished
- * turn and must converge to completed. Other terminal states may only apply an
- * explicit snapshot; they must never infer completion from stale progress.
+ * Close out a Codex plan at its owning turn's terminal event.
+ *
+ * Two independent things happen here, and keeping them separate is the whole
+ * point:
+ *  - **Content**: an explicit `turn/plan/updated` snapshot carried by `done` is
+ *    applied verbatim. Nothing else ever rewrites a step. Codex leaves open
+ *    items on a successful turn routinely (its own prompt asks the model to tick
+ *    them, and the model complies most of the time — not always), and inventing
+ *    the missing ticks makes the transcript claim work that was never reported.
+ *  - **Lifecycle**: a successful, ownership-matched turn *seals* the row. The
+ *    seal is what retires the pinned capsule, so retiring no longer depends on
+ *    the agent having ticked every box.
+ *
+ * Interrupted / failed turns, and any turn whose id does not match, seal
+ * nothing: the task is still alive and the user is usually about to steer it,
+ * so the plan must stay on screen.
  */
-export function resolveCodexPlanSnapshotOnDone(
-  currentPlan: readonly unknown[],
-  snapshot: unknown,
-  inferCompletion: boolean,
-): unknown[] | null {
-  const authoritativeSnapshot = Array.isArray(snapshot) ? snapshot : null;
-  if (!authoritativeSnapshot && !inferCompletion) return null;
-
-  const snapshotSource = authoritativeSnapshot ?? currentPlan;
-  if (!inferCompletion) return authoritativeSnapshot;
-  return snapshotSource.map((item) => {
-    const record = readRecord(item);
-    return record ? { ...record, status: 'completed' } : item;
-  });
-}
-
 export function applyCodexPlanSnapshotOnDone<
   TMessage extends MessageRenderSourceMessageLike,
 >(
@@ -583,9 +603,8 @@ export function applyCodexPlanSnapshotOnDone<
   planUpdatedAtMs?: number,
 ): CodexPlanSnapshotApplyResult<TMessage> {
   const authoritativeSnapshot = Array.isArray(snapshot) ? snapshot : null;
-  const hasAuthoritativeSnapshot = authoritativeSnapshot !== null;
-  const canInferCompletion = terminalStatus === 'completed' && Boolean(turnId);
-  if (!hasAuthoritativeSnapshot && !canInferCompletion) {
+  const sealsTurn = terminalStatus === 'completed' && Boolean(turnId);
+  if (!authoritativeSnapshot && !sealsTurn) {
     return { messages, changed: false, toolUseId: null };
   }
   const expectedToolUseId = turnId ? `plan:${turnId}` : null;
@@ -600,36 +619,36 @@ export function applyCodexPlanSnapshotOnDone<
 
     const input = readRecord(toolInputOf(message));
     if (!Array.isArray(input?.plan)) continue;
-    // maker-core attaches the latest cached turn/plan/updated snapshot to done.
-    // When Codex omits its final plan update, that array still contains open
-    // items and is in progress rather than a terminal snapshot. Converge that
-    // cached progress (or the persisted row when no snapshot exists) only for a
-    // matching, explicitly successful turn. Without a turn id, an array can
-    // still be applied as supplied but completion must never be inferred for an
-    // unrelated last plan row.
-    const nextSnapshot = resolveCodexPlanSnapshotOnDone(
-      input.plan,
-      authoritativeSnapshot,
-      canInferCompletion,
-    );
-    if (!nextSnapshot) {
-      return { messages, changed: false, toolUseId: null };
-    }
-    if (samePlanSnapshot(input.plan, nextSnapshot)) {
+
+    const nextPlan = authoritativeSnapshot ?? input.plan;
+    const planChanged =
+      authoritativeSnapshot !== null && !samePlanSnapshot(input.plan, authoritativeSnapshot);
+    // Seal an already-sealed row again would be a no-op update that still
+    // restarts the capsule's grace timer, so treat it as unchanged.
+    const sealChanged = sealsTurn && message.terminalPlanSnapshot !== true;
+    if (!planChanged && !sealChanged) {
       return { messages, changed: false, toolUseId };
     }
 
     const next = [...messages];
     next[index] = {
       ...message,
+      ...(sealsTurn
+        ? {
+            terminalPlanSnapshot: true,
+            ...(typeof planUpdatedAtMs === 'number' && Number.isFinite(planUpdatedAtMs)
+              ? { terminalPlanAtMs: planUpdatedAtMs }
+              : {}),
+          }
+        : {}),
       ...(typeof planUpdatedAtMs === 'number' && Number.isFinite(planUpdatedAtMs)
         ? { planUpdatedAtMs }
         : {}),
       ...(message.toolInput !== undefined
-        ? { toolInput: { ...input, plan: nextSnapshot } }
+        ? { toolInput: { ...input, plan: nextPlan } }
         : {}),
       ...(content
-        ? { content: { ...content, input: { ...input, plan: nextSnapshot } } }
+        ? { content: { ...content, input: { ...input, plan: nextPlan } } }
         : {}),
     };
     return { messages: next, changed: true, toolUseId };


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex 任务干完后,输入框上方的计划胶囊经常永远不消失。根因不是计时器,而是退场条件本身:胶囊要求"步骤全部勾完"才退场,但 agent 成功收尾时留着未勾步骤是常态(线上真实 rollout 抽样约 22% 的成功 turn 带未完成项收尾;Codex 官方 TUI 同样如实保留、从不补勾)。等一个经常不会来的条件,泡泡就永远挂着。

本 PR 把退场条件从"步骤全勾完"换成"host 的终态章",并把先前补丁(#1842)里"成功收尾就把未完成步骤强行改写成 completed 落库"的伪造逻辑整个删除:

- main 在 Codex turn 成功收尾时给计划行盖 `terminalPlanSnapshot` 章,并记录盖章时刻 `terminalPlanAtMs`。2 秒退场缓冲从真正收尾算起——不带独立时刻的话,长任务收尾时"计划创建时间+2 秒"早已过期,泡泡会秒消失(第一轮真机验证抓到的回归,已有专门测试覆盖);
- 删除 `resolveCodexPlanSnapshotOnDone`:不再把 agent 未报告完成的步骤改写成 completed,历史与手机端(共用同一函数)如实显示实际进度;
- 胶囊只认章:盖章 → 停 2 秒 → 退场;章落库,重开任务/新窗口/重载不复活;新计划更新清章后泡泡重新出现;
- 中断、失败、断线自动续跑不盖章(`!isContinuationBoundary` 守卫已有),计划保持可见——任务还活着,用户正要接着指挥;
- 旧数据无章,按"全勾完"兜底,行为不变。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:完成态计划卡残留(#1842 的后续;该 PR 只解决了部分路径且以篡改步骤状态为代价)
- 本 PR 包含:Codex `update_plan` 计划的终态盖章、胶囊退场逻辑、伪造补全逻辑删除
- 明确不包含:Claude TodoWrite/Task* 计划的同款盖章(缺口仍在,后续 PR);计划归属/跨轮串号修复;"下一轮开始对账旧清单"机制;done/error 双丢与退出竞态的收口
- 用户可见变化:① Codex 任务成功收尾后计划胶囊约 2 秒内自动消失,不再依赖 agent 勾完全部步骤;重开会话不复活。② 历史消息与手机端的计划卡如实显示收尾时的真实勾选状态,不再显示被系统补出来的"全部完成"
- 是否存在 breaking change:无

### UI 变化

- 引用的设计规范:不涉及:未改任何视觉、布局或文案,仅改变既有计划胶囊的隐藏时机判定逻辑(何时算任务收尾),无新增或修改任何视觉呈现。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run PinnedPlanPanel        → 16 passed(新增 6 条:含"计划先显示数秒后才盖章"时间错位复现,修前红)
pnpm --filter @cindy/maker-shared exec vitest run planCompletion messageRender → 72 passed(原"强制补勾"断言改为"盖章不改数据")
pnpm --filter desktop exec vitest run messagePersistBroadcaster → 63 passed(新增"成功收尾无最终快照仅盖章"复现)
pnpm --filter desktop / @cindy/maker-shared / mobile typecheck → 全过
pnpm test:unit → 除 packages/maker-core 一条 Pi 图片集成测试(PI_IMAGE_INPUT_UNSUPPORTED)外全过;
  该失败在干净 checkout(stash 本改动后)同样复现,与本改动无关
```

### 手工验证

macOS,`--isolated=plan-seal` 沙箱,Codex + codex/gpt-5.6-sol,真实任务:"列 4 步计划只执行第 1 步,禁止把未执行步骤标 completed"。

- 计划出现即显示胶囊,执行期间保持可见;收尾后约 2 秒自动消失;重开会话不复活;
- 数据库指纹核验:计划行步骤保持 `inProgress/pending/pending/pending` 原样(未被篡改),同时带 `terminalPlanSnapshot: true` 与 `terminalPlanAtMs`(仅新代码可写),盖章时刻 = 收尾时刻而非计划创建时刻;
- 对照:同场景在改动前代码上胶囊永不消失(即本 bug)。

### 未执行的验证

- 手机端真机回归未执行(改动对 mobile 的影响仅为:历史计划卡不再显示被补全的假完成态;共享函数测试已覆盖)。远程/手机适配结论:本 PR 不新增 IPC channel 或推送事件,复用既有 messages 行广播,无需 allowlist 登记。
- 中断/断线续跑场景做了代码路径与单测验证(不盖章即不退场),未做真机断网演练。

## 风险

### 风险分类

- [x] 其他:用户可见行为变化(见下)

### 影响与回滚

- 行为变化 ①:此前"成功但未勾完"的计划会被系统默默标成全完成;现在如实显示未完成。属于纠正数据伪造,但用户可能注意到历史卡片不再全绿。
- 行为变化 ②:胶囊退场从"勾完驱动"变为"收尾驱动"。中断/失败的计划按设计保留在屏(任务未死),与此前#1842 后的行为一致。
- 回滚:revert 本 commit 即可,无 migration、无协议变更、无数据不可逆写入(章字段对旧版本代码是未知 JSON 字段,向后兼容)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
