### PR TITLE
fix(desktop): 未安装插件时拦截 iOS 模拟器 Host 能力

### DIFF
--- a/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorPluginGate.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorPluginGate.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import type { InstalledGhost } from '../../../shared/ghost.js';
+import { resolveIOSSimulatorPluginAccess } from '../iosSimulatorPluginGate.js';
+
+function ghost(id: string, enabled: boolean, slots: string[] = ['ios-simulator']): InstalledGhost {
+  return {
+    enabled,
+    manifest: { id, name: id, slots },
+  } as unknown as InstalledGhost;
+}
+
+function resolve(
+  ghosts: InstalledGhost[],
+  options: { unavailableIds?: string[]; disabledInWorkdirIds?: string[] } = {},
+) {
+  return resolveIOSSimulatorPluginAccess(ghosts, '/repo', {
+    isAvailableForActiveSession: (id) => !options.unavailableIds?.includes(id),
+    isDisabledForWorkdir: (id) => options.disabledInWorkdirIds?.includes(id) === true,
+  });
+}
+
+describe('iOS Simulator plugin Host gate', () => {
+  it('returns an actionable install result when no provider is installed', () => {
+    expect(resolve([])).toEqual({
+      allowed: false,
+      errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+      message: expect.stringContaining('Plugins → Marketplace'),
+      data: expect.objectContaining({
+        reason: 'not-installed',
+        action: 'install-plugin',
+        pluginId: 'ios-simulator',
+      }),
+    });
+  });
+
+  it('distinguishes a sleeping plugin from a project-scoped disable', () => {
+    expect(resolve([ghost('ios-simulator', false)])).toMatchObject({
+      allowed: false,
+      errorCode: 'IOS_SIMULATOR_PLUGIN_DISABLED',
+      data: { reason: 'disabled', action: 'enable-plugin' },
+    });
+    expect(
+      resolve([ghost('ios-simulator', true)], {
+        disabledInWorkdirIds: ['ios-simulator'],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      errorCode: 'IOS_SIMULATOR_DISABLED',
+      data: { reason: 'disabled-in-workdir', action: 'enable-plugin' },
+    });
+  });
+
+  it('allows any enabled, session-available provider declaring the Host slot', () => {
+    expect(resolve([ghost('replacement-provider', true)])).toEqual({ allowed: true });
+    expect(
+      resolve([ghost('unavailable-provider', true), ghost('replacement-provider', true)], {
+        unavailableIds: ['unavailable-provider'],
+      }),
+    ).toEqual({ allowed: true });
+  });
+
+  it('does not treat an unrelated enabled plugin as a capability provider', () => {
+    expect(resolve([ghost('ordinary-plugin', true, ['skill'])])).toMatchObject({
+      allowed: false,
+      errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+    });
+  });
+});

--- a/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorPluginGate.test.ts
+++ b/apps/desktop/src/main/cindy-brain/__tests__/iosSimulatorPluginGate.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
 import type { InstalledGhost } from '../../../shared/ghost.js';
-import { resolveIOSSimulatorPluginAccess } from '../iosSimulatorPluginGate.js';
+import {
+  resolveIOSSimulatorPluginAccess,
+  shouldEnforceIOSSimulatorShellPolicy,
+} from '../iosSimulatorPluginGate.js';
 
 function ghost(id: string, enabled: boolean, slots: string[] = ['ios-simulator']): InstalledGhost {
   return {
@@ -65,5 +68,38 @@ describe('iOS Simulator plugin Host gate', () => {
       allowed: false,
       errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
     });
+  });
+});
+
+describe('embedded Simulator shell guard scope', () => {
+  it('applies while the plugin grants access', () => {
+    expect(
+      shouldEnforceIOSSimulatorShellPolicy({
+        pluginAccessAllowed: true,
+        hostRuntimeActive: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('stops blocking the user own Xcode tooling once the capability is gated off', () => {
+    // Without the plugin there is no embedded simulator to protect, and the
+    // denial would point at a cindy_ios_simulator tool the gate has removed.
+    expect(
+      shouldEnforceIOSSimulatorShellPolicy({
+        pluginAccessAllowed: false,
+        hostRuntimeActive: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps protecting a runtime this process already installed', () => {
+    // An instance booted while the plugin was enabled stays Cindy-owned after a
+    // disable, so a shell shutdown would race Cindy's own cleanup.
+    expect(
+      shouldEnforceIOSSimulatorShellPolicy({
+        pluginAccessAllowed: false,
+        hostRuntimeActive: true,
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/desktop/src/main/cindy-brain/index.ts
+++ b/apps/desktop/src/main/cindy-brain/index.ts
@@ -207,6 +207,7 @@ import { GhostPreviewSlot } from './previewSlot.js';
 import { GhostScheduleSlot, isMainShellWindowUrl } from './scheduleSlot.js';
 import { GhostWorkspaceSlot, type WorkspaceSessionService } from './workspaceSlot.js';
 import { GhostIOSSimulatorSlot, type IOSSimulatorSlotFocusContext } from './iosSimulatorSlot.js';
+import { resolveIOSSimulatorPluginAccess } from './iosSimulatorPluginGate.js';
 import {
   clearIOSSimulatorRendererAccess,
   focusIOSSimulatorRendererSession,
@@ -711,6 +712,16 @@ export function waitForGhostMutations(): Promise<void> {
 /** Account-managed built-ins are unavailable outside a verified cloud session. */
 export function isGhostAvailableForActiveSession(id: string): boolean {
   return !isCindyAccountGhostId(id) || getAppCapabilities().canUseCindyAccountServices;
+}
+
+/** Live Host capability gate shared by Agent transports and Renderer IPC. */
+export function getIOSSimulatorPluginAccessDecision(
+  workingDir: string | null = null,
+) {
+  return resolveIOSSimulatorPluginAccess(getGhostManager().list(), workingDir, {
+    isAvailableForActiveSession: isGhostAvailableForActiveSession,
+    isDisabledForWorkdir: isGhostDisabledForWorkdir,
+  });
 }
 
 function availableGhosts(): InstalledGhost[] {

--- a/apps/desktop/src/main/cindy-brain/iosSimulatorPluginGate.ts
+++ b/apps/desktop/src/main/cindy-brain/iosSimulatorPluginGate.ts
@@ -24,6 +24,30 @@ function pluginActionData(
 }
 
 /**
+ * Whether the shell guard that blocks external `simctl` / `Simulator.app` use
+ * should still apply.
+ *
+ * That guard exists to protect the ownership, admission, viewer and cleanup
+ * contracts of Cindy's *embedded* simulator. With no plugin there is no embedded
+ * simulator to protect, and blocking the user's own Xcode tooling — while
+ * pointing them at a `cindy_ios_simulator` tool that this gate has just removed
+ * — is a dead end rather than a boundary.
+ *
+ * The runtime condition is the safety half: a simulator instance booted while
+ * the plugin was enabled stays Cindy-owned after it is disabled, and a shell
+ * `simctl shutdown` would then race Cindy's own cleanup. `hostRuntimeActive` is
+ * deliberately coarser than "an instance is live" because the Host exposes no
+ * synchronous instance snapshot, and erring toward keeping the guard on is the
+ * safe direction.
+ */
+export function shouldEnforceIOSSimulatorShellPolicy(state: {
+  pluginAccessAllowed: boolean;
+  hostRuntimeActive: boolean;
+}): boolean {
+  return state.pluginAccessAllowed || state.hostRuntimeActive;
+}
+
+/**
  * Resolve the live product gate for Cindy's Host-owned iOS Simulator.
  *
  * The gateway remains discoverable so an Agent can explain how to install or

--- a/apps/desktop/src/main/cindy-brain/iosSimulatorPluginGate.ts
+++ b/apps/desktop/src/main/cindy-brain/iosSimulatorPluginGate.ts
@@ -1,0 +1,87 @@
+import type { IOSSimulatorMcpAccessDecision } from '@cindy/mcps';
+
+import type { InstalledGhost } from '../../shared/ghost.js';
+
+export interface IOSSimulatorPluginGateDeps {
+  isAvailableForActiveSession(ghostId: string): boolean;
+  isDisabledForWorkdir(ghostId: string, workingDir: string | null): boolean;
+}
+
+const REQUIRED_PLUGIN_ID = 'ios-simulator';
+const REQUIRED_PLUGIN_NAME = 'iOS Simulator';
+
+function pluginActionData(
+  reason: 'not-installed' | 'disabled' | 'disabled-in-workdir' | 'session-unavailable',
+  action: 'install-plugin' | 'enable-plugin',
+  ghost?: InstalledGhost,
+): Record<string, unknown> {
+  return {
+    reason,
+    action,
+    pluginId: ghost?.manifest.id ?? REQUIRED_PLUGIN_ID,
+    pluginName: ghost?.manifest.name ?? REQUIRED_PLUGIN_NAME,
+  };
+}
+
+/**
+ * Resolve the live product gate for Cindy's Host-owned iOS Simulator.
+ *
+ * The gateway remains discoverable so an Agent can explain how to install or
+ * enable the plugin, but every lifecycle/input/media call must re-evaluate this
+ * decision immediately before reaching the Host runtime.
+ */
+export function resolveIOSSimulatorPluginAccess(
+  ghosts: readonly InstalledGhost[],
+  workingDir: string | null,
+  deps: IOSSimulatorPluginGateDeps,
+): IOSSimulatorMcpAccessDecision {
+  const candidates = ghosts.filter((ghost) => ghost.manifest.slots.includes('ios-simulator'));
+  if (candidates.length === 0) {
+    return {
+      allowed: false,
+      errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+      message:
+        "Cindy's embedded iOS Simulator requires the iOS Simulator plugin. Ask the user to open Plugins → Marketplace, install “iOS Simulator”, and enable it. Do not retry until the plugin is installed.",
+      data: pluginActionData('not-installed', 'install-plugin'),
+    };
+  }
+
+  const sessionCandidates = candidates.filter((ghost) =>
+    deps.isAvailableForActiveSession(ghost.manifest.id),
+  );
+  const enabledCandidates = sessionCandidates.filter((ghost) => ghost.enabled === true);
+  const available = enabledCandidates.find(
+    (ghost) => !deps.isDisabledForWorkdir(ghost.manifest.id, workingDir),
+  );
+  if (available) return { allowed: true };
+
+  const workdirDisabled = enabledCandidates[0];
+  if (workdirDisabled) {
+    return {
+      allowed: false,
+      errorCode: 'IOS_SIMULATOR_DISABLED',
+      message:
+        'The iOS Simulator plugin is disabled for the current project. Ask the user to enable it for this working directory before retrying.',
+      data: pluginActionData('disabled-in-workdir', 'enable-plugin', workdirDisabled),
+    };
+  }
+
+  const disabled = sessionCandidates[0];
+  if (disabled) {
+    return {
+      allowed: false,
+      errorCode: 'IOS_SIMULATOR_PLUGIN_DISABLED',
+      message:
+        'The iOS Simulator plugin is installed but disabled. Ask the user to enable it on the Plugins page before retrying.',
+      data: pluginActionData('disabled', 'enable-plugin', disabled),
+    };
+  }
+
+  return {
+    allowed: false,
+    errorCode: 'IOS_SIMULATOR_PLUGIN_DISABLED',
+    message:
+      'The installed iOS Simulator plugin is unavailable in the current Cindy session. Ask the user to open the Plugins page and make the plugin available before retrying.',
+    data: pluginActionData('session-unavailable', 'enable-plugin', candidates[0]),
+  };
+}

--- a/apps/desktop/src/main/maker-host/__tests__/iosSimulatorCodexDynamicTools.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/iosSimulatorCodexDynamicTools.test.ts
@@ -11,18 +11,13 @@ const CONTEXT = {
 };
 
 describe('iOS Simulator Codex dynamic tools', () => {
-  it('registers an eager gateway only when the project capability is enabled', () => {
-    const enabled = createIOSSimulatorCodexDynamicToolProvider({
+  it('keeps the lightweight gateway discoverable so it can explain installation', () => {
+    const provider = createIOSSimulatorCodexDynamicToolProvider({
       deps: { callTool: vi.fn() },
-      isEnabled: () => true,
-    });
-    const disabled = createIOSSimulatorCodexDynamicToolProvider({
-      deps: { callTool: vi.fn() },
-      isEnabled: () => false,
     });
 
     if (process.platform === 'darwin') {
-      expect(enabled.listTools(CONTEXT)).toEqual([
+      expect(provider.listTools(CONTEXT)).toEqual([
         expect.objectContaining({
           type: 'function',
           name: 'cindy_ios_simulator__list_tools',
@@ -35,16 +30,14 @@ describe('iOS Simulator Codex dynamic tools', () => {
         }),
       ]);
     } else {
-      expect(enabled.listTools(CONTEXT)).toEqual([]);
+      expect(provider.listTools(CONTEXT)).toEqual([]);
     }
-    expect(disabled.listTools(CONTEXT)).toEqual([]);
   });
 
   it('lists tools without invoking the simulator host', async () => {
     const callTool = vi.fn();
     const provider = createIOSSimulatorCodexDynamicToolProvider({
       deps: { callTool },
-      isEnabled: () => true,
     });
 
     const result = await provider.callTool(
@@ -73,7 +66,6 @@ describe('iOS Simulator Codex dynamic tools', () => {
     const callTool = vi.fn(async () => ({ ok: true, data: { available: true } }));
     const provider = createIOSSimulatorCodexDynamicToolProvider({
       deps: { callTool },
-      isEnabled: () => true,
     });
 
     const result = await provider.callTool(
@@ -93,10 +85,65 @@ describe('iOS Simulator Codex dynamic tools', () => {
       expect(callTool).toHaveBeenCalledWith(
         'check_environment',
         {},
-        { sessionId: 'session-a', origin: 'agent' },
+        { sessionId: 'session-a', workingDir: '/repo', origin: 'agent' },
       );
     } else {
       expect(result?.success).toBe(false);
+      expect(callTool).not.toHaveBeenCalled();
+    }
+  });
+
+  it('surfaces an actionable plugin-required notice without touching the Host', async () => {
+    const callTool = vi.fn(async () => ({
+      ok: false,
+      errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+      message: 'Install the iOS Simulator plugin.',
+    }));
+    const describeTools = vi.fn(async () => ({
+      ready: false,
+      instanceCount: 0,
+      runningInstanceCount: 0,
+      tools: {
+        check_environment: {
+          state: 'unavailable' as const,
+          reasonCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+        },
+      },
+      notice: {
+        errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED' as const,
+        message: 'Open Plugins → Marketplace and install iOS Simulator.',
+        data: { action: 'install-plugin', pluginId: 'ios-simulator' },
+      },
+    }));
+    const provider = createIOSSimulatorCodexDynamicToolProvider({
+      deps: { callTool, describeTools },
+    });
+
+    const result = await provider.callTool(
+      {
+        threadId: 'thread-a',
+        turnId: 'turn-a',
+        callId: 'call-a',
+        namespace: null,
+        tool: 'cindy_ios_simulator__list_tools',
+        arguments: {},
+      },
+      CONTEXT,
+    );
+
+    if (process.platform === 'darwin') {
+      expect(result?.success).toBe(true);
+      expect(result?.contentItems[0]).toMatchObject({
+        text: expect.stringContaining('IOS_SIMULATOR_PLUGIN_REQUIRED'),
+      });
+      expect(result?.contentItems[0]).toMatchObject({
+        text: expect.stringContaining('install-plugin'),
+      });
+      expect(describeTools).toHaveBeenCalledWith({
+        sessionId: 'session-a',
+        workingDir: '/repo',
+        origin: 'agent',
+      });
       expect(callTool).not.toHaveBeenCalled();
     }
   });

--- a/apps/desktop/src/main/maker-host/__tests__/iosSimulatorShellHook.test.ts
+++ b/apps/desktop/src/main/maker-host/__tests__/iosSimulatorShellHook.test.ts
@@ -57,4 +57,54 @@ describeMac('iOS Simulator shell guard hook', () => {
     expect(persistedLog).not.toContain(command);
     expect(persistedLog).not.toContain('super-secret');
   });
+
+  it('lets the command through when the capability is gated off', async () => {
+    const { logger, warn } = createLoggerSpy();
+    const shouldEnforce = vi.fn(() => false);
+    const hook = createIOSSimulatorShellGuardHook(logger, shouldEnforce);
+
+    const result = await hook(
+      {
+        session_id: 'session-1',
+        transcript_path: '/tmp/transcript',
+        cwd: '/repo',
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'xcrun simctl boot DEVICE' },
+      } as never,
+      'tool-1',
+      { signal: new AbortController().signal },
+    );
+
+    // The user's own Xcode tooling must run when there is no embedded simulator
+    // to protect; denying here would point at a tool the gate has removed.
+    expect(result).toEqual({ continue: true });
+    expect(shouldEnforce).toHaveBeenCalledWith('/repo');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('still denies while the capability is available', async () => {
+    const { logger } = createLoggerSpy();
+    const shouldEnforce = vi.fn(() => true);
+    const hook = createIOSSimulatorShellGuardHook(logger, shouldEnforce);
+
+    const result = await hook(
+      {
+        session_id: 'session-1',
+        transcript_path: '/tmp/transcript',
+        cwd: '   ',
+        hook_event_name: 'PreToolUse',
+        tool_name: 'Bash',
+        tool_input: { command: 'open -a Simulator' },
+      } as never,
+      'tool-2',
+      { signal: new AbortController().signal },
+    );
+
+    expect(result).toMatchObject({
+      hookSpecificOutput: { permissionDecision: 'deny' },
+    });
+    // A blank cwd is unknown, not the repository root.
+    expect(shouldEnforce).toHaveBeenCalledWith(null);
+  });
 });

--- a/apps/desktop/src/main/maker-host/claude-hooks/ios-simulator-shell-hook.ts
+++ b/apps/desktop/src/main/maker-host/claude-hooks/ios-simulator-shell-hook.ts
@@ -4,7 +4,16 @@ import type { HookCallback, PreToolUseHookInput } from '@anthropic-ai/claude-age
 import type { Logger } from '@cindy/maker-core';
 import { getDesktopShellCommandPolicy } from '../shell-command-policy.js';
 
-export function createIOSSimulatorShellGuardHook(logger: Logger): HookCallback {
+export function createIOSSimulatorShellGuardHook(
+  logger: Logger,
+  /**
+   * Whether the embedded Simulator boundary applies to this working directory.
+   * Omitted in tests that only exercise the policy itself; production wiring
+   * always supplies it so an absent plugin does not block the user's own Xcode
+   * tooling.
+   */
+  shouldEnforce?: (workingDir: string | null) => boolean,
+): HookCallback {
   const log = logger.child('hook/ios-simulator-shell-guard');
   return async (input, toolUseId) => {
     if (input.hook_event_name !== 'PreToolUse') return { continue: true };
@@ -13,6 +22,8 @@ export function createIOSSimulatorShellGuardHook(logger: Logger): HookCallback {
     const toolInput = pre.tool_input as Record<string, unknown> | null | undefined;
     const command = toolInput?.command;
     if (typeof command !== 'string') return { continue: true };
+    const workingDir = typeof pre.cwd === 'string' && pre.cwd.trim() ? pre.cwd : null;
+    if (shouldEnforce && !shouldEnforce(workingDir)) return { continue: true };
 
     const policy = getDesktopShellCommandPolicy(command);
     if (!policy) return { continue: true };

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -50,6 +50,7 @@ import { WorktreePool } from '../worktree/index.js';
 import { getReadyBinaryPath, getCachedBinaryStatus } from '../agent-binaries/index.js';
 import { activeOwnerScopeKey, isAppSessionBoundaryPending } from '../appSessionState.js';
 import { getIOSSimulatorPluginAccessDecision } from '../cindy-brain/index.js';
+import { shouldEnforceIOSSimulatorShellPolicy } from '../cindy-brain/iosSimulatorPluginGate.js';
 import {
   desktopClaudeAuthAdapter,
   desktopCodexAuthAdapter,
@@ -133,7 +134,10 @@ import {
 } from './codex-proxy-host.js';
 import { createDesktopMcpProviders } from '../mcp-integrations/mcp-providers.js';
 import { getGhostRosterPrompt } from '../mcp-integrations/ghost.js';
-import { getIOSSimulatorMcpDeps } from '../mcp-integrations/ios-simulator.js';
+import {
+  getIOSSimulatorMcpDeps,
+  isIOSSimulatorHostRuntimeActive,
+} from '../mcp-integrations/ios-simulator.js';
 import { readContactsSettings } from './contacts-settings-store.js';
 import { createIOSSimulatorCodexDynamicToolProvider } from './ios-simulator-codex-dynamic-tools.js';
 import { captureKnownFileBefore, noteOpaqueTurnChange } from '../turn-change-set/store.js';
@@ -671,6 +675,19 @@ export function getMaker(): Maker {
       return { allowed: true as const };
     };
 
+    // The shell guard protects the embedded simulator's ownership/admission/
+    // viewer/cleanup contracts. With the plugin gated off there is nothing to
+    // protect, so blocking the user's own `simctl` / Simulator.app work — and
+    // pointing them at a cindy_ios_simulator tool the gate just removed — would
+    // be a dead end. A runtime this process already installed keeps its
+    // protection either way.
+    const shouldEnforceSimulatorShellGuard = (workingDir: string | null): boolean =>
+      shouldEnforceIOSSimulatorShellPolicy({
+        pluginAccessAllowed: resolveIOSSimulatorAccess({ workingDir: workingDir ?? undefined })
+          .allowed,
+        hostRuntimeActive: isIOSSimulatorHostRuntimeActive(),
+      });
+
     const makerMemoryProviderDeps = {
       getMakerMemoryManager: () => makerMemoryManager,
       lspPool: getLspPool(),
@@ -865,7 +882,12 @@ export function getMaker(): Maker {
           PreToolUse: [
             {
               matcher: 'Bash|PowerShell',
-              hooks: [createIOSSimulatorShellGuardHook(desktopMakerLogger)],
+              hooks: [
+                createIOSSimulatorShellGuardHook(
+                  desktopMakerLogger,
+                  shouldEnforceSimulatorShellGuard,
+                ),
+              ],
             },
             {
               matcher: 'Read',
@@ -1137,7 +1159,10 @@ export function getMaker(): Maker {
       codexHostDynamicToolProvider: createIOSSimulatorCodexDynamicToolProvider({
         deps: getIOSSimulatorMcpDeps({ resolveAccess: resolveIOSSimulatorAccess }),
       }),
-      getShellCommandPolicy: ({ command }) => getDesktopShellCommandPolicy(command),
+      getShellCommandPolicy: ({ command, cwd }) =>
+        shouldEnforceSimulatorShellGuard(cwd?.trim() || null)
+          ? getDesktopShellCommandPolicy(command)
+          : undefined,
       // 通讯录 prompt 段有效状态(codex 版): 在 claude 的判定链之上再与「实际应用
       // 到 running app-server 的 spawn 快照」对齐 —— 开关切换后失效失败(busy,
       // contacts-ipc 折成 codexMcpRefreshed:false)时 stale 桥里没有新工具面,

--- a/apps/desktop/src/main/maker-host/index.ts
+++ b/apps/desktop/src/main/maker-host/index.ts
@@ -29,7 +29,7 @@ import {
   type CodexModelBackfillCoordinator,
 } from './codex-model-backfill.js';
 import { createOrcaWorkerBridgeMcpProvider, type OrcaBridgeMcpDeps } from '@cindy/orca-workflow';
-import { LspServerPool } from '@cindy/mcps';
+import { LspServerPool, type IOSSimulatorMcpCallContext } from '@cindy/mcps';
 
 import { createMessage } from '../localDb/ipc/messages.js';
 import { getWorkerLink, updateWorkerStatus } from '../localDb/orcaTeamStore.js';
@@ -49,6 +49,7 @@ import { remoteInvoke } from '../device-link/index.js';
 import { WorktreePool } from '../worktree/index.js';
 import { getReadyBinaryPath, getCachedBinaryStatus } from '../agent-binaries/index.js';
 import { activeOwnerScopeKey, isAppSessionBoundaryPending } from '../appSessionState.js';
+import { getIOSSimulatorPluginAccessDecision } from '../cindy-brain/index.js';
 import {
   desktopClaudeAuthAdapter,
   desktopCodexAuthAdapter,
@@ -649,10 +650,32 @@ export function getMaker(): Maker {
     // 和项目 .claude/settings.json, mtime-based 缓存, 只在 session start 时同步检查。
     const pluginRegistry = createPluginRegistry();
 
+    const resolveIOSSimulatorAccess = (context?: IOSSimulatorMcpCallContext) => {
+      const workingDir = context?.workingDir?.trim() || null;
+      const pluginAccess = getIOSSimulatorPluginAccessDecision(workingDir);
+      if (!pluginAccess.allowed) return pluginAccess;
+      if (!pluginRegistry.isEnabled('ios-simulator', workingDir ?? undefined)) {
+        return {
+          allowed: false as const,
+          errorCode: 'IOS_SIMULATOR_DISABLED' as const,
+          message:
+            'The iOS Simulator capability is disabled for the current project. Ask the user to enable it in the project plugin settings before retrying.',
+          data: {
+            reason: 'disabled-in-workdir',
+            action: 'enable-plugin',
+            pluginId: 'ios-simulator',
+            pluginName: 'iOS Simulator',
+          },
+        };
+      }
+      return { allowed: true as const };
+    };
+
     const makerMemoryProviderDeps = {
       getMakerMemoryManager: () => makerMemoryManager,
       lspPool: getLspPool(),
       pluginRegistry,
+      resolveIOSSimulatorAccess,
       invokeRemote: remoteInvoke,
       // 只读活跃 Session 的运行时真相。权限切换是 runtime-first、DB-second，
       // 因此插件过户自动放行不得回退 sessions.permission_mode；会话不再 active
@@ -1112,8 +1135,7 @@ export function getMaker(): Maker {
       },
       makerMemory: makerMemoryManager,
       codexHostDynamicToolProvider: createIOSSimulatorCodexDynamicToolProvider({
-        deps: getIOSSimulatorMcpDeps(),
-        isEnabled: (workingDir) => getPluginRegistry().isEnabled('ios-simulator', workingDir),
+        deps: getIOSSimulatorMcpDeps({ resolveAccess: resolveIOSSimulatorAccess }),
       }),
       getShellCommandPolicy: ({ command }) => getDesktopShellCommandPolicy(command),
       // 通讯录 prompt 段有效状态(codex 版): 在 claude 的判定链之上再与「实际应用

--- a/apps/desktop/src/main/maker-host/ios-simulator-codex-dynamic-tools.ts
+++ b/apps/desktop/src/main/maker-host/ios-simulator-codex-dynamic-tools.ts
@@ -82,25 +82,18 @@ function textResponse(
  */
 export function createIOSSimulatorCodexDynamicToolProvider(options: {
   deps: IOSSimulatorMcpDeps;
-  isEnabled: (workingDir: string) => boolean;
 }): CodexHostDynamicToolProvider {
   return {
-    listTools: (context) =>
-      process.platform === 'darwin' && options.isEnabled(context.workingDir)
-        ? TOOLS
-        : [],
+    listTools: () => (process.platform === 'darwin' ? TOOLS : []),
     callTool: async (params, context) => {
       const toolName = innerToolName(params);
       if (!toolName) return undefined;
-      if (
-        process.platform !== 'darwin' ||
-        !options.isEnabled(context.workingDir)
-      ) {
+      if (process.platform !== 'darwin') {
         return textResponse(
           {
             ok: false,
             errorCode: 'IOS_SIMULATOR_DISABLED',
-            data: { message: 'iOS Simulator tools are disabled for this project.' },
+            data: { message: 'The embedded iOS Simulator is available only on macOS.' },
           },
           false,
         );
@@ -119,6 +112,7 @@ export function createIOSSimulatorCodexDynamicToolProvider(options: {
       const registry = new IOSSimulatorToolRegistry();
       registerIOSSimulatorTools(registry, options.deps, () => ({
         sessionId: context.sessionId!,
+        workingDir: context.workingDir,
         origin: 'agent',
       }));
 
@@ -143,6 +137,7 @@ export function createIOSSimulatorCodexDynamicToolProvider(options: {
         }
         const availability = await options.deps.describeTools?.({
           sessionId: context.sessionId,
+          workingDir: context.workingDir,
           origin: 'agent',
         });
         return textResponse({

--- a/apps/desktop/src/main/maker-ipc/__tests__/iosSimulatorHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/iosSimulatorHandlers.test.ts
@@ -17,6 +17,7 @@ describe('iOS Simulator IPC handlers', () => {
   function registerTrusted(harness: IpcHarness, deps: Partial<IOSSimulatorHandlerDeps> = {}): void {
     registerIOSSimulatorHandlers(harness, {
       assertTrustedSender: () => undefined,
+      isPluginAvailable: () => true,
       getOwnerScopeKey: () => 'local:owner-a:1',
       isOwnerBoundaryPending: () => false,
       getSessionAccess: () => ({ sessionId: 'session-a', generation: 1 }),
@@ -51,6 +52,31 @@ describe('iOS Simulator IPC handlers', () => {
       code: 'PERMISSION_DENIED',
     });
     expect(assertTrustedSender).toHaveBeenCalledOnce();
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it('rejects every Renderer entry before reaching the Host when the plugin is unavailable', async () => {
+    const harness = new IpcHarness();
+    const getStatus = vi.fn();
+    const requestSessionAccess = vi.fn();
+    registerIOSSimulatorHandlers(harness, {
+      assertTrustedSender: () => undefined,
+      isPluginAvailable: () => false,
+      getStatus,
+      requestSessionAccess,
+    });
+
+    await expect(
+      harness.invokeFrom(17, MAKER_INVOKE.IOS_SIMULATOR_REQUEST_ACCESS, {
+        sessionId: 'session-a',
+      }),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    await expect(
+      harness.invokeFrom(17, MAKER_INVOKE.IOS_SIMULATOR_STATUS, {
+        sessionId: 'session-a',
+      }),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(requestSessionAccess).not.toHaveBeenCalled();
     expect(getStatus).not.toHaveBeenCalled();
   });
 
@@ -337,6 +363,7 @@ describe('iOS Simulator IPC handlers', () => {
     const callTool = vi.fn();
     registerIOSSimulatorHandlers(harness, {
       assertTrustedSender: () => undefined,
+      isPluginAvailable: () => true,
       hasSessionAccess: () => false,
       getStatus,
       callTool,

--- a/apps/desktop/src/main/maker-ipc/__tests__/iosSimulatorHandlers.test.ts
+++ b/apps/desktop/src/main/maker-ipc/__tests__/iosSimulatorHandlers.test.ts
@@ -18,6 +18,7 @@ describe('iOS Simulator IPC handlers', () => {
     registerIOSSimulatorHandlers(harness, {
       assertTrustedSender: () => undefined,
       isPluginAvailable: () => true,
+      getSessionContext: async () => ({ workingDir: '/repo/session-a' }),
       getOwnerScopeKey: () => 'local:owner-a:1',
       isOwnerBoundaryPending: () => false,
       getSessionAccess: () => ({ sessionId: 'session-a', generation: 1 }),
@@ -62,6 +63,7 @@ describe('iOS Simulator IPC handlers', () => {
     registerIOSSimulatorHandlers(harness, {
       assertTrustedSender: () => undefined,
       isPluginAvailable: () => false,
+      getSessionContext: async () => ({ workingDir: '/repo/session-a' }),
       getStatus,
       requestSessionAccess,
     });
@@ -91,6 +93,25 @@ describe('iOS Simulator IPC handlers', () => {
       }),
     ).resolves.toEqual({ granted: true });
     expect(requestSessionAccess).not.toHaveBeenCalled();
+  });
+
+  it('passes the authoritative session workdir to the plugin gate', async () => {
+    const harness = new IpcHarness();
+    const isPluginAvailable = vi.fn(() => false);
+    const getStatus = vi.fn();
+    registerTrusted(harness, {
+      isPluginAvailable,
+      getSessionContext: async () => ({ workingDir: '/repo/disabled' }),
+      getStatus,
+    });
+
+    await expect(
+      harness.invokeFrom(17, MAKER_INVOKE.IOS_SIMULATOR_STATUS, {
+        sessionId: 'session-a',
+      }),
+    ).rejects.toMatchObject({ code: 'PERMISSION_DENIED' });
+    expect(isPluginAvailable).toHaveBeenCalledWith('/repo/disabled');
+    expect(getStatus).not.toHaveBeenCalled();
   });
 
   it('returns the explicit native confirmation result for a manual access request', async () => {
@@ -364,6 +385,7 @@ describe('iOS Simulator IPC handlers', () => {
     registerIOSSimulatorHandlers(harness, {
       assertTrustedSender: () => undefined,
       isPluginAvailable: () => true,
+      getSessionContext: async () => ({ workingDir: '/repo/session-a' }),
       hasSessionAccess: () => false,
       getStatus,
       callTool,

--- a/apps/desktop/src/main/maker-ipc/iosSimulatorHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/iosSimulatorHandlers.ts
@@ -62,7 +62,10 @@ const IOS_SIMULATOR_SAFE_IPC_MESSAGES: Record<IOSSimulatorIpcOperation, string> 
 
 export interface IOSSimulatorHandlerDeps {
   assertTrustedSender(event: unknown): void;
-  isPluginAvailable(): boolean;
+  isPluginAvailable(workingDir: string | null): boolean;
+  getSessionContext(
+    sessionId: string,
+  ): Promise<{ workingDir: string | null } | null>;
   getOwnerScopeKey(): string;
   isOwnerBoundaryPending(): boolean;
   getSessionAccess(
@@ -142,6 +145,7 @@ const defaultDeps: IOSSimulatorHandlerDeps = {
   // Production registration must inject the live Ghost capability gate. Tests
   // and any accidental alternate registration fail closed by default.
   isPluginAvailable: () => false,
+  getSessionContext: async () => null,
   getOwnerScopeKey: activeOwnerScopeKey,
   isOwnerBoundaryPending: isAppSessionBoundaryPending,
   getSessionAccess: getIOSSimulatorRendererSessionAccess,
@@ -186,9 +190,20 @@ function throwIOSSimulatorIpcError(
 async function callIOSSimulatorHost<T>(
   deps: IOSSimulatorHandlerDeps,
   operation: IOSSimulatorIpcOperation,
+  sessionId: string,
   call: (assertCurrent: () => void) => T | Promise<T>,
   assertStillAuthorized?: () => void,
 ): Promise<T> {
+  let sessionContext: { workingDir: string | null } | null;
+  try {
+    sessionContext = await deps.getSessionContext(sessionId);
+  } catch {
+    sessionContext = null;
+  }
+  if (!sessionContext) {
+    throwIpcError('PERMISSION_DENIED', 'iOS Simulator access is limited to the current task');
+  }
+  const workingDir = sessionContext.workingDir?.trim() || null;
   const ownerScopeKey = deps.getOwnerScopeKey();
   const assertOwnerScopeCurrent = (): void => {
     if (deps.isOwnerBoundaryPending() || deps.getOwnerScopeKey() !== ownerScopeKey) {
@@ -199,7 +214,7 @@ async function callIOSSimulatorHost<T>(
     }
   };
   const assertCurrent = (): void => {
-    if (!deps.isPluginAvailable()) {
+    if (!deps.isPluginAvailable(workingDir)) {
       throwIpcError(
         'PERMISSION_DENIED',
         'The iOS Simulator plugin must be installed and enabled.',
@@ -273,12 +288,6 @@ export function registerIOSSimulatorHandlers(
   const handle: IpcHandlerRegistry['handle'] = (channel, handler) => {
     registry.handle(channel, (event, ...args) => {
       resolved.assertTrustedSender(event);
-      if (!resolved.isPluginAvailable()) {
-        throwIpcError(
-          'PERMISSION_DENIED',
-          'The iOS Simulator plugin must be installed and enabled.',
-        );
-      }
       return handler(event, ...args);
     });
   };
@@ -300,7 +309,7 @@ export function registerIOSSimulatorHandlers(
     if (!expectedAccess || expectedAccess.sessionId !== sessionId) {
       throwIpcError('PERMISSION_DENIED', 'iOS Simulator access is limited to the current task');
     }
-    return callIOSSimulatorHost(resolved, operation, call, () => {
+    return callIOSSimulatorHost(resolved, operation, sessionId, call, () => {
       const currentAccess = resolved.getSessionAccess(sender);
       if (
         !currentAccess ||
@@ -314,7 +323,7 @@ export function registerIOSSimulatorHandlers(
   handle(MAKER_INVOKE.IOS_SIMULATOR_REQUEST_ACCESS, async (event, payload) => {
     const sessionId = readSessionId(payload);
     const sender = readSenderWebContents(event);
-    const granted = await callIOSSimulatorHost(resolved, 'request-access', () =>
+    const granted = await callIOSSimulatorHost(resolved, 'request-access', sessionId, () =>
       resolved.hasSessionAccess(sender, sessionId)
         ? true
         : resolved.requestSessionAccess(sender, sessionId),

--- a/apps/desktop/src/main/maker-ipc/iosSimulatorHandlers.ts
+++ b/apps/desktop/src/main/maker-ipc/iosSimulatorHandlers.ts
@@ -62,6 +62,7 @@ const IOS_SIMULATOR_SAFE_IPC_MESSAGES: Record<IOSSimulatorIpcOperation, string> 
 
 export interface IOSSimulatorHandlerDeps {
   assertTrustedSender(event: unknown): void;
+  isPluginAvailable(): boolean;
   getOwnerScopeKey(): string;
   isOwnerBoundaryPending(): boolean;
   getSessionAccess(
@@ -138,6 +139,9 @@ export interface IOSSimulatorHandlerDeps {
 const defaultDeps: IOSSimulatorHandlerDeps = {
   assertTrustedSender: (event) =>
     assertTrustedAppRendererEvent(event as Parameters<typeof assertTrustedAppRendererEvent>[0]),
+  // Production registration must inject the live Ghost capability gate. Tests
+  // and any accidental alternate registration fail closed by default.
+  isPluginAvailable: () => false,
   getOwnerScopeKey: activeOwnerScopeKey,
   isOwnerBoundaryPending: isAppSessionBoundaryPending,
   getSessionAccess: getIOSSimulatorRendererSessionAccess,
@@ -195,6 +199,12 @@ async function callIOSSimulatorHost<T>(
     }
   };
   const assertCurrent = (): void => {
+    if (!deps.isPluginAvailable()) {
+      throwIpcError(
+        'PERMISSION_DENIED',
+        'The iOS Simulator plugin must be installed and enabled.',
+      );
+    }
     assertOwnerScopeCurrent();
     assertStillAuthorized?.();
   };
@@ -263,6 +273,12 @@ export function registerIOSSimulatorHandlers(
   const handle: IpcHandlerRegistry['handle'] = (channel, handler) => {
     registry.handle(channel, (event, ...args) => {
       resolved.assertTrustedSender(event);
+      if (!resolved.isPluginAvailable()) {
+        throwIpcError(
+          'PERMISSION_DENIED',
+          'The iOS Simulator plugin must be installed and enabled.',
+        );
+      }
       return handler(event, ...args);
     });
   };

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -13248,7 +13248,14 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   registerIOSSimulatorHandlers(
     createElectronIpcHandlerRegistry(),
     {
-      isPluginAvailable: () => getIOSSimulatorPluginAccessDecision().allowed,
+      isPluginAvailable: (workingDir) =>
+        getIOSSimulatorPluginAccessDecision(workingDir).allowed,
+      getSessionContext: async (sessionId) => {
+        const liveSession = maker.getSession(sessionId);
+        if (liveSession) return { workingDir: liveSession.workDir };
+        const snapshot = await getSessionRowSnapshotStrict(sessionId);
+        return snapshot ? { workingDir: snapshot.workingDir } : null;
+      },
     },
   );
 

--- a/apps/desktop/src/main/maker-ipc/register.ts
+++ b/apps/desktop/src/main/maker-ipc/register.ts
@@ -88,6 +88,7 @@ import {
   executeGhostSetupInlineAction,
   getGhostManager,
   getGhostSetupAssessment,
+  getIOSSimulatorPluginAccessDecision,
   isGhostAvailableForActiveSession,
 } from '../cindy-brain/index.js';
 import {
@@ -13246,6 +13247,9 @@ export function registerMakerIpc(maker: Maker, options: RegisterMakerIpcOptions)
   // ── iOS Simulator pane / Agent discovery ────────────────────────────────
   registerIOSSimulatorHandlers(
     createElectronIpcHandlerRegistry(),
+    {
+      isPluginAvailable: () => getIOSSimulatorPluginAccessDecision().allowed,
+    },
   );
 
   // ── Browser automation (Settings →「电脑使用」) ───────────────────────────

--- a/apps/desktop/src/main/mcp-integrations/__tests__/collabSendOutcome.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/collabSendOutcome.test.ts
@@ -36,6 +36,11 @@ vi.mock('@cindy/mcps', () => ({
     mockState.capturedProvidersConfig = config;
     return [
       {
+        name: 'cindy_ios_simulator',
+        isEnabled: () => true,
+        toClaudeSdkConfig: () => null,
+      },
+      {
         name: 'cindy_orca',
         isEnabled: () => true,
         toClaudeSdkConfig: () => null,
@@ -46,7 +51,12 @@ vi.mock('@cindy/mcps', () => ({
 
 vi.mock('../../maker-host/plugins/builtin-plugins.js', () => ({
   BUILTIN_LIZI_MCP_IDS: ['cindy_orca', 'cindy_helper'],
-  pluginIdForProviderName: (name: string) => (name === 'cindy_orca' ? 'collab' : name),
+  pluginIdForProviderName: (name: string) =>
+    name === 'cindy_orca'
+      ? 'collab'
+      : name === 'cindy_ios_simulator'
+        ? 'ios-simulator'
+        : name,
 }));
 
 vi.mock('../../maker-host/index.js', () => ({
@@ -149,13 +159,23 @@ describe('collab send outcome semantics', () => {
       getMakerMemoryManager: vi.fn(),
       lspPool: {} as never,
       pluginRegistry: { isEnabled: () => false } as never,
+      resolveIOSSimulatorAccess: () => ({ allowed: true }),
       invokeRemote: vi.fn(),
     });
     const orcaProvider = providers.find((provider) => provider.name === 'cindy_orca');
+    const iosSimulatorProvider = providers.find(
+      (provider) => provider.name === 'cindy_ios_simulator',
+    );
 
     expect(orcaProvider).toBeDefined();
     expect(
       orcaProvider?.isEnabled?.({
+        agentKind: 'claude-code',
+        workingDir: 'C:/projects/cindy',
+      } as never),
+    ).toBe(true);
+    expect(
+      iosSimulatorProvider?.isEnabled?.({
         agentKind: 'claude-code',
         workingDir: 'C:/projects/cindy',
       } as never),
@@ -310,6 +330,7 @@ describe('collab send outcome semantics', () => {
       getMakerMemoryManager: vi.fn(),
       lspPool: {} as never,
       pluginRegistry: { isEnabled: () => true } as never,
+      resolveIOSSimulatorAccess: () => ({ allowed: true }),
       invokeRemote: vi.fn(),
     });
     const orca = (mockState.capturedProvidersConfig?.orca ?? {}) as {
@@ -358,6 +379,7 @@ describe('collab send outcome semantics', () => {
       getMakerMemoryManager: vi.fn(),
       lspPool: {} as never,
       pluginRegistry: { isEnabled: () => true } as never,
+      resolveIOSSimulatorAccess: () => ({ allowed: true }),
       invokeRemote: vi.fn(),
     });
     const orca = (mockState.capturedProvidersConfig?.orca ?? {}) as {
@@ -417,6 +439,7 @@ describe('collab send outcome semantics', () => {
       getMakerMemoryManager: vi.fn(),
       lspPool: {} as never,
       pluginRegistry: { isEnabled: () => true } as never,
+      resolveIOSSimulatorAccess: () => ({ allowed: true }),
       invokeRemote: vi.fn(),
     });
     const orca = (mockState.capturedProvidersConfig?.orca ?? {}) as {

--- a/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
+++ b/apps/desktop/src/main/mcp-integrations/__tests__/ios-simulator.test.ts
@@ -109,6 +109,40 @@ describe('iOS Simulator host', () => {
     }
   });
 
+  it('keeps plugin-required discovery passive and returns installation guidance', async () => {
+    const getPath = vi.spyOn(app, 'getPath');
+    try {
+      const deps = getIOSSimulatorMcpDeps({
+        resolveAccess: () => ({
+          allowed: false,
+          errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+          message: 'Open Plugins → Marketplace and install iOS Simulator.',
+          data: { action: 'install-plugin', pluginId: 'ios-simulator' },
+        }),
+      });
+
+      await expect(
+        deps.describeTools?.({ sessionId: 'plugin-required-session' }),
+      ).resolves.toMatchObject({
+        ready: false,
+        notice: {
+          errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+          data: { action: 'install-plugin', pluginId: 'ios-simulator' },
+        },
+      });
+      await expect(
+        deps.callTool('check_environment', {}, { sessionId: 'plugin-required-session' }),
+      ).resolves.toMatchObject({
+        ok: false,
+        errorCode: 'IOS_SIMULATOR_PLUGIN_REQUIRED',
+        data: { action: 'install-plugin', pluginId: 'ios-simulator' },
+      });
+      expect(getPath).not.toHaveBeenCalled();
+    } finally {
+      getPath.mockRestore();
+    }
+  });
+
   it('keeps a cold plugin status probe passive and leaves the ownership writer available', async () => {
     const acquireWriter = vi.spyOn(
       IOSSimulatorOwnershipRegistryFile.prototype,

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -62,6 +62,7 @@ import {
 } from '@cindy/ios-simulator-runtime';
 import type {
   IOSSimulatorMcpCallContext,
+  IOSSimulatorMcpAccessDecision,
   IOSSimulatorMcpDeps,
   IOSSimulatorMcpErrorCode,
   IOSSimulatorMcpToolName,
@@ -6648,6 +6649,7 @@ export function updateIOSSimulatorViewerTouch(
 
 export interface IOSSimulatorMcpDepsOptions {
   isIOSSimulatorEnabled?: (context?: IOSSimulatorMcpCallContext) => boolean;
+  resolveAccess?: (context?: IOSSimulatorMcpCallContext) => IOSSimulatorMcpAccessDecision;
   host?: IOSSimulatorHost;
 }
 
@@ -6655,6 +6657,21 @@ export function getIOSSimulatorMcpDeps(
   options: IOSSimulatorMcpDepsOptions = {},
 ): IOSSimulatorMcpDeps {
   const getHost = (): IOSSimulatorHost => options.host ?? initializeIOSSimulatorHost();
+  const resolveAccess = (
+    context?: IOSSimulatorMcpCallContext,
+  ): IOSSimulatorMcpAccessDecision => {
+    const decision = options.resolveAccess?.(context);
+    if (decision) return decision;
+    if (options.isIOSSimulatorEnabled && !options.isIOSSimulatorEnabled(context)) {
+      return {
+        allowed: false,
+        errorCode: 'IOS_SIMULATOR_DISABLED',
+        message: 'iOS Simulator tools are disabled for this project.',
+        data: { reason: 'disabled-in-workdir', action: 'enable-plugin' },
+      };
+    }
+    return { allowed: true };
+  };
   return {
     describeTools: async (context) => {
       const sessionId = context?.sessionId?.trim();
@@ -6669,25 +6686,33 @@ export function getIOSSimulatorMcpDeps(
           },
         };
       }
-      if (options.isIOSSimulatorEnabled && !options.isIOSSimulatorEnabled(context)) {
+      const access = resolveAccess(context);
+      if (!access.allowed) {
         return {
           ready: false,
           instanceCount: 0,
           runningInstanceCount: 0,
           tools: {
-            doctor: { state: 'unavailable', reasonCode: 'IOS_SIMULATOR_DISABLED' },
-            check_environment: { state: 'unavailable', reasonCode: 'IOS_SIMULATOR_DISABLED' },
+            doctor: { state: 'unavailable', reasonCode: access.errorCode },
+            check_environment: { state: 'unavailable', reasonCode: access.errorCode },
+          },
+          notice: {
+            errorCode: access.errorCode,
+            message: access.message,
+            ...(access.data ? { data: access.data } : {}),
           },
         };
       }
       return getHost().describeTools(sessionId);
     },
     callTool: async (name, args, context) => {
-      if (options.isIOSSimulatorEnabled && !options.isIOSSimulatorEnabled(context)) {
+      const access = resolveAccess(context);
+      if (!access.allowed) {
         return {
           ok: false,
-          errorCode: 'IOS_SIMULATOR_DISABLED',
-          message: 'iOS Simulator tools are disabled for this project.',
+          errorCode: access.errorCode,
+          message: access.message,
+          ...(access.data ? { data: access.data } : {}),
         };
       }
       return getHost().callTool(name, args, context);

--- a/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
+++ b/apps/desktop/src/main/mcp-integrations/ios-simulator.ts
@@ -6412,6 +6412,19 @@ function currentIOSSimulatorHost(): IOSSimulatorHost | null {
   return defaultIOSSimulatorRuntime?.host ?? null;
 }
 
+/**
+ * Whether this process installed the Host Simulator runtime, which means Cindy
+ * may hold simulator ownership right now.
+ *
+ * Synchronous and side-effect free by contract: it must never initialize the
+ * Host, because the plugin gate's whole point is that an absent plugin leaves
+ * the runtime untouched. A shutting-down runtime still counts as active so
+ * in-flight cleanup keeps its protection.
+ */
+export function isIOSSimulatorHostRuntimeActive(): boolean {
+  return currentIOSSimulatorHost() !== null || defaultIOSSimulatorRuntimeClosing;
+}
+
 export function getIOSSimulatorSessionStatus(
   sessionId: string,
 ): Promise<IOSSimulatorSessionStatus> {

--- a/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
+++ b/apps/desktop/src/main/mcp-integrations/mcp-providers.ts
@@ -3,6 +3,7 @@ import { join as pathJoin } from 'node:path';
 import {
   createLiziMcpProviders,
   resolveLiziMcpSessionContext,
+  type IOSSimulatorMcpAccessDecision,
   type LiziMcpProvider,
   type LiziMcpSessionContext,
   type LspServerPool,
@@ -55,6 +56,10 @@ export interface DesktopMcpProvidersDeps {
   lspPool: LspServerPool;
   /** 按会话控制启用状态的 plugin registry。 */
   pluginRegistry: PluginRegistry;
+  /** Live installed/enabled plugin gate; evaluated again for every tool call. */
+  resolveIOSSimulatorAccess: (
+    context?: { workingDir?: string },
+  ) => IOSSimulatorMcpAccessDecision;
   /** Device-link transport stays host-injected so provider tests do not load Electron runtime services. */
   invokeRemote: ChatHistoryReaderDeps['invokeRemote'];
   /** 插件文件交接只认活跃 Session 的实时权限；缺失时由 ghost.ts fail closed。 */
@@ -89,11 +94,7 @@ export function createDesktopMcpProviders(deps: DesktopMcpProvidersDeps): LiziMc
         context?.agentKind === 'codex' || pluginRegistry.isEnabled('android'),
     }),
     iosSimulator: getIOSSimulatorMcpDeps({
-      // Project-scoped gating is applied by the provider wrapper below using
-      // the live MCP session context. This host-level check preserves the
-      // existing global fallback for non-session callers.
-      isIOSSimulatorEnabled: (context) =>
-        pluginRegistry.isEnabled('ios-simulator', context?.workingDir),
+      resolveAccess: deps.resolveIOSSimulatorAccess,
     }),
     browser: getBrowserMcpDeps(),
     computer: getComputerMcpDeps({
@@ -448,9 +449,14 @@ export function createDesktopMcpProviders(deps: DesktopMcpProvidersDeps): LiziMc
         // Orca 工具面必须在会话生命周期内保持稳定：Claude query 不会在项目策略
         // 动态启用后重建 MCP。创建入口仍由 Main 按调用时的项目策略 fail closed。
         const keepOrcaProviderStable = pluginId === 'collab';
+        // Keep the lightweight gateway visible even before the public plugin
+        // is installed. Its live call gate returns an actionable install/enable
+        // result, while every runtime mutation remains blocked in Main.
+        const keepIOSSimulatorGatewayStable = pluginId === 'ios-simulator';
         // Plugin gate：registry 负责 essential / machine / project / user / default 判定。
         if (
           !keepOrcaProviderStable &&
+          !keepIOSSimulatorGatewayStable &&
           !deferOrdinaryGate &&
           !pluginRegistry.isEnabled(pluginId, ctx.workingDir)
         ) {

--- a/packages/lizi-mcps/src/types.ts
+++ b/packages/lizi-mcps/src/types.ts
@@ -758,6 +758,8 @@ export type IOSSimulatorMcpErrorCode =
   | 'SESSION_CONTEXT_REQUIRED'
   | 'SESSION_NOT_FOUND'
   | 'UNSUPPORTED_SESSION_KIND'
+  | 'IOS_SIMULATOR_PLUGIN_REQUIRED'
+  | 'IOS_SIMULATOR_PLUGIN_DISABLED'
   | 'IOS_SIMULATOR_DISABLED'
   | 'WDA_UNAVAILABLE'
   | 'XCODE_BUILD_FAILED'
@@ -782,7 +784,21 @@ export interface IOSSimulatorToolAvailabilityReport {
   instanceCount: number;
   runningInstanceCount: number;
   tools: Record<string, IOSSimulatorToolAvailability>;
+  notice?: {
+    errorCode: IOSSimulatorMcpErrorCode;
+    message: string;
+    data?: Record<string, unknown>;
+  };
 }
+
+export type IOSSimulatorMcpAccessDecision =
+  | { allowed: true }
+  | {
+      allowed: false;
+      errorCode: IOSSimulatorMcpErrorCode;
+      message: string;
+      data?: Record<string, unknown>;
+    };
 
 export type IOSSimulatorMcpToolName =
   | 'check_environment'


### PR DESCRIPTION
## 这次改了什么

### 摘要

这是 #2044 的后续修复。iOS Simulator 作为可选插件发布后，Host 仍会在插件未安装或停用时向 Agent 暴露并执行完整模拟器能力，导致用户找不到对应面板，却仍能从 Agent 启动内置模拟器。

本 PR 将插件状态收敛为 Host 的实时能力门：轻量网关保持可发现，用于提示用户前往插件市场安装或启用插件；构建、启动、输入和媒体等真实调用在 Main 进程中统一拦截。插件安装或启用后，后续调用可立即恢复，无需重启任务。

第二个提交把同一道门接到了 **shell 守卫**上。此前 MCP、面板入口与 IPC 都收归插件门之后，`getDesktopShellCommandPolicy` 仍然无条件生效，于是从未安装插件的用户照样无法运行 `open -a Simulator` 或 `simctl` 写操作，而拒绝文案还在让他去用 `cindy_ios_simulator` —— 一个这道门刚刚移除的工具。那道守卫保护的是 Cindy **内嵌**模拟器的归属、准入、viewer 与清理契约；能力被门掉之后没有内嵌模拟器需要保护，用户自己的 Xcode 工具链也不该由 Cindy 拦。

### 变更类型

- [ ] `feat` 新功能
- [x] `fix` 缺陷修复
- [ ] `refactor` / `perf` 重构或性能优化
- [ ] `docs` / `test` / `chore` 文档、测试或工程维护
- [ ] 其他：

### 范围

- 关联 Issue / 需求：Follow-up to #2044
- 本 PR 包含：插件未安装、全局停用、当前项目停用和当前会话不可用的实时判定；Claude/Pi MCP、Codex dynamic tools 与 Renderer IPC 的最终 Host 门控；**shell 守卫（Codex `getShellCommandPolicy` 与 Claude `PreToolUse` hook 两条路径）纳入同一道门**；可操作的安装或启用提示；回归测试。
- 明确不包含：插件市场 UI、插件包内容、iOS Simulator Runtime、Sidecar、WDA 或视频与输入路线的修改。**也不包含 shell 守卫自身的判定逻辑** —— `shell-command-policy.ts` 一行未改（见下方与 #2414 的关系）。
- 用户可见变化：未安装插件时，Agent 会提示前往「插件 → 插件市场」安装并启用 iOS Simulator，而不是实际启动隐藏的 Host 能力；停用时会提示启用。**并且从未安装插件的用户可以正常运行自己的 `open -a Simulator` 与 `simctl` 命令** —— 这些此前会被 shell 守卫拒绝。只读命令本来就没被拦，行为不变：`open -a Xcode`、`xcrun simctl list` / `listapps` / `getenv` / `diagnose`、针对 iphonesimulator SDK 的 `xcodebuild`、`expo run:ios`、`flutter run -d`。
- 是否存在 breaking change：无。已安装并启用的插件继续正常使用；插件可用时 shell 守卫的行为与合并前完全一致。

### UI 变化

不涉及：未修改 Renderer UI、布局或文案资源；提示通过现有 Agent 工具结果返回。

- 引用的设计规范：不涉及。

## 怎么验证的

### 自动验证

```text
pnpm test:unit
结果：通过，exit 0，无 FAIL。

pnpm --filter desktop run typecheck
结果：通过，exit 0。

pnpm --filter @cindy/mcps run build
结果：通过。

pnpm check:dco
结果：通过，2 个提交均带 Signed-off-by。

apps/desktop 定向套件（插件门 / shell hook / shell 策略）
结果：209 passed
  - cindy-brain/__tests__/iosSimulatorPluginGate.test.ts        7 passed（含 shell 守卫作用域 3 条）
  - maker-host/__tests__/iosSimulatorShellHook.test.ts          3 passed
  - maker-host/__tests__/shellCommandPolicy.test.ts           199 passed（未改动，验证判定逻辑无回归）
```

### 手工验证

不涉及；本 PR 通过 Host、MCP、Codex dynamic tools、IPC 与 shell 守卫单元测试覆盖各门控状态。

### 未执行的验证

未执行独立 Desktop 实机回归；建议合并前分别检查未安装、已安装但停用、已安装且启用三种状态。shell 守卫这一侧同样未实机目检——它是纯判定接线，行为差异由上述断言覆盖，但「未装插件的机器上手敲 `open -a Simulator` 能否执行」这一条值得在发版验证时实机确认一次。

## 风险

### 风险分类

- [ ] 无已知风险
- [ ] SQLite / migration
- [ ] system prompt
- [ ] 协议兼容
- [x] 权限 / 安全 / 用户数据
- [x] 存量插件兼容（批准状态 / 指纹 / manifest 校验 / 安装布局 / 包格式）
- [ ] 原生层 / fingerprint / OTA
- [x] 跨平台差异
- [ ] 其他：

### 影响与回滚

- 影响范围：仅 macOS Desktop 的 Host-owned iOS Simulator 能力门与其 shell 边界。非 macOS 继续不暴露该能力（策略入口第一行即按平台返回）。
- 存量插件影响：无。未修改 manifest schema、slot 名称、批准状态、指纹、安装布局或包格式；已安装、已批准并启用的 iOS Simulator 插件无需重装或重新确认。
- 插件作者手册：无需同步；未新增或修改作者可见的 manifest、管子协议、面板协议或打包契约。
- 审批要求：本 PR 修改 `main/cindy-brain/` 能力门，按插件基座规则需要白名单维护者明确 Approve。
- 回滚 / 降级方式：回退这两个提交即可恢复原有门控行为；不涉及持久化数据迁移。

**shell 守卫放宽的安全边界，请按此重点审阅。** 守卫在任一条成立时仍然生效：

1. 插件当前授予访问 —— 按工作目录判定，与 MCP / IPC 走同一个 decision；
2. 或本进程已经装载过 Host Simulator runtime。

第二条是安全条件：插件启用期间起的实例在停用后仍归 Cindy 所有，一条 shell `simctl shutdown` 会与 Cindy 自己的 cleanup 抢。它**故意比「有活跃实例」更粗** —— `IOSSimulatorHost` 没有暴露同步的实例快照，而策略回调是同步的，所以宁可偏向「保持开启」。新增的 `isIOSSimulatorHostRuntimeActive()` 按契约不会初始化 Host，插件缺席时 runtime 仍然不被触碰。

两条执行路径都接了：Codex 侧用回调的 `cwd`，Claude 侧用 hook 输入的 `cwd`；空白 cwd 按「未知」处理而不是回落成仓库根。守卫在插件缺席时不再触发，因此那句指向 `cindy_ios_simulator` 的拒绝文案不会再指向被门移除的工具，无需单独改文案。

**与 #2414 的关系**：#2414 修的是 shell 守卫**判据太宽**（误拒普通命令、并放大成中断 Codex 任务）。本 PR 只改接线、判据留在组合根，`shell-command-policy.ts` 一行未改，因此两个 PR **无文件冲突，合并顺序无关**。

**仍未覆盖的场景**：插件已安装且启用、用户本次就想用外部模拟器 —— 目前只能先停用插件。文案承诺的 explicit host authorization 通道全仓尚未实现。这属于产品交互决策（一次性确认卡 / 任务级开关 / 设置项），建议单独立项，不在本 PR 范围内。

### 提交前检查

- [x] 已 review 完整 diff
- [x] 每个 commit 都带 DCO 签名（`git commit -s`，见 [DCO](../DCO)）
- [x] UI 改动已在「UI 变化」注明引用的设计规范（不涉及 UI）
- [x] 未提交凭证、令牌或授权文件
- [x] 已补充必要文档（无需新增作者契约文档）
- [x] 已确认测试结果或说明未执行原因
