### PR TITLE
fix(desktop): preserve mobile compact commands

### DIFF
--- a/apps/desktop/src/main/__tests__/mobileClientPromptNote.test.ts
+++ b/apps/desktop/src/main/__tests__/mobileClientPromptNote.test.ts
@@ -25,6 +25,7 @@ import {
 import {
   attachMainOwnedInputBoundary,
   buildMobileClientPromptNote,
+  shouldPrependMobileClientPromptNote,
   stampMobileClientOrigin,
   stripMainOnlySendOpts,
 } from '../maker-ipc/mobileClientPromptNote';
@@ -189,6 +190,39 @@ describe('prependNoteToWireUserMessage(wire 注入形态)', () => {
   });
 });
 
+describe('shouldPrependMobileClientPromptNote(内置命令旁路)', () => {
+  it('Claude Code /compact 保持在消息开头，含可选指令也旁路', () => {
+    expect(shouldPrependMobileClientPromptNote('/compact', 'claude-code')).toBe(false);
+    expect(shouldPrependMobileClientPromptNote('/compact focus on decisions', 'claude-code'))
+      .toBe(false);
+    expect(shouldPrependMobileClientPromptNote(
+      { type: 'user', content: '/compact\nkeep the API contract' },
+      'claude-code',
+    )).toBe(false);
+    expect(shouldPrependMobileClientPromptNote(
+      { type: 'user', content: [{ type: 'text', text: '/compact' }] },
+      'claude-code',
+    )).toBe(false);
+  });
+
+  it('不把相似文本、带附件消息或其他 Agent 的输入误判成 Claude 命令', () => {
+    expect(shouldPrependMobileClientPromptNote('/compactness', 'claude-code')).toBe(true);
+    expect(shouldPrependMobileClientPromptNote(' /compact', 'claude-code')).toBe(true);
+    expect(shouldPrependMobileClientPromptNote(
+      {
+        type: 'user',
+        content: [
+          { type: 'text', text: '/compact' },
+          { type: 'image', url: 'x' },
+        ],
+      },
+      'claude-code',
+    )).toBe(true);
+    expect(shouldPrependMobileClientPromptNote('/compact', 'pi')).toBe(true);
+    expect(shouldPrependMobileClientPromptNote('/compact', 'codex')).toBe(true);
+  });
+});
+
 describe('注入接线(源码级守卫)', () => {
   const source = readFileSync(
     resolve(process.cwd(), 'src/main/maker-ipc/makerSendTransaction.ts'),
@@ -196,10 +230,11 @@ describe('注入接线(源码级守卫)', () => {
   );
 
   it('说明只进 wire payload,落库走 persistUserMessage.content', () => {
-    expect(source).toMatch(
-      /const mobileClientNote =\s*deps\.isMobileClientInvoke\?\.\(\) === true/,
+    expect(source).toContain(
+      'deps.isMobileClientInvoke?.() === true || so.fromMobileClient === true',
     );
     expect(source).toContain('prependNoteToWireUserMessage(withHandoff as HandoffWireMessage, mobileClientNote)');
+    expect(source).toContain('shouldPrependMobileClientPromptNote(normalized, sess.agentKind)');
     // 落库内容必须仍取 persistUserMessage.content —— 若改成 outgoing,提示语会写进
     // 用户消息、污染界面显示的原话。
     expect(source).toContain('content: persistUserMessage.content');
@@ -352,6 +387,7 @@ describe('排队 / 插入两条路径的接线(源码级守卫)', () => {
 
   it('steer 投递也注入说明,且只进 wire payload', () => {
     expect(register).toContain("isMobileControllerInvoke() || so.fromMobileClient === true");
+    expect(register).toContain('shouldPrependMobileClientPromptNote(normalized, sess.agentKind)');
     expect(register).toContain('prependNoteToWireUserMessage(normalized as HandoffWireMessage, steerNote)');
     expect(register).toContain('await sess.steer(steerPayload as never');
   });

--- a/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
@@ -1258,6 +1258,74 @@ describe('maker SEND transaction', () => {
   });
 });
 
+describe('mobile client prompt note', () => {
+  it('keeps ordinary mobile messages annotated on the wire but persists the original text', async () => {
+    const session = createSession({ agentKind: 'claude-code' });
+    const { deps } = createDeps({
+      getSession: vi.fn(() => session),
+      isMobileClientInvoke: vi.fn(() => true),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await transaction.sendToAgentAccepted('session-1', 'hello', undefined, {
+      persistUserMessage: { clientId: 'mobile-1', content: 'hello' },
+    });
+
+    const sent = vi.mocked(session.send).mock.calls[0]?.[0];
+    expect(sent).toEqual(expect.stringMatching(/^\[客户端说明\]/));
+    expect(sent).toEqual(expect.stringMatching(/\n\nhello$/));
+    expect(vi.mocked(deps.createDbMessage).mock.calls[0]?.[1].content).toBe('hello');
+  });
+
+  it('sends mobile Claude Code /compact commands without a prepended note', async () => {
+    const session = createSession({ agentKind: 'claude-code' });
+    const { deps } = createDeps({
+      getSession: vi.fn(() => session),
+      isMobileClientInvoke: vi.fn(() => true),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await transaction.sendToAgentAccepted('session-1', '/compact focus on decisions');
+
+    expect(session.send).toHaveBeenCalledWith('/compact focus on decisions', expect.anything());
+  });
+
+  it('keeps the mobile note for /compact text sent to a non-Claude agent', async () => {
+    const session = createSession({ agentKind: 'pi' });
+    const { deps } = createDeps({
+      getSession: vi.fn(() => session),
+      isMobileClientInvoke: vi.fn(() => true),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await transaction.sendToAgentAccepted('session-1', '/compact');
+
+    const sent = vi.mocked(session.send).mock.calls[0]?.[0];
+    expect(sent).toEqual(expect.stringMatching(/^\[客户端说明\]/));
+  });
+
+  it('applies the same command bypass to coordinator-drained mobile messages', async () => {
+    const session = createSession({ agentKind: 'claude-code' });
+    const { deps } = createDeps({
+      getSession: vi.fn(() => session),
+      isMobileClientInvoke: vi.fn(() => false),
+    });
+    const transaction = createMakerSendTransaction(deps);
+
+    await transaction.sendToAgentAccepted(
+      'session-1',
+      { type: 'user', content: '/compact' },
+      undefined,
+      { fromMobileClient: true },
+    );
+
+    expect(session.send).toHaveBeenCalledWith(
+      { type: 'user', content: '/compact' },
+      expect.anything(),
+    );
+  });
+});
+
 describe('session-agent-switch handoff injection', () => {
   it('pending 命中时 wire payload 前置交接段,落库内容保持用户原文,accepted 后 consume', async () => {
     const consumePendingHandoff = vi.fn();

--- a/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
+++ b/apps/desktop/src/main/maker-ipc/makerSendTransaction.ts
@@ -22,7 +22,10 @@ import {
   prependNoteToWireUserMessage,
   type HandoffWireMessage,
 } from './agentHandoff.js';
-import { buildMobileClientPromptNote } from './mobileClientPromptNote.js';
+import {
+  buildMobileClientPromptNote,
+  shouldPrependMobileClientPromptNote,
+} from './mobileClientPromptNote.js';
 import type { MakerSessionCreateOpts } from './sessionRequest.js';
 
 type CreateOpts = MakerSessionCreateOpts;
@@ -736,7 +739,8 @@ export function createMakerSendTransaction(deps: MakerSendTransactionDeps): Make
       // 两个来源:直连 maker:send 走 async context(deps 注入);排队 / 插入路径走
       // coordinator 从队列项透传的 so.fromMobileClient(drain 时 context 已结束)。
       const mobileClientNote =
-        deps.isMobileClientInvoke?.() === true || so.fromMobileClient === true
+        (deps.isMobileClientInvoke?.() === true || so.fromMobileClient === true)
+        && shouldPrependMobileClientPromptNote(normalized, sess.agentKind)
           ? buildMobileClientPromptNote()
           : null;
       const outgoing = mobileClientNote

--- a/apps/desktop/src/main/maker-ipc/mobileClientPromptNote.ts
+++ b/apps/desktop/src/main/maker-ipc/mobileClientPromptNote.ts
@@ -41,6 +41,34 @@ export function buildMobileClientPromptNote(): string {
   );
 }
 
+function singleTextContent(message: unknown): string | null {
+  if (typeof message === 'string') return message;
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return null;
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content) || content.length !== 1) return null;
+  const part = content[0];
+  if (!part || typeof part !== 'object' || Array.isArray(part)) return null;
+  const { type, text } = part as { type?: unknown; text?: unknown };
+  return (
+    (type === 'text' || type === 'input_text' || type === 'output_text')
+    && typeof text === 'string'
+  ) ? text : null;
+}
+
+/**
+ * Claude Code 内置命令必须位于消息开头；手机客户端说明不能抢占这个位置。
+ * 只放行已由 palette 明确暴露的 `/compact`，其它 slash 文本继续保留来源说明。
+ */
+export function shouldPrependMobileClientPromptNote(
+  message: unknown,
+  agentKind: string,
+): boolean {
+  if (agentKind !== 'claude-code') return true;
+  const text = singleTextContent(message);
+  return text === null || !/^\/compact(?:\s|$)/.test(text);
+}
+
 /**
  * 在 IPC 边界给队列项盖上手机来源(返回新对象,不原地改入参)。
  *

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -712,6 +712,7 @@ import {
 import {
   attachMainOwnedInputBoundary,
   buildMobileClientPromptNote,
+  shouldPrependMobileClientPromptNote,
   stripMainOnlySendOpts,
   stampMobileClientOrigin,
   type MainOwnedInputBoundaryStamp,
@@ -9027,7 +9028,8 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
     // 手机说明同样只进 wire payload(steer 路径不落库用户消息,天然不污染原话)。
     // 两个来源都要认:IPC 直连 steer 时 async context 在;coordinator 投递时靠透传。
     const steerNote =
-      isMobileControllerInvoke() || so.fromMobileClient === true
+      (isMobileControllerInvoke() || so.fromMobileClient === true)
+      && shouldPrependMobileClientPromptNote(normalized, sess.agentKind)
         ? buildMobileClientPromptNote()
         : null;
     const steerPayload = steerNote


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机端发给 Claude Code 的 `/compact` 原本会被 Cindy 的客户端说明抢到前面，导致 Claude Code 不再把它识别为内置命令。本 PR 只对 Claude Code 的真实 `/compact` 指令跳过这段说明，并覆盖直接发送、排队后发送和 steer 三条路径；普通手机消息的说明保持不变。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Refs #2242
- 本 PR 包含：Claude Code `/compact` 的移动端原样透传，以及直接发送、队列 drain、steer 接线和回归测试。
- 明确不包含：#2242 中代理返回空或畸形 200 响应的问题；其它 slash command；模型代理改动。
- 用户可见变化：从手机端发送 `/compact` 或 `/compact <instructions>` 时，Claude Code 能正常执行压缩；普通消息行为不变。
- 是否存在 breaking change：无。

远程与移动端适配：
- SSH：无影响，不改变文件位置、Agent 位置或远程路径。
- device-link / mobile：沿用现有 maker send、队列 drain 和 steer 通道；没有新增 IPC、协议字段或 allowlist。
- mobile UI：无 UI 改动，只修复现有移动端发送行为。

### UI 变化

不涉及。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/__tests__/mobileClientPromptNote.test.ts src/main/maker-ipc/__tests__/makerSendTransaction.test.ts
结果：2 files passed，93 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop run --if-present lint
结果：通过

pnpm test:unit
结果：通过（全部 unit workspaces 通过）

pnpm check:dco
结果：通过（1 commit signed off）
```

### 手工验证

不涉及 UI。通过真实 send transaction 测试桩核对 wire payload：Claude Code 的手机 `/compact` 在直接发送和队列 drain 后保持原文，普通手机消息仍附带客户端说明且数据库保留用户原文。

### 未执行的验证

未用实体手机连接桌面端执行 `/compact`；本 PR 不改 mobile bundle，分支行为由 desktop 主进程 transaction 回归测试覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 mobile 来源、目标 Agent 为 Claude Code、且消息是单一文本 `/compact` 指令时不再前置客户端说明。相似文本、附件消息和其他 Agent 不旁路。
- 回滚 / 降级方式：回退本提交即可恢复原先统一前置说明的行为；不涉及数据库、迁移、协议字段或持久化格式。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因