### PR TITLE
fix(mobile): 对齐自动重连状态展示

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -5034,6 +5034,8 @@ export default function SessionScreen() {
     markQueueItemSending(queued.clientId);
     try {
       // 弱网重试与写序边界同 send() 原路径(仅明确可安全重发的瞬时传输错误)。
+      const projectionEpochAtRequestStart =
+        remoteSessionStore.captureInputProjectionAuthorityEpoch(item.sessionId);
       let projection: InputProjection | undefined;
       for (let attempt = 0; ; attempt++) {
         try {
@@ -5048,7 +5050,11 @@ export default function SessionScreen() {
           await new Promise((resolve) => setTimeout(resolve, ENQUEUE_RECONNECT_BACKOFF_MS * 2 ** attempt));
         }
       }
-      remoteSessionStore.setInputProjection(item.sessionId, projection);
+      remoteSessionStore.setInputProjectionIfCurrent(
+        item.sessionId,
+        projection,
+        projectionEpochAtRequestStart,
+      );
     } catch (err) {
       // 与原路径同口径:先对账分辨「确实没应用」vs「已应用但响应丢了」。
       const applied = await (async () => {
@@ -5566,8 +5572,10 @@ export default function SessionScreen() {
           lockReady = true;
           editSaved = await commitQueueEdit(lockOwner, async () => {
             try {
+              const projectionEpochAtRequestStart =
+                remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
               const projection = await maker.input.updateContent(sessionId, editingQueueItem.clientId, updated);
-              applyProjection(projection);
+              applyProjectionIfCurrent(projection, projectionEpochAtRequestStart);
             } catch (err) {
               if (
                 isChannelNotAllowedError(err)
@@ -5581,6 +5589,8 @@ export default function SessionScreen() {
                 // RPC 之间断连)与其余失败分支对称:先还原编辑文本再抛,不许静默丢字
                 // (review P1)。
                 try {
+                  const projectionEpochAtRequestStart =
+                    remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
                   const projection = await maker.input.updateText(
                     sessionId,
                     editingQueueItem.clientId,
@@ -5588,7 +5598,7 @@ export default function SessionScreen() {
                     updated.sessionRefs,
                     updated.trustedSessionReferenceContexts,
                   );
-                  applyProjection(projection);
+                  applyProjectionIfCurrent(projection, projectionEpochAtRequestStart);
                 } catch (fallbackErr) {
                   restoreQueueEditDraftAfterFailure();
                   throw fallbackErr;
@@ -5778,6 +5788,8 @@ export default function SessionScreen() {
         // 不在 pendingQueue 里),盲重会双入队;这类歧义失败直接交给下方 catch
         // 的回滚/报错路径。BACKPRESSURE 在本地发送前或被控端 admission 拒绝
         // 执行时产生,可安全重发。被控端 enqueue 侧另有 clientId 幂等去重兜底。
+        const projectionEpochAtRequestStart =
+          remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
         let projection: InputProjection | undefined;
         for (let attempt = 0; ; attempt++) {
           try {
@@ -5792,7 +5804,11 @@ export default function SessionScreen() {
             await new Promise((resolve) => setTimeout(resolve, ENQUEUE_RECONNECT_BACKOFF_MS * 2 ** attempt));
           }
         }
-        remoteSessionStore.setInputProjection(sessionId, projection);
+        remoteSessionStore.setInputProjectionIfCurrent(
+          sessionId,
+          projection,
+          projectionEpochAtRequestStart,
+        );
       } catch (err) {
         // 回滚前先分辨「确实没应用」vs「已应用但响应丢了」:弱网下 enqueue 的 invoke
         // 响应可能超时丢失而桌面端已入队——此时摘除气泡会让手机隐藏一条桌面将处理的
@@ -5884,8 +5900,8 @@ export default function SessionScreen() {
     sendLatestRef.current = send;
   });
 
-  const applyProjection = useCallback((projection: InputProjection) => {
-    remoteSessionStore.setInputProjection(sessionId, projection);
+  const applyProjectionIfCurrent = useCallback((projection: InputProjection, expectedEpoch: number) => {
+    remoteSessionStore.setInputProjectionIfCurrent(sessionId, projection, expectedEpoch);
   }, [sessionId]);
 
   const runQueueAction = useCallback(async (
@@ -5894,15 +5910,19 @@ export default function SessionScreen() {
     if (queueBusy) return;
     setQueueBusy(true);
     setError(null);
+    const projectionEpochAtRequestStart =
+      remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
     try {
       const result = await action();
-      if (typeof result !== 'boolean') applyProjection(result);
+      if (typeof result !== 'boolean') {
+        applyProjectionIfCurrent(result, projectionEpochAtRequestStart);
+      }
     } catch (err) {
       setError(formatRemoteError(err));
     } finally {
       setQueueBusy(false);
     }
-  }, [applyProjection, queueBusy]);
+  }, [applyProjectionIfCurrent, queueBusy, sessionId]);
 
   /**
    * 乐观队列操作(remove / move 这类纯队列变换):先本地改 pendingQueue 当帧给反馈,
@@ -5922,9 +5942,13 @@ export default function SessionScreen() {
       sessionId,
       opts.optimistic(remoteSessionStore.getInputProjection(sessionId)),
     );
+    const projectionEpochAtRequestStart =
+      remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
     try {
       const result = await opts.action();
-      if (typeof result !== 'boolean') applyProjection(result);
+      if (typeof result !== 'boolean') {
+        applyProjectionIfCurrent(result, projectionEpochAtRequestStart);
+      }
     } catch (err) {
       remoteSessionStore.setInputProjection(
         sessionId,
@@ -5934,7 +5958,7 @@ export default function SessionScreen() {
     } finally {
       setQueueBusy(false);
     }
-  }, [applyProjection, queueBusy, sessionId]);
+  }, [applyProjectionIfCurrent, queueBusy, sessionId]);
 
   // stop 的视觉状态派生自 run status / projection,只有往返后才变;这里补一个本地
   // pending 态让按钮当帧转圈,消除「点了没反应」的歧义。
@@ -6112,15 +6136,17 @@ export default function SessionScreen() {
   };
 
   const setQueueEditLock = useCallback((clientId: string, locked: boolean) => {
+    const projectionEpochAtRequestStart =
+      remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
     return maker.input.setEditLock(sessionId, clientId, locked)
-      .then(applyProjection)
+      .then((projection) => applyProjectionIfCurrent(projection, projectionEpochAtRequestStart))
       .catch((err) => {
         if (queueEditingRef.current?.clientId === clientId) {
           setError(formatRemoteError(err));
         }
         throw err;
       });
-  }, [applyProjection, maker, sessionId]);
+  }, [applyProjectionIfCurrent, maker, sessionId]);
 
   const removeQueueItem = (clientId: string) => {
     const before = remoteSessionStore.getInputProjection(sessionId);
@@ -6445,8 +6471,14 @@ export default function SessionScreen() {
     try {
       const queued = buildQueuedTextMessage(sessionAtSend, prompt);
       queued.createOpts = { ...queued.createOpts, planMode: false };
+      const projectionEpochAtRequestStart =
+        remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
       const projection = await maker.input.enqueue(sessionId, queued, { sendAtMs: Date.now() });
-      remoteSessionStore.setInputProjection(sessionId, projection);
+      remoteSessionStore.setInputProjectionIfCurrent(
+        sessionId,
+        projection,
+        projectionEpochAtRequestStart,
+      );
     } catch (err) {
       if (state.kind === 'error-tail') {
         setRetryHiddenTailClientId((current) => (current === state.clientId ? null : current));

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -3134,19 +3134,27 @@ export default function SessionScreen() {
       const activeSessions = await maker.listActiveSessions().catch(() => []);
       return { activeSessions, activityEpochAtFetchStart };
     };
+    const fetchProjection = async () => {
+      // Capture immediately before every request. Because this helper is invoked inside
+      // withTransientRemoteRetry, each retry receives a fresh projection authority fence.
+      const authorityEpochAtStart =
+        remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
+      const projection = await maker.input.getProjection(sessionId);
+      return { projection, authorityEpochAtStart };
+    };
     if (syncRun.isStale()) return;
     setLoading(true);
     setError(null);
     try {
       if (!isReopen) {
         // 首开 / 强制替换:A1 全量并行(含整窗 listMessages),不回退。
-        const [sessionMeta, history, pendingInteractions, projection, activeSessionSnapshot] = await withTransientRemoteRetry(async () => {
+        const [sessionMeta, history, pendingInteractions, projectionResult, activeSessionSnapshot] = await withTransientRemoteRetry(async () => {
           await openAndSubscribe();
           return Promise.all([
             maker.getSession(sessionId),
             listMessagesWithPayloadRetry((limit) => maker.listMessages(sessionId, { limit })),
             maker.getPendingInteractions(sessionId),
-            maker.input.getProjection(sessionId),
+            fetchProjection(),
             fetchActiveSessionSnapshot(),
           ]);
         });
@@ -3172,15 +3180,19 @@ export default function SessionScreen() {
         remoteSessionStore.markSessionMessagesSynced(sessionId, sessionMeta);
         setHasOlderMessages(moreBeyondWindow);
         remoteSessionStore.setPendingInteractions(sessionId, Array.isArray(pendingInteractions) ? pendingInteractions : []);
-        remoteSessionStore.setInputProjection(sessionId, projection);
+        remoteSessionStore.setInputProjectionIfCurrent(
+          sessionId,
+          projectionResult.projection,
+          projectionResult.authorityEpochAtStart,
+        );
       } else {
         // 重开:便宜并行(不含整窗 listMessages)拿 meta + pending + projection + active。
-        const [sessionMeta, pendingInteractions, projection, activeSessionSnapshot] = await withTransientRemoteRetry(async () => {
+        const [sessionMeta, pendingInteractions, projectionResult, activeSessionSnapshot] = await withTransientRemoteRetry(async () => {
           await openAndSubscribe();
           return Promise.all([
             maker.getSession(sessionId),
             maker.getPendingInteractions(sessionId),
-            maker.input.getProjection(sessionId),
+            fetchProjection(),
             fetchActiveSessionSnapshot(),
           ]);
         });
@@ -3224,7 +3236,11 @@ export default function SessionScreen() {
         }
         remoteSessionStore.upsertDeviceSession(deviceId, deviceName, sessionMeta);
         remoteSessionStore.setPendingInteractions(sessionId, Array.isArray(pendingInteractions) ? pendingInteractions : []);
-        remoteSessionStore.setInputProjection(sessionId, projection);
+        remoteSessionStore.setInputProjectionIfCurrent(
+          sessionId,
+          projectionResult.projection,
+          projectionResult.authorityEpochAtStart,
+        );
       }
       // 不变量:上面 setHasOlderMessages 的校正(:806/:841/:846)与这里的 setLastSyncedAt 之间必须保持
       // 同步尾、无 await —— 否则乐观点亮 effect(依赖 lastSyncedAt===null)会在 await 间隙把刚校正成 false
@@ -5037,9 +5053,16 @@ export default function SessionScreen() {
       // 与原路径同口径:先对账分辨「确实没应用」vs「已应用但响应丢了」。
       const applied = await (async () => {
         try {
+          const projectionEpochAtRequestStart =
+            remoteSessionStore.captureInputProjectionAuthorityEpoch(item.sessionId);
           const fresh = await maker.input.getProjection(item.sessionId);
-          remoteSessionStore.setInputProjection(item.sessionId, fresh);
-          return fresh.pendingQueue.some((entry) => entry.clientId === queued.clientId);
+          const accepted = remoteSessionStore.setInputProjectionIfCurrent(
+            item.sessionId,
+            fresh,
+            projectionEpochAtRequestStart,
+          );
+          const current = accepted ? fresh : remoteSessionStore.getInputProjection(item.sessionId);
+          return current.pendingQueue.some((entry) => entry.clientId === queued.clientId);
         } catch {
           return remoteSessionStore.getInputProjection(item.sessionId).pendingQueue
             .some((entry) => entry.clientId === queued.clientId);
@@ -5777,9 +5800,18 @@ export default function SessionScreen() {
         // refetch 也失败再退回本地 store(订阅推送在此窗口内可能已带回该 clientId)。
         const applied = await (async () => {
           try {
+            const projectionEpochAtRequestStart =
+              remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
             const fresh = await maker.input.getProjection(sessionId);
-            remoteSessionStore.setInputProjection(sessionId, fresh);
-            return fresh.pendingQueue.some((item) => item.clientId === queued.clientId);
+            const accepted = remoteSessionStore.setInputProjectionIfCurrent(
+              sessionId,
+              fresh,
+              projectionEpochAtRequestStart,
+            );
+            // If a newer push/terminal boundary won the fence, the fetched value is
+            // stale for both the mirror and the applied decision; consult current state.
+            const current = accepted ? fresh : remoteSessionStore.getInputProjection(sessionId);
+            return current.pendingQueue.some((item) => item.clientId === queued.clientId);
           } catch {
             return remoteSessionStore.getInputProjection(sessionId).pendingQueue
               .some((item) => item.clientId === queued.clientId);
@@ -6067,8 +6099,14 @@ export default function SessionScreen() {
         deviceId,
       );
       const accepted = await maker.input.steer(sessionId, prepared, { removeFromQueue: true, touchUserSend: true });
+      const projectionEpochAtRequestStart =
+        remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
       const projection = await maker.input.getProjection(sessionId);
-      applyProjection(projection);
+      remoteSessionStore.setInputProjectionIfCurrent(
+        sessionId,
+        projection,
+        projectionEpochAtRequestStart,
+      );
       return accepted;
     });
   };

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -8098,6 +8098,11 @@ export default function SessionScreen() {
                     focusedRequestKey={focusedMessageRequestKey}
                     followLatestRequestKey={messageListFollowLatestRequestKey}
                     isSessionStreaming={isSessionStreaming}
+                    makerTurnRunning={makerTurnRunning}
+                    continuationTurnClientId={inputProjection.continuationTurnClientId}
+                    continuationInFlightProjectionCapability={
+                      inputProjection.continuationInFlightProjectionCapability
+                    }
                     items={messageListItems}
                     pendingSend={pendingSendActions}
                     loadingEarlier={loadingEarlier}

--- a/apps/mobile/src/__tests__/autoResumePresentation.test.ts
+++ b/apps/mobile/src/__tests__/autoResumePresentation.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canExpandMobileAutoResume,
+  getMobileAutoResumePresentation,
+  isMobileAutoResumeRowInFlight,
+  readMobileAutoResumeInfo,
+  summarizeMobileInterruption,
+  toggleMobileAutoResumeExpanded,
+} from '@/session/autoResumePresentation';
+
+describe('autoResumePresentation', () => {
+  const info = { error: 'API Error: socket   hang up. Please retry.', attempt: 2, maxAttempts: 5, sessionTotal: 3 };
+
+  it('keeps pending progress live while the continuation owner is in flight', () => {
+    expect(getMobileAutoResumePresentation({ ...info, live: true }).state).toBe('live');
+    const inFlight = isMobileAutoResumeRowInFlight({
+      isContinuationTurnOwner: true,
+      makerTurnRunning: true,
+      isLastUserInput: false,
+      projectionCapability: 'supported',
+    });
+
+    expect(getMobileAutoResumePresentation({ ...info }, inFlight).state).toBe('live');
+  });
+
+  it('uses the legacy fallback only for a legacy projection', () => {
+    const args = {
+      isContinuationTurnOwner: false,
+      makerTurnRunning: true,
+      isLastUserInput: true,
+    };
+    expect(isMobileAutoResumeRowInFlight({ ...args, projectionCapability: 'legacy' })).toBe(true);
+    expect(isMobileAutoResumeRowInFlight({ ...args, projectionCapability: 'supported' })).toBe(false);
+    expect(isMobileAutoResumeRowInFlight({ ...args, projectionCapability: 'unknown' })).toBe(false);
+  });
+
+  it('lets terminal outcomes win over a stale in-flight signal', () => {
+    expect(getMobileAutoResumePresentation({ ...info, outcome: 'succeeded' }, true).state).toBe('succeeded');
+    expect(getMobileAutoResumePresentation({ ...info, outcome: 'failed' }, true).state).toBe('failed');
+  });
+
+  it('shows a neutral recorded row when there is context but no live or terminal outcome', () => {
+    expect(getMobileAutoResumePresentation({ sessionTotal: 3 }).state).toBe('neutral');
+    expect(getMobileAutoResumePresentation({}).state).toBe('separator');
+  });
+
+  it('normalizes interruption context and keeps expansion bounded to useful detail', () => {
+    expect(readMobileAutoResumeInfo({ attempt: 0, maxAttempts: '5', outcome: 'unknown' })).toEqual({});
+    expect(summarizeMobileInterruption('  API Error: socket   hang up. Please retry. More detail.  '))
+      .toBe('socket hang up.');
+    expect(summarizeMobileInterruption(`API Error: ${'x'.repeat(80)}`)).toHaveLength(72);
+    expect(canExpandMobileAutoResume(info)).toBe(true);
+    expect(canExpandMobileAutoResume({})).toBe(false);
+    expect(toggleMobileAutoResumeExpanded(false, true)).toBe(true);
+    expect(toggleMobileAutoResumeExpanded(true, true)).toBe(false);
+    expect(toggleMobileAutoResumeExpanded(true, false)).toBe(false);
+  });
+});

--- a/apps/mobile/src/__tests__/inputProjection.test.ts
+++ b/apps/mobile/src/__tests__/inputProjection.test.ts
@@ -370,6 +370,31 @@ describe('inputProjection', () => {
     });
   });
 
+  it('distinguishes supported, legacy, and not-yet-received continuation ownership', () => {
+    expect(normalizeInputProjection(undefined)).toMatchObject({
+      continuationTurnClientId: null,
+      continuationInFlightProjectionCapability: 'unknown',
+    });
+    expect(normalizeInputProjection({ sessionId: 'legacy' })).toMatchObject({
+      continuationTurnClientId: null,
+      continuationInFlightProjectionCapability: 'legacy',
+    });
+    expect(normalizeInputProjection({
+      sessionId: 'supported-null',
+      continuationTurnClientId: null,
+    })).toMatchObject({
+      continuationTurnClientId: null,
+      continuationInFlightProjectionCapability: 'supported',
+    });
+    expect(normalizeInputProjection({
+      sessionId: 'supported-owner',
+      continuationTurnClientId: 'resume-1',
+    })).toMatchObject({
+      continuationTurnClientId: 'resume-1',
+      continuationInFlightProjectionCapability: 'supported',
+    });
+  });
+
   it('preserves and pauses queue only when Stop sees queued rows', () => {
     const queued = buildQueuedTextMessage(session(), 'later', new Date(), 'q-1');
 

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2667,11 +2667,13 @@ describe('remoteSessionStore', () => {
   });
 
   it('clears a continuation owner at a terminal boundary without a projection clear push', () => {
-    remoteSessionStore.setInputProjection('s1', {
+    const ownerProjection = {
       ...projection('s1'),
       continuationTurnClientId: 'resume-1',
-    });
+    };
+    remoteSessionStore.setInputProjection('s1', ownerProjection);
     remoteSessionStore.setSessionRunning('s1', true);
+    const operationEpoch = remoteSessionStore.captureInputProjectionAuthorityEpoch('s1');
 
     remoteSessionStore.applyRemotePush('dev-1', 'maker:status-changed', {
       sessionId: 's1',
@@ -2680,6 +2682,7 @@ describe('remoteSessionStore', () => {
 
     expect(remoteSessionStore.getInputProjection('s1').continuationTurnClientId).toBeNull();
     expect(remoteSessionStore.isSessionMakerTurnRunning('s1')).toBe(false);
+    expect(remoteSessionStore.setInputProjectionIfCurrent('s1', ownerProjection, operationEpoch)).toBe(false);
   });
 
   it('soft-invalidates an offline device without deleting sessions or messages', () => {

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2636,6 +2636,36 @@ describe('remoteSessionStore', () => {
     });
   });
 
+  it('rejects a late projection query after a newer push and terminal boundary', () => {
+    const ownerProjection = {
+      ...projection('s1'),
+      continuationTurnClientId: 'resume-1',
+    };
+    const expectedEpoch = remoteSessionStore.captureInputProjectionAuthorityEpoch('s1');
+    remoteSessionStore.setInputProjection('s1', ownerProjection);
+    const queryEpoch = remoteSessionStore.captureInputProjectionAuthorityEpoch('s1');
+
+    remoteSessionStore.applyRemotePush('dev-1', 'maker:input:projection', {
+      ...projection('s1'),
+      continuationTurnClientId: null,
+    });
+    remoteSessionStore.applyRemotePush('dev-1', 'maker:event', {
+      sessionId: 's1',
+      event: { type: 'done', data: {} },
+    });
+
+    expect(remoteSessionStore.setInputProjectionIfCurrent('s1', ownerProjection, queryEpoch)).toBe(false);
+    expect(remoteSessionStore.getInputProjection('s1').continuationTurnClientId).toBeNull();
+    expect(remoteSessionStore.isSessionMakerTurnRunning('s1')).toBe(false);
+    expect(remoteSessionStore.captureInputProjectionAuthorityEpoch('s1')).not.toBe(expectedEpoch);
+  });
+
+  it('accepts a projection query result when no newer authority event arrived', () => {
+    const expectedEpoch = remoteSessionStore.captureInputProjectionAuthorityEpoch('s1');
+    expect(remoteSessionStore.setInputProjectionIfCurrent('s1', projection('s1'), expectedEpoch)).toBe(true);
+    expect(remoteSessionStore.getInputProjection('s1').pendingQueue[0]?.clientId).toBe('q-1');
+  });
+
   it('soft-invalidates an offline device without deleting sessions or messages', () => {
     const meta = session('s1', {
       updatedAt: '2026-01-01T00:00:01.000Z',

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -2666,6 +2666,22 @@ describe('remoteSessionStore', () => {
     expect(remoteSessionStore.getInputProjection('s1').pendingQueue[0]?.clientId).toBe('q-1');
   });
 
+  it('clears a continuation owner at a terminal boundary without a projection clear push', () => {
+    remoteSessionStore.setInputProjection('s1', {
+      ...projection('s1'),
+      continuationTurnClientId: 'resume-1',
+    });
+    remoteSessionStore.setSessionRunning('s1', true);
+
+    remoteSessionStore.applyRemotePush('dev-1', 'maker:status-changed', {
+      sessionId: 's1',
+      status: 'closed',
+    });
+
+    expect(remoteSessionStore.getInputProjection('s1').continuationTurnClientId).toBeNull();
+    expect(remoteSessionStore.isSessionMakerTurnRunning('s1')).toBe(false);
+  });
+
   it('soft-invalidates an offline device without deleting sessions or messages', () => {
     const meta = session('s1', {
       updatedAt: '2026-01-01T00:00:01.000Z',

--- a/apps/mobile/src/__tests__/sendEnqueueRetry.test.ts
+++ b/apps/mobile/src/__tests__/sendEnqueueRetry.test.ts
@@ -17,14 +17,14 @@ describe('send enqueue weak-network retry ordering', () => {
 
   /**
    * 提取全部 enqueue 弱网重试循环体(send 原路径 + outbox 派发路径各一个),
-   * 每个循环以其后最近的「setInputProjection(…, projection);」为界。
+   * 每个循环以其后最近的 projection store 写入为界。
    * 两条路径共用同一套写序边界,守卫必须逐个覆盖,不能只查第一个。
    */
   const LOOP_MARKER = 'for (let attempt = 0; ; attempt++) {';
   const extractRetryLoops = (): string[] => {
     const loops: string[] = [];
     for (let from = source.indexOf(LOOP_MARKER); from > -1; from = source.indexOf(LOOP_MARKER, from + 1)) {
-      const endMatch = /remoteSessionStore\.setInputProjection\([^)]*, projection\);/.exec(source.slice(from));
+      const endMatch = /remoteSessionStore\.setInputProjection(?:IfCurrent)?\(\s*[^,]+,\s*projection(?:,\s*projectionEpochAtRequestStart)?\s*,?\s*\);/.exec(source.slice(from));
       expect(endMatch).not.toBeNull();
       loops.push(source.slice(from, from + (endMatch?.index ?? 0)));
     }

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -161,6 +161,13 @@ describe('mobile session main layer desktop-first noise budget', () => {
     expect(desktopSource).toContain('const titleClass');
     expect(desktopSource).not.toContain('SYSTEM');
     expect(cardSource).toContain('<Text style={styles.systemCardTitle}>{card.title}</Text>');
+    expect(cardSource).toContain('function MobileAutoResumeActionRow');
+    expect(cardSource).toContain('summarizeMobileInterruption');
+    expect(cardSource).toContain('message.systemCard.autoResume.detail.reason');
+    expect(cardSource).toContain('message.systemCard.autoResume.detail.attempt');
+    expect(cardSource).toContain('message.systemCard.autoResume.detail.sessionTotal');
+    expect(cardSource).toContain('CompactActivityIndicator');
+    expect(cardSource).toContain('message.systemCard.autoResume.pendingWithProgress');
     expect(cardSource).not.toContain('SYSTEM');
     expect(cardSource).not.toContain('systemCardEyebrow');
     expect(source).not.toContain('systemCardEyebrow: {');

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -162,12 +162,14 @@ describe('mobile session main layer desktop-first noise budget', () => {
     expect(desktopSource).not.toContain('SYSTEM');
     expect(cardSource).toContain('<Text style={styles.systemCardTitle}>{card.title}</Text>');
     expect(cardSource).toContain('function MobileAutoResumeActionRow');
-    expect(cardSource).toContain('summarizeMobileInterruption');
     expect(cardSource).toContain('message.systemCard.autoResume.detail.reason');
     expect(cardSource).toContain('message.systemCard.autoResume.detail.attempt');
     expect(cardSource).toContain('message.systemCard.autoResume.detail.sessionTotal');
     expect(cardSource).toContain('CompactActivityIndicator');
     expect(cardSource).toContain('message.systemCard.autoResume.pendingWithProgress');
+    expect(cardSource).toContain('importantForAccessibility="no-hide-descendants"');
+    expect(cardSource).toContain('accessible={false}');
+    expect(source).toMatch(/autoResumeHeader:\s*\{[\s\S]*?minHeight:\s*44,/);
     expect(cardSource).not.toContain('SYSTEM');
     expect(cardSource).not.toContain('systemCardEyebrow');
     expect(source).not.toContain('systemCardEyebrow: {');

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -1127,6 +1127,8 @@ async function rebuildSessionSnapshot(
     responsivenessCohort:
       opts?.responsivenessCohort ?? createDeviceSendCohort(deviceId),
   };
+  const projectionEpochAtRequestStart =
+    remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
   // 四路快照独立拉取、独立落库:断连补齐窗口本就脆弱,一个子请求失败不应拖垮
   // 其余(旧实现共用一个 catch,任一失败三份快照全丢)。goal 覆盖断连窗口内
   // 丢失的 maker:goal:status-changed push;model-pref / turn-cost 无对应查询通道,
@@ -1170,7 +1172,11 @@ async function rebuildSessionSnapshot(
     remoteSessionStore.setPendingInteractions(sessionId, pending.value, { finalizeStreaming: true });
   }
   if (projection.status === 'fulfilled' && projection.value) {
-    remoteSessionStore.setInputProjection(sessionId, projection.value);
+    remoteSessionStore.setInputProjectionIfCurrent(
+      sessionId,
+      projection.value,
+      projectionEpochAtRequestStart,
+    );
   }
   // undefined = 未拿到/未知(兼容形态的空返回),不能当作权威「无 goal」落库——
   // 那会把在世的 goal 卡清掉直到下一条 push;只有显式 null 才代表确认无 goal。

--- a/apps/mobile/src/i18n/locales/en/message.json
+++ b/apps/mobile/src/i18n/locales/en/message.json
@@ -183,7 +183,12 @@
       "neutral": "Reconnect",
       "pending": "Reconnecting…",
       "pendingWithProgress": "Reconnecting {{attempt}}/{{total}}…",
-      "details": "Attempt {{attempt}}/{{total}} · {{count}} reconnects in this session"
+      "details": "Attempt {{attempt}}/{{total}} · {{count}} reconnects in this session",
+      "detail": {
+        "reason": "Interruption reason",
+        "attempt": "Attempt {{attempt}}/{{total}}",
+        "sessionTotal": "{{count}} reconnects in this session"
+      }
     },
     "modelLabel": "Model",
     "sessionLabel": "Session",

--- a/apps/mobile/src/i18n/locales/ja/message.json
+++ b/apps/mobile/src/i18n/locales/ja/message.json
@@ -183,7 +183,12 @@
       "neutral": "再接続",
       "pending": "再接続中…",
       "pendingWithProgress": "再接続中 {{attempt}}/{{total}}…",
-      "details": "今回の再試行 {{attempt}}/{{total}} · このセッションでの再接続 {{count}} 回"
+      "details": "今回の再試行 {{attempt}}/{{total}} · このセッションでの再接続 {{count}} 回",
+      "detail": {
+        "reason": "中断の理由",
+        "attempt": "今回の再試行 {{attempt}}/{{total}}",
+        "sessionTotal": "このセッションでの再接続 {{count}} 回"
+      }
     },
     "modelLabel": "モデル",
     "sessionLabel": "セッション",

--- a/apps/mobile/src/i18n/locales/ko/message.json
+++ b/apps/mobile/src/i18n/locales/ko/message.json
@@ -183,7 +183,12 @@
       "neutral": "다시 연결",
       "pending": "다시 연결하는 중…",
       "pendingWithProgress": "다시 연결하는 중 {{attempt}}/{{total}}…",
-      "details": "이번 재시도 {{attempt}}/{{total}} · 이 세션에서 재연결 {{count}}회"
+      "details": "이번 재시도 {{attempt}}/{{total}} · 이 세션에서 재연결 {{count}}회",
+      "detail": {
+        "reason": "중단 원인",
+        "attempt": "이번 재시도 {{attempt}}/{{total}}",
+        "sessionTotal": "이 세션에서 재연결 {{count}}회"
+      }
     },
     "modelLabel": "모델",
     "sessionLabel": "세션",

--- a/apps/mobile/src/i18n/locales/zh-CN/message.json
+++ b/apps/mobile/src/i18n/locales/zh-CN/message.json
@@ -183,7 +183,12 @@
       "neutral": "重新连接",
       "pending": "重新连接中…",
       "pendingWithProgress": "重新连接中 {{attempt}}/{{total}}…",
-      "details": "本次重试 {{attempt}}/{{total}} · 本任务累计重连 {{count}} 次"
+      "details": "本次重试 {{attempt}}/{{total}} · 本任务累计重连 {{count}} 次",
+      "detail": {
+        "reason": "中断原因",
+        "attempt": "本次重试 {{attempt}}/{{total}}",
+        "sessionTotal": "本任务累计重连 {{count}} 次"
+      }
     },
     "modelLabel": "模型",
     "sessionLabel": "任务",

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -275,6 +275,12 @@ import type {
 } from '@/session/mediaPlayerWebViewHtml';
 import { formatMobileSystemCard } from '@/session/systemCard';
 import {
+  getMobileAutoResumePresentation,
+  isMobileAutoResumeRowInFlight,
+  toggleMobileAutoResumeExpanded,
+} from '@/session/autoResumePresentation';
+import type { ContinuationInFlightProjectionCapability } from '@/session/types';
+import {
   projectMobileWorkActivities,
   projectRecentMobileWorkActivities,
   type MobileProjectedThinkingActivity,
@@ -477,6 +483,14 @@ interface MessageActions {
   screenWidth?: number;
   /** 会话是否流式中:驱动工具行 running/done 状态(未 settled 且流式中才显示进行中)。 */
   isSessionStreaming?: boolean;
+  /** 当前 maker vendor turn 是否仍在运行；旧端续跑归属兜底只允许使用这条窄信号。 */
+  makerTurnRunning?: boolean;
+  /** 当前 vendor turn 的自动续跑 owner。 */
+  continuationTurnClientId?: string | null;
+  /** 只有明确识别为 legacy 的投影才允许使用最后一条输入的兼容判据。 */
+  continuationInFlightProjectionCapability?: ContinuationInFlightProjectionCapability;
+  /** 含自动续跑合成行、排除 steer 的最后一条用户输入。 */
+  lastUserInputClientId?: string | null;
 }
 
 export function MessageRenderer({
@@ -505,6 +519,9 @@ export function MessageRenderer({
   emptyTestID,
   bottomOverlayHeight,
   isSessionStreaming,
+  makerTurnRunning,
+  continuationTurnClientId,
+  continuationInFlightProjectionCapability,
   loadingEarlier,
   focusedRequestKey,
   queueFooter,
@@ -547,6 +564,7 @@ export function MessageRenderer({
   const { t } = useTranslation();
   const styles = useThemedStyles(makeStyles);
   const firstUserMessageClientId = findFirstUserMessageClientId(items);
+  const lastUserInputClientId = findLastUserInputClientId(items);
   const focusedItemKeyRef = useRef(focusedItemKey);
   focusedItemKeyRef.current = focusedItemKey;
   const listRef = useRef<LegendListRef>(null);
@@ -800,13 +818,21 @@ export function MessageRenderer({
     busyClientId,
     busyAction,
     firstUserMessageClientId,
+    lastUserInputClientId,
+    makerTurnRunning,
+    continuationTurnClientId,
+    continuationInFlightProjectionCapability,
     isSessionStreaming,
     screenWidth: viewportLayout.contentWidth,
   }), [
     busyClientId,
     busyAction,
+    continuationInFlightProjectionCapability,
+    continuationTurnClientId,
     firstUserMessageClientId,
     isSessionStreaming,
+    lastUserInputClientId,
+    makerTurnRunning,
     onCopyMessageLink,
     onAddMessageToComposer,
     onDeleteMessage,
@@ -1952,6 +1978,13 @@ function MessageBubble({
       ) : null}
       {item.message.systemCardType ? (
         <MobileSystemCard
+          autoResumeInFlight={isMobileAutoResumeRowInFlight({
+            isContinuationTurnOwner: clientId === actions.continuationTurnClientId,
+            makerTurnRunning: actions.makerTurnRunning === true,
+            isLastUserInput: clientId === actions.lastUserInputClientId,
+            projectionCapability:
+              actions.continuationInFlightProjectionCapability ?? 'unknown',
+          })}
           data={item.message.systemCardData}
           type={item.message.systemCardType}
         />
@@ -3229,9 +3262,11 @@ function MobileAgentSwitchCard({ data }: { data?: Record<string, unknown> }) {
 }
 
 function MobileSystemCard({
+  autoResumeInFlight,
   data,
   type,
 }: {
+  autoResumeInFlight?: boolean;
   data?: Record<string, unknown>;
   type: NonNullable<NormalizedRemoteMessage['systemCardType']>;
 }) {
@@ -3240,7 +3275,9 @@ function MobileSystemCard({
   if (type === 'agent-switch') return <MobileAgentSwitchCard data={data} />;
   // auto-resume 复用桌面 AgentActionRow 的单行状态布局:默认只显示当前状态和压缩后的
   // 中断原因,完整诊断按需展开,避免底层错误全文把手机消息流撑成一张大卡片。
-  if (type === 'auto-resume') return <MobileAutoResumeActionRow data={data} />;
+  if (type === 'auto-resume') {
+    return <MobileAutoResumeActionRow data={data} inFlight={autoResumeInFlight === true} />;
+  }
   const card = formatMobileSystemCard(type, data);
   return (
     <View style={styles.systemCard} testID={`message.systemCard.${type}`}>
@@ -3261,61 +3298,21 @@ function MobileSystemCard({
   );
 }
 
-interface MobileAutoResumeInfo {
-  error?: string;
-  attempt?: number;
-  maxAttempts?: number;
-  sessionTotal?: number;
-  outcome?: 'succeeded' | 'failed';
-}
-
-function readMobileAutoResumeInfo(data?: Record<string, unknown>): MobileAutoResumeInfo {
-  const number = (value: unknown) =>
-    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
-  const attempt = number(data?.attempt);
-  const maxAttempts = number(data?.maxAttempts);
-  const sessionTotal = number(data?.sessionTotal);
-  return {
-    ...(typeof data?.error === 'string' && data.error.trim() ? { error: data.error } : {}),
-    ...(attempt !== undefined ? { attempt } : {}),
-    ...(maxAttempts !== undefined ? { maxAttempts } : {}),
-    ...(sessionTotal !== undefined ? { sessionTotal } : {}),
-    ...(data?.outcome === 'succeeded' || data?.outcome === 'failed'
-      ? { outcome: data.outcome }
-      : {}),
-  };
-}
-
-function summarizeMobileInterruption(detail?: string): string | undefined {
-  if (!detail) return undefined;
-  const compact = detail
-    .replace(/^\s*API Error:\s*/i, '')
-    .replace(/\s+/g, ' ')
-    .trim();
-  if (!compact) return undefined;
-  const firstSentence = compact.split(/(?<=[.。!?！？])\s/)[0] ?? compact;
-  return firstSentence.length > 72 ? `${firstSentence.slice(0, 71)}…` : firstSentence;
-}
-
 function MobileAutoResumeActionRow({
   data,
+  inFlight,
 }: {
   data?: Record<string, unknown>;
+  inFlight: boolean;
 }) {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
-  const info = readMobileAutoResumeInfo(data);
-  const hasProgress = info.attempt !== undefined && info.maxAttempts !== undefined;
-  const hasInterruptionContext =
-    data?.live === true ||
-    info.error !== undefined ||
-    hasProgress ||
-    info.sessionTotal !== undefined ||
-    info.outcome !== undefined;
+  const presentation = getMobileAutoResumePresentation(data, inFlight);
+  const { canExpand, hasProgress, info, state, summary } = presentation;
 
-  if (!hasInterruptionContext) {
+  if (state === 'separator') {
     const label = t('message.systemCard.autoResume.separator');
     return (
       <View style={styles.autoResumeSeparator} testID="message.systemCard.auto-resume-separator">
@@ -3329,21 +3326,18 @@ function MobileAutoResumeActionRow({
     );
   }
 
-  const live = data?.live === true;
-  const label = live
+  const label = state === 'live'
     ? hasProgress
       ? t('message.systemCard.autoResume.pendingWithProgress', {
           attempt: info.attempt,
           total: info.maxAttempts,
         })
       : t('message.systemCard.autoResume.pending')
-    : info.outcome === 'succeeded'
+    : state === 'succeeded'
       ? t('message.systemCard.autoResume.succeeded')
-      : info.outcome === 'failed'
+      : state === 'failed'
         ? t('message.systemCard.autoResume.failed')
         : t('message.systemCard.autoResume.neutral');
-  const summary = summarizeMobileInterruption(info.error);
-  const canExpand = Boolean(info.error) || hasProgress || info.sessionTotal !== undefined;
   const accessibilityLabel = summary ? `${label}: ${summary}` : label;
 
   return (
@@ -3353,15 +3347,22 @@ function MobileAutoResumeActionRow({
         accessibilityRole={canExpand ? 'button' : undefined}
         accessibilityState={canExpand ? { expanded } : undefined}
         disabled={!canExpand}
-        onPress={canExpand ? () => setExpanded((value) => !value) : undefined}
+        onPress={canExpand
+          ? () => setExpanded((value) => toggleMobileAutoResumeExpanded(value, canExpand))
+          : undefined}
         style={({ pressed }) => [styles.autoResumeHeader, pressed && styles.pressed]}
       >
-        <View style={styles.autoResumeIconSlot} accessibilityElementsHidden>
-          {live ? (
+        <View
+          accessible={false}
+          accessibilityElementsHidden
+          importantForAccessibility="no-hide-descendants"
+          style={styles.autoResumeIconSlot}
+        >
+          {state === 'live' ? (
             <CompactActivityIndicator color={colors.textTertiary} size={iconSize.sm} />
-          ) : info.outcome === 'succeeded' ? (
+          ) : state === 'succeeded' ? (
             <Check color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
-          ) : info.outcome === 'failed' ? (
+          ) : state === 'failed' ? (
             <X color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
           ) : (
             <RefreshCw color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
@@ -5955,6 +5956,30 @@ function findFirstUserMessageClientIdInItem(
   return undefined;
 }
 
+function findLastUserInputClientId(items: readonly MobileMessageRenderItem[]): string | null {
+  for (let index = items.length - 1; index >= 0; index--) {
+    const found = findLastUserInputClientIdInItem(items[index]);
+    if (found) return found;
+  }
+  return null;
+}
+
+function findLastUserInputClientIdInItem(
+  item: MobileMessageRenderItem | MobileWorkChildItem,
+): string | null {
+  if (item.type === 'message' && item.message.role === 'user') {
+    const delivery = item.message.source.agentMeta?.delivery;
+    return delivery === 'steer' ? null : messageClientId(item);
+  }
+  if (item.type === 'work_group') {
+    for (let index = item.children.length - 1; index >= 0; index--) {
+      const found = findLastUserInputClientIdInItem(item.children[index]);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
 function messageClientId(item: MobileMessageItem): string {
   return item.message.source.clientId || item.message.source.id || item.message.key;
 }
@@ -6263,7 +6288,7 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
     alignItems: 'center',
     flexDirection: 'row',
     gap: spacing.xs,
-    minHeight: 40,
+    minHeight: 44,
     paddingHorizontal: spacing.xs,
   },
   autoResumeIconSlot: {

--- a/apps/mobile/src/session/MessageRenderer.tsx
+++ b/apps/mobile/src/session/MessageRenderer.tsx
@@ -19,6 +19,7 @@ import {
   Layers,
   ListTodo,
   LoaderCircle,
+  RefreshCw,
   PencilLine,
   Share as ShareIcon,
   Send,
@@ -3237,6 +3238,9 @@ function MobileSystemCard({
   const styles = useThemedStyles(makeStyles);
   // agent-switch 走专用「分隔线 + 药丸」渲染(对齐桌面),不落通用盒子卡片。
   if (type === 'agent-switch') return <MobileAgentSwitchCard data={data} />;
+  // auto-resume 复用桌面 AgentActionRow 的单行状态布局:默认只显示当前状态和压缩后的
+  // 中断原因,完整诊断按需展开,避免底层错误全文把手机消息流撑成一张大卡片。
+  if (type === 'auto-resume') return <MobileAutoResumeActionRow data={data} />;
   const card = formatMobileSystemCard(type, data);
   return (
     <View style={styles.systemCard} testID={`message.systemCard.${type}`}>
@@ -3251,6 +3255,161 @@ function MobileSystemCard({
               <Text style={styles.systemCardValue}>{row.value}</Text>
             </View>
           ))}
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+interface MobileAutoResumeInfo {
+  error?: string;
+  attempt?: number;
+  maxAttempts?: number;
+  sessionTotal?: number;
+  outcome?: 'succeeded' | 'failed';
+}
+
+function readMobileAutoResumeInfo(data?: Record<string, unknown>): MobileAutoResumeInfo {
+  const number = (value: unknown) =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+  const attempt = number(data?.attempt);
+  const maxAttempts = number(data?.maxAttempts);
+  const sessionTotal = number(data?.sessionTotal);
+  return {
+    ...(typeof data?.error === 'string' && data.error.trim() ? { error: data.error } : {}),
+    ...(attempt !== undefined ? { attempt } : {}),
+    ...(maxAttempts !== undefined ? { maxAttempts } : {}),
+    ...(sessionTotal !== undefined ? { sessionTotal } : {}),
+    ...(data?.outcome === 'succeeded' || data?.outcome === 'failed'
+      ? { outcome: data.outcome }
+      : {}),
+  };
+}
+
+function summarizeMobileInterruption(detail?: string): string | undefined {
+  if (!detail) return undefined;
+  const compact = detail
+    .replace(/^\s*API Error:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!compact) return undefined;
+  const firstSentence = compact.split(/(?<=[.。!?！？])\s/)[0] ?? compact;
+  return firstSentence.length > 72 ? `${firstSentence.slice(0, 71)}…` : firstSentence;
+}
+
+function MobileAutoResumeActionRow({
+  data,
+}: {
+  data?: Record<string, unknown>;
+}) {
+  const styles = useThemedStyles(makeStyles);
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const info = readMobileAutoResumeInfo(data);
+  const hasProgress = info.attempt !== undefined && info.maxAttempts !== undefined;
+  const hasInterruptionContext =
+    data?.live === true ||
+    info.error !== undefined ||
+    hasProgress ||
+    info.sessionTotal !== undefined ||
+    info.outcome !== undefined;
+
+  if (!hasInterruptionContext) {
+    const label = t('message.systemCard.autoResume.separator');
+    return (
+      <View style={styles.autoResumeSeparator} testID="message.systemCard.auto-resume-separator">
+        <View style={styles.autoResumeDivider} />
+        <View style={styles.autoResumeSeparatorPill}>
+          <RefreshCw color={colors.textTertiary} size={iconSize.xs} strokeWidth={iconStroke.regular} />
+          <Text style={styles.autoResumeSeparatorText}>{label}</Text>
+        </View>
+        <View style={styles.autoResumeDivider} />
+      </View>
+    );
+  }
+
+  const live = data?.live === true;
+  const label = live
+    ? hasProgress
+      ? t('message.systemCard.autoResume.pendingWithProgress', {
+          attempt: info.attempt,
+          total: info.maxAttempts,
+        })
+      : t('message.systemCard.autoResume.pending')
+    : info.outcome === 'succeeded'
+      ? t('message.systemCard.autoResume.succeeded')
+      : info.outcome === 'failed'
+        ? t('message.systemCard.autoResume.failed')
+        : t('message.systemCard.autoResume.neutral');
+  const summary = summarizeMobileInterruption(info.error);
+  const canExpand = Boolean(info.error) || hasProgress || info.sessionTotal !== undefined;
+  const accessibilityLabel = summary ? `${label}: ${summary}` : label;
+
+  return (
+    <View style={styles.autoResumeRow} testID="message.systemCard.auto-resume">
+      <Pressable
+        accessibilityLabel={accessibilityLabel}
+        accessibilityRole={canExpand ? 'button' : undefined}
+        accessibilityState={canExpand ? { expanded } : undefined}
+        disabled={!canExpand}
+        onPress={canExpand ? () => setExpanded((value) => !value) : undefined}
+        style={({ pressed }) => [styles.autoResumeHeader, pressed && styles.pressed]}
+      >
+        <View style={styles.autoResumeIconSlot} accessibilityElementsHidden>
+          {live ? (
+            <CompactActivityIndicator color={colors.textTertiary} size={iconSize.sm} />
+          ) : info.outcome === 'succeeded' ? (
+            <Check color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+          ) : info.outcome === 'failed' ? (
+            <X color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+          ) : (
+            <RefreshCw color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+          )}
+        </View>
+        <Text style={styles.autoResumeTitle} numberOfLines={1}>{label}</Text>
+        {summary ? (
+          <Text style={styles.autoResumeSummary} numberOfLines={1}>{summary}</Text>
+        ) : (
+          <View style={styles.autoResumeHeaderSpacer} />
+        )}
+        {canExpand ? (
+          expanded ? (
+            <ChevronDown color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+          ) : (
+            <ChevronRight color={colors.textTertiary} size={iconSize.sm} strokeWidth={iconStroke.regular} />
+          )
+        ) : null}
+      </Pressable>
+      {expanded && canExpand ? (
+        <View style={styles.autoResumeDetailPanel}>
+          {info.error ? (
+            <>
+              <Text style={styles.autoResumeDetailLabel}>
+                {t('message.systemCard.autoResume.detail.reason')}
+              </Text>
+              <Text selectable style={styles.autoResumeDetailText}>{info.error}</Text>
+            </>
+          ) : null}
+          {(hasProgress || info.sessionTotal !== undefined) ? (
+            <View style={[styles.autoResumeDetailMeta, info.error && styles.autoResumeDetailMetaWithReason]}>
+              {hasProgress ? (
+                <Text style={styles.autoResumeDetailMetaText}>
+                  {t('message.systemCard.autoResume.detail.attempt', {
+                    attempt: info.attempt,
+                    total: info.maxAttempts,
+                  })}
+                </Text>
+              ) : null}
+              {info.sessionTotal !== undefined ? (
+                <Text style={styles.autoResumeDetailMetaText}>
+                  {t('message.systemCard.autoResume.detail.sessionTotal', {
+                    count: info.sessionTotal,
+                  })}
+                </Text>
+              ) : null}
+            </View>
+          ) : null}
         </View>
       ) : null}
     </View>
@@ -6066,6 +6225,102 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   systemCardValue: {
     color: colors.textPrimary,
+    fontSize: typeScale.caption,
+    lineHeight: lineHeight.caption,
+  },
+  autoResumeSeparator: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  autoResumeDivider: {
+    backgroundColor: colors.border,
+    flex: 1,
+    height: StyleSheet.hairlineWidth,
+  },
+  autoResumeSeparatorPill: {
+    alignItems: 'center',
+    borderColor: colors.border,
+    borderRadius: radius.pill,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: 'row',
+    gap: spacing.xs,
+    maxWidth: '78%',
+    minHeight: 28,
+    paddingHorizontal: spacing.sm,
+  },
+  autoResumeSeparatorText: {
+    color: colors.textTertiary,
+    flexShrink: 1,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
+  },
+  autoResumeRow: {
+    alignSelf: 'stretch',
+  },
+  autoResumeHeader: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    gap: spacing.xs,
+    minHeight: 40,
+    paddingHorizontal: spacing.xs,
+  },
+  autoResumeIconSlot: {
+    alignItems: 'center',
+    height: 18,
+    justifyContent: 'center',
+    width: iconSize.md,
+  },
+  autoResumeTitle: {
+    color: colors.textSecondary,
+    flexShrink: 1,
+    flexGrow: 0,
+    fontSize: typeScale.footnote,
+    fontWeight: fontWeight.medium,
+  },
+  autoResumeSummary: {
+    color: colors.textSecondary,
+    flex: 1,
+    fontSize: typeScale.footnote,
+    minWidth: 0,
+  },
+  autoResumeHeaderSpacer: {
+    flex: 1,
+    minWidth: spacing.xs,
+  },
+  autoResumeDetailPanel: {
+    backgroundColor: colors.surfaceElevated,
+    borderColor: colors.border,
+    borderRadius: radius.control,
+    borderWidth: StyleSheet.hairlineWidth,
+    marginHorizontal: spacing.xs,
+    marginBottom: spacing.xs,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+  },
+  autoResumeDetailLabel: {
+    color: colors.textTertiary,
+    fontSize: typeScale.caption,
+    fontWeight: fontWeight.medium,
+  },
+  autoResumeDetailText: {
+    color: colors.textSecondary,
+    fontFamily: monoFont,
+    fontSize: typeScale.caption,
+    lineHeight: lineHeight.caption,
+    marginTop: 2,
+  },
+  autoResumeDetailMeta: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.md,
+  },
+  autoResumeDetailMetaWithReason: {
+    marginTop: spacing.sm,
+  },
+  autoResumeDetailMetaText: {
+    color: colors.textTertiary,
     fontSize: typeScale.caption,
     lineHeight: lineHeight.caption,
   },

--- a/apps/mobile/src/session/autoResumePresentation.ts
+++ b/apps/mobile/src/session/autoResumePresentation.ts
@@ -1,0 +1,98 @@
+import type { ContinuationInFlightProjectionCapability } from '@/session/types';
+
+export interface MobileAutoResumeInfo {
+  error?: string;
+  attempt?: number;
+  maxAttempts?: number;
+  sessionTotal?: number;
+  outcome?: 'succeeded' | 'failed';
+}
+
+export type MobileAutoResumeState = 'separator' | 'live' | 'succeeded' | 'failed' | 'neutral';
+
+export interface MobileAutoResumePresentation {
+  info: MobileAutoResumeInfo;
+  state: MobileAutoResumeState;
+  summary?: string;
+  hasProgress: boolean;
+  canExpand: boolean;
+}
+
+export function readMobileAutoResumeInfo(data?: Record<string, unknown>): MobileAutoResumeInfo {
+  const number = (value: unknown) =>
+    typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : undefined;
+  const attempt = number(data?.attempt);
+  const maxAttempts = number(data?.maxAttempts);
+  const sessionTotal = number(data?.sessionTotal);
+  return {
+    ...(typeof data?.error === 'string' && data.error.trim() ? { error: data.error } : {}),
+    ...(attempt !== undefined ? { attempt } : {}),
+    ...(maxAttempts !== undefined ? { maxAttempts } : {}),
+    ...(sessionTotal !== undefined ? { sessionTotal } : {}),
+    ...(data?.outcome === 'succeeded' || data?.outcome === 'failed'
+      ? { outcome: data.outcome }
+      : {}),
+  };
+}
+
+export function summarizeMobileInterruption(detail?: string): string | undefined {
+  if (!detail) return undefined;
+  const compact = detail
+    .replace(/^\s*API Error:\s*/i, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!compact) return undefined;
+  const firstSentence = compact.split(/(?<=[.。!?！？])\s/)[0] ?? compact;
+  return firstSentence.length > 72 ? `${firstSentence.slice(0, 71)}…` : firstSentence;
+}
+
+export function canExpandMobileAutoResume(info: MobileAutoResumeInfo): boolean {
+  return Boolean(info.error) || (info.attempt !== undefined && info.maxAttempts !== undefined)
+    || info.sessionTotal !== undefined;
+}
+
+export function getMobileAutoResumePresentation(
+  data: Record<string, unknown> | undefined,
+  inFlight = false,
+): MobileAutoResumePresentation {
+  const info = readMobileAutoResumeInfo(data);
+  const hasProgress = info.attempt !== undefined && info.maxAttempts !== undefined;
+  const hasInterruptionContext =
+    data?.live === true ||
+    info.error !== undefined ||
+    hasProgress ||
+    info.sessionTotal !== undefined ||
+    info.outcome !== undefined;
+
+  if (!hasInterruptionContext) {
+    return { info, state: 'separator', hasProgress, canExpand: false };
+  }
+
+  // A recorded terminal outcome wins over any stale live/in-flight signal.
+  const state: MobileAutoResumeState = info.outcome
+    ?? ((data?.live === true || inFlight) ? 'live' : 'neutral');
+  const summary = summarizeMobileInterruption(info.error);
+  return {
+    info,
+    state,
+    ...(summary ? { summary } : {}),
+    hasProgress,
+    canExpand: canExpandMobileAutoResume(info),
+  };
+}
+
+export function toggleMobileAutoResumeExpanded(expanded: boolean, canExpand: boolean): boolean {
+  return canExpand ? !expanded : false;
+}
+
+/** Mirror Desktop's continuation-owner rule, including its explicit legacy fallback. */
+export function isMobileAutoResumeRowInFlight(args: {
+  isContinuationTurnOwner: boolean;
+  makerTurnRunning: boolean;
+  isLastUserInput: boolean;
+  projectionCapability: ContinuationInFlightProjectionCapability;
+}): boolean {
+  return args.isContinuationTurnOwner || (
+    args.projectionCapability === 'legacy' && args.makerTurnRunning && args.isLastUserInput
+  );
+}

--- a/apps/mobile/src/session/autoResumePresentation.ts
+++ b/apps/mobile/src/session/autoResumePresentation.ts
@@ -42,7 +42,7 @@ export function summarizeMobileInterruption(detail?: string): string | undefined
     .replace(/\s+/g, ' ')
     .trim();
   if (!compact) return undefined;
-  const firstSentence = compact.split(/(?<=[.。!?！？])\s/)[0] ?? compact;
+  const firstSentence = compact.match(/^.*?[.。!?！？](?=\s|$)/)?.[0] ?? compact;
   return firstSentence.length > 72 ? `${firstSentence.slice(0, 71)}…` : firstSentence;
 }
 

--- a/apps/mobile/src/session/inputProjection.ts
+++ b/apps/mobile/src/session/inputProjection.ts
@@ -46,11 +46,18 @@ export const EMPTY_INPUT_PROJECTION: InputProjection = Object.freeze({
   recovery: null,
   errorRetryText: null,
   credentialSwitchWait: null,
+  continuationTurnClientId: null,
+  continuationInFlightProjectionCapability: 'unknown',
 });
 
 export function normalizeInputProjection(value: unknown, fallbackSessionId = ''): InputProjection {
   const record = readRecord(value);
   const pendingQueue = readQueuedMessages(record?.pendingQueue);
+  const continuationInFlightProjectionCapability = record === null
+    ? 'unknown'
+    : Object.prototype.hasOwnProperty.call(record, 'continuationTurnClientId')
+      ? 'supported'
+      : 'legacy';
   return {
     sessionId: readString(record?.sessionId) ?? fallbackSessionId,
     pendingQueue,
@@ -64,6 +71,8 @@ export function normalizeInputProjection(value: unknown, fallbackSessionId = '')
     recovery: record?.recovery,
     errorRetryText: readString(record?.errorRetryText),
     autoResumePending: readRecord(record?.autoResumePending),
+    continuationTurnClientId: readString(record?.continuationTurnClientId),
+    continuationInFlightProjectionCapability,
     credentialSwitchWait: readCredentialSwitchWait(record?.credentialSwitchWait),
   };
 }

--- a/apps/mobile/src/session/newSessionCreation.ts
+++ b/apps/mobile/src/session/newSessionCreation.ts
@@ -889,9 +889,15 @@ async function runPipeline(task: InternalTask): Promise<void> {
     }
     try {
       assertTaskOwnerCurrent(task);
+      const projectionEpochAtRequestStart =
+        remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
       const projection = await maker.input.enqueue(sessionId, queued, { sendAtMs: Date.now() });
       assertTaskOwnerCurrent(task);
-      remoteSessionStore.setInputProjection(sessionId, projection);
+      remoteSessionStore.setInputProjectionIfCurrent(
+        sessionId,
+        projection,
+        projectionEpochAtRequestStart,
+      );
     } catch (error) {
       if (isStaleNewSessionOwnerError(error)) throw error;
       // 有界轮询分辨(codex review P1):enqueue 超时时消息可能已被受理并瞬间

--- a/apps/mobile/src/session/newSessionCreation.ts
+++ b/apps/mobile/src/session/newSessionCreation.ts
@@ -714,9 +714,17 @@ async function isFirstMessageApplied(task: InternalTask): Promise<boolean | null
   )) return true;
   try {
     assertTaskOwnerCurrent(task);
+    const projectionEpochAtRequestStart =
+      remoteSessionStore.captureInputProjectionAuthorityEpoch(task.sessionId);
     const projection = await maker.input.getProjection(task.sessionId);
     assertTaskOwnerCurrent(task);
-    if (projection?.pendingQueue?.some((item) => item.clientId === clientId)) return true;
+    const accepted = remoteSessionStore.setInputProjectionIfCurrent(
+      task.sessionId,
+      projection,
+      projectionEpochAtRequestStart,
+    );
+    const current = accepted ? projection : remoteSessionStore.getInputProjection(task.sessionId);
+    if (current.pendingQueue.some((item) => item.clientId === clientId)) return true;
   } catch (error) {
     if (isStaleNewSessionOwnerError(error)) throw error;
     return null;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1891,6 +1891,21 @@ export const remoteSessionStore = {
     // A maker turn boundary supersedes any projection query that started
     // before it. This is the terminal fence for late owner snapshots.
     bumpInputProjectionAuthorityEpoch(sessionId);
+    // The terminal event is also authoritative for the continuation owner. A
+    // paired projection clear push may be lost during a disconnect, so clear a
+    // known owner here instead of leaving the mobile row live until rehydrate.
+    let continuationOwnerCleared = false;
+    if (!running) {
+      const currentProjection = inputProjections.get(sessionId);
+      if (currentProjection?.continuationTurnClientId) {
+        const nextProjection: InputProjection = {
+          ...currentProjection,
+          continuationTurnClientId: null,
+        };
+        continuationOwnerCleared = !deepValueEqual(currentProjection, nextProjection);
+        if (continuationOwnerCleared) inputProjections.set(sessionId, nextProjection);
+      }
+    }
     // 本方法只被 maker 权威信号调用(done / terminal error / status-changed closed),
     // 与 maker turn 边界同步;activity / 快照流走 writeSessionRunStatus,不经过这里。
     // 边界变化必须独立参与 emit 判定:activity 流可能已把宽 run status 置 false,此时
@@ -1907,7 +1922,10 @@ export const remoteSessionStore = {
       sideTaskRunning: running ? current.sideTaskRunning : false,
       startedAt: running ? (current.startedAt ?? Date.now()) : null,
     };
-    if (writeSessionRunStatus(sessionId, next) || turnBoundaryChanged || streamingChanged) emit();
+    if (writeSessionRunStatus(sessionId, next)
+      || turnBoundaryChanged
+      || streamingChanged
+      || continuationOwnerCleared) emit();
   },
 
   captureActiveSessionSnapshotEpoch(): number {

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -255,6 +255,12 @@ function interactionsByRequestId(list: readonly PendingInteraction[]): Map<strin
   return byId;
 }
 const inputProjections = new Map<string, InputProjection>();
+// Projection queries can resolve after a newer push or terminal boundary. Keep
+// a monotonic per-session authority epoch so late snapshots cannot overwrite
+// current queue / continuation state (mirrors Desktop makerChatStore).
+const inputProjectionAuthorityEpochs = new Map<string, number>();
+let nextInputProjectionAuthorityEpoch = 0;
+let inputProjectionAuthorityEpochFloor = 0;
 const sessionLiveActivity = new Map<string, RemoteSessionLiveActivity>();
 const sessionRunning = new Map<string, boolean>();
 const sessionRunStatus = new Map<string, RemoteSessionRunStatus>();
@@ -510,6 +516,19 @@ let deviceList: readonly { deviceId: string; name: string }[] | null = null;
 function emit(): void {
   storeVersion += 1;
   for (const sub of subs) sub();
+}
+
+function bumpInputProjectionAuthorityEpoch(sessionId: string): number {
+  const epoch = ++nextInputProjectionAuthorityEpoch;
+  inputProjectionAuthorityEpochs.set(sessionId, epoch);
+  return epoch;
+}
+
+function commitInputProjection(sessionId: string, next: InputProjection): boolean {
+  if (deepValueEqual(inputProjections.get(sessionId) ?? EMPTY_INPUT_PROJECTION, next)) return false;
+  inputProjections.set(sessionId, next);
+  emit();
+  return true;
 }
 
 function recomputeSessions(): void {
@@ -1836,9 +1855,31 @@ export const remoteSessionStore = {
 
   setInputProjection(sessionId: string, projection: unknown): void {
     const next = normalizeInputProjection(projection, sessionId);
-    if (deepValueEqual(inputProjections.get(sessionId) ?? EMPTY_INPUT_PROJECTION, next)) return;
-    inputProjections.set(sessionId, next);
-    emit();
+    bumpInputProjectionAuthorityEpoch(sessionId);
+    commitInputProjection(sessionId, next);
+  },
+
+  captureInputProjectionAuthorityEpoch(sessionId: string): number {
+    return inputProjectionAuthorityEpochs.get(sessionId) ?? inputProjectionAuthorityEpochFloor;
+  },
+
+  setInputProjectionIfCurrent(
+    sessionId: string,
+    projection: unknown,
+    expectedEpoch: number,
+  ): boolean {
+    const currentEpoch = inputProjectionAuthorityEpochs.get(sessionId) ?? inputProjectionAuthorityEpochFloor;
+    if (currentEpoch !== expectedEpoch) {
+      return false;
+    }
+    const next = normalizeInputProjection(projection, sessionId);
+    bumpInputProjectionAuthorityEpoch(sessionId);
+    commitInputProjection(sessionId, next);
+    return true;
+  },
+
+  invalidateInputProjectionAuthority(sessionId: string): void {
+    bumpInputProjectionAuthorityEpoch(sessionId);
   },
 
   setSessionRunning(
@@ -1847,6 +1888,9 @@ export const remoteSessionStore = {
     boundaryAgentMeta?: Record<string, unknown> | null,
   ): void {
     if (!sessionId) return;
+    // A maker turn boundary supersedes any projection query that started
+    // before it. This is the terminal fence for late owner snapshots.
+    bumpInputProjectionAuthorityEpoch(sessionId);
     // 本方法只被 maker 权威信号调用(done / terminal error / status-changed closed),
     // 与 maker turn 边界同步;activity / 快照流走 writeSessionRunStatus,不经过这里。
     // 边界变化必须独立参与 emit 判定:activity 流可能已把宽 run status 置 false,此时
@@ -2548,6 +2592,7 @@ export const remoteSessionStore = {
       // 投影没了,这份(空)列表就不再权威:重连拿到全量快照前不许据此做清理。
       changed = pendingInteractionsAuthoritative.delete(sessionId) || changed;
       changed = inputProjections.delete(sessionId) || changed;
+      bumpInputProjectionAuthorityEpoch(sessionId);
       changed = sessionLiveActivity.delete(sessionId) || changed;
       changed = sessionGoalStatus.delete(sessionId) || changed;
       changed = sessionTaskUpdates.delete(sessionId) || changed;
@@ -2577,6 +2622,7 @@ export const remoteSessionStore = {
         pendingInteractions.delete(sessionId);
         pendingInteractionsAuthoritative.delete(sessionId);
         inputProjections.delete(sessionId);
+        bumpInputProjectionAuthorityEpoch(sessionId);
         sessionLiveActivity.delete(sessionId);
         sessionRunning.delete(sessionId);
         sessionRunStatus.delete(sessionId);
@@ -2625,6 +2671,10 @@ export const remoteSessionStore = {
     confirmedInteractionDismissals.clear();
     interactionRevisionFloors.clear();
     inputProjections.clear();
+    inputProjectionAuthorityEpochFloor = ++nextInputProjectionAuthorityEpoch;
+    inputProjectionAuthorityEpochs.clear();
+    // Keep authority tombstones monotonic across a global store reset so an
+    // old in-flight query cannot be accepted after the session is recreated.
     sessionLiveActivity.clear();
     sessionRunning.clear();
     sessionRunStatus.clear();

--- a/apps/mobile/src/session/types.ts
+++ b/apps/mobile/src/session/types.ts
@@ -203,6 +203,13 @@ export interface QueuedRemoteMessage {
   origin?: Record<string, unknown>;
 }
 
+/**
+ * Whether the host projection can identify the owner of an in-flight continuation turn.
+ * `legacy` is reserved for projections that omit the field entirely; an explicit `null`
+ * is a supported projection with no continuation owner.
+ */
+export type ContinuationInFlightProjectionCapability = 'unknown' | 'legacy' | 'supported';
+
 export interface InputProjection {
   sessionId: string;
   pendingQueue: QueuedRemoteMessage[];
@@ -216,6 +223,10 @@ export interface InputProjection {
   recovery?: unknown;
   errorRetryText: string | null;
   autoResumePending?: Record<string, unknown> | null;
+  /** Current vendor-turn owner for an auto-resume continuation, when supported by the host. */
+  continuationTurnClientId?: string | null;
+  /** Capability marker kept distinct from an explicit `continuationTurnClientId: null`. */
+  continuationInFlightProjectionCapability?: ContinuationInFlightProjectionCapability;
   /**
    * 凭证切换等待态(对齐桌面 AgentInputProjection.credentialSwitchWait):发送需要
    * 重启共享 Codex 进程,但其它本地 Codex 任务在跑;消息保留在队首,挡路任务结束后


### PR DESCRIPTION
## 这次改了什么

### 摘要

将手机版自动重连状态从通用系统卡片改成与桌面版一致的紧凑活动行，避免原始错误全文长期占据消息流；运行中显示小型活动动画和重试进度，点击后再展开完整中断原因与统计信息。

同时参考桌面版的 authority epoch 处理，为 Mobile input projection 增加按会话隔离的单调栅栏，防止首开、重开、断线补齐或失败对账中的旧 `getProjection()` 结果，在更新的 projection push 或终态之后迟到回写并重新点亮自动重连行。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：手机版重新连接 UI 对齐桌面版。
- 本 PR 包含：自动重连运行中/成功/失败/中性状态行、重试进度、错误摘要、可展开诊断信息、silent-stop 续跑分隔线、四语言文案、Hermes 兼容的中断摘要解析、continuation owner 投影与 capability 兼容判据、Mobile projection authority epoch 栅栏、终态 owner 收口、所有 projection 写操作回包的 authority epoch 校验及竞态回归测试。
- 明确不包含：Device Link 协议与 IPC 契约、IPC allowlist、新的推送 channel、实际重连/重试/超时恢复逻辑、数据库、原生配置、原生依赖与 runtime fingerprint。
- 用户可见变化：自动重试运行时显示小型加载动画；默认只展示状态和压缩后的错误摘要，点击可查看完整原因、当前重试次数和任务累计重连次数。旧投影迟到时不再把已结束的自动重连行重新显示为运行中。
- 多端适配结论：SSH 远程工作区不涉及本次 JS/UI 镜像改动；未新增 IPC 或 push，继续使用现有 `maker:input:projection`；手机版入口与展示已适配。
- 是否存在 breaking change：无。

### 竞态不变量

- 每次 projection 查询在真正发起请求前捕获当前 session epoch；重试会重新捕获。
- projection push、本地 projection 写入、终态边界以及 offline/remove/clear 都推进该 session 的 authority epoch。
- 查询返回只有在 epoch 未变化时才能写入 store；栅栏失效的查询也不能参与“是否已应用”的判断，必须读取当前 store。
- 因此旧查询不能在终态清空 continuation owner 后重新写回旧 owner。

### UI 变化

- 平台：Mobile（iOS；逻辑同样由 React Native 共享给 Android）。无截图/录屏附件，本地使用 iPhone 17 Pro 模拟器验证。
- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §7 Do's and Don'ts：保持紧凑、近单色、无装饰性大动效；活动动画只表达运行状态。
  - `docs/design-rules/DESIGN.md` §10 Light / Dark Dual-Mode Delivery Gate：所有颜色均来自 `ThemeColors` 语义 token，不在组件内硬编码色值。
  - `docs/design-rules/DESIGN.md` §14.4 Motion & Transitions：复用既有 `CompactActivityIndicator`，不新增动画时长或曲线。
  - `docs/design-rules/DESIGN.md` §15.13 Cross-Platform Skin Rules：移动端边框、文字与抬升表面沿用已有 token 语义；展开区域使用 hairline 边框。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-mobile-reconnect-ui
结果：通过（GATE_EXIT=0；rebase 到最终 HEAD cdc520cb0 后重跑）

pnpm --filter mobile run --if-present typecheck
结果：通过

pnpm --filter mobile test:scope
结果：通过（mobile-scope-guard passed）

pnpm exec vitest run src/__tests__/sendEnqueueRetry.test.ts src/__tests__/autoResumePresentation.test.ts src/__tests__/inputProjection.test.ts src/__tests__/remoteSessionStore.test.ts
结果：通过（158 个用例，含 sendEnqueueRetry 回归守卫）

pnpm check:dco
结果：通过（5 个 commit 均带 DCO 签名）

git diff --check
结果：通过
```

### 手工验证

- 设备：iPhone 17 Pro Simulator。
- 区域：Global。
- Worktree：`/Users/dash/Code/Cindy/cindy-fix-mobile-reconnect-ui`，分支 `dash/fix-mobile-reconnect-ui`。
- 早前版本曾使用该功能 worktree 独占 Metro 并提供 bundle；本轮最终 rebase 后未重新启动 Metro 做 build label 复核。

### 未执行的验证

- 推送最终 HEAD `cdc520cb0` 后未重新启动模拟器并复核 `__DEV__` build label。
- 未分别对 Light / Dark 做最终实机目检；实现复用了 `ThemeColors` 语义 token，因此仅能确认代码路径支持双模式，不能将其等同于双模式实机验证。
- 未在 Android 实机/模拟器上手工验证。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Mobile 消息流中的 `auto-resume` 系统消息渲染，以及同一页面/store 的 projection 镜像写入时序。
- 回滚 / 降级方式：回退本 PR 的五个提交即可恢复原通用系统卡片展示和原有 projection 镜像行为；底层重连状态与恢复逻辑不受影响。
- 协议、原生层、runtime fingerprint、OTA、IPC、数据库、存量插件影响：无。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无独立文档需求；已补四语言文案、兼容判据与竞态测试）
- [x] 已确认测试结果或说明未执行原因