### PR TITLE
feat(desktop): track local Ghost plugin usage

### DIFF
--- a/apps/desktop/drizzle/0089_complex_fixer.sql
+++ b/apps/desktop/drizzle/0089_complex_fixer.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS `ghost_usage_daily` (
+	`ghost_id` text NOT NULL,
+	`local_day` text NOT NULL,
+	`call_count` integer DEFAULT 0 NOT NULL,
+	`updated_at` integer NOT NULL,
+	PRIMARY KEY(`ghost_id`, `local_day`)
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS `ghost_usage_daily_day_idx` ON `ghost_usage_daily` (`local_day`);

--- a/apps/desktop/drizzle/meta/0089_snapshot.json
+++ b/apps/desktop/drizzle/meta/0089_snapshot.json
@@ -1,0 +1,3984 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "24dc6762-2d40-4c61-b28a-332c5eb26093",
+  "prevId": "7e28c084-8cbc-4d74-a47f-f84ddefabae0",
+  "tables": {
+    "account_usage_snapshots": {
+      "name": "account_usage_snapshots",
+      "columns": {
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "snapshot": {
+          "name": "snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "agent_input_queue_snapshots": {
+      "name": "agent_input_queue_snapshots",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_input_queue_snapshots_session_id_sessions_id_fk": {
+          "name": "agent_input_queue_snapshots_session_id_sessions_id_fk",
+          "tableFrom": "agent_input_queue_snapshots",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_mcp_servers": {
+      "name": "custom_mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transport": {
+          "name": "transport",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_mcp_servers_sort_order": {
+          "name": "idx_custom_mcp_servers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_providers": {
+      "name": "custom_providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "runtimes": {
+          "name": "runtimes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_providers_sort_order": {
+          "name": "idx_custom_providers_sort_order",
+          "columns": [
+            "sort_order"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_model_usage": {
+      "name": "daily_model_usage",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cache_create_tokens": {
+          "name": "cache_create_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_model_usage_day_agent_kind_model_cost_currency_pk": {
+          "columns": [
+            "day",
+            "agent_kind",
+            "model",
+            "cost_currency"
+          ],
+          "name": "daily_model_usage_day_agent_kind_model_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "daily_spend": {
+      "name": "daily_spend",
+      "columns": {
+        "day": {
+          "name": "day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'USD'"
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "daily_spend_day_cost_currency_pk": {
+          "columns": [
+            "day",
+            "cost_currency"
+          ],
+          "name": "daily_spend_day_cost_currency_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "device_link_ownership": {
+      "name": "device_link_ownership",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_pid": {
+          "name": "owner_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_label": {
+          "name": "owner_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_jobs": {
+      "name": "embedding_jobs",
+      "columns": {
+        "rowid": {
+          "name": "rowid",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locked_at": {
+          "name": "locked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_embedding_jobs_natural": {
+          "name": "uniq_embedding_jobs_natural",
+          "columns": [
+            "source",
+            "source_id",
+            "chunk_index",
+            "model_id"
+          ],
+          "isUnique": true
+        },
+        "idx_embedding_jobs_status_scheduled": {
+          "name": "idx_embedding_jobs_status_scheduled",
+          "columns": [
+            "status",
+            "scheduled_at"
+          ],
+          "isUnique": false
+        },
+        "idx_embedding_jobs_source_id": {
+          "name": "idx_embedding_jobs_source_id",
+          "columns": [
+            "source",
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "embedding_meta": {
+      "name": "embedding_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ghost_cards": {
+      "name": "ghost_cards",
+      "columns": {
+        "call_id": {
+          "name": "call_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ghost_id": {
+          "name": "ghost_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html": {
+          "name": "html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "v": {
+          "name": "v",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ghost_cards_updated_at_idx": {
+          "name": "ghost_cards_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ghost_usage_daily": {
+      "name": "ghost_usage_daily",
+      "columns": {
+        "ghost_id": {
+          "name": "ghost_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "local_day": {
+          "name": "local_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "call_count": {
+          "name": "call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ghost_usage_daily_day_idx": {
+          "name": "ghost_usage_daily_day_idx",
+          "columns": [
+            "local_day"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "ghost_usage_daily_ghost_id_local_day_pk": {
+          "columns": [
+            "ghost_id",
+            "local_day"
+          ],
+          "name": "ghost_usage_daily_ghost_id_local_day_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_context_cursors": {
+      "name": "hook_group_context_cursors",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_key": {
+          "name": "cursor_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cursor_id": {
+          "name": "cursor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_context_cursors_updated_at_idx": {
+          "name": "hook_group_context_cursors_updated_at_idx",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "hook_group_context_cursors_provider_cursor_key_pk": {
+          "columns": [
+            "provider",
+            "cursor_key"
+          ],
+          "name": "hook_group_context_cursors_provider_cursor_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_message_stats": {
+      "name": "hook_group_message_stats",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "row_count": {
+          "name": "row_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_bytes": {
+          "name": "text_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "hook_group_messages": {
+      "name": "hook_group_messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chat_name": {
+          "name": "chat_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_bot": {
+          "name": "is_bot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_names": {
+          "name": "file_names",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "hook_group_messages_msg_idx": {
+          "name": "hook_group_messages_msg_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "message_id"
+          ],
+          "isUnique": true
+        },
+        "hook_group_messages_window_idx": {
+          "name": "hook_group_messages_window_idx",
+          "columns": [
+            "provider",
+            "chat_id",
+            "thread_id",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "im_bindings": {
+      "name": "im_bindings",
+      "columns": {
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bot_context_id": {
+          "name": "bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope_key": {
+          "name": "scope_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attached_via_card_message_id": {
+          "name": "attached_via_card_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_im_bindings_target": {
+          "name": "idx_im_bindings_target",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "im_bindings_target_session_id_sessions_id_fk": {
+          "name": "im_bindings_target_session_id_sessions_id_fk",
+          "tableFrom": "im_bindings",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "im_bindings_channel_bot_context_id_user_id_scope_key_pk": {
+          "columns": [
+            "channel",
+            "bot_context_id",
+            "user_id",
+            "scope_key"
+          ],
+          "name": "im_bindings_channel_bot_context_id_user_id_scope_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_blobs": {
+      "name": "media_blobs",
+      "columns": {
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ext": {
+          "name": "ext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_cache": {
+          "name": "is_cache",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_access_at": {
+          "name": "last_access_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_refs": {
+      "name": "media_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_kind": {
+          "name": "ref_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ref_id": {
+          "name": "ref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "origin_session_id": {
+          "name": "origin_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_kind": {
+          "name": "origin_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "origin_id": {
+          "name": "origin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "media_refs_hash_idx": {
+          "name": "media_refs_hash_idx",
+          "columns": [
+            "hash"
+          ],
+          "isUnique": false
+        },
+        "media_refs_ref_idx": {
+          "name": "media_refs_ref_idx",
+          "columns": [
+            "ref_kind",
+            "ref_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_refs_hash_media_blobs_hash_fk": {
+          "name": "media_refs_hash_media_blobs_hash_fk",
+          "tableFrom": "media_refs",
+          "tableTo": "media_blobs",
+          "columnsFrom": [
+            "hash"
+          ],
+          "columnsTo": [
+            "hash"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_meta": {
+          "name": "agent_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rewind_at": {
+          "name": "rewind_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_messages_session_client": {
+          "name": "uniq_messages_session_client",
+          "columns": [
+            "session_id",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_messages_session_created": {
+          "name": "idx_messages_session_created",
+          "columns": [
+            "session_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_created_at": {
+          "name": "idx_messages_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_rewind_at": {
+          "name": "idx_messages_rewind_at",
+          "columns": [
+            "rewind_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_session_id_sessions_id_fk": {
+          "name": "messages_session_id_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_history": {
+      "name": "migration_history",
+      "columns": {
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "applied_at": {
+          "name": "applied_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "migration_meta": {
+      "name": "migration_meta",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_teams": {
+      "name": "orca_teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "lead_session_id": {
+          "name": "lead_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_active_team_per_lead": {
+          "name": "uniq_active_team_per_lead",
+          "columns": [
+            "lead_session_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_teams\".\"status\" = 'active'"
+        },
+        "idx_orca_teams_status": {
+          "name": "idx_orca_teams_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_teams_lead_session_id_sessions_id_fk": {
+          "name": "orca_teams_lead_session_id_sessions_id_fk",
+          "tableFrom": "orca_teams",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "lead_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_worker_creation_reservations": {
+      "name": "orca_worker_creation_reservations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_worker_creation_reservations_team_label": {
+          "name": "uniq_orca_worker_creation_reservations_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "idx_orca_worker_creation_reservations_expires_at": {
+          "name": "idx_orca_worker_creation_reservations_expires_at",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_worker_creation_reservations_team_id_orca_teams_id_fk": {
+          "name": "orca_worker_creation_reservations_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_worker_creation_reservations",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "orca_workers": {
+      "name": "orca_workers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'idle'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_branch": {
+          "name": "worktree_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'developer'"
+        },
+        "focused": {
+          "name": "focused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "idle_since": {
+          "name": "idle_since",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_orca_workers_session_id": {
+          "name": "uniq_orca_workers_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_team_label": {
+          "name": "uniq_orca_workers_team_label",
+          "columns": [
+            "team_id",
+            "lower(\"label\")"
+          ],
+          "isUnique": true
+        },
+        "uniq_orca_workers_focused_per_team": {
+          "name": "uniq_orca_workers_focused_per_team",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": true,
+          "where": "\"orca_workers\".\"focused\" = true"
+        },
+        "idx_orca_workers_team_id": {
+          "name": "idx_orca_workers_team_id",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "idx_orca_workers_status": {
+          "name": "idx_orca_workers_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "orca_workers_team_id_orca_teams_id_fk": {
+          "name": "orca_workers_team_id_orca_teams_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "orca_teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "orca_workers_session_id_sessions_id_fk": {
+          "name": "orca_workers_session_id_sessions_id_fk",
+          "tableFrom": "orca_workers",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_aliases": {
+      "name": "project_aliases",
+      "columns": {
+        "project_key": {
+          "name": "project_key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_project_aliases_updated_at": {
+          "name": "idx_project_aliases_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "project_automation_consents": {
+      "name": "project_automation_consents",
+      "columns": {
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consented_at": {
+          "name": "consented_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_hash": {
+          "name": "config_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "recent_workdirs": {
+      "name": "recent_workdirs",
+      "columns": {
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_recent_workdirs_last_used_at": {
+          "name": "idx_recent_workdirs_last_used_at",
+          "columns": [
+            "last_used_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "right_sidebar_tabs": {
+      "name": "right_sidebar_tabs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "right_sidebar_tabs_session_idx": {
+          "name": "right_sidebar_tabs_session_idx",
+          "columns": [
+            "session_id",
+            "position"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "right_sidebar_tabs_session_id_sessions_id_fk": {
+          "name": "right_sidebar_tabs_session_id_sessions_id_fk",
+          "tableFrom": "right_sidebar_tabs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedule_runs": {
+      "name": "schedule_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fired_at": {
+          "name": "fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_msg": {
+          "name": "error_msg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_usd": {
+          "name": "estimated_value_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_amount": {
+          "name": "cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "estimated_value_amount": {
+          "name": "estimated_value_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_currency": {
+          "name": "cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_is_approximate": {
+          "name": "cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_attribution": {
+          "name": "cost_attribution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'legacy'"
+        },
+        "result_text": {
+          "name": "result_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_result": {
+          "name": "pre_run_hook_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "heartbeat_at": {
+          "name": "heartbeat_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedule_runs_schedule": {
+          "name": "idx_schedule_runs_schedule",
+          "columns": [
+            "schedule_id",
+            "fired_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedule_runs_schedule_id_schedules_id_fk": {
+          "name": "schedule_runs_schedule_id_schedules_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "schedules",
+          "columnsFrom": [
+            "schedule_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "schedule_runs_session_id_sessions_id_fk": {
+          "name": "schedule_runs_session_id_sessions_id_fk",
+          "tableFrom": "schedule_runs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "schedules": {
+      "name": "schedules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "job_type": {
+          "name": "job_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'prompt'"
+        },
+        "job_config": {
+          "name": "job_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "execution_mode": {
+          "name": "execution_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "script_config": {
+          "name": "script_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "project_config_id": {
+          "name": "project_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "legacy_session_fallback": {
+          "name": "legacy_session_fallback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cron'"
+        },
+        "cron_expr": {
+          "name": "cron_expr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "recurring": {
+          "name": "recurring",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "manual": {
+          "name": "manual",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "interval_ms": {
+          "name": "interval_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "use_worktree": {
+          "name": "use_worktree",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "target_session_id": {
+          "name": "target_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "persistent_session": {
+          "name": "persistent_session",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "silent_when_idle": {
+          "name": "silent_when_idle",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "pre_run_hook_command": {
+          "name": "pre_run_hook_command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pre_run_hook_timeout_ms": {
+          "name": "pre_run_hook_timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skip_log_session_id": {
+          "name": "skip_log_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notify_desktop": {
+          "name": "notify_desktop",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "notify_feishu": {
+          "name": "notify_feishu",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "notify_wecom_group": {
+          "name": "notify_wecom_group",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_finished_at": {
+          "name": "last_finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_fire_at": {
+          "name": "next_fire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expire_at": {
+          "name": "expire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_schedules_active_next": {
+          "name": "idx_schedules_active_next",
+          "columns": [
+            "status",
+            "next_fire_at"
+          ],
+          "isUnique": false
+        },
+        "idx_schedules_target_session": {
+          "name": "idx_schedules_target_session",
+          "columns": [
+            "target_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "schedules_target_session_id_sessions_id_fk": {
+          "name": "schedules_target_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "target_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "schedules_skip_log_session_id_sessions_id_fk": {
+          "name": "schedules_skip_log_session_id_sessions_id_fk",
+          "tableFrom": "schedules",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "skip_log_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_goals": {
+      "name": "session_goals",
+      "columns": {
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "budget_tokens": {
+          "name": "budget_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "no_progress_limit": {
+          "name": "no_progress_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "turns_used": {
+          "name": "turns_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "no_progress_streak": {
+          "name": "no_progress_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "usage_reset_at": {
+          "name": "usage_reset_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_goals_status": {
+          "name": "idx_session_goals_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_goals_session_id_sessions_id_fk": {
+          "name": "session_goals_session_id_sessions_id_fk",
+          "tableFrom": "session_goals",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session_pr_refs": {
+      "name": "session_pr_refs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pr_number": {
+          "name": "pr_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_session_pr_refs": {
+          "name": "uniq_session_pr_refs",
+          "columns": [
+            "session_id",
+            "owner",
+            "repo",
+            "pr_number"
+          ],
+          "isUnique": true
+        },
+        "idx_session_pr_refs_session_last_seen": {
+          "name": "idx_session_pr_refs_session_last_seen",
+          "columns": [
+            "session_id",
+            "last_seen_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_pr_refs_session_id_sessions_id_fk": {
+          "name": "session_pr_refs_session_id_sessions_id_fk",
+          "tableFrom": "session_pr_refs",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sessions": {
+      "name": "sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Maker'"
+        },
+        "working_dir": {
+          "name": "working_dir",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_kind": {
+          "name": "workspace_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'project'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'claude-sonnet-4-6'"
+        },
+        "effort": {
+          "name": "effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'high'"
+        },
+        "permission_mode": {
+          "name": "permission_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ask'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_token_usage": {
+          "name": "total_token_usage",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_usd": {
+          "name": "total_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_amount": {
+          "name": "total_cost_amount",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_cost_currency": {
+          "name": "total_cost_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost_is_approximate": {
+          "name": "total_cost_is_approximate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fast_mode": {
+          "name": "fast_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "plan_mode_enabled": {
+          "name": "plan_mode_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "cleared_at": {
+          "name": "cleared_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned_at": {
+          "name": "pinned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_send_at": {
+          "name": "user_send_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cc'"
+        },
+        "orca_role": {
+          "name": "orca_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "parent_session_id": {
+          "name": "parent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forked_at_message_id": {
+          "name": "forked_at_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "worktree_path": {
+          "name": "worktree_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'desktop'"
+        },
+        "feishu_open_id": {
+          "name": "feishu_open_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feishu_bot_app_id": {
+          "name": "feishu_bot_app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_bot_context_id": {
+          "name": "im_bot_context_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "im_user_id": {
+          "name": "im_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_project_context": {
+          "name": "used_project_context",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "codex_history_has_product_prompt": {
+          "name": "codex_history_has_product_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "extra_dirs": {
+          "name": "extra_dirs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "remote_host_id": {
+          "name": "remote_host_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_started_at": {
+          "name": "active_turn_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "active_turn_pid": {
+          "name": "active_turn_pid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_turn_ended_at": {
+          "name": "last_turn_ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_sessions_updated_at": {
+          "name": "idx_sessions_updated_at",
+          "columns": [
+            "updated_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_user_send_at": {
+          "name": "idx_sessions_user_send_at",
+          "columns": [
+            "user_send_at"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_sdk_session_id": {
+          "name": "idx_sessions_sdk_session_id",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workdir_created": {
+          "name": "idx_sessions_workdir_created",
+          "columns": [
+            "working_dir",
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_created_at": {
+          "name": "idx_sessions_created_at",
+          "columns": [
+            "created_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_workspace_kind": {
+          "name": "idx_sessions_workspace_kind",
+          "columns": [
+            "workspace_kind"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_parent_session_id": {
+          "name": "idx_sessions_parent_session_id",
+          "columns": [
+            "parent_session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_orca_role": {
+          "name": "idx_sessions_orca_role",
+          "columns": [
+            "orca_role"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_worktree_path": {
+          "name": "idx_sessions_worktree_path",
+          "columns": [
+            "worktree_path"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_feishu_lookup": {
+          "name": "idx_sessions_feishu_lookup",
+          "columns": [
+            "source",
+            "feishu_bot_app_id",
+            "feishu_open_id"
+          ],
+          "isUnique": false
+        },
+        "idx_sessions_im_lookup": {
+          "name": "idx_sessions_im_lookup",
+          "columns": [
+            "source",
+            "im_bot_context_id",
+            "im_user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "sessions_parent_session_id_sessions_id_fk": {
+          "name": "sessions_parent_session_id_sessions_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "parent_session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_exposures": {
+      "name": "skill_usage_exposures",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "raw_line_no": {
+          "name": "raw_line_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "skill_path": {
+          "name": "skill_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "skill_document_hash": {
+          "name": "skill_document_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exposure_content_hash": {
+          "name": "exposure_content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "document_hash_source": {
+          "name": "document_hash_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_use_id": {
+          "name": "tool_use_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "seen_at": {
+          "name": "seen_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_call_count": {
+          "name": "tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "repeated_tool_call_count": {
+          "name": "repeated_tool_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "tool_error_count": {
+          "name": "tool_error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_call_count": {
+          "name": "command_call_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "command_failure_count": {
+          "name": "command_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_exposures_skill_document_version": {
+          "name": "idx_skill_usage_exposures_skill_document_version",
+          "columns": [
+            "analyzer_version",
+            "skill_name",
+            "skill_document_hash"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_session": {
+          "name": "idx_skill_usage_exposures_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_exposures_raw_file": {
+          "name": "idx_skill_usage_exposures_raw_file",
+          "columns": [
+            "raw_file_path"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk": {
+          "name": "skill_usage_exposures_raw_file_path_skill_usage_sources_raw_file_path_fk",
+          "tableFrom": "skill_usage_exposures",
+          "tableTo": "skill_usage_sources",
+          "columnsFrom": [
+            "raw_file_path"
+          ],
+          "columnsTo": [
+            "raw_file_path"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "skill_usage_sources": {
+      "name": "skill_usage_sources",
+      "columns": {
+        "raw_file_path": {
+          "name": "raw_file_path",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "analyzer_version": {
+          "name": "analyzer_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'6'"
+        },
+        "agent_kind": {
+          "name": "agent_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sdk_session_id": {
+          "name": "sdk_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mtime_ms": {
+          "name": "mtime_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_scanned_at": {
+          "name": "last_scanned_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'ok'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_skill_usage_sources_session": {
+          "name": "idx_skill_usage_sources_session",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        },
+        "idx_skill_usage_sources_sdk_session": {
+          "name": "idx_skill_usage_sources_sdk_session",
+          "columns": [
+            "sdk_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vec_table_meta": {
+      "name": "vec_table_meta",
+      "columns": {
+        "vec_table": {
+          "name": "vec_table",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "dim": {
+          "name": "dim",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_file_attachments": {
+      "name": "wechat_file_attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "abs_path": {
+          "name": "abs_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bytes": {
+          "name": "bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'staged'"
+        },
+        "promoted_at": {
+          "name": "promoted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wechat_file_attachments_task": {
+          "name": "idx_wechat_file_attachments_task",
+          "columns": [
+            "binding_epoch",
+            "task_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_file_attachments_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_file_attachments_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_file_attachments_session_id_sessions_id_fk": {
+          "name": "wechat_file_attachments_session_id_sessions_id_fk",
+          "tableFrom": "wechat_file_attachments",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_inbox": {
+      "name": "wechat_inbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_seq": {
+          "name": "platform_seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_created_at": {
+          "name": "platform_created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_epoch": {
+          "name": "conversation_epoch",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "payload_json": {
+          "name": "payload_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_nonce": {
+          "name": "context_nonce",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_ciphertext": {
+          "name": "context_ciphertext",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "context_tag": {
+          "name": "context_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_inbox_platform_message": {
+          "name": "uniq_wechat_inbox_platform_message",
+          "columns": [
+            "binding_epoch",
+            "platform_message_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_inbox_queue": {
+          "name": "idx_wechat_inbox_queue",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "received_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_lease": {
+          "name": "idx_wechat_inbox_lease",
+          "columns": [
+            "binding_epoch",
+            "lease_until"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_inbox_conversation": {
+          "name": "idx_wechat_inbox_conversation",
+          "columns": [
+            "binding_epoch",
+            "peer_id",
+            "conversation_epoch"
+          ],
+          "isUnique": false
+        },
+        "uniq_wechat_inbox_running_session": {
+          "name": "uniq_wechat_inbox_running_session",
+          "columns": [
+            "binding_epoch",
+            "session_id"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_inbox\".\"session_id\" IS NOT NULL AND \"wechat_inbox\".\"status\" IN ('dispatching', 'accepted_running', 'waiting_desktop', 'delivery_pending')"
+        }
+      },
+      "foreignKeys": {
+        "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_inbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_inbox_session_id_sessions_id_fk": {
+          "name": "wechat_inbox_session_id_sessions_id_fk",
+          "tableFrom": "wechat_inbox",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_outbox": {
+      "name": "wechat_outbox",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "chunk_index": {
+          "name": "chunk_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_json": {
+          "name": "media_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'[]'"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "next_retry_at": {
+          "name": "next_retry_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_outbox_client_id": {
+          "name": "uniq_wechat_outbox_client_id",
+          "columns": [
+            "binding_epoch",
+            "client_id"
+          ],
+          "isUnique": true
+        },
+        "idx_wechat_outbox_delivery": {
+          "name": "idx_wechat_outbox_delivery",
+          "columns": [
+            "binding_epoch",
+            "status",
+            "next_retry_at"
+          ],
+          "isUnique": false
+        },
+        "idx_wechat_outbox_task": {
+          "name": "idx_wechat_outbox_task",
+          "columns": [
+            "binding_epoch",
+            "task_id",
+            "chunk_index"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk": {
+          "name": "wechat_outbox_binding_epoch_wechat_sync_state_binding_epoch_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_sync_state",
+          "columnsFrom": [
+            "binding_epoch"
+          ],
+          "columnsTo": [
+            "binding_epoch"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wechat_outbox_task_id_wechat_inbox_id_fk": {
+          "name": "wechat_outbox_task_id_wechat_inbox_id_fk",
+          "tableFrom": "wechat_outbox",
+          "tableTo": "wechat_inbox",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "wechat_sync_state": {
+      "name": "wechat_sync_state",
+      "columns": {
+        "binding_epoch": {
+          "name": "binding_epoch",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "sync_cursor": {
+          "name": "sync_cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "last_poll_at": {
+          "name": "last_poll_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error_code": {
+          "name": "last_error_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "uniq_wechat_sync_active": {
+          "name": "uniq_wechat_sync_active",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": true,
+          "where": "\"wechat_sync_state\".\"is_active\" = 1"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "uniq_orca_worker_creation_reservations_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      },
+      "uniq_orca_workers_team_label": {
+        "columns": {
+          "lower(\"label\")": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/desktop/drizzle/meta/_journal.json
+++ b/apps/desktop/drizzle/meta/_journal.json
@@ -624,6 +624,13 @@
       "when": 1786092084443,
       "tag": "0088_thankful_captain_midlands",
       "breakpoints": true
+    },
+    {
+      "idx": 89,
+      "version": "6",
+      "when": 1786290791894,
+      "tag": "0089_complex_fixer",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/desktop/src/main/cindy-brain/__tests__/pipeDispatcher.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/pipeDispatcher.test.ts
@@ -35,6 +35,7 @@ interface Harness {
     runtimeStateOf: ReturnType<typeof vi.fn>;
     spawn: ReturnType<typeof vi.fn>;
     sendToGhost: ReturnType<typeof vi.fn>;
+    recordUsage: ReturnType<typeof vi.fn>;
     log: {
       info: ReturnType<typeof vi.fn>;
       warn: ReturnType<typeof vi.fn>;
@@ -47,6 +48,7 @@ function makeHarness(opts: {
   ghost?: InstalledGhost | null;
   state?: GhostRuntimeState;
   timeoutMs?: number;
+  recordUsage?: (ghostId: string) => Promise<void>;
 } = {}): Harness {
   const sent: GhostPipeToolCall[] = [];
   const deps = {
@@ -57,6 +59,7 @@ function makeHarness(opts: {
       sent.push(payload);
       return true;
     }),
+    recordUsage: vi.fn(opts.recordUsage ?? (async () => undefined)),
     log: {
       info: vi.fn(),
       warn: vi.fn(),
@@ -169,6 +172,7 @@ describe('按需拉起', () => {
     h.deps.spawn.mockResolvedValue({ ok: false, reason: '入口加载失败' });
     const r = await h.dispatcher.callGhostTool(CALL);
     expect(r).toMatchObject({ ok: false, errorCode: 'GHOST_CRASHED' });
+    expect(h.deps.recordUsage).not.toHaveBeenCalled();
   });
 
   it('电子脑离线(send 失败)→ GHOST_CRASHED 立即收卷', async () => {
@@ -177,6 +181,67 @@ describe('按需拉起', () => {
     const r = await h.dispatcher.callGhostTool(CALL);
     expect(r).toMatchObject({ ok: false, errorCode: 'GHOST_CRASHED' });
     expect(h.dispatcher.pendingCount()).toBe(0);
+  });
+});
+
+describe('本地调用计数', () => {
+  it('资格审通过后只记一次，资格失败不记', async () => {
+    const accepted = makeHarness();
+    accepted.deps.sendToGhost.mockReturnValue(false);
+    await expect(accepted.dispatcher.callGhostTool(CALL)).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'GHOST_CRASHED',
+    });
+    expect(accepted.deps.recordUsage).toHaveBeenCalledTimes(1);
+    expect(accepted.deps.recordUsage).toHaveBeenCalledWith('art');
+
+    const rejected = makeHarness({ ghost: null });
+    await rejected.dispatcher.callGhostTool(CALL);
+    expect(rejected.deps.recordUsage).not.toHaveBeenCalled();
+  });
+
+  it('写入未完成或失败都不阻塞派发，也不改变原调用结果', async () => {
+    let rejectUsage!: (error: Error) => void;
+    const usagePending = new Promise<void>((_resolve, reject) => {
+      rejectUsage = reject;
+    });
+    const h = makeHarness({ recordUsage: () => usagePending });
+
+    const call = h.dispatcher.callGhostTool(CALL);
+    expect(h.sent).toHaveLength(1);
+    h.dispatcher.handleToolResult('art', {
+      type: 'tool-result',
+      callId: h.sent[0].callId,
+      ok: true,
+      result: { done: true },
+    });
+    await expect(call).resolves.toEqual({ ok: true, result: { done: true } });
+
+    rejectUsage(new Error('database unavailable'));
+    await vi.waitFor(() =>
+      expect(h.deps.log.warn).toHaveBeenCalledWith('failed to record ghost usage', {
+        ghostId: 'art',
+        error: 'database unavailable',
+      }),
+    );
+  });
+
+  it('记录依赖同步抛错时仍继续派发', async () => {
+    const h = makeHarness({
+      recordUsage: () => {
+        throw new Error('database unavailable');
+      },
+    });
+    h.deps.sendToGhost.mockReturnValue(false);
+
+    await expect(h.dispatcher.callGhostTool(CALL)).resolves.toMatchObject({
+      ok: false,
+      errorCode: 'GHOST_CRASHED',
+    });
+    expect(h.deps.log.warn).toHaveBeenCalledWith('failed to record ghost usage', {
+      ghostId: 'art',
+      error: 'database unavailable',
+    });
   });
 });
 

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -163,6 +163,7 @@ import { GhostCardActionDispatcher } from './cardActionDispatch.js';
 import { GhostSessionActivityTracker } from './ghostSessionActivity.js';
 import { sanitizeGhostCardHtml } from './cardSanitizer.js';
 import { getGhostCard, listGhostCardsBySession, reassignGhostCards, updateGhostCardHeight, upsertGhostCard } from './cardStoreDb.js';
+import { recordGhostUsage } from '../localDb/ghostUsage.js';
 import { updateMessageContent } from '../localDb/ipc/messages.js';
 import { runAssistantReplyHook } from './assistantReplyHook.js';
 import { submitAndAwaitVideo } from '../cindy-proxy-media/video/run.js';
@@ -1095,6 +1096,7 @@ export function getGhostPipeDispatcher(): GhostPipeDispatcher {
         return r.ok ? { ok: true } : { ok: false, reason: r.reason };
       },
       sendToGhost: (ghostId, payload) => sendToGhostLogic(ghostId, payload),
+      recordUsage: recordGhostUsage,
       log,
     });
   }

--- a/apps/desktop/src/main/cindy-brain/pipeDispatcher.ts
+++ b/apps/desktop/src/main/cindy-brain/pipeDispatcher.ts
@@ -38,6 +38,8 @@ export interface PipeDispatcherDeps {
   spawn(ghost: InstalledGhost): Promise<{ ok: true } | { ok: false; reason: string }>;
   /** 把下行消息发到该意识的电子脑逻辑页;false = 逻辑页不在线。 */
   sendToGhost(ghostId: string, payload: GhostPipeToolCall): boolean;
+  /** 记录一次已受理的顶层调用；失败只能记日志，不能影响派发。 */
+  recordUsage(ghostId: string): Promise<void>;
   /** 单次调用超时(默认 330s,见 DEFAULT_TIMEOUT_MS 注释)。 */
   timeoutMs?: number;
   setTimeoutFn?: typeof setTimeout;
@@ -175,6 +177,23 @@ export class GhostPipeDispatcher {
     }
 
     // ── 派发 + 配对等待 ────────────────────────────────────────────────
+    // 此时资格审与按需拉起均已通过，顶层调用已被主进程接受。计数不等插件
+    // 交卷，因此成功、插件失败、派发瞬时失败和超时都各记一次。
+    try {
+      void this.deps.recordUsage(ghostId).catch((error: unknown) => {
+        this.deps.log?.warn('failed to record ghost usage', {
+          ghostId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    } catch (error) {
+      // 依赖实现即使同步抛错也不能改变原有插件调用结果。
+      this.deps.log?.warn('failed to record ghost usage', {
+        ghostId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+
     const callId = request.callId && request.callId.length > 0 ? request.callId : randomUUID();
     const payload: GhostPipeToolCall = { type: 'tool-call', callId, tool, args };
 

--- a/apps/desktop/src/main/localDb/__tests__/ghostUsage.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/ghostUsage.test.ts
@@ -1,0 +1,143 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import Database from 'better-sqlite3';
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import { describe, expect, it } from 'vitest';
+
+import type { GhostUsageDb } from '../ghostUsage';
+import { getGhostUsage7d, recordGhostUsage, shiftedLocalDayKey } from '../ghostUsage';
+import * as schema from '../schema';
+
+const MIGRATION_0089 = path.resolve(__dirname, '../../../../drizzle/0089_complex_fixer.sql');
+
+function freshDb(): { raw: Database.Database; db: GhostUsageDb } {
+  const raw = new Database(':memory:');
+  const sqlText = fs.readFileSync(MIGRATION_0089, 'utf8');
+  for (const statement of sqlText.split('--> statement-breakpoint')) {
+    const trimmed = statement.trim();
+    if (trimmed) raw.exec(trimmed);
+  }
+  return {
+    raw,
+    db: drizzle(raw, { schema }) as unknown as GhostUsageDb,
+  };
+}
+
+function localTimestamp(year: number, month: number, day: number, hour = 12): number {
+  return new Date(year, month - 1, day, hour, 0, 0, 0).getTime();
+}
+
+describe('ghost usage daily counters', () => {
+  it('atomically increments one plugin three times on the same local day', async () => {
+    const { raw, db } = freshDb();
+    try {
+      const now = localTimestamp(2026, 8, 9);
+      await Promise.all([
+        recordGhostUsage('art', db, now),
+        recordGhostUsage('art', db, now + 1),
+        recordGhostUsage('art', db, now + 2),
+      ]);
+
+      expect(await getGhostUsage7d(['art'], db, now)).toEqual({ art: 3 });
+      expect(
+        raw
+          .prepare('SELECT call_count, updated_at FROM ghost_usage_daily WHERE ghost_id = ?')
+          .get('art'),
+      ).toEqual({ call_count: 3, updated_at: now + 2 });
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('keeps concurrent increments for different plugins isolated', async () => {
+    const { raw, db } = freshDb();
+    try {
+      const now = localTimestamp(2026, 8, 9);
+      await Promise.all([
+        recordGhostUsage('art', db, now),
+        recordGhostUsage('calendar', db, now),
+        recordGhostUsage('art', db, now + 1),
+        recordGhostUsage('calendar', db, now + 1),
+      ]);
+
+      expect(await getGhostUsage7d(['art', 'calendar'], db, now)).toEqual({
+        art: 2,
+        calendar: 2,
+      });
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('starts a new bucket across local midnight', async () => {
+    const { raw, db } = freshDb();
+    try {
+      const beforeMidnight = localTimestamp(2026, 8, 9, 23) + 59 * 60_000;
+      const afterMidnight = localTimestamp(2026, 8, 10, 0) + 60_000;
+      await recordGhostUsage('art', db, beforeMidnight);
+      await recordGhostUsage('art', db, afterMidnight);
+
+      expect(
+        raw
+          .prepare(
+            'SELECT local_day, call_count FROM ghost_usage_daily WHERE ghost_id = ? ORDER BY local_day',
+          )
+          .all('art'),
+      ).toEqual([
+        { local_day: '2026-08-09', call_count: 1 },
+        { local_day: '2026-08-10', call_count: 1 },
+      ]);
+      expect(await getGhostUsage7d(['art'], db, afterMidnight)).toEqual({ art: 2 });
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('includes today and the preceding six local days, excluding the eighth day', async () => {
+    const { raw, db } = freshDb();
+    try {
+      const now = localTimestamp(2026, 8, 9);
+      await recordGhostUsage('art', db, now);
+      await recordGhostUsage('art', db, new Date(2026, 7, 3, 12).getTime());
+      await recordGhostUsage('art', db, new Date(2026, 7, 2, 12).getTime());
+      await recordGhostUsage('art', db, new Date(2026, 7, 10, 12).getTime());
+      await recordGhostUsage('calendar', db, now);
+
+      expect(await getGhostUsage7d(['art', 'art'], db, now)).toEqual({ art: 2 });
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('retains 90 local days and removes only rows before that boundary', async () => {
+    const { raw, db } = freshDb();
+    try {
+      const now = localTimestamp(2026, 8, 9);
+      const retainedDay = shiftedLocalDayKey(now, -89);
+      const expiredDay = shiftedLocalDayKey(now, -90);
+      const insert = raw.prepare(
+        'INSERT INTO ghost_usage_daily (ghost_id, local_day, call_count, updated_at) VALUES (?, ?, ?, ?)',
+      );
+      insert.run('retained', retainedDay, 4, now);
+      insert.run('expired', expiredDay, 5, now);
+
+      await recordGhostUsage('art', db, now);
+
+      expect(
+        raw.prepare('SELECT ghost_id, local_day FROM ghost_usage_daily ORDER BY ghost_id').all(),
+      ).toEqual([
+        { ghost_id: 'art', local_day: '2026-08-09' },
+        { ghost_id: 'retained', local_day: retainedDay },
+      ]);
+    } finally {
+      raw.close();
+    }
+  });
+
+  it('returns an empty mapping without touching the database for an empty id list', async () => {
+    const { raw, db } = freshDb();
+    raw.close();
+    await expect(getGhostUsage7d([], db, localTimestamp(2026, 8, 9))).resolves.toEqual({});
+  });
+});

--- a/apps/desktop/src/main/localDb/__tests__/migrationReplay.test.ts
+++ b/apps/desktop/src/main/localDb/__tests__/migrationReplay.test.ts
@@ -134,6 +134,14 @@ describeMigrationReplay('migration replay', () => {
       expect(tableExists(db, 'wechat_inbox')).toBe(true);
       expect(tableExists(db, 'wechat_outbox')).toBe(true);
       expect(tableExists(db, 'wechat_file_attachments')).toBe(true);
+      expect(tableExists(db, 'ghost_usage_daily')).toBe(true);
+      expect(indexExists(db, 'ghost_usage_daily_day_idx')).toBe(true);
+      expect(columnNames(db, 'ghost_usage_daily')).toEqual([
+        'ghost_id',
+        'local_day',
+        'call_count',
+        'updated_at',
+      ]);
     } finally {
       cleanup();
     }

--- a/apps/desktop/src/main/localDb/ghostUsage.ts
+++ b/apps/desktop/src/main/localDb/ghostUsage.ts
@@ -1,0 +1,120 @@
+/**
+ * Local daily counters for accepted top-level Ghost tool calls.
+ *
+ * The table deliberately stores no tool names, arguments, results, sessions, or project data.
+ * Production uses DbClient's async Drizzle proxy; tests inject an in-memory database and clock.
+ */
+
+import { and, gte, inArray, lt, lte, sql } from 'drizzle-orm';
+import type { BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
+
+import { getDbClient } from './client/current.js';
+import { localDayKey } from './dailySpend.js';
+import type * as schema from './schema.js';
+import { ghostUsageDaily } from './schema.js';
+
+export type GhostUsageDb = BetterSQLite3Database<typeof schema>;
+
+const USAGE_WINDOW_DAYS = 7;
+const RETENTION_DAYS = 90;
+
+interface CleanupState {
+  localDay: string;
+  promise: Promise<void>;
+}
+
+/** One low-frequency cleanup per local database and local day. */
+const cleanupByDb = new WeakMap<object, CleanupState>();
+
+function defaultDb(): GhostUsageDb {
+  return getDbClient().drizzle;
+}
+
+/** Shift by local calendar days instead of fixed milliseconds so DST boundaries remain correct. */
+export function shiftedLocalDayKey(ts: number, dayOffset: number): string {
+  const date = new Date(ts);
+  date.setDate(date.getDate() + dayOffset);
+  return localDayKey(date.getTime());
+}
+
+async function cleanupExpiredUsage(db: GhostUsageDb, ts: number): Promise<void> {
+  const dbKey = db as object;
+  const today = localDayKey(ts);
+  const current = cleanupByDb.get(dbKey);
+  if (current?.localDay === today) {
+    await current.promise;
+    return;
+  }
+
+  // Today plus the previous 89 local calendar days remain queryable for diagnostics.
+  const oldestRetainedDay = shiftedLocalDayKey(ts, -(RETENTION_DAYS - 1));
+  const state: CleanupState = {
+    localDay: today,
+    promise: Promise.resolve(
+      db.delete(ghostUsageDaily).where(lt(ghostUsageDaily.localDay, oldestRetainedDay)).run(),
+    ).then(() => undefined),
+  };
+  cleanupByDb.set(dbKey, state);
+  try {
+    await state.promise;
+  } catch (error) {
+    // A transient failure may retry on the next accepted call instead of waiting until tomorrow.
+    if (cleanupByDb.get(dbKey) === state) cleanupByDb.delete(dbKey);
+    throw error;
+  }
+}
+
+/** Atomically add one accepted top-level call to the plugin's local-day bucket. */
+export async function recordGhostUsage(
+  ghostId: string,
+  db: GhostUsageDb = defaultDb(),
+  ts: number = Date.now(),
+): Promise<void> {
+  const localDay = localDayKey(ts);
+  await db
+    .insert(ghostUsageDaily)
+    .values({ ghostId, localDay, callCount: 1, updatedAt: ts })
+    .onConflictDoUpdate({
+      target: [ghostUsageDaily.ghostId, ghostUsageDaily.localDay],
+      set: {
+        callCount: sql`${ghostUsageDaily.callCount} + 1`,
+        updatedAt: ts,
+      },
+    })
+    .run();
+
+  await cleanupExpiredUsage(db, ts);
+}
+
+/**
+ * Return one batch-queried mapping for today and the preceding six local calendar days.
+ * Plugins without a row in that window are omitted.
+ */
+export async function getGhostUsage7d(
+  ghostIds: readonly string[],
+  db: GhostUsageDb = defaultDb(),
+  ts: number = Date.now(),
+): Promise<Record<string, number>> {
+  const uniqueIds = [...new Set(ghostIds)];
+  if (uniqueIds.length === 0) return {};
+
+  const today = localDayKey(ts);
+  const windowStartDay = shiftedLocalDayKey(ts, -(USAGE_WINDOW_DAYS - 1));
+  const rows = await db
+    .select({
+      ghostId: ghostUsageDaily.ghostId,
+      callCount: sql<number>`SUM(${ghostUsageDaily.callCount})`,
+    })
+    .from(ghostUsageDaily)
+    .where(
+      and(
+        inArray(ghostUsageDaily.ghostId, uniqueIds),
+        gte(ghostUsageDaily.localDay, windowStartDay),
+        lte(ghostUsageDaily.localDay, today),
+      ),
+    )
+    .groupBy(ghostUsageDaily.ghostId)
+    .all();
+
+  return Object.fromEntries(rows.map((row) => [row.ghostId, Number(row.callCount)]));
+}

--- a/apps/desktop/src/main/localDb/schema.ts
+++ b/apps/desktop/src/main/localDb/schema.ts
@@ -1133,6 +1133,28 @@ export const dailyModelUsage = sqliteTable(
   }),
 );
 
+/**
+ * Ghost 顶层工具调用的本地日聚合。
+ *
+ * 只保存插件身份、用户本地自然日与调用次数；不保存工具名、参数、结果或会话信息。
+ * 上线后从零累计，不回填历史调用。
+ */
+export const ghostUsageDaily = sqliteTable(
+  'ghost_usage_daily',
+  {
+    ghostId: text('ghost_id').notNull(),
+    /** 用户本地时区 YYYY-MM-DD。 */
+    localDay: text('local_day').notNull(),
+    callCount: integer('call_count').notNull().default(0),
+    /** 最后一次聚合写入的 unix ms。 */
+    updatedAt: integer('updated_at').notNull(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.ghostId, t.localDay] }),
+    byLocalDay: index('ghost_usage_daily_day_idx').on(t.localDay),
+  }),
+);
+
 /** Skill 使用分析的原始 transcript 扫描缓存。 */
 export const skillUsageSources = sqliteTable(
   'skill_usage_sources',

--- a/apps/desktop/src/main/scheduler-host/__tests__/scriptCapabilityBroker.test.ts
+++ b/apps/desktop/src/main/scheduler-host/__tests__/scriptCapabilityBroker.test.ts
@@ -657,6 +657,7 @@ describe('SchedulerScriptCapabilityBroker', () => {
           })();
           return true;
         },
+        recordUsage: async () => undefined,
         timeoutMs: 5_000,
       });
       callGhostToolMock.mockImplementation((request: unknown) =>


### PR DESCRIPTION
## 这次改了什么

### 摘要

新增桌面端本地插件调用次数统计：按插件和用户本地自然日聚合，提供近 7 日批量查询。统计写入采用 fire-and-forget，数据库异常不会影响或延迟原有插件调用。

### 变更类型

- [x] `feat` 新功能
- [ ] `fix` 缺陷修复
- [ ] `refactor` / `perf`
- [ ] `docs` / `test` / `chore`

### 范围

- 关联需求：插件指标展示 P1：本地近 7 日插件调用次数
- 本 PR 包含：
  - `ghost_usage_daily` Drizzle schema 与 0089 迁移
  - 原子 `recordGhostUsage`、批量 `getGhostUsage7d`
  - Dispatcher 顶层调用埋点接线
  - 数据层、Dispatcher、migration replay 测试
- 明确不包含：
  - 公共安装量、服务端 API、pluginMarket
  - IPC/Preload、UI、本地化展示
  - 遥测、历史回填、逐工具/版本/项目/设备维度
  - `ghost-recent-usage` 行为变更
- 用户可见变化：本 PR 只提供本地数据能力，列表/详情文字展示留给后续独立 PR。
- breaking change：无

## 怎么验证的

### 自动验证

```text
pnpm.cmd --filter desktop exec vitest run src/main/localDb/__tests__/ghostUsage.test.ts src/main/cindy-brain/__tests__/pipeDispatcher.test.ts src/main/localDb/__tests__/migrationReplay.test.ts src/main/scheduler-host/__tests__/scriptCapabilityBroker.test.ts
结果：4 files / 70 tests 通过

pnpm.cmd --filter desktop db:validate
结果：迁移 0000..0089、journal/snapshot、schema drift、冻结校验通过

pnpm.cmd --filter desktop run --if-present typecheck
结果：通过

pnpm.cmd test:unit
结果：全 workspace 通过（使用隔离环境关闭本机代理变量，并显式加入 Git Bash 路径）

pnpm.cmd check:dco
结果：通过，1 个 commit 已 Signed-off-by
```

### 手工验证

不涉及 UI；Windows 专用 worktree 完成日期窗口、并发计数、失败隔离和迁移回放验证。macOS 未实机运行。

## 风险

### 风险分类

- [x] SQLite / migration
- [x] 权限 / 安全 / 用户数据
- [x] 跨平台差异

### 影响与回滚

- 统计只从合入后开始累计，不回填历史。
- 只保存插件 ID、本地日期、次数和更新时间，不保存工具名、参数、结果、会话或项目数据。
- 迁移为 append-only；回滚代码时应保留已创建表，避免破坏性 drop。
- 统计写入失败只记录 warn，不改变插件调用结果。
- 需要插件基座白名单放行人明确 `Approve`。
- 无需同步作者契约：不涉及 manifest、管子协议、slot、面板或打包契约。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 带 DCO 签名
- [x] UI 不涉及
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果

P2 公共安装量因服务端缺少权威安装成功数据源，另行阻塞；不在本 PR 范围内。