### PR TITLE
fix(desktop): restore cleared composer placeholder

### DIFF
--- a/apps/desktop/src/renderer/__tests__/composerPlaceholderCss.test.ts
+++ b/apps/desktop/src/renderer/__tests__/composerPlaceholderCss.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const globalsSource = readFileSync(resolve(__dirname, '..', 'styles', 'globals.css'), 'utf8');
+
+describe('composer placeholder CSS', () => {
+  it('renders the placeholder when Tiptap leaves only the empty-node class', () => {
+    expect(globalsSource).toContain(
+      '.ProseMirror > p.is-empty:first-child:only-child::before {',
+    );
+  });
+
+  it('keeps the empty-node fallback hidden while a voice draft is active', () => {
+    expect(globalsSource).toContain(
+      "[data-voice-draft-active='true'] .ProseMirror > p.is-empty:first-child:only-child::before {",
+    );
+  });
+});

--- a/apps/desktop/src/renderer/styles/globals.css
+++ b/apps/desktop/src/renderer/styles/globals.css
@@ -379,15 +379,18 @@ html:lang(ko) {
 /* Tiptap ChatInput — placeholder hook & chip alignment
    (command-palette F2.5). The Placeholder extension injects
    `p.is-editor-empty::before` with the placeholder text in a `data-*`
-   attribute; we style it to match the old textarea placeholder. */
-.ProseMirror > p.is-editor-empty:first-child::before {
+   attribute; after a controlled clear it can leave only `is-empty`, so the
+   sole-empty-paragraph selector preserves the same truly-empty contract. */
+.ProseMirror > p.is-editor-empty:first-child::before,
+.ProseMirror > p.is-empty:first-child:only-child::before {
   content: attr(data-placeholder);
   color: var(--chat-input-placeholder-subtle);
   float: left;
   height: 0;
   pointer-events: none;
 }
-[data-voice-draft-active='true'] .ProseMirror > p.is-editor-empty:first-child::before {
+[data-voice-draft-active='true'] .ProseMirror > p.is-editor-empty:first-child::before,
+[data-voice-draft-active='true'] .ProseMirror > p.is-empty:first-child:only-child::before {
   content: none;
 }
 .ProseMirror {


### PR DESCRIPTION
## 这次改了什么

### 摘要

连续发送消息后，Tiptap 有时会把已经清空的输入框标成 `is-empty`，而不是 `is-editor-empty`。现有样式只识别后者，于是“继续聊一聊…”会消失。本 PR 为“唯一空段落”增加窄兜底，并同步语音草稿的隐藏规则。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #2284
- 本 PR 包含：空 composer 只有 `is-empty` 时恢复占位提示；voice draft 激活时继续隐藏提示；CSS 契约测试。
- 明确不包含：修改 Tiptap 文档状态、推荐提示词、输入行为或其它 composer 样式。
- 用户可见变化：后续轮次结束并清空输入框后，“继续聊一聊…”继续可见。
- 是否存在 breaking change：无。

### UI 变化

恢复原有占位提示，不引入新布局、颜色或交互。深色模式已在 macOS 实机验证；浅色模式未手工目检，选择器复用现有占位样式及语义 token。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Inputs（placeholder 明确表达空态并使用统一 token）、§10 Light / Dark Dual-Mode Delivery Gate（复用现有 `--chat-input-placeholder-subtle`，无硬编码颜色）。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/composerPlaceholderCss.test.ts
结果：1 file passed，2 tests passed

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter desktop exec eslint src/renderer/__tests__/composerPlaceholderCss.test.ts
结果：通过

pnpm test:unit
结果：通过（全部 unit workspaces 通过）

pnpm check:dco
结果：通过（1 commit signed off）
```

### 手工验证

macOS arm64，现有 Cindy dev build：连续完成两轮 Claude Code 对话后稳定复现空输入框提示消失；运行时 DOM 是带 `data-placeholder` 的单一 `p.is-empty`。临时应用本 PR 的选择器后，画面与 AX 文本立即恢复“继续聊一聊…”；撤销临时样式后再次消失。

### 未执行的验证

- 未启动第二个 Electron 构建验证，避免干扰用户已打开的 Cindy；使用现有窗口对同一 DOM 状态完成前后对照。
- 未手工目检浅色模式。
- `pnpm --filter desktop lint` 在未改动的 main 文件上报告 192 个既有错误；本 PR 唯一新增的 TypeScript 测试文件已单独 lint 通过，CSS 无 lint 脚本。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop composer 的空态伪元素选择器。`:only-child` 保证多段空行不会误显示占位提示；voice draft 使用同一兜底保持隐藏。
- 回滚 / 降级方式：回退本提交即可恢复原选择器；不涉及持久化数据或运行时协议。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因