### PR TITLE
fix(codex): 修正子代理卡 token 统计

### DIFF
--- a/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
+++ b/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
@@ -162,6 +162,38 @@ describe('createSubagentLiveCardTracker', () => {
     ).toBe(250);
   });
 
+  it('counts delayed first usage from an earlier observed live turn without a restored snapshot', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'));
+    tracker.handleDescendantNotification('t-child', 'turn/started', {
+      turn: { id: 'child-turn-1' },
+    });
+    tracker.handleDescendantNotification('t-child', 'turn/started', {
+      turn: { id: 'child-turn-2' },
+    });
+
+    // turn 1 的首帧 usage 可以晚于 turn 2 started；它仍是已观测的 live turn，必须用
+    // last 反推 spawn 基线，而不能把整帧误认成 fork / resume 的恢复快照。
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: {
+          total: { totalTokens: 8_250 },
+          last: { totalTokens: 250 },
+        },
+      })?.totalTokens,
+    ).toBe(250);
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-2',
+        tokenUsage: {
+          total: { totalTokens: 8_400 },
+          last: { totalTokens: 150 },
+        },
+      })?.totalTokens,
+    ).toBe(400);
+  });
+
   it('keeps legacy total-only token payloads as absolute snapshots', () => {
     const tracker = createSubagentLiveCardTracker({ now: () => 0 });
     tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'));

--- a/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
+++ b/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
@@ -98,6 +98,163 @@ describe('createSubagentLiveCardTracker', () => {
     expect(afterUsage?.toolUses).toBe(1);
   });
 
+  it('subtracts forked parent history from the token count shown on a subagent card', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+
+    // app-server attaches the forked child by replaying its restored usage before the
+    // first child turn. That absolute total belongs to the parent history, not this card.
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'restored-parent-turn',
+        tokenUsage: {
+          total: { totalTokens: 10_000 },
+          last: { totalTokens: 900 },
+        },
+      }),
+    ).toBeNull();
+    expect(tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'))).toBeNull();
+
+    tracker.handleDescendantNotification('t-child', 'turn/started', {
+      turn: { id: 'child-turn-1' },
+    });
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: {
+          total: { totalTokens: 10_120 },
+          last: { totalTokens: 120 },
+        },
+      })?.totalTokens,
+    ).toBe(120);
+
+    // Later absolute snapshots remain relative to the same spawn baseline.
+    tracker.handleDescendantNotification('t-child', 'turn/started', {
+      turn: { id: 'child-turn-2' },
+    });
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-2',
+        tokenUsage: {
+          total: { totalTokens: 10_310 },
+          last: { totalTokens: 190 },
+        },
+      })?.totalTokens,
+    ).toBe(310);
+  });
+
+  it('infers the spawn baseline from last-turn usage when no restored snapshot arrives', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'));
+    // item 通知也能证明这是 live turn；即使 turn/started 丢失也不能误判成恢复帧。
+    tracker.handleDescendantNotification('t-child', 'item/started', {
+      turnId: 'child-turn-1',
+      item: { id: 'message-1', type: 'agentMessage' },
+    });
+
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: {
+          total: { totalTokens: 8_250 },
+          last: { totalTokens: 250 },
+        },
+      })?.totalTokens,
+    ).toBe(250);
+  });
+
+  it('keeps legacy total-only token payloads as absolute snapshots', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'));
+    tracker.handleDescendantNotification('t-child', 'item/started', {
+      turnId: 'child-turn-1',
+      item: { id: 'child-tool-1', type: 'commandExecution' },
+    });
+
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: { total: { totalTokens: 4_242 } },
+      })?.totalTokens,
+    ).toBe(4_242);
+  });
+
+  it('keeps the original spawn baseline when restored snapshots are duplicated out of order', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'));
+
+    tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+      turnId: 'restored-parent-turn',
+      tokenUsage: { total: { totalTokens: 1_000 }, last: { totalTokens: 100 } },
+    });
+    tracker.handleDescendantNotification('t-child', 'turn/started', {
+      turn: { id: 'child-turn-1' },
+    });
+    // A zero-growth live snapshot leaves the visible counter at zero.
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: { total: { totalTokens: 1_000 }, last: { totalTokens: 0 } },
+      }),
+    ).toBeNull();
+
+    // A stale replay must not replace the already-established 1,000-token baseline.
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'older-parent-turn',
+        tokenUsage: { total: { totalTokens: 900 }, last: { totalTokens: 90 } },
+      }),
+    ).toBeNull();
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: { total: { totalTokens: 1_100 }, last: { totalTokens: 100 } },
+      })?.totalTokens,
+    ).toBe(100);
+  });
+
+  it('keeps cumulative usage monotonic when a prior live turn reports late', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'));
+    tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+      turnId: 'restored-parent-turn',
+      tokenUsage: { total: { totalTokens: 1_000 }, last: { totalTokens: 100 } },
+    });
+    tracker.handleDescendantNotification('t-child', 'turn/started', {
+      turn: { id: 'child-turn-1' },
+    });
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: { total: { totalTokens: 1_100 }, last: { totalTokens: 100 } },
+      })?.totalTokens,
+    ).toBe(100);
+
+    tracker.handleDescendantNotification('t-child', 'turn/started', {
+      turn: { id: 'child-turn-2' },
+    });
+    // The previous turn can finish flushing after the next turn starts; its newer
+    // cumulative snapshot still belongs to this child and must not be discarded.
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: { total: { totalTokens: 1_150 }, last: { totalTokens: 50 } },
+      })?.totalTokens,
+    ).toBe(150);
+    // An older duplicate must not make the displayed count fall back to 100.
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-1',
+        tokenUsage: { total: { totalTokens: 1_100 }, last: { totalTokens: 100 } },
+      }),
+    ).toBeNull();
+    expect(
+      tracker.handleDescendantNotification('t-child', 'thread/tokenUsage/updated', {
+        turnId: 'child-turn-2',
+        tokenUsage: { total: { totalTokens: 1_300 }, last: { totalTokens: 150 } },
+      })?.totalTokens,
+    ).toBe(300);
+  });
+
   it('uses Cindy configured model only until the child thread reports its actual model', () => {
     const tracker = createSubagentLiveCardTracker({ now: () => 0, subagentModelFallback: 'gpt-5.6-terra' });
     expect(tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'))).toMatchObject({
@@ -230,20 +387,35 @@ describe('createSubagentLiveCardTracker', () => {
       toolUses: 2,
     });
 
-    // token 是各线程累计快照之和;同线程再报只覆盖自己那份,不重复相加。
+    // 每个 receiver 都先收到 fork 恢复帧；卡片只累计各线程从自身基线之后的增长。
+    tracker.handleDescendantNotification('t-a', 'thread/tokenUsage/updated', {
+      turnId: 'restored-a',
+      tokenUsage: { total: { totalTokens: 1_000 }, last: { totalTokens: 80 } },
+    });
+    tracker.handleDescendantNotification('t-b', 'thread/tokenUsage/updated', {
+      turnId: 'restored-b',
+      tokenUsage: { total: { totalTokens: 2_000 }, last: { totalTokens: 90 } },
+    });
+    tracker.handleDescendantNotification('t-a', 'turn/started', { turn: { id: 'live-a' } });
+    tracker.handleDescendantNotification('t-b', 'turn/started', { turn: { id: 'live-b' } });
+
+    // token 是各线程 spawn 后累计快照之和;同线程再报只覆盖自己那份,不重复相加。
     expect(
       tracker.handleDescendantNotification('t-a', 'thread/tokenUsage/updated', {
-        tokenUsage: { total: { totalTokens: 100 } },
+        turnId: 'live-a',
+        tokenUsage: { total: { totalTokens: 1_100 }, last: { totalTokens: 100 } },
       })?.totalTokens,
     ).toBe(100);
     expect(
       tracker.handleDescendantNotification('t-b', 'thread/tokenUsage/updated', {
-        tokenUsage: { total: { totalTokens: 40 } },
+        turnId: 'live-b',
+        tokenUsage: { total: { totalTokens: 2_040 }, last: { totalTokens: 40 } },
       })?.totalTokens,
     ).toBe(140);
     expect(
       tracker.handleDescendantNotification('t-a', 'thread/tokenUsage/updated', {
-        tokenUsage: { total: { totalTokens: 130 } },
+        turnId: 'live-a',
+        tokenUsage: { total: { totalTokens: 1_130 }, last: { totalTokens: 30 } },
       })?.totalTokens,
     ).toBe(170);
   });

--- a/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
+++ b/packages/maker-core/src/agents/codex/__tests__/subagentLiveCards.test.ts
@@ -696,6 +696,34 @@ describe('createSubagentLiveCardTracker', () => {
     ).toBeNull();
   });
 
+  it('counts delayed usage from a failed nested child turn without an item notification', () => {
+    const tracker = createSubagentLiveCardTracker({ now: () => 0 });
+    tracker.noteSpawnItem(v2SpawnItem('card-1', 't-child'));
+    // nested spawn 先失败，receiver 随后才补发 turn/started；失败状态必须锁住，但 turn id
+    // 仍要记下，否则后续现代 usage 会被当成恢复帧，烧掉的 token 永久漏计。
+    expect(tracker.noteDescendantThread('t-grand', 't-child', undefined, true)).toBeNull();
+    expect(
+      tracker.handleDescendantNotification('t-grand', 'turn/started', {
+        turn: { id: 'failed-child-turn' },
+      }),
+    ).toBeNull();
+
+    expect(
+      tracker.handleDescendantNotification('t-grand', 'thread/tokenUsage/updated', {
+        turnId: 'failed-child-turn',
+        tokenUsage: {
+          total: { totalTokens: 1_250 },
+          last: { totalTokens: 250 },
+        },
+      }),
+    ).toMatchObject({ status: 'running', totalTokens: 250 });
+    expect(
+      tracker.handleDescendantNotification('t-child', 'turn/completed', {
+        turn: { status: 'completed' },
+      }),
+    ).toMatchObject({ status: 'failed', totalTokens: 250 });
+  });
+
   it('ignores lineage for threads unrelated to any subagent card', () => {
     const tracker = createSubagentLiveCardTracker({ now: () => 0 });
     // 父线程不属于任何卡(例如主线程的后代未经 spawn 登记)→ 无副作用。

--- a/packages/maker-core/src/agents/codex/subagent-live-cards.ts
+++ b/packages/maker-core/src/agents/codex/subagent-live-cards.ts
@@ -472,9 +472,11 @@ export function createSubagentLiveCardTracker(opts: {
         return true;
       }
       case 'turn/started': {
-        if (thread.spawnFailed) return false;
         const turnId = (params as { turn?: { id?: unknown } } | null)?.turn?.id;
         noteObservedLiveTurn(thread, typeof turnId === 'string' ? turnId : undefined);
+        // nested spawn 的失败闩可能早于迟到的 turn/started；状态仍须保持 failed，但 live
+        // turn 身份必须先留下，后续 usage 才不会被误判成 fork / resume 的恢复快照。
+        if (thread.spawnFailed) return false;
         thread.status = 'running';
         return true;
       }

--- a/packages/maker-core/src/agents/codex/subagent-live-cards.ts
+++ b/packages/maker-core/src/agents/codex/subagent-live-cards.ts
@@ -41,7 +41,7 @@ export interface SubagentLiveCardUpdate {
   agentPath?: string;
   /** Observed child-thread model, or Cindy's explicit display fallback. `null` clears a stale badge. */
   model?: string | null;
-  /** 本卡全部子线程从各自本次 spawn 开始的累计 token 之和;未知为 0。 */
+  /** 本卡全部子线程 token 快照之和;现代载荷按 spawn 增量,旧 total-only 载荷保留绝对值。 */
   totalTokens: number;
   /** 本卡全部子线程内的工具类 item 数;未知为 0。 */
   toolUses: number;
@@ -152,18 +152,20 @@ const MAX_PENDING_THREAD_MODELS = MAX_PENDING_LINEAGE_PARENTS * MAX_PENDING_LINE
  * 后台 item/completed,提前清会让迟到的 completed 重复计数),所以只能按条数封顶。
  */
 const MAX_COUNTED_ITEM_IDS = 4096;
+/** 基线建立前保留的 live turn id 上限,用于识别跨 turn 延迟到达的首帧 usage。 */
+const MAX_OBSERVED_LIVE_TURN_IDS = 64;
 
 interface ThreadState {
   status: SubagentLiveCardStatus;
-  /** 该子线程从本次 spawn 开始实际消耗的累计 token。 */
+  /** 现代载荷为本次 spawn 后增量;旧 total-only 载荷保留宿主提供的绝对快照。 */
   totalTokens: number;
   /**
    * app-server 在 fork / resume 连接建立时会先重放一帧恢复后的 tokenUsage；其中 total
    * 含父线程继承历史，不能直接展示。保存该绝对水位，后续 live 快照只显示相对增量。
    */
   tokenUsageBaseline?: number;
-  /** 最近一次真实 live turn id；由 turn/started 或 item 通知确认，用于区分恢复帧。 */
-  liveTurnId?: string;
+  /** 基线建立前已确认的 live turn id；usage 可能晚于下一轮 turn/started 才到。 */
+  observedLiveTurnIds: Set<string>;
   /** Model observed from thread metadata or a spawn item. */
   model?: string;
   /** A failed nested spawn remains terminal despite late lifecycle events. */
@@ -369,6 +371,15 @@ export function createSubagentLiveCardTracker(opts: {
     children.add(childThreadId);
   };
 
+  const noteObservedLiveTurn = (thread: ThreadState, turnId: string | undefined): void => {
+    if (!turnId || thread.tokenUsageBaseline !== undefined || thread.observedLiveTurnIds.has(turnId)) return;
+    if (thread.observedLiveTurnIds.size >= MAX_OBSERVED_LIVE_TURN_IDS) {
+      const oldest = thread.observedLiveTurnIds.values().next();
+      if (!oldest.done) thread.observedLiveTurnIds.delete(oldest.value);
+    }
+    thread.observedLiveTurnIds.add(turnId);
+  };
+
   /** 应用一条通知到卡上;返回是否产生了变化(无变化不必发帧)。 */
   const applyNotification = (
     card: TrackedCard,
@@ -387,7 +398,7 @@ export function createSubagentLiveCardTracker(opts: {
         const itemTurnId = typeof itemParams?.turnId === 'string' ? itemParams.turnId : undefined;
         // app-server 不会把历史 item 重放成 live 通知；即使 turn/started 丢失，item 也能
         // 证明这个 turn 已经真实开跑，避免把随后到来的 live usage 误判成恢复帧。
-        if (itemTurnId) thread.liveTurnId = itemTurnId;
+        noteObservedLiveTurn(thread, itemTurnId);
         const item = itemParams?.item;
         const itemType = typeof item?.type === 'string' ? item.type : '';
         const itemId = typeof item?.id === 'string' ? item.id : '';
@@ -430,13 +441,14 @@ export function createSubagentLiveCardTracker(opts: {
         // 所以只把它记成基线而不产可见帧。无 turnId 的旧宿主载荷沿用原来的绝对快照口径。
         if (
           usageTurnId
-          && usageTurnId !== thread.liveTurnId
+          && !thread.observedLiveTurnIds.has(usageTurnId)
           && thread.tokenUsageBaseline === undefined
         ) {
           thread.tokenUsageBaseline = total;
+          thread.observedLiveTurnIds.clear();
           return false;
         }
-        if (!usageTurnId && !thread.liveTurnId) {
+        if (!usageTurnId && thread.observedLiveTurnIds.size === 0) {
           if (thread.totalTokens === total) return false;
           thread.totalTokens = total;
           return true;
@@ -451,6 +463,7 @@ export function createSubagentLiveCardTracker(opts: {
             && last <= total
             ? total - last
             : total;
+          thread.observedLiveTurnIds.clear();
         }
         const relativeTotal = Math.max(0, total - thread.tokenUsageBaseline);
         // total 是累计快照，乱序旧帧或重复恢复帧都不能让卡片数字回退。
@@ -461,7 +474,7 @@ export function createSubagentLiveCardTracker(opts: {
       case 'turn/started': {
         if (thread.spawnFailed) return false;
         const turnId = (params as { turn?: { id?: unknown } } | null)?.turn?.id;
-        if (typeof turnId === 'string' && turnId) thread.liveTurnId = turnId;
+        noteObservedLiveTurn(thread, typeof turnId === 'string' ? turnId : undefined);
         thread.status = 'running';
         return true;
       }
@@ -514,6 +527,7 @@ export function createSubagentLiveCardTracker(opts: {
       card.threads.set(childThreadId, {
         status: card.spawnFailed || latchSpawnFailure ? 'failed' : 'running',
         totalTokens: 0,
+        observedLiveTurnIds: new Set<string>(),
         ...(initialModel ? { model: initialModel } : {}),
         spawnFailed: latchSpawnFailure,
       });
@@ -702,7 +716,12 @@ export function createSubagentLiveCardTracker(opts: {
         if (card.threads.size === 0) {
           // 一个线程都还没登记上的卡(spawn 刚认出、子线程尚未 started):补一个占位线程,
           // 否则 aggregateStatus 对空集合返回 running,这张卡还是会留在转圈状态。
-          card.threads.set('__shutdown__', { status: 'stopped', totalTokens: 0, spawnFailed: false });
+          card.threads.set('__shutdown__', {
+            status: 'stopped',
+            totalTokens: 0,
+            observedLiveTurnIds: new Set<string>(),
+            spawnFailed: false,
+          });
         }
         out.push(snapshot(card));
       }

--- a/packages/maker-core/src/agents/codex/subagent-live-cards.ts
+++ b/packages/maker-core/src/agents/codex/subagent-live-cards.ts
@@ -41,7 +41,7 @@ export interface SubagentLiveCardUpdate {
   agentPath?: string;
   /** Observed child-thread model, or Cindy's explicit display fallback. `null` clears a stale badge. */
   model?: string | null;
-  /** 本卡全部子线程的累计 token 之和;未知为 0。 */
+  /** 本卡全部子线程从各自本次 spawn 开始的累计 token 之和;未知为 0。 */
   totalTokens: number;
   /** 本卡全部子线程内的工具类 item 数;未知为 0。 */
   toolUses: number;
@@ -155,8 +155,15 @@ const MAX_COUNTED_ITEM_IDS = 4096;
 
 interface ThreadState {
   status: SubagentLiveCardStatus;
-  /** 该子线程最新的**累计** token(tokenUsage.total 是快照,按线程覆盖而非相加)。 */
+  /** 该子线程从本次 spawn 开始实际消耗的累计 token。 */
   totalTokens: number;
+  /**
+   * app-server 在 fork / resume 连接建立时会先重放一帧恢复后的 tokenUsage；其中 total
+   * 含父线程继承历史，不能直接展示。保存该绝对水位，后续 live 快照只显示相对增量。
+   */
+  tokenUsageBaseline?: number;
+  /** 最近一次真实 live turn id；由 turn/started 或 item 通知确认，用于区分恢复帧。 */
+  liveTurnId?: string;
   /** Model observed from thread metadata or a spawn item. */
   model?: string;
   /** A failed nested spawn remains terminal despite late lifecycle events. */
@@ -373,7 +380,15 @@ export function createSubagentLiveCardTracker(opts: {
       case 'item/started':
       case 'item/updated':
       case 'item/completed': {
-        const item = (params as { item?: { type?: unknown; id?: unknown } } | null)?.item;
+        const itemParams = params as {
+          turnId?: unknown;
+          item?: { type?: unknown; id?: unknown };
+        } | null;
+        const itemTurnId = typeof itemParams?.turnId === 'string' ? itemParams.turnId : undefined;
+        // app-server 不会把历史 item 重放成 live 通知；即使 turn/started 丢失，item 也能
+        // 证明这个 turn 已经真实开跑，避免把随后到来的 live usage 误判成恢复帧。
+        if (itemTurnId) thread.liveTurnId = itemTurnId;
+        const item = itemParams?.item;
         const itemType = typeof item?.type === 'string' ? item.type : '';
         const itemId = typeof item?.id === 'string' ? item.id : '';
         if (!itemId || !TOOL_ITEM_TYPES.has(itemType)) return false;
@@ -389,17 +404,67 @@ export function createSubagentLiveCardTracker(opts: {
         return true;
       }
       case 'thread/tokenUsage/updated': {
-        const total = (params as { tokenUsage?: { total?: { totalTokens?: unknown } } } | null)
-          ?.tokenUsage?.total?.totalTokens;
-        if (typeof total !== 'number' || !Number.isFinite(total)) return false;
-        // total 是该线程的累计快照 → 覆盖本线程分量,卡片总量由各线程求和。
-        thread.totalTokens = total;
+        const usageParams = params as {
+          turnId?: unknown;
+          tokenUsage?: {
+            total?: { totalTokens?: unknown };
+            last?: { totalTokens?: unknown };
+          };
+        } | null;
+        const total = usageParams?.tokenUsage?.total?.totalTokens;
+        if (typeof total !== 'number' || !Number.isFinite(total) || total < 0) return false;
+        const usageTurnId = typeof usageParams?.turnId === 'string' ? usageParams.turnId : undefined;
+        const last = usageParams?.tokenUsage?.last?.totalTokens;
+
+        // 旧宿主只给 total（即使附带 turnId），没有 last 就无法从第一帧反推出 spawn 水位。
+        // 这种载荷保持既有绝对快照语义；当前 app-server 的恢复帧与 live 帧都会带 last。
+        if (thread.tokenUsageBaseline === undefined && last === undefined) {
+          if (thread.totalTokens === total) return false;
+          thread.totalTokens = total;
+          return true;
+        }
+
+        // fork / resume 会在子线程第一个 live turn 之前重放恢复后的 usage。它的 total 是
+        // 父线程历史 + 子线程增量的绝对累计值；若直接展示，就会把整段父会话历史算到卡上。
+        // live 用量通知带当前 turnId，恢复帧没有对应的 live turn / item（或 id 不同），
+        // 所以只把它记成基线而不产可见帧。无 turnId 的旧宿主载荷沿用原来的绝对快照口径。
+        if (
+          usageTurnId
+          && usageTurnId !== thread.liveTurnId
+          && thread.tokenUsageBaseline === undefined
+        ) {
+          thread.tokenUsageBaseline = total;
+          return false;
+        }
+        if (!usageTurnId && !thread.liveTurnId) {
+          if (thread.totalTokens === total) return false;
+          thread.totalTokens = total;
+          return true;
+        }
+
+        if (thread.tokenUsageBaseline === undefined) {
+          // 若宿主或 fork 配置没先发恢复帧，用本次 live 增量反推出 spawn 前水位。协议缺
+          // last 时宁可从当前 total 起算（本帧显示 0），也不要再次把继承历史误报成用量。
+          thread.tokenUsageBaseline = typeof last === 'number'
+            && Number.isFinite(last)
+            && last >= 0
+            && last <= total
+            ? total - last
+            : total;
+        }
+        const relativeTotal = Math.max(0, total - thread.tokenUsageBaseline);
+        // total 是累计快照，乱序旧帧或重复恢复帧都不能让卡片数字回退。
+        if (relativeTotal <= thread.totalTokens) return false;
+        thread.totalTokens = relativeTotal;
         return true;
       }
-      case 'turn/started':
+      case 'turn/started': {
         if (thread.spawnFailed) return false;
+        const turnId = (params as { turn?: { id?: unknown } } | null)?.turn?.id;
+        if (typeof turnId === 'string' && turnId) thread.liveTurnId = turnId;
         thread.status = 'running';
         return true;
+      }
       case 'turn/completed': {
         if (thread.spawnFailed) return false;
         const turnStatus = (params as { turn?: { status?: unknown } } | null)?.turn?.status;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修正 Codex 子代理卡把父任务历史 token 计入子代理用量的问题。

Codex fork / resume 子线程时会先重放继承自父线程的累计 `tokenUsage.total`。此前卡片直接显示这个绝对快照，因此会出现千万级数字。本 PR 将恢复帧记录为 spawn 基线，后续只显示子线程从本次 spawn 开始产生的增量。

同时处理重复恢复帧、乱序旧快照、多 receiver 聚合，以及没有恢复帧时从 `last` 反推基线。仅提供 `total` 的旧宿主载荷继续保持原有绝对快照行为。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Codex 子代理卡 token 数错误
- 本 PR 包含：Codex 子代理卡 token 基线与增量聚合；恢复帧、乱序、旧载荷和多 receiver 回归测试
- 明确不包含：Claude / Pi 子代理统计、卡片 UI 样式与文案、服务端协议修改
- 用户可见变化：Codex 子代理卡只显示该子代理实际消耗的 token，不再包含父任务历史累计值
- 是否存在 breaking change：无

### UI 变化

不涉及 UI 结构、样式或文案；仅修正现有子代理卡 token 字段的数据来源。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过；Desktop、Mobile、maker-core 与其余 unit workspaces 全部通过

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/__tests__/subagentLiveCards.test.ts
结果：通过，54 tests

pnpm --filter @cindy/maker-core exec vitest run src/agents/codex/index.test.ts -t "registers the subagent spawn mapping on item/updated|closes out running subagent cards when the transport dies"
结果：通过，2 tests

pnpm --filter @cindy/maker-core exec eslint src/agents/codex/subagent-live-cards.ts src/agents/codex/__tests__/subagentLiveCards.test.ts
结果：通过

pnpm --filter @cindy/maker-core exec tsc --noEmit --strict --skipLibCheck --target ES2022 --module NodeNext --moduleResolution NodeNext src/agents/codex/subagent-live-cards.ts
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

对本机真实 Codex fork rollout 做了脱敏事件回放：

- 旧逻辑首帧显示 `10,057,333`
- 新逻辑首帧显示 `49,388`
- 子任务结束时显示 `790,014`，与 spawn 后各次 `last` 增量之和一致

### 未执行的验证

未启动或覆盖安装 Desktop；本次修改位于纯聚合逻辑，已由单元、集成测试及真实事件流回放覆盖。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Codex 子代理实时卡片的 token 聚合
- 回滚 / 降级方式：回退本 PR；旧宿主仅提供 `total` 的载荷已保留兼容路径

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
