### PR TITLE
fix(desktop): stop retrying invalid embedding models

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/cindySlot.test.ts
@@ -2463,12 +2463,16 @@ describe('文本转向量(embed_text)· 失败码与时间预算', () => {
 
   it.each([
     ['INVALID_MODEL', 'INVALID_PARAMS'],
+    // BAD_REQUEST(400/422 输入/参数错误):不是型号永久失效,修正请求后可重试,
+    // 不能当 INTERNAL 让插件盲目重试同一个坏请求,也不能当型号永久失效。
+    ['BAD_REQUEST', 'INVALID_PARAMS'],
     ['RATE_LIMITED', 'RATE_LIMITED'],
     ['TIMEOUT', 'TIMEOUT'],
     ['AUTH_FAILED', 'NO_CANDIDATE'],
     // 用户在设置里停用了供应商/型号 —— 主机没得选,与"目录里没有可用型号"同一
     // 语义面。FORGE_GUIDE 明确承诺这种情况报 NO_CANDIDATE。
     ['DISABLED', 'NO_CANDIDATE'],
+    ['TRANSIENT_ERROR', 'INTERNAL'],
     ['NETWORK_ERROR', 'INTERNAL'],
     ['SERVER_ERROR', 'INTERNAL'],
   ])('执行层 %s → 协议 %s', async (upstream, expected) => {

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -415,14 +415,21 @@ function supportsContextualEmbedding(model: string): boolean {
  *   - AUTH_FAILED(未登录 / 凭证不可用)、DISABLED(用户在设置里停用了该供应商或型号)
  *     → NO_CANDIDATE:与"目录里没有可用型号"同一语义面 —— 插件改什么都没用,是主机
  *     侧条件不满足,应如实告诉用户而不是重试轰炸;
- *   - BAD_REQUEST(400/422 输入错误)、TRANSIENT_ERROR(404 路由暂时不可达)、
- *     NETWORK_ERROR / SERVER_ERROR / 其它 → INTERNAL:主机侧故障,重试由调方决定。
+ *   - BAD_REQUEST(400/422 输入或参数错误)→ INVALID_PARAMS:与 INVALID_MODEL 不同,
+ *     这不是型号本身不可用,输入修正后可重试;不能把它当主机故障(INTERNAL)让插件
+ *     盲目重试同一个坏请求,也不能当型号永久失效;
+ *   - TRANSIENT_ERROR(404 路由暂时不可达)、NETWORK_ERROR / SERVER_ERROR / 其它
+ *     → INTERNAL:主机侧或网络侧故障,重试由调方决定。
  */
 function embeddingErrorCode(err: unknown): string {
   const code = (err as { code?: unknown } | null)?.code;
   if (typeof code !== 'string') return 'INTERNAL';
   switch (code) {
     case 'INVALID_MODEL':
+      return 'INVALID_PARAMS';
+    case 'BAD_REQUEST':
+      // 输入/参数类错误(400/422):修正请求后可重试,不是型号永久失效。
+      // 与 INVALID_MODEL 区分开 —— 后者是型号本身不可用,改输入也没用。
       return 'INVALID_PARAMS';
     case 'RATE_LIMITED':
       return 'RATE_LIMITED';
@@ -431,6 +438,9 @@ function embeddingErrorCode(err: unknown): string {
     case 'AUTH_FAILED':
     case 'DISABLED':
       return 'NO_CANDIDATE';
+    case 'TRANSIENT_ERROR':
+    case 'NETWORK_ERROR':
+    case 'SERVER_ERROR':
     default:
       return 'INTERNAL';
   }

--- a/apps/desktop/src/main/cindy-brain/cindySlot.ts
+++ b/apps/desktop/src/main/cindy-brain/cindySlot.ts
@@ -408,14 +408,15 @@ function supportsContextualEmbedding(model: string): boolean {
  * 为了一个 instanceof 把它拉进 slot 的静态模块图会破坏这条边界。
  *
  * 映射口径 = "插件拿到这个码该做什么":
- *   - INVALID_MODEL(本地白名单外 / 上游 400,含"该型号不支持这个维度")→ INVALID_PARAMS:
- *     改参数再来,重试同样的请求永远失败;
+ *   - INVALID_MODEL(本地白名单外 / 错误体明确标识 model_not_found / 维度不被该型号支持)
+ *     → INVALID_PARAMS:改参数再来,重试同样的请求永远失败;
  *   - RATE_LIMITED(429)→ 同名:退避后可重试;
  *   - TIMEOUT(预算耗尽)→ 同名:可重试,但要考虑减小批量;
  *   - AUTH_FAILED(未登录 / 凭证不可用)、DISABLED(用户在设置里停用了该供应商或型号)
  *     → NO_CANDIDATE:与"目录里没有可用型号"同一语义面 —— 插件改什么都没用,是主机
  *     侧条件不满足,应如实告诉用户而不是重试轰炸;
- *   - NETWORK_ERROR / SERVER_ERROR / 其它 → INTERNAL:主机侧故障,重试由调方决定。
+ *   - BAD_REQUEST(400/422 输入错误)、TRANSIENT_ERROR(404 路由暂时不可达)、
+ *     NETWORK_ERROR / SERVER_ERROR / 其它 → INTERNAL:主机侧故障,重试由调方决定。
  */
 function embeddingErrorCode(err: unknown): string {
   const code = (err as { code?: unknown } | null)?.code;

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -340,8 +340,11 @@ export class EmbeddingWorker {
           const age = Date.now() - blocked.blockedAt;
           if (age < MODEL_BLOCK_TTL_MS || blocked.probeCount >= MODEL_BLOCK_MAX_REPROBES) {
             // 熔断 TTL 内,或已耗尽自动重探次数:snooze 这批,不出网。
-            // 重启会清空 blockedModels,届时再给一轮新的探测预算。
-            await this.recordFailureBatch(modelJobs, blocked.error, true);
+            // 按当前窗口结束时刻排程(而不是 now + 30min),否则第 29 分钟到达的
+            // 任务会被排到第 59 分钟,即使第 30 分钟探测已成功也不会提前恢复
+            // (PR #2288 Codex P1)。
+            const snoozeUntil = blocked.blockedAt + MODEL_BLOCK_TTL_MS;
+            await this.recordFailureBatch(modelJobs, blocked.error, true, snoozeUntil);
             if (this.aborted) return;
             this.opts.log.debug?.(
               JSON.stringify({
@@ -514,6 +517,7 @@ export class EmbeddingWorker {
     jobs: JobRow[],
     errMsg: string,
     terminal = false,
+    snoozeUntil?: number,
   ): Promise<number> {
     const now = Date.now();
     const result = await this.opts.getDbClient().tx('embedding.recordFailures', {
@@ -521,6 +525,7 @@ export class EmbeddingWorker {
       errMsg: truncate(errMsg, 2000),
       now,
       terminal,
+      snoozeUntil,
     });
     return result.failCount;
   }

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -41,9 +41,15 @@ const TICK_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 32;
 /**
  * 熔断 TTL,必须与 DB 层 TERMINAL_SNOOZE_MS 保持一致。
- * 到期后放行一次探测:成功清熔断,失败重新阻断。
+ * 到期后放行一次探测:成功清熔断,失败重新阻断并递增 probeCount。
  */
 const MODEL_BLOCK_TTL_MS = 30 * 60_000;
+/**
+ * 自动重探上限:首次阻断后最多再放行这么多次探测,避免对永久无效模型
+ * 每 30 分钟无限出网 (PR #2288 Greptile P1)。达到上限后继续 snooze 但
+ * 不再调 embed(),直至应用重启清空 blockedModels。
+ */
+const MODEL_BLOCK_MAX_REPROBES = 2;
 
 /**
  * 只有 INVALID_MODEL 才触发永久熔断。
@@ -98,10 +104,14 @@ export class EmbeddingWorker {
    * INVALID_MODEL (错误体明确包含 model_not_found) 熔断表。
    *
    * TTL 与 DB 层 TERMINAL_SNOOZE_MS 一致 (30 分钟):阻断期间新 job snooze 不出网,
-   * TTL 到期后放行一次探测;探测成功则清除条目,失败则重新阻断。这样网关短暂误报或
-   * 模型恢复后无需重启应用即可自动续跑 (PR #2288 review)。
+   * TTL 到期且 probeCount < MAX_REPROBES 时放行一次探测;探测成功则清除条目,
+   * 失败则重新阻断并递增 probeCount。达到重探上限后停止出网,等重启再试,
+   * 避免对永久无效模型无限周期请求 (PR #2288 review)。
    */
-  private readonly blockedModels = new Map<string, { error: string; blockedAt: number }>();
+  private readonly blockedModels = new Map<
+    string,
+    { error: string; blockedAt: number; probeCount: number }
+  >();
   // 关闭 / 切账号时由 stop() 置 true。in-flight tick 在每个 await 点之后检查它,
   // 一旦为 true 就立刻放弃后续写库直接返回 —— 那批 job 保持 status='pending',
   // 下次启动自动续跑 (零丢失)。目的是退出时让 worker 立即让出 SQLite 写连接,
@@ -328,25 +338,31 @@ export class EmbeddingWorker {
         const blocked = this.blockedModels.get(modelId);
         if (blocked !== undefined) {
           const age = Date.now() - blocked.blockedAt;
-          if (age < MODEL_BLOCK_TTL_MS) {
-            // 熔断 TTL 内:snooze 这批,不出网。
+          if (age < MODEL_BLOCK_TTL_MS || blocked.probeCount >= MODEL_BLOCK_MAX_REPROBES) {
+            // 熔断 TTL 内,或已耗尽自动重探次数:snooze 这批,不出网。
+            // 重启会清空 blockedModels,届时再给一轮新的探测预算。
             await this.recordFailureBatch(modelJobs, blocked.error, true);
+            if (this.aborted) return;
             this.opts.log.debug?.(
               JSON.stringify({
                 event: 'embeddingWorker.batch.skip.invalidModel',
                 modelId,
                 count: modelJobs.length,
-                remainingMs: MODEL_BLOCK_TTL_MS - age,
+                remainingMs: age < MODEL_BLOCK_TTL_MS ? MODEL_BLOCK_TTL_MS - age : 0,
+                probeCount: blocked.probeCount,
               }),
             );
             continue;
           }
-          // TTL 到期:清除熔断,放行一次探测。成功则正常写入,失败会在 catch 中重新阻断。
-          this.blockedModels.delete(modelId);
+          // TTL 到期且仍有探测预算:重置阻断窗口、递增 probeCount,放行一次探测。
+          // 成功会在下面删除条目;失败 catch 会刷新 blockedAt 并保留 probeCount。
+          blocked.blockedAt = Date.now();
+          blocked.probeCount++;
           this.opts.log.info(
             JSON.stringify({
               event: 'embeddingWorker.model.blockExpired.reprobe',
               modelId,
+              probeCount: blocked.probeCount,
             }),
           );
         }
@@ -362,8 +378,19 @@ export class EmbeddingWorker {
           // 写事务 (这是保证 db.backup 无争用的关键)。该批 job 保持 pending, 下次续跑。
           if (this.aborted) return;
           if (isProviderSuspended(source)) break;
+          // 探测成功 — 若之前熔断过,清除条目恢复正常节奏。
+          if (this.blockedModels.has(modelId)) {
+            this.blockedModels.delete(modelId);
+            this.opts.log.info(
+              JSON.stringify({
+                event: 'embeddingWorker.model.unblocked',
+                modelId,
+              }),
+            );
+          }
           // 5. 同步事务: INSERT vec + UPDATE jobs
           await this.commitEmbeddings(modelJobs, res.embeddings);
+          if (this.aborted) return;
           doneCount += modelJobs.length;
           this.opts.log.info(
             JSON.stringify({
@@ -399,12 +426,19 @@ export class EmbeddingWorker {
           const errorText = `[${code}] ${msg}`;
           const terminal = isTerminalInvalidModelError(err);
           if (terminal) {
-            this.blockedModels.set(modelId, { error: errorText, blockedAt: Date.now() });
+            // 若是 TTL 到期后的重探失败,保留已累计的 probeCount;否则从 0 开始。
+            const prev = this.blockedModels.get(modelId);
+            this.blockedModels.set(modelId, {
+              error: errorText,
+              blockedAt: Date.now(),
+              probeCount: prev?.probeCount ?? 0,
+            });
             this.opts.log.warn(
               JSON.stringify({
                 event: 'embeddingWorker.model.blocked.invalidModel',
                 modelId,
                 reason: msg,
+                probeCount: prev?.probeCount ?? 0,
               }),
             );
           }

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -39,6 +39,11 @@ import {
 
 const TICK_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 32;
+/**
+ * 熔断 TTL,必须与 DB 层 TERMINAL_SNOOZE_MS 保持一致。
+ * 到期后放行一次探测:成功清熔断,失败重新阻断。
+ */
+const MODEL_BLOCK_TTL_MS = 30 * 60_000;
 
 /**
  * 只有 INVALID_MODEL 才触发永久熔断。
@@ -90,11 +95,13 @@ export class EmbeddingWorker {
   private vecWarned = false;
   private suspendedWarned = false;
   /**
-   * 只有 INVALID_MODEL (错误体明确包含 model_not_found) 不会自愈。按进程生命周期记住它:
-   * 后续新 job 本地终止, 避免每 5 秒继续打同一个必败请求。400/422 输入错误、404 路由
-   * 错误等均走退避重试, 让网关或模型配置修复后无需重启即可恢复。
+   * INVALID_MODEL (错误体明确包含 model_not_found) 熔断表。
+   *
+   * TTL 与 DB 层 TERMINAL_SNOOZE_MS 一致 (30 分钟):阻断期间新 job snooze 不出网,
+   * TTL 到期后放行一次探测;探测成功则清除条目,失败则重新阻断。这样网关短暂误报或
+   * 模型恢复后无需重启应用即可自动续跑 (PR #2288 review)。
    */
-  private readonly blockedModels = new Map<string, string>();
+  private readonly blockedModels = new Map<string, { error: string; blockedAt: number }>();
   // 关闭 / 切账号时由 stop() 置 true。in-flight tick 在每个 await 点之后检查它,
   // 一旦为 true 就立刻放弃后续写库直接返回 —— 那批 job 保持 status='pending',
   // 下次启动自动续跑 (零丢失)。目的是退出时让 worker 立即让出 SQLite 写连接,
@@ -318,18 +325,30 @@ export class EmbeddingWorker {
           );
           continue;
         }
-        const blockedError = this.blockedModels.get(modelId);
-        if (blockedError !== undefined) {
-          const fc = await this.recordFailureBatch(modelJobs, blockedError, true);
-          failCount += fc;
-          this.opts.log.debug?.(
+        const blocked = this.blockedModels.get(modelId);
+        if (blocked !== undefined) {
+          const age = Date.now() - blocked.blockedAt;
+          if (age < MODEL_BLOCK_TTL_MS) {
+            // 熔断 TTL 内:snooze 这批,不出网。
+            await this.recordFailureBatch(modelJobs, blocked.error, true);
+            this.opts.log.debug?.(
+              JSON.stringify({
+                event: 'embeddingWorker.batch.skip.invalidModel',
+                modelId,
+                count: modelJobs.length,
+                remainingMs: MODEL_BLOCK_TTL_MS - age,
+              }),
+            );
+            continue;
+          }
+          // TTL 到期:清除熔断,放行一次探测。成功则正常写入,失败会在 catch 中重新阻断。
+          this.blockedModels.delete(modelId);
+          this.opts.log.info(
             JSON.stringify({
-              event: 'embeddingWorker.batch.skip.invalidModel',
+              event: 'embeddingWorker.model.blockExpired.reprobe',
               modelId,
-              count: modelJobs.length,
             }),
           );
-          continue;
         }
         const inputs = modelJobs.map((j) => textByRowid.get(j.rowid) as string);
         try {
@@ -380,7 +399,7 @@ export class EmbeddingWorker {
           const errorText = `[${code}] ${msg}`;
           const terminal = isTerminalInvalidModelError(err);
           if (terminal) {
-            this.blockedModels.set(modelId, errorText);
+            this.blockedModels.set(modelId, { error: errorText, blockedAt: Date.now() });
             this.opts.log.warn(
               JSON.stringify({
                 event: 'embeddingWorker.model.blocked.invalidModel',

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -8,7 +8,7 @@
  *   4. 剩下有 text 的按 model_id 再分组, 同组一次 client.embed()
  *   5. 成功 → 一个事务内: INSERT INTO {vec_table}(rowid, embedding) + UPDATE jobs.status='done'
  *   6. 失败 → attempts++, last_error, scheduled_at += 退避; attempts >= MAX → status='failed'
- *      INVALID_MODEL 是确定性配置错误:首批直接 failed,本进程内同模型后续批次不再请求 API。
+ *      只有明确的 404 模型不存在才是确定性配置错误:首批直接 failed,本进程内同模型后续批次不再请求 API。
  *
  * 重要约束 (better-sqlite3 同步事务 vs async embed):
  *   embed() 是 async, 不能在 db.transaction 内 await; 所以流程是
@@ -37,6 +37,15 @@ import {
 
 const TICK_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 32;
+
+/**
+ * INVALID_MODEL 也承载参数不兼容和未分类 4xx，不能据此永久失败整个模型队列。
+ * 目前 XD Gateway 仅以 404 明确表示目标模型不存在；其它状态保留重试路径，给配置
+ * 修复或瞬时网关故障恢复的机会。
+ */
+function isTerminalInvalidModelError(error: unknown): boolean {
+  return error instanceof EmbeddingError && error.code === 'INVALID_MODEL' && error.status === 404;
+}
 
 interface JobRow {
   rowid: number;
@@ -76,9 +85,9 @@ export class EmbeddingWorker {
   private vecWarned = false;
   private suspendedWarned = false;
   /**
-   * INVALID_MODEL 原样重试不会自愈。按进程生命周期记住它:后续新 job 本地终止,
-   * 避免每 5 秒继续打同一个必败请求。应用重启会清空,让修复后的网关/模型配置
-   * 有一次重新探测的机会。
+   * 只有上游明确的 404 模型不存在不会自愈。按进程生命周期记住它:后续新 job 本地终止,
+   * 避免每 5 秒继续打同一个必败请求。普通 4xx 仍走退避重试,让网关或模型配置修复后
+   * 无需重启即可恢复。
    */
   private readonly blockedModels = new Map<string, string>();
   // 关闭 / 切账号时由 stop() 置 true。in-flight tick 在每个 await 点之后检查它,
@@ -356,7 +365,7 @@ export class EmbeddingWorker {
             }),
           );
           const errorText = `[${code}] ${msg}`;
-          const terminal = code === 'INVALID_MODEL';
+          const terminal = isTerminalInvalidModelError(err);
           if (terminal) {
             this.blockedModels.set(modelId, errorText);
             this.opts.log.warn(

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -425,6 +425,20 @@ export class EmbeddingWorker {
           );
           const errorText = `[${code}] ${msg}`;
           const terminal = isTerminalInvalidModelError(err);
+          // 若是 TTL 到期后的重探失败且不是 INVALID_MODEL (例如 NETWORK_ERROR /
+          // RATE_LIMITED / SERVER_ERROR),清熔断让这批走普通退避,不要消耗 probeCount
+          // 也不要让本可恢复的瞬时错误把模型永久冻住 (PR #2288 Codex P1)。
+          if (this.blockedModels.has(modelId) && !terminal) {
+            this.blockedModels.delete(modelId);
+            this.opts.log.info(
+              JSON.stringify({
+                event: 'embeddingWorker.model.unblockOnTransient',
+                modelId,
+                code,
+                error: msg,
+              }),
+            );
+          }
           if (terminal) {
             // 若是 TTL 到期后的重探失败,保留已累计的 probeCount;否则从 0 开始。
             const prev = this.blockedModels.get(modelId);

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -336,6 +336,10 @@ export class EmbeddingWorker {
           continue;
         }
         const blocked = this.blockedModels.get(modelId);
+        // Set when this tick performs a TTL-expired reprobe; the catch block
+        // rolls blockedAt back to this value if the probe is interrupted by a
+        // route suspension so the budget is not consumed by a non-result.
+        let probeStartedAt: number | undefined;
         if (blocked !== undefined) {
           const now = Date.now();
           const age = now - blocked.blockedAt;
@@ -365,10 +369,14 @@ export class EmbeddingWorker {
             );
             continue;
           }
-          // TTL 到期且仍有探测预算:重置阻断窗口、递增 probeCount,放行一次探测。
-          // 成功会在下面删除条目;失败 catch 会刷新 blockedAt 并保留 probeCount。
+          // TTL 到期且仍有探测预算:放行一次探测。不在此处递增 probeCount —
+          // 预算只在探测**再次确认 INVALID_MODEL** 时才消耗(catch 的 terminal
+          // 分支);瞬时错误、探测期间模型被停用 / stop() 都不应消耗这次预算,否则
+          // 两次偶发故障或停用-重启就会让已恢复的模型在重启前永不再探
+          // (PR #2288 Codex/Greptile P1)。刷新 blockedAt 作为探测起点,失败时
+          // catch 会按结果决定是保留、刷新还是回滚。
+          probeStartedAt = blocked.blockedAt;
           blocked.blockedAt = Date.now();
-          blocked.probeCount++;
           this.opts.log.info(
             JSON.stringify({
               event: 'embeddingWorker.model.blockExpired.reprobe',
@@ -414,6 +422,9 @@ export class EmbeddingWorker {
             }),
           );
         } catch (err) {
+          // Snapshot before any early-out so the route-suspended branch below
+          // can roll back the pre-probe blockedAt refresh.
+          const prev = this.blockedModels.get(modelId);
           // stop() 可能在 embed() 网络往返期间触发:此时不应记录熔断或写失败状态,
           // 那批 job 保持 pending, 下次启动续跑 (PR #2288 review)。
           if (this.aborted) return;
@@ -421,7 +432,13 @@ export class EmbeddingWorker {
           if (isProviderSuspended(source)) break;
           // 逐模型停用也可能在网络往返期间发生:该批保持 pending,恢复启用后续跑,
           // 不要把它写成 failed / 写进 blockedModels (PR #2288 review)。
-          if (this.opts.isRouteSuspended?.(modelId as string)) continue;
+          // 回滚探测前刷新的 blockedAt 且不递增 probeCount:这次探测被停用打断,
+          // 不算一次确认,模型重新启用后下个 TTL 窗口应能再次探测而不是被预算耗尽
+          // 永久冻结 (PR #2288 Greptile P1)。
+          if (this.opts.isRouteSuspended?.(modelId as string)) {
+            if (prev && probeStartedAt !== undefined) prev.blockedAt = probeStartedAt;
+            continue;
+          }
           const code = err instanceof EmbeddingError ? err.code : 'UNKNOWN';
           const msg = err instanceof Error ? err.message : String(err);
           this.opts.log.error(
@@ -436,21 +453,23 @@ export class EmbeddingWorker {
           );
           const errorText = `[${code}] ${msg}`;
           const terminal = isTerminalInvalidModelError(err);
-          const prev = this.blockedModels.get(modelId);
           if (terminal) {
-            // 重探确认 INVALID_MODEL:刷新阻断窗口,保留已累计的 probeCount
-            // (不能因中间夹了一次瞬时错误就清零,否则两次重探上限永远耗不尽)。
+            // 首次熔断(无 prev)probeCount 记 0(还没执行过重探);TTL 到期后
+            // 的重探再次确认 INVALID_MODEL 才 +1 消耗预算。瞬时错误不计数,探测
+            // 被停用打断也不计数(见上方 probeStartedAt 回滚),让已恢复模型不会
+            // 因偶发故障耗尽预算 (PR #2288 Codex/Greptile P1)。
+            const nextProbeCount = prev ? prev.probeCount + 1 : 0;
             this.blockedModels.set(modelId, {
               error: errorText,
               blockedAt: Date.now(),
-              probeCount: prev?.probeCount ?? 0,
+              probeCount: nextProbeCount,
             });
             this.opts.log.warn(
               JSON.stringify({
                 event: 'embeddingWorker.model.blocked.invalidModel',
                 modelId,
                 reason: msg,
-                probeCount: prev?.probeCount ?? 0,
+                probeCount: nextProbeCount,
               }),
             );
           } else if (prev) {

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -8,7 +8,8 @@
  *   4. 剩下有 text 的按 model_id 再分组, 同组一次 client.embed()
  *   5. 成功 → 一个事务内: INSERT INTO {vec_table}(rowid, embedding) + UPDATE jobs.status='done'
  *   6. 失败 → attempts++, last_error, scheduled_at += 退避; attempts >= MAX → status='failed'
- *      只有明确的 404 模型不存在才是确定性配置错误:首批直接 failed,本进程内同模型后续批次不再请求 API。
+ *      只有错误体明确包含 model_not_found 信号 (由 mapStatusToCode 归类为 INVALID_MODEL)
+ *      才是确定性配置错误:首批直接 failed,本进程内同模型后续批次不再请求 API。
  *
  * 重要约束 (better-sqlite3 同步事务 vs async embed):
  *   embed() 是 async, 不能在 db.transaction 内 await; 所以流程是
@@ -39,12 +40,15 @@ const TICK_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 32;
 
 /**
- * INVALID_MODEL 也承载参数不兼容和未分类 4xx，不能据此永久失败整个模型队列。
- * 目前 XD Gateway 仅以 404 明确表示目标模型不存在；其它状态保留重试路径，给配置
- * 修复或瞬时网关故障恢复的机会。
+ * 只有 INVALID_MODEL 才触发永久熔断。
+ *
+ * mapStatusToCode 已收紧:仅在错误体明确包含 model_not_found / deployment_not_found
+ * 等确定性信号时才将 HTTP 错误归类为 INVALID_MODEL;400/422 输入错误映射为
+ * BAD_REQUEST,404 路由错误映射为 TRANSIENT_ERROR,均不触发熔断。维度不匹配等
+ * 客户端本地判定的 INVALID_MODEL 同样是确定性的模型/参数不兼容,不可自愈。
  */
 function isTerminalInvalidModelError(error: unknown): boolean {
-  return error instanceof EmbeddingError && error.code === 'INVALID_MODEL' && error.status === 404;
+  return error instanceof EmbeddingError && error.code === 'INVALID_MODEL';
 }
 
 interface JobRow {
@@ -85,9 +89,9 @@ export class EmbeddingWorker {
   private vecWarned = false;
   private suspendedWarned = false;
   /**
-   * 只有上游明确的 404 模型不存在不会自愈。按进程生命周期记住它:后续新 job 本地终止,
-   * 避免每 5 秒继续打同一个必败请求。普通 4xx 仍走退避重试,让网关或模型配置修复后
-   * 无需重启即可恢复。
+   * 只有 INVALID_MODEL (错误体明确包含 model_not_found) 不会自愈。按进程生命周期记住它:
+   * 后续新 job 本地终止, 避免每 5 秒继续打同一个必败请求。400/422 输入错误、404 路由
+   * 错误等均走退避重试, 让网关或模型配置修复后无需重启即可恢复。
    */
   private readonly blockedModels = new Map<string, string>();
   // 关闭 / 切账号时由 stop() 置 true。in-flight tick 在每个 await 点之后检查它,
@@ -299,6 +303,20 @@ export class EmbeddingWorker {
       // 4. 按 model_id 分组调 embed
       const byModel = groupBy(liveJobs, (j) => j.model_id);
       for (const [modelId, modelJobs] of byModel.entries()) {
+        // 逐模型停用(PR #744 review 第十九轮):该 embedding 模型被点名停用时本组
+        // 不下单,job 保持 pending,恢复启用后续跑。
+        // 必须在 blockedModels 熔断检查之前:模型被用户停用时新任务应保持 pending,
+        // 而不是被熔断标为 failed (PR #2288 review)。
+        if (this.opts.isRouteSuspended?.(modelId as string)) {
+          this.opts.log.warn(
+            JSON.stringify({
+              event: 'embeddingWorker.tick.skip.modelDisabled',
+              modelId,
+              count: modelJobs.length,
+            }),
+          );
+          continue;
+        }
         const blockedError = this.blockedModels.get(modelId);
         if (blockedError !== undefined) {
           const fc = await this.recordFailureBatch(modelJobs, blockedError, true);
@@ -306,18 +324,6 @@ export class EmbeddingWorker {
           this.opts.log.debug?.(
             JSON.stringify({
               event: 'embeddingWorker.batch.skip.invalidModel',
-              modelId,
-              count: modelJobs.length,
-            }),
-          );
-          continue;
-        }
-        // 逐模型停用(PR #744 review 第十九轮):该 embedding 模型被点名停用时本组
-        // 不下单,job 保持 pending,恢复启用后续跑。
-        if (this.opts.isRouteSuspended?.(modelId as string)) {
-          this.opts.log.warn(
-            JSON.stringify({
-              event: 'embeddingWorker.tick.skip.modelDisabled',
               modelId,
               count: modelJobs.length,
             }),
@@ -350,6 +356,9 @@ export class EmbeddingWorker {
             }),
           );
         } catch (err) {
+          // stop() 可能在 embed() 网络往返期间触发:此时不应记录熔断或写失败状态,
+          // 那批 job 保持 pending, 下次启动续跑 (PR #2288 review)。
+          if (this.aborted) return;
           // availability 可能在网络往返期间丢失;保留 pending,不要把它记成失败重试。
           if (isProviderSuspended(source)) break;
           const code = err instanceof EmbeddingError ? err.code : 'UNKNOWN';

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -337,13 +337,21 @@ export class EmbeddingWorker {
         }
         const blocked = this.blockedModels.get(modelId);
         if (blocked !== undefined) {
-          const age = Date.now() - blocked.blockedAt;
+          const now = Date.now();
+          const age = now - blocked.blockedAt;
           if (age < MODEL_BLOCK_TTL_MS || blocked.probeCount >= MODEL_BLOCK_MAX_REPROBES) {
             // 熔断 TTL 内,或已耗尽自动重探次数:snooze 这批,不出网。
-            // 按当前窗口结束时刻排程(而不是 now + 30min),否则第 29 分钟到达的
-            // 任务会被排到第 59 分钟,即使第 30 分钟探测已成功也不会提前恢复
-            // (PR #2288 Codex P1)。
-            const snoozeUntil = blocked.blockedAt + MODEL_BLOCK_TTL_MS;
+            // TTL 内按当前窗口结束时刻排程(而不是 now + 30min),否则第 29 分钟
+            // 到达的任务会被排到第 59 分钟,即使第 30 分钟探测已成功也不会提前
+            // 恢复 (PR #2288 Codex P1)。
+            // 预算已耗尽时窗口可能已经过期,blockedAt + TTL 会是过去时刻 → 这批
+            // 任务会每个 5 秒 tick 都被选中、重复写库、挤占其他模型的待处理配额
+            // (调度热循环);此时它们要等重启清空 blockedModels 才会再探,排到
+            // now + TTL 的未来时刻,既避免热循环也保持 snooze 语义 (Greptile/Codex P1)。
+            const withinWindow = age < MODEL_BLOCK_TTL_MS;
+            const snoozeUntil = withinWindow
+              ? blocked.blockedAt + MODEL_BLOCK_TTL_MS
+              : now + MODEL_BLOCK_TTL_MS;
             await this.recordFailureBatch(modelJobs, blocked.error, true, snoozeUntil);
             if (this.aborted) return;
             this.opts.log.debug?.(
@@ -461,7 +469,13 @@ export class EmbeddingWorker {
               }),
             );
           }
-          const fc = await this.recordFailureBatch(modelJobs, errorText, terminal);
+          // 正在熔断/重探期间的失败(无论是再次确认 INVALID_MODEL,还是重探遇到瞬时
+          // 错误)都按 terminal 记录:snooze 到下一窗口、不递增 attempts。否则一个已
+          // 累计了若干普通失败的任务会因重探的瞬时错误被推到 MAX_ATTEMPTS 永久写
+          // failed,模型恢复或重启后也不再续跑 (PR #2288 Greptile P1)。首次进入熔断
+          // 前的普通失败仍走 terminal=false 的正常退避。
+          const snoozeTerminal = terminal || prev !== undefined;
+          const fc = await this.recordFailureBatch(modelJobs, errorText, snoozeTerminal);
           failCount += fc;
         }
       }

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -8,6 +8,7 @@
  *   4. 剩下有 text 的按 model_id 再分组, 同组一次 client.embed()
  *   5. 成功 → 一个事务内: INSERT INTO {vec_table}(rowid, embedding) + UPDATE jobs.status='done'
  *   6. 失败 → attempts++, last_error, scheduled_at += 退避; attempts >= MAX → status='failed'
+ *      INVALID_MODEL 是确定性配置错误:首批直接 failed,本进程内同模型后续批次不再请求 API。
  *
  * 重要约束 (better-sqlite3 同步事务 vs async embed):
  *   embed() 是 async, 不能在 db.transaction 内 await; 所以流程是
@@ -74,6 +75,12 @@ export class EmbeddingWorker {
   private lastTickProcessed: number | null = null;
   private vecWarned = false;
   private suspendedWarned = false;
+  /**
+   * INVALID_MODEL 原样重试不会自愈。按进程生命周期记住它:后续新 job 本地终止,
+   * 避免每 5 秒继续打同一个必败请求。应用重启会清空,让修复后的网关/模型配置
+   * 有一次重新探测的机会。
+   */
+  private readonly blockedModels = new Map<string, string>();
   // 关闭 / 切账号时由 stop() 置 true。in-flight tick 在每个 await 点之后检查它,
   // 一旦为 true 就立刻放弃后续写库直接返回 —— 那批 job 保持 status='pending',
   // 下次启动自动续跑 (零丢失)。目的是退出时让 worker 立即让出 SQLite 写连接,
@@ -283,6 +290,19 @@ export class EmbeddingWorker {
       // 4. 按 model_id 分组调 embed
       const byModel = groupBy(liveJobs, (j) => j.model_id);
       for (const [modelId, modelJobs] of byModel.entries()) {
+        const blockedError = this.blockedModels.get(modelId);
+        if (blockedError !== undefined) {
+          const fc = await this.recordFailureBatch(modelJobs, blockedError, true);
+          failCount += fc;
+          this.opts.log.debug?.(
+            JSON.stringify({
+              event: 'embeddingWorker.batch.skip.invalidModel',
+              modelId,
+              count: modelJobs.length,
+            }),
+          );
+          continue;
+        }
         // 逐模型停用(PR #744 review 第十九轮):该 embedding 模型被点名停用时本组
         // 不下单,job 保持 pending,恢复启用后续跑。
         if (this.opts.isRouteSuspended?.(modelId as string)) {
@@ -335,10 +355,19 @@ export class EmbeddingWorker {
               count: modelJobs.length,
             }),
           );
-          // AUTH_FAILED / INVALID_MODEL 在 client 内已经判断为不可重试 — 但 worker 这层
-          // 不分代码, 一律走 backoff + attempts 计数, MAX_ATTEMPTS 后 → 'failed'。
-          // 这样 INVALID_MODEL 不会立刻冲 5 次烧 token, 因为 client 抛错前没打 API。
-          const fc = await this.recordFailureBatch(modelJobs, `[${code}] ${msg}`);
+          const errorText = `[${code}] ${msg}`;
+          const terminal = code === 'INVALID_MODEL';
+          if (terminal) {
+            this.blockedModels.set(modelId, errorText);
+            this.opts.log.warn(
+              JSON.stringify({
+                event: 'embeddingWorker.model.blocked.invalidModel',
+                modelId,
+                reason: msg,
+              }),
+            );
+          }
+          const fc = await this.recordFailureBatch(modelJobs, errorText, terminal);
           failCount += fc;
         }
       }
@@ -390,12 +419,17 @@ export class EmbeddingWorker {
    * attempts >= MAX → status='failed' 终态。
    * 返回失败数量 (>= MAX 进 'failed' 终态的部分)。
    */
-  private async recordFailureBatch(jobs: JobRow[], errMsg: string): Promise<number> {
+  private async recordFailureBatch(
+    jobs: JobRow[],
+    errMsg: string,
+    terminal = false,
+  ): Promise<number> {
     const now = Date.now();
     const result = await this.opts.getDbClient().tx('embedding.recordFailures', {
       jobs: jobs.map((job) => ({ rowid: job.rowid, attempts: job.attempts })),
       errMsg: truncate(errMsg, 2000),
       now,
+      terminal,
     });
     return result.failCount;
   }

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -8,8 +8,8 @@
  *   4. 剩下有 text 的按 model_id 再分组, 同组一次 client.embed()
  *   5. 成功 → 一个事务内: INSERT INTO {vec_table}(rowid, embedding) + UPDATE jobs.status='done'
  *   6. 失败 → attempts++, last_error, scheduled_at += 退避; attempts >= MAX → status='failed'
- *      只有错误体明确包含 model_not_found 信号 (由 mapStatusToCode 归类为 INVALID_MODEL)
- *      才是确定性配置错误:首批直接 failed,本进程内同模型后续批次不再请求 API。
+ *      INVALID_MODEL (确定性模型不可用) → snooze (保持 pending, 不增加 attempts,
+ *      推后 scheduled_at 30 分钟); 进程内 blockedModels 短路出网, 重启后重新探测。
  *
  * 重要约束 (better-sqlite3 同步事务 vs async embed):
  *   embed() 是 async, 不能在 db.transaction 内 await; 所以流程是
@@ -17,6 +17,7 @@
  *
  * 重试退避由 worker 侧 embedding.recordFailures tx 统一计算;
  *   attempts >= tx 内部上限时不再 schedule, 走 status='failed'。
+ *   terminal (INVALID_MODEL) 走 snooze 而非 failed, 避免网关误报导致永久索引缺失。
  *
  * 不做:
  *   - 不并发 (单 worker 串行, 简单可预期; 真到瓶颈再说)

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -361,6 +361,9 @@ export class EmbeddingWorker {
           if (this.aborted) return;
           // availability 可能在网络往返期间丢失;保留 pending,不要把它记成失败重试。
           if (isProviderSuspended(source)) break;
+          // 逐模型停用也可能在网络往返期间发生:该批保持 pending,恢复启用后续跑,
+          // 不要把它写成 failed / 写进 blockedModels (PR #2288 review)。
+          if (this.opts.isRouteSuspended?.(modelId as string)) continue;
           const code = err instanceof EmbeddingError ? err.code : 'UNKNOWN';
           const msg = err instanceof Error ? err.message : String(err);
           this.opts.log.error(

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -425,23 +425,10 @@ export class EmbeddingWorker {
           );
           const errorText = `[${code}] ${msg}`;
           const terminal = isTerminalInvalidModelError(err);
-          // 若是 TTL 到期后的重探失败且不是 INVALID_MODEL (例如 NETWORK_ERROR /
-          // RATE_LIMITED / SERVER_ERROR),清熔断让这批走普通退避,不要消耗 probeCount
-          // 也不要让本可恢复的瞬时错误把模型永久冻住 (PR #2288 Codex P1)。
-          if (this.blockedModels.has(modelId) && !terminal) {
-            this.blockedModels.delete(modelId);
-            this.opts.log.info(
-              JSON.stringify({
-                event: 'embeddingWorker.model.unblockOnTransient',
-                modelId,
-                code,
-                error: msg,
-              }),
-            );
-          }
+          const prev = this.blockedModels.get(modelId);
           if (terminal) {
-            // 若是 TTL 到期后的重探失败,保留已累计的 probeCount;否则从 0 开始。
-            const prev = this.blockedModels.get(modelId);
+            // 重探确认 INVALID_MODEL:刷新阻断窗口,保留已累计的 probeCount
+            // (不能因中间夹了一次瞬时错误就清零,否则两次重探上限永远耗不尽)。
             this.blockedModels.set(modelId, {
               error: errorText,
               blockedAt: Date.now(),
@@ -453,6 +440,21 @@ export class EmbeddingWorker {
                 modelId,
                 reason: msg,
                 probeCount: prev?.probeCount ?? 0,
+              }),
+            );
+          } else if (prev) {
+            // TTL 重探遇到瞬时错误 (NETWORK / RATE_LIMITED / 5xx):不删除条目,
+            // 刷新 blockedAt 重新开始 30 分钟 snooze,同时保留 probeCount。
+            // 删除会导致下一次 INVALID_MODEL 以 probeCount=0 重建,预算永远耗不尽
+            // (PR #2288 Greptile P1)。
+            prev.blockedAt = Date.now();
+            this.opts.log.info(
+              JSON.stringify({
+                event: 'embeddingWorker.model.reprobeTransient',
+                modelId,
+                code,
+                error: msg,
+                probeCount: prev.probeCount,
               }),
             );
           }

--- a/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
+++ b/apps/desktop/src/main/embedding-host/EmbeddingWorker.ts
@@ -396,7 +396,17 @@ export class EmbeddingWorker {
           // 退出检查点: embed() 网络往返期间可能已触发 stop(), 绝不在 abort 后再开
           // 写事务 (这是保证 db.backup 无争用的关键)。该批 job 保持 pending, 下次续跑。
           if (this.aborted) return;
-          if (isProviderSuspended(source)) break;
+          if (isProviderSuspended(source)) {
+            // source 探测期间被停用:回滚本次探测刷新的 blockedAt,让 source
+            // 恢复后仍能进入重探窗口,而不是被探测开始时刻卡住多休眠完整 TTL
+            // (PR #2288 Codex P1)。entry 仍保留(探测未确认 INVALID_MODEL),
+            // probeCount 也不消耗 —— 与 isRouteSuspended(modelId) 处理保持一致。
+            if (probeStartedAt !== undefined) {
+              const entry = this.blockedModels.get(modelId);
+              if (entry) entry.blockedAt = probeStartedAt;
+            }
+            break;
+          }
           // 探测成功 — 若之前熔断过,清除条目恢复正常节奏。
           if (this.blockedModels.has(modelId)) {
             this.blockedModels.delete(modelId);
@@ -429,7 +439,13 @@ export class EmbeddingWorker {
           // 那批 job 保持 pending, 下次启动续跑 (PR #2288 review)。
           if (this.aborted) return;
           // availability 可能在网络往返期间丢失;保留 pending,不要把它记成失败重试。
-          if (isProviderSuspended(source)) break;
+          if (isProviderSuspended(source)) {
+            // 探测被 source 停用打断:回滚探测前刷新的 blockedAt 且不递增 probeCount,
+            // 与 isRouteSuspended(modelId) 处理一致 —— 这次不算一次确认,source
+            // 重新启用后下个 TTL 窗口应能再次探测 (PR #2288 Codex P1)。
+            if (prev && probeStartedAt !== undefined) prev.blockedAt = probeStartedAt;
+            break;
+          }
           // 逐模型停用也可能在网络往返期间发生:该批保持 pending,恢复启用后续跑,
           // 不要把它写成 failed / 写进 blockedModels (PR #2288 review)。
           // 回滚探测前刷新的 blockedAt 且不递增 probeCount:这次探测被停用打断,

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -57,15 +57,17 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
     });
   });
 
-  it('keeps ordinary invalid-model 4xx failures retryable for later batches', async () => {
+  it('keeps ordinary 4xx input/routing errors retryable for later batches', async () => {
     const batches = [[job(1, 'first')], [job(2, 'second')]];
     const query = vi.fn(async () => batches.shift() ?? []);
     const tx = vi.fn(async (_name: string, args: FailureArgs) => ({
       failCount: args.jobs.length,
     }));
+    // 400 without model_not_found body maps to BAD_REQUEST, not INVALID_MODEL;
+    // 404 routing error maps to TRANSIENT_ERROR. Neither triggers permanent circuit breaker.
     const embed = vi
       .fn()
-      .mockRejectedValueOnce(new EmbeddingError('gateway rejected the request', 'INVALID_MODEL', 400))
+      .mockRejectedValueOnce(new EmbeddingError('input too large', 'BAD_REQUEST', 400))
       .mockResolvedValueOnce({ embeddings: [[0.1]], tokensUsed: 0, cacheHits: 0 });
 
     registerProvider({

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -101,7 +101,7 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
 
   it('re-probes the model after the block TTL expires instead of snoozing forever', async () => {
     // Tick 1: model returns INVALID_MODEL → blocked.
-    // After 30 min TTL: tick 2 should delete the block and call embed() again
+    // After 30 min TTL: tick 2 should allow a probe and call embed() again
     // instead of silently snoozing the batch (PR #2288 Codex P1).
     vi.useFakeTimers();
     try {
@@ -140,6 +140,59 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       await tick();
 
       expect(embed).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops re-probing after the reprobe budget is exhausted (PR #2288 Greptile P1)', async () => {
+    // A genuinely invalid model should not be hit every 30 minutes forever.
+    // After MODEL_BLOCK_MAX_REPROBES failed reprobes, the worker keeps snoozing
+    // without calling embed() until restart.
+    vi.useFakeTimers();
+    try {
+      let now = new Date('2026-08-21T12:00:00Z').getTime();
+      vi.setSystemTime(now);
+      let rowid = 0;
+      const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
+      const tx = vi.fn(async () => ({ failCount: 0 }));
+      const embed = vi.fn(async () => {
+        throw new EmbeddingError('model not found', 'INVALID_MODEL', 404);
+      });
+
+      registerProvider({
+        source: 'chat',
+        getTextsForJobs: async (jobs) =>
+          jobs.map(({ rowid: r, sourceId }) => ({ rowid: r, text: sourceId })),
+      });
+
+      const worker = new EmbeddingWorker({
+        getDbClient: () => ({ query, tx }) as never,
+        getClient: () => ({ embed }) as never,
+        isVecAvailable: () => true,
+        log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+      // Tick 1: initial block.
+      await tick();
+      const callsAfterFirst = embed.mock.calls.length;
+
+      // Two TTL windows: each may use one reprobe attempt.
+      for (let i = 0; i < 2; i++) {
+        now += 31 * 60_000;
+        vi.setSystemTime(now);
+        await tick();
+      }
+      const callsAfterReprobes = embed.mock.calls.length;
+      // 1 initial + 2 reprobes = 3 calls.
+      expect(callsAfterReprobes).toBe(callsAfterFirst + 2);
+
+      // Third TTL window: reprobe budget exhausted, snooze only, no more embed().
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed.mock.calls.length).toBe(callsAfterReprobes);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -288,15 +288,18 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       const tx = vi.fn(async () => ({ failCount: 0 }));
       const embed = vi
         .fn()
-        // Tick 1: initial INVALID_MODEL
+        // Tick 1: initial INVALID_MODEL (probeCount 0)
         .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
-        // TTL 1: first reprobe — transient error
+        // TTL 1: first reprobe — transient error; this does NOT consume the
+        // reprobe budget (probeCount stays 0), otherwise a recovered model
+        // could be frozen forever by two transient failures.
         .mockRejectedValueOnce(new EmbeddingError('connection reset', 'NETWORK_ERROR'))
-        // TTL 2: second reprobe — INVALID_MODEL (probeCount should be 1)
+        // TTL 2: second reprobe — INVALID_MODEL, probeCount 0→1
         .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
-        // TTL 3: third reprobe — INVALID_MODEL (probeCount should be 2, at cap)
+        // TTL 3: third reprobe — INVALID_MODEL, probeCount 1→2 (at cap)
         .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
-        // After cap exhausted, should NOT call embed again
+        // TTL 4: cap exhausted, should NOT call embed; this success must not
+        // be reached.
         .mockResolvedValueOnce({ embeddings: [[0.1]], tokensUsed: 0, cacheHits: 0 });
 
       registerProvider({
@@ -313,29 +316,103 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       });
       const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
 
-      // Tick 1: initial block.
+      // Tick 1: initial block (probeCount 0).
       await tick();
       expect(embed).toHaveBeenCalledTimes(1);
 
-      // TTL 1: first reprobe (probeCount 0→1) returns transient error.
+      // TTL 1: first reprobe returns a transient error. The transient result
+      // does NOT consume the reprobe budget (probeCount stays 0), so the model
+      // is not frozen by a recoverable network blip.
       now += 31 * 60_000;
       vi.setSystemTime(now);
       await tick();
       expect(embed).toHaveBeenCalledTimes(2);
 
-      // TTL 2: second reprobe (probeCount should still be 1, increments to 2)
-      // returns INVALID_MODEL.
+      // TTL 2: second reprobe confirms INVALID_MODEL — probeCount 0→1.
       now += 31 * 60_000;
       vi.setSystemTime(now);
       await tick();
       expect(embed).toHaveBeenCalledTimes(3);
 
-      // TTL 3: probeCount is now 2 (== MAX_REPROBES), so embed must NOT be
-      // called — the batch is snoozed without a network call.
+      // TTL 3: third reprobe confirms INVALID_MODEL again — probeCount 1→2
+      // (== MAX_REPROBES).
       now += 31 * 60_000;
       vi.setSystemTime(now);
       await tick();
-      expect(embed).toHaveBeenCalledTimes(3); // still 3, not 4
+      expect(embed).toHaveBeenCalledTimes(4);
+
+      // TTL 4: budget exhausted, embed must NOT be called — batch snoozes
+      // without a network call until restart.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(4); // still 4, not 5
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not consume reprobe budget when the model is disabled mid-probe (PR #2288 Greptile P1)', async () => {
+    // A TTL-expired reprobe that is interrupted by the user disabling the
+    // model is not a confirmation of INVALID_MODEL, so it must not increment
+    // probeCount. Otherwise two disable/enable cycles would exhaust the budget
+    // and a recovered model would stop being probed until restart.
+    vi.useFakeTimers();
+    try {
+      let now = new Date('2026-08-21T12:00:00Z').getTime();
+      vi.setSystemTime(now);
+      let rowid = 0;
+      const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
+      const tx = vi.fn(async () => ({ failCount: 0 }));
+      let suspended = false;
+      const embed = vi.fn(async () => {
+        // Flip suspended during the first reprobe so the catch sees the route
+        // disabled.
+        if (embed.mock.calls.length === 2) suspended = true;
+        throw new EmbeddingError('model not found', 'INVALID_MODEL', 404);
+      });
+
+      registerProvider({
+        source: 'chat',
+        getTextsForJobs: async (jobs) =>
+          jobs.map(({ rowid: r, sourceId }) => ({ rowid: r, text: sourceId })),
+      });
+
+      const worker = new EmbeddingWorker({
+        getDbClient: () => ({ query, tx }) as never,
+        getClient: () => ({ embed }) as never,
+        isVecAvailable: () => true,
+        isRouteSuspended: () => suspended,
+        log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+      // Tick 1: initial INVALID_MODEL block.
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(1);
+
+      // TTL 1: reprobe interrupted by suspension — budget not consumed.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      suspended = false;
+      await tick();
+      // The embed call during suspension still happens (probe is dispatched
+      // before the post-call suspended check), but probeCount must stay 0.
+      expect(embed).toHaveBeenCalledTimes(2);
+
+      // TTL 2: model still disabled — short-circuit, no embed call.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(2);
+
+      // Re-enable and let the TTL pass — the model must be probed again
+      // (budget was not exhausted by the interrupted probe).
+      suspended = false;
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(3);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -198,6 +198,56 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
     }
   });
 
+  it('unblocks on transient reprobe failure so it does not consume the reprobe budget (PR #2288 Codex P1)', async () => {
+    // After TTL expiry the model gets reprobed. If the reprobe fails with a
+    // recoverable error (NETWORK_ERROR / RATE_LIMITED / 5xx), the block must
+    // be lifted so the next tick retries via the normal backoff instead of
+    // wasting the model's already-spent probe budget.
+    vi.useFakeTimers();
+    try {
+      let now = new Date('2026-08-21T12:00:00Z').getTime();
+      vi.setSystemTime(now);
+      let rowid = 0;
+      const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
+      const tx = vi.fn(async () => ({ failCount: 0 }));
+      const embed = vi
+        .fn()
+        .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
+        .mockRejectedValueOnce(new EmbeddingError('connection reset', 'NETWORK_ERROR'))
+        .mockResolvedValueOnce({ embeddings: [[0.1]], tokensUsed: 0, cacheHits: 0 });
+
+      registerProvider({
+        source: 'chat',
+        getTextsForJobs: async (jobs) =>
+          jobs.map(({ rowid: r, sourceId }) => ({ rowid: r, text: sourceId })),
+      });
+
+      const worker = new EmbeddingWorker({
+        getDbClient: () => ({ query, tx }) as never,
+        getClient: () => ({ embed }) as never,
+        isVecAvailable: () => true,
+        log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(1);
+
+      // TTL elapses; first reprobe hits a transient error and must unblock.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(2);
+
+      // Block should now be gone — next tick calls embed() immediately without
+      // waiting another TTL window.
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps the batch pending when the model is disabled during an in-flight INVALID_MODEL failure', async () => {
     // embed() in-flight -> user disables the model -> request fails with INVALID_MODEL.
     // The catch branch must re-check isRouteSuspended(modelId) and NOT write a terminal

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -99,6 +99,52 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
     });
   });
 
+  it('re-probes the model after the block TTL expires instead of snoozing forever', async () => {
+    // Tick 1: model returns INVALID_MODEL → blocked.
+    // After 30 min TTL: tick 2 should delete the block and call embed() again
+    // instead of silently snoozing the batch (PR #2288 Codex P1).
+    vi.useFakeTimers();
+    try {
+      const T0 = new Date('2026-08-21T12:00:00Z').getTime();
+      vi.setSystemTime(T0);
+      const batches = [[job(1, 'first')], [job(2, 'second')]];
+      const query = vi.fn(async () => batches.shift() ?? []);
+      const tx = vi.fn(async (_name: string, args?: FailureArgs) => ({
+        failCount: args?.jobs?.length ?? 0,
+      }));
+      const embed = vi
+        .fn()
+        .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
+        .mockResolvedValueOnce({ embeddings: [[0.1]], tokensUsed: 0, cacheHits: 0 });
+
+      registerProvider({
+        source: 'chat',
+        getTextsForJobs: async (jobs) =>
+          jobs.map(({ rowid, sourceId }) => ({ rowid, text: sourceId })),
+      });
+
+      const worker = new EmbeddingWorker({
+        getDbClient: () => ({ query, tx }) as never,
+        getClient: () => ({ embed }) as never,
+        isVecAvailable: () => true,
+        log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(1);
+      expect(tx.mock.calls[0]?.[1]).toMatchObject({ terminal: true });
+
+      // Advance past the 30-minute TTL; next tick must re-probe, not snooze.
+      vi.setSystemTime(T0 + 31 * 60_000);
+      await tick();
+
+      expect(embed).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('keeps the batch pending when the model is disabled during an in-flight INVALID_MODEL failure', async () => {
     // embed() in-flight -> user disables the model -> request fails with INVALID_MODEL.
     // The catch branch must re-check isRouteSuspended(modelId) and NOT write a terminal

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -13,14 +13,14 @@ interface FailureArgs {
 describe('EmbeddingWorker invalid-model circuit breaker', () => {
   afterEach(() => clearProviders());
 
-  it('fails the first batch immediately and skips API calls for later batches of that model', async () => {
+  it('fails the first 404 batch immediately and skips API calls for later batches of that model', async () => {
     const batches = [[job(1, 'first')], [job(2, 'second')]];
     const query = vi.fn(async () => batches.shift() ?? []);
     const tx = vi.fn(async (_name: string, args: FailureArgs) => ({
       failCount: args.jobs.length,
     }));
     const embed = vi.fn(async () => {
-      throw new EmbeddingError('model is unsupported', 'INVALID_MODEL', 400);
+      throw new EmbeddingError('model is unsupported', 'INVALID_MODEL', 404);
     });
 
     registerProvider({
@@ -54,6 +54,46 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
     expect(tx.mock.calls[1]?.[1]).toMatchObject({
       jobs: [{ rowid: 2, attempts: 0 }],
       terminal: true,
+    });
+  });
+
+  it('keeps ordinary invalid-model 4xx failures retryable for later batches', async () => {
+    const batches = [[job(1, 'first')], [job(2, 'second')]];
+    const query = vi.fn(async () => batches.shift() ?? []);
+    const tx = vi.fn(async (_name: string, args: FailureArgs) => ({
+      failCount: args.jobs.length,
+    }));
+    const embed = vi
+      .fn()
+      .mockRejectedValueOnce(new EmbeddingError('gateway rejected the request', 'INVALID_MODEL', 400))
+      .mockResolvedValueOnce({ embeddings: [[0.1]], tokensUsed: 0, cacheHits: 0 });
+
+    registerProvider({
+      source: 'chat',
+      getTextsForJobs: async (jobs) =>
+        jobs.map(({ rowid, sourceId }) => ({ rowid, text: sourceId })),
+    });
+
+    const worker = new EmbeddingWorker({
+      getDbClient: () => ({ query, tx }) as never,
+      getClient: () => ({ embed }) as never,
+      isVecAvailable: () => true,
+      log: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+    const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+    await tick();
+    await tick();
+
+    expect(embed).toHaveBeenCalledTimes(2);
+    expect(tx.mock.calls[0]?.[1]).toMatchObject({
+      jobs: [{ rowid: 1, attempts: 0 }],
+      terminal: false,
     });
   });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -1,0 +1,71 @@
+import { EmbeddingError } from '@cindy/embedding-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { EmbeddingWorker } from '../EmbeddingWorker';
+import { clearProviders, registerProvider } from '../providers';
+
+interface FailureArgs {
+  jobs: Array<{ rowid: number; attempts: number }>;
+  errMsg: string;
+  terminal?: boolean;
+}
+
+describe('EmbeddingWorker invalid-model circuit breaker', () => {
+  afterEach(() => clearProviders());
+
+  it('fails the first batch immediately and skips API calls for later batches of that model', async () => {
+    const batches = [[job(1, 'first')], [job(2, 'second')]];
+    const query = vi.fn(async () => batches.shift() ?? []);
+    const tx = vi.fn(async (_name: string, args: FailureArgs) => ({
+      failCount: args.jobs.length,
+    }));
+    const embed = vi.fn(async () => {
+      throw new EmbeddingError('model is unsupported', 'INVALID_MODEL', 400);
+    });
+
+    registerProvider({
+      source: 'chat',
+      getTextsForJobs: async (jobs) =>
+        jobs.map(({ rowid, sourceId }) => ({ rowid, text: sourceId })),
+    });
+
+    const worker = new EmbeddingWorker({
+      getDbClient: () => ({ query, tx }) as never,
+      getClient: () => ({ embed }) as never,
+      isVecAvailable: () => true,
+      log: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+    const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+    await tick();
+    await tick();
+
+    expect(embed).toHaveBeenCalledTimes(1);
+    expect(tx).toHaveBeenCalledTimes(2);
+    expect(tx.mock.calls[0]?.[1]).toMatchObject({
+      jobs: [{ rowid: 1, attempts: 0 }],
+      terminal: true,
+    });
+    expect(tx.mock.calls[1]?.[1]).toMatchObject({
+      jobs: [{ rowid: 2, attempts: 0 }],
+      terminal: true,
+    });
+  });
+});
+
+function job(rowid: number, sourceId: string) {
+  return {
+    rowid,
+    source: 'chat',
+    source_id: sourceId,
+    chunk_index: 0,
+    model_id: 'voyage/voyage-4',
+    vec_table: 'chat_vec',
+    attempts: 0,
+  };
+}

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -98,6 +98,51 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       terminal: false,
     });
   });
+
+  it('keeps the batch pending when the model is disabled during an in-flight INVALID_MODEL failure', async () => {
+    // embed() in-flight -> user disables the model -> request fails with INVALID_MODEL.
+    // The catch branch must re-check isRouteSuspended(modelId) and NOT write a terminal
+    // failure / blockedModels entry, otherwise re-enabling the model later won't
+    // re-index these rows (PR #2288 review).
+    const batches = [[job(1, 'first')], [job(2, 'second')]];
+    const query = vi.fn(async () => batches.shift() ?? []);
+    const tx = vi.fn(async (_name: string, args: FailureArgs) => ({
+      failCount: args.jobs.length,
+    }));
+    let routeSuspended = false;
+    const embed = vi.fn(async () => {
+      // Flip "user disabled model" while the request is in flight, before it rejects.
+      routeSuspended = true;
+      throw new EmbeddingError('model not found', 'INVALID_MODEL', 404);
+    });
+
+    registerProvider({
+      source: 'chat',
+      getTextsForJobs: async (jobs) =>
+        jobs.map(({ rowid, sourceId }) => ({ rowid, text: sourceId })),
+    });
+
+    const worker = new EmbeddingWorker({
+      getDbClient: () => ({ query, tx }) as never,
+      getClient: () => ({ embed }) as never,
+      isVecAvailable: () => true,
+      isRouteSuspended: () => routeSuspended,
+      log: {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as never,
+    });
+    const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+    await tick();
+
+    // embed() was called once; the failure must NOT have been recorded as a terminal
+    // batch — those jobs stay pending so they resume when the model is re-enabled.
+    expect(embed).toHaveBeenCalledTimes(1);
+    expect(tx).not.toHaveBeenCalled();
+  });
 });
 
 function job(rowid: number, sourceId: string) {

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -198,11 +198,12 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
     }
   });
 
-  it('unblocks on transient reprobe failure so it does not consume the reprobe budget (PR #2288 Codex P1)', async () => {
-    // After TTL expiry the model gets reprobed. If the reprobe fails with a
-    // recoverable error (NETWORK_ERROR / RATE_LIMITED / 5xx), the block must
-    // be lifted so the next tick retries via the normal backoff instead of
-    // wasting the model's already-spent probe budget.
+  it('preserves probeCount across a transient reprobe failure (PR #2288 Greptile P1)', async () => {
+    // TTL-expired reprobe hits a transient error: block entry stays (blockedAt
+    // refreshed) but probeCount is NOT reset. If the next reprobe after TTL
+    // returns INVALID_MODEL, probeCount must accumulate so the max-reprobe
+    // cap can still be reached — otherwise the budget never exhausts and a
+    // permanently invalid model gets probed forever.
     vi.useFakeTimers();
     try {
       let now = new Date('2026-08-21T12:00:00Z').getTime();
@@ -212,8 +213,15 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       const tx = vi.fn(async () => ({ failCount: 0 }));
       const embed = vi
         .fn()
+        // Tick 1: initial INVALID_MODEL
         .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
+        // TTL 1: first reprobe — transient error
         .mockRejectedValueOnce(new EmbeddingError('connection reset', 'NETWORK_ERROR'))
+        // TTL 2: second reprobe — INVALID_MODEL (probeCount should be 1)
+        .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
+        // TTL 3: third reprobe — INVALID_MODEL (probeCount should be 2, at cap)
+        .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
+        // After cap exhausted, should NOT call embed again
         .mockResolvedValueOnce({ embeddings: [[0.1]], tokensUsed: 0, cacheHits: 0 });
 
       registerProvider({
@@ -230,19 +238,29 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       });
       const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
 
+      // Tick 1: initial block.
       await tick();
       expect(embed).toHaveBeenCalledTimes(1);
 
-      // TTL elapses; first reprobe hits a transient error and must unblock.
+      // TTL 1: first reprobe (probeCount 0→1) returns transient error.
       now += 31 * 60_000;
       vi.setSystemTime(now);
       await tick();
       expect(embed).toHaveBeenCalledTimes(2);
 
-      // Block should now be gone — next tick calls embed() immediately without
-      // waiting another TTL window.
+      // TTL 2: second reprobe (probeCount should still be 1, increments to 2)
+      // returns INVALID_MODEL.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
       await tick();
       expect(embed).toHaveBeenCalledTimes(3);
+
+      // TTL 3: probeCount is now 2 (== MAX_REPROBES), so embed must NOT be
+      // called — the batch is snoozed without a network call.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(3); // still 3, not 4
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -155,10 +155,11 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       vi.setSystemTime(now);
       let rowid = 0;
       const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
-      const tx = vi.fn(async () => ({ failCount: 0 }));
+      const tx = vi.fn(async (_name: string, _args: Record<string, unknown>) => ({ failCount: 0 }));
       const embed = vi.fn(async () => {
         throw new EmbeddingError('model not found', 'INVALID_MODEL', 404);
       });
+      const TTL = 30 * 60_000;
 
       registerProvider({
         source: 'chat',
@@ -193,6 +194,80 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       vi.setSystemTime(now);
       await tick();
       expect(embed.mock.calls.length).toBe(callsAfterReprobes);
+
+      // The exhausted-budget snooze must schedule into the FUTURE (now + TTL),
+      // not blockedAt + TTL which is already in the past once the window
+      // expired — otherwise the batch is re-selected every 5s tick and rewrites
+      // the DB in a hot loop, starving other models (PR #2288 Greptile/Codex P1).
+      const exhaustedCall = tx.mock.calls.find(
+        (call): call is [string, { terminal?: boolean; snoozeUntil?: number }] =>
+          call[0] === 'embedding.recordFailures'
+          && call[1]?.terminal === true
+          && typeof call[1]?.snoozeUntil === 'number'
+          && (call[1]?.snoozeUntil ?? 0) >= now,
+      );
+      expect(exhaustedCall).toBeDefined();
+      expect(exhaustedCall?.[1].snoozeUntil).toBe(now + TTL);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('snoozes a transient reprobe failure without consuming retry attempts (PR #2288 Greptile P1)', async () => {
+    // When a TTL-expired reprobe hits a transient error (NETWORK / RATE_LIMITED
+    // / 5xx) while already circuit-broken, the batch must be snoozed (terminal,
+    // attempts NOT incremented) rather than recorded as an ordinary failure —
+    // a job already near MAX_ATTEMPTS would otherwise be permanently marked
+    // failed by the transient error and never resume after the model recovers.
+    vi.useFakeTimers();
+    try {
+      let now = new Date('2026-08-21T12:00:00Z').getTime();
+      vi.setSystemTime(now);
+      let rowid = 0;
+      const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`), attempts: 4 }]);
+      const tx = vi.fn(async (_name: string, _args: Record<string, unknown>) => ({ failCount: 0 }));
+      const embed = vi
+        .fn()
+        .mockRejectedValueOnce(new EmbeddingError('model not found', 'INVALID_MODEL', 404))
+        .mockRejectedValueOnce(new EmbeddingError('connection reset', 'NETWORK_ERROR'));
+
+      registerProvider({
+        source: 'chat',
+        getTextsForJobs: async (jobs) =>
+          jobs.map(({ rowid: r, sourceId }) => ({ rowid: r, text: sourceId })),
+      });
+
+      const worker = new EmbeddingWorker({
+        getDbClient: () => ({ query, tx }) as never,
+        getClient: () => ({ embed }) as never,
+        isVecAvailable: () => true,
+        log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+      // Tick 1: initial INVALID_MODEL block.
+      await tick();
+      // TTL 1: reprobe hits NETWORK_ERROR.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(2);
+
+      // The transient reprobe failure must be recorded as terminal (snooze,
+      // attempts not incremented) so failCount stays 0 even though the job
+      // entered with attempts=4 (one ordinary failure from permanent fail).
+      const failureCalls = tx.mock.calls.filter(
+        (call): call is [string, { terminal?: boolean; snoozeUntil?: number }] =>
+          call[0] === 'embedding.recordFailures',
+      );
+      expect(failureCalls.length).toBeGreaterThan(0);
+      const lastFailure = failureCalls.at(-1)![1];
+      expect(lastFailure.terminal).toBe(true);
+      // Snooze is either explicit (short-circuit path) or defaults to now +
+      // TTL in the DB layer; either way it must not be a past timestamp.
+      if (lastFailure.snoozeUntil !== undefined) {
+        expect(lastFailure.snoozeUntil).toBeGreaterThanOrEqual(now);
+      }
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -2,7 +2,7 @@ import { EmbeddingError } from '@cindy/embedding-client';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { EmbeddingWorker } from '../EmbeddingWorker';
-import { clearProviders, registerProvider } from '../providers';
+import { clearProviders, registerProvider, setProviderSuspended } from '../providers';
 
 interface FailureArgs {
   jobs: Array<{ rowid: number; attempts: number }>;
@@ -414,6 +414,128 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       await tick();
       expect(embed).toHaveBeenCalledTimes(3);
     } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('source suspended mid-TTL-reprobe (success path) rolls back blockedAt so re-enable is not blocked by the probe-start timestamp (PR #2288 Codex P1)', async () => {
+    // TTL-expired reprobe that happens to land while the user briefly suspends
+    // the source: the post-embed `isProviderSuspended(source)` check kicks in,
+    // the entry must roll its blockedAt back to the pre-probe timestamp so that
+    // once the source is re-enabled the worker can reprobe on the very next
+    // tick — instead of waiting a full TTL because age is computed from
+    // Date.now() of the probe start.
+    vi.useFakeTimers();
+    try {
+      let now = new Date('2026-08-21T12:00:00Z').getTime();
+      vi.setSystemTime(now);
+      let rowid = 0;
+      const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
+      const tx = vi.fn(async () => ({ failCount: 0 }));
+      const embed = vi.fn(async () => {
+        // Flip source-suspended during the reprobe — embeddings resolve
+        // successfully but the post-call source check sees the suspension.
+        setProviderSuspended('chat', true);
+        return { embeddings: [new Array(10).fill(0.1)], tokensUsed: 0, cacheHits: 0 };
+      });
+
+      registerProvider({
+        source: 'chat',
+        getTextsForJobs: async (jobs) =>
+          jobs.map(({ rowid: r, sourceId }) => ({ rowid: r, text: sourceId })),
+      });
+
+      const worker = new EmbeddingWorker({
+        getDbClient: () => ({ query, tx }) as never,
+        getClient: () => ({ embed }) as never,
+        isVecAvailable: () => true,
+        log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+      // Tick 1: initial INVALID_MODEL block.
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(1);
+
+      // TTL 1: reprobe runs, succeeds, but source is now suspended. The
+      // blockedAt must roll back to the pre-probe timestamp, otherwise the
+      // entry would age as "just blocked" for the next full TTL.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(2);
+
+      // Re-enable source shortly after (well inside the original TTL window).
+      // If blockedAt was correctly rolled back, age is now > TTL again
+      // (since we advanced 31m from the original block); the next tick must
+      // dispatch another reprobe immediately. If the bug were present,
+      // blockedAt would be Date.now() at the reprobe start and age would be
+      // ~0 here, skipping the reprobe.
+      setProviderSuspended('chat', false);
+      now += 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(3);
+    } finally {
+      setProviderSuspended('chat', false);
+      vi.useRealTimers();
+    }
+  });
+
+  it('source suspended mid-TTL-reprobe (error path) rolls back blockedAt and does not consume probeCount (PR #2288 Codex P1)', async () => {
+    // Same scenario as the success-path case but the reprobe itself fails.
+    // The catch's source-suspended branch must also roll back blockedAt to
+    // the pre-probe timestamp and not count this interrupted probe as a
+    // confirmation — otherwise two disable/enable cycles would exhaust the
+    // budget and the model would stop being probed until restart.
+    vi.useFakeTimers();
+    try {
+      let now = new Date('2026-08-21T12:00:00Z').getTime();
+      vi.setSystemTime(now);
+      let rowid = 0;
+      const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
+      const tx = vi.fn(async () => ({ failCount: 0 }));
+      const embed = vi.fn(async () => {
+        if (embed.mock.calls.length === 2) setProviderSuspended('chat', true);
+        throw new EmbeddingError('model not found', 'INVALID_MODEL', 404);
+      });
+
+      registerProvider({
+        source: 'chat',
+        getTextsForJobs: async (jobs) =>
+          jobs.map(({ rowid: r, sourceId }) => ({ rowid: r, text: sourceId })),
+      });
+
+      const worker = new EmbeddingWorker({
+        getDbClient: () => ({ query, tx }) as never,
+        getClient: () => ({ embed }) as never,
+        isVecAvailable: () => true,
+        log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      });
+      const tick = (worker as unknown as { tick: () => Promise<void> }).tick.bind(worker);
+
+      // Tick 1: initial block.
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(1);
+
+      // Tick 2: TTL reprobe, source flips to suspended on this call.
+      now += 31 * 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(2);
+
+      // Re-enable after a short interval. If blockedAt was correctly rolled
+      // back, age is well past TTL (we moved 31m from the original block) and
+      // the next tick must dispatch another reprobe. If the bug were
+      // present, blockedAt would be Date.now() at the reprobe start, age
+      // would be ~0, and we'd stay inside the window (no reprobe).
+      setProviderSuspended('chat', false);
+      now += 60_000;
+      vi.setSystemTime(now);
+      await tick();
+      expect(embed).toHaveBeenCalledTimes(3);
+    } finally {
+      setProviderSuspended('chat', false);
       vi.useRealTimers();
     }
   });

--- a/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/EmbeddingWorker.test.ts
@@ -432,9 +432,14 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       let rowid = 0;
       const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
       const tx = vi.fn(async () => ({ failCount: 0 }));
+      let embedCallCount = 0;
       const embed = vi.fn(async () => {
-        // Flip source-suspended during the reprobe — embeddings resolve
-        // successfully but the post-call source check sees the suspension.
+        embedCallCount++;
+        if (embedCallCount === 1) {
+          // Initial block.
+          throw new EmbeddingError('model is unsupported', 'INVALID_MODEL', 404);
+        }
+        // TTL reprobe: source flips to suspended, embeddings still succeed.
         setProviderSuspended('chat', true);
         return { embeddings: [new Array(10).fill(0.1)], tokensUsed: 0, cacheHits: 0 };
       });
@@ -457,21 +462,22 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       await tick();
       expect(embed).toHaveBeenCalledTimes(1);
 
-      // TTL 1: reprobe runs, succeeds, but source is now suspended. The
-      // blockedAt must roll back to the pre-probe timestamp, otherwise the
-      // entry would age as "just blocked" for the next full TTL.
+      // Tick 2: TTL expires, reprobe runs and flips source-suspended.
       now += 31 * 60_000;
       vi.setSystemTime(now);
       await tick();
       expect(embed).toHaveBeenCalledTimes(2);
 
-      // Re-enable source shortly after (well inside the original TTL window).
-      // If blockedAt was correctly rolled back, age is now > TTL again
-      // (since we advanced 31m from the original block); the next tick must
-      // dispatch another reprobe immediately. If the bug were present,
-      // blockedAt would be Date.now() at the reprobe start and age would be
-      // ~0 here, skipping the reprobe.
+      // Re-enable source before the next tick so the SQL filter at the top
+      // of tick() does not drop 'chat' jobs outright.
       setProviderSuspended('chat', false);
+
+      // Advance another minute (32m total from the original block). If
+      // blockedAt was correctly rolled back to the pre-probe timestamp,
+      // age is well past TTL and the next tick must dispatch another
+      // reprobe. If the bug were present, blockedAt would be Date.now()
+      // at the reprobe start, age would be ~1m, and the tick would stay
+      // inside the window (no reprobe).
       now += 60_000;
       vi.setSystemTime(now);
       await tick();
@@ -495,8 +501,15 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       let rowid = 0;
       const query = vi.fn(async () => [{ ...job(++rowid, `msg-${rowid}`) }]);
       const tx = vi.fn(async () => ({ failCount: 0 }));
+      let embedCallCount = 0;
       const embed = vi.fn(async () => {
-        if (embed.mock.calls.length === 2) setProviderSuspended('chat', true);
+        embedCallCount++;
+        if (embedCallCount === 1) {
+          // Initial block.
+          throw new EmbeddingError('model is unsupported', 'INVALID_MODEL', 404);
+        }
+        // TTL reprobe: source flips to suspended, request still rejects.
+        setProviderSuspended('chat', true);
         throw new EmbeddingError('model not found', 'INVALID_MODEL', 404);
       });
 
@@ -524,12 +537,13 @@ describe('EmbeddingWorker invalid-model circuit breaker', () => {
       await tick();
       expect(embed).toHaveBeenCalledTimes(2);
 
-      // Re-enable after a short interval. If blockedAt was correctly rolled
-      // back, age is well past TTL (we moved 31m from the original block) and
-      // the next tick must dispatch another reprobe. If the bug were
-      // present, blockedAt would be Date.now() at the reprobe start, age
-      // would be ~0, and we'd stay inside the window (no reprobe).
+      // Re-enable source before the next tick so the SQL filter at the top
+      // of tick() does not drop 'chat' jobs outright.
       setProviderSuspended('chat', false);
+
+      // Tick 3 must dispatch another reprobe. Same reasoning as the
+      // success-path test: blockedAt must be rolled back so age is well
+      // past TTL by now.
       now += 60_000;
       vi.setSystemTime(now);
       await tick();

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1053,3 +1053,60 @@ describe('EmbeddingClient · 坐标必须是有限数字', () => {
     ).rejects.toThrow(/document 0 chunk 0 embedding is not an array \(got string\)/);
   });
 });
+
+/**
+ * 构造一个固定 status + body 的假响应,用来断言 mapStatusToCode 对各种错误体的归类。
+ * 这些路径过去出过"误把瞬时 4xx 当模型不存在导致整进程熔断"的 bug (PR #2288 review)。
+ */
+function errorResponse(status: number, body: unknown) {
+  return vi.fn(
+    async () =>
+      new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+  );
+}
+
+describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () => {
+  it('LiteLLM 400 "Invalid model name" → INVALID_MODEL', async () => {
+    const fetchImpl = errorResponse(400, { error: { message: 'Invalid model name' } });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
+  });
+
+  it('Anthropic 风格 400 "model: xxx not found" → INVALID_MODEL', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: voyage/voyage-4 not found' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
+  });
+
+  it('OpenAI 404 "The model `x` does not exist" → INVALID_MODEL', async () => {
+    const fetchImpl = errorResponse(404, {
+      error: { message: 'The model `voyage/voyage-4` does not exist' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
+  });
+
+  it('400 纯输入错误 "input too large" → BAD_REQUEST,不熔断', async () => {
+    const fetchImpl = errorResponse(400, { error: { message: 'input too large' } });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"invalid model input" 是参数错误而非模型不存在 → BAD_REQUEST', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'invalid model input: expected array of strings' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+});

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1143,4 +1143,22 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
   });
+
+  it('"unknown_model_parameter" 下划线机器码不误判 → BAD_REQUEST (PR #2288 Codex P2)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'unknown_model_parameter: dimensions' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"unknown-model-input" 连字符机器码不误判 → BAD_REQUEST (PR #2288 Codex P2)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'unknown-model-input: dimension too small' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1134,4 +1134,13 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
   });
+
+  it('"model \'x\' is unsupported" 是模型不存在 → INVALID_MODEL (PR #2288 Codex P1)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: "model 'voyage/voyage-4' is unsupported" },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
+  });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1161,4 +1161,22 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
+
+  it('"model input is unsupported" 参数错误不误判 → BAD_REQUEST (PR #2288 Codex P2)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model input is unsupported for this endpoint' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"model parameter x is unsupported" 参数错误不误判 → BAD_REQUEST', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: "model parameter 'dimensions' is unsupported" },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1109,4 +1109,29 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
+
+  it('"unknown model parameter" 是参数错误而非模型不存在 → BAD_REQUEST (PR #2288 Codex P1)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'unknown model parameter: dimensions' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"model input field was not found" 是参数错误而非模型不存在 → BAD_REQUEST (PR #2288 Codex P1)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model input field was not found in request body' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"unknown model" 后直接结束(无参数词) 仍是模型不存在 → INVALID_MODEL', async () => {
+    const fetchImpl = errorResponse(400, { error: { message: 'unknown model' } });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
+  });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1264,7 +1264,7 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
   it('JSON 体内 model 与无关 not found 共存不误判 → BAD_REQUEST (PR #2288 Codex P1 L818)', async () => {
     // 错误体里同时出现 "model":"<id>" 与另一个字段的 "... not found" 描述,
     // L818 旧版贪婪 [^\n]{0,80} 会跨字段命中 not found,误判为 INVALID_MODEL。
-    // 修复后 ID 段不允许含 JSON 结构字符 (`"` `,` `{` `}`),跨字段不会成立。
+    // 修复后 ID 段不允许含 JSON 跨字段字符 (`,` `{` `}`),跨字段不会成立。
     const fetchImpl = errorResponse(
       400,
       '{"model":"glm-5","error":"input field not found in request body"}',
@@ -1272,5 +1272,35 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
     await expect(
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('双引号包裹 ID "model \\"glm-5\\" not found" 仍识别为 INVALID_MODEL (PR #2288 L818 双引号回归)', async () => {
+    // OpenAI 等网关会把模型 ID 用 "<id>" 包裹;L818 中间段若排除引号会把这种
+    // 正常 INVALID_MODEL 误判为 BAD_REQUEST。修复用 [^,\n{}] 而非 [^"\n,{}],
+    // 允许 ID 段内出现包裹引号。
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: "glm-5" not found' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
+  });
+
+  it('单引号包裹 ID "model \'glm-5\' was not found" 仍识别为 INVALID_MODEL', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: "model 'glm-5' was not found" },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
+  });
+
+  it('双引号包裹 ID 出现在 model 后空格处 "model \\"glm-5\\" was not found" 仍识别为 INVALID_MODEL', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model "glm-5" was not found' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
   });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1179,4 +1179,40 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
+
+  it('"The model input field does not exist" 参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L823)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'The model input field does not exist in request body' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"The model parameter does not exist" 参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L823)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'The model parameter does not exist in request body' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"model: input is unsupported" 冒号分支参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L833)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: input is unsupported for this endpoint' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"model: parameter dimensions is unsupported" 冒号分支参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L833)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: parameter dimensions is unsupported' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1215,4 +1215,40 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
+
+  it('"The model input_field does not exist" 下划线机器码不误判 → BAD_REQUEST (PR #2288 Codex P1 L823 下划线回归)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'The model input_field does not exist in request body' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"The model parameter_name does not exist" 下划线机器码不误判 → BAD_REQUEST (PR #2288 Codex P1 L823 下划线回归)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'The model parameter_name does not exist in request body' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"model: input_field is unsupported" 冒号分支下划线机器码不误判 → BAD_REQUEST (PR #2288 Codex P1 L833 下划线回归)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: input_field is unsupported for this endpoint' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"model: parameter_name is unsupported" 冒号分支下划线机器码不误判 → BAD_REQUEST (PR #2288 Codex P1 L833 下划线回归)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: parameter_name is unsupported' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1251,4 +1251,26 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
+
+  it('"model: input field not found" 参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L818)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: input field not found in request body' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('JSON 体内 model 与无关 not found 共存不误判 → BAD_REQUEST (PR #2288 Codex P1 L818)', async () => {
+    // 错误体里同时出现 "model":"<id>" 与另一个字段的 "... not found" 描述,
+    // L818 旧版贪婪 [^\n]{0,80} 会跨字段命中 not found,误判为 INVALID_MODEL。
+    // 修复后 ID 段不允许含 JSON 结构字符 (`"` `,` `{` `}`),跨字段不会成立。
+    const fetchImpl = errorResponse(
+      400,
+      '{"model":"glm-5","error":"input field not found in request body"}',
+    );
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
 });

--- a/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
+++ b/apps/desktop/src/main/embedding-host/__tests__/embeddingClientWire.test.ts
@@ -1198,6 +1198,15 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
+  it('"The model schema validation failed: property dimensions does not exist" 不跨段误判 → BAD_REQUEST (PR #2288 Codex P1)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'The model schema validation failed: property dimensions does not exist' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
   it('"model: input is unsupported" 冒号分支参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L833)', async () => {
     const fetchImpl = errorResponse(400, {
       error: { message: 'model: input is unsupported for this endpoint' },
@@ -1210,6 +1219,15 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
   it('"model: parameter dimensions is unsupported" 冒号分支参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L833)', async () => {
     const fetchImpl = errorResponse(400, {
       error: { message: 'model: parameter dimensions is unsupported' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"model: glm-5; parameter dimensions is unsupported" 不吞入后续参数 → BAD_REQUEST (PR #2288 Codex P1)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'model: glm-5; parameter dimensions is unsupported' },
     });
     await expect(
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
@@ -1250,6 +1268,33 @@ describe('EmbeddingClient · mapStatusToCode (INVALID_MODEL 熔断信号)', () =
     await expect(
       clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"invalid model: input must be an array" 冒号后的参数错误不误判 → BAD_REQUEST (PR #2288 Codex P2)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'invalid model: input must be an array' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"invalid_model: parameter dimensions is unsupported" 冒号后的参数错误不误判 → BAD_REQUEST (PR #2288 Codex P2)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'invalid_model: parameter dimensions is unsupported' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('"invalid model: voyage/voyage-4" 仍识别为 INVALID_MODEL (PR #2288 Codex P2 正向回归)', async () => {
+    const fetchImpl = errorResponse(400, {
+      error: { message: 'invalid model: voyage/voyage-4' },
+    });
+    await expect(
+      clientWith(fetchImpl).embed({ texts: ['a'], model: 'voyage/voyage-4' }),
+    ).rejects.toMatchObject({ code: 'INVALID_MODEL' });
   });
 
   it('"model: input field not found" 参数错误不误判 → BAD_REQUEST (PR #2288 Codex P1 L818)', async () => {

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1530,7 +1530,7 @@ function embeddingRecordFailures(readyDb, args) {
   const terminal = payload.terminal === true;
   const snoozeUntil = typeof payload.snoozeUntil === 'number' ? payload.snoozeUntil : now + TERMINAL_SNOOZE_MS;
   const updReschedule = readyDb.prepare('UPDATE embedding_jobs SET attempts = ?, last_error = ?, scheduled_at = ? WHERE rowid = ?');
-  const updSnooze = readyDb.prepare('UPDATE embedding_jobs SET last_error = ?, scheduled_at = ? WHERE rowid = ?');
+  const updSnooze = readyDb.prepare('UPDATE embedding_jobs SET attempts = 0, last_error = ?, scheduled_at = ? WHERE rowid = ?');
   const updFail = readyDb.prepare("UPDATE embedding_jobs SET attempts = ?, last_error = ?, status = 'failed' WHERE rowid = ?");
   const failCount = readyDb.transaction(() => {
     let count = 0;

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1516,6 +1516,10 @@ function embeddingRecordFailures(readyDb, args) {
   const jobs = expectArray(payload.jobs, 'jobs');
   const errMsg = truncate(expectString(payload.errMsg, 'errMsg'), 2000);
   const now = expectNumber(payload.now, 'now');
+  if (payload.terminal !== undefined && typeof payload.terminal !== 'boolean') {
+    throw invalidArgs('terminal must be boolean');
+  }
+  const terminal = payload.terminal === true;
   const updReschedule = readyDb.prepare('UPDATE embedding_jobs SET attempts = ?, last_error = ?, scheduled_at = ? WHERE rowid = ?');
   const updFail = readyDb.prepare("UPDATE embedding_jobs SET attempts = ?, last_error = ?, status = 'failed' WHERE rowid = ?");
   const failCount = readyDb.transaction(() => {
@@ -1524,7 +1528,7 @@ function embeddingRecordFailures(readyDb, args) {
       const job = asRecord(rawJob, 'failure job');
       const rowid = expectNumber(job.rowid, 'job.rowid');
       const nextAttempts = expectNumber(job.attempts, 'job.attempts') + 1;
-      if (nextAttempts >= MAX_ATTEMPTS) {
+      if (terminal || nextAttempts >= MAX_ATTEMPTS) {
         updFail.run(nextAttempts, errMsg, rowid);
         count++;
       } else {

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1528,6 +1528,7 @@ function embeddingRecordFailures(readyDb, args) {
     throw invalidArgs('terminal must be boolean');
   }
   const terminal = payload.terminal === true;
+  const snoozeUntil = typeof payload.snoozeUntil === 'number' ? payload.snoozeUntil : now + TERMINAL_SNOOZE_MS;
   const updReschedule = readyDb.prepare('UPDATE embedding_jobs SET attempts = ?, last_error = ?, scheduled_at = ? WHERE rowid = ?');
   const updSnooze = readyDb.prepare('UPDATE embedding_jobs SET last_error = ?, scheduled_at = ? WHERE rowid = ?');
   const updFail = readyDb.prepare("UPDATE embedding_jobs SET attempts = ?, last_error = ?, status = 'failed' WHERE rowid = ?");
@@ -1539,7 +1540,7 @@ function embeddingRecordFailures(readyDb, args) {
       const currentAttempts = expectNumber(job.attempts, 'job.attempts');
       if (terminal) {
         // Snooze, don't fail — blockedModels handles the process-lifetime block.
-        updSnooze.run(errMsg, now + TERMINAL_SNOOZE_MS, rowid);
+        updSnooze.run(errMsg, snoozeUntil, rowid);
       } else if (currentAttempts + 1 >= MAX_ATTEMPTS) {
         updFail.run(currentAttempts + 1, errMsg, rowid);
         count++;

--- a/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
+++ b/apps/desktop/src/main/localDb/client/WorkerThreadTransport.ts
@@ -1511,6 +1511,14 @@ function embeddingCommit(readyDb, args) {
   })();
 }
 
+/**
+ * Terminal (INVALID_MODEL) failures snooze the job instead of marking it failed:
+ * the process-internal blockedModels map prevents network calls while alive,
+ * and the snooze keeps the job eligible for re-probe after restart or model
+ * recovery, avoiding permanent index loss from a transient gateway misreport.
+ */
+const TERMINAL_SNOOZE_MS = 30 * 60_000;
+
 function embeddingRecordFailures(readyDb, args) {
   const payload = asRecord(args, 'embedding.recordFailures args');
   const jobs = expectArray(payload.jobs, 'jobs');
@@ -1521,19 +1529,23 @@ function embeddingRecordFailures(readyDb, args) {
   }
   const terminal = payload.terminal === true;
   const updReschedule = readyDb.prepare('UPDATE embedding_jobs SET attempts = ?, last_error = ?, scheduled_at = ? WHERE rowid = ?');
+  const updSnooze = readyDb.prepare('UPDATE embedding_jobs SET last_error = ?, scheduled_at = ? WHERE rowid = ?');
   const updFail = readyDb.prepare("UPDATE embedding_jobs SET attempts = ?, last_error = ?, status = 'failed' WHERE rowid = ?");
   const failCount = readyDb.transaction(() => {
     let count = 0;
     for (const rawJob of jobs) {
       const job = asRecord(rawJob, 'failure job');
       const rowid = expectNumber(job.rowid, 'job.rowid');
-      const nextAttempts = expectNumber(job.attempts, 'job.attempts') + 1;
-      if (terminal || nextAttempts >= MAX_ATTEMPTS) {
-        updFail.run(nextAttempts, errMsg, rowid);
+      const currentAttempts = expectNumber(job.attempts, 'job.attempts');
+      if (terminal) {
+        // Snooze, don't fail — blockedModels handles the process-lifetime block.
+        updSnooze.run(errMsg, now + TERMINAL_SNOOZE_MS, rowid);
+      } else if (currentAttempts + 1 >= MAX_ATTEMPTS) {
+        updFail.run(currentAttempts + 1, errMsg, rowid);
         count++;
       } else {
-        const backoff = RETRY_BACKOFF_MS[Math.min(nextAttempts - 1, RETRY_BACKOFF_MS.length - 1)];
-        updReschedule.run(nextAttempts, errMsg, now + backoff, rowid);
+        const backoff = RETRY_BACKOFF_MS[Math.min(currentAttempts, RETRY_BACKOFF_MS.length - 1)];
+        updReschedule.run(currentAttempts + 1, errMsg, now + backoff, rowid);
       }
     }
     return count;

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -2000,7 +2000,7 @@ describe('db worker tx handlers', () => {
     });
   });
 
-  it('embedding.recordFailures can immediately terminate a deterministic failure', async () => {
+  it('embedding.recordFailures snoozes terminal (INVALID_MODEL) failures instead of permanent fail', async () => {
     await withClient(async (client) => {
       const rowid = await insertJob(client, { sourceId: 'invalid-model', attempts: 0 });
       const result = await client.tx('embedding.recordFailures', {
@@ -2010,16 +2010,18 @@ describe('db worker tx handlers', () => {
         terminal: true,
       });
 
-      expect(result).toEqual({ failCount: 1 });
+      // Snoozed jobs are not failed — they stay pending with scheduled_at pushed
+      // forward, so they can be re-probed after restart / model recovery.
+      expect(result).toEqual({ failCount: 0 });
       await expect(
         client.queryOne(
           'SELECT status, attempts, scheduled_at, last_error FROM embedding_jobs WHERE rowid = ?',
           [rowid],
         ),
       ).resolves.toEqual({
-        status: 'failed',
-        attempts: 1,
-        scheduled_at: 0,
+        status: 'pending',
+        attempts: 0,
+        scheduled_at: 10_000 + 30 * 60_000,
         last_error: '[INVALID_MODEL] unsupported model',
       });
     });

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -2027,6 +2027,34 @@ describe('db worker tx handlers', () => {
     });
   });
 
+  it('embedding.recordFailures honors explicit snoozeUntil for circuit-breaker short-circuit batches', async () => {
+    await withClient(async (client) => {
+      // 熔断窗口始于 now 之前,短路批应排到窗口结束时刻,而不是 now + 30min,
+      // 否则临到期的任务会被反复推迟到下一窗口 (PR #2288 Codex P1)。
+      const rowid = await insertJob(client, { sourceId: 'short-circuit', attempts: 0 });
+      const windowEnd = 5_000 + 30 * 60_000;
+      const result = await client.tx('embedding.recordFailures', {
+        jobs: [{ rowid, attempts: 0 }],
+        errMsg: '[INVALID_MODEL] unsupported model',
+        now: 25 * 60_000,
+        terminal: true,
+        snoozeUntil: windowEnd,
+      });
+
+      expect(result).toEqual({ failCount: 0 });
+      await expect(
+        client.queryOne(
+          'SELECT status, attempts, scheduled_at FROM embedding_jobs WHERE rowid = ?',
+          [rowid],
+        ),
+      ).resolves.toEqual({
+        status: 'pending',
+        attempts: 0,
+        scheduled_at: windowEnd,
+      });
+    });
+  });
+
   it('embedding.enqueue inserts only new natural-key jobs', async () => {
     await withClient(async (client) => {
       const result = await client.tx('embedding.enqueue', {

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -2000,6 +2000,31 @@ describe('db worker tx handlers', () => {
     });
   });
 
+  it('embedding.recordFailures can immediately terminate a deterministic failure', async () => {
+    await withClient(async (client) => {
+      const rowid = await insertJob(client, { sourceId: 'invalid-model', attempts: 0 });
+      const result = await client.tx('embedding.recordFailures', {
+        jobs: [{ rowid, attempts: 0 }],
+        errMsg: '[INVALID_MODEL] unsupported model',
+        now: 10_000,
+        terminal: true,
+      });
+
+      expect(result).toEqual({ failCount: 1 });
+      await expect(
+        client.queryOne(
+          'SELECT status, attempts, scheduled_at, last_error FROM embedding_jobs WHERE rowid = ?',
+          [rowid],
+        ),
+      ).resolves.toEqual({
+        status: 'failed',
+        attempts: 1,
+        scheduled_at: 0,
+        last_error: '[INVALID_MODEL] unsupported model',
+      });
+    });
+  });
+
   it('embedding.enqueue inserts only new natural-key jobs', async () => {
     await withClient(async (client) => {
       const result = await client.tx('embedding.enqueue', {

--- a/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
+++ b/apps/desktop/src/main/localDb/client/__tests__/tx.test.ts
@@ -2002,9 +2002,9 @@ describe('db worker tx handlers', () => {
 
   it('embedding.recordFailures snoozes terminal (INVALID_MODEL) failures instead of permanent fail', async () => {
     await withClient(async (client) => {
-      const rowid = await insertJob(client, { sourceId: 'invalid-model', attempts: 0 });
+      const rowid = await insertJob(client, { sourceId: 'invalid-model', attempts: 4 });
       const result = await client.tx('embedding.recordFailures', {
-        jobs: [{ rowid, attempts: 0 }],
+        jobs: [{ rowid, attempts: 4 }],
         errMsg: '[INVALID_MODEL] unsupported model',
         now: 10_000,
         terminal: true,

--- a/apps/desktop/src/main/localDb/client/tx/types.ts
+++ b/apps/desktop/src/main/localDb/client/tx/types.ts
@@ -177,6 +177,8 @@ export interface EmbeddingRecordFailuresArgs {
   jobs: Array<{ rowid: number; attempts: number }>;
   errMsg: string;
   now: number;
+  /** Deterministic failures can bypass retry scheduling and fail this batch immediately. */
+  terminal?: boolean;
 }
 
 export interface EmbeddingEnqueueArgs {

--- a/apps/desktop/src/main/localDb/client/tx/types.ts
+++ b/apps/desktop/src/main/localDb/client/tx/types.ts
@@ -179,6 +179,13 @@ export interface EmbeddingRecordFailuresArgs {
   now: number;
   /** Deterministic failures can bypass retry scheduling and fail this batch immediately. */
   terminal?: boolean;
+  /**
+   * When terminal, the absolute timestamp (ms) at which the snooze should expire.
+   * Defaults to `now + TERMINAL_SNOOZE_MS`; callers that already hold a block
+   * window should pass its end time so short-circuit batches don't repeatedly
+   * push `scheduled_at` a full 30 minutes into the future (PR #2288 Codex P1).
+   */
+  snoozeUntil?: number;
 }
 
 export interface EmbeddingEnqueueArgs {

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1453,6 +1453,10 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
   const jobs = expectArray(payload.jobs, 'jobs');
   const errMsg = truncate(expectString(payload.errMsg, 'errMsg'), 2000);
   const now = expectNumber(payload.now, 'now');
+  if (payload.terminal !== undefined && typeof payload.terminal !== 'boolean') {
+    throw invalidArgs('terminal must be boolean');
+  }
+  const terminal = payload.terminal === true;
   const updReschedule = db.prepare(
     `UPDATE embedding_jobs
         SET attempts = ?, last_error = ?, scheduled_at = ?
@@ -1469,7 +1473,7 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
       const job = asRecord(rawJob, 'failure job');
       const rowid = expectNumber(job.rowid, 'job.rowid');
       const nextAttempts = expectNumber(job.attempts, 'job.attempts') + 1;
-      if (nextAttempts >= MAX_ATTEMPTS) {
+      if (terminal || nextAttempts >= MAX_ATTEMPTS) {
         updFail.run(nextAttempts, errMsg, rowid);
         failCount++;
       } else {

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1448,6 +1448,14 @@ function embeddingCommit(db: Database.Database, args: unknown): void {
   transaction();
 }
 
+/**
+ * Terminal (INVALID_MODEL) failures snooze the job instead of marking it failed:
+ * the process-internal blockedModels map prevents network calls while alive,
+ * and the snooze keeps the job eligible for re-probe after restart or model
+ * recovery, avoiding permanent index loss from a transient gateway misreport.
+ */
+const TERMINAL_SNOOZE_MS = 30 * 60_000;
+
 function embeddingRecordFailures(db: Database.Database, args: unknown): { failCount: number } {
   const payload = asRecord(args, 'embedding.recordFailures args');
   const jobs = expectArray(payload.jobs, 'jobs');
@@ -1462,6 +1470,11 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
         SET attempts = ?, last_error = ?, scheduled_at = ?
       WHERE rowid = ?`,
   );
+  const updSnooze = db.prepare(
+    `UPDATE embedding_jobs
+        SET last_error = ?, scheduled_at = ?
+      WHERE rowid = ?`,
+  );
   const updFail = db.prepare(
     `UPDATE embedding_jobs
         SET attempts = ?, last_error = ?, status = 'failed'
@@ -1472,13 +1485,16 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
     for (const rawJob of jobs) {
       const job = asRecord(rawJob, 'failure job');
       const rowid = expectNumber(job.rowid, 'job.rowid');
-      const nextAttempts = expectNumber(job.attempts, 'job.attempts') + 1;
-      if (terminal || nextAttempts >= MAX_ATTEMPTS) {
-        updFail.run(nextAttempts, errMsg, rowid);
+      const currentAttempts = expectNumber(job.attempts, 'job.attempts');
+      if (terminal) {
+        // Snooze, don't fail — blockedModels handles the process-lifetime block.
+        updSnooze.run(errMsg, now + TERMINAL_SNOOZE_MS, rowid);
+      } else if (currentAttempts + 1 >= MAX_ATTEMPTS) {
+        updFail.run(currentAttempts + 1, errMsg, rowid);
         failCount++;
       } else {
-        const backoff = RETRY_BACKOFF_MS[Math.min(nextAttempts - 1, RETRY_BACKOFF_MS.length - 1)];
-        updReschedule.run(nextAttempts, errMsg, now + backoff, rowid);
+        const backoff = RETRY_BACKOFF_MS[Math.min(currentAttempts, RETRY_BACKOFF_MS.length - 1)];
+        updReschedule.run(currentAttempts + 1, errMsg, now + backoff, rowid);
       }
     }
     return failCount;

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1476,7 +1476,7 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
   );
   const updSnooze = db.prepare(
     `UPDATE embedding_jobs
-        SET last_error = ?, scheduled_at = ?
+        SET attempts = 0, last_error = ?, scheduled_at = ?
       WHERE rowid = ?`,
   );
   const updFail = db.prepare(

--- a/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
+++ b/apps/desktop/src/main/localDb/worker/opHandlers/tx.ts
@@ -1465,6 +1465,10 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
     throw invalidArgs('terminal must be boolean');
   }
   const terminal = payload.terminal === true;
+  const snoozeUntil =
+    typeof payload.snoozeUntil === 'number'
+      ? payload.snoozeUntil
+      : now + TERMINAL_SNOOZE_MS;
   const updReschedule = db.prepare(
     `UPDATE embedding_jobs
         SET attempts = ?, last_error = ?, scheduled_at = ?
@@ -1488,7 +1492,7 @@ function embeddingRecordFailures(db: Database.Database, args: unknown): { failCo
       const currentAttempts = expectNumber(job.attempts, 'job.attempts');
       if (terminal) {
         // Snooze, don't fail — blockedModels handles the process-lifetime block.
-        updSnooze.run(errMsg, now + TERMINAL_SNOOZE_MS, rowid);
+        updSnooze.run(errMsg, snoozeUntil, rowid);
       } else if (currentAttempts + 1 >= MAX_ATTEMPTS) {
         updFail.run(currentAttempts + 1, errMsg, rowid);
         failCount++;

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -826,10 +826,11 @@ const MODEL_NOT_FOUND_PATTERNS = [
   /invalid[_\s-]?model[_\s-]?name/i,
   /invalid[_\s-]?model\s*[:='"`]/i,
   // "model 'x' is unsupported" / `model "x" is unsupported` /
-  // "model: x is unsupported" — 已被 providerErrors 共享分类器识别为 model_not_found,
-  // 但用同一描述也可在这条路径里命中,避免路径分裂。后面不能接 parameter/field/
-  // input/key/argument/property 等参数词,避免把参数错误误判为模型不可用。
-  /model\s*[:'"`]?[^\n]{1,80}\s+is\s+(?:not\s+supported|unsupported)(?!\s+(?:parameter|field|input|key|argument|property))/i,
+// "model: x is unsupported" — 已被 providerErrors 共享分类器识别为 model_not_found,
+// 但用同一描述也可在这条路径里命中,避免路径分裂。必须有引号或冒号紧跟 model
+// (后面跟模型 id),否则 "model input is unsupported" 这类参数错误会被误判
+// (PR #2288 Codex P2)。
+  /model\s*(?:['"`][^\n]{1,80}?|:\s*[^\n]{1,80}?)\s+is\s+(?:not\s+supported|unsupported)/i,
 ];
 
 function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -810,10 +810,17 @@ export class EmbeddingClient {
  * 必须看错误体里有没有明确的 model_not_found / deployment_not_found 信号。
  */
 const MODEL_NOT_FOUND_PATTERNS = [
+  // "model_not_found", "model-not-found", "model not found"
   /model[_\s-]?not[_\s-]?found/i,
+  // Anthropic 风格: "model: glm-5 not found" / "model 'glm-5' was not found"
+  /model[^\n]{0,40}not[_\s-]?found/i,
   /deployment[_\s-]?not[_\s-]?found/i,
   /unknown[_\s-]?model/i,
   /the model .* does not exist/i,
+  // LiteLLM: "Invalid model name" (非存在模型);避免误伤 "invalid model input"
+  // 这类输入/参数错误,只认 "invalid model name" 或后接冒号/引号模型 id 的措辞。
+  /invalid[_\s-]?model[_\s-]?name/i,
+  /invalid[_\s-]?model\s*[:'"`]/i,
 ];
 
 function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -617,8 +617,12 @@ export class EmbeddingClient {
 
   /**
    * 带重试的 POST /v1/embeddings。重试条件:
-   *   - 5xx / 429 / NETWORK_ERROR → 退避后重试 (最多 RETRY_DELAYS_MS.length 次)
-   *   - 401/403 (AUTH_FAILED) / 400 (INVALID_MODEL) / TIMEOUT → 立即抛
+   *   - 5xx / 429 / TRANSIENT_ERROR / NETWORK_ERROR → 退避后重试 (最多 RETRY_DELAYS_MS.length 次)
+   *   - 401/403 (AUTH_FAILED) / BAD_REQUEST / INVALID_MODEL / TIMEOUT → 立即抛
+   *
+   * BAD_REQUEST (400/422) 不在客户端重试:同样的输入不会因退避而变好, 由 Worker
+   * 侧的 job-level 退避重试处理 (网关瞬时校验故障恢复后自然成功)。
+   * TRANSIENT_ERROR (404 路由/端点暂时不可达) 在客户端重试:端点可能在退避后恢复。
    *
    * `opts.timeoutMs` 是**整条链**(含所有重试与退避睡眠)的预算, 不是单次 HTTP 的:
    * 每次尝试只拿剩余额度, 退避前先看剩余额度够不够, 不够就直接抛 TIMEOUT 而不是
@@ -663,7 +667,8 @@ export class EmbeddingClient {
         const retriable =
           lastErr.code === 'NETWORK_ERROR' ||
           lastErr.code === 'RATE_LIMITED' ||
-          lastErr.code === 'SERVER_ERROR';
+          lastErr.code === 'SERVER_ERROR' ||
+          lastErr.code === 'TRANSIENT_ERROR';
         if (!retriable || attempt >= maxAttempts - 1) {
           throw lastErr;
         }
@@ -772,7 +777,7 @@ export class EmbeddingClient {
         } catch {
           /* not JSON */
         }
-        const code = mapStatusToCode(res.status);
+        const code = mapStatusToCode(res.status, text, parsedMsg);
         throw new EmbeddingError(
           `XD Gateway /v1/embeddings ${res.status}: ${parsedMsg || text || res.statusText}`,
           code,
@@ -797,13 +802,47 @@ export class EmbeddingClient {
   }
 }
 
-function mapStatusToCode(status: number): EmbeddingError['code'] {
+/**
+ * 已知的"模型不存在"错误体模式 (2026-08 XD Gateway / LiteLLM)。
+ *
+ * 只在错误体明确匹配这些模式时才判 INVALID_MODEL (永久熔断)。
+ * 404 单独看不可靠 —— 可能是路由/端点暂时不可达, 也可能是模型不存在;
+ * 必须看错误体里有没有明确的 model_not_found / deployment_not_found 信号。
+ */
+const MODEL_NOT_FOUND_PATTERNS = [
+  /model[_\s-]?not[_\s-]?found/i,
+  /deployment[_\s-]?not[_\s-]?found/i,
+  /unknown[_\s-]?model/i,
+  /the model .* does not exist/i,
+];
+
+function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {
+  const haystack = `${parsedMsg}\n${rawBody}`;
+  return MODEL_NOT_FOUND_PATTERNS.some((pattern) => pattern.test(haystack));
+}
+
+function mapStatusToCode(
+  status: number,
+  rawBody: string,
+  parsedMsg: string,
+): EmbeddingError['code'] {
   if (status === 401 || status === 403) return 'AUTH_FAILED';
-  if (status === 400 || status === 404 || status === 422) return 'INVALID_MODEL';
   if (status === 429) return 'RATE_LIMITED';
   if (status >= 500) return 'SERVER_ERROR';
-  // 其它 4xx 视作 INVALID 不重试
-  return 'INVALID_MODEL';
+  // 400/404/422: 只有错误体明确包含 "model not found" 等确定性信号时才判
+  // INVALID_MODEL (永久熔断)。不同网关对 model-not-found 返回的状态码不一致
+  // (OpenAI/LiteLLM 通常 404, 某些代理返回 400), 必须看错误体而不能只看状态码。
+  if ((status === 400 || status === 404 || status === 422) && looksLikeModelNotFound(rawBody, parsedMsg)) {
+    return 'INVALID_MODEL';
+  }
+  // 400/422: 输入类错误 (超大文本、格式错误、不支持的参数等)。
+  // 不映射为 INVALID_MODEL —— 可能是瞬时网关校验故障或用户输入问题,
+  // 不应据此永久熔断整个模型队列。维度不匹配由 assertBatchDimensions 在响应侧判定。
+  if (status === 400 || status === 422) return 'BAD_REQUEST';
+  // 404: 端点/路由暂时不可达 (部署中、路由未就绪等), 可重试。
+  if (status === 404) return 'TRANSIENT_ERROR';
+  // 其它未列出的 4xx: 保守地按可重试错误处理, 不永久熔断。
+  return 'BAD_REQUEST';
 }
 
 /**

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -819,7 +819,7 @@ const MODEL_NOT_FOUND_PATTERNS = [
   /deployment[_\s-]?not[_\s-]?found/i,
   // "unknown model" 独立出现 / 后接冒号引号模型 id;
   // 不匹配 "unknown model parameter / field / input / key / argument" 这类参数错误。
-  /unknown[_\s-]?model(?!\s+(?:parameter|field|input|key|argument|property|option|setting|value|type))/i,
+  /unknown[_\s-]?model(?![_\s-]+(?:parameter|field|input|key|argument|property|option|setting|value|type))/i,
   /the model .* does not exist/i,
   // LiteLLM: "Invalid model name" (非存在模型);避免误伤 "invalid model input"
   // 这类输入/参数错误,只认 "invalid model name" 或后接冒号/引号模型 id 的措辞。

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -825,6 +825,11 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // 这类输入/参数错误,只认 "invalid model name" 或后接冒号/引号模型 id 的措辞。
   /invalid[_\s-]?model[_\s-]?name/i,
   /invalid[_\s-]?model\s*[:='"`]/i,
+  // "model 'x' is unsupported" / `model "x" is unsupported` /
+  // "model: x is unsupported" — 已被 providerErrors 共享分类器识别为 model_not_found,
+  // 但用同一描述也可在这条路径里命中,避免路径分裂。后面不能接 parameter/field/
+  // input/key/argument/property 等参数词,避免把参数错误误判为模型不可用。
+  /model\s*[:'"`]?[^\n]{1,80}\s+is\s+(?:not\s+supported|unsupported)(?!\s+(?:parameter|field|input|key|argument|property))/i,
 ];
 
 function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -811,16 +811,20 @@ export class EmbeddingClient {
  */
 const MODEL_NOT_FOUND_PATTERNS = [
   // "model_not_found", "model-not-found", "model not found"
+  // (model 与 not found 之间没有其它词,不会误伤 "model input field was not found")
   /model[_\s-]?not[_\s-]?found/i,
   // Anthropic 风格: "model: glm-5 not found" / "model 'glm-5' was not found"
-  /model[^\n]{0,40}not[_\s-]?found/i,
+  // 必须在 model 后紧跟冒号或引号(再跟模型 id),避免参数错误措辞命中。
+  /model\s*[:='"`][^\n]{0,80}not[_\s-]?found/i,
   /deployment[_\s-]?not[_\s-]?found/i,
-  /unknown[_\s-]?model/i,
+  // "unknown model" 独立出现 / 后接冒号引号模型 id;
+  // 不匹配 "unknown model parameter / field / input / key / argument" 这类参数错误。
+  /unknown[_\s-]?model(?!\s+(?:parameter|field|input|key|argument|property|option|setting|value|type))/i,
   /the model .* does not exist/i,
   // LiteLLM: "Invalid model name" (非存在模型);避免误伤 "invalid model input"
   // 这类输入/参数错误,只认 "invalid model name" 或后接冒号/引号模型 id 的措辞。
   /invalid[_\s-]?model[_\s-]?name/i,
-  /invalid[_\s-]?model\s*[:'"`]/i,
+  /invalid[_\s-]?model\s*[:='"`]/i,
 ];
 
 function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -820,17 +820,26 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // "unknown model" 独立出现 / 后接冒号引号模型 id;
   // 不匹配 "unknown model parameter / field / input / key / argument" 这类参数错误。
   /unknown[_\s-]?model(?![_\s-]+(?:parameter|field|input|key|argument|property|option|setting|value|type))/i,
-  /the model .* does not exist/i,
+  // "The model `<id>` does not exist" (OpenAI 风格)。排除 "the model input/field/
+  // parameter/... does not exist" 这类参数错误 (PR #2288 Codex P1):中间段开头不能是
+  // 已知的参数／字段名词,否则就是参数描述而非模型标识符。
+  /the model\s+(?!input\b|field\b|parameter\b|argument\b|property\b|option\b|key\b|value\b|type\b|feature\b|attribute\b).*?does not exist/is,
   // LiteLLM: "Invalid model name" (非存在模型);避免误伤 "invalid model input"
   // 这类输入/参数错误,只认 "invalid model name" 或后接冒号/引号模型 id 的措辞。
   /invalid[_\s-]?model[_\s-]?name/i,
   /invalid[_\s-]?model\s*[:='"`]/i,
-  // "model 'x' is unsupported" / `model "x" is unsupported` /
-// "model: x is unsupported" — 已被 providerErrors 共享分类器识别为 model_not_found,
-// 但用同一描述也可在这条路径里命中,避免路径分裂。必须有引号或冒号紧跟 model
-// (后面跟模型 id),否则 "model input is unsupported" 这类参数错误会被误判
-// (PR #2288 Codex P2)。
-  /model\s*(?:['"`][^\n]{1,80}?|:\s*[^\n]{1,80}?)\s+is\s+(?:not\s+supported|unsupported)/i,
+  // "model 'x' is unsupported" / `model "x" is unsupported" —
+  // 引号紧跟 model,中间是模型 id;不会误伤参数措辞。保持不变。
+  /model\s*['"`][^\n]{1,80}?['"`]?\s+is\s+(?:not\s+supported|unsupported)/i,
+  // "model: x is unsupported" 冒号分支 —— 已被 providerErrors 共享分类器识别为
+  // model_not_found,但用同一描述也可在这条路径里命中,避免路径分裂。
+  // 收紧:冒号后首个非空白词不能是 input/field/parameter/... 等参数词,否则就是
+  // 参数错误 ("model: input is unsupported" / "model: parameter dimensions is unsupported"),
+  // 不应触发模型级熔断 (PR #2288 Codex P1 L833)。
+  // 注意:把负向前瞻放在 `\s*` 之后会让 engine 回溯到 cursor 落在冒号后空格的位置,
+  // 此时 lookahead 看到的是空格而非 input,会误判通过。改成把空白匹配放进
+  // lookahead 内部(`[ \t]+` 强制至少一个空白),让 cursor 紧贴首个非空白字符。
+  /model\s*:(?![ \t]*(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)\b)[ \t]*[^\n]{1,80}?\s+is\s+(?:not\s+supported|unsupported)/i,
 ];
 
 function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -813,9 +813,16 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // "model_not_found", "model-not-found", "model not found"
   // (model 与 not found 之间没有其它词,不会误伤 "model input field was not found")
   /model[_\s-]?not[_\s-]?found/i,
-  // Anthropic 风格: "model: glm-5 not found" / "model 'glm-5' was not found"
-  // 必须在 model 后紧跟冒号或引号(再跟模型 id),避免参数错误措辞命中。
-  /model\s*[:='"`][^\n]{0,80}not[_\s-]?found/i,
+  // Anthropic 风格: "model: glm-5 not found" / "model 'glm-5' was not found"。
+  // 收紧两步 (PR #2288 Codex P1):
+  //   1. 中间段不能以 input/field/parameter/... 等参数词开头 —— "model: input field not found"
+  //      是 input field 错误而非模型不存在。
+  //   2. 中间段不能含 JSON 结构字符 `"` `,` `{` `}` —— 防止错误体中
+  //      {"model":"<id>","error":"<not found>"} 这种无关 `not found` 通过贪婪
+  //      `[^\n]{0,80}` 跨字段命中。
+  // lookahead 内含 `[ \t]*` 避免 engine 回溯到 cursor 落在冒号后空格;参数词后接
+  // `(?=_|-|\b|$)` 同样把下划线/连字符当 word boundary (下划线不是 \b)。
+  /model\s*[:='"`](?![ \t]*(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)(?=_|-|\b|$))[ \t]*[^"\n,{}]{0,80}not[_\s-]?found/i,
   /deployment[_\s-]?not[_\s-]?found/i,
   // "unknown model" 独立出现 / 后接冒号引号模型 id;
   // 不匹配 "unknown model parameter / field / input / key / argument" 这类参数错误。

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -817,12 +817,14 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // 收紧两步 (PR #2288 Codex P1):
   //   1. 中间段不能以 input/field/parameter/... 等参数词开头 —— "model: input field not found"
   //      是 input field 错误而非模型不存在。
-  //   2. 中间段不能含 JSON 结构字符 `"` `,` `{` `}` —— 防止错误体中
+  //   2. 中间段不能含 JSON 跨字段字符 `,` `{` `}` —— 防止错误体中
   //      {"model":"<id>","error":"<not found>"} 这种无关 `not found` 通过贪婪
-  //      `[^\n]{0,80}` 跨字段命中。
+  //      `[^\n]{0,80}` 跨字段命中。引号 `"` 仍允许,因为 OpenAI 等网关会把
+  //      模型 ID 用 `"<id>"` 包裹 (model: "glm-5" not found);排除 `"` 会把这种
+  //      正常 INVALID_MODEL 误判为 BAD_REQUEST (regression check)。
   // lookahead 内含 `[ \t]*` 避免 engine 回溯到 cursor 落在冒号后空格;参数词后接
   // `(?=_|-|\b|$)` 同样把下划线/连字符当 word boundary (下划线不是 \b)。
-  /model\s*[:='"`](?![ \t]*(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)(?=_|-|\b|$))[ \t]*[^"\n,{}]{0,80}not[_\s-]?found/i,
+  /model\s*[:='"`](?![ \t]*(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)(?=_|-|\b|$))[ \t]*[^,\n{}]{0,80}not[_\s-]?found/i,
   /deployment[_\s-]?not[_\s-]?found/i,
   // "unknown model" 独立出现 / 后接冒号引号模型 id;
   // 不匹配 "unknown model parameter / field / input / key / argument" 这类参数错误。

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -823,7 +823,10 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // "The model `<id>` does not exist" (OpenAI 风格)。排除 "the model input/field/
   // parameter/... does not exist" 这类参数错误 (PR #2288 Codex P1):中间段开头不能是
   // 已知的参数／字段名词,否则就是参数描述而非模型标识符。
-  /the model\s+(?!input\b|field\b|parameter\b|argument\b|property\b|option\b|key\b|value\b|type\b|feature\b|attribute\b).*?does not exist/is,
+  // 注意:只用 \b 会被下划线形式绕过 (`\b` 在 `_` 不算 word boundary),故每个参数词
+  // 后接 `(?=_|-|\b|$)` —— 下划线/连字符/word boundary/字符串结尾都算"完整词结束"
+  // (PR #2288 Codex P1 下划线回归: input_field / parameter_name 等)。
+  /the model\s+(?!input(?=_|-|\b|$)|field(?=_|-|\b|$)|parameter(?=_|-|\b|$)|argument(?=_|-|\b|$)|property(?=_|-|\b|$)|option(?=_|-|\b|$)|key(?=_|-|\b|$)|value(?=_|-|\b|$)|type(?=_|-|\b|$)|feature(?=_|-|\b|$)|attribute(?=_|-|\b|$)).*?does not exist/is,
   // LiteLLM: "Invalid model name" (非存在模型);避免误伤 "invalid model input"
   // 这类输入/参数错误,只认 "invalid model name" 或后接冒号/引号模型 id 的措辞。
   /invalid[_\s-]?model[_\s-]?name/i,
@@ -836,10 +839,12 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // 收紧:冒号后首个非空白词不能是 input/field/parameter/... 等参数词,否则就是
   // 参数错误 ("model: input is unsupported" / "model: parameter dimensions is unsupported"),
   // 不应触发模型级熔断 (PR #2288 Codex P1 L833)。
-  // 注意:把负向前瞻放在 `\s*` 之后会让 engine 回溯到 cursor 落在冒号后空格的位置,
+  // 注意 1:把负向前瞻放在 `\s*` 之后会让 engine 回溯到 cursor 落在冒号后空格的位置,
   // 此时 lookahead 看到的是空格而非 input,会误判通过。改成把空白匹配放进
   // lookahead 内部(`[ \t]+` 强制至少一个空白),让 cursor 紧贴首个非空白字符。
-  /model\s*:(?![ \t]*(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)\b)[ \t]*[^\n]{1,80}?\s+is\s+(?:not\s+supported|unsupported)/i,
+  // 注意 2:只用 \b 同样会被下划线形式绕过 (`\b` 在 `_` 不算 word boundary),
+  // 故每个参数词后接 `(?=_|-|\b|$)` —— 下划线/连字符/word boundary/字符串结尾都算。
+  /model\s*:(?![ \t]*(?:input(?=_|-|\b|$)|field(?=_|-|\b|$)|parameter(?=_|-|\b|$)|argument(?=_|-|\b|$)|property(?=_|-|\b|$)|option(?=_|-|\b|$)|key(?=_|-|\b|$)|value(?=_|-|\b|$)|type(?=_|-|\b|$)|feature(?=_|-|\b|$)|attribute(?=_|-|\b|$)))[ \t]*[^\n]{1,80}?\s+is\s+(?:not\s+supported|unsupported)/i,
 ];
 
 function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {

--- a/packages/embedding-client/src/client.ts
+++ b/packages/embedding-client/src/client.ts
@@ -829,20 +829,17 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // "unknown model" 独立出现 / 后接冒号引号模型 id;
   // 不匹配 "unknown model parameter / field / input / key / argument" 这类参数错误。
   /unknown[_\s-]?model(?![_\s-]+(?:parameter|field|input|key|argument|property|option|setting|value|type))/i,
-  // "The model `<id>` does not exist" (OpenAI 风格)。排除 "the model input/field/
-  // parameter/... does not exist" 这类参数错误 (PR #2288 Codex P1):中间段开头不能是
-  // 已知的参数／字段名词,否则就是参数描述而非模型标识符。
-  // 注意:只用 \b 会被下划线形式绕过 (`\b` 在 `_` 不算 word boundary),故每个参数词
-  // 后接 `(?=_|-|\b|$)` —— 下划线/连字符/word boundary/字符串结尾都算"完整词结束"
-  // (PR #2288 Codex P1 下划线回归: input_field / parameter_name 等)。
-  /the model\s+(?!input(?=_|-|\b|$)|field(?=_|-|\b|$)|parameter(?=_|-|\b|$)|argument(?=_|-|\b|$)|property(?=_|-|\b|$)|option(?=_|-|\b|$)|key(?=_|-|\b|$)|value(?=_|-|\b|$)|type(?=_|-|\b|$)|feature(?=_|-|\b|$)|attribute(?=_|-|\b|$)).*?does not exist/is,
+  // "The model `<id>` does not exist" (OpenAI 风格)。模型标识符必须是一个
+  // 独立 token 或成对引号包裹的短值，不能让 `.*?` 跨过校验错误正文去命中
+  // 后面的 "property dimensions does not exist" (PR #2288 Codex P1)。
+  /the model\s+(?:`[^`\n,{}]{1,80}`|"[^"\n,{}]{1,80}"|'[^'\n,{}]{1,80}'|(?!(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)(?=_|-|\b|$))[^\s,{};]{1,80})\s+(?:does not exist|is not found|was not found)/i,
   // LiteLLM: "Invalid model name" (非存在模型);避免误伤 "invalid model input"
   // 这类输入/参数错误,只认 "invalid model name" 或后接冒号/引号模型 id 的措辞。
   /invalid[_\s-]?model[_\s-]?name/i,
-  /invalid[_\s-]?model\s*[:='"`]/i,
-  // "model 'x' is unsupported" / `model "x" is unsupported" —
-  // 引号紧跟 model,中间是模型 id;不会误伤参数措辞。保持不变。
-  /model\s*['"`][^\n]{1,80}?['"`]?\s+is\s+(?:not\s+supported|unsupported)/i,
+  /invalid[_\s-]?model\s*:\s*(?:'[^'\n,{}]{1,80}'|"[^"\n,{}]{1,80}"|`[^`\n,{}]{1,80}`|(?!(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)(?=_|-|\b|$))[^\s,;{}]{1,80})/i,
+  // "model 'x' is unsupported" / `model "x" is unsupported"` — 引号紧跟
+  // model,中间只接受一个短模型标识符,避免吞入后续参数错误。
+  /model\s*(?:'[^'\n,{}]{1,80}'|"[^"\n,{}]{1,80}"|`[^`\n,{}]{1,80}`)\s+is\s+(?:not\s+supported|unsupported)/i,
   // "model: x is unsupported" 冒号分支 —— 已被 providerErrors 共享分类器识别为
   // model_not_found,但用同一描述也可在这条路径里命中,避免路径分裂。
   // 收紧:冒号后首个非空白词不能是 input/field/parameter/... 等参数词,否则就是
@@ -851,9 +848,9 @@ const MODEL_NOT_FOUND_PATTERNS = [
   // 注意 1:把负向前瞻放在 `\s*` 之后会让 engine 回溯到 cursor 落在冒号后空格的位置,
   // 此时 lookahead 看到的是空格而非 input,会误判通过。改成把空白匹配放进
   // lookahead 内部(`[ \t]+` 强制至少一个空白),让 cursor 紧贴首个非空白字符。
-  // 注意 2:只用 \b 同样会被下划线形式绕过 (`\b` 在 `_` 不算 word boundary),
-  // 故每个参数词后接 `(?=_|-|\b|$)` —— 下划线/连字符/word boundary/字符串结尾都算。
-  /model\s*:(?![ \t]*(?:input(?=_|-|\b|$)|field(?=_|-|\b|$)|parameter(?=_|-|\b|$)|argument(?=_|-|\b|$)|property(?=_|-|\b|$)|option(?=_|-|\b|$)|key(?=_|-|\b|$)|value(?=_|-|\b|$)|type(?=_|-|\b|$)|feature(?=_|-|\b|$)|attribute(?=_|-|\b|$)))[ \t]*[^\n]{1,80}?\s+is\s+(?:not\s+supported|unsupported)/i,
+  // 注意 2:只用 \b 同样会被下划线形式绕过 (`\b` 在 `_` 不算 word boundary)。
+  // 冒号后也只接受一个短模型标识符,遇到 `; parameter ...` 等后续字段即失败。
+  /model\s*:\s*(?:'[^'\n,{}]{1,80}'|"[^"\n,{}]{1,80}"|`[^`\n,{}]{1,80}`|(?!(?:input|field|parameter|argument|property|option|key|value|type|feature|attribute)(?=_|-|\b|$))[^\s,;{}]{1,80})\s+is\s+(?:not\s+supported|unsupported)/i,
 ];
 
 function looksLikeModelNotFound(rawBody: string, parsedMsg: string): boolean {

--- a/packages/embedding-client/src/types.ts
+++ b/packages/embedding-client/src/types.ts
@@ -157,13 +157,17 @@ export interface EmbedDocumentsResponse {
  * embedding 操作的错误类型, 统一 code 便于 Worker 按 code 决定重试策略。
  *
  * code 语义:
- *   - AUTH_FAILED   : 没拿到 api key, 或 XD Gateway 返 401/403。不重试。
- *   - RATE_LIMITED  : 429。Worker 走 backoff 重试。
- *   - INVALID_MODEL : 调方传了 catalog 里没有的 model id (本地校验), 或 XD Gateway 返 400。不重试。
- *   - NETWORK_ERROR : fetch 抛错 (DNS/socket reset)。Worker 走 backoff 重试。
- *   - SERVER_ERROR  : 5xx。Worker 走 backoff 重试。
- *   - TIMEOUT       : 调方给的 timeoutMs 预算耗尽 (在途请求已 abort)。**不重试** ——
- *                     预算是整条链的, 已经过期, 再试一次只会立刻又超时。
+ *   - AUTH_FAILED     : 没拿到 api key, 或 XD Gateway 返 401/403。不重试。
+ *   - RATE_LIMITED    : 429。Worker 走 backoff 重试。
+ *   - INVALID_MODEL   : 调方传了 catalog 里没有的 model id (本地校验), 维度不被该型号支持,
+ *                       或 XD Gateway 错误体明确标识 model_not_found。**永久熔断**, 不重试。
+ *   - BAD_REQUEST     : 400/422 输入类错误 (超大文本、格式错误等)。可重试 —— 可能是瞬时
+ *                       网关校验故障或上游短暂异常, 不应触发模型级永久熔断。
+ *   - TRANSIENT_ERROR : 404 路由/端点类错误 (端点暂时不可达而非模型不存在)。可重试。
+ *   - NETWORK_ERROR   : fetch 抛错 (DNS/socket reset)。Worker 走 backoff 重试。
+ *   - SERVER_ERROR    : 5xx。Worker 走 backoff 重试。
+ *   - TIMEOUT         : 调方给的 timeoutMs 预算耗尽 (在途请求已 abort)。**不重试** ——
+ *                       预算是整条链的, 已经过期, 再试一次只会立刻又超时。
  */
 export class EmbeddingError extends Error {
   constructor(
@@ -172,6 +176,8 @@ export class EmbeddingError extends Error {
       | 'AUTH_FAILED'
       | 'RATE_LIMITED'
       | 'INVALID_MODEL'
+      | 'BAD_REQUEST'
+      | 'TRANSIENT_ERROR'
       | 'NETWORK_ERROR'
       | 'SERVER_ERROR'
       | 'TIMEOUT',


### PR DESCRIPTION
## 这次改了什么

### 摘要

聊天索引遇到网关明确返回 INVALID_MODEL 后，原先仍会让当前任务走通用退避；后续每条新消息又会产生同类任务，因此客户端会长期重复请求同一个必然失败的模型。

现在首次确认模型无效时会立即终止当前批次，并在本次应用运行期间记住该模型。之后的新批次直接在本地终止，不再出网；应用重启后会重新允许一次探测，避免模型能力恢复后永久锁死。其他网络、限流等可恢复错误仍沿用原有退避。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：#2170（仅处理 embedding 确定性失败子问题）
- 本 PR 包含：INVALID_MODEL 立即终止；同模型进程内熔断；file worker 与 in-process DB 路径一致；回归测试
- 明确不包含：模型能力下发、索引代次切换、设置页告警、Fable 5 与 utility one-shot 两条独立链路
- 用户可见变化：无界面变化；无效 embedding 模型不再持续产生网络请求和 pending 重试
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/embedding-host/__tests__/EmbeddingWorker.test.ts src/main/localDb/client/__tests__/tx.test.ts
结果：2 files / 40 tests passed

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec eslint <本 PR 涉及文件>
结果：通过

pnpm test:unit
结果：通过（root runner 389 passed / 1 skipped；各 workspace unit tier 通过）

node scripts/check-dco.mjs origin/main..HEAD
结果：通过
```

### 手工验证

macOS 实机使用现有 Cindy dev 客户端连续完成两轮对话；主进程日志持续复现 `voyage/voyage-4` 的 INVALID_MODEL 400，确认问题来自真实新消息产生的聊天索引任务，而非构造测试。

### 未执行的验证

未用该分支另启第二个 Electron 做 patched-build 手工验证，避免干扰用户当前正在运行的 Cindy 实例；修复行为由 worker 与真实 DB worker 回归用例覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [x] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只改变 embedding_jobs 确定性 INVALID_MODEL 的失败调度；无 schema/migration 变更。其他错误码保持原逻辑。
- 回滚 / 降级方式：回滚本提交即可恢复通用退避；重启应用会清空进程内模型阻断状态并重新探测。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因