### PR TITLE
fix(desktop): recover corrupted plugin installations

### DIFF
--- a/apps/desktop/src/main/plugin-market/__tests__/ledger.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/ledger.test.ts
@@ -70,6 +70,24 @@ describe('PluginMarketLedger', () => {
     ).toBe(false);
   });
 
+  it('restores one installation and removes only its matching opt-out', () => {
+    const { ledger } = harness();
+    const first = record();
+    const second = record({ pluginId: `c${'b'.repeat(24)}`, ghostId: 'cindy-other' });
+    ledger.upsertInstallation(first);
+    ledger.upsertInstallation(second);
+    ledger.markRemoved(first.ghostId, 'user-a');
+    ledger.markRemoved(second.ghostId, 'user-a');
+
+    expect(ledger.restoreInstallation(first.ghostId, 'user-a')).toBe(true);
+
+    expect(ledger.installationForGhost(first.ghostId)?.installed).toBe(true);
+    expect(ledger.installationForGhost(second.ghostId)?.installed).toBe(false);
+    expect(ledger.isDefaultInstallSuppressed('user-a', first.pluginId)).toBe(false);
+    expect(ledger.isDefaultInstallSuppressed('user-a', second.pluginId)).toBe(true);
+    expect(ledger.restoreInstallation(first.ghostId, 'user-a')).toBe(false);
+  });
+
   it('fails closed to an empty ledger for malformed or future data', () => {
     const { filePath, ledger } = harness();
     fs.mkdirSync(path.dirname(filePath), { recursive: true });

--- a/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
+++ b/apps/desktop/src/main/plugin-market/__tests__/service.test.ts
@@ -1675,6 +1675,49 @@ describe('PluginMarketService migration and defaultInstall', () => {
     expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(false);
   });
 
+  it('restores a 0.1.38 false removal when catalog, owner, and disk digest agree', async () => {
+    const item = summary({ defaultInstall: true });
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-recovery-'));
+    roots.push(installDir);
+    const rawManifest = manifest();
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(rawManifest));
+    runtime.ghosts = [{ manifest: rawManifest, dir: installDir, enabled: true }];
+    const h = harness([item]);
+    h.ledger.upsertInstallation(
+      recordForTest(item, { manifestDigest: ghostManifestDigest(rawManifest) }),
+    );
+    h.ledger.markRemoved(item.ghostId, 'user-1');
+
+    const snapshot = await h.service.snapshot();
+
+    expect(snapshot.items[0]).toMatchObject({ installState: 'installed', enabled: true });
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(true);
+    expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(false);
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['missing digest', undefined],
+    ['mismatched digest', 'f'.repeat(64)],
+  ] as const)('does not restore a false removal with %s', async (_label, manifestDigest) => {
+    const item = summary({ defaultInstall: true });
+    const installDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cindy-market-recovery-skip-'));
+    roots.push(installDir);
+    const rawManifest = manifest();
+    fs.writeFileSync(path.join(installDir, 'ghost.json'), JSON.stringify(rawManifest));
+    runtime.ghosts = [{ manifest: rawManifest, dir: installDir, enabled: true }];
+    const h = harness([item]);
+    h.ledger.upsertInstallation(recordForTest(item, { manifestDigest }));
+    h.ledger.markRemoved(item.ghostId, 'user-1');
+
+    const snapshot = await h.service.snapshot();
+
+    expect(snapshot.items[0]?.installState).toBe('conflict');
+    expect(h.ledger.installationForGhost(item.ghostId)?.installed).toBe(false);
+    expect(h.ledger.isDefaultInstallSuppressed('user-1', item.id)).toBe(true);
+    expect(runtime.install).not.toHaveBeenCalled();
+  });
+
   it('records an opt-out only after a tracked local uninstall succeeds', async () => {
     const item = summary({ defaultInstall: true });
     const h = harness([item]);

--- a/apps/desktop/src/main/plugin-market/ledger.ts
+++ b/apps/desktop/src/main/plugin-market/ledger.ts
@@ -245,6 +245,30 @@ export class PluginMarketLedger {
     this.write(data);
   }
 
+  /**
+   * Repairs a false removal only after the caller has re-established package ownership from
+   * disk and catalog evidence. Unlike a fresh install, this preserves the original provenance
+   * record and removes only the matching opt-out written by the corrupted removal.
+   */
+  restoreInstallation(ghostId: string, userId: string): boolean {
+    const data = this.read();
+    const record = data.installations[ghostId];
+    const optOuts = data.defaultInstallOptOuts[userId] ?? [];
+    if (!record || record.installed || !optOuts.includes(record.pluginId)) return false;
+    data.installations[ghostId] = {
+      ...record,
+      installed: true,
+      updatedAt: new Date().toISOString(),
+    };
+    const remainingOptOuts = optOuts.filter(
+      (pluginId) => pluginId !== record.pluginId,
+    );
+    if (remainingOptOuts.length > 0) data.defaultInstallOptOuts[userId] = remainingOptOuts;
+    else delete data.defaultInstallOptOuts[userId];
+    this.write(data);
+    return true;
+  }
+
   isDefaultInstallSuppressed(userId: string, pluginId: string): boolean {
     return this.read().defaultInstallOptOuts[userId]?.includes(pluginId) ?? false;
   }

--- a/apps/desktop/src/main/plugin-market/service.ts
+++ b/apps/desktop/src/main/plugin-market/service.ts
@@ -442,6 +442,7 @@ export class PluginMarketService {
     const ledger = this.ledgerForOwner(owner);
     await this.adoptLegacyInstallations(plugins, ledger, owner);
     await this.backfillOfficialCindyGithubTrust(ledger, owner);
+    await this.restoreCorruptedInstallations(plugins, ledger, owner);
     // A snapshot is passive discovery: an empty runtime list can be caused by
     // startup, an owner transition, or a transient filesystem view. Only an
     // explicit uninstall may turn that absence into installed=false/opt-out.
@@ -1465,6 +1466,76 @@ export class PluginMarketService {
       });
     } finally {
       await fs.promises.rm(tempPath, { force: true }).catch(() => undefined);
+    }
+  }
+
+  /**
+   * 0.1.38 could observe the signed-out Ghost root during startup and mark every package in
+   * the stable owner root as removed. Recover only records whose original server provenance,
+   * current visible catalog entry, and on-disk validated manifest all agree. Requiring the
+   * recorded digest deliberately excludes older ambiguous records and genuine uninstalls whose
+   * package directory is gone.
+   */
+  private async restoreCorruptedInstallations(
+    plugins: readonly VisiblePluginSummary[],
+    ledger: PluginMarketLedger,
+    owner: ActiveAppSession,
+  ): Promise<void> {
+    const counts = ghostIdCounts(plugins);
+    const pluginByGhostId = new Map(
+      plugins
+        .filter((plugin) => counts.get(plugin.ghostId) === 1)
+        .map((plugin) => [plugin.ghostId, plugin]),
+    );
+    const installSubject = defaultInstallSubject(owner);
+    const ledgerData = ledger.read();
+    const records = Object.values(ledgerData.installations);
+
+    for (const expected of records) {
+      if (
+        expected.installed ||
+        expected.source !== 'market' ||
+        !expected.manifestDigest ||
+        !ledgerData.defaultInstallOptOuts[installSubject]?.includes(expected.pluginId)
+      ) {
+        continue;
+      }
+      const plugin = pluginByGhostId.get(expected.ghostId);
+      if (
+        !plugin ||
+        plugin.id !== expected.pluginId ||
+        plugin.scope !== expected.scope ||
+        plugin.organizationId !== expected.organizationId
+      ) {
+        continue;
+      }
+
+      await this.withLedgerMutation(owner, () => {
+        const current = ledger.installationForGhost(expected.ghostId);
+        if (
+          !current ||
+          current.installed ||
+          current.source !== 'market' ||
+          current.pluginId !== expected.pluginId ||
+          current.scope !== expected.scope ||
+          current.organizationId !== expected.organizationId ||
+          current.manifestDigest !== expected.manifestDigest ||
+          !ledger.isDefaultInstallSuppressed(installSubject, current.pluginId)
+        ) {
+          return;
+        }
+        const installed = getGhostManager()
+          .list()
+          .find((ghost) => ghost.manifest.id === current.ghostId);
+        if (!installed || installedGhostRawManifestDigest(installed.dir) !== current.manifestDigest) {
+          return;
+        }
+        if (!ledger.restoreInstallation(current.ghostId, installSubject)) return;
+        log.info('corrupted plugin installation ledger restored', {
+          pluginId: current.pluginId,
+          ghostId: current.ghostId,
+        });
+      });
     }
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

0.1.38 曾把仍完整保存在磁盘上的插件误记为“已卸载”，并同步写入默认安装拒绝项。#2253 已阻止新的错误状态产生；本 PR 补上保守的存量恢复：只有账本保留可信摘要、磁盘 manifest 校验通过且摘要完全一致、市场归属与当前 owner 也一致时，才恢复安装标记，并只移除该插件对应的错误拒绝项。任一条件不确定都会保持原状。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Fixes #2268；与 #2275 的重启后插件消失现象相关；补充 #2253 对已损坏账本的恢复路径
- 本 PR 包含：高置信度账本恢复、对应 owner 的单项 opt-out 清理、恢复与拒绝恢复的回归测试
- 明确不包含：重新下载或重装插件；修改插件文件、凭证、KV、偏好或 `.disabled`；恢复无摘要、摘要不一致、来源不明或市场归属不一致的记录
- 用户可见变化：符合严格校验条件的存量插件会在启动同步时重新出现在插件列表和工具清单中
- 是否存在 breaking change：无

### UI 变化

不涉及。

- 引用的设计规范：不涉及

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/main/plugin-market/__tests__/ledger.test.ts src/main/plugin-market/__tests__/service.test.ts
结果：2 个测试文件、102 条测试通过

pnpm --filter desktop typecheck
结果：通过

pnpm --filter desktop exec eslint src/main/plugin-market/ledger.ts src/main/plugin-market/service.ts src/main/plugin-market/__tests__/ledger.test.ts src/main/plugin-market/__tests__/service.test.ts
结果：通过

pnpm test:unit
结果：通过

pnpm check:dco
结果：1 个提交签名通过（ae924d99..14fd5168）
```

### 手工验证

macOS 现有开发客户端（Cindy-dev2-pr2206）中核对真实 owner namespace：TapTap Maker 的 `cindy-brain/taptap-maker/ghost.json`、ledger 安装状态、空 opt-out 与插件页“已安装”状态一致。为避免破坏用户真实数据，没有人工制造损坏；恢复路径使用与真实 owner 目录、manifest 和 0.1.38 ledger 结构一致的 fixture 验证。

### 未执行的验证

未在真实用户目录强制写入损坏账本，也未启动第二个 Electron 实例；原因是这两项会污染现有客户端状态。Windows 未手工验证，恢复逻辑使用 Electron 路径 API 且测试不依赖平台。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅影响同时满足“当前 owner 的 market 记录、原有 manifest 摘要、精确 opt-out、唯一可见市场项、磁盘 manifest 校验及摘要完全一致”的 `installed: false` 记录。存量插件影响：无破坏性影响；不移动、不覆盖插件包，也不修改授权、KV、偏好和停用标记。旧布局下的恢复由 service fixture 在 macOS 运行验证。
- 回滚 / 降级方式：回滚提交即可停止自动恢复；已经恢复的记录只将账本恢复为与现存插件包一致的 `installed: true`，没有文件迁移。Windows 路径差异由现有 ownerDir/path.join 处理；若校验失败会保守跳过。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
