### PR TITLE
test(maker-core): 缩小 subagent 扫描预算固件

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/subagent-definitions.test.ts
@@ -339,9 +339,10 @@ describe('discoverSubagentDefinitions', () => {
   // 于是又把覆盖用的 env 设回去。抛出来才能走调用方的显式降级。
   it('文件数超预算 → 抛 SubagentScanBudgetError', async () => {
     const agents = path.join(root, 'repo', '.claude', 'agents');
+    const maxFiles = 5;
     await fs.mkdir(agents, { recursive: true });
     await Promise.all(
-      Array.from({ length: 210 }, (_, i) =>
+      Array.from({ length: maxFiles + 1 }, (_, i) =>
         fs.writeFile(
           path.join(agents, `a${i}.md`),
           `---\nname: a${i}\ndescription: d\n---\nbody\n`,
@@ -354,6 +355,7 @@ describe('discoverSubagentDefinitions', () => {
       discoverInFixture({
         workingDir: path.join(root, 'repo'),
         env: { CLAUDE_CONFIG_DIR: path.join(root, 'empty-home') },
+        maxFiles,
       }),
     ).rejects.toBeInstanceOf(SubagentScanBudgetError);
   });
@@ -485,9 +487,10 @@ describe('discoverSubagentDefinitions', () => {
   // 同步排序还堵住事件循环让外层定时器都没机会触发。改 opendir 流式并就地封顶。
   it('单目录条目数超上限 → 抛(不物化、不排序)', async () => {
     const agents = path.join(root, 'repo', '.claude', 'agents');
+    const maxDirEntries = 5;
     await fs.mkdir(agents, { recursive: true });
     await Promise.all(
-      Array.from({ length: 520 }, (_, i) =>
+      Array.from({ length: maxDirEntries + 1 }, (_, i) =>
         fs.writeFile(path.join(agents, `x${i}.txt`), 'not a definition', 'utf8'),
       ),
     );
@@ -496,19 +499,22 @@ describe('discoverSubagentDefinitions', () => {
       discoverInFixture({
         workingDir: path.join(root, 'repo'),
         env: { CLAUDE_CONFIG_DIR: path.join(root, 'empty-home') },
+        maxDirEntries,
       }),
     ).rejects.toBeInstanceOf(SubagentScanBudgetError);
   });
 
   // 深度上限也是预算:静默返回空会让上层判「没人声明 model」→ 又把覆盖用的 env 设回去。
   it('递归深度超上限 → 抛(不静默截断)', async () => {
-    const deep = path.join(root, 'repo', '.claude', 'agents', ...Array(10).fill('d'));
+    const maxDepth = 2;
+    const deep = path.join(root, 'repo', '.claude', 'agents', ...Array(3).fill('d'));
     await writeAgent(deep, 'x.md', 'name: deep\nmodel: opus');
 
     await expect(
       discoverInFixture({
         workingDir: path.join(root, 'repo'),
         env: { CLAUDE_CONFIG_DIR: path.join(root, 'empty-home') },
+        maxDepth,
       }),
     ).rejects.toBeInstanceOf(SubagentScanBudgetError);
   });

--- a/packages/maker-core/src/agents/claude-code/subagent-definitions.ts
+++ b/packages/maker-core/src/agents/claude-code/subagent-definitions.ts
@@ -121,7 +121,13 @@ const MAX_ELAPSED_MS = 1_500;
 class ScanBudget {
   private files = 0;
   private dirs = 0;
-  constructor(private readonly startedAt: number, private readonly deadlineMs: number) {}
+  constructor(
+    private readonly startedAt: number,
+    private readonly deadlineMs: number,
+    readonly maxDepth: number,
+    readonly maxFiles: number,
+    readonly maxDirEntries: number,
+  ) {}
 
   countDir(): void {
     if (++this.dirs > MAX_DIRS) throw new SubagentScanBudgetError(`dirs>${MAX_DIRS}`);
@@ -129,7 +135,9 @@ class ScanBudget {
   }
 
   countFile(): void {
-    if (++this.files > MAX_FILES) throw new SubagentScanBudgetError(`files>${MAX_FILES}`);
+    if (++this.files > this.maxFiles) {
+      throw new SubagentScanBudgetError(`files>${this.maxFiles}`);
+    }
     this.checkTime();
   }
 
@@ -199,7 +207,7 @@ async function isDirectory(p: string): Promise<boolean> {
 }
 
 /**
- * 流式读一个目录的条目,条目数超 {@link MAX_DIR_ENTRIES} 立即抛。
+ * 流式读一个目录的条目,条目数超扫描预算立即抛。
  *
  * 打不开的目录(权限 / 竞态删除)当作空目录,只跳过它自己;但**条目过多要抛** —— 那种情况下
  * 结果不可信,静默截断会让上层以为「扫完了,没人声明 model」。
@@ -215,8 +223,8 @@ async function readDirEntriesBounded(dir: string, budget: ScanBudget): Promise<D
   const entries: Dirent[] = [];
   // for-await 在 break / throw 时会自动关闭目录句柄。
   for await (const ent of handle) {
-    if (entries.length >= MAX_DIR_ENTRIES) {
-      throw new SubagentScanBudgetError(`dirEntries>${MAX_DIR_ENTRIES}`);
+    if (entries.length >= budget.maxDirEntries) {
+      throw new SubagentScanBudgetError(`dirEntries>${budget.maxDirEntries}`);
     }
     entries.push(ent);
     budget.checkTime();
@@ -278,7 +286,9 @@ async function collectMarkdownFiles(
 ): Promise<string[]> {
   // 深度上限也是预算的一部分,超了同样**抛**而不是返回空:深层目录里若有声明了 model 的定义,
   // 静默截断会让上层判成「没人声明」→ 又把覆盖用的 env 设回去(本 PR 要修的 bug)。
-  if (depth > MAX_DEPTH) throw new SubagentScanBudgetError(`depth>${MAX_DEPTH}`);
+  if (depth > budget.maxDepth) {
+    throw new SubagentScanBudgetError(`depth>${budget.maxDepth}`);
+  }
   // 软链环兜底:按真实路径去重。realpath 失败(悬空链)就跳过这个目录。
   let real: string;
   try {
@@ -451,6 +461,27 @@ export interface DiscoverSubagentsOptions {
   deadlineMs?: number;
   /** 测试注入起始时刻(避免依赖真实时钟)。 */
   now?: () => number;
+  /**
+   * 递归深度上限,有效范围 1..{@link MAX_DEPTH};非法值或超过缺省上限时回退缺省值。
+   * 测试可注入较小值,避免为触发预算创建大量目录。
+   */
+  maxDepth?: number;
+  /**
+   * .md 文件数上限,有效范围 1..{@link MAX_FILES};非法值或超过缺省上限时回退缺省值。
+   * 测试可注入较小值,避免为触发预算创建大量文件。
+   */
+  maxFiles?: number;
+  /**
+   * 单目录条目数上限,有效范围 1..{@link MAX_DIR_ENTRIES};非法值或超过缺省上限时回退缺省值。
+   * 测试可注入较小值,避免为触发预算创建大量目录条目。
+   */
+  maxDirEntries?: number;
+}
+
+function resolveBudgetLimit(value: number | undefined, fallback: number): number {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 && value <= fallback
+    ? value
+    : fallback;
 }
 
 /**
@@ -475,7 +506,13 @@ async function scanSubagentDefinitions(
   opts: DiscoverSubagentsOptions,
   deadlineMs: number,
 ): Promise<DiscoveredSubagent[]> {
-  const budget = new ScanBudget((opts.now ?? Date.now)(), deadlineMs);
+  const budget = new ScanBudget(
+    (opts.now ?? Date.now)(),
+    deadlineMs,
+    resolveBudgetLimit(opts.maxDepth, MAX_DEPTH),
+    resolveBudgetLimit(opts.maxFiles, MAX_FILES),
+    resolveBudgetLimit(opts.maxDirEntries, MAX_DIR_ENTRIES),
+  );
   const visitedDirs = new Set<string>();
   const scoped: Array<{ dir: string; scope: DiscoveredSubagent['scope'] }> = [
     // 顺序 = 跨作用域优先级从高到低(项目近者 > 项目远者 > 用户)。


### PR DESCRIPTION
## 这次改了什么

### 摘要

`subagent-definitions` 的三条扫描预算测试此前只能靠真实创建 210 个文件、520 个目录条目和 10 层目录来撞生产上限。Windows runner 文件 IO 较慢时，这些固件的创建与清理会偶发撞上 Vitest 5 秒超时或扫描的 1.5 秒墙钟预算，让无关 PR 变红。

参照 #1779 已验证的注入式修法：给 `discoverSubagentDefinitions` 增加仅供调用方选择的 `maxFiles`、`maxDirEntries`、`maxDepth`，只接受不超过生产缺省上限的正整数，非法值或超限值回退 200 / 500 / 8。生产调用方不需要修改，`deadlineMs`、`now` 与 `MAX_ELAPSED_MS` 语义不变。

三个预算测试分别注入 5 / 5 / 2，将固件缩到 6 个文件、6 个条目和 3 层目录，仍验证“超限必须抛 `SubagentScanBudgetError`，不能静默返回半份结果”。保留了 #1874 合入的 `discoverInFixture` 本机目录隔离。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Windows CI 上 `subagent-definitions` 扫描预算测试偶发超时
- 本 PR 包含：扫描文件数、单目录条目数、递归深度三项预算的有界注入与对应测试固件缩减
- 明确不包含：`MAX_ELAPSED_MS` 语义调整、扫描结果断言弱化、生产调用方改动
- 用户可见变化：无；只消除测试在慢文件系统上的偶发失败
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/subagent-definitions.test.ts
结果：32/32 通过；随后重复运行 10 轮，10/10 通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过

pnpm test:unit
结果：通过；全部要求的 unit workspace 通过，packages/maker-core unit 通过

pnpm --filter @cindy/maker-core exec eslint src/agents/claude-code/subagent-definitions.ts src/agents/claude-code/__tests__/subagent-definitions.test.ts
结果：通过

pnpm check:dco
结果：通过，1 个提交已签名
```

补充：尝试执行 `pnpm --filter @cindy/maker-core lint` 时，`origin/main` 基线在本次未修改文件中已有 61 个 error、1 个 warning；本次两个改动文件单独 ESLint 通过，未扩大范围修复既有 lint 问题。

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `discoverSubagentDefinitions` 的可选测试预算与三条预算测试固件；生产缺省上限仍为深度 8、文件 200、单目录条目 500
- 回滚 / 降级方式：回退本提交即可；生产调用方从未依赖新增参数

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
