### PR TITLE
fix(im): 个人 Telegram bot 补上离线期积压消息的时效闸

### DIFF
--- a/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
+++ b/packages/lizi-im/src/telegram/__tests__/telegramIM.test.ts
@@ -136,14 +136,25 @@ function createHost(tmpDir: string): { host: IMHost; broadcasts: unknown[]; secr
   return { host, broadcasts, secrets, handlers };
 }
 
-function privateMessage(text: string, fromId: number, messageId = 1): TgUpdate {
+/**
+ * 固件消息默认「刚刚到达」。
+ *
+ * 写死一个过去的时间戳会让每条固件消息都撞上离线积压判据(STALE_MESSAGE_MS);
+ * 这些固件模拟的本来就是实时到达的 update, 时间戳按当下取。要造陈旧消息的
+ * 用例显式传 `ageSec`。
+ */
+function nowSec(ageSec = 0): number {
+  return Math.floor(Date.now() / 1_000) - ageSec;
+}
+
+function privateMessage(text: string, fromId: number, messageId = 1, ageSec = 0): TgUpdate {
   return {
     update_id: messageId,
     message: {
       message_id: messageId,
       from: { id: fromId, is_bot: false, first_name: 'U' },
       chat: { id: fromId, type: 'private' },
-      date: 1_753_000_000,
+      date: nowSec(ageSec),
       text,
     },
   };
@@ -155,6 +166,7 @@ function groupMessage(args: {
   messageId: number;
   mentionBot?: boolean;
   threadId?: number;
+  ageSec?: number;
 }): TgUpdate {
   const text = args.mentionBot ? `@${BOT.username} ${args.text}` : args.text;
   return {
@@ -163,7 +175,7 @@ function groupMessage(args: {
       message_id: args.messageId,
       from: { id: args.fromId, is_bot: false, first_name: 'U' },
       chat: { id: -100200, type: 'supergroup', title: 'Ops' },
-      date: 1_753_000_000,
+      date: nowSec(args.ageSec),
       text,
       ...(args.mentionBot
         ? { entities: [{ type: 'mention', offset: 0, length: BOT.username.length + 1 }] }
@@ -370,7 +382,7 @@ describe('TelegramIM', () => {
       message_id: answerId,
       from: { id: BOT.id, is_bot: true, first_name: 'Cindy' },
       chat: { id: -100200, type: 'supergroup' as const },
-      date: 1_753_000_050,
+      date: nowSec(150),
       text: '这是 Cindy 呀',
     };
     // 成员回复 bot → 同一条群 lane
@@ -381,7 +393,7 @@ describe('TelegramIM', () => {
           message_id: 41,
           from: { id: 222, is_bot: false, first_name: 'F' },
           chat: { id: -100200, type: 'supergroup', title: 'Ops' },
-          date: 1_753_000_100,
+          date: nowSec(100),
           text: '再多讲讲',
           reply_to_message: replyTo,
         },
@@ -397,7 +409,7 @@ describe('TelegramIM', () => {
           message_id: 42,
           from: { id: 111, is_bot: false, first_name: 'U' },
           chat: { id: -100200, type: 'supergroup', title: 'Ops' },
-          date: 1_753_000_200,
+          date: nowSec(0),
           text: '我来补充',
           reply_to_message: replyTo,
         },
@@ -742,7 +754,7 @@ describe('TelegramIM', () => {
         message_id: 50,
         from: { id: 111, is_bot: false, first_name: 'U' },
         chat: { id: 111, type: 'private' },
-        date: 1_753_000_000,
+        date: nowSec(200),
         caption: '慢附件',
         photo: [{ file_id: 'slow', file_unique_id: 'slow-u', width: 10, height: 10 }],
       },
@@ -1087,7 +1099,7 @@ describe('TelegramIM', () => {
         message_id: messageId,
         from: { id: 111, is_bot: false, first_name: 'U' },
         chat: { id: 111, type: 'private' },
-        date: 1_753_000_000,
+        date: nowSec(200),
         media_group_id: 'album-ord',
         ...(caption ? { caption } : {}),
         photo: [{ file_id: `f${messageId}`, file_unique_id: `u${messageId}`, width: 10, height: 10 }],
@@ -1120,7 +1132,7 @@ describe('TelegramIM', () => {
         message_id: messageId,
         from: { id: 111, is_bot: false, first_name: 'U' },
         chat: { id: 111, type: 'private' },
-        date: 1_753_000_000,
+        date: nowSec(200),
         media_group_id: 'album-cap',
         ...(messageId === 45 ? { caption: '慢速相册' } : {}),
         photo: [{ file_id: `f${messageId}`, file_unique_id: `u${messageId}`, width: 10, height: 10 }],
@@ -1151,7 +1163,7 @@ describe('TelegramIM', () => {
         message_id: messageId,
         from: { id: 111, is_bot: false, first_name: 'U' },
         chat: { id: 111, type: 'private' },
-        date: 1_753_000_000,
+        date: nowSec(200),
         media_group_id: 'album-1',
         ...(caption ? { caption } : {}),
         photo: [{ file_id: `f${messageId}`, file_unique_id: `u${messageId}`, width: 10, height: 10 }],
@@ -1179,13 +1191,13 @@ describe('TelegramIM', () => {
           message_id: 51,
           from: { id: 111, is_bot: false, first_name: 'U' },
           chat: { id: 111, type: 'private' },
-          date: 1_753_000_000,
+          date: nowSec(200),
           text: '按这个继续',
           reply_to_message: {
             message_id: 40,
             from: { id: BOT.id, is_bot: true, first_name: 'Cindy' },
             chat: { id: 111, type: 'private' },
-            date: 1_752_999_000,
+            date: nowSec(1_000),
             text: '方案 A: 先改 transport',
           },
         },
@@ -2295,7 +2307,7 @@ describe('TelegramIM', () => {
           message: {
             message_id: 55,
             chat: { id: args.fromId, type: 'private' },
-            date: 1_753_000_000,
+            date: nowSec(200),
             ...(args.keyboard
               ? {
                   reply_markup: {
@@ -2460,6 +2472,72 @@ describe('TelegramIM', () => {
       expect(edits).toHaveLength(2);
       expect(edits[1].params.parse_mode).toBeUndefined();
       expect(edits[1].params.reply_markup).toEqual({ inline_keyboard: [] });
+    });
+  });
+
+  describe('离线期积压消息(stale update)', () => {
+    // Telegram 会替离线的 bot 保留最长 24h 的 update, 一上线整批推来。桌面端
+    // 天天关机开机, 这是个人 bot 的常态而非异常 —— 官方 bot 服务端早有这道闸
+    // (2026-07-27 实踩: 整批历史消息被诈尸回复), 个人侧此前一道都没有。
+
+    it('隔夜私聊消息不再起 turn', async () => {
+      const events: IMMessageEvent[] = [];
+      im.onMessage((e) => events.push(e));
+      await connect();
+      api.pushUpdates([
+        privateMessage('昨晚发的', Number(OWNER_ID), 80, 8 * 3_600),
+        privateMessage('刚发的', Number(OWNER_ID), 81),
+      ]);
+      await vi.waitFor(() => expect(events).toHaveLength(1));
+      // 只有新鲜那条进了 turn; 陈旧那条静默消费。
+      expect(events[0]).toMatchObject({ text: '刚发的' });
+      await new Promise((r) => setTimeout(r, 200));
+      expect(events).toHaveLength(1);
+    });
+
+    it('陌生人的陈旧私聊不再收到「我不认识你」', async () => {
+      await connect();
+      const before = api.calls.filter((c) => c.method === 'sendMessage').length;
+      api.pushUpdates([privateMessage('在吗', 999, 82, 8 * 3_600)]);
+      await new Promise((r) => setTimeout(r, 300));
+      // 隔夜再回一句拒绝语同样是诈尸 —— 一条出站都不该有。
+      expect(api.calls.filter((c) => c.method === 'sendMessage').length).toBe(before);
+    });
+
+    it('陈旧群消息仍进历史池, 但不再唤起回答', async () => {
+      const events: IMMessageEvent[] = [];
+      const windowEntries: TelegramGroupWindowEntry[] = [];
+      im.onMessage((e) => events.push(e));
+      im.onGroupWindowMessage((e) => windowEntries.push(e));
+      await connect();
+      api.pushUpdates([
+        groupMessage({ text: '昨晚问的', fromId: 111, messageId: 83, mentionBot: true, ageSec: 8 * 3_600 }),
+        groupMessage({ text: '刚问的', fromId: 111, messageId: 84, mentionBot: true }),
+      ]);
+      // 群消息的历史价值与「该不该现在回答」是两件事: 两条都入窗, 只有一条起 turn。
+      await vi.waitFor(() => expect(windowEntries).toHaveLength(2));
+      await vi.waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0]).toMatchObject({ text: '刚问的' });
+    });
+
+    it('阈值内的离线积压照常处理 —— 短暂离线不误杀', async () => {
+      const events: IMMessageEvent[] = [];
+      im.onMessage((e) => events.push(e));
+      await connect();
+      // 用户合上电脑二十分钟再打开, 那条正等回复的消息仍然该被处理。
+      api.pushUpdates([privateMessage('二十分钟前发的', Number(OWNER_ID), 85, 20 * 60)]);
+      await vi.waitFor(() => expect(events).toHaveLength(1));
+      expect(events[0]).toMatchObject({ text: '二十分钟前发的' });
+    });
+
+    it('时间戳缺失按新鲜处理 —— 拦错比多回一条严重', async () => {
+      const events: IMMessageEvent[] = [];
+      im.onMessage((e) => events.push(e));
+      await connect();
+      const update = privateMessage('没有时间戳', Number(OWNER_ID), 86);
+      update.message!.date = 0;
+      api.pushUpdates([update]);
+      await vi.waitFor(() => expect(events).toHaveLength(1));
     });
   });
 

--- a/packages/lizi-im/src/telegram/index.ts
+++ b/packages/lizi-im/src/telegram/index.ts
@@ -85,6 +85,19 @@ const POLL_TIMEOUT_SEC = 50;
  * 同一批 getUpdates 里到齐; 静默 1s 后合并成单个事件, 不各起一轮 turn。
  */
 const ALBUM_SETTLE_MS = 1_000;
+/**
+ * 超过该时限的消息视为「离线期积压重放」, 不再起 turn。
+ *
+ * Telegram 会替离线的 bot 保留最长 24h 的 update, 一上线整批推来。官方 bot
+ * 服务端为此设了 10 分钟闸(2026-07-27 实踩: 上线后整批历史消息被诈尸回复,
+ * 半夜给离线桌面派了过期任务), 个人 bot 此前一道闸都没有 —— 而它跑在桌面端,
+ * 天天关机开机, 暴露面比常驻服务端大得多。
+ *
+ * 阈值比官方宽是**有意的**: 服务端离线 = 故障, 桌面关机 = 预期状态。用户合上
+ * 电脑一小时再打开, 那条正等回复的消息仍然该被处理; 但跨夜、跨半天的整批积压
+ * 用户早已不在等, 逐条回答只会刷屏并派出过期任务。
+ */
+const STALE_MESSAGE_MS = 60 * 60 * 1_000;
 const POLL_RETRY_BASE_MS = 1_000;
 const POLL_RETRY_MAX_MS = 30_000;
 /** 409 = 另一个进程在对同一 token 轮询 — 低频探测等它退出。 */
@@ -1284,13 +1297,38 @@ export class TelegramIM extends BaseIM implements ChannelIM {
     this.albumsInFlight.clear();
   }
 
+  /**
+   * 返回消息超龄的毫秒数; 未超龄、或时间戳缺失/不可信时返回 null(按新鲜处理)。
+   *
+   * 缺时间戳时选择放行而非拦截: 拦错等于吞掉用户当下发的消息, 比多回一条
+   * 陈旧消息严重得多。
+   */
+  private staleMessageAgeMs(m: TgMessage): number | null {
+    if (!Number.isFinite(m.date) || m.date <= 0) return null;
+    const age = Date.now() - m.date * 1_000;
+    return age > STALE_MESSAGE_MS ? age : null;
+  }
+
+  /** 只记录时长与 Telegram 侧序号 — 不写用户内容, 也不写 chat / user id。 */
+  private logStaleSkip(ageMs: number, chatType: string, messageId: number): void {
+    this.log.info(
+      `telegram stale message skipped (${Math.round(ageMs / 1_000)}s old ${chatType} message=${messageId})`,
+    );
+  }
+
   private async processInboundMessage(
     m: TgMessage,
     siblings: TgMessage[] = [],
     opts: { skipGroupWindow?: boolean } = {},
   ): Promise<void> {
     if (!m.from) return;
+    const staleFor = this.staleMessageAgeMs(m);
     if (m.chat.type === 'private') {
+      if (staleFor !== null) {
+        // 陌生人提示也一并跳过 —— 隔夜再回一句「我不认识你」同样是诈尸。
+        this.logStaleSkip(staleFor, 'private', m.message_id);
+        return;
+      }
       if (String(m.from.id) !== this.ownerUserId) {
         // 非 owner 私聊: 礼貌回应一句(官方 bot unbound 提示的个人版语义),
         // per-user 冷却防刷屏; 不进任何业务链路。
@@ -1323,6 +1361,12 @@ export class TelegramIM extends BaseIM implements ChannelIM {
       // 缓冲入口已逐条入窗, 这里跳过避免重复(入窗本身幂等, 跳过纯省一次写)。
       if (!opts.skipGroupWindow) {
         this.emitGroupWindow(groupWindowEntryOf(m));
+      }
+      // 群消息的历史价值与「该不该现在回答」是两件事: 上面照常入窗(数据面),
+      // 这里只拦 turn 触发 —— 隔夜的 @ 不再唤起一轮回答。
+      if (staleFor !== null) {
+        this.logStaleSkip(staleFor, m.chat.type, m.message_id);
+        return;
       }
 
       let trigger = detectGroupTrigger(m, this.botId, this.botUsername, this.botDisplayName);


### PR DESCRIPTION
## 这次改了什么

### 摘要

个人 Telegram bot 补上「离线期积压消息不再诈尸回复」的闸。

**症状**:桌面端关机一夜再开机,昨晚发给个人 bot 的消息会被**整批逐条重新回答** —— 并发跑一堆 turn、回复乱序、用户早已不在等的问题被重新处理一遍。

**根因**:Telegram 会替离线的 bot 保留最长 **24h** 的 update,一上线整批推来。个人 bot 对 `message.date` **只记录不判断** —— `sentAt: m.date * 1000` 之外,没有任何时效判据。而桌面端天天关机开机,这是个人 bot 的**常态**,不是异常。

**官方 bot 早有这道闸**:`telegram-hook-server` 的 `STALE_UPDATE_MS = 10min` 有完整判据,代码注释里还留着实踩记录:

> 停机/故障恢复时 Telegram 会重放最长 24h 的积压 update; 陈年消息既不该触发回复也不该派发任务(2026-07-27 实踩: 上线后整批历史消息被"诈尸"回复,半夜给离线桌面派了过期任务)。

个人侧一道都没有 —— 又一处「两个 bot 行为不一致」,而且个人 bot 的暴露面比常驻服务端**大得多**。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求:makecindy/cindy#1855(两个 Telegram bot 用一套消息控制系统)
- 本 PR 包含 —— 补上同一道闸,`STALE_MESSAGE_MS = 1h`:

| 场景 | 行为 |
|---|---|
| 陈旧私聊 | 不起 turn,静默消费 + 日志 |
| 陈旧群消息 | **照常入历史池**,只拦 turn 触发 |
| 陌生人的陈旧私聊 | 不回「我不认识你」(隔夜再回同样是诈尸) |
| `date` 缺失/不可信 | **按新鲜处理**(放行) |
| 阈值内的离线积压 | 照常处理 |

  两个判断值得说明:

  - **群消息仍入池** —— 历史价值与「该不该现在回答」是两件事。隔夜的群聊内容对后续检索仍有用,只是不该唤起一轮回答。
  - **缺时间戳放行** —— 拦错等于吞掉用户**当下**发的消息,比多回一条陈旧消息严重得多。

- 明确不包含:
  - **不发「你离线期间有 N 条消息未处理」的折叠提示** —— 那该**同时**给两个 bot 加才是真正的统一,另立 PR。本 PR 与官方 bot 一样静默消费 + 日志
  - 不改服务端
  - 不改 offset 持久化、顺序门、相册聚合、群触发判定的任何逻辑
- 用户可见变化:隔夜/跨半天的积压消息不再被逐条重新回答;1 小时以内的照常处理
- 是否存在 breaking change:无

### 阈值为什么与官方不同(1h vs 10min)

**服务端离线 = 故障;桌面关机 = 预期状态。**

用户合上电脑一小时再打开,那条正等回复的消息仍然该被处理。跨夜、跨半天的整批积压才是要拦的。这是**有意的**产品差异,不是抄漏 —— 代码注释里写明了。

### 逐渠道回归

改动全部落在 `packages/lizi-im/src/telegram/`:

| 渠道 | 影响 |
|---|---|
| telegram(个人 bot) | 本 PR 的目标 |
| telegram(官方 bot) | 无 —— 走 `hook-control`,与本文件无关 |
| slack / x / feishu / discord / dingtalk / wecom / wechat | 无 —— 各自 IM 实现独立,本 PR 未碰共享层 |

Slack / X 的契约结构一行未碰。

### UI 变化

不涉及:纯入站判据,无界面、样式或文案改动。

- 引用的设计规范:不涉及 —— 未改动 `apps/desktop/src/renderer` 下任何文件,不触及 `docs/design-rules/DESIGN.md` 的视觉规范,因此也不涉及双模式(Light / Dark)交付门槛。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/im run typecheck     # 干净
pnpm --filter @cindy/im exec vitest run   # 438 项全绿(既有 433 + 新增 5)
pnpm test:unit                            # 仓库根全量,全绿
```

新增 5 条回归:隔夜私聊不起 turn / 陌生人陈旧私聊零出站 / 陈旧群消息入池但不起 turn / 20 分钟前的消息照常处理 / `date` 缺失照常处理。

**既有 433 项断言一行未改。**

固件的时间戳做了一次语义修正:原本写死 `date: 1_753_000_000`(2025-07-20)当占位值,加入时效判据后每条固件消息都会撞上闸门(33 项直接红)。改为相对当下取值,**各条之间的秒差完全保留**(`nowSec(1_000)` / `nowSec(200)` / `nowSec(150)` / `nowSec(100)` / `nowSec(0)`)。这些固件模拟的本来就是实时到达的 update。

### 手工验证

不涉及 —— 复现需要真机关机隔夜,见下。

### 未执行的验证

真机「关机隔夜再开机」的端到端目检未做,以固件时间戳覆盖代替。

## 风险

### 风险分类

- [x] 其他:改变了「哪些入站消息会触发回复」的判据

### 影响与回滚

| 风险 | 处置 |
|---|---|
| 误拦用户当下发的消息 | `date` 缺失/不可信一律放行;阈值 1h 远大于任何正常投递延迟 |
| 用户不知道积压消息被跳过 | 与官方 bot 同口径:静默消费 + 日志。折叠提示要同时给两个 bot 加,另立 PR |
| 群历史因此缺失 | 不会 —— 陈旧群消息**照常入池**,只拦 turn 触发 |
| 阈值定得不合适 | 单一常量 `STALE_MESSAGE_MS`,调整成本极低 |

- 影响范围:仅个人 Telegram bot 的入站判据,官方 bot 与其它渠道零改动。
- 回滚 / 降级方式:纯逻辑改动,无 migration、无协议变更。revert 即回到旧行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 不涉及 UI
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

Refs: #1855
