### PR TITLE
fix(desktop): clamp audio byte ranges to EOF

### DIFF
--- a/apps/desktop/src/main/__tests__/audioFileProtocolRange.test.ts
+++ b/apps/desktop/src/main/__tests__/audioFileProtocolRange.test.ts
@@ -74,10 +74,15 @@ describe('parseRangeHeader', () => {
     });
   });
 
-  it('classifies out-of-range as unsatisfiable (not null)', () => {
+  it('clamps an over-long end to the final byte', () => {
     expect(parseRangeHeader('bytes=0-9999', 1000)).toEqual({
-      kind: 'unsatisfiable',
+      kind: 'range',
+      start: 0,
+      end: 999,
     });
+  });
+
+  it('classifies an out-of-range start or inverted range as unsatisfiable', () => {
     expect(parseRangeHeader('bytes=500-100', 1000)).toEqual({
       kind: 'unsatisfiable',
     });
@@ -319,6 +324,19 @@ describe('audio handler range responses', () => {
     expect(res.headers.get('Content-Length')).toBe('4');
     expect(res.headers.get('Accept-Ranges')).toBe('bytes');
     expect(Buffer.from(await res.arrayBuffer()).toString()).toBe('2345');
+  });
+
+  it('serves through EOF when a closed range end exceeds the file size', async () => {
+    const handler = getHandler();
+    const res = await handler(
+      makeRequest('xdt-audio://local/?path=%2Ftmp%2Fclip.mp3', {
+        headers: { Range: 'bytes=2-999' },
+      }),
+    );
+    expect(res.status).toBe(206);
+    expect(res.headers.get('Content-Range')).toBe('bytes 2-9/10');
+    expect(res.headers.get('Content-Length')).toBe('8');
+    expect(Buffer.from(await res.arrayBuffer()).toString()).toBe('23456789');
   });
 
   it('maps an unsatisfiable range to 416 with full media headers', async () => {

--- a/apps/desktop/src/main/audioFileProtocol.ts
+++ b/apps/desktop/src/main/audioFileProtocol.ts
@@ -120,12 +120,15 @@ export function parseRangeHeader(
     end = totalSize - 1;
   } else if (startStr !== '') {
     start = parseInt(startStr, 10);
-    end = endStr === '' ? totalSize - 1 : parseInt(endStr, 10);
+    const requestedEnd = endStr === '' ? totalSize - 1 : parseInt(endStr, 10);
+    // A satisfiable byte-range remains valid when its requested end extends
+    // past the representation; serve through the final available byte.
+    end = Math.min(requestedEnd, totalSize - 1);
     if (!Number.isFinite(start) || !Number.isFinite(end)) return null;
   } else {
     return null;
   }
-  if (start > end || start >= totalSize || end >= totalSize) {
+  if (start > end || start >= totalSize) {
     return { kind: 'unsatisfiable' };
   }
   return { kind: 'range', start, end };

--- a/apps/desktop/src/main/cindy-media/__tests__/rangeResponse.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/rangeResponse.test.ts
@@ -33,6 +33,15 @@ describe('buildRangedMediaResponse', () => {
     expect(Buffer.from(await r.arrayBuffer()).toString()).toBe('2345');
   });
 
+  it('共享媒体响应把超过 EOF 的结束位收窄到最后一个字节', async () => {
+    const r = buildRangedMediaResponse({ ...base, rangeHeader: 'bytes=4-99' });
+
+    expect(r.status).toBe(206);
+    expect(r.headers.get('Content-Range')).toBe('bytes 4-9/10');
+    expect(r.headers.get('Content-Length')).toBe('6');
+    expect(Buffer.from(await r.arrayBuffer()).toString()).toBe('456789');
+  });
+
   it('开区间 Range(bytes=8-)→ 206 到末尾;越界 → 416 带总长', async () => {
     const open = buildRangedMediaResponse({ ...base, rangeHeader: 'bytes=8-' });
     expect(open.status).toBe(206);


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正桌面端共享媒体 Range 边界：当请求起点有效、但结束位置超过文件末尾时，按标准把结束位置收窄到最后一个字节并返回 `206`，而不是错误返回 `416`。

例如 10 字节媒体收到 `Range: bytes=2-999` 时，现在返回 `Content-Range: bytes 2-9/10`、8 字节正文。起点越界和倒置范围仍保持 `416`。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：未关联公开 Issue；修复共享 `parseRangeHeader` 的 EOF 边界
- 本 PR 包含：闭合 Range 的 end 截断；`xdt-audio` 生产协议 handler 与 `buildRangedMediaResponse` 共享消费者回归测试
- 明确不包含：多段 Range、媒体解码、播放器 UI、非法 Range 的既有兼容策略
- 用户可见变化：`xdt-audio`、`cindy-media`、Electron sandbox 与复用共享响应的 device-link 媒体请求在 end 超过 EOF 时可以继续返回有效分片
- 是否存在 breaking change：无

### UI 变化

不涉及：只修改主进程共享媒体 Range 响应。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/main/__tests__/audioFileProtocolRange.test.ts src/main/cindy-media/__tests__/rangeResponse.test.ts
结果：32/32 通过

corepack pnpm check:dco
结果：2 个 commit 均通过 DCO

git diff --check
结果：通过
```

回归分别覆盖真实 `protocol.handle` 回调和共享 `buildRangedMediaResponse`，验证 Response 状态、`Content-Range`、`Content-Length` 与实际正文。

### 手工验证

不涉及：通过生产 handler 与共享响应组装层自动测试覆盖。

### 未执行的验证

临时 worktree 的 Desktop 全量 typecheck 缺少 `cindy-protocol` 依赖，未把该结果记为通过；报错不涉及本 PR 的三个文件。CI 继续执行仓库完整门禁。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：所有复用 `audioFileProtocol.parseRangeHeader` 的桌面端单段 byte Range 响应
- 回滚 / 降级方式：回滚本 PR 的实现提交即可；测试提交可一并回退；无数据或协议版本迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因
