### PR TITLE
fix(ios-simulator): stop shell-guard false positives on interpreter heredocs

### DIFF
--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -296,6 +296,27 @@ AWK`,
     `awk -v x=1 <<'AWK'
 system("xcr" "un" " sim" "ctl shutdown DEVICE")
 AWK`,
+    `python3 - <<'PY'
+import os
+os.system("ECIVED nwodtuhs ltcmis nurxc"[::-1])
+PY`,
+    `python3 - <<'PY'
+import os
+os.system("".join(reversed("ECIVED nwodtuhs ltcmis nurxc")))
+PY`,
+    `python3 - <<'PY'
+import os
+os.system(" ".join("ECIVED nwodtuhs ltcmis nurxc".split()[::-1]))
+PY`,
+    `node - <<'JS'
+require("child_process").execSync("ECIVED nwodtuhs ltcmis nurxc".split("").reverse().join(""))
+JS`,
+    `awk -f /dev/stdin <<'AWK'
+system("xcrun simctl shutdown DEVICE")
+AWK`,
+    `awk -f /dev/fd/0 <<'AWK'
+system("xcr" "un" " sim" "ctl shutdown DEVICE")
+AWK`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -454,6 +475,16 @@ print("hi")
 AWK`,
     `awk -v x=1 <<'AWK'
 print(x)
+AWK`,
+    `python3 - <<'PY'
+print("hello"[::-1])
+PY`,
+    `python3 - <<'PY'
+arr = [1, 2, 3]
+print(arr[::-1])
+PY`,
+    `awk -f /dev/stdin <<'AWK'
+print("hi")
 AWK`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -585,6 +585,8 @@ EOF`,
     `bash <<< 'echo hello'`,
     `cat <<< 'x' | grep -q y <<< 'z'`,
     `cat <<< 'x' | bash <<< 'echo hi'`,
+    `python3 <<< 'print(1)' | cat <<< 'xcrun simctl shutdown DEVICE'`,
+    `python3 <<< 'print(1)' | grep x <<< 'xcrun simctl shutdown DEVICE'`,
     `echo 'echo hello' | sh`,
     `cat <<'EOF' | sh
 printf '%s' "$var"

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -338,6 +338,15 @@ EOF`,
     `cat <<'EOF' | sh
 $(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE
 EOF`,
+    `cat <<'EOF' | sh
+$(printf '%s' xcr) $(printf '%s' un) $(printf '%s' sim) $(printf '%s' ctl) shutdown DEVICE
+EOF`,
+    `cat <<'EOF' | sh
+$(printf '%s %s' xcr un) $(printf '%s %s' sim ctl) shutdown DEVICE
+EOF`,
+    `cat <<'EOF' | sh
+$(printf 'xcr%s' un) $(printf ' sim%s' ctl) shutdown DEVICE
+EOF`,
     `cat <<'EOF' > /tmp/x.sh
 $(printf xcr) $(printf un) shutdown DEVICE
 EOF
@@ -531,6 +540,12 @@ EOF`,
     `echo 'echo hello' | sh`,
     `cat <<'EOF' | sh
 printf '%s' "$var"
+EOF`,
+    `cat <<'EOF' | sh
+$(printf '%s' hello)
+EOF`,
+    `cat <<'EOF' | sh
+$(printf '%d' 42)
 EOF`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -366,6 +366,12 @@ EOF`,
 $(printf '%s' xcr) $(printf '%s' un) $(printf '%s' sim) $(printf '%s' ctl) shutdown DEVICE
 EOF`,
     `cat <<'EOF' | sh
+$(/bin/echo xcr) $(/usr/bin/echo un) $(/bin/echo sim) $(/usr/bin/echo ctl) shutdown DEVICE
+EOF`,
+    `cat <<'EOF' | sh
+$(/usr/bin/printf '%s' xcr) $(/bin/printf '%s' un) shutdown DEVICE
+EOF`,
+    `cat <<'EOF' | sh
 $(printf '%s %s' xcr un) $(printf '%s %s' sim ctl) shutdown DEVICE
 EOF`,
     `cat <<'EOF' | sh
@@ -380,6 +386,7 @@ sh /tmp/x.sh`,
     `python3 <<< 'print("a|b"); os.system("xcrun simctl shutdown DEVICE")'`,
     `python3 <<< 'print("a|b"); os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")'`,
     `python3 <<< 'x = "|"; os.system("xcrun simctl shutdown DEVICE")'`,
+    `python3 <<< 'print(1)' <<< 'xcrun simctl shutdown DEVICE'`,
     `cat <<< 'x' | python3 <<< '"xcr" "un" " sim" "ctl shutdown DEVICE"'`,
     `cat <<< 'x' | python3 <<< 'xcrun simctl shutdown DEVICE'`,
     `cat <<< 'x' | bash <<< 'xcrun simctl shutdown DEVICE'`,
@@ -591,6 +598,8 @@ EOF`,
     `python3 <<< 'print(1)' | cat <<< 'xcrun simctl shutdown DEVICE'`,
     `python3 <<< 'print(1)' | grep x <<< 'xcrun simctl shutdown DEVICE'`,
     `python3 <<< 'print("a|b")' | cat`,
+    `python3 <<< 'xcrun simctl shutdown DEVICE' <<< 'print(1)'`,
+    `python3 <<< 'print(1)' | cat <<< 'simctl'`,
     `echo 'echo hello' | sh`,
     `cat <<'EOF' | sh
 printf '%s' "$var"

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -317,6 +317,21 @@ AWK`,
     `awk -f /dev/fd/0 <<'AWK'
 system("xcr" "un" " sim" "ctl shutdown DEVICE")
 AWK`,
+    `cat <<'SCRIPT' > /tmp/x.sh
+xcrun simctl shutdown DEVICE
+SCRIPT
+sh /tmp/x.sh`,
+    `tee /tmp/x.sh <<'SCRIPT'
+xcrun simctl shutdown DEVICE
+SCRIPT
+sh /tmp/x.sh`,
+    `cat <<'SCRIPT' > /tmp/x.sh
+"xcr" "un" " sim" "ctl shutdown DEVICE"
+SCRIPT
+bash /tmp/x.sh`,
+    `cat <<'EOF'
+xcrun simctl shutdown DEVICE
+EOF`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -486,6 +501,16 @@ PY`,
     `awk -f /dev/stdin <<'AWK'
 print("hi")
 AWK`,
+    `cat <<'EOF'
+{"data": [1, 2, 3]}
+EOF`,
+    `grep foo <<'EOF'
+line one
+line two
+EOF`,
+    `cat <<'EOF'
+hello world
+EOF`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -239,6 +239,33 @@ $(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
 $(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
     `( echo x ) # <<END
 $(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
+    `python3 -c 'x = "
+a <<END
+b
+"'
+$(printf xcr) $(printf un) shutdown DEVICE`,
+    `python3 -c "x = '
+a <<END
+b
+'"
+$(printf xcr) $(printf un) shutdown DEVICE`,
+    `python3 - <<'PY'
+import base64, os
+os.system(base64.b64decode("eGNydW4gc2ltY3RsIHNodXRkb3duIERFVklDRQ=="))
+PY`,
+    `node - <<'JS'
+require("child_process").execSync(atob("eGNydW4gc2ltY3RsIHNodXRkb3duIERFVklDRQ=="))
+JS`,
+    `node - <<'JS'
+require("child_process").execSync(Buffer.from("eGNydW4gc2ltY3RsIHNodXRkb3duIERFVklDRQ==", "base64"))
+JS`,
+    `python3 - <<'PY'
+import os
+os.system(bytes.fromhex("786372756e2073696d63746c2073687574646f776e20444556494345"))
+PY`,
+    `node - <<'JS'
+require("child_process").execSync(\`xcr\${'un'} sim\${'ctl'} shutdown DEVICE\`)
+JS`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -362,6 +389,19 @@ PY`,
     `python3 - <<'PY'
 print("\\x78foo")
 PY`,
+    `python3 -c 'x = "
+a <<END
+b
+"'
+`,
+    `python3 - <<'PY'
+import base64
+print(base64.b64decode("aGVsbG8gd29ybGQ="))
+PY`,
+    `node - <<'JS'
+const name = "world";
+console.log(\`hello \${name}\`);
+JS`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -178,6 +178,26 @@ PY`,
     `sh -c 'eval "$(cat)"' <<'SH'
 xcrun simctl shutdown DEVICE
 SH`,
+    `python3 - <<'PY'
+import os
+os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")
+PY`,
+    `python3 - <<'PY'
+import os
+os.system(f"xcr{'un'} sim{'ctl'} shutdown DEVICE")
+PY`,
+    `python3 - <<'PY'
+import subprocess
+subprocess.run(["xcr" + "un", "sim" + "ctl", "shutdown", "DEVICE"])
+PY`,
+    `python3 -c 'import os; os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")'`,
+    `bash <<'SH'
+xcr"un" sim"ctl" shutdown DEVICE
+SH`,
+    `python3 - <<'PY.SH'
+import os
+os.system("xcrun simctl shutdown DEVICE")
+PY.SH`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -253,6 +273,32 @@ PY`,
 print("ok")
 PY
 )"`,
+    `python3 - <<'PY.SH'
+import json
+print(json.dumps({"ok": True}))
+PY.SH`,
+    `python3 - <<'A' <<'B'
+print("a")
+A
+print("b")
+B`,
+    `python3 - <<-'PY'
+	print("hi")
+	PY`,
+    `python3 - <<PY
+	PY
+print("hi")
+PY`,
+    `python3 - <<'PY'
+print("a")
+PY
+node - <<'JS'
+console.log("b")
+JS`,
+    `python3 - <<'PY'
+print("hello", "world")
+parts = ["a", "b"]
+PY`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -210,6 +210,35 @@ $(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
 print(x) <<END
 PY
 $(printf xcr) $(printf un) shutdown DEVICE`,
+    `python3 - <<'PY'
+import os
+os.system(chr(120)+chr(99)+chr(114)+chr(117)+chr(110)+chr(32)+chr(115)+chr(105)+chr(109)+chr(99)+chr(116)+chr(108))
+PY`,
+    `python3 - <<'PY'
+import os
+os.system("".join(chr(c) for c in [120,99,114,117,110,32,115,105,109,99,116,108]))
+PY`,
+    `node - <<'JS'
+require("child_process").execSync(String.fromCharCode(120,99,114,117,110,32,115,105,109,99,116,108))
+JS`,
+    `python3 - <<'PY'
+import os
+os.system("\\x78\\x63\\x72\\x75\\x6e \\x73\\x69\\x6d\\x63\\x74\\x6c shutdown DEVICE")
+PY`,
+    `python3 - <<'END!'
+import os
+os.system("xcrun simctl shutdown DEVICE")
+END!`,
+    `python3 - <<'END$'
+import os
+os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")
+END$`,
+    `echo x; # <<END
+$(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
+    `echo x | # <<END
+$(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
+    `( echo x ) # <<END
+$(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -317,6 +346,21 @@ print("hi")
 PY`,
     `python3 - <<'PY'
 print(x) <<END
+PY`,
+    `python3 - <<'END!'
+import json
+print(json.dumps({"ok": True}))
+END!`,
+    `python3 - <<'PY'
+print([1, 2, 3])
+colors = [(120, 99, 114), (65, 66, 67)]
+print(colors)
+PY`,
+    `python3 - <<'PY'
+print(chr(65))
+PY`,
+    `python3 - <<'PY'
+print("\\x78foo")
 PY`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -332,6 +332,19 @@ bash /tmp/x.sh`,
     `cat <<'EOF'
 xcrun simctl shutdown DEVICE
 EOF`,
+    `cat <<'EOF' | sh
+$(printf xcr) $(printf un) shutdown DEVICE
+EOF`,
+    `cat <<'EOF' | sh
+$(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE
+EOF`,
+    `cat <<'EOF' > /tmp/x.sh
+$(printf xcr) $(printf un) shutdown DEVICE
+EOF
+sh /tmp/x.sh`,
+    `bash <<< '"xcr" + "un" + " sim" + "ctl shutdown DEVICE"'`,
+    `bash <<< '"xcr" "un" " sim" "ctl shutdown DEVICE"'`,
+    `echo '"xcr" "un" " sim" "ctl shutdown DEVICE"' | sh`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -510,6 +523,14 @@ line two
 EOF`,
     `cat <<'EOF'
 hello world
+EOF`,
+    `cat <<'EOF' | sh
+echo hello
+EOF`,
+    `bash <<< 'echo hello'`,
+    `echo 'echo hello' | sh`,
+    `cat <<'EOF' | sh
+printf '%s' "$var"
 EOF`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -270,6 +270,12 @@ JS`,
 $(printf xcr) $(printf un) shutdown DEVICE`,
     `cat <<< EOF
 $(printf xcr) $(printf un) shutdown DEVICE`,
+    `awk -f - <<'AWK'
+system("xcrun simctl shutdown DEVICE")
+AWK`,
+    `awk -f - <<'AWK'
+system("xcr" "un" " sim" "ctl shutdown DEVICE")
+AWK`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -408,6 +414,15 @@ console.log(\`hello \${name}\`);
 JS`,
     `cat <<<hello`,
     `cat <<< 'simctl'`,
+    `awk -f - <<'AWK'
+print("hi")
+AWK`,
+    `awk '{print}' <<'AWK'
+data line
+AWK`,
+    `awk -f script.awk <<'AWK'
+data line
+AWK`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -266,6 +266,10 @@ PY`,
     `node - <<'JS'
 require("child_process").execSync(\`xcr\${'un'} sim\${'ctl'} shutdown DEVICE\`)
 JS`,
+    `cat <<<EOF
+$(printf xcr) $(printf un) shutdown DEVICE`,
+    `cat <<< EOF
+$(printf xcr) $(printf un) shutdown DEVICE`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -402,6 +406,8 @@ PY`,
 const name = "world";
 console.log(\`hello \${name}\`);
 JS`,
+    `cat <<<hello`,
+    `cat <<< 'simctl'`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -310,6 +310,18 @@ os.system(chr(60*2)+chr(99)+chr(114)+chr(117)+chr(110)+chr(32)+chr(115)+chr(105)
 PY`,
     `python3 - <<'PY'
 import os
+os.system(chr((60*2))+chr(99)+chr(114)+chr(117)+chr(110))
+PY`,
+    `python3 - <<'PY'
+import os
+os.system(chr(2*60)+chr(99)+chr(114)+chr(117)+chr(110))
+PY`,
+    `python3 - <<'PY'
+import os
+os.system(chr(120%120+120)+chr(99)+chr(114)+chr(117)+chr(110))
+PY`,
+    `python3 - <<'PY'
+import os
 os.system("".join(chr(c) for c in [60*2, 99, 114, 117, 110, 32, 115, 105, 109, 99, 116, 108]))
 PY`,
     `python3 - <<'PY'
@@ -498,6 +510,12 @@ PY`,
     `python3 - <<'PY'
 def g(n): return n
 print(chr(g(65)))
+PY`,
+    `python3 - <<'PY'
+print(chr(-1))
+PY`,
+    `python3 - <<'PY'
+print(chr(60*))
 PY`,
     `python3 - <<'PY'
 print("\\x78foo")

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -377,6 +377,9 @@ EOF
 sh /tmp/x.sh`,
     `bash <<< '"xcr" + "un" + " sim" + "ctl shutdown DEVICE"'`,
     `bash <<< '"xcr" "un" " sim" "ctl shutdown DEVICE"'`,
+    `python3 <<< 'print("a|b"); os.system("xcrun simctl shutdown DEVICE")'`,
+    `python3 <<< 'print("a|b"); os.system("xcr" + "un" + " sim" + "ctl shutdown DEVICE")'`,
+    `python3 <<< 'x = "|"; os.system("xcrun simctl shutdown DEVICE")'`,
     `cat <<< 'x' | python3 <<< '"xcr" "un" " sim" "ctl shutdown DEVICE"'`,
     `cat <<< 'x' | python3 <<< 'xcrun simctl shutdown DEVICE'`,
     `cat <<< 'x' | bash <<< 'xcrun simctl shutdown DEVICE'`,
@@ -587,6 +590,7 @@ EOF`,
     `cat <<< 'x' | bash <<< 'echo hi'`,
     `python3 <<< 'print(1)' | cat <<< 'xcrun simctl shutdown DEVICE'`,
     `python3 <<< 'print(1)' | grep x <<< 'xcrun simctl shutdown DEVICE'`,
+    `python3 <<< 'print("a|b")' | cat`,
     `echo 'echo hello' | sh`,
     `cat <<'EOF' | sh
 printf '%s' "$var"

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -198,6 +198,18 @@ SH`,
 import os
 os.system("xcrun simctl shutdown DEVICE")
 PY.SH`,
+    `echo '<<END'
+$(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE
+END`,
+    `echo "<<END"
+$(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE
+END`,
+    `# <<END
+$(printf xcr) $(printf un) $(printf sim) $(printf ctl) shutdown DEVICE`,
+    `python3 - <<'PY'
+print(x) <<END
+PY
+$(printf xcr) $(printf un) shutdown DEVICE`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -298,6 +310,13 @@ JS`,
     `python3 - <<'PY'
 print("hello", "world")
 parts = ["a", "b"]
+PY`,
+    `echo '<<END'`,
+    `python3 - <<'PY'  # note
+print("hi")
+PY`,
+    `python3 - <<'PY'
+print(x) <<END
 PY`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -165,6 +165,19 @@ describeMac('embedded iOS Simulator shell policy', () => {
 import os
 os.system("xcrun simctl shutdown DEVICE")
 PY`,
+    `bash <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
+    `cat <<EOF
+$(xcrun simctl shutdown DEVICE)
+EOF`,
+    `python3 <<'PY'
+import os
+os.system("$(xcrun simctl shutdown DEVICE)")
+PY`,
+    `sh -c 'eval "$(cat)"' <<'SH'
+xcrun simctl shutdown DEVICE
+SH`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -203,6 +216,43 @@ PY`,
     `python3 -c 'print("ordinary project build")'`,
     `python3 -c 'print("Simulator")'`,
     `node -e 'console.log("ordinary project build")'`,
+    `python3 - <<'PY'
+import json
+__import__("json")
+print(json.dumps({"ok": True}))
+PY`,
+    `python3 - <<'PY'
+from xml.etree import ElementTree as ET
+ET.fromstring("<a/>")
+PY`,
+    `node - <<'JS'
+const data = JSON.parse('{"a":1}');
+console.log(data);
+JS`,
+    `node - <<'JS'
+(async () => {})().catch((err) => { console.error(err); });
+JS`,
+    `swift - <<'SW'
+let x = { (a: Int) -> Int in a * 2 }(21)
+print(x)
+SW`,
+    `perl - <<'PL'
+my $x = join(",", (1..5));
+print $x;
+PL`,
+    `cat <<'EOF'
+{"data": [1, 2, 3]}
+EOF`,
+    `cat <<EOF
+{"data": [1, 2, 3]}
+EOF`,
+    `python3 -c 'import sys; print(sys.stdin.read())' <<'PY'
+{"data": [1, 2, 3]}
+PY`,
+    `echo "$(python3 - <<'PY'
+print("ok")
+PY
+)"`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -306,6 +306,18 @@ os.system("".join(reversed("ECIVED nwodtuhs ltcmis nurxc")))
 PY`,
     `python3 - <<'PY'
 import os
+os.system(chr(60*2)+chr(99)+chr(114)+chr(117)+chr(110)+chr(32)+chr(115)+chr(105)+chr(109)+chr(99)+chr(116)+chr(108))
+PY`,
+    `python3 - <<'PY'
+import os
+os.system("".join(chr(c) for c in [60*2, 99, 114, 117, 110, 32, 115, 105, 109, 99, 116, 108]))
+PY`,
+    `python3 - <<'PY'
+import os
+os.system("".join(chr(c) for c in (60*2, 99, 114, 117, 110)))
+PY`,
+    `python3 - <<'PY'
+import os
 os.system(" ".join("ECIVED nwodtuhs ltcmis nurxc".split()[::-1]))
 PY`,
     `node - <<'JS'
@@ -473,6 +485,19 @@ print(colors)
 PY`,
     `python3 - <<'PY'
 print(chr(65))
+PY`,
+    `python3 - <<'PY'
+print(chr(65+0))
+PY`,
+    `python3 - <<'PY'
+print(chr(n))
+PY`,
+    `python3 - <<'PY'
+print([1*2, 3+4])
+PY`,
+    `python3 - <<'PY'
+def g(n): return n
+print(chr(g(65)))
 PY`,
     `python3 - <<'PY'
 print("\\x78foo")

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -276,6 +276,14 @@ AWK`,
     `awk -f - <<'AWK'
 system("xcr" "un" " sim" "ctl shutdown DEVICE")
 AWK`,
+    `python3 - <<PY:
+import os
+os.system("xcrun simctl shutdown DEVICE")
+PY:`,
+    `python3 - <<PY:
+print("hi")
+PY:
+$(printf xcr) $(printf un) shutdown DEVICE`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -423,6 +431,12 @@ AWK`,
     `awk -f script.awk <<'AWK'
 data line
 AWK`,
+    `python3 - <<PY:
+print("hi")
+PY:`,
+    `python3 - <<PY+
+print("hi")
+PY+`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -284,6 +284,18 @@ PY:`,
 print("hi")
 PY:
 $(printf xcr) $(printf un) shutdown DEVICE`,
+    `awk -f- <<'AWK'
+system("xcrun simctl shutdown DEVICE")
+AWK`,
+    `awk -f- <<'AWK'
+system("xcr" "un" " sim" "ctl shutdown DEVICE")
+AWK`,
+    `awk <<'AWK'
+system("xcrun simctl shutdown DEVICE")
+AWK`,
+    `awk -v x=1 <<'AWK'
+system("xcr" "un" " sim" "ctl shutdown DEVICE")
+AWK`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
     `python3 -c 'import subprocess; subprocess.run(["/usr/bin/open","-a","Simulator"])'`,
@@ -437,6 +449,12 @@ PY:`,
     `python3 - <<PY+
 print("hi")
 PY+`,
+    `awk -f- <<'AWK'
+print("hi")
+AWK`,
+    `awk -v x=1 <<'AWK'
+print(x)
+AWK`,
     'swift test --filter IOSSimulatorTests',
     'swift build --product IOSSimulatorRuntime',
     'find . -maxdepth 1 -name simctl',

--- a/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/shellCommandPolicy.test.ts
@@ -377,6 +377,9 @@ EOF
 sh /tmp/x.sh`,
     `bash <<< '"xcr" + "un" + " sim" + "ctl shutdown DEVICE"'`,
     `bash <<< '"xcr" "un" " sim" "ctl shutdown DEVICE"'`,
+    `cat <<< 'x' | python3 <<< '"xcr" "un" " sim" "ctl shutdown DEVICE"'`,
+    `cat <<< 'x' | python3 <<< 'xcrun simctl shutdown DEVICE'`,
+    `cat <<< 'x' | bash <<< 'xcrun simctl shutdown DEVICE'`,
     `echo '"xcr" "un" " sim" "ctl shutdown DEVICE"' | sh`,
     `osascript -e 'set cmd to "/usr/bin/xcrun simctl shutdown DEVICE"' -e 'do shell script cmd'`,
     `osascript -l JavaScript -e 'ObjC.import("Foundation"); const task = $.NSTask.alloc.init; task.launchPath = "/usr/bin/xcrun"; task.arguments = ["simctl", "shutdown", "DEVICE"]; task.launch'`,
@@ -580,6 +583,8 @@ EOF`,
 echo hello
 EOF`,
     `bash <<< 'echo hello'`,
+    `cat <<< 'x' | grep -q y <<< 'z'`,
+    `cat <<< 'x' | bash <<< 'echo hi'`,
     `echo 'echo hello' | sh`,
     `cat <<'EOF' | sh
 printf '%s' "$var"

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1096,6 +1096,48 @@ function containsInterpreterHeredocBypass(command: string): boolean {
   return false;
 }
 
+/** Executable of the command segment that receives a heredoc, or null. */
+function heredocConsumerExecutable(prefix: string): string | null {
+  // A heredoc binds to the last command of its pipeline, so search backwards.
+  const segments = shellSegments(prefix);
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const unwrapped = unwrapCommand(tokenizeShellSegment(segments[index] ?? ''));
+    if (unwrapped.nestedShell !== null || unwrapped.unresolvedWrapper) continue;
+    if (unwrapped.tokens.length === 0) continue;
+    return executableName(unwrapped.tokens[0]);
+  }
+  return null;
+}
+
+/**
+ * Heredoc bodies consumed by a non-shell program (a code interpreter such as
+ * python/node, or a data tool such as cat/grep) are not shell program text.
+ * Re-parsing those lines as shell segments trips the fail-closed
+ * dynamic-expansion check on ordinary interpreter source (for example
+ * `__import__("json")` contains `(`/`)` in command position), denying harmless
+ * commands. Blank such bodies before the shell scans below; literal Simulator
+ * executors inside bodies are still classified by containsShellConsumedLiteralBypass
+ * over the original text, and bodies of shell-consumed heredocs (`bash <<EOF`)
+ * stay intact because they are real shell code.
+ */
+function redactNonShellHeredocBodies(command: string): string {
+  const lines = command.split('\n');
+  const redacted = [...lines];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? '';
+    const marker = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/.exec(line);
+    if (!marker) continue;
+    const consumer = heredocConsumerExecutable(line.slice(0, marker.index));
+    if (consumer === null || SHELL_EXECUTABLES.has(consumer)) continue;
+    const delimiter = marker[2]!;
+    for (index += 1; index < lines.length; index += 1) {
+      if ((lines[index] ?? '').replace(/^\t+/, '').trim() === delimiter) break;
+      redacted[index] = '';
+    }
+  }
+  return redacted.join('\n');
+}
+
 /** A here-string is executable stdin just like a heredoc or producer pipeline. */
 function containsInterpreterHereStringBypass(command: string): boolean {
   for (const clause of shellClauses(command)) {
@@ -1258,17 +1300,23 @@ function containsSimulatorAliasDefinition(tokens: string[], depth: number): bool
 
 function containsSimulatorBypass(command: string, depth = 0): boolean {
   if (depth > 8) return /\b(?:simctl|Simulator(?:\.app)?)\b/i.test(command);
+  // Heredoc bodies of non-shell consumers are not shell program text; scan
+  // them only for literal Simulator executors (below, over the original text)
+  // so ordinary interpreter source such as `__import__("json")` cannot trip
+  // the fail-closed shell checks. Nested subcommands keep the original text:
+  // their recursive scan re-classifies heredoc bodies in their own context.
+  const scannable = redactNonShellHeredocBodies(command);
   if (
-    containsTaintedVariableExecution(command) ||
+    containsTaintedVariableExecution(scannable) ||
     containsShellConsumedLiteralBypass(command) ||
-    containsSimulatorFunctionBody(command, depth)
+    containsSimulatorFunctionBody(scannable, depth)
   ) {
     return true;
   }
   for (const nested of shellSubcommands(command)) {
     if (containsSimulatorBypass(nested, depth + 1)) return true;
   }
-  for (const segment of shellSegments(command)) {
+  for (const segment of shellSegments(scannable)) {
     // Function bodies were classified recursively above. The leading
     // `name(){` token is not an execution wrapper in its own right.
     if (SHELL_FUNCTION_DEFINITION_PREFIX.test(segment)) {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1720,7 +1720,8 @@ function containsInterpreterHereStringBypass(command: string): boolean {
       ) {
         return true;
       }
-      break;
+      // A pipeline may carry several here-strings with different consumers
+      // (`cat <<< a | python3 <<< b`); keep scanning for the next one.
     }
   }
   return false;

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1073,11 +1073,15 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
 }
 
 /**
- * Quoted delimiters may contain punctuation (`<<'END.SH'`); unquoted
- * delimiters are shell words. `<<-` permits leading tabs on the delimiter
- * line, a plain `<<` does not.
+ * Quoted delimiters may contain any character except whitespace and the
+ * quoting character itself (`<<'END.SH'`, `<<'END!'`, `<<"END$"`); unquoted
+ * delimiters are shell words and stay restricted. `<<-` permits leading tabs
+ * on the delimiter line, a plain `<<` does not.
  */
-const HEREDOC_MARKER = /<<(-?)\s*(['"]?)([A-Za-z0-9_.-]+)\2/g;
+const HEREDOC_MARKER =
+  /<<(-?)\s*(?:'([^'\n]+)'|"([^"\n]+)"|([A-Za-z0-9_.-]+))/g;
+const HEREDOC_MARKER_START =
+  /^<<(-?)\s*(?:'([^'\n]+)'|"([^"\n]+)"|([A-Za-z0-9_.-]+))/;
 
 interface HeredocRegion {
   /** Line index of the line that opens the heredoc. */
@@ -1095,10 +1099,10 @@ interface HeredocRegion {
 /**
  * Mask quoted, commented, and command/process-substituted regions of a line
  * so heredoc markers inside them are not mistaken for real openers. A `#`
- * starts a comment only at a word boundary; `$'...'` is treated as a plain
- * single-quoted region. Substitutions (`$(...)`, `<(...)`, `>(...)`,
- * backticks) are re-scanned recursively by the caller, so masking their
- * markers here is safe.
+ * starts a comment at the start of a word, i.e. after whitespace or a shell
+ * control operator; `$'...'` is treated as a plain single-quoted region.
+ * Substitutions (`$(...)`, `<(...)`, `>(...)`, backticks) are re-scanned
+ * recursively by the caller, so masking their markers here is safe.
  */
 function maskQuotedAndCommentRegions(line: string): string {
   const masked = line.split('');
@@ -1144,13 +1148,17 @@ function maskQuotedAndCommentRegions(line: string): string {
     // A real heredoc marker keeps its delimiter word and quoting unmasked:
     // the quotes in `<<'END'` are syntax, not text.
     if (char === '<' && line[index + 1] === '<' && line[index + 2] !== '<') {
-      const marker = /^<<(-?)\s*(['"]?)([A-Za-z0-9_.-]+)\2/.exec(line.slice(index));
+      const marker = HEREDOC_MARKER_START.exec(line.slice(index));
       if (marker) {
         index += marker[0].length - 1;
         continue;
       }
     }
-    if (char === '#' && (index === 0 || /\s/.test(line[index - 1] ?? ''))) {
+    const prev = line[index - 1] ?? '';
+    if (
+      char === '#' &&
+      (index === 0 || /\s/.test(prev) || /[;&|()<>]/.test(prev))
+    ) {
       comment = true;
       masked[index] = ' ';
       continue;
@@ -1179,7 +1187,7 @@ function parseHeredocRegions(command: string): HeredocRegion[] {
         pending.push({
           lineIndex: index,
           markerIndex: match.index ?? 0,
-          delimiter: match[3] ?? '',
+          delimiter: match[2] ?? match[3] ?? match[4] ?? '',
           tabStripped: match[1] === '-',
         });
       }
@@ -1247,7 +1255,10 @@ function heredocConsumerExecutable(prefix: string): string | null {
  * Static pieces of the string literals in `value`, in source order. Pieces
  * are split at f-string `{...}` expression boundaries and string literals
  * inside expressions are collected as their own pieces, so an f-string
- * assembles to the same pieces the runtime produces.
+ * assembles to the same pieces the runtime produces. Escapes are kept as
+ * written (`\x78` stays two characters) so a quoted delimiter or quote
+ * inside an escape cannot end the literal early; decodeEscape decodes them
+ * for the assembly check.
  */
 function stringLiteralPieces(value: string): string[] {
   const pieces: string[] = [];
@@ -1265,8 +1276,12 @@ function stringLiteralPieces(value: string): string[] {
     while (cursor < value.length) {
       const char = value[cursor]!;
       if (char === '\\') {
-        if (braces === 0) piece += value[cursor + 1] ?? '';
-        cursor += 2;
+        if (braces === 0) {
+          piece += '\\' + (value[cursor + 1] ?? '');
+          cursor += 2;
+        } else {
+          cursor += 2;
+        }
         continue;
       }
       if (braces > 0) {
@@ -1276,7 +1291,7 @@ function stringLiteralPieces(value: string): string[] {
           let innerPiece = '';
           while (innerCursor < value.length && value[innerCursor] !== innerQuote) {
             if (value[innerCursor] === '\\') {
-              innerPiece += value[innerCursor + 1] ?? '';
+              innerPiece += '\\' + (value[innerCursor + 1] ?? '');
               innerCursor += 2;
             } else {
               innerPiece += value[innerCursor]!;
@@ -1316,15 +1331,62 @@ function stringLiteralPieces(value: string): string[] {
 }
 
 /**
+ * Decode statically resolvable character-producing constructs: `chr(120)`,
+ * `String.fromCharCode(120, 99, ...)`, integer arrays `[120, 99, ...]`, and
+ * `\xHH`/`\uHHHH` escapes. Runtime values (variables, file contents) have no
+ * static text and stay outside command-text policy.
+ */
+function decodedCharCodePieces(value: string): string[] {
+  const pieces: string[] = [];
+  const pushNumber = (number: string): void => {
+    const code = parseInt(number, 0) & 0xffff;
+    if (code > 0) pieces.push(String.fromCharCode(code));
+  };
+  for (const match of value.matchAll(/\b(?:chr|String\.fromCharCode)\(([^)]*)\)/g)) {
+    const numbers = (match[1] ?? '')
+      .split(',')
+      .map((part) => part.trim())
+      .filter((part) => part !== '');
+    if (numbers.length > 0 && numbers.every((n) => /^-?(?:\d+|0x[0-9a-f]+)$/i.test(n))) {
+      for (const number of numbers) pushNumber(number);
+    }
+  }
+  for (const match of value.matchAll(/\[([0-9,\s]+)\]|\(([0-9,\s]+)\)/g)) {
+    const body = (match[1] ?? match[2] ?? '').trim();
+    if (!body) continue;
+    const numbers = body.split(',').map((part) => part.trim());
+    if (numbers.every((n) => /^-?(?:\d+|0x[0-9a-f]+)$/i.test(n))) {
+      for (const number of numbers) pushNumber(number);
+    }
+  }
+  // `\xHH` / `\uHHHH` escapes inside string literals; a preceding backslash
+  // means the escape itself was escaped and must not decode.
+  for (const match of value.matchAll(/(?<!\\)\\x([0-9a-fA-F]{2})/g)) {
+    const code = parseInt(match[1] ?? '', 16);
+    if (code > 0) pieces.push(String.fromCharCode(code));
+  }
+  for (const match of value.matchAll(/(?<!\\)\\u([0-9a-fA-F]{4})/g)) {
+    const code = parseInt(match[1] ?? '', 16);
+    if (code > 0) pieces.push(String.fromCharCode(code));
+  }
+  return pieces;
+}
+
+/**
  * A literal scan alone cannot see an executor that is assembled at runtime,
  * e.g. `"xcr" + "un" + " sim" + "ctl"`, an f-string `f"xcr{'un'} sim{'ctl'}"`,
- * or an argv array `["xcr", "un", " sim", "ctl"]`. Join the string-literal
- * pieces in source order and scan the assembled text so redacting a heredoc
- * body cannot hide an assembled Simulator command from the shell-level checks.
+ * an argv array, `chr(120) + chr(99) + ...`, or `"\x78\x63..."` escapes. Join
+ * the statically decodable pieces in source order and scan the assembled text
+ * so redacting a heredoc body cannot hide an assembled Simulator command from
+ * the shell-level checks.
  */
 function containsAssembledSimulatorExecutor(value: string): boolean {
   if (containsLiteralSimulatorExecutor(value)) return true;
-  const pieces = stringLiteralPieces(value);
+  // Decoded character constructs count as their own pieces: a lone literal
+  // like `"\x78\x63..."` or a `chr(...)` chain must be checked even though
+  // the raw text yields only one string piece.
+  const decoded = decodedCharCodePieces(value);
+  const pieces = [...stringLiteralPieces(value), ...decoded];
   if (pieces.length < 2) return false;
   const joined = pieces.join('').replace(/[^A-Za-z0-9]/g, '');
   return /(?:xcrun|simctl|iphonesimulator|simulatorapp)/i.test(joined);

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1269,17 +1269,20 @@ function parseHeredocRegions(command: string): HeredocRegion[] {
   return regions;
 }
 
-function containsInterpreterHeredocBypass(command: string): boolean {
+/**
+ * Any non-shell consumer's heredoc body can reach execution: interpreters run
+ * it as a program, and data tools (cat, tee, `>` redirection) can write it to
+ * a script file that a later `sh file` executes. The body text is visible in
+ * the command, so scan every body whose consumer is not a shell for literal
+ * and assembled Simulator executors; bodies of shell-consumed heredocs stay
+ * classified by the shell scans instead.
+ */
+function containsNonShellHeredocBypass(command: string): boolean {
   const lines = command.split(/\r?\n/);
   for (const region of parseHeredocRegions(command)) {
     const line = lines[region.lineIndex] ?? '';
-    if (
-      !shellSegments(line.slice(0, region.markerIndex)).some((segment) =>
-        consumesStdinAsProgram(tokenizeShellSegment(segment)),
-      )
-    ) {
-      continue;
-    }
+    const consumer = heredocConsumerExecutable(line.slice(0, region.markerIndex));
+    if (consumer === null || SHELL_EXECUTABLES.has(consumer)) continue;
     const body = lines.slice(region.bodyStart, region.bodyEnd).join('\n');
     if (containsAssembledSimulatorExecutor(body)) return true;
   }
@@ -1588,7 +1591,7 @@ function containsInterpreterHereStringBypass(command: string): boolean {
 
 /** A literal command piped to a code-reading interpreter becomes executable input. */
 function containsShellConsumedLiteralBypass(command: string): boolean {
-  if (containsInterpreterHeredocBypass(command) || containsInterpreterHereStringBypass(command)) {
+  if (containsNonShellHeredocBypass(command) || containsInterpreterHereStringBypass(command)) {
     return true;
   }
   for (const clause of shellClauses(command)) {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1403,6 +1403,7 @@ function stringLiteralPieces(value: string): string[] {
         braces += 1;
         if (piece) {
           pieces.push(piece);
+          if (/['"]/.test(piece)) pieces.push(...stringLiteralPieces(piece));
           piece = '';
         }
         cursor += 1;
@@ -1411,7 +1412,12 @@ function stringLiteralPieces(value: string): string[] {
       piece += char;
       cursor += 1;
     }
-    if (piece) pieces.push(piece);
+    if (piece) {
+      pieces.push(piece);
+      // A quoted payload may wrap further string literals
+      // (`'"xcr" + "un" ...'`); collect those pieces too.
+      if (/['"]/.test(piece)) pieces.push(...stringLiteralPieces(piece));
+    }
     if (!closed) break;
     index = cursor + 1;
   }
@@ -1468,6 +1474,16 @@ function decodedCharCodePieces(value: string): string[] {
     const numbers = body.split(',').map((part) => part.trim());
     if (numbers.every((n) => /^-?(?:\d+|0x[0-9a-f]+)$/i.test(n))) {
       for (const number of numbers) pushNumber(number);
+    }
+  }
+  // Command substitutions emitting a literal (`$(printf xcr)`, `$(echo un)`)
+  // assemble an executor their output is invisible to; decode the literal.
+  for (const match of value.matchAll(/\$\(\s*(?:printf|echo)\s+([^)]+)\)/g)) {
+    const arg = (match[1] ?? '').trim();
+    if (/%[sdif]/.test(arg) || /[$`]/.test(arg)) continue; // format/expanding
+    const literal = arg.replace(/^['"]|['"]$/g, '').replace(/\s+/g, '');
+    for (const char of literal) {
+      if (char.charCodeAt(0) > 0) pieces.push(char);
     }
   }
   // `\xHH` / `\uHHHH` escapes inside string literals; a preceding backslash
@@ -1579,7 +1595,7 @@ function containsInterpreterHereStringBypass(command: string): boolean {
         shellSegments(consumer).some((segment) =>
           consumesStdinAsProgram(tokenizeShellSegment(segment)),
         ) &&
-        containsLiteralSimulatorExecutor(payload)
+        containsAssembledSimulatorExecutor(payload)
       ) {
         return true;
       }
@@ -1599,7 +1615,7 @@ function containsShellConsumedLiteralBypass(command: string): boolean {
     const segments = shellSegments(clause);
     if (
       segments.some((segment) => consumesStdinAsProgram(tokenizeShellSegment(segment))) &&
-      containsLiteralSimulatorExecutor(clause)
+      containsAssembledSimulatorExecutor(clause)
     ) {
       return true;
     }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1103,10 +1103,15 @@ interface HeredocRegion {
  * control operator; `$'...'` is treated as a plain single-quoted region.
  * Substitutions (`$(...)`, `<(...)`, `>(...)`, backticks) are re-scanned
  * recursively by the caller, so masking their markers here is safe.
+ * Shell quotes may span lines, so `initialQuote` carries the quote state
+ * from the previous line and the end state is returned for the next one.
  */
-function maskQuotedAndCommentRegions(line: string): string {
+function maskQuotedAndCommentRegions(
+  line: string,
+  initialQuote: "'" | '"' | '`' | null,
+): { masked: string; endQuote: "'" | '"' | '`' | null } {
   const masked = line.split('');
-  let quote: "'" | '"' | '`' | null = null;
+  let quote = initialQuote;
   let escaped = false;
   let comment = false;
   let parenDepth = 0;
@@ -1164,7 +1169,7 @@ function maskQuotedAndCommentRegions(line: string): string {
       continue;
     }
   }
-  return masked.join('');
+  return { masked: masked.join(''), endQuote: quote };
 }
 
 /**
@@ -1180,10 +1185,14 @@ function parseHeredocRegions(command: string): HeredocRegion[] {
   const regions: HeredocRegion[] = [];
   const pending: Array<Pick<HeredocRegion, 'lineIndex' | 'markerIndex' | 'delimiter' | 'tabStripped'>> =
     [];
+  // Quote state spans lines; body lines are data and do not affect it.
+  let quote: "'" | '"' | '`' | null = null;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? '';
     if (pending.length === 0) {
-      for (const match of maskQuotedAndCommentRegions(line).matchAll(HEREDOC_MARKER)) {
+      const { masked, endQuote } = maskQuotedAndCommentRegions(line, quote);
+      quote = endQuote;
+      for (const match of masked.matchAll(HEREDOC_MARKER)) {
         pending.push({
           lineIndex: index,
           markerIndex: match.index ?? 0,
@@ -1265,8 +1274,45 @@ function stringLiteralPieces(value: string): string[] {
   let index = 0;
   while (index < value.length) {
     const quote = value[index];
-    if (quote !== '"' && quote !== "'") {
+    if (quote !== '"' && quote !== "'" && quote !== '`') {
       index += 1;
+      continue;
+    }
+    if (quote === '`') {
+      // Template literal: static text is a piece, `${...}` expressions
+      // contribute the string literals they contain.
+      let cursor = index + 1;
+      let piece = '';
+      let closed = false;
+      while (cursor < value.length) {
+        const char = value[cursor]!;
+        if (char === '\\') {
+          piece += '\\' + (value[cursor + 1] ?? '');
+          cursor += 2;
+          continue;
+        }
+        if (char === '$' && value[cursor + 1] === '{') {
+          let depth = 1;
+          let end = cursor + 2;
+          while (end < value.length && depth > 0) {
+            if (value[end] === '{') depth += 1;
+            else if (value[end] === '}') depth -= 1;
+            end += 1;
+          }
+          pieces.push(...stringLiteralPieces(value.slice(cursor + 2, end - 1)));
+          cursor = end;
+          continue;
+        }
+        if (char === '`') {
+          closed = true;
+          break;
+        }
+        piece += char;
+        cursor += 1;
+      }
+      if (piece) pieces.push(piece);
+      if (!closed) break;
+      index = cursor + 1;
       continue;
     }
     let cursor = index + 1;
@@ -1368,6 +1414,29 @@ function decodedCharCodePieces(value: string): string[] {
   for (const match of value.matchAll(/(?<!\\)\\u([0-9a-fA-F]{4})/g)) {
     const code = parseInt(match[1] ?? '', 16);
     if (code > 0) pieces.push(String.fromCharCode(code));
+  }
+  // Base64/hex payloads decoded and executed at runtime: base64.b64decode,
+  // b64decode, atob, Buffer.from(..., base64|hex), bytes.fromhex.
+  const pushDecoded = (decoded: string): void => {
+    for (const char of decoded) {
+      if (char.charCodeAt(0) > 0) pieces.push(char);
+    }
+  };
+  for (const match of value.matchAll(
+    /(?:base64\.)?b64decode\(\s*["']([A-Za-z0-9+/=]+)["']\s*\)/g,
+  )) {
+    pushDecoded(Buffer.from(match[1] ?? '', 'base64').toString('utf8'));
+  }
+  for (const match of value.matchAll(/\batob\(\s*["']([A-Za-z0-9+/=]+)["']\s*\)/g)) {
+    pushDecoded(Buffer.from(match[1] ?? '', 'base64').toString('utf8'));
+  }
+  for (const match of value.matchAll(
+    /Buffer\.from\(\s*["']([A-Za-z0-9+/=]+)["']\s*,\s*["'](base64|hex)["']\s*\)/g,
+  )) {
+    pushDecoded(Buffer.from(match[1] ?? '', match[2] === 'hex' ? 'hex' : 'base64').toString('utf8'));
+  }
+  for (const match of value.matchAll(/bytes\.fromhex\(\s*["']([0-9a-fA-F]+)["']\s*\)/g)) {
+    pushDecoded(Buffer.from(match[1] ?? '', 'hex').toString('utf8'));
   }
   return pieces;
 }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1150,6 +1150,15 @@ function maskQuotedAndCommentRegions(
       index += 1;
       continue;
     }
+    // `<<<` is a here-string operator, not a heredoc opener; mask all three
+    // characters so the scanner cannot match a `<<EOF` from the second `<`.
+    if (char === '<' && line[index + 1] === '<' && line[index + 2] === '<') {
+      masked[index] = ' ';
+      masked[index + 1] = ' ';
+      masked[index + 2] = ' ';
+      index += 2;
+      continue;
+    }
     // A real heredoc marker keeps its delimiter word and quoting unmasked:
     // the quotes in `<<'END'` are syntax, not text.
     if (char === '<' && line[index + 1] === '<' && line[index + 2] !== '<') {

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -609,7 +609,12 @@ function containsLiteralSimulatorExecutor(value: string): boolean {
  */
 function containsInterpreterSimulatorPayload(tokens: string[]): boolean {
   const interpreter = executableName(tokens[0]);
-  const payload = tokens.slice(1).join('\n');
+  // A here-string redirection (`<<< payload`) feeds stdin, not argv; drop the
+  // operator and its payload so it is not mistaken for interpreter code.
+  const args = tokens.slice(1);
+  const payload = args
+    .filter((token, index) => token !== '<<<' && args[index - 1] !== '<<<')
+    .join('\n');
   if (PROGRAMMABLE_INTERPRETER.test(interpreter)) {
     return containsAssembledSimulatorExecutor(payload);
   }
@@ -1096,7 +1101,16 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
   } else {
     return false;
   }
-  const positional = args.find((arg) => !arg.startsWith('-'));
+  // Redirection operators (`<<< payload`, `> file`) are not program
+  // arguments; skip the operator and its target when looking for the
+  // program string.
+  const redirectionOperator = /^(?:\d+)?(?:<<<|<<-?|<>|<|>>?|>&|<&|>\|)$/;
+  const positional = args.find(
+    (arg, index) =>
+      !arg.startsWith('-') &&
+      !redirectionOperator.test(arg) &&
+      !(index > 0 && redirectionOperator.test(args[index - 1] ?? '')),
+  );
   return positional === undefined || positional === '-';
 }
 
@@ -1569,9 +1583,10 @@ function decodedCharCodePieces(value: string): string[] {
     const numbers = body.split(',').map((part) => part.trim());
     for (const number of numbers) pushConstant(number);
   }
-  // Command substitutions emitting a literal (`$(printf xcr)`, `$(echo un)`)
-  // assemble an executor their output is invisible to; decode the literal.
-  for (const match of value.matchAll(/\$\(\s*echo\s+([^)]+)\)/g)) {
+  // Command substitutions emitting a literal (`$(printf xcr)`, `$(echo un)`,
+  // also with a command path like `$(/bin/echo xcr)`) assemble an executor
+  // their output is invisible to; decode the literal.
+  for (const match of value.matchAll(/\$\(\s*(?:[A-Za-z0-9_./-]+\/)*echo\s+([^)]+)\)/g)) {
     const arg = (match[1] ?? '').trim();
     if (/[$`]/.test(arg)) continue; // expanding
     const literal = arg.replace(/^['"]|['"]$/g, '').replace(/\s+/g, '');
@@ -1581,7 +1596,7 @@ function decodedCharCodePieces(value: string): string[] {
   }
   // `$(printf <fmt> <literal args...>)`: expand `%s` placeholders when every
   // argument is a literal; other directives or runtime values stay skipped.
-  for (const match of value.matchAll(/\$\(\s*printf\s+([^)]+)\)/g)) {
+  for (const match of value.matchAll(/\$\(\s*(?:[A-Za-z0-9_./-]+\/)*printf\s+([^)]+)\)/g)) {
     const parts = cmdsubTokens(match[1] ?? '');
     if (parts.length === 0) continue;
     const fmt = parts[0]!.replace(/^['"]|['"]$/g, '');
@@ -1689,38 +1704,24 @@ function redactNonShellHeredocBodies(command: string): string {
   return redacted.join('\n');
 }
 
-/** Index of the first `|` outside quotes, or -1. */
-function unquotedPipeIndex(text: string): number {
-  let quote: "'" | '"' | '`' | null = null;
-  let escaped = false;
-  for (let index = 0; index < text.length; index += 1) {
-    const char = text[index]!;
-    if (escaped) {
-      escaped = false;
-      continue;
-    }
-    if (char === '\\' && quote !== "'") {
-      escaped = true;
-      continue;
-    }
-    if (quote) {
-      if (char === quote) quote = null;
-      continue;
-    }
-    if (char === "'" || char === '"' || char === '`') {
-      quote = char;
-      continue;
-    }
-    if (char === '|') return index;
-  }
-  return -1;
-}
-
 /** A here-string is executable stdin just like a heredoc or producer pipeline. */
 function containsInterpreterHereStringBypass(command: string): boolean {
   for (const clause of shellClauses(command)) {
-    let quote: "'" | '"' | null = null;
+    // Collect here-strings with quote awareness. A pipeline segment may
+    // carry several here-strings; the shell uses the last one as stdin, so
+    // earlier ones in the same segment are covered and must not be scanned.
+    const hereStrings: Array<{
+      index: number;
+      end: number;
+      covered: boolean;
+      consumerStart: number;
+    }> = [];
+    let quote: "'" | '"' | '`' | null = null;
     let escaped = false;
+    let segment = 0;
+    let lastPipe = -1;
+    let pending: { index: number; segment: number; end: number; consumerStart: number } | null =
+      null;
     for (let index = 0; index < clause.length - 2; index += 1) {
       const char = clause[index]!;
       if (escaped) {
@@ -1731,19 +1732,48 @@ function containsInterpreterHereStringBypass(command: string): boolean {
         escaped = true;
         continue;
       }
-      if (char === "'" || char === '"') {
-        if (quote === char) quote = null;
-        else if (quote === null) quote = char;
+      if (quote) {
+        if (char === quote) quote = null;
         continue;
       }
-      if (quote || clause.slice(index, index + 3) !== '<<<') continue;
-      const consumer = clause.slice(0, index).trim();
-      // The payload ends at the next unquoted pipeline boundary: a later
-      // here-string belongs to a different consumer (`python3 <<< code |
-      // cat <<< data`), while a `|` inside quotes is payload text.
-      const rest = clause.slice(index + 3);
-      const pipeIndex = unquotedPipeIndex(rest);
-      const payload = pipeIndex === -1 ? rest : rest.slice(0, pipeIndex);
+      if (char === "'" || char === '"' || char === '`') {
+        quote = char;
+        continue;
+      }
+      if (char === '|') {
+        if (pending) pending.end = index;
+        lastPipe = index;
+        segment += 1;
+        continue;
+      }
+      if (clause.slice(index, index + 3) === '<<<') {
+        if (pending) {
+          hereStrings.push({
+            index: pending.index,
+            end: pending.end,
+            covered: pending.segment === segment,
+            consumerStart: pending.consumerStart,
+          });
+        }
+        pending = { index, segment, end: clause.length, consumerStart: lastPipe + 1 };
+        index += 2;
+        continue;
+      }
+    }
+    if (pending) {
+      hereStrings.push({
+        index: pending.index,
+        end: pending.end,
+        covered: false,
+        consumerStart: pending.consumerStart,
+      });
+    }
+    for (const hereString of hereStrings) {
+      if (hereString.covered) continue;
+      // The consumer is the command segment after the last pipe, not an
+      // earlier pipeline stage (`python3 <<< code | cat <<< data`).
+      const consumer = clause.slice(hereString.consumerStart, hereString.index).trim();
+      const payload = clause.slice(hereString.index + 3, hereString.end);
       if (
         shellSegments(consumer).some((segment) =>
           consumesStdinAsProgram(tokenizeShellSegment(segment)),
@@ -1752,8 +1782,6 @@ function containsInterpreterHereStringBypass(command: string): boolean {
       ) {
         return true;
       }
-      // A pipeline may carry several here-strings with different consumers
-      // (`cat <<< a | python3 <<< b`); keep scanning for the next one.
     }
   }
   return false;
@@ -1769,7 +1797,12 @@ function containsShellConsumedLiteralBypass(command: string): boolean {
     const segments = shellSegments(clause);
     if (
       segments.some((segment) => consumesStdinAsProgram(tokenizeShellSegment(segment))) &&
-      containsAssembledSimulatorExecutor(clause)
+      // A here-string payload binds to its own redirection and never flows
+      // through the pipe; exclude it so data on the consumer side (`cat <<<
+      // data | python3 <<< code`) is not mistaken for piped program text.
+      containsAssembledSimulatorExecutor(
+        clause.replace(/<<<\s*(?:"[^"]*"|'[^']*'|\S+)/g, ''),
+      )
     ) {
       return true;
     }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1453,18 +1453,67 @@ function cmdsubTokens(text: string): string[] {
   return tokens;
 }
 
-/** Evaluate a constant integer expression made of literals and arithmetic. */
+/**
+ * Evaluate a constant integer expression made of literals and arithmetic
+ * (`60*2`, `0x3c*2`, `(1+2)*3`). A hand-written recursive-descent parser is
+ * used instead of eval: the expression is validated character-by-character
+ * before any evaluation runs.
+ */
 function evalConstantInt(expr: string): number | null {
-  const normalized = expr
+  const text = expr
     .replace(/\s+/g, '')
     .replace(/0x([0-9a-fA-F]+)/g, (_, hex) => String(parseInt(hex, 16)));
-  if (!/^[\d()+\-*/%]+$/.test(normalized)) return null;
-  try {
-    const value = Function(`"use strict"; return (${normalized});`)();
-    return typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : null;
-  } catch {
-    return null;
-  }
+  if (!/^[\d()+\-*/%]+$/.test(text)) return null;
+  let index = 0;
+  const peek = (): string => text[index] ?? '';
+  const expect = (char: string): boolean => {
+    if (peek() === char) {
+      index += 1;
+      return true;
+    }
+    return false;
+  };
+  const parseAddSub = (): number | null => {
+    let value = parseMulDiv();
+    while (value !== null && (peek() === '+' || peek() === '-')) {
+      const op = text[index]!;
+      index += 1;
+      const rhs = parseMulDiv();
+      if (rhs === null) return null;
+      value = op === '+' ? value + rhs : value - rhs;
+    }
+    return value;
+  };
+  const parseMulDiv = (): number | null => {
+    let value = parseUnary();
+    while (value !== null && (peek() === '*' || peek() === '/' || peek() === '%')) {
+      const op = text[index]!;
+      index += 1;
+      const rhs = parseUnary();
+      if (rhs === null) return null;
+      if (op === '*') value *= rhs;
+      else value = rhs === 0 ? NaN : op === '/' ? value / rhs : value % rhs;
+    }
+    return value;
+  };
+  const parseUnary = (): number | null => {
+    if (expect('-')) {
+      const value = parseUnary();
+      return value === null ? null : -value;
+    }
+    if (expect('(')) {
+      const value = parseAddSub();
+      if (value === null || !expect(')')) return null;
+      return value;
+    }
+    const start = index;
+    while (peek() >= '0' && peek() <= '9') index += 1;
+    if (start === index) return null;
+    return parseInt(text.slice(start, index), 10);
+  };
+  const result = parseAddSub();
+  if (result === null || index !== text.length) return null;
+  return Number.isFinite(result) ? Math.trunc(result) : null;
 }
 
 /**
@@ -1505,7 +1554,9 @@ function decodedCharCodePieces(value: string): string[] {
   )) {
     pushReversed(match[1] ?? '');
   }
-  for (const match of value.matchAll(/\b(?:chr|String\.fromCharCode)\(([^)]*)\)/g)) {
+  for (const match of value.matchAll(
+    /\b(?:chr|String\.fromCharCode)\(((?:[^()]|\([^()]*\))*)\)/g,
+  )) {
     const numbers = (match[1] ?? '')
       .split(',')
       .map((part) => part.trim())

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1061,7 +1061,20 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
   } else if (executable === 'osascript') {
     if (args.some((arg) => arg === '-e' || arg.startsWith('-e'))) return false;
   } else if (PROGRAMMABLE_INTERPRETER.test(executable)) {
-    if (/^(?:(?:g|m|n)?awk)$/.test(executable)) return false;
+    if (/^(?:(?:g|m|n)?awk)$/.test(executable)) {
+      // awk reads its program from a file with `-f progfile`, but `-f -`
+      // reads the program from stdin, which is executable heredoc input.
+      let flagIndex = 0;
+      while (flagIndex < args.length) {
+        const flag = args[flagIndex]!;
+        if (flag === '-f') return args[flagIndex + 1] === '-';
+        if (/^-[A-Za-z]*f[A-Za-z]*$/.test(flag) && flag.slice(flag.indexOf('f') + 1) === '-') {
+          return true;
+        }
+        flagIndex += 1;
+      }
+      return false;
+    }
     if (args.some((arg) => /^(?:-c|-e|-p|-m|--eval|--print|--input-type|--module)$/.test(arg))) {
       return false;
     }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1453,17 +1453,34 @@ function cmdsubTokens(text: string): string[] {
   return tokens;
 }
 
+/** Evaluate a constant integer expression made of literals and arithmetic. */
+function evalConstantInt(expr: string): number | null {
+  const normalized = expr
+    .replace(/\s+/g, '')
+    .replace(/0x([0-9a-fA-F]+)/g, (_, hex) => String(parseInt(hex, 16)));
+  if (!/^[\d()+\-*/%]+$/.test(normalized)) return null;
+  try {
+    const value = Function(`"use strict"; return (${normalized});`)();
+    return typeof value === 'number' && Number.isFinite(value) ? Math.trunc(value) : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Decode statically resolvable character-producing constructs: `chr(120)`,
- * `String.fromCharCode(120, 99, ...)`, integer arrays `[120, 99, ...]`, and
- * `\xHH`/`\uHHHH` escapes. Runtime values (variables, file contents) have no
- * static text and stay outside command-text policy.
+ * `String.fromCharCode(120, 99, ...)`, integer arrays `[120, 99, ...]`,
+ * constant arithmetic (`chr(60*2)`, `[0x3c*2, ...]`), and `\xHH`/`\uHHHH`
+ * escapes. Runtime values (variables, file contents) have no static text and
+ * stay outside command-text policy.
  */
 function decodedCharCodePieces(value: string): string[] {
   const pieces: string[] = [];
-  const pushNumber = (number: string): void => {
-    const code = parseInt(number, 0) & 0xffff;
-    if (code > 0) pieces.push(String.fromCharCode(code));
+  const pushConstant = (expr: string): boolean => {
+    const code = evalConstantInt(expr);
+    if (code === null) return false;
+    if (code > 0) pieces.push(String.fromCharCode(code & 0xffff));
+    return true;
   };
   // Reversed string literals (`"..."[::-1]`, `reversed("...")`, node's
   // `"..." .split("").reverse()`) reassemble an executor the literal scan
@@ -1493,17 +1510,13 @@ function decodedCharCodePieces(value: string): string[] {
       .split(',')
       .map((part) => part.trim())
       .filter((part) => part !== '');
-    if (numbers.length > 0 && numbers.every((n) => /^-?(?:\d+|0x[0-9a-f]+)$/i.test(n))) {
-      for (const number of numbers) pushNumber(number);
-    }
+    for (const number of numbers) pushConstant(number);
   }
-  for (const match of value.matchAll(/\[([0-9,\s]+)\]|\(([0-9,\s]+)\)/g)) {
+  for (const match of value.matchAll(/\[([0-9+\-*/%(),\s]*?)\]|\(([0-9+\-*/%(),\s]*?)\)/g)) {
     const body = (match[1] ?? match[2] ?? '').trim();
     if (!body) continue;
     const numbers = body.split(',').map((part) => part.trim());
-    if (numbers.every((n) => /^-?(?:\d+|0x[0-9a-f]+)$/i.test(n))) {
-      for (const number of numbers) pushNumber(number);
-    }
+    for (const number of numbers) pushConstant(number);
   }
   // Command substitutions emitting a literal (`$(printf xcr)`, `$(echo un)`)
   // assemble an executor their output is invisible to; decode the literal.

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1088,13 +1088,15 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
 /**
  * Quoted delimiters may contain any character except whitespace and the
  * quoting character itself (`<<'END.SH'`, `<<'END!'`, `<<"END$"`); unquoted
- * delimiters are shell words and stay restricted. `<<-` permits leading tabs
- * on the delimiter line, a plain `<<` does not.
+ * delimiters are shell words and stay restricted to characters with no shell
+ * meaning in word position (`:` and `+` are ordinary word characters, so
+ * `<<PY:` is a legal unquoted delimiter). `<<-` permits leading tabs on the
+ * delimiter line, a plain `<<` does not.
  */
 const HEREDOC_MARKER =
-  /<<(-?)\s*(?:'([^'\n]+)'|"([^"\n]+)"|([A-Za-z0-9_.-]+))/g;
+  /<<(-?)\s*(?:'([^'\n]+)'|"([^"\n]+)"|([A-Za-z0-9_.:+-]+))/g;
 const HEREDOC_MARKER_START =
-  /^<<(-?)\s*(?:'([^'\n]+)'|"([^"\n]+)"|([A-Za-z0-9_.-]+))/;
+  /^<<(-?)\s*(?:'([^'\n]+)'|"([^"\n]+)"|([A-Za-z0-9_.:+-]+))/;
 
 interface HeredocRegion {
   /** Line index of the line that opens the heredoc. */

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1070,7 +1070,7 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
         const flag = args[flagIndex]!;
         if (flag === '-f') {
           const file = args[flagIndex + 1];
-          return file === '-';
+          return file === '-' || file === '/dev/stdin' || file === '/dev/fd/0';
         }
         if (/^-[A-Za-z]*f-$/.test(flag)) return true;
         if (/^-[A-Za-z]*f[A-Za-z]*$/.test(flag)) return false;
@@ -1427,6 +1427,29 @@ function decodedCharCodePieces(value: string): string[] {
     const code = parseInt(number, 0) & 0xffff;
     if (code > 0) pieces.push(String.fromCharCode(code));
   };
+  // Reversed string literals (`"..."[::-1]`, `reversed("...")`, node's
+  // `"..." .split("").reverse()`) reassemble an executor the literal scan
+  // cannot see; decode them into the assembly check.
+  const pushReversed = (literal: string): void => {
+    if (literal.length < 2) return;
+    for (const char of [...literal].reverse()) pieces.push(char);
+  };
+  for (const match of value.matchAll(/["']([^"'\n]*)["']\s*\[\s*::\s*-?\s*1\s*\]/g)) {
+    pushReversed(match[1] ?? '');
+  }
+  for (const match of value.matchAll(/\breversed\(\s*["']([^"'\n]*)["']\s*\)/g)) {
+    pushReversed(match[1] ?? '');
+  }
+  for (const match of value.matchAll(
+    /["']([^"'\n]*)["']\s*\.split\(\s*["']?["']?\s*\)\s*\[\s*::\s*-?\s*1\s*\]/g,
+  )) {
+    pushReversed(match[1] ?? '');
+  }
+  for (const match of value.matchAll(
+    /["']([^"'\n]*)["']\s*\.split\(\s*["']?["']?\s*\)\s*\.reverse\(\)/g,
+  )) {
+    pushReversed(match[1] ?? '');
+  }
   for (const match of value.matchAll(/\b(?:chr|String\.fromCharCode)\(([^)]*)\)/g)) {
     const numbers = (match[1] ?? '')
       .split(',')

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1093,9 +1093,79 @@ interface HeredocRegion {
 }
 
 /**
+ * Mask quoted, commented, and command/process-substituted regions of a line
+ * so heredoc markers inside them are not mistaken for real openers. A `#`
+ * starts a comment only at a word boundary; `$'...'` is treated as a plain
+ * single-quoted region. Substitutions (`$(...)`, `<(...)`, `>(...)`,
+ * backticks) are re-scanned recursively by the caller, so masking their
+ * markers here is safe.
+ */
+function maskQuotedAndCommentRegions(line: string): string {
+  const masked = line.split('');
+  let quote: "'" | '"' | '`' | null = null;
+  let escaped = false;
+  let comment = false;
+  let parenDepth = 0;
+  for (let index = 0; index < line.length; index += 1) {
+    const char = line[index]!;
+    if (comment || escaped) {
+      masked[index] = ' ';
+      if (escaped) escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'" && parenDepth === 0) {
+      masked[index] = ' ';
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      masked[index] = ' ';
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (parenDepth > 0) {
+      masked[index] = ' ';
+      if (char === '(') parenDepth += 1;
+      else if (char === ')') parenDepth -= 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      masked[index] = ' ';
+      quote = char;
+      continue;
+    }
+    if ((char === '$' || char === '<' || char === '>') && line[index + 1] === '(') {
+      masked[index] = ' ';
+      masked[index + 1] = ' ';
+      parenDepth = 1;
+      index += 1;
+      continue;
+    }
+    // A real heredoc marker keeps its delimiter word and quoting unmasked:
+    // the quotes in `<<'END'` are syntax, not text.
+    if (char === '<' && line[index + 1] === '<' && line[index + 2] !== '<') {
+      const marker = /^<<(-?)\s*(['"]?)([A-Za-z0-9_.-]+)\2/.exec(line.slice(index));
+      if (marker) {
+        index += marker[0].length - 1;
+        continue;
+      }
+    }
+    if (char === '#' && (index === 0 || /\s/.test(line[index - 1] ?? ''))) {
+      comment = true;
+      masked[index] = ' ';
+      continue;
+    }
+  }
+  return masked.join('');
+}
+
+/**
  * Locate every heredoc region. Heredocs are matched FIFO: with several
  * openings on one line (`cmd <<A <<B`) each opener receives the body lines
- * between its predecessor's delimiter and its own.
+ * between its predecessor's delimiter and its own. Markers inside quotes,
+ * comments, or substitutions do not open a heredoc, and lines inside an
+ * open heredoc body are data, not commands, so they are not scanned for
+ * markers either.
  */
 function parseHeredocRegions(command: string): HeredocRegion[] {
   const lines = command.split(/\r?\n/);
@@ -1104,13 +1174,15 @@ function parseHeredocRegions(command: string): HeredocRegion[] {
     [];
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? '';
-    for (const match of line.matchAll(HEREDOC_MARKER)) {
-      pending.push({
-        lineIndex: index,
-        markerIndex: match.index ?? 0,
-        delimiter: match[3] ?? '',
-        tabStripped: match[1] === '-',
-      });
+    if (pending.length === 0) {
+      for (const match of maskQuotedAndCommentRegions(line).matchAll(HEREDOC_MARKER)) {
+        pending.push({
+          lineIndex: index,
+          markerIndex: match.index ?? 0,
+          delimiter: match[3] ?? '',
+          tabStripped: match[1] === '-',
+        });
+      }
     }
     const head = pending[0];
     if (!head) continue;

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1711,7 +1711,11 @@ function containsInterpreterHereStringBypass(command: string): boolean {
       }
       if (quote || clause.slice(index, index + 3) !== '<<<') continue;
       const consumer = clause.slice(0, index).trim();
-      const payload = clause.slice(index + 3);
+      // The payload ends at the next pipeline boundary: a later here-string
+      // belongs to a different consumer (`python3 <<< code | cat <<< data`).
+      const rest = clause.slice(index + 3);
+      const pipeIndex = rest.indexOf('|');
+      const payload = pipeIndex === -1 ? rest : rest.slice(0, pipeIndex);
       if (
         shellSegments(consumer).some((segment) =>
           consumesStdinAsProgram(tokenizeShellSegment(segment)),

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1062,18 +1062,33 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
     if (args.some((arg) => arg === '-e' || arg.startsWith('-e'))) return false;
   } else if (PROGRAMMABLE_INTERPRETER.test(executable)) {
     if (/^(?:(?:g|m|n)?awk)$/.test(executable)) {
-      // awk reads its program from a file with `-f progfile`, but `-f -`
-      // reads the program from stdin, which is executable heredoc input.
+      // awk reads its program from stdin when invoked with `-f -` (or the
+      // merged `-f-`) or with no program source at all; `-f progfile` reads
+      // a file and a positional argument is the program string.
       let flagIndex = 0;
       while (flagIndex < args.length) {
         const flag = args[flagIndex]!;
-        if (flag === '-f') return args[flagIndex + 1] === '-';
-        if (/^-[A-Za-z]*f[A-Za-z]*$/.test(flag) && flag.slice(flag.indexOf('f') + 1) === '-') {
-          return true;
+        if (flag === '-f') {
+          const file = args[flagIndex + 1];
+          return file === '-';
         }
-        flagIndex += 1;
+        if (/^-[A-Za-z]*f-$/.test(flag)) return true;
+        if (/^-[A-Za-z]*f[A-Za-z]*$/.test(flag)) return false;
+        if (flag === '-e') return false; // gawk -e program
+        if (flag === '-F' || flag === '-v') {
+          if (args[flagIndex + 1] !== undefined && !args[flagIndex + 1]!.startsWith('-')) {
+            flagIndex += 1;
+          }
+          flagIndex += 1;
+          continue;
+        }
+        if (flag === '--' || flag.startsWith('-')) {
+          flagIndex += 1;
+          continue;
+        }
+        return false;
       }
-      return false;
+      return true;
     }
     if (args.some((arg) => /^(?:-c|-e|-p|-m|--eval|--print|--input-type|--module)$/.test(arg))) {
       return false;

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1689,6 +1689,33 @@ function redactNonShellHeredocBodies(command: string): string {
   return redacted.join('\n');
 }
 
+/** Index of the first `|` outside quotes, or -1. */
+function unquotedPipeIndex(text: string): number {
+  let quote: "'" | '"' | '`' | null = null;
+  let escaped = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]!;
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (char === '\\' && quote !== "'") {
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '|') return index;
+  }
+  return -1;
+}
+
 /** A here-string is executable stdin just like a heredoc or producer pipeline. */
 function containsInterpreterHereStringBypass(command: string): boolean {
   for (const clause of shellClauses(command)) {
@@ -1711,10 +1738,11 @@ function containsInterpreterHereStringBypass(command: string): boolean {
       }
       if (quote || clause.slice(index, index + 3) !== '<<<') continue;
       const consumer = clause.slice(0, index).trim();
-      // The payload ends at the next pipeline boundary: a later here-string
-      // belongs to a different consumer (`python3 <<< code | cat <<< data`).
+      // The payload ends at the next unquoted pipeline boundary: a later
+      // here-string belongs to a different consumer (`python3 <<< code |
+      // cat <<< data`), while a `|` inside quotes is payload text.
       const rest = clause.slice(index + 3);
-      const pipeIndex = rest.indexOf('|');
+      const pipeIndex = unquotedPipeIndex(rest);
       const payload = pipeIndex === -1 ? rest : rest.slice(0, pipeIndex);
       if (
         shellSegments(consumer).some((segment) =>

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -1424,6 +1424,35 @@ function stringLiteralPieces(value: string): string[] {
   return pieces;
 }
 
+/** Split command-substitution words without splitting inside quotes. */
+function cmdsubTokens(text: string): string[] {
+  const tokens: string[] = [];
+  let current = '';
+  let quote: "'" | '"' | null = null;
+  for (const char of text) {
+    if (quote) {
+      current += char;
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      current += char;
+      continue;
+    }
+    if (/\s/.test(char)) {
+      if (current) {
+        tokens.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+  if (current) tokens.push(current);
+  return tokens;
+}
+
 /**
  * Decode statically resolvable character-producing constructs: `chr(120)`,
  * `String.fromCharCode(120, 99, ...)`, integer arrays `[120, 99, ...]`, and
@@ -1478,11 +1507,39 @@ function decodedCharCodePieces(value: string): string[] {
   }
   // Command substitutions emitting a literal (`$(printf xcr)`, `$(echo un)`)
   // assemble an executor their output is invisible to; decode the literal.
-  for (const match of value.matchAll(/\$\(\s*(?:printf|echo)\s+([^)]+)\)/g)) {
+  for (const match of value.matchAll(/\$\(\s*echo\s+([^)]+)\)/g)) {
     const arg = (match[1] ?? '').trim();
-    if (/%[sdif]/.test(arg) || /[$`]/.test(arg)) continue; // format/expanding
+    if (/[$`]/.test(arg)) continue; // expanding
     const literal = arg.replace(/^['"]|['"]$/g, '').replace(/\s+/g, '');
     for (const char of literal) {
+      if (char.charCodeAt(0) > 0) pieces.push(char);
+    }
+  }
+  // `$(printf <fmt> <literal args...>)`: expand `%s` placeholders when every
+  // argument is a literal; other directives or runtime values stay skipped.
+  for (const match of value.matchAll(/\$\(\s*printf\s+([^)]+)\)/g)) {
+    const parts = cmdsubTokens(match[1] ?? '');
+    if (parts.length === 0) continue;
+    const fmt = parts[0]!.replace(/^['"]|['"]$/g, '');
+    if (fmt.replace(/%s/g, '').includes('%')) continue; // %% / %d / %f etc.
+    const args = parts.slice(1).map((arg) => {
+      if (/^["'][^"']*["']$/.test(arg)) return arg.slice(1, -1);
+      if (/^[A-Za-z0-9_.:+-]+$/.test(arg)) return arg;
+      return null; // runtime value — not statically decodable
+    });
+    if (args.some((arg) => arg === null)) continue;
+    let out = '';
+    let argIndex = 0;
+    for (const segment of fmt.split(/(%s)/)) {
+      if (segment === '%s') {
+        out += args[argIndex] ?? '';
+        argIndex += 1;
+      } else {
+        out += segment;
+      }
+    }
+    for (; argIndex < args.length; argIndex += 1) out += args[argIndex]!; // format reuse
+    for (const char of out.replace(/\s+/g, '')) {
       if (char.charCodeAt(0) > 0) pieces.push(char);
     }
   }

--- a/apps/desktop/src/main/maker-host/shell-command-policy.ts
+++ b/apps/desktop/src/main/maker-host/shell-command-policy.ts
@@ -603,22 +603,22 @@ function containsLiteralSimulatorExecutor(value: string): boolean {
 
 /**
  * General-purpose interpreters can spawn simctl without making it the shell
- * executable. Treat a literal Simulator executor in their payload/argv as a
- * mutation-capable wrapper; command-text policy cannot safely inspect the
- * language semantics beneath this point.
+ * executable. Treat a literal or quoted-fragment-assembled Simulator executor
+ * in their payload/argv as a mutation-capable wrapper; command-text policy
+ * cannot safely inspect the language semantics beneath this point.
  */
 function containsInterpreterSimulatorPayload(tokens: string[]): boolean {
   const interpreter = executableName(tokens[0]);
   const payload = tokens.slice(1).join('\n');
   if (PROGRAMMABLE_INTERPRETER.test(interpreter)) {
-    return containsLiteralSimulatorExecutor(payload);
+    return containsAssembledSimulatorExecutor(payload);
   }
   if (interpreter === 'osascript') {
     // AppleScript can execute through `do shell script`, while JavaScript for
     // Automation can reach NSTask/NSProcessInfo directly. Once an osascript
     // payload contains a literal Simulator executor, command-text policy cannot
     // safely distinguish an inert reference from executable code.
-    return containsLiteralSimulatorExecutor(payload);
+    return containsAssembledSimulatorExecutor(payload);
   }
   return false;
 }
@@ -1072,26 +1072,88 @@ function consumesStdinAsProgram(tokens: string[]): boolean {
   return positional === undefined || positional === '-';
 }
 
-function containsInterpreterHeredocBypass(command: string): boolean {
+/**
+ * Quoted delimiters may contain punctuation (`<<'END.SH'`); unquoted
+ * delimiters are shell words. `<<-` permits leading tabs on the delimiter
+ * line, a plain `<<` does not.
+ */
+const HEREDOC_MARKER = /<<(-?)\s*(['"]?)([A-Za-z0-9_.-]+)\2/g;
+
+interface HeredocRegion {
+  /** Line index of the line that opens the heredoc. */
+  lineIndex: number;
+  /** Character offset of the `<<` marker within that line. */
+  markerIndex: number;
+  delimiter: string;
+  tabStripped: boolean;
+  /** First line of the body (one past the marker line). */
+  bodyStart: number;
+  /** One past the last body line (the delimiter line). */
+  bodyEnd: number;
+}
+
+/**
+ * Locate every heredoc region. Heredocs are matched FIFO: with several
+ * openings on one line (`cmd <<A <<B`) each opener receives the body lines
+ * between its predecessor's delimiter and its own.
+ */
+function parseHeredocRegions(command: string): HeredocRegion[] {
   const lines = command.split(/\r?\n/);
+  const regions: HeredocRegion[] = [];
+  const pending: Array<Pick<HeredocRegion, 'lineIndex' | 'markerIndex' | 'delimiter' | 'tabStripped'>> =
+    [];
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index] ?? '';
-    const marker = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/.exec(line);
-    if (!marker) continue;
+    for (const match of line.matchAll(HEREDOC_MARKER)) {
+      pending.push({
+        lineIndex: index,
+        markerIndex: match.index ?? 0,
+        delimiter: match[3] ?? '',
+        tabStripped: match[1] === '-',
+      });
+    }
+    const head = pending[0];
+    if (!head) continue;
+    const isDelimiterLine = head.tabStripped
+      ? line.replace(/^\t+/, '') === head.delimiter
+      : line === head.delimiter;
+    if (!isDelimiterLine) continue;
+    regions.push({
+      lineIndex: head.lineIndex,
+      markerIndex: head.markerIndex,
+      delimiter: head.delimiter,
+      tabStripped: head.tabStripped,
+      bodyStart: head.lineIndex + 1,
+      bodyEnd: index,
+    });
+    pending.shift();
+  }
+  for (const head of pending) {
+    regions.push({
+      lineIndex: head.lineIndex,
+      markerIndex: head.markerIndex,
+      delimiter: head.delimiter,
+      tabStripped: head.tabStripped,
+      bodyStart: head.lineIndex + 1,
+      bodyEnd: lines.length,
+    });
+  }
+  return regions;
+}
+
+function containsInterpreterHeredocBypass(command: string): boolean {
+  const lines = command.split(/\r?\n/);
+  for (const region of parseHeredocRegions(command)) {
+    const line = lines[region.lineIndex] ?? '';
     if (
-      !shellSegments(line.slice(0, marker.index)).some((segment) =>
+      !shellSegments(line.slice(0, region.markerIndex)).some((segment) =>
         consumesStdinAsProgram(tokenizeShellSegment(segment)),
       )
     ) {
       continue;
     }
-    const delimiter = marker[2]!;
-    const body: string[] = [];
-    for (index += 1; index < lines.length; index += 1) {
-      if ((lines[index] ?? '').replace(/^\t+/, '').trim() === delimiter) break;
-      body.push(lines[index] ?? '');
-    }
-    if (containsLiteralSimulatorExecutor(body.join('\n'))) return true;
+    const body = lines.slice(region.bodyStart, region.bodyEnd).join('\n');
+    if (containsAssembledSimulatorExecutor(body)) return true;
   }
   return false;
 }
@@ -1110,28 +1172,112 @@ function heredocConsumerExecutable(prefix: string): string | null {
 }
 
 /**
+ * Static pieces of the string literals in `value`, in source order. Pieces
+ * are split at f-string `{...}` expression boundaries and string literals
+ * inside expressions are collected as their own pieces, so an f-string
+ * assembles to the same pieces the runtime produces.
+ */
+function stringLiteralPieces(value: string): string[] {
+  const pieces: string[] = [];
+  let index = 0;
+  while (index < value.length) {
+    const quote = value[index];
+    if (quote !== '"' && quote !== "'") {
+      index += 1;
+      continue;
+    }
+    let cursor = index + 1;
+    let piece = '';
+    let braces = 0;
+    let closed = false;
+    while (cursor < value.length) {
+      const char = value[cursor]!;
+      if (char === '\\') {
+        if (braces === 0) piece += value[cursor + 1] ?? '';
+        cursor += 2;
+        continue;
+      }
+      if (braces > 0) {
+        if (char === '"' || char === "'") {
+          const innerQuote = char;
+          let innerCursor = cursor + 1;
+          let innerPiece = '';
+          while (innerCursor < value.length && value[innerCursor] !== innerQuote) {
+            if (value[innerCursor] === '\\') {
+              innerPiece += value[innerCursor + 1] ?? '';
+              innerCursor += 2;
+            } else {
+              innerPiece += value[innerCursor]!;
+              innerCursor += 1;
+            }
+          }
+          if (innerPiece) pieces.push(innerPiece);
+          cursor = innerCursor + 1;
+          continue;
+        }
+        if (char === '{') braces += 1;
+        else if (char === '}') braces -= 1;
+        cursor += 1;
+        continue;
+      }
+      if (char === quote) {
+        closed = true;
+        break;
+      }
+      if (char === '{') {
+        braces += 1;
+        if (piece) {
+          pieces.push(piece);
+          piece = '';
+        }
+        cursor += 1;
+        continue;
+      }
+      piece += char;
+      cursor += 1;
+    }
+    if (piece) pieces.push(piece);
+    if (!closed) break;
+    index = cursor + 1;
+  }
+  return pieces;
+}
+
+/**
+ * A literal scan alone cannot see an executor that is assembled at runtime,
+ * e.g. `"xcr" + "un" + " sim" + "ctl"`, an f-string `f"xcr{'un'} sim{'ctl'}"`,
+ * or an argv array `["xcr", "un", " sim", "ctl"]`. Join the string-literal
+ * pieces in source order and scan the assembled text so redacting a heredoc
+ * body cannot hide an assembled Simulator command from the shell-level checks.
+ */
+function containsAssembledSimulatorExecutor(value: string): boolean {
+  if (containsLiteralSimulatorExecutor(value)) return true;
+  const pieces = stringLiteralPieces(value);
+  if (pieces.length < 2) return false;
+  const joined = pieces.join('').replace(/[^A-Za-z0-9]/g, '');
+  return /(?:xcrun|simctl|iphonesimulator|simulatorapp)/i.test(joined);
+}
+
+/**
  * Heredoc bodies consumed by a non-shell program (a code interpreter such as
  * python/node, or a data tool such as cat/grep) are not shell program text.
  * Re-parsing those lines as shell segments trips the fail-closed
  * dynamic-expansion check on ordinary interpreter source (for example
  * `__import__("json")` contains `(`/`)` in command position), denying harmless
- * commands. Blank such bodies before the shell scans below; literal Simulator
- * executors inside bodies are still classified by containsShellConsumedLiteralBypass
- * over the original text, and bodies of shell-consumed heredocs (`bash <<EOF`)
- * stay intact because they are real shell code.
+ * commands. Blank such bodies before the shell scans below; bodies are still
+ * classified by containsShellConsumedLiteralBypass over the original text
+ * (literal and quoted-fragment assembles), and bodies of shell-consumed
+ * heredocs (`bash <<EOF`) stay intact because they are real shell code.
  */
 function redactNonShellHeredocBodies(command: string): string {
-  const lines = command.split('\n');
+  const lines = command.split(/\r?\n/);
   const redacted = [...lines];
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines[index] ?? '';
-    const marker = /<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1/.exec(line);
-    if (!marker) continue;
-    const consumer = heredocConsumerExecutable(line.slice(0, marker.index));
+  for (const region of parseHeredocRegions(command)) {
+    const consumer = heredocConsumerExecutable(
+      (lines[region.lineIndex] ?? '').slice(0, region.markerIndex),
+    );
     if (consumer === null || SHELL_EXECUTABLES.has(consumer)) continue;
-    const delimiter = marker[2]!;
-    for (index += 1; index < lines.length; index += 1) {
-      if ((lines[index] ?? '').replace(/^\t+/, '').trim() === delimiter) break;
+    for (let index = region.bodyStart; index < region.bodyEnd; index += 1) {
       redacted[index] = '';
     }
   }


### PR DESCRIPTION
Fixes #2378

## 这次改了什么

### 摘要

修复 macOS 桌面端 iOS Simulator shell guard 对普通解释器 heredoc 的误拦截：`__import__("json")`、`print(...)` 等解释器源码行被当作 shell 段触发 fail-closed 动态扩展检查（Issue #2378）。修复后非 shell 消费者的 heredoc 正文不再按 shell 逐行解析，只做执行器字面量/静态组装检测；同时按自动审查轮次补强了策略边界（引号/注释/跨行/here-string/伪标记词法、拼接/转义/译码/反转/base64/命令替换载荷、awk stdin 程序分类、数据 heredoc 写脚本执行路径、here-string/pipeline 拼装）。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2378
- 本 PR 包含：`apps/desktop/src/main/maker-host/shell-command-policy.ts` 的 heredoc 解析与载荷检测重构、对应回归测试
- 明确不包含：移动端、其他平台守卫、正常 shell 权限流程
- 用户可见变化：被误拦截的普通 Python/Node/Swift/Perl heredoc 命令恢复正常执行；真实 Simulator 绕过（字面量/拼接/译码/反转/base64/命令替换/写脚本执行）继续被拒绝
- 是否存在 breaking change：无

### UI 变化

不涉及（纯后端命令策略模块，无 UI 代码路径）。

## 怎么验证的

### 自动验证

```text
apps/desktop: npx vitest run src/main/maker-host/__tests__/shellCommandPolicy.test.ts src/main/maker-host/__tests__/iosSimulatorShellHook.test.ts
结果：301 用例全部通过（含 80+ 新增回归用例）

apps/desktop: npx vitest run src/main/maker-host
结果：1860 用例全部通过

apps/desktop: tsc --noEmit / eslint
结果：通过，无错误

本地 11 轮复现/回归脚本（Issue 原始复现 + 各轮审查绕过变体）：全部符合预期
```

### 手工验证

不涉及（命令行策略纯逻辑模块，本地测试覆盖；macOS 上策略开关按 `process.platform === 'darwin'` 生效）。

### 未执行的验证

无。CI 的 Linux unit tests (1/2) 唯一失败为无关 flaky（`customProviderDialogPresetLocale.test.tsx` UI 手势测试，本地 9/9 通过，已留言说明）。

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据（shell 命令策略收紧，见下）
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [ ] 存量插件兼容
- [ ] 原生层 / fingerprint / OTA
- [ ] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 macOS 桌面端 Codex shell 命令策略；只影响被判断为 Simulator 绕过或含执行器字面量的 heredoc/here-string 命令
- 回滚 / 降级方式：本 PR 仅改 `shell-command-policy.ts` 及对应测试，revert 单个 commit 即可回滚
- 保守方向说明：非 shell heredoc 正文含执行器字面量（如文档/示例文本中的 `xcrun simctl`）会被拒绝，与修复前行为一致，属于命令文本无法证明安全的既定立场（模块 docstring）；变量/环境/IO 来源的运行时构造无静态文本，不在命令文本策略可证明范围，由正常 shell 权限边界兜底

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（PR description 与审查回复）
- [x] 已确认测试结果
