### PR TITLE
fix(model-providers): 修复自定义渠道模型 effort 识别

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts
@@ -458,6 +458,81 @@ describe('provider catalog realm reload', () => {
     ).toEqual(activeXaiModels);
   });
 
+  it('reprojects custom provider efforts when the registry refreshes', async () => {
+    const current = structuredClone(
+      catalogNamed('catalog-before-custom-reproject', '2026-07-31T13:00:00.000Z'),
+    );
+    const currentEntry = current.modelRegistry?.models.find(
+      (entry) => entry.id === 'openai/gpt-5.6-sol',
+    );
+    if (!currentEntry) throw new Error('expected gpt-5.6-sol registry entry');
+    currentEntry.perAgent = {
+      ...currentEntry.perAgent,
+      codex: { ...currentEntry.perAgent?.codex, efforts: ['high'], defaultEffort: 'high' },
+    };
+    setActiveCatalog(current);
+
+    const config: CustomProviderConfig = {
+      id: 'registry-relay',
+      name: 'Registry Relay',
+      runtimes: {
+        codex: {
+          baseUrl: 'https://relay.example/v1',
+          models: [{ id: 'gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+        },
+      },
+    };
+    h.customProviderRead.mockResolvedValueOnce([config]);
+    await refreshCustomProvidersIntoCatalog();
+
+    const before = getActiveCatalog().providers.find((provider) => provider.id === config.id);
+    expect(before?.models.codex?.[0]).toMatchObject({
+      id: 'gpt-5.6-sol',
+      efforts: ['high'],
+      defaultEffort: 'high',
+    });
+
+    const next = structuredClone(
+      catalogNamed('catalog-after-custom-reproject', '2026-07-31T14:00:00.000Z'),
+    );
+    const nextEntry = next.modelRegistry?.models.find(
+      (entry) => entry.id === 'openai/gpt-5.6-sol',
+    );
+    if (!nextEntry) throw new Error('expected gpt-5.6-sol registry entry');
+    nextEntry.perAgent = {
+      ...nextEntry.perAgent,
+      codex: {
+        ...nextEntry.perAgent?.codex,
+        efforts: ['high', 'max', 'ultra'],
+        defaultEffort: 'ultra',
+      },
+    };
+
+    const events: number[] = [];
+    setActiveCatalogChangedListener((revision) => events.push(revision));
+    try {
+      const refresh = refreshActiveCatalogFromSource();
+      await Promise.resolve();
+      h.refreshLoads.at(-1)!.resolve({ catalog: next, source: 'remote' });
+      await refresh;
+
+      const after = getActiveCatalog().providers.find((provider) => provider.id === config.id);
+      expect(after).toMatchObject({
+        id: config.id,
+        routing: { codex: { upstream: 'https://relay.example/v1' } },
+      });
+      expect(after?.models.codex?.[0]).toMatchObject({
+        id: 'gpt-5.6-sol',
+        efforts: ['high', 'max', 'ultra'],
+        defaultEffort: 'ultra',
+      });
+      expect(events).toHaveLength(1);
+    } finally {
+      setActiveCatalogChangedListener(null);
+      setCustomProviders([]);
+    }
+  });
+
   it('按时间语义守卫 offset/Z 等价 revision,拒收真实旧值和坏值,接受真实新值', async () => {
     setActiveCatalog(catalogNamed('current-offset', '2026-08-02T10:00:00+08:00'));
     h.warn.mockClear();

--- a/apps/desktop/src/main/maker-host/active-catalog.ts
+++ b/apps/desktop/src/main/maker-host/active-catalog.ts
@@ -26,10 +26,12 @@
 
 import {
   BUNDLED_CATALOG,
+  buildUserProvider,
   findModelRegistryRoute,
   type AgentKind,
   type Catalog,
   type CatalogModel,
+  type CustomProviderConfig,
   type Provider,
 } from '@cindy/model-providers';
 
@@ -57,6 +59,11 @@ import {
 let base: Catalog | null = null;
 /** 用户自定义供应商(已 buildUserProvider 展开的标准 Provider),追加在 base 之后。 */
 let custom: Provider[] = [];
+/**
+ * 当前 owner 的原始自定义供应商配置。保留它是为了在 base registry 热更新时同步重建
+ * effort 投影；null 表示 custom 由测试/旧调用方直接注入，不能安全重建。
+ */
+let customConfigs: CustomProviderConfig[] | null = null;
 /**
  * codex cache 派生的规范化模型快照(原始 slug,不带 chatgpt/ 前缀)。先 augment 到
  * openai.codex,再从生效后的 codex 列表投影 openai.claude-code bridge,确保两边名称和排序同源。
@@ -767,6 +774,11 @@ export function getCatalogModelContextWindow(
 /** 由 host 的目录加载器(ensureActiveCatalogLoaded)在拉取成功后写入基础目录。 */
 export function setActiveCatalog(catalog: Catalog): void {
   base = catalog;
+  if (customConfigs) {
+    custom = customConfigs.map((config) =>
+      buildUserProvider(config, { modelRegistry: catalog.modelRegistry }),
+    );
+  }
   markChanged();
 }
 
@@ -792,6 +804,11 @@ export function commitModelPlaneFromCatalog(catalog: Catalog): void {
     providers,
     ...(catalog.modelRegistry ? { modelRegistry: catalog.modelRegistry } : {}),
   };
+  if (customConfigs) {
+    custom = customConfigs.map((config) =>
+      buildUserProvider(config, { modelRegistry: base?.modelRegistry }),
+    );
+  }
   markChanged();
 }
 
@@ -814,7 +831,20 @@ export function getModelPlaneWarnings(): readonly ModelPlaneWarning[] {
  * 传入的是已 `buildUserProvider` 展开的标准 `Provider[]`(**不含 API key**)。
  */
 export function setCustomProviders(providers: Provider[]): void {
+  customConfigs = null;
   custom = [...providers];
+  markChanged();
+}
+
+/**
+ * 注入当前 owner 的原始自定义供应商配置，并按当前 registry 展开。保留原配置供后续
+ * registry 热更新原子重建，避免 custom provider 持有旧 effort 快照。
+ */
+export function setCustomProviderConfigs(configs: CustomProviderConfig[]): void {
+  customConfigs = [...configs];
+  custom = customConfigs.map((config) =>
+    buildUserProvider(config, { modelRegistry: (base ?? BUNDLED_CATALOG).modelRegistry }),
+  );
   markChanged();
 }
 

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -684,7 +684,9 @@ export async function refreshCustomProvidersIntoCatalog(
       log.info('discarded stale custom provider catalog refresh');
       return;
     }
-    setCustomProviders(configs.map((c) => buildUserProvider(c)));
+    setCustomProviders(
+      configs.map((c) => buildUserProvider(c, { modelRegistry: getActiveCatalog().modelRegistry })),
+    );
     log.info('custom providers merged into active catalog', { count: configs.length });
   } catch (err) {
     if (!shouldApply()) {

--- a/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
+++ b/apps/desktop/src/main/maker-host/createDesktopProviderService.ts
@@ -23,7 +23,6 @@ import path from 'node:path';
 
 import {
   BUNDLED_CATALOG,
-  buildUserProvider,
   compareModelRegistryRevisions,
   decideModelRegistrySnapshot,
   DEFAULT_REMOTE_CATALOG_BUDGET_MS,
@@ -43,6 +42,7 @@ import {
   getActiveCatalog,
   getModelPlaneWarnings,
   setActiveCatalog,
+  setCustomProviderConfigs,
   setCustomProviders,
   setDiscoveredCodexModels,
   setLocalCatalogOverrides,
@@ -684,9 +684,7 @@ export async function refreshCustomProvidersIntoCatalog(
       log.info('discarded stale custom provider catalog refresh');
       return;
     }
-    setCustomProviders(
-      configs.map((c) => buildUserProvider(c, { modelRegistry: getActiveCatalog().modelRegistry })),
-    );
+    setCustomProviderConfigs(configs);
     log.info('custom providers merged into active catalog', { count: configs.length });
   } catch (err) {
     if (!shouldApply()) {

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from 'vitest';
 
 import { buildUserProvider, DEFAULT_CUSTOM_CONTEXT_WINDOW } from '../user-provider.js';
 import type { CustomProviderConfig } from '../types.js';
+import { BUNDLED_CATALOG } from '../catalog.js';
 
 const codexOnly: CustomProviderConfig = {
   id: 'openrouter',
@@ -104,6 +105,80 @@ describe('buildUserProvider (per-runtime)', () => {
       group: 'custom:openrouter',
       defaultEnabled: true,
     });
+  });
+
+  it('inherits registry effort capabilities for known models without changing the custom route', () => {
+    const provider = buildUserProvider(
+      {
+        ...codexOnly,
+        id: 'relay',
+        name: 'Relay',
+        runtimes: {
+          codex: {
+            ...codexOnly.runtimes.codex!,
+            models: [
+              { id: 'gpt-5.6-sol', name: 'GPT-5.6-Sol' },
+              { id: 'chatgpt/gpt-5.6-sol', name: 'GPT-5.6-Sol (ChatGPT)' },
+              { id: 'gpt-5.6-terra', name: 'GPT-5.6-Terra' },
+              { id: 'gpt-5.6-luna', name: 'GPT-5.6-Luna' },
+              { id: 'z-ai/glm-5.2', name: 'GLM-5.2' },
+              { id: 'claude-haiku-4-5', name: 'Claude Haiku 4.5' },
+              { id: 'unregistered-model', name: 'Unregistered' },
+            ],
+          },
+          'claude-code': {
+            baseUrl: 'https://openrouter.ai/api/v1',
+            models: [{ id: 'gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+
+    expect(provider.id).toBe('relay');
+    expect(provider.routing.codex?.upstream).toBe('https://openrouter.ai/api/v1');
+    expect(provider.models.codex).toEqual([
+      expect.objectContaining({ id: 'gpt-5.6-sol', efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'], defaultEffort: 'high' }),
+      expect.objectContaining({ id: 'chatgpt/gpt-5.6-sol', efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'], defaultEffort: 'high' }),
+      expect.objectContaining({ id: 'gpt-5.6-terra', efforts: ['low', 'medium', 'high', 'xhigh', 'max', 'ultra'], defaultEffort: 'high' }),
+      expect.objectContaining({ id: 'gpt-5.6-luna', efforts: ['low', 'medium', 'high', 'xhigh', 'max'], defaultEffort: 'high' }),
+      expect.objectContaining({ id: 'z-ai/glm-5.2', efforts: ['minimal', 'high', 'max'], defaultEffort: 'max' }),
+      expect.objectContaining({ id: 'claude-haiku-4-5', efforts: [], defaultEffort: null }),
+      expect.objectContaining({ id: 'unregistered-model', efforts: ['low', 'medium', 'high', 'xhigh'], defaultEffort: 'high' }),
+    ]);
+    expect(provider.models['claude-code']).toEqual([
+      expect.objectContaining({
+        id: 'gpt-5.6-sol',
+        efforts: ['low', 'medium', 'high', 'xhigh', 'max'],
+        defaultEffort: 'high',
+      }),
+    ]);
+  });
+
+  it('uses the supplied registry when a newer catalog changes a known model capability', () => {
+    const registry = structuredClone(BUNDLED_CATALOG.modelRegistry);
+    if (!registry) throw new Error('missing bundled model registry');
+    const entry = registry.models.find((candidate) => candidate.id === 'openai/gpt-5.6-sol');
+    if (!entry) throw new Error('missing gpt-5.6-sol registry entry');
+    entry.perAgent = {
+      ...entry.perAgent,
+      codex: { ...entry.perAgent?.codex, efforts: ['high', 'ultra'], defaultEffort: 'ultra' },
+    };
+
+    const provider = buildUserProvider(
+      {
+        ...codexOnly,
+        runtimes: {
+          codex: {
+            ...codexOnly.runtimes.codex!,
+            models: [{ id: 'gpt-5.6-sol', name: 'GPT-5.6-Sol' }],
+          },
+        },
+      },
+      { modelRegistry: registry },
+    );
+    const model = provider.models.codex?.find((candidate) => candidate.id === 'gpt-5.6-sol');
+    expect(model).toMatchObject({ efforts: ['high', 'ultra'], defaultEffort: 'ultra' });
   });
 
   it('respects an explicit hidden default for discovered models', () => {

--- a/packages/model-providers/src/__tests__/user-provider.test.ts
+++ b/packages/model-providers/src/__tests__/user-provider.test.ts
@@ -181,6 +181,35 @@ describe('buildUserProvider (per-runtime)', () => {
     expect(model).toMatchObject({ efforts: ['high', 'ultra'], defaultEffort: 'ultra' });
   });
 
+  it('requires a target-agent route before inheriting a canonical registry entry', () => {
+    const provider = buildUserProvider(
+      {
+        id: 'relay',
+        name: 'Relay',
+        runtimes: {
+          codex: {
+            baseUrl: 'https://relay.example/v1',
+            models: [{ id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' }],
+          },
+          'claude-code': {
+            baseUrl: 'https://relay.example/v1',
+            models: [{ id: 'google/gemini-3.5-flash', name: 'Gemini 3.5 Flash' }],
+          },
+        },
+      },
+      { modelRegistry: BUNDLED_CATALOG.modelRegistry },
+    );
+
+    expect(provider.models.codex?.[0]).toMatchObject({
+      efforts: ['low', 'medium', 'high', 'xhigh'],
+      defaultEffort: 'high',
+    });
+    expect(provider.models['claude-code']?.[0]).toMatchObject({
+      efforts: ['low', 'medium', 'high'],
+      defaultEffort: 'high',
+    });
+  });
+
   it('respects an explicit hidden default for discovered models', () => {
     const p = buildUserProvider({
       ...codexOnly,

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -63,10 +63,11 @@ function registryEffortMetadata(
   const candidates = new Set([modelId]);
   if (modelId.startsWith('chatgpt/')) candidates.add(modelId.slice('chatgpt/'.length));
   const matches = registry.models.filter((entry) =>
-    candidates.has(entry.id)
-      || entry.routes.some(
-        (route) => route.agents.includes(agent) && candidates.has(route.modelId),
-      ),
+    entry.routes.some(
+      (route) =>
+        route.agents.includes(agent) &&
+        (candidates.has(entry.id) || candidates.has(route.modelId)),
+    ),
   );
   const entries = [...new Map(matches.map((entry) => [entry.id, entry])).values()];
   if (entries.length !== 1) return undefined;

--- a/packages/model-providers/src/user-provider.ts
+++ b/packages/model-providers/src/user-provider.ts
@@ -11,6 +11,8 @@
  *   - 用户模型可携带预设确认的 contextWindow；缺省时补保守默认，effort 使用 runtime 默认。
  */
 
+import type { ModelRegistry } from '@cindy/model-access-protocol';
+
 import type {
   AgentKind,
   CatalogModel,
@@ -41,6 +43,48 @@ const CUSTOM_EFFORTS: Partial<Record<AgentKind, Effort[]>> = {
 /** 自定义模型默认选中的 effort（与内置旗舰一致）。 */
 const DEFAULT_CUSTOM_EFFORT: Effort = 'high';
 
+interface RegistryEffortMetadata {
+  efforts: Effort[];
+  defaultEffort: Effort | null;
+}
+
+/**
+ * Resolve a custom model's capabilities from the canonical registry when its id is known.
+ * Registry routes are provider-specific, but custom providers intentionally keep their own
+ * provider id and model id; only the effort metadata is shared here.
+ */
+function registryEffortMetadata(
+  registry: ModelRegistry | null | undefined,
+  modelId: string,
+  agent: AgentKind,
+): RegistryEffortMetadata | undefined {
+  if (agent === 'pi' || !registry) return undefined;
+
+  const candidates = new Set([modelId]);
+  if (modelId.startsWith('chatgpt/')) candidates.add(modelId.slice('chatgpt/'.length));
+  const matches = registry.models.filter((entry) =>
+    candidates.has(entry.id)
+      || entry.routes.some(
+        (route) => route.agents.includes(agent) && candidates.has(route.modelId),
+      ),
+  );
+  const entries = [...new Map(matches.map((entry) => [entry.id, entry])).values()];
+  if (entries.length !== 1) return undefined;
+
+  const entry = entries[0];
+  const perAgent = entry.perAgent?.[agent];
+  const efforts = perAgent?.efforts ?? entry.efforts;
+  if (!efforts) return undefined;
+  const declaredDefaultEffort = perAgent?.defaultEffort ?? entry.defaultEffort;
+  const defaultEffort =
+    declaredDefaultEffort && efforts.includes(declaredDefaultEffort)
+      ? declaredDefaultEffort
+      : efforts.includes(DEFAULT_CUSTOM_EFFORT)
+        ? DEFAULT_CUSTOM_EFFORT
+        : (efforts[efforts.length - 1] ?? null);
+  return { efforts: [...efforts], defaultEffort };
+}
+
 /** 固定 agent 顺序：保证派生出的 provider.agents / routing / models 顺序稳定。 */
 const AGENT_ORDER: readonly AgentKind[] = ['claude-code', 'codex', 'pi'];
 
@@ -49,6 +93,7 @@ function toCatalogModel(
   m: ProviderRuntimeModelConfig,
   providerId: string,
   agent: AgentKind,
+  modelRegistry: ModelRegistry | null | undefined,
 ): CatalogModel {
   // Pi BYOM 不从 runtime / 协议猜模型能力：只有用户逐模型明确确认后才向 catalog 暴露
   // effort。这样 catalog/UI 与稍后写入 models.json 的能力保持同一份契约，旧配置安全关闭。
@@ -58,9 +103,13 @@ function toCatalogModel(
         ? [...(m.reasoningEfforts ?? [])]
         : []
       : (CUSTOM_EFFORTS[agent] ?? []);
-  const defaultEffort = efforts.includes(DEFAULT_CUSTOM_EFFORT)
-    ? DEFAULT_CUSTOM_EFFORT
-    : (efforts[0] ?? null);
+  const registryEfforts = registryEffortMetadata(modelRegistry, m.id, agent);
+  const effectiveEfforts = registryEfforts?.efforts ?? efforts;
+  const defaultEffort =
+    registryEfforts?.defaultEffort ??
+    (effectiveEfforts.includes(DEFAULT_CUSTOM_EFFORT)
+      ? DEFAULT_CUSTOM_EFFORT
+      : (effectiveEfforts[0] ?? null));
   return {
     id: m.id,
     name: m.name,
@@ -71,7 +120,7 @@ function toCatalogModel(
     // 显式配置的窗口打标:编辑表单回转配置时必须与「缺省物化成的默认值」可区分,
     // 哪怕用户显式填的恰好等于当前默认(未来默认升级后显式值要原样保留)。
     ...(m.contextWindow !== undefined ? { contextWindowExplicit: true } : {}),
-    efforts,
+    efforts: effectiveEfforts,
     defaultEffort,
     // 选择器右栏按 group 聚合：同一自定义来源的模型聚成一组（渲染层用 provider 名兜底标签）。
     group: `custom:${providerId}`,
@@ -123,7 +172,14 @@ function toRouting(
  * 按 `runtimes` 里**已配置的 runtime** 生成各 agent 的 routing / models（每 runtime 独立 baseUrl /
  * 模型 / headers）；空 runtimes 产出空 Provider（不出现在任何 agent 列表，无害）。
  */
-export function buildUserProvider(config: CustomProviderConfig): Provider {
+export interface BuildUserProviderOptions {
+  modelRegistry?: ModelRegistry | null;
+}
+
+export function buildUserProvider(
+  config: CustomProviderConfig,
+  options: BuildUserProviderOptions = {},
+): Provider {
   // OAuth 形态路由走 Runner Bearer；none 明确走无鉴权且由 host 剥凭证；缺省保持历史 API key。
   const oauth = config.auth?.method === 'oauth' ? config.auth.oauth : undefined;
   const isOAuth = oauth !== undefined;
@@ -145,7 +201,9 @@ export function buildUserProvider(config: CustomProviderConfig): Provider {
       rt.modelsUrl,
       rt.wireProtocol,
     );
-    models[agent] = rt.models.map((m) => toCatalogModel(m, config.id, agent));
+    models[agent] = rt.models.map((m) =>
+      toCatalogModel(m, config.id, agent, options.modelRegistry),
+    );
   }
   return {
     id: config.id,


### PR DESCRIPTION
## 这次改了什么

### 摘要

自定义/中转 provider 现在会从当前生效的 model registry 继承已登记模型的 reasoning effort 元数据，同时保留用户选择的 provider、模型 ID、Base URL 和路由。修复 `gpt-5.6-sol` 在主窗口与协作 Worker 中缺少 Max/Ultra 的问题，并覆盖 Terra、Luna、GLM 等已登记模型及不同 Agent 的能力差异。

根据 review 补齐了 registry 热更新生命周期：active catalog 保留当前账号的原始自定义 provider 配置，在 base registry 更新时原子重建 custom provider 投影，无需 provider CRUD、切换账号或重启；registry 与 custom provider 仍只产生一次 revision/广播。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #1536；Related #1869、#1872（后两者现象相近但包含不同链路，本 PR 不关闭）
- 本 PR 包含：自定义 provider 的 registry effort 继承、registry 热更新时的原子重投影、对应回归测试
- 明确不包含：XD Gateway 实时模型能力投影、Codex 终端独立入口改造、Pi BYOM 能力推断
- 用户可见变化：registry 已登记的自定义渠道模型会展示并接受该 Agent 实际支持的档位；未登记或歧义模型保持原行为
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 代码；现有模型选择器会消费修正后的 capability 数据。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（Desktop、Mobile、maker-core、model-providers 及协议 workspace 全部通过）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/model-providers run --if-present typecheck
结果：命令通过；该 package 当前没有 typecheck script，按仓库门禁跳过

pnpm --filter desktop exec vitest run src/main/maker-host/__tests__/providerCatalogRealmReload.test.ts src/main/maker-host/__tests__/activeCatalogRevision.test.ts
结果：通过（2 files / 20 tests）

pnpm check:dco
结果：通过（3 commits signed off）
```

### 手工验证

不涉及：未使用真实中转渠道凭证发起请求；路由保持、能力投影和热更新生命周期由单元测试交叉验证。

### 未执行的验证

未做真实中转渠道端到端请求，避免引入个人凭证；无 UI 代码改动，未做 Light/Dark 目检。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 自定义 provider catalog 的模型 effort 元数据，以及 model registry 热更新时的 custom provider 投影
- 回滚 / 降级方式：回滚本 PR 的两个独立 commit；无数据迁移、协议或持久化变更

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需新增文档）
- [x] 已确认测试结果或说明未执行原因