### PR TITLE
fix(claude): preserve DeepSeek Flash bare model wire id

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/models.test.ts
@@ -83,6 +83,10 @@ describe('ClaudeCodeAgent model capabilities', () => {
     expect(toSdkModelString('z-ai/glm-5.2')).toBe('z-ai/glm-5.2[1m]');
   });
 
+  it('maps the bare DeepSeek V4 Flash id to the 1M Claude Code route', () => {
+    expect(toSdkModelString('deepseek-v4-flash')).toBe('deepseek-v4-flash[1m]');
+  });
+
   it('keeps the [1m] beta channel for the official gpt-5.5 / gpt-5.4 (true 1M)', () => {
     expect(toSdkModelString('gpt-5.5')).toBe('gpt-5.5[1m]');
     expect(toSdkModelString('gpt-5.4')).toBe('gpt-5.4[1m]');

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -213,7 +213,11 @@ function legacyToSdkModelString(model: string): string {
   if (model === 'codex/gpt-5.5' || model === 'codex/gpt-5.4') return model;
   if (model === 'codex/gpt-5.6-sol' || model === 'codex/gpt-5.6-terra') return model;
   // DeepSeek 的 [1m] 是历史兼容路由后缀; 上下文大小另走 maker capabilities。
-  if (model === 'deepseek/deepseek-v4-pro' || model === 'deepseek/deepseek-v4-flash') return `${model}[1m]`;
+  if (
+    model === 'deepseek/deepseek-v4-pro' ||
+    model === 'deepseek/deepseek-v4-flash' ||
+    model === 'deepseek-v4-flash'
+  ) return `${model}[1m]`;
   if (model === 'z-ai/glm-5.2') return `${model}[1m]`;
   return model;
 }


### PR DESCRIPTION
## 这次改了什么

关联 #1491。Claude Code 的自定义 DeepSeek V4 Flash 使用裸模型名时，补齐历史兼容的 `[1m]` wire 后缀，避免官方 Anthropic 兼容端点拒绝 `deepseek-v4-flash`；保留已有命名空间模型行为。

## 怎么验证的

- `models.test.ts`: 13 tests passed（含裸 `deepseek-v4-flash` 回归）
- `git diff --check`: passed
- maker-core typecheck: main 基线已有测试类型错误，本次改动文件无新增错误
- changed-files ESLint: main 基线已有 `SUBSCRIPTION_TOKEN_KEY` / `PROVIDER_KEY_KEYS` 两处 unused 错误，本次改动无新增命中

## 风险

仅影响 Claude Code 未带 catalog contextWindow 的裸 `deepseek-v4-flash` 模型字符串；命名空间 DeepSeek、已知窗口模型和其他 provider 行为不变。

@codex review