### PR TITLE
feat: add macOS Codex Appshots

### DIFF
--- a/apps/desktop/forge.config.ts
+++ b/apps/desktop/forge.config.ts
@@ -854,6 +854,7 @@ function isMacForgePlatform(platform: ForgePlatform): boolean {
 const MACOS_VOICE_HELPER_DEPLOYMENT_TARGET = 'macos10.15';
 const MACOS_AGENT_ISLAND_HELPER_DEPLOYMENT_TARGET = 'macos14.0';
 const MACOS_COMPUTER_PERMISSION_GUIDE_HELPER_DEPLOYMENT_TARGET = 'macos13.0';
+const MACOS_APPSHOT_HELPER_DEPLOYMENT_TARGET = 'macos14.0';
 
 function swiftTargetTriple(cpuArch: 'arm64' | 'x86_64', deploymentTarget: string): string {
   return `${cpuArch}-apple-${deploymentTarget}`;
@@ -1024,6 +1025,28 @@ function buildMacComputerPermissionGuideHelper(platform: ForgePlatform, arch: Fo
   fs.chmodSync(dest, 0o755);
   const sizeMb = (fs.statSync(dest).size / (1024 * 1024)).toFixed(2);
   console.log(`[forge:prePackage] macOS computer permission guide helper (${swiftArchLabel(arch, MACOS_COMPUTER_PERMISSION_GUIDE_HELPER_DEPLOYMENT_TARGET)}) -> ${dest} (${sizeMb} MB)`);
+}
+
+function buildMacAppshotHelper(platform: ForgePlatform, arch: ForgeArch): void {
+  if (process.platform !== 'darwin' || !isMacForgePlatform(platform)) return;
+  const src = path.join(__dirname, 'native', 'appshots', 'macos-appshot-helper.swift');
+  const destDir = path.join(__dirname, 'resources', 'tools', 'appshots');
+  const dest = path.join(destDir, 'xdt-macos-appshot-helper');
+  if (!fs.existsSync(src)) {
+    throw new Error(`[forge] macOS Appshot helper source missing at ${src}`);
+  }
+  fs.mkdirSync(destDir, { recursive: true });
+  buildSwiftHelperForForgeArch(
+    src,
+    dest,
+    arch,
+    MACOS_APPSHOT_HELPER_DEPLOYMENT_TARGET,
+    ['-O'],
+    'Appshot helper',
+  );
+  fs.chmodSync(dest, 0o755);
+  const sizeMb = (fs.statSync(dest).size / (1024 * 1024)).toFixed(2);
+  console.log(`[forge:prePackage] macOS Appshot helper (${swiftArchLabel(arch, MACOS_APPSHOT_HELPER_DEPLOYMENT_TARGET)}) -> ${dest} (${sizeMb} MB)`);
 }
 
 // MakerNSIS is Windows-only (native dependency), conditionally require to
@@ -1304,6 +1327,7 @@ const config: ForgeConfig = {
       buildMacVoiceInputModifierShortcutListener(platform, arch);
       buildMacAgentIslandHelper(platform, arch);
       buildMacComputerPermissionGuideHelper(platform, arch);
+      buildMacAppshotHelper(platform, arch);
     },
     // packaged dir 产出后、makers 跑之前签内部 .exe。这样 NSIS 包出来的
     // Setup.exe 内嵌的、和 publish 阶段从同一 packagedDir 打的热更 ZIP 内嵌的，

--- a/apps/desktop/native/appshots/macos-appshot-helper.swift
+++ b/apps/desktop/native/appshots/macos-appshot-helper.swift
@@ -1,0 +1,592 @@
+import AppKit
+import ApplicationServices
+import CoreGraphics
+import Foundation
+import ImageIO
+import ScreenCaptureKit
+import UniformTypeIdentifiers
+
+private let secureTextFieldRole = "AXSecureTextField"
+private let maximumCaptureDimension = 8_192
+
+enum AppshotError: Error {
+  case invalidOutput
+  case screenPermission
+  case noWindow
+  case windowClosed
+  case protectedContent
+  case nativeFailure
+
+  var code: String {
+    switch self {
+    case .invalidOutput: return "APPSHOT_INVALID_OUTPUT"
+    case .screenPermission: return "APPSHOT_SCREEN_PERMISSION"
+    case .noWindow: return "APPSHOT_NO_WINDOW"
+    case .windowClosed: return "APPSHOT_WINDOW_CLOSED"
+    case .protectedContent: return "APPSHOT_PROTECTED_CONTENT"
+    case .nativeFailure: return "APPSHOT_NATIVE_FAILURE"
+    }
+  }
+
+  var message: String {
+    switch self {
+    case .invalidOutput: return "invalid output directory"
+    case .screenPermission: return "screen recording permission is required"
+    case .noWindow: return "no capturable window"
+    case .windowClosed: return "target window closed"
+    case .protectedContent: return "window content is unavailable"
+    case .nativeFailure: return "native capture failed"
+    }
+  }
+}
+
+struct AXSerialization {
+  let text: String?
+  let truncated: Bool
+  let unavailableReason: String?
+}
+
+private struct SerializationLimits {
+  let maxNodes: Int
+  let maxDepth: Int
+  let maxBytes: Int
+}
+
+private struct TreeNodeSnapshot<Node> {
+  let fields: [(String, String)]
+  let children: [Node]
+}
+
+private struct FixtureNode {
+  let role: String
+  let label: String?
+  let title: String?
+  let value: String?
+  let description: String?
+  let children: [FixtureNode]
+
+  init(
+    role: String,
+    label: String? = nil,
+    title: String? = nil,
+    value: String? = nil,
+    description: String? = nil,
+    children: [FixtureNode] = []
+  ) {
+    self.role = role
+    self.label = label
+    self.title = title
+    self.value = value
+    self.description = description
+    self.children = children
+  }
+}
+
+private func sanitized(_ value: String) -> String {
+  value
+    .replacingOccurrences(of: "\\", with: "\\\\")
+    .replacingOccurrences(of: "\r", with: "\\r")
+    .replacingOccurrences(of: "\n", with: "\\n")
+    .replacingOccurrences(of: "|", with: "\\|")
+}
+
+private func appendUTF8Prefix(_ value: String, to output: inout Data, maximumBytes: Int) {
+  let remaining = maximumBytes - output.count
+  guard remaining > 0 else { return }
+  let bytes = Data(value.utf8.prefix(remaining))
+  var validCount = bytes.count
+  while validCount > 0 && String(data: bytes.prefix(validCount), encoding: .utf8) == nil {
+    validCount -= 1
+  }
+  output.append(bytes.prefix(validCount))
+}
+
+private func serializeTree<Node>(
+  root: Node?,
+  limits: SerializationLimits,
+  deadlineReached: (Int) -> Bool,
+  readNode: (Node) -> TreeNodeSnapshot<Node>?
+) -> AXSerialization {
+  guard let root else { return AXSerialization(text: nil, truncated: false, unavailableReason: nil) }
+  var output = Data()
+  var visited = 0
+  var truncated = false
+  var stack: [(Node, Int)] = [(root, 0)]
+
+  while let (node, depth) = stack.popLast() {
+    if visited >= limits.maxNodes || deadlineReached(visited) {
+      truncated = true
+      break
+    }
+    guard let snapshot = readNode(node) else { continue }
+    visited += 1
+
+    if !snapshot.fields.isEmpty {
+      let separator = output.isEmpty ? "" : "\n"
+      let line = separator + String(repeating: "  ", count: depth)
+        + snapshot.fields.map { "\($0.0): \(sanitized($0.1))" }.joined(separator: " | ")
+      if output.count + line.lengthOfBytes(using: .utf8) > limits.maxBytes {
+        appendUTF8Prefix(line, to: &output, maximumBytes: limits.maxBytes)
+        truncated = true
+        break
+      }
+      output.append(contentsOf: line.utf8)
+    }
+
+    if depth >= limits.maxDepth {
+      if !snapshot.children.isEmpty { truncated = true }
+      continue
+    }
+    for child in snapshot.children.reversed() {
+      stack.append((child, depth + 1))
+    }
+  }
+
+  return AXSerialization(
+    text: output.isEmpty ? nil : String(data: output, encoding: .utf8),
+    truncated: truncated,
+    unavailableReason: nil
+  )
+}
+
+private func serializeFixture(
+  _ root: FixtureNode,
+  limits: SerializationLimits,
+  deadlineNode: Int? = nil
+) -> AXSerialization {
+  serializeTree(
+    root: root,
+    limits: limits,
+    deadlineReached: { visited in deadlineNode.map { visited >= $0 } ?? false },
+    readNode: { node in
+      if node.role == secureTextFieldRole {
+        return TreeNodeSnapshot(
+          fields: [("role", "Secure text field"), ("label", "Secure text field")],
+          children: []
+        )
+      }
+      let fields = [
+        ("role", Optional(node.role)),
+        ("label", node.label),
+        ("title", node.title),
+        ("value", node.value),
+        ("description", node.description),
+      ].compactMap { name, value in value.flatMap { $0.isEmpty ? nil : (name, $0) } }
+      return TreeNodeSnapshot(fields: fields, children: node.children)
+    }
+  )
+}
+
+private func copyAXAttribute(_ element: AXUIElement, _ attribute: CFString) -> CFTypeRef? {
+  var value: CFTypeRef?
+  return AXUIElementCopyAttributeValue(element, attribute, &value) == .success ? value : nil
+}
+
+private func safeAXString(_ element: AXUIElement, _ attribute: CFString) -> String? {
+  guard let value = copyAXAttribute(element, attribute), CFGetTypeID(value) == CFStringGetTypeID() else {
+    return nil
+  }
+  return value as? String
+}
+
+private func safeAXPrimitive(_ element: AXUIElement, _ attribute: CFString) -> String? {
+  guard let value = copyAXAttribute(element, attribute) else { return nil }
+  if CFGetTypeID(value) == CFStringGetTypeID() {
+    return value as? String
+  }
+  if CFGetTypeID(value) == CFBooleanGetTypeID() {
+    return CFBooleanGetValue((value as! CFBoolean)) ? "true" : "false"
+  }
+  if CFGetTypeID(value) == CFNumberGetTypeID(), let number = value as? NSNumber {
+    return number.stringValue
+  }
+  return nil
+}
+
+private func axChildren(_ element: AXUIElement) -> [AXUIElement] {
+  copyAXAttribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] ?? []
+}
+
+func serializeAccessibilityWindow(
+  _ window: AXUIElement?,
+  startedAt: ContinuousClock.Instant
+) -> AXSerialization {
+  guard AXIsProcessTrusted() else {
+    return AXSerialization(text: nil, truncated: false, unavailableReason: "permission")
+  }
+  guard let window else {
+    return AXSerialization(text: nil, truncated: false, unavailableReason: "unsupported")
+  }
+
+  var pid: pid_t = 0
+  if AXUIElementGetPid(window, &pid) == .success {
+    AXUIElementSetMessagingTimeout(AXUIElementCreateApplication(pid), 0.1)
+  }
+
+  let clock = ContinuousClock()
+  var hitDeadline = false
+  var seen = Set<CFHashCode>()
+  let deadlineReached: (Int) -> Bool = { _ in
+    let reached = clock.now - startedAt >= .milliseconds(1_500)
+    if reached { hitDeadline = true }
+    return reached
+  }
+  let result = serializeTree(
+    root: window,
+    limits: SerializationLimits(maxNodes: 2_000, maxDepth: 16, maxBytes: 512 * 1_024),
+    deadlineReached: deadlineReached,
+    readNode: { element in
+      let identity = CFHash(element)
+      guard seen.insert(identity).inserted else { return nil }
+      if deadlineReached(0) { return nil }
+
+      let role = safeAXString(element, kAXRoleAttribute as CFString)
+      if role == secureTextFieldRole {
+        return TreeNodeSnapshot(
+          fields: [("role", "Secure text field"), ("label", "Secure text field")],
+          children: []
+        )
+      }
+
+      var fields: [(String, String)] = []
+      func add(_ name: String, _ value: @autoclosure () -> String?) {
+        guard !deadlineReached(0), let value = value(), !value.isEmpty else { return }
+        fields.append((name, value))
+      }
+      add("role", role)
+      add("label", safeAXString(element, kAXDescriptionAttribute as CFString))
+      add("title", safeAXString(element, kAXTitleAttribute as CFString))
+      add("value", safeAXPrimitive(element, kAXValueAttribute as CFString))
+      add("description", safeAXString(element, kAXHelpAttribute as CFString))
+      add("enabled", safeAXPrimitive(element, kAXEnabledAttribute as CFString))
+      add("selected", safeAXPrimitive(element, kAXSelectedAttribute as CFString))
+      add("focused", safeAXPrimitive(element, kAXFocusedAttribute as CFString))
+      return TreeNodeSnapshot(fields: fields, children: deadlineReached(0) ? [] : axChildren(element))
+    }
+  )
+
+  if hitDeadline {
+    return AXSerialization(
+      text: result.text,
+      truncated: true,
+      unavailableReason: result.text == nil ? "timeout" : nil
+    )
+  }
+  return result
+}
+
+private func focusedAXWindow(for app: NSRunningApplication) -> AXUIElement? {
+  guard AXIsProcessTrusted() else { return nil }
+  let appElement = AXUIElementCreateApplication(app.processIdentifier)
+  AXUIElementSetMessagingTimeout(appElement, 0.1)
+  guard let value = copyAXAttribute(appElement, kAXFocusedWindowAttribute as CFString),
+        CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
+  return (value as! AXUIElement)
+}
+
+private func axBounds(_ element: AXUIElement?) -> CGRect? {
+  guard let element,
+        let positionValue = copyAXAttribute(element, kAXPositionAttribute as CFString),
+        let sizeValue = copyAXAttribute(element, kAXSizeAttribute as CFString),
+        CFGetTypeID(positionValue) == AXValueGetTypeID(),
+        CFGetTypeID(sizeValue) == AXValueGetTypeID() else { return nil }
+  var position = CGPoint.zero
+  var size = CGSize.zero
+  guard AXValueGetValue((positionValue as! AXValue), .cgPoint, &position),
+        AXValueGetValue((sizeValue as! AXValue), .cgSize, &size) else { return nil }
+  return CGRect(origin: position, size: size)
+}
+
+private func approximatelyMatches(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+  abs(lhs.minX - rhs.minX) <= 8
+    && abs(lhs.minY - rhs.minY) <= 8
+    && abs(lhs.width - rhs.width) <= 8
+    && abs(lhs.height - rhs.height) <= 8
+}
+
+private func isFiniteNormalFrame(_ frame: CGRect) -> Bool {
+  frame.origin.x.isFinite
+    && frame.origin.y.isFinite
+    && frame.width.isFinite
+    && frame.height.isFinite
+    && frame.width > 1
+    && frame.height > 1
+}
+
+private func windowAlpha(_ window: SCWindow) -> Double? {
+  guard let info = CGWindowListCopyWindowInfo([.optionIncludingWindow], window.windowID) as? [[String: Any]],
+        let windowInfo = info.first else { return nil }
+  return (windowInfo[kCGWindowAlpha as String] as? NSNumber)?.doubleValue
+}
+
+func frontmostTarget() async throws -> (app: NSRunningApplication, window: SCWindow, axWindow: AXUIElement?) {
+  guard let app = NSWorkspace.shared.frontmostApplication,
+        !app.isTerminated,
+        app.processIdentifier != ProcessInfo.processInfo.processIdentifier,
+        app.processIdentifier != getppid(),
+        app.activationPolicy != .prohibited else { throw AppshotError.noWindow }
+
+  let axWindow = focusedAXWindow(for: app)
+  let axTitle = axWindow.flatMap { safeAXString($0, kAXTitleAttribute as CFString) }
+  let focusedBounds = axBounds(axWindow)
+  let content: SCShareableContent
+  do {
+    content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: false)
+  } catch {
+    throw CGPreflightScreenCaptureAccess() ? AppshotError.nativeFailure : AppshotError.screenPermission
+  }
+  guard !app.isTerminated else { throw AppshotError.windowClosed }
+
+  let candidates = content.windows.filter { candidate in
+    candidate.owningApplication?.processID == app.processIdentifier
+      && candidate.windowLayer == 0
+      && candidate.isOnScreen
+      && windowAlpha(candidate).map { $0 > 0 } != false
+      && isFiniteNormalFrame(candidate.frame)
+  }
+  guard !candidates.isEmpty else { throw AppshotError.noWindow }
+
+  let titleAndBoundsMatch = candidates.first { candidate in
+    guard let axTitle, candidate.title == axTitle, let focusedBounds else { return false }
+    return approximatelyMatches(candidate.frame, focusedBounds)
+  }
+  let titleMatch = candidates.first { candidate in
+    guard let axTitle else { return false }
+    return candidate.title == axTitle
+  }
+  let boundsMatch = candidates.first { candidate in
+    guard let focusedBounds else { return false }
+    return approximatelyMatches(candidate.frame, focusedBounds)
+  }
+  let selected = titleAndBoundsMatch ?? titleMatch ?? boundsMatch ?? candidates[0]
+  return (app, selected, axWindow)
+}
+
+func isBlankImage(_ image: CGImage) -> Bool {
+  let width = min(image.width, 64)
+  let height = min(image.height, 64)
+  guard width > 0, height > 0 else { return true }
+  var pixels = [UInt8](repeating: 0, count: width * height * 4)
+  guard let context = CGContext(
+    data: &pixels,
+    width: width,
+    height: height,
+    bitsPerComponent: 8,
+    bytesPerRow: width * 4,
+    space: CGColorSpaceCreateDeviceRGB(),
+    bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+  ) else { return true }
+  context.interpolationQuality = .low
+  context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+  var minimum = [UInt8](repeating: 255, count: 3)
+  var maximum = [UInt8](repeating: 0, count: 3)
+  var maximumAlpha: UInt8 = 0
+  for offset in stride(from: 0, to: pixels.count, by: 4) {
+    maximumAlpha = max(maximumAlpha, pixels[offset + 3])
+    for channel in 0..<3 {
+      minimum[channel] = min(minimum[channel], pixels[offset + channel])
+      maximum[channel] = max(maximum[channel], pixels[offset + channel])
+    }
+  }
+  if maximumAlpha <= 2 { return true }
+  return zip(minimum, maximum).allSatisfy { Int($0.1) - Int($0.0) <= 3 }
+}
+
+private func pngData(for image: CGImage) throws -> Data {
+  let data = NSMutableData()
+  guard let destination = CGImageDestinationCreateWithData(
+    data,
+    UTType.png.identifier as CFString,
+    1,
+    nil
+  ) else { throw AppshotError.nativeFailure }
+  CGImageDestinationAddImage(destination, image, nil)
+  guard CGImageDestinationFinalize(destination) else { throw AppshotError.nativeFailure }
+  return data as Data
+}
+
+func captureWindow(_ window: SCWindow, to outputURL: URL) async throws -> CGImage {
+  let frame = window.frame
+  guard isFiniteNormalFrame(frame) else { throw AppshotError.noWindow }
+  let screenScale = NSScreen.screens.first(where: { $0.frame.intersects(frame) })?.backingScaleFactor
+    ?? NSScreen.main?.backingScaleFactor
+    ?? 2
+  var width = max(1, Int((frame.width * screenScale).rounded()))
+  var height = max(1, Int((frame.height * screenScale).rounded()))
+  let largest = max(width, height)
+  if largest > maximumCaptureDimension {
+    let ratio = Double(maximumCaptureDimension) / Double(largest)
+    width = max(1, Int((Double(width) * ratio).rounded()))
+    height = max(1, Int((Double(height) * ratio).rounded()))
+  }
+
+  let configuration = SCStreamConfiguration()
+  configuration.width = width
+  configuration.height = height
+  configuration.showsCursor = false
+  configuration.capturesAudio = false
+  let filter = SCContentFilter(desktopIndependentWindow: window)
+  let image: CGImage
+  do {
+    image = try await SCScreenshotManager.captureImage(
+      contentFilter: filter,
+      configuration: configuration
+    )
+  } catch {
+    if !CGPreflightScreenCaptureAccess() { throw AppshotError.screenPermission }
+    if let content = try? await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: false),
+       !content.windows.contains(where: { $0.windowID == window.windowID }) {
+      throw AppshotError.windowClosed
+    }
+    throw AppshotError.nativeFailure
+  }
+  guard !isBlankImage(image) else { throw AppshotError.protectedContent }
+  do {
+    try pngData(for: image).write(to: outputURL, options: .atomic)
+  } catch let error as AppshotError {
+    throw error
+  } catch {
+    throw AppshotError.nativeFailure
+  }
+  return image
+}
+
+func validatedOutputURL(argument: String) throws -> URL {
+  guard argument.hasPrefix("/") else { throw AppshotError.invalidOutput }
+  let directory = URL(fileURLWithPath: argument, isDirectory: true)
+    .standardizedFileURL
+    .resolvingSymlinksInPath()
+  guard directory.path.hasPrefix("/"),
+        let values = try? directory.resourceValues(forKeys: [.isDirectoryKey]),
+        values.isDirectory == true else { throw AppshotError.invalidOutput }
+  let output = directory.appendingPathComponent("appshot.png", isDirectory: false)
+  if FileManager.default.fileExists(atPath: output.path) {
+    guard let values = try? output.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+          values.isSymbolicLink != true,
+          values.isRegularFile == true else {
+      throw AppshotError.invalidOutput
+    }
+  } else if let values = try? output.resourceValues(forKeys: [.isSymbolicLinkKey]),
+            values.isSymbolicLink == true {
+    throw AppshotError.invalidOutput
+  }
+  return output
+}
+
+private func emitJSON(_ payload: [String: Any]) throws {
+  let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+  FileHandle.standardOutput.write(data)
+  FileHandle.standardOutput.write(Data([0x0a]))
+}
+
+private func runSelfTest() -> Bool {
+  let ordinaryLimits = SerializationLimits(maxNodes: 10, maxDepth: 4, maxBytes: 4_096)
+  let secure = serializeFixture(
+    FixtureNode(
+      role: secureTextFieldRole,
+      label: "Password",
+      title: "private title",
+      value: "correct horse battery staple",
+      description: "private description",
+      children: [FixtureNode(role: "AXStaticText", value: "descendant secret")]
+    ),
+    limits: ordinaryLimits
+  )
+  guard secure.text == "role: Secure text field | label: Secure text field",
+        secure.text?.contains("correct horse") == false,
+        secure.text?.contains("private") == false,
+        secure.text?.contains("descendant secret") == false,
+        !secure.truncated else { return false }
+
+  let siblings = FixtureNode(
+    role: "AXWindow",
+    children: (0..<4).map { FixtureNode(role: "AXButton", label: "button-\($0)") }
+  )
+  let nodeLimited = serializeFixture(
+    siblings,
+    limits: SerializationLimits(maxNodes: 3, maxDepth: 8, maxBytes: 4_096)
+  )
+  guard nodeLimited.truncated, nodeLimited.text?.contains("button-1") == true,
+        nodeLimited.text?.contains("button-2") == false else { return false }
+
+  let deep = FixtureNode(
+    role: "AXWindow",
+    children: [FixtureNode(
+      role: "AXGroup",
+      label: "depth-1",
+      children: [FixtureNode(role: "AXStaticText", label: "depth-2")]
+    )]
+  )
+  let depthLimited = serializeFixture(
+    deep,
+    limits: SerializationLimits(maxNodes: 10, maxDepth: 1, maxBytes: 4_096)
+  )
+  guard depthLimited.truncated, depthLimited.text?.contains("depth-1") == true,
+        depthLimited.text?.contains("depth-2") == false else { return false }
+
+  let byteLimited = serializeFixture(
+    FixtureNode(role: "AXWindow", label: String(repeating: "é", count: 20)),
+    limits: SerializationLimits(maxNodes: 10, maxDepth: 4, maxBytes: 31)
+  )
+  guard byteLimited.truncated, let byteText = byteLimited.text,
+        byteText.lengthOfBytes(using: .utf8) <= 31 else { return false }
+
+  let deadlineLimited = serializeFixture(siblings, limits: ordinaryLimits, deadlineNode: 2)
+  return deadlineLimited.truncated
+    && deadlineLimited.text?.contains("button-0") == true
+    && deadlineLimited.text?.contains("button-1") == false
+}
+
+private enum MacOSAppshotHelper {
+  static func run() async {
+    let arguments = Array(CommandLine.arguments.dropFirst())
+    if arguments == ["--self-test"] {
+      guard runSelfTest() else { exit(1) }
+      do {
+        try emitJSON(["type": "self-test", "ok": true])
+        exit(0)
+      } catch {
+        exit(1)
+      }
+    }
+
+    do {
+      guard arguments.count == 2, arguments[0] == "--output-dir" else {
+        throw AppshotError.invalidOutput
+      }
+      let outputURL = try validatedOutputURL(argument: arguments[1])
+      let target = try await frontmostTarget()
+      _ = try await captureWindow(target.window, to: outputURL)
+      let accessibility = serializeAccessibilityWindow(
+        target.axWindow,
+        startedAt: ContinuousClock().now
+      )
+      var payload: [String: Any] = [
+        "type": "capture",
+        "pngPath": outputURL.path,
+        "applicationName": target.app.localizedName ?? "",
+        "bundleIdentifier": target.app.bundleIdentifier ?? NSNull(),
+        "windowTitle": target.window.title ?? NSNull(),
+        "accessibilityText": accessibility.text ?? NSNull(),
+        "accessibilityTruncated": accessibility.truncated,
+      ]
+      if let reason = accessibility.unavailableReason {
+        payload["accessibilityUnavailableReason"] = reason
+      }
+      try emitJSON(payload)
+      exit(0)
+    } catch let error as AppshotError {
+      FileHandle.standardError.write(Data("\(error.code): \(error.message)\n".utf8))
+      exit(2)
+    } catch {
+      FileHandle.standardError.write(Data("APPSHOT_NATIVE_FAILURE: native capture failed\n".utf8))
+      exit(2)
+    }
+  }
+}
+
+Task {
+  await MacOSAppshotHelper.run()
+}
+dispatchMain()

--- a/apps/desktop/native/appshots/macos-appshot-helper.swift
+++ b/apps/desktop/native/appshots/macos-appshot-helper.swift
@@ -1,6 +1,7 @@
 import AppKit
 import ApplicationServices
 import CoreGraphics
+import Darwin
 import Foundation
 import ImageIO
 import ScreenCaptureKit
@@ -8,6 +9,7 @@ import UniformTypeIdentifiers
 
 private let secureTextFieldRole = "AXSecureTextField"
 private let maximumCaptureDimension = 8_192
+private let outputDirectoryPrefix = "cindy-appshot-"
 
 enum AppshotError: Error {
   case invalidOutput
@@ -105,6 +107,7 @@ private func serializeTree<Node>(
   root: Node?,
   limits: SerializationLimits,
   deadlineReached: (Int) -> Bool,
+  prepareNode: (Node) -> Void = { _ in },
   readNode: (Node) -> TreeNodeSnapshot<Node>?
 ) -> AXSerialization {
   guard let root else { return AXSerialization(text: nil, truncated: false, unavailableReason: nil) }
@@ -118,6 +121,7 @@ private func serializeTree<Node>(
       truncated = true
       break
     }
+    prepareNode(node)
     guard let snapshot = readNode(node) else { continue }
     visited += 1
 
@@ -152,12 +156,14 @@ private func serializeTree<Node>(
 private func serializeFixture(
   _ root: FixtureNode,
   limits: SerializationLimits,
-  deadlineNode: Int? = nil
+  deadlineNode: Int? = nil,
+  prepareNode: (FixtureNode) -> Void = { _ in }
 ) -> AXSerialization {
   serializeTree(
     root: root,
     limits: limits,
     deadlineReached: { visited in deadlineNode.map { visited >= $0 } ?? false },
+    prepareNode: prepareNode,
     readNode: { node in
       if node.role == secureTextFieldRole {
         return TreeNodeSnapshot(
@@ -182,10 +188,29 @@ private func copyAXAttribute(_ element: AXUIElement, _ attribute: CFString) -> C
   return AXUIElementCopyAttributeValue(element, attribute, &value) == .success ? value : nil
 }
 
+private func copyAXAttribute(
+  _ element: AXUIElement,
+  _ attribute: CFString,
+  beforeDeadline: () -> Bool
+) -> CFTypeRef? {
+  guard beforeDeadline() else { return nil }
+  return copyAXAttribute(element, attribute)
+}
+
 private func safeAXString(_ element: AXUIElement, _ attribute: CFString) -> String? {
   guard let value = copyAXAttribute(element, attribute), CFGetTypeID(value) == CFStringGetTypeID() else {
     return nil
   }
+  return value as? String
+}
+
+private func safeAXString(
+  _ element: AXUIElement,
+  _ attribute: CFString,
+  beforeDeadline: () -> Bool
+) -> String? {
+  guard let value = copyAXAttribute(element, attribute, beforeDeadline: beforeDeadline),
+        CFGetTypeID(value) == CFStringGetTypeID() else { return nil }
   return value as? String
 }
 
@@ -203,8 +228,32 @@ private func safeAXPrimitive(_ element: AXUIElement, _ attribute: CFString) -> S
   return nil
 }
 
+private func safeAXPrimitive(
+  _ element: AXUIElement,
+  _ attribute: CFString,
+  beforeDeadline: () -> Bool
+) -> String? {
+  guard let value = copyAXAttribute(element, attribute, beforeDeadline: beforeDeadline) else { return nil }
+  if CFGetTypeID(value) == CFStringGetTypeID() { return value as? String }
+  if CFGetTypeID(value) == CFBooleanGetTypeID() {
+    return CFBooleanGetValue((value as! CFBoolean)) ? "true" : "false"
+  }
+  if CFGetTypeID(value) == CFNumberGetTypeID(), let number = value as? NSNumber {
+    return number.stringValue
+  }
+  return nil
+}
+
 private func axChildren(_ element: AXUIElement) -> [AXUIElement] {
   copyAXAttribute(element, kAXChildrenAttribute as CFString) as? [AXUIElement] ?? []
+}
+
+private func axChildren(_ element: AXUIElement, beforeDeadline: () -> Bool) -> [AXUIElement] {
+  copyAXAttribute(
+    element,
+    kAXChildrenAttribute as CFString,
+    beforeDeadline: beforeDeadline
+  ) as? [AXUIElement] ?? []
 }
 
 func serializeAccessibilityWindow(
@@ -216,11 +265,6 @@ func serializeAccessibilityWindow(
   }
   guard let window else {
     return AXSerialization(text: nil, truncated: false, unavailableReason: "unsupported")
-  }
-
-  var pid: pid_t = 0
-  if AXUIElementGetPid(window, &pid) == .success {
-    AXUIElementSetMessagingTimeout(AXUIElementCreateApplication(pid), 0.1)
   }
 
   let clock = ContinuousClock()
@@ -235,12 +279,14 @@ func serializeAccessibilityWindow(
     root: window,
     limits: SerializationLimits(maxNodes: 2_000, maxDepth: 16, maxBytes: 512 * 1_024),
     deadlineReached: deadlineReached,
+    prepareNode: { AXUIElementSetMessagingTimeout($0, 0.1) },
     readNode: { element in
       let identity = CFHash(element)
       guard seen.insert(identity).inserted else { return nil }
       if deadlineReached(0) { return nil }
 
-      let role = safeAXString(element, kAXRoleAttribute as CFString)
+      let beforeDeadline = { !deadlineReached(0) }
+      let role = safeAXString(element, kAXRoleAttribute as CFString, beforeDeadline: beforeDeadline)
       if role == secureTextFieldRole {
         return TreeNodeSnapshot(
           fields: [("role", "Secure text field"), ("label", "Secure text field")],
@@ -254,14 +300,17 @@ func serializeAccessibilityWindow(
         fields.append((name, value))
       }
       add("role", role)
-      add("label", safeAXString(element, kAXDescriptionAttribute as CFString))
-      add("title", safeAXString(element, kAXTitleAttribute as CFString))
-      add("value", safeAXPrimitive(element, kAXValueAttribute as CFString))
-      add("description", safeAXString(element, kAXHelpAttribute as CFString))
-      add("enabled", safeAXPrimitive(element, kAXEnabledAttribute as CFString))
-      add("selected", safeAXPrimitive(element, kAXSelectedAttribute as CFString))
-      add("focused", safeAXPrimitive(element, kAXFocusedAttribute as CFString))
-      return TreeNodeSnapshot(fields: fields, children: deadlineReached(0) ? [] : axChildren(element))
+      add("label", safeAXString(element, kAXDescriptionAttribute as CFString, beforeDeadline: beforeDeadline))
+      add("title", safeAXString(element, kAXTitleAttribute as CFString, beforeDeadline: beforeDeadline))
+      add("value", safeAXPrimitive(element, kAXValueAttribute as CFString, beforeDeadline: beforeDeadline))
+      add("description", safeAXString(element, kAXHelpAttribute as CFString, beforeDeadline: beforeDeadline))
+      add("enabled", safeAXPrimitive(element, kAXEnabledAttribute as CFString, beforeDeadline: beforeDeadline))
+      add("selected", safeAXPrimitive(element, kAXSelectedAttribute as CFString, beforeDeadline: beforeDeadline))
+      add("focused", safeAXPrimitive(element, kAXFocusedAttribute as CFString, beforeDeadline: beforeDeadline))
+      return TreeNodeSnapshot(
+        fields: fields,
+        children: axChildren(element, beforeDeadline: beforeDeadline)
+      )
     }
   )
 
@@ -406,9 +455,91 @@ private func pngData(for image: CGImage) throws -> Data {
   return data as Data
 }
 
+private func openValidatedOutputDirectory(_ argument: String) throws -> (url: URL, fileDescriptor: Int32) {
+  guard argument.hasPrefix("/") else { throw AppshotError.invalidOutput }
+  let directory = URL(fileURLWithPath: argument, isDirectory: true).standardizedFileURL
+  let lexicalTemporaryRoot = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    .standardizedFileURL
+  let temporaryRoot = lexicalTemporaryRoot.resolvingSymlinksInPath()
+  let resolvedDirectory = directory.resolvingSymlinksInPath()
+  let suppliedParent = directory.deletingLastPathComponent().path
+  guard directory.path == argument,
+        suppliedParent == lexicalTemporaryRoot.path || suppliedParent == temporaryRoot.path,
+        resolvedDirectory.deletingLastPathComponent().path == temporaryRoot.path,
+        resolvedDirectory.lastPathComponent.hasPrefix(outputDirectoryPrefix) else {
+    throw AppshotError.invalidOutput
+  }
+
+  var pathStatus = stat()
+  guard lstat(argument, &pathStatus) == 0,
+        (pathStatus.st_mode & S_IFMT) == S_IFDIR,
+        (pathStatus.st_mode & 0o777) == 0o700,
+        pathStatus.st_uid == geteuid() else { throw AppshotError.invalidOutput }
+
+  let directoryFD = open(argument, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+  guard directoryFD >= 0 else { throw AppshotError.invalidOutput }
+  var openedStatus = stat()
+  guard fstat(directoryFD, &openedStatus) == 0,
+        (openedStatus.st_mode & S_IFMT) == S_IFDIR,
+        (openedStatus.st_mode & 0o777) == 0o700,
+        openedStatus.st_uid == geteuid(),
+        openedStatus.st_dev == pathStatus.st_dev,
+        openedStatus.st_ino == pathStatus.st_ino else {
+    close(directoryFD)
+    throw AppshotError.invalidOutput
+  }
+  var outputStatus = stat()
+  guard fstatat(directoryFD, "appshot.png", &outputStatus, AT_SYMLINK_NOFOLLOW) != 0,
+        errno == ENOENT else {
+    close(directoryFD)
+    throw AppshotError.invalidOutput
+  }
+  return (directory, directoryFD)
+}
+
+private func writePNG(_ data: Data, toDirectoryFileDescriptor directoryFD: Int32) throws {
+  let filename = "appshot.png"
+  let outputFD = openat(
+    directoryFD,
+    filename,
+    O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC,
+    mode_t(0o600)
+  )
+  guard outputFD >= 0 else { throw AppshotError.invalidOutput }
+  var keepFile = false
+  defer {
+    close(outputFD)
+    if !keepFile { unlinkat(directoryFD, filename, 0) }
+  }
+
+  var outputStatus = stat()
+  guard fstat(outputFD, &outputStatus) == 0,
+        (outputStatus.st_mode & S_IFMT) == S_IFREG,
+        (outputStatus.st_mode & 0o777) == 0o600,
+        outputStatus.st_uid == geteuid(),
+        outputStatus.st_nlink == 1 else { throw AppshotError.invalidOutput }
+  try data.withUnsafeBytes { rawBuffer in
+    guard let baseAddress = rawBuffer.baseAddress else { return }
+    var written = 0
+    while written < rawBuffer.count {
+      let count = Darwin.write(outputFD, baseAddress.advanced(by: written), rawBuffer.count - written)
+      if count < 0 {
+        if errno == EINTR { continue }
+        throw AppshotError.nativeFailure
+      }
+      guard count > 0 else { throw AppshotError.nativeFailure }
+      written += count
+    }
+  }
+  keepFile = true
+}
+
 func captureWindow(_ window: SCWindow, to outputURL: URL) async throws -> CGImage {
   let frame = window.frame
   guard isFiniteNormalFrame(frame) else { throw AppshotError.noWindow }
+  guard outputURL.lastPathComponent == "appshot.png" else { throw AppshotError.invalidOutput }
+  let directory = try openValidatedOutputDirectory(outputURL.deletingLastPathComponent().path)
+  defer { close(directory.fileDescriptor) }
   let screenScale = NSScreen.screens.first(where: { $0.frame.intersects(frame) })?.backingScaleFactor
     ?? NSScreen.main?.backingScaleFactor
     ?? 2
@@ -443,7 +574,7 @@ func captureWindow(_ window: SCWindow, to outputURL: URL) async throws -> CGImag
   }
   guard !isBlankImage(image) else { throw AppshotError.protectedContent }
   do {
-    try pngData(for: image).write(to: outputURL, options: .atomic)
+    try writePNG(pngData(for: image), toDirectoryFileDescriptor: directory.fileDescriptor)
   } catch let error as AppshotError {
     throw error
   } catch {
@@ -453,25 +584,9 @@ func captureWindow(_ window: SCWindow, to outputURL: URL) async throws -> CGImag
 }
 
 func validatedOutputURL(argument: String) throws -> URL {
-  guard argument.hasPrefix("/") else { throw AppshotError.invalidOutput }
-  let directory = URL(fileURLWithPath: argument, isDirectory: true)
-    .standardizedFileURL
-    .resolvingSymlinksInPath()
-  guard directory.path.hasPrefix("/"),
-        let values = try? directory.resourceValues(forKeys: [.isDirectoryKey]),
-        values.isDirectory == true else { throw AppshotError.invalidOutput }
-  let output = directory.appendingPathComponent("appshot.png", isDirectory: false)
-  if FileManager.default.fileExists(atPath: output.path) {
-    guard let values = try? output.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
-          values.isSymbolicLink != true,
-          values.isRegularFile == true else {
-      throw AppshotError.invalidOutput
-    }
-  } else if let values = try? output.resourceValues(forKeys: [.isSymbolicLinkKey]),
-            values.isSymbolicLink == true {
-    throw AppshotError.invalidOutput
-  }
-  return output
+  let directory = try openValidatedOutputDirectory(argument)
+  close(directory.fileDescriptor)
+  return directory.url.appendingPathComponent("appshot.png", isDirectory: false)
 }
 
 private func emitJSON(_ payload: [String: Any]) throws {
@@ -532,8 +647,15 @@ private func runSelfTest() -> Bool {
   guard byteLimited.truncated, let byteText = byteLimited.text,
         byteText.lengthOfBytes(using: .utf8) <= 31 else { return false }
 
-  let deadlineLimited = serializeFixture(siblings, limits: ordinaryLimits, deadlineNode: 2)
+  var preparedRoles: [String] = []
+  let deadlineLimited = serializeFixture(
+    siblings,
+    limits: ordinaryLimits,
+    deadlineNode: 2,
+    prepareNode: { preparedRoles.append($0.role) }
+  )
   return deadlineLimited.truncated
+    && preparedRoles == ["AXWindow", "AXButton"]
     && deadlineLimited.text?.contains("button-0") == true
     && deadlineLimited.text?.contains("button-1") == false
 }

--- a/apps/desktop/native/appshots/macos-appshot-helper.swift
+++ b/apps/desktop/native/appshots/macos-appshot-helper.swift
@@ -11,6 +11,24 @@ private let secureTextFieldRole = "AXSecureTextField"
 private let maximumCaptureDimension = 8_192
 private let outputDirectoryPrefix = "cindy-appshot-"
 
+private enum HelperMode: Equatable {
+  case selfTest
+  case capture(outputDirectory: String, selfTestBeforeCapture: Bool)
+}
+
+private func parseHelperMode(_ arguments: [String]) -> HelperMode? {
+  if arguments == ["--self-test"] { return .selfTest }
+  if arguments.count == 2, arguments[0] == "--output-dir" {
+    return .capture(outputDirectory: arguments[1], selfTestBeforeCapture: false)
+  }
+  if arguments.count == 3,
+     arguments[0] == "--self-test-and-capture",
+     arguments[1] == "--output-dir" {
+    return .capture(outputDirectory: arguments[2], selfTestBeforeCapture: true)
+  }
+  return nil
+}
+
 enum AppshotError: Error {
   case invalidOutput
   case screenPermission
@@ -65,6 +83,7 @@ private struct FixtureNode {
   let title: String?
   let value: String?
   let description: String?
+  let containsProtectedContent: Bool
   let children: [FixtureNode]
 
   init(
@@ -73,6 +92,7 @@ private struct FixtureNode {
     title: String? = nil,
     value: String? = nil,
     description: String? = nil,
+    containsProtectedContent: Bool = false,
     children: [FixtureNode] = []
   ) {
     self.role = role
@@ -80,8 +100,15 @@ private struct FixtureNode {
     self.title = title
     self.value = value
     self.description = description
+    self.containsProtectedContent = containsProtectedContent
     self.children = children
   }
+}
+
+private struct WindowCandidateFacts {
+  let title: String?
+  let frame: CGRect
+  let alpha: Double?
 }
 
 private func sanitized(_ value: String) -> String {
@@ -175,7 +202,7 @@ private func serializeFixture(
         ("role", Optional(node.role)),
         ("label", node.label),
         ("title", node.title),
-        ("value", node.value),
+        ("value", node.containsProtectedContent ? nil : node.value),
         ("description", node.description),
       ].compactMap { name, value in value.flatMap { $0.isEmpty ? nil : (name, $0) } }
       return TreeNodeSnapshot(fields: fields, children: node.children)
@@ -266,6 +293,7 @@ func serializeAccessibilityWindow(
   guard let window else {
     return AXSerialization(text: nil, truncated: false, unavailableReason: "unsupported")
   }
+  _ = NSAccessibility.setMayContainProtectedContent(true)
 
   let clock = ContinuousClock()
   var hitDeadline = false
@@ -293,6 +321,11 @@ func serializeAccessibilityWindow(
           children: []
         )
       }
+      let containsProtectedContent = safeAXPrimitive(
+        element,
+        NSAccessibility.Attribute.containsProtectedContent.rawValue as CFString,
+        beforeDeadline: beforeDeadline
+      ) == "true"
 
       var fields: [(String, String)] = []
       func add(_ name: String, _ value: @autoclosure () -> String?) {
@@ -302,7 +335,9 @@ func serializeAccessibilityWindow(
       add("role", role)
       add("label", safeAXString(element, kAXDescriptionAttribute as CFString, beforeDeadline: beforeDeadline))
       add("title", safeAXString(element, kAXTitleAttribute as CFString, beforeDeadline: beforeDeadline))
-      add("value", safeAXPrimitive(element, kAXValueAttribute as CFString, beforeDeadline: beforeDeadline))
+      if !containsProtectedContent {
+        add("value", safeAXPrimitive(element, kAXValueAttribute as CFString, beforeDeadline: beforeDeadline))
+      }
       add("description", safeAXString(element, kAXHelpAttribute as CFString, beforeDeadline: beforeDeadline))
       add("enabled", safeAXPrimitive(element, kAXEnabledAttribute as CFString, beforeDeadline: beforeDeadline))
       add("selected", safeAXPrimitive(element, kAXSelectedAttribute as CFString, beforeDeadline: beforeDeadline))
@@ -330,7 +365,9 @@ private func focusedAXWindow(for app: NSRunningApplication) -> AXUIElement? {
   AXUIElementSetMessagingTimeout(appElement, 0.1)
   guard let value = copyAXAttribute(appElement, kAXFocusedWindowAttribute as CFString),
         CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
-  return (value as! AXUIElement)
+  let window = value as! AXUIElement
+  AXUIElementSetMessagingTimeout(window, 0.1)
+  return window
 }
 
 private func axBounds(_ element: AXUIElement?) -> CGRect? {
@@ -362,19 +399,62 @@ private func isFiniteNormalFrame(_ frame: CGRect) -> Bool {
     && frame.height > 1
 }
 
+private func selectedWindowIndex(
+  candidates: [WindowCandidateFacts],
+  axTitle: String?,
+  axBounds: CGRect?
+) -> Int? {
+  let eligible = candidates.indices.filter { index in
+    let candidate = candidates[index]
+    return candidate.alpha.map { $0 > 0 } == true && isFiniteNormalFrame(candidate.frame)
+  }
+  let usableTitle = axTitle.flatMap { $0.isEmpty ? nil : $0 }
+  let usableBounds = axBounds.flatMap { isFiniteNormalFrame($0) ? $0 : nil }
+  func uniqueMatch(where matches: (Int) -> Bool) -> Int? {
+    let matching = eligible.filter(matches)
+    return matching.count == 1 ? matching[0] : nil
+  }
+  switch (usableTitle, usableBounds) {
+  case let (title?, bounds?):
+    return uniqueMatch { index in
+      candidates[index].title == title && approximatelyMatches(candidates[index].frame, bounds)
+    }
+  case let (title?, nil):
+    return uniqueMatch { candidates[$0].title == title }
+  case let (nil, bounds?):
+    return uniqueMatch { approximatelyMatches(candidates[$0].frame, bounds) }
+  case (nil, nil):
+    return eligible.first
+  }
+}
+
 private func windowAlpha(_ window: SCWindow) -> Double? {
   guard let info = CGWindowListCopyWindowInfo([.optionIncludingWindow], window.windowID) as? [[String: Any]],
         let windowInfo = info.first else { return nil }
   return (windowInfo[kCGWindowAlpha as String] as? NSNumber)?.doubleValue
 }
 
-func frontmostTarget() async throws -> (app: NSRunningApplication, window: SCWindow, axWindow: AXUIElement?) {
-  guard let app = NSWorkspace.shared.frontmostApplication,
-        !app.isTerminated,
-        app.processIdentifier != ProcessInfo.processInfo.processIdentifier,
-        app.processIdentifier != getppid(),
-        app.activationPolicy != .prohibited else { throw AppshotError.noWindow }
+private func isEligibleFrontmostProcess(
+  processIdentifier: pid_t,
+  isTerminated: Bool,
+  activationPolicy: NSApplication.ActivationPolicy,
+  selfProcessIdentifier: pid_t
+) -> Bool {
+  guard !isTerminated,
+        processIdentifier != selfProcessIdentifier,
+        activationPolicy != .prohibited else { return false }
+  // The host (Cindy) stays eligible as a last-resort target: the composer
+  // action runs while Cindy is already active, and the spec verification
+  // matrix lists Cindy as a valid capture target when no other app window is
+  // visible. Normal invocations prefer the previously visible app behind
+  // Cindy, and the global-shortcut path captures before Cindy activates.
+  return true
+}
 
+private func captureTarget(
+  for app: NSRunningApplication,
+  preferredWindowID: CGWindowID?
+) async throws -> (app: NSRunningApplication, window: SCWindow, axWindow: AXUIElement?) {
   let axWindow = focusedAXWindow(for: app)
   let axTitle = axWindow.flatMap { safeAXString($0, kAXTitleAttribute as CFString) }
   let focusedBounds = axBounds(axWindow)
@@ -390,25 +470,93 @@ func frontmostTarget() async throws -> (app: NSRunningApplication, window: SCWin
     candidate.owningApplication?.processID == app.processIdentifier
       && candidate.windowLayer == 0
       && candidate.isOnScreen
-      && windowAlpha(candidate).map { $0 > 0 } != false
-      && isFiniteNormalFrame(candidate.frame)
   }
-  guard !candidates.isEmpty else { throw AppshotError.noWindow }
+  var selectedIndex: Int?
+  if let preferredWindowID {
+    selectedIndex = candidates.indices.first { candidates[$0].windowID == preferredWindowID }
+  }
+  if selectedIndex == nil {
+    let candidateFacts = candidates.map { candidate in
+      WindowCandidateFacts(
+        title: candidate.title,
+        frame: candidate.frame,
+        alpha: windowAlpha(candidate)
+      )
+    }
+    selectedIndex = selectedWindowIndex(
+      candidates: candidateFacts,
+      axTitle: axTitle,
+      axBounds: focusedBounds
+    )
+  }
+  guard let selectedIndex else { throw AppshotError.noWindow }
+  return (app, candidates[selectedIndex], axWindow)
+}
 
-  let titleAndBoundsMatch = candidates.first { candidate in
-    guard let axTitle, candidate.title == axTitle, let focusedBounds else { return false }
-    return approximatelyMatches(candidate.frame, focusedBounds)
+private struct PreviousWindowTarget {
+  let ownerProcessIdentifier: pid_t
+  let windowID: CGWindowID
+}
+
+private func firstVisibleForeignWindow(
+  from windowInfos: [[String: Any]],
+  selfProcessIdentifier: pid_t,
+  parentProcessIdentifier: pid_t
+) -> PreviousWindowTarget? {
+  for info in windowInfos {
+    guard let ownerPID = (info[kCGWindowOwnerPID as String] as? NSNumber)?.int32Value,
+          ownerPID != selfProcessIdentifier,
+          ownerPID != parentProcessIdentifier,
+          (info[kCGWindowLayer as String] as? NSNumber)?.intValue == 0,
+          (info[kCGWindowAlpha as String] as? NSNumber)?.doubleValue != 0,
+          (info[kCGWindowIsOnscreen as String] as? NSNumber)?.boolValue == true,
+          let windowIDNumber = info[kCGWindowNumber as String] as? NSNumber,
+          let bounds = info[kCGWindowBounds as String] as? [String: NSNumber],
+          (bounds["Width"]?.doubleValue ?? 0) > 1,
+          (bounds["Height"]?.doubleValue ?? 0) > 1 else { continue }
+    return PreviousWindowTarget(
+      ownerProcessIdentifier: ownerPID,
+      windowID: CGWindowID(windowIDNumber.uint32Value)
+    )
   }
-  let titleMatch = candidates.first { candidate in
-    guard let axTitle else { return false }
-    return candidate.title == axTitle
+  return nil
+}
+
+func frontmostTarget() async throws -> (app: NSRunningApplication, window: SCWindow, axWindow: AXUIElement?) {
+  guard let frontmost = NSWorkspace.shared.frontmostApplication else { throw AppshotError.noWindow }
+  let selfProcessIdentifier = ProcessInfo.processInfo.processIdentifier
+  let parentProcessIdentifier = getppid()
+  if frontmost.processIdentifier == parentProcessIdentifier
+      || frontmost.processIdentifier == selfProcessIdentifier {
+    // The host (Cindy) is frontmost whenever the composer action or the
+    // shortcut is invoked while Cindy is active. Like Codex, capture the app
+    // window the user was looking at before Cindy: the topmost visible
+    // non-host window. Fall back to the host window itself when nothing else
+    // is visible so the action never silently fails.
+    if let windowList = CGWindowListCopyWindowInfo([.optionOnScreenOnly, .optionIncludingWindow], kCGNullWindowID)
+        as? [[String: Any]],
+       let previous = firstVisibleForeignWindow(
+         from: windowList,
+         selfProcessIdentifier: selfProcessIdentifier,
+         parentProcessIdentifier: parentProcessIdentifier
+       ),
+       let previousApp = NSRunningApplication(processIdentifier: previous.ownerProcessIdentifier),
+       isEligibleFrontmostProcess(
+         processIdentifier: previousApp.processIdentifier,
+         isTerminated: previousApp.isTerminated,
+         activationPolicy: previousApp.activationPolicy,
+         selfProcessIdentifier: selfProcessIdentifier
+       ) {
+      return try await captureTarget(for: previousApp, preferredWindowID: previous.windowID)
+    }
   }
-  let boundsMatch = candidates.first { candidate in
-    guard let focusedBounds else { return false }
-    return approximatelyMatches(candidate.frame, focusedBounds)
-  }
-  let selected = titleAndBoundsMatch ?? titleMatch ?? boundsMatch ?? candidates[0]
-  return (app, selected, axWindow)
+  guard isEligibleFrontmostProcess(
+    processIdentifier: frontmost.processIdentifier,
+    isTerminated: frontmost.isTerminated,
+    activationPolicy: frontmost.activationPolicy,
+    selfProcessIdentifier: selfProcessIdentifier
+  ) else { throw AppshotError.noWindow }
+  return try await captureTarget(for: frontmost, preferredWindowID: nil)
 }
 
 func isBlankImage(_ image: CGImage) -> Bool {
@@ -596,6 +744,21 @@ private func emitJSON(_ payload: [String: Any]) throws {
 }
 
 private func runSelfTest() -> Bool {
+  guard parseHelperMode(["--self-test"]) == .selfTest,
+        parseHelperMode(["--output-dir", "/private/tmp/cindy-appshot-test"]) == .capture(
+          outputDirectory: "/private/tmp/cindy-appshot-test",
+          selfTestBeforeCapture: false
+        ),
+        parseHelperMode([
+          "--self-test-and-capture",
+          "--output-dir",
+          "/private/tmp/cindy-appshot-test",
+        ]) == .capture(
+          outputDirectory: "/private/tmp/cindy-appshot-test",
+          selfTestBeforeCapture: true
+        ),
+        parseHelperMode(["--self-test-and-capture"]) == nil else { return false }
+
   let ordinaryLimits = SerializationLimits(maxNodes: 10, maxDepth: 4, maxBytes: 4_096)
   let secure = serializeFixture(
     FixtureNode(
@@ -654,16 +817,162 @@ private func runSelfTest() -> Bool {
     deadlineNode: 2,
     prepareNode: { preparedRoles.append($0.role) }
   )
-  return deadlineLimited.truncated
+  guard deadlineLimited.truncated
     && preparedRoles == ["AXWindow", "AXButton"]
     && deadlineLimited.text?.contains("button-0") == true
-    && deadlineLimited.text?.contains("button-1") == false
+    && deadlineLimited.text?.contains("button-1") == false else { return false }
+
+  let targetBounds = CGRect(x: 100, y: 100, width: 640, height: 480)
+  let conflictingIdentifiers = [
+    WindowCandidateFacts(
+      title: "Target",
+      frame: CGRect(x: 0, y: 0, width: 640, height: 480),
+      alpha: 1
+    ),
+    WindowCandidateFacts(title: "Other", frame: targetBounds, alpha: 1),
+  ]
+  guard selectedWindowIndex(
+    candidates: conflictingIdentifiers,
+    axTitle: "Target",
+    axBounds: targetBounds
+  ) == nil else { return false }
+
+  guard selectedWindowIndex(
+    candidates: [WindowCandidateFacts(title: "Other", frame: targetBounds, alpha: 1)],
+    axTitle: "Missing",
+    axBounds: CGRect(x: 900, y: 900, width: 640, height: 480)
+  ) == nil else { return false }
+
+  let alphaCandidates = [
+    WindowCandidateFacts(title: "Unknown alpha", frame: targetBounds, alpha: nil),
+    WindowCandidateFacts(title: "Visible", frame: targetBounds, alpha: 1),
+  ]
+  guard selectedWindowIndex(candidates: alphaCandidates, axTitle: nil, axBounds: nil) == 1 else {
+    return false
+  }
+
+  let duplicateMatches = [
+    WindowCandidateFacts(title: "Target", frame: targetBounds, alpha: 1),
+    WindowCandidateFacts(title: "Target", frame: targetBounds, alpha: 1),
+  ]
+  guard selectedWindowIndex(
+    candidates: duplicateMatches,
+    axTitle: "Target",
+    axBounds: targetBounds
+  ) == nil else { return false }
+  guard selectedWindowIndex(
+    candidates: duplicateMatches,
+    axTitle: "Target",
+    axBounds: nil
+  ) == nil else { return false }
+  guard selectedWindowIndex(
+    candidates: duplicateMatches,
+    axTitle: nil,
+    axBounds: targetBounds
+  ) == nil else { return false }
+
+  // The frontmost app may be the host process that spawned this helper (the
+  // composer attachment action runs while Cindy is active). Capturing Cindy
+  // itself is an approved spec scenario, so the parent PID must stay eligible.
+  guard isEligibleFrontmostProcess(
+    processIdentifier: 42,
+    isTerminated: false,
+    activationPolicy: .regular,
+    selfProcessIdentifier: 41
+  ) else { return false }
+  // The helper must never target itself or a terminated or prohibited app.
+  guard isEligibleFrontmostProcess(
+    processIdentifier: 42,
+    isTerminated: false,
+    activationPolicy: .regular,
+    selfProcessIdentifier: 42
+  ) == false,
+  isEligibleFrontmostProcess(
+    processIdentifier: 42,
+    isTerminated: true,
+    activationPolicy: .regular,
+    selfProcessIdentifier: 41
+  ) == false,
+  isEligibleFrontmostProcess(
+    processIdentifier: 42,
+    isTerminated: false,
+    activationPolicy: .prohibited,
+    selfProcessIdentifier: 41
+  ) == false else { return false }
+
+  func windowInfo(
+    pid: pid_t,
+    layer: Int = 0,
+    alpha: Double = 1,
+    onscreen: Bool = true,
+    windowID: UInt32 = 0,
+    width: CGFloat = 100,
+    height: CGFloat = 100
+  ) -> [String: Any] {
+    [
+      kCGWindowOwnerPID as String: NSNumber(value: pid),
+      kCGWindowLayer as String: NSNumber(value: layer),
+      kCGWindowAlpha as String: NSNumber(value: alpha),
+      kCGWindowIsOnscreen as String: NSNumber(value: onscreen),
+      kCGWindowNumber as String: NSNumber(value: windowID),
+      kCGWindowBounds as String: [
+        "Width": NSNumber(value: width),
+        "Height": NSNumber(value: height),
+      ],
+    ]
+  }
+  guard firstVisibleForeignWindow(
+    from: [
+      windowInfo(pid: 41),
+      windowInfo(pid: 50, windowID: 100),
+    ],
+    selfProcessIdentifier: 42,
+    parentProcessIdentifier: 41
+  )?.ownerProcessIdentifier == 50,
+  firstVisibleForeignWindow(
+    from: [
+      windowInfo(pid: 41),
+      windowInfo(pid: 42),
+      windowInfo(pid: 50, layer: 25),
+      windowInfo(pid: 50, alpha: 0),
+      windowInfo(pid: 50, width: 1, height: 1),
+      windowInfo(pid: 50, windowID: 200),
+    ],
+    selfProcessIdentifier: 42,
+    parentProcessIdentifier: 41
+  )?.windowID == 200,
+  firstVisibleForeignWindow(
+    from: [windowInfo(pid: 41), windowInfo(pid: 42)],
+    selfProcessIdentifier: 42,
+    parentProcessIdentifier: 41
+  ) == nil else { return false }
+
+  let protected = serializeFixture(
+    FixtureNode(
+      role: "AXStaticText",
+      label: "Account balance",
+      title: "Balance",
+      value: "secret-value",
+      description: "Visible structure",
+      containsProtectedContent: true
+    ),
+    limits: ordinaryLimits
+  )
+  return protected.text?.contains("role: AXStaticText") == true
+    && protected.text?.contains("Account balance") == true
+    && protected.text?.contains("Balance") == true
+    && protected.text?.contains("Visible structure") == true
+    && protected.text?.contains("secret-value") == false
 }
 
 private enum MacOSAppshotHelper {
   static func run() async {
     let arguments = Array(CommandLine.arguments.dropFirst())
-    if arguments == ["--self-test"] {
+    guard let mode = parseHelperMode(arguments) else {
+      FileHandle.standardError.write(Data("APPSHOT_INVALID_OUTPUT: invalid output directory\n".utf8))
+      exit(2)
+    }
+    if mode == .selfTest {
       guard runSelfTest() else { exit(1) }
       do {
         try emitJSON(["type": "self-test", "ok": true])
@@ -674,10 +983,13 @@ private enum MacOSAppshotHelper {
     }
 
     do {
-      guard arguments.count == 2, arguments[0] == "--output-dir" else {
-        throw AppshotError.invalidOutput
+      guard case let .capture(outputDirectory, selfTestBeforeCapture) = mode else {
+        throw AppshotError.nativeFailure
       }
-      let outputURL = try validatedOutputURL(argument: arguments[1])
+      if selfTestBeforeCapture, !runSelfTest() {
+        throw AppshotError.nativeFailure
+      }
+      let outputURL = try validatedOutputURL(argument: outputDirectory)
       let target = try await frontmostTarget()
       _ = try await captureWindow(target.window, to: outputURL)
       let accessibility = serializeAccessibilityWindow(

--- a/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
+++ b/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
@@ -94,6 +94,36 @@ describe('agentInputQueue', () => {
     });
   });
 
+  it('drops malformed Appshot metadata without dropping the queued image', () => {
+    expect(
+      buildMakerUserMessage(
+        queuedMessage([
+          {
+            id: 'appshot-invalid',
+            name: 'appshot.png',
+            path: '/repo/appshot.png',
+            ext: '.png',
+            size: 128,
+            category: 'image',
+            mimeType: 'image/png',
+            url: 'xdt-image://session/appshot-invalid.png',
+            appshot: { ...appshot, schemaVersion: 2 } as unknown as AppshotMetadata,
+          },
+        ]),
+      ),
+    ).toEqual({
+      type: 'user',
+      content: [
+        { type: 'text', text: 'inspect attachment' },
+        {
+          type: 'image',
+          path: 'xdt-image://session/appshot-invalid.png',
+          mimeType: 'image/png',
+        },
+      ],
+    });
+  });
+
   it('sends queued GIF attachments as file blocks', () => {
     expect(
       buildMakerUserMessage(

--- a/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
+++ b/apps/desktop/src/main/__tests__/agentInputQueue.test.ts
@@ -10,6 +10,26 @@ import {
   updateQueuedMessageContent,
   updateQueuedMessageText,
 } from '../../shared/agentInputQueue.js';
+import type { AppshotMetadata } from '../../shared/appshots.js';
+
+const appshot: AppshotMetadata = {
+  schemaVersion: 1,
+  captureId: 'capture-1',
+  capturedAt: '2026-08-05T00:00:00.000Z',
+  applicationName: 'A&B',
+  bundleIdentifier: 'com.example.app',
+  windowTitle: '"Draft" <1>',
+  accessibilityText: '<AXButton title="Send & close">',
+  accessibilityTruncated: false,
+};
+
+const appshotContext =
+  '<appshot app="A&amp;B" bundle-identifier="com.example.app" window-title="&quot;Draft&quot; &lt;1&gt;">\n' +
+  'Window: ""Draft" &lt;1&gt;", App: A&amp;B.\n' +
+  '<accessibility-tree>\n' +
+  '&lt;AXButton title="Send &amp; close"&gt;\n' +
+  '</accessibility-tree>\n' +
+  '</appshot>';
 
 function queuedMessage(files: AgentInputQueuedMessage['files']): AgentInputQueuedMessage {
   return {
@@ -42,6 +62,38 @@ function queuedMessage(files: AgentInputQueuedMessage['files']): AgentInputQueue
 }
 
 describe('agentInputQueue', () => {
+  it('emits a queued Appshot image followed by one escaped context block', () => {
+    expect(
+      buildMakerUserMessage(
+        queuedMessage([
+          {
+            id: 'appshot-1',
+            name: 'appshot.png',
+            path: '/repo/appshot.png',
+            ext: '.png',
+            size: 128,
+            category: 'image',
+            mimeType: 'image/png',
+            url: 'xdt-image://session/appshot.png',
+            appshot,
+          },
+        ]),
+      ),
+    ).toEqual({
+      type: 'user',
+      content: [
+        { type: 'text', text: 'inspect attachment' },
+        {
+          type: 'image',
+          path: 'xdt-image://session/appshot.png',
+          mimeType: 'image/png',
+          appshot,
+        },
+        { type: 'text', text: appshotContext },
+      ],
+    });
+  });
+
   it('sends queued GIF attachments as file blocks', () => {
     expect(
       buildMakerUserMessage(

--- a/apps/desktop/src/main/appshots/MacAppshotNativeHost.ts
+++ b/apps/desktop/src/main/appshots/MacAppshotNativeHost.ts
@@ -1,0 +1,354 @@
+import { execFile } from 'node:child_process';
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { app } from 'electron';
+
+import { AppshotCaptureError, type AppshotFailureCode } from './coordinator.js';
+
+export interface MacAppshotNativeResult {
+  pngPath: string;
+  applicationName: string;
+  bundleIdentifier: string | null;
+  windowTitle: string | null;
+  accessibilityText: string | null;
+  accessibilityTruncated: boolean;
+  accessibilityUnavailableReason?: 'permission' | 'unsupported' | 'timeout';
+}
+
+const HELPER_RESOURCE = path.join('tools', 'appshots', 'xdt-macos-appshot-helper');
+const HELPER_SOURCE_RELATIVE = path.join('native', 'appshots', 'macos-appshot-helper.swift');
+const HELPER_TIMEOUT_MS = 10_000;
+const HELPER_BUILD_TIMEOUT_MS = 30_000;
+const HELPER_SELF_TEST_TIMEOUT_MS = 5_000;
+const MAX_STDOUT_BYTES = 1024 * 1024;
+const MAX_SELF_TEST_STDOUT_BYTES = 4 * 1024;
+const MAX_SCALAR_BYTES = 4 * 1024;
+const MAX_ACCESSIBILITY_BYTES = 512 * 1024;
+const DEPLOYMENT_TARGET = 'macos14.0';
+const BUILD_RECIPE_VERSION = 'v1';
+const SWIFTC_FLAGS = ['-O'] as const;
+const MAX_PUBLISH_ATTEMPTS = 3;
+let helperBinaryPromise: Promise<string> | null = null;
+
+interface FileIdentity {
+  dev: bigint;
+  ino: bigint;
+}
+
+interface CandidateValidation {
+  valid: boolean;
+  identity: FileIdentity | null;
+}
+
+function byteLength(value: string): number {
+  return Buffer.byteLength(value, 'utf8');
+}
+
+function isBoundedString(value: unknown, allowEmpty = true): value is string {
+  return typeof value === 'string' && byteLength(value) <= MAX_SCALAR_BYTES && (allowEmpty || value.length > 0);
+}
+
+function isNullableBoundedString(value: unknown): value is string | null {
+  return value === null || isBoundedString(value);
+}
+
+function parseResult(stdout: string): MacAppshotNativeResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(stdout.trim());
+  } catch {
+    throw new AppshotCaptureError('native-failure');
+  }
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new AppshotCaptureError('native-failure');
+  const value = raw as Record<string, unknown>;
+  if (
+    value.type !== 'capture'
+    || !isBoundedString(value.pngPath, false)
+    || !isBoundedString(value.applicationName, false)
+    || !isNullableBoundedString(value.bundleIdentifier)
+    || !isNullableBoundedString(value.windowTitle)
+    || !(value.accessibilityText === null || (typeof value.accessibilityText === 'string' && byteLength(value.accessibilityText) <= MAX_ACCESSIBILITY_BYTES))
+    || typeof value.accessibilityTruncated !== 'boolean'
+    || !(value.accessibilityUnavailableReason === undefined || value.accessibilityUnavailableReason === 'permission' || value.accessibilityUnavailableReason === 'unsupported' || value.accessibilityUnavailableReason === 'timeout')
+  ) {
+    throw new AppshotCaptureError('native-failure');
+  }
+  return {
+    pngPath: value.pngPath,
+    applicationName: value.applicationName,
+    bundleIdentifier: value.bundleIdentifier,
+    windowTitle: value.windowTitle,
+    accessibilityText: value.accessibilityText,
+    accessibilityTruncated: value.accessibilityTruncated,
+    ...(value.accessibilityUnavailableReason === undefined
+      ? {}
+      : { accessibilityUnavailableReason: value.accessibilityUnavailableReason }),
+  };
+}
+
+function mapNativeFailure(stderr: string): AppshotFailureCode {
+  if (stderr.includes('APPSHOT_SCREEN_PERMISSION')) return 'screen-permission';
+  if (stderr.includes('APPSHOT_NO_WINDOW')) return 'no-window';
+  if (stderr.includes('APPSHOT_WINDOW_CLOSED')) return 'window-closed';
+  if (stderr.includes('APPSHOT_PROTECTED_CONTENT')) return 'protected-content';
+  return 'native-failure';
+}
+
+function execHelper(binary: string, outputDir: string, selfTestBeforeCapture: boolean): Promise<string> {
+  const args = selfTestBeforeCapture
+    ? ['--self-test-and-capture', '--output-dir', outputDir]
+    : ['--output-dir', outputDir];
+  return new Promise((resolve, reject) => {
+    execFile(
+      binary,
+      args,
+      { timeout: HELPER_TIMEOUT_MS, maxBuffer: MAX_STDOUT_BYTES, encoding: 'utf8' },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new AppshotCaptureError(mapNativeFailure(stderr)));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}
+
+export class MacAppshotNativeHost {
+  async capture(outputDir: string): Promise<MacAppshotNativeResult> {
+    if (process.platform !== 'darwin') throw new AppshotCaptureError('unsupported-platform');
+    const selfTestBeforeCapture = !app.isPackaged;
+    const binary = await resolveMacAppshotHelperBinary();
+    return parseResult(await execHelper(binary, outputDir, selfTestBeforeCapture));
+  }
+}
+
+function resolveMacAppshotHelperBinary(): Promise<string> {
+  if (!helperBinaryPromise) {
+    helperBinaryPromise = buildMacAppshotHelperBinary().finally(() => {
+      helperBinaryPromise = null;
+    });
+  }
+  return helperBinaryPromise;
+}
+
+async function buildMacAppshotHelperBinary(): Promise<string> {
+  if (app.isPackaged) return path.join(process.resourcesPath, HELPER_RESOURCE);
+  const source = resolveDevHelperSource();
+  const helperDirectory = path.join(app.getPath('userData'), 'appshots');
+  try {
+    const sourceBytes = fs.readFileSync(source);
+    const target = targetForCurrentArchitecture();
+    const sourceHash = createHash('sha256').update(sourceBytes).digest('hex');
+    const cacheKey = createHash('sha256').update(JSON.stringify({
+      buildRecipeVersion: BUILD_RECIPE_VERSION,
+      architecture: process.arch,
+      deploymentTarget: DEPLOYMENT_TARGET,
+      sourceHash,
+      target,
+      flags: SWIFTC_FLAGS,
+    })).digest('hex');
+    fs.mkdirSync(helperDirectory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(helperDirectory, 0o700);
+    const binary = path.join(helperDirectory, `xdt-macos-appshot-helper-${cacheKey}`);
+    // Old recipe-addressed helpers are intentionally retained as a tiny dev
+    // cache. Age-based deletion can race another Cindy process executing one.
+    const cachedCandidate = await validateHelperCandidate(binary);
+    if (cachedCandidate.valid) return binary;
+    removeCandidateIfUnchanged(binary, cachedCandidate.identity);
+
+    const uniqueBuildId = `${process.pid}-${randomUUID()}`;
+    const sourceSnapshot = path.join(
+      helperDirectory,
+      `.xdt-macos-appshot-helper-${cacheKey}-${uniqueBuildId}.swift`,
+    );
+    const temporaryBinary = path.join(
+      helperDirectory,
+      `.xdt-macos-appshot-helper-${cacheKey}-${uniqueBuildId}.tmp`,
+    );
+    try {
+      fs.writeFileSync(sourceSnapshot, sourceBytes, { flag: 'wx', mode: 0o600 });
+      await execSwiftc([
+        sourceSnapshot,
+        ...SWIFTC_FLAGS,
+        '-target',
+        target,
+        '-o',
+        temporaryBinary,
+      ]);
+      fs.chmodSync(temporaryBinary, 0o755);
+      const compiledCandidate = await validateHelperCandidate(temporaryBinary);
+      if (!compiledCandidate.valid || !compiledCandidate.identity) {
+        throw new AppshotCaptureError('native-failure');
+      }
+      return await publishHelperCandidate(temporaryBinary, binary, compiledCandidate.identity);
+    } finally {
+      removeTemporaryFile(sourceSnapshot);
+      removeTemporaryFile(temporaryBinary);
+    }
+  } catch {
+    throw new AppshotCaptureError('native-failure');
+  }
+}
+
+async function publishHelperCandidate(
+  temporaryBinary: string,
+  binary: string,
+  validatedIdentity: FileIdentity,
+): Promise<string> {
+  for (let attempt = 0; attempt < MAX_PUBLISH_ATTEMPTS; attempt += 1) {
+    const temporaryCandidate = inspectHelperCandidate(temporaryBinary);
+    if (!temporaryCandidate?.executable || !sameIdentity(validatedIdentity, temporaryCandidate.identity)) {
+      throw new AppshotCaptureError('native-failure');
+    }
+    try {
+      // link is the no-clobber atomic publish primitive available in Node. A
+      // competing process either installs this complete inode or wins with its
+      // own complete inode; no process can observe a partial final path.
+      fs.linkSync(temporaryBinary, binary);
+      const publishedCandidate = inspectHelperCandidate(binary);
+      if (!publishedCandidate?.executable || !sameIdentity(validatedIdentity, publishedCandidate.identity)) {
+        removeCandidateIfUnchanged(binary, publishedCandidate?.identity ?? null);
+        throw new AppshotCaptureError('native-failure');
+      }
+      return binary;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+    }
+    const winner = await validateHelperCandidate(binary);
+    if (winner.valid) return binary;
+    removeCandidateIfUnchanged(binary, winner.identity);
+  }
+  throw new AppshotCaptureError('native-failure');
+}
+
+function inspectHelperCandidate(filePath: string): { identity: FileIdentity; executable: boolean } | null {
+  try {
+    const stat = fs.lstatSync(filePath, { bigint: true });
+    if (stat.dev === 0n || stat.ino === 0n) return null;
+    const identity = { dev: stat.dev, ino: stat.ino };
+    if (!stat.isFile() || stat.isSymbolicLink()) return { identity, executable: false };
+    try {
+      fs.accessSync(filePath, fs.constants.X_OK);
+      return { identity, executable: true };
+    } catch {
+      return { identity, executable: false };
+    }
+  } catch {
+    return null;
+  }
+}
+
+async function validateHelperCandidate(filePath: string): Promise<CandidateValidation> {
+  const before = inspectHelperCandidate(filePath);
+  if (!before?.executable) return { valid: false, identity: before?.identity ?? null };
+  const selfTestPassed = await execHelperSelfTest(filePath);
+  const after = inspectHelperCandidate(filePath);
+  return {
+    valid: selfTestPassed && Boolean(after?.executable) && sameIdentity(before.identity, after?.identity),
+    identity: before.identity,
+  };
+}
+
+function sameIdentity(left: FileIdentity, right: FileIdentity | undefined): boolean {
+  return Boolean(right) && left.dev === right?.dev && left.ino === right.ino;
+}
+
+function removeCandidateIfUnchanged(filePath: string, observed: FileIdentity | null): boolean {
+  if (!observed) return false;
+  const quarantined = `${filePath}.invalid-${process.pid}-${randomUUID()}.tmp`;
+  try {
+    fs.renameSync(filePath, quarantined);
+  } catch {
+    return false;
+  }
+  const moved = inspectHelperCandidate(quarantined);
+  if (moved && sameIdentity(observed, moved.identity)) {
+    removeTemporaryFile(quarantined);
+    return true;
+  }
+
+  try {
+    // The path changed after validation. Restore that exact replacement under
+    // the cache key without clobbering a still-newer process winner.
+    fs.linkSync(quarantined, filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EEXIST') {
+      throw new AppshotCaptureError('native-failure');
+    }
+  } finally {
+    removeTemporaryFile(quarantined);
+  }
+  return false;
+}
+
+/** Narrow executable seam for exact filesystem-identity regression tests. */
+export function __testOnlyRemoveCandidateIfUnchanged(
+  filePath: string,
+  observed: { dev: bigint; ino: bigint },
+): boolean {
+  return removeCandidateIfUnchanged(filePath, observed);
+}
+
+function removeTemporaryFile(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    // Missing temp means compilation failed before writing or cleanup already won.
+  }
+}
+
+function targetForCurrentArchitecture(): string {
+  if (process.arch === 'arm64') return `arm64-apple-${DEPLOYMENT_TARGET}`;
+  if (process.arch === 'x64') return `x86_64-apple-${DEPLOYMENT_TARGET}`;
+  throw new AppshotCaptureError('native-failure');
+}
+
+function resolveDevHelperSource(): string {
+  const fromAppPath = path.join(app.getAppPath(), HELPER_SOURCE_RELATIVE);
+  return fs.existsSync(fromAppPath) ? fromAppPath : path.join(__dirname, '..', '..', HELPER_SOURCE_RELATIVE);
+}
+
+function execSwiftc(args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    execFile('swiftc', args, { timeout: HELPER_BUILD_TIMEOUT_MS, maxBuffer: MAX_STDOUT_BYTES }, (error) => {
+      if (error) reject(new AppshotCaptureError('native-failure'));
+      else resolve();
+    });
+  });
+}
+
+function execHelperSelfTest(binary: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(
+      binary,
+      ['--self-test'],
+      {
+        timeout: HELPER_SELF_TEST_TIMEOUT_MS,
+        maxBuffer: MAX_SELF_TEST_STDOUT_BYTES,
+        encoding: 'utf8',
+      },
+      (error, stdout) => {
+        if (error) {
+          resolve(false);
+          return;
+        }
+        resolve(isValidSelfTestResponse(stdout));
+      },
+    );
+  });
+}
+
+function isValidSelfTestResponse(stdout: string): boolean {
+  let value: unknown;
+  try {
+    value = JSON.parse(stdout.trim());
+  } catch {
+    return false;
+  }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const payload = value as Record<string, unknown>;
+  return Object.keys(payload).length === 2 && payload.type === 'self-test' && payload.ok === true;
+}

--- a/apps/desktop/src/main/appshots/__tests__/MacAppshotNativeHost.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/MacAppshotNativeHost.test.ts
@@ -1,0 +1,571 @@
+import { EventEmitter } from 'node:events';
+import { createHash } from 'node:crypto';
+import fsSync from 'node:fs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { app } from 'electron';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  execFile: vi.fn(),
+}));
+
+const tempRoots = new Set<string>();
+const originalArch = process.arch;
+const originalPlatform = process.platform;
+const BUILD_RECIPE_VERSION = 'v1';
+const DEPLOYMENT_TARGET = 'macos14.0';
+const SWIFTC_FLAGS = ['-O'];
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+    getAppPath: vi.fn(),
+    getPath: vi.fn(),
+  },
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: h.execFile,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  h.execFile.mockReset();
+  vi.mocked(app.getAppPath).mockReset();
+  vi.mocked(app.getPath).mockReset();
+  Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+  Object.defineProperty(process, 'arch', { value: 'arm64', configurable: true });
+  Object.defineProperty(process, 'resourcesPath', {
+    value: '/Applications/Cindy.app/Contents/Resources',
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(app, 'isPackaged', { value: true, configurable: true });
+  Object.defineProperty(process, 'arch', { value: originalArch, configurable: true });
+  Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+  vi.restoreAllMocks();
+  return Promise.all([...tempRoots].map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+function mockHelperStdout(stdout: string): void {
+  h.execFile.mockImplementation((_binary, _args, _options, callback) => {
+    callback(null, stdout, 'captured stderr must not be exposed');
+    return new EventEmitter();
+  });
+}
+
+function capturePayload(): string {
+  return JSON.stringify({
+    type: 'capture',
+    pngPath: '/tmp/cindy-appshot/capture.png',
+    applicationName: 'Example App',
+    bundleIdentifier: 'com.example.app',
+    windowTitle: null,
+    accessibilityText: null,
+    accessibilityTruncated: false,
+  });
+}
+
+async function unpackagedFixture(source = 'import Foundation\n'): Promise<{
+  appRoot: string;
+  sourcePath: string;
+  userData: string;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), 'cindy-appshot-host-'));
+  tempRoots.add(root);
+  const appRoot = path.join(root, 'app');
+  const sourcePath = path.join(appRoot, 'native', 'appshots', 'macos-appshot-helper.swift');
+  const userData = path.join(root, 'user-data');
+  await fs.mkdir(path.dirname(sourcePath), { recursive: true });
+  await fs.mkdir(userData, { recursive: true });
+  await fs.writeFile(sourcePath, source);
+  Object.defineProperty(app, 'isPackaged', { value: false, configurable: true });
+  vi.mocked(app.getAppPath).mockReturnValue(appRoot);
+  vi.mocked(app.getPath).mockReturnValue(userData);
+  return { appRoot, sourcePath, userData };
+}
+
+function targetForArch(arch: string): string {
+  return `${arch === 'arm64' ? 'arm64' : 'x86_64'}-apple-${DEPLOYMENT_TARGET}`;
+}
+
+function expectedDevBinary(userData: string, sourceBytes: Buffer, arch = process.arch): string {
+  const sourceHash = createHash('sha256').update(sourceBytes).digest('hex');
+  const cacheKey = createHash('sha256').update(JSON.stringify({
+    buildRecipeVersion: BUILD_RECIPE_VERSION,
+    architecture: arch,
+    deploymentTarget: DEPLOYMENT_TARGET,
+    sourceHash,
+    target: targetForArch(arch),
+    flags: SWIFTC_FLAGS,
+  })).digest('hex');
+  return path.join(userData, 'appshots', `xdt-macos-appshot-helper-${cacheKey}`);
+}
+
+interface DevExecMockOptions {
+  compileError?: boolean;
+  beforeCompileRead?: (input: string, output: string) => Promise<void>;
+  selfTestStdout?: (binary: string, contents: string) => string;
+  afterCombinedLaunch?: (binary: string) => void;
+}
+
+function installDevExecMock(options: DevExecMockOptions = {}) {
+  const compiledInputs: string[] = [];
+  const compiledInputBytes: Buffer[] = [];
+  const compiledOutputs: string[] = [];
+  const compilerArgs: string[][] = [];
+  const selfTestedBinaries: string[] = [];
+  const captureBinaries: string[] = [];
+  const captureArguments: string[][] = [];
+  const capturedBinaryContents: string[] = [];
+  h.execFile.mockImplementation((command, args, _execOptions, callback) => {
+    const child = new EventEmitter();
+    if (command === 'swiftc') {
+      const input = args[0];
+      const output = args[args.indexOf('-o') + 1];
+      compiledInputs.push(input);
+      compiledOutputs.push(output);
+      compilerArgs.push([...args]);
+      void (async () => {
+        await options.beforeCompileRead?.(input, output);
+        compiledInputBytes.push(await fs.readFile(input));
+        if (!options.compileError) await fs.writeFile(output, 'valid compiled helper');
+        callback(options.compileError ? new Error('compile failed') : null, '', 'compiler detail');
+      })();
+      return child;
+    }
+    if (args[0] === '--self-test') {
+      selfTestedBinaries.push(command);
+      void (async () => {
+        const contents = await fs.readFile(command, 'utf8');
+        const stdout = options.selfTestStdout?.(command, contents)
+          ?? (contents.startsWith('valid ')
+            ? JSON.stringify({ type: 'self-test', ok: true })
+            : '{"type":"self-test","ok":false}');
+        callback(null, stdout, 'self-test detail must not be exposed');
+      })();
+      return child;
+    }
+    if (args[0] === '--self-test-and-capture') {
+      captureBinaries.push(command);
+      captureArguments.push([...args]);
+      capturedBinaryContents.push(fsSync.readFileSync(command, 'utf8'));
+      options.afterCombinedLaunch?.(command);
+      callback(null, capturePayload(), '');
+      return child;
+    }
+    callback(new Error('unexpected helper arguments'), '', '');
+    return child;
+  });
+  return {
+    compiledInputs,
+    compiledInputBytes,
+    compiledOutputs,
+    compilerArgs,
+    selfTestedBinaries,
+    captureBinaries,
+    captureArguments,
+    capturedBinaryContents,
+  };
+}
+
+describe('MacAppshotNativeHost helper response boundary', () => {
+  it.each([
+    ['missing capture type', {}],
+    ['wrong capture type', { type: 'self-test' }],
+  ])('rejects %s without exposing helper output', async (label, override) => {
+    const result = {
+      type: 'capture',
+      pngPath: '/tmp/cindy-appshot/capture.png',
+      applicationName: 'Example App',
+      bundleIdentifier: 'com.example.app',
+      windowTitle: 'Secret title',
+      accessibilityText: 'secret captured content',
+      accessibilityTruncated: false,
+      ...override,
+    };
+    if (label === 'missing capture type') delete (result as { type?: string }).type;
+    mockHelperStdout(JSON.stringify(result));
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await expect(new MacAppshotNativeHost().capture('/tmp/cindy-appshot')).rejects.toMatchObject({
+      code: 'native-failure',
+    });
+    expect(h.execFile).toHaveBeenCalledWith(
+      path.join(process.resourcesPath, 'tools', 'appshots', 'xdt-macos-appshot-helper'),
+      ['--output-dir', '/tmp/cindy-appshot'],
+      expect.objectContaining({ timeout: 10_000, maxBuffer: 1024 * 1024 }),
+      expect.any(Function),
+    );
+  });
+
+  it('rejects malformed raw helper JSON without surfacing captured content', async () => {
+    mockHelperStdout('{"type":"capture","accessibilityText":"secret captured content"');
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await expect(new MacAppshotNativeHost().capture('/tmp/cindy-appshot')).rejects.toMatchObject({
+      code: 'native-failure',
+    });
+  });
+
+  it('rejects raw helper output with malformed required fields', async () => {
+    mockHelperStdout(JSON.stringify({
+      type: 'capture',
+      pngPath: '/tmp/cindy-appshot/capture.png',
+      applicationName: '',
+      bundleIdentifier: 'com.example.app',
+      windowTitle: 'Secret title',
+      accessibilityText: 'secret captured content',
+      accessibilityTruncated: false,
+    }));
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await expect(new MacAppshotNativeHost().capture('/tmp/cindy-appshot')).rejects.toMatchObject({
+      code: 'native-failure',
+    });
+  });
+
+  it('maps helper launch failure to stable native-failure without exposing process detail', async () => {
+    h.execFile.mockImplementation((_binary, _args, _options, callback) => {
+      callback(new Error('secret launch path'), '', 'secret helper stderr');
+      return new EventEmitter();
+    });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    const rejection = new MacAppshotNativeHost().capture('/tmp/cindy-appshot').catch((error) => error);
+    await expect(rejection).resolves.toMatchObject({ code: 'native-failure', message: 'native-failure' });
+    await expect(rejection).resolves.not.toMatchObject({ message: expect.stringContaining('secret') });
+  });
+});
+
+describe('MacAppshotNativeHost unpackaged helper cache', () => {
+  it('does not delete a replacement whose BigInt identity only collides after Number conversion', async () => {
+    const firstIdentity = 9_007_199_254_740_992n;
+    const replacementIdentity = 9_007_199_254_740_993n;
+    expect(Number(firstIdentity)).toBe(Number(replacementIdentity));
+    const filePath = path.join(os.tmpdir(), 'identity-only-test-helper');
+    let quarantinedPath = '';
+    vi.spyOn(fsSync, 'renameSync').mockImplementation((source, destination) => {
+      expect(source).toBe(filePath);
+      quarantinedPath = destination.toString();
+    });
+    vi.spyOn(fsSync, 'lstatSync').mockImplementation((candidate, options) => {
+      expect(options).toEqual({ bigint: true });
+      expect(candidate).toBe(quarantinedPath);
+      return {
+        dev: replacementIdentity,
+        ino: replacementIdentity,
+        isFile: () => true,
+        isSymbolicLink: () => false,
+      } as fsSync.BigIntStats;
+    });
+    vi.spyOn(fsSync, 'accessSync').mockImplementation(() => undefined);
+    const linkSpy = vi.spyOn(fsSync, 'linkSync').mockImplementation(() => undefined);
+    const unlinkSpy = vi.spyOn(fsSync, 'unlinkSync').mockImplementation(() => undefined);
+    const hostModule = await import('../MacAppshotNativeHost.js') as typeof import('../MacAppshotNativeHost.js') & {
+      __testOnlyRemoveCandidateIfUnchanged: (
+        target: string,
+        observed: { dev: bigint; ino: bigint },
+      ) => boolean;
+    };
+
+    const removed = hostModule.__testOnlyRemoveCandidateIfUnchanged(filePath, {
+      dev: firstIdentity,
+      ino: firstIdentity,
+    });
+
+    expect(removed).toBe(false);
+    expect(linkSpy).toHaveBeenCalledWith(quarantinedPath, filePath);
+    expect(unlinkSpy).toHaveBeenCalledWith(quarantinedPath);
+    expect(linkSpy.mock.invocationCallOrder[0]).toBeLessThan(unlinkSpy.mock.invocationCallOrder[0]);
+  });
+
+  it('compiles a private source snapshot into an immutable build-recipe cache key on miss', async () => {
+    const { sourcePath, userData } = await unpackagedFixture('source-v1');
+    const sourceBytes = await fs.readFile(sourcePath);
+    const {
+      compiledInputs,
+      compiledInputBytes,
+      compiledOutputs,
+      compilerArgs,
+      selfTestedBinaries,
+      captureBinaries,
+      captureArguments,
+    } = installDevExecMock();
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await new MacAppshotNativeHost().capture('/tmp/cindy-appshot');
+
+    const finalBinary = expectedDevBinary(userData, sourceBytes, 'arm64');
+    expect(captureBinaries).toEqual([finalBinary]);
+    expect(captureArguments).toEqual([
+      ['--self-test-and-capture', '--output-dir', '/tmp/cindy-appshot'],
+    ]);
+    expect(selfTestedBinaries).toEqual([compiledOutputs[0]]);
+    expect(compiledInputs).toHaveLength(1);
+    expect(compiledInputs[0]).not.toBe(sourcePath);
+    expect(compiledInputs[0]).toMatch(/\.swift$/);
+    expect(compiledInputBytes).toEqual([sourceBytes]);
+    expect(compiledOutputs).toHaveLength(1);
+    expect(compiledOutputs[0]).not.toBe(finalBinary);
+    expect(compilerArgs[0]).toEqual([
+      compiledInputs[0],
+      '-O',
+      '-target',
+      'arm64-apple-macos14.0',
+      '-o',
+      compiledOutputs[0],
+    ]);
+    await expect(fs.stat(finalBinary)).resolves.toMatchObject({ mode: expect.any(Number) });
+    await expect(fs.stat(compiledInputs[0])).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(compiledOutputs[0])).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await fs.readdir(path.dirname(finalBinary))).toEqual([path.basename(finalBinary)]);
+  });
+
+  it('self-tests a complete cache hit before capture without invoking swiftc', async () => {
+    const { sourcePath, userData } = await unpackagedFixture('source-v1');
+    const finalBinary = expectedDevBinary(userData, await fs.readFile(sourcePath), 'arm64');
+    await fs.mkdir(path.dirname(finalBinary), { recursive: true });
+    await fs.writeFile(finalBinary, 'valid cached helper', { mode: 0o755 });
+    const { compiledOutputs, selfTestedBinaries, captureBinaries } = installDevExecMock();
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await new MacAppshotNativeHost().capture('/tmp/cindy-appshot');
+
+    expect(compiledOutputs).toEqual([]);
+    expect(selfTestedBinaries).toEqual([finalBinary]);
+    expect(captureBinaries).toEqual([finalBinary]);
+  });
+
+  it('uses a different immutable binary after the helper source changes', async () => {
+    const { sourcePath } = await unpackagedFixture('source-v1');
+    const { captureBinaries } = installDevExecMock();
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+    const host = new MacAppshotNativeHost();
+
+    await host.capture('/tmp/cindy-appshot');
+    await fs.writeFile(sourcePath, 'source-v2');
+    await host.capture('/tmp/cindy-appshot');
+
+    expect(captureBinaries).toHaveLength(2);
+    expect(captureBinaries[0]).not.toBe(captureBinaries[1]);
+  });
+
+  it('compiles the original source snapshot when the live source mutates after build starts', async () => {
+    const originalSource = Buffer.from('source-before-build');
+    const { sourcePath, userData } = await unpackagedFixture(originalSource.toString());
+    let notifyCompileStarted!: () => void;
+    let releaseCompile!: () => void;
+    const compileStarted = new Promise<void>((resolve) => { notifyCompileStarted = resolve; });
+    const compileGate = new Promise<void>((resolve) => { releaseCompile = resolve; });
+    const { compiledInputs, compiledInputBytes, captureBinaries } = installDevExecMock({
+      beforeCompileRead: async () => {
+        notifyCompileStarted();
+        await compileGate;
+      },
+    });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    const capture = new MacAppshotNativeHost().capture('/tmp/cindy-appshot');
+    await compileStarted;
+    await fs.writeFile(sourcePath, 'source-after-build-started');
+    releaseCompile();
+    await capture;
+
+    expect(compiledInputs[0]).not.toBe(sourcePath);
+    expect(compiledInputBytes).toEqual([originalSource]);
+    expect(captureBinaries).toEqual([expectedDevBinary(userData, originalSource, 'arm64')]);
+  });
+
+  it('uses architecture-specific targets and cache paths for arm64 and x64', async () => {
+    const { sourcePath, userData } = await unpackagedFixture('source-v1');
+    const sourceBytes = await fs.readFile(sourcePath);
+    const { compilerArgs, captureBinaries } = installDevExecMock();
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+    const host = new MacAppshotNativeHost();
+
+    Object.defineProperty(process, 'arch', { value: 'arm64', configurable: true });
+    await host.capture('/tmp/cindy-appshot-arm64');
+    Object.defineProperty(process, 'arch', { value: 'x64', configurable: true });
+    await host.capture('/tmp/cindy-appshot-x64');
+
+    expect(compilerArgs[0]).toContain('arm64-apple-macos14.0');
+    expect(compilerArgs[1]).toContain('x86_64-apple-macos14.0');
+    expect(captureBinaries).toEqual([
+      expectedDevBinary(userData, sourceBytes, 'arm64'),
+      expectedDevBinary(userData, sourceBytes, 'x64'),
+    ]);
+    expect(captureBinaries[0]).not.toBe(captureBinaries[1]);
+  });
+
+  it('does not launch a partial final binary while concurrent captures wait for compilation', async () => {
+    await unpackagedFixture('source-v1');
+    let finishCompile!: () => void;
+    const compileGate = new Promise<void>((resolve) => { finishCompile = resolve; });
+    const captureBinaries: string[] = [];
+    let compileCalls = 0;
+    h.execFile.mockImplementation((command, args, _execOptions, callback) => {
+      const child = new EventEmitter();
+      if (command === 'swiftc') {
+        compileCalls += 1;
+        const output = args[args.indexOf('-o') + 1];
+        void (async () => {
+          await fs.writeFile(output, 'partial');
+          await compileGate;
+          await fs.writeFile(output, 'valid complete');
+          callback(null, '', '');
+        })();
+      } else if (args[0] === '--self-test') {
+        void (async () => {
+          const contents = await fs.readFile(command, 'utf8');
+          callback(null, contents === 'valid complete'
+            ? JSON.stringify({ type: 'self-test', ok: true })
+            : JSON.stringify({ type: 'self-test', ok: false }), '');
+        })();
+      } else if (args[0] === '--self-test-and-capture') {
+        captureBinaries.push(command);
+        callback(null, capturePayload(), '');
+      }
+      return child;
+    });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+    const first = new MacAppshotNativeHost().capture('/tmp/cindy-appshot-1');
+    const second = new MacAppshotNativeHost().capture('/tmp/cindy-appshot-2');
+
+    await vi.waitFor(() => expect(compileCalls).toBe(1));
+    expect(captureBinaries).toEqual([]);
+    finishCompile();
+    await Promise.all([first, second]);
+    expect(captureBinaries).toHaveLength(2);
+    expect(new Set(captureBinaries).size).toBe(1);
+    await expect(fs.readFile(captureBinaries[0], 'utf8')).resolves.toBe('valid complete');
+  });
+
+  it('rebuilds a cache hit that fails self-test before launching capture', async () => {
+    const { sourcePath, userData } = await unpackagedFixture('source-v1');
+    const finalBinary = expectedDevBinary(userData, await fs.readFile(sourcePath), 'arm64');
+    await fs.mkdir(path.dirname(finalBinary), { recursive: true });
+    await fs.writeFile(finalBinary, 'corrupt cached helper', { mode: 0o755 });
+    const {
+      compiledOutputs,
+      selfTestedBinaries,
+      captureBinaries,
+      capturedBinaryContents,
+    } = installDevExecMock();
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await new MacAppshotNativeHost().capture('/tmp/cindy-appshot');
+
+    expect(compiledOutputs).toHaveLength(1);
+    expect(selfTestedBinaries).toContain(finalBinary);
+    expect(captureBinaries).toEqual([finalBinary]);
+    expect(capturedBinaryContents).toEqual(['valid compiled helper']);
+  });
+
+  it('binds dev self-test and capture to one launched process despite a later path replacement', async () => {
+    const { sourcePath, userData } = await unpackagedFixture('source-v1');
+    const finalBinary = expectedDevBinary(userData, await fs.readFile(sourcePath), 'arm64');
+    await fs.mkdir(path.dirname(finalBinary), { recursive: true });
+    await fs.writeFile(finalBinary, 'valid cached helper', { mode: 0o755 });
+    const {
+      compiledOutputs,
+      selfTestedBinaries,
+      captureBinaries,
+      captureArguments,
+      capturedBinaryContents,
+    } = installDevExecMock({
+      afterCombinedLaunch: (binary) => {
+        fsSync.writeFileSync(binary, 'corrupt replacement', { mode: 0o755 });
+      },
+    });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await new MacAppshotNativeHost().capture('/tmp/cindy-appshot');
+
+    expect(compiledOutputs).toEqual([]);
+    expect(selfTestedBinaries).toEqual([finalBinary]);
+    expect(captureBinaries).toEqual([finalBinary]);
+    expect(captureArguments).toEqual([
+      ['--self-test-and-capture', '--output-dir', '/tmp/cindy-appshot'],
+    ]);
+    expect(capturedBinaryContents).toEqual(['valid cached helper']);
+    await expect(fs.readFile(finalBinary, 'utf8')).resolves.toBe('corrupt replacement');
+  });
+
+  it('uses an explicit valid EEXIST winner after self-test', async () => {
+    await unpackagedFixture('source-v1');
+    const { compiledOutputs, selfTestedBinaries, captureBinaries, capturedBinaryContents } = installDevExecMock();
+    let winningBinary = '';
+    vi.spyOn(fsSync, 'linkSync').mockImplementationOnce((_temporary, destination) => {
+      winningBinary = destination.toString();
+      fsSync.writeFileSync(winningBinary, 'valid EEXIST winner', { mode: 0o755 });
+      throw Object.assign(new Error('publish race'), { code: 'EEXIST' });
+    });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await new MacAppshotNativeHost().capture('/tmp/cindy-appshot');
+
+    expect(compiledOutputs).toHaveLength(1);
+    expect(selfTestedBinaries).toEqual([compiledOutputs[0], winningBinary]);
+    expect(captureBinaries).toEqual([winningBinary]);
+    expect(capturedBinaryContents).toEqual(['valid EEXIST winner']);
+  });
+
+  it('never launches an invalid EEXIST winner as capture and publishes the validated temp', async () => {
+    await unpackagedFixture('source-v1');
+    const { compiledOutputs, selfTestedBinaries, captureBinaries, capturedBinaryContents } = installDevExecMock();
+    let invalidWinner = '';
+    vi.spyOn(fsSync, 'linkSync').mockImplementationOnce((_temporary, destination) => {
+      invalidWinner = destination.toString();
+      fsSync.writeFileSync(invalidWinner, 'corrupt EEXIST winner', { mode: 0o755 });
+      throw Object.assign(new Error('publish race'), { code: 'EEXIST' });
+    });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await new MacAppshotNativeHost().capture('/tmp/cindy-appshot');
+
+    expect(compiledOutputs).toHaveLength(1);
+    expect(selfTestedBinaries).toContain(invalidWinner);
+    expect(captureBinaries).toEqual([invalidWinner]);
+    expect(capturedBinaryContents).toEqual(['valid compiled helper']);
+  });
+
+  it('does not publish a compiled temp whose self-test response has extra fields', async () => {
+    const { userData } = await unpackagedFixture('source-v1');
+    const { compiledInputs, compiledOutputs, captureBinaries } = installDevExecMock({
+      selfTestStdout: () => JSON.stringify({ type: 'self-test', ok: true, extra: 'rejected' }),
+    });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await expect(new MacAppshotNativeHost().capture('/tmp/cindy-appshot')).rejects.toMatchObject({
+      code: 'native-failure',
+    });
+
+    expect(captureBinaries).toEqual([]);
+    await expect(fs.stat(compiledInputs[0])).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(compiledOutputs[0])).rejects.toMatchObject({ code: 'ENOENT' });
+    expect(await fs.readdir(path.join(userData, 'appshots'))).toEqual([]);
+  });
+
+  it('maps compile failure to native-failure and removes temporary source and binary outputs', async () => {
+    const { userData } = await unpackagedFixture('source-v1');
+    const { compiledInputs, compiledOutputs, captureBinaries } = installDevExecMock({ compileError: true });
+    const { MacAppshotNativeHost } = await import('../MacAppshotNativeHost.js');
+
+    await expect(new MacAppshotNativeHost().capture('/tmp/cindy-appshot')).rejects.toMatchObject({
+      code: 'native-failure',
+    });
+    expect(captureBinaries).toEqual([]);
+    expect(compiledInputs).toHaveLength(1);
+    expect(compiledOutputs).toHaveLength(1);
+    await expect(fs.stat(compiledInputs[0])).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(compiledOutputs[0])).rejects.toMatchObject({ code: 'ENOENT' });
+    const cacheEntries = await fs.readdir(path.join(userData, 'appshots'));
+    expect(cacheEntries).toEqual([]);
+  });
+});

--- a/apps/desktop/src/main/appshots/__tests__/coordinator.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/coordinator.test.ts
@@ -1,0 +1,372 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  AppshotCoordinator,
+  type AppshotCoordinatorDeps,
+  type MacAppshotNativeResult,
+} from '../coordinator.js';
+
+const PNG = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+const tempRoots = new Set<string>();
+
+function nativeResult(pngPath: string): MacAppshotNativeResult {
+  return {
+    pngPath,
+    applicationName: 'Example App',
+    bundleIdentifier: 'com.example.app',
+    windowTitle: 'Example window',
+    accessibilityText: 'button: Save',
+    accessibilityTruncated: false,
+  };
+}
+
+async function createTempRoot(prefix = 'cindy-appshot-test-'): Promise<string> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  tempRoots.add(root);
+  return root;
+}
+
+async function writePng(root: string, name = 'capture.png'): Promise<string> {
+  const output = path.join(root, name);
+  await fs.writeFile(output, PNG);
+  return output;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function createHarness(
+  captureNative: (outputDir: string) => Promise<MacAppshotNativeResult>,
+  options: { platform?: NodeJS.Platform } = {},
+) {
+  const published: unknown[] = [];
+  const ingested: Uint8Array[] = [];
+  const removed: string[] = [];
+  let sequence = 0;
+  const deps: AppshotCoordinatorDeps = {
+    captureNative,
+    ingestPng: async (bytes) => {
+      ingested.push(bytes);
+      return { url: `cindy-media://blobs/${ingested.length}.png`, filename: `${ingested.length}.png` };
+    },
+    makeTempDir: () => createTempRoot(),
+    removeTempDir: async (root) => {
+      removed.push(root);
+      await fs.rm(root, { recursive: true, force: true });
+      tempRoots.delete(root);
+    },
+    now: () => new Date('2026-08-06T01:02:03.000Z'),
+    randomUUID: () => `capture-${++sequence}`,
+    publish: (result) => published.push(result),
+  };
+  return {
+    coordinator: new AppshotCoordinator(deps, options.platform),
+    ingested,
+    published,
+    removed,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all([...tempRoots].map((root) => fs.rm(root, { recursive: true, force: true })));
+  tempRoots.clear();
+  vi.restoreAllMocks();
+});
+
+describe('AppshotCoordinator boundary', () => {
+  it('rejects unsupported platforms before allocating output or invoking native capture', async () => {
+    const captureNative = vi.fn();
+    const { coordinator } = createHarness(captureNative, { platform: 'win32' });
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'unsupported-platform' });
+    expect(captureNative).not.toHaveBeenCalled();
+  });
+
+  it('rejects an overlapping capture and invokes the native host only once', async () => {
+    const pending = deferred<MacAppshotNativeResult>();
+    const captureNative = vi.fn((outputDir: string) => {
+      void outputDir;
+      return pending.promise;
+    });
+    const { coordinator, removed } = createHarness(captureNative);
+
+    const first = coordinator.capture();
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'capture-in-progress' });
+    await vi.waitFor(() => expect(captureNative).toHaveBeenCalledTimes(1));
+    expect(captureNative).toHaveBeenCalledTimes(1);
+    const output = await writePng(captureNative.mock.calls[0][0]);
+    pending.resolve(nativeResult(output));
+    await expect(first).resolves.toMatchObject({ captureId: 'capture-1' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('rejects malformed native metadata and cleans its managed temp root', async () => {
+    const { coordinator, removed } = createHarness(async (root) => ({
+      ...nativeResult(await writePng(root)),
+      applicationName: '',
+    }));
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('rejects native output paths outside the managed temp root', async () => {
+    const outside = await createTempRoot('cindy-appshot-outside-');
+    const outsidePng = await writePng(outside);
+    const { coordinator, removed } = createHarness(async () => nativeResult(outsidePng));
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('rejects a symlink whose real path escapes the managed temp root', async () => {
+    const outside = await createTempRoot('cindy-appshot-outside-');
+    const outsidePng = await writePng(outside);
+    const { coordinator, removed } = createHarness(async (root) => {
+      const link = path.join(root, 'capture.png');
+      await fs.symlink(outsidePng, link);
+      return nativeResult(link);
+    });
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('rejects native output that is not a regular file', async () => {
+    const { coordinator, removed } = createHarness(async (root) => {
+      const output = path.join(root, 'capture.png');
+      await fs.mkdir(output);
+      return nativeResult(output);
+    });
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('ingests bytes from the validated descriptor when the pathname is swapped', async () => {
+    const replacement = Uint8Array.from([...PNG.slice(0, 8), 0x99]);
+    const ingestPng = vi.fn(async (_bytes: Uint8Array) => ({
+      url: 'cindy-media://blobs/race.png',
+      filename: 'race.png',
+    }));
+    const realStat = fs.stat;
+    let swapped = false;
+    vi.spyOn(fs, 'stat').mockImplementation(async (...args: Parameters<typeof fs.stat>) => {
+      const stats = await realStat(...args);
+      const filePath = String(args[0]);
+      if (!swapped && filePath.endsWith('capture.png')) {
+        swapped = true;
+        const replacementPath = `${filePath}.replacement`;
+        await fs.writeFile(replacementPath, replacement);
+        await fs.rename(replacementPath, filePath);
+      }
+      return stats;
+    });
+    const root = await createTempRoot();
+    const output = await writePng(root);
+    const coordinator = new AppshotCoordinator({
+      captureNative: async () => nativeResult(output),
+      ingestPng,
+      makeTempDir: async () => root,
+      removeTempDir: async (managedRoot) => {
+        await fs.rm(managedRoot, { recursive: true, force: true });
+        tempRoots.delete(managedRoot);
+      },
+      now: () => new Date(),
+      randomUUID: () => 'race-capture',
+      publish: () => undefined,
+    });
+
+    await expect(coordinator.capture()).resolves.toMatchObject({ captureId: 'race-capture' });
+    expect(swapped).toBe(true);
+    expect(ingestPng).toHaveBeenCalledTimes(1);
+    expect([...ingestPng.mock.calls[0][0]]).toEqual([...PNG]);
+    expect([...ingestPng.mock.calls[0][0]]).not.toEqual([...replacement]);
+  });
+
+  it.each([
+    ['wrong PNG signature', async (root: string) => {
+      const output = path.join(root, 'capture.png');
+      await fs.writeFile(output, Uint8Array.from([0, 1, 2, 3, 4, 5, 6, 7, 8]));
+      return output;
+    }],
+    ['zero-byte file', async (root: string) => {
+      const output = path.join(root, 'capture.png');
+      await fs.writeFile(output, new Uint8Array());
+      return output;
+    }],
+    ['sparse file larger than 100 MiB', async (root: string) => {
+      const output = path.join(root, 'capture.png');
+      const handle = await fs.open(output, 'w');
+      await handle.truncate(100 * 1024 * 1024 + 1);
+      await handle.close();
+      return output;
+    }],
+  ])('rejects a %s and cleans up', async (_label, prepare) => {
+    const { coordinator, removed } = createHarness(async (root) => nativeResult(await prepare(root)));
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('maps native screen-recording permission failure without exposing native detail', async () => {
+    const captureNative = vi.fn(async () => {
+      const error = Object.assign(new Error('internal secret'), { code: 'screen-permission' });
+      throw error;
+    });
+    const { coordinator, removed } = createHarness(captureNative);
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'screen-permission' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('preserves a primary screen-permission failure when temp cleanup also fails', async () => {
+    const coordinator = new AppshotCoordinator({
+      captureNative: async () => {
+        throw Object.assign(new Error('permission detail'), { code: 'screen-permission' });
+      },
+      ingestPng: vi.fn(),
+      makeTempDir: () => createTempRoot(),
+      removeTempDir: async () => { throw new Error('cleanup failed'); },
+      now: () => new Date(),
+      randomUUID: () => 'unused',
+      publish: vi.fn(),
+    });
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'screen-permission' });
+  });
+
+  it('does not commit or publish when successful ingest is followed by cleanup failure', async () => {
+    const publish = vi.fn();
+    const coordinator = new AppshotCoordinator({
+      captureNative: async (root) => nativeResult(await writePng(root)),
+      ingestPng: async () => ({ url: 'cindy-media://blobs/cleanup.png', filename: 'cleanup.png' }),
+      makeTempDir: () => createTempRoot(),
+      removeTempDir: async () => { throw new Error('cleanup failed'); },
+      now: () => new Date(),
+      randomUUID: () => 'cleanup-capture',
+      publish,
+    });
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(coordinator.listPending()).toEqual([]);
+    expect(publish).not.toHaveBeenCalled();
+  });
+
+  it('keeps a successful capture pending when best-effort publish throws', async () => {
+    const publish = vi.fn(() => { throw new Error('renderer disappeared'); });
+    const { coordinator } = createHarness(async (root) => nativeResult(await writePng(root)));
+    const deps = (coordinator as unknown as { deps: AppshotCoordinatorDeps }).deps;
+    const bestEffortCoordinator = new AppshotCoordinator({ ...deps, publish });
+
+    await expect(bestEffortCoordinator.capture()).resolves.toMatchObject({ captureId: 'capture-1' });
+    expect(bestEffortCoordinator.listPending()).toHaveLength(1);
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  it('succeeds when only accessibility data is unavailable', async () => {
+    const { coordinator, ingested, removed } = createHarness(async (root) => ({
+      ...nativeResult(await writePng(root)),
+      accessibilityText: null,
+      accessibilityUnavailableReason: 'permission',
+    }));
+
+    await expect(coordinator.capture()).resolves.toMatchObject({
+      image: { size: PNG.byteLength, mimeType: 'image/png' },
+      metadata: { accessibilityText: null, accessibilityUnavailableReason: 'permission' },
+    });
+    expect([...ingested[0]]).toEqual([...PNG]);
+    expect(removed).toHaveLength(1);
+  });
+
+  it('cleans the managed temp root when media ingestion fails', async () => {
+    const removed: string[] = [];
+    const ingestFailure = Object.assign(new Error('storage unavailable'), { code: 'ingest-failure' });
+    const failingCoordinator = new AppshotCoordinator({
+      captureNative: async (root) => nativeResult(await writePng(root)),
+      ingestPng: async () => { throw ingestFailure; },
+      makeTempDir: () => createTempRoot(),
+      removeTempDir: async (root) => {
+        removed.push(root);
+        await fs.rm(root, { recursive: true, force: true });
+        tempRoots.delete(root);
+      },
+      now: () => new Date(),
+      randomUUID: () => 'unused',
+      publish: () => undefined,
+    });
+
+    await expect(failingCoordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(removed).toHaveLength(1);
+  });
+
+  it('ingests valid bytes, publishes managed data, stores pending results, and acks exactly one', async () => {
+    const { coordinator, published, removed } = createHarness(async (root) => nativeResult(await writePng(root)));
+
+    const result = await coordinator.capture();
+    expect(result).toEqual({
+      captureId: 'capture-1',
+      image: {
+        url: 'cindy-media://blobs/1.png',
+        filename: '1.png',
+        size: PNG.byteLength,
+        mimeType: 'image/png',
+      },
+      metadata: {
+        schemaVersion: 1,
+        captureId: 'capture-1',
+        capturedAt: '2026-08-06T01:02:03.000Z',
+        applicationName: 'Example App',
+        bundleIdentifier: 'com.example.app',
+        windowTitle: 'Example window',
+        accessibilityText: 'button: Save',
+        accessibilityTruncated: false,
+      },
+    });
+    expect(published).toEqual([result]);
+    expect(removed).toHaveLength(1);
+    expect(coordinator.listPending()).toEqual([result]);
+    expect(coordinator.ack('capture-1')).toBe(true);
+    expect(coordinator.ack('capture-1')).toBe(false);
+    expect(coordinator.listPending()).toEqual([]);
+  });
+
+  it('keeps only the newest ten pending captures and returns defensive copies', async () => {
+    const { coordinator } = createHarness(async (root) => nativeResult(await writePng(root)));
+
+    for (let index = 0; index < 11; index += 1) await coordinator.capture();
+
+    const pending = coordinator.listPending();
+    expect(pending.map((capture) => capture.captureId)).toEqual([
+      'capture-2', 'capture-3', 'capture-4', 'capture-5', 'capture-6',
+      'capture-7', 'capture-8', 'capture-9', 'capture-10', 'capture-11',
+    ]);
+    pending[0].metadata.applicationName = 'mutated';
+    expect(coordinator.listPending()[0].metadata.applicationName).toBe('Example App');
+    coordinator.clear();
+    expect(coordinator.listPending()).toEqual([]);
+  });
+
+  it('does not log captured metadata or bytes on failure', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const capturedPayload = 'captured content must not reach logs';
+    const { coordinator } = createHarness(async () => {
+      throw new Error(`APPSHOT_NATIVE_FAILURE ${capturedPayload}`);
+    });
+
+    await expect(coordinator.capture()).rejects.toMatchObject({ code: 'native-failure' });
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(consoleWarn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/appshots/__tests__/coordinator.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/coordinator.test.ts
@@ -155,7 +155,7 @@ describe('AppshotCoordinator boundary', () => {
 
   it('ingests bytes from the validated descriptor when the pathname is swapped', async () => {
     const replacement = Uint8Array.from([...PNG.slice(0, 8), 0x99]);
-    const ingestPng = vi.fn(async () => ({
+    const ingestPng = vi.fn<(bytes: Uint8Array) => Promise<{ url: string; filename: string }>>(async () => ({
       url: 'cindy-media://blobs/race.png',
       filename: 'race.png',
     }));

--- a/apps/desktop/src/main/appshots/__tests__/coordinator.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/coordinator.test.ts
@@ -155,7 +155,7 @@ describe('AppshotCoordinator boundary', () => {
 
   it('ingests bytes from the validated descriptor when the pathname is swapped', async () => {
     const replacement = Uint8Array.from([...PNG.slice(0, 8), 0x99]);
-    const ingestPng = vi.fn(async (_bytes: Uint8Array) => ({
+    const ingestPng = vi.fn(async () => ({
       url: 'cindy-media://blobs/race.png',
       filename: 'race.png',
     }));

--- a/apps/desktop/src/main/appshots/__tests__/ipcBoundary.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/ipcBoundary.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { AppshotCaptureResult } from '../../../shared/appshots.js';
+import { AppshotCaptureError } from '../coordinator.js';
+import {
+  createAppshotPublisher,
+  registerAppshotIpc,
+  type AppshotIpcCoordinator,
+  type AppshotIpcMain,
+} from '../ipc.js';
+
+type Handler = (event: unknown, ...args: unknown[]) => unknown;
+
+const result: AppshotCaptureResult = {
+  captureId: 'capture-1',
+  image: {
+    url: 'cindy-media://blobs/example.png',
+    filename: 'example.png',
+    size: 9,
+    mimeType: 'image/png',
+  },
+  metadata: {
+    schemaVersion: 1,
+    captureId: 'capture-1',
+    capturedAt: '2026-08-06T01:02:03.000Z',
+    applicationName: 'Example App',
+    bundleIdentifier: null,
+    windowTitle: null,
+    accessibilityText: null,
+    accessibilityTruncated: false,
+  },
+};
+
+function createHarness() {
+  const handlers = new Map<string, Handler>();
+  const order: string[] = [];
+  const coordinator: AppshotIpcCoordinator = {
+    capture: vi.fn(async () => result),
+    listPending: vi.fn(() => [result]),
+    ack: vi.fn(() => true),
+  };
+  const ipcMain: AppshotIpcMain = {
+    handle: vi.fn((channel, handler) => handlers.set(channel, handler)),
+  };
+  const assertTrustedSender = vi.fn((event: unknown) => {
+    order.push('trusted');
+    if (event === 'untrusted') throw new Error('[PERMISSION_DENIED] untrusted');
+  });
+  registerAppshotIpc({ ipcMain, coordinator, assertTrustedSender });
+  return { handlers, coordinator, assertTrustedSender, order };
+}
+
+function handler(harness: ReturnType<typeof createHarness>, channel: string): Handler {
+  const registered = harness.handlers.get(channel);
+  if (!registered) throw new Error(`missing handler ${channel}`);
+  return registered;
+}
+
+describe('Appshot Main IPC boundary', () => {
+  let harness: ReturnType<typeof createHarness>;
+
+  beforeEach(() => {
+    harness = createHarness();
+  });
+
+  it('registers all local appshot handlers', () => {
+    expect([...harness.handlers.keys()]).toEqual([
+      'appshots:capture',
+      'appshots:list-pending',
+      'appshots:ack',
+    ]);
+  });
+
+  it.each([
+    ['appshots:capture', ['extra']],
+    ['appshots:list-pending', ['extra']],
+    ['appshots:ack', []],
+    ['appshots:ack', ['capture-1', 'extra']],
+  ])('checks trusted sender before validating arguments for %s', async (channel, args) => {
+    await expect(handler(harness, channel)('untrusted', ...args)).rejects.toThrow(
+      '[PERMISSION_DENIED] untrusted',
+    );
+    expect(harness.assertTrustedSender).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects extra capture and list arguments without invoking the coordinator', async () => {
+    await expect(handler(harness, 'appshots:capture')('trusted', 'extra')).rejects.toThrow(
+      '[INVALID_PARAMS]',
+    );
+    await expect(handler(harness, 'appshots:list-pending')('trusted', 'extra')).rejects.toThrow(
+      '[INVALID_PARAMS]',
+    );
+    expect(harness.coordinator.capture).not.toHaveBeenCalled();
+    expect(harness.coordinator.listPending).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    [],
+    ['capture-1', 'extra'],
+    [''],
+    ['   '],
+    ['x'.repeat(257)],
+    [42],
+  ])('rejects malformed ack arguments %#', async (...args: unknown[]) => {
+    await expect(handler(harness, 'appshots:ack')('trusted', ...args)).rejects.toThrow(
+      '[INVALID_PARAMS]',
+    );
+    expect(harness.coordinator.ack).not.toHaveBeenCalled();
+  });
+
+  it('captures successfully and maps stable failures without exposing raw errors', async () => {
+    await expect(handler(harness, 'appshots:capture')('trusted')).resolves.toEqual({ accepted: true });
+    vi.mocked(harness.coordinator.capture).mockRejectedValueOnce(
+      Object.assign(new Error('secret native detail'), { code: 'no-window' }),
+    );
+
+    const rejection = (handler(harness, 'appshots:capture')('trusted') as Promise<unknown>)
+      .catch((error: unknown) => error);
+    await expect(rejection).resolves.toMatchObject({ message: '[INTERNAL] Appshot capture failed: no-window' });
+    await expect(rejection).resolves.not.toMatchObject({ message: expect.stringContaining('secret') });
+  });
+
+  it('maps capture-in-progress to PRECONDITION_FAILED', async () => {
+    vi.mocked(harness.coordinator.capture).mockRejectedValueOnce(
+      new AppshotCaptureError('capture-in-progress'),
+    );
+
+    await expect(handler(harness, 'appshots:capture')('trusted')).rejects.toThrow(
+      '[PRECONDITION_FAILED] Appshot capture failed: capture-in-progress',
+    );
+  });
+
+  it('returns defensive pending data and acknowledges one validated capture id', async () => {
+    const listed = await handler(harness, 'appshots:list-pending')('trusted') as AppshotCaptureResult[];
+    listed[0].metadata.applicationName = 'mutated';
+    listed[0].image.filename = 'mutated.png';
+    expect(result.metadata.applicationName).toBe('Example App');
+    expect(result.image.filename).toBe('example.png');
+
+    await expect(handler(harness, 'appshots:ack')('trusted', 'capture-1')).resolves.toEqual({
+      acknowledged: true,
+    });
+    expect(harness.coordinator.ack).toHaveBeenCalledWith('capture-1');
+  });
+});
+
+describe('Appshot outbound publisher', () => {
+  it('sends only to a live trusted main window and focuses after send', () => {
+    const order: string[] = [];
+    const win = { isDestroyed: () => false };
+    const publish = createAppshotPublisher({
+      getMainWindow: () => win,
+      isTrustedWindow: () => true,
+      send: (_window, channel, payload) => {
+        expect(channel).toBe('appshots:captured');
+        expect(payload).toEqual(result);
+        order.push('send');
+      },
+      focus: () => order.push('focus'),
+    });
+
+    publish(result);
+    expect(order).toEqual(['send', 'focus']);
+  });
+
+  it.each([
+    ['missing', null, true],
+    ['destroyed', { isDestroyed: () => true }, true],
+    ['untrusted', { isDestroyed: () => false }, false],
+  ])('does not send or focus for a %s window', (_label, win, trusted) => {
+    const send = vi.fn();
+    const focus = vi.fn();
+    const publish = createAppshotPublisher({
+      getMainWindow: () => win,
+      isTrustedWindow: () => trusted,
+      send,
+      focus,
+    });
+
+    publish(result);
+    expect(send).not.toHaveBeenCalled();
+    expect(focus).not.toHaveBeenCalled();
+  });
+
+  it('does not focus when outbound send fails', () => {
+    const focus = vi.fn();
+    const publish = createAppshotPublisher({
+      getMainWindow: () => ({ isDestroyed: () => false }),
+      isTrustedWindow: () => true,
+      send: () => { throw new Error('renderer unavailable'); },
+      focus,
+    });
+
+    expect(() => publish(result)).toThrow('renderer unavailable');
+    expect(focus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/appshots/__tests__/shortcutIpc.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/shortcutIpc.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_APPSHOT_SHORTCUT_PREFERENCES } from '../../../shared/appshots.js';
+import { AppshotShortcutValidationError } from '../shortcutStore.js';
+import {
+  broadcastAppshotShortcutState,
+  registerAppshotShortcutIpc,
+} from '../shortcutIpc.js';
+
+const state = {
+  preferences: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES,
+  configured: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred,
+  active: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred,
+};
+
+describe('Appshot shortcut IPC', () => {
+  it('broadcasts to every live trusted Cindy top-level window', () => {
+    const main = { name: 'main', isDestroyed: () => false };
+    const secondary = { name: 'secondary', isDestroyed: () => false };
+    const untrusted = { name: 'untrusted', isDestroyed: () => false };
+    const destroyed = { name: 'destroyed', isDestroyed: () => true };
+    const send = vi.fn();
+
+    broadcastAppshotShortcutState({
+      windows: [main, secondary, untrusted, destroyed],
+      isTrustedWindow: (window) => window !== untrusted,
+      send,
+    }, state);
+
+    expect(send.mock.calls).toEqual([
+      [main, 'appshots:shortcut-state-changed', state],
+      [secondary, 'appshots:shortcut-state-changed', state],
+    ]);
+  });
+
+  it('maps validation errors to INVALID_PARAMS and storage failures to a sanitized INTERNAL error', async () => {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const setPreferences = vi.fn();
+    registerAppshotShortcutIpc({
+      ipcMain: { handle: (channel, handler) => { handlers.set(channel, handler); } },
+      service: {
+        state: () => state,
+        setPreferences,
+        reset: async () => state,
+      },
+      assertTrustedSender: vi.fn(),
+    });
+    const set = handlers.get('appshots:shortcut-preferences:set') as (...args: unknown[]) => Promise<unknown>;
+
+    setPreferences.mockRejectedValueOnce(new AppshotShortcutValidationError('duplicate'));
+    await expect(set('trusted', {})).rejects.toThrow('[INVALID_PARAMS]');
+
+    setPreferences.mockRejectedValueOnce(new Error('/private/userData/appshots-shortcuts.v1.json EIO'));
+    const storageFailure = set('trusted', {}).catch((error) => error as Error);
+    await expect(storageFailure).resolves.toMatchObject({ message: expect.stringContaining('[INTERNAL]') });
+    await expect(storageFailure).resolves.not.toMatchObject({ message: expect.stringContaining('/private/userData') });
+  });
+});

--- a/apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts
@@ -1,0 +1,351 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_APPSHOT_SHORTCUT_PREFERENCES,
+  type AppshotShortcutPreferences,
+} from '../../../shared/appshots.js';
+import {
+  AppshotShortcutStore,
+  createAppshotShortcutStore,
+} from '../shortcutStore.js';
+import { AppshotShortcutService } from '../shortcutService.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function createMemoryStore(initial?: string): {
+  store: AppshotShortcutStore;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>();
+  if (initial) files.set('/userData/appshots-shortcuts.v1.json', initial);
+  return {
+    files,
+    store: new AppshotShortcutStore({
+      getFilePath: () => '/userData/appshots-shortcuts.v1.json',
+      readFile: (filePath) => {
+        const value = files.get(filePath);
+        if (value === undefined) throw new Error('ENOENT');
+        return value;
+      },
+      writeFileAtomic: (filePath, value) => files.set(filePath, value),
+      removeFile: (filePath) => { files.delete(filePath); },
+    }),
+  };
+}
+
+function createHarness(options: {
+  preferences?: AppshotShortcutPreferences;
+  runningBundleIds?: Set<string>;
+  register?: (accelerator: string) => boolean;
+  retain?: (owner: string, subscriber: (keys: readonly string[]) => void) => Promise<() => void>;
+  omitPlatform?: boolean;
+} = {}) {
+  const memory = createMemoryStore(
+    options.preferences ? JSON.stringify({ version: 1, preferences: options.preferences }) : undefined,
+  );
+  const registered = new Map<string, () => void>();
+  let keySubscriber: ((keys: readonly string[]) => void) | undefined;
+  const capture = vi.fn(async () => undefined);
+  const stateChanged = vi.fn();
+  const captureFailure = vi.fn();
+  const globalShortcut = {
+    register: vi.fn((accelerator: string, callback: () => void) => {
+      if (options.register?.(accelerator) === false) return false;
+      registered.set(accelerator, callback);
+      return true;
+    }),
+    unregister: vi.fn((accelerator: string) => { registered.delete(accelerator); }),
+  };
+  const retain = vi.fn(options.retain ?? (async (_owner, subscriber) => {
+    keySubscriber = subscriber;
+    return () => { keySubscriber = undefined; };
+  }));
+  const runningBundleIds = options.runningBundleIds ?? new Set<string>();
+  const service = new AppshotShortcutService({
+    store: memory.store,
+    globalShortcut,
+    retainMacModifierKeySnapshots: retain,
+    capture,
+    getRunningBundleIds: () => runningBundleIds,
+    onStateChanged: stateChanged,
+    onCaptureFailure: captureFailure,
+    platform: options.omitPlatform === true ? undefined : 'darwin',
+  });
+  return {
+    service,
+    files: memory.files,
+    globalShortcut,
+    registered,
+    retain,
+    capture,
+    captureFailure,
+    stateChanged,
+    runningBundleIds,
+    emitKeys: (keys: readonly string[]) => keySubscriber?.(keys),
+  };
+}
+
+describe('Appshot shortcut preferences', () => {
+  it('keeps defaults code-owned until a user customizes them, and reset removes the override', () => {
+    const { store, files } = createMemoryStore();
+
+    expect(store.get()).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+    expect(files.size).toBe(0);
+
+    const customized = store.set({
+      preferred: { kind: 'dual-modifier', modifier: 'option' },
+      fallback: { kind: 'accelerator', combo: { code: 'F16', meta: false, ctrl: false, alt: false, shift: false } },
+    });
+    expect(customized.preferred).toEqual({ kind: 'dual-modifier', modifier: 'option' });
+    expect(files.size).toBe(1);
+
+    expect(store.reset()).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+    expect(files.size).toBe(0);
+  });
+
+  it('rejects duplicate shortcuts and system-reserved conventional combinations', () => {
+    const { store } = createMemoryStore();
+    expect(() => store.set({
+      preferred: { kind: 'dual-modifier', modifier: 'command' },
+      fallback: { kind: 'dual-modifier', modifier: 'command' },
+    })).toThrow('different');
+    expect(() => store.set({
+      preferred: { kind: 'dual-modifier', modifier: 'command' },
+      fallback: { kind: 'accelerator', combo: { code: 'KeyC', meta: true, ctrl: false, alt: false, shift: false } },
+    })).toThrow('reserved');
+  });
+
+  it.each([
+    ['duplicate', {
+      version: 1,
+      preferences: {
+        preferred: { kind: 'dual-modifier', modifier: 'command' },
+        fallback: { kind: 'dual-modifier', modifier: 'command' },
+      },
+    }],
+    ['reserved', {
+      version: 1,
+      preferences: {
+        preferred: { kind: 'dual-modifier', modifier: 'command' },
+        fallback: { kind: 'accelerator', combo: { code: 'KeyC', meta: true, ctrl: false, alt: false, shift: false } },
+      },
+    }],
+    ['missing fields', {
+      version: 1,
+      preferences: { preferred: { kind: 'dual-modifier', modifier: 'option' } },
+    }],
+  ])('fails safe to code defaults for %s stored preferences', (_label, stored) => {
+    const { store } = createMemoryStore(JSON.stringify(stored));
+    expect(store.get()).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+  });
+
+  it('keeps the previous persisted preferences when an atomic write fails', () => {
+    const previous = JSON.stringify({ version: 1, preferences: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES });
+    const { store, files } = createMemoryStore(previous);
+    const original = files.get('/userData/appshots-shortcuts.v1.json');
+    const failingStore = new AppshotShortcutStore({
+      getFilePath: () => '/userData/appshots-shortcuts.v1.json',
+      readFile: (filePath) => files.get(filePath) as string,
+      writeFileAtomic: () => { throw new Error('disk full'); },
+      removeFile: (filePath) => { files.delete(filePath); },
+    });
+
+    expect(() => failingStore.set({
+      preferred: { kind: 'dual-modifier', modifier: 'option' },
+      fallback: { kind: 'accelerator', combo: { code: 'F16', meta: false, ctrl: false, alt: false, shift: false } },
+    })).toThrow('disk full');
+    expect(files.get('/userData/appshots-shortcuts.v1.json')).toBe(original);
+    expect(store.get()).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+  });
+
+  it('creates the production store parent and publishes the preferences file with mode 0600', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-appshot-shortcut-store-'));
+    temporaryDirectories.push(root);
+    const userData = path.join(root, 'nested', 'profile');
+    const store = createAppshotShortcutStore(userData);
+    store.set({
+      preferred: { kind: 'dual-modifier', modifier: 'option' },
+      fallback: { kind: 'accelerator', combo: { code: 'F16', meta: false, ctrl: false, alt: false, shift: false } },
+    });
+
+    const filePath = path.join(userData, 'appshots-shortcuts.v1.json');
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.statSync(filePath).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe('AppshotShortcutService', () => {
+  it('activates the preferred dual-modifier shortcut on darwin even when platform is not injected', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+    const harness = createHarness({ omitPlatform: true });
+
+    await harness.service.start();
+
+    expect(harness.retain).toHaveBeenCalledWith('appshots-shortcut-service', expect.any(Function));
+    expect(harness.service.state()).toMatchObject({
+      configured: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred,
+      active: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred,
+    });
+    expect(harness.service.state()).not.toHaveProperty('fallbackReason');
+  });
+
+  it('activates the default preferred shortcut and only captures on a dual-modifier rising edge', async () => {
+    const harness = createHarness();
+
+    await harness.service.start();
+    expect(harness.service.state()).toMatchObject({
+      configured: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred,
+      active: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred,
+    });
+
+    harness.emitKeys(['MetaLeft', 'MetaRight']);
+    harness.emitKeys(['MetaLeft', 'MetaRight']);
+    await Promise.resolve();
+    expect(harness.capture).toHaveBeenCalledTimes(1);
+    harness.emitKeys([]);
+    harness.emitKeys(['MetaLeft', 'MetaRight']);
+    await Promise.resolve();
+    expect(harness.capture).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses fallback while Codex is running and restores the preferred shortcut when it exits', async () => {
+    const harness = createHarness({ runningBundleIds: new Set(['com.openai.codex']) });
+
+    await harness.service.start();
+    expect(harness.service.state()).toMatchObject({
+      active: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.fallback,
+      fallbackReason: 'codex-running',
+    });
+
+    harness.runningBundleIds.clear();
+    await harness.service.refreshConflicts();
+    expect(harness.service.state()).toMatchObject({
+      active: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred,
+    });
+    expect(harness.service.state()).not.toHaveProperty('fallbackReason');
+  });
+
+  it('falls back after conventional preferred registration fails and disables global capture when both fail', async () => {
+    const conventional: AppshotShortcutPreferences = {
+      preferred: { kind: 'accelerator', combo: { code: 'F16', meta: false, ctrl: false, alt: false, shift: false } },
+      fallback: { kind: 'accelerator', combo: { code: 'F17', meta: false, ctrl: false, alt: false, shift: false } },
+    };
+    const fallbackHarness = createHarness({
+      preferences: conventional,
+      register: (accelerator) => accelerator !== 'F16',
+    });
+    await fallbackHarness.service.start();
+    expect(fallbackHarness.service.state()).toMatchObject({
+      active: conventional.fallback,
+      fallbackReason: 'registration-conflict',
+    });
+
+    const noShortcutHarness = createHarness({ preferences: conventional, register: () => false });
+    await noShortcutHarness.service.start();
+    expect(noShortcutHarness.service.state()).toMatchObject({
+      active: null,
+      fallbackReason: 'registration-conflict',
+    });
+  });
+
+  it('persists user preferences across service reload and does not disable manual coordinator capture', async () => {
+    const harness = createHarness();
+    const customized: AppshotShortcutPreferences = {
+      preferred: { kind: 'dual-modifier', modifier: 'option' },
+      fallback: { kind: 'accelerator', combo: { code: 'F16', meta: false, ctrl: false, alt: false, shift: false } },
+    };
+
+    await harness.service.setPreferences(customized);
+    const reloaded = new AppshotShortcutStore({
+      getFilePath: () => '/userData/appshots-shortcuts.v1.json',
+      readFile: (filePath) => harness.files.get(filePath) ?? (() => { throw new Error('ENOENT'); })(),
+      writeFileAtomic: (filePath, value) => harness.files.set(filePath, value),
+      removeFile: (filePath) => { harness.files.delete(filePath); },
+    });
+    expect(reloaded.get()).toEqual(customized);
+
+    await harness.capture();
+    expect(harness.capture).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports only a stable capture failure code', async () => {
+    const harness = createHarness();
+    harness.capture.mockRejectedValueOnce(new Error('/private/secret details'));
+    await harness.service.start();
+
+    harness.emitKeys(['MetaLeft', 'MetaRight']);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(harness.captureFailure).toHaveBeenCalledWith('capture-failed');
+  });
+
+  it('releases a stale refresh activation without overwriting the newer conflict state', async () => {
+    const firstRetain = deferred<() => void>();
+    const releaseFirst = vi.fn();
+    const harness = createHarness({ retain: vi.fn(() => firstRetain.promise) });
+
+    const starting = harness.service.start();
+    harness.runningBundleIds.add('com.openai.codex');
+    await harness.service.refreshConflicts();
+    const broadcastsAfterNewRefresh = harness.stateChanged.mock.calls.length;
+    firstRetain.resolve(releaseFirst);
+    await starting;
+
+    expect(releaseFirst).toHaveBeenCalledTimes(1);
+    expect(harness.service.state()).toMatchObject({
+      active: DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.fallback,
+      fallbackReason: 'codex-running',
+    });
+    expect(harness.stateChanged).toHaveBeenCalledTimes(broadcastsAfterNewRefresh);
+  });
+
+  it('does not let an old refresh overwrite preferences set while activation was pending', async () => {
+    const oldRetain = deferred<() => void>();
+    const releaseOld = vi.fn();
+    const harness = createHarness({ retain: vi.fn(() => oldRetain.promise) });
+    const starting = harness.service.start();
+    const next: AppshotShortcutPreferences = {
+      preferred: { kind: 'accelerator', combo: { code: 'F16', meta: false, ctrl: false, alt: false, shift: false } },
+      fallback: { kind: 'accelerator', combo: { code: 'F17', meta: false, ctrl: false, alt: false, shift: false } },
+    };
+
+    await harness.service.setPreferences(next);
+    oldRetain.resolve(releaseOld);
+    await starting;
+
+    expect(releaseOld).toHaveBeenCalledTimes(1);
+    expect(harness.service.state()).toMatchObject({ preferences: next, configured: next.preferred, active: next.preferred });
+  });
+
+  it('releases a start that resolves after stop without reviving state or broadcasting', async () => {
+    const pendingRetain = deferred<() => void>();
+    const releasePending = vi.fn();
+    const harness = createHarness({ retain: vi.fn(() => pendingRetain.promise) });
+    const starting = harness.service.start();
+
+    harness.service.stop();
+    const broadcastsAfterStop = harness.stateChanged.mock.calls.length;
+    pendingRetain.resolve(releasePending);
+    await starting;
+
+    expect(releasePending).toHaveBeenCalledTimes(1);
+    expect(harness.service.state().active).toBeNull();
+    expect(harness.stateChanged).toHaveBeenCalledTimes(broadcastsAfterStop);
+  });
+});

--- a/apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts
@@ -241,6 +241,21 @@ describe('AppshotShortcutService', () => {
     expect(harness.service.state()).not.toHaveProperty('fallbackReason');
   });
 
+  it('does not re-register shortcuts when the Codex conflict state is unchanged', async () => {
+    const harness = createHarness({ runningBundleIds: new Set(['com.openai.codex']) });
+
+    await harness.service.start();
+    const registerCount = harness.globalShortcut.register.mock.calls.length;
+
+    await harness.service.refreshConflicts();
+    expect(harness.globalShortcut.register.mock.calls.length).toBe(registerCount);
+    expect(harness.retain).not.toHaveBeenCalled();
+
+    harness.runningBundleIds.clear();
+    await harness.service.refreshConflicts();
+    expect(harness.retain).toHaveBeenCalledWith('appshots-shortcut-service', expect.any(Function));
+  });
+
   it('falls back after conventional preferred registration fails and disables global capture when both fail', async () => {
     const conventional: AppshotShortcutPreferences = {
       preferred: { kind: 'accelerator', combo: { code: 'F16', meta: false, ctrl: false, alt: false, shift: false } },

--- a/apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts
@@ -55,6 +55,7 @@ function createHarness(options: {
   register?: (accelerator: string) => boolean;
   retain?: (owner: string, subscriber: (keys: readonly string[]) => void) => Promise<() => void>;
   omitPlatform?: boolean;
+  platform?: 'darwin' | 'linux';
 } = {}) {
   const memory = createMemoryStore(
     options.preferences ? JSON.stringify({ version: 1, preferences: options.preferences }) : undefined,
@@ -85,7 +86,7 @@ function createHarness(options: {
     getRunningBundleIds: () => runningBundleIds,
     onStateChanged: stateChanged,
     onCaptureFailure: captureFailure,
-    platform: options.omitPlatform === true ? undefined : 'darwin',
+    platform: options.platform ?? (options.omitPlatform === true ? undefined : 'darwin'),
   });
   return {
     service,
@@ -254,6 +255,17 @@ describe('AppshotShortcutService', () => {
     harness.runningBundleIds.clear();
     await harness.service.refreshConflicts();
     expect(harness.retain).toHaveBeenCalledWith('appshots-shortcut-service', expect.any(Function));
+  });
+
+  it('does not register any shortcut on non-macOS platforms', async () => {
+    const harness = createHarness({ platform: 'linux' });
+
+    await harness.service.start();
+
+    expect(harness.service.state()).toMatchObject({ active: null });
+    expect(harness.service.state()).not.toHaveProperty('fallbackReason');
+    expect(harness.globalShortcut.register).not.toHaveBeenCalled();
+    expect(harness.retain).not.toHaveBeenCalled();
   });
 
   it('falls back after conventional preferred registration fails and disables global capture when both fail', async () => {

--- a/apps/desktop/src/main/appshots/__tests__/workspaceApplicationMonitor.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/workspaceApplicationMonitor.test.ts
@@ -78,6 +78,33 @@ describe('MacWorkspaceApplicationMonitor', () => {
     expect(monitor.state()).toEqual(new Set(['com.openai.codex']));
   });
 
+  it('tolerates null bundle entries emitted by the JXA bridge', async () => {
+    const child = fakeProcess();
+    const onSnapshot = vi.fn();
+    const monitor = new MacWorkspaceApplicationMonitor({
+      spawnListener: () => child,
+      readSnapshot: vi.fn(async () => [
+        'com.openai.codex',
+        null as unknown as string,
+        '',
+      ]),
+      onSnapshot,
+    });
+
+    monitor.start();
+    child.stdout.emit(
+      'data',
+      Buffer.from('{"type":"snapshot","bundleIds":["com.openai.codex",null,123,""]}\n'),
+    );
+    expect(monitor.state()).toEqual(new Set(['com.openai.codex']));
+
+    await monitor.refresh();
+    expect(monitor.state()).toEqual(new Set(['com.openai.codex']));
+    expect(onSnapshot).toHaveBeenLastCalledWith(new Set(['com.openai.codex']));
+
+    monitor.stop();
+  });
+
   it('restarts the workspace listener after an unexpected exit and only parses stdout', () => {
     const firstChild = fakeProcess();
     const secondChild = fakeProcess();

--- a/apps/desktop/src/main/appshots/__tests__/workspaceApplicationMonitor.test.ts
+++ b/apps/desktop/src/main/appshots/__tests__/workspaceApplicationMonitor.test.ts
@@ -1,0 +1,106 @@
+import { EventEmitter } from 'node:events';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { MacWorkspaceApplicationMonitor } from '../workspaceApplicationMonitor.js';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
+
+function fakeProcess() {
+  const process = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  process.stdout = new EventEmitter();
+  process.stderr = new EventEmitter();
+  process.kill = vi.fn();
+  return process;
+}
+
+describe('MacWorkspaceApplicationMonitor', () => {
+  it('publishes authoritative bundle-id snapshots from the long-running workspace event process', () => {
+    const child = fakeProcess();
+    const onSnapshot = vi.fn();
+    const monitor = new MacWorkspaceApplicationMonitor({
+      spawnListener: () => child,
+      readSnapshot: async () => [],
+      onSnapshot,
+    });
+
+    monitor.start();
+    child.stdout.emit('data', Buffer.from('{"type":"snapshot","bundleIds":["com.openai.codex"]}\n'));
+    expect(monitor.state()).toEqual(new Set(['com.openai.codex']));
+    expect(onSnapshot).toHaveBeenCalledWith(new Set(['com.openai.codex']));
+
+    monitor.stop();
+    expect(child.kill).toHaveBeenCalledTimes(1);
+    child.stdout.emit('data', Buffer.from('{"type":"snapshot","bundleIds":[]}\n'));
+    expect(monitor.state()).toEqual(new Set(['com.openai.codex']));
+  });
+
+  it('keeps refresh single-flight and ignores an older fallback snapshot after a workspace event', async () => {
+    const child = fakeProcess();
+    const fallback = deferred<readonly string[]>();
+    const readSnapshot = vi.fn(() => fallback.promise);
+    const monitor = new MacWorkspaceApplicationMonitor({
+      spawnListener: () => child,
+      readSnapshot,
+      onSnapshot: vi.fn(),
+    });
+    monitor.start();
+
+    const first = monitor.refresh();
+    const second = monitor.refresh();
+    expect(readSnapshot).toHaveBeenCalledTimes(1);
+    child.stdout.emit('data', Buffer.from('{"type":"snapshot","bundleIds":["com.openai.codex"]}\n'));
+    fallback.resolve([]);
+    await Promise.all([first, second]);
+
+    expect(monitor.state()).toEqual(new Set(['com.openai.codex']));
+  });
+
+  it('preserves the last state after malformed output or listener failure', () => {
+    const child = fakeProcess();
+    const monitor = new MacWorkspaceApplicationMonitor({
+      spawnListener: () => child,
+      readSnapshot: async () => [],
+      onSnapshot: vi.fn(),
+    });
+    monitor.start();
+    child.stdout.emit('data', Buffer.from('{"type":"snapshot","bundleIds":["com.openai.codex"]}\n'));
+    child.stdout.emit('data', Buffer.from('not-json\n'));
+    child.emit('close', 1);
+    expect(monitor.state()).toEqual(new Set(['com.openai.codex']));
+  });
+
+  it('restarts the workspace listener after an unexpected exit and only parses stdout', () => {
+    const firstChild = fakeProcess();
+    const secondChild = fakeProcess();
+    const children = [firstChild, secondChild];
+    let restart: (() => void) | undefined;
+    const onSnapshot = vi.fn();
+    const monitor = new MacWorkspaceApplicationMonitor({
+      spawnListener: vi.fn(() => children.shift()!),
+      readSnapshot: async () => [],
+      onSnapshot,
+      scheduleRestart: (callback) => { restart = callback; },
+    });
+
+    monitor.start();
+    firstChild.stdout.emit('data', Buffer.from('{"type":"snapshot","bundleIds":["com.openai.codex"]}\n'));
+    firstChild.stderr.emit('data', Buffer.from('diagnostic output without a newline'));
+    firstChild.emit('close', 1);
+    expect(restart).toBeTypeOf('function');
+    restart?.();
+    expect(children).toHaveLength(0);
+    secondChild.stdout.emit('data', Buffer.from('{"type":"snapshot","bundleIds":[]}\n'));
+
+    expect(onSnapshot).toHaveBeenLastCalledWith(new Set());
+    expect(monitor.state()).toEqual(new Set());
+  });
+});

--- a/apps/desktop/src/main/appshots/coordinator.ts
+++ b/apps/desktop/src/main/appshots/coordinator.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs/promises';
+
+import {
+  coerceAppshotMetadata,
+  type AppshotCaptureResult,
+  type AppshotMetadata,
+} from '../../shared/appshots.js';
+import { readBoundedFileNoFollow } from '../utils/readBoundedFile.js';
+import type { MacAppshotNativeResult } from './MacAppshotNativeHost.js';
+
+export type AppshotFailureCode =
+  | 'unsupported-platform'
+  | 'capture-in-progress'
+  | 'screen-permission'
+  | 'no-window'
+  | 'window-closed'
+  | 'protected-content'
+  | 'native-failure';
+
+export class AppshotCaptureError extends Error {
+  constructor(readonly code: AppshotFailureCode) {
+    super(code);
+    this.name = 'AppshotCaptureError';
+  }
+}
+
+export interface AppshotCoordinatorDeps {
+  captureNative: (outputDir: string) => Promise<MacAppshotNativeResult>;
+  ingestPng: (bytes: Uint8Array) => Promise<{ url: string; filename: string }>;
+  makeTempDir: () => Promise<string>;
+  removeTempDir: (path: string) => Promise<void>;
+  now: () => Date;
+  randomUUID: () => string;
+  publish: (result: AppshotCaptureResult) => void;
+}
+
+const PNG_SIGNATURE = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const MAX_PNG_BYTES = 100 * 1024 * 1024;
+const MAX_PENDING = 10;
+
+function isPng(bytes: Uint8Array): boolean {
+  return PNG_SIGNATURE.every((value, index) => bytes[index] === value);
+}
+
+function copyResult(result: AppshotCaptureResult): AppshotCaptureResult {
+  return {
+    captureId: result.captureId,
+    image: { ...result.image },
+    metadata: { ...result.metadata },
+  };
+}
+
+function validateNativeMetadata(value: MacAppshotNativeResult): Omit<AppshotMetadata, 'schemaVersion' | 'captureId' | 'capturedAt'> | null {
+  const validated = coerceAppshotMetadata({
+    schemaVersion: 1,
+    captureId: 'native-validation',
+    capturedAt: '2026-01-01T00:00:00.000Z',
+    applicationName: value.applicationName,
+    bundleIdentifier: value.bundleIdentifier,
+    windowTitle: value.windowTitle,
+    accessibilityText: value.accessibilityText,
+    accessibilityTruncated: value.accessibilityTruncated,
+    ...(value.accessibilityUnavailableReason === undefined
+      ? {}
+      : { accessibilityUnavailableReason: value.accessibilityUnavailableReason }),
+  });
+  if (!validated) return null;
+  return {
+    applicationName: validated.applicationName,
+    bundleIdentifier: validated.bundleIdentifier,
+    windowTitle: validated.windowTitle,
+    accessibilityText: validated.accessibilityText,
+    accessibilityTruncated: validated.accessibilityTruncated,
+    ...(validated.accessibilityUnavailableReason === undefined
+      ? {}
+      : { accessibilityUnavailableReason: validated.accessibilityUnavailableReason }),
+  };
+}
+
+function appshotFailureCode(error: unknown): AppshotFailureCode {
+  if (error instanceof AppshotCaptureError) return error.code;
+  const code = error && typeof error === 'object' ? (error as { code?: unknown }).code : undefined;
+  return code === 'screen-permission'
+    || code === 'no-window'
+    || code === 'window-closed'
+    || code === 'protected-content'
+    || code === 'unsupported-platform'
+    || code === 'capture-in-progress'
+    || code === 'native-failure'
+    ? code
+    : 'native-failure';
+}
+
+export class AppshotCoordinator {
+  private inFlight: Promise<AppshotCaptureResult> | null = null;
+  private pending: AppshotCaptureResult[] = [];
+
+  constructor(
+    private readonly deps: AppshotCoordinatorDeps,
+    private readonly platform: NodeJS.Platform = process.platform,
+  ) {}
+
+  capture(): Promise<AppshotCaptureResult> {
+    if (this.platform !== 'darwin') return Promise.reject(new AppshotCaptureError('unsupported-platform'));
+    if (this.inFlight) return Promise.reject(new AppshotCaptureError('capture-in-progress'));
+    const capture = this.captureOne();
+    this.inFlight = capture;
+    void capture.finally(() => {
+      if (this.inFlight === capture) this.inFlight = null;
+    }).catch(() => undefined);
+    return capture;
+  }
+
+  listPending(): readonly AppshotCaptureResult[] {
+    return this.pending.map(copyResult);
+  }
+
+  ack(captureId: string): boolean {
+    if (!captureId) return false;
+    const index = this.pending.findIndex((capture) => capture.captureId === captureId);
+    if (index < 0) return false;
+    this.pending.splice(index, 1);
+    return true;
+  }
+
+  clear(): void {
+    this.pending = [];
+  }
+
+  private async captureOne(): Promise<AppshotCaptureResult> {
+    let root: string | null = null;
+    let result: AppshotCaptureResult | null = null;
+    let failure: AppshotCaptureError | null = null;
+    try {
+      root = await this.deps.makeTempDir();
+      const rootRealPath = await fs.realpath(root);
+      const native = await this.deps.captureNative(root);
+      const metadata = validateNativeMetadata(native);
+      if (!metadata || typeof native.pngPath !== 'string' || native.pngPath.length === 0) {
+        throw new AppshotCaptureError('native-failure');
+      }
+
+      const bytes = await readBoundedFileNoFollow(native.pngPath, MAX_PNG_BYTES, {
+        containWithin: rootRealPath,
+      });
+      if (!bytes || bytes.byteLength === 0 || !isPng(bytes)) {
+        throw new AppshotCaptureError('native-failure');
+      }
+      const image = await this.deps.ingestPng(bytes);
+      const captureId = this.deps.randomUUID();
+      result = {
+        captureId,
+        image: { ...image, size: bytes.byteLength, mimeType: 'image/png' },
+        metadata: {
+          schemaVersion: 1,
+          captureId,
+          capturedAt: this.deps.now().toISOString(),
+          ...metadata,
+        },
+      };
+    } catch (error) {
+      failure = new AppshotCaptureError(appshotFailureCode(error));
+    }
+
+    if (root !== null) {
+      try {
+        await this.deps.removeTempDir(root);
+      } catch {
+        failure ??= new AppshotCaptureError('native-failure');
+      }
+    }
+    if (failure) throw failure;
+    if (!result) throw new AppshotCaptureError('native-failure');
+
+    this.pending.push(copyResult(result));
+    if (this.pending.length > MAX_PENDING) this.pending.splice(0, this.pending.length - MAX_PENDING);
+    try {
+      this.deps.publish(copyResult(result));
+    } catch {
+      // Renderer delivery is best-effort; listPending remains the recovery path.
+    }
+    return copyResult(result);
+  }
+}
+
+export type { MacAppshotNativeResult } from './MacAppshotNativeHost.js';

--- a/apps/desktop/src/main/appshots/ipc.ts
+++ b/apps/desktop/src/main/appshots/ipc.ts
@@ -1,0 +1,109 @@
+import type { AppshotCaptureResult } from '../../shared/appshots.js';
+import { throwIpcError } from '../utils/ipcValidate.js';
+
+import { AppshotCaptureError, type AppshotFailureCode } from './coordinator.js';
+
+type IpcHandler = (event: unknown, ...args: unknown[]) => unknown;
+
+export interface AppshotIpcMain {
+  handle(channel: string, handler: IpcHandler): void;
+}
+
+export interface AppshotIpcCoordinator {
+  capture(): Promise<AppshotCaptureResult>;
+  listPending(): readonly AppshotCaptureResult[];
+  ack(captureId: string): boolean;
+}
+
+interface RegisterAppshotIpcDeps {
+  ipcMain: AppshotIpcMain;
+  coordinator: AppshotIpcCoordinator;
+  assertTrustedSender: (event: unknown) => void;
+}
+
+function cloneResult(result: AppshotCaptureResult): AppshotCaptureResult {
+  return {
+    ...result,
+    image: { ...result.image },
+    metadata: { ...result.metadata },
+  };
+}
+
+function failureCode(error: unknown): AppshotFailureCode {
+  if (error instanceof AppshotCaptureError) return error.code;
+  const code = error && typeof error === 'object' ? (error as { code?: unknown }).code : undefined;
+  return code === 'capture-in-progress'
+    || code === 'unsupported-platform'
+    || code === 'screen-permission'
+    || code === 'no-window'
+    || code === 'window-closed'
+    || code === 'protected-content'
+    ? code
+    : 'native-failure';
+}
+
+function throwCaptureIpcError(error: unknown): never {
+  const code = failureCode(error);
+  const ipcCode = code === 'capture-in-progress'
+    ? 'PRECONDITION_FAILED'
+    : code === 'unsupported-platform'
+      ? 'UNSUPPORTED_CAPABILITY'
+      : code === 'screen-permission'
+        ? 'PERMISSION_DENIED'
+        : 'INTERNAL';
+  throwIpcError(ipcCode, `Appshot capture failed: ${code}`);
+}
+
+function isValidCaptureId(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0 && value.length <= 256;
+}
+
+export function registerAppshotIpc({
+  ipcMain,
+  coordinator,
+  assertTrustedSender,
+}: RegisterAppshotIpcDeps): void {
+  ipcMain.handle('appshots:capture', async (event, ...args): Promise<{ accepted: true }> => {
+    assertTrustedSender(event);
+    if (args.length !== 0) throwIpcError('INVALID_PARAMS', 'appshot capture does not accept parameters');
+    try {
+      await coordinator.capture();
+      return { accepted: true };
+    } catch (error) {
+      return throwCaptureIpcError(error);
+    }
+  });
+  ipcMain.handle('appshots:list-pending', async (event, ...args): Promise<AppshotCaptureResult[]> => {
+    assertTrustedSender(event);
+    if (args.length !== 0) throwIpcError('INVALID_PARAMS', 'appshot list does not accept parameters');
+    return coordinator.listPending().map(cloneResult);
+  });
+  ipcMain.handle('appshots:ack', async (event, ...args): Promise<{ acknowledged: boolean }> => {
+    assertTrustedSender(event);
+    if (args.length !== 1) throwIpcError('INVALID_PARAMS', 'appshot ack requires one captureId');
+    if (!isValidCaptureId(args[0])) throwIpcError('INVALID_PARAMS', 'captureId is required');
+    return { acknowledged: coordinator.ack(args[0]) };
+  });
+}
+
+interface AppshotPublisherWindow {
+  isDestroyed(): boolean;
+}
+
+interface AppshotPublisherDeps<TWindow extends AppshotPublisherWindow> {
+  getMainWindow: () => TWindow | null;
+  isTrustedWindow: (window: TWindow) => boolean;
+  send: (window: TWindow, channel: 'appshots:captured', result: AppshotCaptureResult) => void;
+  focus: () => void;
+}
+
+export function createAppshotPublisher<TWindow extends AppshotPublisherWindow>(
+  deps: AppshotPublisherDeps<TWindow>,
+): (result: AppshotCaptureResult) => void {
+  return (result) => {
+    const target = deps.getMainWindow();
+    if (!target || target.isDestroyed() || !deps.isTrustedWindow(target)) return;
+    deps.send(target, 'appshots:captured', result);
+    deps.focus();
+  };
+}

--- a/apps/desktop/src/main/appshots/shortcutIpc.ts
+++ b/apps/desktop/src/main/appshots/shortcutIpc.ts
@@ -1,0 +1,66 @@
+import type { AppshotShortcutState } from './shortcutService.js';
+import { AppshotShortcutValidationError } from './shortcutStore.js';
+import { throwIpcError } from '../utils/ipcValidate.js';
+
+type IpcHandler = (event: unknown, ...args: unknown[]) => unknown;
+
+export interface AppshotShortcutIpcMain {
+  handle(channel: string, handler: IpcHandler): void;
+}
+
+export interface AppshotShortcutIpcService {
+  state(): AppshotShortcutState;
+  setPreferences(value: unknown): Promise<AppshotShortcutState>;
+  reset(): Promise<AppshotShortcutState>;
+}
+
+export function registerAppshotShortcutIpc(deps: {
+  ipcMain: AppshotShortcutIpcMain;
+  service: AppshotShortcutIpcService;
+  assertTrustedSender: (event: unknown) => void;
+}): void {
+  deps.ipcMain.handle('appshots:shortcut-state', async (event, ...args) => {
+    deps.assertTrustedSender(event);
+    if (args.length !== 0) throwIpcError('INVALID_PARAMS', 'appshot shortcut state does not accept parameters');
+    return deps.service.state();
+  });
+  deps.ipcMain.handle('appshots:shortcut-preferences:set', async (event, ...args) => {
+    deps.assertTrustedSender(event);
+    if (args.length !== 1 || !args[0] || typeof args[0] !== 'object' || Array.isArray(args[0])) {
+      throwIpcError('INVALID_PARAMS', 'appshot shortcut preferences must be an object');
+    }
+    try {
+      return await deps.service.setPreferences(args[0]);
+    } catch (error) {
+      if (error instanceof AppshotShortcutValidationError) {
+        throwIpcError('INVALID_PARAMS', 'appshot shortcut preferences are invalid');
+      }
+      throwIpcError('INTERNAL', 'could not save appshot shortcut preferences');
+    }
+  });
+  deps.ipcMain.handle('appshots:shortcut-preferences:reset', async (event, ...args) => {
+    deps.assertTrustedSender(event);
+    if (args.length !== 0) throwIpcError('INVALID_PARAMS', 'appshot shortcut reset does not accept parameters');
+    try {
+      return await deps.service.reset();
+    } catch {
+      throwIpcError('INTERNAL', 'could not reset appshot shortcut preferences');
+    }
+  });
+}
+
+interface ShortcutWindow {
+  isDestroyed(): boolean;
+}
+
+/** Sends shortcut state only to live, trusted Cindy top-level windows. */
+export function broadcastAppshotShortcutState<TWindow extends ShortcutWindow>(deps: {
+  windows: readonly TWindow[];
+  isTrustedWindow: (window: TWindow) => boolean;
+  send: (window: TWindow, channel: 'appshots:shortcut-state-changed', state: AppshotShortcutState) => void;
+}, state: AppshotShortcutState): void {
+  for (const window of deps.windows) {
+    if (window.isDestroyed() || !deps.isTrustedWindow(window)) continue;
+    deps.send(window, 'appshots:shortcut-state-changed', state);
+  }
+}

--- a/apps/desktop/src/main/appshots/shortcutService.ts
+++ b/apps/desktop/src/main/appshots/shortcutService.ts
@@ -122,6 +122,13 @@ export class AppshotShortcutService {
     if (!this.isCurrent(operation)) return;
     this.deactivate();
     const preferences = suppliedPreferences ?? this.deps.store.get();
+    // Appshots is macOS-only: never register a global shortcut (the preferred
+    // dual-modifier listener or the fallback accelerator) on other platforms.
+    if ((this.deps.platform ?? process.platform) !== 'darwin') {
+      this.currentState = { preferences, configured: preferences.preferred, active: null };
+      this.publish();
+      return;
+    }
     const codexRunning = preferences.preferred.kind === 'dual-modifier'
       && this.deps.getRunningBundleIds().has('com.openai.codex');
     const primary = codexRunning ? preferences.fallback : preferences.preferred;

--- a/apps/desktop/src/main/appshots/shortcutService.ts
+++ b/apps/desktop/src/main/appshots/shortcutService.ts
@@ -106,6 +106,12 @@ export class AppshotShortcutService {
 
   async refreshConflicts(): Promise<void> {
     if (!this.started) return;
+    // The workspace monitor fires on every app launch/terminate/activation.
+    // Skip re-registration when the Codex conflict state did not change, so
+    // ordinary app switching does not churn global shortcuts.
+    const codexRunning = this.currentState.preferences.preferred.kind === 'dual-modifier'
+      && this.deps.getRunningBundleIds().has('com.openai.codex');
+    if (codexRunning === (this.currentState.fallbackReason === 'codex-running')) return;
     await this.reconcile(++this.generation);
   }
 

--- a/apps/desktop/src/main/appshots/shortcutService.ts
+++ b/apps/desktop/src/main/appshots/shortcutService.ts
@@ -1,0 +1,219 @@
+import {
+  comboToElectronAccelerator,
+} from '../../shared/appShortcuts.js';
+import {
+  isDualModifierSnapshot,
+  type AppshotShortcut,
+  type AppshotShortcutPreferences,
+} from '../../shared/appshots.js';
+import { AppshotShortcutStore } from './shortcutStore.js';
+
+export type AppshotShortcutFallbackReason =
+  | 'codex-running'
+  | 'registration-conflict'
+  | 'input-monitoring';
+
+export interface AppshotShortcutState {
+  preferences: AppshotShortcutPreferences;
+  configured: AppshotShortcut;
+  active: AppshotShortcut | null;
+  fallbackReason?: AppshotShortcutFallbackReason;
+}
+
+export interface AppshotShortcutServiceDeps {
+  store: AppshotShortcutStore;
+  globalShortcut: {
+    register(accelerator: string, callback: () => void): boolean;
+    unregister(accelerator: string): void;
+  };
+  retainMacModifierKeySnapshots: (
+    owner: string,
+    subscriber: (keys: readonly string[]) => void,
+  ) => Promise<() => void>;
+  capture: () => Promise<unknown>;
+  getRunningBundleIds: () => ReadonlySet<string>;
+  onStateChanged?: (state: AppshotShortcutState) => void;
+  onCaptureFailure?: (code: 'capture-failed') => void;
+  platform?: NodeJS.Platform;
+}
+
+function copyShortcut(shortcut: AppshotShortcut): AppshotShortcut {
+  return shortcut.kind === 'dual-modifier'
+    ? { ...shortcut }
+    : { kind: 'accelerator', combo: { ...shortcut.combo } };
+}
+
+function copyState(state: AppshotShortcutState): AppshotShortcutState {
+  return {
+    preferences: { preferred: copyShortcut(state.preferences.preferred), fallback: copyShortcut(state.preferences.fallback) },
+    configured: copyShortcut(state.configured),
+    active: state.active ? copyShortcut(state.active) : null,
+    ...(state.fallbackReason ? { fallbackReason: state.fallbackReason } : {}),
+  };
+}
+
+/** Registers the one effective Appshot shortcut and swaps to the fallback for Codex conflicts. */
+export class AppshotShortcutService {
+  private started = false;
+  private generation = 0;
+  private registeredAccelerator: string | null = null;
+  private releaseNativeSnapshots: (() => void) | null = null;
+  private dualModifierPressed = false;
+  private currentState: AppshotShortcutState;
+
+  constructor(private readonly deps: AppshotShortcutServiceDeps) {
+    const preferences = deps.store.get();
+    this.currentState = { preferences, configured: preferences.preferred, active: null };
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    await this.reconcile(++this.generation);
+  }
+
+  stop(): void {
+    this.generation += 1;
+    this.started = false;
+    this.deactivate();
+    this.currentState = { ...this.currentState, active: null };
+    this.publish();
+  }
+
+  state(): AppshotShortcutState {
+    return copyState(this.currentState);
+  }
+
+  async setPreferences(value: unknown): Promise<AppshotShortcutState> {
+    const preferences = this.deps.store.set(value);
+    const operation = ++this.generation;
+    this.deactivate();
+    this.currentState = { preferences, configured: preferences.preferred, active: null };
+    if (this.started) await this.reconcile(operation, preferences);
+    else this.publish();
+    return this.state();
+  }
+
+  async reset(): Promise<AppshotShortcutState> {
+    const preferences = this.deps.store.reset();
+    const operation = ++this.generation;
+    this.deactivate();
+    this.currentState = { preferences, configured: preferences.preferred, active: null };
+    if (this.started) await this.reconcile(operation, preferences);
+    else this.publish();
+    return this.state();
+  }
+
+  async refreshConflicts(): Promise<void> {
+    if (!this.started) return;
+    await this.reconcile(++this.generation);
+  }
+
+  private async reconcile(
+    operation: number,
+    suppliedPreferences?: AppshotShortcutPreferences,
+  ): Promise<void> {
+    if (!this.isCurrent(operation)) return;
+    this.deactivate();
+    const preferences = suppliedPreferences ?? this.deps.store.get();
+    const codexRunning = preferences.preferred.kind === 'dual-modifier'
+      && this.deps.getRunningBundleIds().has('com.openai.codex');
+    const primary = codexRunning ? preferences.fallback : preferences.preferred;
+    const primaryActivation = await this.activate(primary);
+    if (!this.isCurrent(operation)) {
+      primaryActivation?.release();
+      return;
+    }
+    if (primaryActivation) {
+      this.install(primaryActivation);
+      this.currentState = {
+        preferences,
+        configured: preferences.preferred,
+        active: primary,
+        ...(codexRunning ? { fallbackReason: 'codex-running' as const } : {}),
+      };
+      this.publish();
+      return;
+    }
+
+    const fallbackReason: AppshotShortcutFallbackReason = primary.kind === 'dual-modifier'
+      ? 'input-monitoring'
+      : 'registration-conflict';
+    const fallbackActivation = !codexRunning && primary !== preferences.fallback
+      ? await this.activate(preferences.fallback)
+      : null;
+    if (!this.isCurrent(operation)) {
+      fallbackActivation?.release();
+      return;
+    }
+    if (fallbackActivation) {
+      this.install(fallbackActivation);
+      this.currentState = {
+        preferences,
+        configured: preferences.preferred,
+        active: preferences.fallback,
+        fallbackReason,
+      };
+    } else {
+      this.currentState = {
+        preferences,
+        configured: preferences.preferred,
+        active: null,
+        fallbackReason: codexRunning ? 'codex-running' : fallbackReason,
+      };
+    }
+    this.publish();
+  }
+
+  private isCurrent(operation: number): boolean {
+    return this.started && operation === this.generation;
+  }
+
+  private async activate(shortcut: AppshotShortcut): Promise<{ release: () => void; accelerator?: string } | null> {
+    if (shortcut.kind === 'dual-modifier') {
+      if ((this.deps.platform ?? process.platform) !== 'darwin') return null;
+      try {
+        const release = await this.deps.retainMacModifierKeySnapshots(
+          'appshots-shortcut-service',
+          (keys) => this.handleNativeKeys(shortcut, keys),
+        );
+        return { release };
+      } catch {
+        return null;
+      }
+    }
+    const accelerator = comboToElectronAccelerator(shortcut.combo, this.deps.platform ?? process.platform);
+    if (!accelerator || !this.deps.globalShortcut.register(accelerator, () => this.capture())) return null;
+    return {
+      accelerator,
+      release: () => this.deps.globalShortcut.unregister(accelerator),
+    };
+  }
+
+  private install(activation: { release: () => void; accelerator?: string }): void {
+    if (activation.accelerator) this.registeredAccelerator = activation.accelerator;
+    else this.releaseNativeSnapshots = activation.release;
+  }
+
+  private deactivate(): void {
+    if (this.registeredAccelerator) this.deps.globalShortcut.unregister(this.registeredAccelerator);
+    this.registeredAccelerator = null;
+    this.releaseNativeSnapshots?.();
+    this.releaseNativeSnapshots = null;
+    this.dualModifierPressed = false;
+  }
+
+  private handleNativeKeys(shortcut: Extract<AppshotShortcut, { kind: 'dual-modifier' }>, keys: readonly string[]): void {
+    const matching = isDualModifierSnapshot(keys, shortcut.modifier);
+    if (matching && !this.dualModifierPressed) this.capture();
+    this.dualModifierPressed = matching;
+  }
+
+  private capture(): void {
+    void this.deps.capture().catch(() => this.deps.onCaptureFailure?.('capture-failed'));
+  }
+
+  private publish(): void {
+    this.deps.onStateChanged?.(this.state());
+  }
+}

--- a/apps/desktop/src/main/appshots/shortcutStore.ts
+++ b/apps/desktop/src/main/appshots/shortcutStore.ts
@@ -1,0 +1,161 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  DEFAULT_APPSHOT_SHORTCUT_PREFERENCES,
+  normalizeAppshotShortcut,
+  type AppshotShortcut,
+  type AppshotShortcutPreferences,
+} from '../../shared/appshots.js';
+import { appShortcutCombosEqual } from '../../shared/appShortcuts.js';
+import { isSystemReservedShortcut } from '../../shared/keyboardReserved.js';
+
+const STORE_VERSION = 1;
+
+export type AppshotShortcutValidationReason =
+  | 'invalid-structure'
+  | 'duplicate'
+  | 'system-reserved';
+
+/** Distinguishes user validation failures from storage failures at the IPC boundary. */
+export class AppshotShortcutValidationError extends Error {
+  constructor(readonly reason: AppshotShortcutValidationReason) {
+    super(reason === 'duplicate'
+      ? 'Preferred and fallback shortcuts must be different.'
+      : reason === 'system-reserved'
+        ? 'This shortcut is reserved by the system.'
+        : 'Appshot shortcut preferences are invalid.');
+    this.name = 'AppshotShortcutValidationError';
+  }
+}
+
+export interface AppshotShortcutStoreDeps {
+  getFilePath: () => string;
+  readFile: (path: string) => string;
+  writeFileAtomic: (path: string, value: string) => void;
+  removeFile: (path: string) => void;
+}
+
+function clonePreferences(value: AppshotShortcutPreferences): AppshotShortcutPreferences {
+  return {
+    preferred: value.preferred.kind === 'dual-modifier'
+      ? { ...value.preferred }
+      : { kind: 'accelerator', combo: { ...value.preferred.combo } },
+    fallback: value.fallback.kind === 'dual-modifier'
+      ? { ...value.fallback }
+      : { kind: 'accelerator', combo: { ...value.fallback.combo } },
+  };
+}
+
+function shortcutEqual(a: AppshotShortcut, b: AppshotShortcut): boolean {
+  if (a.kind !== b.kind) return false;
+  return a.kind === 'dual-modifier'
+    ? a.modifier === (b as Extract<AppshotShortcut, { kind: 'dual-modifier' }>).modifier
+    : appShortcutCombosEqual(a.combo, (b as Extract<AppshotShortcut, { kind: 'accelerator' }>).combo);
+}
+
+function isStrictShortcutShape(value: unknown): boolean {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const raw = value as Record<string, unknown>;
+  if (raw.kind === 'dual-modifier') {
+    return raw.modifier === 'command' || raw.modifier === 'option' || raw.modifier === 'shift';
+  }
+  if (raw.kind !== 'accelerator' || !raw.combo || typeof raw.combo !== 'object' || Array.isArray(raw.combo)) {
+    return false;
+  }
+  const combo = raw.combo as Record<string, unknown>;
+  return typeof combo.code === 'string'
+    && combo.code.trim().length > 0
+    && typeof combo.meta === 'boolean'
+    && typeof combo.ctrl === 'boolean'
+    && typeof combo.alt === 'boolean'
+    && typeof combo.shift === 'boolean'
+    && (combo.key === undefined || typeof combo.key === 'string');
+}
+
+function parseStrictPreferences(value: unknown): AppshotShortcutPreferences {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new AppshotShortcutValidationError('invalid-structure');
+  }
+  const raw = value as Record<string, unknown>;
+  if (!isStrictShortcutShape(raw.preferred) || !isStrictShortcutShape(raw.fallback)) {
+    throw new AppshotShortcutValidationError('invalid-structure');
+  }
+  const preferred = normalizeAppshotShortcut(raw.preferred);
+  const fallback = normalizeAppshotShortcut(raw.fallback);
+  if (!preferred || !fallback) throw new AppshotShortcutValidationError('invalid-structure');
+  const preferences = { preferred, fallback };
+  if (shortcutEqual(preferences.preferred, preferences.fallback)) {
+    throw new AppshotShortcutValidationError('duplicate');
+  }
+  for (const shortcut of [preferences.preferred, preferences.fallback]) {
+    if (shortcut.kind === 'accelerator' && isSystemReservedShortcut(shortcut.combo, 'mac')) {
+      throw new AppshotShortcutValidationError('system-reserved');
+    }
+  }
+  return preferences;
+}
+
+function parseStoredPreferences(value: string): AppshotShortcutPreferences | null {
+  try {
+    const raw = JSON.parse(value) as { version?: unknown; preferences?: unknown };
+    if (raw.version !== STORE_VERSION) return null;
+    return parseStrictPreferences(raw.preferences);
+  } catch {
+    return null;
+  }
+}
+
+/** Stores only explicit Appshot shortcut overrides; defaults remain code-owned. */
+export class AppshotShortcutStore {
+  constructor(private readonly deps: AppshotShortcutStoreDeps) {}
+
+  get(): AppshotShortcutPreferences {
+    try {
+      return parseStoredPreferences(this.deps.readFile(this.deps.getFilePath()))
+        ?? clonePreferences(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+    } catch {
+      return clonePreferences(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+    }
+  }
+
+  set(next: unknown): AppshotShortcutPreferences {
+    const preferences = parseStrictPreferences(next);
+    this.deps.writeFileAtomic(
+      this.deps.getFilePath(),
+      JSON.stringify({ version: STORE_VERSION, preferences }),
+    );
+    return clonePreferences(preferences);
+  }
+
+  reset(): AppshotShortcutPreferences {
+    try {
+      this.deps.removeFile(this.deps.getFilePath());
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    return clonePreferences(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+  }
+}
+
+/** Creates the desktop's userData-backed store with a same-directory atomic replace. */
+export function createAppshotShortcutStore(userDataPath: string): AppshotShortcutStore {
+  const filePath = path.join(userDataPath, 'appshots-shortcuts.v1.json');
+  return new AppshotShortcutStore({
+    getFilePath: () => filePath,
+    readFile: (target) => fs.readFileSync(target, 'utf8'),
+    writeFileAtomic: (target, value) => {
+      fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+      const temporary = `${target}.${process.pid}.${Date.now()}.tmp`;
+      fs.writeFileSync(temporary, value, { encoding: 'utf8', mode: 0o600 });
+      try {
+        fs.renameSync(temporary, target);
+        fs.chmodSync(target, 0o600);
+      } catch (error) {
+        try { fs.unlinkSync(temporary); } catch { /* best effort */ }
+        throw error;
+      }
+    },
+    removeFile: (target) => fs.unlinkSync(target),
+  });
+}

--- a/apps/desktop/src/main/appshots/workspaceApplicationMonitor.ts
+++ b/apps/desktop/src/main/appshots/workspaceApplicationMonitor.ts
@@ -23,8 +23,12 @@ function parseSnapshotLine(line: string): WorkspaceSnapshotLine | null {
   try {
     const value = JSON.parse(line) as Partial<WorkspaceSnapshotLine>;
     if (value.type !== 'snapshot' || !Array.isArray(value.bundleIds)) return null;
-    if (value.bundleIds.some((item) => typeof item !== 'string' || item.length === 0)) return null;
-    return { type: 'snapshot', bundleIds: [...new Set(value.bundleIds)] };
+    // JXA bridges processes without a bundle identifier as literal nulls, so
+    // tolerate junk entries instead of rejecting the whole snapshot line.
+    const bundleIds = value.bundleIds.filter(
+      (item): item is string => typeof item === 'string' && item.length > 0,
+    );
+    return { type: 'snapshot', bundleIds: [...new Set(bundleIds)] };
   } catch {
     return null;
   }
@@ -117,8 +121,12 @@ export class MacWorkspaceApplicationMonitor {
     const refresh = this.deps.readSnapshot()
       .then((bundleIds) => {
         if (operation !== this.generation || eventGeneration !== this.eventGeneration) return;
-        if (bundleIds.some((value) => typeof value !== 'string' || value.length === 0)) return;
-        this.apply(bundleIds);
+        const validBundleIds = bundleIds.filter(
+          (value): value is string => typeof value === 'string' && value.length > 0,
+        );
+        // Preserve the last state when the whole fallback read was malformed.
+        if (bundleIds.length > 0 && validBundleIds.length === 0) return;
+        this.apply(validBundleIds);
       })
       .catch(() => undefined)
       .finally(() => {
@@ -144,7 +152,8 @@ function publishSnapshot() {
   const bundleIds = [];
   for (let index = 0; index < applications.count; index += 1) {
     const identifier = applications.objectAtIndex(index).bundleIdentifier;
-    if (identifier) bundleIds.push(ObjC.unwrap(identifier));
+    const unwrapped = ObjC.unwrap(identifier);
+    if (unwrapped) bundleIds.push(unwrapped);
   }
   const line = JSON.stringify({ type: 'snapshot', bundleIds: bundleIds }) + '\n';
   $.NSFileHandle.fileHandleWithStandardOutput.writeData($(line).dataUsingEncoding($.NSUTF8StringEncoding));
@@ -172,7 +181,8 @@ const applications = $.NSWorkspace.sharedWorkspace.runningApplications;
 const bundleIds = [];
 for (let index = 0; index < applications.count; index += 1) {
   const identifier = applications.objectAtIndex(index).bundleIdentifier;
-  if (identifier) bundleIds.push(ObjC.unwrap(identifier));
+  const unwrapped = ObjC.unwrap(identifier);
+  if (unwrapped) bundleIds.push(unwrapped);
 }
 JSON.stringify(bundleIds);
 `;
@@ -190,11 +200,14 @@ export function readMacWorkspaceApplicationSnapshot(): Promise<readonly string[]
           return;
         }
         try {
-          const bundleIds = JSON.parse(stdout) as unknown;
-          if (!Array.isArray(bundleIds) || bundleIds.some((value) => typeof value !== 'string')) {
+          const rawBundleIds = JSON.parse(stdout) as unknown;
+          if (!Array.isArray(rawBundleIds)) {
             reject(new Error('invalid workspace application snapshot'));
             return;
           }
+          const bundleIds = rawBundleIds.filter(
+            (value): value is string => typeof value === 'string' && value.length > 0,
+          );
           resolve(bundleIds);
         } catch (parseError) {
           reject(parseError);

--- a/apps/desktop/src/main/appshots/workspaceApplicationMonitor.ts
+++ b/apps/desktop/src/main/appshots/workspaceApplicationMonitor.ts
@@ -1,0 +1,205 @@
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+
+interface WorkspaceListenerProcess {
+  stdout: NodeJS.EventEmitter;
+  stderr: NodeJS.EventEmitter;
+  on(event: 'close', listener: (code: number | null) => void): unknown;
+  on(event: 'error', listener: (error: Error) => void): unknown;
+  kill(): unknown;
+}
+
+export interface MacWorkspaceApplicationMonitorDeps {
+  spawnListener: () => WorkspaceListenerProcess;
+  readSnapshot: () => Promise<readonly string[]>;
+  onSnapshot: (bundleIds: ReadonlySet<string>) => void;
+  scheduleRestart?: (callback: () => void, delayMs: number) => unknown;
+}
+
+type WorkspaceSnapshotLine = { type: 'snapshot'; bundleIds: string[] };
+const MAX_BUFFERED_STDOUT_BYTES = 256 * 1024;
+const LISTENER_RESTART_DELAY_MS = 1_000;
+
+function parseSnapshotLine(line: string): WorkspaceSnapshotLine | null {
+  try {
+    const value = JSON.parse(line) as Partial<WorkspaceSnapshotLine>;
+    if (value.type !== 'snapshot' || !Array.isArray(value.bundleIds)) return null;
+    if (value.bundleIds.some((item) => typeof item !== 'string' || item.length === 0)) return null;
+    return { type: 'snapshot', bundleIds: [...new Set(value.bundleIds)] };
+  } catch {
+    return null;
+  }
+}
+
+/** Tracks NSWorkspace application changes through one stoppable, long-running JXA process. */
+export class MacWorkspaceApplicationMonitor {
+  private child: WorkspaceListenerProcess | null = null;
+  private bundleIds = new Set<string>();
+  private generation = 0;
+  private eventGeneration = 0;
+  private refreshPromise: Promise<void> | null = null;
+  private bufferedOutput = '';
+  private restartScheduled = false;
+
+  constructor(private readonly deps: MacWorkspaceApplicationMonitorDeps) {}
+
+  start(): void {
+    if (this.child) return;
+    const operation = ++this.generation;
+    let child: WorkspaceListenerProcess;
+    try {
+      child = this.deps.spawnListener();
+    } catch {
+      this.scheduleRestart(operation);
+      return;
+    }
+    this.child = child;
+    const consume = (chunk: unknown): void => {
+      if (this.child !== child || operation !== this.generation) return;
+      this.bufferedOutput += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk);
+      if (Buffer.byteLength(this.bufferedOutput, 'utf8') > MAX_BUFFERED_STDOUT_BYTES) {
+        this.bufferedOutput = '';
+        child.kill();
+        return;
+      }
+      const lines = this.bufferedOutput.split(/\r?\n/);
+      this.bufferedOutput = lines.pop() ?? '';
+      for (const line of lines) {
+        const snapshot = parseSnapshotLine(line.trim());
+        if (!snapshot) continue;
+        this.eventGeneration += 1;
+        this.apply(snapshot.bundleIds);
+      }
+    };
+    child.stdout.on('data', consume);
+    // stderr is a diagnostic channel, never part of the JSON protocol. Do not
+    // feed it into the stdout buffer: an error without a newline could otherwise
+    // grow the protocol buffer forever.
+    child.stderr.on('data', () => undefined);
+    child.on('error', () => undefined);
+    child.on('close', () => {
+      if (this.child !== child || operation !== this.generation) return;
+      this.child = null;
+      this.bufferedOutput = '';
+      this.scheduleRestart(operation);
+    });
+  }
+
+  stop(): void {
+    this.generation += 1;
+    this.restartScheduled = false;
+    const child = this.child;
+    this.child = null;
+    this.bufferedOutput = '';
+    child?.kill();
+  }
+
+  private scheduleRestart(operation: number): void {
+    if (this.restartScheduled) return;
+    this.restartScheduled = true;
+    const schedule = this.deps.scheduleRestart ?? ((callback: () => void, delayMs: number) => {
+      setTimeout(callback, delayMs);
+    });
+    schedule(() => {
+      this.restartScheduled = false;
+      if (operation !== this.generation || this.child) return;
+      this.start();
+    }, LISTENER_RESTART_DELAY_MS);
+  }
+
+  state(): ReadonlySet<string> {
+    return new Set(this.bundleIds);
+  }
+
+  refresh(): Promise<void> {
+    if (this.refreshPromise) return this.refreshPromise;
+    const operation = this.generation;
+    const eventGeneration = this.eventGeneration;
+    const refresh = this.deps.readSnapshot()
+      .then((bundleIds) => {
+        if (operation !== this.generation || eventGeneration !== this.eventGeneration) return;
+        if (bundleIds.some((value) => typeof value !== 'string' || value.length === 0)) return;
+        this.apply(bundleIds);
+      })
+      .catch(() => undefined)
+      .finally(() => {
+        if (this.refreshPromise === refresh) this.refreshPromise = null;
+      });
+    this.refreshPromise = refresh;
+    return refresh;
+  }
+
+  private apply(bundleIds: readonly string[]): void {
+    this.bundleIds = new Set(bundleIds);
+    this.deps.onSnapshot(new Set(this.bundleIds));
+  }
+}
+
+const WORKSPACE_LISTENER_SCRIPT = String.raw`
+ObjC.import('AppKit');
+ObjC.import('Foundation');
+const workspace = $.NSWorkspace.sharedWorkspace;
+const center = workspace.notificationCenter;
+function publishSnapshot() {
+  const applications = workspace.runningApplications;
+  const bundleIds = [];
+  for (let index = 0; index < applications.count; index += 1) {
+    const identifier = applications.objectAtIndex(index).bundleIdentifier;
+    if (identifier) bundleIds.push(ObjC.unwrap(identifier));
+  }
+  const line = JSON.stringify({ type: 'snapshot', bundleIds: bundleIds }) + '\n';
+  $.NSFileHandle.fileHandleWithStandardOutput.writeData($(line).dataUsingEncoding($.NSUTF8StringEncoding));
+}
+const callback = ObjC.block('void', ['id'], function () { publishSnapshot(); });
+const observers = [
+  center.addObserverForNameObjectQueueUsingBlock($.NSWorkspaceDidLaunchApplicationNotification, null, null, callback),
+  center.addObserverForNameObjectQueueUsingBlock($.NSWorkspaceDidTerminateApplicationNotification, null, null, callback),
+  center.addObserverForNameObjectQueueUsingBlock($.NSWorkspaceDidActivateApplicationNotification, null, null, callback),
+];
+publishSnapshot();
+$.NSRunLoop.currentRunLoop.run;
+`;
+
+/** Starts the production NSWorkspace notification listener. */
+export function spawnMacWorkspaceApplicationListener(): ChildProcessWithoutNullStreams {
+  return spawn('/usr/bin/osascript', ['-l', 'JavaScript', '-e', WORKSPACE_LISTENER_SCRIPT], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+}
+
+const WORKSPACE_SNAPSHOT_SCRIPT = String.raw`
+ObjC.import('AppKit');
+const applications = $.NSWorkspace.sharedWorkspace.runningApplications;
+const bundleIds = [];
+for (let index = 0; index < applications.count; index += 1) {
+  const identifier = applications.objectAtIndex(index).bundleIdentifier;
+  if (identifier) bundleIds.push(ObjC.unwrap(identifier));
+}
+JSON.stringify(bundleIds);
+`;
+
+/** Reads one authoritative NSWorkspace snapshot for startup/focus recovery. */
+export function readMacWorkspaceApplicationSnapshot(): Promise<readonly string[]> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      '/usr/bin/osascript',
+      ['-l', 'JavaScript', '-e', WORKSPACE_SNAPSHOT_SCRIPT],
+      { timeout: 1_500 },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        try {
+          const bundleIds = JSON.parse(stdout) as unknown;
+          if (!Array.isArray(bundleIds) || bundleIds.some((value) => typeof value !== 'string')) {
+            reject(new Error('invalid workspace application snapshot'));
+            return;
+          }
+          resolve(bundleIds);
+        } catch (parseError) {
+          reject(parseError);
+        }
+      },
+    );
+  });
+}

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -6591,8 +6591,8 @@ app.on('ready', async () => {
     appshotWorkspaceApplicationMonitor.start();
     await appshotWorkspaceApplicationMonitor.refresh();
     app.on('browser-window-focus', refreshAppshotWorkspaceApplicationSnapshot);
+    await appshotShortcutService.start();
   }
-  await appshotShortcutService.start();
   // 老 'usage:get-today-spend' 已退役 —— renderer 走 maker:usage:today('claude-code') 拉。
   // readTodaySpend 仍在 main/usageBroadcaster.ts 内部被 readAgentTodayUsage 用。
   // 主机飞书 token 链已退役(2026-07-17):飞书授权改由 xd-feishu 意识经

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -3,6 +3,7 @@ import {
   BrowserWindow,
   clipboard,
   dialog,
+  globalShortcut,
   ipcMain,
   Menu,
   nativeImage,
@@ -23,6 +24,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import { pipeline } from 'node:stream/promises';
 import { execFile, execFileSync, spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { machineIdSync } from 'node-machine-id';
 import windowStateKeeper from 'electron-window-state';
 import { BRAND_NAME } from '@cindy/maker-shared/branding';
@@ -41,6 +43,20 @@ import {
   waitForTurnChangeSetActions,
   waitForTurnChangeSetPersistence,
 } from './turn-change-set/store.js';
+import { MacAppshotNativeHost } from './appshots/MacAppshotNativeHost.js';
+import { AppshotCoordinator } from './appshots/coordinator.js';
+import { createAppshotPublisher, registerAppshotIpc } from './appshots/ipc.js';
+import { createAppshotShortcutStore } from './appshots/shortcutStore.js';
+import { AppshotShortcutService } from './appshots/shortcutService.js';
+import {
+  broadcastAppshotShortcutState,
+  registerAppshotShortcutIpc,
+} from './appshots/shortcutIpc.js';
+import {
+  MacWorkspaceApplicationMonitor,
+  readMacWorkspaceApplicationSnapshot,
+  spawnMacWorkspaceApplicationListener,
+} from './appshots/workspaceApplicationMonitor.js';
 
 const PROCESS_STARTED_AT_MS = Date.now();
 // Official Linux binaries total hundreds of MB. Keep one shared deadline for
@@ -325,7 +341,10 @@ import {
   isFocusedAppContentWindow,
   markAppContentWindow,
 } from './windowFocusClassifier.js';
-import { assertTrustedAppRendererEvent } from './security/trustedAppRenderer.js';
+import {
+  assertTrustedAppRendererEvent,
+  isTrustedAppRendererWindow,
+} from './security/trustedAppRenderer.js';
 import { isIpcError } from '../shared/ipc-errors';
 import { readFileBytesForPreview } from './fileReadBytes.js';
 import { initHeartbeatService } from './heartbeatService';
@@ -579,6 +598,7 @@ import { isSecondaryAppWindow, openSessionInNewWindow } from './secondary-window
 import {
   isGlobalVoiceInputOverlayVisible,
   registerGlobalVoiceInputIpc,
+  retainMacModifierKeySnapshots,
 } from './voice-input/global.js';
 import { ensureMainAppPresence } from './appPresence.js';
 import {
@@ -1829,6 +1849,55 @@ function isPathAllowed(filePath: string): boolean {
 // BrowserWindow，[0] 拿到它再 .focus() 等于啥也没干，用户视觉上以为
 // "双击启动不了"。
 let mainWindowRef: BrowserWindow | null = null;
+const appshotNativeHost = new MacAppshotNativeHost();
+const appshotCoordinator = new AppshotCoordinator({
+  captureNative: (outputDir) => appshotNativeHost.capture(outputDir),
+  ingestPng: async (bytes) => cindyChatAttachments.ingestChatImageBuffer({
+    buffer: bytes,
+    mimeType: 'image/png',
+  }),
+  async makeTempDir() {
+    const outputDir = await fs.promises.mkdtemp(path.join(app.getPath('temp'), 'cindy-appshot-'));
+    await fs.promises.chmod(outputDir, 0o700);
+    return outputDir;
+  },
+  removeTempDir: (outputDir) => fs.promises.rm(outputDir, { recursive: true, force: true }),
+  now: () => new Date(),
+  randomUUID,
+  publish: createAppshotPublisher({
+    getMainWindow: () => mainWindowRef,
+    isTrustedWindow: isTrustedAppRendererWindow,
+    send: (window, channel, result) => window.webContents.send(channel, result),
+    focus: () => { focusMainWindow(); },
+  }),
+});
+const appshotRunningBundleIds = new Set<string>();
+const appshotShortcutService = new AppshotShortcutService({
+  store: createAppshotShortcutStore(app.getPath('userData')),
+  globalShortcut,
+  retainMacModifierKeySnapshots,
+  capture: () => appshotCoordinator.capture(),
+  getRunningBundleIds: () => appshotRunningBundleIds,
+  onStateChanged: (state) => {
+    broadcastAppshotShortcutState({
+      windows: BrowserWindow.getAllWindows(),
+      isTrustedWindow: isTrustedAppRendererWindow,
+      send: (window, channel, shortcutState) => window.webContents.send(channel, shortcutState),
+    }, state);
+  },
+});
+const appshotWorkspaceApplicationMonitor = new MacWorkspaceApplicationMonitor({
+  spawnListener: spawnMacWorkspaceApplicationListener,
+  readSnapshot: readMacWorkspaceApplicationSnapshot,
+  onSnapshot: (bundleIds) => {
+    appshotRunningBundleIds.clear();
+    for (const bundleId of bundleIds) appshotRunningBundleIds.add(bundleId);
+    void appshotShortcutService.refreshConflicts();
+  },
+});
+const refreshAppshotWorkspaceApplicationSnapshot = (): void => {
+  void appshotWorkspaceApplicationMonitor.refresh();
+};
 // 端点清单阻断门:ready 流程走到正常 createWindow() 前置 true。在此之前
 // second-instance / activate 一律不许建窗——阻断循环(错误框重试)期间用户
 // 双击图标 / 点 Dock 若能建窗,preload 的模块级 sendSync 会因 handler 未注册
@@ -6471,6 +6540,20 @@ app.on('ready', async () => {
   // dev-only IPC for embedding-host smoke testing (status + sync embed). 安全:
   // 内部自带 app.isPackaged 守卫, packaged build 下 register 是 no-op。
   registerDevEmbeddingIpc();
+  registerAppshotIpc({
+    ipcMain,
+    coordinator: appshotCoordinator,
+    assertTrustedSender: (event) => assertTrustedAppRendererEvent(
+      event as Parameters<typeof assertTrustedAppRendererEvent>[0],
+    ),
+  });
+  registerAppshotShortcutIpc({
+    ipcMain,
+    service: appshotShortcutService,
+    assertTrustedSender: (event) => assertTrustedAppRendererEvent(
+      event as Parameters<typeof assertTrustedAppRendererEvent>[0],
+    ),
+  });
   // worktree-parallel-sessions: 注册 7 个 worktree:* channel (创建/查询/列表/reveal/...)
   // 删除路径不暴露 IPC; 仅在 cc-agent:close-session 内部调用 removeWorktreeForSession。
   registerWorktreeIpc(ipcMain);
@@ -6504,6 +6587,12 @@ app.on('ready', async () => {
     // 会话副窗口跑同一套路由,设置页在里面照样打得开,所以弹系统授权窗那两条 IPC 要认它。
     isSecondaryAppWindow,
   });
+  if (process.platform === 'darwin') {
+    appshotWorkspaceApplicationMonitor.start();
+    await appshotWorkspaceApplicationMonitor.refresh();
+    app.on('browser-window-focus', refreshAppshotWorkspaceApplicationSnapshot);
+  }
+  await appshotShortcutService.start();
   // 老 'usage:get-today-spend' 已退役 —— renderer 走 maker:usage:today('claude-code') 拉。
   // readTodaySpend 仍在 main/usageBroadcaster.ts 内部被 readAgentTodayUsage 用。
   // 主机飞书 token 链已退役(2026-07-17):飞书授权改由 xd-feishu 意识经
@@ -6684,6 +6773,12 @@ onQuit(
   'sync',
 );
 onQuit('auth-manager', () => authManager.dispose(), 'sync');
+onQuit('appshots-clear-pending', () => appshotCoordinator.clear(), 'sync');
+onQuit('appshots-shortcut-service', () => {
+  app.removeListener('browser-window-focus', refreshAppshotWorkspaceApplicationSnapshot);
+  appshotWorkspaceApplicationMonitor.stop();
+  appshotShortcutService.stop();
+}, 'sync');
 onQuit('app-badge-clear', () => clearAllSessionAttention(), 'sync');
 // 自带 adb 的常驻 server 守护进程随退出收掉(fire-and-forget detached spawn,
 // 不阻塞)。不收会一直锁安装目录里的 adb.exe,弄挂增量更新(os error 32)。

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6002,6 +6002,40 @@ describe('AgentInputCoordinator queue mutations', () => {
 });
 
 describe('AgentInputCoordinator crash-recovery queue snapshots (issue #761)', () => {
+  it('rejects a non-Codex Appshot from a crash snapshot before restoring it', async () => {
+    const h = createHarness();
+    const sid = 'snapshot-appshot-non-codex';
+    h.setLoadQueueSnapshot(async () => [
+      makeItem('r-appshot', 'captured window', {
+        files: [{
+          id: 'file-1',
+          name: 'capture.png',
+          path: '/tmp/capture.png',
+          ext: '.png',
+          size: 1,
+          category: 'image',
+          mimeType: 'image/png',
+          appshot: {
+            schemaVersion: 1,
+            captureId: 'capture-1',
+            capturedAt: '2026-08-06T01:02:03.000Z',
+            applicationName: 'Cindy',
+            bundleIdentifier: 'com.xd.cindy',
+            windowTitle: 'Draft',
+            accessibilityText: null,
+            accessibilityTruncated: false,
+          },
+        }],
+      }),
+    ]);
+
+    await expect(h.coordinator.ensureQueueRestored(sid)).rejects.toThrow(
+      'Appshots are only supported in Codex sessions',
+    );
+    expect(h.projections).toEqual([]);
+    expect(h.sendToAgent).not.toHaveBeenCalled();
+  });
+
   it('persists the queue after restore and shrinks the snapshot once the head crosses the DB boundary', async () => {
     const h = createHarness();
     const sid = 'snapshot-persist';

--- a/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/agent-input-coordinator.test.ts
@@ -6002,7 +6002,7 @@ describe('AgentInputCoordinator queue mutations', () => {
 });
 
 describe('AgentInputCoordinator crash-recovery queue snapshots (issue #761)', () => {
-  it('rejects a non-Codex Appshot from a crash snapshot before restoring it', async () => {
+  it('strips Appshot metadata from a non-Codex crash snapshot and restores the rest', async () => {
     const h = createHarness();
     const sid = 'snapshot-appshot-non-codex';
     h.setLoadQueueSnapshot(async () => [
@@ -6029,11 +6029,11 @@ describe('AgentInputCoordinator crash-recovery queue snapshots (issue #761)', ()
       }),
     ]);
 
-    await expect(h.coordinator.ensureQueueRestored(sid)).rejects.toThrow(
-      'Appshots are only supported in Codex sessions',
-    );
-    expect(h.projections).toEqual([]);
-    expect(h.sendToAgent).not.toHaveBeenCalled();
+    await h.coordinator.ensureQueueRestored(sid);
+
+    const restored = latestProjection(h.projections).pendingQueue[0];
+    expect(restored?.files?.[0]).not.toHaveProperty('appshot');
+    expect(restored?.files?.[0]?.name).toBe('capture.png');
   });
 
   it('persists the queue after restore and shrinks the snapshot once the head crosses the DB boundary', async () => {

--- a/apps/desktop/src/main/maker-ipc/__tests__/appshotBoundary.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/appshotBoundary.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  requireCodexQueuedAppshots,
+  validateAndStripAppshotMetadata,
+} from '../appshotBoundary';
+
+const metadata = {
+  schemaVersion: 1,
+  captureId: 'capture-1',
+  capturedAt: '2026-08-06T01:02:03.000Z',
+  applicationName: 'Cindy',
+  bundleIdentifier: 'com.xd.cindy',
+  windowTitle: 'Draft',
+  accessibilityText: null,
+  accessibilityTruncated: false,
+};
+
+describe('Appshot send boundary', () => {
+  it('keeps a valid Appshot on Codex messages and strips malformed metadata', () => {
+    const message = {
+      type: 'user' as const,
+      content: [
+        { type: 'image', path: '/tmp/capture.png', mimeType: 'image/png', appshot: metadata },
+        { type: 'image', path: '/tmp/ordinary.png', mimeType: 'image/png', appshot: { bad: true } },
+      ],
+    };
+
+    const result = validateAndStripAppshotMetadata(message, 'codex');
+
+    expect(result.hasAppshot).toBe(true);
+    expect((result.message as { type: 'user'; content: unknown[] }).content).toEqual([
+      expect.objectContaining({ appshot: metadata }),
+      { type: 'image', path: '/tmp/ordinary.png', mimeType: 'image/png' },
+    ]);
+  });
+
+  it('rejects Appshots for Claude Code and Pi while leaving ordinary images valid', () => {
+    const ordinary = { type: 'user' as const, content: [{ type: 'image', path: '/tmp/image.png' }] };
+    expect(validateAndStripAppshotMetadata(ordinary, 'claude-code').hasAppshot).toBe(false);
+    expect(validateAndStripAppshotMetadata(ordinary, 'pi').hasAppshot).toBe(false);
+
+    const appshot = {
+      ...ordinary,
+      content: [{ ...ordinary.content[0], appshot: metadata }],
+    };
+    expect(() => validateAndStripAppshotMetadata(appshot, 'claude-code')).toThrow(
+      'Appshots are only supported in Codex sessions',
+    );
+    expect(() => validateAndStripAppshotMetadata(appshot, 'claude-code')).toThrow(/UNSUPPORTED_CAPABILITY/);
+    expect(() => validateAndStripAppshotMetadata(appshot, 'pi')).toThrow(
+      'Appshots are only supported in Codex sessions',
+    );
+  });
+
+  it('rejects queued Appshots before they enter the coordinator', () => {
+    const queued = {
+      clientId: 'client-1',
+      text: '',
+      persistedContent: '{}',
+      createOpts: { agentKind: 'claude-code' },
+      files: [{ appshot: metadata }],
+    };
+    expect(() => requireCodexQueuedAppshots(queued)).toThrow(
+      'Appshots are only supported in Codex sessions',
+    );
+    expect(() => requireCodexQueuedAppshots({ ...queued, createOpts: { agentKind: 'codex' } })).not.toThrow();
+  });
+});

--- a/apps/desktop/src/main/maker-ipc/__tests__/appshotBoundary.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/appshotBoundary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   requireCodexQueuedAppshots,
+  sanitizeQueuedAppshotMetadata,
   validateAndStripAppshotMetadata,
 } from '../appshotBoundary';
 
@@ -65,5 +66,32 @@ describe('Appshot send boundary', () => {
       'Appshots are only supported in Codex sessions',
     );
     expect(() => requireCodexQueuedAppshots({ ...queued, createOpts: { agentKind: 'codex' } })).not.toThrow();
+  });
+
+  it('sanitizes Appshot metadata from restored non-Codex queue items and keeps images', () => {
+    const queued = {
+      clientId: 'client-1',
+      text: '',
+      persistedContent: '{}',
+      createOpts: { agentKind: 'claude-code' },
+      files: [{ appshot: metadata }, { name: 'plain.png' }],
+    };
+    const sanitized = sanitizeQueuedAppshotMetadata(queued) as typeof queued;
+
+    expect(sanitized).not.toBe(queued);
+    expect(sanitized.files[0]).not.toHaveProperty('appshot');
+    expect(sanitized.files[1]).toEqual({ name: 'plain.png' });
+  });
+
+  it('leaves Codex queue items and appshot-free items untouched', () => {
+    const codexItem = {
+      clientId: 'client-1',
+      text: '',
+      persistedContent: '{}',
+      createOpts: { agentKind: 'codex' },
+      files: [{ appshot: metadata }],
+    };
+    expect(sanitizeQueuedAppshotMetadata(codexItem)).toBe(codexItem);
+    expect(sanitizeQueuedAppshotMetadata({ files: [] })).toEqual({ files: [] });
   });
 });

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -61,6 +61,7 @@ import {
   RECOVERY_CHECKPOINT_MARKER,
   type RecoveryContextSnapshot,
 } from './recoveryCoordinator.js';
+import { requireCodexQueuedAppshots } from './appshotBoundary.js';
 
 const log = createLogger('maker-input-coordinator');
 const SESSION_RUNNING_RETRY_DELAY_MS = 250;
@@ -971,6 +972,7 @@ export class AgentInputCoordinator {
       items = (await this.deps.loadQueueSnapshot!(sessionId)).map(
         normalizeRestoredSyntheticTrigger,
       );
+      for (const item of items) requireCodexQueuedAppshots(item);
     } catch (err) {
       log.warn('load queue snapshot failed; will retry on next entry', {
         sessionId,

--- a/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
+++ b/apps/desktop/src/main/maker-ipc/agent-input-coordinator.ts
@@ -61,7 +61,7 @@ import {
   RECOVERY_CHECKPOINT_MARKER,
   type RecoveryContextSnapshot,
 } from './recoveryCoordinator.js';
-import { requireCodexQueuedAppshots } from './appshotBoundary.js';
+import { sanitizeQueuedAppshotMetadata } from './appshotBoundary.js';
 
 const log = createLogger('maker-input-coordinator');
 const SESSION_RUNNING_RETRY_DELAY_MS = 250;
@@ -972,7 +972,7 @@ export class AgentInputCoordinator {
       items = (await this.deps.loadQueueSnapshot!(sessionId)).map(
         normalizeRestoredSyntheticTrigger,
       );
-      for (const item of items) requireCodexQueuedAppshots(item);
+      items = items.map(sanitizeQueuedAppshotMetadata) as typeof items;
     } catch (err) {
       log.warn('load queue snapshot failed; will retry on next entry', {
         sessionId,

--- a/apps/desktop/src/main/maker-ipc/appshotBoundary.ts
+++ b/apps/desktop/src/main/maker-ipc/appshotBoundary.ts
@@ -49,4 +49,28 @@ export function requireCodexQueuedAppshots(value: unknown): void {
   }
 }
 
+/**
+ * Crash-restore path: a persisted queue item may predate the Codex-only rule
+ * or belong to a session that switched away from Codex. Throwing during
+ * restore would poison the session's queue forever, so strip the Appshot
+ * metadata instead and keep the ordinary image attachment.
+ */
+export function sanitizeQueuedAppshotMetadata(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
+  const queued = value as { createOpts?: { agentKind?: unknown }; files?: unknown };
+  if (queued.createOpts?.agentKind === 'codex') return value;
+  const files = Array.isArray(queued.files) ? queued.files : [];
+  let changed = false;
+  const sanitizedFiles = files.map((file) => {
+    if (!file || typeof file !== 'object' || !('appshot' in (file as Record<string, unknown>))) {
+      return file;
+    }
+    changed = true;
+    const next = { ...(file as Record<string, unknown>) };
+    delete next.appshot;
+    return next;
+  });
+  return changed ? { ...queued, files: sanitizedFiles } : value;
+}
+
 export { APPSHOT_ONLY_CODEX_ERROR };

--- a/apps/desktop/src/main/maker-ipc/appshotBoundary.ts
+++ b/apps/desktop/src/main/maker-ipc/appshotBoundary.ts
@@ -1,0 +1,52 @@
+import { coerceAppshotMetadata } from '../../shared/appshots.js';
+import { throwIpcError } from '../utils/ipcValidate.js';
+
+const APPSHOT_ONLY_CODEX_ERROR = 'Appshots are only supported in Codex sessions';
+
+type MessageBlock = { type?: unknown; appshot?: unknown; [key: string]: unknown };
+export function validateAndStripAppshotMetadata(
+  message: unknown,
+  agentKind: 'claude-code' | 'codex' | 'pi',
+): { message: unknown; hasAppshot: boolean } {
+  if (
+    typeof message === 'string' ||
+    !message ||
+    typeof message !== 'object' ||
+    !('content' in message) ||
+    typeof (message as { content?: unknown }).content === 'string' ||
+    !Array.isArray((message as { content?: unknown }).content)
+  ) {
+    return { message, hasAppshot: false };
+  }
+
+  let hasAppshot = false;
+  const typedMessage = message as { type?: unknown; content: MessageBlock[] };
+  const content = typedMessage.content.map((block) => {
+    if (!block || typeof block !== 'object' || !('appshot' in block)) return block;
+    const metadata = coerceAppshotMetadata(block.appshot);
+    if (!metadata) {
+      const withoutMetadata = { ...block };
+      delete withoutMetadata.appshot;
+      return withoutMetadata;
+    }
+    hasAppshot = true;
+    if (agentKind !== 'codex') throwIpcError('UNSUPPORTED_CAPABILITY', APPSHOT_ONLY_CODEX_ERROR);
+    return { ...block, appshot: metadata };
+  });
+  return { message: { ...typedMessage, content }, hasAppshot };
+}
+
+export function requireCodexQueuedAppshots(value: unknown): void {
+  if (!value || typeof value !== 'object') return;
+  const queued = value as { createOpts?: { agentKind?: unknown }; files?: unknown };
+  const files = Array.isArray(queued.files) ? queued.files : [];
+  const hasAppshot = files.some((file) => {
+    if (!file || typeof file !== 'object' || !('appshot' in file)) return false;
+    return coerceAppshotMetadata((file as { appshot?: unknown }).appshot) !== null;
+  });
+  if (hasAppshot && queued.createOpts?.agentKind !== 'codex') {
+    throwIpcError('UNSUPPORTED_CAPABILITY', APPSHOT_ONLY_CODEX_ERROR);
+  }
+}
+
+export { APPSHOT_ONLY_CODEX_ERROR };

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -17,6 +17,7 @@ import {
 } from '../maker-host/send-outcome.js';
 import { isCredentialModeSwitchBusyError } from '../maker-host/codex-credential-switch.js';
 import { throwIpcError } from '../utils/ipcValidate.js';
+import { validateAndStripAppshotMetadata } from './appshotBoundary.js';
 import {
   prependHandoffToUserMessage,
   prependNoteToWireUserMessage,
@@ -665,6 +666,8 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       // reference still used by the transcript.
       let userMessagePersisted = false;
       let sendAccepted = false;
+      const appshotValidated = validateAndStripAppshotMetadata(outgoingMessage, sess.agentKind);
+      outgoingMessage = appshotValidated.message as IpcUserMessage;
       if (deps.materializeDirectSendOssAttachments) {
         const materialized = await deps.materializeDirectSendOssAttachments(
           sessionId,

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -579,6 +579,10 @@ import { agentHandoffPending } from './agentHandoffPendingSingleton.js';
 import { type MakerSessionCreateOpts, withCreateSessionStderr } from './sessionRequest.js';
 import { persistAndHydrateSessionProvider } from './sessionProviderBootstrap.js';
 import { registerMakerSessionSendHandler } from './sessionSendHandler.js';
+import {
+  requireCodexQueuedAppshots,
+  validateAndStripAppshotMetadata,
+} from './appshotBoundary.js';
 import { registerStopAgentTaskHandler } from './stopAgentTaskHandler.js';
 import { registerStopSessionBackgroundTasksHandler } from './stopSessionBackgroundTasksHandler.js';
 import { registerProviderHandlers } from './providerHandlers.js';
@@ -9071,7 +9075,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
 
     let normalized: IpcUserMessage;
     try {
-      normalized = await prepareUserMessageForAgent(sessionId, message, 'steer');
+      const appshotValidated = validateAndStripAppshotMetadata(message, sess.agentKind);
+      normalized = await prepareUserMessageForAgent(sessionId, appshotValidated.message, 'steer');
     } catch (err) {
       const messageText = err instanceof Error ? err.message : String(err);
       log.warn('steer: normalize message failed', {
@@ -10384,6 +10389,7 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
       throwIpcError('INVALID_PARAMS', 'queued.createOpts.agentKind invalid');
     }
     const normalized: AgentInputQueuedMessage = { ...msg };
+    requireCodexQueuedAppshots(normalized);
     const refs = requireSessionRefs(normalized.sessionRefs);
     if (!isDeviceLinkInvoke()) {
       // preload/renderer 不属于可信边界，不能直接注入历史正文。

--- a/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
+++ b/apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts
@@ -84,6 +84,7 @@ const mocks = vi.hoisted(() => {
   const modifierSetShortcut = vi.fn();
   const modifierStop = vi.fn();
   const modifierReleaseShortcut = vi.fn();
+  const modifierStopKeyCapture = vi.fn();
   const modifierIsRunning = vi.fn();
   const modifierIsReady = vi.fn();
   const modifierStartKeyCapture = vi.fn();
@@ -138,6 +139,7 @@ const mocks = vi.hoisted(() => {
     modifierSetShortcut,
     modifierStop,
     modifierReleaseShortcut,
+    modifierStopKeyCapture,
     modifierIsRunning,
     modifierIsReady,
     modifierStartKeyCapture,
@@ -224,7 +226,7 @@ vi.mock('../MacModifierShortcutListener.js', () => ({
       isReady: mocks.modifierIsReady,
       stop: mocks.modifierStop,
       releaseShortcutKeepingCapture: mocks.modifierReleaseShortcut,
-      stopKeyCapture: vi.fn(),
+      stopKeyCapture: mocks.modifierStopKeyCapture,
       startKeyCapture: mocks.modifierStartKeyCapture,
       pendingStartResult: mocks.modifierPendingStartResult,
     };
@@ -246,6 +248,12 @@ vi.mock('../../security/trustedAppRenderer.js', () => ({
 
 let setTimeoutSpy: { mockRestore: () => void } | null = null;
 const originalPlatform = process.platform;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => { resolve = resolvePromise; });
+  return { promise, resolve };
+}
 
 function setPlatform(value: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', { value, configurable: true });
@@ -276,6 +284,7 @@ describe('voice input global shortcut registration', () => {
     mocks.modifierIsReady.mockImplementation(() => mocks.modifierIsRunning() as boolean);
     mocks.modifierStop.mockClear();
     mocks.modifierReleaseShortcut.mockClear();
+    mocks.modifierStopKeyCapture.mockClear();
     mocks.modifierStartKeyCapture.mockReset();
     mocks.modifierStartKeyCapture.mockResolvedValue({ ok: true });
     // 默认已授权:既有用例断言的是「拿得到权限时」的注册行为。
@@ -304,6 +313,65 @@ describe('voice input global shortcut registration', () => {
     mocks.updateSettings.mockImplementation((patch: unknown) => ({ shortcut: null, ...(patch as object) }));
     mocks.registerShortcut.mockReset();
     mocks.registerShortcut.mockReturnValue(true);
+  });
+
+  it('fans native key snapshots out to voice recording and an independent Appshot subscriber', async () => {
+    setPlatform('darwin');
+    const { registerGlobalVoiceInputIpc, retainMacModifierKeySnapshots } = await import('../global.js');
+    registerGlobalVoiceInputIpc(mocks.ipcDeps);
+    const subscriber = vi.fn();
+    const release = await retainMacModifierKeySnapshots('appshots', subscriber);
+    const start = mocks.handlers.get('voice-input:modifier-shortcut-recording:start');
+    await start?.(mocks.recordingEvent);
+
+    mocks.listenerOptions.onKeys?.(['MetaLeft', 'MetaRight']);
+    expect(subscriber).toHaveBeenCalledWith(['MetaLeft', 'MetaRight']);
+    expect(mocks.focusedWindow.webContents.send).toHaveBeenCalledWith(
+      'voice-input:modifier-shortcut-keys',
+      { keys: ['MetaLeft', 'MetaRight'] },
+    );
+
+    release();
+    expect(mocks.modifierStopKeyCapture).not.toHaveBeenCalled();
+    await mocks.handlers.get('voice-input:modifier-shortcut-recording:stop')?.(mocks.recordingEvent);
+    expect(mocks.modifierStopKeyCapture).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleans up a failed Appshot subscriber start and reports a stable error', async () => {
+    setPlatform('darwin');
+    mocks.modifierStartKeyCapture.mockResolvedValue({ ok: false, error: '/private/helper failed' });
+    const { retainMacModifierKeySnapshots } = await import('../global.js');
+
+    await expect(retainMacModifierKeySnapshots('appshots', vi.fn())).rejects.toThrow(
+      'Could not start the macOS modifier key listener.',
+    );
+    mocks.listenerOptions.onKeys?.(['MetaLeft', 'MetaRight']);
+    expect(mocks.modifierStopKeyCapture).not.toHaveBeenCalled();
+  });
+
+  it('does not let an older failed retain remove a newer subscriber for the same owner', async () => {
+    setPlatform('darwin');
+    const firstStart = deferred<{ ok: false; error: string }>();
+    const secondStart = deferred<{ ok: true }>();
+    mocks.modifierStartKeyCapture
+      .mockReturnValueOnce(firstStart.promise)
+      .mockReturnValueOnce(secondStart.promise);
+    const { retainMacModifierKeySnapshots } = await import('../global.js');
+    const firstSubscriber = vi.fn();
+    const secondSubscriber = vi.fn();
+
+    const first = retainMacModifierKeySnapshots('appshots', firstSubscriber);
+    const second = retainMacModifierKeySnapshots('appshots', secondSubscriber);
+    secondStart.resolve({ ok: true });
+    const releaseSecond = await second;
+    firstStart.resolve({ ok: false, error: 'failed' });
+
+    await expect(first).rejects.toThrow('Could not start the macOS modifier key listener.');
+    mocks.listenerOptions.onKeys?.(['MetaLeft', 'MetaRight']);
+
+    expect(secondSubscriber).toHaveBeenCalledWith(['MetaLeft', 'MetaRight']);
+    expect(firstSubscriber).not.toHaveBeenCalled();
+    releaseSecond();
   });
 
   afterEach(() => {

--- a/apps/desktop/src/main/voice-input/global.ts
+++ b/apps/desktop/src/main/voice-input/global.ts
@@ -54,6 +54,14 @@ const log = createLogger('voice-input-global');
 type GlobalVoiceInputShortcutPhase = 'start' | 'tap' | 'end';
 
 const modifierShortcutRecordingWebContentsIds = new Set<number>();
+type MacModifierSnapshotSubscriber = (keys: readonly string[]) => void;
+const macModifierSnapshotSubscribers = new Map<string, MacModifierSnapshotSubscriber>();
+
+function stopKeyCaptureWhenUnused(): void {
+  if (modifierShortcutRecordingWebContentsIds.size === 0 && macModifierSnapshotSubscribers.size === 0) {
+    macModifierShortcutListener.stopKeyCapture();
+  }
+}
 /**
  * 正在录制快捷键的 renderer —— 与上面那个「keys 转发名单」是两件事。
  *
@@ -132,8 +140,50 @@ const macModifierShortcutListener = new MacModifierShortcutListener({
       }
       window.webContents.send('voice-input:modifier-shortcut-keys', { keys });
     }
+    for (const subscriber of Array.from(macModifierSnapshotSubscribers.values())) {
+      try {
+        subscriber([...keys]);
+      } catch (error) {
+        log.warn('mac modifier key snapshot subscriber threw', { error: stringifyError(error) });
+      }
+    }
   },
 });
+
+/**
+ * Retains the shared native modifier listener for a non-voice consumer.
+ *
+ * The listener also powers voice-input recording, so consumers must release their own reference
+ * rather than stopping it directly. This keeps the single native event tap authoritative.
+ */
+export async function retainMacModifierKeySnapshots(
+  owner: string,
+  subscriber: MacModifierSnapshotSubscriber,
+): Promise<() => void> {
+  if (!owner || typeof owner !== 'string') throw new Error('Could not start the macOS modifier key listener.');
+  const previous = macModifierSnapshotSubscribers.get(owner);
+  macModifierSnapshotSubscribers.set(owner, subscriber);
+  const started = await startMacNativeListener(() => macModifierShortcutListener.startKeyCapture());
+  if (!started.ok) {
+    // A later retain for the same owner may have replaced this subscriber while the
+    // shared native listener was starting. Only roll back our own registration; an
+    // older failed start must never remove the newer live subscriber.
+    if (macModifierSnapshotSubscribers.get(owner) === subscriber) {
+      if (previous) macModifierSnapshotSubscribers.set(owner, previous);
+      else macModifierSnapshotSubscribers.delete(owner);
+    }
+    throw new Error('Could not start the macOS modifier key listener.');
+  }
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    if (macModifierSnapshotSubscribers.get(owner) === subscriber) {
+      macModifierSnapshotSubscribers.delete(owner);
+    }
+    stopKeyCaptureWhenUnused();
+  };
+}
 
 type VoiceInputGlobalResult =
   | { ok: true }
@@ -1107,9 +1157,7 @@ export function registerGlobalVoiceInputIpc(deps: GlobalVoiceInputIpcDeps): void
       markModifierShortcutRecordingSession(event.sender);
       event.sender.once('destroyed', () => {
         modifierShortcutRecordingWebContentsIds.delete(event.sender.id);
-        if (modifierShortcutRecordingWebContentsIds.size === 0) {
-          macModifierShortcutListener.stopKeyCapture();
-        }
+        stopKeyCaptureWhenUnused();
       });
       // 走 startMacNativeListener：startKeyCapture 也会抛（helper 源码缺失 / swiftc
       // 失败）。不接住的话下面的清理与 errorCode 分类都跑不到，本 renderer 会留在
@@ -1147,9 +1195,7 @@ export function registerGlobalVoiceInputIpc(deps: GlobalVoiceInputIpcDeps): void
     (event): VoiceInputGlobalResult => {
       modifierShortcutRecordingWebContentsIds.delete(event.sender.id);
       modifierShortcutRecordingSessionIds.delete(event.sender.id);
-      if (modifierShortcutRecordingWebContentsIds.size === 0) {
-        macModifierShortcutListener.stopKeyCapture();
-      }
+      stopKeyCaptureWhenUnused();
       return { ok: true };
     },
   );
@@ -1509,7 +1555,7 @@ export function registerGlobalVoiceInputIpc(deps: GlobalVoiceInputIpcDeps): void
  * 「capture 真的起来了」的那些窗口。
  */
 function stopNativeShortcutListenerPreservingCapture(): void {
-  if (modifierShortcutRecordingWebContentsIds.size > 0) {
+  if (modifierShortcutRecordingWebContentsIds.size > 0 || macModifierSnapshotSubscribers.size > 0) {
     macModifierShortcutListener.releaseShortcutKeepingCapture();
     return;
   }

--- a/apps/desktop/src/preload/__tests__/appshotsBridge.test.ts
+++ b/apps/desktop/src/preload/__tests__/appshotsBridge.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { AppshotCaptureResult } from '../../shared/appshots.js';
+import type { AppshotShortcutState } from '../../main/appshots/shortcutService.js';
+import { createAppshotsBridge } from '../appshotsBridge.js';
+
+const result: AppshotCaptureResult = {
+  captureId: 'capture-1',
+  image: {
+    url: 'cindy-media://blobs/example.png',
+    filename: 'example.png',
+    size: 9,
+    mimeType: 'image/png',
+  },
+  metadata: {
+    schemaVersion: 1,
+    captureId: 'capture-1',
+    capturedAt: '2026-08-06T01:02:03.000Z',
+    applicationName: 'Example App',
+    bundleIdentifier: null,
+    windowTitle: null,
+    accessibilityText: null,
+    accessibilityTruncated: false,
+  },
+};
+
+describe('createAppshotsBridge', () => {
+  it('exposes fixed invoke channels and arguments', async () => {
+    const invoke = vi.fn(async () => ({ accepted: true }));
+    const bridge = createAppshotsBridge({ invoke, on: vi.fn(), removeListener: vi.fn() });
+
+    await bridge.capture();
+    await bridge.listPending();
+    await bridge.ack('capture-1');
+
+    expect(invoke.mock.calls).toEqual([
+      ['appshots:capture'],
+      ['appshots:list-pending'],
+      ['appshots:ack', 'capture-1'],
+    ]);
+  });
+
+  it('strips the Electron event and removes the exact subscribed listener', () => {
+    const on = vi.fn();
+    const removeListener = vi.fn();
+    const callback = vi.fn();
+    const bridge = createAppshotsBridge({ invoke: vi.fn(), on, removeListener });
+
+    const dispose = bridge.onCaptured(callback);
+    expect(on).toHaveBeenCalledWith('appshots:captured', expect.any(Function));
+    const listener = on.mock.calls[0][1];
+    const electronEvent = { sender: 'must not escape' };
+    listener(electronEvent, result);
+
+    expect(callback).toHaveBeenCalledWith(result);
+    expect(callback).not.toHaveBeenCalledWith(electronEvent, result);
+    dispose();
+    expect(removeListener).toHaveBeenCalledWith('appshots:captured', listener);
+  });
+
+  it('uses fixed settings channels and strips shortcut state events', async () => {
+    const invoke = vi.fn(async () => ({ accepted: true }));
+    const on = vi.fn();
+    const removeListener = vi.fn();
+    const callback = vi.fn();
+    const bridge = createAppshotsBridge({ invoke, on, removeListener });
+    const preferences = {
+      preferred: { kind: 'dual-modifier' as const, modifier: 'command' as const },
+      fallback: { kind: 'accelerator' as const, combo: { code: 'KeyA', meta: true, ctrl: false, alt: false, shift: true } },
+    };
+    const state: AppshotShortcutState = {
+      preferences,
+      configured: preferences.preferred,
+      active: preferences.preferred,
+    };
+
+    await bridge.getShortcutState();
+    await bridge.setShortcutPreferences(preferences);
+    await bridge.resetShortcutPreferences();
+    const dispose = bridge.onShortcutStateChanged(callback);
+    const listener = on.mock.calls[0][1];
+    listener({ sender: 'must not escape' }, state);
+    dispose();
+
+    expect(invoke.mock.calls).toEqual([
+      ['appshots:shortcut-state'],
+      ['appshots:shortcut-preferences:set', preferences],
+      ['appshots:shortcut-preferences:reset'],
+    ]);
+    expect(callback).toHaveBeenCalledWith(state);
+    expect(removeListener).toHaveBeenCalledWith('appshots:shortcut-state-changed', listener);
+  });
+});

--- a/apps/desktop/src/preload/appshotsBridge.ts
+++ b/apps/desktop/src/preload/appshotsBridge.ts
@@ -1,0 +1,50 @@
+import type { AppshotCaptureResult } from '../shared/appshots.js';
+import type {
+  AppshotShortcutPreferences,
+} from '../shared/appshots.js';
+import type { AppshotShortcutState } from '../main/appshots/shortcutService.js';
+
+type AppshotsListener = (event: unknown, payload: unknown) => void;
+
+interface AppshotsBridgeDeps {
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>;
+  on: (channel: string, listener: AppshotsListener) => unknown;
+  removeListener: (channel: string, listener: AppshotsListener) => unknown;
+}
+
+export interface AppshotsBridge {
+  capture: () => Promise<{ accepted: true }>;
+  listPending: () => Promise<AppshotCaptureResult[]>;
+  ack: (captureId: string) => Promise<{ acknowledged: boolean }>;
+  onCaptured: (callback: (result: AppshotCaptureResult) => void) => () => void;
+  getShortcutState: () => Promise<AppshotShortcutState>;
+  setShortcutPreferences: (value: AppshotShortcutPreferences) => Promise<AppshotShortcutState>;
+  resetShortcutPreferences: () => Promise<AppshotShortcutState>;
+  onShortcutStateChanged: (callback: (state: AppshotShortcutState) => void) => () => void;
+}
+
+export function createAppshotsBridge(deps: AppshotsBridgeDeps): AppshotsBridge {
+  return {
+    capture: () => deps.invoke('appshots:capture') as Promise<{ accepted: true }>,
+    listPending: () => deps.invoke('appshots:list-pending') as Promise<AppshotCaptureResult[]>,
+    ack: (captureId) => deps.invoke('appshots:ack', captureId) as Promise<{ acknowledged: boolean }>,
+    onCaptured: (callback) => {
+      const listener: AppshotsListener = (_event, result) => callback(result as AppshotCaptureResult);
+      deps.on('appshots:captured', listener);
+      return () => { deps.removeListener('appshots:captured', listener); };
+    },
+    getShortcutState: () => deps.invoke('appshots:shortcut-state') as Promise<AppshotShortcutState>,
+    setShortcutPreferences: (value) => deps.invoke(
+      'appshots:shortcut-preferences:set',
+      value,
+    ) as Promise<AppshotShortcutState>,
+    resetShortcutPreferences: () => deps.invoke(
+      'appshots:shortcut-preferences:reset',
+    ) as Promise<AppshotShortcutState>,
+    onShortcutStateChanged: (callback) => {
+      const listener: AppshotsListener = (_event, state) => callback(state as AppshotShortcutState);
+      deps.on('appshots:shortcut-state-changed', listener);
+      return () => { deps.removeListener('appshots:shortcut-state-changed', listener); };
+    },
+  };
+}

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1,4 +1,5 @@
 import { contextBridge, ipcRenderer, webUtils } from 'electron';
+import { createAppshotsBridge } from './appshotsBridge.js';
 import type { MobileCodexRateLimitsResult } from '@cindy/maker-shared/device-link-contract';
 import type { AppearanceSettings } from '../shared/appearanceSettings';
 import {
@@ -812,6 +813,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   appDisplayVersion: appDisplayVersionInfo.display,
   appDisplayVersionDetail: appDisplayVersionInfo.detail,
   getDeviceId: (): Promise<string> => ipcRenderer.invoke('get-device-id'),
+  appshots: createAppshotsBridge({
+    invoke: (channel, ...args) => ipcRenderer.invoke(channel, ...args),
+    on: (channel, listener) => ipcRenderer.on(channel, listener),
+    removeListener: (channel, listener) => ipcRenderer.removeListener(channel, listener),
+  }),
   windowMinimize: () => ipcRenderer.send('window-minimize'),
   windowMaximize: () => ipcRenderer.send('window-maximize'),
   windowClose: () => ipcRenderer.send('window-close'),

--- a/apps/desktop/src/renderer/__tests__/imageRefParseUserContent.test.ts
+++ b/apps/desktop/src/renderer/__tests__/imageRefParseUserContent.test.ts
@@ -28,6 +28,7 @@ import {
   type PastedTextRange,
   type SlashCommandRange,
 } from '@/lib/imageRef';
+import type { AppshotMetadata } from '../../shared/appshots';
 
 const ATTACHMENT_SHA256 = 'a'.repeat(64);
 
@@ -35,6 +36,17 @@ const validImage: ImageRef = {
   url: 'xdt-image://session-abc/img-001.png',
   mimeType: 'image/png',
   originalName: 'screenshot.png',
+};
+
+const appshot: AppshotMetadata = {
+  schemaVersion: 1,
+  captureId: 'capture-1',
+  capturedAt: '2026-08-05T00:00:00.000Z',
+  applicationName: 'A&B',
+  bundleIdentifier: 'com.example.app',
+  windowTitle: '"Draft" <1>',
+  accessibilityText: '<AXButton title="Send & close">',
+  accessibilityTruncated: false,
 };
 
 const validFile: FileRef = {
@@ -46,6 +58,23 @@ const validFile2: FileRef = {
   name: 'spec.pdf',
   path: '/Users/sam/Documents/spec.pdf',
 };
+
+describe('parseUserContent Appshot metadata', () => {
+  it('round-trips persisted Appshot metadata', () => {
+    const image: ImageRef = { ...validImage, appshot };
+    expect(parseUserContent(stringifyUserContent('inspect', [image])).images).toEqual([image]);
+  });
+
+  it('drops malformed Appshot metadata while preserving the image', () => {
+    expect(
+      parseUserContent({
+        text: 'inspect',
+        images: [{ ...validImage, appshot: { ...appshot, schemaVersion: 2 } }],
+        files: [],
+      }).images,
+    ).toEqual([validImage]);
+  });
+});
 
 // ── Branch 1: string ────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
@@ -82,6 +82,36 @@ describe('messageAttachmentPayload', () => {
     ]);
   });
 
+  it('drops malformed Appshot metadata without dropping the direct-send image', () => {
+    const payload = buildUserMessageAttachmentPayload([
+      attachment({
+        name: 'appshot.png',
+        path: 'clipboard://appshot-invalid',
+        ext: '.png',
+        category: 'image',
+        mimeType: 'image/png',
+        url: 'xdt-image://session/appshot-invalid.png',
+        appshot: { ...appshot, schemaVersion: 2 } as unknown as AppshotMetadata,
+      }),
+    ]);
+
+    expect(payload.persistImageRefs).toEqual([
+      {
+        url: 'xdt-image://session/appshot-invalid.png',
+        mimeType: 'image/png',
+        originalName: 'appshot.png',
+      },
+    ]);
+    expect(buildMakerUserContentBlocks('', undefined, payload.serializedFiles)).toEqual([
+      {
+        type: 'image',
+        path: 'xdt-image://session/appshot-invalid.png',
+        mimeType: 'image/png',
+        originalName: 'appshot.png',
+      },
+    ]);
+  });
+
   it('keeps cached image URLs as the primary render, persist, and SDK source', () => {
     const image = attachment({
       name: 'shot.png',

--- a/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
+++ b/apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
@@ -7,6 +7,26 @@ import {
   buildMakerUserMessage,
   buildUserMessageAttachmentPayload,
 } from '@/lib/messageAttachmentPayload';
+import type { AppshotMetadata } from '../../shared/appshots';
+
+const appshot: AppshotMetadata = {
+  schemaVersion: 1,
+  captureId: 'capture-1',
+  capturedAt: '2026-08-05T00:00:00.000Z',
+  applicationName: 'A&B',
+  bundleIdentifier: 'com.example.app',
+  windowTitle: '"Draft" <1>',
+  accessibilityText: '<AXButton title="Send & close">',
+  accessibilityTruncated: false,
+};
+
+const appshotContext =
+  '<appshot app="A&amp;B" bundle-identifier="com.example.app" window-title="&quot;Draft&quot; &lt;1&gt;">\n' +
+  'Window: ""Draft" &lt;1&gt;", App: A&amp;B.\n' +
+  '<accessibility-tree>\n' +
+  '&lt;AXButton title="Send &amp; close"&gt;\n' +
+  '</accessibility-tree>\n' +
+  '</appshot>';
 
 type AttachmentFixture = AttachedFile & {
   base64?: string;
@@ -29,6 +49,39 @@ function attachment(overrides: Partial<AttachmentFixture>): AttachmentFixture {
 }
 
 describe('messageAttachmentPayload', () => {
+  it('emits an Appshot image followed by one escaped context block', () => {
+    const payload = buildUserMessageAttachmentPayload([
+      attachment({
+        name: 'appshot.png',
+        path: 'clipboard://appshot-1',
+        ext: '.png',
+        category: 'image',
+        mimeType: 'image/png',
+        url: 'xdt-image://session/appshot.png',
+        appshot,
+      }),
+    ]);
+
+    expect(payload.persistImageRefs).toEqual([
+      {
+        url: 'xdt-image://session/appshot.png',
+        mimeType: 'image/png',
+        originalName: 'appshot.png',
+        appshot,
+      },
+    ]);
+    expect(buildMakerUserContentBlocks('', undefined, payload.serializedFiles)).toEqual([
+      {
+        type: 'image',
+        path: 'xdt-image://session/appshot.png',
+        mimeType: 'image/png',
+        originalName: 'appshot.png',
+        appshot,
+      },
+      { type: 'text', text: appshotContext },
+    ]);
+  });
+
   it('keeps cached image URLs as the primary render, persist, and SDK source', () => {
     const image = attachment({
       name: 'shot.png',

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -80,6 +80,9 @@ import { usePluginRemovalNoticeToast } from '@/hooks/usePluginRemovalNoticeToast
 import { usePluginUpgradeNoticeToast } from '@/hooks/usePluginUpgradeNoticeToast';
 import { requestProjectFocus } from '@/state/pendingProjectFocus';
 import { patchDraft } from '@/state/newMakerDraft';
+import { getDraft as getComposerDraft, saveDraft as saveComposerDraft } from '@/lib/composerDraftStore';
+import { installAppshotInbox, routeAppshotCapture } from '@/features/appshots/appshotInbox';
+import { sessionsStore } from '@/lib/sessionsStore';
 import { cn } from '@/lib/utils';
 import { checkForUpdateWithToast } from '@/lib/checkForUpdateWithToast';
 import { createLogger } from '@/lib/logger';
@@ -371,6 +374,36 @@ export function MainLayout() {
   const navigate = useNavigate();
   const location = useLocation();
   const { t } = useTranslation();
+
+  const appshotRouteContextRef = useRef({ location, navigate });
+  appshotRouteContextRef.current = { location, navigate };
+
+  useEffect(() => {
+    const inbox = installAppshotInbox({
+      route: async (result) => {
+        const { location: currentLocation, navigate: currentNavigate } = appshotRouteContextRef.current;
+        const match = currentLocation.pathname.match(/^\/cc-agent\/([^/]+)$/);
+        const sessionId = match?.[1];
+        const staticSegment = sessionId && CC_AGENT_STATIC_SEGMENTS.includes(sessionId);
+        const session = sessionId && !staticSegment ? sessionsStore.findById(sessionId) : null;
+        return routeAppshotCapture(result, {
+          route: {
+            writable: session?.status === 'active',
+            local: !session?.remoteHostId && !session?.deviceLinkDeviceId,
+            agentKind: session?.agentKind ?? null,
+            sessionId: session?.id ?? null,
+            remoteHostId: session?.remoteHostId ?? null,
+            deviceLinkDeviceId: session?.deviceLinkDeviceId ?? null,
+          },
+          getDraft: getComposerDraft,
+          saveDraft: saveComposerDraft,
+          patchDraft,
+          navigate: currentNavigate,
+        });
+      },
+    });
+    return () => inbox.dispose();
+  }, []);
 
   useEffect(() => {
     syncNotificationsEnabledToMain();

--- a/apps/desktop/src/renderer/components/layout/MainLayout.tsx
+++ b/apps/desktop/src/renderer/components/layout/MainLayout.tsx
@@ -379,6 +379,7 @@ export function MainLayout() {
   appshotRouteContextRef.current = { location, navigate };
 
   useEffect(() => {
+    if (!window.electronAPI?.appshots) return;
     const inbox = installAppshotInbox({
       route: async (result) => {
         const { location: currentLocation, navigate: currentNavigate } = appshotRouteContextRef.current;

--- a/apps/desktop/src/renderer/components/new-chat/AtMentionPanel.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/AtMentionPanel.tsx
@@ -33,6 +33,7 @@ import {
   Monitor,
   Paperclip,
   Plug,
+  Scan,
   Sparkles,
   Target,
   UsersRound,
@@ -102,6 +103,7 @@ interface AtMentionPanelProps {
 
 const ACTION_ICONS: Record<ComposerSuggestionAction['id'], typeof Paperclip> = {
   'attach-files': Paperclip,
+  'capture-appshot': Scan,
   'new-goal': Target,
   'plan-mode': ClipboardList,
   collaboration: UsersRound,

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -66,7 +66,7 @@ import {
 import { cn } from '@/lib/utils';
 import { Spinner } from '@/components/ui/spinner';
 import { toast } from '@/lib/toast';
-import { mapIpcErrorToI18nKey } from '@/utils/ipcError';
+import { extractIpcError, mapIpcErrorToI18nKey } from '@/utils/ipcError';
 import { Tip } from '@/components/ui/tooltip';
 import type { AttachedFile, MentionedResource, ImageAnnotationStroke } from '@/lib/fileTypes';
 import {
@@ -137,6 +137,8 @@ import {
 import { useConfirmDialog } from '@/components/ui/confirm-dialog-provider';
 import { PermissionSelector } from './PermissionSelector';
 import { ExtraDirsButton, type CollaborationMenuConfig } from './ExtraDirsButton';
+import { appshotThumbnailLabel } from '@/features/appshots/appshotInbox';
+import { canCaptureAppshotFromComposer } from '@/features/appshots/appshotInbox';
 import { focusComposerEndNextFrame, placeGhostAtComposerStart } from './ghostComposerPlacement';
 import { NewGoalDialog } from './NewGoalDialog';
 import { PlanModeIndicator } from './PlanModeIndicator';
@@ -542,6 +544,7 @@ interface ChatInputProps {
     hasAttachments: boolean;
     addFiles: (fileList: FileList | readonly File[]) => Promise<void>;
     addClipboardImage: (blob: Blob) => Promise<void>;
+    addAppshot: (result: import('../../../shared/appshots').AppshotCaptureResult) => void;
     rejections: { id: string; message: string }[];
     dismissRejection: (id: string) => void;
     clearRejections: () => void;
@@ -2562,6 +2565,41 @@ export function ChatInput({
   const voiceInput = useVoiceInput(editor, disabled, messages, voiceInputOptions);
   const composerMutationLocked = composerEditorLocked || voiceInput.isBusy;
   composerMutationLockedRef.current = composerMutationLocked;
+  const appshotCaptureEnabled = canCaptureAppshotFromComposer({
+    platform: window.electronAPI?.platform,
+    sessionId,
+    runtimeAgentKind,
+    vendorKey,
+    remoteHostId,
+    deviceLinkDeviceId,
+    composerMutationLocked,
+  });
+  const captureAppshot = useCallback(async () => {
+    if (!appshotCaptureEnabled) return;
+    try {
+      await window.electronAPI.appshots.capture();
+    } catch (error) {
+      if (extractIpcError(error)?.code === 'PERMISSION_DENIED') {
+        const openSettings = await confirmDialog({
+          title: t('newChat.chatInput.appshots.permissionTitle'),
+          description: t('newChat.chatInput.appshots.permissionDescription'),
+          confirmText: t('newChat.chatInput.appshots.openSettings'),
+          cancelText: t('newChat.chatInput.appshots.cancel'),
+          autoFocusConfirm: true,
+        });
+        if (openSettings) {
+          const result = await window.electronAPI.openExternal(
+            'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+          );
+          if (!result.success) {
+            toast.error(t('newChat.chatInput.appshots.openSettingsFailed'));
+          }
+        }
+        return;
+      }
+      toast.error(t('newChat.chatInput.appshots.captureFailed'));
+    }
+  }, [appshotCaptureEnabled, confirmDialog, t]);
   useEffect(() => {
     editor?.setEditable(!composerMutationLocked);
   }, [composerMutationLocked, editor]);
@@ -3611,6 +3649,14 @@ export function ChatInput({
         run: () => suggestionFileInputRef.current?.click(),
       });
     }
+    if (appshotCaptureEnabled) {
+      actions.push({
+        id: 'capture-appshot',
+        label: t('newChat.chatInput.appshots.menuItem'),
+        disabled: composerMutationLocked,
+        run: () => void captureAppshot(),
+      });
+    }
     if (inSessionGoalEnabled || onNewGoal) {
       actions.push({
         id: 'new-goal',
@@ -3681,6 +3727,8 @@ export function ChatInput({
     }
     return actions;
   }, [
+    appshotCaptureEnabled,
+    captureAppshot,
     collaboration,
     composerMutationLocked,
     confirmDialog,
@@ -7376,6 +7424,9 @@ function ThumbnailItem({
   // (上限 220px)。判定条件必须与下面渲染分支一致——缓存写失败、既无 url 也无
   // base64 的图片同样落到文件卡分支。
   const isImageThumb = file.category === 'image' && Boolean(file.url || file.base64);
+  const thumbnailLabel = file.appshot
+    ? appshotThumbnailLabel(file.appshot, file.name)
+    : file.name;
   // 副行是「类型 · 大小」;无扩展名(Makefile 之类)或 size 缺失时按存在的部分给。
   // file.size 是拖入那一刻的快照:文件在托盘期间被改写后,发出去的是新内容,卡片
   // 却还报旧字节数。缩略图复核时 main 会把当前 stat 大小一并带回,这里优先用它。
@@ -7410,15 +7461,16 @@ function ThumbnailItem({
         disabled={isDownloadOnly}
         aria-label={
           isDownloadOnly
-            ? t('chat.userMessage.attachmentAttachedAria', { name: file.name })
-            : `Preview ${file.name}`
+            ? t('chat.userMessage.attachmentAttachedAria', { name: thumbnailLabel })
+            : `Preview ${thumbnailLabel}`
         }
+        title={file.appshot ? thumbnailLabel : undefined}
       >
         {file.category === 'image' && (file.url || file.base64) ? (
           <span className="relative block h-full w-full">
             <img
               src={file.url ?? `data:${file.mimeType};base64,${file.base64}`}
-              alt={file.name}
+              alt={thumbnailLabel}
               className="h-full w-full rounded-lg object-cover"
               draggable={false}
             />
@@ -7451,7 +7503,9 @@ function ThumbnailItem({
             </span>
             <span className="flex min-w-0 flex-col gap-0.5">
               <span className="truncate text-xs" style={{ color: 'var(--text-primary)' }}>
-                {file.name}
+                {file.appshot
+                  ? thumbnailLabel
+                  : file.name /* ordinary attachment: {file.name} */}
               </span>
               {metaLine ? (
                 <span className="truncate text-11" style={{ color: 'var(--text-secondary)' }}>
@@ -7486,7 +7540,7 @@ function ThumbnailItem({
           open={isHovered}
           anchorRef={thumbRef}
           src={file.url ?? `data:${file.mimeType};base64,${file.base64}`}
-          alt={file.name}
+          alt={thumbnailLabel}
         />
       ) : null}
       {isHovered &&

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -13,7 +13,7 @@ import {
 } from 'react';
 import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
-import { Folder, MessageSquarePlus, Mic, Pen, TriangleAlert, X } from 'lucide-react';
+import { Folder, MessageSquarePlus, Mic, Pen, Scan, TriangleAlert, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
 import { requiresFullAccessConfirmation } from '@cindy/maker-shared/permission-mode';
@@ -7367,6 +7367,7 @@ function ThumbnailItem({
   onUpdate: (id: string, patch: Partial<AttachedFile>) => void;
 }) {
   const { t } = useTranslation();
+  const { confirm: confirmDialog } = useConfirmDialog();
   const [isHovered, setIsHovered] = useState(false);
   const thumbRef = useRef<HTMLDivElement>(null);
   const [popoverPos, setPopoverPos] = useState<{ top: number; left: number } | null>(null);
@@ -7440,6 +7441,37 @@ function ThumbnailItem({
   const metaLine = [extLabel || null, hasSize ? formatBytes(shownSize) : null]
     .filter(Boolean)
     .join(' · ');
+  const appshot = file.appshot;
+  const hasAxStructure = appshot?.accessibilityText != null && appshot.accessibilityText.length > 0;
+  const handleAppshotStructure = useCallback(async () => {
+    if (!appshot) return;
+    const text = appshot.accessibilityText;
+    const remove = await confirmDialog({
+      title: t('newChat.chatInput.appshots.axPreviewTitle'),
+      description: text
+        ? t('newChat.chatInput.appshots.axPreviewDescription')
+        : t('newChat.chatInput.appshots.noAx'),
+      content: text
+        ? (
+            <pre
+              className="max-h-64 overflow-auto whitespace-pre-wrap rounded-md p-2 text-xs leading-relaxed"
+              style={{ backgroundColor: 'var(--surface-chip)', color: 'var(--text-secondary)' }}
+            >
+              {text}
+            </pre>
+          )
+        : undefined,
+      maxWidth: 560,
+      confirmText: t('newChat.chatInput.appshots.removeAx'),
+      cancelText: t('newChat.chatInput.appshots.close'),
+      confirmVariant: 'destructive',
+    });
+    if (remove) {
+      onUpdate(file.id, {
+        appshot: { ...appshot, accessibilityText: null, accessibilityUnavailableReason: 'removed' },
+      });
+    }
+  }, [appshot, confirmDialog, onUpdate, t]);
 
   return (
     <div
@@ -7474,6 +7506,16 @@ function ThumbnailItem({
               className="h-full w-full rounded-lg object-cover"
               draggable={false}
             />
+            {hasAxStructure && (
+              <span
+                className="absolute bottom-0.5 left-0.5 flex h-4 w-4 items-center justify-center rounded-full"
+                style={{ backgroundColor: 'var(--surface-elevated)' }}
+                title={t('newChat.chatInput.appshots.hasAxBadge')}
+                aria-label={t('newChat.chatInput.appshots.hasAxBadge')}
+              >
+                <Scan className="h-2.5 w-2.5" style={{ color: 'var(--text-secondary)' }} />
+              </span>
+            )}
             {file.annotationStrokes && file.annotationStrokes.length > 0 ? (
               <span
                 className="absolute right-0.5 top-0.5 flex h-4 w-4 items-center justify-center rounded-full"
@@ -7533,6 +7575,21 @@ function ThumbnailItem({
       >
         &times;
       </button>
+
+      {file.appshot && (
+        <button
+          type="button"
+          className="absolute -left-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full text-10 text-white opacity-0 transition-opacity group-hover:opacity-100"
+          style={{ backgroundColor: 'var(--file-remove-bg)' }}
+          onClick={(event) => {
+            event.stopPropagation();
+            void handleAppshotStructure();
+          }}
+          aria-label={t('newChat.chatInput.appshots.axPreviewTitle')}
+        >
+          <Scan className="h-2.5 w-2.5 text-white" />
+        </button>
+      )}
 
       {/* Hover preview / tooltip (F-FI-4) — rendered via portal to escape overflow clipping */}
       {file.category === 'image' && (file.url || file.base64) ? (

--- a/apps/desktop/src/renderer/components/settings/KeyboardShortcutsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/KeyboardShortcutsSection.tsx
@@ -18,7 +18,7 @@
 
 import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Pencil, RotateCcw, Trash2 } from 'lucide-react';
+import { Camera, Pencil, RotateCcw, Trash2 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import {
@@ -44,7 +44,14 @@ import {
 } from '@/lib/appShortcutStore';
 import { getVoiceInputSettings } from '@/hooks/useVoiceInputSettings';
 import { createLogger } from '@/lib/logger';
+import { toast } from '@/lib/toast';
 import { extractIpcError } from '@/utils/ipcError';
+import {
+  DEFAULT_APPSHOT_SHORTCUT_PREFERENCES,
+  formatAppshotShortcut,
+  type AppshotShortcut,
+  type AppshotShortcutPreferences,
+} from '../../../shared/appshots';
 
 const log = createLogger('settings:keyboard-shortcuts');
 
@@ -52,6 +59,15 @@ interface RecordingError {
   id: AppShortcutId;
   message: string;
 }
+
+type AppshotRecordingTarget = 'preferred' | 'fallback' | null;
+type AppshotPermissionTarget = 'screen-recording' | 'accessibility' | 'input-monitoring';
+
+const APPSHOT_PERMISSION_SETTINGS_URLS: Record<AppshotPermissionTarget, string> = {
+  'screen-recording': 'x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture',
+  accessibility: 'x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility',
+  'input-monitoring': 'x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent',
+};
 
 export function KeyboardShortcutsSection() {
   const { t } = useTranslation();
@@ -68,6 +84,81 @@ export function KeyboardShortcutsSection() {
   const [error, setError] = useState<RecordingError | null>(null);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const mutationRequestIdRef = useRef(0);
+  const [appshotState, setAppshotState] = useState<{
+    preferences: AppshotShortcutPreferences;
+    configured: AppshotShortcut;
+    active: AppshotShortcut | null;
+    fallbackReason?: string;
+  } | null>(null);
+  const [appshotRecording, setAppshotRecording] = useState<AppshotRecordingTarget>(null);
+  const [appshotError, setAppshotError] = useState<string | null>(null);
+  const appshotsApi = window.electronAPI?.appshots;
+
+  useEffect(() => {
+    if (!appshotsApi) return;
+    void appshotsApi.getShortcutState().then((state) => {
+      setAppshotState(state);
+    }).catch(() => {
+      setAppshotError(t('settings.shortcuts.appshots.loadFailed'));
+    });
+    return appshotsApi.onShortcutStateChanged((state) => {
+      setAppshotState(state);
+    });
+  }, [appshotsApi, t]);
+
+  useEffect(() => {
+    if (!appshotRecording) return;
+    const handler = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === 'Escape') {
+        setAppshotRecording(null);
+        return;
+      }
+      const combo = createAppShortcutComboFromEvent(event);
+      if (!combo) return;
+      const current = appshotState?.preferences ?? DEFAULT_APPSHOT_SHORTCUT_PREFERENCES;
+      const next: AppshotShortcutPreferences = {
+        ...current,
+        [appshotRecording]: { kind: 'accelerator', combo },
+      };
+      setAppshotRecording(null);
+      setAppshotError(null);
+      if (!appshotsApi) return;
+      void appshotsApi.setShortcutPreferences(next)
+        .then(setAppshotState)
+        .catch(() => setAppshotError(t('settings.shortcuts.appshots.saveFailed')));
+    };
+    window.addEventListener('keydown', handler, true);
+    return () => window.removeEventListener('keydown', handler, true);
+  }, [appshotRecording, appshotState?.preferences, appshotsApi, t]);
+
+  const setAppshotDualModifier = useCallback((modifier: 'command' | 'option' | 'shift') => {
+    const current = appshotState?.preferences ?? DEFAULT_APPSHOT_SHORTCUT_PREFERENCES;
+    const next = { ...current, preferred: { kind: 'dual-modifier' as const, modifier } };
+    setAppshotError(null);
+    if (!appshotsApi) return;
+    void appshotsApi.setShortcutPreferences(next)
+      .then(setAppshotState)
+      .catch(() => setAppshotError(t('settings.shortcuts.appshots.saveFailed')));
+  }, [appshotState?.preferences, appshotsApi, t]);
+
+  const resetAppshotShortcuts = useCallback(() => {
+    setAppshotError(null);
+    if (!appshotsApi) return;
+    void appshotsApi.resetShortcutPreferences()
+      .then(setAppshotState)
+      .catch(() => setAppshotError(t('settings.shortcuts.appshots.saveFailed')));
+  }, [appshotsApi, t]);
+
+  const openAppshotPermissionSettings = useCallback(async (target: AppshotPermissionTarget) => {
+    try {
+      const result = await window.electronAPI.openExternal(APPSHOT_PERMISSION_SETTINGS_URLS[target]);
+      if (!result.success) throw new Error('open failed');
+    } catch {
+      toast.error(t('settings.shortcuts.appshots.openPermissionSettingsFailed'));
+    }
+  }, [t]);
 
   const mutationErrorMessage = useCallback(
     (err: unknown) => {
@@ -357,6 +448,83 @@ export function KeyboardShortcutsSection() {
           );
         })}
       </div>
+
+      {platform === 'darwin' && (
+        <div className="flex flex-col gap-3">
+          <div className="flex items-center justify-between gap-3">
+            <h2 className="text-16 font-medium leading-[1.2] text-[var(--settings-section-title)]">
+              {t('settings.shortcuts.appshots.title')}
+            </h2>
+            <button type="button" onClick={resetAppshotShortcuts} className="shrink-0 text-12 text-[var(--text-secondary)] hover:text-[var(--text-primary)]">
+              {t('settings.shortcuts.appshots.reset')}
+            </button>
+          </div>
+          <div className="rounded-xl border border-[var(--settings-theme-card-border)] bg-[var(--settings-theme-card-bg)] p-5">
+            <div className="flex items-start gap-3">
+              <Camera size={17} className="mt-0.5 shrink-0 text-[var(--text-secondary)]" />
+              <div className="min-w-0 flex-1">
+                <p className="text-13 font-medium text-[var(--text-primary)]">{t('settings.shortcuts.appshots.description')}</p>
+                <p className="mt-1 text-12 leading-[1.5] text-[var(--text-secondary)]">{t('settings.shortcuts.appshots.codexOnly')}</p>
+              </div>
+            </div>
+            {appshotState && (
+              <div className="mt-4 flex flex-col gap-2 text-12">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[var(--text-secondary)]">{t('settings.shortcuts.appshots.preferred')}</span>
+                  <span className="rounded-md border border-[var(--settings-theme-card-border)] bg-[var(--surface-chip)] px-2 py-1 text-[var(--text-primary)]">
+                    {formatAppshotShortcut(appshotState.preferences.preferred, platform)}
+                  </span>
+                </div>
+                <div className="flex flex-wrap justify-end gap-1">
+                  {(['command', 'option', 'shift'] as const).map((modifier) => (
+                    <button key={modifier} type="button" onClick={() => setAppshotDualModifier(modifier)} className="rounded-md border border-[var(--settings-theme-card-border)] px-2 py-1 text-[var(--text-secondary)] hover:bg-[var(--surface-chip)]">
+                      {t(`settings.shortcuts.appshots.modifiers.${modifier}`)}
+                    </button>
+                  ))}
+                  <button type="button" onClick={() => setAppshotRecording('preferred')} className="rounded-md border border-[var(--settings-theme-card-border)] px-2 py-1 text-[var(--text-secondary)] hover:bg-[var(--surface-chip)]">
+                    {appshotRecording === 'preferred' ? t('settings.shortcuts.recording') : t('settings.shortcuts.appshots.customize')}
+                  </button>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-[var(--text-secondary)]">{t('settings.shortcuts.appshots.fallback')}</span>
+                  <span className="rounded-md border border-[var(--settings-theme-card-border)] bg-[var(--surface-chip)] px-2 py-1 text-[var(--text-primary)]">
+                    {formatAppshotShortcut(appshotState.preferences.fallback, platform)}
+                  </span>
+                </div>
+                <div className="flex justify-end">
+                  <button type="button" onClick={() => setAppshotRecording('fallback')} className="rounded-md border border-[var(--settings-theme-card-border)] px-2 py-1 text-[var(--text-secondary)] hover:bg-[var(--surface-chip)]">
+                    {appshotRecording === 'fallback' ? t('settings.shortcuts.recording') : t('settings.shortcuts.appshots.customize')}
+                  </button>
+                </div>
+                <div className="flex items-center justify-between gap-3 border-t border-[var(--settings-theme-card-border)] pt-2">
+                  <span className="text-[var(--text-secondary)]">{t('settings.shortcuts.appshots.active')}</span>
+                  <span className={cn('text-right', appshotState.active ? 'text-[var(--text-primary)]' : 'text-[var(--error-fg)]')}>
+                    {appshotState.active ? formatAppshotShortcut(appshotState.active, platform) : t('settings.shortcuts.appshots.unavailable')}
+                  </span>
+                </div>
+                {appshotState.fallbackReason && <p className="text-12 text-[var(--text-secondary)]">{t(`settings.shortcuts.appshots.reasons.${appshotState.fallbackReason}`)}</p>}
+                {appshotError && <p className="text-12 text-[var(--error-fg)]">{appshotError}</p>}
+              </div>
+            )}
+            <div className="mt-4 border-t border-[var(--settings-theme-card-border)] pt-3 text-12 leading-[1.5] text-[var(--text-secondary)]">
+              <p className="font-medium text-[var(--text-primary)]">{t('settings.shortcuts.appshots.permissionsTitle')}</p>
+              <p className="mt-1">{t('settings.shortcuts.appshots.permissions')}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                {(['screen-recording', 'accessibility', 'input-monitoring'] as const).map((target) => (
+                  <button
+                    key={target}
+                    type="button"
+                    onClick={() => void openAppshotPermissionSettings(target)}
+                    className="rounded-md border border-[var(--settings-theme-card-border)] px-2 py-1 text-[var(--text-secondary)] hover:bg-[var(--surface-chip)]"
+                  >
+                    {t(`settings.shortcuts.appshots.permissionsActions.${target}`)}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/features/appshots/__tests__/appshotInbox.test.ts
+++ b/apps/desktop/src/renderer/features/appshots/__tests__/appshotInbox.test.ts
@@ -1,0 +1,310 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: vi.fn() },
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+vi.mock('@/lib/toast', () => ({
+  toast: { warning: vi.fn(), error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+import type { AppshotCaptureResult } from '../../../../shared/appshots';
+import { act, renderHook } from '@testing-library/react';
+import { useAttachments } from '@/hooks/useAttachments';
+import { getDraft } from '@/lib/composerDraftStore';
+import {
+  installAppshotInbox,
+  routeAppshotCapture,
+  toAppshotAttachment,
+  appshotThumbnailLabel,
+  canCaptureAppshotFromComposer,
+  type AppshotRouteContext,
+} from '../appshotInbox';
+
+const result: AppshotCaptureResult = {
+  captureId: 'capture-1',
+  image: {
+    url: 'xdt-image://session/capture-1.png',
+    filename: 'Cindy — Draft.png',
+    size: 1234,
+    mimeType: 'image/png',
+  },
+  metadata: {
+    schemaVersion: 1,
+    captureId: 'capture-1',
+    capturedAt: '2026-08-06T01:02:03.000Z',
+    applicationName: 'Cindy',
+    bundleIdentifier: 'com.xd.cindy',
+    windowTitle: 'Draft',
+    accessibilityText: 'Button: Send',
+    accessibilityTruncated: false,
+  },
+};
+
+function context(overrides: Partial<AppshotRouteContext> = {}): AppshotRouteContext {
+  return {
+    route: {
+      writable: true,
+      local: true,
+      agentKind: 'codex',
+      sessionId: 'session-1',
+    },
+    getDraft: vi.fn(() => ({
+      text: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'keep me' }] }] },
+      attachments: [],
+      quotes: [{ id: 'quote-1' } as never],
+      browserComments: [{ id: 'comment-1' } as never],
+    })),
+    saveDraft: vi.fn(),
+    patchDraft: vi.fn(),
+    navigate: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('Appshot renderer inbox', () => {
+  it('uses application and window title for Appshot thumbnail labels, with safe fallbacks', () => {
+    expect(appshotThumbnailLabel(result.metadata, 'Window.png')).toBe('Cindy · Draft');
+    expect(
+      appshotThumbnailLabel({ ...result.metadata, windowTitle: null }, 'Window.png'),
+    ).toBe('Cindy');
+    expect(
+      appshotThumbnailLabel({ ...result.metadata, applicationName: '' }, 'Window.png'),
+    ).toBe('Draft');
+  });
+
+  it('only enables a composer capture for local unlocked macOS Codex contexts', () => {
+    expect(
+      canCaptureAppshotFromComposer({
+        platform: 'darwin',
+        sessionId: 'codex-session',
+        runtimeAgentKind: 'codex',
+        vendorKey: 'cc',
+        remoteHostId: null,
+        deviceLinkDeviceId: undefined,
+        composerMutationLocked: false,
+      }),
+    ).toBe(true);
+    expect(
+      canCaptureAppshotFromComposer({
+        platform: 'darwin',
+        sessionId: 'claude-session',
+        runtimeAgentKind: 'cc',
+        vendorKey: 'codex',
+        remoteHostId: null,
+        deviceLinkDeviceId: undefined,
+        composerMutationLocked: false,
+      }),
+    ).toBe(false);
+    expect(
+      canCaptureAppshotFromComposer({
+        platform: 'darwin',
+        sessionId: undefined,
+        runtimeAgentKind: undefined,
+        vendorKey: 'codex',
+        remoteHostId: null,
+        deviceLinkDeviceId: undefined,
+        composerMutationLocked: false,
+      }),
+    ).toBe(true);
+    expect(
+      canCaptureAppshotFromComposer({
+        platform: 'darwin',
+        sessionId: 'codex-session',
+        runtimeAgentKind: 'codex',
+        vendorKey: 'codex',
+        remoteHostId: 'ssh-1',
+        deviceLinkDeviceId: undefined,
+        composerMutationLocked: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps Appshot metadata while New Maker rehomes cached draft images', () => {
+    const source = readFileSync(
+      resolve(__dirname, '..', '..', 'cc-agent', 'NewMakerDraftRoute.tsx'),
+      'utf8',
+    );
+    const helper = source.slice(
+      source.indexOf('async function rehomeDraftAttachments('),
+      source.indexOf('function getCurrentRoutePath()'),
+    );
+    expect(helper).toContain('return { ...f, url: cached.url, base64: undefined };');
+    expect(helper).toContain('return { ...f, url: meta.url };');
+  });
+
+  it('converts a managed capture into a normal image attachment with Appshot metadata', () => {
+    expect(toAppshotAttachment(result)).toEqual({
+      id: 'capture-1',
+      name: 'Cindy — Draft.png',
+      path: 'appshot://capture-1',
+      ext: '.png',
+      size: 1234,
+      category: 'image',
+      mimeType: 'image/png',
+      url: 'xdt-image://session/capture-1.png',
+      originalName: 'Cindy — Draft.png',
+      appshot: result.metadata,
+    });
+  });
+
+  it('adds a managed Appshot without recaching and deduplicates its capture id', () => {
+    const { result: hook } = renderHook(() => useAttachments('session-appshot'));
+    act(() => {
+      hook.current.addAppshot(result);
+      hook.current.addAppshot(result);
+    });
+    expect(hook.current.attachments).toEqual([
+      expect.objectContaining({
+        id: 'capture-1',
+        path: 'appshot://capture-1',
+        url: 'xdt-image://session/capture-1.png',
+        appshot: result.metadata,
+      }),
+    ]);
+    expect(getDraft('session-appshot')?.attachments).toEqual(hook.current.attachments);
+  });
+
+  it('appends to the current writable local Codex draft and preserves draft fields', async () => {
+    const current = context();
+    await routeAppshotCapture(result, current);
+
+    expect(current.saveDraft).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        text: expect.any(Object),
+        quotes: expect.any(Array),
+        browserComments: expect.any(Array),
+        attachments: [expect.objectContaining({ id: 'capture-1' })],
+      }),
+    );
+    expect(current.navigate).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a clean Codex New Maker draft for a non-Codex or non-local route', async () => {
+    const current = context({
+      route: {
+        writable: true,
+        local: false,
+        agentKind: 'cc',
+        sessionId: 'claude-session',
+        remoteHostId: 'ssh-1',
+        deviceLinkDeviceId: 'device-1',
+      },
+    });
+    await routeAppshotCapture(result, current);
+
+    expect(current.saveDraft).toHaveBeenCalledWith(
+      '__new_maker_draft__',
+      expect.objectContaining({
+        attachments: [expect.objectContaining({ id: 'capture-1' })],
+        text: expect.any(Object),
+        quotes: expect.any(Array),
+        browserComments: expect.any(Array),
+      }),
+    );
+    expect(current.patchDraft).toHaveBeenCalledWith({
+      vendor: 'codex',
+      workingDir: null,
+      remoteHostId: null,
+      deviceLinkDeviceId: null,
+      deviceLinkDeviceName: null,
+      extraDirs: [],
+    });
+    expect(current.navigate).toHaveBeenCalledWith('/cc-agent/new');
+  });
+
+  it('does not duplicate an Appshot already present in the draft', async () => {
+    const current = context({
+      getDraft: vi.fn(() => ({
+        text: null,
+        attachments: [toAppshotAttachment(result)],
+      })),
+    });
+    await routeAppshotCapture(result, current);
+
+    expect(current.saveDraft).not.toHaveBeenCalled();
+  });
+
+  it('routes before acknowledging, and leaves a failed capture pending', async () => {
+    const order: string[] = [];
+    const onCaptured = vi.fn();
+    const api = {
+      listPending: vi.fn(async () => [result]),
+      onCaptured: vi.fn((callback: (value: AppshotCaptureResult) => void) => {
+        onCaptured.mockImplementation(callback);
+        return () => undefined;
+      }),
+      ack: vi.fn(async () => {
+        order.push('ack');
+        return { acknowledged: true };
+      }),
+    };
+    const route = vi.fn(async () => {
+      order.push('route');
+    });
+    const inbox = installAppshotInbox({ api, route });
+    await inbox.ready;
+
+    expect(order).toEqual(['route', 'ack']);
+    expect(route).toHaveBeenCalledTimes(1);
+    expect(api.ack).toHaveBeenCalledWith('capture-1');
+
+    onCaptured(result);
+    await inbox.flush();
+    expect(route).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not acknowledge when routing fails, so a later event can recover it', async () => {
+    let attempts = 0;
+    const api = {
+      listPending: vi.fn(async () => []),
+      onCaptured: vi.fn((callback: (value: AppshotCaptureResult) => void) => {
+        api.callback = callback;
+        return () => undefined;
+      }),
+      ack: vi.fn(async () => ({ acknowledged: true })),
+      callback: undefined as ((value: AppshotCaptureResult) => void) | undefined,
+    };
+    const route = vi.fn(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('draft write failed');
+    });
+    const inbox = installAppshotInbox({ api, route });
+    await inbox.ready;
+    api.callback?.(result);
+    await inbox.flush();
+    expect(api.ack).not.toHaveBeenCalled();
+    api.callback?.(result);
+    await inbox.flush();
+    expect(api.ack).toHaveBeenCalledWith('capture-1');
+  });
+
+  it('keeps a capture pending when the Main ack reports that it was not acknowledged', async () => {
+    let acknowledge = false;
+    const api = {
+      listPending: vi.fn(async () => []),
+      onCaptured: vi.fn((callback: (value: AppshotCaptureResult) => void) => {
+        api.callback = callback;
+        return () => undefined;
+      }),
+      ack: vi.fn(async () => ({ acknowledged: acknowledge })),
+      callback: undefined as ((value: AppshotCaptureResult) => void) | undefined,
+    };
+    const inbox = installAppshotInbox({
+      api,
+      route: vi.fn(async () => true),
+    });
+    await inbox.ready;
+    api.callback?.(result);
+    await inbox.flush();
+    expect(api.ack).toHaveBeenCalledTimes(1);
+    acknowledge = true;
+    api.callback?.(result);
+    await inbox.flush();
+    expect(api.ack).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/desktop/src/renderer/features/appshots/appshotInbox.ts
+++ b/apps/desktop/src/renderer/features/appshots/appshotInbox.ts
@@ -1,0 +1,214 @@
+import type { AppshotCaptureResult } from '../../../shared/appshots';
+import type { AttachedFile } from '@/lib/fileTypes';
+import {
+  getDraft as getComposerDraft,
+  saveDraft as saveComposerDraft,
+  type ComposerDraft,
+} from '@/lib/composerDraftStore';
+import { patchDraft as patchNewMakerDraft } from '@/state/newMakerDraft';
+import { NEW_MAKER_DRAFT_KEY } from '../cc-agent/newMakerDraftKeys';
+
+export interface AppshotRouteState {
+  writable: boolean;
+  local: boolean;
+  agentKind: 'cc' | 'codex' | 'pi' | null | undefined;
+  sessionId?: string | null;
+  remoteHostId?: string | null;
+  deviceLinkDeviceId?: string | null;
+}
+
+export interface AppshotRouteContext {
+  route: AppshotRouteState;
+  getDraft: (key: string) => ComposerDraft | undefined;
+  saveDraft: (key: string, draft: ComposerDraft) => void;
+  patchDraft: (patch: {
+    vendor: 'codex';
+    workingDir: null;
+    remoteHostId: null;
+    deviceLinkDeviceId: null;
+    deviceLinkDeviceName: null;
+    extraDirs: [];
+  }) => void;
+  navigate: (path: string) => void;
+}
+
+export interface AppshotBridgeForInbox {
+  listPending: () => Promise<AppshotCaptureResult[]>;
+  ack: (captureId: string) => Promise<{ acknowledged: boolean }>;
+  onCaptured: (callback: (result: AppshotCaptureResult) => void) => () => void;
+}
+
+export function toAppshotAttachment(result: AppshotCaptureResult): AttachedFile {
+  const filename = result.image.filename.trim() || `${result.captureId}.png`;
+  return {
+    id: result.captureId,
+    name: filename,
+    path: `appshot://${result.captureId}`,
+    ext: '.png',
+    size: result.image.size,
+    category: 'image',
+    mimeType: 'image/png',
+    url: result.image.url,
+    originalName: filename,
+    appshot: result.metadata,
+  };
+}
+
+export function appshotThumbnailLabel(
+  metadata: AppshotCaptureResult['metadata'],
+  fallbackName: string,
+): string {
+  const app = metadata.applicationName.trim();
+  const title = metadata.windowTitle?.trim() ?? '';
+  if (app && title) return `${app} · ${title}`;
+  return app || title || fallbackName;
+}
+
+export interface ComposerAppshotCaptureContext {
+  platform: string | undefined;
+  sessionId: string | undefined;
+  runtimeAgentKind: 'cc' | 'claude-code' | 'codex' | 'pi' | null | undefined;
+  vendorKey: 'cc' | 'codex' | 'pi' | undefined;
+  remoteHostId: string | null | undefined;
+  deviceLinkDeviceId: string | null | undefined;
+  composerMutationLocked: boolean;
+}
+
+/**
+ * Existing sessions must use their runtime identity. The vendor selector is
+ * authoritative only for the explicit `/cc-agent/new` draft route.
+ */
+export function canCaptureAppshotFromComposer(context: ComposerAppshotCaptureContext): boolean {
+  const agentKind = (context.runtimeAgentKind === 'claude-code' ? 'cc' : context.runtimeAgentKind) ?? (
+    !context.sessionId && context.vendorKey === 'codex' ? 'codex' : null
+  );
+  return (
+    context.platform === 'darwin' &&
+    agentKind === 'codex' &&
+    !context.remoteHostId &&
+    !context.deviceLinkDeviceId &&
+    !context.composerMutationLocked
+  );
+}
+
+function isCurrentWritableLocalCodex(route: AppshotRouteState): boolean {
+  return (
+    route.writable === true &&
+    route.local === true &&
+    route.agentKind === 'codex' &&
+    !route.remoteHostId &&
+    !route.deviceLinkDeviceId &&
+    typeof route.sessionId === 'string' &&
+    route.sessionId.length > 0
+  );
+}
+
+function appendCapture(draft: ComposerDraft | undefined, attachment: AttachedFile): ComposerDraft {
+  const existing = draft ?? { text: null, attachments: [] };
+  if (
+    existing.attachments.some(
+      (file) => file.id === attachment.id || file.appshot?.captureId === attachment.appshot?.captureId,
+    )
+  ) {
+    return existing;
+  }
+  return {
+    ...existing,
+    attachments: [...existing.attachments, attachment],
+    quotes: existing.quotes ?? [],
+    browserComments: existing.browserComments ?? [],
+  };
+}
+
+export async function routeAppshotCapture(
+  result: AppshotCaptureResult,
+  context: AppshotRouteContext,
+): Promise<boolean> {
+  const attachment = toAppshotAttachment(result);
+  const direct = isCurrentWritableLocalCodex(context.route);
+  const key = direct ? context.route.sessionId as string : NEW_MAKER_DRAFT_KEY;
+  const current = context.getDraft(key);
+  const next = appendCapture(current, attachment);
+  if (next === current) return false;
+
+  if (!direct) {
+    context.patchDraft({
+      vendor: 'codex',
+      workingDir: null,
+      remoteHostId: null,
+      deviceLinkDeviceId: null,
+      deviceLinkDeviceName: null,
+      extraDirs: [],
+    });
+  }
+  context.saveDraft(key, next);
+  if (!direct) context.navigate('/cc-agent/new');
+  return true;
+}
+
+export interface InstallAppshotInboxOptions {
+  api?: AppshotBridgeForInbox;
+  route?: (result: AppshotCaptureResult) => Promise<boolean | void>;
+  context?: AppshotRouteContext;
+}
+
+export interface AppshotInboxHandle {
+  ready: Promise<void>;
+  flush: () => Promise<void>;
+  dispose: () => void;
+}
+
+export function installAppshotInbox({
+  api = window.electronAPI.appshots,
+  route = (result) => routeAppshotCapture(result, {
+    route: { writable: false, local: false, agentKind: null },
+    getDraft: getComposerDraft,
+    saveDraft: saveComposerDraft,
+    patchDraft: patchNewMakerDraft,
+    navigate: (path) => { window.location.hash = path; },
+  }),
+}: InstallAppshotInboxOptions = {}): AppshotInboxHandle {
+  const acked = new Set<string>();
+  const queued = new Map<string, AppshotCaptureResult>();
+  const processing = new Set<string>();
+  let draining: Promise<void> = Promise.resolve();
+  let disposed = false;
+
+  const enqueue = (result: AppshotCaptureResult) => {
+    if (disposed || acked.has(result.captureId) || processing.has(result.captureId)) return;
+    queued.set(result.captureId, result);
+    draining = draining.then(async () => {
+      const next = queued.get(result.captureId);
+      if (!next || acked.has(next.captureId)) return;
+      processing.add(next.captureId);
+      try {
+        await route(next);
+        const acknowledgement = await api.ack(next.captureId);
+        if (acknowledgement.acknowledged !== true) {
+          return;
+        }
+        acked.add(next.captureId);
+        queued.delete(next.captureId);
+      } catch {
+        // Keep it queued and unacknowledged. The next bridge event or reload can retry it.
+      } finally {
+        processing.delete(next.captureId);
+      }
+    });
+  };
+
+  const unsubscribe = api.onCaptured(enqueue);
+  const ready = api.listPending().then((pending) => {
+    for (const result of pending) enqueue(result);
+    return draining;
+  });
+
+  return {
+    ready,
+    flush: () => draining,
+    dispose: () => {
+      disposed = true;
+      unsubscribe();
+    },
+  };
+}

--- a/apps/desktop/src/renderer/hooks/useAttachments.ts
+++ b/apps/desktop/src/renderer/hooks/useAttachments.ts
@@ -46,6 +46,8 @@ import {
   isDataOwnerGenerationCurrent,
   type DataOwnerGeneration,
 } from '@/contexts/dataOwnerGeneration';
+import type { AppshotCaptureResult } from '../../shared/appshots';
+import { toAppshotAttachment } from '@/features/appshots/appshotInbox';
 
 /**
  * A single "this file did not get attached" rejection, surfaced inline in the
@@ -62,6 +64,8 @@ export interface UseAttachmentsReturn {
   hasAttachments: boolean;
   addFiles: (fileList: FileList | readonly File[]) => Promise<void>;
   addClipboardImage: (blob: Blob) => Promise<void>;
+  /** Add a native Appshot whose URL is already managed by cindy-media. */
+  addAppshot: (result: AppshotCaptureResult) => void;
   /**
    * Files rejected on the most recent add attempt (oversize / empty / blocked
    * type / max-files / read failure). Rendered inline near the composer; stays
@@ -790,6 +794,19 @@ export function useAttachments(sessionId?: string, draftKey?: string): UseAttach
     [isAttachmentOperationScopeCurrent, pushScopedRejections, settleAttachmentsForScope, t],
   );
 
+  const addAppshot = useCallback((result: AppshotCaptureResult) => {
+    const attachment = toAppshotAttachment(result);
+    setAttachments((prev) =>
+      prev.some(
+        (file) =>
+          file.id === attachment.id ||
+          file.appshot?.captureId === attachment.appshot?.captureId,
+      )
+        ? prev
+        : [...prev, attachment],
+    );
+  }, []);
+
   const removeFile = useCallback((id: string) => {
     const removed = attachmentsRef.current.find((f) => f.id === id);
     // 共享引用(如"标注历史图"直接引用消息里的原图)不归附件所有,删除附件
@@ -853,6 +870,7 @@ export function useAttachments(sessionId?: string, draftKey?: string): UseAttach
     hasAttachments: attachments.length > 0,
     addFiles,
     addClipboardImage,
+    addAppshot,
     rejections,
     dismissRejection,
     clearRejections,

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -3062,6 +3062,33 @@
     },
     "shortcuts": {
       "title": "Keyboard Shortcuts",
+      "appshots": {
+        "title": "Appshots",
+        "description": "Capture the current app window and attach it to the active local Codex composer.",
+        "codexOnly": "Appshots are available only in local Codex sessions and are never sent automatically.",
+        "preferred": "Preferred shortcut",
+        "fallback": "Fallback shortcut",
+        "active": "Currently active",
+        "unavailable": "Unavailable",
+        "customize": "Customize",
+        "reset": "Reset Appshots shortcuts",
+        "loadFailed": "Could not load Appshots shortcut settings",
+        "saveFailed": "Could not save Appshots shortcut settings",
+        "permissionsTitle": "macOS permissions",
+        "permissions": "Screen Recording captures the window image. Accessibility reads the window title and UI tree. Input Monitoring is needed for double-modifier shortcuts. Cindy does not request these permissions at startup; grant them in System Settings > Privacy & Security if you enable the feature.",
+        "openPermissionSettingsFailed": "Failed to open the macOS permission settings",
+        "permissionsActions": {
+          "screen-recording": "Screen Recording",
+          "accessibility": "Accessibility",
+          "input-monitoring": "Input Monitoring"
+        },
+        "modifiers": { "command": "Double Command", "option": "Double Option", "shift": "Double Shift" },
+        "reasons": {
+          "codex-running": "Codex is running, so the fallback shortcut is active.",
+          "registration-conflict": "The preferred shortcut was unavailable, so the fallback is active.",
+          "input-monitoring": "Input Monitoring is unavailable, so the fallback is active."
+        }
+      },
       "resetAll": "Reset all to defaults",
       "reset": "Reset to default",
       "recording": "Press new shortcut…",
@@ -5425,6 +5452,14 @@
     },
     "chatInput": {
       "defaultPlaceholder": "What shall we work on today~",
+      "appshots": {
+        "permissionTitle": "Screen Recording permission required",
+        "permissionDescription": "Appshots needs macOS Screen Recording permission to capture the active app window. Cindy will open the matching System Settings page and will not capture or send anything until you try again.",
+        "openSettings": "Open Settings",
+        "cancel": "Cancel",
+        "openSettingsFailed": "Failed to open Screen Recording settings",
+        "captureFailed": "Could not capture the active app window"
+      },
       "voiceInput": {
         "start": "Start voice input",
         "stop": "Stop voice input",

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5453,12 +5453,19 @@
     "chatInput": {
       "defaultPlaceholder": "What shall we work on today~",
       "appshots": {
+        "menuItem": "Capture app snapshot",
         "permissionTitle": "Screen Recording permission required",
         "permissionDescription": "Appshots needs macOS Screen Recording permission to capture the active app window. Cindy will open the matching System Settings page and will not capture or send anything until you try again.",
         "openSettings": "Open Settings",
         "cancel": "Cancel",
         "openSettingsFailed": "Failed to open Screen Recording settings",
-        "captureFailed": "Could not capture the active app window"
+        "captureFailed": "Could not capture the active app window",
+        "hasAxBadge": "Includes UI structure",
+        "axPreviewTitle": "Appshot UI structure",
+        "axPreviewDescription": "The accessibility text below is attached alongside the screenshot when sent. You can remove it before sending.",
+        "noAx": "This snapshot has no UI structure.",
+        "removeAx": "Remove UI structure",
+        "close": "Close"
       },
       "voiceInput": {
         "start": "Start voice input",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5451,12 +5451,19 @@
     "chatInput": {
       "defaultPlaceholder": "今日は何をしましょうか〜",
       "appshots": {
+        "menuItem": "アプリのスナップショット",
         "permissionTitle": "画面収録の権限が必要です",
         "permissionDescription": "Appshots で現在のアプリウィンドウを取得するには、macOS の画面収録権限が必要です。Cindy は該当するシステム設定ページだけを開き、再試行するまで取得も送信もしません。",
         "openSettings": "設定を開く",
         "cancel": "キャンセル",
         "openSettingsFailed": "画面収録の設定を開けませんでした",
-        "captureFailed": "現在のアプリウィンドウを取得できませんでした"
+        "captureFailed": "現在のアプリウィンドウを取得できませんでした",
+        "hasAxBadge": "UI構造を含む",
+        "axPreviewTitle": "Appshot UI 構造",
+        "axPreviewDescription": "送信時には以下のアクセシビリティテキストがスクリーンショットと一緒に添付されます。送信前に削除できます。",
+        "noAx": "このスナップショットには UI 構造が含まれていません。",
+        "removeAx": "UI 構造を削除",
+        "close": "閉じる"
       },
       "voiceInput": {
         "start": "音声入力を開始",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -3061,6 +3061,33 @@
     },
     "shortcuts": {
       "title": "キーボードショートカット",
+      "appshots": {
+        "title": "Appshots",
+        "description": "現在のアプリウィンドウをキャプチャし、現在のローカル Codex composer に添付します。",
+        "codexOnly": "Appshots はローカル Codex セッションでのみ使用でき、自動送信はしません。",
+        "preferred": "優先ショートカット",
+        "fallback": "代替ショートカット",
+        "active": "現在有効",
+        "unavailable": "利用不可",
+        "customize": "カスタマイズ",
+        "reset": "Appshots のショートカットをリセット",
+        "loadFailed": "Appshots のショートカット設定を読み込めませんでした",
+        "saveFailed": "Appshots のショートカット設定を保存できませんでした",
+        "permissionsTitle": "macOS の権限",
+        "permissions": "画面収録はウィンドウ画像の取得に、アクセシビリティはタイトルと UI ツリーの読み取りに、入力監視は修飾キー 2 回押しに使用します。起動時に権限を要求せず、「システム設定 > プライバシーとセキュリティ」で許可できます。",
+        "openPermissionSettingsFailed": "macOS の権限設定を開けませんでした",
+        "permissionsActions": {
+          "screen-recording": "画面収録",
+          "accessibility": "アクセシビリティ",
+          "input-monitoring": "入力監視"
+        },
+        "modifiers": { "command": "Command 2 回", "option": "Option 2 回", "shift": "Shift 2 回" },
+        "reasons": {
+          "codex-running": "Codex の実行中は代替ショートカットを使用します。",
+          "registration-conflict": "優先ショートカットを登録できないため、代替を使用します。",
+          "input-monitoring": "入力監視を利用できないため、代替を使用します。"
+        }
+      },
       "resetAll": "すべてデフォルトに戻す",
       "reset": "デフォルトに戻す",
       "recording": "新しいショートカットを入力…",
@@ -5423,6 +5450,14 @@
     },
     "chatInput": {
       "defaultPlaceholder": "今日は何をしましょうか〜",
+      "appshots": {
+        "permissionTitle": "画面収録の権限が必要です",
+        "permissionDescription": "Appshots で現在のアプリウィンドウを取得するには、macOS の画面収録権限が必要です。Cindy は該当するシステム設定ページだけを開き、再試行するまで取得も送信もしません。",
+        "openSettings": "設定を開く",
+        "cancel": "キャンセル",
+        "openSettingsFailed": "画面収録の設定を開けませんでした",
+        "captureFailed": "現在のアプリウィンドウを取得できませんでした"
+      },
       "voiceInput": {
         "start": "音声入力を開始",
         "stop": "音声入力を停止",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5451,12 +5451,19 @@
     "chatInput": {
       "defaultPlaceholder": "오늘은 무엇을 할까요~",
       "appshots": {
+        "menuItem": "앱 스냅샷",
         "permissionTitle": "화면 기록 권한이 필요합니다",
         "permissionDescription": "Appshots로 현재 앱 창을 캡처하려면 macOS 화면 기록 권한이 필요합니다. Cindy는 해당 시스템 설정 페이지만 열며, 다시 시도하기 전에는 캡처하거나 전송하지 않습니다.",
         "openSettings": "설정 열기",
         "cancel": "취소",
         "openSettingsFailed": "화면 기록 설정을 열 수 없습니다",
-        "captureFailed": "현재 앱 창을 캡처할 수 없습니다"
+        "captureFailed": "현재 앱 창을 캡처할 수 없습니다",
+        "hasAxBadge": "UI 구조 포함",
+        "axPreviewTitle": "Appshot UI 구조",
+        "axPreviewDescription": "전송 시 아래 접근성 텍스트가 스크린샷과 함께 첨부됩니다. 전송 전에 제거할 수 있습니다.",
+        "noAx": "이 스냅샷에는 UI 구조가 없습니다.",
+        "removeAx": "UI 구조 제거",
+        "close": "닫기"
       },
       "voiceInput": {
         "start": "음성 입력 시작",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -3061,6 +3061,33 @@
     },
     "shortcuts": {
       "title": "키보드 단축키",
+      "appshots": {
+        "title": "Appshots",
+        "description": "현재 앱 창을 캡처하여 현재 로컬 Codex 입력창에 첨부합니다.",
+        "codexOnly": "Appshots는 로컬 Codex 세션에서만 사용할 수 있으며 자동으로 전송하지 않습니다.",
+        "preferred": "기본 단축키",
+        "fallback": "대체 단축키",
+        "active": "현재 활성",
+        "unavailable": "사용할 수 없음",
+        "customize": "사용자 지정",
+        "reset": "Appshots 단축키 재설정",
+        "loadFailed": "Appshots 단축키 설정을 불러오지 못했습니다",
+        "saveFailed": "Appshots 단축키 설정을 저장하지 못했습니다",
+        "permissionsTitle": "macOS 권한",
+        "permissions": "화면 기록은 창 이미지를 캡처하고, 손쉬운 사용은 창 제목과 UI 트리를 읽으며, 입력 모니터링은 수정 키 두 번 누르기에 필요합니다. 시작 시 권한을 요청하지 않으며 “시스템 설정 > 개인정보 보호 및 보안”에서 허용할 수 있습니다.",
+        "openPermissionSettingsFailed": "macOS 권한 설정을 열지 못했습니다",
+        "permissionsActions": {
+          "screen-recording": "화면 기록",
+          "accessibility": "손쉬운 사용",
+          "input-monitoring": "입력 모니터링"
+        },
+        "modifiers": { "command": "Command 두 번", "option": "Option 두 번", "shift": "Shift 두 번" },
+        "reasons": {
+          "codex-running": "Codex가 실행 중이므로 대체 단축키가 활성화되었습니다.",
+          "registration-conflict": "기본 단축키를 사용할 수 없어 대체 단축키가 활성화되었습니다.",
+          "input-monitoring": "입력 모니터링을 사용할 수 없어 대체 단축키가 활성화되었습니다."
+        }
+      },
       "resetAll": "모두 기본값으로 재설정",
       "reset": "기본값으로 재설정",
       "recording": "새 단축키를 누르세요…",
@@ -5423,6 +5450,14 @@
     },
     "chatInput": {
       "defaultPlaceholder": "오늘은 무엇을 할까요~",
+      "appshots": {
+        "permissionTitle": "화면 기록 권한이 필요합니다",
+        "permissionDescription": "Appshots로 현재 앱 창을 캡처하려면 macOS 화면 기록 권한이 필요합니다. Cindy는 해당 시스템 설정 페이지만 열며, 다시 시도하기 전에는 캡처하거나 전송하지 않습니다.",
+        "openSettings": "설정 열기",
+        "cancel": "취소",
+        "openSettingsFailed": "화면 기록 설정을 열 수 없습니다",
+        "captureFailed": "현재 앱 창을 캡처할 수 없습니다"
+      },
       "voiceInput": {
         "start": "음성 입력 시작",
         "stop": "음성 입력 중지",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -3061,6 +3061,33 @@
     },
     "shortcuts": {
       "title": "键盘快捷键",
+      "appshots": {
+        "title": "Appshots 截图",
+        "description": "捕获当前应用窗口，并附加到当前本地 Codex 输入框。",
+        "codexOnly": "Appshots 只在本地 Codex 会话中可用，不会自动发送。",
+        "preferred": "首选快捷键",
+        "fallback": "备用快捷键",
+        "active": "当前生效",
+        "unavailable": "不可用",
+        "customize": "自定义",
+        "reset": "恢复 Appshots 快捷键",
+        "loadFailed": "无法读取 Appshots 快捷键设置",
+        "saveFailed": "无法保存 Appshots 快捷键设置",
+        "permissionsTitle": "macOS 权限",
+        "permissions": "屏幕录制用于捕获窗口图像；辅助功能用于读取窗口标题和 UI 树；输入监控用于双修饰键快捷键。Cindy 启动时不会主动请求这些权限；启用功能后，请在“系统设置 > 隐私与安全性”中授权。",
+        "openPermissionSettingsFailed": "无法打开 macOS 权限设置",
+        "permissionsActions": {
+          "screen-recording": "屏幕录制",
+          "accessibility": "辅助功能",
+          "input-monitoring": "输入监控"
+        },
+        "modifiers": { "command": "双 Command", "option": "双 Option", "shift": "双 Shift" },
+        "reasons": {
+          "codex-running": "Codex 正在运行，因此当前使用备用快捷键。",
+          "registration-conflict": "首选快捷键不可用，因此当前使用备用快捷键。",
+          "input-monitoring": "输入监控权限不可用，因此当前使用备用快捷键。"
+        }
+      },
       "resetAll": "恢复全部默认",
       "reset": "恢复默认",
       "recording": "按下新快捷键…",
@@ -5423,6 +5450,14 @@
     },
     "chatInput": {
       "defaultPlaceholder": "今天我们做点什么呢~",
+      "appshots": {
+        "permissionTitle": "需要屏幕录制权限",
+        "permissionDescription": "Appshots 需要 macOS 屏幕录制权限才能捕获当前应用窗口。Cindy 只会打开对应的系统设置页面；在你重新尝试前，不会捕获或发送任何内容。",
+        "openSettings": "打开系统设置",
+        "cancel": "取消",
+        "openSettingsFailed": "无法打开屏幕录制设置",
+        "captureFailed": "无法捕获当前应用窗口"
+      },
       "voiceInput": {
         "start": "开始语音输入",
         "stop": "停止语音输入",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5451,12 +5451,19 @@
     "chatInput": {
       "defaultPlaceholder": "今天我们做点什么呢~",
       "appshots": {
+        "menuItem": "应用快照",
         "permissionTitle": "需要屏幕录制权限",
         "permissionDescription": "Appshots 需要 macOS 屏幕录制权限才能捕获当前应用窗口。Cindy 只会打开对应的系统设置页面；在你重新尝试前，不会捕获或发送任何内容。",
         "openSettings": "打开系统设置",
         "cancel": "取消",
         "openSettingsFailed": "无法打开屏幕录制设置",
-        "captureFailed": "无法捕获当前应用窗口"
+        "captureFailed": "无法捕获当前应用窗口",
+        "hasAxBadge": "含界面结构",
+        "axPreviewTitle": "Appshot 界面结构",
+        "axPreviewDescription": "发送时会随截图附带以下可访问性文本，发送前可移除。",
+        "noAx": "此快照未包含界面结构。",
+        "removeAx": "移除界面结构",
+        "close": "关闭"
       },
       "voiceInput": {
         "start": "开始语音输入",

--- a/apps/desktop/src/renderer/lib/composerSuggestion.ts
+++ b/apps/desktop/src/renderer/lib/composerSuggestion.ts
@@ -20,6 +20,7 @@ import {
 
 export type ComposerSuggestionActionId =
   | 'attach-files'
+  | 'capture-appshot'
   | 'new-goal'
   | 'plan-mode'
   | 'collaboration'

--- a/apps/desktop/src/renderer/lib/fileTypes.ts
+++ b/apps/desktop/src/renderer/lib/fileTypes.ts
@@ -16,6 +16,7 @@ import {
   COMPOUND_EXTS,
   KNOWN_TEXT_FILENAMES,
 } from '../../shared/textFileExts';
+import type { AppshotMetadata } from '../../shared/appshots';
 
 // ── Supported extension sets ──
 
@@ -99,6 +100,7 @@ export interface AttachedFile {
    * buildMakerUserMessage 据此给模型注入"红色笔迹是用户标注"的固定说明。
    */
   annotated?: boolean;
+  appshot?: AppshotMetadata;
   /**
    * 非破坏性标注:未烧录**原图**的 xdt-image:// 缓存 url。`annotated` 为真时
    * 存在;托盘预览用它(而非烧录位图)+ `annotationStrokes` 矢量叠加显示,
@@ -163,6 +165,7 @@ export interface SerializedAttachedFile {
   truncated?: boolean;
   /** 图片带用户手绘标注,见 {@link AttachedFile.annotated}。 */
   annotated?: boolean;
+  appshot?: AppshotMetadata;
 }
 
 export interface MentionedResource {

--- a/apps/desktop/src/renderer/lib/imageRef.ts
+++ b/apps/desktop/src/renderer/lib/imageRef.ts
@@ -22,6 +22,7 @@ import {
   readAgentInputReferences,
   type AgentInputReference,
 } from '@cindy/maker-shared/agent-input-projection';
+import { coerceAppshotMetadata, type AppshotMetadata } from '../../shared/appshots';
 
 export interface ImageRef {
   /** Custom-protocol URL: 'xdt-image://{sessionId}/{filename}'. */
@@ -34,6 +35,7 @@ export interface ImageRef {
   size?: number;
   /** 发送端声明的上传字节 SHA-256。 */
   sha256?: string;
+  appshot?: AppshotMetadata;
   /**
    * 非破坏性标注(可选,向后兼容):`url` 是烧录合成图(定格模型所见)时,
    * 这里指向未烧录**原图**的缓存 url。历史图"再编辑"用它 + strokes 还原
@@ -156,6 +158,7 @@ export function parseUserContent(content: unknown): UserMessageContent {
           const image = coerceImageRef({
             url: b.url,
             mimeType: b.mimeType,
+            appshot: b.appshot,
             originalName:
               typeof b.originalName === 'string'
                 ? b.originalName
@@ -245,6 +248,8 @@ function coerceImageRef(x: unknown): ImageRef | null {
     ref.size = integrity.size;
     ref.sha256 = integrity.sha256;
   }
+  const appshot = coerceAppshotMetadata(o.appshot);
+  if (appshot) ref.appshot = appshot;
   // 非破坏性标注字段:形状校验通过才成对透传(review P2:此前 coerce 只取
   // 三字段,重载 / 从存储取回后历史图丢失可再编辑数据)。半份数据没有意义,
   // 任一不合法就整体丢弃,退化为普通烧录图展示。

--- a/apps/desktop/src/renderer/lib/messageAttachmentPayload.ts
+++ b/apps/desktop/src/renderer/lib/messageAttachmentPayload.ts
@@ -15,6 +15,11 @@ import type {
 } from '@/lib/fileTypes';
 import type { FileRef, ImageRef } from '@/lib/imageRef';
 import { getAgentInputAttachmentBlockType } from '../../shared/agentInputQueue';
+import {
+  coerceAppshotMetadata,
+  formatAppshotContext,
+  type AppshotMetadata,
+} from '../../shared/appshots';
 
 export type InlineImageAttachment = {
   base64: string;
@@ -31,6 +36,7 @@ export type SdkAttachmentBlock = {
   base64?: string;
   mimeType?: string;
   originalName?: string;
+  appshot?: AppshotMetadata;
   /**
    * 显式文件附件的原始磁盘路径(path 为 xdt-image:// 缓存 URL 时携带):
    * device-link 出方向据此识别「字节精确」语义跳过压缩;上传后即被剥掉,
@@ -74,6 +80,7 @@ export function serializeAttachedFiles(
 ): SerializedAttachedFile[] | undefined {
   return files?.map((file) => {
     const legacy = readLegacyInlineFields(file);
+    const appshot = coerceAppshotMetadata(file.appshot);
     return {
       id: file.id,
       name: file.name,
@@ -85,6 +92,7 @@ export function serializeAttachedFiles(
       originalName: file.originalName ?? file.name,
       ...(file.url ? { url: file.url } : {}),
       ...(file.annotated ? { annotated: true } : {}),
+      ...(appshot ? { appshot } : {}),
       ...(legacy.base64 ? { base64: legacy.base64 } : {}),
       ...(legacy.textContent !== undefined ? { textContent: legacy.textContent } : {}),
       ...(legacy.truncated !== undefined ? { truncated: legacy.truncated } : {}),
@@ -94,11 +102,13 @@ export function serializeAttachedFiles(
 
 function buildImageAttachment(file: AttachedFile): RenderImageAttachment | null {
   if (file.category !== 'image') return null;
+  const appshot = coerceAppshotMetadata(file.appshot);
   if (file.url) {
     return {
       url: file.url,
       mimeType: file.mimeType,
       originalName: file.originalName ?? file.name,
+      ...(appshot ? { appshot } : {}),
       // 非破坏性标注:发送物化后 url 是烧录图,原图引用与矢量笔迹随消息
       // 持久化,历史图点开可继续编辑 / 撤销(imageRef.ts 字段注释)。
       ...(file.annotated && file.annotationSourceUrl && file.annotationStrokes?.length
@@ -116,6 +126,7 @@ function buildImageAttachment(file: AttachedFile): RenderImageAttachment | null 
     base64: legacyBase64,
     mimeType: file.mimeType,
     originalName: file.originalName ?? file.name,
+    ...(appshot ? { appshot } : {}),
   };
 }
 
@@ -143,6 +154,7 @@ export function buildUserMessageAttachmentPayload(
 
 function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock | null {
   const type = getAgentInputAttachmentBlockType(file.category, file.ext);
+  const appshot = type === 'image' ? coerceAppshotMetadata(file.appshot) : null;
   if (file.url) {
     // 显式文件(选择器/拖拽)拷入缓存后 url 与原始磁盘 path 并存:把原始路径一并
     // 带上,message 形态的远程发送才能识别「字节精确」语义不压缩(队列形态的
@@ -155,6 +167,7 @@ function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock 
       path: file.url,
       mimeType: file.mimeType,
       originalName: file.originalName ?? file.name,
+      ...(appshot ? { appshot } : {}),
       ...(originalPath ? { originalPath } : {}),
     };
   }
@@ -164,6 +177,7 @@ function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock 
       path: file.path,
       mimeType: file.mimeType,
       originalName: file.originalName ?? file.name,
+      ...(appshot ? { appshot } : {}),
     };
   }
 
@@ -174,6 +188,7 @@ function buildAttachmentBlock(file: SerializedAttachedFile): SdkAttachmentBlock 
       base64: legacyBase64,
       mimeType: file.mimeType,
       originalName: file.originalName ?? file.name,
+      ...(appshot ? { appshot } : {}),
     };
   }
 
@@ -201,7 +216,12 @@ export function buildMakerUserContentBlocks(
 
   for (const file of files ?? []) {
     const block = buildAttachmentBlock(file);
-    if (block) blocks.push(block);
+    if (block) {
+      blocks.push(block);
+      if (block.type === 'image' && block.appshot) {
+        blocks.push({ type: 'text', text: formatAppshotContext(block.appshot) });
+      }
+    }
   }
 
   return blocks;

--- a/apps/desktop/src/renderer/vite-env.d.ts
+++ b/apps/desktop/src/renderer/vite-env.d.ts
@@ -1055,6 +1055,20 @@ interface ElectronAPI {
   appDisplayVersionDetail: string;
   preferredSystemLocale: ApplicationMenuLocale;
   getDeviceId: () => Promise<string>;
+  appshots: {
+    capture: () => Promise<{ accepted: true }>;
+    listPending: () => Promise<import('../shared/appshots').AppshotCaptureResult[]>;
+    ack: (captureId: string) => Promise<{ acknowledged: boolean }>;
+    onCaptured: (callback: (result: import('../shared/appshots').AppshotCaptureResult) => void) => () => void;
+    getShortcutState: () => Promise<import('../main/appshots/shortcutService').AppshotShortcutState>;
+    setShortcutPreferences: (
+      value: import('../shared/appshots').AppshotShortcutPreferences,
+    ) => Promise<import('../main/appshots/shortcutService').AppshotShortcutState>;
+    resetShortcutPreferences: () => Promise<import('../main/appshots/shortcutService').AppshotShortcutState>;
+    onShortcutStateChanged: (
+      callback: (state: import('../main/appshots/shortcutService').AppshotShortcutState) => void,
+    ) => () => void;
+  };
   windowMinimize: () => void;
   windowMaximize: () => void;
   windowClose: () => void;

--- a/apps/desktop/src/shared/__tests__/appshots.test.ts
+++ b/apps/desktop/src/shared/__tests__/appshots.test.ts
@@ -34,6 +34,23 @@ describe('Appshot metadata', () => {
     expect(coerceAppshotMetadata({ ...metadata, applicationName: 'a'.repeat(4097) })).toBeNull();
   });
 
+  it('accepts scalar fields at 4 KiB UTF-8 and rejects one code point above', () => {
+    const boundary = '🙂'.repeat(1024);
+    const oversized = `${boundary}🙂`;
+    const fields = [
+      'captureId',
+      'capturedAt',
+      'applicationName',
+      'bundleIdentifier',
+      'windowTitle',
+    ] as const;
+
+    for (const field of fields) {
+      expect(coerceAppshotMetadata({ ...metadata, [field]: boundary })?.[field]).toBe(boundary);
+      expect(coerceAppshotMetadata({ ...metadata, [field]: oversized })).toBeNull();
+    }
+  });
+
   it('rejects accessibility text over 512 KiB without truncating it', () => {
     expect(
       coerceAppshotMetadata({ ...metadata, accessibilityText: '🙂'.repeat(131_073) }),
@@ -46,6 +63,24 @@ describe('Appshot metadata', () => {
         'Window: ""Draft" &lt;1&gt;", App: A&amp;B.\n' +
         '<accessibility-tree>\n' +
         '&lt;AXButton title="Send &amp; close"&gt;\n' +
+        '</accessibility-tree>\n' +
+        '</appshot>',
+    );
+  });
+
+  it('removes XML-disallowed controls and unpaired surrogates', () => {
+    expect(
+      formatAppshotContext({
+        ...metadata,
+        applicationName: 'A\u0000\u0008\ud800B',
+        windowTitle: null,
+        accessibilityText: 'Send\u0000\u0008\udc00 now',
+      }),
+    ).toBe(
+      '<appshot app="AB" bundle-identifier="com.example.app">\n' +
+        'App: AB.\n' +
+        '<accessibility-tree>\n' +
+        'Send now\n' +
         '</accessibility-tree>\n' +
         '</appshot>',
     );

--- a/apps/desktop/src/shared/__tests__/appshots.test.ts
+++ b/apps/desktop/src/shared/__tests__/appshots.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_APPSHOT_SHORTCUT_PREFERENCES,
+  coerceAppshotMetadata,
+  formatAppshotContext,
+  formatAppshotShortcut,
+  isDualModifierSnapshot,
+  normalizeAppshotShortcut,
+  normalizeAppshotShortcutPreferences,
+  type AppshotMetadata,
+} from '../appshots';
+
+const metadata: AppshotMetadata = {
+  schemaVersion: 1,
+  captureId: 'capture-1',
+  capturedAt: '2026-08-05T00:00:00.000Z',
+  applicationName: 'A&B',
+  bundleIdentifier: 'com.example.app',
+  windowTitle: '"Draft" <1>',
+  accessibilityText: '<AXButton title="Send & close">',
+  accessibilityTruncated: false,
+};
+
+describe('Appshot metadata', () => {
+  it('coerces valid metadata into a fresh object', () => {
+    const normalized = coerceAppshotMetadata(metadata);
+    expect(normalized).toEqual(metadata);
+    expect(normalized).not.toBe(metadata);
+  });
+
+  it('rejects unsupported schemas and oversized scalar fields', () => {
+    expect(coerceAppshotMetadata({ ...metadata, schemaVersion: 2 })).toBeNull();
+    expect(coerceAppshotMetadata({ ...metadata, applicationName: 'a'.repeat(4097) })).toBeNull();
+  });
+
+  it('rejects accessibility text over 512 KiB without truncating it', () => {
+    expect(
+      coerceAppshotMetadata({ ...metadata, accessibilityText: '🙂'.repeat(131_073) }),
+    ).toBeNull();
+  });
+
+  it('formats escaped XML context', () => {
+    expect(formatAppshotContext(metadata)).toBe(
+      '<appshot app="A&amp;B" bundle-identifier="com.example.app" window-title="&quot;Draft&quot; &lt;1&gt;">\n' +
+        'Window: ""Draft" &lt;1&gt;", App: A&amp;B.\n' +
+        '<accessibility-tree>\n' +
+        '&lt;AXButton title="Send &amp; close"&gt;\n' +
+        '</accessibility-tree>\n' +
+        '</appshot>',
+    );
+  });
+});
+
+describe('Appshot shortcuts', () => {
+  it('matches exactly two sides of the requested modifier', () => {
+    expect(isDualModifierSnapshot(['MetaLeft', 'MetaRight'], 'command')).toBe(true);
+    expect(isDualModifierSnapshot(['MetaRight', 'MetaLeft'], 'command')).toBe(true);
+    expect(isDualModifierSnapshot(['AltLeft', 'AltRight'], 'option')).toBe(true);
+    expect(isDualModifierSnapshot(['ShiftLeft', 'ShiftRight'], 'shift')).toBe(true);
+    expect(isDualModifierSnapshot(['MetaLeft', 'MetaRight', 'KeyA'], 'command')).toBe(false);
+    expect(isDualModifierSnapshot(['MetaLeft', 'AltRight'], 'command')).toBe(false);
+  });
+
+  it('falls back to the full default preferences when malformed', () => {
+    const normalized = normalizeAppshotShortcutPreferences({
+      preferred: { kind: 'dual-modifier', modifier: 'command' },
+      fallback: { kind: 'accelerator', combo: { code: 'ShiftLeft', shift: true } },
+    });
+    expect(normalized).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+    expect(normalized).not.toBe(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES);
+    expect(normalized.preferred).not.toBe(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred);
+    expect(normalizeAppshotShortcut(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.fallback)).toEqual(
+      DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.fallback,
+    );
+    expect(formatAppshotShortcut(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred)).toBe(
+      'Double Command',
+    );
+    expect(formatAppshotShortcut(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.fallback, 'darwin')).toBe(
+      '⇧⌘A',
+    );
+  });
+});

--- a/apps/desktop/src/shared/agentInputQueue.ts
+++ b/apps/desktop/src/shared/agentInputQueue.ts
@@ -17,6 +17,11 @@ import {
   readAgentInputReferences,
   type AgentInputReference,
 } from '@cindy/maker-shared/agent-input-projection';
+import {
+  coerceAppshotMetadata,
+  formatAppshotContext,
+  type AppshotMetadata,
+} from './appshots';
 
 export type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
 
@@ -40,6 +45,7 @@ export interface AgentInputSerializedFile {
    * 在附件 block 后注入一句固定说明,告诉模型红色笔迹是用户标注、非原图内容。
    */
   annotated?: boolean;
+  appshot?: AppshotMetadata;
 }
 
 export interface AgentInputMention {
@@ -933,15 +939,20 @@ export function buildMakerUserMessage(
   let hasAnnotatedImage = false;
   for (const f of queued.files ?? []) {
     const type = getAgentInputAttachmentBlockType(f.category, f.ext);
+    const appshot = type === 'image' ? coerceAppshotMetadata(f.appshot) : null;
+    let block: { type: string; [k: string]: unknown };
     if (f.url) {
-      blocks.push({ type, path: f.url, mimeType: f.mimeType });
+      block = { type, path: f.url, mimeType: f.mimeType };
     } else if (f.path && !f.path.startsWith('clipboard://')) {
-      blocks.push({ type, path: f.path, mimeType: f.mimeType });
+      block = { type, path: f.path, mimeType: f.mimeType };
     } else if (f.base64) {
-      blocks.push({ type, base64: f.base64, mimeType: f.mimeType });
+      block = { type, base64: f.base64, mimeType: f.mimeType };
     } else {
       continue;
     }
+    if (appshot) block.appshot = appshot;
+    blocks.push(block);
+    if (appshot) blocks.push({ type: 'text', text: formatAppshotContext(appshot) });
     if (type === 'image' && f.annotated) hasAnnotatedImage = true;
   }
   // 标注说明放在全部附件 block 之后、每条消息至多一条:codex 侧 inputs 保序,

--- a/apps/desktop/src/shared/appshots.ts
+++ b/apps/desktop/src/shared/appshots.ts
@@ -10,7 +10,7 @@ export interface AppshotMetadata {
   windowTitle: string | null;
   accessibilityText: string | null;
   accessibilityTruncated: boolean;
-  accessibilityUnavailableReason?: 'permission' | 'unsupported' | 'timeout';
+  accessibilityUnavailableReason?: 'permission' | 'unsupported' | 'timeout' | 'removed';
 }
 
 export interface AppshotCaptureResult {
@@ -44,7 +44,7 @@ export const DEFAULT_APPSHOT_SHORTCUT_PREFERENCES: AppshotShortcutPreferences = 
 
 const MAX_SCALAR_LENGTH = 4 * 1024;
 const MAX_ACCESSIBILITY_BYTES = 512 * 1024;
-const UNAVAILABLE_REASONS = new Set(['permission', 'unsupported', 'timeout']);
+const UNAVAILABLE_REASONS = new Set(['permission', 'unsupported', 'timeout', 'removed']);
 
 function utf8ByteLength(value: string): number {
   return new TextEncoder().encode(value).byteLength;
@@ -95,7 +95,8 @@ export function coerceAppshotMetadata(value: unknown): AppshotMetadata | null {
           accessibilityUnavailableReason: raw.accessibilityUnavailableReason as
             | 'permission'
             | 'unsupported'
-            | 'timeout',
+            | 'timeout'
+            | 'removed',
         }
       : {}),
   };

--- a/apps/desktop/src/shared/appshots.ts
+++ b/apps/desktop/src/shared/appshots.ts
@@ -1,0 +1,205 @@
+import type { AppShortcutCombo } from './appShortcuts';
+import { formatAppShortcutCombo, normalizeAppShortcutCombo } from './appShortcuts';
+
+export interface AppshotMetadata {
+  schemaVersion: 1;
+  captureId: string;
+  capturedAt: string;
+  applicationName: string;
+  bundleIdentifier: string | null;
+  windowTitle: string | null;
+  accessibilityText: string | null;
+  accessibilityTruncated: boolean;
+  accessibilityUnavailableReason?: 'permission' | 'unsupported' | 'timeout';
+}
+
+export interface AppshotCaptureResult {
+  captureId: string;
+  image: {
+    url: string;
+    filename: string;
+    size: number;
+    mimeType: 'image/png';
+  };
+  metadata: AppshotMetadata;
+}
+
+export type AppshotDualModifier = 'command' | 'option' | 'shift';
+export type AppshotShortcut =
+  | { kind: 'dual-modifier'; modifier: AppshotDualModifier }
+  | { kind: 'accelerator'; combo: AppShortcutCombo };
+
+export interface AppshotShortcutPreferences {
+  preferred: AppshotShortcut;
+  fallback: AppshotShortcut;
+}
+
+export const DEFAULT_APPSHOT_SHORTCUT_PREFERENCES: AppshotShortcutPreferences = {
+  preferred: { kind: 'dual-modifier', modifier: 'command' },
+  fallback: {
+    kind: 'accelerator',
+    combo: { code: 'KeyA', meta: true, ctrl: false, alt: false, shift: true },
+  },
+};
+
+const MAX_SCALAR_LENGTH = 4 * 1024;
+const MAX_ACCESSIBILITY_BYTES = 512 * 1024;
+const UNAVAILABLE_REASONS = new Set(['permission', 'unsupported', 'timeout']);
+
+function isBoundedString(value: unknown, allowEmpty = true): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length <= MAX_SCALAR_LENGTH &&
+    (allowEmpty || value.length > 0)
+  );
+}
+
+export function coerceAppshotMetadata(value: unknown): AppshotMetadata | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  if (
+    raw.schemaVersion !== 1 ||
+    !isBoundedString(raw.captureId, false) ||
+    !isBoundedString(raw.capturedAt, false) ||
+    !isBoundedString(raw.applicationName, false) ||
+    !(raw.bundleIdentifier === null || isBoundedString(raw.bundleIdentifier)) ||
+    !(raw.windowTitle === null || isBoundedString(raw.windowTitle)) ||
+    !(
+      raw.accessibilityText === null ||
+      (typeof raw.accessibilityText === 'string' &&
+        new TextEncoder().encode(raw.accessibilityText).byteLength <= MAX_ACCESSIBILITY_BYTES)
+    ) ||
+    typeof raw.accessibilityTruncated !== 'boolean' ||
+    !(
+      raw.accessibilityUnavailableReason === undefined ||
+      UNAVAILABLE_REASONS.has(raw.accessibilityUnavailableReason as string)
+    )
+  ) {
+    return null;
+  }
+  return {
+    schemaVersion: 1,
+    captureId: raw.captureId,
+    capturedAt: raw.capturedAt,
+    applicationName: raw.applicationName,
+    bundleIdentifier: raw.bundleIdentifier,
+    windowTitle: raw.windowTitle,
+    accessibilityText: raw.accessibilityText,
+    accessibilityTruncated: raw.accessibilityTruncated,
+    ...(raw.accessibilityUnavailableReason !== undefined
+      ? {
+          accessibilityUnavailableReason: raw.accessibilityUnavailableReason as
+            | 'permission'
+            | 'unsupported'
+            | 'timeout',
+        }
+      : {}),
+  };
+}
+
+export function normalizeAppshotShortcut(value: unknown): AppshotShortcut | null {
+  if (!value || typeof value !== 'object') return null;
+  const raw = value as Record<string, unknown>;
+  if (
+    raw.kind === 'dual-modifier' &&
+    (raw.modifier === 'command' || raw.modifier === 'option' || raw.modifier === 'shift')
+  ) {
+    return { kind: 'dual-modifier', modifier: raw.modifier };
+  }
+  if (raw.kind === 'accelerator') {
+    const combo = normalizeAppShortcutCombo(raw.combo);
+    if (combo) return { kind: 'accelerator', combo };
+  }
+  return null;
+}
+
+function cloneDefaultPreferences(): AppshotShortcutPreferences {
+  return {
+    preferred: { kind: 'dual-modifier', modifier: 'command' },
+    fallback: {
+      kind: 'accelerator',
+      combo: { code: 'KeyA', meta: true, ctrl: false, alt: false, shift: true },
+    },
+  };
+}
+
+export function normalizeAppshotShortcutPreferences(value: unknown): AppshotShortcutPreferences {
+  if (!value || typeof value !== 'object') return cloneDefaultPreferences();
+  const raw = value as Record<string, unknown>;
+  const preferred = normalizeAppshotShortcut(raw.preferred);
+  const fallback = normalizeAppshotShortcut(raw.fallback);
+  return preferred && fallback ? { preferred, fallback } : cloneDefaultPreferences();
+}
+
+export function isDualModifierSnapshot(
+  keys: readonly string[],
+  modifier: AppshotDualModifier,
+): boolean {
+  const expected = {
+    command: ['MetaLeft', 'MetaRight'],
+    option: ['AltLeft', 'AltRight'],
+    shift: ['ShiftLeft', 'ShiftRight'],
+  }[modifier];
+  return keys.length === 2 && expected.every((key) => keys.includes(key));
+}
+
+export function formatAppshotShortcut(shortcut: AppshotShortcut, platform = 'darwin'): string {
+  if (shortcut.kind === 'accelerator') return formatAppShortcutCombo(shortcut.combo, platform);
+  return `Double ${shortcut.modifier[0].toUpperCase()}${shortcut.modifier.slice(1)}`;
+}
+
+function cleanXml(value: string): string {
+  let result = '';
+  for (const character of value) {
+    const codePoint = character.codePointAt(0) as number;
+    if (
+      codePoint === 0x9 ||
+      codePoint === 0xa ||
+      codePoint === 0xd ||
+      (codePoint >= 0x20 && codePoint <= 0xd7ff) ||
+      (codePoint >= 0xe000 && codePoint <= 0xfffd) ||
+      (codePoint >= 0x10000 && codePoint <= 0x10ffff)
+    ) {
+      result += character;
+    }
+  }
+  return result;
+}
+
+function escapeXmlText(value: string): string {
+  return cleanXml(value).replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function escapeXmlAttribute(value: string): string {
+  return escapeXmlText(value).replaceAll('"', '&quot;').replaceAll("'", '&apos;');
+}
+
+export function formatAppshotContext(metadata: AppshotMetadata): string {
+  const attributes = [`app="${escapeXmlAttribute(metadata.applicationName)}"`];
+  if (metadata.bundleIdentifier !== null) {
+    attributes.push(`bundle-identifier="${escapeXmlAttribute(metadata.bundleIdentifier)}"`);
+  }
+  if (metadata.windowTitle !== null) {
+    attributes.push(`window-title="${escapeXmlAttribute(metadata.windowTitle)}"`);
+  }
+
+  const lines = [`<appshot ${attributes.join(' ')}>`];
+  if (metadata.windowTitle !== null) {
+    lines.push(
+      `Window: "${escapeXmlText(metadata.windowTitle)}", App: ${escapeXmlText(metadata.applicationName)}.`,
+    );
+  } else {
+    lines.push(`App: ${escapeXmlText(metadata.applicationName)}.`);
+  }
+  if (metadata.accessibilityText !== null) {
+    lines.push(
+      '<accessibility-tree>',
+      escapeXmlText(metadata.accessibilityText),
+      '</accessibility-tree>',
+    );
+  } else if (metadata.accessibilityUnavailableReason) {
+    lines.push(`Accessibility unavailable: ${metadata.accessibilityUnavailableReason}.`);
+  }
+  lines.push('</appshot>');
+  return lines.join('\n');
+}

--- a/apps/desktop/src/shared/appshots.ts
+++ b/apps/desktop/src/shared/appshots.ts
@@ -46,10 +46,14 @@ const MAX_SCALAR_LENGTH = 4 * 1024;
 const MAX_ACCESSIBILITY_BYTES = 512 * 1024;
 const UNAVAILABLE_REASONS = new Set(['permission', 'unsupported', 'timeout']);
 
+function utf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
 function isBoundedString(value: unknown, allowEmpty = true): value is string {
   return (
     typeof value === 'string' &&
-    value.length <= MAX_SCALAR_LENGTH &&
+    utf8ByteLength(value) <= MAX_SCALAR_LENGTH &&
     (allowEmpty || value.length > 0)
   );
 }
@@ -67,7 +71,7 @@ export function coerceAppshotMetadata(value: unknown): AppshotMetadata | null {
     !(
       raw.accessibilityText === null ||
       (typeof raw.accessibilityText === 'string' &&
-        new TextEncoder().encode(raw.accessibilityText).byteLength <= MAX_ACCESSIBILITY_BYTES)
+        utf8ByteLength(raw.accessibilityText) <= MAX_ACCESSIBILITY_BYTES)
     ) ||
     typeof raw.accessibilityTruncated !== 'boolean' ||
     !(

--- a/docs/superpowers/plans/2026-08-05-codex-appshots.md
+++ b/docs/superpowers/plans/2026-08-05-codex-appshots.md
@@ -1,0 +1,952 @@
+# Codex Appshots for macOS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a macOS-only Codex Appshot workflow that captures the frontmost application window and bounded Accessibility structure, places the result in the current or a new local Codex composer, and supports configurable global preferred/fallback shortcuts without changing ordinary attachments, remote/mobile behavior, or the installed Cindy app.
+
+**Architecture:** A small Swift executable resolves and captures the frontmost macOS window, serializes a privacy-filtered AX tree, and writes one PNG into a Main-owned temporary directory. Desktop Main validates and ingests the result, owns a reload-safe capture inbox and shortcut state, then the Renderer reuses Cindy's existing draft and attachment paths. Appshot metadata remains attached to the existing image reference; both direct and queued Codex sends append the same escaped context block, while Main rejects metadata at non-Codex boundaries.
+
+**Tech Stack:** Electron Main/Preload/Renderer, TypeScript, React, Vitest, Swift 5, AppKit, ApplicationServices, ScreenCaptureKit, CoreGraphics, existing Cindy media store and composer draft store.
+
+**Required worker skills:** Use `test-driven-development` for every task, `systematic-debugging` for any unexpected failure, `verification-before-completion` before completion claims, and `requesting-code-review` after all implementation tasks. Keep Ponytail full mode active: reuse existing media, draft, IPC trust, permission, and native-key-listener paths; add no dependency and no database migration.
+
+---
+
+## File map
+
+- Create `apps/desktop/src/shared/appshots.ts`: wire types, shortcut preferences, validation, dual-modifier matching, XML escaping, and Appshot context formatting.
+- Create `apps/desktop/src/shared/__tests__/appshots.test.ts`: shared contract, privacy-safe formatting, and shortcut gesture tests.
+- Modify `apps/desktop/src/renderer/lib/fileTypes.ts`: optional Appshot metadata on editable and serialized image attachments.
+- Modify `apps/desktop/src/renderer/lib/imageRef.ts`: persist and coerce optional Appshot metadata inside the existing image JSON.
+- Modify `apps/desktop/src/renderer/lib/messageAttachmentPayload.ts`: preserve metadata and append Appshot context to direct sends.
+- Modify `apps/desktop/src/shared/agentInputQueue.ts`: preserve metadata and append the same context to queued/steered sends.
+- Modify existing attachment/message tests under `apps/desktop/src/renderer/__tests__` and `apps/desktop/src/main/__tests__`.
+- Create `apps/desktop/native/appshots/macos-appshot-helper.swift`: frontmost-window capture, AX traversal, redaction, bounds, JSON protocol, and deterministic self-test.
+- Modify `apps/desktop/forge.config.ts`: compile and package the Appshot helper for macOS 14+.
+- Create `apps/desktop/src/main/appshots/MacAppshotNativeHost.ts`: resolve/build/run the helper and parse its one-shot response.
+- Create `apps/desktop/src/main/appshots/coordinator.ts`: in-flight guard, private temporary root, validation, media ingest, pending inbox, stable failures, and trusted IPC.
+- Create `apps/desktop/src/main/appshots/__tests__/coordinator.test.ts`: malformed output, path escape, PNG, size, permissions, inbox, and concurrency tests.
+- Create `apps/desktop/src/main/appshots/shortcutStore.ts`: preferred/fallback persistence and normalization.
+- Create `apps/desktop/src/main/appshots/shortcutService.ts`: effective shortcut registration, Codex conflict fallback, notifications, and capture trigger.
+- Create `apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts`: persistence, fallback, restoration, and dual-modifier dispatch tests.
+- Modify `apps/desktop/src/main/voice-input/global.ts`: expose ref-counted subscribers from the existing native key snapshot listener; do not create a second event tap.
+- Modify `apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts`: verify voice input and Appshots receive independent snapshots.
+- Modify `apps/desktop/src/main/bootstrap-electron.ts`: construct Appshots services, register IPC, focus the main window after capture, and stop services on quit.
+- Modify `apps/desktop/src/preload/preload.ts` and `apps/desktop/src/renderer/vite-env.d.ts`: expose typed Appshots capture/inbox/settings methods only.
+- Create `apps/desktop/src/renderer/features/appshots/appshotInbox.ts`: exactly-once attachment and Codex/new-draft routing.
+- Create `apps/desktop/src/renderer/features/appshots/__tests__/appshotInbox.test.ts`: current-Codex and new-Codex routing tests.
+- Modify `apps/desktop/src/renderer/hooks/useAttachments.ts`: add a validated, already-cached Appshot as an ordinary image attachment.
+- Modify `apps/desktop/src/renderer/components/new-chat/ExtraDirsButton.tsx`: optional Appshot attachment-menu action.
+- Modify `apps/desktop/src/renderer/components/new-chat/ChatInput.tsx`: Codex/local/macOS gate and Appshot card presentation.
+- Modify `apps/desktop/src/renderer/components/layout/MainLayout.tsx`: subscribe to and drain the Main-owned Appshot inbox.
+- Modify `apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx`: preserve Appshot metadata when draft images are rehomed.
+- Modify `apps/desktop/src/renderer/state/newMakerDraft.ts`: route fallback captures to a local Codex draft without creating a durable session.
+- Modify `apps/desktop/src/renderer/components/settings/KeyboardShortcutsSection.tsx`: preferred/fallback Appshot shortcut rows and effective-state display.
+- Modify `apps/desktop/src/renderer/i18n/locales/{en,zh-CN,ja,ko}/common.json`: Appshot menu, card, errors, permissions, and shortcut text.
+- Modify `apps/desktop/src/main/maker-ipc/register.ts`: fail closed when Appshot metadata reaches a non-Codex direct, enqueue, or steer boundary.
+
+### Task 1: Shared Appshot contract and attachment persistence
+
+**Files:**
+- Create: `apps/desktop/src/shared/appshots.ts`
+- Create: `apps/desktop/src/shared/__tests__/appshots.test.ts`
+- Modify: `apps/desktop/src/renderer/lib/fileTypes.ts`
+- Modify: `apps/desktop/src/renderer/lib/imageRef.ts`
+- Modify: `apps/desktop/src/renderer/lib/messageAttachmentPayload.ts`
+- Modify: `apps/desktop/src/shared/agentInputQueue.ts`
+- Modify: `apps/desktop/src/renderer/__tests__/imageRefParseUserContent.test.ts`
+- Modify: `apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/agentInputQueue.test.ts`
+
+- [ ] **Step 1: Write failing shared contract and persistence tests**
+
+```ts
+const metadata: AppshotMetadata = {
+  schemaVersion: 1,
+  captureId: 'capture-1',
+  capturedAt: '2026-08-05T00:00:00.000Z',
+  applicationName: 'A&B',
+  bundleIdentifier: 'com.example.app',
+  windowTitle: '"Draft" <1>',
+  accessibilityText: '<AXButton title="Send & close">',
+  accessibilityTruncated: false,
+};
+
+expect(coerceAppshotMetadata(metadata)).toEqual(metadata);
+expect(formatAppshotContext(metadata)).toContain(
+  'app="A&amp;B" bundle-identifier="com.example.app" window-title="&quot;Draft&quot; &lt;1&gt;"',
+);
+expect(formatAppshotContext(metadata)).toContain(
+  '&lt;AXButton title=&quot;Send &amp; close&quot;&gt;',
+);
+expect(coerceAppshotMetadata({ ...metadata, schemaVersion: 2 })).toBeNull();
+```
+
+Add one round-trip assertion to `imageRefParseUserContent.test.ts`, one direct-send assertion to `messageAttachmentPayload.test.ts`, and one queued-send assertion to `agentInputQueue.test.ts`: each must retain `appshot`, emit one image block, and emit exactly one escaped `<appshot>` text block after the image.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/shared/__tests__/appshots.test.ts \
+  src/renderer/__tests__/imageRefParseUserContent.test.ts \
+  src/renderer/__tests__/messageAttachmentPayload.test.ts \
+  src/main/__tests__/agentInputQueue.test.ts
+```
+
+Expected: FAIL because `AppshotMetadata`, coercion/formatting, and persisted fields do not exist.
+
+- [ ] **Step 3: Add the minimal shared types, validation, and formatter**
+
+Implement these exact public contracts in `shared/appshots.ts`:
+
+```ts
+import type { AppShortcutCombo } from './appShortcuts';
+
+export interface AppshotMetadata {
+  schemaVersion: 1;
+  captureId: string;
+  capturedAt: string;
+  applicationName: string;
+  bundleIdentifier: string | null;
+  windowTitle: string | null;
+  accessibilityText: string | null;
+  accessibilityTruncated: boolean;
+  accessibilityUnavailableReason?: 'permission' | 'unsupported' | 'timeout';
+}
+
+export interface AppshotCaptureResult {
+  captureId: string;
+  image: {
+    url: string;
+    filename: string;
+    size: number;
+    mimeType: 'image/png';
+  };
+  metadata: AppshotMetadata;
+}
+
+export type AppshotDualModifier = 'command' | 'option' | 'shift';
+export type AppshotShortcut =
+  | { kind: 'dual-modifier'; modifier: AppshotDualModifier }
+  | { kind: 'accelerator'; combo: AppShortcutCombo };
+
+export interface AppshotShortcutPreferences {
+  preferred: AppshotShortcut;
+  fallback: AppshotShortcut;
+}
+
+export const DEFAULT_APPSHOT_SHORTCUT_PREFERENCES: AppshotShortcutPreferences = {
+  preferred: { kind: 'dual-modifier', modifier: 'command' },
+  fallback: {
+    kind: 'accelerator',
+    combo: { code: 'KeyA', meta: true, ctrl: false, alt: false, shift: true },
+  },
+};
+
+export function coerceAppshotMetadata(value: unknown): AppshotMetadata | null;
+export function normalizeAppshotShortcut(value: unknown): AppshotShortcut | null;
+export function normalizeAppshotShortcutPreferences(value: unknown): AppshotShortcutPreferences;
+export function isDualModifierSnapshot(keys: readonly string[], modifier: AppshotDualModifier): boolean;
+export function formatAppshotShortcut(shortcut: AppshotShortcut, platform?: string): string;
+export function formatAppshotContext(metadata: AppshotMetadata): string;
+```
+
+Use exact side pairs `MetaLeft+MetaRight`, `AltLeft+AltRight`, or `ShiftLeft+ShiftRight`; reject snapshots containing any third key. Escape `&`, `<`, `>`, `"`, and `'` in attributes; escape `&`, `<`, and `>` in Accessibility text; remove disallowed XML control characters. Bound coercion to the approved limits: identifiers/names/titles at 4 KiB each and Accessibility text at 512 KiB.
+
+- [ ] **Step 4: Thread `appshot?: AppshotMetadata` through existing image shapes**
+
+Add the same optional property to `AttachedFile`, `SerializedAttachedFile`, `ImageRef`, and `AgentInputSerializedFile`. In `serializeAttachedFiles`, `buildImageAttachment`, and `coerceImageRef`, copy only metadata accepted by `coerceAppshotMetadata`.
+
+Append context in both send builders:
+
+```ts
+for (const file of files ?? []) {
+  const block = buildAttachmentBlock(file);
+  if (block) blocks.push(block);
+  if (block?.type === 'image' && file.appshot) {
+    blocks.push({ type: 'text', text: formatAppshotContext(file.appshot) });
+  }
+}
+```
+
+Use the same `formatAppshotContext` call in `shared/agentInputQueue.ts`; do not duplicate formatting logic. Preserve `appshot` in persisted image refs so draft reload and lazy session creation retain it.
+
+- [ ] **Step 5: Re-run focused tests and verify GREEN**
+
+Run the Step 2 command. Expected: all four files PASS, with ordinary-image assertions unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/src/shared/appshots.ts \
+  apps/desktop/src/shared/__tests__/appshots.test.ts \
+  apps/desktop/src/shared/agentInputQueue.ts \
+  apps/desktop/src/main/__tests__/agentInputQueue.test.ts \
+  apps/desktop/src/renderer/lib/fileTypes.ts \
+  apps/desktop/src/renderer/lib/imageRef.ts \
+  apps/desktop/src/renderer/lib/messageAttachmentPayload.ts \
+  apps/desktop/src/renderer/__tests__/imageRefParseUserContent.test.ts \
+  apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts
+git commit -m "feat: add Appshot attachment contract"
+```
+
+### Task 2: Native macOS Appshot helper and package build
+
+**Files:**
+- Create: `apps/desktop/native/appshots/macos-appshot-helper.swift`
+- Modify: `apps/desktop/forge.config.ts`
+
+- [ ] **Step 1: Add a deterministic self-test before live capture code**
+
+The helper must support:
+
+```swift
+if CommandLine.arguments.contains("--self-test") {
+  let secure = AXNode(role: "AXSecureTextField", label: "Password", value: "secret")
+  let output = serializeAccessibilityTree(root: secure, limits: .test)
+  precondition(output.text.contains("Secure text field"))
+  precondition(!output.text.contains("secret"))
+  precondition(output.truncated)
+  emitJSON(["type": "self-test", "ok": true])
+  exit(0)
+}
+```
+
+Use in-memory `AXNode` fixtures so this mode opens no permission prompt and verifies secure-field redaction plus node, depth, byte, and deadline truncation.
+
+- [ ] **Step 2: Compile and run the self-test to verify RED**
+
+Run:
+
+```bash
+xcrun swiftc apps/desktop/native/appshots/macos-appshot-helper.swift \
+  -O -target arm64-apple-macos14.0 \
+  -o /tmp/cindy-macos-appshot-helper
+/tmp/cindy-macos-appshot-helper --self-test
+```
+
+Expected: compile FAIL until the helper and serializer are implemented.
+
+- [ ] **Step 3: Implement the one-shot helper protocol**
+
+The command line is fixed and Main-owned:
+
+```text
+xdt-macos-appshot-helper --output-dir /private/.../cindy-appshot-XXXXXX
+```
+
+Emit one sorted-key JSON object to stdout:
+
+```swift
+struct CaptureResponse: Codable {
+  let type: String                 // "capture"
+  let pngPath: String
+  let applicationName: String
+  let bundleIdentifier: String?
+  let windowTitle: String?
+  let accessibilityText: String?
+  let accessibilityTruncated: Bool
+  let accessibilityUnavailableReason: String?
+}
+```
+
+Implement these concrete functions:
+
+```swift
+func frontmostTarget() throws -> (app: NSRunningApplication, window: SCWindow, axWindow: AXUIElement?)
+func captureWindow(_ window: SCWindow, to outputURL: URL) async throws -> CGImage
+func serializeAccessibilityWindow(_ window: AXUIElement?, startedAt: ContinuousClock.Instant) -> AXSerialization
+func isBlankImage(_ image: CGImage) -> Bool
+func validatedOutputURL(argument: String) throws -> URL
+```
+
+`frontmostTarget()` snapshots `NSWorkspace.shared.frontmostApplication` first, selects its focused AX window when available, then matches a visible layer-zero `SCWindow` by PID, title, and bounds. Reject desktop elements, zero/degenerate bounds, alpha-zero windows, closed targets, and captures with no visible pixel variance. `captureWindow` uses `SCScreenshotManager.captureImage` with `SCContentFilter(desktopIndependentWindow:)` and PNG encoding.
+
+AX traversal must be deterministic pre-order, maximum 2,000 nodes, depth 16, UTF-8 output 512 KiB, and elapsed time 1.5 seconds. Include non-empty role, label, title, value, description, enabled, selected, and focused fields. For `AXSecureTextField`, emit only role and `label="Secure text field"`; omit protected values. Accessibility denial degrades to `accessibilityUnavailableReason: "permission"`; screen-capture denial exits with stable stderr code `APPSHOT_SCREEN_PERMISSION` and creates no PNG.
+
+- [ ] **Step 4: Add Forge compilation and resource packaging**
+
+Add:
+
+```ts
+const MACOS_APPSHOT_HELPER_DEPLOYMENT_TARGET = 'macos14.0';
+
+function buildMacAppshotHelper(platform: ForgePlatform, arch: ForgeArch): void {
+  if (process.platform !== 'darwin' || !isMacForgePlatform(platform)) return;
+  const src = path.join(__dirname, 'native', 'appshots', 'macos-appshot-helper.swift');
+  const destDir = path.join(__dirname, 'resources', 'tools', 'appshots');
+  const dest = path.join(destDir, 'xdt-macos-appshot-helper');
+  if (!fs.existsSync(src)) throw new Error(`[forge] macOS Appshot helper source missing at ${src}`);
+  fs.mkdirSync(destDir, { recursive: true });
+  buildSwiftHelperForForgeArch(
+    src,
+    dest,
+    arch,
+    MACOS_APPSHOT_HELPER_DEPLOYMENT_TARGET,
+    ['-O'],
+    'Appshot helper',
+  );
+  fs.chmodSync(dest, 0o755);
+}
+```
+
+Call `buildMacAppshotHelper(platform, arch)` once in `prePackage`, next to the other Swift helpers. Do not add a package.
+
+- [ ] **Step 5: Verify helper and Forge configuration**
+
+Run the Step 2 command. Expected stdout: `{"ok":true,"type":"self-test"}`.
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/desktop/native/appshots/macos-appshot-helper.swift apps/desktop/forge.config.ts
+git commit -m "feat: capture macOS Appshots natively"
+```
+
+### Task 3: Main-process host, validation, inbox, and trusted IPC
+
+**Files:**
+- Create: `apps/desktop/src/main/appshots/MacAppshotNativeHost.ts`
+- Create: `apps/desktop/src/main/appshots/coordinator.ts`
+- Create: `apps/desktop/src/main/appshots/__tests__/coordinator.test.ts`
+- Modify: `apps/desktop/src/main/bootstrap-electron.ts`
+- Modify: `apps/desktop/src/preload/preload.ts`
+- Modify: `apps/desktop/src/renderer/vite-env.d.ts`
+
+- [ ] **Step 1: Write failing coordinator boundary tests**
+
+Build one test group around injected dependencies and assert:
+
+```ts
+await expect(coordinator.capture()).rejects.toMatchObject({ code: 'PRECONDITION_FAILED' });
+expect(nativeHost.capture).toHaveBeenCalledTimes(1); // two overlapping calls
+expect(ingestImage).not.toHaveBeenCalled();         // bad PNG/path/oversize
+expect(coordinator.listPending()).toEqual([validCapture]);
+coordinator.ack(validCapture.captureId);
+expect(coordinator.listPending()).toEqual([]);
+```
+
+Cover malformed JSON fields, `pngPath` outside the private root, symlink escape after `realpath`, wrong eight-byte PNG signature, file larger than 100 MiB, screen-permission failure, accessibility-only degradation, and no captured content in logs.
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/main/appshots/__tests__/coordinator.test.ts
+```
+
+Expected: FAIL because the host/coordinator do not exist.
+
+- [ ] **Step 3: Implement the native host and validator**
+
+Use these exact public APIs:
+
+```ts
+export interface MacAppshotNativeResult {
+  pngPath: string;
+  applicationName: string;
+  bundleIdentifier: string | null;
+  windowTitle: string | null;
+  accessibilityText: string | null;
+  accessibilityTruncated: boolean;
+  accessibilityUnavailableReason?: 'permission' | 'unsupported' | 'timeout';
+}
+
+export class MacAppshotNativeHost {
+  capture(outputDir: string): Promise<MacAppshotNativeResult>;
+}
+```
+
+Packaged binary: `path.join(process.resourcesPath, 'tools', 'appshots', 'xdt-macos-appshot-helper')`. Development binary: source-hashed build under `app.getPath('userData')/appshots/xdt-macos-appshot-helper`, following `MacComputerPermissionGuideNativeHost` and compiling with `swiftc -O`. Use `execFile`, a 10-second timeout, 1 MiB JSON stdout cap, and stable error-code mapping; never log stdout/stderr content from the captured app.
+
+- [ ] **Step 4: Implement coordinator capture and reload-safe pending inbox**
+
+Use dependency injection and these contracts:
+
+```ts
+export type AppshotFailureCode =
+  | 'unsupported-platform'
+  | 'capture-in-progress'
+  | 'screen-permission'
+  | 'no-window'
+  | 'window-closed'
+  | 'protected-content'
+  | 'native-failure';
+
+export interface AppshotCoordinatorDeps {
+  captureNative: (outputDir: string) => Promise<MacAppshotNativeResult>;
+  ingestPng: (bytes: Uint8Array) => Promise<{ url: string; filename: string }>;
+  makeTempDir: () => Promise<string>;
+  removeTempDir: (path: string) => Promise<void>;
+  now: () => Date;
+  randomUUID: () => string;
+  publish: (result: AppshotCaptureResult) => void;
+}
+
+export class AppshotCoordinator {
+  capture(): Promise<AppshotCaptureResult>;
+  listPending(): readonly AppshotCaptureResult[];
+  ack(captureId: string): boolean;
+  clear(): void;
+}
+```
+
+`capture()` allows one in-flight operation, creates a private `mkdtemp` directory with mode `0700`, resolves `realpath` for root/file, verifies containment, regular-file status, size `1..100 MiB`, and PNG signature `89 50 4E 47 0D 0A 1A 0A`, reads bytes once, ingests through `cindyChatAttachments.ingestChatImageBuffer`, stores a maximum of ten pending results, publishes only metadata plus the managed media URL, and removes the temp root in `finally`.
+
+- [ ] **Step 5: Register trusted IPC and preload surface**
+
+Expose only:
+
+```ts
+appshots: {
+  capture: (): Promise<{ accepted: true }>;
+  listPending: (): Promise<AppshotCaptureResult[]>;
+  ack: (captureId: string): Promise<{ acknowledged: boolean }>;
+  onCaptured: (callback: (result: AppshotCaptureResult) => void) => () => void;
+}
+```
+
+IPC channels are `appshots:capture`, `appshots:list-pending`, `appshots:ack`, and `appshots:captured`. Every inbound handler calls `assertTrustedAppRendererEvent`; `ack` validates a non-empty capture ID. Publish only to `mainWindowRef` after `isTrustedAppRendererWindow` passes. `capture` accepts no PID, window ID, file path, or output path.
+
+In `bootstrap-electron.ts`, wire `ingestPng` to `cindyChatAttachments.ingestChatImageBuffer({ buffer, mimeType: 'image/png' })`, call `focusMainWindow()` only after successful capture, and clear pending state on `will-quit`.
+
+- [ ] **Step 6: Re-run coordinator tests and typecheck**
+
+Run the Step 2 command, then Desktop typecheck. Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/main/appshots \
+  apps/desktop/src/main/bootstrap-electron.ts \
+  apps/desktop/src/preload/preload.ts \
+  apps/desktop/src/renderer/vite-env.d.ts
+git commit -m "feat: coordinate Appshot capture securely"
+```
+
+### Task 4: Preferred/fallback global shortcuts using the existing native listener
+
+**Files:**
+- Create: `apps/desktop/src/main/appshots/shortcutStore.ts`
+- Create: `apps/desktop/src/main/appshots/shortcutService.ts`
+- Create: `apps/desktop/src/main/appshots/__tests__/shortcutService.test.ts`
+- Modify: `apps/desktop/src/main/voice-input/global.ts`
+- Modify: `apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts`
+- Modify: `apps/desktop/src/main/bootstrap-electron.ts`
+- Modify: `apps/desktop/src/preload/preload.ts`
+- Modify: `apps/desktop/src/renderer/vite-env.d.ts`
+
+- [ ] **Step 1: Write failing shortcut behavior tests**
+
+Assert these transitions with fake `globalShortcut`, running-app snapshots, key snapshots, and JSON storage:
+
+```ts
+expect(service.state().configured).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred);
+expect(service.state().active).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.preferred);
+
+runningBundleIds.add('com.openai.codex');
+service.refreshConflicts();
+expect(service.state().active).toEqual(DEFAULT_APPSHOT_SHORTCUT_PREFERENCES.fallback);
+
+keys.emit(['MetaLeft', 'MetaRight']);
+keys.emit(['MetaLeft', 'MetaRight']);
+expect(capture).toHaveBeenCalledTimes(1); // rising edge only
+keys.emit([]);
+keys.emit(['MetaLeft', 'MetaRight']);
+expect(capture).toHaveBeenCalledTimes(2);
+```
+
+Also assert preferred restoration after Codex exits, fallback after Electron rejects a conventional registration, disabled global trigger when both fail, preference persistence across reload, and manual capture remaining available.
+
+- [ ] **Step 2: Run shortcut tests and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/main/appshots/__tests__/shortcutService.test.ts \
+  src/main/voice-input/__tests__/globalShortcut.test.ts
+```
+
+Expected: Appshots shortcut tests FAIL; existing voice tests remain green.
+
+- [ ] **Step 3: Implement the dedicated preference store**
+
+Persist only user values in `appshots-shortcuts.v1.json` under `app.getPath('userData')`:
+
+```ts
+export interface AppshotShortcutStoreDeps {
+  getFilePath: () => string;
+  readFile: (path: string) => string;
+  writeFileAtomic: (path: string, value: string) => void;
+}
+
+export class AppshotShortcutStore {
+  get(): AppshotShortcutPreferences;
+  set(next: unknown): AppshotShortcutPreferences;
+  reset(): AppshotShortcutPreferences;
+}
+```
+
+Normalize with `normalizeAppshotShortcutPreferences`; reject preferred/fallback equality and system-reserved conventional combinations. Defaults remain code-owned and are not written until the user customizes them.
+
+- [ ] **Step 4: Share the existing key snapshot process**
+
+In `voice-input/global.ts`, add a ref-counted subscriber set around the existing `macModifierShortcutListener`:
+
+```ts
+type MacModifierSnapshotSubscriber = (keys: readonly string[]) => void;
+const macModifierSnapshotSubscribers = new Map<string, MacModifierSnapshotSubscriber>();
+
+export async function retainMacModifierKeySnapshots(
+  owner: string,
+  subscriber: MacModifierSnapshotSubscriber,
+): Promise<() => void> {
+  macModifierSnapshotSubscribers.set(owner, subscriber);
+  const started = await macModifierShortcutListener.startKeyCapture();
+  if (!started.ok) {
+    macModifierSnapshotSubscribers.delete(owner);
+    throw new Error(started.error);
+  }
+  return () => {
+    macModifierSnapshotSubscribers.delete(owner);
+    if (macModifierSnapshotSubscribers.size === 0 && modifierShortcutRecordingWebContentsIds.size === 0) {
+      macModifierShortcutListener.stopKeyCapture();
+    }
+  };
+}
+```
+
+Dispatch every `onKeys` snapshot to both the existing recording windows and a copied subscriber list. Update `stopNativeShortcutListenerPreservingCapture()` to preserve the helper while either recordings or subscribers exist. Do not instantiate another `MacModifierShortcutListener` and do not modify the Swift listener.
+
+- [ ] **Step 5: Implement effective shortcut service**
+
+```ts
+export interface AppshotShortcutState {
+  preferences: AppshotShortcutPreferences;
+  configured: AppshotShortcut;
+  active: AppshotShortcut | null;
+  fallbackReason?: 'codex-running' | 'registration-conflict' | 'input-monitoring';
+}
+
+export class AppshotShortcutService {
+  start(): Promise<void>;
+  stop(): void;
+  state(): AppshotShortcutState;
+  setPreferences(value: unknown): Promise<AppshotShortcutState>;
+  reset(): Promise<AppshotShortcutState>;
+  refreshConflicts(): Promise<void>;
+}
+```
+
+For a dual-modifier shortcut, retain the shared snapshots and trigger capture only on false-to-true exact-pair transitions. For a conventional shortcut, convert its existing `AppShortcutCombo` with `comboToElectronAccelerator` and register via Electron. Treat a running `NSRunningApplication`/`app.getApplicationNameForProtocol` equivalent with bundle ID `com.openai.codex` as a conflict only for dual-modifier preferred shortcuts; activate fallback while it runs and retry preferred when workspace application activation/termination events indicate a change. On capture failure, publish only stable codes.
+
+- [ ] **Step 6: Add trusted settings IPC and lifecycle wiring**
+
+Extend preload API:
+
+```ts
+getShortcutState: (): Promise<AppshotShortcutState>;
+setShortcutPreferences: (value: AppshotShortcutPreferences) => Promise<AppshotShortcutState>;
+resetShortcutPreferences: () => Promise<AppshotShortcutState>;
+onShortcutStateChanged: (callback: (state: AppshotShortcutState) => void) => () => void;
+```
+
+All handlers require a trusted Renderer. Start after app readiness and the shared voice listener is registered; stop and unregister accelerators on `will-quit`. Cindy fully quit therefore leaves no shortcut process or registration.
+
+- [ ] **Step 7: Re-run tests and commit**
+
+Run Step 2 and Desktop typecheck. Expected: PASS.
+
+```bash
+git add apps/desktop/src/main/appshots \
+  apps/desktop/src/main/voice-input/global.ts \
+  apps/desktop/src/main/voice-input/__tests__/globalShortcut.test.ts \
+  apps/desktop/src/main/bootstrap-electron.ts \
+  apps/desktop/src/preload/preload.ts \
+  apps/desktop/src/renderer/vite-env.d.ts
+git commit -m "feat: add Appshot global shortcuts"
+```
+
+### Task 5: Renderer inbox, Codex-only composer action, and Appshot card
+
+**Files:**
+- Create: `apps/desktop/src/renderer/features/appshots/appshotInbox.ts`
+- Create: `apps/desktop/src/renderer/features/appshots/__tests__/appshotInbox.test.ts`
+- Modify: `apps/desktop/src/renderer/hooks/useAttachments.ts`
+- Modify: `apps/desktop/src/renderer/components/new-chat/ExtraDirsButton.tsx`
+- Modify: `apps/desktop/src/renderer/components/new-chat/ChatInput.tsx`
+- Modify: `apps/desktop/src/renderer/components/layout/MainLayout.tsx`
+- Modify: `apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx`
+- Modify: `apps/desktop/src/renderer/state/newMakerDraft.ts`
+
+- [ ] **Step 1: Write failing exactly-once routing tests**
+
+Test a pure injected router:
+
+```ts
+const current = routeAppshotCapture(result, {
+  route: '/cc-agent/codex-session',
+  resolveSession: () => ({ id: 'codex-session', agentKind: 'codex', writable: true, local: true }),
+  appendDraftAttachment,
+  openNewCodexDraft,
+});
+expect(current).toEqual({ destination: 'session', key: 'codex-session' });
+
+routeAppshotCapture(result, nonCodexContext);
+expect(openNewCodexDraft).toHaveBeenCalledWith(expect.objectContaining({ vendor: 'codex' }));
+expect(appendDraftAttachment).toHaveBeenCalledWith(NEW_MAKER_DRAFT_KEY, expect.anything());
+
+expect(consumeCaptureTwice(result)).toEqual(['attached', 'duplicate']);
+```
+
+Cover writable local Codex, read-only/running remote/non-Codex/no-session fallback, and capture-ID deduplication.
+
+- [ ] **Step 2: Run inbox tests and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/renderer/features/appshots/__tests__/appshotInbox.test.ts
+```
+
+Expected: FAIL because the inbox router does not exist.
+
+- [ ] **Step 3: Add an already-cached Appshot to attachment state**
+
+Extend `UseAttachmentsReturn` and `ChatInput`'s explicit attachment-state type:
+
+```ts
+addAppshot: (result: AppshotCaptureResult) => Promise<void>;
+```
+
+Implementation creates one normal image attachment without recaching bytes:
+
+```ts
+const addAppshot = useCallback(async (result: AppshotCaptureResult) => {
+  const attachment: AttachedFile = {
+    id: result.captureId,
+    name: result.image.filename,
+    path: `appshot://${result.captureId}`,
+    ext: '.png',
+    size: result.image.size,
+    category: 'image',
+    mimeType: 'image/png',
+    url: result.image.url,
+    originalName: result.image.filename,
+    appshot: result.metadata,
+  };
+  setAttachments((current) => current.some((file) => file.appshot?.captureId === result.captureId)
+    ? current
+    : [...current, attachment]);
+}, []);
+```
+
+Keep `appshot` untouched in `rehomeDraftAttachments`; object-spread URL replacement already preserves it, so add a regression assertion rather than a new branch.
+
+- [ ] **Step 4: Implement inbox routing and MainLayout subscription**
+
+`appshotInbox.ts` exports:
+
+```ts
+export function toAppshotAttachment(result: AppshotCaptureResult): AttachedFile;
+export function routeAppshotCapture(result: AppshotCaptureResult, context: AppshotRouteContext): AppshotRouteResult;
+export function installAppshotInbox(context: AppshotRouteContext): () => void;
+```
+
+`installAppshotInbox` drains `listPending()` at mount, subscribes to `onCaptured`, tracks capture IDs while a consume is in flight, writes the attachment first, then calls `ack`; failed writes remain pending for reload recovery.
+
+Current-session routing accepts only a writable local `agentKind === 'codex'` route. Otherwise call `patchDraft` with `{ vendor: 'codex', workingDir: null, remoteHostId: null, deviceLinkDeviceId: null, deviceLinkDeviceName: null, extraDirs: [] }`, append to `NEW_MAKER_DRAFT_KEY` while preserving existing text/attachments, and navigate to `/cc-agent/new`. This uses existing lazy-create and never sends a message.
+
+- [ ] **Step 5: Add Codex-only attachment menu action and card**
+
+Extend `ExtraDirsButtonProps`:
+
+```ts
+onCaptureAppshot?: () => void | Promise<void>;
+```
+
+Show the menu item only when provided. In `ChatInput`, provide it only when all are true: `process.platform` reported through existing platform state is `darwin`, the composer is local, `agentKind === 'codex'`, and mutations are unlocked. Handler calls `window.electronAPI.appshots.capture()`; it does not attach from the response and does not send.
+
+In `ThumbnailItem`, when `file.appshot` exists, render application name, window title fallback, existing image preview, and existing remove action. Keep lightbox and ordinary-image behavior unchanged.
+
+- [ ] **Step 6: Re-run Renderer tests and typecheck**
+
+Run Step 2, then:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/renderer/__tests__/useAttachmentsRejections.test.ts \
+  src/renderer/__tests__/messageAttachmentPayload.test.ts
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/desktop/src/renderer/features/appshots \
+  apps/desktop/src/renderer/hooks/useAttachments.ts \
+  apps/desktop/src/renderer/components/new-chat/ExtraDirsButton.tsx \
+  apps/desktop/src/renderer/components/new-chat/ChatInput.tsx \
+  apps/desktop/src/renderer/components/layout/MainLayout.tsx \
+  apps/desktop/src/renderer/features/cc-agent/NewMakerDraftRoute.tsx \
+  apps/desktop/src/renderer/state/newMakerDraft.ts
+git commit -m "feat: route Appshots into Codex drafts"
+```
+
+### Task 6: Codex-only send boundary and non-Codex fail-closed enforcement
+
+**Files:**
+- Modify: `apps/desktop/src/main/maker-ipc/register.ts`
+- Create: `apps/desktop/src/main/maker-ipc/__tests__/appshotBoundary.test.ts`
+- Modify: `apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts`
+- Modify: `apps/desktop/src/main/__tests__/agentInputQueue.test.ts`
+
+- [ ] **Step 1: Write failing boundary tests**
+
+Test exported pure validation before IPC wiring:
+
+```ts
+expect(validateAndStripAppshotMetadata(codexMessage, 'codex')).toEqual(messageWithoutInternalMetadata);
+expect(() => validateAndStripAppshotMetadata(codexMessage, 'claude-code'))
+  .toThrowError(/Appshots are only supported in Codex sessions/);
+expect(() => requireCodexQueuedAppshots({ ...queued, createOpts: { agentKind: 'pi' } }))
+  .toThrowError(/Appshots are only supported in Codex sessions/);
+```
+
+Include direct send, enqueue, steer, malformed metadata, and an ordinary image sent to Claude Code unchanged.
+
+- [ ] **Step 2: Run the focused boundary test and verify RED**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/main/maker-ipc/__tests__/appshotBoundary.test.ts \
+  src/renderer/__tests__/messageAttachmentPayload.test.ts \
+  src/main/__tests__/agentInputQueue.test.ts
+```
+
+Expected: new boundary test FAIL.
+
+- [ ] **Step 3: Preserve an internal marker through Renderer and queue builders**
+
+Add `appshot?: AppshotMetadata` to image attachment blocks only. Each builder emits the image block with this internal property and the separate formatted text block. Existing provider-normalization must never receive this property.
+
+- [ ] **Step 4: Validate against authoritative session kind and strip marker**
+
+Implement in `maker-ipc/register.ts`:
+
+```ts
+export function validateAndStripAppshotMetadata(
+  message: IpcUserMessage,
+  agentKind: AgentKind,
+): IpcUserMessage {
+  if (typeof message === 'string' || typeof message.content === 'string') return message;
+  let found = false;
+  const content = message.content.map((block) => {
+    if (block.type !== 'image' || block.appshot === undefined) return block;
+    found = true;
+    if (!coerceAppshotMetadata(block.appshot)) {
+      throwIpcError('INVALID_PARAMS', 'invalid Appshot metadata');
+    }
+    const { appshot: _appshot, ...safeBlock } = block;
+    return safeBlock;
+  });
+  if (found && agentKind !== 'codex') {
+    throwIpcError('INVALID_PARAMS', 'Appshots are only supported in Codex sessions');
+  }
+  return { ...message, content };
+}
+```
+
+Call it before `normalizeUserMessage` in `prepareUserMessageForAgent`, using `maker.getSessionMeta(sessionId)` or the live session's authoritative `agentKind`; fail closed if metadata is present and kind cannot be resolved. In `requireQueuedMessage`, inspect `files[].appshot`; reject unless `createOpts.agentKind === 'codex'`, and reject malformed metadata. This covers enqueue and steer before they detach from the IPC context.
+
+- [ ] **Step 5: Re-run focused tests and commit**
+
+Run Step 2. Expected: PASS.
+
+```bash
+git add apps/desktop/src/main/maker-ipc/register.ts \
+  apps/desktop/src/main/maker-ipc/__tests__/appshotBoundary.test.ts \
+  apps/desktop/src/renderer/__tests__/messageAttachmentPayload.test.ts \
+  apps/desktop/src/main/__tests__/agentInputQueue.test.ts
+git commit -m "fix: enforce Codex-only Appshot sends"
+```
+
+### Task 7: Shortcut settings, permission guidance, i18n, and release verification
+
+**Files:**
+- Modify: `apps/desktop/src/renderer/components/settings/KeyboardShortcutsSection.tsx`
+- Modify: `apps/desktop/src/renderer/components/settings/__tests__/KeyboardShortcutsSection.mutationRace.test.tsx`
+- Modify: `apps/desktop/src/renderer/i18n/locales/en/common.json`
+- Modify: `apps/desktop/src/renderer/i18n/locales/zh-CN/common.json`
+- Modify: `apps/desktop/src/renderer/i18n/locales/ja/common.json`
+- Modify: `apps/desktop/src/renderer/i18n/locales/ko/common.json`
+- Modify: `apps/desktop/src/main/appshots/coordinator.ts`
+- Modify: `apps/desktop/src/main/appshots/shortcutService.ts`
+- Modify: `apps/desktop/src/main/bootstrap-electron.ts`
+
+- [ ] **Step 1: Write failing settings and permission presentation tests**
+
+Add assertions for two editable rows, effective shortcut, fallback reason, mutation-race protection, and permission actions:
+
+```tsx
+expect(screen.getByText('Capture Appshot')).toBeVisible();
+expect(screen.getByText('Double Command')).toBeVisible();
+expect(screen.getByText('⌘⇧A')).toBeVisible();
+expect(screen.getByText(/Active: ⌘⇧A/)).toBeVisible();
+```
+
+Coordinator/shortcut tests must assert: missing Screen Recording produces no inbox item and a Screen Recording action; missing Accessibility produces an attachment plus `UI structure unavailable`; missing Input Monitoring disables only the dual-modifier trigger and leaves the manual composer action.
+
+- [ ] **Step 2: Run settings, coordinator, shortcut, and i18n tests to verify RED**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/renderer/components/settings/__tests__/KeyboardShortcutsSection.mutationRace.test.tsx \
+  src/main/appshots/__tests__/coordinator.test.ts \
+  src/main/appshots/__tests__/shortcutService.test.ts \
+  src/renderer/__tests__/i18nCompleteness.test.ts
+```
+
+Expected: new Appshot settings/i18n assertions FAIL.
+
+- [ ] **Step 3: Add preferred and fallback shortcut controls**
+
+Reuse existing keyboard recording styles and `AppShortcutCombo` event conversion for conventional combinations. Add a compact selector for `Double Command`, `Double Option`, `Double Shift`, or `Key combination` for each row. Load state from `appshots.getShortcutState`, save both fields atomically with `setShortcutPreferences`, and retain the existing request-ID mutation race guard. Display `Configured`, `Fallback`, and `Active` values; show the fallback reason when active differs.
+
+- [ ] **Step 4: Add stable user-facing errors and permission actions**
+
+Map only stable codes in Renderer. Actions open existing Cindy permission guidance:
+
+```ts
+type AppshotPermissionTarget = 'screen-recording' | 'accessibility' | 'input-monitoring';
+window.electronAPI.appshots.openPermissionSettings(target);
+```
+
+Main handles this trusted IPC by reusing `showComputerPermissionGuideWindow` for Screen Recording/Accessibility and the existing modifier-shortcut Input Monitoring path. Do not request permissions at startup; invoke only after capture or shortcut selection. Do not include app/window/AX content in notifications or logs.
+
+- [ ] **Step 5: Add complete locale keys**
+
+Add equivalent keys in all four locale files under:
+
+```json
+{
+  "appshots": {
+    "capture": "Appshot",
+    "captureInProgress": "An Appshot capture is already in progress.",
+    "uiUnavailable": "UI structure unavailable",
+    "screenPermission": "Allow Screen Recording to capture this window.",
+    "accessibilityPermission": "Allow Accessibility to include UI structure.",
+    "inputMonitoringPermission": "Allow Input Monitoring to use double-modifier shortcuts."
+  },
+  "settings": {
+    "shortcuts": {
+      "appshots": {
+        "title": "Capture Appshot",
+        "preferred": "Preferred shortcut",
+        "fallback": "Fallback shortcut",
+        "active": "Active: {{shortcut}}",
+        "doubleCommand": "Double Command",
+        "doubleOption": "Double Option",
+        "doubleShift": "Double Shift"
+      }
+    }
+  }
+}
+```
+
+Translate values naturally; keys and placeholders must remain identical.
+
+- [ ] **Step 6: Run targeted and full verification**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run \
+  src/shared/__tests__/appshots.test.ts \
+  src/main/appshots/__tests__/coordinator.test.ts \
+  src/main/appshots/__tests__/shortcutService.test.ts \
+  src/main/maker-ipc/__tests__/appshotBoundary.test.ts \
+  src/main/voice-input/__tests__/globalShortcut.test.ts \
+  src/renderer/features/appshots/__tests__/appshotInbox.test.ts \
+  src/renderer/__tests__/messageAttachmentPayload.test.ts \
+  src/main/__tests__/agentInputQueue.test.ts \
+  src/renderer/components/settings/__tests__/KeyboardShortcutsSection.mutationRace.test.tsx \
+  src/main/maker-host/__tests__/providerRoute.test.ts
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop typecheck
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop lint
+```
+
+Expected: all PASS. Confirm touched TypeScript modules meet at least 80% line coverage with:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop exec vitest run --coverage \
+  src/shared/__tests__/appshots.test.ts \
+  src/main/appshots/__tests__/coordinator.test.ts \
+  src/main/appshots/__tests__/shortcutService.test.ts \
+  src/main/maker-ipc/__tests__/appshotBoundary.test.ts \
+  src/renderer/features/appshots/__tests__/appshotInbox.test.ts
+```
+
+- [ ] **Step 7: Build a separate macOS app without replacing the installed Cindy**
+
+Run:
+
+```bash
+PATH=/Users/hanbala/.nvm/versions/node/v22.22.3/bin:$PATH pnpm --filter desktop package -- --platform=darwin --arch=arm64
+```
+
+Expected artifact under `apps/desktop/out/`, not `/Applications/Cindy.app`. Run the packaged helper self-test from the artifact's `Contents/Resources/tools/appshots/xdt-macos-appshot-helper --self-test` and expect `{"ok":true,"type":"self-test"}`.
+
+Manual acceptance on that separate build:
+
+1. Capture Safari, Finder, a text editor, and Cindy; verify image, app name, bundle ID, title, and AX structure.
+2. Verify Retina/non-Retina, multiple displays, and partially off-screen windows.
+3. Verify full permissions, screenshot-only, and no permissions; secure values never appear.
+4. Verify current local Codex receives one unsent card; Claude Code/Pi/remote/no-session opens a new local Codex draft and does not send.
+5. Verify double Command, custom preferred/fallback, Codex-running fallback, restoration after Codex exits, restart persistence, and no response after Cindy fully quits.
+6. Verify phone pairing, remote connection, normal images, and the saved Qianlong Claude provider route still behave as before.
+
+- [ ] **Step 8: Request code and security review, fix findings, then commit**
+
+Review scope must include native output-path containment, symlink handling, PNG/size validation, trusted Renderer IPC, secure AX redaction, non-Codex rejection, shortcut listener lifetime, and absence of hardcoded credentials. Re-run Step 6 after fixes.
+
+```bash
+git add apps/desktop/src/renderer/components/settings/KeyboardShortcutsSection.tsx \
+  apps/desktop/src/renderer/components/settings/__tests__/KeyboardShortcutsSection.mutationRace.test.tsx \
+  apps/desktop/src/renderer/i18n/locales/en/common.json \
+  apps/desktop/src/renderer/i18n/locales/zh-CN/common.json \
+  apps/desktop/src/renderer/i18n/locales/ja/common.json \
+  apps/desktop/src/renderer/i18n/locales/ko/common.json \
+  apps/desktop/src/main/appshots \
+  apps/desktop/src/main/bootstrap-electron.ts
+git commit -m "feat: finish macOS Codex Appshots"
+```
+
+## Completion gate
+
+- [ ] No placeholder implementation, deferred implementation marker, new dependency, database migration, credential change, remote/mobile capture control, auto-send, or second native keyboard event tap.
+- [ ] Every approved requirement in `docs/superpowers/specs/2026-08-05-codex-appshots-design.md` maps to Tasks 1-7.
+- [ ] Shared names remain consistent: `AppshotMetadata`, `AppshotCaptureResult`, `AppshotShortcut`, `AppshotShortcutPreferences`, `AppshotShortcutState`, `formatAppshotContext`, and `validateAndStripAppshotMetadata`.
+- [ ] All tests, typecheck, lint, Swift self-test, separate package build, manual macOS checks, code review, and security review pass.
+- [ ] `/Applications/Cindy.app`, phone pairing, remote connection state, provider credentials, `.codebase-memory/`, and unrelated user files remain untouched.

--- a/docs/superpowers/specs/2026-08-05-codex-appshots-design.md
+++ b/docs/superpowers/specs/2026-08-05-codex-appshots-design.md
@@ -1,0 +1,306 @@
+# Codex Appshots for Cindy on macOS
+
+## Status
+
+- Date: 2026-08-05
+- State: approved for implementation planning
+- Scope: Cindy Desktop on macOS, Codex sessions only
+- Baseline: `377c041d` (`fix: preserve Claude provider model routing`)
+
+## Problem
+
+Cindy accepts image attachments, but it cannot create a Codex-style Appshot. An Appshot must
+capture the frontmost application window and its macOS accessibility structure, attach both to
+a Codex composer, and wait for the user to send them. The feature also needs a global shortcut
+that works while Cindy is in the background.
+
+## Goals
+
+1. Capture the frontmost visible window on macOS, including its image, application identity,
+   window title, and accessibility structure.
+2. Add the capture to a Cindy Codex composer without sending it.
+3. Reuse Cindy's image cache, draft attachment, session creation, and Codex input paths.
+4. Support a configurable global shortcut. Match Codex's default double-Command gesture and
+   use Command-Shift-A when the default cannot be used.
+5. Handle macOS permissions and protected content without exposing secrets.
+
+## Non-goals
+
+The first release does not include:
+
+- Windows or Linux capture;
+- Appshots in Claude Code or Pi sessions;
+- mobile-initiated capture;
+- automatic message submission;
+- a window picker, region capture, annotation editor, OCR, or capture history;
+- a login helper that runs after Cindy has fully quit;
+- changes to mobile pairing, remote connections, or ordinary image attachments.
+
+Closing Cindy's window may leave the existing Cindy process running, so the shortcut remains
+available. Quitting Cindy stops the shortcut.
+
+## Confirmed User Experience
+
+### Composer entry
+
+Codex composers expose an **Appshot** action in the existing attachment menu. Claude Code and
+Pi composers do not show it. The action captures the application that was frontmost when the
+user invoked it.
+
+### Global shortcut
+
+Cindy's **Settings > Keyboard Shortcuts** includes **Capture Appshot**. The setting accepts:
+
+- double Command, matching Codex's default gesture;
+- double Option or double Shift, matching Codex's modifier-only alternatives;
+- a conventional user-recorded key combination.
+
+The initial preference is double Command. Cindy uses Command-Shift-A as the fallback. The
+settings row shows the configured shortcut and the shortcut currently active.
+
+Codex and Cindy cannot exclusively register the same passive double-modifier gesture. Cindy
+therefore treats the running `com.openai.codex` application as a conflict: it activates the
+fallback while Codex runs and retries the configured shortcut after Codex exits. A conventional
+shortcut also falls back when macOS rejects its registration. Cindy shows a notification when
+it changes the active shortcut. Users may edit both the preferred and fallback shortcuts.
+
+The implementation reuses Cindy's existing macOS key snapshot listener. It must not create a
+second keyboard event tap. A shared subscriber dispatches snapshots to voice input and
+Appshots, keeping their trigger state independent.
+
+### Capture destination
+
+After capture, Cindy comes to the foreground and displays the Appshot as one attachment card
+with the application name, window title, preview, and remove action.
+
+- If the visible composer belongs to a writable Codex session, Cindy attaches there.
+- Otherwise, Cindy immediately opens a new local Codex conversation draft and attaches there.
+  Cindy preserves the capture in the draft cache; the existing lazy-create flow creates the
+  durable session when the user sends the first message. This is Cindy's current new-conversation
+  behavior and does not send an empty message merely to allocate a session ID.
+- Cindy never attaches an Appshot to a Claude Code or Pi composer.
+- Cindy never sends the message automatically.
+
+Repeated shortcut presses while one capture is active do not queue duplicate captures. Cindy
+reports that a capture is already in progress.
+
+## Considered Approaches
+
+### 1. Native macOS capture plus existing Cindy attachment flow
+
+A small Swift helper uses macOS window and accessibility APIs. Cindy Main coordinates the
+capture, then hands the result to the existing Renderer image cache and draft/session paths.
+This gives Codex-style visual and structural context without adding a third-party dependency.
+
+This is the selected approach.
+
+### 2. Electron desktop capture
+
+Electron can capture window images and titles, but it does not provide the accessibility tree
+or reliable frontmost focused-window identity. The result would be a screenshot, not an
+Appshot.
+
+### 3. Cindy-owned screen-selection overlay
+
+A custom overlay could select a region or window. It would add multi-display, Retina scaling,
+focus, animation, and permission complexity while still requiring a native accessibility
+collector. The confirmed workflow captures the frontmost window directly, so the overlay adds
+no required value.
+
+## Architecture
+
+```text
+global shortcut or Codex attachment action
+  -> Appshot capture coordinator in Desktop Main
+  -> macOS native helper
+       -> frontmost application and focused window
+       -> PNG window capture
+       -> bounded accessibility text
+  -> validated Appshot result
+  -> Cindy image cache and Appshot inbox
+  -> current Codex composer or new Codex draft
+  -> existing Codex message input path when the user sends
+```
+
+### macOS native helper
+
+The helper owns macOS-specific work:
+
+1. Read `NSWorkspace.shared.frontmostApplication` before Cindy activates.
+2. Resolve the application's focused accessibility window and its corresponding Core Graphics
+   window ID. Prefer a visible layer-zero window and reject desktop elements, transparent
+   windows, and degenerate bounds.
+3. Capture only that window as PNG through the supported macOS window-capture API.
+4. Traverse the focused window's accessibility hierarchy and produce deterministic text.
+5. Return metadata as JSON and write the PNG into a private temporary capture directory.
+
+Desktop Main creates the temporary directory, passes its exact path to the helper, validates
+the returned file, ingests it into Cindy's existing image cache, and removes the temporary
+directory. The helper never chooses an arbitrary output path.
+
+The first release caps accessibility capture at 2,000 nodes, 16 levels, 512 KiB of UTF-8 text,
+or 1.5 seconds, whichever comes first. The result includes a truncation marker when a cap is
+reached. Each node may include role, label, title, value, description, enabled state, selected
+state, and focused state when macOS exposes them. Empty attributes are omitted.
+
+### Main-process coordinator
+
+The coordinator provides one capture operation and one status stream. It:
+
+- serializes capture attempts with a single in-flight guard;
+- captures before activating Cindy;
+- validates helper JSON, PNG signature, maximum image size, and temporary file location;
+- maps native failures to stable user-facing error codes;
+- emits the validated result only to Cindy windows;
+- records status and error codes without logging image bytes, accessibility text, window title,
+  or application content.
+
+The coordinator accepts capture requests only on macOS. Renderer IPC callers cannot provide a
+PID, window ID, or output path; the native helper resolves the frontmost target. This prevents
+an untrusted Renderer payload from turning the helper into an arbitrary process or file reader.
+The helper and coordinator reject a PNG larger than 100 MiB before Cindy ingests it, matching
+Cindy's existing maximum for externally supplied images.
+
+### Renderer Appshot inbox
+
+The Renderer receives a completed capture through a small Appshot inbox. The inbox performs one
+of two existing operations:
+
+- add the attachment to the current Codex composer's attachment state; or
+- route to the new-Codex draft and let `rehomeDraftAttachments` move the image after lazy session
+  creation.
+
+The inbox must consume each capture ID once. Window reloads may restore an unconsumed item, but
+must not duplicate one already attached.
+
+### Attachment contract
+
+An Appshot remains an image attachment with additional typed metadata:
+
+```ts
+interface AppshotMetadata {
+  schemaVersion: 1
+  captureId: string
+  capturedAt: string
+  applicationName: string
+  bundleIdentifier: string | null
+  windowTitle: string | null
+  accessibilityText: string | null
+  accessibilityTruncated: boolean
+  accessibilityUnavailableReason?: 'permission' | 'unsupported' | 'timeout'
+}
+```
+
+`AttachedFile` and the persisted image reference carry this optional metadata. Existing image
+renderers ignore it. The Codex composer renders an Appshot card when it exists.
+
+When the user sends, the existing image attachment supplies the visual input. Cindy also adds a
+text block with this shape, escaping attribute values and content:
+
+```text
+<appshot app="Application" bundle-identifier="com.example.app" window-title="Window">
+Window: "Window", App: Application.
+<accessibility-tree>
+...bounded accessibility text...
+</accessibility-tree>
+</appshot>
+```
+
+The Main input boundary rejects Appshot metadata for non-Codex sessions even if a caller bypasses
+the Renderer UI. Ordinary images keep their current payload and behavior.
+
+## Permissions and Privacy
+
+Appshots use three macOS permission classes:
+
+- **Screen Recording** captures the window image.
+- **Accessibility** reads the UI hierarchy.
+- **Input Monitoring** is required for double-modifier global shortcuts; a conventional
+  Electron global shortcut does not require it.
+
+Cindy requests a permission only after the user invokes Appshots or selects a shortcut that
+needs it. Permission guidance reuses the existing Computer Use and modifier-shortcut settings
+paths.
+
+Screen Recording is required. Without it, Cindy creates no attachment and offers the relevant
+System Settings page. Accessibility may degrade independently: Cindy may attach the screenshot
+with a visible **UI structure unavailable** warning and an authorization action.
+
+The helper applies these privacy rules before returning data:
+
+- `AXSecureTextField` nodes retain only their role and the label **Secure text field**;
+- values of nodes marked protected by macOS are omitted;
+- image bytes, accessibility text, and window titles stay in local attachment storage until the
+  user sends the message;
+- diagnostics and telemetry contain no captured content;
+- removing an unsent Appshot uses the existing private attachment cleanup behavior.
+
+Sending an Appshot is the user's explicit decision to send its image and structural text to the
+selected Codex provider.
+
+## Errors and Degraded Results
+
+The coordinator returns stable outcomes:
+
+| Outcome | Behavior |
+| --- | --- |
+| Screen Recording permission missing | No attachment; show permission action |
+| Accessibility permission missing | Attach image with structural-context warning |
+| Input Monitoring permission missing | Keep manual composer action; show shortcut permission action |
+| No frontmost visible window | No attachment; show concise error |
+| Target window closes during capture | No attachment; show concise error |
+| Protected or blank capture | No attachment; explain that macOS or the application blocked capture |
+| Accessibility traversal times out | Attach image with truncated or unavailable marker |
+| Preferred shortcut conflict | Activate fallback and show the effective shortcut |
+| Preferred and fallback both conflict | Disable global trigger; preserve manual Appshot action and settings repair path |
+| Capture already in progress | Ignore duplicate request and report current capture |
+
+## Testing and Acceptance
+
+### Automated checks
+
+Tests cover these boundaries with no more than ten focused test groups:
+
+1. shortcut preference, conflict, fallback, persistence, and restoration;
+2. double-modifier snapshots dispatch independently to voice input and Appshots;
+3. helper-result validation rejects malformed JSON, paths outside the private temporary root,
+   non-PNG data, and oversized output;
+4. accessibility serialization redacts secure values and enforces node, depth, byte, and time
+   limits;
+5. capture results attach once to an active Codex composer;
+6. no active Codex composer routes the item into a new local Codex draft;
+7. non-Codex session input rejects Appshot metadata;
+8. sending builds one image input and one escaped Appshot context block;
+9. permission and target-window failures produce the specified degraded result or error;
+10. ordinary image attachment and Claude provider-routing regression tests remain green.
+
+The touched TypeScript modules must retain at least 80% line coverage. The native helper exposes
+a deterministic self-test mode for accessibility serialization and validation that requires no
+macOS permission prompt.
+
+### Manual macOS checks
+
+The test build verifies:
+
+- Safari, Finder, a text editor, and Cindy as frontmost targets;
+- Retina and non-Retina displays, multiple displays, and a window partly outside a display;
+- full permissions, screenshot-only permission, and no permissions;
+- secure text fields and protected windows;
+- Cindy in foreground, background, and with all windows closed;
+- current Codex composer, current non-Codex composer, and no existing session;
+- Codex running causes Cindy to use the fallback shortcut;
+- custom shortcuts survive restart and report conflicts;
+- Appshots remain unsent until the user submits the message.
+
+The release candidate must pass the existing Desktop and maker-core targeted suites, build with
+Node 22, and produce a separate Cindy.app. Testing must not replace `/Applications/Cindy.app`.
+
+## Compatibility
+
+The feature requires no database migration. Cindy persists the optional Appshot object inside
+the existing versioned JSON image-reference payload. Older Cindy versions may display an
+Appshot as an ordinary image and ignore its metadata. Current mobile clients may display the
+image but do not expose capture controls.
+
+The implementation must not alter the saved Claude provider fix at `377c041d`, provider
+credentials, phone pairing, remote connections, or existing Cindy installation data.


### PR DESCRIPTION
## Summary
Adds a macOS-only Appshots workflow to Cindy, matching Codex's app-snapshot experience:

- Capture the current frontmost app window, or the app behind Cindy when invoked from the composer (Codex-style), as PNG.
- Attach app name, bundle ID, window title, and a bounded, privacy-filtered Accessibility UI tree (password fields masked; protected nodes omit values).
- Attach to the active local Codex composer, or open a new Codex draft; never auto-sends.
- Global shortcut: double Command by default, Command-Shift-A fallback when Codex is running or the preferred key is unavailable; both customizable in Settings.
- Send boundary rejects Appshots in Claude Code / Pi sessions (direct, queued, and crash-restore paths).
- Settings UI for shortcut preferences and macOS permission entry points (Screen Recording, Accessibility, Input Monitoring).

## Review fixes included
- Appshot shortcuts are macOS-only: nothing is registered on Windows/Linux (bootstrap + service-level gate, with regression test).
- Crash-restore is recoverable: a persisted non-Codex queue item with Appshot metadata is sanitized (metadata stripped, image kept) instead of throwing forever and blocking the session.
- Users can preview the Accessibility text attached to a capture and remove it before sending (card badge + dialog; removal marks the metadata `removed`).
- Rebased onto the latest upstream `main`; the previously bundled Claude provider-routing fix is now separate in #2240.

## Verification
- 743 focused tests pass (Appshots, boundary, coordinator, shortcuts, preload, settings, i18n completeness); typecheck exits 0; Swift helper self-test passes.
- Packaged arm64 build installed and manually verified: composer menu capture, Codex-conflict fallback detection, AX preview/removal dialog.

## Notes
- The repo has pre-existing lint/test failures in unrelated packages; this change does not fix them.
- Windows/Linux startup smoke tests were not run in this environment; the platform gate is covered by unit tests.