### PR TITLE
fix(desktop): 还原子代理在对话流里的原有交互

### DIFF
--- a/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
+++ b/apps/desktop/src/renderer/__tests__/AgentTaskCard.test.ts
@@ -31,15 +31,11 @@ vi.mock('@/hooks/useExpandedBlockMemory', () => ({
   }),
 }));
 
-const { openBackgroundTasksTabMock, openSubagentsTabMock } = vi.hoisted(() => ({
+const { openBackgroundTasksTabMock } = vi.hoisted(() => ({
   openBackgroundTasksTabMock: vi.fn().mockResolvedValue(undefined),
-  openSubagentsTabMock: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('@/features/right-sidebar/lib/openBackgroundTasksTab', () => ({
   openBackgroundTasksTab: openBackgroundTasksTabMock,
-}));
-vi.mock('@/features/right-sidebar/lib/openSubagentsTab', () => ({
-  openSubagentsTab: openSubagentsTabMock,
 }));
 
 const { getWorkflowProgressForMock } = vi.hoisted(() => ({
@@ -519,9 +515,8 @@ describe('AgentTaskCard', () => {
     expect(progressLine(container)?.textContent).toBe('2/2 Agent');
   });
 
-  it('renders no workflow progress line and opens ordinary Subagents in their durable panel', () => {
+  it('renders no progress line when workflowProgress is absent, and keeps non-workflow cards off the panel entry', () => {
     openBackgroundTasksTabMock.mockClear();
-    openSubagentsTabMock.mockClear();
     const workflow = render(
       React.createElement(AgentTaskCard, {
         sessionId: 'session-1',
@@ -536,59 +531,23 @@ describe('AgentTaskCard', () => {
     expect(progressLine(workflow.container)).toBeNull();
 
     const normal = render(
-      withPanelHost(
-        'session-1',
-        React.createElement(AgentTaskCard, {
-          sessionId: 'session-1',
-          update: {
-            provider: 'claude-code',
-            taskId: 'task-1',
-            status: 'running',
-            title: 'Inspect files',
-          },
-        }),
-      ),
+      React.createElement(AgentTaskCard, {
+        sessionId: 'session-1',
+        update: {
+          provider: 'claude-code',
+          taskId: 'task-1',
+          status: 'running',
+          title: 'Inspect files',
+        },
+      }),
     );
-    const subagentButton = headerButton(normal.container);
-    expect(subagentButton).not.toBeNull();
+    // 普通卡头部仍是展开 toggle,不触发面板。
+    const toggleBtn = normal.container.querySelector<HTMLButtonElement>('button[aria-expanded]');
+    expect(toggleBtn).not.toBeNull();
     act(() => {
-      subagentButton!.click();
+      toggleBtn!.click();
     });
     expect(openBackgroundTasksTabMock).not.toHaveBeenCalled();
-    expect(openSubagentsTabMock).toHaveBeenCalledWith('session-1', {
-      focusRunId: 'task-1',
-      focusProvider: 'claude-code',
-    });
     expect(progressLine(normal.container)).toBeNull();
-  });
-
-  it('keeps Codex control cards expandable instead of opening a nonexistent Subagent run', () => {
-    openSubagentsTabMock.mockClear();
-    const { container } = render(
-      withPanelHost(
-        'session-1',
-        React.createElement(AgentTaskCard, {
-          sessionId: 'session-1',
-          toolCall: {
-            clientId: 'wait-1',
-            role: 'tool_use',
-            content: '',
-            toolName: 'collab:wait',
-            toolUseId: 'wait-1',
-          },
-          update: {
-            provider: 'codex',
-            taskId: 'wait-1',
-            status: 'completed',
-            title: 'wait',
-          },
-        }),
-      ),
-    );
-
-    const toggleButton = container.querySelector<HTMLButtonElement>('button[aria-expanded]');
-    expect(toggleButton).not.toBeNull();
-    act(() => toggleButton!.click());
-    expect(openSubagentsTabMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
+++ b/apps/desktop/src/renderer/components/chat/AgentTaskCard.tsx
@@ -20,7 +20,6 @@ import { Spinner } from '@/components/ui/spinner';
 import type { AgentTaskUpdate, ChatMessage } from '@/hooks/useCCAgentChat';
 import { getWorkflowProgressFor, isRemoteSessionSticky } from '@/lib/makerTransport';
 import { openBackgroundTasksTab } from '@/features/right-sidebar/lib/openBackgroundTasksTab';
-import { openSubagentsTab } from '@/features/right-sidebar/lib/openSubagentsTab';
 import { extractWorkflowTaskId } from '@/features/right-sidebar/plugins/background-tasks/listSessionTasks';
 import { WorkflowAgentStrip } from '@/features/right-sidebar/plugins/background-tasks/WorkflowAgentStrip';
 import {
@@ -32,7 +31,6 @@ import { cn } from '@/lib/utils';
 import { formatModelShortLabel } from '@/lib/modelShortLabel';
 import { CODEX_SUBAGENT_EFFORTS } from '../../../shared/subagentModelSettings';
 import {
-  isSubagentSpawnToolName,
   PI_SUBAGENT_TOOL_NAME,
   subagentSpawnReceiptName,
   subagentSpawnResultIndicatesRunning,
@@ -222,10 +220,6 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
   // 是「后台命令」—— 终端图标 + shell provider 标签,避免用户把跑测试的 bash
   // 误读成一个子 Agent。
   const isBash = update?.taskType === 'local_bash';
-  const isSubagent =
-    !isWorkflow &&
-    !isBash &&
-    (!toolCall?.toolName || isSubagentSpawnToolName(toolCall.toolName));
   const AvatarIcon = isWorkflow ? Workflow : isBash ? SquareTerminal : Bot;
   const title = compactText(
     (isWorkflow ? update?.workflowName : undefined) ??
@@ -293,39 +287,19 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
       .finally(() => setStopping(false));
   }, [sessionId, update?.taskId]);
 
-  // workflow / Subagent 卡整卡点击 → 打开对应 Cindy 右栏工作区并定位本任务。
-  // Subagent 使用 Cindy 逻辑 id、父 toolUseId 等任一已知别名；工作区会把别名
-  // 解析成持久 run id，因此三种 harness 不需要共享原生 thread/session 形态。
-  // 定位信息不全时退回传统展开交互，让 description/summary 就地可读，不做
-  // 「点了没反应」的假入口。
+  // workflow 卡整卡点击 → 打开右栏后台任务面板并定位本任务(workflowTaskId 在
+  // 组件顶部与状态修正共用同一次推导)。三者缺一就退回传统展开交互,让
+  // description/summary 就地可读,不做「点了没反应」的假入口。
   //
   // panelReachable:内嵌宿主(协同 worker 面板 / workdir-browse 窄 rail / Orca
   // split)里右栏显示的是别的会话(或压根没在场),往本会话 bucket 写 tab 用户看
   // 不到 —— 那里必须退回展开区,否则卡片既点不动、又因面板入口化丢掉了展开区。
   const panelReachable = useSidebarPanelReachable(sessionId);
-  const subagentFocusId =
-    update?.taskId ?? update?.parentToolUseId ?? toolCall?.toolUseId ?? toolCall?.clientId;
-  const canOpenWorkflowPanel =
-    isWorkflow && Boolean(sessionId) && Boolean(workflowTaskId) && panelReachable;
-  const canOpenSubagentPanel =
-    isSubagent && Boolean(sessionId) && Boolean(subagentFocusId) && panelReachable;
-  const canOpenInPanel = canOpenWorkflowPanel || canOpenSubagentPanel;
-  const openWorkflowPanel = useCallback(() => {
+  const canOpenInPanel = Boolean(sessionId) && Boolean(workflowTaskId) && panelReachable;
+  const openInPanel = useCallback(() => {
     if (!sessionId || !workflowTaskId) return;
     void openBackgroundTasksTab(sessionId, { focusTaskId: workflowTaskId });
   }, [sessionId, workflowTaskId]);
-  const openSubagentPanel = useCallback(() => {
-    if (!sessionId || !subagentFocusId) return;
-    void openSubagentsTab(sessionId, {
-      focusRunId: subagentFocusId,
-      focusProvider: provider,
-    });
-  }, [provider, sessionId, subagentFocusId]);
-  const handleHeaderClick = canOpenWorkflowPanel
-    ? openWorkflowPanel
-    : canOpenSubagentPanel
-      ? openSubagentPanel
-      : toggle;
 
   // workflow 摘要行:当前运行中 agent 的 phaseTitle + 已收口/总数。收口判定走
   // workflowAgentVisualState 归一(与方块条 / 面板同一词表源,done 与 failed 都算收口)。
@@ -384,14 +358,14 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
       {...(toolCall?.clientId ? { 'data-message-client-id': toolCall.clientId } : {})}
     >
       <div className="w-full rounded-[12px] border border-[var(--border-default)] bg-[var(--surface-elevated)] px-3 py-2">
-        {/* 头部按钮:可达的 workflow/Subagent 卡 = 右栏详情入口；其余 = 展开 toggle。
+        {/* 头部按钮:普通卡 = 展开 toggle;workflow 卡 = 打开后台任务面板入口。
             button 不能嵌套,停止按钮以兄弟节点挂在右侧(仅 running 时出现)。 */}
         <div className="flex w-full items-start gap-2">
         <button
           type="button"
-          onClick={handleHeaderClick}
+          onClick={isWorkflow && canOpenInPanel ? openInPanel : toggle}
           className="flex min-w-0 flex-1 items-start gap-2 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--focus-ring)]"
-          {...(canOpenInPanel
+          {...(isWorkflow && canOpenInPanel
             ? { 'aria-label': t('chat.agentTask.openInPanel') }
             : {
                 'aria-expanded': expanded,
@@ -458,7 +432,7 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
               </span>
             )}
           </span>
-          {canOpenInPanel ? (
+          {isWorkflow && canOpenInPanel ? (
             <PanelRight
               size={14}
               className="mt-1 shrink-0 text-[var(--text-tertiary)]"
@@ -496,9 +470,9 @@ export function AgentTaskCard({ toolCall, update, result, subagentModel, session
         )}
         </div>
 
-        {/* 能进入右栏的 workflow/Subagent 卡不再重复渲染就地展开区；
-            不可达的嵌入宿主/历史降级路径仍保留 description/summary。 */}
-        {!canOpenInPanel && (
+        {/* live workflow 卡不渲染展开区(详情在后台任务面板);历史 workflow 卡
+            (无 live taskId,面板无数据)保留展开区兜底展示 description/summary。 */}
+        {!(isWorkflow && canOpenInPanel) && (
           <Collapse open={expanded}>
             <div className="mt-2 border-l-2 border-[var(--agent-actions-rail)] pl-3 text-13 leading-5 text-[var(--text-secondary)]">
               {description && <p className="mb-1">{description}</p>}

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardModelChip.test.tsx
@@ -21,10 +21,6 @@ vi.mock('@/features/right-sidebar/lib/openBackgroundTasksTab', () => ({
   openBackgroundTasksTab: vi.fn(),
 }));
 
-vi.mock('@/features/right-sidebar/lib/openSubagentsTab', () => ({
-  openSubagentsTab: vi.fn(),
-}));
-
 vi.mock('@/features/right-sidebar/plugins/background-tasks/listSessionTasks', () => ({
   extractWorkflowTaskId: () => undefined,
 }));

--- a/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentLive.test.tsx
+++ b/apps/desktop/src/renderer/components/chat/__tests__/AgentTaskCardSubagentLive.test.tsx
@@ -30,10 +30,6 @@ vi.mock('@/features/right-sidebar/lib/openBackgroundTasksTab', () => ({
   openBackgroundTasksTab: vi.fn(),
 }));
 
-vi.mock('@/features/right-sidebar/lib/openSubagentsTab', () => ({
-  openSubagentsTab: vi.fn(),
-}));
-
 vi.mock('@/features/right-sidebar/plugins/background-tasks/listSessionTasks', () => ({
   extractWorkflowTaskId: () => undefined,
 }));
@@ -105,7 +101,7 @@ describe('AgentTaskCard codex subagent live state', () => {
   });
 
   it('keeps the localized receipt for history replay (no live update)', () => {
-    // 聊天卡的历史回放不重建 live update；持久详情在独立 Subagent 面板。
+    // 历史回放拿不到 live update(agent_task_update 不落库),回执是唯一可读摘要。
     const { container } = render(<AgentTaskCard toolCall={spawnToolCall()} result="/root/scout" />);
     expect(container.textContent ?? '').toContain('chat.agentTask.subagentStarted');
   });

--- a/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
+++ b/apps/desktop/src/renderer/features/cc-agent/CCAgentSessionView.tsx
@@ -282,6 +282,19 @@ import {
 } from '../../../shared/conversationSearchJump';
 
 const log = createLogger('CCAgentSessionView');
+/**
+ * 子代理页签只登记、不抢占。
+ *
+ * 子代理在对话流里已经有自己的卡片,右栏再自动弹出会把同一件事讲两遍,还会抢走
+ * 用户当时正在看的东西。入口保持可发现即可,展开留给用户点卡片或点右栏开关。
+ * 两条登记路径(历史挂载 / 首个实时子代理)共用这一份参数,避免其中一条被单独改回
+ * 自动展开。
+ */
+const SUBAGENT_TAB_REGISTER_ONLY = {
+  focusTab: false,
+  revealSidebar: false,
+  userInitiated: false,
+} as const;
 // perf-baseline(与 MessageStream / sidebar 的 perf/session-switch 探针同通道):
 // stream:profile 记录 MessageStream 子树每次 ≥50ms 的 React commit(phase +
 // actualDuration),与 perf/interaction 的 longtask 时长对齐即可判定长任务
@@ -549,9 +562,9 @@ export function CCAgentSessionView({
     });
   }, [navigate, sessionId, viewVisible]);
 
-  // A task that has Subagents owns one durable Subagent tab. On history mount
-  // we silently ensure the tab exists; the first live child also reveals the
-  // sidebar, without stealing OS focus or replacing an already-active tab.
+  // A task that has Subagents owns one durable Subagent tab. Both on history
+  // mount and on the first live child we only ensure the tab exists — never
+  // stealing OS focus, replacing an already-active tab, or opening the sidebar.
   useEffect(() => {
     if (!ownsWindowRoute || !viewVisible || !sessionId) return;
     let disposed = false;
@@ -567,11 +580,7 @@ export function CCAgentSessionView({
         ) {
           return;
         }
-        return openSubagentsTab(sessionId, {
-          focusTab: false,
-          revealSidebar: false,
-          userInitiated: false,
-        });
+        return openSubagentsTab(sessionId, SUBAGENT_TAB_REGISTER_ONLY);
       })
       .catch(() => undefined);
     const unsubscribe = window.electronAPI.localDb.subagentRuns.onChanged(
@@ -584,11 +593,7 @@ export function CCAgentSessionView({
         ) {
           return;
         }
-        void openSubagentsTab(sessionId, {
-          focusTab: false,
-          revealSidebar: payload.created && payload.firstForSession,
-          userInitiated: false,
-        }).catch(() => undefined);
+        void openSubagentsTab(sessionId, SUBAGENT_TAB_REGISTER_ONLY).catch(() => undefined);
       },
     );
     return () => {


### PR DESCRIPTION
## 这次改了什么

### 摘要

把 #2263 对对话流的两处侵入改回去。子代理在对话里本来就有自己的卡片，那张卡应该能自己把事情讲完。

1. **右栏不再自动弹出** —— 第一个子代理出现时右栏会自己推开，抢走用户当时正在看的东西。
2. **卡片恢复就地展开** —— #2263 把整卡点击从「就地展开看 description / summary」改成了「跳右栏」，并移除了就地展开区。用户为了看一句 summary 得离开当前阅读位置，右栏再把同一件事讲一遍。

右栏入口仍然存在（页签照常登记），只是不再自动弹、也不再由卡片代劳。

### 变更类型

- [x] `fix` 缺陷修复

### 范围

- 关联 Issue / 需求：还原 #2263 引入的对话流交互变化；外推项见 #2409
- 本 PR 包含：
  - `CCAgentSessionView.tsx` 两条页签登记路径收敛到同一份参数常量，`revealSidebar` 恒为 `false`
  - `AgentTaskCard.tsx` 与三个相关测试还原到 #2263 之前的版本（`git checkout a3b3e7ebc`，逐字节一致）
- 明确不包含：
  - 不动 `SubagentRunsChangedPayload` 的 `created` / `firstForSession` 字段（仍是主进程 IPC 契约的一部分）
  - 不动右栏 Subagent 面板本身的实现
  - 不修 detached 命令队列互相覆盖的问题（外推 #2409，理由见该 issue 与 review 回复）
- 用户可见变化：
  - 首个子代理出现时不再自动展开右侧栏
  - 子代理卡整卡点击恢复为就地展开 / 收起，展开区回来了
  - workflow 卡的面板入口是 #2263 之前就有的行为，不受影响
- 是否存在 breaking change：无

### UI 变化

行为回到 #2263 之前的形态，未引入任何新的界面元素、布局、样式或文案。卡片部分是逐字节还原，不是重写。

- 引用的设计规范：不涉及：本 PR 不新增或修改任何界面元素、布局、样式与文案；两处变化分别是关闭一个自动展开行为、以及把卡片代码还原回改动前的版本。

## 怎么验证的

### 自动验证

```text
npx vitest run --root apps/desktop \
  src/renderer/__tests__/AgentTaskCard.test.ts \
  src/renderer/components/chat/__tests__/ \
  src/renderer/features/cc-agent/ \
  src/renderer/features/right-sidebar/
结果：Test Files 111 passed (111) / Tests 1277 passed (1277)

pnpm --filter desktop run typecheck
结果：无 AgentTaskCard / CCAgentSessionView 相关错误

pnpm run test:unit
结果：52 个 workspace PASS

# 还原是否真的逐字节一致（4 个文件逐一比对 #2263 父提交）
for f in <4 files>; do diff <(git show a3b3e7ebc:"$f") "$f"; done
结果：4 个文件全部无差异
```

已知失败（与本 PR 无关，在干净 `main` 上同样复现，本分支未触及这两个文件）：

- `src/renderer/components/settings/__tests__/CustomProviderDialogAccessibility.test.tsx`
- `src/main/voice-input/__tests__/RealtimeAsrWebSocketProvider.test.ts`

### 手工验证

不涉及：本次是行为还原，覆盖点由上述 1277 项定向测试保证；未在实机上目检两种主题。

### 未执行的验证

- 未做实机 Light / Dark 目检。本 PR 不改任何样式与颜色，卡片部分是还原到已在线上运行过的版本。

## 风险

### 风险分类

- [x] 无已知风险

### 影响与回滚

- 影响范围：仅 Desktop renderer 的子代理卡片与右栏页签登记时机。不涉及数据库、协议、system prompt、原生层与插件。三套 Harness 的启动、调度、取消与返回逻辑均未触碰。
- 回滚 / 降级方式：`git revert` 本 PR 的两个 commit 即可，无数据迁移、无持久化状态变更。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名
- [x] UI 改动已在「UI 变化」注明引用的设计规范章节
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档
- [x] 已确认测试结果或说明未执行原因
