### PR TITLE
ci: 并行拆分 Linux 单元测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,9 @@ env:
   NODE_OPTIONS: '--max-old-space-size=8192'
 
 jobs:
-  verify:
+  # 静态检查、类型检查和 runner 自测与 Linux 单测分片并行。这里不装
+  # bundled ripgrep；它只在 Desktop 单测收集时需要，由单测分片自行安装。
+  verify-checks:
     runs-on: ubuntu-latest
     timeout-minutes: 40
 
@@ -53,7 +55,7 @@ jobs:
           fi
           echo "cindy-protocol submodule 来源校验通过: $actual_url"
 
-      # 本 job 只做本仓 typecheck / 单测 / 各类 guard。cindy-protocol 是公开的
+      # 本 job 只做本仓 typecheck / runner 自测 / 各类 guard。cindy-protocol 是公开的
       # workspace 依赖,需要 checkout 以供 pnpm install 解析,但不在本 job 运行
       # 协议仓自己的 CI。
       # 公开客户端不包含内建插件种子；相关单测只在 os.tmpdir 里自造夹具。
@@ -90,14 +92,10 @@ jobs:
       - name: Build model-access protocol
         run: pnpm --filter @cindy/model-access-protocol build
 
-      # XDT_SKIP_AGENT_BIN_INSTALL 跳过了 postinstall 的全部 agent 二进制,但
-      # runtime-configs.ts 模块顶层的 bundledRipgrepDir() 缺 rg 时直接 throw,
-      # 会让 apps/desktop 单测在收集阶段全挂——ripgrep 必须单独装回来。
-      # install:ripgrep 不带 --best-effort,不受上面的 skip 环境变量影响。
-      - name: Install bundled ripgrep
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: pnpm install:ripgrep
+      # test:unit 的 runner 自测不能跟着 Vitest 分片重复执行；在检查 job 中跑一次，
+      # 两个 Linux 单测分片只负责 workspace unit tier。
+      - name: Run test runner self-tests
+        run: pnpm test:runner
 
       - name: Check endpoint literals
         run: pnpm check:endpoints
@@ -132,14 +130,97 @@ jobs:
           XDT_MIGRATION_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before || 'origin/main' }}
         run: pnpm --filter desktop db:validate
 
-      - name: Run client and package unit tests
-        run: pnpm test:unit
-
       - name: Run scheduler architecture guard
         run: pnpm ci:scheduler-guard
 
       - name: Run mobile scope guard
         run: pnpm --filter mobile test:scope
+
+  # Linux 单测使用与 Windows 相同的确定性 Vitest 分片。两个分片分别覆盖每个
+  # workspace 经 Vitest 切分后的测试文件，并集等于完整 unit tier；不重复 test:runner。
+  linux-unit-shards:
+    name: Linux unit tests (${{ matrix.shard }}/2)
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    env:
+      XDT_UNIT_TEST_SHARD: ${{ matrix.shard }}/2
+
+    steps:
+      - name: Checkout client
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          lfs: true
+
+      - name: Verify cindy-protocol submodule source
+        run: |
+          set -euo pipefail
+          expected_url='https://github.com/makecindy/cindy-protocol.git'
+          expected_path='cindy-protocol'
+          actual_url="$(git config -f .gitmodules --get submodule.cindy-protocol.url || true)"
+          actual_path="$(git config -f .gitmodules --get submodule.cindy-protocol.path || true)"
+          if [ "$actual_url" != "$expected_url" ] || [ "$actual_path" != "$expected_path" ]; then
+            echo "::error file=.gitmodules::cindy-protocol source mismatch: url='$actual_url' path='$actual_path' (expected url='$expected_url' path='$expected_path')"
+            exit 1
+          fi
+          echo "cindy-protocol submodule source verified: $actual_url"
+
+      - name: Fetch cindy-protocol submodule
+        run: |
+          git submodule sync -- cindy-protocol
+          git submodule update --init --force --recursive -- cindy-protocol
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+        with:
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build model-access protocol
+        run: pnpm --filter @cindy/model-access-protocol build
+
+      # XDT_SKIP_AGENT_BIN_INSTALL 跳过了 postinstall 的全部 agent 二进制,但
+      # runtime-configs.ts 模块顶层的 bundledRipgrepDir() 缺 rg 时直接 throw,
+      # 会让 apps/desktop 单测在收集阶段全挂——每个分片都必须单独装回来。
+      - name: Install bundled ripgrep
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: pnpm install:ripgrep
+
+      - name: Run client and package unit test shard
+        # 通过 pnpm 启动 runner，保留当前 pnpm 入口；否则嵌套的 protocol
+        # workspace 无法从主仓根 node_modules 解析 Vitest。
+        run: pnpm exec node scripts/test-workspaces.mjs --tier unit
+
+  # 保留原 required check 名 verify；检查 job 或任一 Linux 分片失败、取消都阻断。
+  verify:
+    name: verify
+    if: ${{ always() }}
+    needs:
+      - verify-checks
+      - linux-unit-shards
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require checks and both Linux unit shards
+        env:
+          VERIFY_CHECKS_RESULT: ${{ needs.verify-checks.result }}
+          LINUX_UNIT_SHARDS_RESULT: ${{ needs.linux-unit-shards.result }}
+        run: |
+          test "$VERIFY_CHECKS_RESULT" = "success"
+          test "$LINUX_UNIT_SHARDS_RESULT" = "success"
 
   # Linux 全绿不能覆盖 path separator、盘符、大小写和文件系统能力差异。两个
   # Windows 分片并行运行，分片并集仍完整覆盖 test:unit，不能缩成少量 smoke。

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,14 @@ jobs:
           git submodule sync -- cindy-protocol
           git submodule update --init --force --recursive -- cindy-protocol
 
+      # 分片会安装并执行 submodule 代码，不能只依赖并行的 verify-checks 最终阻断；
+      # 每个分片都必须在安装依赖前独立拒绝回滚、分叉或未发布的 gitlink。
+      - name: Reject cindy-protocol rollback or divergence
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          CINDY_PROTOCOL_BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/check-submodule-forward.mjs
+
       - name: Setup pnpm
         uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
         with:

--- a/scripts/__tests__/dev-docs-contract.test.mjs
+++ b/scripts/__tests__/dev-docs-contract.test.mjs
@@ -198,3 +198,33 @@ test("client CI keeps the complete two-shard unit gate on Windows", () => {
 	assert.match(gate, /^          WINDOWS_UNIT_SHARDS_RESULT: \$\{\{ needs\.windows-unit-shards\.result \}\}$/m);
 	assert.match(gate, /^        run: test "\$WINDOWS_UNIT_SHARDS_RESULT" = "success"$/m);
 });
+
+test("client CI runs Linux checks and complete unit shards in parallel behind stable verify", () => {
+	const workflow = readText(".github/workflows/ci.yml");
+	const checks = workflowJob(workflow, "verify-checks");
+	assert.ok(checks, "client CI must define independent Linux verification checks");
+	assert.doesNotMatch(checks, /^    needs:/m);
+	assert.match(checks, /^        run: pnpm test:runner$/m);
+	assert.doesNotMatch(checks, /node scripts\/test-workspaces\.mjs --tier unit/);
+
+	const shards = workflowJob(workflow, "linux-unit-shards");
+	assert.ok(shards, "client CI must define Linux unit shards");
+	assert.match(shards, /^    runs-on: ubuntu-latest$/m);
+	assert.doesNotMatch(shards, /^    needs:/m);
+	assert.match(shards, /^      fail-fast: false$/m);
+	assert.match(shards, /^        shard: \[1, 2\]$/m);
+	assert.match(shards, /^      XDT_UNIT_TEST_SHARD: \$\{\{ matrix\.shard \}\}\/2$/m);
+	assert.match(shards, /^        run: pnpm exec node scripts\/test-workspaces\.mjs --tier unit$/m);
+	assert.doesNotMatch(shards, /pnpm test:(?:unit|runner)/);
+
+	const gate = workflowJob(workflow, "verify");
+	assert.ok(gate, "client CI must preserve the stable verify check");
+	assert.match(gate, /^    name: verify$/m);
+	assert.match(gate, /^    if: \$\{\{ always\(\) \}\}$/m);
+	assert.match(gate, /^      - verify-checks$/m);
+	assert.match(gate, /^      - linux-unit-shards$/m);
+	assert.match(gate, /^          VERIFY_CHECKS_RESULT: \$\{\{ needs\.verify-checks\.result \}\}$/m);
+	assert.match(gate, /^          LINUX_UNIT_SHARDS_RESULT: \$\{\{ needs\.linux-unit-shards\.result \}\}$/m);
+	assert.match(gate, /^          test "\$VERIFY_CHECKS_RESULT" = "success"$/m);
+	assert.match(gate, /^          test "\$LINUX_UNIT_SHARDS_RESULT" = "success"$/m);
+});

--- a/scripts/__tests__/dev-docs-contract.test.mjs
+++ b/scripts/__tests__/dev-docs-contract.test.mjs
@@ -214,6 +214,10 @@ test("client CI runs Linux checks and complete unit shards in parallel behind st
 	assert.match(shards, /^      fail-fast: false$/m);
 	assert.match(shards, /^        shard: \[1, 2\]$/m);
 	assert.match(shards, /^      XDT_UNIT_TEST_SHARD: \$\{\{ matrix\.shard \}\}\/2$/m);
+	assert.match(shards, /^      - name: Reject cindy-protocol rollback or divergence$/m);
+	assert.match(shards, /^        if: \$\{\{ github\.event_name == 'pull_request' \}\}$/m);
+	assert.match(shards, /^          CINDY_PROTOCOL_BASE_REF: \$\{\{ github\.event\.pull_request\.base\.sha \}\}$/m);
+	assert.match(shards, /^        run: node scripts\/check-submodule-forward\.mjs$/m);
 	assert.match(shards, /^        run: pnpm exec node scripts\/test-workspaces\.mjs --tier unit$/m);
 	assert.doesNotMatch(shards, /pnpm test:(?:unit|runner)/);
 

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -124,9 +124,14 @@ test("client CI builds model-access protocol before consumer checks", () => {
 	).replace(/\r\n/g, "\n");
 	const jobs = [
 		{
-			name: "verify",
-			body: workflow.match(/\n  verify:\n([\s\S]*?)\n  windows-unit-shards:/)?.[1],
+			name: "verify-checks",
+			body: workflow.match(/\n  verify-checks:\n([\s\S]*?)\n  linux-unit-shards:/)?.[1],
 			consumerCommand: "run: pnpm --filter desktop typecheck",
+		},
+		{
+			name: "linux-unit-shards",
+			body: workflow.match(/\n  linux-unit-shards:\n([\s\S]*?)\n  verify:/)?.[1],
+			consumerCommand: "run: pnpm exec node scripts/test-workspaces.mjs --tier unit",
 		},
 		{
 			name: "windows-unit-shards",

--- a/scripts/__tests__/test-workspaces.test.mjs
+++ b/scripts/__tests__/test-workspaces.test.mjs
@@ -156,6 +156,21 @@ test("client CI builds model-access protocol before consumer checks", () => {
 	}
 });
 
+test("Linux unit shards reject unsafe protocol gitlinks before installing dependencies", () => {
+	const workflow = fs.readFileSync(
+		path.join(ROOT, ".github", "workflows", "ci.yml"),
+		"utf8",
+	).replace(/\r\n/g, "\n");
+	const body = workflow.match(/\n  linux-unit-shards:\n([\s\S]*?)\n  verify:/)?.[1];
+	assert.ok(body, "client CI must define Linux unit shards");
+	const fetchIndex = body.indexOf("git submodule update --init --force --recursive -- cindy-protocol");
+	const guardIndex = body.indexOf("run: node scripts/check-submodule-forward.mjs");
+	const installIndex = body.indexOf("run: pnpm install --frozen-lockfile");
+	assert.ok(fetchIndex >= 0, "Linux unit shards must fetch cindy-protocol");
+	assert.ok(guardIndex > fetchIndex, "Linux unit shards must validate the fetched protocol gitlink");
+	assert.ok(installIndex > guardIndex, "Linux unit shards must reject unsafe gitlinks before install");
+});
+
 test("help groups copyable desktop, binary, and Mobile workflows", async () => {
 	const { printHelp } = await import("../help.mjs");
 	const lines = [];


### PR DESCRIPTION
## 这次改了什么

### 摘要

把原来串行执行的 Linux `verify` 拆成并行的工程检查和两片单元测试，缩短 Linux 门禁的等待时间。保留名为 `verify` 的汇总检查，任一检查、分片失败、取消或跳过都会阻断。

### 为什么现在拆

GitHub Actions 当前可见的近期样本只有 2026 年 7 月 27 日至 8 月 8 日约 12 天，不能当作长期增长预测，但短期增长已经明显推高 Linux `verify`：

| 日期 | 单测文件 | 单测阶段 | `verify` 总时长 |
|---|---:|---:|---:|
| 7 月 27 日 | 1,734 | 6:58 | 9:00 |
| 7 月 30 日 | 1,931 | 7:55 | 10:15 |
| 8 月 2 日 | 2,150 | 9:17 | 11:41 |
| 8 月 5 日 | 2,284 | 10:36 | 13:21 |
| 8 月 8 日 | 2,369 | 11:05 | 13:49 |

这 12 天内：

- 单测文件增加 635 个，增长 36.6%。
- 单测阶段增加 4:07，增长约 59%。
- `verify` 总时长增加 4:49，增长 53.5%。
- 当前 Desktop 约占单测文件的 73%，近期新增测试约 79% 来自 Desktop，是主要增长来源。

开源初期提交密度较高，这个速度不应直接外推。两片是阶段性方案；如果较慢 Linux 分片连续多次超过 8 分钟，再评估从 2 片增加到 3 片，而不是提前消耗更多 runner。

### 变更类型

- [ ] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [x] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：将 Linux 静态检查、类型检查、migration、guard 和 runner 自测放入 `verify-checks`；用两个 Ubuntu matrix job 分片运行完整 unit tier；增加稳定的 `verify` 汇总门禁和对应契约测试；每个分片在安装依赖前独立拒绝 cindy-protocol 回滚、分叉或未发布 gitlink。
- 明确不包含：不调整 Windows 单元测试，不修改测试用例分组算法，不减少测试覆盖。
- 用户可见变化：无；仅调整 CI 调度。
- 是否存在 breaking change：无。

### 实际耗时变化

拆分前近期 Linux `verify` 约为 13:12～14:00。PR 首轮 GitHub Actions 实测：

| Job | 时长 |
|---|---:|
| `verify-checks` | 3:00 |
| Linux unit `1/2` | 6:16 |
| Linux unit `2/2` | 6:07 |
| `verify` 汇总 | 0:04 |

最新 head 的 Linux 门禁关键路径为 6:22，相比拆分前约 13:12～14:00，减少约 6:50～7:38，约 52%～55%。三个实际执行 job 与汇总合计约 15.5 runner-minutes，比拆分前增加约 1.5～2.3 runner-minutes（约 11%～17%）；峰值 Ubuntu runner 并发从 1 个增加为 3 个。Windows 最慢分片本轮为 10:32，整体 required checks 仍由 Windows 决定。

最新 head `5badef212` 的 GitHub Actions 已全部通过；每个 Linux 分片都会在安装依赖前独立执行 protocol 前进性校验。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；runner 自测 389 passed、1 skipped，全部 required unit workspace 通过。

CI=1 XDT_UNIT_TEST_SHARD=1/2 pnpm exec node scripts/test-workspaces.mjs --tier unit
结果：通过；第一片全部 required workspace 通过。

CI=1 XDT_UNIT_TEST_SHARD=2/2 pnpm exec node scripts/test-workspaces.mjs --tier unit
结果：通过；第二片全部 required workspace 通过。

CI=1 node --test scripts/__tests__/test-workspaces.test.mjs scripts/__tests__/dev-docs-contract.test.mjs
结果：83/83 通过。

YAML 解析与 git diff --check
结果：通过；verify-checks 和 linux-unit-shards 均无 needs，matrix 为 [1, 2]，verify 汇总依赖两者；分片顺序为 submodule update → protocol guard → pnpm install。

pnpm check:dco -- origin/main..HEAD
结果：通过，2 个 commit 均已签名。
```

### 手工验证

不涉及。

### 未执行的验证

未在本地模拟 Windows；Windows workflow 未改动。最新 head 的 GitHub Actions 已全部通过，包括干净 Ubuntu runner 上的 matrix、protocol guard、依赖安装和汇总门禁。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：CI 基础设施与 runner 并发

### 影响与回滚

- 影响范围：Linux `verify` 从一个串行 job 调整为检查 job、两个单测分片和汇总 job。首轮实测 Linux runner 总分钟数基本持平，但峰值并发增加；整体 required checks 仍可能由 Windows 决定。
- 回滚 / 降级方式：恢复为单个 `verify` job 内执行 `pnpm test:unit`；required check 名未变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因

