### PR TITLE
fix(desktop): pi 会话仅连 BYOM 来源时钉住 providerId，避免 null 误路由网关

### DIFF
--- a/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
+++ b/apps/desktop/src/renderer/__tests__/draftModelCalibration.test.ts
@@ -730,4 +730,32 @@ describe('resolveDraftSessionProviderId', () => {
       }),
     ).toBe('xd');
   });
+
+  it('pi 只有 BYOM 来源已连接时不得省略来源,否则 null 会落在网关鉴权失败', () => {
+    const deepseek = provider('deepseek', true, { pi: [model('deepseek-v4-flash')] });
+
+    expect(
+      resolveDraftSessionProviderId({
+        providers: [deepseek],
+        agent: 'pi',
+        model: 'deepseek-v4-flash',
+        explicitProviderId: null,
+        effectiveProviderId: 'deepseek',
+      }),
+    ).toBe('deepseek');
+  });
+
+  it('pi 网关(xd)生效时可省略来源,与 null 恒路由网关的语义一致', () => {
+    const gateway = provider('xd', true, { pi: [model('gpt-5.4-mini')] });
+
+    expect(
+      resolveDraftSessionProviderId({
+        providers: [gateway],
+        agent: 'pi',
+        model: 'gpt-5.4-mini',
+        explicitProviderId: null,
+        effectiveProviderId: 'xd',
+      }),
+    ).toBeNull();
+  });
 });

--- a/apps/desktop/src/renderer/lib/draftModelCalibration.ts
+++ b/apps/desktop/src/renderer/lib/draftModelCalibration.ts
@@ -274,12 +274,19 @@ export function resolveDraftSessionProviderId({
   // 模型”的来源里重算。典型分叉：XD 与 Anthropic 都已连接，只有 Anthropic 目录含
   // claude-opus-5。modelDefault 是 anthropic，但 agentDefault 仍是 xd；若只比较前者
   // 就会错误地省略 providerId，main 随后拿 gateway key 启动 XD 路由(issue #1196)。
-  const agentDefaultProviderId = nativeDefaultSourceId(
-    // main 的 spawn 默认不读取用户的 suspended 开关；这里必须保留 suspended 来源，
-    // 否则 UI 停用 XD 后会把 agentDefault 错算成 Anthropic，再次把必需的来源省略掉。
-    connectedProvidersForAgent([...providers], agent, { includeSuspended: true }),
-    agent,
-  );
+  // pi 例外：pi 的 providerId=null 在 main 恒路由 Cindy 网关（PI_PROVIDER_ID），不按 agent
+  // 原生默认回退。nativeDefaultSourceId 在“仅 BYOM 已连接”时会把 rail[0]（该 BYOM）误算
+  // 成 agent 默认，这里因此误判“可安全省略”→ 会话发往网关，未登录 Cindy 时鉴权失败。
+  // 所以 pi 的“null 落点”恒为网关（renderer 侧即 'xd'），非网关来源必须显式钉住。
+  const agentDefaultProviderId =
+    agent === 'pi'
+      ? 'xd'
+      : nativeDefaultSourceId(
+          // main 的 spawn 默认不读取用户的 suspended 开关；这里必须保留 suspended 来源，
+          // 否则 UI 停用 XD 后会把 agentDefault 错算成 Anthropic，再次把必需的来源省略掉。
+          connectedProvidersForAgent([...providers], agent, { includeSuspended: true }),
+          agent,
+        );
   return modelDefaultProviderId === effectiveProviderId &&
     agentDefaultProviderId === effectiveProviderId
     ? null


### PR DESCRIPTION
## 这次改了什么

### 摘要

未登录 Cindy 时，pi 会话使用自定义 BYOM 供应商（如 DeepSeek）新建即报 `LAZY_CREATE_FAILED: pi not authenticated: cindy_gateway_key_unavailable`。

根因：renderer 的 `resolveDraftSessionProviderId` 用 `nativeDefaultSourceId` 推断「省略 providerId 后可落回的目标」，但 pi 的 `providerId=null` 恒路由 Cindy 网关（`packages/maker-core/src/agents/pi/index.ts`），不按 agent 默认回退。仅 BYOM 已连接时 `nativeDefaultSourceId` 返回 rail 首项（即该 BYOM），函数误判「可安全省略」→ `sessions.provider_id` 落 NULL → 会话发往网关 → 鉴权失败。

修复：`agent === 'pi'` 时把 null 落点固定为网关（renderer 侧 `'xd'`），非网关来源一律显式钉住；网关生效时仍省略，与 null 恒路由网关的语义一致。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #2152
- 本 PR 包含：`apps/desktop/src/renderer/lib/draftModelCalibration.ts` 一处条件分支 + 2 个回归测试
- 明确不包含：既有 `provider_id = NULL` 会话的恢复路径（恢复后需重选来源或新建会话）；cc / codex 行为不变
- 用户可见变化：pi 会话 + BYOM 来源 + 未登录网关时不再报错，直连自定义端点
- 是否存在 breaking change：无

### UI 变化

不涉及：纯来源路由决策逻辑（renderer lib），无视觉 / 交互 / 文案变化。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/draftModelCalibration.test.ts
结果：44 passed（含 2 个新增回归测试；反向验证：去掉修复后新测试精确复现 bug）

pnpm --filter desktop exec tsc --noEmit -p tsconfig.json
结果：通过
```

### 手工验证

不涉及。

### 未执行的验证

无 —— 本改动相关单测与类型检查均已在本机执行；仓库级全量单测由 CI client-ci 门禁覆盖（本机算力受限，未单独运行）。

## 风险

- 无已知风险：单函数单分支窄改动，仅影响 `agent === 'pi'` 的新建草稿来源解析。
- 影响范围：pi 标签页新建会话的来源路由。
- 回滚方式：revert 本 commit 即可。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
