### PR TITLE
fix(desktop): localize automation template schedules

### DIFF
--- a/apps/desktop/src/renderer/features/scheduler/components/TemplateCard.tsx
+++ b/apps/desktop/src/renderer/features/scheduler/components/TemplateCard.tsx
@@ -26,9 +26,11 @@ interface TemplateCardProps {
 }
 
 export function TemplateCard({ template, selected = false, onSelect }: TemplateCardProps) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const Icon = iconForTemplate(template.id);
-  const scheduleText = template.cronExpr ? cronToHuman(template.cronExpr) : '';
+  const scheduleText = template.cronExpr
+    ? cronToHuman(template.cronExpr, t, i18n.resolvedLanguage ?? i18n.language)
+    : '';
   // user/project 模板的 capabilities 不受包词表约束：Object.hasOwn（而不是 in）挡住
   // 'toString' 这类原型链 key，Set 去重避免重复项撞 React key。
   const capabilities = [...new Set(template.capabilities ?? [])].filter(

--- a/apps/desktop/src/renderer/features/scheduler/lib/__tests__/cronToHuman.test.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/__tests__/cronToHuman.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { cronToHuman } from '../cronToHuman';
+
+const zh = (key: string, options: Record<string, unknown> = {}): string => {
+  const messages: Record<string, string> = {
+    'scheduler.builtinTemplates.schedule.daily': `每天 ${options.time}`,
+    'scheduler.builtinTemplates.schedule.weekdays': `工作日 ${options.time}`,
+    'scheduler.builtinTemplates.schedule.weekly': `${options.weekday} ${options.time}`,
+    'scheduler.builtinTemplates.schedule.monthly': `每月 ${options.day} 日 ${options.time}`,
+  };
+  return messages[key] ?? key;
+};
+
+describe('cronToHuman', () => {
+  it('localizes the built-in template schedule shapes', () => {
+    expect(cronToHuman('0 2 * * *', zh, 'zh-CN')).toBe('每天 02:00');
+    expect(cronToHuman('0 10 * * 1-5', zh, 'zh-CN')).toBe('工作日 10:00');
+    expect(cronToHuman('0 16 * * 5', zh, 'zh-CN')).toBe('周五 16:00');
+    expect(cronToHuman('0 10 1 * *', zh, 'zh-CN')).toBe('每月 1 日 10:00');
+  });
+
+  it('keeps unsupported custom cron output readable', () => {
+    expect(cronToHuman('0 9 * 1 *', zh, 'zh-CN')).toBe('At 09:00 in Jan');
+  });
+});

--- a/apps/desktop/src/renderer/features/scheduler/lib/cronToHuman.ts
+++ b/apps/desktop/src/renderer/features/scheduler/lib/cronToHuman.ts
@@ -1,17 +1,36 @@
-/**
- * cronToHuman — 透传 Phase 1 引擎的英文输出
- * ---------------------------------------------------------------------------
- * Phase 1 `@cindy/maker-scheduler/engine/cron.ts:cronToHuman` 已是英文 + 纯函数。
- * Scheduler UI 已统一英文（Phase 8），这里直接透传，不再做 zh i18n 包装。
- *
- * 仍保留这个 wrapper 文件而不是直接 import 引擎是为了：
- * (a) 限定从 ./cron 子路径 import — 顶层 `@cindy/maker-scheduler` re-export 的
- *     `./engine/scheduler.js` 用 EventEmitter，浏览器加载即崩。
- * (b) 给将来再做 i18n 留单一改点。
- */
+/** Localized schedule labels for the template gallery. */
 
 import { cronToHuman as cronToHumanEN } from '@cindy/maker-scheduler/cron';
+import { cronToConfig } from './cronCodexPreset';
 
-export function cronToHuman(expr: string): string {
-  return cronToHumanEN(expr);
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
+export function cronToHuman(expr: string, t: Translate, locale: string): string {
+  const config = cronToConfig(expr);
+  const time = `${pad(config.hour)}:${pad(config.minute)}`;
+
+  switch (config.mode) {
+    case 'daily':
+      return t('scheduler.builtinTemplates.schedule.daily', { time });
+    case 'weekdays':
+      return t('scheduler.builtinTemplates.schedule.weekdays', { time });
+    case 'weekly':
+      return t('scheduler.builtinTemplates.schedule.weekly', {
+        time,
+        weekday: formatWeekday(config.weekday, locale),
+      });
+    case 'monthly':
+      return t('scheduler.builtinTemplates.schedule.monthly', { time, day: config.monthDay });
+    default:
+      return cronToHumanEN(expr);
+  }
+}
+
+function formatWeekday(weekday: number, locale: string): string {
+  const sunday = new Date(Date.UTC(2024, 0, 7 + weekday));
+  return new Intl.DateTimeFormat(locale, { weekday: 'short', timeZone: 'UTC' }).format(sunday);
+}
+
+function pad(value: number): string {
+  return String(value).padStart(2, '0');
 }

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -8063,6 +8063,12 @@
       }
     },
     "builtinTemplates": {
+      "schedule": {
+        "daily": "Daily at {{time}}",
+        "weekdays": "Weekdays at {{time}}",
+        "weekly": "{{weekday}} at {{time}}",
+        "monthly": "Monthly on day {{day}} at {{time}}"
+      },
       "categories": {
         "dev-automation": "Development automation",
         "info-radar": "Information radar",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -8051,6 +8051,12 @@
       }
     },
     "builtinTemplates": {
+      "schedule": {
+        "daily": "毎日 {{time}}",
+        "weekdays": "平日 {{time}}",
+        "weekly": "{{weekday}} {{time}}",
+        "monthly": "毎月{{day}}日 {{time}}"
+      },
       "categories": {
         "dev-automation": "開発自動化",
         "info-radar": "情報レーダー",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -8051,6 +8051,12 @@
       }
     },
     "builtinTemplates": {
+      "schedule": {
+        "daily": "매일 {{time}}",
+        "weekdays": "평일 {{time}}",
+        "weekly": "{{weekday}} {{time}}",
+        "monthly": "매월 {{day}}일 {{time}}"
+      },
       "categories": {
         "dev-automation": "개발 자동화",
         "info-radar": "정보 레이더",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -8051,6 +8051,12 @@
       }
     },
     "builtinTemplates": {
+      "schedule": {
+        "daily": "每天 {{time}}",
+        "weekdays": "工作日 {{time}}",
+        "weekly": "{{weekday}} {{time}}",
+        "monthly": "每月 {{day}} 日 {{time}}"
+      },
       "categories": {
         "dev-automation": "开发自动化",
         "info-radar": "信息雷达",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -8051,6 +8051,12 @@
       }
     },
     "builtinTemplates": {
+      "schedule": {
+        "daily": "每天 {{time}}",
+        "weekdays": "工作日 {{time}}",
+        "weekly": "{{weekday}} {{time}}",
+        "monthly": "每月 {{day}} 日 {{time}}"
+      },
       "categories": {
         "dev-automation": "開發自動化",
         "info-radar": "資訊雷達",


### PR DESCRIPTION
## 这次改了什么

### 摘要

中文界面的自动化模板已经翻译了名称、说明和能力标签，但执行时间仍固定显示英文，例如“`At 10:00 on Mon,Tue,Wed,Thu,Fri`”。本 PR 只把六个内置模板的常见时间说明接入现有语言设置；自定义 cron 继续使用原来的稳定兜底。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：macOS 实机在「自动化 → 从模板开始」复现
- 本 PR 包含：内置模板的每天、工作日、每周和每月时间文案本地化；五种语言资源；回归测试
- 明确不包含：调度引擎、自定义 cron 解析、表单或布局调整
- 用户可见变化：非英文界面的模板时间不再夹杂英文
- 是否存在 breaking change：无

### UI 变化

仅替换模板卡片内已有时间 chip 的文字，不改变尺寸、颜色、间距或交互。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §11 Voice & Content：界面语言保持一致，时间说明使用短句并保留明确的时刻。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/features/scheduler/lib/__tests__/cronToHuman.test.ts --reporter=dot
结果：2/2 通过

pnpm --filter desktop typecheck
结果：通过

pnpm check:i18n
结果：五种语言 6990 个 key 一致

pnpm check:i18n-glossary
结果：通过

pnpm test:unit
结果：整库通过
```

### 手工验证

macOS arm64，现有 Cindy dev 客户端（中文）：打开「自动化 → 从模板开始」，实机确认六个模板的名称和说明为中文，但时间 chip 显示英文。修复后的对应输出由回归测试覆盖，例如“工作日 10:00”“周五 16:00”“每月 1 日 10:00”。

### 未执行的验证

未启动第二个 Electron 构建，避免干扰用户当前已打开的 Cindy。视觉结构未变化；修复后文字由同一 TemplateCard、同一 chip 样式渲染。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：Desktop 自动化模板卡片的时间文字
- 回滚 / 降级方式：回滚本提交；调度数据和执行语义不受影响

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [ ] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因