### PR TITLE
fix(desktop): 修复审查生成文件误报与大文件卡顿

### DIFF
--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -265,6 +265,13 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(extractCommandOutputPathCandidates("cp 'source file.txt' output/")).toEqual([
       'output/source file.txt',
     ]);
+    expect(extractCommandOutputPathCandidates('cp source\\ file.txt output/')).toEqual([
+      'output/source file.txt',
+    ]);
+    expect(extractCommandOutputPathCandidates('cp -t /dest /src/a.txt')).toEqual(['/dest/a.txt']);
+    expect(extractCommandOutputPathCandidates('cp --target-directory=/dest /src/a.txt')).toEqual([
+      '/dest/a.txt',
+    ]);
     expect(
       extractCommandOutputPathCandidates(
         'Get-ChildItem inputs/source.txt | Copy-Item -Destination output/',
@@ -370,6 +377,11 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(
       extractCommandOutputPathCandidates(
         "Set-Content -Value (Get-Content -Path 'inputs/source.txt') -Path 'artifacts/result.txt'",
+      ),
+    ).toEqual(['artifacts/result.txt']);
+    expect(
+      extractCommandOutputPathCandidates(
+        `Set-Content -Value '${'x'.repeat(300)}' -Path 'artifacts/result.txt'`,
       ),
     ).toEqual(['artifacts/result.txt']);
     expect(

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -221,6 +221,12 @@ describe('extractCommandOutputPathCandidates', () => {
       extractCommandOutputPathCandidates("df.to_csv(index=False, path_or_buf='out/report.csv')"),
     ).toEqual(['out/report.csv']);
     expect(
+      extractCommandOutputPathCandidates("torch.save(model.state_dict(), 'out/model.pt')"),
+    ).toEqual(['out/model.pt']);
+    expect(extractCommandOutputPathCandidates("joblib.dump(model, 'out/model.pkl')")).toEqual([
+      'out/model.pkl',
+    ]);
+    expect(
       extractCommandOutputPathCandidates('workbook.to_excel(excel_writer="out/report.xlsx")'),
     ).toEqual(['out/report.xlsx']);
     expect(extractCommandOutputPathCandidates("plt.savefig('out/chart.png')")).toEqual([
@@ -235,6 +241,11 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(extractCommandOutputPathCandidates('tee /work/out/report.txt')).toEqual([
       '/work/out/report.txt',
     ]);
+    expect(
+      extractCommandOutputPathCandidates(
+        "wget --output-document='out/report.pdf' https://example.com/report.pdf",
+      ),
+    ).toEqual(['out/report.pdf']);
     expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual([
       'output/source.txt',
     ]);
@@ -244,6 +255,15 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(extractCommandOutputPathCandidates('cp inputs/a.txt inputs/b.txt output/')).toEqual([
       'output/a.txt',
       'output/b.txt',
+    ]);
+    expect(extractCommandOutputPathCandidates('cp -t output source.txt')).toEqual([
+      'output/source.txt',
+    ]);
+    expect(extractCommandOutputPathCandidates('mv --target-directory output source.txt')).toEqual([
+      'output/source.txt',
+    ]);
+    expect(extractCommandOutputPathCandidates("cp 'source file.txt' output/")).toEqual([
+      'output/source file.txt',
     ]);
     expect(
       extractCommandOutputPathCandidates(

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -222,6 +222,12 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(extractCommandOutputPathCandidates("plt.savefig(fname='out/chart.pdf', bbox_inches='tight')")).toEqual([
       'out/chart.pdf',
     ]);
+    expect(
+      extractCommandOutputPathCandidates("printf 'report' | tee 'out/report.md'"),
+    ).toEqual(['out/report.md']);
+    expect(extractCommandOutputPathCandidates('tee /work/out/report.txt')).toEqual([
+      '/work/out/report.txt',
+    ]);
     expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual(['output/source.txt']);
     expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual(['output\\source.txt']);
     expect(
@@ -236,6 +242,12 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(
       extractCommandOutputPathCandidates('Copy-Item -Destination output/ -Path inputs/source.txt'),
     ).toEqual(['output/source.txt']);
+    expect(
+      extractCommandOutputPathCandidates("Copy-Item 'inputs/source.txt' 'artifacts/report.txt'"),
+    ).toEqual(['artifacts/report.txt']);
+    expect(extractCommandOutputPathCandidates('Copy-Item inputs/source.txt output/')).toEqual([
+      'output/source.txt',
+    ]);
   });
 
   it('skips temp dirs, extension-less tokens, plain filenames and URLs', () => {

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -265,6 +265,10 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(extractCommandOutputPathCandidates('Copy-Item inputs/source.txt report.txt')).toEqual([
       'report.txt',
     ]);
+    expect(extractCommandOutputPathCandidates('cp source.txt report.txt')).toEqual(['report.txt']);
+    expect(extractCommandOutputPathCandidates('copy source.txt report.txt')).toEqual([
+      'report.txt',
+    ]);
   });
 
   it('skips temp dirs, extension-less tokens, plain filenames and URLs', () => {
@@ -325,6 +329,21 @@ describe('extractCommandOutputPathCandidates', () => {
         "Set-Content -Path 'artifacts/result.txt' -Value (Get-Content 'inputs/source.txt')",
       ),
     ).toEqual(['artifacts/result.txt']);
+    expect(
+      extractCommandOutputPathCandidates(
+        "Set-Content -Value (Get-Content 'inputs/source.txt') -Path 'artifacts/result.txt'",
+      ),
+    ).toEqual(['artifacts/result.txt']);
+    expect(
+      extractCommandOutputPathCandidates(
+        "Set-Content -Value (Get-Content -Path 'inputs/source.txt') -Path 'artifacts/result.txt'",
+      ),
+    ).toEqual(['artifacts/result.txt']);
+    expect(
+      extractCommandOutputPathCandidates(
+        "Set-Content -Value (Get-Content -Path 'inputs/source.txt')",
+      ),
+    ).toEqual([]);
     expect(
       extractCommandOutputPathCandidates(
         "Set-Content $output ([System.IO.File]::ReadAllText('inputs/source.txt'))",

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -218,6 +218,10 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(
       extractCommandOutputPathCandidates("workbook.to_excel(excel_writer=\"out/report.xlsx\")"),
     ).toEqual(['out/report.xlsx']);
+    expect(extractCommandOutputPathCandidates("plt.savefig('out/chart.png')")).toEqual(['out/chart.png']);
+    expect(extractCommandOutputPathCandidates("plt.savefig(fname='out/chart.pdf', bbox_inches='tight')")).toEqual([
+      'out/chart.pdf',
+    ]);
     expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual(['output/source.txt']);
     expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual(['output\\source.txt']);
     expect(
@@ -229,6 +233,9 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(
       extractCommandOutputPathCandidates('Get-ChildItem inputs/ | Copy-Item -Destination output/'),
     ).toEqual(['output/']);
+    expect(
+      extractCommandOutputPathCandidates('Copy-Item -Destination output/ -Path inputs/source.txt'),
+    ).toEqual(['output/source.txt']);
   });
 
   it('skips temp dirs, extension-less tokens, plain filenames and URLs', () => {

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -212,6 +212,12 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(
       extractCommandOutputPathCandidates("Path('out/data.bin').write_bytes(payload)"),
     ).toEqual(['out/data.bin']);
+    expect(
+      extractCommandOutputPathCandidates("df.to_csv(path_or_buf='out/report.csv', index=False)"),
+    ).toEqual(['out/report.csv']);
+    expect(
+      extractCommandOutputPathCandidates("workbook.to_excel(excel_writer=\"out/report.xlsx\")"),
+    ).toEqual(['out/report.xlsx']);
     expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual(['output/source.txt']);
     expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual(['output\\source.txt']);
     expect(

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { collectGeneratedFiles, extractCommandPathCandidates } from '../lib/generatedFiles';
+import { collectGeneratedFiles, extractCommandOutputPathCandidates } from '../lib/generatedFiles';
 
 const WORKDIR = '/work';
 
@@ -118,21 +118,23 @@ describe('collectGeneratedFiles', () => {
       ],
       'C:\\work',
     );
-    expect(files.map((f) => f.path)).toEqual(['C:\\work\\report.docx', 'C:\\work\\输出\\表格.xlsx']);
+    expect(files.map((f) => f.path)).toEqual([
+      'C:\\work\\report.docx',
+      'C:\\work\\输出\\表格.xlsx',
+    ]);
     expect(files[0].source).toBe('tool');
   });
 
   it('collapses doubled backslashes so escaped wrapper commands do not duplicate chips', () => {
-    // 实测场景(pr-watch session):powershell 包一层 node -e,落库命令文本里的
-    // 路径带转义残留(`C:\\Users\\...`);同轮另一条命令用正斜杠形态。fs 层它们
-    // 是同一文件(Windows 归并重复分隔符),不折叠会出两个同名 chip。
+    // 包装脚本里的写出路径可能带转义残留(`C:\\Users\\...`);同轮另一条命令用
+    // 正斜杠形态。fs 层它们是同一文件(Windows 归并重复分隔符),不折叠会出两个同名 chip。
     const files = collectGeneratedFiles(
       [
         toolUse('Bash', {
-          command: "powershell -Command '$p = 'C:\\\\Users\\\\U\\\\pr-watch\\\\registry.json'; Get-Content $p'",
+          command: 'node -e "save(\'C:\\\\Users\\\\U\\\\pr-watch\\\\registry.json\')"',
         }),
         toolUse('Bash', {
-          command: "node -e \"const p='C:/Users/U/pr-watch/registry.json'; console.log(p);\"",
+          command: 'node -e "save(\'C:/Users/U/pr-watch/registry.json\')"',
         }),
       ],
       'C:\\Users\\U\\pr-watch',
@@ -188,33 +190,82 @@ describe('collectGeneratedFiles', () => {
   });
 });
 
-describe('extractCommandPathCandidates', () => {
-  it('extracts quoted paths (CJK, spaces) and bare absolute paths', () => {
+describe('extractCommandOutputPathCandidates', () => {
+  it('extracts paths from explicit save, redirection and copy destinations', () => {
     expect(
-      extractCommandPathCandidates("wb.save(r'C:\\Users\\A\\My Docs\\报表 v2.xlsx')"),
+      extractCommandOutputPathCandidates("wb.save(r'C:\\Users\\A\\My Docs\\报表 v2.xlsx')"),
     ).toEqual(['C:\\Users\\A\\My Docs\\报表 v2.xlsx']);
-    expect(extractCommandPathCandidates('node gen.js > C:/out/result.json')).toContain(
+    expect(extractCommandOutputPathCandidates('node gen.js > C:/out/result.json')).toContain(
       'C:/out/result.json',
     );
-    expect(extractCommandPathCandidates('cp a "/home/u/输出/report.pdf"')).toContain(
+    expect(extractCommandOutputPathCandidates('cp a "/home/u/输出/report.pdf"')).toContain(
       '/home/u/输出/report.pdf',
     );
+    expect(
+      extractCommandOutputPathCandidates(
+        'Get-Content "inputs/source.md" && copy "inputs/source.md" \'artifacts/report.md\'',
+      ),
+    ).toEqual(['artifacts/report.md']);
   });
 
   it('skips temp dirs, extension-less tokens, plain filenames and URLs', () => {
-    expect(extractCommandPathCandidates("save('/tmp/x.xlsx')")).toEqual([]);
-    expect(extractCommandPathCandidates("save('C:\\Users\\A\\AppData\\Local\\Temp\\x.xlsx')")).toEqual([]);
-    expect(extractCommandPathCandidates('cat /dev/null && echo done')).toEqual([]);
+    expect(extractCommandOutputPathCandidates("save('/tmp/x.xlsx')")).toEqual([]);
+    expect(
+      extractCommandOutputPathCandidates("save('C:\\Users\\A\\AppData\\Local\\Temp\\x.xlsx')"),
+    ).toEqual([]);
+    expect(extractCommandOutputPathCandidates('cat /dev/null && echo done')).toEqual([]);
     // 纯文件名不收(随机带点 token 误报率太高),相对路径需含分隔符。
-    expect(extractCommandPathCandidates("save('输出.xlsx')")).toEqual([]);
-    expect(extractCommandPathCandidates("save('out/输出.xlsx')")).toEqual(['out/输出.xlsx']);
-    expect(extractCommandPathCandidates('curl https://x.com/a.js')).toEqual([]);
-    expect(extractCommandPathCandidates('')).toEqual([]);
+    expect(extractCommandOutputPathCandidates("save('输出.xlsx')")).toEqual([]);
+    expect(extractCommandOutputPathCandidates("save('out/输出.xlsx')")).toEqual(['out/输出.xlsx']);
+    expect(extractCommandOutputPathCandidates('curl https://x.com/a.js')).toEqual([]);
+    expect(extractCommandOutputPathCandidates('')).toEqual([]);
   });
 
-  it('dedupes the same path appearing quoted and bare', () => {
+  it('dedupes the same output path', () => {
     expect(
-      extractCommandPathCandidates('python gen.py C:/out/a.csv && stat "C:/out/a.csv"'),
+      extractCommandOutputPathCandidates(
+        'python gen.py > C:/out/a.csv && node gen.js --output "C:/out/a.csv"',
+      ),
     ).toEqual(['C:/out/a.csv']);
+  });
+
+  it('does not treat paths in PowerShell and shell read commands as outputs', () => {
+    const powershellRead =
+      'powershell.exe -Command \'$p="docs/design-rules/DESIGN.md"; ' +
+      "$l=[System.IO.File]::ReadAllLines($p); $l[0..20]'";
+    expect(extractCommandOutputPathCandidates(powershellRead)).toEqual([]);
+    expect(
+      extractCommandOutputPathCandidates(
+        "Get-Content 'docs/dev-rules/repo-map.md'; rg foo 'apps/desktop/src/index.tsx'",
+      ),
+    ).toEqual([]);
+  });
+
+  it('keeps only the explicit output when a command also names input files', () => {
+    expect(
+      extractCommandOutputPathCandidates(
+        "python convert.py 'inputs/source.md' --output 'artifacts/report.pdf'",
+      ),
+    ).toEqual(['artifacts/report.pdf']);
+    expect(
+      extractCommandOutputPathCandidates(
+        "open('inputs/source.txt', 'r'); open('artifacts/result.txt', 'wb')",
+      ),
+    ).toEqual(['artifacts/result.txt']);
+    expect(
+      extractCommandOutputPathCandidates(
+        "Set-Content -Path 'artifacts/result.txt' -Value (Get-Content 'inputs/source.txt')",
+      ),
+    ).toEqual(['artifacts/result.txt']);
+    expect(
+      extractCommandOutputPathCandidates(
+        "Set-Content $output ([System.IO.File]::ReadAllText('inputs/source.txt'))",
+      ),
+    ).toEqual([]);
+    expect(
+      extractCommandOutputPathCandidates(
+        "node convert.js 'inputs/source.md' --output='artifacts/result.html'",
+      ),
+    ).toEqual(['artifacts/result.html']);
   });
 });

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -212,10 +212,16 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(
       extractCommandOutputPathCandidates("Path('out/data.bin').write_bytes(payload)"),
     ).toEqual(['out/data.bin']);
-    expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual(['output/']);
-    expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual(['output\\']);
+    expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual(['output/source.txt']);
+    expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual(['output\\source.txt']);
     expect(
       extractCommandOutputPathCandidates('cp inputs/a.txt inputs/b.txt output/'),
+    ).toEqual(['output/a.txt', 'output/b.txt']);
+    expect(
+      extractCommandOutputPathCandidates('Get-ChildItem inputs/source.txt | Copy-Item -Destination output/'),
+    ).toEqual(['output/source.txt']);
+    expect(
+      extractCommandOutputPathCandidates('Get-ChildItem inputs/ | Copy-Item -Destination output/'),
     ).toEqual(['output/']);
   });
 

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -206,6 +206,17 @@ describe('extractCommandOutputPathCandidates', () => {
         'Get-Content "inputs/source.md" && copy "inputs/source.md" \'artifacts/report.md\'',
       ),
     ).toEqual(['artifacts/report.md']);
+    expect(
+      extractCommandOutputPathCandidates("python -c \"from pathlib import Path; Path('out/report.md').write_text('ok')\""),
+    ).toEqual(['out/report.md']);
+    expect(
+      extractCommandOutputPathCandidates("Path('out/data.bin').write_bytes(payload)"),
+    ).toEqual(['out/data.bin']);
+    expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual(['output/']);
+    expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual(['output\\']);
+    expect(
+      extractCommandOutputPathCandidates('cp inputs/a.txt inputs/b.txt output/'),
+    ).toEqual(['output/']);
   });
 
   it('skips temp dirs, extension-less tokens, plain filenames and URLs', () => {

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -269,6 +269,19 @@ describe('extractCommandOutputPathCandidates', () => {
     expect(extractCommandOutputPathCandidates('copy source.txt report.txt')).toEqual([
       'report.txt',
     ]);
+    expect(
+      extractCommandOutputPathCandidates("mv 'tmp/report.pdf' 'artifacts/report.pdf'"),
+    ).toEqual(['artifacts/report.pdf']);
+    expect(extractCommandOutputPathCandidates("mv 'tmp/report.pdf' 'artifacts/'")).toEqual([
+      'artifacts/report.pdf',
+    ]);
+    expect(extractCommandOutputPathCandidates('mv source.txt report.txt')).toEqual(['report.txt']);
+    expect(extractCommandOutputPathCandidates('move source.txt report.txt')).toEqual([
+      'report.txt',
+    ]);
+    expect(
+      extractCommandOutputPathCandidates('Move-Item -Destination output/ -Path inputs/source.txt'),
+    ).toEqual(['output/source.txt']);
   });
 
   it('skips temp dirs, extension-less tokens, plain filenames and URLs', () => {

--- a/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
+++ b/apps/desktop/src/renderer/__tests__/generatedFiles.test.ts
@@ -207,34 +207,48 @@ describe('extractCommandOutputPathCandidates', () => {
       ),
     ).toEqual(['artifacts/report.md']);
     expect(
-      extractCommandOutputPathCandidates("python -c \"from pathlib import Path; Path('out/report.md').write_text('ok')\""),
+      extractCommandOutputPathCandidates(
+        "python -c \"from pathlib import Path; Path('out/report.md').write_text('ok')\"",
+      ),
     ).toEqual(['out/report.md']);
-    expect(
-      extractCommandOutputPathCandidates("Path('out/data.bin').write_bytes(payload)"),
-    ).toEqual(['out/data.bin']);
+    expect(extractCommandOutputPathCandidates("Path('out/data.bin').write_bytes(payload)")).toEqual(
+      ['out/data.bin'],
+    );
     expect(
       extractCommandOutputPathCandidates("df.to_csv(path_or_buf='out/report.csv', index=False)"),
     ).toEqual(['out/report.csv']);
     expect(
-      extractCommandOutputPathCandidates("workbook.to_excel(excel_writer=\"out/report.xlsx\")"),
+      extractCommandOutputPathCandidates("df.to_csv(index=False, path_or_buf='out/report.csv')"),
+    ).toEqual(['out/report.csv']);
+    expect(
+      extractCommandOutputPathCandidates('workbook.to_excel(excel_writer="out/report.xlsx")'),
     ).toEqual(['out/report.xlsx']);
-    expect(extractCommandOutputPathCandidates("plt.savefig('out/chart.png')")).toEqual(['out/chart.png']);
-    expect(extractCommandOutputPathCandidates("plt.savefig(fname='out/chart.pdf', bbox_inches='tight')")).toEqual([
-      'out/chart.pdf',
+    expect(extractCommandOutputPathCandidates("plt.savefig('out/chart.png')")).toEqual([
+      'out/chart.png',
     ]);
     expect(
-      extractCommandOutputPathCandidates("printf 'report' | tee 'out/report.md'"),
-    ).toEqual(['out/report.md']);
+      extractCommandOutputPathCandidates("plt.savefig(fname='out/chart.pdf', bbox_inches='tight')"),
+    ).toEqual(['out/chart.pdf']);
+    expect(extractCommandOutputPathCandidates("printf 'report' | tee 'out/report.md'")).toEqual([
+      'out/report.md',
+    ]);
     expect(extractCommandOutputPathCandidates('tee /work/out/report.txt')).toEqual([
       '/work/out/report.txt',
     ]);
-    expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual(['output/source.txt']);
-    expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual(['output\\source.txt']);
+    expect(extractCommandOutputPathCandidates('cp source.txt output/')).toEqual([
+      'output/source.txt',
+    ]);
+    expect(extractCommandOutputPathCandidates('copy source.txt output\\')).toEqual([
+      'output\\source.txt',
+    ]);
+    expect(extractCommandOutputPathCandidates('cp inputs/a.txt inputs/b.txt output/')).toEqual([
+      'output/a.txt',
+      'output/b.txt',
+    ]);
     expect(
-      extractCommandOutputPathCandidates('cp inputs/a.txt inputs/b.txt output/'),
-    ).toEqual(['output/a.txt', 'output/b.txt']);
-    expect(
-      extractCommandOutputPathCandidates('Get-ChildItem inputs/source.txt | Copy-Item -Destination output/'),
+      extractCommandOutputPathCandidates(
+        'Get-ChildItem inputs/source.txt | Copy-Item -Destination output/',
+      ),
     ).toEqual(['output/source.txt']);
     expect(
       extractCommandOutputPathCandidates('Get-ChildItem inputs/ | Copy-Item -Destination output/'),
@@ -247,6 +261,9 @@ describe('extractCommandOutputPathCandidates', () => {
     ).toEqual(['artifacts/report.txt']);
     expect(extractCommandOutputPathCandidates('Copy-Item inputs/source.txt output/')).toEqual([
       'output/source.txt',
+    ]);
+    expect(extractCommandOutputPathCandidates('Copy-Item inputs/source.txt report.txt')).toEqual([
+      'report.txt',
     ]);
   });
 
@@ -294,6 +311,15 @@ describe('extractCommandOutputPathCandidates', () => {
         "open('inputs/source.txt', 'r'); open('artifacts/result.txt', 'wb')",
       ),
     ).toEqual(['artifacts/result.txt']);
+    expect(extractCommandOutputPathCandidates("open('artifacts/result.txt', mode='w')")).toEqual([
+      'artifacts/result.txt',
+    ]);
+    expect(
+      extractCommandOutputPathCandidates(
+        "open('artifacts/result.bin', encoding='utf8', mode='wb')",
+      ),
+    ).toEqual(['artifacts/result.bin']);
+    expect(extractCommandOutputPathCandidates("open('inputs/source.txt', mode='r')")).toEqual([]);
     expect(
       extractCommandOutputPathCandidates(
         "Set-Content -Path 'artifacts/result.txt' -Value (Get-Content 'inputs/source.txt')",

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/__tests__/PlainUnifiedDiff.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/__tests__/PlainUnifiedDiff.test.ts
@@ -16,6 +16,7 @@ import type { FileDiff, Hunk } from '@/lib/gitReview.types';
 import { buildSplitRows, buildUnifiedRows, shouldVirtualizeDiffRows, shouldVirtualizeFileList } from '../diffRows';
 import {
   collectHighlightLines,
+  HIGHLIGHT_MAX_DIFF_LINES,
   HIGHLIGHT_MAX_LINE_LENGTH,
   highlightLineKey,
   LruCache,
@@ -523,14 +524,19 @@ describe('PlainUnifiedDiff split rows', () => {
 
 describe('PlainUnifiedDiff performance helpers', () => {
   it('uses explicit thresholds for diff and file-list virtualization', () => {
-    expect(shouldVirtualizeDiffRows(500)).toBe(false);
-    expect(shouldVirtualizeDiffRows(501)).toBe(true);
+    expect(shouldVirtualizeDiffRows(200)).toBe(false);
+    expect(shouldVirtualizeDiffRows(201)).toBe(true);
     expect(shouldVirtualizeFileList(100)).toBe(false);
     expect(shouldVirtualizeFileList(101)).toBe(true);
   });
 
-  it('marks the virtualized diff branch for large diffs', () => {
-    const manyLines = Array.from({ length: 510 }, (_, index) =>
+  it('virtualizes files shaped like the two-file whole-file rewrite regression', () => {
+    expect(shouldVirtualizeDiffRows(487)).toBe(true);
+    expect(shouldVirtualizeDiffRows(478)).toBe(true);
+  });
+
+  it('marks the virtualized diff branch for a file from the two-file regression', () => {
+    const manyLines = Array.from({ length: 487 }, (_, index) =>
       line(index, 'context', `line ${index}`, index + 1, index + 1),
     );
     const diff: FileDiff = {
@@ -677,6 +683,19 @@ describe('PlainUnifiedDiff highlighting helpers', () => {
       { key: '0:2', content: 'const b = 2;' },
     ]);
     expect(shouldSkipHighlightDiff(rows)).toBe(false);
+  });
+
+  it('skips per-line worker highlighting for medium whole-file rewrites', () => {
+    const manyLines = Array.from({ length: HIGHLIGHT_MAX_DIFF_LINES + 1 }, (_, index) =>
+      line(index, 'add', `const value${index} = true;`, null, index + 1),
+    );
+    const rows = buildUnifiedRows([{
+      ...hunk(0, 1, manyLines.length),
+      lines: manyLines,
+      selectableLines: manyLines.map((_, index) => index),
+    }]);
+
+    expect(shouldSkipHighlightDiff(rows)).toBe(true);
   });
 
   it('keeps multi-hunk highlight keys from overwriting same local line indices', () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/diffRows.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/diffRows.ts
@@ -37,7 +37,9 @@ export interface HunkActionAnchor {
   hunk: Hunk;
 }
 
-export const DIFF_ROW_VIRTUAL_THRESHOLD = 500;
+// Keep medium-sized files off the eager DOM path. Two files just below the old
+// 500-row cutoff could otherwise mount roughly a thousand diff rows at once.
+export const DIFF_ROW_VIRTUAL_THRESHOLD = 200;
 export const FILE_LIST_VIRTUAL_THRESHOLD = 100;
 
 function oldEndLine(hunk: Hunk): number {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/highlight.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/highlight.ts
@@ -2,7 +2,9 @@ import type { DiffRenderRow } from './diffRows';
 
 export const HIGHLIGHT_MAX_LINE_LENGTH = 1000;
 export const HIGHLIGHT_MAX_DIFF_CHARS = 200_000;
-export const HIGHLIGHT_MAX_DIFF_LINES = 1200;
+// The highlighter sends one worker request per line. Virtualized medium diffs
+// stay responsive by rendering plain text instead of queueing hundreds at once.
+export const HIGHLIGHT_MAX_DIFF_LINES = 400;
 
 type HighlightRequest = { id: string; code: string; lang: string };
 type HighlightResponse =

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/inlineDiff.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/DiffViewer/inlineDiff.ts
@@ -22,9 +22,9 @@ interface InlineDiffOptions {
 }
 
 export const INLINE_DIFF_MIN_COMMON_RATIO = 0.3;
-// Guard the pre-virtualization hot path: 400 paired changed lines at 500 chars
-// each is already enough useful signal, while larger diffs can block rendering.
-export const INLINE_DIFF_MAX_PAIR_COUNT = 400;
+// Inline word diffing is synchronous. Keep it away from medium whole-file
+// rewrites even when an existing task has the legacy word-diff default enabled.
+export const INLINE_DIFF_MAX_PAIR_COUNT = 150;
 export const INLINE_DIFF_MAX_TOTAL_CHARS = 200_000;
 
 const inlineDiffCache = new LruCache<string, InlineDiffPair | null>(2000);

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/ReviewTabBody.tsx
@@ -564,7 +564,7 @@ function TurnChangeSetReviewBody({ state, ctx, setSource, setSelectedCommitOid }
           onViewModeChange={(diffViewMode) => ctx.patchState({ diffViewMode })}
           onRichMarkdownPreviewChange={(richMarkdownPreview) => ctx.patchState({ richMarkdownPreview })}
           wordWrap={state.wordWrap ?? false}
-          wordDiff={state.wordDiff ?? true}
+          wordDiff={state.wordDiff ?? false}
           fileTreeVisible={state.fileTreeVisible ?? false}
           jumpRequest={jumpRequest}
           loadImagePreview={unavailablePreview}
@@ -612,7 +612,7 @@ function GitReviewTabBody({ state, ctx, source, setSource, selectedCommitOid, se
   const diffViewMode: DiffViewMode = state.diffViewMode ?? 'unified';
   const fileTreeVisible = state.fileTreeVisible ?? false;
   const wordWrap = state.wordWrap ?? false;
-  const wordDiff = state.wordDiff ?? true;
+  const wordDiff = state.wordDiff ?? false;
   const richMarkdownPreview = state.richMarkdownPreview ?? true;
   const collapsedSet = useMemo(() => new Set(state.collapsedPaths ?? []), [state.collapsedPaths]);
   const rawUnstaged = data?.diffs.unstaged ?? [];

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/plugin.test.ts
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/__tests__/plugin.test.ts
@@ -44,7 +44,7 @@ describe('review plugin', () => {
     expect(a.diffViewMode).toBe('unified');
     expect(a.fileTreeVisible).toBe(false);
     expect(a.wordWrap).toBe(false);
-    expect(a.wordDiff).toBe(true);
+    expect(a.wordDiff).toBe(false);
     expect(a.hideWhitespace).toBe(false);
     expect(a.richMarkdownPreview).toBe(true);
     expect(a.branchBaseRef).toBeNull();
@@ -101,12 +101,12 @@ describe('review plugin', () => {
     expect((p.hydrateState!({}) as { wordWrap: boolean }).wordWrap).toBe(false);
   });
 
-  it('hydrateState defaults word diff to enabled for invalid values', () => {
+  it('hydrateState defaults word diff to disabled for invalid values', () => {
     const p = registry.getTabKind('review')!;
     expect((p.hydrateState!({ wordDiff: false }) as { wordDiff: boolean }).wordDiff).toBe(false);
     expect((p.hydrateState!({ wordDiff: true }) as { wordDiff: boolean }).wordDiff).toBe(true);
-    expect((p.hydrateState!({ wordDiff: 'no' }) as { wordDiff: boolean }).wordDiff).toBe(true);
-    expect((p.hydrateState!({}) as { wordDiff: boolean }).wordDiff).toBe(true);
+    expect((p.hydrateState!({ wordDiff: 'no' }) as { wordDiff: boolean }).wordDiff).toBe(false);
+    expect((p.hydrateState!({}) as { wordDiff: boolean }).wordDiff).toBe(false);
   });
 
   it('hydrateState falls back to visible whitespace changes for invalid values', () => {

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/index.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/index.tsx
@@ -43,7 +43,7 @@ export interface ReviewState {
   fileTreeVisible: boolean;
   /** diff 行是否自动换行。默认关闭,保留横向滚动。 */
   wordWrap: boolean;
-  /** 是否显示行内文字差异强调。对齐 Codex,默认开启。 */
+  /** 是否显示行内文字差异强调。默认关闭,避免大文件审查时增加渲染开销。 */
   wordDiff: boolean;
   /** 是否用忽略空白模式读取 diff。默认关闭,避免影响 patch 类操作。 */
   hideWhitespace: boolean;

--- a/apps/desktop/src/renderer/features/right-sidebar/plugins/review/index.tsx
+++ b/apps/desktop/src/renderer/features/right-sidebar/plugins/review/index.tsx
@@ -59,7 +59,7 @@ const DEFAULT_STATE: ReviewState = {
   diffViewMode: 'unified',
   fileTreeVisible: false,
   wordWrap: false,
-  wordDiff: true,
+  wordDiff: false,
   hideWhitespace: false,
   richMarkdownPreview: true,
   branchBaseRef: null,

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -111,8 +111,7 @@ interface CommandPathToken {
   end: number;
 }
 
-const RELATIVE_PATH_TOKEN_RE =
-  /(?:^|[\s=(,>])([^\s'"<>|?*]+[\\/])(?=$|[\s'"<>|])/g;
+const RELATIVE_PATH_TOKEN_RE = /(?:^|[\s=(,>])([^\s'"<>|?*]+[\\/])(?=$|[\s'"<>|])/g;
 
 /** 提取路径 token 及其在命令中的位置;写出语义需要靠相邻文本判断。 */
 function extractCommandPathTokens(command: string): CommandPathToken[] {
@@ -155,11 +154,16 @@ function extractCommandPathTokens(command: string): CommandPathToken[] {
       push(raw, start, start + raw.length);
     }
   }
+  for (const token of extractCopyItemPlainFilenameDestinations(command)) {
+    out.push(token);
+  }
   return out.sort((a, b) => a.start - b.start || a.end - b.end);
 }
 
 const WRITE_CALL_PREFIX_RE =
   /(?:\.|\b)(?:save|savefig|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*(?:(?:path_or_buf|excel_writer|path|filename|fname|fp|file)\s*=\s*)?(?:[rubf]{0,2})?['"]$/i;
+const WRITE_CALL_LATER_KEYWORD_PREFIX_RE =
+  /(?:\.|\b)(?:save|savefig|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*[^();\r\n]+,\s*(?:path_or_buf|excel_writer|path|filename|fname|fp|file)\s*=\s*(?:[rubf]{0,2})?['"]$/i;
 const POWERSHELL_CMDLET_RE = /\b[A-Za-z][A-Za-z0-9]*-[A-Za-z][A-Za-z0-9-]*\b/g;
 const POWERSHELL_WRITE_COMMANDS = new Set([
   'out-file',
@@ -173,6 +177,52 @@ const OUTPUT_OPTION_PREFIX_RE = /(?:^|\s)(?:-o|--output(?:-file)?|--outfile)(?:\
 const REDIRECT_PREFIX_RE = /(?:^|[^>])>{1,2}\s*['"]?$/;
 const SAVE_COMMAND_PREFIX_RE = /(?:^|[;&|]\s*|\s)save\s+['"]?$/i;
 const TEE_COMMAND_PREFIX_RE = /(?:^|[|;&]\s*)tee(?:\.exe)?\b[^|;&\r\n]*['"]?$/i;
+
+function extractCopyItemPlainFilenameDestinations(command: string): CommandPathToken[] {
+  const out: CommandPathToken[] = [];
+  const commandRe = /\bCopy-Item\b([^|;\r\n]*?)(?=\|{1,2}|;|\r?$|\n)/gim;
+  for (const commandMatch of command.matchAll(commandRe)) {
+    const argsText = commandMatch[1] ?? '';
+    const argsStart = (commandMatch.index ?? 0) + commandMatch[0].indexOf(argsText);
+    const args = [...argsText.matchAll(/'([^'\r\n]*)'|"([^"\r\n]*)"|([^\s]+)/g)].map((match) => {
+      const value = match[1] ?? match[2] ?? match[3] ?? '';
+      const offset = match[1] !== undefined || match[2] !== undefined ? 1 : 0;
+      const start = argsStart + (match.index ?? 0) + offset;
+      return { value, start, end: start + value.length };
+    });
+    const isPlainFilename = (value: string): boolean =>
+      EXT_RE.test(value) && !/[\\/<>|?*]/.test(value);
+    const explicitDestinationIndex = args.findIndex((arg) =>
+      /^-(?:Destination|LiteralDestination|Target)$/i.test(arg.value),
+    );
+    if (explicitDestinationIndex >= 0) {
+      const destination = args[explicitDestinationIndex + 1];
+      if (destination && isPlainFilename(destination.value)) {
+        out.push({ path: destination.value, start: destination.start, end: destination.end });
+      }
+      continue;
+    }
+
+    const positional: typeof args = [];
+    let namedSource = false;
+    for (let index = 0; index < args.length; index += 1) {
+      const arg = args[index];
+      if (!arg.value.startsWith('-')) {
+        positional.push(arg);
+        continue;
+      }
+      if (/^-(?:Path|LiteralPath)$/i.test(arg.value)) namedSource = true;
+      if (!/^-(?:Force|Recurse|PassThru|Container|Confirm|WhatIf)$/i.test(arg.value)) {
+        index += 1;
+      }
+    }
+    const destination = namedSource ? positional[0] : positional[1];
+    if (destination && isPlainFilename(destination.value)) {
+      out.push({ path: destination.value, start: destination.start, end: destination.end });
+    }
+  }
+  return out;
+}
 
 function isPowerShellOutputPosition(before: string): boolean {
   let lastCmdlet: RegExpMatchArray | null = null;
@@ -193,6 +243,7 @@ function isExplicitOutputPath(
   const after = command.slice(token.end, token.end + 80);
   if (
     WRITE_CALL_PREFIX_RE.test(before) ||
+    WRITE_CALL_LATER_KEYWORD_PREFIX_RE.test(before) ||
     /^\s*['"]?\s*\)\s*\.\s*write_(?:text|bytes)\s*\(/i.test(after) ||
     isPowerShellOutputPosition(before) ||
     OUTPUT_OPTION_PREFIX_RE.test(before) ||
@@ -205,7 +256,8 @@ function isExplicitOutputPath(
   // Python / Ruby 等的 open(path, 'w'|'a'|'x'|'wb'...)。
   if (
     /\bopen\s*\(\s*(?:[rubf]{0,2})?['"]$/i.test(before) &&
-    /^['"]\s*,\s*['"][wax][bt+]*['"]/i.test(after)
+    (/^['"]\s*,\s*['"][wax][bt+]*['"]/i.test(after) ||
+      /^['"]\s*,\s*[^();\r\n]*\bmode\s*=\s*['"][wax][bt+]*['"]/i.test(after))
   ) {
     return true;
   }
@@ -278,16 +330,25 @@ function copyDirectoryOutputs(
     .map((token) => token.path);
   const beforeDestination = command.slice(segmentStart, destination.start);
   const afterDestination = command.slice(destination.end, segmentEnd);
-  for (const match of beforeDestination.matchAll(/(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g)) {
+  for (const match of beforeDestination.matchAll(
+    /(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g,
+  )) {
     if (!sourcePaths.includes(match[1])) sourcePaths.push(match[1]);
   }
-  for (const match of afterDestination.matchAll(/(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g)) {
+  for (const match of afterDestination.matchAll(
+    /(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g,
+  )) {
     if (!sourcePaths.includes(match[1])) sourcePaths.push(match[1]);
   }
-  const outputs = sourcePaths.map((source) => {
-    const sourceName = source.replace(/[\\/]$/, '').split(/[\\/]/).at(-1);
-    return sourceName ? `${destination.path}${sourceName}` : null;
-  }).filter((path): path is string => Boolean(path));
+  const outputs = sourcePaths
+    .map((source) => {
+      const sourceName = source
+        .replace(/[\\/]$/, '')
+        .split(/[\\/]/)
+        .at(-1);
+      return sourceName ? `${destination.path}${sourceName}` : null;
+    })
+    .filter((path): path is string => Boolean(path));
   return outputs.length > 0 ? outputs : [destination.path];
 }
 

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -6,15 +6,15 @@
  * `describeToolUse` 归一化,不自己维护工具名表:
  *   - kind==='file' 且 action==='create'  → Write / write(claude / pi 新建文件)
  *   - kind==='fileChange' 的 changes 里 action==='add' → codex file_change 新增文件
- *   - kind==='command' → 从命令文本启发式提取产物路径候选(source:'command')。
+ *   - kind==='command' → 从命令文本里带明确写出语义的位置提取产物路径候选(source:'command')。
  *     Excel / Word / PDF 等二进制产物只能靠脚本(Bash/exec 跑 python、node)生成,
  *     没有文件工具记录;不补这个盲区,卡在「帮我生成个表格」主场景直接失灵。
  * 「修改已有文件」(edit / update)与读取不算产出(产品口径:只收新建,见
  * AskUserQuestion 决策)。move / delete 同样排除。
  *
  * 误报防线(source:'command' 特有,由渲染方 GeneratedFilesCard 执行):
- *   命令文本里出现路径 ≠ 命令创建了它(可能只是读输入)。所以 command 候选除
- *   存在性外,还必须满足「文件 mtime 落在本轮时间窗内」才出 chip;窗口不可得
+ *   命令文本里出现路径 ≠ 命令创建了它(可能只是读输入)。所以只认重定向、save / write
+ *   API、输出参数等明确写出位置;候选除存在性外,还必须满足「文件 mtime 落在本轮时间窗内」才出 chip;窗口不可得
  *   (消息无 createdAt / 远程会话无法 stat)时宁可不出。tool 来源保持原判定。
  */
 
@@ -72,9 +72,7 @@ function dedupeKeyForPath(abs: string): string {
 function canonicalizeWindowsShape(abs: string): string {
   // 连续分隔符折叠进画布路径本身(不只 dedupe key):stat 虽能容忍 `C:\\x`,但
   // Explorer `/select` 与 chip 展示不该带转义残留。盘符形态不存在 UNC 头,可整段折叠。
-  return /^[a-zA-Z]:[\\/]/.test(abs)
-    ? abs.replace(/\//g, '\\').replace(/\\{2,}/g, '\\')
-    : abs;
+  return /^[a-zA-Z]:[\\/]/.test(abs) ? abs.replace(/\//g, '\\').replace(/\\{2,}/g, '\\') : abs;
 }
 
 /** 单条 tool_use 消息 → 它新建的文件原始路径列表(可能为空)。 */
@@ -84,9 +82,7 @@ function createdPathsFromToolUse(toolName: string, input: unknown): string[] {
     return descriptor.action === 'create' && descriptor.filePath ? [descriptor.filePath] : [];
   }
   if (descriptor.kind === 'fileChange') {
-    return descriptor.changes
-      .filter((c) => c.action === 'add' && c.path)
-      .map((c) => c.path);
+    return descriptor.changes.filter((c) => c.action === 'add' && c.path).map((c) => c.path);
   }
   return [];
 }
@@ -109,31 +105,139 @@ function isPathCandidate(raw: string): boolean {
   return isAbs || hasSep;
 }
 
-/**
- * 命令文本 → 产物路径候选。两个来源:
- *   1. 引号字符串(`'...'` / `"..."`):脚本内路径的主形态,可含空格与 CJK,
- *      如 python 的 `wb.save(r'C:\Users\x\表格.xlsx')`;
- *   2. 裸 token:重定向 / CLI 参数里的无引号绝对路径(不含空格)。
- * 只做形态过滤,不判断读写意图——读写区分交给渲染方的 mtime 时间窗。
- */
-export function extractCommandPathCandidates(command: string): string[] {
+interface CommandPathToken {
+  path: string;
+  start: number;
+  end: number;
+}
+
+/** 提取路径 token 及其在命令中的位置;写出语义需要靠相邻文本判断。 */
+function extractCommandPathTokens(command: string): CommandPathToken[] {
   if (!command) return [];
-  const out: string[] = [];
-  const seen = new Set<string>();
-  const push = (raw: string): void => {
+  const out: CommandPathToken[] = [];
+  const quotedRanges: Array<{ start: number; end: number }> = [];
+  const push = (raw: string, start: number, end: number): void => {
     const s = raw.trim();
     if (!isPathCandidate(s)) return;
-    if (seen.has(s)) return;
-    seen.add(s);
-    out.push(s);
+    out.push({ path: s, start, end });
   };
-  for (const m of command.matchAll(/'([^'\r\n]+)'|"([^"\r\n]+)"/g)) {
-    push(m[1] ?? m[2] ?? '');
-  }
+  // 单、双引号分开扫描,才能识别 `node -e "save('C:\\out\\a.xlsx')"` 这类
+  // 外层 shell 引号包内层语言字符串的常见形态。合并成一个 alternation 会被外层先吞掉。
+  const scanQuoted = (re: RegExp): void => {
+    for (const m of command.matchAll(re)) {
+      const raw = m[1] ?? '';
+      const matchStart = m.index ?? 0;
+      quotedRanges.push({ start: matchStart, end: matchStart + m[0].length });
+      push(raw, matchStart + 1, matchStart + 1 + raw.length);
+    }
+  };
+  scanQuoted(/'([^'\r\n]+)'/g);
+  scanQuoted(/"([^"\r\n]+)"/g);
   // 裸 Windows 盘符路径与裸 POSIX 绝对路径(前面是行首/空白/常见分隔)。
   // 盘符前不允许字母数字:排除 URL scheme 尾字母被当盘符(https://…)。
-  for (const m of command.matchAll(/(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s'"<>|?*]+/g)) push(m[0]);
-  for (const m of command.matchAll(/(?:^|[\s=(,>])(\/[^\s'"<>|?*:]+)/g)) push(m[1]);
+  const insideQuotedRange = (index: number): boolean =>
+    quotedRanges.some((range) => index >= range.start && index < range.end);
+  for (const m of command.matchAll(/(?<![A-Za-z0-9])[A-Za-z]:[\\/][^\s'"<>|?*]+/g)) {
+    const start = m.index ?? 0;
+    if (!insideQuotedRange(start)) push(m[0], start, start + m[0].length);
+  }
+  for (const m of command.matchAll(/(?:^|[\s=(,>])(\/[^\s'"<>|?*:]+)/g)) {
+    const start = (m.index ?? 0) + m[0].length - m[1].length;
+    if (!insideQuotedRange(start)) push(m[1], start, start + m[1].length);
+  }
+  return out.sort((a, b) => a.start - b.start || a.end - b.end);
+}
+
+const WRITE_CALL_PREFIX_RE =
+  /(?:\.|\b)(?:save|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*(?:[rubf]{0,2})?['"]$/i;
+const POWERSHELL_CMDLET_RE = /\b[A-Za-z][A-Za-z0-9]*-[A-Za-z][A-Za-z0-9-]*\b/g;
+const POWERSHELL_WRITE_COMMANDS = new Set([
+  'out-file',
+  'set-content',
+  'add-content',
+  'export-csv',
+  'export-clixml',
+  'new-item',
+]);
+const OUTPUT_OPTION_PREFIX_RE = /(?:^|\s)(?:-o|--output(?:-file)?|--outfile)(?:\s+|=)['"]?$/i;
+const REDIRECT_PREFIX_RE = /(?:^|[^>])>{1,2}\s*['"]?$/;
+const SAVE_COMMAND_PREFIX_RE = /(?:^|[;&|]\s*|\s)save\s+['"]?$/i;
+
+function isPowerShellOutputPosition(before: string): boolean {
+  let lastCmdlet: RegExpMatchArray | null = null;
+  for (const match of before.matchAll(POWERSHELL_CMDLET_RE)) lastCmdlet = match;
+  if (!lastCmdlet || !POWERSHELL_WRITE_COMMANDS.has(lastCmdlet[0].toLowerCase())) return false;
+  const trailing = before.slice((lastCmdlet.index ?? 0) + lastCmdlet[0].length);
+  // Support the first positional path and the cmdlets' explicit path switches.
+  // Any nested/read cmdlet becomes the last cmdlet and therefore cannot leak its input path.
+  return /^\s*['"]?$/.test(trailing) || /-(?:FilePath|LiteralPath|Path)\s+['"]?$/i.test(trailing);
+}
+
+function isExplicitOutputPath(
+  command: string,
+  token: CommandPathToken,
+  tokens: readonly CommandPathToken[],
+): boolean {
+  const before = command.slice(Math.max(0, token.start - 240), token.start);
+  const after = command.slice(token.end, token.end + 80);
+  if (
+    WRITE_CALL_PREFIX_RE.test(before) ||
+    isPowerShellOutputPosition(before) ||
+    OUTPUT_OPTION_PREFIX_RE.test(before) ||
+    REDIRECT_PREFIX_RE.test(before) ||
+    SAVE_COMMAND_PREFIX_RE.test(before)
+  ) {
+    return true;
+  }
+  // Python / Ruby 等的 open(path, 'w'|'a'|'x'|'wb'...)。
+  if (
+    /\bopen\s*\(\s*(?:[rubf]{0,2})?['"]$/i.test(before) &&
+    /^['"]\s*,\s*['"][wax][bt+]*['"]/i.test(after)
+  ) {
+    return true;
+  }
+
+  // cp/copy 的最后一个路径参数是目标。只看当前命令段,避免把前一条读取命令的路径带进来。
+  const previousSeparators = [
+    { index: command.lastIndexOf(';', token.start - 1), length: 1 },
+    { index: command.lastIndexOf('\n', token.start - 1), length: 1 },
+    { index: command.lastIndexOf('&&', token.start - 1), length: 2 },
+    { index: command.lastIndexOf('||', token.start - 1), length: 2 },
+  ];
+  const previousSeparator = previousSeparators.reduce((latest, candidate) =>
+    candidate.index > latest.index ? candidate : latest,
+  );
+  const segmentStart = previousSeparator.index + previousSeparator.length;
+  const nextSeparators = [
+    command.indexOf(';', token.end),
+    command.indexOf('\n', token.end),
+    command.indexOf('&&', token.end),
+    command.indexOf('||', token.end),
+  ].filter((index) => index >= 0);
+  const segmentEnd = nextSeparators.length > 0 ? Math.min(...nextSeparators) : command.length;
+  const segment = command.slice(segmentStart, segmentEnd);
+  const lastPath = tokens
+    .filter((candidate) => candidate.start >= segmentStart && candidate.end <= segmentEnd)
+    .at(-1);
+  return lastPath === token && /(?:^|[|]\s*)\s*(?:cp|copy|Copy-Item)\b/i.test(segment);
+}
+
+/**
+ * 命令文本 → 明确写出位置里的产物路径候选。
+ *
+ * mtime 只能证明文件最近变过,不能证明是当前命令创建的(新 worktree 中所有文件尤其容易
+ * 同时命中时间窗)。因此普通参数、变量赋值、Get-Content / ReadAllLines 等读取位置一律不收;
+ * 只认重定向、常见 save/write API、输出参数及复制目标。后续仍由渲染方做时间窗复核。
+ */
+export function extractCommandOutputPathCandidates(command: string): string[] {
+  const tokens = extractCommandPathTokens(command);
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const token of tokens) {
+    if (!isExplicitOutputPath(command, token, tokens) || seen.has(token.path)) continue;
+    seen.add(token.path);
+    out.push(token.path);
+  }
   return out;
 }
 
@@ -190,7 +294,7 @@ export function collectGeneratedFiles(
     }
     const descriptor = describeToolUse(toolName, msg.toolInput);
     if (descriptor.kind === 'command' && descriptor.command) {
-      for (const rawPath of extractCommandPathCandidates(descriptor.command)) {
+      for (const rawPath of extractCommandOutputPathCandidates(descriptor.command)) {
         addPath(rawPath, 'command');
       }
     }

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -159,7 +159,7 @@ function extractCommandPathTokens(command: string): CommandPathToken[] {
 }
 
 const WRITE_CALL_PREFIX_RE =
-  /(?:\.|\b)(?:save|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*(?:[rubf]{0,2})?['"]$/i;
+  /(?:\.|\b)(?:save|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*(?:(?:path_or_buf|excel_writer|path|filename|fname|fp|file)\s*=\s*)?(?:[rubf]{0,2})?['"]$/i;
 const POWERSHELL_CMDLET_RE = /\b[A-Za-z][A-Za-z0-9]*-[A-Za-z][A-Za-z0-9-]*\b/g;
 const POWERSHELL_WRITE_COMMANDS = new Set([
   'out-file',

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -119,12 +119,30 @@ interface CommandArgument {
 }
 
 function extractCommandArguments(text: string, offset = 0): CommandArgument[] {
-  return [...text.matchAll(/'([^'\r\n]*)'|"([^"\r\n]*)"|([^\s]+)/g)].map((match) => {
+  const parsed = [...text.matchAll(/'([^'\r\n]*)'|"([^"\r\n]*)"|([^\s]+)/g)].map((match) => {
     const value = match[1] ?? match[2] ?? match[3] ?? '';
-    const quoteOffset = match[1] !== undefined || match[2] !== undefined ? 1 : 0;
+    const quoted = match[1] !== undefined || match[2] !== undefined;
+    const quoteOffset = quoted ? 1 : 0;
     const start = offset + (match.index ?? 0) + quoteOffset;
-    return { value, start, end: start + value.length };
+    return { value, start, end: start + value.length, quoted };
   });
+  const merged: typeof parsed = [];
+  // POSIX shell 的奇数个尾随反斜杠会转义紧随其后的空白;只消费最后一个反斜杠,
+  // 避免把 Windows 路径里的普通反斜杠做全局反转义。
+  for (const argument of parsed) {
+    const previous = merged.at(-1);
+    const trailingBackslashes = previous?.value.match(/\\+$/)?.[0].length ?? 0;
+    if (previous && !previous.quoted && !argument.quoted && trailingBackslashes % 2 === 1) {
+      const gap = text.slice(previous.end - offset, argument.start - offset);
+      if (/^[ \t]+$/.test(gap)) {
+        previous.value = `${previous.value.slice(0, -1)}${gap[0]}${argument.value}`;
+        previous.end = argument.end;
+        continue;
+      }
+    }
+    merged.push(argument);
+  }
+  return merged.map(({ value, start, end }) => ({ value, start, end }));
 }
 
 const RELATIVE_PATH_TOKEN_RE = /(?:^|[\s=(,>])([^\s'"<>|?*]+[\\/])(?=$|[\s'"<>|])/g;
@@ -336,13 +354,14 @@ function isExplicitOutputPath(
   tokens: readonly CommandPathToken[],
 ): boolean {
   const before = command.slice(Math.max(0, token.start - 240), token.start);
+  const powerShellBefore = command.slice(0, token.start);
   const after = command.slice(token.end, token.end + 80);
   if (
     WRITE_CALL_PREFIX_RE.test(before) ||
     WRITE_CALL_LATER_KEYWORD_PREFIX_RE.test(before) ||
     OBJECT_FIRST_WRITE_CALL_PREFIX_RE.test(before) ||
     /^\s*['"]?\s*\)\s*\.\s*write_(?:text|bytes)\s*\(/i.test(after) ||
-    isPowerShellOutputPosition(before) ||
+    isPowerShellOutputPosition(powerShellBefore) ||
     OUTPUT_OPTION_PREFIX_RE.test(before) ||
     REDIRECT_PREFIX_RE.test(before) ||
     SAVE_COMMAND_PREFIX_RE.test(before) ||
@@ -382,21 +401,19 @@ function isExplicitOutputPath(
     .filter((candidate) => candidate.start >= segmentStart && candidate.end <= segmentEnd)
     .sort((a, b) => a.start - b.start || a.end - b.end)
     .at(-1);
+  const beforeInSegment = command.slice(segmentStart, token.start);
   if (/(?:^|\|\s*)(?:Copy-Item|Move-Item)\b/i.test(segment.trim())) {
-    const beforeInSegment = command.slice(segmentStart, token.start);
     const hasExplicitDestination = /-(?:Destination|LiteralDestination|Target)\s+/i.test(segment);
     if (hasExplicitDestination) {
       return /-(?:Destination|LiteralDestination|Target)\s+['"]?$/i.test(beforeInSegment);
     }
     return lastPath?.start === token.start && lastPath.end === token.end;
   }
-  if (
+  const isTargetDirectoryTransfer =
     /(?:^|\|\s*)(?:cp|mv)\s+/i.test(segment.trim()) &&
-    /(?:^|\s)(?:-t|--target-directory)(?:\s+|=)['"]?$/i.test(
-      command.slice(segmentStart, token.start),
-    )
-  ) {
-    return true;
+    /(?:^|\s)(?:-t(?:\s+|$)|--target-directory(?:\s+|=))/i.test(segment);
+  if (isTargetDirectoryTransfer) {
+    return /(?:^|\s)(?:-t|--target-directory)(?:\s+|=)['"]?$/i.test(beforeInSegment);
   }
   return (
     lastPath?.start === token.start &&

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -10,7 +10,8 @@
  *     Excel / Word / PDF 等二进制产物只能靠脚本(Bash/exec 跑 python、node)生成,
  *     没有文件工具记录;不补这个盲区,卡在「帮我生成个表格」主场景直接失灵。
  * 「修改已有文件」(edit / update)与读取不算产出(产品口径:只收新建,见
- * AskUserQuestion 决策)。move / delete 同样排除。
+ * AskUserQuestion 决策)。结构化文件工具的 move / delete 同样排除;命令层把明确的
+ * copy / move 目标作为候选,用于临时文件落到最终产物路径的场景。
  *
  * 误报防线(source:'command' 特有,由渲染方 GeneratedFilesCard 执行):
  *   命令文本里出现路径 ≠ 命令创建了它(可能只是读输入)。所以只认重定向、save / write
@@ -87,7 +88,7 @@ function createdPathsFromToolUse(toolName: string, input: unknown): string[] {
   return [];
 }
 
-/** 文件候选需带扩展名;复制命令的目录目标可用末尾分隔符明确表达。 */
+/** 文件候选需带扩展名;复制/移动命令的目录目标可用末尾分隔符明确表达。 */
 const EXT_RE = /\.[A-Za-z][A-Za-z0-9]{0,7}$/;
 
 /** 临时目录里的产物是脚本自身/中间文件的高发区,一律不算「本轮产出」。 */
@@ -154,7 +155,7 @@ function extractCommandPathTokens(command: string): CommandPathToken[] {
       push(raw, start, start + raw.length);
     }
   }
-  for (const token of extractCopyPlainFilenameDestinations(command)) {
+  for (const token of extractTransferPlainFilenameDestinations(command)) {
     out.push(token);
   }
   return out.sort((a, b) => a.start - b.start || a.end - b.end);
@@ -178,9 +179,10 @@ const REDIRECT_PREFIX_RE = /(?:^|[^>])>{1,2}\s*['"]?$/;
 const SAVE_COMMAND_PREFIX_RE = /(?:^|[;&|]\s*|\s)save\s+['"]?$/i;
 const TEE_COMMAND_PREFIX_RE = /(?:^|[|;&]\s*)tee(?:\.exe)?\b[^|;&\r\n]*['"]?$/i;
 
-function extractCopyPlainFilenameDestinations(command: string): CommandPathToken[] {
+function extractTransferPlainFilenameDestinations(command: string): CommandPathToken[] {
   const out: CommandPathToken[] = [];
-  const commandRe = /\b(Copy-Item|copy|cp)\b([^|;\r\n]*?)(?=\|{1,2}|;|\r?$|\n)/gim;
+  const commandRe =
+    /\b(Copy-Item|Move-Item|copy|move|cp|mv)\b([^|;\r\n]*?)(?=\|{1,2}|;|\r?$|\n)/gim;
   for (const commandMatch of command.matchAll(commandRe)) {
     const commandName = (commandMatch[1] ?? '').toLowerCase();
     const argsText = commandMatch[2] ?? '';
@@ -193,12 +195,12 @@ function extractCopyPlainFilenameDestinations(command: string): CommandPathToken
     });
     const isPlainFilename = (value: string): boolean =>
       EXT_RE.test(value) && !/[\\/<>|?*]/.test(value);
-    if (commandName !== 'copy-item') {
+    if (commandName !== 'copy-item' && commandName !== 'move-item') {
       if (args.some((arg) => /^(?:-t|--target-directory(?:=|$))/i.test(arg.value))) continue;
       const positional = args.filter(
         (arg) =>
           !arg.value.startsWith('-') &&
-          !(commandName === 'copy' && /^\/[A-Za-z]+$/.test(arg.value)),
+          !((commandName === 'copy' || commandName === 'move') && /^\/[A-Za-z]+$/.test(arg.value)),
       );
       const destination = positional.length >= 2 ? positional.at(-1) : undefined;
       if (destination && isPlainFilename(destination.value)) {
@@ -320,7 +322,7 @@ function isExplicitOutputPath(
     return true;
   }
 
-  // cp/copy 的最后一个路径参数是目标。只看当前命令段,避免把前一条读取命令的路径带进来。
+  // copy/move 的最后一个路径参数是目标。只看当前命令段,避免把前一条命令的路径带进来。
   const previousSeparators = [
     { index: command.lastIndexOf(';', token.start - 1), length: 1 },
     { index: command.lastIndexOf('\n', token.start - 1), length: 1 },
@@ -343,7 +345,7 @@ function isExplicitOutputPath(
     .filter((candidate) => candidate.start >= segmentStart && candidate.end <= segmentEnd)
     .sort((a, b) => a.start - b.start || a.end - b.end)
     .at(-1);
-  if (/(?:^|\|\s*)Copy-Item\b/i.test(segment.trim())) {
+  if (/(?:^|\|\s*)(?:Copy-Item|Move-Item)\b/i.test(segment.trim())) {
     const beforeInSegment = command.slice(segmentStart, token.start);
     const hasExplicitDestination = /-(?:Destination|LiteralDestination|Target)\s+/i.test(segment);
     if (hasExplicitDestination) {
@@ -354,11 +356,11 @@ function isExplicitOutputPath(
   return (
     lastPath?.start === token.start &&
     lastPath.end === token.end &&
-    /(?:^|\|\s*)(?:cp|copy|Copy-Item)\s+/i.test(segment.trim())
+    /(?:^|\|\s*)(?:cp|copy|mv|move|Copy-Item|Move-Item)\s+/i.test(segment.trim())
   );
 }
 
-function copyDirectoryOutputs(
+function transferDirectoryOutputs(
   command: string,
   destination: CommandPathToken,
   tokens: readonly CommandPathToken[],
@@ -423,7 +425,7 @@ export function extractCommandOutputPathCandidates(command: string): string[] {
   const out: string[] = [];
   for (const token of tokens) {
     if (!isExplicitOutputPath(command, token, tokens)) continue;
-    for (const output of copyDirectoryOutputs(command, token, tokens)) {
+    for (const output of transferDirectoryOutputs(command, token, tokens)) {
       if (seen.has(output)) continue;
       seen.add(output);
       out.push(output);

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -112,6 +112,21 @@ interface CommandPathToken {
   end: number;
 }
 
+interface CommandArgument {
+  value: string;
+  start: number;
+  end: number;
+}
+
+function extractCommandArguments(text: string, offset = 0): CommandArgument[] {
+  return [...text.matchAll(/'([^'\r\n]*)'|"([^"\r\n]*)"|([^\s]+)/g)].map((match) => {
+    const value = match[1] ?? match[2] ?? match[3] ?? '';
+    const quoteOffset = match[1] !== undefined || match[2] !== undefined ? 1 : 0;
+    const start = offset + (match.index ?? 0) + quoteOffset;
+    return { value, start, end: start + value.length };
+  });
+}
+
 const RELATIVE_PATH_TOKEN_RE = /(?:^|[\s=(,>])([^\s'"<>|?*]+[\\/])(?=$|[\s'"<>|])/g;
 
 /** 提取路径 token 及其在命令中的位置;写出语义需要靠相邻文本判断。 */
@@ -165,6 +180,8 @@ const WRITE_CALL_PREFIX_RE =
   /(?:\.|\b)(?:save|savefig|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*(?:(?:path_or_buf|excel_writer|path|filename|fname|fp|file)\s*=\s*)?(?:[rubf]{0,2})?['"]$/i;
 const WRITE_CALL_LATER_KEYWORD_PREFIX_RE =
   /(?:\.|\b)(?:save|savefig|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*[^();\r\n]+,\s*(?:path_or_buf|excel_writer|path|filename|fname|fp|file)\s*=\s*(?:[rubf]{0,2})?['"]$/i;
+const OBJECT_FIRST_WRITE_CALL_PREFIX_RE =
+  /\b(?:torch\.save|joblib\.dump)\s*\(\s*(?:[^();\r\n]|\([^()]*\))+,\s*(?:[rubf]{0,2})?['"]$/i;
 const POWERSHELL_CMDLET_RE = /\b[A-Za-z][A-Za-z0-9]*-[A-Za-z][A-Za-z0-9-]*\b/g;
 const POWERSHELL_WRITE_COMMANDS = new Set([
   'out-file',
@@ -174,7 +191,8 @@ const POWERSHELL_WRITE_COMMANDS = new Set([
   'export-clixml',
   'new-item',
 ]);
-const OUTPUT_OPTION_PREFIX_RE = /(?:^|\s)(?:-o|--output(?:-file)?|--outfile)(?:\s+|=)['"]?$/i;
+const OUTPUT_OPTION_PREFIX_RE =
+  /(?:^|\s)(?:-o|--output(?:-file|-document)?|--outfile)(?:\s+|=)['"]?$/i;
 const REDIRECT_PREFIX_RE = /(?:^|[^>])>{1,2}\s*['"]?$/;
 const SAVE_COMMAND_PREFIX_RE = /(?:^|[;&|]\s*|\s)save\s+['"]?$/i;
 const TEE_COMMAND_PREFIX_RE = /(?:^|[|;&]\s*)tee(?:\.exe)?\b[^|;&\r\n]*['"]?$/i;
@@ -187,16 +205,34 @@ function extractTransferPlainFilenameDestinations(command: string): CommandPathT
     const commandName = (commandMatch[1] ?? '').toLowerCase();
     const argsText = commandMatch[2] ?? '';
     const argsStart = (commandMatch.index ?? 0) + commandMatch[0].length - argsText.length;
-    const args = [...argsText.matchAll(/'([^'\r\n]*)'|"([^"\r\n]*)"|([^\s]+)/g)].map((match) => {
-      const value = match[1] ?? match[2] ?? match[3] ?? '';
-      const offset = match[1] !== undefined || match[2] !== undefined ? 1 : 0;
-      const start = argsStart + (match.index ?? 0) + offset;
-      return { value, start, end: start + value.length };
-    });
+    const args = extractCommandArguments(argsText, argsStart);
     const isPlainFilename = (value: string): boolean =>
       EXT_RE.test(value) && !/[\\/<>|?*]/.test(value);
     if (commandName !== 'copy-item' && commandName !== 'move-item') {
-      if (args.some((arg) => /^(?:-t|--target-directory(?:=|$))/i.test(arg.value))) continue;
+      const supportsTargetDirectoryOption = commandName === 'cp' || commandName === 'mv';
+      const targetDirectoryOptionIndex = supportsTargetDirectoryOption
+        ? args.findIndex((arg) => /^(?:-t|--target-directory(?:=|$))/i.test(arg.value))
+        : -1;
+      if (targetDirectoryOptionIndex >= 0) {
+        const option = args[targetDirectoryOptionIndex];
+        const equalsIndex = option.value.indexOf('=');
+        const separateDestination = args[targetDirectoryOptionIndex + 1];
+        const rawDestination =
+          equalsIndex >= 0 ? option.value.slice(equalsIndex + 1) : separateDestination?.value;
+        const destinationStart =
+          equalsIndex >= 0
+            ? option.start + equalsIndex + 1
+            : (separateDestination?.start ?? option.end);
+        const destination = rawDestination?.replace(/^(['"])(.*)\1$/, '$2');
+        if (destination && !TEMP_DIR_RE.test(destination) && !/[<>|?*]/.test(destination)) {
+          out.push({
+            path: /[\\/]$/.test(destination) ? destination : `${destination}/`,
+            start: destinationStart,
+            end: destinationStart + destination.length,
+          });
+        }
+        continue;
+      }
       const positional = args.filter(
         (arg) =>
           !arg.value.startsWith('-') &&
@@ -304,6 +340,7 @@ function isExplicitOutputPath(
   if (
     WRITE_CALL_PREFIX_RE.test(before) ||
     WRITE_CALL_LATER_KEYWORD_PREFIX_RE.test(before) ||
+    OBJECT_FIRST_WRITE_CALL_PREFIX_RE.test(before) ||
     /^\s*['"]?\s*\)\s*\.\s*write_(?:text|bytes)\s*\(/i.test(after) ||
     isPowerShellOutputPosition(before) ||
     OUTPUT_OPTION_PREFIX_RE.test(before) ||
@@ -353,6 +390,14 @@ function isExplicitOutputPath(
     }
     return lastPath?.start === token.start && lastPath.end === token.end;
   }
+  if (
+    /(?:^|\|\s*)(?:cp|mv)\s+/i.test(segment.trim()) &&
+    /(?:^|\s)(?:-t|--target-directory)(?:\s+|=)['"]?$/i.test(
+      command.slice(segmentStart, token.start),
+    )
+  ) {
+    return true;
+  }
   return (
     lastPath?.start === token.start &&
     lastPath.end === token.end &&
@@ -388,17 +433,14 @@ function transferDirectoryOutputs(
     .filter((token) => token.start !== destination.start)
     .filter((token) => !/[\\/]$/.test(token.path))
     .map((token) => token.path);
-  const beforeDestination = command.slice(segmentStart, destination.start);
-  const afterDestination = command.slice(destination.end, segmentEnd);
-  for (const match of beforeDestination.matchAll(
-    /(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g,
-  )) {
-    if (!sourcePaths.includes(match[1])) sourcePaths.push(match[1]);
-  }
-  for (const match of afterDestination.matchAll(
-    /(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g,
-  )) {
-    if (!sourcePaths.includes(match[1])) sourcePaths.push(match[1]);
+  const segmentArguments = extractCommandArguments(
+    command.slice(segmentStart, segmentEnd),
+    segmentStart,
+  );
+  for (const argument of segmentArguments) {
+    if (argument.start === destination.start) continue;
+    if (!EXT_RE.test(argument.value) || /[<>|?*]/.test(argument.value)) continue;
+    if (!sourcePaths.includes(argument.value)) sourcePaths.push(argument.value);
   }
   const outputs = sourcePaths
     .map((source) => {
@@ -417,7 +459,7 @@ function transferDirectoryOutputs(
  *
  * mtime 只能证明文件最近变过,不能证明是当前命令创建的(新 worktree 中所有文件尤其容易
  * 同时命中时间窗)。因此普通参数、变量赋值、Get-Content / ReadAllLines 等读取位置一律不收;
- * 只认重定向、常见 save/write API、输出参数及复制目标。后续仍由渲染方做时间窗复核。
+ * 只认重定向、常见 save/write API、输出参数及复制/移动目标。后续仍由渲染方做时间窗复核。
  */
 export function extractCommandOutputPathCandidates(command: string): string[] {
   const tokens = extractCommandPathTokens(command);

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -234,8 +234,46 @@ function isExplicitOutputPath(
   return (
     lastPath?.start === token.start &&
     lastPath.end === token.end &&
-    /^(?:cp|copy|Copy-Item)\s+/i.test(segment.trim())
+    /(?:^|\|\s*)(?:cp|copy|Copy-Item)\s+/i.test(segment.trim())
   );
+}
+
+function copyDirectoryOutputs(
+  command: string,
+  destination: CommandPathToken,
+  tokens: readonly CommandPathToken[],
+): string[] {
+  if (!/[\\/]$/.test(destination.path)) return [destination.path];
+  const previousSeparators = [
+    { index: command.lastIndexOf(';', destination.start - 1), length: 1 },
+    { index: command.lastIndexOf('\n', destination.start - 1), length: 1 },
+    { index: command.lastIndexOf('&&', destination.start - 1), length: 2 },
+    { index: command.lastIndexOf('||', destination.start - 1), length: 2 },
+  ];
+  const previousSeparator = previousSeparators.reduce((latest, candidate) =>
+    candidate.index > latest.index ? candidate : latest,
+  );
+  const segmentStart = previousSeparator.index + previousSeparator.length;
+  const nextSeparators = [
+    command.indexOf(';', destination.end),
+    command.indexOf('\n', destination.end),
+    command.indexOf('&&', destination.end),
+    command.indexOf('||', destination.end),
+  ].filter((index) => index >= 0);
+  const segmentEnd = nextSeparators.length > 0 ? Math.min(...nextSeparators) : command.length;
+  const sourcePaths = tokens
+    .filter((token) => token.start >= segmentStart && token.end <= destination.start)
+    .filter((token) => token.start !== destination.start && !/[\\/]$/.test(token.path))
+    .map((token) => token.path);
+  const beforeDestination = command.slice(segmentStart, destination.start);
+  for (const match of beforeDestination.matchAll(/(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g)) {
+    if (!sourcePaths.includes(match[1])) sourcePaths.push(match[1]);
+  }
+  const outputs = sourcePaths.map((source) => {
+    const sourceName = source.replace(/[\\/]$/, '').split(/[\\/]/).at(-1);
+    return sourceName ? `${destination.path}${sourceName}` : null;
+  }).filter((path): path is string => Boolean(path));
+  return outputs.length > 0 ? outputs : [destination.path];
 }
 
 /**
@@ -250,9 +288,12 @@ export function extractCommandOutputPathCandidates(command: string): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const token of tokens) {
-    if (!isExplicitOutputPath(command, token, tokens) || seen.has(token.path)) continue;
-    seen.add(token.path);
-    out.push(token.path);
+    if (!isExplicitOutputPath(command, token, tokens)) continue;
+    for (const output of copyDirectoryOutputs(command, token, tokens)) {
+      if (seen.has(output)) continue;
+      seen.add(output);
+      out.push(output);
+    }
   }
   return out;
 }

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -87,7 +87,7 @@ function createdPathsFromToolUse(toolName: string, input: unknown): string[] {
   return [];
 }
 
-/** 带扩展名(1–8 位字母数字,不含纯数字)的路径才算候选;`a.b.c` 取末段。 */
+/** 文件候选需带扩展名;复制命令的目录目标可用末尾分隔符明确表达。 */
 const EXT_RE = /\.[A-Za-z][A-Za-z0-9]{0,7}$/;
 
 /** 临时目录里的产物是脚本自身/中间文件的高发区,一律不算「本轮产出」。 */
@@ -96,7 +96,7 @@ const TEMP_DIR_RE = /(^|[\\/])(tmp|temp)([\\/])|[\\/]AppData[\\/]Local[\\/]Temp[
 function isPathCandidate(raw: string): boolean {
   const s = raw.trim();
   if (s.length < 3 || s.length > 512) return false;
-  if (!EXT_RE.test(s)) return false;
+  if (!EXT_RE.test(s) && !/[\\/]$/.test(s)) return false;
   if (TEMP_DIR_RE.test(s)) return false;
   // 绝对路径,或含分隔符的相对路径(交给 resolveToolFilePath 按 workingDir 解析)。
   // 纯文件名(`输出.xlsx`)不收:随机带点 token 误报率太高。
@@ -110,6 +110,9 @@ interface CommandPathToken {
   start: number;
   end: number;
 }
+
+const RELATIVE_PATH_TOKEN_RE =
+  /(?:^|[\s=(,>])([^\s'"<>|?*]+[\\/])(?=$|[\s'"<>|])/g;
 
 /** 提取路径 token 及其在命令中的位置;写出语义需要靠相邻文本判断。 */
 function extractCommandPathTokens(command: string): CommandPathToken[] {
@@ -144,6 +147,13 @@ function extractCommandPathTokens(command: string): CommandPathToken[] {
   for (const m of command.matchAll(/(?:^|[\s=(,>])(\/[^\s'"<>|?*:]+)/g)) {
     const start = (m.index ?? 0) + m[0].length - m[1].length;
     if (!insideQuotedRange(start)) push(m[1], start, start + m[1].length);
+  }
+  for (const m of command.matchAll(RELATIVE_PATH_TOKEN_RE)) {
+    const raw = m[1];
+    const start = (m.index ?? 0) + m[0].length - raw.length;
+    if (!insideQuotedRange(start) && !/^https?:\/\//i.test(raw)) {
+      push(raw, start, start + raw.length);
+    }
   }
   return out.sort((a, b) => a.start - b.start || a.end - b.end);
 }
@@ -182,6 +192,7 @@ function isExplicitOutputPath(
   const after = command.slice(token.end, token.end + 80);
   if (
     WRITE_CALL_PREFIX_RE.test(before) ||
+    /^\s*['"]?\s*\)\s*\.\s*write_(?:text|bytes)\s*\(/i.test(after) ||
     isPowerShellOutputPosition(before) ||
     OUTPUT_OPTION_PREFIX_RE.test(before) ||
     REDIRECT_PREFIX_RE.test(before) ||
@@ -218,8 +229,13 @@ function isExplicitOutputPath(
   const segment = command.slice(segmentStart, segmentEnd);
   const lastPath = tokens
     .filter((candidate) => candidate.start >= segmentStart && candidate.end <= segmentEnd)
+    .sort((a, b) => a.start - b.start || a.end - b.end)
     .at(-1);
-  return lastPath === token && /(?:^|[|]\s*)\s*(?:cp|copy|Copy-Item)\b/i.test(segment);
+  return (
+    lastPath?.start === token.start &&
+    lastPath.end === token.end &&
+    /^(?:cp|copy|Copy-Item)\s+/i.test(segment.trim())
+  );
 }
 
 /**

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -159,7 +159,7 @@ function extractCommandPathTokens(command: string): CommandPathToken[] {
 }
 
 const WRITE_CALL_PREFIX_RE =
-  /(?:\.|\b)(?:save|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*(?:(?:path_or_buf|excel_writer|path|filename|fname|fp|file)\s*=\s*)?(?:[rubf]{0,2})?['"]$/i;
+  /(?:\.|\b)(?:save|savefig|writeFileSync|writeFile|writeAllText|writeAllBytes|createWriteStream|write_text|write_bytes|to_csv|to_excel|to_json|to_parquet|imwrite|imsave|dump)\s*\(\s*(?:(?:path_or_buf|excel_writer|path|filename|fname|fp|file)\s*=\s*)?(?:[rubf]{0,2})?['"]$/i;
 const POWERSHELL_CMDLET_RE = /\b[A-Za-z][A-Za-z0-9]*-[A-Za-z][A-Za-z0-9-]*\b/g;
 const POWERSHELL_WRITE_COMMANDS = new Set([
   'out-file',
@@ -231,6 +231,9 @@ function isExplicitOutputPath(
     .filter((candidate) => candidate.start >= segmentStart && candidate.end <= segmentEnd)
     .sort((a, b) => a.start - b.start || a.end - b.end)
     .at(-1);
+  if (/(?:^|\|\s*)Copy-Item\b/i.test(segment.trim())) {
+    return /-(?:Destination|LiteralDestination|Target)\s+['"]?$/i.test(before);
+  }
   return (
     lastPath?.start === token.start &&
     lastPath.end === token.end &&
@@ -262,11 +265,16 @@ function copyDirectoryOutputs(
   ].filter((index) => index >= 0);
   const segmentEnd = nextSeparators.length > 0 ? Math.min(...nextSeparators) : command.length;
   const sourcePaths = tokens
-    .filter((token) => token.start >= segmentStart && token.end <= destination.start)
-    .filter((token) => token.start !== destination.start && !/[\\/]$/.test(token.path))
+    .filter((token) => token.start >= segmentStart && token.end <= segmentEnd)
+    .filter((token) => token.start !== destination.start)
+    .filter((token) => !/[\\/]$/.test(token.path))
     .map((token) => token.path);
   const beforeDestination = command.slice(segmentStart, destination.start);
+  const afterDestination = command.slice(destination.end, segmentEnd);
   for (const match of beforeDestination.matchAll(/(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g)) {
+    if (!sourcePaths.includes(match[1])) sourcePaths.push(match[1]);
+  }
+  for (const match of afterDestination.matchAll(/(?:^|[\s'"])([^\s'"]+\.[A-Za-z][A-Za-z0-9]{0,7})(?=$|[\s'"])/g)) {
     if (!sourcePaths.includes(match[1])) sourcePaths.push(match[1]);
   }
   const outputs = sourcePaths.map((source) => {

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -154,7 +154,7 @@ function extractCommandPathTokens(command: string): CommandPathToken[] {
       push(raw, start, start + raw.length);
     }
   }
-  for (const token of extractCopyItemPlainFilenameDestinations(command)) {
+  for (const token of extractCopyPlainFilenameDestinations(command)) {
     out.push(token);
   }
   return out.sort((a, b) => a.start - b.start || a.end - b.end);
@@ -178,12 +178,13 @@ const REDIRECT_PREFIX_RE = /(?:^|[^>])>{1,2}\s*['"]?$/;
 const SAVE_COMMAND_PREFIX_RE = /(?:^|[;&|]\s*|\s)save\s+['"]?$/i;
 const TEE_COMMAND_PREFIX_RE = /(?:^|[|;&]\s*)tee(?:\.exe)?\b[^|;&\r\n]*['"]?$/i;
 
-function extractCopyItemPlainFilenameDestinations(command: string): CommandPathToken[] {
+function extractCopyPlainFilenameDestinations(command: string): CommandPathToken[] {
   const out: CommandPathToken[] = [];
-  const commandRe = /\bCopy-Item\b([^|;\r\n]*?)(?=\|{1,2}|;|\r?$|\n)/gim;
+  const commandRe = /\b(Copy-Item|copy|cp)\b([^|;\r\n]*?)(?=\|{1,2}|;|\r?$|\n)/gim;
   for (const commandMatch of command.matchAll(commandRe)) {
-    const argsText = commandMatch[1] ?? '';
-    const argsStart = (commandMatch.index ?? 0) + commandMatch[0].indexOf(argsText);
+    const commandName = (commandMatch[1] ?? '').toLowerCase();
+    const argsText = commandMatch[2] ?? '';
+    const argsStart = (commandMatch.index ?? 0) + commandMatch[0].length - argsText.length;
     const args = [...argsText.matchAll(/'([^'\r\n]*)'|"([^"\r\n]*)"|([^\s]+)/g)].map((match) => {
       const value = match[1] ?? match[2] ?? match[3] ?? '';
       const offset = match[1] !== undefined || match[2] !== undefined ? 1 : 0;
@@ -192,6 +193,19 @@ function extractCopyItemPlainFilenameDestinations(command: string): CommandPathT
     });
     const isPlainFilename = (value: string): boolean =>
       EXT_RE.test(value) && !/[\\/<>|?*]/.test(value);
+    if (commandName !== 'copy-item') {
+      if (args.some((arg) => /^(?:-t|--target-directory(?:=|$))/i.test(arg.value))) continue;
+      const positional = args.filter(
+        (arg) =>
+          !arg.value.startsWith('-') &&
+          !(commandName === 'copy' && /^\/[A-Za-z]+$/.test(arg.value)),
+      );
+      const destination = positional.length >= 2 ? positional.at(-1) : undefined;
+      if (destination && isPlainFilename(destination.value)) {
+        out.push({ path: destination.value, start: destination.start, end: destination.end });
+      }
+      continue;
+    }
     const explicitDestinationIndex = args.findIndex((arg) =>
       /^-(?:Destination|LiteralDestination|Target)$/i.test(arg.value),
     );
@@ -224,14 +238,58 @@ function extractCopyItemPlainFilenameDestinations(command: string): CommandPathT
   return out;
 }
 
+function isTopLevelPowerShellTail(value: string): boolean {
+  let depth = 0;
+  let quote: "'" | '"' | null = null;
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index];
+    if (char === '`') {
+      index += 1;
+      continue;
+    }
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+    if (char === '(' || char === '[' || char === '{') {
+      depth += 1;
+      continue;
+    }
+    if (char === ')' || char === ']' || char === '}') {
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+    if (depth === 0 && (char === ';' || char === '|' || char === '\r' || char === '\n')) {
+      return false;
+    }
+  }
+  return depth === 0;
+}
+
 function isPowerShellOutputPosition(before: string): boolean {
-  let lastCmdlet: RegExpMatchArray | null = null;
-  for (const match of before.matchAll(POWERSHELL_CMDLET_RE)) lastCmdlet = match;
-  if (!lastCmdlet || !POWERSHELL_WRITE_COMMANDS.has(lastCmdlet[0].toLowerCase())) return false;
-  const trailing = before.slice((lastCmdlet.index ?? 0) + lastCmdlet[0].length);
+  const cmdlets = [...before.matchAll(POWERSHELL_CMDLET_RE)];
+  const lastCmdlet = cmdlets.at(-1);
+  const lastWriteCmdlet = cmdlets
+    .filter((match) => POWERSHELL_WRITE_COMMANDS.has(match[0].toLowerCase()))
+    .at(-1);
+  if (!lastCmdlet || !lastWriteCmdlet) return false;
+  const writeTail = before.slice((lastWriteCmdlet.index ?? 0) + lastWriteCmdlet[0].length);
   // Support the first positional path and the cmdlets' explicit path switches.
-  // Any nested/read cmdlet becomes the last cmdlet and therefore cannot leak its input path.
-  return /^\s*['"]?$/.test(trailing) || /-(?:FilePath|LiteralPath|Path)\s+['"]?$/i.test(trailing);
+  // An explicit switch may follow a nested read expression, but it must remain at the writer's
+  // top level so a nested `Get-Content -Path` cannot leak its input path.
+  if (
+    /-(?:FilePath|LiteralPath|Path)\s+['"]?$/i.test(writeTail) &&
+    isTopLevelPowerShellTail(writeTail)
+  ) {
+    return true;
+  }
+  if (lastCmdlet.index !== lastWriteCmdlet.index) return false;
+  const trailing = before.slice((lastCmdlet.index ?? 0) + lastCmdlet[0].length);
+  return /^\s*['"]?$/.test(trailing);
 }
 
 function isExplicitOutputPath(

--- a/apps/desktop/src/renderer/lib/generatedFiles.ts
+++ b/apps/desktop/src/renderer/lib/generatedFiles.ts
@@ -172,6 +172,7 @@ const POWERSHELL_WRITE_COMMANDS = new Set([
 const OUTPUT_OPTION_PREFIX_RE = /(?:^|\s)(?:-o|--output(?:-file)?|--outfile)(?:\s+|=)['"]?$/i;
 const REDIRECT_PREFIX_RE = /(?:^|[^>])>{1,2}\s*['"]?$/;
 const SAVE_COMMAND_PREFIX_RE = /(?:^|[;&|]\s*|\s)save\s+['"]?$/i;
+const TEE_COMMAND_PREFIX_RE = /(?:^|[|;&]\s*)tee(?:\.exe)?\b[^|;&\r\n]*['"]?$/i;
 
 function isPowerShellOutputPosition(before: string): boolean {
   let lastCmdlet: RegExpMatchArray | null = null;
@@ -196,7 +197,8 @@ function isExplicitOutputPath(
     isPowerShellOutputPosition(before) ||
     OUTPUT_OPTION_PREFIX_RE.test(before) ||
     REDIRECT_PREFIX_RE.test(before) ||
-    SAVE_COMMAND_PREFIX_RE.test(before)
+    SAVE_COMMAND_PREFIX_RE.test(before) ||
+    TEE_COMMAND_PREFIX_RE.test(before)
   ) {
     return true;
   }
@@ -232,7 +234,12 @@ function isExplicitOutputPath(
     .sort((a, b) => a.start - b.start || a.end - b.end)
     .at(-1);
   if (/(?:^|\|\s*)Copy-Item\b/i.test(segment.trim())) {
-    return /-(?:Destination|LiteralDestination|Target)\s+['"]?$/i.test(before);
+    const beforeInSegment = command.slice(segmentStart, token.start);
+    const hasExplicitDestination = /-(?:Destination|LiteralDestination|Target)\s+/i.test(segment);
+    if (hasExplicitDestination) {
+      return /-(?:Destination|LiteralDestination|Target)\s+['"]?$/i.test(beforeInSegment);
+    }
+    return lastPath?.start === token.start && lastPath.end === token.end;
   }
   return (
     lastPath?.start === token.start &&


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复审查面板把命令读取的输入文件误判为生成文件的问题，并降低大文件 diff 渲染造成的卡顿。

### 变更类型

- [x] `fix` 缺陷修复
- [x] `refactor` / `perf` 重构或性能优化

### 范围

- 关联 Issue / 需求：当前任务反馈
- 本 PR 包含：明确写出位置的命令产物识别、diff 行计算与高亮路径的性能优化、Windows 测试环境兼容。
- 明确不包含：文件写入、暂存、还原、提交和推送能力变更。
- 用户可见变化：审查面板不再展示仅读取的文件；两个大文件的 diff 面板响应更流畅。
- 是否存在 breaking change：无

### UI 变化

- 引用的设计规范：不涉及：本次仅调整审查数据筛选与 diff 计算，没有视觉样式、交互结构或 UI 文案变化；沿用现有组件和主题 token。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过（全量 unit tier）

pnpm --filter desktop run --if-present typecheck
结果：通过

pnpm --filter @cindy/maker-core run --if-present typecheck
结果：无 typecheck script，按规则跳过

pnpm --filter @cindy/ios-simulator-runtime run --if-present typecheck
结果：无 typecheck script，按规则跳过
```

定向回归测试：

- `packages/ios-simulator-runtime/src/project-adapter.test.ts`：通过
- `packages/maker-core/src/agents/shared/review-read-scope.test.ts`：通过
- `apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator-artifact.test.ts`：通过（Windows 跳过普通文件 symlink 用例）

### 手工验证

已完成当前任务的 Desktop dev 沙盒黑盒验收：确认审查面板不再显示仅读取文件，并验证两个文件的大 diff 面板可用。

### 未执行的验证

无

## 风险

### 风险分类

- [x] 跨平台差异

### 影响与回滚

- 影响范围：审查面板生成文件识别和 diff 展示路径。
- 回滚 / 降级方式：回滚本 PR 提交即可恢复原逻辑。
- Windows 测试使用目录 junction 绕过普通 symlink 权限限制；非 Windows 继续保留 symlink 语义覆盖。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] 未提交凭证、令牌或授权文件
- [x] 已确认测试结果