### PR TITLE
fix(desktop): 恢复 Git 市场插件头像

### DIFF
--- a/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
+++ b/apps/desktop/src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
@@ -249,12 +249,31 @@ describe('ghostPluginViewModel', () => {
     ]);
   });
 
-  it('treats a market null icon as an explicit presentation override', () => {
+  it('treats a server market null icon as an explicit presentation override', () => {
     const ghost = installed({ iconDataUrl: 'data:image/png;base64,OLD' });
     const presentation = marketPresentationForInstalledGhost(ghost, marketItem({ icon: null }));
 
     expect(presentation).not.toBeNull();
     expect(toGhostPluginListItem(ghost, presentation)).not.toHaveProperty('iconDataUrl');
+  });
+
+  it('uses the installed package icon for an exact Git market mapping', () => {
+    const ghost = installed({ iconDataUrl: 'data:image/png;base64,LOCAL' });
+    const presentation = marketPresentationForInstalledGhost(
+      ghost,
+      marketItem({
+        sourceType: 'git-market',
+        sourceMarketName: 'community-plugins',
+        icon: null,
+      }),
+    );
+
+    expect(toGhostPluginListItem(ghost, presentation)).toMatchObject({
+      iconDataUrl: 'data:image/png;base64,LOCAL',
+    });
+    expect(toGhostPluginDetail(ghost, presentation)).toMatchObject({
+      iconDataUrl: 'data:image/png;base64,LOCAL',
+    });
   });
 
   it.each([

--- a/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
+++ b/apps/desktop/src/renderer/features/plugin/lib/ghostPluginViewModel.ts
@@ -73,8 +73,8 @@ export interface GhostPluginDetail extends GhostPluginListItem {
 /**
  * 展示投影只覆盖用户能看到的四个字段；运行时仍完全来自本地安装包。
  *
- * `iconDataUrl` 是有意要求存在的字段：市场项的 `icon: null` 也必须覆盖本地
- * 包图标，而不是因为缺少 URL 又显示旧图标。
+ * `iconDataUrl` 是有意要求存在的字段：服务端市场项的 `icon: null` 仍覆盖本地
+ * 包图标。Git 市场是窄例外：精确匹配到已安装版本时，可复用安装包里已验证的图标。
  */
 export interface GhostPluginMarketPresentation {
   name: string;
@@ -89,11 +89,18 @@ export interface GhostPluginMarketPresentation {
  * market item, or a pending version update must keep using its local manifest.
  */
 export function marketPresentationForInstalledGhost(
-  ghost: Pick<InstalledGhost, 'manifest'>,
+  ghost: Pick<InstalledGhost, 'manifest' | 'iconDataUrl'>,
   marketItem:
     | Pick<
         PluginMarketItem,
-        'ghostId' | 'installState' | 'version' | 'name' | 'description' | 'author' | 'icon'
+        | 'ghostId'
+        | 'installState'
+        | 'version'
+        | 'name'
+        | 'description'
+        | 'author'
+        | 'icon'
+        | 'sourceType'
       >
     | null
     | undefined,
@@ -110,7 +117,10 @@ export function marketPresentationForInstalledGhost(
     name: marketItem.name,
     description: marketItem.description ?? '',
     author: marketItem.author,
-    iconDataUrl: marketItem.icon?.url,
+    iconDataUrl:
+      marketItem.sourceType === 'git-market' && !marketItem.icon
+        ? ghost.iconDataUrl
+        : marketItem.icon?.url,
   };
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复从 Git marketplace 安装的第三方插件在插件列表和已安装详情页丢失头像的问题。

Composer 已经直接使用安装包中的 `InstalledGhost.iconDataUrl`，所以头像正常；插件页在精确匹配市场版本后会改用市场展示投影，而 Git 市场当前没有远程图标 URL，导致本地头像被清空。本 PR 只在“Git 市场 + 插件 ID/安装状态/版本精确匹配”时复用已安装包中已经验证并读取好的头像。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Refs #1387（仅插件图标部分）
- 本 PR 包含：已安装 Git 市场插件的头像展示映射，以及列表/详情共用回归测试
- 明确不包含：未安装市场插件图标、本地图标 IPC、文件读取、缓存/重试/批处理、Local folder marketplace、Ghost Skill 命名、registry 或 harness 调整
- 用户可见变化：从 Git 市场安装的插件在插件列表和已安装详情页显示与 Composer 相同的包内头像
- 找不到精确映射或包内没有头像时：继续使用现在的占位图，不新增错误或加载状态
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及；只修复现有图标数据映射，不修改布局、样式、交互或文案

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
结果：27 tests passed

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/features/plugin/lib/ghostPluginViewModel.ts src/renderer/cindy-brain/__tests__/ghostPluginViewModel.test.ts
结果：通过

pnpm test:unit
结果：全部 workspace 通过

pnpm check:dco
结果：通过
```

### 手工验证

未执行 Electron 手工验证；本次只改变纯 view-model 映射，列表和详情由同一回归测试覆盖。

### 未执行的验证

未启动 Electron；未修改 Main、preload、IPC、文件系统或运行时链路。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Renderer 的已装插件展示投影；运行时、安装状态、批准状态、manifest、安装目录与包格式均不变
- 存量插件影响：无。无需迁移或用户操作；没有新增持久状态或校验规则
- 作者手册：无需同步；不涉及插件作者契约
- 回滚 / 降级方式：回滚本提交即可恢复原有占位图行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明不涉及的理由
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要回归测试
- [x] 已确认测试结果
