### PR TITLE
fix(maker-core): abort 在 accept 阶段不抢清 turnInFlight,保住取消终态

### DIFF
--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -5123,11 +5123,13 @@ export class ClaudeCodeAgent extends BaseAgent {
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
             turnInFlight = false;
-          } else {
+          } else if (!sendInAcceptPhase) {
             // interrupt 成功且无后台任务需要清：被中断的 turn 会收到
             // error_during_execution result → translator 在 onTurnEnd 清
             // turnInFlight。这里显式补清以防 SDK 未 drain result 的极端
-            // 情况(确保不会 SESSION_RUNNING 永拒)。
+            // 情况(确保不会 SESSION_RUNNING 永拒)。accept 阶段不抢清:
+            // finishSendBeforeUserInput 需要 turnInFlight=true 才会补
+            // send_cancelled_before_acceptance 终态,提前清掉会吞 boundary。
             turnInFlight = false;
           }
         } catch (e) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

3d3a6b59e(P1-A:abort 保持 turnInFlight 直到 interrupt 返回)引入回归:interrupt **成功**分支无条件补清 `turnInFlight`,若此刻并发 send 正处于 accept replay(`sendInAcceptPhase=true`),send 侧的 `finishSendBeforeUserInput` 因 `turnInFlight=false` 提前返回,不再发出 `send_cancelled_before_acceptance` 终态 boundary。`rewind-runtime-settings.test.ts > cancels a post-rebuild send if Stop arrives during accept replay` 自该提交起在 main 上稳定失败(runs 31233013088 / 31233773418 / 31235003321 连续三次),并把当前所有 open PR 的 verify / Windows (2/2) 一并染红。

修复为 2 行:interrupt 成功分支的补清挂 `!sendInAcceptPhase` 守卫。这与同一函数上方既有约定一致("sendInAcceptPhase 守卫: 并发 send 处于 accept 阶段时, 由 send 自己的 finishSendBeforeUserInput 负责清 turnInFlight + emit boundary, abort 不能抢清, 否则 boundary 丢失, review 3541310178");P1-A 要防的 SESSION_RUNNING 永拒兜底在非 accept 路径原样保留(accept 路径的清理责任本就在 send 侧,且 5s INTERRUPT_TIMEOUT 分支不受影响)。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联:3d3a6b59e 引入的 main CI 回归
- 本 PR 包含:`packages/maker-core/src/agents/claude-code/index.ts` 单处守卫(+4/-2,含注释)
- 明确不包含:其他 abort/interrupt 行为变化
- 用户可见变化:修复"accept replay 期间按 Stop"场景下取消终态丢失(该场景下 UI 可能观察不到 turn 结束)
- 是否存在 breaking change:无

### UI 变化

不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core exec vitest run rewind-runtime-settings
→ 修复前:1 failed(cancels a post-rebuild send if Stop arrives during accept replay,本地 macOS 复现与 CI 同断言)
→ 修复后:36 passed
pnpm --filter @cindy/maker-core exec vitest run → 2065 passed | 1 skipped(全量)
pnpm --filter @cindy/maker-core run typecheck → 过
```

### 手工验证

不涉及(纯状态机时序,单测覆盖)。

### 未执行的验证

- 未跑全仓 `pnpm test:unit`(改动限定在 maker-core 单文件单函数,该包全量已过;最终以 CI 为准)。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

单守卫条件,revert 即回滚。风险面:若存在"send 卡在 accept 阶段永不返回"的第三种路径,turnInFlight 会依赖 send 侧清理——这正是 3541310178 review 时已确立的责任划分,本 PR 只是恢复它。

🤖 Generated with [Claude Code](https://claude.com/claude-code)