### PR TITLE
test(desktop): 收敛 OAuth 两单端口交接夹具

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/ghostOauthFlow.test.ts
@@ -379,25 +379,28 @@ describe('startGhostOauthFlow', () => {
   });
 
   it('钉死端口:第二单顶掉第一单后立刻复用同一端口(自家僵尸监听自愈,无需回收器)', async () => {
-    const [firstResult, secondResult] = await pinnedPortCase(async (fixedPort) => {
-      let secondDone: Promise<unknown> = Promise.resolve();
-      const first = await startGhostOauthFlow({
-        config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-        fetchImpl: vi.fn() as unknown as typeof fetch,
-        openExternal: () => {
-          // 第一单占着钉死端口等回调时,第二单同端口进场——必须等到第一单的
-          // 监听真正关闭后成功 listen,而不是 LISTEN_FAILED。
-          secondDone = startGhostOauthFlow({
-            config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
-            fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-heal' })) as unknown as typeof fetch,
-            openExternal: (url2) => {
-              browserRedirect(url2, (au) => ({ code: 'c-heal', state: au.searchParams.get('state') ?? '' }));
-            },
-          });
-        },
-      });
-      return [first, await secondDone];
+    let secondDone: Promise<unknown> = Promise.resolve();
+    const firstResult = await startGhostOauthFlow({
+      config: { ...BASE_CONFIG, pkce: false },
+      fetchImpl: vi.fn() as unknown as typeof fetch,
+      openExternal: (url) => {
+        const redirectUri = new URL(url).searchParams.get('redirect_uri');
+        if (!redirectUri) throw new Error('authorize URL 缺 redirect_uri');
+        const fixedPort = Number(new URL(redirectUri).port);
+        if (!fixedPort) throw new Error('redirect_uri 缺端口');
+
+        // 第一单已由系统分配并占住端口;第二单复用该端口进场——必须等到
+        // 第一单监听真正关闭后成功 listen,而不是 LISTEN_FAILED。
+        secondDone = startGhostOauthFlow({
+          config: { ...BASE_CONFIG, pkce: false, redirectPort: fixedPort },
+          fetchImpl: vi.fn(async () => jsonResponse({ access_token: 'at-heal' })) as unknown as typeof fetch,
+          openExternal: (url2) => {
+            browserRedirect(url2, (au) => ({ code: 'c-heal', state: au.searchParams.get('state') ?? '' }));
+          },
+        });
+      },
     });
+    const secondResult = await secondDone;
     expect(firstResult).toMatchObject({ ok: false, error: 'CANCELLED' });
     expect(secondResult).toMatchObject({ ok: true });
   });


### PR DESCRIPTION
## 这次改了什么

- 优化已有的“两单固定端口交接”单测：第一单直接使用系统分配的 `listen(0)` 端口。
- 从第一单授权 URL 的 `redirect_uri` 读取实际端口，让第二单显式复用该端口。
- 保留原有断言：第一单 `CANCELLED`，第二单成功。

## 为什么改

PR #2062 已修复三单交接用例的同类端口准备窗口；复核发现两单用例仍使用 `probeFreePort()`，存在相同的“探测后释放、首次绑定前被并行 socket 抢占”窗口。这是测试夹具优化，不是新增覆盖，也不是产品逻辑回归。

## 验证

- `ghostOauthFlow.test.ts`：41/41 通过；连续 30 轮通过。
- `pnpm --filter desktop typecheck`：通过。
- 根 `pnpm test:unit`：通过（Desktop、Mobile、所有 required package；notApplicable workspace 按规则跳过）。
- `pnpm check:dco`：通过。

## 风险与边界

- 只改测试文件，不改 `ghostOauthFlow.ts`。
- 未添加 sleep、任意 retry、timeout 放宽或固定端口。
- 第一单关闭到第二单重新绑定之间仍是真实 loopback 行为，理论上仍受外部进程抢占影响；本修复消除了测试自身制造的首绑探测窗口。

## UI 变化

不涉及：仅修改 Desktop main 单元测试，无 UI 变化。