### PR TITLE
fix(claude): resume thinking-only silent turns

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/abort-stops-background-tasks.test.ts
@@ -1556,6 +1556,36 @@ describe('ClaudeCodeAgent abort stops background wake tasks', () => {
     await handle.close().catch(() => undefined);
   });
 
+  it('fresh Query does not inherit a thinking-only marker from the aborted turn', async () => {
+    const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
+
+    await handle.send({ type: 'user', content: 'turn that will abort before result' });
+    stream.emit({
+      type: 'assistant',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'thinking', thinking: 'still working', signature: 'sig-stale' }],
+      },
+    });
+    stream.emit(taskStarted('task-unconfirmed', 'local_agent'));
+    await waitFor(() => taskEvents(events).length >= 1, 'wake task observed');
+
+    fakeQuery.stopTask!.mockRejectedValueOnce(new Error('remote stop rejected'));
+    await handle.abort();
+    await waitFor(() => events.filter(isProductTerminal).length === 1, 'synthetic foreground terminal observed');
+
+    await handle.send({ type: 'user', content: 'fresh result-only turn' });
+    expect(fakeQueries).toHaveLength(2);
+    stream.emit(turnResult(''));
+    await waitFor(() => events.filter((event) => event.type === 'done').length >= 2, 'fresh done observed');
+
+    const freshDone = events.filter((event) => event.type === 'done').at(-1);
+    expect((freshDone?.data as { silentStop?: boolean } | undefined)?.silentStop).toBeUndefined();
+
+    stream.end();
+    await handle.close().catch(() => undefined);
+  });
+
   it('Stop rebuild waits for an in-flight remote Query close before creating the replacement', async () => {
     const { handle, stream, events, fakeQuery, fakeQueries } = await startSessionWithStream();
     const closeDeferred = createDeferred<void>();

--- a/packages/maker-core/src/agents/claude-code/__tests__/translator-silent-stop.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/translator-silent-stop.test.ts
@@ -103,7 +103,11 @@ describe('Claude Code translator silent-stop observation (log only)', () => {
     const ctx = createCtx(tracker);
 
     pushToolUseMessage(queue, ctx);
-    pushEmptyThinkingMessage(queue, ctx);
+    translateSdkMessage(
+      { type: 'assistant', message: { content: [{ type: 'thinking', thinking: '继续分析中', signature: 'sig-2' }] } },
+      queue,
+      ctx,
+    );
     translateSdkMessage(
       { type: 'result', total_cost_usd: 0.1, usage: NON_EMPTY_USAGE },
       queue,
@@ -210,7 +214,7 @@ describe('Claude Code translator silent-stop observation (log only)', () => {
     expect(silentStopWarned(ctx)).toBe(false);
   });
 
-  it('does NOT log on a zero-tool turn (plain exchange, not a mid-task stall)', async () => {
+  it('marks a zero-tool thinking-only turn as a silent stop', async () => {
     const tracker = new UsageTracker();
     const queue = createAsyncQueue<AgentEvent>();
     const ctx = createCtx(tracker);
@@ -227,8 +231,106 @@ describe('Claude Code translator silent-stop observation (log only)', () => {
       ctx,
     );
 
-    await drain(queue);
+    const events = await drain(queue);
+    expect(silentStopWarned(ctx)).toBe(true);
+    expect(doneSilentStopFlag(events)).toBe(true);
+  });
+
+  it('marks the thinking-only auto-resume turn after a tool turn also silently stops', async () => {
+    const tracker = new UsageTracker();
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+
+    pushToolUseMessage(queue, ctx);
+    pushEmptyThinkingMessage(queue, ctx);
+    translateSdkMessage(
+      { type: 'result', stop_reason: 'end_turn', total_cost_usd: 0.1, usage: NON_EMPTY_USAGE },
+      queue,
+      ctx,
+    );
+
+    translateSdkMessage(
+      { type: 'stream_event', event: { type: 'message_start', message: { model: 'claude-fable-5', usage: { input_tokens: 2000 } } } },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      { type: 'assistant', message: { content: [{ type: 'thinking', thinking: '续跑后仍在分析', signature: 'sig-2' }] } },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'result',
+        stop_reason: 'end_turn',
+        total_cost_usd: 0.2,
+        usage: { input_tokens: 2000, output_tokens: 4 },
+      },
+      queue,
+      ctx,
+    );
+
+    const events = await drain(queue);
+    const flags = events
+      .filter((event) => event.type === 'done')
+      .map((event) => (event.data as { silentStop?: boolean }).silentStop);
+    expect(flags).toEqual([true, true]);
+  });
+
+  it('does NOT mark a zero-tool turn that already emitted visible text before trailing thinking', async () => {
+    const tracker = new UsageTracker();
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+
+    translateSdkMessage(
+      { type: 'stream_event', event: { type: 'message_start', message: { model: 'claude-fable-5', usage: { input_tokens: 1000 } } } },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      { type: 'assistant', message: { content: [{ type: 'text', text: '先给你结论。' }] } },
+      queue,
+      ctx,
+    );
+    pushEmptyThinkingMessage(queue, ctx);
+    translateSdkMessage(
+      { type: 'result', stop_reason: 'end_turn', total_cost_usd: 0.1, usage: NON_EMPTY_USAGE },
+      queue,
+      ctx,
+    );
+
+    const events = await drain(queue);
     expect(silentStopWarned(ctx)).toBe(false);
+    expect(doneSilentStopFlag(events)).toBeUndefined();
+  });
+
+  it('treats unknown assistant blocks as substance instead of auto-resuming them', async () => {
+    const tracker = new UsageTracker();
+    const queue = createAsyncQueue<AgentEvent>();
+    const ctx = createCtx(tracker);
+
+    translateSdkMessage(
+      { type: 'stream_event', event: { type: 'message_start', message: { model: 'claude-fable-5', usage: { input_tokens: 1000 } } } },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      {
+        type: 'assistant',
+        message: { content: [{ type: 'server_tool_use', id: 'server-tool-1', name: 'web_search' }] },
+      },
+      queue,
+      ctx,
+    );
+    translateSdkMessage(
+      { type: 'result', stop_reason: 'end_turn', total_cost_usd: 0.1, usage: NON_EMPTY_USAGE },
+      queue,
+      ctx,
+    );
+
+    const events = await drain(queue);
+    expect(silentStopWarned(ctx)).toBe(false);
+    expect(doneSilentStopFlag(events)).toBeUndefined();
   });
 
   it('does NOT log when result.result repairs the missing tail (truncation fallback already recovers)', async () => {

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1941,7 +1941,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     const runtimeState: RuntimeState = newRuntimeState();
     const beginNewTurn = (): void => {
       // usageTracker.beginTurn() 只清 usage 桶；translator 的 turnState 也要在新 turn
-      // 开始时清掉，避免上一轮 abnormal/abort 没走 result 时污染下一轮 API call 计数。
+      // 开始时清掉，避免上一轮 abnormal/abort 没走 result 时污染下一轮状态。
       usageTracker.beginTurn();
       turnState.text = '';
       turnState.toolUses = 0;
@@ -1951,6 +1951,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       turnState.uiEmittedText = '';
       turnState.pendingApiError = null;
       turnState.lastAssistantRequestId = undefined;
+      turnState.lastAssistantMsgHadSubstance = true;
       // 代际前进: 迟到的被打断 result 据此被 translator 识别为已被本 send 接管。
       turnState.generation += 1;
       // interruptRequested **刻意不在这里清**: watchdog / tool-loop guard 先置

--- a/packages/maker-core/src/agents/claude-code/translator.ts
+++ b/packages/maker-core/src/agents/claude-code/translator.ts
@@ -93,8 +93,8 @@ export interface TurnState {
   /** interrupt 置位时的 generation 快照(见 generation 注释)。 */
   interruptGeneration: number;
   /**
-   * 最近一条 assistant API 消息是否带「实质内容」(非空 text 块或 tool_use 块;
-   * 只有 thinking——包括空 thinking——不算)。逐条 assistant 消息覆盖写,turn end
+   * 最近一条 assistant API 消息是否带「实质内容」(非空 text 或任何非 thinking 块;
+   * thinking / redacted_thinking 不算)。逐条 assistant 消息覆盖写,turn end
    * 时留下的即"最后一条 assistant 消息"的判定,是 silent-stop 观测的核心依据:
    * 上游偶发用一条空内容消息收尾整个 turn(空 thinking + end_turn,或 SSE 流被
    * 静默中断后 stop_reason 缺失;社区同型报告 anthropics/claude-code#50597 /
@@ -986,6 +986,20 @@ function mapTaskUpdatedStatus(status: string | undefined, hasError: boolean): Ag
 
 // ── assistant 子分支 ─────────────────────────────────────────────────────────
 
+/**
+ * 只有不可见的 thinking 块不算 assistant 的实质产出。未知/新增块按有实质内容
+ * 保守处理，避免 SDK 增加 server tool / control block 后被误判成 silent stop。
+ */
+function assistantBlockHasSubstance(block: Record<string, unknown>): boolean {
+  if (block.type === 'text') {
+    return typeof block.text === 'string' && block.text.length > 0;
+  }
+  if (block.type === 'thinking' || block.type === 'redacted_thinking') {
+    return false;
+  }
+  return true;
+}
+
 function handleAssistant(
   msg: { message?: { content?: Array<Record<string, unknown>> }; error?: string },
   queue: EventQueue,
@@ -1048,15 +1062,10 @@ function handleAssistant(
   ctx.rt.lastAssistantMeta = assistantMeta;
 
   const content = msg.message?.content ?? [];
-  // silent-stop 观测素材: 本条消息是否带实质内容(非空 text / tool_use;thinking 不算)。
+  // silent-stop 观测素材: 本条消息是否带实质内容(非空 text / 非 thinking 块)。
+  // 未知块 fail-safe 为有内容，避免 SDK 新 block 被误续跑。
   // 逐条覆盖写, turn end 时留下的就是最后一条 assistant 消息的判定(见 TurnState 字段注释)。
-  ctx.turn.lastAssistantMsgHadSubstance = content.some((blockRaw) => {
-    const block = blockRaw as { type?: string; text?: string };
-    return (
-      (block.type === 'text' && typeof block.text === 'string' && block.text.length > 0) ||
-      block.type === 'tool_use'
-    );
-  });
+  ctx.turn.lastAssistantMsgHadSubstance = content.some(assistantBlockHasSubstance);
   for (const blockRaw of content) {
     const block = blockRaw as { type?: string; text?: string; name?: string; id?: string; input?: unknown; thinking?: string; signature?: string };
     if (block.type === 'text' && typeof block.text === 'string') {
@@ -1627,13 +1636,15 @@ function handleResult(
       source: 'claude-code',
     });
   }
-  // silent-stop 判定: turn 内干过活(有 tool 调用), 但最后一条 assistant 消息没有任何
-  // 实质内容(典型: 只有一个空 thinking 块), result 也没兜出可补的文本 —— 上游把"任务
-  // 进行到一半"的 turn 静默收了尾, 用户侧表现为"干着干着停了、看起来像正常结束"。已知
+  // silent-stop 判定: turn 内干过活(有 tool 调用),或整轮没有任何用户可见正文,且最后
+  // 一条 assistant 消息没有实质内容(典型: 只有 thinking 块),result 也没兜出可补的
+  // 文本 —— 上游把 turn 静默收了尾,用户侧表现为"干着干着停了、看起来像正常结束"。已知
   // 上游形态: 模型偶发 thinking-only 空响应(anthropics/claude-code#50597,
   // stop_reason=end_turn)与 SSE 流被静默中断后 SDK 按正常结束处理(#38905, 此形态
   // stop_reason 常缺失)。与 isEmptyResponseTurn(整轮 0 产出 + usage 全 0)互斥:
-  // 这里要求 toolUses > 0。沿用 turn 收尾同款排除项: is_error(另有 error 收尾)、
+  // 零 tool 但零可见正文也必须命中:第一次自动补发「继续」后,上游可能再次只返回
+  // thinking；旧的 toolUses > 0 守卫会把第二次当正常完成。已有可见正文的零 tool turn
+  // 则不扩张判定。沿用 turn 收尾同款排除项: is_error(另有 error 收尾)、
   // interruptRequested(用户停止/watchdog)、sawCompactBoundary(compact 轮合法空)。
   // 命中后事件流仍走正常 Done/done 收尾(记账/收口零变更), 只在 done.data 附加
   // silentStop 标记交给 host 的自动续跑守卫决策; WARN 日志保留作 dev 排查。
@@ -1642,7 +1653,7 @@ function handleResult(
     !ctx.turn.interruptRequested &&
     !ctx.turn.sawCompactBoundary &&
     !isEmptyResponseTurn &&
-    ctx.turn.toolUses > 0 &&
+    (ctx.turn.toolUses > 0 || ctx.turn.uiEmittedText.length === 0) &&
     !ctx.turn.lastAssistantMsgHadSubstance &&
     fallbackTail.length === 0;
   if (isSilentStopTurn) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Claude Code 偶尔会正常结束一个 turn，却只返回 thinking、没有任何用户可见正文。现有 silent-stop 检测只覆盖本轮调用过工具的情况，因此第一次自动补发“继续”后，如果恢复 turn 再次只 thinking、且没有调用工具，它会被误当成正常完成。

本 PR 将“零工具、零可见正文、最后只有 thinking”的 turn 也标为 silent stop，让现有 host 自动续跑守卫继续接管；同时把未知/新增 assistant block 保守视为有效内容，避免 server tool 或 control block 被误续跑。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Addresses #2096
- 本 PR 包含：Claude translator 的 thinking-only silent-stop 判定；连续两轮 silent stop 的回归；正常正文与未知 block 的防误判用例
- 明确不包含：自动续跑预算、会话熔断、Desktop UI、prompt、MCP/工具注册改动
- 用户可见变化：模型只“思考”却不回复时，不再静默显示为正常完成；由既有机制自动续跑，额度耗尽后显示明确继续提示
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
corepack pnpm --filter @cindy/maker-core exec vitest run src/agents/claude-code/__tests__/translator-silent-stop.test.ts
结果：12/12 通过

corepack pnpm --filter @cindy/maker-core test
结果：98 个测试文件通过，2229 项通过，1 项 skipped，1 项 todo

corepack pnpm --filter @cindy/maker-core run --if-present typecheck
结果：通过（该 package 当前未声明 typecheck script）

corepack pnpm --filter desktop run --if-present typecheck
结果：通过

corepack pnpm test:unit
结果：全部 required workspace unit tiers 通过（含 Desktop、Mobile、maker-core 与协议包）

corepack pnpm check:dco
结果：1 个 commit 已签名，通过

git diff --check origin/main...HEAD
结果：通过
```

补充尝试：`corepack pnpm --filter @cindy/maker-core run build` 会命中仓库当前其他测试文件的既存 TypeScript 错误；错误列表不含本 PR 改动的两个文件。正式门禁使用上述仓库规定的 `--if-present typecheck` 与根 `test:unit`。

### 手工验证

- macOS 本地以脱敏后的真实事件序列回放：`tool_use → thinking-only → silentStop → 自动续跑 → zero-tool + 非空 thinking-only → silentStop`
- 对比事件流：正文、thinking、tool 事件内容与顺序不变；只在此前漏判的最终 `done.data` 增加 `silentStop: true`
- 缓存率：未改 prompt、历史输入或缓存前缀
- 返回速度：assistant content 仍是一次 O(n) 小数组扫描；无 IO、网络、额外 await 或深拷贝
- 事件准确性：正常正文、已有正文后尾随 thinking、未知 server tool、result fallback、error、interrupt、compact 与 empty-response 均保持原有收口

### 未执行的验证

- 未构建并替换正在运行的 Cindy.app；独立 worktree 的 maker-core 改动不会热更新当前宿主
- 未在 Windows 真机手工验证；改动不含平台分支
- 未运行 `pnpm test:all`；已运行仓库提交硬门禁 `pnpm test:unit`、相关 package typecheck 与 maker-core 全套测试

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Claude Code turn 完成语义

### 影响与回滚

- 影响范围：仅 Claude Code translator 对“最后只有 thinking 且没有可见正文”的正常结束 turn 的 `silentStop` 标记；现有 Desktop guard 的 2 次单消息额度、6 次会话熔断与提示行为不变
- system prompt：不涉及，未修改
- 影响缓存/性能：无 prompt/cache 前缀变化；热路径只保留同阶的小数组判定
- 回滚 / 降级方式：回滚本 commit 即恢复原判定；Desktop 现有 silent-stop kill switch 仍可关闭自动续跑

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（不需要额外用户文档；行为由回归测试约束）
- [x] 已确认测试结果或说明未执行原因
