### PR TITLE
fix(plugin-market): 阻止启动扫描损坏插件安装状态

### DIFF
--- a/apps/desktop/scripts/smoke-packaged.mjs
+++ b/apps/desktop/scripts/smoke-packaged.mjs
@@ -58,10 +58,11 @@ function parseArgs() {
   const arch = out.arch || process.arch;
   const outDir = out['out-dir'] || null;
   const appName = out['app-name'] || PACKAGED_APP_NAME;
-  return { platform, arch, outDir, appName };
+  const pluginStorage = args.includes('--plugin-storage');
+  return { platform, arch, outDir, appName, pluginStorage };
 }
 
-const { platform, arch, outDir, appName } = parseArgs();
+const { platform, arch, outDir, appName, pluginStorage } = parseArgs();
 
 if (!['win32', 'darwin', 'linux'].includes(platform)) {
   console.error(`[smoke] ERROR: unsupported --platform=${platform}`);
@@ -170,6 +171,7 @@ const child = spawn(
   [
     '--smoke-test',
     `--smoke-user=${SMOKE_USER}`,
+    ...(pluginStorage ? ['--smoke-plugin-storage'] : []),
     `--user-data-dir=${tmpUserData}`,
   ],
   {
@@ -252,6 +254,24 @@ child.on('exit', (code, signal) => {
       process.exit(1);
     }
   }
+  if (pluginStorage) {
+    const storage = parsed.plugin_storage || {};
+    if (storage.ownerGhostFound !== true) {
+      console.error('[smoke] FAIL: owner Plugin was not found after signed-out startup recovery');
+      cleanupUserData();
+      process.exit(1);
+    }
+    if (storage.ledgerInstalledAfterEmptySnapshot !== true) {
+      console.error('[smoke] FAIL: passive empty snapshot changed installed ledger state');
+      cleanupUserData();
+      process.exit(1);
+    }
+    if (storage.optOutAfterEmptySnapshot !== false) {
+      console.error('[smoke] FAIL: passive empty snapshot wrote a default-install opt-out');
+      cleanupUserData();
+      process.exit(1);
+    }
+  }
   if (code !== 0) {
     console.error(`[smoke] FAIL: child exit code ${code} (expected 0)`);
     cleanupUserData();
@@ -260,7 +280,8 @@ child.on('exit', (code, signal) => {
 
   console.log(
     `✅ smoke test passed: schema_version=${parsed.schema_version}, ` +
-      `sessions=${t.sessions}, messages=${t.messages}, migration_meta=${t.migration_meta}`,
+      `sessions=${t.sessions}, messages=${t.messages}, migration_meta=${t.migration_meta}` +
+      (pluginStorage ? ', plugin_storage=passed' : ''),
   );
   cleanupUserData();
   process.exit(0);

--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -707,6 +707,7 @@ import { registerPluginMarketIpc, syncDefaultMarketPlugins } from './plugin-mark
 import { findCindyFileInArgv } from './cindy-brain/argv.js';
 import { handleIncomingCindyFile } from './cindy-brain/openFileInstall.js';
 import { registerCindyFileAssociation } from './cindy-brain/fileAssociation.js';
+import { runPluginStorageSmoke } from './smoke/pluginStorageSmoke.js';
 import { setMainLocale, t } from './i18n.js';
 import { requireObject, throwIpcError } from './utils/ipcValidate.js';
 import { pickNativeAtResource } from './nativeAtResourcePicker.js';
@@ -5947,14 +5948,31 @@ const registerIpcHandlers = () => {
 // schema_version + core tables, emit JSON to stdout, and exit. Electron's
 // native `--user-data-dir` flag is expected to be passed by the smoke script
 // so the fake DB lives in a scratch directory.
-function parseSmokeArgs(): { enabled: boolean; userId: string } {
-  const enabled = process.argv.includes('--smoke-test');
+function parseSmokeArgs(): {
+  enabled: boolean;
+  userId: string;
+  pluginStorage: boolean;
+  resultFile: string | null;
+} {
+  const resultFile = !app.isPackaged
+    ? process.env.XDT_PLUGIN_STORAGE_SMOKE_RESULT_FILE?.trim() || null
+    : null;
+  const enabled = process.argv.includes('--smoke-test') || resultFile !== null;
   const userFlag = process.argv.find((a) => a.startsWith('--smoke-user='));
   const userId = userFlag ? userFlag.slice('--smoke-user='.length) : '__smoke_test__';
-  return { enabled, userId };
+  return {
+    enabled,
+    userId,
+    pluginStorage: process.argv.includes('--smoke-plugin-storage') || resultFile !== null,
+    resultFile,
+  };
 }
 
-async function runSmokeTest(userId: string): Promise<void> {
+async function runSmokeTest(
+  userId: string,
+  pluginStorage: boolean,
+  resultFile: string | null,
+): Promise<void> {
   try {
     const result = await localDbEnsureReady(userId);
     if (!result.ready) {
@@ -5977,8 +5995,10 @@ async function runSmokeTest(userId: string): Promise<void> {
     const metaCount = (
       db.prepare('SELECT COUNT(*) AS c FROM migration_meta').get() as { c: number }
     ).c;
-    process.stdout.write(
-      `${JSON.stringify({
+    const pluginStorageResult = pluginStorage
+      ? await runPluginStorageSmoke(userId)
+      : undefined;
+    const payload = {
         ok: true,
         schema_version: schemaVersion,
         tables: {
@@ -5986,8 +6006,11 @@ async function runSmokeTest(userId: string): Promise<void> {
           messages: messagesCount,
           migration_meta: metaCount,
         },
-      })}\n`,
-    );
+        ...(pluginStorageResult ? { plugin_storage: pluginStorageResult } : {}),
+      };
+    const serialized = `${JSON.stringify(payload)}\n`;
+    if (resultFile) fs.writeFileSync(resultFile, serialized, { mode: 0o600 });
+    process.stdout.write(serialized);
     localDbCloseDb();
     app.quit();
   } catch (err) {
@@ -6085,7 +6108,7 @@ app.on('ready', async () => {
   // Smoke-test flag short-circuit: skip all normal init paths.
   const smoke = parseSmokeArgs();
   if (smoke.enabled) {
-    await runSmokeTest(smoke.userId);
+    await runSmokeTest(smoke.userId, smoke.pluginStorage, smoke.resultFile);
     return;
   }
 

--- a/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/marketGhostSessionBoundary.test.ts
@@ -58,4 +58,25 @@ describe('market Ghost session boundary', () => {
     expect(leaseIndex).toBeGreaterThan(inspectIndex);
     expect(body).toContain('releaseMutation?.();');
   });
+
+  it('runs the final market callback before both initial install and update placement', () => {
+    const installStart = source.indexOf(
+      'async function installOrUpdateMarketGhostPackageLocked(',
+    );
+    const installEnd = source.indexOf(
+      '\n}\n\ntype GhostUninstallLedgerCompletion',
+      installStart,
+    );
+    const body = source.slice(installStart, installEnd);
+    const initialBranch = body.slice(
+      body.indexOf('if (!installed) {'),
+      body.indexOf('const runtime = getGhostRuntime();'),
+    );
+
+    expect(initialBranch.indexOf('expected.beforeCommitInLock?.();')).toBeGreaterThan(-1);
+    expect(initialBranch.indexOf('expected.beforeCommitInLock?.();')).toBeLessThan(
+      initialBranch.indexOf('return installAndDock('),
+    );
+    expect(body.match(/expected\.beforeCommitInLock\?\.\(\);/g)).toHaveLength(2);
+  });
 });

--- a/apps/desktop/src/main/cindy-brain/__tests__/repoRoot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/repoRoot.test.ts
@@ -6,7 +6,11 @@
 import { describe, it, expect, vi } from 'vitest';
 import path from 'node:path';
 
-import { resolveGhostRepoRoot, type GhostRepoRootDeps } from '../repoRoot';
+import {
+  resolveCachedGhostRepoRoot,
+  resolveGhostRepoRoot,
+  type GhostRepoRootDeps,
+} from '../repoRoot';
 
 const USER_DATA = path.join(path.sep, 'fake', 'userData');
 const ROOT = path.join(USER_DATA, 'cindy-brain');
@@ -60,5 +64,68 @@ describe('resolveGhostRepoRoot', () => {
     const { deps, rename } = makeDeps([ROOT]);
     expect(resolveGhostRepoRoot(deps)).toBe(ROOT);
     expect(rename).not.toHaveBeenCalled();
+  });
+});
+
+describe('resolveCachedGhostRepoRoot', () => {
+  it('reuses the resolved root while the owner scope is unchanged', () => {
+    const first = makeDeps([]);
+    const cached = resolveCachedGhostRepoRoot(null, 'signed-out:none:0', first.deps);
+    const second = makeDeps([], {
+      userDataDir: path.join(path.sep, 'unused'),
+      exists: vi.fn(() => false),
+    });
+
+    const resolved = resolveCachedGhostRepoRoot(
+      cached,
+      'signed-out:none:0',
+      second.deps,
+    );
+
+    expect(resolved).toBe(cached);
+    expect(second.deps.exists).not.toHaveBeenCalled();
+  });
+
+  it('resolves the real owner root after signed-out startup restores an account', () => {
+    const signedOut = makeDeps([], {
+      userDataDir: path.join(path.sep, 'userData', 'cindy-no-session', '123'),
+    });
+    const initial = resolveCachedGhostRepoRoot(
+      null,
+      'signed-out:none:0',
+      signedOut.deps,
+    );
+    const ownerDataDir = path.join(path.sep, 'userData', 'owners', 'user-1');
+    const restored = makeDeps([], { userDataDir: ownerDataDir });
+
+    const resolved = resolveCachedGhostRepoRoot(
+      initial,
+      'cloud:user-1:1',
+      restored.deps,
+    );
+
+    expect(resolved).not.toBe(initial);
+    expect(resolved).toEqual({
+      ownerScopeKey: 'cloud:user-1:1',
+      rootDir: path.join(ownerDataDir, 'cindy-brain'),
+    });
+  });
+
+  it('does not reuse one account root for another account', () => {
+    const ownerA = path.join(path.sep, 'userData', 'owners', 'user-a');
+    const ownerB = path.join(path.sep, 'userData', 'owners', 'user-b');
+    const initial = resolveCachedGhostRepoRoot(
+      null,
+      'cloud:user-a:1',
+      makeDeps([], { userDataDir: ownerA }).deps,
+    );
+
+    const resolved = resolveCachedGhostRepoRoot(
+      initial,
+      'cloud:user-b:2',
+      makeDeps([], { userDataDir: ownerB }).deps,
+    );
+
+    expect(resolved.rootDir).toBe(path.join(ownerB, 'cindy-brain'));
   });
 });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -3729,6 +3729,7 @@ async function installOrUpdateMarketGhostPackageLocked(
       // inspect 与 install 各自重读磁盘,临时 .cindy 在两读之间被替换时,
       // 所有前置校验(保留前缀/审阅比对/签名/解压上限)都会作用在旧字节上。
       // 本地 .cindy 装入通道已强制此对账,市场通道同一口径。
+      expected.beforeCommitInLock?.();
       return installAndDock(manager, cindyFilePath, {
         ghostId: expected.ghostId,
         enable: true,

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -74,7 +74,10 @@ import { serverApiFetch } from '../serverApiClient.js';
 import { getClientEndpoint } from '../clientEndpointsService.js';
 import { createGhostOauthBrokerClient } from './ghostOauthBroker.js';
 import { readRefImagesWithinBudget } from './refImageBudget.js';
-import { resolveGhostRepoRoot } from './repoRoot.js';
+import {
+  resolveCachedGhostRepoRoot,
+  type GhostRepoRootCacheEntry,
+} from './repoRoot.js';
 import { takePendingCindyInstall } from './openFileInstall.js';
 import { GhostRuntime } from './runtime/GhostRuntime.js';
 import {
@@ -751,17 +754,19 @@ export function suspendAllGhosts(): void {
 let ipcRegistered = false;
 
 /** 意识仓库根(userData/cindy-brain;旧 brain 目录首次解析时原地迁移)。 */
-let brainRootCache: string | null = null;
+let brainRootCache: GhostRepoRootCacheEntry | null = null;
 function brainRootDir(): string {
-  if (!brainRootCache) {
-    brainRootCache = resolveGhostRepoRoot({
+  brainRootCache = resolveCachedGhostRepoRoot(
+    brainRootCache,
+    activeOwnerScopeKey(),
+    {
       userDataDir: ownerScopedUserDataPath(),
       exists: (p) => fs.existsSync(p),
       rename: (from, to) => fs.renameSync(from, to),
       log,
-    });
-  }
-  return brainRootCache;
+    },
+  );
+  return brainRootCache.rootDir;
 }
 
 /**

--- a/apps/desktop/src/main/cindy-brain/repoRoot.ts
+++ b/apps/desktop/src/main/cindy-brain/repoRoot.ts
@@ -20,6 +20,11 @@ export interface GhostRepoRootDeps {
   };
 }
 
+export interface GhostRepoRootCacheEntry {
+  ownerScopeKey: string;
+  rootDir: string;
+}
+
 /** 解析意识仓库根;调用方自行缓存结果(迁移只应尝试一次)。 */
 export function resolveGhostRepoRoot(deps: GhostRepoRootDeps): string {
   const root = path.join(deps.userDataDir, 'cindy-brain');
@@ -44,4 +49,17 @@ export function resolveGhostRepoRoot(deps: GhostRepoRootDeps): string {
     return legacy;
   }
   return root;
+}
+
+/** Cache the resolved repository root only for the owner scope that produced it. */
+export function resolveCachedGhostRepoRoot(
+  cache: GhostRepoRootCacheEntry | null,
+  ownerScopeKey: string,
+  deps: GhostRepoRootDeps,
+): GhostRepoRootCacheEntry {
+  if (cache?.ownerScopeKey === ownerScopeKey) return cache;
+  return {
+    ownerScopeKey,
+    rootDir: resolveGhostRepoRoot(deps),
+  };
 }

--- a/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service-custom-sources.test.ts
@@ -225,6 +225,28 @@ describe('PluginMarketService 自定义市场聚合', () => {
     });
   });
 
+  it('does not mark a custom market installation removed when discovery is temporarily empty', async () => {
+    const h = harness([], []);
+    const pluginId = customMarketPluginId('team-lib', 'alpha');
+    h.ledger.upsertInstallation({
+      pluginId,
+      ghostId: 'alpha',
+      releaseId: customMarketReleaseId('team-lib', 'alpha', '1.0.0'),
+      version: '1.0.0',
+      sha256: 'custom-unverified',
+      scope: 'public',
+      organizationId: null,
+      source: 'local-market',
+      installed: true,
+      updatedAt: '2026-07-30T02:00:00.000Z',
+    });
+
+    await expect(h.service.snapshot()).resolves.toMatchObject({ items: [] });
+
+    expect(h.ledger.installationForGhost('alpha')?.installed).toBe(true);
+    expect(h.ledger.isDefaultInstallSuppressed('user-1', pluginId)).toBe(false);
+  });
+
   it('does not expose custom market releases that require a newer Cindy version', async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-custom-fixture-'));
     roots.push(root);

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -1649,9 +1649,9 @@ describe('PluginMarketService migration and defaultInstall', () => {
     });
   });
 
-  it('treats a missing previously-managed directory as an opt-out and does not reinstall', async () => {
+  it('does not turn a temporarily missing managed directory into an uninstall or opt-out', async () => {
     const item = summary({ defaultInstall: true });
-    const h = harness([item]);
+    const h = harness([]);
     h.ledger.upsertInstallation({
       pluginId: item.id,
       ghostId: item.ghostId,
@@ -1668,8 +1668,9 @@ describe('PluginMarketService migration and defaultInstall', () => {
     const snapshot = await h.service.snapshot();
 
     expect(runtime.install).not.toHaveBeenCalled();
-    expect(snapshot.items[0]?.installState).toBe('not-installed');
-    expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(true);
+    expect(snapshot.items).toEqual([]);
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(true);
+    expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(false);
   });
 
   it('records an opt-out only after a tracked local uninstall succeeds', async () => {
@@ -1682,6 +1683,25 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(complete).not.toBeNull();
     expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(true);
     await complete?.();
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
+    expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(true);
+  });
+
+  it('does not reinstall a default Plugin when a snapshot races its explicit uninstall', async () => {
+    const item = summary({ defaultInstall: true });
+    const h = harness([item]);
+    h.ledger.upsertInstallation(recordForTest(item));
+    runtime.ghosts = [ghostEntry(item.ghostId)];
+    let racingSnapshot: ReturnType<typeof h.service.snapshot> | null = null;
+    runtime.uninstall.mockImplementationOnce(async () => {
+      runtime.ghosts = [];
+      racingSnapshot = h.service.snapshot();
+    });
+
+    await expect(h.service.uninstall(item.id)).resolves.toEqual({ ok: true });
+    await expect(racingSnapshot).resolves.toMatchObject({ unavailableReason: null });
+
+    expect(runtime.install).not.toHaveBeenCalled();
     expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
     expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(true);
   });

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -459,11 +459,12 @@ describe('PluginMarketService migration and defaultInstall', () => {
 
     expect(runtime.install).toHaveBeenCalledWith(
       expect.stringMatching(/\.cindy$/),
-      {
+      expect.objectContaining({
         ghostId: 'cindy-test',
         version: '1.0.0',
         reviewedManifest: manifest(),
-      },
+        beforeCommitInLock: expect.any(Function),
+      }),
     );
     expect(snapshot.items[0]).toMatchObject({
       installState: 'installed',
@@ -1035,11 +1036,12 @@ describe('PluginMarketService migration and defaultInstall', () => {
 
     expect(runtime.install).toHaveBeenCalledWith(
       expect.stringMatching(/\.cindy$/),
-      {
+      expect.objectContaining({
         ghostId: item.ghostId,
         version: item.currentRelease.version,
         reviewedManifest: manifest(),
-      },
+        beforeCommitInLock: expect.any(Function),
+      }),
     );
     expect(snapshot.items[0]).toMatchObject({
       installState: 'installed',
@@ -1702,6 +1704,41 @@ describe('PluginMarketService migration and defaultInstall', () => {
     await expect(racingSnapshot).resolves.toMatchObject({ unavailableReason: null });
 
     expect(runtime.install).not.toHaveBeenCalled();
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
+    expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(true);
+  });
+
+  it('cancels an in-flight default install when local uninstall records opt-out during download', async () => {
+    const item = summary({ defaultInstall: true });
+    const h = harness([item]);
+    h.ledger.upsertInstallation(recordForTest(item));
+    runtime.ghosts = [ghostEntry(item.ghostId)];
+    const completeLocalUninstall = h.service.prepareLocalUninstallTracking(item.ghostId);
+    expect(completeLocalUninstall).not.toBeNull();
+
+    const downloadMock = vi.mocked(
+      (await import('../download.js')).downloadVerifiedPlugin,
+    );
+    const downloadStarted = deferred();
+    const downloadGate = deferred();
+    downloadMock.mockImplementationOnce(async () => {
+      downloadStarted.resolve();
+      await downloadGate.promise;
+    });
+    runtime.install.mockImplementationOnce(async (_file, options) => {
+      options.beforeCommitInLock?.();
+      throw new Error('runtime install must be cancelled before package placement');
+    });
+
+    // 本地插件页已完成目录移除并广播空清单，账本 completion 紧随其后。
+    runtime.ghosts = [];
+    const snapshotPromise = h.service.snapshot();
+    await downloadStarted.promise;
+    await completeLocalUninstall?.();
+    downloadGate.resolve();
+
+    await expect(snapshotPromise).resolves.toMatchObject({ unavailableReason: null });
+    expect(runtime.install).toHaveBeenCalledOnce();
     expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
     expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(true);
   });

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -86,6 +86,7 @@ type PackagePermissionReviewer = (
 
 class SilentUpgradeBusyError extends Error {}
 class SilentUpgradeStaleBaselineError extends Error {}
+class SilentDefaultInstallCancelledError extends Error {}
 
 /**
  * 来源增删改的互斥键。自定义市场安装的提交段也要拿这把锁，保证所选来源从
@@ -1617,6 +1618,27 @@ export class PluginMarketService {
               // 上限；真实包若额外扩权，installDetail 会安全取消并等待用户之后
               // 从详情页手动安装、在原请求窗口完成确认。
               reviewedManifest: reviewedManifest.manifest,
+              // 下载期间用户可能从本地插件页完成显式卸载。最终落位前在
+              // ghostId 锁内重读卸载意图，不能让旧 snapshot 把插件装回来。
+              beforeCommitInLock: () => {
+                const commitLedgerData = ledger.read();
+                if (
+                  commitLedgerData.defaultInstallOptOuts[installSubject]?.includes(summary.id)
+                ) {
+                  throw new SilentDefaultInstallCancelledError(
+                    'Default Plugin was explicitly uninstalled',
+                  );
+                }
+                const commitLocal = this.localInstallSnapshot(
+                  ledger,
+                  commitLedgerData.installations,
+                );
+                if (this.toItem(summary, commitLocal).installState !== 'not-installed') {
+                  throw new SilentDefaultInstallCancelledError(
+                    'Default Plugin install state changed',
+                  );
+                }
+              },
             },
             owner,
             ledger,
@@ -1624,10 +1646,12 @@ export class PluginMarketService {
         });
       } catch (error) {
         // 单个默认插件失败不拖垮整个市场；下次同步可重试。
-        log.warn('default plugin install failed', {
-          pluginId: summary.id,
-          error: error instanceof Error ? error.message : String(error),
-        });
+        if (!(error instanceof SilentDefaultInstallCancelledError)) {
+          log.warn('default plugin install failed', {
+            pluginId: summary.id,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
     }
   }

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -441,8 +441,14 @@ export class PluginMarketService {
     const ledger = this.ledgerForOwner(owner);
     await this.adoptLegacyInstallations(plugins, ledger, owner);
     await this.backfillOfficialCindyGithubTrust(ledger, owner);
-    await this.reconcileRemovedInstallations(ledger, owner);
+    // A snapshot is passive discovery: an empty runtime list can be caused by
+    // startup, an owner transition, or a transient filesystem view. Only an
+    // explicit uninstall may turn that absence into installed=false/opt-out.
     await this.applyServerRemovals(removals, owner, ledger);
+    // Explicit uninstall completion is allowed to finish its physical removal
+    // before its ledger write. Wait for queued ledger mutations before deciding
+    // whether a default plugin should be installed again.
+    await this.ledgerMutation;
     // 自定义来源只影响自己的目录发现；暂时不可读的来源不能阻塞官方默认安装。
     // 已经落地的同 id 插件仍由 applyDefaultInstalls → installDetail 的本地事实检查保护。
     await this.applyDefaultInstalls(plugins, owner, ledger);
@@ -1461,26 +1467,6 @@ export class PluginMarketService {
     }
   }
 
-  private async reconcileRemovedInstallations(
-    ledger: PluginMarketLedger,
-    owner: ActiveAppSession,
-  ): Promise<void> {
-    const installSubject = defaultInstallSubject(owner);
-    for (const record of Object.values(ledger.read().installations)) {
-      if (!record.installed) continue;
-      await this.withLedgerMutation(owner, () => {
-        // 在场判定必须与写入同处一把锁内且即时重取:manager.update 的两次
-        // rename 之间 ghosts/<id> 短暂不存在,锁外的一次性快照会把这类瞬态
-        // 误判成"已卸载",把 pluginId 永久写进 defaultInstallOptOuts,该
-        // 默认安装插件从此不再自动装回。
-        const stillInstalled = getGhostManager()
-          .list()
-          .some((ghost) => ghost.manifest.id === record.ghostId);
-        if (!stillInstalled) ledger.markRemoved(record.ghostId, installSubject);
-      });
-    }
-  }
-
   private async applyServerRemovals(
     removals: readonly PluginRemovalNotice[],
     owner: ActiveAppSession,
@@ -1607,6 +1593,14 @@ export class PluginMarketService {
       try {
         await this.withMutation(summary.id, async () => {
           requireSameMarketOwner(owner);
+          const freshLedgerData = ledger.read();
+          if (freshLedgerData.defaultInstallOptOuts[installSubject]?.includes(summary.id)) {
+            return;
+          }
+          const freshLocal = this.localInstallSnapshot(ledger, freshLedgerData.installations);
+          if (this.toItem(summary, freshLocal).installState !== 'not-installed') {
+            return;
+          }
           const detail = await this.api.detail(summary.id);
           requireSameMarketOwner(owner);
           assertDetailMatchesSummary(summary, detail);

--- a/apps/desktop/src/main/smoke/pluginStorageSmoke.ts
+++ b/apps/desktop/src/main/smoke/pluginStorageSmoke.ts
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { app } from 'electron';
+import { CLIENT_ENDPOINT_KEYS, type ClientEndpointMap } from '@cindy/maker-shared/client-endpoints';
+import type { VisiblePluginSummary } from '@cindy/plugin-protocol';
+
+import {
+  commitActiveAppSession,
+  dataOwnerStorageKey,
+} from '../appSessionState.js';
+import { getGhostManager } from '../cindy-brain/index.js';
+import { resetClientEndpointsForTest } from '../clientEndpointsService.js';
+import type { PluginMarketApi } from '../plugin-market/api.js';
+import { PluginMarketLedger } from '../plugin-market/ledger.js';
+import { PluginMarketService } from '../plugin-market/service.js';
+import { MarketSourceStore } from '../plugin-market/sources/store.js';
+
+const GHOST_ID = 'cindy-smoke-storage';
+const PLUGIN_ID = `c${'f'.repeat(24)}`;
+
+export interface PluginStorageSmokeResult {
+  initialSignedOutCount: number;
+  ownerGhostFound: boolean;
+  ownerGhostDir: string | null;
+  ledgerInstalledAfterEmptySnapshot: boolean;
+  optOutAfterEmptySnapshot: boolean;
+}
+
+function endpointFixture(): ClientEndpointMap {
+  const endpoints = Object.fromEntries(
+    CLIENT_ENDPOINT_KEYS.map((key) => [key, '']),
+  ) as ClientEndpointMap;
+  endpoints.pluginApiBaseUrl = 'https://plugin-smoke.invalid';
+  return endpoints;
+}
+
+function pluginSummary(): VisiblePluginSummary {
+  return {
+    id: PLUGIN_ID,
+    ghostId: GHOST_ID,
+    name: 'Plugin storage smoke',
+    description: 'Packaged smoke fixture',
+    author: 'Cindy',
+    scope: 'public',
+    organizationId: null,
+    defaultInstall: false,
+    currentRelease: {
+      id: 'release-smoke-1',
+      version: '1.0.0',
+      sha256: 'a'.repeat(64),
+      sizeBytes: 1,
+      publishedAt: '2026-08-09T00:00:00.000Z',
+      icon: null,
+    },
+  };
+}
+
+/**
+ * Packaged-process black-box fixture for the plugin storage startup boundary.
+ * This function is called only by the explicit `--smoke-plugin-storage` path.
+ */
+export async function runPluginStorageSmoke(ownerId: string): Promise<PluginStorageSmokeResult> {
+  const manager = getGhostManager();
+  const initialSignedOutCount = manager.list().length;
+  const ownerRoot = path.join(
+    app.getPath('userData'),
+    'owners',
+    dataOwnerStorageKey(ownerId),
+  );
+  const ghostDir = path.join(ownerRoot, 'cindy-brain', GHOST_ID);
+  const marketDir = path.join(ownerRoot, 'plugin-market');
+  const ledgerPath = path.join(marketDir, 'ledger.v1.json');
+  fs.mkdirSync(ghostDir, { recursive: true });
+  fs.mkdirSync(marketDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(ghostDir, 'ghost.json'),
+    `${JSON.stringify({
+      schemaVersion: 2,
+      id: GHOST_ID,
+      name: 'Plugin storage smoke',
+      description: 'Packaged smoke fixture',
+      author: 'Cindy',
+      version: '1.0.0',
+      kind: 'chip',
+      entry: 'main.js',
+      slots: ['notify'],
+    })}\n`,
+  );
+  fs.writeFileSync(path.join(ghostDir, 'main.js'), '// packaged plugin storage smoke\n');
+
+  const ledger = new PluginMarketLedger(ledgerPath);
+  ledger.upsertInstallation({
+    pluginId: PLUGIN_ID,
+    ghostId: GHOST_ID,
+    releaseId: 'release-smoke-1',
+    version: '1.0.0',
+    sha256: 'a'.repeat(64),
+    scope: 'public',
+    organizationId: null,
+    source: 'market',
+    installed: true,
+    updatedAt: '2026-08-09T00:00:00.000Z',
+  });
+
+  commitActiveAppSession('cloud', ownerId);
+  const ownerGhost = manager.list().find((ghost) => ghost.manifest.id === GHOST_ID) ?? null;
+
+  // A passive snapshot must not translate temporary absence into an uninstall.
+  fs.renameSync(ghostDir, path.join(ownerRoot, 'cindy-brain', `.${GHOST_ID}-hidden`));
+  resetClientEndpointsForTest(endpointFixture());
+  const api = {
+    listAll: async () => ({ plugins: [pluginSummary()], removals: [] }),
+  } as unknown as PluginMarketApi;
+  const service = new PluginMarketService(
+    api,
+    ledger,
+    new MarketSourceStore(path.join(marketDir, 'sources.v1.json')),
+  );
+  await service.snapshot();
+  const record = ledger.installationForGhost(GHOST_ID);
+
+  return {
+    initialSignedOutCount,
+    ownerGhostFound: ownerGhost !== null,
+    ownerGhostDir: ownerGhost?.dir ?? null,
+    ledgerInstalledAfterEmptySnapshot: record?.installed === true,
+    optOutAfterEmptySnapshot: ledger.isDefaultInstallSuppressed(ownerId, PLUGIN_ID),
+  };
+}

--- a/scripts/restart-desktop-remote.mjs
+++ b/scripts/restart-desktop-remote.mjs
@@ -534,6 +534,8 @@ export function devEnvPrefix(env = process.env, platform = process.platform) {
     ['OPEN_DEVTOOLS', env.OPEN_DEVTOOLS],
     // --wait-ready 的一次性状态文件：runner 写失败，Electron main ready-to-show 写成功。
     ['XDT_DESKTOP_DEV_STARTUP_STATUS_FILE', env.XDT_DESKTOP_DEV_STARTUP_STATUS_FILE],
+    // 插件存储启动边界的 dev 黑盒验收：仅显式临时结果路径时启用。
+    ['XDT_PLUGIN_STORAGE_SMOKE_RESULT_FILE', env.XDT_PLUGIN_STORAGE_SMOKE_RESULT_FILE],
   ].filter(([, value]) => value);
   if (envEntries.length === 0) return '';
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 冷启动恢复账号时，插件根目录仍复用未登录临时目录、市场快照因此把已安装插件误写为已卸载的问题。

插件根目录缓存现在与 owner scope 绑定；被动快照不再依据一次目录缺席持久化卸载和默认安装 opt-out；默认安装在插件锁内重新读取账本与运行时状态，避免与显式卸载竞态。

同时增加 dev 隔离沙盒和 packaged smoke 可复用的插件存储黑盒验收入口。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2247、#2251、#2244
- 本 PR 包含：owner 作用域插件根缓存、保守的市场账本对账、默认安装并发复核、回归测试和黑盒 smoke
- 明确不包含：自动修复此前已损坏的 ledger / opt-out 数据
- 用户可见变化：升级后不会再因冷启动扫描或短暂目录不可见而把已安装插件标记成已卸载
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/cindy-brain/__tests__/repoRoot.test.ts src/main/plugin-market/__tests__/service.test.ts src/main/plugin-market/__tests__/service-custom-sources.test.ts
结果：3 个测试文件、137 个测试全部通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:runner
结果：382 通过、8 跳过、0 失败

pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=1 <unit tier excludes>
结果：Desktop 完整 unit 范围通过

pnpm check:dco
结果：通过
```

### 手工验证

Windows dev 隔离沙盒 `Cindy-dev2-issue2247-smoke`：

- 未登录状态先初始化 GhostManager
- 写入 owner 插件目录与已安装 ledger
- 恢复 cloud owner 后再次扫描
- 临时隐藏插件目录并执行市场 snapshot

结果：

```json
{
  "initialSignedOutCount": 0,
  "ownerGhostFound": true,
  "ledgerInstalledAfterEmptySnapshot": true,
  "optOutAfterEmptySnapshot": false
}
```

验收后已删除隔离沙盒。

### 未执行的验证

- 原样并行 `pnpm test:unit` 已执行，但 Desktop Vitest 8-worker 运行中出现 `ERR_IPC_CHANNEL_CLOSED`；其余 workspace 全部通过。随后以单 worker 重跑相同 Desktop unit 范围并全部通过。
- packaged smoke 未执行：当前 Windows 环境缺少 MSVC `link.exe`，Forge 在构建 Rust/Tauri updater 的 prePackage 阶段退出。已使用实际 Electron dev 隔离沙盒完成同一 smoke 场景。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 插件根目录解析、市场快照账本写入与默认安装并发路径
- 存量插件影响：无。不会要求用户重新安装、重新批准权限或重新配置；本改动只阻止错误写坏安装状态
- 回滚 / 降级方式：回滚本 PR 可恢复旧行为，但会重新暴露冷启动误写 ledger 的数据损坏风险
- 合并要求：本改动命中插件基座，需按仓库规则由白名单把关人明确 Approve

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需额外文档）
- [x] 已确认测试结果或说明未执行原因

## 关联 Issue

- #2247
- #2251
- #2244