### PR TITLE
fix(codex): 修复 Ask 答案返回契约

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,17 @@ jobs:
 
       # XDT_SKIP_AGENT_BIN_INSTALL 跳过了 postinstall 的全部 agent 二进制,但
       # runtime-configs.ts 模块顶层的 bundledRipgrepDir() 缺 rg 时直接 throw,
-      # 会让 apps/desktop 单测在收集阶段全挂——ripgrep 必须单独装回来。
-      # install:ripgrep 不带 --best-effort,不受上面的 skip 环境变量影响。
+      # code-mode 边界测试也会启动随包 Codex——两者都必须单独装回来。
+      # 显式安装命令不带 --best-effort,不受上面的 skip 环境变量影响。
       - name: Install bundled ripgrep
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm install:ripgrep
+
+      - name: Install bundled Codex
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm install:codex
 
       - name: Check endpoint literals
         run: pnpm check:endpoints
@@ -196,6 +201,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm install:ripgrep
+
+      - name: Install bundled Codex
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm install:codex
 
       - name: Run client and package unit tests
         run: pnpm test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,14 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm install:ripgrep
 
+      # Linux verify runs the real Codex functions.exec boundary regression. Windows
+      # intentionally skips that integration because the bundled binary's teardown
+      # is not reliable on the hosted runner.
+      - name: Install bundled Codex
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm install:codex
+
       - name: Check endpoint literals
         run: pnpm check:endpoints
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,17 +86,12 @@ jobs:
 
       # XDT_SKIP_AGENT_BIN_INSTALL 跳过了 postinstall 的全部 agent 二进制,但
       # runtime-configs.ts 模块顶层的 bundledRipgrepDir() 缺 rg 时直接 throw,
-      # code-mode 边界测试也会启动随包 Codex——两者都必须单独装回来。
-      # 显式安装命令不带 --best-effort,不受上面的 skip 环境变量影响。
+      # 会让 apps/desktop 单测在收集阶段全挂——ripgrep 必须单独装回来。
+      # install:ripgrep 不带 --best-effort,不受上面的 skip 环境变量影响。
       - name: Install bundled ripgrep
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm install:ripgrep
-
-      - name: Install bundled Codex
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: pnpm install:codex
 
       - name: Check endpoint literals
         run: pnpm check:endpoints
@@ -201,11 +196,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm install:ripgrep
-
-      - name: Install bundled Codex
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: pnpm install:codex
 
       - name: Run client and package unit tests
         run: pnpm test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,14 +93,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: pnpm install:ripgrep
 
-      # Linux verify runs the real Codex functions.exec boundary regression. Windows
-      # intentionally skips that integration because the bundled binary's teardown
-      # is not reliable on the hosted runner.
-      - name: Install bundled Codex
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: pnpm install:codex
-
       - name: Check endpoint literals
         run: pnpm check:endpoints
 

--- a/packages/maker-core/src/agents/codex/code-mode-ask-result.integration.test.ts
+++ b/packages/maker-core/src/agents/codex/code-mode-ask-result.integration.test.ts
@@ -1,0 +1,286 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { Logger } from '../../interfaces/logger.js';
+import { AppServerHost } from './app-server/host.js';
+import { Method, type ThreadStartResponse } from './app-server/protocol.js';
+import { createStdioTransport } from './app-server/stdioTransport.js';
+
+const repoRoot = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../../../../..');
+const codexBinary = path.join(
+  repoRoot,
+  'apps',
+  'codex-bin',
+  `${process.platform}-${process.arch}`,
+  process.platform === 'win32' ? 'codex.exe' : 'codex',
+);
+
+const answerPayload = {
+  pr_3322_decision: { answers: ['缩回重发'] },
+};
+
+const logger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => logger,
+};
+
+function sse(events: unknown[]): string {
+  return events.map((event) => {
+    const type = (event as { type: string }).type;
+    return `event: ${type}\ndata: ${JSON.stringify(event)}\n\n`;
+  }).join('');
+}
+
+function responseCreated(id: string): unknown {
+  return { type: 'response.created', response: { id } };
+}
+
+function responseCompleted(id: string): unknown {
+  return {
+    type: 'response.completed',
+    response: {
+      id,
+      usage: {
+        input_tokens: 0,
+        input_tokens_details: null,
+        output_tokens: 0,
+        output_tokens_details: null,
+        total_tokens: 0,
+      },
+    },
+  };
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address() as AddressInfo;
+  return `http://127.0.0.1:${address.port}`;
+}
+
+describe('Codex Ask code-mode return contract', () => {
+  const cleanups: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanups.length > 0) {
+      await cleanups.pop()?.();
+    }
+  });
+
+  it('returns the dynamic Ask response to functions.exec as a directly parseable JSON string', async () => {
+    const responseBodies: Array<Record<string, unknown>> = [];
+    const code = `
+const raw = await tools.cindy__ask_user_question({
+  questions: [{
+    id: "pr_3322_decision",
+    header: "熔断裁决",
+    question: "请选择后续处置",
+    options: [{ label: "缩回重发" }],
+    isOther: false,
+  }],
+});
+text(JSON.stringify({
+  type: typeof raw,
+  parsed: JSON.parse(raw),
+  contentIsUndefined: raw.content === undefined,
+  structuredContentIsUndefined: raw.structuredContent === undefined,
+}));
+`;
+    const responses = [
+      sse([
+        responseCreated('response-1'),
+        {
+          type: 'response.output_item.done',
+          item: {
+            type: 'custom_tool_call',
+            call_id: 'exec-call-1',
+            name: 'exec',
+            input: code,
+          },
+        },
+        responseCompleted('response-1'),
+      ]),
+      sse([
+        responseCreated('response-2'),
+        {
+          type: 'response.output_item.done',
+          item: {
+            type: 'message',
+            role: 'assistant',
+            id: 'message-1',
+            content: [{ type: 'output_text', text: 'done' }],
+          },
+        },
+        responseCompleted('response-2'),
+      ]),
+    ];
+    const server = createServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(Buffer.from(chunk));
+      if (req.method !== 'POST' || !req.url?.endsWith('/responses')) {
+        res.writeHead(404).end();
+        return;
+      }
+      responseBodies.push(JSON.parse(Buffer.concat(chunks).toString('utf8')) as Record<string, unknown>);
+      const body = responses.shift();
+      if (!body) {
+        res.writeHead(500).end('unexpected extra Responses request');
+        return;
+      }
+      res.writeHead(200, {
+        'content-type': 'text/event-stream',
+        connection: 'close',
+      });
+      res.end(body);
+    });
+    const baseUrl = await listen(server);
+    cleanups.push(() => new Promise<void>((resolve) => server.close(() => resolve())));
+
+    const tempRoot = mkdtempSync(path.join(tmpdir(), 'cindy-codex-ask-contract-'));
+    const codexHome = path.join(tempRoot, 'codex-home');
+    const workingDir = path.join(tempRoot, 'workdir');
+    mkdirSync(codexHome, { recursive: true });
+    mkdirSync(workingDir, { recursive: true });
+    writeFileSync(path.join(codexHome, 'config.toml'), `
+model = "mock-model"
+model_provider = "mock_provider"
+approval_policy = "never"
+sandbox_mode = "read-only"
+
+[features.code_mode]
+enabled = true
+
+[model_providers.mock_provider]
+name = "Mock provider for Ask contract test"
+base_url = "${baseUrl}/v1"
+wire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
+`);
+    cleanups.push(() => rmSync(tempRoot, { recursive: true, force: true }));
+
+    const host = new AppServerHost({
+      createTransport: () => createStdioTransport({
+        binaryPath: codexBinary,
+        cwd: workingDir,
+        env: {
+          ...process.env,
+          CODEX_HOME: codexHome,
+          OPENAI_API_KEY: 'test-key',
+        },
+      }),
+      logger,
+      clientInfo: { name: 'cindy-ask-contract-test', version: '0.0.0' },
+    });
+    cleanups.push(() => host.shutdown());
+
+    const thread = await withTimeout(
+      host.request<ThreadStartResponse>(Method.ThreadStart, {
+        model: 'mock-model',
+        modelProvider: 'mock_provider',
+        cwd: workingDir,
+        approvalPolicy: 'never',
+        sandbox: 'read-only',
+        dynamicTools: [{
+          namespace: 'cindy',
+          name: 'ask_user_question',
+          description: 'Collect a user choice.',
+          inputSchema: {
+            type: 'object',
+            properties: { questions: { type: 'array' } },
+            required: ['questions'],
+            additionalProperties: false,
+          },
+        }],
+      }, { timeoutMs: 20_000 }),
+      25_000,
+      'thread/start',
+    );
+
+    let resolveTurnCompleted!: () => void;
+    const turnCompleted = new Promise<void>((resolve) => {
+      resolveTurnCompleted = resolve;
+    });
+    const dynamicCalls: unknown[] = [];
+    const subscription = host.subscribeThread(thread.thread.id, {
+      turnCompleted: () => resolveTurnCompleted(),
+      dynamicToolCall: async (params) => {
+        dynamicCalls.push(params);
+        return {
+          contentItems: [{ type: 'inputText', text: JSON.stringify(answerPayload) }],
+          success: true,
+        };
+      },
+    });
+    cleanups.push(() => subscription.release());
+
+    await withTimeout(
+      host.request(Method.TurnStart, {
+        threadId: thread.thread.id,
+        input: [{ type: 'text', text: 'Ask for the decision through functions.exec.' }],
+      }, { timeoutMs: 20_000 }),
+      25_000,
+      'turn/start',
+    );
+    await withTimeout(turnCompleted, 25_000, 'turn/completed');
+
+    expect(dynamicCalls).toEqual([
+      expect.objectContaining({
+        namespace: 'cindy',
+        tool: 'ask_user_question',
+      }),
+    ]);
+    expect(responseBodies).toHaveLength(2);
+    const input = responseBodies[1]?.input;
+    expect(Array.isArray(input)).toBe(true);
+    const execOutput = (input as Array<Record<string, unknown>>).find((item) => (
+      item.type === 'custom_tool_call_output' && item.call_id === 'exec-call-1'
+    ));
+    expect(execOutput).toBeDefined();
+    const output = execOutput?.output;
+    expect(Array.isArray(output)).toBe(true);
+    const emittedTexts = (output as Array<Record<string, unknown>>)
+      .filter((item) => item.type === 'input_text' && typeof item.text === 'string')
+      .map((item) => item.text as string);
+    const directResult = JSON.parse(emittedTexts.at(-1) ?? '') as Record<string, unknown>;
+    expect(directResult).toEqual({
+      type: 'string',
+      parsed: answerPayload,
+      contentIsUndefined: true,
+      structuredContentIsUndefined: true,
+    });
+  }, 40_000);
+});

--- a/packages/maker-core/src/agents/codex/code-mode-ask-result.integration.test.ts
+++ b/packages/maker-core/src/agents/codex/code-mode-ask-result.integration.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -190,7 +191,12 @@ wire_api = "responses"
 request_max_retries = 0
 stream_max_retries = 0
 `);
-    cleanups.push(() => rmSync(tempRoot, { recursive: true, force: true }));
+    cleanups.push(() => rm(tempRoot, {
+      recursive: true,
+      force: true,
+      maxRetries: 20,
+      retryDelay: 100,
+    }));
 
     const host = new AppServerHost({
       createTransport: () => createStdioTransport({

--- a/packages/maker-core/src/agents/codex/code-mode-ask-result.integration.test.ts
+++ b/packages/maker-core/src/agents/codex/code-mode-ask-result.integration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -21,6 +21,7 @@ const codexBinary = path.join(
   `${process.platform}-${process.arch}`,
   process.platform === 'win32' ? 'codex.exe' : 'codex',
 );
+const codexBoundaryAvailable = process.platform !== 'win32' && existsSync(codexBinary);
 
 const answerPayload = {
   pr_3322_decision: { answers: ['缩回重发'] },
@@ -92,7 +93,10 @@ async function listen(server: Server): Promise<string> {
   return `http://127.0.0.1:${address.port}`;
 }
 
-describe('Codex Ask code-mode return contract', () => {
+// This is a real app-server/functions.exec boundary test. Keep it out of unit lanes
+// that cannot provide a reliable bundled Codex binary (notably Windows); local runs
+// with the binary present still exercise the complete boundary.
+describe.skipIf(!codexBoundaryAvailable)('Codex Ask code-mode return contract', () => {
   const cleanups: Array<() => Promise<void> | void> = [];
 
   afterEach(async () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -12477,12 +12477,6 @@ describe('CodexAgent MCP thread context hooks', () => {
         text: JSON.stringify({ 'question-1': { answers: ['Keep going'] } }),
       },
     ]);
-    const resultText = result.contentItems
-      .map((item) => item.type === 'inputText' ? item.text : '')
-      .join('');
-    expect(JSON.parse(resultText)).toEqual({
-      'question-1': { answers: ['Keep going'] },
-    });
     expect(nativeDuplicateResult).toEqual({
       answers: { 'native-q1': { answers: ['Keep going'] } },
     });

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -12130,6 +12130,9 @@ describe('CodexAgent MCP thread context hooks', () => {
     expect(startParams.dynamicTools?.[0]?.description).toContain('the user asks to choose');
     expect(startParams.dynamicTools?.[0]?.description).toContain('provide a generic list');
     expect(startParams.dynamicTools?.[0]?.description).toContain('Ask 1 to 3 short questions in a single call');
+    expect(startParams.dynamicTools?.[0]?.description).toContain('returns the awaited result as a JSON string');
+    expect(startParams.dynamicTools?.[0]?.description).toContain('JSON.parse(raw)');
+    expect(startParams.dynamicTools?.[0]?.description).toContain('Do not read .content or .structuredContent');
     expect(startParams.dynamicTools?.[0]?.inputSchema?.properties?.questions?.description).toContain('Bundle independent choices');
 
     const openAiAgent = new CodexAgent(createDeps());
@@ -12474,6 +12477,12 @@ describe('CodexAgent MCP thread context hooks', () => {
         text: JSON.stringify({ 'question-1': { answers: ['Keep going'] } }),
       },
     ]);
+    const resultText = result.contentItems
+      .map((item) => item.type === 'inputText' ? item.text : '')
+      .join('');
+    expect(JSON.parse(resultText)).toEqual({
+      'question-1': { answers: ['Keep going'] },
+    });
     expect(nativeDuplicateResult).toEqual({
       answers: { 'native-q1': { answers: ['Keep going'] } },
     });

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -519,6 +519,9 @@ const ASK_USER_DYNAMIC_TOOL: DynamicToolSpec = {
     'Use a later follow-up call only when the next question depends on the user answer to an earlier question.',
     'Do not use it for routine implementation details; choose a reasonable default.',
     'This tool does not replace authorization for destructive or external actions.',
+    'Codex code-mode returns the awaited result as a JSON string shaped like {"question-id":{"answers":["Choice"]}}; it is not an MCP CallToolResult object.',
+    'In functions.exec, use: const raw = await tools.cindy__ask_user_question({ questions: [...] }); const answers = JSON.parse(raw); text(JSON.stringify(answers));',
+    'Do not read .content or .structuredContent from the result; expose the raw or parsed answer with text(...) before the exec cell ends.',
   ].join(' '),
   inputSchema: {
     type: 'object',


### PR DESCRIPTION
## 这次改了什么

### 摘要

Codex code-mode 中，Cindy 的动态 Ask 工具返回值会被 app-server 作为 JSON 字符串交给 `functions.exec`。此前工具契约没有说明这一点，Agent 容易把结果误当成 MCP `CallToolResult`，读取不存在的 `.structuredContent` / `.content`，最终把已提交的用户答案静默变成 `undefined`。

本 PR 在 Codex Ask 动态工具描述中明确真实返回形状、正确的 `JSON.parse(raw)` / `text(...)` 用法和禁止的错误解包方式；同时增加真实 code-mode 边界回归：启动仓库随包 Codex 0.145.0 app-server，由本地 mock Responses 流触发 `functions.exec`，在 JS 内 await 动态 Ask，并断言直接返回值是可解析的 JSON string，且无需 `.content` / `.structuredContent` 解包。

真实边界测试采用环境门控：仅在非 Windows 且检测到 bundled Codex binary 时运行完整 app-server / `functions.exec` 路径；Windows 或缺少 binary 的环境会整组 skip。本 PR 不修改 `.github/workflows/ci.yml`，CI 保持 `main` 基线；当前 head 的 8 项 required checks 全部成功。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Codex Ask 返回后 Agent 未感知用户答案（本次会话稳定复现）
- 本 PR 包含：Codex 动态 Ask 工具的 code-mode 返回契约说明；注册描述断言；真实 app-server / `functions.exec` 返回边界回归及其环境门控
- 明确不包含：Claude / Pi Ask；通用 interaction 重构；Codex 上游协议改动；Ask UI 或答案落库语义改动；为该测试扩张 CI 基础设施
- 用户可见变化：Codex 在 Ask 完成后会按真实字符串契约读取并继续使用用户答案，不再因错误解包静默得到 `undefined`
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及 UI

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/code-mode-ask-result.integration.test.ts
结果：通过；本地 macOS bundled Codex 环境真实执行 1 个测试，启动 app-server 并穿过 functions.exec 返回边界

pnpm --filter @cindy/maker-core test
结果：通过；93 个 test files 通过，1972 passed | 1 skipped

pnpm check:dco
结果：通过，所有 PR 非 merge commit 均带匹配 author 的 Signed-off-by；merge commit 按仓库规则豁免

GitHub required checks（当前 head 45f2ea096d95fae08c1adc7b36c064c79f5c4b8c）
结果：8/8 成功，包括 verify、check:pr-design-basis、Windows unit tests 两个 shard 及汇总、Desktop Git integration、DCO、Greptile Review
```

额外检查：`maker-core` 全量 lint / build 仍命中 `origin/main` 已存在的无关存量错误；新增边界测试未出现在错误列表，本 PR 未修改这些错误所在逻辑，也未扩大范围处理。

### 手工验证

修复前在 Codex code-mode 现场稳定复现：动态工具返回原始 JSON 字符串；按 MCP 对象读取 `.structuredContent ?? .content` 会得到 `undefined`。

本地 macOS bundled Codex 环境执行了同一真实边界：随包 Codex app-server 执行 `functions.exec`，动态 Ask 返回 `{"pr_3322_decision":{"answers":["缩回重发"]}}` 后，JS 侧断言 `typeof raw === "string"`、`JSON.parse(raw)` 得到答案，且 `raw.content` / `raw.structuredContent` 均为 `undefined`。

### 未执行的验证

未在 Windows 或缺少 bundled Codex 的环境强制执行真实 app-server 边界测试；这些环境按门控 skip，且 `.github/workflows/ci.yml` 保持 `main` 基线。未启动包含本分支的新 Desktop UI 做人工端到端 Ask；本次变更不涉及 UI 或答案落库。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Codex tool definition 行为说明

### 影响与回滚

- 影响范围：新建的非 xAI Codex 会话注册 `cindy__ask_user_question` 时的工具描述；动态工具响应结构、Interaction 流程和其它 Agent 不变
- 核心指标评估：返回准确性是预期改善点；描述内容为稳定常量，不引入逐轮变化或额外 I/O，不影响 event loop 性能；工具定义仅增加固定文本，不改变 system prompt 拼接顺序或会话中途工具集合
- 实测结论：注册描述断言、本地真实 bundled Codex app-server / code-mode / `functions.exec` 返回边界、maker-core 全量测试和当前 head 的 8 项 required checks 均通过
- 回滚 / 降级方式：回退本 PR 即可恢复原工具描述与测试；`.github/workflows/ci.yml` 未被本 PR 修改，无 CI 接线需要回滚；无数据迁移或持久化状态

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
