### PR TITLE
fix(desktop): 为置顶计划增加手动关闭入口

### DIFF
--- a/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
@@ -264,9 +264,9 @@ export function TodoListCard({
                   className={cn(
                     'absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full',
                     'text-[var(--msg-tool-card-chevron)] transition-colors',
-                    'hover:bg-[var(--surface-hover)] hover:text-[var(--msg-tool-card-text)]',
+                    'hover:bg-[var(--model-item-hover)] hover:text-[var(--msg-tool-card-text)]',
                     'active:scale-[0.98]',
-                    'focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
                   )}
                 >
                   <X size={14} aria-hidden="true" />

--- a/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
@@ -21,7 +21,7 @@
  */
 
 import { useEffect, useId, useRef, useState } from 'react';
-import { CircleCheck, CircleDot, Circle } from 'lucide-react';
+import { CircleCheck, CircleDot, Circle, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { MessageRenderTodoItem } from '@cindy/maker-shared/message-render';
 
@@ -102,6 +102,7 @@ export function TodoListCard({
   todos,
   animated = false,
   maxWidth,
+  onDismiss,
 }: {
   todos: TodoItem[];
   /**
@@ -112,6 +113,8 @@ export function TodoListCard({
   animated?: boolean;
   /** Composer/chat column width. Keeps the flyout inside clipped compact panes. */
   maxWidth?: number;
+  /** Hide the current rendered snapshot without mutating the agent's plan state. */
+  onDismiss?: () => void;
 }) {
   const { t } = useTranslation();
   const flyoutId = useId();
@@ -243,7 +246,7 @@ export function TodoListCard({
             <div
               aria-hidden={!revealed}
               className={cn(
-                'w-full origin-bottom overflow-hidden rounded-[12px]',
+                'relative w-full origin-bottom overflow-hidden rounded-[12px]',
                 'border border-[var(--msg-tool-card-border)]',
                 'bg-[var(--msg-tool-card-bg)]',
                 revealed ? 'animate-float-in' : 'animate-float-out',
@@ -252,7 +255,29 @@ export function TodoListCard({
                 if (!revealed) setRenderFlyout(false);
               }}
             >
-              <div className="flex max-h-[280px] flex-col gap-[2px] overflow-y-auto px-[14px] py-[10px]">
+              {onDismiss && revealed && (
+                <button
+                  type="button"
+                  onClick={onDismiss}
+                  aria-label={t('chat.planPill.dismiss')}
+                  title={t('chat.planPill.dismiss')}
+                  className={cn(
+                    'absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full',
+                    'text-[var(--msg-tool-card-chevron)] transition-colors',
+                    'hover:bg-[var(--surface-hover)] hover:text-[var(--msg-tool-card-text)]',
+                    'active:scale-[0.98]',
+                    'focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                  )}
+                >
+                  <X size={14} aria-hidden="true" />
+                </button>
+              )}
+              <div
+                className={cn(
+                  'flex max-h-[280px] flex-col gap-[2px] overflow-y-auto py-[10px] pl-[14px]',
+                  onDismiss ? 'pr-10' : 'pr-[14px]',
+                )}
+              >
                 {todos.map((todo, i) => (
                   <div key={i} className="flex h-[30px] items-center gap-[10px]">
                       {/* Icon */}

--- a/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/TodoListCard.tsx
@@ -25,6 +25,7 @@ import { CircleCheck, CircleDot, Circle, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { MessageRenderTodoItem } from '@cindy/maker-shared/message-render';
 
+import { Tip } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
 // ---------------------------------------------------------------------------
@@ -256,21 +257,22 @@ export function TodoListCard({
               }}
             >
               {onDismiss && revealed && (
-                <button
-                  type="button"
-                  onClick={onDismiss}
-                  aria-label={t('chat.planPill.dismiss')}
-                  title={t('chat.planPill.dismiss')}
-                  className={cn(
-                    'absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full',
-                    'text-[var(--msg-tool-card-chevron)] transition-colors',
-                    'hover:bg-[var(--model-item-hover)] hover:text-[var(--msg-tool-card-text)]',
-                    'active:scale-[0.98]',
-                    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
-                  )}
-                >
-                  <X size={14} aria-hidden="true" />
-                </button>
+                <Tip text={t('chat.planPill.dismiss')}>
+                  <button
+                    type="button"
+                    onClick={onDismiss}
+                    aria-label={t('chat.planPill.dismiss')}
+                    className={cn(
+                      'absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full',
+                      'text-[var(--msg-tool-card-chevron)] transition-colors',
+                      'hover:bg-[var(--model-item-hover)] hover:text-[var(--msg-tool-card-text)]',
+                      'active:scale-[0.98]',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]',
+                    )}
+                  >
+                    <X size={14} aria-hidden="true" />
+                  </button>
+                </Tip>
               )}
               <div
                 className={cn(

--- a/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
@@ -7,8 +7,8 @@ import { TodoListCard } from '../TodoListCard';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
-    t: (_key: string, values: { current: number; total: number }) =>
-      `Step ${values.current} / ${values.total}`,
+    t: (key: string, values?: { current: number; total: number }) =>
+      key === 'chat.planPill.dismiss' ? 'Close Plan' : `Step ${values?.current} / ${values?.total}`,
   }),
 }));
 
@@ -152,6 +152,17 @@ describe('TodoListCard flyout interaction', () => {
 
     fireEvent.click(trigger, { detail: 0 });
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('offers an accessible close action inside the expanded plan', () => {
+    const onDismiss = vi.fn();
+    render(<TodoListCard todos={TODOS} animated={false} onDismiss={onDismiss} />);
+
+    const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole('button', { name: 'Close Plan' }));
+
+    expect(onDismiss).toHaveBeenCalledOnce();
   });
 
   it('keeps centering and entrance animation transforms on separate elements', () => {

--- a/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
@@ -160,7 +160,13 @@ describe('TodoListCard flyout interaction', () => {
 
     const trigger = screen.getByRole('button', { name: 'Step 1 / 2' });
     fireEvent.click(trigger);
-    fireEvent.click(screen.getByRole('button', { name: 'Close Plan' }));
+    const closeButton = screen.getByRole('button', { name: 'Close Plan' });
+
+    expect(closeButton.classList.contains('hover:bg-[var(--model-item-hover)]')).toBe(true);
+    expect(closeButton.classList.contains('hover:bg-[var(--surface-hover)]')).toBe(false);
+    expect(closeButton.classList.contains('focus-visible:outline-none')).toBe(true);
+
+    fireEvent.click(closeButton);
 
     expect(onDismiss).toHaveBeenCalledOnce();
   });

--- a/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/TodoListCard.test.tsx
@@ -154,7 +154,7 @@ describe('TodoListCard flyout interaction', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
-  it('offers an accessible close action inside the expanded plan', () => {
+  it('offers an accessible close action with a keyboard-visible shared tooltip', async () => {
     const onDismiss = vi.fn();
     render(<TodoListCard todos={TODOS} animated={false} onDismiss={onDismiss} />);
 
@@ -165,6 +165,10 @@ describe('TodoListCard flyout interaction', () => {
     expect(closeButton.classList.contains('hover:bg-[var(--model-item-hover)]')).toBe(true);
     expect(closeButton.classList.contains('hover:bg-[var(--surface-hover)]')).toBe(false);
     expect(closeButton.classList.contains('focus-visible:outline-none')).toBe(true);
+    expect(closeButton.getAttribute('title')).toBeNull();
+
+    fireEvent.focus(closeButton);
+    expect((await screen.findByRole('tooltip')).textContent).toBe('Close Plan');
 
     fireEvent.click(closeButton);
 

--- a/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/PinnedPlanPanel.tsx
@@ -133,10 +133,19 @@ export function PinnedPlanPanel({
     if (current?.identity === completionIdentity && current.deadlineMs >= completionDeadlineMs) return;
     deadlineFloorRef.current = { identity: completionIdentity, deadlineMs: completionDeadlineMs };
   }, [completionDeadlineMs, completionIdentity]);
+  const snapshotIdentity = insertion
+    ? JSON.stringify([
+        sessionId ?? 'unknown',
+        insertion.key,
+        insertion.updatedAtMs ?? insertion.createdAt ?? null,
+        insertion.todos.map((todo) => [todo.status, todo.content]),
+      ])
+    : null;
   const completedPlanExpired = Boolean(
     completionDeadlineMs !== null && completionDeadlineMs <= Date.now(),
   );
   const [hiddenInsertionKey, setHiddenInsertionKey] = useState<string | null>(null);
+  const [dismissedSnapshotIdentity, setDismissedSnapshotIdentity] = useState<string | null>(null);
 
   useEffect(() => {
     if (!insertion || !retired) {
@@ -172,7 +181,8 @@ export function PinnedPlanPanel({
     !insertion ||
     insertion.todos.length < 2 ||
     completedPlanExpired ||
-    hiddenInsertionKey === insertion.key
+    hiddenInsertionKey === insertion.key ||
+    dismissedSnapshotIdentity === snapshotIdentity
   )
     return null;
 
@@ -187,6 +197,7 @@ export function PinnedPlanPanel({
         todos={insertion.todos}
         animated={animated}
         maxWidth={width}
+        onDismiss={() => setDismissedSnapshotIdentity(snapshotIdentity)}
       />
     </div>
   );

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
@@ -1,14 +1,27 @@
 // @vitest-environment jsdom
 
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChatMessage } from '@/lib/makerChatStore';
 
 import { PinnedPlanPanel } from '../PinnedPlanPanel';
 
 vi.mock('@/components/chat/TodoListCard', () => ({
-  TodoListCard: ({ todos }: { todos: Array<{ content: string }> }) => (
-    <div data-testid="plan-pill">{todos.map((todo) => todo.content).join(',')}</div>
+  TodoListCard: ({
+    todos,
+    onDismiss,
+  }: {
+    todos: Array<{ content: string }>;
+    onDismiss?: () => void;
+  }) => (
+    <div>
+      <div data-testid="plan-pill">{todos.map((todo) => todo.content).join(',')}</div>
+      {onDismiss && (
+        <button type="button" onClick={onDismiss}>
+          Dismiss Plan
+        </button>
+      )}
+    </div>
   ),
 }));
 
@@ -145,6 +158,53 @@ describe('PinnedPlanPanel completed plan lifetime', () => {
     );
 
     act(() => vi.advanceTimersByTime(10_000));
+    expect(screen.queryByTestId('plan-pill')).not.toBeNull();
+  });
+
+  it('keeps the current plan snapshot hidden after the user dismisses it', () => {
+    const running = planMessage('in_progress');
+    const view = render(
+      <PinnedPlanPanel sessionId="manual-dismiss" messages={[running]} animated width={400} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss Plan' }));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+
+    view.rerender(
+      <PinnedPlanPanel
+        sessionId="manual-dismiss"
+        messages={[
+          running,
+          {
+            clientId: 'unrelated-answer',
+            role: 'assistant',
+            content: 'Unrelated response',
+          },
+        ]}
+        animated={false}
+        width={400}
+      />,
+    );
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+  });
+
+  it('shows a dismissed plan again when the agent reports a newer snapshot', () => {
+    const running = planMessage('in_progress');
+    const view = render(
+      <PinnedPlanPanel sessionId="dismiss-update" messages={[running]} animated width={400} />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss Plan' }));
+    expect(screen.queryByTestId('plan-pill')).toBeNull();
+
+    view.rerender(
+      <PinnedPlanPanel
+        sessionId="dismiss-update"
+        messages={[planMessage('completed', T0, T0 + 1_000)]}
+        animated={false}
+        width={400}
+      />,
+    );
     expect(screen.queryByTestId('plan-pill')).not.toBeNull();
   });
 

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -6531,7 +6531,8 @@
       "outputFile": "Output: {{path}}"
     },
     "planPill": {
-      "step": "Step {{current}} of {{total}}"
+      "step": "Step {{current}} of {{total}}",
+      "dismiss": "Close Plan"
     },
     "forkOrigin": {
       "label": "Created from another session"

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -6529,7 +6529,8 @@
       "outputFile": "出力: {{path}}"
     },
     "planPill": {
-      "step": "ステップ {{current}} / {{total}}"
+      "step": "ステップ {{current}} / {{total}}",
+      "dismiss": "計画を閉じる"
     },
     "forkOrigin": {
       "label": "元のセッションから作成"

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -6529,7 +6529,8 @@
       "outputFile": "출력: {{path}}"
     },
     "planPill": {
-      "step": "{{current}} / {{total}}단계"
+      "step": "{{current}} / {{total}}단계",
+      "dismiss": "계획 닫기"
     },
     "forkOrigin": {
       "label": "원래 세션에서 생성됨"

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -6529,7 +6529,8 @@
       "outputFile": "输出：{{path}}"
     },
     "planPill": {
-      "step": "第 {{current}} / {{total}} 步"
+      "step": "第 {{current}} / {{total}} 步",
+      "dismiss": "关闭计划"
     },
     "forkOrigin": {
       "label": "基于原任务创建"

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -6527,9 +6527,10 @@
       "lastTool": "最近工具：{{tool}}",
       "outputFile": "輸出：{{path}}"
     },
-    "planPill": {
-      "step": "第 {{current}} / {{total}} 步"
-    },
+      "planPill": {
+        "step": "第 {{current}} / {{total}} 步",
+        "dismiss": "關閉計劃"
+      },
     "forkOrigin": {
       "label": "基於原任務建立"
     },


### PR DESCRIPTION
## 这次改了什么

### 摘要

给输入框上方的置顶计划浮层增加手动关闭入口，作为陈旧计划未能正常退场时的用户兜底。

- 展开计划浮层后，右上角显示可键盘聚焦、带无障碍标签的关闭按钮；
- 关闭只隐藏当前 renderer 中的这一份计划快照，不修改数据库，也不向 agent 发送清空计划；
- 无关消息更新不会让已关闭的快照复活；同一计划收到新的结构化进度快照后会重新出现；
- 新增 zh-CN / en / ja / ko 四语文案与回归测试。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2176（本 PR 补齐手动关闭兜底；成功终态退场与跨轮归属/对账分别由 #2065、#2137 处理）
- 本 PR 包含：置顶计划浮层关闭入口、当前快照的 renderer 侧隐藏语义、后续计划更新重新显示、四语 i18n 与测试
- 明确不包含：计划终态盖章、跨轮计划归属、自动对账、修改 agent 上报的步骤状态
- 用户可见变化：展开输入框上方的计划胶囊后，可以点击右上角关闭当前计划；若 agent 后续继续更新计划，新快照会重新显示
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：
  - `docs/design-rules/DESIGN.md` §4 Buttons / Cards：关闭操作使用紧凑圆形按钮与既有卡片 token，不新增颜色、阴影或圆角体系；
  - `docs/design-rules/DESIGN.md` §10 Light / Dark 双模式交付门槛：默认、hover、focus 状态全部复用语义 token，Light / Dark 共用同一实现；
  - `docs/design-rules/DESIGN.md` §11 Voice & Content：英文使用动词 + 对象的 `Close Plan`，四语同步落地；
  - `docs/design-rules/DESIGN.md` §14.2 Focus Management：关闭按钮可键盘聚焦，并使用现有 focus-ring token。

未附截图：本次未启动 Desktop 做实机目检，见下方「未执行的验证」。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；Desktop、Mobile、maker-core 及其余所有 required unit workspace 全绿

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec vitest run src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx src/renderer/components/chat/__tests__/TodoListCard.test.tsx
结果：2 files / 25 tests passed

pnpm check:i18n
pnpm check:i18n-glossary
结果：通过；四语 key 一致，无新增术语违规

pnpm exec eslint src/renderer/components/chat/TodoListCard.tsx src/renderer/components/chat/__tests__/TodoListCard.test.tsx src/renderer/components/new-chat/PinnedPlanPanel.tsx src/renderer/components/new-chat/__tests__/PinnedPlanPanel.test.tsx
结果：通过

node scripts/hardcoded-color-audit.mjs --base-ref upstream/main
结果：PASS，unexpected=0
```

### 手工验证

未执行 Desktop 实机验证；交互语义由 jsdom 回归测试覆盖：关闭当前快照、无关消息不复活、计划新快照重新显示、关闭按钮无障碍名称可访问。

### 未执行的验证

- Light / Dark 实机目检均未执行；实现只消费既有 `--msg-tool-card-*`、`--surface-hover`、`--focus-ring` 语义 token，不把这一事实表述为已完成双模式目检。
- `pnpm --filter desktop lint` 已尝试，但被当前 `upstream/main@512e3536` 的 192 个既有 ESLint error 阻断；本 PR 触及的 4 个 TS/TSX 文件单独 lint 通过。

## 风险

### 风险分类

- [x] 其他：用户可见的 renderer 侧隐藏行为

### 影响与回滚

- 影响范围：仅 Desktop 输入框上方的置顶计划展示；不改持久化 schema、agent 事件或共享消息模型。
- 取舍：关闭是当前 renderer 生命周期内的安全隐藏，不持久化“忽略”状态；应用重载后若底层仍只有同一份陈旧快照，它可能再次出现。这样避免把 UI 兜底误写成 agent 计划清空或新的用户持久偏好；#2065/#2137 负责从生命周期根因上减少陈旧快照。
- 回滚 / 降级方式：revert 本 commit 即可，无数据迁移或不可逆状态。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需修改仓库文档）
- [x] 已确认测试结果或说明未执行原因
