### PR TITLE
fix(desktop): 移除模型选择器重复关闭按钮

### DIFF
--- a/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
+++ b/apps/desktop/src/renderer/components/settings/CustomProviderDialog.tsx
@@ -24,7 +24,7 @@ import {
   type RefObject,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, ChevronDown, Plug, Plus, RefreshCw, Sparkles, Trash2, X } from 'lucide-react';
+import { Check, ChevronDown, Plug, Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react';
 
 import { cn } from '@/lib/utils';
 import { toast } from '@/lib/toast';
@@ -2430,7 +2430,7 @@ export function ModelPickerOverlay({
           style={{ WebkitAppRegion: 'no-drag' } as React.CSSProperties}
         >
           {/* Header */}
-          <div className="flex items-center justify-between px-5 pb-1 pt-4">
+          <div className="flex items-center px-5 pb-1 pt-4">
             <div className="flex min-w-0 flex-col gap-0.5">
               <Dialog.Title className="text-15 font-semibold text-[var(--settings-section-title)]">
                 {t('settings.providers.custom.fetch.pickerTitle', {
@@ -2447,14 +2447,6 @@ export function ModelPickerOverlay({
                 })}
               </Dialog.Description>
             </div>
-            <button
-              type="button"
-              onClick={onClose}
-              aria-label={t('settings.providers.custom.cancel')}
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-[var(--text-tertiary)] transition-colors hover:bg-[var(--surface-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
-            >
-              <X size={16} />
-            </button>
           </div>
           {/* 搜索（项目多才显示）+ 全选/清空（作用于当前过滤结果） */}
           <div className="flex flex-col gap-2 px-5 pt-2">

--- a/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderModelPickerOverlay.test.tsx
+++ b/apps/desktop/src/renderer/components/settings/__tests__/CustomProviderModelPickerOverlay.test.tsx
@@ -60,6 +60,10 @@ describe('ModelPickerOverlay', () => {
     const user = userEvent.setup();
     render(<Harness />);
 
+    expect(
+      screen.queryAllByRole('button', { name: 'settings.providers.custom.cancel' }),
+    ).toHaveLength(1);
+
     await waitFor(() =>
       expect(document.activeElement).toBe(
         screen.getByPlaceholderText('settings.providers.custom.fetch.searchPlaceholder'),


### PR DESCRIPTION
## 这次改了什么

### 摘要

移除自定义供应商模型选择器标题栏中重复的右上角关闭按钮，只保留页脚“取消”、Esc 和点击遮罩三种既有关闭路径。

根因是模型选择器迁移到 Radix Dialog 时新增了右上角 ×，与页脚“取消”形成重复关闭 affordance，不符合 `docs/design-rules/DESIGN.md` §4 Dialog & Modal。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore`

### 范围

- 本 PR 包含：删除未使用的 `X` 图标导入、模型选择器标题栏关闭按钮，并新增“仅有一个取消按钮”的回归断言。
- 明确不包含：runtime fill、供应商配置、凭据、IPC、持久化或其它弹窗改动。
- 用户可见变化：模型选择器不再同时显示右上角 × 和页脚“取消”。
- Breaking change：无。

### UI 变化

这是对现有界面的单控件删除：模型选择器 header 不再显示重复的右上角 ×；页脚“取消”、Esc、遮罩关闭、IME 组合输入保护、焦点陷阱及关闭后焦点恢复均保持不变。未新增布局、颜色、文案或视觉资产。

- 引用的设计规范：`docs/design-rules/DESIGN.md` §4 Dialog & Modal——dismissible dialog 使用页脚取消、Esc 和遮罩关闭，不同时增加右上角 ×。
- 界面证据（改动后，head `f72a936be`）：[在线预览（Light / Dark）](https://htmlpreview.github.io/?https://gist.githubusercontent.com/nanaco666/fa88509568005dfbc82ae0f68ed34961/raw/6ed7ee82afc274b8e909a14e483bc7006de9571e/pr2372-evidence.html)；[源 HTML](https://gist.github.com/nanaco666/fa88509568005dfbc82ae0f68ed34961)。证据按 `ModelPickerOverlay` 的实际结构、zh-CN 文案和 Cindy Light/Dark token 渲染，明确展示 header 无右上角 ×、页脚“取消”仍在；不复用 #2291 旧截图。

## 怎么验证的

### 自动验证

- `CustomProviderModelPickerOverlay.test.tsx`：2 项通过；新增断言验证对话框中只有一个名为“取消”的按钮。
- 定向 ESLint：通过。
- Desktop typecheck：通过。
- `git diff --check`：通过。
- GitHub CI：Linux/Windows unit shards、verify、verify-checks、Desktop Git integration、DCO、Greptile、design basis 全部通过。

### 本地完整 unit 说明

`pnpm test:unit` runner 自测 393 项通过；workspace sweep 在开始前被本地既有 `cindy-protocol/packages/skill-protocol` 与上游测试 manifest 不一致阻断。本 PR 未修改或提交该子模块；干净 GitHub CI 的完整 Linux/Windows unit shards 已全部通过。

## 风险

### 风险评估

- 风险等级：低。
- 可能副作用：用户少一个重复的点击关闭入口。
- 保留的关闭路径：页脚“取消”、Esc、点击遮罩。
- 可访问性：打开聚焦、焦点陷阱、IME Escape 保护及关闭后焦点恢复逻辑未改；回归测试继续覆盖这些行为。
- 数据与安全：不涉及配置、凭据、网络请求、IPC、数据库或存储。

### 回滚

回滚单个提交 `f72a936be` 即可恢复标题栏关闭按钮，无数据迁移。

### 提交前检查

- [x] 已 review 完整 diff
- [x] commit 带 DCO 签名
- [x] UI 改动已注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要测试并确认 CI 结果
