### PR TITLE
feat(desktop): 审查面板支持 device-link 远程会话只读查看

### DIFF
--- a/apps/desktop/src/main/bootstrap-electron.ts
+++ b/apps/desktop/src/main/bootstrap-electron.ts
@@ -390,7 +390,7 @@ import {
 import { reconcileSavepointRefsForDeletedSessions } from './git-snapshot/savepointCleanup';
 // session-git-pr-context: 会话分支感知 + PR 关联状态 IPC
 import { registerGitContextIpc, disposeGitContext } from './git-context';
-import { registerGitReviewIpc } from './git-review';
+import { registerGitReviewDeviceOp, registerGitReviewIpc } from './git-review';
 import { registerSidebarSettingsIpc } from './sidebarSettingsStore';
 import { registerRemotePrecreatedWorktreeLedgerIpc } from './remotePrecreatedWorktreeLedger';
 import { registerTerminalHandlers } from './maker-ipc/terminal-handlers';
@@ -6718,6 +6718,9 @@ app.on('ready', async () => {
       }
     },
   });
+  // device-link 远程 git 审查(只读):git-review:remote-op handler(被控端角色;
+  // invoke-registry 捕获后供控制端隧道调用,本机 renderer 不调用)。
+  registerGitReviewDeviceOp();
   registerSidebarSettingsIpc();
   registerRemotePrecreatedWorktreeLedgerIpc();
   // RSB terminal tab: PTY backend + 8 个 terminal:* IPC channels(create/write/resize/dispose/restart

--- a/apps/desktop/src/main/git-review/__tests__/deviceOp.test.ts
+++ b/apps/desktop/src/main/git-review/__tests__/deviceOp.test.ts
@@ -1,0 +1,136 @@
+/**
+ * git-review device-op 单测:device-link 远程审查(只读)的被控端执行层。
+ * 覆盖——
+ *   1. op 白名单:未知 op 与写 op(stage / commit / push / open-file)确定性拒绝,
+ *      不进 dispatch(只读契约是安全边界,必须有回归)
+ *   2. 只读 op 路由:payload 经真实 parse* 校验后到达对应 readReview*;
+ *      非法 pathspec 被 parseFileDiffPayload 拦下([INVALID_PARAMS] 原样上抛)
+ *   3. 响应编码:小结果明文;大可压缩结果 gzip(resultGz 回读一致);
+ *      gzip 后仍超预算 → 结构化 OVERSIZE(不裸炸帧限)
+ */
+
+import { randomBytes } from 'node:crypto';
+import { gunzipSync } from 'node:zlib';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readReviewDataMock = vi.fn();
+const readReviewSummaryMock = vi.fn();
+const readReviewCommitsMock = vi.fn();
+const readReviewCommitDiffMock = vi.fn();
+const readReviewBranchDiffMock = vi.fn();
+const readReviewFileDiffMock = vi.fn();
+const readReviewImagePreviewMock = vi.fn();
+const readReviewMarkdownPreviewMock = vi.fn();
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  shell: { openPath: vi.fn() },
+}));
+
+vi.mock('../ipc.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../ipc.js')>();
+  return {
+    ...actual,
+    readReviewData: (...args: unknown[]) => readReviewDataMock(...args),
+    readReviewSummary: (...args: unknown[]) => readReviewSummaryMock(...args),
+    readReviewCommits: (...args: unknown[]) => readReviewCommitsMock(...args),
+    readReviewCommitDiff: (...args: unknown[]) => readReviewCommitDiffMock(...args),
+    readReviewBranchDiff: (...args: unknown[]) => readReviewBranchDiffMock(...args),
+    readReviewFileDiff: (...args: unknown[]) => readReviewFileDiffMock(...args),
+    readReviewImagePreview: (...args: unknown[]) => readReviewImagePreviewMock(...args),
+    readReviewMarkdownPreview: (...args: unknown[]) => readReviewMarkdownPreviewMock(...args),
+  };
+});
+
+import { __gitReviewDeviceOpTesting } from '../device-op.js';
+
+const { handleRemoteOp, GIT_REVIEW_MAX_JSON_BYTES } = __gitReviewDeviceOpTesting;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('git-review device-op', () => {
+  it('rejects invalid args deterministically', async () => {
+    expect(await handleRemoteOp(undefined as never)).toEqual({ ok: false, message: 'invalid remote-op args' });
+    expect(await handleRemoteOp({ payload: {} } as never)).toEqual({ ok: false, message: 'invalid remote-op args' });
+  });
+
+  it('rejects unknown and write ops without dispatching (read-only contract)', async () => {
+    for (const op of ['nope', 'stage-file', 'unstage-file', 'discard-file', 'stage-hunk', 'commit', 'push', 'open-file']) {
+      expect(await handleRemoteOp({ op, payload: { sessionId: 's1' } })).toEqual({
+        ok: false,
+        message: `unknown op: ${op}`,
+      });
+    }
+    expect(readReviewDataMock).not.toHaveBeenCalled();
+    expect(readReviewFileDiffMock).not.toHaveBeenCalled();
+  });
+
+  it('routes get with parsed diff options', async () => {
+    readReviewDataMock.mockResolvedValue({ scope: { sessionId: 's1' } });
+    const res = await handleRemoteOp({ op: 'get', payload: { sessionId: 's1', ignoreWhitespace: true } });
+    expect(readReviewDataMock).toHaveBeenCalledWith('s1', { ignoreWhitespace: true });
+    expect(res).toEqual({ ok: true, result: { scope: { sessionId: 's1' } } });
+  });
+
+  it('routes summary / commits / commit-diff / branch-diff / file-diff / previews', async () => {
+    readReviewSummaryMock.mockResolvedValue({ dirty: false });
+    readReviewCommitsMock.mockResolvedValue({ commits: [] });
+    readReviewCommitDiffMock.mockResolvedValue({ diffs: [] });
+    readReviewBranchDiffMock.mockResolvedValue({ diffs: [] });
+    readReviewFileDiffMock.mockResolvedValue({ diff: null });
+
+    await handleRemoteOp({ op: 'summary', payload: { sessionId: 's1' } });
+    expect(readReviewSummaryMock).toHaveBeenCalledWith('s1');
+
+    await handleRemoteOp({ op: 'commits', payload: { sessionId: 's1', baseRef: 'origin/main' } });
+    expect(readReviewCommitsMock).toHaveBeenCalledWith('s1', 'origin/main');
+
+    const oid = 'a'.repeat(40);
+    await handleRemoteOp({ op: 'commit-diff', payload: { sessionId: 's1', oid } });
+    expect(readReviewCommitDiffMock).toHaveBeenCalledWith('s1', oid, { ignoreWhitespace: false });
+
+    await handleRemoteOp({ op: 'branch-diff', payload: { sessionId: 's1', baseRef: null } });
+    expect(readReviewBranchDiffMock).toHaveBeenCalledWith('s1', null, { ignoreWhitespace: false });
+
+    await handleRemoteOp({
+      op: 'file-diff',
+      payload: { sessionId: 's1', source: 'unstaged', path: 'src/a.ts' },
+    });
+    expect(readReviewFileDiffMock).toHaveBeenCalledWith('s1', expect.objectContaining({
+      source: 'unstaged',
+      path: 'src/a.ts',
+    }));
+  });
+
+  it('surfaces [INVALID_PARAMS] from real payload validation (unsafe pathspec)', async () => {
+    await expect(
+      handleRemoteOp({ op: 'file-diff', payload: { sessionId: 's1', source: 'unstaged', path: '../evil' } }),
+    ).rejects.toThrow(/INVALID_PARAMS/);
+    expect(readReviewFileDiffMock).not.toHaveBeenCalled();
+  });
+
+  it('summarizes untagged dispatch errors as structured {ok:false}', async () => {
+    readReviewDataMock.mockRejectedValue(new Error('boom'));
+    expect(await handleRemoteOp({ op: 'get', payload: { sessionId: 's1' } })).toEqual({ ok: false, message: 'boom' });
+  });
+
+  it('gzips large compressible results and round-trips through resultGz', async () => {
+    const result = { diff: 'context line\n'.repeat(300_000) }; // ~3.9MB JSON,高度可压缩
+    readReviewDataMock.mockResolvedValue(result);
+    const res = await handleRemoteOp({ op: 'get', payload: { sessionId: 's1' } });
+    expect(res.ok).toBe(true);
+    if (!('resultGz' in res)) throw new Error('expected resultGz encoding');
+    expect(res.resultGz.length).toBeLessThanOrEqual(GIT_REVIEW_MAX_JSON_BYTES);
+    const decoded = JSON.parse(gunzipSync(Buffer.from(res.resultGz, 'base64')).toString('utf8'));
+    expect(decoded).toEqual(result);
+  });
+
+  it('returns structured OVERSIZE when even gzip cannot fit the frame budget', async () => {
+    // 随机字节的 base64 不可压缩:gzip 后仍远超预算 → OVERSIZE。
+    readReviewDataMock.mockResolvedValue({ blob: randomBytes(2_500_000).toString('base64') });
+    expect(await handleRemoteOp({ op: 'get', payload: { sessionId: 's1' } })).toEqual({ ok: false, code: 'OVERSIZE' });
+  });
+});

--- a/apps/desktop/src/main/git-review/device-op.ts
+++ b/apps/desktop/src/main/git-review/device-op.ts
@@ -1,0 +1,174 @@
+/**
+ * device-op — device-link 远程 git 审查(只读)的被控端执行层。
+ *
+ * 控制端经隧道 `deviceLink.invoke(deviceId, 'git-review:remote-op', [args])`
+ * 到达这里(invoke-registry 捕获本文件注册的 ipcMain.handle;本机 renderer
+ * 不调用该 channel)。单聚合 channel 的取舍与 file-browser/device-op 一致:
+ * 老被控端 CHANNEL_NOT_ALLOWED = 能力全无,控制端渲染"设备版本过旧"占位。
+ *
+ * 安全:
+ *  - **只读**:仅暴露 status / diff / commit 列表 / 文件 diff / 图片与 Markdown
+ *    预览。写 op(stage / discard / commit / push)与 openFile(本机 shell 副作用)
+ *    一律不实现,未知 op 确定性回 `{ok:false}`。
+ *  - 入参只有 sessionId + 结构化查询字段(复用本机 IPC 的 parse* 校验),不接受
+ *    任何客户端路径:workdir 由被控端 resolveReviewScope 从自己的 session 记录
+ *    解析;SSH 远程会话由 scope 层返回 remote-session 禁用态(不二跳,对齐
+ *    本机审查面板现状)。
+ *
+ * oversize:响应序列化超 relay 帧限(MAX_FRAME_BYTES=2MiB)前主动预判——先
+ * gzip(diff 文本压缩率高),仍超回结构化 `{ ok:false, code:'OVERSIZE' }`,
+ * 绝不裸炸 FRAME_TOO_LARGE。新 channel 两端同代次,控制端恒可解 gzip,
+ * 不需要 file-browser 那样的 caps 探测。
+ */
+
+import { gzip as gzipCb } from 'node:zlib';
+import { promisify } from 'node:util';
+import { ipcMain } from 'electron';
+import { GIT_REVIEW_REMOTE_OP_CHANNEL } from '@cindy/device-link';
+
+import { createLogger } from '../logger.js';
+import {
+  parseBranchDiffPayload,
+  parseCommitDiffPayload,
+  parseCommitsPayload,
+  parseFileDiffPayload,
+  parseImagePreviewPayload,
+  parseMarkdownPreviewPayload,
+  parseReviewDataPayload,
+  parseSessionId,
+  readReviewBranchDiff,
+  readReviewCommitDiff,
+  readReviewCommits,
+  readReviewData,
+  readReviewFileDiff,
+  readReviewImagePreview,
+  readReviewMarkdownPreview,
+  readReviewSummary,
+} from './ipc.js';
+
+const log = createLogger('git-review/device-op');
+
+const gzipAsync = promisify(gzipCb);
+
+/**
+ * 响应的 device-link 上帧预算。量纲对齐 file-browser/device-op 的
+ * DEVICE_READ_MAX_JSON_BYTES:relay 单帧 MAX_FRAME_BYTES=2MiB 按 UTF-8 字节判,
+ * 用 JSON.stringify 后的字节数覆盖转义膨胀,再给 envelope 留余量。
+ */
+const GIT_REVIEW_MAX_JSON_BYTES = 1_800_000;
+
+export interface GitReviewRemoteOpArgs {
+  op: string;
+  /** 与本机 git-review IPC 同形的 payload(sessionId + 结构化查询字段)。 */
+  payload: unknown;
+}
+
+/** 成功响应:明文 result 或(超预算时)gzip+base64 的 resultGz,二者互斥。 */
+export type GitReviewRemoteOpResult =
+  | { ok: true; result: unknown }
+  | { ok: true; resultGz: string }
+  | { ok: false; code: 'OVERSIZE' }
+  | { ok: false; message: string };
+
+function bad(message: string): GitReviewRemoteOpResult {
+  return { ok: false, message };
+}
+
+/** 结果编码:明文不超预算 → 原样;超预算 → gzip;gzip 后仍超 → OVERSIZE。 */
+async function encodeResult(result: unknown): Promise<GitReviewRemoteOpResult> {
+  const json = JSON.stringify(result);
+  if (Buffer.byteLength(json, 'utf8') <= GIT_REVIEW_MAX_JSON_BYTES) {
+    return { ok: true, result };
+  }
+  // base64 纯 ASCII,字符数 = UTF-8 字节数,JSON 转义零膨胀。
+  const gzB64 = (await gzipAsync(Buffer.from(json, 'utf8'))).toString('base64');
+  if (gzB64.length <= GIT_REVIEW_MAX_JSON_BYTES) {
+    return { ok: true, resultGz: gzB64 };
+  }
+  return { ok: false, code: 'OVERSIZE' };
+}
+
+async function dispatchRemoteOp(op: string, payload: unknown): Promise<unknown> {
+  switch (op) {
+    case 'get': {
+      const { sessionId, options } = parseReviewDataPayload(payload);
+      return readReviewData(sessionId, options);
+    }
+    case 'summary':
+      return readReviewSummary(parseSessionId(payload));
+    case 'commits': {
+      const { sessionId, baseRef } = parseCommitsPayload(payload);
+      return readReviewCommits(sessionId, baseRef);
+    }
+    case 'commit-diff': {
+      const { sessionId, oid, options } = parseCommitDiffPayload(payload);
+      return readReviewCommitDiff(sessionId, oid, options);
+    }
+    case 'branch-diff': {
+      const { sessionId, baseRef, options } = parseBranchDiffPayload(payload);
+      return readReviewBranchDiff(sessionId, baseRef, options);
+    }
+    case 'file-diff': {
+      const { sessionId, request } = parseFileDiffPayload(payload);
+      return readReviewFileDiff(sessionId, request);
+    }
+    case 'image-preview': {
+      const { sessionId, request } = parseImagePreviewPayload(payload);
+      return readReviewImagePreview(sessionId, request);
+    }
+    case 'markdown-preview': {
+      const { sessionId, request } = parseMarkdownPreviewPayload(payload);
+      return readReviewMarkdownPreview(sessionId, request);
+    }
+    default:
+      return null;
+  }
+}
+
+const READ_OPS = new Set([
+  'get',
+  'summary',
+  'commits',
+  'commit-diff',
+  'branch-diff',
+  'file-diff',
+  'image-preview',
+  'markdown-preview',
+]);
+
+async function handleRemoteOp(args: GitReviewRemoteOpArgs): Promise<GitReviewRemoteOpResult> {
+  if (!args || typeof args.op !== 'string') {
+    return bad('invalid remote-op args');
+  }
+  if (!READ_OPS.has(args.op)) {
+    // 未知 / 写 op:确定性拒绝(而非 throw),供控制端做能力探测语义。
+    return bad(`unknown op: ${args.op}`);
+  }
+  try {
+    const result = await dispatchRemoteOp(args.op, args.payload);
+    return await encodeResult(result);
+  } catch (err) {
+    // 与本机 handler 同口径:带 [CODE] 标记的错误原样抛(经 invoke error 信封
+    // 到控制端 reject,extractIpcError 可解);其余摘要为结构化 message,
+    // 避免把内部堆栈带回控制端。
+    if (err instanceof Error && /\[(INVALID_PARAMS|PRECONDITION_FAILED)\]/.test(err.message)) throw err;
+    const message = err instanceof Error ? err.message : String(err);
+    log.warn('git-review remote-op failed', { op: args.op, message });
+    return bad(message);
+  }
+}
+
+/** 注册 remote-op handler。bootstrap 期调用一次(installInvokeCapture 之后)。 */
+export function registerGitReviewDeviceOp(): void {
+  ipcMain.handle(GIT_REVIEW_REMOTE_OP_CHANNEL, async (_event, args: GitReviewRemoteOpArgs) => {
+    return handleRemoteOp(args);
+  });
+  log.info('git-review device-op registered');
+}
+
+/** 单测入口:绕开 ipcMain 直接驱动分发。 */
+export const __gitReviewDeviceOpTesting = {
+  handleRemoteOp,
+  encodeResult,
+  GIT_REVIEW_MAX_JSON_BYTES,
+};

--- a/apps/desktop/src/main/git-review/index.ts
+++ b/apps/desktop/src/main/git-review/index.ts
@@ -1,4 +1,5 @@
 export { registerGitReviewIpc, GIT_REVIEW_INVOKE } from './ipc.js';
+export { registerGitReviewDeviceOp } from './device-op.js';
 export { runGit, GitRunError } from './gitRunner.js';
 export { resolveReviewScope } from './scopeResolver.js';
 export { readStatus, parsePorcelainV2Status } from './statusReader.js';

--- a/apps/desktop/src/main/git-review/ipc.ts
+++ b/apps/desktop/src/main/git-review/ipc.ts
@@ -425,7 +425,7 @@ export async function runReviewPush(
   }
 }
 
-function parseSessionId(payload: unknown): string {
+export function parseSessionId(payload: unknown): string {
   const obj = requireObject(payload);
   return requireString(obj.sessionId, 'sessionId');
 }
@@ -441,7 +441,7 @@ function readDiffOptions(obj: Record<string, unknown>): ReviewDiffReadOptions {
   return { ignoreWhitespace: readOptionalBoolean(obj, 'ignoreWhitespace') === true };
 }
 
-function parseReviewDataPayload(payload: unknown): { sessionId: string; options: ReviewDiffReadOptions } {
+export function parseReviewDataPayload(payload: unknown): { sessionId: string; options: ReviewDiffReadOptions } {
   const obj = requireObject(payload);
   return {
     sessionId: requireString(obj.sessionId, 'sessionId'),
@@ -460,7 +460,7 @@ export function parseCommitDiffPayload(payload: unknown): { sessionId: string; o
   };
 }
 
-function parseCommitsPayload(payload: unknown): { sessionId: string; baseRef: string | null } {
+export function parseCommitsPayload(payload: unknown): { sessionId: string; baseRef: string | null } {
   const obj = requireObject(payload);
   const rawBaseRef = typeof obj.baseRef === 'string' && obj.baseRef.trim() ? obj.baseRef.trim() : null;
   if (rawBaseRef && !isSafeBranchBaseRef(rawBaseRef)) {
@@ -472,7 +472,7 @@ function parseCommitsPayload(payload: unknown): { sessionId: string; baseRef: st
   };
 }
 
-function parseBranchDiffPayload(payload: unknown): { sessionId: string; baseRef: string | null; options: ReviewDiffReadOptions } {
+export function parseBranchDiffPayload(payload: unknown): { sessionId: string; baseRef: string | null; options: ReviewDiffReadOptions } {
   const obj = requireObject(payload);
   const rawBaseRef = typeof obj.baseRef === 'string' && obj.baseRef.trim() ? obj.baseRef.trim() : null;
   if (rawBaseRef && !isSafeBranchBaseRef(rawBaseRef)) {

--- a/apps/desktop/src/renderer/__tests__/gitReviewTransport.test.ts
+++ b/apps/desktop/src/renderer/__tests__/gitReviewTransport.test.ts
@@ -1,0 +1,90 @@
+/**
+ * gitReviewTransport 单测:git 审查的 device-link 透明传输层。
+ *  - deviceId 为空 → 原样返回本地 window.electronAPI.gitReview(零包装)。
+ *  - device 分支:op/payload 信封形状、明文 result 与 resultGz(gzip+base64)
+ *    解码回读、结构化 OVERSIZE → 带稳定标记的 reject(isReviewRemoteOversizeError
+ *    判真)、{ok:false,message} → 原样 reject。
+ * window.electronAPI 用 vi.stubGlobal 注入(node 环境,无 jsdom)。
+ */
+
+import { gzipSync } from 'node:zlib';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type InvokeMock = ReturnType<typeof vi.fn>;
+
+let invokeMock: InvokeMock;
+let localGitReview: Record<string, unknown>;
+let transport: typeof import('../lib/gitReviewTransport');
+
+beforeEach(async () => {
+  invokeMock = vi.fn();
+  localGitReview = { get: vi.fn(), summary: vi.fn() };
+  vi.stubGlobal('window', {
+    electronAPI: {
+      gitReview: localGitReview,
+      deviceLink: { invoke: invokeMock },
+    },
+  });
+  transport = await import('../lib/gitReviewTransport');
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('gitReviewApiFor', () => {
+  it('returns the local API untouched when deviceId is empty', () => {
+    expect(transport.gitReviewApiFor(null)).toBe(localGitReview);
+    expect(transport.gitReviewApiFor(undefined)).toBe(localGitReview);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('tunnels reads through git-review:remote-op with {op, payload} envelope', async () => {
+    invokeMock.mockResolvedValue({ ok: true, result: { scope: { sessionId: 's1' } } });
+    const api = transport.gitReviewApiFor('device-1');
+    const data = await api.get({ sessionId: 's1', ignoreWhitespace: true });
+    expect(data).toEqual({ scope: { sessionId: 's1' } });
+    expect(invokeMock).toHaveBeenCalledWith('device-1', 'git-review:remote-op', [
+      { op: 'get', payload: { sessionId: 's1', ignoreWhitespace: true } },
+    ]);
+  });
+
+  it('maps read methods to their op names', async () => {
+    invokeMock.mockResolvedValue({ ok: true, result: null });
+    const api = transport.gitReviewApiFor('device-1');
+    await api.summary({ sessionId: 's1' });
+    await api.commits({ sessionId: 's1', baseRef: null });
+    await api.commitDiff({ sessionId: 's1', oid: 'a'.repeat(40) });
+    await api.branchDiff({ sessionId: 's1' });
+    await api.fileDiff({ sessionId: 's1', source: 'unstaged', path: 'a.ts' });
+    const ops = invokeMock.mock.calls.map((call) => (call[2] as Array<{ op: string }>)[0].op);
+    expect(ops).toEqual(['summary', 'commits', 'commit-diff', 'branch-diff', 'file-diff']);
+  });
+
+  it('decodes resultGz (gzip+base64) transparently', async () => {
+    const result = { diffs: ['line'.repeat(10_000)] };
+    invokeMock.mockResolvedValue({
+      ok: true,
+      resultGz: gzipSync(Buffer.from(JSON.stringify(result), 'utf8')).toString('base64'),
+    });
+    const api = transport.gitReviewApiFor('device-1');
+    expect(await api.get({ sessionId: 's1' })).toEqual(result);
+  });
+
+  it('rejects OVERSIZE with a stable marker recognized by isReviewRemoteOversizeError', async () => {
+    invokeMock.mockResolvedValue({ ok: false, code: 'OVERSIZE' });
+    const api = transport.gitReviewApiFor('device-1');
+    const err = await api.get({ sessionId: 's1' }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(transport.isReviewRemoteOversizeError(err)).toBe(true);
+    expect(transport.isReviewRemoteOversizeError(new Error('other'))).toBe(false);
+  });
+
+  it('rejects structured {ok:false,message} with the original message', async () => {
+    invokeMock.mockResolvedValue({ ok: false, message: 'unknown op: get' });
+    const api = transport.gitReviewApiFor('device-1');
+    await expect(api.get({ sessionId: 's1' })).rejects.toThrow('unknown op: get');
+  });
+});

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
@@ -726,24 +726,36 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
     () => getGitApplyCopyAvailability(visibleDiffs, hideWhitespace, platform),
     [hideWhitespace, platform, visibleDiffs],
   );
+  /**
+   * device-link 预览请求只需 parsePreviewDiffPayload 读取的字段(source/id/path/oldPath/index);
+   * 全量 FileDiff(hunks/hunksPlain 等)经隧道传输浪费帧预算且从不被被控端读取。
+   * 本地调用仍传完整 diff 保持兼容。
+   */
+  const trimPreviewDiff = useCallback((diff: FileDiff): FileDiff => ({
+    source: diff.source,
+    id: diff.id,
+    path: diff.path,
+    oldPath: diff.oldPath,
+    index: diff.index,
+  } as FileDiff), []);
   const loadImagePreview = useCallback<LoadImagePreview>((diff) => {
     if (!sessionId) return Promise.reject(new Error('sessionId is required'));
     return gitReviewApiFor(deviceLinkDeviceId).imagePreview({
       sessionId,
-      diff,
+      diff: deviceLinkDeviceId ? trimPreviewDiff(diff) : diff,
       commitOid: diff.source === 'commit' ? effectiveCommitOid : null,
       branchBaseRef: diff.source === 'branch' ? currentBranchDiffData?.baseRef ?? branchBaseRef : null,
-    });
-  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId]);
+    } as Parameters<typeof window.electronAPI.gitReview.imagePreview>[0]);
+  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId, trimPreviewDiff]);
   const loadMarkdownPreview = useCallback<LoadMarkdownPreview>((diff) => {
     if (!sessionId) return Promise.reject(new Error('sessionId is required'));
     return gitReviewApiFor(deviceLinkDeviceId).markdownPreview({
       sessionId,
-      diff,
+      diff: deviceLinkDeviceId ? trimPreviewDiff(diff) : diff,
       commitOid: diff.source === 'commit' ? effectiveCommitOid : null,
       branchBaseRef: diff.source === 'branch' ? currentBranchDiffData?.baseRef ?? branchBaseRef : null,
-    });
-  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId]);
+    } as Parameters<typeof window.electronAPI.gitReview.markdownPreview>[0]);
+  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId, trimPreviewDiff]);
   const openReviewFile = useCallback((diff: FileDiff) => {
     if (!sessionId) return;
     void window.electronAPI.gitReview.openFile({ sessionId, path: diff.path })

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
@@ -57,7 +57,7 @@ import type {
   ReviewStageOperationSummary,
 } from '@/lib/gitReview.types';
 import { formatSidebarTime } from '@/features/cc-agent/lib/formatSidebarTime';
-import { isDeviceTooOldError } from '@/lib/fileBrowserTransport';
+
 import { gitReviewApiFor, isReviewRemoteOversizeError } from '@/lib/gitReviewTransport';
 import { makerChatStore } from '@/lib/makerChatStore';
 import type { TurnChangeSetDetail } from '../../../../../shared/turnChangeSet';
@@ -583,7 +583,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
   const sessionId = ctx.sessionId || null;
   const hideWhitespace = state.hideWhitespace ?? false;
   const branchBaseRef = state.branchBaseRef ?? null;
-  const { data, loading, error, refresh, setData: setReviewData } = useReviewGitState(sessionId, hideWhitespace, deviceLinkDeviceId);
+  const { data, loading, error, errorCode, refresh, setData: setReviewData } = useReviewGitState(sessionId, hideWhitespace, deviceLinkDeviceId);
   const commitsState = useReviewCommits(sessionId, branchBaseRef, deviceLinkDeviceId);
   const [pendingKey, setPendingKey] = useState<string | null>(null);
   const [operationError, setOperationError] = useState<string | null>(null);
@@ -1112,7 +1112,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
   if (error && !data) {
     // device-link 远程会话的两类确定性失败给专属占位:老被控端无 remote-op
     // channel(升级即解决,刷新无用),以及响应超设备互联帧预算。
-    if (deviceLinkDeviceId && isDeviceTooOldError(error)) {
+    if (deviceLinkDeviceId && errorCode === 'DEVICE_LINK_CHANNEL_NOT_ALLOWED') {
       return (
         <CenteredState
           icon={<AlertTriangle size={24} />}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
@@ -727,9 +727,9 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
     [hideWhitespace, platform, visibleDiffs],
   );
   /**
-   * device-link 预览请求只需 parsePreviewDiffPayload 读取的字段(source/id/path/oldPath/index);
-   * 全量 FileDiff(hunks/hunksPlain 等)经隧道传输浪费帧预算且从不被被控端读取。
-   * 本地调用仍传完整 diff 保持兼容。
+   * device-link 预览请求只发送被控端实际读取的轻量 diff 字段，裁剪 hunks / hunksPlain
+   * 等大字段以节省帧预算。markdownReader 额外读取 kind/size/status/isTooLarge/isBinary,
+   * imageReader 读取 kind。本地调用仍传完整 diff 保持兼容。
    */
   const trimPreviewDiff = useCallback((diff: FileDiff): FileDiff => ({
     source: diff.source,
@@ -737,6 +737,11 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
     path: diff.path,
     oldPath: diff.oldPath,
     index: diff.index,
+    kind: diff.kind,
+    size: diff.size,
+    status: diff.status,
+    isTooLarge: diff.isTooLarge,
+    isBinary: diff.isBinary,
   } as FileDiff), []);
   const loadImagePreview = useCallback<LoadImagePreview>((diff) => {
     if (!sessionId) return Promise.reject(new Error('sessionId is required'));

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
@@ -750,8 +750,11 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
       diff: deviceLinkDeviceId ? trimPreviewDiff(diff) : diff,
       commitOid: diff.source === 'commit' ? effectiveCommitOid : null,
       branchBaseRef: diff.source === 'branch' ? currentBranchDiffData?.baseRef ?? branchBaseRef : null,
-    } as Parameters<typeof window.electronAPI.gitReview.imagePreview>[0]);
-  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId, trimPreviewDiff]);
+    } as Parameters<typeof window.electronAPI.gitReview.imagePreview>[0]).catch((err) => {
+      if (isReviewRemoteOversizeError(err)) throw new Error(t('rightSidebar.review.remote.oversizeDesc'));
+      throw err;
+    });
+  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId, t, trimPreviewDiff]);
   const loadMarkdownPreview = useCallback<LoadMarkdownPreview>((diff) => {
     if (!sessionId) return Promise.reject(new Error('sessionId is required'));
     return gitReviewApiFor(deviceLinkDeviceId).markdownPreview({
@@ -759,8 +762,11 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
       diff: deviceLinkDeviceId ? trimPreviewDiff(diff) : diff,
       commitOid: diff.source === 'commit' ? effectiveCommitOid : null,
       branchBaseRef: diff.source === 'branch' ? currentBranchDiffData?.baseRef ?? branchBaseRef : null,
-    } as Parameters<typeof window.electronAPI.gitReview.markdownPreview>[0]);
-  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId, trimPreviewDiff]);
+    } as Parameters<typeof window.electronAPI.gitReview.markdownPreview>[0]).catch((err) => {
+      if (isReviewRemoteOversizeError(err)) throw new Error(t('rightSidebar.review.remote.oversizeDesc'));
+      throw err;
+    });
+  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId, t, trimPreviewDiff]);
   const openReviewFile = useCallback((diff: FileDiff) => {
     if (!sessionId) return;
     void window.electronAPI.gitReview.openFile({ sessionId, path: diff.path })

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
@@ -57,6 +57,8 @@ import type {
   ReviewStageOperationSummary,
 } from '@/lib/gitReview.types';
 import { formatSidebarTime } from '@/features/cc-agent/lib/formatSidebarTime';
+import { isDeviceTooOldError } from '@/lib/fileBrowserTransport';
+import { gitReviewApiFor, isReviewRemoteOversizeError } from '@/lib/gitReviewTransport';
 import { makerChatStore } from '@/lib/makerChatStore';
 import type { TurnChangeSetDetail } from '../../../../../shared/turnChangeSet';
 import { extractIpcError } from '@/utils/ipcError';
@@ -574,11 +576,15 @@ function TurnChangeSetReviewBody({ state, ctx, setSource, setSelectedCommitOid }
 function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, setSelectedCommitOid }: GitReviewBodyProps) {
   const { t } = useTranslation();
   const { confirm } = useConfirmDialog();
+  // device-link 远程会话:session 行在被控设备的 DB 里,只读查询经 gitReviewTransport
+  // 隧道到被控端执行(被控端以它自己的 session 记录解析 workdir);写操作与本机
+  // 文件打开在控制端禁用(readOnly 经 writeDisabledReasons 的 remote-device 档)。
+  const deviceLinkDeviceId = ctx.deviceLinkDeviceId ?? null;
   const sessionId = ctx.sessionId || null;
   const hideWhitespace = state.hideWhitespace ?? false;
   const branchBaseRef = state.branchBaseRef ?? null;
-  const { data, loading, error, refresh, setData: setReviewData } = useReviewGitState(sessionId, hideWhitespace);
-  const commitsState = useReviewCommits(sessionId, branchBaseRef);
+  const { data, loading, error, refresh, setData: setReviewData } = useReviewGitState(sessionId, hideWhitespace, deviceLinkDeviceId);
+  const commitsState = useReviewCommits(sessionId, branchBaseRef, deviceLinkDeviceId);
   const [pendingKey, setPendingKey] = useState<string | null>(null);
   const [operationError, setOperationError] = useState<string | null>(null);
   const [operationSummary, setOperationSummary] = useState<ReviewStageOperationSummary | null>(null);
@@ -612,8 +618,8 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
   const staged = useMemo(() => filterWhitespaceHiddenDiffs(rawStaged, hideWhitespace), [hideWhitespace, rawStaged]);
   const commits = commitsState.data?.commits ?? [];
   const effectiveCommitOid = source === 'commit' ? selectedCommitOid : null;
-  const commitDiffState = useReviewCommitDiff(sessionId, effectiveCommitOid, hideWhitespace);
-  const branchDiffState = useReviewBranchDiff(sessionId, branchBaseRef, hideWhitespace, source === 'branch');
+  const commitDiffState = useReviewCommitDiff(sessionId, effectiveCommitOid, hideWhitespace, deviceLinkDeviceId);
+  const branchDiffState = useReviewBranchDiff(sessionId, branchBaseRef, hideWhitespace, source === 'branch', deviceLinkDeviceId);
   const currentBranchDiffData = getCurrentBranchDiffData(branchDiffState.data, branchBaseRef);
   const availableLastTurnDiffs = useMemo(
     () => rawUnstaged.concat(rawStaged).filter((diff) => lastTurnPaths.has(diff.path)),
@@ -638,7 +644,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
       ignoreWhitespace: hideWhitespace,
     }));
   }, [hideWhitespace, lastTurnCapped, lastTurnCappedEntries, source]);
-  const lastTurnHydratedDiffState = useReviewFileDiffs(sessionId, lastTurnHydrationRequests);
+  const lastTurnHydratedDiffState = useReviewFileDiffs(sessionId, lastTurnHydrationRequests, deviceLinkDeviceId);
   const hydratedLastTurnDiffs = useMemo(
     () => lastTurnHydratedDiffState.data?.map((item) => item.diff).filter((diff): diff is FileDiff => diff !== null) ?? [],
     [lastTurnHydratedDiffState.data],
@@ -701,7 +707,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
     branchBaseRef: selectedCappedSummaryDiff.source === 'branch' ? currentBranchDiffData?.baseRef ?? branchBaseRef : null,
     ignoreWhitespace: hideWhitespace,
   } : null;
-  const cappedFileDiffState = useReviewFileDiff(sessionId, cappedFileDiffRequest, reviewWriteVersion);
+  const cappedFileDiffState = useReviewFileDiff(sessionId, cappedFileDiffRequest, reviewWriteVersion, deviceLinkDeviceId);
   const cappedFileDiffData = cappedFileDiffState.data;
   const maybeCappedLoadedDiff = cappedFileDiffData?.diff ?? null;
   const cappedLoadedDiff = maybeCappedLoadedDiff?.id === selectedCappedSummaryDiff?.id
@@ -722,22 +728,22 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
   );
   const loadImagePreview = useCallback<LoadImagePreview>((diff) => {
     if (!sessionId) return Promise.reject(new Error('sessionId is required'));
-    return window.electronAPI.gitReview.imagePreview({
+    return gitReviewApiFor(deviceLinkDeviceId).imagePreview({
       sessionId,
       diff,
       commitOid: diff.source === 'commit' ? effectiveCommitOid : null,
       branchBaseRef: diff.source === 'branch' ? currentBranchDiffData?.baseRef ?? branchBaseRef : null,
     });
-  }, [branchBaseRef, currentBranchDiffData?.baseRef, effectiveCommitOid, sessionId]);
+  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId]);
   const loadMarkdownPreview = useCallback<LoadMarkdownPreview>((diff) => {
     if (!sessionId) return Promise.reject(new Error('sessionId is required'));
-    return window.electronAPI.gitReview.markdownPreview({
+    return gitReviewApiFor(deviceLinkDeviceId).markdownPreview({
       sessionId,
       diff,
       commitOid: diff.source === 'commit' ? effectiveCommitOid : null,
       branchBaseRef: diff.source === 'branch' ? currentBranchDiffData?.baseRef ?? branchBaseRef : null,
     });
-  }, [branchBaseRef, currentBranchDiffData?.baseRef, effectiveCommitOid, sessionId]);
+  }, [branchBaseRef, currentBranchDiffData?.baseRef, deviceLinkDeviceId, effectiveCommitOid, sessionId]);
   const openReviewFile = useCallback((diff: FileDiff) => {
     if (!sessionId) return;
     void window.electronAPI.gitReview.openFile({ sessionId, path: diff.path })
@@ -746,12 +752,21 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
         toast.error(t('rightSidebar.review.openFileFailed', { error: message }));
       });
   }, [sessionId, t]);
+  // device-link 远程会话没有本机文件可打开:传 undefined 让「打开文件」入口整体不渲染。
+  const openFileHandler = deviceLinkDeviceId ? undefined : openReviewFile;
+  // 次级视图(提交 / 分支 / 单文件)错误串的 OVERSIZE 标记 → 可读文案;其余原样。
+  const localizeReviewError = useCallback(<T extends string | null>(message: T): T | string => {
+    if (message && isReviewRemoteOversizeError(message)) return t('rightSidebar.review.remote.oversizeDesc');
+    return message;
+  }, [t]);
   const writeDisabledReasons = data?.status?.writeDisabledReasons ?? [];
   const effectiveWriteDisabledReasons = useMemo(() => {
     const reasons = [...writeDisabledReasons];
+    // device-link 首期只读:被控端 handler 也不实现写 op,这里是同一契约的 UI 面。
+    if (deviceLinkDeviceId) reasons.push('remote-device');
     if (agentRunning) reasons.push('agent-running');
     return reasons;
-  }, [agentRunning, writeDisabledReasons]);
+  }, [agentRunning, deviceLinkDeviceId, writeDisabledReasons]);
   const canWrite = Boolean(data?.status && effectiveWriteDisabledReasons.length === 0 && !pendingKey);
   const commitOrPushPending = pendingKey === 'commit' || pendingKey === 'commit-push' || pendingKey === 'push';
   const pushPending = pendingKey === 'push' || pendingKey === 'commit-push';
@@ -1095,6 +1110,28 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
   }
 
   if (error && !data) {
+    // device-link 远程会话的两类确定性失败给专属占位:老被控端无 remote-op
+    // channel(升级即解决,刷新无用),以及响应超设备互联帧预算。
+    if (deviceLinkDeviceId && isDeviceTooOldError(error)) {
+      return (
+        <CenteredState
+          icon={<AlertTriangle size={24} />}
+          title={t('rightSidebar.review.remote.deviceTooOldTitle')}
+          desc={t('rightSidebar.review.remote.deviceTooOldDesc')}
+        />
+      );
+    }
+    if (deviceLinkDeviceId && isReviewRemoteOversizeError(error)) {
+      return (
+        <CenteredState
+          icon={<AlertTriangle size={24} />}
+          title={t('rightSidebar.review.remote.oversizeTitle')}
+          desc={t('rightSidebar.review.remote.oversizeDesc')}
+          actionLabel={t('rightSidebar.review.refresh')}
+          onAction={refresh}
+        />
+      );
+    }
     return <CenteredState icon={<AlertTriangle size={24} />} title={t('rightSidebar.review.errorTitle')} desc={error} actionLabel={t('rightSidebar.review.refresh')} onAction={refresh} />;
   }
 
@@ -1278,7 +1315,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           selectedSummaryDiff={selectedCappedSummaryDiff}
           loadedDiff={cappedLoadedDiff}
           loading={cappedFileDiffState.loading && !cappedLoadedDiff}
-          error={cappedFileDiffState.error}
+          error={localizeReviewError(cappedFileDiffState.error)}
           onSelectFile={selectCappedFile}
           onRefresh={refreshAll}
           refreshPending={reviewRefreshPending}
@@ -1303,7 +1340,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           loadImagePreview={loadImagePreview}
           loadMarkdownPreview={loadMarkdownPreview}
           richMarkdownPreview={richMarkdownPreview}
-          onOpenFile={openReviewFile}
+          onOpenFile={openFileHandler}
           writeAction={source === 'unstaged' ? {
             canWrite,
             pendingKey,
@@ -1335,7 +1372,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           diffs={commitDiffs}
           rawDiffCount={rawCommitDiffs.length}
           diffLoading={commitDiffState.loading && !selectedCommitDiff}
-          diffError={commitDiffState.error}
+          diffError={localizeReviewError(commitDiffState.error)}
           onRefreshDiff={commitDiffState.refresh}
           onRefresh={refreshAll}
           refreshPending={reviewRefreshPending}
@@ -1351,7 +1388,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           loadImagePreview={loadImagePreview}
           loadMarkdownPreview={loadMarkdownPreview}
           richMarkdownPreview={richMarkdownPreview}
-          onOpenFile={openReviewFile}
+          onOpenFile={openFileHandler}
         />
       ) : source === 'branch' ? (
         <BranchSourceView
@@ -1361,7 +1398,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           diffs={branchDiffs}
           rawDiffCount={rawBranchDiffs.length}
           diffLoading={branchDiffState.loading && !currentBranchDiffData}
-          diffError={branchDiffState.error}
+          diffError={localizeReviewError(branchDiffState.error)}
           onSelectBase={setBranchBaseRef}
           onRefreshDiff={branchDiffState.refresh}
           onRefresh={refreshAll}
@@ -1378,7 +1415,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           loadImagePreview={loadImagePreview}
           loadMarkdownPreview={loadMarkdownPreview}
           richMarkdownPreview={richMarkdownPreview}
-          onOpenFile={openReviewFile}
+          onOpenFile={openFileHandler}
         />
       ) : source === 'staged' ? (
         <StagedSourceView
@@ -1404,7 +1441,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           loadImagePreview={loadImagePreview}
           loadMarkdownPreview={loadMarkdownPreview}
           richMarkdownPreview={richMarkdownPreview}
-          onOpenFile={openReviewFile}
+          onOpenFile={openFileHandler}
           hunkActionsEnabled={canUsePatchBasedReviewActions(hideWhitespace)}
         />
       ) : source === 'last-turn' && lastTurnHydrating ? (
@@ -1417,7 +1454,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
         <CenteredState
           icon={<AlertTriangle size={24} />}
           title={t('rightSidebar.review.errorTitle')}
-          desc={lastTurnHydrationError}
+          desc={localizeReviewError(lastTurnHydrationError)}
           actionLabel={t('rightSidebar.review.refresh')}
           onAction={refreshAll}
         />
@@ -1450,7 +1487,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
           loadImagePreview={loadImagePreview}
           loadMarkdownPreview={loadMarkdownPreview}
           richMarkdownPreview={richMarkdownPreview}
-          onOpenFile={openReviewFile}
+          onOpenFile={openFileHandler}
           writeAction={source === 'last-turn' ? undefined : {
             canWrite,
             pendingKey,
@@ -2571,7 +2608,7 @@ function DiffList({
   loadImagePreview: LoadImagePreview;
   loadMarkdownPreview: LoadMarkdownPreview;
   richMarkdownPreview: boolean;
-  onOpenFile: (diff: FileDiff) => void;
+  onOpenFile?: (diff: FileDiff) => void;
   writeAction?: WriteActionProps;
 }) {
   const parentRef = useRef<HTMLDivElement | null>(null);
@@ -3312,7 +3349,7 @@ export function CappedSourceView({
   loadImagePreview: LoadImagePreview;
   loadMarkdownPreview: LoadMarkdownPreview;
   richMarkdownPreview: boolean;
-  onOpenFile: (diff: FileDiff) => void;
+  onOpenFile?: (diff: FileDiff) => void;
   writeAction?: WriteActionProps;
 }) {
   const { t } = useTranslation();
@@ -3490,7 +3527,7 @@ function CommitSourceView({
   loadImagePreview: LoadImagePreview;
   loadMarkdownPreview: LoadMarkdownPreview;
   richMarkdownPreview: boolean;
-  onOpenFile: (diff: FileDiff) => void;
+  onOpenFile?: (diff: FileDiff) => void;
 }) {
   const { t } = useTranslation();
 
@@ -3581,7 +3618,7 @@ function BranchSourceView({
   loadImagePreview: LoadImagePreview;
   loadMarkdownPreview: LoadMarkdownPreview;
   richMarkdownPreview: boolean;
-  onOpenFile: (diff: FileDiff) => void;
+  onOpenFile?: (diff: FileDiff) => void;
 }) {
   const { t } = useTranslation();
   const blockingWarning = warning && warning.code !== 'base-missing' ? warning : null;
@@ -3840,7 +3877,7 @@ function StagedSourceView({
   loadMarkdownPreview: LoadMarkdownPreview;
   richMarkdownPreview: boolean;
   hunkActionsEnabled: boolean;
-  onOpenFile: (diff: FileDiff) => void;
+  onOpenFile?: (diff: FileDiff) => void;
 }) {
   const { t } = useTranslation();
   const filteredEmpty = diffs.length === 0 && stagedCount > 0;
@@ -3911,7 +3948,7 @@ function FileRow({
   loadMarkdownPreview: LoadMarkdownPreview;
   richMarkdownPreview: boolean;
   onImagePreviewLoad: () => void;
-  onOpenFile: (diff: FileDiff) => void;
+  onOpenFile?: (diff: FileDiff) => void;
 }) {
   const { t } = useTranslation();
   const fileName = basename(diff.path);

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/useReviewGitState.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/useReviewGitState.test.ts
@@ -20,8 +20,8 @@ function Probe({ sessionId, oid }: { sessionId: string; oid: string }) {
   return createElement('div', { 'data-testid': 'state' }, `${state.data?.commitOid ?? 'null'}|${state.loading ? 'loading' : 'idle'}`);
 }
 
-function SummaryProbe({ sessionId }: { sessionId: string | null }) {
-  const state = useReviewDirtySummary(sessionId);
+function SummaryProbe({ sessionId, deviceId = null }: { sessionId: string | null; deviceId?: string | null }) {
+  const state = useReviewDirtySummary(sessionId, deviceId);
   return createElement('div', { 'data-testid': 'state' }, `${state.data?.sessionId ?? 'null'}|${state.loading ? 'loading' : 'idle'}`);
 }
 
@@ -128,25 +128,40 @@ describe('useReviewGitState cache continuity', () => {
     });
     await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('commit-b|idle'));
   });
-
-  it('does not write back an in-flight request after the session is disabled', async () => {
-    const pending = deferred<ReviewDirtySummary>();
-    const summary = vi.fn(() => pending.promise);
+  it('invalidates an in-flight request before a new device scope load effect runs', async () => {
+    const pendingOld = deferred<{ ok: true; result: ReviewDirtySummary }>();
+    const invoke = vi.fn((deviceId: string) => {
+      if (deviceId === 'device-a') return pendingOld.promise;
+      return Promise.reject(new Error('device-b unavailable'));
+    });
     (window as unknown as { electronAPI: unknown }).electronAPI = {
-      gitReview: { summary },
+      deviceLink: {
+        invoke: (deviceId: string) => invoke(deviceId),
+      },
     };
 
-    const { rerender } = render(createElement(SummaryProbe, { sessionId: 'summary-session' }));
+    const { rerender } = render(createElement(SummaryProbe, {
+      sessionId: 'shared-session',
+      deviceId: 'device-a',
+    }));
     await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('null|loading'));
 
-    rerender(createElement(SummaryProbe, { sessionId: null }));
-    await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('null|idle'));
-
+    let oldRequestResolved = false;
     await act(async () => {
-      pending.resolve(dirtySummary('summary-session'));
-      await pending.promise;
+      rerender(createElement(SummaryProbe, {
+        sessionId: 'shared-session',
+        deviceId: 'device-b',
+      }));
+      pendingOld.resolve({ ok: true, result: dirtySummary('shared-session') });
+      oldRequestResolved = true;
+      await pendingOld.promise;
+      await Promise.resolve();
     });
-    expect(screen.getByTestId('state').textContent).toBe('null|idle');
+    expect(oldRequestResolved).toBe(true);
+    expect(screen.getByTestId('state').textContent).not.toContain('shared-session');
+
+    await waitFor(() => expect(invoke).toHaveBeenCalledWith('device-b'));
+    await waitFor(() => expect(screen.getByTestId('state').textContent).toBe('null|idle'));
   });
 
   it('reloads a file diff when the write refresh version changes without changing the IPC payload', async () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
@@ -31,12 +31,10 @@ interface LoadState<T> {
   data: T | null;
   loading: boolean;
   error: string | null;
+  /** IPC error code (e.g. 'DEVICE_LINK_CHANNEL_NOT_ALLOWED'); null when error is absent or not an IPC error. */
+  errorCode: string | null;
   refresh: () => void;
   setData: (data: T) => void;
-}
-
-function messageFromError(err: unknown): string {
-  return extractIpcError(err)?.message ?? (err instanceof Error ? err.message : String(err));
 }
 
 function useDebouncedCallback(cb: () => void, delayMs: number): () => void {
@@ -84,6 +82,7 @@ function useGitReviewLoad<T>(
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<string | null>(null);
   const requestRef = useRef(0);
   const setData = useCallback((next: T) => {
     setDataState(next);
@@ -95,6 +94,7 @@ function useGitReviewLoad<T>(
       requestRef.current += 1;
       if (!preserveWhenDisabled) setDataState(null);
       setError(null);
+      setErrorCode(null);
       setLoading(false);
       return;
     }
@@ -106,12 +106,14 @@ function useGitReviewLoad<T>(
         if (requestRef.current !== requestId) return;
         setData(next);
         setError(null);
+        setErrorCode(null);
       })
       .catch((err) => {
         if (requestRef.current !== requestId) return;
-        const message = messageFromError(err);
-        setError(message);
-        log.warn(logLabel, { sessionId, message });
+        const ipcErr = extractIpcError(err);
+        setError(ipcErr?.message ?? (err instanceof Error ? err.message : String(err)));
+        setErrorCode(ipcErr?.code ?? null);
+        log.warn(logLabel, { sessionId, message: ipcErr?.message ?? String(err) });
       })
       .finally(() => {
         if (requestRef.current === requestId) setLoading(false);
@@ -143,7 +145,7 @@ function useGitReviewLoad<T>(
     };
   }, [sessionId, debouncedLoad]);
 
-  return { data, loading, error, refresh: load, setData };
+  return { data, loading, error, errorCode, refresh: load, setData };
 }
 
 export function useReviewGitState(

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
@@ -86,6 +86,7 @@ function useGitReviewLoad<T>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<string | null>(null);
+  const requestRef = useRef(0);
   // 渲染期 keyed reset(React "derived state during render"),不等 useEffect——effect
   // 跑在 paint 之后,切换的第一帧会把上一个 key 的旧审查结果画给新会话(review P1):
   //  - 新 key 有缓存 → 当帧采纳缓存;
@@ -102,6 +103,12 @@ function useGitReviewLoad<T>(
     setPaintedScopeKey(scopeKey);
     setPaintedCacheKey(cacheKey);
     const cached = cacheKey ? reviewLoadCache.get(cacheKey) as T | undefined : undefined;
+    if (scopeChanged) {
+      // 立即让旧 scope 的在途请求失效；不能等新 scope 的 load effect，旧请求可能
+      // 在 render 与 effect 之间完成并把 A 会话数据写回 B 会话。
+      requestRef.current += 1;
+      setLoading(false);
+    }
     if (cached !== undefined) {
       setDataState(cached);
     } else if (scopeChanged && (scopeKey !== null || !preserveWhenDisabled)) {
@@ -110,7 +117,6 @@ function useGitReviewLoad<T>(
       setErrorCode(null);
     }
   }
-  const requestRef = useRef(0);
   const setData = useCallback((next: T) => {
     setDataState(next);
     if (cacheKey) reviewLoadCache.set(cacheKey, next);
@@ -182,7 +188,9 @@ export function useReviewGitState(
 export function useReviewDirtySummary(sessionId: string | null, deviceId: string | null = null): LoadState<ReviewDirtySummary> {
   const fetchReviewSummary = useCallback((currentSessionId: string) =>
     gitReviewApiFor(deviceId).summary({ sessionId: currentSessionId }), [deviceId]);
-  return useGitReviewLoad(sessionId, fetchReviewSummary, 'git review summary failed');
+  return useGitReviewLoad(sessionId, fetchReviewSummary, 'git review summary failed', {
+    scopeKey: sessionId ? `${deviceId ?? 'local'}:${sessionId}` : null,
+  });
 }
 
 export function useReviewCommits(
@@ -192,7 +200,9 @@ export function useReviewCommits(
 ): LoadState<ReviewCommitListData> {
   const fetchReviewCommits = useCallback((currentSessionId: string) =>
     gitReviewApiFor(deviceId).commits({ sessionId: currentSessionId, baseRef }), [baseRef, deviceId]);
-  return useGitReviewLoad(sessionId, fetchReviewCommits, 'git review commits failed');
+  return useGitReviewLoad(sessionId, fetchReviewCommits, 'git review commits failed', {
+    scopeKey: sessionId ? `${deviceId ?? 'local'}:${sessionId}` : null,
+  });
 }
 
 export function useReviewCommitDiff(

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
@@ -127,6 +127,9 @@ function useGitReviewLoad<T>(
       setDataState(cached);
     } else if (!sessionId && !preserveWhenDisabled) {
       setDataState(null);
+    } else if (sessionId) {
+      // cacheKey 变化且新 key 无缓存（切换设备/session）时，先清旧数据避免闪现旧审查结果
+      setDataState(null);
     }
   }, [cacheKey, preserveWhenDisabled, sessionId]);
 

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
@@ -72,10 +72,13 @@ function useGitReviewLoad<T>(
   sessionId: string | null,
   fetch: (sessionId: string) => Promise<T>,
   logLabel: string,
-  options: { cacheKey?: string | null; preserveWhenDisabled?: boolean } = {},
+  options: { cacheKey?: string | null; preserveWhenDisabled?: boolean; scopeKey?: string | null } = {},
 ): LoadState<T> {
   const cacheKey = options.cacheKey ?? null;
   const preserveWhenDisabled = options.preserveWhenDisabled ?? false;
+  // scope = 数据归属的会话/设备身份(`<deviceId|local>:<sessionId>`)。cacheKey 还编码
+  // oid / baseRef / whitespace 等查询参数,粒度比 scope 细。
+  const scopeKey = options.scopeKey ?? cacheKey;
   const [data, setDataState] = useState<T | null>(() => {
     const cached = cacheKey ? reviewLoadCache.get(cacheKey) as T | undefined : undefined;
     return cached ?? null;
@@ -83,6 +86,30 @@ function useGitReviewLoad<T>(
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<string | null>(null);
+  // 渲染期 keyed reset(React "derived state during render"),不等 useEffect——effect
+  // 跑在 paint 之后,切换的第一帧会把上一个 key 的旧审查结果画给新会话(review P1):
+  //  - 新 key 有缓存 → 当帧采纳缓存;
+  //  - scope(会话/设备)变了且无缓存 → 当帧清空 fail closed,绝不把 A 会话的 diff
+  //    画给 B 会话;
+  //  - 同 scope 内换 key(切 commit / baseRef / whitespace)且无缓存 → 保留旧数据,
+  //    由 loading 态覆盖(既有 cache continuity 契约,见 useReviewGitState.test)。
+  // preserveWhenDisabled 仅保护「scope 变 null 的禁用窗口」(commit/branch diff 视图
+  // 暂时失焦),非空 scope 之间的切换一律重置。
+  const [paintedScopeKey, setPaintedScopeKey] = useState(scopeKey);
+  const [paintedCacheKey, setPaintedCacheKey] = useState(cacheKey);
+  if (paintedScopeKey !== scopeKey || paintedCacheKey !== cacheKey) {
+    const scopeChanged = paintedScopeKey !== scopeKey;
+    setPaintedScopeKey(scopeKey);
+    setPaintedCacheKey(cacheKey);
+    const cached = cacheKey ? reviewLoadCache.get(cacheKey) as T | undefined : undefined;
+    if (cached !== undefined) {
+      setDataState(cached);
+    } else if (scopeChanged && (scopeKey !== null || !preserveWhenDisabled)) {
+      setDataState(null);
+      setError(null);
+      setErrorCode(null);
+    }
+  }
   const requestRef = useRef(0);
   const setData = useCallback((next: T) => {
     setDataState(next);
@@ -122,18 +149,6 @@ function useGitReviewLoad<T>(
   const debouncedLoad = useDebouncedCallback(load, REFRESH_DEBOUNCE_MS);
 
   useEffect(() => {
-    const cached = cacheKey ? reviewLoadCache.get(cacheKey) as T | undefined : undefined;
-    if (cached !== undefined) {
-      setDataState(cached);
-    } else if (!sessionId && !preserveWhenDisabled) {
-      setDataState(null);
-    } else if (sessionId) {
-      // cacheKey 变化且新 key 无缓存（切换设备/session）时，先清旧数据避免闪现旧审查结果
-      setDataState(null);
-    }
-  }, [cacheKey, preserveWhenDisabled, sessionId]);
-
-  useEffect(() => {
     load();
   }, [load]);
 
@@ -160,6 +175,7 @@ export function useReviewGitState(
     gitReviewApiFor(deviceId).get({ sessionId: currentSessionId, ignoreWhitespace }), [deviceId, ignoreWhitespace]);
   return useGitReviewLoad(sessionId, fetchReviewData, 'git review load failed', {
     cacheKey: sessionId ? `${deviceId ?? 'local'}:worktree:${sessionId}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
+    scopeKey: sessionId ? `${deviceId ?? 'local'}:${sessionId}` : null,
   });
 }
 
@@ -191,6 +207,7 @@ export function useReviewCommitDiff(
   }, [deviceId, ignoreWhitespace, oid]);
   return useGitReviewLoad(sessionId && oid ? sessionId : null, fetchCommitDiff, 'git review commit diff failed', {
     cacheKey: sessionId && oid ? `${deviceId ?? 'local'}:commit:${sessionId}:${oid}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
+    scopeKey: sessionId && oid ? `${deviceId ?? 'local'}:${sessionId}` : null,
     preserveWhenDisabled: true,
   });
 }
@@ -210,6 +227,7 @@ export function useReviewBranchDiff(
     }), [baseRef, deviceId, ignoreWhitespace]);
   return useGitReviewLoad(sessionId && enabled ? sessionId : null, fetchBranchDiff, 'git review branch diff failed', {
     cacheKey: sessionId ? `${deviceId ?? 'local'}:branch:${sessionId}:${baseRef ?? 'default'}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
+    scopeKey: sessionId ? `${deviceId ?? 'local'}:${sessionId}` : null,
     preserveWhenDisabled: true,
   });
 }
@@ -243,6 +261,7 @@ export function useReviewFileDiff(
     : null;
   return useGitReviewLoad(sessionId && source && path ? sessionId : null, fetchFileDiff, 'git review file diff failed', {
     cacheKey,
+    scopeKey: sessionId && source && path ? `${deviceId ?? 'local'}:${sessionId}` : null,
     preserveWhenDisabled: true,
   });
 }
@@ -280,6 +299,7 @@ export function useReviewFileDiffs(
     'git review file diff batch failed',
     {
       cacheKey: sessionId && requestKey ? `${deviceId ?? 'local'}:files:${sessionId}:${requestKey}` : null,
+      scopeKey: sessionId && requestKey ? `${deviceId ?? 'local'}:${sessionId}` : null,
       preserveWhenDisabled: false,
     },
   );

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/useReviewGitState.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { createLogger } from '@/lib/logger';
+import { gitReviewApiFor } from '@/lib/gitReviewTransport';
 import { makerChatStore } from '@/lib/makerChatStore';
 import type {
   ReviewBranchDiffData,
@@ -145,27 +146,31 @@ function useGitReviewLoad<T>(
   return { data, loading, error, refresh: load, setData };
 }
 
-const fetchReviewSummary = (sessionId: string): Promise<ReviewDirtySummary> =>
-  window.electronAPI.gitReview.summary({ sessionId });
-
 export function useReviewGitState(
   sessionId: string | null,
   ignoreWhitespace = false,
+  deviceId: string | null = null,
 ): LoadState<ReviewData> {
   const fetchReviewData = useCallback((currentSessionId: string) =>
-    window.electronAPI.gitReview.get({ sessionId: currentSessionId, ignoreWhitespace }), [ignoreWhitespace]);
+    gitReviewApiFor(deviceId).get({ sessionId: currentSessionId, ignoreWhitespace }), [deviceId, ignoreWhitespace]);
   return useGitReviewLoad(sessionId, fetchReviewData, 'git review load failed', {
-    cacheKey: sessionId ? `worktree:${sessionId}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
+    cacheKey: sessionId ? `${deviceId ?? 'local'}:worktree:${sessionId}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
   });
 }
 
-export function useReviewDirtySummary(sessionId: string | null): LoadState<ReviewDirtySummary> {
+export function useReviewDirtySummary(sessionId: string | null, deviceId: string | null = null): LoadState<ReviewDirtySummary> {
+  const fetchReviewSummary = useCallback((currentSessionId: string) =>
+    gitReviewApiFor(deviceId).summary({ sessionId: currentSessionId }), [deviceId]);
   return useGitReviewLoad(sessionId, fetchReviewSummary, 'git review summary failed');
 }
 
-export function useReviewCommits(sessionId: string | null, baseRef: string | null): LoadState<ReviewCommitListData> {
+export function useReviewCommits(
+  sessionId: string | null,
+  baseRef: string | null,
+  deviceId: string | null = null,
+): LoadState<ReviewCommitListData> {
   const fetchReviewCommits = useCallback((currentSessionId: string) =>
-    window.electronAPI.gitReview.commits({ sessionId: currentSessionId, baseRef }), [baseRef]);
+    gitReviewApiFor(deviceId).commits({ sessionId: currentSessionId, baseRef }), [baseRef, deviceId]);
   return useGitReviewLoad(sessionId, fetchReviewCommits, 'git review commits failed');
 }
 
@@ -173,13 +178,14 @@ export function useReviewCommitDiff(
   sessionId: string | null,
   oid: string | null,
   ignoreWhitespace = false,
+  deviceId: string | null = null,
 ): LoadState<ReviewCommitDiffData> {
   const fetchCommitDiff = useCallback((currentSessionId: string) => {
     if (!oid) return Promise.reject(new Error('commit oid is required'));
-    return window.electronAPI.gitReview.commitDiff({ sessionId: currentSessionId, oid, ignoreWhitespace });
-  }, [ignoreWhitespace, oid]);
+    return gitReviewApiFor(deviceId).commitDiff({ sessionId: currentSessionId, oid, ignoreWhitespace });
+  }, [deviceId, ignoreWhitespace, oid]);
   return useGitReviewLoad(sessionId && oid ? sessionId : null, fetchCommitDiff, 'git review commit diff failed', {
-    cacheKey: sessionId && oid ? `commit:${sessionId}:${oid}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
+    cacheKey: sessionId && oid ? `${deviceId ?? 'local'}:commit:${sessionId}:${oid}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
     preserveWhenDisabled: true,
   });
 }
@@ -189,15 +195,16 @@ export function useReviewBranchDiff(
   baseRef: string | null,
   ignoreWhitespace = false,
   enabled = true,
+  deviceId: string | null = null,
 ): LoadState<ReviewBranchDiffData> {
   const fetchBranchDiff = useCallback((currentSessionId: string) =>
-    window.electronAPI.gitReview.branchDiff({
+    gitReviewApiFor(deviceId).branchDiff({
       sessionId: currentSessionId,
       baseRef,
       ignoreWhitespace,
-    }), [baseRef, ignoreWhitespace]);
+    }), [baseRef, deviceId, ignoreWhitespace]);
   return useGitReviewLoad(sessionId && enabled ? sessionId : null, fetchBranchDiff, 'git review branch diff failed', {
-    cacheKey: sessionId ? `branch:${sessionId}:${baseRef ?? 'default'}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
+    cacheKey: sessionId ? `${deviceId ?? 'local'}:branch:${sessionId}:${baseRef ?? 'default'}:${ignoreWhitespace ? 'w' : 'plain'}` : null,
     preserveWhenDisabled: true,
   });
 }
@@ -206,6 +213,7 @@ export function useReviewFileDiff(
   sessionId: string | null,
   request: ReviewFileDiffRequest | null,
   refreshVersion = 0,
+  deviceId: string | null = null,
 ): LoadState<ReviewFileDiffData> {
   const source = request?.source ?? null;
   const path = request?.path ?? null;
@@ -215,7 +223,7 @@ export function useReviewFileDiff(
   const ignoreWhitespace = request?.ignoreWhitespace === true;
   const fetchFileDiff = useCallback((currentSessionId: string) => {
     if (!source || !path) return Promise.reject(new Error('file diff request is required'));
-    return window.electronAPI.gitReview.fileDiff({
+    return gitReviewApiFor(deviceId).fileDiff({
       sessionId: currentSessionId,
       source,
       path,
@@ -224,9 +232,9 @@ export function useReviewFileDiff(
       branchBaseRef,
       ignoreWhitespace,
     });
-  }, [branchBaseRef, commitOid, ignoreWhitespace, oldPath, path, refreshVersion, source]);
+  }, [branchBaseRef, commitOid, deviceId, ignoreWhitespace, oldPath, path, refreshVersion, source]);
   const cacheKey = sessionId && source && path
-    ? `file:${sessionId}:${source}:${commitOid ?? branchBaseRef ?? 'worktree'}:${oldPath ?? ''}:${path}:${ignoreWhitespace ? 'w' : 'plain'}:${refreshVersion}`
+    ? `${deviceId ?? 'local'}:file:${sessionId}:${source}:${commitOid ?? branchBaseRef ?? 'worktree'}:${oldPath ?? ''}:${path}:${ignoreWhitespace ? 'w' : 'plain'}:${refreshVersion}`
     : null;
   return useGitReviewLoad(sessionId && source && path ? sessionId : null, fetchFileDiff, 'git review file diff failed', {
     cacheKey,
@@ -237,6 +245,7 @@ export function useReviewFileDiff(
 export function useReviewFileDiffs(
   sessionId: string | null,
   requests: readonly ReviewFileDiffRequest[],
+  deviceId: string | null = null,
 ): LoadState<ReviewFileDiffData[]> {
   const requestKey = requests.length > 0
     ? JSON.stringify(requests.map((request) => ({
@@ -251,7 +260,7 @@ export function useReviewFileDiffs(
   // React exhaustive-deps note: requestKey encodes request contents; array identity changes alone should not reload the batch.
   const fetchFileDiffs = useCallback((currentSessionId: string) =>
     mapWithConcurrency(requests, FILE_DIFF_BATCH_CONCURRENCY, (request) =>
-      window.electronAPI.gitReview.fileDiff({
+      gitReviewApiFor(deviceId).fileDiff({
         sessionId: currentSessionId,
         source: request.source,
         path: request.path,
@@ -259,13 +268,13 @@ export function useReviewFileDiffs(
         commitOid: request.commitOid ?? null,
         branchBaseRef: request.branchBaseRef ?? null,
         ignoreWhitespace: request.ignoreWhitespace === true,
-      })), [requestKey]);
+      })), [deviceId, requestKey]);
   return useGitReviewLoad(
     sessionId && requestKey ? sessionId : null,
     fetchFileDiffs,
     'git review file diff batch failed',
     {
-      cacheKey: sessionId && requestKey ? `files:${sessionId}:${requestKey}` : null,
+      cacheKey: sessionId && requestKey ? `${deviceId ?? 'local'}:files:${sessionId}:${requestKey}` : null,
       preserveWhenDisabled: false,
     },
   );

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -4764,7 +4764,14 @@
         "unmerged": "unmerged files",
         "in-progress": "git operation in progress",
         "agent-running": "agent is running",
-        "disabled": "review unavailable"
+        "disabled": "review unavailable",
+        "remote-device": "remote device sessions are view-only"
+      },
+      "remote": {
+        "deviceTooOldTitle": "Device version too old",
+        "deviceTooOldDesc": "The {{appName}} version on the other device is too old for remote review. Please upgrade the controlled device and try again.",
+        "oversizeTitle": "Changes too large",
+        "oversizeDesc": "The changes in this view exceed the device-link transfer limit. Please view them on the controlled device."
       },
       "unmodifiedLines_one": "{{count}} unmodified line",
       "unmodifiedLines_other": "{{count}} unmodified lines",
@@ -4965,7 +4972,7 @@
         },
         "no-session": {
           "title": "Session not found",
-          "desc": "The current session record could not be found."
+          "desc": "The session record could not be found on this device."
         },
         "no-workdir": {
           "title": "No workdir",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -4762,7 +4762,14 @@
         "unmerged": "未マージのファイルがあります",
         "in-progress": "git 操作が進行中です",
         "agent-running": "エージェントが実行中です",
-        "disabled": "レビューを利用できません"
+        "disabled": "レビューを利用できません",
+        "remote-device": "リモートデバイスのセッションは閲覧のみです"
+      },
+      "remote": {
+        "deviceTooOldTitle": "相手デバイスのバージョンが古すぎます",
+        "deviceTooOldDesc": "相手デバイスの {{appName}} のバージョンが古く、リモートレビューに対応していません。相手デバイスをアップグレードしてから再試行してください。",
+        "oversizeTitle": "変更データが大きすぎます",
+        "oversizeDesc": "このビューの変更はデバイス連携の転送上限を超えています。相手デバイス上でご確認ください。"
       },
       "unmodifiedLines_one": "{{count}} 行未変更",
       "unmodifiedLines_other": "{{count}} 行未変更",
@@ -4963,7 +4970,7 @@
         },
         "no-session": {
           "title": "セッションが見つかりません",
-          "desc": "現在のセッション記録が見つかりません。"
+          "desc": "このデバイスでは現在のセッション記録が見つかりません。"
         },
         "no-workdir": {
           "title": "作業ディレクトリがありません",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -4762,7 +4762,14 @@
         "unmerged": "병합되지 않은 파일 있음",
         "in-progress": "git 작업 진행 중",
         "agent-running": "에이전트 실행 중",
-        "disabled": "리뷰를 사용할 수 없음"
+        "disabled": "리뷰를 사용할 수 없음",
+        "remote-device": "원격 기기 세션은 보기 전용입니다"
+      },
+      "remote": {
+        "deviceTooOldTitle": "상대 기기 버전이 너무 오래되었습니다",
+        "deviceTooOldDesc": "상대 기기의 {{appName}} 버전이 오래되어 원격 리뷰를 지원하지 않습니다. 피제어 기기를 업그레이드한 후 다시 시도해 주세요.",
+        "oversizeTitle": "변경 데이터가 너무 큽니다",
+        "oversizeDesc": "이 보기의 변경 사항이 기기 연결 전송 한도를 초과합니다. 피제어 기기에서 확인해 주세요."
       },
       "unmodifiedLines_one": "{{count}}줄 변경 없음",
       "unmodifiedLines_other": "{{count}}줄 변경 없음",
@@ -4963,7 +4970,7 @@
         },
         "no-session": {
           "title": "세션을 찾을 수 없음",
-          "desc": "현재 세션 기록을 찾을 수 없습니다."
+          "desc": "이 기기에서 현재 세션 기록을 찾을 수 없습니다."
         },
         "no-workdir": {
           "title": "작업 디렉터리 없음",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -4762,7 +4762,14 @@
         "unmerged": "存在未合并文件",
         "in-progress": "git 操作进行中",
         "agent-running": "Agent 正在运行",
-        "disabled": "审查不可用"
+        "disabled": "审查不可用",
+        "remote-device": "远程设备任务仅支持查看"
+      },
+      "remote": {
+        "deviceTooOldTitle": "对方设备版本过旧",
+        "deviceTooOldDesc": "对方设备的 {{appName}} 版本过旧，暂不支持远程审查，请升级被控设备后重试。",
+        "oversizeTitle": "改动数据过大",
+        "oversizeDesc": "该视图的改动超过设备互联单次传输上限，请在被控设备上查看。"
       },
       "unmodifiedLines_one": "{{count}} 行未改动",
       "unmodifiedLines_other": "{{count}} 行未改动",
@@ -4963,7 +4970,7 @@
         },
         "no-session": {
           "title": "任务不存在",
-          "desc": "找不到当前任务记录。"
+          "desc": "本设备上找不到该任务记录。"
         },
         "no-workdir": {
           "title": "没有工作目录",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -4765,7 +4765,14 @@
         "unmerged": "存在未合併檔案",
         "in-progress": "git 操作進行中",
         "agent-running": "Agent 正在執行",
-        "disabled": "審查不可用"
+        "disabled": "審查不可用",
+        "remote-device": "遠端設備任務僅支援檢視"
+      },
+      "remote": {
+        "deviceTooOldTitle": "對方設備版本過舊",
+        "deviceTooOldDesc": "對方設備的 {{appName}} 版本過舊，暫不支援遠端審查，請升級被控設備後重試。",
+        "oversizeTitle": "改動資料過大",
+        "oversizeDesc": "該視圖的改動超過裝置互聯單次傳輸上限，請在被控設備上檢視。"
       },
       "unmodifiedLines_one": "{{count}} 行未改動",
       "unmodifiedLines_other": "{{count}} 行未改動",
@@ -4966,7 +4973,7 @@
         },
         "no-session": {
           "title": "任務不存在",
-          "desc": "找不到當前任務記錄。"
+          "desc": "本裝置上找不到該任務記錄。"
         },
         "no-workdir": {
           "title": "沒有工作目錄",

--- a/apps/desktop/src/renderer/lib/gitReviewTransport.ts
+++ b/apps/desktop/src/renderer/lib/gitReviewTransport.ts
@@ -1,0 +1,91 @@
+/**
+ * gitReviewTransport —— git 审查的 device-link 透明传输层(fileBrowserTransport 同款模式)。
+ *
+ * 让 useReviewGitState 等 hooks 的只读查询**按会话来源**自动切换:
+ *   - 本地 / SSH remote 会话 → 原样走 window.electronAPI.gitReview(SSH 由 scope
+ *     层返回 remote-session 禁用态,renderer 无感)
+ *   - device-link 远程会话(被控设备)→ 走 deviceLink.invoke(deviceId,
+ *     'git-review:remote-op', [{op, payload}]) 隧道,被控端 git-review/device-op
+ *     以它自己的 session 记录解析 workdir 并执行
+ *
+ * 只覆盖只读子集(get / summary / commits / commitDiff / branchDiff / fileDiff /
+ * imagePreview / markdownPreview);写操作与 openFile 在 device-link 场景由 UI 层
+ * 直接禁用,不进传输层。
+ *
+ * 响应编码:被控端超帧预算时以 resultGz(gzip+base64)返回,这里解回原形,
+ * hooks 零感知;gzip 后仍超帧回结构化 OVERSIZE → 这里抛带稳定标记的错误,
+ * UI 据 isReviewRemoteOversizeError 渲染"改动过大"占位。
+ *
+ * 版本偏差:老被控端没有 remote-op channel,invoke reject
+ * DEVICE_LINK_CHANNEL_NOT_ALLOWED —— 复用 fileBrowserTransport 的
+ * isDeviceTooOldError 给上层渲染"对方设备版本过旧"占位。
+ */
+
+import { gunzipBase64ToText } from './gzipBase64';
+
+type LocalGitReview = typeof window.electronAPI.gitReview;
+
+/** 只读子集:device-link 场景可用的查询面。 */
+export type GitReviewReadApi = Pick<
+  LocalGitReview,
+  | 'get'
+  | 'summary'
+  | 'commits'
+  | 'commitDiff'
+  | 'branchDiff'
+  | 'fileDiff'
+  | 'imagePreview'
+  | 'markdownPreview'
+>;
+
+const REMOTE_OP_CHANNEL = 'git-review:remote-op';
+
+/** OVERSIZE 的稳定错误标记(进 Error.message,供 UI 分支判定,不面向用户展示)。 */
+const OVERSIZE_MARKER = 'GIT_REVIEW_REMOTE_OVERSIZE';
+
+export function isReviewRemoteOversizeError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes(OVERSIZE_MARKER);
+}
+
+/** 被控端 remote-op 的响应信封(与 main/git-review/device-op.ts 对齐)。 */
+type RemoteOpResult =
+  | { ok: true; result: unknown }
+  | { ok: true; resultGz: string }
+  | { ok: false; code: 'OVERSIZE' }
+  | { ok: false; message: string };
+
+async function invokeOp<T>(deviceId: string, op: string, payload: object): Promise<T> {
+  const res = (await window.electronAPI.deviceLink.invoke(deviceId, REMOTE_OP_CHANNEL, [
+    { op, payload },
+  ])) as RemoteOpResult | null | undefined;
+  if (res && res.ok === true) {
+    if ('resultGz' in res && typeof res.resultGz === 'string') {
+      return JSON.parse(await gunzipBase64ToText(res.resultGz)) as T;
+    }
+    return (res as { ok: true; result: unknown }).result as T;
+  }
+  if (res && res.ok === false && 'code' in res && res.code === 'OVERSIZE') {
+    throw new Error(`${OVERSIZE_MARKER}: review payload exceeds device-link frame budget`);
+  }
+  const message = res && res.ok === false && 'message' in res ? res.message : 'git-review remote-op failed';
+  throw new Error(message);
+}
+
+/**
+ * 与 window.electronAPI.gitReview 只读子集同形,按 deviceId 路由。
+ * device 分支的返回形状由被控端复用本机 readReview* 实现逐字段保证一致。
+ */
+export function gitReviewApiFor(deviceId: string | null | undefined): GitReviewReadApi {
+  if (!deviceId) return window.electronAPI.gitReview;
+  return {
+    get: (p) => invokeOp(deviceId, 'get', p),
+    summary: (p) => invokeOp(deviceId, 'summary', p),
+    commits: (p) => invokeOp(deviceId, 'commits', p),
+    commitDiff: (p) => invokeOp(deviceId, 'commit-diff', p),
+    branchDiff: (p) => invokeOp(deviceId, 'branch-diff', p),
+    fileDiff: (p) => invokeOp(deviceId, 'file-diff', p),
+    imagePreview: (p) => invokeOp(deviceId, 'image-preview', p),
+    markdownPreview: (p) => invokeOp(deviceId, 'markdown-preview', p),
+  };
+}

--- a/packages/device-link/src/allowlist.ts
+++ b/packages/device-link/src/allowlist.ts
@@ -444,6 +444,18 @@ const EXTENDED_INVOKE_CHANNELS: readonly string[] = [
   //  - readFile 结果超帧限前被控端预判回结构化 oversize,不裸炸 FRAME_TOO_LARGE。
   //  - 老被控端无此 channel → CHANNEL_NOT_ALLOWED,控制端渲染"设备版本过旧"占位。
   'file-browser:remote-op',
+  // —— 远程 git 审查(右侧栏审查面板,只读)——
+  // 单聚合 channel:被控端专用 handler(见 apps/desktop/src/main/git-review/device-op.ts),
+  // 不复用本机 renderer 的 git-review:* handler。准入:
+  //  - 只读 git 数据(status / diff / commit 列表 / 文件 diff / 图片与 Markdown 预览),
+  //    **不放行任何写 op**(stage / discard / commit / push 不在被控端 handler 实现)。
+  //  - 入参只有 sessionId + 结构化查询字段,不接受任何客户端路径:workdir 一律由被控端
+  //    resolveReviewScope 从它自己的 session 记录解析,路径越界在 fsPathGuard 层拦。
+  //  - device-link 已是同账号 + remoteControlEnabled 显式 opt-in,控制端本就能在
+  //    workingDir 跑 agent(任意读/exec),只读 git 数据不扩大攻击面(fs:list-dir 同款论证)。
+  //  - 响应超帧限前被控端预判:先 gzip,仍超回结构化 OVERSIZE,不裸炸 FRAME_TOO_LARGE。
+  //  - 老被控端无此 channel → CHANNEL_NOT_ALLOWED,控制端渲染"设备版本过旧"占位。
+  'git-review:remote-op',
   // —— 窄口径文本预览(消息附件 / tool 文件引用只读查看)——
   // 不是裸文件读:handler 要求绝对路径,复用系统目录 blocklist,10MB 上限,
   // 并用 reason 明确 oversize / not_found / forbidden。见 bootstrap-electron text-file:read-preview。

--- a/packages/device-link/src/topics.ts
+++ b/packages/device-link/src/topics.ts
@@ -33,6 +33,9 @@ export const FILE_BROWSER_EVENT_CHANNEL = 'maker:file-browser:event';
 /** 远程文件浏览的聚合 invoke channel(单 channel:老被控端 CHANNEL_NOT_ALLOWED 即全无能力)。 */
 export const FILE_BROWSER_REMOTE_OP_CHANNEL = 'file-browser:remote-op';
 
+/** 远程 git 审查(只读)的聚合 invoke channel(单 channel:老被控端 CHANNEL_NOT_ALLOWED 即全无能力)。 */
+export const GIT_REVIEW_REMOTE_OP_CHANNEL = 'git-review:remote-op';
+
 const FS_WATCH_TOPIC_PREFIX = 'fs-watch:';
 
 export function fsWatchTopic(workdir: string): Topic {


### PR DESCRIPTION
## 这次改了什么

### 摘要

设备互联控制端查看被控设备任务时，审查面板此前会把远程任务 ID 交给本机数据库查询，因此误报"任务不存在"。本 PR 新增只读的 device-link 审查通道，让状态、工作区差异、提交列表、提交/分支/单文件差异，以及图片和 Markdown 预览在被控设备上读取后返回控制端。

远程审查保持只读：暂存、取消暂存、还原、提交、推送和"打开文件"不开放。响应接近设备互联 2 MiB 帧上限时先 gzip，仍超限则返回明确的"改动数据过大"占位；旧版被控设备显示升级提示。

### 变更类型

- [x] `feat` 新功能
- [x] `fix` 缺陷修复（CHANNEL_NOT_ALLOWED 降级路径）

### 范围

- 关联需求：用户反馈 device-link 远程任务的审查面板误报"任务不存在"，并要求先支持只读审查。
- 本 PR 包含：
  - 被控端只读聚合通道 `git-review:remote-op` 与 device-link allowlist 准入。
  - 控制端透明 transport、各审查 hook 的 deviceId 路由和按设备隔离的缓存 key。
  - device-link 远程任务只读门禁，以及版本过旧、响应过大和本设备找不到任务的明确提示。
  - 覆盖 op 白名单、参数校验、压缩/超限和控制端解码的回归测试。
  - 修复 Electron IPC 序列化导致 Error.code 丢失，CHANNEL_NOT_ALLOWED 降级路径误显 raw 报错的 bug。
- 明确不包含：
  - SSH 远程工作区审查。
  - device-link 远程写操作（stage / discard / commit / push）和远程打开文件。
  - 手机端审查面板入口。
- 不存在 breaking change。

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §1 Visual Theme & Atmosphere、§2 Color Palette & Roles、§3 Typography Rules。复用现有审查面板、CenteredState、只读警告条和语义 token；没有新增硬编码颜色、阴影或独立视觉组件，Light / Dark 由现有主题 token 同时覆盖。新增远程会话专属占位："对方设备版本过旧"、"改动数据过大"、"远程设备任务仅支持查看"。

## 怎么验证的

### 自动验证

```text
deviceOp.test.ts + gitReviewTransport.test.ts: 14 tests passed
review 完整套件: 131 tests passed
typecheck: desktop 通过
i18nCompleteness: 2 tests passed
```

### 手工验证

- 控制端连接旧版正式版被控端 → 审查面板显示「对方设备版本过旧」友好占位，不再裸报 raw 错误。
- 控制端 + 被控端均运行本 PR 代码 → 双设备端到端只读审查正常。

### 未执行的验证

- Light / Dark 实机目检：UI 全部复用现有 themed 组件与语义 token，不等同于双模式已经实机验证。

## 风险

### 风险分类

- [x] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 其他：device-link 帧大小与双设备端到端行为需验证

### 影响与回滚

- 影响范围：Desktop device-link 远程控制下的右侧栏审查面板，以及 device-link invoke allowlist。
- 权限边界：被控端仅实现只读 op，不接受客户端提供的 workdir，路径由被控端的 session 记录解析。
- 协议兼容：新控制端连接旧被控端 → 确定性降级显示"对方设备版本过旧"；旧控制端连接新被控端 → 无影响。
- 帧上限：响应超 1.8 MiB 时先 gzip；仍超则返回结构化 OVERSIZE。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)