### PR TITLE
fix(desktop): localize model list label

### DIFF
--- a/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorProviderGroups.test.tsx
@@ -25,6 +25,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'newChat.modelSelector.trigger.placeholder': '选择模型',
         'newChat.modelSelector.trigger.aria': `Select model. Current: ${options?.model ?? ''}`,
         'newChat.modelSelector.trigger.ariaWithEffort': `Select model. Current: ${options?.model ?? ''}, effort: ${options?.effort ?? ''}`,
+        'newChat.modelSelector.modelListAria': '模型列表',
         'newChat.modelSelector.search.noResults': '无匹配模型',
         'newChat.modelSelector.pricing.free': '限时免费',
         'newChat.modelSelector.source.disconnected': '已断开',
@@ -378,7 +379,7 @@ describe('ModelSelector provider groups', () => {
     await openDropdown();
     await waitForSearchInputFocus();
 
-    const modelList = screen.getByRole('listbox', { name: 'Model list' });
+    const modelList = screen.getByRole('listbox', { name: '模型列表' });
     const row = within(modelList).getByRole('option', { name: /Opus 4\.8/ });
     await openModelOptionsPanel(row);
 
@@ -487,7 +488,7 @@ describe('ModelSelector provider groups', () => {
     // keydown 后 React 同步 flush 的具体顺序。
     await waitFor(() => {
       expect(screen.queryByTestId('model-options-floating-panel')).toBeNull();
-      expect(screen.getByRole('listbox', { name: 'Model list' })).toBeTruthy();
+      expect(screen.getByRole('listbox', { name: '模型列表' })).toBeTruthy();
     });
   });
 
@@ -497,7 +498,7 @@ describe('ModelSelector provider groups', () => {
 
     const searchInput = await waitForSearchInputFocus();
 
-    const modelList = screen.getByRole('listbox', { name: 'Model list' });
+    const modelList = screen.getByRole('listbox', { name: '模型列表' });
     const originalRow = within(modelList).getByRole('option', { name: /Opus 4\.8/ });
     await openModelOptionsPanel(originalRow);
     await screen.findByTestId('model-options-floating-panel');

--- a/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
+++ b/apps/desktop/src/renderer/__tests__/modelSelectorTriggerVariant.test.ts
@@ -32,6 +32,7 @@ vi.mock('react-i18next', async (importOriginal) => ({
         'newChat.modelSelector.trigger.placeholder': '选择模型',
         'newChat.modelSelector.trigger.agent.claudeCode': 'Claude Code',
         'newChat.modelSelector.trigger.agent.codex': 'Codex',
+        'newChat.modelSelector.modelListAria': '模型列表',
         'newChat.modelSelector.hidden': '已隐藏',
         'newChat.modelSelector.pricing.free': '限时免费',
         'newChat.modelSelector.source.disconnected': '已断开',
@@ -1151,7 +1152,7 @@ describe('ModelSelector trigger variants', () => {
       await act(async () => {
         fireEvent.click(screen.getByRole('button', { name: /Current: Subscription Model 1/ }));
       });
-      const list = screen.getByRole('listbox', { name: 'Model list' });
+      const list = screen.getByRole('listbox', { name: '模型列表' });
 
       expect(list.className).toContain('max-h-[300px]');
       expect(list.className).toContain('overflow-y-auto');
@@ -1202,7 +1203,7 @@ describe('ModelSelector trigger variants', () => {
           vendorKey: 'cc',
         }),
       );
-      const list = screen.getByRole('listbox', { name: 'Model list' });
+      const list = screen.getByRole('listbox', { name: '模型列表' });
       Object.defineProperty(list, 'scrollTop', { configurable: true, writable: true, value: 80 });
 
       view.rerender(
@@ -1856,7 +1857,7 @@ describe('ModelSelector trigger variants', () => {
     expect(screen.getByRole('group', { name: /Opus 4\.8/ })).toBeTruthy();
 
     // 列表滚动不派发 pointerleave,浮层会跟着滚出视口的锚点行跑到菜单外 → 用户滚动必须立即收起。
-    fireEvent.scroll(screen.getByRole('listbox', { name: 'Model list' }));
+    fireEvent.scroll(screen.getByRole('listbox', { name: '模型列表' }));
     expect(screen.queryByRole('group', { name: /Opus 4\.8/ })).toBeNull();
     vi.useRealTimers();
   });
@@ -2191,7 +2192,7 @@ describe('ModelSelector trigger variants', () => {
       const row = screen.getByRole('option', { name: /Qwen 3\.7/ });
       expect(row.className).toContain('min-h-9');
       expect(within(row).getByText('Qwen 3.7').className).toContain('leading-5');
-      expect(screen.getByRole('listbox', { name: 'Model list' }).style.maxHeight).toBe('226px');
+      expect(screen.getByRole('listbox', { name: '模型列表' }).style.maxHeight).toBe('226px');
       expect(row.textContent).not.toContain('¥6 / ¥18');
       expect(row.textContent).not.toContain('¥12 / ¥36');
       const rowBadge = within(row).getByText('立省 50%');

--- a/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
+++ b/apps/desktop/src/renderer/components/new-chat/ModelSelector.tsx
@@ -2208,7 +2208,7 @@ function ModelSelectorContentView({
             : { maxHeight: `${constrainedListMaxHeight}px` }
         }
         role="listbox"
-        aria-label="Model list"
+        aria-label={t('newChat.modelSelector.modelListAria')}
         onScroll={() => {
           if (suppressScrollDismissRef.current) {
             suppressScrollDismissRef.current = false;

--- a/apps/desktop/src/renderer/i18n/locales/en/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/en/common.json
@@ -5402,6 +5402,7 @@
     "modelSelector": {
       "budgetNeedsApiKey": "This model needs an API key — configure it in Settings",
       "hidden": "Hidden",
+      "modelListAria": "Model list",
       "subscriptionDirectDisabled": {
         "chatgpt": "Subscription-direct GPT models are not supported in SSH remote sessions yet",
         "xai": "Subscription-direct Grok models are not supported in SSH remote sessions yet",

--- a/apps/desktop/src/renderer/i18n/locales/ja/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ja/common.json
@@ -5400,6 +5400,7 @@
     "modelSelector": {
       "budgetNeedsApiKey": "このモデルは設定で API key を構成してから使用できます",
       "hidden": "非表示",
+      "modelListAria": "モデル一覧",
       "subscriptionDirectDisabled": {
         "chatgpt": "サブスクリプション直結の GPT モデルは SSH リモートセッションに未対応です",
         "xai": "サブスクリプション直結の Grok モデルは SSH リモートセッションに未対応です",

--- a/apps/desktop/src/renderer/i18n/locales/ko/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/ko/common.json
@@ -5400,6 +5400,7 @@
     "modelSelector": {
       "budgetNeedsApiKey": "이 모델은 설정에서 API key를 구성해야 사용할 수 있습니다",
       "hidden": "숨김",
+      "modelListAria": "모델 목록",
       "subscriptionDirectDisabled": {
         "chatgpt": "구독 직결 GPT 모델은 SSH 원격 세션을 아직 지원하지 않습니다",
         "xai": "구독 직결 Grok 모델은 SSH 원격 세션을 아직 지원하지 않습니다",

--- a/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-CN/common.json
@@ -5400,6 +5400,7 @@
     "modelSelector": {
       "budgetNeedsApiKey": "此模型需先在设置里配置 API key 才能使用",
       "hidden": "已隐藏",
+      "modelListAria": "模型列表",
       "subscriptionDirectDisabled": {
         "chatgpt": "订阅直连的 GPT 模型协议暂不支持 SSH 远程会话",
         "xai": "订阅直连的 Grok 模型协议暂不支持 SSH 远程会话",

--- a/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
+++ b/apps/desktop/src/renderer/i18n/locales/zh-TW/common.json
@@ -5403,6 +5403,7 @@
     "modelSelector": {
       "budgetNeedsApiKey": "此模型需先在設定裡配置 API key 才能使用",
       "hidden": "已隱藏",
+      "modelListAria": "模型列表",
       "subscriptionDirectDisabled": {
         "chatgpt": "訂閱直連的 GPT 模型協議暫不支援 SSH 遠端會話",
         "xai": "訂閱直連的 Grok 模型協議暫不支援 SSH 遠端會話",


### PR DESCRIPTION
## 这次改了什么

### 摘要

中文、繁中、日文和韩文界面的模型选择弹窗，读屏名称仍固定为英文 “Model list”。本 PR 改为使用已有 i18n 体系，并补齐五种语言的模型列表名称与回归测试。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：实机走查发现
- 本 PR 包含：模型列表的本地化无障碍名称、五语文案、相关回归测试
- 明确不包含：模型展示、选择、排序和请求逻辑
- 用户可见变化：可见界面不变；读屏会按当前语言朗读模型列表
- 是否存在 breaking change：无

### UI 变化

不涉及视觉变化：仅替换模型列表的无障碍名称。

- 引用的设计规范：`DESIGN.md §11 Voice & Content`；界面文案通过 i18n key 提供，并保持 zh-CN / zh-TW / en / ja / ko 对齐。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/__tests__/modelSelectorProviderGroups.test.tsx src/renderer/__tests__/modelSelectorTriggerVariant.test.ts --reporter=dot
结果：2 files / 68 tests passed

pnpm --filter desktop exec vitest run src/renderer/__tests__/i18nCompleteness.test.ts --reporter=dot
结果：1 file / 2 tests passed

pnpm check:i18n && pnpm check:i18n-glossary
结果：7131 keys 五语一致；术语检查通过（仅仓库既有警告）

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit
结果：全仓通过（desktop 及全部可执行 workspace）

pnpm check:dco --base origin/main
结果：1 commit signed off
```

### 手工验证

macOS、中文界面、现有 Cindy 开发客户端：打开新任务页的模型选择器，通过系统无障碍树确认搜索框已本地化，但列表框显示英文 “Model list”。未启动第二个 Electron。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅桌面端模型列表的无障碍名称
- 回滚 / 降级方式：回退本提交即可；不涉及数据或协议

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因