### PR TITLE
fix(desktop): Seedance 2.5 拆出独立 provider，修正继承自 2.0 的值域

### DIFF
--- a/apps/desktop/src/main/__tests__/devCliFlags.test.ts
+++ b/apps/desktop/src/main/__tests__/devCliFlags.test.ts
@@ -206,7 +206,12 @@ describe('resolveDevCliFlags', () => {
           });
           expect(viaLink.isolatedDirIsEpochDerived).toBe(true);
         } finally {
-          rmSync(linkAncestor, { force: true });
+          // 指向目录的 symlink 要走 rmdir 语义:不带 recursive 的 rmSync 按
+          // unlink 处理,Windows 上直接抛 EISDIR(Path is a directory),把整个
+          // pnpm test:unit 门禁带红。只有拿到 symlink 权限的开发机(canSymlink
+          // 为 true)会走到这里,CI 拿不到权限所以看不见这条。recursive 对
+          // symlink 只删链接本身,不跟随进目标目录(已实测)。
+          rmSync(linkAncestor, { recursive: true, force: true });
         }
       }
       // TOCTOU 稳定性:目录被并发进程创建前后,同一写法的判定结果一致——

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -855,9 +855,10 @@ export class GhostCindySlot {
     }
 
     // 画面参数按**解析出的型号**二次校验:协议层值域是所有 provider 的
-    // 交集,单个型号支持的时长/帧率差异很大(seedance 4/6/8/10 秒,
-    // happyhorse 只有 5 秒)。不支持即明拒并列出该型号的可用值,不做最近似
-    // 降级——静默改成别的档位会让意识以为自己的参数生效了。
+    // 交集,单个型号支持的时长/帧率差异很大(seedance 2.0 是 4/6/8/10 秒,
+    // seedance 2.5 是 4–30 秒且没有 1080p,happyhorse 只有 5 秒)。不支持即
+    // 明拒并列出该型号的可用值,不做最近似降级——静默改成别的档位会让意识
+    // 以为自己的参数生效了。
     if (info.category === 'video' && presentVideoKeys.length > 0) {
       const caps = this.deps.videoCapabilities?.(model) ?? null;
       if (caps) {

--- a/apps/desktop/src/main/cindy-proxy-media/video/__tests__/seedance25Provider.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/__tests__/seedance25Provider.test.ts
@@ -1,0 +1,478 @@
+/**
+ * seedance25Provider.test.ts
+ * ---------------------------------------------------------------------------
+ * Seedance 2.5 与 2.0 的差异点锁定。共享骨架(submit/poll/download 的 URL 拼接、
+ * 状态映射、下载)由 seedanceProvider.test.ts 覆盖,这里只钉**代次差异**:
+ *   - model 字段是网关映射名 `bytedance/seedance-2.5`,不是方舟原生 id;
+ *   - 后缀串**不写 `--fps`**(方舟弱校验白名单里没这一项);
+ *   - `adaptive` 只当默认值:省略 ratio 时**不写 `--ratio`**,而它不进
+ *     supportedRatios(协议层枚举不认,显式传进不来);
+ *   - 给了具体画幅就**原样透传**,不按 refMode 拦(passthrough,由上游裁决);
+ *   - 时长 4–30、分辨率没有 1080p。
+ *
+ * alias 与 provider.id 是两个东西,本文件都钉:alias 是对外契约
+ * `bytedance/seedance-2.5`(Art 插件按它点名),provider.id 是内部标识
+ * `seedance-2.5`(也是错误话术前缀)。
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createSeedance25Provider,
+  createSeedanceProvider,
+} from '../providers/seedance.js';
+import { VideoProviderRegistry } from '../registry.js';
+import { submitAndAwaitVideo } from '../run.js';
+import type { VideoGenerationRequest } from '../types.js';
+
+const BASE_URL = 'https://llm-proxy.example.test';
+const SUBMIT_URL = `${BASE_URL}/volcengine/api/v3/contents/generations/tasks`;
+const ALIAS = 'bytedance/seedance-2.5';
+const MODEL = 'bytedance/seedance-2.5';
+
+function makeProvider(fakeFetch: typeof fetch) {
+  return createSeedance25Provider({
+    baseUrl: BASE_URL,
+    getApiKey: () => 'test-key',
+    fetchImplementation: fakeFetch,
+  });
+}
+
+/** submit 只回一个 task id;取回请求体给断言用。 */
+function makeSubmitMock(): {
+  fetchMock: typeof fetch;
+  bodyOf: (i?: number) => { model: string; content: Array<Record<string, unknown>>; generate_audio?: boolean };
+} {
+  const calls: RequestInit[] = [];
+  const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+    calls.push(init ?? {});
+    return new Response(JSON.stringify({ id: 'cgt-25-FAKE' }), { status: 200 });
+  }) as unknown as typeof fetch;
+  return {
+    fetchMock,
+    bodyOf: (i = 0) => JSON.parse(calls[i].body as string),
+  };
+}
+
+/** 取 content 里那个 text 节点的文本。 */
+async function promptTextOf(req: VideoGenerationRequest): Promise<string> {
+  const { fetchMock, bodyOf } = makeSubmitMock();
+  await makeProvider(fetchMock).submit(req, 'bytedance/seedance-2.5');
+  return bodyOf().content[0].text as string;
+}
+
+describe('seedance 2.5 · capabilities', () => {
+  const p = makeProvider(vi.fn() as unknown as typeof fetch);
+
+  it('alias 是插件契约名、provider.id 是内部名,内部 model 是网关映射名', () => {
+    // alias 必须与 Art 插件 mapVideoModel 的输出逐字一致
+    // (cindy-official-plugins#82 已上线),改名就是断插件。
+    expect(p.capabilities.modelAliases).toHaveLength(1);
+    expect(p.capabilities.modelAliases[0].alias).toBe(ALIAS);
+    // internalModel 与 alias 同串是巧合:这里要的是网关映射名(LiteLLM 风格),
+    // 不是方舟原生 id doubao-seedance-2-5-*。
+    expect(p.capabilities.modelAliases[0].internalModel).toBe(MODEL);
+    expect(p.id).toBe('seedance-2.5');
+  });
+
+  it('分辨率只有 480p / 720p —— **没有 1080p**(照抄 2.0 三档就会放行必被上游拒的值)', () => {
+    expect(p.capabilities.supportedResolutions).toEqual(['480p', '720p']);
+    expect(p.capabilities.supportedResolutions).not.toContain('1080p');
+  });
+
+  it('时长覆盖 4–30 的每个整数秒,边界内含 4 与 30、外侧不含 3 与 31', () => {
+    const d = p.capabilities.supportedDurations;
+    expect(d).toHaveLength(27);
+    expect(d).toContain(4);
+    expect(d).toContain(30);
+    expect(d).not.toContain(3);
+    expect(d).not.toContain(31);
+  });
+
+  /**
+   * `adaptive` 只当默认值,**不进 supportedRatios**。
+   *
+   * 两件事:
+   *   - 它必须是 `defaults.ratio` —— 执行器不接受"不指定"(run.ts 把缺省项回落成
+   *     defaults 再摊进请求体),"不指定画幅"这个语义只能由一个具体默认值表达。
+   *   - 它不能进 supportedRatios —— 协议层 GHOST_VIDEO_RATIOS 是闭集、不含它,
+   *     插件显式传会先被 cindySlot 粗筛拒掉("未知视频画幅"),列进来等于公布一个
+   *     永远到不了 provider 的值。合法组合:assertParamSupported 在 value 为
+   *     undefined 时直接 return(run.ts),压根不校验 defaults。
+   */
+  it('adaptive 是默认值但不在 supportedRatios 里(公布了插件也传不进来)', () => {
+    expect(p.capabilities.defaults.ratio).toBe('adaptive');
+    expect(p.capabilities.supportedRatios).not.toContain('adaptive');
+    expect(p.capabilities.supportedRatios).toEqual([
+      '16:9',
+      '9:16',
+      '1:1',
+      '4:3',
+      '3:4',
+    ]);
+  });
+
+  it('有音频开关,上游默认出声(同 2.0 的原生音画同生)', () => {
+    expect(p.capabilities.supportsAudio).toBe(true);
+    expect(p.capabilities.audioDefault).toBe(true);
+  });
+});
+
+describe('seedance 2.5 · submit body shape', () => {
+  it('model 用网关映射名,URL 与 2.0 同一个 endpoint', async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init: init ?? {} });
+      return new Response(JSON.stringify({ id: 'cgt-25-1' }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const handle = await makeProvider(fetchMock).submit(
+      { prompt: '海浪拍打礁石', duration: 8, resolution: '720p' },
+      'bytedance/seedance-2.5',
+    );
+    expect(handle.providerId).toBe('seedance-2.5');
+    expect(handle.taskId).toBe('cgt-25-1');
+    expect(handle.modelUsed).toBe(MODEL);
+    expect(calls[0].url).toBe(SUBMIT_URL);
+    const headers = calls[0].init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer test-key');
+    expect(JSON.parse(calls[0].init.body as string).model).toBe(MODEL);
+  });
+
+  it('**不写 --fps**:方舟弱校验后缀白名单里没有 fps 这一项', async () => {
+    const text = await promptTextOf({
+      prompt: '一只猫打哈欠',
+      duration: 6,
+      resolution: '720p',
+      // 执行器一定会把 fps 补进请求(run.ts 无条件回落 defaults),所以这里
+      // 显式传一个值,验证 provider 拿到了也不往后缀里写。
+      fps: 24,
+    });
+    expect(text).not.toContain('--fps');
+    expect(text).toBe('一只猫打哈欠 --duration 6 --resolution 720p');
+  });
+
+  it('省略 ratio → 回落 adaptive → 不写 --ratio(这是 adaptive 唯一的到达路径)', async () => {
+    const omitted = await promptTextOf({ prompt: 'p', duration: 5, resolution: '720p' });
+    expect(omitted).not.toContain('--ratio');
+    expect(omitted).toBe('p --duration 5 --resolution 720p');
+  });
+
+  it('provider 内部收到 adaptive 也不写 --ratio(defaults 之外没别的来路,兜底同形)', async () => {
+    // 这条走的是 provider 直调,不经 cindySlot 粗筛 —— 插件路径上
+    // `ratio: 'adaptive'` 会被协议层先拒(GHOST_VIDEO_RATIOS 闭集不含它),
+    // 所以生产里这个值只可能来自 defaults 回落。这里钉的是"万一从别处来也同形"。
+    const explicit = await promptTextOf({
+      prompt: 'p',
+      duration: 5,
+      resolution: '720p',
+      ratio: 'adaptive',
+    });
+    expect(explicit).not.toContain('--ratio');
+    expect(explicit).toBe('p --duration 5 --resolution 720p');
+  });
+
+  it('给了具体画幅就原样透传 —— 文生视频', async () => {
+    const text = await promptTextOf({
+      prompt: 'p',
+      duration: 5,
+      resolution: '720p',
+      ratio: '16:9',
+    });
+    expect(text).toBe('p --duration 5 --resolution 720p --ratio 16:9');
+  });
+
+  it('给了具体画幅就原样透传 —— 首帧/首尾帧场景**照样不拦**(passthrough,由上游裁决)', async () => {
+    // 文档说 2.5 的首帧/首尾帧"默认且仅支持 adaptive",但主机不替上游立规矩:
+    // 照写用户给的比例,忽略或报错都由方舟决定,错误原样透传。
+    for (const images of [
+      ['data:image/png;base64,ONE'],
+      ['data:image/png;base64,ONE', 'data:image/png;base64,TWO'],
+    ]) {
+      const text = await promptTextOf({
+        prompt: 'p',
+        duration: 5,
+        resolution: '720p',
+        ratio: '9:16',
+        images,
+      });
+      expect(text, `images=${images.length}`).toContain('--ratio 9:16');
+    }
+  });
+
+  it('给了具体画幅就原样透传 —— reference_image 模式', async () => {
+    const text = await promptTextOf({
+      prompt: '[图片1] 的猫',
+      duration: 5,
+      resolution: '720p',
+      ratio: '4:3',
+      refMode: 'reference_image',
+      images: ['data:image/png;base64,ONE'],
+    });
+    expect(text).toContain('--ratio 4:3');
+  });
+
+  it('时长 30 秒放行,有参考图时同样放行(ratio 的 adaptive 规则不牵连时长)', async () => {
+    const textOnly = await promptTextOf({ prompt: 'p', duration: 30, resolution: '720p' });
+    expect(textOnly).toContain('--duration 30');
+
+    const withImage = await promptTextOf({
+      prompt: 'p',
+      duration: 30,
+      resolution: '720p',
+      images: ['data:image/png;base64,ONE'],
+    });
+    expect(withImage).toContain('--duration 30');
+  });
+
+  it('音频开关走顶层 generate_audio,三态(不传就不写这个键)', async () => {
+    const { fetchMock, bodyOf } = makeSubmitMock();
+    const p = makeProvider(fetchMock);
+    await p.submit({ prompt: 'p', duration: 5 }, 'bytedance/seedance-2.5');
+    expect('generate_audio' in bodyOf(0)).toBe(false);
+
+    for (const [i, audio] of [true, false].entries()) {
+      await p.submit({ prompt: 'p', duration: 5, audio }, 'bytedance/seedance-2.5');
+      const body = bodyOf(i + 1);
+      expect(body.generate_audio, `audio=${audio}`).toBe(audio);
+      expect(body.content[0].text as string).not.toContain('audio');
+    }
+  });
+
+  it('参考图 role 与 2.0 同源:首尾帧分 first_frame / last_frame,参考图模式全 reference_image', async () => {
+    const { fetchMock, bodyOf } = makeSubmitMock();
+    const p = makeProvider(fetchMock);
+
+    await p.submit(
+      { prompt: 'p', images: ['data:image/png;base64,A', 'data:image/png;base64,B'] },
+      'bytedance/seedance-2.5',
+    );
+    expect(bodyOf(0).content[1].role).toBe('first_frame');
+    expect(bodyOf(0).content[2].role).toBe('last_frame');
+
+    await p.submit(
+      {
+        prompt: 'p',
+        refMode: 'reference_image',
+        images: ['data:image/png;base64,A', 'data:image/png;base64,B'],
+      },
+      'bytedance/seedance-2.5',
+    );
+    expect(bodyOf(1).content.slice(1).map((c) => c.role)).toEqual([
+      'reference_image',
+      'reference_image',
+    ]);
+  });
+
+  it('未知 alias 提交前就拒,话术带本 provider 的名字', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response('{}', { status: 200 }),
+    ) as unknown as typeof fetch;
+    const p = makeProvider(fetchMock);
+    await expect(p.submit({ prompt: 'x' }, 'seedance-fast')).rejects.toThrow(
+      /seedance-2\.5: unknown alias/,
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('seedance 2.5 · poll / 错误话术', () => {
+  const handle = {
+    providerId: 'seedance-2.5',
+    taskId: 'cgt-25-X',
+    modelUsed: MODEL,
+    submittedAt: 0,
+  };
+
+  it('succeeded → 带 video_url 与上游上报的 meta', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          id: 'cgt-25-X',
+          status: 'succeeded',
+          content: { video_url: 'https://tos.example/v25.mp4' },
+          duration: 30,
+          resolution: '720p',
+          ratio: '9:16',
+          framespersecond: 24,
+        }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+    const status = await makeProvider(fetchMock).poll(handle);
+    expect(status.state).toBe('succeeded');
+    if (status.state === 'succeeded') {
+      expect(status.videoUrl).toBe('https://tos.example/v25.mp4');
+      expect(status.meta).toMatchObject({ durationSec: 30, resolution: '720p', ratio: '9:16' });
+    }
+  });
+
+  it('succeeded 但没有 video_url → failed,话术带 provider 名', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({ id: 'cgt-25-X', status: 'succeeded', content: {} }),
+        { status: 200 },
+      ),
+    ) as unknown as typeof fetch;
+    const status = await makeProvider(fetchMock).poll(handle);
+    expect(status.state).toBe('failed');
+    if (status.state === 'failed') {
+      expect(status.error).toContain('seedance-2.5');
+    }
+  });
+
+  it('failed 且上游没给 message → 兜底话术带 provider 名', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify({ id: 'cgt-25-X', status: 'failed' }), { status: 200 }),
+    ) as unknown as typeof fetch;
+    const status = await makeProvider(fetchMock).poll(handle);
+    expect(status.state).toBe('failed');
+    if (status.state === 'failed') {
+      expect(status.error).toContain('seedance-2.5 task failed');
+    }
+  });
+});
+
+describe('seedance 2.5 · 经执行器端到端', () => {
+  function makeRegistry(fetchMock: typeof fetch): VideoProviderRegistry {
+    const r = new VideoProviderRegistry();
+    r.register(makeProvider(fetchMock));
+    return r;
+  }
+
+  it('1080p 在提交前就被明拒,一个请求都不发(话术自带该型号可用值)', async () => {
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    await expect(
+      submitAndAwaitVideo(makeRegistry(fetchMock), {
+        alias: 'bytedance/seedance-2.5',
+        prompt: 'p',
+        resolution: '1080p',
+      }),
+    ).rejects.toThrow(/does not support resolution 1080p/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('时长 30 秒走得通,而 31 秒被拒(4–30 的边界在执行器上生效)', async () => {
+    const fetchMock = vi.fn() as unknown as typeof fetch;
+    await expect(
+      submitAndAwaitVideo(makeRegistry(fetchMock), {
+        alias: 'bytedance/seedance-2.5',
+        prompt: 'p',
+        duration: 31,
+      }),
+    ).rejects.toThrow(/does not support duration 31/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('不传画面参数 → adaptive 落进请求(不写 --ratio)、回执报 adaptive', async () => {
+    const bodies: string[] = [];
+    const fetchMock = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        bodies.push(init.body as string);
+        return new Response(JSON.stringify({ id: 'cgt-25-E2E' }), { status: 200 });
+      }
+      if (url.endsWith('/cgt-25-E2E')) {
+        // 上游只报 status + video_url(不报 ratio),回执就得回落我们的提交值。
+        return new Response(
+          JSON.stringify({
+            id: 'cgt-25-E2E',
+            status: 'succeeded',
+            content: { video_url: 'https://tos.example/e2e.mp4' },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response(new Uint8Array([1, 2, 3]), {
+        status: 200,
+        headers: { 'content-type': 'video/mp4' },
+      });
+    }) as unknown as typeof fetch;
+
+    const r = await submitAndAwaitVideo(makeRegistry(fetchMock), {
+      alias: 'bytedance/seedance-2.5',
+      prompt: '雨中的城市',
+    });
+
+    const text = JSON.parse(bodies[0]).content[0].text as string;
+    expect(text).toBe('雨中的城市 --duration 5 --resolution 720p');
+    expect(r.modelUsed).toBe(MODEL);
+    expect(r.effectiveParams).toMatchObject({
+      duration: 5,
+      resolution: '720p',
+      ratio: 'adaptive',
+      audio: true,
+    });
+  });
+});
+
+/**
+ * 两代值域**互不放宽**——本 PR 的核心不变量,也是唯一能证明"拆 provider 拆对了"
+ * 的测试。
+ *
+ * 上面那些 case 只注册 2.5 一个 provider,证明的是"2.5 自己的值域对"。但两代共用
+ * 一份 capabilities 的真实危害是**双向污染**:2.0 的窄值域会卡死 2.5 的长片,2.5
+ * 的宽值域又会替 2.0 放宽。所以这里按真实装配同时注册两代,拿同一个执行器、同一
+ * 组参数正反各打一次 —— 一份 capabilities 的实现下,这四条里必然有两条会翻。
+ */
+describe('两代值域互不放宽(同一执行器下的隔离)', () => {
+  /** 按 cindyProxyMedia.ts 的真实装配顺序注册两代。 */
+  function makeBothRegistry(fetchImplementation: typeof fetch): VideoProviderRegistry {
+    const stub = { baseUrl: BASE_URL, getApiKey: () => 'k', fetchImplementation };
+    const r = new VideoProviderRegistry();
+    r.register(createSeedanceProvider(stub));
+    r.register(createSeedance25Provider(stub));
+    return r;
+  }
+
+  /**
+   * 拿到该型号的拒绝话术;没被拒就返回 `'(未拒)'`。
+   *
+   * 值域校验(assertParamSupported)发生在任何 fetch 之前,所以桩只需要证明
+   * "被拒的那一侧一个请求都没发";放行的那一侧会走到提交,让桩抛一个可辨认的
+   * 错误收尾 —— 断言只看话术里有没有值域字样,不会跟它混。
+   */
+  async function rejection(
+    alias: string,
+    params: { duration?: number; resolution?: string },
+  ): Promise<{ message: string; fetched: boolean }> {
+    const fetchMock = vi.fn(async () => {
+      throw new Error('__submitted__');
+    }) as unknown as typeof fetch;
+    try {
+      await submitAndAwaitVideo(makeBothRegistry(fetchMock), {
+        alias,
+        prompt: 'p',
+        ...params,
+      });
+      return { message: '(未拒)', fetched: true };
+    } catch (e) {
+      return {
+        message: (e as Error).message,
+        fetched: (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls.length > 0,
+      };
+    }
+  }
+
+  it('时长 30:2.5 放行,2.0 明拒(2.5 的宽值域没有替 2.0 放宽)', async () => {
+    // 2.0 必须报"不支持 duration 30",且一个请求都不发。它放行 = 2.5 的 4–30
+    // 漏进了 2.0 的 capabilities,2.0 的单子会一路发到上游才被拒。
+    const v20 = await rejection('seedance-fast', { duration: 30 });
+    expect(v20.message).toMatch(/does not support duration 30/);
+    expect(v20.fetched).toBe(false);
+
+    // 2.5 侧不该在**校验**这一关被拦(拦了就是 2.0 的窄值域卡住了 2.5 的长片)。
+    // 它应当走到提交 —— fetched 为真就是证据。
+    const v25 = await rejection('bytedance/seedance-2.5', { duration: 30 });
+    expect(v25.message).not.toMatch(/does not support duration/);
+    expect(v25.fetched).toBe(true);
+  });
+
+  it('1080p:2.0 放行,2.5 明拒(2.0 的三档没有漏给 2.5)', async () => {
+    const v25 = await rejection('bytedance/seedance-2.5', { resolution: '1080p' });
+    expect(v25.message).toMatch(/does not support resolution 1080p/);
+    expect(v25.fetched).toBe(false);
+
+    const v20 = await rejection('seedance-fast', { resolution: '1080p' });
+    expect(v20.message).not.toMatch(/does not support resolution/);
+    expect(v20.fetched).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/cindy-proxy-media/video/__tests__/seedanceProvider.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/__tests__/seedanceProvider.test.ts
@@ -32,13 +32,23 @@ describe('seedance provider · capabilities', () => {
       true,
     );
   });
-  it('exposes the catalog Seedance 2.5 id as an explicit opt-in model', () => {
-    expect(
-      p.capabilities.modelAliases.find((a) => a.alias === 'bytedance/seedance-2.5'),
-    ).toMatchObject({
-      internalModel: 'doubao-seedance-2-5-260628',
-    });
-    expect(p.capabilities.expectedSecondsByAlias['bytedance/seedance-2.5']).toBe(300);
+  /**
+   * 反向不变量:2.0 provider **不得**承载 2.5 的 alias。
+   *
+   * capabilities 是 per-provider 而非 per-alias(run.ts 与 cindy-brain 的
+   * getGhostVideoCapabilities 取的都是 `provider.capabilities`),所以把 2.5 挂成
+   * 这里的第三个 alias 会让它整份继承下面这些 2.0 的值域 —— 时长被卡在
+   * 4/6/8/10(2.5 的 4–30 长片一律明拒)、1080p 被放行(2.5 只到 720p)、
+   * 画幅没有 adaptive、后缀串还照 2.0 写 `--fps`。反向同样成立:2.5 的宽值域
+   * 挤进来就替 2.0 放宽了。2.5 归 createSeedance25Provider,见
+   * seedance25Provider.test.ts。
+   */
+  it('不承载 2.5:2.0 的 capabilities 里只有 2.0 的档位', () => {
+    expect(p.capabilities.modelAliases.map((a) => a.alias)).toEqual([
+      'seedance-fast',
+      'seedance-pro',
+    ]);
+    expect(p.capabilities.expectedSecondsByAlias['bytedance/seedance-2.5']).toBeUndefined();
   });
   it('首尾帧模式上限 2 张,参考图模式 9 张(同一个 2.0 模型的两种 role)', () => {
     expect(p.capabilities.maxImagesByRefMode).toEqual({
@@ -161,19 +171,17 @@ describe('seedance provider · submit body shape', () => {
     expect(body.content[2].role).toBe('last_frame');
   });
 
-  it('Seedance 2.5: translates the catalog id to the Volcengine model id', async () => {
+  it('2.5 的 alias 在 2.0 provider 上提交前就被拒,一个请求都不发', async () => {
+    // 走错 provider 时必须早拒。放行的话 2.5 的单子就会带着 2.0 的值域上路
+    // (--fps、无 adaptive、时长卡 4/6/8/10),错误要到上游才暴露。
     const fetchMock = vi.fn(async () =>
       new Response(JSON.stringify({ id: 'cgt-FAKE-25' }), { status: 200 }),
     ) as unknown as typeof fetch;
     const p = makeProvider(fetchMock);
-    const handle = await p.submit(
-      { prompt: '一只猫在雨里奔跑' },
-      'bytedance/seedance-2.5',
-    );
-    const init = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit;
-    const body = JSON.parse(init.body as string);
-    expect(body.model).toBe('doubao-seedance-2-5-260628');
-    expect(handle.modelUsed).toBe('doubao-seedance-2-5-260628');
+    await expect(
+      p.submit({ prompt: '一只猫在雨里奔跑' }, 'bytedance/seedance-2.5'),
+    ).rejects.toThrow(/unknown alias/);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('refMode:reference_image → 每张图都是 role:reference_image,顺序原样保留', async () => {

--- a/apps/desktop/src/main/cindy-proxy-media/video/__tests__/videoModelsSync.test.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/__tests__/videoModelsSync.test.ts
@@ -13,18 +13,25 @@ import { describe, expect, it } from 'vitest';
 
 import {
   GHOST_VIDEO_MAX_SOURCES_BY_REF_MODE,
+  GHOST_VIDEO_RATIOS,
   GHOST_VIDEO_REF_MODES,
 } from '../../../../shared/ghost.js';
 import { GATEWAY_VIDEO_MODELS } from '../../types.js';
 import { VideoProviderRegistry } from '../registry.js';
-import { createSeedanceProvider } from '../providers/seedance.js';
+import {
+  createSeedance25Provider,
+  createSeedanceProvider,
+} from '../providers/seedance.js';
 import { createHappyhorseProvider } from '../providers/happyhorse.js';
 
 function buildRealRegistry(): VideoProviderRegistry {
-  // 与 desktop art.ts 同一装配顺序(seedance 先注册,seedance-fast 是全局默认)。
+  // 与 desktop mcp-integrations/cindyProxyMedia.ts 同一装配顺序(seedance 先注册,
+  // seedance-fast 是全局默认)。这份 fixture 必须跟着真实装配走 —— 它就是本文件
+  // 那几条同源守卫的被测对象。
   const registry = new VideoProviderRegistry();
   const stub = { baseUrl: 'https://example.invalid', getApiKey: () => null };
   registry.register(createSeedanceProvider(stub));
+  registry.register(createSeedance25Provider(stub));
   registry.register(createHappyhorseProvider(stub));
   return registry;
 }
@@ -87,6 +94,42 @@ describe('参考图张数上界 ↔ provider capabilities 同源', () => {
     const union = registry.collectUnionParams().maxImagesUpperBoundByRefMode;
     for (const mode of Object.keys(union)) {
       expect(known.has(mode), `provider 声明了协议层没有的 refMode '${mode}'`).toBe(true);
+    }
+  });
+});
+
+/**
+ * 同源守卫之三:`supportedRatios` 与协议层 `GHOST_VIDEO_RATIOS`(同 refMode 那条
+ * 一样的双源困境:`shared/` 不能依赖 `main/`)。
+ *
+ * **公布了但传不进来的值,等于没有。** cindySlot 校验 ratio 分两层:先用协议层
+ * 的闭集 GHOST_VIDEO_RATIOS 粗筛,再按型号拿 capabilities.supportedRatios 细筛。
+ * 粗筛在前,所以 provider 往 supportedRatios 里塞一个协议层没有的值时,插件按
+ * capabilities 显式提交只会撞上"未知视频画幅"——而那句话术报的还是协议层那几档,
+ * 根本不提该型号多出来的那个值。上游支持不等于这里能列(2.5 的 `adaptive` 与
+ * `21:9` 都属此类:前者只当 defaults.ratio,后者干脆不接)。
+ *
+ * **`defaults.ratio` 刻意不受这条约束**:它不是"可显式提交的值",而是"调用方
+ * 省略时用什么"的载体,走的是 run.ts 的回落分支(assertParamSupported 遇
+ * undefined 直接 return,压根不校验 defaults)。2.5 正是靠这个区分让
+ * "省略 ratio = 上游自适应"畅通,同时不公布一个假承诺。
+ */
+describe('画幅值域 ↔ 协议层枚举同源', () => {
+  it('每个 alias 报出的画幅都在协议层枚举内(公布了插件也传不进来)', () => {
+    const registry = buildRealRegistry();
+    const known = new Set<string>(GHOST_VIDEO_RATIOS);
+    // 按 alias 遍历而不是按 provider:这正是插件的视角 —— cindySlot 拿到型号名后
+    // 经 getGhostVideoCapabilities 解析出的就是该 alias 背后 provider 的 caps。
+    for (const { alias } of registry.collectAllAliases()) {
+      const caps = registry.resolveByAlias(alias).provider.capabilities;
+      for (const ratio of caps.supportedRatios) {
+        expect(
+          known.has(ratio),
+          `型号 '${alias}' 公布了协议层没有的画幅 '${ratio}':插件按 capabilities ` +
+            `显式提交会被 cindySlot 粗筛拒掉,而话术报的还是协议层那几档。` +
+            `只想当默认值就放 defaults.ratio,别放 supportedRatios。`,
+        ).toBe(true);
+      }
     }
   });
 });

--- a/apps/desktop/src/main/cindy-proxy-media/video/providers/seedance.ts
+++ b/apps/desktop/src/main/cindy-proxy-media/video/providers/seedance.ts
@@ -1,14 +1,27 @@
 /**
  * art/video/providers/seedance.ts
  * ---------------------------------------------------------------------------
- * VideoProvider implementation for Volcengine ARK Doubao Seedance 2.x models,
- * routed through XD Gateway's `/volcengine/api/v3/contents/generations/tasks`
- * passthrough.
+ * VideoProvider implementations for Volcengine ARK Seedance, routed through XD
+ * Gateway's `/volcengine/api/v3/contents/generations/tasks` passthrough.
  *
- * Three model choices exposed:
- *   - 'seedance-fast' → doubao-seedance-2-0-fast-260128 (≈2min, default)
- *   - 'seedance-pro'  → doubao-seedance-2-0-260128       (≈5min, quality tier)
- *   - 'bytedance/seedance-2.5' → doubao-seedance-2-5-260628 (explicit opt-in)
+ * 两代模型 = 两个**独立 provider**,不是同一个 provider 的多个 alias:
+ *   - `createSeedanceProvider`   → Seedance 2.0
+ *       'seedance-fast' → doubao-seedance-2-0-fast-260128 (≈2min, default)
+ *       'seedance-pro'  → doubao-seedance-2-0-260128       (≈5min, quality tier)
+ *   - `createSeedance25Provider` → Seedance 2.5
+ *       'bytedance/seedance-2.5' → bytedance/seedance-2.5  (需显式点名)
+ *
+ * **为什么两代不能共用一个 provider**:`VideoProviderCapabilities` 挂在 provider
+ * 上,执行器(run.ts)与主机侧的按型号校验(cindy-brain 的
+ * getGhostVideoCapabilities)取的都是 `provider.capabilities` —— 是 per-provider
+ * 而不是 per-alias。所以把 2.5 挂成 2.0 的第三个 alias 时,它会**整份继承 2.0 的
+ * 值域**,而两代的值域差得很远,四个后果都是真的:
+ *   - 时长被 2.0 的 [4,6,8,10] 卡住,2.5 的 4–30 长片一律明拒;
+ *   - 1080p 被放行,而 2.5 只出到 720p,等于放过一个必然被上游拒的值;
+ *   - 画幅没有 `adaptive`,首帧/首尾帧单子只能带着具体 `--ratio` 提交;
+ *   - 后缀串照 2.0 的口径写 `--fps`,而方舟弱校验白名单里压根没有这一项。
+ * 反向也成立:2.5 的宽值域挤进同一份 capabilities 就会替 2.0 放宽(2.0 收到
+ * `duration: 30` 会一路发到上游才被拒)。两代互相放宽 = 按型号校验形同虚设。
  *
  * API quirks worth knowing:
  *   - Submit body uses Volcengine's chat-style `content` array:
@@ -19,6 +32,9 @@
  *     fields — they have to be appended as `--key value` flag suffixes inside
  *     the text content node. This provider does that translation so the LLM
  *     never has to construct flag strings.
+ *     **两代的后缀集合不同**:2.0 分支照旧写 `--fps`(存量行为,方舟其实没有这个
+ *     参数,改它会动已出片的产出口径,单独评估);2.5 分支不写。差异的出处见
+ *     buildSeedance25PromptText。
  *   - Poll returns the final mp4 as a 24h-signed TOS URL in `content.video_url`;
  *     download has no extra auth, plain GET.
  */
@@ -68,11 +84,8 @@ const CAPABILITIES: VideoProviderCapabilities = {
       summary: '精(~5min) - 用户显式要"高质量"再选',
       internalModel: 'doubao-seedance-2-0-260128',
     },
-    {
-      alias: 'bytedance/seedance-2.5',
-      summary: 'Seedance 2.5(~5min) - 用户显式点名 2.5 再选',
-      internalModel: 'doubao-seedance-2-5-260628',
-    },
+    // 这里**只放 2.0 的档位**。2.5 归 CAPABILITIES_25,理由见文件头:
+    // capabilities 是 per-provider,2.5 挂进来就会整份继承下面这些 2.0 的值域。
   ],
   supportedDurations: [4, 6, 8, 10],
   supportedResolutions: ['480p', '720p', '1080p'],
@@ -96,12 +109,75 @@ const CAPABILITIES: VideoProviderCapabilities = {
   expectedSecondsByAlias: {
     'seedance-fast': 120,
     'seedance-pro': 300,
-    'bytedance/seedance-2.5': 300,
   },
   defaults: {
     duration: 4,
     resolution: '720p',
     ratio: '16:9',
+    fps: 24,
+  },
+};
+
+/** 4–30 的每个整数秒。方舟 2.5 的 duration 取值范围是 `[4, 30]`。 */
+const SEEDANCE_25_DURATIONS: ReadonlyArray<number> = Array.from(
+  { length: 27 },
+  (_, i) => i + 4,
+);
+
+/**
+ * Seedance 2.5。与 2.0 的差异都在这份常量里,逐项都有出处:
+ *   - 时长放宽到 4–30(2.0 只有 4/6/8/10)。**不支持 `-1`**(上游的"智能选时长"):
+ *     协议层 cindySlot 用 isPositiveIntWithin 收口,负数进不来,而 -1 主要服务于
+ *     本次没接的视频编辑任务。
+ *   - **没有 1080p**。2.5 只出 480p / 720p,所以这里不能照抄 2.0 的三档 ——
+ *     抄了就会放行一个必然被上游拒的分辨率。
+ *   - **`adaptive` 只当默认值,不进 `supportedRatios`**。它是 2.5 的上游默认
+ *     (输出跟随输入自适应),但协议层的 GHOST_VIDEO_RATIOS 是闭集、不含它,
+ *     插件显式传会先被 cindySlot 的粗筛拒掉("未知视频画幅")。所以列进
+ *     supportedRatios 只会公布一个**永远到不了 provider 的值**,而错误话术还报的
+ *     是协议层那五档 —— 与下面 `21:9` 不列是同一条规则。
+ *     它仍必须是 `defaults.ratio`:执行器不接受"不指定" —— run.ts 会把缺省项
+ *     回落成 defaults 再摊进请求体,"不指定画幅"这个语义只能由一个具体默认值
+ *     来表达。**省略 ratio = 走 adaptive**,这条路径畅通,也是图生视频想要的。
+ *   - `21:9` 上游支持但这里不列:协议层 GHOST_VIDEO_RATIOS 没有它,插件传不进来,
+ *     列进来只会让错误话术出现一个拿不到的值。
+ *   - 参考图上限仍按 9(上游到 30)。提上限要同步抬协议层的
+ *     GHOST_VIDEO_MAX_SOURCES_BY_REF_MODE,不在本次范围。
+ */
+const CAPABILITIES_25: VideoProviderCapabilities = {
+  modelAliases: [
+    {
+      // alias 与 catalog id 同串,且与 Art 插件 mapVideoModel 的输出逐字一致
+      // (cindy-official-plugins#82 已上线):插件把用户说的 2.5 翻成这个串发来,
+      // 主机白名单(cindySlot 的 whitelist.has)按它命中。改名就是断插件。
+      alias: 'bytedance/seedance-2.5',
+      summary: '2.5(有声,最长 30s) - 用户显式点名再选',
+      // 与 alias 同串是巧合而非冗余:这里要的是**网关映射名**,不是方舟原生
+      // model id(doubao-seedance-2-5-*)。XD Gateway 收下这个 LiteLLM 风格的串
+      // 再自己翻译到方舟。endpoint 与请求体形状仍是方舟那套。
+      internalModel: 'bytedance/seedance-2.5',
+    },
+  ],
+  supportedDurations: SEEDANCE_25_DURATIONS,
+  supportedResolutions: ['480p', '720p'],
+  supportedRatios: ['16:9', '9:16', '1:1', '4:3', '3:4'],
+  supportedFps: [24],
+  maxImagesByRefMode: {
+    first_and_last_frame: 2,
+    reference_image: 9,
+  },
+  // 同 2.0:原生音画同生,顶层 generate_audio,上游默认出声。
+  supportsAudio: true,
+  audioDefault: true,
+  // 估值,未实测。它 × 3 就是执行器的轮询超时(run.ts),30s 长片可能更慢,
+  // 实测后按真实耗时回填。
+  expectedSecondsByAlias: {
+    'bytedance/seedance-2.5': 360,
+  },
+  defaults: {
+    duration: 5,
+    resolution: '720p',
+    ratio: 'adaptive',
     fps: 24,
   },
 };
@@ -135,6 +211,35 @@ function buildSeedancePromptText(req: VideoGenerationRequest): string {
   return `${req.prompt} ${flags.join(' ')}`;
 }
 
+/**
+ * 2.5 的后缀串。与 2.0 差两处,都是刻意的:
+ *
+ *   1. **不写 `--fps`**。方舟的弱校验后缀白名单是 resolution / ratio / duration /
+ *      frames / seed / camera_fixed / watermark —— 压根没有 fps 这一项。
+ *      capabilities 里仍声明 `[24]`,那是给回执用的(方舟视频固定 24fps:
+ *      官方的帧数公式就是"时长 × 24"),不代表请求里该写这个野生 flag。
+ *      注:2.0 分支照旧写 `--fps`,那是存量行为,改它会动已出片的产出口径,
+ *      单独评估。
+ *   2. **`adaptive` 不写 `--ratio`**。adaptive 本身就是上游默认(自适应输入),
+ *      写成 `--ratio adaptive` 反而是往弱校验里塞一个非枚举值。
+ *      这个分支只会由 `CAPABILITIES_25.defaults.ratio` 触发(调用方省略了 ratio)——
+ *      `adaptive` 不在 supportedRatios 里,显式传进不来,理由见 CAPABILITIES_25。
+ *
+ * 画幅给了具体比例时**原样透传**,不按 refMode 拦。文档说 2.5 的首帧/首尾帧
+ * 场景"默认且仅支持 adaptive",但这里遵循与参考图上限同一条口径:由上游在提交期
+ * 裁决(忽略或报错),错误原样透传给调用方,主机不替上游立规矩。
+ */
+function buildSeedance25PromptText(req: VideoGenerationRequest): string {
+  const flags: string[] = [];
+  const d = req.duration ?? CAPABILITIES_25.defaults.duration;
+  const r = req.resolution ?? CAPABILITIES_25.defaults.resolution;
+  const ar = req.ratio ?? CAPABILITIES_25.defaults.ratio;
+  flags.push(`--duration ${d}`);
+  flags.push(`--resolution ${r}`);
+  if (ar !== 'adaptive') flags.push(`--ratio ${ar}`);
+  return `${req.prompt} ${flags.join(' ')}`;
+}
+
 interface SeedanceContentItem {
   type: 'text' | 'image_url';
   text?: string;
@@ -149,10 +254,16 @@ interface SeedanceContentItem {
  *     「图片1 / 图片2 / …」序号,所以**不能重排**。
  * 两种 role 不混用:方舟文档只是并列列出,没说能否共存,混发等于赌未定义
  * 行为。
+ *
+ * 两代共用这一份:content 的形状(text 节点 + 带 role 的 image_url 节点)两代
+ * 完全一致,只有 text 里的后缀串不同,所以后缀构造由 `buildText` 注入。
  */
-function buildSeedanceContent(req: VideoGenerationRequest): SeedanceContentItem[] {
+function buildSeedanceContent(
+  req: VideoGenerationRequest,
+  buildText: (req: VideoGenerationRequest) => string,
+): SeedanceContentItem[] {
   const content: SeedanceContentItem[] = [
-    { type: 'text', text: buildSeedancePromptText(req) },
+    { type: 'text', text: buildText(req) },
   ];
   const images = req.images ?? [];
   if (req.refMode === 'reference_image') {
@@ -182,13 +293,43 @@ function buildSeedanceContent(req: VideoGenerationRequest): SeedanceContentItem[
   return content;
 }
 
-export function createSeedanceProvider(
+/** 一代 Seedance 的全部代次差异。骨架(submit/poll/download)按它参数化。 */
+interface SeedanceVariant {
+  /** VideoProvider.id,同时也是错误话术前缀与 VideoTaskHandle.providerId。 */
+  id: string;
+  capabilities: VideoProviderCapabilities;
+  buildPromptText: (req: VideoGenerationRequest) => string;
+}
+
+const VARIANT_20: SeedanceVariant = {
+  id: 'seedance',
+  capabilities: CAPABILITIES,
+  buildPromptText: buildSeedancePromptText,
+};
+
+// provider.id 刻意**不等于** alias(同 2.0 的 `seedance` 也不是任何 alias):
+// alias 是对外契约(插件按它点名),id 是内部标识 + 错误话术前缀,让话术保持
+// `seedance-2.5 task failed` 而不是带上网关前缀。
+const VARIANT_25: SeedanceVariant = {
+  id: 'seedance-2.5',
+  capabilities: CAPABILITIES_25,
+  buildPromptText: buildSeedance25PromptText,
+};
+
+/**
+ * 共享骨架。两代打的是同一个方舟接口(同 endpoint、同请求体形状、同轮询响应),
+ * 所以状态映射、下载与错误处理都在这里单源 —— 上游哪天改了轮询字段,改一处
+ * 两代都跟上。
+ */
+function createArkSeedanceProvider(
+  variant: SeedanceVariant,
   opts: CreateSeedanceProviderOptions,
 ): VideoProvider {
   const submitPath = opts.submitPath ?? DEFAULT_SUBMIT_PATH;
   const pollTemplate = opts.pollPathTemplate ?? DEFAULT_POLL_TEMPLATE;
   const submitUrl = joinProxyUrl(opts.baseUrl, submitPath);
   const doFetch = opts.fetchImplementation ?? fetch;
+  const caps = variant.capabilities;
 
   function pollUrl(taskId: string): string {
     const path = pollTemplate.replace('{id}', encodeURIComponent(taskId));
@@ -200,19 +341,19 @@ export function createSeedanceProvider(
     alias: string,
     signal?: AbortSignal,
   ): Promise<VideoTaskHandle> {
-    const aliasInfo = CAPABILITIES.modelAliases.find((a) => a.alias === alias);
+    const aliasInfo = caps.modelAliases.find((a) => a.alias === alias);
     if (!aliasInfo) {
       throw new GatewayHttpError(
-        `seedance: unknown alias '${alias}'`,
+        `${variant.id}: unknown alias '${alias}'`,
         400,
       );
     }
     const apiKey = await requireApiKey({ getApiKey: opts.getApiKey });
     const body = {
       model: aliasInfo.internalModel,
-      content: buildSeedanceContent(req),
+      content: buildSeedanceContent(req, variant.buildPromptText),
       // 音频开关是请求体**顶层布尔字段**,不是 content 文本里的 `--flag` 后缀
-      // (画面那四项走后缀是 1.0 时代的口径,音频没有对应的后缀写法)。
+      // (画面那几项走后缀是 1.0 时代的口径,音频没有对应的后缀写法)。
       // 三态:调用方没表态就不写这个键,上游按自己的默认(true)出片,与本
       // 字段出现之前的请求体逐字节同形。
       ...(req.audio !== undefined ? { generate_audio: req.audio } : {}),
@@ -229,13 +370,13 @@ export function createSeedanceProvider(
     const parsed = await parseJsonResponse<{ id?: string }>(res, opts.logger);
     if (!parsed.id) {
       throw new GatewayHttpError(
-        'seedance submit response missing id',
+        `${variant.id} submit response missing id`,
         res.status,
         parsed,
       );
     }
     return {
-      providerId: 'seedance',
+      providerId: variant.id,
       taskId: parsed.id,
       modelUsed: aliasInfo.internalModel,
       submittedAt: Date.now(),
@@ -265,7 +406,7 @@ export function createSeedanceProvider(
           state: 'failed',
           error:
             data.error?.message ??
-            `seedance task ${data.status} (no error message)`,
+            `${variant.id} task ${data.status} (no error message)`,
           raw: data,
         };
       case 'succeeded': {
@@ -273,7 +414,7 @@ export function createSeedanceProvider(
         if (!url) {
           return {
             state: 'failed',
-            error: 'seedance reported succeeded but no video_url in content',
+            error: `${variant.id} reported succeeded but no video_url in content`,
             raw: data,
           };
         }
@@ -306,7 +447,7 @@ export function createSeedanceProvider(
     const res = await doFetch(videoUrl, { method: 'GET', signal });
     if (!res.ok) {
       throw new GatewayHttpError(
-        `seedance download failed HTTP ${res.status}`,
+        `${variant.id} download failed HTTP ${res.status}`,
         res.status,
       );
     }
@@ -316,10 +457,24 @@ export function createSeedanceProvider(
   }
 
   return {
-    id: 'seedance',
-    capabilities: CAPABILITIES,
+    id: variant.id,
+    capabilities: caps,
     submit,
     poll,
     download,
   };
+}
+
+/** Seedance 2.0(`seedance-fast` / `seedance-pro`)。出厂默认型号在这一家。 */
+export function createSeedanceProvider(
+  opts: CreateSeedanceProviderOptions,
+): VideoProvider {
+  return createArkSeedanceProvider(VARIANT_20, opts);
+}
+
+/** Seedance 2.5(alias `bytedance/seedance-2.5`)。opt-in,需显式点名。 */
+export function createSeedance25Provider(
+  opts: CreateSeedanceProviderOptions,
+): VideoProvider {
+  return createArkSeedanceProvider(VARIANT_25, opts);
 }

--- a/apps/desktop/src/main/mcp-integrations/cindyProxyMedia.ts
+++ b/apps/desktop/src/main/mcp-integrations/cindyProxyMedia.ts
@@ -1,6 +1,9 @@
 import { createCindyProxyMediaService } from '../cindy-proxy-media/service.js';
 import type { CindyProxyMediaService } from '../cindy-proxy-media/types.js';
-import { createSeedanceProvider } from '../cindy-proxy-media/video/providers/seedance.js';
+import {
+  createSeedance25Provider,
+  createSeedanceProvider,
+} from '../cindy-proxy-media/video/providers/seedance.js';
 import { createHappyhorseProvider } from '../cindy-proxy-media/video/providers/happyhorse.js';
 import { resolveSafe as resolveXdtImage } from '../imageCacheStore.js';
 import {
@@ -58,6 +61,14 @@ export function getCindyProxyMediaService(): CindyProxyMediaService {
     // 只有用户显式点名才切。
     const videoProviders = [
       createSeedanceProvider({
+        baseUrl: getGatewayBaseUrl(),
+        getApiKey: readApiKey,
+        logger: log,
+      }),
+      // Seedance 2.5 是独立 provider(值域与 2.0 差太远,capabilities 是
+      // per-provider 的,详见 seedance.ts 文件头)。同样是 opt-in:排在
+      // seedance-fast 之后,不抢出厂默认。
+      createSeedance25Provider({
         baseUrl: getGatewayBaseUrl(),
         getApiKey: readApiKey,
         logger: log,

--- a/packages/model-providers/src/builtin.ts
+++ b/packages/model-providers/src/builtin.ts
@@ -177,6 +177,8 @@ const XD_PROVIDER: Provider = {
     { id: 'bytedance/seedance-2.5', name: 'Seedance 2.5' },
     { id: 'happyhorse', name: 'HappyHorse 1.0' },
   ],
+  // 2.5 刻意不接管 best:它只到 720p,而 seedance-pro 有 1080p —— 让 tier=best
+  // 指向 2.5 会把"要 1080p"的单子从可用变成明拒。2.5 需显式点名。
   videoDefaults: {
     standard: 'seedance-fast',
     best: 'seedance-pro',


### PR DESCRIPTION
> **本 PR 已改变性质。** 原稿是「新增 2.5 接入」，与 #2084 撞车。#2084 已合并，
> 所以现在改成**在它之上修正 2.5 继承自 2.0 的值域**，并把 2.5 拆成独立 provider。
> 已 rebase 到含 #2084 的 main，alias 沿用它的 `bytedance/seedance-2.5` 不变。

## 改动内容

#2084 把 2.5 挂成 2.0 provider 的第三个 alias。但 `VideoProviderCapabilities` 挂在
**provider** 上 —— 执行器（`run.ts:148`）与主机侧按型号校验（`cindy-brain` 的
`getGhostVideoCapabilities`）取的都是 `provider.capabilities`，是 per-provider 不是
per-alias。所以 2.5 整份继承了 2.0 的值域，四个后果都是真的：

| # | 缺陷 | 用户可见后果 |
|---|---|---|
| 1 | 时长卡在 `[4,6,8,10]` | 2.5 的 4–30 长片一律被主机明拒，话术还报「只支持 4/6/8/10」。**30s 直出这个核心能力用不了** |
| 2 | `1080p` 被放行 | 2.5 只出到 720p。主机放过一个必然被上游拒的值，白等一轮往返 |
| 3 | 画幅没有 `adaptive` | 首帧/首尾帧单子只能带着具体 `--ratio` 提交，而文档说该场景「默认且仅支持 adaptive」 |
| 4 | 照写 `--fps` | 方舟弱校验后缀白名单是 `resolution`/`ratio`/`duration`/`frames`/`seed`/`camera_fixed`/`watermark` —— 没有 `fps` |

反向也成立：2.5 的宽值域挤进同一份 capabilities 就会**替 2.0 放宽**（2.0 收到
`duration: 30` 会一路发到上游才被拒）。两代互相放宽 = 按型号校验形同虚设。

本次把 2.5 迁到独立 provider（`createSeedance25Provider`），值域按 2.5 自己的规格。
`submit`/`poll`/`download` 骨架抽出来两代共用，上游改轮询字段只需改一处。

### alias 不变，internalModel 换成实测过的那个

- **alias 沿用 `bytedance/seedance-2.5`**：与已上线的 Art 插件 `mapVideoModel` 输出
  逐字一致（`cindy-official-plugins#82`），改名就是断插件。
- **`internalModel` 改为 `bytedance/seedance-2.5`**（网关映射名），不再是 #2084 的
  方舟原生 `doubao-seedance-2-5-260628`。这个串**已真机实测出片**；原生 id 绕过网关
  的 LiteLLM 映射层，#2084 的描述也写明「未执行真实 Seedance 2.5 生成请求」。

### `adaptive` 只当默认值，不进 `supportedRatios`

这是 Greptile 在原稿上提的 P1，确实是我错了，已改。

协议层 `GHOST_VIDEO_RATIOS` 是闭集、不含 `adaptive`，插件按 capabilities 显式提交会
先被 `cindySlot.ts:750` 粗筛拒掉（「未知视频画幅(可用:16:9 / 9:16 / 1:1 / 4:3 / 3:4)」）。
列进 `supportedRatios` 等于公布一个**永远到不了 provider 的值** —— 与本文件对 `21:9`
已有的口径本该一致，原稿自相矛盾了。

能力本身没丢：`adaptive` 仍是 `defaults.ratio`，**省略 `ratio` 就走它**（`run.ts:182`
回落 → provider 不写 `--ratio` → 上游自适应）。合法组合的依据是 `run.ts:125`
`if (value === undefined || supported.includes(value)) return;` —— defaults 不过校验。
`forge.ts:1527` 给意识的说明本来就是「四项全可选，不传 = 该型号出厂默认，这也是最省心
的用法」，默认路径是被推荐的那条。

新增同源守卫钉住这条：**每个 alias 报出的画幅都必须在协议层枚举内**
（`videoModelsSync.test.ts`），与已有的 refMode 守卫同构。

### 具体画幅原样透传（Codex P2 的建议，未采纳）

给了具体比例时照写、不按 refMode 拦。文档说 2.5 首帧/首尾帧「默认且仅支持 adaptive」，
但主机不替上游立规矩：由方舟在提交期裁决（忽略或报错），错误原样透传，与
`seedance.ts` 对参考图张数上限已有的口径一致（「真实上限更低时上游会在提交期拒，错误
原样透传给调用方，不会静默出片」）。这是明确的产品决策，理由与代价写在
`buildSeedance25PromptText` 的注释里。

### 不动的东西

- `videoDefaults` 刻意不动：2.5 只到 720p，让 `tier=best` 指向它会把「要 1080p」的单子
  从可用变成明拒。2.5 需显式点名。
- 协议层（`shared/ghost.ts`）与执行器**零改动**：4–30 天然通过 `cindySlot` 的
  `isPositiveIntWithin(d, 60)`；1080p 由 `assertParamSupported` 按 2.5 值域明拒，话术
  自带该型号可用值。
- 2.0 的两个 alias 请求体与错误话术**逐字节不变**。

## 验证

真机实测（本 PR 的 `internalModel` 值就是靠它定的）：

- ✅ 网关接受 `bytedance/seedance-2.5` 并出片。
- ✅ 文生视频、图生视频（首帧/首尾帧/参考图）均正常。
- ✅ 省略 `ratio` 时上游按 adaptive 出片。

本地门禁全绿：

- `pnpm test:unit` —— 全部通过
- `pnpm --filter desktop run --if-present typecheck` —— exit 0
- `pnpm --filter @cindy/model-providers run --if-present typecheck` —— exit 0
- `pnpm check:dco` —— 2 commits signed off

视频链路 + 区域投影定向跑：103 passed（7 个文件）。其中：

- `seedance25Provider.test.ts`（24 条）：alias 与 provider.id 的区分、`body.model` 是
  网关映射名、不写 `--fps`、省略 ratio 不写 `--ratio`、具体画幅在两种 refMode 下都透传、
  `duration: 30` 放行、`1080p` 与 `duration: 31` 提交前明拒且零 fetch。
- `seedanceProvider.test.ts`（18 条）：新增反向不变量 —— 2.0 **不得**承载 2.5 的 alias，
  走错 provider 时提交前就拒。
- `videoModelsSync.test.ts`（6 条）：新增画幅 ↔ 协议层枚举同源守卫。
- **新增「两代值域互不放宽」的隔离测试**：同时注册两代，拿同一个执行器、同一组参数
  正反各打一次 —— `duration: 30` 时 2.5 走到提交而 2.0 明拒且零 fetch，`1080p` 时
  2.0 走到提交而 2.5 明拒且零 fetch。这是唯一能证明「拆对了」的测试：只注册 2.5 一个
  provider 只能证明它自己的值域对，证不了双向隔离。

  **该守卫做过变异验证**（守卫本身可能假绿，不验不算数）：临时把
  `CAPABILITIES_25.supportedDurations` 改回 `[4,6,8,10]` 模拟共用 capabilities，
  隔离测试立刻翻红 2 条；还原后 24 条全绿。

## 风险

1. **首帧/首尾帧传具体 ratio 时上游行为不确定**。文档只说「该参数将被忽略或触发报错」，
   两种都可能：被忽略 = 出片并计费（比例跟首帧图，不是用户要的那个）；报错 = 英文错误
   原样透传。已按 passthrough 定案，这是该选择的已知代价，也是 Codex P2 提醒的点。
2. `expectedSecondsByAlias: 360` 是估值（× 3 = 轮询超时 18min）。尚未拿一单 30s 长片的
   实测耗时校准，长片理论上可能撞超时。
3. `supportedDurations` 全量列举 27 个值 → `assertParamSupported` 的拒绝话术会列出 27 个
   数字，难看但准确。

## 不在本次范围

2.5 独有能力：参考视频 / 参考音频 / 样片 / `output_format: mov` / `priority` /
`tools: web_search` / `return_last_frame` / `execution_expires_after` /
`safety_identifier`。另外 `duration: -1`（智能时长）、`21:9`、参考图 30 张这三项要动协议层
（`GHOST_VIDEO_RATIOS`、`isPositiveIntWithin`、`GHOST_VIDEO_MAX_SOURCES_BY_REF_MODE`），
单独评估。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
