### PR TITLE
test(desktop): remove model selector floating timing coupling

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -282,13 +282,71 @@ async function openDropdown(): Promise<void> {
   });
 }
 
+type FloatingOptions = {
+  strategy: string;
+  placement: string;
+  transform: boolean;
+  open: boolean;
+  elements: { reference: HTMLElement };
+  whileElementsMounted: (
+    reference: HTMLElement,
+    floating: HTMLElement,
+    update: () => void,
+  ) => () => void;
+};
+
+function floatingOptionsForReference(reference: HTMLElement): FloatingOptions {
+  // React/Floating UI 可能因并发重渲染产生多次调用；按「当前连接锚点 + open」取值，
+  // 守护实际生效的浮层，而不是把调用顺序误当成契约。
+  const options = floatingUiMocks.useFloating.mock.calls
+    .map(([call]) => call as FloatingOptions)
+    .findLast((call) => call.open && call.elements?.reference === reference);
+  expect(options).toBeDefined();
+  if (!options) throw new Error('Floating UI options for the active model row were not found');
+  return options;
+}
+
+function sizeOptionsForFloatingPanel(): {
+  apply: (args: { elements: { floating: HTMLElement }; availableHeight: number }) => void;
+} {
+  // size middleware 的行为由其稳定参数和 apply 回调表达；匹配参数可避开其它渲染留下的调用。
+  const options = floatingUiMocks.size.mock.calls
+    .map(
+      ([call]) =>
+        call as {
+          padding?: number;
+          boundary?: Element[];
+          altBoundary?: boolean;
+          apply?: (args: { elements: { floating: HTMLElement }; availableHeight: number }) => void;
+        },
+    )
+    .findLast(
+      (call) =>
+        call.padding === 8 &&
+        Array.isArray(call.boundary) &&
+        call.boundary.length === 0 &&
+        call.altBoundary === false &&
+        typeof call.apply === 'function',
+    );
+  expect(options).toBeDefined();
+  if (!options?.apply) throw new Error('Floating UI size middleware was not configured');
+  return { apply: options.apply };
+}
+
 async function openModelOptionsPanel(row: HTMLElement): Promise<void> {
   await act(async () => {
-    // These tests cover floating-panel geometry and anchor replacement. ArrowLeft
-    // is an explicitly supported entry point that invokes the reveal path without
-    // coupling the assertion to pointer trust or focus/blur timing under CI load.
+    // ArrowLeft 是模型行公开支持的配置入口；调用前由用例等待 MorphPopover 的 settle 焦点，
+    // 避免把异步焦点交接顺序误当成浮层锚点契约。
     fireEvent.keyDown(row, { key: 'ArrowLeft' });
   });
+}
+
+async function waitForSearchInputFocus(): Promise<HTMLElement> {
+  const searchInput = screen.getByRole('textbox');
+  // MorphPopover settle 后才把焦点交给搜索框；先等这个最终状态，避免后续 ArrowLeft
+  // reveal 与尚未完成的焦点交接竞态。
+  await waitFor(() => expect(document.activeElement).toBe(searchInput));
+  return searchInput;
 }
 
 describe('ModelSelector provider groups', () => {
@@ -318,6 +376,7 @@ describe('ModelSelector provider groups', () => {
   it('keeps the create-agent secondary panel at the original left/center position with layout coordinates', async () => {
     renderSelector({ visualVariant: 'create-agent', useMorphPopover: true });
     await openDropdown();
+    await waitForSearchInputFocus();
 
     const modelList = screen.getByRole('listbox', { name: 'Model list' });
     const row = within(modelList).getByRole('option', { name: /Opus 4\.8/ });
@@ -330,7 +389,9 @@ describe('ModelSelector provider groups', () => {
     expect(positioner?.style.position).toBe('fixed');
     expect(positioner?.style.left).toBe('120px');
     expect(positioner?.style.top).toBe('24px');
-    expect(positioner?.style.transform).toBe('');
+    // Electron app-region 依赖布局矩形，定位层不能通过 translate 重新定位；这里只守护
+    // no-translate 行为，不锁定 jsdom 对空 transform 的具体序列化。
+    expect(positioner?.style.transform ?? '').not.toMatch(/translate/);
     expect(
       (positioner?.style as CSSStyleDeclaration & { WebkitAppRegion: string }).WebkitAppRegion,
     ).toBe('no-drag');
@@ -338,18 +399,7 @@ describe('ModelSelector provider groups', () => {
     expect(secondaryPanel.className).not.toContain('max-h-[');
     expect(secondaryPanel.className).not.toContain('overflow-y-auto');
 
-    const floatingOptions = floatingUiMocks.useFloating.mock.calls.at(-1)?.[0] as {
-      strategy: string;
-      placement: string;
-      transform: boolean;
-      open: boolean;
-      elements: { reference: HTMLElement };
-      whileElementsMounted: (
-        reference: HTMLElement,
-        floating: HTMLElement,
-        update: () => void,
-      ) => () => void;
-    };
+    const floatingOptions = floatingOptionsForReference(row);
     expect(floatingOptions).toMatchObject({
       strategy: 'fixed',
       placement: 'left',
@@ -359,19 +409,39 @@ describe('ModelSelector provider groups', () => {
     expect(floatingOptions.elements.reference).toBe(row);
     const floatingElement = document.createElement('div');
     const cleanup = floatingOptions.whileElementsMounted(row, floatingElement, vi.fn());
-    expect(floatingUiMocks.autoUpdate).toHaveBeenCalledWith(
+    // autoUpdate 必须绑定当前行与浮层元素；按参数匹配，避免其它重渲染的调用顺序影响断言。
+    const autoUpdateCall = floatingUiMocks.autoUpdate.mock.calls.findLast(
+      (call: unknown[]) => call[0] === row && call[1] === floatingElement,
+    );
+    expect(autoUpdateCall).toEqual([
       row,
       floatingElement,
       expect.any(Function),
       { animationFrame: false },
-    );
+    ]);
     cleanup();
 
-    expect(floatingUiMocks.offset).toHaveBeenLastCalledWith({
-      mainAxis: 8,
-      alignmentAxis: 0,
-    });
-    expect(floatingUiMocks.shift).toHaveBeenLastCalledWith(
+    // middleware 参数保留左侧贴边、碰撞留白和可用高度回归；按参数匹配而非取最后调用，
+    // 避免 React 并发重渲染改变 mock 调用顺序。
+    const offsetOptions = floatingUiMocks.offset.mock.calls
+      .map(([call]) => call)
+      .findLast(
+        (call) =>
+          (call as { mainAxis?: number; alignmentAxis?: number })?.mainAxis === 8 &&
+          (call as { mainAxis?: number; alignmentAxis?: number })?.alignmentAxis === 0,
+      );
+    expect(offsetOptions).toEqual({ mainAxis: 8, alignmentAxis: 0 });
+    const shiftOptions = floatingUiMocks.shift.mock.calls
+      .map(([call]) => call)
+      .findLast(
+        (call) =>
+          (call as { mainAxis?: boolean; crossAxis?: boolean; padding?: number })?.mainAxis ===
+            true &&
+          (call as { mainAxis?: boolean; crossAxis?: boolean; padding?: number })?.crossAxis ===
+            false &&
+          (call as { mainAxis?: boolean; crossAxis?: boolean; padding?: number })?.padding === 8,
+      );
+    expect(shiftOptions).toEqual(
       expect.objectContaining({
         mainAxis: true,
         crossAxis: false,
@@ -381,14 +451,22 @@ describe('ModelSelector provider groups', () => {
         altBoundary: false,
       }),
     );
-    expect(floatingUiMocks.flip).toHaveBeenLastCalledWith({
-      padding: 8,
-      boundary: [],
-      altBoundary: false,
-    });
-    const sizeOptions = floatingUiMocks.size.mock.calls.at(-1)?.[0] as {
-      apply: (args: { elements: { floating: HTMLElement }; availableHeight: number }) => void;
-    };
+    const flipOptions = floatingUiMocks.flip.mock.calls
+      .map(([call]) => call)
+      .findLast(
+        (call) =>
+          (call as { padding?: number; boundary?: Element[]; altBoundary?: boolean })?.padding ===
+            8 &&
+          Array.isArray(
+            (call as { padding?: number; boundary?: Element[]; altBoundary?: boolean })?.boundary,
+          ) &&
+          (call as { padding?: number; boundary?: Element[]; altBoundary?: boolean })?.boundary
+            ?.length === 0 &&
+          (call as { padding?: number; boundary?: Element[]; altBoundary?: boolean })
+            ?.altBoundary === false,
+      );
+    expect(flipOptions).toEqual({ padding: 8, boundary: [], altBoundary: false });
+    const sizeOptions = sizeOptionsForFloatingPanel();
     sizeOptions.apply({ elements: { floating: floatingElement }, availableHeight: 180 });
     expect(floatingElement.style.getPropertyValue('--radix-popover-content-available-height')).toBe(
       '180px',
@@ -405,51 +483,54 @@ describe('ModelSelector provider groups', () => {
     expect(document.activeElement).toBe(lastPanelOption);
 
     fireEvent.keyDown(row, { key: 'Escape' });
-    expect(screen.queryByTestId('model-options-floating-panel')).toBeNull();
-    expect(screen.getByRole('listbox', { name: 'Model list' })).toBeTruthy();
+    // Escape 关闭的是行级浮层，一级模型列表仍保持打开；等待两个最终 DOM 状态而非依赖
+    // keydown 后 React 同步 flush 的具体顺序。
+    await waitFor(() => {
+      expect(screen.queryByTestId('model-options-floating-panel')).toBeNull();
+      expect(screen.getByRole('listbox', { name: 'Model list' })).toBeTruthy();
+    });
   });
 
   it('refreshes the create-agent floating anchor after search remounts the active model row', async () => {
     renderSelector({ visualVariant: 'create-agent', useMorphPopover: true });
     await openDropdown();
 
-    const searchInput = screen.getByRole('textbox');
-    await waitFor(() => {
-      expect(document.activeElement).toBe(searchInput);
-    });
+    const searchInput = await waitForSearchInputFocus();
 
     const modelList = screen.getByRole('listbox', { name: 'Model list' });
     const originalRow = within(modelList).getByRole('option', { name: /Opus 4\.8/ });
     await openModelOptionsPanel(originalRow);
     await screen.findByTestId('model-options-floating-panel');
 
-    const originalFloatingOptions = floatingUiMocks.useFloating.mock.calls.at(-1)?.[0] as {
-      elements: { reference: HTMLElement };
-    };
+    const originalFloatingOptions = floatingOptionsForReference(originalRow);
     expect(originalFloatingOptions.elements.reference).toBe(originalRow);
 
     await act(async () => {
       fireEvent.change(searchInput, { target: { value: 'qwen' } });
     });
-    expect(originalRow.isConnected).toBe(false);
-    expect(screen.queryByTestId('model-options-floating-panel')).toBeNull();
-    const floatingCallCountAfterFilter = floatingUiMocks.useFloating.mock.calls.length;
+    // 搜索过滤会卸载旧行，行级浮层必须随之关闭，不能继续引用 detached DOM；这是行为契约，
+    // 不依赖 useFloating 的渲染/调用次数。
+    await waitFor(() => {
+      expect(originalRow.isConnected).toBe(false);
+      expect(screen.queryByTestId('model-options-floating-panel')).toBeNull();
+    });
 
     await act(async () => {
       fireEvent.change(searchInput, { target: { value: '' } });
     });
+    // 清空搜索会重新挂载新行，但旧 editing 状态不能让浮层自动复活或把新行误标 active。
+    await waitFor(() => {
+      const restoredRow = within(modelList).getByRole('option', { name: /Opus 4\.8/ });
+      expect(restoredRow).not.toBe(originalRow);
+      expect(restoredRow.getAttribute('data-model-options-active')).toBeNull();
+      expect(screen.queryByTestId('model-options-floating-panel')).toBeNull();
+    });
     const restoredRow = within(modelList).getByRole('option', { name: /Opus 4\.8/ });
-    expect(restoredRow).not.toBe(originalRow);
-    expect(restoredRow.getAttribute('data-model-options-active')).toBeNull();
-    expect(screen.queryByTestId('model-options-floating-panel')).toBeNull();
-    expect(floatingUiMocks.useFloating).toHaveBeenCalledTimes(floatingCallCountAfterFilter);
 
     await openModelOptionsPanel(restoredRow);
     await screen.findByTestId('model-options-floating-panel');
 
-    const restoredFloatingOptions = floatingUiMocks.useFloating.mock.calls.at(-1)?.[0] as {
-      elements: { reference: HTMLElement };
-    };
+    const restoredFloatingOptions = floatingOptionsForReference(restoredRow);
     expect(restoredFloatingOptions.elements.reference).toBe(restoredRow);
     expect(restoredFloatingOptions.elements.reference.isConnected).toBe(true);
   });


### PR DESCRIPTION
## 这次改了什么

### 摘要

把模型选择器两个 Windows CI 偶发失败用例从“依赖 React/Floating UI 调用顺序”改成“按当前锚点和最终 DOM 状态验证”。保留浮层定位、middleware、no-drag、键盘循环等回归保护。

这三次前修分别是：
- `8a74204e2`：把 pointerMove×2 换成 focus；只换了触发入口。
- `fadcf0e63`：把 focus 换成 ArrowLeft；仍只换了触发入口。
- `ee6847f1a`：等待搜索框聚焦；补了焦点时序，但仍保留 mock 最后调用和调用次数断言。

它们没有根治的原因是断言仍把并发渲染/effect flush 的先后和 `useFloating` 调用次数当成契约。本次消除两类耦合：
1. 用 `findLast` 按当前 `reference`/稳定 middleware 参数匹配，消除 mock 调用次序依赖。
2. 删除 `useFloating` 调用次数断言，改为等待过滤/恢复后的最终 DOM 和新锚点连接状态；Escape 也等待最终关闭状态。

### 变更类型

- [x] `docs` / `test` / `chore` 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：Windows CI modelSelectorProviderGroups 偶发失败
- 本 PR 包含：`apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx` 两个浮层回归用例的时序解耦
- 明确不包含：生产代码、其它测试、固定延时、跳过或删除用例
- 用户可见变化：无；仅测试判据调整
- 是否存在 breaking change：无

## UI 变化

- 不涉及：只修改 Renderer 测试文件，不改变产品 UI、交互或样式。
- 引用的设计规范：不涉及产品 UI 变更。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorProviderGroups.test.tsx --pool=threads
结果：通过，11/11。

目标文件 --pool=threads 连跑 10 轮
结果：10 轮全部通过，每轮 11/11。

pnpm --filter desktop exec eslint src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
结果：通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

pnpm test:unit
结果：通过；root runner 387 项中 386 通过、1 个仓库既有条件跳过；Desktop unit 79.3s，其余 workspace 全部通过，另有配置标记的无可收集测试 workspace 跳过。

pnpm check:dco
结果：通过，1 个提交带 Signed-off-by。
```

### 手工验证

不涉及。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [x] 跨平台差异

### 影响与回滚

影响范围：仅 Desktop Renderer 单元测试判据；不改变运行时代码。验证重点是 Windows CI 上不再依赖渲染调用顺序，macOS 本地定向测试也已通过。

回滚 / 降级方式：回滚本 PR 提交即可恢复原测试判据，不涉及用户数据或发布产物。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 DCO）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
