### PR TITLE
fix(desktop): 修复同账号冷启动远程连接恢复

### DIFF
--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+import { shouldTeardownColdStartRuntime } from '../authColdStartBoundary';
 
 /** Regression guard for login progress that is intentionally owned by Electron main. */
 describe('auth login-flow reset', () => {
@@ -192,21 +194,40 @@ describe('auth login-flow reset', () => {
     expect(refreshBody).toContain('preservePersistedRefreshToken: true');
   });
 
-  it('does not tear down a same-account runtime during cold-start recovery', () => {
-    const coldStart = source.indexOf('async function runColdStartRefreshFlow(');
-    const coldEnd = source.indexOf('\n}\n\nasync function loadLoginProviders()', coldStart);
-    const coldBody = source.slice(coldStart, coldEnd);
+  it('does not call teardown for a fresh signed-out/null cold-start session', () => {
+    const teardown = vi.fn();
+    const previousAppSession = {
+      mode: 'signed-out' as const,
+      dataOwnerId: null,
+      generation: 0,
+    };
 
-    // Automatic relaunch restores the same cloud account. The startup DB and
-    // device-link runtime must remain alive; teardown is only for a real owner
-    // boundary (signed-out/local mode or a different account).
-    expect(coldBody).toContain('const previousAppSession = getActiveAppSession();');
-    expect(coldBody).toContain(
-      "previousAppSession.mode !== 'cloud' ||\n      previousAppSession.dataOwnerId !== refreshData.membership.id",
-    );
-    expect(coldBody).toContain(
-      'if (accountSwitchTeardown && needsColdStartAccountBoundary) {',
-    );
+    if (shouldTeardownColdStartRuntime(previousAppSession, 'account-1')) {
+      teardown();
+    }
+
+    expect(teardown).not.toHaveBeenCalled();
+  });
+
+  it('tears down only an already-committed runtime that crosses an owner boundary', () => {
+    expect(
+      shouldTeardownColdStartRuntime(
+        { mode: 'cloud', dataOwnerId: 'account-1', generation: 1 },
+        'account-1',
+      ),
+    ).toBe(false);
+    expect(
+      shouldTeardownColdStartRuntime(
+        { mode: 'cloud', dataOwnerId: 'account-1', generation: 1 },
+        'account-2',
+      ),
+    ).toBe(true);
+    expect(
+      shouldTeardownColdStartRuntime(
+        { mode: 'local', dataOwnerId: 'local-v1', generation: 1 },
+        'account-1',
+      ),
+    ).toBe(true);
   });
 
   it('drops a runtime refresh result after logout or a newer login changes auth generation', () => {

--- a/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
+++ b/apps/desktop/src/main/__tests__/authLoginFlowReset.test.ts
@@ -192,6 +192,23 @@ describe('auth login-flow reset', () => {
     expect(refreshBody).toContain('preservePersistedRefreshToken: true');
   });
 
+  it('does not tear down a same-account runtime during cold-start recovery', () => {
+    const coldStart = source.indexOf('async function runColdStartRefreshFlow(');
+    const coldEnd = source.indexOf('\n}\n\nasync function loadLoginProviders()', coldStart);
+    const coldBody = source.slice(coldStart, coldEnd);
+
+    // Automatic relaunch restores the same cloud account. The startup DB and
+    // device-link runtime must remain alive; teardown is only for a real owner
+    // boundary (signed-out/local mode or a different account).
+    expect(coldBody).toContain('const previousAppSession = getActiveAppSession();');
+    expect(coldBody).toContain(
+      "previousAppSession.mode !== 'cloud' ||\n      previousAppSession.dataOwnerId !== refreshData.membership.id",
+    );
+    expect(coldBody).toContain(
+      'if (accountSwitchTeardown && needsColdStartAccountBoundary) {',
+    );
+  });
+
   it('drops a runtime refresh result after logout or a newer login changes auth generation', () => {
     const refreshStart = source.indexOf('export async function refresh(): Promise<boolean> {');
     const refreshEnd = source.indexOf('\n}\n\nexport async function logout()', refreshStart);

--- a/apps/desktop/src/main/authColdStartBoundary.ts
+++ b/apps/desktop/src/main/authColdStartBoundary.ts
@@ -1,0 +1,20 @@
+import type { ActiveAppSession } from './appSessionState.js';
+
+/**
+ * Decide whether cold-start auth may need to tear down an existing owner runtime.
+ *
+ * `appSessionState` is process-local. A new process intentionally initializes a
+ * persisted `cloud` intent as `signed-out` with generation 0, before the
+ * refresh token proves the membership. There is no previous owner runtime in
+ * that process to tear down; the account-switch teardown hook is for a runtime
+ * that this process has already committed and may still own.
+ */
+export function shouldTeardownColdStartRuntime(
+  previousAppSession: Pick<ActiveAppSession, 'mode' | 'dataOwnerId' | 'generation'>,
+  nextOwnerId: string,
+): boolean {
+  if (previousAppSession.generation === 0) return false;
+  return (
+    previousAppSession.mode !== 'cloud' || previousAppSession.dataOwnerId !== nextOwnerId
+  );
+}

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -2219,14 +2219,24 @@ async function runColdStartRefreshFlow(
       commitActiveAppSession('signed-out');
       return snapshotLoggedOutAuthState();
     }
-    if (accountSwitchTeardown) {
+    const previousAppSession = getActiveAppSession();
+    const needsColdStartAccountBoundary =
+      previousAppSession.mode !== 'cloud' ||
+      previousAppSession.dataOwnerId !== refreshData.membership.id;
+    if (accountSwitchTeardown && needsColdStartAccountBoundary) {
       // Cold-start refresh may outlive initialize()'s startup timeout. Keep
       // the owner boundary held for the entire late commit sequence so stale
       // IPC cannot reopen the previous owner's database while teardown,
       // namespace claiming, and session publication are still in flight.
+      //
+      // A normal restart of the same cloud account is not an account switch.
+      // In that case the new process has no old in-memory owner runtime to
+      // tear down; calling this hook after localDb:ensure-ready would dispose
+      // the freshly-created DbClient and stop device-link, leaving the process
+      // permanently stuck at "DbClient not ready" until another restart.
       releaseBoundary = beginAppSessionBoundary();
       await accountSwitchTeardown({
-        previousUserId: getActiveAppSession().dataOwnerId ?? 'signed-out',
+        previousUserId: previousAppSession.dataOwnerId ?? 'signed-out',
         nextUserId: refreshData.membership.id,
       });
       if (epochChanged('after-cold-start-teardown')) {

--- a/apps/desktop/src/main/authManager.ts
+++ b/apps/desktop/src/main/authManager.ts
@@ -95,6 +95,7 @@ import {
   getActiveDataOwnerPushStamp,
   type AppSessionMode,
 } from './appSessionState.js';
+import { shouldTeardownColdStartRuntime } from './authColdStartBoundary.js';
 import {
   claimLegacyOwnerNamespace,
   recordLegacyGhostMigrationResult,
@@ -2220,9 +2221,10 @@ async function runColdStartRefreshFlow(
       return snapshotLoggedOutAuthState();
     }
     const previousAppSession = getActiveAppSession();
-    const needsColdStartAccountBoundary =
-      previousAppSession.mode !== 'cloud' ||
-      previousAppSession.dataOwnerId !== refreshData.membership.id;
+    const needsColdStartAccountBoundary = shouldTeardownColdStartRuntime(
+      previousAppSession,
+      refreshData.membership.id,
+    );
     if (accountSwitchTeardown && needsColdStartAccountBoundary) {
       // Cold-start refresh may outlive initialize()'s startup timeout. Keep
       // the owner boundary held for the entire late commit sequence so stale


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 在自动更新重启后恢复同一 Cloud 账号时，误把启动流程当成账号切换的问题。此前 `localDb:ensure-ready` 完成后会触发账号 teardown，刚初始化的 DbClient 和 device-link runtime 随即被销毁，进程之后持续处于 `DbClient not ready`，导致远程连接无法恢复。

根因是 `appSessionState` 只在进程内保存 owner；新进程会把持久化的 `cloud` 意图初始化为 `signed-out/null`，但这不代表存在可清理的旧 owner runtime。现在冷启动 teardown 判定先要求当前进程已经 commit 过 runtime（`generation > 0`），再检查是否真的跨越 owner 边界。

不变量：新进程同账号冷启动不执行 teardown；只有当前进程已有 owner runtime 且恢复到不同账号或不同模式时才执行 teardown。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 回归测试

### 范围

- 关联 Issue / 需求：无（由 Mac mini 自动更新重启后的远程连接故障触发）
- 本 PR 包含：Desktop auth 冷启动 owner-runtime 判定、纯判定 helper，以及 signed-out/null 冷启动和真实 owner 边界的回归测试。
- 明确不包含：未修改自动更新强退路径、device-link wire protocol、relay、数据库 schema 或服务端。
- 用户可见变化：Cindy 自动更新并重启后，同一账号的 Desktop 远程连接可继续恢复，无需再次手动重启。
- 是否存在 breaking change：无。

### UI 变化

不涉及：仅修改 Desktop main 侧认证生命周期判定和单元测试，没有界面、交互或文案变化。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-device-link-relaunch-recovery
结果：通过（GATE_EXIT=0）

pnpm --filter desktop exec vitest run src/main/__tests__/authLoginFlowReset.test.ts
结果：15 tests passed

pnpm --filter desktop typecheck
结果：通过

pnpm check:dco
结果：通过（2 commits signed off）
```

### 手工验证

在 2026 年 8 月 8 日通过 Cindy 自有远程连接重启 Mac mini 上的 Cindy，观察重启后的 main 日志：DbClient smoke、scheduler、embeddingHost 和 ownership 均正常启动；device-link 于 2026-08-08 19:26:34 NZST 上线，之后未继续出现新的 `DbClient not ready`。

### 未执行的验证

Windows/macOS 双平台实机验证未在本 PR 中执行；改动使用平台无关的 Desktop main 状态判定，现有自动化门禁已覆盖类型和单元测试。

## 风险

### 风险分类

- [x] 跨平台差异
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）

### 影响与回滚

- 影响范围：仅影响 Desktop 冷启动时是否执行账号 teardown。真正换账号、登出或本地模式仍保留原 teardown 路径；device-link 和移动端共用的服务端连接协议未改动，因此不会扩大 relay/link 故障半径，也不会影响其它 peer。
- 故障半径三问：本修复不新增 IPC、topic、relay 或重试机制；故障仍局限于当前 Desktop 进程的本地启动生命周期；移动端和其它已连接设备不会感知到该本地判定变化。
- 回滚 / 降级方式：回滚本 PR 的两个提交即可恢复原逻辑，不涉及数据迁移；升级到包含本修复的版本即可获得修复。

自动更新器的 `process.exit(0)` 强退路径未在本 PR 修改。该路径属于高风险更新链，按 `docs/dev-rules/cindy-updater.md` 需维护者确认后单独处理；本 PR 通过修复新实例的同账号冷启动边界，避免其继续 teardown 新 runtime。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI，已注明）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档：本 PR 不改变对外接口或行为契约，无需额外文档
- [x] 已确认测试结果或说明未执行原因
