### PR TITLE
fix(proxy): 修复密文恢复留下消息空壳

### DIFF
--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -324,7 +324,7 @@ describe('anthropic-compat-proxy encrypted content retry', () => {
         res.writeHead(400, { 'content-type': 'application/json' });
         res.end(JSON.stringify({
           error: {
-            message: "Missing required parameter: 'input[1].content[1].encrypted_content'.",
+            message: "Missing required parameter: 'input[2].content[1].encrypted_content'.",
             code: 'missing_required_parameter',
           },
         }));

--- a/packages/anthropic-compat-proxy/src/server.test.ts
+++ b/packages/anthropic-compat-proxy/src/server.test.ts
@@ -302,6 +302,112 @@ describe('anthropic-compat-proxy tool_use provider field compatibility', () => {
 });
 
 describe('anthropic-compat-proxy encrypted content retry', () => {
+  it('preserves readable agent progress when foreign reasoning ciphertext triggers recovery', async () => {
+    const upstream = await startFakeUpstream((_idx, rawBody, res) => {
+      const body = JSON.parse(rawBody) as {
+        input?: Array<{ type?: string; content?: unknown[]; encrypted_content?: unknown }>;
+      };
+      const encryptedParts = (body.input ?? [])
+        .filter((item) => item.type === 'agent_message' && Array.isArray(item.content))
+        .flatMap((item) => item.content ?? [])
+        .filter((part): part is Record<string, unknown> => (
+          typeof part === 'object'
+          && part !== null
+          && 'type' in part
+          && part.type === 'encrypted_content'
+        ));
+      const foreignReasoning = (body.input ?? []).some((item) => (
+        item.type === 'reasoning'
+        && item.encrypted_content === 'gAAAAA-foreign-reasoning'
+      ));
+      if (encryptedParts.some((part) => typeof part.encrypted_content !== 'string')) {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          error: {
+            message: "Missing required parameter: 'input[1].content[1].encrypted_content'.",
+            code: 'missing_required_parameter',
+          },
+        }));
+      } else if (foreignReasoning) {
+        res.writeHead(400, { 'content-type': 'application/json' });
+        res.end(ENC_ERROR_BODY);
+      } else {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+      }
+    });
+    upstreamClose = upstream.close;
+    const controller = createThreadStripController();
+    proxy = await createAnthropicCompatProxy({
+      upstream: upstream.url,
+      transformRequest: [createActiveStripTransform({
+        controller,
+        enabled: () => true,
+        strip: stripEncryptedContentFromBody,
+      })],
+      recoveryRules: [createEncryptedContentRecoveryRule({
+        enabled: () => true,
+        onRetry: (threadId, model) => controller.markActive(threadId, model),
+      })],
+    });
+    const request = {
+      model: 'gpt-5.6-sol',
+      input: [
+        { type: 'message', role: 'user', content: 'go' },
+        {
+          type: 'reasoning',
+          id: 'foreign-reasoning',
+          summary: [],
+          encrypted_content: 'gAAAAA-foreign-reasoning',
+        },
+        {
+          type: 'agent_message',
+          author: '/root/progress_test',
+          recipient: '/root',
+          content: [
+            { type: 'input_text', text: 'progress' },
+            { type: 'encrypted_content', encrypted_content: 'gAAAAA-progress' },
+          ],
+          internal_chat_message_metadata_passthrough: { source: 'send_message' },
+        },
+        {
+          type: 'agent_message',
+          author: '/root/progress_test',
+          recipient: '/root',
+          content: [{ type: 'input_text', text: 'complete' }],
+        },
+        {
+          type: 'agent_message',
+          author: '/root/opaque',
+          content: [{ type: 'encrypted_content', encrypted_content: 'gAAAAA-only' }],
+        },
+      ],
+    };
+
+    expect((await post(proxy.url, request)).status).toBe(200);
+    expect(upstream.bodies).toHaveLength(2);
+    expect(JSON.parse(upstream.bodies[1]).input).toEqual([
+      { type: 'message', role: 'user', content: 'go' },
+      {
+        type: 'agent_message',
+        author: '/root/progress_test',
+        recipient: '/root',
+        content: [{ type: 'input_text', text: 'progress' }],
+        internal_chat_message_metadata_passthrough: { source: 'send_message' },
+      },
+      {
+        type: 'agent_message',
+        author: '/root/progress_test',
+        recipient: '/root',
+        content: [{ type: 'input_text', text: 'complete' }],
+      },
+    ]);
+
+    expect((await post(proxy.url, request)).status).toBe(200);
+    expect(upstream.bodies).toHaveLength(3);
+    expect(upstream.bodies[2]).toBe(upstream.bodies[1]);
+  });
+
   it('retries invalid_encrypted_content once when enabled and marks the thread active', async () => {
     const upstream = await startFakeUpstream((idx, _body, res) => {
       if (idx === 0) {

--- a/packages/anthropic-compat-proxy/src/transform.test.ts
+++ b/packages/anthropic-compat-proxy/src/transform.test.ts
@@ -39,6 +39,54 @@ const ctx: RequestTransformCtx = {
 };
 
 describe('stripEncryptedContentFromBody', () => {
+  it('drops ciphertext from intermediate agent messages while preserving readable progress and completion', () => {
+    const body = buf({
+      model: 'gpt-5.6-sol',
+      input: [
+        {
+          type: 'agent_message',
+          author: '/root/progress_test',
+          recipient: '/root',
+          content: [
+            { type: 'input_text', text: 'progress' },
+            { type: 'encrypted_content', encrypted_content: 'gAAAAA-progress' },
+          ],
+          internal_chat_message_metadata_passthrough: { source: 'send_message' },
+        },
+        {
+          type: 'agent_message',
+          author: '/root/progress_test',
+          recipient: '/root',
+          content: [{ type: 'input_text', text: 'complete' }],
+        },
+        {
+          type: 'agent_message',
+          author: '/root/opaque',
+          content: [{ type: 'encrypted_content', encrypted_content: 'gAAAAA-only' }],
+        },
+      ],
+    });
+
+    const out = stripEncryptedContentFromBody(body);
+
+    expect(out).not.toBeNull();
+    expect(JSON.parse(out!.toString('utf8')).input).toEqual([
+      {
+        type: 'agent_message',
+        author: '/root/progress_test',
+        recipient: '/root',
+        content: [{ type: 'input_text', text: 'progress' }],
+        internal_chat_message_metadata_passthrough: { source: 'send_message' },
+      },
+      {
+        type: 'agent_message',
+        author: '/root/progress_test',
+        recipient: '/root',
+        content: [{ type: 'input_text', text: 'complete' }],
+      },
+    ]);
+  });
+
   it('removes encrypted_content nested in Responses-style input items', () => {
     const body = buf({
       model: 'gpt-5.5',

--- a/packages/anthropic-compat-proxy/src/transform.ts
+++ b/packages/anthropic-compat-proxy/src/transform.ts
@@ -117,6 +117,47 @@ function isCompactionItem(node: Record<string, unknown>): boolean {
 }
 
 /**
+ * Drop Codex agent-to-agent ciphertext at its protocol-defined location.
+ *
+ * A spawned Codex agent can call `send_message` from an otherwise ordinary
+ * session; the resulting `agent_message` carries readable text and an optional
+ * `{ type: 'encrypted_content', encrypted_content: '...' }` part. Deleting only
+ * the field leaves a schema-invalid encrypted-content shell, so remove the
+ * whole part before the generic recursive key strip. If the message contained
+ * only ciphertext, the message itself has no replayable content and is dropped.
+ *
+ * This intentionally inspects only top-level Responses `input[]`; nested
+ * business objects with a similarly shaped `content` array are not protocol
+ * history and must not be interpreted by shape.
+ */
+function dropEncryptedAgentMessageContentParts(body: unknown): number {
+  if (!isPlainObject(body) || !Array.isArray(body.input)) return 0;
+
+  let removed = 0;
+  const input: unknown[] = [];
+  for (const item of body.input) {
+    if (!isPlainObject(item) || item.type !== 'agent_message' || !Array.isArray(item.content)) {
+      input.push(item);
+      continue;
+    }
+
+    const content = item.content.filter((part) => {
+      if (!isPlainObject(part) || part.type !== 'encrypted_content') return true;
+      removed += 1;
+      return false;
+    });
+    if (content.length === item.content.length) {
+      input.push(item);
+    } else if (content.length > 0) {
+      input.push({ ...item, content });
+    }
+  }
+
+  if (removed > 0) body.input = input;
+  return removed;
+}
+
+/**
  * 递归删除 body 里所有 `encrypted_content` 键, 返回删掉的个数。
  * 用于 invalid_encrypted_content 报错后的透明重试 (见 stripEncryptedContentFromBody)。
  *
@@ -224,12 +265,15 @@ export function stripEncryptedContentFromBody(rawBody: Buffer): Buffer | null {
   } catch {
     return null;
   }
+  // agent_message 的密文是 content part；必须在通用递归删键之前整块移除，否则会留下
+  // `{ type: 'encrypted_content' }` 并被 OpenAI 拒绝为 missing_required_parameter。
+  const removedAgentMessageParts = dropEncryptedAgentMessageContentParts(parsed);
   const removedKeys = deepDeleteEncryptedContent(parsed);
   // 空壳清理独立计数: 请求体里可能只带着一个缺 blob 的 compaction 空壳 (没有任何
   // encrypted_content 键可删), 那一样是必须处理的坏 payload, 不能因 removedKeys=0 放行。
   // 这一步只扫顶层 input[] (单次线性扫描), 不是第二遍深度遍历。
   const removedShells = dropEncryptedShellInputItems(parsed, removedKeys > 0);
-  if (removedKeys === 0 && removedShells === 0) return null;
+  if (removedAgentMessageParts === 0 && removedKeys === 0 && removedShells === 0) return null;
   try {
     return Buffer.from(JSON.stringify(parsed), 'utf8');
   } catch {


### PR DESCRIPTION
## 这次改了什么

### 摘要

当上游拒绝无法解密的历史密文时，兼容代理会清理密文并透明重试。旧逻辑只递归删除 `encrypted_content` 字段，导致 Codex `agent_message.content[]` 留下 `{ type: "encrypted_content" }` 空壳；重试随后转为 `missing_required_parameter`，使任务持续卡死。

本 PR 在通用递归清理前删除完整的密文 content part；消息同时包含可读文本时保留文本和消息元数据，仅含密文时删除整条不可回放消息。确定性服务级用例同时构造“失效 reasoning 密文触发恢复”和“agent_message 含密文 part”两个条件，覆盖原始错误链和恢复后的主动清理路径。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无
- 本 PR 包含：Responses 请求历史中的 `agent_message` 密文 part 清理，以及转换层和服务级回归测试
- 明确不包含：上游首次产生 `invalid_encrypted_content` 的机制、UI、数据库或 wire schema 变更
- 用户可见变化：模型或 provider 切换遇到无法解密的历史密文时，可以自动恢复，不再因缺参错误永久卡住任务
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（rebase 最新 main 后完整执行）

pnpm --filter @cindy/anthropic-compat-proxy run --if-present typecheck
结果：通过

pnpm --filter @cindy/anthropic-compat-proxy exec vitest run src/transform.test.ts src/server.test.ts
结果：通过，2 个文件、206 个测试

pnpm exec eslint packages/anthropic-compat-proxy/src/transform.ts packages/anthropic-compat-proxy/src/transform.test.ts packages/anthropic-compat-proxy/src/server.test.ts
结果：通过

pnpm check:dco
结果：通过，1 个 commit 已签名

git diff --check origin/main...HEAD
结果：通过
```

### 手工验证

Windows 隔离 dev 沙盒 `Cindy-dev2-issue2247` 中，以普通任务（未启用 Cindy 协同）完成 XD 网关到 OpenAI direct 的续发冒烟验证，任务可继续响应。该次自然请求没有触发首次 `invalid_encrypted_content`，因此仅作为正常链路冒烟；精确故障恢复由可控 fake upstream 的服务级测试覆盖。

### 未执行的验证

未执行真实上游的“强制失效密文”打包黑盒测试：密文是否失效由上游状态决定，客户端 UI 无法稳定制造。已使用服务级集成测试精确返回 `invalid_encrypted_content`，并验证清理后的重试不会转为 `missing_required_parameter`。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响兼容代理在密文恢复或已激活主动清理时发送给上游的 Responses 请求；可读 agent 进度、最终消息及其元数据保持不变，仅密文 part 和仅含密文的不可回放消息会被移除
- 回滚 / 降级方式：revert 本 PR 的提交即可恢复旧清理行为；不涉及数据迁移、持久化格式或服务端部署

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因