### PR TITLE
fix(desktop): reject media URL cache aliases

### DIFF
--- a/apps/desktop/src/main/cindy-media/__tests__/blobStore.test.ts
+++ b/apps/desktop/src/main/cindy-media/__tests__/blobStore.test.ts
@@ -97,6 +97,25 @@ describe('parseBlobUrl / resolveSafe(取件形状校验)', () => {
     }
   });
 
+  it('拒绝为同一 blob 制造缓存别名的 URL 附加部分', () => {
+    const canonical = `cindy-media://blobs/${PNG_HASH}.png`;
+    for (const alias of [
+      `${canonical}?nonce=1`,
+      `${canonical}?`,
+      `${canonical}#preview`,
+      `${canonical}#`,
+      `cindy-media://user@blobs/${PNG_HASH}.png`,
+      `cindy-media://blobs:443/${PNG_HASH}.png`,
+      `cindy-media://blobs/${PNG_HASH}.PNG`,
+      `cindy-media://@blobs/${PNG_HASH}.png`,
+      `cindy-media://blobs:/${PNG_HASH}.png`,
+      `cindy-media://blobs/a/../${PNG_HASH}.png`,
+    ]) {
+      expect(blobStore.parseBlobUrl(alias)).toBeNull();
+      expect(() => blobStore.resolveSafe(alias)).toThrow('invalid url');
+    }
+  });
+
   it('resolveHashRef 拒绝非法指纹与扩展名(供图分支复用同一校验)', () => {
     expect(() => blobStore.resolveHashRef('..', '.png')).toThrow('invalid hash');
     expect(() => blobStore.resolveHashRef(PNG_HASH, '.sh')).toThrow('unsupported ext');

--- a/apps/desktop/src/main/cindy-media/blobStore.ts
+++ b/apps/desktop/src/main/cindy-media/blobStore.ts
@@ -199,13 +199,27 @@ export function parseBlobUrl(url: string): { hash: string; ext: string } | null 
   } catch {
     return null;
   }
-  if (parsed.hostname !== HOST_BLOBS) return null;
+  if (
+    parsed.hostname !== HOST_BLOBS ||
+    parsed.username ||
+    parsed.password ||
+    parsed.port ||
+    parsed.search ||
+    parsed.hash ||
+    url.includes('?') ||
+    url.includes('#')
+  ) {
+    return null;
+  }
   const pathname = parsed.pathname.startsWith('/') ? parsed.pathname.slice(1) : parsed.pathname;
   const dotIdx = pathname.lastIndexOf('.');
   if (dotIdx <= 0) return null;
   const hash = pathname.slice(0, dotIdx);
   const ext = pathname.slice(dotIdx).toLowerCase();
   if (!HASH_RE.test(hash) || !MIME_BY_EXT[ext]) return null;
+  // URL 解析会规范化空 authority、空 port 与 dot segment；只接受本仓
+  // 自己生成的字面地址，避免同一 immutable blob 有多个 Chromium cache key。
+  if (url !== blobUrl(hash, ext)) return null;
   return { hash, ext };
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

收紧 Desktop `cindy-media://blobs/<sha256>.<ext>` 的取件地址校验，只接受仓库自身生成的唯一字面 URL。过去 `new URL()` 会把空 authority、空 port、dot segment 等别名规范化成同一地址，导致同一个 immutable blob 可以制造多个 Chromium cache key。

解析完成后现在会把原始输入与 `blobUrl(hash, ext)` 的 canonical 结果逐字比较，并拒绝 query、fragment、credentials、port、大小写扩展名及 parser-normalized aliases。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Codex review thread `discussion_r3739240211`；`docs/dev-rules/media-storage-and-protocols.md` 的 canonical-address 约束
- 本 PR 包含：blob URL canonical equality 校验；query/fragment/credentials/port/空 authority/空 port/dot segment 等别名回归
- 明确不包含：image/video/model cache 的其他协议解析、缓存迁移、UI 改动
- 用户可见变化：非 canonical 或携带附加部分的 blob URL 会被拒绝；合法仓库生成 URL 行为不变
- 是否存在 breaking change：无（仅拒绝此前不应接受的非 canonical 输入）

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter desktop exec vitest run src/main/cindy-media/__tests__/blobStore.test.ts
结果：10/10 通过；旧实现对新增 aliases 用例失败

corepack pnpm --filter desktop typecheck
结果：通过

定向 ESLint（两个改动文件）
结果：通过

git diff --check
结果：通过

GitHub DCO / Greptile Review
结果：通过
```

补充：提交时运行过 Desktop 全套测试和 lint；仓库当时其他模块及本机 native artifact 存在无关基线失败，未通过删除/跳过测试规避。本 PR 的定向测试、typecheck、ESLint 均通过。

### 手工验证

- canonical URL：解析并取件正常
- 非 canonical 矩阵：query、fragment、credentials、显式 port、大小写扩展名、`@blobs`、空 port、dot segment 均被 `parseBlobUrl` 与 `resolveSafe` 拒绝
- 缓存/性能：只新增一次短字符串相等比较；无 IO、网络或缓存布局变化

### 未执行的验证

- 未在当前最新 `main` 合成树重跑根 `pnpm test:unit`；PR 当前 `MERGEABLE`，且 `main` 后续提交未修改本 PR 两个文件
- 未在 Windows 真机手工验证；代码无平台分支
- fork 的 required client CI 尚无运行结果，需维护者批准/触发后以 `verify` 与 Windows unit tests 为准

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：自定义媒体 URL 输入兼容边界

### 影响与回滚

- 影响范围：仅 Desktop main 进程的 blob URL 解析与安全取件
- system prompt：不涉及，未修改
- 回滚 / 降级方式：回滚本 commit 即恢复旧解析；无数据迁移和持久化格式变化

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无额外用户文档需要）
- [x] 已确认测试结果或说明未执行原因
