### PR TITLE
fix(desktop,mobile): worktree 勾选记忆只对具备资格的目录生效

### DIFF
--- a/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerCreateAgentVisualContract.test.ts
@@ -335,13 +335,13 @@ describe('NewMakerDraftRoute CREATE AGENT visual contract', () => {
 
   it('keeps the worktree control visible for a detached HEAD checkout', () => {
     // currentBranch=null 是合法的 detached HEAD，不等于“不是 git 仓库”。
-    // 未勾选时仍展示 HEAD；若环境后来失效但记忆为 ON，也必须保留关闭入口。
+    // 未勾选时仍展示 HEAD;确认不合格(2026-08-07 裁决)才隐藏——探测中/失败
+    // (confirmedIneligible === null)且记忆 ON 时仍显示,由发送侧 fail closed。
     expect(worktreeChipsRowSource).toContain(
       "const branchLabel = sourceBranch || branches.current || currentBranch || 'HEAD';",
     );
-    expect(worktreeChipsRowSource).toContain(
-      'const showBranchChip = !advancedHidden && (enabled || !!detect.data?.isGitRepo);',
-    );
+    expect(worktreeChipsRowSource).toContain('confirmedIneligible !== true');
+    expect(worktreeChipsRowSource).toContain('&& (enabled || !!detect.data?.isGitRepo)');
     expect(worktreeChipsRowSource).not.toContain(
       'const showBranchChip = !advancedHidden && !!branchLabel',
     );

--- a/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerProjectPicker.test.ts
@@ -196,9 +196,10 @@ describe('Shared create project picker', () => {
     expect(worktreeChipsSource).toContain(
       'const switchDisabled = disabled || checkboxDisabled || (environmentDisabled && !enabled)',
     );
-    expect(worktreeChipsSource).toContain(
-      'const showBranchChip = !advancedHidden && (enabled || !!detect.data?.isGitRepo)',
-    );
+    // 2026-08-07 裁决:确认不合格(confirmedIneligible === true)时整条控件隐藏、
+    // 发送侧放行普通会话;探测中/失败(null)时已 ON 仍显示并 fail closed。
+    expect(worktreeChipsSource).toContain('confirmedIneligible !== true');
+    expect(worktreeChipsSource).toContain('&& (enabled || !!detect.data?.isGitRepo)');
     const toggleHandler = newMakerDraftRouteSource.slice(
       newMakerDraftRouteSource.indexOf('const handleWtEnabledChange = useCallback('),
       newMakerDraftRouteSource.indexOf('const handleWtSourceBranchChange = useCallback('),
@@ -213,8 +214,12 @@ describe('Shared create project picker', () => {
       'if (isDeviceLinkDraft) setWtEnabled(false);',
     );
     expect(newMakerDraftRouteSource).toContain('wt.enabled && wt.baseRepo');
+    const sendGuardStart = newMakerDraftRouteSource.indexOf(
+      '&& selectedWorktree.confirmedIneligible !== true',
+    );
+    expect(sendGuardStart).toBeGreaterThan(-1);
     const sendGuard = newMakerDraftRouteSource.slice(
-      newMakerDraftRouteSource.indexOf('if (selectedWorkingDir && !isRemoteProjectDraft && selectedWorktree.enabled) {'),
+      sendGuardStart,
       newMakerDraftRouteSource.indexOf('const dataOwnerAtSend = getDataOwnerGeneration();'),
     );
     expect(sendGuard).toContain('worktreeMissingRepo');
@@ -226,9 +231,10 @@ describe('Shared create project picker', () => {
   it('only forwards a worktree-eligible repo root to fail-closed creation gates', () => {
     // linked worktree、非 Git 目录和探测失败都不能把 repoRoot 暴露给发送 / Goal；
     // checkbox 仍保留用户输入，由上层 ON 门明确阻塞，不能静默降级成 base-repo 创建。
-    expect(worktreeChipsSource).toMatch(
-      /const baseRepo =\s*detect\.data\?\.gitInstalled === true[\s\S]*detect\.data\.isGitRepo[\s\S]*!detect\.data\.isInsideWorktree[\s\S]*detect\.data\.repoRoot \?\? null/,
-    );
+    // baseRepo 与 confirmedIneligible 从共享的 gitEligible 派生,保证两处使用同一条件。
+    expect(worktreeChipsSource).toContain('const gitEligible: boolean | null = detect.data');
+    expect(worktreeChipsSource).toContain('detect.data.gitInstalled && detect.data.isGitRepo && !detect.data.isInsideWorktree');
+    expect(worktreeChipsSource).toContain('const baseRepo = gitEligible ? (detect.data!.repoRoot ?? null) : null;');
   });
 
   it('mirrors the repo-scoped source branch through the selected working device', () => {

--- a/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
+++ b/apps/desktop/src/renderer/__tests__/newMakerWorktreeSend.test.ts
@@ -38,7 +38,7 @@ describe('NewMakerDraftRoute worktree send flow', () => {
   it('never silently downgrades an explicit worktree request to a normal session', () => {
     const selected = source.indexOf('const selectedWorktree = { ...wtRef.current };');
     const guard = source.indexOf(
-      'if (selectedWorkingDir && !isRemoteProjectDraft && selectedWorktree.enabled) {',
+      '&& selectedWorktree.confirmedIneligible !== true',
       selected,
     );
     const markInFlight = source.indexOf('markSendInFlight(true);', guard);
@@ -51,6 +51,21 @@ describe('NewMakerDraftRoute worktree send flow', () => {
     expect(guardedSource).toContain('!selectedWorktree.branchPreferenceReady');
     expect(guardedSource).toContain('selectedWorktree.supportsRecoveryKeyDiscard !== true');
     expect(guardedSource).toContain('return false;');
+  });
+
+  it('lets a confirmed-ineligible directory create a plain session while keeping the ON memory', () => {
+    // 2026-08-07 裁决:探测成功且确认不合格(非 git / 无 git / 已在 worktree 内)时,
+    // 勾选记忆不生效——发送 / Goal 门、worktree 副作用分支全部按普通会话放行;
+    // confirmedIneligible === null(探测中 / 失败)必须仍走 fail closed。
+    // Send 门与 Goal 门各有一处放行条件;Goal 的本地 worktree 使用点同样排除。
+    expect(
+      source.match(/&& selectedWorktree\.confirmedIneligible !== true/g)?.length ?? 0,
+    ).toBeGreaterThanOrEqual(3);
+    // device-link 预创建两条路径(Send / Goal)同样不得对确认不合格目录发起 worktree:create。
+    expect(source).toContain('wt.confirmedIneligible !== true');
+    // 确认态来源:WorktreeChipsRow 的探测回包,null 表示未确认。
+    expect(source).toContain('const [wtConfirmedIneligible, setWtConfirmedIneligible]');
+    expect(source).toContain('onConfirmedIneligibleChange={handleWtConfirmedIneligibleChange}');
   });
 
   it('keeps the first message as a session draft when background worktree creation fails', () => {

--- a/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/WorktreeChipsRow.tsx
@@ -8,9 +8,17 @@
  *
  * 状态不变量:**勾选状态只属于用户**——
  *   - 系统/环境因素(切项目、探测结果、播种)永远不改 checkbox;资格不满足只是
- *     在 OFF 时禁用开启；若已 ON 则保留可见的关闭入口,发送仍由上层 fail closed;
+ *     在 OFF 时禁用开启;
  *   - 唯一改动路径 = 用户点击 checkbox 本体,并写入工作端勾选记忆;
  *   - 分支选择始终只修改 worktree 源分支,永远不联动 checkbox。
+ *
+ * 2026-08-07 用户裁决(取代 2026-07-29「已 ON 保留关闭入口 + fail-closed」形态):
+ * 勾选记忆**只对具备 worktree 资格的目录生效**——
+ *   - 探测成功且确认不合格(非 git 仓库 / git 未安装 / 已在 worktree 内)时整条控件
+ *     隐藏,发送侧按普通会话放行;记忆本身保留不动,回到合格目录自动恢复;
+ *   - 探测进行中 / 探测失败(断线、老端通道缺失等)时**不算**确认不合格:已 ON 则
+ *     照旧显示并由上层 fail closed 拦截——一次弱网不能把用户要求的隔离静默降级。
+ * 两种状态的区分经 onConfirmedIneligibleChange 上报(null = 尚未确认)。
  *
  * 分支区语义:始终选择新 worktree 的源分支;checkbox 只决定本次新 session 是否
  * 真正创建 worktree。两者是独立控制,允许用户先选分支、再决定是否隔离。
@@ -69,6 +77,12 @@ export interface WorktreeChipsRowProps {
    * 上层发送侧必须把非 true 视为不具备该能力。
    */
   onRecoveryKeyDiscardSupportChange?: (supported: boolean | null) => void;
+  /**
+   * 探测**成功**且确认目录不具备 worktree 资格(非 git 仓库 / git 未安装 / 已在
+   * worktree 内)时为 true;null = 探测中或探测失败(未确认,上层必须维持 fail
+   * closed)。true 时上层发送门放行普通会话——勾选记忆只对合格目录生效。
+   */
+  onConfirmedIneligibleChange?: (confirmed: boolean | null) => void;
   onSuggestedNameChange?: (name: string) => void;
   worktreeDisabled?: boolean;
   /** Shared creation/environment gate for both halves of the joined control. */
@@ -112,6 +126,7 @@ export function WorktreeChipsRow({
   onSourceBranchChange,
   onBaseRepoChange,
   onRecoveryKeyDiscardSupportChange,
+  onConfirmedIneligibleChange,
   onSuggestedNameChange,
   worktreeDisabled,
   disabled,
@@ -131,32 +146,51 @@ export function WorktreeChipsRow({
     deviceLinkDeviceId,
     deviceLinkReconnectEpoch,
   );
-  const baseRepo =
-    detect.data?.gitInstalled === true &&
-    detect.data.isGitRepo &&
-    !detect.data.isInsideWorktree
-      ? (detect.data.repoRoot ?? null)
-      : null;
+  // 探测成功且三种资格(已装 git / 是 git 仓库 / 未嵌套)同时满足为 true;
+  // detect.data 未到达(探测中/失败)时为 null——与「确认不合格」不同,后者必须
+  // fail closed。baseRepo 与 confirmedIneligible 皆从此派生,保证两处使用同一条件。
+  const gitEligible: boolean | null = detect.data
+    ? detect.data.gitInstalled && detect.data.isGitRepo && !detect.data.isInsideWorktree
+    : null;
+  const baseRepo = gitEligible ? (detect.data!.repoRoot ?? null) : null;
+  const confirmedIneligible: boolean | null = detect.data ? !gitEligible : null;
 
-  // 只有明确具备 worktree 资格的仓库才向发送侧提供 repoRoot；linked worktree、非 Git
-  // 目录或探测失败都传 null。发送 / Goal 的 ON 门会据此 fail closed，不能静默降级。
-  // useDetectCwd 同时按 {cwd, deviceId} 做 render 阶段 fence，切目标时这里先写 null。
+  // 只有明确具备 worktree 资格的仓库才向发送侧提供 repoRoot。发送 / Goal 的 ON 门
+  // 据此 fail closed，不能静默降级。useDetectCwd 同时按 {cwd, deviceId} 做 render
+  // 阶段 fence，切目标时这里先写 null。
   useLayoutEffect(() => {
     onBaseRepoChange?.(baseRepo);
     onRecoveryKeyDiscardSupportChange?.(
       detect.data ? detect.data.supportsRecoveryKeyDiscard === true : null,
     );
-  }, [baseRepo, detect.data, onBaseRepoChange, onRecoveryKeyDiscardSupportChange]);
+    onConfirmedIneligibleChange?.(confirmedIneligible);
+  }, [
+    baseRepo,
+    detect.data,
+    // confirmedIneligible 从 detect.data 纯派生，同一 render 下与 detect.data 同步变化；
+    // 保留仅满足 exhaustive-deps lint，运行时不会独立触发此 effect。
+    confirmedIneligible,
+    onBaseRepoChange,
+    onRecoveryKeyDiscardSupportChange,
+    onConfirmedIneligibleChange,
+  ]);
 
   const cantUseReason = useMemo<string | null>(() => {
     if (detect.loading) return t('newChat.worktree.detecting');
-    if (!detect.data) return null;
+    if (!detect.data) {
+      // 探测失败(非 loading 且无回包):与「确认非 git」不同,这里维持 fail closed,
+      // 控件保留、给出失败原因,不能让一次断线看起来像"目录不合格被隐藏"。
+      // worktreeDisabled 时根本没发起探测(hook 收到 null),不属于失败。
+      return cwd && !worktreeDisabled ? t('newChat.worktree.detectFailed') : null;
+    }
     const d = detect.data;
     if (!d.gitInstalled) return t('newChat.worktree.gitMissing');
     if (!d.isGitRepo) return t('newChat.worktree.notGitRepo');
+    // 2026-08-07 裁决:isInsideWorktree 时 confirmedIneligible=true → 整条控件隐藏,
+    // 此分支的 tooltip 当前不可达,但保留以解耦 cantUseReason 与控件显隐逻辑。
     if (d.isInsideWorktree) return t('newChat.worktree.alreadyInWorktree');
     return null;
-  }, [detect.data, detect.loading, t]);
+  }, [cwd, detect.data, detect.loading, t, worktreeDisabled]);
 
   const environmentDisabled =
     worktreeDisabled || !!cantUseReason || detect.loading || !cwd || baseRepo === null;
@@ -207,7 +241,12 @@ export function WorktreeChipsRow({
   // 分支与 checkbox 独立:未勾时也要回显用户刚选的源分支,否则菜单虽然可点、
   // 选择后却仍显示当前 HEAD,看起来像没有生效。首次未选择时回退当前 checkout。
   const branchLabel = sourceBranch || branches.current || currentBranch || 'HEAD';
-  const showBranchChip = !advancedHidden && (enabled || !!detect.data?.isGitRepo);
+  // 确认不合格(2026-08-07 裁决)→ 整条控件隐藏,勾选记忆保留、发送侧放行普通会话;
+  // 探测中/失败(confirmedIneligible === null)时已 ON 仍显示,由上层 fail closed。
+  const showBranchChip =
+    !advancedHidden
+    && confirmedIneligible !== true
+    && (enabled || !!detect.data?.isGitRepo);
   // 分支选择与 checkbox 是两条独立轴；仅环境不具备 worktree 资格或创建在途时禁用。
   const branchInteractive =
     !(disabled || branchDisabled || environmentDisabled) && baseRepo !== null;

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -2977,10 +2977,15 @@ export function NewMakerDraftRoute() {
       // Checkbox APPLY 是双向门：无论 ON→OFF 还是 OFF→ON，创建都必须等
       // 工作端确认，否则会把旧状态误当成这次用户意图。分支 APPLY 则只在
       // Worktree ON 时阻塞；OFF 仍可直接创建普通 session，保持两条轴独立。
+      // 确认不合格(2026-08-07 裁决)时控件隐藏、勾选不生效，偏好写入在途不应
+      // 卡住普通会话创建——确认不合格目录永远不会创建 worktree。
       if (
-        wtPreferenceSavingRef.current
-        || wtPreferenceAuthorityUnknownRef.current
-        || (selectedWorktree.enabled && wtBranchPreferenceSavingRef.current)
+        selectedWorktree.confirmedIneligible !== true
+        && (
+          wtPreferenceSavingRef.current
+          || wtPreferenceAuthorityUnknownRef.current
+          || (selectedWorktree.enabled && wtBranchPreferenceSavingRef.current)
+        )
       ) {
         toast.warning(t('ccAgent.draft.deviceStillLoading'));
         return false;
@@ -3760,10 +3765,14 @@ export function NewMakerDraftRoute() {
         // while an in-flight branch write only blocks a Worktree-enabled
         // project.  OFF remains an ordinary base-repo create even if the
         // independent branch preference transaction is still settling.
+        // 确认不合格(2026-08-07 裁决)时跳过偏好写入守卫,与 Send 同口径。
         if (
-          wtPreferenceSavingRef.current
-          || wtPreferenceAuthorityUnknownRef.current
-          || (selectedWorktree.enabled && wtBranchPreferenceSavingRef.current)
+          selectedWorktree.confirmedIneligible !== true
+          && (
+            wtPreferenceSavingRef.current
+            || wtPreferenceAuthorityUnknownRef.current
+            || (selectedWorktree.enabled && wtBranchPreferenceSavingRef.current)
+          )
         ) {
           throw new Error(t('ccAgent.draft.deviceStillLoading'));
         }

--- a/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx
@@ -676,6 +676,10 @@ export function NewMakerDraftRoute() {
   const [wtSupportsRecoveryKeyDiscard, setWtSupportsRecoveryKeyDiscard] = useState<boolean | null>(
     null,
   );
+  // 探测成功且确认目录不具备 worktree 资格(非 git / 无 git / 已在 worktree 内)= true:
+  // 发送门放行普通会话(2026-08-07 裁决,勾选记忆只对合格目录生效)。null = 探测中或
+  // 失败,维持 fail closed——「确认不是 git」和「探测不出来」不是一回事。
+  const [wtConfirmedIneligible, setWtConfirmedIneligible] = useState<boolean | null>(null);
   // repo-scoped 分支偏好以工作端 main 为权威。target ref 在换设备 / repo 的同步动作里先行
   // 改写，挡住 React commit 前一瞬间到达的旧 GET / APPLY / push；seq 另挡异步 GET 晚到。
   const wtBranchTargetRef = useRef<DraftWorktreeBranchTarget>({
@@ -2032,6 +2036,7 @@ export function NewMakerDraftRoute() {
         setWtBaseRepo(null);
         setWtSourceBranch('');
         setWtSupportsRecoveryKeyDiscard(null);
+        setWtConfirmedIneligible(null);
       }
       if (deviceChanged) {
         // A checkbox write belongs to the previous work device. Invalidate its
@@ -2816,6 +2821,9 @@ export function NewMakerDraftRoute() {
   const handleWtRecoveryKeyDiscardSupportChange = useCallback((supported: boolean | null) => {
     setWtSupportsRecoveryKeyDiscard(supported);
   }, []);
+  const handleWtConfirmedIneligibleChange = useCallback((confirmed: boolean | null) => {
+    setWtConfirmedIneligible(confirmed);
+  }, []);
   const handleWtNameChange = useCallback((name: string) => {
     setWtName(name);
   }, []);
@@ -2837,6 +2845,7 @@ export function NewMakerDraftRoute() {
     sourceBranch: wtSourceBranch,
     baseRepo: wtBaseRepo,
     supportsRecoveryKeyDiscard: wtSupportsRecoveryKeyDiscard,
+    confirmedIneligible: wtConfirmedIneligible,
     branchPreferenceReady: wtBranchPreferenceReady,
     branchPreferenceSaving: wtBranchPreferenceSaving,
     preferenceSaving: wtPreferenceSaving,
@@ -2847,6 +2856,7 @@ export function NewMakerDraftRoute() {
     sourceBranch: wtSourceBranch,
     baseRepo: wtBaseRepo,
     supportsRecoveryKeyDiscard: wtSupportsRecoveryKeyDiscard,
+    confirmedIneligible: wtConfirmedIneligible,
     branchPreferenceReady: wtBranchPreferenceReady,
     branchPreferenceSaving: wtBranchPreferenceSaving,
     preferenceSaving: wtPreferenceSaving,
@@ -2975,7 +2985,15 @@ export function NewMakerDraftRoute() {
         toast.warning(t('ccAgent.draft.deviceStillLoading'));
         return false;
       }
-      if (selectedWorkingDir && !isRemoteProjectDraft && selectedWorktree.enabled) {
+      // 确认不合格(探测成功、目录无 worktree 资格)时勾选记忆不生效:整段 ON 门跳过,
+      // 按普通会话创建(2026-08-07 裁决)。confirmedIneligible === null(探测中/失败)
+      // 仍走 fail-closed —— 探测不出来不等于确认不是 git。
+      if (
+        selectedWorkingDir
+        && !isRemoteProjectDraft
+        && selectedWorktree.enabled
+        && selectedWorktree.confirmedIneligible !== true
+      ) {
         if (!selectedWorktree.baseRepo) {
           toast.error(t('ccAgent.draft.worktreeMissingRepo'));
           return false;
@@ -3052,6 +3070,7 @@ export function NewMakerDraftRoute() {
             if (
               effectiveWorkingDir &&
               wt.enabled &&
+              wt.confirmedIneligible !== true &&
               wt.baseRepo &&
               wt.supportsRecoveryKeyDiscard === true
             ) {
@@ -3748,7 +3767,14 @@ export function NewMakerDraftRoute() {
         ) {
           throw new Error(t('ccAgent.draft.deviceStillLoading'));
         }
-        if (selectedWorkingDir && !isRemoteProjectDraft && selectedWorktree.enabled) {
+        // 与 handleSend 同口径:确认不合格时勾选记忆不生效,整段 ON 门跳过、按普通
+        // 会话创建;null(探测中/失败)仍 fail closed(2026-08-07 裁决)。
+        if (
+          selectedWorkingDir
+          && !isRemoteProjectDraft
+          && selectedWorktree.enabled
+          && selectedWorktree.confirmedIneligible !== true
+        ) {
           if (!selectedWorktree.baseRepo) {
             throw new Error(t('ccAgent.draft.worktreeMissingRepo'));
           }
@@ -3837,6 +3863,7 @@ export function NewMakerDraftRoute() {
           if (
             selectedWorkingDir
             && selectedWorktree.enabled
+            && selectedWorktree.confirmedIneligible !== true
             && selectedWorktree.baseRepo
             && selectedWorktree.supportsRecoveryKeyDiscard === true
           ) {
@@ -4079,8 +4106,13 @@ export function NewMakerDraftRoute() {
           navigate(`/cc-agent/${remoteSessionId}`, { replace: true });
           return;
         }
+        // 确认不合格时按普通会话走(上方 ON 门已放行,这里必须一起排除,否则
+        // baseRepo 为 null 会命中下方的非空断言)。
         const useLocalGoalWorktree = Boolean(
-          selectedWorkingDir && !isRemoteProjectDraft && selectedWorktree.enabled,
+          selectedWorkingDir
+          && !isRemoteProjectDraft
+          && selectedWorktree.enabled
+          && selectedWorktree.confirmedIneligible !== true,
         );
         const goalSessionId = makeDraftSessionId();
         let goalWorkingDir = selectedWorkingDir;
@@ -4486,6 +4518,7 @@ export function NewMakerDraftRoute() {
                   onSourceBranchChange={handleWtSourceBranchChange}
                   onBaseRepoChange={handleWtBaseRepoChange}
                   onRecoveryKeyDiscardSupportChange={handleWtRecoveryKeyDiscardSupportChange}
+                  onConfirmedIneligibleChange={handleWtConfirmedIneligibleChange}
                   onSuggestedNameChange={handleWtNameChange}
                   // SSH 远程仍禁用 worktree(远端 git 探测未落地);device-link 远程可用:
                   // 探测/建议名/创建全部经隧道在被控端执行(与 488cb33 前口径一致)。

--- a/apps/desktop/src/renderer/hooks/__tests__/useWorktreeQueries.test.ts
+++ b/apps/desktop/src/renderer/hooks/__tests__/useWorktreeQueries.test.ts
@@ -23,7 +23,7 @@ const REPO_A = {
 
 describe('detectCwdStateForTarget', () => {
   const snapshot: DetectCwdSnapshot = {
-    target: { cwd: '/repo-a', deviceLinkDeviceId: 'device-a' },
+    target: { cwd: '/repo-a', deviceLinkDeviceId: 'device-a', refreshEpoch: 0 },
     data: REPO_A,
     loading: false,
   };
@@ -33,6 +33,7 @@ describe('detectCwdStateForTarget', () => {
       detectCwdStateForTarget(snapshot, {
         cwd: '/repo-a',
         deviceLinkDeviceId: 'device-a',
+        refreshEpoch: 0,
       }),
     ).toEqual({ data: REPO_A, loading: false });
   });
@@ -51,6 +52,17 @@ describe('detectCwdStateForTarget', () => {
       detectCwdStateForTarget(snapshot, {
         cwd: '/repo-a',
         deviceLinkDeviceId: 'device-b',
+        refreshEpoch: 0,
+      }),
+    ).toEqual({ data: null, loading: true });
+  });
+
+  it('synchronously fences stale data when the reconnect epoch changes', () => {
+    expect(
+      detectCwdStateForTarget(snapshot, {
+        cwd: '/repo-a',
+        deviceLinkDeviceId: 'device-a',
+        refreshEpoch: 1,
       }),
     ).toEqual({ data: null, loading: true });
   });
@@ -80,6 +92,7 @@ describe('useDetectCwd', () => {
     expect(invoke).toHaveBeenCalledTimes(1);
 
     rerender({ reconnectEpoch: 1 });
+    expect(result.current).toEqual({ data: null, loading: true });
 
     await waitFor(() => {
       expect(result.current).toEqual({ data: REPO_A, loading: false });

--- a/apps/desktop/src/renderer/hooks/useWorktreeQueries.ts
+++ b/apps/desktop/src/renderer/hooks/useWorktreeQueries.ts
@@ -63,6 +63,8 @@ export interface DetectCwdState {
 export interface DetectCwdTarget {
   cwd: string;
   deviceLinkDeviceId: string | null;
+  /** 同设备/目录的重探代次；变化时旧结果也必须同步失效。 */
+  refreshEpoch?: number;
 }
 
 export interface DetectCwdSnapshot extends DetectCwdState {
@@ -70,8 +72,8 @@ export interface DetectCwdSnapshot extends DetectCwdState {
 }
 
 /**
- * 只向当前设备/目录暴露同 target 的探测结果。effect 要到 commit 后才会重置 state；
- * render 阶段先做同步 fence，切项目或设备后的首帧不会复用上一仓库的 repoRoot。
+ * 只向当前设备/目录/重探代次暴露同 target 的探测结果。effect 要到 commit 后才会重置
+ * state；render 阶段先做同步 fence，切项目、设备或同目标重连后的首帧不会复用旧结果。
  */
 export function detectCwdStateForTarget(
   snapshot: DetectCwdSnapshot,
@@ -82,6 +84,7 @@ export function detectCwdStateForTarget(
     !snapshot.target
     || snapshot.target.cwd !== target.cwd
     || snapshot.target.deviceLinkDeviceId !== target.deviceLinkDeviceId
+    || snapshot.target.refreshEpoch !== target.refreshEpoch
   ) {
     return { data: null, loading: true };
   }
@@ -107,7 +110,7 @@ export function useDetectCwd(
     loading: false,
   });
   const target: DetectCwdTarget | null = cwd
-    ? { cwd, deviceLinkDeviceId: deviceLinkDeviceId ?? null }
+    ? { cwd, deviceLinkDeviceId: deviceLinkDeviceId ?? null, refreshEpoch }
     : null;
 
   useEffect(() => {
@@ -118,6 +121,7 @@ export function useDetectCwd(
     const requestTarget: DetectCwdTarget = {
       cwd,
       deviceLinkDeviceId: deviceLinkDeviceId ?? null,
+      refreshEpoch,
     };
     let cancelled = false;
     setSnapshot({ target: requestTarget, data: null, loading: true });

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5552,6 +5552,7 @@
     },
     "worktree": {
       "detecting": "Detecting environment…",
+      "detectFailed": "Environment detection failed; worktree unavailable for now",
       "gitMissing": "git not detected, please install it first",
       "notGitRepo": "Current directory is not a git repository",
       "alreadyInWorktree": "Already inside a worktree, nesting is not allowed",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5550,6 +5550,7 @@
     },
     "worktree": {
       "detecting": "環境を検出中…",
+      "detectFailed": "環境の検出に失敗しました。worktree は現在使用できません",
       "gitMissing": "git が検出されません。先にインストールしてください",
       "notGitRepo": "現在のディレクトリは git リポジトリではありません",
       "alreadyInWorktree": "すでに worktree 内です。ネストは禁止です",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5550,6 +5550,7 @@
     },
     "worktree": {
       "detecting": "환경 감지 중…",
+      "detectFailed": "환경 감지에 실패하여 worktree를 당분간 사용할 수 없습니다",
       "gitMissing": "git이 감지되지 않습니다. 먼저 설치하세요",
       "notGitRepo": "현재 디렉터리는 git 리포지토리가 아닙니다",
       "alreadyInWorktree": "이미 worktree 안에 있어 중첩이 금지됩니다",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5550,6 +5550,7 @@
     },
     "worktree": {
       "detecting": "检测环境中…",
+      "detectFailed": "环境检测失败，worktree 暂不可用",
       "gitMissing": "未检测到 git，请先安装",
       "notGitRepo": "当前目录不是 git 仓库",
       "alreadyInWorktree": "已在 worktree 中，禁止嵌套",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -5553,6 +5553,7 @@
     },
     "worktree": {
       "detecting": "檢測環境中…",
+      "detectFailed": "環境檢測失敗，worktree 暫不可用",
       "gitMissing": "未檢測到 git，請先安裝",
       "notGitRepo": "當前目錄不是 git 倉庫",
       "alreadyInWorktree": "已在 worktree 中，禁止巢狀",

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1336,10 +1336,18 @@ export default function NewRemoteSessionScreen() {
       && intent.eligibility.status !== 'ineligible'
     ) return false;
     const currentEligibility = worktreeEligibilityRef.current;
-    if (
-      currentEligibility.status !== 'eligible'
-      || currentEligibility.baseRepo !== intent.eligibility.baseRepo
-    ) return false;
+    // eligible 与 ineligible 对 current 的要求不同:eligible 需要 repo
+    // 与 baseRepo 完全匹配;ineligible 只需状态仍为 ineligible(无需
+    // baseRepo,也不可能走到下方的分支/偏好校验)。
+    if (intent.eligibility.status === 'eligible') {
+      if (
+        currentEligibility.status !== 'eligible'
+        || currentEligibility.baseRepo !== intent.eligibility.baseRepo
+      ) return false;
+    } else if (intent.eligibility.status === 'ineligible') {
+      if (currentEligibility.status !== 'ineligible') return false;
+    }
+    if (intent.eligibility.status !== 'eligible') return true;
     const currentStoredBranch = remoteSessionStore.getNewMakerWorktreeBranchPreference(
       intent.target.deviceId,
       currentEligibility.baseRepo,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1143,12 +1143,16 @@ export default function NewRemoteSessionScreen() {
     && worktreePreferenceAuthorityUnknownByDeviceRef.current.has(selectedDeviceId);
   const worktreeApplicable = draft.workspaceKind === 'project'
     && draft.workingDir.trim().length > 0;
+  // ineligible(2026-08-07 裁决):确认目录不合格时无需等偏好就绪——反正不会
+  // 创建 worktree,GET 在途不应卡住普通会话创建。
   const worktreePreferenceCreateBlocked = worktreeApplicable
-    && selectedDeviceId != null && (
-    worktreePreferenceSaving
-    || worktreePreferenceAuthorityUnknown
-    || !worktreePreferenceReady
-  );
+    && selectedDeviceId != null
+    && worktreeEligibility.status !== 'ineligible'
+    && (
+      worktreePreferenceSaving
+      || worktreePreferenceAuthorityUnknown
+      || !worktreePreferenceReady
+    );
   // host preference 虽然持久化，连接代次仍属于权威读取 identity：桌面重启/重连后
   // 即使 deviceId/repo 没变，也重新 GET，不能只相信手机内存里的旧快照。
   const worktreeBranchPreferenceSyncKey = worktreeBranchPreferenceKey

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1331,7 +1331,10 @@ export default function NewRemoteSessionScreen() {
       .getNewMakerWorktreePreference(intent.target.deviceId).enabled;
     if (currentEnabled !== intent.enabled) return false;
     if (!intent.enabled) return true;
-    if (intent.eligibility.status !== 'eligible') return false;
+    if (
+      intent.eligibility.status !== 'eligible'
+      && intent.eligibility.status !== 'ineligible'
+    ) return false;
     const currentEligibility = worktreeEligibilityRef.current;
     if (
       currentEligibility.status !== 'eligible'

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1325,6 +1325,9 @@ export default function NewRemoteSessionScreen() {
       || currentTarget.deviceId !== intent.target.deviceId
       || currentTarget.workingDir.trim() !== intent.target.workingDir.trim()
     ) return false;
+    // ineligible 目标不创建 worktree,无需等偏好同步/就绪——提前返回,
+    // 避免偏好 GET 在途时被下方偏好守卫拦截(2026-08-07 裁决)。
+    if (intent.enabled && intent.eligibility.status === 'ineligible') return true;
     if (
       worktreePreferenceSyncKeyRef.current !== intent.preferenceSyncKey
       || worktreePreferenceReadyKeyRef.current !== intent.preferenceSyncKey
@@ -1335,23 +1338,9 @@ export default function NewRemoteSessionScreen() {
       .getNewMakerWorktreePreference(intent.target.deviceId).enabled;
     if (currentEnabled !== intent.enabled) return false;
     if (!intent.enabled) return true;
-    if (
-      intent.eligibility.status !== 'eligible'
-      && intent.eligibility.status !== 'ineligible'
-    ) return false;
+    // ineligible 已在前面提前返回,此处只可能是 eligible(2026-08-07 裁决)。
+    if (intent.eligibility.status !== 'eligible') return false;
     const currentEligibility = worktreeEligibilityRef.current;
-    // eligible 与 ineligible 对 current 的要求不同:eligible 需要 repo
-    // 与 baseRepo 完全匹配;ineligible 只需状态仍为 ineligible(无需
-    // baseRepo,也不可能走到下方的分支/偏好校验)。
-    if (intent.eligibility.status === 'eligible') {
-      if (
-        currentEligibility.status !== 'eligible'
-        || currentEligibility.baseRepo !== intent.eligibility.baseRepo
-      ) return false;
-    } else if (intent.eligibility.status === 'ineligible') {
-      if (currentEligibility.status !== 'ineligible') return false;
-    }
-    if (intent.eligibility.status !== 'eligible') return true;
     const currentStoredBranch = remoteSessionStore.getNewMakerWorktreeBranchPreference(
       intent.target.deviceId,
       currentEligibility.baseRepo,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1077,11 +1077,12 @@ export default function NewRemoteSessionScreen() {
   );
   const WorkspaceIcon = draft.workspaceKind === 'dialogue' ? MessageCircle : Folder;
   const agentLabel = mobileAgentLabel(draft.agentKind);
-  // effect 在 commit 后才会把旧探测结果重置为 probing；render 期先按设备 + cwd 同步
-  // 对齐 target，切项目/设备后立即创建也拿不到上一仓库的 baseRepo/sourceBranch。
+  // effect 在 commit 后才会把旧探测结果重置为 probing；render 期先按设备 + cwd +
+  // 连接代次同步对齐 target，切项目/设备或同目标重连后立即创建也拿不到旧结果。
   const worktreeTarget = {
     deviceId: selectedDeviceId ?? '',
     workingDir: draft.workspaceKind === 'project' ? draft.workingDir.trim() : '',
+    probeGeneration: `${connectionEpoch}\u0000${presenceVersion}`,
   };
   worktreeBranchTargetRef.current = worktreeTarget;
   const worktreeEligibility = worktreeEligibilityForTarget(worktreeProbe, worktreeTarget);
@@ -2175,7 +2176,11 @@ export default function NewRemoteSessionScreen() {
   useEffect(() => {
     const cwd = draft.workspaceKind === 'project' ? draft.workingDir.trim() : '';
     const seq = ++worktreeDetectSeqRef.current;
-    const target = { deviceId: selectedDeviceId ?? '', workingDir: cwd };
+    const target = {
+      deviceId: selectedDeviceId ?? '',
+      workingDir: cwd,
+      probeGeneration: `${connectionEpoch}\u0000${presenceVersion}`,
+    };
     let cancelled = false;
     let retryTimer: ReturnType<typeof setTimeout> | null = null;
     const probingEligibility: NewSessionWorktreeEligibility = { status: 'probing' };

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1326,8 +1326,8 @@ export default function NewRemoteSessionScreen() {
       || currentTarget.workingDir.trim() !== intent.target.workingDir.trim()
     ) return false;
     // ineligible 目标不创建 worktree,无需等偏好同步/就绪——提前返回,
-    // 避免偏好 GET 在途时被下方偏好守卫拦截(2026-08-07 裁决)。
-    if (intent.enabled && intent.eligibility.status === 'ineligible') return true;
+    // 避免偏好 GET 在途时被下方偏好守卫拦截;与 enabled 无关(2026-08-07 裁决)。
+    if (intent.eligibility.status === 'ineligible') return true;
     if (
       worktreePreferenceSyncKeyRef.current !== intent.preferenceSyncKey
       || worktreePreferenceReadyKeyRef.current !== intent.preferenceSyncKey

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1345,7 +1345,13 @@ export default function NewRemoteSessionScreen() {
     if (!intent.enabled) return true;
     // ineligible 已在前面提前返回,此处只可能是 eligible(2026-08-07 裁决)。
     if (intent.eligibility.status !== 'eligible') return false;
+    // 与 ineligible 快照同理:eligible 快照也必须复核 live 资格仍是同一 repo 的
+    // eligible,await 期间被重探成别的状态或换了 repo 都不能继续建 worktree。
     const currentEligibility = worktreeEligibilityRef.current;
+    if (
+      currentEligibility.status !== 'eligible'
+      || currentEligibility.baseRepo !== intent.eligibility.baseRepo
+    ) return false;
     const currentStoredBranch = remoteSessionStore.getNewMakerWorktreeBranchPreference(
       intent.target.deviceId,
       currentEligibility.baseRepo,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -3821,6 +3821,7 @@ export default function NewRemoteSessionScreen() {
     }
     if (
       worktreeApplicable
+      && worktreeEligibility.status !== 'ineligible'
       && (
         worktreePreferenceWriteTargetRef.current === selectedDeviceId
         || worktreePreferenceAuthorityUnknownByDeviceRef.current.has(selectedDeviceId)
@@ -4387,6 +4388,7 @@ export default function NewRemoteSessionScreen() {
     }
     if (
       worktreeApplicable
+      && worktreeEligibility.status !== 'ineligible'
       && (
         worktreePreferenceWriteTargetRef.current === selectedDeviceId
         || worktreePreferenceAuthorityUnknownByDeviceRef.current.has(selectedDeviceId)

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -1327,7 +1327,12 @@ export default function NewRemoteSessionScreen() {
     ) return false;
     // ineligible 目标不创建 worktree,无需等偏好同步/就绪——提前返回,
     // 避免偏好 GET 在途时被下方偏好守卫拦截;与 enabled 无关(2026-08-07 裁决)。
-    if (intent.eligibility.status === 'ineligible') return true;
+    // 但快照不能替代实时状态:await 期间同目标可能被重探回 probing/eligible/
+    // detect-failed,旧 ineligible 快照必须复核 live ref 仍为 ineligible 才放行,
+    // 否则回到 fail closed(探测未定不等于确认不合格)。
+    if (intent.eligibility.status === 'ineligible') {
+      return worktreeEligibilityRef.current.status === 'ineligible';
+    }
     if (
       worktreePreferenceSyncKeyRef.current !== intent.preferenceSyncKey
       || worktreePreferenceReadyKeyRef.current !== intent.preferenceSyncKey

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1827,7 +1827,8 @@ describe('new session worktree wiring (source locks)', () => {
       'applicable: worktreeApplicable,',
     );
     const createEntry = newSource.indexOf('const create = useCallback(async () => {');
-    const createBody = newSource.slice(createEntry, createEntry + 1_800);
+    // ineligible 豁免守卫使 create 函数体略长,窗口扩至 1600 确保覆盖 worktreeCreateBlocked。
+    const createBody = newSource.slice(createEntry, createEntry + 1_600);
     expect(createBody).not.toContain('|| worktreePreferenceSaving');
     expect(createBody).toContain('if (worktreeCreateBlocked) {');
     expect(newSource).toContain('worktreeBranchPreferenceSaving');

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1942,6 +1942,7 @@ describe('new session worktree wiring (source locks)', () => {
     expect(newSource).toContain('const worktreeTarget = {');
     expect(newSource).toContain('deviceId: selectedDeviceId ??');
     expect(newSource).toContain('worktreeEligibilityForTarget(worktreeProbe, worktreeTarget)');
+    expect(newSource).toContain('probeGeneration: `${connectionEpoch}\\u0000${presenceVersion}`');
     expect(newSource).toContain('worktreeSourceBranchFromPreference(');
     expect(newSource).toContain('shouldAcceptWorktreeBranchListResult({');
     expect(newSource).toContain('sourceBranch: worktreeIntent.sourceBranch,');

--- a/apps/mobile/src/__tests__/newSessionWorktree.test.ts
+++ b/apps/mobile/src/__tests__/newSessionWorktree.test.ts
@@ -532,13 +532,14 @@ describe('shouldBlockNewSessionCreateForWorktree', () => {
         preferenceSaving: false,
       })).toBe(false);
     }
-    // 偏好写入在途仍拦截,与资格无关。
+    // 偏好写入在途也不应拦截 ineligible——确认不合格目录不创建 worktree,
+    // preference 写入在途不该卡住普通会话创建。
     expect(shouldBlockNewSessionCreateForWorktree({
       applicable: true,
       enabled: true,
       eligibility: { status: 'ineligible', reason: 'notGitRepo' },
       preferenceSaving: true,
-    })).toBe(true);
+    })).toBe(false);
   });
 });
 

--- a/apps/mobile/src/__tests__/newSessionWorktree.test.ts
+++ b/apps/mobile/src/__tests__/newSessionWorktree.test.ts
@@ -94,7 +94,7 @@ describe('resolveWorktreeEligibility', () => {
 
 describe('worktreeEligibilityForTarget', () => {
   const snapshot = {
-    target: { deviceId: 'dev-a', workingDir: '/repo/a' },
+    target: { deviceId: 'dev-a', workingDir: '/repo/a', probeGeneration: '1\u00002' },
     eligibility: {
       status: 'eligible' as const,
       baseRepo: '/repo/a',
@@ -102,10 +102,11 @@ describe('worktreeEligibilityForTarget', () => {
     },
   };
 
-  it('只向同设备 + 同 cwd 暴露探测结果', () => {
+  it('只向同设备 + 同 cwd + 同探测代次暴露探测结果', () => {
     expect(worktreeEligibilityForTarget(snapshot, {
       deviceId: 'dev-a',
       workingDir: ' /repo/a ',
+      probeGeneration: '1\u00002',
     })).toEqual(snapshot.eligibility);
   });
 
@@ -113,10 +114,25 @@ describe('worktreeEligibilityForTarget', () => {
     expect(worktreeEligibilityForTarget(snapshot, {
       deviceId: 'dev-a',
       workingDir: '/repo/b',
+      probeGeneration: '1\u00002',
     })).toEqual({ status: 'probing' });
     expect(worktreeEligibilityForTarget(snapshot, {
       deviceId: 'dev-b',
       workingDir: '/repo/a',
+      probeGeneration: '1\u00002',
+    })).toEqual({ status: 'probing' });
+  });
+
+  it('同设备和目录重连重探时首帧同步回落 probing', () => {
+    expect(worktreeEligibilityForTarget(snapshot, {
+      deviceId: 'dev-a',
+      workingDir: '/repo/a',
+      probeGeneration: '2\u00002',
+    })).toEqual({ status: 'probing' });
+    expect(worktreeEligibilityForTarget(snapshot, {
+      deviceId: 'dev-a',
+      workingDir: '/repo/a',
+      probeGeneration: '1\u00003',
     })).toEqual({ status: 'probing' });
   });
 });

--- a/apps/mobile/src/__tests__/newSessionWorktree.test.ts
+++ b/apps/mobile/src/__tests__/newSessionWorktree.test.ts
@@ -440,6 +440,30 @@ describe('shouldShowWorktreeToggle / caption key', () => {
     expect(shouldShowWorktreeToggle({ workspaceKind: 'project', workingDir: '/repo', eligibility: { status: 'probing' }, enabled: false })).toBe(true);
   });
 
+  it('确认不合格(ineligible)时开关行隐藏,即使记忆为 ON(2026-08-07 裁决)', () => {
+    for (const reason of ['gitMissing', 'notGitRepo', 'alreadyInWorktree'] as const) {
+      expect(shouldShowWorktreeToggle({
+        workspaceKind: 'project',
+        workingDir: '/repo',
+        eligibility: { status: 'ineligible', reason },
+        enabled: true,
+      })).toBe(false);
+      expect(shouldShowWorktreeToggle({
+        workspaceKind: 'project',
+        workingDir: '/repo',
+        eligibility: { status: 'ineligible', reason },
+        enabled: false,
+      })).toBe(false);
+    }
+    // 探测失败 ≠ 确认不合格:已 ON 时保持显示(fail closed 需要可见入口)。
+    expect(shouldShowWorktreeToggle({
+      workspaceKind: 'project',
+      workingDir: '/repo',
+      eligibility: { status: 'detect-failed' },
+      enabled: true,
+    })).toBe(true);
+  });
+
   it('caption key 覆盖探测中 / 三种不合格原因 / 探测失败;eligible 无 caption', () => {
     expect(worktreeEligibilityCaptionKey({ status: 'probing' })).toBe('session.new.worktreeDetecting');
     expect(worktreeEligibilityCaptionKey({ status: 'recovering' })).toBe('session.new.worktreeRecovering');
@@ -481,15 +505,12 @@ describe('shouldBlockNewSessionCreateForWorktree', () => {
     })).toBe(false);
   });
 
-  it('ON 时必须等当前目标 eligible，unsupported 也不能把显式选择静默降级成普通创建', () => {
+  it('ON 时探测未定必须拦截，unsupported 也不能把显式选择静默降级成普通创建', () => {
     expect(shouldBlockNewSessionCreateForWorktree({
       applicable: true, enabled: true, eligibility: { status: 'probing' }, preferenceSaving: false,
     })).toBe(true);
     expect(shouldBlockNewSessionCreateForWorktree({
-      applicable: true,
-      enabled: true,
-      eligibility: { status: 'ineligible', reason: 'notGitRepo' },
-      preferenceSaving: false,
+      applicable: true, enabled: true, eligibility: { status: 'detect-failed' }, preferenceSaving: false,
     })).toBe(true);
     expect(shouldBlockNewSessionCreateForWorktree({
       applicable: true, enabled: true, eligibility: eligible, preferenceSaving: false,
@@ -499,6 +520,24 @@ describe('shouldBlockNewSessionCreateForWorktree', () => {
     })).toBe(false);
     expect(shouldBlockNewSessionCreateForWorktree({
       applicable: true, enabled: true, eligibility: { status: 'unsupported' }, preferenceSaving: false,
+    })).toBe(true);
+  });
+
+  it('确认不合格(ineligible)+ ON 放行普通会话——记忆只对合格目录生效(2026-08-07 裁决)', () => {
+    for (const reason of ['gitMissing', 'notGitRepo', 'alreadyInWorktree'] as const) {
+      expect(shouldBlockNewSessionCreateForWorktree({
+        applicable: true,
+        enabled: true,
+        eligibility: { status: 'ineligible', reason },
+        preferenceSaving: false,
+      })).toBe(false);
+    }
+    // 偏好写入在途仍拦截,与资格无关。
+    expect(shouldBlockNewSessionCreateForWorktree({
+      applicable: true,
+      enabled: true,
+      eligibility: { status: 'ineligible', reason: 'notGitRepo' },
+      preferenceSaving: true,
     })).toBe(true);
   });
 });

--- a/apps/mobile/src/session/newSessionWorktree.ts
+++ b/apps/mobile/src/session/newSessionWorktree.ts
@@ -40,9 +40,14 @@ export type NewSessionWorktreeEligibility =
   | { status: 'unsupported' }
   | { status: 'detect-failed' };
 
-export interface NewSessionWorktreeProbeTarget {
+export interface NewSessionWorktreeBranchTarget {
   deviceId: string;
   workingDir: string;
+}
+
+export interface NewSessionWorktreeProbeTarget extends NewSessionWorktreeBranchTarget {
+  /** 设备连接/在线存在变化时递增；同目录旧探测结果不能跨 generation 复用。 */
+  probeGeneration: string;
 }
 
 /** 探测结果与发起时的设备/目录绑定，防切换目标后的首帧误用上一仓库结果。 */
@@ -55,7 +60,7 @@ export interface NewSessionWorktreeProbeSnapshot {
 
 /** 用户显式选择的源分支只属于发起选择时的设备 + 工作目录，不得跨目标复用。 */
 export interface NewSessionWorktreeBranchSelectionSnapshot {
-  target: NewSessionWorktreeProbeTarget;
+  target: NewSessionWorktreeBranchTarget;
   sourceBranch: string;
 }
 
@@ -63,8 +68,8 @@ export interface NewSessionWorktreeBranchSelectionSnapshot {
 export function shouldAcceptWorktreeBranchListResult(input: {
   requestSeq: number;
   latestSeq: number;
-  requestTarget: NewSessionWorktreeProbeTarget;
-  latestTarget: NewSessionWorktreeProbeTarget;
+  requestTarget: NewSessionWorktreeBranchTarget;
+  latestTarget: NewSessionWorktreeBranchTarget;
 }): boolean {
   return input.requestSeq === input.latestSeq
     && input.requestTarget.deviceId === input.latestTarget.deviceId
@@ -72,8 +77,9 @@ export function shouldAcceptWorktreeBranchListResult(input: {
 }
 
 /**
- * 只向当前选择暴露同 target 的结果。React effect 要到 commit 后才会把 state 重置为
- * probing；render 阶段先做这道同步 fence，用户切项目/设备后立即创建也不会拿旧 baseRepo。
+ * 只向当前选择与连接代次暴露同 target 的结果。React effect 要到 commit 后才会把 state
+ * 重置为 probing；render 阶段先做这道同步 fence，用户切项目/设备或同目标重连后立即创建
+ * 也不会拿旧资格。
  */
 export function worktreeEligibilityForTarget(
   snapshot: NewSessionWorktreeProbeSnapshot | null,
@@ -83,6 +89,7 @@ export function worktreeEligibilityForTarget(
     !snapshot
     || snapshot.target.deviceId !== target.deviceId
     || snapshot.target.workingDir.trim() !== target.workingDir.trim()
+    || snapshot.target.probeGeneration !== target.probeGeneration
   ) {
     return { status: 'probing' };
   }
@@ -96,7 +103,7 @@ export function worktreeEligibilityForTarget(
  */
 export function worktreeSourceBranchForTarget(
   snapshot: NewSessionWorktreeBranchSelectionSnapshot | null,
-  target: NewSessionWorktreeProbeTarget,
+  target: NewSessionWorktreeBranchTarget,
   eligibility: NewSessionWorktreeEligibility,
 ): string {
   if (

--- a/apps/mobile/src/session/newSessionWorktree.ts
+++ b/apps/mobile/src/session/newSessionWorktree.ts
@@ -323,6 +323,11 @@ export function isWorktreeChannelNotAllowedError(error: unknown): boolean {
 /**
  * 开关行是否显示:正常情况下是 project + workingDir + 通道可用；若老端不支持但
  * 镜像仍为 ON，保留已勾选的关闭入口，不能把用户锁在 fail-closed 状态。
+ *
+ * 2026-08-07 用户裁决(对齐桌面 WorktreeChipsRow):勾选记忆只对具备资格的目录
+ * 生效——探测**成功**且确认不合格(ineligible:非 git / 无 git / 已在 worktree 内)
+ * 时开关行隐藏、创建按普通会话放行,记忆保留;probing / detect-failed 不算确认,
+ * 维持显示 + fail closed,一次断连不能把用户要求的隔离静默降级。
  */
 export function shouldShowWorktreeToggle(input: {
   workspaceKind: 'project' | 'dialogue';
@@ -332,13 +337,19 @@ export function shouldShowWorktreeToggle(input: {
 }): boolean {
   return input.workspaceKind === 'project'
     && input.workingDir.trim().length > 0
+    && input.eligibility.status !== 'ineligible'
     && (input.eligibility.status !== 'unsupported' || input.enabled);
 }
 
 /**
- * checkbox 正在写工作端时不能按旧镜像创建；已勾选且当前目标尚未确认 eligible 时，
+ * checkbox 正在写工作端时不能按旧镜像创建；已勾选且当前目标**探测未定**时,
  * 也不能静默退化为普通目录会话。unsupported + ON 仍 fail closed，但保留显式关闭
  * 入口，不能绕过 worktree:create 落到 base repo，也不能把用户永久锁住。
+ *
+ * ineligible(探测成功、确认不合格)放行(2026-08-07 裁决):勾选记忆只对合格
+ * 目录生效,确认非 git 等三种资格缺失时按普通会话创建,开关行同步隐藏
+ * (shouldShowWorktreeToggle)。probing / recovering / detect-failed 仍拦截——
+ * 「确认不是 git」和「探测不出来」不是一回事。
  */
 export function shouldBlockNewSessionCreateForWorktree(input: {
   /** 当前草稿是否真的会使用 worktree：仅 project + 已选目录。 */
@@ -352,7 +363,8 @@ export function shouldBlockNewSessionCreateForWorktree(input: {
   if (!input.applicable) return false;
   if (input.preferenceSaving) return true;
   return input.enabled
-    && input.eligibility.status !== 'eligible';
+    && input.eligibility.status !== 'eligible'
+    && input.eligibility.status !== 'ineligible';
 }
 
 /** 资格未通过时的 caption 文案 key(session.json);eligible 无 caption。 */

--- a/apps/mobile/src/session/newSessionWorktree.ts
+++ b/apps/mobile/src/session/newSessionWorktree.ts
@@ -361,10 +361,12 @@ export function shouldBlockNewSessionCreateForWorktree(input: {
   // 对话工作区 / 尚未选目录时 worktree 控件本就隐藏，工作端记忆不能反向卡住
   // 普通会话创建；切回具体项目后再按该项目资格决定是否阻止。
   if (!input.applicable) return false;
+  // ineligible 目标不创建 worktree,preference 写入在途也不该卡住普通会话
+  // 创建(2026-08-07 裁决);仅 eligible/probing/detect-failed/unsupported 需要等。
+  if (input.eligibility.status === 'ineligible') return false;
   if (input.preferenceSaving) return true;
   return input.enabled
-    && input.eligibility.status !== 'eligible'
-    && input.eligibility.status !== 'ineligible';
+    && input.eligibility.status !== 'eligible';
 }
 
 /** 资格未通过时的 caption 文案 key(session.json);eligible 无 caption。 */


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户反馈:上个会话勾选过 worktree 后,在非 git 目录新建会话时顶栏仍显示 [HEAD │ ☑ worktree] 控件(显示 HEAD 且看不出当前不可用),点发送才被 fail-closed 拦下,困惑度高。经用户裁决(2026-08-07),将 2026-07-29 的「显示但拦截」形态调整为:**勾选记忆只对具备 worktree 资格的目录生效**。

新语义(两端一致):

- **探测成功且确认不合格**(非 git 仓库 / git 未安装 / 已在 worktree 内,三种确认态统一处理):worktree 控件隐藏,发送不拦截、按普通会话创建;勾选记忆保留不动,回到合格目录自动恢复生效。
- **探测进行中 / 探测失败**(断线、超时、老端通道缺失等):维持 fail-closed——记忆 ON 时控件照旧显示、发送拦截;桌面端补上此前缺失的失败原因提示(`newChat.worktree.detectFailed`)。核心区分:「确认不是 git」和「探测不出来」不是一回事,后者不能被当成放行依据,否则一次弱网就会把用户要求的隔离静默降级成普通会话。

实现要点:

- 桌面 `WorktreeChipsRow` 新增 `confirmedIneligible` 派生值(只认探测成功回包里的资格缺失),经新 prop `onConfirmedIneligibleChange` 上报;`showBranchChip` 在确认不合格时隐藏整条控件。
- `NewMakerDraftRoute` 的 Send 门、Goal 门、本地 Goal worktree 使用点、device-link 两条预创建路径共 5 处加 `confirmedIneligible !== true` 条件:确认不合格放行普通会话,null(探测中/失败)维持原拦截。
- 移动端 `newSessionWorktree`:`shouldShowWorktreeToggle` 对 ineligible 隐藏,`shouldBlockNewSessionCreateForWorktree` 对 ineligible 放行;probing / recovering / detect-failed / unsupported 全部维持原拦截。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他:

### 范围

- 关联 Issue / 需求:无(来自用户会话内反馈与当面裁决)
- 本 PR 包含:桌面 WorktreeChipsRow / NewMakerDraftRoute 的显隐与发送门语义、移动端 newSessionWorktree 两个纯函数、四语 i18n 新 key、两端测试更新
- 明确不包含:Git 安全空目录自动 git init 的提示改进(独立产品裁决);移动端 worktree 偏好播种卡死问题(另一工单);移动端 unsupported 语义(维持现状)
- 用户可见变化:确认非 git 的目录上不再显示 worktree 控件、发送不再被拦截;探测失败时桌面端新增原因提示
- 是否存在 breaking change:无

### UI 变化

不涉及新样式:只增删既有控件的渲染分支,新增的失败提示复用现有 cantUseReason tooltip 通道(语义 token)。

- 引用的设计规范:不涉及:无新增视觉/布局/颜色;文案新增已过术语表门禁(worktree 按裁决保留英文原词)。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果:全部通过(apps/desktop 144.9s PASS,apps/mobile 14.9s PASS,exit 0)
pnpm --filter desktop run --if-present typecheck
结果:通过
pnpm --filter mobile run --if-present typecheck
结果:通过
pnpm check:i18n-glossary
结果:通过(无新增违规)
pnpm check:dco
结果:通过(1 commit signed off)
```

新增/更新测试:桌面 3 个 contract 测试的 source pin 更新并新增「确认不合格放行普通会话」用例;移动端新增 ineligible 隐藏/放行用例,并补齐 detect-failed 拦截期望。

### 手工验证

未执行(见下)。

### 未执行的验证

- Light/Dark 双模式实机目检未做:本次无新增样式,失败提示走既有 themed tooltip;如实注明「复用 themed 样式,双模式未实机验证」。
- 移动端实机未验证:改动为纯函数逻辑,已有单测覆盖;未在真机/模拟器目检开关行显隐。
- device-link 远程目录的确认不合格场景未实机联调(探测经隧道,confirmedIneligible 仅在成功回包时非 null,失败路径维持原 fail-closed,无行为回归面)。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容(批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式)
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他:产品行为变更(取代 2026-07-29 用户裁决,由用户 2026-08-07 重新裁决)

### 影响与回滚

- 影响范围:新建会话页的 worktree 控件显隐与发送门。确认非 git 目录 + 记忆 ON 的用户此后会无提示地创建普通会话(新语义的预期行为,裁决时已确认接受)。移动端改动为热更可达的纯 JS,仅改 apps/mobile/src 与测试,无 app.json / config plugin / 原生依赖改动,**不改变 runtime fingerprint、不触发冷更**。
- 回滚 / 降级方式:revert 本 commit 即回到「显示但拦截」形态;无数据迁移、无持久化格式变化(勾选记忆的存储与写入路径完全未动)。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因