### PR TITLE
fix(mcps): 隔离并发 session 上下文

### DIFF
--- a/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
+++ b/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
@@ -7,6 +7,7 @@ import { createLiziMcpProviders } from '../providers.js';
 import { createXdtHelperMcpServer } from '../lizi_xdtHelperMcpServer.js';
 import {
   getLiziMcpSessionContext,
+  resolveLiziMcpSessionContext,
   runWithLiziMcpSessionContext,
 } from '../session-context.js';
 import type { OrcaMcpDeps } from '../orca/server.js';
@@ -357,6 +358,31 @@ describe('dynamic lizi MCP session context', () => {
       ok: false,
       errorCode: 'NO_SESSION_CONTEXT',
     });
+  });
+
+  it('keeps a sessionInstanceId-only captured context isolated from ambient ALS', () => {
+    const capturedContext: LiziMcpSessionContext = {
+      agentKind: 'claude-code',
+      workingDir: '',
+      sessionInstanceId: 'cc-instance',
+    };
+
+    const resolved = runWithLiziMcpSessionContext(
+      {
+        agentKind: 'codex',
+        workingDir: '/codex-repo',
+        sessionId: 'codex-session',
+        sessionInstanceId: 'codex-instance',
+      },
+      () => resolveLiziMcpSessionContext(capturedContext),
+    );
+
+    expect(resolved).toBe(capturedContext);
+    expect(resolved).toMatchObject({
+      agentKind: 'claude-code',
+      sessionInstanceId: 'cc-instance',
+    });
+    expect(resolved.sessionId).toBeUndefined();
   });
 
   it('keeps concurrent Claude Code and Codex helper calls on their own session ids', async () => {

--- a/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
+++ b/packages/lizi-mcps/src/__tests__/sessionContext.test.ts
@@ -5,8 +5,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { createOrcaMcpServer } from '../orca/server.js';
 import { createLiziMcpProviders } from '../providers.js';
 import { createXdtHelperMcpServer } from '../lizi_xdtHelperMcpServer.js';
-import { runWithLiziMcpSessionContext } from '../session-context.js';
+import {
+  getLiziMcpSessionContext,
+  runWithLiziMcpSessionContext,
+} from '../session-context.js';
 import type { OrcaMcpDeps } from '../orca/server.js';
+import type { LiziMcpSessionContext } from '../types.js';
 import type { RenameSessionsDeps } from '../xdt-helper/rename_sessions.js';
 import type { SetCurrentSessionTitleDeps } from '../xdt-helper/set_current_session_title.js';
 
@@ -328,6 +332,129 @@ describe('dynamic lizi MCP session context', () => {
       agent_kind: 'codex',
       working_dir: '/repo',
     });
+  });
+
+  it('fails closed when the authoritative accessor cannot resolve a session', async () => {
+    const provider = createLiziMcpProviders({ xdtHelper: {} }).find(
+      (candidate) => candidate.name === 'cindy_helper',
+    );
+    if (!provider) throw new Error('cindy_helper provider missing');
+
+    const cfg = provider.toClaudeSdkConfig({
+      agentKind: 'codex',
+      workingDir: '/captured-other-workdir',
+      sessionId: 'captured-other-session',
+      vendorOptions: { source: 'captured-other-source' },
+      getSessionContext: () => undefined,
+    }) as { type: 'sdk'; instance: unknown };
+
+    const result = await tools(cfg.instance).call_tool.handler({
+      name: 'get_current_session_id',
+      args: {},
+    });
+
+    expect(parse(result as never)).toMatchObject({
+      ok: false,
+      errorCode: 'NO_SESSION_CONTEXT',
+    });
+  });
+
+  it('keeps concurrent Claude Code and Codex helper calls on their own session ids', async () => {
+    const provider = createLiziMcpProviders({ xdtHelper: {} }).find(
+      (candidate) => candidate.name === 'cindy_helper',
+    );
+    if (!provider) throw new Error('cindy_helper provider missing');
+
+    const claudeContext: LiziMcpSessionContext = {
+      agentKind: 'claude-code' as const,
+      workingDir: '/cc-repo',
+      sessionId: 'cc-session',
+      vendorOptions: {},
+      getSessionContext: () => claudeContext,
+    };
+    const codexFactoryContext = {
+      agentKind: 'codex' as const,
+      workingDir: '',
+      vendorOptions: {},
+      getSessionContext: getLiziMcpSessionContext,
+    };
+    const claudeServer = (
+      provider.toClaudeSdkConfig(claudeContext) as {
+        type: 'sdk';
+        instance: unknown;
+      }
+    ).instance;
+    const codexServer = (
+      provider.toClaudeSdkConfig(codexFactoryContext) as {
+        type: 'sdk';
+        instance: unknown;
+      }
+    ).instance;
+
+    const codexRequestContext = {
+      agentKind: 'codex' as const,
+      workingDir: '/codex-repo',
+      sessionId: 'codex-session',
+      vendorOptions: {},
+    };
+    const [claudeResult, codexResult] = await runWithLiziMcpSessionContext(
+      codexRequestContext,
+      async () =>
+        Promise.all([
+          tools(claudeServer).call_tool.handler({
+            name: 'get_current_session_id',
+            args: {},
+          }),
+          tools(codexServer).call_tool.handler({
+            name: 'get_current_session_id',
+            args: {},
+          }),
+        ]),
+    );
+
+    expect(parse(claudeResult as never)).toMatchObject({
+      ok: true,
+      session_id: 'cc-session',
+      agent_kind: 'claude-code',
+      working_dir: '/cc-repo',
+    });
+    expect(parse(codexResult as never)).toMatchObject({
+      ok: true,
+      session_id: 'codex-session',
+      agent_kind: 'codex',
+      working_dir: '/codex-repo',
+    });
+  });
+
+  it('keeps scheduler caller ownership fail-closed when dynamic context is absent', async () => {
+    const resolveInflightRunForSession = vi.fn(() => 'wrong-run');
+    const silenceRun = vi.fn(() => true);
+    const provider = createLiziMcpProviders({
+      scheduler: {
+        getScheduler: () =>
+          ({ resolveInflightRunForSession, silenceRun }) as never,
+      },
+    }).find((candidate) => candidate.name === 'cindy_scheduler');
+    if (!provider) throw new Error('cindy_scheduler provider missing');
+
+    const cfg = provider.toClaudeSdkConfig({
+      agentKind: 'codex',
+      workingDir: '/captured-other-workdir',
+      sessionId: 'captured-other-session',
+      vendorOptions: {},
+      getSessionContext: () => undefined,
+    }) as { type: 'sdk'; instance: unknown };
+    const result = await tools(cfg.instance).call_tool.handler({
+      name: 'schedule_silence_current_run',
+      args: { runId: 'explicit-run' },
+    });
+
+    expect(parse(result as never)).toMatchObject({
+      ok: true,
+      data: { silenced: true, runId: 'explicit-run' },
+    });
+    expect(resolveInflightRunForSession).not.toHaveBeenCalled();
+    expect(silenceRun).toHaveBeenCalledWith('explicit-run');
   });
 
   it('lets cindy_helper update the current session title dynamically', async () => {

--- a/packages/lizi-mcps/src/cindy_schedulerMcpServer.ts
+++ b/packages/lizi-mcps/src/cindy_schedulerMcpServer.ts
@@ -53,6 +53,7 @@ import type { LiziMcpSessionContext, SchedulerMcpDeps } from './types.js';
 export interface SchedulerMcpSessionCtx {
   agentKind: 'claude-code' | 'codex' | 'pi';
   workingDir: string;
+  getSessionContext?: () => LiziMcpSessionContext | undefined;
   sessionId?: string;
   vendorOptions?: Record<string, unknown>;
 }

--- a/packages/lizi-mcps/src/lizi_xdtHelperMcpServer.ts
+++ b/packages/lizi-mcps/src/lizi_xdtHelperMcpServer.ts
@@ -255,6 +255,7 @@ export interface XdtHelperMcpDeps {
 export interface XdtHelperMcpSessionCtx {
   agentKind: 'claude-code' | 'codex' | 'pi';
   workingDir: string;
+  getSessionContext?: () => import('./types.js').LiziMcpSessionContext | undefined;
   sessionId?: string;
   vendorOptions?: Record<string, unknown>;
 }

--- a/packages/lizi-mcps/src/orca/server.ts
+++ b/packages/lizi-mcps/src/orca/server.ts
@@ -238,6 +238,7 @@ export interface OrcaWorkerDiagnosticOutput extends OrcaWorkerDiagnosticStatus {
 export interface OrcaMcpSessionCtx {
   agentKind: ControlWorkerAgent;
   workingDir: string;
+  getSessionContext?: () => import('../types.js').LiziMcpSessionContext | undefined;
   sessionId?: string;
   /** start_team / end_team 读 vendorOptions.orcaRole 决定是否允许调用
    *  (worker session 不能再开 team)。 */

--- a/packages/lizi-mcps/src/providers.ts
+++ b/packages/lizi-mcps/src/providers.ts
@@ -314,6 +314,7 @@ export function createLiziMcpProviders(
         instance: createSchedulerMcpServer(opts.scheduler!, {
           agentKind: ctx.agentKind === 'codex' ? 'codex' : ctx.agentKind === 'pi' ? 'pi' : 'claude-code',
           workingDir: ctx.workingDir,
+          ...(ctx.getSessionContext ? { getSessionContext: ctx.getSessionContext } : {}),
           sessionId: ctx.sessionId,
           vendorOptions: ctx.vendorOptions,
         }),
@@ -353,6 +354,7 @@ export function createLiziMcpProviders(
         instance: createXdtHelperMcpServer(opts.xdtHelper!, {
           agentKind: ctx.agentKind === 'codex' ? 'codex' : ctx.agentKind === 'pi' ? 'pi' : 'claude-code',
           workingDir: ctx.workingDir,
+          ...(ctx.getSessionContext ? { getSessionContext: ctx.getSessionContext } : {}),
           sessionId: ctx.sessionId,
           vendorOptions: ctx.vendorOptions,
         }),
@@ -375,6 +377,7 @@ export function createLiziMcpProviders(
         instance: createOrcaMcpServer(opts.orca!, {
           agentKind: ctx.agentKind === 'codex' ? 'codex' : ctx.agentKind === 'pi' ? 'pi' : 'claude-code',
           workingDir: ctx.workingDir,
+          ...(ctx.getSessionContext ? { getSessionContext: ctx.getSessionContext } : {}),
           sessionId: ctx.sessionId,
           vendorOptions: ctx.vendorOptions,
         }),

--- a/packages/lizi-mcps/src/session-context.ts
+++ b/packages/lizi-mcps/src/session-context.ts
@@ -44,6 +44,7 @@ export function resolveLiziMcpSessionContext<T extends LiziMcpSessionContext>(
   // consult the ambient ALS store.
   if (
     fallback.sessionId ||
+    fallback.sessionInstanceId ||
     fallback.workingDir ||
     fallback.remoteHostId ||
     (fallback.vendorOptions && Object.keys(fallback.vendorOptions).length > 0)

--- a/packages/lizi-mcps/src/session-context.ts
+++ b/packages/lizi-mcps/src/session-context.ts
@@ -15,8 +15,40 @@ export function getLiziMcpSessionContext(): LiziMcpSessionContext | undefined {
   return storage.getStore();
 }
 
+function withoutSessionAttribution<T extends LiziMcpSessionContext>(fallback: T): T {
+  return {
+    ...fallback,
+    workingDir: '',
+    sessionId: undefined,
+    sessionInstanceId: undefined,
+    remoteHostId: undefined,
+    vendorOptions: undefined,
+  };
+}
+
 export function resolveLiziMcpSessionContext<T extends LiziMcpSessionContext>(
   fallback: T,
 ): T {
+  // Host-provided accessors carry the provenance of this MCP server. Claude
+  // returns its per-session closure; Codex / Pi resolve the current request.
+  // An accessor that cannot resolve a context is authoritative too: returning
+  // the captured fallback (or an unrelated ambient ALS store) would silently
+  // impersonate another session, so strip all session attribution instead.
+  if (fallback.getSessionContext) {
+    return (fallback.getSessionContext() as T | undefined) ?? withoutSessionAttribution(fallback);
+  }
+
+  // Backward compatibility for direct package consumers that construct bridge
+  // servers without the newer explicit accessor. A concrete captured context
+  // is still authoritative; only an unmistakably empty bridge placeholder may
+  // consult the ambient ALS store.
+  if (
+    fallback.sessionId ||
+    fallback.workingDir ||
+    fallback.remoteHostId ||
+    (fallback.vendorOptions && Object.keys(fallback.vendorOptions).length > 0)
+  ) {
+    return fallback;
+  }
   return (storage.getStore() as T | undefined) ?? fallback;
 }

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -733,6 +733,15 @@ export interface LiziMcpSessionContext {
   agentKind: string;
   workingDir: string;
   /**
+   * 当前 tool-call 的权威 session ctx accessor。
+   *
+   * Claude in-process 路径返回闭包绑定的当前 session；Codex / Pi bridge
+   * 路径从请求作用域恢复当前 session。只要提供了本 accessor，它就是唯一可信
+   * 来源：返回 undefined 表示本次调用无法确认归属，调用方必须 fail closed，
+   * 不能再回落到构建 server 时捕获的 ctx 或环境中的其它 AsyncLocalStorage store。
+   */
+  getSessionContext?: () => LiziMcpSessionContext | undefined;
+  /**
    * SSH remote 会话的 host id (本地会话缺省)。workingDir 此时是远端机器上的
    * 路径字符串 — cindy_memory 等按 workdir 分区的工具必须用
    * buildMemoryScopeKey(workingDir, remoteHostId) 定位 store, 不得把远端路径


### PR DESCRIPTION
Fixes #2179

## 这次改了什么

- 将 MCP session context 的来源改为“显式 accessor 优先且唯一可信”：Claude Code 使用各自 server 闭包绑定的 context，Codex / Pi 在每次请求时恢复 context。
- accessor 无法确认归属时清空 sessionId、workingDir、sessionInstanceId、remoteHostId 与 vendorOptions，按现有调用方语义返回 `NO_SESSION_CONTEXT` 或走显式参数回退，绝不借用 captured ctx 或其它并发请求的 ALS store。
- 将同族入口一次覆盖到 `cindy_helper`、`cindy_scheduler` 与 `cindy_orca`，并补充 fail-closed、Claude Code + Codex 并发隔离、scheduler caller ownership 回归测试。
- Decision archaeology：检查了 `session-context.ts` 的提交历史与 PR #743；该 resolver 自首次引入后没有被改回。Issue 中“ALS 无 store 时回落到 provider ctx”不是本次实测根因；真实事故链是 resolver 无条件用 ambient ALS store 覆盖 fallback，使运行在 Codex ALS 环境里的 Claude Code in-process server 被错认成 Codex session。

## 怎么验证的

- `pnpm --filter @cindy/mcps test`（38 个文件、452 个测试通过）
- `pnpm --filter @cindy/mcps build`
- `pnpm --filter @cindy/mcps run --if-present typecheck`（该包无独立 typecheck script，按仓库门禁正常跳过）
- `pnpm test:unit`（全仓通过）
- `pnpm check:dco`
- `node ~/.agents/skills/git-workflow/scripts/pr-size-gate.mjs`
- `node ~/.agents/skills/git-workflow/scripts/pre-pr-freshness.mjs`

## 风险

- 行为变化只发生在 MCP session 归属解析：拿不准时从“可能静默串号”改为 fail-closed；依赖 session context 的工具可能返回无上下文或使用其已有显式参数回退，这是预期的安全退化。
- 保留无 accessor 的兼容路径：具体 captured ctx 仍优先；只有明确为空的 bridge placeholder 才读取 ALS，避免破坏现有直接消费者。
- 不涉及 UI，不涉及 `apps/desktop/src/renderer/**` 或 `packages/maker-core/**`，未触发相关人工审核门。
