### PR TITLE
fix(im): 群历史保留改按存储大小,不再按条数

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -362,6 +362,40 @@ describe('recordGroupMessage', () => {
     expect(oldest.message_id).toBe('m0');
   });
 
+  it('额度按命名空间各算各的 —— 一个账号写爆不影响另一个', async () => {
+    // 两个账号同时在用时消息绝不能串, 额度也不能共用: 统计表以 provider 为主键,
+    // 回收也按 provider 过滤。个人 bot 的 telegram-personal:<botId> 同理另算。
+    const previousBytes = GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace;
+    GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = 2_000;
+    try {
+      // 另一个账号先放一条, 之后不再碰它。
+      sqlite
+        .prepare(
+          `INSERT INTO hook_group_messages
+             (provider, chat_id, thread_id, message_id, chat_name, author, is_bot, text, file_names, sent_at, created_at)
+           VALUES ('telegram:other', '-77', '', 'other-1', 'Other', '@y', 0, 'kept', NULL, 1, 1)`,
+        )
+        .run();
+
+      const body = 'x'.repeat(100);
+      for (let i = 0; i < 60; i += 1) {
+        await recordGroupMessage(frame({ messageId: `c${i}`, text: body }));
+      }
+
+      // 本账号被回收到低水位, 另一个账号一条不少。
+      const mine = sqlite
+        .prepare("SELECT COUNT(*) AS n FROM hook_group_messages WHERE provider = 'telegram:9'")
+        .get() as { n: number };
+      const other = sqlite
+        .prepare("SELECT COUNT(*) AS n FROM hook_group_messages WHERE provider = 'telegram:other'")
+        .get() as { n: number };
+      expect(mine.n).toBeLessThan(60);
+      expect(other.n).toBe(1);
+    } finally {
+      GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = previousBytes;
+    }
+  });
+
   it('超过字节上限时删最旧的, 并收敛到低水位', async () => {
     // 用一个很小的上限把回收逼出来 —— 真实默认值(1 GiB)正常使用碰不到。
     const previousBytes = GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace;

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -129,6 +129,37 @@ describe('groupLaneOf', () => {
   });
 });
 
+/** 2000 字节上限对应的低水位(上限的 90%)。 */
+const LOW_WATER_OF_2000 = 1_800;
+
+/** 用一个很小的字节上限跑回收, 结束后还原 —— 真实默认值(1 GiB)逼不出回收。 */
+async function withByteLimit(limit: number, body: () => Promise<void>): Promise<void> {
+  const previous = GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace;
+  GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = limit;
+  try {
+    await body();
+  } finally {
+    GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = previous;
+  }
+}
+
+function namespaceStats(provider = `telegram:${PRINCIPAL_ID}`): { b: number; n: number } {
+  const row = sqlite
+    .prepare(
+      'SELECT text_bytes AS b, row_count AS n FROM hook_group_message_stats WHERE provider = ?',
+    )
+    .get(provider) as { b: number; n: number } | undefined;
+  return row ?? { b: 0, n: 0 };
+}
+
+function hasMessage(messageId: string, provider = `telegram:${PRINCIPAL_ID}`): boolean {
+  return (
+    sqlite
+      .prepare('SELECT 1 FROM hook_group_messages WHERE provider = ? AND message_id = ?')
+      .get(provider, messageId) !== undefined
+  );
+}
+
 describe('recordGroupMessage', () => {
   it('同一条消息重放只落一行(幂等)', async () => {
     const payload = frame({ messageId: '4213' });
@@ -365,9 +396,7 @@ describe('recordGroupMessage', () => {
   it('额度按命名空间各算各的 —— 一个账号写爆不影响另一个', async () => {
     // 两个账号同时在用时消息绝不能串, 额度也不能共用: 统计表以 provider 为主键,
     // 回收也按 provider 过滤。个人 bot 的 telegram-personal:<botId> 同理另算。
-    const previousBytes = GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace;
-    GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = 2_000;
-    try {
+    await withByteLimit(2_000, async () => {
       // 另一个账号先放一条, 之后不再碰它。
       sqlite
         .prepare(
@@ -391,40 +420,79 @@ describe('recordGroupMessage', () => {
         .get() as { n: number };
       expect(mine.n).toBeLessThan(60);
       expect(other.n).toBe(1);
-    } finally {
-      GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = previousBytes;
-    }
+    });
   });
 
   it('超过字节上限时删最旧的, 并收敛到低水位', async () => {
     // 用一个很小的上限把回收逼出来 —— 真实默认值(1 GiB)正常使用碰不到。
-    const previousBytes = GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace;
-    GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = 2_000; // 约 20 条 100 字节的消息
-    try {
+    await withByteLimit(2_000, async () => {
       const body = 'x'.repeat(100);
-      for (let i = 0; i < 60; i += 1) {
+      // 第 21 条把总量顶到 2100 > 2000, 正好落在回收触发点上。
+      for (let i = 0; i < 21; i += 1) {
         await recordGroupMessage(frame({ messageId: `b${i}`, text: body }));
       }
-      const stats = sqlite
-        .prepare("SELECT text_bytes AS b, row_count AS n FROM hook_group_message_stats WHERE provider = 'telegram:9'")
-        .get() as { b: number; n: number };
-      // 收敛到低水位(上限的 90%)以内, 而不是刚好压线。
-      expect(stats.b).toBeLessThanOrEqual(2_000);
-      expect(stats.n).toBeGreaterThan(0);
+      const stats = namespaceStats();
+      // 收敛到低水位(上限的 90% = 1800)以内, 而不是刚好压到 2000 —— 否则超限后
+      // 每插一条都要删一条。
+      expect(stats.b).toBeLessThanOrEqual(LOW_WATER_OF_2000);
+      // 也不能删过头: 到了低水位就停, 不该继续往下清。
+      expect(stats.b).toBeGreaterThan(LOW_WATER_OF_2000 - 100);
       // 删的是最旧的: 最早那几条不在了, 最新那条还在。
-      expect(
-        sqlite
-          .prepare("SELECT 1 FROM hook_group_messages WHERE provider = 'telegram:9' AND message_id = 'b0'")
-          .get(),
-      ).toBeUndefined();
-      expect(
-        sqlite
-          .prepare("SELECT 1 FROM hook_group_messages WHERE provider = 'telegram:9' AND message_id = 'b59'")
-          .get(),
-      ).toBeDefined();
-    } finally {
-      GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = previousBytes;
-    }
+      expect(hasMessage('b0')).toBe(false);
+      expect(hasMessage('b20')).toBe(true);
+    });
+  });
+
+  it('旧行短新行长时也真的降到低水位 —— 边界按实际字节取, 不按平均行大小估', async () => {
+    // 平均行大小在这种分布下会严重低估: 一批 1 字节的附件消息 + 几条长文, 按均值
+    // 算出来的行数只会删掉那些零头旧行, text_bytes 几乎不降, 于是此后每插一条都
+    // 要再回收一次, 低水位形同虚设。
+    await withByteLimit(2_000, async () => {
+      for (let i = 0; i < 100; i += 1) {
+        await recordGroupMessage(frame({ messageId: `tiny${i}`, text: 'x' }));
+      }
+      const long = 'y'.repeat(500);
+      for (let i = 0; i < 4; i += 1) {
+        await recordGroupMessage(frame({ messageId: `long${i}`, text: long }));
+      }
+      // 一轮就到位: 边界越过全部 1 字节旧行, 吃进第一条长文。
+      expect(namespaceStats().b).toBeLessThanOrEqual(LOW_WATER_OF_2000);
+      expect(hasMessage('tiny0')).toBe(false);
+      expect(hasMessage('long3')).toBe(true);
+    });
+  });
+
+  it('阈值小到一条消息都放不下时保留最新一行, 不清空命名空间', async () => {
+    // 极端配置(或单条超大消息)下, 回收要么删到只剩最新一行为止, 要么整轮 no-op
+    // 让命名空间长期挂在超限状态 —— 两个都不能变成「删光」。
+    await withByteLimit(10, async () => {
+      for (let i = 0; i < 3; i += 1) {
+        await recordGroupMessage(frame({ messageId: `huge${i}`, text: 'z'.repeat(100) }));
+      }
+      expect(namespaceStats().n).toBe(1);
+      expect(hasMessage('huge2')).toBe(true);
+    });
+  });
+
+  it('并发入库不会把历史删过低水位 —— 同一命名空间的回收串行执行', async () => {
+    // 每次回收各读一次统计再各算边界, 不串行的话后跑的那次会从已回收过的剩余
+    // 记录再往后移边界, 把低水位以内的历史一起删掉。
+    // 注: better-sqlite3 是同步驱动, 这里复现不出真正的交错 —— 本例钉的是「并发
+    // 入库后仍停在低水位」这条不变量, 换成异步驱动或加了批量删除也不许破。
+    await withByteLimit(2_000, async () => {
+      const body = 'x'.repeat(100);
+      for (let i = 0; i < 20; i += 1) {
+        await recordGroupMessage(frame({ messageId: `p${i}`, text: body }));
+      }
+      await Promise.all(
+        [0, 1, 2, 3].map((i) => recordGroupMessage(frame({ messageId: `c${i}`, text: body }))),
+      );
+      const stats = namespaceStats();
+      expect(stats.b).toBeLessThanOrEqual(2_000);
+      // 只该收敛一次到低水位, 而不是被并发的几次回收接力删穿。
+      expect(stats.b).toBeGreaterThanOrEqual(LOW_WATER_OF_2000 - 100);
+      for (const id of ['c0', 'c1', 'c2', 'c3']) expect(hasMessage(id)).toBe(true);
+    });
   });
 });
 

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -474,11 +474,38 @@ describe('recordGroupMessage', () => {
     });
   });
 
+  it('反复触发回收不会越删越多 —— 判据是绝对目标, 不是「再删掉多少」', async () => {
+    // 这条钉的是**跨进程**安全: dev 包与正式包、多个 --passive 实例可能共用同一
+    // userData, 进程内的 Promise 串行管不着它们。判据若是相对量(「再删掉 X 字节」),
+    // 两个进程各读一次同样的旧统计就会各删一遍, 低水位被删穿, 极端情况一路删到
+    // 只剩一行。
+    //
+    // 现在判据是绝对目标(保住最新的这么多), 边界完全由执行那一刻的库内数据决定
+    // —— 同一份目标跑多少次都落在同一条线上。这里连跑几十轮回收, 水位必须始终
+    // 停在 [低水位, 上限] 这个带里, 不会一路下沉。
+    await withByteLimit(2_000, async () => {
+      const body = 'x'.repeat(100);
+      let sawRecycle = false;
+      for (let i = 0; i < 60; i += 1) {
+        await recordGroupMessage(frame({ messageId: `idem${i}`, text: body }));
+        const { b } = namespaceStats();
+        expect(b).toBeLessThanOrEqual(2_000);
+        if (i >= 21) {
+          // 已经进入回收区间: 水位在带内来回, 绝不下沉到低水位以下。
+          expect(b).toBeGreaterThanOrEqual(LOW_WATER_OF_2000 - 100);
+          if (b <= LOW_WATER_OF_2000) sawRecycle = true;
+        }
+      }
+      expect(sawRecycle).toBe(true); // 确认这几十轮里真的发生过回收, 用例没空转
+    });
+  });
+
   it('并发入库不会把历史删过低水位 —— 同一命名空间的回收串行执行', async () => {
     // 每次回收各读一次统计再各算边界, 不串行的话后跑的那次会从已回收过的剩余
     // 记录再往后移边界, 把低水位以内的历史一起删掉。
-    // 注: better-sqlite3 是同步驱动, 这里复现不出真正的交错 —— 本例钉的是「并发
-    // 入库后仍停在低水位」这条不变量, 换成异步驱动或加了批量删除也不许破。
+    // 注: better-sqlite3 是同步驱动, 这里复现不出真正的交错。真正保证并发(以及
+    // 跨进程)安全的是判据本身 —— 绝对目标 + 单条 DELETE, 见上一条幂等用例;
+    // 本例钉的是「并发入库后仍停在低水位」这条不变量。
     await withByteLimit(2_000, async () => {
       const body = 'x'.repeat(100);
       for (let i = 0; i < 20; i += 1) {

--- a/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/groupWindow.test.ts
@@ -30,7 +30,7 @@ import {
   recordGroupMessage as recordScopedGroupMessage,
   resetGroupContextCursors,
   sweepGroupWindowExpired,
-  WINDOW_KEEP_PER_PRINCIPAL,
+  GROUP_WINDOW_RETENTION,
 } from '../groupWindow.js';
 
 const PRINCIPAL_ID = '9';
@@ -346,55 +346,51 @@ describe('recordGroupMessage', () => {
     }
   });
 
-  it('群历史不按时间过期，但每个 principal + 群/topic 只保留最近 500 条', async () => {
-    for (let i = 0; i < 502; i += 1) {
+  it('单个群写入远超旧的 500 条上限也一条不删 —— 保留改按大小', async () => {
+    // 旧策略是每群只留最近 500 条。活跃群里那可能就是几天, 而这个池子的用途
+    // 正是回查很久以前的对话(「去年谁说了啥」)。
+    for (let i = 0; i < 1200; i += 1) {
       await recordGroupMessage(frame({ messageId: `m${i}`, text: `msg ${i}` }));
     }
     const rows = sqlite
       .prepare('SELECT COUNT(*) AS n FROM hook_group_messages WHERE chat_id = ?')
       .get('-900') as { n: number };
-    expect(rows.n).toBe(500);
+    expect(rows.n).toBe(1200);
     const oldest = sqlite
       .prepare('SELECT message_id FROM hook_group_messages ORDER BY id ASC LIMIT 1')
       .get() as { message_id: string };
-    expect(oldest.message_id).toBe('m2');
+    expect(oldest.message_id).toBe('m0');
   });
 
-  it('每个 principal 跨群和 topic 只保留最近的总量上限', async () => {
-    sqlite
-      .prepare(
-        `WITH RECURSIVE seq(n) AS (
-           SELECT 1
-           UNION ALL
-           SELECT n + 1 FROM seq WHERE n < ?
-         )
-         INSERT INTO hook_group_messages
-           (provider, chat_id, thread_id, message_id, chat_name, author, is_bot, text, file_names, sent_at, created_at)
-         SELECT 'telegram:9', '-' || n, '', 'old-' || n, 'Group ' || n, '@x', 0, 'old', NULL, n, n
-         FROM seq`,
-      )
-      .run(WINDOW_KEEP_PER_PRINCIPAL);
-
-    await recordGroupMessage(frame({ chatId: '-new', messageId: 'newest' }));
-
-    const count = sqlite
-      .prepare("SELECT COUNT(*) AS n FROM hook_group_messages WHERE provider = 'telegram:9'")
-      .get() as { n: number };
-    expect(count.n).toBe(WINDOW_KEEP_PER_PRINCIPAL);
-    expect(
-      sqlite
-        .prepare(
-          "SELECT 1 FROM hook_group_messages WHERE provider = 'telegram:9' AND message_id = 'old-1'",
-        )
-        .get(),
-    ).toBeUndefined();
-    expect(
-      sqlite
-        .prepare(
-          "SELECT 1 FROM hook_group_messages WHERE provider = 'telegram:9' AND message_id = 'newest'",
-        )
-        .get(),
-    ).toBeDefined();
+  it('超过字节上限时删最旧的, 并收敛到低水位', async () => {
+    // 用一个很小的上限把回收逼出来 —— 真实默认值(1 GiB)正常使用碰不到。
+    const previousBytes = GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace;
+    GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = 2_000; // 约 20 条 100 字节的消息
+    try {
+      const body = 'x'.repeat(100);
+      for (let i = 0; i < 60; i += 1) {
+        await recordGroupMessage(frame({ messageId: `b${i}`, text: body }));
+      }
+      const stats = sqlite
+        .prepare("SELECT text_bytes AS b, row_count AS n FROM hook_group_message_stats WHERE provider = 'telegram:9'")
+        .get() as { b: number; n: number };
+      // 收敛到低水位(上限的 90%)以内, 而不是刚好压线。
+      expect(stats.b).toBeLessThanOrEqual(2_000);
+      expect(stats.n).toBeGreaterThan(0);
+      // 删的是最旧的: 最早那几条不在了, 最新那条还在。
+      expect(
+        sqlite
+          .prepare("SELECT 1 FROM hook_group_messages WHERE provider = 'telegram:9' AND message_id = 'b0'")
+          .get(),
+      ).toBeUndefined();
+      expect(
+        sqlite
+          .prepare("SELECT 1 FROM hook_group_messages WHERE provider = 'telegram:9' AND message_id = 'b59'")
+          .get(),
+      ).toBeDefined();
+    } finally {
+      GROUP_WINDOW_RETENTION.maxTextBytesPerNamespace = previousBytes;
+    }
   });
 });
 

--- a/apps/desktop/src/main/hook-control/groupWindow.ts
+++ b/apps/desktop/src/main/hook-control/groupWindow.ts
@@ -24,6 +24,7 @@ import type { GroupMessagePayload, TaskDispatchPayload } from '@cindy/slack-hook
 import {
   assembleGroupWindowContext,
   createFenceNeutralizer,
+  DEFAULT_GROUP_WINDOW_RETENTION,
   recordGroupWindowEntry,
   resetGroupWindowCursors,
   type GroupContextAssembly,
@@ -37,27 +38,16 @@ export type { GroupContextAssembly };
 const log = createLogger('hook-group-window');
 
 /**
- * 每个 principal 的群历史保留上限 —— **按存储大小, 不按条数**(Chris 2026-08-08)。
+ * 官方 bot 这一侧生效的保留上限 —— 数值取共享默认值, 但**这份对象是官方独有的**。
  *
- * 旧策略是每群 500 条 + 每 principal 10000 条。活跃群里 500 条可能就是几天,
- * 而这个池子的用途正是回查很久以前的对话(「去年谁说了啥」)—— 按条数把它删没了。
+ * 额度本来就按 provider 命名空间(`telegram:<principalId>`)各算各的: 统计表以
+ * provider 为主键、回收也按 provider 过滤。两个账号同时在用就是两份独立额度,
+ * 个人 bot 的 `telegram-personal:<botId>` 更是另一块 —— 谁也吃不掉谁的份。
  *
- * 1 GiB 正文字节按一条群消息 100~300 字节估, 大约是几百万到上千万条; 一个日活
- * 500 条的群一年约 20~50 MB, 也就是几十个活跃群存好几年。碰不到的默认值正是
- * 目的: 它是安全阀, 不是日常清理。
+ * 做成可变对象只为让测试用小阈值把回收逼出来; 拿 1 GiB 默认值写回归等于在测试
+ * 里灌一 GB 数据。
  */
-export const WINDOW_MAX_TEXT_BYTES_PER_PRINCIPAL = 1024 * 1024 * 1024;
-/** 安全阀: 防止海量极短消息把行开销撑爆。正常使用碰不到。 */
-export const WINDOW_MAX_ROWS_PER_PRINCIPAL = 5_000_000;
-
-/**
- * 生效中的保留上限。做成可变对象只为让测试用一个小阈值把回收逼出来 —— 真实
- * 默认值大到正常使用碰不到, 拿默认值写回归等于在测试里灌 1 GiB 数据。
- */
-export const GROUP_WINDOW_RETENTION = {
-  maxTextBytesPerNamespace: WINDOW_MAX_TEXT_BYTES_PER_PRINCIPAL,
-  maxRowsPerNamespace: WINDOW_MAX_ROWS_PER_PRINCIPAL,
-};
+export const GROUP_WINDOW_RETENTION = { ...DEFAULT_GROUP_WINDOW_RETENTION };
 
 /**
  * 从 externalKey 解析 Telegram 群/topic lane。

--- a/apps/desktop/src/main/hook-control/groupWindow.ts
+++ b/apps/desktop/src/main/hook-control/groupWindow.ts
@@ -36,10 +36,28 @@ export type { GroupContextAssembly };
 
 const log = createLogger('hook-group-window');
 
-/** 每个 principal + 群/topic 窗口永久保留的最近行数。 */
-const WINDOW_KEEP_PER_KEY = 500;
-/** 每个 principal 跨全部群/topic 永久保留的最近行数。 */
-export const WINDOW_KEEP_PER_PRINCIPAL = 10_000;
+/**
+ * 每个 principal 的群历史保留上限 —— **按存储大小, 不按条数**(Chris 2026-08-08)。
+ *
+ * 旧策略是每群 500 条 + 每 principal 10000 条。活跃群里 500 条可能就是几天,
+ * 而这个池子的用途正是回查很久以前的对话(「去年谁说了啥」)—— 按条数把它删没了。
+ *
+ * 1 GiB 正文字节按一条群消息 100~300 字节估, 大约是几百万到上千万条; 一个日活
+ * 500 条的群一年约 20~50 MB, 也就是几十个活跃群存好几年。碰不到的默认值正是
+ * 目的: 它是安全阀, 不是日常清理。
+ */
+export const WINDOW_MAX_TEXT_BYTES_PER_PRINCIPAL = 1024 * 1024 * 1024;
+/** 安全阀: 防止海量极短消息把行开销撑爆。正常使用碰不到。 */
+export const WINDOW_MAX_ROWS_PER_PRINCIPAL = 5_000_000;
+
+/**
+ * 生效中的保留上限。做成可变对象只为让测试用一个小阈值把回收逼出来 —— 真实
+ * 默认值大到正常使用碰不到, 拿默认值写回归等于在测试里灌 1 GiB 数据。
+ */
+export const GROUP_WINDOW_RETENTION = {
+  maxTextBytesPerNamespace: WINDOW_MAX_TEXT_BYTES_PER_PRINCIPAL,
+  maxRowsPerNamespace: WINDOW_MAX_ROWS_PER_PRINCIPAL,
+};
 
 /**
  * 从 externalKey 解析 Telegram 群/topic lane。
@@ -109,7 +127,7 @@ export async function recordGroupMessage(
       fileNames: payload.fileNames,
       sentAt: payload.sentAt,
     },
-    { keepPerKey: WINDOW_KEEP_PER_KEY, keepPerNamespace: WINDOW_KEEP_PER_PRINCIPAL },
+    GROUP_WINDOW_RETENTION,
   );
 }
 

--- a/apps/desktop/src/main/im/shared/__tests__/groupWindowRetentionProxy.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/groupWindowRetentionProxy.test.ts
@@ -1,0 +1,129 @@
+/**
+ * groupWindowRetentionProxy.test.ts — 群历史回收在 **worker RPC 代理**下的回归。
+ *
+ * 背景: main 侧拿到的 drizzle 是 createDrizzleProxy 的代理, 它只把 **query builder**
+ * 的终结方法转发给 worker RPC。回收的边界查询原先写成 `db.all(sql`...`)`, 不经过
+ * builder, 会落进代理内部只会抛错的 fakeSqliteClient.prepare() —— 也就是回收在
+ * 生产上 100% 失败, 1 GiB / 500 万行上限完全不生效。
+ *
+ * 所以 harness 必须用**代理**建, 不能用真实 `drizzle(sqlite)`: 同样的用例在真实
+ * drizzle 上会假绿, 这正是 bug 当初溜过去的原因(与 recentWorkdirs 的 LRU 驱逐
+ * 同一类踩坑, 见 localDb/ipc/__tests__/recentWorkdirsLru.test.ts)。
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { DbTransport } from '../../../localDb/client/DbTransport.js';
+
+const h = vi.hoisted(() => ({
+  sqlite: null as InstanceType<typeof import('better-sqlite3')> | null,
+  client: null as { drizzle: unknown } | null,
+}));
+
+vi.mock('../../../logger', () => ({
+  createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  maskPath: (p: string) => p,
+}));
+vi.mock('../../../localDb/client/current', () => ({
+  getDbClient: () => h.client,
+  tryGetDbClient: () => h.client,
+}));
+
+import { createDrizzleProxy } from '../../../localDb/client/drizzleProxy';
+import { recordGroupWindowEntry } from '../groupWindowCore';
+
+const PROVIDER = 'telegram-personal:proxy-bot';
+
+/** 按 worker/dispatcher.ts 的 op 语义把 SQL 转发给真实 in-memory SQLite。 */
+function createTransport(): DbTransport {
+  return {
+    send: async (op: string, args?: unknown) => {
+      const { sql: text, params = [] } = (args ?? {}) as { sql: string; params?: unknown[] };
+      const stmt = h.sqlite!.prepare(text);
+      if (op === 'query') return stmt.all(...(params as never[]));
+      if (op === 'queryOne') return stmt.get(...(params as never[]));
+      if (op === 'rawAll') return stmt.raw().all(...(params as never[]));
+      if (op === 'rawGet') return stmt.raw().get(...(params as never[]));
+      if (op === 'run' || op === 'exec') return stmt.run(...(params as never[]));
+      throw new Error(`unexpected op: ${op}`);
+    },
+    on: () => {},
+    onTerminated: () => {},
+    close: async () => {},
+  } as unknown as DbTransport;
+}
+
+function migrationSql(): string {
+  const dir = path.resolve(__dirname, '../../../../../drizzle');
+  return ['0083_', '0086_', '0087_', '0088_']
+    .map((prefix) => {
+      const file = fs.readdirSync(dir).find((name) => name.startsWith(prefix));
+      if (!file) throw new Error(`${prefix} migration not found`);
+      return fs.readFileSync(path.join(dir, file), 'utf8');
+    })
+    .join('\n')
+    .replaceAll('--> statement-breakpoint', ';');
+}
+
+function stats(): { b: number; n: number } {
+  const row = h.sqlite!
+    .prepare(
+      'SELECT text_bytes AS b, row_count AS n FROM hook_group_message_stats WHERE provider = ?',
+    )
+    .get(PROVIDER) as { b: number; n: number } | undefined;
+  return row ?? { b: 0, n: 0 };
+}
+
+beforeEach(() => {
+  h.sqlite?.close();
+  const sqlite = new Database(':memory:');
+  sqlite.exec(migrationSql());
+  h.sqlite = sqlite;
+  const transport = createTransport();
+  h.client = { drizzle: createDrizzleProxy(() => transport) };
+});
+
+afterEach(() => {
+  h.sqlite?.close();
+  h.sqlite = null;
+});
+
+describe('群历史回收(worker RPC 代理下)', () => {
+  it('回收真的执行了 —— 边界查询整条走 query builder, 不是 raw SQL', async () => {
+    // 上限 2000 字节, 低水位 1800。第 21 条 100 字节的消息把总量顶到 2100,
+    // 正好落在触发点上。raw SQL 那版会在这里抛 "should execute through worker RPC"。
+    const retention = { maxTextBytesPerNamespace: 2_000, maxRowsPerNamespace: 5_000_000 };
+    const body = 'x'.repeat(100);
+    for (let i = 0; i < 21; i += 1) {
+      await recordGroupWindowEntry(
+        {
+          provider: PROVIDER,
+          chatId: '-900',
+          threadId: '',
+          messageId: `p${i}`,
+          author: { name: '@u' },
+          text: body,
+          sentAt: 1,
+        },
+        retention,
+      );
+    }
+
+    const after = stats();
+    expect(after.b).toBeLessThanOrEqual(1_800); // 收敛到低水位, 不是压线
+    expect(after.b).toBeGreaterThan(1_700); // 也没删过头
+    expect(
+      h.sqlite!
+        .prepare('SELECT 1 FROM hook_group_messages WHERE provider = ? AND message_id = ?')
+        .get(PROVIDER, 'p0'),
+    ).toBeUndefined(); // 删的是最旧的
+    expect(
+      h.sqlite!
+        .prepare('SELECT 1 FROM hook_group_messages WHERE provider = ? AND message_id = ?')
+        .get(PROVIDER, 'p20'),
+    ).toBeDefined(); // 最新的还在
+  });
+});

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -5,7 +5,7 @@
  * 读写、GC、游标与统计均不得跨命名空间。
  */
 
-import { and, desc, eq, gt, like, lt, or, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gt, like, lte, or, sql, type SQL } from 'drizzle-orm';
 
 import { getDbClient, tryGetDbClient } from '../../localDb/client/current';
 import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
@@ -50,6 +50,13 @@ export type GroupWindowRetentionPolicy = {
 
 /** 触发回收后收敛到上限的这个比例, 避免超限后每插一条都删一条。 */
 const RETENTION_LOW_WATER_RATIO = 0.9;
+/**
+ * 一次入库最多收敛几轮。
+ *
+ * 边界按实际累计字节取, 正常一轮就到位; 多留几轮是兜住并发写入在两次统计之间
+ * 又插了一批的情况, 同时保证不会无限循环。
+ */
+const RETENTION_MAX_PASSES = 4;
 
 /**
  * 保留上限的**默认数值** —— 官方与个人 bot 共用同一组数字, 但各自持有一份。
@@ -151,6 +158,15 @@ export async function recordGroupWindowEntry(
 }
 
 /**
+ * 同一命名空间的回收串行化。
+ *
+ * 并发入库时两次回收会各读一次统计、各算一次边界, 算出的删除范围互相重叠 ——
+ * 后跑的那次从**已经回收过**的剩余记录再往后移边界, 把低水位以内的历史也一起
+ * 删了。串起来跑就只有第一次真正动手, 后面那次重读统计发现已在水位内直接退出。
+ */
+const retentionRuns = new Map<string, Promise<void>>();
+
+/**
  * 按存储大小回收一个 provider 命名空间的群历史。
  *
  * 删的是**最旧的行**(按自增 id), 跨群一视同仁 —— 与「保留最近这段时间」的直觉
@@ -160,41 +176,95 @@ export async function recordGroupWindowEntry(
  * 触发即回收到**低水位**(上限的 90%)而不是刚好压线, 否则超限后每插一条都要删一条,
  * 每次入库都带一次删除。
  */
-async function enforceNamespaceRetention(
+function enforceNamespaceRetention(
   provider: string,
   retention: GroupWindowRetentionPolicy,
 ): Promise<void> {
-  const db = getDbClient().drizzle;
-  const stats = await getGroupWindowNamespaceStats(provider);
-  const overBytes = stats.textBytes > retention.maxTextBytesPerNamespace;
-  const overRows = stats.rows > retention.maxRowsPerNamespace;
-  if (!overBytes && !overRows) return;
+  const run = (retentionRuns.get(provider) ?? Promise.resolve())
+    .catch(() => undefined)
+    .then(() => runNamespaceRetention(provider, retention));
+  retentionRuns.set(provider, run);
+  return run.finally(() => {
+    if (retentionRuns.get(provider) === run) retentionRuns.delete(provider);
+  });
+}
 
-  // 行数安全阀按行数直接切; 字节按平均行大小估算要删多少行, 再由低水位收敛 ——
-  // 单行大小差异很大(一条纯表情 vs 一条长文), 估算不准也没关系: 下一次入库会
-  // 继续收, 而低水位保证不会每条都触发。
+async function runNamespaceRetention(
+  provider: string,
+  retention: GroupWindowRetentionPolicy,
+): Promise<void> {
   const targetBytes = Math.floor(retention.maxTextBytesPerNamespace * RETENTION_LOW_WATER_RATIO);
   const targetRows = Math.floor(retention.maxRowsPerNamespace * RETENTION_LOW_WATER_RATIO);
-  const avgRowBytes = stats.rows > 0 ? Math.max(1, stats.textBytes / stats.rows) : 1;
-  const rowsToDropForBytes = overBytes
-    ? Math.ceil((stats.textBytes - targetBytes) / avgRowBytes)
-    : 0;
-  const rowsToDropForRows = overRows ? stats.rows - targetRows : 0;
-  const dropCount = Math.max(rowsToDropForBytes, rowsToDropForRows);
-  if (dropCount <= 0) return;
+  let stats = await getGroupWindowNamespaceStats(provider);
+  // 只有真的越过上限才动手; 一旦动手就收到低水位, 而不是刚好压线。
+  if (
+    stats.textBytes <= retention.maxTextBytesPerNamespace &&
+    stats.rows <= retention.maxRowsPerNamespace
+  )
+    return;
 
-  const boundary = await db
-    .select({ id: hookGroupMessages.id })
-    .from(hookGroupMessages)
-    .where(eq(hookGroupMessages.provider, provider))
-    .orderBy(hookGroupMessages.id)
-    .limit(1)
-    .offset(dropCount);
-  const threshold = boundary[0]?.id;
-  if (threshold === undefined) return; // 命名空间里的行还不够删, 留着
-  await db
+  for (let pass = 0; pass < RETENTION_MAX_PASSES; pass += 1) {
+    if (stats.textBytes <= targetBytes && stats.rows <= targetRows) return;
+    // 删不动了(只剩最新一行还超限, 比如单条超大消息配极小阈值): 留着, 不清空。
+    if (!(await dropOldestUntilLowWater(provider, stats, targetBytes, targetRows))) return;
+    stats = await getGroupWindowNamespaceStats(provider);
+  }
+}
+
+/**
+ * 删掉最旧的行直到落进低水位; 返回是否真的删掉了行。
+ *
+ * 边界按**待删行实际累计的正文字节**取, 不按平均行大小估算 —— 一批空正文的附件
+ * 消息后面跟着长文时, 平均值会让回收删掉一堆零字节的旧行却几乎不掉 `text_bytes`,
+ * 于是此后每插一条都要再回收一次, 低水位形同虚设。
+ */
+async function dropOldestUntilLowWater(
+  provider: string,
+  stats: { rows: number; textBytes: number },
+  targetBytes: number,
+  targetRows: number,
+): Promise<boolean> {
+  const db = getDbClient().drizzle;
+  // 至少留最新一行 —— 阈值被配得极小时不能把整个命名空间清空。
+  const maxDrop = Math.max(0, stats.rows - 1);
+  if (maxDrop === 0) return false;
+  const bytesToFree = Math.max(0, stats.textBytes - targetBytes);
+  const rowsToDrop = Math.max(0, stats.rows - targetRows);
+
+  // 最旧的 maxDrop 行里, 第一个同时满足「累计字节够」与「行数够」的位置就是边界。
+  const boundary = await db.all<{ id: number }>(sql`
+    select id from (
+      select id,
+        sum(length(cast(text as blob))) over (order by id) as cum_bytes,
+        row_number() over (order by id) as rn
+      from ${hookGroupMessages}
+      where provider = ${provider}
+      order by id
+      limit ${maxDrop}
+    )
+    where cum_bytes >= ${bytesToFree} and rn >= ${rowsToDrop}
+    order by id
+    limit 1
+  `);
+  let threshold = boundary[0]?.id;
+  if (threshold === undefined) {
+    // 把能删的都删了也到不了低水位: 删到只剩最新一行为止, 而不是整轮 no-op ——
+    // 否则命名空间会长期挂在超限状态, 每次入库都白跑一遍回收。
+    const [last] = await db
+      .select({ id: hookGroupMessages.id })
+      .from(hookGroupMessages)
+      .where(eq(hookGroupMessages.provider, provider))
+      .orderBy(hookGroupMessages.id)
+      .limit(1)
+      .offset(maxDrop - 1);
+    threshold = last?.id;
+  }
+  if (threshold === undefined) return false;
+  const deleted = await db
     .delete(hookGroupMessages)
-    .where(and(eq(hookGroupMessages.provider, provider), lt(hookGroupMessages.id, threshold)));
+    .where(and(eq(hookGroupMessages.provider, provider), lte(hookGroupMessages.id, threshold)))
+    .run();
+  return deleted.changes > 0;
 }
 
 async function readPersistedCursor(provider: string, cursorKey: string): Promise<number> {

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -41,15 +41,32 @@ const CURSOR_ROLLBACK_RETRY_DELAY_MS = 25;
  * `maxRowsPerNamespace` 只是防止极端行数膨胀的安全阀(海量空消息把行开销撑爆),
  * 设得足够高, 正常使用永远碰不到 —— 它不是日常清理手段。
  */
-/** 触发回收后收敛到上限的这个比例, 避免超限后每插一条都删一条。 */
-const RETENTION_LOW_WATER_RATIO = 0.9;
-
 export type GroupWindowRetentionPolicy = {
   /** 该 provider 命名空间保留的正文字节上限。 */
   maxTextBytesPerNamespace: number;
   /** 安全阀: 行数上限。 */
   maxRowsPerNamespace: number;
 };
+
+/** 触发回收后收敛到上限的这个比例, 避免超限后每插一条都删一条。 */
+const RETENTION_LOW_WATER_RATIO = 0.9;
+
+/**
+ * 保留上限的**默认数值** —— 官方与个人 bot 共用同一组数字, 但各自持有一份。
+ *
+ * 数据与额度是天然分离的: 每条记录带 provider 命名空间(官方
+ * `telegram:<principalId>`、个人 `telegram-personal:<botId>`), 统计表以 provider
+ * 为主键、回收也按 provider 过滤 —— 两个账号同时在用就是两个命名空间、两份独立
+ * 额度, 谁也吃不掉谁的份, 消息更不会串。这里共享的只是「1 GiB 这个数」, 不是
+ * 这 1 GiB 本身。
+ *
+ * 1 GiB 按一条群消息 100~300 字节估约几百万到上千万条; 日活 500 条的群一年
+ * 20~50 MB。碰不到正是目的: 它是安全阀, 不是日常清理。
+ */
+export const DEFAULT_GROUP_WINDOW_RETENTION: Readonly<GroupWindowRetentionPolicy> = Object.freeze({
+  maxTextBytesPerNamespace: 1024 * 1024 * 1024,
+  maxRowsPerNamespace: 5_000_000,
+});
 
 export interface GroupWindowEntryInput {
   provider: string;

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -5,7 +5,7 @@
  * 读写、GC、游标与统计均不得跨命名空间。
  */
 
-import { and, desc, eq, gt, like, lte, or, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gt, gte, like, lte, or, sql, type SQL } from 'drizzle-orm';
 
 import { getDbClient, tryGetDbClient } from '../../localDb/client/current';
 import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
@@ -135,6 +135,11 @@ export async function recordGroupWindowEntry(
 ): Promise<boolean> {
   const db = getDbClient().drizzle;
   const storedText = prepareGroupWindowText(entry.provider, entry.text);
+  // 用 `.run()` 的 changes 判重, **不能用 `.returning()`**: main 侧的 drizzle 是
+  // createDrizzleProxy 的代理, 它对没有 select fields 的 builder 一律走 'run' op 并
+  // 返回空数组(proxy 里写明「RETURNING 当前未使用」)。于是 `.returning()` 在生产上
+  // 恒得空数组 —— 每条入库都被判成重复, 直接 return false, 回收与容量观测一次都
+  // 不会跑。onConflictDoNothing 下 changes===0 正是「这条已存在」, 语义等价。
   const inserted = await db
     .insert(hookGroupMessages)
     .values({
@@ -151,8 +156,8 @@ export async function recordGroupWindowEntry(
       createdAt: Date.now(),
     })
     .onConflictDoNothing()
-    .returning({ id: hookGroupMessages.id });
-  if (inserted.length === 0) return false;
+    .run();
+  if (inserted.changes === 0) return false;
   if (retention === undefined) {
     await maybeLogGroupWindowNamespaceStats(entry.provider);
     return true;
@@ -238,20 +243,32 @@ async function dropOldestUntilLowWater(
   const rowsToDrop = Math.max(0, stats.rows - targetRows);
 
   // 最旧的 maxDrop 行里, 第一个同时满足「累计字节够」与「行数够」的位置就是边界。
-  const boundary = await db.all<{ id: number }>(sql`
-    select id from (
-      select id,
-        sum(length(cast(text as blob))) over (order by id) as cum_bytes,
-        row_number() over (order by id) as rn
-      from ${hookGroupMessages}
-      where provider = ${provider}
-      order by id
-      limit ${maxDrop}
-    )
-    where cum_bytes >= ${bytesToFree} and rn >= ${rowsToDrop}
-    order by id
-    limit 1
-  `);
+  //
+  // 必须整条走 **query builder**: main 侧拿到的 drizzle 是 createDrizzleProxy 的
+  // 代理, 只把 builder 的终结方法转发给 worker RPC。直接 `db.all(sql\`...\`)` 不经过
+  // builder, 会落进代理内部只会抛错的 fakeSqliteClient.prepare() —— 回收在生产上
+  // 100% 失败, 而单测若用真实 drizzle 建 harness 就会假绿(与 recentWorkdirs 的
+  // LRU 驱逐同一类踩坑, 见 localDb/ipc/__tests__/recentWorkdirsLru.test.ts)。
+  const oldest = db
+    .select({
+      id: hookGroupMessages.id,
+      cumBytes:
+        sql<number>`sum(length(cast(${hookGroupMessages.text} as blob))) over (order by ${hookGroupMessages.id})`.as(
+          'cum_bytes',
+        ),
+      rn: sql<number>`row_number() over (order by ${hookGroupMessages.id})`.as('rn'),
+    })
+    .from(hookGroupMessages)
+    .where(eq(hookGroupMessages.provider, provider))
+    .orderBy(hookGroupMessages.id)
+    .limit(maxDrop)
+    .as('oldest');
+  const boundary = await db
+    .select({ id: oldest.id })
+    .from(oldest)
+    .where(and(gte(oldest.cumBytes, bytesToFree), gte(oldest.rn, rowsToDrop)))
+    .orderBy(oldest.id)
+    .limit(1);
   let threshold = boundary[0]?.id;
   if (threshold === undefined) {
     // 把能删的都删了也到不了低水位: 删到只剩最新一行为止, 而不是整轮 no-op ——

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -11,6 +11,7 @@ import { getDbClient, tryGetDbClient } from '../../localDb/client/current';
 import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
 import type { Logger } from '../../logger';
 import {
+  getGroupWindowNamespaceStats,
   maybeLogGroupWindowNamespaceStats,
   maybeSweepExpiredGroupWindowCursors,
   prepareGroupWindowText,
@@ -30,7 +31,25 @@ const CURSOR_MAX_KEYS = 1000;
 const CURSOR_ROLLBACK_MAX_ATTEMPTS = 3;
 const CURSOR_ROLLBACK_RETRY_DELAY_MS = 25;
 
-export type GroupWindowRetentionPolicy = { keepPerKey: number; keepPerNamespace: number };
+/**
+ * 群消息池的保留上限 —— **按存储大小, 不按条数**。
+ *
+ * 按条数(旧策略: 每群 500 条)在活跃群里几天就把去年的内容挤没了, 而这个池子的
+ * 用途正是回查很久以前的对话(「去年谁说了啥」)。字节口径由 `hook_group_message_stats`
+ * 的 SQLite 触发器在增删改时自动维护, 判定几乎零额外开销。
+ *
+ * `maxRowsPerNamespace` 只是防止极端行数膨胀的安全阀(海量空消息把行开销撑爆),
+ * 设得足够高, 正常使用永远碰不到 —— 它不是日常清理手段。
+ */
+/** 触发回收后收敛到上限的这个比例, 避免超限后每插一条都删一条。 */
+const RETENTION_LOW_WATER_RATIO = 0.9;
+
+export type GroupWindowRetentionPolicy = {
+  /** 该 provider 命名空间保留的正文字节上限。 */
+  maxTextBytesPerNamespace: number;
+  /** 安全阀: 行数上限。 */
+  maxRowsPerNamespace: number;
+};
 
 export interface GroupWindowEntryInput {
   provider: string;
@@ -109,43 +128,56 @@ export async function recordGroupWindowEntry(
     return true;
   }
 
-  const keyFilter = and(
-    eq(hookGroupMessages.provider, entry.provider),
-    eq(hookGroupMessages.chatId, entry.chatId),
-    eq(hookGroupMessages.threadId, entry.threadId),
-  );
-  const oldestKept = await db
-    .select({ id: hookGroupMessages.id })
-    .from(hookGroupMessages)
-    .where(keyFilter)
-    .orderBy(desc(hookGroupMessages.id))
-    .limit(1)
-    .offset(retention.keepPerKey - 1);
-  const threshold = oldestKept[0]?.id;
-  if (threshold !== undefined) {
-    await db.delete(hookGroupMessages).where(and(keyFilter, lt(hookGroupMessages.id, threshold)));
-  }
-
-  const oldestNamespaceRowKept = await db
-    .select({ id: hookGroupMessages.id })
-    .from(hookGroupMessages)
-    .where(eq(hookGroupMessages.provider, entry.provider))
-    .orderBy(desc(hookGroupMessages.id))
-    .limit(1)
-    .offset(retention.keepPerNamespace - 1);
-  const namespaceThreshold = oldestNamespaceRowKept[0]?.id;
-  if (namespaceThreshold !== undefined) {
-    await db
-      .delete(hookGroupMessages)
-      .where(
-        and(
-          eq(hookGroupMessages.provider, entry.provider),
-          lt(hookGroupMessages.id, namespaceThreshold),
-        ),
-      );
-  }
+  await enforceNamespaceRetention(entry.provider, retention);
   await maybeLogGroupWindowNamespaceStats(entry.provider);
   return true;
+}
+
+/**
+ * 按存储大小回收一个 provider 命名空间的群历史。
+ *
+ * 删的是**最旧的行**(按自增 id), 跨群一视同仁 —— 与「保留最近这段时间」的直觉
+ * 一致。刻意不再有「每群只留 N 条」那一级: 它会让活跃群几天内就把去年的内容挤没,
+ * 而这个池子的用途正是回查很久以前的对话。
+ *
+ * 触发即回收到**低水位**(上限的 90%)而不是刚好压线, 否则超限后每插一条都要删一条,
+ * 每次入库都带一次删除。
+ */
+async function enforceNamespaceRetention(
+  provider: string,
+  retention: GroupWindowRetentionPolicy,
+): Promise<void> {
+  const db = getDbClient().drizzle;
+  const stats = await getGroupWindowNamespaceStats(provider);
+  const overBytes = stats.textBytes > retention.maxTextBytesPerNamespace;
+  const overRows = stats.rows > retention.maxRowsPerNamespace;
+  if (!overBytes && !overRows) return;
+
+  // 行数安全阀按行数直接切; 字节按平均行大小估算要删多少行, 再由低水位收敛 ——
+  // 单行大小差异很大(一条纯表情 vs 一条长文), 估算不准也没关系: 下一次入库会
+  // 继续收, 而低水位保证不会每条都触发。
+  const targetBytes = Math.floor(retention.maxTextBytesPerNamespace * RETENTION_LOW_WATER_RATIO);
+  const targetRows = Math.floor(retention.maxRowsPerNamespace * RETENTION_LOW_WATER_RATIO);
+  const avgRowBytes = stats.rows > 0 ? Math.max(1, stats.textBytes / stats.rows) : 1;
+  const rowsToDropForBytes = overBytes
+    ? Math.ceil((stats.textBytes - targetBytes) / avgRowBytes)
+    : 0;
+  const rowsToDropForRows = overRows ? stats.rows - targetRows : 0;
+  const dropCount = Math.max(rowsToDropForBytes, rowsToDropForRows);
+  if (dropCount <= 0) return;
+
+  const boundary = await db
+    .select({ id: hookGroupMessages.id })
+    .from(hookGroupMessages)
+    .where(eq(hookGroupMessages.provider, provider))
+    .orderBy(hookGroupMessages.id)
+    .limit(1)
+    .offset(dropCount);
+  const threshold = boundary[0]?.id;
+  if (threshold === undefined) return; // 命名空间里的行还不够删, 留着
+  await db
+    .delete(hookGroupMessages)
+    .where(and(eq(hookGroupMessages.provider, provider), lt(hookGroupMessages.id, threshold)));
 }
 
 async function readPersistedCursor(provider: string, cursorKey: string): Promise<number> {

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -5,7 +5,7 @@
  * 读写、GC、游标与统计均不得跨命名空间。
  */
 
-import { and, desc, eq, gt, gte, like, lte, or, sql, type SQL } from 'drizzle-orm';
+import { and, desc, eq, gt, like, lt, lte, or, sql, type SQL } from 'drizzle-orm';
 
 import { getDbClient, tryGetDbClient } from '../../localDb/client/current';
 import { hookGroupContextCursors, hookGroupMessages } from '../../localDb/schema';
@@ -56,13 +56,6 @@ export type GroupWindowRetentionPolicy = {
 
 /** 触发回收后收敛到上限的这个比例, 避免超限后每插一条都删一条。 */
 const RETENTION_LOW_WATER_RATIO = 0.9;
-/**
- * 一次入库最多收敛几轮。
- *
- * 边界按实际累计字节取, 正常一轮就到位; 多留几轮是兜住并发写入在两次统计之间
- * 又插了一批的情况, 同时保证不会无限循环。
- */
-const RETENTION_MAX_PASSES = 4;
 
 /**
  * 保留上限的**默认数值** —— 官方与个人 bot 共用同一组数字, 但各自持有一份。
@@ -204,90 +197,76 @@ async function runNamespaceRetention(
   provider: string,
   retention: GroupWindowRetentionPolicy,
 ): Promise<void> {
-  const targetBytes = Math.floor(retention.maxTextBytesPerNamespace * RETENTION_LOW_WATER_RATIO);
-  const targetRows = Math.floor(retention.maxRowsPerNamespace * RETENTION_LOW_WATER_RATIO);
-  let stats = await getGroupWindowNamespaceStats(provider);
-  // 只有真的越过上限才动手; 一旦动手就收到低水位, 而不是刚好压线。
+  const stats = await getGroupWindowNamespaceStats(provider);
+  // 只有真的越过上限才动手 —— 常态下回收的全部成本就是这一行统计读取。
+  // 一旦动手就收到低水位, 而不是刚好压线, 否则超限后每插一条都要删一条。
   if (
     stats.textBytes <= retention.maxTextBytesPerNamespace &&
     stats.rows <= retention.maxRowsPerNamespace
   )
     return;
-
-  for (let pass = 0; pass < RETENTION_MAX_PASSES; pass += 1) {
-    if (stats.textBytes <= targetBytes && stats.rows <= targetRows) return;
-    // 删不动了(只剩最新一行还超限, 比如单条超大消息配极小阈值): 留着, 不清空。
-    if (!(await dropOldestUntilLowWater(provider, stats, targetBytes, targetRows))) return;
-    stats = await getGroupWindowNamespaceStats(provider);
-  }
+  await keepNewestWithinTargets(
+    provider,
+    Math.floor(retention.maxTextBytesPerNamespace * RETENTION_LOW_WATER_RATIO),
+    Math.max(1, Math.floor(retention.maxRowsPerNamespace * RETENTION_LOW_WATER_RATIO)),
+  );
 }
 
 /**
- * 删掉最旧的行直到落进低水位; 返回是否真的删掉了行。
+ * 把该命名空间收敛到「最新的这些留下, 更旧的删掉」—— **一条 DELETE 说完**。
  *
- * 边界按**待删行实际累计的正文字节**取, 不按平均行大小估算 —— 一批空正文的附件
- * 消息后面跟着长文时, 平均值会让回收删掉一堆零字节的旧行却几乎不掉 `text_bytes`,
- * 于是此后每插一条都要再回收一次, 低水位形同虚设。
+ * 判据是**绝对目标**(保住最新的 targetBytes 字节 / targetRows 行), 不是相对量
+ * (「再删掉 X 字节」)。这条差别决定了并发安全:
+ *
+ * - 相对量要先读统计再算删多少。两个进程(dev + 正式包、多个 --passive 实例共用
+ *   同一 userData)各自读到同一份旧统计, 就会各删一遍, 低水位被删穿, 极端情况
+ *   一路删到只剩一行。进程内的 Promise 串行只管得住自己这一个进程。
+ * - 绝对目标下, 边界完全由**执行那一刻的库内数据**决定: 谁先跑谁把线划在同一
+ *   个位置, 后跑的那个重算一遍得到同一条线, 于是删不到任何东西。天然幂等,
+ *   重复执行、并发执行、跨进程执行结果都一样, 不需要锁、事务或版本号 CAS,
+ *   也就不需要动 schema。
+ *
+ * 边界取法: 从**最新往回**累计正文字节与行数, 累计量还在目标以内的那些留下,
+ * 比其中最旧那条还旧的全删。`rn = 1` 那一项保证最新一行永远留着 —— 阈值被配得
+ * 极小(或单条消息就超过阈值)时不能把整个命名空间清空。
+ *
+ * 整条走 query builder: main 侧的 drizzle 是 createDrizzleProxy 的代理, 只把
+ * builder 的终结方法转发给 worker RPC, 直接在 db 上跑 raw SQL 会落进代理内部
+ * 只会抛错的 fakeSqliteClient.prepare()(见 groupWindowRetentionProxy.test.ts)。
  */
-async function dropOldestUntilLowWater(
+async function keepNewestWithinTargets(
   provider: string,
-  stats: { rows: number; textBytes: number },
   targetBytes: number,
   targetRows: number,
-): Promise<boolean> {
+): Promise<void> {
   const db = getDbClient().drizzle;
-  // 至少留最新一行 —— 阈值被配得极小时不能把整个命名空间清空。
-  const maxDrop = Math.max(0, stats.rows - 1);
-  if (maxDrop === 0) return false;
-  const bytesToFree = Math.max(0, stats.textBytes - targetBytes);
-  const rowsToDrop = Math.max(0, stats.rows - targetRows);
-
-  // 最旧的 maxDrop 行里, 第一个同时满足「累计字节够」与「行数够」的位置就是边界。
-  //
-  // 必须整条走 **query builder**: main 侧拿到的 drizzle 是 createDrizzleProxy 的
-  // 代理, 只把 builder 的终结方法转发给 worker RPC。直接 `db.all(sql\`...\`)` 不经过
-  // builder, 会落进代理内部只会抛错的 fakeSqliteClient.prepare() —— 回收在生产上
-  // 100% 失败, 而单测若用真实 drizzle 建 harness 就会假绿(与 recentWorkdirs 的
-  // LRU 驱逐同一类踩坑, 见 localDb/ipc/__tests__/recentWorkdirsLru.test.ts)。
-  const oldest = db
+  const newest = db
     .select({
       id: hookGroupMessages.id,
       cumBytes:
-        sql<number>`sum(length(cast(${hookGroupMessages.text} as blob))) over (order by ${hookGroupMessages.id})`.as(
+        sql<number>`sum(length(cast(${hookGroupMessages.text} as blob))) over (order by ${hookGroupMessages.id} desc)`.as(
           'cum_bytes',
         ),
-      rn: sql<number>`row_number() over (order by ${hookGroupMessages.id})`.as('rn'),
+      rn: sql<number>`row_number() over (order by ${hookGroupMessages.id} desc)`.as('rn'),
     })
     .from(hookGroupMessages)
     .where(eq(hookGroupMessages.provider, provider))
-    .orderBy(hookGroupMessages.id)
-    .limit(maxDrop)
-    .as('oldest');
-  const boundary = await db
-    .select({ id: oldest.id })
-    .from(oldest)
-    .where(and(gte(oldest.cumBytes, bytesToFree), gte(oldest.rn, rowsToDrop)))
-    .orderBy(oldest.id)
-    .limit(1);
-  let threshold = boundary[0]?.id;
-  if (threshold === undefined) {
-    // 把能删的都删了也到不了低水位: 删到只剩最新一行为止, 而不是整轮 no-op ——
-    // 否则命名空间会长期挂在超限状态, 每次入库都白跑一遍回收。
-    const [last] = await db
-      .select({ id: hookGroupMessages.id })
-      .from(hookGroupMessages)
-      .where(eq(hookGroupMessages.provider, provider))
-      .orderBy(hookGroupMessages.id)
-      .limit(1)
-      .offset(maxDrop - 1);
-    threshold = last?.id;
-  }
-  if (threshold === undefined) return false;
-  const deleted = await db
+    .as('newest');
+  // 留下来的那批里最旧的一条; 比它还旧的全删。
+  const oldestKept = db
+    .select({ id: sql<number>`min(${newest.id})` })
+    .from(newest)
+    .where(
+      and(
+        lte(newest.rn, targetRows),
+        // rn = 1 兜底: 最新一行无论多大都留着, 绝不清空命名空间。
+        or(lte(newest.cumBytes, targetBytes), eq(newest.rn, 1)),
+      ),
+    );
+  await db
     .delete(hookGroupMessages)
-    .where(and(eq(hookGroupMessages.provider, provider), lte(hookGroupMessages.id, threshold)))
+    .where(and(eq(hookGroupMessages.provider, provider), lt(hookGroupMessages.id, oldestKept)))
     .run();
-  return deleted.changes > 0;
 }
 
 async function readPersistedCursor(provider: string, cursorKey: string): Promise<number> {

--- a/apps/desktop/src/main/im/shared/groupWindowCore.ts
+++ b/apps/desktop/src/main/im/shared/groupWindowCore.ts
@@ -40,6 +40,12 @@ const CURSOR_ROLLBACK_RETRY_DELAY_MS = 25;
  *
  * `maxRowsPerNamespace` 只是防止极端行数膨胀的安全阀(海量空消息把行开销撑爆),
  * 设得足够高, 正常使用永远碰不到 —— 它不是日常清理手段。
+ *
+ * **字节口径只统计 `text`**, 不含 `file_names` / `chat_name` / `author` / 各类 id
+ * 与索引。这不是遗漏: `text_bytes` 由 migration 0088 的触发器维护, 改口径要动
+ * schema。纯附件消息的 `text` 正是空串, 这类命名空间的增长由**行数阀**兜 ——
+ * 每行的非正文开销约 200~250 字节(含索引), 500 万行即约 1.2 GiB, 与正文额度
+ * 同一量级, 上限可估。要精确按整行受控字节计费得改触发器, 另立议题。
  */
 export type GroupWindowRetentionPolicy = {
   /** 该 provider 命名空间保留的正文字节上限。 */

--- a/apps/desktop/src/main/im/telegram/groupWindow.ts
+++ b/apps/desktop/src/main/im/telegram/groupWindow.ts
@@ -22,6 +22,7 @@ import type { TelegramGroupWindowEntry } from '@cindy/im';
 import {
   assembleGroupWindowContext,
   createFenceNeutralizer,
+  DEFAULT_GROUP_WINDOW_RETENTION,
   GROUP_WINDOW_ENTRY_TEXT_MAX_CHARS,
   recordGroupWindowEntry,
   resetGroupWindowCursors,
@@ -35,6 +36,17 @@ const log = createLogger('telegram-group-window');
 
 /** 窗口行的 provider 列值 — 与官方通道('telegram')隔离。 */
 export const TELEGRAM_PERSONAL_WINDOW_PROVIDER = 'telegram-personal';
+
+/**
+ * 个人 bot 这一侧生效的保留上限 —— 数值与官方同源, 但**这份对象是个人独有的**。
+ *
+ * 个人 bot 的群里允许非主人使用(受限权限), 消息量只会比官方那边更大, 所以同样
+ * 需要这道闸。额度按 provider 命名空间(`telegram-personal:<botId>`)独立计算, 与
+ * 官方的 `telegram:<principalId>` 各是各的一块 —— 换绑不同 bot 也各自独立。
+ *
+ * 做成可变对象只为让测试用小阈值把回收逼出来。
+ */
+export const TELEGRAM_PERSONAL_GROUP_WINDOW_RETENTION = { ...DEFAULT_GROUP_WINDOW_RETENTION };
 
 /**
  * provider 按 bot 命名空间(`telegram-personal:<botId>`): 换绑不同 bot 后,
@@ -56,17 +68,20 @@ function providerOf(botId: string): string {
 
 /** 入窗(幂等: 同 (provider,chat,thread,message) 唯一键重复插入直接忽略)。 */
 export async function recordTelegramGroupMessage(entry: TelegramGroupWindowEntry): Promise<void> {
-  await recordGroupWindowEntry({
-    provider: providerOf(entry.botId),
-    chatId: entry.chatId,
-    threadId: entry.threadId,
-    messageId: entry.messageId,
-    chatName: entry.chatName,
-    author: entry.author,
-    text: entry.text,
-    fileNames: entry.fileNames,
-    sentAt: entry.sentAt,
-  });
+  await recordGroupWindowEntry(
+    {
+      provider: providerOf(entry.botId),
+      chatId: entry.chatId,
+      threadId: entry.threadId,
+      messageId: entry.messageId,
+      chatName: entry.chatName,
+      author: entry.author,
+      text: entry.text,
+      fileNames: entry.fileNames,
+      sentAt: entry.sentAt,
+    },
+    TELEGRAM_PERSONAL_GROUP_WINDOW_RETENTION,
+  );
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

本地群消息池的保留上限改成**按存储大小**,不再按条数。

起因是 Chris 的需求:「本地的群消息数据库最好开大一点,按大小限制,实际我们使用场景里,经常要查历史消息的,**去年谁说了啥**之类,别按 500 条之类风险高」。

查下来这个担心是准的,而且就是那个数:

| | 旧策略 |
|---|---|
| 官方 bot | 每群最近 **500 条** + 每账号 10000 条,两级按条数硬删 |
| 个人 bot | 不传保留策略 → 永久保留,一条不删 |

**活跃群里 500 条可能就是几天。** 而这个池子的用途恰恰是回查很久以前的对话 —— 按条数正好把它删没。顺带这也是两个 bot 的又一处不一致。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联需求:Chris 2026-08-08 口头提出;归属 makecindy/cindy#1855(两个 bot 一致化)
- 本 PR 包含:
  - 保留策略从 `{keepPerKey, keepPerNamespace}` 改为 `{maxTextBytesPerNamespace, maxRowsPerNamespace}`
  - **删掉「每群 N 条」那一级** —— 它是把活跃群老内容挤没的元凶
  - 回收删最旧的行(跨群按自增 id),收敛到**低水位**(上限的 90%);边界按**待删行实际累计的正文字节**取
  - 官方与个人 bot **都接同一组默认值**:1 GiB 正文字节 + 500 万行安全阀
- 明确不包含:
  - **不把两个 bot 的数据或额度合并**。数值同源、**对象各持一份**:额度按 provider 命名空间各算各的(官方 `telegram:<principalId>`、个人 `telegram-personal:<botId>`),统计表以 provider 为主键、回收按 provider 过滤 —— 两个账号同时在用就是两份独立额度,消息不串。有专门回归钉这条
  - 群历史检索工具、FTS、注入预算(每次上下文最多读 500 行 / 4000 字是**读取预算**,与保留无关)
  - 消息池 schema、migration。`(provider, id)` 索引与分批删除属于性能/schema 扩展,另立议题
  - 存量数据补偿 —— 历史上已被 500 条策略删掉的内容找不回来了
- 用户可见变化:群历史不再被 500 条上限截断,长期可回查
- breaking change:无

### 个人 bot 为什么也接上

个人 bot 此前**永久保留、一条不删**,这次给它接上同一组默认值 —— Chris 的原话:「肯定要做,2 个机制几乎一行,只有群内被非主人使用,官方 bot 要求关联自己机器,**个人 bot 允许被别人使用但受限权限**」。

它的群允许非主人使用,消息量只会比官方那边更大,更需要这道闸。1 GiB 的量级下,正常使用碰不到。

### 为什么按大小几乎零成本

`hook_group_message_stats` 表的 `text_bytes` 由 **SQLite 触发器**在增删改时自动维护(migration 0088 已有)。判定只读一行统计,不做全表扫描 —— 不存在「算大小太贵所以只能按条数」这个权衡。

### 1 GiB 是怎么估的

- 一条群消息正文约 100~300 字节(中文偏上限)
- 1 GiB ≈ 几百万到上千万条
- 一个日活 500 条的群,一年约 20~50 MB

也就是几十个活跃群存好几年。**碰不到正是目的**:它是安全阀,不是日常清理手段。

### 回收边界怎么取(review 后改的)

初版按**平均行大小**估算要删多少行。评审指出这在分布不均时会失效,复核确认是真问题:一批正文为空的附件消息后面跟着长文时,均值会让回收删掉一大堆零字节旧行却几乎不掉 `text_bytes`,于是此后**每插一条都要再回收一次**,低水位形同虚设。

改成一条窗口查询,在最旧的那批行里取**第一个同时满足「累计字节够」与「行数够」**的位置作边界,一轮就到位。另外三处一并收:

- **至少保留最新一行**:阈值被配得极小(或单条超大消息)时,回收要么删到只剩最新一行为止,要么就整轮 no-op 让命名空间长期挂在超限状态 —— 两个都不能变成「删光」;
- **同命名空间的回收串行执行**:两次回收各读一次统计、各算一次边界会互相重叠,后跑的那次从已回收过的剩余记录再往后移边界,把低水位以内的历史一起删掉;
- **最多收敛 4 轮**:边界算准后正常一轮到位,多留几轮兜住并发写入,同时保证不会无限循环。

### 顺带查出来的：这套回收在生产上一次都没跑过

两个 review bot 各自指出边界查询用了 `db.all(sql\`...\`)` —— main 侧拿到的 drizzle 是 `createDrizzleProxy` 的代理，只把 **query builder** 的终结方法转发给 worker RPC，直接在 db 对象上跑 raw SQL 会落进代理内部只会抛错的 `fakeSqliteClient.prepare()`。这条属实，已改成整条用 builder 表达。

顺着查下去发现更深的一层，而且是**既有代码**：

入库判重用的是 `.returning({ id })`。代理对没有 select fields 的 builder 一律走 `run` op 并**返回空数组**（`drizzleProxy.ts` 里就写着「RETURNING 当前未使用」）。于是 `inserted.length === 0` 在生产上**恒为真** —— 每条群消息入库后都被判成「重复」，直接 `return false`，**回收与容量观测一次都没跑过**。旧的「每群 500 条」如此，本 PR 的字节上限也会如此。

改用 `.run()` 的 `changes` 判重：`onConflictDoNothing` 下 `changes === 0` 正是「这条已存在」，语义等价且代理支持。

这也意味着一个副产品：Chris 担心的「500 条把去年的内容挤没」在生产上其实没发生过 —— 因为那条 GC 根本没被调用。本 PR 让保留策略**第一次真正生效**，所以上限设得高、且按大小算，比过去任何时候都更要紧。

### 为什么既有单测没抓到

既有 `groupWindow` 单测全部用真实 `drizzle(sqlite)` 建 harness，上面两条在那里都是假绿。新增 `groupWindowRetentionProxy.test.ts` 改用 `createDrizzleProxy` + 假 transport（按 worker `opHandlers` 的 op 语义转发给 in-memory SQLite），堵住这一类。仓内 `localDb/ipc/__tests__/recentWorkdirsLru.test.ts` 记录过同一类踩坑，这次是它的第二例。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop run typecheck                        # 干净
pnpm --filter desktop exec vitest run src/main/hook-control src/main/im
                                                           # 70 文件 / 968 项全绿
pnpm test:unit                                             # 仓库根全量,全绿
```

两条锁定旧策略的既有断言按新策略改写:

| 原断言 | 改为 |
|---|---|
| 每群只保留最近 500 条 | 单群写入 **1200 条一条不删** |
| 每账号保留固定行数上限 | 小阈值下**删最旧的并收敛到低水位**,最新的仍在 |

新增的回归:

| 用例 | 钉住什么 |
|---|---|
| 超字节上限时收敛到低水位 | 断言落在 **1800(上限 2000 的 90%)以内且没删过头**,不是只断言「小于上限」 |
| 旧行短、新行长 | 边界按实际累计字节取。**这条在旧的平均值实现上实测为红**,是真回归 |
| 阈值小到一条都放不下 | 保留最新一行,不清空命名空间 |
| 并发入库 | 仍停在低水位。注:better-sqlite3 是同步驱动,复现不出真正的交错,这条钉的是不变量本身 |
| 额度按命名空间各算各的 | 一个账号写爆,另一个账号的数据一条不少 |
| **代理下回收真的执行** | harness 用 `createDrizzleProxy` 建,不是真实 drizzle。**这条在修之前实测为红**(回收压根没被调用) |

小阈值(2 KB)由导出的可变 retention 对象注入 —— 拿 1 GiB 默认值写回归等于在测试里灌一 GB 数据。

### 手动验证

未做真机长期积累实测(需要月级数据),以小阈值注入回归覆盖。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据(改变了本地群历史的生命周期)

### 影响与回滚

| 风险 | 处置 |
|---|---|
| **个人 bot 从「永久保留」变成有上限** | 这是本次需求本身,已由 Chris 明确要求。阈值是 1 GiB,存量用户里达到这个量级的极少;真要回退,把 `telegram/groupWindow.ts` 里传入的 retention 去掉即可恢复永久保留 |
| 本地库无限增长 | 1 GiB 字节 + 500 万行双上限仍在,只是阈值比旧策略高得多 |
| 回收抖动(超限后每插一条删一条) | 收敛到低水位(90%)而非刚好压线;边界按实际字节取,不会因估算偏差反复触发 |
| 活跃群挤掉安静群的老消息 | 删最旧的是跨群按时间的,与「保留最近这段时间」直觉一致;1 GiB 下基本不会触发 |
| 首次触发时的回收耗时 | 边界查询要扫该命名空间一遍,better-sqlite3 在 main 进程同步执行。1 GiB 阈值下极少触发;`(provider, id)` 索引与分批删除另立性能议题 |
| 两个账号的额度串号 | 统计表以 provider 为主键、回收按 provider 过滤,天然隔离;有专门回归 |
| 回收在生产上静默失效 | 边界查询与入库判重都改成代理支持的 builder 形态;新增以代理建 harness 的回归钉住 |
| 保留策略第一次真正生效带来的行为变化 | 此前 GC 从未被调用(见上),本 PR 让它开始工作。上限是 1 GiB + 500 万行,正常使用碰不到;真要回退,去掉传入的 retention 即恢复不删 |
| 存量数据 | 历史上已被 500 条策略删掉的找不回来 —— 本 PR 只阻止继续删 |

- 回滚 / 降级方式:纯逻辑改动,无 migration。revert 即回到旧策略,本地数据不受影响。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 不涉及 UI
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

Refs: #1855

