### PR TITLE
fix(desktop): reject malformed media URLs

### DIFF
--- a/apps/desktop/src/main/__tests__/imageCacheStoreResolve.test.ts
+++ b/apps/desktop/src/main/__tests__/imageCacheStoreResolve.test.ts
@@ -26,7 +26,7 @@ vi.mock('electron', () => ({
   },
 }));
 
-const { resolveSafe, resolveSessionImageLenient } = await import('../imageCacheStore');
+const { resolveSafe, resolveSessionImageLenient, collectSessionImageUrls } = await import('../imageCacheStore');
 
 describe('resolveSafe — reserved hosts', () => {
   it('feishu-media-images host routes to feishu-media/images/', () => {
@@ -148,6 +148,12 @@ describe('resolveSafe — session-id path (regression)', () => {
   it('non-xdt-image URL is rejected', () => {
     expect(() => resolveSafe('http://example.com/x.png')).toThrow(/invalid url/);
   });
+
+  it('rejects malformed percent-encoding as a malformed URL', () => {
+    expect(() => resolveSafe('xdt-image://sess-abc/%E0%A4%A.png')).toThrow(
+      /malformed url/,
+    );
+  });
 });
 
 describe('resolveSessionImageLenient — ghost attachment grant forms', () => {
@@ -206,5 +212,9 @@ describe('resolveSessionImageLenient — ghost attachment grant forms', () => {
     expect(() =>
       resolveSessionImageLenient('xdt-image://no-such-file-1700000000000.png'),
     ).toThrow();
+  });
+
+  it('ignores malformed percent-encoding while collecting session URLs', () => {
+    expect(collectSessionImageUrls('see xdt-image://sess-lenient/%E0%A4%A.png')).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/__tests__/mediaProtocolMalformedUrl.test.ts
+++ b/apps/desktop/src/main/__tests__/mediaProtocolMalformedUrl.test.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const handle = vi.fn();
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/tmp/cindy-media-protocol-test') },
+  protocol: { handle },
+}));
+vi.mock('../logger', () => ({ createLogger: () => ({ error: vi.fn() }) }));
+
+const { registerImageProtocolHandler } = await import('../imageProtocol');
+const { registerVideoProtocolHandler } = await import('../videoProtocol');
+const { registerModelProtocolHandler } = await import('../modelProtocol');
+
+describe('media protocol malformed URLs', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 403 instead of 500 for malformed percent encoding', async () => {
+    registerImageProtocolHandler();
+    registerVideoProtocolHandler();
+    registerModelProtocolHandler();
+    const handlers = new Map(handle.mock.calls);
+    for (const scheme of ['xdt-image', 'xdt-video', 'xdt-model']) {
+      const handler = handlers.get(scheme);
+      await expect(handler(new Request(`${scheme}://session/%E0%A4%A`))).resolves.toMatchObject({ status: 403 });
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/mediaProtocolMalformedUrl.test.ts
+++ b/apps/desktop/src/main/__tests__/mediaProtocolMalformedUrl.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const handle = vi.fn();
+type ProtocolHandler = (request: Request) => Promise<Response>;
+
+const handle = vi.fn<(scheme: string, handler: ProtocolHandler) => void>();
 vi.mock('electron', () => ({
   app: { getPath: vi.fn(() => '/tmp/cindy-media-protocol-test') },
   protocol: { handle },
@@ -18,9 +20,11 @@ describe('media protocol malformed URLs', () => {
     registerImageProtocolHandler();
     registerVideoProtocolHandler();
     registerModelProtocolHandler();
-    const handlers = new Map(handle.mock.calls);
+    const handlers = new Map<string, ProtocolHandler>(handle.mock.calls);
     for (const scheme of ['xdt-image', 'xdt-video', 'xdt-model']) {
       const handler = handlers.get(scheme);
+      expect(handler).toBeTypeOf('function');
+      if (!handler) throw new Error(`missing protocol handler for ${scheme}`);
       await expect(handler(new Request(`${scheme}://session/%E0%A4%A`))).resolves.toMatchObject({ status: 403 });
     }
   });

--- a/apps/desktop/src/main/__tests__/modelCacheStoreResolve.test.ts
+++ b/apps/desktop/src/main/__tests__/modelCacheStoreResolve.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it, vi } from 'vitest';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('electron', () => ({
+  app: { getPath: () => path.join(os.tmpdir(), 'model-cache-resolve') },
+}));
+
+const { resolveSafe } = await import('../modelCacheStore');
+
+describe('modelCacheStore.resolveSafe', () => {
+  it('rejects malformed percent-encoding as a malformed URL', () => {
+    expect(() => resolveSafe('xdt-model://mivo-3d-cache/%E0%A4%A.glb')).toThrow(
+      /malformed url/i,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/videoCacheStoreResolve.test.ts
+++ b/apps/desktop/src/main/__tests__/videoCacheStoreResolve.test.ts
@@ -59,4 +59,10 @@ describe('videoCacheStore.resolveSafe', () => {
       /invalid url/i,
     );
   });
+
+  it('rejects malformed percent-encoding as a malformed URL', () => {
+    expect(() => resolveSafe('xdt-video://lizi-art-media-videos/%E0%A4%A.mp4')).toThrow(
+      /malformed url/i,
+    );
+  });
 });

--- a/apps/desktop/src/main/imageCacheStore.ts
+++ b/apps/desktop/src/main/imageCacheStore.ts
@@ -200,10 +200,16 @@ function parseSessionImageUrl(url: string): { sessionId: string; filename: strin
     return null;
   }
 
-  const host = decodeURIComponent(parsed.hostname);
-  if (RESERVED_HOSTS[host]) return null;
-  const pathnameRaw = parsed.pathname.startsWith('/') ? parsed.pathname.slice(1) : parsed.pathname;
-  const filename = decodeURIComponent(pathnameRaw);
+  let host: string;
+  let filename: string;
+  try {
+    host = decodeURIComponent(parsed.hostname);
+    if (RESERVED_HOSTS[host]) return null;
+    const pathnameRaw = parsed.pathname.startsWith('/') ? parsed.pathname.slice(1) : parsed.pathname;
+    filename = decodeURIComponent(pathnameRaw);
+  } catch {
+    return null;
+  }
 
   try {
     assertSafeSessionId(host);
@@ -550,10 +556,16 @@ export function resolveSafe(url: string): { absPath: string; mimeType: string } 
   } catch {
     throw new Error('xdt-image: malformed url');
   }
-  const host = decodeURIComponent(parsed.hostname);
-  // pathname is e.g. "/abc-123.png" → strip leading slash
-  const pathnameRaw = parsed.pathname.startsWith('/') ? parsed.pathname.slice(1) : parsed.pathname;
-  const filename = decodeURIComponent(pathnameRaw);
+  let host: string;
+  let filename: string;
+  try {
+    host = decodeURIComponent(parsed.hostname);
+    // pathname is e.g. "/abc-123.png" → strip leading slash
+    const pathnameRaw = parsed.pathname.startsWith('/') ? parsed.pathname.slice(1) : parsed.pathname;
+    filename = decodeURIComponent(pathnameRaw);
+  } catch {
+    throw new Error('xdt-image: malformed url');
+  }
 
   if (
     !host ||

--- a/apps/desktop/src/main/modelCacheStore.ts
+++ b/apps/desktop/src/main/modelCacheStore.ts
@@ -43,11 +43,17 @@ export function resolveSafe(url: string): { absPath: string; mimeType: string } 
   } catch {
     throw new Error('xdt-model: malformed url');
   }
-  const host = decodeURIComponent(parsed.hostname);
-  const pathnameRaw = parsed.pathname.startsWith('/')
-    ? parsed.pathname.slice(1)
-    : parsed.pathname;
-  const filename = decodeURIComponent(pathnameRaw);
+  let host: string;
+  let filename: string;
+  try {
+    host = decodeURIComponent(parsed.hostname);
+    const pathnameRaw = parsed.pathname.startsWith('/')
+      ? parsed.pathname.slice(1)
+      : parsed.pathname;
+    filename = decodeURIComponent(pathnameRaw);
+  } catch {
+    throw new Error('xdt-model: malformed url');
+  }
 
   if (
     !host ||

--- a/apps/desktop/src/main/videoCacheStore.ts
+++ b/apps/desktop/src/main/videoCacheStore.ts
@@ -60,11 +60,17 @@ export function resolveSafe(url: string): { absPath: string; mimeType: string } 
   } catch {
     throw new Error('xdt-video: malformed url');
   }
-  const host = decodeURIComponent(parsed.hostname);
-  const pathnameRaw = parsed.pathname.startsWith('/')
-    ? parsed.pathname.slice(1)
-    : parsed.pathname;
-  const filename = decodeURIComponent(pathnameRaw);
+  let host: string;
+  let filename: string;
+  try {
+    host = decodeURIComponent(parsed.hostname);
+    const pathnameRaw = parsed.pathname.startsWith('/')
+      ? parsed.pathname.slice(1)
+      : parsed.pathname;
+    filename = decodeURIComponent(pathnameRaw);
+  } catch {
+    throw new Error('xdt-video: malformed url');
+  }
 
   if (
     !host ||


### PR DESCRIPTION
## 这次改了什么

### 摘要

Desktop 的 image、video、model 自定义媒体 URL resolver 直接调用 `decodeURIComponent()`；恶意或损坏的 percent-encoding 会抛出 `URIError`，使协议 handler 把输入错误误报成 500。

本 PR 在三条 resolver 路径统一捕获解码失败并归一为 malformed URL，使协议 handler 返回 403；同时让会话图片 URL 收集忽略坏 URL，不因一条损坏引用中断整批解析。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Desktop 自定义媒体协议的 malformed percent-encoding 防御
- 本 PR 包含：image/video/model resolver；三个 protocol handler 的 403 回归；宽松图片 URL 收集的坏输入忽略逻辑
- 明确不包含：合法 URL 语义、媒体文件布局、缓存迁移、Renderer/UI 改动
- 用户可见变化：损坏或恶意 percent-encoding 被稳定拒绝为 403，不再泄漏为内部 500；合法媒体 URL 行为不变
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/main/__tests__/imageCacheStoreResolve.test.ts src/main/__tests__/videoCacheStoreResolve.test.ts src/main/__tests__/modelCacheStoreResolve.test.ts src/main/__tests__/mediaProtocolMalformedUrl.test.ts
结果：29/29 通过

corepack pnpm --filter desktop typecheck
结果：通过

定向 ESLint（七个改动文件）
结果：通过

git diff --check
结果：通过

GitHub DCO / Greptile Review
结果：通过；Copilot 审查 7/7 文件，无 actionable comment
```

补充：提交时运行过 Desktop 全套测试和 lint；仓库当时其他 Maker/Orca 测试与本机 sqlite-vec native artifact 存在无关基线失败，未通过删除/跳过测试规避。本 PR 的定向测试、typecheck、ESLint 均通过。

### 手工验证

- image/video/model resolver 对 malformed percent-encoding 均返回稳定输入错误
- 三个 protocol handler 均验证为 403，而非 500
- 合法媒体 URL 与宽松图片 URL 收集保持原行为；坏图片引用被忽略

### 未执行的验证

- 未在当前最新 `main` 合成树重跑根 `pnpm test:unit`；PR 当前 `MERGEABLE`，且 `main` 后续提交未修改本 PR 生产文件
- 未在 Windows 真机手工验证；代码无平台分支
- required fork workflows 当前为 `action_required`，需维护者批准后等待 `verify` 与 Windows unit tests 全绿

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：自定义媒体协议输入校验

### 影响与回滚

- 影响范围：Desktop main 进程的 image/video/model 自定义 URL 解析和协议错误映射
- system prompt：不涉及，未修改
- 回滚 / 降级方式：回滚本 commit 即恢复旧解析；无数据迁移、缓存格式或 UI 状态变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无额外用户文档需要）
- [x] 已确认测试结果或说明未执行原因
