### PR TITLE
fix(brain): Codex 图像通道 host 模型按账号模型清单动态选型,替代硬编码 gpt-5.5

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -503,6 +503,7 @@ import {
   getChatgptBridgeAuth,
   invalidateChatgptBridgeAuth,
 } from './maker-host/anthropic-responses-bridge-host.js';
+import { resolveCodexImageHostModel } from './maker-host/codex-model-discovery.js';
 import {
   readSilentEncryptedRetrySettingsState,
   resetSilentEncryptedRetrySettings,
@@ -1392,6 +1393,7 @@ registerLayoutIpc();
 setCodexImageAuthBinding({
   getAuth: getChatgptBridgeAuth,
   onAuthFailure: invalidateChatgptBridgeAuth,
+  getHostModel: resolveCodexImageHostModel,
 });
 registerGhostIpc();
 registerPluginMarketIpc();

--- a/apps/desktop/src/main/cindy-brain/__tests__/codexImageClient.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/codexImageClient.test.ts
@@ -12,6 +12,7 @@ function makeChannel(
   fetchImplementation: typeof fetch,
   beforeDispatch?: (model: string) => void,
   onAuthFailure?: Parameters<typeof createCodexImageChannel>[0]['onAuthFailure'],
+  getHostModel?: Parameters<typeof createCodexImageChannel>[0]['getHostModel'],
 ) {
   return createCodexImageChannel({
     hasOAuthLogin: () => true,
@@ -19,6 +20,7 @@ function makeChannel(
     fetchImplementation,
     beforeDispatch,
     onAuthFailure,
+    getHostModel,
   });
 }
 
@@ -44,9 +46,12 @@ describe('codexImageClient', () => {
     expect(String(url)).toBe('https://chatgpt.com/backend-api/codex/responses');
     expect((init?.headers as Record<string, string>)['ChatGPT-Account-Id']).toBe('account-id');
     const body = JSON.parse(String(init?.body)) as {
+      model: string;
       tools: Array<Record<string, unknown>>;
       tool_choice?: unknown;
     };
+    // 未提供账号解析时 host 模型保持静态兜底。
+    expect(body.model).toBe('gpt-5.5');
     expect(body.tools).toContainEqual(
       expect.objectContaining({
         type: 'image_generation',
@@ -176,5 +181,39 @@ describe('codexImageClient', () => {
     await expect(empty.generateImage({ model: 'openai/gpt-image-2', prompt: 'p' })).rejects.toThrow(
       '没有图片',
     );
+  });
+
+  it('host 模型采用账号解析结果(订阅计划不含静态兜底模型时不再被上游拒绝)', async () => {
+    const doFetch = vi.fn<typeof fetch>(async () =>
+      sseResponse([{ type: 'image_generation_call', result: 'aW1hZ2U=' }]),
+    );
+    const channel = makeChannel(doFetch, undefined, undefined, async () => 'gpt-5.6-luna');
+    await channel.generateImage({ model: 'openai/gpt-image-2', prompt: 'p' });
+    const body = JSON.parse(String(doFetch.mock.calls[0]?.[1]?.body)) as { model: string };
+    expect(body.model).toBe('gpt-5.6-luna');
+  });
+
+  it('host 模型解析抛错 / 返回空白时退回静态兜底,不挡住出图', async () => {
+    const throwingFetch = vi.fn<typeof fetch>(async () =>
+      sseResponse([{ type: 'image_generation_call', result: 'aW1hZ2U=' }]),
+    );
+    const throwing = makeChannel(throwingFetch, undefined, undefined, async () => {
+      throw new Error('models cache missing');
+    });
+    await expect(
+      throwing.generateImage({ model: 'openai/gpt-image-2', prompt: 'p' }),
+    ).resolves.toMatchObject({ data: [{ b64_json: 'aW1hZ2U=' }] });
+    expect(
+      (JSON.parse(String(throwingFetch.mock.calls[0]?.[1]?.body)) as { model: string }).model,
+    ).toBe('gpt-5.5');
+
+    const blankFetch = vi.fn<typeof fetch>(async () =>
+      sseResponse([{ type: 'image_generation_call', result: 'aW1hZ2U=' }]),
+    );
+    const blank = makeChannel(blankFetch, undefined, undefined, async () => '   ');
+    await blank.generateImage({ model: 'openai/gpt-image-2', prompt: 'p' });
+    expect(
+      (JSON.parse(String(blankFetch.mock.calls[0]?.[1]?.body)) as { model: string }).model,
+    ).toBe('gpt-5.5');
   });
 });

--- a/apps/desktop/src/main/cindy-brain/codexImageAuthBinding.ts
+++ b/apps/desktop/src/main/cindy-brain/codexImageAuthBinding.ts
@@ -14,6 +14,11 @@ export interface CodexImageAuthBinding {
     body: string;
     failedAccessToken: string;
   }): unknown | Promise<unknown>;
+  /**
+   * Best-effort 解析当前账号可用的 Codex Responses host 模型(按账号模型清单派生)。
+   * 返回 null 或抛错都让通道侧退回静态兜底模型——解析失败绝不能挡住出图。
+   */
+  getHostModel?(): Promise<string | null>;
 }
 
 let binding: CodexImageAuthBinding | null = null;

--- a/apps/desktop/src/main/cindy-brain/codexImageClient.ts
+++ b/apps/desktop/src/main/cindy-brain/codexImageClient.ts
@@ -14,7 +14,12 @@ import { sniffMediaMime } from '../cindy-media/sniffMediaMime.js';
 import { createLogger } from '../logger.js';
 
 const CODEX_RESPONSES_URL = 'https://chatgpt.com/backend-api/codex/responses';
-const HOST_MODEL = 'gpt-5.5';
+/**
+ * 静态兜底 host 模型:Codex Responses 需要一个 host 模型来编排 hosted image_generation
+ * tool。账号订阅计划不含该模型时上游会直接拒绝请求,因此 generate() 优先采用
+ * getHostModel 按账号模型清单解析出的模型;解析失败才退回这里。
+ */
+const DEFAULT_HOST_MODEL = 'gpt-5.5';
 const IMAGE_MODEL = 'gpt-image-2';
 const USER_AGENT = `codex_cli_rs/cindy (${process.platform}; ${process.arch})`;
 const SSE_EVENT_BOUNDARY = /(?:\r\n|\r|\n){2}/;
@@ -37,6 +42,11 @@ export interface CreateCodexImageChannelOptions {
   }): void | Promise<void>;
   fetchImplementation?: typeof fetch;
   beforeDispatch?(model: string): void;
+  /**
+   * Best-effort 解析当前账号实际可用的 host 模型(订阅计划不含静态兜底模型时,
+   * 硬编码会被上游拒绝)。返回 null / 抛错都安全——通道侧退回静态兜底模型。
+   */
+  getHostModel?(): Promise<string | null>;
 }
 
 function extractImageB64(value: unknown): string | null {
@@ -138,6 +148,22 @@ async function httpError(
 export function createCodexImageChannel(opts: CreateCodexImageChannelOptions): ImageChannel {
   const doFetch = opts.fetchImplementation ?? fetch;
 
+  /**
+   * 本次请求的 host 模型:优先账号模型清单解析结果;解析抛错 / 返回空值退回静态
+   * 兜底——清单缺失不能挡住出图。
+   */
+  async function resolveHostModel(): Promise<string> {
+    try {
+      const candidate = await opts.getHostModel?.();
+      if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+    } catch (err) {
+      log.warn('Codex image host model resolution failed, falling back to default', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+    return DEFAULT_HOST_MODEL;
+  }
+
   async function generate(params: {
     model: string;
     prompt: string;
@@ -150,9 +176,10 @@ export function createCodexImageChannel(opts: CreateCodexImageChannelOptions): I
     // 先在 token 刷新 / 本地参考图读取之前拦停，后面的二次检查继续覆盖
     // 准备请求期间发生的模型停用。
     opts.beforeDispatch?.(params.model);
-    const [auth, images] = await Promise.all([
+    const [auth, images, hostModel] = await Promise.all([
       opts.getAuth(),
       Promise.all((params.imagePaths ?? []).map(inputImage)),
+      resolveHostModel(),
     ]);
     opts.beforeDispatch?.(params.model);
     const content: Array<Record<string, unknown>> = [
@@ -171,7 +198,7 @@ export function createCodexImageChannel(opts: CreateCodexImageChannelOptions): I
         ...(auth.accountId ? { 'ChatGPT-Account-Id': auth.accountId } : {}),
       },
       body: JSON.stringify({
-        model: HOST_MODEL,
+        model: hostModel,
         store: false,
         stream: true,
         instructions: 'Use the image_generation tool to fulfill this image request.',

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -2650,6 +2650,7 @@ function getImageChannelRegistry(): ImageChannelRegistry {
     const codexImagesClient = createCodexImageChannel({
       hasOAuthLogin: hasCodexOAuthLoginReadOnly,
       getAuth: () => getCodexImageAuthBinding().getAuth(),
+      getHostModel: () => getCodexImageAuthBinding().getHostModel?.() ?? Promise.resolve(null),
       onAuthFailure: async (failure) => {
         await getCodexImageAuthBinding().onAuthFailure(failure);
       },

--- a/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/codexModelDiscovery.test.ts
@@ -16,8 +16,10 @@ vi.mock('node:fs/promises', () => ({ default: { readFile: vi.fn() } }));
 import {
   mapCodexModelsToCatalog,
   mapCodexAppServerModelsToCatalog,
+  pickCodexImageHostModel,
   readCodexDiscoveredModels,
   readCodexDiscoveredModelsForAuthRefresh,
+  resolveCodexImageHostModel,
 } from '../codex-model-discovery.js';
 
 // 取自本机 ~/.codex/models_cache.json 的真实结构(裁剪到关键字段)。
@@ -276,5 +278,38 @@ describe('readCodexDiscoveredModelsForAuthRefresh', () => {
     await expect(
       readCodexDiscoveredModelsForAuthRefresh(vi.fn().mockResolvedValue(discovered)),
     ).resolves.toBe(discovered);
+  });
+});
+
+describe('pickCodexImageHostModel', () => {
+  it('账号清单含首选模型时原样保留(存量账号零行为变化)', () => {
+    expect(pickCodexImageHostModel(mapCodexModelsToCatalog(SAMPLE))).toBe('gpt-5.5');
+  });
+
+  it('账号无首选模型时取上游 priority 最小的旗舰(计划内没有 gpt-5.5 也能出图)', () => {
+    const without55 = { models: SAMPLE.models.filter((m) => m.slug !== 'gpt-5.5') };
+    expect(pickCodexImageHostModel(mapCodexModelsToCatalog(without55))).toBe('gpt-5.6');
+  });
+
+  it('空清单返回 null,让通道侧保留静态兜底', () => {
+    expect(pickCodexImageHostModel([])).toBeNull();
+  });
+});
+
+describe('resolveCodexImageHostModel', () => {
+  beforeEach(() => {
+    vi.mocked(fsp.readFile).mockReset();
+  });
+
+  it('从账号 cache 派生 host 模型;cache 不可读时返回 null 交通道兜底', async () => {
+    vi.mocked(fsp.readFile)
+      .mockResolvedValueOnce(OAUTH_AUTH)
+      .mockResolvedValueOnce(JSON.stringify(SAMPLE));
+    await expect(resolveCodexImageHostModel()).resolves.toBe('gpt-5.5');
+
+    vi.mocked(fsp.readFile)
+      .mockResolvedValueOnce(OAUTH_AUTH)
+      .mockRejectedValueOnce(new Error('missing'));
+    await expect(resolveCodexImageHostModel()).resolves.toBeNull();
   });
 });

--- a/apps/desktop/src/main/maker-host/codex-model-discovery.ts
+++ b/apps/desktop/src/main/maker-host/codex-model-discovery.ts
@@ -272,3 +272,34 @@ export async function readCodexDiscoveredModelsForAuthRefresh(
     return [];
   }
 }
+
+/** Codex 图像通道的静态兜底 host 模型;与 cindy-brain codexImageClient 的兜底保持一致。 */
+const CODEX_IMAGE_HOST_PREFERRED_MODEL = 'gpt-5.5';
+
+/**
+ * Codex 图像通道 host 模型选型(纯函数)。
+ *
+ * Codex Responses 面需要一个「host 模型」编排 hosted image_generation tool,而订阅
+ * 计划不保证包含任意指定 host 模型(计划内没有时上游直接拒答)。策略:首选模型在
+ * 账号清单内就原样保留(存量账号零行为变化);否则取上游 priority 数值最小的模型
+ * (最接近账号默认选择的旗舰)。空清单返回 null,让通道侧保留静态兜底。
+ */
+export function pickCodexImageHostModel(
+  models: readonly CatalogModel[],
+  preferred: string = CODEX_IMAGE_HOST_PREFERRED_MODEL,
+): string | null {
+  if (models.length === 0) return null;
+  if (models.some((m) => m.id === preferred)) return preferred;
+  const order = (m: CatalogModel) => m.sortOrder ?? Number.MAX_SAFE_INTEGER;
+  return [...models].sort((a, b) => order(a) - order(b))[0]?.id ?? null;
+}
+
+/**
+ * 从账号模型 cache 派生 Codex 图像通道的 host 模型。
+ * cache 读不到 / OAuth 未激活 / 清单为空 → null,通道侧退回静态兜底模型,不挡出图。
+ */
+export async function resolveCodexImageHostModel(): Promise<string | null> {
+  const models = await readCodexDiscoveredModels();
+  if (!models) return null;
+  return pickCodexImageHostModel(models);
+}


### PR DESCRIPTION
## 问题

ChatGPT 订阅 OAuth 出图通道（`cindy-brain/codexImageClient.ts`）把 Codex Responses 请求的 host 模型硬编码为 `gpt-5.5`。host 模型负责编排 hosted `image_generation` tool，而订阅计划并不保证包含任意指定模型——计划里没有 gpt-5.5 的账号，这条免 API key 的出图兜底通道会被上游直接拒绝，出图彻底不可用（与 #640 同域）。

macOS 0.1.36 上已实测：该 OAuth 通道端到端可用（证据见 #640 评论区），唯一残留缺陷即此硬编码。

## 改动

- `codexImageClient` 新增可选 `getHostModel`：派发时优先采用按账号模型清单解析出的 host 模型；解析抛错 / 返回空值退回静态兜底 `gpt-5.5`——清单缺失绝不挡住出图。
- `maker-host/codex-model-discovery` 新增纯函数选型 `pickCodexImageHostModel`（首选模型在账号清单内原样保留，存量账号零行为变化；否则取上游 priority 最小的旗舰模型）与 `resolveCodexImageHostModel`。
- 经既有静态装配 seam（`codexImageAuthBinding`）在 `bootstrap-electron` 接线，不引入 cindy-brain → maker-host 运行期依赖（不产生延迟 chunk）。

## 验证

- 通道采用/兜底语义（解析值生效、抛错/空白退回兜底、默认仍为 gpt-5.5）与选型逻辑（首选保留/缺首选取旗舰/空清单 null）新增单测，相关 31 项全过。
- `tsc --noEmit` 全量干净。

相关：#640

🤖 Generated with [Claude Code](https://claude.com/claude-code)
