### PR TITLE
fix(orca): release settled auto-bridge state

### DIFF
--- a/packages/orca-workflow/src/__tests__/orca-bridge-mcp.test.ts
+++ b/packages/orca-workflow/src/__tests__/orca-bridge-mcp.test.ts
@@ -11,6 +11,7 @@ import type {
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  __testing,
   createOrcaWorkerBridgeMcpProvider,
   type OrcaBridgeMcpDeps,
   type OrcaWorkerLink,
@@ -365,6 +366,29 @@ describe('orca_worker_bridge MCP helpers', () => {
     });
     expect(persisted).toEqual([]);
     expect(statusUpdates).toEqual([]);
+  });
+
+  it('does not retain settled auto-bridge state after send_to_lead succeeds', async () => {
+    const lead = makeSession('lead-1');
+    const { server } = makeWorkerBridgeLeadHarness(lead);
+    __testing.clearAutoBridgeState('worker-1');
+
+    try {
+      const result = await server._registeredTools.send_to_lead.handler({
+        worker_id: 'worker-1',
+        message: 'completed work',
+      });
+
+      expect(parseToolJson(result)).toMatchObject({
+        ok: true,
+        worker_id: 'worker-1',
+        lead_session_id: 'lead-1',
+      });
+      expect(__testing.hasAutoBridgePending('worker-1')).toBe(false);
+      expect(__testing.autoBridgeStateCount()).toBe(0);
+    } finally {
+      __testing.clearAutoBridgeState('worker-1');
+    }
   });
 
   it('hydrates lead provider route before cold send_to_lead creates the lead session', async () => {

--- a/packages/orca-workflow/src/orca-bridge-mcp.ts
+++ b/packages/orca-workflow/src/orca-bridge-mcp.ts
@@ -390,6 +390,10 @@ function peekAutoBridgeState(workerId: string): AutoBridgeState | null {
 }
 
 function setAutoBridgePending(workerId: string, pending: boolean): void {
+  if (!pending) {
+    workerAutoBridgePending.delete(workerId);
+    return;
+  }
   let state = peekAutoBridgeState(workerId);
   if (!state) {
     state = { pending: false, ready: false, inFlight: false, version: 0 };


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Orca Worker 每次通过 `send_to_lead` 成功回报后，package-local auto-bridge Map 仍保留一条 `pending:false` 无效记录的问题。

当前代码没有生产路径再读取这条终态记录，也没有 `setAutoBridgePending(true)` 调用；成功回报后直接删除对应 worker 条目，与现有行为等价，同时避免长时间协同后 Map 持续增长。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：未关联公开 Issue；修复 `send_to_lead` 成功后的无效内存状态残留
- 本 PR 包含：`pending=false` 时删除 Map 条目；真实 MCP handler 回归测试
- 明确不包含：Worker/Lead 消息派发、Team 关闭、状态持久化、自动桥接功能改造
- 用户可见变化：无直接 UI 变化；长时间协同不再积累无用 auto-bridge 条目
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/orca-workflow test
结果：28/28 通过

pnpm --filter @cindy/orca-workflow build
结果：通过

pnpm --filter @cindy/orca-workflow lint
结果：通过

pnpm test:unit
结果：相关 required unit gate 通过

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

新增测试实际调用 `send_to_lead` handler 并走到 `settleWorkerReport()`；旧实现会留下 1 条记录，新实现断言 Map 回到 0。

### 手工验证

不涉及：MCP handler 生产路径由自动回归覆盖。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 `packages/orca-workflow` 内 Worker 成功回报后的临时 Map 清理
- 回滚 / 降级方式：回滚本提交即可；无持久化或协议变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因
