### PR TITLE
fix(bridge): fail closed when Chat bridge drops web_search

### DIFF
--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -73,6 +73,29 @@ describe('createResponsesChatHandler', () => {
     expect(res.ended).toBe(true);
   });
 
+  it('rejects a built-in web_search tool instead of silently dropping it', async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const handler = createResponsesChatHandler({
+      upstreamBase: 'https://provider.example/v1',
+      buildHeaders: async () => ({}),
+    }, { fetchImpl });
+    const res = new FakeResponse();
+
+    await handler.handle({
+      parsedBody: {
+        model: 'custom-model',
+        input: [{ type: 'message', role: 'user', content: 'search' }],
+        tools: [{ type: 'web_search' }],
+      },
+      res: res as never,
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.chunks.join('')).toContain('unsupported_feature');
+    expect(res.chunks.join('')).toContain('web_search');
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
   it('preserves the upstream base query when applying the chat path', async () => {
     const fetchImpl = vi.fn(async () =>
       streamResponse([

--- a/packages/responses-chat-bridge/src/__tests__/handler.test.ts
+++ b/packages/responses-chat-bridge/src/__tests__/handler.test.ts
@@ -75,10 +75,11 @@ describe('createResponsesChatHandler', () => {
 
   it('rejects a built-in web_search tool instead of silently dropping it', async () => {
     const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const warn = vi.fn();
     const handler = createResponsesChatHandler({
       upstreamBase: 'https://provider.example/v1',
       buildHeaders: async () => ({}),
-    }, { fetchImpl });
+    }, { fetchImpl, logger: { warn } });
     const res = new FakeResponse();
 
     await handler.handle({
@@ -92,8 +93,14 @@ describe('createResponsesChatHandler', () => {
 
     expect(res.status).toBe(400);
     expect(res.chunks.join('')).toContain('unsupported_feature');
+    expect(res.chunks.join('')).toContain('tools[0]');
     expect(res.chunks.join('')).toContain('web_search');
     expect(fetchImpl).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('responses-chat bridge rejected unsupported feature', {
+      model: 'custom-model',
+      feature: 'tools[0].web_search',
+    });
   });
 
   it('preserves the upstream base query when applying the chat path', async () => {

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -165,10 +165,10 @@ export function createResponsesChatHandler(
           model: realModel,
           capabilities: provider.capabilities,
           onDroppedTool: (type, index) => {
-            log.warn?.('responses-chat bridge dropped non-function tool', { type, index });
             if (type === 'web_search') {
-              throw new UnsupportedResponsesFeatureError('tool web_search');
+              throw new UnsupportedResponsesFeatureError(`tools[${index}].web_search`);
             }
+            log.warn?.('responses-chat bridge dropped non-function tool', { type, index });
           },
         });
       } catch (error) {

--- a/packages/responses-chat-bridge/src/handler.ts
+++ b/packages/responses-chat-bridge/src/handler.ts
@@ -166,6 +166,9 @@ export function createResponsesChatHandler(
           capabilities: provider.capabilities,
           onDroppedTool: (type, index) => {
             log.warn?.('responses-chat bridge dropped non-function tool', { type, index });
+            if (type === 'web_search') {
+              throw new UnsupportedResponsesFeatureError('tool web_search');
+            }
           },
         });
       } catch (error) {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Closes #1593。Responses 到 Chat bridge 遇到内建 web_search 时，先按不支持能力拒绝，不再先记录 dropped 日志；错误定位包含 tools[索引].web_search。

### 变更类型

- [x] fix 缺陷修复
- [ ] feat 新功能
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护

### 范围

- 关联 Issue / 需求：#1593
- 本 PR 包含：web_search 的结构化 unsupported_feature 400 响应、日志顺序与定位字段修正、回归测试
- 明确不包含：其他非 function tool 的 fail-closed 改造、UI 重设计、协议架构改造
- 用户可见变化：收到不支持的 web_search 时获得明确错误，不再得到静默成功结果
- 是否存在 breaking change：有。此前该请求可能被静默丢弃并继续上游请求；现在明确返回 400。

### UI 变化

- 不涉及：仅修改 Responses 到 Chat bridge 与测试，无 UI 代码变化。
- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

- responses-chat-bridge focused tests：133 passed
- responses-chat-bridge TypeScript check：passed
- responses-chat-bridge ESLint：passed
- git diff --check：passed

### 手工验证

不涉及：通过 handler 单元测试验证 400 响应、unsupported_feature、tools[0].web_search、未调用上游及日志内容。

### 未执行的验证

根目录 pnpm test:unit 已尝试，但 test-runner 受本地 sandbox 的 EPERM 端口绑定与端口占用环境阻断，workspace unit tier 未完成；已由 focused package tests 覆盖本次改动路径。

## 风险

### 风险分类

- [x] 协议兼容
- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 权限 / 安全 / 用户数据
- [ ] 跨平台差异
- [ ] 其他

### 影响与回滚

- 影响范围：仅 Responses 到 Chat bridge 中携带 web_search 的自定义 OpenAI 兼容模型请求；function tool 转换不变。
- 回滚 / 降级方式：回滚提交 d4f0e0b6e 即可恢复原行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因