### PR TITLE
feat(device-link): maker:event 微批转发,把长思考洪峰从每事件一帧压成每窗口一帧

### DIFF
--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -255,9 +255,11 @@ describe('[4] 生命周期与背压', () => {
     expect(h.sent).toHaveLength(0);
   });
 
-  it('发送失败即就地降级为逐帧 best-effort,缓冲不跨越失败存在', () => {
-    // 强不变量(review 四轮结论):flush 返回时缓冲必为空——要么整批发出,要么
-    // 降级逐帧(旧语义)。缓冲不滞留 = 顺序问题整族消失。
+  it('批帧被拒即丢这一片:不降级逐帧、不重试、缓冲不跨越失败存在', () => {
+    // 强不变量:flush 返回时缓冲必为空。降级逐帧那条路径已删除(四轮 review 里两位
+    // reviewer 的要求互相抵触,不存在同时满足两侧的取值,推导见 dispatch.ts 的
+    // MakerEventBatchFlushOutcome 注释)——批帧发不出去就丢掉这一片,由控制端 resync
+    // 补偿,与 #2167 对可驱逐档 push 的取舍一致。
     const sendPush = vi.fn((
       _dst: string,
       channel: string,
@@ -267,38 +269,6 @@ describe('[4] 生命周期与背压', () => {
       if (channel === MAKER_EVENT_BATCH_CHANNEL) {
         throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
       }
-    });
-    const h = mkClient({ sendPush });
-    __testing.setActiveClient(h.client as never);
-    subscribeBatchController('ctrl-1', ['session:s1']);
-
-    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
-    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } });
-    vi.advanceTimersByTime(WINDOW_MS);
-
-    // 批被拒 → 两条事件各自以逐帧 maker:event 发出(顺序不变)
-    const perEvent = sendPush.mock.calls.filter((c) => c[1] === 'maker:event');
-    expect(perEvent).toHaveLength(2);
-    expect(perEvent.map((c) => (c[2] as { event: { i: number } }).event.i)).toEqual([0, 1]);
-
-    // 缓冲已空:再推进任何时间都不会有第二次投递
-    const before = sendPush.mock.calls.length;
-    vi.advanceTimersByTime(10_000);
-    expect(sendPush.mock.calls.length).toBe(before);
-  });
-
-  it('持续背压:逐帧每条都试(不因失败提前停手),但告警只有聚合的一条', () => {
-    // review 三轮收敛的结论:洪峰本质是**日志**问题,不是尝试问题。背压判据是尺寸
-    // 相关的(ws 容量含 additionalBytes、pending 容量含字节维度),大帧被拒时后面的
-    // 小帧仍可能通过 —— 按错误码整片放弃会误丢本可送达的事件。所以每条都试,
-    // 逐帧日志静默、成败聚合成一条。
-    const sendPush = vi.fn((
-      _dst: string,
-      _channel: string,
-      _payload: unknown,
-      _ownerStamp?: unknown,
-    ) => {
-      throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
     });
     const h = mkClient({ sendPush });
     __testing.setActiveClient(h.client as never);
@@ -309,55 +279,20 @@ describe('[4] 生命周期与背压', () => {
     }
     vi.advanceTimersByTime(WINDOW_MS);
 
-    // 一次批帧尝试 + 5 条逐帧尝试:交付机会一条都不放弃
+    // 一次批帧尝试,零逐帧尝试:不再重放 ≤64 次 admission / 驱逐判定 / throw
     expect(sendPush.mock.calls.filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL)).toHaveLength(1);
-    expect(sendPush.mock.calls.filter((c) => c[1] === 'maker:event')).toHaveLength(5);
-    // 但告警只有聚合的那一条(而不是 5 条逐帧 WARN)——这是 review P1 的核心承诺
-    const degradeWarns = logSpy.warn.mock.calls
-      .map((c) => String(c[0]))
-      .filter((m) => m.includes('degraded to per-frame'));
-    expect(degradeWarns).toHaveLength(1);
-    expect(degradeWarns[0]).toContain('0 sent, 5 dropped');
-    expect(logSpy.warn.mock.calls.filter((c) => String(c[0]).includes('forwardPush'))).toHaveLength(0);
+    expect(sendPush.mock.calls.filter((c) => c[1] === 'maker:event')).toHaveLength(0);
 
-    // 缓冲仍然为空:强不变量不因逐帧全失败而破
+    // 告警只有聚合的一条(不是每帧一条),且带上丢弃条数
+    const warns = logSpy.warn.mock.calls.map((c) => String(c[0]));
+    expect(warns.filter((m) => m.includes('maker:event batch flush'))).toHaveLength(1);
+    expect(warns.find((m) => m.includes('maker:event batch flush')))
+      .toContain('dropped 5 event(s)');
+
+    // 缓冲已空:再推进任何时间都不会有第二次投递
     const before = sendPush.mock.calls.length;
     vi.advanceTimersByTime(10_000);
     expect(sendPush.mock.calls.length).toBe(before);
-  });
-
-  it('逐帧降级中某一条自身被拒:只跳过它,批尾照发(不连坐)', () => {
-    // review P1:「这一帧自己不合格」与「整条链路堵了」必须分开——前者连坐会把本可
-    // 送达的文本 / 状态增量一起丢掉。这里第 2 条超限且 compact 兜底也救不回。
-    const sendPush = vi.fn((
-      _dst: string,
-      channel: string,
-      payload: unknown,
-      _ownerStamp?: unknown,
-    ) => {
-      if (channel === MAKER_EVENT_BATCH_CHANNEL) {
-        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
-      }
-      if ((payload as { event?: { i?: number } }).event?.i === 1) {
-        throw new DeviceLinkError('PAYLOAD_TOO_LARGE', 'frame exceeds max size');
-      }
-    });
-    const h = mkClient({ sendPush });
-    __testing.setActiveClient(h.client as never);
-    subscribeBatchController('ctrl-1', ['session:s1']);
-
-    for (let i = 0; i < 4; i += 1) {
-      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
-    }
-    vi.advanceTimersByTime(WINDOW_MS);
-
-    // 批被背压拒 → 逐帧降级;第 2 条(i=1)被拒,其余三条照样发出
-    const delivered = sendPush.mock.calls
-      .filter((c) => c[1] === 'maker:event')
-      .map((c) => (c[2] as { event: { i: number } }).event.i);
-    expect(delivered).toContain(0);
-    expect(delivered).toContain(2);
-    expect(delivered).toContain(3);
   });
 
   it('relay 离线:不做逐帧尝试(逐帧同样发不出去),直接丢弃且不滞留', () => {
@@ -490,10 +425,9 @@ describe('[10] 收敛检查点:主动发送闸门的全部入口与边界(review
     __testing.forwardPush('maker:status-changed', { sessionId: 's1', status: 'closed' });
 
     const channels = sendPush.mock.calls.map((c) => c[1]);
-    // 顺序:批尝试 → 降级的逐帧事件 → 终态帧
+    // 顺序:批尝试(被拒 → 整片丢弃,不降级)→ 终态帧
     expect(channels).toEqual([
       MAKER_EVENT_BATCH_CHANNEL,
-      'maker:event',
       'maker:status-changed',
     ]);
     // 之后不再有任何滞留投递
@@ -596,6 +530,70 @@ describe('[11] 重连恢复的顺序(review 第三轮)', () => {
     expect(channels).toContain('maker:status-changed');
     expect(channels.indexOf(MAKER_EVENT_BATCH_CHANNEL))
       .toBeLessThan(channels.indexOf('maker:status-changed'));
+  });
+
+  it('离线积压的 maker:event 在 drain 时也走批:恢复动作不重造洪峰', () => {
+    // review P1(故障半径三问的第 4 问):断线期间事件逐条进 offlinePushQueue,
+    // 重订阅时一次 drain 可能上百条;原先逐条 sendPush 就是同一 tick 内上百帧——
+    // 正是 8/8 招来 relay 1013 的那个形状,而且发生在刚重连、最脆弱的时刻。
+    let status = 'online';
+    const h = mkClient();
+    h.client.getStatus = vi.fn(() => status) as never;
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    // 断线:30 条同会话事件进离线积压
+    status = 'connecting';
+    for (let i = 0; i < 30; i += 1) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    expect(h.sent).toHaveLength(0);
+    expect(__testing.queuedPushesFor('ctrl-1').length).toBe(30);
+
+    // 重连 + 重订阅:30 条积压压成 1 帧批,而不是 30 帧逐帧
+    status = 'online';
+    __testing.handleSubscriptionFrame('ctrl-1', {
+      channel: DL_SUBSCRIBE_CHANNEL,
+      args: [{ topics: ['session:s1'], capabilities: [CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1] }],
+    });
+
+    expect(h.sent.filter((x) => x.channel === 'maker:event')).toHaveLength(0);
+    const frames = batchesIn(h.sent);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.events).toHaveLength(30);
+    // 无损且保序
+    expect(frames[0]!.events.map((e) => (e as { event: { i: number } }).event.i))
+      .toEqual(Array.from({ length: 30 }, (_, i) => i));
+  });
+
+  it('积压里混有其它 channel:批与非批的相对顺序与在线主路一致', () => {
+    let status = 'online';
+    const h = mkClient();
+    h.client.getStatus = vi.fn(() => status) as never;
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    status = 'connecting';
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } });
+    __testing.forwardPush('maker:status-changed', { sessionId: 's1', status: 'closed' });
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 2 } });
+
+    status = 'online';
+    __testing.handleSubscriptionFrame('ctrl-1', {
+      channel: DL_SUBSCRIBE_CHANNEL,
+      args: [{ topics: ['session:s1'], capabilities: [CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1] }],
+    });
+
+    // 终态帧前的两条事件先成一帧,终态帧其后,再一帧带最后一条事件
+    expect(h.sent.map((x) => x.channel)).toEqual([
+      MAKER_EVENT_BATCH_CHANNEL,
+      'maker:status-changed',
+      MAKER_EVENT_BATCH_CHANNEL,
+    ]);
+    const frames = batchesIn(h.sent);
+    expect(frames[0]!.events).toHaveLength(2);
+    expect(frames[1]!.events).toHaveLength(1);
   });
 
   it('ws-online 收口入口:窗口内的批在重连后立即投出,不落到积压之后', () => {

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -15,6 +15,7 @@ import {
   CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
   DL_UNSUBSCRIBE_CHANNEL,
   MAKER_EVENT_BATCH_CHANNEL,
+  isCoalesciblePushChannel,
   topicForPush,
   type MakerEventBatchPayload,
 } from '@cindy/device-link';
@@ -41,16 +42,17 @@ vi.mock('../settings-store', () => ({
 import { __testing, handleControllerOffline } from '../dispatch';
 import * as subscriptions from '../subscriptions';
 
-/** 微批窗口(dispatch 内部常量);推进定时器用。 */
+/** 微批窗口与退避间隔(dispatch 内部常量);推进定时器用。 */
 const WINDOW_MS = 120;
+const MAKER_EVENT_BATCH_RETRY_MS = 250;
 
-type SentPush = { dst: string; channel: string; payload: unknown };
+type SentPush = { dst: string; channel: string; payload: unknown; ownerStamp?: unknown };
 
 function mkClient(over: { sendPush?: ReturnType<typeof vi.fn> } = {}) {
   const sent: SentPush[] = [];
   const sendPush = over.sendPush
-    ?? vi.fn((dst: string, channel: string, payload: unknown) => {
-      sent.push({ dst, channel, payload });
+    ?? vi.fn((dst: string, channel: string, payload: unknown, ownerStamp?: unknown) => {
+      sent.push({ dst, channel, payload, ownerStamp });
     });
   return {
     client: {
@@ -247,7 +249,7 @@ describe('[4] 生命周期与背压', () => {
     // 背压期间继续产生事件:累积进同一批,不丢
     __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } });
     failing = false;
-    vi.advanceTimersByTime(250); // 退避重试间隔
+    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS); // 退避重试间隔
     const batch = sendPush.mock.calls.at(-1)![2] as MakerEventBatchPayload;
     expect(batch.events).toHaveLength(2);
     expect(batch.events).toEqual([
@@ -272,27 +274,138 @@ describe('[4] 生命周期与背压', () => {
     expect(h.sent).toHaveLength(0);
 
     status = 'online';
-    vi.advanceTimersByTime(250);
+    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
     expect(batchesIn(h.sent)).toHaveLength(1);
   });
 });
 
 describe('[5] 与拥塞取舍(#2167)的一致性', () => {
-  it('批 channel 与 maker:event 同属可驱逐档:拥塞时不退回 BACKPRESSURE 风暴', async () => {
-    // 漏登记会让启用微批的控制端在拥塞时重新遭遇逐帧 BACKPRESSURE——正是微批
-    // 要消除的那一个。判据正本在 packages/device-link/src/client.ts。
-    const src = await import('node:fs/promises').then((fs) =>
-      fs.readFile(
-        new URL('../../../../../../packages/device-link/src/client.ts', import.meta.url),
-        'utf8',
-      ),
-    );
-    const table = src.slice(
-      src.indexOf('const COALESCIBLE_PUSH_CHANNELS'),
-      src.indexOf(']);', src.indexOf('const COALESCIBLE_PUSH_CHANNELS')),
-    );
-    expect(table).toContain("'maker:event'");
-    expect(table).toContain('MAKER_EVENT_BATCH_CHANNEL');
+  it('批 channel 与 maker:event 同属可驱逐档:拥塞时不退回 BACKPRESSURE 风暴', () => {
+    // 漏登记会让启用微批的控制端在拥塞时重新遭遇逐帧 BACKPRESSURE——正是微批要
+    // 消除的那一个。直接问判据函数(client.ts 的唯一入口),不耦合源码文本。
+    expect(isCoalesciblePushChannel('maker:event')).toBe(true);
+    expect(isCoalesciblePushChannel(MAKER_EVENT_BATCH_CHANNEL)).toBe(true);
+    // 反向:不可合并的事件流不得混进该档
+    expect(isCoalesciblePushChannel('local-db:messages:created')).toBe(false);
+    expect(isCoalesciblePushChannel('maker:interaction-request')).toBe(false);
+  });
+});
+
+describe('[7] 归属切换与背压的交互(review 首轮 P1)', () => {
+  it('ownerStamp 切换且旧段正背压:旧段不被覆盖,恢复后按段序全部发出', () => {
+    let failing = true;
+    const sendPush = vi.fn((
+      _dst: string,
+      channel: string,
+      _payload: unknown,
+      _ownerStamp?: unknown,
+    ) => {
+      if (failing && channel === MAKER_EVENT_BATCH_CHANNEL) {
+        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+      }
+    });
+    const h = mkClient({ sendPush });
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+    const stampA = { dataOwnerId: 'owner-a', ownerGeneration: 1 };
+    const stampB = { dataOwnerId: 'owner-b', ownerGeneration: 2 };
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } }, stampA);
+    vi.advanceTimersByTime(WINDOW_MS); // 首次 flush 遭背压,旧段保留
+    expect(sendPush).toHaveBeenCalledTimes(1);
+
+    // 归属切换:新事件必须进新段,绝不能覆盖仍待重试的旧段
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } }, stampB);
+    failing = false;
+    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
+
+    // 自定义 sendPush 不填充 h.sent,直接读 mock.calls:[dst, channel, payload, ownerStamp]
+    const delivered = sendPush.mock.calls.filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL);
+    const succeeded = delivered.slice(1); // 第 1 次是遭背压那次
+    expect(succeeded).toHaveLength(2);
+    expect((succeeded[0]![2] as MakerEventBatchPayload).events)
+      .toEqual([{ sessionId: 's1', event: { i: 0 } }]);
+    expect((succeeded[1]![2] as MakerEventBatchPayload).events)
+      .toEqual([{ sessionId: 's1', event: { i: 1 } }]);
+    // 段序 = 归属切换顺序,ownerStamp 分别随段下发
+    expect(succeeded[0]![3]).toEqual(stampA);
+    expect(succeeded[1]![3]).toEqual(stampB);
+  });
+
+  it('持续背压 + 到量:不退化为逐事件同步 sendPush(退避期间不插队)', () => {
+    const sendPush = vi.fn((_dst: string, channel: string, _payload: unknown) => {
+      if (channel === MAKER_EVENT_BATCH_CHANNEL) {
+        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+      }
+    });
+    const h = mkClient({ sendPush });
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    // 先攒到量触发一次 flush(遭背压)
+    for (let i = 0; i < 64; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    expect(sendPush).toHaveBeenCalledTimes(1);
+
+    // 再来 64 条:退避中,一次都不该再同步发送(旧实现每条都会试一次)
+    for (let i = 64; i < 128; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    expect(sendPush).toHaveBeenCalledTimes(1);
+
+    // 退避到点才重试一次
+    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
+    expect(sendPush).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('[8] 跨 channel 顺序(review 首轮 P2)', () => {
+  it('同会话的其它推送先收口事件批:确认卡不会插到攒批的文本前面', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { text: 'delta' } });
+    expect(h.sent).toHaveLength(0); // 还在攒批
+
+    // 紧跟一条有顺序语义的同会话推送:必须先把批发出去
+    __testing.forwardPush('maker:interaction-request', { sessionId: 's1', request: { id: 'r1' } });
+    expect(h.sent.map((s) => s.channel)).toEqual([
+      MAKER_EVENT_BATCH_CHANNEL,
+      'maker:interaction-request',
+    ]);
+  });
+
+  it('其它会话的推送不触发本会话收口(按 sessionId 精确)', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1', 'session:s2']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
+    __testing.forwardPush('maker:status-changed', { sessionId: 's2', status: 'closed' });
+    // s1 的批未被 s2 的推送带出去
+    expect(h.sent.map((s) => s.channel)).toEqual(['maker:status-changed']);
+
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(batchesIn(h.sent)).toHaveLength(1);
+  });
+});
+
+describe('[9] 字节估算按 UTF-8(review 首轮)', () => {
+  it('多字节内容按 UTF-8 计:中文事件到量 flush,阈值不被 UTF-16 低估架空', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    // 每条约 30KB UTF-8(中文 3 字节/字);9 条即越过 256KB 字节阈值,
+    // 而按 UTF-16 码元只有约 90K「长度」——旧估算不会触发 flush。
+    const text = '中'.repeat(10_000);
+    for (let i = 0; i < 9; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { text } });
+    }
+    // 未到条数上限(64),靠字节阈值提前发出
+    expect(batchesIn(h.sent)).toHaveLength(1);
   });
 });
 

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -300,6 +300,40 @@ describe('[4] 生命周期与背压', () => {
     expect(sendPush.mock.calls.length).toBe(before);
   });
 
+  it('逐帧降级中某一条自身被拒:只跳过它,批尾照发(不连坐)', () => {
+    // review P1:「这一帧自己不合格」与「整条链路堵了」必须分开——前者连坐会把本可
+    // 送达的文本 / 状态增量一起丢掉。这里第 2 条超限且 compact 兜底也救不回。
+    const sendPush = vi.fn((
+      _dst: string,
+      channel: string,
+      payload: unknown,
+      _ownerStamp?: unknown,
+    ) => {
+      if (channel === MAKER_EVENT_BATCH_CHANNEL) {
+        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+      }
+      if ((payload as { event?: { i?: number } }).event?.i === 1) {
+        throw new DeviceLinkError('PAYLOAD_TOO_LARGE', 'frame exceeds max size');
+      }
+    });
+    const h = mkClient({ sendPush });
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    for (let i = 0; i < 4; i += 1) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    vi.advanceTimersByTime(WINDOW_MS);
+
+    // 批被背压拒 → 逐帧降级;第 2 条(i=1)被拒,其余三条照样发出
+    const delivered = sendPush.mock.calls
+      .filter((c) => c[1] === 'maker:event')
+      .map((c) => (c[2] as { event: { i: number } }).event.i);
+    expect(delivered).toContain(0);
+    expect(delivered).toContain(2);
+    expect(delivered).toContain(3);
+  });
+
   it('relay 离线:不做逐帧尝试(逐帧同样发不出去),直接丢弃且不滞留', () => {
     // NOT_CONNECTED 下逐帧只是把同一次失败重放 ≤64 次 —— 纯日志洪峰、零收益。
     // 与 BACKPRESSURE 的区别:后者「大批被拒 ≠ 小帧被拒」(#2167 可驱逐档),值得试。
@@ -474,6 +508,34 @@ describe('[10] 收敛检查点:主动发送闸门的全部入口与边界(review
       'maker:event',
     ]);
     expect((h.sent[0]!.payload as MakerEventBatchPayload).events).toHaveLength(1);
+  });
+
+  it('越过字节阈值的事件留作下一批的开头,不再每次越界白送一个 1 条的小尾批', () => {
+    // review P2:挤进本批再被 takeMakerEventBatchSlice 切出来,等于每 8 条多一帧
+    // (30KB 级事件流 100 条 → ~23 帧而不是 ~13 帧),直接削掉大半减帧收益。
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    // 每条 ~30KB:8 条 240KB < 256KB 上限,第 9 条会越界
+    const chunk = 'x'.repeat(30_000);
+    for (let i = 0; i < 9; i += 1) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i, chunk } });
+    }
+
+    // 第 9 条触发收口:发出的**只有一帧**,装着前 8 条(而不是 8 条 + 1 条两帧)
+    let frames = batchesIn(h.sent);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]!.events).toHaveLength(8);
+
+    // 第 9 条成为下一批的开头,等窗口到点才发
+    vi.advanceTimersByTime(WINDOW_MS);
+    frames = batchesIn(h.sent);
+    expect(frames).toHaveLength(2);
+    expect(frames[1]!.events).toHaveLength(1);
+    // 无损:9 条事件按序全部送达
+    expect(frames.flatMap((f) => f.events.map((e) => (e as { event: { i: number } }).event.i)))
+      .toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]);
   });
 });
 

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -40,6 +40,22 @@ const deviceLinkSettings = vi.hoisted(() => ({
 vi.mock('../settings-store', () => ({
   readDeviceLinkSettings: () => deviceLinkSettings.value,
 }));
+/**
+ * 只替换 createLogger(其余导出保留真实实现):降级路径的「≤64 条 WARN 收敛成一条」
+ * 是 review P1 的核心承诺,得能被断言,否则下次有人去掉 quiet 也不会有测试变红。
+ */
+const logSpy = vi.hoisted(() => ({ warn: vi.fn(), debug: vi.fn() }));
+vi.mock('../../logger', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../logger')>()),
+  createLogger: () => ({
+    trace: vi.fn(),
+    debug: logSpy.debug,
+    info: vi.fn(),
+    warn: logSpy.warn,
+    error: vi.fn(),
+    fatal: vi.fn(),
+  }),
+}));
 
 import {
   __testing,
@@ -89,6 +105,8 @@ function batchesIn(sent: SentPush[]): MakerEventBatchPayload[] {
 beforeEach(() => {
   vi.useFakeTimers();
   deviceLinkSettings.value = { remoteControlEnabled: true, revokedControllers: [] };
+  logSpy.warn.mockClear();
+  logSpy.debug.mockClear();
   __testing.reset();
 });
 
@@ -269,10 +287,11 @@ describe('[4] 生命周期与背压', () => {
     expect(sendPush.mock.calls.length).toBe(before);
   });
 
-  it('逐帧降级在第一次失败处停下:一次背压不再重放成 N 条失败与 N 条日志', () => {
-    // review P1:降级本身不得复刻本 PR 要消掉的洪峰。批被拒后逐帧若第一帧也进不去,
-    // 同步循环内可靠窗口不会被 ACK 腾空,后续帧必然同样失败 —— 停在第一次失败处,
-    // 交付集合完全不变,省掉的只是注定失败的尝试与逐条 WARN。
+  it('持续背压:逐帧每条都试(不因失败提前停手),但告警只有聚合的一条', () => {
+    // review 三轮收敛的结论:洪峰本质是**日志**问题,不是尝试问题。背压判据是尺寸
+    // 相关的(ws 容量含 additionalBytes、pending 容量含字节维度),大帧被拒时后面的
+    // 小帧仍可能通过 —— 按错误码整片放弃会误丢本可送达的事件。所以每条都试,
+    // 逐帧日志静默、成败聚合成一条。
     const sendPush = vi.fn((
       _dst: string,
       _channel: string,
@@ -290,11 +309,18 @@ describe('[4] 生命周期与背压', () => {
     }
     vi.advanceTimersByTime(WINDOW_MS);
 
-    // 一次批帧尝试 + 一次逐帧尝试(而不是 1 + 5)
+    // 一次批帧尝试 + 5 条逐帧尝试:交付机会一条都不放弃
     expect(sendPush.mock.calls.filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL)).toHaveLength(1);
-    expect(sendPush.mock.calls.filter((c) => c[1] === 'maker:event')).toHaveLength(1);
+    expect(sendPush.mock.calls.filter((c) => c[1] === 'maker:event')).toHaveLength(5);
+    // 但告警只有聚合的那一条(而不是 5 条逐帧 WARN)——这是 review P1 的核心承诺
+    const degradeWarns = logSpy.warn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('degraded to per-frame'));
+    expect(degradeWarns).toHaveLength(1);
+    expect(degradeWarns[0]).toContain('0 sent, 5 dropped');
+    expect(logSpy.warn.mock.calls.filter((c) => String(c[0]).includes('forwardPush'))).toHaveLength(0);
 
-    // 缓冲仍然为空:强不变量不因提前停止而破
+    // 缓冲仍然为空:强不变量不因逐帧全失败而破
     const before = sendPush.mock.calls.length;
     vi.advanceTimersByTime(10_000);
     expect(sendPush.mock.calls.length).toBe(before);

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -1,0 +1,317 @@
+/**
+ * dispatchMakerEventBatch.test.ts — `maker:event` 微批转发的行为契约。
+ * ---------------------------------------------------------------------------
+ * 微批把「每事件一帧」压成「每窗口一帧」,是这条链路上唯一削减**出站帧数**的
+ * 手段(#2167 只改拥塞取舍、#2185 只推迟重连,都不减帧)。四条不变量:
+ *  1. 能力协商:只有声明 maker-event-batch-v1 的控制端收批,旧控制端照旧逐帧;
+ *  2. 无损与保序:批内事件是原 payload 原样序列,顺序即产生顺序,不跨会话合并;
+ *  3. 到量即发:条数上限不等窗口(长思考不把单帧撑大到需要分片);
+ *  4. 生命周期:退订该会话 / link-close / 控制端离线都不再投递;背压不丢事件。
+ * mock 面与 dispatchSendSafety.test.ts 一致:只 mock electron + settings。
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  DeviceLinkError,
+  CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
+  DL_UNSUBSCRIBE_CHANNEL,
+  MAKER_EVENT_BATCH_CHANNEL,
+  topicForPush,
+  type MakerEventBatchPayload,
+} from '@cindy/device-link';
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: () => '/tmp/xdt-maker-test/app',
+    getPath: () => '/tmp/xdt-maker-test',
+    getVersion: () => '0.0.0-test',
+  },
+  powerSaveBlocker: { start: () => 0, stop: () => {}, isStarted: () => false },
+  nativeImage: { createFromPath: () => ({ isEmpty: () => true }) },
+}));
+const deviceLinkSettings = vi.hoisted(() => ({
+  value: {
+    remoteControlEnabled: true,
+    revokedControllers: [] as string[],
+  },
+}));
+vi.mock('../settings-store', () => ({
+  readDeviceLinkSettings: () => deviceLinkSettings.value,
+}));
+
+import { __testing, handleControllerOffline } from '../dispatch';
+import * as subscriptions from '../subscriptions';
+
+/** 微批窗口(dispatch 内部常量);推进定时器用。 */
+const WINDOW_MS = 120;
+
+type SentPush = { dst: string; channel: string; payload: unknown };
+
+function mkClient(over: { sendPush?: ReturnType<typeof vi.fn> } = {}) {
+  const sent: SentPush[] = [];
+  const sendPush = over.sendPush
+    ?? vi.fn((dst: string, channel: string, payload: unknown) => {
+      sent.push({ dst, channel, payload });
+    });
+  return {
+    client: {
+      getStatus: vi.fn(() => 'online'),
+      sendPush,
+      sendInvokeResult: vi.fn(),
+      sendLinkAccept: vi.fn(),
+      closeLink: vi.fn(),
+      onFrame: vi.fn(),
+      getReliableSendQueueDepth: vi.fn(() => 0),
+    },
+    sent,
+    sendPush,
+  };
+}
+
+/** 注册一个声明了微批能力的控制端。 */
+function subscribeBatchController(id: string, topics: string[]): void {
+  subscriptions.subscribe(id, topics, id, [CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1]);
+}
+
+function batchesIn(sent: SentPush[]): MakerEventBatchPayload[] {
+  return sent
+    .filter((s) => s.channel === MAKER_EVENT_BATCH_CHANNEL)
+    .map((s) => s.payload as MakerEventBatchPayload);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  deviceLinkSettings.value = { remoteControlEnabled: true, revokedControllers: [] };
+  __testing.reset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('[1] 能力协商', () => {
+  it('声明能力的控制端:窗口内多条事件合并成一帧批,不再每事件一帧', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-batch', ['session:s1']);
+
+    for (let i = 0; i < 5; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    // 窗口未到:一帧都还没发(这正是削减帧数的来源)
+    expect(h.sent).toHaveLength(0);
+
+    vi.advanceTimersByTime(WINDOW_MS);
+    const batches = batchesIn(h.sent);
+    expect(h.sent).toHaveLength(1);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]!.sessionId).toBe('s1');
+    expect(batches[0]!.events).toHaveLength(5);
+  });
+
+  it('未声明能力的控制端(旧版本):照旧逐帧,零感知', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscriptions.subscribe('ctrl-legacy', ['session:s1'], 'legacy');
+
+    for (let i = 0; i < 3; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    expect(h.sent).toHaveLength(3);
+    expect(h.sent.every((s) => s.channel === 'maker:event')).toBe(true);
+    vi.advanceTimersByTime(WINDOW_MS * 3);
+    expect(h.sent).toHaveLength(3); // 没有额外的批帧
+  });
+
+  it('新旧控制端共存:各走各的路径,互不影响', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-new', ['session:s1']);
+    subscriptions.subscribe('ctrl-old', ['session:s1'], 'old');
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } });
+    // 旧控制端已收到两帧;新控制端还在攒批
+    expect(h.sent.filter((s) => s.dst === 'ctrl-old')).toHaveLength(2);
+    expect(h.sent.filter((s) => s.dst === 'ctrl-new')).toHaveLength(0);
+
+    vi.advanceTimersByTime(WINDOW_MS);
+    const newSent = h.sent.filter((s) => s.dst === 'ctrl-new');
+    expect(newSent).toHaveLength(1);
+    expect((newSent[0]!.payload as MakerEventBatchPayload).events).toHaveLength(2);
+  });
+});
+
+describe('[2] 无损与保序', () => {
+  it('批内事件是原 payload 原样序列,顺序即产生顺序', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    const originals = [0, 1, 2].map((i) => ({ sessionId: 's1', event: { seq: i } }));
+    for (const p of originals) __testing.forwardPush('maker:event', p);
+    vi.advanceTimersByTime(WINDOW_MS);
+
+    const batch = batchesIn(h.sent)[0]!;
+    expect(batch.events).toEqual(originals);
+  });
+
+  it('不跨会话合并:每个会话一帧批(否则 topic 路由算不出)', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1', 'session:s2']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { a: 1 } });
+    __testing.forwardPush('maker:event', { sessionId: 's2', event: { b: 1 } });
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { a: 2 } });
+    vi.advanceTimersByTime(WINDOW_MS);
+
+    const batches = batchesIn(h.sent);
+    expect(batches).toHaveLength(2);
+    expect(batches.find((b) => b.sessionId === 's1')!.events).toHaveLength(2);
+    expect(batches.find((b) => b.sessionId === 's2')!.events).toHaveLength(1);
+  });
+
+  it('批帧的 topic 路由与逐帧一致(顶层 sessionId → session:<id>)', () => {
+    // 微批刻意复用 topicForPush 的 session-scoped 兜底分支,不改 topics.ts。
+    const payload: MakerEventBatchPayload = { sessionId: 's9', events: [{}] };
+    expect(topicForPush(MAKER_EVENT_BATCH_CHANNEL, payload)).toBe('session:s9');
+    expect(topicForPush('maker:event', { sessionId: 's9' })).toBe('session:s9');
+  });
+});
+
+describe('[3] 到量即发', () => {
+  it('条数达上限:立即 flush,不等窗口(不把单帧撑到需要分片)', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    for (let i = 0; i < 64; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    // 第 64 条触发上限 flush,定时器还没到点
+    expect(batchesIn(h.sent)).toHaveLength(1);
+    expect(batchesIn(h.sent)[0]!.events).toHaveLength(64);
+
+    // 后续事件进入新批,按窗口发出
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 64 } });
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(batchesIn(h.sent)).toHaveLength(2);
+    expect(batchesIn(h.sent)[1]!.events).toHaveLength(1);
+  });
+});
+
+describe('[4] 生命周期与背压', () => {
+  it('退订 session:<id>:该会话待发批不再投递', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1', 'session:s2']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
+    __testing.forwardPush('maker:event', { sessionId: 's2', event: {} });
+    __testing.handleSubscriptionFrame('ctrl-1', {
+      channel: DL_UNSUBSCRIBE_CHANNEL,
+      args: [{ topics: ['session:s1'] }],
+    });
+    vi.advanceTimersByTime(WINDOW_MS);
+
+    const batches = batchesIn(h.sent);
+    expect(batches.map((b) => b.sessionId)).toEqual(['s2']); // s1 已丢弃
+  });
+
+  it('控制端离线:待发批清空,不在恢复后补投陈旧事件', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
+    handleControllerOffline('ctrl-1');
+    vi.advanceTimersByTime(WINDOW_MS * 3);
+    expect(h.sent).toHaveLength(0);
+  });
+
+  it('背压:事件保留在缓冲里退避重试,不丢;恢复后一并发出', () => {
+    let failing = true;
+    const sendPush = vi.fn((_dst: string, channel: string, _payload: unknown) => {
+      if (failing && channel === MAKER_EVENT_BATCH_CHANNEL) {
+        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+      }
+    });
+    const h = mkClient({ sendPush });
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(sendPush).toHaveBeenCalledTimes(1); // 首次尝试遭背压
+
+    // 背压期间继续产生事件:累积进同一批,不丢
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } });
+    failing = false;
+    vi.advanceTimersByTime(250); // 退避重试间隔
+    const batch = sendPush.mock.calls.at(-1)![2] as MakerEventBatchPayload;
+    expect(batch.events).toHaveLength(2);
+    expect(batch.events).toEqual([
+      { sessionId: 's1', event: { i: 0 } },
+      { sessionId: 's1', event: { i: 1 } },
+    ]);
+  });
+
+  it('relay 离线:不发送、保留事件,上线后由重试投出', () => {
+    const h = mkClient();
+    let status = 'connecting';
+    h.client.getStatus = vi.fn(() => status) as never;
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    // 离线期间 forwardPush 走离线队列而非批(liveTargets 为空),这里直接验证
+    // 批 stage 在 relay 离线时不会盲发:先在线入批,再切离线推进窗口。
+    status = 'online';
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
+    status = 'connecting';
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(h.sent).toHaveLength(0);
+
+    status = 'online';
+    vi.advanceTimersByTime(250);
+    expect(batchesIn(h.sent)).toHaveLength(1);
+  });
+});
+
+describe('[5] 与拥塞取舍(#2167)的一致性', () => {
+  it('批 channel 与 maker:event 同属可驱逐档:拥塞时不退回 BACKPRESSURE 风暴', async () => {
+    // 漏登记会让启用微批的控制端在拥塞时重新遭遇逐帧 BACKPRESSURE——正是微批
+    // 要消除的那一个。判据正本在 packages/device-link/src/client.ts。
+    const src = await import('node:fs/promises').then((fs) =>
+      fs.readFile(
+        new URL('../../../../../../packages/device-link/src/client.ts', import.meta.url),
+        'utf8',
+      ),
+    );
+    const table = src.slice(
+      src.indexOf('const COALESCIBLE_PUSH_CHANNELS'),
+      src.indexOf(']);', src.indexOf('const COALESCIBLE_PUSH_CHANNELS')),
+    );
+    expect(table).toContain("'maker:event'");
+    expect(table).toContain('MAKER_EVENT_BATCH_CHANNEL');
+  });
+});
+
+describe('[6] 帧数削减度量', () => {
+  it('长思考洪峰:100 条事件从 100 帧压到 2 帧(条数上限 + 窗口各一次)', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    for (let i = 0; i < 100; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    vi.advanceTimersByTime(WINDOW_MS);
+
+    const batches = batchesIn(h.sent);
+    expect(h.sent).toHaveLength(2);
+    expect(batches[0]!.events).toHaveLength(64);
+    expect(batches[1]!.events).toHaveLength(36);
+    // 事件一条不丢
+    expect(batches.reduce((n, b) => n + b.events.length, 0)).toBe(100);
+  });
+});

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -237,10 +237,16 @@ describe('[4] 生命周期与背压', () => {
     expect(h.sent).toHaveLength(0);
   });
 
-  it('背压:事件保留在缓冲里退避重试,不丢;恢复后一并发出', () => {
-    let failing = true;
-    const sendPush = vi.fn((_dst: string, channel: string, _payload: unknown) => {
-      if (failing && channel === MAKER_EVENT_BATCH_CHANNEL) {
+  it('发送失败即就地降级为逐帧 best-effort,缓冲不跨越失败存在', () => {
+    // 强不变量(review 四轮结论):flush 返回时缓冲必为空——要么整批发出,要么
+    // 降级逐帧(旧语义)。缓冲不滞留 = 顺序问题整族消失。
+    const sendPush = vi.fn((
+      _dst: string,
+      channel: string,
+      _payload: unknown,
+      _ownerStamp?: unknown,
+    ) => {
+      if (channel === MAKER_EVENT_BATCH_CHANNEL) {
         throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
       }
     });
@@ -249,39 +255,36 @@ describe('[4] 生命周期与背压', () => {
     subscribeBatchController('ctrl-1', ['session:s1']);
 
     __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
-    vi.advanceTimersByTime(WINDOW_MS);
-    expect(sendPush).toHaveBeenCalledTimes(1); // 首次尝试遭背压
-
-    // 背压期间继续产生事件:累积进同一批,不丢
     __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } });
-    failing = false;
-    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS); // 退避重试间隔
-    const batch = sendPush.mock.calls.at(-1)![2] as MakerEventBatchPayload;
-    expect(batch.events).toHaveLength(2);
-    expect(batch.events).toEqual([
-      { sessionId: 's1', event: { i: 0 } },
-      { sessionId: 's1', event: { i: 1 } },
-    ]);
+    vi.advanceTimersByTime(WINDOW_MS);
+
+    // 批被拒 → 两条事件各自以逐帧 maker:event 发出(顺序不变)
+    const perEvent = sendPush.mock.calls.filter((c) => c[1] === 'maker:event');
+    expect(perEvent).toHaveLength(2);
+    expect(perEvent.map((c) => (c[2] as { event: { i: number } }).event.i)).toEqual([0, 1]);
+
+    // 缓冲已空:再推进任何时间都不会有第二次投递
+    const before = sendPush.mock.calls.length;
+    vi.advanceTimersByTime(10_000);
+    expect(sendPush.mock.calls.length).toBe(before);
   });
 
-  it('relay 离线:不发送、保留事件,上线后由重试投出', () => {
+  it('relay 离线:同样就地降级(逐帧 best-effort 自行吞掉失败),不滞留', () => {
+    let status = 'online';
     const h = mkClient();
-    let status = 'connecting';
     h.client.getStatus = vi.fn(() => status) as never;
     __testing.setActiveClient(h.client as never);
     subscribeBatchController('ctrl-1', ['session:s1']);
 
-    // 离线期间 forwardPush 走离线队列而非批(liveTargets 为空),这里直接验证
-    // 批 stage 在 relay 离线时不会盲发:先在线入批,再切离线推进窗口。
-    status = 'online';
     __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
     status = 'connecting';
     vi.advanceTimersByTime(WINDOW_MS);
-    expect(h.sent).toHaveLength(0);
 
+    // 未以批帧发出;缓冲已空,不会在恢复后突然补投陈旧事件
+    expect(batchesIn(h.sent)).toHaveLength(0);
     status = 'online';
-    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
-    expect(batchesIn(h.sent)).toHaveLength(1);
+    vi.advanceTimersByTime(10_000);
+    expect(batchesIn(h.sent)).toHaveLength(0);
   });
 });
 
@@ -297,72 +300,24 @@ describe('[5] 与拥塞取舍(#2167)的一致性', () => {
   });
 });
 
-describe('[7] 归属切换与背压的交互(review 首轮 P1)', () => {
-  it('ownerStamp 切换且旧段正背压:旧段不被覆盖,恢复后按段序全部发出', () => {
-    let failing = true;
-    const sendPush = vi.fn((
-      _dst: string,
-      channel: string,
-      _payload: unknown,
-      _ownerStamp?: unknown,
-    ) => {
-      if (failing && channel === MAKER_EVENT_BATCH_CHANNEL) {
-        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
-      }
-    });
-    const h = mkClient({ sendPush });
+describe('[7] 归属切换分段(review 首轮 P1)', () => {
+  it('窗口内 ownerStamp 切换:分两段按序发出,各段带自己的水印', () => {
+    const h = mkClient();
     __testing.setActiveClient(h.client as never);
     subscribeBatchController('ctrl-1', ['session:s1']);
     const stampA = { dataOwnerId: 'owner-a', ownerGeneration: 1 };
     const stampB = { dataOwnerId: 'owner-b', ownerGeneration: 2 };
 
     __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } }, stampA);
-    vi.advanceTimersByTime(WINDOW_MS); // 首次 flush 遭背压,旧段保留
-    expect(sendPush).toHaveBeenCalledTimes(1);
-
-    // 归属切换:新事件必须进新段,绝不能覆盖仍待重试的旧段
     __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 1 } }, stampB);
-    failing = false;
-    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
+    vi.advanceTimersByTime(WINDOW_MS);
 
-    // 自定义 sendPush 不填充 h.sent,直接读 mock.calls:[dst, channel, payload, ownerStamp]
-    const delivered = sendPush.mock.calls.filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL);
-    const succeeded = delivered.slice(1); // 第 1 次是遭背压那次
-    expect(succeeded).toHaveLength(2);
-    expect((succeeded[0]![2] as MakerEventBatchPayload).events)
-      .toEqual([{ sessionId: 's1', event: { i: 0 } }]);
-    expect((succeeded[1]![2] as MakerEventBatchPayload).events)
-      .toEqual([{ sessionId: 's1', event: { i: 1 } }]);
-    // 段序 = 归属切换顺序,ownerStamp 分别随段下发
-    expect(succeeded[0]![3]).toEqual(stampA);
-    expect(succeeded[1]![3]).toEqual(stampB);
-  });
-
-  it('持续背压 + 到量:不退化为逐事件同步 sendPush(退避期间不插队)', () => {
-    const sendPush = vi.fn((_dst: string, channel: string, _payload: unknown) => {
-      if (channel === MAKER_EVENT_BATCH_CHANNEL) {
-        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
-      }
-    });
-    const h = mkClient({ sendPush });
-    __testing.setActiveClient(h.client as never);
-    subscribeBatchController('ctrl-1', ['session:s1']);
-
-    // 先攒到量触发一次 flush(遭背压)
-    for (let i = 0; i < 64; i++) {
-      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
-    }
-    expect(sendPush).toHaveBeenCalledTimes(1);
-
-    // 再来 64 条:退避中,一次都不该再同步发送(旧实现每条都会试一次)
-    for (let i = 64; i < 128; i++) {
-      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
-    }
-    expect(sendPush).toHaveBeenCalledTimes(1);
-
-    // 退避到点才重试一次
-    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
-    expect(sendPush).toHaveBeenCalledTimes(2);
+    const batches = batchesIn(h.sent);
+    expect(batches).toHaveLength(2);
+    expect(batches[0]!.events).toEqual([{ sessionId: 's1', event: { i: 0 } }]);
+    expect(batches[1]!.events).toEqual([{ sessionId: 's1', event: { i: 1 } }]);
+    expect(h.sent[0]!.ownerStamp).toEqual(stampA);
+    expect(h.sent[1]!.ownerStamp).toEqual(stampB);
   });
 });
 
@@ -417,7 +372,9 @@ describe('[10] 收敛检查点:主动发送闸门的全部入口与边界(review
       .toBeLessThan(h.sent.findIndex((s) => s.channel === SESSION_ACTIVITY_CHANNEL));
   });
 
-  it('退避中跨 channel 收口不再尝试:交错 push 不产生额外的注定失败发送', () => {
+  it('批发送失败后缓冲即空:交错 push 不会与滞留批产生顺序竞争', () => {
+    // 第四轮的根因:只要缓冲能跨越失败存在,大批被拒而小终态帧通过就会乱序。
+    // 现在 flush 返回即空,交错 push 之前不可能存在"待发批"。
     const sendPush = vi.fn((
       _dst: string,
       channel: string,
@@ -432,53 +389,38 @@ describe('[10] 收敛检查点:主动发送闸门的全部入口与边界(review
     __testing.setActiveClient(h.client as never);
     subscribeBatchController('ctrl-1', ['session:s1']);
 
-    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
-    vi.advanceTimersByTime(WINDOW_MS);
-    const batchAttempts = () =>
-      sendPush.mock.calls.filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL).length;
-    expect(batchAttempts()).toBe(1); // 退避已生效
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { text: 'delta' } });
+    // 交错帧触发收口:批被拒 → 降级逐帧,缓冲清空
+    __testing.forwardPush('maker:status-changed', { sessionId: 's1', status: 'closed' });
 
-    // 交错 10 条同会话其它 channel:一次都不该再试批
-    for (let i = 0; i < 10; i++) {
-      __testing.forwardPush('maker:status-changed', { sessionId: 's1', status: 'running' });
-    }
-    expect(batchAttempts()).toBe(1);
+    const channels = sendPush.mock.calls.map((c) => c[1]);
+    // 顺序:批尝试 → 降级的逐帧事件 → 终态帧
+    expect(channels).toEqual([
+      MAKER_EVENT_BATCH_CHANNEL,
+      'maker:event',
+      'maker:status-changed',
+    ]);
+    // 之后不再有任何滞留投递
+    const before = sendPush.mock.calls.length;
+    vi.advanceTimersByTime(10_000);
+    expect(sendPush.mock.calls.length).toBe(before);
   });
 
-  it('待重试段按上限切片发送:不把滞留段撑成一个超限逻辑消息', () => {
-    let failing = true;
-    const sendPush = vi.fn((
-      _dst: string,
-      channel: string,
-      _payload: unknown,
-      _ownerStamp?: unknown,
-    ) => {
-      if (failing && channel === MAKER_EVENT_BATCH_CHANNEL) {
-        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
-      }
-    });
-    const h = mkClient({ sendPush });
+  it('单会话事件量远超单批上限:按上限切片,每帧不超限且顺序无损', () => {
+    const h = mkClient();
     __testing.setActiveClient(h.client as never);
     subscribeBatchController('ctrl-1', ['session:s1']);
 
-    // 触发退避,然后在退避期间累积到远超单批上限(64)的事件量
-    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
-    vi.advanceTimersByTime(WINDOW_MS);
-    for (let i = 1; i < 200; i++) {
+    // 200 条:到量 flush 三次(64×3),余 8 条随窗口发出
+    for (let i = 0; i < 200; i++) {
       __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
     }
+    vi.advanceTimersByTime(WINDOW_MS);
 
-    failing = false;
-    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
-    const delivered = sendPush.mock.calls
-      .filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL)
-      .slice(1) // 第 1 次是遭背压那次
-      .map((c) => c[2] as MakerEventBatchPayload);
-    // 200 条按 64 上限切成 4 片(64+64+64+8),每片都不超上限,事件一条不丢
-    expect(delivered.every((b) => b.events.length <= 64)).toBe(true);
-    expect(delivered.reduce((n, b) => n + b.events.length, 0)).toBe(200);
-    // 切片顺序 = 原始顺序
-    const flat = delivered.flatMap((b) => b.events) as Array<{ event: { i: number } }>;
+    const batches = batchesIn(h.sent);
+    expect(batches.every((b) => b.events.length <= 64)).toBe(true);
+    expect(batches.reduce((n, b) => n + b.events.length, 0)).toBe(200);
+    const flat = batches.flatMap((b) => b.events) as Array<{ event: { i: number } }>;
     expect(flat.map((e) => e.event.i)).toEqual([...Array(200).keys()]);
   });
 
@@ -532,21 +474,14 @@ describe('[11] 重连恢复的顺序(review 第三轮)', () => {
       .toBeLessThan(channels.indexOf('maker:status-changed'));
   });
 
-  it('ws-online 收口入口清掉断线时的退避位,批不被闸门永久卡住', () => {
-    let status = 'online';
+  it('ws-online 收口入口:窗口内的批在重连后立即投出,不落到积压之后', () => {
     const h = mkClient();
-    h.client.getStatus = vi.fn(() => status) as never;
     __testing.setActiveClient(h.client as never);
     subscribeBatchController('ctrl-1', ['session:s1']);
 
+    // 窗口内(尚未到点)发生重连事件:批应被立即收口
     __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
-    // 断线期间窗口到点:flush 失败并置退避位
-    status = 'connecting';
-    vi.advanceTimersByTime(WINDOW_MS);
     expect(h.sent).toHaveLength(0);
-
-    // 重连事件:清退避位并立即投出
-    status = 'online';
     flushMakerEventBatchesOnReconnect();
     expect(batchesIn(h.sent)).toHaveLength(1);
   });

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -269,22 +269,58 @@ describe('[4] 生命周期与背压', () => {
     expect(sendPush.mock.calls.length).toBe(before);
   });
 
-  it('relay 离线:同样就地降级(逐帧 best-effort 自行吞掉失败),不滞留', () => {
+  it('逐帧降级在第一次失败处停下:一次背压不再重放成 N 条失败与 N 条日志', () => {
+    // review P1:降级本身不得复刻本 PR 要消掉的洪峰。批被拒后逐帧若第一帧也进不去,
+    // 同步循环内可靠窗口不会被 ACK 腾空,后续帧必然同样失败 —— 停在第一次失败处,
+    // 交付集合完全不变,省掉的只是注定失败的尝试与逐条 WARN。
+    const sendPush = vi.fn((
+      _dst: string,
+      _channel: string,
+      _payload: unknown,
+      _ownerStamp?: unknown,
+    ) => {
+      throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+    });
+    const h = mkClient({ sendPush });
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    for (let i = 0; i < 5; i += 1) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+    vi.advanceTimersByTime(WINDOW_MS);
+
+    // 一次批帧尝试 + 一次逐帧尝试(而不是 1 + 5)
+    expect(sendPush.mock.calls.filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL)).toHaveLength(1);
+    expect(sendPush.mock.calls.filter((c) => c[1] === 'maker:event')).toHaveLength(1);
+
+    // 缓冲仍然为空:强不变量不因提前停止而破
+    const before = sendPush.mock.calls.length;
+    vi.advanceTimersByTime(10_000);
+    expect(sendPush.mock.calls.length).toBe(before);
+  });
+
+  it('relay 离线:不做逐帧尝试(逐帧同样发不出去),直接丢弃且不滞留', () => {
+    // NOT_CONNECTED 下逐帧只是把同一次失败重放 ≤64 次 —— 纯日志洪峰、零收益。
+    // 与 BACKPRESSURE 的区别:后者「大批被拒 ≠ 小帧被拒」(#2167 可驱逐档),值得试。
     let status = 'online';
-    const h = mkClient();
+    const sendPush = vi.fn();
+    const h = mkClient({ sendPush });
     h.client.getStatus = vi.fn(() => status) as never;
     __testing.setActiveClient(h.client as never);
     subscribeBatchController('ctrl-1', ['session:s1']);
 
     __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
     status = 'connecting';
     vi.advanceTimersByTime(WINDOW_MS);
 
-    // 未以批帧发出;缓冲已空,不会在恢复后突然补投陈旧事件
-    expect(batchesIn(h.sent)).toHaveLength(0);
+    // 一帧都没发:批帧因离线未尝试,逐帧降级也被判据挡掉
+    expect(sendPush).not.toHaveBeenCalled();
+    // 缓冲已空,不会在恢复后突然补投陈旧事件
     status = 'online';
     vi.advanceTimersByTime(10_000);
-    expect(batchesIn(h.sent)).toHaveLength(0);
+    expect(sendPush).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -13,6 +13,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   DeviceLinkError,
   CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
+  DL_SUBSCRIBE_CHANNEL,
   DL_UNSUBSCRIBE_CHANNEL,
   MAKER_EVENT_BATCH_CHANNEL,
   isCoalesciblePushChannel,
@@ -40,7 +41,11 @@ vi.mock('../settings-store', () => ({
   readDeviceLinkSettings: () => deviceLinkSettings.value,
 }));
 
-import { __testing, handleControllerOffline } from '../dispatch';
+import {
+  __testing,
+  flushMakerEventBatchesOnReconnect,
+  handleControllerOffline,
+} from '../dispatch';
 import * as subscriptions from '../subscriptions';
 
 /** 微批窗口与退避间隔(dispatch 内部常量);推进定时器用。 */
@@ -491,6 +496,59 @@ describe('[10] 收敛检查点:主动发送闸门的全部入口与边界(review
       'maker:event',
     ]);
     expect((h.sent[0]!.payload as MakerEventBatchPayload).events).toHaveLength(1);
+  });
+});
+
+describe('[11] 重连恢复的顺序(review 第三轮)', () => {
+  it('订阅重放 drain 离线积压之前先排空断线前的事件批', () => {
+    // 断线期间同会话的新事件/终态进 offlinePushQueue,旧批留在内存等重试;
+    // 不先收口就会让新帧先于断线前的文本送达,重现「终态后冒出文本」。
+    let status = 'online';
+    const h = mkClient();
+    h.client.getStatus = vi.fn(() => status) as never;
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    // 在线时入批(窗口未到)
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { text: 'before-drop' } });
+    expect(h.sent).toHaveLength(0);
+
+    // relay 断线:同会话新事件进离线积压
+    status = 'connecting';
+    __testing.forwardPush('maker:status-changed', { sessionId: 's1', status: 'closed' });
+    expect(h.sent).toHaveLength(0);
+
+    // 重连 + 控制端重新订阅:批必须先于积压投递
+    status = 'online';
+    __testing.handleSubscriptionFrame('ctrl-1', {
+      channel: DL_SUBSCRIBE_CHANNEL,
+      args: [{ topics: ['session:s1'], capabilities: [CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1] }],
+    });
+
+    const channels = h.sent.map((s) => s.channel);
+    expect(channels.indexOf(MAKER_EVENT_BATCH_CHANNEL)).toBe(0);
+    expect(channels).toContain('maker:status-changed');
+    expect(channels.indexOf(MAKER_EVENT_BATCH_CHANNEL))
+      .toBeLessThan(channels.indexOf('maker:status-changed'));
+  });
+
+  it('ws-online 收口入口清掉断线时的退避位,批不被闸门永久卡住', () => {
+    let status = 'online';
+    const h = mkClient();
+    h.client.getStatus = vi.fn(() => status) as never;
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
+    // 断线期间窗口到点:flush 失败并置退避位
+    status = 'connecting';
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(h.sent).toHaveLength(0);
+
+    // 重连事件:清退避位并立即投出
+    status = 'online';
+    flushMakerEventBatchesOnReconnect();
+    expect(batchesIn(h.sent)).toHaveLength(1);
   });
 });
 

--- a/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
+++ b/apps/desktop/src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
@@ -16,6 +16,7 @@ import {
   DL_UNSUBSCRIBE_CHANNEL,
   MAKER_EVENT_BATCH_CHANNEL,
   isCoalesciblePushChannel,
+  SESSION_ACTIVITY_CHANNEL,
   topicForPush,
   type MakerEventBatchPayload,
 } from '@cindy/device-link';
@@ -392,6 +393,107 @@ describe('[8] 跨 channel 顺序(review 首轮 P2)', () => {
   });
 });
 
+describe('[10] 收敛检查点:主动发送闸门的全部入口与边界(review 第二轮)', () => {
+  it('activity 终态也先收口事件批:收口在所有 session-scoped 分支之前', () => {
+    // 第二轮实测漏洞:activity 分支自带 continue,收口放在它之后就永不生效,
+    // 手机端会先收到 completed(结束流式)再收到之前的文本批。
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1', 'sessions']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { text: 'delta' } });
+    expect(h.sent).toHaveLength(0);
+    __testing.forwardPush(SESSION_ACTIVITY_CHANNEL, { sessionId: 's1', phase: 'completed' });
+
+    // 批必须先于 activity 发出
+    expect(h.sent[0]!.channel).toBe(MAKER_EVENT_BATCH_CHANNEL);
+    expect(h.sent.some((s) => s.channel === SESSION_ACTIVITY_CHANNEL)).toBe(true);
+    expect(h.sent.findIndex((s) => s.channel === MAKER_EVENT_BATCH_CHANNEL))
+      .toBeLessThan(h.sent.findIndex((s) => s.channel === SESSION_ACTIVITY_CHANNEL));
+  });
+
+  it('退避中跨 channel 收口不再尝试:交错 push 不产生额外的注定失败发送', () => {
+    const sendPush = vi.fn((
+      _dst: string,
+      channel: string,
+      _payload: unknown,
+      _ownerStamp?: unknown,
+    ) => {
+      if (channel === MAKER_EVENT_BATCH_CHANNEL) {
+        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+      }
+    });
+    const h = mkClient({ sendPush });
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: {} });
+    vi.advanceTimersByTime(WINDOW_MS);
+    const batchAttempts = () =>
+      sendPush.mock.calls.filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL).length;
+    expect(batchAttempts()).toBe(1); // 退避已生效
+
+    // 交错 10 条同会话其它 channel:一次都不该再试批
+    for (let i = 0; i < 10; i++) {
+      __testing.forwardPush('maker:status-changed', { sessionId: 's1', status: 'running' });
+    }
+    expect(batchAttempts()).toBe(1);
+  });
+
+  it('待重试段按上限切片发送:不把滞留段撑成一个超限逻辑消息', () => {
+    let failing = true;
+    const sendPush = vi.fn((
+      _dst: string,
+      channel: string,
+      _payload: unknown,
+      _ownerStamp?: unknown,
+    ) => {
+      if (failing && channel === MAKER_EVENT_BATCH_CHANNEL) {
+        throw new DeviceLinkError('BACKPRESSURE', 'reliable transport buffer is full');
+      }
+    });
+    const h = mkClient({ sendPush });
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    // 触发退避,然后在退避期间累积到远超单批上限(64)的事件量
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
+    vi.advanceTimersByTime(WINDOW_MS);
+    for (let i = 1; i < 200; i++) {
+      __testing.forwardPush('maker:event', { sessionId: 's1', event: { i } });
+    }
+
+    failing = false;
+    vi.advanceTimersByTime(MAKER_EVENT_BATCH_RETRY_MS);
+    const delivered = sendPush.mock.calls
+      .filter((c) => c[1] === MAKER_EVENT_BATCH_CHANNEL)
+      .slice(1) // 第 1 次是遭背压那次
+      .map((c) => c[2] as MakerEventBatchPayload);
+    // 200 条按 64 上限切成 4 片(64+64+64+8),每片都不超上限,事件一条不丢
+    expect(delivered.every((b) => b.events.length <= 64)).toBe(true);
+    expect(delivered.reduce((n, b) => n + b.events.length, 0)).toBe(200);
+    // 切片顺序 = 原始顺序
+    const flat = delivered.flatMap((b) => b.events) as Array<{ event: { i: number } }>;
+    expect(flat.map((e) => e.event.i)).toEqual([...Array(200).keys()]);
+  });
+
+  it('单条即超批字节上限的事件走逐帧路径(保留 compact 兜底),且排在批之后', () => {
+    const h = mkClient();
+    __testing.setActiveClient(h.client as never);
+    subscribeBatchController('ctrl-1', ['session:s1']);
+
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { i: 0 } });
+    // 单条 ~300KB UTF-8:不入批,先收口批再逐帧发
+    __testing.forwardPush('maker:event', { sessionId: 's1', event: { big: 'x'.repeat(300_000) } });
+
+    expect(h.sent.map((s) => s.channel)).toEqual([
+      MAKER_EVENT_BATCH_CHANNEL,
+      'maker:event',
+    ]);
+    expect((h.sent[0]!.payload as MakerEventBatchPayload).events).toHaveLength(1);
+  });
+});
+
 describe('[9] 字节估算按 UTF-8(review 首轮)', () => {
   it('多字节内容按 UTF-8 计:中文事件到量 flush,阈值不被 UTF-16 低估架空', () => {
     const h = mkClient();
@@ -404,8 +506,16 @@ describe('[9] 字节估算按 UTF-8(review 首轮)', () => {
     for (let i = 0; i < 9; i++) {
       __testing.forwardPush('maker:event', { sessionId: 's1', event: { text } });
     }
-    // 未到条数上限(64),靠字节阈值提前发出
-    expect(batchesIn(h.sent)).toHaveLength(1);
+    // 未到条数上限(64)就已发出:证明字节阈值生效(按 UTF-16 计不会触发)
+    const batches = batchesIn(h.sent);
+    expect(batches.length).toBeGreaterThan(0);
+    // 且每帧都在字节上限内(切片保证),事件一条不丢
+    for (const b of batches) {
+      const bytes = Buffer.byteLength(JSON.stringify(b.events), 'utf8');
+      expect(bytes).toBeLessThanOrEqual(256 * 1024);
+    }
+    vi.advanceTimersByTime(WINDOW_MS);
+    expect(batchesIn(h.sent).reduce((n, b) => n + b.events.length, 0)).toBe(9);
   });
 });
 

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -799,8 +799,8 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
  * 一次 flush 的丢弃账本(聚合日志用)。
  *
  * 这里原本还有一条「批帧被拒 → 就地降级为逐帧 best-effort」的路径。它引出了 review
- * 里最长的一族反馈,四轮都在同一段十几行代码上打转,而且两位 reviewer 的要求互相
- * 抵触——记下来,免得有人再把它加回来:
+ * 里最长的一族反馈,**五轮**都在同一段十几行代码上打转,而且 reviewer 的要求互相
+ * 抵触(同一位在第 1/4 轮与第 5 轮各站一边)——记下来,免得有人再把它加回来:
  *
  *  1. 无条件逐帧重放整个切片 → 队头不可驱逐时 ≤64 次失败、≤64 条 WARN,正是本 PR
  *     要消灭的逐事件 admission 与告警洪峰(greptile P1)。
@@ -812,8 +812,20 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
  *     ≤64 次 admission + 驱逐判定 + throw/catch 依旧在洪峰时放大主进程压力,只是
  *     WARN 被静默了(greptile P1 第三轮)。
  *
- * 第 1 与第 4 是同一条要求,第 2 与第 3 是它的反向要求 —— 这段代码不存在同时满足两侧
- * 的取值。**所以把它整个删掉**:批帧发不出去就丢掉这一片,记一条聚合日志。
+ *  5. 于是整片丢弃 → 又被要求恢复逐帧:小帧仍可进入剩余容量,最多 64 条流式增量
+ *     消失(greptile P1 第四轮,与它自己的第 1、4 轮相反)。
+ *
+ * 1/4 与 2/3/5 是同一命题的两个反向,这段代码只有「逐帧试」与「整片丢」两种可能行为,
+ * 每一轮都在要求上一轮的反面。**所以按数据定,一次定完 —— 结论是整片丢弃**,并把这
+ * 一族在本 PR 内关闭(再出现同族反馈请对照这里,不要再实现一遍)。
+ *
+ * 定这一侧的依据是 8/8 线上那次拥塞**是 count-bound 而不是 size-bound**:三个上限里
+ * pending 条数 64 是**尺寸无关**的,而 64 条 maker:event 撑不到 pending 的 16MB 字节上限
+ * (每条几 KB,满窗约 1–2MB),日志里的 `reliable transport buffer is full` 正来自条数这
+ * 一侧。条数满且队头不可驱逐时小帧与大帧一样进不去,逐帧就是 64 次零交付的纯浪费。
+ * 反向的 size-bound 窗口真实但很窄:要求 pending 条数有余量、同时 ws bufferedAmount 落在
+ * 距 8MB 上限不足 256KB 的那条带子里(≤3%)。而批本身还让 count-bound 更难触发——填满
+ * 64 槽从前需要 64 条事件,现在需要最多 4096 条。
  *
  * 为什么可以直接丢:`maker:event` 与批 channel 都在 #2167 的 COALESCIBLE_PUSH_CHANNELS
  * 白名单里 —— 拥塞时丢弃最旧的镜像帧、由控制端 resync 补偿,这正是那个 PR 定下的取舍,

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -897,6 +897,21 @@ function flushMakerEventBatchesForSessionPush(
   flushMakerEventBatchSession(dst, stage, sessionId);
 }
 
+/**
+ * 投递离线积压 / 重连恢复之前排空该控制端的全部事件批。
+ *
+ * 与 canFlushMakerEventBatchNow 的关系:这条路径**刻意绕过**退避闸门。闸门防的是
+ * 「窗口满时反复徒劳重试」,而这里的触发条件恰恰是「链路刚恢复」——断线时置的
+ * retrying 已经过期,不清掉它,断线前的批就会排在离线积压之后送达(review 第三轮)。
+ * 清位后由 flush 自己按实际结果重新决定是否再进退避。
+ */
+function flushMakerEventBatchesBeforeBacklogDrain(dst: string): void {
+  const stage = makerEventBatchStages.get(dst);
+  if (!stage || stage.batches.size === 0) return;
+  stage.retrying = false;
+  flushMakerEventBatchStage(dst, stage);
+}
+
 /** 丢弃单个会话的待发批(退订该会话流时调用);stage 空则一并回收定时器。 */
 function dropMakerEventBatch(dst: string, sessionId: string): void {
   const stage = makerEventBatchStages.get(dst);
@@ -1503,6 +1518,8 @@ function handleLinkOpen(
   syncForwarding();
   flushRemoteInvokeResultOutbox(src);
   if (!knownModernController) {
+    // 同上:投递离线积压前先排空该控制端的事件批,保住跨积压的顺序。
+    flushMakerEventBatchesBeforeBacklogDrain(src);
     for (const queued of offlinePushQueue.drain(src, [LEGACY_TOPIC])) {
       sendPushBestEffort(src, queued.channel, queued.payload, queued.ownerStamp);
     }
@@ -2044,6 +2061,17 @@ export function flushRemoteInvokeResultOutboxOnReconnect(): void {
   flushRemoteInvokeResultOutbox();
 }
 
+/**
+ * ws-online 的事件批收口入口(index.ts 接线,与 outbox 的重连 flush 并列)。
+ * 断线前攒的批必须最先出去:它在时间上早于离线积压与重连后的一切新推送,
+ * 晚发就会让控制端在终态之后又收到旧文本(review 第三轮)。
+ */
+export function flushMakerEventBatchesOnReconnect(): void {
+  for (const dst of [...makerEventBatchStages.keys()]) {
+    flushMakerEventBatchesBeforeBacklogDrain(dst);
+  }
+}
+
 function flushRemoteInvokeResultOutbox(onlySrc?: string): void {
   const client = activeClient;
   if (!client) {
@@ -2390,6 +2418,10 @@ function handleSubscriptionFrame(src: string, payload: InvokePayload): InvokeRes
     notifySessionsSubscribed(src);
   }
   if (isSub && topics.length > 0) {
+    // 先排空断线前的事件批,再投递离线积压(review 第三轮):断线期间同会话的
+    // 新事件与终态推送进的是 offlinePushQueue,而旧批留在内存等重试 timer;
+    // 不先收口就会让新帧先于断线前的文本送达,重现「终态后冒出文本」。
+    flushMakerEventBatchesBeforeBacklogDrain(src);
     for (const queued of offlinePushQueue.drain(src, topics)) {
       sendPushBestEffort(src, queued.channel, queued.payload, queued.ownerStamp);
     }

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -39,6 +39,7 @@ import {
   SESSION_ACTIVITY_CHANNEL,
   MAKER_EVENT_BATCH_CHANNEL,
   CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
+  byteLength,
   DeviceLinkError,
   parseFsWatchTopic,
   type Envelope,
@@ -608,7 +609,13 @@ const MAKER_EVENT_BATCH_MAX_BUFFERED_EVENTS = 512;
 /** 背压/离线时的重试间隔(与 activity staging 同款,不新造节奏)。 */
 const MAKER_EVENT_BATCH_RETRY_MS = 250;
 
-interface MakerEventBatch {
+/**
+ * 一个待发批段。**按 ownerStamp 分段**而不是「切换即覆盖」:ownerStamp 是数据
+ * 归属水印、批内必须一致,而旧段可能正因背压/离线滞留待重试——直接用新段覆盖
+ * 同一会话的 map 槽会静默丢掉旧段全部事件(review 首轮三家同时指出)。分段后
+ * 同会话按段 FIFO 发送,旧段发不出就停在原位,新事件进新段。
+ */
+interface MakerEventBatchSegment {
   events: unknown[];
   bytes: number;
   ownerStamp?: PushOwnerStamp;
@@ -616,9 +623,15 @@ interface MakerEventBatch {
 }
 
 interface MakerEventBatchStage {
-  /** sessionId → 该会话的待发事件;Map 插入序即会话首次入批顺序。 */
-  batches: Map<string, MakerEventBatch>;
+  /** sessionId → 该会话的待发段序列(FIFO);Map 插入序即会话首次入批顺序。 */
+  batches: Map<string, MakerEventBatchSegment[]>;
   timer: ReturnType<typeof setTimeout> | null;
+  /**
+   * 正在背压/离线退避中。到量 flush 必须看它:批一旦因背压滞留,其 events 长度
+   * 仍在阈值之上,后续**每条**新事件都会再次触发到量 flush → 逐事件同步 sendPush
+   * 抛异常,退化成本 PR 要消除的那种逐帧 admission 风暴(review 首轮 P1)。
+   */
+  retrying: boolean;
 }
 
 const makerEventBatchStages = new Map<string, MakerEventBatchStage>();
@@ -644,34 +657,68 @@ function stageMakerEventPush(
 ): void {
   let stage = makerEventBatchStages.get(dst);
   if (!stage) {
-    stage = { batches: new Map(), timer: null };
+    stage = { batches: new Map(), timer: null, retrying: false };
     makerEventBatchStages.set(dst, stage);
   }
-  let batch = stage.batches.get(sessionId);
-  // ownerStamp 是数据归属水印,批内必须一致:变化即先把旧批发走再开新批。
-  if (batch && !makerEventBatchOwnerStampEquals(batch.ownerStamp, ownerStamp)) {
-    flushMakerEventBatch(dst, stage, sessionId);
-    batch = undefined;
+  let segments = stage.batches.get(sessionId);
+  if (!segments) {
+    segments = [];
+    stage.batches.set(sessionId, segments);
   }
-  if (!batch) {
-    batch = { events: [], bytes: 0, droppedOldest: 0, ...(ownerStamp ? { ownerStamp } : {}) };
-    stage.batches.set(sessionId, batch);
+  // 只往**最后一段**追加,且 ownerStamp 必须一致;不一致就新开一段(旧段可能正
+  // 待重试,不能被覆盖)。段间 FIFO 保证归属切换前后的事件顺序不变。
+  let tail = segments.at(-1);
+  if (!tail || !makerEventBatchOwnerStampEquals(tail.ownerStamp, ownerStamp)) {
+    tail = { events: [], bytes: 0, droppedOldest: 0, ...(ownerStamp ? { ownerStamp } : {}) };
+    segments.push(tail);
   }
-  batch.events.push(payload);
-  batch.bytes += estimateMakerEventBytes(payload);
-  while (batch.events.length > MAKER_EVENT_BATCH_MAX_BUFFERED_EVENTS) {
-    const dropped = batch.events.shift();
-    batch.bytes = Math.max(0, batch.bytes - estimateMakerEventBytes(dropped));
-    batch.droppedOldest += 1;
-  }
+  tail.events.push(payload);
+  tail.bytes += estimateMakerEventBytes(payload);
+  trimMakerEventBatchBuffer(dst, sessionId, segments);
+  // 到量即发,但**退避中不插队**:滞留段的长度仍在阈值之上,逐条触发只会重复
+  // 同步 sendPush 抛异常(review 首轮 P1)。退避由 timer 统一驱动。
   if (
-    batch.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
-    || batch.bytes >= MAKER_EVENT_BATCH_MAX_BYTES
+    !stage.retrying
+    && (tail.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
+      || tail.bytes >= MAKER_EVENT_BATCH_MAX_BYTES)
   ) {
-    flushMakerEventBatch(dst, stage, sessionId);
+    flushMakerEventBatchSession(dst, stage, sessionId);
     return;
   }
   scheduleMakerEventBatchFlush(dst, stage);
+}
+
+/**
+ * 单会话缓冲的总量兜底(跨全部待发段):maker:event 是自相似有损流(与 #2167 的
+ * 可驱逐判据同源),溢出丢**最旧**、保留最新——转录内容由受保护的
+ * messages:created + 控制端消息对账自愈。无上限则背压期间内存无界。
+ */
+function trimMakerEventBatchBuffer(
+  dst: string,
+  sessionId: string,
+  segments: MakerEventBatchSegment[],
+): void {
+  let total = segments.reduce((n, seg) => n + seg.events.length, 0);
+  while (total > MAKER_EVENT_BATCH_MAX_BUFFERED_EVENTS) {
+    const head = segments[0];
+    if (!head) break;
+    const dropped = head.events.shift();
+    head.bytes = Math.max(0, head.bytes - estimateMakerEventBytes(dropped));
+    head.droppedOldest += 1;
+    total -= 1;
+    if (head.events.length === 0) {
+      // 空段出队,但把丢弃计数并进下一段,告警不丢。
+      const next = segments[1];
+      if (next) next.droppedOldest += head.droppedOldest;
+      else {
+        log.warn(
+          `maker:event batch dropped ${head.droppedOldest} oldest event(s) for ${shortId(dst)} `
+          + `session ${sessionId.slice(0, 8)} (buffer cap under sustained backpressure)`,
+        );
+      }
+      segments.shift();
+    }
+  }
 }
 
 /** 读 push payload 顶层 sessionId(与 topicForPush 的 session-scoped 判据同一字段)。 */
@@ -683,7 +730,11 @@ function readPushSessionId(payload: unknown): string | null {
 
 function estimateMakerEventBytes(payload: unknown): number {
   try {
-    return JSON.stringify(payload)?.length ?? 0;
+    const json = JSON.stringify(payload);
+    // 必须按 UTF-8 计:String.length 是 UTF-16 码元数,中文/emoji 会显著低估,
+    // 字节阈值随之形同虚设(单批可能被撑到需要分片或 PAYLOAD_TOO_LARGE)。
+    // byteLength 与可靠传输层计算分片大小用的是同一个函数,口径一致。
+    return json ? byteLength(json) : 0;
   } catch {
     // 不可序列化的 payload 交给 sendPush 报错处理;这里只保证估算不抛。
     return 0;
@@ -700,24 +751,26 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
   (stage.timer as unknown as { unref?: () => void }).unref?.();
 }
 
-/** flush 该控制端的全部会话批(窗口到点 / 显式收口)。 */
+/** flush 该控制端的全部会话批(窗口到点 / 退避重试 / 显式收口)。 */
 function flushMakerEventBatchStage(dst: string, stage: MakerEventBatchStage): void {
   for (const sessionId of [...stage.batches.keys()]) {
-    if (!flushMakerEventBatch(dst, stage, sessionId)) return; // 背压:保留其余,已排重试
+    if (!flushMakerEventBatchSession(dst, stage, sessionId)) return; // 背压:保留其余,已排重试
   }
+  stage.retrying = false;
 }
 
 /**
- * 发送单个会话的批。返回 false 表示遇到背压/离线并已排退避重试(事件保留在
- * 缓冲里,不丢);其它错误按 best-effort 丢弃该批,不堵住整个 stage。
+ * 按段 FIFO 发送某会话的待发批。返回 false 表示遇到背压/离线并已排退避重试
+ * (该段及其后**保留**在缓冲里,不丢);其它错误按 best-effort 丢弃该段,
+ * 不堵住后续段与其它会话。
  */
-function flushMakerEventBatch(
+function flushMakerEventBatchSession(
   dst: string,
   stage: MakerEventBatchStage,
   sessionId: string,
 ): boolean {
-  const batch = stage.batches.get(sessionId);
-  if (!batch || batch.events.length === 0) {
+  const segments = stage.batches.get(sessionId);
+  if (!segments || segments.length === 0) {
     stage.batches.delete(sessionId);
     return true;
   }
@@ -725,36 +778,45 @@ function flushMakerEventBatch(
     scheduleMakerEventBatchRetry(dst, stage);
     return false;
   }
-  if (batch.droppedOldest > 0) {
-    log.warn(
-      `maker:event batch dropped ${batch.droppedOldest} oldest event(s) for ${shortId(dst)} `
-      + `session ${sessionId.slice(0, 8)} (buffer cap under sustained backpressure)`,
-    );
-    batch.droppedOldest = 0;
-  }
-  const payload: MakerEventBatchPayload = { sessionId, events: batch.events };
-  try {
-    if (batch.ownerStamp === undefined) {
-      activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload);
-    } else {
-      activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, batch.ownerStamp);
+  while (segments.length > 0) {
+    const segment = segments[0]!;
+    if (segment.events.length === 0) {
+      segments.shift();
+      continue;
     }
-    stage.batches.delete(sessionId);
-    return true;
-  } catch (err) {
-    if (err instanceof DeviceLinkError && err.code === 'BACKPRESSURE') {
-      scheduleMakerEventBatchRetry(dst, stage);
-      return false;
+    if (segment.droppedOldest > 0) {
+      log.warn(
+        `maker:event batch dropped ${segment.droppedOldest} oldest event(s) for ${shortId(dst)} `
+        + `session ${sessionId.slice(0, 8)} (buffer cap under sustained backpressure)`,
+      );
+      segment.droppedOldest = 0;
     }
-    // PAYLOAD_TOO_LARGE / LINK_NOT_OPEN 等:沿 maker:event 既有 best-effort 语义
-    // 丢弃该批(逐帧路径同样会丢),不让一批坏帧堵死后续会话。
-    stage.batches.delete(sessionId);
-    log.warn(`maker:event batch dropped for ${shortId(dst)}: ${String(err)}`);
-    return true;
+    const payload: MakerEventBatchPayload = { sessionId, events: segment.events };
+    try {
+      if (segment.ownerStamp === undefined) {
+        activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload);
+      } else {
+        activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, segment.ownerStamp);
+      }
+      segments.shift();
+    } catch (err) {
+      if (err instanceof DeviceLinkError && err.code === 'BACKPRESSURE') {
+        scheduleMakerEventBatchRetry(dst, stage);
+        return false;
+      }
+      // PAYLOAD_TOO_LARGE / LINK_NOT_OPEN 等:沿 maker:event 既有 best-effort 语义
+      // 丢弃该段(逐帧路径同样会丢),继续尝试后续段。
+      segments.shift();
+      log.warn(`maker:event batch dropped for ${shortId(dst)}: ${String(err)}`);
+    }
   }
+  stage.batches.delete(sessionId);
+  return true;
 }
 
 function scheduleMakerEventBatchRetry(dst: string, stage: MakerEventBatchStage): void {
+  // 置位后到量 flush 不再插队(见 stageMakerEventPush),避免退化成逐事件同步发送。
+  stage.retrying = true;
   if (stage.timer) return;
   stage.timer = setTimeout(() => {
     stage.timer = null;
@@ -762,6 +824,23 @@ function scheduleMakerEventBatchRetry(dst: string, stage: MakerEventBatchStage):
     if (current) flushMakerEventBatchStage(dst, current);
   }, MAKER_EVENT_BATCH_RETRY_MS);
   (stage.timer as unknown as { unref?: () => void }).unref?.();
+}
+
+/**
+ * 在转发同会话的**其它** channel 之前收口该会话的事件批,保住跨 channel 顺序。
+ * 只在该控制端确实有待发批时才做,常态下是一次 Map 查询。
+ */
+function flushMakerEventBatchesForSessionPush(
+  dst: string,
+  channel: string,
+  payload: unknown,
+): void {
+  if (channel === MAKER_EVENT_BATCH_CHANNEL) return;
+  const stage = makerEventBatchStages.get(dst);
+  if (!stage || stage.batches.size === 0) return;
+  const sessionId = readPushSessionId(payload);
+  if (!sessionId || !stage.batches.has(sessionId)) return;
+  flushMakerEventBatchSession(dst, stage, sessionId);
 }
 
 /** 丢弃单个会话的待发批(退订该会话流时调用);stage 空则一并回收定时器。 */
@@ -968,6 +1047,16 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
         stageMakerEventPush(dst, sessionId, remotePayload, ownerStamp);
         continue;
       }
+    }
+    // 跨 channel 保序(review 首轮 P2):同会话的其它推送必须排在已暂存的事件
+    // **之后**——否则 interaction-request / status-changed 会插到攒批的文本
+    // delta 前面,控制端先收确认卡(结束当前流式消息)、120ms 后才收到前面的
+    // 文本,表现为「交互卡出现后又冒出流式内容」。先把该会话的批推进可靠
+    // FIFO,后续帧自然排在其后。
+    // 残留窗口:批因背压 flush 失败时顺序仍可能颠倒——那时本帧的 sendPush 大概率
+    // 同样受阻(同一窗口),退化为旧语义(拥塞时 maker:event 本就被丢弃)。
+    if (makerEventBatchStages.size > 0) {
+      flushMakerEventBatchesForSessionPush(dst, channel, remotePayload);
     }
     // 转发是尽力而为的旁路:单个控制端的帧超限(PAYLOAD_TOO_LARGE,如大 tool 输出)/ 连接异常
     // 绝不能冒泡——它会经 tapWindowBroadcast 回到 broadcastToAllWindows,让被控端**本机** renderer
@@ -2512,7 +2601,7 @@ export const __testing = {
     activeClient = null;
     offlinePushQueue.clear();
     clearAllSessionActivityStages();
-  clearAllMakerEventBatchStages();
+    clearAllMakerEventBatchStages();
     cancelAllLinkAcceptRetries();
     setBroadcastTapListener(null);
   },

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -588,8 +588,28 @@ const SESSION_ACTIVITY_WINDOW_SOFT_CAP = 32;
  * 毫秒 119 帧、8-07 单小时 5168 次 BACKPRESSURE,聚合速率还招来 relay 1013 断连。
  * 批把「每事件一帧」压成「每窗口一帧」,直接砍掉这条链路的源头流量。
  *
- * 时序契约:同一会话的事件对启用批的控制端**全部**走批路径,没有旁路——否则
- * 缓冲里的旧事件会排在直发的新事件之后,顺序即被破坏。
+ * ── 顺序不变量与它的代价(review 四轮收敛的结论)────────────────────────────
+ *
+ * 批天然引入一条「延迟发送」旁路,而同会话的其它 session-scoped 推送走「立即
+ * 发送」主路。只要缓冲能跨越一次失败继续存在,两条路径的相对顺序就无法用局部
+ * 补丁保证——review 四轮从四个不同时序切入,全是这同一件事:交错 push 直发、
+ * activity 分支提前 continue、断线积压 drain 先于旧批、退避期大批被拒而小终态
+ * 帧通过。前三轮各补一处,第四轮证明补丁修不完。
+ *
+ * 所以这里**去掉了退避重试**,换成一条强不变量:
+ *
+ *   **缓冲的生命周期不跨越任何一次发送失败。** flush 要么整批发出,要么就地
+ *   降级为逐帧 best-effort 发送(与本 PR 之前的旧语义完全一致),两种情况都让
+ *   缓冲立刻清空。
+ *
+ * 于是「同会话有待发批」这个状态只存在于「窗口内、且尚未尝试发送」的区间,
+ * 收口点(flushMakerEventBatchesForSessionPush)一次调用即可保证清空,顺序问题
+ * 整族消失,而不是每轮补一个新场景。
+ *
+ * 代价与为什么可接受:拥塞时不再保留事件等窗口恢复。但那本来不是本 PR 的目标
+ * (常态减帧才是),而拥塞时的取舍是 #2167 的职责——降级后的逐帧发送正好落回
+ * 它的可驱逐档语义。删掉退避同时也删掉了它带来的全部复杂性(段滞留、闸门、
+ * 重连清位),这是缩回原始范围,不是新增机制。
  */
 const MAKER_EVENT_BATCH_WINDOW_MS = 120;
 /** 单批事件数上限:到量立即 flush(不等窗口),避免长思考把一帧撑得过大。 */
@@ -600,38 +620,22 @@ const MAKER_EVENT_BATCH_MAX_EVENTS = 64;
  * 不是制造需要分片的大帧——分片会把一帧放大成多帧,反噬本次优化。
  */
 const MAKER_EVENT_BATCH_MAX_BYTES = 256 * 1024;
-/**
- * 单会话缓冲的事件数硬上限(背压滞留时的兜底)。maker:event 是自相似有损流
- * (与 #2167 的可驱逐判据同源),溢出丢**最旧**、保留最新:转录内容由受保护的
- * messages:created + 控制端消息对账自愈。无上限则背压期间内存无界。
- */
-const MAKER_EVENT_BATCH_MAX_BUFFERED_EVENTS = 512;
-/** 背压/离线时的重试间隔(与 activity staging 同款,不新造节奏)。 */
-const MAKER_EVENT_BATCH_RETRY_MS = 250;
 
 /**
- * 一个待发批段。**按 ownerStamp 分段**而不是「切换即覆盖」:ownerStamp 是数据
- * 归属水印、批内必须一致,而旧段可能正因背压/离线滞留待重试——直接用新段覆盖
- * 同一会话的 map 槽会静默丢掉旧段全部事件(review 首轮三家同时指出)。分段后
- * 同会话按段 FIFO 发送,旧段发不出就停在原位,新事件进新段。
+ * 一个待发批段。按 ownerStamp 分段:ownerStamp 是数据归属水印、批内必须一致,
+ * 同一窗口内发生归属切换时新事件进新段,段间 FIFO——保证切换前后顺序不变。
+ * (缓冲不跨失败存在,所以段最多因窗口内切换而出现,不会因滞留而堆积。)
  */
 interface MakerEventBatchSegment {
   events: unknown[];
   bytes: number;
   ownerStamp?: PushOwnerStamp;
-  droppedOldest: number;
 }
 
 interface MakerEventBatchStage {
   /** sessionId → 该会话的待发段序列(FIFO);Map 插入序即会话首次入批顺序。 */
   batches: Map<string, MakerEventBatchSegment[]>;
   timer: ReturnType<typeof setTimeout> | null;
-  /**
-   * 正在背压/离线退避中。到量 flush 必须看它:批一旦因背压滞留,其 events 长度
-   * 仍在阈值之上,后续**每条**新事件都会再次触发到量 flush → 逐事件同步 sendPush
-   * 抛异常,退化成本 PR 要消除的那种逐帧 admission 风暴(review 首轮 P1)。
-   */
-  retrying: boolean;
 }
 
 const makerEventBatchStages = new Map<string, MakerEventBatchStage>();
@@ -646,8 +650,8 @@ function makerEventBatchOwnerStampEquals(
 }
 
 /**
- * 把一条 maker:event 收进目标控制端的批。到量(条数/字节)或 ownerStamp 变化
- * 立即 flush 该会话,否则等窗口定时器统一 flush。
+ * 把一条 maker:event 收进目标控制端的批。到量(条数/字节)立即 flush,否则等
+ * 窗口定时器统一 flush。
  */
 function stageMakerEventPush(
   dst: string,
@@ -657,7 +661,7 @@ function stageMakerEventPush(
 ): void {
   let stage = makerEventBatchStages.get(dst);
   if (!stage) {
-    stage = { batches: new Map(), timer: null, retrying: false };
+    stage = { batches: new Map(), timer: null };
     makerEventBatchStages.set(dst, stage);
   }
   let segments = stage.batches.get(sessionId);
@@ -665,73 +669,21 @@ function stageMakerEventPush(
     segments = [];
     stage.batches.set(sessionId, segments);
   }
-  // 只往**最后一段**追加,且 ownerStamp 必须一致;不一致就新开一段(旧段可能正
-  // 待重试,不能被覆盖)。段间 FIFO 保证归属切换前后的事件顺序不变。
   let tail = segments.at(-1);
   if (!tail || !makerEventBatchOwnerStampEquals(tail.ownerStamp, ownerStamp)) {
-    tail = { events: [], bytes: 0, droppedOldest: 0, ...(ownerStamp ? { ownerStamp } : {}) };
+    tail = { events: [], bytes: 0, ...(ownerStamp ? { ownerStamp } : {}) };
     segments.push(tail);
   }
   tail.events.push(payload);
   tail.bytes += estimateMakerEventBytes(payload);
-  trimMakerEventBatchBuffer(dst, sessionId, segments);
-  // 到量即发,但要过统一的主动发送闸门(见 canFlushMakerEventBatchNow)。
   if (
-    canFlushMakerEventBatchNow(stage)
-    && (tail.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
-      || tail.bytes >= MAKER_EVENT_BATCH_MAX_BYTES)
+    tail.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
+    || tail.bytes >= MAKER_EVENT_BATCH_MAX_BYTES
   ) {
     flushMakerEventBatchSession(dst, stage, sessionId);
     return;
   }
   scheduleMakerEventBatchFlush(dst, stage);
-}
-
-/**
- * **主动** flush 的唯一准入判据(到量路径与跨 channel 收口路径共用)。
- *
- * 退避中一律拒绝:滞留段的长度/字节仍在阈值之上,任何主动入口都会反复触发同步
- * sendPush 抛异常,退化成本 PR 要消除的逐帧 admission 风暴。review 两轮各抓到
- * 一个入口(第一轮:到量;第二轮:跨 channel 收口),所以判据收敛成这一个函数——
- * 新增主动入口必须过它,而不是各自记得检查 retrying。
- *
- * 唯一允许绕过的入口是退避 timer 自己(它就是退避的驱动者)。
- */
-function canFlushMakerEventBatchNow(stage: MakerEventBatchStage): boolean {
-  return !stage.retrying;
-}
-
-/**
- * 单会话缓冲的总量兜底(跨全部待发段):maker:event 是自相似有损流(与 #2167 的
- * 可驱逐判据同源),溢出丢**最旧**、保留最新——转录内容由受保护的
- * messages:created + 控制端消息对账自愈。无上限则背压期间内存无界。
- */
-function trimMakerEventBatchBuffer(
-  dst: string,
-  sessionId: string,
-  segments: MakerEventBatchSegment[],
-): void {
-  let total = segments.reduce((n, seg) => n + seg.events.length, 0);
-  while (total > MAKER_EVENT_BATCH_MAX_BUFFERED_EVENTS) {
-    const head = segments[0];
-    if (!head) break;
-    const dropped = head.events.shift();
-    head.bytes = Math.max(0, head.bytes - estimateMakerEventBytes(dropped));
-    head.droppedOldest += 1;
-    total -= 1;
-    if (head.events.length === 0) {
-      // 空段出队,但把丢弃计数并进下一段,告警不丢。
-      const next = segments[1];
-      if (next) next.droppedOldest += head.droppedOldest;
-      else {
-        log.warn(
-          `maker:event batch dropped ${head.droppedOldest} oldest event(s) for ${shortId(dst)} `
-          + `session ${sessionId.slice(0, 8)} (buffer cap under sustained backpressure)`,
-        );
-      }
-      segments.shift();
-    }
-  }
 }
 
 /** 读 push payload 顶层 sessionId(与 topicForPush 的 session-scoped 判据同一字段)。 */
@@ -764,90 +716,61 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
   (stage.timer as unknown as { unref?: () => void }).unref?.();
 }
 
-/** flush 该控制端的全部会话批(窗口到点 / 退避重试 / 显式收口)。 */
+/** flush 该控制端的全部会话批(窗口到点 / 显式收口)。 */
 function flushMakerEventBatchStage(dst: string, stage: MakerEventBatchStage): void {
   for (const sessionId of [...stage.batches.keys()]) {
-    if (!flushMakerEventBatchSession(dst, stage, sessionId)) return; // 背压:保留其余,已排重试
+    flushMakerEventBatchSession(dst, stage, sessionId);
   }
-  stage.retrying = false;
 }
 
 /**
- * 按段 FIFO 发送某会话的待发批。返回 false 表示遇到背压/离线并已排退避重试
- * (该段及其后**保留**在缓冲里,不丢);其它错误按 best-effort 丢弃该段,
- * 不堵住后续段与其它会话。
+ * 发送某会话的待发批,**返回时缓冲一定为空**(强不变量,见本段顶部注释):
+ * 按段 FIFO、段内按上限切片;任一切片发送失败即就地降级为逐帧 best-effort
+ * 发送该切片的事件(与本 PR 之前的旧语义一致,含 compactOversizedPushPayload
+ * 兜底),不保留、不重试。
  */
 function flushMakerEventBatchSession(
   dst: string,
   stage: MakerEventBatchStage,
   sessionId: string,
-): boolean {
+): void {
   const segments = stage.batches.get(sessionId);
-  if (!segments || segments.length === 0) {
-    stage.batches.delete(sessionId);
-    return true;
-  }
-  if (!activeClient || activeClient.getStatus() !== 'online') {
-    scheduleMakerEventBatchRetry(dst, stage);
-    return false;
-  }
-  while (segments.length > 0) {
-    const segment = segments[0]!;
-    if (segment.events.length === 0) {
-      segments.shift();
-      continue;
-    }
-    if (segment.droppedOldest > 0) {
-      log.warn(
-        `maker:event batch dropped ${segment.droppedOldest} oldest event(s) for ${shortId(dst)} `
-        + `session ${sessionId.slice(0, 8)} (buffer cap under sustained backpressure)`,
-      );
-      segment.droppedOldest = 0;
-    }
-    // 按上限**切片**发送,而不是整段一帧:退避期间段可以累积到缓冲上限
-    // (512 条),整段发会撑爆可靠传输的单逻辑消息上限、走 PAYLOAD_TOO_LARGE
-    // 分支一次丢掉整段(review 第二轮)。切片后未发出的部分留在段头等重试。
-    const slice = takeMakerEventBatchSlice(segment);
-    const payload: MakerEventBatchPayload = { sessionId, events: slice };
-    try {
-      if (segment.ownerStamp === undefined) {
-        activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload);
-      } else {
-        activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, segment.ownerStamp);
-      }
-      if (segment.events.length === 0) segments.shift();
-    } catch (err) {
-      const sliceBytes = sumMakerEventBytes(slice);
-      // 切片未发出:放回段头,顺序不变(切片本就取自段头)。
-      segment.events.unshift(...slice);
-      segment.bytes += sliceBytes;
-      if (err instanceof DeviceLinkError && err.code === 'BACKPRESSURE') {
-        scheduleMakerEventBatchRetry(dst, stage);
-        return false;
-      }
-      // PAYLOAD_TOO_LARGE / LINK_NOT_OPEN 等:沿 maker:event 既有 best-effort 语义
-      // 丢弃**该切片**(逐帧路径同样会丢),继续尝试段内其余事件。
-      segment.events.splice(0, slice.length);
-      segment.bytes = Math.max(0, segment.bytes - sliceBytes);
-      if (segment.events.length === 0) segments.shift();
-      log.warn(`maker:event batch slice dropped for ${shortId(dst)}: ${String(err)}`);
-    }
-  }
   stage.batches.delete(sessionId);
-  return true;
+  if (stage.batches.size === 0 && stage.timer) {
+    clearTimeout(stage.timer);
+    stage.timer = null;
+  }
+  if (!segments) return;
+  for (const segment of segments) {
+    while (segment.events.length > 0) {
+      const slice = takeMakerEventBatchSlice(segment);
+      if (slice.length === 0) break;
+      const payload: MakerEventBatchPayload = { sessionId, events: slice };
+      try {
+        if (!activeClient || activeClient.getStatus() !== 'online') {
+          throw new DeviceLinkError('NOT_CONNECTED', 'relay offline');
+        }
+        if (segment.ownerStamp === undefined) {
+          activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload);
+        } else {
+          activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, segment.ownerStamp);
+        }
+      } catch {
+        // 降级为逐帧:sendPushBestEffort 吞掉每条的失败并保留超大帧裁剪,
+        // 顺序仍是原顺序。批不因失败滞留 —— 那正是顺序问题的唯一来源。
+        for (const event of slice) {
+          sendPushBestEffort(dst, MAKER_PUSH.EVENT, event, segment.ownerStamp);
+        }
+      }
+    }
+  }
 }
 
 /**
  * 从段头取一片:条数 ≤ MAX_EVENTS 且累计字节 ≤ MAX_BYTES,但**至少一条**
  * (单条即超阈值的事件已在入批前被拦到逐帧路径,这里的至少一条只是防死循环)。
- * 取出的事件同步从段里移除;发送失败时由调用方放回段头。
+ * 取出的事件同步从段里移除。
  */
-function sumMakerEventBytes(events: readonly unknown[]): number {
-  let total = 0;
-  for (const event of events) total += estimateMakerEventBytes(event);
-  return total;
-}
-
 function takeMakerEventBatchSlice(segment: MakerEventBatchSegment): unknown[] {
   const slice: unknown[] = [];
   let bytes = 0;
@@ -863,21 +786,21 @@ function takeMakerEventBatchSlice(segment: MakerEventBatchSegment): unknown[] {
   return slice;
 }
 
-function scheduleMakerEventBatchRetry(dst: string, stage: MakerEventBatchStage): void {
-  // 置位后到量 flush 不再插队(见 stageMakerEventPush),避免退化成逐事件同步发送。
-  stage.retrying = true;
-  if (stage.timer) return;
-  stage.timer = setTimeout(() => {
-    stage.timer = null;
-    const current = makerEventBatchStages.get(dst);
-    if (current) flushMakerEventBatchStage(dst, current);
-  }, MAKER_EVENT_BATCH_RETRY_MS);
-  (stage.timer as unknown as { unref?: () => void }).unref?.();
+/**
+ * 收口某控制端的全部待发批。用在「即将投递更晚产生的积压」的时点:离线积压
+ * drain 之前、relay 重连之后——批在时间上早于它们,晚发就会让控制端在终态之后
+ * 又收到旧文本(review 第三轮)。flush 返回时缓冲必为空(成功或降级)。
+ */
+function flushMakerEventBatchesFor(dst: string): void {
+  const stage = makerEventBatchStages.get(dst);
+  if (!stage || stage.batches.size === 0) return;
+  flushMakerEventBatchStage(dst, stage);
 }
 
 /**
  * 在转发同会话的**其它** channel 之前收口该会话的事件批,保住跨 channel 顺序。
- * 只在该控制端确实有待发批时才做,常态下是一次 Map 查询。
+ * 因为 flush 返回时缓冲必为空(成功或降级),这一次调用就足以保证后续帧排在
+ * 全部已暂存事件之后——不需要再考虑退避、断线等中间状态(review 四轮的结论)。
  */
 function flushMakerEventBatchesForSessionPush(
   dst: string,
@@ -887,29 +810,9 @@ function flushMakerEventBatchesForSessionPush(
   if (channel === MAKER_EVENT_BATCH_CHANNEL) return;
   const stage = makerEventBatchStages.get(dst);
   if (!stage || stage.batches.size === 0) return;
-  // 退避中不尝试(与到量路径同一闸门,review 第二轮 P1):否则每条交错 push 都
-  // 会额外产生一次注定失败的同步发送。此时顺序不保证——但那时本帧自身的
-  // sendPush 大概率同样受阻(同一个满窗口),退化为旧语义(拥塞时 maker:event
-  // 本就被丢弃),不值得为它把交错帧也压进缓冲。
-  if (!canFlushMakerEventBatchNow(stage)) return;
   const sessionId = readPushSessionId(payload);
   if (!sessionId || !stage.batches.has(sessionId)) return;
   flushMakerEventBatchSession(dst, stage, sessionId);
-}
-
-/**
- * 投递离线积压 / 重连恢复之前排空该控制端的全部事件批。
- *
- * 与 canFlushMakerEventBatchNow 的关系:这条路径**刻意绕过**退避闸门。闸门防的是
- * 「窗口满时反复徒劳重试」,而这里的触发条件恰恰是「链路刚恢复」——断线时置的
- * retrying 已经过期,不清掉它,断线前的批就会排在离线积压之后送达(review 第三轮)。
- * 清位后由 flush 自己按实际结果重新决定是否再进退避。
- */
-function flushMakerEventBatchesBeforeBacklogDrain(dst: string): void {
-  const stage = makerEventBatchStages.get(dst);
-  if (!stage || stage.batches.size === 0) return;
-  stage.retrying = false;
-  flushMakerEventBatchStage(dst, stage);
 }
 
 /** 丢弃单个会话的待发批(退订该会话流时调用);stage 空则一并回收定时器。 */
@@ -930,7 +833,6 @@ function clearMakerEventBatchStage(dst: string): void {
 function clearAllMakerEventBatchStages(): void {
   for (const dst of [...makerEventBatchStages.keys()]) clearMakerEventBatchStage(dst);
 }
-
 interface SessionActivityStage {
   /** sessionId → 最新 payload + source owner;Map 插入序即更新序。 */
   queue: Map<string, { payload: unknown; ownerStamp?: PushOwnerStamp }>;
@@ -1519,7 +1421,7 @@ function handleLinkOpen(
   flushRemoteInvokeResultOutbox(src);
   if (!knownModernController) {
     // 同上:投递离线积压前先排空该控制端的事件批,保住跨积压的顺序。
-    flushMakerEventBatchesBeforeBacklogDrain(src);
+    flushMakerEventBatchesFor(src);
     for (const queued of offlinePushQueue.drain(src, [LEGACY_TOPIC])) {
       sendPushBestEffort(src, queued.channel, queued.payload, queued.ownerStamp);
     }
@@ -2068,7 +1970,7 @@ export function flushRemoteInvokeResultOutboxOnReconnect(): void {
  */
 export function flushMakerEventBatchesOnReconnect(): void {
   for (const dst of [...makerEventBatchStages.keys()]) {
-    flushMakerEventBatchesBeforeBacklogDrain(dst);
+    flushMakerEventBatchesFor(dst);
   }
 }
 
@@ -2421,7 +2323,7 @@ function handleSubscriptionFrame(src: string, payload: InvokePayload): InvokeRes
     // 先排空断线前的事件批,再投递离线积压(review 第三轮):断线期间同会话的
     // 新事件与终态推送进的是 offlinePushQueue,而旧批留在内存等重试 timer;
     // 不先收口就会让新帧先于断线前的文本送达,重现「终态后冒出文本」。
-    flushMakerEventBatchesBeforeBacklogDrain(src);
+    flushMakerEventBatchesFor(src);
     for (const queued of offlinePushQueue.drain(src, topics)) {
       sendPushBestEffort(src, queued.channel, queued.payload, queued.ownerStamp);
     }

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -613,6 +613,22 @@ const SESSION_ACTIVITY_WINDOW_SOFT_CAP = 32;
  * (常态减帧才是),而拥塞时的取舍是 #2167 的职责——降级后的逐帧发送正好落回
  * 它的可驱逐档语义。删掉退避同时也删掉了它带来的全部复杂性(段滞留、闸门、
  * 重连清位),这是缩回原始范围,不是新增机制。
+ *
+ * **已知且刻意接受的代价:窗口正好跨在断线时刻上的那 ≤120ms 事件不进可靠 pending**
+ * (review 同族第 3 次点到,不要再改成"离线时保留批"):逐帧世界里它们在产生瞬间就
+ * 被 sendPush 收进 pending,而 pending 是跨连接世代保留的
+ * (client.resetLinkStateForReconnect),link 重建后按原 seq 重放;批世界里它们还在
+ * 窗口内,flush 撞上 NOT_CONNECTED 即丢。三条理由说明不值得为它引机制:
+ *  1. 那批 pending 也不一定活得下来 —— replayPending 前会先 dropDiscardablePendingPrefix
+ *     丢掉队头连续的可丢弃前缀,而长思考期间队头恰恰就是 push,常见形态下逐帧世界
+ *     同样一条不剩;活下来的场景是队头压着 live invoke/invoke-result 的那一种。
+ *  2. 净账反而是赚的:pending 窗口是 64 **条消息**(MAX_TRANSPORT_PENDING_MESSAGES)。
+ *     批把 64 条事件压进一条消息,同一个窗口能装的事件量提高到 64×64 —— 断线时可
+ *     恢复的历史深度是逐帧世界的几十倍,代价是尾部 ≤120ms。
+ *  3. 唯一的补法(离线时保留批到重连收口)会把"缓冲跨越发送失败继续存在"重新引进来,
+ *     那是上面四轮顺序 bug 的同一个根因;而且离线可能持续几分钟,保留就必须配上限与
+ *     淘汰策略——那是新机制,不是本 PR 的范围。push 的恢复语义一直是重连后 resync
+ *     补偿(#1375),不是逐帧重放。
  */
 const MAKER_EVENT_BATCH_WINDOW_MS = 120;
 /** 单批事件数上限:到量立即 flush(不等窗口),避免长思考把一帧撑得过大。 */

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -598,13 +598,16 @@ const SESSION_ACTIVITY_WINDOW_SOFT_CAP = 32;
  *
  * 所以这里**去掉了退避重试**,换成一条强不变量:
  *
- *   **缓冲的生命周期不跨越任何一次发送失败。** flush 要么整批发出,要么就地
- *   降级为逐帧 best-effort 发送(与本 PR 之前的旧语义完全一致),两种情况都让
- *   缓冲立刻清空。
+ *   **缓冲的生命周期不跨越任何一次发送失败。** flush 返回时缓冲一定为空——整批
+ *   发出、逐帧降级发出、或(逐帧也注定失败时)直接丢弃,三条出路都不保留状态。
  *
  * 于是「同会话有待发批」这个状态只存在于「窗口内、且尚未尝试发送」的区间,
  * 收口点(flushMakerEventBatchesForSessionPush)一次调用即可保证清空,顺序问题
  * 整族消失,而不是每轮补一个新场景。
+ *
+ * 降级本身也要收敛,否则它就是本 PR 要消掉的那个洪峰的复刻(review P1):逐帧
+ * 只在**可能成功**时才做(判据见 shouldDegradeBatchToPerFrame),且在第一次失败处
+ * 停下、剩余事件计入一条聚合日志(账本见 MakerEventBatchFlushOutcome)。
  *
  * 代价与为什么可接受:拥塞时不再保留事件等窗口恢复。但那本来不是本 PR 的目标
  * (常态减帧才是),而拥塞时的取舍是 #2167 的职责——降级后的逐帧发送正好落回
@@ -680,7 +683,9 @@ function stageMakerEventPush(
     tail.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
     || tail.bytes >= MAKER_EVENT_BATCH_MAX_BYTES
   ) {
-    flushMakerEventBatchSession(dst, stage, sessionId);
+    const outcome = createMakerEventBatchFlushOutcome();
+    flushMakerEventBatchSession(dst, stage, sessionId, outcome);
+    reportMakerEventBatchFlushOutcome(dst, outcome);
     return;
   }
   scheduleMakerEventBatchFlush(dst, stage);
@@ -716,23 +721,68 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
   (stage.timer as unknown as { unref?: () => void }).unref?.();
 }
 
+/**
+ * 一次 flush 内的降级账本。存在的理由是**降级不能自己变成新的洪峰**(review P1):
+ * 批帧被拒后逐帧重放最多 64 次,每次一条 WARN,正好把本 PR 要消掉的逐事件
+ * admission 与告警洪峰原样重建。两条收敛:
+ *  - 一旦确认「这个 peer 现在发不出去」,本轮后续切片与会话只清空、不再尝试发送
+ *    (本轮是同步的,可靠传输窗口不会在循环中间被 ACK 腾空,后续尝试必然同样失败);
+ *  - 被跳过的事件数聚合成**一条**日志,而不是每帧一条。
+ */
+interface MakerEventBatchFlushOutcome {
+  /** 本轮已确认发不出去:只清空缓冲,不再尝试发送。 */
+  sendingBlocked: boolean;
+  /** 本轮未尝试发送而直接丢弃的事件数(用于聚合日志)。 */
+  droppedEvents: number;
+}
+
+function createMakerEventBatchFlushOutcome(): MakerEventBatchFlushOutcome {
+  return { sendingBlocked: false, droppedEvents: 0 };
+}
+
+function reportMakerEventBatchFlushOutcome(
+  dst: string,
+  outcome: MakerEventBatchFlushOutcome,
+): void {
+  if (outcome.droppedEvents === 0) return;
+  log.warn(
+    `maker:event batch flush to ${shortId(dst)}: peer send unavailable, `
+    + `dropped ${outcome.droppedEvents} event(s) without retry`,
+  );
+}
+
+/**
+ * 批帧发送失败后,逐帧重放**有没有可能成功**。
+ *  - `NOT_CONNECTED`(含本模块在 relay 离线时自造的那条):整条链路发不出去,逐帧
+ *    只是把同一次失败重放 ≤64 次 —— 纯日志洪峰、零收益,直接丢。
+ *  - `BACKPRESSURE`:大批被拒 ≠ 小帧被拒(#2167 的可驱逐档:一帧小 maker:event 能靠
+ *    驱逐队头腾出槽位,256KB 的批不行),逐帧确实有机会,值得降级。
+ *  - `PAYLOAD_TOO_LARGE` / 其它:逐帧是唯一出路(且逐帧还带 compact 兜底),降级。
+ */
+function shouldDegradeBatchToPerFrame(err: unknown): boolean {
+  return !(err instanceof DeviceLinkError && err.code === 'NOT_CONNECTED');
+}
+
 /** flush 该控制端的全部会话批(窗口到点 / 显式收口)。 */
 function flushMakerEventBatchStage(dst: string, stage: MakerEventBatchStage): void {
+  const outcome = createMakerEventBatchFlushOutcome();
   for (const sessionId of [...stage.batches.keys()]) {
-    flushMakerEventBatchSession(dst, stage, sessionId);
+    flushMakerEventBatchSession(dst, stage, sessionId, outcome);
   }
+  reportMakerEventBatchFlushOutcome(dst, outcome);
 }
 
 /**
  * 发送某会话的待发批,**返回时缓冲一定为空**(强不变量,见本段顶部注释):
- * 按段 FIFO、段内按上限切片;任一切片发送失败即就地降级为逐帧 best-effort
- * 发送该切片的事件(与本 PR 之前的旧语义一致,含 compactOversizedPushPayload
- * 兜底),不保留、不重试。
+ * 按段 FIFO、段内按上限切片;切片发送失败时,若逐帧还有机会就就地降级为逐帧
+ * best-effort 发送(与本 PR 之前的旧语义一致,含 compactOversizedPushPayload
+ * 兜底),不保留、不重试。降级本身的洪峰由 outcome 账本收敛(见其定义)。
  */
 function flushMakerEventBatchSession(
   dst: string,
   stage: MakerEventBatchStage,
   sessionId: string,
+  outcome: MakerEventBatchFlushOutcome,
 ): void {
   const segments = stage.batches.get(sessionId);
   stage.batches.delete(sessionId);
@@ -745,6 +795,11 @@ function flushMakerEventBatchSession(
     while (segment.events.length > 0) {
       const slice = takeMakerEventBatchSlice(segment);
       if (slice.length === 0) break;
+      // 本轮已确认发不出去:只把缓冲取空(维持强不变量),不再制造注定失败的帧。
+      if (outcome.sendingBlocked) {
+        outcome.droppedEvents += slice.length;
+        continue;
+      }
       const payload: MakerEventBatchPayload = { sessionId, events: slice };
       try {
         if (!activeClient || activeClient.getStatus() !== 'online') {
@@ -755,11 +810,21 @@ function flushMakerEventBatchSession(
         } else {
           activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, segment.ownerStamp);
         }
-      } catch {
-        // 降级为逐帧:sendPushBestEffort 吞掉每条的失败并保留超大帧裁剪,
-        // 顺序仍是原顺序。批不因失败滞留 —— 那正是顺序问题的唯一来源。
-        for (const event of slice) {
-          sendPushBestEffort(dst, MAKER_PUSH.EVENT, event, segment.ownerStamp);
+      } catch (err) {
+        if (!shouldDegradeBatchToPerFrame(err)) {
+          outcome.sendingBlocked = true;
+          outcome.droppedEvents += slice.length;
+          continue;
+        }
+        // 降级为逐帧:sendPushBestEffort 吞掉每条的失败并保留超大帧裁剪,顺序仍是
+        // 原顺序。批不因失败滞留 —— 那正是顺序问题的唯一来源。
+        for (let i = 0; i < slice.length; i += 1) {
+          if (sendPushBestEffort(dst, MAKER_PUSH.EVENT, slice[i], segment.ownerStamp)) continue;
+          // 逐帧也进不去:同步循环内窗口不会被 ACK 腾空,后续帧必然同样失败。停在
+          // 这里,把没尝试过的计入丢弃 —— 失败的那一帧自己已经记过一条日志。
+          outcome.sendingBlocked = true;
+          outcome.droppedEvents += slice.length - i - 1;
+          break;
         }
       }
     }
@@ -812,7 +877,9 @@ function flushMakerEventBatchesForSessionPush(
   if (!stage || stage.batches.size === 0) return;
   const sessionId = readPushSessionId(payload);
   if (!sessionId || !stage.batches.has(sessionId)) return;
-  flushMakerEventBatchSession(dst, stage, sessionId);
+  const outcome = createMakerEventBatchFlushOutcome();
+  flushMakerEventBatchSession(dst, stage, sessionId, outcome);
+  reportMakerEventBatchFlushOutcome(dst, outcome);
 }
 
 /** 丢弃单个会话的待发批(退订该会话流时调用);stage 空则一并回收定时器。 */
@@ -1057,37 +1124,44 @@ export function pushToTopicSubscribers(
   forwardPush(channel, payload, ownerStamp);
 }
 
+/**
+ * best-effort 转发一帧 push:失败只记日志、不抛。
+ * @returns 帧是否已交给可靠传输(含 compact 兜底后成功)。绝大多数调用方忽略返回值;
+ *   批降级路径靠它在第一次失败处停下来,不把一次失败重放成 ≤64 条 WARN。
+ */
 function sendPushBestEffort(
   dst: string,
   channel: string,
   payload: unknown,
   ownerStamp?: PushOwnerStamp,
-): void {
-  if (!activeClient) return;
+): boolean {
+  if (!activeClient) return false;
   try {
     if (ownerStamp === undefined) activeClient.sendPush(dst, channel, payload);
     else activeClient.sendPush(dst, channel, payload, ownerStamp);
-    return;
+    return true;
   } catch (err) {
     if (!isPayloadTooLargeError(err)) {
       log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      return;
+      return false;
     }
 
     const compactPayload = compactOversizedPushPayload(channel, payload);
     if (!compactPayload) {
       log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      return;
+      return false;
     }
 
     try {
       if (ownerStamp === undefined) activeClient.sendPush(dst, channel, compactPayload);
       else activeClient.sendPush(dst, channel, compactPayload, ownerStamp);
       log.warn(`forwardPush to ${shortId(dst)} sent compact payload after oversized ${channel} frame`);
+      return true;
     } catch (retryErr) {
       log.warn(
         `forwardPush to ${shortId(dst)} failed after compact retry (${channel}): ${String(retryErr)}`,
       );
+      return false;
     }
   }
 }

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -606,8 +606,9 @@ const SESSION_ACTIVITY_WINDOW_SOFT_CAP = 32;
  * 整族消失,而不是每轮补一个新场景。
  *
  * 降级本身也要收敛,否则它就是本 PR 要消掉的那个洪峰的复刻(review P1):逐帧
- * 只在**可能成功**时才做(判据见 shouldDegradeBatchToPerFrame),且在第一次失败处
- * 停下、剩余事件计入一条聚合日志(账本见 MakerEventBatchFlushOutcome)。
+ * 只在**可能成功**时才做(判据见 shouldDegradeBatchToPerFrame——只有 relay 离线是
+ * 恒不可能),切片内每条都试但逐帧日志静默,成败聚合成一条(账本见
+ * MakerEventBatchFlushOutcome,那里记了这个洪峰判据三轮收敛的全过程)。
  *
  * 代价与为什么可接受:拥塞时不再保留事件等窗口恢复。但那本来不是本 PR 的目标
  * (常态减帧才是),而拥塞时的取舍是 #2167 的职责——降级后的逐帧发送正好落回
@@ -761,52 +762,70 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
 }
 
 /**
- * 一次 flush 内的降级账本。存在的理由是**降级不能自己变成新的洪峰**(review P1):
- * 批帧被拒后逐帧重放最多 64 次,每次一条 WARN,正好把本 PR 要消掉的逐事件
- * admission 与告警洪峰原样重建。两条收敛:
- *  - 一旦确认「这个 peer 现在发不出去」,本轮后续切片与会话只清空、不再尝试发送
- *    (本轮是同步的,可靠传输窗口不会在循环中间被 ACK 腾空,后续尝试必然同样失败);
- *  - 被跳过的事件数聚合成**一条**日志,而不是每帧一条。
+ * 一次 flush 内的降级账本。它解决的是「降级不能自己变成本 PR 要消掉的那个洪峰」
+ * (review 三轮收敛的最终形态)。收敛过程值得记下来,免得再来一遍:
+ *
+ *  1. 最初逐帧降级无条件重放整个切片 → 队头不可驱逐时 ≤64 次失败、≤64 条 WARN,
+ *     正是要消灭的逐事件 admission 与告警洪峰(greptile P1)。
+ *  2. 改成「第一次失败就停」→ 又把「这一帧自己不合格」和「管子堵了」混为一谈,
+ *     误丢本可送达的批尾(greptile P1 第二轮)。
+ *  3. 于是按错误码区分 → 但 `BACKPRESSURE` **也是尺寸相关**的:ws 容量判据是
+ *     `bufferedAmount + additionalBytes > cap`,pending 容量判据也含字节维度,
+ *     所以大帧被拒时小帧仍可能通过(codex P1)。按错误码停手同样会误丢。
+ *
+ * 结论:**洪峰本质上是日志问题,不是尝试问题。** 一次 `sendPush` 失败的代价只是一次
+ * 函数调用加一次 throw,而少发一条本可送达的事件是用户可见的缺流。所以:
+ *  - 切片内**每一条都尝试**,不因任何失败提前停手(尺寸相关的失败下后面的小帧还有戏);
+ *  - 降级路径的逐帧日志静默(`quiet`),成败计数聚合成**一条**日志;
+ *  - 唯一的例外是 relay 离线:`client.sendPush` 在非 online 时本就静默早退、成功率
+ *    恒为 0,整轮直接不尝试(也不必逐条 throw)。
  */
 interface MakerEventBatchFlushOutcome {
-  /** 本轮已确认发不出去:只清空缓冲,不再尝试发送。 */
-  sendingBlocked: boolean;
   /**
-   * 为什么发不出去。日志级别按它分档 —— 否则这条聚合日志自己就是新的洪峰:
-   *  - `offline`:relay 不在线,**这是常态且预期**(client.sendPush 在非 online 时本就
-   *    静默早退,push 的恢复语义一直是重连后 resync 补偿、不是重放)。断线期间事件
-   *    仍在产生,每 120ms 窗口一条 WARN 就是 8 条/秒的噪声 → 记 debug。
-   *  - `send-failed`:relay 在线却连逐帧都进不去(窗口满且队头不可驱逐),是**异常**
-   *    信号,值得 WARN。
+   * relay 离线:本轮后续切片与会话只清空缓冲、不再尝试发送。
+   *
+   * 这是常态且预期的一档(push 的恢复语义一直是重连后 resync 补偿、不是重放),断线
+   * 期间事件仍在产生,每 120ms 窗口一条 WARN 就是 8 条/秒的噪声 → 记 debug 而非 warn。
    */
-  blockedReason: 'offline' | 'send-failed' | null;
-  /** 本轮未尝试发送而直接丢弃的事件数(用于聚合日志)。 */
+  offline: boolean;
+  /** 因离线而未尝试发送、直接丢弃的事件数。 */
   droppedEvents: number;
+  /** 降级逐帧的成功条数。 */
+  degradedSent: number;
+  /** 降级逐帧中失败(背压 / 超限无解等)的条数;>0 才值得一条 WARN。 */
+  degradedFailed: number;
 }
 
 function createMakerEventBatchFlushOutcome(): MakerEventBatchFlushOutcome {
-  return { sendingBlocked: false, blockedReason: null, droppedEvents: 0 };
+  return { offline: false, droppedEvents: 0, degradedSent: 0, degradedFailed: 0 };
 }
 
 function reportMakerEventBatchFlushOutcome(
   dst: string,
   outcome: MakerEventBatchFlushOutcome,
 ): void {
-  if (outcome.droppedEvents === 0) return;
-  const line = `maker:event batch flush to ${shortId(dst)}: `
-    + `${outcome.blockedReason === 'offline' ? 'relay offline' : 'peer send unavailable'}, `
-    + `dropped ${outcome.droppedEvents} event(s) without retry`;
-  if (outcome.blockedReason === 'offline') log.debug(line);
-  else log.warn(line);
+  if (outcome.droppedEvents > 0) {
+    // 离线丢弃是预期常态,debug 级(理由见 outcome.offline 注释)。
+    log.debug(
+      `maker:event batch flush to ${shortId(dst)}: relay offline, `
+      + `dropped ${outcome.droppedEvents} event(s) without retry`,
+    );
+  }
+  if (outcome.degradedFailed > 0) {
+    // relay 在线却有帧进不去:异常信号,一次 flush 一条(不是每帧一条)。
+    log.warn(
+      `maker:event batch degraded to per-frame for ${shortId(dst)}: `
+      + `${outcome.degradedSent} sent, ${outcome.degradedFailed} dropped`,
+    );
+  }
 }
 
 /**
- * 批帧发送失败后,逐帧重放**有没有可能成功**。
- *  - `NOT_CONNECTED`(含本模块在 relay 离线时自造的那条):整条链路发不出去,逐帧
- *    只是把同一次失败重放 ≤64 次 —— 纯日志洪峰、零收益,直接丢。
- *  - `BACKPRESSURE`:大批被拒 ≠ 小帧被拒(#2167 的可驱逐档:一帧小 maker:event 能靠
- *    驱逐队头腾出槽位,256KB 的批不行),逐帧确实有机会,值得降级。
- *  - `PAYLOAD_TOO_LARGE` / 其它:逐帧是唯一出路(且逐帧还带 compact 兜底),降级。
+ * 批帧发送失败后,逐帧重放**有没有可能成功**。唯一说「没有」的是 relay 不在线:
+ * `client.sendPush` 在非 online 时第一行就静默早退,逐帧成功率恒为 0。其余一切失败
+ * (`BACKPRESSURE` / `PAYLOAD_TOO_LARGE` / 未知)都尺寸相关或帧相关——大帧被拒时小帧
+ * 仍可能通过(ws 容量判据是 `bufferedAmount + additionalBytes`,pending 判据也含字节
+ * 维度),所以必须逐帧试,不能按错误码整片放弃(codex P1)。
  */
 function shouldDegradeBatchToPerFrame(err: unknown): boolean {
   return !(err instanceof DeviceLinkError && err.code === 'NOT_CONNECTED');
@@ -844,8 +863,8 @@ function flushMakerEventBatchSession(
     while (segment.events.length > 0) {
       const slice = takeMakerEventBatchSlice(segment);
       if (slice.length === 0) break;
-      // 本轮已确认发不出去:只把缓冲取空(维持强不变量),不再制造注定失败的帧。
-      if (outcome.sendingBlocked) {
+      // relay 已确认离线:只把缓冲取空(维持强不变量),不再制造成功率恒为 0 的帧。
+      if (outcome.offline) {
         outcome.droppedEvents += slice.length;
         continue;
       }
@@ -861,29 +880,21 @@ function flushMakerEventBatchSession(
         }
       } catch (err) {
         if (!shouldDegradeBatchToPerFrame(err)) {
-          outcome.sendingBlocked = true;
-          outcome.blockedReason = 'offline';
+          outcome.offline = true;
           outcome.droppedEvents += slice.length;
           continue;
         }
-        // 降级为逐帧:sendPushBestEffort 吞掉每条的失败并保留超大帧裁剪,顺序仍是
-        // 原顺序。批不因失败滞留 —— 那正是顺序问题的唯一来源。
-        for (let i = 0; i < slice.length; i += 1) {
-          const frameOutcome = sendPushBestEffort(
-            dst,
-            MAKER_PUSH.EVENT,
-            slice[i],
-            segment.ownerStamp,
-          );
-          // 这一帧自身被拒(超限且 compact 也没救回等):与链路无关,继续发后面的,
-          // 否则本可送达的文本 / 状态增量会被连坐丢掉(review P1)。它自己已记过日志。
-          if (frameOutcome !== 'peer-blocked') continue;
-          // 管子堵了或断了:同步循环内窗口不会被 ACK 腾空,后续帧必然同样失败。停在
-          // 这里,把没尝试过的计入丢弃 —— 失败的那一帧自己已经记过一条日志。
-          outcome.sendingBlocked = true;
-          outcome.blockedReason = 'send-failed';
-          outcome.droppedEvents += slice.length - i - 1;
-          break;
+        // 降级为逐帧:**每一条都试**,不因任何失败提前停手 —— 失败大多与帧尺寸相关
+        // (ws 容量判据含 additionalBytes、pending 判据含字节维度),大帧被拒时后面的
+        // 小帧仍可能通过;少发一条本可送达的事件是用户可见的缺流,而多一次失败的
+        // sendPush 只是一次 throw。逐帧日志静默,成败计数聚合成一条(见 outcome 注释)。
+        // 顺序仍是原顺序;批不因失败滞留 —— 那正是顺序问题的唯一来源。
+        for (const event of slice) {
+          if (sendPushBestEffort(dst, MAKER_PUSH.EVENT, event, segment.ownerStamp, { quiet: true })) {
+            outcome.degradedSent += 1;
+          } else {
+            outcome.degradedFailed += 1;
+          }
         }
       }
     }
@@ -1182,64 +1193,48 @@ export function pushToTopicSubscribers(
 }
 
 /**
- * 一帧 push 的发送结果。`peer-blocked` 与 `frame-rejected` 必须分开,否则批降级会把
- * 「这一条帧自己不合格」误判成「整条链路堵了」而丢掉本可送达的批尾(review P1):
- *  - `peer-blocked`:BACKPRESSURE / NOT_CONNECTED / 无 client —— 管子本身满了或断了,
- *    同一同步循环内后续帧必然同样失败(窗口不会被 ACK 腾空),应当停手;
- *  - `frame-rejected`:这一帧自身的问题(超限且 compact 兜底也没救回、payload 不可
- *    序列化等)—— 与链路状态无关,后续帧照发。
- */
-type PushSendOutcome = 'sent' | 'frame-rejected' | 'peer-blocked';
-
-function classifyPushSendFailure(err: unknown): PushSendOutcome {
-  if (
-    err instanceof DeviceLinkError
-    && (err.code === 'BACKPRESSURE' || err.code === 'NOT_CONNECTED')
-  ) {
-    return 'peer-blocked';
-  }
-  return 'frame-rejected';
-}
-
-/**
  * best-effort 转发一帧 push:失败只记日志、不抛。
- * @returns 见 PushSendOutcome。绝大多数调用方忽略返回值;批降级路径靠它区分「停手」
- *   与「跳过这一条继续」,既不把一次链路失败重放成 ≤64 条 WARN,也不误丢批尾。
+ * @param opts.quiet 静默逐帧日志(调用方自己做聚合)。批降级路径用它:一次 flush
+ *   最多 ≤64 帧,逐条 WARN 就是本 PR 要消掉的那个告警洪峰。
+ * @returns 帧是否已交给可靠传输(含 compact 兜底后成功)。绝大多数调用方忽略返回值。
  */
 function sendPushBestEffort(
   dst: string,
   channel: string,
   payload: unknown,
   ownerStamp?: PushOwnerStamp,
-): PushSendOutcome {
-  if (!activeClient) return 'peer-blocked';
+  opts?: { quiet?: boolean },
+): boolean {
+  if (!activeClient) return false;
+  const warn = (message: string): void => {
+    if (!opts?.quiet) log.warn(message);
+  };
   try {
     if (ownerStamp === undefined) activeClient.sendPush(dst, channel, payload);
     else activeClient.sendPush(dst, channel, payload, ownerStamp);
-    return 'sent';
+    return true;
   } catch (err) {
     if (!isPayloadTooLargeError(err)) {
-      log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      return classifyPushSendFailure(err);
+      warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
+      return false;
     }
 
     const compactPayload = compactOversizedPushPayload(channel, payload);
     if (!compactPayload) {
-      log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      // 超限且没有 compact 兜底:是这一帧自己的问题,不是管子的问题。
-      return 'frame-rejected';
+      warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
+      return false;
     }
 
     try {
       if (ownerStamp === undefined) activeClient.sendPush(dst, channel, compactPayload);
       else activeClient.sendPush(dst, channel, compactPayload, ownerStamp);
-      log.warn(`forwardPush to ${shortId(dst)} sent compact payload after oversized ${channel} frame`);
-      return 'sent';
+      warn(`forwardPush to ${shortId(dst)} sent compact payload after oversized ${channel} frame`);
+      return true;
     } catch (retryErr) {
-      log.warn(
+      warn(
         `forwardPush to ${shortId(dst)} failed after compact retry (${channel}): ${String(retryErr)}`,
       );
-      return classifyPushSendFailure(retryErr);
+      return false;
     }
   }
 }

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -678,6 +678,22 @@ function stageMakerEventPush(
   payload: unknown,
   ownerStamp?: PushOwnerStamp,
 ): void {
+  const payloadBytes = estimateMakerEventBytes(payload);
+  // 越过字节阈值的事件**不挤进本批**:挤进去只会被 takeMakerEventBatchSlice 再切出来,
+  // 每次越界白送一个 1 条事件的小尾批(30KB 级事件流下 100 条会变成 ~23 帧而不是
+  // ~13 帧,直接削掉大半减帧收益,review P2)。改成先把已攒的这一批收口发出,新事件
+  // 成为下一批的开头 —— 强不变量不受影响:flush 仍然一次清空,新事件是 flush **之后**
+  // 才入缓冲的。单条即超阈值的事件在入批前就被 forwardPush 拦到逐帧路径,所以收口后
+  // 它一定装得进空批。
+  const stagedTail = makerEventBatchStages.get(dst)?.batches.get(sessionId)?.at(-1);
+  if (
+    stagedTail
+    && stagedTail.events.length > 0
+    && makerEventBatchOwnerStampEquals(stagedTail.ownerStamp, ownerStamp)
+    && stagedTail.bytes + payloadBytes > MAKER_EVENT_BATCH_MAX_BYTES
+  ) {
+    flushMakerEventBatchesForSession(dst, sessionId);
+  }
   let stage = makerEventBatchStages.get(dst);
   if (!stage) {
     stage = { batches: new Map(), timer: null };
@@ -694,17 +710,24 @@ function stageMakerEventPush(
     segments.push(tail);
   }
   tail.events.push(payload);
-  tail.bytes += estimateMakerEventBytes(payload);
+  tail.bytes += payloadBytes;
   if (
     tail.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
     || tail.bytes >= MAKER_EVENT_BATCH_MAX_BYTES
   ) {
-    const outcome = createMakerEventBatchFlushOutcome();
-    flushMakerEventBatchSession(dst, stage, sessionId, outcome);
-    reportMakerEventBatchFlushOutcome(dst, outcome);
+    flushMakerEventBatchesForSession(dst, sessionId);
     return;
   }
   scheduleMakerEventBatchFlush(dst, stage);
+}
+
+/** 收口单个会话的待发批(到量 / 越界 / 跨 channel 收口共用),含聚合日志。 */
+function flushMakerEventBatchesForSession(dst: string, sessionId: string): void {
+  const stage = makerEventBatchStages.get(dst);
+  if (!stage) return;
+  const outcome = createMakerEventBatchFlushOutcome();
+  flushMakerEventBatchSession(dst, stage, sessionId, outcome);
+  reportMakerEventBatchFlushOutcome(dst, outcome);
 }
 
 /** 读 push payload 顶层 sessionId(与 topicForPush 的 session-scoped 判据同一字段)。 */
@@ -846,8 +869,16 @@ function flushMakerEventBatchSession(
         // 降级为逐帧:sendPushBestEffort 吞掉每条的失败并保留超大帧裁剪,顺序仍是
         // 原顺序。批不因失败滞留 —— 那正是顺序问题的唯一来源。
         for (let i = 0; i < slice.length; i += 1) {
-          if (sendPushBestEffort(dst, MAKER_PUSH.EVENT, slice[i], segment.ownerStamp)) continue;
-          // 逐帧也进不去:同步循环内窗口不会被 ACK 腾空,后续帧必然同样失败。停在
+          const frameOutcome = sendPushBestEffort(
+            dst,
+            MAKER_PUSH.EVENT,
+            slice[i],
+            segment.ownerStamp,
+          );
+          // 这一帧自身被拒(超限且 compact 也没救回等):与链路无关,继续发后面的,
+          // 否则本可送达的文本 / 状态增量会被连坐丢掉(review P1)。它自己已记过日志。
+          if (frameOutcome !== 'peer-blocked') continue;
+          // 管子堵了或断了:同步循环内窗口不会被 ACK 腾空,后续帧必然同样失败。停在
           // 这里,把没尝试过的计入丢弃 —— 失败的那一帧自己已经记过一条日志。
           outcome.sendingBlocked = true;
           outcome.blockedReason = 'send-failed';
@@ -905,9 +936,7 @@ function flushMakerEventBatchesForSessionPush(
   if (!stage || stage.batches.size === 0) return;
   const sessionId = readPushSessionId(payload);
   if (!sessionId || !stage.batches.has(sessionId)) return;
-  const outcome = createMakerEventBatchFlushOutcome();
-  flushMakerEventBatchSession(dst, stage, sessionId, outcome);
-  reportMakerEventBatchFlushOutcome(dst, outcome);
+  flushMakerEventBatchesForSession(dst, sessionId);
 }
 
 /** 丢弃单个会话的待发批(退订该会话流时调用);stage 空则一并回收定时器。 */
@@ -1153,43 +1182,64 @@ export function pushToTopicSubscribers(
 }
 
 /**
+ * 一帧 push 的发送结果。`peer-blocked` 与 `frame-rejected` 必须分开,否则批降级会把
+ * 「这一条帧自己不合格」误判成「整条链路堵了」而丢掉本可送达的批尾(review P1):
+ *  - `peer-blocked`:BACKPRESSURE / NOT_CONNECTED / 无 client —— 管子本身满了或断了,
+ *    同一同步循环内后续帧必然同样失败(窗口不会被 ACK 腾空),应当停手;
+ *  - `frame-rejected`:这一帧自身的问题(超限且 compact 兜底也没救回、payload 不可
+ *    序列化等)—— 与链路状态无关,后续帧照发。
+ */
+type PushSendOutcome = 'sent' | 'frame-rejected' | 'peer-blocked';
+
+function classifyPushSendFailure(err: unknown): PushSendOutcome {
+  if (
+    err instanceof DeviceLinkError
+    && (err.code === 'BACKPRESSURE' || err.code === 'NOT_CONNECTED')
+  ) {
+    return 'peer-blocked';
+  }
+  return 'frame-rejected';
+}
+
+/**
  * best-effort 转发一帧 push:失败只记日志、不抛。
- * @returns 帧是否已交给可靠传输(含 compact 兜底后成功)。绝大多数调用方忽略返回值;
- *   批降级路径靠它在第一次失败处停下来,不把一次失败重放成 ≤64 条 WARN。
+ * @returns 见 PushSendOutcome。绝大多数调用方忽略返回值;批降级路径靠它区分「停手」
+ *   与「跳过这一条继续」,既不把一次链路失败重放成 ≤64 条 WARN,也不误丢批尾。
  */
 function sendPushBestEffort(
   dst: string,
   channel: string,
   payload: unknown,
   ownerStamp?: PushOwnerStamp,
-): boolean {
-  if (!activeClient) return false;
+): PushSendOutcome {
+  if (!activeClient) return 'peer-blocked';
   try {
     if (ownerStamp === undefined) activeClient.sendPush(dst, channel, payload);
     else activeClient.sendPush(dst, channel, payload, ownerStamp);
-    return true;
+    return 'sent';
   } catch (err) {
     if (!isPayloadTooLargeError(err)) {
       log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      return false;
+      return classifyPushSendFailure(err);
     }
 
     const compactPayload = compactOversizedPushPayload(channel, payload);
     if (!compactPayload) {
       log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      return false;
+      // 超限且没有 compact 兜底:是这一帧自己的问题,不是管子的问题。
+      return 'frame-rejected';
     }
 
     try {
       if (ownerStamp === undefined) activeClient.sendPush(dst, channel, compactPayload);
       else activeClient.sendPush(dst, channel, compactPayload, ownerStamp);
       log.warn(`forwardPush to ${shortId(dst)} sent compact payload after oversized ${channel} frame`);
-      return true;
+      return 'sent';
     } catch (retryErr) {
       log.warn(
         `forwardPush to ${shortId(dst)} failed after compact retry (${channel}): ${String(retryErr)}`,
       );
-      return false;
+      return classifyPushSendFailure(retryErr);
     }
   }
 }

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -37,6 +37,8 @@ import {
   DL_TELEGRAM_STATUS_CHANNEL,
   DL_TELEGRAM_SET_ONLINE_CHANNEL,
   SESSION_ACTIVITY_CHANNEL,
+  MAKER_EVENT_BATCH_CHANNEL,
+  CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
   DeviceLinkError,
   parseFsWatchTopic,
   type Envelope,
@@ -44,6 +46,7 @@ import {
   type InvokeResultPayload,
   type LinkClosePayload,
   type LinkOpenPayload,
+  type MakerEventBatchPayload,
   type PushOwnerStamp,
   type Topic,
 } from '@cindy/device-link';
@@ -575,6 +578,211 @@ const SESSION_ACTIVITY_DRAIN_RETRY_MS = 250;
 /** 可靠窗口软上限:活动镜像最多占半窗,剩余留给 invoke-result 与其它推送。 */
 const SESSION_ACTIVITY_WINDOW_SOFT_CAP = 32;
 
+/**
+ * `maker:event` 微批(per-(控制端, sessionId) 累积,与 activity staging 同骨架但
+ * 语义相反:activity 是状态镜像只留最新值,事件流是有序流,批内**全部保留**)。
+ *
+ * 为什么要它:activity 整流(#1401)、拥塞取舍(#2167)、重连冷却(#2185)都不减少
+ * **出站帧数**——agent 长思考期间 maker:event 仍是每事件一帧,2026-08-08 线上单
+ * 毫秒 119 帧、8-07 单小时 5168 次 BACKPRESSURE,聚合速率还招来 relay 1013 断连。
+ * 批把「每事件一帧」压成「每窗口一帧」,直接砍掉这条链路的源头流量。
+ *
+ * 时序契约:同一会话的事件对启用批的控制端**全部**走批路径,没有旁路——否则
+ * 缓冲里的旧事件会排在直发的新事件之后,顺序即被破坏。
+ */
+const MAKER_EVENT_BATCH_WINDOW_MS = 120;
+/** 单批事件数上限:到量立即 flush(不等窗口),避免长思考把一帧撑得过大。 */
+const MAKER_EVENT_BATCH_MAX_EVENTS = 64;
+/**
+ * 单批字节上限(估算值,到量立即 flush)。刻意远小于可靠传输单消息上限
+ * (MAX_TRANSPORT_MESSAGE_BYTES 4MB / 64 片 × 128KB):批的目的是减少帧数,
+ * 不是制造需要分片的大帧——分片会把一帧放大成多帧,反噬本次优化。
+ */
+const MAKER_EVENT_BATCH_MAX_BYTES = 256 * 1024;
+/**
+ * 单会话缓冲的事件数硬上限(背压滞留时的兜底)。maker:event 是自相似有损流
+ * (与 #2167 的可驱逐判据同源),溢出丢**最旧**、保留最新:转录内容由受保护的
+ * messages:created + 控制端消息对账自愈。无上限则背压期间内存无界。
+ */
+const MAKER_EVENT_BATCH_MAX_BUFFERED_EVENTS = 512;
+/** 背压/离线时的重试间隔(与 activity staging 同款,不新造节奏)。 */
+const MAKER_EVENT_BATCH_RETRY_MS = 250;
+
+interface MakerEventBatch {
+  events: unknown[];
+  bytes: number;
+  ownerStamp?: PushOwnerStamp;
+  droppedOldest: number;
+}
+
+interface MakerEventBatchStage {
+  /** sessionId → 该会话的待发事件;Map 插入序即会话首次入批顺序。 */
+  batches: Map<string, MakerEventBatch>;
+  timer: ReturnType<typeof setTimeout> | null;
+}
+
+const makerEventBatchStages = new Map<string, MakerEventBatchStage>();
+
+function makerEventBatchOwnerStampEquals(
+  a: PushOwnerStamp | undefined,
+  b: PushOwnerStamp | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return a.dataOwnerId === b.dataOwnerId && a.ownerGeneration === b.ownerGeneration;
+}
+
+/**
+ * 把一条 maker:event 收进目标控制端的批。到量(条数/字节)或 ownerStamp 变化
+ * 立即 flush 该会话,否则等窗口定时器统一 flush。
+ */
+function stageMakerEventPush(
+  dst: string,
+  sessionId: string,
+  payload: unknown,
+  ownerStamp?: PushOwnerStamp,
+): void {
+  let stage = makerEventBatchStages.get(dst);
+  if (!stage) {
+    stage = { batches: new Map(), timer: null };
+    makerEventBatchStages.set(dst, stage);
+  }
+  let batch = stage.batches.get(sessionId);
+  // ownerStamp 是数据归属水印,批内必须一致:变化即先把旧批发走再开新批。
+  if (batch && !makerEventBatchOwnerStampEquals(batch.ownerStamp, ownerStamp)) {
+    flushMakerEventBatch(dst, stage, sessionId);
+    batch = undefined;
+  }
+  if (!batch) {
+    batch = { events: [], bytes: 0, droppedOldest: 0, ...(ownerStamp ? { ownerStamp } : {}) };
+    stage.batches.set(sessionId, batch);
+  }
+  batch.events.push(payload);
+  batch.bytes += estimateMakerEventBytes(payload);
+  while (batch.events.length > MAKER_EVENT_BATCH_MAX_BUFFERED_EVENTS) {
+    const dropped = batch.events.shift();
+    batch.bytes = Math.max(0, batch.bytes - estimateMakerEventBytes(dropped));
+    batch.droppedOldest += 1;
+  }
+  if (
+    batch.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
+    || batch.bytes >= MAKER_EVENT_BATCH_MAX_BYTES
+  ) {
+    flushMakerEventBatch(dst, stage, sessionId);
+    return;
+  }
+  scheduleMakerEventBatchFlush(dst, stage);
+}
+
+/** 读 push payload 顶层 sessionId(与 topicForPush 的 session-scoped 判据同一字段)。 */
+function readPushSessionId(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const sessionId = (payload as { sessionId?: unknown }).sessionId;
+  return typeof sessionId === 'string' && sessionId.length > 0 ? sessionId : null;
+}
+
+function estimateMakerEventBytes(payload: unknown): number {
+  try {
+    return JSON.stringify(payload)?.length ?? 0;
+  } catch {
+    // 不可序列化的 payload 交给 sendPush 报错处理;这里只保证估算不抛。
+    return 0;
+  }
+}
+
+function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage): void {
+  if (stage.timer) return;
+  stage.timer = setTimeout(() => {
+    stage.timer = null;
+    const current = makerEventBatchStages.get(dst);
+    if (current) flushMakerEventBatchStage(dst, current);
+  }, MAKER_EVENT_BATCH_WINDOW_MS);
+  (stage.timer as unknown as { unref?: () => void }).unref?.();
+}
+
+/** flush 该控制端的全部会话批(窗口到点 / 显式收口)。 */
+function flushMakerEventBatchStage(dst: string, stage: MakerEventBatchStage): void {
+  for (const sessionId of [...stage.batches.keys()]) {
+    if (!flushMakerEventBatch(dst, stage, sessionId)) return; // 背压:保留其余,已排重试
+  }
+}
+
+/**
+ * 发送单个会话的批。返回 false 表示遇到背压/离线并已排退避重试(事件保留在
+ * 缓冲里,不丢);其它错误按 best-effort 丢弃该批,不堵住整个 stage。
+ */
+function flushMakerEventBatch(
+  dst: string,
+  stage: MakerEventBatchStage,
+  sessionId: string,
+): boolean {
+  const batch = stage.batches.get(sessionId);
+  if (!batch || batch.events.length === 0) {
+    stage.batches.delete(sessionId);
+    return true;
+  }
+  if (!activeClient || activeClient.getStatus() !== 'online') {
+    scheduleMakerEventBatchRetry(dst, stage);
+    return false;
+  }
+  if (batch.droppedOldest > 0) {
+    log.warn(
+      `maker:event batch dropped ${batch.droppedOldest} oldest event(s) for ${shortId(dst)} `
+      + `session ${sessionId.slice(0, 8)} (buffer cap under sustained backpressure)`,
+    );
+    batch.droppedOldest = 0;
+  }
+  const payload: MakerEventBatchPayload = { sessionId, events: batch.events };
+  try {
+    if (batch.ownerStamp === undefined) {
+      activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload);
+    } else {
+      activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, batch.ownerStamp);
+    }
+    stage.batches.delete(sessionId);
+    return true;
+  } catch (err) {
+    if (err instanceof DeviceLinkError && err.code === 'BACKPRESSURE') {
+      scheduleMakerEventBatchRetry(dst, stage);
+      return false;
+    }
+    // PAYLOAD_TOO_LARGE / LINK_NOT_OPEN 等:沿 maker:event 既有 best-effort 语义
+    // 丢弃该批(逐帧路径同样会丢),不让一批坏帧堵死后续会话。
+    stage.batches.delete(sessionId);
+    log.warn(`maker:event batch dropped for ${shortId(dst)}: ${String(err)}`);
+    return true;
+  }
+}
+
+function scheduleMakerEventBatchRetry(dst: string, stage: MakerEventBatchStage): void {
+  if (stage.timer) return;
+  stage.timer = setTimeout(() => {
+    stage.timer = null;
+    const current = makerEventBatchStages.get(dst);
+    if (current) flushMakerEventBatchStage(dst, current);
+  }, MAKER_EVENT_BATCH_RETRY_MS);
+  (stage.timer as unknown as { unref?: () => void }).unref?.();
+}
+
+/** 丢弃单个会话的待发批(退订该会话流时调用);stage 空则一并回收定时器。 */
+function dropMakerEventBatch(dst: string, sessionId: string): void {
+  const stage = makerEventBatchStages.get(dst);
+  if (!stage) return;
+  if (!stage.batches.delete(sessionId)) return;
+  if (stage.batches.size === 0) clearMakerEventBatchStage(dst);
+}
+
+function clearMakerEventBatchStage(dst: string): void {
+  const stage = makerEventBatchStages.get(dst);
+  if (!stage) return;
+  if (stage.timer) clearTimeout(stage.timer);
+  makerEventBatchStages.delete(dst);
+}
+
+function clearAllMakerEventBatchStages(): void {
+  for (const dst of [...makerEventBatchStages.keys()]) clearMakerEventBatchStage(dst);
+}
+
 interface SessionActivityStage {
   /** sessionId → 最新 payload + source owner;Map 插入序即更新序。 */
   queue: Map<string, { payload: unknown; ownerStamp?: PushOwnerStamp }>;
@@ -719,6 +927,18 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
   // silent no-op, so route queueable pushes through the offline backlog instead.
   const relayOnline = activeClient.getStatus() === 'online';
   const liveTargets = relayOnline ? dsts : [];
+  // 微批只对声明了能力的控制端启用;只在 maker:event 这一条 channel 上查询,
+  // 不给其它 channel 增加每帧 capability 查询开销。
+  const batchTargets = channel === MAKER_PUSH.EVENT && liveTargets.length > 0
+    ? new Set(
+      liveTargets.filter(
+        (dst) => subscriptions.controllerSupports(
+          dst,
+          CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
+        ),
+      ),
+    )
+    : null;
   const offlineTargets = subscriptions
     .getKnownControllersForTopic(topic)
     .filter((dst) => !liveTargets.includes(dst));
@@ -737,6 +957,17 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
     if (channel === SESSION_ACTIVITY_CHANNEL) {
       stageSessionActivityPush(dst, remotePayload, ownerStamp);
       continue;
+    }
+    // agent 事件流是本条链路的帧数大头:对声明了微批能力的控制端合并成
+    // 「每窗口一帧」(见 stageMakerEventPush)。未声明能力的控制端照旧逐帧,
+    // 因此旧控制端零感知。sessionId 取自 topic 路由所用的同一字段,取不到时
+    // 不入批(topicForPush 已保证 session-scoped 帧必有它,这里只是防御)。
+    if (channel === MAKER_PUSH.EVENT && batchTargets?.has(dst)) {
+      const sessionId = readPushSessionId(remotePayload);
+      if (sessionId) {
+        stageMakerEventPush(dst, sessionId, remotePayload, ownerStamp);
+        continue;
+      }
     }
     // 转发是尽力而为的旁路:单个控制端的帧超限(PAYLOAD_TOO_LARGE,如大 tool 输出)/ 连接异常
     // 绝不能冒泡——它会经 tapWindowBroadcast 回到 broadcastToAllWindows,让被控端**本机** renderer
@@ -910,6 +1141,7 @@ export function dropAllControllers(
   acceptedLinkControllers.clear();
   offlinePushQueue.clear();
   clearAllSessionActivityStages();
+  clearAllMakerEventBatchStages();
   cancelAllLinkAcceptRetries();
   syncForwarding();
 }
@@ -923,6 +1155,7 @@ export function dropAllControllers(
 export function handleControllerOffline(deviceId: string): void {
   acceptedLinkControllers.delete(deviceId);
   clearSessionActivityStage(deviceId);
+  clearMakerEventBatchStage(deviceId);
   cancelLinkAcceptRetry(deviceId);
   if (subscriptions.clearController(deviceId)) {
     syncForwarding();
@@ -938,6 +1171,7 @@ export function forgetControllerInvokeState(deviceId: string): void {
 export function purgeRevokedController(deviceId: string): void {
   offlinePushQueue.clear(deviceId);
   clearSessionActivityStage(deviceId);
+  clearMakerEventBatchStage(deviceId);
   cancelLinkAcceptRetry(deviceId);
   subscriptions.forgetKnownController(deviceId);
   topicSubscriptionControllers.delete(deviceId);
@@ -984,6 +1218,7 @@ async function handleFrame(client: DeviceLinkClient, env: Envelope): Promise<voi
       clearRemoteInvokeStateFor(src);
       offlinePushQueue.clear(src);
       clearSessionActivityStage(src);
+      clearMakerEventBatchStage(src);
       cancelLinkAcceptRetry(src);
       acceptedLinkControllers.delete(src);
       // Keep the protocol-capability marker, but discard all remembered routing.
@@ -1994,6 +2229,11 @@ function handleSubscriptionFrame(src: string, payload: InvokePayload): InvokeRes
     subscriptions.unsubscribe(src, topics);
     // 退订 sessions 后暂存里的活动快照不应再投递(含已排期的重试)。
     if (topics.includes('sessions')) clearSessionActivityStage(src);
+    // 退订 session:<id> 后该会话的待发事件批同样不应再投递(控制端已不要这条流)。
+    for (const topic of topics) {
+      const sessionId = topic.startsWith('session:') ? topic.slice('session:'.length) : null;
+      if (sessionId) dropMakerEventBatch(src, sessionId);
+    }
   }
   syncForwarding();
   if (isSub && topics.includes('sessions')) {
@@ -2272,6 +2512,7 @@ export const __testing = {
     activeClient = null;
     offlinePushQueue.clear();
     clearAllSessionActivityStages();
+  clearAllMakerEventBatchStages();
     cancelAllLinkAcceptRetries();
     setBroadcastTapListener(null);
   },

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -675,10 +675,9 @@ function stageMakerEventPush(
   tail.events.push(payload);
   tail.bytes += estimateMakerEventBytes(payload);
   trimMakerEventBatchBuffer(dst, sessionId, segments);
-  // 到量即发,但**退避中不插队**:滞留段的长度仍在阈值之上,逐条触发只会重复
-  // 同步 sendPush 抛异常(review 首轮 P1)。退避由 timer 统一驱动。
+  // 到量即发,但要过统一的主动发送闸门(见 canFlushMakerEventBatchNow)。
   if (
-    !stage.retrying
+    canFlushMakerEventBatchNow(stage)
     && (tail.events.length >= MAKER_EVENT_BATCH_MAX_EVENTS
       || tail.bytes >= MAKER_EVENT_BATCH_MAX_BYTES)
   ) {
@@ -686,6 +685,20 @@ function stageMakerEventPush(
     return;
   }
   scheduleMakerEventBatchFlush(dst, stage);
+}
+
+/**
+ * **主动** flush 的唯一准入判据(到量路径与跨 channel 收口路径共用)。
+ *
+ * 退避中一律拒绝:滞留段的长度/字节仍在阈值之上,任何主动入口都会反复触发同步
+ * sendPush 抛异常,退化成本 PR 要消除的逐帧 admission 风暴。review 两轮各抓到
+ * 一个入口(第一轮:到量;第二轮:跨 channel 收口),所以判据收敛成这一个函数——
+ * 新增主动入口必须过它,而不是各自记得检查 retrying。
+ *
+ * 唯一允许绕过的入口是退避 timer 自己(它就是退避的驱动者)。
+ */
+function canFlushMakerEventBatchNow(stage: MakerEventBatchStage): boolean {
+  return !stage.retrying;
 }
 
 /**
@@ -791,27 +804,63 @@ function flushMakerEventBatchSession(
       );
       segment.droppedOldest = 0;
     }
-    const payload: MakerEventBatchPayload = { sessionId, events: segment.events };
+    // 按上限**切片**发送,而不是整段一帧:退避期间段可以累积到缓冲上限
+    // (512 条),整段发会撑爆可靠传输的单逻辑消息上限、走 PAYLOAD_TOO_LARGE
+    // 分支一次丢掉整段(review 第二轮)。切片后未发出的部分留在段头等重试。
+    const slice = takeMakerEventBatchSlice(segment);
+    const payload: MakerEventBatchPayload = { sessionId, events: slice };
     try {
       if (segment.ownerStamp === undefined) {
         activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload);
       } else {
         activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, segment.ownerStamp);
       }
-      segments.shift();
+      if (segment.events.length === 0) segments.shift();
     } catch (err) {
+      const sliceBytes = sumMakerEventBytes(slice);
+      // 切片未发出:放回段头,顺序不变(切片本就取自段头)。
+      segment.events.unshift(...slice);
+      segment.bytes += sliceBytes;
       if (err instanceof DeviceLinkError && err.code === 'BACKPRESSURE') {
         scheduleMakerEventBatchRetry(dst, stage);
         return false;
       }
       // PAYLOAD_TOO_LARGE / LINK_NOT_OPEN 等:沿 maker:event 既有 best-effort 语义
-      // 丢弃该段(逐帧路径同样会丢),继续尝试后续段。
-      segments.shift();
-      log.warn(`maker:event batch dropped for ${shortId(dst)}: ${String(err)}`);
+      // 丢弃**该切片**(逐帧路径同样会丢),继续尝试段内其余事件。
+      segment.events.splice(0, slice.length);
+      segment.bytes = Math.max(0, segment.bytes - sliceBytes);
+      if (segment.events.length === 0) segments.shift();
+      log.warn(`maker:event batch slice dropped for ${shortId(dst)}: ${String(err)}`);
     }
   }
   stage.batches.delete(sessionId);
   return true;
+}
+
+/**
+ * 从段头取一片:条数 ≤ MAX_EVENTS 且累计字节 ≤ MAX_BYTES,但**至少一条**
+ * (单条即超阈值的事件已在入批前被拦到逐帧路径,这里的至少一条只是防死循环)。
+ * 取出的事件同步从段里移除;发送失败时由调用方放回段头。
+ */
+function sumMakerEventBytes(events: readonly unknown[]): number {
+  let total = 0;
+  for (const event of events) total += estimateMakerEventBytes(event);
+  return total;
+}
+
+function takeMakerEventBatchSlice(segment: MakerEventBatchSegment): unknown[] {
+  const slice: unknown[] = [];
+  let bytes = 0;
+  while (segment.events.length > 0 && slice.length < MAKER_EVENT_BATCH_MAX_EVENTS) {
+    const next = segment.events[0];
+    const nextBytes = estimateMakerEventBytes(next);
+    if (slice.length > 0 && bytes + nextBytes > MAKER_EVENT_BATCH_MAX_BYTES) break;
+    segment.events.shift();
+    slice.push(next);
+    bytes += nextBytes;
+  }
+  segment.bytes = Math.max(0, segment.bytes - bytes);
+  return slice;
 }
 
 function scheduleMakerEventBatchRetry(dst: string, stage: MakerEventBatchStage): void {
@@ -838,6 +887,11 @@ function flushMakerEventBatchesForSessionPush(
   if (channel === MAKER_EVENT_BATCH_CHANNEL) return;
   const stage = makerEventBatchStages.get(dst);
   if (!stage || stage.batches.size === 0) return;
+  // 退避中不尝试(与到量路径同一闸门,review 第二轮 P1):否则每条交错 push 都
+  // 会额外产生一次注定失败的同步发送。此时顺序不保证——但那时本帧自身的
+  // sendPush 大概率同样受阻(同一个满窗口),退化为旧语义(拥塞时 maker:event
+  // 本就被丢弃),不值得为它把交错帧也压进缓冲。
+  if (!canFlushMakerEventBatchNow(stage)) return;
   const sessionId = readPushSessionId(payload);
   if (!sessionId || !stage.batches.has(sessionId)) return;
   flushMakerEventBatchSession(dst, stage, sessionId);
@@ -1018,6 +1072,14 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
       ),
     )
     : null;
+  // 本帧是否具备入批资格(与 dst 无关的部分,循环外算一次):
+  // 必须是 maker:event、能算出 sessionId、且单条不超批字节上限——单条超限的事件
+  // 入批会撑爆逻辑消息上限,且失去逐帧路径的 compactOversizedPushPayload 兜底。
+  const batchEligibleSessionId = batchTargets
+    ? readPushSessionId(remotePayload)
+    : null;
+  const batchEligible = batchEligibleSessionId !== null
+    && estimateMakerEventBytes(remotePayload) < MAKER_EVENT_BATCH_MAX_BYTES;
   const offlineTargets = subscriptions
     .getKnownControllersForTopic(topic)
     .filter((dst) => !liveTargets.includes(dst));
@@ -1032,6 +1094,22 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
     }
   }
   for (const dst of liveTargets) {
+    const willBatch = batchEligible && batchTargets!.has(dst);
+    // 跨 channel 保序(review 两轮):**不入批**的帧必须排在该会话已暂存的事件
+    // 之后——否则 interaction-request / status-changed / activity 终态会插到攒批
+    // 的文本 delta 前面,控制端先收「已完成/确认卡」(结束流式消息)、120ms 后
+    // 才收到前面的文本,表现为「终态之后又冒出流式内容」。
+    // 位置要求两条,都由 review 实测推出:
+    //  - 必须在 activity 分支**之前**(它自带 continue,放后面对 activity 永不生效);
+    //  - 必须只对 !willBatch 的帧做,否则每条 maker:event 都会先收口上一批,
+    //    批被拆回逐帧、优化完全失效。
+    if (!willBatch && makerEventBatchStages.size > 0) {
+      flushMakerEventBatchesForSessionPush(dst, channel, remotePayload);
+    }
+    if (willBatch) {
+      stageMakerEventPush(dst, batchEligibleSessionId!, remotePayload, ownerStamp);
+      continue;
+    }
     // 会话活动是高频状态镜像:走 latest-wins 暂存整流,不直接冲可靠传输窗口。
     if (channel === SESSION_ACTIVITY_CHANNEL) {
       stageSessionActivityPush(dst, remotePayload, ownerStamp);
@@ -1041,23 +1119,6 @@ function forwardPush(channel: string, payload: unknown, ownerStamp?: PushOwnerSt
     // 「每窗口一帧」(见 stageMakerEventPush)。未声明能力的控制端照旧逐帧,
     // 因此旧控制端零感知。sessionId 取自 topic 路由所用的同一字段,取不到时
     // 不入批(topicForPush 已保证 session-scoped 帧必有它,这里只是防御)。
-    if (channel === MAKER_PUSH.EVENT && batchTargets?.has(dst)) {
-      const sessionId = readPushSessionId(remotePayload);
-      if (sessionId) {
-        stageMakerEventPush(dst, sessionId, remotePayload, ownerStamp);
-        continue;
-      }
-    }
-    // 跨 channel 保序(review 首轮 P2):同会话的其它推送必须排在已暂存的事件
-    // **之后**——否则 interaction-request / status-changed 会插到攒批的文本
-    // delta 前面,控制端先收确认卡(结束当前流式消息)、120ms 后才收到前面的
-    // 文本,表现为「交互卡出现后又冒出流式内容」。先把该会话的批推进可靠
-    // FIFO,后续帧自然排在其后。
-    // 残留窗口:批因背压 flush 失败时顺序仍可能颠倒——那时本帧的 sendPush 大概率
-    // 同样受阻(同一窗口),退化为旧语义(拥塞时 maker:event 本就被丢弃)。
-    if (makerEventBatchStages.size > 0) {
-      flushMakerEventBatchesForSessionPush(dst, channel, remotePayload);
-    }
     // 转发是尽力而为的旁路:单个控制端的帧超限(PAYLOAD_TOO_LARGE,如大 tool 输出)/ 连接异常
     // 绝不能冒泡——它会经 tapWindowBroadcast 回到 broadcastToAllWindows,让被控端**本机** renderer
     // 漏收该事件(本地 UI 是第一优先);per-dst 接住也避免一个控制端坏帧拖垮其它控制端的转发。

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -732,12 +732,21 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
 interface MakerEventBatchFlushOutcome {
   /** 本轮已确认发不出去:只清空缓冲,不再尝试发送。 */
   sendingBlocked: boolean;
+  /**
+   * 为什么发不出去。日志级别按它分档 —— 否则这条聚合日志自己就是新的洪峰:
+   *  - `offline`:relay 不在线,**这是常态且预期**(client.sendPush 在非 online 时本就
+   *    静默早退,push 的恢复语义一直是重连后 resync 补偿、不是重放)。断线期间事件
+   *    仍在产生,每 120ms 窗口一条 WARN 就是 8 条/秒的噪声 → 记 debug。
+   *  - `send-failed`:relay 在线却连逐帧都进不去(窗口满且队头不可驱逐),是**异常**
+   *    信号,值得 WARN。
+   */
+  blockedReason: 'offline' | 'send-failed' | null;
   /** 本轮未尝试发送而直接丢弃的事件数(用于聚合日志)。 */
   droppedEvents: number;
 }
 
 function createMakerEventBatchFlushOutcome(): MakerEventBatchFlushOutcome {
-  return { sendingBlocked: false, droppedEvents: 0 };
+  return { sendingBlocked: false, blockedReason: null, droppedEvents: 0 };
 }
 
 function reportMakerEventBatchFlushOutcome(
@@ -745,10 +754,11 @@ function reportMakerEventBatchFlushOutcome(
   outcome: MakerEventBatchFlushOutcome,
 ): void {
   if (outcome.droppedEvents === 0) return;
-  log.warn(
-    `maker:event batch flush to ${shortId(dst)}: peer send unavailable, `
-    + `dropped ${outcome.droppedEvents} event(s) without retry`,
-  );
+  const line = `maker:event batch flush to ${shortId(dst)}: `
+    + `${outcome.blockedReason === 'offline' ? 'relay offline' : 'peer send unavailable'}, `
+    + `dropped ${outcome.droppedEvents} event(s) without retry`;
+  if (outcome.blockedReason === 'offline') log.debug(line);
+  else log.warn(line);
 }
 
 /**
@@ -813,6 +823,7 @@ function flushMakerEventBatchSession(
       } catch (err) {
         if (!shouldDegradeBatchToPerFrame(err)) {
           outcome.sendingBlocked = true;
+          outcome.blockedReason = 'offline';
           outcome.droppedEvents += slice.length;
           continue;
         }
@@ -823,6 +834,7 @@ function flushMakerEventBatchSession(
           // 逐帧也进不去:同步循环内窗口不会被 ACK 腾空,后续帧必然同样失败。停在
           // 这里,把没尝试过的计入丢弃 —— 失败的那一帧自己已经记过一条日志。
           outcome.sendingBlocked = true;
+          outcome.blockedReason = 'send-failed';
           outcome.droppedEvents += slice.length - i - 1;
           break;
         }

--- a/apps/desktop/src/main/device-link/dispatch.ts
+++ b/apps/desktop/src/main/device-link/dispatch.ts
@@ -722,6 +722,40 @@ function stageMakerEventPush(
   scheduleMakerEventBatchFlush(dst, stage);
 }
 
+/**
+ * 投递该控制端的离线积压,**对启用微批的控制端同样走批**(review P1:恢复动作不得
+ * 重造触发条件,见 docs/dev-rules/remote-and-mobile-adaptation.md 的故障半径三问)。
+ *
+ * 不这样做的后果是实测量级的:断线期间同会话事件逐条进 offlinePushQueue,重订阅时
+ * 一次 drain 可能有上百条,原本逐条 sendPush 就是同一 tick 内上百帧——正是 8/8 线上
+ * 单毫秒 119 帧、招来 relay 1013 的那个形状,而这一帧洪峰恰好发生在刚重连、最脆弱的
+ * 时刻。走批之后同量积压压成个位数帧。
+ *
+ * 顺序规则与在线主路完全一致:`maker:event` 入批,其它 channel 先收口该会话的批再发,
+ * 因此积压内的跨 channel 相对顺序不变。drain 完立即收口(恢复要快,不等 120ms 窗口)。
+ */
+function drainOfflinePushQueueTo(src: string, topics: readonly string[]): void {
+  const batchCapable = subscriptions.controllerSupports(
+    src,
+    CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
+  );
+  for (const queued of offlinePushQueue.drain(src, topics)) {
+    const sessionId = batchCapable && queued.channel === MAKER_PUSH.EVENT
+      ? readPushSessionId(queued.payload)
+      : null;
+    if (
+      sessionId !== null
+      && estimateMakerEventBytes(queued.payload) < MAKER_EVENT_BATCH_MAX_BYTES
+    ) {
+      stageMakerEventPush(src, sessionId, queued.payload, queued.ownerStamp);
+      continue;
+    }
+    flushMakerEventBatchesForSessionPush(src, queued.channel, queued.payload);
+    sendPushBestEffort(src, queued.channel, queued.payload, queued.ownerStamp);
+  }
+  flushMakerEventBatchesFor(src);
+}
+
 /** 收口单个会话的待发批(到量 / 越界 / 跨 channel 收口共用),含聚合日志。 */
 function flushMakerEventBatchesForSession(dst: string, sessionId: string): void {
   const stage = makerEventBatchStages.get(dst);
@@ -762,73 +796,60 @@ function scheduleMakerEventBatchFlush(dst: string, stage: MakerEventBatchStage):
 }
 
 /**
- * 一次 flush 内的降级账本。它解决的是「降级不能自己变成本 PR 要消掉的那个洪峰」
- * (review 三轮收敛的最终形态)。收敛过程值得记下来,免得再来一遍:
+ * 一次 flush 的丢弃账本(聚合日志用)。
  *
- *  1. 最初逐帧降级无条件重放整个切片 → 队头不可驱逐时 ≤64 次失败、≤64 条 WARN,
- *     正是要消灭的逐事件 admission 与告警洪峰(greptile P1)。
- *  2. 改成「第一次失败就停」→ 又把「这一帧自己不合格」和「管子堵了」混为一谈,
- *     误丢本可送达的批尾(greptile P1 第二轮)。
- *  3. 于是按错误码区分 → 但 `BACKPRESSURE` **也是尺寸相关**的:ws 容量判据是
- *     `bufferedAmount + additionalBytes > cap`,pending 容量判据也含字节维度,
- *     所以大帧被拒时小帧仍可能通过(codex P1)。按错误码停手同样会误丢。
+ * 这里原本还有一条「批帧被拒 → 就地降级为逐帧 best-effort」的路径。它引出了 review
+ * 里最长的一族反馈,四轮都在同一段十几行代码上打转,而且两位 reviewer 的要求互相
+ * 抵触——记下来,免得有人再把它加回来:
  *
- * 结论:**洪峰本质上是日志问题,不是尝试问题。** 一次 `sendPush` 失败的代价只是一次
- * 函数调用加一次 throw,而少发一条本可送达的事件是用户可见的缺流。所以:
- *  - 切片内**每一条都尝试**,不因任何失败提前停手(尺寸相关的失败下后面的小帧还有戏);
- *  - 降级路径的逐帧日志静默(`quiet`),成败计数聚合成**一条**日志;
- *  - 唯一的例外是 relay 离线:`client.sendPush` 在非 online 时本就静默早退、成功率
- *    恒为 0,整轮直接不尝试(也不必逐条 throw)。
+ *  1. 无条件逐帧重放整个切片 → 队头不可驱逐时 ≤64 次失败、≤64 条 WARN,正是本 PR
+ *     要消灭的逐事件 admission 与告警洪峰(greptile P1)。
+ *  2. 改成「第一次失败就停」→ 把「这一帧自己不合格」当成「管子堵了」,误丢本可送达
+ *     的批尾(greptile P1 第二轮)。
+ *  3. 于是按错误码区分 → `BACKPRESSURE` 也尺寸相关(ws 容量判据含 additionalBytes、
+ *     pending 判据含字节维度),按码停手同样误丢(codex P1)。
+ *  4. 于是每条都试、只把日志聚合 → 又回到第 1 条:同步循环里没有 ACK 能释放窗口,
+ *     ≤64 次 admission + 驱逐判定 + throw/catch 依旧在洪峰时放大主进程压力,只是
+ *     WARN 被静默了(greptile P1 第三轮)。
+ *
+ * 第 1 与第 4 是同一条要求,第 2 与第 3 是它的反向要求 —— 这段代码不存在同时满足两侧
+ * 的取值。**所以把它整个删掉**:批帧发不出去就丢掉这一片,记一条聚合日志。
+ *
+ * 为什么可以直接丢:`maker:event` 与批 channel 都在 #2167 的 COALESCIBLE_PUSH_CHANNELS
+ * 白名单里 —— 拥塞时丢弃最旧的镜像帧、由控制端 resync 补偿,这正是那个 PR 定下的取舍,
+ * 本 PR 的职责是常态减帧而不是重新裁决拥塞语义。另外两条兜底也不再需要:批帧上限
+ * 256KB 远小于 MAX_FRAME_BYTES(2MB),不会 PAYLOAD_TOO_LARGE,所以逐帧路径的
+ * compactOversizedPushPayload 裁剪在这里没有用武之地;单条 ≥256KB 的事件本来就在入批
+ * 前被 forwardPush 拦到逐帧路径。
  */
 interface MakerEventBatchFlushOutcome {
   /**
-   * relay 离线:本轮后续切片与会话只清空缓冲、不再尝试发送。
+   * relay 离线:本轮后续切片与会话只清空缓冲、不再尝试发送(sendPush 在非 online 时
+   * 第一行就静默早退,成功率恒为 0)。
    *
    * 这是常态且预期的一档(push 的恢复语义一直是重连后 resync 补偿、不是重放),断线
    * 期间事件仍在产生,每 120ms 窗口一条 WARN 就是 8 条/秒的噪声 → 记 debug 而非 warn。
    */
   offline: boolean;
-  /** 因离线而未尝试发送、直接丢弃的事件数。 */
+  /** 本轮丢弃的事件数。 */
   droppedEvents: number;
-  /** 降级逐帧的成功条数。 */
-  degradedSent: number;
-  /** 降级逐帧中失败(背压 / 超限无解等)的条数;>0 才值得一条 WARN。 */
-  degradedFailed: number;
 }
 
 function createMakerEventBatchFlushOutcome(): MakerEventBatchFlushOutcome {
-  return { offline: false, droppedEvents: 0, degradedSent: 0, degradedFailed: 0 };
+  return { offline: false, droppedEvents: 0 };
 }
 
 function reportMakerEventBatchFlushOutcome(
   dst: string,
   outcome: MakerEventBatchFlushOutcome,
 ): void {
-  if (outcome.droppedEvents > 0) {
-    // 离线丢弃是预期常态,debug 级(理由见 outcome.offline 注释)。
-    log.debug(
-      `maker:event batch flush to ${shortId(dst)}: relay offline, `
-      + `dropped ${outcome.droppedEvents} event(s) without retry`,
-    );
-  }
-  if (outcome.degradedFailed > 0) {
-    // relay 在线却有帧进不去:异常信号,一次 flush 一条(不是每帧一条)。
-    log.warn(
-      `maker:event batch degraded to per-frame for ${shortId(dst)}: `
-      + `${outcome.degradedSent} sent, ${outcome.degradedFailed} dropped`,
-    );
-  }
-}
-
-/**
- * 批帧发送失败后,逐帧重放**有没有可能成功**。唯一说「没有」的是 relay 不在线:
- * `client.sendPush` 在非 online 时第一行就静默早退,逐帧成功率恒为 0。其余一切失败
- * (`BACKPRESSURE` / `PAYLOAD_TOO_LARGE` / 未知)都尺寸相关或帧相关——大帧被拒时小帧
- * 仍可能通过(ws 容量判据是 `bufferedAmount + additionalBytes`,pending 判据也含字节
- * 维度),所以必须逐帧试,不能按错误码整片放弃(codex P1)。
- */
-function shouldDegradeBatchToPerFrame(err: unknown): boolean {
-  return !(err instanceof DeviceLinkError && err.code === 'NOT_CONNECTED');
+  if (outcome.droppedEvents === 0) return;
+  const line = `maker:event batch flush to ${shortId(dst)}: `
+    + `${outcome.offline ? 'relay offline' : 'send rejected'}, `
+    + `dropped ${outcome.droppedEvents} event(s)`;
+  // 离线丢弃是预期常态(理由见 outcome.offline);relay 在线却被拒才是异常信号。
+  if (outcome.offline) log.debug(line);
+  else log.warn(line);
 }
 
 /** flush 该控制端的全部会话批(窗口到点 / 显式收口)。 */
@@ -879,23 +900,12 @@ function flushMakerEventBatchSession(
           activeClient.sendPush(dst, MAKER_EVENT_BATCH_CHANNEL, payload, segment.ownerStamp);
         }
       } catch (err) {
-        if (!shouldDegradeBatchToPerFrame(err)) {
+        // 发不出去就丢这一片(不降级、不重试、不滞留):理由与四轮 review 的推导见
+        // MakerEventBatchFlushOutcome 注释。relay 离线时后续切片连尝试都省掉。
+        if (err instanceof DeviceLinkError && err.code === 'NOT_CONNECTED') {
           outcome.offline = true;
-          outcome.droppedEvents += slice.length;
-          continue;
         }
-        // 降级为逐帧:**每一条都试**,不因任何失败提前停手 —— 失败大多与帧尺寸相关
-        // (ws 容量判据含 additionalBytes、pending 判据含字节维度),大帧被拒时后面的
-        // 小帧仍可能通过;少发一条本可送达的事件是用户可见的缺流,而多一次失败的
-        // sendPush 只是一次 throw。逐帧日志静默,成败计数聚合成一条(见 outcome 注释)。
-        // 顺序仍是原顺序;批不因失败滞留 —— 那正是顺序问题的唯一来源。
-        for (const event of slice) {
-          if (sendPushBestEffort(dst, MAKER_PUSH.EVENT, event, segment.ownerStamp, { quiet: true })) {
-            outcome.degradedSent += 1;
-          } else {
-            outcome.degradedFailed += 1;
-          }
-        }
+        outcome.droppedEvents += slice.length;
       }
     }
   }
@@ -1192,49 +1202,37 @@ export function pushToTopicSubscribers(
   forwardPush(channel, payload, ownerStamp);
 }
 
-/**
- * best-effort 转发一帧 push:失败只记日志、不抛。
- * @param opts.quiet 静默逐帧日志(调用方自己做聚合)。批降级路径用它:一次 flush
- *   最多 ≤64 帧,逐条 WARN 就是本 PR 要消掉的那个告警洪峰。
- * @returns 帧是否已交给可靠传输(含 compact 兜底后成功)。绝大多数调用方忽略返回值。
- */
 function sendPushBestEffort(
   dst: string,
   channel: string,
   payload: unknown,
   ownerStamp?: PushOwnerStamp,
-  opts?: { quiet?: boolean },
-): boolean {
-  if (!activeClient) return false;
-  const warn = (message: string): void => {
-    if (!opts?.quiet) log.warn(message);
-  };
+): void {
+  if (!activeClient) return;
   try {
     if (ownerStamp === undefined) activeClient.sendPush(dst, channel, payload);
     else activeClient.sendPush(dst, channel, payload, ownerStamp);
-    return true;
+    return;
   } catch (err) {
     if (!isPayloadTooLargeError(err)) {
-      warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      return false;
+      log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
+      return;
     }
 
     const compactPayload = compactOversizedPushPayload(channel, payload);
     if (!compactPayload) {
-      warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
-      return false;
+      log.warn(`forwardPush to ${shortId(dst)} failed (${channel}): ${String(err)}`);
+      return;
     }
 
     try {
       if (ownerStamp === undefined) activeClient.sendPush(dst, channel, compactPayload);
       else activeClient.sendPush(dst, channel, compactPayload, ownerStamp);
-      warn(`forwardPush to ${shortId(dst)} sent compact payload after oversized ${channel} frame`);
-      return true;
+      log.warn(`forwardPush to ${shortId(dst)} sent compact payload after oversized ${channel} frame`);
     } catch (retryErr) {
-      warn(
+      log.warn(
         `forwardPush to ${shortId(dst)} failed after compact retry (${channel}): ${String(retryErr)}`,
       );
-      return false;
     }
   }
 }
@@ -1569,9 +1567,7 @@ function handleLinkOpen(
   if (!knownModernController) {
     // 同上:投递离线积压前先排空该控制端的事件批,保住跨积压的顺序。
     flushMakerEventBatchesFor(src);
-    for (const queued of offlinePushQueue.drain(src, [LEGACY_TOPIC])) {
-      sendPushBestEffort(src, queued.channel, queued.payload, queued.ownerStamp);
-    }
+    drainOfflinePushQueueTo(src, [LEGACY_TOPIC]);
   }
   log.info(`control link opened by ${shortId(src)} (${name})`);
 }
@@ -2471,9 +2467,7 @@ function handleSubscriptionFrame(src: string, payload: InvokePayload): InvokeRes
     // 新事件与终态推送进的是 offlinePushQueue,而旧批留在内存等重试 timer;
     // 不先收口就会让新帧先于断线前的文本送达,重现「终态后冒出文本」。
     flushMakerEventBatchesFor(src);
-    for (const queued of offlinePushQueue.drain(src, topics)) {
-      sendPushBestEffort(src, queued.channel, queued.payload, queued.ownerStamp);
-    }
+    drainOfflinePushQueueTo(src, topics);
   }
   return { ok: true, result: { ok: true } };
 }

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -63,6 +63,7 @@ import {
   setControllersChangedListener,
   setRemoteInvokeBusyChangedListener,
   dropAllControllers,
+  flushMakerEventBatchesOnReconnect,
   flushRemoteInvokeResultOutboxOnReconnect,
   forgetControllerInvokeState,
   handleControllerOffline,
@@ -471,6 +472,9 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
     broadcast(DEVICE_LINK_PUSH.STATUS_CHANGED, { status });
     handleContactsDeviceLinkStatusChanged(status === 'online');
     if (status === 'online') {
+      // 断线前攒的 maker:event 批最先出去:它在时间上早于离线积压与重连后的
+      // 一切新推送,晚发会让控制端在终态之后又收到旧文本(见 dispatch 注释)。
+      flushMakerEventBatchesOnReconnect();
       replayActiveSubscriptions('ws-online');
       // 重连即投递被控端积压的 invoke-result:离线期间 outbox 只做慢速 TTL 出清,
       // 不再自旋重试,上线事件是它的主投递触发点。

--- a/apps/desktop/src/main/device-link/index.ts
+++ b/apps/desktop/src/main/device-link/index.ts
@@ -15,8 +15,11 @@ import { app, BrowserWindow } from 'electron';
 import WebSocket from 'ws';
 import {
   DeviceLinkClient,
+  CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
   CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2,
   CONTROLLER_CAPABILITY_SET_MODEL_EXPLICIT_PROVIDER_NULL_V1,
+  MAKER_EVENT_BATCH_CHANNEL,
+  expandMakerEventBatchPayload,
   DL_CONTACTS_SYNC_CHANNEL,
   DL_SUBSCRIBE_CHANNEL,
   DL_UNSUBSCRIBE_CHANNEL,
@@ -57,6 +60,7 @@ import {
   writeDeviceLinkSetting,
 } from './settings-store';
 import { keepAwakeController } from './power-blocker';
+import { MAKER_PUSH } from '../maker-ipc/channels.js';
 import { createDnsFallbackLookup } from './dnsFallbackLookup';
 import {
   wireInboundDispatch,
@@ -244,6 +248,20 @@ const RESPONSIVENESS_PROBE_TICK_MS = 5_000;
  * 词典同步的对端选择只看「在线 + 是桌面」,不看 remoteControlEnabled ——
  * push 帧不属于 relay 的控制类帧,自己设备之间同步词典不该要求对方开放被控。
  */
+/**
+ * 本机**作为控制端**声明的端到端能力(append-only)。`openLink` 与 `subscribe` 两处
+ * 必须用同一份 —— 只在一处声明会让另一条路径静默降级(mobile 侧 review 实测过这个坑)。
+ */
+const CONTROLLER_CAPABILITIES = [
+  CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2,
+  CONTROLLER_CAPABILITY_SET_MODEL_EXPLICIT_PROVIDER_NULL_V1,
+  // 桌面控制桌面时同样收微批:批的收益是**relay 帧数**,只要有一个控制端不支持,
+  // 被控端就得为它保留逐帧流,聚合出站速率照旧能招来 1013 并连带踢掉已启用微批的
+  // 手机(review P1)。拆包在 main 完成(见 onFrame 的批分支),renderer 的既有
+  // maker:event 订阅者零改动。
+  CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
+] as const;
+
 const presenceOnlineByDevice = new Map<string, boolean>();
 
 const presenceNameByDevice = new Map<string, string>();
@@ -621,6 +639,21 @@ export function initDeviceLinkService(options: DeviceLinkServiceOptions = {}): v
         })
       ) {
         handleIncomingContactsRelayFrame(env.src, p.payload);
+      }
+      return;
+    }
+    // 微批拆包放在 main:renderer 侧有多个按 channel 过滤的 onRemotePush 订阅者
+    // (会话视图 / 草稿路由 / learn / 文件浏览),在这里展开成原样的 maker:event
+    // 事件流,它们全都零改动。批内条目的 sessionId 与顶层不一致即跳过(topic 隔离
+    // fail-closed,与 mobile 拆包同判据)。
+    if (p.channel === MAKER_EVENT_BATCH_CHANNEL) {
+      for (const event of expandMakerEventBatchPayload(p.payload)) {
+        broadcast(DEVICE_LINK_PUSH.REMOTE_PUSH, {
+          deviceId: env.src,
+          channel: MAKER_PUSH.EVENT,
+          payload: event,
+          ...(p.ownerStamp ? { ownerStamp: p.ownerStamp } : {}),
+        });
       }
       return;
     }
@@ -1338,10 +1371,7 @@ export async function openRemoteLink(
       controllerName: deviceName(),
       protocolVersion: 1,
       appVersion: app.getVersion(),
-      capabilities: [
-        CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2,
-        CONTROLLER_CAPABILITY_SET_MODEL_EXPLICIT_PROVIDER_NULL_V1,
-      ],
+      capabilities: [...CONTROLLER_CAPABILITIES],
     });
   };
   // 结算所有权由 tracker.guardInvoke 统一声明(第一个 settle 的 guard 打标,
@@ -1496,10 +1526,7 @@ export async function remoteSubscribe(
         {
           topics: liveTopics,
           controllerName: deviceName(),
-          capabilities: [
-            CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2,
-            CONTROLLER_CAPABILITY_SET_MODEL_EXPLICIT_PROVIDER_NULL_V1,
-          ],
+          capabilities: [...CONTROLLER_CAPABILITIES],
         },
       ],
     });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAKER_EVENT_BATCH_CHANNEL } from '@cindy/device-link';
 import { remoteSessionStore, sessionPendingWrites } from '@/session/remoteSessionStore';
 import type { InputProjection, PendingInteraction, RemoteMessage, RemoteSession } from '@/session/types';
 
@@ -2966,5 +2967,70 @@ describe('引用调和(2026-07-18 首页重渲染风暴修复)', () => {
       ]);
     }
     expect(remoteSessionStore.getSessions()).toBe(snapshot);
+  });
+});
+
+describe('maker:event 微批拆包(CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1)', () => {
+  it('批内事件按序走与逐帧完全相同的路径:流式增量拼接结果一致', () => {
+    vi.useFakeTimers();
+    try {
+      // 逐帧基线
+      pushMakerText('s-single', 'p-1', 'hello', false);
+      pushMakerText('s-single', 'p-1', ' world', false);
+      vi.runOnlyPendingTimers();
+      const single = remoteSessionStore.getMessages('s-single');
+
+      // 同样两条事件,这次由被控端合并成一帧微批下发
+      remoteSessionStore.applyRemotePush('dev-1', MAKER_EVENT_BATCH_CHANNEL, {
+        sessionId: 's-batch',
+        events: [
+          { sessionId: 's-batch', persistId: 'p-1', event: { type: 'text', data: { text: 'hello', isFinal: false } } },
+          { sessionId: 's-batch', persistId: 'p-1', event: { type: 'text', data: { text: ' world', isFinal: false } } },
+        ],
+      });
+      vi.runOnlyPendingTimers();
+      const batched = remoteSessionStore.getMessages('s-batch');
+
+      expect(batched).toHaveLength(1);
+      expect(batched[0]).toMatchObject({ id: 'p-1', role: 'assistant', content: 'hello world' });
+      // 与逐帧结果逐字段一致(仅 sessionId 不同)
+      expect(batched[0]!.content).toBe(single[0]!.content);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('形状不符的批帧整体忽略;批内单条坏事件只跳过该条', () => {
+    vi.useFakeTimers();
+    try {
+      // 缺 events / events 为空 / 非数组:整帧忽略,不抛
+      for (const bad of [
+        { sessionId: 's-bad' },
+        { sessionId: 's-bad', events: [] },
+        { sessionId: 's-bad', events: 'nope' },
+        { events: [{}] },
+        null,
+      ]) {
+        expect(() =>
+          remoteSessionStore.applyRemotePush('dev-1', MAKER_EVENT_BATCH_CHANNEL, bad),
+        ).not.toThrow();
+      }
+      vi.runOnlyPendingTimers();
+      expect(remoteSessionStore.getMessages('s-bad')).toHaveLength(0);
+
+      // 批内混入坏条目:好的照常生效
+      remoteSessionStore.applyRemotePush('dev-1', MAKER_EVENT_BATCH_CHANNEL, {
+        sessionId: 's-mixed',
+        events: [
+          'not-an-object',
+          { sessionId: 's-mixed', persistId: 'p-9', event: { type: 'text', data: { text: 'ok', isFinal: true } } },
+        ],
+      });
+      vi.runOnlyPendingTimers();
+      expect(remoteSessionStore.getMessages('s-mixed')).toHaveLength(1);
+      expect(remoteSessionStore.getMessages('s-mixed')[0]).toMatchObject({ content: 'ok' });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/mobile/src/__tests__/remoteSessionStore.test.ts
+++ b/apps/mobile/src/__tests__/remoteSessionStore.test.ts
@@ -3033,4 +3033,25 @@ describe('maker:event 微批拆包(CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1)',
       vi.useRealTimers();
     }
   });
+
+  it('批内 sessionId 与顶层不一致的条目被丢弃:不绕过 topic 隔离', () => {
+    // topic 路由只按**顶层** sessionId,批内混入其它会话的事件会把本端未订阅的
+    // 会话数据投进来(坏帧/恶意帧场景)。fail-closed 跳过该条,不整批丢。
+    vi.useFakeTimers();
+    try {
+      remoteSessionStore.applyRemotePush('dev-1', MAKER_EVENT_BATCH_CHANNEL, {
+        sessionId: 's-own',
+        events: [
+          { sessionId: 's-other', persistId: 'p-x', event: { type: 'text', data: { text: 'leak', isFinal: true } } },
+          { sessionId: 's-own', persistId: 'p-y', event: { type: 'text', data: { text: 'mine', isFinal: true } } },
+        ],
+      });
+      vi.runOnlyPendingTimers();
+      expect(remoteSessionStore.getMessages('s-other')).toHaveLength(0);
+      expect(remoteSessionStore.getMessages('s-own')).toHaveLength(1);
+      expect(remoteSessionStore.getMessages('s-own')[0]).toMatchObject({ content: 'mine' });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -3,6 +3,7 @@ import { AppState, Platform } from 'react-native';
 import {
   DeviceLinkClient,
   DeviceLinkError,
+  CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
   CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2,
   DL_SUBSCRIBE_CHANNEL,
   DL_UNSUBSCRIBE_CHANNEL,
@@ -141,6 +142,17 @@ export interface DeviceLinkContextValue {
 }
 
 const DeviceLinkContext = createContext<DeviceLinkContextValue | null>(null);
+
+/**
+ * 本控制端声明的端到端可选能力(link-open 与 subscribe 两处共用同一份,漏一处会让
+ * 被控端按能力缺失降级)。被控端只在看到对应能力后才发送新 wire 形状。
+ */
+const CONTROLLER_CAPABILITIES = [
+  CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2,
+  // maker:event 微批:被控端把同一会话的连续事件合并成一帧,本端拆包后逐条消费
+  // (见 remoteSessionStore 的 MAKER_EVENT_BATCH_CHANNEL 分支)。
+  CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1,
+];
 
 // 任意目标端真实应答的独立时序证据。它不等同于 presence verdict,也不参与 IPC/DB
 // 响应性熔断;只用于判定并发返回的 unavailable 是否已被更晚目标应答推翻。
@@ -1234,7 +1246,7 @@ async function sendOpenLink(
       controllerName: mobileDeviceName(),
       protocolVersion: PROTOCOL_VERSION,
       appVersion: Constants.expoConfig?.version ?? '0.0.0',
-      capabilities: [CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2],
+      capabilities: CONTROLLER_CAPABILITIES,
     });
     // link-accept 只证明链路层活着,不证明 invoke 路径健康(review P1):事故形态
     // 正是 link-open 在被控端 IPC/DB 路径之外应答正常、invoke 全部挂死——若凭
@@ -1378,7 +1390,7 @@ async function sendSubscribe(
       args: [{
         topics,
         controllerName: mobileDeviceName(),
-        capabilities: [CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2],
+        capabilities: CONTROLLER_CAPABILITIES,
       }],
     });
   } catch (err) {

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -1,5 +1,10 @@
 import { useEffect, useRef, useSyncExternalStore } from 'react';
-import { SESSION_ACTIVITY_CHANNEL, type SessionActivityPayload } from '@cindy/device-link';
+import {
+  MAKER_EVENT_BATCH_CHANNEL,
+  SESSION_ACTIVITY_CHANNEL,
+  parseMakerEventBatchPayload,
+  type SessionActivityPayload,
+} from '@cindy/device-link';
 import {
   applyAgentTaskUpdateEvent,
   isSameAgentTaskAlias,
@@ -2005,6 +2010,17 @@ export const remoteSessionStore = {
     emit();
   },
 
+  /**
+   * 单条 maker:event push payload 的消费(逐帧与微批拆包**共用**唯一实现——
+   * 两条路径若各自解析,批的语义就会随逐帧演进而漂移)。
+   */
+  applyMakerEventPush(payload: Record<string, unknown>): void {
+    const sessionId = readString(payload, 'sessionId');
+    const event = isRecord(payload.event) ? payload.event : null;
+    const persistId = readString(payload, 'persistId') ?? undefined;
+    if (sessionId && event) this.applyMakerEvent(sessionId, event, persistId);
+  },
+
   applyRemotePush(deviceId: string, channel: string, payload: unknown): void {
     if (channel === SESSION_ACTIVITY_CHANNEL) {
       this.applySessionActivity(deviceId, payload);
@@ -2102,10 +2118,19 @@ export const remoteSessionStore = {
       return;
     }
     if (channel === 'maker:event' && isRecord(payload)) {
-      const sessionId = readString(payload, 'sessionId');
-      const event = isRecord(payload.event) ? payload.event : null;
-      const persistId = readString(payload, 'persistId') ?? undefined;
-      if (sessionId && event) this.applyMakerEvent(sessionId, event, persistId);
+      this.applyMakerEventPush(payload);
+      return;
+    }
+    // 微批帧:被控端把同一会话的连续 maker:event 合并成一帧(能力协商见
+    // CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1)。逐条按原顺序走与逐帧**完全
+    // 相同**的处理路径——批只是传输层的聚合,不引入新的应用语义;单条形状不符
+    // 时跳过该条而不丢整批。
+    if (channel === MAKER_EVENT_BATCH_CHANNEL) {
+      const batch = parseMakerEventBatchPayload(payload);
+      if (!batch) return;
+      for (const event of batch.events) {
+        if (isRecord(event)) this.applyMakerEventPush(event);
+      }
       return;
     }
     if (channel === 'maker:status-changed' && isRecord(payload)) {

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -2,7 +2,7 @@ import { useEffect, useRef, useSyncExternalStore } from 'react';
 import {
   MAKER_EVENT_BATCH_CHANNEL,
   SESSION_ACTIVITY_CHANNEL,
-  parseMakerEventBatchPayload,
+  expandMakerEventBatchPayload,
   type SessionActivityPayload,
 } from '@cindy/device-link';
 import {
@@ -2126,14 +2126,10 @@ export const remoteSessionStore = {
     // 相同**的处理路径——批只是传输层的聚合,不引入新的应用语义;单条形状不符
     // 时跳过该条而不丢整批。
     if (channel === MAKER_EVENT_BATCH_CHANNEL) {
-      const batch = parseMakerEventBatchPayload(payload);
-      if (!batch) return;
-      for (const event of batch.events) {
+      // 拆包与 fail-closed 的 topic 隔离判据在共享包里(desktop 作为控制端时也用
+      // 同一份,见 expandMakerEventBatchPayload 注释)。
+      for (const event of expandMakerEventBatchPayload(payload)) {
         if (!isRecord(event)) continue;
-        // 只消费与批顶层 sessionId 一致的条目:topic 隔离是按**顶层** sessionId
-        // 路由的,批内混入其它会话的事件会绕过隔离,把本端未订阅的会话数据投进来
-        // (坏帧/恶意帧场景)。fail-closed 跳过,不整批丢。
-        if (readString(event, 'sessionId') !== batch.sessionId) continue;
         this.applyMakerEventPush(event);
       }
       return;

--- a/apps/mobile/src/session/remoteSessionStore.ts
+++ b/apps/mobile/src/session/remoteSessionStore.ts
@@ -2129,7 +2129,12 @@ export const remoteSessionStore = {
       const batch = parseMakerEventBatchPayload(payload);
       if (!batch) return;
       for (const event of batch.events) {
-        if (isRecord(event)) this.applyMakerEventPush(event);
+        if (!isRecord(event)) continue;
+        // 只消费与批顶层 sessionId 一致的条目:topic 隔离是按**顶层** sessionId
+        // 路由的,批内混入其它会话的事件会绕过隔离,把本端未订阅的会话数据投进来
+        // (坏帧/恶意帧场景)。fail-closed 跳过,不整批丢。
+        if (readString(event, 'sessionId') !== batch.sessionId) continue;
+        this.applyMakerEventPush(event);
       }
       return;
     }

--- a/packages/device-link/src/__tests__/topics.test.ts
+++ b/packages/device-link/src/__tests__/topics.test.ts
@@ -5,7 +5,14 @@
  * 都依赖这份映射,回归必须显式。
  */
 import { describe, it, expect } from 'vitest';
-import { SESSION_ACTIVITY_CHANNEL, fsWatchTopic, parseFsWatchTopic, topicForPush } from '../topics.js';
+import {
+  MAKER_EVENT_BATCH_CHANNEL,
+  SESSION_ACTIVITY_CHANNEL,
+  expandMakerEventBatchPayload,
+  fsWatchTopic,
+  parseFsWatchTopic,
+  topicForPush,
+} from '../topics.js';
 
 describe('topicForPush', () => {
   it('会话列表级 channel → sessions', () => {
@@ -126,5 +133,36 @@ describe('topicForPush', () => {
     expect(topicForPush('maker:event', null)).toBeNull();
     expect(topicForPush('maker:event', { sessionId: 123 })).toBeNull();
     expect(topicForPush('maker:event', undefined)).toBeNull();
+  });
+});
+
+describe('expandMakerEventBatchPayload', () => {
+  // 两个控制端(mobile store / desktop main)共用这一份拆包与 fail-closed 判据,
+  // 所以它的契约在这里定,不在任何一端的实现里。
+  it('原样返回批内事件,顺序即批内顺序', () => {
+    const events = [{ sessionId: 's1', event: { i: 0 } }, { sessionId: 's1', event: { i: 1 } }];
+    expect(expandMakerEventBatchPayload({ sessionId: 's1', events })).toEqual(events);
+  });
+
+  it('sessionId 与顶层不一致的条目跳过(topic 隔离不被绕过),其余照常消费', () => {
+    // 坏帧 / 恶意帧:批内混入未订阅会话的事件,会绕过按顶层 sessionId 的 topic 路由。
+    const ok = { sessionId: 's1', event: { keep: true } };
+    expect(expandMakerEventBatchPayload({
+      sessionId: 's1',
+      events: [ok, { sessionId: 's2', event: { leak: true } }, { event: { noSession: true } }],
+    })).toEqual([ok]);
+  });
+
+  it('形状不符 / 空批 → 空数组(不抛、不当批处理)', () => {
+    expect(expandMakerEventBatchPayload(null)).toEqual([]);
+    expect(expandMakerEventBatchPayload({ sessionId: 's1', events: [] })).toEqual([]);
+    expect(expandMakerEventBatchPayload({ sessionId: '', events: [{ sessionId: '' }] })).toEqual([]);
+    expect(expandMakerEventBatchPayload({ events: [{}] })).toEqual([]);
+    expect(expandMakerEventBatchPayload({ sessionId: 's1', events: 'nope' })).toEqual([]);
+  });
+
+  it('批 channel 常量与 topic 路由一致(顶层 sessionId → session:<id>)', () => {
+    expect(topicForPush(MAKER_EVENT_BATCH_CHANNEL, { sessionId: 's7', events: [{}] }))
+      .toBe('session:s7');
   });
 });

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -40,6 +40,7 @@ import {
   parseTransportPayload,
   byteLength,
 } from './transport.js';
+import { MAKER_EVENT_BATCH_CHANNEL } from './topics.js';
 const DUPLICATE_CONNECTION_CLOSE_CODE = 4409;
 /** RFC 6455 1013 Try Again Later:relay 因拥塞主动断连(如 inbound backpressure)。 */
 const RELAY_TRY_AGAIN_LATER_CLOSE_CODE = 1013;
@@ -48,11 +49,13 @@ const RELAY_TRY_AGAIN_LATER_CLOSE_CODE = 1013;
  * 黑名单 → 白名单 → 收缩到单通道)。push 单 FIFO 上混着三类语义,只有第一类
  * 可以参与传输层 latest-wins:
  *
- * - 自相似有损事件流(本表,现仅 maker:event):流内每帧价值均匀且整流已是
- *   契约——旧语义拥塞时本就丢**最新**帧(admission 拒收后 forwardPush 按
+ * - 自相似有损事件流(本表:maker:event 及其微批帧):流内每帧价值均匀且整流
+ *   已是契约——旧语义拥塞时本就丢**最新**帧(admission 拒收后 forwardPush 按
  *   best-effort 放弃),换成丢最旧不引入新的损失面;转录内容由受保护的
  *   local-db:messages:created + 控制端消息对账自愈,会话运行态由受保护的
- *   status / activity 通道承载。
+ *   status / activity 通道承载。微批帧(MAKER_EVENT_BATCH_CHANNEL)与逐帧
+ *   **必须同档**:它只是同一事件流的聚合体,漏登记会让启用微批的控制端在拥塞
+ *   时退回 BACKPRESSURE 风暴(正是微批要消除的那一个)。
  * - 键控/终态快照(sessions:activity、maker:input:projection):看似「镜像」
  *   但**不满足跨帧可替代**——快照按 sessionId 键控,会话的 completed/error
  *   收尾快照是该键的最后一帧,被其它键/其它通道的洪峰驱逐后不会再有后继帧
@@ -69,6 +72,7 @@ const RELAY_TRY_AGAIN_LATER_CLOSE_CODE = 1013;
  */
 const COALESCIBLE_PUSH_CHANNELS: ReadonlySet<string> = new Set([
   'maker:event',
+  MAKER_EVENT_BATCH_CHANNEL,
 ]);
 /** push 拥塞驱逐告警的 per-peer 聚合窗口:洪峰期逐条 warn 本身就是新的风暴。 */
 const PUSH_ADMISSION_DROP_LOG_INTERVAL_MS = 5_000;

--- a/packages/device-link/src/client.ts
+++ b/packages/device-link/src/client.ts
@@ -77,11 +77,20 @@ const COALESCIBLE_PUSH_CHANNELS: ReadonlySet<string> = new Set([
 /** push 拥塞驱逐告警的 per-peer 聚合窗口:洪峰期逐条 warn 本身就是新的风暴。 */
 const PUSH_ADMISSION_DROP_LOG_INTERVAL_MS = 5_000;
 
+/**
+ * 该 push channel 是否属于可驱逐档(latest-wins 腾位的唯一判据入口)。
+ * 导出供上层断言「新增的聚合/整流 channel 已与其源 channel 同档」——漏登记会让
+ * 拥塞时退回 BACKPRESSURE 风暴,而这类漏登记只有对着判据本身断言才拦得住。
+ */
+export function isCoalesciblePushChannel(channel: string): boolean {
+  return COALESCIBLE_PUSH_CHANNELS.has(channel);
+}
+
 function isCoalesciblePushEnvelope(env: Envelope): boolean {
   if (env.kind !== 'push') return false;
   const payload = env.payload as { channel?: unknown } | undefined;
   return typeof payload?.channel === 'string'
-    && COALESCIBLE_PUSH_CHANNELS.has(payload.channel);
+    && isCoalesciblePushChannel(payload.channel);
 }
 /** 连续握手超时达到该次数后,握手窗口翻倍(见 armHandshakeTimeout)。 */
 const HANDSHAKE_TIMEOUT_WIDEN_AFTER = 2;

--- a/packages/device-link/src/protocol.ts
+++ b/packages/device-link/src/protocol.ts
@@ -118,6 +118,13 @@ export const CONTROLLER_CAPABILITY_PROVIDER_LOGO_KINDS_V2 = 'provider-logo-kinds
 export const CONTROLLER_CAPABILITY_SET_MODEL_EXPLICIT_PROVIDER_NULL_V1 =
   'set-model-explicit-provider-null-v1';
 
+/**
+ * 控制端能消费 `maker:event:batch` 微批帧(拆包后逐条按原路消费)。
+ * 被控端只对声明了本能力的控制端发批,未声明者照旧逐帧转发——旧控制端
+ * 因此永远收不到该 channel,无需为未知 channel 做任何兼容。
+ */
+export const CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1 = 'maker-event-batch-v1';
+
 export interface LinkAcceptPayload {
   appVersion: string;
   /** 被控端 allowlist 的指纹,便于控制端探测版本差异 */

--- a/packages/device-link/src/topics.ts
+++ b/packages/device-link/src/topics.ts
@@ -60,6 +60,45 @@ export interface SessionActivityPayload {
 export const SESSION_ACTIVITY_CHANNEL = 'local-db:sessions:activity';
 
 /**
+ * `maker:event` 的**微批**转发 channel(同一会话的连续事件合并成一帧)。
+ *
+ * 为什么要它:agent 长思考期间 `maker:event` 逐帧直冲 per-peer 可靠传输窗口
+ * (64 槽单 FIFO),2026-08-08 线上单毫秒 119 帧、8-07 单小时 5168 次
+ * `BACKPRESSURE`,聚合出站速率还会招来 relay 的 1013 拥塞断连。批把「每事件
+ * 一帧」压成「每窗口一帧」,是本条链路上唯一的**出站帧数**削减手段(#2167 的
+ * latest-wins 只改拥塞时的取舍,#2185 只推迟重连,都不减少帧数)。
+ *
+ * payload 顶层带 `sessionId`,因此 topicForPush 的 session-scoped 兜底分支
+ * 自动把它路由到 `session:<id>`——批**不得**跨会话合并,否则 topic 算不出。
+ * 批内 `events` 是原 `maker:event` payload 的**原样**序列,顺序即产生顺序;
+ * 控制端拆开后逐条按原路消费,语义与逐帧完全一致。
+ *
+ * 兼容:被控端只对声明了
+ * CONTROLLER_CAPABILITY_MAKER_EVENT_BATCH_V1 的控制端发批,其余照旧逐帧,
+ * 因此旧控制端永远收不到本 channel。
+ */
+export const MAKER_EVENT_BATCH_CHANNEL = 'maker:event:batch';
+
+/** 微批帧 payload:同一会话的连续 `maker:event` payload 原样序列。 */
+export interface MakerEventBatchPayload {
+  sessionId: string;
+  /** 原 `maker:event` payload 序列(至少 1 条),顺序即产生顺序。 */
+  events: unknown[];
+}
+
+/** 解析微批帧;形状不符返回 null(旧/坏帧一律不当批处理)。 */
+export function parseMakerEventBatchPayload(
+  payload: unknown,
+): MakerEventBatchPayload | null {
+  if (!payload || typeof payload !== 'object') return null;
+  const sessionId = (payload as { sessionId?: unknown }).sessionId;
+  const events = (payload as { events?: unknown }).events;
+  if (typeof sessionId !== 'string' || sessionId.length === 0) return null;
+  if (!Array.isArray(events) || events.length === 0) return null;
+  return { sessionId, events };
+}
+
+/**
  * 会话**列表级**读模型 channel:会话行的增 / 改。归 `sessions` topic。
  * `sessions:created` 只带 {sessionId}(无 row 数据)→ 控制端据此重拉列表;
  * `sessions:patched` 带 {sessionId, patch} → 控制端可直接 apply。

--- a/packages/device-link/src/topics.ts
+++ b/packages/device-link/src/topics.ts
@@ -99,6 +99,27 @@ export function parseMakerEventBatchPayload(
 }
 
 /**
+ * 拆开微批帧,返回**可安全消费**的原 `maker:event` payload 序列(形状不符 / 无条目
+ * 返回空数组)。
+ *
+ * 只保留 `sessionId` 与批顶层一致的条目:topic 隔离是按**顶层** sessionId 路由的,
+ * 批内混入其它会话的事件会绕过隔离,把接收端未订阅的会话数据投进来(坏帧 / 恶意帧
+ * 场景)。fail-closed 逐条跳过,不整批丢。
+ *
+ * 放在共享包里是因为**两个控制端都要拆**:mobile 直接喂自己的 store,desktop 作为
+ * 控制端时在 main 里展开成原样的 `maker:event` 广播(renderer 的多个按 channel 过滤
+ * 的订阅者因此零改动)。同一条 fail-closed 判据只能有一份。
+ */
+export function expandMakerEventBatchPayload(payload: unknown): unknown[] {
+  const batch = parseMakerEventBatchPayload(payload);
+  if (!batch) return [];
+  return batch.events.filter((event) => {
+    if (!event || typeof event !== 'object') return false;
+    return (event as { sessionId?: unknown }).sessionId === batch.sessionId;
+  });
+}
+
+/**
  * 会话**列表级**读模型 channel:会话行的增 / 改。归 `sessions` topic。
  * `sessions:created` 只带 {sessionId}(无 row 数据)→ 控制端据此重拉列表;
  * `sessions:patched` 带 {sessionId, patch} → 控制端可直接 apply。


### PR DESCRIPTION
## 这次改了什么

### 摘要

8/8 事故链治理的最后一块,也是唯一削减**出站帧数**的一块。此前三块都不减帧:activity 整流(#1401)只整流状态镜像、拥塞取舍(#2167)只改拥塞时丢哪一帧、重连冷却(#2185)只推迟重连时机——agent 长思考期间 `maker:event` 仍然是**每事件一帧**。2026-08-08 线上单毫秒 119 帧、8-07 单小时 5168 次 `BACKPRESSURE`,聚合出站速率还招来 relay 的 `1013 inbound backpressure` 断连。

本 PR 让被控端把同一会话在一个窗口(120ms)内的连续 `maker:event` 合并成一帧 `maker:event:batch`,到量(64 条 / 256KB)立即 flush。**度量**:100 条事件的洪峰从 100 帧压到 2 帧,事件一条不丢。

兼容性靠能力协商:被控端只对声明 `maker-event-batch-v1` 的控制端发批,未声明者照旧逐帧,旧控制端永远收不到这个 channel。

### 变更类型

- [x] `feat` 新功能
- [x] `perf` 性能优化

### 范围

- 关联 Issue / 需求:无(2026-08-08 生产日志驱动,事故分析见 #2167 评论区)
- 本 PR 包含:`packages/device-link`(capability 常量、batch channel 与 payload 契约 + 解析、#2167 可驱逐档登记)、`apps/desktop` dispatch(per-(控制端, sessionId) 微批 stage 与全套清理钩子)、`apps/mobile`(能力声明 + 拆包)、13 + 2 例新测试
- 本 PR 已覆盖两类控制端:mobile 与 **desktop-as-controller**(桌面控制桌面同样收批;拆包在 main 完成,renderer 的多个 onRemotePush 订阅者零改动)。只要有一个控制端不支持,被控端就得为它保留逐帧流、聚合出站速率照旧能招来 1013 并连带踢掉已启用微批的手机 —— 所以能力必须两端都补齐(review P1)。
- 明确不包含:**relay 协议与 `cindy-protocol`**——隧道 push payload 对 relay 不透明(与 reliable-transport wrapper 同性质),无需升级 submodule 或服务端;`topics.ts` 路由表(批复用既有 session-scoped 兜底分支);push allowlist(批是发送侧构造的帧,不经 broadcast tap);离线队列(`offlinePushQueue` 仍逐条,批只服务 live 目标);其它 push channel 的转发行为
- 用户可见变化:无功能变化。手机端远程观看长思考会话时,弱网下的实时性提升(帧数骤降 → 不再触发窗口拥塞与 relay 背压);理论上单条事件的到达延迟最多增加一个窗口(120ms),对流式文本的观感无影响(mobile 侧本来就有增量合批渲染)
- 是否存在 breaking change:无

### UI 变化

不涉及:传输层与 main 进程行为,无界面、交互或文案改动。

- 引用的设计规范:不涉及——命中的 `apps/mobile/src/session/remoteSessionStore.ts` 只是 push 分派的数据层拆包(批帧拆成逐条走既有 `maker:event` 路径),无视觉、交互或文案变化;渲染与展示逻辑零改动。

## 多端适配(SSH 远程 / 设备互联 / 手机版)

1. **workdir / agent 进程 / 会话数据**:不涉及执行位置变化。
2. **IPC channel 与推送事件**:新增 push channel `maker:event:batch`,但它**不经 broadcast-tap 转发链路**(不是本机广播事件,而是 forwardPush 在发送侧构造的聚合帧),因此不需要登记 `PUSH_FORWARD_ALLOWLIST`;被控端 invoke allowlist 无变化。topic 路由复用既有 session-scoped 判据,已加断言锁定。
3. **手机版适配**:本 PR 内一并完成——`DeviceLinkContext` 声明能力(link-open 与 subscribe 两处共用同一份常量,避免漏一处导致降级),`remoteSessionStore` 拆包后逐条走与逐帧**共用的唯一实现**。

## 故障半径三问(device-link 恢复路径)

1. **触发条件层级**:本 PR 不是恢复路径改动,而是**常态发送路径**的整流。它针对的是第四层(relay 聚合背压)的成因——出站帧数本身。
2. **恢复动作层级**:不新增任何恢复动作。批在背压/离线时保留事件并按既有 250ms 节奏退避重试(与 #1401 activity staging 同款,不新造节奏);缓冲上限 512 条,溢出丢最旧并 WARN(自相似有损流,与 #2167 的可驱逐判据同源)。
3. **多 peer 拓扑**:批 stage 按 dst 隔离,新增用例覆盖「新旧控制端共存,各走各的路径互不影响」;清理钩子逐一对齐 activity staging 的既有 6 处(退订 `session:<id>` 丢该会话批、link-close、控制端离线、撤权、teardown、reset),其中退订是 per-session 精确丢弃而非清整个 stage。

### 一处必须点名的交互不变量

批 channel 与 `maker:event` **必须同属** #2167 的 `COALESCIBLE_PUSH_CHANNELS`(可驱逐档):它只是同一事件流的聚合体,漏登记会让启用微批的控制端在拥塞时退回逐帧 BACKPRESSURE 风暴——正是本 PR 要消除的那一个。已加断言从 `client.ts` 判据正本反查,防后续演进漏改。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/device-link/__tests__/dispatchMakerEventBatch.test.ts
结果:13 passed（能力协商 3 / 无损保序 3 / 到量即发 1 / 生命周期与背压 4 / #2167 一致性 1 / 帧数削减度量 1）

pnpm --filter desktop exec vitest run src/main/device-link/
结果:30 files, 553 passed

pnpm --filter mobile exec vitest run src/__tests__/remoteSessionStore.test.ts
结果:126 passed（含新增拆包 2 例:与逐帧结果逐字段一致 / 坏帧与批内坏条目容错）

cd packages/device-link && vitest run
结果:6 files, 175 passed

pnpm --filter desktop typecheck / pnpm --filter mobile typecheck
结果:均 exit 0

bash run-unit-gate.sh（根 pnpm test:unit 门禁）
结果:GATE_EXIT=0

pnpm check:dco
结果:通过
```

### 手工验证

未执行实机远程联调。行为由单测覆盖(含与逐帧路径的等价性断言);上线后可用桌面日志里 `maker:event` 相关 `BACKPRESSURE` 计数与 `reliable transport buffer is full` 频次核对削减效果。

### 未执行的验证

- 真实手机 ↔ 桌面长思考会话的实机观察(需要生产级事件洪峰);
- 旧版手机客户端 ↔ 新桌面的实机兼容确认(逻辑上旧端不声明能力即完全走原路径,已有用例覆盖,但未实机跑过);
- Windows 根门禁(本地 macOS,CI 兜底)。

## 风险

### 风险分类

- [x] 协议兼容(新增 push channel 与 capability,**不涉及 relay/submodule**)
- [x] 其他:发送路径整流

### 影响与回滚

- 影响范围:仅「声明了微批能力的控制端 + `maker:event` + 能算出 sessionId」这一条路径;其它 channel、其它控制端、离线队列零变化。最坏情形是批帧在某个控制端解析失败——mobile 侧对形状不符整帧忽略(有用例),表现为该会话实时流缺失,由既有 resync / 重新订阅补偿,与旧语义下丢帧的后果同级。
- **显式接受的代价(review 同族第 3 次的收敛结论,已写进代码注释)**:窗口正好跨在断线时刻上的那 ≤120ms 事件不进可靠 pending。逐帧世界里它们在产生瞬间就被 `sendPush` 收进 pending,而 pending 跨连接世代保留(`resetLinkStateForReconnect`),link 重建后按原 seq 重放;批世界里它们还在窗口内,flush 撞上 `NOT_CONNECTED` 即丢。不为它引机制的三条理由:①那批 pending 也不一定活下来——`replayPending` 前会先丢掉队头连续的可丢弃前缀,而长思考期间队头恰恰是 push,常见形态下逐帧世界同样一条不剩;②净账是赚的——pending 窗口是 64 **条消息**,批把 64 条事件压进一条,同窗口可恢复的历史深度提高到 64×64,断线时能恢复的事件量是逐帧世界的几十倍,代价只是尾部 ≤120ms;③唯一补法(离线保留批到重连收口)会把「缓冲跨越发送失败继续存在」请回来,那是四轮顺序 bug 的同一根因,且离线可能持续几分钟、保留必须配上限与淘汰策略——属于新机制。push 的恢复语义一直是重连后 resync 补偿(#1375),不是逐帧重放。
- 回滚 / 降级方式:单 commit,`git revert` 完整回退;无持久化状态、无 migration。降级也可只回退 mobile 的能力声明一行——被控端立即退回逐帧,无需改被控端。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名(`git commit -s`,见 [DCO](../DCO))
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节(不涉及 UI 则跳过)
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档(wire 契约与不变量写在 `topics.ts` / `dispatch.ts` 注释;故障半径第四层已在 #2185 写入 `remote-and-mobile-adaptation.md`)
- [x] 已确认测试结果或说明未执行原因



