### PR TITLE
fix(desktop): 设置页协同与 Agent 资源占用对齐房规卡片版式

### DIFF
--- a/apps/desktop/src/renderer/components/settings/AgentResourceSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AgentResourceSection.tsx
@@ -23,6 +23,36 @@ type PresetId = 'full' | 'balanced' | 'background';
 const PRIORITY_OPTIONS: AgentResourceProcessPriority[] = ['normal', 'low', 'lowest'];
 const MAX_CONCURRENT_CAP = 64;
 
+/** 档位提示的全部取值(含 activePreset 为 null 时的 custom);顺序即 DOM 叠放顺序。 */
+const PRESET_HINT_KEYS = ['full', 'balanced', 'background', 'custom'] as const;
+
+/** 带分割线的多行卡片:卡片自身不留内边距,由每行 `px-4 py-4` 承担(房规见 SubagentModelSection 卡 2)。 */
+const CARD_CLASS = cn(
+  'flex flex-col rounded-xl',
+  'bg-[var(--settings-theme-card-bg)]',
+  'border border-[var(--settings-theme-card-border)]',
+);
+/** 卡片内一行:左侧标签 + 说明,右侧控件相对整块垂直居中(设置页各 section 通用版式)。 */
+const ROW_CLASS = 'flex items-center justify-between gap-3 px-4 py-4';
+const ROW_LABEL_CLASS = 'text-13 font-medium text-[var(--settings-section-sublabel)]';
+const ROW_HINT_CLASS =
+  'text-12 leading-[1.4] text-[var(--settings-section-sublabel)] opacity-70';
+/** 行间分割线:左右缩进与行内边距对齐。 */
+const DIVIDER_CLASS = 'mx-4 h-px bg-[var(--settings-theme-card-border)]';
+
+/**
+ * 数字输入框的框体规格,与设置页统一输入框 `SettingsTextInput` 的 md 档一致
+ * (DESIGN.md §4-5:单行输入走药丸圆角;fill 必须是 `--surface-elevated` —— 设置卡片
+ * 本身是 ivory,ivory 输入压在 ivory 卡上会与背景同色、填充对比度归零)。
+ * 上下调节沿用浏览器原生步进器,不自绘 —— 设置页的控件样式统一是独立议题,留待整体收敛。
+ */
+const NUMBER_INPUT_CLASS = cn(
+  'h-9 w-24 shrink-0 rounded-full px-4 text-13 outline-none transition-colors',
+  'bg-[var(--surface-elevated)] text-[var(--settings-input-text)]',
+  'border border-[var(--settings-input-border)] focus:border-[var(--settings-input-border-focus)]',
+  'focus:ring-2 focus:ring-[var(--focus-ring)]',
+);
+
 /**
  * 均衡档并发值:本机核数的一半,至少 2(与 main 侧 toolchain-thread-cap 的口径一致),
  * 且不超过 IPC 校验上限 —— 超高核数工作站(>128 核)算出的值若越过 cap,首个 IPC 写
@@ -173,8 +203,10 @@ export function AgentResourceSection() {
   if (!settings) return null;
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-3">
+    <div className="flex flex-col gap-[14px]">
+      {/* min-h 锁住标题行高度:DefaultOverrideControls 未自定义时返回 null,若不预留
+          高度,首次改动让「已自定义」+ 恢复按钮(30px)出现会把整段往下顶,列表抖一下。 */}
+      <div className="flex min-h-[30px] items-center justify-between gap-3">
         <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.agentResource.title')}
         </h2>
@@ -196,134 +228,165 @@ export function AgentResourceSection() {
         />
       </div>
 
-      <p className="text-11 leading-relaxed text-[var(--text-tertiary)]">
+      <p className="text-12 leading-[1.45] text-[var(--settings-section-desc)]">
         {t('settings.agentResource.description')}
       </p>
 
-      {/* 预设条:三个字段的组合快捷方式;都不匹配 = 自定义,均不高亮 */}
-      <div className="flex flex-col gap-1.5">
-        <span className="text-12 font-medium text-[var(--text-primary)]">
-          {t('settings.agentResource.preset')}
-        </span>
-        <div
-          role="radiogroup"
-          aria-label={t('settings.agentResource.preset')}
-          className="flex w-fit shrink-0 items-center gap-0.5 rounded-full border border-[var(--settings-theme-card-border)] p-0.5"
-        >
-          {(['full', 'balanced', 'background'] as const).map((id) => {
-            const active = activePreset === id;
-            return (
-              <button
-                key={id}
-                type="button"
-                role="radio"
-                aria-checked={active}
-                disabled={applyingPreset}
-                onClick={() => void applyPreset(id)}
-                className={cn(
-                  'rounded-full px-2.5 py-1 text-xs transition-colors',
-                  active
-                    ? 'bg-[var(--chat-input-chip-bg)] font-medium text-[var(--msg-assistant-text)]'
-                    : 'text-[var(--settings-section-sublabel)] hover:bg-sidebar-item-hover',
-                  applyingPreset && 'opacity-60',
-                )}
-              >
-                {t(`settings.agentResource.presets.${id}`)}
-              </button>
-            );
-          })}
+      <div className={CARD_CLASS}>
+        {/* 预设条:三个字段的组合快捷方式;都不匹配 = 自定义,均不高亮。
+            这行提示随档位变化,四语长度差异极大(en full 162 字符 vs custom 53),会在不同
+            行数间跳变、把下方各行顶动。防抖靠下面的 grid 叠放 —— 四段提示占同一格,容器
+            高度恒等于四者中最高的一段,与窗口宽度和语言都无关(固定 min-height 只是下限,
+            长文案照样会溢出撑高)。因为与宽度无关,提示就留在左列、不必独占整行,分段控件
+            才能像同卡其它行一样相对「标签 + 说明」整块垂直居中。 */}
+        <div className={ROW_CLASS}>
+          <div className="flex min-w-0 flex-col gap-1">
+            <p className={ROW_LABEL_CLASS} style={{ letterSpacing: '0.12px' }}>
+              {t('settings.agentResource.preset')}
+            </p>
+            {/* 四段提示全部常挂载、叠在同一个 grid 格里,只有当前档位那段可见(其余
+                visibility:hidden —— 不进无障碍树、不可聚焦,但仍参与撑高)。 */}
+            <div className="grid">
+              {PRESET_HINT_KEYS.map((key) => {
+                const shown = (activePreset ?? 'custom') === key;
+                return (
+                  <p
+                    key={key}
+                    data-preset-hint={key}
+                    aria-hidden={!shown || undefined}
+                    className={cn(
+                      ROW_HINT_CLASS,
+                      'col-start-1 row-start-1',
+                      !shown && 'invisible',
+                    )}
+                  >
+                    {t(`settings.agentResource.presetHints.${key}`)}
+                  </p>
+                );
+              })}
+            </div>
+          </div>
+          <div
+            role="radiogroup"
+            aria-label={t('settings.agentResource.preset')}
+            className="flex w-fit shrink-0 items-center gap-0.5 rounded-full border border-[var(--settings-theme-card-border)] p-0.5"
+          >
+            {(['full', 'balanced', 'background'] as const).map((id) => {
+              const active = activePreset === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  disabled={applyingPreset}
+                  onClick={() => void applyPreset(id)}
+                  className={cn(
+                    'rounded-full px-2.5 py-1 text-xs transition-colors',
+                    active
+                      ? 'bg-[var(--chat-input-chip-bg)] font-medium text-[var(--msg-assistant-text)]'
+                      : 'text-[var(--settings-section-sublabel)] hover:bg-sidebar-item-hover',
+                    applyingPreset && 'opacity-60',
+                  )}
+                >
+                  {t(`settings.agentResource.presets.${id}`)}
+                </button>
+              );
+            })}
+          </div>
         </div>
-        <span className="text-11 text-[var(--text-tertiary)]">
-          {activePreset
-            ? t(`settings.agentResource.presetHints.${activePreset}`)
-            : t('settings.agentResource.presetHints.custom')}
-        </span>
-      </div>
 
-      {/* 并发命令上限 */}
-      <label className="flex flex-col gap-1.5">
-        <span className="text-12 font-medium text-[var(--text-primary)]">
-          {t('settings.agentResource.maxConcurrent')}
-        </span>
-        <span className="text-11 text-[var(--text-tertiary)]">
-          {t('settings.agentResource.maxConcurrentHint')}
-        </span>
-        <input
-          type="number"
-          min={0}
-          max={MAX_CONCURRENT_CAP}
-          disabled={applyingPreset}
-          value={maxDraft ?? String(settings.maxConcurrentCommands)}
-          onChange={(e) => setMaxDraft(e.target.value)}
-          onBlur={() => {
-            // 唯一提交点(DESIGN §14.3:Settings 单行编辑器 Enter 不得提交):
-            // 仅 0..64 的整数且与当前值不同才写盘;非法/未变草稿作废,
-            // 回显权威值(clamp 会绕过 main 侧硬拒语义,一律拒绝不改写)
-            const text = (maxDraft ?? '').trim();
-            setMaxDraft(null);
-            if (!/^\d+$/.test(text)) return;
-            const raw = Number(text);
-            if (raw > MAX_CONCURRENT_CAP) return;
-            if (raw === settings.maxConcurrentCommands) return;
-            persist('maxConcurrentCommands', raw);
-          }}
-          className="mt-0.5 w-24 rounded-full border border-[var(--border-default)] bg-[var(--surface-elevated)] px-3 py-1.5 text-13 text-[var(--settings-input-text)] outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring-soft)]"
-        />
-      </label>
+        <div className={DIVIDER_CLASS} />
 
-      {/* 进程优先级 */}
-      <div className="flex flex-col gap-1.5">
-        <span className="text-12 font-medium text-[var(--text-primary)]">
-          {t('settings.agentResource.priority')}
-        </span>
-        <span className="text-11 text-[var(--text-tertiary)]">
-          {t('settings.agentResource.priorityHint')}
-        </span>
-        <div
-          role="radiogroup"
-          aria-label={t('settings.agentResource.priority')}
-          className="mt-0.5 flex w-fit shrink-0 items-center gap-0.5 rounded-full border border-[var(--settings-theme-card-border)] p-0.5"
-        >
-          {PRIORITY_OPTIONS.map((tier) => {
-            const active = settings.processPriority === tier;
-            return (
-              <button
-                key={tier}
-                type="button"
-                role="radio"
-                aria-checked={active}
-                disabled={applyingPreset}
-                onClick={() => persist('processPriority', tier)}
-                className={cn(
-                  'rounded-full px-2.5 py-1 text-xs transition-colors',
-                  active
-                    ? 'bg-[var(--chat-input-chip-bg)] font-medium text-[var(--msg-assistant-text)]'
-                    : 'text-[var(--settings-section-sublabel)] hover:bg-sidebar-item-hover',
-                )}
-              >
-                {t(`settings.agentResource.priorityOptions.${tier}`)}
-              </button>
-            );
-          })}
-        </div>
-      </div>
-
-      {/* 工具链限核 */}
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex flex-col gap-1.5">
-          <span className="text-12 font-medium text-[var(--text-primary)]">
-            {t('settings.agentResource.capThreads')}
+        {/* 并发命令上限 */}
+        <label className={ROW_CLASS}>
+          <span className="flex min-w-0 flex-col gap-1">
+            <span className={ROW_LABEL_CLASS} style={{ letterSpacing: '0.12px' }}>
+              {t('settings.agentResource.maxConcurrent')}
+            </span>
+            <span className={ROW_HINT_CLASS}>
+              {t('settings.agentResource.maxConcurrentHint')}
+            </span>
           </span>
-          <span className="text-11 text-[var(--text-tertiary)]">
-            {t('settings.agentResource.capThreadsHint')}
-          </span>
+          <input
+            type="number"
+            min={0}
+            max={MAX_CONCURRENT_CAP}
+            disabled={applyingPreset}
+            value={maxDraft ?? String(settings.maxConcurrentCommands)}
+            onChange={(e) => setMaxDraft(e.target.value)}
+            onBlur={() => {
+              // 唯一提交点(DESIGN §14.3:Settings 单行编辑器 Enter 不得提交):
+              // 仅 0..64 的整数且与当前值不同才写盘;非法/未变草稿作废,
+              // 回显权威值(clamp 会绕过 main 侧硬拒语义,一律拒绝不改写)
+              const text = (maxDraft ?? '').trim();
+              setMaxDraft(null);
+              if (!/^\d+$/.test(text)) return;
+              const raw = Number(text);
+              if (raw > MAX_CONCURRENT_CAP) return;
+              if (raw === settings.maxConcurrentCommands) return;
+              persist('maxConcurrentCommands', raw);
+            }}
+            className={NUMBER_INPUT_CLASS}
+          />
+        </label>
+
+        <div className={DIVIDER_CLASS} />
+
+        {/* 进程优先级 */}
+        <div className={ROW_CLASS}>
+          <div className="flex min-w-0 flex-col gap-1">
+            <p className={ROW_LABEL_CLASS} style={{ letterSpacing: '0.12px' }}>
+              {t('settings.agentResource.priority')}
+            </p>
+            <p className={ROW_HINT_CLASS}>{t('settings.agentResource.priorityHint')}</p>
+          </div>
+          <div
+            role="radiogroup"
+            aria-label={t('settings.agentResource.priority')}
+            className="flex w-fit shrink-0 items-center gap-0.5 rounded-full border border-[var(--settings-theme-card-border)] p-0.5"
+          >
+            {PRIORITY_OPTIONS.map((tier) => {
+              const active = settings.processPriority === tier;
+              return (
+                <button
+                  key={tier}
+                  type="button"
+                  role="radio"
+                  aria-checked={active}
+                  disabled={applyingPreset}
+                  onClick={() => persist('processPriority', tier)}
+                  className={cn(
+                    'rounded-full px-2.5 py-1 text-xs transition-colors',
+                    active
+                      ? 'bg-[var(--chat-input-chip-bg)] font-medium text-[var(--msg-assistant-text)]'
+                      : 'text-[var(--settings-section-sublabel)] hover:bg-sidebar-item-hover',
+                  )}
+                >
+                  {t(`settings.agentResource.priorityOptions.${tier}`)}
+                </button>
+              );
+            })}
+          </div>
         </div>
-        <Switch
-          checked={settings.capToolchainThreads}
-          disabled={applyingPreset}
-          onCheckedChange={(next) => persist('capToolchainThreads', next)}
-          aria-label={t('settings.agentResource.capThreads')}
-        />
+
+        <div className={DIVIDER_CLASS} />
+
+        {/* 工具链限核 */}
+        <div className={ROW_CLASS}>
+          <div className="flex min-w-0 flex-col gap-1">
+            <p className={ROW_LABEL_CLASS} style={{ letterSpacing: '0.12px' }}>
+              {t('settings.agentResource.capThreads')}
+            </p>
+            <p className={ROW_HINT_CLASS}>{t('settings.agentResource.capThreadsHint')}</p>
+          </div>
+          <Switch
+            checked={settings.capToolchainThreads}
+            disabled={applyingPreset}
+            onCheckedChange={(next) => persist('capToolchainThreads', next)}
+            aria-label={t('settings.agentResource.capThreads')}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/components/settings/AppearanceSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AppearanceSection.tsx
@@ -813,7 +813,7 @@ export function AppearanceSection() {
         <div
           role="radiogroup"
           aria-label={t('settings.appearance.sidebarCardMode.aria')}
-          className="flex shrink-0 items-center gap-0.5 rounded-lg border border-[var(--settings-theme-card-border)] p-0.5"
+          className="flex shrink-0 items-center gap-0.5 rounded-full border border-[var(--settings-theme-card-border)] p-0.5"
         >
           {([
             { value: 'text', labelKey: 'ccAgent.sidebar.viewStyleList' },
@@ -827,7 +827,7 @@ export function AppearanceSection() {
               aria-checked={sidebarViewMode === opt.value}
               onClick={() => setSidebarViewMode(opt.value)}
               className={cn(
-                'rounded-md px-2.5 py-1 text-xs transition-colors',
+                'rounded-full px-2.5 py-1 text-xs transition-colors',
                 sidebarViewMode === opt.value
                   ? 'bg-[var(--chat-input-chip-bg)] font-medium text-[var(--msg-assistant-text)]'
                   : 'text-[var(--settings-section-sublabel)] hover:bg-sidebar-item-hover',

--- a/apps/desktop/src/renderer/components/settings/CollaborationSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/CollaborationSection.tsx
@@ -4,8 +4,36 @@
 
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
 import { DefaultOverrideControls } from './DefaultOverrideControls';
+
+/** 带分割线的多行卡片:卡片自身不留内边距,由每行 `px-4 py-4` 承担(房规见 SubagentModelSection 卡 2)。 */
+const CARD_CLASS = cn(
+  'flex flex-col rounded-xl',
+  'bg-[var(--settings-theme-card-bg)]',
+  'border border-[var(--settings-theme-card-border)]',
+);
+/** 卡片内一行:左侧标签 + 说明,右侧控件相对整块垂直居中。 */
+const ROW_CLASS = 'flex items-center justify-between gap-3 px-4 py-4';
+const ROW_LABEL_CLASS = 'text-13 font-medium text-[var(--settings-section-sublabel)]';
+const ROW_HINT_CLASS =
+  'text-12 leading-[1.4] text-[var(--settings-section-sublabel)] opacity-70';
+/** 行间分割线:左右缩进与行内边距对齐。 */
+const DIVIDER_CLASS = 'mx-4 h-px bg-[var(--settings-theme-card-border)]';
+
+/**
+ * 数字输入框的框体规格,与设置页统一输入框 `SettingsTextInput` 的 md 档一致
+ * (DESIGN.md §4-5:单行输入走药丸圆角;fill 必须是 `--surface-elevated` —— 设置卡片
+ * 本身是 ivory,ivory 输入压在 ivory 卡上会与背景同色、填充对比度归零)。
+ * 上下调节沿用浏览器原生步进器,不自绘 —— 设置页的控件样式统一是独立议题,留待整体收敛。
+ */
+const NUMBER_INPUT_CLASS = cn(
+  'h-9 w-24 shrink-0 rounded-full px-4 text-13 outline-none transition-colors',
+  'bg-[var(--surface-elevated)] text-[var(--settings-input-text)]',
+  'border border-[var(--settings-input-border)] focus:border-[var(--settings-input-border-focus)]',
+  'focus:ring-2 focus:ring-[var(--focus-ring)]',
+);
 
 interface CollaborationSettings {
   workerSoftLimit: number;
@@ -52,8 +80,10 @@ export function CollaborationSection() {
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex items-center justify-between gap-3">
+    <div className="flex flex-col gap-[14px]">
+      {/* min-h 锁住标题行高度:DefaultOverrideControls 未自定义时返回 null,若不预留
+          高度,首次改动让「已自定义」+ 恢复按钮(30px)出现会把整段往下顶,列表抖一下。 */}
+      <div className="flex min-h-[30px] items-center justify-between gap-3">
         <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
           {t('settings.collaboration.title')}
         </h2>
@@ -73,69 +103,81 @@ export function CollaborationSection() {
         />
       </div>
 
-      {/* Worker Soft Limit */}
-      <label className="flex flex-col gap-1.5">
-        <span className="text-12 font-medium text-[var(--text-primary)]">
-          {t('settings.collaboration.workerSoftLimit')}
-        </span>
-        <span className="text-11 text-[var(--text-tertiary)]">
-          {t('settings.collaboration.workerSoftLimitHint')}
-        </span>
-        <input
-          type="number"
-          min={1}
-          max={settings.workerHardLimit}
-          value={settings.workerSoftLimit}
-          onChange={(e) => {
-            const v = Math.max(1, Math.min(settings.workerHardLimit, Number(e.target.value) || 1));
-            persist('workerSoftLimit', v);
-          }}
-          className="mt-0.5 w-20 rounded-lg border border-[var(--border-default)] bg-transparent px-3 py-1.5 text-13 text-[var(--settings-input-text)] outline-none"
-        />
-      </label>
+      <div className={CARD_CLASS}>
+        {/* Worker Soft Limit */}
+        <label className={ROW_CLASS}>
+          <span className="flex min-w-0 flex-col gap-1">
+            <span className={ROW_LABEL_CLASS} style={{ letterSpacing: '0.12px' }}>
+              {t('settings.collaboration.workerSoftLimit')}
+            </span>
+            <span className={ROW_HINT_CLASS}>
+              {t('settings.collaboration.workerSoftLimitHint')}
+            </span>
+          </span>
+          <input
+            type="number"
+            min={1}
+            max={settings.workerHardLimit}
+            value={settings.workerSoftLimit}
+            onChange={(e) => {
+              const v = Math.max(1, Math.min(settings.workerHardLimit, Number(e.target.value) || 1));
+              persist('workerSoftLimit', v);
+            }}
+            className={NUMBER_INPUT_CLASS}
+          />
+        </label>
 
-      {/* Worker Hard Limit */}
-      <label className="flex flex-col gap-1.5">
-        <span className="text-12 font-medium text-[var(--text-primary)]">
-          {t('settings.collaboration.workerHardLimit')}
-        </span>
-        <span className="text-11 text-[var(--text-tertiary)]">
-          {t('settings.collaboration.workerHardLimitHint')}
-        </span>
-        <input
-          type="number"
-          min={settings.workerSoftLimit}
-          max={20}
-          value={settings.workerHardLimit}
-          onChange={(e) => {
-            const v = Math.max(settings.workerSoftLimit, Math.min(20, Number(e.target.value) || settings.workerSoftLimit));
-            persist('workerHardLimit', v);
-          }}
-          className="mt-0.5 w-20 rounded-lg border border-[var(--border-default)] bg-transparent px-3 py-1.5 text-13 text-[var(--settings-input-text)] outline-none"
-        />
-      </label>
+        <div className={DIVIDER_CLASS} />
 
-      {/* Idle Release Minutes */}
-      <label className="flex flex-col gap-1.5">
-        <span className="text-12 font-medium text-[var(--text-primary)]">
-          {t('settings.collaboration.idleRelease')}
-        </span>
-        <span className="text-11 text-[var(--text-tertiary)]">
-          {t('settings.collaboration.idleReleaseHint')}
-        </span>
-        <input
-          type="number"
-          min={0}
-          max={120}
-          value={settings.workerIdleReleaseMinutes}
-          onChange={(e) => {
-            const raw = Number(e.target.value);
-            const v = Math.max(0, Math.min(120, Number.isFinite(raw) ? Math.trunc(raw) : 0));
-            persist('workerIdleReleaseMinutes', v);
-          }}
-          className="mt-0.5 w-20 rounded-lg border border-[var(--border-default)] bg-transparent px-3 py-1.5 text-13 text-[var(--settings-input-text)] outline-none"
-        />
-      </label>
+        {/* Worker Hard Limit */}
+        <label className={ROW_CLASS}>
+          <span className="flex min-w-0 flex-col gap-1">
+            <span className={ROW_LABEL_CLASS} style={{ letterSpacing: '0.12px' }}>
+              {t('settings.collaboration.workerHardLimit')}
+            </span>
+            <span className={ROW_HINT_CLASS}>
+              {t('settings.collaboration.workerHardLimitHint')}
+            </span>
+          </span>
+          <input
+            type="number"
+            min={settings.workerSoftLimit}
+            max={20}
+            value={settings.workerHardLimit}
+            onChange={(e) => {
+              const v = Math.max(settings.workerSoftLimit, Math.min(20, Number(e.target.value) || settings.workerSoftLimit));
+              persist('workerHardLimit', v);
+            }}
+            className={NUMBER_INPUT_CLASS}
+          />
+        </label>
+
+        <div className={DIVIDER_CLASS} />
+
+        {/* Idle Release Minutes */}
+        <label className={ROW_CLASS}>
+          <span className="flex min-w-0 flex-col gap-1">
+            <span className={ROW_LABEL_CLASS} style={{ letterSpacing: '0.12px' }}>
+              {t('settings.collaboration.idleRelease')}
+            </span>
+            <span className={ROW_HINT_CLASS}>
+              {t('settings.collaboration.idleReleaseHint')}
+            </span>
+          </span>
+          <input
+            type="number"
+            min={0}
+            max={120}
+            value={settings.workerIdleReleaseMinutes}
+            onChange={(e) => {
+              const raw = Number(e.target.value);
+              const v = Math.max(0, Math.min(120, Number.isFinite(raw) ? Math.trunc(raw) : 0));
+              persist('workerIdleReleaseMinutes', v);
+            }}
+            className={NUMBER_INPUT_CLASS}
+          />
+        </label>
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/settings/LinkOpenSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/LinkOpenSection.tsx
@@ -63,7 +63,7 @@ export function LinkOpenSection() {
         <div
           role="radiogroup"
           aria-label={t('settings.linkOpen.card.ariaLabel')}
-          className="flex w-fit shrink-0 items-center gap-0.5 rounded-lg border border-[var(--settings-theme-card-border)] p-0.5"
+          className="flex w-fit shrink-0 items-center gap-0.5 rounded-full border border-[var(--settings-theme-card-border)] p-0.5"
         >
           {OPTIONS.map((opt) => {
             const active = preference === opt.value;
@@ -75,7 +75,7 @@ export function LinkOpenSection() {
                 aria-checked={active}
                 onClick={() => setPreference(opt.value)}
                 className={cn(
-                  'rounded-md px-2.5 py-1 text-xs transition-colors',
+                  'rounded-full px-2.5 py-1 text-xs transition-colors',
                   active
                     ? 'bg-[var(--chat-input-chip-bg)] font-medium text-[var(--msg-assistant-text)]'
                     : 'text-[var(--settings-section-sublabel)] hover:bg-sidebar-item-hover',

--- a/apps/desktop/src/renderer/components/settings/WindowBehaviorSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/WindowBehaviorSection.tsx
@@ -138,7 +138,7 @@ export function WindowBehaviorSection() {
           <div
             role="radiogroup"
             aria-label={t('settings.windowBehavior.closeBehavior.aria')}
-            className="flex w-fit shrink-0 items-center gap-0.5 rounded-lg border border-[var(--settings-theme-card-border)] p-0.5"
+            className="flex w-fit shrink-0 items-center gap-0.5 rounded-full border border-[var(--settings-theme-card-border)] p-0.5"
           >
             {(['tray', 'quit'] as const).map((behavior) => {
               const active = windowsCloseBehavior === behavior;
@@ -150,7 +150,7 @@ export function WindowBehaviorSection() {
                   aria-checked={active}
                   onClick={() => setWindowsCloseBehavior(behavior)}
                   className={cn(
-                    'rounded-md px-2.5 py-1 text-xs transition-colors',
+                    'rounded-full px-2.5 py-1 text-xs transition-colors',
                     active
                       ? 'bg-[var(--chat-input-chip-bg)] font-medium text-[var(--msg-assistant-text)]'
                       : 'text-[var(--settings-section-sublabel)] hover:bg-sidebar-item-hover',

--- a/apps/desktop/src/renderer/components/settings/__tests__/AgentResourceSectionRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/AgentResourceSectionRendering.test.tsx
@@ -33,6 +33,19 @@ vi.mock('@/components/ui/switch', () => ({
   ),
 }));
 
+/**
+ * 档位提示的四段文案全部常挂载(叠在同一 grid 格里防布局抖动),只有当前档位那段
+ * 可见 —— 因此断言必须看可见性,不能看存在性(getByText 对四段一律成立)。
+ * 同时校验"有且仅有一段可见",防止叠放层的显隐条件写错导致两段同时露出。
+ */
+function visiblePresetHint(): string | null {
+  const shown = Array.from(document.querySelectorAll('[data-preset-hint]')).filter(
+    (el) => el.getAttribute('aria-hidden') !== 'true',
+  );
+  expect(shown).toHaveLength(1);
+  return shown[0]?.textContent ?? null;
+}
+
 type WireShape = {
   maxConcurrentCommands: number;
   processPriority: 'normal' | 'low' | 'lowest';
@@ -93,7 +106,7 @@ describe('AgentResourceSection', () => {
     });
     const fullBtn = screen.getByText('settings.agentResource.presets.full');
     expect(fullBtn.getAttribute('aria-checked')).toBe('true');
-    expect(screen.getByText('settings.agentResource.presetHints.full')).toBeTruthy();
+    expect(visiblePresetHint()).toBe('settings.agentResource.presetHints.full');
     const numberInput = screen.getByRole('spinbutton') as HTMLInputElement;
     expect(numberInput.value).toBe('0');
     expect(screen.getByRole('switch').getAttribute('aria-checked')).toBe('false');
@@ -133,7 +146,7 @@ describe('AgentResourceSection', () => {
     render(<AgentResourceSection />);
 
     await waitFor(() => {
-      expect(screen.getByText('settings.agentResource.presetHints.custom')).toBeTruthy();
+      expect(visiblePresetHint()).toBe('settings.agentResource.presetHints.custom');
     });
     for (const preset of ['full', 'balanced', 'background']) {
       expect(

--- a/apps/desktop/src/renderer/components/settings/__tests__/CollaborationSectionRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/CollaborationSectionRendering.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+/**
+ * 「协同」设置面板的渲染与写入回归。
+ *
+ * 这一段的落盘语义与「Agent 资源占用」相反 —— 它是 onChange 即写盘 + clamp(而不是
+ * onBlur 提交制 + 拒绝非法值)。这里把该口径钉住,重点覆盖软/硬上限的耦合:软上限的
+ * 上界是当前硬上限,不是常量。
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CollaborationSection } from '../CollaborationSection';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+type Wire = {
+  workerSoftLimit: number;
+  workerHardLimit: number;
+  workerIdleReleaseMinutes: number;
+  isCustomized?: boolean;
+};
+
+const DEFAULT_WIRE: Wire = {
+  workerSoftLimit: 5,
+  workerHardLimit: 8,
+  workerIdleReleaseMinutes: 0,
+  isCustomized: false,
+};
+
+function installElectronApi(initial: Wire) {
+  let current = { ...initial };
+  const getCollaborationSettings = vi.fn(async () => current);
+  const setCollaborationSetting = vi.fn(async (key: string, value: number) => {
+    current = { ...current, [key]: value, isCustomized: true };
+    return current;
+  });
+  const resetCollaborationSettings = vi.fn(async () => {
+    current = { ...DEFAULT_WIRE };
+    return current;
+  });
+  (window as unknown as { electronAPI: unknown }).electronAPI = {
+    localDb: {
+      orcaWorkflows: {
+        getCollaborationSettings,
+        setCollaborationSetting,
+        resetCollaborationSettings,
+      },
+    },
+  };
+  return { getCollaborationSettings, setCollaborationSetting, resetCollaborationSettings };
+}
+
+/** 三个数字框按 DOM 顺序 = 软上限 / 硬上限 / 空闲释放。 */
+function limitInputs(): HTMLInputElement[] {
+  return screen.getAllByRole('spinbutton') as HTMLInputElement[];
+}
+
+describe('CollaborationSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the three worker limits', async () => {
+    installElectronApi(DEFAULT_WIRE);
+    render(<CollaborationSection />);
+
+    await waitFor(() => {
+      expect(screen.getByText('settings.collaboration.title')).toBeTruthy();
+    });
+    expect(limitInputs().map((i) => i.value)).toEqual(['5', '8', '0']);
+  });
+
+  it('writes the soft limit on change without waiting for blur', async () => {
+    const api = installElectronApi(DEFAULT_WIRE);
+    render(<CollaborationSection />);
+    await waitFor(() => limitInputs());
+
+    fireEvent.change(limitInputs()[0]!, { target: { value: '6' } });
+    await waitFor(() => {
+      expect(api.setCollaborationSetting).toHaveBeenCalledWith('workerSoftLimit', 6);
+    });
+  });
+
+  it('clamps the soft limit to the current hard limit', async () => {
+    const api = installElectronApi(DEFAULT_WIRE); // hard = 8
+    render(<CollaborationSection />);
+    await waitFor(() => limitInputs());
+
+    // 软上限的上界是硬上限(8),不是常量 —— 越界值被夹到 8 而不是原样落盘
+    fireEvent.change(limitInputs()[0]!, { target: { value: '99' } });
+    await waitFor(() => {
+      expect(api.setCollaborationSetting).toHaveBeenCalledWith('workerSoftLimit', 8);
+    });
+  });
+
+  it('clamps the idle-release minutes into range and truncates decimals', async () => {
+    const api = installElectronApi(DEFAULT_WIRE);
+    render(<CollaborationSection />);
+    await waitFor(() => limitInputs());
+
+    fireEvent.change(limitInputs()[2]!, { target: { value: '999' } });
+    await waitFor(() => {
+      expect(api.setCollaborationSetting).toHaveBeenCalledWith('workerIdleReleaseMinutes', 120);
+    });
+
+    fireEvent.change(limitInputs()[2]!, { target: { value: '7.9' } });
+    await waitFor(() => {
+      expect(api.setCollaborationSetting).toHaveBeenCalledWith('workerIdleReleaseMinutes', 7);
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/settings/__tests__/CollaborationSectionRendering.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/CollaborationSectionRendering.test.tsx
@@ -104,6 +104,24 @@ describe('CollaborationSection', () => {
     });
   });
 
+  it('clamps the hard limit between the current soft limit and 20', async () => {
+    const api = installElectronApi(DEFAULT_WIRE); // soft = 5
+    render(<CollaborationSection />);
+    await waitFor(() => limitInputs());
+
+    // 上界是常量 20
+    fireEvent.change(limitInputs()[1]!, { target: { value: '99' } });
+    await waitFor(() => {
+      expect(api.setCollaborationSetting).toHaveBeenCalledWith('workerHardLimit', 20);
+    });
+
+    // 下界是当前软上限(5),不是 1 —— 硬上限必须 >= 软上限
+    fireEvent.change(limitInputs()[1]!, { target: { value: '1' } });
+    await waitFor(() => {
+      expect(api.setCollaborationSetting).toHaveBeenCalledWith('workerHardLimit', 5);
+    });
+  });
+
   it('clamps the idle-release minutes into range and truncates decimals', async () => {
     const api = installElectronApi(DEFAULT_WIRE);
     render(<CollaborationSection />);


### PR DESCRIPTION
<!-- pr-intent:start -->
目标: 把设置页「通用」tab 里「协同」与「Agent 资源占用」两段的版式对齐仓库既有的房规卡片形态,并修掉这两段的两处布局抖动。
非目标: 折叠 / 渐进披露改造(档位加「自定义」档开展开面板、协同收成带摘要的折叠卡);抽 SegmentedControl / NumberField 共享组件;改任何 UI 文案;修全设置页说明文字的对比度债。以上均已与 owner 讨论并明确推后。
验收: 两段与 NotificationSection / GitSafetySection 逐项同规(卡片、行版式、字号阶梯、说明色);四个数字输入框规格一致且都有焦点环;切档位与首次触发「已自定义」不再产生布局位移;pnpm test:unit 全绿 + desktop typecheck 通过 + 改动文件 ESLint 通过;逻辑面零变动(git diff -w 核对 handler / IPC / 校验 / 提交时机)。
<!-- pr-intent:end -->

## 这次改了什么

### 摘要

设置页「通用」tab 下的「协同」和「Agent 资源占用」是这一页 11 个区块里**唯二没有卡片容器**的,裸字段直接贴在页面背景上,夹在上下相邻的 ivory 卡片序列中间,视觉上断裂。这次把它们对齐房规,顺带修掉两处布局抖动,并统一了设置页分段控件的圆角。

不改任何行为:两段的落盘语义原样保留(「协同」是 onChange 即写盘 + clamp,「Agent 资源占用」是 onBlur 提交制 + 拒绝非法值)。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无(owner 直接指出设置页这两段不符合设计规范)
- 本 PR 包含：
  - 两段套上带分割线的多行 ivory 卡片,规格取自 `SubagentModelSection` 的 Codex 护栏卡
  - 字号阶梯归位(标签 12→13px、说明 11→12px)、说明文字换用房规的 `--settings-section-sublabel`
  - 四个数字输入框统一为 `SettingsTextInput` 的 md 档规格,补上「协同」三个框缺失的焦点环
  - 修两处布局抖动(标题行预留高度、档位提示 grid 叠放)
  - 设置页分段控件圆角统一为 pill(外观 / 链接打开方式 / 应用行为三处原为 6px)
  - 「协同」新增测试文件(此前无任何覆盖)
- 明确不包含：折叠 / 渐进披露改造;抽共享组件(`SegmentedControl` / `NumberField`);UI 文案改写;全设置页说明文字的对比度债。均已与 owner 讨论后明确推后。
- 用户可见变化：仅这两段的视觉版式与分段控件圆角;所有设置项的行为、取值范围、落盘时机不变。
- 是否存在 breaking change：无

### UI 变化

设置 → 通用 → 「协同」与「Agent 资源占用」两段改为带分割线的 ivory 卡片版式;外观、链接打开方式、应用行为三处分段控件圆角由 6px 改为 pill。

**未附截图**:提交流程的 demo 证据门由 owner 显式跳过。**Light 与 Dark 两种模式已由 owner 实机目检、未报异常**(见「怎么验证的 → 手工验证」);但 PR 内没有截图作为可复核的视觉证据,故不声称「视觉证据完整」。

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §9 Agent Prompt Guide(设置区块示例)：设置区块为 ivory Card(`--surface-card-ivory`,12px 圆角,1px `--border-default` 描边)。本次两段套上 `rounded-xl` + `--settings-theme-card-bg`(解析到 `--surface-card-ivory`)+ 1px `--settings-theme-card-border`(解析到 `--border-default`),满足该条。
  - `DESIGN.md` §3 Typography Hierarchy：Small 为 12px、Micro Label(10–13px)明确「仅用于辅助 / 非阅读性标签,绝不用于用户逐句阅读的正文」。原说明文字为 11px 且是完整解释句(「Agent 资源占用」的 description 是三行段落),违反该条;本次改为 12px。
  - `DESIGN.md` §4 Inputs & Forms：`input/text` 的 radius 为 9999px(药丸)、fill 为 `--surface-elevated`、focus 走 focus-ring。原「协同」三个数字框是 8px 圆角 + 透明底且完全没有焦点环,本次统一为药丸 + `--surface-elevated` + `focus:ring-2 focus:ring-[var(--focus-ring)]`,规格与同目录 `SettingsTextInput` 的 md 档一致。
  - `DESIGN.md` §4 Tabs：分段选择器一律 pill(9999px),选中态 `--surface-chip`、未选中透明。`DESIGN.md` §5 Border Radius Scale：合法圆角只有 8 / 12 / 9999 三档,「no 4px / 6px / 10px, and no arbitrary radii」。外观、链接打开方式、应用行为三处分段控件原为 `rounded-lg` 外壳 + `rounded-md`(**6px**)按钮,两条都违反,本次收为 pill。
  - `DESIGN.md` §5 Spacing System / Whitespace：行内边距与分割线缩进取 16px(`px-4 py-4` + `mx-4`),与 `SubagentModelSection` 护栏卡一致。
  - `DESIGN.md` §10 Token 使用规则：颜色全部经语义 token 消费,无硬编码 hex / rgba,无 `bg-[#xxx] dark:bg-[#xxx]` 条件补丁(已 grep 自查)。
  - `DESIGN.md` §10 双模式交付门槛：新增样式全部走既有 token,两种模式由 token 体系同时覆盖;**Light 与 Dark 均已由 owner 实机目检、未报异常**(见「手工验证」)。按该节「验证是 best-effort 且必须如实报告」的要求标注执行人与证据形态:目检由 owner 完成,PR 内未附截图。

## 怎么验证的

### 自动验证

以下命令均可从仓库根**逐字复制执行**（已实跑核对，非事后追写）：

```text
pnpm test:unit
结果：EXIT=0，零 FAIL（PASS apps/desktop unit / PASS apps/mobile unit）

pnpm --filter desktop run typecheck
结果：EXIT=0（rebase 到 origin/main 后在合并态复跑）

# eslint 必须在 apps/desktop 的 package cwd 下跑：仓库根没有 eslint 扁平配置，
# 从根执行 `npx eslint <path>` 会 exit 2。
pnpm --filter desktop exec eslint \
  src/renderer/components/settings/CollaborationSection.tsx \
  src/renderer/components/settings/AgentResourceSection.tsx \
  src/renderer/components/settings/AppearanceSection.tsx \
  src/renderer/components/settings/LinkOpenSection.tsx \
  src/renderer/components/settings/WindowBehaviorSection.tsx \
  src/renderer/components/settings/__tests__/AgentResourceSectionRendering.test.tsx \
  src/renderer/components/settings/__tests__/CollaborationSectionRendering.test.tsx
结果：EXIT=0（无输出）

pnpm check:dco
结果：DCO check passed

# 逻辑零变动复核：-U0 去掉上下文行，只留真正的 +/- 变更行，再筛出所有
# handler / IPC / 校验 / min-max / 提交时机相关的行。pathspec 必须写完整仓库相对路径。
git diff -w -U0 origin/main...HEAD -- \
  apps/desktop/src/renderer/components/settings/CollaborationSection.tsx \
  apps/desktop/src/renderer/components/settings/AgentResourceSection.tsx \
  | grep -E '^[-+]' | grep -vE '^[-+]{3}' \
  | grep -E 'persist\(|electronAPI|Math\.|onChange=|onBlur=|min=|max=|value=|disabled='
结果：无输出（grep exit 1 = 无匹配）—— 忽略缩进后 handler / IPC / 校验 / min-max / 提交时机零变动
```

测试细节：

- `AgentResourceSectionRendering.test.tsx` 原 8 条全部保留并通过。其中两条档位提示断言从「存在性」改为「可见性 + 有且仅有一段可见」——四段提示改为常挂载后,`getByText` 对四段一律成立,原断言会退化成空断言。已做变异验证:把显隐条件写成恒真后,正是这两条失败。
- `CollaborationSectionRendering.test.tsx` 为新增(该 section 此前无任何测试),5 条,锁住 onChange 即写盘与三个字段各自的 clamp 口径:软上限夹到**当前硬上限**(动态上界)、硬上限夹在**当前软上限与 20 之间**(下界同样是动态的)、空闲释放越界夹取与小数截断。已对两处 clamp 各做变异验证:分别打断软上限与硬上限的 clamp 后,对应那条测试失败,其余通过。

### 手工验证

**Light / Dark 双模式实机目检:已完成(由 owner 在本机运行的 Desktop 上核验,未报告任何异常)。**
覆盖设置 → 通用 → 「协同」与「Agent 资源占用」两段的卡片、分割线、说明文字、数字输入框与分段控件。
按 `DESIGN.md` §10 双模式交付门槛的口径如实标注执行人:该目检由 owner 完成,不是提交者自测;
PR 内未附截图(见「未执行的验证」的 demo 证据门一条)。

### 未执行的验证

- **PR 内未附截图**(提交流程的 demo 证据门由 owner 显式跳过)。双模式实机目检本身已由 owner 完成(见「手工验证」),但**本 PR 正文里没有截图或录屏作为可复核的视觉证据**。因此本 PR 不声称「视觉证据完整」——它声称的是「owner 已实机核验两种模式且未报异常」,这两者不是一回事,审阅者若需要视觉证据请要求补图。
- **档位提示防抖在极窄窗口未实测**。四段提示改为 grid 叠放取最大自然高度,该做法在原理上与窗口宽度和语言都无关;但未在主窗口下限(800×600)下对 en / ja / ko 逐个实测。
- **版本 bump 未执行**:本仓根目录无 `VERSIONING.md`,未找到适用的 bump 规范。若本仓有约定请指出,我补。
- **本地提交流程的最后一道机器闸(push-guard)未跑**。本 PR 走的本地提交流程在 push 前有一道把共识产物与「修复编排链」哈希绑定到 push 动作上的闸。它要求「共识产物里有 finding」时必须携带完整编排链,而编排链的 SC 台账 schema 要求至少一条 SC —— 本次两条 finding 一条是「以证据答复后被审查席接受、不改代码」,另一条的修复改的是 PR 正文文本而非仓库文件,都写不出诚实的 SC,该闸因此跑不起来。**卡点是结构性错配,不是有未处置的质量问题**:三席均 APPROVED、零 blocker 零 major、共识门已 PASS。经 owner 明确决定跳过该闸直接提 PR。仓库自身的门禁(client-ci / DCO check / pr-design-basis / 自动 code review)不受影响,照常生效。
- **本正文相对三席审阅版本多了上面这一条**。三席审阅的是不含本条的版本;新增内容仅为如实补充「push-guard 未跑」这一事实,未修改任何技术声称或验证结论。

## 本地三审对账（round 1）

三席（`claude-adversarial` / `codex-adversarial` / `upstream-preview`）盲审 candidate `8280d2bb`，
`review_input_hash=53b8c18f…`。**三席均 APPROVED，blocker 0 / major 0，共 4 条 suggestion。**
`consensus-gate` round 1 仅 conjunct②（每条 finding 须由 origin 席自己 close）未过,故有本轮修复。

| finding | 席 | 处置 | 产物锚点 |
|---|---|---|---|
| `upstream-preview-r1-verify-cmd-repro`：本正文的「逻辑零变动」复现命令用裸文件名当 pathspec 且未加 `-U0`,按字面执行不会得到「无输出」 | ③ | **修** | 本正文「自动验证」段已改为可逐字执行的完整命令,并实跑核对（`grep` exit 1 = 无匹配） |
| `G-S1`：本正文的 `npx eslint <文件>` 从仓库根执行会 exit 2（根目录无 eslint 扁平配置） | ② | **修** | 本正文改为 `pnpm --filter desktop exec eslint …` 并注明 cwd 原因；已复现根目录 exit 2 与修正后 exit 0 |
| `F1`：`CollaborationSection` 硬上限输入框自身的 clamp（`Math.max(soft, Math.min(20, …))`）无任何测试触发其上下界 | ① | **修** | `CollaborationSectionRendering.test.tsx` 新增 `clamps the hard limit between the current soft limit and 20`（上界 20 / 下界为当前软上限两个方向都断言），并做变异验证 |
| `upstream-preview-r1-scope-radius-bundle`：把三处**其它 section** 的分段控件圆角一并改掉,超出「修这两段」的目标句范围,建议未来拆独立 commit | ③ | **答** | 依据：① 已在本正文「范围」与「引用的设计规范」中透明披露；② 有真实 §5 违规依据（6px 不在合法三档）；③ diff 极小（3 文件各 2 行 className）、零逻辑、不造成现有测试回归；④ 该席自身的 `product-arch-gate` 亦判其按 blocker 白名单不构成阻塞。结论保留于本 PR，不拆分 |

另有 4 条 `out_of_scope_notes`（主证据落在本次 diff 之外,按契约走 `out_of_scope_notes[]` 通道而非 finding,不进共识判定）：

| # | 席 | 内容 |
|---|---|---|
| OOS-1 | ① | 预设/优先级按钮选中态用 `--chat-input-chip-bg` / `--msg-assistant-text`,与设置页其它选中态 token 不统一（base 版本即有,本次未触碰） |
| OOS-2 | ① | `DESIGN.md` §4 Inputs 正文写 focus 用 `--focus-ring-soft`,而 `SettingsTextInput` 基线实际用 opaque `--focus-ring`,文档与实现不一致 |
| OOS-3 | ② | Light 模式 ivory 卡上 12px 说明文字的对比度债（≈3.6:1 < AA 4.5:1）—— 本 PR 意图明确列为非目标 |
| OOS-4 | ② | `components/settings/` 目录其它文件仍有 `rounded-md` / `rounded-lg` 遗留圆角债（不在本次实改集内） |

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop renderer 的设置页。改动集中在 5 个 section 组件的 JSX 与 className;其中 3 个文件(`AppearanceSection` / `LinkOpenSection` / `WindowBehaviorSection`)各只改 2 行圆角类名。无 main 进程、无 IPC、无 schema、无持久化改动。
- 回滚 / 降级方式：单 commit,`git revert` 即可完全回滚,无数据迁移、无状态残留。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次不涉及文档变更；设计依据已写入本 PR 的「引用的设计规范」）
- [x] 已确认测试结果或说明未执行原因
