### PR TITLE
fix(claude): honor Cindy model selection over stale allowlist

### DIFF
--- a/packages/maker-core/src/agents/claude-code/__tests__/flag-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/flag-settings.test.ts
@@ -51,6 +51,16 @@ describe('buildClaudeFlagSettings', () => {
     ).toBe(false);
   });
 
+  it('host model catalog overrides a user availableModels allowlist', () => {
+    const settings = buildClaudeFlagSettings({
+      showThinkingSummaries: false,
+      fastMode: false,
+      selectedModelId: 'gpt-5.6-sol',
+    });
+
+    expect(settings.availableModels).toEqual(['gpt-5.6-sol']);
+  });
+
   it('adds namespaced plugin skill overrides from the host routing policy', () => {
     const settings = buildClaudeFlagSettings({
       showThinkingSummaries: false,

--- a/packages/maker-core/src/agents/claude-code/__tests__/flag-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/flag-settings.test.ts
@@ -51,14 +51,14 @@ describe('buildClaudeFlagSettings', () => {
     ).toBe(false);
   });
 
-  it('host model catalog overrides a user availableModels allowlist', () => {
+  it('uses host-provided Claude SDK wire models over a user availableModels allowlist', () => {
     const settings = buildClaudeFlagSettings({
       showThinkingSummaries: false,
       fastMode: false,
-      selectedModelId: 'gpt-5.6-sol',
+      availableModels: ['claude-opus-4-6[1m]', 'claude-sonnet-5'],
     });
 
-    expect(settings.availableModels).toEqual(['gpt-5.6-sol']);
+    expect(settings.availableModels).toEqual(['claude-opus-4-6[1m]', 'claude-sonnet-5']);
   });
 
   it('adds namespaced plugin skill overrides from the host routing policy', () => {

--- a/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
+++ b/packages/maker-core/src/agents/claude-code/__tests__/rewind-runtime-settings.test.ts
@@ -237,6 +237,23 @@ afterEach(async () => {
 });
 
 describe('ClaudeCodeAgent runtime settings during rewind window', () => {
+  it('keeps the selected and catalog Claude wire models available for a live model switch', async () => {
+    const { handle, firstQuery } = await startRewindableSession();
+
+    const startArgs = sdkMock.query.mock.calls[0]?.[0] as {
+      options: { settings?: { availableModels?: string[] } };
+    };
+    expect(startArgs.options.settings?.availableModels).toEqual([
+      'claude-opus-4-6[1m]',
+      'claude-sonnet-5',
+    ]);
+
+    await handle.setModel?.('claude-sonnet-5');
+    expect(firstQuery.setModel).toHaveBeenCalledWith('claude-sonnet-5');
+
+    await handle.close();
+  });
+
   it('passes max through when changing effort in a live Sonnet 5 session', async () => {
     const { handle, firstQuery } = await startRewindableSession();
 

--- a/packages/maker-core/src/agents/claude-code/flag-settings.ts
+++ b/packages/maker-core/src/agents/claude-code/flag-settings.ts
@@ -47,6 +47,12 @@ export interface ClaudeFlagSettingsInput {
   fastMode: boolean;
   /** Host-owned policy for colliding downstream skills. */
   capabilityRouting?: CapabilityRoutingPolicy;
+  /**
+   * Cindy's model selector is authoritative for the active session. Keep the
+   * selected model available even when a user's Claude settings file carries
+   * a stale availableModels allowlist.
+   */
+  selectedModelId?: string;
 }
 
 /** 装配 startSession 注入的 flag settings 对象。纯函数 —— 每次调用读最新输入值。 */
@@ -61,6 +67,7 @@ export function buildClaudeFlagSettings(input: ClaudeFlagSettingsInput): Setting
       autoDreamEnabled: input.memoryOverride,
     }),
     ...(input.fastMode && { fastMode: true }),
+    ...(input.selectedModelId ? { availableModels: [input.selectedModelId] } : {}),
     ...(Object.keys(skillOverrides).length > 0 && { skillOverrides }),
   };
 }

--- a/packages/maker-core/src/agents/claude-code/flag-settings.ts
+++ b/packages/maker-core/src/agents/claude-code/flag-settings.ts
@@ -48,11 +48,10 @@ export interface ClaudeFlagSettingsInput {
   /** Host-owned policy for colliding downstream skills. */
   capabilityRouting?: CapabilityRoutingPolicy;
   /**
-   * Cindy's model selector is authoritative for the active session. Keep the
-   * selected model available even when a user's Claude settings file carries
-   * a stale availableModels allowlist.
+   * Final Claude SDK wire model strings that Cindy allows for this session.
+   * This highest-priority list replaces any stale user availableModels list.
    */
-  selectedModelId?: string;
+  availableModels?: readonly string[];
 }
 
 /** 装配 startSession 注入的 flag settings 对象。纯函数 —— 每次调用读最新输入值。 */
@@ -67,7 +66,9 @@ export function buildClaudeFlagSettings(input: ClaudeFlagSettingsInput): Setting
       autoDreamEnabled: input.memoryOverride,
     }),
     ...(input.fastMode && { fastMode: true }),
-    ...(input.selectedModelId ? { availableModels: [input.selectedModelId] } : {}),
+    ...(input.availableModels && input.availableModels.length > 0 && {
+      availableModels: [...new Set(input.availableModels)],
+    }),
     ...(Object.keys(skillOverrides).length > 0 && { skillOverrides }),
   };
 }

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1763,7 +1763,17 @@ export class ClaudeCodeAgent extends BaseAgent {
     const buildSettings = (): Settings =>
       buildClaudeFlagSettings({
         showThinkingSummaries,
-        selectedModelId: mutableModel,
+        // availableModels is the SDK's highest-priority allowlist. Convert the
+        // whole current catalog and the selected model through the one
+        // catalog-id → wire-string mapper so startup and live switches share
+        // the same [1m] and legacy conversion rules. Keep the selected model
+        // even when it is temporarily outside the catalog.
+        availableModels: [
+          ...new Set([
+            ...this.capabilities.availableModels.map(({ id }) => sdkModelFor(id)),
+            sdkModelFor(mutableModel),
+          ]),
+        ],
         // Do not carry the local manager's native-memory suppression across the
         // SSH boundary: the remote host retains its own Claude memory
         // configuration. Maker Memory on remote sessions is injected via the

--- a/packages/maker-core/src/agents/claude-code/index.ts
+++ b/packages/maker-core/src/agents/claude-code/index.ts
@@ -1763,6 +1763,7 @@ export class ClaudeCodeAgent extends BaseAgent {
     const buildSettings = (): Settings =>
       buildClaudeFlagSettings({
         showThinkingSummaries,
+        selectedModelId: mutableModel,
         // Do not carry the local manager's native-memory suppression across the
         // SSH boundary: the remote host retains its own Claude memory
         // configuration. Maker Memory on remote sessions is injected via the


### PR DESCRIPTION
## 这次改了什么
- 在 Claude SDK flag settings 层锁定 Cindy 当前选中的模型，避免用户 ~/.claude/settings.json 的 stale availableModels 把已选模型静默回退到默认模型。
- 增加回归测试覆盖。

Fixes #363

## 怎么验证的
- Claude Code focused suite: 531 tests passed
- focused flag-settings: 6 tests passed
- git diff --check passed
- changed-file ESLint passed for flag-settings.ts and its test; index.ts retains 2 pre-existing unused-variable errors at lines 5415–5416

## 风险
- 仅影响 Claude Code 会话的当前模型 allowlist；不改用户文件或凭证。

@codex review