### PR TITLE
fix(desktop): 隐藏不可处理的旧插件恢复提示

### DIFF
--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -537,7 +537,11 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+    ).toEqual({
+      state: 'partial',
+      legacyPluginCount: 1,
+      canRetry: false,
+    });
     await expect(
       recoverLegacyGhostPlugins(
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
@@ -571,7 +575,11 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+    ).toEqual({
+      state: 'partial',
+      legacyPluginCount: 1,
+      canRetry: false,
+    });
     await expect(
       recoverLegacyGhostPlugins(
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
@@ -622,7 +630,11 @@ describe('legacy Ghost plugin recovery', () => {
         false,
         { reservedCommands: new Set(['draw']) },
       ),
-    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+    ).toEqual({
+      state: 'partial',
+      legacyPluginCount: 1,
+      canRetry: false,
+    });
   });
 
   it('ignores tombstones from a foreign shared root during recovery planning', async () => {
@@ -733,7 +745,11 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+    ).toEqual({
+      state: 'partial',
+      legacyPluginCount: 1,
+      canRetry: false,
+    });
     await expect(
       recoverLegacyGhostPlugins(
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
@@ -1026,7 +1042,11 @@ describe('legacy Ghost plugin recovery', () => {
     );
 
     expect(result).toMatchObject({ status: 'partial', moved: 0, conflicts: 1 });
-    expect(status).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+    expect(status).toEqual({
+      state: 'partial',
+      legacyPluginCount: 1,
+      canRetry: false,
+    });
     await expect(fs.readFile(path.join(target, 'ghost.json'), 'utf-8')).resolves.toBe('scoped');
     await expect(
       fs.readFile(path.join(root, 'cindy-brain', 'valid-plugin', 'ghost.json'), 'utf-8'),
@@ -1151,7 +1171,11 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+    ).toEqual({
+      state: 'partial',
+      legacyPluginCount: 1,
+      canRetry: false,
+    });
 
     await expect(
       recoverLegacyGhostPlugins(
@@ -1207,7 +1231,11 @@ describe('legacy Ghost plugin recovery', () => {
         {},
         (pid) => pid === 4242,
       ),
-    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+    ).toEqual({
+      state: 'deferred',
+      legacyPluginCount: 1,
+      canRetry: false,
+    });
 
     const result = await recoverLegacyGhostPlugins(
       { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
@@ -1328,7 +1356,11 @@ describe('legacy Ghost plugin recovery', () => {
           { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
           root,
         ),
-      ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
+      ).toEqual({
+        state: 'deferred',
+        legacyPluginCount: 1,
+        canRetry: false,
+      });
     } finally {
       delete process.env.XDT_PASSIVE_SHARED_USER_DATA;
     }

--- a/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
+++ b/apps/desktop/src/main/__tests__/ownerNamespaceMigration.test.ts
@@ -537,11 +537,7 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({
-      state: 'partial',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
     await expect(
       recoverLegacyGhostPlugins(
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
@@ -575,11 +571,7 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({
-      state: 'partial',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
     await expect(
       recoverLegacyGhostPlugins(
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
@@ -630,11 +622,7 @@ describe('legacy Ghost plugin recovery', () => {
         false,
         { reservedCommands: new Set(['draw']) },
       ),
-    ).toEqual({
-      state: 'partial',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
   });
 
   it('ignores tombstones from a foreign shared root during recovery planning', async () => {
@@ -667,10 +655,19 @@ describe('legacy Ghost plugin recovery', () => {
         realFsDeps(root),
         { rejectReservedIds: true },
       ),
-    ).resolves.toMatchObject({ status: 'partial', moved: 0, conflicts: 1 });
+    ).resolves.toEqual({ status: 'skipped', moved: 0, conflicts: 0 });
+    expect(
+      getLegacyGhostRecoveryStatus(
+        { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
+        root,
+        false,
+        { rejectReservedIds: true },
+      ),
+    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
     await expect(
       fs.readFile(path.join(root, 'brain', 'cindy-untrusted', 'ghost.json'), 'utf-8'),
     ).resolves.toContain('"id":"cindy-untrusted"');
+    await expect(fs.access(path.join(root, __testing.CLAIM_MARKER))).rejects.toThrow();
   });
 
   it('moves builtin provisioning state with plugins before reconciliation', async () => {
@@ -736,11 +733,7 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({
-      state: 'partial',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
     await expect(
       recoverLegacyGhostPlugins(
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
@@ -1033,11 +1026,7 @@ describe('legacy Ghost plugin recovery', () => {
     );
 
     expect(result).toMatchObject({ status: 'partial', moved: 0, conflicts: 1 });
-    expect(status).toEqual({
-      state: 'partial',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    expect(status).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
     await expect(fs.readFile(path.join(target, 'ghost.json'), 'utf-8')).resolves.toBe('scoped');
     await expect(
       fs.readFile(path.join(root, 'cindy-brain', 'valid-plugin', 'ghost.json'), 'utf-8'),
@@ -1162,11 +1151,7 @@ describe('legacy Ghost plugin recovery', () => {
         { mode: 'cloud', dataOwnerId: ownerId, user: { id: ownerId } },
         root,
       ),
-    ).toEqual({
-      state: 'partial',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
 
     await expect(
       recoverLegacyGhostPlugins(
@@ -1222,11 +1207,7 @@ describe('legacy Ghost plugin recovery', () => {
         {},
         (pid) => pid === 4242,
       ),
-    ).toEqual({
-      state: 'deferred',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
 
     const result = await recoverLegacyGhostPlugins(
       { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
@@ -1290,7 +1271,7 @@ describe('legacy Ghost plugin recovery', () => {
     expect(hasLegacyOwnerNamespaceClaim('cloud-a', root)).toBe(false);
   });
 
-  it('reports claimed-by-other-owner and never moves plugins across accounts', async () => {
+  it('ignores foreign-owned shared plugins and never moves them across accounts', async () => {
     const root = await tempRoot();
     await writeGhostDir(root, 'cindy-brain', 'valid-plugin');
     await fs.writeFile(
@@ -1308,14 +1289,13 @@ describe('legacy Ghost plugin recovery', () => {
     );
 
     expect(result).toEqual({ status: 'claimed-by-other-owner', moved: 0, conflicts: 0 });
-    expect(status).toEqual({
-      state: 'claimed-by-other-owner',
-      legacyPluginCount: 1,
-      canRetry: false,
-    });
+    expect(status).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
     await expect(
       fs.access(path.join(root, 'owners', dataOwnerStorageKey('cloud-b'), 'cindy-brain')),
     ).rejects.toThrow();
+    await expect(
+      fs.readFile(path.join(root, 'cindy-brain', 'valid-plugin', 'ghost.json'), 'utf-8'),
+    ).resolves.toContain('"id":"valid-plugin"');
   });
 
   it('reports retryable partial status when legacy plugins appear after a completed owner claim', async () => {
@@ -1348,11 +1328,7 @@ describe('legacy Ghost plugin recovery', () => {
           { mode: 'cloud', dataOwnerId: 'cloud-a', user: { id: 'cloud-a' } },
           root,
         ),
-      ).toEqual({
-        state: 'deferred',
-        legacyPluginCount: 1,
-        canRetry: false,
-      });
+      ).toEqual({ state: 'none', legacyPluginCount: 0, canRetry: false });
     } finally {
       delete process.env.XDT_PASSIVE_SHARED_USER_DATA;
     }

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -536,7 +536,10 @@ function getLegacyGhostRecoveryStatusForActiveSession(): LegacyGhostRecoveryStat
     currentLegacyGhostMigrationSession(),
     undefined,
     isAppSessionBoundaryPending(),
-    { reservedCommands: reservedBuiltinCommands },
+    {
+      reservedCommands: reservedBuiltinCommands,
+      rejectReservedIds: app.isPackaged,
+    },
   );
 }
 

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -286,6 +286,13 @@ interface LegacyGhostDir {
   command: string | null;
 }
 
+function filterLegacyGhostsByIdPolicy(
+  ghosts: LegacyGhostDir[],
+  rejectReservedIds: boolean,
+): LegacyGhostDir[] {
+  return rejectReservedIds ? ghosts.filter((ghost) => !isOfficialGhostId(ghost.id)) : ghosts;
+}
+
 function readValidLegacyGhostDir(
   dir: string,
   expectedId: string,
@@ -483,7 +490,10 @@ export function getLegacyGhostRecoveryStatus(
   session: MigrationSessionState,
   userDataDir?: string,
   boundaryPending = false,
-  options: { reservedCommands?: ReadonlySet<string> } = {},
+  options: {
+    reservedCommands?: ReadonlySet<string>;
+    rejectReservedIds?: boolean;
+  } = {},
   isPidAlive: (pid: number) => boolean = isPidAliveDefault,
 ): LegacyGhostRecoveryStatus {
   if (boundaryPending || session.mode !== 'cloud' || !session.dataOwnerId || !session.user) {
@@ -493,14 +503,15 @@ export function getLegacyGhostRecoveryStatus(
 
   const root = userDataDir ?? app.getPath('userData');
   const ownerKey = dataOwnerStorageKey(session.dataOwnerId);
-  const sharedLegacyGhosts = listSharedLegacyGhostDirs(root);
-  const scopedLegacyGhosts = listOwnerScopedLegacyGhostDirs(root, ownerKey);
-  const legacyGhosts = [...sharedLegacyGhosts, ...scopedLegacyGhosts];
-  const legacyPluginCount = legacyGhosts.length;
-  if (legacyPluginCount === 0) return NO_LEGACY_GHOST_RECOVERY;
-  if (process.env.XDT_PASSIVE_SHARED_USER_DATA === '1') {
-    return { state: 'deferred', legacyPluginCount, canRetry: false };
-  }
+  const rejectReservedIds = options.rejectReservedIds === true;
+  const sharedLegacyGhosts = filterLegacyGhostsByIdPolicy(
+    listSharedLegacyGhostDirs(root),
+    rejectReservedIds,
+  );
+  const scopedLegacyGhosts = filterLegacyGhostsByIdPolicy(
+    listOwnerScopedLegacyGhostDirs(root, ownerKey),
+    rejectReservedIds,
+  );
 
   const markerRead = readMarkerSync(root);
   const sharedRecoveryBlocked =
@@ -508,19 +519,25 @@ export function getLegacyGhostRecoveryStatus(
     (markerRead.invalid ||
       (markerRead.marker !== null && markerRead.marker.ownerKey !== ownerKey));
   if (sharedRecoveryBlocked && scopedLegacyGhosts.length === 0) {
-    if (markerRead.marker && markerRead.marker.ownerKey !== ownerKey) {
-      return { state: 'claimed-by-other-owner', legacyPluginCount, canRetry: false };
-    }
-    return { state: 'partial', legacyPluginCount, canRetry: false };
+    // 无法证明属于当前账号的共享目录不是当前账号的恢复任务：保留原文件，
+    // 但不向 Renderer 暴露数量，也不展示一个用户无法处理的永久状态。
+    return NO_LEGACY_GHOST_RECOVERY;
+  }
+  const eligibleLegacyGhosts = sharedRecoveryBlocked
+    ? scopedLegacyGhosts
+    : [...sharedLegacyGhosts, ...scopedLegacyGhosts];
+  const legacyPluginCount = eligibleLegacyGhosts.length;
+  if (legacyPluginCount === 0) return NO_LEGACY_GHOST_RECOVERY;
+  if (process.env.XDT_PASSIVE_SHARED_USER_DATA === '1') {
+    return NO_LEGACY_GHOST_RECOVERY;
   }
   if (hasConcurrentLiveInstanceSync(root, isPidAlive)) {
-    return { state: 'deferred', legacyPluginCount, canRetry: false };
+    return NO_LEGACY_GHOST_RECOVERY;
   }
 
-  const eligibleLegacyGhosts = sharedRecoveryBlocked ? scopedLegacyGhosts : legacyGhosts;
   const targetRoot = path.join(root, 'owners', ownerKey, 'cindy-brain');
   if (!hasSafeRecoveryTargetChainSync(root, targetRoot)) {
-    return { state: 'partial', legacyPluginCount, canRetry: false };
+    return NO_LEGACY_GHOST_RECOVERY;
   }
   const occupiedCommands = new Set(
     listLegacyGhostDirsInRoots([targetRoot])
@@ -542,15 +559,7 @@ export function getLegacyGhostRecoveryStatus(
     return command === null || !occupiedCommands.has(command);
   });
   if (!canRetry) {
-    if (
-      sharedRecoveryBlocked &&
-      markerRead.marker &&
-      markerRead.marker.ownerKey !== ownerKey &&
-      scopedLegacyGhosts.length === 0
-    ) {
-      return { state: 'claimed-by-other-owner', legacyPluginCount, canRetry: false };
-    }
-    return { state: 'partial', legacyPluginCount, canRetry: false };
+    return NO_LEGACY_GHOST_RECOVERY;
   }
 
   const marker = markerRead.marker;
@@ -577,8 +586,15 @@ export async function recoverLegacyGhostPlugins(
   const userDataDir = deps.userDataDir();
   const ownerKey = dataOwnerStorageKey(ownerId);
   const markerPath = path.join(userDataDir, CLAIM_MARKER);
-  const sharedLegacyGhosts = listSharedLegacyGhostDirs(userDataDir);
-  const scopedLegacyGhosts = listOwnerScopedLegacyGhostDirs(userDataDir, ownerKey);
+  const rejectReservedIds = options.rejectReservedIds === true;
+  const sharedLegacyGhosts = filterLegacyGhostsByIdPolicy(
+    listSharedLegacyGhostDirs(userDataDir),
+    rejectReservedIds,
+  );
+  const scopedLegacyGhosts = filterLegacyGhostsByIdPolicy(
+    listOwnerScopedLegacyGhostDirs(userDataDir, ownerKey),
+    rejectReservedIds,
+  );
   let marker: ClaimMarker | null = null;
   let eligibleSharedGhosts = sharedLegacyGhosts;
   let sharedRecoveryBlocked = false;
@@ -616,10 +632,6 @@ export async function recoverLegacyGhostPlugins(
   let movableLegacyGhosts: ReturnType<typeof listLegacyGhostDirs> = [];
   let conflicts = sharedRecoveryBlocked ? sharedLegacyGhosts.length : 0;
   for (const legacy of [...eligibleSharedGhosts, ...scopedLegacyGhosts]) {
-    if (options.rejectReservedIds && isOfficialGhostId(legacy.id)) {
-      conflicts += 1;
-      continue;
-    }
     if ((await pathType(deps, path.join(targetRoot, legacy.id))) === 'missing') {
       movableLegacyGhosts.push(legacy);
     } else {

--- a/apps/desktop/src/main/ownerNamespaceMigration.ts
+++ b/apps/desktop/src/main/ownerNamespaceMigration.ts
@@ -519,9 +519,15 @@ export function getLegacyGhostRecoveryStatus(
     (markerRead.invalid ||
       (markerRead.marker !== null && markerRead.marker.ownerKey !== ownerKey));
   if (sharedRecoveryBlocked && scopedLegacyGhosts.length === 0) {
-    // 无法证明属于当前账号的共享目录不是当前账号的恢复任务：保留原文件，
-    // 但不向 Renderer 暴露数量，也不展示一个用户无法处理的永久状态。
-    return NO_LEGACY_GHOST_RECOVERY;
+    if (markerRead.marker && markerRead.marker.ownerKey !== ownerKey) {
+      // 已明确属于其他账号的共享目录不是当前账号的恢复任务。
+      return NO_LEGACY_GHOST_RECOVERY;
+    }
+    return {
+      state: 'partial',
+      legacyPluginCount: sharedLegacyGhosts.length,
+      canRetry: false,
+    };
   }
   const eligibleLegacyGhosts = sharedRecoveryBlocked
     ? scopedLegacyGhosts
@@ -529,15 +535,15 @@ export function getLegacyGhostRecoveryStatus(
   const legacyPluginCount = eligibleLegacyGhosts.length;
   if (legacyPluginCount === 0) return NO_LEGACY_GHOST_RECOVERY;
   if (process.env.XDT_PASSIVE_SHARED_USER_DATA === '1') {
-    return NO_LEGACY_GHOST_RECOVERY;
+    return { state: 'deferred', legacyPluginCount, canRetry: false };
   }
   if (hasConcurrentLiveInstanceSync(root, isPidAlive)) {
-    return NO_LEGACY_GHOST_RECOVERY;
+    return { state: 'deferred', legacyPluginCount, canRetry: false };
   }
 
   const targetRoot = path.join(root, 'owners', ownerKey, 'cindy-brain');
   if (!hasSafeRecoveryTargetChainSync(root, targetRoot)) {
-    return NO_LEGACY_GHOST_RECOVERY;
+    return { state: 'partial', legacyPluginCount, canRetry: false };
   }
   const occupiedCommands = new Set(
     listLegacyGhostDirsInRoots([targetRoot])
@@ -559,7 +565,7 @@ export function getLegacyGhostRecoveryStatus(
     return command === null || !occupiedCommands.has(command);
   });
   if (!canRetry) {
-    return NO_LEGACY_GHOST_RECOVERY;
+    return { state: 'partial', legacyPluginCount, canRetry: false };
   }
 
   const marker = markerRead.marker;


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复旧插件目录已被其他账号认领时，当前账号仍持续看到“旧版本插件正在等待恢复”的误提示。Main 现在只把当前账号实际可重试的旧插件目录展示为恢复任务；无法归属当前账号、被并发实例占用、目标冲突以及打包版保留的官方插件 ID 均保持原文件不动，并对当前账号忽略。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Refs #1857；修复旧插件跨账号恢复误提示
- 本 PR 包含：恢复状态可操作性判定、打包版保留 ID 过滤、相关回归用例
- 明确不包含：插件安装器、市场服务端、ledger/manifest、UI 文案改造
- 用户可见变化：其他账号的旧插件目录不再让当前账号看到“等待恢复”；当前账号可恢复的旧插件仍可正常重试
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：仅修正 Main 返回的恢复状态，不改界面、交互或文案。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（全仓 unit tier）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm check:dco
结果：通过
```

### 手工验证

- macOS，CN dev，使用复用既有登录态的独立 QA 数据副本。
- 构造“其他账号认领标记 + 10 个旧插件目录”，插件页不再显示恢复误提示。
- 10 个目录保持原位，当前账号 owner 目录新增 0 个；原 `cindy-local` 数据未修改。

### 未执行的验证

- Windows 实机未执行；相关路径和迁移分支由全量单测覆盖。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅旧插件 owner namespace 恢复状态投影及打包版 reserved ID 过滤。存量插件影响：无；不会删除、移动或接管其他账号目录，当前账号可恢复目录仍沿用原迁移流程。无需同步作者手册，不改变 manifest、包格式、权限 slot 或作者契约。本 PR 命中插件基座路径，合并前需按仓库规则由把关人明确 Approve。
- 回滚 / 降级方式：回退本 PR 即恢复原状态判定；不涉及 schema 或数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节（不涉及 UI 则跳过）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需补充：不改变外部契约）
- [x] 已确认测试结果或说明未执行原因
