### PR TITLE
feat(browser): detect Chrome Beta on macOS

### DIFF
--- a/packages/browser-control-runtime/src/__tests__/chrome-executable-discovery.test.ts
+++ b/packages/browser-control-runtime/src/__tests__/chrome-executable-discovery.test.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  findChromeExecutableMac,
+  resolveGoogleChromeExecutableForPlatform,
+} from '../_generated/extension/src/browser/chrome.executables.js';
+
+const stablePath = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const bravePath = '/Applications/Brave Browser.app/Contents/MacOS/Brave Browser';
+const testHome = path.join(path.sep, 'Users', 'test');
+const betaPaths = [
+  '/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta',
+  path.join(
+    testHome,
+    'Applications',
+    'Google Chrome Beta.app',
+    'Contents',
+    'MacOS',
+    'Google Chrome Beta',
+  ),
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('macOS Chrome executable discovery', () => {
+  it.each(betaPaths)('detects Chrome Beta at %s', (betaPath) => {
+    vi.spyOn(os, 'homedir').mockReturnValue(testHome);
+    vi.spyOn(fs, 'existsSync').mockImplementation(
+      (candidate) => String(candidate) === betaPath,
+    );
+
+    expect(findChromeExecutableMac()).toEqual({
+      kind: 'chrome',
+      path: betaPath,
+    });
+    expect(resolveGoogleChromeExecutableForPlatform('darwin')).toEqual({
+      kind: 'chrome',
+      path: betaPath,
+    });
+  });
+
+  it('keeps stable Chrome ahead of Beta', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue(testHome);
+    vi.spyOn(fs, 'existsSync').mockImplementation((candidate) =>
+      [stablePath, ...betaPaths].includes(String(candidate)),
+    );
+
+    expect(findChromeExecutableMac()).toEqual({ kind: 'chrome', path: stablePath });
+    expect(resolveGoogleChromeExecutableForPlatform('darwin')).toEqual({
+      kind: 'chrome',
+      path: stablePath,
+    });
+  });
+
+  it('keeps stable third-party browsers ahead of Beta', () => {
+    vi.spyOn(os, 'homedir').mockReturnValue(testHome);
+    vi.spyOn(fs, 'existsSync').mockImplementation((candidate) =>
+      [bravePath, ...betaPaths].includes(String(candidate)),
+    );
+
+    expect(findChromeExecutableMac()).toEqual({ kind: 'brave', path: bravePath });
+    expect(resolveGoogleChromeExecutableForPlatform('darwin')).toEqual({
+      kind: 'chrome',
+      path: betaPaths[0],
+    });
+  });
+});

--- a/packages/browser-control-runtime/src/_generated/extension/src/browser/chrome.executables.ts
+++ b/packages/browser-control-runtime/src/_generated/extension/src/browser/chrome.executables.ts
@@ -578,6 +578,17 @@ export function findChromeExecutableMac(): BrowserExecutable | null {
       path: path.join(os.homedir(), "Applications/Chromium.app/Contents/MacOS/Chromium"),
     },
     {
+      kind: "chrome",
+      path: "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+    },
+    {
+      kind: "chrome",
+      path: path.join(
+        os.homedir(),
+        "Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+      ),
+    },
+    {
       kind: "canary",
       path: "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
     },
@@ -594,14 +605,37 @@ export function findChromeExecutableMac(): BrowserExecutable | null {
 }
 
 function findGoogleChromeExecutableMac(): BrowserExecutable | null {
-  return findFirstChromeExecutable([
-    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    path.join(os.homedir(), "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
-    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
-    path.join(
-      os.homedir(),
-      "Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
-    ),
+  return findFirstExecutable([
+    {
+      kind: "chrome",
+      path: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    },
+    {
+      kind: "chrome",
+      path: path.join(os.homedir(), "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+    },
+    {
+      kind: "chrome",
+      path: "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+    },
+    {
+      kind: "chrome",
+      path: path.join(
+        os.homedir(),
+        "Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+      ),
+    },
+    {
+      kind: "canary",
+      path: "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    },
+    {
+      kind: "canary",
+      path: path.join(
+        os.homedir(),
+        "Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      ),
+    },
   ]);
 }
 

--- a/packages/browser-control-runtime/upstream/browser-runtime.lock.json
+++ b/packages/browser-control-runtime/upstream/browser-runtime.lock.json
@@ -15,6 +15,14 @@
   ],
   "patches": [
     {
+      "file": "extension/src/browser/chrome.executables.ts",
+      "desc": "detect macOS Google Chrome Beta after stable Chromium-family browsers"
+    },
+    {
+      "file": "extension/src/browser/chrome.executables.ts",
+      "desc": "classify macOS Google Chrome Beta within the Chrome-only fallback"
+    },
+    {
       "file": "extension/src/browser/config.ts",
       "desc": "preserve narrow fake-IP SSRF allowances from the host config without enabling general private-network access"
     },
@@ -24,7 +32,7 @@
     }
   ],
   "fileCount": 335,
-  "contentHash": "1bc2c6ddddf76824846b6e14ce5bf27e3b222b3283c9fbf2beda1d4283d3040a",
+  "contentHash": "ec71c1f65b7239df32b0e861d8ac55a1dc55747487dae4fcf1ea4d16002c02ec",
   "fsSafe": {
     "package": "@openclaw/fs-safe",
     "version": "0.4.0"

--- a/scripts/browser-runtime/sync.mjs
+++ b/scripts/browser-runtime/sync.mjs
@@ -248,6 +248,82 @@ function header(srcLabel) {
  * src/shim/* for anything that can live at the adapter boundary.
  */
 const LOCAL_PATCHES = {
+  'extension/src/browser/chrome.executables.ts': [
+    {
+      desc: 'detect macOS Google Chrome Beta after stable Chromium-family browsers',
+      find: `    {
+      kind: "chromium",
+      path: path.join(os.homedir(), "Applications/Chromium.app/Contents/MacOS/Chromium"),
+    },
+    {
+      kind: "canary",`,
+      replace: `    {
+      kind: "chromium",
+      path: path.join(os.homedir(), "Applications/Chromium.app/Contents/MacOS/Chromium"),
+    },
+    {
+      kind: "chrome",
+      path: "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+    },
+    {
+      kind: "chrome",
+      path: path.join(
+        os.homedir(),
+        "Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+      ),
+    },
+    {
+      kind: "canary",`,
+    },
+    {
+      desc: 'classify macOS Google Chrome Beta within the Chrome-only fallback',
+      find: `function findGoogleChromeExecutableMac(): BrowserExecutable | null {
+  return findFirstChromeExecutable([
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    path.join(os.homedir(), "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    path.join(
+      os.homedir(),
+      "Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    ),
+  ]);
+}`,
+      replace: `function findGoogleChromeExecutableMac(): BrowserExecutable | null {
+  return findFirstExecutable([
+    {
+      kind: "chrome",
+      path: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    },
+    {
+      kind: "chrome",
+      path: path.join(os.homedir(), "Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+    },
+    {
+      kind: "chrome",
+      path: "/Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+    },
+    {
+      kind: "chrome",
+      path: path.join(
+        os.homedir(),
+        "Applications/Google Chrome Beta.app/Contents/MacOS/Google Chrome Beta",
+      ),
+    },
+    {
+      kind: "canary",
+      path: "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+    },
+    {
+      kind: "canary",
+      path: path.join(
+        os.homedir(),
+        "Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+      ),
+    },
+  ]);
+}`,
+    },
+  ],
   'extension/src/browser/config.ts': [
     {
       desc: 'preserve narrow fake-IP SSRF allowances from the host config without enabling general private-network access',


### PR DESCRIPTION
## 这次改了什么

### 摘要

Detect Google Chrome Beta in the system and user Applications directories on macOS without changing stable-browser priority. Fixes #506.

### 变更类型

- [x] `feat`
- [ ] `fix`
- [ ] `refactor` / `perf`
- [x] `docs` / `test` / `chore`
- [ ] Other

### 范围

- Included: macOS Chrome Beta discovery, generated-runtime sync metadata, and tests.
- Excluded: other browsers and platforms.
- User-visible change: general discovery uses Beta only after Chrome, Brave, Edge, and Chromium; the Chrome-only fallback still prefers Beta to Canary.
- Breaking change: No.

### UI 变化

Not applicable. No UI code or copy changed.

- 引用的设计规范: Not applicable. No UI code or copy changed.

## 怎么验证的

### 自动验证

```text
pnpm test:unit
Passed.

NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
Passed.

pnpm check:dco -- --base origin/main
Passed.
```

### 手工验证

Not run on macOS. Executable discovery and priority are covered by tests.

### 未执行的验证

Manual macOS executable discovery was not run. `pnpm sync:browser-runtime -- --check` was not rerun because it requires authenticated GitHub access, which is intentionally unavailable in the verifier. The checked-in generated artifacts are covered by the offline unit suite.

## 风险

### 风险分类

- [ ] No known risk
- [ ] SQLite / migration
- [ ] System prompt
- [ ] Protocol compatibility
- [ ] Permissions / security / user data
- [ ] Existing plugin compatibility
- [ ] Native layer / fingerprint / OTA
- [x] Cross-platform differences
- [ ] Other

### 影响与回滚

- Impact: adds macOS discovery candidates while preserving stable browser priority.
- Rollback: revert the commit; no migration or cleanup is required.

### 提交前检查

- [x] Reviewed the complete diff
- [x] Every commit has a DCO sign-off
- [x] No UI change
- [x] No credentials, tokens, or authorization files are included
- [x] No additional documentation is required
- [x] Test results and untested paths are documented
