### PR TITLE
fix(maker-core): abort 在并发 send accept 窗口不再抢清 turnInFlight

### DIFF
--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -5111,7 +5111,11 @@ export class ClaudeCodeAgent extends BaseAgent {
               // foreground turn has not already produced a terminal, replace
               // it with one synthetic boundary; a raced natural result leaves
               // foregroundWasInFlight=false and therefore does not get a duplicate.
-              if (foregroundWasInFlight) emitTurnBoundary('user_stop_unconfirmed_wake_tasks');
+              // accept 阶段的并发 send 例外:boundary 由它的 finishSendBeforeUserInput
+              // 发,这里再发会双 boundary(review 3541310178)。
+              if (foregroundWasInFlight && !sendInAcceptPhase) {
+                emitTurnBoundary('user_stop_unconfirmed_wake_tasks');
+              }
             }
             inputQueue.clear();
             try {
@@ -5122,13 +5126,18 @@ export class ClaudeCodeAgent extends BaseAgent {
             recordCanceledQueryClose(cancelledQuery, 'user_stop cancellation');
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
-            turnInFlight = false;
+            // sendInAcceptPhase 时留给 finishSendBeforeUserInput 清 + 发 boundary
+            // (inputQueue 已 end,并发 send 的 push 必失败进 catch)。
+            if (!sendInAcceptPhase) turnInFlight = false;
           } else {
             // interrupt 成功且无后台任务需要清：被中断的 turn 会收到
             // error_during_execution result → translator 在 onTurnEnd 清
             // turnInFlight。这里显式补清以防 SDK 未 drain result 的极端
             // 情况(确保不会 SESSION_RUNNING 永拒)。
-            turnInFlight = false;
+            // sendInAcceptPhase 例外:并发 send 仍在 accept 窗口,抢清会让它的
+            // finishSendBeforeUserInput 在 `if (!turnInFlight) return` 提前返回,
+            // send_cancelled_before_acceptance boundary 丢失(review 3541310178)。
+            if (!sendInAcceptPhase) turnInFlight = false;
           }
         } catch (e) {
           const errMsg = e instanceof Error ? e.message : String(e);
@@ -5155,11 +5164,12 @@ export class ClaudeCodeAgent extends BaseAgent {
             recordCanceledQueryClose(q, 'user_stop interrupt timeout');
             runningBackgroundTasks.clear();
             terminalBackgroundTaskIds.clear();
-            turnInFlight = false;
+            // 同上:accept 阶段并发 send 的收口权归 finishSendBeforeUserInput。
+            if (!sendInAcceptPhase) turnInFlight = false;
           } else {
             // interrupt 真正抛错(非超时)，回收标记防误抑制(同 watchdog)。
             turnState.interruptRequested = false;
-            turnInFlight = false;
+            if (!sendInAcceptPhase) turnInFlight = false;
             log.warn('abort threw', { error: String(e) });
           }
         }


### PR DESCRIPTION
## 改动说明

修复主干 client-ci 自 3d3a6b59e 起持续红的 maker-core 测试回归:
`rewind-runtime-settings.test.ts > cancels a post-rebuild send if Stop arrives during accept replay`。

### 根因

P1-A 修复 (3d3a6b59e) 让 `abort()` 保持 `turnInFlight=true` 直到 interrupt 返回,并在入口用 `sendInAcceptPhase` 守卫跳过抢清。但 interrupt 之后的各收口分支(close-query / interrupt 成功补清 / 超时 / 抛错)都**无条件** `turnInFlight = false`,绕过了该守卫:

并发 send 还在 accept replay(runtime drift replay 的 control request await)时,abort 的收口先把 `turnInFlight` 清掉 → send 随后走到 `finishSendBeforeUserInput('send_cancelled_before_acceptance')`,在 `if (!turnInFlight) return` 提前返回 → **terminal boundary 丢失**,上层永远等不到 `done` 事件。

### 修复

abort 的四个收口分支统一改为 `sendInAcceptPhase` 时不清 `turnInFlight`,收口权(清状态 + emit boundary)归并发 send 的 `finishSendBeforeUserInput`;unconfirmed-wake-tasks 分支的 synthetic boundary 同样让位,避免双 boundary。

安全性:`sendInAcceptPhase` 只在 send 的 beginNewTurn→push 窗口内为 true,该窗口内 send 必然走到自己的 finally 收口(成功置 false / 失败走 finishSendBeforeUserInput),不存在悬置泄漏。

## 验证

- `pnpm test:unit` 全绿(此前主干红)
- `rewind-runtime-settings.test.ts` 36/36 通过(含此前失败的 accept replay 用例)
- `abort-stops-background-tasks.test.ts` 73/73 通过(P1-A 的两条新断言不回退)
- `pnpm --filter @cindy/maker-core run typecheck` 通过

## 风险

改动仅限 abort 收口时序,不改 interrupt/close 语义。风险集中在 Stop 与 send 并发的窄窗口,已有两个测试文件覆盖双向场景。

🤖 Generated with [Claude Code](https://claude.com/claude-code)