### PR TITLE
fix(anthropic-bridge): replay collab agent messages

### DIFF
--- a/packages/responses-anthropic-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/responses-anthropic-bridge/src/__tests__/translate-request.test.ts
@@ -56,6 +56,104 @@ describe('Responses → Anthropic request translation', () => {
     })).toThrowError('instructions[0].input_image');
   });
 
+  it('replays collab agent messages as Anthropic assistant text', () => {
+    const result = translateResponsesRequest({
+      model: 'claude',
+      input: [
+        { role: 'user', content: 'delegate this' },
+        {
+          type: 'agent_message',
+          author: '/root/\r\n researcher',
+          content: [
+            { type: 'input_text', text: 'first finding' },
+            { type: 'encrypted_content', data: 'provider-secret' },
+            { type: 'output_text', text: 'second finding' },
+          ],
+        },
+        {
+          role: 'user',
+          content: [{ type: 'input_image', image_url: 'data:image/png;base64,abc' }],
+        },
+      ],
+    });
+
+    expect(result.request.messages[1]).toEqual({
+      role: 'assistant',
+      content: [{
+        type: 'text',
+        text: '[collab /root/ researcher]\nfirst finding\nsecond finding',
+      }],
+    });
+    expect(result.request.messages[2].content).toEqual([{
+      type: 'image',
+      source: { type: 'base64', media_type: 'image/png', data: 'abc' },
+    }]);
+    expect(JSON.stringify(result.request)).not.toContain('agent_message');
+    expect(JSON.stringify(result.request)).not.toContain('encrypted_content');
+    expect(JSON.stringify(result.request)).not.toContain('provider-secret');
+  });
+
+  it('keeps collab string, empty, and encrypted-only history distinguishable', () => {
+    const result = translateResponsesRequest({
+      model: 'claude',
+      input: [
+        { role: 'user', content: 'delegate this' },
+        { type: 'agent_message', content: 'plain result' },
+        { type: 'agent_message', author: '', content: [] },
+        {
+          type: 'agent_message',
+          author: 'worker',
+          content: [{ type: 'encrypted_content', data: 'opaque' }],
+        },
+        { role: 'user', content: 'continue' },
+      ],
+    });
+
+    expect(result.request.messages[1].content).toEqual([
+      { type: 'text', text: '[collab agent]\nplain result' },
+      { type: 'text', text: '[collab message from agent; empty content]' },
+      { type: 'text', text: '[collab message from worker; encrypted payload omitted]' },
+    ]);
+  });
+
+  it('rejects malformed collab content with its input path', () => {
+    expect(() => translateResponsesRequest({
+      model: 'claude',
+      input: [{ type: 'agent_message', content: [{ type: 'image_url' }] }],
+    })).toThrowError('input[0].content.image_url');
+
+    expect(() => translateResponsesRequest({
+      model: 'claude',
+      input: [{ type: 'agent_message', content: [{ type: 'text' }] }],
+    })).toThrowError('input[0].content.text');
+
+    expect(() => translateResponsesRequest({
+      model: 'claude',
+      input: [{ type: 'agent_message', content: null }],
+    })).toThrowError('input[0].content');
+  });
+
+  it('keeps collab text inside a valid tool-use round', () => {
+    const result = translateResponsesRequest({
+      model: 'claude',
+      input: [
+        { role: 'user', content: 'run it' },
+        { type: 'function_call', call_id: 'c1', name: 'run', arguments: '{}' },
+        { type: 'agent_message', author: 'worker', content: 'working result' },
+        { type: 'function_call_output', call_id: 'c1', output: 'ok' },
+      ],
+      tools: [{ type: 'function', name: 'run', parameters: { type: 'object' } }],
+    });
+
+    expect(result.request.messages[1].content).toEqual([
+      expect.objectContaining({ type: 'tool_use', id: 'c1', name: 'run' }),
+      { type: 'text', text: '[collab worker]\nworking result' },
+    ]);
+    expect(result.request.messages[2].content).toEqual([
+      expect.objectContaining({ type: 'tool_result', tool_use_id: 'c1' }),
+    ]);
+  });
+
   it('rejects structured-output constraints instead of silently dropping them', () => {
     expect(() => translateResponsesRequest({
       model: 'claude',

--- a/packages/responses-anthropic-bridge/src/translate-request.ts
+++ b/packages/responses-anthropic-bridge/src/translate-request.ts
@@ -97,6 +97,45 @@ function instructionsText(value: ResponsesRequest['instructions']): string {
   }).join('');
 }
 
+function agentMessageText(item: JsonObject, itemIndex: number): string {
+  const normalizedAuthor = typeof item.author === 'string'
+    ? item.author.replace(/\s*[\r\n]+\s*/g, ' ').trim()
+    : '';
+  const author = normalizedAuthor || 'agent';
+  let body = '';
+  let omittedEncryptedContent = false;
+  if (typeof item.content === 'string') {
+    body = item.content;
+  } else if (Array.isArray(item.content)) {
+    const parts: string[] = [];
+    for (const part of item.content) {
+      if (!isObject(part) || typeof part.type !== 'string') {
+        throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
+      }
+      if (part.type === 'encrypted_content') {
+        omittedEncryptedContent = true;
+        continue;
+      }
+      if (part.type === 'input_text' || part.type === 'output_text' || part.type === 'text') {
+        if (typeof part.text !== 'string') {
+          throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content.${part.type}`);
+        }
+        parts.push(part.text);
+        continue;
+      }
+      throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content.${part.type}`);
+    }
+    body = parts.join('\n');
+  } else {
+    throw new UnsupportedResponsesFeatureError(`input[${itemIndex}].content`);
+  }
+  return body.trim()
+    ? `[collab ${author}]\n${body}`
+    : omittedEncryptedContent
+      ? `[collab message from ${author}; encrypted payload omitted]`
+      : `[collab message from ${author}; empty content]`;
+}
+
 function parseDataUrl(value: string): { mediaType: string; data: string } | null {
   const match = /^data:([^;,]+)(?:;[^,]*)*;base64,([\s\S]+)$/i.exec(value);
   if (!match) return null;
@@ -1112,7 +1151,8 @@ export function translateResponsesRequest(
     assistant = null;
   };
 
-  for (const rawItem of items) {
+  for (let itemIndex = 0; itemIndex < items.length; itemIndex += 1) {
+    const rawItem = items[itemIndex];
     if (!isObject(rawItem)) throw new UnsupportedResponsesFeatureError('input item');
     const type = stringValue(rawItem.type);
     if (type === 'reasoning') {
@@ -1166,6 +1206,11 @@ export function translateResponsesRequest(
         name: mapping.wireName,
         input: inputValue,
       });
+      continue;
+    }
+    if (type === 'agent_message') {
+      assistant ??= { role: 'assistant', content: [] };
+      assistant.content.push(textPart(agentMessageText(rawItem, itemIndex)));
       continue;
     }
     if (type === 'input_text' || type === 'input_image' || type === 'input_file') {


### PR DESCRIPTION
## 这次改了什么

### 摘要

Anthropic Messages 路线现在能继续读取 Codex 多 Agent 协同产生的 `agent_message` 历史，不会再因为一条子 Agent 回执让整个任务永久卡住。

转换时保留可读文本和来源标记，去掉只对原供应商有意义的密文；空内容和纯密文会变成明确占位，未知或畸形内容仍然拒绝，避免静默吞掉新格式。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2273
- 本 PR 包含：Anthropic bridge 对 `agent_message` 的安全降级，以及真实历史形状、密文、空内容、畸形 part、工具轮顺序的回归测试
- 明确不包含：不修改 Chat Completions 图片能力，不放宽其他未知 Responses 输入项
- 用户可见变化：用过多 Agent 协同的任务可以继续通过 Anthropic Messages 路线对话和发送图片
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/responses-anthropic-bridge test -- translate-request.test.ts
结果：4 files / 93 tests passed

pnpm --filter @cindy/responses-anthropic-bridge run --if-present typecheck
结果：通过

pnpm --filter @cindy/responses-anthropic-bridge lint
结果：通过

pnpm test:unit
结果：全部 workspace 通过（Desktop、Mobile、maker-core、bridge 及 protocol packages）

pnpm check:dco
结果：通过，1 个 commit 已签名
```

### 手工验证

用 Issue 中的实际回放形状构造本地转换请求，确认输出的 Anthropic wire body：

- 保留 `[collab <author>]` 与多段文本顺序；
- 不包含 `agent_message`、`encrypted_content` 或密文载荷；
- 后续纯文本和 base64 图片仍进入 Anthropic user message；
- `function_call → agent_message → function_call_output` 保持合法的 tool-use/tool-result 邻接。

### 未执行的验证

未向真实第三方 Anthropic 中转发送请求；本问题发生在 Cindy 本地转换、请求发出之前，已用无外网的 wire body 回归覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Responses → Anthropic Messages bridge 对已知 `agent_message` 历史项的转换；其他未知 item 继续 fail-closed
- 回滚 / 降级方式：回滚本 commit 后恢复为遇到 `agent_message` 时发送前报错，不涉及持久化格式或数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（本次无需文档变更）
- [x] 已确认测试结果或说明未执行原因
