### PR TITLE
fix(mobile): restore zh-TW share image copy

### DIFF
--- a/apps/mobile/src/i18n/locales/zh-TW/session.json
+++ b/apps/mobile/src/i18n/locales/zh-TW/session.json
@@ -44,6 +44,7 @@
     "locateMessageNotFound": "未找到要定位的訊息。",
     "shareNoLocalImage": "無法獲取本地圖片檔案",
     "shareFailedTitle": "分享失敗",
+    "shareImageFailed": "無法產生或開啟分享圖片，請重試。",
     "shareUnsupported": "當前客戶端暫不支援分享，更新到最新版本後重試。",
     "downloadFailed": "下載失敗",
     "voiceNoRemoteDevice": "缺少遠端裝置，不能開始語音輸入。",
@@ -105,6 +106,17 @@
     "forkConfirmDescription": "系統會根據這裡的對話上下文建立一個獨立的新任務。原任務不會改變，之後兩邊的訊息互不影響。",
     "forkConfirm": "開啟新任務",
     "forkCancel": "取消"
+  },
+  "shareImage": {
+    "title": "分享對話",
+    "selectedCount": "已選擇 {{count}} 條訊息",
+    "selectAll": "全選",
+    "clearAll": "取消全選",
+    "cancel": "取消分享",
+    "share": "分享圖片",
+    "generating": "正在準備…",
+    "checkboxLabel": "選擇要分享的訊息",
+    "shareMessage": "分享這條訊息"
   },
   "new": {
     "selectDevice": "選擇裝置",


### PR DESCRIPTION
## 这次改了什么

### 摘要

补齐繁体中文里遗漏的“分享对话图片”文案。此前最新主分支已在其他语言加入这组文案，但繁中缺了 10 个键，会退回英文，并让整库语言一致性测试失败。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：最新主分支的繁中文案与其他语言不一致
- 本 PR 包含：补齐 `session.screen.shareImageFailed` 和 `session.shareImage` 的繁中翻译
- 明确不包含：分享逻辑、布局或交互调整
- 用户可见变化：繁中用户分享对话图片时不再看到英文回退文案
- 是否存在 breaking change：无

### UI 变化

仅补齐现有界面文案，不改变视觉布局或交互。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11 Voice & Content：文案简洁、直接，并与现有简中语义保持一致。

## 怎么验证的

### 自动验证

```text
pnpm --filter mobile exec vitest run src/__tests__/i18nCatalogParity.test.ts --reporter=dot
结果：15/15 通过

pnpm --filter mobile typecheck
结果：通过

pnpm check:i18n-glossary
结果：通过

pnpm test:unit
结果：整库通过
```

### 手工验证

核对繁中文案在 JSON 中的层级、变量 `{{count}}` 与其他语言完全一致；本次不改界面结构或执行逻辑。

### 未执行的验证

未启动 mobile 客户端截图：本次工作区未连接 Metro，且改动仅恢复缺失的静态语言键；已用目录一致性测试覆盖键名和变量结构。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅繁体中文静态文案
- 回滚 / 降级方式：回滚本提交即可；无数据迁移

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
