### PR TITLE
fix(maker-core): abort 不再抢清 accept 阶段的 turn 状态

### DIFF
--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -5111,7 +5111,12 @@ export class ClaudeCodeAgent extends BaseAgent {
               // foreground turn has not already produced a terminal, replace
               // it with one synthetic boundary; a raced natural result leaves
               // foregroundWasInFlight=false and therefore does not get a duplicate.
-              if (foregroundWasInFlight) emitTurnBoundary('user_stop_unconfirmed_wake_tasks');
+              // accept 阶段的 foreground 终态归 send 的 finishSendBeforeUserInput:
+              // 它醒来后按 signal.aborted / push 失败走到自己的 boundary。这里
+              // 抢发会重复——一次 Stop 冒出两个终态。
+              if (foregroundWasInFlight && !sendInAcceptPhase) {
+                emitTurnBoundary('user_stop_unconfirmed_wake_tasks');
+              }
             }
             inputQueue.clear();
             try {
@@ -5122,13 +5127,19 @@ export class ClaudeCodeAgent extends BaseAgent {
             recordCanceledQueryClose(cancelledQuery, 'user_stop cancellation');
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
-            turnInFlight = false;
+            if (!sendInAcceptPhase) turnInFlight = false;
           } else {
             // interrupt 成功且无后台任务需要清：被中断的 turn 会收到
             // error_during_execution result → translator 在 onTurnEnd 清
             // turnInFlight。这里显式补清以防 SDK 未 drain result 的极端
             // 情况(确保不会 SESSION_RUNNING 永拒)。
-            turnInFlight = false;
+            //
+            // accept 阶段除外——finishSendBeforeUserInput 的入口守卫是
+            // `if (!turnInFlight) return`,abort 抢清会让它以为已被收口而直接
+            // 返回,send_cancelled_before_acceptance 的终态 boundary 从此丢失,
+            // isTurnRunning 悬置(正是 5042 行注释声明、却只挡了 pendingToolIds
+            // 的那半个守卫;review 3541310178 的反馈原型用例钉的就是它)。
+            if (!sendInAcceptPhase) turnInFlight = false;
           }
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);
@@ -5155,11 +5166,13 @@ export class ClaudeCodeAgent extends BaseAgent {
             recordCanceledQueryClose(q, 'user_stop interrupt timeout');
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
-            turnInFlight = false;
+            // accept 阶段同上——终态与清理归 send 自己(query 已被关闭, send 的
+            // push 会失败并走 finishSendBeforeUserInput)。
+            if (!sendInAcceptPhase) turnInFlight = false;
           } else {
             // interrupt 真正抛错(非超时)，回收标记防误抑制(同 watchdog)。
             turnState.interruptRequested = false;
-            turnInFlight = false;
+            if (!sendInAcceptPhase) turnInFlight = false;
             log.warn('abort threw', { error: String(e) });
           }
         }

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -3145,6 +3145,19 @@ export class ClaudeCodeAgent extends BaseAgent {
     // still has buffered activity. Suppress that cancelled tail until its
     // Query is replaced before the next explicit user turn.
     let continuationCancellationGeneration: number | null = null;
+    /**
+     * 本次 Stop 已经发过终态 boundary 的那一代。
+     *
+     * accept 阶段的 foreground 终态归 send 的 finishSendBeforeUserInput 发, 但
+     * abort 若同时取消了一个 awaiting continuation, 它已经先发过
+     * turn_continuation_cancelled —— 同一次 Stop 再补一个 done 就是双终态,
+     * Session 不按 generation 去重, 所有监听方都会收到两条。
+     *
+     * 单独记一个代次而不是复用 continuationCancellationGeneration: 后者在关
+     * query 分支里**无条件**设置(哪怕那一轮根本没发 boundary), 拿它当去重依据
+     * 会把 send 该发的那个终态一起吞掉。
+     */
+    let stopTerminalEmittedGeneration: number | null = null;
     let continuationCancellationRequiresQueryRebuild = false;
     const continuationClaims = new Map<number, ContinuationClaim>();
     const continuationListeners = new Set<(
@@ -3415,6 +3428,8 @@ export class ClaudeCodeAgent extends BaseAgent {
         continuationId: claim.id,
       });
       if (emitTurnBoundary('turn_continuation_cancelled', undefined, true)) {
+        // 这一代的终态已经出去了 —— accept 阶段的 send 醒来后不要再补一个。
+        stopTerminalEmittedGeneration = turnState.generation;
         // Install the cancelled-tail fence at the same enqueue boundary as
         // the synthetic product terminal. stopTask can win before interrupt
         // resolves, so waiting for the interrupt ACK leaves a double-terminal
@@ -4702,7 +4717,11 @@ export class ClaudeCodeAgent extends BaseAgent {
           pendingToolIds.clear();
           acceptingRebuiltSend = false;
           clearUpstreamResponseIdle();
-          emitTurnBoundary(reason);
+          // 同一次 Stop 只发一个终态: abort 若已为被取消的 continuation 发过
+          // turn_continuation_cancelled(同一代), 这里只清状态、不再补 done。
+          if (stopTerminalEmittedGeneration !== turnState.generation) {
+            emitTurnBoundary(reason);
+          }
         };
         if (pendingRewindTo || activeBridgeRewindResumeAt) {
           const resumeAt = pendingRewindTo ?? activeBridgeRewindResumeAt;

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -5012,6 +5012,12 @@ export class ClaudeCodeAgent extends BaseAgent {
           runningBackgroundTasks.clear();
           terminalBackgroundTaskIds.clear();
           turnInFlight = false;
+          // 本分支自己发 bridge_aborted 终态, send 的收尾责任就此交接完毕 ——
+          // 一并清 sendInAcceptPhase。不清的话: send 醒来走进
+          // finishSendBeforeUserInput, 入口守卫见 turnInFlight=false 直接返回,
+          // sendInAcceptPhase 悬置 true, 后续每次 abort 都被 accept 让位守卫
+          // 错误短路。boundary 只从这里发一次, send 那侧早退不再补发。
+          sendInAcceptPhase = false;
           turnState.interruptRequested = false;
           preserveBridgeRetryTarget(abortedBridgeKind, abortedRewindResumeAt);
           emitTurnBoundary(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修 main 上持续红的 `rewind-runtime-settings` 用例「cancels a post-rebuild send if Stop arrives during accept replay」—— 它红在 main 自身（`031585fd` 的 client-ci 三项失败），**当前所有开着的 PR 的 CI 都跟着红在同一处**，整条合并链被卡住。

根因是「abort 不再等待 SDK interrupt」（PR 2131 合入）之后，abort 与 send 在 **accept 阶段**的责任交接只做了一半：

- `abort()` 里的注释已经写明契约：「并发 send 处于 accept 阶段时，由 send 自己的 `finishSendBeforeUserInput` 负责清 `turnInFlight` + emit boundary，abort 不能抢清，否则 boundary 丢失（review 3541310178）」；
- 但那个 `sendInAcceptPhase` 守卫**只挡了 `pendingToolIds.clear()`**，后面四处 `turnInFlight = false`（interrupt 成功、关 query、interrupt 超时、interrupt 抛错）一处都没挡；
- 而 `finishSendBeforeUserInput` 的入口守卫是 `if (!turnInFlight) return`。abort 先把 `turnInFlight` 清掉，send 从 `replayRuntimeDrift` 醒来走到它时直接返回 —— `send_cancelled_before_acceptance` 的终态 boundary 从此不发，`isTurnRunning` 的收口事件缺失。用例断言的正是这个 boundary。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：PR 2131（abort 即刻恢复会话可用）的收尾；main CI 红
- 本 PR 包含：abort 内四处 `turnInFlight = false` 按已声明的契约补上 `if (!sendInAcceptPhase)` 守卫；close-query 分支的合成 boundary 同样让位（否则一次 Stop 冒出两个终态）
- 明确不包含：不动 abort 的 interrupt 竞速 / 超时 / stopTask 语义；不动 `finishSendBeforeUserInput` 本身；不动 translator / turn 状态机的任何其它路径
- 用户可见变化：修复「任务重建后立刻按 Stop，会话可能收不到结束事件」的窗口
- 是否存在 breaking change：无

### 为什么悬置风险不存在

`sendInAcceptPhase` 只在 send 的 accept 段为 true。该段结束只有两条路：要么输入被接受（`sendInAcceptPhase = false`，turn 正常走，终态由 translator 收口），要么必经 `finishSendBeforeUserInput`（它统一清 `turnInFlight` + `sendInAcceptPhase` 并 emit boundary）。abort 让位不会把 `turnInFlight` 留成永久 true。

### UI 变化

不涉及：纯 maker-core 状态机时序，无界面、样式或文案改动。

- 引用的设计规范：不涉及 —— 未改动 `apps/desktop/src/renderer` 下任何文件。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/maker-core run typecheck                 # 干净
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
                                                              # 36 项全绿（修前该用例在本机稳定红，与 main CI 一致）
pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code
                                                              # 31 文件 / 519 项全绿（含 abort-stops-background-tasks 全量 73 项）
pnpm --filter @cindy/maker-core exec vitest run               # 95 文件 / 2065 项全绿
pnpm test:unit                                                # 仓库根全量，全绿
```

未新增测试：红着的用例本身就是这个 bug 的回归（review 3541310178 的反馈原型），它从红转绿即验证。

### 手工验证

不涉及 —— 时序窗口毫秒级，以既有用例覆盖。

### 未执行的验证

真机「rewind 后立刻 Stop」的端到端目检未做，以该场景的专用单测覆盖代替。

## 风险

### 风险分类

- [x] 其他：abort 与 send 的状态交接时序

### 影响与回滚

| 风险 | 处置 |
|---|---|
| turnInFlight 悬置导致 SESSION_RUNNING 永拒 | 见上节：accept 段两条出路都必然收口；abort 只在该段让位，段外行为逐字节不变 |
| Stop 时 boundary 少发/多发 | 少发正是修的 bug；多发由 close-query 分支的同一守卫挡住 |
| 影响 PR 2131 的原修复（SDK backoff 期间 abort 卡死） | 不影响：interrupt 竞速、5s 超时、关 query 的路径全部保留，只是 accept 段的 turnInFlight 归 send 清 |

- 影响范围：仅 claude-code agent 的 abort 路径在 send accept 段的行为。
- 回滚 / 降级方式：纯逻辑改动，revert 即回到（现在 main 的）红态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 不涉及 UI
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因

Refs: #2131
