### PR TITLE
fix(mobile): 对齐断线重连与离线发送体验

### DIFF
--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -200,6 +200,7 @@ import {
   dismissNewSessionCreation,
   prepareNewSessionCreationForEdit,
   getNewSessionCreationTask,
+  retryNewSessionLegacyPlanRestore,
   retryNewSessionCreation,
   shouldBlockSessionSync,
   stashNewSessionDraftForEdit,
@@ -1221,10 +1222,11 @@ export default function SessionScreen() {
       if (items.length === 0) return;
       outboxRef.current = [];
       setOutboxItems([]);
+      const unsentItems = items.filter((item) => !item.restoreOnly);
       // 草稿按条目自身归属写回(而非本 effect 捕获的 sessionId):防御性一致。
       // 引用正文同步恢复 quote store，输入框只接收剥过 marker 的可见文字。
-      restoreOutboxItemsToDraft(items);
-      for (const item of items) {
+      restoreOutboxItemsToDraft(unsentItems);
+      for (const item of unsentItems) {
         for (const localId of [...item.waitingIds, ...item.failedIds]) removePendingUpload(localId);
         for (const attachment of outboxItemAttachments(item)) {
           discardMobileUploadedAttachment(attachment, {
@@ -1450,6 +1452,13 @@ export default function SessionScreen() {
   // 同步真源(上传回调 / 派发循环 / send 同步段都要读最新值),state 只驱动渲染。
   const [outboxItems, setOutboxItems] = useState<readonly MobileOutboxItem[]>([]);
   const outboxRef = useRef<readonly MobileOutboxItem[]>([]);
+  // 页面内代次只用于保护同一屏生命周期内「旧消息恢复」与「用户重新打开 Plan」
+  // 的竞态；不做跨页面、跨进程持久化，边界与现有 outbox 一致。
+  const legacyPlanArmEpochBySessionRef = useRef(new Map<string, number>());
+  const prePlanPermissionModeRef = useRef<{ sessionId: string; mode: string | null }>({
+    sessionId,
+    mode: null,
+  });
   // 派发循环重入锁 + 路由函数的 ref 中转(onUploaded 闭包声明在组件前部,实际
   // 路由/派发逻辑声明在 send() 附近,经 ref 断开声明顺序依赖,同 composerAnnotationsRef)。
   const outboxPumpBusyRef = useRef(false);
@@ -1791,15 +1800,23 @@ export default function SessionScreen() {
   const heldOutboxTransportError = outboxTransportHold?.deviceId === deviceId
     ? outboxTransportHold.error
     : null;
-  const activeOutboxTransportError = screenAutoRecoveringError ?? heldOutboxTransportError;
+  // 当前 error 比旧 hold 更新：确定性错误出现时必须立即压过旧的断线提示；只有
+  // 当前 error 已清空，才继续沿用 hold 等权威同步收口。
+  const activeOutboxTransportError = connectionError === null
+    ? heldOutboxTransportError
+    : screenAutoRecoveringError;
   useEffect(() => {
-    if (!deviceId || !screenAutoRecoveringError) return;
+    if (!deviceId || !connectionError) return;
+    if (!screenAutoRecoveringError) {
+      setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);
+      return;
+    }
     setOutboxTransportHold((current) => (
       current?.deviceId === deviceId && current.error === screenAutoRecoveringError
         ? current
         : { deviceId, error: screenAutoRecoveringError }
     ));
-  }, [deviceId, screenAutoRecoveringError]);
+  }, [connectionError, deviceId, screenAutoRecoveringError]);
   const outboxConnectionState: MobileOutboxConnectionState = {
     relayOnline: status === 'online',
     targetAvailable: targetAvailableForDispatch,
@@ -3764,9 +3781,13 @@ export default function SessionScreen() {
     const prev = prevCreationStatusRef.current;
     const status = creationTask?.status ?? null;
     prevCreationStatusRef.current = status;
+    if (status === 'restoring-plan') {
+      setError(creationTask?.error ?? null);
+      return;
+    }
     if (status === prev) return;
     if (status === null) {
-      if (prev === 'running') {
+      if (prev === 'running' || prev === 'restoring-plan') {
         setError(null);
         void load();
       }
@@ -4105,7 +4126,11 @@ export default function SessionScreen() {
         identity: retryIdentity,
         attempt: retryState.attempt + 1,
       };
-      void load();
+      if (creationTask?.status === 'restoring-plan') {
+        retryNewSessionLegacyPlanRestore(sessionId);
+      } else {
+        void load();
+      }
     }, connectionRecoverySyncRetryDelayMs(retryState.attempt));
     return () => clearTimeout(timer);
   }, [
@@ -4117,6 +4142,7 @@ export default function SessionScreen() {
     load,
     loading,
     connectionEpoch,
+    creationTask?.status,
     sessionId,
     status,
     targetAvailableForDispatch,
@@ -5405,6 +5431,9 @@ export default function SessionScreen() {
    * 没有在途任务要清。
    */
   const salvageOutboxItem = (item: MobileOutboxItem) => {
+    // 已接受/已取消消息留下的隐藏恢复屏障不是草稿，也不再持有附件资源。
+    // 页面离场后按现有 outbox 生命周期丢弃，不扩成跨页面恢复机制。
+    if (item.restoreOnly) return;
     restoreOutboxItemsToDraft([item]);
     for (const attachment of outboxItemAttachments(item)) {
       discardMobileUploadedAttachment(attachment, {
@@ -5437,21 +5466,72 @@ export default function SessionScreen() {
           : [outboxItemWithEnqueueFailure(item, message), ...items]
       ));
     };
-    const waitForConnection = (error: unknown) => {
+    const waitForConnection = (
+      error: unknown,
+      waitingItem: MobileOutboxItem = item,
+    ) => {
       // 与失败回插同一归属边界：离场后不能把旧会话气泡塞进当前页面，降级回该
       // 会话的持久草稿；仍在本页则恢复为 uploading/ready，留在 FIFO 队首。
-      if (outboxSessionAliveRef.current !== item.sessionId) {
-        salvageOutboxItem(item);
+      if (outboxSessionAliveRef.current !== waitingItem.sessionId) {
+        salvageOutboxItem(waitingItem);
         return;
       }
-      const waiting = outboxItemWaitingForConnection(item);
+      const waiting = outboxItemWaitingForConnection(waitingItem);
       updateOutbox((items) => (
-        items.some((existing) => existing.clientId === item.clientId)
+        items.some((existing) => existing.clientId === waitingItem.clientId)
           ? replaceOutboxItem(items, waiting)
           : [waiting, ...items]
       ));
       setError(formatRemoteError(error));
     };
+    const resolveLegacyPlanRestoreTarget = (restoreItem: MobileOutboxItem): string | null => {
+      if (!restoreItem.legacyPlanRestore) return null;
+      const latestArmEpoch = legacyPlanArmEpochBySessionRef.current.get(restoreItem.sessionId) ?? 0;
+      if (latestArmEpoch > restoreItem.legacyPlanArmEpochAtSend) return 'plan';
+      const currentMode = remoteSessionStore.getSessions()
+        .find((entry) => entry.id === restoreItem.sessionId)?.permissionMode;
+      return currentMode && currentMode !== 'plan'
+        ? currentMode
+        : restoreItem.legacyPlanRestore;
+    };
+    const removeRestoreBarrier = (acceptedItem: MobileOutboxItem) => {
+      if (outboxSessionAliveRef.current !== acceptedItem.sessionId) return;
+      updateOutbox((items) => items.filter((entry) => entry.clientId !== acceptedItem.clientId));
+    };
+    const restoreLegacyPlanOffPage = async (restoreItem: MobileOutboxItem) => {
+      const restoreMode = resolveLegacyPlanRestoreTarget(restoreItem);
+      if (!restoreMode) return;
+      try {
+        await withTransientRemoteRetry(
+          () => maker.setPermissionMode(restoreItem.sessionId, restoreMode),
+          { maxAttempts: 2 },
+        );
+      } catch {
+        // 页面生命周期边界内的 best-effort。
+      }
+    };
+    const restoreLegacyPlanAfterEnqueue = async (acceptedItem: MobileOutboxItem) => {
+      const restoreMode = resolveLegacyPlanRestoreTarget(acceptedItem);
+      if (!restoreMode) {
+        removeRestoreBarrier(acceptedItem);
+        return;
+      }
+      try {
+        await withTransientRemoteRetry(
+          () => maker.setPermissionMode(acceptedItem.sessionId, restoreMode),
+        );
+      } catch (err) {
+        if (isAutoRecoveringRemoteError(err)) {
+          waitForConnection(err, acceptedItem);
+          return 'deferred' as const;
+        }
+        // 恢复沿用旧实现的 best-effort 语义：确定性拒绝不应永久挡住后续消息。
+        removeRestoreBarrier(acceptedItem);
+        return;
+      }
+      removeRestoreBarrier(acceptedItem);
+    };
+    if (item.restoreOnly) return restoreLegacyPlanAfterEnqueue(item);
     const sessionNow = remoteSessionStore.getSessions().find((entry) => entry.id === item.sessionId);
     if (!sessionNow) {
       failItem(t('session.screen.sessionNotFoundResync'));
@@ -5494,6 +5574,30 @@ export default function SessionScreen() {
       return;
     }
     if (outboxSessionAliveRef.current !== item.sessionId) return 'stopped' as const;
+    if (item.legacyPlanRestore) {
+      try {
+        // 引用材料准备完成后才显式武装，缩小“远端已是 plan、消息尚未越过
+        // enqueue”的窗口。每条旧协议 Plan 都要单独武装：上一条的恢复会把 live
+        // session 切回普通档，而旧端不会从 queued.createOpts 重放该快照。
+        await withTransientRemoteRetry(() => maker.setPermissionMode(item.sessionId, 'plan'));
+      } catch (err) {
+        // set RPC 的回执也可能丢失，不能假定远端没有切到 plan。
+        if (outboxSessionAliveRef.current !== item.sessionId) {
+          await restoreLegacyPlanOffPage(item);
+          return 'stopped' as const;
+        }
+        if (isAutoRecoveringRemoteError(err)) {
+          waitForConnection(err);
+          return 'deferred' as const;
+        }
+        failItem(formatRemoteError(err));
+        return;
+      }
+      if (outboxSessionAliveRef.current !== item.sessionId) {
+        await restoreLegacyPlanOffPage(item);
+        return 'stopped' as const;
+      }
+    }
     // 乐观交接:进本地 pendingQueue 的同一同步段把条目移出 outbox,气泡原位从
     // 「发送中」变「排队中」不闪断;enqueue 成功后用权威 projection 覆盖 reconcile。
     const projectionBeforeSend = remoteSessionStore.getInputProjection(item.sessionId);
@@ -5570,12 +5674,40 @@ export default function SessionScreen() {
           return 'deferred' as const;
         }
         failItem(formatRemoteError(err));
+        return;
       }
       // applied:消息已在桌面队列,按成功继续(不回滚、不报错)。
     } finally {
       // 落定(入队确认 / 回 outbox 标失败)后收掉转圈:失败条目的气泡由 outbox 侧
       // 重新持有(它自己画错误徽标),排队行里不该留下悬空的在途标记。
       clearQueueItemSending(queued.clientId);
+    }
+    if (item.legacyPlanRestore) {
+      // 消息已经被接受：原条目转换为隐藏的恢复屏障。它留在同一页 outbox 的 FIFO
+      // 队首，只重试权限恢复，绝不再次 enqueue 消息或在离场时回填草稿。
+      const acceptedBarrier: MobileOutboxItem = {
+        ...item,
+        text: '',
+        attachmentSlots: [],
+        slotMeta: [],
+        slotByLocalId: {},
+        waitingIds: [],
+        failedIds: [],
+        enqueueError: null,
+        restoreOnly: true,
+        phase: 'dispatching',
+      };
+      if (outboxSessionAliveRef.current === item.sessionId) {
+        // 用户可能在 arm / enqueue 在途时删除了可见条目，删除路径会先留下同
+        // clientId 的恢复屏障；此处原位替换，不能再插入第二个屏障。
+        updateOutbox((items) => (
+          items.some((entry) => entry.clientId === acceptedBarrier.clientId)
+            ? replaceOutboxItem(items, acceptedBarrier)
+            : [acceptedBarrier, ...items]
+        ));
+      }
+      const restoreResult = await restoreLegacyPlanAfterEnqueue(acceptedBarrier);
+      if (restoreResult === 'deferred') return restoreResult;
     }
     // enqueue / 对账期间离场时，成功路径无需恢复草稿，但旧 pump 也绝不能接着
     // 消费新任务的 outbox；失败路径已由 failItem / waitForConnection 按 A 收口。
@@ -5662,7 +5794,21 @@ export default function SessionScreen() {
     const item = outboxRef.current.find((entry) => entry.clientId === clientId);
     if (!item) return;
     setQueueSelectedClientId(null);
-    updateOutbox((items) => items.filter((entry) => entry.clientId !== clientId));
+    const restoreBarrier = item.legacyPlanRestore ? {
+      ...item,
+      text: '',
+      attachmentSlots: [],
+      slotMeta: [],
+      slotByLocalId: {},
+      waitingIds: [],
+      failedIds: [],
+      enqueueError: null,
+      restoreOnly: true,
+      phase: 'uploading' as const,
+    } : null;
+    updateOutbox((items) => items.flatMap((entry) => (
+      entry.clientId !== clientId ? [entry] : restoreBarrier ? [restoreBarrier] : []
+    )));
     for (const localId of [...item.waitingIds, ...item.failedIds]) removePendingUpload(localId);
     for (const attachment of outboxItemAttachments(item)) {
       discardMobileUploadedAttachment(attachment, { getToken: () => auth.getAccessToken() });
@@ -5671,7 +5817,10 @@ export default function SessionScreen() {
     void pumpOutbox();
   };
 
-  const outboxDisplayItems = useMemo(() => outboxItems.map(outboxDisplayItem), [outboxItems]);
+  const outboxDisplayItems = useMemo(
+    () => outboxItems.filter((item) => !item.restoreOnly).map(outboxDisplayItem),
+    [outboxItems],
+  );
 
   /**
    * 取出并清空某会话的 outbox 条目(创建失败的两条收尾路径都要用)。
@@ -5691,9 +5840,11 @@ export default function SessionScreen() {
     targetSessionId: string,
     uploads: 'release-to-tray' | 'cancel',
   ): { items: MobileOutboxItem[]; cancelledUploadCount: number } => {
-    const taken = outboxRef.current.filter((item) => item.sessionId === targetSessionId);
-    if (taken.length === 0) return { items: [], cancelledUploadCount: 0 };
+    const owned = outboxRef.current.filter((item) => item.sessionId === targetSessionId);
+    if (owned.length === 0) return { items: [], cancelledUploadCount: 0 };
     updateOutbox((items) => items.filter((item) => item.sessionId !== targetSessionId));
+    const taken = owned.filter((item) => !item.restoreOnly);
+    if (taken.length === 0) return { items: [], cancelledUploadCount: 0 };
     const pendingLocalIds = taken.flatMap((item) => [...item.waitingIds, ...item.failedIds]);
     if (uploads === 'release-to-tray') {
       // 已就绪附件的中转对象由调用方决定是否随草稿保留,不在这里回收。
@@ -5918,6 +6069,21 @@ export default function SessionScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connectionEpoch, outboxDispatchBlocked]);
 
+  const readLegacyPlanRestoreMode = () => {
+    const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
+    const remembered = prePlanPermissionModeRef.current.sessionId === sessionId
+      ? prePlanPermissionModeRef.current.mode
+      : null;
+    return remembered && remembered !== 'plan' ? remembered : fallback;
+  };
+
+  const consumeLegacyPlanLocally = (restoreMode: string | null) => {
+    if (!restoreMode) return;
+    remoteSessionStore.applySessionPatch(deviceId, sessionId, {
+      permissionMode: restoreMode,
+    });
+  };
+
   async function send(options: {
     draftOverride?: string;
     documentOverride?: ComposerDocument;
@@ -6086,9 +6252,19 @@ export default function SessionScreen() {
     // 会话参数未就绪(缓存种入 / 新建在途)同样走本分支:此刻 enqueue 不可用,但消息
     // 照常上屏,由派发循环在就绪后按序发出——composer 不再为此进只读档。
     const dispatchBlockedAtSend = outboxDispatchBlockedNow();
+    const sessionForDispatchDecision = readSessionRowNow() ?? currentSession;
+    const permissionModeAtDecision = permissionModeOrAsk(
+      sessionForDispatchDecision.permissionMode,
+    );
+    const legacyPlanRestoreAtDecision = permissionModeAtDecision === 'plan'
+      ? readLegacyPlanRestoreMode()
+      : null;
     if (outboxEligible && !earlyLocalCommand && !earlyDesktopCommand
       && (sessionRefsAtSend.length > 0 || uploadsInFlight > 0 || outboxRef.current.length > 0
-        || outboxPumpBusyRef.current || dispatchBlockedAtSend)) {
+        || outboxPumpBusyRef.current || dispatchBlockedAtSend
+        // 旧协议 Plan 一律经 outbox 串行武装 → enqueue → 恢复，避免 chip 的乐观
+        // setPermissionMode 与直发 enqueue 竞速。
+        || legacyPlanRestoreAtDecision !== null)) {
       try {
         // workingDir 校验只对「此刻就能派发」的消息前置:dialogue 会话的工作目录由
         // 被控端在创建时分配,合成行此刻本就为空,而 dispatchOutboxItem 会在真正派发
@@ -6133,13 +6309,14 @@ export default function SessionScreen() {
         setAttachmentError(null);
         // plan 一次性语义:权限档快照进条目(派发按快照发),chip 立即恢复——
         // 不等附件上传完,与「消息已发出」的乐观语义一致。
-        const permissionModeAtSend = permissionModeOrAsk(currentSession.permissionMode);
-        if (permissionModeAtSend === 'plan') {
-          const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
-          const remembered = prePlanPermissionModeRef.current;
-          const restored = remembered && remembered !== 'plan' ? remembered : fallback;
-          void maker.setPermissionMode(sessionId, restored).catch(() => undefined);
-        }
+        const permissionModeAtSend = permissionModeAtDecision;
+        const legacyPlanRestore = legacyPlanRestoreAtDecision;
+        const legacyPlanArmEpochAtSend = legacyPlanRestore
+          ? legacyPlanArmEpochBySessionRef.current.get(sessionId) ?? 0
+          : 0;
+        // 本地立即消费一次性 Plan，后续输入按恢复档快照；远端必须保持 plan 到
+        // 本条真正 enqueue，恢复动作由 dispatchOutboxItem 在确认入队后执行。
+        consumeLegacyPlanLocally(legacyPlanRestore);
         updateOutbox((items) => [...items, buildOutboxItem({
           clientId: createOutboxClientId(),
           sessionId,
@@ -6150,6 +6327,8 @@ export default function SessionScreen() {
           pastedTextRanges: pastedTextRangesAtSend,
           slashCommandRanges: slashCommandRangesAtSend ?? [],
           permissionModeAtSend,
+          legacyPlanRestore,
+          legacyPlanArmEpochAtSend,
           readyAttachments,
           readyPreviews,
           claimedUploads,
@@ -6183,8 +6362,12 @@ export default function SessionScreen() {
       // currentSession 同理是等待前的快照:上传等待期间(sending 不锁控制面板)用户
       // 可能已切 model / effort / permission / fast,重读 store 拿最新会话字段,
       // 排队消息与 UI 显示的运行时保持一致(codex review R19)。
-      const sessionAtSend = remoteSessionStore.getSessions().find((item) => item.id === sessionId)
+      const latestSessionAtSend = remoteSessionStore.getSessions().find((item) => item.id === sessionId)
         ?? currentSession;
+      const sessionAtSend = {
+        ...latestSessionAtSend,
+        permissionMode: permissionModeAtDecision,
+      };
       const hasAttachments = sendAttachments.length > 0;
       if (!text && !hasAttachments) return;
       // 排队消息编辑态:发送按钮语义变为「保存修改」——整条内容(文本+附件)替换回
@@ -6575,18 +6758,10 @@ export default function SessionScreen() {
         // 否则回滚后集合残留、同 clientId 重发时首帧仍是转圈。
         clearQueueItemSending(queued.clientId);
       }
+      const scopeStillAlive = sendScopeStillAlive();
       // 消息已由 A 路径落定；若等待期间切到 B，只停止旧 continuation，不能再用
-      // A 的附件 id / plan 状态去清理 B 的 composer UI。
-      if (!sendScopeStillAlive()) return;
-      if (sessionAtSend.permissionMode === 'plan') {
-        // 一次性语义(对齐桌面 PR#494 / 产品决策):计划模式只对本条消息生效,发送后
-        // 自动恢复进入前的权限档;本条消息通常已按 plan 派发,切换只影响后续消息。
-        // best-effort:失败不打断发送流程,chip 会保留、用户可手动退出。
-        const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
-        const remembered = prePlanPermissionModeRef.current;
-        const restored = remembered && remembered !== 'plan' ? remembered : fallback;
-        void maker.setPermissionMode(sessionId, restored).catch(() => undefined);
-      }
+      // A 的附件 id 去清理 B 的 composer UI。
+      if (!scopeStillAlive) return;
       voiceDictionaryLearningTrackerRef.current?.flush();
       // 只清本次实际发出那批(sendAttachments)的映射:enqueue 在途期间(弱网数秒)
       // composer 全程可交互,期间新落定的附件已写进这两个映射——全量清空会把它们的
@@ -7399,27 +7574,35 @@ export default function SessionScreen() {
   //    状态读 session.planModeEnabled;一次性消耗由被控端执行(下一 turn 消耗武装态,
   //    plan_mode_changed → planModeEnabled=false 经 sessions:patched 回流),手机端不做本地恢复。
   //  - 老被控端兼容(permissionModes 仍含 'plan'):沿用 permissionMode 切换 + 发送后本地恢复。
-  const prePlanPermissionModeRef = useRef<string | null>(null);
   const planModeCapability = runtimeOptions?.planModeSupported === true;
   const legacyPlanSupported = runtimeOptions?.permissionOptions.some((option) => option.id === 'plan') ?? false;
   const planModeSupported = planModeCapability || legacyPlanSupported;
   const legacyPlanModeOn = currentSession?.permissionMode === 'plan';
   const planModeOn = planModeCapability ? currentSession?.planModeEnabled === true : legacyPlanModeOn;
   const togglePlanMode = useCallback((next: boolean) => {
-    // sessionSettingsLocked:会话建成前不动权限档(老协议分支还会写
-    // prePlanPermissionModeRef,提前 return 免得留下没生效的「进入前档位」记录)。
+    // sessionSettingsLocked:会话建成前不动权限档(老协议分支还会写进入前档位，
+    // 提前 return 免得留下没生效的本地记录)。
     if (!canUseComposer || sessionSettingsLocked || !currentSession) return;
     if (planModeCapability) {
       void runControlAction(() => maker.setPlanMode(sessionId, next), { planModeEnabled: next });
       return;
     }
     if (next) {
-      prePlanPermissionModeRef.current = currentSession.permissionMode ?? null;
+      prePlanPermissionModeRef.current = {
+        sessionId,
+        mode: currentSession.permissionMode ?? null,
+      };
+      legacyPlanArmEpochBySessionRef.current.set(
+        sessionId,
+        (legacyPlanArmEpochBySessionRef.current.get(sessionId) ?? 0) + 1,
+      );
       void runControlAction(() => maker.setPermissionMode(sessionId, 'plan'), { permissionMode: 'plan' });
       return;
     }
     const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
-    const remembered = prePlanPermissionModeRef.current;
+    const remembered = prePlanPermissionModeRef.current.sessionId === sessionId
+      ? prePlanPermissionModeRef.current.mode
+      : null;
     const restored = remembered && remembered !== 'plan' ? remembered : fallback;
     void runControlAction(() => maker.setPermissionMode(sessionId, restored), { permissionMode: restored });
   }, [canUseComposer, currentSession, maker, planModeCapability, runControlAction, runtimeOptions, sessionId, sessionSettingsLocked]);
@@ -7427,8 +7610,10 @@ export default function SessionScreen() {
   // 本就与 plan 正交,直接展示;仅老被控端 permissionMode='plan' 时替换为进入前的底层权限档
   // (无记录时回退首个非 plan 档),激活态由 composer 的 PlanModeChip 表达。
   const displayPermissionMode = legacyPlanModeOn
-    ? ((prePlanPermissionModeRef.current && prePlanPermissionModeRef.current !== 'plan')
-      ? prePlanPermissionModeRef.current
+    ? ((prePlanPermissionModeRef.current.sessionId === sessionId
+      && prePlanPermissionModeRef.current.mode
+      && prePlanPermissionModeRef.current.mode !== 'plan')
+      ? prePlanPermissionModeRef.current.mode
       : runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask')
     : currentSession?.permissionMode ?? 'ask';
   // 权限模式独立浮窗(2026-07-29 用户裁决,对齐 Codex 与新建页):composer 左侧图标钮

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -6644,8 +6644,8 @@ export default function SessionScreen() {
     if (queueBusy) return;
     if (remoteStopUnavailable) {
       setError(status === 'online'
-        ? '[DEVICE_OFFLINE] target device unavailable'
-        : '[NOT_CONNECTED] relay reconnecting');
+        ? '[DEVICE_OFFLINE]'
+        : '[NOT_CONNECTED]');
       return;
     }
     setStopPending(true);

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -895,7 +895,6 @@ export default function SessionScreen() {
     connectionIssue,
     getPresenceAvailability,
     invoke,
-    lastPresenceSnapshot,
     openLink,
     status,
     subscribe,
@@ -1525,11 +1524,11 @@ export default function SessionScreen() {
   const [extraDirBrowseLoading, setExtraDirBrowseLoading] = useState(false);
   const [extraDirBrowseError, setExtraDirBrowseError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  // UI 错误可被任意操作清掉；transport hold 独立保留到当前设备完成一次权威同步。
-  // 否则「加载更早 / 刷新用量」的 setError(null) 会误放行仍在断线恢复中的 outbox。
+  // UI 错误可被任意操作清掉；transport hold 独立锁存所有连接恢复来源，直到当前
+  // 设备完成一次权威同步。error 可空：纯 relay / presence 断线未必产生请求错误。
   const [outboxTransportHold, setOutboxTransportHold] = useState<{
     deviceId: string;
-    error: string;
+    error: string | null;
   } | null>(null);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   // 会话已读回执的同步门槛 key:`${sessionId}:${connectionEpoch}`,由 syncSession 尾部写入。
@@ -1769,45 +1768,73 @@ export default function SessionScreen() {
     isDeviceAccessRevoked ? '[ACCESS_REVOKED] access revoked by target device' : error,
     isDeviceUnresponsive,
   );
-  // dispatch / Stop 只认 Context 内随 connection epoch 重置的三态 verdict。
-  // lastPresenceSnapshot 与下方 ref 只用于 false→true 的 resync edge，不能作为门禁：
-  // 它们会跨 epoch 保留，旧 offline 否则会把新连接永久卡死。
+  // dispatch / Stop 与恢复 edge 共用 Context 内随 connection epoch 重置的三态 verdict，
+  // 不再拿跨 epoch 保留的旧 presence 快照作第二份可用性真源。
   const targetAvailableForDispatch = getPresenceAvailability(deviceId);
   const screenAutoRecoveringError = connectionError && isAutoRecoveringRemoteError(connectionError)
     ? connectionError
     : null;
-  const heldOutboxTransportError = outboxTransportHold?.deviceId === deviceId
+  const hasLatchedOutboxTransportHold = outboxTransportHold?.deviceId === deviceId;
+  const heldOutboxTransportError = hasLatchedOutboxTransportHold
     ? outboxTransportHold.error
     : null;
+  const latchOutboxTransportHold = useCallback((nextError: string | null) => {
+    if (!deviceId) return;
+    setOutboxTransportHold((current) => {
+      const currentError = current?.deviceId === deviceId ? current.error : null;
+      const errorForHold = nextError ?? currentError;
+      if (current?.deviceId === deviceId && current.error === errorForHold) return current;
+      return { deviceId, error: errorForHold };
+    });
+  }, [deviceId]);
   // 当前 error 比旧 hold 更新：确定性错误出现时必须立即压过旧的断线提示；只有
   // 当前 error 已清空，才继续沿用 hold 等权威同步收口。
   const activeOutboxTransportError = connectionError === null
     ? heldOutboxTransportError
     : screenAutoRecoveringError;
-  useEffect(() => {
-    if (!deviceId || !connectionError) return;
-    if (!screenAutoRecoveringError) {
-      setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);
-      return;
-    }
-    setOutboxTransportHold((current) => (
-      current?.deviceId === deviceId && current.error === screenAutoRecoveringError
-        ? current
-        : { deviceId, error: screenAutoRecoveringError }
-    ));
-  }, [connectionError, deviceId, screenAutoRecoveringError]);
+  // 连接阻塞一旦出现就锁存。layout effect 早于下方 passive pump effect，保证同一
+  // commit 的状态翻转也先关门；成功 sync 尾是唯一清门位置，失败（含 NOT_FOUND）
+  // 都不能拿旧 session 行派发。
+  useLayoutEffect(() => {
+    const connectionBlocked = status !== 'online'
+      || targetAvailableForDispatch === false
+      || isDeviceUnresponsive
+      || screenAutoRecoveringError !== null;
+    if (!connectionBlocked) return;
+    latchOutboxTransportHold(screenAutoRecoveringError);
+  }, [
+    isDeviceUnresponsive,
+    latchOutboxTransportHold,
+    screenAutoRecoveringError,
+    status,
+    targetAvailableForDispatch,
+  ]);
+  // 若 offline→online 被 React 合并进单次 render，旧连接代没有机会先锁存；render
+  // 阶段直接比较 epoch / presence edge，挡住本帧 pump。对应 effect 随即锁存 hold
+  // 并启动 sync，后续仍只由成功尾解除。
+  const connectionEpochRecoverySyncPending = status === 'online'
+    && syncedConnectionEpochRef.current !== connectionEpoch;
+  const presenceRecoverySyncPending = status === 'online'
+    && targetAvailableForDispatch === true
+    && (
+      targetAvailableDeviceRef.current !== deviceId
+      || targetAvailableRef.current !== true
+    );
+  const outboxRecoverySyncHeld = hasLatchedOutboxTransportHold
+    || connectionEpochRecoverySyncPending
+    || presenceRecoverySyncPending;
   // 对齐 Desktop：输入与发送仍可排队，但模型、权限、Plan、停止等需要即时访问
   // 被控端的操作在明确断线时禁用。presence unknown 仍允许，避免旧缓存永久锁死入口。
   const remoteRealtimeControlsUnavailable = status !== 'online'
     || targetAvailableForDispatch === false
     || isDeviceUnresponsive
-    || activeOutboxTransportError !== null;
+    || outboxRecoverySyncHeld;
   const remoteStopUnavailable = remoteRealtimeControlsUnavailable;
   const outboxConnectionState: MobileOutboxConnectionState = {
     relayOnline: status === 'online',
     targetAvailable: targetAvailableForDispatch,
     deviceUnresponsive: isDeviceUnresponsive,
-    autoRecoveringError: activeOutboxTransportError !== null,
+    autoRecoveringError: outboxRecoverySyncHeld,
     syncInProgress: loading,
   };
   // pumpOutbox 是跨 render 的 async 循环，每轮必须读最新连接态；只捕获某一帧会在
@@ -3692,24 +3719,27 @@ export default function SessionScreen() {
       if (!syncRun.isStale()) {
         const formatted = formatRemoteError(err);
         setError(formatted);
-        // transient 失败刷新 hold，保证共享 UI error 被其它操作清理时 outbox 仍不
-        // 提前派发；确定性失败则清旧 hold，交给普通错误与手动重试入口处理。
-        setOutboxTransportHold((current) => {
-          if (!isAutoRecoveringRemoteError(err)) {
-            return current?.deviceId === deviceId ? null : current;
-          }
-          return current?.deviceId === deviceId && current.error === formatted
-            ? current
-            : { deviceId, error: formatted };
-        });
+        // 两类失败都写入 hold 且不能清门：瞬态错误继续自动重试，确定性错误保留
+        // 手动同步入口；共享 UI error 被其它操作清掉时也不会变成不可见的永久自锁。
+        latchOutboxTransportHold(formatted);
       }
     } finally {
       if (!syncRun.isStale()) setLoading(false);
     }
-  }, [deviceId, deviceName, maker, openLink, sessionId, subscribe]);
+  }, [deviceId, deviceName, latchOutboxTransportHold, maker, openLink, sessionId, subscribe]);
+  // 任一连接恢复身份变化都会让旧读取失去提交资格。否则断线前启动的同步可能在
+  // 新 hold 锁存后迟到，并从成功尾误清恢复屏障。
+  const remoteSyncContextKey = JSON.stringify([
+    deviceId,
+    sessionId,
+    connectionEpoch,
+    status,
+    targetAvailableForDispatch,
+    isDeviceUnresponsive,
+  ]);
   const requestSync = useRemoteSyncCoordinator(
     (run) => syncSession(run),
-    `${deviceId}:${sessionId}`,
+    remoteSyncContextKey,
   );
   const load = useCallback(
     () => requestSync({ reason: 'passive-refresh' }),
@@ -4043,20 +4073,25 @@ export default function SessionScreen() {
   useEffect(() => {
     if (status !== 'online') return;
     if (syncedConnectionEpochRef.current === connectionEpoch) return;
+    latchOutboxTransportHold(null);
     syncedConnectionEpochRef.current = connectionEpoch;
     void load();
-  }, [connectionEpoch, load, status]);
+  }, [connectionEpoch, latchOutboxTransportHold, load, status]);
 
   useEffect(() => {
-    if (!lastPresenceSnapshot || lastPresenceSnapshot.deviceId !== deviceId) return;
-    const available = lastPresenceSnapshot.online && lastPresenceSnapshot.remoteControlEnabled;
-    const wasAvailable = targetAvailableDeviceRef.current === deviceId
+    const sameDevice = targetAvailableDeviceRef.current === deviceId;
+    const wasAvailable = sameDevice
       ? targetAvailableRef.current
       : null;
     targetAvailableDeviceRef.current = deviceId ?? null;
-    targetAvailableRef.current = available;
-    if (available && wasAvailable === false && status === 'online') void load();
-  }, [deviceId, lastPresenceSnapshot, load, status]);
+    targetAvailableRef.current = targetAvailableForDispatch;
+    if (targetAvailableForDispatch === true && wasAvailable !== true && status === 'online') {
+      latchOutboxTransportHold(null);
+      // 首次进入 / 原地换设备已有 mount effect 负责同步；同设备的 unknown|false→true
+      // 是 context 变化废弃旧轮次后的恢复沿，必须补一轮新 identity 的读取。
+      if (sameDevice) void load();
+    }
+  }, [deviceId, latchOutboxTransportHold, load, status, targetAvailableForDispatch]);
 
   useEffect(() => {
     if (currentSession || !deviceId || !sessionId || loading || status !== 'online') return;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -705,14 +705,6 @@ function isAutoRecoveringSessionReferencePreparationError(err: unknown): boolean
     || (err instanceof MobileSessionReferenceError && err.code === 'SESSION_REFERENCE_OFFLINE');
 }
 
-/**
- * 明确未发出的连接失败和「请求可能已到桌面、只丢了回执」都留在 outbox。
- * 后一类必须复用原 clientId 重试，由桌面 enqueue 幂等去重，不能恢复草稿后生成新 id。
- */
-function shouldWaitForOutboxEnqueueRecovery(err: unknown): boolean {
-  return isSafelyUnsentOutboxEnqueueError(err) || isAutoRecoveringRemoteError(err);
-}
-
 /** enqueue 对可安全重发的瞬时传输错误做有界退避。 */
 const ENQUEUE_RECONNECT_RETRIES = 3;
 const ENQUEUE_RECONNECT_BACKOFF_MS = 300;
@@ -5557,23 +5549,46 @@ export default function SessionScreen() {
       );
     } catch (err) {
       // 与原路径同口径:先对账分辨「确实没应用」vs「已应用但响应丢了」。
-      const applied = await (async (): Promise<boolean> => {
-        const authorityEpochAtReconcileStart =
-          remoteSessionStore.captureInputProjectionAuthorityEpoch(item.sessionId);
+      const safeToRetry = isSafelyUnsentOutboxEnqueueError(err);
+      const acceptanceUnknown = !safeToRetry && isAutoRecoveringRemoteError(err);
+      if (acceptanceUnknown) {
+        // 写请求已出、回执不确定时，fresh projection 不含 clientId 也不能证明没应用：
+        // 空闲 agent 可能已把消息从 pendingQueue 取进 active turn。只在 fresh 明确
+        // 含原 id 时吸收它；否则保留现有 optimistic projection，交给后续权威同步
+        // 收敛。这里绝不回 outbox / 草稿，避免离场后用新 id 重发造成重复执行。
         try {
+          const projectionEpochAtRequestStart =
+            remoteSessionStore.captureInputProjectionAuthorityEpoch(item.sessionId);
+          const fresh = await maker.input.getProjection(item.sessionId);
+          if (fresh.pendingQueue.some((entry) => entry.clientId === queued.clientId)) {
+            remoteSessionStore.setInputProjectionIfCurrent(
+              item.sessionId,
+              fresh,
+              projectionEpochAtRequestStart,
+            );
+          }
+        } catch {
+          // 自动恢复同步会继续收敛；当前 optimistic clientId 仍是唯一 Mobile owner。
+        }
+        if (outboxSessionAliveRef.current === item.sessionId) {
+          setError(formatRemoteError(err));
+        }
+        return;
+      }
+      const applied = await (async () => {
+        try {
+          const projectionEpochAtRequestStart =
+            remoteSessionStore.captureInputProjectionAuthorityEpoch(item.sessionId);
           const fresh = await maker.input.getProjection(item.sessionId);
           remoteSessionStore.setInputProjectionIfCurrent(
             item.sessionId,
             fresh,
-            authorityEpochAtReconcileStart,
+            projectionEpochAtRequestStart,
           );
-          // applied 判定只认这次 RPC 返回的权威 projection。fence 被 turn boundary
-          // 拒绝时，本地 store 仍可能只是我们刚 append 的乐观项，绝不能拿来自证。
+          // safeToRetry 时 fresh 是同 clientId 先前重试是否已经生效的唯一证据；本地
+          // optimistic pendingQueue 不能自证。确定性远端失败也沿用同一权威口径。
           return fresh.pendingQueue.some((entry) => entry.clientId === queued.clientId);
         } catch {
-          // 本地乐观 projection 本来就含这个 clientId，不能拿它自证送达；通用
-          // authority epoch 还会被 turn boundary 推进，并不代表 pendingQueue 收到
-          // 了权威替换。对账失败时一律按「无法证明已送达」处理。
           return false;
         }
       })();
@@ -5583,7 +5598,7 @@ export default function SessionScreen() {
           ...current,
           pendingQueue: current.pendingQueue.filter((entry) => entry.clientId !== queued.clientId),
         });
-        if (shouldWaitForOutboxEnqueueRecovery(err)) {
+        if (safeToRetry) {
           waitForConnection(err);
           return 'deferred' as const;
         }
@@ -5591,8 +5606,8 @@ export default function SessionScreen() {
       }
       // applied:消息已在桌面队列,按成功继续(不回滚、不报错)。
     } finally {
-      // 落定(入队确认 / 回 outbox 标失败)后收掉转圈:失败条目的气泡由 outbox 侧
-      // 重新持有(它自己画错误徽标),排队行里不该留下悬空的在途标记。
+      // 入队确认、回 outbox / 失败，或转交 optimistic projection 等待权威同步后，
+      // 都不再是当前 RPC 在途；收掉 sending 标记，避免后续同 id 气泡悬空转圈。
       clearQueueItemSending(queued.clientId);
     }
     // enqueue / 对账期间离场时，成功路径无需恢复草稿，但旧 pump 也绝不能接着
@@ -6235,9 +6250,6 @@ export default function SessionScreen() {
       }
       // await 之后闭包里的 attachments 是旧值,经 ref 拿含刚落定图片的最新列表。
       const sendAttachments = attachmentsRef.current;
-      const sendAttachmentPreviews = sendAttachments.map(
-        (attachment) => attachmentPreviews[attachment.id] ?? null,
-      );
       // currentSession 同理是等待前的快照:上传等待期间(sending 不锁控制面板)用户
       // 可能已切 model / effort / permission / fast,重读 store 拿最新会话字段,
       // 排队消息与 UI 显示的运行时保持一致(codex review R19)。
@@ -6552,25 +6564,24 @@ export default function SessionScreen() {
         // 回滚前先分辨「确实没应用」vs「已应用但响应丢了」:弱网下 enqueue 的 invoke
         // 响应可能超时丢失而桌面端已入队——此时摘除气泡会让手机隐藏一条桌面将处理的
         // 消息,用户重发即重复(codex review R19)。优先 refetch 权威 projection 判断,
-        // refetch 失败时不能拿本地乐观 projection 自证送达。
-        const applied = await (async (): Promise<boolean> => {
-          const authorityEpochAtReconcileStart =
-            remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
+        // refetch 也失败再退回本地 store(订阅推送在此窗口内可能已带回该 clientId)。
+        const applied = await (async () => {
           try {
+            const projectionEpochAtRequestStart =
+              remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
             const fresh = await maker.input.getProjection(sessionId);
-            remoteSessionStore.setInputProjectionIfCurrent(
+            const accepted = remoteSessionStore.setInputProjectionIfCurrent(
               sessionId,
               fresh,
-              authorityEpochAtReconcileStart,
+              projectionEpochAtRequestStart,
             );
-            // store 写入可被更新的 turn boundary 挡住，但送达证据只来自刚返回的
-            // 权威 projection；本地乐观 pendingQueue 没有证明资格。
-            return fresh.pendingQueue.some((item) => item.clientId === queued.clientId);
+            // If a newer push/terminal boundary won the fence, the fetched value is
+            // stale for both the mirror and the applied decision; consult current state.
+            const current = accepted ? fresh : remoteSessionStore.getInputProjection(sessionId);
+            return current.pendingQueue.some((item) => item.clientId === queued.clientId);
           } catch {
-            // 本地乐观 projection 不能自证送达；通用 authority epoch 还会被 turn
-            // boundary 推进，并不代表 pendingQueue 收到权威替换。对账失败时一律
-            // 按「无法证明已送达」处理。
-            return false;
+            return remoteSessionStore.getInputProjection(sessionId).pendingQueue
+              .some((item) => item.clientId === queued.clientId);
           }
         })();
         if (!applied) {
@@ -6581,52 +6592,18 @@ export default function SessionScreen() {
             ...current,
             pendingQueue: current.pendingQueue.filter((item) => item.clientId !== queued.clientId),
           });
-          const recoverableItem = buildOutboxItem({
-            clientId: queued.clientId,
-            sessionId,
-            text,
-            quotesEncoded: quotesEncodedAtSend,
-            sessionRefs: sessionRefsAtSend,
-            agentReferences: agentReferencesAtSend,
-            pastedTextRanges: pastedTextRangesAtSend,
-            slashCommandRanges: slashCommandRangesAtSend ?? [],
-            permissionModeAtSend: sessionAtSend.permissionMode,
-            readyAttachments: sendAttachments,
-            readyPreviews: sendAttachmentPreviews,
-            claimedUploads: [],
-          });
-          if (outboxSessionAliveRef.current !== sessionId) {
-            // await 期间原地切任务 / 退屏：两类失败都不能恢复进 B 的 composer，
-            // 也不能继续执行后续 UI 清理。交回 A 的持久草稿后直接收口。
-            salvageOutboxItem(recoverableItem);
-            return;
-          }
-          if (shouldWaitForOutboxEnqueueRecovery(err) && !legacyPlanRequiresLiveDispatch) {
-            // 明确未发出或 enqueue 已到桌面但回执不确定：都把同一 clientId/内容
-            // 接回 outbox。恢复后同 id 重试由桌面幂等去重，不能恢复草稿让用户用
-            // 新 id 重发，否则第一次其实已执行时会产生重复任务。
-            updateOutbox((items) => (
-              items.some((item) => item.clientId === recoverableItem.clientId)
-                ? replaceOutboxItem(items, recoverableItem)
-                : [recoverableItem, ...items]
-            ));
-            setError(formatRemoteError(err));
-          } else {
-            // 旧协议 Plan 依赖实时会话权限，不能在这里转入恢复后自动重试的 outbox；
-            // 沿用改动前的在线失败收口，把内容与附件完整交还 composer。
-            // 合并而非替换(与成功路径的差集清理对称,codex review R11):enqueue 在途期间
-            // 新落定的附件已进 attachments / ref,整体覆盖会把它从托盘丢掉且预览映射残留、
-            // OSS 中转对象失去 UI 移除路径;恢复本批的同时保留期间新增。
-            const restoredIds = new Set(sendAttachments.map((attachment) => attachment.id));
-            const mergeRestored = (current: RemoteSerializedAttachment[]) => [
-              ...sendAttachments,
-              ...current.filter((attachment) => !restoredIds.has(attachment.id)),
-            ];
-            attachmentsRef.current = mergeRestored(attachmentsRef.current);
-            setAttachments(mergeRestored);
-            restoreDirectSendDraftAfterFailure();
-            throw err;
-          }
+          // 在线直发一旦开始 enqueue 就不再转入本 PR 的页面 outbox。该 outbox 只
+          // 拥有写请求开始前已知要等待的消息；在线失败继续沿用既有收口，避免为
+          // 离场回执不确定场景新增跨页 clientId owner。
+          const restoredIds = new Set(sendAttachments.map((attachment) => attachment.id));
+          const mergeRestored = (current: RemoteSerializedAttachment[]) => [
+            ...sendAttachments,
+            ...current.filter((attachment) => !restoredIds.has(attachment.id)),
+          ];
+          attachmentsRef.current = mergeRestored(attachmentsRef.current);
+          setAttachments(mergeRestored);
+          restoreDirectSendDraftAfterFailure();
+          throw err;
         }
         // applied:消息已在桌面队列(权威 / 推送 projection 已含该 clientId),
         // 按成功继续——不回滚、不报错,后续收尾(plan 恢复 / 映射清理)照常执行。

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -6035,7 +6035,6 @@ export default function SessionScreen() {
     if (legacyPlanRequiresLiveDispatch && (
       dispatchBlockedAtSend || outboxRef.current.length > 0 || outboxPumpBusyRef.current
     )) {
-      if (dispatchBlockedAtSend) setError(t('session.menu.aiRenameOffline'));
       sendInFlightRef.current = false;
       setSending(false);
       return;

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -79,9 +79,12 @@ import { useDeviceLink } from '@/device-link/DeviceLinkContext';
 import { useRevokedDevices } from '@/device-link/revokedDevicesStore';
 import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import {
+  connectionIssueHint,
+  describeRemoteComposerBlockingError,
   describeRemoteError,
   formatRemoteError,
   humanizeRemoteError,
+  isAutoRecoveringRemoteError,
   isPreconditionFailedRemoteError,
 } from '@/device-link/remoteStatus';
 import { agentAuthGateHint, agentAuthGateVerdict } from '@/session/agentAuthGate';
@@ -334,14 +337,18 @@ import { useMobileLocalAttachments } from '@/session/useMobileLocalAttachments';
 import {
   buildOutboxItem,
   createOutboxClientId,
+  isSafelyUnsentOutboxEnqueueError,
   outboxDisplayItem,
   outboxItemAttachments,
   outboxItemReady,
   outboxItemRetrying,
+  outboxItemWaitingForConnection,
   outboxItemWithEnqueueFailure,
   outboxWithUploadResult,
   recoverOutboxItemsToComposerDraft,
   replaceOutboxItem,
+  shouldHoldOutboxDispatchForConnection,
+  type MobileOutboxConnectionState,
   type MobileOutboxItem,
   type MobileRecoverableDraftItem,
 } from '@/session/sessionOutbox';
@@ -472,6 +479,7 @@ import {
 } from '@/session/sessionLinks';
 import {
   extractMobileSessionReferences,
+  MobileSessionReferenceError,
   prepareMobileQueuedSessionReferences,
   prepareMobileQueuedSessionReferencesForSteer,
 } from '@/session/sessionReferences';
@@ -688,6 +696,12 @@ function isRetryableEnqueueTransportError(err: unknown): boolean {
     || formatted.includes('[DEVICE_LINK_NOT_CONNECTED]')
     || formatted.includes('[BACKPRESSURE]')
   );
+}
+
+/** 引用 capability 查询是只读前置步骤，离线后可安全等待连接恢复再做。 */
+function isAutoRecoveringSessionReferencePreparationError(err: unknown): boolean {
+  return isAutoRecoveringRemoteError(err)
+    || (err instanceof MobileSessionReferenceError && err.code === 'SESSION_REFERENCE_OFFLINE');
 }
 
 /** enqueue 对可安全重发的瞬时传输错误做有界退避。 */
@@ -1727,6 +1741,7 @@ export default function SessionScreen() {
   const appliedRouteFocusKeyRef = useRef<string | null>(null);
   const appliedRouteComposerFocusKeyRef = useRef<string | null>(null);
   const targetAvailableRef = useRef<boolean | null>(null);
+  const targetAvailableDeviceRef = useRef<string | null>(null);
   // 记录已为哪个连接 epoch 触发过 resync;初值 = 首渲染时的 epoch,使首开由 mount effect 单独负责,
   // 这个 epoch effect 只在真正重连(epoch 变化)时再同步,避免首开连环重 sync 导致列表重排跳动。
   const syncedConnectionEpochRef = useRef(connectionEpoch);
@@ -1745,6 +1760,31 @@ export default function SessionScreen() {
   const connectionError = resolveEffectiveConnectionError(
     isDeviceAccessRevoked ? '[ACCESS_REVOKED] access revoked by target device' : error,
     isDeviceUnresponsive,
+  );
+  // Presence 是全局流，最后一帧可能属于别的设备；只复用明确属于当前 deviceId 的
+  // 记忆，避免原地切设备后拿上一台电脑的 online 状态误派发。
+  const targetAvailableForDispatch = lastPresenceSnapshot?.deviceId === deviceId
+    ? lastPresenceSnapshot.online && lastPresenceSnapshot.remoteControlEnabled
+    : targetAvailableDeviceRef.current === deviceId
+      ? targetAvailableRef.current
+      : null;
+  // 对齐 Desktop:断线恢复期间设置入口仍可操作,但明确知道电脑不可达时拦下停止任务。
+  // presence 未知时仍允许尝试,避免旧缓存把停止入口永久锁死。
+  const remoteStopUnavailable =
+    status !== 'online' || targetAvailableForDispatch === false;
+  const outboxConnectionState: MobileOutboxConnectionState = {
+    relayOnline: status === 'online',
+    targetAvailable: targetAvailableForDispatch,
+    deviceUnresponsive: isDeviceUnresponsive,
+    autoRecoveringError: isAutoRecoveringRemoteError(connectionError),
+    syncInProgress: loading,
+  };
+  // pumpOutbox 是跨 render 的 async 循环，每轮必须读最新连接态；只捕获某一帧会在
+  // 派发第一条期间掉线后继续把后续 FIFO 条目打进已经断开的链路。
+  const outboxConnectionStateRef = useRef(outboxConnectionState);
+  outboxConnectionStateRef.current = outboxConnectionState;
+  const outboxConnectionDispatchBlocked = shouldHoldOutboxDispatchForConnection(
+    outboxConnectionState,
   );
   // 弱网普通断线也要有可见信号(消息流静默停更没有任何提示),经防闪延迟后显示
   const showConnectionBanner = useShowConnectionBanner(status, connectionError, connectionIssue, isDeviceUnresponsive);
@@ -1890,6 +1930,16 @@ export default function SessionScreen() {
     () => describeRemoteError(connectionError),
     [connectionError],
   );
+  // 自动恢复类错误只影响 outbox 派发，不锁 composer；确定性错误（撤权、关闭远程
+  // 控制、版本不兼容等）仍按原规则禁发。连接 issue 沿用 banner 的 active 判定，
+  // unstable 属于自动恢复，其余需要用户先修复连接身份/版本。
+  const activeComposerConnectionIssue = status !== 'online' || connectionIssue?.kind === 'unstable'
+    ? connectionIssue
+    : null;
+  const composerRemoteUnavailableReason = activeComposerConnectionIssue
+    && activeComposerConnectionIssue.kind !== 'unstable'
+      ? connectionIssueHint(activeComposerConnectionIssue.kind)
+      : describeRemoteComposerBlockingError(connectionError);
   // 缓存种入的会话行只是首屏骨架:字段经瘦身/截断(240 字符),不能作为发送参数
   // (buildQueuedTextMessage 会把 workingDir / model / permission 复制进队列请求)。
   const cacheSeededReason = currentSession?.cacheSeeded
@@ -1901,9 +1951,10 @@ export default function SessionScreen() {
   const pendingCreationReason = currentSession?.pendingLocalCreation
     ? t('session.screen.composerCreating')
     : null;
-  // 会话设置类动作(model / effort / fast / permission / plan)在会话建成前不可用:
-  // 它们是打到被控端会话的 RPC。cacheSeeded 不锁——那种会话在被控端是存在的,只是
-  // 本地行还是瘦身缓存。硬门在 runControlAction 里,这里供按钮表达灰态。
+  // 会话设置类动作(model / effort / fast / permission / plan)仅在会话尚未建成时不可用。
+  // 对齐 Desktop,暂时断线时入口继续可点:现有乐观 RPC 会在失败后回滚并展示提示。
+  // cacheSeeded 不锁——那种会话在被控端是存在的,只是本地行还是瘦身缓存。
+  // 硬门在 runControlAction 里,这里供按钮表达灰态。
   // 判据与命令式路径共用 isRemoteSessionMissing(见其注释):这里是渲染需要的
   // reactive 形态,send / runControlAction 用读 store 的 Now 形态。
   const sessionSettingsLocked = isRemoteSessionMissing(currentSession);
@@ -1917,11 +1968,11 @@ export default function SessionScreen() {
       hasCurrentSession,
       hasActivePendingInteraction,
       pendingInteractionBlocksComposer,
-      remoteUnavailableReason,
+      remoteUnavailableReason: composerRemoteUnavailableReason,
       // composer 用 composer-only reason:Lead → editable(可发消息),worker → read-only。
       readOnlyReason: composerReadOnlyReason,
     }),
-    [composerReadOnlyReason, hasActivePendingInteraction, hasCurrentSession, pendingInteractionBlocksComposer, remoteUnavailableReason],
+    [composerReadOnlyReason, composerRemoteUnavailableReason, hasActivePendingInteraction, hasCurrentSession, pendingInteractionBlocksComposer],
   );
   useEffect(() => {
     if (!pendingInteractionActiveRequestId) return;
@@ -1952,6 +2003,7 @@ export default function SessionScreen() {
     }
   }, [activePendingKind, activePendingRequestId, sessionOperationLayout.composerSlot]);
   const canUseComposer = sessionOperationLayout.canUseComposer;
+  const canUseRemoteSessionControls = canUseComposer && !sessionSettingsLocked;
   // 共享模型自造的那两条禁发理由是中文直出,而它会经 composer 与队列行的
   // accessibility hint 读给用户 —— 按 locale 翻译后再用,否则读屏在 en / ja / ko
   // 下念混语(#530 review)。调用方自己传进去的理由(离线 / 只读 / 同步中)已本地化,
@@ -1966,8 +2018,8 @@ export default function SessionScreen() {
   // interaction 等),inline 化后气泡必须留在消息流里,故改为保留渲染、按同一规则
   // 禁用操作(取消/编辑/插话/重试/恢复),禁用理由沿用 composerDisabledReason。
   // 会话参数未就绪(缓存种入 / 新建在途)时队列行仍只读:取消 / 编辑 / 插队都是打到
-  // 被控端队列的 RPC,会话在那边可能还不存在。composer 已按乐观语义放开,只有这些
-  // 队列操作留在禁用档。
+  // 被控端队列的 RPC,会话在那边可能还不存在。暂时断线则与 Desktop 一致继续允许
+  // 尝试,失败由 runQueueAction 报错,不把连接恢复职责转嫁给用户。
   const queueInlineReadOnlyReason = collaborationReadOnlyReason
     ?? cacheSeededReason
     ?? pendingCreationReason
@@ -2208,7 +2260,7 @@ export default function SessionScreen() {
     // pending(乐观上传中)计入:拍完照 / 选完文件立即可点发送,send() 内部会等落定。
     attachmentCount: attachments.length + pendingUploads.length,
     attachmentPickerOpen: false,
-    canStop: canUseComposer && canStopComposer,
+    canStop: canUseRemoteSessionControls && canStopComposer,
     draftText: draft,
     queueBusy,
     quoteCount: composerQuoteCount,
@@ -2219,6 +2271,7 @@ export default function SessionScreen() {
     attachments.length,
     pendingUploads.length,
     canStopComposer,
+    canUseRemoteSessionControls,
     canUseComposer,
     composerQuoteCount,
     composerSendUnavailableReason,
@@ -2250,8 +2303,8 @@ export default function SessionScreen() {
     && !sending
     && !voiceIsBusy
     && !voiceStartPending;
-  // 降级 composer(未同步/离线):输入框可编辑并持续保存草稿,但发送禁用,
-  // 直到 currentSession 和远端连接恢复后自动恢复可发送。
+  // 只有确定性不可用(撤权 / 关闭远控等)才禁发送；普通断线与自动恢复状态仍可发，
+  // 消息进入本地 outbox 等连接恢复。输入框在两类状态下都保持可编辑与持久化。
   const composerSendDisabled = composerLayout.send.disabled;
   const composerShowInlineStop = composerLayout.stop.visible && !composerSendSlotIsStop && !sending;
   const composerHasPayload = composerHasText || attachments.length > 0 || pendingUploads.length > 0 || composerQuoteCount > 0;
@@ -2579,7 +2632,7 @@ export default function SessionScreen() {
       <RouteActionButton
         accessibilityLabel={t('models.picker.permissionModeAccessibility', { mode: presentation.label })}
         active={permissionSheetOpen}
-        disabled={controlBusy || !canUseComposer}
+        disabled={controlBusy || !canUseRemoteSessionControls}
         hitSlop={COMPOSER_CONTROL_HIT_SLOP}
         onPress={() => {
           setModelSheetOpen(false);
@@ -2917,10 +2970,10 @@ export default function SessionScreen() {
   }, [sessionId]);
 
   useEffect(() => {
-    if (canUseComposer) return;
+    if (canUseRemoteSessionControls) return;
     setModelSheetOpen(false);
     setPermissionSheetOpen(false);
-  }, [canUseComposer]);
+  }, [canUseRemoteSessionControls]);
 
   useEffect(() => {
     const subscription = AppState.addEventListener('change', (nextState) => {
@@ -3050,7 +3103,7 @@ export default function SessionScreen() {
   }, [draft, sessionId]);
 
   useEffect(() => {
-    if (!canUseComposer || composerTrigger.kind !== 'slash' || !currentSession || !deviceId) {
+    if (!canUseRemoteSessionControls || composerTrigger.kind !== 'slash' || !currentSession || !deviceId) {
       slashLoadSeqRef.current += 1;
       setSlashCommands([]);
       setSlashPaletteLoading(false);
@@ -3131,10 +3184,10 @@ export default function SessionScreen() {
       .finally(() => {
         if (slashLoadSeqRef.current === seq) setSlashPaletteLoading(false);
       });
-  }, [canUseComposer, composerTrigger.kind, currentSession, deviceId, maker, openLink]);
+  }, [canUseRemoteSessionControls, composerTrigger.kind, currentSession, deviceId, maker, openLink]);
 
   useEffect(() => {
-    if (!canUseComposer || composerTrigger.kind !== 'at' || !currentSession?.workingDir || !deviceId) {
+    if (!canUseRemoteSessionControls || composerTrigger.kind !== 'at' || !currentSession?.workingDir || !deviceId) {
       atLoadSeqRef.current += 1;
       setAtResources([]);
       setAtPaletteLoading(false);
@@ -3235,7 +3288,7 @@ export default function SessionScreen() {
         });
     }, query === '' ? 0 : AT_RESOURCE_QUERY_DEBOUNCE_MS);
     return () => clearTimeout(timer);
-  }, [canUseComposer, composerTrigger, currentSession, deviceId, maker, openLink]);
+  }, [canUseRemoteSessionControls, composerTrigger, currentSession, deviceId, maker, openLink]);
 
   useEffect(() => {
     if (!currentAgentKind || !deviceId) {
@@ -3937,7 +3990,10 @@ export default function SessionScreen() {
   useEffect(() => {
     if (!lastPresenceSnapshot || lastPresenceSnapshot.deviceId !== deviceId) return;
     const available = lastPresenceSnapshot.online && lastPresenceSnapshot.remoteControlEnabled;
-    const wasAvailable = targetAvailableRef.current;
+    const wasAvailable = targetAvailableDeviceRef.current === deviceId
+      ? targetAvailableRef.current
+      : null;
+    targetAvailableDeviceRef.current = deviceId ?? null;
     targetAvailableRef.current = available;
     if (available && wasAvailable === false && status === 'online') void load();
   }, [deviceId, lastPresenceSnapshot, load, status]);
@@ -5299,6 +5355,7 @@ export default function SessionScreen() {
    * 切会话,消息必须始终发进它所属的会话(review P1)。
    */
   const dispatchOutboxItem = async (item: MobileOutboxItem) => {
+    if (outboxSessionAliveRef.current !== item.sessionId) return 'stopped' as const;
     const failItem = (message: string) => {
       // 归属校验:条目所属会话已离场(切会话 cleanup 已跑 / 屏已卸载)时不回插
       // 共享 ref——那会把 A 会话的失败气泡画进 B,或写进没人消费的 ref 让文字
@@ -5312,6 +5369,21 @@ export default function SessionScreen() {
           ? replaceOutboxItem(items, outboxItemWithEnqueueFailure(item, message))
           : [outboxItemWithEnqueueFailure(item, message), ...items]
       ));
+    };
+    const waitForConnection = (error: unknown) => {
+      // 与失败回插同一归属边界：离场后不能把旧会话气泡塞进当前页面，降级回该
+      // 会话的持久草稿；仍在本页则恢复为 uploading/ready，留在 FIFO 队首。
+      if (outboxSessionAliveRef.current !== item.sessionId) {
+        salvageOutboxItem(item);
+        return;
+      }
+      const waiting = outboxItemWaitingForConnection(item);
+      updateOutbox((items) => (
+        items.some((existing) => existing.clientId === item.clientId)
+          ? replaceOutboxItem(items, waiting)
+          : [waiting, ...items]
+      ));
+      setError(formatRemoteError(error));
     };
     const sessionNow = remoteSessionStore.getSessions().find((entry) => entry.id === item.sessionId);
     if (!sessionNow) {
@@ -5344,9 +5416,17 @@ export default function SessionScreen() {
         deviceId,
       );
     } catch (err) {
+      // prepare 期间条目仍在 outbox；离场 cleanup 已负责恢复草稿与回收附件，
+      // 这里既不能重复 salvage，也不能让旧 continuation 继续 enqueue。
+      if (outboxSessionAliveRef.current !== item.sessionId) return 'stopped' as const;
+      if (isAutoRecoveringSessionReferencePreparationError(err)) {
+        waitForConnection(err);
+        return 'deferred' as const;
+      }
       failItem(formatRemoteError(err));
       return;
     }
+    if (outboxSessionAliveRef.current !== item.sessionId) return 'stopped' as const;
     // 乐观交接:进本地 pendingQueue 的同一同步段把条目移出 outbox,气泡原位从
     // 「发送中」变「排队中」不闪断;enqueue 成功后用权威 projection 覆盖 reconcile。
     const projectionBeforeSend = remoteSessionStore.getInputProjection(item.sessionId);
@@ -5392,21 +5472,24 @@ export default function SessionScreen() {
       );
     } catch (err) {
       // 与原路径同口径:先对账分辨「确实没应用」vs「已应用但响应丢了」。
-      const applied = await (async () => {
+      const applied = await (async (): Promise<boolean> => {
+        const authorityEpochAtReconcileStart =
+          remoteSessionStore.captureInputProjectionAuthorityEpoch(item.sessionId);
         try {
-          const projectionEpochAtRequestStart =
-            remoteSessionStore.captureInputProjectionAuthorityEpoch(item.sessionId);
           const fresh = await maker.input.getProjection(item.sessionId);
-          const accepted = remoteSessionStore.setInputProjectionIfCurrent(
+          remoteSessionStore.setInputProjectionIfCurrent(
             item.sessionId,
             fresh,
-            projectionEpochAtRequestStart,
+            authorityEpochAtReconcileStart,
           );
-          const current = accepted ? fresh : remoteSessionStore.getInputProjection(item.sessionId);
-          return current.pendingQueue.some((entry) => entry.clientId === queued.clientId);
+          // applied 判定只认这次 RPC 返回的权威 projection。fence 被 turn boundary
+          // 拒绝时，本地 store 仍可能只是我们刚 append 的乐观项，绝不能拿来自证。
+          return fresh.pendingQueue.some((entry) => entry.clientId === queued.clientId);
         } catch {
-          return remoteSessionStore.getInputProjection(item.sessionId).pendingQueue
-            .some((entry) => entry.clientId === queued.clientId);
+          // 本地乐观 projection 本来就含这个 clientId，不能拿它自证送达；通用
+          // authority epoch 还会被 turn boundary 推进，并不代表 pendingQueue 收到
+          // 了权威替换。对账失败时一律按「无法证明已送达」处理。
+          return false;
         }
       })();
       if (!applied) {
@@ -5415,6 +5498,10 @@ export default function SessionScreen() {
           ...current,
           pendingQueue: current.pendingQueue.filter((entry) => entry.clientId !== queued.clientId),
         });
+        if (isSafelyUnsentOutboxEnqueueError(err)) {
+          waitForConnection(err);
+          return 'deferred' as const;
+        }
         failItem(formatRemoteError(err));
       }
       // applied:消息已在桌面队列,按成功继续(不回滚、不报错)。
@@ -5423,15 +5510,24 @@ export default function SessionScreen() {
       // 重新持有(它自己画错误徽标),排队行里不该留下悬空的在途标记。
       clearQueueItemSending(queued.clientId);
     }
+    // enqueue / 对账期间离场时，成功路径无需恢复草稿，但旧 pump 也绝不能接着
+    // 消费新任务的 outbox；失败路径已由 failItem / waitForConnection 按 A 收口。
+    if (outboxSessionAliveRef.current !== item.sessionId) return 'stopped' as const;
   };
 
   /** 会话行的同步真源(store);命令式路径不能读可能落后一帧的 render 快照。 */
   const readSessionRowNow = () => remoteSessionStore.getSessions().find((item) => item.id === sessionId) ?? null;
 
+  /** async pump 每轮读取 ref 中的最新连接态，断线后立即停在当前 FIFO 队首。 */
+  const outboxConnectionBlockedNow = () => shouldHoldOutboxDispatchForConnection(
+    outboxConnectionStateRef.current,
+  );
+
   /**
    * 「会话参数还没就绪,现在不能 enqueue」——outbox 只排队不派发的判据。
    *
-   * 这三种状态下消息仍然照常上屏(乐观语义,composer 不进只读档),只是派发要等:
+   * 下列状态中消息仍然照常上屏(乐观语义,composer 不进只读档),只是派发要等:
+   *  - relay / 目标 presence 断开、设备熔断或请求命中自动恢复类错误;
    *  - 会话行还没到:没有任何可用的发送参数;
    *  - 缓存种入行:字段经瘦身 / 截断(240 字符),不能当发送参数;
    *  - 新建在途 / 创建管线未收口:会话可能还没在被控端建成,且首条 enqueue 落定前
@@ -5440,6 +5536,7 @@ export default function SessionScreen() {
    * 读 store 而非 render 快照:pump 是异步循环,每轮都要看当下的真相。
    */
   const outboxDispatchBlockedNow = () => {
+    if (outboxConnectionBlockedNow()) return true;
     const row = readSessionRowNow();
     // 「会话在被控端还不存在」是子集;派发还额外要求字段权威、创建管线已收口。
     if (isRemoteSessionMissing(row)) return true;
@@ -5459,7 +5556,8 @@ export default function SessionScreen() {
         // 下方的解禁 effect 重新 pump。
         if (outboxDispatchBlockedNow()) return;
         updateOutbox((items) => replaceOutboxItem(items, { ...head, phase: 'dispatching' }));
-        await dispatchOutboxItem({ ...head, phase: 'dispatching' });
+        const result = await dispatchOutboxItem({ ...head, phase: 'dispatching' });
+        if (result === 'deferred' || result === 'stopped') return;
       }
     } finally {
       outboxPumpBusyRef.current = false;
@@ -5743,14 +5841,15 @@ export default function SessionScreen() {
   const outboxDispatchBlocked = !currentSession
     || currentSession.cacheSeeded === true
     || currentSession.pendingLocalCreation === true
-    || creationTask !== null;
+    || creationTask !== null
+    || outboxConnectionDispatchBlocked;
   useEffect(() => {
     if (outboxDispatchBlocked) return;
     void pumpOutbox();
     // pumpOutbox 是每 render 重建的普通闭包,不入依赖(入了会每帧重跑);它内部读
     // outboxRef / store 的最新真相,不依赖捕获值。
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [outboxDispatchBlocked]);
+  }, [connectionEpoch, outboxDispatchBlocked]);
 
   async function send(options: {
     draftOverride?: string;
@@ -5800,9 +5899,12 @@ export default function SessionScreen() {
       if (options.documentOverride) applyComposerDocument(options.documentOverride);
       return;
     }
+    const connectionDispatchBlockedAtSend = outboxConnectionBlockedNow();
     sendInFlightRef.current = true;
     setSending(true);
-    setError(null);
+    // 自动恢复中的 error 也是 outbox 的派发门；先清掉会让刚入队的消息在下一帧
+    // 立刻撞回断链。真正恢复后的 load / connection epoch 会负责清理并唤醒 pump。
+    if (!connectionDispatchBlockedAtSend) setError(null);
     const outboxEligible = !queueEditAtSendStart;
     const uploadsInFlight = outboxEligible ? getPendingUploadCount() : 0;
     const willHaveAttachments = attachmentsRef.current.length > 0 || uploadsInFlight > 0;
@@ -5860,6 +5962,21 @@ export default function SessionScreen() {
         applyComposerDocument(documentBeforeSend);
       }
     };
+    let scopeExitDraftRecovered = false;
+    const sendScopeStillAlive = () => outboxSessionAliveRef.current === sessionId;
+    const recoverCapturedDraftForScopeExit = () => {
+      if (scopeExitDraftRecovered || !outboxEligible) return;
+      scopeExitDraftRecovered = true;
+      // 乐观清空已持久删除 A 草稿；切到 B 后不能再读写共享 composer ref。
+      // 直接按捕获的发送快照合并回 A 的草稿库，并保留 A 期间新输入的后续文字。
+      restoreRecoverableItemsToDraft(sessionId, [{
+        text,
+        quotesEncoded: quotesEncodedAtSend,
+        agentReferences: agentReferencesAtSend,
+        pastedTextRanges: pastedTextRangesAtSend,
+        slashCommandRanges: slashCommandRangesAtSend ?? [],
+      }]);
+    };
     if (text) applyComposerDocument(documentAfterOptimisticClear);
     // A pasted message link is committed to the editor synchronously, while
     // its readable body is fetched from the source device asynchronously.
@@ -5870,6 +5987,12 @@ export default function SessionScreen() {
       documentAtSend,
       resolvePastedSessionLinkLabel,
     );
+    if (!sendScopeStillAlive()) {
+      recoverCapturedDraftForScopeExit();
+      sendInFlightRef.current = false;
+      setSending(false);
+      return;
+    }
     if (!composerDocumentsEqual(hydratedDocumentAtSend, documentAtSend)) {
       agentReferencesAtSend = queueEditAtSendStart
         ? resolveQueueEditTextSubmission(
@@ -5882,8 +6005,9 @@ export default function SessionScreen() {
     // 可能点 × 放弃或切换编辑目标——等待结束后以快照与最新 ref 比对,不一致则中止
     // 保存,防止编辑文本被当成一条全新消息发出(PR#709 review P1)。
     requestMessageListFollowLatest();
-    // —— 乐观 outbox 路径:附件仍在上传(或 outbox 已有排队消息,保 FIFO)时不再
-    // 原地等待,消息立即以待发气泡上屏,附件落定后由派发循环真正入队。豁免场景走
+    // —— 乐观 outbox 路径:附件仍在上传、消息含任务引用(其 capability 读取也可能
+    // 途中断线),或 outbox 已有排队消息时不再原地等待，消息立即以待发气泡上屏，
+    // 条件满足后由派发循环真正入队。豁免场景走
     // 下方原路径:排队编辑保存(语义是改队列原条目)、纯文本本地命令(/context 等,
     // 本地卡片无顺序问题;此时 composer 域无在途上传,waitForPendingUploads 秒回)。
     // 粘贴占位窗口(uploadsInFlight 计入占位数)同样走本分支:先等占位落定再划归,
@@ -5896,8 +6020,8 @@ export default function SessionScreen() {
     // 照常上屏,由派发循环在就绪后按序发出——composer 不再为此进只读档。
     const dispatchBlockedAtSend = outboxDispatchBlockedNow();
     if (outboxEligible && !earlyLocalCommand && !earlyDesktopCommand
-      && (uploadsInFlight > 0 || outboxRef.current.length > 0 || outboxPumpBusyRef.current
-        || dispatchBlockedAtSend)) {
+      && (sessionRefsAtSend.length > 0 || uploadsInFlight > 0 || outboxRef.current.length > 0
+        || outboxPumpBusyRef.current || dispatchBlockedAtSend)) {
       try {
         // workingDir 校验只对「此刻就能派发」的消息前置:dialogue 会话的工作目录由
         // 被控端在创建时分配,合成行此刻本就为空,而 dispatchOutboxItem 会在真正派发
@@ -5911,7 +6035,13 @@ export default function SessionScreen() {
         // 已入 controller;失败 / 超时 60s 兜底后同样放行,错误 toast 已由占位路径
         // 给出),不等上传本身。等待通常数百 ms(本机剪贴板),极端跨设备剪贴板由
         // 发送按钮转圈承载;等待期间 sendInFlightRef 挡住重入。
-        if (hasPastePlaceholders()) await waitForPastePlaceholdersSettled();
+        if (hasPastePlaceholders()) {
+          await waitForPastePlaceholdersSettled();
+          if (!sendScopeStillAlive()) {
+            recoverCapturedDraftForScopeExit();
+            return;
+          }
+        }
         // 划归:当前全部未 claim 上传任务(active + 失败卡)随本条消息走——离开
         // composer 托盘与限额,产物经 onUploaded/onError 的 localId 路由回填。
         const claimedUploads = claimActiveUploads();
@@ -5970,12 +6100,19 @@ export default function SessionScreen() {
       // 拍照 / 选图后立刻点发送是常见路径:等在途图片上传落定(乐观托盘)。
       // 有失败就中止发送——错误文案已由上传回调写入 attachmentError,让用户处理。
       const { failedCount } = await waitForPendingUploads();
+      if (!sendScopeStillAlive()) {
+        recoverCapturedDraftForScopeExit();
+        return;
+      }
       if (failedCount > 0) {
         restoreDraftAfterFailure();
         return;
       }
       // await 之后闭包里的 attachments 是旧值,经 ref 拿含刚落定图片的最新列表。
       const sendAttachments = attachmentsRef.current;
+      const sendAttachmentPreviews = sendAttachments.map(
+        (attachment) => attachmentPreviews[attachment.id] ?? null,
+      );
       // currentSession 同理是等待前的快照:上传等待期间(sending 不锁控制面板)用户
       // 可能已切 model / effort / permission / fast,重读 store 拿最新会话字段,
       // 排队消息与 UI 显示的运行时保持一致(codex review R19)。
@@ -6290,24 +6427,25 @@ export default function SessionScreen() {
         // 回滚前先分辨「确实没应用」vs「已应用但响应丢了」:弱网下 enqueue 的 invoke
         // 响应可能超时丢失而桌面端已入队——此时摘除气泡会让手机隐藏一条桌面将处理的
         // 消息,用户重发即重复(codex review R19)。优先 refetch 权威 projection 判断,
-        // refetch 也失败再退回本地 store(订阅推送在此窗口内可能已带回该 clientId)。
-        const applied = await (async () => {
+        // refetch 失败时不能拿本地乐观 projection 自证送达。
+        const applied = await (async (): Promise<boolean> => {
+          const authorityEpochAtReconcileStart =
+            remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
           try {
-            const projectionEpochAtRequestStart =
-              remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
             const fresh = await maker.input.getProjection(sessionId);
-            const accepted = remoteSessionStore.setInputProjectionIfCurrent(
+            remoteSessionStore.setInputProjectionIfCurrent(
               sessionId,
               fresh,
-              projectionEpochAtRequestStart,
+              authorityEpochAtReconcileStart,
             );
-            // If a newer push/terminal boundary won the fence, the fetched value is
-            // stale for both the mirror and the applied decision; consult current state.
-            const current = accepted ? fresh : remoteSessionStore.getInputProjection(sessionId);
-            return current.pendingQueue.some((item) => item.clientId === queued.clientId);
+            // store 写入可被更新的 turn boundary 挡住，但送达证据只来自刚返回的
+            // 权威 projection；本地乐观 pendingQueue 没有证明资格。
+            return fresh.pendingQueue.some((item) => item.clientId === queued.clientId);
           } catch {
-            return remoteSessionStore.getInputProjection(sessionId).pendingQueue
-              .some((item) => item.clientId === queued.clientId);
+            // 本地乐观 projection 不能自证送达；通用 authority epoch 还会被 turn
+            // boundary 推进，并不代表 pendingQueue 收到权威替换。对账失败时一律
+            // 按「无法证明已送达」处理。
+            return false;
           }
         })();
         if (!applied) {
@@ -6318,18 +6456,49 @@ export default function SessionScreen() {
             ...current,
             pendingQueue: current.pendingQueue.filter((item) => item.clientId !== queued.clientId),
           });
-          // 合并而非替换(与成功路径的差集清理对称,codex review R11):enqueue 在途期间
-          // 新落定的附件已进 attachments / ref,整体覆盖会把它从托盘丢掉且预览映射残留、
-          // OSS 中转对象失去 UI 移除路径;恢复本批的同时保留期间新增。
-          const restoredIds = new Set(sendAttachments.map((attachment) => attachment.id));
-          const mergeRestored = (current: RemoteSerializedAttachment[]) => [
-            ...sendAttachments,
-            ...current.filter((attachment) => !restoredIds.has(attachment.id)),
-          ];
-          attachmentsRef.current = mergeRestored(attachmentsRef.current);
-          setAttachments(mergeRestored);
-          restoreDraftAfterFailure();
-          throw err;
+          const recoverableItem = buildOutboxItem({
+            clientId: queued.clientId,
+            sessionId,
+            text,
+            quotesEncoded: quotesEncodedAtSend,
+            sessionRefs: sessionRefsAtSend,
+            agentReferences: agentReferencesAtSend,
+            pastedTextRanges: pastedTextRangesAtSend,
+            slashCommandRanges: slashCommandRangesAtSend ?? [],
+            permissionModeAtSend: sessionAtSend.permissionMode,
+            readyAttachments: sendAttachments,
+            readyPreviews: sendAttachmentPreviews,
+            claimedUploads: [],
+          });
+          if (outboxSessionAliveRef.current !== sessionId) {
+            // await 期间原地切任务 / 退屏：两类失败都不能恢复进 B 的 composer，
+            // 也不能继续执行后续 UI 清理。交回 A 的持久草稿后直接收口。
+            salvageOutboxItem(recoverableItem);
+            return;
+          }
+          if (isSafelyUnsentOutboxEnqueueError(err)) {
+            // 点击时链路尚健康、真正派发前才撞上断线：把同一 clientId/内容接回
+            // 本地 outbox，保持乐观气泡与 FIFO，恢复后自动 pump；不把草稿塞回输入框。
+            updateOutbox((items) => (
+              items.some((item) => item.clientId === recoverableItem.clientId)
+                ? replaceOutboxItem(items, recoverableItem)
+                : [recoverableItem, ...items]
+            ));
+            setError(formatRemoteError(err));
+          } else {
+            // 合并而非替换(与成功路径的差集清理对称,codex review R11):enqueue 在途期间
+            // 新落定的附件已进 attachments / ref,整体覆盖会把它从托盘丢掉且预览映射残留、
+            // OSS 中转对象失去 UI 移除路径;恢复本批的同时保留期间新增。
+            const restoredIds = new Set(sendAttachments.map((attachment) => attachment.id));
+            const mergeRestored = (current: RemoteSerializedAttachment[]) => [
+              ...sendAttachments,
+              ...current.filter((attachment) => !restoredIds.has(attachment.id)),
+            ];
+            attachmentsRef.current = mergeRestored(attachmentsRef.current);
+            setAttachments(mergeRestored);
+            restoreDraftAfterFailure();
+            throw err;
+          }
         }
         // applied:消息已在桌面队列(权威 / 推送 projection 已含该 clientId),
         // 按成功继续——不回滚、不报错,后续收尾(plan 恢复 / 映射清理)照常执行。
@@ -6338,6 +6507,9 @@ export default function SessionScreen() {
         // 否则回滚后集合残留、同 clientId 重发时首帧仍是转圈。
         clearQueueItemSending(queued.clientId);
       }
+      // 消息已由 A 路径落定；若等待期间切到 B，只停止旧 continuation，不能再用
+      // A 的附件 id / plan 状态去清理 B 的 composer UI。
+      if (!sendScopeStillAlive()) return;
       if (sessionAtSend.permissionMode === 'plan') {
         // 一次性语义(对齐桌面 PR#494 / 产品决策):计划模式只对本条消息生效,发送后
         // 自动恢复进入前的权限档;本条消息通常已按 plan 派发,切换只影响后续消息。
@@ -6386,7 +6558,7 @@ export default function SessionScreen() {
   ) => {
     if (queueBusy) return;
     setQueueBusy(true);
-    setError(null);
+    if (!outboxConnectionDispatchBlocked) setError(null);
     const projectionEpochAtRequestStart =
       remoteSessionStore.captureInputProjectionAuthorityEpoch(sessionId);
     try {
@@ -6399,7 +6571,7 @@ export default function SessionScreen() {
     } finally {
       setQueueBusy(false);
     }
-  }, [applyProjectionIfCurrent, queueBusy, sessionId]);
+  }, [applyProjectionIfCurrent, outboxConnectionDispatchBlocked, queueBusy, sessionId]);
 
   /**
    * 乐观队列操作(remove / move 这类纯队列变换):先本地改 pendingQueue 当帧给反馈,
@@ -6414,7 +6586,7 @@ export default function SessionScreen() {
   }) => {
     if (queueBusy) return;
     setQueueBusy(true);
-    setError(null);
+    if (!outboxConnectionDispatchBlocked) setError(null);
     remoteSessionStore.setInputProjection(
       sessionId,
       opts.optimistic(remoteSessionStore.getInputProjection(sessionId)),
@@ -6435,13 +6607,19 @@ export default function SessionScreen() {
     } finally {
       setQueueBusy(false);
     }
-  }, [applyProjectionIfCurrent, queueBusy, sessionId]);
+  }, [applyProjectionIfCurrent, outboxConnectionDispatchBlocked, queueBusy, sessionId]);
 
   // stop 的视觉状态派生自 run status / projection,只有往返后才变;这里补一个本地
   // pending 态让按钮当帧转圈,消除「点了没反应」的歧义。
   const [stopPending, setStopPending] = useState(false);
   const stopSession = () => {
     if (queueBusy) return;
+    if (remoteStopUnavailable) {
+      setError(status === 'online'
+        ? '[DEVICE_OFFLINE] target device unavailable'
+        : '[NOT_CONNECTED] relay reconnecting');
+      return;
+    }
     setStopPending(true);
     void runQueueAction(() => maker.input.stop(sessionId, stopOptionsForProjection(inputProjection)))
       .finally(() => setStopPending(false));
@@ -7014,7 +7192,8 @@ export default function SessionScreen() {
     // 这里用 reactive 形态就够:按钮就是按这一帧的快照渲染的,点击不跨帧竞争。
     if (sessionSettingsLocked) return;
     setControlBusy(true);
-    setError(null);
+    // 不要因一次设置尝试清掉仍在恢复中的连接错误,否则会提前放开 outbox 派发门。
+    if (!outboxConnectionDispatchBlocked) setError(null);
     let rollbackPatch: Partial<RemoteSession> | null = null;
     if (optimisticPatch && deviceId && currentSession) {
       const rollback: Record<string, unknown> = {};
@@ -7061,7 +7240,15 @@ export default function SessionScreen() {
     } finally {
       setControlBusy(false);
     }
-  }, [controlBusy, currentSession, deviceId, maker, sessionId, sessionSettingsLocked]);
+  }, [
+    controlBusy,
+    currentSession,
+    deviceId,
+    maker,
+    outboxConnectionDispatchBlocked,
+    sessionId,
+    sessionSettingsLocked,
+  ]);
 
   const writeSessionAgentSwitchIntent = useCallback(async (
     nextIntent: NonNullable<RemoteSession['agentSwitchIntent']>,
@@ -7077,7 +7264,7 @@ export default function SessionScreen() {
       remoteSessionStore.getSessions().find((item) => item.id === sessionId)?.agentSwitchIntent,
     );
     setControlBusy(true);
-    setError(null);
+    if (!outboxConnectionDispatchBlocked) setError(null);
     remoteSessionStore.applySessionPatch(deviceId, sessionId, { agentSwitchIntent: nextIntent });
     try {
       const result = await maker.switchSessionAgent(
@@ -7130,7 +7317,14 @@ export default function SessionScreen() {
     } finally {
       if (agentSwitchWriteSeqRef.current === seq) setControlBusy(false);
     }
-  }, [controlBusy, deviceId, maker, sessionId, sessionSettingsLocked]);
+  }, [
+    controlBusy,
+    deviceId,
+    maker,
+    outboxConnectionDispatchBlocked,
+    sessionId,
+    sessionSettingsLocked,
+  ]);
 
   // Context 面板「计划模式」开关,双路径(#494 迁移):
   //  - 新协议(capabilities.planMode.supported):maker:set-plan-mode 开关一级 flag,
@@ -7420,7 +7614,7 @@ export default function SessionScreen() {
   // 会话镜像记忆 → 沿用当前档 → 模型默认;同模型换来源不沿用;fast 按镜像恢复、fastEditable 门控)。
   const selectComposerModelRow = useCallback((row: ProviderModelRow) => {
     setModelSheetOpen(false);
-    if (!canUseComposer || !currentSession || !modelSheetSelection) return;
+    if (!canUseRemoteSessionControls || !currentSession || !modelSheetSelection) return;
     const next = resolveRowSelection({
       row,
       agentKind: modelSheetAgentKind,
@@ -7462,7 +7656,7 @@ export default function SessionScreen() {
     }, { recover: 'refetch' });
   }, [
     agentSwitchIntent,
-    canUseComposer,
+    canUseRemoteSessionControls,
     currentSession,
     maker,
     modelSheetAgentKind,
@@ -7476,12 +7670,12 @@ export default function SessionScreen() {
   ]);
   const selectComposerFlatModel = useCallback((option: MobileModelOption) => {
     setModelSheetOpen(false);
-    if (!canUseComposer || modelSheetAgentKind !== sessionAgentKind) return;
+    if (!canUseRemoteSessionControls || modelSheetAgentKind !== sessionAgentKind) return;
     void runControlAction(() => maker.setModel(sessionId, option.id), {
       model: option.id,
       ...(agentSwitchIntent ? { agentSwitchIntent: null } : {}),
     });
-  }, [agentSwitchIntent, canUseComposer, maker, modelSheetAgentKind, runControlAction, sessionAgentKind, sessionId]);
+  }, [agentSwitchIntent, canUseRemoteSessionControls, maker, modelSheetAgentKind, runControlAction, sessionAgentKind, sessionId]);
   const browseComposerModelAgent = useCallback(async (next: MobileSessionAgentKind) => {
     if (next === modelSheetAgentKind) return true;
     if (next !== sessionAgentKind) {
@@ -7517,7 +7711,7 @@ export default function SessionScreen() {
     }
   }, [agentSwitchIntent, maker, modelSheetAgentKind, runControlAction, sessionAgentKind, sessionId, writeSessionAgentSwitchIntent]);
   const toggleComposerModelPicker = useCallback(() => {
-    if (!canUseComposer) {
+    if (!canUseRemoteSessionControls) {
       setModelSheetOpen(false);
       return;
     }
@@ -7527,7 +7721,7 @@ export default function SessionScreen() {
     }
     setModelSheetAgentKind(agentSwitchIntent?.targetAgentKind ?? sessionAgentKind);
     setModelSheetOpen(true);
-  }, [agentSwitchIntent, canUseComposer, modelSheetOpen, sessionAgentKind]);
+  }, [agentSwitchIntent, canUseRemoteSessionControls, modelSheetOpen, sessionAgentKind]);
 
   const refreshContextUsage = useCallback(async () => {
     if (!currentSession || contextLoading) return;
@@ -8459,7 +8653,7 @@ export default function SessionScreen() {
                   // 点击即切换计划模式并关面板(产品决策,不做开关);已开启时显示 ✓,再点退出。
                   <ContextSheetRow
                     accessibilityHint={composerSendUnavailableReason ?? undefined}
-                    disabled={!canUseComposer || controlBusy}
+                    disabled={!canUseRemoteSessionControls || controlBusy}
                     icon={<ListTodo color={colors.textPrimary} size={iconSize.lg} strokeWidth={iconStroke.regular} />}
                     label={t('session.common.planMode')}
                     onPress={() => {
@@ -8567,12 +8761,12 @@ export default function SessionScreen() {
             agentSwitch={sessionAgentSwitchSupported ? {
               browsingAgentKind: modelSheetAgentKind,
               currentAgentKind: sessionAgentKind,
-              disabled: controlBusy || !canUseComposer,
+              disabled: controlBusy || !canUseRemoteSessionControls,
               onBrowseAgent: browseComposerModelAgent,
             } : undefined}
             apiKeyStatus={deviceApiKeyStatus}
             capabilities={modelSheetCapabilities}
-            disabled={controlBusy || !canUseComposer}
+            disabled={controlBusy || !canUseRemoteSessionControls}
             emptyHint={modelSheetCapabilitiesError ?? undefined}
             flatOptions={modelSheetRuntimeOptions.modelOptions}
             modelVisibilityOverrides={composerDeviceProviders.modelVisibilityOverrides}
@@ -8589,7 +8783,7 @@ export default function SessionScreen() {
             hidePermissionTrigger
             onSelectPermissionMode={selectSessionPermissionMode}
             onSelectProviderRow={selectComposerModelRow}
-            permissionDisabled={controlBusy || !canUseComposer}
+            permissionDisabled={controlBusy || !canUseRemoteSessionControls}
             permissionOptions={runtimeOptions.permissionOptions}
             pricing={deviceModelPricing}
             providers={composerDeviceProviders.providers}
@@ -8597,7 +8791,7 @@ export default function SessionScreen() {
             selectedFastMode={modelSheetSelection.fastMode}
             selectedProviderId={modelSheetSelection.providerId}
             testID="session.modelSheet"
-            visible={modelSheetOpen && canUseComposer}
+            visible={modelSheetOpen && canUseRemoteSessionControls}
           />
         ) : null}
         {/* 权限模式独立浮窗(composer 权限图标钮点开;列表复用 MobilePermissionPickerList,
@@ -8607,7 +8801,7 @@ export default function SessionScreen() {
             backdropTestID="session.permissionSheet.backdrop"
             onBackdropPress={() => setPermissionSheetOpen(false)}
             onRequestClose={() => setPermissionSheetOpen(false)}
-            visible={permissionSheetOpen && canUseComposer}
+            visible={permissionSheetOpen && canUseRemoteSessionControls}
           >
             <SheetSurface
               bottomInset={insets.bottom}
@@ -8620,7 +8814,7 @@ export default function SessionScreen() {
             >
               <MobilePermissionPickerList
                 activeMode={displayPermissionMode}
-                disabled={controlBusy || !canUseComposer}
+                disabled={controlBusy || !canUseRemoteSessionControls}
                 onSelect={(mode) => {
                   selectSessionPermissionMode(mode);
                   setPermissionSheetOpen(false);
@@ -8644,10 +8838,12 @@ export default function SessionScreen() {
         {composerAnnotations.host}
         <View style={styles.sessionMainLayer} testID="session.mainLayer">
           {sessionOperationLayout.composerSlot === 'missing-session' && remoteUnavailableReason ? (
-            // 设备真不可用(离线/被撤销):消息区保留阻塞占位和重试入口;底部 composer 仍可编辑草稿。
+            // 会话行尚未到达时保留状态占位；自动恢复类错误不再提供手动同步入口。
             <SessionSyncPlaceholder
               loading={loading}
-              onSync={() => void requestSync({ reason: 'manual', replaceMessages: false })}
+              onSync={composerRemoteUnavailableReason
+                ? () => void requestSync({ reason: 'manual', replaceMessages: false })
+                : undefined}
             />
           ) : (
             <>
@@ -9541,7 +9737,7 @@ function SessionSyncPlaceholder({
   onSync,
 }: {
   loading: boolean;
-  onSync(): void;
+  onSync?: () => void;
 }) {
   const styles = useThemedStyles(makeStyles);
   const { colors } = useTheme();
@@ -9550,19 +9746,21 @@ function SessionSyncPlaceholder({
       <View style={styles.sessionSyncPlaceholder} testID="session.unsyncedState">
       <View style={styles.sessionSyncRow}>
         <Text style={styles.sessionSyncTitle}>{loading ? t('session.screen.syncingSession') : t('session.screen.awaitingSync')}</Text>
-        <RouteActionButton
-          accessibilityLabel={t('session.screen.resync')}
-          disabled={loading}
-          onPress={onSync}
-          style={styles.sessionSyncButton}
-          testID="session.unsyncedSyncButton"
-        >
-          {loading ? (
-            <ActivityIndicator color={colors.textSecondary} size="small" />
-          ) : (
-            <RefreshCw color={colors.textSecondary} size={iconSize.md} strokeWidth={iconStroke.regular} />
-          )}
-        </RouteActionButton>
+        {onSync ? (
+          <RouteActionButton
+            accessibilityLabel={t('session.screen.resync')}
+            disabled={loading}
+            onPress={onSync}
+            style={styles.sessionSyncButton}
+            testID="session.unsyncedSyncButton"
+          >
+            {loading ? (
+              <ActivityIndicator color={colors.textSecondary} size="small" />
+            ) : (
+              <RefreshCw color={colors.textSecondary} size={iconSize.md} strokeWidth={iconStroke.regular} />
+            )}
+          </RouteActionButton>
+        ) : null}
       </View>
     </View>
   );

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -200,7 +200,6 @@ import {
   dismissNewSessionCreation,
   prepareNewSessionCreationForEdit,
   getNewSessionCreationTask,
-  retryNewSessionLegacyPlanRestore,
   retryNewSessionCreation,
   shouldBlockSessionSync,
   stashNewSessionDraftForEdit,
@@ -1222,11 +1221,10 @@ export default function SessionScreen() {
       if (items.length === 0) return;
       outboxRef.current = [];
       setOutboxItems([]);
-      const unsentItems = items.filter((item) => !item.restoreOnly);
       // 草稿按条目自身归属写回(而非本 effect 捕获的 sessionId):防御性一致。
       // 引用正文同步恢复 quote store，输入框只接收剥过 marker 的可见文字。
-      restoreOutboxItemsToDraft(unsentItems);
-      for (const item of unsentItems) {
+      restoreOutboxItemsToDraft(items);
+      for (const item of items) {
         for (const localId of [...item.waitingIds, ...item.failedIds]) removePendingUpload(localId);
         for (const attachment of outboxItemAttachments(item)) {
           discardMobileUploadedAttachment(attachment, {
@@ -1452,13 +1450,6 @@ export default function SessionScreen() {
   // 同步真源(上传回调 / 派发循环 / send 同步段都要读最新值),state 只驱动渲染。
   const [outboxItems, setOutboxItems] = useState<readonly MobileOutboxItem[]>([]);
   const outboxRef = useRef<readonly MobileOutboxItem[]>([]);
-  // 页面内代次只用于保护同一屏生命周期内「旧消息恢复」与「用户重新打开 Plan」
-  // 的竞态；不做跨页面、跨进程持久化，边界与现有 outbox 一致。
-  const legacyPlanArmEpochBySessionRef = useRef(new Map<string, number>());
-  const prePlanPermissionModeRef = useRef<{ sessionId: string; mode: string | null }>({
-    sessionId,
-    mode: null,
-  });
   // 派发循环重入锁 + 路由函数的 ref 中转(onUploaded 闭包声明在组件前部,实际
   // 路由/派发逻辑声明在 send() 附近,经 ref 断开声明顺序依赖,同 composerAnnotationsRef)。
   const outboxPumpBusyRef = useRef(false);
@@ -1790,10 +1781,6 @@ export default function SessionScreen() {
   // lastPresenceSnapshot 与下方 ref 只用于 false→true 的 resync edge，不能作为门禁：
   // 它们会跨 epoch 保留，旧 offline 否则会把新连接永久卡死。
   const targetAvailableForDispatch = getPresenceAvailability(deviceId);
-  // 对齐 Desktop:断线恢复期间设置入口仍可操作,但明确知道电脑不可达时拦下停止任务。
-  // presence 未知时仍允许尝试,避免旧缓存把停止入口永久锁死。
-  const remoteStopUnavailable =
-    status !== 'online' || targetAvailableForDispatch === false;
   const screenAutoRecoveringError = connectionError && isAutoRecoveringRemoteError(connectionError)
     ? connectionError
     : null;
@@ -1817,6 +1804,13 @@ export default function SessionScreen() {
         : { deviceId, error: screenAutoRecoveringError }
     ));
   }, [connectionError, deviceId, screenAutoRecoveringError]);
+  // 对齐 Desktop：输入与发送仍可排队，但模型、权限、Plan、停止等需要即时访问
+  // 被控端的操作在明确断线时禁用。presence unknown 仍允许，避免旧缓存永久锁死入口。
+  const remoteRealtimeControlsUnavailable = status !== 'online'
+    || targetAvailableForDispatch === false
+    || isDeviceUnresponsive
+    || activeOutboxTransportError !== null;
+  const remoteStopUnavailable = remoteRealtimeControlsUnavailable;
   const outboxConnectionState: MobileOutboxConnectionState = {
     relayOnline: status === 'online',
     targetAvailable: targetAvailableForDispatch,
@@ -2002,10 +1996,10 @@ export default function SessionScreen() {
   const pendingCreationReason = currentSession?.pendingLocalCreation
     ? t('session.screen.composerCreating')
     : null;
-  // 会话设置类动作(model / effort / fast / permission / plan)仅在会话尚未建成时不可用。
-  // 对齐 Desktop,暂时断线时入口继续可点:现有乐观 RPC 会在失败后回滚并展示提示。
-  // cacheSeeded 不锁——那种会话在被控端是存在的,只是本地行还是瘦身缓存。
-  // 硬门在 runControlAction 里,这里供按钮表达灰态。
+  // 会话尚未建成时，所有远端实时控制都不可用。cacheSeeded 不锁——那种会话在
+  // 被控端是存在的，只是本地行还是瘦身缓存。断线门另由
+  // remoteRealtimeControlsUnavailable 表达；两者在 canUseRemoteSessionControls
+  // 汇合，但不影响 composer 输入和 outbox 排队。
   // 判据与命令式路径共用 isRemoteSessionMissing(见其注释):这里是渲染需要的
   // reactive 形态,send / runControlAction 用读 store 的 Now 形态。
   const sessionSettingsLocked = isRemoteSessionMissing(currentSession);
@@ -2054,7 +2048,9 @@ export default function SessionScreen() {
     }
   }, [activePendingKind, activePendingRequestId, sessionOperationLayout.composerSlot]);
   const canUseComposer = sessionOperationLayout.canUseComposer;
-  const canUseRemoteSessionControls = canUseComposer && !sessionSettingsLocked;
+  const canUseRemoteSessionControls = canUseComposer
+    && !sessionSettingsLocked
+    && !remoteRealtimeControlsUnavailable;
   // 共享模型自造的那两条禁发理由是中文直出,而它会经 composer 与队列行的
   // accessibility hint 读给用户 —— 按 locale 翻译后再用,否则读屏在 en / ja / ko
   // 下念混语(#530 review)。调用方自己传进去的理由(离线 / 只读 / 同步中)已本地化,
@@ -2311,7 +2307,8 @@ export default function SessionScreen() {
     // pending(乐观上传中)计入:拍完照 / 选完文件立即可点发送,send() 内部会等落定。
     attachmentCount: attachments.length + pendingUploads.length,
     attachmentPickerOpen: false,
-    canStop: canUseRemoteSessionControls && canStopComposer,
+    // Stop 的可见性跟随真实运行 / 队列状态；断线时只单独禁用交互。
+    canStop: canStopComposer,
     draftText: draft,
     queueBusy,
     quoteCount: composerQuoteCount,
@@ -2322,7 +2319,6 @@ export default function SessionScreen() {
     attachments.length,
     pendingUploads.length,
     canStopComposer,
-    canUseRemoteSessionControls,
     canUseComposer,
     composerQuoteCount,
     composerSendUnavailableReason,
@@ -2357,6 +2353,10 @@ export default function SessionScreen() {
   // 只有确定性不可用(撤权 / 关闭远控等)才禁发送；普通断线与自动恢复状态仍可发，
   // 消息进入本地 outbox 等连接恢复。输入框在两类状态下都保持可编辑与持久化。
   const composerSendDisabled = composerLayout.send.disabled;
+  const composerStopDisabled = composerLayout.stop.disabled || !canUseRemoteSessionControls;
+  const composerStopDisabledReason = !canUseRemoteSessionControls
+    ? remoteUnavailableReason ?? t('session.menu.aiRenameOffline')
+    : composerLayout.stop.disabledReason;
   const composerShowInlineStop = composerLayout.stop.visible && !composerSendSlotIsStop && !sending;
   const composerHasPayload = composerHasText || attachments.length > 0 || pendingUploads.length > 0 || composerQuoteCount > 0;
   // send.visible 在语音生命周期内恒 true(sessionOperation.ts),这里不再按
@@ -2712,7 +2712,7 @@ export default function SessionScreen() {
       {renderSessionPermissionButton()}
       {planModeOn ? (
         <PlanModeChip
-          disabled={!canUseComposer || controlBusy || sessionSettingsLocked}
+          disabled={controlBusy || !canUseRemoteSessionControls}
           onExit={() => togglePlanMode(false)}
           testID="session.planModeChip"
         />
@@ -2720,6 +2720,7 @@ export default function SessionScreen() {
       <ComposerToolbarSpacer />
       {composerRuntimeSummary ? (
         <ComposerRuntimePill
+          disabled={controlBusy || !canUseRemoteSessionControls}
           fastOn={composerPillFastOn}
           label={composerRuntimeLabel}
           leading={agentSwitchIntent ? (
@@ -3781,13 +3782,9 @@ export default function SessionScreen() {
     const prev = prevCreationStatusRef.current;
     const status = creationTask?.status ?? null;
     prevCreationStatusRef.current = status;
-    if (status === 'restoring-plan') {
-      setError(creationTask?.error ?? null);
-      return;
-    }
     if (status === prev) return;
     if (status === null) {
-      if (prev === 'running' || prev === 'restoring-plan') {
+      if (prev === 'running') {
         setError(null);
         void load();
       }
@@ -4126,11 +4123,7 @@ export default function SessionScreen() {
         identity: retryIdentity,
         attempt: retryState.attempt + 1,
       };
-      if (creationTask?.status === 'restoring-plan') {
-        retryNewSessionLegacyPlanRestore(sessionId);
-      } else {
-        void load();
-      }
+      void load();
     }, connectionRecoverySyncRetryDelayMs(retryState.attempt));
     return () => clearTimeout(timer);
   }, [
@@ -4142,7 +4135,6 @@ export default function SessionScreen() {
     load,
     loading,
     connectionEpoch,
-    creationTask?.status,
     sessionId,
     status,
     targetAvailableForDispatch,
@@ -5431,9 +5423,6 @@ export default function SessionScreen() {
    * 没有在途任务要清。
    */
   const salvageOutboxItem = (item: MobileOutboxItem) => {
-    // 已接受/已取消消息留下的隐藏恢复屏障不是草稿，也不再持有附件资源。
-    // 页面离场后按现有 outbox 生命周期丢弃，不扩成跨页面恢复机制。
-    if (item.restoreOnly) return;
     restoreOutboxItemsToDraft([item]);
     for (const attachment of outboxItemAttachments(item)) {
       discardMobileUploadedAttachment(attachment, {
@@ -5466,72 +5455,21 @@ export default function SessionScreen() {
           : [outboxItemWithEnqueueFailure(item, message), ...items]
       ));
     };
-    const waitForConnection = (
-      error: unknown,
-      waitingItem: MobileOutboxItem = item,
-    ) => {
+    const waitForConnection = (error: unknown) => {
       // 与失败回插同一归属边界：离场后不能把旧会话气泡塞进当前页面，降级回该
       // 会话的持久草稿；仍在本页则恢复为 uploading/ready，留在 FIFO 队首。
-      if (outboxSessionAliveRef.current !== waitingItem.sessionId) {
-        salvageOutboxItem(waitingItem);
+      if (outboxSessionAliveRef.current !== item.sessionId) {
+        salvageOutboxItem(item);
         return;
       }
-      const waiting = outboxItemWaitingForConnection(waitingItem);
+      const waiting = outboxItemWaitingForConnection(item);
       updateOutbox((items) => (
-        items.some((existing) => existing.clientId === waitingItem.clientId)
+        items.some((existing) => existing.clientId === item.clientId)
           ? replaceOutboxItem(items, waiting)
           : [waiting, ...items]
       ));
       setError(formatRemoteError(error));
     };
-    const resolveLegacyPlanRestoreTarget = (restoreItem: MobileOutboxItem): string | null => {
-      if (!restoreItem.legacyPlanRestore) return null;
-      const latestArmEpoch = legacyPlanArmEpochBySessionRef.current.get(restoreItem.sessionId) ?? 0;
-      if (latestArmEpoch > restoreItem.legacyPlanArmEpochAtSend) return 'plan';
-      const currentMode = remoteSessionStore.getSessions()
-        .find((entry) => entry.id === restoreItem.sessionId)?.permissionMode;
-      return currentMode && currentMode !== 'plan'
-        ? currentMode
-        : restoreItem.legacyPlanRestore;
-    };
-    const removeRestoreBarrier = (acceptedItem: MobileOutboxItem) => {
-      if (outboxSessionAliveRef.current !== acceptedItem.sessionId) return;
-      updateOutbox((items) => items.filter((entry) => entry.clientId !== acceptedItem.clientId));
-    };
-    const restoreLegacyPlanOffPage = async (restoreItem: MobileOutboxItem) => {
-      const restoreMode = resolveLegacyPlanRestoreTarget(restoreItem);
-      if (!restoreMode) return;
-      try {
-        await withTransientRemoteRetry(
-          () => maker.setPermissionMode(restoreItem.sessionId, restoreMode),
-          { maxAttempts: 2 },
-        );
-      } catch {
-        // 页面生命周期边界内的 best-effort。
-      }
-    };
-    const restoreLegacyPlanAfterEnqueue = async (acceptedItem: MobileOutboxItem) => {
-      const restoreMode = resolveLegacyPlanRestoreTarget(acceptedItem);
-      if (!restoreMode) {
-        removeRestoreBarrier(acceptedItem);
-        return;
-      }
-      try {
-        await withTransientRemoteRetry(
-          () => maker.setPermissionMode(acceptedItem.sessionId, restoreMode),
-        );
-      } catch (err) {
-        if (isAutoRecoveringRemoteError(err)) {
-          waitForConnection(err, acceptedItem);
-          return 'deferred' as const;
-        }
-        // 恢复沿用旧实现的 best-effort 语义：确定性拒绝不应永久挡住后续消息。
-        removeRestoreBarrier(acceptedItem);
-        return;
-      }
-      removeRestoreBarrier(acceptedItem);
-    };
-    if (item.restoreOnly) return restoreLegacyPlanAfterEnqueue(item);
     const sessionNow = remoteSessionStore.getSessions().find((entry) => entry.id === item.sessionId);
     if (!sessionNow) {
       failItem(t('session.screen.sessionNotFoundResync'));
@@ -5574,30 +5512,6 @@ export default function SessionScreen() {
       return;
     }
     if (outboxSessionAliveRef.current !== item.sessionId) return 'stopped' as const;
-    if (item.legacyPlanRestore) {
-      try {
-        // 引用材料准备完成后才显式武装，缩小“远端已是 plan、消息尚未越过
-        // enqueue”的窗口。每条旧协议 Plan 都要单独武装：上一条的恢复会把 live
-        // session 切回普通档，而旧端不会从 queued.createOpts 重放该快照。
-        await withTransientRemoteRetry(() => maker.setPermissionMode(item.sessionId, 'plan'));
-      } catch (err) {
-        // set RPC 的回执也可能丢失，不能假定远端没有切到 plan。
-        if (outboxSessionAliveRef.current !== item.sessionId) {
-          await restoreLegacyPlanOffPage(item);
-          return 'stopped' as const;
-        }
-        if (isAutoRecoveringRemoteError(err)) {
-          waitForConnection(err);
-          return 'deferred' as const;
-        }
-        failItem(formatRemoteError(err));
-        return;
-      }
-      if (outboxSessionAliveRef.current !== item.sessionId) {
-        await restoreLegacyPlanOffPage(item);
-        return 'stopped' as const;
-      }
-    }
     // 乐观交接:进本地 pendingQueue 的同一同步段把条目移出 outbox,气泡原位从
     // 「发送中」变「排队中」不闪断;enqueue 成功后用权威 projection 覆盖 reconcile。
     const projectionBeforeSend = remoteSessionStore.getInputProjection(item.sessionId);
@@ -5674,40 +5588,12 @@ export default function SessionScreen() {
           return 'deferred' as const;
         }
         failItem(formatRemoteError(err));
-        return;
       }
       // applied:消息已在桌面队列,按成功继续(不回滚、不报错)。
     } finally {
       // 落定(入队确认 / 回 outbox 标失败)后收掉转圈:失败条目的气泡由 outbox 侧
       // 重新持有(它自己画错误徽标),排队行里不该留下悬空的在途标记。
       clearQueueItemSending(queued.clientId);
-    }
-    if (item.legacyPlanRestore) {
-      // 消息已经被接受：原条目转换为隐藏的恢复屏障。它留在同一页 outbox 的 FIFO
-      // 队首，只重试权限恢复，绝不再次 enqueue 消息或在离场时回填草稿。
-      const acceptedBarrier: MobileOutboxItem = {
-        ...item,
-        text: '',
-        attachmentSlots: [],
-        slotMeta: [],
-        slotByLocalId: {},
-        waitingIds: [],
-        failedIds: [],
-        enqueueError: null,
-        restoreOnly: true,
-        phase: 'dispatching',
-      };
-      if (outboxSessionAliveRef.current === item.sessionId) {
-        // 用户可能在 arm / enqueue 在途时删除了可见条目，删除路径会先留下同
-        // clientId 的恢复屏障；此处原位替换，不能再插入第二个屏障。
-        updateOutbox((items) => (
-          items.some((entry) => entry.clientId === acceptedBarrier.clientId)
-            ? replaceOutboxItem(items, acceptedBarrier)
-            : [acceptedBarrier, ...items]
-        ));
-      }
-      const restoreResult = await restoreLegacyPlanAfterEnqueue(acceptedBarrier);
-      if (restoreResult === 'deferred') return restoreResult;
     }
     // enqueue / 对账期间离场时，成功路径无需恢复草稿，但旧 pump 也绝不能接着
     // 消费新任务的 outbox；失败路径已由 failItem / waitForConnection 按 A 收口。
@@ -5794,21 +5680,7 @@ export default function SessionScreen() {
     const item = outboxRef.current.find((entry) => entry.clientId === clientId);
     if (!item) return;
     setQueueSelectedClientId(null);
-    const restoreBarrier = item.legacyPlanRestore ? {
-      ...item,
-      text: '',
-      attachmentSlots: [],
-      slotMeta: [],
-      slotByLocalId: {},
-      waitingIds: [],
-      failedIds: [],
-      enqueueError: null,
-      restoreOnly: true,
-      phase: 'uploading' as const,
-    } : null;
-    updateOutbox((items) => items.flatMap((entry) => (
-      entry.clientId !== clientId ? [entry] : restoreBarrier ? [restoreBarrier] : []
-    )));
+    updateOutbox((items) => items.filter((entry) => entry.clientId !== clientId));
     for (const localId of [...item.waitingIds, ...item.failedIds]) removePendingUpload(localId);
     for (const attachment of outboxItemAttachments(item)) {
       discardMobileUploadedAttachment(attachment, { getToken: () => auth.getAccessToken() });
@@ -5817,10 +5689,7 @@ export default function SessionScreen() {
     void pumpOutbox();
   };
 
-  const outboxDisplayItems = useMemo(
-    () => outboxItems.filter((item) => !item.restoreOnly).map(outboxDisplayItem),
-    [outboxItems],
-  );
+  const outboxDisplayItems = useMemo(() => outboxItems.map(outboxDisplayItem), [outboxItems]);
 
   /**
    * 取出并清空某会话的 outbox 条目(创建失败的两条收尾路径都要用)。
@@ -5840,11 +5709,9 @@ export default function SessionScreen() {
     targetSessionId: string,
     uploads: 'release-to-tray' | 'cancel',
   ): { items: MobileOutboxItem[]; cancelledUploadCount: number } => {
-    const owned = outboxRef.current.filter((item) => item.sessionId === targetSessionId);
-    if (owned.length === 0) return { items: [], cancelledUploadCount: 0 };
-    updateOutbox((items) => items.filter((item) => item.sessionId !== targetSessionId));
-    const taken = owned.filter((item) => !item.restoreOnly);
+    const taken = outboxRef.current.filter((item) => item.sessionId === targetSessionId);
     if (taken.length === 0) return { items: [], cancelledUploadCount: 0 };
+    updateOutbox((items) => items.filter((item) => item.sessionId !== targetSessionId));
     const pendingLocalIds = taken.flatMap((item) => [...item.waitingIds, ...item.failedIds]);
     if (uploads === 'release-to-tray') {
       // 已就绪附件的中转对象由调用方决定是否随草稿保留,不在这里回收。
@@ -6069,21 +5936,6 @@ export default function SessionScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [connectionEpoch, outboxDispatchBlocked]);
 
-  const readLegacyPlanRestoreMode = () => {
-    const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
-    const remembered = prePlanPermissionModeRef.current.sessionId === sessionId
-      ? prePlanPermissionModeRef.current.mode
-      : null;
-    return remembered && remembered !== 'plan' ? remembered : fallback;
-  };
-
-  const consumeLegacyPlanLocally = (restoreMode: string | null) => {
-    if (!restoreMode) return;
-    remoteSessionStore.applySessionPatch(deviceId, sessionId, {
-      permissionMode: restoreMode,
-    });
-  };
-
   async function send(options: {
     draftOverride?: string;
     documentOverride?: ComposerDocument;
@@ -6172,6 +6024,22 @@ export default function SessionScreen() {
     const sessionRefsAtSend = outboxEligible && !earlyLocalCommand && !earlyDesktopCommand
       ? extractMobileSessionReferences(text, remoteSessionStore.getSessionDeviceId)
       : [];
+    const dispatchBlockedAtSend = outboxDispatchBlockedNow();
+    const legacyPlanRequiresLiveDispatch = outboxEligible
+      && !earlyLocalCommand
+      && !earlyDesktopCommand
+      && runtimeOptions?.planModeSupported !== true
+      && permissionModeOrAsk((readSessionRowNow() ?? currentSession).permissionMode) === 'plan';
+    // 旧协议 Plan 依赖会话级 permissionMode，不能排在既有本地消息后，也不能在
+    // 已知断线时托管给自动恢复。必须在乐观清空和任何 await 前拒绝，原草稿原位保留。
+    if (legacyPlanRequiresLiveDispatch && (
+      dispatchBlockedAtSend || outboxRef.current.length > 0 || outboxPumpBusyRef.current
+    )) {
+      if (dispatchBlockedAtSend) setError(t('session.menu.aiRenameOffline'));
+      sendInFlightRef.current = false;
+      setSending(false);
+      return;
+    }
     pendingSkillSelectionRef.current = null;
     // 乐观第一拍:点发送立刻清空输入框并跟到底部,不等任何网络往返(enqueue 是
     // device-link 远程调用,弱网下数秒;文字已捕获进 text)。失败时若输入框仍为空
@@ -6186,6 +6054,13 @@ export default function SessionScreen() {
             nodes: documentAtSend.nodes.filter((node) => node.type === 'quote'),
           })
         : emptyComposerDocument();
+    const capturedDraftRecoveryItem = (): MobileRecoverableDraftItem => ({
+      text,
+      quotesEncoded: quotesEncodedAtSend,
+      agentReferences: agentReferencesAtSend,
+      pastedTextRanges: pastedTextRangesAtSend,
+      slashCommandRanges: slashCommandRangesAtSend ?? [],
+    });
     const restoreDraftAfterFailure = () => {
       // 走持久化写回(setComposerDraft 而非 restoreComposerDraft):乐观清空那拍已把
       // 草稿库删除并打了 cleared 标,只回内存的话 remount 后草稿读到 null、原文丢失
@@ -6195,6 +6070,26 @@ export default function SessionScreen() {
         applyComposerDocument(documentBeforeSend);
       }
     };
+    const restoreDirectSendDraftAfterFailure = () => {
+      if (
+        !legacyPlanRequiresLiveDispatch
+        || composerDocumentsEqual(composerDocumentRef.current, documentAfterOptimisticClear)
+      ) {
+        restoreDraftAfterFailure();
+        return;
+      }
+      // 在线旧协议 Plan 的直发路径仍可能在 await 期间断线。用户若已继续输入，
+      // 不能用旧草稿覆盖新草稿，也不能把旧消息静默丢掉；按发送顺序前置合并。
+      const currentDocument = composerDocumentRef.current;
+      const currentSerialized = serializeComposerDocument(currentDocument);
+      const recovery = recoverOutboxItemsToComposerDraft([capturedDraftRecoveryItem()], {
+        visibleText: composerDocumentProjectedText(currentDocument),
+        encodedBody: currentSerialized.text,
+        quotes: [],
+        document: currentDocument,
+      });
+      applyComposerDocument(recovery.document);
+    };
     let scopeExitDraftRecovered = false;
     const sendScopeStillAlive = () => outboxSessionAliveRef.current === sessionId;
     const recoverCapturedDraftForScopeExit = () => {
@@ -6202,13 +6097,7 @@ export default function SessionScreen() {
       scopeExitDraftRecovered = true;
       // 乐观清空已持久删除 A 草稿；切到 B 后不能再读写共享 composer ref。
       // 直接按捕获的发送快照合并回 A 的草稿库，并保留 A 期间新输入的后续文字。
-      restoreRecoverableItemsToDraft(sessionId, [{
-        text,
-        quotesEncoded: quotesEncodedAtSend,
-        agentReferences: agentReferencesAtSend,
-        pastedTextRanges: pastedTextRangesAtSend,
-        slashCommandRanges: slashCommandRangesAtSend ?? [],
-      }]);
+      restoreRecoverableItemsToDraft(sessionId, [capturedDraftRecoveryItem()]);
     };
     if (text) applyComposerDocument(documentAfterOptimisticClear);
     // A pasted message link is committed to the editor synchronously, while
@@ -6251,20 +6140,14 @@ export default function SessionScreen() {
     // 在途消息,破坏 FIFO(review P1);计入 pump busy 让它同样进 outbox 排队。
     // 会话参数未就绪(缓存种入 / 新建在途)同样走本分支:此刻 enqueue 不可用,但消息
     // 照常上屏,由派发循环在就绪后按序发出——composer 不再为此进只读档。
-    const dispatchBlockedAtSend = outboxDispatchBlockedNow();
-    const sessionForDispatchDecision = readSessionRowNow() ?? currentSession;
-    const permissionModeAtDecision = permissionModeOrAsk(
-      sessionForDispatchDecision.permissionMode,
-    );
-    const legacyPlanRestoreAtDecision = permissionModeAtDecision === 'plan'
-      ? readLegacyPlanRestoreMode()
-      : null;
-    if (outboxEligible && !earlyLocalCommand && !earlyDesktopCommand
+    const shouldUseLocalOutbox = outboxEligible && !earlyLocalCommand && !earlyDesktopCommand
       && (sessionRefsAtSend.length > 0 || uploadsInFlight > 0 || outboxRef.current.length > 0
-        || outboxPumpBusyRef.current || dispatchBlockedAtSend
-        // 旧协议 Plan 一律经 outbox 串行武装 → enqueue → 恢复，避免 chip 的乐观
-        // setPermissionMode 与直发 enqueue 竞速。
-        || legacyPlanRestoreAtDecision !== null)) {
+        || outboxPumpBusyRef.current || dispatchBlockedAtSend);
+    // 旧协议 Plan 依赖会话级 permissionMode，无法安全跨断线 / 页面生命周期托管。
+    // 本 PR 的本地 FIFO 因此只接普通消息与现代 Plan；连接正常且队列为空时，
+    // 旧协议 Plan 即使含附件 / 引用也回落到下方原有在线路径，等待材料后直接派发。
+    const useLocalOutbox = shouldUseLocalOutbox && !legacyPlanRequiresLiveDispatch;
+    if (useLocalOutbox) {
       try {
         // workingDir 校验只对「此刻就能派发」的消息前置:dialogue 会话的工作目录由
         // 被控端在创建时分配,合成行此刻本就为空,而 dispatchOutboxItem 会在真正派发
@@ -6309,14 +6192,13 @@ export default function SessionScreen() {
         setAttachmentError(null);
         // plan 一次性语义:权限档快照进条目(派发按快照发),chip 立即恢复——
         // 不等附件上传完,与「消息已发出」的乐观语义一致。
-        const permissionModeAtSend = permissionModeAtDecision;
-        const legacyPlanRestore = legacyPlanRestoreAtDecision;
-        const legacyPlanArmEpochAtSend = legacyPlanRestore
-          ? legacyPlanArmEpochBySessionRef.current.get(sessionId) ?? 0
-          : 0;
-        // 本地立即消费一次性 Plan，后续输入按恢复档快照；远端必须保持 plan 到
-        // 本条真正 enqueue，恢复动作由 dispatchOutboxItem 在确认入队后执行。
-        consumeLegacyPlanLocally(legacyPlanRestore);
+        const permissionModeAtSend = permissionModeOrAsk(currentSession.permissionMode);
+        if (permissionModeAtSend === 'plan') {
+          const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
+          const remembered = prePlanPermissionModeRef.current;
+          const restored = remembered && remembered !== 'plan' ? remembered : fallback;
+          void maker.setPermissionMode(sessionId, restored).catch(() => undefined);
+        }
         updateOutbox((items) => [...items, buildOutboxItem({
           clientId: createOutboxClientId(),
           sessionId,
@@ -6327,8 +6209,6 @@ export default function SessionScreen() {
           pastedTextRanges: pastedTextRangesAtSend,
           slashCommandRanges: slashCommandRangesAtSend ?? [],
           permissionModeAtSend,
-          legacyPlanRestore,
-          legacyPlanArmEpochAtSend,
           readyAttachments,
           readyPreviews,
           claimedUploads,
@@ -6351,7 +6231,7 @@ export default function SessionScreen() {
         return;
       }
       if (failedCount > 0) {
-        restoreDraftAfterFailure();
+        restoreDirectSendDraftAfterFailure();
         return;
       }
       // await 之后闭包里的 attachments 是旧值,经 ref 拿含刚落定图片的最新列表。
@@ -6362,12 +6242,8 @@ export default function SessionScreen() {
       // currentSession 同理是等待前的快照:上传等待期间(sending 不锁控制面板)用户
       // 可能已切 model / effort / permission / fast,重读 store 拿最新会话字段,
       // 排队消息与 UI 显示的运行时保持一致(codex review R19)。
-      const latestSessionAtSend = remoteSessionStore.getSessions().find((item) => item.id === sessionId)
+      const sessionAtSend = remoteSessionStore.getSessions().find((item) => item.id === sessionId)
         ?? currentSession;
-      const sessionAtSend = {
-        ...latestSessionAtSend,
-        permissionMode: permissionModeAtDecision,
-      };
       const hasAttachments = sendAttachments.length > 0;
       if (!text && !hasAttachments) return;
       // 排队消息编辑态:发送按钮语义变为「保存修改」——整条内容(文本+附件)替换回
@@ -6537,7 +6413,7 @@ export default function SessionScreen() {
       const desktopCommand = hasAttachments ? null : earlyDesktopCommand;
       if (!sessionAtSend.workingDir && !localSystemCommand && !desktopCommand) {
         setError(t('session.screen.missingWorkingDir'));
-        restoreDraftAfterFailure();
+        restoreDirectSendDraftAfterFailure();
         return;
       }
       if (desktopCommand?.name === 'learn') {
@@ -6616,7 +6492,7 @@ export default function SessionScreen() {
           deviceId,
         );
       } catch (err) {
-        restoreDraftAfterFailure();
+        restoreDirectSendDraftAfterFailure();
         throw err;
       }
       // 乐观第二拍:附件落定后立即把 queued 追加进本地 projection,消息气泡当帧上屏、
@@ -6726,7 +6602,7 @@ export default function SessionScreen() {
             salvageOutboxItem(recoverableItem);
             return;
           }
-          if (shouldWaitForOutboxEnqueueRecovery(err)) {
+          if (shouldWaitForOutboxEnqueueRecovery(err) && !legacyPlanRequiresLiveDispatch) {
             // 明确未发出或 enqueue 已到桌面但回执不确定：都把同一 clientId/内容
             // 接回 outbox。恢复后同 id 重试由桌面幂等去重，不能恢复草稿让用户用
             // 新 id 重发，否则第一次其实已执行时会产生重复任务。
@@ -6737,6 +6613,8 @@ export default function SessionScreen() {
             ));
             setError(formatRemoteError(err));
           } else {
+            // 旧协议 Plan 依赖实时会话权限，不能在这里转入恢复后自动重试的 outbox；
+            // 沿用改动前的在线失败收口，把内容与附件完整交还 composer。
             // 合并而非替换(与成功路径的差集清理对称,codex review R11):enqueue 在途期间
             // 新落定的附件已进 attachments / ref,整体覆盖会把它从托盘丢掉且预览映射残留、
             // OSS 中转对象失去 UI 移除路径;恢复本批的同时保留期间新增。
@@ -6747,7 +6625,7 @@ export default function SessionScreen() {
             ];
             attachmentsRef.current = mergeRestored(attachmentsRef.current);
             setAttachments(mergeRestored);
-            restoreDraftAfterFailure();
+            restoreDirectSendDraftAfterFailure();
             throw err;
           }
         }
@@ -6758,10 +6636,18 @@ export default function SessionScreen() {
         // 否则回滚后集合残留、同 clientId 重发时首帧仍是转圈。
         clearQueueItemSending(queued.clientId);
       }
-      const scopeStillAlive = sendScopeStillAlive();
       // 消息已由 A 路径落定；若等待期间切到 B，只停止旧 continuation，不能再用
-      // A 的附件 id 去清理 B 的 composer UI。
-      if (!scopeStillAlive) return;
+      // A 的附件 id / plan 状态去清理 B 的 composer UI。
+      if (!sendScopeStillAlive()) return;
+      if (sessionAtSend.permissionMode === 'plan') {
+        // 一次性语义(对齐桌面 PR#494 / 产品决策):计划模式只对本条消息生效,发送后
+        // 自动恢复进入前的权限档;本条消息通常已按 plan 派发,切换只影响后续消息。
+        // best-effort:失败不打断发送流程,chip 会保留、用户可手动退出。
+        const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
+        const remembered = prePlanPermissionModeRef.current;
+        const restored = remembered && remembered !== 'plan' ? remembered : fallback;
+        void maker.setPermissionMode(sessionId, restored).catch(() => undefined);
+      }
       voiceDictionaryLearningTrackerRef.current?.flush();
       // 只清本次实际发出那批(sendAttachments)的映射:enqueue 在途期间(弱网数秒)
       // composer 全程可交互,期间新落定的附件已写进这两个映射——全量清空会把它们的
@@ -6928,27 +6814,27 @@ export default function SessionScreen() {
   const renderComposerStopButton = () => (
     <RouteActionButton
       accessibilityLabel={t('session.screen.stopSession')}
-      accessibilityHint={composerLayout.stop.disabledReason ?? undefined}
-      disabled={composerLayout.stop.disabled}
+      accessibilityHint={composerStopDisabledReason ?? undefined}
+      disabled={composerStopDisabled}
       hitSlop={COMPOSER_CONTROL_HIT_SLOP}
       onPress={stopSession}
       pressedStyle={styles.sendButtonPressed}
       style={[
         styles.sendButton,
-        composerLayout.stop.disabled && styles.sendButtonInactive,
+        composerStopDisabled && styles.sendButtonInactive,
       ]}
       testID="session.stopButton"
     >
       {stopPending ? (
-        <ActivityIndicator color={composerLayout.stop.disabled ? colors.textSecondary : colors.ctaText} size="small" />
+        <ActivityIndicator color={composerStopDisabled ? colors.textSecondary : colors.ctaText} size="small" />
       ) : (
         <Square
-          color={composerLayout.stop.disabled ? colors.textSecondary : colors.ctaText}
+          color={composerStopDisabled ? colors.textSecondary : colors.ctaText}
           // 停止钮实心 Square:10px 填充块语义(非阶梯图标),零描边即语义本身
           // (designTokenDiscipline ALLOWLIST 登记豁免)。
           size={10}
           strokeWidth={0}
-          fill={composerLayout.stop.disabled ? colors.textSecondary : colors.ctaText}
+          fill={composerStopDisabled ? colors.textSecondary : colors.ctaText}
         />
       )}
     </RouteActionButton>
@@ -7431,9 +7317,9 @@ export default function SessionScreen() {
     // 失败并弹错,把「一切正常」的乐观观感打碎。静默忽略(不发 RPC、不写乐观 patch、
     // 不报错),对应入口的按钮同期也是灰的;窗口只有几秒。
     // composer 与发送不受此限:那条路径改走 outbox 排队(见 outboxDispatchBlockedNow)。
-    // 判据与 send 里的命令门同源(sessionSettingsLocked = isRemoteSessionMissing);
-    // 这里用 reactive 形态就够:按钮就是按这一帧的快照渲染的,点击不跨帧竞争。
-    if (sessionSettingsLocked) return;
+    // 按钮与命令式入口共用同一判据：会话未建成或明确断线时都不发 RPC；
+    // composer 与普通消息发送不受这个门影响。
+    if (!canUseRemoteSessionControls) return;
     setControlBusy(true);
     // 不要因一次设置尝试清掉仍在恢复中的连接错误,否则会提前放开 outbox 派发门。
     if (!outboxConnectionDispatchBlocked) setError(null);
@@ -7490,18 +7376,16 @@ export default function SessionScreen() {
     maker,
     outboxConnectionDispatchBlocked,
     sessionId,
-    sessionSettingsLocked,
+    canUseRemoteSessionControls,
   ]);
 
   const writeSessionAgentSwitchIntent = useCallback(async (
     nextIntent: NonNullable<RemoteSession['agentSwitchIntent']>,
   ): Promise<boolean> => {
     if (!deviceId || controlBusy) return false;
-    // 会话建成前不写切换意图:被控端的 switch handler 要求会话行已存在,合成行阶段
-    // 一律 NOT_FOUND。这里是**全部** agent-switch 写入的唯一出口(换模型 / 换 effort /
-    // 换 fast 三条路都经它),门放在这里而不是各调用点,新增入口不会漏(review P1:
-    // 换模型那条路不走 runControlAction,只在那儿加锁就漏了它)。
-    if (sessionSettingsLocked) return false;
+    // 会话未建成或明确断线时不写切换意图。这里是全部 agent-switch 写入的唯一出口，
+    // 门放在这里而不是各调用点，新增入口不会漏。
+    if (!canUseRemoteSessionControls) return false;
     const seq = ++agentSwitchWriteSeqRef.current;
     const previousIntent = normalizeSessionAgentSwitchIntent(
       remoteSessionStore.getSessions().find((item) => item.id === sessionId)?.agentSwitchIntent,
@@ -7566,7 +7450,7 @@ export default function SessionScreen() {
     maker,
     outboxConnectionDispatchBlocked,
     sessionId,
-    sessionSettingsLocked,
+    canUseRemoteSessionControls,
   ]);
 
   // Context 面板「计划模式」开关,双路径(#494 迁移):
@@ -7574,46 +7458,36 @@ export default function SessionScreen() {
   //    状态读 session.planModeEnabled;一次性消耗由被控端执行(下一 turn 消耗武装态,
   //    plan_mode_changed → planModeEnabled=false 经 sessions:patched 回流),手机端不做本地恢复。
   //  - 老被控端兼容(permissionModes 仍含 'plan'):沿用 permissionMode 切换 + 发送后本地恢复。
+  const prePlanPermissionModeRef = useRef<string | null>(null);
   const planModeCapability = runtimeOptions?.planModeSupported === true;
   const legacyPlanSupported = runtimeOptions?.permissionOptions.some((option) => option.id === 'plan') ?? false;
   const planModeSupported = planModeCapability || legacyPlanSupported;
   const legacyPlanModeOn = currentSession?.permissionMode === 'plan';
   const planModeOn = planModeCapability ? currentSession?.planModeEnabled === true : legacyPlanModeOn;
   const togglePlanMode = useCallback((next: boolean) => {
-    // sessionSettingsLocked:会话建成前不动权限档(老协议分支还会写进入前档位，
-    // 提前 return 免得留下没生效的本地记录)。
-    if (!canUseComposer || sessionSettingsLocked || !currentSession) return;
+    // 会话未建成或明确断线时不动权限档；老协议分支还会记录进入前档位，
+    // 因此必须在任何本地 mutation 前返回。
+    if (!canUseRemoteSessionControls || !currentSession) return;
     if (planModeCapability) {
       void runControlAction(() => maker.setPlanMode(sessionId, next), { planModeEnabled: next });
       return;
     }
     if (next) {
-      prePlanPermissionModeRef.current = {
-        sessionId,
-        mode: currentSession.permissionMode ?? null,
-      };
-      legacyPlanArmEpochBySessionRef.current.set(
-        sessionId,
-        (legacyPlanArmEpochBySessionRef.current.get(sessionId) ?? 0) + 1,
-      );
+      prePlanPermissionModeRef.current = currentSession.permissionMode ?? null;
       void runControlAction(() => maker.setPermissionMode(sessionId, 'plan'), { permissionMode: 'plan' });
       return;
     }
     const fallback = runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask';
-    const remembered = prePlanPermissionModeRef.current.sessionId === sessionId
-      ? prePlanPermissionModeRef.current.mode
-      : null;
+    const remembered = prePlanPermissionModeRef.current;
     const restored = remembered && remembered !== 'plan' ? remembered : fallback;
     void runControlAction(() => maker.setPermissionMode(sessionId, restored), { permissionMode: restored });
-  }, [canUseComposer, currentSession, maker, planModeCapability, runControlAction, runtimeOptions, sessionId, sessionSettingsLocked]);
+  }, [canUseRemoteSessionControls, currentSession, maker, planModeCapability, runControlAction, runtimeOptions, sessionId]);
   // 权限位置(设置面板下拉)不体现 plan(对齐桌面 PR#494 / Cursor):新协议下 permissionMode
   // 本就与 plan 正交,直接展示;仅老被控端 permissionMode='plan' 时替换为进入前的底层权限档
   // (无记录时回退首个非 plan 档),激活态由 composer 的 PlanModeChip 表达。
   const displayPermissionMode = legacyPlanModeOn
-    ? ((prePlanPermissionModeRef.current.sessionId === sessionId
-      && prePlanPermissionModeRef.current.mode
-      && prePlanPermissionModeRef.current.mode !== 'plan')
-      ? prePlanPermissionModeRef.current.mode
+    ? ((prePlanPermissionModeRef.current && prePlanPermissionModeRef.current !== 'plan')
+      ? prePlanPermissionModeRef.current
       : runtimeOptions?.permissionOptions.find((option) => option.id !== 'plan')?.id ?? 'ask')
     : currentSession?.permissionMode ?? 'ask';
   // 权限模式独立浮窗(2026-07-29 用户裁决,对齐 Codex 与新建页):composer 左侧图标钮
@@ -10189,6 +10063,7 @@ const RouteActionButton = forwardRef<View, RouteActionButtonProps>(function Rout
 });
 
 function ComposerRuntimePill({
+  disabled = false,
   icon: Icon,
   fastOn = false,
   label,
@@ -10197,6 +10072,7 @@ function ComposerRuntimePill({
   testID,
   tone,
 }: {
+  disabled?: boolean;
   icon?: typeof Hand;
   /** Fast 已生效 → label 后缀 Zap 闪电(对齐桌面 trigger)。 */
   fastOn?: boolean;
@@ -10213,6 +10089,7 @@ function ComposerRuntimePill({
   return (
     <RouteActionButton
       accessibilityLabel={label}
+      disabled={disabled}
       hitSlop={COMPOSER_CONTROL_HIT_SLOP}
       onPress={onPress}
       style={styles.composerRuntimePill}

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -79,6 +79,7 @@ import { useDeviceLink } from '@/device-link/DeviceLinkContext';
 import { useRevokedDevices } from '@/device-link/revokedDevicesStore';
 import { useUnresponsiveDevices } from '@/device-link/unresponsiveDevicesStore';
 import {
+  connectionRecoverySyncRetryDelayMs,
   connectionIssueHint,
   describeRemoteComposerBlockingError,
   describeRemoteError,
@@ -702,6 +703,14 @@ function isRetryableEnqueueTransportError(err: unknown): boolean {
 function isAutoRecoveringSessionReferencePreparationError(err: unknown): boolean {
   return isAutoRecoveringRemoteError(err)
     || (err instanceof MobileSessionReferenceError && err.code === 'SESSION_REFERENCE_OFFLINE');
+}
+
+/**
+ * 明确未发出的连接失败和「请求可能已到桌面、只丢了回执」都留在 outbox。
+ * 后一类必须复用原 clientId 重试，由桌面 enqueue 幂等去重，不能恢复草稿后生成新 id。
+ */
+function shouldWaitForOutboxEnqueueRecovery(err: unknown): boolean {
+  return isSafelyUnsentOutboxEnqueueError(err) || isAutoRecoveringRemoteError(err);
 }
 
 /** enqueue 对可安全重发的瞬时传输错误做有界退避。 */
@@ -1743,7 +1752,7 @@ export default function SessionScreen() {
   // 点选的 skill 不被白名单拦截误分流到 learn:start。
   const pendingSkillSelectionRef = useRef<{ name: string; sid: string } | null>(null);
   const extraDirBrowseSeqRef = useRef(0);
-  const autoRetrySyncKeyRef = useRef<string | null>(null);
+  const autoRetrySyncStateRef = useRef<{ identity: string; attempt: number } | null>(null);
   const loadedRouteFocusKeyRef = useRef<string | null>(null);
   const appliedRouteFocusKeyRef = useRef<string | null>(null);
   const appliedRouteComposerFocusKeyRef = useRef<string | null>(null);
@@ -3670,7 +3679,20 @@ export default function SessionScreen() {
         setReadAckSyncedKey(`${sessionId}:${readAckEpochAtStart}`);
       }
     } catch (err) {
-      if (!syncRun.isStale()) setError(formatRemoteError(err));
+      if (!syncRun.isStale()) {
+        const formatted = formatRemoteError(err);
+        setError(formatted);
+        // transient 失败刷新 hold，保证共享 UI error 被其它操作清理时 outbox 仍不
+        // 提前派发；确定性失败则清旧 hold，交给普通错误与手动重试入口处理。
+        setOutboxTransportHold((current) => {
+          if (!isAutoRecoveringRemoteError(err)) {
+            return current?.deviceId === deviceId ? null : current;
+          }
+          return current?.deviceId === deviceId && current.error === formatted
+            ? current
+            : { deviceId, error: formatted };
+        });
+      }
     } finally {
       if (!syncRun.isStale()) setLoading(false);
     }
@@ -4049,38 +4071,55 @@ export default function SessionScreen() {
     void load();
   }, [deviceId, isDeviceUnresponsive, load, sessionId, status]);
 
+  const shouldAutoRetryConnectionSync = connectionRecoveryError !== null
+    && isAutoRecoveringRemoteError(connectionRecoveryError);
   useEffect(() => {
-    if (!connectionRecoveryError) {
-      if (!loading) autoRetrySyncKeyRef.current = null;
+    if (!shouldAutoRetryConnectionSync) {
+      autoRetrySyncStateRef.current = null;
       return;
     }
     if (
       isDeviceAccessRevoked
-      || !currentSession
+      || !hasCurrentSession
       || !deviceId
       || !sessionId
       || loading
       || status !== 'online'
+      || targetAvailableForDispatch === false
+      || isDeviceUnresponsive
     ) {
       return;
     }
-    const retryKey = `${deviceId}:${sessionId}:${connectionEpoch}:${connectionRecoveryError}`;
-    if (autoRetrySyncKeyRef.current === retryKey) return;
+    // 错误全文不属于 identity：同一次故障可能在 NOT_CONNECTED / INVOKE_TIMEOUT
+    // 之间切换，不能因此把退避不断重置回 900ms。
+    const retryIdentity = `${deviceId}:${sessionId}:${connectionEpoch}`;
+    const current = autoRetrySyncStateRef.current;
+    const retryState = current?.identity === retryIdentity
+      ? current
+      : { identity: retryIdentity, attempt: 0 };
+    autoRetrySyncStateRef.current = retryState;
     const timer = setTimeout(() => {
-      autoRetrySyncKeyRef.current = retryKey;
+      const latest = autoRetrySyncStateRef.current;
+      if (latest?.identity !== retryIdentity || latest.attempt !== retryState.attempt) return;
+      autoRetrySyncStateRef.current = {
+        identity: retryIdentity,
+        attempt: retryState.attempt + 1,
+      };
       void load();
-    }, 900);
+    }, connectionRecoverySyncRetryDelayMs(retryState.attempt));
     return () => clearTimeout(timer);
   }, [
-    connectionRecoveryError,
-    currentSession,
+    shouldAutoRetryConnectionSync,
+    hasCurrentSession,
     deviceId,
     isDeviceAccessRevoked,
+    isDeviceUnresponsive,
     load,
     loading,
     connectionEpoch,
     sessionId,
     status,
+    targetAvailableForDispatch,
   ]);
 
   // 监听 error-persisted 脏信号:被控端落库完成后通知控制端,保留了缓存消息但失效了 sync marker。
@@ -5526,7 +5565,7 @@ export default function SessionScreen() {
           ...current,
           pendingQueue: current.pendingQueue.filter((entry) => entry.clientId !== queued.clientId),
         });
-        if (isSafelyUnsentOutboxEnqueueError(err)) {
+        if (shouldWaitForOutboxEnqueueRecovery(err)) {
           waitForConnection(err);
           return 'deferred' as const;
         }
@@ -6504,9 +6543,10 @@ export default function SessionScreen() {
             salvageOutboxItem(recoverableItem);
             return;
           }
-          if (isSafelyUnsentOutboxEnqueueError(err)) {
-            // 点击时链路尚健康、真正派发前才撞上断线：把同一 clientId/内容接回
-            // 本地 outbox，保持乐观气泡与 FIFO，恢复后自动 pump；不把草稿塞回输入框。
+          if (shouldWaitForOutboxEnqueueRecovery(err)) {
+            // 明确未发出或 enqueue 已到桌面但回执不确定：都把同一 clientId/内容
+            // 接回 outbox。恢复后同 id 重试由桌面幂等去重，不能恢复草稿让用户用
+            // 新 id 重发，否则第一次其实已执行时会产生重复任务。
             updateOutbox((items) => (
               items.some((item) => item.clientId === recoverableItem.clientId)
                 ? replaceOutboxItem(items, recoverableItem)
@@ -8555,7 +8595,7 @@ export default function SessionScreen() {
               <ConnectionBanner
                 density="compact"
                 deviceUnresponsive={isDeviceUnresponsive}
-                error={connectionError}
+                error={connectionRecoveryError}
                 issue={connectionIssue}
                 lastSyncedAt={lastSyncedAt}
                 loading={loading}

--- a/apps/mobile/app/sessions/[sessionId].tsx
+++ b/apps/mobile/app/sessions/[sessionId].tsx
@@ -892,6 +892,7 @@ export default function SessionScreen() {
   const {
     connectionEpoch,
     connectionIssue,
+    getPresenceAvailability,
     invoke,
     lastPresenceSnapshot,
     openLink,
@@ -1523,6 +1524,12 @@ export default function SessionScreen() {
   const [extraDirBrowseLoading, setExtraDirBrowseLoading] = useState(false);
   const [extraDirBrowseError, setExtraDirBrowseError] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // UI 错误可被任意操作清掉；transport hold 独立保留到当前设备完成一次权威同步。
+  // 否则「加载更早 / 刷新用量」的 setError(null) 会误放行仍在断线恢复中的 outbox。
+  const [outboxTransportHold, setOutboxTransportHold] = useState<{
+    deviceId: string;
+    error: string;
+  } | null>(null);
   const [lastSyncedAt, setLastSyncedAt] = useState<number | null>(null);
   // 会话已读回执的同步门槛 key:`${sessionId}:${connectionEpoch}`,由 syncSession 尾部写入。
   // 与 lastSyncedAt 不同,它按 session + 连接代区分——屏实例复用、原地切 session 时
@@ -1761,22 +1768,34 @@ export default function SessionScreen() {
     isDeviceAccessRevoked ? '[ACCESS_REVOKED] access revoked by target device' : error,
     isDeviceUnresponsive,
   );
-  // Presence 是全局流，最后一帧可能属于别的设备；只复用明确属于当前 deviceId 的
-  // 记忆，避免原地切设备后拿上一台电脑的 online 状态误派发。
-  const targetAvailableForDispatch = lastPresenceSnapshot?.deviceId === deviceId
-    ? lastPresenceSnapshot.online && lastPresenceSnapshot.remoteControlEnabled
-    : targetAvailableDeviceRef.current === deviceId
-      ? targetAvailableRef.current
-      : null;
+  // dispatch / Stop 只认 Context 内随 connection epoch 重置的三态 verdict。
+  // lastPresenceSnapshot 与下方 ref 只用于 false→true 的 resync edge，不能作为门禁：
+  // 它们会跨 epoch 保留，旧 offline 否则会把新连接永久卡死。
+  const targetAvailableForDispatch = getPresenceAvailability(deviceId);
   // 对齐 Desktop:断线恢复期间设置入口仍可操作,但明确知道电脑不可达时拦下停止任务。
   // presence 未知时仍允许尝试,避免旧缓存把停止入口永久锁死。
   const remoteStopUnavailable =
     status !== 'online' || targetAvailableForDispatch === false;
+  const screenAutoRecoveringError = connectionError && isAutoRecoveringRemoteError(connectionError)
+    ? connectionError
+    : null;
+  const heldOutboxTransportError = outboxTransportHold?.deviceId === deviceId
+    ? outboxTransportHold.error
+    : null;
+  const activeOutboxTransportError = screenAutoRecoveringError ?? heldOutboxTransportError;
+  useEffect(() => {
+    if (!deviceId || !screenAutoRecoveringError) return;
+    setOutboxTransportHold((current) => (
+      current?.deviceId === deviceId && current.error === screenAutoRecoveringError
+        ? current
+        : { deviceId, error: screenAutoRecoveringError }
+    ));
+  }, [deviceId, screenAutoRecoveringError]);
   const outboxConnectionState: MobileOutboxConnectionState = {
     relayOnline: status === 'online',
     targetAvailable: targetAvailableForDispatch,
     deviceUnresponsive: isDeviceUnresponsive,
-    autoRecoveringError: isAutoRecoveringRemoteError(connectionError),
+    autoRecoveringError: activeOutboxTransportError !== null,
     syncInProgress: loading,
   };
   // pumpOutbox 是跨 render 的 async 循环，每轮必须读最新连接态；只捕获某一帧会在
@@ -1787,7 +1806,13 @@ export default function SessionScreen() {
     outboxConnectionState,
   );
   // 弱网普通断线也要有可见信号(消息流静默停更没有任何提示),经防闪延迟后显示
-  const showConnectionBanner = useShowConnectionBanner(status, connectionError, connectionIssue, isDeviceUnresponsive);
+  const connectionRecoveryError = activeOutboxTransportError ?? connectionError;
+  const showConnectionBanner = useShowConnectionBanner(
+    status,
+    connectionRecoveryError,
+    connectionIssue,
+    isDeviceUnresponsive,
+  );
   const hasCurrentSession = currentSession !== null;
   const currentAgentKind = useMemo(
     () => currentSession ? agentKindForSession(currentSession) : null,
@@ -3634,6 +3659,9 @@ export default function SessionScreen() {
       // 同步尾、无 await —— 否则乐观点亮 effect(依赖 lastSyncedAt===null)会在 await 间隙把刚校正成 false
       // 的「加载更早」入口重新点亮。将来切勿在两者之间插入 await。
       if (syncRun.isStale()) return;
+      // 当前设备的权威 session + projection 同步已完整落定，才解除独立 transport hold。
+      // 不在 connectionEpoch 刚推进时提前清，避免同一 commit 的 outbox effect 抢在 resync 前派发。
+      setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);
       setLastSyncedAt(Date.now());
       // 已读回执门槛:本会话在当前连接代完成过整窗同步。sessionId / epoch / 门槛代号
       // 都取 sync 开始时的快照——原地切 session、重连、attention 上升沿之后,启动更早
@@ -4022,7 +4050,7 @@ export default function SessionScreen() {
   }, [deviceId, isDeviceUnresponsive, load, sessionId, status]);
 
   useEffect(() => {
-    if (!connectionError) {
+    if (!connectionRecoveryError) {
       if (!loading) autoRetrySyncKeyRef.current = null;
       return;
     }
@@ -4036,7 +4064,7 @@ export default function SessionScreen() {
     ) {
       return;
     }
-    const retryKey = `${deviceId}:${sessionId}:${connectionEpoch}:${connectionError}`;
+    const retryKey = `${deviceId}:${sessionId}:${connectionEpoch}:${connectionRecoveryError}`;
     if (autoRetrySyncKeyRef.current === retryKey) return;
     const timer = setTimeout(() => {
       autoRetrySyncKeyRef.current = retryKey;
@@ -4044,7 +4072,7 @@ export default function SessionScreen() {
     }, 900);
     return () => clearTimeout(timer);
   }, [
-    connectionError,
+    connectionRecoveryError,
     currentSession,
     deviceId,
     isDeviceAccessRevoked,

--- a/apps/mobile/app/sessions/new.tsx
+++ b/apps/mobile/app/sessions/new.tsx
@@ -419,6 +419,7 @@ export default function NewRemoteSessionScreen() {
   const router = useRouter();
   const auth = useAuth();
   const {
+    getPresenceAvailability,
     invoke,
     openLink,
     subscribe,
@@ -3801,6 +3802,19 @@ export default function NewRemoteSessionScreen() {
       setError(t('session.new.selectDeviceError'));
       return;
     }
+    // 旧协议 Plan 依赖会话级 permissionMode，不能安全进入断线创建 / 离线 FIFO。
+    // 保留草稿与 Plan 选择，等 relay 和目标电脑恢复后再走原有在线兼容路径。
+    if (
+      !planModeCapability
+      && draft.permissionMode === 'plan'
+      && (
+        deviceLinkStatus !== 'online'
+        || getPresenceAvailability(selectedDeviceId) === false
+      )
+    ) {
+      setError(t('session.menu.aiRenameOffline'));
+      return;
+    }
     if (
       worktreeApplicable
       && (
@@ -4321,10 +4335,12 @@ export default function NewRemoteSessionScreen() {
     agentAuthVerdict,
     auth.user?.id,
     confirmAgentUnauthenticated,
+    deviceLinkStatus,
     selectedDeviceId,
     selectedDeviceName,
     draft,
     finishVoiceRecording,
+    getPresenceAvailability,
     maker,
     openLink,
     planModeCapability,

--- a/apps/mobile/e2e/maestro/visual_session_offline.yaml
+++ b/apps/mobile/e2e/maestro/visual_session_offline.yaml
@@ -26,5 +26,14 @@ appId: ${APP_ID}
     visible:
       id: "session.sendButton"
     timeout: 5000
+- assertNotVisible:
+    id: "connection.syncButton"
+- tapOn:
+    id: "session.sendButton"
+- extendedWaitUntil:
+    visible:
+      id: "pendingSend.badge.uploading"
+    timeout: 5000
+- assertVisible: "Offline visual draft"
 - takeScreenshot:
     path: visual-session-offline

--- a/apps/mobile/src/__tests__/connectionBannerVisibility.test.ts
+++ b/apps/mobile/src/__tests__/connectionBannerVisibility.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  resolveConnectionBannerSyncActionVisibility,
   resolveConnectionBannerVisibility,
   resolveEffectiveConnectionError,
 } from '@/components/connectionBannerVisibility';
@@ -62,5 +63,36 @@ describe('resolveEffectiveConnectionError', () => {
     expect(resolveEffectiveConnectionError('[NOT_CONNECTED] offline', false)).toBe('[NOT_CONNECTED] offline');
     expect(resolveEffectiveConnectionError(null, false)).toBeNull();
     expect(resolveEffectiveConnectionError(null, true)).toBeNull();
+  });
+});
+
+describe('resolveConnectionBannerSyncActionVisibility', () => {
+  const actionBase = {
+    online: true,
+    hasActiveIssue: false,
+    deviceUnresponsive: false,
+    hasRequestError: true,
+    requestErrorAutoRecovering: false,
+  };
+
+  it('普通请求级同步失败仍可手动重试', () => {
+    expect(resolveConnectionBannerSyncActionVisibility(actionBase)).toBe(true);
+  });
+
+  it('断线、连接 issue、熔断与瞬时请求错误都交给系统自动恢复', () => {
+    expect(resolveConnectionBannerSyncActionVisibility({ ...actionBase, online: false })).toBe(false);
+    expect(resolveConnectionBannerSyncActionVisibility({ ...actionBase, hasActiveIssue: true })).toBe(false);
+    expect(resolveConnectionBannerSyncActionVisibility({ ...actionBase, deviceUnresponsive: true })).toBe(false);
+    expect(resolveConnectionBannerSyncActionVisibility({
+      ...actionBase,
+      requestErrorAutoRecovering: true,
+    })).toBe(false);
+  });
+
+  it('没有请求错误时不造一个常驻同步入口', () => {
+    expect(resolveConnectionBannerSyncActionVisibility({
+      ...actionBase,
+      hasRequestError: false,
+    })).toBe(false);
   });
 });

--- a/apps/mobile/src/__tests__/nativeE2eEnvironment.test.ts
+++ b/apps/mobile/src/__tests__/nativeE2eEnvironment.test.ts
@@ -69,6 +69,9 @@ describe('native e2e environment', () => {
     expect(visualOfflineFlow).toContain('- inputText: "Offline visual draft"');
     expect(visualOfflineFlow).toContain('- hideKeyboard');
     expect(visualOfflineFlow).toContain('id: "session.sendButton"');
+    expect(visualOfflineFlow).toContain('id: "pendingSend.badge.uploading"');
+    expect(visualOfflineFlow).toContain('- assertNotVisible:');
+    expect(visualOfflineFlow).toContain('id: "connection.syncButton"');
     expect(visualOfflineFlow).not.toContain('session.collaborationReadOnlyComposer');
   });
 

--- a/apps/mobile/src/__tests__/newSession.test.ts
+++ b/apps/mobile/src/__tests__/newSession.test.ts
@@ -1827,7 +1827,7 @@ describe('new session worktree wiring (source locks)', () => {
       'applicable: worktreeApplicable,',
     );
     const createEntry = newSource.indexOf('const create = useCallback(async () => {');
-    const createBody = newSource.slice(createEntry, createEntry + 1_200);
+    const createBody = newSource.slice(createEntry, createEntry + 1_800);
     expect(createBody).not.toContain('|| worktreePreferenceSaving');
     expect(createBody).toContain('if (worktreeCreateBlocked) {');
     expect(newSource).toContain('worktreeBranchPreferenceSaving');

--- a/apps/mobile/src/__tests__/newSessionCreation.test.ts
+++ b/apps/mobile/src/__tests__/newSessionCreation.test.ts
@@ -35,6 +35,7 @@ import {
   drainStashedNewSessionDraft,
   getNewSessionCreationTask,
   prepareNewSessionCreationForEdit,
+  retryNewSessionLegacyPlanRestore,
   retryNewSessionCreation,
   shouldBlockSessionSync,
   stashNewSessionDraftForEdit,
@@ -161,6 +162,10 @@ describe('newSessionCreation pipeline', () => {
       's21',
       's22',
       's23',
+      's24',
+      's25',
+      's26',
+      's27',
     ]) dismissNewSessionCreation(id);
   });
 
@@ -178,6 +183,41 @@ describe('newSessionCreation pipeline', () => {
     expect(projection.pendingQueue[0]?.text).toBe('hello world');
     expect(projection.pendingQueue[0]?.clientId).toBe(getNewSessionCreationTask('s1')?.firstMessageClientId);
     expect(shouldBlockSessionSync('s1')).toBe(true);
+  });
+
+  it('旧协议首条保留 plan 快照，但创建期间的会话镜像立即恢复供后续消息使用', async () => {
+    const planDraft = { ...DRAFT, permissionMode: 'plan' };
+    const maker = makeMaker({
+      getSession: vi.fn(async () => sessionFromCreateResult({ sessionId: 's24' }, planDraft)),
+      // 锁定「权威会话已回流、首条 enqueue 尚未落定」窗口。
+      input: {
+        enqueue: vi.fn(() => new Promise(() => undefined)),
+      } as MakerMock['input'],
+    });
+    startNewSessionCreation(makeParams('s24', maker, {
+      draft: planDraft,
+      legacyPlanRestore: 'auto',
+    }));
+
+    expect(remoteSessionStore.getSessions().find((s) => s.id === 's24')?.permissionMode)
+      .toBe('auto');
+    expect(remoteSessionStore.getInputProjection('s24').pendingQueue[0]).toMatchObject({
+      permissionMode: 'plan',
+      createOpts: expect.objectContaining({ permissionMode: 'plan' }),
+    });
+
+    await flushPipeline();
+
+    expect(remoteSessionStore.getSessions().find((s) => s.id === 's24')?.permissionMode)
+      .toBe('auto');
+    expect(maker.input.enqueue).toHaveBeenCalledWith(
+      's24',
+      expect.objectContaining({
+        permissionMode: 'plan',
+        createOpts: expect.objectContaining({ permissionMode: 'plan' }),
+      }),
+      expect.anything(),
+    );
   });
 
   it('成功链路:createSession 收到预生成 id、enqueue 用同 clientId,task 移除、守卫解除、禁发标清除', async () => {
@@ -518,6 +558,72 @@ describe('newSessionCreation pipeline', () => {
     // 禁发标同步清除:用户要用 composer 重发回填草稿,不能被 pendingLocalCreation
     // 卡到 load 成功才解禁(codex P2)。
     expect(remoteSessionStore.getSessions().find((s) => s.id === 's5')?.pendingLocalCreation).toBe(false);
+  });
+
+  it('旧协议首条 enqueue 未应用时重新武装本地 plan，和仍为 plan 的远端保持一致', async () => {
+    const maker = makeMaker();
+    maker.input.enqueue.mockRejectedValue(new Error('INVOKE_TIMEOUT'));
+    startNewSessionCreation(makeParams('s25', maker, {
+      draft: { ...DRAFT, permissionMode: 'plan' },
+      legacyPlanRestore: 'auto',
+    }));
+
+    await flushPipeline();
+
+    expect(getNewSessionCreationTask('s25')?.status).toBe('enqueue-failed');
+    expect(remoteSessionStore.getSessions().find((s) => s.id === 's25')).toMatchObject({
+      pendingLocalCreation: false,
+      permissionMode: 'plan',
+    });
+    expect(maker.setPermissionMode).not.toHaveBeenCalled();
+  });
+
+  it('旧协议首条已入队但断线恢复失败时保留恢复屏障，成功后才放行 follow-up', async () => {
+    const maker = makeMaker({
+      setPermissionMode: vi.fn(async () => {
+        throw new Error('[DEVICE_OFFLINE] target offline');
+      }),
+    });
+    startNewSessionCreation(makeParams('s26', maker, {
+      draft: { ...DRAFT, permissionMode: 'plan' },
+      legacyPlanRestore: 'auto',
+    }));
+
+    await flushPipeline();
+
+    expect(getNewSessionCreationTask('s26')?.status).toBe('restoring-plan');
+    expect(shouldBlockSessionSync('s26')).toBe(true);
+    expect(maker.setPermissionMode).toHaveBeenCalledWith('s26', 'auto');
+    expect(remoteSessionStore.getSessions().find((s) => s.id === 's26')?.permissionMode)
+      .toBe('auto');
+
+    maker.setPermissionMode.mockResolvedValue(undefined);
+    retryNewSessionLegacyPlanRestore('s26');
+    await flushPipeline();
+
+    expect(getNewSessionCreationTask('s26')).toBeNull();
+    expect(shouldBlockSessionSync('s26')).toBe(false);
+    expect(remoteSessionStore.getSessions().find((s) => s.id === 's26')?.pendingLocalCreation)
+      .toBe(false);
+  });
+
+  it('旧协议恢复遇到确定性拒绝时沿用 best-effort，不永久锁死已创建会话', async () => {
+    const maker = makeMaker({
+      setPermissionMode: vi.fn(async () => {
+        throw new Error('CHANNEL_NOT_ALLOWED');
+      }),
+    });
+    startNewSessionCreation(makeParams('s27', maker, {
+      draft: { ...DRAFT, permissionMode: 'plan' },
+      legacyPlanRestore: 'auto',
+    }));
+
+    await flushPipeline();
+
+    expect(getNewSessionCreationTask('s27')).toBeNull();
+    expect(shouldBlockSessionSync('s27')).toBe(false);
+    expect(remoteSessionStore.getSessions().find((s) => s.id === 's27')?.pendingLocalCreation)
+      .toBe(false);
   });
 
   it('enqueue 回执丢失但队列里已有该 clientId → 按成功收敛,不打扰用户', async () => {

--- a/apps/mobile/src/__tests__/newSessionCreation.test.ts
+++ b/apps/mobile/src/__tests__/newSessionCreation.test.ts
@@ -35,7 +35,6 @@ import {
   drainStashedNewSessionDraft,
   getNewSessionCreationTask,
   prepareNewSessionCreationForEdit,
-  retryNewSessionLegacyPlanRestore,
   retryNewSessionCreation,
   shouldBlockSessionSync,
   stashNewSessionDraftForEdit,
@@ -162,10 +161,6 @@ describe('newSessionCreation pipeline', () => {
       's21',
       's22',
       's23',
-      's24',
-      's25',
-      's26',
-      's27',
     ]) dismissNewSessionCreation(id);
   });
 
@@ -183,41 +178,6 @@ describe('newSessionCreation pipeline', () => {
     expect(projection.pendingQueue[0]?.text).toBe('hello world');
     expect(projection.pendingQueue[0]?.clientId).toBe(getNewSessionCreationTask('s1')?.firstMessageClientId);
     expect(shouldBlockSessionSync('s1')).toBe(true);
-  });
-
-  it('旧协议首条保留 plan 快照，但创建期间的会话镜像立即恢复供后续消息使用', async () => {
-    const planDraft = { ...DRAFT, permissionMode: 'plan' };
-    const maker = makeMaker({
-      getSession: vi.fn(async () => sessionFromCreateResult({ sessionId: 's24' }, planDraft)),
-      // 锁定「权威会话已回流、首条 enqueue 尚未落定」窗口。
-      input: {
-        enqueue: vi.fn(() => new Promise(() => undefined)),
-      } as MakerMock['input'],
-    });
-    startNewSessionCreation(makeParams('s24', maker, {
-      draft: planDraft,
-      legacyPlanRestore: 'auto',
-    }));
-
-    expect(remoteSessionStore.getSessions().find((s) => s.id === 's24')?.permissionMode)
-      .toBe('auto');
-    expect(remoteSessionStore.getInputProjection('s24').pendingQueue[0]).toMatchObject({
-      permissionMode: 'plan',
-      createOpts: expect.objectContaining({ permissionMode: 'plan' }),
-    });
-
-    await flushPipeline();
-
-    expect(remoteSessionStore.getSessions().find((s) => s.id === 's24')?.permissionMode)
-      .toBe('auto');
-    expect(maker.input.enqueue).toHaveBeenCalledWith(
-      's24',
-      expect.objectContaining({
-        permissionMode: 'plan',
-        createOpts: expect.objectContaining({ permissionMode: 'plan' }),
-      }),
-      expect.anything(),
-    );
   });
 
   it('成功链路:createSession 收到预生成 id、enqueue 用同 clientId,task 移除、守卫解除、禁发标清除', async () => {
@@ -558,72 +518,6 @@ describe('newSessionCreation pipeline', () => {
     // 禁发标同步清除:用户要用 composer 重发回填草稿,不能被 pendingLocalCreation
     // 卡到 load 成功才解禁(codex P2)。
     expect(remoteSessionStore.getSessions().find((s) => s.id === 's5')?.pendingLocalCreation).toBe(false);
-  });
-
-  it('旧协议首条 enqueue 未应用时重新武装本地 plan，和仍为 plan 的远端保持一致', async () => {
-    const maker = makeMaker();
-    maker.input.enqueue.mockRejectedValue(new Error('INVOKE_TIMEOUT'));
-    startNewSessionCreation(makeParams('s25', maker, {
-      draft: { ...DRAFT, permissionMode: 'plan' },
-      legacyPlanRestore: 'auto',
-    }));
-
-    await flushPipeline();
-
-    expect(getNewSessionCreationTask('s25')?.status).toBe('enqueue-failed');
-    expect(remoteSessionStore.getSessions().find((s) => s.id === 's25')).toMatchObject({
-      pendingLocalCreation: false,
-      permissionMode: 'plan',
-    });
-    expect(maker.setPermissionMode).not.toHaveBeenCalled();
-  });
-
-  it('旧协议首条已入队但断线恢复失败时保留恢复屏障，成功后才放行 follow-up', async () => {
-    const maker = makeMaker({
-      setPermissionMode: vi.fn(async () => {
-        throw new Error('[DEVICE_OFFLINE] target offline');
-      }),
-    });
-    startNewSessionCreation(makeParams('s26', maker, {
-      draft: { ...DRAFT, permissionMode: 'plan' },
-      legacyPlanRestore: 'auto',
-    }));
-
-    await flushPipeline();
-
-    expect(getNewSessionCreationTask('s26')?.status).toBe('restoring-plan');
-    expect(shouldBlockSessionSync('s26')).toBe(true);
-    expect(maker.setPermissionMode).toHaveBeenCalledWith('s26', 'auto');
-    expect(remoteSessionStore.getSessions().find((s) => s.id === 's26')?.permissionMode)
-      .toBe('auto');
-
-    maker.setPermissionMode.mockResolvedValue(undefined);
-    retryNewSessionLegacyPlanRestore('s26');
-    await flushPipeline();
-
-    expect(getNewSessionCreationTask('s26')).toBeNull();
-    expect(shouldBlockSessionSync('s26')).toBe(false);
-    expect(remoteSessionStore.getSessions().find((s) => s.id === 's26')?.pendingLocalCreation)
-      .toBe(false);
-  });
-
-  it('旧协议恢复遇到确定性拒绝时沿用 best-effort，不永久锁死已创建会话', async () => {
-    const maker = makeMaker({
-      setPermissionMode: vi.fn(async () => {
-        throw new Error('CHANNEL_NOT_ALLOWED');
-      }),
-    });
-    startNewSessionCreation(makeParams('s27', maker, {
-      draft: { ...DRAFT, permissionMode: 'plan' },
-      legacyPlanRestore: 'auto',
-    }));
-
-    await flushPipeline();
-
-    expect(getNewSessionCreationTask('s27')).toBeNull();
-    expect(shouldBlockSessionSync('s27')).toBe(false);
-    expect(remoteSessionStore.getSessions().find((s) => s.id === 's27')?.pendingLocalCreation)
-      .toBe(false);
   });
 
   it('enqueue 回执丢失但队列里已有该 clientId → 按成功收敛,不打扰用户', async () => {

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -21,7 +21,7 @@ function readSource(relativePath: string): string {
 const SCREEN = 'app/sessions/[sessionId].tsx';
 
 describe('mobile optimistic composer while session is not ready', () => {
-  it('keeps the composer out of the read-only slot and only gates remote controls until the session exists', () => {
+  it('keeps the composer out of the read-only slot while gating remote controls separately', () => {
     const source = readSource(SCREEN);
 
     // composer 只认真正的协作只读理由。
@@ -42,10 +42,14 @@ describe('mobile optimistic composer while session is not ready', () => {
     const stopStart = source.indexOf('const stopSession = () => {');
     const stopEnd = source.indexOf('\n  };', stopStart);
     const stop = source.slice(stopStart, stopEnd);
+    const stopButtonStart = source.indexOf('const renderComposerStopButton = () => (');
+    const stopButtonEnd = source.indexOf('\n  );', stopButtonStart);
+    const stopButton = source.slice(stopButtonStart, stopButtonEnd);
 
-    // 模型 / effort / fast / 权限 / plan 继续可点;RPC 失败走既有乐观回滚。
+    // 模型 / effort / fast / 权限 / plan / Stop 都需要实时访问被控端，明确断线时禁用。
     expect(source).toContain('const sessionSettingsLocked = isRemoteSessionMissing(currentSession);');
-    expect(source).not.toContain('const sessionSettingsLocked = isRemoteSessionMissing(currentSession)\n    ||');
+    expect(source).toContain("const remoteRealtimeControlsUnavailable = status !== 'online'");
+    expect(source).toContain('const canUseRemoteSessionControls = canUseComposer\n    && !sessionSettingsLocked\n    && !remoteRealtimeControlsUnavailable;');
     // UI error 可独立清理；transport hold 只在权威 sync 成功后解除，不再借共享 error
     // 充当 outbox 门禁。
     expect(source).toContain('const [outboxTransportHold, setOutboxTransportHold] = useState<');
@@ -66,19 +70,28 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(queueGate).not.toContain('remoteUnavailableReason');
     expect(queueGate).not.toContain('outboxConnectionDispatchBlocked');
     // Stop 保持可见,但明确断线时不发送 RPC,只进入自动恢复提示。
-    expect(source).toContain("status !== 'online' || targetAvailableForDispatch === false");
+    expect(source).toContain("const remoteRealtimeControlsUnavailable = status !== 'online'");
     const dispatchPresenceStart = source.indexOf('const targetAvailableForDispatch =');
     const dispatchPresenceEnd = source.indexOf(';', dispatchPresenceStart);
     const dispatchPresence = source.slice(dispatchPresenceStart, dispatchPresenceEnd);
     expect(dispatchPresence).toContain('getPresenceAvailability(deviceId)');
     expect(dispatchPresence).not.toContain('lastPresenceSnapshot');
     expect(dispatchPresence).not.toContain('targetAvailableRef');
-    expect(source).toContain('canStop: canUseRemoteSessionControls && canStopComposer,');
+    expect(source).toContain('canStop: canStopComposer,');
+    expect(source).toContain(
+      'const composerStopDisabled = composerLayout.stop.disabled || !canUseRemoteSessionControls;',
+    );
+    expect(stopButton).toContain('disabled={composerStopDisabled}');
     expect(stop).toContain('if (remoteStopUnavailable) {');
     expect(stop).toContain("'[DEVICE_OFFLINE]'");
     expect(stop).toContain("'[NOT_CONNECTED]'");
     expect(stop).not.toContain('target device unavailable');
     expect(stop).not.toContain('relay reconnecting');
+    const runtimePillStart = source.indexOf('function ComposerRuntimePill({');
+    const runtimePillEnd = source.indexOf('\nfunction ComposerActivityStatus', runtimePillStart);
+    const runtimePill = source.slice(runtimePillStart, runtimePillEnd);
+    expect(runtimePill).toContain('disabled = false,');
+    expect(runtimePill).toContain('disabled={disabled}');
   });
 
   it('publishes every transport-side presence availability transition to context consumers', () => {
@@ -129,42 +142,41 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(source).toContain('if (!dispatchBlockedAtSend && !currentSession.workingDir) {');
   });
 
-  it('restores legacy plan only after outbox enqueue acceptance and blocks FIFO while offline', () => {
+  it('keeps legacy Plan out of deferred delivery without affecting the modern Plan path', () => {
     const source = readSource(SCREEN);
-    const dispatchStart = source.indexOf('const dispatchOutboxItem = async');
-    const prepareStart = source.indexOf('queued = await prepareMobileQueuedSessionReferences(', dispatchStart);
-    const rearmStart = source.indexOf("maker.setPermissionMode(item.sessionId, 'plan')", dispatchStart);
-    const enqueueStart = source.indexOf('projection = await maker.input.enqueue', dispatchStart);
-    const acceptedBarrierStart = source.indexOf('const acceptedBarrier: MobileOutboxItem = {', enqueueStart);
-    const acceptedRestoreStart = source.indexOf(
-      'await restoreLegacyPlanAfterEnqueue(acceptedBarrier)',
-      acceptedBarrierStart,
-    );
+    const guardStart = source.indexOf('const legacyPlanRequiresLiveDispatch =');
+    const optimisticClearStart = source.indexOf('if (text) applyComposerDocument(documentAfterOptimisticClear);');
+    const outboxStart = source.indexOf('if (useLocalOutbox) {', guardStart);
+    const guard = source.slice(guardStart, outboxStart);
 
+    expect(guardStart).toBeGreaterThan(-1);
+    expect(guardStart).toBeLessThan(optimisticClearStart);
+    expect(guard).toContain("runtimeOptions?.planModeSupported !== true");
+    expect(guard).toContain('const useLocalOutbox = shouldUseLocalOutbox && !legacyPlanRequiresLiveDispatch;');
+    expect(guard).toContain('dispatchBlockedAtSend || outboxRef.current.length > 0 || outboxPumpBusyRef.current');
+    expect(guard).toContain("setError(t('session.menu.aiRenameOffline'));");
     expect(source).toContain(
-      'legacyPlanRestore,\n          legacyPlanArmEpochAtSend,\n          readyAttachments,',
+      'const recovery = recoverOutboxItemsToComposerDraft([capturedDraftRecoveryItem()], {',
     );
-    expect(source).toContain('legacyPlanArmEpochAtSend,');
-    expect(prepareStart).toBeGreaterThan(dispatchStart);
-    expect(rearmStart).toBeGreaterThan(prepareStart);
-    expect(enqueueStart).toBeGreaterThan(rearmStart);
-    expect(acceptedBarrierStart).toBeGreaterThan(enqueueStart);
-    expect(acceptedRestoreStart).toBeGreaterThan(enqueueStart);
-    expect(source).toContain('if (item.restoreOnly) return restoreLegacyPlanAfterEnqueue(item);');
-    expect(source).toContain('restoreOnly: true,');
-    expect(source).toContain('outboxItems.filter((item) => !item.restoreOnly)');
-    expect(source).toContain('const unsentItems = items.filter((item) => !item.restoreOnly);');
-    expect(source).not.toContain("from '@/session/legacyPlanRecovery'");
+    expect(source).toContain('applyComposerDocument(recovery.document);');
+    expect((source.match(/restoreDirectSendDraftAfterFailure\(\)/g) ?? [])).toHaveLength(4);
+    expect(source).toContain(
+      'if (shouldWaitForOutboxEnqueueRecovery(err) && !legacyPlanRequiresLiveDispatch) {',
+    );
+    expect(source).toContain('maker.setPlanMode(sessionId, next)');
+    expect(source).not.toContain('restoreOnly');
+    expect(source).not.toContain('legacyPlanRecovery');
+    expect(source).not.toContain('legacyPlanRestore');
+  });
 
-    const optimisticOutboxStart = source.indexOf('const legacyPlanRestore = legacyPlanRestoreAtDecision;');
-    const optimisticOutboxBuild = source.indexOf('updateOutbox((items) => [...items, buildOutboxItem({', optimisticOutboxStart);
-    const optimisticOutboxSetup = source.slice(optimisticOutboxStart, optimisticOutboxBuild);
-    expect(optimisticOutboxSetup).toContain('consumeLegacyPlanLocally(legacyPlanRestore);');
-    expect(optimisticOutboxSetup).not.toContain('maker.setPermissionMode');
-    expect(source).toContain("const legacyPlanRestoreAtDecision = permissionModeAtDecision === 'plan'");
-    expect(source).toContain('|| legacyPlanRestoreAtDecision !== null)) {');
-    expect(source).toContain('legacyPlanArmEpochBySessionRef.current.set(');
-    expect(source).toContain('items.some((entry) => entry.clientId === acceptedBarrier.clientId)');
+  it('preserves a new-session legacy Plan draft until live dispatch is available', () => {
+    const source = readSource('app/sessions/new.tsx');
+
+    expect(source).toContain('!planModeCapability');
+    expect(source).toContain("draft.permissionMode === 'plan'");
+    expect(source).toContain("deviceLinkStatus !== 'online'");
+    expect(source).toContain('getPresenceAvailability(selectedDeviceId) === false');
+    expect(source).toContain("setError(t('session.menu.aiRenameOffline'));");
   });
 
   it('defers disconnect races instead of turning them into failed or falsely delivered messages', () => {
@@ -174,8 +186,7 @@ describe('mobile optimistic composer while session is not ready', () => {
     const recoveryHelper = source.slice(recoveryHelperStart, recoveryHelperEnd);
 
     expect(source).toContain('const waitForConnection = (');
-    expect(source).toContain('waitingItem: MobileOutboxItem = item,');
-    expect(source).toContain('outboxItemWaitingForConnection(waitingItem)');
+    expect(source).toContain('const waiting = outboxItemWaitingForConnection(item);');
     expect(source).toContain("if (result === 'deferred' || result === 'stopped') return;");
     expect(source).toContain("return 'stopped' as const;");
     expect(source).toContain('isSafelyUnsentOutboxEnqueueError(err)');
@@ -183,7 +194,7 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(recoveryHelper).toContain('isAutoRecoveringRemoteError(err)');
     // direct 与 outbox-originated enqueue 都必须用同一判据，把回执不确定项保留在
     // 原 clientId 上自动重试；不能一条自动等、另一条退回草稿生成新 id。
-    expect((source.match(/if \(shouldWaitForOutboxEnqueueRecovery\(err\)\)/g) ?? []))
+    expect((source.match(/shouldWaitForOutboxEnqueueRecovery\(err\)/g) ?? []))
       .toHaveLength(2);
     expect((source.match(/按「无法证明已送达」处理。\n\s+return false;/g) ?? [])).toHaveLength(2);
     expect(source).not.toContain('const authorityAdvanced = remoteSessionStore.captureInputProjectionAuthorityEpoch(');
@@ -227,7 +238,7 @@ describe('mobile optimistic composer while session is not ready', () => {
     const source = readSource(SCREEN);
 
     expect(source).toContain('const recoverCapturedDraftForScopeExit = () => {');
-    expect(source).toContain('restoreRecoverableItemsToDraft(sessionId, [{');
+    expect(source).toContain('restoreRecoverableItemsToDraft(sessionId, [capturedDraftRecoveryItem()]);');
     expect(source).toContain('const hydratedDocumentAtSend = await hydrateComposerMessageReferenceBodies(');
     expect(source).toContain('if (!sendScopeStillAlive()) {\n      recoverCapturedDraftForScopeExit();');
     expect(source).toContain('await waitForPastePlaceholdersSettled();\n          if (!sendScopeStillAlive()) {');
@@ -366,10 +377,10 @@ describe('mobile optimistic composer while session is not ready', () => {
     const fnEnd = screen.indexOf('\n\n  // Context 面板', fnStart);
     expect(fnEnd).toBeGreaterThan(fnStart);
     const fn = screen.slice(fnStart, fnEnd);
-    expect(fn).toContain('if (sessionSettingsLocked) return false;');
+    expect(fn).toContain('if (!canUseRemoteSessionControls) return false;');
     // 锁进依赖,回调不会停留在「未锁」那一帧。
     expect(fn).toContain('outboxConnectionDispatchBlocked,');
-    expect(fn).toContain('sessionSettingsLocked,');
+    expect(fn).toContain('canUseRemoteSessionControls,');
   });
 
   it('binds sticky/locked derived state to the thing it belongs to', () => {
@@ -394,9 +405,9 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(source).toContain('return !row || row.pendingLocalCreation === true;');
     // 1) 渲染:按钮灰态。
     expect(source).toContain('const sessionSettingsLocked = isRemoteSessionMissing(currentSession);');
-    expect(source).toContain('disabled={!canUseComposer || controlBusy || sessionSettingsLocked}');
+    expect(source).toContain('disabled={controlBusy || !canUseRemoteSessionControls}');
     // 2) 会话设置 RPC 的硬门(统一入口,覆盖全部 runControlAction 调用点)。
-    expect(source).toContain('if (sessionSettingsLocked) return;\n    setControlBusy(true);');
+    expect(source).toContain('if (!canUseRemoteSessionControls) return;\n    setControlBusy(true);');
     // 3) 消息派发:复合判据,「不存在」是它的子集。
     expect(source).toContain('if (isRemoteSessionMissing(row)) return true;');
     expect(source).not.toContain('const sessionSettingsLocked = currentSession?.pendingLocalCreation === true;');

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -1,5 +1,5 @@
 /**
- * 会话参数未就绪(新建在途 / 缓存种入)时 composer 保持正常,发送走 outbox 排队。
+ * 会话参数未就绪或连接自动恢复中时 composer 保持正常,发送走 outbox 排队。
  *
  * 这两种状态原先经 buildSessionOperationLayout 的 readOnlyReason 进来,共享模型据此把
  * 整个输入框换成「只读模式」卡片——每次新建会话都必然经过几秒,观感是「刚发出消息就
@@ -8,7 +8,7 @@
  * sendAtMs 注释)。
  *
  * mobile 没有组件渲染测试设施(惯例见 chatQuoteCrossDevice.test.ts),这里做源码级接线
- * 断言:门在该在的位置、失败路径不放行、设置类 RPC 仍被挡。
+ * 断言:门在该在的位置、失败路径不放行,并且远程控制按 Desktop 的断线分层处理。
  */
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -21,20 +21,50 @@ function readSource(relativePath: string): string {
 const SCREEN = 'app/sessions/[sessionId].tsx';
 
 describe('mobile optimistic composer while session is not ready', () => {
-  it('keeps the composer out of the read-only slot and only gates queue rows', () => {
+  it('keeps the composer out of the read-only slot and only gates remote controls until the session exists', () => {
     const source = readSource(SCREEN);
 
     // composer 只认真正的协作只读理由。
     expect(source).toContain('      readOnlyReason: composerReadOnlyReason,\n');
     expect(source).not.toContain('readOnlyReason: cacheSeededReason');
-    // 队列行(取消 / 编辑 / 插队都是打到被控端队列的 RPC)仍然只读。
+    // 断线 / 弱网 / 熔断只锁 outbox 派发；确定性错误仍进共享布局锁 composer。
+    expect(source).toContain('remoteUnavailableReason: composerRemoteUnavailableReason,');
+    expect(source).toContain('describeRemoteComposerBlockingError(connectionError)');
+    // 会话尚未在被控端建成时,队列行(取消 / 编辑 / 插队)仍然只读。
     expect(source).toContain('const queueInlineReadOnlyReason = collaborationReadOnlyReason\n    ?? cacheSeededReason\n    ?? pendingCreationReason');
+  });
+
+  it('matches Desktop control behavior during a transient disconnect', () => {
+    const source = readSource(SCREEN);
+    const queueGateStart = source.indexOf('const queueInlineReadOnlyReason =');
+    const queueGateEnd = source.indexOf(';', queueGateStart);
+    const queueGate = source.slice(queueGateStart, queueGateEnd);
+    const stopStart = source.indexOf('const stopSession = () => {');
+    const stopEnd = source.indexOf('\n  };', stopStart);
+    const stop = source.slice(stopStart, stopEnd);
+
+    // 模型 / effort / fast / 权限 / plan 继续可点;RPC 失败走既有乐观回滚。
+    expect(source).toContain('const sessionSettingsLocked = isRemoteSessionMissing(currentSession);');
+    expect(source).not.toContain('const sessionSettingsLocked = isRemoteSessionMissing(currentSession)\n    ||');
+    // 设置与队列动作都不能在尝试 RPC 前清掉连接错误,否则消息 outbox 会被误放行。
+    expect((source.match(/if \(!outboxConnectionDispatchBlocked\) setError\(null\);/g) ?? []))
+      .toHaveLength(4);
+    // Desktop 断线时仍允许尝试队列编辑类动作,不把整行切成只读。
+    expect(queueGate).not.toContain('remoteUnavailableReason');
+    expect(queueGate).not.toContain('outboxConnectionDispatchBlocked');
+    // Stop 保持可见,但明确断线时不发送 RPC,只进入自动恢复提示。
+    expect(source).toContain("status !== 'online' || targetAvailableForDispatch === false");
+    expect(source).toContain('canStop: canUseRemoteSessionControls && canStopComposer,');
+    expect(stop).toContain('if (remoteStopUnavailable) {');
+    expect(stop).toContain("'[DEVICE_OFFLINE] target device unavailable'");
+    expect(stop).toContain("'[NOT_CONNECTED] relay reconnecting'");
   });
 
   it('blocks outbox dispatch until the session row can actually be sent with', () => {
     const source = readSource(SCREEN);
 
     expect(source).toContain('const outboxDispatchBlockedNow = () => {');
+    expect(source).toContain('if (outboxConnectionBlockedNow()) return true;');
     // 「会话在被控端还不存在」走共用判据(见下方的入口收敛测试);派发还额外要求字段
     // 权威(cacheSeeded 行被瘦身截断过)与创建管线已收口。
     expect(source).toContain('if (isRemoteSessionMissing(row)) return true;');
@@ -44,17 +74,55 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(source).toContain('if (outboxDispatchBlockedNow()) return;');
     // 解禁那一帧重新 pump。
     expect(source).toContain('const outboxDispatchBlocked = !currentSession');
+    expect(source).toContain('|| outboxConnectionDispatchBlocked;');
     expect(source).toContain('if (outboxDispatchBlocked) return;\n    void pumpOutbox();');
+    // 即使 blocked boolean 恰好没变化，新的连接 epoch 也要重新唤醒一次。
+    expect(source).toContain('}, [connectionEpoch, outboxDispatchBlocked]);');
   });
 
   it('routes sends through the outbox while blocked and defers the workingDir check', () => {
     const source = readSource(SCREEN);
 
     expect(source).toContain('const dispatchBlockedAtSend = outboxDispatchBlockedNow();');
+    expect(source).toContain('sessionRefsAtSend.length > 0 || uploadsInFlight > 0');
     expect(source).toContain('|| dispatchBlockedAtSend)) {');
     // dialogue 会话的 workingDir 由被控端在创建时分配,合成行此刻为空 —— 校验推迟到
     // dispatch(那时会重读 store 拿权威值),否则新建对话发消息会被误判成缺工作目录。
     expect(source).toContain('if (!dispatchBlockedAtSend && !currentSession.workingDir) {');
+  });
+
+  it('defers disconnect races instead of turning them into failed or falsely delivered messages', () => {
+    const source = readSource(SCREEN);
+
+    expect(source).toContain('const waitForConnection = (error: unknown) => {');
+    expect(source).toContain('outboxItemWaitingForConnection(item)');
+    expect(source).toContain("if (result === 'deferred' || result === 'stopped') return;");
+    expect(source).toContain("return 'stopped' as const;");
+    expect(source).toContain('isSafelyUnsentOutboxEnqueueError(err)');
+    expect((source.match(/按「无法证明已送达」处理。\n\s+return false;/g) ?? [])).toHaveLength(2);
+    expect(source).not.toContain('const authorityAdvanced = remoteSessionStore.captureInputProjectionAuthorityEpoch(');
+    expect(source).toContain('isAutoRecoveringSessionReferencePreparationError(err)');
+    expect(source).toContain('const recoverableItem = buildOutboxItem({');
+    expect(source).toContain('if (outboxSessionAliveRef.current !== sessionId) {');
+    expect(source).toContain('salvageOutboxItem(recoverableItem);\n            return;');
+    expect(source).toContain('setError(formatRemoteError(err));');
+    // enqueue 对账是否已送达只能看刚拉回的权威 projection。即使 store 写入被较新的
+    // turn boundary 拒绝，也不能退回本地乐观 pendingQueue 自证成功。
+    expect((source.match(/return fresh\.pendingQueue\.some/g) ?? [])).toHaveLength(2);
+    expect(source).not.toContain('const current = accepted ? fresh : remoteSessionStore.getInputProjection');
+    expect(source).not.toContain('const accepted = remoteSessionStore.setInputProjectionIfCurrent');
+  });
+
+  it('fences every pre-outbox await against an in-place session switch', () => {
+    const source = readSource(SCREEN);
+
+    expect(source).toContain('const recoverCapturedDraftForScopeExit = () => {');
+    expect(source).toContain('restoreRecoverableItemsToDraft(sessionId, [{');
+    expect(source).toContain('const hydratedDocumentAtSend = await hydrateComposerMessageReferenceBodies(');
+    expect(source).toContain('if (!sendScopeStillAlive()) {\n      recoverCapturedDraftForScopeExit();');
+    expect(source).toContain('await waitForPastePlaceholdersSettled();\n          if (!sendScopeStillAlive()) {');
+    expect(source).toContain('const { failedCount } = await waitForPendingUploads();\n      if (!sendScopeStillAlive()) {');
+    expect(source).toContain('if (outboxSessionAliveRef.current !== item.sessionId) return \'stopped\' as const;');
   });
 
   it('recovers the first message and the follow-ups together, in order', () => {
@@ -185,12 +253,13 @@ describe('mobile optimistic composer while session is not ready', () => {
     const screen = readSource(SCREEN);
     const fnStart = screen.indexOf('const writeSessionAgentSwitchIntent = useCallback(async (');
     expect(fnStart).toBeGreaterThan(-1);
-    const fnEnd = screen.indexOf('  }, [controlBusy, deviceId, maker, sessionId', fnStart);
+    const fnEnd = screen.indexOf('\n\n  // Context 面板', fnStart);
     expect(fnEnd).toBeGreaterThan(fnStart);
     const fn = screen.slice(fnStart, fnEnd);
     expect(fn).toContain('if (sessionSettingsLocked) return false;');
     // 锁进依赖,回调不会停留在「未锁」那一帧。
-    expect(screen).toContain('}, [controlBusy, deviceId, maker, sessionId, sessionSettingsLocked]);');
+    expect(fn).toContain('outboxConnectionDispatchBlocked,');
+    expect(fn).toContain('sessionSettingsLocked,');
   });
 
   it('binds sticky/locked derived state to the thing it belongs to', () => {

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -154,7 +154,7 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(guard).toContain("runtimeOptions?.planModeSupported !== true");
     expect(guard).toContain('const useLocalOutbox = shouldUseLocalOutbox && !legacyPlanRequiresLiveDispatch;');
     expect(guard).toContain('dispatchBlockedAtSend || outboxRef.current.length > 0 || outboxPumpBusyRef.current');
-    expect(guard).toContain("setError(t('session.menu.aiRenameOffline'));");
+    expect(guard).not.toContain("setError(t('session.menu.aiRenameOffline'));");
     expect(source).toContain(
       'const recovery = recoverOutboxItemsToComposerDraft([capturedDraftRecoveryItem()], {',
     );

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -49,7 +49,16 @@ describe('mobile optimistic composer while session is not ready', () => {
     // UI error 可独立清理；transport hold 只在权威 sync 成功后解除，不再借共享 error
     // 充当 outbox 门禁。
     expect(source).toContain('const [outboxTransportHold, setOutboxTransportHold] = useState<');
-    expect(source).toContain('const activeOutboxTransportError = screenAutoRecoveringError ?? heldOutboxTransportError;');
+    expect(source).toContain(
+      'const activeOutboxTransportError = connectionError === null\n'
+      + '    ? heldOutboxTransportError\n'
+      + '    : screenAutoRecoveringError;',
+    );
+    expect(source).toContain('if (!deviceId || !connectionError) return;');
+    expect(source).toContain('if (!screenAutoRecoveringError) {');
+    expect(source).toContain(
+      'setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);',
+    );
     expect(source).toContain('autoRecoveringError: activeOutboxTransportError !== null,');
     expect(source).toContain('setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);');
     expect(source).not.toContain('autoRecoveringError: isAutoRecoveringRemoteError(connectionError),');
@@ -114,10 +123,48 @@ describe('mobile optimistic composer while session is not ready', () => {
 
     expect(source).toContain('const dispatchBlockedAtSend = outboxDispatchBlockedNow();');
     expect(source).toContain('sessionRefsAtSend.length > 0 || uploadsInFlight > 0');
-    expect(source).toContain('|| dispatchBlockedAtSend)) {');
+    expect(source).toContain('|| outboxPumpBusyRef.current || dispatchBlockedAtSend');
     // dialogue 会话的 workingDir 由被控端在创建时分配,合成行此刻为空 —— 校验推迟到
     // dispatch(那时会重读 store 拿权威值),否则新建对话发消息会被误判成缺工作目录。
     expect(source).toContain('if (!dispatchBlockedAtSend && !currentSession.workingDir) {');
+  });
+
+  it('restores legacy plan only after outbox enqueue acceptance and blocks FIFO while offline', () => {
+    const source = readSource(SCREEN);
+    const dispatchStart = source.indexOf('const dispatchOutboxItem = async');
+    const prepareStart = source.indexOf('queued = await prepareMobileQueuedSessionReferences(', dispatchStart);
+    const rearmStart = source.indexOf("maker.setPermissionMode(item.sessionId, 'plan')", dispatchStart);
+    const enqueueStart = source.indexOf('projection = await maker.input.enqueue', dispatchStart);
+    const acceptedBarrierStart = source.indexOf('const acceptedBarrier: MobileOutboxItem = {', enqueueStart);
+    const acceptedRestoreStart = source.indexOf(
+      'await restoreLegacyPlanAfterEnqueue(acceptedBarrier)',
+      acceptedBarrierStart,
+    );
+
+    expect(source).toContain(
+      'legacyPlanRestore,\n          legacyPlanArmEpochAtSend,\n          readyAttachments,',
+    );
+    expect(source).toContain('legacyPlanArmEpochAtSend,');
+    expect(prepareStart).toBeGreaterThan(dispatchStart);
+    expect(rearmStart).toBeGreaterThan(prepareStart);
+    expect(enqueueStart).toBeGreaterThan(rearmStart);
+    expect(acceptedBarrierStart).toBeGreaterThan(enqueueStart);
+    expect(acceptedRestoreStart).toBeGreaterThan(enqueueStart);
+    expect(source).toContain('if (item.restoreOnly) return restoreLegacyPlanAfterEnqueue(item);');
+    expect(source).toContain('restoreOnly: true,');
+    expect(source).toContain('outboxItems.filter((item) => !item.restoreOnly)');
+    expect(source).toContain('const unsentItems = items.filter((item) => !item.restoreOnly);');
+    expect(source).not.toContain("from '@/session/legacyPlanRecovery'");
+
+    const optimisticOutboxStart = source.indexOf('const legacyPlanRestore = legacyPlanRestoreAtDecision;');
+    const optimisticOutboxBuild = source.indexOf('updateOutbox((items) => [...items, buildOutboxItem({', optimisticOutboxStart);
+    const optimisticOutboxSetup = source.slice(optimisticOutboxStart, optimisticOutboxBuild);
+    expect(optimisticOutboxSetup).toContain('consumeLegacyPlanLocally(legacyPlanRestore);');
+    expect(optimisticOutboxSetup).not.toContain('maker.setPermissionMode');
+    expect(source).toContain("const legacyPlanRestoreAtDecision = permissionModeAtDecision === 'plan'");
+    expect(source).toContain('|| legacyPlanRestoreAtDecision !== null)) {');
+    expect(source).toContain('legacyPlanArmEpochBySessionRef.current.set(');
+    expect(source).toContain('items.some((entry) => entry.clientId === acceptedBarrier.clientId)');
   });
 
   it('defers disconnect races instead of turning them into failed or falsely delivered messages', () => {
@@ -126,8 +173,9 @@ describe('mobile optimistic composer while session is not ready', () => {
     const recoveryHelperEnd = source.indexOf('\n}', recoveryHelperStart);
     const recoveryHelper = source.slice(recoveryHelperStart, recoveryHelperEnd);
 
-    expect(source).toContain('const waitForConnection = (error: unknown) => {');
-    expect(source).toContain('outboxItemWaitingForConnection(item)');
+    expect(source).toContain('const waitForConnection = (');
+    expect(source).toContain('waitingItem: MobileOutboxItem = item,');
+    expect(source).toContain('outboxItemWaitingForConnection(waitingItem)');
     expect(source).toContain("if (result === 'deferred' || result === 'stopped') return;");
     expect(source).toContain("return 'stopped' as const;");
     expect(source).toContain('isSafelyUnsentOutboxEnqueueError(err)');

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -160,9 +160,7 @@ describe('mobile optimistic composer while session is not ready', () => {
     );
     expect(source).toContain('applyComposerDocument(recovery.document);');
     expect((source.match(/restoreDirectSendDraftAfterFailure\(\)/g) ?? [])).toHaveLength(4);
-    expect(source).toContain(
-      'if (shouldWaitForOutboxEnqueueRecovery(err) && !legacyPlanRequiresLiveDispatch) {',
-    );
+    expect(source).not.toContain('shouldWaitForOutboxEnqueueRecovery');
     expect(source).toContain('maker.setPlanMode(sessionId, next)');
     expect(source).not.toContain('restoreOnly');
     expect(source).not.toContain('legacyPlanRecovery');
@@ -179,35 +177,40 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(source).toContain("setError(t('session.menu.aiRenameOffline'));");
   });
 
-  it('defers disconnect races instead of turning them into failed or falsely delivered messages', () => {
+  it('keeps the page outbox on the pre-write side of the enqueue ownership boundary', () => {
     const source = readSource(SCREEN);
-    const recoveryHelperStart = source.indexOf('function shouldWaitForOutboxEnqueueRecovery');
-    const recoveryHelperEnd = source.indexOf('\n}', recoveryHelperStart);
-    const recoveryHelper = source.slice(recoveryHelperStart, recoveryHelperEnd);
+    const outboxStart = source.indexOf('const dispatchOutboxItem = async (item: MobileOutboxItem) => {');
+    const directStart = source.indexOf('const queuedDraft = buildQueuedTextMessage(');
+    const directEnd = source.indexOf('// applied:消息已在桌面队列', directStart);
+    const outboxDispatch = source.slice(outboxStart, directStart);
+    const directRecovery = source.slice(directStart, directEnd);
+    const unknownStart = outboxDispatch.indexOf('if (acceptanceUnknown) {');
+    const unknownEnd = outboxDispatch.indexOf('const applied = await', unknownStart);
+    const acceptanceUnknownRecovery = outboxDispatch.slice(unknownStart, unknownEnd);
 
     expect(source).toContain('const waitForConnection = (');
     expect(source).toContain('const waiting = outboxItemWaitingForConnection(item);');
     expect(source).toContain("if (result === 'deferred' || result === 'stopped') return;");
     expect(source).toContain("return 'stopped' as const;");
-    expect(source).toContain('isSafelyUnsentOutboxEnqueueError(err)');
-    expect(recoveryHelper).toContain('isSafelyUnsentOutboxEnqueueError(err)');
-    expect(recoveryHelper).toContain('isAutoRecoveringRemoteError(err)');
-    // direct 与 outbox-originated enqueue 都必须用同一判据，把回执不确定项保留在
-    // 原 clientId 上自动重试；不能一条自动等、另一条退回草稿生成新 id。
-    expect((source.match(/shouldWaitForOutboxEnqueueRecovery\(err\)/g) ?? []))
-      .toHaveLength(2);
-    expect((source.match(/按「无法证明已送达」处理。\n\s+return false;/g) ?? [])).toHaveLength(2);
-    expect(source).not.toContain('const authorityAdvanced = remoteSessionStore.captureInputProjectionAuthorityEpoch(');
+    expect(source).toContain('const safeToRetry = isSafelyUnsentOutboxEnqueueError(err);');
+    expect(source).toContain(
+      'const acceptanceUnknown = !safeToRetry && isAutoRecoveringRemoteError(err);',
+    );
+    expect(source).toContain('if (safeToRetry) {\n          waitForConnection(err);');
+    // 回执不确定时只保留原 optimistic projection，不能把已开始写的消息重新交给
+    // page-local outbox / 草稿；后者离场时没有跨页 clientId owner。
+    expect(acceptanceUnknownRecovery).toContain('fresh.pendingQueue.some(');
+    expect(acceptanceUnknownRecovery).toContain('setError(formatRemoteError(err));');
+    expect(acceptanceUnknownRecovery).not.toContain('failItem(');
+    expect(acceptanceUnknownRecovery).not.toContain('waitForConnection(');
+    expect(acceptanceUnknownRecovery).not.toContain('salvageOutboxItem(');
+    expect(outboxDispatch).toContain('return fresh.pendingQueue.some(');
+    expect(source).not.toContain('shouldWaitForOutboxEnqueueRecovery');
     expect(source).toContain('isAutoRecoveringSessionReferencePreparationError(err)');
-    expect(source).toContain('const recoverableItem = buildOutboxItem({');
-    expect(source).toContain('if (outboxSessionAliveRef.current !== sessionId) {');
-    expect(source).toContain('salvageOutboxItem(recoverableItem);\n            return;');
-    expect(source).toContain('setError(formatRemoteError(err));');
-    // enqueue 对账是否已送达只能看刚拉回的权威 projection。即使 store 写入被较新的
-    // turn boundary 拒绝，也不能退回本地乐观 pendingQueue 自证成功。
-    expect((source.match(/return fresh\.pendingQueue\.some/g) ?? [])).toHaveLength(2);
-    expect(source).not.toContain('const current = accepted ? fresh : remoteSessionStore.getInputProjection');
-    expect(source).not.toContain('const accepted = remoteSessionStore.setInputProjectionIfCurrent');
+    expect(directRecovery).not.toContain('buildOutboxItem({');
+    expect(directRecovery).not.toContain('salvageOutboxItem(');
+    expect(directRecovery).not.toContain('updateOutbox(');
+    expect(directRecovery).toContain('在线直发一旦开始 enqueue 就不再转入本 PR 的页面 outbox');
   });
 
   it('keeps retrying authoritative recovery syncs with bounded backoff', () => {

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -66,8 +66,27 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(dispatchPresence).not.toContain('targetAvailableRef');
     expect(source).toContain('canStop: canUseRemoteSessionControls && canStopComposer,');
     expect(stop).toContain('if (remoteStopUnavailable) {');
-    expect(stop).toContain("'[DEVICE_OFFLINE] target device unavailable'");
-    expect(stop).toContain("'[NOT_CONNECTED] relay reconnecting'");
+    expect(stop).toContain("'[DEVICE_OFFLINE]'");
+    expect(stop).toContain("'[NOT_CONNECTED]'");
+    expect(stop).not.toContain('target device unavailable');
+    expect(stop).not.toContain('relay reconnecting');
+  });
+
+  it('publishes every transport-side presence availability transition to context consumers', () => {
+    const source = readSource('src/device-link/DeviceLinkContext.tsx');
+    const helperStart = source.indexOf('const publishPresenceAvailabilityMutation =');
+    const helperEnd = source.indexOf('\n\n  const sendOpenLinkOnce', helperStart);
+    const helper = source.slice(helperStart, helperEnd);
+
+    expect(helper).toContain('const before = availabilityByDevice.get(deviceId) ?? null;');
+    expect(helper).toContain('const after = availabilityByDevice.get(deviceId) ?? null;');
+    expect(helper).toContain('if (before !== after) setPresenceVersion((version) => version + 1);');
+    expect(source).not.toContain('presenceAvailableByDeviceRef.current.set');
+    expect((source.match(
+      /publishPresenceAvailabilityMutation\(deviceId, \(availabilityByDevice\) =>/g,
+    ) ?? [])).toHaveLength(5);
+    expect(source).toContain('setConnectionEpoch((n) => n + 1);');
+    expect(source).toContain('setPresenceVersion((n) => n + 1);\n      const presence = updatePresenceAvailability(');
   });
 
   it('blocks outbox dispatch until the session row can actually be sent with', () => {

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -46,14 +46,24 @@ describe('mobile optimistic composer while session is not ready', () => {
     // 模型 / effort / fast / 权限 / plan 继续可点;RPC 失败走既有乐观回滚。
     expect(source).toContain('const sessionSettingsLocked = isRemoteSessionMissing(currentSession);');
     expect(source).not.toContain('const sessionSettingsLocked = isRemoteSessionMissing(currentSession)\n    ||');
-    // 设置与队列动作都不能在尝试 RPC 前清掉连接错误,否则消息 outbox 会被误放行。
-    expect((source.match(/if \(!outboxConnectionDispatchBlocked\) setError\(null\);/g) ?? []))
-      .toHaveLength(4);
+    // UI error 可独立清理；transport hold 只在权威 sync 成功后解除，不再借共享 error
+    // 充当 outbox 门禁。
+    expect(source).toContain('const [outboxTransportHold, setOutboxTransportHold] = useState<');
+    expect(source).toContain('const activeOutboxTransportError = screenAutoRecoveringError ?? heldOutboxTransportError;');
+    expect(source).toContain('autoRecoveringError: activeOutboxTransportError !== null,');
+    expect(source).toContain('setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);');
+    expect(source).not.toContain('autoRecoveringError: isAutoRecoveringRemoteError(connectionError),');
     // Desktop 断线时仍允许尝试队列编辑类动作,不把整行切成只读。
     expect(queueGate).not.toContain('remoteUnavailableReason');
     expect(queueGate).not.toContain('outboxConnectionDispatchBlocked');
     // Stop 保持可见,但明确断线时不发送 RPC,只进入自动恢复提示。
     expect(source).toContain("status !== 'online' || targetAvailableForDispatch === false");
+    const dispatchPresenceStart = source.indexOf('const targetAvailableForDispatch =');
+    const dispatchPresenceEnd = source.indexOf(';', dispatchPresenceStart);
+    const dispatchPresence = source.slice(dispatchPresenceStart, dispatchPresenceEnd);
+    expect(dispatchPresence).toContain('getPresenceAvailability(deviceId)');
+    expect(dispatchPresence).not.toContain('lastPresenceSnapshot');
+    expect(dispatchPresence).not.toContain('targetAvailableRef');
     expect(source).toContain('canStop: canUseRemoteSessionControls && canStopComposer,');
     expect(stop).toContain('if (remoteStopUnavailable) {');
     expect(stop).toContain("'[DEVICE_OFFLINE] target device unavailable'");

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -122,12 +122,21 @@ describe('mobile optimistic composer while session is not ready', () => {
 
   it('defers disconnect races instead of turning them into failed or falsely delivered messages', () => {
     const source = readSource(SCREEN);
+    const recoveryHelperStart = source.indexOf('function shouldWaitForOutboxEnqueueRecovery');
+    const recoveryHelperEnd = source.indexOf('\n}', recoveryHelperStart);
+    const recoveryHelper = source.slice(recoveryHelperStart, recoveryHelperEnd);
 
     expect(source).toContain('const waitForConnection = (error: unknown) => {');
     expect(source).toContain('outboxItemWaitingForConnection(item)');
     expect(source).toContain("if (result === 'deferred' || result === 'stopped') return;");
     expect(source).toContain("return 'stopped' as const;");
     expect(source).toContain('isSafelyUnsentOutboxEnqueueError(err)');
+    expect(recoveryHelper).toContain('isSafelyUnsentOutboxEnqueueError(err)');
+    expect(recoveryHelper).toContain('isAutoRecoveringRemoteError(err)');
+    // direct 与 outbox-originated enqueue 都必须用同一判据，把回执不确定项保留在
+    // 原 clientId 上自动重试；不能一条自动等、另一条退回草稿生成新 id。
+    expect((source.match(/if \(shouldWaitForOutboxEnqueueRecovery\(err\)\)/g) ?? []))
+      .toHaveLength(2);
     expect((source.match(/按「无法证明已送达」处理。\n\s+return false;/g) ?? [])).toHaveLength(2);
     expect(source).not.toContain('const authorityAdvanced = remoteSessionStore.captureInputProjectionAuthorityEpoch(');
     expect(source).toContain('isAutoRecoveringSessionReferencePreparationError(err)');
@@ -140,6 +149,30 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect((source.match(/return fresh\.pendingQueue\.some/g) ?? [])).toHaveLength(2);
     expect(source).not.toContain('const current = accepted ? fresh : remoteSessionStore.getInputProjection');
     expect(source).not.toContain('const accepted = remoteSessionStore.setInputProjectionIfCurrent');
+  });
+
+  it('keeps retrying authoritative recovery syncs with bounded backoff', () => {
+    const source = readSource(SCREEN);
+    const retryStart = source.indexOf('const shouldAutoRetryConnectionSync =');
+    const retryEnd = source.indexOf('\n\n  // 监听 error-persisted', retryStart);
+    const retry = source.slice(retryStart, retryEnd);
+    const syncCatchStart = source.indexOf('    } catch (err) {', source.indexOf('const syncSession ='));
+    const syncCatchEnd = source.indexOf('    } finally {', syncCatchStart);
+    const syncCatch = source.slice(syncCatchStart, syncCatchEnd);
+
+    expect(source).toContain("useRef<{ identity: string; attempt: number } | null>(null)");
+    expect(retry).toContain('isAutoRecoveringRemoteError(connectionRecoveryError)');
+    expect(retry).toContain('const retryIdentity = `${deviceId}:${sessionId}:${connectionEpoch}`;');
+    expect(retry).not.toContain('${connectionRecoveryError}');
+    expect(retry).toContain('attempt: retryState.attempt + 1,');
+    expect(retry).toContain('connectionRecoverySyncRetryDelayMs(retryState.attempt)');
+    expect(retry).toContain('return () => clearTimeout(timer);');
+    expect(retry).toContain('targetAvailableForDispatch === false');
+    expect(retry).toContain('|| isDeviceUnresponsive');
+    expect(syncCatch).toContain('if (!isAutoRecoveringRemoteError(err)) {');
+    expect(syncCatch).toContain('return current?.deviceId === deviceId ? null : current;');
+    expect(syncCatch).toContain(': { deviceId, error: formatted };');
+    expect(source).toContain('error={connectionRecoveryError}');
   });
 
   it('fences every pre-outbox await against an in-place session switch', () => {

--- a/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
+++ b/apps/mobile/src/__tests__/optimisticSessionComposer.test.ts
@@ -58,12 +58,10 @@ describe('mobile optimistic composer while session is not ready', () => {
       + '    ? heldOutboxTransportError\n'
       + '    : screenAutoRecoveringError;',
     );
-    expect(source).toContain('if (!deviceId || !connectionError) return;');
-    expect(source).toContain('if (!screenAutoRecoveringError) {');
-    expect(source).toContain(
-      'setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);',
-    );
-    expect(source).toContain('autoRecoveringError: activeOutboxTransportError !== null,');
+    expect(source).toContain('error: string | null;');
+    expect(source).toContain('const latchOutboxTransportHold = useCallback(');
+    expect(source).toContain('const outboxRecoverySyncHeld = hasLatchedOutboxTransportHold');
+    expect(source).toContain('autoRecoveringError: outboxRecoverySyncHeld,');
     expect(source).toContain('setOutboxTransportHold((current) => current?.deviceId === deviceId ? null : current);');
     expect(source).not.toContain('autoRecoveringError: isAutoRecoveringRemoteError(connectionError),');
     // Desktop 断线时仍允许尝试队列编辑类动作,不把整行切成只读。
@@ -129,6 +127,55 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(source).toContain('if (outboxDispatchBlocked) return;\n    void pumpOutbox();');
     // 即使 blocked boolean 恰好没变化，新的连接 epoch 也要重新唤醒一次。
     expect(source).toContain('}, [connectionEpoch, outboxDispatchBlocked]);');
+  });
+
+  it('latches every connection recovery edge until authoritative sync succeeds', () => {
+    const source = readSource(SCREEN);
+    const latchStart = source.indexOf('// 连接阻塞一旦出现就锁存。');
+    const latch = source.slice(latchStart, source.indexOf('// 对齐 Desktop', latchStart));
+    const syncStart = source.indexOf('const syncSession = useCallback(async');
+    const syncCatchStart = source.indexOf('    } catch (err) {', syncStart);
+    const syncCatchEnd = source.indexOf('    } finally {', syncCatchStart);
+    const syncCatch = source.slice(syncCatchStart, syncCatchEnd);
+    const epochEffectStart = source.indexOf("if (status !== 'online') return;", syncCatchEnd);
+    const epochEffect = source.slice(epochEffectStart, source.indexOf('\n  },', epochEffectStart));
+    const presenceEffectStart = source.indexOf(
+      'const sameDevice = targetAvailableDeviceRef.current === deviceId',
+      epochEffectStart,
+    );
+    const presenceEffect = source.slice(
+      presenceEffectStart,
+      source.indexOf('\n  },', presenceEffectStart),
+    );
+    const syncIdentityStart = source.indexOf('const remoteSyncContextKey = JSON.stringify([');
+    const syncIdentity = source.slice(syncIdentityStart, source.indexOf(']);', syncIdentityStart));
+
+    expect(latch).toContain('useLayoutEffect(() => {');
+    expect(latch).toContain("status !== 'online'");
+    expect(latch).toContain('targetAvailableForDispatch === false');
+    expect(latch).toContain('|| isDeviceUnresponsive');
+    expect(latch).toContain('|| screenAutoRecoveringError !== null');
+    expect(latch).toContain('latchOutboxTransportHold(screenAutoRecoveringError);');
+    expect(latch).toContain('syncedConnectionEpochRef.current !== connectionEpoch');
+    expect(latch).toContain('targetAvailableRef.current !== true');
+    expect(syncIdentity).toMatch(
+      /deviceId[\s\S]*sessionId[\s\S]*connectionEpoch[\s\S]*status[\s\S]*targetAvailableForDispatch[\s\S]*isDeviceUnresponsive/,
+    );
+    expect(source).toContain('(run) => syncSession(run),\n    remoteSyncContextKey,');
+    expect(epochEffect.indexOf('latchOutboxTransportHold(null);'))
+      .toBeLessThan(epochEffect.indexOf('void load();'));
+    expect(presenceEffect.indexOf('latchOutboxTransportHold(null);'))
+      .toBeLessThan(presenceEffect.indexOf('void load();'));
+    expect(presenceEffect).toContain('wasAvailable !== true');
+    expect(presenceEffect).toContain('if (sameDevice) void load();');
+    expect(source).not.toContain('lastPresenceSnapshot');
+    expect((source.match(
+      /setOutboxTransportHold\(\(current\) => current\?\.deviceId === deviceId \? null : current\);/g,
+    ) ?? [])).toHaveLength(1);
+    expect(syncCatch).toContain('latchOutboxTransportHold(formatted);');
+    expect(syncCatch).not.toContain('if (isAutoRecoveringRemoteError(err))');
+    expect(syncCatch).not.toContain('setOutboxTransportHold(');
+    expect(syncCatch).not.toContain('? null : current');
   });
 
   it('routes sends through the outbox while blocked and defers the workingDir check', () => {
@@ -231,9 +278,8 @@ describe('mobile optimistic composer while session is not ready', () => {
     expect(retry).toContain('return () => clearTimeout(timer);');
     expect(retry).toContain('targetAvailableForDispatch === false');
     expect(retry).toContain('|| isDeviceUnresponsive');
-    expect(syncCatch).toContain('if (!isAutoRecoveringRemoteError(err)) {');
-    expect(syncCatch).toContain('return current?.deviceId === deviceId ? null : current;');
-    expect(syncCatch).toContain(': { deviceId, error: formatted };');
+    expect(syncCatch).toContain('latchOutboxTransportHold(formatted);');
+    expect(syncCatch).not.toContain('? null : current');
     expect(source).toContain('error={connectionRecoveryError}');
   });
 

--- a/apps/mobile/src/__tests__/remoteStatus.test.ts
+++ b/apps/mobile/src/__tests__/remoteStatus.test.ts
@@ -6,6 +6,7 @@ import {
   describeRemoteComposerBlockingError,
   describeRemoteError,
   formatRemoteError,
+  humanizeRemoteError,
   isAutoRecoveringRemoteError,
   relayStatusHint,
   relayStatusLabel,
@@ -28,7 +29,7 @@ describe('remoteStatus', () => {
     expect(describeRemoteError('[REMOTE_DISABLED] disabled')).toContain('关闭允许远程控制');
     expect(describeRemoteError("[CHANNEL_NOT_ALLOWED] channel 'x'")).toContain('版本不支持');
     expect(describeRemoteError('[ACCESS_REVOKED] revoked')).toContain('撤销手机访问权限');
-    expect(describeRemoteError('[NOT_CONNECTED] offline')).toContain('稍后重新同步');
+    expect(describeRemoteError('[NOT_CONNECTED] offline')).toBe(i18n.t('session.screen.networkReconnecting'));
     expect(describeRemoteError('unknown failure')).toBe('unknown failure');
   });
 
@@ -46,6 +47,7 @@ describe('remoteStatus', () => {
   it('keeps the composer writable for automatic recovery, but blocks deterministic failures', () => {
     for (const error of [
       '[NOT_CONNECTED] offline',
+      '[DEVICE_OFFLINE] target unavailable',
       '[LINK_NOT_OPEN] reopening',
       '[INVOKE_TIMEOUT] timed out',
       '[DEVICE_UNRESPONSIVE] circuit open',
@@ -62,6 +64,25 @@ describe('remoteStatus', () => {
     expect(describeRemoteComposerBlockingError("[CHANNEL_NOT_ALLOWED] channel 'x'"))
       .toContain('版本不支持');
     expect(describeRemoteComposerBlockingError(null)).toBeNull();
+  });
+
+  it('localizes Stop connection recovery errors without dropping their structured classification', async () => {
+    const previousLanguage = i18n.language;
+    try {
+      for (const locale of ['en', 'ja', 'ko', 'zh-TW'] as const) {
+        await i18n.changeLanguage(locale);
+        expect(describeRemoteError('[DEVICE_OFFLINE]')).toBe(i18n.t('session.menu.aiRenameOffline'));
+        expect(describeRemoteError('[NOT_CONNECTED]')).toBe(i18n.t('session.screen.networkReconnecting'));
+        expect(humanizeRemoteError(
+          Object.assign(new Error('target unavailable'), { code: 'DEVICE_OFFLINE' }),
+        )).toBe(i18n.t('session.menu.aiRenameOffline'));
+        expect(humanizeRemoteError(
+          Object.assign(new Error('relay reconnecting'), { code: 'NOT_CONNECTED' }),
+        )).toBe(i18n.t('session.screen.networkReconnecting'));
+      }
+    } finally {
+      await i18n.changeLanguage(previousLanguage);
+    }
   });
 
   it('localizes every connection issue kind', async () => {

--- a/apps/mobile/src/__tests__/remoteStatus.test.ts
+++ b/apps/mobile/src/__tests__/remoteStatus.test.ts
@@ -3,8 +3,10 @@ import { DeviceLinkError } from '@cindy/device-link';
 import {
   connectionIssueHint,
   connectionIssueTitle,
+  describeRemoteComposerBlockingError,
   describeRemoteError,
   formatRemoteError,
+  isAutoRecoveringRemoteError,
   relayStatusHint,
   relayStatusLabel,
 } from '@/device-link/remoteStatus';
@@ -39,6 +41,27 @@ describe('remoteStatus', () => {
       '[REMOTE_DISABLED] remote disabled',
     );
     expect(formatRemoteError(new Error('[NOT_CONNECTED] offline'))).toBe('[NOT_CONNECTED] offline');
+  });
+
+  it('keeps the composer writable for automatic recovery, but blocks deterministic failures', () => {
+    for (const error of [
+      '[NOT_CONNECTED] offline',
+      '[LINK_NOT_OPEN] reopening',
+      '[INVOKE_TIMEOUT] timed out',
+      '[DEVICE_UNRESPONSIVE] circuit open',
+      '[SESSION_REFERENCE_OFFLINE] target unavailable',
+    ]) {
+      expect(isAutoRecoveringRemoteError(error), error).toBe(true);
+      expect(describeRemoteComposerBlockingError(error), error).toBeNull();
+    }
+
+    expect(describeRemoteComposerBlockingError('[ACCESS_REVOKED] revoked'))
+      .toContain('撤销手机访问权限');
+    expect(describeRemoteComposerBlockingError('[REMOTE_DISABLED] disabled'))
+      .toContain('关闭允许远程控制');
+    expect(describeRemoteComposerBlockingError("[CHANNEL_NOT_ALLOWED] channel 'x'"))
+      .toContain('版本不支持');
+    expect(describeRemoteComposerBlockingError(null)).toBeNull();
   });
 
   it('localizes every connection issue kind', async () => {

--- a/apps/mobile/src/__tests__/remoteStatus.test.ts
+++ b/apps/mobile/src/__tests__/remoteStatus.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { DeviceLinkError } from '@cindy/device-link';
 import {
+  connectionRecoverySyncRetryDelayMs,
   connectionIssueHint,
   connectionIssueTitle,
   describeRemoteComposerBlockingError,
@@ -14,6 +15,12 @@ import {
 import { i18n } from '@/i18n';
 
 describe('remoteStatus', () => {
+  it('backs repeated connection recovery syncs off and caps the delay', () => {
+    expect([0, 1, 2, 3, 4, 5, 6].map(connectionRecoverySyncRetryDelayMs))
+      .toEqual([900, 1_800, 3_600, 7_200, 14_400, 28_800, 30_000]);
+    expect(connectionRecoverySyncRetryDelayMs(20)).toBe(30_000);
+  });
+
   it('labels relay status', () => {
     expect(relayStatusLabel('online')).toBe('Relay 已连接');
     expect(relayStatusLabel('connecting')).toBe('正在连接 Relay');
@@ -52,10 +59,15 @@ describe('remoteStatus', () => {
       '[INVOKE_TIMEOUT] timed out',
       '[DEVICE_UNRESPONSIVE] circuit open',
       '[SESSION_REFERENCE_OFFLINE] target unavailable',
+      '[REMOTE_OPTIMISTIC_SESSION_STATE_UNAVAILABLE] dedupe state unavailable',
     ]) {
       expect(isAutoRecoveringRemoteError(error), error).toBe(true);
       expect(describeRemoteComposerBlockingError(error), error).toBeNull();
     }
+
+    const deliveryUnknown = new DeviceLinkError('NOT_CONNECTED', 'ack may be lost');
+    deliveryUnknown.inFlight = true;
+    expect(isAutoRecoveringRemoteError(deliveryUnknown)).toBe(true);
 
     expect(describeRemoteComposerBlockingError('[ACCESS_REVOKED] revoked'))
       .toContain('撤销手机访问权限');

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -323,7 +323,7 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('const currentTurnStreaming = useMemo(');
     expect(source).toContain('const canStopCurrentRun = (remoteSessionRunning || currentTurnStreaming)');
     expect(source).toContain('const canStopComposer = canStopQueue || canStopCurrentRun;');
-    expect(source).toContain('canStop: canUseComposer && canStopComposer,');
+    expect(source).toContain('canStop: canUseRemoteSessionControls && canStopComposer,');
     expect(source).not.toContain('canStop: canUseComposer && canStopQueue,');
     expect(source).toContain('const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);');
     expect(source).toContain('const composerVoicePlacement = voiceUiAvailable');
@@ -516,11 +516,11 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain(': hydrateQuotes(sessionId);');
     expect(source).toContain('quoteHydration,');
     expect(source).toContain('!composerDocumentsEqual(composerDocumentRef.current, immediateDocumentSnapshot)');
-    expect(source).toContain('if (canUseComposer) return;');
+    expect(source).toContain('if (canUseRemoteSessionControls) return;');
     expect(source).toContain('setModelSheetOpen(false);');
-    expect(source).toContain('if (!canUseComposer || !currentSession || !modelSheetSelection) return;');
-    expect(source).toContain('modelSheetOpen && canUseComposer');
-    expect(source).toContain('disabled={controlBusy || !canUseComposer}');
+    expect(source).toContain('if (!canUseRemoteSessionControls || !currentSession || !modelSheetSelection) return;');
+    expect(source).toContain('modelSheetOpen && canUseRemoteSessionControls');
+    expect(source).toContain('disabled={controlBusy || !canUseRemoteSessionControls}');
     expect(source).toContain('createMobileCindyVoiceCredential');
     // Voice startup claims the pressIn-prewarmed ASR connection when one is
     // fresh (credential already resolved, WebSocket already connecting) and

--- a/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerDesktopFirst.test.ts
@@ -323,7 +323,10 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('const currentTurnStreaming = useMemo(');
     expect(source).toContain('const canStopCurrentRun = (remoteSessionRunning || currentTurnStreaming)');
     expect(source).toContain('const canStopComposer = canStopQueue || canStopCurrentRun;');
-    expect(source).toContain('canStop: canUseRemoteSessionControls && canStopComposer,');
+    expect(source).toContain('canStop: canStopComposer,');
+    expect(source).toContain(
+      'const composerStopDisabled = composerLayout.stop.disabled || !canUseRemoteSessionControls;',
+    );
     expect(source).not.toContain('canStop: canUseComposer && canStopQueue,');
     expect(source).toContain('const voiceUiAvailable = shouldShowMobileVoiceUi(Platform.OS);');
     expect(source).toContain('const composerVoicePlacement = voiceUiAvailable');
@@ -566,8 +569,8 @@ describe('mobile session composer desktop-first surface', () => {
     expect(source).toContain('updateHistoryEntry: (entryId, text) => updateMobileVoiceInputHistoryEntryForHost(deviceId, entryId, text)');
     expect(source).not.toContain('styles.sendButtonStop');
     expect(source).not.toContain('sendButtonStop:');
-    expect(source).toContain('fill={composerLayout.stop.disabled ? colors.textSecondary : colors.ctaText}');
-    expect(source).toContain('color={composerLayout.stop.disabled ? colors.textSecondary : colors.ctaText}');
+    expect(source).toContain('fill={composerStopDisabled ? colors.textSecondary : colors.ctaText}');
+    expect(source).toContain('color={composerStopDisabled ? colors.textSecondary : colors.ctaText}');
     expect(source).toContain('pressedStyle={styles.sendButtonPressed}');
     expect(source).toContain('pressedStyle === undefined ? styles.routeButtonPressed : pressedStyle');
     expect(source).not.toContain('composerShowStatusRow');

--- a/apps/mobile/src/__tests__/sessionComposerLayout.test.ts
+++ b/apps/mobile/src/__tests__/sessionComposerLayout.test.ts
@@ -111,15 +111,15 @@ describe('sessionComposerLayout', () => {
     });
   });
 
-  it('keeps text editable while a restored draft cannot be sent offline', () => {
+  it('keeps text editable while a deterministic remote error blocks sending', () => {
     const layout = buildSessionComposerLayout({
       attachmentBusy: false,
       attachmentCount: 0,
       attachmentPickerOpen: false,
       canStop: false,
-      draftText: '等电脑恢复后发送',
+      draftText: '等待重新授权后发送',
       queueBusy: false,
-      sendUnavailableReason: '网络或被控端暂时不可用，可以稍后重新同步。',
+      sendUnavailableReason: '这台电脑已撤销手机访问权限。',
       sending: false,
       voiceState: 'idle',
     });
@@ -130,11 +130,11 @@ describe('sessionComposerLayout', () => {
     });
     expect(layout.send).toEqual({
       disabled: true,
-      disabledReason: '网络或被控端暂时不可用，可以稍后重新同步。',
+      disabledReason: '这台电脑已撤销手机访问权限。',
       label: '发送',
       visible: true,
     });
-    expect(layout.guidanceText).toBe('网络或被控端暂时不可用，可以稍后重新同步。');
+    expect(layout.guidanceText).toBe('这台电脑已撤销手机访问权限。');
   });
 
   it('summarizes attachment and voice tool state for the compact mobile composer', () => {

--- a/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionHeaderDesktopFirst.test.ts
@@ -212,7 +212,10 @@ describe('mobile session header desktop-first surface', () => {
     expect(hydration).toContain('if (cancelled || appliedRouteDraftRef.current !== key) return;');
     expect(hydration).toContain('if (!composerDocumentsEqual(composerDocumentRef.current, immediateDocumentSnapshot)) {');
     const queueCleanupStart = source.indexOf('// 切会话 / 卸载时收尾上一个会话的排队编辑态');
-    const queueCleanupEnd = source.indexOf('useEffect(() => {\n    if (canUseComposer)', queueCleanupStart);
+    const queueCleanupEnd = source.indexOf(
+      'useEffect(() => {\n    if (canUseRemoteSessionControls)',
+      queueCleanupStart,
+    );
     const queueCleanup = source.slice(queueCleanupStart, queueCleanupEnd);
     expect(queueCleanup).toContain('attachmentsRef.current = [];\n      setAttachments([]);');
     expect(queueCleanup).not.toContain('setAttachments([...editing.stashedAttachments])');

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -42,10 +42,10 @@ describe('mobile session main layer desktop-first noise budget', () => {
     const syncEnd = source.indexOf('function MessageHistoryToggle', syncStart);
     const syncSource = source.slice(syncStart, syncEnd);
 
-    // banner 渲染条件(useShowConnectionBanner):请求级 error / 可分类连接问题 /
+    // banner 渲染条件(useShowConnectionBanner):请求级 / transport hold error、可分类连接问题、
     // 目标设备熔断 open(电脑端未响应)立即显示;普通弱网断线经防闪窗口后也显示,不再彻底静默。
     expect(routeSource).toContain('{showConnectionBanner ? (');
-    expect(source).toContain('useShowConnectionBanner(status, connectionError, connectionIssue, isDeviceUnresponsive)');
+    expect(source).toContain('useShowConnectionBanner(\n    status,\n    connectionRecoveryError,');
     expect(routeSource).not.toContain('connectionError || (loading && !currentSession)');
     expect(syncSource).toContain("t('session.screen.awaitingSync')");
     expect(syncSource).toContain("t('session.screen.resync')");

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -45,7 +45,8 @@ describe('mobile session main layer desktop-first noise budget', () => {
     // banner 渲染条件(useShowConnectionBanner):请求级 / transport hold error、可分类连接问题、
     // 目标设备熔断 open(电脑端未响应)立即显示;普通弱网断线经防闪窗口后也显示,不再彻底静默。
     expect(routeSource).toContain('{showConnectionBanner ? (');
-    expect(source).toContain('useShowConnectionBanner(\n    status,\n    connectionRecoveryError,');
+    expect(source.replace(/\r\n/g, '\n'))
+      .toContain('useShowConnectionBanner(\n    status,\n    connectionRecoveryError,');
     expect(routeSource).not.toContain('connectionError || (loading && !currentSession)');
     expect(syncSource).toContain("t('session.screen.awaitingSync')");
     expect(syncSource).toContain("t('session.screen.resync')");

--- a/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
+++ b/apps/mobile/src/__tests__/sessionMainLayerDesktopFirst.test.ts
@@ -102,9 +102,10 @@ describe('mobile session main layer desktop-first noise budget', () => {
     const source = readFileSync(resolve(process.cwd(), 'app/sessions/[sessionId].tsx'), 'utf8');
 
     expect(source).toContain('connectionEpoch');
-    expect(source).toContain('lastPresenceSnapshot');
+    expect(source).toContain('getPresenceAvailability(deviceId)');
     expect(source).toContain('targetAvailableRef');
-    expect(source).toContain("lastPresenceSnapshot.deviceId !== deviceId");
+    expect(source).toContain('wasAvailable !== true');
+    expect(source).not.toContain('lastPresenceSnapshot');
     expect(source).not.toContain('presenceVersion');
   });
 

--- a/apps/mobile/src/__tests__/sessionOperationLayout.test.ts
+++ b/apps/mobile/src/__tests__/sessionOperationLayout.test.ts
@@ -83,16 +83,16 @@ describe("session operation layout", () => {
     });
   });
 
-  it("keeps a cached remote session editable while sync is failing but prevents send actions", () => {
+  it("keeps deterministic remote failures visible and prevents send actions", () => {
     expect(
       buildSessionOperationLayout({
         hasCurrentSession: true,
         hasActivePendingInteraction: true,
-        remoteUnavailableReason: "网络或被控端暂时不可用，可以稍后重新同步。",
+        remoteUnavailableReason: "这台电脑已撤销手机访问权限。",
       }),
     ).toEqual({
       canUseComposer: false,
-      composerDisabledReason: "网络或被控端暂时不可用，可以稍后重新同步。",
+      composerDisabledReason: "这台电脑已撤销手机访问权限。",
       composerDisabledReasonSource: "caller-provided",
       composerSlot: "editable",
       messageHistoryMode: "visible",

--- a/apps/mobile/src/__tests__/sessionOutbox.test.ts
+++ b/apps/mobile/src/__tests__/sessionOutbox.test.ts
@@ -84,6 +84,21 @@ describe('shouldHoldOutboxDispatchForConnection', () => {
       targetAvailable: null,
     })).toBe(false);
   });
+
+  it('新连接代把旧 offline 降为 unknown，且本代新 offline 仍会重新阻塞', () => {
+    expect(shouldHoldOutboxDispatchForConnection({
+      ...online,
+      targetAvailable: false,
+    })).toBe(true);
+    expect(shouldHoldOutboxDispatchForConnection({
+      ...online,
+      targetAvailable: null,
+    })).toBe(false);
+    expect(shouldHoldOutboxDispatchForConnection({
+      ...online,
+      targetAvailable: false,
+    })).toBe(true);
+  });
 });
 
 describe('isSafelyUnsentOutboxEnqueueError', () => {

--- a/apps/mobile/src/__tests__/sessionOutbox.test.ts
+++ b/apps/mobile/src/__tests__/sessionOutbox.test.ts
@@ -148,6 +148,24 @@ describe('buildOutboxItem', () => {
     const item = itemWith();
     expect(outboxItemReady(item)).toBe(true);
     expect(outboxItemAttachments(item)).toEqual([]);
+    expect(item.legacyPlanRestore).toBeNull();
+    expect(item.legacyPlanArmEpochAtSend).toBe(0);
+    expect(item.restoreOnly).toBe(false);
+  });
+
+  it('保留旧协议计划模式的恢复屏障字段直到真正恢复', () => {
+    const item = itemWith({
+      permissionModeAtSend: 'plan',
+      legacyPlanRestore: 'acceptEdits',
+      legacyPlanArmEpochAtSend: 3,
+      restoreOnly: true,
+    });
+    expect(item).toMatchObject({
+      permissionModeAtSend: 'plan',
+      legacyPlanRestore: 'acceptEdits',
+      legacyPlanArmEpochAtSend: 3,
+      restoreOnly: true,
+    });
   });
 
   it('keeps quote metadata until the outbox item is dispatched', () => {
@@ -362,10 +380,15 @@ describe('outboxItemRetrying / outboxItemWithEnqueueFailure', () => {
   });
 
   it('派发途中断线回到等待连接态，不变成需要用户重试的失败项', () => {
-    const dispatching = { ...itemWith(), phase: 'dispatching' as const };
+    const dispatching = {
+      ...itemWith({ legacyPlanRestore: 'ask', restoreOnly: true }),
+      phase: 'dispatching' as const,
+    };
     const waiting = outboxItemWaitingForConnection(dispatching);
     expect(waiting.phase).toBe('uploading');
     expect(waiting.enqueueError).toBeNull();
+    expect(waiting.legacyPlanRestore).toBe('ask');
+    expect(waiting.restoreOnly).toBe(true);
     expect(outboxItemReady(waiting)).toBe(true);
   });
 });

--- a/apps/mobile/src/__tests__/sessionOutbox.test.ts
+++ b/apps/mobile/src/__tests__/sessionOutbox.test.ts
@@ -148,24 +148,6 @@ describe('buildOutboxItem', () => {
     const item = itemWith();
     expect(outboxItemReady(item)).toBe(true);
     expect(outboxItemAttachments(item)).toEqual([]);
-    expect(item.legacyPlanRestore).toBeNull();
-    expect(item.legacyPlanArmEpochAtSend).toBe(0);
-    expect(item.restoreOnly).toBe(false);
-  });
-
-  it('保留旧协议计划模式的恢复屏障字段直到真正恢复', () => {
-    const item = itemWith({
-      permissionModeAtSend: 'plan',
-      legacyPlanRestore: 'acceptEdits',
-      legacyPlanArmEpochAtSend: 3,
-      restoreOnly: true,
-    });
-    expect(item).toMatchObject({
-      permissionModeAtSend: 'plan',
-      legacyPlanRestore: 'acceptEdits',
-      legacyPlanArmEpochAtSend: 3,
-      restoreOnly: true,
-    });
   });
 
   it('keeps quote metadata until the outbox item is dispatched', () => {
@@ -380,15 +362,10 @@ describe('outboxItemRetrying / outboxItemWithEnqueueFailure', () => {
   });
 
   it('派发途中断线回到等待连接态，不变成需要用户重试的失败项', () => {
-    const dispatching = {
-      ...itemWith({ legacyPlanRestore: 'ask', restoreOnly: true }),
-      phase: 'dispatching' as const,
-    };
+    const dispatching = { ...itemWith(), phase: 'dispatching' as const };
     const waiting = outboxItemWaitingForConnection(dispatching);
     expect(waiting.phase).toBe('uploading');
     expect(waiting.enqueueError).toBeNull();
-    expect(waiting.legacyPlanRestore).toBe('ask');
-    expect(waiting.restoreOnly).toBe(true);
     expect(outboxItemReady(waiting)).toBe(true);
   });
 });

--- a/apps/mobile/src/__tests__/sessionOutbox.test.ts
+++ b/apps/mobile/src/__tests__/sessionOutbox.test.ts
@@ -1,12 +1,15 @@
 import { beforeAll, describe, expect, it } from 'vitest';
+import { DeviceLinkError } from '@cindy/device-link';
 import { i18n } from '@/i18n';
 import {
   buildOutboxItem,
   createOutboxClientId,
+  isSafelyUnsentOutboxEnqueueError,
   outboxDisplayItem,
   outboxItemAttachments,
   outboxItemReady,
   outboxItemRetrying,
+  outboxItemWaitingForConnection,
   outboxItemWithEnqueueFailure,
   outboxItemWithUpload,
   outboxItemWithUploadFailure,
@@ -14,6 +17,7 @@ import {
   outboxWithUploadResult,
   recoverOutboxItemsToComposerDraft,
   replaceOutboxItem,
+  shouldHoldOutboxDispatchForConnection,
 } from '@/session/sessionOutbox';
 import type { RemoteSerializedAttachment } from '@/session/types';
 import { serializeComposerDocument } from '@/session/composerDocument';
@@ -53,6 +57,53 @@ describe('createOutboxClientId', () => {
     const b = createOutboxClientId();
     expect(a).toBeTruthy();
     expect(a).not.toBe(b);
+  });
+});
+
+describe('shouldHoldOutboxDispatchForConnection', () => {
+  const online = {
+    relayOnline: true,
+    targetAvailable: true,
+    deviceUnresponsive: false,
+    autoRecoveringError: false,
+    syncInProgress: false,
+  };
+
+  it('只在 relay、目标 presence、熔断和请求状态都健康时派发', () => {
+    expect(shouldHoldOutboxDispatchForConnection(online)).toBe(false);
+    expect(shouldHoldOutboxDispatchForConnection({ ...online, relayOnline: false })).toBe(true);
+    expect(shouldHoldOutboxDispatchForConnection({ ...online, targetAvailable: false })).toBe(true);
+    expect(shouldHoldOutboxDispatchForConnection({ ...online, deviceUnresponsive: true })).toBe(true);
+    expect(shouldHoldOutboxDispatchForConnection({ ...online, autoRecoveringError: true })).toBe(true);
+    expect(shouldHoldOutboxDispatchForConnection({ ...online, syncInProgress: true })).toBe(true);
+  });
+
+  it('presence 尚未知时不把健康连接永久卡住', () => {
+    expect(shouldHoldOutboxDispatchForConnection({
+      ...online,
+      targetAvailable: null,
+    })).toBe(false);
+  });
+});
+
+describe('isSafelyUnsentOutboxEnqueueError', () => {
+  it('只允许明确发生在派发前的连接失败自动回队', () => {
+    expect(isSafelyUnsentOutboxEnqueueError(
+      new DeviceLinkError('NOT_CONNECTED', 'not connected'),
+    )).toBe(true);
+    expect(isSafelyUnsentOutboxEnqueueError(
+      new DeviceLinkError('LINK_NOT_OPEN', 'link is closed'),
+    )).toBe(true);
+    expect(isSafelyUnsentOutboxEnqueueError('[DEVICE_UNRESPONSIVE] circuit open')).toBe(true);
+  });
+
+  it('拒绝可能已经到达被控端的 in-flight 断线与 invoke 超时', () => {
+    const ambiguous = new DeviceLinkError('NOT_CONNECTED', 'ack may be lost');
+    ambiguous.inFlight = true;
+    expect(isSafelyUnsentOutboxEnqueueError(ambiguous)).toBe(false);
+    expect(isSafelyUnsentOutboxEnqueueError(
+      new DeviceLinkError('INVOKE_TIMEOUT', 'no result'),
+    )).toBe(false);
   });
 });
 
@@ -293,6 +344,14 @@ describe('outboxItemRetrying / outboxItemWithEnqueueFailure', () => {
     expect(outboxItemReady(item)).toBe(false);
     item = outboxItemRetrying(item);
     expect(outboxItemReady(item)).toBe(true);
+  });
+
+  it('派发途中断线回到等待连接态，不变成需要用户重试的失败项', () => {
+    const dispatching = { ...itemWith(), phase: 'dispatching' as const };
+    const waiting = outboxItemWaitingForConnection(dispatching);
+    expect(waiting.phase).toBe('uploading');
+    expect(waiting.enqueueError).toBeNull();
+    expect(outboxItemReady(waiting)).toBe(true);
   });
 });
 

--- a/apps/mobile/src/__tests__/sessionReferences.test.ts
+++ b/apps/mobile/src/__tests__/sessionReferences.test.ts
@@ -252,6 +252,31 @@ describe('mobile session-reference links', () => {
     );
   });
 
+  it('falls back to the raw link when the source device is offline', async () => {
+    const invoke = vi.fn(async (deviceId: string, channel: string) => {
+      if (channel === DL_SESSION_REFERENCE_CAPABILITY_CHANNEL) {
+        expect(deviceId).toBe('target-device');
+        return { supported: true, version: 1 };
+      }
+      expect(deviceId).toBe('source-device');
+      throw new DeviceLinkError('DEVICE_OFFLINE', 'source offline');
+    });
+
+    await expect(prepareMobileQueuedSessionReferences(
+      {
+        text: 'compare cindy://session/source',
+        sessionRefs: [{ sessionId: 'source', deviceId: 'source-device' }],
+      },
+      asInvoke(invoke),
+      () => undefined,
+      'target-device',
+    )).resolves.toEqual({ text: 'compare cindy://session/source' });
+    expect(console.warn).toHaveBeenCalledWith(
+      '[session-references] trusted history unavailable; preserving raw link text',
+      expect.objectContaining({ phase: 'source-resolution', code: 'SESSION_REFERENCE_OFFLINE' }),
+    );
+  });
+
   it('probes a new target before resolving source history', async () => {
     const channels: string[] = [];
     const invoke = asInvoke(async (_deviceId, channel, args) => {

--- a/apps/mobile/src/components/ConnectionBanner.tsx
+++ b/apps/mobile/src/components/ConnectionBanner.tsx
@@ -7,11 +7,13 @@ import {
   connectionIssueHint,
   connectionIssueTitle,
   describeRemoteError,
+  isAutoRecoveringRemoteError,
   relayStatusHint,
   relayStatusLabel,
 } from '@/device-link/remoteStatus';
 import { MainWindowActionButton, StatusDot } from '@/components/MobilePrimitives';
 import {
+  resolveConnectionBannerSyncActionVisibility,
   resolveConnectionBannerVisibility,
   resolveEffectiveConnectionError,
 } from '@/components/connectionBannerVisibility';
@@ -93,6 +95,13 @@ export function ConnectionBanner({
   // useShowConnectionBanner 同一判定,否则会出现可见但无内容的空壳 banner)。
   const effectiveError = resolveEffectiveConnectionError(error, deviceUnresponsive);
   const friendlyError = activeIssue || showUnresponsive ? null : describeRemoteError(effectiveError);
+  const showSyncAction = resolveConnectionBannerSyncActionVisibility({
+    online: status === 'online',
+    hasActiveIssue: activeIssue !== null,
+    deviceUnresponsive: showUnresponsive,
+    hasRequestError: friendlyError !== null,
+    requestErrorAutoRecovering: isAutoRecoveringRemoteError(effectiveError),
+  });
   const tone = activeIssue
     ? 'off'
     : showUnresponsive
@@ -144,12 +153,14 @@ export function ConnectionBanner({
           </Text>
         ) : null}
       </View>
-      <ConnectionSyncButton
-        compact={compact}
-        loading={loading}
-        onPress={onSync}
-        testID="connection.syncButton"
-      />
+      {showSyncAction ? (
+        <ConnectionSyncButton
+          compact={compact}
+          loading={loading}
+          onPress={onSync}
+          testID="connection.syncButton"
+        />
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/src/components/connectionBannerVisibility.ts
+++ b/apps/mobile/src/components/connectionBannerVisibility.ts
@@ -23,6 +23,25 @@ export function resolveConnectionBannerVisibility(input: {
 }
 
 /**
+ * 连接类恢复全部由系统处理，不给用户一个与自动重连并行的“同步”按钮。
+ * 只有链路已在线、没有连接级 issue，且确实是非自动恢复的请求级同步失败时，
+ * 才保留手动重试入口。
+ */
+export function resolveConnectionBannerSyncActionVisibility(input: {
+  online: boolean;
+  hasActiveIssue: boolean;
+  deviceUnresponsive: boolean;
+  hasRequestError: boolean;
+  requestErrorAutoRecovering: boolean;
+}): boolean {
+  return input.online
+    && !input.hasActiveIssue
+    && !input.deviceUnresponsive
+    && input.hasRequestError
+    && !input.requestErrorAutoRecovering;
+}
+
+/**
  * 屏幕层持有的请求级 error 是快照:熔断 open 期间的重试失败会把
  * DEVICE_UNRESPONSIVE 文案存进去,而探测成功自动关熔断只翻转
  * deviceUnresponsive,不会替屏幕清 error(review P1)。熔断已关时这类

--- a/apps/mobile/src/debug/visualMock.ts
+++ b/apps/mobile/src/debug/visualMock.ts
@@ -147,6 +147,9 @@ export function createVisualMockDeviceLinkContext(): DeviceLinkContextValue {
       busy: false,
       lastSeenAt: NOW,
     },
+    getPresenceAvailability: (candidateDeviceId: string) => (
+      candidateDeviceId === deviceId ? true : null
+    ),
     openLink: async (): Promise<LinkAcceptPayload> => ({
       appVersion: '0.0.0-visual-mock',
       allowlistHash: 'visual-mock',

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -298,6 +298,23 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
   const [connectionEpoch, setConnectionEpoch] = useState(0);
   const [lastPresenceSnapshot, setLastPresenceSnapshot] = useState<PresenceSnapshot | null>(null);
 
+  /**
+   * availability 放在 ref 里供 transport 同步读取；每次真实的三态变化也必须发布给
+   * Context consumers。before / after 比较避免 rehydrate 重试重复写 false 时制造
+   * 无意义渲染，也避免只清 verdict、availability 仍为 unknown 时误报变化。
+   */
+  const publishPresenceAvailabilityMutation = useCallback(<T,>(
+    deviceId: string,
+    mutate: (availabilityByDevice: Map<string, boolean>) => T,
+  ): T => {
+    const availabilityByDevice = presenceAvailableByDeviceRef.current;
+    const before = availabilityByDevice.get(deviceId) ?? null;
+    const result = mutate(availabilityByDevice);
+    const after = availabilityByDevice.get(deviceId) ?? null;
+    if (before !== after) setPresenceVersion((version) => version + 1);
+    return result;
+  }, []);
+
   const sendOpenLinkOnce = useCallback((
     client: DeviceLinkClient,
     deviceId: string,
@@ -521,7 +538,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
                   presenceWipeTimersRef.current,
                   deviceId,
                 );
-                presenceAvailableByDeviceRef.current.set(deviceId, false);
+                publishPresenceAvailabilityMutation(deviceId, (availabilityByDevice) => {
+                  availabilityByDevice.set(deviceId, false);
+                });
                 presenceUnavailableVerdictsRef.current.set(deviceId, {
                   kind: 'disabled',
                   responseEvidenceEpoch: capturePresenceAvailabilityEpoch(
@@ -539,7 +558,9 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
                 // 当前代 false verdict,让退避重跑过滤该设备而不是持续重放整套计划。
                 // rehydrate 已按请求发起时的 presence epoch 丢弃旧路由离线回包,
                 // 因此这里不会覆盖更晚的 available=true。
-                presenceAvailableByDeviceRef.current.set(deviceId, false);
+                publishPresenceAvailabilityMutation(deviceId, (availabilityByDevice) => {
+                  availabilityByDevice.set(deviceId, false);
+                });
                 presenceUnavailableVerdictsRef.current.set(deviceId, {
                   kind: 'offline',
                   responseEvidenceEpoch: capturePresenceAvailabilityEpoch(
@@ -581,7 +602,13 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       state.inFlight = run;
       return run;
     },
-    [probeUnresponsiveDevice, scheduleRehydrateRetry, sendOpenLinkOnce, sendTrackedSubscribe],
+    [
+      probeUnresponsiveDevice,
+      publishPresenceAvailabilityMutation,
+      scheduleRehydrateRetry,
+      sendOpenLinkOnce,
+      sendTrackedSubscribe,
+    ],
   );
 
   useEffect(() => {
@@ -789,12 +816,14 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
           // presence=false(入站帧无时序歧义,disabled 判定仍保留)。
           // revoked/熔断/in-flight 去重等保护由 rehydrate 自身的既有门把守。
           markRemoteResponseEvidence(deviceId);
-          reconcileAvailabilityAfterInboundFrame(
-            presenceAvailableByDeviceRef.current,
-            presencePendingRecoveryDeviceIdsRef.current,
-            presenceUnavailableVerdictsRef.current,
-            deviceId,
-          );
+          publishPresenceAvailabilityMutation(deviceId, (availabilityByDevice) => (
+            reconcileAvailabilityAfterInboundFrame(
+              availabilityByDevice,
+              presencePendingRecoveryDeviceIdsRef.current,
+              presenceUnavailableVerdictsRef.current,
+              deviceId,
+            )
+          ));
           // 直接可达证据必须同步收口此前 unavailable presence 建的镜像清理
           // 计时器:该 timer 的触发条件是 availability 非明确 true——若随后的
           // open/subscribe/rehydrate 瞬时失败或停在 unknown,遗留 timer 仍会
@@ -854,12 +883,14 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         noteSessionLiveStreamsInterrupted,
       );
       markRemoteResponseEvidence(deviceId);
-      reconcileAvailabilityAfterInboundFrame(
-        presenceAvailableByDeviceRef.current,
-        presencePendingRecoveryDeviceIdsRef.current,
-        presenceUnavailableVerdictsRef.current,
-        deviceId,
-      );
+      publishPresenceAvailabilityMutation(deviceId, (availabilityByDevice) => (
+        reconcileAvailabilityAfterInboundFrame(
+          availabilityByDevice,
+          presencePendingRecoveryDeviceIdsRef.current,
+          presenceUnavailableVerdictsRef.current,
+          deviceId,
+        )
+      ));
       clearOnePresenceWipeTimer(presenceWipeTimersRef.current, deviceId);
       void rehydrateWithClient(client);
     });
@@ -870,13 +901,15 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
         remoteResponseEvidenceEpochs,
         deviceId,
       );
-      if (!reconcileOfflineVerdictAfterResponse(
-        presenceAvailableByDeviceRef.current,
-        presencePendingRecoveryDeviceIdsRef.current,
-        presenceUnavailableVerdictsRef.current,
-        deviceId,
-        currentEpoch,
-      )) {
+      if (!publishPresenceAvailabilityMutation(deviceId, (availabilityByDevice) => (
+        reconcileOfflineVerdictAfterResponse(
+          availabilityByDevice,
+          presencePendingRecoveryDeviceIdsRef.current,
+          presenceUnavailableVerdictsRef.current,
+          deviceId,
+          currentEpoch,
+        )
+      ))) {
         return;
       }
 
@@ -1002,7 +1035,13 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
       backgroundReleaseInFlightRef.current = false;
       if (clientRef.current === client) clientRef.current = null;
     };
-  }, [auth.getAccessToken, auth.isAuthenticated, clearRehydrateRetry, rehydrateWithClient]);
+  }, [
+    auth.getAccessToken,
+    auth.isAuthenticated,
+    clearRehydrateRetry,
+    publishPresenceAvailabilityMutation,
+    rehydrateWithClient,
+  ]);
 
   const openLink = useCallback(
     async (deviceId: string) => {

--- a/apps/mobile/src/device-link/DeviceLinkContext.tsx
+++ b/apps/mobile/src/device-link/DeviceLinkContext.tsx
@@ -121,6 +121,8 @@ export interface DeviceLinkContextValue {
   presenceVersion: number;
   connectionEpoch: number;
   lastPresenceSnapshot: PresenceSnapshot | null;
+  /** 当前 relay 连接代内的逐设备 availability；null = 本代尚无权威 verdict。 */
+  getPresenceAvailability(deviceId: string): boolean | null;
   openLink(deviceId: string): Promise<LinkAcceptPayload>;
   closeLink(deviceId: string): void;
   /**
@@ -1053,12 +1055,17 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     await sendUnsubscribe(requireClient(clientRef.current), deviceId, toSend);
   }, []);
 
+  const getPresenceAvailability = useCallback((deviceId: string): boolean | null => (
+    presenceAvailableByDeviceRef.current.get(deviceId) ?? null
+  ), []);
+
   const value = useMemo<DeviceLinkContextValue>(() => ({
     status,
     connectionIssue,
     presenceVersion,
     connectionEpoch,
     lastPresenceSnapshot,
+    getPresenceAvailability,
     openLink,
     closeLink,
     invoke,
@@ -1068,6 +1075,7 @@ export function DeviceLinkProvider({ children }: { children: ReactNode }) {
     closeLink,
     connectionEpoch,
     connectionIssue,
+    getPresenceAvailability,
     invoke,
     lastPresenceSnapshot,
     openLink,

--- a/apps/mobile/src/device-link/remoteStatus.ts
+++ b/apps/mobile/src/device-link/remoteStatus.ts
@@ -1,5 +1,6 @@
 import {
   describeRemoteError as describeRemoteErrorShared,
+  formatRemoteError as formatRemoteErrorShared,
   humanizeRemoteError as humanizeRemoteErrorShared,
   isDeviceUnresponsiveRemoteError,
   isTransientRemoteError,
@@ -41,18 +42,26 @@ export function connectionIssueHint(kind: DeviceLinkConnectionIssueKind): string
   return i18n.t(CONNECTION_ISSUE_COPY_KEYS[kind].hint);
 }
 
+/** 自动恢复类连接错误保留结构化 marker 做状态分类，展示文案则复用 Mobile i18n。 */
+function localizedConnectionRecoveryCopy(error: unknown): string | null {
+  const formatted = typeof error === 'string' ? error : formatRemoteErrorShared(error);
+  if (formatted.includes('DEVICE_OFFLINE')) return i18n.t('session.menu.aiRenameOffline');
+  if (formatted.includes('NOT_CONNECTED')) return i18n.t('session.screen.networkReconnecting');
+  return null;
+}
+
 /**
- * mobile 侧的 humanizeRemoteError / describeRemoteError:熔断快速失败
- * (DEVICE_UNRESPONSIVE)先走四语言 i18n(与 ConnectionBanner 同一组文案),
- * 其余委托 maker-shared 原实现。共享层的文案是中文硬编码(历史现状),直接
- * 透出会让 en/ja/ko 用户在 Alert / banner 里看到中文(review P1 两轮)——
- * 本 PR 新增的错误码不再走那条老路。mobile 代码一律从本文件 import,
- * 不要直接 import 共享层的这两个函数。
+ * mobile 侧的 humanizeRemoteError / describeRemoteError:熔断快速失败与 Stop
+ * 会主动产生的自动恢复错误先走 Mobile i18n,其余委托 maker-shared 原实现。
+ * 共享层的文案是中文硬编码(历史现状),新接入的错误出口不能直接透给其它语言
+ * 用户。mobile 代码一律从本文件 import,不要直接 import 共享层的这两个函数。
  */
 export function humanizeRemoteError(error: unknown): string {
   if (isDeviceUnresponsiveRemoteError(error)) {
     return i18n.t('deviceLink.deviceUnresponsiveHint');
   }
+  const recoveryCopy = localizedConnectionRecoveryCopy(error);
+  if (recoveryCopy) return recoveryCopy;
   return humanizeRemoteErrorShared(error);
 }
 
@@ -76,6 +85,8 @@ export function describeRemoteError(error: string | null): string | null {
   if (error?.includes('DEVICE_UNRESPONSIVE')) {
     return i18n.t('deviceLink.deviceUnresponsiveHint');
   }
+  const recoveryCopy = localizedConnectionRecoveryCopy(error);
+  if (recoveryCopy) return recoveryCopy;
   return describeRemoteErrorShared(error);
 }
 

--- a/apps/mobile/src/device-link/remoteStatus.ts
+++ b/apps/mobile/src/device-link/remoteStatus.ts
@@ -77,8 +77,19 @@ export function isAutoRecoveringRemoteError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
   return code === 'SESSION_REFERENCE_OFFLINE'
     || message.includes('SESSION_REFERENCE_OFFLINE')
+    // 桌面端 fail-closed：持久消息 / input coordinator 暂时无法完成 clientId
+    // 去重核验。原消息必须留在 outbox 等状态恢复，不能让用户换 id 重发。
+    || message.includes('REMOTE_OPTIMISTIC_SESSION_STATE_UNAVAILABLE')
     || isTransientRemoteError(error)
     || isDeviceUnresponsiveRemoteError(error);
+}
+
+/**
+ * 权威同步的一轮内置瞬态重试耗尽后，页面继续自动恢复所用的外层退避。
+ * 900ms 尽快吃掉短抖动，随后指数放缓并封顶 30s，避免电脑长期离线时形成请求风暴。
+ */
+export function connectionRecoverySyncRetryDelayMs(attempt: number): number {
+  return Math.min(900 * 2 ** Math.max(0, Math.floor(attempt)), 30_000);
 }
 
 export function describeRemoteError(error: string | null): string | null {

--- a/apps/mobile/src/device-link/remoteStatus.ts
+++ b/apps/mobile/src/device-link/remoteStatus.ts
@@ -2,6 +2,7 @@ import {
   describeRemoteError as describeRemoteErrorShared,
   humanizeRemoteError as humanizeRemoteErrorShared,
   isDeviceUnresponsiveRemoteError,
+  isTransientRemoteError,
 } from '@cindy/maker-shared/device-link-contract';
 import type { DeviceLinkConnectionIssueKind } from '@cindy/device-link';
 import { i18n } from '@/i18n';
@@ -55,9 +56,34 @@ export function humanizeRemoteError(error: unknown): string {
   return humanizeRemoteErrorShared(error);
 }
 
+/**
+ * 连接恢复中的错误不会转成用户手动处理的失败态。
+ *
+ * DEVICE_UNRESPONSIVE 在通用 retry helper 里故意归为 permanent（避免熔断 open
+ * 时原地重试风暴），但对消息 outbox 来说仍是自动探测可恢复状态，必须留在本地
+ * 等熔断关闭，而不是让用户重发。
+ */
+export function isAutoRecoveringRemoteError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null)?.code;
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  return code === 'SESSION_REFERENCE_OFFLINE'
+    || message.includes('SESSION_REFERENCE_OFFLINE')
+    || isTransientRemoteError(error)
+    || isDeviceUnresponsiveRemoteError(error);
+}
+
 export function describeRemoteError(error: string | null): string | null {
   if (error?.includes('DEVICE_UNRESPONSIVE')) {
     return i18n.t('deviceLink.deviceUnresponsiveHint');
   }
   return describeRemoteErrorShared(error);
+}
+
+/**
+ * 只有确定性远端错误才锁 composer；断线、弱网、超时与熔断由本地 outbox 接住，
+ * 恢复后自动派发。返回 null 表示 composer 可以继续收消息。
+ */
+export function describeRemoteComposerBlockingError(error: string | null): string | null {
+  if (!error || isAutoRecoveringRemoteError(error)) return null;
+  return describeRemoteError(error);
 }

--- a/apps/mobile/src/session/newSessionCreation.ts
+++ b/apps/mobile/src/session/newSessionCreation.ts
@@ -8,6 +8,7 @@
  * openLink / createSession / 首条消息 enqueue 全部在本模块后台串行完成。
  *
  * 状态机:running → done(task 移除)
+ *              → restoring-plan(首条已入队,等旧协议权限恢复后才放行后续 outbox)
  *              → create-failed(会话页横幅:重试[同 id 幂等安全] / 返回编辑[草稿回填])
  *              → enqueue-failed(会话已建成:乐观气泡摘除、草稿+附件回填 composer,
  *                                用户走正常 handleSend 重发)
@@ -30,7 +31,7 @@ import * as ExpoCrypto from 'expo-crypto';
 import { isPreconditionFailedRemoteError } from '@cindy/maker-shared/device-link-contract';
 import { i18n } from '@/i18n';
 import { isTransientRemoteError, withTransientRemoteRetry } from '@/device-link/remoteRetry';
-import { formatRemoteError } from '@/device-link/remoteStatus';
+import { formatRemoteError, isAutoRecoveringRemoteError } from '@/device-link/remoteStatus';
 import type { MobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { buildQueuedTextMessage } from '@/session/inputProjection';
 import {
@@ -58,7 +59,11 @@ import type {
   RemoteSession,
 } from '@/session/types';
 
-export type NewSessionCreationStatus = 'running' | 'create-failed' | 'enqueue-failed';
+export type NewSessionCreationStatus =
+  | 'running'
+  | 'restoring-plan'
+  | 'create-failed'
+  | 'enqueue-failed';
 
 export interface NewSessionCreationTransport {
   maker: MobileMakerTransport;
@@ -252,6 +257,19 @@ function synthesizeSession(params: NewSessionCreationParams, draftOverride?: New
 }
 
 /**
+ * 老协议首条消息仍以 permissionMode='plan' 快照入队，但手机镜像要立即显示恢复档，
+ * 这样创建管线未收口时用户继续发送的消息不会再次继承一次性 Plan。
+ */
+function sessionWhileFirstMessagePending(
+  session: RemoteSession,
+  legacyPlanRestore: string | null,
+): RemoteSession {
+  return legacyPlanRestore
+    ? { ...session, permissionMode: legacyPlanRestore }
+    : session;
+}
+
+/**
  * 启动乐观创建:同步完成 store 写入(合成会话行 + 乐观排队气泡),登记 task 并
  * 后台跑管线。调用方随后立即 router.replace 进会话页。
  */
@@ -263,7 +281,11 @@ export function startNewSessionCreation(params: NewSessionCreationParams): void 
     remoteSessionStore.getSessionDeviceId,
   );
   const session = synthesizeSession(params);
-  remoteSessionStore.upsertDeviceSession(params.deviceId, params.deviceName, session);
+  remoteSessionStore.upsertDeviceSession(
+    params.deviceId,
+    params.deviceName,
+    sessionWhileFirstMessagePending(session, params.legacyPlanRestore),
+  );
   const queued = attachFirstMessageSessionReferences(buildQueuedTextMessage(
     session,
     params.draft.firstMessage,
@@ -307,7 +329,11 @@ export function retryNewSessionCreation(sessionId: string): void {
   task.error = null;
   // 重试前把乐观行 / 气泡恢复(返回编辑路径可能没走,行一般还在,upsert 幂等)。
   const session = synthesizeSession(task.params);
-  remoteSessionStore.upsertDeviceSession(task.deviceId, task.deviceName, session);
+  remoteSessionStore.upsertDeviceSession(
+    task.deviceId,
+    task.deviceName,
+    sessionWhileFirstMessagePending(session, task.params.legacyPlanRestore),
+  );
   const queued = attachFirstMessageSessionReferences(buildQueuedTextMessage(
     session,
     task.draft.firstMessage,
@@ -452,11 +478,12 @@ export function getNewSessionCreationTask(sessionId: string): NewSessionCreation
 /**
  * 会话页 syncSession 守卫:running(被控端可能还没有这个会话,getSession 会
  * NOT_FOUND 报错横幅)与 create-failed(确定不存在)都要跳过同步;
- * enqueue-failed / done 时会话已建成,照常同步。
+ * restoring-plan 仍要保护本地已消费的权限镜像，避免权威 plan 回灌后让 follow-up
+ * 错误快照；enqueue-failed / done 时会话已建成且无恢复屏障，照常同步。
  */
 export function shouldBlockSessionSync(sessionId: string): boolean {
   const status = tasks.get(sessionId)?.status;
-  return status === 'running' || status === 'create-failed';
+  return status === 'running' || status === 'restoring-plan' || status === 'create-failed';
 }
 
 function subscribeTasks(callback: () => void): () => void {
@@ -557,7 +584,13 @@ function failTask(task: InternalTask, status: 'create-failed' | 'enqueue-failed'
     // 禁发标——弱网下 fresh getSession / 会话页 load 可能都还没成功,不清的话
     // 用户拿着回填草稿仍被禁发,只能干等 load(codex review P2)。
     remoteSessionStore.setInputProjection(task.sessionId, null);
-    remoteSessionStore.applySessionPatch(task.deviceId, task.sessionId, { pendingLocalCreation: false });
+    remoteSessionStore.applySessionPatch(task.deviceId, task.sessionId, {
+      pendingLocalCreation: false,
+      // 旧协议首条并未确认入队，远端仍保持 plan；本地也重新武装，让回填草稿
+      // 的下一次发送继续承载用户原本的一次性 Plan 意图，而不是 UI 普通/远端
+      // Plan 的分叉状态。
+      ...(task.params.legacyPlanRestore ? { permissionMode: 'plan' } : {}),
+    });
   }
   emit();
 }
@@ -582,6 +615,56 @@ function finishTask(task: InternalTask): void {
   forgetPrecreatedRecoveryRecord(task);
   tasks.delete(task.sessionId);
   emit();
+}
+
+async function restoreLegacyPlanAfterFirstMessage(task: InternalTask): Promise<boolean> {
+  const restoreMode = task.params.legacyPlanRestore;
+  if (!restoreMode) return true;
+  try {
+    assertTaskOwnerCurrent(task);
+    await withTransientRemoteRetry(
+      () => task.params.transport.maker.setPermissionMode(task.sessionId, restoreMode),
+      task.params.sleep ? { sleep: task.params.sleep } : undefined,
+    );
+    assertTaskOwnerCurrent(task);
+    return true;
+  } catch (error) {
+    if (isStaleNewSessionOwnerError(error) || !isTaskOwnerCurrent(task)) {
+      cancelStaleOwnerTask(task);
+      return false;
+    }
+    // 旧实现本就是 best-effort：确定性拒绝不能把已创建、首条已接受的任务永久
+    // 锁死。只有系统能自行恢复的传输错误才保留既有 creation task 作为屏障。
+    if (!isAutoRecoveringRemoteError(error)) return true;
+    task.status = 'restoring-plan';
+    task.error = formatRemoteError(error);
+    emit();
+    return false;
+  }
+}
+
+function finishAfterLegacyPlanRestore(task: InternalTask): void {
+  if (tasks.get(task.sessionId) !== task || !isTaskOwnerCurrent(task)) return;
+  remoteSessionStore.applySessionPatch(task.deviceId, task.sessionId, {
+    pendingLocalCreation: false,
+  });
+  finishTask(task);
+}
+
+/** 重试已接受首条消息后的旧协议 Plan 恢复，不重跑创建或 enqueue。 */
+export function retryNewSessionLegacyPlanRestore(sessionId: string): void {
+  const task = tasks.get(sessionId);
+  if (!task || task.status !== 'restoring-plan') return;
+  if (!isTaskOwnerCurrent(task)) {
+    cancelStaleOwnerTask(task);
+    return;
+  }
+  task.status = 'running';
+  task.error = null;
+  emit();
+  void restoreLegacyPlanAfterFirstMessage(task).then((restored) => {
+    if (restored) finishAfterLegacyPlanRestore(task);
+  });
 }
 
 function exactSessionFromProbe(value: unknown, sessionId: string): RemoteSession | null {
@@ -940,10 +1023,14 @@ async function runPipeline(task: InternalTask): Promise<void> {
       // 排到首条前面,违背「首条消息发出后即可继续发送」语义(codex review P2)。
       // 解禁统一在 enqueue 落定后:成功路径 finishTask 前清标 / enqueue-failed 在
       // failTask 内清标。
-      remoteSessionStore.upsertDeviceSession(params.deviceId, params.deviceName, {
-        ...freshSession,
-        pendingLocalCreation: true,
-      });
+      remoteSessionStore.upsertDeviceSession(
+        params.deviceId,
+        params.deviceName,
+        sessionWhileFirstMessagePending({
+          ...freshSession,
+          pendingLocalCreation: true,
+        }, params.legacyPlanRestore),
+      );
     } catch (error) {
       if (isStaleNewSessionOwnerError(error)) throw error;
       freshSession = null;
@@ -980,7 +1067,11 @@ async function runPipeline(task: InternalTask): Promise<void> {
     // 已按 started 后目录修正)——任一发生都必须回写,否则 UI/后续发送仍用
     // 已删除来源。
     if (!freshSession && (draftPatch !== null || effectiveFinalDraft !== finalDraft)) {
-      remoteSessionStore.upsertDeviceSession(params.deviceId, params.deviceName, sessionForQueue);
+      remoteSessionStore.upsertDeviceSession(
+        params.deviceId,
+        params.deviceName,
+        sessionWhileFirstMessagePending(sessionForQueue, params.legacyPlanRestore),
+      );
     }
     const queuedDraft = attachFirstMessageSessionReferences(buildQueuedTextMessage(
       sessionForQueue,
@@ -1051,23 +1142,11 @@ async function runPipeline(task: InternalTask): Promise<void> {
       // 已应用:回执丢失,按成功收敛(权威 projection 由 push / 会话页同步补齐)。
     }
 
-    if (params.legacyPlanRestore) {
-      // 老协议 plan 一次性语义:入队后恢复底层权限档,best-effort(对齐原 create())。
-      assertTaskOwnerCurrent(task);
-      try {
-        await maker.setPermissionMode(sessionId, params.legacyPlanRestore);
-      } catch {
-        // best-effort
-      }
-      assertTaskOwnerCurrent(task);
-    }
+    if (!await restoreLegacyPlanAfterFirstMessage(task)) return;
 
-    // 收口前主动清合成行的 pendingLocalCreation 禁发标:正常情况下上面的 fresh
-    // getSession 已用权威行(无标)覆盖,但弱网下 getSession 可能失败,靠会话页
-    // load 兜底又可能再失败——首条消息已入队,禁发理由已消失,不能让标残留。
-    remoteSessionStore.applySessionPatch(params.deviceId, sessionId, { pendingLocalCreation: false });
-    // 完成:task 移除后会话页守卫解除,由会话页 effect 触发一轮完整 syncSession。
-    finishTask(task);
+    // 首条已入队且旧协议权限恢复完成：清合成行禁发标并移除 task，随后会话页
+    // effect 才会放行 follow-up outbox 与完整 syncSession。
+    finishAfterLegacyPlanRestore(task);
   } catch (err) {
     if (isStaleNewSessionOwnerError(err) || !isTaskOwnerCurrent(task)) {
       cancelStaleOwnerTask(task);

--- a/apps/mobile/src/session/newSessionCreation.ts
+++ b/apps/mobile/src/session/newSessionCreation.ts
@@ -8,7 +8,6 @@
  * openLink / createSession / 首条消息 enqueue 全部在本模块后台串行完成。
  *
  * 状态机:running → done(task 移除)
- *              → restoring-plan(首条已入队,等旧协议权限恢复后才放行后续 outbox)
  *              → create-failed(会话页横幅:重试[同 id 幂等安全] / 返回编辑[草稿回填])
  *              → enqueue-failed(会话已建成:乐观气泡摘除、草稿+附件回填 composer,
  *                                用户走正常 handleSend 重发)
@@ -31,7 +30,7 @@ import * as ExpoCrypto from 'expo-crypto';
 import { isPreconditionFailedRemoteError } from '@cindy/maker-shared/device-link-contract';
 import { i18n } from '@/i18n';
 import { isTransientRemoteError, withTransientRemoteRetry } from '@/device-link/remoteRetry';
-import { formatRemoteError, isAutoRecoveringRemoteError } from '@/device-link/remoteStatus';
+import { formatRemoteError } from '@/device-link/remoteStatus';
 import type { MobileMakerTransport } from '@/device-link/mobileMakerTransport';
 import { buildQueuedTextMessage } from '@/session/inputProjection';
 import {
@@ -59,11 +58,7 @@ import type {
   RemoteSession,
 } from '@/session/types';
 
-export type NewSessionCreationStatus =
-  | 'running'
-  | 'restoring-plan'
-  | 'create-failed'
-  | 'enqueue-failed';
+export type NewSessionCreationStatus = 'running' | 'create-failed' | 'enqueue-failed';
 
 export interface NewSessionCreationTransport {
   maker: MobileMakerTransport;
@@ -257,19 +252,6 @@ function synthesizeSession(params: NewSessionCreationParams, draftOverride?: New
 }
 
 /**
- * 老协议首条消息仍以 permissionMode='plan' 快照入队，但手机镜像要立即显示恢复档，
- * 这样创建管线未收口时用户继续发送的消息不会再次继承一次性 Plan。
- */
-function sessionWhileFirstMessagePending(
-  session: RemoteSession,
-  legacyPlanRestore: string | null,
-): RemoteSession {
-  return legacyPlanRestore
-    ? { ...session, permissionMode: legacyPlanRestore }
-    : session;
-}
-
-/**
  * 启动乐观创建:同步完成 store 写入(合成会话行 + 乐观排队气泡),登记 task 并
  * 后台跑管线。调用方随后立即 router.replace 进会话页。
  */
@@ -281,11 +263,7 @@ export function startNewSessionCreation(params: NewSessionCreationParams): void 
     remoteSessionStore.getSessionDeviceId,
   );
   const session = synthesizeSession(params);
-  remoteSessionStore.upsertDeviceSession(
-    params.deviceId,
-    params.deviceName,
-    sessionWhileFirstMessagePending(session, params.legacyPlanRestore),
-  );
+  remoteSessionStore.upsertDeviceSession(params.deviceId, params.deviceName, session);
   const queued = attachFirstMessageSessionReferences(buildQueuedTextMessage(
     session,
     params.draft.firstMessage,
@@ -329,11 +307,7 @@ export function retryNewSessionCreation(sessionId: string): void {
   task.error = null;
   // 重试前把乐观行 / 气泡恢复(返回编辑路径可能没走,行一般还在,upsert 幂等)。
   const session = synthesizeSession(task.params);
-  remoteSessionStore.upsertDeviceSession(
-    task.deviceId,
-    task.deviceName,
-    sessionWhileFirstMessagePending(session, task.params.legacyPlanRestore),
-  );
+  remoteSessionStore.upsertDeviceSession(task.deviceId, task.deviceName, session);
   const queued = attachFirstMessageSessionReferences(buildQueuedTextMessage(
     session,
     task.draft.firstMessage,
@@ -478,12 +452,11 @@ export function getNewSessionCreationTask(sessionId: string): NewSessionCreation
 /**
  * 会话页 syncSession 守卫:running(被控端可能还没有这个会话,getSession 会
  * NOT_FOUND 报错横幅)与 create-failed(确定不存在)都要跳过同步;
- * restoring-plan 仍要保护本地已消费的权限镜像，避免权威 plan 回灌后让 follow-up
- * 错误快照；enqueue-failed / done 时会话已建成且无恢复屏障，照常同步。
+ * enqueue-failed / done 时会话已建成,照常同步。
  */
 export function shouldBlockSessionSync(sessionId: string): boolean {
   const status = tasks.get(sessionId)?.status;
-  return status === 'running' || status === 'restoring-plan' || status === 'create-failed';
+  return status === 'running' || status === 'create-failed';
 }
 
 function subscribeTasks(callback: () => void): () => void {
@@ -584,13 +557,7 @@ function failTask(task: InternalTask, status: 'create-failed' | 'enqueue-failed'
     // 禁发标——弱网下 fresh getSession / 会话页 load 可能都还没成功,不清的话
     // 用户拿着回填草稿仍被禁发,只能干等 load(codex review P2)。
     remoteSessionStore.setInputProjection(task.sessionId, null);
-    remoteSessionStore.applySessionPatch(task.deviceId, task.sessionId, {
-      pendingLocalCreation: false,
-      // 旧协议首条并未确认入队，远端仍保持 plan；本地也重新武装，让回填草稿
-      // 的下一次发送继续承载用户原本的一次性 Plan 意图，而不是 UI 普通/远端
-      // Plan 的分叉状态。
-      ...(task.params.legacyPlanRestore ? { permissionMode: 'plan' } : {}),
-    });
+    remoteSessionStore.applySessionPatch(task.deviceId, task.sessionId, { pendingLocalCreation: false });
   }
   emit();
 }
@@ -615,56 +582,6 @@ function finishTask(task: InternalTask): void {
   forgetPrecreatedRecoveryRecord(task);
   tasks.delete(task.sessionId);
   emit();
-}
-
-async function restoreLegacyPlanAfterFirstMessage(task: InternalTask): Promise<boolean> {
-  const restoreMode = task.params.legacyPlanRestore;
-  if (!restoreMode) return true;
-  try {
-    assertTaskOwnerCurrent(task);
-    await withTransientRemoteRetry(
-      () => task.params.transport.maker.setPermissionMode(task.sessionId, restoreMode),
-      task.params.sleep ? { sleep: task.params.sleep } : undefined,
-    );
-    assertTaskOwnerCurrent(task);
-    return true;
-  } catch (error) {
-    if (isStaleNewSessionOwnerError(error) || !isTaskOwnerCurrent(task)) {
-      cancelStaleOwnerTask(task);
-      return false;
-    }
-    // 旧实现本就是 best-effort：确定性拒绝不能把已创建、首条已接受的任务永久
-    // 锁死。只有系统能自行恢复的传输错误才保留既有 creation task 作为屏障。
-    if (!isAutoRecoveringRemoteError(error)) return true;
-    task.status = 'restoring-plan';
-    task.error = formatRemoteError(error);
-    emit();
-    return false;
-  }
-}
-
-function finishAfterLegacyPlanRestore(task: InternalTask): void {
-  if (tasks.get(task.sessionId) !== task || !isTaskOwnerCurrent(task)) return;
-  remoteSessionStore.applySessionPatch(task.deviceId, task.sessionId, {
-    pendingLocalCreation: false,
-  });
-  finishTask(task);
-}
-
-/** 重试已接受首条消息后的旧协议 Plan 恢复，不重跑创建或 enqueue。 */
-export function retryNewSessionLegacyPlanRestore(sessionId: string): void {
-  const task = tasks.get(sessionId);
-  if (!task || task.status !== 'restoring-plan') return;
-  if (!isTaskOwnerCurrent(task)) {
-    cancelStaleOwnerTask(task);
-    return;
-  }
-  task.status = 'running';
-  task.error = null;
-  emit();
-  void restoreLegacyPlanAfterFirstMessage(task).then((restored) => {
-    if (restored) finishAfterLegacyPlanRestore(task);
-  });
 }
 
 function exactSessionFromProbe(value: unknown, sessionId: string): RemoteSession | null {
@@ -1023,14 +940,10 @@ async function runPipeline(task: InternalTask): Promise<void> {
       // 排到首条前面,违背「首条消息发出后即可继续发送」语义(codex review P2)。
       // 解禁统一在 enqueue 落定后:成功路径 finishTask 前清标 / enqueue-failed 在
       // failTask 内清标。
-      remoteSessionStore.upsertDeviceSession(
-        params.deviceId,
-        params.deviceName,
-        sessionWhileFirstMessagePending({
-          ...freshSession,
-          pendingLocalCreation: true,
-        }, params.legacyPlanRestore),
-      );
+      remoteSessionStore.upsertDeviceSession(params.deviceId, params.deviceName, {
+        ...freshSession,
+        pendingLocalCreation: true,
+      });
     } catch (error) {
       if (isStaleNewSessionOwnerError(error)) throw error;
       freshSession = null;
@@ -1067,11 +980,7 @@ async function runPipeline(task: InternalTask): Promise<void> {
     // 已按 started 后目录修正)——任一发生都必须回写,否则 UI/后续发送仍用
     // 已删除来源。
     if (!freshSession && (draftPatch !== null || effectiveFinalDraft !== finalDraft)) {
-      remoteSessionStore.upsertDeviceSession(
-        params.deviceId,
-        params.deviceName,
-        sessionWhileFirstMessagePending(sessionForQueue, params.legacyPlanRestore),
-      );
+      remoteSessionStore.upsertDeviceSession(params.deviceId, params.deviceName, sessionForQueue);
     }
     const queuedDraft = attachFirstMessageSessionReferences(buildQueuedTextMessage(
       sessionForQueue,
@@ -1142,11 +1051,23 @@ async function runPipeline(task: InternalTask): Promise<void> {
       // 已应用:回执丢失,按成功收敛(权威 projection 由 push / 会话页同步补齐)。
     }
 
-    if (!await restoreLegacyPlanAfterFirstMessage(task)) return;
+    if (params.legacyPlanRestore) {
+      // 老协议 plan 一次性语义:入队后恢复底层权限档,best-effort(对齐原 create())。
+      assertTaskOwnerCurrent(task);
+      try {
+        await maker.setPermissionMode(sessionId, params.legacyPlanRestore);
+      } catch {
+        // best-effort
+      }
+      assertTaskOwnerCurrent(task);
+    }
 
-    // 首条已入队且旧协议权限恢复完成：清合成行禁发标并移除 task，随后会话页
-    // effect 才会放行 follow-up outbox 与完整 syncSession。
-    finishAfterLegacyPlanRestore(task);
+    // 收口前主动清合成行的 pendingLocalCreation 禁发标:正常情况下上面的 fresh
+    // getSession 已用权威行(无标)覆盖,但弱网下 getSession 可能失败,靠会话页
+    // load 兜底又可能再失败——首条消息已入队,禁发理由已消失,不能让标残留。
+    remoteSessionStore.applySessionPatch(params.deviceId, sessionId, { pendingLocalCreation: false });
+    // 完成:task 移除后会话页守卫解除,由会话页 effect 触发一轮完整 syncSession。
+    finishTask(task);
   } catch (err) {
     if (isStaleNewSessionOwnerError(err) || !isTaskOwnerCurrent(task)) {
       cancelStaleOwnerTask(task);

--- a/apps/mobile/src/session/sessionOutbox.ts
+++ b/apps/mobile/src/session/sessionOutbox.ts
@@ -124,6 +124,22 @@ export interface MobileOutboxItem {
    * store 拿到的已是恢复后的值,消息本身必须仍按发送时刻的档位派发。
    */
   permissionModeAtSend: string;
+  /**
+   * 老协议把一次性计划模式编码成 permissionMode='plan'。消息真正 enqueue 前必须
+   * 保持远端会话为 plan；确认 enqueue 后再恢复到此档位。null = 新协议或本条
+   * 不需要兼容恢复。
+   */
+  legacyPlanRestore: string | null;
+  /**
+   * 本条发送时最近一次手动武装旧协议 Plan 的本地代次。恢复阶段用它识别用户在
+   * 发送后重新武装的新意图，避免旧消息的收尾把新 Plan 误熄灭。
+   */
+  legacyPlanArmEpochAtSend: number;
+  /**
+   * true = 原消息已被接受或已由用户取消，只保留旧协议权限恢复动作。
+   * 恢复屏障不再 enqueue、显示成气泡或在页面离场时回填草稿。
+   */
+  restoreOnly: boolean;
   /** 附件槽位(按用户可见顺序);null = 对应上传任务尚未落定。 */
   attachmentSlots: ReadonlyArray<RemoteSerializedAttachment | null>;
   /**
@@ -201,6 +217,9 @@ export function buildOutboxItem(input: {
   pastedTextRanges?: Array<{ start: number; end: number; display: string }>;
   slashCommandRanges?: Array<{ start: number; end: number }>;
   permissionModeAtSend: string;
+  legacyPlanRestore?: string | null;
+  legacyPlanArmEpochAtSend?: number;
+  restoreOnly?: boolean;
   /** 发送时刻已就绪的附件(占前段槽位)。 */
   readyAttachments: readonly RemoteSerializedAttachment[];
   /** 就绪附件的本地预览 uri(与 readyAttachments 对齐;缺失传 null)。 */
@@ -241,6 +260,9 @@ export function buildOutboxItem(input: {
     pastedTextRanges: input.pastedTextRanges ?? [],
     slashCommandRanges: input.slashCommandRanges ?? [],
     permissionModeAtSend: input.permissionModeAtSend,
+    legacyPlanRestore: input.legacyPlanRestore ?? null,
+    legacyPlanArmEpochAtSend: input.legacyPlanArmEpochAtSend ?? 0,
+    restoreOnly: input.restoreOnly ?? false,
     attachmentSlots: slots,
     slotMeta,
     slotByLocalId,

--- a/apps/mobile/src/session/sessionOutbox.ts
+++ b/apps/mobile/src/session/sessionOutbox.ts
@@ -15,6 +15,11 @@
  *
  * 本模块只做纯数据变换(node 可单测);上传路由、enqueue RPC、React state 接线
  * 在 [sessionId].tsx。
+ *
+ * 生命周期与 Desktop 的 device-link renderer outbox 对齐：队列只在当前客户端进程内
+ * 自动重连续发，不承诺 App 重启后恢复。正常切任务 / 退屏由页面 cleanup 把尚未派发的
+ * 正文接回草稿；若未来要跨进程恢复，必须单独设计可对账的持久 outbox，不能把草稿库
+ * 当 write-ahead log（它没有消息边界、附件任务或远端 acceptance 状态）。
  */
 import { i18n } from '@/i18n';
 import type { MobileSessionReference } from '@/session/sessionReferences';

--- a/apps/mobile/src/session/sessionOutbox.ts
+++ b/apps/mobile/src/session/sessionOutbox.ts
@@ -16,10 +16,12 @@
  * 本模块只做纯数据变换(node 可单测);上传路由、enqueue RPC、React state 接线
  * 在 [sessionId].tsx。
  *
- * 生命周期与 Desktop 的 device-link renderer outbox 对齐：队列只在当前客户端进程内
- * 自动重连续发，不承诺 App 重启后恢复。正常切任务 / 退屏由页面 cleanup 把尚未派发的
- * 正文接回草稿；若未来要跨进程恢复，必须单独设计可对账的持久 outbox，不能把草稿库
- * 当 write-ahead log（它没有消息边界、附件任务或远端 acceptance 状态）。
+ * 生命周期边界：队列只拥有尚未开始 enqueue、或能证明请求尚未发出的条目，并在当前
+ * 会话页存活期间自动重连续发。正常切任务 / 退屏由页面 cleanup 把这些正文接回草稿；
+ * 一旦 enqueue 已开始，所有权转给既有在线发送 / optimistic projection 路径，回执不确定
+ * 的写请求绝不重新降级成会丢 clientId 的草稿。若未来要跨页面或跨进程继续自动重试，
+ * 必须单独设计可对账的 outbox owner，不能把草稿库当 write-ahead log（它没有消息边界、
+ * 附件任务或远端 acceptance 状态）。
  */
 import { i18n } from '@/i18n';
 import type { MobileSessionReference } from '@/session/sessionReferences';

--- a/apps/mobile/src/session/sessionOutbox.ts
+++ b/apps/mobile/src/session/sessionOutbox.ts
@@ -19,6 +19,7 @@
 import { i18n } from '@/i18n';
 import type { MobileSessionReference } from '@/session/sessionReferences';
 import type { RemoteSerializedAttachment } from '@/session/types';
+import { isInFlightDeviceLinkError } from '@cindy/device-link';
 import type { AgentInputReference } from '@cindy/maker-shared/agent-input-projection';
 import {
   composerDocumentFromSerializedMessage,
@@ -38,6 +39,53 @@ export function createOutboxClientId(): string {
   const cryptoWithUuid = globalThis.crypto as Crypto | undefined;
   if (typeof cryptoWithUuid?.randomUUID === 'function') return cryptoWithUuid.randomUUID();
   return `mobile-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export interface MobileOutboxConnectionState {
+  relayOnline: boolean;
+  /** null = 尚未拿到当前目标设备的 presence，不据未知状态阻塞。 */
+  targetAvailable: boolean | null;
+  deviceUnresponsive: boolean;
+  /** 请求级错误已被判定为断线 / 弱网 / 超时等自动恢复类错误。 */
+  autoRecoveringError: boolean;
+  /** 恢复同步开始时会先清旧 error；同步落定前仍不能据此提前派发。 */
+  syncInProgress: boolean;
+}
+
+/**
+ * 连接恢复期间 outbox 只收消息、不向被控端派发；任一恢复信号转好后由页面重新 pump。
+ */
+export function shouldHoldOutboxDispatchForConnection(
+  state: MobileOutboxConnectionState,
+): boolean {
+  return !state.relayOnline
+    || state.targetAvailable === false
+    || state.deviceUnresponsive
+    || state.autoRecoveringError
+    || state.syncInProgress;
+}
+
+/**
+ * enqueue 只有在能证明请求尚未交给被控端时才可自动回 outbox。
+ * in-flight 断线与 INVOKE_TIMEOUT 都可能是「已执行、回执丢失」，必须排除。
+ */
+export function isSafelyUnsentOutboxEnqueueError(error: unknown): boolean {
+  if (isInFlightDeviceLinkError(error)) return false;
+  const code = (error as { code?: unknown } | null)?.code;
+  if (
+    code === 'NOT_CONNECTED'
+    || code === 'BACKPRESSURE'
+    || code === 'LINK_NOT_OPEN'
+    || code === 'DEVICE_OFFLINE'
+    || code === 'DEVICE_UNRESPONSIVE'
+  ) return true;
+  const message = error instanceof Error ? error.message : typeof error === 'string' ? error : '';
+  return message.includes('[NOT_CONNECTED]')
+    || message.includes('[DEVICE_LINK_NOT_CONNECTED]')
+    || message.includes('[BACKPRESSURE]')
+    || message.includes('[LINK_NOT_OPEN]')
+    || message.includes('[DEVICE_OFFLINE]')
+    || message.includes('[DEVICE_UNRESPONSIVE]');
 }
 
 export type MobileOutboxPhase =
@@ -330,6 +378,11 @@ export function outboxItemRetrying(item: MobileOutboxItem): MobileOutboxItem {
     enqueueError: null,
     phase: 'uploading',
   };
+}
+
+/** 派发途中撞上断线：回到可派发态留在队首，等连接恢复，不显示失败操作。 */
+export function outboxItemWaitingForConnection(item: MobileOutboxItem): MobileOutboxItem {
+  return { ...item, enqueueError: null, phase: 'uploading' };
 }
 
 /** enqueue RPC 失败:条目回队首失败态(附件都在,重试只需重新派发)。 */

--- a/apps/mobile/src/session/sessionOutbox.ts
+++ b/apps/mobile/src/session/sessionOutbox.ts
@@ -124,22 +124,6 @@ export interface MobileOutboxItem {
    * store 拿到的已是恢复后的值,消息本身必须仍按发送时刻的档位派发。
    */
   permissionModeAtSend: string;
-  /**
-   * 老协议把一次性计划模式编码成 permissionMode='plan'。消息真正 enqueue 前必须
-   * 保持远端会话为 plan；确认 enqueue 后再恢复到此档位。null = 新协议或本条
-   * 不需要兼容恢复。
-   */
-  legacyPlanRestore: string | null;
-  /**
-   * 本条发送时最近一次手动武装旧协议 Plan 的本地代次。恢复阶段用它识别用户在
-   * 发送后重新武装的新意图，避免旧消息的收尾把新 Plan 误熄灭。
-   */
-  legacyPlanArmEpochAtSend: number;
-  /**
-   * true = 原消息已被接受或已由用户取消，只保留旧协议权限恢复动作。
-   * 恢复屏障不再 enqueue、显示成气泡或在页面离场时回填草稿。
-   */
-  restoreOnly: boolean;
   /** 附件槽位(按用户可见顺序);null = 对应上传任务尚未落定。 */
   attachmentSlots: ReadonlyArray<RemoteSerializedAttachment | null>;
   /**
@@ -217,9 +201,6 @@ export function buildOutboxItem(input: {
   pastedTextRanges?: Array<{ start: number; end: number; display: string }>;
   slashCommandRanges?: Array<{ start: number; end: number }>;
   permissionModeAtSend: string;
-  legacyPlanRestore?: string | null;
-  legacyPlanArmEpochAtSend?: number;
-  restoreOnly?: boolean;
   /** 发送时刻已就绪的附件(占前段槽位)。 */
   readyAttachments: readonly RemoteSerializedAttachment[];
   /** 就绪附件的本地预览 uri(与 readyAttachments 对齐;缺失传 null)。 */
@@ -260,9 +241,6 @@ export function buildOutboxItem(input: {
     pastedTextRanges: input.pastedTextRanges ?? [],
     slashCommandRanges: input.slashCommandRanges ?? [],
     permissionModeAtSend: input.permissionModeAtSend,
-    legacyPlanRestore: input.legacyPlanRestore ?? null,
-    legacyPlanArmEpochAtSend: input.legacyPlanArmEpochAtSend ?? 0,
-    restoreOnly: input.restoreOnly ?? false,
     attachmentSlots: slots,
     slotMeta,
     slotByLocalId,


### PR DESCRIPTION
## 这次改了什么

### 摘要

手机版在电脑暂时离线、relay 断线、弱网或设备熔断时，不再把连接恢复职责交给用户：自动恢复状态隐藏“同步”按钮，输入框与发送保持可用；在远端写请求开始前已知需要等待的普通消息进入当前会话页的本地 FIFO outbox，连接恢复后自动派发。

需要实时访问电脑的操作与 Desktop 对齐：模型、来源、effort、Fast、权限、计划模式和停止任务在断线时禁用；停止按钮仍保持可见，只禁用交互。旧协议一次性 Plan 不进入本地 outbox，继续走原有在线兼容路径，避免为它新增跨页面恢复机制。

### 变更类型

- [ ] feat 新功能
- [x] fix 缺陷修复
- [ ] refactor / perf 重构或性能优化
- [ ] docs / test / chore 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Dash 本次手机版断线体验反馈
- 本 PR 包含：
  - 自动恢复类连接状态不再显示手动同步入口
  - composer 断线可编辑、可发送；远端写请求开始前已知需要等待的普通消息进入当前会话页的本地 FIFO outbox
  - 连接、presence 或 connection epoch 恢复后自动唤醒派发
  - session 切换、附件上传、任务引用准备及安全未发送重试的草稿与归属保护
  - 已开始 enqueue 但回执不确定的写请求保留原 optimistic projection / clientId，等待后续权威同步，不转回页面 outbox 或无 clientId 草稿
  - 模型、来源、effort、Fast、权限、计划模式和停止任务在断线时禁用；Stop 保持可见
  - 删除本 PR 后续长出的旧协议 Plan 隐藏恢复屏障与恢复任务，收敛回在线兼容路径
- 明确不包含：Desktop、服务端、wire protocol、device-link relay/link 生命周期、跨页面或跨 App 重启的 outbox owner / 持久 outbox、原生配置改动
- 用户可见变化：普通断线时没有“同步”按钮；输入框与发送不再置灰；普通待发消息在恢复后自动送出；实时远程控制置灰；旧协议 Plan 在断线或已有本地积压时保留原草稿、等待在线后重试
- 是否存在 breaking change：无

### 多端与远程适配

- SSH 远程工作区：不改变 workdir、agent 进程或 SSH 文件访问路径，继续使用既有远程通道。
- IPC / 推送白名单：未新增或修改 channel、push topic、allowlist 或 wire protocol。
- 手机版：本 PR 一并完成连接提示、composer、outbox 与实时控制交互适配。
- 故障半径：只暂停当前手机版会话的本地 outbox 派发；不 teardown peer link、不重启共享 relay，也不改变其他 peer 的连接状态。

### 状态模型 / 不变量

一句话不变量：页面 outbox 只拥有尚未开始 enqueue、或能证明请求尚未发出的消息；一旦远端写请求开始，所有权不会回流到页面 outbox。

唯一 owner：

- composer draft：可编辑、尚未写入，或已明确失败并可安全还原的内容。
- page outbox：当前会话页内，写请求开始前已知要等待，或能证明尚未发出的 FIFO 条目。
- optimistic projection / 既有在线发送路径：已开始 enqueue 且 acceptance / 回执不确定的原 clientId。
- Desktop：按 clientId 接受、去重并形成权威 projection 后的远端 owner。

事件 × 状态：

| 事件 | 归属与处理 |
| --- | --- |
| 写请求开始前已知断线、已有 FIFO 或引用准备暂时失败 | 进入 page outbox，保留原 clientId，当前页恢复连接后按 FIFO 派发 |
| enqueue 明确证明未发出 | 当前页存活时以同一 clientId 等待重试；离场时可安全恢复为草稿 |
| enqueue 已开始但 acceptance / 回执不确定 | 不进入 outbox、不恢复成无 clientId 草稿；保留原 optimistic projection / clientId，等待权威同步收敛 |
| 权威 projection 已包含 clientId | Desktop 拥有该消息，Mobile 不回滚、不重投 |

对称性与判据：

- 新消息与 outbox 派发共用同一写入边界；在线直发一旦开始 enqueue，不再转换为 page outbox。
- `isSafelyUnsentOutboxEnqueueError` 是唯一写侧回队判据；`isAutoRecoveringRemoteError` 仅用于连接提示、只读准备与同步恢复，不作为写请求重投依据。
- 正常切任务 / 退屏只回收尚未写入或明确未发出的 page outbox 条目；回执不确定的写请求绝不降级成会生成新 clientId 的草稿。
- 区分性测试固定：timeout / in-flight 等 acceptance-unknown 错误不能回流 outbox，在线直发收口范围内不存在 `buildOutboxItem` / `salvageOutboxItem` / `updateOutbox` 转换。
- 输入与发送能力独立于实时控制能力；断线只禁用必须即时访问电脑的操作。
- 旧协议 Plan 依赖会话级 permissionMode，不进入本 PR 的本地 outbox；已知断线或已有积压时在乐观清空前拦住并保留原草稿。
- 跨页面或跨进程自动重试需要另行设计可对账的 owner / WAL，明确不在本 PR 范围内。

恢复同步屏障：

- 不变量：relay、当前设备 presence、connection epoch 或熔断状态一旦使派发失效，page outbox 必须保持锁存，直到同一恢复身份下的 session + input projection 权威同步完整成功；旧连接代的迟到读取、瞬态失败和确定性失败都无权解锁。
- 唯一 owner：既有 `outboxTransportHold` 负责锁存；`DeviceLinkContext.getPresenceAvailability(deviceId)` 是唯一 presence 真源；既有 sync coordinator 的 context generation 负责淘汰旧恢复身份读取。没有新增恢复状态机。

| 恢复事件 | 屏障处理 |
| --- | --- |
| relay offline、presence=false、设备熔断或自动恢复类错误 | 立即锁存，输入与发送继续进入 page outbox，实时远程控制禁用 |
| connection epoch / presence 恢复 | 当前 render 先挡派发，再启动新恢复身份的权威同步 |
| 当前恢复身份同步成功 | session 与 projection 都提交后，由同步成功尾唯一解锁并唤醒 FIFO |
| 同步瞬态或确定性失败 | 保持锁存；瞬态错误自动退避重试，确定性错误保留手动同步处置 |
| 旧恢复身份读取迟到 | coordinator 判 stale，不提交 session / projection，也不解锁 |

- 区分性测试固定：sync identity 必须包含 device、session、connection epoch、relay status、Context presence 与 breaker；断线前启动的 sync 即使在新 hold 后返回，也必须因 stale 无权清门。

### UI 变化

- 引用的设计规范：
  - docs/design-rules/DESIGN.md §4 Component Stylings / Inputs & Forms：复用既有 composer、状态条与按钮组件。
  - docs/design-rules/DESIGN.md §10 Light / Dark Dual-Mode Delivery Gate：没有新增颜色或单主题分支，继续使用语义 token 与 themed styles。
  - docs/design-rules/DESIGN.md §14 Interaction Conventions：输入、发送和实时控制使用分层可用性判据，Stop 保持位置稳定并以 disabled 表达断线状态。

## 怎么验证的

### 自动验证

    pnpm test:unit
    结果：通过

    pnpm --filter mobile exec vitest run src/__tests__/optimisticSessionComposer.test.ts src/__tests__/sessionOutbox.test.ts src/__tests__/sessionMainLayerDesktopFirst.test.ts
    结果：通过（3 files，58 tests）

    pnpm check:i18n && pnpm check:i18n-glossary
    结果：通过；rebase 后直接复用 origin/main 已合入的 3 个 zh-TW 文案键，本 PR 不再携带重复 Desktop i18n diff

    pnpm --filter desktop run --if-present typecheck
    结果：通过

    pnpm --filter mobile run --if-present typecheck
    结果：通过

    pnpm --filter mobile test:scope
    结果：通过（mobile-scope-guard passed）

    git diff --check origin/main..HEAD
    结果：通过

    pnpm check:dco
    结果：通过

### 手工验证

不涉及：本轮未启动 Mobile 模拟器或真机。

### 未执行的验证

- 未执行 Light / Dark 实机目检；本次未新增样式或颜色，复用现有 themed 组件，但不将其表述为已完成双模式目检。
- 未实跑 Maestro visual_session_offline.yaml；自动化单测与源码接线断言覆盖本次断线发送、控制禁用及无同步按钮行为。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [x] 其他：Mobile 断线竞态、本地 outbox 与旧协议一次性 Plan 的在线兼容边界

### 影响与回滚

- 影响范围：仅 apps/mobile 的远程会话连接提示、composer、页面内发送 outbox、旧协议 Plan 边界与实时控制门禁；不改变原生 runtime fingerprint、协议或服务端。
- 生命周期边界：本地 outbox 是当前会话页状态；切换任务、退屏或系统在重连前终止 App 时，不保证继续自动派发 page outbox。已开始 enqueue 的回执不确定消息不归 page outbox，也不会被恢复成新 clientId 草稿。
- 回滚 / 降级方式：回滚本 PR 即恢复原有断线禁发与手动同步行为；没有数据 migration 或持久化 schema 需要处理。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（git commit -s，见 DCO）
- [x] UI 改动已在“UI 变化”注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因
