### PR TITLE
fix(memory): owner 未就绪时 fail-closed，拒绝静默降级到 %TEMP%（#2341）

### DIFF
--- a/apps/desktop/src/main/maker-host/maker-memory-host.ts
+++ b/apps/desktop/src/main/maker-host/maker-memory-host.ts
@@ -75,10 +75,16 @@ export function createDesktopMakerMemoryManager(): MakerMemoryManager {
     return path.join(app.getPath('userData'), 'owners', dataOwnerStorageKey(ownerId));
   };
   // 脱敏作用域键: owner id 经 sha256 前 20 hex 隐藏, 日志可直接记录。
+  // 追加 boundary 位 (review #2388 第二轮 P1): beginAppSessionBoundary() 后、
+  // commitActiveAppSession() 前 getActiveAppSession() 仍返回旧 owner —— 若 key
+  // 不含 boundary 状态, 已捕获 scopeAtEntry 的在途异步操作跨 await 复核会放行,
+  // 把旧 owner store 缓存入池。追加 ':boundary' 后 boundary 开始即 key 变化,
+  // 所有在途操作复核必失败, fail-closed 到新 commit。
   const ownerScopeKey = (): string => {
     const session = getActiveAppSession();
     const ownerSegment = session.dataOwnerId ? dataOwnerStorageKey(session.dataOwnerId) : 'none';
-    return `${session.mode}:${ownerSegment}:${session.generation}`;
+    const boundary = isAppSessionBoundaryPending() ? ':boundary' : '';
+    return `${session.mode}:${ownerSegment}:${session.generation}${boundary}`;
   };
   // 构造时快照仅用于 initialEnabled 读取与日志; 运行期以 resolveBasePath 为准。
   const basePath = resolveBasePath();

--- a/apps/desktop/src/main/maker-host/maker-memory-host.ts
+++ b/apps/desktop/src/main/maker-host/maker-memory-host.ts
@@ -49,19 +49,41 @@ const sqliteFactory: SqliteFactory = (filePath) => {
  *
  * basePath 直传 userData 根; manager 内部自己拼 'maker-memory/<sanitized-workdir>/'
  * 子结构, host 不应该假设这个细节 (避免之前的双重叠加 bug)。
+ *
+ * 修复 #2341 (owner 静默降级到 %TEMP%\cindy-no-session):
+ *  - basePath 不再在构造时冻结 —— 通过 resolveBasePath 每次访问时按
+ *    getActiveAppSession().dataOwnerId 现取; owner 未就绪 (signed-out / 认证
+ *    未落定) 返回 null, manager 将 fail-closed 抛 MAKER_MEMORY_NOT_READY,
+ *    绝不写临时目录。
+ *  - ownerScopeKey 注入脱敏作用域键 (mode + owner hash + generation), 登录/
+ *    登出/切账号 (commit 使 generation+1) 后 manager 自动关闭旧 store 重建新根。
  */
 export function createDesktopMakerMemoryManager(): MakerMemoryManager {
-  const ownerId = getActiveAppSession().dataOwnerId;
-  const basePath = ownerId
-    ? path.join(app.getPath('userData'), 'owners', dataOwnerStorageKey(ownerId))
-    : path.join(app.getPath('temp'), 'cindy-no-session', String(process.pid));
+  // owner 存储根: 有 owner → userData/owners/<hash>; 无 owner → null (fail-closed,
+  // 不再退到 %TEMP%\cindy-no-session\<pid>\, 那是 #2341 静默丢失的根源)。
+  const resolveBasePath = (): string | null => {
+    const ownerId = getActiveAppSession().dataOwnerId;
+    if (!ownerId) return null;
+    return path.join(app.getPath('userData'), 'owners', dataOwnerStorageKey(ownerId));
+  };
+  // 脱敏作用域键: owner id 经 sha256 前 20 hex 隐藏, 日志可直接记录。
+  const ownerScopeKey = (): string => {
+    const session = getActiveAppSession();
+    const ownerSegment = session.dataOwnerId ? dataOwnerStorageKey(session.dataOwnerId) : 'none';
+    return `${session.mode}:${ownerSegment}:${session.generation}`;
+  };
+  // 构造时快照仅用于 initialEnabled 读取与日志; 运行期以 resolveBasePath 为准。
+  const basePath = resolveBasePath();
   return new MakerMemoryManager({
-    basePath,
+    basePath: basePath ?? app.getPath('userData'),
+    resolveBasePath,
+    ownerScopeKey,
     sqliteFactory,
     agents: {}, // 占位, attachAgents 补上
     logger: desktopMakerLogger.child('maker-memory'),
     // 持久化 store 读 — 重启后保持用户上次设置，新用户默认开启。
-    initialEnabled: readMemorySettings({ rootPath: basePath }).maker,
+    // owner 未就绪时读全局 userData 默认 (不读 temp 一次性目录)。
+    initialEnabled: readMemorySettings({ rootPath: basePath ?? undefined }).maker,
     reviewAgent: 'claude-code', // memory_review 用 claude haiku 最便宜
     // 停用轴:review 的 oneShot 是新的付费调用,默认 one-shot 路由被停用时不派发
     // (PR #744 review 第十六轮)。

--- a/apps/desktop/src/main/maker-host/maker-memory-host.ts
+++ b/apps/desktop/src/main/maker-host/maker-memory-host.ts
@@ -32,7 +32,11 @@ import { desktopMakerLogger } from './logger-adapter.js';
 import { isAgentOneShotRouteDisabled } from './model-route-guard-live.js';
 import { readMemorySettings } from './memory-settings-store.js';
 import { createBetterSqliteDatabase } from '../localDb/betterSqliteFactory.js';
-import { dataOwnerStorageKey, getActiveAppSession } from '../appSessionState.js';
+import {
+  dataOwnerStorageKey,
+  getActiveAppSession,
+  isAppSessionBoundaryPending,
+} from '../appSessionState.js';
 
 const sqliteFactory: SqliteFactory = (filePath) => {
   // better-sqlite3 sync open. WAL 让多 session 并发读写更稳, busyTimeout 防小撞锁。
@@ -62,6 +66,10 @@ export function createDesktopMakerMemoryManager(): MakerMemoryManager {
   // owner 存储根: 有 owner → userData/owners/<hash>; 无 owner → null (fail-closed,
   // 不再退到 %TEMP%\cindy-no-session\<pid>\, 那是 #2341 静默丢失的根源)。
   const resolveBasePath = (): string | null => {
+    // 会话边界窗口 (beginAppSessionBoundary 已调、commitActiveAppSession 未落定)
+    // 期间 getActiveAppSession() 仍返回旧 owner — 此时也必须 fail-closed,
+    // 否则边界期读写会继续落旧账号 (review #2388 P1)。
+    if (isAppSessionBoundaryPending()) return null;
     const ownerId = getActiveAppSession().dataOwnerId;
     if (!ownerId) return null;
     return path.join(app.getPath('userData'), 'owners', dataOwnerStorageKey(ownerId));

--- a/apps/desktop/src/main/maker-host/maker-memory-host.ts
+++ b/apps/desktop/src/main/maker-host/maker-memory-host.ts
@@ -92,6 +92,11 @@ export function createDesktopMakerMemoryManager(): MakerMemoryManager {
     basePath: basePath ?? app.getPath('userData'),
     resolveBasePath,
     ownerScopeKey,
+    // owner 作用域变化（首次解析 / 换根）后按新 owner 根重新读取 enabled —
+    // 修复冷启动竞态里 initialEnabled 冻结为全局默认、owner 就绪后不重绑定的
+    // 问题 (review #2388 Codex 4th P1)。
+    reloadEnabled: () =>
+      readMemorySettings({ rootPath: resolveBasePath() ?? undefined }).maker,
     sqliteFactory,
     agents: {}, // 占位, attachAgents 补上
     logger: desktopMakerLogger.child('maker-memory'),

--- a/packages/lizi-mcps/src/__tests__/memoryErrors.test.ts
+++ b/packages/lizi-mcps/src/__tests__/memoryErrors.test.ts
@@ -1,13 +1,29 @@
 /**
- * memory/errors.ts 回归 — issue #2341:
+ * memory/errors.ts + _shared.ts 回归 — issue #2341:
  * manager 的 owner 作用域守卫抛的 memory:not-ready 必须翻译成
- * MAKER_MEMORY_NOT_READY, 与「真空库返回 ok+[]」在响应层面可区分。
+ * MAKER_MEMORY_NOT_READY, 与「真空库返回 ok+[]」在响应层面可区分;
+ * withStore 在 store 操作完成后复核 scope (review #2388 Codex 4th P1)。
  */
 
-import { MemoryError } from '@cindy/maker-core';
+import { MemoryError, type MakerMemoryManager } from '@cindy/maker-core';
 import { describe, expect, it } from 'vitest';
 
 import { classifyMemoryError } from '../memory/errors.js';
+import { withStore } from '../memory/_shared.js';
+import type { MemoryMcpDeps } from '../types.js';
+
+const mockStore = {
+  write: async () => ({ ok: true as const, filename: 'x.md' }),
+  list: async () => [],
+  delete: async () => ({ ok: true as const }),
+};
+
+function depsWithManager(manager: Partial<MakerMemoryManager>): MemoryMcpDeps {
+  return {
+    getManager: () => manager as MakerMemoryManager,
+    workdir: '/work',
+  };
+}
 
 describe('classifyMemoryError · owner not-ready (#2341)', () => {
   it('MemoryError("not-ready") → MAKER_MEMORY_NOT_READY', () => {
@@ -43,5 +59,45 @@ describe('classifyMemoryError · owner not-ready (#2341)', () => {
       'INVALID_PARAMS',
     );
     expect(classifyMemoryError(new Error('boom')).code).toBe('INTERNAL');
+  });
+});
+
+describe('withStore · 操作后 scope 复核 (review #2388 Codex 4th P1)', () => {
+  it('fn 执行期间 owner 切换 → 返回 MAKER_MEMORY_NOT_READY, 不按成功返回', async () => {
+    let scope = 'cloud:old:1';
+    const manager: Partial<MakerMemoryManager> = {
+      isEnabled: () => true,
+      getStore: async () => mockStore as never,
+      currentOwnerScopeKey: () => scope,
+    };
+    const deps = depsWithManager(manager);
+    // fn 执行中模拟登出/切账号: scope 前进
+    const result = await withStore(deps, async () => {
+      scope = 'cloud:new:2';
+      return mockStore.list();
+    });
+    expect((result.content[0] as { text?: string }).text ?? "").toContain('MAKER_MEMORY_NOT_READY');
+    expect(result.isError).toBe(true);
+  });
+
+  it('scope 未变 → 正常返回 ok+data (回归)', async () => {
+    const manager: Partial<MakerMemoryManager> = {
+      isEnabled: () => true,
+      getStore: async () => mockStore as never,
+      currentOwnerScopeKey: () => 'cloud:abc:1',
+    };
+    const result = await withStore(depsWithManager(manager), async (s) => s.list());
+    expect(result.isError).toBeUndefined();
+    expect((result.content[0] as { text?: string }).text ?? "").toContain('"ok": true');
+  });
+
+  it('manager 未提供 currentOwnerScopeKey (旧 host) → 不复核, 兼容', async () => {
+    const manager: Partial<MakerMemoryManager> = {
+      isEnabled: () => true,
+      getStore: async () => mockStore as never,
+    };
+    const result = await withStore(depsWithManager(manager), async (s) => s.list());
+    expect(result.isError).toBeUndefined();
+    expect((result.content[0] as { text?: string }).text ?? "").toContain('"ok": true');
   });
 });

--- a/packages/lizi-mcps/src/__tests__/memoryErrors.test.ts
+++ b/packages/lizi-mcps/src/__tests__/memoryErrors.test.ts
@@ -1,0 +1,47 @@
+/**
+ * memory/errors.ts 回归 — issue #2341:
+ * manager 的 owner 作用域守卫抛的 memory:not-ready 必须翻译成
+ * MAKER_MEMORY_NOT_READY, 与「真空库返回 ok+[]」在响应层面可区分。
+ */
+
+import { MemoryError } from '@cindy/maker-core';
+import { describe, expect, it } from 'vitest';
+
+import { classifyMemoryError } from '../memory/errors.js';
+
+describe('classifyMemoryError · owner not-ready (#2341)', () => {
+  it('MemoryError("not-ready") → MAKER_MEMORY_NOT_READY', () => {
+    const result = classifyMemoryError(
+      new MemoryError('not-ready', 'owner scope unavailable; refusing ephemeral fallback'),
+    );
+    expect(result.code).toBe('MAKER_MEMORY_NOT_READY');
+    expect(result.message).toMatch(/memory:not-ready/);
+  });
+
+  it('裸 Error 带 memory:not-ready 前缀 → MAKER_MEMORY_NOT_READY', () => {
+    const result = classifyMemoryError(
+      new Error('memory:not-ready owner scope unavailable (signed-out or auth not settled)'),
+    );
+    expect(result.code).toBe('MAKER_MEMORY_NOT_READY');
+  });
+
+  it('旧的 manager 状态错文案仍映射 NOT_READY (回归)', () => {
+    expect(classifyMemoryError(new Error('manager not ready: ...')).code).toBe(
+      'MAKER_MEMORY_NOT_READY',
+    );
+    expect(classifyMemoryError(new Error('maker memory disabled (mode != "maker")')).code).toBe(
+      'MAKER_MEMORY_NOT_READY',
+    );
+  });
+
+  it('其他 memory 错误码不受影响 (回归)', () => {
+    expect(classifyMemoryError(new MemoryError('not-found', 'x')).code).toBe('NOT_FOUND');
+    expect(classifyMemoryError(new MemoryError('already-exists', 'x')).code).toBe(
+      'ALREADY_EXISTS',
+    );
+    expect(classifyMemoryError(new MemoryError('shard-too-large', 'x')).code).toBe(
+      'INVALID_PARAMS',
+    );
+    expect(classifyMemoryError(new Error('boom')).code).toBe('INTERNAL');
+  });
+});

--- a/packages/lizi-mcps/src/memory/_shared.ts
+++ b/packages/lizi-mcps/src/memory/_shared.ts
@@ -35,6 +35,7 @@ export async function withStore(
   fn: (store: MakerMemoryStore) => Promise<unknown>,
 ): Promise<MemoryToolResult> {
   let store: MakerMemoryStore;
+  let scopeAtEntry: string | null = null;
   try {
     const manager = deps.getManager();
     if (!manager.isEnabled()) {
@@ -43,6 +44,10 @@ export async function withStore(
         true,
       );
     }
+    // 操作锚点 (review #2388 Codex 4th P1): getStore 返回的裸 store 在 manager
+    // 守卫之外被调用方 await — 在拿 store 前捕获 scope, fn 完成后复核, 期间
+    // 登出/切账号则操作结果不可信, fail-closed。
+    scopeAtEntry = manager.currentOwnerScopeKey?.() ?? null;
     const ctx = deps.getSessionContext?.();
     const workdir = ctx?.workingDir ?? deps.workdir;
     // SSH remote 会话 (ctx 带 remoteHostId) 的 workdir 是远端路径 — 经 scope
@@ -54,6 +59,17 @@ export async function withStore(
   }
   try {
     const data = await fn(store);
+    // 操作后复核: owner 在 fn 执行期间切换 → 结果不可信, 不得按成功返回。
+    if (scopeAtEntry !== null && deps.getManager().currentOwnerScopeKey?.() !== scopeAtEntry) {
+      return buildJsonResult(
+        {
+          ok: false,
+          code: 'MAKER_MEMORY_NOT_READY',
+          message: 'owner scope changed during memory operation; result not trusted',
+        },
+        true,
+      );
+    }
     return buildJsonResult({ ok: true, data });
   } catch (err) {
     const { code, message } = classifyMemoryError(err);

--- a/packages/lizi-mcps/src/memory/errors.ts
+++ b/packages/lizi-mcps/src/memory/errors.ts
@@ -47,6 +47,9 @@ export function classifyMemoryError(err: unknown): MemoryToolError {
       return { code: 'INVALID_PARAMS', message };
     }
     if (code === 'io-error') return { code: 'INTERNAL', message };
+    // owner 作用域守卫抛的 not-ready (见 manager.ts ensureOwnerScope) — 与
+    // 「真空库返回 ok+[]」可区分 (issue #2341)。
+    if (code === 'not-ready') return { code: 'MAKER_MEMORY_NOT_READY', message };
   }
   // manager 显式抛的两种状态错
   if (/manager not (?:available|ready|injected)|memory disabled/i.test(message)) {

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -381,4 +381,31 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     expect(viaWorkdir.removedCount).toBe(0);
     manager.dispose();
   });
+
+  it('isEnabled 读取前同步 scope, 不残留旧 owner flag (review Codex 11th P1)', async () => {
+    let currentScope = 'cloud:disabled:1'; // owner A: maker:false
+    let enabledForOwner = false;
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => currentScope,
+      reloadEnabled: () => enabledForOwner,
+      initialEnabled: false,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+    // 冷启动: owner 未就绪时 isEnabled 读的是初始值 (false) — withStore 会短路
+    expect(manager.isEnabled()).toBe(false);
+    // owner B 就绪且 maker:true: 无需任何 getStore, isEnabled 必须刷新
+    currentScope = 'cloud:enabled:2';
+    enabledForOwner = true;
+    expect(manager.isEnabled()).toBe(true);
+    // 反向: 切回 disabled owner, 再次同步
+    currentScope = 'cloud:disabled:3';
+    enabledForOwner = false;
+    expect(manager.isEnabled()).toBe(false);
+    manager.dispose();
+  });
 });

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -436,4 +436,28 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     expect(existsSync(memoryDirFor(rootA))).toBe(true);
     manager.dispose();
   });
+
+  it('resetAll 后旧 store 任何操作抛 not-ready, 不碰已关 db (review Greptile 20th P1)', async () => {
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => 'cloud:abc:1',
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+    const store = await manager.getStore(WORKDIR);
+    await store.write({
+      type: 'project', name: 'a', title: 'A', description: 'd', body: 'b',
+    });
+    // resetAll 完整执行 → 旧 store 的 db 已被 closeAllStores 关闭
+    await manager.resetAll();
+    // 调用方持有的旧世代 store: 读/搜均 fail-closed 抛 not-ready,
+    // 不得访问已关句柄抛裸 database is closed
+    await expect(store.list()).rejects.toThrow(/memory:not-ready/);
+    await expect(store.search('a')).rejects.toThrow(/memory:not-ready/);
+    await expect(store.getIndex()).rejects.toThrow(/memory:not-ready/);
+    manager.dispose();
+  });
 });

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -408,4 +408,32 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     expect(manager.isEnabled()).toBe(false);
     manager.dispose();
   });
+
+  it('resetAll 清空目录并重建 store (review Greptile 16th)', async () => {
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => 'cloud:abc:1',
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+    const storeA = await manager.getStore(WORKDIR);
+    await storeA.write({
+      type: 'project', name: 'a', title: 'A', description: 'd', body: 'b',
+    });
+    expect(existsSync(memoryDirFor(rootA))).toBe(true);
+
+    // resetAll: 开头关闭入口池 (避免 fs.rm EBUSY) + 并发拒绝 → 删除全部目录
+    const result = await manager.resetAll();
+    expect(result.removedCount).toBeGreaterThan(0);
+    expect(existsSync(memoryDirFor(rootA))).toBe(false);
+
+    // 再次 getStore: 池已清空 → 全新 store + 目录重建
+    const storeB = await manager.getStore(WORKDIR);
+    expect(storeB).not.toBe(storeA);
+    expect(existsSync(memoryDirFor(rootA))).toBe(true);
+    manager.dispose();
+  });
 });

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -176,4 +176,86 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     expect(sqlite.closes).toHaveLength(0);
     manager.dispose();
   });
+
+  // ── 异步竞态 (review #2388 P1) ──────────────────────────────────────────
+
+  it('getStore 异步 init 期间 owner 切换 → 抛 not-ready 且旧 store 不入池', async () => {
+    let currentRoot = rootA;
+    let currentScope = 'cloud:old:1';
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => currentRoot,
+      ownerScopeKey: () => currentScope,
+      sqliteFactory: (filePath) => {
+        // 模拟「初始化 await 窗口内 owner commit」: factory 在 mkdir 后、
+        // store.init 前被调用, 此时切换 scope/root 等效于窗口期切换账号。
+        currentRoot = rootB;
+        currentScope = 'cloud:new:2';
+        return sqlite.factory(filePath);
+      },
+      agents: {},
+      logger: noopLogger,
+    });
+
+    // 旧 owner 的 getStore 必须 fail-closed, 不得把旧 root store 提交入池
+    await expect(manager.getStore(WORKDIR)).rejects.toThrow(/memory:not-ready/);
+
+    // 当前 scope 已是 new/rootB: 后续 getStore 建在新根
+    const store = await manager.getStore(WORKDIR);
+    expect(store).toBeDefined();
+    expect(existsSync(memoryDirFor(rootB))).toBe(true);
+    manager.dispose();
+  });
+
+  it('owner 切换后 resetAll 扫新根, 不删旧 owner 数据', async () => {
+    let currentRoot = rootA;
+    let currentScope = 'cloud:old:1';
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => currentRoot,
+      ownerScopeKey: () => currentScope,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+
+    // 旧 owner 在 rootA 写入一条 memory
+    const storeA = await manager.getStore(WORKDIR);
+    await storeA.write({
+      type: 'project', name: 'keep', title: 'A', description: 'desc', body: 'content-A',
+    });
+    expect(existsSync(path.join(memoryDirFor(rootA), 'project_keep.md'))).toBe(true);
+
+    // 切换 owner → resetAll 入口 ensureOwnerScope 换根到 rootB, 只扫 rootB (空)
+    currentRoot = rootB;
+    currentScope = 'cloud:new:2';
+    const result = await manager.resetAll();
+    expect(result.removedCount).toBe(0);
+    // rootA (旧 owner) 数据完好
+    expect(existsSync(path.join(memoryDirFor(rootA), 'project_keep.md'))).toBe(true);
+    manager.dispose();
+  });
+
+  it('同 workdir 并发 getStore 复用池内实例, 多余 db 被关闭', async () => {
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => 'cloud:abc:1',
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+
+    const [s1, s2] = await Promise.all([
+      manager.getStore(WORKDIR),
+      manager.getStore(WORKDIR),
+    ]);
+    expect(s1).toBe(s2); // 池内单实例
+    // 后完成的那次打开了多余 db, 发现池中已有实例后必须关闭 (不泄漏句柄)
+    expect(sqlite.closes.length).toBeGreaterThan(0);
+    manager.dispose();
+  });
 });

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -314,6 +314,25 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     manager.dispose();
   });
 
+  it('store 级只读守卫: scope 变化后 getIndex 抛 not-ready (review Codex 6th P1)', async () => {
+    let currentScope = 'cloud:old:1';
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => currentScope,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+    const store = await manager.getStore(WORKDIR);
+    // session 启动路径: getStore().getIndex() 直接拼 prompt, 边界窗口不得注入旧 owner 索引
+    currentScope = 'cloud:new:2';
+    await expect(store.getIndex()).rejects.toThrow(/memory:not-ready/);
+    await expect(store.list()).rejects.toThrow(/memory:not-ready/);
+    manager.dispose();
+  });
+
   it('rebind 到 disabled owner 后 getStore fail-closed (review Codex 5th P1)', async () => {
     let currentScope = 'cloud:enabled:1';
     let enabledForOwner = true;

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -238,6 +238,39 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     manager.dispose();
   });
 
+  it('owner 切换后 resetDigests 用新根, 不动旧 owner digest 文件', async () => {
+    let currentRoot = rootA;
+    let currentScope = 'cloud:old:1';
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => currentRoot,
+      ownerScopeKey: () => currentScope,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+
+    // 旧 owner 在 rootA 写入一条 digest + 一条 curated
+    const storeA = await manager.getStore(WORKDIR);
+    await storeA.write({
+      type: 'digest', name: 'pi-drop', title: 'D', description: 'digest', body: 'summary',
+    });
+    await storeA.write({
+      type: 'project', name: 'keep', title: 'K', description: 'curated', body: 'content-K',
+    });
+    expect(existsSync(path.join(memoryDirFor(rootA), 'digest_pi-drop.md'))).toBe(true);
+
+    // 切换 owner → resetDigests 入口换根到 rootB (空), 不扫旧根
+    currentRoot = rootB;
+    currentScope = 'cloud:new:2';
+    const result = await manager.resetDigests();
+    expect(result.removedCount).toBe(0);
+    expect(existsSync(path.join(memoryDirFor(rootA), 'digest_pi-drop.md'))).toBe(true);
+    expect(existsSync(path.join(memoryDirFor(rootA), 'project_keep.md'))).toBe(true);
+    manager.dispose();
+  });
+
   it('同 workdir 并发 getStore 复用池内实例, 多余 db 被关闭', async () => {
     const sqlite = trackingSqlite();
     const manager = new MakerMemoryManager({

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -357,4 +357,28 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     await expect(manager.getStore(WORKDIR)).rejects.toThrow(/memory:not-ready/);
     manager.dispose();
   });
+
+  it('disabled owner 下 resetAll/resetWorkdir 仍可清空 (review Codex 10th P2)', async () => {
+    let currentScope = 'cloud:disabled:2';
+    let enabledForOwner = false;
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => currentScope,
+      reloadEnabled: () => enabledForOwner,
+      initialEnabled: false,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+    // 打开 store 被拒 (disabled) — 正常工具/会话路径
+    await expect(manager.getStore(WORKDIR)).rejects.toThrow(/memory:not-ready/);
+    // 清理路径仍允许: 用户关闭 memory 后要能删掉已有记忆
+    const viaManager = await manager.resetAll();
+    expect(viaManager.removedCount).toBe(0);
+    const viaWorkdir = await manager.resetWorkdir(WORKDIR);
+    expect(viaWorkdir.removedCount).toBe(0);
+    manager.dispose();
+  });
 });

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -291,4 +291,51 @@ describe('MakerMemoryManager · owner scope guard (#2341)', () => {
     expect(sqlite.closes.length).toBeGreaterThan(0);
     manager.dispose();
   });
+
+  it('store 级 mutation 前置守卫: scope 变化后 write 抛 not-ready (review Codex 5th P1)', async () => {
+    let currentScope = 'cloud:old:1';
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => currentScope,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+    const store = await manager.getStore(WORKDIR);
+    // 调用方拿到裸 store 后, owner 切换发生在 write 之前 — mutation 前置守卫拦截
+    currentScope = 'cloud:new:2';
+    await expect(
+      store.write({
+        type: 'project', name: 'x', title: 'X', description: 'd', body: 'b',
+      }),
+    ).rejects.toThrow(/memory:not-ready/);
+    manager.dispose();
+  });
+
+  it('rebind 到 disabled owner 后 getStore fail-closed (review Codex 5th P1)', async () => {
+    let currentScope = 'cloud:enabled:1';
+    let enabledForOwner = true;
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => currentScope,
+      reloadEnabled: () => enabledForOwner, // desktop: 按新 owner 根读 settings
+      initialEnabled: true,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+    // owner A: enabled → 正常拿到 store
+    const storeA = await manager.getStore(WORKDIR);
+    expect(storeA).toBeDefined();
+    // 切到关闭 maker memory 的 owner B: 调用方可能已持过期 enabled=true 快照,
+    // getStore 必须 fail-closed, 不得打开 B 的 store
+    currentScope = 'cloud:disabled:2';
+    enabledForOwner = false;
+    await expect(manager.getStore(WORKDIR)).rejects.toThrow(/memory:not-ready/);
+    manager.dispose();
+  });
 });

--- a/packages/maker-core/src/memory/manager.scope.test.ts
+++ b/packages/maker-core/src/memory/manager.scope.test.ts
@@ -1,0 +1,179 @@
+/**
+ * MakerMemoryManager owner 作用域守卫 — issue #2341 修复的回归测试:
+ *  - owner 缺失 (resolveBasePath → null) 必须 fail-closed 抛 memory:not-ready,
+ *    绝不创建/写入 %TEMP% 式临时目录 (静默丢失根源);
+ *  - ownerScopeKey 变化 (登录/登出/切账号) 必须关闭旧 store 池并重建到新根,
+ *    杜绝旧 db 句柄与新 owner 数据混用;
+ *  - 无 resolveBasePath/ownerScopeKey 的静态 basePath 宿主行为不变。
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import DatabaseCtor from 'better-sqlite3';
+import type Database from 'better-sqlite3';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { MakerMemoryManager } from './manager.js';
+import { memoryScopeDirName } from './storage.js';
+import type { Logger } from '../interfaces/logger.js';
+
+const noopLogger: Logger = {
+  trace: () => {}, debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, fatal: () => {},
+  child: () => noopLogger,
+};
+
+const WORKDIR = 'D:/repo/workdir';
+const SCOPE_DIR = memoryScopeDirName(WORKDIR); // Windows: 'D--repo-workdir'
+const memoryDirFor = (root: string) => path.join(root, 'maker-memory', SCOPE_DIR);
+
+let rootA: string;
+let rootB: string;
+
+beforeEach(async () => {
+  rootA = await mkdtemp(path.join(tmpdir(), 'memory-scope-a-'));
+  rootB = await mkdtemp(path.join(tmpdir(), 'memory-scope-b-'));
+});
+afterEach(async () => {
+  await rm(rootA, { recursive: true, force: true });
+  await rm(rootB, { recursive: true, force: true });
+});
+
+/** 真 better-sqlite3, 并统计每个 open 的 db 的 close 次数 */
+function trackingSqlite() {
+  const closes: number[] = [];
+  return {
+    closes,
+    factory: (filePath: string): Database.Database => {
+      const db = new DatabaseCtor(filePath);
+      const originalClose = db.close.bind(db);
+      db.close = () => {
+        closes.push(closes.length + 1);
+        originalClose();
+        return db; // better-sqlite3 声明 close(): this
+      };
+      return db;
+    },
+  };
+}
+
+describe('MakerMemoryManager · owner scope guard (#2341)', () => {
+  it('owner 缺失时 getStore 抛 memory:not-ready, 且不创建任何存储目录', async () => {
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => null, // 模拟 signed-out / 认证未落定
+      ownerScopeKey: () => 'signed-out:none:0',
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+
+    await expect(manager.getStore(WORKDIR)).rejects.toThrow(/memory:not-ready/);
+    // 止血: 不得落盘 — 连 maker-memory 根目录都不该出现
+    expect(existsSync(memoryDirFor(rootA))).toBe(false);
+    expect(existsSync(path.join(rootA, 'maker-memory'))).toBe(false);
+    expect(sqlite.closes).toHaveLength(0);
+  });
+
+  it('owner 缺失时 write / list 同路径 fail-closed (不经 getStore 成功)', async () => {
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => null,
+      ownerScopeKey: () => 'signed-out:none:0',
+      sqliteFactory: () => { throw new Error('must not open sqlite when owner missing'); },
+      agents: {},
+      logger: noopLogger,
+    });
+
+    await expect(
+      manager.write(WORKDIR, {
+        type: 'project',
+        name: 'leak',
+        title: '不应落盘',
+        description: 'owner 缺失时禁止写临时库',
+        body: 'xxx',
+      }),
+    ).rejects.toThrow(/memory:not-ready/);
+    expect(existsSync(memoryDirFor(rootA))).toBe(false);
+  });
+
+  it('scope 稳定时复用同一 store 实例 (行为回归)', async () => {
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => rootA,
+      ownerScopeKey: () => 'cloud:abc:1',
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+
+    const store1 = await manager.getStore(WORKDIR);
+    const store2 = await manager.getStore(WORKDIR);
+    expect(store1).toBe(store2); // 同 scope 复用池内实例
+    expect(sqlite.closes).toHaveLength(0); // 不应触发关闭
+    manager.dispose();
+  });
+
+  it('scope 变化时关闭旧 db 并重建到新根 (owner 提交/切换)', async () => {
+    let currentRoot = rootA;
+    let currentScope = 'signed-out:none:0';
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      resolveBasePath: () => currentRoot,
+      ownerScopeKey: () => currentScope,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+
+    // 首次 getStore → rootA 建库
+    const storeA = await manager.getStore(WORKDIR);
+    await storeA.write({
+      type: 'project', name: 'note', title: 'A', description: 'desc', body: 'content-A',
+    });
+    expect(existsSync(memoryDirFor(rootA))).toBe(true);
+
+    // owner 就绪/切换: root 与 scope 同时变化
+    currentRoot = rootB;
+    currentScope = 'cloud:abc:2';
+    const storeB = await manager.getStore(WORKDIR);
+
+    // 旧 store 的 db 已关闭, 新 store 指向新根且看不到旧数据
+    expect(sqlite.closes.length).toBeGreaterThan(0);
+    expect(storeB).not.toBe(storeA);
+    expect((await storeB.list()).length).toBe(0);
+    expect(existsSync(memoryDirFor(rootB))).toBe(true);
+
+    // 再写一条 → 落在新根 (验证没有写回旧 owner 的库)
+    await storeB.write({
+      type: 'project', name: 'note-b', title: 'B', description: 'desc', body: 'content-B',
+    });
+    expect(existsSync(path.join(memoryDirFor(rootA), 'project_note.md'))).toBe(true);
+    expect(existsSync(path.join(memoryDirFor(rootB), 'project_note-b.md'))).toBe(true);
+    manager.dispose();
+  });
+
+  it('无 resolveBasePath/ownerScopeKey 的静态 basePath 宿主行为不变 (回归)', async () => {
+    const sqlite = trackingSqlite();
+    const manager = new MakerMemoryManager({
+      basePath: rootA,
+      sqliteFactory: sqlite.factory,
+      agents: {},
+      logger: noopLogger,
+    });
+
+    const store = await manager.getStore(WORKDIR);
+    await store.write({
+      type: 'project', name: 'plain', title: 'P', description: 'desc', body: 'content-P',
+    });
+    expect((await store.list()).length).toBe(1);
+    expect(existsSync(memoryDirFor(rootA))).toBe(true);
+    expect(sqlite.closes).toHaveLength(0);
+    manager.dispose();
+  });
+});

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -458,9 +458,17 @@ export class MakerMemoryManager {
     // mkdir 在 storage.init() 里也会做, 但 db open 时父目录必须存在 — 提前 mkdir
     const fs = await import('node:fs');
     // await import 窗口后、mkdir/SQLite 打开前复核 (review #2388 Codex 22nd P2):
-    // rootAtEntry 捕获后边界可能发生 — 不得用旧 root 创建目录/打开 fts.db
-    // (首个守卫在 store.init 内, 对 mkdir/open 副作用来说太晚)。
+    // rootAtEntry 捕获后边界可能发生 — 不得用旧 root 创建目录/打开 fts.db。
+    // 同时复核 reset 屏障 (review #2388 Codex 24th P1): resetAll 可能在本调用
+    // 挂起于 import 时开始 — resetInFlight 在先前检查之后变正, scope-only 检查
+    // 会放行 mkdir/open, Windows 上阻塞并发 fs.rm / POSIX 返回被删目录的 store。
     this.assertScopeUnchanged(scopeAtEntry);
+    if (this.resetInFlight > 0) {
+      throw new MemoryError('not-ready', 'memory reset started; retry shortly');
+    }
+    if (this.poolGeneration !== generationAtEntry) {
+      throw new MemoryError('not-ready', 'memory reset completed; retry against current state');
+    }
     fs.mkdirSync(storageDir, { recursive: true });
 
     const db = this.deps.sqliteFactory(dbPath);

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -605,6 +605,9 @@ export class MakerMemoryManager {
     try {
       entries = await fs.readdir(memoryRoot);
     } catch {
+      // 异常早退路径也复核 (review #2388 Greptile 24th P1): readdir await 期间
+      // owner 切换 → 不得把部分完成的跨边界重置报为成功, 抛 not-ready 让调用方重试。
+      this.assertScopeUnchanged(scopeAtEntry);
       return { removedCount: total };
     }
     for (const entry of entries) {

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -490,6 +490,20 @@ export class MakerMemoryManager {
         'owner scope changed during store init; retry against current scope',
       );
     }
+    // 跨 await 复核: init 等待期间并发 resetAll 已开始 (review #2388 Greptile
+    // 18th P1) — 目标目录将被删除, 不得把指向它的 store 入池 (Windows 上 open
+    // 的 fts.db 还会阻塞目录删除 / 返回指向已删目录的实例)。
+    if (this.resetInFlight > 0) {
+      try {
+        db.close();
+      } catch {
+        /* swallow */
+      }
+      throw new MemoryError(
+        'not-ready',
+        'memory reset started during store init; retry against current state',
+      );
+    }
     // 并发去重: 同 workdir 的并发 getStore 可能已把 store 提交入池, 复用池内实例。
     // 仅复用同世代的 (resetAll 后旧世代条目先关闭, 由本调用重建覆盖)。
     const existing = this.stores.get(absWorkdir);

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -666,6 +666,10 @@ export class MakerMemoryManager {
       try {
         entries = await fs.readdir(memoryRoot);
       } catch {
+        // 空根/ENOENT 分支 (review #2388 Codex 21st P1): 也视为一次完成的 reset
+        // 尝试 — 必须 bump generation, 否则 init 中暂停的 getStore 恢复后通过
+        // generation 检查, 在用户可见的 reset 完成后写入新 memory。
+        this.poolGeneration += 1;
         return { removedCount: 0 };
       }
       for (const entry of entries) {
@@ -751,6 +755,9 @@ export class MakerMemoryManager {
     ].join('\n');
 
     const suggestions = await agent.oneShot(prompt, { maxTokens: 800, timeoutMs: 60_000 });
+    // oneShot await 后、返回前复核 (review #2388 Codex 21st P1): 边界在 LLM
+    // 调用期间发生则建议文本基于旧 owner 数据 — 不得向当前 session 报 ok。
+    this.assertScopeUnchanged(scopeAtEntry);
     return { suggestions };
   }
 

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -130,14 +130,15 @@ export class MakerMemoryManager {
    */
   private poolGeneration = 0;
   /**
-   * resetAll 进行中标志: 期间并发 getStore 一律拒绝 (not-ready)。
-   * 两个目的:
+   * resetAll 进行中**计数** (review #2388 Greptile 17th: 布尔标志在多并发
+   * resetAll 下会提前解除屏障): >0 期间并发 getStore 与 store 操作一律
+   * 拒绝 (not-ready)。用途:
    *  - 删除目录时池中 db 若仍打开 (better-sqlite3 占用 fts.db) 会 EBUSY —
    *    resetAll 开头 closeAllStores 清池, 期间拒绝新入池, 删除无占用;
-   *  - 消除 resetAll 与并发 getStore 同 workdir 的固有竞态 (Greptile 13th/16th
-   *    反复追的「清理实时池 vs 误关在用 store」在无并发时不再存在)。
+   *  - 在途 store 操作在下一复核点 (assertStoreOperable) 抛 not-ready 中止,
+   *    不再访问已被 closeAllStores 关闭的 db 句柄。
    */
-  private resetInFlight = false;
+  private resetInFlight = 0;
 
   constructor(private readonly deps: MakerMemoryManagerDeps) {
     this.enabled = deps.initialEnabled ?? false;
@@ -232,6 +233,22 @@ export class MakerMemoryManager {
       this.logger.info('maker memory enabled rebound after owner scope change', { enabled: next });
       this.enabled = next;
     }
+  }
+
+  /**
+   * store 操作复核点 (注入 store 的 scopeCheck, 每次公开操作/写盘前调用):
+   * 1. resetAll 进行中 → 抛 not-ready (review #2388 Greptile 17th): 在途操作
+   *    在下一复核点中止, 不再访问已被 closeAllStores 关闭的 db 句柄;
+   * 2. owner scope 变化 → 抛 not-ready (assertScopeUnchanged)。
+   */
+  private assertStoreOperable(scopeAtEntry: string | null): void {
+    if (this.resetInFlight > 0) {
+      throw new MemoryError(
+        'not-ready',
+        'memory reset in progress; store operation aborted',
+      );
+    }
+    this.assertScopeUnchanged(scopeAtEntry);
   }
 
   /** 关闭池内全部 db (作用域切换 / dispose / resetAll 共用)。幂等。 */
@@ -396,9 +413,9 @@ export class MakerMemoryManager {
         'maker memory disabled for current owner scope; refusing to open store',
       );
     }
-    // resetAll 进行中 (review #2388 Greptile 16th): 删除期间入池会导致目录被删后
-    // 残留失效条目 / EBUSY — 并发 getStore 一律拒绝, 调用方重试。
-    if (this.resetInFlight) {
+    // resetAll 进行中 (review #2388 Greptile 16th/17th): 删除期间入池会导致目录
+    // 被删后残留失效条目 / EBUSY — 并发 getStore 一律拒绝, 调用方重试。
+    if (this.resetInFlight > 0) {
       throw new MemoryError('not-ready', 'memory reset in progress; retry shortly');
     }
     const cached = this.stores.get(absWorkdir);
@@ -441,7 +458,7 @@ export class MakerMemoryManager {
       // 后置复核无法撤销已发生的写操作 —— 锚定 store 创建时 scope, 每次
       // write/delete/consolidate 前复核, scope 已变即抛 not-ready。
       ...(this.deps.ownerScopeKey
-        ? { scopeCheck: () => this.assertScopeUnchanged(scopeAtEntry) }
+        ? { scopeCheck: () => this.assertStoreOperable(scopeAtEntry) }
         : {}),
     });
     try {
@@ -591,8 +608,9 @@ export class MakerMemoryManager {
     // 竞态锚点 (review #2388 P1): 捕获 scope + root, 跨 await 不再 re-read 动态根;
     // 每次目录删除前复核, owner 已切换则中止, 绝不递归删新 owner 的 maker-memory。
     const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
-    // 置位并发拒绝 (review #2388 Greptile 16th): 删除期间不得有新 store 入池。
-    this.resetInFlight = true;
+    // 置位并发拒绝计数 (review #2388 Greptile 17th): 并发 resetAll 各自 +1,
+    // 较早结束的 -1 后仍 >0, 不会提前解除屏障。
+    this.resetInFlight += 1;
     try {
       // 先关闭并清空池 — 池中 db 打开着会占 fts.db 导致 fs.rm EBUSY;
       // 入口时已存在的 store 在清空语义下关闭合理 (已返回实例在 reset 后本就失效)。
@@ -641,7 +659,7 @@ export class MakerMemoryManager {
       this.poolGeneration += 1;
       return { removedCount: total };
     } finally {
-      this.resetInFlight = false;
+      this.resetInFlight -= 1;
     }
   }
 

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -541,6 +541,10 @@ export class MakerMemoryManager {
     // 每次目录删除前复核, owner 已切换则中止, 绝不递归删新 owner 的 maker-memory。
     const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
     const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
+    // 入口池快照 (review #2388 Greptile 12th): 删除 await 期间 owner 可能切换,
+    // 新 owner 的并发 getStore 会换根重建 store 入池 — 结尾只能关闭/移除**本
+    // 次操作开始时**的 entry, 绝不碰新加入的 store。
+    const storeSnapshot = [...this.stores.entries()];
     let total = 0;
     // 还没 open 的 workdir 文件也要清: 扫 basePath/maker-memory 下所有目录
     const fs = await import('node:fs/promises');
@@ -567,11 +571,13 @@ export class MakerMemoryManager {
         });
       }
     }
-    // 已 open 的 db 都失效了, 全部 close + 清池 — 下次 getStore 会重建
-    for (const { db } of this.stores.values()) {
+    // 仅关闭/移除入口快照内的 entry — 已失效 (旧 owner) 的 db 全部 close;
+    // 若 scope 未变则等价于清空池; 若已切换, 快照内 db 可能已被 closeAllStores
+    // 关闭 (幂等), 且**不得**动并发新加入的新 owner store。
+    for (const [workdir, { db }] of storeSnapshot) {
       try { db.close(); } catch { /* swallow */ }
+      if (this.stores.get(workdir)?.db === db) this.stores.delete(workdir);
     }
-    this.stores.clear();
     // 删除后复核 (review #2388 Greptile 5th): 目标 root 在入口已固定为操作开始时
     // owner (不会误删新 owner), 但删除期间 owner 若已切换, 结果不可信 ——
     // fail-closed 抛 not-ready, 调用方不得按「成功清空」对待。

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -185,6 +185,24 @@ export class MakerMemoryManager {
   }
 
   /**
+   * 跨 await 作用域复核 — owner 竞态守卫的第二道闸 (review #2388 P1):
+   * 异步操作 (getStore 的 store.init、resetAll/resetDigests 的 fs 操作) 期间
+   * owner 可能已提交/切换。用 ownerScopeKey() 的**实时值**与入口捕获的
+   * scopeAtEntry 比较 (不能依赖 activeScopeKey —— 它只在 ensureOwnerScope
+   * 被再次调用时才刷新), 不一致立即中止 fail-closed, 绝不把旧 owner 的结果
+   * 提交到新 owner 的池/文件系统。
+   */
+  private assertScopeUnchanged(scopeAtEntry: string | null): void {
+    if (!this.deps.ownerScopeKey) return;
+    if (this.deps.ownerScopeKey() !== scopeAtEntry) {
+      throw new MemoryError(
+        'not-ready',
+        'owner scope changed during async memory operation; aborting (retry against current scope)',
+      );
+    }
+  }
+
+  /**
    * Bootstrap-time agents 注入 — 解决"manager 需要 agents, agents 需要 manager"
    * 的鸡生蛋时序: manager 先建 (agents 传 {}) → agents 创建时拿 manager 引用 →
    * setAgents() 把 agents 挂回 manager。后续 enable() 才能遍历到。
@@ -296,10 +314,15 @@ export class MakerMemoryManager {
     const cached = this.stores.get(absWorkdir);
     if (cached) return cached.store;
 
+    // 异步初始化期间的竞态锚点 (review #2388 P1): 整个流程用入口捕获的 scope +
+    // root, 不再跨 await re-read 动态根; 完成后复核 scope 未变才提交入池。
+    const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
+    const rootAtEntry = this.resolvedBasePath!;
+
     // 目录名派生见 memoryScopeDirName:本地键 = sanitizeWorkdir 原规则 (不迁移),
     // 远端 ssh: 键 = 碰撞安全的 hash 形态 (review R4 P2)。
     const sanitized = memoryScopeDirName(absWorkdir);
-    const storageDir = path.join(this.resolvedBasePath!, MEMORY_SUBDIR, sanitized);
+    const storageDir = path.join(rootAtEntry, MEMORY_SUBDIR, sanitized);
     const dbPath = path.join(storageDir, FTS_DB_FILENAME);
 
     // mkdir 在 storage.init() 里也会做, 但 db open 时父目录必须存在 — 提前 mkdir
@@ -315,6 +338,33 @@ export class MakerMemoryManager {
       ...(this.deps.config ? { config: this.deps.config } : {}),
     });
     await store.init();
+    // 跨 await 复核: 期间 owner 已切换 → 丢弃刚建的旧 owner store, fail-closed,
+    // 绝不入池。用实时 ownerScopeKey() 比较 (不依赖 activeScopeKey 被刷新)。
+    if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
+      try {
+        db.close();
+      } catch {
+        /* swallow */
+      }
+      this.logger.warn('getStore aborted: owner scope changed during async init', {
+        scopeAtEntry,
+        activeScope: this.activeScopeKey,
+      });
+      throw new MemoryError(
+        'not-ready',
+        'owner scope changed during store init; retry against current scope',
+      );
+    }
+    // 并发去重: 同 workdir 的并发 getStore 可能已把 store 提交入池, 复用池内实例。
+    const existing = this.stores.get(absWorkdir);
+    if (existing) {
+      try {
+        db.close();
+      } catch {
+        /* swallow */
+      }
+      return existing.store;
+    }
     this.stores.set(absWorkdir, { store, db });
     this.logger.debug('memory store opened', { workdir: absWorkdir, sanitized });
     return store;
@@ -342,6 +392,10 @@ export class MakerMemoryManager {
    */
   async resetDigests(): Promise<{ removedCount: number }> {
     this.ensureOwnerScope();
+    // 竞态锚点 (review #2388 P1): 捕获 scope + root, 跨 await 不再 re-read 动态根;
+    // 每次 fs 写操作前复核, owner 已切换则中止, 绝不扫/删新 owner 的目录。
+    const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
+    const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
     let total = 0;
     const activeDirs = new Set<string>();
     for (const [workdir, { store }] of this.stores) {
@@ -350,7 +404,7 @@ export class MakerMemoryManager {
     }
 
     const fs = await import('node:fs/promises');
-    const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
+    this.assertScopeUnchanged(scopeAtEntry);
     let entries: string[];
     try {
       entries = await fs.readdir(memoryRoot);
@@ -363,6 +417,7 @@ export class MakerMemoryManager {
       let filenames: string[];
       try {
         if (!(await fs.stat(dir)).isDirectory()) continue;
+        this.assertScopeUnchanged(scopeAtEntry);
         filenames = await fs.readdir(dir);
       } catch {
         continue;
@@ -370,9 +425,11 @@ export class MakerMemoryManager {
       for (const filename of filenames) {
         if (parseFilename(filename)?.type !== 'digest') continue;
         try {
+          this.assertScopeUnchanged(scopeAtEntry);
           await fs.unlink(path.join(dir, filename));
           total += 1;
         } catch (error) {
+          if (error instanceof MemoryError && error.code === 'not-ready') throw error;
           this.logger.warn('resetDigests: failed to remove digest', {
             filename,
             error: String(error),
@@ -386,10 +443,14 @@ export class MakerMemoryManager {
   /** 清空所有 workdir 全部 memory. 慎用. */
   async resetAll(): Promise<{ removedCount: number }> {
     this.ensureOwnerScope();
+    // 竞态锚点 (review #2388 P1): 捕获 scope + root, 跨 await 不再 re-read 动态根;
+    // 每次目录删除前复核, owner 已切换则中止, 绝不递归删新 owner 的 maker-memory。
+    const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
+    const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
     let total = 0;
     // 还没 open 的 workdir 文件也要清: 扫 basePath/maker-memory 下所有目录
     const fs = await import('node:fs/promises');
-    const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
+    this.assertScopeUnchanged(scopeAtEntry);
     let entries: string[] = [];
     try {
       entries = await fs.readdir(memoryRoot);
@@ -401,9 +462,11 @@ export class MakerMemoryManager {
       try {
         const stat = await fs.stat(dir);
         if (!stat.isDirectory()) continue;
+        this.assertScopeUnchanged(scopeAtEntry);
         await fs.rm(dir, { recursive: true, force: true });
         total += 1;
       } catch (e) {
+        if (e instanceof MemoryError && e.code === 'not-ready') throw e;
         this.logger.warn('resetAll: failed to remove workdir memory dir', {
           dir,
           error: String(e),

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -27,6 +27,7 @@ import type Database from 'better-sqlite3';
 
 import { MakerMemoryStore, memoryScopeDirName, parseFilename } from './store.js';
 import {
+  MemoryError,
   type MemoryConfig,
   type WriteOptions,
 } from './types.js';
@@ -41,6 +42,24 @@ export type SqliteFactory = (filePath: string) => Database.Database;
 export interface MakerMemoryManagerDeps {
   /** Maker memory 文件根目录, host 注入 (e.g. <electron userData>/maker-memory) */
   basePath: string;
+  /**
+   * 动态解析当前 owner 作用域的存储根（desktop: 按 getActiveAppSession().dataOwnerId 现取）。
+   * 返回 null = owner 作用域不可用（signed-out / 认证未就绪 / 边界切换中），此时 manager
+   * 必须 fail-closed（抛 memory:not-ready），绝不降级写临时目录。
+   * 缺席 = 退化为静态 basePath（测试 / 无 owner 概念宿主）。
+   *
+   * 修复 #2341：构造时冻结 basePath 会让冷启动竞态把根锁死在
+   * %TEMP%\cindy-no-session\<pid>\ 且不再重解析 —— 每次访问都重新解析根，
+   * 配合 ownerScopeKey 在作用域变化时清池换根。
+   */
+  resolveBasePath?: () => string | null;
+  /**
+   * 当前 owner 作用域的不透明键（desktop: activeOwnerScopeKey 的脱敏形态，
+   * 含 mode + 脱敏 owner + generation）。每次 commit（登录/登出/切账号，generation+1）
+   * 都会变化：manager 检测到变化时先关闭全部旧 store db 再重建到新根，杜绝旧句柄
+   * 与新 owner 数据混用。缺席 = 不做作用域追踪（静态 basePath 宿主）。
+   */
+  ownerScopeKey?: () => string;
   /** SQLite open 工厂, host 注入 (better-sqlite3 是 native module, 不能在 maker-core require) */
   sqliteFactory: SqliteFactory;
   /** Agent 引用 — 强联动 setMemory(false) 关原生时用 */
@@ -89,6 +108,12 @@ export class MakerMemoryManager {
   private enabled: boolean;
   private readonly stores = new Map<string, PooledEntry>();
   private readonly logger: Logger;
+  /**
+   * 最近一次校验通过的 owner 作用域 key（deps.ownerScopeKey 的快照）。
+   * 变化时清池换根；null = 尚未校验过。仅用于相等性比较，日志已由 host
+   * 注入的 ownerScopeKey 保证脱敏（不落明文 owner id）。
+   */
+  private activeScopeKey: string | null = null;
 
   constructor(private readonly deps: MakerMemoryManagerDeps) {
     this.enabled = deps.initialEnabled ?? false;
@@ -98,6 +123,65 @@ export class MakerMemoryManager {
       basePath: deps.basePath,
       reviewAgent: deps.reviewAgent ?? 'claude-code',
     });
+  }
+
+  /**
+   * 当前生效的存储根: 优先动态 resolveBasePath (可为 null = owner 未就绪),
+   * 缺席时退化为静态 basePath。
+   *
+   * 注意不能用 `deps.resolveBasePath?.() ?? deps.basePath` —— resolveBasePath
+   * 返回 null 是「owner 不可用」的显式信号, `??` 会把 null 误当成未提供而
+   * 回退到静态 basePath, 让 fail-closed 守卫失效 (#2341)。
+   */
+  private get resolvedBasePath(): string | null {
+    return this.deps.resolveBasePath ? this.deps.resolveBasePath() : this.deps.basePath;
+  }
+
+  /**
+   * owner 作用域守卫 (每次 getStore / resetDigests / resetAll 前调用):
+   *  1. ownerScopeKey 变化 → 关闭旧 store 池全部 db, 重解析根 (修复 #2341 的
+   *     「启动期根冻结后不再重解析」);
+   *  2. resolveBasePath 返回 null → 抛 memory:not-ready, 绝不创建/写入临时目录
+   *     (修复「write 返回成功但数据落 %TEMP% 一次性目录」的静默丢失)。
+   *
+   * 抛出的 MemoryError 会被 MCP 层 classifyMemoryError 翻译成
+   * MAKER_MEMORY_NOT_READY, 与「空库返回 ok+[]」可区分。
+   */
+  private ensureOwnerScope(): void {
+    if (this.deps.ownerScopeKey) {
+      const key = this.deps.ownerScopeKey();
+      if (this.activeScopeKey === null) {
+        this.activeScopeKey = key;
+      } else if (key !== this.activeScopeKey) {
+        this.logger.warn('maker memory owner scope changed — closing stores and rebinding root', {
+          fromScope: this.activeScopeKey,
+          toScope: key,
+        });
+        this.closeAllStores();
+        this.activeScopeKey = key;
+      }
+    }
+    if (this.resolvedBasePath === null) {
+      this.logger.warn('maker memory owner scope unavailable — refusing ephemeral fallback', {
+        scopeKey: this.activeScopeKey,
+      });
+      throw new MemoryError(
+        'not-ready',
+        'owner scope unavailable (signed-out or auth not settled); refusing to fall back to ephemeral storage',
+      );
+    }
+  }
+
+  /** 关闭池内全部 db (作用域切换 / dispose / resetAll 共用)。幂等。 */
+  private closeAllStores(): void {
+    for (const [workdir, { db }] of this.stores) {
+      try {
+        db.close();
+      } catch (e) {
+        this.logger.warn('close store db failed', { workdir, error: String(e) });
+      }
+    }
+    this.stores.clear();
   }
 
   /**
@@ -207,13 +291,15 @@ export class MakerMemoryManager {
     if (!absWorkdir || absWorkdir.length === 0) {
       throw new Error('MakerMemoryManager.getStore: absWorkdir required');
     }
+    // owner 作用域守卫: 缺 owner 直接拒绝 (不建临时库), scope 变化则换根。
+    this.ensureOwnerScope();
     const cached = this.stores.get(absWorkdir);
     if (cached) return cached.store;
 
     // 目录名派生见 memoryScopeDirName:本地键 = sanitizeWorkdir 原规则 (不迁移),
     // 远端 ssh: 键 = 碰撞安全的 hash 形态 (review R4 P2)。
     const sanitized = memoryScopeDirName(absWorkdir);
-    const storageDir = path.join(this.deps.basePath, MEMORY_SUBDIR, sanitized);
+    const storageDir = path.join(this.resolvedBasePath!, MEMORY_SUBDIR, sanitized);
     const dbPath = path.join(storageDir, FTS_DB_FILENAME);
 
     // mkdir 在 storage.init() 里也会做, 但 db open 时父目录必须存在 — 提前 mkdir
@@ -255,6 +341,7 @@ export class MakerMemoryManager {
    * MEMORY.md，因此无需改写用户索引。
    */
   async resetDigests(): Promise<{ removedCount: number }> {
+    this.ensureOwnerScope();
     let total = 0;
     const activeDirs = new Set<string>();
     for (const [workdir, { store }] of this.stores) {
@@ -263,7 +350,7 @@ export class MakerMemoryManager {
     }
 
     const fs = await import('node:fs/promises');
-    const memoryRoot = path.join(this.deps.basePath, MEMORY_SUBDIR);
+    const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
     let entries: string[];
     try {
       entries = await fs.readdir(memoryRoot);
@@ -298,10 +385,11 @@ export class MakerMemoryManager {
 
   /** 清空所有 workdir 全部 memory. 慎用. */
   async resetAll(): Promise<{ removedCount: number }> {
+    this.ensureOwnerScope();
     let total = 0;
     // 还没 open 的 workdir 文件也要清: 扫 basePath/maker-memory 下所有目录
     const fs = await import('node:fs/promises');
-    const memoryRoot = path.join(this.deps.basePath, MEMORY_SUBDIR);
+    const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
     let entries: string[] = [];
     try {
       entries = await fs.readdir(memoryRoot);
@@ -383,14 +471,7 @@ export class MakerMemoryManager {
 
   /** Maker.shutdown 调 (跟 agent.dispose 同时机). 关闭所有 db, 清池. 幂等. */
   dispose(): void {
-    for (const [workdir, { db }] of this.stores) {
-      try {
-        db.close();
-      } catch (e) {
-        this.logger.warn('dispose: db close failed', { workdir, error: String(e) });
-      }
-    }
-    this.stores.clear();
+    this.closeAllStores();
     this.logger.info('MakerMemoryManager disposed');
   }
 }

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -563,6 +563,19 @@ export class MakerMemoryManager {
         this.assertScopeUnchanged(scopeAtEntry);
         await fs.rm(dir, { recursive: true, force: true });
         total += 1;
+        // 目录已删 — 池中指向它的 store 全部失效 (review #2388 Greptile 13th):
+        // 删除 await 期间同 owner 的并发 getStore 可能打开该 workdir 入池,
+        // 快照清理碰不到它, 这里按 sanitized 目录名匹配实时池移除, 防止后续
+        // getStore 复用指向已删目录的条目。
+        for (const [workdirKey, { db: staleDb }] of [...this.stores]) {
+          if (memoryScopeDirName(workdirKey) !== entry) continue;
+          try {
+            staleDb.close();
+          } catch {
+            /* swallow */
+          }
+          this.stores.delete(workdirKey);
+        }
       } catch (e) {
         if (e instanceof MemoryError && e.code === 'not-ready') throw e;
         this.logger.warn('resetAll: failed to remove workdir memory dir', {

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -106,6 +106,8 @@ export interface SetEnabledResult {
 interface PooledEntry {
   store: MakerMemoryStore;
   db: Database.Database;
+  /** 入池时的池世代 — resetAll 后 +1, getStore 命中旧世代时惰性关闭重建 */
+  generation: number;
 }
 
 const MEMORY_SUBDIR = 'maker-memory';
@@ -121,6 +123,21 @@ export class MakerMemoryManager {
    * 注入的 ownerScopeKey 保证脱敏（不落明文 owner id）。
    */
   private activeScopeKey: string | null = null;
+  /**
+   * 池世代 (review #2388 Greptile 16th): resetAll 清空全部 workdir 后 +1,
+   * 池内所有旧世代 store 惰性失效 — getStore 命中旧世代时 close + 重建。
+   * 不立即关闭任何 store: 已返回给调用方的实例 (可能正在使用) 不被误伤。
+   */
+  private poolGeneration = 0;
+  /**
+   * resetAll 进行中标志: 期间并发 getStore 一律拒绝 (not-ready)。
+   * 两个目的:
+   *  - 删除目录时池中 db 若仍打开 (better-sqlite3 占用 fts.db) 会 EBUSY —
+   *    resetAll 开头 closeAllStores 清池, 期间拒绝新入池, 删除无占用;
+   *  - 消除 resetAll 与并发 getStore 同 workdir 的固有竞态 (Greptile 13th/16th
+   *    反复追的「清理实时池 vs 误关在用 store」在无并发时不再存在)。
+   */
+  private resetInFlight = false;
 
   constructor(private readonly deps: MakerMemoryManagerDeps) {
     this.enabled = deps.initialEnabled ?? false;
@@ -379,8 +396,23 @@ export class MakerMemoryManager {
         'maker memory disabled for current owner scope; refusing to open store',
       );
     }
+    // resetAll 进行中 (review #2388 Greptile 16th): 删除期间入池会导致目录被删后
+    // 残留失效条目 / EBUSY — 并发 getStore 一律拒绝, 调用方重试。
+    if (this.resetInFlight) {
+      throw new MemoryError('not-ready', 'memory reset in progress; retry shortly');
+    }
     const cached = this.stores.get(absWorkdir);
-    if (cached) return cached.store;
+    if (cached) {
+      // 旧世代 (resetAll 后) 的缓存条目惰性失效: close + 移除, 走重建;
+      // 不立即关闭已返回给调用方的实例 (review #2388 Greptile 16th)。
+      if (cached.generation === this.poolGeneration) return cached.store;
+      try {
+        cached.db.close();
+      } catch {
+        /* swallow */
+      }
+      this.stores.delete(absWorkdir);
+    }
 
     // 异步初始化期间的竞态锚点 (review #2388 P1): 整个流程用入口捕获的 scope +
     // root, 不再跨 await re-read 动态根; 完成后复核 scope 未变才提交入池。
@@ -442,16 +474,24 @@ export class MakerMemoryManager {
       );
     }
     // 并发去重: 同 workdir 的并发 getStore 可能已把 store 提交入池, 复用池内实例。
+    // 仅复用同世代的 (resetAll 后旧世代条目先关闭, 由本调用重建覆盖)。
     const existing = this.stores.get(absWorkdir);
     if (existing) {
+      if (existing.generation === this.poolGeneration) {
+        try {
+          db.close();
+        } catch {
+          /* swallow */
+        }
+        return existing.store;
+      }
       try {
-        db.close();
+        existing.db.close();
       } catch {
         /* swallow */
       }
-      return existing.store;
     }
-    this.stores.set(absWorkdir, { store, db });
+    this.stores.set(absWorkdir, { store, db, generation: this.poolGeneration });
     this.logger.debug('memory store opened', { workdir: absWorkdir, sanitized });
     return store;
   }
@@ -551,74 +591,58 @@ export class MakerMemoryManager {
     // 竞态锚点 (review #2388 P1): 捕获 scope + root, 跨 await 不再 re-read 动态根;
     // 每次目录删除前复核, owner 已切换则中止, 绝不递归删新 owner 的 maker-memory。
     const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
-    const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
-    // 入口池快照 (review #2388 Greptile 12th): 删除 await 期间 owner 可能切换,
-    // 新 owner 的并发 getStore 会换根重建 store 入池 — 结尾只能关闭/移除**本
-    // 次操作开始时**的 entry, 绝不碰新加入的 store。
-    const storeSnapshot = [...this.stores.entries()];
-    let total = 0;
-    // 还没 open 的 workdir 文件也要清: 扫 basePath/maker-memory 下所有目录
-    const fs = await import('node:fs/promises');
-    this.assertScopeUnchanged(scopeAtEntry);
-    let entries: string[] = [];
+    // 置位并发拒绝 (review #2388 Greptile 16th): 删除期间不得有新 store 入池。
+    this.resetInFlight = true;
     try {
-      entries = await fs.readdir(memoryRoot);
-    } catch {
-      return { removedCount: 0 };
-    }
-    for (const entry of entries) {
-      const dir = path.join(memoryRoot, entry);
+      // 先关闭并清空池 — 池中 db 打开着会占 fts.db 导致 fs.rm EBUSY;
+      // 入口时已存在的 store 在清空语义下关闭合理 (已返回实例在 reset 后本就失效)。
+      this.closeAllStores();
+      const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
+      let total = 0;
+      // 还没 open 的 workdir 文件也要清: 扫 basePath/maker-memory 下所有目录
+      const fs = await import('node:fs/promises');
+      this.assertScopeUnchanged(scopeAtEntry);
+      let entries: string[] = [];
       try {
-        const stat = await fs.stat(dir);
-        if (!stat.isDirectory()) continue;
-        this.assertScopeUnchanged(scopeAtEntry);
-        await fs.rm(dir, { recursive: true, force: true });
-        total += 1;
-        // 目录已删 — 池中指向它的 store 全部失效 (review #2388 Greptile 13th):
-        // 删除 await 期间同 owner 的并发 getStore 可能打开该 workdir 入池,
-        // 快照清理碰不到它, 这里按 sanitized 目录名匹配实时池移除, 防止后续
-        // getStore 复用指向已删目录的条目。
-        // 先复核 scope (review #2388 Greptile 14th): fs.rm 的 await 窗口后若
-        // owner 已切换 (换根清池, 新 owner 的并发 getStore 可能同 workdir 入池),
-        // 不得按目录名关闭/移除新 owner 正在使用的 store — 立即中止 fail-closed。
-        this.assertScopeUnchanged(scopeAtEntry);
-        for (const [workdirKey, { db: staleDb }] of [...this.stores]) {
-          if (memoryScopeDirName(workdirKey) !== entry) continue;
-          try {
-            staleDb.close();
-          } catch {
-            /* swallow */
-          }
-          this.stores.delete(workdirKey);
-        }
-      } catch (e) {
-        if (e instanceof MemoryError && e.code === 'not-ready') throw e;
-        this.logger.warn('resetAll: failed to remove workdir memory dir', {
-          dir,
-          error: String(e),
-        });
+        entries = await fs.readdir(memoryRoot);
+      } catch {
+        return { removedCount: 0 };
       }
+      for (const entry of entries) {
+        const dir = path.join(memoryRoot, entry);
+        try {
+          const stat = await fs.stat(dir);
+          if (!stat.isDirectory()) continue;
+          this.assertScopeUnchanged(scopeAtEntry);
+          await fs.rm(dir, { recursive: true, force: true });
+          total += 1;
+        } catch (e) {
+          if (e instanceof MemoryError && e.code === 'not-ready') throw e;
+          this.logger.warn('resetAll: failed to remove workdir memory dir', {
+            dir,
+            error: String(e),
+          });
+        }
+      }
+      // 删除后复核 (review #2388 Greptile 5th): 目标 root 在入口已固定为操作开始时
+      // owner (不会误删新 owner), 但删除期间 owner 若已切换, 结果不可信 ——
+      // fail-closed 抛 not-ready, 调用方不得按「成功清空」对待。
+      if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
+        this.logger.warn('resetAll crossed owner boundary; aborting as not-ready', {
+          scopeAtEntry,
+        });
+        throw new MemoryError(
+          'not-ready',
+          'owner scope changed during resetAll; result is partial and must not be trusted',
+        );
+      }
+      // 池世代兜底失效 (review #2388 Greptile 13th/16th): 即使有漏网旧条目,
+      // getStore 命中旧世代也会 close + 重建, 不残留指向已删目录的条目。
+      this.poolGeneration += 1;
+      return { removedCount: total };
+    } finally {
+      this.resetInFlight = false;
     }
-    // 仅关闭/移除入口快照内的 entry — 已失效 (旧 owner) 的 db 全部 close;
-    // 若 scope 未变则等价于清空池; 若已切换, 快照内 db 可能已被 closeAllStores
-    // 关闭 (幂等), 且**不得**动并发新加入的新 owner store。
-    for (const [workdir, { db }] of storeSnapshot) {
-      try { db.close(); } catch { /* swallow */ }
-      if (this.stores.get(workdir)?.db === db) this.stores.delete(workdir);
-    }
-    // 删除后复核 (review #2388 Greptile 5th): 目标 root 在入口已固定为操作开始时
-    // owner (不会误删新 owner), 但删除期间 owner 若已切换, 结果不可信 ——
-    // fail-closed 抛 not-ready, 调用方不得按「成功清空」对待。
-    if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
-      this.logger.warn('resetAll crossed owner boundary; aborting as not-ready', {
-        scopeAtEntry,
-      });
-      throw new MemoryError(
-        'not-ready',
-        'owner scope changed during resetAll; result is partial and must not be trusted',
-      );
-    }
-    return { removedCount: total };
   }
 
   // ── Review (LLM 自审) ────────────────────────────────────────────────────

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -412,7 +412,18 @@ export class MakerMemoryManager {
         ? { scopeCheck: () => this.assertScopeUnchanged(scopeAtEntry) }
         : {}),
     });
-    await store.init();
+    try {
+      await store.init();
+    } catch (e) {
+      // init 内 (storage.init 写 meta.json 前守卫 / fts 初始化) 可能已因 scope
+      // 变化抛 not-ready — 关闭刚开的 db 防止句柄泄漏, 再重新抛出。
+      try {
+        db.close();
+      } catch {
+        /* swallow */
+      }
+      throw e;
+    }
     // 跨 await 复核: 期间 owner 已切换 → 丢弃刚建的旧 owner store, fail-closed,
     // 绝不入池。用实时 ownerScopeKey() 比较 (不依赖 activeScopeKey 被刷新)。
     if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
@@ -567,6 +578,10 @@ export class MakerMemoryManager {
         // 删除 await 期间同 owner 的并发 getStore 可能打开该 workdir 入池,
         // 快照清理碰不到它, 这里按 sanitized 目录名匹配实时池移除, 防止后续
         // getStore 复用指向已删目录的条目。
+        // 先复核 scope (review #2388 Greptile 14th): fs.rm 的 await 窗口后若
+        // owner 已切换 (换根清池, 新 owner 的并发 getStore 可能同 workdir 入池),
+        // 不得按目录名关闭/移除新 owner 正在使用的 store — 立即中止 fail-closed。
+        this.assertScopeUnchanged(scopeAtEntry);
         for (const [workdirKey, { db: staleDb }] of [...this.stores]) {
           if (memoryScopeDirName(workdirKey) !== entry) continue;
           try {

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -399,6 +399,10 @@ export class MakerMemoryManager {
     let total = 0;
     const activeDirs = new Set<string>();
     for (const [workdir, { store }] of this.stores) {
+      // 迭代前复核 (review #2388 第三轮 P1): resetType 自身 await (list/delete),
+      // 期间 owner 切换会使本循环持有的 store 被 closeAllStores 关闭 —— 必须先
+      // 复核再操作, 不得在切换后继续用已失效的 store。
+      this.assertScopeUnchanged(scopeAtEntry);
       activeDirs.add(memoryScopeDirName(workdir));
       total += (await store.resetType('digest')).removedCount;
     }

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -457,6 +457,10 @@ export class MakerMemoryManager {
 
     // mkdir 在 storage.init() 里也会做, 但 db open 时父目录必须存在 — 提前 mkdir
     const fs = await import('node:fs');
+    // await import 窗口后、mkdir/SQLite 打开前复核 (review #2388 Codex 22nd P2):
+    // rootAtEntry 捕获后边界可能发生 — 不得用旧 root 创建目录/打开 fts.db
+    // (首个守卫在 store.init 内, 对 mkdir/open 副作用来说太晚)。
+    this.assertScopeUnchanged(scopeAtEntry);
     fs.mkdirSync(storageDir, { recursive: true });
 
     const db = this.deps.sqliteFactory(dbPath);

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -60,6 +60,13 @@ export interface MakerMemoryManagerDeps {
    * 与新 owner 数据混用。缺席 = 不做作用域追踪（静态 basePath 宿主）。
    */
   ownerScopeKey?: () => string;
+  /**
+   * owner 作用域变化（首次解析 / 换根）后重新读取 enabled 初值的回调
+   * （desktop: 按新 owner 根读 memory-settings.json）。修复冷启动竞态里
+   * initialEnabled 在 owner 未就绪时冻结为全局默认、owner 就绪后不重绑定的
+   * 问题（#2388 review Codex 4th P1）。缺席 = 不重绑定（静态宿主）。
+   */
+  reloadEnabled?: () => boolean;
   /** SQLite open 工厂, host 注入 (better-sqlite3 是 native module, 不能在 maker-core require) */
   sqliteFactory: SqliteFactory;
   /** Agent 引用 — 强联动 setMemory(false) 关原生时用 */
@@ -151,7 +158,10 @@ export class MakerMemoryManager {
     if (this.deps.ownerScopeKey) {
       const key = this.deps.ownerScopeKey();
       if (this.activeScopeKey === null) {
+        // 首次解析 — 构造期 owner 可能尚未就绪 (initialEnabled 是全局默认),
+        // 这里锚定 scope 的同时按当前 owner 重绑定 enabled。
         this.activeScopeKey = key;
+        this.rebindEnabled();
       } else if (key !== this.activeScopeKey) {
         this.logger.warn('maker memory owner scope changed — closing stores and rebinding root', {
           fromScope: this.activeScopeKey,
@@ -159,6 +169,7 @@ export class MakerMemoryManager {
         });
         this.closeAllStores();
         this.activeScopeKey = key;
+        this.rebindEnabled();
       }
     }
     if (this.resolvedBasePath === null) {
@@ -169,6 +180,26 @@ export class MakerMemoryManager {
         'not-ready',
         'owner scope unavailable (signed-out or auth not settled); refusing to fall back to ephemeral storage',
       );
+    }
+  }
+
+  /**
+   * 当前 owner 作用域键的公开只读快照 — 供 MCP 工具层 (withStore) 在拿到
+   * store 后、对 store 发起 await 操作前捕获 / 操作后复核 (review #2388
+   * Codex 4th P1: getStore 返回的裸 store 在 manager 守卫之外被调用方使用)。
+   * 返回 null = 未注入 ownerScopeKey (静态宿主)。
+   */
+  currentOwnerScopeKey(): string | null {
+    return this.deps.ownerScopeKey?.() ?? null;
+  }
+
+  /** owner 作用域变化时按新 owner 设置重绑定 enabled (host 注入 reloadEnabled)。 */
+  private rebindEnabled(): void {
+    if (!this.deps.reloadEnabled) return;
+    const next = this.deps.reloadEnabled();
+    if (next !== this.enabled) {
+      this.logger.info('maker memory enabled rebound after owner scope change', { enabled: next });
+      this.enabled = next;
     }
   }
 
@@ -444,13 +475,17 @@ export class MakerMemoryManager {
         }
       }
     }
-    // 删除后复核 (review #2388 Greptile 4th): 目标 root 在入口已固定为操作开始时
-    // owner, 执行期间切换不改变删除对象 (旧 owner 数据), 但记录日志让「跨边界、
-    // 结果可能不完整」可观测。
+    // 删除后复核 (review #2388 Greptile 5th): 目标 root 在入口已固定为操作开始时
+    // owner (不会误删新 owner), 但删除期间 owner 若已切换, 结果不可信 ——
+    // fail-closed 抛 not-ready, 调用方不得按「成功清空」对待。
     if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
-      this.logger.warn('resetDigests crossed owner boundary; target fixed to scope at entry (result may be partial)', {
+      this.logger.warn('resetDigests crossed owner boundary; aborting as not-ready', {
         scopeAtEntry,
       });
+      throw new MemoryError(
+        'not-ready',
+        'owner scope changed during resetDigests; result is partial and must not be trusted',
+      );
     }
     return { removedCount: total };
   }
@@ -493,13 +528,17 @@ export class MakerMemoryManager {
       try { db.close(); } catch { /* swallow */ }
     }
     this.stores.clear();
-    // 删除后复核 (review #2388 Greptile 4th): 目标 root 在入口已固定为操作开始时
-    // owner, 执行期间切换不改变删除对象 (旧 owner 数据), 但记录日志让「跨边界、
-    // 结果可能不完整」可观测。
+    // 删除后复核 (review #2388 Greptile 5th): 目标 root 在入口已固定为操作开始时
+    // owner (不会误删新 owner), 但删除期间 owner 若已切换, 结果不可信 ——
+    // fail-closed 抛 not-ready, 调用方不得按「成功清空」对待。
     if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
-      this.logger.warn('resetAll crossed owner boundary; target fixed to scope at entry (result may be partial)', {
+      this.logger.warn('resetAll crossed owner boundary; aborting as not-ready', {
         scopeAtEntry,
       });
+      throw new MemoryError(
+        'not-ready',
+        'owner scope changed during resetAll; result is partial and must not be trusted',
+      );
     }
     return { removedCount: total };
   }

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -172,17 +172,11 @@ export class MakerMemoryManager {
         this.rebindEnabled();
       }
       // 换根/首次锚定后新 owner 若关闭了 maker memory (enabled=false), 调用方
-      // 可能已持过期的 isEnabled()=true 通过检查 (withStore / session opts 快照)
-      // — 这里必须 fail-closed, 不得继续打开新 owner 的 store (review #2388
-      // Codex 5th P1: rebind 到 disabled owner 后应立即停止)。
-      // 仅在 host 提供 reloadEnabled (desktop) 时判定: 静态宿主/测试无 rebind
-      // 语义, initialEnabled=false 属正常 disabled 态, 由调用方 isEnabled 拦截。
-      if (this.deps.reloadEnabled && !this.enabled) {
-        throw new MemoryError(
-          'not-ready',
-          'maker memory disabled for current owner scope; refusing to open store',
-        );
-      }
+      // 可能已持过期的 isEnabled()=true 通过检查 — 打开 store 路径必须
+      // fail-closed (见 getStore 的 disabled 检查)。
+      // 注意 disabled 检查**不**放在这里: resetAll/resetDigests 等清理路径也走
+      // ensureOwnerScope, 用户关闭 memory 后仍需能清空已有记忆 — 重置入口按
+      // 「不论 makerEnabled 值都能清」语义工作 (review #2388 Codex 10th P2)。
     }
     if (this.resolvedBasePath === null) {
       this.logger.warn('maker memory owner scope unavailable — refusing ephemeral fallback', {
@@ -347,13 +341,30 @@ export class MakerMemoryManager {
    * key 语义: 本地会话传 workdir 绝对路径; SSH remote 会话传
    * buildMemoryScopeKey 产出的 `ssh:<hostId>:<path>` 复合键 (调用方负责,
    * manager 不自己判远端) — 见 storage.ts buildMemoryScopeKey。
+   *
+   * opts.skipDisabledCheck: 清理路径 (resetWorkdir) 用 — 用户关闭 maker memory
+   * 后仍需能清空已有记忆, 重置入口按「不论 makerEnabled 值都能清」语义工作
+   * (review #2388 Codex 10th P2)。
    */
-  async getStore(absWorkdir: string): Promise<MakerMemoryStore> {
+  async getStore(
+    absWorkdir: string,
+    opts?: { skipDisabledCheck?: boolean },
+  ): Promise<MakerMemoryStore> {
     if (!absWorkdir || absWorkdir.length === 0) {
       throw new Error('MakerMemoryManager.getStore: absWorkdir required');
     }
     // owner 作用域守卫: 缺 owner 直接拒绝 (不建临时库), scope 变化则换根。
     this.ensureOwnerScope();
+    // 打开 store 路径的 disabled 检查 (review #2388 Codex 5th P1): 调用方
+    // 可能已持过期 isEnabled()=true 快照 (withStore / session opts) 通过检查,
+    // 换根后 enabled=false 不得继续打开新 owner store; 仅 host 提供
+    // reloadEnabled 时判定 (静态宿主无 rebind 语义, disabled 由 isEnabled 拦)。
+    if (!opts?.skipDisabledCheck && this.deps.reloadEnabled && !this.enabled) {
+      throw new MemoryError(
+        'not-ready',
+        'maker memory disabled for current owner scope; refusing to open store',
+      );
+    }
     const cached = this.stores.get(absWorkdir);
     if (cached) return cached.store;
 
@@ -427,9 +438,9 @@ export class MakerMemoryManager {
 
   // ── 重置 ─────────────────────────────────────────────────────────────────
 
-  /** 清空某 workdir 全部 memory (UI 调) */
+  /** 清空某 workdir 全部 memory (UI 调) — 清理路径, 绕过 disabled 检查 */
   async resetWorkdir(absWorkdir: string): Promise<{ removedCount: number }> {
-    const store = await this.getStore(absWorkdir);
+    const store = await this.getStore(absWorkdir, { skipDisabledCheck: true });
     return store.resetAll();
   }
 

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -572,6 +572,10 @@ export class MakerMemoryManager {
    * write/delete tool, 保留可观测性。manager 只是 "起一次审查 LLM 调用" 的入口。
    */
   async runReview(absWorkdir: string): Promise<{ suggestions: string }> {
+    // 竞态锚点 (review #2388 Codex 9th P1): 读记录与发 oneShot 之间有 await
+    // (isOneShotRouteDisabled / agent 派发), 边界窗口内不得把旧 owner 的
+    // memory dump 发给 review LLM — 构造/发送 prompt 前复核 scope。
+    const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
     const store = await this.getStore(absWorkdir);
     const records = await store.list();
     if (records.length === 0) {
@@ -587,6 +591,8 @@ export class MakerMemoryManager {
         `runReview: one-shot route for '${reviewAgentKind}' is disabled in settings`,
       );
     }
+    // 发送前复核: 边界已切换则丢弃旧 owner 的 records, fail-closed。
+    this.assertScopeUnchanged(scopeAtEntry);
 
     const summary = records
       .map((r) => `### ${r.filename}\n- title: ${r.frontmatter.title}\n- description: ${r.frontmatter.description}\n- updatedAt: ${r.frontmatter.updatedAt}\n\n${r.body}`)

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -171,6 +171,18 @@ export class MakerMemoryManager {
         this.activeScopeKey = key;
         this.rebindEnabled();
       }
+      // 换根/首次锚定后新 owner 若关闭了 maker memory (enabled=false), 调用方
+      // 可能已持过期的 isEnabled()=true 通过检查 (withStore / session opts 快照)
+      // — 这里必须 fail-closed, 不得继续打开新 owner 的 store (review #2388
+      // Codex 5th P1: rebind 到 disabled owner 后应立即停止)。
+      // 仅在 host 提供 reloadEnabled (desktop) 时判定: 静态宿主/测试无 rebind
+      // 语义, initialEnabled=false 属正常 disabled 态, 由调用方 isEnabled 拦截。
+      if (this.deps.reloadEnabled && !this.enabled) {
+        throw new MemoryError(
+          'not-ready',
+          'maker memory disabled for current owner scope; refusing to open store',
+        );
+      }
     }
     if (this.resolvedBasePath === null) {
       this.logger.warn('maker memory owner scope unavailable — refusing ephemeral fallback', {
@@ -367,6 +379,13 @@ export class MakerMemoryManager {
       db,
       logger: this.logger.child(`memory:${sanitized}`),
       ...(this.deps.config ? { config: this.deps.config } : {}),
+      // store 级 mutation 前置守卫 (review #2388 Codex 5th P1): 裸 store 在
+      // manager 守卫之外被调用方使用 (withStore fn / agent prompt 注入路径),
+      // 后置复核无法撤销已发生的写操作 —— 锚定 store 创建时 scope, 每次
+      // write/delete/consolidate 前复核, scope 已变即抛 not-ready。
+      ...(this.deps.ownerScopeKey
+        ? { scopeCheck: () => this.assertScopeUnchanged(scopeAtEntry) }
+        : {}),
     });
     await store.init();
     // 跨 await 复核: 期间 owner 已切换 → 丢弃刚建的旧 owner store, fail-closed,

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -154,30 +154,38 @@ export class MakerMemoryManager {
    * 抛出的 MemoryError 会被 MCP 层 classifyMemoryError 翻译成
    * MAKER_MEMORY_NOT_READY, 与「空库返回 ok+[]」可区分。
    */
-  private ensureOwnerScope(): void {
-    if (this.deps.ownerScopeKey) {
-      const key = this.deps.ownerScopeKey();
-      if (this.activeScopeKey === null) {
-        // 首次解析 — 构造期 owner 可能尚未就绪 (initialEnabled 是全局默认),
-        // 这里锚定 scope 的同时按当前 owner 重绑定 enabled。
-        this.activeScopeKey = key;
-        this.rebindEnabled();
-      } else if (key !== this.activeScopeKey) {
-        this.logger.warn('maker memory owner scope changed — closing stores and rebinding root', {
-          fromScope: this.activeScopeKey,
-          toScope: key,
-        });
-        this.closeAllStores();
-        this.activeScopeKey = key;
-        this.rebindEnabled();
-      }
-      // 换根/首次锚定后新 owner 若关闭了 maker memory (enabled=false), 调用方
-      // 可能已持过期的 isEnabled()=true 通过检查 — 打开 store 路径必须
-      // fail-closed (见 getStore 的 disabled 检查)。
-      // 注意 disabled 检查**不**放在这里: resetAll/resetDigests 等清理路径也走
-      // ensureOwnerScope, 用户关闭 memory 后仍需能清空已有记忆 — 重置入口按
-      // 「不论 makerEnabled 值都能清」语义工作 (review #2388 Codex 10th P2)。
+  /**
+   * 纯 scope 同步 (不抛): 首次锚定 / ownerScopeKey 变化时关闭旧 store 池、
+   * 换根并重绑定 enabled。供 ensureOwnerScope (fail-closed 前) 与 isEnabled()
+   * (纯查询, 不能抛) 共用 — review #2388 Codex 11th P1: rebindEnabled 此前
+   * 只在 ensureOwnerScope 里跑, 先读 isEnabled() 的路径 (withStore 短路、
+   * session/remote option backfills) 会停留在旧 owner 的 flag 上。
+   */
+  private syncOwnerScope(): void {
+    if (!this.deps.ownerScopeKey) return;
+    const key = this.deps.ownerScopeKey();
+    if (this.activeScopeKey === null) {
+      // 首次解析 — 构造期 owner 可能尚未就绪 (initialEnabled 是全局默认),
+      // 这里锚定 scope 的同时按当前 owner 重绑定 enabled。
+      this.activeScopeKey = key;
+      this.rebindEnabled();
+    } else if (key !== this.activeScopeKey) {
+      this.logger.warn('maker memory owner scope changed — closing stores and rebinding root', {
+        fromScope: this.activeScopeKey,
+        toScope: key,
+      });
+      this.closeAllStores();
+      this.activeScopeKey = key;
+      this.rebindEnabled();
     }
+  }
+
+  private ensureOwnerScope(): void {
+    // scope 同步 + fail-closed: 缺 owner 直接拒绝 (不建临时库), scope 变化则换根。
+    this.syncOwnerScope();
+    // 注意 disabled 检查**不**放在这里: resetAll/resetDigests 等清理路径也走
+    // ensureOwnerScope, 用户关闭 memory 后仍需能清空已有记忆 — 重置入口按
+    // 「不论 makerEnabled 值都能清」语义工作 (review #2388 Codex 10th P2)。
     if (this.resolvedBasePath === null) {
       this.logger.warn('maker memory owner scope unavailable — refusing ephemeral fallback', {
         scopeKey: this.activeScopeKey,
@@ -260,6 +268,12 @@ export class MakerMemoryManager {
   }
 
   isEnabled(): boolean {
+    // 读取前同步 scope (review #2388 Codex 11th P1): rebindEnabled 只在
+    // ensureOwnerScope/syncOwnerScope 里跑, 先读 isEnabled() 的路径 (withStore
+    // 短路、session/remote option backfills) 会停留在旧 owner 的 flag —
+    // owner A false→B true 时不得继续短路, B false→A true 时不得漏暴露。
+    // 纯查询语义, 不抛 (owner 缺失由 getStore fail-closed)。
+    this.syncOwnerScope();
     return this.enabled;
   }
 

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -139,6 +139,13 @@ export class MakerMemoryManager {
    *    不再访问已被 closeAllStores 关闭的 db 句柄。
    */
   private resetInFlight = 0;
+  /**
+   * init 进行中的 db (review #2388 Codex 26th P1): db 打开后、store.init 完成
+   * 入池前不在 this.stores 里 — resetAll 只关池内 store, Windows 上 fs.rm 会
+   * 碰到这个未跟踪的 open fts.db → 跳过该 workdir 且报成功。closeAllStores
+   * 同时关闭该集合, 保证 reset 扫描前无任何 open 句柄。
+   */
+  private readonly openingStores = new Set<Database.Database>();
 
   constructor(private readonly deps: MakerMemoryManagerDeps) {
     this.enabled = deps.initialEnabled ?? false;
@@ -270,6 +277,16 @@ export class MakerMemoryManager {
       }
     }
     this.stores.clear();
+    // 关闭 init 进行中的 db (review #2388 Codex 26th P1): 未入池的 open 句柄
+    // 在 Windows 上会阻塞 resetAll 的 fs.rm — reset 扫描前必须全部关掉。
+    for (const db of this.openingStores) {
+      try {
+        db.close();
+      } catch (e) {
+        this.logger.warn('close opening db failed', { error: String(e) });
+      }
+    }
+    this.openingStores.clear();
   }
 
   /**
@@ -472,6 +489,9 @@ export class MakerMemoryManager {
     fs.mkdirSync(storageDir, { recursive: true });
 
     const db = this.deps.sqliteFactory(dbPath);
+    // 注册 in-flight 打开的 db (review #2388 Codex 26th P1): init 完成前不在
+    // this.stores, resetAll 需能关闭它避免 Windows fs.rm EBUSY 跳过该 workdir。
+    this.openingStores.add(db);
     const store = new MakerMemoryStore({
       storageDir,
       absWorkdir,
@@ -496,8 +516,10 @@ export class MakerMemoryManager {
       } catch {
         /* swallow */
       }
+      this.openingStores.delete(db);
       throw e;
     }
+    this.openingStores.delete(db);
     // 跨 await 复核: 期间 owner 已切换 → 丢弃刚建的旧 owner store, fail-closed,
     // 绝不入池。用实时 ownerScopeKey() 比较 (不依赖 activeScopeKey 被刷新)。
     if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -239,13 +239,22 @@ export class MakerMemoryManager {
    * store 操作复核点 (注入 store 的 scopeCheck, 每次公开操作/写盘前调用):
    * 1. resetAll 进行中 → 抛 not-ready (review #2388 Greptile 17th): 在途操作
    *    在下一复核点中止, 不再访问已被 closeAllStores 关闭的 db 句柄;
-   * 2. owner scope 变化 → 抛 not-ready (assertScopeUnchanged)。
+   * 2. store 创建后 resetAll 已完整执行 → 其 db 已被 closeAllStores 关闭
+   *    (review #2388 Greptile 20th P1): 调用方持有的旧世代 store 任何操作
+   *    都不得访问已关句柄, fail-closed 抛 not-ready 而非裸 database is closed;
+   * 3. owner scope 变化 → 抛 not-ready (assertScopeUnchanged)。
    */
-  private assertStoreOperable(scopeAtEntry: string | null): void {
+  private assertStoreOperable(scopeAtEntry: string | null, generationAtCreation: number): void {
     if (this.resetInFlight > 0) {
       throw new MemoryError(
         'not-ready',
         'memory reset in progress; store operation aborted',
+      );
+    }
+    if (this.poolGeneration !== generationAtCreation) {
+      throw new MemoryError(
+        'not-ready',
+        'memory was reset after this store was created; retry with a fresh store',
       );
     }
     this.assertScopeUnchanged(scopeAtEntry);
@@ -462,7 +471,7 @@ export class MakerMemoryManager {
       // 后置复核无法撤销已发生的写操作 —— 锚定 store 创建时 scope, 每次
       // write/delete/consolidate 前复核, scope 已变即抛 not-ready。
       ...(this.deps.ownerScopeKey
-        ? { scopeCheck: () => this.assertStoreOperable(scopeAtEntry) }
+        ? { scopeCheck: () => this.assertStoreOperable(scopeAtEntry, generationAtEntry) }
         : {}),
     });
     try {

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -673,6 +673,9 @@ export class MakerMemoryManager {
         // 空根/ENOENT 分支 (review #2388 Codex 21st P1): 也视为一次完成的 reset
         // 尝试 — 必须 bump generation, 否则 init 中暂停的 getStore 恢复后通过
         // generation 检查, 在用户可见的 reset 完成后写入新 memory。
+        // 先复核 scope (review #2388 Greptile 23rd P1): readdir await 期间边界
+        // 可能发生 — 不得把跨边界的 reset 误判为成功。
+        this.assertScopeUnchanged(scopeAtEntry);
         this.poolGeneration += 1;
         return { removedCount: 0 };
       }

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -434,6 +434,10 @@ export class MakerMemoryManager {
     // 异步初始化期间的竞态锚点 (review #2388 P1): 整个流程用入口捕获的 scope +
     // root, 不再跨 await re-read 动态根; 完成后复核 scope 未变才提交入池。
     const scopeAtEntry = this.deps.ownerScopeKey?.() ?? null;
+    // 池世代锚点 (review #2388 Codex 20th P1): init 等待期间并发 resetAll 可能
+    // 开始**并完成** (resetInFlight 已回 0) — 用 generation 对比识别「重置前
+    // 打开、closeAllStores 从未见过的 stale store」。
+    const generationAtEntry = this.poolGeneration;
     const rootAtEntry = this.resolvedBasePath!;
 
     // 目录名派生见 memoryScopeDirName:本地键 = sanitizeWorkdir 原规则 (不迁移),
@@ -502,6 +506,21 @@ export class MakerMemoryManager {
       throw new MemoryError(
         'not-ready',
         'memory reset started during store init; retry against current state',
+      );
+    }
+    // 跨 await 复核: init 等待期间 resetAll 已**完成** (review #2388 Codex 20th
+    // P1) — resetInFlight 已回 0, 用 generation 对比识别: 本 store 是重置前
+    // 打开的旧世代 (closeAllStores 从未关闭其 db, Windows 上阻塞目录删除 /
+    // POSIX 返回指向已删目录的实例), 不得入池。
+    if (this.poolGeneration !== generationAtEntry) {
+      try {
+        db.close();
+      } catch {
+        /* swallow */
+      }
+      throw new MemoryError(
+        'not-ready',
+        'memory reset completed during store init; retry against current state',
       );
     }
     // 并发去重: 同 workdir 的并发 getStore 可能已把 store 提交入池, 复用池内实例。

--- a/packages/maker-core/src/memory/manager.ts
+++ b/packages/maker-core/src/memory/manager.ts
@@ -398,7 +398,10 @@ export class MakerMemoryManager {
     const memoryRoot = path.join(this.resolvedBasePath!, MEMORY_SUBDIR);
     let total = 0;
     const activeDirs = new Set<string>();
-    for (const [workdir, { store }] of this.stores) {
+    // 入口快照池 — owner 切换时 closeAllStores 会 clear Map, for-of 直遍历会提前
+    // 结束; 用快照保证循环体仍按原 owner 的 store 逐项复核+处理 (review #2388)。
+    const storeSnapshot = [...this.stores.entries()];
+    for (const [workdir, { store }] of storeSnapshot) {
       // 迭代前复核 (review #2388 第三轮 P1): resetType 自身 await (list/delete),
       // 期间 owner 切换会使本循环持有的 store 被 closeAllStores 关闭 —— 必须先
       // 复核再操作, 不得在切换后继续用已失效的 store。
@@ -441,6 +444,14 @@ export class MakerMemoryManager {
         }
       }
     }
+    // 删除后复核 (review #2388 Greptile 4th): 目标 root 在入口已固定为操作开始时
+    // owner, 执行期间切换不改变删除对象 (旧 owner 数据), 但记录日志让「跨边界、
+    // 结果可能不完整」可观测。
+    if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
+      this.logger.warn('resetDigests crossed owner boundary; target fixed to scope at entry (result may be partial)', {
+        scopeAtEntry,
+      });
+    }
     return { removedCount: total };
   }
 
@@ -482,6 +493,14 @@ export class MakerMemoryManager {
       try { db.close(); } catch { /* swallow */ }
     }
     this.stores.clear();
+    // 删除后复核 (review #2388 Greptile 4th): 目标 root 在入口已固定为操作开始时
+    // owner, 执行期间切换不改变删除对象 (旧 owner 数据), 但记录日志让「跨边界、
+    // 结果可能不完整」可观测。
+    if (this.deps.ownerScopeKey && this.deps.ownerScopeKey() !== scopeAtEntry) {
+      this.logger.warn('resetAll crossed owner boundary; target fixed to scope at entry (result may be partial)', {
+        scopeAtEntry,
+      });
+    }
     return { removedCount: total };
   }
 

--- a/packages/maker-core/src/memory/storage.ts
+++ b/packages/maker-core/src/memory/storage.ts
@@ -307,6 +307,8 @@ export class MemoryStorage {
     // await 期间边界可能发生, 不得继续在旧 owner 下 rebuildIndex / 返回成功。
     this.beforeFileWrite?.();
     await this.rebuildIndex();
+    // rebuildIndex 自身多次 await 后、返回前复核 (review #2388 Codex 13th P1)。
+    this.beforeFileWrite?.();
 
     const result: WriteResult = { ok: true, filename };
     const detail = this.computeWarning(nextBody);
@@ -383,6 +385,9 @@ export class MemoryStorage {
       }
     }
     const content = lines.join('\n');
+    // 索引写盘前复核 (review #2388 Codex 13th P1): rebuildIndex 自身有多次
+    // awaited shard reads, 边界不得在旧 owner 下重写 MEMORY.md。
+    this.beforeFileWrite?.();
     await fs.writeFile(path.join(this.dir, INDEX_FILENAME), content, 'utf8');
     this.indexCache = content;
   }

--- a/packages/maker-core/src/memory/storage.ts
+++ b/packages/maker-core/src/memory/storage.ts
@@ -187,6 +187,9 @@ export class MemoryStorage {
     try {
       await fs.access(metaPath);
     } catch {
+      // 首次打开副作用也 fail-closed (review #2388 Codex 16th P1): 异步初始化
+      // 期间边界发生, 不得在旧 owner 下创建 meta.json。
+      this.beforeFileWrite?.();
       const meta: MemoryStorageMeta = {
         absPath: absWorkdir,
         createdAt: new Date().toISOString(),

--- a/packages/maker-core/src/memory/storage.ts
+++ b/packages/maker-core/src/memory/storage.ts
@@ -170,6 +170,14 @@ export class MemoryStorage {
     /** 已就绪的目录绝对路径, e.g. <userData>/maker-memory/<sanitized-workdir>/ */
     public readonly dir: string,
     public readonly config: MemoryConfig = DEFAULT_MEMORY_CONFIG,
+    /**
+     * 文件系统写入前守卫 (review #2388 Codex 8th P1): write 内部在真正写盘前
+     * 有 await (tryReadRaw 读现有文件判 mode), 边界可在此窗口发生 — 必须在该
+     * await 之后、fs.writeFile 之前复核 owner scope, 否则直接调用方 (如 Pi
+     * compaction 经 manager.write, withStore 后置检查之外) 会把写入落到旧
+     * owner 根后报成功。由 store 透传 manager 注入的 scopeCheck。
+     */
+    private readonly beforeFileWrite?: () => void,
   ) {}
 
   /** mkdir -p + 写 meta.json (如缺失). 幂等。 */
@@ -291,6 +299,9 @@ export class MemoryStorage {
     }
 
     const fileText = matter.stringify(nextBody, nextFrontmatter);
+    // tryReadRaw 的 await 窗口后、真正写盘前复核 owner scope (review #2388
+    // Codex 8th P1): 边界不得把 shard 写入旧 owner 根。
+    this.beforeFileWrite?.();
     await fs.writeFile(fullPath, fileText, 'utf8');
     await this.rebuildIndex();
 

--- a/packages/maker-core/src/memory/storage.ts
+++ b/packages/maker-core/src/memory/storage.ts
@@ -165,6 +165,13 @@ export interface MemoryStorageMeta {
 
 export class MemoryStorage {
   private indexCache: string | null = null;
+  /**
+   * 派生索引 (MEMORY.md) 失效标记 (review #2388 Codex 23rd P1/P2): shard
+   * write/delete 已落盘但其后的 rebuildIndex 被 owner 边界中止时置位 —
+   * 文件与索引不一致; 下次安全打开 (init) 时 repairIndexIfDirty 惰性修复,
+   * 防止同 owner 后续 session 把 stale 索引读进 system prompt。
+   */
+  private derivedIndexDirty = false;
 
   constructor(
     /** 已就绪的目录绝对路径, e.g. <userData>/maker-memory/<sanitized-workdir>/ */
@@ -308,7 +315,8 @@ export class MemoryStorage {
     await fs.writeFile(fullPath, fileText, 'utf8');
     // shard write 后、索引重建前复核 (review #2388 Codex 12th P1): writeFile
     // await 期间边界可能发生, 不得继续在旧 owner 下 rebuildIndex / 返回成功。
-    this.beforeFileWrite?.();
+    // not-ready 时文件已落盘但 MEMORY.md 未更新 → 标记派生索引 dirty (Codex 23rd)。
+    this.guardAfterMutation();
     await this.rebuildIndex();
     // rebuildIndex 自身多次 await 后、返回前复核 (review #2388 Codex 13th P1)。
     this.beforeFileWrite?.();
@@ -335,10 +343,46 @@ export class MemoryStorage {
       throw new MemoryError('io-error', `unlink failed: ${(e as Error).message}`);
     }
     // unlink 后复核 — await 窗口后边界可能发生, 不得继续在旧 owner 下重建索引。
-    this.beforeFileWrite?.();
+    // not-ready 时文件已删但 MEMORY.md 仍列出 → 标记派生索引 dirty (Codex 23rd)。
+    this.guardAfterMutation();
     await this.rebuildIndex();
     // rebuildIndex 内部多次 await 后、返回前复核。
     this.beforeFileWrite?.();
+  }
+
+  /**
+   * 变更后复核辅助 (review #2388 Codex 23rd P1/P2): shard 已落盘但其后
+   * rebuildIndex 被 owner 边界中止 → 文件与 MEMORY.md 不一致, 标记派生索引
+   * dirty; 下次安全打开 (init) 时 repairIndexIfDirty 惰性重建, 防止同 owner
+   * 后续 session 把 stale 索引读进 system prompt。
+   */
+  private guardAfterMutation(): void {
+    try {
+      this.beforeFileWrite?.();
+    } catch (e) {
+      if (e instanceof MemoryError && e.code === 'not-ready') {
+        this.derivedIndexDirty = true;
+        this.indexCache = null;
+      }
+      throw e;
+    }
+  }
+
+  private markIndexDirty(): void {
+    this.derivedIndexDirty = true;
+    this.indexCache = null;
+  }
+
+  /** 派生索引 (MEMORY.md) 是否因中止的写/删而失效 */
+  isIndexDirty(): boolean {
+    return this.derivedIndexDirty;
+  }
+
+  /** 惰性修复: 上次变更被边界中止 → 重建 MEMORY.md 恢复一致 (幂等) */
+  async repairIndexIfDirty(): Promise<void> {
+    if (!this.derivedIndexDirty) return;
+    await this.rebuildIndex();
+    this.derivedIndexDirty = false;
   }
 
   /** 当前 MEMORY.md 内容 (索引文本, 给 system prompt 拼). 不存在返空串 */
@@ -369,6 +413,18 @@ export class MemoryStorage {
    *   ...
    */
   async rebuildIndex(): Promise<void> {
+    try {
+      await this.rebuildIndexInner();
+    } catch (e) {
+      // 重建被 owner 边界中止 → 索引未更新, 标记 dirty (review #2388 Codex 23rd)
+      if (e instanceof MemoryError && e.code === 'not-ready') {
+        this.markIndexDirty();
+      }
+      throw e;
+    }
+  }
+
+  private async rebuildIndexInner(): Promise<void> {
     const records = await this.list();
     const grouped = new Map<MemoryType, MemoryRecord[]>();
     for (const rec of records) {

--- a/packages/maker-core/src/memory/storage.ts
+++ b/packages/maker-core/src/memory/storage.ts
@@ -303,6 +303,9 @@ export class MemoryStorage {
     // Codex 8th P1): 边界不得把 shard 写入旧 owner 根。
     this.beforeFileWrite?.();
     await fs.writeFile(fullPath, fileText, 'utf8');
+    // shard write 后、索引重建前复核 (review #2388 Codex 12th P1): writeFile
+    // await 期间边界可能发生, 不得继续在旧 owner 下 rebuildIndex / 返回成功。
+    this.beforeFileWrite?.();
     await this.rebuildIndex();
 
     const result: WriteResult = { ok: true, filename };

--- a/packages/maker-core/src/memory/storage.ts
+++ b/packages/maker-core/src/memory/storage.ts
@@ -322,13 +322,20 @@ export class MemoryStorage {
   async delete(filename: string): Promise<void> {
     this.assertSafeFilename(filename);
     const fullPath = path.join(this.dir, filename);
+    // 删除前复核 (review #2388 Codex 14th P1): 单次预检只保护 delete 开始瞬间,
+    // 边界在 fs.unlink / rebuildIndex 之间发生仍会删旧 owner 文件并重建索引。
+    this.beforeFileWrite?.();
     try {
       await fs.unlink(fullPath);
     } catch (e) {
       if (isENOENT(e)) throw new MemoryError('not-found', `${filename} 不存在`);
       throw new MemoryError('io-error', `unlink failed: ${(e as Error).message}`);
     }
+    // unlink 后复核 — await 窗口后边界可能发生, 不得继续在旧 owner 下重建索引。
+    this.beforeFileWrite?.();
     await this.rebuildIndex();
+    // rebuildIndex 内部多次 await 后、返回前复核。
+    this.beforeFileWrite?.();
   }
 
   /** 当前 MEMORY.md 内容 (索引文本, 给 system prompt 拼). 不存在返空串 */

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -271,8 +271,12 @@ export class MakerMemoryStore {
     this.assertScopeOk();
     try {
       const all = await this.storage.list();
+      // list await 后、rebuild 前复核 (review #2388 Codex 17th P1): list 在途时
+      // 边界可能发生; not-ready 透传, FTS 不得写入旧 owner fts.db。
+      this.assertScopeOk();
       this.fts.rebuild(all);
     } catch (e) {
+      if (e instanceof MemoryError && e.code === 'not-ready') throw e;
       this.logger.warn('consolidate fts rebuild failed', { error: String(e) });
     }
 

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -269,8 +269,16 @@ export class MakerMemoryStore {
     this.assertScopeOk();
     await this.init();
     const all = await this.storage.list();
+    // list 是 await 窗口 — 逐项删除前必须逐次复核 (review #2388 Greptile 8th P1):
+    // 边界在 list 期间发生则删除不得继续作用于旧 owner 文件。
     for (const r of all) {
-      try { await this.storage.delete(r.filename); } catch { /* swallow */ }
+      try {
+        this.assertScopeOk();
+        await this.storage.delete(r.filename);
+      } catch (e) {
+        if (e instanceof MemoryError && e.code === 'not-ready') throw e;
+        /* swallow */
+      }
     }
     try { this.fts.rebuild([]); } catch { /* swallow */ }
     return { removedCount: all.length };

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -207,15 +207,22 @@ export class MakerMemoryStore {
     } else {
       writeOpts.mode = 'create';
     }
+    // tryReadRaw 与 entry check 之间有 await 窗口 — 写 target 前再复核一次
+    // (review #2388 Codex 7th P1), 边界不得写入旧 owner 文件。
+    this.assertScopeOk();
     const writeRes = await this.storage.write(writeOpts);
 
-    // 删源
+    // 删源 — 每次删除前复核 scope (review #2388 Codex 7th P1): target write 与
+    // 删源之间有 await, 边界若在窗口内发生, 裸 storage.delete 仍会变更旧 owner
+    // 文件; 后置复核无法撤销, 必须在每个删除动作前拦截。
     const deleted: string[] = [];
     for (const src of sourcesToDelete) {
       try {
+        this.assertScopeOk();
         await this.storage.delete(src);
         deleted.push(src);
       } catch (e) {
+        if (e instanceof MemoryError && e.code === 'not-ready') throw e;
         if (e instanceof MemoryError && e.code === 'not-found') continue;
         this.logger.warn('consolidate: failed to delete source (continuing)', {
           source: src,

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -109,8 +109,13 @@ export class MakerMemoryStore {
   async init(): Promise<void> {
     if (this.initialized) return;
     await this.storage.init(this.deps.absWorkdir);
+    // storage.init await 后、FTS 副作用前复核 (review #2388 Codex 18th P1):
+    // 首次打开的 getStore 无 withStore 后置检查, 边界不得在此创建旧 owner 的 fts.db。
+    this.assertScopeOk();
     this.fts.init();
     await this.sanityCheck();
+    // sanityCheck 内部多次 await (storage.list + fts.rebuild) 后复核。
+    this.assertScopeOk();
     this.initialized = true;
   }
 

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -187,6 +187,9 @@ export class MakerMemoryStore {
   // ── 检索 ─────────────────────────────────────────────────────────────────
 
   async search(query: string, opts?: SearchOptions): Promise<SearchHit[]> {
+    // 读守卫 (review #2388 Codex 10th P2): 与 list/read/getIndex 一致,
+    // 边界不得把旧 owner 的 FTS 检索结果返回给新会话。
+    this.assertScopeOk();
     await this.init();
     return this.fts.search(query, opts);
   }

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -119,25 +119,37 @@ export class MakerMemoryStore {
   async list(): Promise<MemoryRecord[]> {
     this.assertScopeOk();
     await this.init();
-    return this.storage.list();
+    const records = await this.storage.list();
+    // await 后复核 (review #2388 Codex 11th P1): 读取在途时边界可能发生,
+    // 不得把旧 owner 数据返回给新会话。
+    this.assertScopeOk();
+    return records;
   }
 
   async read(filename: string): Promise<MemoryRecord> {
     this.assertScopeOk();
     await this.init();
-    return this.storage.read(filename);
+    const rec = await this.storage.read(filename);
+    this.assertScopeOk();
+    return rec;
   }
 
   async getIndex(): Promise<string> {
     this.assertScopeOk();
     await this.init();
-    return this.storage.getIndex();
+    const index = await this.storage.getIndex();
+    // session 启动路径 getStore().getIndex() 无 withStore 后置检查 — 返回前
+    // 复核, 边界窗口不得把旧 owner 的 MEMORY.md 赋给 makerMemoryIndex。
+    this.assertScopeOk();
+    return index;
   }
 
   async getIndexSize(): Promise<number> {
     this.assertScopeOk();
     await this.init();
-    return this.storage.getIndexSize();
+    const size = await this.storage.getIndexSize();
+    this.assertScopeOk();
+    return size;
   }
 
   // ── 写入类 (storage + fts 两侧同步) ─────────────────────────────────────
@@ -191,7 +203,9 @@ export class MakerMemoryStore {
     // 边界不得把旧 owner 的 FTS 检索结果返回给新会话。
     this.assertScopeOk();
     await this.init();
-    return this.fts.search(query, opts);
+    const hits = await this.fts.search(query, opts);
+    this.assertScopeOk();
+    return hits;
   }
 
   // ── 合并 (LLM 在 size warning 后调) ─────────────────────────────────────
@@ -229,6 +243,8 @@ export class MakerMemoryStore {
       try {
         this.assertScopeOk();
         await this.storage.delete(src);
+        // 删除后复核 — storage.delete 跨越 fs.unlink, 边界不得在其后继续 (review #2388)
+        this.assertScopeOk();
         deleted.push(src);
       } catch (e) {
         if (e instanceof MemoryError && e.code === 'not-ready') throw e;
@@ -278,6 +294,10 @@ export class MakerMemoryStore {
       try {
         this.assertScopeOk();
         await this.storage.delete(r.filename);
+        // 删除后复核 (review #2388 Greptile 9th P1): storage.delete 跨越
+        // fs.unlink 与 rebuildIndex, 最后一次删除等待期间切换则删除+索引重建
+        // 不得跨边界完成 — 立即中止, 不返回成功 removedCount。
+        this.assertScopeOk();
       } catch (e) {
         if (e instanceof MemoryError && e.code === 'not-ready') throw e;
         /* swallow */

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -109,16 +109,21 @@ export class MakerMemoryStore {
   async init(): Promise<void> {
     if (this.initialized) return;
     await this.storage.init(this.deps.absWorkdir);
-    // 修复上次变更被 owner 边界中止的派生索引 (review #2388 Codex 23rd P1/P2):
-    // shard 已写/删但 MEMORY.md 未更新 — 打开时惰性重建, 防止同 owner 后续
-    // session 把 stale 索引读进 system prompt。
-    await this.storage.repairIndexIfDirty();
+    // 派生索引 (MEMORY.md) 无条件重建 (review #2388 Codex 24th P1): dirty 标记
+    // 是实例内存态 — 写/删被边界中止后 store 会被 close/重建, 标记丢失;
+    // 安全打开时直接重建, 不依赖实例状态, 同 owner 后续 session 不再读 stale 索引。
+    await this.storage.rebuildIndex();
     // storage.init await 后、FTS 副作用前复核 (review #2388 Codex 18th P1):
     // 首次打开的 getStore 无 withStore 后置检查, 边界不得在此创建旧 owner 的 fts.db。
     this.assertScopeOk();
     this.fts.init();
     await this.sanityCheck();
-    // sanityCheck 内部多次 await (storage.list + fts.rebuild) 后复核。
+    // FTS 无条件重建 (review #2388 Codex 24th P2): update/append 被边界中止时
+    // 文件数不变, sanityCheck 的 count 检查永不触发 — open 时全量重建保证
+    // memory_search 不返回 stale 结果。
+    const all = await this.storage.list();
+    this.fts.rebuild(all);
+    // sanityCheck/list 内部多次 await 后复核。
     this.assertScopeOk();
     this.initialized = true;
   }

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -164,8 +164,12 @@ export class MakerMemoryStore {
     // FTS 同步 — 失败只 warn, 文件已落盘
     try {
       const rec = await this.storage.read(result.filename);
+      // reread await 后、upsert 前复核 (review #2388 Codex 16th P1): 边界
+      // 不得让 FTS 写入旧 owner 的 fts.db; not-ready 透传 (fail-closed)。
+      this.assertScopeOk();
       this.fts.upsert(rec);
     } catch (e) {
+      if (e instanceof MemoryError && e.code === 'not-ready') throw e;
       this.logger.warn('memory fts upsert failed (file written ok, will rebuild on next sanity)', {
         filename: result.filename,
         error: String(e),

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -105,10 +105,14 @@ export class MakerMemoryStore {
     this.deps.scopeCheck?.();
   }
 
-  /** mkdir + meta.json + FTS 表创建 + sanity check (count 不一致 → rebuild). 幂等。 */
+  /** mkdir + meta.json + FTS 表创建 + sanity check (count 不一致 → rebuild). 幂等. */
   async init(): Promise<void> {
     if (this.initialized) return;
     await this.storage.init(this.deps.absWorkdir);
+    // 修复上次变更被 owner 边界中止的派生索引 (review #2388 Codex 23rd P1/P2):
+    // shard 已写/删但 MEMORY.md 未更新 — 打开时惰性重建, 防止同 owner 后续
+    // session 把 stale 索引读进 system prompt。
+    await this.storage.repairIndexIfDirty();
     // storage.init await 后、FTS 副作用前复核 (review #2388 Codex 18th P1):
     // 首次打开的 getStore 无 withStore 后置检查, 边界不得在此创建旧 owner 的 fts.db。
     this.assertScopeOk();

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -122,6 +122,9 @@ export class MakerMemoryStore {
     // 文件数不变, sanityCheck 的 count 检查永不触发 — open 时全量重建保证
     // memory_search 不返回 stale 结果。
     const all = await this.storage.list();
+    // list await 后、rebuild 前复核 (review #2388 Codex 25th P1): 边界/resetAll
+    // 在 list 在途时开始 — 不得重写旧 owner 的 fts.db 或碰被删的 db。
+    this.assertScopeOk();
     this.fts.rebuild(all);
     // sanityCheck/list 内部多次 await 后复核。
     this.assertScopeOk();

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -158,6 +158,9 @@ export class MakerMemoryStore {
     this.assertScopeOk();
     await this.init();
     const result = await this.storage.write(opts);
+    // storage await 后、FTS 同步前复核 (review #2388 Codex 15th P1): 边界不得
+    // 让 manager.write 直接路径 (Pi compaction) 改旧 owner 的 fts.db。
+    this.assertScopeOk();
     // FTS 同步 — 失败只 warn, 文件已落盘
     try {
       const rec = await this.storage.read(result.filename);
@@ -175,6 +178,8 @@ export class MakerMemoryStore {
     this.assertScopeOk();
     await this.init();
     await this.storage.delete(filename);
+    // storage await 后、FTS 同步前复核 (review #2388 Codex 15th P1)
+    this.assertScopeOk();
     try {
       this.fts.delete(filename);
     } catch (e) {
@@ -257,6 +262,9 @@ export class MakerMemoryStore {
     }
 
     // FTS 同步 (整体重建一次, 比逐个 upsert/delete 简单且更不容易出错)
+    // rebuild 前复核 (review #2388 Codex 15th P1): 删源循环的 await 窗口后,
+    // 边界不得让 FTS 重建落在旧 owner 的 sqlite 上。
+    this.assertScopeOk();
     try {
       const all = await this.storage.list();
       this.fts.rebuild(all);

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -44,6 +44,14 @@ export interface MakerMemoryStoreDeps {
   logger: Logger;
   /** 配置覆盖, 缺省走 DEFAULT_MEMORY_CONFIG */
   config?: Partial<MemoryConfig>;
+  /**
+   * 每次 mutation (write/delete/consolidate/resetType/resetAll) 执行前的 owner
+   * scope 守卫 (review #2388 Codex 5th P1): 裸 store 经 getStore 返回后可能被
+   * 调用方在 manager 守卫之外使用, 后置复核无法撤销已发生的文件变更 —— 必须在
+   * 写操作开始前复核。由 manager 注入 (锚定 store 创建时的 scope), scope 已变
+   * 则抛 memory:not-ready。缺席 = 静态宿主, 不守卫。
+   */
+  scopeCheck?: () => void;
 }
 
 export interface ConsolidateOptions {
@@ -76,6 +84,16 @@ export class MakerMemoryStore {
     this.storage = new MemoryStorage(deps.storageDir, config);
     this.fts = new MemoryFts(deps.db);
     this.logger = deps.logger;
+  }
+
+  /**
+   * mutation 前置守卫: owner scope 已变则抛 memory:not-ready (manager 注入,
+   * 锚定 store 创建时 scope)。任何写操作 (write/delete/consolidate/resetType/
+   * resetAll) 开始前调用 —— 文件系统变更发生前拦截, 后置复核无法撤销已发生的
+   * 变更 (review #2388 Codex 5th P1)。
+   */
+  private assertMutable(): void {
+    this.deps.scopeCheck?.();
   }
 
   /** mkdir + meta.json + FTS 表创建 + sanity check (count 不一致 → rebuild). 幂等。 */
@@ -112,6 +130,7 @@ export class MakerMemoryStore {
   // ── 写入类 (storage + fts 两侧同步) ─────────────────────────────────────
 
   async write(opts: WriteOptions): Promise<WriteResult> {
+    this.assertMutable();
     await this.init();
     const result = await this.storage.write(opts);
     // FTS 同步 — 失败只 warn, 文件已落盘
@@ -128,6 +147,7 @@ export class MakerMemoryStore {
   }
 
   async delete(filename: string): Promise<void> {
+    this.assertMutable();
     await this.init();
     await this.storage.delete(filename);
     try {
@@ -142,6 +162,7 @@ export class MakerMemoryStore {
 
   /** 仅清空一种 memory；给 agent 私有的系统记忆（如 Pi digest）使用。 */
   async resetType(type: MemoryType): Promise<{ removedCount: number }> {
+    this.assertMutable();
     await this.init();
     const matching = (await this.storage.list()).filter((record) => record.frontmatter.type === type);
     for (const record of matching) {
@@ -165,6 +186,7 @@ export class MakerMemoryStore {
    * 失败时尽力恢复: 若新条目写失败直接抛; 若删除中途失败已删的不回滚 (文件系统不支持)。
    */
   async consolidate(opts: ConsolidateOptions): Promise<ConsolidateResult> {
+    this.assertMutable();
     await this.init();
     // 防呆: 不允许把 target 写到正要被删的 source 里 (否则会自删)
     const targetFilename = buildFilename(opts.target.type, opts.target.name);
@@ -224,6 +246,7 @@ export class MakerMemoryStore {
 
   /** 清空当前 workdir 全部 memory (manager.resetWorkdir 调). 慎用 */
   async resetAll(): Promise<{ removedCount: number }> {
+    this.assertMutable();
     await this.init();
     const all = await this.storage.list();
     for (const r of all) {

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -81,7 +81,13 @@ export class MakerMemoryStore {
 
   constructor(private readonly deps: MakerMemoryStoreDeps) {
     const config = { ...DEFAULT_MEMORY_CONFIG, ...(deps.config ?? {}) };
-    this.storage = new MemoryStorage(deps.storageDir, config);
+    this.storage = new MemoryStorage(
+      deps.storageDir,
+      config,
+      // 透传 scope 守卫到 storage 写路径 — write 内部 tryReadRaw await 窗口后、
+      // 真正写盘前复核 (review #2388 Codex 8th P1)
+      deps.scopeCheck ? () => this.assertScopeOk() : undefined,
+    );
     this.fts = new MemoryFts(deps.db);
     this.logger = deps.logger;
   }

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -324,6 +324,9 @@ export class MakerMemoryStore {
         /* swallow */
       }
     }
+    // 最终 FTS 重建前复核 (review #2388 Codex 19th P1): 删除循环后仍可能跨
+    // 边界, 不得在旧 owner 的 fts.db 上 rebuild; not-ready 透传 fail-closed。
+    this.assertScopeOk();
     try { this.fts.rebuild([]); } catch { /* swallow */ }
     return { removedCount: all.length };
   }
@@ -333,10 +336,17 @@ export class MakerMemoryStore {
   /** storage 跟 fts count 不一致 → 全量 rebuild fts */
   private async sanityCheck(): Promise<void> {
     const fileCount = (await this.storage.list()).length;
+    // list await 后、访问 SQLite 前复核 (review #2388 Greptile 18th P1):
+    // 首次打开的 init 期间并发 resetAll 可能已关闭 db — 不得用已关句柄调
+    // fts.count() 抛裸 SQLite/IO 错误, 应 fail-closed 抛 not-ready。
+    this.assertScopeOk();
     const ftsCount = this.fts.count();
     if (ftsCount === -1 || ftsCount !== fileCount) {
       this.logger.info('memory fts inconsistent, rebuilding', { fileCount, ftsCount });
       const all = await this.storage.list();
+      // list await 后、rebuild 前复核 (review #2388 Codex 19th P1): 边界不得
+      // 在旧 owner 的 fts.db 上重建。
+      this.assertScopeOk();
       this.fts.rebuild(all);
     }
   }

--- a/packages/maker-core/src/memory/store.ts
+++ b/packages/maker-core/src/memory/store.ts
@@ -87,12 +87,15 @@ export class MakerMemoryStore {
   }
 
   /**
-   * mutation 前置守卫: owner scope 已变则抛 memory:not-ready (manager 注入,
-   * 锚定 store 创建时 scope)。任何写操作 (write/delete/consolidate/resetType/
-   * resetAll) 开始前调用 —— 文件系统变更发生前拦截, 后置复核无法撤销已发生的
-   * 变更 (review #2388 Codex 5th P1)。
+   * scope 前置守卫: owner scope 已变则抛 memory:not-ready (manager 注入,
+   * 锚定 store 创建时 scope)。所有公开操作 (读 + 写) 开始前调用:
+   *  - 写操作: 文件系统变更发生前拦截, 后置复核无法撤销已发生的变更
+   *    (review #2388 Codex 5th P1);
+   *  - 只读操作: session 启动时 Claude/Codex 直接 getStore().getIndex() 拼
+   *    system prompt (在 withStore 后置检查之外), 边界窗口不得把旧 owner 的
+   *    MEMORY.md 注入新 session (review #2388 Codex 6th P1)。
    */
-  private assertMutable(): void {
+  private assertScopeOk(): void {
     this.deps.scopeCheck?.();
   }
 
@@ -108,21 +111,25 @@ export class MakerMemoryStore {
   // ── 直通 storage 的方法 (read 类) ────────────────────────────────────────
 
   async list(): Promise<MemoryRecord[]> {
+    this.assertScopeOk();
     await this.init();
     return this.storage.list();
   }
 
   async read(filename: string): Promise<MemoryRecord> {
+    this.assertScopeOk();
     await this.init();
     return this.storage.read(filename);
   }
 
   async getIndex(): Promise<string> {
+    this.assertScopeOk();
     await this.init();
     return this.storage.getIndex();
   }
 
   async getIndexSize(): Promise<number> {
+    this.assertScopeOk();
     await this.init();
     return this.storage.getIndexSize();
   }
@@ -130,7 +137,7 @@ export class MakerMemoryStore {
   // ── 写入类 (storage + fts 两侧同步) ─────────────────────────────────────
 
   async write(opts: WriteOptions): Promise<WriteResult> {
-    this.assertMutable();
+    this.assertScopeOk();
     await this.init();
     const result = await this.storage.write(opts);
     // FTS 同步 — 失败只 warn, 文件已落盘
@@ -147,7 +154,7 @@ export class MakerMemoryStore {
   }
 
   async delete(filename: string): Promise<void> {
-    this.assertMutable();
+    this.assertScopeOk();
     await this.init();
     await this.storage.delete(filename);
     try {
@@ -162,7 +169,7 @@ export class MakerMemoryStore {
 
   /** 仅清空一种 memory；给 agent 私有的系统记忆（如 Pi digest）使用。 */
   async resetType(type: MemoryType): Promise<{ removedCount: number }> {
-    this.assertMutable();
+    this.assertScopeOk();
     await this.init();
     const matching = (await this.storage.list()).filter((record) => record.frontmatter.type === type);
     for (const record of matching) {
@@ -186,7 +193,7 @@ export class MakerMemoryStore {
    * 失败时尽力恢复: 若新条目写失败直接抛; 若删除中途失败已删的不回滚 (文件系统不支持)。
    */
   async consolidate(opts: ConsolidateOptions): Promise<ConsolidateResult> {
-    this.assertMutable();
+    this.assertScopeOk();
     await this.init();
     // 防呆: 不允许把 target 写到正要被删的 source 里 (否则会自删)
     const targetFilename = buildFilename(opts.target.type, opts.target.name);
@@ -246,7 +253,7 @@ export class MakerMemoryStore {
 
   /** 清空当前 workdir 全部 memory (manager.resetWorkdir 调). 慎用 */
   async resetAll(): Promise<{ removedCount: number }> {
-    this.assertMutable();
+    this.assertScopeOk();
     await this.init();
     const all = await this.storage.list();
     for (const r of all) {

--- a/packages/maker-core/src/memory/types.ts
+++ b/packages/maker-core/src/memory/types.ts
@@ -142,7 +142,8 @@ export type MemoryErrorCode =
   | 'already-exists'
   | 'not-found'
   | 'path-traversal'
-  | 'io-error';
+  | 'io-error'
+  | 'not-ready';
 
 export class MemoryError extends Error {
   constructor(


### PR DESCRIPTION
## 这次改了什么

### 摘要

修复 `cindy_memory` 在 owner 作用域未就绪时静默降级到 `%TEMP%\cindy-no-session` 的问题（#2341）：store 根改为按当前 owner 动态解析，owner 缺失 / 会话边界切换期间 fail-closed（抛 `MAKER_MEMORY_NOT_READY`，绝不写临时目录）；异步操作跨 `await` 复核 scope，杜绝旧 owner 数据写入新账号库或跨账号误删。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：#2341
- 本 PR 包含：`MakerMemoryManager` 作用域守卫（`resolveBasePath` / `ownerScopeKey` / `ensureOwnerScope` / `assertScopeUnchanged`）、desktop 工厂动态根注入（含会话边界位）、MCP 错误码映射、配套单测
- 明确不包含：`%TEMP%` 残留数据的自动迁移（归属/冲突/幂等未定，与 #1652 分开处理）
- 用户可见变化：owner 未就绪时 memory 工具返回 `MAKER_MEMORY_NOT_READY` 错误，不再出现「write 返回成功但数据丢失」的静默失败
- 是否存在 breaking change：无

### UI 变化

不涉及（纯 main 进程存储层改动，无 UI 代码路径）

## 怎么验证的

### 自动验证

```text
vitest packages/maker-core/src/memory/          → 5 文件 35/35 通过
vitest packages/lizi-mcps/src/__tests__/memoryErrors.test.ts   → 4/4 通过
vitest packages/lizi-mcps/src/__tests__/sessionContext.test.ts → 14/14 通过
新增 manager.scope.test.ts（8 用例）：owner 缺失拒绝且不落盘 / write fail-closed /
  scope 切换换根 / getStore init 竞态丢弃 / resetAll 换根不删旧数据 / 并发去重 / 静态 basePath 回归
新增 memoryErrors.test.ts（4 用例）：not-ready → MAKER_MEMORY_NOT_READY 且不误映射
tsc --noEmit（maker-core / lizi-mcps / desktop）→ 本次改动零新增错误
```

### 手工验证

不涉及

### 未执行的验证

- Windows 桌面真实冷启动 smoke test（模拟认证延迟 / 断电残留 / `%TEMP%` 清理）：当前仅静态源码 + 单测证据，需在打包的 Desktop 上做一次真实冷启动验证后再发布

## 风险

### 风险分类

- [x] 权限 / 安全 / 用户数据（owner 作用域隔离正是本修复目标）

### 影响与回滚

- 影响范围：所有走 `cindy_memory` MCP 的会话（Claude / Codex / 本地 / SSH）；owner 未就绪窗口从「静默写 `%TEMP%` 一次性目录（数据不可恢复）」变为「显式报错」，不再产生静默丢失
- 回滚 / 降级方式：回退本分支即恢复旧行为（旧行为即本 bug 源头，不建议）；本修复不移动既有 owner 库数据，无数据迁移需求

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`）
- [x] UI 改动已在「UI 变化」注明设计规范章节（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无新增文档需求）
- [x] 已确认测试结果或说明未执行原因

---

**评审回复索引**：Codex 边界窗口 → [thread](https://github.com/makecindy/cindy/pull/2388#discussion_r3752251560)（commit 2f496b5c + 66dce346）；Codex reset 竞态 → [thread](https://github.com/makecindy/cindy/pull/2388#discussion_r3752251573)（commit 2f496b5c）；Codex boundary scope key → [thread](https://github.com/makecindy/cindy/pull/2388#discussion_r3752400045)（commit 66dce346）。Greptile 首轮 3 条意见已确认修复（Confidence 5/5）。
