### PR TITLE
fix(desktop): 修复回车发送后输入框失焦

### DIFF
--- a/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
@@ -55,7 +55,7 @@ describe('ChatInput session switch focus contract', () => {
     );
     expect(restoreNextDraftBlock).toContain('if (!isCurrentTransition()) return;');
     expect(restoreNextDraftBlock).toContain(
-      'if (hasFocusMovedToInteractiveElement(storageKeyFocusAnchor, editor)) return;',
+      'if (hasFocusMovedToInteractiveElement(storageKeyFocusAnchor, editor.view.dom)) return;',
     );
     expect(restoreNextDraftBlock).toContain("editor.commands.focus('end');");
     expect(firstMountHydrationBlock).toContain('focusOnStorageKeyChangeRef.current');
@@ -87,41 +87,25 @@ describe('ChatInput session switch focus contract', () => {
   });
 
   it('guards delayed storageKey focus against stealing from another focused control', () => {
-    expect(chatInputSource).toContain('function hasFocusMovedToInteractiveElement(');
-    expect(chatInputSource).toContain('if (activeElement === focusAnchor) return false;');
-    expect(chatInputSource).toContain('if (editor.view.dom.contains(activeElement)) return false;');
-    expect(chatInputSource).toContain('return isInteractiveFocusedElement(activeElement);');
+    expect(chatInputSource).toContain(
+      'hasFocusMovedToInteractiveElement(storageKeyFocusAnchor, editor.view.dom)',
+    );
   });
 
-  it('restores keyboard focus after the temporary local send lock without stealing it', () => {
-    const editorLockEffect = extractBetween(
-      chatInputSource,
-      'const composerMutationLocked = composerEditorLocked || voiceInput.isBusy;',
-      'const { settings: voiceInputSettings }',
-    );
+  it('wires local send locking through the behavior-tested focus restore hook', () => {
     const localSendLockBlock = extractBetween(
       chatInputSource,
       '// Local/SSH sends keep the live composer while references and runtime',
       'try {\n        let serializedContent',
     );
 
-    expect(chatInputSource).toContain('const pendingSendFocusRestoreRef = useRef<{');
-    expect(chatInputSource).toContain('focusAnchor: Element | null;');
-    expect(localSendLockBlock).toContain('pendingSendFocusRestoreRef.current = editor.isFocused');
-    expect(localSendLockBlock.indexOf('pendingSendFocusRestoreRef.current')).toBeLessThan(
+    expect(chatInputSource).toContain(
+      'const captureSendFocusForRestore = useComposerSendFocusRestore(',
+    );
+    expect(localSendLockBlock).toContain('captureSendFocusForRestore();');
+    expect(localSendLockBlock.indexOf('captureSendFocusForRestore();')).toBeLessThan(
       localSendLockBlock.indexOf('setSendDispatchInFlight(true);'),
     );
-    expect(editorLockEffect).toContain('editor?.setEditable(!composerMutationLocked);');
-    expect(editorLockEffect).toContain('if (!editor || sendDispatchInFlight) return;');
-    expect(editorLockEffect).toContain('pendingSendFocusRestoreRef.current = null;');
-    expect(editorLockEffect).toContain('if (composerMutationLocked) return;');
-    expect(editorLockEffect).toContain(
-      'if (editor.isDestroyed || !editor.isEditable || editor.isFocused) return;',
-    );
-    expect(editorLockEffect).toContain(
-      'hasFocusMovedToInteractiveElement(pendingFocusRestore.focusAnchor, editor)',
-    );
-    expect(editorLockEffect).toContain('editor.commands.focus();');
   });
 
   it('reuses in-composer Plugin placement for routed Use and end-focuses Create with Cindy', () => {

--- a/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
+++ b/apps/desktop/src/renderer/__tests__/chatInputSessionFocus.test.ts
@@ -93,6 +93,37 @@ describe('ChatInput session switch focus contract', () => {
     expect(chatInputSource).toContain('return isInteractiveFocusedElement(activeElement);');
   });
 
+  it('restores keyboard focus after the temporary local send lock without stealing it', () => {
+    const editorLockEffect = extractBetween(
+      chatInputSource,
+      'const composerMutationLocked = composerEditorLocked || voiceInput.isBusy;',
+      'const { settings: voiceInputSettings }',
+    );
+    const localSendLockBlock = extractBetween(
+      chatInputSource,
+      '// Local/SSH sends keep the live composer while references and runtime',
+      'try {\n        let serializedContent',
+    );
+
+    expect(chatInputSource).toContain('const pendingSendFocusRestoreRef = useRef<{');
+    expect(chatInputSource).toContain('focusAnchor: Element | null;');
+    expect(localSendLockBlock).toContain('pendingSendFocusRestoreRef.current = editor.isFocused');
+    expect(localSendLockBlock.indexOf('pendingSendFocusRestoreRef.current')).toBeLessThan(
+      localSendLockBlock.indexOf('setSendDispatchInFlight(true);'),
+    );
+    expect(editorLockEffect).toContain('editor?.setEditable(!composerMutationLocked);');
+    expect(editorLockEffect).toContain('if (!editor || sendDispatchInFlight) return;');
+    expect(editorLockEffect).toContain('pendingSendFocusRestoreRef.current = null;');
+    expect(editorLockEffect).toContain('if (composerMutationLocked) return;');
+    expect(editorLockEffect).toContain(
+      'if (editor.isDestroyed || !editor.isEditable || editor.isFocused) return;',
+    );
+    expect(editorLockEffect).toContain(
+      'hasFocusMovedToInteractiveElement(pendingFocusRestore.focusAnchor, editor)',
+    );
+    expect(editorLockEffect).toContain('editor.commands.focus();');
+  });
+
   it('reuses in-composer Plugin placement for routed Use and end-focuses Create with Cindy', () => {
     expect(pluginPageSource).toContain('pendingGhostId: ghost.manifest.id');
     expect(pluginPageSource.match(/focusAtEnd: true/g)).toHaveLength(1);

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -1651,6 +1651,12 @@ export function ChatInput({
   const [sendDispatchInFlight, setSendDispatchInFlight] = useState(false);
   const composerEditorLocked = disabled || sendDispatchInFlight;
   const composerMutationLockedRef = useRef(composerEditorLocked);
+  // Chromium moves focus to <body> when the ProseMirror root becomes
+  // contenteditable=false. Remember keyboard-owned focus so the temporary
+  // send lock can restore it without stealing focus from another control.
+  const pendingSendFocusRestoreRef = useRef<{
+    focusAnchor: Element | null;
+  } | null>(null);
   composerMutationLockedRef.current = composerEditorLocked;
 
   useEffect(() => {
@@ -2579,7 +2585,19 @@ export function ChatInput({
   composerMutationLockedRef.current = composerMutationLocked;
   useEffect(() => {
     editor?.setEditable(!composerMutationLocked);
-  }, [composerMutationLocked, editor]);
+    if (!editor || sendDispatchInFlight) return;
+
+    const pendingFocusRestore = pendingSendFocusRestoreRef.current;
+    if (!pendingFocusRestore) return;
+    pendingSendFocusRestoreRef.current = null;
+    if (composerMutationLocked) return;
+
+    window.requestAnimationFrame(() => {
+      if (editor.isDestroyed || !editor.isEditable || editor.isFocused) return;
+      if (hasFocusMovedToInteractiveElement(pendingFocusRestore.focusAnchor, editor)) return;
+      editor.commands.focus();
+    });
+  }, [composerMutationLocked, editor, sendDispatchInFlight]);
   const { settings: voiceInputSettings } = useVoiceInputSettings();
   const voiceInputShortcutLabel = useMemo(
     () => formatVoiceInputShortcut(voiceInputSettings.shortcut),
@@ -4234,7 +4252,12 @@ export function ChatInput({
       // Local/SSH sends keep the live composer while references and runtime
       // settings settle; remote sends must stay editable after their
       // click-time snapshot is cleared.
-      if (!optimisticallyClearRemoteComposer) setSendDispatchInFlight(true);
+      if (!optimisticallyClearRemoteComposer) {
+        pendingSendFocusRestoreRef.current = editor.isFocused
+          ? { focusAnchor: document.activeElement }
+          : null;
+        setSendDispatchInFlight(true);
+      }
       try {
         let serializedContent = serializedAtClick;
         if (!serializedContent) {

--- a/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ChatInput.tsx
@@ -47,6 +47,10 @@ import {
 import { WindowsSelectionReplacement } from './WindowsSelectionReplacement';
 import { EmptyDocSelectionGuard } from './EmptyDocSelectionGuard';
 import {
+  hasFocusMovedToInteractiveElement,
+  useComposerSendFocusRestore,
+} from './useComposerSendFocusRestore';
+import {
   setVoiceInputDraftDecoration,
   VoiceInputDraftDecoration,
   type VoiceInputCaretState,
@@ -191,7 +195,6 @@ import { composerDocIsEmpty } from './composerDocState';
 import { canUseLocalAttachmentPicker } from './localAttachmentPicker';
 import {
   isComposerBlankPointerTarget,
-  isInteractiveFocusedElement,
   resolveComposerBlankFocusIntent,
 } from './composerBlankPointerFocus';
 import {
@@ -742,20 +745,6 @@ function scrollVoiceInputDraftEndIntoView(editor: Editor): void {
   } else if (draftBox.bottom < scrollerBox.top + PAD) {
     scroller.scrollTop -= scrollerBox.top + PAD - draftBox.bottom;
   }
-}
-
-function hasFocusMovedToInteractiveElement(focusAnchor: Element | null, editor: Editor): boolean {
-  const activeElement = document.activeElement;
-  if (
-    !activeElement ||
-    activeElement === document.body ||
-    activeElement === document.documentElement
-  ) {
-    return false;
-  }
-  if (activeElement === focusAnchor) return false;
-  if (editor.view.dom.contains(activeElement)) return false;
-  return isInteractiveFocusedElement(activeElement);
 }
 
 /**
@@ -1651,12 +1640,6 @@ export function ChatInput({
   const [sendDispatchInFlight, setSendDispatchInFlight] = useState(false);
   const composerEditorLocked = disabled || sendDispatchInFlight;
   const composerMutationLockedRef = useRef(composerEditorLocked);
-  // Chromium moves focus to <body> when the ProseMirror root becomes
-  // contenteditable=false. Remember keyboard-owned focus so the temporary
-  // send lock can restore it without stealing focus from another control.
-  const pendingSendFocusRestoreRef = useRef<{
-    focusAnchor: Element | null;
-  } | null>(null);
   composerMutationLockedRef.current = composerEditorLocked;
 
   useEffect(() => {
@@ -2585,19 +2568,12 @@ export function ChatInput({
   composerMutationLockedRef.current = composerMutationLocked;
   useEffect(() => {
     editor?.setEditable(!composerMutationLocked);
-    if (!editor || sendDispatchInFlight) return;
-
-    const pendingFocusRestore = pendingSendFocusRestoreRef.current;
-    if (!pendingFocusRestore) return;
-    pendingSendFocusRestoreRef.current = null;
-    if (composerMutationLocked) return;
-
-    window.requestAnimationFrame(() => {
-      if (editor.isDestroyed || !editor.isEditable || editor.isFocused) return;
-      if (hasFocusMovedToInteractiveElement(pendingFocusRestore.focusAnchor, editor)) return;
-      editor.commands.focus();
-    });
-  }, [composerMutationLocked, editor, sendDispatchInFlight]);
+  }, [composerMutationLocked, editor]);
+  const captureSendFocusForRestore = useComposerSendFocusRestore(
+    editor,
+    composerMutationLocked,
+    sendDispatchInFlight,
+  );
   const { settings: voiceInputSettings } = useVoiceInputSettings();
   const voiceInputShortcutLabel = useMemo(
     () => formatVoiceInputShortcut(voiceInputSettings.shortcut),
@@ -3113,7 +3089,7 @@ export function ChatInput({
         window.requestAnimationFrame(() => {
           if (editor.isDestroyed || !editor.isEditable) return;
           if (latestStorageKeyRef.current !== storageKey) return;
-          if (hasFocusMovedToInteractiveElement(storageKeyFocusAnchor, editor)) return;
+          if (hasFocusMovedToInteractiveElement(storageKeyFocusAnchor, editor.view.dom)) return;
           editor.commands.focus('end');
         });
       }
@@ -3180,7 +3156,7 @@ export function ChatInput({
         if (!focusOnStorageKeyChangeRef.current) return;
         if (disableAutofocusRef.current || disabledRef.current) return;
         if (editor.isDestroyed || !editor.isEditable) return;
-        if (hasFocusMovedToInteractiveElement(storageKeyFocusAnchor, editor)) return;
+        if (hasFocusMovedToInteractiveElement(storageKeyFocusAnchor, editor.view.dom)) return;
         editor.commands.focus('end');
       });
     };
@@ -4253,9 +4229,7 @@ export function ChatInput({
       // settings settle; remote sends must stay editable after their
       // click-time snapshot is cleared.
       if (!optimisticallyClearRemoteComposer) {
-        pendingSendFocusRestoreRef.current = editor.isFocused
-          ? { focusAnchor: document.activeElement }
-          : null;
+        captureSendFocusForRestore();
         setSendDispatchInFlight(true);
       }
       try {
@@ -4832,6 +4806,7 @@ export function ChatInput({
       confirmDialog,
       navigate,
       planModeEntry,
+      captureSendFocusForRestore,
     ],
   );
   useEffect(() => {

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/useComposerSendFocusRestore.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/useComposerSendFocusRestore.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { useEffect } from 'react';
-import { act, renderHook } from '@testing-library/react';
+import { act, fireEvent, renderHook } from '@testing-library/react';
 import { Editor } from '@tiptap/core';
 import Document from '@tiptap/extension-document';
 import Paragraph from '@tiptap/extension-paragraph';
@@ -171,5 +171,37 @@ describe('useComposerSendFocusRestore', () => {
 
     expect(document.activeElement).toBe(document.body);
     expect(document.getSelection()?.toString()).toBe('select');
+  });
+
+  it('does not interrupt a message selection drag before the range expands', () => {
+    const editor = createEditor();
+    const message = document.createElement('p');
+    const messageText = document.createTextNode('start selecting here');
+    message.append(messageText);
+    document.body.prepend(message);
+    const hook = renderRestoreHook(editor);
+
+    focusComposerSelection(editor);
+    act(() => {
+      hook.result.current();
+    });
+    hook.rerender({ composerMutationLocked: true, sendDispatchInFlight: true });
+    act(() => {
+      editor.view.dom.blur();
+      const range = document.createRange();
+      range.setStart(messageText, 0);
+      range.collapse(true);
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+    fireEvent.pointerDown(message);
+
+    hook.rerender({ composerMutationLocked: false, sendDispatchInFlight: false });
+    flushAnimationFrames();
+
+    expect(document.activeElement).toBe(document.body);
+    expect(document.getSelection()?.isCollapsed).toBe(true);
+    expect(document.getSelection()?.anchorNode).toBe(messageText);
   });
 });

--- a/apps/desktop/src/renderer/components/new-chat/__tests__/useComposerSendFocusRestore.test.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/__tests__/useComposerSendFocusRestore.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+import { useEffect } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { Editor } from '@tiptap/core';
+import Document from '@tiptap/extension-document';
+import Paragraph from '@tiptap/extension-paragraph';
+import Text from '@tiptap/extension-text';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useComposerSendFocusRestore } from '../useComposerSendFocusRestore';
+
+interface HarnessProps {
+  composerMutationLocked: boolean;
+  sendDispatchInFlight: boolean;
+}
+
+let createdEditors: Editor[] = [];
+
+function createEditor(): Editor {
+  const mount = document.createElement('div');
+  document.body.append(mount);
+  const editor = new Editor({
+    element: mount,
+    extensions: [Document, Paragraph, Text],
+    content: '<p>next message</p>',
+    editorProps: { handleScrollToSelection: () => true },
+  });
+  createdEditors.push(editor);
+  return editor;
+}
+
+describe('useComposerSendFocusRestore', () => {
+  let nextFrameId = 1;
+  let frames = new Map<number, FrameRequestCallback>();
+
+  beforeEach(() => {
+    createdEditors = [];
+    frames = new Map();
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      const id = nextFrameId++;
+      frames.set(id, callback);
+      return id;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => {
+      frames.delete(id);
+    });
+  });
+
+  afterEach(() => {
+    for (const editor of createdEditors) editor.destroy();
+    document.getSelection()?.removeAllRanges();
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  const flushAnimationFrames = () => {
+    act(() => {
+      for (let round = 0; frames.size > 0 && round < 10; round += 1) {
+        const pendingFrames = [...frames.values()];
+        frames.clear();
+        for (const callback of pendingFrames) callback(0);
+      }
+    });
+  };
+
+  const renderRestoreHook = (editor: Editor) =>
+    renderHook(
+      ({ composerMutationLocked, sendDispatchInFlight }: HarnessProps) => {
+        useEffect(() => {
+          editor.setEditable(!composerMutationLocked);
+        }, [composerMutationLocked, editor]);
+        return useComposerSendFocusRestore(editor, composerMutationLocked, sendDispatchInFlight);
+      },
+      {
+        initialProps: { composerMutationLocked: false, sendDispatchInFlight: false },
+      },
+    );
+
+  const focusComposerSelection = (editor: Editor) => {
+    act(() => {
+      editor.commands.setTextSelection({ from: 2, to: 6 });
+      editor.view.focus();
+    });
+    expect(document.activeElement).toBe(editor.view.dom);
+  };
+
+  it('restores the focused composer after the temporary send lock', () => {
+    const editor = createEditor();
+    const hook = renderRestoreHook(editor);
+
+    focusComposerSelection(editor);
+    act(() => {
+      hook.result.current();
+    });
+    hook.rerender({ composerMutationLocked: true, sendDispatchInFlight: true });
+    act(() => editor.view.dom.blur());
+    expect(document.activeElement).toBe(document.body);
+
+    hook.rerender({ composerMutationLocked: false, sendDispatchInFlight: false });
+    flushAnimationFrames();
+
+    expect(document.activeElement).toBe(editor.view.dom);
+    expect(editor.state.selection.from).toBe(2);
+    expect(editor.state.selection.to).toBe(6);
+  });
+
+  it('keeps the restore intent until every composer lock is released', () => {
+    const editor = createEditor();
+    const hook = renderRestoreHook(editor);
+
+    focusComposerSelection(editor);
+    act(() => {
+      hook.result.current();
+    });
+    hook.rerender({ composerMutationLocked: true, sendDispatchInFlight: true });
+    act(() => editor.view.dom.blur());
+
+    // The send lock has settled, but voice input still owns the mutation lock.
+    hook.rerender({ composerMutationLocked: true, sendDispatchInFlight: false });
+    flushAnimationFrames();
+    expect(document.activeElement).toBe(document.body);
+
+    hook.rerender({ composerMutationLocked: false, sendDispatchInFlight: false });
+    flushAnimationFrames();
+    expect(document.activeElement).toBe(editor.view.dom);
+  });
+
+  it('does not steal focus from another interactive control', () => {
+    const editor = createEditor();
+    const button = document.createElement('button');
+    document.body.append(button);
+    const hook = renderRestoreHook(editor);
+
+    focusComposerSelection(editor);
+    act(() => {
+      hook.result.current();
+    });
+    hook.rerender({ composerMutationLocked: true, sendDispatchInFlight: true });
+    act(() => button.focus());
+    hook.rerender({ composerMutationLocked: false, sendDispatchInFlight: false });
+    flushAnimationFrames();
+
+    expect(document.activeElement).toBe(button);
+  });
+
+  it('preserves a non-collapsed message selection created during the send lock', () => {
+    const editor = createEditor();
+    const message = document.createElement('p');
+    const messageText = document.createTextNode('select this message');
+    message.append(messageText);
+    document.body.prepend(message);
+    const hook = renderRestoreHook(editor);
+
+    focusComposerSelection(editor);
+    act(() => {
+      hook.result.current();
+    });
+    hook.rerender({ composerMutationLocked: true, sendDispatchInFlight: true });
+    act(() => {
+      editor.view.dom.blur();
+      const range = document.createRange();
+      range.setStart(messageText, 0);
+      range.setEnd(messageText, 6);
+      const selection = document.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+
+    hook.rerender({ composerMutationLocked: false, sendDispatchInFlight: false });
+    flushAnimationFrames();
+
+    expect(document.activeElement).toBe(document.body);
+    expect(document.getSelection()?.toString()).toBe('select');
+  });
+});

--- a/apps/desktop/src/renderer/components/new-chat/useComposerSendFocusRestore.ts
+++ b/apps/desktop/src/renderer/components/new-chat/useComposerSendFocusRestore.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+import { isInteractiveFocusedElement } from './composerBlankPointerFocus';
+
+export interface ComposerFocusEditor {
+  readonly isDestroyed: boolean;
+  readonly isEditable: boolean;
+  readonly isFocused: boolean;
+  readonly view: { readonly dom: HTMLElement };
+  readonly commands: { focus: () => unknown };
+}
+
+interface PendingComposerFocusRestore {
+  readonly editor: ComposerFocusEditor;
+  readonly focusAnchor: Element | null;
+}
+
+export function hasFocusMovedToInteractiveElement(
+  focusAnchor: Element | null,
+  editorDom: HTMLElement,
+): boolean {
+  const activeElement = editorDom.ownerDocument.activeElement;
+  if (
+    !activeElement ||
+    activeElement === editorDom.ownerDocument.body ||
+    activeElement === editorDom.ownerDocument.documentElement
+  ) {
+    return false;
+  }
+  if (activeElement === focusAnchor) return false;
+  if (editorDom.contains(activeElement)) return false;
+  return isInteractiveFocusedElement(activeElement);
+}
+
+export function hasNonCollapsedSelectionOutsideComposer(editorDom: HTMLElement): boolean {
+  const selection = editorDom.ownerDocument.getSelection?.() ?? null;
+  if (!selection || selection.rangeCount === 0 || selection.isCollapsed) return false;
+  const { anchorNode, focusNode } = selection;
+  if (!anchorNode || !focusNode) return false;
+  return !editorDom.contains(anchorNode) || !editorDom.contains(focusNode);
+}
+
+export function useComposerSendFocusRestore(
+  editor: ComposerFocusEditor | null,
+  composerMutationLocked: boolean,
+  sendDispatchInFlight: boolean,
+): () => void {
+  const pendingRestoreRef = useRef<PendingComposerFocusRestore | null>(null);
+
+  useEffect(() => {
+    if (!editor || sendDispatchInFlight || composerMutationLocked) return;
+
+    const pendingRestore = pendingRestoreRef.current;
+    if (!pendingRestore) return;
+    if (pendingRestore.editor !== editor) {
+      pendingRestoreRef.current = null;
+      return;
+    }
+
+    const frame = window.requestAnimationFrame(() => {
+      if (pendingRestoreRef.current !== pendingRestore) return;
+      if (editor.isDestroyed) {
+        pendingRestoreRef.current = null;
+        return;
+      }
+      // A second lock can begin before this frame runs. Keep the pending intent
+      // so the next unlocked effect can try again instead of dropping it.
+      if (!editor.isEditable) return;
+      if (editor.isFocused) {
+        pendingRestoreRef.current = null;
+        return;
+      }
+      if (
+        hasFocusMovedToInteractiveElement(pendingRestore.focusAnchor, editor.view.dom) ||
+        hasNonCollapsedSelectionOutsideComposer(editor.view.dom)
+      ) {
+        pendingRestoreRef.current = null;
+        return;
+      }
+
+      pendingRestoreRef.current = null;
+      editor.commands.focus();
+    });
+
+    return () => window.cancelAnimationFrame(frame);
+  }, [composerMutationLocked, editor, sendDispatchInFlight]);
+
+  return useCallback(() => {
+    pendingRestoreRef.current =
+      editor && !editor.isDestroyed && editor.isFocused
+        ? { editor, focusAnchor: editor.view.dom.ownerDocument.activeElement }
+        : null;
+  }, [editor]);
+}

--- a/apps/desktop/src/renderer/components/new-chat/useComposerSendFocusRestore.ts
+++ b/apps/desktop/src/renderer/components/new-chat/useComposerSendFocusRestore.ts
@@ -48,6 +48,24 @@ export function useComposerSendFocusRestore(
   const pendingRestoreRef = useRef<PendingComposerFocusRestore | null>(null);
 
   useEffect(() => {
+    if (!editor) return;
+    const editorDom = editor.view.dom;
+    const ownerDocument = editorDom.ownerDocument;
+    const cancelRestoreForOutsidePointer = (event: PointerEvent) => {
+      const pendingRestore = pendingRestoreRef.current;
+      if (!pendingRestore || pendingRestore.editor !== editor) return;
+      const target = event.target;
+      if (target instanceof Node && editorDom.contains(target)) return;
+      pendingRestoreRef.current = null;
+    };
+
+    ownerDocument.addEventListener('pointerdown', cancelRestoreForOutsidePointer, true);
+    return () => {
+      ownerDocument.removeEventListener('pointerdown', cancelRestoreForOutsidePointer, true);
+    };
+  }, [editor]);
+
+  useEffect(() => {
     if (!editor || sendDispatchInFlight || composerMutationLocked) return;
 
     const pendingRestore = pendingRestoreRef.current;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 Desktop 聊天输入框在回车发送本地或 SSH 消息后失去焦点的问题。

发送流程会短暂把 ProseMirror 编辑器设为不可编辑，Chromium 因此把焦点移到页面；恢复可编辑时此前没有恢复焦点。本 PR 仅在发送前确实由输入框持有焦点时记录恢复意图，发送锁解除后恢复原有编辑器 selection；如果用户期间已把焦点移到其他交互控件，则不抢回焦点。Device Link 的乐观发送路径保持不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：用户反馈 Desktop 输入框回车发送后失焦
- 本 PR 包含：本地/SSH 发送锁解除后的条件式焦点恢复；对应回归测试
- 明确不包含：Device Link 乐观发送行为、编辑器视觉样式、发送流程重构
- 用户可见变化：回车发送后可以直接继续输入；若用户主动切到其他控件，焦点停留在该控件
- 是否存在 breaking change：无

### UI 变化

不涉及视觉、布局、颜色或文案变化；仅修正输入框交互焦点行为。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §14.2 Focus Management（焦点行为应可预测且不破坏用户主动焦点移动）与 §14.3 Keyboard & IME（聊天输入框 Enter 发送语义）。本改动不新增样式或颜色，Light / Dark 表现不受影响。

## 怎么验证的

### 自动验证

```text
bash /Users/dash/Code/XD/dash/Skills/git/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-fix-composer-send-focus
结果：通过（Desktop、Mobile、共享 packages 与 cindy-protocol unit workspaces 全部通过）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/components/new-chat/ChatInput.tsx src/renderer/__tests__/chatInputSessionFocus.test.ts
结果：通过
```

额外使用无头 Chromium 行为探针验证：键盘发送解除锁定后恢复输入框焦点；锁定期间若用户聚焦其他按钮，则按钮焦点不会被抢走。

### 手工验证

不涉及：未启动 Desktop dev 实例，也未进行 Desktop 实机视觉检查。

### 未执行的验证

未执行 Desktop 实机 Light / Dark 目检；本 PR 不改样式、颜色或布局。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 本地/SSH 聊天输入框的发送后焦点恢复
- 回滚 / 降级方式：回退本 PR 即恢复原行为；无数据迁移或持久化影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本修复无需额外文档）
- [x] 已确认测试结果或说明未执行原因
