### PR TITLE
fix(codex): fork 走一次性 host 并瘦身响应，避免熔断全部活跃会话

### DIFF
--- a/apps/desktop/src/main/__tests__/fork.test.ts
+++ b/apps/desktop/src/main/__tests__/fork.test.ts
@@ -313,6 +313,8 @@ describe('forkSessionAtMessage', () => {
 
     expect(forkSdkSessionMock).toHaveBeenCalledWith('codex', {
       sourceSdkSessionId: 'codex-thread-source',
+      model: 'gpt-5.4',
+      providerId: 'xd',
       upToMessageId: undefined,
       tailTurnsToDrop: 2,
       title: '[Fork] Project A',
@@ -404,6 +406,8 @@ describe('forkSessionAtMessage', () => {
 
     expect(forkSdkSessionMock).toHaveBeenCalledWith('codex', {
       sourceSdkSessionId: 'codex-thread-source',
+      model: 'gpt-5.5',
+      providerId: 'xd',
       upToMessageId: undefined,
       title: '[Fork·已剥离] Project A',
       workingDir: '/work',
@@ -748,6 +752,8 @@ describe('forkSessionAtMessage', () => {
 
     expect(forkSdkSessionMock).toHaveBeenCalledWith('codex', {
       sourceSdkSessionId: 'parked-codex-thread',
+      model: 'gpt-5.4',
+      providerId: null,
       upToMessageId: undefined,
       tailTurnsToDrop: 2,
       title: '[Fork] Project A',
@@ -1091,6 +1097,8 @@ describe('forkSessionAtMessage', () => {
 
     expect(forkSdkSessionMock).toHaveBeenCalledWith('codex', {
       sourceSdkSessionId: 'codex-thread-source',
+      model: 'claude-sonnet-4-6',
+      providerId: 'xd',
       upToMessageId: undefined,
       tailTurnsToDrop: 1,
       title: '[Fork] Project A',

--- a/apps/desktop/src/main/maker-orchestration/fork.ts
+++ b/apps/desktop/src/main/maker-orchestration/fork.ts
@@ -568,6 +568,7 @@ export async function forkSessionAtMessage(
     const agentKind = dbToMakerAgentKind(forkSource.agentKind);
     const forkResult = await getMaker().forkSdkSession(agentKind, {
       sourceSdkSessionId: forkSource.sdkSessionId,
+      ...(isCodex ? { model: forkSource.model, providerId: forkSource.providerId } : {}),
       upToMessageId: assistantUuid,
       ...(tailTurnsToDrop !== undefined ? { tailTurnsToDrop } : {}),
       title: newTitle,
@@ -704,6 +705,8 @@ export async function forkSessionStripEncrypted(sourceSessionId: string): Promis
     : `[Fork·已剥离] ${source.title}`;
   const { newSdkSessionId, uuidMap } = await getMaker().forkSdkSession('codex', {
     sourceSdkSessionId: source.sdkSessionId,
+    model: source.model,
+    providerId: source.providerId,
     upToMessageId: undefined,
     title: newTitle,
     workingDir: source.workingDir ?? undefined,

--- a/packages/maker-core/src/agents/codex/app-server/protocol.ts
+++ b/packages/maker-core/src/agents/codex/app-server/protocol.ts
@@ -468,6 +468,12 @@ export interface ThreadForkParams {
   sandbox?: SandboxMode;
   /** Per-request config overrides, including named permission profile definitions. */
   config?: Record<string, unknown>;
+  /**
+   * 只返回 thread 元数据与 live fork state,不把完整历史塞进单条 NDJSON response。
+   * 与 thread/resume.excludeTurns 同族;超长历史 thread 的 fork 响应体与历史成
+   * 正比、无上界,曾实测单行 31MiB 超过 client maxLineBytes(16MiB)熔断整条连接。
+   */
+  excludeTurns?: boolean;
   [k: string]: unknown;
 }
 

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -433,11 +433,12 @@ function installFakeHost(
     discardPendingDescendantLineage: vi.fn(),
   };
 
+  const getHost = vi.fn(async () => host);
   Object.defineProperty(agent, 'getHost', {
-    value: async () => host,
+    value: getHost,
   });
 
-  return host;
+  return Object.assign(host, { getHost });
 }
 
 async function nextEvent(iterator: AsyncIterator<AgentEvent>): Promise<AgentEvent> {
@@ -13535,13 +13536,20 @@ describe('CodexAgent.forkSdkSession', () => {
       tailTurnsToDrop: 0,
     });
 
-    // The isolated host is created through the same provider-oauth credential
-    // path as the source session; this prevents custom-provider forks from
-    // falling back to unrelated local credentials.
+    expect(host.getHost).toHaveBeenCalledWith(
+      undefined,
+      'provider-oauth',
+      expect.objectContaining({
+        keyOverride: expect.stringMatching(/^local-fork:/),
+        hostPurpose: 'control-plane',
+      }),
+    );
     expect(host.request).toHaveBeenCalledWith(Method.ThreadFork, expect.objectContaining({
       threadId: 'source-thread-id',
     }));
-  });  it('forks from a temporary rollout copy without unsafe payload lines', async () => {
+  });
+
+  it('forks from a temporary rollout copy without unsafe payload lines', async () => {
     const agent = new CodexAgent(createDeps());
     let copied = '';
     const host = installFakeHost(agent, async (method, params) => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -5006,8 +5006,12 @@ describe('CodexAgent MCP thread context hooks', () => {
     });
 
     expect(result.newSdkSessionId).toMatch(/^fork-thread-/);
-    expect(createdTransports).toHaveLength(1);
+    // Fork runs on its own ephemeral host (fault-radius isolation): a second
+    // transport is spawned for the fork and retired when it finishes, while
+    // the explicit credential session host stays untouched and open.
+    expect(createdTransports).toHaveLength(2);
     expect(createdTransports[0].closed).toBe(false);
+    expect(createdTransports[1].closed).toBe(true);
     expect(prepareCodexLocalCredentialModeSwitch).not.toHaveBeenCalled();
 
     await handle.close();
@@ -13430,7 +13434,7 @@ describe('CodexAgent.forkSdkSession', () => {
     expect(host.unsubscribeThread).not.toHaveBeenCalledWith('source-thread-id');
   });
 
-  it('retires the captured host and rejects when a forked child cannot be unloaded', async () => {
+  it('retires the ephemeral fork host and rejects when a forked child cannot be unloaded', async () => {
     const agent = new CodexAgent(createDeps());
     const host = installFakeHost(agent);
     host.unsubscribeThread.mockRejectedValueOnce(new Error('unsubscribe failed'));
@@ -13448,15 +13452,75 @@ describe('CodexAgent.forkSdkSession', () => {
     })).rejects.toThrow('unsubscribe failed');
 
     expect(retireHostKey).toHaveBeenCalledWith(
-      'local',
-      'Codex fork child fork-thread-id could not be unloaded safely',
+      expect.stringMatching(/^local-fork:/),
+      'Codex fork host is single-use',
       expect.objectContaining({
         failIfActive: false,
-        logPrefix: 'codex fork child cleanup',
-        expectedGeneration: 0,
+        logPrefix: 'codex fork host cleanup',
       }),
     );
     expect(host.unsubscribeThread).not.toHaveBeenCalledWith('source-thread-id');
+  });
+
+  it('retires the ephemeral fork host after a successful fork', async () => {
+    const agent = new CodexAgent(createDeps());
+    installFakeHost(agent);
+    const retireHostKey = vi
+      .spyOn(
+        agent as unknown as { retireHostKey: (...args: unknown[]) => Promise<void> },
+        'retireHostKey',
+      )
+      .mockResolvedValue(undefined);
+
+    await agent.forkSdkSession({
+      sourceSdkSessionId: 'source-thread-id',
+      upToMessageId: undefined,
+      tailTurnsToDrop: 0,
+    });
+
+    expect(retireHostKey).toHaveBeenCalledTimes(1);
+    expect(retireHostKey).toHaveBeenCalledWith(
+      expect.stringMatching(/^local-fork:/),
+      'Codex fork host is single-use',
+      expect.objectContaining({
+        failIfActive: false,
+        logPrefix: 'codex fork host cleanup',
+      }),
+    );
+  });
+
+  it('requests excludeTurns on thread/fork when the daemon supports it', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, undefined, { userAgent: 'mock-codex/0.145.0' });
+
+    await agent.forkSdkSession({
+      sourceSdkSessionId: 'source-thread-id',
+      upToMessageId: undefined,
+      tailTurnsToDrop: 0,
+    });
+
+    expect(host.request).toHaveBeenCalledWith(Method.ThreadFork, {
+      threadId: 'source-thread-id',
+      persistExtendedHistory: true,
+      excludeTurns: true,
+    });
+  });
+
+  it('omits excludeTurns for daemons older than 0.145.0', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent, undefined, { userAgent: 'mock-codex/0.144.6' });
+
+    await agent.forkSdkSession({
+      sourceSdkSessionId: 'source-thread-id',
+      upToMessageId: undefined,
+      tailTurnsToDrop: 0,
+    });
+
+    const forkParams = host.request.mock.calls.find(([m]) => m === Method.ThreadFork)?.[1] as
+      | { excludeTurns?: boolean }
+      | undefined;
+    expect(forkParams).toBeDefined();
+    expect(forkParams?.excludeTurns).toBeUndefined();
   });
 
   it('forks from a temporary rollout copy without unsafe payload lines', async () => {

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -13523,7 +13523,25 @@ describe('CodexAgent.forkSdkSession', () => {
     expect(forkParams?.excludeTurns).toBeUndefined();
   });
 
-  it('forks from a temporary rollout copy without unsafe payload lines', async () => {
+  it('preserves source provider credentials on an isolated fork host', async () => {
+    const agent = new CodexAgent(createDeps());
+    const host = installFakeHost(agent);
+
+    await agent.forkSdkSession({
+      sourceSdkSessionId: 'source-thread-id',
+      model: 'gpt-5.4',
+      providerId: 'custom-provider',
+      upToMessageId: undefined,
+      tailTurnsToDrop: 0,
+    });
+
+    // The isolated host is created through the same provider-oauth credential
+    // path as the source session; this prevents custom-provider forks from
+    // falling back to unrelated local credentials.
+    expect(host.request).toHaveBeenCalledWith(Method.ThreadFork, expect.objectContaining({
+      threadId: 'source-thread-id',
+    }));
+  });  it('forks from a temporary rollout copy without unsafe payload lines', async () => {
     const agent = new CodexAgent(createDeps());
     let copied = '';
     const host = installFakeHost(agent, async (method, params) => {

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -10115,7 +10115,12 @@ export class CodexAgent extends BaseAgent {
       note: 'Codex 精确 fork: 独立一次性 host 上 thread/fork 后按需 thread/rollback 新 thread 尾部 turn',
     });
     try {
-      const host = await this.getHost(undefined, undefined, {
+      const forkCredentialMode = resolveAgentCredentialMode({
+        agentKind: 'codex',
+        providerId: opts.providerId,
+        model: opts.model,
+      });
+      const host = await this.getHost(undefined, forkCredentialMode, {
         keyOverride: forkHostKey,
         hostPurpose: 'control-plane',
       });

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -22,6 +22,7 @@
 
 import os from 'node:os';
 import path from 'node:path';
+import { randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { structuredPatch } from 'diff';
 
@@ -374,6 +375,22 @@ function isLocalControlPlaneHostKey(key: string): boolean {
 }
 
 /**
+ * 一次性 fork host key。thread/fork 的响应体与源 thread 历史成正比、无上界,
+ * 不能与正在服务活跃 session 的共享 host 同进程 —— 单条超限 NDJSON 会熔断整条
+ * 连接,把无关 session 一起拖下水(故障半径隔离,见 forkSdkSession)。
+ * 随机后缀保证并发 fork 互不复用。
+ */
+const LOCAL_FORK_HOST_PREFIX = 'local-fork:';
+
+function localForkHostKey(): string {
+  return `${LOCAL_FORK_HOST_PREFIX}${randomUUID()}`;
+}
+
+function isLocalForkHostKey(key: string): boolean {
+  return key.startsWith(LOCAL_FORK_HOST_PREFIX);
+}
+
+/**
  * maker permissionMode → app-server { approvalPolicy, approvalsReviewer, sandbox }。
  *
  * Phase 2 起 'ask' 走 'on-request' — server 真发 CommandExecutionRequestApproval,
@@ -464,6 +481,18 @@ function supportsCodexCapabilityRoutingProtocol(userAgent: string | undefined): 
  */
 function supportsCodexResumeExcludeTurns(userAgent: string | undefined): boolean {
   return codexUserAgentAtLeast(userAgent, [0, 125, 0]);
+}
+
+/**
+ * `thread/fork.excludeTurns` was verified against the app-server bundled with
+ * Codex 0.145.0. Without it, the fork response inlines the entire source-thread
+ * history in one NDJSON line — a 47MB rollout produced a 31MiB single line that
+ * exceeded the client's 16MiB maxLineBytes guard and killed the whole
+ * connection (2026-08-08 field incident). Older daemons keep the legacy
+ * full-history fork response.
+ */
+function supportsCodexForkExcludeTurns(userAgent: string | undefined): boolean {
+  return codexUserAgentAtLeast(userAgent, [0, 145, 0]);
 }
 
 const READONLY_REFERENCES_PERMISSION_PROFILE = 'cindy-readonly-references';
@@ -10048,41 +10077,30 @@ export class CodexAgent extends BaseAgent {
     const log = this.deps.logger.child('codex/fork');
     const tailTurnsToDrop = normalizeTailTurnsToDrop(opts.tailTurnsToDrop);
     let stripCopyPath: string | undefined;
-    let utilityHostKey: string | undefined;
-    let utilityHost: AppServerHost | undefined;
-    let utilityHostGeneration: number | undefined;
-    let utilityHostWasRegistered = false;
+    // 故障半径隔离(2026-08-08 实排):thread/fork 的响应体与源 thread 历史成正比、
+    // 无上界 —— 47MB rollout 实测产出 31MiB 单行 NDJSON,超过 client 16MiB
+    // maxLineBytes 守卫后整条连接被熔断,当时共享 utility host 上挂着的 5 个活跃
+    // session 全部同时报错。fork 是离线控制面操作(不跑 turn、无订阅者),改用
+    // 唯一 key 的一次性 app-server:超限只让 fork 自己失败,不波及活跃任务。
+    const forkHostKey = localForkHostKey();
+    let forkHost: AppServerHost | undefined;
     const createdThreadIds = new Set<string>();
     const cleanupCreatedThreads = async (): Promise<void> => {
-      if (!utilityHost || !utilityHostKey || createdThreadIds.size === 0) return;
+      if (!forkHost || createdThreadIds.size === 0) return;
       for (const threadId of createdThreadIds) {
         try {
-          // Codex 0.145 keeps a forked child loaded in the shared app-server.
-          // Unload it before the new Cindy Session resumes with its own MCP
-          // instance URL; otherwise thread/resume.config is ignored and the
-          // child remains bound to the utility host's spawn-level URL.
-          await utilityHost.unsubscribeThread(threadId);
+          // Codex 0.145 keeps a forked child loaded in the app-server. Unload
+          // it before the new Cindy Session resumes with its own MCP instance
+          // URL; otherwise thread/resume.config is ignored and the child
+          // remains bound to this host's spawn-level URL. The ephemeral host
+          // is retired right after, but graceful unload also flushes the
+          // child's state before the process dies.
+          await forkHost.unsubscribeThread(threadId);
         } catch (error) {
-          const reason = `Codex fork child ${threadId} could not be unloaded safely`;
-          log.warn('fork child cleanup failed; retiring shared app-server', {
+          log.warn('fork child cleanup failed; ephemeral fork host will be retired', {
             threadId,
             error: error instanceof Error ? error.message : String(error),
           });
-          try {
-            await this.retireHostKey(utilityHostKey, reason, {
-              failIfActive: false,
-              logPrefix: 'codex fork child cleanup',
-              ...(utilityHostWasRegistered ? { expectedHost: utilityHost } : {}),
-              ...(utilityHostGeneration !== undefined
-                ? { expectedGeneration: utilityHostGeneration }
-                : {}),
-            });
-          } catch (retireError) {
-            log.warn('fork child cleanup host retire threw', {
-              threadId,
-              error: retireError instanceof Error ? retireError.message : String(retireError),
-            });
-          }
           throw error;
         }
       }
@@ -10093,20 +10111,23 @@ export class CodexAgent extends BaseAgent {
       upToMessageId: opts.upToMessageId,
       tailTurnsToDrop,
       stripEncryptedReasoning: opts.stripEncryptedReasoning === true,
-      note: 'Codex 精确 fork: thread/fork 后按需 thread/rollback 新 thread 尾部 turn',
+      forkHostKey,
+      note: 'Codex 精确 fork: 独立一次性 host 上 thread/fork 后按需 thread/rollback 新 thread 尾部 turn',
     });
     try {
-      const utility = await this.getUtilityHost();
-      utilityHostKey = utility.key;
-      utilityHost = utility.host;
-      utilityHostGeneration = this.hostGenerations.get(utility.key) ?? 0;
-      utilityHostWasRegistered = this.hosts.get(utility.key) === utility.host;
-      const { host } = utility;
-      await host.ensureStarted();
+      const host = await this.getHost(undefined, undefined, {
+        keyOverride: forkHostKey,
+        hostPurpose: 'control-plane',
+      });
+      forkHost = host;
+      const initResp = await host.ensureStarted();
+      // createSafeForkRolloutCopy 扫描 this.codexHome;之前由共享 host 启动时填充,
+      // 隔离后 fork 可能是本进程第一台 host,须自己补上。
+      if (initResp.codexHome) this.codexHome = initResp.codexHome;
       // Imported Codex threads may still live under another CODEX_HOME. Resume
       // already asks the desktop host to link/adopt their state and rollout;
       // fork must cross the same preparation boundary before thread/fork or the
-      // utility app-server cannot resolve a freshly imported thread.
+      // fork app-server cannot resolve a freshly imported thread.
       const preparedRolloutResult = await this.deps.prepareCodexResumeSession?.(opts.sourceSdkSessionId);
       const preparedRolloutPath = typeof preparedRolloutResult === 'string'
         ? preparedRolloutResult
@@ -10121,6 +10142,10 @@ export class CodexAgent extends BaseAgent {
       const params: ThreadForkParams = {
         threadId: opts.sourceSdkSessionId,
         persistExtendedHistory: true,
+        // 响应体瘦身:fork 后 Cindy 自己的会话数据负责历史展示,thread.turns 全量
+        // 回传只会撑爆单行上限。老 daemon 不认识该字段则保持 legacy 行为 —— 此时
+        // 一次性 host 的隔离仍兜住故障半径。
+        ...(supportsCodexForkExcludeTurns(initResp.userAgent) ? { excludeTurns: true } : {}),
         ...(stripCopyPath ? { path: stripCopyPath } : {}),
         ...(opts.workingDir ? { cwd: opts.workingDir } : {}),
       };
@@ -10132,6 +10157,8 @@ export class CodexAgent extends BaseAgent {
           threadId: newSdkSessionId,
           numTurns: tailTurnsToDrop,
         };
+        // thread/rollback 没有 excludeTurns 对应物,响应仍可能携带完整历史;
+        // 超限时熔断的只是这台一次性 host,活跃 session 不受影响。
         const rollbackResp = await host.request<ThreadRollbackResponse>(
           Method.ThreadRollback,
           rollbackParams,
@@ -10146,6 +10173,20 @@ export class CodexAgent extends BaseAgent {
       try {
         await cleanupCreatedThreads();
       } finally {
+        // 一次性 host 用完即收,无论成败。key 唯一、无 session 绑定,
+        // retire 不会波及任何共享 host 或活跃会话。
+        if (forkHost) {
+          await this.retireHostKey(forkHostKey, 'Codex fork host is single-use', {
+            failIfActive: false,
+            logPrefix: 'codex fork host cleanup',
+            expectedHost: forkHost,
+          }).catch((err) => {
+            log.warn('fork host retire failed', {
+              forkHostKey,
+              err: err instanceof Error ? err.message : String(err),
+            });
+          });
+        }
         if (stripCopyPath) {
           await fs.rm(path.dirname(stripCopyPath), { recursive: true, force: true }).catch((err) => {
             log.warn('strip encrypted rollout temp cleanup failed', {
@@ -10238,10 +10279,10 @@ export class CodexAgent extends BaseAgent {
   async forceDisposeLocalHostForAuthChange(reason = 'CodexAgent local auth changed'): Promise<void> {
     const keys = new Set<string>([hostKey()]);
     for (const key of this.hosts.keys()) {
-      if (isLocalControlPlaneHostKey(key)) keys.add(key);
+      if (isLocalControlPlaneHostKey(key) || isLocalForkHostKey(key)) keys.add(key);
     }
     for (const key of this.hostPromises.keys()) {
-      if (isLocalControlPlaneHostKey(key)) keys.add(key);
+      if (isLocalControlPlaneHostKey(key) || isLocalForkHostKey(key)) keys.add(key);
     }
     await Promise.all(Array.from(keys, (key) =>
       this.retireHostKey(key, reason, {
@@ -10402,7 +10443,10 @@ export class CodexAgent extends BaseAgent {
     // 立即 push, 让所有 live thread 通过 server 端 reload_user_config 拿到新值
     try {
       const localSessionHosts = Array.from(this.hosts.entries()).filter(
-        ([key]) => !key.startsWith('remote:') && !isLocalControlPlaneHostKey(key),
+        ([key]) =>
+          !key.startsWith('remote:') &&
+          !isLocalControlPlaneHostKey(key) &&
+          !isLocalForkHostKey(key),
       );
       if (localSessionHosts.length === 0) {
         log.info('setMemory ◀ no live app-server, will apply on next session');

--- a/packages/maker-core/src/types/events.ts
+++ b/packages/maker-core/src/types/events.ts
@@ -363,6 +363,13 @@ export interface ForkSdkSessionOptions {
   /** 源 session 的 SDK sessionId (从 sessions.sdk_session_id 取)。 */
   sourceSdkSessionId: string;
   /**
+   * 源原生 session 的模型与供应商来源。Codex 的隔离 fork host 需要用相同上下文
+   * 解析 credential mode；否则 provider-oauth 源任务在本机没有 fallback 凭证时会
+   * 被误判为未登录。Claude/PI 不消费这两个字段。
+   */
+  model?: string;
+  providerId?: string | null;
+  /**
    * 截断锚点 — 必须是 SDK assistant 消息的 uuid (调用方反查 + 跳 subagent)。
    * Claude 必填; Codex 协议无 message uuid, 此字段被 CodexAgent 忽略,
    * 调用方传 undefined 即可。


### PR DESCRIPTION
## 这次改了什么

### 摘要

修一个会让**所有活跃任务同时失败**的线上故障。

2026-08-08 实排：对一个 6/21 起的长会话（rollout 文件 47MB）做 fork，codex
app-server 回了一条 **31MiB 的单行 NDJSON**（32,581,981 字节），超过 client 侧
16MiB 的 `maxLineBytes` 守卫。守卫按设计把超限行判为传输层故障并熔断整条连接——
而 fork 借用的是**共享 utility host**，于是挂在同一进程上的 5 个活跃 session
同时收到 `app-server transport error` 全部失败（各自重试时新起进程，所以「重试
又好了」）。

问题分两层，本 PR 两层都修：

1. **触发层**：`thread/fork` 的响应体与源 thread 历史成正比、无上界。改为带上
   `excludeTurns`，让 app-server 只回 thread 元数据与 live fork state；fork 后的
   历史展示本来就由 Cindy 自己的会话数据负责，不需要 app-server 内联全量 turns。
   已用 `strings` 对捆绑的 codex 0.145.0 二进制核实 `thread/fork.excludeTurns`
   确实存在；沿用既有 `resume.excludeTurns` 的门控惯例，老 daemon 省略该字段、
   保持 legacy 行为。

2. **爆炸半径层**：fork 是离线控制面操作（不跑 turn、无订阅者），没有理由和活跃
   会话共用进程。改为用唯一 key（`local-fork:<uuid>` + `hostPurpose:
   'control-plane'`）起**一次性 app-server**，`finally` 里无条件收割。这样即使
   `thread/rollback`（没有 excludeTurns 对应物）的响应仍然超限，熔断的也只是这台
   一次性进程，活跃会话完全无感。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：无（线上实排，日志见摘要）
- 本 PR 包含：`thread/fork` 的 `excludeTurns` 参数与版本门控；fork 改用一次性
  隔离 host；登出收割与 `setMemory` 的 host key 枚举补上新前缀；`codexHome` 回填。
- 明确不包含：调整 `maxLineBytes` 上限（治标不治本，放大只会推迟爆炸）；
  `thread/rollback` 的响应体瘦身（协议无对应字段，靠隔离兜住）；client 侧超限行
  的降级处理（超限意味着字节流可能已错位，跳过单行不安全，维持现状）。
- 用户可见变化：fork（分叉会话）不再可能连带打断其它正在运行的任务；对超长历史
  会话做 fork 从必然失败变为可用。
- 是否存在 breaking change：无

### UI 变化

不涉及

## 怎么验证的

### 自动验证

```text
packages/maker-core: npx vitest run src/agents/codex/index.test.ts
结果：424 passed (424)  ← 含本 PR 新增/更新的 5 个 fork 用例

packages/maker-core: pnpm run build（tsc --noEmit）
结果：错误集合与改动前逐条一致（存量测试文件本就有 69 处 TS 错误，非本 PR 引入；
      已用 stash 前后 diff 比对确认，改动本身零新增错误）

pnpm test:unit（仓库根，全量）
结果：22432 + 2067 passed，2 failed —— 两处失败均与本 PR 无关，见下「未执行的验证」
```

新增测试：
- fork 成功后收割一次性 host（key 匹配 `^local-fork:`）
- 0.145.0 daemon 下 `thread/fork` 带 `excludeTurns: true`
- 0.144.6 daemon 下省略 `excludeTurns`

更新测试（原断言的是「fork 复用 session host」这一被本 PR 改掉的行为，其**意图**
——fork 不得干扰 session 的 host——被保留并强化）：
- `does not retire an explicit credential host for Codex fork utility calls`：
  现在断言 fork 另起一条 transport 并在结束时关闭，而 session 的 transport 保持 open
- `retires the ephemeral fork host and rejects when a forked child cannot be unloaded`

### 手工验证

不涉及（故障路径需要一个 47MB rollout 的长会话才能复现；本 PR 的正确性由上述
单测 + 对 codex 0.145.0 二进制的协议字段核实覆盖）。

### 未执行的验证

全量 `pnpm test:unit` 有 2 处失败，均为**存量问题，与本 PR 无关**：

1. `packages/maker-core` — `rewind-runtime-settings.test.ts > cancels a
   post-rebuild send if Stop arrives during accept replay`：在**未改动的 main
   检出**上同样失败，3 次重跑稳定失败。
2. `apps/desktop` — `VolcengineSaucAsrProvider.test.ts > does not reopen a
   socket after stop while recovery is connecting`：单独跑（本 worktree 与 main
   均）通过，仅全量并发下偶发。

另：`main` 分支最近两次 push 的 client-ci 本身即为 failure，与上述基线一致。
按「失败与当前 PR diff 无关 → 不混入无关修复」处理，未在本 PR 中修。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 其他：多起一个短命 codex app-server 进程

### 影响与回滚

- 影响范围：仅 `CodexAgent.forkSdkSession` 一条路径。
  - **协议兼容**：新增的 `excludeTurns` 走 `codexUserAgentAtLeast([0,145,0])`
    门控，低版本 daemon（含可能比 desktop 活得更久的远端 daemon）不会收到未知
    字段，行为与改动前完全一致；此时隔离 host 仍独立兜住故障半径。
  - **进程开销**：每次 fork 多 spawn 一个 app-server，用完即 retire。fork 是低频
    用户主动操作，且原本也要走一次 `getUtilityHost()`；权衡上用一次短命进程换掉
    「拖垮所有活跃会话」的风险是划算的。
  - 一次性 host 的 key 唯一且无 session 绑定，`retireHostKey` 带 `expectedHost`
    身份闸，不可能误伤共享 host 或活跃会话。
- 回滚 / 降级方式：单 commit，`git revert` 即可完全回到旧行为，无数据迁移、无
  持久化状态、无 schema 变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`pnpm check:dco` 通过）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（协议字段与门控函数均有说明性注释，含实排背景）
- [x] 已确认测试结果或说明未执行原因
