### PR TITLE
fix(desktop): label font size inputs

### DIFF
--- a/apps/desktop/src/renderer/components/settings/AppearanceSection.tsx
+++ b/apps/desktop/src/renderer/components/settings/AppearanceSection.tsx
@@ -683,6 +683,7 @@ export function AppearanceSection() {
             />
             <input
               type="number"
+              aria-label={t('settings.appearance.font.uiSize.label')}
               min={12}
               max={24}
               step={1}
@@ -767,6 +768,7 @@ export function AppearanceSection() {
             />
             <input
               type="number"
+              aria-label={t('settings.appearance.font.codeSize.label')}
               min={10}
               max={24}
               step={1}

--- a/apps/desktop/src/renderer/components/settings/__tests__/AppearanceSection.accessibility.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/AppearanceSection.accessibility.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppearanceSection } from '../AppearanceSection';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('@/hooks/useTheme', () => ({
+  resolveIsDark: () => false,
+  useTheme: () => ({
+    theme: 'system',
+    setTheme: vi.fn(),
+    familyId: 'cindy',
+    setFamily: vi.fn(),
+    fallbackFromType: null,
+  }),
+}));
+
+vi.mock('@/hooks/useFontSettings', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/useFontSettings')>()),
+  useFontSettings: () => ({
+    uiFamily: '',
+    codeFamily: '',
+    uiSize: 14,
+    codeSize: 14,
+    setUiFamily: vi.fn(),
+    setCodeFamily: vi.fn(),
+    setUiSize: vi.fn(),
+    setCodeSize: vi.fn(),
+    resetUiFamily: vi.fn(),
+    resetCodeFamily: vi.fn(),
+    resetUiSize: vi.fn(),
+    resetCodeSize: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useSidebarCardMode', () => ({
+  useSidebarCardMode: () => ({ mode: 'text', setMode: vi.fn() }),
+}));
+
+vi.mock('@/themes/local-themes', () => ({
+  buildCopyFromTheme: vi.fn(),
+  getLocalThemes: () => [],
+  onLocalThemesChange: () => () => {},
+  refreshLocalThemes: vi.fn(async () => {}),
+}));
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => children,
+  PopoverContent: ({ children }: { children: React.ReactNode }) => children,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tip: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/components/ui/slider', () => ({
+  Slider: ({
+    value,
+    onValueChange: _onValueChange,
+    ...props
+  }: React.InputHTMLAttributes<HTMLInputElement> & {
+    value?: number[];
+    onValueChange?: (value: number[]) => void;
+  }) => <input type="range" value={value?.[0]} readOnly {...props} />,
+}));
+
+vi.mock('../FontFamilyPicker', () => ({ FontFamilyPicker: () => null }));
+vi.mock('../LayoutResetControl', () => ({ LayoutResetControl: () => null }));
+
+describe('AppearanceSection accessibility', () => {
+  it('labels the UI and code font-size number inputs', () => {
+    render(<AppearanceSection />);
+
+    expect(
+      screen.getByRole('spinbutton', { name: 'settings.appearance.font.uiSize.label' }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('spinbutton', { name: 'settings.appearance.font.codeSize.label' }),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## 这次改了什么

### 摘要

设置页的“界面字号”和“代码字号”都有滑块与数字输入框。实机无障碍树里，两个数字输入框只有当前数值，没有名称，读屏用户无法区分它们。本 PR 为两个输入框补上对应的本地化名称，并添加组件回归测试。

### 变更类型

- [x] `fix` 缺陷修复
- [ ] `feat` 新功能
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：实机走查发现
- 本 PR 包含：两个字号数字输入框的无障碍名称与回归测试
- 明确不包含：字号范围、默认值、保存逻辑、布局或样式
- 用户可见变化：可见界面不变；读屏可区分“界面字号”和“代码字号”
- 是否存在 breaking change：无

### UI 变化

不涉及视觉变化：仅为现有数字输入框补充无障碍名称。

- 引用的设计规范：`DESIGN.md §4 Inputs & Forms` 与 `§11 Voice & Content`；复用现有本地化字段名称，不增加新的视觉文案。

## 怎么验证的

### 自动验证

```text
pnpm --filter desktop exec vitest run src/renderer/components/settings/__tests__/AppearanceSection.accessibility.test.tsx --reporter=dot
结果：1 file / 1 test passed

pnpm --filter desktop typecheck
结果：通过

pnpm test:unit
结果：全仓通过（desktop、mobile 及全部可执行 workspace）

pnpm check:dco --base origin/main
结果：1 commit signed off
```

### 手工验证

macOS、中文界面、现有 Cindy 开发客户端：设置 → 通用 → 外观。系统无障碍树显示两个字号滑块有名称，但相邻的两个数字步进输入框都只显示值 “14”，无法区分。未启动第二个 Electron。

### 未执行的验证

无。

## 风险

### 风险分类

- [x] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 权限 / 安全 / 用户数据
- [ ] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅桌面设置页两个数字输入框的无障碍名称
- 回滚 / 降级方式：回退本提交即可；不涉及数据或协议

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因