### PR TITLE
feat(desktop): 支持 Art 插件调用 Seedance 2.5

### DIFF
--- a/apps/desktop/src/main/cindy-proxy-media/types.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/types.ts
@@ -77,6 +77,7 @@ export type GatewayImageModel = (typeof GATEWAY_IMAGE_MODELS)[number]['id'];
 export const GATEWAY_VIDEO_MODELS = [
   { id: 'seedance-fast', label: 'Seedance 快速' },
   { id: 'seedance-pro', label: 'Seedance Pro' },
+  { id: 'bytedance/seedance-2.5', label: 'Seedance 2.5' },
   { id: 'happyhorse', label: 'HappyHorse 1.0' },
 ] as const;
 

--- a/apps/desktop/src/main/cindy-proxy-media/video/__tests__/seedanceProvider.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/__tests__/seedanceProvider.test.ts
@@ -32,6 +32,14 @@ describe('seedance provider · capabilities', () => {
       true,
     );
   });
+  it('exposes the catalog Seedance 2.5 id as an explicit opt-in model', () => {
+    expect(
+      p.capabilities.modelAliases.find((a) => a.alias === 'bytedance/seedance-2.5'),
+    ).toMatchObject({
+      internalModel: 'doubao-seedance-2-5-260628',
+    });
+    expect(p.capabilities.expectedSecondsByAlias['bytedance/seedance-2.5']).toBe(300);
+  });
   it('首尾帧模式上限 2 张,参考图模式 9 张(同一个 2.0 模型的两种 role)', () => {
     expect(p.capabilities.maxImagesByRefMode).toEqual({
       first_and_last_frame: 2,
@@ -151,6 +159,21 @@ describe('seedance provider · submit body shape', () => {
     expect(body.content).toHaveLength(3);
     expect(body.content[1].role).toBe('first_frame');
     expect(body.content[2].role).toBe('last_frame');
+  });
+
+  it('Seedance 2.5: translates the catalog id to the Volcengine model id', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'cgt-FAKE-25' }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const p = makeProvider(fetchMock);
+    const handle = await p.submit(
+      { prompt: '一只猫在雨里奔跑' },
+      'bytedance/seedance-2.5',
+    );
+    const init = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe('doubao-seedance-2-5-260628');
+    expect(handle.modelUsed).toBe('doubao-seedance-2-5-260628');
   });
 
   it('refMode:reference_image → 每张图都是 role:reference_image,顺序原样保留', async () => {

--- a/apps/desktop/src/main/cindy-proxy-media/video/providers/seedance.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/providers/seedance.ts
@@ -1,7 +1,7 @@
 /**
  * art/video/providers/seedance.ts
  * ---------------------------------------------------------------------------
- * VideoProvider implementation for Volcengine ARK doubao-seedance-2-0,
+ * VideoProvider implementation for Volcengine ARK Doubao Seedance 2.x models,
  * routed through XD Gateway's `/volcengine/api/v3/contents/generations/tasks`
  * passthrough.
  *

--- a/apps/desktop/src/main/cindy-proxy-media/video/providers/seedance.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/providers/seedance.ts
@@ -5,9 +5,10 @@
  * routed through XD Gateway's `/volcengine/api/v3/contents/generations/tasks`
  * passthrough.
  *
- * Two model tiers exposed:
+ * Three model choices exposed:
  *   - 'seedance-fast' → doubao-seedance-2-0-fast-260128 (≈2min, default)
  *   - 'seedance-pro'  → doubao-seedance-2-0-260128       (≈5min, quality tier)
+ *   - 'bytedance/seedance-2.5' → doubao-seedance-2-5-260628 (explicit opt-in)
  *
  * API quirks worth knowing:
  *   - Submit body uses Volcengine's chat-style `content` array:
@@ -67,6 +68,11 @@ const CAPABILITIES: VideoProviderCapabilities = {
       summary: '精(~5min) - 用户显式要"高质量"再选',
       internalModel: 'doubao-seedance-2-0-260128',
     },
+    {
+      alias: 'bytedance/seedance-2.5',
+      summary: 'Seedance 2.5(~5min) - 用户显式点名 2.5 再选',
+      internalModel: 'doubao-seedance-2-5-260628',
+    },
   ],
   supportedDurations: [4, 6, 8, 10],
   supportedResolutions: ['480p', '720p', '1080p'],
@@ -90,6 +96,7 @@ const CAPABILITIES: VideoProviderCapabilities = {
   expectedSecondsByAlias: {
     'seedance-fast': 120,
     'seedance-pro': 300,
+    'bytedance/seedance-2.5': 300,
   },
   defaults: {
     duration: 4,

--- a/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerAccessPolicy.test.ts
@@ -38,6 +38,7 @@ function catalog(): Catalog {
     { ...model('gpt-image-2'), group: 'image' },
     { ...model('seedance-fast'), group: 'video' },
     { ...model('seedance-pro'), group: 'video' },
+    { ...model('bytedance/seedance-2.5'), group: 'video' },
     { ...model('happyhorse'), group: 'video' },
     { ...model('voyage/voyage-4'), group: 'embedding' },
   ]);
@@ -49,6 +50,7 @@ function catalog(): Catalog {
   xd.videoModels = [
     { id: 'seedance-fast', name: 'Seedance Fast' },
     { id: 'seedance-pro', name: 'Seedance Pro' },
+    { id: 'bytedance/seedance-2.5', name: 'Seedance 2.5' },
     { id: 'happyhorse', name: 'HappyHorse' },
   ];
   xd.videoDefaults = {
@@ -114,6 +116,7 @@ describe('provider access policy', () => {
       expect(xd?.videoModels?.map((item) => item.id)).toEqual([
         'seedance-fast',
         'seedance-pro',
+        'bytedance/seedance-2.5',
       ]);
       expect(xd?.videoDefaults).toEqual({
         standard: 'seedance-fast',
@@ -125,6 +128,7 @@ describe('provider access policy', () => {
         'xd-only-model',
         'seedance-fast',
         'seedance-pro',
+        'bytedance/seedance-2.5',
       ]);
       expect(xd?.models.codex).toEqual([]);
     },
@@ -165,7 +169,11 @@ describe('projectProviderCatalogForBuildRegion — 用户自有媒体来源', ()
     const xd = projected.providers.find((p) => p.id === 'xd');
     expect(xd?.imageModels).toEqual([]);
     expect(xd?.imageDefaults).toBeUndefined();
-    expect(xd?.videoModels?.map((m) => m.id)).toEqual(['seedance-fast', 'seedance-pro']);
+    expect(xd?.videoModels?.map((m) => m.id)).toEqual([
+      'seedance-fast',
+      'seedance-pro',
+      'bytedance/seedance-2.5',
+    ]);
   });
 
   it.each(['cn', 'dev'] as const)(

--- a/apps/desktop/src/main/maker-host/provider-access-policy.ts
+++ b/apps/desktop/src/main/maker-host/provider-access-policy.ts
@@ -17,6 +17,7 @@ const CINDY_AI_PROVIDER_ID = 'xd';
 const MAINLAND_VIDEO_MODEL_IDS: ReadonlySet<string> = new Set([
   'seedance-fast',
   'seedance-pro',
+  'bytedance/seedance-2.5',
 ]);
 
 function projectVideoDefaults(

--- a/packages/model-providers/src/builtin.ts
+++ b/packages/model-providers/src/builtin.ts
@@ -174,6 +174,7 @@ const XD_PROVIDER: Provider = {
   videoModels: [
     { id: 'seedance-fast', name: 'Seedance 快速' },
     { id: 'seedance-pro', name: 'Seedance Pro' },
+    { id: 'bytedance/seedance-2.5', name: 'Seedance 2.5' },
     { id: 'happyhorse', name: 'HappyHorse 1.0' },
   ],
   videoDefaults: {


### PR DESCRIPTION
## 这次改了什么

### 摘要

让 Art 插件在显式选择 `bytedance/seedance-2.5` 时，Desktop 运行时能够解析该模型并提交到火山视频生成接口。运行时会将目录 ID 映射为 `doubao-seedance-2-5-260628`，同时补齐内置模型目录和 CN/dev 区域投影；现有 `seedance-fast` 默认行为保持不变。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：https://github.com/makecindy/cindy-official-plugins/pull/82
- 本 PR 包含：Seedance 2.5 运行时 alias 映射、媒体模型目录、CN/dev 区域放行及回归测试
- 明确不包含：Art 插件自身改动、默认视频模型调整、模型计费或上游服务配置
- 用户可见变化：Art 插件显式点名 Seedance 2.5 后可以正常调用，不再被运行时判定为未知模型
- `FORGE_GUIDE`：无需同步。现有手册已要求插件仅在用户显式点名时原样透传 `model`，并明确禁止插件写死主机型号；本次只扩充主机管理的模型目录，不改变 slot kind、参数或插件作者用法
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，全部 required workspace PASS

pnpm --filter desktop typecheck
结果：通过，0 errors

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/main/cindy-proxy-media/types.ts src/main/cindy-proxy-media/video/providers/seedance.ts src/main/cindy-proxy-media/video/__tests__/seedanceProvider.test.ts src/main/maker-host/provider-access-policy.ts src/main/maker-host/__tests__/providerAccessPolicy.test.ts
结果：通过

pnpm --filter @cindy/model-providers run --if-present lint
结果：通过

git diff --check
结果：通过
```

补充：Desktop 全仓 lint 仍报告 190 个存量问题，本 PR 修改的文件定向 lint 均通过。

### 手工验证

不涉及：未使用真实账号和付费模型执行端到端视频生成。

### 未执行的验证

- 未执行真实 Seedance 2.5 生成请求，避免消耗线上额度；模型 ID 与 Art 插件目录保持一致

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：依赖上游 Seedance 2.5 模型可用性；等待预算暂沿用 Seedance Pro 的 300 秒

### 影响与回滚

- 影响范围：仅新增 `bytedance/seedance-2.5` 的显式调用路径；`seedance-fast` 继续作为默认模型
- 回滚 / 降级方式：回滚本提交即可恢复原目录与运行时映射；Art 插件仍可继续使用已有 Seedance 2.0 模型
- 存量插件影响：无，不修改插件批准状态、指纹、manifest、安装布局或包格式

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
