### PR TITLE
fix(desktop): 修复 Windows OAuth 返回后窗口未前置

### DIFF
--- a/apps/desktop/src/main/__tests__/deepLink.test.ts
+++ b/apps/desktop/src/main/__tests__/deepLink.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { BrowserWindow } from 'electron';
+import { app, type BrowserWindow } from 'electron';
 
 // vitest 跑测试时不会真的初始化 Electron app, 单 import 需要 mock electron。
 // deepLink.ts 只在 registerDeepLinkProtocol / dispatchDeepLink 用到 app /
@@ -39,9 +39,32 @@ import {
   DEEP_LINK_PROTOCOL,
   OPEN_FOLDER_FLAG,
   OPEN_SHARE_FILE_FLAG,
+  focusMainWindow,
   openMainWindowVoiceSettings,
   setDeepLinkMainWindow,
 } from '../deepLink';
+
+describe('user-initiated main-window focus', () => {
+  it('activates and raises the target window before focusing on Windows', () => {
+    const calls: string[] = [];
+    const mainWindow = {
+      isDestroyed: () => false,
+      isVisible: () => false,
+      isMinimized: () => true,
+      show: vi.fn(() => calls.push('show')),
+      restore: vi.fn(() => calls.push('restore')),
+      moveTop: vi.fn(() => calls.push('moveTop')),
+      focus: vi.fn(() => calls.push('window.focus')),
+    };
+    vi.mocked(app.focus).mockImplementation(() => calls.push('app.focus'));
+    setDeepLinkMainWindow(mainWindow as unknown as BrowserWindow);
+
+    expect(focusMainWindow('win32')).toBe(true);
+
+    expect(calls).toEqual(['show', 'restore', 'app.focus', 'moveTop', 'window.focus']);
+    setDeepLinkMainWindow(null);
+  });
+});
 
 describe('internal main-window navigation', () => {
   it('focuses the main window and routes voice settings to the requested tab', () => {

--- a/apps/desktop/src/main/deepLink.ts
+++ b/apps/desktop/src/main/deepLink.ts
@@ -288,17 +288,26 @@ export function handleIncomingShareFile(filePath: string, source: string): void 
 }
 
 /**
- * 把主窗口拉回前台 (show + restore + focus;macOS 额外 app.focus steal——从浏览器
- * 等其它前台应用手里抢焦点,单靠 win.focus() 在 macOS 上不可靠)。
+ * 把主窗口拉回前台 (show + restore + focus)。Windows 的外部协议唤起需要先
+ * 激活应用并提升目标窗口 z-order；macOS 额外使用 app.focus steal——
+ * 从浏览器等其它前台应用手里抢焦点，单靠 win.focus() 不可靠。
  * 窗口不存在 / 已销毁时返回 false,调用方自行决定是否忽略。
  */
-export function focusMainWindow(): boolean {
+export function focusMainWindow(platform: NodeJS.Platform = process.platform): boolean {
   const win = mainWindowRef;
   if (!win || win.isDestroyed()) return false;
   if (!win.isVisible()) win.show();
   if (win.isMinimized()) win.restore();
+  if (platform === 'win32') {
+    // Windows 可以收到 second-instance deep link 但仍把浏览器保留在
+    // 前台。app.focus() 先激活应用，moveTop() 再确保用户主动点击的
+    // OAuth 返回窗口不被原浏览器遮挡。该函数只用于 focus deep link，
+    // 不会把后台 Ghost workspace 请求扩大为强制抢前台。
+    app.focus();
+    win.moveTop();
+  }
   win.focus();
-  if (process.platform === 'darwin') app.focus({ steal: true });
+  if (platform === 'darwin') app.focus({ steal: true });
   return true;
 }
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

Windows 上从浏览器完成 OAuth 后，`cindy://` deep link 虽然会被 Cindy 接收，但主窗口可能仍被浏览器遮挡。本 PR 在用户主动触发的 deep-link 聚焦路径中先激活应用，再将目标窗口提升到顶层并聚焦；macOS 的既有 `app.focus({ steal: true })` 行为保持不变。

同时新增 Windows 调用顺序回归测试，覆盖隐藏、最小化、应用激活、窗口置顶和最终聚焦。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：Closes #2338
- 本 PR 包含：Windows deep-link/OAuth 返回时的主窗口前置；对应单元测试
- 明确不包含：OAuth 服务端、协议注册、登录页面或插件实现调整
- 用户可见变化：点击授权成功页的“Return to Cindy”后，Windows 上 Cindy 主窗口会回到前台
- 是否存在 breaking change：无

### UI 变化

不涉及视觉 UI：仅调整 Electron main process 的窗口激活与 z-order 行为，没有布局、样式或文案变化。

- 引用的设计规范：不涉及，原因同上

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=1 src/main/__tests__/deepLink.test.ts
结果：36 passed，2 个既有平台测试 skipped

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm test:runner
结果：385 passed，8 skipped，0 failed

pnpm test:unit -- --no-lock / workspace unit
结果：主流程覆盖完成；高并发下 2 个既有 10 秒 hook 测试出现瞬时超时，变基后协议子模块首次运行缺少独立 devDependencies。执行 frozen install 后针对全部失败集合复验：
- codexAuthInvalidation + review plugin：46/46 passed（单 worker）
- model-access-protocol：32/32 passed
- plugin-protocol：64/64 passed
- slack-hook-protocol：149/149 passed
其余 workspace 在全量运行中均通过。

pnpm check:dco
结果：通过，1 个 commit 已签署
```

### 手工验证

Windows 11：已在安装版复现授权成功后 Cindy 收到 deep link、但浏览器仍保持前台的问题。修复后的调用顺序由单元测试覆盖。

### 未执行的验证

未重新打包完整 Windows 安装包进行端到端 OAuth 授权；未在 macOS 运行时验证。macOS 分支逻辑未改变。

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：仅 `focusMainWindow` 在 Windows 的用户主动 deep-link 聚焦路径；后台 Ghost workspace 路径不使用该强制前置逻辑
- 回滚 / 降级方式：移除 Windows 分支中的 `app.focus()` 与 `win.moveTop()` 即可恢复原行为

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及视觉 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试
- [x] 已确认测试结果或说明未执行原因