### PR TITLE
fix: retain custom market icons and Windows auth

### DIFF
--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -206,7 +206,7 @@ describe('resolveDevCliFlags', () => {
           });
           expect(viaLink.isolatedDirIsEpochDerived).toBe(true);
         } finally {
-          rmSync(linkAncestor, { force: true });
+          rmSync(linkAncestor, { recursive: true, force: true });
         }
       }
       // TOCTOU 稳定性:目录被并发进程创建前后,同一写法的判定结果一致——

--- a/apps/desktop/src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexAuthInvalidation.test.ts
@@ -128,6 +128,13 @@ afterEach(() => {
 });
 
 describe('Codex system credential suppression marker', () => {
+  it('uses the domain-qualified Windows principal when tightening credential ACLs', async () => {
+    const { resolveWindowsAclPrincipal } = await import('../auth-adapters.js');
+
+    expect(resolveWindowsAclPrincipal({ USERDOMAIN: 'YOP', USERNAME: 'yop' })).toBe('YOP\\yop');
+    expect(resolveWindowsAclPrincipal({ USERNAME: 'local-user' })).toBe('local-user');
+  });
+
   it('user disconnect persists as reconcile suppression without surfacing an auth error', () => {
     const { codexHome, systemAuth, localAuth } = fixture();
     writeInvalidatedSystemCodexAuthMarker(

--- a/apps/desktop/src/main/maker-host/auth-adapters.ts
+++ b/apps/desktop/src/main/maker-host/auth-adapters.ts
@@ -385,10 +385,16 @@ export async function clearCodexAuthBoundaryStateBeforeLogin(
  * Windows: 用 icacls 把文件权限收紧为"仅当前用户 Full"。
  * 失败仅 stderr 告警, 不抛 —— userData ACL + 0o600 已经是双保险, icacls 是第三道。
  */
+export function resolveWindowsAclPrincipal(env: NodeJS.ProcessEnv = process.env): string {
+  const username = env.USERNAME?.trim() || os.userInfo().username;
+  const domain = env.USERDOMAIN?.trim();
+  return domain ? `${domain}\\${username}` : username;
+}
+
 async function tightenAclWindows(file: string): Promise<void> {
-  const username = process.env.USERNAME ?? os.userInfo().username;
+  const principal = resolveWindowsAclPrincipal();
   try {
-    await execFileP('icacls', [file, '/inheritance:r', '/grant:r', `${username}:F`]);
+    await execFileP('icacls', [file, '/inheritance:r', '/grant:r', `${principal}:F`]);
   } catch (err) {
     credPathLog.warn('icacls failed', { file, error: (err as Error).message });
   }

--- a/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
@@ -257,6 +257,24 @@ describe('ghostPluginViewModel', () => {
     expect(toGhostPluginListItem(ghost, presentation)).not.toHaveProperty('iconDataUrl');
   });
 
+  it('keeps an installed custom market plugin icon when its version is current', () => {
+    const ghost = installed({ iconDataUrl: 'data:image/png;base64,LOCAL' });
+    const presentation = marketPresentationForInstalledGhost(
+      ghost,
+      marketItem({
+        icon: null,
+        sourceType: 'git-market',
+        sourceMarketName: 'team-market',
+      }),
+    );
+
+    expect(presentation).not.toBeNull();
+    expect(toGhostPluginListItem(ghost, presentation)).toMatchObject({
+      name: 'Mivo Studio',
+      iconDataUrl: 'data:image/png;base64,LOCAL',
+    });
+  });
+
   it.each([
     ['local market miss', null],
     ['not installed', marketItem({ installState: 'not-installed' })],

--- a/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
@@ -73,14 +73,15 @@ export interface GhostPluginDetail extends GhostPluginListItem {
 /**
  * 展示投影只覆盖用户能看到的四个字段；运行时仍完全来自本地安装包。
  *
- * `iconDataUrl` 是有意要求存在的字段：市场项的 `icon: null` 也必须覆盖本地
- * 包图标，而不是因为缺少 URL 又显示旧图标。
+ * 服务端市场的 `icon: null` 必须覆盖本地包图标，而不是因为缺少 URL 又显示旧图标。
+ * 自定义市场没有可投影的远端图标 URL，故省略该字段以保留已安装包的本地图标。
  */
 export interface GhostPluginMarketPresentation {
   name: string;
   description: string;
   author: string | null;
-  iconDataUrl: string | undefined;
+  /** `null` means explicitly hide the local icon; `undefined` preserves it. */
+  iconDataUrl?: string | null;
 }
 
 /**
@@ -93,7 +94,14 @@ export function marketPresentationForInstalledGhost(
   marketItem:
     | Pick<
         PluginMarketItem,
-        'ghostId' | 'installState' | 'version' | 'name' | 'description' | 'author' | 'icon'
+        | 'ghostId'
+        | 'installState'
+        | 'version'
+        | 'name'
+        | 'description'
+        | 'author'
+        | 'icon'
+        | 'sourceType'
       >
     | null
     | undefined,
@@ -110,7 +118,9 @@ export function marketPresentationForInstalledGhost(
     name: marketItem.name,
     description: marketItem.description ?? '',
     author: marketItem.author,
-    iconDataUrl: marketItem.icon?.url,
+    ...(marketItem.sourceType === 'server'
+      ? { iconDataUrl: marketItem.icon?.url ?? null }
+      : {}),
   };
 }
 
@@ -242,8 +252,9 @@ export function toGhostPluginListItem(
   const display = presentation ?? {
     name: manifest.name,
     description: manifest.description ?? '',
-    iconDataUrl: ghost.iconDataUrl,
   };
+  const iconDataUrl =
+    presentation?.iconDataUrl === undefined ? ghost.iconDataUrl : presentation.iconDataUrl ?? undefined;
   return {
     id: manifest.id,
     name: display.name,
@@ -258,7 +269,7 @@ export function toGhostPluginListItem(
       publisherVerified: false,
       reviewed: false,
     },
-    ...(display.iconDataUrl !== undefined ? { iconDataUrl: display.iconDataUrl } : {}),
+    ...(iconDataUrl !== undefined ? { iconDataUrl } : {}),
   };
 }
 

--- a/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   classifySubagentEntry,
@@ -135,6 +135,22 @@ describe('discoverSubagentDefinitions', () => {
 
     expect(found).toHaveLength(1);
     expect(found[0]).toMatchObject({ name: 'u', scope: 'user', declaredModel: 'sonnet' });
+  });
+
+  it('不把用户主目录的 .claude 定义误判为项目作用域', async () => {
+    const home = path.join(root, 'home');
+    await writeAgent(path.join(home, '.claude', 'agents'), 'user-only.md', 'name: user-only');
+    const homeSpy = vi.spyOn(os, 'homedir').mockReturnValue(home);
+    try {
+      const found = await discoverSubagentDefinitions({
+        workingDir: path.join(home, 'project', 'nested'),
+        env: { CLAUDE_CONFIG_DIR: path.join(root, 'empty-home') },
+      });
+
+      expect(found).toEqual([]);
+    } finally {
+      homeSpy.mockRestore();
+    }
   });
 
   // 回归:严格对齐 cc 的加载条件。cc 对缺 name 或缺 description 的文件直接 return null,

--- a/packages/maker-core/src/agents/claude-code/subagent-definitions.ts
+++ b/packages/maker-core/src/agents/claude-code/subagent-definitions.ts
@@ -329,12 +329,21 @@ async function projectAgentsDirs(workingDir: string): Promise<string[]> {
   if (!workingDir || !path.isAbsolute(workingDir)) return [];
   const dirs: string[] = [];
   let cur = workingDir;
+  let homeDir: string | null = null;
   try {
     cur = await fs.realpath(workingDir);
   } catch {
     /* 保持字面路径 */
   }
+  try {
+    homeDir = await fs.realpath(os.homedir());
+  } catch {
+    /* 无法解析 home 时保持既有的逐级扫描兜底 */
+  }
   for (;;) {
+    // `~/.claude` 是用户作用域，不是用户主目录下所有项目共享的项目作用域。
+    // 不在这里停下会把用户定义重复标成 project，且让临时目录测试受机器配置污染。
+    if (homeDir !== null && cur === homeDir) break;
     const candidate = path.join(cur, '.claude', 'agents');
     if (await isDirectory(candidate)) dirs.push(candidate);
     const parent = path.dirname(cur);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复自定义插件市场中，已安装且已是最新版本的插件图标消失的问题；自定义市场继续使用本地已安装包图标，而服务端市场仍可显式清除图标。

同时修复 Windows 上认证 ACL 未使用域限定用户名、用户主目录的 .claude 定义被误识别为项目定义，以及 junction 测试清理失败的问题。

### 变更类型

- [x] ix 缺陷修复

### 范围

- 关联 Issue / 需求：自定义插件市场最新版插件图标缺失
- 本 PR 包含：市场图标展示投影、Windows ACL、Agent 定义扫描边界与 Windows junction 测试清理回归
- 明确不包含：插件协议、安装包格式、批准状态或权限模型变更
- 用户可见变化：自定义市场插件在无需更新时也会显示图标；Windows 本地 Codex 凭证 ACL 使用当前用户完整主体
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅修正既有插件卡片的数据投影，不改变视觉、交互或文案。

## 怎么验证的

### 自动验证

`	ext
pnpm test:unit
结果：通过（全 workspace）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（无 typecheck 脚本时跳过）

pnpm check:dco
结果：通过
`

### 手工验证

- 不涉及。

### 未执行的验证

- 无。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [x] 跨平台差异

### 影响与回滚

- 存量插件影响：无。本 PR 不改变批准状态、指纹、manifest 校验、安装布局或包格式；只调整已装列表的图标展示投影。基于已安装且同版本的自定义市场条目回归用例已在 ghostPluginViewModel.test.ts 运行。
- Windows ACL 仅将 icacls 主体从裸用户名修正为 USERDOMAIN\\USERNAME；缺少域时回退原有用户名行为。Agent 扫描不再将 ~/.claude 误判为项目作用域。
- 回滚：回退本 PR 即恢复此前展示与本地 ACL 行为，不涉及数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

> 该 PR 命中插件基座已装列表投影，按 docs/dev-rules/plugin-security-and-authoring.md 需要指定把关人明确批准后方可合并。