### PR TITLE
refactor(im): centralize personal bot command registry

### DIFF
--- a/apps/desktop/src/main/im/host.ts
+++ b/apps/desktop/src/main/im/host.ts
@@ -56,6 +56,7 @@ import {
   WechatCompatibilityPolicyService,
 } from './wechat/compatibilityPolicy';
 import { fetchPublicImageBytes } from './publicImageFetch';
+import { buildPersonalBotCommandMenu } from './shared/personalBotCommands';
 
 const log = createLogger('im/host');
 
@@ -190,12 +191,7 @@ export const telegramIm = createTelegramIM(host, {
   // 行为配置 getter: transport 每次使用时现读 → 设置卡改动即生效。
   behavior: readTelegramBehavior,
   // owner 私聊的 "/" 命令菜单(BotCommandScopeChat 只发 owner, 其他人不可见)。
-  commandMenu: ['start', 'new', 'help', 'stop', 'session', 'project', 'model', 'permission', 'ctr', 'exctr'].map(
-    (command) => ({
-      command,
-      description: t(`settings.telegramBot.commandMenu.${command}`),
-    }),
-  ),
+  commandMenu: buildPersonalBotCommandMenu((key) => t(key)),
 });
 export const dingtalkIm = createDingTalkIM(host, {
   fetcher: (input, init) => net.fetch(input instanceof URL ? input.toString() : input, init),

--- a/apps/desktop/src/main/im/shared/__tests__/personalBotCommands.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/personalBotCommands.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildPersonalBotCommandMenu,
+  parsePersonalBotCommand,
+  PERSONAL_BOT_COMMAND_LOCALE_POLICY,
+  PERSONAL_BOT_COMMANDS,
+} from '../personalBotCommands';
+
+describe('personal bot command registry', () => {
+  it('keeps the existing personal Telegram menu order and desktop-locale keys', () => {
+    expect(PERSONAL_BOT_COMMAND_LOCALE_POLICY).toBe('desktop-app');
+    expect(PERSONAL_BOT_COMMANDS).toEqual(
+      [
+        ['start', false],
+        ['new', false],
+        ['help', false],
+        ['stop', false],
+        ['session', true],
+        ['project', true],
+        ['model', true],
+        ['permission', true],
+        ['ctr', true],
+        ['exctr', false],
+      ].map(([command, interactive]) => ({
+        command,
+        menuDescriptionKey: `settings.telegramBot.commandMenu.${command}`,
+        interactive,
+        ...(command === 'exctr' ? { aliases: ['exitctr'] } : {}),
+      })),
+    );
+
+    expect(buildPersonalBotCommandMenu((key) => `translated:${key}`)).toEqual(
+      PERSONAL_BOT_COMMANDS.map(({ command, menuDescriptionKey }) => ({
+        command,
+        description: `translated:${menuDescriptionKey}`,
+      })),
+    );
+  });
+
+  it('normalizes the hidden /exitctr alias while preserving its invocation and arguments', () => {
+    expect(parsePersonalBotCommand('/exitctr now')).toMatchObject({
+      definition: { command: 'exctr', interactive: false },
+      invocation: '/exitctr',
+      args: ['now'],
+    });
+    expect(parsePersonalBotCommand('/HELP')).toBeNull();
+    expect(parsePersonalBotCommand('/unknown')).toBeNull();
+  });
+});

--- a/apps/desktop/src/main/im/shared/__tests__/slashCommands.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/slashCommands.test.ts
@@ -264,6 +264,22 @@ describe('IM slash commands', () => {
     expect(mocks.sendMarkdownText).toHaveBeenCalledWith('ou_user', ui.agent.stopDone(2));
   });
 
+  it('/exitctr 隐藏别名与 /exctr 同路径 — 归一化后仍走 executeDetach', async () => {
+    // 守住注册表 alias 归一化链: 老 switch 的 `case '/exitctr':` label 已删,
+    // 等价性依赖 parsePersonalBotCommand 把别名归一到 /exctr — 这里做 dispatch 级兜底。
+    const { executeDetach } = await import('../../binding');
+    vi.mocked(executeDetach).mockResolvedValue({ wasAttached: true } as never);
+    const { handlers } = makeHarness();
+
+    await handlers.handleSlashCommand('/exitctr', { botContextId: 'bot', userId: 'ou_user' });
+
+    expect(executeDetach).toHaveBeenCalledWith(
+      { channel: 'feishu', botContextId: 'bot', userId: 'ou_user' },
+      'feishu-slash',
+    );
+    expect(mocks.sendMarkdownText).toHaveBeenCalledWith('ou_user', ui.slash.detachedBySlash);
+  });
+
   it('/start 有欢迎语的渠道回欢迎语, 否则回未知命令', async () => {
     const { handlers } = makeHarness({
       adapterOverrides: {
@@ -311,9 +327,7 @@ describe('IM slash commands', () => {
     expect(mocks.sendInteractiveCard).not.toHaveBeenCalled();
     expect(turnRunner.resolveRouteTarget).toHaveBeenCalledOnce();
     expect(mocks.sendMarkdownText.mock.calls.slice(0, 3).map(([, text]) => text)).toEqual(
-      ['/model', '/ctr', '/session'].map((command) =>
-        ui.slash.unknownCommand(command),
-      ),
+      ['/model', '/ctr', '/session'].map((command) => ui.slash.unknownCommand(command)),
     );
     expect(mocks.sendMarkdownText.mock.calls[3]?.[1]).toContain('/permission auto');
   });

--- a/apps/desktop/src/main/im/shared/personalBotCommands.ts
+++ b/apps/desktop/src/main/im/shared/personalBotCommands.ts
@@ -1,0 +1,109 @@
+/**
+ * Personal IM bot command registry.
+ *
+ * This is the client-side source of truth for the personal bot command set,
+ * Telegram owner menu copy keys, locale policy, aliases and card capability.
+ * The official bot keeps its server-owned command surface until the later
+ * bridge cutover in #1855.
+ */
+
+export const PERSONAL_BOT_COMMAND_LOCALE_POLICY = 'desktop-app' as const;
+
+export interface PersonalBotCommandDefinition {
+  /** Canonical command without the leading slash. */
+  command: string;
+  /** Desktop i18n key used to render the personal Telegram owner menu. */
+  menuDescriptionKey: `settings.telegramBot.commandMenu.${string}`;
+  /** Whether the command needs a rich-card capable channel. */
+  interactive: boolean;
+  /** Accepted spellings that stay hidden from the Telegram command menu. */
+  aliases?: readonly string[];
+}
+
+export const PERSONAL_BOT_COMMANDS = [
+  {
+    command: 'start',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.start',
+    interactive: false,
+  },
+  {
+    command: 'new',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.new',
+    interactive: false,
+  },
+  {
+    command: 'help',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.help',
+    interactive: false,
+  },
+  {
+    command: 'stop',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.stop',
+    interactive: false,
+  },
+  {
+    command: 'session',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.session',
+    interactive: true,
+  },
+  {
+    command: 'project',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.project',
+    interactive: true,
+  },
+  {
+    command: 'model',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.model',
+    interactive: true,
+  },
+  {
+    command: 'permission',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.permission',
+    interactive: true,
+  },
+  {
+    command: 'ctr',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.ctr',
+    interactive: true,
+  },
+  {
+    command: 'exctr',
+    menuDescriptionKey: 'settings.telegramBot.commandMenu.exctr',
+    interactive: false,
+    aliases: ['exitctr'],
+  },
+] as const satisfies readonly PersonalBotCommandDefinition[];
+
+export type PersonalBotCommandName = (typeof PERSONAL_BOT_COMMANDS)[number]['command'];
+
+const commandByInvocation = new Map<string, (typeof PERSONAL_BOT_COMMANDS)[number]>();
+for (const definition of PERSONAL_BOT_COMMANDS) {
+  commandByInvocation.set(`/${definition.command}`, definition);
+  for (const alias of 'aliases' in definition ? (definition.aliases ?? []) : []) {
+    commandByInvocation.set(`/${alias}`, definition);
+  }
+}
+
+export interface ParsedPersonalBotCommand {
+  definition: (typeof PERSONAL_BOT_COMMANDS)[number];
+  /** Exact spelling supplied by the user, including the leading slash. */
+  invocation: string;
+  args: readonly string[];
+}
+
+/** Parse a known personal bot command without changing legacy case sensitivity. */
+export function parsePersonalBotCommand(text: string): ParsedPersonalBotCommand | null {
+  const [invocation, ...args] = text.trim().split(/\s+/);
+  const definition = commandByInvocation.get(invocation);
+  return definition ? { definition, invocation, args } : null;
+}
+
+/** Render the owner-scoped Telegram menu using the desktop application's locale. */
+export function buildPersonalBotCommandMenu(
+  translate: (key: PersonalBotCommandDefinition['menuDescriptionKey']) => string,
+): ReadonlyArray<{ command: string; description: string }> {
+  return PERSONAL_BOT_COMMANDS.map(({ command, menuDescriptionKey }) => ({
+    command,
+    description: translate(menuDescriptionKey),
+  }));
+}

--- a/apps/desktop/src/main/im/shared/slashCommands.ts
+++ b/apps/desktop/src/main/im/shared/slashCommands.ts
@@ -42,14 +42,7 @@ import {
   renderTextPermissionModeResult,
   resolvePermissionMode,
 } from './permissionModeControl';
-
-const INTERACTIVE_SLASH_COMMANDS = new Set([
-  '/model',
-  '/permission',
-  '/ctr',
-  '/session',
-  '/project',
-]);
+import { parsePersonalBotCommand } from './personalBotCommands';
 
 /** Quick text-only check; treat anything starting with '/' (no spaces before) as a command. */
 export function looksLikeSlashCommand(text: string): boolean {
@@ -98,13 +91,16 @@ export function createSlashHandlers(
   }
 
   async function handleSlashCommand(text: string, ctx: SlashCtx): Promise<boolean> {
-    const [cmd, ...commandArgs] = text.trim().split(/\s+/);
-    log.info(`slash cmd=${cmd} userId=...${ctx.userId.slice(-8)}`);
+    const [invocation, ...fallbackArgs] = text.trim().split(/\s+/);
+    const registered = parsePersonalBotCommand(text);
+    const cmd = registered ? `/${registered.definition.command}` : invocation;
+    const commandArgs = registered?.args ?? fallbackArgs;
+    log.info(`slash cmd=${registered?.invocation ?? cmd} userId=...${ctx.userId.slice(-8)}`);
 
     const supportsTextPermissionCommand = channel === 'wecom' && cmd === '/permission';
     if (
       adapter.output.kind === 'chunked-text' &&
-      INTERACTIVE_SLASH_COMMANDS.has(cmd) &&
+      registered?.definition.interactive === true &&
       !supportsTextPermissionCommand
     ) {
       await safeSendText(
@@ -243,8 +239,7 @@ export function createSlashHandlers(
         return true;
       }
 
-      case '/exctr':
-      case '/exitctr': {
+      case '/exctr': {
         // thread 模型: 同一用户可能有多个接管 thread, 顶层 slash 不知道指哪个 —
         // 语义定为"全部退出"(单退走 thread root 卡片的退出按钮)。
         if (threadScoped && threadUi) {
@@ -260,7 +255,7 @@ export function createSlashHandlers(
               if (r.wasAttached) detached += 1;
             } catch (err) {
               const msg = err instanceof Error ? err.message : String(err);
-              log.error(`${cmd} executeDetach(scope) threw: ${msg}`);
+              log.error(`${registered?.invocation ?? cmd} executeDetach(scope) threw: ${msg}`);
             }
           }
           await safeSendText(ctx.userId, threadUi.exctrAllDone(detached));
@@ -283,7 +278,7 @@ export function createSlashHandlers(
           }
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
-          log.error(`${cmd} executeDetach threw: ${msg}`);
+          log.error(`${registered?.invocation ?? cmd} executeDetach threw: ${msg}`);
           await safeSendText(ctx.userId, `❌ 结束接管失败：${msg}`);
         }
         return true;


### PR DESCRIPTION
## 这次改了什么

### 摘要

把个人 bot 的命令菜单和命令分发接到同一个 `apps/desktop/src/main/im/shared/personalBotCommands.ts` 注册表。个人 Telegram owner 菜单不再在 `im/host.ts` 维护第二份命令清单，`slashCommands.ts` 也从注册表读取命令参数与交互能力；既有处理分支保持原样。

### 变更类型

- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求：Refs makecindy/cindy#1855（工作流三 / 纯客户端第一点五刀）
- 本 PR 包含：个人 bot 10 条命令的注册表、Telegram owner 菜单生成、个人 IM slash 解析/交互分类消费注册表，以及 `/exitctr` 隐藏别名契约测试。
- 明确不包含：官方 bot 与服务端命令处理；命令集并集调整；slash 命令卡收敛；配置存储、协议、消息池、TurnPresenter、`packages/lizi-im` transport；微信 transport 专属 `/status`、`/stop all` task/outbox 命令流。
- 用户可见变化：无。命令顺序、菜单文案 key、桌面语言来源、别名、逐渠道可用性和反馈语义保持不变。
- 是否存在 breaking change：无。

### 意图契约

- 目标：让个人 bot 的命令菜单与命令分发共同消费 `im/shared` 的统一命令注册表。
- 生命周期/投递：本 PR 不接触官方 bot 生命周期、服务端解析、wire protocol 或 transport 投递语义；如果后续 PR 永远不来，个人 bot 仍沿用完整旧行为，只是命令元数据由单一出处提供。
- 规模：4 个文件；非测试新增 121 行、测试新增 50 行。规模门禁通过，属于一个可独立发布的完整目标。

## UI 变化

- 不涉及：仅修改 main 侧命令元数据与分发，未修改 renderer UI、菜单文案值或设计。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/im test
结果：36 test files / 433 tests 全部通过。

pnpm --filter desktop exec vitest run src/main/im src/main/hook-control
结果：67 test files / 954 tests 全部通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm test:unit
结果：全部 workspace PASS；仅仓库既有无可收集测试的 workspace 按契约 skip。

pnpm check:dco
结果：1 个提交通过 DCO；提交使用 git commit -s。

node ~/.agents/skills/git-workflow/scripts/pr-size-gate.mjs
结果：PASS；非测试新增 121 行，测试新增 50 行。
```

IM 共享层逐渠道覆盖：

- Telegram：`@cindy/im` 全量包含 TelegramIM 86 tests，desktop IM Telegram suites 通过。
- 飞书：desktop IM suites 通过，既有 `slashCommands` / message routing 断言未改。
- Discord：`@cindy/im` 与 desktop IM suites 通过。
- 钉钉：`@cindy/im` 与 desktop IM suites 通过。
- 企微：`@cindy/im` 与 desktop IM suites 通过，文本权限命令回归通过。
- 微信：既有 WeChat transport/task/outbox 命令路径未修改；desktop IM 全量套件通过。
- 官方 Slack / 官方 Telegram / X：`hook-control` 67-file suite 通过；本 PR 未改官方 bot 代码。

### 手工验证

不涉及。命令元数据为纯函数，行为由既有和新增单测覆盖。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [x] 跨平台差异（仅 TypeScript 纯数据/解析逻辑；未引入平台 API）

### 影响与回滚

- 影响范围：个人 IM 主进程的命令元数据读取与 slash 解析；无 renderer、mobile、数据库、协议或服务端影响。
- 回滚 / 降级方式：revert 本 PR 提交即可恢复 `host.ts` 内联菜单和 `slashCommands.ts` 原有交互命令集合；无 migration 或持久化数据需要回滚。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明（本 PR 不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（意图契约与 PR 描述）
- [x] 已确认测试结果
