### PR TITLE
fix(desktop): show loading feedback in browser tab

### DIFF
--- a/apps/desktop/src/renderer/features/right-sidebar/TabBar.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/TabBar.tsx
@@ -607,7 +607,7 @@ function TabPill({
           )}
         >
           {IconNode ? (
-            <IconNode state={hydratedState} sessionId={sessionId} active={active} />
+            <IconNode state={hydratedState} sessionId={sessionId} active={active} tabId={tab.id} />
           ) : (
             <FallbackIcon size={13} />
           )}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx
@@ -223,9 +223,7 @@ export const BrowserChrome = forwardRef<BrowserChromeHandle, BrowserChromeProps>
         tooltip={t('rightSidebar.browser.goForward')}
       />
       <ChromeIconButton
-        icon={RotateCw}
-        reducedMotionIcon={isLoading ? XIcon : undefined}
-        spinning={isLoading}
+        icon={isLoading ? XIcon : RotateCw}
         onClick={isLoading ? onStop : onReload}
         tooltip={
           isLoading
@@ -334,29 +332,19 @@ export const BrowserChrome = forwardRef<BrowserChromeHandle, BrowserChromeProps>
  */
 function ChromeIconButton({
   icon: Icon,
-  reducedMotionIcon: ReducedMotionIcon,
   size = 14,
   inlinePill = false,
   disabled = false,
   active = false,
-  spinning = false,
   onClick,
   tooltip,
 }: {
   icon: React.ComponentType<{ size?: number; strokeWidth?: number; className?: string }>;
-  /** reduced-motion 下用静态动作图标表达 loading 状态，避免刷新/空闲态无法区分。 */
-  reducedMotionIcon?: React.ComponentType<{
-    size?: number;
-    strokeWidth?: number;
-    className?: string;
-  }>;
   size?: number;
   inlinePill?: boolean;
   disabled?: boolean;
   /** 常亮 active 态(如评论模式进行中):反色底,提示当前处于该工具的模式里。 */
   active?: boolean;
-  /** 加载态旋转放在 HTML wrapper 上,避免 SVG 常驻动画触发主线程重绘。 */
-  spinning?: boolean;
   onClick: () => void;
   tooltip: string;
 }) {
@@ -367,7 +355,6 @@ function ChromeIconButton({
       onClick={onClick}
       title={tooltip}
       aria-label={tooltip}
-      aria-busy={spinning || undefined}
       className={cn(
         'flex shrink-0 items-center justify-center rounded-md transition-colors',
         inlinePill ? 'size-[18px]' : 'size-6',
@@ -378,25 +365,9 @@ function ChromeIconButton({
             : 'text-sidebar-action-icon hover:bg-sidebar-item-active hover:text-sidebar-item-active-foreground',
       )}
     >
-      {spinning && ReducedMotionIcon ? (
-        <>
-          <span className="inline-flex animate-spinner motion-reduce:hidden">
-            <Icon size={size} strokeWidth={2} />
-          </span>
-          <span className="hidden motion-reduce:inline-flex">
-            <ReducedMotionIcon size={size} strokeWidth={2} />
-          </span>
-        </>
-      ) : (
-        <span
-          className={cn(
-            'inline-flex',
-            spinning && 'animate-spinner motion-reduce:animate-none',
-          )}
-        >
-          <Icon size={size} strokeWidth={2} />
-        </span>
-      )}
+      <span className="inline-flex">
+        <Icon size={size} strokeWidth={2} />
+      </span>
     </button>
   );
 }

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx
@@ -52,6 +52,7 @@ import type { TabKindHostContext } from '../../types';
 
 import { BrowserChrome, type BrowserChromeHandle } from './BrowserChrome';
 import { BrowserCommentPopover } from './BrowserCommentPopover';
+import { setWebBrowserLoading } from './browserLoadingStore';
 import { useBrowserComment } from './useBrowserComment';
 import { useLocalHtmlAutoReload } from './useLocalHtmlAutoReload';
 import type { WebBrowserState } from './index';
@@ -124,6 +125,13 @@ export function BrowserTabBody({ state, ctx, active, shellVisible }: BrowserTabB
   stateUrlRef.current = state.url;
   browserUrlRef.current = browser.url;
   navigateRef.current = browser.navigate;
+
+  // 页签 loading 是纯运行时视图状态，不进入持久化 state；内嵌 webview 与
+  // 原生 popup surface 都从这里把同一份 isLoading 投影到 tab favicon 位置。
+  useEffect(() => {
+    setWebBrowserLoading(tabId, browser.isLoading);
+  }, [browser.isLoading, tabId]);
+  useEffect(() => () => setWebBrowserLoading(tabId, false), [tabId]);
 
   // 当前会话一轮结束后，如果该轮产物修改了正在预览的本地 HTML，则刷新一次。
   // 不监听磁盘；非激活 tab 与 SSH 远程会话不参与。

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts
@@ -17,8 +17,8 @@ vi.mock('react-i18next', () => ({
 // 沿用仓库既定测试模式:mock 成始终展开的直通组件,Item 渲染成普通 <button>,
 // 把 Radix 的 onSelect 映射到 onClick、透传 disabled —— 这样能直接断言菜单项的
 // 可用性与回调,不依赖真实菜单开合。
-vi.mock('@/components/ui/dropdown-menu', () => {
-  const react = require('react') as typeof import('react');
+vi.mock('@/components/ui/dropdown-menu', async () => {
+  const react = await import('react');
   return {
     DropdownMenu: ({ children }: { children: React.ReactNode }) =>
       react.createElement(react.Fragment, null, children),
@@ -114,7 +114,7 @@ describe('BrowserChrome', () => {
     ).toBeNull();
   });
 
-  it('shows a compositor-friendly refresh animation while loading and stops on click', () => {
+  it('shows a static stop icon while loading and stops on click', () => {
     const onReload = vi.fn();
     const onStop = vi.fn();
     renderChrome('https://www.taptap.cn/', {
@@ -124,17 +124,9 @@ describe('BrowserChrome', () => {
     });
 
     const button = screen.getByRole('button', { name: 'rightSidebar.browser.stop' });
-    const spinner = button.querySelector('span');
-    expect(button.getAttribute('aria-busy')).toBe('true');
-    expect(spinner?.classList.contains('animate-spinner')).toBe(true);
-    expect(spinner?.classList.contains('animate-spin')).toBe(false);
-    expect(spinner?.classList.contains('motion-reduce:hidden')).toBe(true);
-    expect(button.querySelector('.lucide-rotate-cw')).toBeTruthy();
-    expect(
-      button.querySelector('.lucide-x')?.parentElement?.classList.contains(
-        'motion-reduce:inline-flex',
-      ),
-    ).toBe(true);
+    expect(button.hasAttribute('aria-busy')).toBe(false);
+    expect(button.querySelector('.lucide-x')).toBeTruthy();
+    expect(button.querySelector('.lucide-rotate-cw')).toBeNull();
 
     fireEvent.click(button);
     expect(onStop).toHaveBeenCalledOnce();
@@ -155,7 +147,7 @@ describe('BrowserChrome', () => {
     expect(onStop).not.toHaveBeenCalled();
   });
 
-  it('routes the refresh spinner through the approved semantic cycle token', () => {
+  it('keeps the approved semantic spinner token available for tab loading feedback', () => {
     const animation = (
       tailwindConfig.theme?.extend?.animation as Record<string, string> | undefined
     )?.spinner;
@@ -200,9 +192,7 @@ describe('BrowserChrome', () => {
   });
 
   it('disables system-browser opening when the host has no safe opener for the URL', () => {
-    const { onOpenInSystemBrowser, onCopyLink } = renderChrome('file:///tmp/notes.md', {
-      canOpenInSystemBrowser: false,
-    });
+    renderChrome('file:///tmp/notes.md', { canOpenInSystemBrowser: false });
 
     const openItem = screen.getByRole('button', {
       name: 'rightSidebar.browser.openInSystemBrowser',

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/WebBrowserTabPillIcon.test.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/__tests__/WebBrowserTabPillIcon.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { WebBrowserTabPillIcon, type WebBrowserState } from '../index';
+import { setWebBrowserLoading } from '../browserLoadingStore';
 
 function browserState(favicon: string | null): WebBrowserState {
   return {
@@ -15,11 +16,14 @@ function browserState(favicon: string | null): WebBrowserState {
 }
 
 describe('WebBrowserTabPillIcon', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    setWebBrowserLoading('tab-1', false);
+    cleanup();
+  });
 
   it('renders the observed page favicon', () => {
     const view = render(
-      <WebBrowserTabPillIcon state={browserState('https://example.com/favicon.ico')} />,
+      <WebBrowserTabPillIcon state={browserState('https://example.com/favicon.ico')} tabId="tab-1" />,
     );
 
     const image = view.container.querySelector('img');
@@ -29,7 +33,7 @@ describe('WebBrowserTabPillIcon', () => {
 
   it('falls back to Globe when the favicon cannot load', () => {
     const view = render(
-      <WebBrowserTabPillIcon state={browserState('https://example.com/missing.ico')} />,
+      <WebBrowserTabPillIcon state={browserState('https://example.com/missing.ico')} tabId="tab-1" />,
     );
 
     fireEvent.error(view.container.querySelector('img')!);
@@ -40,16 +44,38 @@ describe('WebBrowserTabPillIcon', () => {
 
   it('retries with a new favicon URL after an earlier URL failed', () => {
     const view = render(
-      <WebBrowserTabPillIcon state={browserState('https://example.com/missing.ico')} />,
+      <WebBrowserTabPillIcon state={browserState('https://example.com/missing.ico')} tabId="tab-1" />,
     );
     fireEvent.error(view.container.querySelector('img')!);
 
     view.rerender(
-      <WebBrowserTabPillIcon state={browserState('https://example.com/favicon-v2.ico')} />,
+      <WebBrowserTabPillIcon state={browserState('https://example.com/favicon-v2.ico')} tabId="tab-1" />,
     );
 
     expect(view.container.querySelector('img')?.getAttribute('src'))
       .toBe('https://example.com/favicon-v2.ico');
     expect(view.container.querySelector('.lucide-globe')).toBeNull();
+  });
+
+  it('shows a loading ring in place of the favicon while the web page is loading', () => {
+    const view = render(
+      <WebBrowserTabPillIcon
+        state={browserState('https://example.com/favicon.ico')}
+        tabId="tab-1"
+      />,
+    );
+
+    act(() => setWebBrowserLoading('tab-1', true));
+
+    expect(view.getByTestId('web-browser-tab-loading')).toBeTruthy();
+    expect(view.container.querySelector('img')).toBeNull();
+    const loadingRing = view.getByTestId('web-browser-tab-loading');
+    expect(loadingRing.classList.contains('animate-spinner')).toBe(true);
+    expect(loadingRing.classList.contains('motion-reduce:animate-none')).toBe(true);
+
+    act(() => setWebBrowserLoading('tab-1', false));
+    expect(view.container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://example.com/favicon.ico',
+    );
   });
 });

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserLoadingStore.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/browserLoadingStore.ts
@@ -1,0 +1,44 @@
+import { useCallback, useSyncExternalStore } from 'react';
+
+type Listener = () => void;
+
+const loadingByTabId = new Map<string, boolean>();
+const listenersByTabId = new Map<string, Set<Listener>>();
+
+function notify(tabId: string): void {
+  listenersByTabId.get(tabId)?.forEach((listener) => listener());
+}
+
+export function setWebBrowserLoading(tabId: string, loading: boolean): void {
+  if (loadingByTabId.get(tabId) === loading) return;
+  if (loading) {
+    loadingByTabId.set(tabId, true);
+  } else {
+    loadingByTabId.delete(tabId);
+  }
+  notify(tabId);
+}
+
+export function useWebBrowserLoading(tabId: string | undefined): boolean {
+  const subscribe = useCallback(
+    (listener: Listener) => {
+      if (!tabId) return () => undefined;
+      let listeners = listenersByTabId.get(tabId);
+      if (!listeners) {
+        listeners = new Set();
+        listenersByTabId.set(tabId, listeners);
+      }
+      listeners.add(listener);
+      return () => {
+        listeners?.delete(listener);
+        if (listeners?.size === 0) listenersByTabId.delete(tabId);
+      };
+    },
+    [tabId],
+  );
+  const getSnapshot = useCallback(
+    () => (tabId ? loadingByTabId.get(tabId) === true : false),
+    [tabId],
+  );
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/index.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/web-browser/index.tsx
@@ -15,7 +15,7 @@
  * 注册:模块顶层 import-side-effect,plugins/index.ts 把它 import 进来。
  */
 
-import { Globe, Volume2 } from 'lucide-react';
+import { Globe, LoaderCircle, Volume2 } from 'lucide-react';
 import type { TFunction } from 'i18next';
 import { useState } from 'react';
 
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils';
 import { registerTabKind } from '../../registry';
 import type { TabKindPlugin } from '../../types';
 import { BrowserTabBody } from './BrowserTabBody';
+import { useWebBrowserLoading } from './browserLoadingStore';
 
 /** plugin state shape —— 反序列化口径:JSON identity 即可恢复。 */
 export interface WebBrowserState {
@@ -71,8 +72,23 @@ function WebBrowserTabPillTitle({
  * tab pill 行为一致 —— 用户能从图标一眼看出哪个 tab 在发声)。
  * favicon onError(404 / 取不到)→ 也走 fallback,不让破图占位。
  */
-export function WebBrowserTabPillIcon({ state }: { state: WebBrowserState }) {
-  const base = state.favicon ? (
+export function WebBrowserTabPillIcon({
+  state,
+  tabId,
+}: {
+  state: WebBrowserState;
+  tabId?: string;
+}) {
+  const isLoading = useWebBrowserLoading(tabId);
+  const base = isLoading ? (
+    <span
+      data-testid="web-browser-tab-loading"
+      className="inline-flex animate-spinner motion-reduce:animate-none"
+      aria-hidden="true"
+    >
+      <LoaderCircle size={13} />
+    </span>
+  ) : state.favicon ? (
     <FaviconImage
       key={state.favicon}
       src={state.favicon}

--- a/apps/desktop/src/renderer/features/right-sidebar/types.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/types.ts
@@ -112,6 +112,8 @@ export interface TabPillIconRenderProps<TState = unknown> {
   state: TState;
   sessionId: string | null;
   active: boolean;
+  /** Stable tab id for runtime-only pill signals (for example browser loading). */
+  tabId?: string;
 }
 
 /**


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复内置浏览器刷新反馈方向错误：刷新进行中，工具栏刷新按钮改为静态终止 `X`，对应网页 tab 的 favicon 位置显示加载圆环；加载结束后恢复原 favicon 或 Globe fallback。运行时 loading 状态按 tab 隔离，不写入持久化 tab state。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Closes #2350
- 本 PR 包含：Desktop 内置浏览器刷新/停止按钮语义、内嵌 WebView 与 native popup surface 的 tab favicon loading feedback、reduced-motion 视觉降级及对应测试。
- 明确不包含：导航状态机改动、favicon 持久化或恢复策略、并行 PR/Issue #2166 的 favicon persistence 工作，以及其他浏览器 UX 重构。
- 用户可见变化：刷新时工具栏显示 `X` 并可点击停止；正在加载的网页 tab 左侧显示加载圆环；完成后回到 favicon/Globe。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：`docs/design-rules/DESIGN.md` §动效与可访问性：加载状态使用语义 loading 动效，`motion-reduce` 下禁用连续动画；§图标与状态反馈：进行中的操作显示终止动作，状态反馈放在对应内容对象上。本实现让 toolbar `X` 表达可停止动作，让网页 tab favicon 位置承载 loading ring，并在 reduced-motion 下保持静止。
- 手工截图/录屏：未执行（本次使用自动 UI 组件测试覆盖 DOM、交互和 reduced-motion class；未启动完整 Electron 手工会话）。

## 怎么验证的

### 自动验证

```text
pnpm --dir apps/desktop exec vitest run --pool=forks --maxWorkers=1 src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts src/renderer/features/right-sidebar/plugins/web-browser/__tests__/WebBrowserTabPillIcon.test.tsx src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserTabBody.navigation.test.ts
结果：3 个测试文件、40 个测试全部通过。

pnpm --filter desktop typecheck
结果：通过。

pnpm --filter desktop exec eslint src/renderer/features/right-sidebar/TabBar.tsx src/renderer/features/right-sidebar/types.ts src/renderer/features/right-sidebar/plugins/web-browser/BrowserChrome.tsx src/renderer/features/right-sidebar/plugins/web-browser/BrowserTabBody.tsx src/renderer/features/right-sidebar/plugins/web-browser/browserLoadingStore.ts src/renderer/features/right-sidebar/plugins/web-browser/index.tsx src/renderer/features/right-sidebar/plugins/web-browser/__tests__/BrowserChrome.test.ts src/renderer/features/right-sidebar/plugins/web-browser/__tests__/WebBrowserTabPillIcon.test.tsx
结果：通过。

git diff --check
结果：通过。

pnpm check:dco
结果：通过，1 个 commit 带 DCO sign-off。
```

补充：`pnpm test:unit` 的 runner 自测通过（392 passed, 1 skipped）；其余 workspace unit tests 通过。Desktop 全量 unit 在本机第一次因受管 Electron 二进制缺失而收集失败，补齐 Electron 后第二次运行已执行并通过 1,787 个 suite，但 Vitest worker 最终被本机以 `SIGSEGV` 终止；未观察到本 PR 相关断言失败，因此不将该环境结果标为全量通过。

### 手工验证

未执行：未启动完整 Electron 应用进行手工浏览器操作；自动测试覆盖刷新/停止按钮、tab loading ring、favicon 恢复与 reduced-motion class。

### 未执行的验证

完整 Desktop unit suite 未能在当前 macOS 工作站稳定完成：依赖二进制补齐后仍因 Vitest worker `SIGSEGV` 退出。需要 CI 或干净 Electron 环境补做全量 Desktop unit。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 Desktop renderer 的内置浏览器 tab chrome/icon loading feedback；不改变导航、URL、favicon 持久化或 WebView 生命周期。
- 回滚 / 降级方式：回滚 commit `0150f67fd` 即可恢复原有刷新按钮行为；无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果或说明未执行原因
