### PR TITLE
fix: preserve Claude provider model routing

### DIFF
--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -19,6 +19,7 @@ import {
 } from '@cindy/maker-core';
 import {
   getActiveCatalog,
+  getCatalogModelContextWindow,
   setActiveCatalogChangedListener,
   setDiscoveredCodexModels,
 } from './active-catalog.js';
@@ -795,6 +796,10 @@ export function getMaker(): Maker {
       capabilityAdditions: {
         availableModels: deriveAvailableModels(getDesktopSelectableCatalog(), 'claude-code'),
       },
+      resolveClaudeModelContextWindow: (providerId, modelId) =>
+        providerId
+          ? getCatalogModelContextWindow(providerId, 'claude-code', modelId)
+          : null,
       // SDK PreToolUse / PostToolUse 等 in-process hook 注入点。host 自己定义 hook
       // 实现 (./claude-hooks/*.ts), maker-core 不感知具体逻辑。
       //

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -416,6 +416,16 @@ export interface AgentDeps {
   capabilityAdditions?: AgentCapabilityAdditions;
 
   /**
+   * Claude Code wire-model context window for one provider route.
+   * Unlike resolveVerifiedContextWindow, catalog defaults are valid here: they prevent a
+   * colliding built-in model from incorrectly adding the `[1m]` transport suffix.
+   */
+  resolveClaudeModelContextWindow?: (
+    providerId: string | null | undefined,
+    modelId: string,
+  ) => number | null;
+
+  /**
    * Host-owned arbitration for capabilities that overlap with harness-native
    * plugins, skills, MCP servers, apps, or tools.
    *

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -51,6 +51,13 @@ const originalIdleTimeout = process.env.XDT_CC_SSE_IDLE_TIMEOUT_MS;
 
 const TEST_MODELS: ModelDescriptor[] = [
   {
+    id: 'claude-opus-4-8',
+    displayName: 'Claude Opus 4.8',
+    contextWindow: 1_000_000,
+    efforts: ['low', 'medium', 'high', 'max'],
+    defaultEffort: 'high',
+  },
+  {
     id: 'claude-opus-4-6',
     displayName: 'Claude Opus 4.6',
     contextWindow: 1_000_000,
@@ -193,7 +200,13 @@ async function makeTempDir(): Promise<string> {
 }
 
 async function startRewindableSession(
-  options: { autoCompactThresholdPct?: number; idleTimeoutMs?: number } = {},
+  options: {
+    autoCompactThresholdPct?: number;
+    idleTimeoutMs?: number;
+    model?: string;
+    providerId?: string;
+    resolveClaudeModelContextWindow?: AgentDeps['resolveClaudeModelContextWindow'];
+  } = {},
 ) {
   const configDir = await makeTempDir();
   process.env.CLAUDE_CONFIG_DIR = configDir;
@@ -207,10 +220,12 @@ async function startRewindableSession(
   const agent = new ClaudeCodeAgent({
     ...createDeps({ autoCompactThresholdPct: options.autoCompactThresholdPct }),
     capabilityAdditions: { availableModels: TEST_MODELS },
+    resolveClaudeModelContextWindow: options.resolveClaudeModelContextWindow,
   });
   const handle = await agent.startSession({
     sessionId: 'session-rewind',
-    model: 'claude-opus-4-6',
+    model: options.model ?? 'claude-opus-4-6',
+    providerId: options.providerId,
     workingDir,
     permissionMode: 'acceptEdits',
   });
@@ -237,6 +252,42 @@ afterEach(async () => {
 });
 
 describe('ClaudeCodeAgent runtime settings during rewind window', () => {
+  it('uses the selected provider context window across start, switch, and rebuild', async () => {
+    const resolveClaudeModelContextWindow = vi.fn(
+      (providerId: string | null | undefined, modelId: string) =>
+        modelId === 'claude-opus-4-8'
+          ? providerId === 'cc'
+            ? 200_000
+            : providerId === 'anthropic'
+              ? 1_000_000
+              : null
+          : null,
+    );
+    const { handle, firstQuery } = await startRewindableSession({
+      model: 'claude-opus-4-8',
+      providerId: 'cc',
+      resolveClaudeModelContextWindow,
+    });
+
+    const args = sdkMock.query.mock.calls[0]?.[0] as { options: Record<string, unknown> };
+    expect(args.options.model).toBe('claude-opus-4-8');
+    expect(resolveClaudeModelContextWindow).toHaveBeenCalledWith('cc', 'claude-opus-4-8');
+
+    await handle.setModel?.('claude-opus-4-8', { providerId: 'anthropic' });
+    expect(firstQuery.setModel).toHaveBeenLastCalledWith('claude-opus-4-8[1m]');
+
+    await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');
+    await handle.setModel?.('claude-opus-4-8', { providerId: 'cc' });
+    const rebuiltQuery = createFakeQuery();
+    sdkMock.query.mockReturnValue(rebuiltQuery);
+    await handle.send({ type: 'user', content: 'resume through qianlong' });
+
+    const rebuiltArgs = sdkMock.query.mock.calls[1]?.[0] as { options: Record<string, unknown> };
+    expect(rebuiltArgs.options.model).toBe('claude-opus-4-8');
+
+    await handle.close();
+  });
+
   it('passes max through when changing effort in a live Sonnet 5 session', async () => {
     const { handle, firstQuery } = await startRewindableSession();
 
@@ -406,6 +457,33 @@ describe('ClaudeCodeAgent runtime settings during rewind window', () => {
     expect(rebuildArgs.options.model).toBe('claude-opus-4-6[1m]');
     // sonnet-5 fixture 窗口 500K < 1M → wire 串不带 [1m](窗口驱动规则)。
     expect(secondQuery.setModel).toHaveBeenCalledWith('claude-sonnet-5');
+
+    await handle.close();
+  });
+
+  it('replays a same-model provider switch that arrives during query rebuild', async () => {
+    const resolveClaudeModelContextWindow = (
+      providerId: string | null | undefined,
+      modelId: string,
+    ) => modelId === 'claude-opus-4-8' && providerId === 'cc' ? 200_000 : 1_000_000;
+    const { handle } = await startRewindableSession({
+      model: 'claude-opus-4-8',
+      providerId: 'anthropic',
+      resolveClaudeModelContextWindow,
+    });
+    await handle.commitRewindFiles?.('user-uuid-1', 'assistant-uuid-1');
+
+    const secondQuery = createFakeQuery();
+    sdkMock.query.mockImplementationOnce(() => {
+      void handle.setModel?.('claude-opus-4-8', { providerId: 'cc' });
+      return secondQuery;
+    });
+
+    await handle.send({ type: 'user', content: 'switch provider during rebuild' });
+
+    const rebuildArgs = sdkMock.query.mock.calls[1]?.[0] as { options: Record<string, unknown> };
+    expect(rebuildArgs.options.model).toBe('claude-opus-4-8[1m]');
+    expect(secondQuery.setModel).toHaveBeenCalledWith('claude-opus-4-8');
 
     await handle.close();
   });

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -622,13 +622,16 @@ export class ClaudeCodeAgent extends BaseAgent {
   }
 
   /**
-   * catalog id → SDK wire 串,[1m] 由目录 contextWindow 驱动(见 toSdkModelString)。
-   * 模型不在 capabilities(目录外/host 未注入)时窗口传 undefined → 走 legacy 兜底链。
+   * catalog id → SDK wire 串,[1m] 优先由当前 provider 路由的 contextWindow 驱动。
+   * host 未注入路由解析器时回落扁平 capabilities；模型仍未知才走 legacy 兜底链。
    */
-  private sdkModelFor(model: string): string {
+  private sdkModelFor(model: string, providerId?: string | null): string {
+    const routedWindow = this.deps.resolveClaudeModelContextWindow?.(providerId, model);
     const descriptor = this.capabilities.availableModels.find((m) => m.id === model);
     const window =
-      descriptor && Number.isFinite(descriptor.contextWindow) && descriptor.contextWindow > 0
+      typeof routedWindow === 'number' && Number.isFinite(routedWindow) && routedWindow > 0
+        ? routedWindow
+        : descriptor && Number.isFinite(descriptor.contextWindow) && descriptor.contextWindow > 0
         ? descriptor.contextWindow
         : undefined;
     return toSdkModelString(model, window);
@@ -879,10 +882,11 @@ export class ClaudeCodeAgent extends BaseAgent {
 
     // 箭头别名捕获 this —— 下方 replayRuntimeDrift(普通 function)与 handle 对象
     // 字面量方法里没有类实例 this,统一经它取 wire 串。
-    const sdkModelFor = (model: string): string => this.sdkModelFor(model);
+    const sdkModelFor = (model: string, providerId?: string | null): string =>
+      this.sdkModelFor(model, providerId);
     const resolveRemoteClaudeRoute = this.deps.resolveRemoteClaudeRoute?.bind(this.deps);
     const getAuthEnv = this.deps.auth.getAuthEnv.bind(this.deps.auth);
-    const sdkModel = sdkModelFor(opts.model);
+    const sdkModel = sdkModelFor(opts.model, opts.providerId);
     const initialSdkEffort = this.sdkEffortForModel(opts.model, opts.effort ?? 'high');
     const binaryPath = this.deps.binaryPath;
     const providerRoutedModels = this.capabilities.availableModels.filter((model) =>
@@ -2282,7 +2286,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       permissionMode?: SdkPermissionMode;
       fresh?: boolean;
     }): Promise<Query> => {
-      const currentSdkModel = sdkModelFor(mutableModel);
+      const currentSdkModel = sdkModelFor(mutableModel, mutableProviderId);
       const currentSdkEffort = getSdkEffortForModel(mutableModel, mutableEffort);
       const baseResumeAt = vo.resumeSessionAt as string | undefined;
       const baseFork = vo.forkSession as boolean | undefined;
@@ -4304,6 +4308,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       // 避免新 query 带旧 model/flags 起跑而 handle getter 报新值。
       const runtimeSnapshot: QueryRuntimeSnapshot = {
         model: mutableModel,
+        providerId: mutableProviderId,
         effort: mutableEffort,
         fastMode: mutableFastMode,
         sdkPermissionMode: currentTurnSdkPermissionMode(),
@@ -4412,6 +4417,7 @@ export class ClaudeCodeAgent extends BaseAgent {
       canceledBridgeQueries.has(q);
     type QueryRuntimeSnapshot = {
       model: string;
+      providerId: string | null;
       effort: Effort;
       fastMode: boolean;
       sdkPermissionMode: SdkPermissionMode;
@@ -4419,13 +4425,18 @@ export class ClaudeCodeAgent extends BaseAgent {
     async function replayRuntimeDrift(snapshot: QueryRuntimeSnapshot, label: string): Promise<void> {
       for (let pass = 0; pass < 5; pass += 1) {
         let replayed = false;
-        if (mutableModel !== snapshot.model) {
+        if (mutableModel !== snapshot.model || mutableProviderId !== snapshot.providerId) {
           replayed = true;
           const targetModel = mutableModel;
+          const targetProviderId = mutableProviderId;
           try {
-            await q.setModel(sdkModelFor(targetModel));
+            await q.setModel(sdkModelFor(targetModel, targetProviderId));
             snapshot.model = targetModel;
-            log.debug(`${label}: replayed setModel`, { model: targetModel });
+            snapshot.providerId = targetProviderId;
+            log.debug(`${label}: replayed setModel`, {
+              model: targetModel,
+              providerId: targetProviderId,
+            });
           } catch (e) {
             log.warn(`${label}: replay setModel failed`, { error: String(e) });
           }
@@ -4748,6 +4759,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 闭包值; await 期间若有切换到达(被 controlRequestsBlocked() 短路成"只更新闭包"),
           // 下方 diff 重放据此识别漂移项。
           const snapModel = mutableModel;
+          const snapProviderId = mutableProviderId;
           const snapEffort = mutableEffort;
           const snapFastMode = mutableFastMode;
           // 用 turn-scoped 档快照 (planTurnActive + mutablePermissionMode), 不含 mutablePlanMode
@@ -4789,6 +4801,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           clearBridgeState();
           runtimeReplaySnapshot = {
             model: snapModel,
+            providerId: snapProviderId,
             effort: snapEffort,
             fastMode: snapFastMode,
             sdkPermissionMode: snapSdkPermissionMode,
@@ -5447,7 +5460,7 @@ export class ClaudeCodeAgent extends BaseAgent {
           // 才有)若被当成 spawn 声明,下次切模会与仍烤着旧快照的 remoteEnv 比对
           // 误拒(codex P2 #1035)。
         }
-        const sdkModel = sdkModelFor(newModel);
+        const sdkModel = sdkModelFor(newModel, targetProviderId);
         const isControlBlocked = controlRequestsBlocked();
         log.debug('setModel', { from: mutableModel, to: newModel, sdk: sdkModel, controlRequestsBlocked: isControlBlocked });
         if (!isControlBlocked) {


### PR DESCRIPTION
## Summary
Fixes a model-routing bug for custom Claude providers (e.g. the `cc` provider): CINDY merged models by ID only, so a built-in provider's same-named model (1M context) overrode the custom provider's 200K configuration. Claude Code then sent `claude-opus-4-8[1m]`, which the custom provider rejected with `model_not_found`.

- `sdkModelFor()` now resolves the context window by `providerId + modelId` through a host-injected resolver, falling back to flat capabilities only when no resolver is available.
- The rewind/runtime snapshot now tracks `providerId`, so a same-model provider switch arriving during query rebuild is replayed instead of dropped.

## Verification
- 38 targeted tests pass, including start/switch/rebuild coverage and a same-model provider-switch race regression.