### PR TITLE
fix(anthropic-responses-bridge): 让非流式 fallback 真正生效(补 #2332)

### DIFF
--- a/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/handler.test.ts
@@ -100,7 +100,7 @@ describe('createResponsesHandler', () => {
     }));
     const handler = createResponsesHandler({ providers: [providerConfig()] });
 
-    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] }, { prefs: { fast: true, reasoningEffort: 'xhigh' } });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true }, { prefs: { fast: true, reasoningEffort: 'xhigh' } });
     expect(r.status).toBe(200);
     expect(r.text).toContain('message_start');
     expect(r.text).toContain('"chatgpt/gpt-5.5"'); // message_start 回显带前缀 model(记账判据)
@@ -113,7 +113,7 @@ describe('createResponsesHandler', () => {
 
     // fast=false / provider 无 fastServiceTier → 不发 service_tier。
     seen.length = 0;
-    await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] }, { prefs: { fast: false } });
+    await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true }, { prefs: { fast: false } });
     expect(seen[0].body.service_tier).toBeUndefined();
   });
 
@@ -132,7 +132,7 @@ describe('createResponsesHandler', () => {
       providers: [providerConfig()],
       logger: { warn: (msg) => warns.push(msg) },
     });
-    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true });
     expect(r.status).toBe(200);
     expect(r.text).toContain('event: error');
     expect(r.text).toContain('no translatable SSE events');
@@ -152,7 +152,7 @@ describe('createResponsesHandler', () => {
       providers: [providerConfig()],
       logger: { warn: (msg) => warns.push(msg) },
     });
-    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true });
     expect(r.text).toContain('message_stop');
     expect(warns).not.toContain('upstream 2xx with non-SSE content-type');
   });
@@ -177,7 +177,7 @@ describe('createResponsesHandler', () => {
       { status: 200, headers: { 'content-type': 'text/event-stream' } },
     )));
     const handler = createResponsesHandler({ providers: [providerConfig()] });
-    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true });
     expect(r.text).toContain('message_start');
     expect(r.text).toContain('upstream stream error: socket reset');
     // 截断响应必须以 error 事件收尾,不能以 message_stop 伪装正常完成。
@@ -190,7 +190,7 @@ describe('createResponsesHandler', () => {
       { status: 200, headers: { 'content-type': 'text/event-stream' } },
     )));
     const handler = createResponsesHandler({ providers: [providerConfig()] });
-    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    const r = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true });
     expect(r.status).toBe(200);
     expect(r.text).toContain('[server_error] boom');
     expect(r.text).not.toContain('no translatable SSE events');
@@ -204,7 +204,7 @@ describe('createResponsesHandler', () => {
     }));
     const handler = createResponsesHandler({ providers: [providerConfig({ prefix: 'xai/' })] });
 
-    const r = await invoke(handler, { model: 'xai/grok-4.3[1m]', messages: [] });
+    const r = await invoke(handler, { model: 'xai/grok-4.3[1m]', messages: [], stream: true });
     expect(r.status).toBe(200);
     expect(seen[0].body.model).toBe('grok-4.3');
   });
@@ -226,18 +226,18 @@ describe('createResponsesHandler', () => {
       })],
     });
 
-    await invoke(handler, { model: 'xai/grok-4.5', messages: [] });
+    await invoke(handler, { model: 'xai/grok-4.5', messages: [], stream: true });
     expect(seen[0].body.tools).toEqual([{ type: 'x_search' }]);
     // 门控拿到的是剥掉前缀与 [1m] 后缀的真实 model id。
     expect(askedModels).toEqual(['grok-4.5']);
 
     // 编码模型:门控返回空 → 完全不发 tools。
     seen.length = 0;
-    await invoke(handler, { model: 'xai/grok-code-fast', messages: [] });
+    await invoke(handler, { model: 'xai/grok-code-fast', messages: [], stream: true });
     expect(seen[0].body.tools).toBeUndefined();
   });
 
-  it('stream:false → 上游 Responses JSON,下游返回完整 Anthropic Message JSON', async () => {
+  it('stream:false → 上游仍恒 stream:true + SSE Accept,下游返回完整 Anthropic Message JSON', async () => {
     const seen: Array<{ body: Record<string, unknown>; accept: string }> = [];
     vi.stubGlobal('fetch', vi.fn(async (_url: string, init: RequestInit) => {
       seen.push({
@@ -288,10 +288,35 @@ describe('createResponsesHandler', () => {
       { type: 'text', text: 'hello' },
       { type: 'tool_use', id: 'call_1', name: 'Bash', input: { command: 'pwd' } },
     ]);
-    expect(seen[0]).toMatchObject({ body: { stream: false }, accept: 'application/json' });
+    // 上游恒流式:codex 对 stream:false 返 400 `{"detail":"Stream must be set to true"}`,
+    // 非流式只体现在**下游**表示上。本用例同时覆盖上游直接给 Responses JSON 的兼容路径。
+    expect(seen[0]).toMatchObject({ body: { stream: true }, accept: 'text/event-stream' });
   });
 
-  it('stream:false 上游仍返回 SSE → bridge 缓冲后返回 Anthropic Message JSON', async () => {
+  it('省略 stream 字段(cc 非流式 fallback 的真实形态)→ 返回 Message JSON,不回 SSE', async () => {
+    // Claude Code 的非流式 fallback 走 SDK 的 messages.create(),请求体**没有 stream 字段**
+    // (随包 cc 二进制实测)。按 `stream !== false` 判会把它误当流式、回 SSE,CLI 随即报
+    // "empty or malformed response (HTTP 200)" —— 正是用户截图那条。
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(sse(OK_SSE), {
+      status: 200,
+      headers: { 'content-type': 'text/event-stream' },
+    })));
+    const handler = createResponsesHandler({ providers: [providerConfig()] });
+
+    const result = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+
+    expect(result.status).toBe(200);
+    expect(String(result.headers['content-type'])).toContain('application/json');
+    expect(result.text).not.toContain('event: ');
+    expect(JSON.parse(result.text)).toMatchObject({
+      type: 'message',
+      role: 'assistant',
+      content: [{ type: 'text', text: 'hi' }],
+      stop_reason: 'end_turn',
+    });
+  });
+
+  it('stream:false 上游返回 SSE(真实形态)→ bridge 缓冲后返回 Anthropic Message JSON', async () => {
     vi.stubGlobal('fetch', vi.fn(async () => new Response(sse(OK_SSE), {
       status: 200,
       headers: { 'content-type': 'text/event-stream' },
@@ -395,7 +420,7 @@ describe('createResponsesHandler', () => {
     })));
     const handler = createResponsesHandler({ providers: [providerConfig()] });
 
-    const result = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [] });
+    const result = await invoke(handler, { model: 'chatgpt/gpt-5.5', messages: [], stream: true });
 
     expect(result.status).toBe(200);
     expect(result.text).toContain('stream_truncated');

--- a/packages/anthropic-responses-bridge/src/__tests__/live-bridge.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/live-bridge.test.ts
@@ -189,4 +189,49 @@ describe.skipIf(!LIVE)('bridge live e2e (chatgpt codex, handler 形态)', () => 
       await harness.close();
     }
   }, 60000);
+
+  /**
+   * 非流式 fallback 的活体验证 —— Claude Code 的 stream watchdog 触发后会以 stream:false
+   * 重试同一轮,并期待一个完整的 Anthropic Message JSON。这里直接构造该请求,不必复现卡顿。
+   *
+   * 它同时验证一个关键假设:**chatgpt.com/backend-api/codex 是否接受 stream:false**。
+   * 若上游拒收(4xx),说明桥不该把 stream 透传给上游,而应恒请求 SSE、只改下游表示。
+   */
+  for (const model of ['chatgpt/gpt-5.5', 'chatgpt/gpt-5.6-sol']) {
+    it(`非流式 fallback:${model} + stream:false → 完整 Anthropic Message JSON`, async () => {
+      const harness = await startHarness(makeCodexHandler());
+      try {
+        const res = await fetch(`${harness.url}/v1/messages`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json', 'x-claude-code-session-id': 'live-test-nonstream' },
+          body: JSON.stringify({
+            model,
+            system: 'You are terse.',
+            max_tokens: 64,
+            stream: false,
+            messages: [{ role: 'user', content: 'Reply with exactly: nonstream ok' }],
+          }),
+        });
+        const bodyText = await res.text();
+        console.log(`[${model}] 非流式 status:`, res.status, '| content-type:', res.headers.get('content-type'));
+        console.log(`[${model}] 非流式正文:`, bodyText.slice(0, 1200));
+        expect(res.status).toBe(200);
+        // 下游必须是 JSON,不能是 SSE —— 这正是截图里 CLI 判 malformed 的原因。
+        expect(res.headers.get('content-type')).toContain('application/json');
+        const msg = JSON.parse(bodyText) as Record<string, unknown>;
+        expect(msg.type).toBe('message');
+        expect(msg.role).toBe('assistant');
+        expect(msg.model).toBe(model);
+        expect(Array.isArray(msg.content)).toBe(true);
+        const text = (msg.content as Array<Record<string, unknown>>)
+          .filter((b) => b.type === 'text')
+          .map((b) => String(b.text ?? ''))
+          .join('');
+        console.log(`[${model}] 非流式输出文本:`, JSON.stringify(text), '| stop_reason:', msg.stop_reason);
+        expect(text.toLowerCase()).toContain('nonstream');
+      } finally {
+        await harness.close();
+      }
+    }, 60000);
+  }
 });

--- a/packages/anthropic-responses-bridge/src/__tests__/nonstream-fallback-e2e.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/nonstream-fallback-e2e.test.ts
@@ -1,0 +1,205 @@
+/**
+ * 端到端验证「stream watchdog → 非流式 fallback → bridge」整条链路 —— **不联网、不用凭证**。
+ *
+ * 拓扑:
+ *   真实 claude 二进制(apps/claude-code-bin,与 Desktop 随包同一份)
+ *     → ANTHROPIC_BASE_URL 指向本地 bridge handler
+ *       → upstreamBase 指向本地 Responses stub
+ *
+ * stub 的第一次请求故意「发一半就挂住」,触发 cc 内置 watchdog(阈值压到 1.5s);cc 随后在
+ * 同一轮以 `stream:false` 重试,bridge 必须回一个完整的 Anthropic Message JSON。修复前
+ * bridge 回的是 HTTP 200 + SSE,cc 会报
+ * "API returned an empty or malformed response (HTTP 200)" —— 正是用户截图那条。
+ *
+ * 默认跳过(spawn 真实 CLI、耗时数十秒);需要时:
+ *   BRIDGE_E2E=1 pnpm --filter @cindy/anthropic-responses-bridge exec vitest run src/__tests__/nonstream-fallback-e2e.test.ts
+ */
+import { spawn } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { createResponsesHandler } from '../handler.js';
+
+const E2E = process.env.BRIDGE_E2E === '1';
+const ANSWER = 'nonstream fallback ok';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const claudeBin = path.join(repoRoot, 'apps/claude-code-bin/darwin-arm64/claude');
+
+function sseFrame(event: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+/** 完整的一轮 Responses SSE(纯文本回答)。 */
+function completeStream(): string {
+  return [
+    sseFrame({ type: 'response.created', response: { id: 'resp_stub', model: 'gpt-5.6-sol' } }),
+    sseFrame({ type: 'response.output_item.added', output_index: 0, item: { id: 'msg_1', type: 'message' } }),
+    sseFrame({ type: 'response.output_text.delta', output_index: 0, delta: ANSWER }),
+    sseFrame({ type: 'response.output_item.done', output_index: 0, item: { id: 'msg_1', type: 'message' } }),
+    sseFrame({
+      type: 'response.completed',
+      response: { status: 'completed', usage: { input_tokens: 12, output_tokens: 5 } },
+    }),
+  ].join('');
+}
+
+/** bridge 与 stub 共享的链路状态。 */
+interface ChainState {
+  /** bridge 收到的下游非流式请求数(`stream` 非 true = cc 升级到非流式 fallback)。 */
+  nonStream: number;
+}
+
+/**
+ * Responses stub:**在 cc 升级到非流式 fallback 之前,每次请求都发一半后挂住**,逼 cc 把
+ * 流式重试耗尽 —— cc 只在流式尝试抛错后才走非流式(二进制里的
+ * "Error streaming, falling back to non-streaming mode" 分支)。一旦 bridge 收到
+ * `stream:false`(state.nonStream > 0),后续请求给完整流,让这一轮能正常收敛。
+ */
+function startStubUpstream(state: ChainState): Promise<{ url: string; requests: () => number; close: () => Promise<void> }> {
+  let seen = 0;
+  const stalled: Array<{ destroy: () => void }> = [];
+  const server: Server = createServer((req, res) => {
+    req.on('data', () => { /* 请求体不参与判定:bridge 对上游恒发 stream:true */ });
+    req.on('end', () => {
+      seen += 1;
+      res.writeHead(200, {
+        'content-type': 'text/event-stream; charset=utf-8',
+        'cache-control': 'no-cache',
+        connection: 'keep-alive',
+      });
+      if (state.nonStream === 0) {
+        // 发出开头两帧后**直接断 socket** —— 硬流式错误,cc 二进制里
+        // "Error streaming, falling back to non-streaming mode" 的直接触发条件。
+        // (纯 idle 挂住会让 cc 等到 API_TIMEOUT_MS 才动,慢且不确定。)
+        res.write(sseFrame({ type: 'response.created', response: { id: 'resp_stall', model: 'gpt-5.6-sol' } }));
+        res.write(sseFrame({ type: 'response.output_item.added', output_index: 0, item: { id: 'msg_0', type: 'message' } }));
+        setTimeout(() => res.destroy(), 50);
+        return;
+      }
+      res.end(completeStream());
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        requests: () => seen,
+        close: () => new Promise<void>((r) => {
+          for (const s of stalled) s.destroy();
+          server.close(() => r());
+        }),
+      });
+    });
+  });
+}
+
+/** 本地 Anthropic 面:把请求交给 bridge handler(与 compat-proxy 的 localHandler 同形态)。 */
+function startBridge(upstreamBase: string, state: ChainState): Promise<{ url: string; close: () => Promise<void> }> {
+  const handler = createResponsesHandler({
+    providers: [{
+      prefix: 'chatgpt/',
+      upstreamBase,
+      buildHeaders: async () => ({ authorization: 'Bearer stub' }),
+    }],
+  });
+  const server: Server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      let parsedBody: unknown;
+      try {
+        parsedBody = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      } catch {
+        parsedBody = undefined;
+      }
+      // cc 的非流式 fallback **不带 stream 字段**(SDK messages.create()),不是 stream:false。
+      if (parsedBody && typeof parsedBody === 'object' && (parsedBody as { stream?: unknown }).stream !== true) {
+        state.nonStream += 1;
+      }
+      const headers: Record<string, string> = {};
+      for (const [k, v] of Object.entries(req.headers)) {
+        headers[k.toLowerCase()] = Array.isArray(v) ? v.join(', ') : String(v ?? '');
+      }
+      void handler.handle({
+        parsedBody,
+        ctx: { method: req.method ?? 'POST', url: req.url ?? '/', headers },
+        res,
+      });
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr ? addr.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+describe.skipIf(!E2E)('watchdog → 非流式 fallback → bridge(真实 claude 二进制,本地 stub 上游)', () => {
+  it('上游中途静默 → cc 以 stream:false 重试 → bridge 回完整 Message,cc 正常出答案', async () => {
+    expect(fs.existsSync(claudeBin)).toBe(true);
+    const state: ChainState = { nonStream: 0 };
+    const stub = await startStubUpstream(state);
+    const bridge = await startBridge(stub.url, state);
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'cc-e2e-home-'));
+    try {
+      const child = spawn(claudeBin, [
+        '--print',
+        '--model', 'chatgpt/gpt-5.6-sol',
+        `Reply with exactly: ${ANSWER}`,
+      ], {
+        env: {
+          PATH: process.env.PATH ?? '',
+          HOME: home,
+          CLAUDE_CONFIG_DIR: home,
+          ANTHROPIC_BASE_URL: bridge.url,
+          ANTHROPIC_AUTH_TOKEN: 'stub-token',
+          ANTHROPIC_API_KEY: 'stub-token',
+          // 与 Desktop 的 env-builder 同口径:开 watchdog、保留非流式 fallback。
+          CLAUDE_ENABLE_STREAM_WATCHDOG: 'true',
+          CLAUDE_STREAM_IDLE_TIMEOUT_MS: '1500',
+          API_TIMEOUT_MS: '15000',
+          DISABLE_TELEMETRY: '1',
+          DISABLE_ERROR_REPORTING: '1',
+          OTEL_SDK_DISABLED: 'true',
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout.on('data', (c: Buffer) => { stdout += c.toString('utf8'); });
+      child.stderr.on('data', (c: Buffer) => { stderr += c.toString('utf8'); });
+      const code = await new Promise<number | null>((resolve) => {
+        const timer = setTimeout(() => { child.kill('SIGKILL'); resolve(null); }, 240_000);
+        child.on('close', (c) => { clearTimeout(timer); resolve(c); });
+      });
+
+      console.log('cc exit code:', code);
+      console.log('cc stdout:', stdout.trim().slice(0, 2000));
+      if (stderr.trim()) console.log('cc stderr:', stderr.trim().slice(0, 2000));
+      console.log('stub 收到上游请求数:', stub.requests(), '| bridge 收到非流式请求数:', state.nonStream);
+
+      // 关键断言:watchdog 触发过(上游被打了 ≥2 次)、bridge 收到过非流式请求,
+      // 且 cc 最终拿到了答案而不是那条 empty/malformed banner。
+      expect(state.nonStream).toBeGreaterThan(0);
+      expect(stub.requests()).toBeGreaterThan(1);
+      expect(stdout + stderr).not.toContain('empty or malformed response');
+      expect(stdout.toLowerCase()).toContain('nonstream fallback ok');
+    } finally {
+      await bridge.close();
+      await stub.close();
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  }, 300_000);
+});

--- a/packages/anthropic-responses-bridge/src/__tests__/nonstream-fallback-e2e.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/nonstream-fallback-e2e.test.ts
@@ -6,13 +6,15 @@
  *     → ANTHROPIC_BASE_URL 指向本地 bridge handler
  *       → upstreamBase 指向本地 Responses stub
  *
- * stub 的第一次请求故意「发一半就挂住」,触发 cc 内置 watchdog(阈值压到 1.5s);cc 随后在
- * 同一轮以 `stream:false` 重试,bridge 必须回一个完整的 Anthropic Message JSON。修复前
- * bridge 回的是 HTTP 200 + SSE,cc 会报
+ * stub 在 cc 升级到非流式之前每次都「发两帧后断 socket」,逼它把流式重试耗尽 —— cc 只在
+ * 流式尝试抛错后才走非流式 fallback,且该 fallback 请求**不带 stream 字段**。bridge 必须
+ * 回一个完整的 Anthropic Message JSON;修复前它回的是 HTTP 200 + SSE,cc 随即报
  * "API returned an empty or malformed response (HTTP 200)" —— 正是用户截图那条。
  *
  * 默认跳过(spawn 真实 CLI、耗时数十秒);需要时:
  *   BRIDGE_E2E=1 pnpm --filter @cindy/anthropic-responses-bridge exec vitest run src/__tests__/nonstream-fallback-e2e.test.ts
+ *
+ * 二进制按当前平台解析,本平台没有随包二进制时用例显式 skip(见 resolveClaudeBin)。
  */
 import { spawn } from 'node:child_process';
 import { createServer, type Server } from 'node:http';
@@ -28,7 +30,19 @@ const E2E = process.env.BRIDGE_E2E === '1';
 const ANSWER = 'nonstream fallback ok';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
-const claudeBin = path.join(repoRoot, 'apps/claude-code-bin/darwin-arm64/claude');
+
+/**
+ * 按当前平台解析随包 cc 二进制(与 scripts/ensure-agent-binaries.mjs 的
+ * `currentPlatformKey()` / `binFileFor()` 同约定:`<platform>-<arch>` 目录 + win32 带 .exe)。
+ * 该平台没有就位的二进制时返回 null —— 由用例显式 skip,而不是断言失败:随包二进制按平台
+ * 下载,别的平台开 BRIDGE_E2E=1 不该看到一个「测试失败」。
+ */
+function resolveClaudeBin(): string | null {
+  const platformKey = `${process.platform}-${process.arch}`;
+  const binFile = platformKey.startsWith('win32') ? 'claude.exe' : 'claude';
+  const candidate = path.join(repoRoot, 'apps/claude-code-bin', platformKey, binFile);
+  return fs.existsSync(candidate) ? candidate : null;
+}
 
 function sseFrame(event: Record<string, unknown>): string {
   return `data: ${JSON.stringify(event)}\n\n`;
@@ -147,8 +161,15 @@ function startBridge(upstreamBase: string, state: ChainState): Promise<{ url: st
 }
 
 describe.skipIf(!E2E)('watchdog → 非流式 fallback → bridge(真实 claude 二进制,本地 stub 上游)', () => {
-  it('上游中途静默 → cc 以 stream:false 重试 → bridge 回完整 Message,cc 正常出答案', async () => {
-    expect(fs.existsSync(claudeBin)).toBe(true);
+  it('上游中途断流 → cc 升级非流式 fallback → bridge 回完整 Message,cc 正常出答案', async (ctx) => {
+    const claudeBin = resolveClaudeBin();
+    if (!claudeBin) {
+      // 随包二进制按平台下载(见 scripts/ensure-agent-binaries.mjs);本平台没有就位时
+      // 明确跳过,不伪装成失败。
+      console.warn(`跳过:本平台(${process.platform}-${process.arch})没有随包 claude 二进制`);
+      ctx.skip();
+      return;
+    }
     const state: ChainState = { nonStream: 0 };
     const stub = await startStubUpstream(state);
     const bridge = await startBridge(stub.url, state);

--- a/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
+++ b/packages/anthropic-responses-bridge/src/__tests__/translate-request.test.ts
@@ -21,13 +21,15 @@ describe('translateRequest', () => {
     ]);
   });
 
-  it('preserves stream:false for Claude Code non-streaming fallback', () => {
+  it('上游恒流式:调用方 stream:false 也发 stream:true(codex 对 stream:false 返 400)', () => {
+    // chatgpt.com/backend-api/codex 实测:stream:false → 400
+    // `{"detail":"Stream must be set to true"}`。非流式调用方由 handler 在下游缓冲满足。
     const req: AnthropicMessagesRequest = {
       model: 'chatgpt/gpt-5.5',
       messages: [{ role: 'user', content: 'hi' }],
       stream: false,
     };
-    expect(translateRequest(req, { model: 'gpt-5.5' }).stream).toBe(false);
+    expect(translateRequest(req, { model: 'gpt-5.5' }).stream).toBe(true);
   });
 
   it('joins array-form system blocks', () => {

--- a/packages/anthropic-responses-bridge/src/handler.ts
+++ b/packages/anthropic-responses-bridge/src/handler.ts
@@ -304,7 +304,11 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
     // 保证同一会话逐轮请求带同一份工具列表(前缀稳定)。
     const serverSideTools = provider.serverSideTools?.(realModel);
 
-    const downstreamStreaming = parsed.stream !== false;
+    // Anthropic Messages 语义:**只有显式 `stream:true` 才是 SSE**,字段缺失等同非流式。
+    // Claude Code 的非流式 fallback 走 SDK 的 `messages.create()`,它**不带 stream 字段**
+    // (2026-08-10 用随包 cc 二进制实测),按 `stream !== false` 判会把 fallback 误当流式、
+    // 回一个 SSE,CLI 随即报 "empty or malformed response (HTTP 200)"。
+    const downstreamStreaming = parsed.stream === true;
     const responsesReq = translateRequest(parsed, {
       model: realModel,
       promptCacheKey: sessionId,
@@ -325,7 +329,9 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
         headers: {
           ...providerHeaders,
           'content-type': 'application/json',
-          accept: downstreamStreaming ? 'text/event-stream' : 'application/json',
+          // 恒 SSE:上游只接受流式(见 translateRequest 的 stream 注释),非流式调用方
+          // 由下游缓冲满足。
+          accept: 'text/event-stream',
         },
         body: JSON.stringify(responsesReq),
         signal: abort.signal,
@@ -390,8 +396,9 @@ export function createResponsesHandler(opts: ResponsesHandlerOptions): Responses
     const upstreamContentType = upstream.headers.get('content-type') ?? '';
     const upstreamIsSse = upstreamContentType.toLowerCase().includes('event-stream');
 
-    // Claude Code 的 stream watchdog 会以 stream:false 做 fallback。该调用方要求一个完整
-    // Anthropic Message JSON;上游正常会返回 Responses JSON,但仍兼容忽略 stream:false 的 SSE 源。
+    // 非流式调用方(Claude Code 流式失败后的 fallback,请求体不带 stream 字段)要求一个
+    // 完整的 Anthropic Message JSON。上游恒回 SSE(只接受流式),所以这里缓冲整流后组装;
+    // 同时兼容个别上游直接给 Responses JSON 的情况。
     if (!downstreamStreaming) {
       const translator = new SseTranslator(wireModel);
       const collector = new AnthropicMessageCollector();

--- a/packages/anthropic-responses-bridge/src/translate-request.ts
+++ b/packages/anthropic-responses-bridge/src/translate-request.ts
@@ -359,9 +359,12 @@ export function translateRequest(
     model: opts.model,
     input,
     store: false,
-    // 保持调用方的响应模式:Claude Code 的 stream watchdog 会用 stream:false 做非流式
-    // fallback,bridge 必须让上游返回可组装成单个 Anthropic Message 的 Responses JSON。
-    stream: req.stream !== false,
+    // 上游**恒流式**,与调用方的 stream 无关。chatgpt.com/backend-api/codex 对
+    // stream:false 直接 400 `{"detail":"Stream must be set to true"}`(2026-08-10 实测,
+    // gpt-5.5 与 gpt-5.6-sol 一致),SSE 是这些订阅上游唯一可用的响应形态。
+    // 调用方的非流式需求(Claude Code stream watchdog 的 fallback)由 handler 在**下游**
+    // 把整流缓冲成单个 Anthropic Message JSON 满足,不靠上游换模式。
+    stream: true,
     include: ['reasoning.encrypted_content'],
   };
 


### PR DESCRIPTION
## 这次改了什么

### 摘要

#2332 号称修掉了订阅模型经 Claude Code 的 `API returned an empty or malformed response (HTTP 200)`，
**但实测证明它对真实链路零效果**。本 PR 修掉两个真实原因，并补一条能复现该错误的端到端用例。

**错 1：非流式判据错（决定性）**

Claude Code 流式失败后的 fallback 走 SDK 的 `messages.create()`，请求体**不带 `stream` 字段**——
不是 `stream:false`。#2332 用的是 `parsed.stream !== false`，字段缺失时恒为真，于是 bridge 把
fallback 请求当成流式、回了 `HTTP 200 + text/event-stream`，CLI 的 Message 校验随即失败并报出
那条 banner。改为 `parsed.stream === true`，与 Anthropic Messages 语义一致（只有显式 `true` 是 SSE，
缺省即非流式）。

**错 2：上游根本不接受 `stream:false`**

`chatgpt.com/backend-api/codex` 对 `stream:false` 直接返回
`400 {"detail":"Stream must be set to true"}`（`gpt-5.5` 与 `gpt-5.6-sol` 实测一致）。
#2332 把调用方的 `stream:false` 透传给上游，即便判据对了，fallback 也会被上游拒。
本 PR 把上游改回恒 `stream:true` + `Accept: text/event-stream`，调用方的非流式需求由 handler
在**下游**把整流缓冲成单个 Anthropic Message JSON 满足——#2332 已经写好的「上游回 SSE、调用方要
JSON」缓冲分支正好承接，只是此前永远进不去。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联：补 #2332（已合并）的两个缺陷
- 本 PR 包含：
  - `handler.ts`：`downstreamStreaming` 判据改为 `parsed.stream === true`；上游 `Accept` 恒 SSE
  - `translate-request.ts`：上游 `stream` 恒 `true`
  - `handler.test.ts`：期望 SSE 的用例补上显式 `stream: true`（真实 cc 流式请求就是这样发的）；
    新增「省略 `stream` 字段 → 返回 Message JSON、不回 SSE」用例
  - `live-bridge.test.ts`：新增 2 个非流式活体用例（`BRIDGE_LIVE=1`），把上游 400 那个事实固化
  - 新增 `nonstream-fallback-e2e.test.ts`（`BRIDGE_E2E=1`）：**不联网、不用凭证**的端到端复现
- 明确不包含：不动 `anthropic-compat-proxy` 的透传语义、不改 watchdog 阈值或 fallback 开关、
  不碰 `chatgpt/` / `xai/` 之外的路由
- 用户可见变化：订阅模型在流式失败自愈后不再报 empty/malformed 200，而是正常出答案
- 是否存在 breaking change：无。流式主路径（`stream:true`）行为不变；公开导出未变

### UI 变化

不涉及

- 引用的设计规范：不涉及（只改协议翻译层，无界面/组件/样式/UI 文案改动）

### 远程 / 手机版适配

不涉及，理由：改动只在 Desktop 主进程内的回环协议翻译 handler，不触及 workdir 文件、agent 进程或
会话数据，不新增 IPC channel / 推送事件，无需手机端入口。SSH 远程会话的 Claude Code 由远端
cc-manager 驱动，不经本地这个 bridge。

## 怎么验证的

### 自动验证

```text
BRIDGE_E2E=1 pnpm --filter @cindy/anthropic-responses-bridge exec vitest run src/__tests__/nonstream-fallback-e2e.test.ts
结果（修复前，仅把本 PR 的实现改动还原）：
  cc stdout: API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request
  cc exit code: 1 | stub 收到上游请求 4 次 | bridge 收到非流式请求 0 次
结果（修复后）：
  cc stdout: nonstream fallback ok
  cc exit code: 0 | stub 收到上游请求 3 次 | bridge 收到非流式请求 1 次
  Tests 1 passed

BRIDGE_LIVE=1 pnpm --filter @cindy/anthropic-responses-bridge exec vitest run src/__tests__/live-bridge.test.ts -t '非流式 fallback'
结果（#2332 的实现，stream:false 透传给上游）：
  400 {"type":"error","error":{"type":"invalid_request_error","message":"{\"detail\":\"Stream must be set to true\"}"}}
  gpt-5.5 与 gpt-5.6-sol 一致
结果（本 PR 的实现，上游恒 stream:true）：
  429 usage_limit_reached —— 参数已被上游接受，只差配额（该测试账号额度已用尽，
  重置约需 21 天），故未能拿到成功的 200

pnpm --filter @cindy/anthropic-responses-bridge test
结果：Test Files 3 passed | 2 skipped；Tests 72 passed | 6 skipped
      （skip 的是 BRIDGE_LIVE / BRIDGE_E2E 门控用例）

pnpm --filter @cindy/anthropic-responses-bridge typecheck / lint
结果：均通过

pnpm --filter desktop typecheck
结果：通过（exit 0）

pnpm test:unit
结果：exit 0，全绿（无失败）

pnpm check:dco
结果：DCO check passed: 1 commit signed off — range 3fce01d4..af67dda2
```

`nonstream-fallback-e2e.test.ts` 的拓扑：随包真实 `claude` 二进制（与 Desktop 同一份）
→ `ANTHROPIC_BASE_URL` 指向进程内 bridge handler → `upstreamBase` 指向本地 Responses stub。
stub 在 cc 升级到非流式之前每次都「发两帧后断 socket」，逼它把流式重试耗尽（cc 只在流式尝试
抛错后才走非流式，见其二进制里的 `Error streaming, falling back to non-streaming mode` 分支）。
默认 skip，CI 不受影响。

### 手工验证

不涉及。改动在 worktree 内，运行中的宿主实例不会热更到该 checkout，无法在此重启宿主实机验证
（见 docs/dev-rules/development-workflow.md 第 1 节）。上面的 e2e 用例用真实 cc 二进制覆盖了
同一条链路，比实机点按更可控。

### 未执行的验证

- **真实上游的成功路径未验证**：本 PR 的请求形状已被 codex 后端接受（400 → 429），但测试账号
  额度耗尽（business plan，约 21 天后重置），没能拿到一个真实的 200。上游响应的翻译逻辑与流式
  主路径共用同一个 `SseTranslator`，风险有限，但请知悉这一点未经真实上游端到端确认。
- **Desktop 实机未验证**：同上，需能重启宿主的人跑一次真实 `chatgpt/gpt-5.6-sol` 会话。
- **xAI 路由未单独活体验证**：`xai/` 与 `chatgpt/` 共用同一实现，本次只对 codex 后端做了活体确认。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [x] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：只影响经本地 Responses bridge 的订阅直连模型（`chatgpt/*`、`xai/*`）。
  reviewer 请重点看这一处语义收紧：**判据从「非 `false` 即流式」变成「必须显式 `true` 才流式」**。
  也就是说，任何**省略 `stream` 字段**却期待 SSE 的调用方，现在会收到 JSON。这符合 Anthropic
  Messages 规范（`stream` 缺省即非流式），而真实 Claude Code 流式请求一律显式带 `stream:true`
  （本 PR 也把测试里省略该字段的 SSE 用例都补成显式 `true`，让这个前提在测试里可见）。
  上游侧恒 `stream:true`，请求体逐字节稳定，**prompt 前缀稳定性与缓存率不受影响**。
- 回滚 / 降级方式：单个 commit，`git revert` 即可回到 #2332 的行为（也就是回到「fallback 仍报
  empty/malformed 200」的状态）。无数据迁移、无持久化状态、无跨端 wire 变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（协议行为与实测结论写在改动处注释里；无规则文档需同步修正）
- [x] 已确认测试结果或说明未执行原因

🤖 Generated with [Claude Code](https://claude.com/claude-code)
