### PR TITLE
fix(orca): 阻止 Worker 内 spawn_agent 子代理越级向 Lead 汇报

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/cc-remote-mcp.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/cc-remote-mcp.test.ts
@@ -225,6 +225,8 @@ describe('buildCcRemoteHttpMcpServers', () => {
       sessionId: 's1',
       sessionInstanceId: 'instance-1',
       agentKind: 'claude-code',
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
       vendorOptions: { orcaRole: 'lead', orcaLeadSessionId: 's1' },
     });
   });

--- a/apps/desktop/src/main/maker-host/cc-remote-mcp.ts
+++ b/apps/desktop/src/main/maker-host/cc-remote-mcp.ts
@@ -176,6 +176,8 @@ export async function buildCcRemoteHttpMcpServers(
   const ctx = {
     agentKind: 'claude-code' as const,
     sessionId: args.sessionId,
+    mcpCallerKind: 'root' as const,
+    mcpCallerAttested: true,
     ...(args.sessionInstanceId ? { sessionInstanceId: args.sessionInstanceId } : {}),
     workingDir: args.workingDir,
     // remote ctx: scope key 语义见 maker-core buildMemoryScopeKey。

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -1253,7 +1253,7 @@ export function getMaker(): Maker {
             : {}),
         };
       },
-      registerCodexMcpThreadContext: ({ threadId, sessionId, sessionInstanceId, workingDir, remoteHostId, vendorOptions }) => {
+      registerCodexMcpThreadContext: ({ threadId, sessionId, sessionInstanceId, mcpCallerKind, mcpCallerAttested, workingDir, remoteHostId, vendorOptions }) => {
         // Codex shares one app-server across sessions. Freeze the effective
         // ordinary-tool policy at thread creation so later Settings changes do
         // not mutate a runtime that is already running.
@@ -1263,6 +1263,8 @@ export function getMaker(): Maker {
         registerCodexMcpThreadContext(threadId, {
           agentKind: 'codex',
           sessionId,
+          mcpCallerKind,
+          mcpCallerAttested,
           ...(sessionInstanceId ? { sessionInstanceId } : {}),
           workingDir,
           // remote thread ctx: scope key 语义见 buildMemoryScopeKey。

--- a/apps/desktop/src/main/mcp-integrations/__tests__/codexEnvironment.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/codexEnvironment.test.ts
@@ -135,6 +135,8 @@ describe('codexEnvironment', () => {
       sessionInstanceId: 'instance-old',
       workingDir: '/project',
       vendorOptions: { [CODEX_DISABLED_BUILTIN_PLUGIN_IDS_KEY]: ['cindy-ssh'] },
+      mcpCallerKind: 'descendant',
+      mcpCallerAttested: true,
     });
     registerCodexMcpThreadContext('thread-1', {
       agentKind: 'codex',
@@ -146,6 +148,8 @@ describe('codexEnvironment', () => {
     expect(register).toHaveBeenLastCalledWith(
       'thread-1',
       expect.objectContaining({
+        mcpCallerKind: 'descendant',
+        mcpCallerAttested: true,
         vendorOptions: expect.objectContaining({
           [CODEX_DISABLED_BUILTIN_PLUGIN_IDS_KEY]: ['cindy-ssh'],
         }),
@@ -157,11 +161,15 @@ describe('codexEnvironment', () => {
       sessionInstanceId: 'instance-new',
       workingDir: '/project',
       vendorOptions: { [CODEX_DISABLED_BUILTIN_PLUGIN_IDS_KEY]: [] },
+      mcpCallerKind: 'descendant',
+      mcpCallerAttested: true,
     });
     expect(register).toHaveBeenLastCalledWith(
       'thread-1',
       expect.objectContaining({
         sessionInstanceId: 'instance-new',
+        mcpCallerKind: 'descendant',
+        mcpCallerAttested: true,
         vendorOptions: expect.objectContaining({
           [CODEX_DISABLED_BUILTIN_PLUGIN_IDS_KEY]: [],
         }),
@@ -172,6 +180,127 @@ describe('codexEnvironment', () => {
     expect(unregister).not.toHaveBeenCalled();
     unregisterCodexMcpThreadContext('thread-1', 'instance-new');
     expect(unregister).toHaveBeenCalledWith('thread-1', 'instance-new');
+  });
+
+  it('does not carry provenance into a new session instance and preserves explicit unknown/false', async () => {
+    const cfg = await getCodexExtraSpawnConfig({
+      mcpProviders: [testProvider()],
+      logger: noopLogger(),
+    });
+    const register = vi.spyOn(cfg.bridge!, 'registerThreadContext');
+
+    registerCodexMcpThreadContext('thread-provenance', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-old',
+      workingDir: '/project',
+      mcpCallerKind: 'descendant',
+      mcpCallerAttested: true,
+    });
+    registerCodexMcpThreadContext('thread-provenance', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-new',
+      workingDir: '/project',
+    });
+    expect(register).toHaveBeenLastCalledWith(
+      'thread-provenance',
+      expect.objectContaining({
+        sessionInstanceId: 'instance-new',
+        mcpCallerKind: undefined,
+        mcpCallerAttested: undefined,
+      }),
+    );
+
+    registerCodexMcpThreadContext('thread-provenance', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-new',
+      workingDir: '/project',
+      mcpCallerKind: 'unknown',
+      mcpCallerAttested: false,
+    });
+    registerCodexMcpThreadContext('thread-provenance', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-new',
+      workingDir: '/project',
+    });
+    expect(register).toHaveBeenLastCalledWith(
+      'thread-provenance',
+      expect.objectContaining({
+        mcpCallerKind: 'unknown',
+        mcpCallerAttested: false,
+      }),
+    );
+  });
+
+  it('clears provenance on unregister so a reused thread starts unknown', async () => {
+    const cfg = await getCodexExtraSpawnConfig({
+      mcpProviders: [testProvider()],
+      logger: noopLogger(),
+    });
+    const register = vi.spyOn(cfg.bridge!, 'registerThreadContext');
+    const unregister = vi.spyOn(cfg.bridge!, 'unregisterThreadContext');
+
+    registerCodexMcpThreadContext('thread-reused', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-old',
+      workingDir: '/project',
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
+    });
+    unregisterCodexMcpThreadContext('thread-reused', 'instance-old');
+    registerCodexMcpThreadContext('thread-reused', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-new',
+      workingDir: '/project',
+    });
+
+    expect(unregister).toHaveBeenCalledWith('thread-reused', 'instance-old');
+    expect(register).toHaveBeenLastCalledWith(
+      'thread-reused',
+      expect.objectContaining({
+        sessionInstanceId: 'instance-new',
+        mcpCallerKind: undefined,
+        mcpCallerAttested: undefined,
+      }),
+    );
+  });
+
+  it('does not let an old unregister clear a new provenance generation without vendor policy', async () => {
+    const cfg = await getCodexExtraSpawnConfig({
+      mcpProviders: [testProvider()],
+      logger: noopLogger(),
+    });
+    const register = vi.spyOn(cfg.bridge!, 'registerThreadContext');
+    const unregister = vi.spyOn(cfg.bridge!, 'unregisterThreadContext');
+
+    registerCodexMcpThreadContext('thread-generation', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-old',
+      workingDir: '/project',
+      mcpCallerKind: 'descendant',
+      mcpCallerAttested: true,
+    });
+    registerCodexMcpThreadContext('thread-generation', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-new',
+      workingDir: '/project',
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
+    });
+
+    unregisterCodexMcpThreadContext('thread-generation', 'instance-old');
+    expect(unregister).not.toHaveBeenCalled();
+    registerCodexMcpThreadContext('thread-generation', {
+      agentKind: 'codex',
+      sessionInstanceId: 'instance-new',
+      workingDir: '/project',
+    });
+    expect(register).toHaveBeenLastCalledWith(
+      'thread-generation',
+      expect.objectContaining({
+        mcpCallerKind: 'root',
+        mcpCallerAttested: true,
+      }),
+    );
   });
 
   it('Slack 在 bridge 启动后完成绑定时，清缓存会按最新 provider gate 重建', async () => {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/piEnvironment.test.ts
@@ -123,6 +123,8 @@ describe('piEnvironment per-session identity', () => {
       sessionInstanceId: 'pi-instance-1',
       workingDir: '/repo',
       vendorOptions: {},
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
     });
     expect(config?.mcpBridge).toBeTruthy();
     const server = config!.mcpBridge!.servers[0]!;

--- a/apps/desktop/src/main/mcp-integrations/codexEnvironment.ts
+++ b/apps/desktop/src/main/mcp-integrations/codexEnvironment.ts
@@ -59,6 +59,14 @@ const disabledPluginPolicyByThread = new Map<
   string,
   { sessionInstanceId?: string; policy: unknown }
 >();
+const callerProvenanceByThread = new Map<
+  string,
+  {
+    sessionInstanceId: string;
+    mcpCallerKind?: LiziMcpSessionContext['mcpCallerKind'];
+    mcpCallerAttested?: boolean;
+  }
+>();
 
 /**
  * 懒启动 + 缓存。多个 codex session 并发首次调用共享同一个 in-flight Promise，
@@ -157,8 +165,40 @@ export function registerCodexMcpThreadContext(
     });
   }
   const effectivePolicy = disabledPluginPolicyByThread.get(threadId)?.policy;
+  const previousProvenance = callerProvenanceByThread.get(threadId);
+  const sameSessionInstance =
+    ctx.sessionInstanceId !== undefined &&
+    previousProvenance?.sessionInstanceId === ctx.sessionInstanceId;
+  if (ctx.sessionInstanceId !== undefined) {
+    callerProvenanceByThread.set(threadId, {
+      sessionInstanceId: ctx.sessionInstanceId,
+      ...(sameSessionInstance && ctx.mcpCallerKind === undefined
+        ? previousProvenance?.mcpCallerKind !== undefined
+          ? { mcpCallerKind: previousProvenance.mcpCallerKind }
+          : {}
+        : ctx.mcpCallerKind !== undefined
+          ? { mcpCallerKind: ctx.mcpCallerKind }
+          : {}),
+      ...(sameSessionInstance && ctx.mcpCallerAttested === undefined
+        ? previousProvenance?.mcpCallerAttested !== undefined
+          ? { mcpCallerAttested: previousProvenance.mcpCallerAttested }
+          : {}
+        : ctx.mcpCallerAttested !== undefined
+          ? { mcpCallerAttested: ctx.mcpCallerAttested }
+          : {}),
+    });
+  } else {
+    callerProvenanceByThread.delete(threadId);
+  }
+  const effectiveProvenance = callerProvenanceByThread.get(threadId);
   activeBridge?.registerThreadContext(threadId, {
     ...ctx,
+    ...(effectiveProvenance?.mcpCallerKind !== undefined
+      ? { mcpCallerKind: effectiveProvenance.mcpCallerKind }
+      : { mcpCallerKind: undefined }),
+    ...(effectiveProvenance?.mcpCallerAttested !== undefined
+      ? { mcpCallerAttested: effectiveProvenance.mcpCallerAttested }
+      : { mcpCallerAttested: undefined }),
     vendorOptions: {
       ...ctx.vendorOptions,
       [CODEX_DISABLED_BUILTIN_PLUGIN_IDS_KEY]: effectivePolicy,
@@ -171,14 +211,16 @@ export function unregisterCodexMcpThreadContext(
   expectedSessionInstanceId?: string,
 ): void {
   const frozen = disabledPluginPolicyByThread.get(threadId);
+  const provenance = callerProvenanceByThread.get(threadId);
   if (
     expectedSessionInstanceId !== undefined &&
-    frozen !== undefined &&
-    frozen.sessionInstanceId !== expectedSessionInstanceId
+    ((frozen !== undefined && frozen.sessionInstanceId !== expectedSessionInstanceId) ||
+      (provenance !== undefined && provenance.sessionInstanceId !== expectedSessionInstanceId))
   ) {
     return;
   }
   disabledPluginPolicyByThread.delete(threadId);
+  callerProvenanceByThread.delete(threadId);
   activeBridge?.unregisterThreadContext(threadId, expectedSessionInstanceId);
 }
 
@@ -212,6 +254,8 @@ async function doStart(
         ...(active.remoteHostId ? { remoteHostId: active.remoteHostId } : {}),
         vendorOptions: active.vendorOptions,
         sessionId: active.sessionId,
+        ...(active.mcpCallerKind ? { mcpCallerKind: active.mcpCallerKind } : {}),
+        ...(active.mcpCallerAttested ? { mcpCallerAttested: true } : {}),
         ...(active.sessionInstanceId
           ? { sessionInstanceId: active.sessionInstanceId }
           : {}),

--- a/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
+++ b/apps/desktop/src/main/mcp-integrations/piEnvironment.ts
@@ -184,6 +184,8 @@ export async function getPiExtraSpawnConfig(
       : {}),
     workingDir: sessionCtx?.workingDir ?? '',
     vendorOptions,
+    mcpCallerKind: sessionCtx?.mcpCallerKind ?? 'unknown',
+    mcpCallerAttested: sessionCtx?.mcpCallerAttested === true,
   };
   // 同 session 重建(resume/reattach)直接覆盖注册,注册表以 sessionId 为 key,
   // 天然不累积。必须在返回(即 spawn)前完成 —— cindy-bridge extension 一起进程
@@ -317,6 +319,8 @@ async function doStart(
         workingDir: active.workingDir,
         vendorOptions: active.vendorOptions,
         sessionId: active.sessionId,
+        mcpCallerKind: active.mcpCallerKind,
+        mcpCallerAttested: active.mcpCallerAttested,
         ...(active.sessionInstanceId
           ? { sessionInstanceId: active.sessionInstanceId }
           : {}),

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -729,6 +729,8 @@ export interface AndroidMcpDeps {
   logger?: LiziMcpLogger;
 }
 
+export type LiziMcpCallerKind = 'root' | 'descendant' | 'unknown';
+
 export interface LiziMcpSessionContext {
   agentKind: string;
   workingDir: string;
@@ -767,6 +769,10 @@ export interface LiziMcpSessionContext {
    * 模型或插件可控的工具参数。
    */
   sessionInstanceId?: string;
+  /** Host-owned caller provenance; never sourced from model tool arguments. */
+  mcpCallerKind?: LiziMcpCallerKind;
+  /** True only when the harness bridge has installed provenance enforcement. */
+  mcpCallerAttested?: boolean;
 }
 
 export interface CodexHttpMcpConfig {

--- a/packages/maker-cc-manager/__tests__/protocol.test.ts
+++ b/packages/maker-cc-manager/__tests__/protocol.test.ts
@@ -17,8 +17,8 @@ describe('protocol constants', () => {
     expect(PROTOCOL_VERSION).toBeGreaterThan(0);
   });
 
-  it('requires v2 so old daemons cannot ignore host tool guards', () => {
-    expect(PROTOCOL_VERSION).toBe(2);
+  it('requires v3 so old daemons cannot ignore root-only host tool guards', () => {
+    expect(PROTOCOL_VERSION).toBe(3);
   });
 
   it('METHODS has expected method names', () => {

--- a/packages/maker-cc-manager/__tests__/sdk-handlers.test.ts
+++ b/packages/maker-cc-manager/__tests__/sdk-handlers.test.ts
@@ -394,6 +394,22 @@ describe('sdk-handlers end-to-end', () => {
     });
   });
 
+  it('query/start accepts an exact root-only Orca tool guard', async () => {
+    await ctx!.client.request('query/start', {
+      sessionId: 's-root-only',
+      cwd: '/a',
+      model: 'm',
+      env: {},
+      toolGuards: [{
+        toolNamePrefix: 'mcp__orca_worker_bridge__send_to_lead',
+        sourceServerId: 'orca_worker_bridge',
+        invocation: 'root-only',
+      }],
+    });
+    await waitFor(() => ctx!.notifications.length >= 1);
+    expect(latestFactoryOptions?.hooks?.PreToolUse?.[0]?.hooks[0]).toBeDefined();
+  });
+
   it('query/close ends consume loop → session.alive=false + closed notification', async () => {
     await ctx!.client.request('query/start', { sessionId: 's1', cwd: '/a', model: 'm', env: {} });
     await waitFor(() => ctx!.notifications.length >= 1);

--- a/packages/maker-cc-manager/__tests__/session-registry.test.ts
+++ b/packages/maker-cc-manager/__tests__/session-registry.test.ts
@@ -245,6 +245,47 @@ describe('SessionRegistry', () => {
     ).resolves.toEqual({ continue: true });
   });
 
+  it('allows the exact Orca report tool for the root and denies nested Claude agents', async () => {
+    const { factory: baseFactory } = buildFakeFactory();
+    let captured: SdkQueryFactoryOptions | undefined;
+    const registry = new SessionRegistry({
+      sdkQueryFactory: (opts) => {
+        captured = opts;
+        return baseFactory(opts);
+      },
+    });
+    registry.create({
+      sessionId: 's-orca-root-only',
+      cwd: '/x',
+      model: 'm',
+      env: {},
+      toolGuards: [{
+        toolNamePrefix: 'mcp__orca_worker_bridge__send_to_lead',
+        sourceServerId: 'orca_worker_bridge',
+        invocation: 'root-only',
+        denialMessage: 'NESTED_AGENT_NOT_ALLOWED',
+      }],
+    });
+    const preToolUse = captured?.hooks?.PreToolUse?.[0]?.hooks[0];
+    expect(preToolUse).toBeDefined();
+    const call = {
+      hook_event_name: 'PreToolUse',
+      tool_name: 'mcp__orca_worker_bridge__send_to_lead',
+    };
+    await expect(preToolUse!(call)).resolves.toEqual({ continue: true });
+    await expect(preToolUse!({ ...call, agent_id: 'child-1' })).resolves.toMatchObject({
+      hookSpecificOutput: {
+        permissionDecision: 'deny',
+        permissionDecisionReason: 'NESTED_AGENT_NOT_ALLOWED',
+      },
+    });
+    await expect(preToolUse!({
+      ...call,
+      tool_name: 'mcp__orca_worker_bridge__read_lead',
+      agent_id: 'child-1',
+    })).resolves.toEqual({ continue: true });
+  });
+
   it('keeps explicit selection across accepted same-turn steering inputs', async () => {
     let captured: SdkQueryFactoryOptions | undefined;
     const factory: SdkQueryFactory = (opts) => {

--- a/packages/maker-cc-manager/src/protocol.ts
+++ b/packages/maker-cc-manager/src/protocol.ts
@@ -23,12 +23,15 @@
  * PreToolUse 闸门。旧 daemon 会无声忽略未知字段，导致 capability routing
  * fail-open，因此这项表面上的字段新增必须按不兼容协议升级处理。
  *
+ * v3: toolGuards 增加 root-only，使用 SDK agent_id 阻止远端 subagent
+ * 调用受保护工具。旧 daemon 无法证明调用来源，因此必须升级协议。
+ *
  * v1 (redesign): 删除 dead-session drain/archive 握手,对齐 codex 模式。
  * reattach 只接新 events (live-only subscription),不 replay 旧 ring buffer。
  * ring buffer 降级为纯内存 fast-path(同一 daemon 进程生命周期内的 mid-turn 续流)。
  * 断开期间跑完的输出暂不自动补回 chat(follow-up: jsonl recovery 统一 cc + codex)。
  */
-export const PROTOCOL_VERSION = 2 as const;
+export const PROTOCOL_VERSION = 3 as const;
 
 /**
  * cc-mgr bundle 版本号 — 手动 bump。
@@ -37,7 +40,7 @@ export const PROTOCOL_VERSION = 2 as const;
  * 无关依赖变化而变。desktop 用这个（而非 bundle sha256）判断远端 daemon
  * 是否需要 upgrade,避免无关的 pnpm install 触发全量远端重装。
  */
-export const CC_MGR_BUNDLE_VERSION = '0.0.6' as const;
+export const CC_MGR_BUNDLE_VERSION = '0.0.7' as const;
 
 export type RpcId = number;
 
@@ -211,7 +214,7 @@ export interface QueryToolGuard {
   toolNamePrefix: string;
   /** Exact harness-owned MCP server id before Claude normalizes punctuation. */
   sourceServerId?: string;
-  invocation: 'auto' | 'explicit-only' | 'disabled';
+  invocation: 'auto' | 'explicit-only' | 'disabled' | 'root-only';
   /** Explicit command tokens that select this source for the active turn. */
   explicitSelectors?: string[];
   /** Optional user-facing denial reason returned by the PreToolUse hook. */

--- a/packages/maker-cc-manager/src/sdk-handlers.ts
+++ b/packages/maker-cc-manager/src/sdk-handlers.ts
@@ -372,10 +372,11 @@ function validateToolGuards(value: unknown): QueryToolGuard[] | undefined {
     if (
       guard.invocation !== 'auto' &&
       guard.invocation !== 'explicit-only' &&
-      guard.invocation !== 'disabled'
+      guard.invocation !== 'disabled' &&
+      guard.invocation !== 'root-only'
     ) {
       throwInvalid(
-        `toolGuards[${index}].invocation must be auto, explicit-only, or disabled`,
+        `toolGuards[${index}].invocation must be auto, explicit-only, disabled, or root-only`,
       );
     }
     if (
@@ -399,9 +400,12 @@ function validateToolGuards(value: unknown): QueryToolGuard[] | undefined {
     }
     const toolNamePrefix = guard.toolNamePrefix.trim();
     const sourceServerId = guard.sourceServerId?.trim();
-    if (!/^mcp__[A-Za-z0-9_-]+__$/.test(toolNamePrefix)) {
+    const validToolName = guard.invocation === 'root-only'
+      ? /^mcp__[A-Za-z0-9_-]+__[A-Za-z0-9_-]+$/.test(toolNamePrefix)
+      : /^mcp__[A-Za-z0-9_-]+__$/.test(toolNamePrefix);
+    if (!validToolName) {
       throwInvalid(
-        `toolGuards[${index}].toolNamePrefix must be a normalized Claude MCP tool prefix`,
+        `toolGuards[${index}].toolNamePrefix must be a normalized Claude MCP tool ${guard.invocation === 'root-only' ? 'name' : 'prefix'}`,
       );
     }
     return {

--- a/packages/maker-cc-manager/src/session-registry.ts
+++ b/packages/maker-cc-manager/src/session-registry.ts
@@ -1121,6 +1121,7 @@ function hasToolGuardMcpPrefixCollision(
   guard: QueryToolGuard,
   mcpServerNames: ReadonlySet<string>,
 ): boolean {
+  if (guard.invocation === 'root-only') return false;
   if (!guard.sourceServerId) return false;
   // The caller passes only connected host/user/project/local MCPs. An exact id
   // can therefore be a user MCP shadowing the harness source.
@@ -1135,13 +1136,19 @@ function findDeniedToolGuard(
   toolName: string,
   selectionText: string,
   mcpServerNames: ReadonlySet<string>,
+  agentId?: string,
 ): QueryToolGuard | undefined {
   const guard = toolGuards?.find(
     (candidate) =>
-      toolName.startsWith(candidate.toolNamePrefix) &&
+      (candidate.invocation === 'root-only'
+        ? toolName === candidate.toolNamePrefix
+        : toolName.startsWith(candidate.toolNamePrefix)) &&
       !hasToolGuardMcpPrefixCollision(candidate, mcpServerNames),
   );
   if (!guard || guard.invocation === 'auto') return undefined;
+  if (guard.invocation === 'root-only') {
+    return typeof agentId === 'string' && agentId.length > 0 ? guard : undefined;
+  }
   if (
     guard.invocation === 'explicit-only' &&
     guard.explicitSelectors?.some((selector) =>
@@ -1173,6 +1180,7 @@ function createToolGuardHooks(
       toolName,
       getSelectionText(),
       getMcpServerNames(),
+      typeof input.agent_id === 'string' ? input.agent_id : undefined,
     );
     if (!guard) return { continue: true };
 

--- a/packages/maker-core/src/agents/base-agent.ts
+++ b/packages/maker-core/src/agents/base-agent.ts
@@ -83,6 +83,9 @@ export interface AgentCapabilityAdditions {
 export interface CodexMcpThreadContextArgs {
   threadId: string;
   sessionId: string;
+  /** Host-owned app-server thread lineage. */
+  mcpCallerKind: 'root' | 'descendant' | 'unknown';
+  mcpCallerAttested: boolean;
   /** 当前 Maker Session 实例代号；同 business session 重建后必须变化。 */
   sessionInstanceId?: string;
   workingDir: string;
@@ -209,6 +212,8 @@ export interface PiExtraSpawnConfigContext {
   sessionInstanceId?: string;
   workingDir: string;
   vendorOptions?: Record<string, unknown>;
+  mcpCallerKind?: 'root' | 'descendant' | 'unknown';
+  mcpCallerAttested?: boolean;
 }
 
 export interface CodexExtraSpawnConfig {

--- a/packages/maker-core/src/agents/claude-code/__tests__/capability-routing.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/capability-routing.test.ts
@@ -2,11 +2,49 @@ import { describe, expect, it } from 'vitest';
 
 import type { CapabilityRoutingPolicy } from '../../../types/capability-routing.js';
 import {
+  buildClaudeOrcaCallerProvenanceHooks,
+  buildClaudeRemoteOrcaCallerGuards,
   buildClaudeLocalToolGuardHooks,
   buildClaudeRemoteToolGuards,
   buildClaudeSkillOverrides,
   mergeClaudeHookSets,
+  ORCA_SEND_TO_LEAD_TOOL_NAME,
 } from '../capability-routing.js';
+
+describe('Claude Orca caller provenance', () => {
+  it('allows the root locally but denies a native subagent before MCP dispatch', async () => {
+    const hook = buildClaudeOrcaCallerProvenanceHooks().PreToolUse?.[0]?.hooks[0];
+    if (!hook) throw new Error('expected Orca caller provenance hook');
+    const input = {
+      hook_event_name: 'PreToolUse' as const,
+      session_id: 'session-orca-worker',
+      transcript_path: '/tmp/transcript',
+      cwd: '/repo',
+      tool_name: ORCA_SEND_TO_LEAD_TOOL_NAME,
+      tool_input: { worker_id: 'forged-worker-id' },
+      tool_use_id: 'tool-orca-report',
+    };
+
+    await expect(hook(input, 'tool-orca-report', {
+      signal: new AbortController().signal,
+    })).resolves.toEqual({ continue: true });
+    await expect(hook({ ...input, agent_id: 'native-child-1' }, 'tool-orca-report', {
+      signal: new AbortController().signal,
+    })).resolves.toMatchObject({
+      hookSpecificOutput: { permissionDecision: 'deny' },
+    });
+  });
+
+  it('serializes one exact root-only guard for a remote Orca worker', () => {
+    expect(buildClaudeRemoteOrcaCallerGuards(true)).toEqual([{
+      toolNamePrefix: ORCA_SEND_TO_LEAD_TOOL_NAME,
+      sourceServerId: 'orca_worker_bridge',
+      invocation: 'root-only',
+      denialMessage: 'NESTED_AGENT_NOT_ALLOWED: nested agent cannot report directly to the lead',
+    }]);
+    expect(buildClaudeRemoteOrcaCallerGuards(false)).toEqual([]);
+  });
+});
 
 describe('buildClaudeSkillOverrides', () => {
   it('maps host policy to Claude Code native skill visibility', () => {

--- a/packages/maker-core/src/agents/claude-code/capability-routing.ts
+++ b/packages/maker-core/src/agents/claude-code/capability-routing.ts
@@ -16,8 +16,29 @@ import {
   isHarnessOwnedCapabilitySource,
   isCapabilityRouteInvocationAllowed,
 } from '../../types/capability-routing.js';
+import { ORCA_NESTED_REPORT_DENIAL_REASON } from '../shared/orca-report-policy.js';
 
 const CLAUDE_CODE_HARNESS_ID = 'claude-code';
+export const ORCA_SEND_TO_LEAD_TOOL_NAME = 'mcp__orca_worker_bridge__send_to_lead';
+
+/** Claude root calls have no agent_id; native subagents always carry one. */
+export function buildClaudeOrcaCallerProvenanceHooks(): Partial<Record<HookEvent, HookCallbackMatcher[]>> {
+  const guardTool: HookCallback = async (input) => {
+    if (input.hook_event_name !== 'PreToolUse') return { continue: true };
+    const pre = input as PreToolUseHookInput;
+    if (pre.tool_name !== ORCA_SEND_TO_LEAD_TOOL_NAME) return { continue: true };
+    if (typeof pre.agent_id !== 'string' || pre.agent_id.length === 0) return { continue: true };
+    return {
+      continue: true,
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: ORCA_NESTED_REPORT_DENIAL_REASON,
+      },
+    };
+  };
+  return { PreToolUse: [{ matcher: ORCA_SEND_TO_LEAD_TOOL_NAME, hooks: [guardTool] }] };
+}
 
 function isClaudeSkillDirective(directive: CapabilityRouteOverride): boolean {
   return (
@@ -60,9 +81,19 @@ export function buildClaudeSkillOverrides(
 export interface ClaudeRemoteToolGuard {
   toolNamePrefix: string;
   sourceServerId: string;
-  invocation: 'auto' | 'explicit-only' | 'disabled';
+  invocation: 'auto' | 'explicit-only' | 'disabled' | 'root-only';
   explicitSelectors?: string[];
   denialMessage?: string;
+}
+
+export function buildClaudeRemoteOrcaCallerGuards(isOrcaWorker: boolean): ClaudeRemoteToolGuard[] {
+  if (!isOrcaWorker) return [];
+  return [{
+    toolNamePrefix: ORCA_SEND_TO_LEAD_TOOL_NAME,
+    sourceServerId: 'orca_worker_bridge',
+    invocation: 'root-only',
+    denialMessage: ORCA_NESTED_REPORT_DENIAL_REASON,
+  }];
 }
 
 /**

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -109,7 +109,9 @@ import {
 } from './env-builder.js';
 import { buildClaudeFlagSettings } from './flag-settings.js';
 import {
+  buildClaudeOrcaCallerProvenanceHooks,
   buildClaudeLocalToolGuardHooks,
+  buildClaudeRemoteOrcaCallerGuards,
   buildClaudeRemoteToolGuards,
   mergeClaudeHookSets,
 } from './capability-routing.js';
@@ -1172,6 +1174,8 @@ export class ClaudeCodeAgent extends BaseAgent {
         // 到对应 session 的业务函数。host 直接调 startSession 而没透 sessionId
         // 时此处为 undefined, 工具按"无 session 绑定"语义处理。
         sessionId: opts.sessionId,
+        mcpCallerKind: 'root',
+        mcpCallerAttested: true,
         ...(opts.sessionInstanceId ? { sessionInstanceId: opts.sessionInstanceId } : {}),
         getSessionContext: () => context,
       };
@@ -1299,6 +1303,10 @@ export class ClaudeCodeAgent extends BaseAgent {
         PostToolUse: [{ hooks: [turnChangeCaptureHook] }],
         PostToolUseFailure: [{ hooks: [turnChangeCaptureHook] }],
       },
+      // Keep the existing local routing/capture hooks first: callers and tests
+      // rely on their observable order. The exact-match Orca provenance guard
+      // still runs for send_to_lead after those hooks and denies descendants.
+      buildClaudeOrcaCallerProvenanceHooks(),
       this.deps.claudeHooks,
     );
     const deniedCapabilityRoute = (toolName: string) => {
@@ -2422,9 +2430,10 @@ export class ClaudeCodeAgent extends BaseAgent {
             ? 'auto'
             : requestedRemotePermissionMode;
         sdkInPlanMode = remotePermissionMode === 'plan';
-        const remoteToolGuards = buildClaudeRemoteToolGuards(
-          this.deps.capabilityRouting,
-        );
+        const remoteToolGuards = [
+          ...buildClaudeRemoteToolGuards(this.deps.capabilityRouting),
+          ...buildClaudeRemoteOrcaCallerGuards(vo.orcaRole === 'worker'),
+        ];
 
         const startParams: Record<string, unknown> = {
           cwd: opts.workingDir,

--- a/packages/maker-core/src/agents/codex/index.test.ts
+++ b/packages/maker-core/src/agents/codex/index.test.ts
@@ -3271,12 +3271,16 @@ describe('CodexAgent.startSession developerInstructions', () => {
       sessionId: 'session-child-route',
       workingDir: '/repo',
       vendorOptions: {},
+      mcpCallerKind: 'descendant',
+      mcpCallerAttested: true,
     });
     expect(registerCodexMcpThreadContext).toHaveBeenNthCalledWith(3, {
       threadId: 'grandchild-thread-id',
       sessionId: 'session-child-route',
       workingDir: '/repo',
       vendorOptions: {},
+      mcpCallerKind: 'descendant',
+      mcpCallerAttested: true,
     });
 
     await handle.close();
@@ -6052,6 +6056,8 @@ describe('CodexAgent MCP thread context hooks', () => {
       sessionInstanceId: 'instance-codex-mcp-context',
       workingDir: '/repo',
       vendorOptions: { orcaRole: 'lead' },
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
     });
 
     await handle.close();
@@ -10715,6 +10721,8 @@ describe('CodexAgent MCP thread context hooks', () => {
       // ssh:<hostId>:<path> 的独立 store。
       remoteHostId: 'remote-host-1',
       vendorOptions: {},
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
     });
     await handle.close();
     expect(unregisterCodexMcpThreadContext).toHaveBeenCalledWith('start-thread-id');

--- a/packages/maker-core/src/agents/codex/index.ts
+++ b/packages/maker-core/src/agents/codex/index.ts
@@ -3663,7 +3663,10 @@ export class CodexAgent extends BaseAgent {
       });
     }
 
-    const registerCodexMcpContext = (threadId: string): void => {
+    const registerCodexMcpContext = (
+      threadId: string,
+      mcpCallerKind: 'root' | 'descendant',
+    ): void => {
       // remoteHostId 不再跳过:远端 daemon 经 SSH remote-forward 直连本机
       // HTTP MCP bridge 后,tool call 同样按 params._meta.threadId 路由,
       // 需要这条注册让 CodexMcpThreadContextStore 能解析 remote thread。
@@ -3674,6 +3677,8 @@ export class CodexAgent extends BaseAgent {
         register({
           threadId,
           sessionId: sid,
+          mcpCallerKind,
+          mcpCallerAttested: true,
           ...(opts.sessionInstanceId ? { sessionInstanceId: opts.sessionInstanceId } : {}),
           workingDir: opts.workingDir,
           // remote thread ctx: scope key 语义见 buildMemoryScopeKey。
@@ -3683,6 +3688,7 @@ export class CodexAgent extends BaseAgent {
         log.debug('codex MCP thread context registered', {
           threadId: prefixId(threadId),
           sessionId: prefixId(sid),
+          mcpCallerKind,
           orcaRole: typeof vo.orcaRole === 'string' ? vo.orcaRole : undefined,
           workerId: typeof vo.orcaWorkerId === 'string' ? prefixId(vo.orcaWorkerId) : undefined,
         });
@@ -3706,10 +3712,14 @@ export class CodexAgent extends BaseAgent {
       }
     };
     const descendantMcpThreadIds = new Set<string>();
+    const registerRootCodexMcpContext = (): void => {
+      descendantMcpThreadIds.delete(threadId);
+      registerCodexMcpContext(threadId, 'root');
+    };
     const registerDescendantCodexMcpContext = (descendantThreadId: string): void => {
       if (descendantThreadId === threadId || descendantMcpThreadIds.has(descendantThreadId)) return;
       descendantMcpThreadIds.add(descendantThreadId);
-      registerCodexMcpContext(descendantThreadId);
+      registerCodexMcpContext(descendantThreadId, 'descendant');
     };
     const unregisterDescendantCodexMcpContexts = (): void => {
       for (const descendantThreadId of descendantMcpThreadIds) {
@@ -4665,7 +4675,7 @@ export class CodexAgent extends BaseAgent {
           threadId = nextThreadId;
           sdkSessionId = nextThreadId;
           subscription = host.subscribeThread(threadId, handlers);
-          registerCodexMcpContext(threadId);
+          registerRootCodexMcpContext();
           refreshCodexAutoReviewerRoute(threadId);
           eventQueue.push({ type: 'session_id', data: sdkSessionId, source: 'codex' });
           if (replacementServiceTierGeneration !== serviceTierMutationGeneration) {
@@ -4791,7 +4801,7 @@ export class CodexAgent extends BaseAgent {
       pendingForTurn: Map<string, PendingUserInputInteraction>;
       pendingInteraction: PendingUserInputInteraction;
     }>();
-    registerCodexMcpContext(threadId);
+    registerRootCodexMcpContext();
     let mcpElicitationSeq = 0;
 
     const codexSessionApprovalSuggestions = () =>
@@ -9964,9 +9974,9 @@ export class CodexAgent extends BaseAgent {
         // Keep the same vendorOptions object so active MCP handlers and the
         // host bridge see runtime Orca role/workflow updates by reference.
         Object.assign(vo, patch);
-        registerCodexMcpContext(threadId);
+        registerRootCodexMcpContext();
         for (const descendantThreadId of descendantMcpThreadIds) {
-          registerCodexMcpContext(descendantThreadId);
+          registerCodexMcpContext(descendantThreadId, 'descendant');
         }
         log.debug('setVendorOptions', {
           patchKeys: Object.keys(patch),
@@ -10029,7 +10039,7 @@ export class CodexAgent extends BaseAgent {
           readonlyReferencesProfileActive = false;
           threadMayHaveRollout = true;
           subscription = host.subscribeThread(threadId, handlers);
-          registerCodexMcpContext(threadId);
+          registerRootCodexMcpContext();
           refreshCodexAutoReviewerRoute(threadId);
           registerCodexDeveloperInstructions(threadId, registeredDeveloperInstructions);
           eventQueue.push({ type: 'session_id', data: sdkSessionId, source: 'codex' });

--- a/packages/maker-core/src/agents/index.ts
+++ b/packages/maker-core/src/agents/index.ts
@@ -74,6 +74,11 @@ export {
   type AutoReviewRequest,
 } from './shared/auto-review-decision.js';
 export type { ReviewableAction } from './shared/auto-review.js';
+export {
+  ORCA_NESTED_REPORT_DENIAL_REASON,
+  ORCA_NESTED_REPORT_ERROR_CODE,
+  ORCA_NESTED_REPORT_ERROR_MESSAGE,
+} from './shared/orca-report-policy.js';
 // host 侧会话分享(导出/导入 .xdtshare)需要按 cwd 复算 CLI 转录目录、
 // 定位/落位 jsonl。规则单点维护在 claude-projects-fs.ts,这里仅 re-export。
 export {

--- a/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
+++ b/packages/maker-core/src/agents/pi/__tests__/pi-startsession-cleanup.test.ts
@@ -178,6 +178,8 @@ describe('PiAgent.startSession failure cleanup (mocked pi process)', () => {
       sessionId: 's1',
       sessionInstanceId: 'pi-instance-1',
       workingDir: cwd,
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
     });
     expect(disposed).toBe(0);
     expect(proxyDisposed).toBe(0);

--- a/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
+++ b/packages/maker-core/src/agents/pi/cindy-subagent-source.ts
@@ -371,7 +371,9 @@ function runTask(binary, task, runtime, signal, onProgress) {
     // 见文件头),而 bridge 一见到 CINDY_PI_MCP_BRIDGE 就会**逐个 connect 所有 MCP server**
     // 并持有有状态 transport。子代理的 --tools 白名单里根本没有 MCP 工具,所以这些连接纯属
     // 浪费:每个子代理一整套连接、每次派发一轮连接风暴(并发 4、单次最多 8),而且子代理不会
-    // 显式 close,只能等进程退出(review)。剥这一个变量即可 —— 权限门与网关路由不受影响。
+    // 显式 close,只能等进程退出(review)。这也是来源隔离不变量:子代理不能继承 root
+    // bridge；未来若开放 MCP，Host 必须为子进程签发 descendant provenance。
+    // 剥这一个变量即可 —— 权限门与网关路由不受影响。
     delete childEnv[MCP_BRIDGE_ENV];
 
     let child;

--- a/packages/maker-core/src/agents/pi/index.ts
+++ b/packages/maker-core/src/agents/pi/index.ts
@@ -962,6 +962,8 @@ export class PiAgent extends BaseAgent {
           ...(opts.sessionInstanceId ? { sessionInstanceId: opts.sessionInstanceId } : {}),
           workingDir: opts.workingDir,
           vendorOptions: mutableVendorOptions,
+          mcpCallerKind: 'root',
+          mcpCallerAttested: true,
         });
         mcpBridge = extra?.mcpBridge ?? null;
         mcpEnv = extra?.mcpEnv ?? {};

--- a/packages/maker-core/src/agents/shared/orca-report-policy.ts
+++ b/packages/maker-core/src/agents/shared/orca-report-policy.ts
@@ -1,0 +1,5 @@
+export const ORCA_NESTED_REPORT_ERROR_CODE = 'NESTED_AGENT_NOT_ALLOWED' as const;
+export const ORCA_NESTED_REPORT_ERROR_MESSAGE =
+  'nested agent cannot report directly to the lead' as const;
+export const ORCA_NESTED_REPORT_DENIAL_REASON =
+  `${ORCA_NESTED_REPORT_ERROR_CODE}: ${ORCA_NESTED_REPORT_ERROR_MESSAGE}` as const;

--- a/packages/maker-core/src/interfaces/mcp-provider.ts
+++ b/packages/maker-core/src/interfaces/mcp-provider.ts
@@ -1,5 +1,7 @@
 import type { AgentKind } from '../types/common.js';
 
+export type McpCallerKind = 'root' | 'descendant' | 'unknown';
+
 export interface McpProviderContext {
   agentKind: AgentKind;
   workingDir: string;
@@ -22,6 +24,10 @@ export interface McpProviderContext {
    * 但不得下发成模型或插件可控的工具参数。
    */
   sessionInstanceId?: string;
+  /** Host-owned caller provenance; never sourced from model tool arguments. */
+  mcpCallerKind?: McpCallerKind;
+  /** True only when the harness bridge has installed provenance enforcement. */
+  mcpCallerAttested?: boolean;
   /**
    * 返回当前 tool-call 绑定的真实 session ctx。
    *

--- a/packages/orca-workflow/src/__tests__/orca-bridge-mcp.test.ts
+++ b/packages/orca-workflow/src/__tests__/orca-bridge-mcp.test.ts
@@ -4,6 +4,7 @@ import type {
   Logger,
   Maker,
   McpProvider,
+  McpProviderContext,
   Session,
   SessionSendOptions,
   SessionSendResult,
@@ -12,7 +13,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   __testing,
+  authorizeSendToLeadCaller,
   createOrcaWorkerBridgeMcpProvider,
+  SEND_TO_LEAD_TOOL_DESCRIPTION,
   type OrcaBridgeMcpDeps,
   type OrcaWorkerLink,
 } from '../orca-bridge-mcp';
@@ -254,7 +257,11 @@ function makeProvider(opts?: {
 function getServer(provider: McpProvider, ctx: Record<string, unknown>) {
   const toClaudeSdkConfig = provider.toClaudeSdkConfig;
   if (!toClaudeSdkConfig) throw new Error('expected SDK MCP provider');
-  const config = toClaudeSdkConfig(ctx as never) as { type?: string; instance?: unknown } | null;
+  const config = toClaudeSdkConfig({
+    mcpCallerKind: 'root',
+    mcpCallerAttested: true,
+    ...ctx,
+  } as never) as { type?: string; instance?: unknown } | null;
   if (config?.type !== 'sdk') throw new Error('expected sdk MCP config');
   return config.instance as unknown as FakeMcpServer;
 }
@@ -267,6 +274,111 @@ function parseToolJson(result: unknown): Record<string, unknown> {
 }
 
 describe('orca_worker_bridge MCP helpers', () => {
+  it('keeps the caller policy and model-only report contract concise', () => {
+    expect(authorizeSendToLeadCaller({
+      agentKind: 'codex',
+      workingDir: '/repo',
+      mcpCallerKind: 'root',
+      mcpCallerAttested: true,
+    })).toEqual({ ok: true });
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).toContain('direct reporting channel to the Lead');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).toContain('Native subagents are internal helpers');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).toContain('return findings to the Worker instead of calling this tool');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).toContain('Call once per turn');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).toContain('final report or one blocking question');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).toContain('After a question, stop and wait for send_to_worker');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).toContain('do not send progress');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION).not.toContain('root Orca Worker');
+    expect(SEND_TO_LEAD_TOOL_DESCRIPTION.length).toBeLessThan(700);
+  });
+
+  it.each([
+    ['descendant', true, 'NESTED_AGENT_NOT_ALLOWED'],
+    ['unknown', true, 'CALLER_PROVENANCE_REQUIRED'],
+    ['root', false, 'CALLER_PROVENANCE_REQUIRED'],
+  ] as const)('rejects %s/attested=%s before every send side effect', async (
+    mcpCallerKind,
+    mcpCallerAttested,
+    expectedCode,
+  ) => {
+    const lead = makeSession('lead-1');
+    const workerLink: OrcaWorkerLink = {
+      workerId: 'worker-1',
+      workflowId: 'workflow-1',
+      workerSessionId: 'worker-session-1',
+      leadSessionId: 'lead-1',
+      leadSession: {
+        sessionId: 'lead-1',
+        agentKind: 'claude-code',
+        workingDir: '/repo',
+        model: 'claude-opus-4-7',
+      },
+    };
+    const getWorkerLink = vi.fn(async () => workerLink);
+    const dispatchInterAgentMessage = vi.fn();
+    const { createSessionCalls, maker, persisted, statusUpdates } = makeProvider({
+      activeSessions: { 'lead-1': lead },
+      workerLink,
+    });
+    const provider = createOrcaWorkerBridgeMcpProvider({
+      getMaker: () => maker as unknown as Maker,
+      logger: makeLogger(),
+      persistUserMessage: async (sessionId, message) => {
+        persisted.push({ sessionId, content: message.content });
+      },
+      wireSession: () => undefined,
+      dispatchInterAgentMessage,
+      orcaTeamStore: {
+        getWorkerLink,
+        async updateWorkerStatus(workerId, status) {
+          statusUpdates.push({ workerId, status });
+        },
+      },
+    });
+    const runtimeContext: McpProviderContext = {
+      agentKind: 'codex',
+      workingDir: '/repo',
+      sessionId: 'worker-session-1',
+      mcpCallerKind,
+      mcpCallerAttested,
+      vendorOptions: {
+        orcaRole: 'worker',
+        orcaWorkerId: 'worker-1',
+        orcaWorkerSessionId: 'worker-session-1',
+      },
+    };
+    const server = getServer(provider, {
+      agentKind: 'codex',
+      workingDir: '/repo',
+      getSessionContext: () => runtimeContext,
+    });
+
+    expect(parseToolJson(await server._registeredTools.read_lead.handler({
+      worker_id: 'worker-1',
+    }))).toMatchObject({ lead_session_id: 'lead-1' });
+    const lookupCount = getWorkerLink.mock.calls.length;
+    __testing.setAutoBridgePending('worker-1', true);
+
+    try {
+      expect(expectToolError(await server._registeredTools.send_to_lead.handler({
+        worker_id: 'forged-worker-id',
+        message: 'partial child result',
+      }))).toMatchObject({ code: expectedCode });
+      expect(getWorkerLink).toHaveBeenCalledTimes(lookupCount);
+      expect(dispatchInterAgentMessage).not.toHaveBeenCalled();
+      expect(createSessionCalls).toEqual([]);
+      expect(persisted).toEqual([]);
+      expect(statusUpdates).toEqual([]);
+      expect(lead.sent).toEqual([]);
+      expect(__testing.hasAutoBridgePending('worker-1')).toBe(true);
+      expect(parseToolJson(await server._registeredTools.lead_status.handler({
+        worker_id: 'worker-1',
+      }))).toMatchObject({ lead_session_id: 'lead-1' });
+    } finally {
+      __testing.clearAutoBridgeState('worker-1');
+    }
+  });
+
   function makeWorkerBridgeLeadHarness(lead: FakeSession) {
     const logger = makeLogger();
     const workerLink: OrcaWorkerLink = {
@@ -1204,6 +1316,8 @@ describe('orca_worker_bridge MCP helpers', () => {
         agentKind: 'codex',
         workingDir: '/repo',
         sessionId: 'other-session',
+        mcpCallerKind: 'root',
+        mcpCallerAttested: true,
         vendorOptions: {
           orcaRole: 'worker',
           orcaWorkerId: 'worker-1',

--- a/packages/orca-workflow/src/__tests__/orca-bridge-prompt.test.ts
+++ b/packages/orca-workflow/src/__tests__/orca-bridge-prompt.test.ts
@@ -127,6 +127,8 @@ describe('renderOrcaLeadSystemPrompt', () => {
 describe('renderOrcaWorkerSystemPrompt', () => {
   const subagentHint =
     'If the user asks for a "subagent" / "子代理", use your own native subagent mechanism (for example Codex spawn_agent, or the Claude Code Agent/Task tool) to handle it yourself — do NOT escalate to the lead for it, and do NOT call start_team / create_worker (you cannot create Orca workers). If you have no native subagent mechanism, tell the user so instead of substituting an Orca Worker or spawning processes yourself; an Orca Worker is never a substitute for a subagent.';
+  const workerSubagentReportingBoundary =
+    'If you use native subagents, have them return findings only to you. Never tell them to contact the Lead or call send_to_lead; aggregate their results and report to the Lead yourself.';
 
   const workerMeta = {
     workerId: 'worker-1',
@@ -139,6 +141,20 @@ describe('renderOrcaWorkerSystemPrompt', () => {
     const prompt = renderOrcaWorkerSystemPrompt(workerMeta);
 
     expect(prompt).toContain(subagentHint);
+  });
+
+  it('keeps native subagent reporting with the Orca Worker', () => {
+    const prompt = renderOrcaWorkerSystemPrompt(workerMeta);
+    expect(prompt).toContain(workerSubagentReportingBoundary);
+    expect(prompt).toContain('3. ALWAYS call send_to_lead when complete or blocked.');
+    expect(prompt).toContain('4. Report once; do not send progress updates.');
+    expect(prompt).toContain('10. If the user asks for a "subagent" / "子代理"');
+    expect(prompt.indexOf('3. ALWAYS call send_to_lead')).toBeLessThan(
+      prompt.indexOf(workerSubagentReportingBoundary),
+    );
+    expect(prompt.indexOf(workerSubagentReportingBoundary)).toBeLessThan(
+      prompt.indexOf('4. Report once; do not send progress updates.'),
+    );
   });
 
   it('keeps the subagent routing hint with worker identity metadata', () => {

--- a/packages/orca-workflow/src/orca-bridge-mcp.ts
+++ b/packages/orca-workflow/src/orca-bridge-mcp.ts
@@ -2,7 +2,12 @@ import { randomUUID } from 'node:crypto';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import { isTerminalAgentErrorEvent, toSessionDispatchOutcome } from '@cindy/maker-core';
+import {
+  isTerminalAgentErrorEvent,
+  ORCA_NESTED_REPORT_ERROR_CODE,
+  ORCA_NESTED_REPORT_ERROR_MESSAGE,
+  toSessionDispatchOutcome,
+} from '@cindy/maker-core';
 import type { AgentEvent, AgentKind, Logger, Maker, McpProvider, McpProviderContext, Session } from '@cindy/maker-core';
 import {
   isProductTurnDoneEvent,
@@ -175,6 +180,37 @@ interface SanitizedOrcaSendError {
 const ORCA_SEND_OWNER = 'orca-workflow';
 const SAFE_ERROR_NAME_RE = /^[A-Za-z][A-Za-z0-9]{0,63}$/;
 const SAFE_SEND_ERROR_CODES = new Set(['SESSION_RUNNING']);
+
+export const SEND_TO_LEAD_TOOL_DESCRIPTION = [
+  'Pass the worker_id from the latest Lead message.',
+  'This tool is the assigned Orca Worker\'s direct reporting channel to the Lead.',
+  'Native subagents are internal helpers, so they return findings to the Worker instead of calling this tool.',
+  'Call once per turn, only with the final report or one blocking question.',
+  'After a question, stop and wait for send_to_worker.',
+  'Combine all results; do not send progress, partial findings, or same-turn corrections.',
+].join(' ');
+
+export function authorizeSendToLeadCaller(ctx: McpProviderContext):
+  | { ok: true }
+  | { ok: false; error: { error: string; code: 'NESTED_AGENT_NOT_ALLOWED' | 'CALLER_PROVENANCE_REQUIRED' } } {
+  if (ctx.mcpCallerAttested === true && ctx.mcpCallerKind === 'root') return { ok: true };
+  if (ctx.mcpCallerAttested === true && ctx.mcpCallerKind === 'descendant') {
+    return {
+      ok: false,
+      error: {
+        error: ORCA_NESTED_REPORT_ERROR_MESSAGE,
+        code: ORCA_NESTED_REPORT_ERROR_CODE,
+      },
+    };
+  }
+  return {
+    ok: false,
+    error: {
+      error: 'caller provenance is required to report directly to the lead',
+      code: 'CALLER_PROVENANCE_REQUIRED',
+    },
+  };
+}
 
 function makeOrcaSendContext(entrypoint: string, sessionId: string, action: string): string {
   return `${entrypoint}/${sessionId}/${action}`;
@@ -418,6 +454,7 @@ export const __testing = {
   autoBridgeStateCount: () => workerAutoBridgePending.size,
   clearAutoBridgeState: clearAutoBridgePending,
   hasAutoBridgePending,
+  setAutoBridgePending,
 };
 
 function attachSessionCapture(entry: CapturedSessionEntry): void {
@@ -664,12 +701,14 @@ export function createOrcaWorkerBridgeMcpProvider(deps: OrcaBridgeMcpDeps): McpP
 
       server.tool(
         'send_to_lead',
-        'You MUST pass your worker_id (see the Bridge note at the end of the most recent lead message). Report results or ask a question to the lead session.',
+        SEND_TO_LEAD_TOOL_DESCRIPTION,
         {
           message: z.string().min(1),
           worker_id: z.string().min(1).describe('Required. Your assigned worker_id. Find it in the Bridge note at the end of the most recent lead message, or in the system prompt Identity line.'),
         },
         async ({ message, worker_id }) => {
+          const authorization = authorizeSendToLeadCaller(resolveRuntimeMcpContext(ctx));
+          if (!authorization.ok) return text(authorization.error, true);
           const resolved = await resolveLead(worker_id);
           if (!resolved.ok) return text(resolved.error, true);
           const { link, entry } = resolved;

--- a/packages/orca-workflow/src/orca-bridge-prompt.ts
+++ b/packages/orca-workflow/src/orca-bridge-prompt.ts
@@ -99,6 +99,7 @@ export function renderOrcaWorkerSystemPrompt(meta: OrcaWorkerPromptMeta): string
     '1. Execute the task assigned by the lead.',
     '2. Implement, run /review, fix issues, and repeat until clean. Build/test when applicable.',
     '3. ALWAYS call send_to_lead when complete or blocked. Do not only reply in the worker pane; the lead cannot see it unless you call send_to_lead.',
+    '3a. If you use native subagents, have them return findings only to you. Never tell them to contact the Lead or call send_to_lead; aggregate their results and report to the Lead yourself.',
     '4. Report once; do not send progress updates.',
     '5. Do not poll read_lead/lead_status. Wait for the lead to send_to_worker when it has a response.',
     '6. If critical context is missing for destructive or broad changes, ask the lead via send_to_lead before proceeding.',


### PR DESCRIPTION
## 这次改了什么

### 摘要

当 Orca Worker 执行多阶段任务时，它可能调用 `collaboration.spawn_agent`，在自己的任务内部创建多个子代理并行调查。

修复前，这些子代理会继承 Worker 的 `orca_worker_bridge`。某个子代理完成局部任务后，可能直接调用 `send_to_lead`，绕过父 Worker 把局部结果发给 Lead。此时父 Worker 和其他子代理仍在工作，Lead 却已经提前收到一份不完整报告；父 Worker 收齐结果后还会再次汇报，造成报告碎片化和重复。

本 PR 分两层修复：

1. 正常流程：明确要求 Worker 创建的 `collaboration.spawn_agent` 子代理只把结果返回父 Worker，由父 Worker 收齐并统一向 Lead 汇报。
2. 保底门禁：Host 区分调用者是 Worker 本身还是 Worker 内的子代理。只有经过 Host 证明的 Worker 本身可以调用 `send_to_lead`；子代理即使尝试直接调用，也会在产生任何消息投递、状态更新或持久化副作用前被拒绝。

本 PR 不禁止 Worker 使用 `collaboration.spawn_agent`，也不依靠 Host 拒绝来完成正常的子任务回传。正常路径仍然是“子代理返回 Worker → Worker 统一汇报”，Host 门禁只负责阻止异常越级调用。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Orca Worker 内 `collaboration.spawn_agent` 子代理越级向 Lead 汇报
- 本 PR 包含：Worker 内 `collaboration.spawn_agent` 子代理的汇报规则；`send_to_lead` 的 Worker 本体/子代理来源识别与 Host 门禁；Codex、Claude Code、Pi 及远端 Claude manager 的来源接线和回归测试。
- 明确不包含：不禁用或限制 `collaboration.spawn_agent`；不要求子代理直接与 Lead 通信；不实现 Worker turn 级的报告次数状态机；不把“每轮只报告一次”变成 Host 全局硬限制。
- 用户可见变化：Lead 不再收到 Worker 内子代理的局部报告；父 Worker 收齐结果后统一汇总。若模型仍尝试越级，Host 会拒绝而不会投递给 Lead。
- 是否存在 breaking change：无用户可见 breaking change。远端 CC manager 内部协议升级到 v3 / bundle 0.0.7，旧 daemon 会按既有握手机制强制升级，不会静默忽略来源门禁。

### UI 变化

不涉及：未修改 Renderer、布局、样式或 UI 文案。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过。runner 389 passed / 1 skipped；所有要求运行的 Desktop、Mobile、maker-core、Orca workflow、CC manager 及其他 workspace unit 全部通过。

pnpm --filter desktop run --if-present typecheck
pnpm --filter @cindy/mcps run --if-present typecheck
pnpm --filter @cindy/maker-cc-manager run --if-present typecheck
pnpm --filter @cindy/maker-core run --if-present typecheck
pnpm --filter @cindy/orca-workflow run --if-present typecheck
结果：全部通过。

pnpm --filter @cindy/orca-workflow run lint
pnpm --filter @cindy/orca-workflow run build
pnpm check:dco
git diff --check origin/main..HEAD
结果：全部通过。

定向回归：
- Orca bridge / prompt：33/33
- Desktop Codex / Pi / HTTP bridge / 远端 CC：64/64
- maker-core Codex / Claude / Pi：518/518
- maker-cc-manager protocol / SDK / session registry：55/55
```

### 手工验证

- 中国大陆版 Desktop Dev App，Playground 全新会话，Codex GPT-5.6 Sol，Worker effort=high。
- 修复前自然场景：Orca Worker 在没有收到任何子代理汇报路径提示的情况下，自行调用 `collaboration.spawn_agent` 创建多个子代理。父 Worker 和其他子代理仍在运行时，第一个子代理的局部结果已经到达 Lead。
- 修复前强制场景：Worker 内的 `collaboration.spawn_agent` 子代理直接调用 `send_to_lead`，Host 返回 `ok=true`，测试 marker 到达 Lead。
- 修复后强制场景：同类子代理真实调用 `send_to_lead`，Host 返回 `NESTED_AGENT_NOT_ALLOWED`，marker 未到达 Lead，父 Worker 仍能正常汇总。
- 修复后自然场景：Worker 正常创建多个子代理，子代理结果返回父 Worker，Host 门禁没有触发；父 Worker 收齐后统一汇报。该任务文本要求合并报告，因此只用于证明正常子代理链路未被门禁误伤。
- blocking question → Lead `send_to_worker` → 新 turn 最终回报通过；`read_lead` / `lead_status` smoke 通过。

### 未执行的验证

- rebase 到最新 main 后未重复运行“完全不含合并/汇报暗示”的自然行为 E2E；最终提交已通过完整单测、定向回归和独立对抗性审查。
- 未在真实 SSH 旧 daemon 上手工演练升级，也未覆盖 macOS 之外的真实 Claude/Codex/Pi 二进制 E2E；协议握手、强制升级与来源分支由单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [x] system prompt
- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Orca Worker 的 `send_to_lead` 来源校验和相关 Agent harness 接线。`read_lead`、`lead_status`、普通 MCP、普通 Claude 审批链及非 Orca 会话不受影响。
- system prompt：只新增已在本需求中确认的 Worker Rule 3a；不修改全局按需委托提示。文案为稳定静态内容，不引入易变前缀。
- 核心指标：授权为同步常量字段比较和 O(1) context/map 访问，不增加网络、磁盘或额外 await；tool 集合不变，usage/token 计量链不变。
- 回滚 / 降级方式：整体 revert 本提交；远端 CC protocol version、bundle version和 root-only guard 必须一并回滚，不能只降其中一层。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因
