### PR TITLE
fix(device-link): push 拥塞入队改 latest-wins 腾位，消除 BACKPRESSURE 风暴

### DIFF
--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -11,7 +11,6 @@ import {
   DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
   MAX_TRANSPORT_PENDING_MESSAGES,
   MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES,
-  TRANSPORT_PENDING_PUSH_MAX_AGE_MS,
   encodeReliableFrames,
   makeTransportSkipPayload,
   parseTransportPayload,
@@ -2072,10 +2071,8 @@ describe('DeviceLinkClient', () => {
     for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
       h.client.sendPush('dev-b', 'maker:event', { i });
     }
-    // push 之间不互相驱逐：新鲜 push 溢出仍按原语义被背压拒绝
-    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
-      expect.objectContaining({ code: 'BACKPRESSURE' }),
-    );
+    // （push 拥塞入队的 latest-wins 语义见专项用例
+    //   「缓冲被未 ACK 的 push 占满时，新 push latest-wins 驱逐最旧帧入队」）
 
     // invoke-result 是控制端的存活凭据：丢弃整个队头可丢弃前缀（fresh push
     // 一并放弃），立即入队发出，不留任何 push 排在 result 之前
@@ -2143,53 +2140,94 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
-  it('push 入队压力只做 TTL 兜底清扫（单调时钟计量），新鲜 push 之间仍互相背压', async () => {
-    // TTL 用单调时钟：墙钟被 NTP 向前校正超过 TTL 时，刚入队的 push 不得被误判过期
-    const proto = DeviceLinkClient.prototype as unknown as { monotonicNow(): number };
-    let nowMs = 10_000;
-    const clock = vi.spyOn(proto, 'monotonicNow').mockImplementation(() => nowMs);
-    try {
-      const warn = vi.fn();
-      const h = makeHarness({
-        timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
-        logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
-      });
-      h.client.start();
-      await tick();
-      h.current().ack();
-      await establishInboundReliableLink(h, 'ttl-stream');
+  it('缓冲被未 ACK 的 push 占满时，新 push latest-wins 驱逐最旧帧入队，不再 BACKPRESSURE', async () => {
+    // 生产反例（2026-08-07，P0 度量实锤）：对端停 ACK 时新鲜 push 互相背压，
+    // 一小时 5168 次 BACKPRESSURE（maker:event），镜像零交付只放大重试风暴。
+    // 现改为按需腾位：只丢最旧的可丢弃帧，较新的镜像历史保留给对端恢复后交付。
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'latest-wins-stream');
 
-      h.client.sendPush('dev-b', 'maker:event', { text: 'old-1' });
-      h.client.sendPush('dev-b', 'maker:event', { text: 'old-2' });
-      // 只推进单调时钟：前两条 push 超龄，后续 push 保持新鲜
-      nowMs += TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1;
-      for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
-        h.client.sendPush('dev-b', 'maker:event', { i });
-      }
-
-      // 缓冲满：新 push 触发 TTL 兜底清扫，只有 2 条过期 push 出队，新 push 入队
-      expect(() =>
-        h.client.sendPush('dev-b', 'maker:event', { text: 'fresh-after-sweep' }),
-      ).not.toThrow();
-      expect(warn).toHaveBeenCalledWith(
-        expect.stringContaining('dropped 2 discardable pending frame(s)'),
-      );
-      const frames = h.current().sent.filter(
-        (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
-      );
-      const meta = parseTransportPayload(frames[frames.length - 1].payload)!.meta;
-      expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
-      expect(meta.baseSeq).toBe(3);
-
-      // 填回满员后队头是新鲜 push：不互相驱逐，仍按原语义背压
-      h.client.sendPush('dev-b', 'maker:event', { text: 'refill' });
-      expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
-        expect.objectContaining({ code: 'BACKPRESSURE' }),
-      );
-      h.client.stop();
-    } finally {
-      clock.mockRestore();
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
     }
+
+    // 满员后的新 push：只驱逐最旧的 1 条（seq=1）腾位，自身入队；
+    // baseSeq 前移到 2，接收端整体跳过被驱逐的 seq，无空洞
+    expect(() =>
+      h.client.sendPush('dev-b', 'maker:event', { text: 'newest-1' }),
+    ).not.toThrow();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('latest-wins push admission'),
+    );
+    const pushFrames = () => h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    let meta = parseTransportPayload(pushFrames().at(-1)!.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 1);
+    expect(meta.baseSeq).toBe(2);
+
+    // 连续洪峰：每条新 push 轮换掉一条最旧帧，队列保持满员而不再抛背压
+    expect(() =>
+      h.client.sendPush('dev-b', 'maker:event', { text: 'newest-2' }),
+    ).not.toThrow();
+    meta = parseTransportPayload(pushFrames().at(-1)!.payload)!.meta;
+    expect(meta.seq).toBe(MAX_TRANSPORT_PENDING_MESSAGES + 2);
+    expect(meta.baseSeq).toBe(3);
+    h.client.stop();
+  });
+
+  it('push 拥塞腾位不跨 live 帧：队头是 live invoke 时新 push 维持 BACKPRESSURE', async () => {
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, requestTimeoutMs: 5_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+
+    const open = h.client.openLink('dev-b', {
+      controllerName: 'Test',
+      protocolVersion: 1,
+      appVersion: '1',
+    });
+    const sentOpen = h.current().sent.find((e) => e.kind === 'link-open')!;
+    h.current().push({
+      v: PROTOCOL_VERSION,
+      kind: 'link-accept',
+      id: sentOpen.id,
+      src: 'dev-b',
+      payload: {
+        appVersion: '1',
+        allowlistHash: 'hash',
+        capabilities: [DEVICE_LINK_CAPABILITY_RELIABLE_TRANSPORT],
+        transportStreamId: 'remote-stream',
+      },
+    });
+    await open;
+
+    // 队头 seq=1 是仍在等待响应的 live invoke，其后被 push 填满：
+    // live 帧是可丢弃前缀的边界，push 腾位不得跨越（会留 seq 空洞）
+    const p = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
+    p.catch(() => {});
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 1; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'overflow' })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('latest-wins push admission'),
+    );
+    h.client.stop();
   });
 
   it('队头 skip 占位不再挡住腾位：invoke 超时成 skip 后，invoke-result 跨过 skip 与 push 入队，重连后第一个重放', async () => {
@@ -3679,10 +3717,9 @@ describe('DeviceLinkClient', () => {
         for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
           h.client.sendPush('ctrl-1', 'sessions', { i });
         }
-        // 第 65 条:队头未过滞留阈值 → 仍是 BACKPRESSURE(原有语义不变)
-        expect(() => h.client.sendPush('ctrl-1', 'sessions', { overflow: true })).toThrow(
-          /reliable transport buffer is full/,
-        );
+        // 第 65 条:队头未过滞留阈值 → latest-wins 驱逐最旧 push 腾位入队,
+        // 不再 BACKPRESSURE(link 恢复后仍可交付较新镜像)
+        expect(() => h.client.sendPush('ctrl-1', 'sessions', { overflow: true })).not.toThrow();
         // 滞留超阈值后:入队前整队放弃,新帧不再被顶回
         nowMs += 51;
         expect(() => h.client.sendPush('ctrl-1', 'sessions', { after: true })).not.toThrow();

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -2292,6 +2292,60 @@ describe('DeviceLinkClient', () => {
     h.client.stop();
   });
 
+  it('白名单外的事件流 push(messages:created)不参与 latest-wins:不驱逐别人,也不被驱逐', async () => {
+    // review P1(第二轮):local-db:messages:created 是不可合并的事件流——拥塞
+    // 驱逐发生时 link 未断,reconnect reseed 不会跑,静默驱逐 = UI 永久漏一条消息。
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'event-stream-guard-stream');
+
+    // 方向一:满员时它自己入队不驱逐镜像,维持 BACKPRESSURE
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    expect(() =>
+      h.client.sendPush('dev-b', 'local-db:messages:created', { messageId: 'm1' }),
+    ).toThrow(expect.objectContaining({ code: 'BACKPRESSURE' }));
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('latest-wins push admission'),
+    );
+    h.client.stop();
+  });
+
+  it('已入队的事件流 push 是腾位边界:镜像洪峰驱逐到 messages:created 即止', async () => {
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'event-stream-boundary-stream');
+
+    // 队形:1 条镜像(seq1) + 1 条 messages:created(seq2) + 镜像填满到 64
+    h.client.sendPush('dev-b', 'maker:event', { i: 0 });
+    h.client.sendPush('dev-b', 'local-db:messages:created', { messageId: 'm1' });
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { fill: i });
+    }
+
+    const pushFrames = () => h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    // 第一条洪峰驱逐 seq1 镜像入队;第二条队头已是 messages:created,拒收
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'newest-1' })).not.toThrow();
+    expect(parseTransportPayload(pushFrames().at(-1)!.payload)!.meta.baseSeq).toBe(2);
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'blocked' })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    h.client.stop();
+  });
+
   it('WebSocket 缓冲满时 push 在驱逐前拒绝:不为无法入队的帧清空镜像历史', async () => {
     // review P1:容量预检若晚于驱逐,连续调用会逐步清空本可重试的镜像历史,
     // 却一帧未纳。预检先行后,ws 满那一轮必须一条都不驱逐。
@@ -3856,15 +3910,16 @@ describe('DeviceLinkClient', () => {
         await makeLinkDownPeer(h);
 
         // link down:push 只入队不发送,填满 pending(64 条)
+        // (用可合并镜像通道 maker:event:白名单外通道不参与 latest-wins)
         for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
-          h.client.sendPush('ctrl-1', 'sessions', { i });
+          h.client.sendPush('ctrl-1', 'maker:event', { i });
         }
         // 第 65 条:队头未过滞留阈值 → latest-wins 驱逐最旧 push 腾位入队,
         // 不再 BACKPRESSURE(link 恢复后仍可交付较新镜像)
-        expect(() => h.client.sendPush('ctrl-1', 'sessions', { overflow: true })).not.toThrow();
+        expect(() => h.client.sendPush('ctrl-1', 'maker:event', { overflow: true })).not.toThrow();
         // 滞留超阈值后:入队前整队放弃,新帧不再被顶回
         nowMs += 51;
-        expect(() => h.client.sendPush('ctrl-1', 'sessions', { after: true })).not.toThrow();
+        expect(() => h.client.sendPush('ctrl-1', 'maker:event', { after: true })).not.toThrow();
         h.client.stop();
       } finally {
         clock.mockRestore();

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -17,6 +17,7 @@ import {
   parseTransportPayload,
 } from '../transport.js';
 import { DL_CONTACTS_SYNC_CHANNEL } from '../contactsSyncProtocol.js';
+import { SESSION_ACTIVITY_CHANNEL } from '../topics.js';
 
 type Handler = (...args: unknown[]) => void;
 
@@ -2343,6 +2344,41 @@ describe('DeviceLinkClient', () => {
     expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'blocked' })).toThrow(
       expect.objectContaining({ code: 'BACKPRESSURE' }),
     );
+    h.client.stop();
+  });
+
+  it('键控终态快照(sessions:activity)不参与 latest-wins:收尾快照不被 maker:event 洪峰驱逐', async () => {
+    // review P2(第三轮):activity 按 sessionId 键控,completed/error 收尾快照是
+    // 该键最后一帧;staging 在 sendPush 成功后即删暂存不再重试,link 不重连
+    // reseed 不会跑——被驱逐 = 手机端永远显示 running。
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'activity-final-stream');
+
+    // 队形:1 条镜像(seq1) + 会话 A 的 completed 快照(seq2) + 镜像填满到 64
+    h.client.sendPush('dev-b', 'maker:event', { i: 0 });
+    h.client.sendPush('dev-b', SESSION_ACTIVITY_CHANNEL, { sessionId: 'a', status: 'completed' });
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { fill: i });
+    }
+
+    const pushFrames = () => h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    // 洪峰驱逐 seq1 镜像后,队头是 activity 收尾快照:边界生效,后续洪峰拒收
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'newest-1' })).not.toThrow();
+    expect(parseTransportPayload(pushFrames().at(-1)!.payload)!.meta.baseSeq).toBe(2);
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'blocked' })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    // activity 满员入队也不驱逐别人(不在白名单)
+    expect(() =>
+      h.client.sendPush('dev-b', SESSION_ACTIVITY_CHANNEL, { sessionId: 'b', status: 'running' }),
+    ).toThrow(expect.objectContaining({ code: 'BACKPRESSURE' }));
     h.client.stop();
   });
 

--- a/packages/device-link/src/__tests__/client.test.ts
+++ b/packages/device-link/src/__tests__/client.test.ts
@@ -11,10 +11,12 @@ import {
   DEVICE_LINK_TRANSPORT_ACK_CHANNEL,
   MAX_TRANSPORT_PENDING_MESSAGES,
   MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES,
+  TRANSPORT_PENDING_PUSH_MAX_AGE_MS,
   encodeReliableFrames,
   makeTransportSkipPayload,
   parseTransportPayload,
 } from '../transport.js';
+import { DL_CONTACTS_SYNC_CHANNEL } from '../contactsSyncProtocol.js';
 
 type Handler = (...args: unknown[]) => void;
 
@@ -2228,6 +2230,146 @@ describe('DeviceLinkClient', () => {
       expect.stringContaining('latest-wins push admission'),
     );
     h.client.stop();
+  });
+
+  it('流控 push(contacts-sync)满员入队不驱逐镜像帧,维持 BACKPRESSURE 交发送方流控', async () => {
+    // contacts-sync sender 对 BACKPRESSURE 做阻塞等待重试(它的流控协议),
+    // 它的帧不得触发 latest-wins 驱逐别人——满员时按原语义拒收即可。
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'flow-controlled-in-stream');
+
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    expect(() =>
+      h.client.sendPush('dev-b', DL_CONTACTS_SYNC_CHANNEL, { version: 1, type: 'chunk' }),
+    ).toThrow(expect.objectContaining({ code: 'BACKPRESSURE' }));
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('latest-wins push admission'),
+    );
+    h.client.stop();
+  });
+
+  it('已入队的流控 push 是腾位边界:镜像洪峰驱逐到它即止,分片不被静默丢弃', async () => {
+    // 反例(review P2):contacts-sync 的 cipher-chunk 一旦被 maker:event 洪峰
+    // 静默驱逐,发送方以为已送达,接收端永远拼不出本次传输。
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'flow-controlled-boundary-stream');
+
+    // 队形:2 条镜像(seq1-2) + 1 条 contacts 分片(seq3) + 镜像填满到 64
+    h.client.sendPush('dev-b', 'maker:event', { i: 0 });
+    h.client.sendPush('dev-b', 'maker:event', { i: 1 });
+    h.client.sendPush('dev-b', DL_CONTACTS_SYNC_CHANNEL, { version: 1, type: 'chunk', index: 0 });
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 3; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { fill: i });
+    }
+
+    const pushFrames = () => h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    // 洪峰驱逐 seq1、seq2 两条镜像后,队头是 contacts 分片:边界生效,第三条拒收
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'newest-1' })).not.toThrow();
+    expect(parseTransportPayload(pushFrames().at(-1)!.payload)!.meta.baseSeq).toBe(2);
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'newest-2' })).not.toThrow();
+    expect(parseTransportPayload(pushFrames().at(-1)!.payload)!.meta.baseSeq).toBe(3);
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'blocked' })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    h.client.stop();
+  });
+
+  it('WebSocket 缓冲满时 push 在驱逐前拒绝:不为无法入队的帧清空镜像历史', async () => {
+    // review P1:容量预检若晚于驱逐,连续调用会逐步清空本可重试的镜像历史,
+    // 却一帧未纳。预检先行后,ws 满那一轮必须一条都不驱逐。
+    const warn = vi.fn();
+    const h = makeHarness({
+      timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000 },
+      logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+    });
+    h.client.start();
+    await tick();
+    h.current().ack();
+    await establishInboundReliableLink(h, 'ws-precheck-stream');
+
+    for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES; i++) {
+      h.client.sendPush('dev-b', 'maker:event', { i });
+    }
+    h.current().bufferedAmount = MAX_TRANSPORT_WEBSOCKET_BUFFERED_BYTES;
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'rejected' })).toThrow(
+      expect.objectContaining({ code: 'BACKPRESSURE' }),
+    );
+    expect(warn).not.toHaveBeenCalledWith(
+      expect.stringContaining('latest-wins push admission'),
+    );
+
+    // ws 恢复后的下一条 push 只驱逐本轮的 1 条(baseSeq=2):
+    // 证明 ws 满那一轮没有发生任何驱逐,否则基线会更靠后
+    h.current().bufferedAmount = 0;
+    expect(() => h.client.sendPush('dev-b', 'maker:event', { text: 'admitted' })).not.toThrow();
+    const pushFrames = h.current().sent.filter(
+      (env) => env.kind === 'push' && parseTransportPayload(env.payload) !== null,
+    );
+    expect(parseTransportPayload(pushFrames.at(-1)!.payload)!.meta.baseSeq).toBe(2);
+    h.client.stop();
+  });
+
+  it('live invoke 入队压力只做 TTL 兜底清扫(单调时钟计量):过期 push 出队,新鲜 push 不被 invoke 驱逐', async () => {
+    // TTL 用单调时钟:墙钟被 NTP 向前校正超过 TTL 时,刚入队的 push 不得被误判过期。
+    // (push 入队已改 latest-wins,TTL 路径由 live invoke 的入队压力触达。)
+    const proto = DeviceLinkClient.prototype as unknown as { monotonicNow(): number };
+    let nowMs = 10_000;
+    const clock = vi.spyOn(proto, 'monotonicNow').mockImplementation(() => nowMs);
+    try {
+      const warn = vi.fn();
+      const h = makeHarness({
+        timing: { pingIntervalMs: 10_000, transportRetryIntervalMs: 60_000, requestTimeoutMs: 5_000 },
+        logger: { debug: vi.fn(), info: vi.fn(), warn, error: vi.fn() },
+      });
+      h.client.start();
+      await tick();
+      h.current().ack();
+      await establishInboundReliableLink(h, 'ttl-invoke-stream');
+
+      h.client.sendPush('dev-b', 'maker:event', { text: 'old-1' });
+      h.client.sendPush('dev-b', 'maker:event', { text: 'old-2' });
+      // 只推进单调时钟:前两条 push 超龄,后续 push 保持新鲜
+      nowMs += TRANSPORT_PENDING_PUSH_MAX_AGE_MS + 1;
+      for (let i = 0; i < MAX_TRANSPORT_PENDING_MESSAGES - 2; i++) {
+        h.client.sendPush('dev-b', 'maker:event', { i });
+      }
+
+      // 缓冲满:live invoke 触发 TTL 兜底清扫,2 条过期 push 出队,invoke 入队
+      const p1 = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
+      p1.catch(() => {});
+      await tick();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('dropped 2 discardable pending frame(s)'),
+      );
+
+      // 填回满员后队头是新鲜 push:invoke 不得驱逐它们,维持 BACKPRESSURE
+      h.client.sendPush('dev-b', 'maker:event', { text: 'refill' });
+      let backpressured: unknown;
+      const p2 = h.client.invoke('dev-b', { channel: 'maker:list-active', args: [] }, 5_000);
+      await p2.catch((err: unknown) => { backpressured = err; });
+      expect(backpressured).toEqual(expect.objectContaining({ code: 'BACKPRESSURE' }));
+      h.client.stop();
+    } finally {
+      clock.mockRestore();
+    }
   });
 
   it('队头 skip 占位不再挡住腾位：invoke 超时成 skip 后，invoke-result 跨过 skip 与 push 入队，重连后第一个重放', async () => {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -40,27 +40,38 @@ import {
   parseTransportPayload,
   byteLength,
 } from './transport.js';
-import { DL_CONTACTS_SYNC_CHANNEL } from './contactsSyncProtocol.js';
+import { SESSION_ACTIVITY_CHANNEL } from './topics.js';
 
 const DUPLICATE_CONNECTION_CLOSE_CODE = 4409;
 /**
- * 把 BACKPRESSURE 当流控信号的 push 通道:发送方对 BACKPRESSURE 做阻塞等待
- * 重试(见 contacts-sync sender 的 sendRelayFrame),帧是**有序数据流**而非可
- * 由 resync 再生的状态镜像。latest-wins 腾位对这类通道双向禁用——新帧满员时
- * 维持原背压语义交给发送方流控,已入队的帧也绝不被镜像洪峰驱逐:cipher-chunk
- * 被静默驱逐后发送方以为已送达,接收端却永远拼不出本次传输。
+ * latest-wins 腾位适用的**可合并镜像通道白名单**(review 两轮 P1 收敛:先是
+ * contacts-sync 黑名单,再反转为白名单)。push 单 FIFO 上混着两类语义:
+ *
+ * - 可合并镜像/可再生流(本表):agent 事件流、会话活动快照、输入投影。丢最旧
+ *   帧只损失中间态,最新状态由后续帧或控制端 resync 补偿;其中 maker:event 在
+ *   旧语义下拥塞时本就丢**最新**帧(admission 拒收后 forwardPush 按 best-effort
+ *   放弃),换成丢最旧不引入新的损失面。
+ * - 不可合并事件/流控数据(表外全部,fail-closed):local-db:messages:created、
+ *   maker:interaction-request(确认卡)、fs-watch 事件、contacts-sync 分片
+ *   (发送方以 BACKPRESSURE 为流控信号,见 contacts-sync sender)等。拥塞驱逐
+ *   发生时 link 并未断开,reconnect reseed 不会跑——静默驱逐 = UI 永久漏一条
+ *   消息/确认卡,或分片传输永远拼不出。这类通道维持原背压语义。
+ *
+ * 新增 push 通道默认**不可驱逐**;确属镜像语义需在此显式登记。
  */
-const FLOW_CONTROLLED_PUSH_CHANNELS: ReadonlySet<string> = new Set([
-  DL_CONTACTS_SYNC_CHANNEL,
+const COALESCIBLE_PUSH_CHANNELS: ReadonlySet<string> = new Set([
+  'maker:event',
+  SESSION_ACTIVITY_CHANNEL,
+  'maker:input:projection',
 ]);
 /** push 拥塞驱逐告警的 per-peer 聚合窗口:洪峰期逐条 warn 本身就是新的风暴。 */
 const PUSH_ADMISSION_DROP_LOG_INTERVAL_MS = 5_000;
 
-function isFlowControlledPushEnvelope(env: Envelope): boolean {
+function isCoalesciblePushEnvelope(env: Envelope): boolean {
   if (env.kind !== 'push') return false;
   const payload = env.payload as { channel?: unknown } | undefined;
   return typeof payload?.channel === 'string'
-    && FLOW_CONTROLLED_PUSH_CHANNELS.has(payload.channel);
+    && COALESCIBLE_PUSH_CHANNELS.has(payload.channel);
 }
 /** 连续握手超时达到该次数后,握手窗口翻倍(见 armHandshakeTimeout)。 */
 const HANDSHAKE_TIMEOUT_WIDEN_AFTER = 2;
@@ -2109,19 +2120,20 @@ export class DeviceLinkClient {
         // 帧饿死：丢弃整个队头可丢弃前缀（fresh push 一并放弃——单 FIFO 无法同时
         // 做到 push 无损与 result 抢占），让 result 成为最早可交付的 live seq。
         this.dropDiscardablePendingPrefix(env.dst, peer, false, 'to make room for invoke-result');
-      } else if (env.kind === 'push' && !isFlowControlledPushEnvelope(env)) {
-        // push 是尽力而为的状态镜像（控制端重连/回前台会整体 resync + 重新订阅）。
-        // 拥塞即对端未在 ACK：2026-08-07 线上该形态一小时内 5168 次连续
-        // BACKPRESSURE（maker:event），镜像状态一条都没交付，只放大重试风暴。
-        // latest-wins：只从队头驱逐最旧的可丢弃镜像帧直到放得下（剩余镜像历史
-        // 保留，对端恢复后仍可交付最新状态）；队头是 live 帧或流控 push 时无位
-        // 可让，维持原 BACKPRESSURE 语义。只删队头 → baseSeq 单调前移，无 seq 空洞。
+      } else if (env.kind === 'push' && isCoalesciblePushEnvelope(env)) {
+        // 可合并镜像 push（COALESCIBLE_PUSH_CHANNELS）是尽力而为的状态镜像
+        // （控制端重连/回前台会整体 resync + 重新订阅）。拥塞即对端未在 ACK：
+        // 2026-08-07 线上该形态一小时内 5168 次连续 BACKPRESSURE（maker:event），
+        // 镜像状态一条都没交付，只放大重试风暴。latest-wins：只从队头驱逐最旧
+        // 的可合并镜像帧直到放得下（剩余镜像历史保留，对端恢复后仍可交付最新
+        // 状态）；队头是 live 帧或白名单外 push 时无位可让，维持原 BACKPRESSURE
+        // 语义。只删队头 → baseSeq 单调前移，无 seq 空洞。
         this.dropOldestDiscardableForPushAdmission(env.dst, peer, reservedBytes);
       } else {
-        // live invoke 与流控 push（FLOW_CONTROLLED_PUSH_CHANNELS，发送方以
-        // BACKPRESSURE 为流控信号）的入队压力只做 TTL 兜底清扫：过期 push 已无
-        // 实时价值，先出队腾位；新鲜 push 不互相驱逐（这两类帧不能以丢镜像
-        // 为代价抢占）。
+        // live invoke 与白名单外 push（不可合并事件流/流控数据，见
+        // COALESCIBLE_PUSH_CHANNELS 注释）的入队压力只做 TTL 兜底清扫：过期
+        // push 已无实时价值，先出队腾位；新鲜 push 不互相驱逐（这两类帧不能
+        // 以丢镜像为代价抢占）。
         this.dropDiscardablePendingPrefix(env.dst, peer, true, 'after pending push TTL expiry');
       }
     }
@@ -2463,8 +2475,9 @@ export class DeviceLinkClient {
   }
 
   /**
-   * 可丢弃帧判据（重连重放、invoke-result 腾位、push latest-wins 腾位三条
-   * 路径共用的不变量）：
+   * 可丢弃帧判据（重连重放与 invoke-result 腾位两条路径共用的不变量;
+   * push latest-wins 腾位用更窄的白名单判据,见
+   * dropOldestDiscardableForPushAdmission）：
    * best-effort push，以及 timeout / relay-error 后被 dropReliablePendingForRequest
    * 换成 transport-skip 占位 payload 的帧——其外层 kind 仍是原 invoke /
    * invoke-result，但已无任何业务副作用。两者都可以通过推进 baseSeq 让接收端
@@ -2550,12 +2563,15 @@ export class DeviceLinkClient {
    * 腾位」而非「整段前缀丢弃」：对端只是暂时未 ACK 时，队列里较新的镜像历史保留
    * 下来，恢复后仍能交付；被驱逐的最旧镜像由控制端 resync 补偿，不是静默丢数据。
    *
-   * 可驱逐判据比 isDiscardablePending 更窄：流控 push（FLOW_CONTROLLED_PUSH_CHANNELS）
-   * 虽是 push kind，但发送方以 BACKPRESSURE 为流控信号、帧是有序数据流，被镜像
-   * 洪峰静默驱逐 = 发送方以为已送达而接收端永远拼不出传输——它们与 live
-   * invoke/invoke-result 一样是腾位边界。队头不可驱逐时无位可让（跨过会制造
-   * seq 空洞），调用方按容量复检结果维持原 BACKPRESSURE 语义。只删队头 →
-   * baseSeq 单调前移，接收端按新基线整体跳过被驱逐 seq，无空洞、不挂累计 ACK。
+   * 可驱逐判据比 isDiscardablePending 更窄（白名单，fail-closed）：只有
+   * COALESCIBLE_PUSH_CHANNELS 里的镜像 push 与 transport-skip 占位可被驱逐。
+   * 白名单外的 push（不可合并事件流如 local-db:messages:created、确认卡、
+   * 以 BACKPRESSURE 为流控信号的 contacts-sync 分片）被静默驱逐时 link 并未
+   * 断开、reconnect reseed 不会跑，等价于 UI 永久漏事件或传输永久拼不出——
+   * 它们与 live invoke/invoke-result 一样是腾位边界。队头不可驱逐时无位可让
+   * （跨过会制造 seq 空洞），调用方按容量复检结果维持原 BACKPRESSURE 语义。
+   * 只删队头 → baseSeq 单调前移，接收端按新基线整体跳过被驱逐 seq，无空洞、
+   * 不挂累计 ACK。
    *
    * 生产反例（2026-08-07，P0 度量实锤）：对端停 ACK 时新鲜 push 之间互相背压，
    * 每条新 push 都抛 BACKPRESSURE，一小时 5168 次（maker:event），镜像零交付。
@@ -2576,8 +2592,8 @@ export class DeviceLinkClient {
       if (head.done) break;
       const [seq, pending] = head.value;
       if (
-        !this.isDiscardablePending(pending)
-        || isFlowControlledPushEnvelope(pending.envelope)
+        !isTransportSkipPayload(pending.envelope.payload)
+        && !isCoalesciblePushEnvelope(pending.envelope)
       ) break;
       this.removePendingEntry(peer, seq, pending);
       dropped += 1;

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -2078,9 +2078,17 @@ export class DeviceLinkClient {
         // 帧饿死：丢弃整个队头可丢弃前缀（fresh push 一并放弃——单 FIFO 无法同时
         // 做到 push 无损与 result 抢占），让 result 成为最早可交付的 live seq。
         this.dropDiscardablePendingPrefix(env.dst, peer, false, 'to make room for invoke-result');
+      } else if (env.kind === 'push') {
+        // push 是尽力而为的状态镜像（控制端重连/回前台会整体 resync + 重新订阅）。
+        // 拥塞即对端未在 ACK：2026-08-07 线上该形态一小时内 5168 次连续
+        // BACKPRESSURE（maker:event），镜像状态一条都没交付，只放大重试风暴。
+        // latest-wins：只从队头驱逐最旧的可丢弃帧直到放得下（剩余镜像历史保留，
+        // 对端恢复后仍可交付最新状态）；队头是 live 帧时无位可让，维持原
+        // BACKPRESSURE 语义。只删队头 → baseSeq 单调前移，无 seq 空洞。
+        this.dropOldestDiscardableForPushAdmission(env.dst, peer, reservedBytes);
       } else {
-        // 其它帧的入队压力只做 TTL 兜底清扫：过期 push 已无实时价值，先出队腾位；
-        // 新鲜 push 之间维持原有 BACKPRESSURE 语义，不互相驱逐。
+        // live invoke 的入队压力只做 TTL 兜底清扫：过期 push 已无实时价值，先出队
+        // 腾位；新鲜 push 不互相驱逐（invoke 不能以丢镜像为代价抢占）。
         this.dropDiscardablePendingPrefix(env.dst, peer, true, 'after pending push TTL expiry');
       }
     }
@@ -2424,7 +2432,8 @@ export class DeviceLinkClient {
   }
 
   /**
-   * 可丢弃帧判据（重连重放与 invoke-result 腾位两条路径共用的不变量）：
+   * 可丢弃帧判据（重连重放、invoke-result 腾位、push latest-wins 腾位三条
+   * 路径共用的不变量）：
    * best-effort push，以及 timeout / relay-error 后被 dropReliablePendingForRequest
    * 换成 transport-skip 占位 payload 的帧——其外层 kind 仍是原 invoke /
    * invoke-result，但已无任何业务副作用。两者都可以通过推进 baseSeq 让接收端
@@ -2502,6 +2511,43 @@ export class DeviceLinkClient {
       clearInterval(peer.retryTimer);
       peer.retryTimer = null;
     }
+  }
+
+  /**
+   * push 入队的拥塞腾位（latest-wins）：只从队头连续移除最旧的可丢弃帧，直到
+   * 放得下新帧或队头变成 live 帧。与 dropDiscardablePendingPrefix 的区别是「按需
+   * 腾位」而非「整段前缀丢弃」：对端只是暂时未 ACK 时，队列里较新的镜像历史保留
+   * 下来，恢复后仍能交付；被驱逐的最旧镜像由控制端 resync 补偿，不是静默丢数据。
+   * 队头是 live invoke/invoke-result 时无位可让（保留会制造 seq 空洞的帧），调用方
+   * 按容量复检结果维持原 BACKPRESSURE 语义。只删队头 → baseSeq 单调前移，接收端
+   * 按新基线整体跳过被驱逐 seq，无空洞、不挂累计 ACK。
+   *
+   * 生产反例（2026-08-07，P0 度量实锤）：对端停 ACK 时新鲜 push 之间互相背压，
+   * 每条新 push 都抛 BACKPRESSURE，一小时 5168 次（maker:event），镜像零交付。
+   */
+  private dropOldestDiscardableForPushAdmission(
+    dst: string,
+    peer: PeerTransportState,
+    reservedBytes: number,
+  ): number {
+    let dropped = 0;
+    while (
+      peer.pending.size >= MAX_TRANSPORT_PENDING_MESSAGES
+      || peer.pendingBytes + reservedBytes > MAX_TRANSPORT_PENDING_BYTES
+    ) {
+      const head = peer.pending.entries().next();
+      if (head.done) break;
+      const [seq, pending] = head.value;
+      if (!this.isDiscardablePending(pending)) break;
+      this.removePendingEntry(peer, seq, pending);
+      dropped += 1;
+    }
+    if (dropped > 0) {
+      this.log.warn(
+        `dropped ${dropped} oldest discardable pending frame(s) for peer ${dst.slice(0, 8)} latest-wins push admission`,
+      );
+    }
+    return dropped;
   }
 
   private ensureRetryTimer(dst: string): void {

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -40,8 +40,28 @@ import {
   parseTransportPayload,
   byteLength,
 } from './transport.js';
+import { DL_CONTACTS_SYNC_CHANNEL } from './contactsSyncProtocol.js';
 
 const DUPLICATE_CONNECTION_CLOSE_CODE = 4409;
+/**
+ * 把 BACKPRESSURE 当流控信号的 push 通道:发送方对 BACKPRESSURE 做阻塞等待
+ * 重试(见 contacts-sync sender 的 sendRelayFrame),帧是**有序数据流**而非可
+ * 由 resync 再生的状态镜像。latest-wins 腾位对这类通道双向禁用——新帧满员时
+ * 维持原背压语义交给发送方流控,已入队的帧也绝不被镜像洪峰驱逐:cipher-chunk
+ * 被静默驱逐后发送方以为已送达,接收端却永远拼不出本次传输。
+ */
+const FLOW_CONTROLLED_PUSH_CHANNELS: ReadonlySet<string> = new Set([
+  DL_CONTACTS_SYNC_CHANNEL,
+]);
+/** push 拥塞驱逐告警的 per-peer 聚合窗口:洪峰期逐条 warn 本身就是新的风暴。 */
+const PUSH_ADMISSION_DROP_LOG_INTERVAL_MS = 5_000;
+
+function isFlowControlledPushEnvelope(env: Envelope): boolean {
+  if (env.kind !== 'push') return false;
+  const payload = env.payload as { channel?: unknown } | undefined;
+  return typeof payload?.channel === 'string'
+    && FLOW_CONTROLLED_PUSH_CHANNELS.has(payload.channel);
+}
 /** 连续握手超时达到该次数后,握手窗口翻倍(见 armHandshakeTimeout)。 */
 const HANDSHAKE_TIMEOUT_WIDEN_AFTER = 2;
 /** 「link 未就绪收到可靠帧」通知的 per-peer 节流(见 onReliableFrameBeforeLink)。 */
@@ -316,6 +336,10 @@ interface PeerTransportState {
   receive: Map<string, ReceiveStreamState>;
   highestAckSeq: number;
   lastReplayEpoch: number;
+  /** latest-wins 腾位驱逐的聚合计数(自上次告警起),仅服务日志聚合。 */
+  pushAdmissionDropCount: number;
+  /** 上次输出 latest-wins 驱逐告警的单调时刻;0 表示从未输出。 */
+  pushAdmissionDropLogAt: number;
 }
 
 interface PendingInboundLinkOffer {
@@ -2072,23 +2096,32 @@ export class DeviceLinkClient {
       peer.pending.size < MAX_TRANSPORT_PENDING_MESSAGES
       && peer.pendingBytes + reservedBytes <= MAX_TRANSPORT_PENDING_BYTES
     );
+    // link 已 ready 时,native send buffer 满就在**任何驱逐/腾位之前**拒绝:
+    // 该帧本轮注定入不了队,先驱逐再拒绝会在连续调用下逐步清空本可重试的
+    // 镜像历史,却一帧未纳(review P1)。link 未恢复时不检——帧只进有界
+    // pending 等重放,不触碰 socket。
+    if (peer.linkReady) {
+      this.assertWebSocketCapacity(this.measureReliableFrames(frames));
+    }
     if (!hasPendingCapacity()) {
       if (env.kind === 'invoke-result') {
         // invoke-result 是控制端确认被控端存活的唯一凭据，绝不能被堆积的可丢弃
         // 帧饿死：丢弃整个队头可丢弃前缀（fresh push 一并放弃——单 FIFO 无法同时
         // 做到 push 无损与 result 抢占），让 result 成为最早可交付的 live seq。
         this.dropDiscardablePendingPrefix(env.dst, peer, false, 'to make room for invoke-result');
-      } else if (env.kind === 'push') {
+      } else if (env.kind === 'push' && !isFlowControlledPushEnvelope(env)) {
         // push 是尽力而为的状态镜像（控制端重连/回前台会整体 resync + 重新订阅）。
         // 拥塞即对端未在 ACK：2026-08-07 线上该形态一小时内 5168 次连续
         // BACKPRESSURE（maker:event），镜像状态一条都没交付，只放大重试风暴。
-        // latest-wins：只从队头驱逐最旧的可丢弃帧直到放得下（剩余镜像历史保留，
-        // 对端恢复后仍可交付最新状态）；队头是 live 帧时无位可让，维持原
-        // BACKPRESSURE 语义。只删队头 → baseSeq 单调前移，无 seq 空洞。
+        // latest-wins：只从队头驱逐最旧的可丢弃镜像帧直到放得下（剩余镜像历史
+        // 保留，对端恢复后仍可交付最新状态）；队头是 live 帧或流控 push 时无位
+        // 可让，维持原 BACKPRESSURE 语义。只删队头 → baseSeq 单调前移，无 seq 空洞。
         this.dropOldestDiscardableForPushAdmission(env.dst, peer, reservedBytes);
       } else {
-        // live invoke 的入队压力只做 TTL 兜底清扫：过期 push 已无实时价值，先出队
-        // 腾位；新鲜 push 不互相驱逐（invoke 不能以丢镜像为代价抢占）。
+        // live invoke 与流控 push（FLOW_CONTROLLED_PUSH_CHANNELS，发送方以
+        // BACKPRESSURE 为流控信号）的入队压力只做 TTL 兜底清扫：过期 push 已无
+        // 实时价值，先出队腾位；新鲜 push 不互相驱逐（这两类帧不能以丢镜像
+        // 为代价抢占）。
         this.dropDiscardablePendingPrefix(env.dst, peer, true, 'after pending push TTL expiry');
       }
     }
@@ -2098,12 +2131,8 @@ export class DeviceLinkClient {
         `reliable transport buffer is full for peer ${env.dst.slice(0, 8)}`,
       );
     }
-    // link 暂未恢复时先进入有界 pending，等 link-open/link-accept 后再发。
-    // 已经 ready 的初次发送若 native send buffer 满，则在占用 seq 前拒绝，
-    // 避免一个从未发出的 seq 堵住累计 ACK。
-    if (peer.linkReady) {
-      this.assertWebSocketCapacity(this.measureReliableFrames(frames));
-    }
+    // link 暂未恢复时帧先进入有界 pending，等 link-open/link-accept 后再发
+    // （ws 容量已在驱逐前预检）。
     const pending: PendingReliableMessage = {
       seq,
       envelope: env,
@@ -2235,6 +2264,8 @@ export class DeviceLinkClient {
         receive: new Map(),
         highestAckSeq: 0,
         lastReplayEpoch: this.connEpoch,
+        pushAdmissionDropCount: 0,
+        pushAdmissionDropLogAt: 0,
       };
       this.peerTransport.set(dst, peer);
     }
@@ -2514,16 +2545,22 @@ export class DeviceLinkClient {
   }
 
   /**
-   * push 入队的拥塞腾位（latest-wins）：只从队头连续移除最旧的可丢弃帧，直到
-   * 放得下新帧或队头变成 live 帧。与 dropDiscardablePendingPrefix 的区别是「按需
+   * push 入队的拥塞腾位（latest-wins）：只从队头连续移除最旧的可驱逐帧，直到
+   * 放得下新帧或队头变成不可驱逐帧。与 dropDiscardablePendingPrefix 的区别是「按需
    * 腾位」而非「整段前缀丢弃」：对端只是暂时未 ACK 时，队列里较新的镜像历史保留
    * 下来，恢复后仍能交付；被驱逐的最旧镜像由控制端 resync 补偿，不是静默丢数据。
-   * 队头是 live invoke/invoke-result 时无位可让（保留会制造 seq 空洞的帧），调用方
-   * 按容量复检结果维持原 BACKPRESSURE 语义。只删队头 → baseSeq 单调前移，接收端
-   * 按新基线整体跳过被驱逐 seq，无空洞、不挂累计 ACK。
+   *
+   * 可驱逐判据比 isDiscardablePending 更窄：流控 push（FLOW_CONTROLLED_PUSH_CHANNELS）
+   * 虽是 push kind，但发送方以 BACKPRESSURE 为流控信号、帧是有序数据流，被镜像
+   * 洪峰静默驱逐 = 发送方以为已送达而接收端永远拼不出传输——它们与 live
+   * invoke/invoke-result 一样是腾位边界。队头不可驱逐时无位可让（跨过会制造
+   * seq 空洞），调用方按容量复检结果维持原 BACKPRESSURE 语义。只删队头 →
+   * baseSeq 单调前移，接收端按新基线整体跳过被驱逐 seq，无空洞、不挂累计 ACK。
    *
    * 生产反例（2026-08-07，P0 度量实锤）：对端停 ACK 时新鲜 push 之间互相背压，
    * 每条新 push 都抛 BACKPRESSURE，一小时 5168 次（maker:event），镜像零交付。
+   * 告警按 peer 聚合（PUSH_ADMISSION_DROP_LOG_INTERVAL_MS 窗口）：洪峰期驱逐
+   * 逐条 warn 会把 5168 次背压风暴换成 5168 行日志风暴（review P2）。
    */
   private dropOldestDiscardableForPushAdmission(
     dst: string,
@@ -2538,14 +2575,28 @@ export class DeviceLinkClient {
       const head = peer.pending.entries().next();
       if (head.done) break;
       const [seq, pending] = head.value;
-      if (!this.isDiscardablePending(pending)) break;
+      if (
+        !this.isDiscardablePending(pending)
+        || isFlowControlledPushEnvelope(pending.envelope)
+      ) break;
       this.removePendingEntry(peer, seq, pending);
       dropped += 1;
     }
     if (dropped > 0) {
-      this.log.warn(
-        `dropped ${dropped} oldest discardable pending frame(s) for peer ${dst.slice(0, 8)} latest-wins push admission`,
-      );
+      peer.pushAdmissionDropCount += dropped;
+      const now = this.monotonicNow();
+      // 首次驱逐(lastLogAt=0)立即告警,之后按窗口聚合——单调时钟起点接近 0,
+      // 纯差值判据会把进程早期的首次驱逐静默吞掉。
+      if (
+        peer.pushAdmissionDropLogAt === 0
+        || now - peer.pushAdmissionDropLogAt >= PUSH_ADMISSION_DROP_LOG_INTERVAL_MS
+      ) {
+        this.log.warn(
+          `dropped ${peer.pushAdmissionDropCount} oldest discardable pending frame(s) for peer ${dst.slice(0, 8)} latest-wins push admission (aggregated since last report)`,
+        );
+        peer.pushAdmissionDropCount = 0;
+        peer.pushAdmissionDropLogAt = now;
+      }
     }
     return dropped;
   }

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -40,29 +40,33 @@ import {
   parseTransportPayload,
   byteLength,
 } from './transport.js';
-import { SESSION_ACTIVITY_CHANNEL } from './topics.js';
-
 const DUPLICATE_CONNECTION_CLOSE_CODE = 4409;
 /**
- * latest-wins 腾位适用的**可合并镜像通道白名单**(review 两轮 P1 收敛:先是
- * contacts-sync 黑名单,再反转为白名单)。push 单 FIFO 上混着两类语义:
+ * latest-wins 腾位适用的**可驱逐通道白名单**(review 三轮收敛:contacts-sync
+ * 黑名单 → 白名单 → 收缩到单通道)。push 单 FIFO 上混着三类语义,只有第一类
+ * 可以参与传输层 latest-wins:
  *
- * - 可合并镜像/可再生流(本表):agent 事件流、会话活动快照、输入投影。丢最旧
- *   帧只损失中间态,最新状态由后续帧或控制端 resync 补偿;其中 maker:event 在
- *   旧语义下拥塞时本就丢**最新**帧(admission 拒收后 forwardPush 按 best-effort
- *   放弃),换成丢最旧不引入新的损失面。
- * - 不可合并事件/流控数据(表外全部,fail-closed):local-db:messages:created、
- *   maker:interaction-request(确认卡)、fs-watch 事件、contacts-sync 分片
- *   (发送方以 BACKPRESSURE 为流控信号,见 contacts-sync sender)等。拥塞驱逐
- *   发生时 link 并未断开,reconnect reseed 不会跑——静默驱逐 = UI 永久漏一条
- *   消息/确认卡,或分片传输永远拼不出。这类通道维持原背压语义。
+ * - 自相似有损事件流(本表,现仅 maker:event):流内每帧价值均匀且整流已是
+ *   契约——旧语义拥塞时本就丢**最新**帧(admission 拒收后 forwardPush 按
+ *   best-effort 放弃),换成丢最旧不引入新的损失面;转录内容由受保护的
+ *   local-db:messages:created + 控制端消息对账自愈,会话运行态由受保护的
+ *   status / activity 通道承载。
+ * - 键控/终态快照(sessions:activity、maker:input:projection):看似「镜像」
+ *   但**不满足跨帧可替代**——快照按 sessionId 键控,会话的 completed/error
+ *   收尾快照是该键的最后一帧,被其它键/其它通道的洪峰驱逐后不会再有后继帧
+ *   补偿;sessions:activity 的 staging(dispatch 层 latest-wins)在 sendPush
+ *   成功后即删暂存、不再重试,link 不重连 reseed 也不会跑,驱逐 = 手机端
+ *   永远显示 running(review 第三轮)。传输层不做同键比较(head-only 前缀
+ *   约束下同键驱逐在多会话混流时够不着队头,机制无效),这类通道整体回到
+ *   原背压语义,由各自上游的整流/重试契约保证送达。
+ * - 不可合并事件/流控数据(local-db:messages:created、确认卡、fs-watch、
+ *   contacts-sync 分片等):静默驱逐 = UI 永久漏事件或传输永久拼不出。
  *
- * 新增 push 通道默认**不可驱逐**;确属镜像语义需在此显式登记。
+ * 新增 push 通道默认**不可驱逐**(fail-closed);要进本表必须论证「流内自
+ * 相似、无键控终态、丢帧可由受保护通道自愈」三点。
  */
 const COALESCIBLE_PUSH_CHANNELS: ReadonlySet<string> = new Set([
   'maker:event',
-  SESSION_ACTIVITY_CHANNEL,
-  'maker:input:projection',
 ]);
 /** push 拥塞驱逐告警的 per-peer 聚合窗口:洪峰期逐条 warn 本身就是新的风暴。 */
 const PUSH_ADMISSION_DROP_LOG_INTERVAL_MS = 5_000;


### PR DESCRIPTION
## 这次改了什么

### 摘要

可靠传输缓冲满时，新 push 不再直接抛 `BACKPRESSURE`，而是从队头按需驱逐最旧的可丢弃帧（push / transport-skip 占位）腾位入队（latest-wins）；队头是 live invoke / invoke-result 时维持原背压语义。只删队头 → baseSeq 单调前移，接收端按新基线整体跳过，无 seq 空洞。

动机来自被控端生产日志（2026-08-07）：对端停 ACK 时「新鲜 push 互相背压」的旧语义导致一小时内 5168 次 `reliable transport buffer is full`（全部 maker:event），状态镜像零交付，只放大重试风暴，表现为手机端远程控制的秒级卡顿。push 本身是尽力而为的状态镜像（控制端重连/回前台会整体 resync + 重新订阅），latest-wins 后洪峰期队列自动轮换，保留最新的镜像历史供对端恢复后交付。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求：无（来自本地生产日志度量）
- 本 PR 包含：`packages/device-link` 发送端拥塞入队策略（`sendPeerEnvelope` 容量分支 + 新增 `dropOldestDiscardableForPushAdmission`）；配套单测新增 2 例、更新 3 处既有断言
- 明确不包含：wire protocol 变化（无新 kind / 字段，复用现有帧与 baseSeq 机制）；invoke / invoke-result 的背压语义；接收端逻辑；relay 侧
- 用户可见变化：拥塞期可丢弃镜像帧按「最旧优先」轮换丢弃而非整队拒收；远程控制实时状态在弱网下的交付率提升，`buffer is full` 告警从洪峰变为零星
- 是否存在 breaking change：无（对端协议行为不变：仍是按 baseSeq 跳过被驱逐 seq；BACKPRESSURE 在 live 帧队头场景仍会出现）

### UI 变化

不涉及：纯传输层（main 进程 packages/device-link），不触碰任何 renderer / UI 代码路径。

## 怎么验证的

### 自动验证

```text
cd packages/device-link
../../node_modules/.bin/vitest run
结果：Test Files 6 passed (6)，Tests 168 passed (168)
（含新增用例：「缓冲被未 ACK 的 push 占满时，新 push latest-wins 驱逐最旧帧入队，不再 BACKPRESSURE」「push 拥塞腾位不跨 live 帧：队头是 live invoke 时新 push 维持 BACKPRESSURE」）

cd packages/device-link
../../node_modules/.bin/tsc --noEmit
结果：exit 0

pnpm test:unit（根级提交门禁，含 packages/device-link unit tier）
结果：exit 0，PASS packages/device-link unit

pnpm --filter desktop typecheck
结果：exit 0
```

### 手工验证

不涉及（无 UI；行为验证由单测中的洪峰轮换与 live 队头边界用例覆盖）。

### 未执行的验证

mobile 端联调：本 PR 只改共享包发送端入队策略，mobile 侧作为接收端按既有 baseSeq 语义消化，无代码路径变化；如需端到端复测，建议在弱网模拟环境观察 `latest-wins push admission` 日志与镜像交付率。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 其他：传输层拥塞行为变化

### 影响与回滚

- 影响范围：仅发送端拥塞时的帧取舍策略。协议面（帧结构、baseSeq、ACK、link-open/accept/close 语义）零变化；新旧客户端混跑安全——对端只看到 baseSeq 前移，这是既有「建链/重放丢前缀」路径已在使用的机制。拥塞期最旧镜像帧会被提前丢弃（原语义下它们同样无法交付，只会以 BACKPRESSURE 形式反复失败），由控制端既有 resync 补偿。
- 回滚 / 降级方式：单 commit，`git revert` 即可完整回退；无持久化状态、无 migration、无能力协商变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（代码内注释含生产数据与不变量说明）
- [x] 已确认测试结果或说明未执行原因
