### PR TITLE
fix(maker-core): abort 不再等待 SDK interrupt、即刻恢复会话可用

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -748,4 +748,64 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     stream.end();
     await handle.close().catch(() => undefined);
   });
+
+  it('clears turnInFlight immediately, not after interrupt resolves', async () => {
+    const { handle, stream, fakeQuery } = await startSessionWithStream();
+
+    // 模拟 SDK 在 retry backoff 中不立即响应 interrupt(如全池冷却 503)。
+    let interruptResolved = false;
+    fakeQuery.interrupt.mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+      interruptResolved = true;
+    });
+
+    await handle.send({ type: 'user', content: 'test' });
+    stream.emit(assistantText('thinking...'));
+    await waitFor(() => handle.isTurnRunning?.() === true, 'turn is running');
+
+    const abortPromise = handle.abort();
+
+    // turnInFlight 应在 interrupt 返回前就已清除。
+    await new Promise((r) => setTimeout(r, 10));
+    expect(handle.isTurnRunning?.()).toBe(false);
+    expect(interruptResolved).toBe(false);
+
+    await abortPromise;
+    expect(interruptResolved).toBe(true);
+    expect(fakeQuery.interrupt).toHaveBeenCalled();
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
+  it('calls q.close when interrupt does not respond within timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const { handle, stream, fakeQuery } = await startSessionWithStream();
+
+      // interrupt 永远不响应(simulate hung SDK in retry backoff)。
+      fakeQuery.interrupt.mockImplementation(() => new Promise(() => {}));
+
+      await handle.send({ type: 'user', content: 'test' });
+      stream.emit(assistantText('thinking...'));
+      await waitFor(() => handle.isTurnRunning?.() === true, 'turn is running');
+
+      const abortPromise = handle.abort();
+
+      // turnInFlight 应立刻清除。
+      await vi.advanceTimersByTimeAsync(10);
+      expect(handle.isTurnRunning?.()).toBe(false);
+
+      // 快进到 10s 超时。
+      await vi.advanceTimersByTimeAsync(11_000);
+
+      expect(fakeQuery.close).toHaveBeenCalled();
+
+      stream.end();
+      await abortPromise;
+      await handle.close().catch(() => undefined);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1954,6 +1954,11 @@ export class ClaudeCodeAgent extends BaseAgent {
     // SSE idle watchdog 触发时也会主动清, 防止 SDK drain 期间又起 timer。
     // rewind preview/commit 业务层用 isTurnRunning() 前置守卫, 不在 turn 跑时操作 SDK。
     let turnInFlight = false;
+    // send() 处于 beginNewTurn→userInputAccepted 之间时置 true。
+    // abort() 在此期间跳过 turnInFlight 清除:并发 send 负责在错误路径上
+    // (finishSendBeforeUserInput) 自行清 turnInFlight 并 emit boundary,
+    // abort 抢清会让 boundary 丢失、acceptingRebuiltSend 残留(review #485)。
+    let sendInAcceptPhase = false;
     /**
      * "桥接 turn"计数器: rebuild 尾部注入的 /compact 是 SDK 独立 turn, 但产品层视角
      * 它是"用户 turn 的一部分" — 该 /compact 的 done / end-status 不能让上层做 turn
@@ -4255,6 +4260,7 @@ export class ClaudeCodeAgent extends BaseAgent {
               log.warn('send failed after bridge /compact injection: q.close threw', { error: String(closeError) });
             }
             turnInFlight = false;
+            sendInAcceptPhase = false;
             turnState.interruptRequested = false;
             pendingToolIds.clear();
             acceptingRebuiltSend = false;
@@ -4269,6 +4275,7 @@ export class ClaudeCodeAgent extends BaseAgent {
             error: error === undefined ? undefined : String(error),
           });
           turnInFlight = false;
+          sendInAcceptPhase = false;
           turnState.interruptRequested = false;
           pendingToolIds.clear();
           acceptingRebuiltSend = false;
@@ -4387,6 +4394,7 @@ export class ClaudeCodeAgent extends BaseAgent {
         toolLoopGuard?.resetTurn();
         // 标记 turn 进入 in-flight 态 (translator.onTurnEnd 在 result 事件回调时清);
         // rewind preview/commit 守卫读 isTurnRunning() 决定能否操作。
+        sendInAcceptPhase = true;
         turnInFlight = true;
         // 对齐老 agentManager.ts:1623 — send 入口立刻 emit "Thinking...", 让 renderer 的
         // RunningStatusBar 一发就亮; 否则从 send 到 SDK message_start 之间的几百 ms~几秒 gap
@@ -4472,6 +4480,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           activeCapabilitySelectionText = userMessageTextForCapabilityRouting(message.content);
           setAutoReviewIntent(message.content);
           replayableUserInput = sdkInput;
+          sendInAcceptPhase = false;
           // upstream-response-idle watchdog 起表 — 放在 inputQueue.push 之后, 避免把
           // client 端的 toClaudeSdkContent (多模态 image-resizer 同步等几秒) 算进上游
           // 响应配额。否则 warn 日志里 lastEventType=null + msSinceLast=null 会指错方向
@@ -4602,23 +4611,57 @@ export class ClaudeCodeAgent extends BaseAgent {
         // 用户主动停止: SDK 被 interrupt 后会 drain 出 error_during_execution 的
         // is_error result, 打标记让 translator turn-end 跳过"失败兜底 error",
         // 否则用户点停止会被误报成"执行失败"通知。
-        // turnInFlight 守卫(与 watchdog / tool-loop 对齐): turn 已自然结束时的
-        // 迟到 Stop 不置位 —— idle query 上的 interrupt 不保证产出 result 来消费
-        // 标记, 残留会泄漏到下一真实 turn 吞掉其失败兜底(review P2)。
+        // turnInFlight 守卫: turn 已自然结束时的迟到 Stop 不置位 —— idle query
+        // 上的 interrupt 不保证产出 result 来消费标记, 残留会泄漏到下一真实 turn
+        // 吞掉其失败兜底(review P2)。
         if (turnInFlight) {
           turnState.interruptRequested = true;
           turnState.interruptGeneration = turnState.generation;
+        }
+        // 先关 turn-in-flight 再 interrupt, 与 upstream-idle watchdog 同模式。
+        // SDK retry backoff 的 setTimeout 期间不响应 interrupt(2026-08 实踩,
+        // OAuth 全池冷却 503 持续重试), 等它返回会让后续 send 被 SESSION_RUNNING
+        // 永拒。generation 守卫(translator handleResult)保证旧 q 的迟到
+        // error_during_execution result 被丢弃、不污染新 turn。
+        // sendInAcceptPhase 守卫: 并发 send 处于 accept 阶段时, 由 send 自己的
+        // finishSendBeforeUserInput 负责清 turnInFlight + emit boundary,
+        // abort 不能抢清, 否则 boundary 丢失(review 3541310178)。
+        if (!sendInAcceptPhase) {
+          turnInFlight = false;
+          pendingToolIds.clear();
         }
         // 用户 Stop 的产品语义 = 本会话所有模型调用停止:先发 stopTask 再 interrupt
         // (同一控制通道按序处理),封掉「interrupt 后任务恰好完成 → task_notification
         // 自动续跑新 turn」的竞态窗口。fire-and-forget,不阻塞 interrupt。
         stopRunningWakeBackgroundTasks('user_stop');
+        const ABORT_INTERRUPT_TIMEOUT_MS = 10_000;
         try {
-          await q.interrupt();
+          await Promise.race([
+            q.interrupt(),
+            new Promise<void>((_, reject) =>
+              setTimeout(() => reject(new Error('INTERRUPT_TIMEOUT')), ABORT_INTERRUPT_TIMEOUT_MS),
+            ),
+          ]);
         } catch (e) {
-          // interrupt 失败 → 无 result 消费标记, 回收防误抑制(同 watchdog)。
-          turnState.interruptRequested = false;
-          log.warn('abort threw', { error: String(e) });
+          const errMsg = e instanceof Error ? e.message : String(e);
+          if (errMsg === 'INTERRUPT_TIMEOUT') {
+            // SDK 长时间不响应 interrupt(在 retry backoff 中) → 关 query 防止
+            // 信号悬挂。旧 q forward loop 随后按 U2 兜底收口, 事件循环自然终止。
+            log.warn('interrupt timed out during user stop — closing query', {
+              sdkSessionId,
+            });
+            try {
+              q.close();
+            } catch (closeError) {
+              log.warn('q.close after interrupt timeout threw', {
+                error: String(closeError),
+              });
+            }
+          } else {
+            // interrupt 真正抛错(非超时), 回收标记防误抑制(同 watchdog)。
+            turnState.interruptRequested = false;
+            log.warn('abort threw', { error: String(e) });
+          }
         }
       },
 

--- a/packages/maker-core/src/session.ts
+++ b/packages/maker-core/src/session.ts
@@ -99,12 +99,12 @@ export const STALL_ABORT_RECOVERY_GRACE_MS = 10_000;
 /**
  * 手动 abort(用户按 Stop)之后的复核宽限。
  *
- * 比看门狗那条(10s)长得多是刻意的:看门狗开火前已经确诊"整条链路零事件"，可以果断;
- * 手动 Stop 只说明用户想停，transport 很可能完全健康，只是这一次 interrupt 往返慢
- * (远端 daemon / SSH 隧道)。用 10s 判它"没生效"会把正常会话误关。60s 远超任何健康
- * 往返，又给"按了 Stop 却永远停不下来"留了有界出路(review #944 第十一轮 P1)。
+ * agent 层的 abort() 已自带 interrupt 超时(10s) + turnInFlight 即刻清除;
+ * 超时后走 q.close() → U2 兜底收口。本宽限是最后的保险:只保 agent 层 timeout
+ * 和 q.close() 都失败(极度罕见)的极端情况。从 60s 缩到 15s, 与 agent 层互不叠加,
+ * 端到端最长不超过 15s(review #944 第十一轮末尾调优)。
  */
-export const MANUAL_ABORT_RECOVERY_GRACE_MS = 60_000;
+export const MANUAL_ABORT_RECOVERY_GRACE_MS = 15_000;
 
 /**
  * turn 零事件看门狗的计时分片长度。额度按片累加,片尾核对真实经过时间,


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户按 Stop 后，`handle.abort()` 改为先清 `turnInFlight` 再 interrupt，与 upstream-idle watchdog 同模式。解决 SDK retry backoff 期间（如全池 OAuth 冷却 503 持续重试）不响应 interrupt 导致 session 假死的问题。

问题链路：
```
SDK retry 503 → api_retry 事件重置 idle timer → watchdog 不开火
→ 用户点 Stop → q.interrupt() 因 SDK 在 setTimeout 里等待重试而不返回
→ turnInFlight 永远是 true → isTurnRunning() = true
→ 后续 send 被 SESSION_RUNNING 拒 → session 假死
→ 只能等 60s abort 复核或重启
```

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（2026-08 实踩，全池 OAuth 冷却 503 持续重试）
- 本 PR 包含：`handle.abort()` 逻辑重写 + Session 层复核宽限缩短
- 明确不包含：SDK 层的 503 重试策略修改（在 Claude Code SDK 侧）
- 用户可见变化：点 Stop 后能立刻发新消息，不再卡死
- 是否存在 breaking change：无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：全部 PASS，零失败（包含 455 个 claude-code 测试 + 21 个 session 测试）

maker-core 定向：
npx vitest run src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
结果：20 passed（含 2 个新增的 abort 回归测试）

npx vitest run src/session.turn-stall.test.ts
结果：21 passed
```

### 手工验证

建议实机验证三个场景：
1. **正常 Stop**：生成中按 Stop，能立刻发下一条
2. **503 重试期间 Stop**（核心场景）：在 proxy debug 日志看到 retry 时按 Stop，不再卡死
3. **rewind 期间 Stop**：历史 rewind rebuild 过程中按 Stop，正常收口

### 未执行的验证

实机 503 模拟需配合上游限流场景，常规开发环境未复现。单元测试用 fake timers 覆盖了 interrupt 超时路径。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 `handle.abort()` 的执行时序和 Session 层复核宽限，不影响正常生成路径、rewind、send 等
- 回滚 / 降级方式：`git revert` 即可

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果

🤖 Generated with [Claude Code](https://claude.com/claude-code)