### PR TITLE
fix(desktop): 修复 ChatGPT 失效后的重新登录入口

### DIFF
--- a/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/providersSectionDeepLink.test.tsx
@@ -178,7 +178,7 @@ afterEach(() => {
 });
 
 describe('ProvidersSection — 深链定位', () => {
-  it('ChatGPT 系统共享登录失效时显示来源说明并打开 ChatGPT App', async () => {
+  it('ChatGPT 系统共享登录失效时显示来源说明并在 Cindy 中重新登录', async () => {
     codexAuthState.state = {
       kind: 'reconnect-required',
       reason: 'token_revoked',
@@ -201,13 +201,13 @@ describe('ProvidersSection — 深链定位', () => {
       'var(--remote-status-failed)',
     );
     expect(await screen.findByText('chatgptAuthRecovery.systemSharedInvalidated')).not.toBeNull();
-    fireEvent.click(screen.getByRole('button', { name: 'chatgptAuthRecovery.openApp' }));
+    fireEvent.click(screen.getByRole('button', { name: 'chatgptAuthRecovery.relogin' }));
 
-    await waitFor(() => expect(window.electronAPI.openChatGPTApp).toHaveBeenCalledOnce());
-    expect(codexAuthActions.triggerLogin).not.toHaveBeenCalled();
+    await waitFor(() => expect(codexAuthActions.triggerLogin).toHaveBeenCalledOnce());
+    expect(window.electronAPI.openChatGPTApp).not.toHaveBeenCalled();
   });
 
-  it('ChatGPT App 打开失败时保留恢复入口并提示用户', async () => {
+  it('ChatGPT 系统共享重新登录被取消时保留恢复入口', async () => {
     codexAuthState.state = {
       kind: 'reconnect-required',
       reason: 'token_revoked',
@@ -222,18 +222,15 @@ describe('ProvidersSection — 深链定位', () => {
         models: { codex: [], 'claude-code': [] },
       }),
     ];
-    vi.mocked(window.electronAPI.openChatGPTApp).mockRejectedValueOnce(
-      new Error('bridge unavailable'),
-    );
+    codexAuthActions.triggerLogin.mockResolvedValueOnce('cancelled');
     renderAt('?tab=providers&connect=openai');
 
-    fireEvent.click(await screen.findByRole('button', { name: 'chatgptAuthRecovery.openApp' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'chatgptAuthRecovery.relogin' }));
 
-    await waitFor(() =>
-      expect(toastError).toHaveBeenCalledWith('chatgptAuthRecovery.openAppFailed'),
-    );
-    expect(screen.getByRole('button', { name: 'chatgptAuthRecovery.openApp' })).not.toBeNull();
-    expect(codexAuthActions.triggerLogin).not.toHaveBeenCalled();
+    await waitFor(() => expect(codexAuthActions.triggerLogin).toHaveBeenCalledOnce());
+    expect(toastError).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'chatgptAuthRecovery.relogin' })).not.toBeNull();
+    expect(window.electronAPI.openChatGPTApp).not.toHaveBeenCalled();
   });
 
   it('connect=anthropic(未占行内置渠道)→ 向导 builtin 直达;参数消费后清除', async () => {

--- a/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
+++ b/apps/desktop/src/renderer/components/chat/ErrorBanner.tsx
@@ -408,15 +408,6 @@ export function ErrorBanner({
       await refreshOpenAiAuth();
       return;
     }
-    if (openAiCredentialScope === 'system-shared') {
-      try {
-        const result = await window.electronAPI.openChatGPTApp();
-        if (!result.success) toast.error(t('chatgptAuthRecovery.openAppFailed'));
-      } catch {
-        toast.error(t('chatgptAuthRecovery.openAppFailed'));
-      }
-      return;
-    }
     promptCodexSessionExpired(error);
   };
 
@@ -541,8 +532,8 @@ export function ErrorBanner({
         )}
       </div>
       {openAiReconnectRequired && (
-        // 系统共享凭证必须回 ChatGPT App 修复；Cindy 独立凭证才启动 Cindy OAuth。
-        // 登录候选出现后先走账号级服务端探测，探测成功前继续隐藏请求 Retry。
+        // 所有凭证来源都由 Cindy 启动可产生新 Codex 凭据的登录流程；登录候选出现后
+        // 先走账号级服务端探测，探测成功前继续隐藏请求 Retry。
         <button
           type="button"
           onClick={() => void handleOpenAiRecovery()}
@@ -558,9 +549,7 @@ export function ErrorBanner({
               ? 'chatgptAuthRecovery.recheck'
               : openAiRecoveryBusy
                 ? 'chatgptAuthRecovery.checking'
-                : openAiCredentialScope === 'system-shared'
-                  ? 'chatgptAuthRecovery.openApp'
-                  : 'chatgptAuthRecovery.relogin',
+                : 'chatgptAuthRecovery.relogin',
           )}
         >
           <Spinner icon={RefreshCw} size={12} spinning={openAiRecoveryBusy} />
@@ -569,9 +558,7 @@ export function ErrorBanner({
               ? 'chatgptAuthRecovery.checking'
               : openAiRecoveryCheck === 'failed'
                 ? 'chatgptAuthRecovery.recheck'
-                : openAiCredentialScope === 'system-shared'
-                  ? 'chatgptAuthRecovery.openApp'
-                  : 'chatgptAuthRecovery.relogin',
+                : 'chatgptAuthRecovery.relogin',
           )}
         </button>
       )}

--- a/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
@@ -148,7 +148,7 @@ describe('ErrorBanner OpenAI connection recovery', () => {
     expect(screen.queryByText(error)).toBeNull();
   });
 
-  it('opens the ChatGPT App for an invalidated system-shared login', async () => {
+  it('starts Cindy login for an invalidated system-shared login', async () => {
     mocks.getState.mockResolvedValue({
       authenticated: false,
       errorReason: 'token_revoked',
@@ -166,11 +166,12 @@ describe('ErrorBanner OpenAI connection recovery', () => {
     );
 
     expect(await screen.findByText('chatgptAuthRecovery.systemSharedInvalidated')).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'chatgptAuthRecovery.openApp' }));
+    fireEvent.click(screen.getByRole('button', { name: 'chatgptAuthRecovery.relogin' }));
 
-    await waitFor(() => expect(mocks.openChatGPTApp).toHaveBeenCalledOnce());
-    expect(mocks.triggerLogin).not.toHaveBeenCalled();
-    expect(screen.queryByRole('button', { name: 'chat.errorBanner.retry' })).toBeNull();
+    await waitFor(() => expect(mocks.triggerLogin).toHaveBeenCalledOnce());
+    expect(mocks.openChatGPTApp).not.toHaveBeenCalled();
+    expect(await screen.findByText('chatgptAuthRecovery.recovered')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'chat.errorBanner.retry' })).toBeTruthy();
   });
 
   it('keeps the recovery action disabled until the credential source is known', async () => {
@@ -204,7 +205,7 @@ describe('ErrorBanner OpenAI connection recovery', () => {
       });
       await initialState.promise;
     });
-    expect(await screen.findByRole('button', { name: 'chatgptAuthRecovery.openApp' })).toBeTruthy();
+    expect(await screen.findByRole('button', { name: 'chatgptAuthRecovery.relogin' })).toBeTruthy();
   });
 
   it('does not restore retry on a fresh mount until the replacement account probe succeeds', async () => {
@@ -247,13 +248,16 @@ describe('ErrorBanner OpenAI connection recovery', () => {
     expect(screen.getByRole('button', { name: 'chat.errorBanner.retry' })).toBeTruthy();
   });
 
-  it('keeps the recovery action available when the ChatGPT App cannot be opened', async () => {
+  it('keeps the system-shared recovery action after user cancellation', async () => {
     mocks.getState.mockResolvedValue({
       authenticated: false,
       errorReason: 'token_revoked',
       credentialScope: 'system-shared',
     });
-    mocks.openChatGPTApp.mockResolvedValueOnce({ success: false });
+    mocks.triggerLogin.mockResolvedValueOnce({
+      authenticated: false,
+      errorReason: 'login_cancelled',
+    });
     render(
       <ErrorBanner
         error="token_revoked"
@@ -265,23 +269,25 @@ describe('ErrorBanner OpenAI connection recovery', () => {
       />,
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'chatgptAuthRecovery.openApp' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'chatgptAuthRecovery.relogin' }));
 
-    await waitFor(() => {
-      expect(mocks.toastError).toHaveBeenCalledWith('chatgptAuthRecovery.openAppFailed');
-    });
-    expect(mocks.triggerLogin).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'chatgptAuthRecovery.openApp' })).toBeTruthy();
+    await waitFor(() => expect(mocks.triggerLogin).toHaveBeenCalledOnce());
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(mocks.openChatGPTApp).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'chatgptAuthRecovery.relogin' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'chat.errorBanner.retry' })).toBeNull();
   });
 
-  it('keeps the recovery action available when opening the ChatGPT App rejects', async () => {
+  it('keeps the system-shared recovery action after login failure', async () => {
     mocks.getState.mockResolvedValue({
       authenticated: false,
       errorReason: 'token_revoked',
       credentialScope: 'system-shared',
     });
-    mocks.openChatGPTApp.mockRejectedValueOnce(new Error('bridge unavailable'));
+    mocks.triggerLogin.mockResolvedValueOnce({
+      authenticated: false,
+      errorReason: 'login_timeout',
+    });
     render(
       <ErrorBanner
         error="token_revoked"
@@ -293,13 +299,14 @@ describe('ErrorBanner OpenAI connection recovery', () => {
       />,
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'chatgptAuthRecovery.openApp' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'chatgptAuthRecovery.relogin' }));
 
     await waitFor(() => {
-      expect(mocks.toastError).toHaveBeenCalledWith('chatgptAuthRecovery.openAppFailed');
+      expect(mocks.toastError).toHaveBeenCalledWith('settings.connections.codex.toast.loginFailed');
     });
-    expect(mocks.triggerLogin).not.toHaveBeenCalled();
-    expect(screen.getByRole('button', { name: 'chatgptAuthRecovery.openApp' })).toBeTruthy();
+    expect(mocks.triggerLogin).toHaveBeenCalledOnce();
+    expect(mocks.openChatGPTApp).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'chatgptAuthRecovery.relogin' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'chat.errorBanner.retry' })).toBeNull();
   });
 
@@ -728,7 +735,7 @@ describe('ErrorBanner OpenAI connection recovery', () => {
     expect(mocks.cancelLogin).not.toHaveBeenCalled();
   });
 
-  it('uses the system-shared voice recovery copy and opens the ChatGPT App', async () => {
+  it('uses the system-shared voice recovery copy and starts Cindy login', async () => {
     mocks.getState.mockResolvedValue({
       authenticated: false,
       errorReason: 'token_revoked',
@@ -745,16 +752,16 @@ describe('ErrorBanner OpenAI connection recovery', () => {
       expect(mocks.confirm).toHaveBeenCalledWith({
         title: 'chatgptAuthRecovery.title',
         description: 'chatgptAuthRecovery.systemSharedInvalidated',
-        confirmText: 'chatgptAuthRecovery.openApp',
+        confirmText: 'chatgptAuthRecovery.relogin',
         cancelText: 'chatgptAuthRecovery.later',
         autoFocusConfirm: true,
       }),
     );
-    await waitFor(() => expect(mocks.openChatGPTApp).toHaveBeenCalledOnce());
-    expect(mocks.triggerLogin).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.triggerLogin).toHaveBeenCalledOnce());
+    expect(mocks.openChatGPTApp).not.toHaveBeenCalled();
   });
 
-  it('keeps the original shared recovery flow when an authenticated hint cannot be verified', async () => {
+  it('starts Cindy login when an authenticated system-shared hint cannot be verified', async () => {
     mocks.getState.mockResolvedValue({
       authenticated: true,
       identity: 'user@example.com',
@@ -773,14 +780,16 @@ describe('ErrorBanner OpenAI connection recovery', () => {
       expect(mocks.confirm).toHaveBeenCalledWith({
         title: 'chatgptAuthRecovery.title',
         description: 'chatgptAuthRecovery.systemSharedInvalidated',
-        confirmText: 'chatgptAuthRecovery.openApp',
+        confirmText: 'chatgptAuthRecovery.relogin',
         cancelText: 'chatgptAuthRecovery.later',
         autoFocusConfirm: true,
       }),
     );
-    await waitFor(() => expect(mocks.openChatGPTApp).toHaveBeenCalledOnce());
-    expect(mocks.toastSuccess).not.toHaveBeenCalled();
-    expect(mocks.triggerLogin).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.triggerLogin).toHaveBeenCalledOnce());
+    expect(mocks.openChatGPTApp).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('logic.toasts.codexConnected'),
+    );
   });
 
   it('localizes event-loop terminal errors from the stable reason key', () => {

--- a/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/ProvidersSection.tsx
@@ -583,17 +583,8 @@ function OpenAiHeader({ provider, onChanged }: { provider?: ProviderView; onChan
       await refresh();
       return;
     }
-    if (credentialScope === 'system-shared') {
-      try {
-        const result = await window.electronAPI.openChatGPTApp();
-        if (!result.success) toast.error(t('chatgptAuthRecovery.openAppFailed'));
-      } catch {
-        toast.error(t('chatgptAuthRecovery.openAppFailed'));
-      }
-      return;
-    }
     await handleLogin();
-  }, [credentialScope, handleLogin, loggingIn, recoveryCheck, refresh, t]);
+  }, [handleLogin, loggingIn, recoveryCheck, refresh]);
 
   const recoveryDetail = reconnectRequired ? (
     <p className="text-12 leading-relaxed text-[var(--settings-integration-subtitle)]">
@@ -624,9 +615,7 @@ function OpenAiHeader({ provider, onChanged }: { provider?: ProviderView; onChan
             ? 'chatgptAuthRecovery.checking'
             : recoveryCheck === 'failed'
               ? 'chatgptAuthRecovery.recheck'
-              : credentialScope === 'system-shared'
-                ? 'chatgptAuthRecovery.openApp'
-                : 'chatgptAuthRecovery.relogin',
+              : 'chatgptAuthRecovery.relogin',
         )}
         onClick={() => void handleRecovery()}
         disabled={recoveryCheck === 'checking' || loggingIn}

--- a/apps/desktop/src/renderer/hooks/useCodexSessionExpiredPrompt.ts
+++ b/apps/desktop/src/renderer/hooks/useCodexSessionExpiredPrompt.ts
@@ -18,7 +18,7 @@ function reconnectCopyForScope(scope: CodexCredentialScope): {
   if (scope === 'system-shared') {
     return {
       description: 'chatgptAuthRecovery.systemSharedInvalidated',
-      confirmText: 'chatgptAuthRecovery.openApp',
+      confirmText: 'chatgptAuthRecovery.relogin',
     };
   }
   return {
@@ -111,22 +111,6 @@ export function useCodexSessionExpiredPrompt(options?: {
             closePrompt();
             return;
           }
-        }
-
-        if (credentialScope === 'system-shared') {
-          try {
-            const result = await window.electronAPI.openChatGPTApp();
-            if (mountedRef.current && !result.success) {
-              toast.error(t('chatgptAuthRecovery.openAppFailed'));
-            }
-          } catch {
-            if (mountedRef.current) {
-              toast.error(t('chatgptAuthRecovery.openAppFailed'));
-            }
-          } finally {
-            if (mountedRef.current) closePrompt();
-          }
-          return;
         }
 
         try {

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5628,7 +5628,7 @@
   },
   "chatgptAuthRecovery": {
     "title": "ChatGPT Sign-In Is No Longer Valid",
-    "systemSharedInvalidated": "Cindy is currently using this computer’s ChatGPT sign-in. That sign-in is no longer valid. Open the ChatGPT App, sign in again, then retry.",
+    "systemSharedInvalidated": "Cindy is currently using this computer’s ChatGPT sign-in. That sign-in is no longer valid. Sign in again in Cindy, then retry.",
     "instanceIsolatedInvalidated": "Cindy is currently using a separately signed-in ChatGPT account. That sign-in is no longer valid. Sign in again in Cindy, then retry.",
     "unknownInvalidated": "Cindy’s current ChatGPT sign-in is no longer valid. Sign in again, then retry.",
     "recovered": "ChatGPT sign-in has been restored. Please retry.",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5626,7 +5626,7 @@
   },
   "chatgptAuthRecovery": {
     "title": "ChatGPT のログインが無効になりました",
-    "systemSharedInvalidated": "Cindy は現在、このコンピューターの ChatGPT ログインを使用しています。このログインは無効になりました。ChatGPT App を開いて再度ログインしてから、再試行してください。",
+    "systemSharedInvalidated": "Cindy は現在、このコンピューターの ChatGPT ログインを使用しています。このログインは無効になりました。Cindy で再度ログインしてから、再試行してください。",
     "instanceIsolatedInvalidated": "Cindy は現在、個別にログインした ChatGPT アカウントを使用しています。このログインは無効になりました。Cindy で再度ログインしてから、再試行してください。",
     "unknownInvalidated": "Cindy の現在の ChatGPT ログインは無効になりました。再度ログインしてから、再試行してください。",
     "recovered": "ChatGPT ログインが復旧しました。再試行してください。",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5626,7 +5626,7 @@
   },
   "chatgptAuthRecovery": {
     "title": "ChatGPT 로그인이 더 이상 유효하지 않습니다",
-    "systemSharedInvalidated": "Cindy는 현재 이 컴퓨터의 ChatGPT 로그인을 사용하고 있습니다. 이 로그인이 만료되었습니다. ChatGPT App을 열어 다시 로그인한 후 재시도하세요.",
+    "systemSharedInvalidated": "Cindy는 현재 이 컴퓨터의 ChatGPT 로그인을 사용하고 있습니다. 이 로그인이 만료되었습니다. Cindy에서 다시 로그인한 후 재시도하세요.",
     "instanceIsolatedInvalidated": "Cindy는 현재 별도로 로그인한 ChatGPT 계정을 사용하고 있습니다. 이 로그인이 만료되었습니다. Cindy에서 다시 로그인한 후 재시도하세요.",
     "unknownInvalidated": "Cindy의 현재 ChatGPT 로그인이 만료되었습니다. 다시 로그인한 후 재시도하세요.",
     "recovered": "ChatGPT 로그인이 복구되었습니다. 다시 시도하세요.",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5626,7 +5626,7 @@
   },
   "chatgptAuthRecovery": {
     "title": "ChatGPT 登录已失效",
-    "systemSharedInvalidated": "Cindy 当前沿用了本机的 ChatGPT 登录。该登录已失效。请打开 ChatGPT App 重新登录后重试。",
+    "systemSharedInvalidated": "Cindy 当前沿用了本机的 ChatGPT 登录。该登录已失效。请在 Cindy 中重新登录后重试。",
     "instanceIsolatedInvalidated": "Cindy 当前使用的是单独登录的 ChatGPT 账号。该登录已失效。请在 Cindy 中重新登录后重试。",
     "unknownInvalidated": "Cindy 当前的 ChatGPT 登录已失效。请重新登录后重试。",
     "recovered": "ChatGPT 登录已恢复，请重试。",


### PR DESCRIPTION
## 这次改了什么

### 摘要

ChatGPT 系统共享授权失效时，Cindy 原先只让用户打开 ChatGPT App；该动作不会刷新 Cindy/Codex 实际读取的授权，所以界面一直无法恢复，而命令行 `codex login` 能恢复。

本 PR 把设置页、聊天错误横幅、语音失效提示三个恢复入口统一改为 Cindy 现有的 Codex 登录流程。登录完成后继续沿用现有账号级验证与热恢复，无需重启 Cindy。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 ChatGPT/Codex 授权失效后无法从 Cindy 重新配置
- 本 PR 包含：三个系统共享授权恢复入口改为 Cindy 内重新登录；四语言提示同步；成功、取消、失败路径回归测试
- 明确不包含：OAuth 存储、失效 marker、系统凭据 reconcile、账号级恢复验证、旧 ChatGPT App IPC 清理
- 用户可见变化：按钮由“打开 ChatGPT App”改为“重新登录 ChatGPT”，点击后直接启动 Cindy 登录流程
- 是否存在 breaking change：无

### UI 变化

无布局或样式变化；仅修正恢复按钮动作与对应四语言文案。未附截图。

- 引用的设计规范：`docs/design-rules/DESIGN.md §11 Voice & Content`——提示准确说明当前失效状态，按钮文案直接描述会执行的恢复动作；四语言同步并通过 i18n 检查。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/providersSectionDeepLink.test.tsx src/renderer/components/chat/__tests__/ErrorBannerCodexOAuth.test.tsx
结果：2 个文件、38 项测试通过

pnpm check:i18n
结果：通过；四语言 6873 个 key 一致，仅保留仓库既有非阻塞警告

pnpm check:i18n-glossary
结果：通过；无新增术语违规

pnpm --filter desktop run --if-present typecheck
结果：通过

bash -c 'for v in $(env | awk -F= "/^CLAUDE/{print $1}"); do unset $v; done; pnpm test:unit'
结果：全部必跑 workspace 通过
```

### 手工验证

不主动撤销当前真实账号授权，避免破坏本机正在使用的登录；实际组件交互由设置页、聊天横幅和语音提示的回归测试覆盖。

### 未执行的验证

- 未用真实账号制造系统共享授权失效；可在下次真实失效时点击“重新登录 ChatGPT”，确认浏览器登录完成后 Cindy 无需重启即恢复。
- 未单独启动 dev 实例做视觉走查；本 PR 不改布局或样式，用户可见变化限于按钮文案和说明文字。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：ChatGPT/Codex 授权恢复交互

### 影响与回滚

- 影响范围：仅本机 ChatGPT/Codex 授权已失效时的恢复入口；正常登录、退出和其它供应商不受影响。
- 回滚 / 降级方式：回滚本提交即可恢复旧的“打开 ChatGPT App”入口；凭据格式与存储未变化。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
