### PR TITLE
feat(desktop): mark pending token usage

### DIFF
--- a/apps/desktop/src/renderer/__tests__/runningTokenUsage.test.ts
+++ b/apps/desktop/src/renderer/__tests__/runningTokenUsage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRunningTokenUsage } from '@/features/cc-agent/lib/runningTokenUsage';
+
+describe('formatRunningTokenUsage', () => {
+  it('marks zero usage as pending while a turn is running', () => {
+    expect(formatRunningTokenUsage(0, true)).toBe('— tokens');
+  });
+
+  it('keeps authoritative completed and positive usage values', () => {
+    expect(formatRunningTokenUsage(0, false)).toBe('0 tokens');
+    expect(formatRunningTokenUsage(999, true)).toBe('999 tokens');
+    expect(formatRunningTokenUsage(1250, true)).toBe('1.3k tokens');
+  });
+});

--- a/apps/desktop/src/renderer/__tests__/runningTokenUsage.test.ts
+++ b/apps/desktop/src/renderer/__tests__/runningTokenUsage.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { formatRunningTokenUsage } from '@/features/cc-agent/lib/runningTokenUsage';
+import { formatRunningTokenCount } from '@/features/cc-agent/lib/runningTokenUsage';
 
-describe('formatRunningTokenUsage', () => {
+describe('formatRunningTokenCount', () => {
   it('marks zero usage as pending while a turn is running', () => {
-    expect(formatRunningTokenUsage(0, true)).toBe('— tokens');
+    expect(formatRunningTokenCount(0, true)).toBe('—');
   });
 
   it('keeps authoritative completed and positive usage values', () => {
-    expect(formatRunningTokenUsage(0, false)).toBe('0 tokens');
-    expect(formatRunningTokenUsage(999, true)).toBe('999 tokens');
-    expect(formatRunningTokenUsage(1250, true)).toBe('1.3k tokens');
+    expect(formatRunningTokenCount(0, false)).toBe('0');
+    expect(formatRunningTokenCount(999, true)).toBe('999');
+    expect(formatRunningTokenCount(1250, true)).toBe('1.3k');
   });
 });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -191,7 +191,7 @@ import { useSessionHardwareTaskActions } from './lib/sessionHardwareTaskActions'
 import { isRemoteSessionWriteBlocked } from './lib/remoteSessionWriteGuard';
 import { getModelById, getDefaultModelForVendor, getModelsForVendor } from '@/lib/modelDefinitions';
 import { resolveDisplayContextWindow } from '@/lib/contextWindow';
-import { formatRunningTokenUsage } from './lib/runningTokenUsage';
+import { formatRunningTokenCount } from './lib/runningTokenUsage';
 import { matchNavigationCommandName, tryHandleNavigationCommand } from '@/lib/navigationCommands';
 import { extractIpcError } from '@/utils/ipcError';
 import { listActiveRunsForSession } from '@/features/learn/useLearnRun';
@@ -5050,7 +5050,9 @@ function RunningStatusBar({
   // code's CLI status line ticks. The hook re-anchors from the displayed value
   // on every target change, so rapid updates blend without snap-back.
   const animatedTokens = useAnimatedNumber(tokenUsage, 400);
-  const tokenText = formatRunningTokenUsage(animatedTokens, visible);
+  const tokenText = t('chat.messageActionBar.turnTokens', {
+    tokens: formatRunningTokenCount(animatedTokens, visible),
+  });
 
   // 淡入淡出/隐藏占位样式 —— 同时作用于左(状态)、右(elapsed/tokens)两段。
   // visibility:hidden 只隐藏不收高,让 linger / fade 阶段稳定;淡出结束后整个

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -191,6 +191,7 @@ import { useSessionHardwareTaskActions } from './lib/sessionHardwareTaskActions'
 import { isRemoteSessionWriteBlocked } from './lib/remoteSessionWriteGuard';
 import { getModelById, getDefaultModelForVendor, getModelsForVendor } from '@/lib/modelDefinitions';
 import { resolveDisplayContextWindow } from '@/lib/contextWindow';
+import { formatRunningTokenUsage } from './lib/runningTokenUsage';
 import { matchNavigationCommandName, tryHandleNavigationCommand } from '@/lib/navigationCommands';
 import { extractIpcError } from '@/utils/ipcError';
 import { listActiveRunsForSession } from '@/features/learn/useLearnRun';
@@ -5049,10 +5050,7 @@ function RunningStatusBar({
   // code's CLI status line ticks. The hook re-anchors from the displayed value
   // on every target change, so rapid updates blend without snap-back.
   const animatedTokens = useAnimatedNumber(tokenUsage, 400);
-  const tokenText =
-    animatedTokens >= 1000
-      ? `${(animatedTokens / 1000).toFixed(1)}k tokens`
-      : `${animatedTokens} tokens`;
+  const tokenText = formatRunningTokenUsage(animatedTokens, visible);
 
   // 淡入淡出/隐藏占位样式 —— 同时作用于左(状态)、右(elapsed/tokens)两段。
   // visibility:hidden 只隐藏不收高,让 linger / fade 阶段稳定;淡出结束后整个

--- a/apps/desktop/src/renderer/features/cc-agent/lib/runningTokenUsage.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/runningTokenUsage.ts
@@ -1,0 +1,6 @@
+export function formatRunningTokenUsage(tokenUsage: number, isRunning: boolean): string {
+  if (isRunning && tokenUsage === 0) return '— tokens';
+  return tokenUsage >= 1000
+    ? `${(tokenUsage / 1000).toFixed(1)}k tokens`
+    : `${tokenUsage} tokens`;
+}

--- a/apps/desktop/src/renderer/features/cc-agent/lib/runningTokenUsage.ts
+++ b/apps/desktop/src/renderer/features/cc-agent/lib/runningTokenUsage.ts
@@ -1,6 +1,6 @@
-export function formatRunningTokenUsage(tokenUsage: number, isRunning: boolean): string {
-  if (isRunning && tokenUsage === 0) return '— tokens';
+export function formatRunningTokenCount(tokenUsage: number, isRunning: boolean): string {
+  if (isRunning && tokenUsage === 0) return '—';
   return tokenUsage >= 1000
-    ? `${(tokenUsage / 1000).toFixed(1)}k tokens`
-    : `${tokenUsage} tokens`;
+    ? `${(tokenUsage / 1000).toFixed(1)}k`
+    : `${tokenUsage}`;
 }


### PR DESCRIPTION
## 这次改了什么

### 摘要

Show `— tokens` while a turn is running and no usage measurement has arrived, without changing completed zero or positive values.

### 变更类型

- [x] `feat`
- [ ] `fix`
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore`
- [ ] Other

### 范围

- Related to #1436.
- Included: running token formatting, locale-owned token labels, and focused tests.
- Not included: token collection or completed-turn behavior.
- User-visible change: pending usage is displayed as `— tokens` instead of `0 tokens`.
- Breaking change: None.

### UI 变化

Desktop. Reuses the existing localized turn-token template, typography, and colors.

```html
<span class="running-token-usage">— tokens</span>
```

- 引用的设计规范: `DESIGN.md` §10 and §11. The change keeps the existing status hierarchy and semantic styling.

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/runningTokenUsage.test.ts --pool=threads --maxWorkers=1
NODE_OPTIONS=--max-old-space-size=6144 pnpm --filter desktop run --if-present typecheck
pnpm test:unit
pnpm check:dco -- --base origin/main
Result: passed.
```

### 手工验证

Not run.

### 未执行的验证

Light and dark mode checks were not run. The formatter behavior is covered by focused tests.

## 风险

### 风险分类

- [x] No known risk
- [ ] SQLite / migration
- [ ] System prompt
- [ ] Protocol compatibility
- [ ] Permissions / security / user data
- [ ] Existing plugin compatibility
- [ ] Native layer / fingerprint / OTA
- [ ] Cross-platform differences
- [ ] Other

### 影响与回滚

- Impact: the desktop running token label only.
- Rollback: revert the commit.

### 提交前检查

- [x] Reviewed the complete diff
- [x] Every commit has a DCO sign-off
- [x] UI changes reference the applicable design rules
- [x] No credentials, tokens, or authorization files are included
- [x] No additional documentation is required
- [x] Test results and untested paths are documented
