### PR TITLE
fix(telegram): preserve official bot progress through finalization

### DIFF
--- a/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
+++ b/apps/desktop/src/main/hook-control/__tests__/session-runner.test.ts
@@ -1701,6 +1701,64 @@ describe('进度快照(turn.progress 链路)', () => {
     }
   });
 
+  it('官方 Telegram 运行中累计多段正文，done 立即冲刷节流窗里的最后答案', async () => {
+    vi.useFakeTimers();
+    try {
+      fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
+        makeManualSession(opts.id ?? 'sess-x'),
+      );
+      const emitted: string[] = [];
+      const runner = createMakerHookSessionRunner({ log });
+      const p = runner.run(
+        baseReq({
+          source: { im: 'telegram', userText: 'hi' },
+          onProgress: (text: string) => emitted.push(text),
+        }),
+      );
+      await flush();
+
+      const cb = h.eventCbs.get('sess-new')!;
+      cb({ type: 'text', data: { text: '先说第一段。', isFinal: true }, source: 'codex' });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(emitted.at(-1)).toContain('先说第一段。');
+
+      // 对齐 Hermes 的事件流思路：thinking / tool 先作为结构化事件
+      // 进入共享 presenter，Telegram whole 模式再投影过程区与累计正文。
+      cb({
+        type: 'thinking',
+        data: { stage: 'final', blockId: 'check-final', text: '核对收口链路' },
+      });
+      cb({
+        type: 'tool_use',
+        data: {
+          toolUseId: 'read-final',
+          toolName: 'Read',
+          input: { file_path: '/repo/final.ts' },
+        },
+      });
+
+      // 第二段还在 1.5s trailing 窗口内就结束。旧逻辑 teardown 会清 timer，
+      // 导致这段正文从未进入 turn.progress；Telegram 路径必须立刻发累计快照。
+      cb({ type: 'text', data: { text: '最后答案。', isFinal: true }, source: 'codex' });
+      cb({ type: 'done', data: null });
+      const outcome = await p;
+
+      expect(outcome.status).toBe('ok');
+      // 工具前的短旁白只属于运行过程：进度快照要保留，正式终稿
+      // 仍按桌面消息流规则折叠它，不把过程旁白混进答案。
+      expect(outcome.finalText).toBe('最后答案。');
+      expect(emitted.at(-1)).toContain('先说第一段。\n\n最后答案。');
+      expect(emitted.at(-1)).toContain('工作中 · 2 项');
+      expect(emitted.at(-1)).toContain('核对收口链路');
+      expect(emitted.at(-1)).toContain('读取 final.ts');
+      const countAfterDone = emitted.length;
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(emitted).toHaveLength(countAfterDone);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('未注入 onProgress 时零开销路径: 正常收口无异常', async () => {
     fakeMaker.createSession.mockImplementationOnce(async (opts: { id?: string }) =>
       makeManualSession(opts.id ?? 'sess-x'),

--- a/apps/desktop/src/main/hook-control/session-runner.ts
+++ b/apps/desktop/src/main/hook-control/session-runner.ts
@@ -803,10 +803,14 @@ export function createMakerHookSessionRunner(deps: {
       // 就会让"续跑接回渠道"那条路径静默落后于本路径。
       // tool_result 旁路收集的出站图片 absPath(收口时随 turn.end 附件外发)
       const extraImageAbsPaths: string[] = [];
+      const useTelegramProgressParity = req.source?.im === 'telegram';
       const observer = observeHookTurn(session, {
-        // 进度快照不按渠道/聊天类型分叉: 过程区时间线在上正文在下,
-        // Telegram DM / 群 / topic 与 Slack 一致。
+        // Telegram 对齐个人 bot：过程消息累积展示整轮正文，done 先冲刷最后一帧。
+        // Slack / X 保留只展示当前消息的旧行为，避免顺带改变其它车道。
         ...(req.onProgress ? { onProgress: req.onProgress } : {}),
+        ...(useTelegramProgressParity
+          ? { progressBodyMode: 'whole' as const, flushProgressOnDone: true }
+          : {}),
         onToolResult: (fullText) => collectOutboundImages(fullText, extraImageAbsPaths, log),
         onSilentStopSettled,
         log,
@@ -1157,12 +1161,16 @@ function beginContinuationWatch(
   const extraImageAbsPaths: string[] = [];
   let claimed = false;
   let settled = false;
+  const useTelegramProgressParity = req.source?.im === 'telegram';
   const observer = observeHookTurn(session, {
-    // 与 run() 同一呈现: 过程区时间线在上正文在下, 不按聊天类型分叉。
+    // 与 run() 同一呈现；Telegram 续跑同样累计正文并在 done 冲刷最后一帧。
     onProgress: (text) => {
       // 认领之前不发进度: 那时 server 还没把这条消息挂到新 requestId 上。
       if (claimed) req.onProgress(text);
     },
+    ...(useTelegramProgressParity
+      ? { progressBodyMode: 'whole' as const, flushProgressOnDone: true }
+      : {}),
     onToolResult: (fullText) => collectOutboundImages(fullText, extraImageAbsPaths, log),
     onSilentStopSettled,
     log,

--- a/apps/desktop/src/main/hook-control/turnObserver.ts
+++ b/apps/desktop/src/main/hook-control/turnObserver.ts
@@ -24,7 +24,10 @@
 import type { AgentEvent, TurnContinuationState } from '@cindy/maker-core';
 import { isTerminalAgentErrorEvent } from '@cindy/maker-core';
 
-import { createTurnPresenter } from '../im/shared/turnPresenter.js';
+import {
+  createTurnPresenter,
+  type ProgressBodyMode,
+} from '../im/shared/turnPresenter.js';
 import { overloadFailureNotice } from '../im/shared/turnRetryNotice.js';
 
 /*
@@ -83,6 +86,10 @@ export interface ObservableSession {
 export interface HookTurnObserverDeps {
   /** 渲染快照出口(turn.progress); 省略 = 不发进度, 零开销路径。 */
   onProgress?: (text: string) => void;
+  /** 运行中正文范围；官方 Telegram 用 whole 对齐个人 bot，其它车道保留 latest。 */
+  progressBodyMode?: ProgressBodyMode;
+  /** done 时跳过尾沿节流并先发最新进度；仅官方 Telegram 车道启用。 */
+  flushProgressOnDone?: boolean;
   /** tool_result 全文旁路(出站图片收集留在调用方, 观察器不碰 IO)。 */
   onToolResult?: (fullText: string) => void;
   /** 完整 turn（含后台续跑）收口时同步通知，早于 finished settle。 */
@@ -124,14 +131,26 @@ export function observeHookTurn(
   session: ObservableSession,
   deps: HookTurnObserverDeps,
 ): HookTurnObserver {
-  const { onProgress, onToolResult, onTurnTerminal, onSilentStopSettled, log } = deps;
+  const {
+    onProgress,
+    progressBodyMode,
+    flushProgressOnDone,
+    onToolResult,
+    onTurnTerminal,
+    onSilentStopSettled,
+    log,
+  } = deps;
   // 呈现大脑(正文累积 / render 投影 / 过程区合成 / trailing-edge 快照)抽到
   // im/shared/turnPresenter, 与个人 IM 渠道共用同一实现。这里用 finalized-segments
   // 策略: isFinal 逐条契约、定稿段按消息切开、claude fallbackTail 自成段、uuid 缺失
   // 退 requestId、完成态经 buildMessageRenderItems 折叠 —— #1272/#1636/#1703 的实踩
   // 教训随代码留在该模块。收口(何时结束)刻意**不在** presenter: 见下面 done /
   // silentStop / onStatusChange 三条出口, 只有它们能让本观察器 settle。
-  const presenter = createTurnPresenter({ mode: 'finalized-segments', onProgress });
+  const presenter = createTurnPresenter({
+    mode: 'finalized-segments',
+    onProgress,
+    progressBodyMode,
+  });
 
   let stopListening: (() => void) | undefined;
   const finished = new Promise<void>((resolve, reject) => {
@@ -235,6 +254,9 @@ export function observeHookTurn(
           return;
         }
         presenter.seal();
+        // Telegram 的 turn.end 仍要经过 server 发布队列。先把节流窗里的最新安全
+        // 快照冲进既有 progress 载体，避免客户端在 teardown 时直接吞掉最后一帧。
+        if (flushProgressOnDone) presenter.flushProgress();
         // done 是 SDK turn 的权威完成事件；只有 provider 明确锁存了会自动
         // 唤醒下一 turn 的任务时，它才是中间边界。agent_task_update 只是 UI
         // 任务卡事件，Codex / Pi 子代理和 local_bash 都没有资格阻塞收口。

--- a/apps/desktop/src/main/im/shared/__tests__/turnPresenter.test.ts
+++ b/apps/desktop/src/main/im/shared/__tests__/turnPresenter.test.ts
@@ -96,6 +96,50 @@ describe('createTurnPresenter — finalized-segments 策略(官方 bot 现有行
     expect(p.progressBody()).toBe('第二段。');
   });
 
+  it('progressBodyMode=whole 时进度发射器展示整轮累计正文', () => {
+    vi.useFakeTimers();
+    try {
+      const frames: string[] = [];
+      const p = createTurnPresenter({
+        mode: 'finalized-segments',
+        progressBodyMode: 'whole',
+        onProgress: (frame) => void frames.push(frame),
+      });
+      p.applyText(text('第一段。', true, { source: 'codex' }));
+      p.scheduleProgress();
+      vi.advanceTimersByTime(0);
+      p.applyText(text('第二段。', true, { source: 'codex' }));
+      p.flushProgress();
+
+      expect(frames.at(-1)).toContain('第一段。\n\n第二段。');
+      p.stopProgress();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('whole 累计视图超过单帧上限时退回当前消息，不把最新答案截在末尾', () => {
+    vi.useFakeTimers();
+    try {
+      const frames: string[] = [];
+      const p = createTurnPresenter({
+        mode: 'finalized-segments',
+        progressBodyMode: 'whole',
+        onProgress: (frame) => void frames.push(frame),
+        policy: { ...DEFAULT_PRESENTER_POLICY, intermediateMaxRenderedChars: 12 },
+      });
+      p.applyText(text('很长的第一段内容。', true, { source: 'codex' }));
+      p.applyText(text('最新答案。', true, { source: 'codex' }));
+      p.flushProgress();
+
+      expect(frames.at(-1)).toContain('最新答案。');
+      expect(frames.at(-1)).not.toContain('很长的第一段内容。');
+      p.stopProgress();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('claude 同一条消息(同 uuid)的相邻文本块连拼, 不同消息空行分隔', () => {
     const p = createTurnPresenter({ mode: 'finalized-segments' });
     p.applyText(text('前半', true, { source: 'claude-code', agentMeta: { uuid: 'm1' } }));
@@ -188,6 +232,31 @@ describe('createProgressEmitter — trailing-edge 1.5s 节流骨架', () => {
       emitter.schedule();
       vi.advanceTimersByTime(1500);
       expect(frames).toEqual([]);
+      emitter.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('flush 跳过剩余节流窗口并取消原 trailing timer', () => {
+    vi.useFakeTimers();
+    try {
+      const frames: string[] = [];
+      let body = '第一帧';
+      const emitter = createProgressEmitter((t) => void frames.push(t), () => body);
+      emitter.schedule();
+      vi.advanceTimersByTime(0);
+      expect(frames).toEqual(['第一帧']);
+
+      body = '最后一帧';
+      emitter.schedule();
+      vi.advanceTimersByTime(100);
+      expect(frames).toEqual(['第一帧']);
+      emitter.flush();
+      expect(frames).toEqual(['第一帧', '最后一帧']);
+
+      vi.advanceTimersByTime(PROGRESS_THROTTLE_MS);
+      expect(frames).toEqual(['第一帧', '最后一帧']);
       emitter.stop();
     } finally {
       vi.useRealTimers();

--- a/apps/desktop/src/main/im/shared/turnPresenter.ts
+++ b/apps/desktop/src/main/im/shared/turnPresenter.ts
@@ -156,6 +156,8 @@ export function shouldEmitProgressFrame(candidate: string, slots: ProgressDedupe
 /** trailing-edge 节流发射器的公开形态。 */
 export interface ProgressEmitter {
   schedule(): void;
+  /** 取消节流等待并立即尝试发出当前最新快照。 */
+  flush(): void;
   ensureTicker(): void;
   stop(): void;
 }
@@ -260,6 +262,12 @@ export function createProgressEmitter(
   };
   return {
     schedule,
+    flush(): void {
+      if (stopped) return;
+      if (pending !== null) clearTimeout(pending);
+      pending = null;
+      fire();
+    },
     ensureTicker(): void {
       if (stopped || ticker !== null) return;
       ticker = setInterval(schedule, PROGRESS_TICK_MS);
@@ -290,12 +298,17 @@ export function composeProgressView(activityText: string, body: string): string 
 /** 正文累积策略。见模块头。 */
 export type TurnPresenterMode = 'finalized-segments' | 'buffer-replace';
 
+/** 运行中正文投影：默认只露当前消息；whole 与个人 IM 一样露出整轮累计正文。 */
+export type ProgressBodyMode = 'latest' | 'whole';
+
 export interface TurnPresenterOptions {
   mode: TurnPresenterMode;
   /** 过程区耗时基准(activity.startedAt); 缺省取当前时刻。 */
   startedAt?: number;
   /** 注入后启用 trailing-edge 进度发射器(observer 路径); 省略 = 零开销, 无发射器。 */
   onProgress?: (text: string) => void;
+  /** 运行中正文范围；缺省保留官方 bot 既有的 latest 行为。 */
+  progressBodyMode?: ProgressBodyMode;
   /** 纯呈现策略(节流/长度上限/惰性占位); 省略 = DEFAULT_PRESENTER_POLICY(两侧同值)。 */
   policy?: PresenterPolicy;
 }
@@ -333,6 +346,8 @@ export interface TurnPresenter {
 
   // ── trailing-edge 发射器(仅当注入 onProgress 时有效, 否则均为 no-op) ──
   scheduleProgress(): void;
+  /** 跳过剩余节流窗口，立即尝试发出当前最新快照。 */
+  flushProgress(): void;
   ensureProgressTicker(): void;
   stopProgress(): void;
 }
@@ -659,8 +674,17 @@ export function createTurnPresenter(options: TurnPresenterOptions): TurnPresente
   const activity = createTurnActivity(startedAt);
   const composeRunning = (b: string): string =>
     composeProgressView(renderActivity(activity, Date.now()), b);
+  const composeProgress = (): string => {
+    if (options.progressBodyMode !== 'whole') return composeRunning(body.progressBody());
+    const whole = composeRunning(body.wholeText());
+    // 累计正文跨过单帧上限后不能继续头截断：那会让最新答案永远落在截点外。
+    // 退回当前消息，至少保住最新进展；终稿仍由 turn.end 带完整正文。
+    return whole.length <= policy.intermediateMaxRenderedChars
+      ? whole
+      : composeRunning(body.progressBody());
+  };
   const emitter = options.onProgress
-    ? createProgressEmitter(options.onProgress, () => composeRunning(body.progressBody()), policy)
+    ? createProgressEmitter(options.onProgress, composeProgress, policy)
     : null;
 
   return {
@@ -713,6 +737,9 @@ export function createTurnPresenter(options: TurnPresenterOptions): TurnPresente
     composeRunning,
     scheduleProgress(): void {
       emitter?.schedule();
+    },
+    flushProgress(): void {
+      emitter?.flush();
     },
     ensureProgressTicker(): void {
       emitter?.ensureTicker();

--- a/docs/product-rules/telegram-bot-parity.md
+++ b/docs/product-rules/telegram-bot-parity.md
@@ -70,7 +70,8 @@ Cindy 有两个 Telegram bot，用户看到的是同一个产品：
 | 阶段 | 个人 bot | 官方 bot |
 |---|---|---|
 | 首帧 | 有真实内容（含工具步骤）就建一条**真实消息**；空内容不建（惰性占位） | 快照进 `turn.progress` 帧发给服务端 |
-| 过程中 | **第一帧真实内容用 `sendMessage` 建消息（这一条会推送），之后持续 `editMessageText` 覆盖（编辑不推送）**，用户看着它长大：过程区在上、正文在下 | **私聊**：进 Telegram **草稿**（`sendDraft`）——在输入框那个位置，**不在消息流里**；**群**：一条进度消息，`editMessageText` 覆盖 |
+| 过程中 | **第一帧真实内容用 `sendMessage` 建消息（这一条会推送），之后持续 `editMessageText` 覆盖（编辑不推送）**，用户看着它长大：过程区在上、正文在下，正文是整轮累计内容 | **私聊**：进 Telegram **草稿**（`sendDraft`）——在输入框那个位置，**不在消息流里**；**群**：一条进度消息，`editMessageText` 覆盖。桌面端对 Telegram 专门用 `progressBodyMode: 'whole'`，在 3800 字单帧上限内同样累计展示整轮正文；超过后退回当前 assistant 消息，避免头部截断把最新答案藏掉。Slack / X 仍只展示当前 assistant 消息 |
+| `done` 交接 | 最后一帧由个人 driver 自己定稿 | 桌面端在 `turn.end` 之前先 `flushProgress()`，跳过尚余的 1.5 秒尾沿节流，把最新安全快照放进既有进度载体；这是防止 observer teardown 吞掉最后一帧的客户端兜底，**不等于**服务端终稿已发布成功 |
 | 终稿内容（**成功收口**） | **只有正文**（`composeStreamingView` 在 `turn.done` 时直接 `return body`，不再合成过程区） | **只有正文**（`presenter.finalText()` 取 body 引擎的缓冲，不经过 `composeProgressView`） |
 | 终稿落在哪 | **单段且原位编辑成功时**留在那条消息里。**会新发消息的只有两种**：终稿超长被切成多段（第 1 段仍原位，第 2 段起逐段 `send`）；原位编辑失败后整条 repost 承载终稿，再尽力删掉停在过程态的旧消息——**删不掉就两条并存**。**受管图片不算**：它只让终稿跳过 rich 一次性定稿（`editFinal`），后面照样算 `inPlaceText` 走 `finalizeInPlaceOrRepost` 编辑原消息，图片随后由 `uploadImages` 另发 | **私聊**：新发一条正文消息，草稿随之消失；**群**：编辑那条进度消息 |
 | **失败收口**（普通轮次） | **过程区保留**：错误路径不置 `turn.done`，`composeStreamingView` 仍走运行中合成——卡片定稿成「过程区 + 正文 + ❌ 错误：…」，用户能看到失败前干到了哪一步 | 终稿正文为**空**，错误信息走独立的 `errorMessage` 字段，由服务端按语言渲染成「任务失败：…」——**不带过程区** |


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复官方 Telegram bot 的客户端流式呈现与收口：思考、工具调用和多段正文会持续保留在进度消息中，任务完成时会立即冲掉最后一帧节流缓存，避免末尾内容一直停在“等待发送”。

这部分只依赖现有服务端进度协议，可以先独立上线。把终稿作为一条新的 Telegram 消息发布、再删除旧进度消息，以及终稿 outbox/retry 可靠性仍属于服务端后续改动。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：官方 Telegram bot 客户端体验与个人 bot 对齐
- 本 PR 包含：累计呈现多段正文与思考/工具活动；超长进度优先保留最新正文；`done` 时立即 flush 待发进度；补充回归测试与能力台账
- 明确不包含：服务端终稿发布、重试/outbox、删除草稿后另发终稿；个人 bot 行为；消息特效
- 用户可见变化：官方 bot 的过程消息不再只剩最后一小段，任务完成边界的最后一帧不会继续卡在节流等待中
- 是否存在 breaking change：无

### UI 变化

不涉及桌面或移动端界面组件、布局、样式与 UI 文案；仅调整 Telegram 渠道消息聚合和收口逻辑，因此无截图。

- 引用的设计规范：不涉及；产品行为依据 `docs/product-rules/telegram-bot-parity.md` 的 Telegram 双 bot 能力台账，并已同步更新对应条目

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/im test
结果：445/445 通过

pnpm --filter @cindy/im build
结果：通过

pnpm --filter desktop exec vitest run src/main/hook-control/__tests__/session-runner.test.ts src/main/im/shared/__tests__/turnPresenter.test.ts
结果：131/131 通过

pnpm check:dco
结果：通过

git diff --check
结果：通过
```

### 手工验证

不涉及：本 PR 未连接真实官方 Telegram 服务端环境；行为由 turn presenter、turn observer 与 session runner 回归测试覆盖。

### 未执行的验证

未执行真实官方 Telegram 端到端验证。终稿作为新消息可靠发布仍依赖服务端后续改动，不在本 PR 范围内。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Telegram 渠道消息呈现时序

### 影响与回滚

- 影响范围：Desktop 主进程内官方 Telegram hook-control 的进度聚合与完成收口；Slack、X 和个人 Telegram bot 保持原行为
- 回滚 / 降级方式：回滚本 PR 即恢复旧的进度快照与节流收口逻辑；不涉及数据迁移、协议变更或持久数据

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
