### PR TITLE
fix(chat): 隐藏无内容的文件变更卡片

### DIFF
--- a/apps/desktop/src/main/turn-change-set/store.ts
+++ b/apps/desktop/src/main/turn-change-set/store.ts
@@ -921,10 +921,10 @@ export async function captureKnownFileBefore(input: KnownFileWriteCapture): Prom
     // A known write target literally outside the workspace (agent temp files,
     // scratchpad, OS temp dirs) is a deliberate scope exclusion, not a capture
     // loss: turn change tracking only covers the workspace tree. Recording
-    // 'outside-workspace' here spawned a dead-end "+0 -0" partial card for
-    // turns that never touched the workspace at all. The realpath escape check
-    // below still records the reason — there the workspace tree appears
-    // touched, which is worth flagging.
+    // 'outside-workspace' here records a scope exclusion for turns that never
+    // touched the workspace at all. The realpath escape check below still records
+    // the reason — there the workspace tree appears touched, which is worth
+    // flagging.
     return;
   }
   if (detectSensitivePath(target.relativePath, { allowEnvTemplates: true })) {

--- a/apps/desktop/src/main/turn-change-set/store.ts
+++ b/apps/desktop/src/main/turn-change-set/store.ts
@@ -918,13 +918,10 @@ export async function captureKnownFileBefore(input: KnownFileWriteCapture): Prom
   const pending = ensurePending(input.sessionId, input.provider, input.cwd);
   const target = safeRelativeTarget(input.cwd, input.targetPath);
   if (!target) {
-    // A known write target literally outside the workspace (agent temp files,
-    // scratchpad, OS temp dirs) is a deliberate scope exclusion, not a capture
-    // loss: turn change tracking only covers the workspace tree. Recording
-    // 'outside-workspace' here records a scope exclusion for turns that never
-    // touched the workspace at all. The realpath escape check below still records
-    // the reason — there the workspace tree appears touched, which is worth
-    // flagging.
+    // Literal out-of-workspace targets are deliberately skipped without recording
+    // a reason because the workspace tree was never touched. The realpath escape
+    // check below still records 'outside-workspace' when a workspace path resolves
+    // beyond that tree, which is worth flagging.
     return;
   }
   if (detectSensitivePath(target.relativePath, { allowEnvTemplates: true })) {

--- a/apps/desktop/src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
+++ b/apps/desktop/src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
@@ -327,7 +327,7 @@ describe('buildRenderItems — key stability', () => {
     expect(items.indexOf(cards[0])).toBeGreaterThan(items.findIndex((item) => item.key === 'msg-a1'));
   });
 
-  it('hides zero-file cards without change evidence but keeps evidence-bearing ones', () => {
+  it('hides all zero-file change cards because they have no reviewable content', () => {
     const base: TurnChangeSetSummary = {
       id: 'cs-base',
       sessionId: 's1',
@@ -346,13 +346,11 @@ describe('buildRenderItems — key stability', () => {
       additions: 0,
       deletions: 0,
     };
-    // Only "we might not have seen everything" reasons: review pane would be empty.
-    const noEvidence: TurnChangeSetSummary = {
+    const opaque: TurnChangeSetSummary = {
       ...base,
       id: 'cs-noise',
       incompleteReasons: ['opaque-tool', 'turn-failed', 'concurrent-workspace'],
     };
-    // Proof that real changes existed but were not recorded: card must stay.
     const truncated: TurnChangeSetSummary = {
       ...base,
       id: 'cs-too-large',
@@ -360,8 +358,6 @@ describe('buildRenderItems — key stability', () => {
       createdAt: 3,
       completedAt: 4,
     };
-    // The store only records 'outside-workspace' for suspicious captures (symlink
-    // escapes, fail-closed provider diff blocks) — that evidence must stay visible.
     const escaped: TurnChangeSetSummary = {
       ...base,
       id: 'cs-escape',
@@ -374,12 +370,12 @@ describe('buildRenderItems — key stability', () => {
       [mkUser('u1'), mkAssistant('a1'), mkUser('u2')],
       undefined,
       undefined,
-      { turnChangeSets: [noEvidence, truncated, escaped] },
+      { turnChangeSets: [opaque, truncated, escaped] },
     );
     const cards = items.filter(
       (item): item is Extract<RenderItem, { type: 'turn_changes' }> => item.type === 'turn_changes',
     );
-    expect(cards.map((card) => card.changeSet.id)).toEqual(['cs-too-large', 'cs-escape']);
+    expect(cards).toEqual([]);
   });
 
   it('keeps opaque command artifacts as fallback chips without duplicating exact files', () => {

--- a/apps/desktop/src/renderer/components/chat/MessageStream.tsx
+++ b/apps/desktop/src/renderer/components/chat/MessageStream.tsx
@@ -1074,8 +1074,8 @@ export function buildRenderItems(
       }
     }
     for (const changeSet of changeSets) {
-      // Zero-file entries without change evidence (e.g. only opaque tools ran)
-      // would render a card whose review pane is empty — skip the dead end.
+      // Zero-file entries have nothing the user can inspect or act on. Keep their
+      // diagnostic sidecars in Main, but do not add a warning-only chat card.
       if (!hasReviewableTurnChanges(changeSet)) continue;
       items.push({
         type: 'turn_changes',

--- a/apps/desktop/src/shared/turnChangeSet.ts
+++ b/apps/desktop/src/shared/turnChangeSet.ts
@@ -76,28 +76,12 @@ export interface PersistedTurnChangeSetV1 {
 }
 
 /**
- * Reasons that only say "the capture may not have seen everything", without any
- * evidence that a change actually happened (opaque tools ran, the turn failed, or
- * another session overlapped). Reasons outside this set prove changes existed but
- * were not recorded — including 'outside-workspace', which the store only records
- * for suspicious cases (a workspace path whose realpath escapes via symlink, or a
- * provider diff block rejected as unsafe); literal out-of-workspace targets are
- * skipped at capture time without recording any reason.
- */
-const NO_CHANGE_EVIDENCE_REASONS: ReadonlySet<TurnChangeIncompleteReason> = new Set([
-  'opaque-tool',
-  'turn-failed',
-  'concurrent-workspace',
-]);
-
-/**
- * Whether a summary carries anything a standalone review card can show. Zero-file
- * entries whose reasons carry no change evidence open an empty review pane — hide
- * the chat-stream card instead of sending users into a dead end.
+ * Whether a summary carries file content a standalone review card can show.
+ * Incomplete zero-file records remain persisted for diagnostics, but rendering a
+ * warning-only card in the chat stream gives the user nothing to inspect or act on.
  */
 export function hasReviewableTurnChanges(summary: TurnChangeSetSummary): boolean {
-  if (summary.fileCount > 0 || summary.files.length > 0) return true;
-  return summary.incompleteReasons.some((reason) => !NO_CHANGE_EVIDENCE_REASONS.has(reason));
+  return summary.fileCount > 0 || summary.files.length > 0;
 }
 
 export interface TurnChangeSetUpdatedPayload {


### PR DESCRIPTION
## 这次改了什么

### 摘要

当 turn change set 没有任何文件条目时，不再在消息流渲染“文件变更未完整记录”卡片。此类 sidecar 仍在 Main 保存用于诊断；有实际文件条目时维持原有审查/撤销卡片。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈“没有可显示内容时不要显示文件变更卡片”。
- 本 PR 包含：收紧 `hasReviewableTurnChanges` 判定；消息流隐藏所有零文件变更卡片；更新对应回归测试和注释。
- 明确不包含：不改变 Main 侧 sidecar 持久化、不改变有文件条目的审查/撤销行为、不调整生成文件卡片。
- 用户可见变化：没有可审查文件内容时，消息流不再出现空的文件变更警告卡片。
- 是否存在 breaking change：无。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §2「Surface / Card / Board」与 §4「Cards & Containers」；本次仅移除没有可审阅内容的空卡片渲染，不新增样式，保留有文件内容卡片的既有布局与双模式语义 token。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
结果：59/59 通过。

pnpm --filter desktop exec vitest run src/renderer/components/chat/__tests__/TurnChangesCard.test.tsx src/renderer/__tests__/buildRenderItemsKeyStability.test.ts
结果：70/70 通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm test:unit
结果：通过（test:runner 382 通过、8 跳过；所有适用 workspace unit sweep 通过）。

pnpm check:dco
结果：通过，1 个提交带 DCO 签名。
```

### 手工验证

未涉及：本次没有修改卡片样式或布局；行为由 renderer 回归测试覆盖。

### 未执行的验证

桌面 Light / Dark 实机目检未执行，原因是本次仅改变零文件卡片是否渲染，未改变样式；有内容卡片继续复用现有 themed 样式。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 renderer 消息流中 turn change card 的投影判定；Main 仍保留零文件 sidecar 用于诊断。
- 回滚 / 降级方式：回退提交 `0ee07c2cc` 即可恢复原有渲染行为。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果并如实说明未执行项