### PR TITLE
fix(anthropic-responses-bridge): 修复订阅模型经 Claude Code 的空响应 200

### DIFF
--- a/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
@@ -43,7 +43,7 @@ async function invoke(
   handler: ResponsesBridgeHandler,
   body: unknown,
   opts?: { url?: string; prefs?: BridgeSessionPrefs },
-): Promise<{ status: number; text: string }> {
+): Promise<{ status: number; text: string; headers: Record<string, string | string[] | undefined> }> {
   const server: Server = createServer((req, res) => {
     void handler.handle({
       parsedBody: body,
@@ -57,11 +57,15 @@ async function invoke(
   const port = typeof addr === 'object' && addr ? addr.port : 0;
   try {
     // 用 node:http 直连 harness —— 全局 fetch 已被 stub 成 mock 上游,不能拿来打 harness。
-    return await new Promise<{ status: number; text: string }>((resolve, reject) => {
+    return await new Promise<{ status: number; text: string; headers: Record<string, string | string[] | undefined> }>((resolve, reject) => {
       const req = httpRequest({ hostname: '127.0.0.1', port, method: 'POST', path: '/' }, (res) => {
         const chunks: Buffer[] = [];
         res.on('data', (c: Buffer) => chunks.push(c));
-        res.on('end', () => resolve({ status: res.statusCode ?? 0, text: Buffer.concat(chunks).toString('utf8') }));
+        res.on('end', () => resolve({
+          status: res.statusCode ?? 0,
+          text: Buffer.concat(chunks).toString('utf8'),
+          headers: res.headers,
+        }));
         res.on('error', reject);
       });
       req.on('error', reject);
@@ -220,6 +224,135 @@ describe('createResponsesHandler', () => {
     seen.length = 0;
     await invoke(handler, { model: 'xai/grok-code-fast', messages: [] });
     expect(seen[0].body.tools).toBeUndefined();
+  });
+
+  it('stream:false → 上游 Responses JSON,下游返回完整 Anthropic Message JSON', async () => {
+    const seen: Array<{ body: Record<string, unknown>; accept: string }> = [];
+    vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
+      seen.push({
+        body: JSON.parse(String(init.body)),
+        accept: new Headers(init.headers).get('accept') ?? '',
+      });
+      return new Response(JSON.stringify({
+        id: 'resp_1',
+        model: 'gpt-5.6-sol',
+        status: 'completed',
+        output: [
+          {
+            id: 'msg_1',
+            type: 'message',
+            role: 'assistant',
+            content: [{ type: 'output_text', text: 'hello' }],
+          },
+          {
+            id: 'fc_1',
+            type: 'function_call',
+            call_id: 'call_1',
+            name: 'Bash',
+            arguments: '{"command":"pwd"}',
+          },
+        ],
+        usage: { input_tokens: 4, output_tokens: 2 },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }));
+    const handler = createResponsesHandler({ providers: [providerConfig()] });
+
+    const result = await invoke(handler, {
+      model: 'chatgpt/gpt-5.6-sol',
+      messages: [],
+      stream: false,
+    });
+
+    expect(result.status).toBe(200);
+    expect(String(result.headers['content-type'])).toContain('application/json');
+    const message = JSON.parse(result.text) as Record<string, unknown>;
+    expect(message).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+      model: 'chatgpt/gpt-5.6-sol',
+      stop_reason: 'tool_use',
+      usage: { input_tokens: 4, output_tokens: 2 },
+    });
+    expect(message.content).toEqual([
+      { type: 'text', text: 'hello' },
+      { type: 'tool_use', id: 'call_1', name: 'Bash', input: { command: 'pwd' } },
+    ]);
+    expect(seen[0]).toMatchObject({ body: { stream: false }, accept: 'application/json' });
+  });
+
+  it('stream:false 上游仍返回 SSE → bridge 缓冲后返回 Anthropic Message JSON', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(sse(OK_SSE), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })));
+    const handler = createResponsesHandler({ providers: [providerConfig()] });
+
+    const result = await invoke(handler, {
+      model: 'chatgpt/gpt-5.5',
+      messages: [],
+      stream: false,
+    });
+
+    expect(result.status).toBe(200);
+    expect(String(result.headers['content-type'])).toContain('application/json');
+    expect(JSON.parse(result.text)).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hi' }],
+      stop_reason: 'end_turn',
+    });
+  });
+
+  it('stream:false 上游返回流内错误 / 无内容 → 502 带上游原因,不回空 message', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      id: 'resp_1',
+      status: 'failed',
+      error: { code: 'context_length_exceeded', message: 'prompt too large' },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+    const failed = createResponsesHandler({ providers: [providerConfig()] });
+    const failedResult = await invoke(failed, { model: 'chatgpt/gpt-5.5', messages: [], stream: false });
+    expect(failedResult.status).toBe(502);
+    expect(failedResult.text).toContain('[context_length_exceeded] prompt too large');
+
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      id: 'resp_2',
+      status: 'completed',
+      output: [],
+      usage: { input_tokens: 1, output_tokens: 0 },
+    }), { status: 200, headers: { 'content-type': 'application/json' } })));
+    const empty = createResponsesHandler({ providers: [providerConfig()] });
+    const emptyResult = await invoke(empty, { model: 'chatgpt/gpt-5.5', messages: [], stream: false });
+    expect(emptyResult.status).toBe(502);
+    expect(emptyResult.text).toContain('no content blocks');
+  });
+
+  it('上游 HTTP 200 无 body → 返回 502,不保留伪成功状态', async () => {
+    const onUpstreamError = vi.fn();
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(null, { status: 200 })));
+    const handler = createResponsesHandler({
+      providers: [providerConfig({ onUpstreamError })],
+    });
+
+    const result = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+
+    expect(result.status).toBe(502);
+    expect(result.text).toContain('successful response without a body');
+    expect(onUpstreamError).not.toHaveBeenCalled();
+  });
+
+  it('上游 SSE clean EOF 且未完成 → error 事件收尾,不补 message_stop', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(sse(OK_SSE.slice(0, 3)), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })));
+    const handler = createResponsesHandler({ providers: [providerConfig()] });
+
+    const result = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+
+    expect(result.status).toBe(200);
+    expect(result.text).toContain('stream_truncated');
+    expect(result.text).toContain('event: error');
+    expect(result.text).not.toContain('message_stop');
   });
 
   it('count_tokens 本地估算;无匹配 provider → 400;buildHeaders 抛错 → 502', async () => {

--- a/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
@@ -28,6 +28,17 @@ const OK_SSE = [
   JSON.stringify({ type: 'response.completed', response: { status: 'completed', usage: { input_tokens: 1, output_tokens: 1 } } }),
 ];
 
+/** 原样投递一段 SSE 文本(用于构造跨多行 data: 的事件)。 */
+function rawStream(text: string): ReadableStream<Uint8Array> {
+  const enc = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(enc.encode(text));
+      controller.close();
+    },
+  });
+}
+
 function providerConfig(overrides?: Partial<BridgeProviderConfig>): BridgeProviderConfig {
   return {
     prefix: 'chatgpt/',
@@ -295,6 +306,43 @@ describe('createResponsesHandler', () => {
 
     expect(result.status).toBe(200);
     expect(String(result.headers['content-type'])).toContain('application/json');
+    expect(JSON.parse(result.text)).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hi' }],
+      stop_reason: 'end_turn',
+    });
+  });
+
+  it('stream:false 上游 SSE 事件跨多行 data: → 按空行合并后解析,不误判成坏帧(review 反馈)', async () => {
+    // SSE 规范允许同一事件由多条 data: 行组成(以 \n 拼接)。逐行独立 JSON.parse 会在
+    // 第一段就抛错,把一个合法响应变成 502。
+    const body = [
+      'event: response.created',
+      'data: {"type":"response.created",',
+      'data:  "response":{"id":"r","model":"gpt-5.5"}}',
+      '',
+      'data: {"type":"response.output_item.added","output_index":0,"item":{"type":"message"}}',
+      '',
+      'data: {"type":"response.output_text.delta","output_index":0,',
+      'data:  "delta":"hi"}',
+      '',
+      'data: {"type":"response.output_item.done","output_index":0,"item":{"type":"message"}}',
+      '',
+      'data: {"type":"response.completed","response":{"status":"completed","usage":{"input_tokens":1,"output_tokens":1}}}',
+      '',
+      'data: [DONE]',
+      '',
+    ].join('\n');
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(rawStream(body), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })));
+    const handler = createResponsesHandler({ providers: [providerConfig()] });
+
+    const result = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: false });
+
+    expect(result.status).toBe(200);
     expect(JSON.parse(result.text)).toMatchObject({
       type: 'message',
       role: 'assistant',

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -14,10 +14,20 @@ describe('translateRequest', () => {
     expect(out.model).toBe('gpt-5.5');
     expect(out.instructions).toBe('You are terse.');
     expect(out.store).toBe(false);
+    expect(out.stream).toBe(true);
     expect(out.include).toContain('reasoning.encrypted_content');
     expect(out.input).toEqual([
       { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'hi' }] },
     ]);
+  });
+
+  it('preserves stream:false for Claude Code non-streaming fallback', () => {
+    const req: AnthropicMessagesRequest = {
+      model: 'chatgpt/gpt-5.5',
+      messages: [{ role: 'user', content: 'hi' }],
+      stream: false,
+    };
+    expect(translateRequest(req, { model: 'gpt-5.5' }).stream).toBe(false);
   });
 
   it('joins array-form system blocks', () => {

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-sse.test.ts
@@ -470,7 +470,8 @@ describe('SseTranslator', () => {
       (e) => (e.data.delta as Record<string, unknown>).type === 'text_delta',
     );
     expect(textDeltas.map((e) => (e.data.delta as Record<string, unknown>).text).join('')).toBe('半截话');
-    expect(types(out)).toContain('message_stop');
+    expect(types(out)).toContain('error');
+    expect(types(out)).not.toContain('message_stop');
   });
 
   it('既有顺序流(codex 风格)行为不变:块序与内容与修复前一致', () => {
@@ -625,16 +626,56 @@ describe('SseTranslator', () => {
     expect((starts[0].data.content_block as Record<string, unknown>).data).toBe('#id=rs_1#ENC');
   });
 
-  it('finish() 兜底:上游断流也发 message_delta + message_stop', () => {
+  it('clean EOF before response.completed → error without message_stop', () => {
     const t = new SseTranslator('gpt-5.5');
     const out: AnthropicSseEvent[] = [];
     out.push(...t.push({ type: 'response.created', response: { id: 'r', model: 'gpt-5.5' } }));
     out.push(...t.push({ type: 'response.output_item.added', output_index: 0, item: { type: 'message' } }));
     out.push(...t.push({ type: 'response.output_text.delta', output_index: 0, delta: 'x' }));
     out.push(...t.finish());
-    expect(types(out)).toContain('message_delta');
-    expect(types(out)).toContain('message_stop');
+    expect(types(out)).toContain('error');
+    expect(types(out)).not.toContain('message_delta');
+    expect(types(out)).not.toContain('message_stop');
+    expect((byType(out, 'error')[0].data.error as Record<string, unknown>).message).toContain('stream_truncated');
     // finish 幂等
     expect(t.finish()).toHaveLength(0);
+  });
+
+  it('非流式 Responses JSON 复用状态机翻译 text / tool / usage', () => {
+    const t = new SseTranslator('chatgpt/gpt-5.6-sol');
+    const out = t.pushJson({
+      id: 'resp_1',
+      model: 'gpt-5.6-sol',
+      status: 'completed',
+      output: [
+        {
+          id: 'msg_1',
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'hello' }],
+        },
+        {
+          id: 'fc_1',
+          type: 'function_call',
+          call_id: 'call_1',
+          name: 'Bash',
+          arguments: '{"command":"pwd"}',
+        },
+      ],
+      usage: { input_tokens: 3, output_tokens: 2 },
+    });
+    expect(types(out)).toContain('message_start');
+    expect(types(out)).toContain('message_stop');
+    expect((byType(out, 'message_delta')[0].data.delta as Record<string, unknown>).stop_reason).toBe('tool_use');
+    const text = byType(out, 'content_block_delta')
+      .filter((event) => (event.data.delta as Record<string, unknown>).type === 'text_delta')
+      .map((event) => (event.data.delta as Record<string, unknown>).text)
+      .join('');
+    expect(text).toBe('hello');
+    const toolInput = byType(out, 'content_block_delta')
+      .filter((event) => (event.data.delta as Record<string, unknown>).type === 'input_json_delta')
+      .map((event) => (event.data.delta as Record<string, unknown>).partial_json)
+      .join('');
+    expect(toolInput).toBe('{"command":"pwd"}');
   });
 });

--- a/packages/anthropic-responses-bridge/src/anthropic-message-collector.ts
+++ b/packages/anthropic-responses-bridge/src/anthropic-message-collector.ts
@@ -1,0 +1,179 @@
+interface ContentBlockState {
+  index: number;
+  block: Record<string, unknown>;
+  inputJson: string;
+}
+
+export type AnthropicMessageCollectionResult =
+  | { ok: true; message: Record<string, unknown> }
+  | { ok: false; error: { type: string; message: string } };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * 把已翻译的 Anthropic SSE 事件收集成 Messages API 的非流式 Message JSON。
+ *
+ * 非流式 fallback 必须拿到单个完整 Message,不能直接收到 SSE。收集器复用流式翻译器的
+ * 事件输出,保证 text / thinking / tool_use 的排序和 usage 映射只有一套事实源。
+ */
+export class AnthropicMessageCollector {
+  private message: Record<string, unknown> | null = null;
+  private readonly blocks = new Map<number, ContentBlockState>();
+  private stopped = false;
+  private error: { type: string; message: string } | null = null;
+
+  push(event: { event: string; data: Record<string, unknown> }): void {
+    if (this.error || this.stopped) return;
+
+    switch (event.event) {
+      case 'message_start':
+        this.onMessageStart(event.data);
+        break;
+      case 'content_block_start':
+        this.onBlockStart(event.data);
+        break;
+      case 'content_block_delta':
+        this.onBlockDelta(event.data);
+        break;
+      case 'content_block_stop':
+        this.onBlockStop(event.data);
+        break;
+      case 'message_delta':
+        this.onMessageDelta(event.data);
+        break;
+      case 'message_stop':
+        this.stopped = true;
+        break;
+      case 'error': {
+        const error = isRecord(event.data.error) ? event.data.error : {};
+        this.error = {
+          type: asString(error.type) || 'api_error',
+          message: asString(error.message) || 'upstream response failed',
+        };
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  finish(): AnthropicMessageCollectionResult {
+    if (this.error) return { ok: false, error: this.error };
+    if (!this.message || !this.stopped) {
+      return {
+        ok: false,
+        error: {
+          type: 'api_error',
+          message: 'upstream response did not produce a complete Anthropic message',
+        },
+      };
+    }
+
+    const content = [...this.blocks.values()]
+      .sort((a, b) => a.index - b.index)
+      .map((state) => state.block);
+    // 非流式调用方需要一个可用的 Message:零 content block 的「成功」响应正是 Claude Code
+    // 报 "empty or malformed response" 的形态,按上游错误如实上报而不是回一个空 message。
+    if (content.length === 0) {
+      return {
+        ok: false,
+        error: { type: 'api_error', message: 'upstream response contained no content blocks' },
+      };
+    }
+    return { ok: true, message: { ...this.message, content } };
+  }
+
+  private onMessageStart(data: Record<string, unknown>): void {
+    const message = isRecord(data.message) ? data.message : null;
+    if (!message) {
+      this.error = { type: 'api_error', message: 'upstream response produced an invalid message_start' };
+      return;
+    }
+    this.message = {
+      ...message,
+      type: 'message',
+      role: 'assistant',
+      content: [],
+    };
+  }
+
+  private onBlockStart(data: Record<string, unknown>): void {
+    const index = typeof data.index === 'number' ? data.index : -1;
+    const contentBlock = isRecord(data.content_block) ? data.content_block : null;
+    if (index < 0 || !contentBlock || this.blocks.has(index)) {
+      this.error = { type: 'api_error', message: 'upstream response produced an invalid content block' };
+      return;
+    }
+    this.blocks.set(index, {
+      index,
+      block: { ...contentBlock },
+      inputJson: '',
+    });
+  }
+
+  private onBlockDelta(data: Record<string, unknown>): void {
+    const index = typeof data.index === 'number' ? data.index : -1;
+    const state = this.blocks.get(index);
+    const delta = isRecord(data.delta) ? data.delta : null;
+    if (!state || !delta) {
+      this.error = { type: 'api_error', message: 'upstream response produced an orphan content delta' };
+      return;
+    }
+
+    switch (delta.type) {
+      case 'text_delta':
+        state.block.text = asString(state.block.text) + asString(delta.text);
+        break;
+      case 'thinking_delta':
+        state.block.thinking = asString(state.block.thinking) + asString(delta.thinking);
+        break;
+      case 'signature_delta':
+        state.block.signature = asString(state.block.signature) + asString(delta.signature);
+        break;
+      case 'input_json_delta':
+        state.inputJson += asString(delta.partial_json);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private onBlockStop(data: Record<string, unknown>): void {
+    const index = typeof data.index === 'number' ? data.index : -1;
+    const state = this.blocks.get(index);
+    if (!state) {
+      this.error = { type: 'api_error', message: 'upstream response stopped an unknown content block' };
+      return;
+    }
+    if (state.block.type !== 'tool_use') return;
+    if (!state.inputJson) {
+      state.block.input = isRecord(state.block.input) ? state.block.input : {};
+      return;
+    }
+    try {
+      state.block.input = JSON.parse(state.inputJson) as unknown;
+    } catch {
+      this.error = { type: 'api_error', message: 'upstream response produced malformed tool arguments' };
+    }
+  }
+
+  private onMessageDelta(data: Record<string, unknown>): void {
+    if (!this.message) {
+      this.error = { type: 'api_error', message: 'upstream response produced message_delta before message_start' };
+      return;
+    }
+    const delta = isRecord(data.delta) ? data.delta : {};
+    if ('stop_reason' in delta) this.message.stop_reason = delta.stop_reason ?? null;
+    if ('stop_sequence' in delta) this.message.stop_sequence = delta.stop_sequence ?? null;
+    if (isRecord(data.usage)) {
+      const initialUsage = isRecord(this.message.usage) ? this.message.usage : {};
+      this.message.usage = { ...initialUsage, ...data.usage };
+    }
+  }
+}

--- a/packages/anthropic-responses-bridge/src/handler.ts
+++ b/packages/anthropic-responses-bridge/src/handler.ts
@@ -126,11 +126,20 @@ async function readBodyWithLimit(response: Response, limitBytes: number): Promis
   }
 }
 
+/**
+ * 按 SSE 规范切事件:空行分隔事件,**同一事件的多条 `data:` 行先以 `\n` 拼成一个负载**
+ * 再解析。逐行独立 JSON.parse 会把「合法但跨多行」的事件当成坏帧,整个非流式 fallback
+ * 被判成 502(review 反馈)。与 responses-anthropic-bridge 的 parseSseBlock 同口径。
+ */
 function parseSsePayloads(body: string): unknown[] {
   const payloads: unknown[] = [];
-  for (const line of body.split(/\r?\n/)) {
-    if (!line.startsWith('data:')) continue;
-    const payload = line.slice(5).trim();
+  for (const block of body.split(/\r?\n\r?\n/)) {
+    const data: string[] = [];
+    for (const line of block.split(/\r?\n/)) {
+      if (line.startsWith('data:')) data.push(line.slice(5).trimStart());
+    }
+    if (data.length === 0) continue;
+    const payload = data.join('\n').trim();
     if (!payload || payload === '[DONE]') continue;
     payloads.push(JSON.parse(payload) as unknown);
   }

--- a/packages/anthropic-responses-bridge/src/handler.ts
+++ b/packages/anthropic-responses-bridge/src/handler.ts
@@ -7,7 +7,7 @@
  *   1. strip model 前缀 → 真实 model id
  *   2. translateRequest → OpenAI Responses 请求
  *   3. 注入 OAuth headers(provider.buildHeaders 拿最新凭证)→ POST 上游 /responses
- *   4. 逐条把上游 Responses SSE 翻译成 Anthropic Messages SSE 写回 res
+ *   4. 按调用方的 stream 模式把上游 Responses SSE / JSON 翻译成 Anthropic Messages SSE / JSON
  *
  * 会话态(effort / Fast)由 host 的 routingTransform 在决策点解析后经 `prefs` 闭包传入,
  * 不走任何伪 header。响应是**翻译流**(非字节透传)——这是本包与 compat-proxy 引擎的分工:
@@ -19,6 +19,7 @@
 
 import type { ServerResponse } from 'node:http';
 
+import { AnthropicMessageCollector } from './anthropic-message-collector.js';
 import { translateRequest, type ResponsesReasoningEffort } from './translate-request.js';
 import { SseTranslator, type AnthropicSseEvent } from './translate-sse.js';
 import type {
@@ -97,6 +98,43 @@ function writeJson(res: ServerResponse, status: number, body: unknown): void {
 
 function writeSseEvent(res: ServerResponse, ev: AnthropicSseEvent): void {
   res.write(`event: ${ev.event}\ndata: ${JSON.stringify(ev.data)}\n\n`);
+}
+
+const MAX_NON_STREAM_BODY_BYTES = 16 * 1024 * 1024;
+
+async function readBodyWithLimit(response: Response, limitBytes: number): Promise<string> {
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let body = '';
+  let bytesRead = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytesRead += value.byteLength;
+      if (bytesRead > limitBytes) {
+        await reader.cancel();
+        throw new Error(`upstream response exceeds ${limitBytes} bytes`);
+      }
+      body += decoder.decode(value, { stream: true });
+    }
+    body += decoder.decode();
+    return body;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+function parseSsePayloads(body: string): unknown[] {
+  const payloads: unknown[] = [];
+  for (const line of body.split(/\r?\n/)) {
+    if (!line.startsWith('data:')) continue;
+    const payload = line.slice(5).trim();
+    if (!payload || payload === '[DONE]') continue;
+    payloads.push(JSON.parse(payload) as unknown);
+  }
+  return payloads;
 }
 
 /** image block 的粗估 token 占位(Anthropic 图像典型 ~1100-1600 tok;粗估用中值,免 stringify 整段 base64)。 */
@@ -257,6 +295,7 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
     // 保证同一会话逐轮请求带同一份工具列表(前缀稳定)。
     const serverSideTools = provider.serverSideTools?.(realModel);
 
+    const downstreamStreaming = parsed.stream !== false;
     const responsesReq = translateRequest(parsed, {
       model: realModel,
       promptCacheKey: sessionId,
@@ -277,7 +316,7 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
         headers: {
           ...providerHeaders,
           'content-type': 'application/json',
-          accept: 'text/event-stream',
+          accept: downstreamStreaming ? 'text/event-stream' : 'application/json',
         },
         body: JSON.stringify(responsesReq),
         signal: abort.signal,
@@ -291,7 +330,12 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
 
     if (!upstream.ok || !upstream.body) {
       const text = upstream.body ? await upstream.text().catch(() => '') : '';
-      log.warn?.('upstream non-2xx', { reqId, status: upstream.status, body: text.slice(0, 2000) });
+      const status = upstream.ok ? 502 : upstream.status;
+      log.warn?.(upstream.ok ? 'upstream 2xx without response body' : 'upstream non-2xx', {
+        reqId,
+        status: upstream.status,
+        body: text.slice(0, 2000),
+      });
       if (!upstream.ok && provider.onUpstreamError) {
         try {
           await provider.onUpstreamError({
@@ -308,9 +352,16 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
           });
         }
       }
-      writeJson(res, upstream.status, {
+      writeJson(res, status, {
         type: 'error',
-        error: { type: anthropicErrorType(upstream.status), message: text.slice(0, 2000) || `upstream ${upstream.status}` },
+        error: {
+          type: anthropicErrorType(status),
+          message: text.slice(0, 2000) || (
+            upstream.ok
+              ? 'provider returned a successful response without a body'
+              : `upstream ${upstream.status}`
+          ),
+        },
       });
       return;
     }
@@ -327,12 +378,53 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
       }
     }
 
+    const upstreamContentType = upstream.headers.get('content-type') ?? '';
+    const upstreamIsSse = upstreamContentType.toLowerCase().includes('event-stream');
+
+    // Claude Code 的 stream watchdog 会以 stream:false 做 fallback。该调用方要求一个完整
+    // Anthropic Message JSON;上游正常会返回 Responses JSON,但仍兼容忽略 stream:false 的 SSE 源。
+    if (!downstreamStreaming) {
+      const translator = new SseTranslator(wireModel);
+      const collector = new AnthropicMessageCollector();
+      const collect = (event: AnthropicSseEvent): void => collector.push(event);
+      try {
+        const body = await readBodyWithLimit(upstream, MAX_NON_STREAM_BODY_BYTES);
+        if (!body.trim()) throw new Error('provider returned an empty response body');
+        if (upstreamIsSse) {
+          for (const event of parseSsePayloads(body)) {
+            for (const output of translator.push(event)) collect(output);
+          }
+          for (const output of translator.finish()) collect(output);
+        } else {
+          const responseJson = JSON.parse(body) as unknown;
+          for (const output of translator.pushJson(responseJson)) collect(output);
+        }
+      } catch (err) {
+        // 客户端已断开(res close → abort):上游读取抛错只是取消的副作用,不写响应。
+        if (abort.signal.aborted) return;
+        const message = err instanceof Error ? err.message : String(err);
+        log.warn?.('upstream non-stream response invalid', { reqId, error: message });
+        writeJson(res, 502, {
+          type: 'error',
+          error: { type: 'api_error', message: `invalid upstream response: ${message}` },
+        });
+        return;
+      }
+
+      const result = collector.finish();
+      if (!result.ok) {
+        writeJson(res, 502, { type: 'error', error: result.error });
+        return;
+      }
+      writeJson(res, 200, result.message);
+      return;
+    }
+
     // 上游 2xx 但 content-type 不是 SSE(反代/网关吐 JSON 或 HTML):大概率整流翻不出
     // 任何事件,先留一条 warn ——零事件收尾时的合成 error 会带上正文前缀(#941)。
     // 判定大小写不敏感(HTTP header 值的 media type 不区分大小写);真实状态码进日志,
     // 本路径接受任意 2xx,不硬编码 200(review 反馈)。
-    const upstreamContentType = upstream.headers.get('content-type') ?? '';
-    if (!upstreamContentType.toLowerCase().includes('event-stream')) {
+    if (!upstreamIsSse) {
       log.warn?.('upstream 2xx with non-SSE content-type', {
         reqId,
         status: upstream.status,
@@ -364,26 +456,30 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
       writeSseEvent(res, ev);
     };
     const finalizeStream = (): void => {
-      for (const outEv of translator.finish()) writeOut(outEv);
-      if (eventsWritten > 0) return;
-      const bodyPrefix = rawPrefix.trim().slice(0, 300);
-      log.warn?.('upstream stream yielded no translatable events', {
-        reqId,
-        contentType: upstreamContentType || '(missing)',
-        bodyPrefix,
-      });
-      writeOut({
-        event: 'error',
-        data: {
-          type: 'error',
-          error: {
-            type: 'api_error',
-            message:
-              `upstream returned HTTP ${upstream.status} but produced no translatable SSE events ` +
-              `(content-type: ${upstreamContentType || 'missing'}${bodyPrefix ? `; body: ${bodyPrefix}` : ''})`,
+      if (eventsWritten === 0) {
+        const bodyPrefix = rawPrefix.trim().slice(0, 300);
+        log.warn?.('upstream stream yielded no translatable events', {
+          reqId,
+          contentType: upstreamContentType || '(missing)',
+          bodyPrefix,
+        });
+        writeOut({
+          event: 'error',
+          data: {
+            type: 'error',
+            error: {
+              type: 'api_error',
+              message:
+                `upstream returned HTTP ${upstream.status} but produced no translatable SSE events ` +
+                `(content-type: ${upstreamContentType || 'missing'}${bodyPrefix ? `; body: ${bodyPrefix}` : ''})`,
+            },
           },
-        },
-      });
+        });
+        return;
+      }
+      // 至少有一个事件但没有 response.completed / response.incomplete:finish() 产出
+      // stream_truncated error,绝不把 clean EOF 伪装成正常 message_stop。
+      for (const outEv of translator.finish()) writeOut(outEv);
     };
     try {
       for (;;) {
@@ -414,8 +510,8 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
         }
         if (start > 0) buf = buf.slice(start);
       }
-      // 上游正常结束但没走 response.completed(极少)→ 兜底收尾;整流零事件时合成
-      // 带上游信息的 error 事件,绝不空 200 收尾。
+      // 上游干净结束:零事件时合成带上游信息的 error 事件;有事件但没走
+      // response.completed 时按截断报错。两条路径都绝不以空 200 / 伪装完成收尾。
       finalizeStream();
     } catch (err) {
       if (!abort.signal.aborted) {

--- a/packages/anthropic-responses-bridge/src/index.ts
+++ b/packages/anthropic-responses-bridge/src/index.ts
@@ -3,7 +3,8 @@
  *
  * 订阅直连协议翻译 handler:让 Claude Code SDK(只会说 Anthropic Messages API)通过用户的
  * ChatGPT 订阅 / xAI 订阅的 OAuth 凭证,以各自 native 的 OpenAI Responses wire 协议调用
- * gpt-5.5 等模型。请求侧 Anthropic Messages → Responses,响应侧 Responses SSE → Anthropic SSE。
+ * gpt-5.5 等模型。请求侧 Anthropic Messages → Responses,响应侧按调用方模式把
+ * Responses SSE / JSON → Anthropic Messages SSE / JSON。
  *
  * 与 @cindy/anthropic-compat-proxy 的分工(一层代理、引擎 + 插槽):
  *   - compat-proxy:代理引擎 —— 字节级透传 + 字段裁剪 + 路由,守 SSE 零延迟(响应不解析)。

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -359,9 +359,9 @@ export function translateRequest(
     model: opts.model,
     input,
     store: false,
-    // 恒 stream:server.ts 的响应翻译器只解析 SSE(非流式 JSON 会被静默丢成空响应)。
-    // Claude Code SDK 全程流式;万一上游拿到 stream:false 请求也强制转成流,保证解析路径唯一。
-    stream: true,
+    // 保持调用方的响应模式:Claude Code 的 stream watchdog 会用 stream:false 做非流式
+    // fallback,bridge 必须让上游返回可组装成单个 Anthropic Message 的 Responses JSON。
+    stream: req.stream !== false,
     include: ['reasoning.encrypted_content'],
   };
 

--- a/packages/anthropic-responses-bridge/src/translate-sse.ts
+++ b/packages/anthropic-responses-bridge/src/translate-sse.ts
@@ -2,8 +2,9 @@
  * 流式响应翻译 —— OpenAI Responses SSE → Anthropic Messages SSE(有状态)。
  *
  * 用法:server 逐条 parse 上游 `data:` 行成对象,喂给 `push(event)`,拿回 0..N 条
- * Anthropic SSE 事件顺序写回客户端。上游流结束后调 `finish()` 兜底收尾(极少触发,
- * 正常 response.completed 已收尾)。
+ * Anthropic SSE 事件顺序写回客户端。上游流结束后调 `finish()`:正常 response.completed
+ * 已收尾时它是 no-op,否则按流截断发 error(不合成 message_stop)。非流式调用方走
+ * `pushJson()` 把整个 Responses JSON 喂进同一状态机。
  *
  * Responses 事件序列(Phase0 探针实测):
  *   response.created → in_progress
@@ -235,21 +236,75 @@ export class SseTranslator {
     return out;
   }
 
-  /** 上游流意外结束(没收到 response.completed)时兜底收尾。 */
+  /** 上游流结束时验证已收到 Responses terminal event;否则按截断失败收尾。 */
   finish(): AnthropicSseEvent[] {
     if (this.finished) return [];
-    const out: AnthropicSseEvent[] = [];
-    // 断流时不再有解锁事件,强制回放暂存队列(fc 块 args 已注定残缺,如实关块)。
-    this.drainDeferred(out, true);
-    this.closeAllOpenBlocks(out);
-    if (this.messageStarted) {
-      out.push({
-        event: 'message_delta',
-        data: { type: 'message_delta', delta: { stop_reason: this.defaultStopReason(), stop_sequence: null }, usage: { output_tokens: 0 } },
-      });
-      out.push({ event: 'message_stop', data: { type: 'message_stop' } });
+    return this.fail('upstream stream ended before response.completed (stream_truncated)');
+  }
+
+  /**
+   * 非流式 Responses JSON → 与 SSE 相同的 Anthropic 事件状态机。
+   *
+   * 先合成标准 Responses 生命周期事件,再复用 push():content block 顺序、reasoning blob、
+   * tool arguments、usage 和 stop reason 因而与流式路径保持一致。
+   */
+  pushJson(raw: unknown): AnthropicSseEvent[] {
+    const response = asRecord(raw);
+    if (Object.keys(response).length === 0) {
+      return this.fail('upstream returned an invalid Responses JSON object');
     }
-    this.finished = true;
+    if (response.status === 'failed' || response.error) {
+      return this.push({ type: 'response.failed', response });
+    }
+    if (response.status !== 'completed' && response.status !== 'incomplete') {
+      return this.fail('upstream returned a non-terminal Responses JSON object');
+    }
+
+    const out: AnthropicSseEvent[] = [];
+    out.push(...this.push({ type: 'response.created', response }));
+    const output = Array.isArray(response.output) ? response.output : [];
+    for (let outputIndex = 0; outputIndex < output.length; outputIndex += 1) {
+      const item = asRecord(output[outputIndex]);
+      const itemType = typeof item.type === 'string' ? item.type : '';
+      out.push(...this.push({ type: 'response.output_item.added', output_index: outputIndex, item }));
+
+      if (itemType === 'message') {
+        const content = Array.isArray(item.content) ? item.content : [];
+        for (const partValue of content) {
+          const part = asRecord(partValue);
+          if (part.type === 'output_text' && typeof part.text === 'string') {
+            out.push(...this.push({
+              type: 'response.output_text.delta',
+              output_index: outputIndex,
+              delta: part.text,
+            }));
+          }
+        }
+      } else if (itemType === 'reasoning') {
+        const summary = Array.isArray(item.summary) ? item.summary : [];
+        for (const partValue of summary) {
+          const part = asRecord(partValue);
+          if (part.type === 'summary_text' && typeof part.text === 'string') {
+            out.push(...this.push({
+              type: 'response.reasoning_summary_text.delta',
+              output_index: outputIndex,
+              delta: part.text,
+            }));
+          }
+        }
+      } else if (itemType === 'function_call' && typeof item.arguments === 'string') {
+        out.push(...this.push({
+          type: 'response.function_call_arguments.delta',
+          output_index: outputIndex,
+          delta: item.arguments,
+        }));
+      }
+
+      out.push(...this.push({ type: 'response.output_item.done', output_index: outputIndex, item }));
+    }
+
+    const status = response.status === 'incomplete' ? 'response.incomplete' : 'response.completed';
+    out.push(...this.push({ type: status, response }));
     return out;
   }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

用户用 ChatGPT 订阅的 GPT 模型（`chatgpt/*`）跑 Claude Code 时，经常撞到
`API Error: API returned an empty or malformed response (HTTP 200)`。

这条错误来自随包 Claude Code 的**非流式 fallback**：`env-builder.ts` 有意开着
stream watchdog 并保留 `CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK` 默认关，所以流式
请求卡住后，同一轮会以 `stream:false` 重试，并期待一个完整的 Anthropic Message JSON。

但 `@cindy/anthropic-responses-bridge` 此前无条件把上游请求改成 `stream:true`，并且
无论调用方要什么都只回 `text/event-stream`。于是 fallback 拿到 HTTP 200 + SSE，Message
校验失败 → 就是截图里那条错误。顺带修掉同一路径上另外两处会制造「空响应」的语义问题。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：无（用户实机反馈截图）
- 本 PR 包含：
  1. **非流式 fallback 契约**：`translateRequest` 的 `stream` 跟随调用方
     （`req.stream !== false`），上游 `Accept` 随模式切换；`stream:false` 时 handler
     缓冲上游响应并返回单个 Anthropic Message JSON。上游若无视 `stream:false` 仍回 SSE，
     也在桥内缓冲后组装，不把 SSE 丢给 JSON 解析器。
     新增 `SseTranslator.pushJson()` 让非流式 Responses JSON 复用同一套状态机 ——
     text / reasoning blob / tool arguments / usage / stop_reason 只有一套事实源；
     新增 `AnthropicMessageCollector` 负责收敛成 Message，拼不出合法 message、
     tool arguments 非法 JSON 或零 content block 时返回 502 带上游原因。
  2. **上游 2xx 无 body**：改回 **502**。此前沿用上游状态码，产出
     `HTTP 200 + {type:"error"}` 这种自相矛盾的响应，非流式 fallback 同样会判成 malformed。
     反向桥 `responses-anthropic-bridge` 早已是 502，两侧口径现在一致。
  3. **干净 EOF 不再伪装完成**：`SseTranslator.finish()` 不再合成
     `message_delta + message_stop`；没收到 `response.completed` / `response.incomplete`
     就按 `stream_truncated` 发 error。此前上游在 `message_start` 之后干净断开会被翻译成
     「正常完成但没正文」，用户侧表现为静默空回复。
- 明确不包含：
  - 不改 `anthropic-compat-proxy` 对 XD / Cindy AI 未加前缀模型的字节级透传语义；
  - 不动 stream watchdog 的超时策略或 Claude Code fallback 开关（本 PR 是让桥接层
    履行既有 fallback 契约，不是绕过它）；
  - 不改 `chatgpt/` / `xai/` 之外的任何路由。
- 用户可见变化：订阅模型在 watchdog 自愈后不再报 empty/malformed 200；上游真实故障
  （空 body、截断流、流内错误）现在带原因暴露出来，而不是空回复或盲目重试。
- 是否存在 breaking change：无。流式路径（正常主路径）行为不变，公开导出未变。

### UI 变化

不涉及

- 引用的设计规范：不涉及（只改 `packages/anthropic-responses-bridge` 协议翻译层，无
  界面、组件、样式或 UI 文案改动）

### 远程 / 手机版适配（docs/dev-rules/remote-and-mobile-adaptation.md）

不涉及，理由：本改动只在 Desktop 主进程内的回环协议翻译 handler 里，不触及 workdir
文件、agent 进程或会话数据的读写位置，不新增 IPC channel / 推送事件，也没有需要手机端
呈现的入口。SSH 远程会话的 Claude Code 由远端 cc-manager 驱动，不经本地这个 bridge。

## 怎么验证的

### 自动验证

```text
pnpm --filter @cindy/anthropic-responses-bridge test
结果：Test Files 3 passed | 1 skipped (4)；Tests 70 passed | 3 skipped (73)
      （skip 的 3 个是需要 BRIDGE_LIVE=1 + 本机订阅凭证的联网活体测试）

pnpm --filter @cindy/anthropic-responses-bridge typecheck
结果：通过（tsc --noEmit 无输出）

pnpm --filter @cindy/anthropic-responses-bridge lint
结果：通过

pnpm --filter desktop typecheck
结果：通过（exit 0）

pnpm test:unit
结果：31 个 workspace 通过、6 个 notApplicable 跳过；唯一失败是
      apps/desktop 的 src/renderer/__tests__/i18nCompleteness.test.ts
      （23764 passed / 1 failed / 2 skipped）。该失败与本 PR 无关，见下。

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range 9bcf7bd1..1007375f
```

新增/调整的用例（`packages/anthropic-responses-bridge/src/__tests__/`）：

- `stream:false` → 上游收到 `stream:false` + `Accept: application/json`，下游收到
  完整 Message JSON（text + tool_use，`input` 已由 arguments 解析成对象，usage / stop_reason 正确）
- `stream:false` 但上游仍返回 SSE → 桥内缓冲后仍返回 Message JSON
- `stream:false` 且上游 `response.failed` → 502 并透传 `[context_length_exceeded] ...`
- `stream:false` 且上游 completed 但零 output → 502 `no content blocks`，不回空 message
- 上游 HTTP 200 无 body → 502，且不触发 `onUpstreamError`（它的契约是非 2xx）
- 流式 SSE 干净 EOF 未完成 → `event: error` + `stream_truncated`，不含 `message_stop`
- `translateRequest` 的 `stream` 透传（默认 true / 显式 false）
- `pushJson()` 的 text / tool arguments / stop_reason 映射

### 手工验证

不涉及。改动在 worktree 内，Vite/宿主实例不会热更到该 checkout，我无法在此重启宿主
做实机验证（见 docs/dev-rules/development-workflow.md 第 1 节）。

### 未执行的验证

- **实机端到端未验证**：没有在真实 Desktop 实例里复现「watchdog 触发 → 非流式 fallback
  → 正常拿到回答」的完整链路，需要重启宿主。建议合并前由能重启实例的人跑一次真实
  `chatgpt/gpt-5.6-sol` 会话，并观察 watchdog 触发后是否还出现该 banner。
- **活体桥接测试未执行**：`live-bridge.test.ts` 需要 `BRIDGE_LIVE=1` 与本机
  `~/.codex/auth.json` 订阅凭证，本次未跑，也未新增覆盖非流式路径的活体用例。
- **基线预先存在的失败**：`i18nCompleteness` 缺的三个 key
  （`settings.subagentModels.guardrails.cindyPolicy{Label,Hint,Aria}` 在 `zh-TW` 缺失）
  由本 PR 的 base 提交 `9bcf7bd1a` 引入（`git log -S cindyPolicyLabel` 指向该提交，
  en/ko/ja/zh-CN 都有、zh-TW 没有）。本 PR 不含任何 renderer / i18n 改动，因此没有
  顺手在这里补 —— 应由该功能作者或单独的 i18n 修复处理。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响经本地 Responses bridge 的订阅直连模型（`chatgpt/*`、`xai/*`）。
  协议兼容点有两处需要 reviewer 重点看：
  1. **上游请求的 `stream` 不再恒为 true**。`stream:false` 只在 Claude Code 走非流式
     fallback 时出现，正常主路径仍是 `stream:true`，请求体逐字节不变，
     **prompt 前缀稳定性与缓存率不受影响**（tools / instructions / reasoning 组装均未改）。
  2. **`finish()` 的语义从「兜底补完成」变成「按截断报错」**。若某个上游会以只发
     `[DONE]`、不发 `response.completed` 的方式结束流，行为会从「静默当成 end_turn」
     变成「报 stream_truncated」。已核对 codex 后端与 api.x.ai 的实测事件序列都以
     `response.completed` 收尾（`translate-sse.ts` 文件头记录的 Phase0 探针序列），
     且 `[DONE]` 帧本就被 handler 跳过；反向桥 `responses-anthropic-bridge.finish()`
     早已是同一口径。
- 回滚 / 降级方式：改动集中在单个 package 的 3 个文件 + 1 个新文件，`git revert` 该
  commit 即可完全回到原行为，无数据迁移、无持久化状态、无跨端 wire 变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（协议行为变化写在改动处的注释里；无规则文档需要同步修正）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
