### PR TITLE
fix(desktop): 对话分组新建任务继承远程机器

### DIFF
--- a/apps/desktop/src/renderer/__tests__/dialogueCreateTarget.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueCreateTarget.test.ts
@@ -12,25 +12,36 @@ const devices: SwitcherDevice[] = [
 
 describe('resolveDialogueDeviceTarget', () => {
   it('inherits the only selected remote machine', () => {
-    expect(resolveDialogueDeviceTarget(['remote-a'], devices)).toEqual({
-      deviceId: 'remote-a',
-      deviceName: 'Remote A',
+    expect(resolveDialogueDeviceTarget(['remote-a'], devices, true)).toEqual({
+      status: 'ready',
+      target: { deviceId: 'remote-a', deviceName: 'Remote A' },
     });
-    expect(resolveDialogueDeviceTarget(['remote-b'], devices)).toEqual({
-      deviceId: 'remote-b',
-      deviceName: 'Remote B',
+    expect(resolveDialogueDeviceTarget(['remote-b'], devices, true)).toEqual({
+      status: 'ready',
+      target: { deviceId: 'remote-b', deviceName: 'Remote B' },
     });
   });
 
   it('keeps the local default when the machine scope is not a unique remote target', () => {
-    expect(resolveDialogueDeviceTarget(MACHINE_ALL, devices)).toBeNull();
-    expect(resolveDialogueDeviceTarget([MACHINE_LOCAL], devices)).toBeNull();
-    expect(resolveDialogueDeviceTarget([MACHINE_LOCAL, 'remote-a'], devices)).toBeNull();
-    expect(resolveDialogueDeviceTarget(['remote-a', 'remote-b'], devices)).toBeNull();
+    const local = { status: 'ready', target: null };
+    expect(resolveDialogueDeviceTarget(MACHINE_ALL, devices, false)).toEqual(local);
+    expect(resolveDialogueDeviceTarget([MACHINE_LOCAL], devices, false)).toEqual(local);
+    expect(resolveDialogueDeviceTarget([MACHINE_LOCAL, 'remote-a'], devices, false)).toEqual(local);
+    expect(resolveDialogueDeviceTarget(['remote-a', 'remote-b'], devices, false)).toEqual(local);
   });
 
-  it('does not inherit an unavailable or rejected device', () => {
-    expect(resolveDialogueDeviceTarget(['missing'], devices)).toBeNull();
-    expect(resolveDialogueDeviceTarget(['remote-rejected'], devices)).toBeNull();
+  it('waits for an unresolved unique remote until the directory settles', () => {
+    expect(resolveDialogueDeviceTarget(['remote-a'], [], false)).toEqual({ status: 'pending' });
+    expect(resolveDialogueDeviceTarget(['remote-a'], [], true)).toEqual({
+      status: 'ready',
+      target: null,
+    });
+  });
+
+  it('does not inherit a rejected device', () => {
+    expect(resolveDialogueDeviceTarget(['remote-rejected'], devices, true)).toEqual({
+      status: 'ready',
+      target: null,
+    });
   });
 });

--- a/apps/desktop/src/renderer/__tests__/dialogueCreateTarget.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueCreateTarget.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveDialogueDeviceTarget } from '@/features/cc-agent/lib/dialogueCreateTarget';
+import { MACHINE_ALL, MACHINE_LOCAL } from '@/features/device-link/selectedMachineStore';
+import type { SwitcherDevice } from '@/features/device-link/switcherDevices';
+
+const devices: SwitcherDevice[] = [
+  { deviceId: 'remote-a', name: 'Remote A', status: 'connected' },
+  { deviceId: 'remote-b', name: 'Remote B', status: 'connecting' },
+  { deviceId: 'remote-rejected', name: 'Rejected', status: 'rejected' },
+];
+
+describe('resolveDialogueDeviceTarget', () => {
+  it('inherits the only selected remote machine', () => {
+    expect(resolveDialogueDeviceTarget(['remote-a'], devices)).toEqual({
+      deviceId: 'remote-a',
+      deviceName: 'Remote A',
+    });
+    expect(resolveDialogueDeviceTarget(['remote-b'], devices)).toEqual({
+      deviceId: 'remote-b',
+      deviceName: 'Remote B',
+    });
+  });
+
+  it('keeps the local default when the machine scope is not a unique remote target', () => {
+    expect(resolveDialogueDeviceTarget(MACHINE_ALL, devices)).toBeNull();
+    expect(resolveDialogueDeviceTarget([MACHINE_LOCAL], devices)).toBeNull();
+    expect(resolveDialogueDeviceTarget([MACHINE_LOCAL, 'remote-a'], devices)).toBeNull();
+    expect(resolveDialogueDeviceTarget(['remote-a', 'remote-b'], devices)).toBeNull();
+  });
+
+  it('does not inherit an unavailable or rejected device', () => {
+    expect(resolveDialogueDeviceTarget(['missing'], devices)).toBeNull();
+    expect(resolveDialogueDeviceTarget(['remote-rejected'], devices)).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -207,6 +207,10 @@ describe('Dialogue sidebar section', () => {
     expect(newMakerDraftRouteSource).toMatch(
       /applyDraftTarget\(\{\s*deviceId: dialogueTargetRequest\.deviceId,\s*deviceName: dialogueTargetRequest\.deviceName,\s*workingDir: null,/,
     );
+    expect(newMakerDraftRouteSource).toContain(
+      'state: consumeNewMakerDialogueTargetRequest(location.state)',
+    );
+    expect(newMakerDraftRouteSource).toContain('replace: true');
     expect(handler).toContain("navigate('/cc-agent/new'");
     expect((sidebarSource.match(/onCreateDialogue={handleCreateDialogue}/g) ?? []).length).toBe(2);
     expect(sidebarSource).toContain('createDisabled={dialogueCreatePending}');

--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -40,6 +40,12 @@ const newMakerDraftRouteSource = readFileSync(
   'utf8',
 );
 
+function extractHandlerBlock(source: string, name: string): string {
+  const match = source.match(new RegExp(`const ${name}\\s*=\\s*[\\s\\S]*?(?:\\}, \\[|\\};)`));
+  expect(match, `expected to find handler ${name}`).not.toBeNull();
+  return match![0];
+}
+
 const remoteProjectsHookSource = readFileSync(
   resolve(__dirname, '..', 'features', 'device-link', 'useDeviceLinkRemoteProjects.ts'),
   'utf8',
@@ -178,20 +184,29 @@ describe('Dialogue sidebar section', () => {
     expect(dialogueSectionSource).toContain('className={HEADER_ACTIONS_CLASS}');
   });
 
-  it('creates a standalone dialogue and inherits an explicitly selected remote machine', () => {
-    expect(sidebarSource).toContain('resetDraftWorkspaceTargets();');
+  it('routes standalone dialogue targets through the mounted draft page transition', () => {
+    const handler = extractHandlerBlock(sidebarSource, 'handleCreateDialogue');
     expect(sidebarSource).toContain(
       'resolveDialogueDeviceTarget(selectedMachineId, switcherDevices)',
     );
-    expect(sidebarSource).toContain(
-      'deviceLinkDeviceId: selectedDialogueDeviceTarget.deviceId',
+    expect(handler).toContain(
+      'state: makeDialogueNewMakerRouteState(selectedDialogueDeviceTarget)',
     );
-    expect(sidebarSource).toContain(
-      'deviceLinkDeviceName: selectedDialogueDeviceTarget.deviceName',
+    expect(handler).not.toContain('resetDraftWorkspaceTargets');
+    expect(handler).not.toContain('patchNewMakerDraft');
+    expect(newMakerDraftRouteSource).toContain(
+      'readNewMakerDialogueTargetRequest(location.state)',
     );
-    expect(sidebarSource).toMatch(
-      /navigate\(['`]\/cc-agent\/new['`],\s*\{\s*state:\s*makeNewMakerRouteState\('dialogue'\)\s*\}\)/,
+    expect(newMakerDraftRouteSource).toContain(
+      'handledDialogueTargetRequestRef.current === dialogueTargetRequest.requestId',
     );
+    expect(newMakerDraftRouteSource).toContain(
+      'patchCollab({ enabled: false });',
+    );
+    expect(newMakerDraftRouteSource).toMatch(
+      /applyDraftTarget\(\{\s*deviceId: dialogueTargetRequest\.deviceId,\s*deviceName: dialogueTargetRequest\.deviceName,\s*workingDir: null,/,
+    );
+    expect(handler).toContain("navigate('/cc-agent/new'");
     expect(sidebarSource).toContain('onCreateDialogue={handleCreateDialogue}');
   });
 

--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -178,8 +178,17 @@ describe('Dialogue sidebar section', () => {
     expect(dialogueSectionSource).toContain('className={HEADER_ACTIONS_CLASS}');
   });
 
-  it('creates a standalone dialogue without inheriting a project draft directory', () => {
+  it('creates a standalone dialogue and inherits an explicitly selected remote machine', () => {
     expect(sidebarSource).toContain('resetDraftWorkspaceTargets();');
+    expect(sidebarSource).toContain(
+      'resolveDialogueDeviceTarget(selectedMachineId, switcherDevices)',
+    );
+    expect(sidebarSource).toContain(
+      'deviceLinkDeviceId: selectedDialogueDeviceTarget.deviceId',
+    );
+    expect(sidebarSource).toContain(
+      'deviceLinkDeviceName: selectedDialogueDeviceTarget.deviceName',
+    );
     expect(sidebarSource).toMatch(
       /navigate\(['`]\/cc-agent\/new['`],\s*\{\s*state:\s*makeNewMakerRouteState\('dialogue'\)\s*\}\)/,
     );

--- a/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
+++ b/apps/desktop/src/renderer/__tests__/dialogueSidebarSection.test.ts
@@ -187,10 +187,11 @@ describe('Dialogue sidebar section', () => {
   it('routes standalone dialogue targets through the mounted draft page transition', () => {
     const handler = extractHandlerBlock(sidebarSource, 'handleCreateDialogue');
     expect(sidebarSource).toContain(
-      'resolveDialogueDeviceTarget(selectedMachineId, switcherDevices)',
+      'resolveDialogueDeviceTarget(selectedMachineId, switcherDevices, deviceListSettled)',
     );
+    expect(handler).toContain("selectedDialogueDeviceResolution.status === 'pending'");
     expect(handler).toContain(
-      'state: makeDialogueNewMakerRouteState(selectedDialogueDeviceTarget)',
+      'state: makeDialogueNewMakerRouteState(selectedDialogueDeviceResolution.target)',
     );
     expect(handler).not.toContain('resetDraftWorkspaceTargets');
     expect(handler).not.toContain('patchNewMakerDraft');
@@ -207,7 +208,10 @@ describe('Dialogue sidebar section', () => {
       /applyDraftTarget\(\{\s*deviceId: dialogueTargetRequest\.deviceId,\s*deviceName: dialogueTargetRequest\.deviceName,\s*workingDir: null,/,
     );
     expect(handler).toContain("navigate('/cc-agent/new'");
-    expect(sidebarSource).toContain('onCreateDialogue={handleCreateDialogue}');
+    expect((sidebarSource.match(/onCreateDialogue={handleCreateDialogue}/g) ?? []).length).toBe(2);
+    expect(sidebarSource).toContain('createDisabled={dialogueCreatePending}');
+    expect(sidebarSource).toContain('isCreateDialogueDisabled={dialogueCreatePending}');
+    expect(dialogueSectionSource).toContain('disabled={createDisabled}');
   });
 
   it('allows the shared create route to send a standalone dialogue without picking a project', () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerGenericCreatePreservesDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerGenericCreatePreservesDraft.test.ts
@@ -59,7 +59,10 @@ describe('通用「新建」保留 newMakerDraft 选择', () => {
 
   it('显式「新建对话」入口仍清空 workingDir,但由创建页集中迁移目标', () => {
     const block = extractHandlerBlock(sidebarUpperSource, 'handleCreateDialogue');
-    expect(block).toContain('makeDialogueNewMakerRouteState(selectedDialogueDeviceTarget)');
+    expect(block).toContain(
+      'makeDialogueNewMakerRouteState(selectedDialogueDeviceResolution.target)',
+    );
+    expect(block).toContain("selectedDialogueDeviceResolution.status === 'pending'");
     expect(block).not.toContain('resetDraftWorkspaceTargets');
     expect(draftRouteSource).toMatch(
       /applyDraftTarget\(\{\s*deviceId: dialogueTargetRequest\.deviceId,\s*deviceName: dialogueTargetRequest\.deviceName,\s*workingDir: null,/,

--- a/apps/desktop/src/renderer/__tests__/newMakerGenericCreatePreservesDraft.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerGenericCreatePreservesDraft.test.ts
@@ -57,9 +57,13 @@ describe('通用「新建」保留 newMakerDraft 选择', () => {
     expect(block).not.toContain('workingDir: null');
   });
 
-  it('显式「新建对话」入口 handleCreateDialogue 仍清空 workingDir(不受本次修复影响)', () => {
+  it('显式「新建对话」入口仍清空 workingDir,但由创建页集中迁移目标', () => {
     const block = extractHandlerBlock(sidebarUpperSource, 'handleCreateDialogue');
-    expect(block).toContain('resetDraftWorkspaceTargets();');
+    expect(block).toContain('makeDialogueNewMakerRouteState(selectedDialogueDeviceTarget)');
+    expect(block).not.toContain('resetDraftWorkspaceTargets');
+    expect(draftRouteSource).toMatch(
+      /applyDraftTarget\(\{\s*deviceId: dialogueTargetRequest\.deviceId,\s*deviceName: dialogueTargetRequest\.deviceName,\s*workingDir: null,/,
+    );
   });
 
   // 保留与清空的分界(2026-07-25 用户定稿):workingDir / 文本 / 模型是便利性

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -1166,10 +1166,10 @@ describe('Shared create project picker', () => {
    * 它真正依赖的那一半(设备 / 项目)。第五条路径出现时,①会直接失败,而②保证它自动是对的。
    */
   it('routes every draft-target transition through the single action', () => {
-    // 四条路径:设备 pill、设备域浏览器选项目、工作区 picker、所选设备失效后的自动回落。
-    // 声明本身是 `= useCallback(` 不匹配这个模式,所以数出来的就是调用点。
+    // 五条路径:设备 pill、设备域浏览器选项目、工作区 picker、所选设备失效后的自动回落、
+    // “对话”分组导航请求。声明本身是 `= useCallback(` 不匹配这个模式,所以数出来的就是调用点。
     const calls = newMakerDraftRouteSource.match(/applyDraftTarget\(\{/g) ?? [];
-    expect(calls.length).toBe(4);
+    expect(calls.length).toBe(5);
     // 组件里不得再有任何一处手写这些副作用 —— 手写一处就等于又开了一条绕过推导的路。
     // patchDraft 仍可出现(入场清 extraDirs、发送后复位),但不得再带设备字段。
     expect(newMakerDraftRouteSource).not.toContain('deviceLinkDeviceId: deviceId,');

--- a/apps/desktop/src/renderer/__tests__/newMakerRouteState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerRouteState.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  makeDialogueNewMakerRouteState,
+  readNewMakerDialogueTargetRequest,
+} from '@/features/cc-agent/lib/newMakerRouteState';
+
+describe('new maker dialogue route target request', () => {
+  it('encodes remote and local dialogue targets', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1234);
+    const remote = makeDialogueNewMakerRouteState({
+      deviceId: 'remote-a',
+      deviceName: 'Remote A',
+    });
+    const local = makeDialogueNewMakerRouteState(null);
+
+    expect(readNewMakerDialogueTargetRequest(remote)).toMatchObject({
+      deviceId: 'remote-a',
+      deviceName: 'Remote A',
+    });
+    expect(readNewMakerDialogueTargetRequest(local)).toMatchObject({
+      deviceId: null,
+      deviceName: null,
+    });
+  });
+
+  it('generates a fresh request for repeated navigation to an already-mounted route', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1234);
+    const first = readNewMakerDialogueTargetRequest(makeDialogueNewMakerRouteState(null));
+    const second = readNewMakerDialogueTargetRequest(makeDialogueNewMakerRouteState(null));
+    expect(first?.requestId).not.toBe(second?.requestId);
+  });
+
+  it('rejects malformed route state instead of guessing a target', () => {
+    expect(readNewMakerDialogueTargetRequest(null)).toBeNull();
+    expect(readNewMakerDialogueTargetRequest({ dialogueTargetRequest: {} })).toBeNull();
+    expect(
+      readNewMakerDialogueTargetRequest({
+        dialogueTargetRequest: {
+          requestId: 'bad',
+          deviceId: null,
+          deviceName: 'orphan-name',
+        },
+      }),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/newMakerRouteState.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerRouteState.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  consumeNewMakerDialogueTargetRequest,
   makeDialogueNewMakerRouteState,
   readNewMakerDialogueTargetRequest,
 } from '@/features/cc-agent/lib/newMakerRouteState';
@@ -43,5 +44,35 @@ describe('new maker dialogue route target request', () => {
         },
       }),
     ).toBeNull();
+  });
+
+  it('consumes an applied target request without changing the original or other route state', () => {
+    const original = {
+      workspacePrompt: 'dialogue',
+      dialogueTargetRequest: {
+        requestId: 'request-a',
+        deviceId: 'remote-a',
+        deviceName: 'Remote A',
+      },
+      preserved: { source: 'sidebar' },
+    };
+
+    const consumed = consumeNewMakerDialogueTargetRequest(original);
+
+    expect(consumed).toEqual({
+      workspacePrompt: 'dialogue',
+      preserved: { source: 'sidebar' },
+    });
+    expect(readNewMakerDialogueTargetRequest(consumed)).toBeNull();
+    expect(readNewMakerDialogueTargetRequest(original)).toMatchObject({
+      requestId: 'request-a',
+      deviceId: 'remote-a',
+    });
+  });
+
+  it('leaves unrelated or non-object history state untouched', () => {
+    const unrelated = { workspacePrompt: 'generic' };
+    expect(consumeNewMakerDialogueTargetRequest(unrelated)).toBe(unrelated);
+    expect(consumeNewMakerDialogueTargetRequest(null)).toBeNull();
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -103,7 +103,6 @@ import {
 } from '@/lib/sessionAttentionStore';
 import {
   patchDraft as patchNewMakerDraft,
-  resetDraftWorkspaceTargets,
 } from '@/state/newMakerDraft';
 import { consumePendingProjectFocus, usePendingProjectFocus } from '@/state/pendingProjectFocus';
 import { requestConversationSearch } from '@/state/conversationSearchRequest';
@@ -245,6 +244,7 @@ import {
   type DeletedScheduleGeneratedSessionResult,
 } from '@/features/scheduler/hooks/useDeleteScheduleWithSessions';
 import { resolveDialogueDeviceTarget } from './lib/dialogueCreateTarget';
+import { makeDialogueNewMakerRouteState } from './lib/newMakerRouteState';
 
 const log = createLogger('CCAgentSidebarUpper');
 // perf-baseline(与 MessageStream 的 perf/session-switch 探针同通道):
@@ -1964,14 +1964,9 @@ function ExpandedView({
 
   const handleCreateDialogue = useCallback(() => {
     handleClearSelection();
-    resetDraftWorkspaceTargets();
-    if (selectedDialogueDeviceTarget) {
-      patchNewMakerDraft({
-        deviceLinkDeviceId: selectedDialogueDeviceTarget.deviceId,
-        deviceLinkDeviceName: selectedDialogueDeviceTarget.deviceName,
-      });
-    }
-    navigate('/cc-agent/new', { state: makeNewMakerRouteState('dialogue') });
+    navigate('/cc-agent/new', {
+      state: makeDialogueNewMakerRouteState(selectedDialogueDeviceTarget),
+    });
   }, [handleClearSelection, navigate, selectedDialogueDeviceTarget]);
 
   const handleLinkCodexProject = useCallback(

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -237,6 +237,7 @@ import {
 } from '@/features/device-link/useMachineSwitcher';
 import {
   retryDeviceLinkDeviceList,
+  useDeviceLinkDeviceListSettled,
   useDeviceLinkDeviceListRequestState,
 } from '@/features/device-link/useDeviceLinkDeviceList';
 import {
@@ -1107,10 +1108,12 @@ function ExpandedView({
   // 过滤在源头做,下游 grouping / pinned / projects / dialogues / date-grouped / search 自动继承。
   const selectedMachineId = useEffectiveSelectedMachineId();
   const switcherDevices = useSwitcherDevices();
-  const selectedDialogueDeviceTarget = useMemo(
-    () => resolveDialogueDeviceTarget(selectedMachineId, switcherDevices),
-    [selectedMachineId, switcherDevices],
+  const deviceListSettled = useDeviceLinkDeviceListSettled();
+  const selectedDialogueDeviceResolution = useMemo(
+    () => resolveDialogueDeviceTarget(selectedMachineId, switcherDevices, deviceListSettled),
+    [selectedMachineId, switcherDevices, deviceListSettled],
   );
+  const dialogueCreatePending = selectedDialogueDeviceResolution.status === 'pending';
   // 「所有」或含远程设备的作用域还要等 device-link 首次 sessions snapshot；
   // 否则本地 sessions 先完成时会把尚未知的远程空数组误报成真实空态。
   const remoteSessionBootstrapLoading = useRemoteSessionBootstrapLoading(selectedMachineId);
@@ -1963,11 +1966,15 @@ function ExpandedView({
   ]);
 
   const handleCreateDialogue = useCallback(() => {
+    // 冷启动时 effective selection 会刻意保留持久化的唯一远端选择，但设备目录可能尚未
+    // settle、switcherDevices 仍为空。此时不能把“尚未解析”当成“确认缺失”并回落本机；
+    // 展开态段头与折叠 rail 面板共用这个 handler，因此在目标可判定前统一不创建。
+    if (selectedDialogueDeviceResolution.status === 'pending') return;
     handleClearSelection();
     navigate('/cc-agent/new', {
-      state: makeDialogueNewMakerRouteState(selectedDialogueDeviceTarget),
+      state: makeDialogueNewMakerRouteState(selectedDialogueDeviceResolution.target),
     });
-  }, [handleClearSelection, navigate, selectedDialogueDeviceTarget]);
+  }, [handleClearSelection, navigate, selectedDialogueDeviceResolution]);
 
   const handleLinkCodexProject = useCallback(
     async (project: ProjectNode) => {
@@ -3089,6 +3096,7 @@ function ExpandedView({
                     projectOptions={projectPickerOptions}
                     onScheduleAction={handleScheduleAction}
                     onCreateDialogue={handleCreateDialogue}
+                    createDisabled={dialogueCreatePending}
                     sortBy={dialogueSortBy}
                     onSortByChange={setDialogueSortBy}
                   />
@@ -3174,6 +3182,7 @@ function ExpandedView({
         projectOptions={projectPickerOptions}
         onScheduleAction={handleScheduleAction}
         onCreateDialogue={handleCreateDialogue}
+        isCreateDialogueDisabled={dialogueCreatePending}
         onCreateInProject={handleCreateInProject}
         onToggleProjectPin={handleToggleProjectPin}
         onRemoveProjectFromSidebar={handleRemoveProjectFromSidebar}
@@ -3443,6 +3452,7 @@ interface RailPanelsProps {
   onScheduleAction: Parameters<typeof SessionEntryList>[0]['onScheduleAction'];
   /** 新建对话(对话面板头部 SquarePen)——展开态 DialogueSection 段头同源 handler。 */
   onCreateDialogue: () => void;
+  isCreateDialogueDisabled: boolean;
   /** 在此项目内新建(项目行右键菜单 + 三级面板头部)——展开态 ProjectNode
    *  的 newInDirectory 主操作同源 handler(内置远程写保护)。 */
   onCreateInProject: (project: ProjectNode) => void;
@@ -3481,6 +3491,7 @@ function RailPanels({
   projectOptions,
   onScheduleAction,
   onCreateDialogue,
+  isCreateDialogueDisabled,
   onCreateInProject,
   onToggleProjectPin,
   onRemoveProjectFromSidebar,
@@ -3829,7 +3840,11 @@ function RailPanels({
             {panelHead(
               t('ccAgent.sidebar.railNav.dialogues'),
               dialogues.length,
-              panelHeadCreateButton(t('ccAgent.sidebar.newDialogue'), onCreateDialogue),
+              panelHeadCreateButton(
+                t('ccAgent.sidebar.newDialogue'),
+                onCreateDialogue,
+                isCreateDialogueDisabled,
+              ),
             )}
             <div className="max-h-[420px] overflow-y-auto [scrollbar-width:thin]">
               <SessionEntryList

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSidebarUpper.tsx
@@ -234,6 +234,7 @@ import {
   useRemoteSessionBootstrapLoading,
   useRemoteSessionBootstrapLoadingDevices,
   useSelectedMachineConnecting,
+  useSwitcherDevices,
 } from '@/features/device-link/useMachineSwitcher';
 import {
   retryDeviceLinkDeviceList,
@@ -243,6 +244,7 @@ import {
   useDeleteScheduleWithSessions,
   type DeletedScheduleGeneratedSessionResult,
 } from '@/features/scheduler/hooks/useDeleteScheduleWithSessions';
+import { resolveDialogueDeviceTarget } from './lib/dialogueCreateTarget';
 
 const log = createLogger('CCAgentSidebarUpper');
 // perf-baseline(与 MessageStream 的 perf/session-switch 探针同通道):
@@ -1104,6 +1106,11 @@ function ExpandedView({
   // 机器切换栏选中机器后整体过滤:本机 → 只本地会话;远程 → 只该机器会话。
   // 过滤在源头做,下游 grouping / pinned / projects / dialogues / date-grouped / search 自动继承。
   const selectedMachineId = useEffectiveSelectedMachineId();
+  const switcherDevices = useSwitcherDevices();
+  const selectedDialogueDeviceTarget = useMemo(
+    () => resolveDialogueDeviceTarget(selectedMachineId, switcherDevices),
+    [selectedMachineId, switcherDevices],
+  );
   // 「所有」或含远程设备的作用域还要等 device-link 首次 sessions snapshot；
   // 否则本地 sessions 先完成时会把尚未知的远程空数组误报成真实空态。
   const remoteSessionBootstrapLoading = useRemoteSessionBootstrapLoading(selectedMachineId);
@@ -1958,8 +1965,14 @@ function ExpandedView({
   const handleCreateDialogue = useCallback(() => {
     handleClearSelection();
     resetDraftWorkspaceTargets();
+    if (selectedDialogueDeviceTarget) {
+      patchNewMakerDraft({
+        deviceLinkDeviceId: selectedDialogueDeviceTarget.deviceId,
+        deviceLinkDeviceName: selectedDialogueDeviceTarget.deviceName,
+      });
+    }
     navigate('/cc-agent/new', { state: makeNewMakerRouteState('dialogue') });
-  }, [handleClearSelection, navigate]);
+  }, [handleClearSelection, navigate, selectedDialogueDeviceTarget]);
 
   const handleLinkCodexProject = useCallback(
     async (project: ProjectNode) => {

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -123,7 +123,10 @@ import { makerChatStore } from '@/lib/makerChatStore';
 import { worktreeCreationStore } from '@/lib/worktreeCreationStore';
 import { useRefreshWorktrees } from '@/contexts/WorktreeContext';
 import { crossAgentConvertService } from '@/lib/crossAgentConvertService';
-import { readNewMakerDialogueTargetRequest } from './lib/newMakerRouteState';
+import {
+  consumeNewMakerDialogueTargetRequest,
+  readNewMakerDialogueTargetRequest,
+} from './lib/newMakerRouteState';
 import { useCrossAgentMigrationDialog } from '@/hooks/useCrossAgentConvertPrompt';
 import { getCollaborationStartErrorMessage } from './collaborationErrors';
 import { resolveCollabEntryPolicy } from './collabEntryPolicy';
@@ -2078,7 +2081,11 @@ export function NewMakerDraftRoute() {
       deviceName: dialogueTargetRequest.deviceName,
       workingDir: null,
     });
-  }, [applyDraftTarget, dialogueTargetRequest]);
+    navigate(`${location.pathname}${location.search}${location.hash}`, {
+      replace: true,
+      state: consumeNewMakerDialogueTargetRequest(location.state),
+    });
+  }, [applyDraftTarget, dialogueTargetRequest, location, navigate]);
 
   // 弹窗确认添加后的落点:SSH 立即建会话 + navigate;device-link 把当前草稿指向被控端项目,
   // 首条消息发出时走既有 create-on-send 链路(见下方 isDeviceLinkDraft 分支)。

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -36,7 +36,7 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import { NEW_MAKER_DRAFT_KEY } from './newMakerDraftKeys';
 import { CreateWorkerPopover, type CreateWorkerForm } from './CreateWorkerPopover';
 import { createWorkerLabel } from './workerLabel';
-import { useNavigate, useOutletContext } from 'react-router-dom';
+import { useLocation, useNavigate, useOutletContext } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '@/contexts/AuthContext';
@@ -123,6 +123,7 @@ import { makerChatStore } from '@/lib/makerChatStore';
 import { worktreeCreationStore } from '@/lib/worktreeCreationStore';
 import { useRefreshWorktrees } from '@/contexts/WorktreeContext';
 import { crossAgentConvertService } from '@/lib/crossAgentConvertService';
+import { readNewMakerDialogueTargetRequest } from './lib/newMakerRouteState';
 import { useCrossAgentMigrationDialog } from '@/hooks/useCrossAgentConvertPrompt';
 import { getCollaborationStartErrorMessage } from './collaborationErrors';
 import { resolveCollabEntryPolicy } from './collabEntryPolicy';
@@ -565,7 +566,13 @@ export function NewMakerDraftRoute() {
   const { t } = useTranslation();
   const { dataOwnerId } = useAuth();
   const draft = useNewMakerDraft();
+  const location = useLocation();
   const navigate = useNavigate();
+  const dialogueTargetRequest = useMemo(
+    () => readNewMakerDialogueTargetRequest(location.state),
+    [location.state],
+  );
+  const handledDialogueTargetRequestRef = useRef<string | null>(null);
   // 首参 914=内容封顶宽(→ inputWidth 封顶 934):大屏留出左右呼吸空间,不再顶满全宽;
   // 与进行中对话页(CCAgentSessionView 同传 914)一致,发送首条消息时输入框宽度不跳变。
   // minWidth=640:小屏兜一个体面下限(与对话页对称);窄于下限时 hook 自动回落成
@@ -2052,6 +2059,26 @@ export function NewMakerDraftRoute() {
       dropPathBackedAttachments,
     ],
   );
+
+  // “对话”分组可能在 /cc-agent/new 已经打开时再次导航到同一路由，组件不会 remount。
+  // 目标因此随 location.state 交给本页消费，而不是让侧栏直接 patch device 字段；无论首次进入
+  // 还是重复导航，local ↔ remote / remote A ↔ B / 项目 → 对话都统一经过 applyDraftTarget，
+  // mention、路径型附件、远程运行配置和 worktree 三态才不会绕过集中迁移。
+  useLayoutEffect(() => {
+    if (
+      !dialogueTargetRequest ||
+      handledDialogueTargetRequestRef.current === dialogueTargetRequest.requestId
+    ) {
+      return;
+    }
+    handledDialogueTargetRequestRef.current = dialogueTargetRequest.requestId;
+    patchCollab({ enabled: false });
+    applyDraftTarget({
+      deviceId: dialogueTargetRequest.deviceId,
+      deviceName: dialogueTargetRequest.deviceName,
+      workingDir: null,
+    });
+  }, [applyDraftTarget, dialogueTargetRequest]);
 
   // 弹窗确认添加后的落点:SSH 立即建会话 + navigate;device-link 把当前草稿指向被控端项目,
   // 首条消息发出时走既有 create-on-send 链路(见下方 isDeviceLinkDraft 分支)。

--- a/apps/desktop/src/renderer/features/cc-agent/lib/dialogueCreateTarget.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/dialogueCreateTarget.ts
@@ -1,0 +1,27 @@
+import {
+  MACHINE_ALL,
+  MACHINE_LOCAL,
+  type MachineSelection,
+} from '@/features/device-link/selectedMachineStore';
+import type { SwitcherDevice } from '@/features/device-link/switcherDevices';
+
+export interface DialogueDeviceTarget {
+  deviceId: string;
+  deviceName: string;
+}
+
+/**
+ * “对话”分组的新建入口只在作用域明确指向一台远程机器时继承设备。
+ * “所有”、本机、混合或多台远程机器都没有唯一目标，继续使用既有本机默认。
+ */
+export function resolveDialogueDeviceTarget(
+  selectedMachineId: MachineSelection,
+  devices: readonly SwitcherDevice[],
+): DialogueDeviceTarget | null {
+  if (selectedMachineId === MACHINE_ALL || selectedMachineId.length !== 1) return null;
+  const deviceId = selectedMachineId[0];
+  if (deviceId === MACHINE_LOCAL) return null;
+  const device = devices.find((candidate) => candidate.deviceId === deviceId);
+  if (!device || device.status === 'rejected') return null;
+  return { deviceId, deviceName: device.name };
+}

--- a/apps/desktop/src/renderer/features/cc-agent/lib/dialogueCreateTarget.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/dialogueCreateTarget.ts
@@ -10,6 +10,10 @@ export interface DialogueDeviceTarget {
   deviceName: string;
 }
 
+export type DialogueDeviceTargetResolution =
+  | { status: 'pending' }
+  | { status: 'ready'; target: DialogueDeviceTarget | null };
+
 /**
  * “对话”分组的新建入口只在作用域明确指向一台远程机器时继承设备。
  * “所有”、本机、混合或多台远程机器都没有唯一目标，继续使用既有本机默认。
@@ -17,11 +21,17 @@ export interface DialogueDeviceTarget {
 export function resolveDialogueDeviceTarget(
   selectedMachineId: MachineSelection,
   devices: readonly SwitcherDevice[],
-): DialogueDeviceTarget | null {
-  if (selectedMachineId === MACHINE_ALL || selectedMachineId.length !== 1) return null;
+  deviceListSettled: boolean,
+): DialogueDeviceTargetResolution {
+  if (selectedMachineId === MACHINE_ALL || selectedMachineId.length !== 1) {
+    return { status: 'ready', target: null };
+  }
   const deviceId = selectedMachineId[0];
-  if (deviceId === MACHINE_LOCAL) return null;
+  if (deviceId === MACHINE_LOCAL) return { status: 'ready', target: null };
   const device = devices.find((candidate) => candidate.deviceId === deviceId);
-  if (!device || device.status === 'rejected') return null;
-  return { deviceId, deviceName: device.name };
+  if (!device) {
+    return deviceListSettled ? { status: 'ready', target: null } : { status: 'pending' };
+  }
+  if (device.status === 'rejected') return { status: 'ready', target: null };
+  return { status: 'ready', target: { deviceId, deviceName: device.name } };
 }

--- a/apps/desktop/src/renderer/features/cc-agent/lib/newMakerRouteState.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/newMakerRouteState.ts
@@ -46,3 +46,14 @@ export function readNewMakerDialogueTargetRequest(
   if (deviceId === null && deviceName !== null) return null;
   return { requestId: record.requestId, deviceId, deviceName };
 }
+
+/**
+ * dialogueTargetRequest 是一次性导航指令。首次应用后从当前 history entry 移除，避免用户
+ * 浏览器后退到旧的 /cc-agent/new 记录时再次迁移草稿目标；其它 route state 必须原样保留。
+ */
+export function consumeNewMakerDialogueTargetRequest(state: unknown): unknown {
+  if (!state || typeof state !== 'object' || Array.isArray(state)) return state;
+  if (!Object.prototype.hasOwnProperty.call(state, 'dialogueTargetRequest')) return state;
+  const { dialogueTargetRequest: _consumed, ...remainingState } = state as Record<string, unknown>;
+  return remainingState;
+}

--- a/apps/desktop/src/renderer/features/cc-agent/lib/newMakerRouteState.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/newMakerRouteState.ts
@@ -1,0 +1,48 @@
+import type { DialogueDeviceTarget } from './dialogueCreateTarget';
+
+export interface NewMakerDialogueTargetRequest {
+  requestId: string;
+  deviceId: string | null;
+  deviceName: string | null;
+}
+
+export interface NewMakerRouteState {
+  workspacePrompt: 'generic' | 'dialogue';
+  dialogueTargetRequest?: NewMakerDialogueTargetRequest;
+}
+
+let dialogueTargetRequestSequence = 0;
+
+/**
+ * “对话”分组每次点击都生成新 requestId。同路由重复 navigate 不会 remount 创建页，
+ * 但 location.state 会更新，创建页可据此再次执行完整 target transition。
+ */
+export function makeDialogueNewMakerRouteState(
+  target: DialogueDeviceTarget | null,
+): NewMakerRouteState {
+  dialogueTargetRequestSequence += 1;
+  return {
+    workspacePrompt: 'dialogue',
+    dialogueTargetRequest: {
+      requestId: `${Date.now()}-${dialogueTargetRequestSequence}`,
+      deviceId: target?.deviceId ?? null,
+      deviceName: target?.deviceName ?? null,
+    },
+  };
+}
+
+export function readNewMakerDialogueTargetRequest(
+  state: unknown,
+): NewMakerDialogueTargetRequest | null {
+  if (!state || typeof state !== 'object') return null;
+  const request = (state as Record<string, unknown>).dialogueTargetRequest;
+  if (!request || typeof request !== 'object') return null;
+  const record = request as Record<string, unknown>;
+  if (typeof record.requestId !== 'string' || record.requestId.length === 0) return null;
+  const deviceId = record.deviceId;
+  const deviceName = record.deviceName;
+  if (deviceId !== null && (typeof deviceId !== 'string' || deviceId.length === 0)) return null;
+  if (deviceName !== null && typeof deviceName !== 'string') return null;
+  if (deviceId === null && deviceName !== null) return null;
+  return { requestId: record.requestId, deviceId, deviceName };
+}

--- a/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/DialogueSection.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/sidebar/sections/DialogueSection.tsx
@@ -83,6 +83,7 @@ export interface DialogueSectionProps {
   projectOptions?: readonly FolderPickerOption[];
   onScheduleAction: (group: AutomationSessionGroup, action: AutomationScheduleAction) => void;
   onCreateDialogue: () => void;
+  createDisabled?: boolean;
   /** 排序受控化:状态提升到 ExpandedView,折叠 rail 的对话面板与本段共用同一
    *  排序(否则折叠后面板前 N 条与展开态刚排好的顺序不一致,codex review)。 */
   sortBy: DialogueSortBy;
@@ -130,6 +131,7 @@ export function DialogueSection({
   projectOptions,
   onScheduleAction,
   onCreateDialogue,
+  createDisabled = false,
   sortBy,
   onSortByChange,
 }: DialogueSectionProps) {
@@ -244,6 +246,7 @@ export function DialogueSection({
             <button
               type="button"
               onClick={onCreateDialogue}
+              disabled={createDisabled}
               aria-label={t('ccAgent.sidebar.newDialogue')}
               className={cn(
                 'flex h-7 w-7 items-center justify-center rounded-md',


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复左侧机器范围明确选中一台远程机器时，从“对话”分组右侧新建任务，创建页却默认回到本机的问题。

“对话”新建入口把一次性的目标设备请求随导航交给创建页处理。无论首次进入创建页，还是已经停留在 `/cc-agent/new` 后再次点击同一路由，目标切换都统一经过现有 `applyDraftTarget` 迁移，避免旧项目的 mention、路径附件、远程运行配置或 worktree 状态跨设备残留。一次性目标请求首次应用后会从当前 history 记录中消费，随后浏览器后退到旧的创建页记录也不会重放旧设备目标、误清当前草稿。

冷启动恢复了唯一远程机器选择、但设备目录尚未结算时，展开态和折叠 rail 的“对话”创建动作会共同等待目标可判定，不再把“尚未解析”误当成“设备缺失”并回落本机。目录确认目标存在后继承远程设备；确认缺失或被拒后才使用本机安全默认。“所有”、本机、混合或多台远程机器仍不猜测目标。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈
- 本 PR 包含：“对话”分组新建入口的远程机器继承；唯一目标判定；设备目录加载边界；同路由重复导航时的集中目标迁移；回归测试
- 明确不包含：项目目录行新建入口；通用新建入口；Device Link、maker-core 或设备切换交互重构
- 用户可见变化：明确选中一台远程机器后，从“对话”分组新建任务，创建页和发送目标保持在该机器；设备目录尚未结算时不会错误创建到本机
- 是否存在 breaking change：无

### UI 变化

不涉及视觉、布局、动效或文案变化，只修复 Renderer 内现有入口的导航、加载期门禁与草稿目标迁移逻辑。

- 引用的设计规范：不涉及；未新增或修改视觉组件与 UI 文案

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（全部 workspace）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run \
  src/renderer/__tests__/dialogueCreateTarget.test.ts \
  src/renderer/__tests__/dialogueSidebarSection.test.ts \
  src/renderer/__tests__/newMakerGenericCreatePreservesDraft.test.ts \
  src/renderer/__tests__/newMakerProjectPicker.test.ts \
  src/renderer/__tests__/newMakerRouteState.test.ts
结果：104 项通过

pnpm check:dco
结果：通过

node ~/.agents/skills/git-workflow/scripts/pr-size-gate.mjs
结果：PASS

git diff --check
结果：通过
```

回归覆盖：
- 唯一选中的已连接或连接中远程机器会被继承
- 唯一远程选择但设备目录尚未结算时，展开态与折叠态创建入口都不会回落本机
- 目录结算后确认目标存在、缺失或被拒的三种结果
- “所有”、仅本机、混合、多台远程机器不会被武断映射到某台设备
- 已打开创建页后的重复导航仍会触发集中迁移
- 一次性目标请求应用后会从对应 history 记录消费，浏览器后退不会重放旧目标
- local → remote、remote A → B、remote → local 与项目 → 对话不会保留上一目标的路径型草稿状态

### 手工验证

2026-08-08，用户已在隔离 DEV 沙盒 `remote-conversation-inherit` 实测通过：选中一台远程机器后，点击“对话”分组右侧新建按钮，创建页设备指针正确保持在该远程机器。

### 未执行的验证

- 未人工制造冷启动设备目录加载窗口；该边界由纯函数与两个共享创建入口的回归测试覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 左侧“对话”分组的新建任务入口
- 回滚 / 降级方式：回退本 PR；不涉及数据迁移或持久化格式

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 变化已如实说明为“不涉及视觉改动”
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果

