### PR TITLE
fix(desktop): align Auto-review timeouts

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/autoPermissionReviewer.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/autoPermissionReviewer.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { AutoReviewRequest } from '@cindy/maker-core';
+import {
+  DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY,
+  type AutoReviewRequest,
+} from '@cindy/maker-core';
 
 import {
   buildAutoPermissionReviewPrompt,
@@ -193,12 +196,29 @@ describe('createAutoPermissionReviewer', () => {
     });
 
     const pending = reviewer(request());
-    await vi.advanceTimersByTimeAsync(8_000);
+    await vi.advanceTimersByTimeAsync(DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY.requestTimeoutMs);
 
     await expect(pending).resolves.toBeNull();
     expect(logger.warn).toHaveBeenCalledWith(
       'auto permission reviewer timed out',
-      expect.objectContaining({ durationMs: 8_000 }),
+      expect.objectContaining({ durationMs: DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY.requestTimeoutMs }),
     );
+  });
+
+  it('accepts a response after the legacy eight-second limit but before the shared deadline', async () => {
+    vi.useFakeTimers();
+    let resolveRequest: ((value: string | null) => void) | undefined;
+    const reviewer = createAutoPermissionReviewer({
+      requestText: vi.fn(() => new Promise<string | null>((resolve) => {
+        resolveRequest = resolve;
+      })),
+      logger: { debug: vi.fn(), warn: vi.fn() },
+    });
+
+    const pending = reviewer(request());
+    await vi.advanceTimersByTimeAsync(8_001);
+    resolveRequest?.('{"verdict":"allow","reason":"Routine test"}');
+
+    await expect(pending).resolves.toEqual({ verdict: 'allow', reason: 'Routine test' });
   });
 });

--- a/apps/desktop/src/main/maker-host/auto-permission-reviewer.ts
+++ b/apps/desktop/src/main/maker-host/auto-permission-reviewer.ts
@@ -1,6 +1,8 @@
 import {
   getAutoReviewActionTextLength,
   MAX_AUTO_REVIEW_ACTION_TEXT_CHARS,
+  DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY,
+  type AutoReviewTimeoutPolicy,
   type AutoReviewDecision,
   type AutoReviewRequest,
 } from '@cindy/maker-core';
@@ -20,7 +22,6 @@ const MAX_REVIEW_OUTPUT_CHARS = 1_024;
 const MAX_USER_INTENT_CHARS = 2_000;
 const MAX_WORKSPACE_ROOTS = 8;
 const MAX_WORKSPACE_ROOT_CHARS = 512;
-const REVIEW_TIMEOUT_MS = 8_000;
 const REVIEW_TIMEOUT = Symbol('auto-review-timeout');
 
 function compactText(value: string, maxChars: number): string {
@@ -119,6 +120,7 @@ export function parseAutoPermissionReviewDecision(text: string): AutoReviewDecis
 
 export function createAutoPermissionReviewer(
   deps: AutoPermissionReviewerDeps,
+  timeoutPolicy: Readonly<AutoReviewTimeoutPolicy> = DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY,
 ): (request: AutoReviewRequest) => Promise<AutoReviewDecision | null> {
   return async (request) => {
     const actionTextChars = getAutoReviewActionTextLength(request.action);
@@ -139,7 +141,7 @@ export function createAutoPermissionReviewer(
       const text = await Promise.race([
         deps.requestText(request, buildAutoPermissionReviewPrompt(request)),
         new Promise<typeof REVIEW_TIMEOUT>((resolve) => {
-          timeout = setTimeout(() => resolve(REVIEW_TIMEOUT), REVIEW_TIMEOUT_MS);
+          timeout = setTimeout(() => resolve(REVIEW_TIMEOUT), timeoutPolicy.requestTimeoutMs);
         }),
       ]);
       if (text === REVIEW_TIMEOUT) {

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -14,6 +14,7 @@ import {
   Maker,
   ClaudeCodeAgent,
   CodexAgent,
+  DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY,
   configureDefaultImageResizer,
   type McpProvider,
 } from '@cindy/maker-core';
@@ -230,7 +231,7 @@ const reviewAutoPermissionAction = createAutoPermissionReviewer({
       agentKind: request.agentKind,
       model: request.model,
       maxTokens: 384,
-      timeoutMs: 8_000,
+      timeoutMs: DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY.requestTimeoutMs,
       reasoningEffort: 'low',
     });
     return result.ok ? result.text : null;

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -66,12 +66,14 @@ export {
 export { isNetworkishErrorMessage } from './shared/network-error.js';
 export {
   AUTO_REVIEW_UNAVAILABLE_CODE,
+  DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY,
   getAutoReviewActionTextLength,
   isAutoReviewUnavailableNotice,
   MAX_AUTO_REVIEW_ACTION_TEXT_CHARS,
   type AutoReviewDecision,
   type AutoReviewDelegate,
   type AutoReviewRequest,
+  type AutoReviewTimeoutPolicy,
 } from './shared/auto-review-decision.js';
 export type { ReviewableAction } from './shared/auto-review.js';
 // host 侧会话分享(导出/导入 .xdtshare)需要按 cwd 复算 CLI 转录目录、

--- a/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AUTO_REVIEW_UNAVAILABLE_CODE,
+  DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY,
   classifyLocalAutoReviewTier,
   isAutoReviewUnavailableNotice,
   composeAutoReviewIntentWithApprovedPlan,
@@ -169,7 +170,7 @@ describe('resolveAutoReviewDecision', () => {
       async () => new Promise<never>(() => {}),
     );
 
-    await vi.advanceTimersByTimeAsync(8_000);
+    await vi.advanceTimersByTimeAsync(DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY.delegateTimeoutMs);
 
     await expect(pending).resolves.toMatchObject({
       verdict: 'block',
@@ -207,8 +208,23 @@ describe('resolveAutoReviewDecision', () => {
     it('flags a reviewer timeout as unavailable', async () => {
       vi.useFakeTimers();
       const pending = resolveAutoReviewDecision(gray, async () => new Promise<never>(() => {}));
-      await vi.advanceTimersByTimeAsync(8_000);
+      await vi.advanceTimersByTimeAsync(DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY.delegateTimeoutMs);
       await expect(pending).resolves.toMatchObject({ verdict: 'block', unavailable: true });
+    });
+
+    it('allows a valid delegate response after eight seconds but before the shared outer deadline', async () => {
+      vi.useFakeTimers();
+      let resolveDelegate: ((value: { verdict: 'allow' }) => void) | undefined;
+      const pending = resolveAutoReviewDecision(
+        gray,
+        async () => new Promise<{ verdict: 'allow' }>((resolve) => {
+          resolveDelegate = resolve;
+        }),
+      );
+      await vi.advanceTimersByTimeAsync(8_001);
+      resolveDelegate?.({ verdict: 'allow' });
+
+      await expect(pending).resolves.toEqual({ verdict: 'allow' });
     });
 
     it('does NOT flag a model block — that one stays silent by design', async () => {

--- a/packages/maker-core/src/agents/shared/auto-review-decision.ts
+++ b/packages/maker-core/src/agents/shared/auto-review-decision.ts
@@ -104,7 +104,20 @@ export type AutoReviewDelegate = (
 
 export const MAX_AUTO_REVIEW_ACTION_TEXT_CHARS = 4_096;
 const MAX_AUTO_REVIEW_REASON_CHARS = 240;
-const AUTO_REVIEW_DELEGATE_TIMEOUT_MS = 8_000;
+/**
+ * Auto-review is deliberately bounded: a reviewer outage must still deny a
+ * gray action. Keep the host request deadline below the core guard so a valid
+ * answer at the request deadline can return before the outer guard fires.
+ */
+export interface AutoReviewTimeoutPolicy {
+  requestTimeoutMs: number;
+  delegateTimeoutMs: number;
+}
+
+export const DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY: Readonly<AutoReviewTimeoutPolicy> = Object.freeze({
+  requestTimeoutMs: 12_000,
+  delegateTimeoutMs: 13_000,
+});
 const AUTO_REVIEW_TIMEOUT = Symbol('auto-review-timeout');
 
 export function getAutoReviewActionTextLength(action: ReviewableAction): number {
@@ -213,7 +226,7 @@ export async function resolveAutoReviewDecision(
       new Promise<typeof AUTO_REVIEW_TIMEOUT>((resolve) => {
         timeout = setTimeout(
           () => resolve(AUTO_REVIEW_TIMEOUT),
-          AUTO_REVIEW_DELEGATE_TIMEOUT_MS,
+          DEFAULT_AUTO_REVIEW_TIMEOUT_POLICY.delegateTimeoutMs,
         );
       }),
     ]);


### PR DESCRIPTION
## 这次改了什么

把 Auto-review 的三层超时收敛到同一份策略：utility 请求与 Desktop reviewer 为 12 秒，maker-core 保留 13 秒的 fail-closed 兜底。这样合法审阅结果不会再被旧的 8 秒边界竞态提前拒绝；未完成、异常或非法结果仍拒绝，不改变 provider/model 路由。

## 怎么验证的

- 根目录完整单测通过。
- Desktop typecheck 通过。
- Desktop reviewer 回归测试通过。
- maker-core 自动审阅决策回归测试通过。
- 新增用例验证：结果在旧 8 秒后、最终期限前返回时仍会被接受；最终超时仍返回 unavailable block。

## 风险

只有需要模型审阅的灰区动作，最长等待时间从 8 秒增加到 12 秒；明确本地 allow/ask 路径不受影响。审阅器超时、异常、空响应或非法输出仍 fail-closed，不会扩大自动权限。