### PR TITLE
fix(desktop): 折叠的计划预览恢复可选中,只把被裁控件移出 tab 序

### DIFF
--- a/apps/desktop/src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx
@@ -34,7 +34,15 @@ vi.mock('@/components/chat/MarkdownRenderer', () => ({
       data-session-title={currentSessionTitle ?? ''}
       data-file-refs={(localFileRefs ?? []).map((r) => r.name).join(',')}
     >
-      {content}
+      <span data-testid="markdown-content">{content}</span>
+      {/* 折叠用例要的两个可聚焦元素:一个完全在折叠视窗内,一个被裁到线下。
+          位置由 data-test-bottom 喂给下面 mock 的 getBoundingClientRect。 */}
+      <a href="https://example.com" data-testid="visible-link" data-test-bottom="40">
+        可见链接
+      </a>
+      <a href="https://example.com" data-testid="clipped-link" data-test-bottom="400">
+        被裁链接
+      </a>
     </div>
   ),
 }));
@@ -63,20 +71,47 @@ function collapsedBoxOf(markdown: HTMLElement): HTMLElement {
 }
 
 /**
- * 让 offsetHeight 返回一个超过折叠上限的值,逼出折叠分支。jsdom 不做布局,
- * offsetHeight 恒 0,否则永远测不到 overflowing=true 这一半。
+ * jsdom 不做布局:offsetHeight 恒 0、getBoundingClientRect 全返回 0,所以
+ * overflowing=true 与"元素是否被裁"两条分支都测不到。这里把两者一起打桩 ——
+ * 高度顶到超过折叠上限,矩形则按元素自带的 data-test-bottom 返回底边。
  */
 function withOverflowingContent(run: () => void) {
-  const original = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+  const savedHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
+  const savedRect = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'getBoundingClientRect',
+  );
+
   Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
     configurable: true,
     get: () => 9999,
   });
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value(this: HTMLElement) {
+      const bottom = Number(this.dataset.testBottom ?? 0);
+      return {
+        top: 0,
+        bottom,
+        left: 0,
+        right: 0,
+        width: 0,
+        height: bottom,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect;
+    },
+  });
+
   try {
     run();
   } finally {
-    if (original) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', original);
-    else delete (HTMLElement.prototype as unknown as Record<string, unknown>).offsetHeight;
+    const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
+    if (savedHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', savedHeight);
+    else delete proto.offsetHeight;
+    if (savedRect) Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', savedRect);
+    else delete proto.getBoundingClientRect;
   }
 }
 
@@ -92,7 +127,7 @@ describe('PlanReviewBubble 计划正文渲染', () => {
     );
 
     const markdown = screen.getByTestId('markdown');
-    expect(markdown.textContent).toBe(PLAN);
+    expect(screen.getByTestId('markdown-content').textContent).toBe(PLAN);
     expect(markdown.getAttribute('data-working-dir')).toBe('/tmp/repo');
     // 源码直出的 <pre> 不再出现。
     expect(container.querySelector('pre')).toBeNull();
@@ -128,17 +163,18 @@ describe('PlanReviewBubble 计划正文渲染', () => {
           currentSessionId="sess-42"
         />,
       );
-      expect(screen.getByTestId('markdown').textContent).toBe(PLAN);
+      expect(screen.getByTestId('markdown-content').textContent).toBe(PLAN);
       expect(screen.getByTestId('markdown').getAttribute('data-session-id')).toBe('sess-42');
       unmount();
     }
   });
 
-  it('内容没超过折叠高度时不折叠:不设 inert、不出展开按钮', () => {
+  it('内容没超过折叠高度时不折叠:不动 tab 序、不出展开按钮', () => {
     // jsdom 里 offsetHeight 恒 0,等价于"内容没超高"这一分支。
     render(<PlanReviewBubble message={planReviewMessage()} workingDir="/tmp/repo" />);
 
     expect(collapsedBoxOf(screen.getByTestId('markdown')).hasAttribute('inert')).toBe(false);
+    expect(screen.getByTestId('clipped-link').hasAttribute('tabindex')).toBe(false);
     expect(screen.queryByRole('button')).toBeNull();
   });
 
@@ -157,11 +193,13 @@ describe('PlanReviewBubble 计划正文渲染', () => {
     expect(screen.getByText('# 这是我原话里的井号')).toBeTruthy();
   });
 
-  // 回归护栏(PR #1083 review 第二轮):overflow-hidden + mask 只挡"看得见",
-  // 被裁掉的 Markdown 链接 / 文件 chip / 代码块按钮仍留在 tab 序与 a11y 树里 ——
-  // 键盘用户能激活看不见的控件,焦点进入还会滚动容器把折叠预览顶掉。
+  // 回归护栏。两条不变量必须同时成立,任何一半单独满足都是缺陷:
+  //   (a) 被裁掉的控件不可用键盘激活 —— overflow-hidden + mask 只挡"看得见",
+  //       否则键盘能聚焦一个隐形链接,焦点进入还会滚动容器把折叠预览顶掉;
+  //   (b) 可见的正文照常可选、可见控件照常可交互 —— DESIGN.md §14.1 要求消息
+  //       正文默认可选,所以不能靠整块 inert 去满足 (a)。
   describe('折叠态', () => {
-    it('三态被裁时都设 inert 且都给得出展开入口', () => {
+    it('三态都把被裁控件移出 tab 序、保留可见控件、并给得出展开入口', () => {
       for (const status of ['approved', 'expired', 'cancelled'] as const) {
         withOverflowingContent(() => {
           const { unmount } = render(
@@ -171,22 +209,29 @@ describe('PlanReviewBubble 计划正文渲染', () => {
             />,
           );
 
-          expect(collapsedBoxOf(screen.getByTestId('markdown')).hasAttribute('inert')).toBe(true);
-          expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('false');
+          expect(screen.getByTestId('clipped-link').getAttribute('tabindex')).toBe('-1');
+          expect(screen.getByTestId('visible-link').hasAttribute('tabindex')).toBe(false);
+          // 不整块 inert:inert 会连带禁掉预览文字的选中。
+          expect(collapsedBoxOf(screen.getByTestId('markdown')).hasAttribute('inert')).toBe(false);
+          expect(screen.getByRole('button', { name: /showFull/ }).getAttribute('aria-expanded'))
+            .toBe('false');
           unmount();
         });
       }
     });
 
-    it('展开后解除 inert,正文恢复可聚焦可选中', () => {
+    it('展开后把被裁控件还原回 tab 序', () => {
       withOverflowingContent(() => {
         render(<PlanReviewBubble message={planReviewMessage()} workingDir="/tmp/repo" />);
 
-        const toggle = screen.getByRole('button');
-        fireEvent.click(toggle);
+        expect(screen.getByTestId('clipped-link').getAttribute('tabindex')).toBe('-1');
 
-        expect(collapsedBoxOf(screen.getByTestId('markdown')).hasAttribute('inert')).toBe(false);
-        expect(screen.getByRole('button').getAttribute('aria-expanded')).toBe('true');
+        fireEvent.click(screen.getByRole('button', { name: /showFull/ }));
+
+        // 原本没有 tabindex 的元素要还原成"没有",不能留下 tabindex="0"。
+        expect(screen.getByTestId('clipped-link').hasAttribute('tabindex')).toBe(false);
+        expect(screen.getByRole('button', { name: /collapse/ }).getAttribute('aria-expanded'))
+          .toBe('true');
       });
     });
   });

--- a/apps/desktop/src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx
@@ -4,7 +4,7 @@
 // 回归背景:approved 态原本用 <pre> 打印 planReviewPlan,聊天记录里回看时满屏
 // `#` / `**` / 表格竖线,和底部 Plan Viewer Card 的排版观感完全脱节。
 
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('react-i18next', () => ({
@@ -75,7 +75,7 @@ function collapsedBoxOf(markdown: HTMLElement): HTMLElement {
  * overflowing=true 与"元素是否被裁"两条分支都测不到。这里把两者一起打桩 ——
  * 高度顶到超过折叠上限,矩形则按元素自带的 data-test-bottom 返回底边。
  */
-function withOverflowingContent(run: () => void) {
+function installLayoutStubs(): () => void {
   const savedHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight');
   const savedRect = Object.getOwnPropertyDescriptor(
     HTMLElement.prototype,
@@ -104,14 +104,30 @@ function withOverflowingContent(run: () => void) {
     },
   });
 
-  try {
-    run();
-  } finally {
+  return () => {
     const proto = HTMLElement.prototype as unknown as Record<string, unknown>;
     if (savedHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', savedHeight);
     else delete proto.offsetHeight;
     if (savedRect) Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', savedRect);
     else delete proto.getBoundingClientRect;
+  };
+}
+
+function withOverflowingContent(run: () => void) {
+  const restore = installLayoutStubs();
+  try {
+    run();
+  } finally {
+    restore();
+  }
+}
+
+async function withOverflowingContentAsync(run: () => Promise<void>) {
+  const restore = installLayoutStubs();
+  try {
+    await run();
+  } finally {
+    restore();
   }
 }
 
@@ -232,6 +248,38 @@ describe('PlanReviewBubble 计划正文渲染', () => {
         expect(screen.getByTestId('clipped-link').hasAttribute('tabindex')).toBe(false);
         expect(screen.getByRole('button', { name: /collapse/ }).getAttribute('aria-expanded'))
           .toBe('true');
+      });
+    });
+
+    // 回归护栏(PR #2274 review):MarkdownRenderer 的 useResolvedMarkdownTarget
+    // 会在初次布局之后把本地路径异步解析成带 tabIndex={0} 的 FileTargetChip。
+    // 这种行内替换可能一点尺寸都不改 —— 于是 effect 依赖没变、ResizeObserver
+    // 也不响,新 chip 会绕过同步继续留在 tab 序里。靠 MutationObserver 兜住。
+    it('延迟出现的可聚焦控件也按位置同步(被裁的摘掉、可见的不动)', async () => {
+      await withOverflowingContentAsync(async () => {
+        render(<PlanReviewBubble message={planReviewMessage()} workingDir="/tmp/repo" />);
+
+        const body = screen.getByTestId('markdown');
+        // 模拟异步解析就绪:往子树里插入两个 chip,一个在裁剪线下、一个在线上。
+        const lateClipped = document.createElement('span');
+        lateClipped.setAttribute('role', 'button');
+        lateClipped.setAttribute('tabindex', '0');
+        lateClipped.dataset.testid = 'late-clipped-chip';
+        lateClipped.dataset.testBottom = '500';
+
+        const lateVisible = document.createElement('span');
+        lateVisible.setAttribute('role', 'button');
+        lateVisible.setAttribute('tabindex', '0');
+        lateVisible.dataset.testid = 'late-visible-chip';
+        lateVisible.dataset.testBottom = '30';
+
+        body.append(lateClipped, lateVisible);
+
+        await waitFor(() => {
+          expect(lateClipped.getAttribute('tabindex')).toBe('-1');
+        });
+        // 线上的 chip 必须保持可聚焦 —— 它是用户看得见、点得到的控件。
+        expect(lateVisible.getAttribute('tabindex')).toBe('0');
       });
     });
   });

--- a/apps/desktop/src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx
@@ -259,7 +259,7 @@ describe('PlanReviewBubble 计划正文渲染', () => {
       await withOverflowingContentAsync(async () => {
         render(<PlanReviewBubble message={planReviewMessage()} workingDir="/tmp/repo" />);
 
-        const body = screen.getByTestId('markdown');
+        const body: HTMLElement = screen.getByTestId('markdown');
         // 模拟异步解析就绪:往子树里插入两个 chip,一个在裁剪线下、一个在线上。
         const lateClipped = document.createElement('span');
         lateClipped.setAttribute('role', 'button');
@@ -280,6 +280,30 @@ describe('PlanReviewBubble 计划正文渲染', () => {
         });
         // 线上的 chip 必须保持可聚焦 —— 它是用户看得见、点得到的控件。
         expect(lateVisible.getAttribute('tabindex')).toBe('0');
+      });
+    });
+
+    // 回归护栏(PR #2274 review):overflow-hidden 只挡手动滚动。计划里指向折叠线
+    // 下标题的内部锚点会调 scrollIntoView() 把预览卷到下半段 —— 既露出本该藏起来
+    // 的内容,也让"可见"与 tab 序错位。折叠态遇到程序化滚动应当直接展开。
+    it('折叠态被程序化滚动(内部锚点 scrollIntoView)时自动展开并还原 tab 序', () => {
+      withOverflowingContent(() => {
+        render(<PlanReviewBubble message={planReviewMessage()} workingDir="/tmp/repo" />);
+
+        expect(screen.getByRole('button', { name: /showFull/ }).getAttribute('aria-expanded'))
+          .toBe('false');
+        expect(screen.getByTestId('clipped-link').getAttribute('tabindex')).toBe('-1');
+
+        const box = collapsedBoxOf(screen.getByTestId('markdown'));
+        box.scrollTop = 200;
+        fireEvent.scroll(box);
+
+        // 展开:折叠预览不再把内容卷在窗口里。
+        expect(screen.getByRole('button', { name: /collapse/ }).getAttribute('aria-expanded'))
+          .toBe('true');
+        // 卷走导致的可见性变化不会留下错位的 tab 序 —— 展开后全部还原。
+        expect(screen.getByTestId('clipped-link').hasAttribute('tabindex')).toBe(false);
+        expect(box.scrollTop).toBe(0);
       });
     });
   });

--- a/apps/desktop/src/renderer/components/chat/PlanReviewBubble.tsx
+++ b/apps/desktop/src/renderer/components/chat/PlanReviewBubble.tsx
@@ -76,6 +76,46 @@ const INACTIVE_COLLAPSED_MAX_HEIGHT = 56;
 const COLLAPSED_FADE_MASK =
   'linear-gradient(to bottom, black calc(100% - 28px), transparent 100%)';
 
+/** 折叠时要从 tab 序里摘掉的元素(MarkdownRenderer 会产出链接、文件 chip、
+ *  代码块复制按钮、媒体控件,其中 chip 靠 tabIndex={0} 参与键盘导航)。 */
+const FOCUSABLE_SELECTOR =
+  'a[href], button, input, select, textarea, summary, audio[controls], video[controls], [tabindex], [contenteditable="true"]';
+
+/** 暂存被改动前的 tabindex 原值,空串表示"原本没有这个属性"。属性跟着节点走,
+ *  React 重渲染换了节点也不会把还原值串到别的元素上。 */
+const SAVED_TABINDEX_ATTR = 'data-plan-collapse-tabindex';
+
+/**
+ * 把 root 内"底边超过 cutoff"的可聚焦元素移出 tab 序;cutoff 为 null(未折叠)
+ * 时全部还原。
+ *
+ * 判据用底边而不是顶边:跨在裁剪线上的控件只露出一半,聚焦它同样会把
+ * overflow-hidden 容器滚起来,所以按"不完全可见"处理。只改 tabindex、不加
+ * aria-hidden —— 读屏用户没有"折叠"这个视觉概念,把内容从 a11y 树里摘掉是净
+ * 损失;避免"激活看不见的控件"只需要它进不了 tab 序。
+ */
+function syncClippedFocusability(root: HTMLElement, cutoff: number | null): void {
+  const rootTop = root.getBoundingClientRect().top;
+  root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR).forEach((el) => {
+    const saved = el.getAttribute(SAVED_TABINDEX_ATTR);
+    const clipped =
+      cutoff != null && el.getBoundingClientRect().bottom - rootTop > cutoff;
+
+    if (clipped) {
+      if (saved == null) {
+        el.setAttribute(SAVED_TABINDEX_ATTR, el.getAttribute('tabindex') ?? '');
+      }
+      el.setAttribute('tabindex', '-1');
+      return;
+    }
+
+    if (saved == null) return;
+    if (saved === '') el.removeAttribute('tabindex');
+    else el.setAttribute('tabindex', saved);
+    el.removeAttribute(SAVED_TABINDEX_ATTR);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -203,9 +243,13 @@ export function PlanReviewBubble({
  * 行高与外边距差得很远,行数和视觉高度没有稳定关系,而"能否展开"必须和用户
  * 真正看到的有没有被切掉一致 —— 否则会出现按钮点了没变化(或该给按钮时没给)。
  *
- * 折叠态整块 inert(见下方注释):裁掉的部分只是视觉上不见了,DOM 里仍在 tab 序
- * 与 a11y 树里。所以任何会被裁的状态都必须给得出展开入口 —— 三态共用同一个
- * 折叠+展开机制,只有折叠高度不同。
+ * 折叠只裁"看得见",所以被裁掉的链接 / 文件 chip / 代码块按钮仍留在 tab 序里:
+ * 键盘能聚焦并激活一个看不见的控件,而且焦点一进去浏览器就会滚动这个
+ * overflow-hidden 容器,把折叠预览顶掉。修法是**只**把不完全可见的可聚焦元素
+ * 移出 tab 序(syncClippedFocusability),不整块 inert —— inert 会连带禁掉预览
+ * 文字的选中,而 DESIGN.md §14.1 要求消息正文默认可选。可见控件因此照常能点,
+ * 被裁内容对读屏仍可读(只是 tab 不到),任何会被裁的状态都给得出展开入口 ——
+ * 三态共用同一个折叠 + 展开机制,只有折叠高度不同。
  */
 function PlanMarkdownBody({
   workingDir,
@@ -230,19 +274,23 @@ function PlanMarkdownBody({
   const bodyRef = useRef<HTMLDivElement>(null);
 
   // useLayoutEffect:首帧就在 paint 前定下折叠与否,否则长计划会先整段铺开
-  // 再收起,滚动位置和卡片高度跳一下。
+  // 再收起,滚动位置和卡片高度跳一下。tab 序同步也放这里 —— 它依赖布局,必须
+  // 在同一时机跟着高度一起算,并由 ResizeObserver 在图片加载 / 字体就位 /
+  // 窗口改宽导致回流后重算。
   useLayoutEffect(() => {
     const el = bodyRef.current;
     if (!el) return;
-    const measure = () => {
-      setOverflowing(el.offsetHeight > collapsedMaxHeight + 1);
+    const sync = () => {
+      const tooTall = el.offsetHeight > collapsedMaxHeight + 1;
+      setOverflowing(tooTall);
+      syncClippedFocusability(el, tooTall && !expanded ? collapsedMaxHeight : null);
     };
-    measure();
+    sync();
     if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(measure);
+    const observer = new ResizeObserver(sync);
     observer.observe(el);
     return () => observer.disconnect();
-  }, [collapsedMaxHeight, plan]);
+  }, [collapsedMaxHeight, plan, expanded]);
 
   const collapsed = !expanded && overflowing;
 
@@ -250,15 +298,6 @@ function PlanMarkdownBody({
     <div className="flex flex-col gap-[8px]">
       <div
         className={cn('min-w-0', collapsed && 'overflow-hidden')}
-        // 折叠态整块 inert。overflow-hidden 与 mask 只挡住"看得见",被裁掉的
-        // Markdown 链接、文件 chip、代码块按钮仍留在 tab 序与 a11y 树里:键盘
-        // 用户能聚焦并激活一个看不见的控件,而且焦点一进去浏览器就会滚动这个
-        // overflow-hidden 容器,把折叠预览顶掉、露出本该藏起来的下半部分。
-        // inert 一次解决聚焦、点击和 a11y 三条路径,唯一入口收敛到下方的展开
-        // 按钮(它在本容器之外,不受影响)。
-        // 代价:inert 子树内的文字不能选中,所以折叠预览无法复制 —— 这也是三态
-        // 都必须给展开按钮的原因,展开后完整可选可交互。
-        inert={collapsed}
         style={
           collapsed
             ? ({

--- a/apps/desktop/src/renderer/components/chat/PlanReviewBubble.tsx
+++ b/apps/desktop/src/renderer/components/chat/PlanReviewBubble.tsx
@@ -86,6 +86,20 @@ const FOCUSABLE_SELECTOR =
 const SAVED_TABINDEX_ATTR = 'data-plan-collapse-tabindex';
 
 /**
+ * 监听会新增 / 改变可聚焦节点的子树变动。
+ * - childList + subtree:异步解析把纯文本换成 FileTargetChip 这类节点替换;
+ * - tabindex / href:原地把一个普通节点变成可聚焦节点(FOCUSABLE_SELECTOR 就靠
+ *   这两个属性判定 `[tabindex]` 与 `a[href]`)。
+ * 刻意不监听 SAVED_TABINDEX_ATTR —— 那是本组件自己的记账属性。
+ */
+const FOCUSABILITY_OBSERVE_OPTIONS: MutationObserverInit = {
+  childList: true,
+  subtree: true,
+  attributes: true,
+  attributeFilter: ['tabindex', 'href'],
+};
+
+/**
  * 把 root 内"底边超过 cutoff"的可聚焦元素移出 tab 序;cutoff 为 null(未折叠)
  * 时全部还原。
  *
@@ -275,21 +289,46 @@ function PlanMarkdownBody({
 
   // useLayoutEffect:首帧就在 paint 前定下折叠与否,否则长计划会先整段铺开
   // 再收起,滚动位置和卡片高度跳一下。tab 序同步也放这里 —— 它依赖布局,必须
-  // 在同一时机跟着高度一起算,并由 ResizeObserver 在图片加载 / 字体就位 /
-  // 窗口改宽导致回流后重算。
+  // 在同一时机跟着高度一起算。
+  //
+  // 三个重算触发源,缺一个就会漏掉一类"隐形可聚焦元素":
+  //   - effect 依赖(plan / expanded / 折叠高度):内容或折叠状态本身变了;
+  //   - ResizeObserver:图片加载、字体就位、窗口改宽导致回流,裁剪线两侧的
+  //     元素易主;
+  //   - MutationObserver:**尺寸不变的子树替换**。MarkdownRenderer 的
+  //     useResolvedMarkdownTarget 会在初次布局之后把本地路径异步解析成带
+  //     tabIndex={0} 的 FileTargetChip,这种行内替换可能一点尺寸都不改 ——
+  //     那么前两个触发源都不响,新 chip 就绕过同步、继续留在 tab 序里。
   useLayoutEffect(() => {
     const el = bodyRef.current;
     if (!el) return;
+
+    let mutationObserver: MutationObserver | null = null;
+
     const sync = () => {
       const tooTall = el.offsetHeight > collapsedMaxHeight + 1;
       setOverflowing(tooTall);
+      // 本函数自己就会改 tabindex,而 tabindex 也在 MutationObserver 的监听项里。
+      // 改之前断开:disconnect() 会连带清空已排队的记录,所以自己造成的变动不会
+      // 再回调进来,不存在自触发循环。
+      mutationObserver?.disconnect();
       syncClippedFocusability(el, tooTall && !expanded ? collapsedMaxHeight : null);
+      mutationObserver?.observe(el, FOCUSABILITY_OBSERVE_OPTIONS);
     };
+
+    if (typeof MutationObserver !== 'undefined') {
+      mutationObserver = new MutationObserver(sync);
+    }
     sync();
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(sync);
-    observer.observe(el);
-    return () => observer.disconnect();
+
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(sync) : null;
+    resizeObserver?.observe(el);
+
+    return () => {
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+    };
   }, [collapsedMaxHeight, plan, expanded]);
 
   const collapsed = !expanded && overflowing;

--- a/apps/desktop/src/renderer/components/chat/PlanReviewBubble.tsx
+++ b/apps/desktop/src/renderer/components/chat/PlanReviewBubble.tsx
@@ -257,13 +257,32 @@ export function PlanReviewBubble({
  * 行高与外边距差得很远,行数和视觉高度没有稳定关系,而"能否展开"必须和用户
  * 真正看到的有没有被切掉一致 —— 否则会出现按钮点了没变化(或该给按钮时没给)。
  *
- * 折叠只裁"看得见",所以被裁掉的链接 / 文件 chip / 代码块按钮仍留在 tab 序里:
- * 键盘能聚焦并激活一个看不见的控件,而且焦点一进去浏览器就会滚动这个
- * overflow-hidden 容器,把折叠预览顶掉。修法是**只**把不完全可见的可聚焦元素
- * 移出 tab 序(syncClippedFocusability),不整块 inert —— inert 会连带禁掉预览
- * 文字的选中,而 DESIGN.md §14.1 要求消息正文默认可选。可见控件因此照常能点,
- * 被裁内容对读屏仍可读(只是 tab 不到),任何会被裁的状态都给得出展开入口 ——
- * 三态共用同一个折叠 + 展开机制,只有折叠高度不同。
+ * ## 不变量(折叠态的唯一约束)
+ *
+ * **用户看得见的内容 == 能被键盘聚焦 / 激活的内容。**
+ *
+ * 只用 `overflow-hidden` + mask 满足不了它:那两者只挡"看得见",被裁掉的链接 /
+ * 文件 chip / 代码块按钮仍留在 tab 序里,键盘能聚焦并激活一个隐形控件,焦点一
+ * 进去浏览器还会滚动这个容器把预览顶掉。反过来,整块 `inert` 又管得太宽,会连
+ * 带禁掉可见正文的选中(DESIGN.md §14.1 要求消息正文默认可选)、可见控件的点击、
+ * find-in-page 与读屏。所以判据只有一个 —— `syncClippedFocusability()` 按渲染
+ * 后的位置逐个摘 tabindex,可见部分一律不碰。
+ *
+ * ## 会打破它的全部路径(逐条都要有对应机制)
+ *
+ * 1. 内容或折叠状态本身变了 → effect 依赖(`plan` / `expanded` / 折叠高度);
+ * 2. 回流让裁剪线两侧易主(图片加载、字体就位、窗口改宽)→ `ResizeObserver`;
+ * 3. **尺寸不变**的子树替换(`useResolvedMarkdownTarget` 异步把纯文本换成带
+ *    `tabIndex={0}` 的 `FileTargetChip`)→ `MutationObserver`;
+ * 4. **容器被程序化滚动**(计划里指向折叠线下标题的内部锚点走
+ *    `MarkdownRenderer` 的 anchor 分支调 `scrollIntoView()`;`overflow-hidden`
+ *    容器照样能被程序化滚动)→ 折叠态的 `onScroll` 直接展开。
+ *
+ * 第 5 条"焦点进入被裁元素导致滚动"不需要单独机制:1–4 保证被裁元素永远不在
+ * tab 序里,它就不可能拿到焦点。
+ *
+ * 任何会被裁的状态都必须给得出展开入口 —— 三态共用同一个折叠 + 展开机制,只有
+ * 折叠高度不同。
  */
 function PlanMarkdownBody({
   workingDir,
@@ -337,6 +356,21 @@ function PlanMarkdownBody({
     <div className="flex flex-col gap-[8px]">
       <div
         className={cn('min-w-0', collapsed && 'overflow-hidden')}
+        // 路径 4(见上方不变量注释):overflow-hidden 只挡用户手动滚动,程序化滚动
+        // 照样生效 —— 计划开头指向折叠线下标题的内部锚点会调 scrollIntoView(),
+        // 把预览直接卷到下半段:既显示了本该藏起来的内容,也让"可见"与 tab 序
+        // 错位(卷走的可聚焦元素还在序里、新露出的仍是 -1)。既然有东西要跳到下面,
+        // 就直接展开;先把已经卷走的位置退回去,避免展开前闪一下下半段。展开后
+        // effect 依赖变化会重跑 sync,状态自然回到一致。
+        // 鼠标滚轮不会走到这里:overflow-hidden 容器不响应 wheel。
+        onScroll={
+          collapsed
+            ? (event) => {
+                event.currentTarget.scrollTop = 0;
+                setExpanded(true);
+              }
+            : undefined
+        }
         style={
           collapsed
             ? ({


### PR DESCRIPTION
## 这次改了什么

### 摘要

#1083 的 follow-up。

聊天记录里的「计划审阅」卡片，计划太长时只露开头一小段、其余折叠。折叠只是**视觉上**盖住下半部分，被盖住的链接和文件 chip 其实还在 DOM 里 —— 用键盘 Tab 能跳到一个看不见的链接上并按回车打开它。#1083 最后一版为了堵这个洞，给整个限高容器加了 `inert`。

洞是堵住了，但 `inert` 是**整棵子树**的行为开关，把露在外面那半截预览一起废掉了，四个后果都能被用户感知：

1. **可见正文无法选中 / 复制** —— 与 `docs/design-rules/DESIGN.md` §14.1「message body text ... Selectable by default」冲突。仓库全局 CSS 的 `.select-text *{user-select:text}`（`MarkdownRenderer` 根节点带 `select-text`）救不回来：`inert` 的"禁止选择"是行为层规定（MDN: *"Disallow users from selecting text contained within their content"*），不是可被 author CSS 覆盖的样式。
2. **可见的链接 / 文件 chip 点不动** —— *"Do not have click events fired when clicked on."* 计划正文里常有文件路径链接，折叠预览里看得见却按不动。这一条不依赖上面那个"CSS 能否覆盖"的判断，是确定的功能缺陷。
3. **折叠内容无法被浏览器 find-in-page 命中** —— *"Are not searchable via browser find-in-page features."*
4. **折叠内容被移出 a11y 树**，读屏用户读不到 —— 而视觉裁剪本不该影响读屏。

改成精确处理：**只**把"底边超过折叠上限"的可聚焦元素改成 `tabindex="-1"`，展开时按暂存的原值还原。原始目的（被裁控件不可用键盘激活）照旧达成，上面四条都不再发生。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无。#1083 review 里 Codex 提的第三条 P1（[discussion_r3682973941](https://github.com/makecindy/cindy/pull/1083#discussion_r3682973941) 的后续条目），该 thread 被 auto-review 流程用一条与内容无关的通用回复 resolve 掉，随 `96c299d5` 合入 main，问题未实质处理。
- 本 PR 包含：
  - `PlanReviewBubble` 折叠态去掉整块 `inert`，改为 `syncClippedFocusability()` 只摘不完全可见的可聚焦元素
  - review 过程中补齐了另外两条会打破同一不变量的路径（见下方「折叠态不变量」）：尺寸不变的异步子树替换、容器被程序化滚动
  - 测试覆盖到每条路径，并逐条做过反向验证（临时摘掉对应机制时只有该用例失败）

**折叠态不变量**（收敛检查点产物，给后续 reviewer 当锚点；同一份清单已写进 `PlanMarkdownBody` 的文档注释）：

> **用户看得见的内容 == 能被键盘聚焦 / 激活的内容。**
>
> 只用 `overflow-hidden` + mask 满足不了它（那两者只挡"看得见"）；整块 `inert` 又管得太宽（连带禁掉可见正文的选中、可见控件的点击、find-in-page 与读屏，违反 §14.1）。所以判据只有一个：`syncClippedFocusability()` 按渲染后的位置逐个摘 `tabindex`，可见部分一律不碰。
>
> 会打破它的**全部**路径，逐条都有对应机制与回归用例：
>
> | # | 路径 | 机制 |
> |---|---|---|
> | 1 | 内容或折叠状态本身变了 | effect 依赖（`plan` / `expanded` / 折叠高度） |
> | 2 | 回流让裁剪线两侧易主（图片加载、字体就位、窗口改宽） | `ResizeObserver` |
> | 3 | **尺寸不变**的子树替换（`useResolvedMarkdownTarget` 异步把纯文本换成带 `tabIndex={0}` 的 `FileTargetChip`） | `MutationObserver`（`childList + subtree` + `tabindex` / `href`；改 `tabindex` 前 `disconnect()` 防自触发） |
> | 4 | **容器被程序化滚动**（内部锚点走 anchor 分支调 `scrollIntoView()`，`overflow-hidden` 照样能被程序化滚动） | 折叠态 `onScroll` → 归零 + 展开 |
>
> 第 5 条「焦点进入被裁元素导致滚动」不需要单独机制：1–4 保证被裁元素永远不在 tab 序里，它拿不到焦点。
- 明确不包含：
  - 折叠机制本身（高度判定 120 / 56、`mask-image` 淡出、三态共用展开入口）不动，#1083 那部分是对的
  - `PlanViewerCard`（底部实时审阅卡）只传 `workingDir`、远程会话里计划内媒体会坏图 —— 这是 #1083 之前就有的既有缺口，不是本次引入，要改另一条 props 链（`CCAgentSessionView` / `InteractionPromptHost`），按"一个 PR 只做一件事"单独处理
- 用户可见变化：折叠的计划预览恢复可选中 / 可复制，露在外面的链接和文件 chip 恢复可点击，这段内容重新能被页面内查找命中、也重新对读屏可读。被折叠藏起来的控件仍然按不到（Tab 跳不过去），与 #1083 的意图一致。另外：折叠预览里点到指向下半段的内部锚点时，现在会自动展开再跳转，而不是把预览卷走。
- 是否存在 breaking change：无

### UI 变化

未附截图：截图 / 录屏属对外可见材料，按个人工作流需 Dash 确认后才上传，这里改用文字说明。视觉上**没有任何变化** —— 折叠高度、淡出遮罩、展开按钮全部照旧；变的只是折叠预览的可选中 / 可点击 / 可查找 / 可读屏这几项非视觉交互行为。

- 引用的设计规范：
  - `DESIGN.md` §14.1「Text Selectability (user-select)」——「**Content is selectable**: message body text, code blocks, document previews ... Selectable by default; leave it alone.」计划正文属于 message body，折叠预览里可见的部分是可读内容而非 chrome，因此必须可选。本 PR 正是把 #1083 无意破坏的这一条恢复回来；`select-none` 仍只留在 badge / 状态短语这些 UI chrome 上（未改动）。
  - `DESIGN.md` §14「Interaction Conventions」引言的口径——"pins those **non-visual interaction behaviors** as global conventions ... Whatever code can guarantee uniformly should not rely on human memory"。本 PR 把「哪些控件可 Tab」交给一个按布局计算的函数，把打破不变量的四条路径逐条用单测锁死，而不是靠人记住"折叠里还藏着控件"。
  - `DESIGN.md` §14.2「Focus Management」——不涉及：本 PR 不改焦点落点或关闭后的焦点返回，只改被裁元素的 tab 可达性。
  - `DESIGN.md` §10「Light / Dark 双模式交付门槛」——不涉及新增视觉：本 PR 未新增或修改任何颜色、圆角、间距、字号，也没有新增状态样式；`inert` 属性的移除不带任何色值。折叠淡出仍走 `mask-image`（alpha 载体，与主题无关）。

**与仓库既有做法的关系**：`components/ui/morph-popover.tsx` 用 `panel.inert = true` 处理收合余辉是合适的 —— 那整块面板本来就不该被读、被选；而计划预览露在外面的部分是**正文**，性质不同，所以这里不能照搬 `inert`。

## 怎么验证的

### 自动验证

```text
bash <git skill>/scripts/run-unit-gate.sh /Users/dash/Code/Cindy/cindy-plan-preview-selectable
结果：GATE_EXIT=0，0 failed，PASS apps/desktop unit（仓库根 pnpm test:unit 全量，跑在 rebase 后的基线 2d42f44f）

npx vitest run src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx --pool=threads
结果：10 tests passed（含三条路径各自的回归用例）

NODE_OPTIONS="--max-old-space-size=12288" npx tsc --noEmit -p tsconfig.json
结果：通过（见下方说明：默认 heap 会 OOM）

npx eslint src/renderer/components/chat/PlanReviewBubble.tsx \
  src/renderer/__tests__/planReviewBubbleMarkdown.test.tsx
结果：无告警

pnpm check:i18n-glossary
结果：通过（本 PR 未新增 UI 文案）

pnpm check:dco
结果：3 commits signed off
```

测试补充说明：jsdom 不做布局（`offsetHeight` 恒 0、`getBoundingClientRect` 全返回 0），所以"内容是否超高"与"某个元素是否被裁"两条分支原本都测不到。用例把这两者一起打桩 —— 高度顶到超过折叠上限，矩形按元素自带的 `data-test-bottom` 返回底边 —— 才能覆盖折叠那一半。路径 3 用「渲染后往子树插入带 `tabIndex={0}` 的节点」模拟异步解析就绪，路径 4 用「派发 scroll」模拟 `scrollIntoView()`。

每条路径的用例都做过**反向验证**：临时摘掉对应机制（`MutationObserver` / `onScroll`）时，只有该条用例失败、其余全过 —— 确认它们锁的是真缺口，不是恰好被别的触发源带过。

### 手工验证

不涉及：本次未起 dev 实例实机查看（见下）。

### 未执行的验证

- **未实机目检**：没有起 dev 实例逐一验证「折叠预览能选中文字」「可见链接能点」「Tab 跳不到被裁链接」「点内部锚点会自动展开」。本 PR 的判断依据是 `inert` 的规范行为（MDN 明确列出禁止选择 / 不触发 click / 不可 find-in-page / 移出 a11y 树四条）与单测覆盖，而不是实机观察。
- **Light / Dark 未逐模式目检**：本 PR 不新增或修改任何颜色与视觉样式，但按仓库口径不把"没动颜色"上升为"双模式已验证"。
- 未跑 `pnpm test:all`：改动局限于桌面 renderer 单个展示组件，无跨模块、协议或数据层影响，以全量 `test:unit` + `typecheck` 收口，其余交 CI。
- **一个与本 PR 无关但值得记录的环境事实**：`apps/desktop` 的 `tsc --noEmit` 在当前 main 基线上用默认 4GB heap 会 OOM（`Ineffective mark-compacts near heap limit`），需要 `--max-old-space-size` 提高上限才能跑完。这不是本次改动引起的（本 PR 只动两个文件），但本地跑 typecheck 的人和 CI 都可能撞上，先在此登记。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅桌面聊天流里 `plan_review` 消息折叠预览的非视觉交互行为。纯展示层，不触碰 `planReviewPlan` 的存储、审批链路或 agent 侧协议；`tabindex` 的改动只发生在本气泡自己的子树内，用 `data-plan-collapse-tabindex` 暂存原值，还原是幂等的。新增的 `MutationObserver` 与 `onScroll` 同样只作用于本气泡：observer 在改 `tabindex` 前 `disconnect()`，不存在自触发循环；`onScroll` 只在折叠态挂载，且 `overflow-hidden` 不响应滚轮，所以只有程序化滚动才会触发展开。
- 回滚 / 降级方式：revert 本 PR 的三个 commit 即可（只动 `PlanReviewBubble.tsx` + 测试），无数据迁移、无持久化格式变化。回滚后会退回 #1083 的 `inert` 行为（即上文四条后果重现）。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（组件内注释写清了为什么不用 `inert`、为什么判据取底边、为什么不加 `aria-hidden`；无需改 docs/）
- [x] 已确认测试结果或说明未执行原因

