### PR TITLE
fix(mobile): 调整输入文字跨平台垂直对齐

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -284,7 +284,6 @@ import {
   MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
   MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
   MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
-  MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
   MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   MOBILE_COMPOSER_TOOL_GAP,
   MobileComposerInputRow,
@@ -340,6 +339,10 @@ import {
   shouldArmComposerVoiceHold,
 } from '@/session/composerVoiceHold';
 import { COMPOSER_TEXT_HORIZONTAL_PADDING } from '@/session/composerTextMetrics';
+import {
+  COMPOSER_TEXT_PADDING_BOTTOM,
+  COMPOSER_TEXT_PADDING_TOP,
+} from '@/session/composerTextPlatformMetrics';
 import {
   isMobileRealtimeAudioAvailable,
   prewarmMobileRealtimeAudio,
@@ -543,7 +546,6 @@ const COMPOSER_CONTROL_HIT_SLOP = { bottom: 8, left: 8, right: 8, top: 8 };
 const COMPOSER_INPUT_SINGLE_LINE_CONTENT_HEIGHT = MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT;
 const COMPOSER_INPUT_MULTILINE_CONTENT_THRESHOLD = 34;
 const COMPOSER_INPUT_LINE_HEIGHT = MOBILE_COMPOSER_INPUT_LINE_HEIGHT;
-const COMPOSER_INPUT_VERTICAL_PADDING = MOBILE_COMPOSER_INPUT_VERTICAL_PADDING;
 const COMPOSER_INPUT_MAX_CONTENT_HEIGHT = MOBILE_COMPOSER_INPUT_MAX_HEIGHT;
 const COMPOSER_VERTICAL_PADDING_HEIGHT = 12;
 const COMPOSER_STATUS_ROW_RESERVED_HEIGHT = 28;
@@ -9760,8 +9762,9 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   // 内边距与真实输入框同源:差一点就会让听写文字与非听写文字左右错位、换行位置不同。
   voiceDraftOverlayContent: {
+    paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM,
     paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
-    paddingVertical: COMPOSER_INPUT_VERTICAL_PADDING,
+    paddingTop: COMPOSER_TEXT_PADDING_TOP,
   },
   voiceDraftMeasuredBlock: {
     minHeight: COMPOSER_INPUT_LINE_HEIGHT,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -207,7 +207,6 @@ import {
   MOBILE_COMPOSER_INPUT_LINE_HEIGHT,
   MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
   MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
-  MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
   MOBILE_COMPOSER_MIN_TOUCH_TARGET,
   MobileComposerInputRow,
   VoiceMicWaveCaret,
@@ -228,6 +227,10 @@ import {
   shouldArmComposerVoiceHold,
 } from '@/session/composerVoiceHold';
 import { COMPOSER_TEXT_HORIZONTAL_PADDING } from '@/session/composerTextMetrics';
+import {
+  COMPOSER_TEXT_PADDING_BOTTOM,
+  COMPOSER_TEXT_PADDING_TOP,
+} from '@/session/composerTextPlatformMetrics';
 import {
   isMobileRealtimeAudioAvailable,
   prewarmMobileRealtimeAudio,
@@ -5788,8 +5791,9 @@ const makeStyles = (colors: ThemeColors) => StyleSheet.create({
   },
   // 内边距与真实输入框同源:差一点就会让听写文字与非听写文字左右错位、换行位置不同。
   voiceDraftOverlayContent: {
+    paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM,
     paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
-    paddingVertical: MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
+    paddingTop: COMPOSER_TEXT_PADDING_TOP,
   },
   voiceDraftMeasuredBlock: {
     minHeight: MOBILE_COMPOSER_INPUT_LINE_HEIGHT,

--- a/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
+++ b/apps/mobile/src/__tests__/composerRichInputHtml.test.ts
@@ -55,6 +55,28 @@ describe('mobile composer rich input HTML', () => {
     expect(html).not.toContain('border-radius: 4px');
   });
 
+  it('does not apply the iOS optical offset to Android rich input', () => {
+    const androidHtml = buildComposerRichInputHtml({
+      accessibilityLabel: '输入消息',
+      document: { version: 1, nodes: [] },
+      editable: true,
+      maxHeight: 264,
+      platform: 'android',
+      placeholder: '发送消息',
+      theme: {
+        background: '#eee',
+        border: '#aaa',
+        chip: '#ddd',
+        focus: '#555',
+        placeholder: '#777',
+        text: '#111',
+        textSecondary: '#333',
+      },
+    });
+    expect(androidHtml).toContain('padding: 3px 4px 3px;');
+    expect(androidHtml).not.toContain('padding: 6px 4px 0px;');
+  });
+
   it('keeps the WebKit caret in an editable text anchor after every atom', () => {
     expect(html).toContain("const CARET_ANCHOR = '\\u200B'");
     expect(html).toContain('return node.type === \'text\' ? [element] : [element, makeCaretAnchor()]');

--- a/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
+++ b/apps/mobile/src/__tests__/composerVoiceDraftMetrics.test.ts
@@ -1,6 +1,15 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import {
+  COMPOSER_SINGLE_LINE_HEIGHT,
+  COMPOSER_TEXT_LINE_HEIGHT,
+  COMPOSER_TEXT_OPTICAL_OFFSET_Y,
+  COMPOSER_TEXT_PADDING_BOTTOM,
+  COMPOSER_TEXT_PADDING_TOP,
+  COMPOSER_TEXT_VERTICAL_PADDING,
+  composerTextPaddingForPlatform,
+} from '@/session/composerTextMetrics';
 
 /**
  * Composer 三个文本渲染器的度量一致性守护。
@@ -55,17 +64,37 @@ describe('composer voice draft text metrics', () => {
     expect(source).toContain('export const MOBILE_COMPOSER_INPUT_LINE_HEIGHT = COMPOSER_TEXT_LINE_HEIGHT;');
   });
 
+  it('optically lowers composer glyphs without changing the single-line height', () => {
+    expect(COMPOSER_TEXT_OPTICAL_OFFSET_Y).toBe(3);
+    expect(COMPOSER_TEXT_PADDING_TOP).toBe(6);
+    expect(COMPOSER_TEXT_PADDING_BOTTOM).toBe(0);
+    expect(COMPOSER_TEXT_PADDING_TOP + COMPOSER_TEXT_PADDING_BOTTOM)
+      .toBe(COMPOSER_TEXT_VERTICAL_PADDING * 2);
+    expect(COMPOSER_SINGLE_LINE_HEIGHT)
+      .toBe(COMPOSER_TEXT_LINE_HEIGHT + COMPOSER_TEXT_PADDING_TOP + COMPOSER_TEXT_PADDING_BOTTOM);
+  });
+
+  it('keeps the optical offset iOS-only because Android has different font padding', () => {
+    expect(composerTextPaddingForPlatform('ios')).toEqual({ top: 6, bottom: 0 });
+    expect(composerTextPaddingForPlatform('android')).toEqual({ top: 3, bottom: 3 });
+    expect(composerTextPaddingForPlatform('default')).toEqual({ top: 3, bottom: 3 });
+  });
+
   it('renders the real composer TextInput with the shared metrics', () => {
-    const block = styleBlock(read(COMPOSER_ROW), 'input');
+    const composerRowSource = read(COMPOSER_ROW);
+    const block = styleBlock(composerRowSource, 'input');
+    expect(composerRowSource).toContain("from '@/session/composerTextPlatformMetrics'");
     expect(block).toContain('...COMPOSER_TEXT_STYLE');
+    expect(block).toContain('paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM');
     expect(block).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
+    expect(block).toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
   });
 
   it('renders the WebView rich composer with the shared metrics instead of CSS literals', () => {
     const source = read(RICH_INPUT_HTML);
     expect(source).toContain('font-size: ${COMPOSER_TEXT_FONT_SIZE}px');
     expect(source).toContain('line-height: ${COMPOSER_TEXT_LINE_HEIGHT}px');
-    expect(source).toContain('padding: ${COMPOSER_TEXT_VERTICAL_PADDING}px ${COMPOSER_TEXT_HORIZONTAL_PADDING}px');
+    expect(source).toContain('padding: ${composerTextPadding.top}px ${COMPOSER_TEXT_HORIZONTAL_PADDING}px ${composerTextPadding.bottom}px');
     // #editor 的排版不得回退成字面量(CSS 不在 typographyTokenDiscipline 的扫描面内)。
     const editorBlock = /#editor \{([^}]*)\}/.exec(source)?.[1] ?? '';
     expect(editorBlock).not.toMatch(/font-size:\s*\d/);
@@ -81,8 +110,12 @@ describe('composer voice draft text metrics', () => {
         expect(block, `${rel} ${name} 不得自带字号 / 行高`).not.toMatch(/fontSize|lineHeight/);
       }
       const overlayContent = styleBlock(source, 'voiceDraftOverlayContent');
+      expect(overlayContent, `${rel} 覆盖层底部内边距必须与输入框同源`)
+        .toContain('paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM');
       expect(overlayContent, `${rel} 覆盖层水平内边距必须与输入框同源`)
         .toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
+      expect(overlayContent, `${rel} 覆盖层顶部内边距必须与输入框同源`)
+        .toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
     }
   });
 

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -214,9 +214,11 @@ describe('mobile session composer desktop-first surface', () => {
     expect(inputStyle).toContain('...COMPOSER_TEXT_STYLE');
     expect(inputStyle).toContain('maxHeight: MOBILE_COMPOSER_INPUT_MAX_HEIGHT');
     expect(inputStyle).toContain('minHeight: MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT');
+    expect(inputStyle).toContain('paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM');
     expect(inputStyle).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
-    expect(inputStyle).toContain('paddingVertical: MOBILE_COMPOSER_INPUT_VERTICAL_PADDING');
+    expect(inputStyle).toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
     expect(inputStyle).toContain("textAlignVertical: 'top'");
+    expect(floatingButtonStyle).toContain("bottom: Platform.OS === 'ios' ? 8 : 11");
     // Composer input is a single stable, always-multiline, always-inline instance (no compact↔expanded
     // swap that remounts the native input) so the first tap reliably opens the keyboard — guards the
     // "two taps to focus" regression. Compact rest look kept via minHeight (no fixed height that clips).
@@ -247,7 +249,6 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('const COMPOSER_INPUT_SINGLE_LINE_CONTENT_HEIGHT = MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT;');
     expect(source).toContain('const COMPOSER_INPUT_MULTILINE_CONTENT_THRESHOLD = 34;');
     expect(source).toContain('const COMPOSER_INPUT_LINE_HEIGHT = MOBILE_COMPOSER_INPUT_LINE_HEIGHT;');
-    expect(source).toContain('const COMPOSER_INPUT_VERTICAL_PADDING = MOBILE_COMPOSER_INPUT_VERTICAL_PADDING;');
     expect(source).toContain('const COMPOSER_INPUT_MAX_CONTENT_HEIGHT = MOBILE_COMPOSER_INPUT_MAX_HEIGHT;');
     expect(sharedSource).toContain('export const MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES = 12;');
     expect(sharedSource).toContain('export const MOBILE_COMPOSER_INPUT_MAX_HEIGHT = (MOBILE_COMPOSER_INPUT_LINE_HEIGHT * MOBILE_COMPOSER_INPUT_MAX_VISIBLE_LINES)');
@@ -363,8 +364,9 @@ describe('mobile session composer desktop-first surface', () => {
     expect(voiceDraftOverlayStyle).toContain("overflow: 'hidden'");
     expect(voiceDraftOverlayContentStyle).not.toContain('minHeight: COMPOSER_INPUT_SINGLE_LINE_CONTENT_HEIGHT');
     expect(voiceDraftOverlayContentStyle).not.toContain("alignItems: 'flex-start'");
+    expect(voiceDraftOverlayContentStyle).toContain('paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM');
     expect(voiceDraftOverlayContentStyle).toContain('paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING');
-    expect(voiceDraftOverlayContentStyle).toContain('paddingVertical: COMPOSER_INPUT_VERTICAL_PADDING');
+    expect(voiceDraftOverlayContentStyle).toContain('paddingTop: COMPOSER_TEXT_PADDING_TOP');
     expect(voiceDraftOverlayContentStyle).not.toContain("width: '100%'");
     expect(voiceDraftMeasuredBlockStyle).not.toContain("alignSelf: 'flex-start'");
     expect(voiceDraftMeasuredBlockStyle).toContain('minHeight: COMPOSER_INPUT_LINE_HEIGHT');
@@ -483,7 +485,7 @@ describe('mobile session composer desktop-first surface', () => {
     expect(inlineButtonStyle).not.toContain('width: 42');
     expect(floatingButtonStyle).toContain("position: 'absolute'");
     expect(floatingButtonStyle).toContain('right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT');
-    expect(floatingButtonStyle).toContain('bottom: 11');
+    expect(floatingButtonStyle).toContain("bottom: Platform.OS === 'ios' ? 8 : 11");
     expect(floatingButtonStyle).toContain('zIndex: 2');
     expect(sharedSource).toContain('right: spacing.md + MOBILE_COMPOSER_CONTROL_SIZE + MOBILE_COMPOSER_TOOL_GAP');
     expect(sendButtonStyle).toContain('height: 34');

--- a/apps/mobile/src/session/ComposerRichInput.tsx
+++ b/apps/mobile/src/session/ComposerRichInput.tsx
@@ -95,6 +95,7 @@ export const ComposerRichInput = forwardRef<ComposerRichInputHandle, ComposerRic
       document,
       editable,
       maxHeight,
+      platform: Platform.OS === 'ios' ? 'ios' as const : Platform.OS === 'android' ? 'android' as const : 'default' as const,
       placeholder,
       theme,
     });

--- a/apps/mobile/src/session/MobileComposerInputRow.tsx
+++ b/apps/mobile/src/session/MobileComposerInputRow.tsx
@@ -1,6 +1,7 @@
 import {
   Animated,
   Easing,
+  Platform,
   StyleSheet,
   View,
   type GestureResponderHandlers,
@@ -25,6 +26,10 @@ import {
   COMPOSER_TEXT_STYLE,
   COMPOSER_TEXT_VERTICAL_PADDING,
 } from '@/session/composerTextMetrics';
+import {
+  COMPOSER_TEXT_PADDING_BOTTOM,
+  COMPOSER_TEXT_PADDING_TOP,
+} from '@/session/composerTextPlatformMetrics';
 
 /**
  * Composer 草稿文本的排版档。正本在 `composerTextMetrics`——原生输入框、WebView 富文本
@@ -568,14 +573,17 @@ const makeMobileComposerInputRowStyles = (colors: ThemeColors) => ({
     ...COMPOSER_TEXT_STYLE,
     maxHeight: MOBILE_COMPOSER_INPUT_MAX_HEIGHT,
     minHeight: MOBILE_COMPOSER_INPUT_SINGLE_LINE_HEIGHT,
+    paddingBottom: COMPOSER_TEXT_PADDING_BOTTOM,
     paddingHorizontal: COMPOSER_TEXT_HORIZONTAL_PADDING,
-    paddingVertical: MOBILE_COMPOSER_INPUT_VERTICAL_PADDING,
+    paddingTop: COMPOSER_TEXT_PADDING_TOP,
     textAlignVertical: 'top',
   },
   // 语音按钮的 absolute 锚点：简洁态贴输入行右侧垂直居中；
   // 有发送按钮时向左让位；卡片态下沉到底部工具排的占位上。
   voiceButtonAnchor: {
-    bottom: 11,
+    // iOS 的文字 padding 是 6/0,按钮随文字下移 3pt；Android 保持 3/3,
+    // 不应继承 iOS 的补偿。
+    bottom: Platform.OS === 'ios' ? 8 : 11,
     position: 'absolute',
     right: MOBILE_COMPOSER_VOICE_ANCHOR_RIGHT,
     zIndex: 2,

--- a/apps/mobile/src/session/composerRichInputHtml.ts
+++ b/apps/mobile/src/session/composerRichInputHtml.ts
@@ -11,7 +11,8 @@ import {
   COMPOSER_TEXT_FONT_SIZE,
   COMPOSER_TEXT_HORIZONTAL_PADDING,
   COMPOSER_TEXT_LINE_HEIGHT,
-  COMPOSER_TEXT_VERTICAL_PADDING,
+  composerTextPaddingForPlatform,
+  type ComposerTextPlatform,
 } from '@/session/composerTextMetrics';
 
 export interface ComposerRichInputTheme {
@@ -30,6 +31,7 @@ export interface ComposerRichInputConfig {
   editable: boolean;
   maxHeight: number;
   placeholder: string;
+  platform?: ComposerTextPlatform;
   theme: ComposerRichInputTheme;
 }
 
@@ -40,6 +42,7 @@ export interface ComposerRichInputConfig {
  */
 export function buildComposerRichInputHtml(config: ComposerRichInputConfig): string {
   const bootstrap = JSON.stringify(config).replace(/</g, '\\u003c');
+  const composerTextPadding = composerTextPaddingForPlatform(config.platform ?? 'ios');
   return `<!doctype html>
 <html><head><meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
 <style>
@@ -54,7 +57,7 @@ export function buildComposerRichInputHtml(config: ComposerRichInputConfig): str
     font-size: ${COMPOSER_TEXT_FONT_SIZE}px; line-height: ${COMPOSER_TEXT_LINE_HEIGHT}px;
     min-height: ${COMPOSER_SINGLE_LINE_HEIGHT}px; max-height: var(--max-height);
     overflow-y: auto; outline: none;
-    padding: ${COMPOSER_TEXT_VERTICAL_PADDING}px ${COMPOSER_TEXT_HORIZONTAL_PADDING}px;
+    padding: ${composerTextPadding.top}px ${COMPOSER_TEXT_HORIZONTAL_PADDING}px ${composerTextPadding.bottom}px;
     white-space: pre-wrap; overflow-wrap: anywhere; -webkit-user-select: text;
   }
   #editor:empty::before { content: attr(data-placeholder); color: var(--placeholder); pointer-events: none; }

--- a/apps/mobile/src/session/composerTextMetrics.ts
+++ b/apps/mobile/src/session/composerTextMetrics.ts
@@ -26,12 +26,39 @@ export const COMPOSER_TEXT_FONT_SIZE = typeScale.code;
 export const COMPOSER_TEXT_LINE_HEIGHT = lineHeight.body;
 /** 输入文本左右内边距:三个渲染器必须一致,否则听写与非听写的文字左右错位。 */
 export const COMPOSER_TEXT_HORIZONTAL_PADDING = spacing.xs;
-/** 输入文本上下内边距(单行行高之外的呼吸)。 */
+/** 输入文本上下内边距总量的一半；盒高计算仍保持上下合计 6pt。 */
 export const COMPOSER_TEXT_VERTICAL_PADDING = 3;
+/**
+ * iOS 字形在 15/22 行框里的视觉中心比几何中心高约 3pt。Android 的
+ * includeFontPadding 默认值不同,不能直接复用这个偏移；调用方应通过
+ * composerTextPaddingForPlatform 取对应平台的上下值。
+ */
+export const COMPOSER_TEXT_OPTICAL_OFFSET_Y = 3;
+
+export type ComposerTextPlatform = 'ios' | 'android' | 'default';
+
+export interface ComposerTextPadding {
+  bottom: number;
+  top: number;
+}
+
+export function composerTextPaddingForPlatform(platform: ComposerTextPlatform): ComposerTextPadding {
+  const opticalOffset = platform === 'ios' ? COMPOSER_TEXT_OPTICAL_OFFSET_Y : 0;
+  return {
+    bottom: COMPOSER_TEXT_VERTICAL_PADDING - opticalOffset,
+    top: COMPOSER_TEXT_VERTICAL_PADDING + opticalOffset,
+  };
+}
+
+// Node-side consumers and the existing iOS WebView tests use iOS as the
+// canonical reference. React Native consumers import the platform adapter.
+const iosComposerTextPadding = composerTextPaddingForPlatform('ios');
+export const COMPOSER_TEXT_PADDING_TOP = iosComposerTextPadding.top;
+export const COMPOSER_TEXT_PADDING_BOTTOM = iosComposerTextPadding.bottom;
 
 /** 单行输入区的可视高度 = 单行行高 + 上下内边距;原生输入框与 WebView 编辑器同源。 */
 export const COMPOSER_SINGLE_LINE_HEIGHT =
-  COMPOSER_TEXT_LINE_HEIGHT + (COMPOSER_TEXT_VERTICAL_PADDING * 2);
+  COMPOSER_TEXT_LINE_HEIGHT + COMPOSER_TEXT_PADDING_TOP + COMPOSER_TEXT_PADDING_BOTTOM;
 
 /** RN 样式片段:`...COMPOSER_TEXT_STYLE` 一次展开字号 + 行高,不给漂移留缝。 */
 export const COMPOSER_TEXT_STYLE = {

--- a/apps/mobile/src/session/composerTextPlatformMetrics.ts
+++ b/apps/mobile/src/session/composerTextPlatformMetrics.ts
@@ -1,0 +1,17 @@
+import { Platform } from 'react-native';
+import {
+  composerTextPaddingForPlatform,
+  type ComposerTextPlatform,
+} from '@/session/composerTextMetrics';
+
+const composerTextPlatform: ComposerTextPlatform = Platform.OS === 'ios'
+  ? 'ios'
+  : Platform.OS === 'android'
+    ? 'android'
+    : 'default';
+
+const composerTextPadding = composerTextPaddingForPlatform(composerTextPlatform);
+
+/** Platform-specific padding adapter; the base metrics remain node-testable. */
+export const COMPOSER_TEXT_PADDING_TOP = composerTextPadding.top;
+export const COMPOSER_TEXT_PADDING_BOTTOM = composerTextPadding.bottom;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复移动端 Composer 输入文字在 iOS 上的视觉垂直偏移，并让原生输入框、富文本 WebView 编辑器和语音听写覆盖层使用同一套平台化文字度量。iOS 使用 `6/0` 的上下内边距，Android 保持 `3/3`，上下内边距总量不变，因此单行输入框高度不变。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `test` 测试补充

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Composer 文本上下内边距的平台适配；原生 TextInput、富文本 WebView、语音覆盖层和麦克风锚点同步；相关守护测试。
- 明确不包含：消息气泡的固定偏移或按行数特殊处理。该实验已撤回，消息气泡保持原有对称 padding。
- 用户可见变化：iOS Composer 输入文字视觉上向下调整；Android 保持原有文字位置和输入框总高度。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §3 Typography（字号与行高来自既有 token）；§5 Layout Principles / Spacing System（保持既有间距总量与稳定输入框高度）；双模式交付要求（颜色与主题未改，Light/Dark 继续复用现有语义 token）。

## 怎么验证的

### 自动验证

```text
pnpm install
结果：通过；同时完成仓库 postinstall 的 model-access-protocol 构建。

pnpm --filter @cindy/plugin-protocol build
结果：通过。

pnpm --filter mobile typecheck
结果：通过。

pnpm --filter mobile exec vitest run src/__tests__/composerRichInputHtml.test.ts src/__tests__/composerVoiceDraftMetrics.test.ts src/__tests__/sessionComposerDesktopFirst.test.ts
结果：3 个测试文件、22 个用例通过。

bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy/.cindy-worktrees/auto-hgoqma
结果：GATE_EXIT=0，全仓单元测试通过。

pnpm check:dco
结果：通过，1 个提交包含 DCO Signed-off-by。
```

### 手工验证

在 `cindy/auto-hgoqma` worktree 的 iPhone 17 Pro iOS Simulator 上启动过当前版本并检查过移动端会话界面。模拟器未用于最终 Composer 多行滚动到最大高度的完整目检。

### 未执行的验证

- 未完成 iOS Composer 多行输入滚动到最大高度时末行下缘留白的最终目检。
- 未完成 Android 实机/模拟器目检。
- 未完成 Light/Dark 两种模式的最终截图目检。

## 风险

### 风险分类

- [x] 跨平台差异
- [x] 其他：移动端 UI 排版调整

### 影响与回滚

- 影响范围：移动端 Composer 的文本内边距和语音按钮锚点；不涉及消息气泡、协议、数据、原生依赖或 Expo 配置。
- 回滚 / 降级方式：回滚本 PR 即恢复原有对称 `3/3` 输入文字内边距和原有麦克风锚点；本 PR 不改变 mobile runtime fingerprint 输入。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
