### PR TITLE
fix(desktop): 修复供应商详情头重叠

### DIFF
--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -218,9 +218,11 @@ describe('ProvidersSection — 双栏管理', () => {
       (await screen.findAllByText('settings.providers.xd.title')).length,
     ).toBeGreaterThanOrEqual(2);
     // 详情标题的模型数/订阅标签必须在可用宽度内折行，不能溢出覆盖右侧连接操作。
+    const identity = screen.getByTestId('provider-detail-identity');
     const metadata = screen.getByTestId('provider-detail-metadata');
+    expect(identity.contains(metadata)).toBe(true);
+    expect(identity.classList.contains('flex-auto')).toBe(true);
     expect(metadata.classList.contains('flex-wrap')).toBe(true);
-    expect(metadata.parentElement?.classList.contains('flex-auto')).toBe(true);
     // 未连接的 Anthropic 不出现在左栏(无检测建议时整页不出现)。
     expect(screen.queryByText('Anthropic')).toBeNull();
     // xd 实时模型为空 → 详情仍渲染模型工具行与刷新入口，避免用户无从恢复。

--- a/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
@@ -217,6 +217,10 @@ describe('ProvidersSection — 双栏管理', () => {
     expect(
       (await screen.findAllByText('settings.providers.xd.title')).length,
     ).toBeGreaterThanOrEqual(2);
+    // 详情标题的模型数/订阅标签必须在可用宽度内折行，不能溢出覆盖右侧连接操作。
+    const metadata = screen.getByTestId('provider-detail-metadata');
+    expect(metadata.classList.contains('flex-wrap')).toBe(true);
+    expect(metadata.parentElement?.classList.contains('flex-auto')).toBe(true);
     // 未连接的 Anthropic 不出现在左栏(无检测建议时整页不出现)。
     expect(screen.queryByText('Anthropic')).toBeNull();
     // xd 实时模型为空 → 详情仍渲染模型工具行与刷新入口，避免用户无从恢复。

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -350,8 +350,11 @@ function DetailHeader({
             {icon}
           </div>
 
-          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-            <div className="flex items-center gap-2">
+          <div className="flex min-w-0 flex-auto flex-col gap-0.5">
+            <div
+              data-testid="provider-detail-metadata"
+              className="flex min-w-0 flex-wrap items-center gap-2"
+            >
               <span
                 className="min-w-0 truncate text-14 font-medium leading-tight"
                 style={{ color: 'var(--settings-section-title)' }}

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -340,45 +340,50 @@ function DetailHeader({
             不被卡片 overflow-hidden 裁掉(PR #1102 review 第三轮)。 */}
         <div className="flex flex-wrap items-center gap-3 gap-y-2">
           <div
-            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
-            style={{
-              backgroundColor: 'var(--settings-integration-avatar-bg)',
-              border: '1px solid var(--settings-integration-avatar-border)',
-              color: 'var(--settings-integration-avatar-icon)',
-            }}
+            data-testid="provider-detail-identity"
+            className="flex min-w-0 flex-auto items-center gap-3"
           >
-            {icon}
-          </div>
-
-          <div className="flex min-w-0 flex-auto flex-col gap-0.5">
             <div
-              data-testid="provider-detail-metadata"
-              className="flex min-w-0 flex-wrap items-center gap-2"
+              className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg"
+              style={{
+                backgroundColor: 'var(--settings-integration-avatar-bg)',
+                border: '1px solid var(--settings-integration-avatar-border)',
+                color: 'var(--settings-integration-avatar-icon)',
+              }}
             >
-              <span
-                className="min-w-0 truncate text-14 font-medium leading-tight"
-                style={{ color: 'var(--settings-section-title)' }}
-              >
-                {title}
-              </span>
-              {modelCount !== null && <ModelCountChip count={modelCount} />}
-              {subscriptionProduct && (
-                <CustomTag
-                  label={t('settings.providers.models.subscriptionProduct', {
-                    product: subscriptionProduct,
-                  })}
-                />
-              )}
-              {provider?.suspended && <CustomTag label={t('settings.providers.pill.suspended')} />}
-              {badge}
+              {icon}
             </div>
-            <span
-              className="truncate text-13 leading-tight"
-              style={{ color: 'var(--settings-integration-subtitle)' }}
-            >
-              {subtitle}
-              {singleAgentNote ? ` · ${singleAgentNote}` : ''}
-            </span>
+
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <div
+                data-testid="provider-detail-metadata"
+                className="flex min-w-0 flex-wrap items-center gap-2"
+              >
+                <span
+                  className="min-w-0 truncate text-14 font-medium leading-tight"
+                  style={{ color: 'var(--settings-section-title)' }}
+                >
+                  {title}
+                </span>
+                {modelCount !== null && <ModelCountChip count={modelCount} />}
+                {subscriptionProduct && (
+                  <CustomTag
+                    label={t('settings.providers.models.subscriptionProduct', {
+                      product: subscriptionProduct,
+                    })}
+                  />
+                )}
+                {provider?.suspended && <CustomTag label={t('settings.providers.pill.suspended')} />}
+                {badge}
+              </div>
+              <span
+                className="truncate text-13 leading-tight"
+                style={{ color: 'var(--settings-integration-subtitle)' }}
+              >
+                {subtitle}
+                {singleAgentNote ? ` · ${singleAgentNote}` : ''}
+              </span>
+            </div>
           </div>
 
           {trailing}


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Mac 国际版 0.1.37 Settings → Providers 中，OpenAI 详情头的模型数/订阅标签与“已连接 / 断开”操作区重叠的问题。让标题元数据在窄栏内折行，并让标题列按内容基准参与外层换行。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Slack thread 反馈（万方 / huahua，附件截图）
- 本 PR 包含：Providers 详情头的响应式布局修复；补充布局 class 回归断言。
- 明确不包含：连接逻辑、供应商数据、文案、颜色 token 或其它 Settings 页面。
- 用户可见变化：窄窗口下连接状态和按钮会完整换到下一行，不再被模型数或订阅标签覆盖。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §8 Desktop Window（最小窗口 800×600、窗口缩小时流式重排、控件不缩小）；§10 Light / Dark Dual-Mode Delivery Gate（复用现有语义 token，Light/Dark 行为一致）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/providersSectionUnavailableModels.test.tsx
结果：1 个测试文件，7/7 通过。

pnpm --filter desktop run --if-present typecheck
结果：通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-settings-providers-overlap
结果：GATE_EXIT=0（全仓单元测试通过）。

pnpm check:dco
结果：通过。
```

### 手工验证

未启动宿主 Desktop；通过 Chromium flex 布局模型对 375/430/500/600px 详情宽度做几何复核，均无重叠，窄宽时操作组换行，宽处保持同一行。

### 未执行的验证

未做 Light/Dark 实机目检；本次没有新增颜色或主题分支，完全复用现有语义 token。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop Settings → Providers 详情头的响应式布局；所有供应商共用该头部，但仅改变窄宽下换行行为。
- 回滚 / 降级方式：回滚本 PR commit 即恢复原布局，不涉及数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档（不需要：布局修复无文档契约变化）
- [x] 已确认测试结果或说明未执行原因
